### PR TITLE
dev: add pre-push hook enforcing tag naming convention

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Enforces tag naming convention before any push.
+#
+# Rules:
+#   - vX.X.X        -> commit must be reachable from origin/main
+#   - vX.X.X-devel  -> commit must be reachable from origin/devel
+#                      but NOT yet merged into origin/main
+#   - Neither branch -> rejected
+#
+# Enable: git config core.hooksPath .githooks
+
+z40="0000000000000000000000000000000000000000"
+
+while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
+    # Only inspect tag pushes
+    case "$remote_ref" in refs/tags/*) ;; *) continue ;; esac
+
+    # Skip tag deletions
+    [ "$local_sha" = "$z40" ] && continue
+
+    tag="${remote_ref#refs/tags/}"
+
+    # Only enforce versioned tags (vX.X.X or vX.X.X-*)
+    case "$tag" in v[0-9]*.[0-9]*.[0-9]*) ;; *) continue ;; esac
+
+    # Dereference annotated tags to the underlying commit
+    commit=$(git rev-parse --verify "${local_sha}^{commit}" 2>/dev/null) \
+        || commit="$local_sha"
+
+    on_main=0
+    on_devel=0
+    git merge-base --is-ancestor "$commit" "origin/main"  2>/dev/null && on_main=1
+    git merge-base --is-ancestor "$commit" "origin/devel" 2>/dev/null && on_devel=1
+
+    if [ "$on_main" = 0 ] && [ "$on_devel" = 0 ]; then
+        echo "error: '$tag' does not point to a commit reachable from 'origin/main' or 'origin/devel'" >&2
+        echo "       Push the commit to the appropriate branch and wait for CI to pass before tagging." >&2
+        exit 1
+    fi
+
+    # A commit merged into main must use the plain vX.X.X form
+    if [ "$on_main" = 1 ]; then
+        case "$tag" in
+            *-devel)
+                echo "error: '$tag' points to a commit on 'main'; use vX.X.X (drop the -devel suffix)" >&2
+                exit 1
+                ;;
+        esac
+    # A commit only on devel must use the vX.X.X-devel form
+    elif [ "$on_devel" = 1 ]; then
+        case "$tag" in
+            *-devel) ;;
+            *)
+                echo "error: '$tag' points to a commit only on 'devel'; use vX.X.X-devel" >&2
+                exit 1
+                ;;
+        esac
+    fi
+done
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,14 @@ pfBlockerNG/
 └── README.md
 ```
 
-Release archives include only `usr/` and `etc/`. Everything else (stubs, scripts, tests, CI, pyproject.toml) is dev-only.
+Release archives include only `usr/` and `etc/`. Everything else (stubs, scripts, tests, CI, pyproject.toml, `.githooks/`) is dev-only.
+
+---
+
+## Git hooks
+
+`.githooks/pre-push` enforces tag naming before pushes reach the remote.
+Activate once after cloning: `git config core.hooksPath .githooks`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,27 @@ The default version is the minimum pfSense CE release supported by this package
 relevant pfSense source files from GitHub and rewrites all stub files except
 `stubs/pfsense/globals.php`, which is manually maintained.
 
+### Git hooks
+
+The repository ships a `pre-push` hook in `.githooks/` that enforces the tag
+naming convention before anything is pushed to the remote:
+
+| Commit reachable from | Required tag form  |
+| --------------------- | ------------------ |
+| `origin/main`         | `vX.X.X`           |
+| `origin/devel` only   | `vX.X.X-devel`     |
+| Neither               | push is rejected   |
+
+Activate the hook once after cloning:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+This is a local client-side guard. The CI release workflow enforces the same
+rules server-side, so tags that bypass the hook are still rejected by GitHub
+Actions.
+
 ### Running the test suite locally
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ When a new version is ready to ship, tag the commit and push the tag:
 
 ```sh
 # From devel (pre-release)
-git tag v3.2.17
-git push origin v3.2.17
+git tag v3.2.17-devel
+git push origin v3.2.17-devel
 
 # From main (production release)
 git tag v3.2.16
-git push origin v3.2.16
+
 ```
 
 The release workflow will:


### PR DESCRIPTION
.githooks/pre-push rejects tag pushes that violate the convention: vX.X.X for commits on main, vX.X.X-devel for devel-only commits. Activate with: git config core.hooksPath .githooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a client-side pre-push Git hook that validates tag pushes against version naming conventions
  * Requires activation after cloning via git config core.hooksPath .githooks
  * Excluded hook files from release archives

* **Documentation**
  * Added a Git hooks section to the development workflow
  * Documented branch-specific tag naming and release/tagging examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andrebrait/pfBlockerNG/pull/1?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->