### PR TITLE
ADR-02: Drop non-Python (native Unbound) DNSBL mode

### DIFF
--- a/.ADRs/ADR_02_Drop_Unbound_Mode/01_Keystone_Force_Python.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/01_Keystone_Force_Python.txt
@@ -1,0 +1,108 @@
+================================================================================
+PHASE 1 PROMPT — Keystone: force Python-only + migrate config
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md  (read it first, esp. §1, §2, §6)
+================================================================================
+
+ROLE
+You are working in the pfBlockerNG repository on the `edge` branch (feature
+branch off `devel`). You are performing Phase 1 of ADR-02 "Drop the non-Python
+(native Unbound) DNSBL mode". This phase is the KEYSTONE: it makes every install
+behave as Python-only DNSBL and migrates stored config, WITHOUT yet deleting any
+native code. Native branches become unreachable but remain in the tree (later
+phases delete them). This keeps the diff reviewable and the package working at
+every commit.
+
+WHY THIS PHASE EXISTS (read before coding)
+DNSBL "mode" is two config keys collapsing into one boolean (ADR §1):
+  dnsbl_mode ∈ {dnsbl_unbound, dnsbl_python}  +  pfb_py_block ∈ {on, off}
+    → $pfb['dnsbl_py_blacklist'] = (dnsbl_mode==dnsbl_python && pfb_py_block==on)
+TRUE = Python blocks; FALSE = native Unbound blocks. By pinning this boolean to
+TRUE in code (the runtime safety net) AND rewriting stored config (the cleanup),
+every state becomes state 3 (Python-only). Nothing downstream needs to change in
+this phase — the existing native branches simply stop executing.
+
+REQUIRED READING (inspect before editing)
+- This is Phase 1 — there is NO prior handoff to read. Start from the ADR below.
+  (You WRITE the handoff for Phase 2 at the end — see HANDOFF.)
+- .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc
+    * the keystone read block (~L844–864): $pfb['dnsbl_mode'], $pfb['dnsbl_py_block'],
+      and the $pfb['dnsbl_py_blacklist'] = FALSE / if(...) TRUE resolution.
+    * the python config generation that emits `python_blocking` (search
+      "python_blocking" / "$python_blocking") — confirm it derives from
+      dnsbl_py_blacklist, so pinning TRUE keeps `python_blocking = on`.
+- src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+    * the existing VIP-migration block (L34–107) — COPY ITS STYLE: read config/0,
+      mutate, write_config, idempotent.
+    * the $upgrade_type loop (L211+) for how per-package config upgrades run.
+- CLAUDE.md — PHP standards (tabs, PHP 8.3, no die/exit, stubs for pfSense fns).
+
+ACTION PLAN (ordered)
+1. pfblockerng.inc keystone (~L844–864):
+   - Force the mode: assign $pfb['dnsbl_mode'] = 'dnsbl_python'; (ignore the
+     stored value — runtime safety net for not-yet-migrated configs).
+   - Force the switch: replace the L861–863 conditional with
+     $pfb['dnsbl_py_blacklist'] = TRUE;
+   - Leave the other py_* reads (pfb_py_reply, pfb_py_block, pfb_hsts, …) intact
+     for now; later phases prune pfb_py_block. Do NOT delete native branches yet.
+   - Add a short comment: "// ADR-02: DNSBL is Python-only; native Unbound mode removed."
+
+2. pfblockerng_install.inc — add an idempotent migration (place it near the VIP
+   migration, after L107, before the $upgrade_type loop):
+   - $cfg = config_get_path('installedpackages/pfblockerngdnsblsettings/config/0', []);
+   - If $cfg is non-empty AND (dnsbl_mode !== 'dnsbl_python' || (pfb_py_block ?? '') !== 'on'):
+       set dnsbl_mode = 'dnsbl_python'; set pfb_py_block = 'on';
+       (optionally unset native-only TLD-Whitelist keys IF you can identify them
+        unambiguously — otherwise leave them; they become inert. Do NOT touch
+        pfb_tld / wildcard-blocking keys.)
+       config_set_path(...); write_config('pfBlockerNG: migrated DNSBL to Python-only mode');
+   - Guard so re-running on an already-migrated config is a no-op (the if-condition
+     above already provides this).
+   - Do NOT force a reload here directly; the standard install/upgrade flow
+     rebuilds DNSBL. (If the surrounding code has an established reload trigger
+     used by other migrations, follow it; otherwise leave the rebuild to the
+     normal sync.)
+
+CONSTRAINTS
+- PHP: tabs; PHP 8.3; no die()/exit() in library code; pfSense functions resolve
+  from stubs/pfsense/ (add a stub if intelephense flags a genuinely new fn — do
+  not expand suppressions).
+- Do NOT delete any native code path in this phase. Do NOT touch the UI, shell,
+  alerts, widget, or pfb_unbound.py.
+- Keep `python_blocking = on` being emitted (verify, don't assume).
+
+VERIFICATION
+- `php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc` and
+  `php -l src/usr/local/pkg/pfblockerng/pfblockerng_install.inc` → no syntax errors
+  (if php is unavailable in the env, say so and rely on careful diff-read).
+- grep: $pfb['dnsbl_py_blacklist'] is now assigned TRUE unconditionally and the
+  former FALSE/if resolution is gone.
+- `python -m pytest` → still green (pfb_unbound.py untouched; sanity only).
+- Reason through the migration: a config with dnsbl_mode=dnsbl_unbound, and one
+  with dnsbl_python+pfb_py_block=off, both end on dnsbl_python+pfb_py_block=on;
+  a second run is a no-op.
+
+EXPECTED RESULT
+- Fresh installs and upgraded installs both run Python-only DNSBL.
+- Native branches are dead-but-present (deleted in Phases 2–5).
+- No behavior change for users already in state 3.
+
+COMMIT
+Single commit:
+    pfblockerng: force Python-only DNSBL and migrate legacy mode config (ADR-02 P1)
+Land on `edge`. Push directly; open a PR only if the push is rejected by branch
+protection. PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/01_Results.txt`
+This file is a HANDOFF for the agent that will perform the NEXT phase
+(02_UI_Remove_Toggle.txt) — NOT merely a changelog of this phase. Write it as
+plain text (.txt, not markdown), and make it self-sufficient: the next agent
+should be able to start from it without re-deriving this phase's work. Include:
+- State after this phase: $pfb['dnsbl_py_blacklist'] is now a constant TRUE; both
+  legacy config states migrate to dnsbl_python + pfb_py_block=on.
+- What changed: exact lines edited in the keystone; the migration block added.
+- Verification results: php -l / pytest output; confirmation that
+  `python_blocking = on` is still emitted.
+- Watch-outs and any deviation from this prompt the next agent must know.
+- Go-ahead for Phase 2: the UI selector/toggle can now be removed safely.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/02_UI_Remove_Toggle.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/02_UI_Remove_Toggle.txt
@@ -1,0 +1,102 @@
+================================================================================
+PHASE 2 PROMPT — Web UI: remove the mode selector + native-only controls
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md  (read §2 "What is removed" / "kept")
+================================================================================
+
+ROLE
+You are on the `edge` branch performing Phase 2 of ADR-02. Phase 1 already pinned
+DNSBL to Python-only in code + config. Now remove the user-facing controls that
+selected the mode or the native-only behavior from the DNSBL settings page. The
+page must still save and render with no PHP notices.
+
+WHY THIS PHASE EXISTS
+With Python the only mode, the "DNSBL Mode" selector and the "Python blocking"
+(pfb_py_block) checkbox are meaningless, and the native-only "TLD Whitelist" UI
+no longer applies. Several JS handlers gate fields on `dnsbl_mode == 'dnsbl_python'`
+or on pfb_py_block; with one mode these collapse to "always shown".
+
+CRITICAL DISTINCTION (do not get this wrong — ADR §2 "kept")
+- REMOVE: "DNSBL Mode" select (dnsbl_mode), "Python blocking" checkbox
+  (pfb_py_block), the `.dnsbl_unbound_tld` infoblocks, and the **TLD Whitelist**
+  UI (tld_segment / dnsbl_tld_remove consolidation — native-only).
+- KEEP: the "Wildcard Blocking (TLD)" checkbox (pfb_tld) — this is the shared
+  wildcard-blocking feature used in Python mode too. KEEP all other python
+  feature controls (pfb_py_reply, pfb_py_nolog, pfb_noaaaa, pfb_pytld, pfb_hsts,
+  pfb_cname, pfb_gp, pfb_regex, pfb_control).
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/01_Results.txt — it states the actual
+  post-Phase-1 code state and any deviations from plan. If it is missing, Phase 1
+  is not complete; STOP and report.
+- .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
+- src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+    * pconfig defaults for dnsbl_mode (~L57–62) and pfb_py_block (~L67).
+    * $options_dnsbl_mode (~L118).
+    * POST save: pfb_py_block + dnsbl_mode handling and the reload-on-mode-change
+      logic (~L611–622); the select_options validation default
+      'dnsbl_mode' => 'dnsbl_unbound' (~L356).
+    * dnsbl_mode Form_Select (~L769–784) and pfb_py_block Form_Checkbox (~L834+).
+    * `.dnsbl_unbound_tld` infoblocks (~L724–768) and TLD-Whitelist UI; the note
+      at ~L2894 ("TLD Whitelist is not utilized for Unbound python mode").
+    * JS block ~L3106–3220: hideCheckbox(... !python) calls, the
+      `dnsbl_mode == 'dnsbl_unbound'` / `pfb_py_block` show/hide, `.dnsbl_unbound_tld`
+      toggles, and the `$('#dnsbl_mode').click(...)` / `$('#pfb_py_block').click(...)` handlers.
+
+ACTION PLAN
+1. Remove the pconfig blocks that derive/seed dnsbl_mode (~L57–62) and
+   pfb_py_block (~L67).
+2. Remove $options_dnsbl_mode (~L118).
+3. Remove the dnsbl_mode Form_Select and the pfb_py_block Form_Checkbox inputs.
+4. POST/save: remove reads of $_POST['dnsbl_mode'] and $_POST['pfb_py_block'],
+   the reload-on-mode-change branch (~L611–612), the `?: 'dnsbl_unbound'` default
+   write (~L622), and the 'dnsbl_mode' entry in the select_options validation
+   array (~L356). Do not break neighboring field saves.
+5. Remove the `.dnsbl_unbound_tld` infoblocks and the TLD-Whitelist UI section
+   (and its ~L2894 conditional message). Keep the pfb_tld "Wildcard Blocking"
+   checkbox.
+6. JS (~L3106–3220): simplify. The page now always runs Python mode, so:
+   - treat the `python` condition as always-true: remove `hideCheckbox(..., !python)`
+     gating so those fields are unconditionally shown; delete branches keyed on
+     `dnsbl_mode == 'dnsbl_unbound'` and on `pfb_py_block` visibility.
+   - remove `.dnsbl_unbound_tld` show/hide logic entirely.
+   - remove the `$('#dnsbl_mode').click(...)` and `$('#pfb_py_block').click(...)`
+     handlers and any function that only existed to react to them.
+   - keep handlers for surviving fields (pfb_pytld text, pfb_regex, pfb_noaaaa,
+     pfb_gp visibility) — but since they were gated on `dnsbl_mode=='dnsbl_python'`
+     (now always true), unwrap that guard.
+
+CONSTRAINTS
+- PHP: tabs; no die()/exit(); keep Form_* API usage consistent with the page.
+- Do NOT remove pfb_tld or any python feature control. Do NOT touch
+  pfblockerng.inc native branches yet (Phase 3), the shell, alerts, or widget.
+
+VERIFICATION
+- `php -l src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php` → clean.
+- grep the file: no remaining `dnsbl_mode`, `pfb_py_block`, `$options_dnsbl_mode`,
+  or `dnsbl_unbound_tld` references.
+- Diff-read the JS: no references to removed element IDs/classes; surviving
+  field toggles still wired.
+- `python -m pytest` → green (sanity).
+
+EXPECTED RESULT
+- DNSBL settings page shows no mode selector and no Python-blocking checkbox;
+  saving works; python feature fields render unconditionally; TLD Whitelist UI
+  is gone; Wildcard Blocking (pfb_tld) remains.
+
+COMMIT
+    pfblockerng: remove DNSBL mode selector and native-only UI (ADR-02 P2)
+Land on `edge`. Push directly; PR only if rejected. PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/02_Results.txt`
+This file is a HANDOFF for the agent that will perform the NEXT phase
+(03_Core_Remove_Native.txt) — NOT merely a changelog of this phase. Write it as
+plain text (.txt, not markdown), self-sufficient for the next agent. Include:
+- State after this phase: the DNSBL settings page no longer posts dnsbl_mode or
+  pfb_py_block; native-only UI (TLD Whitelist, .dnsbl_unbound_tld) is gone;
+  pfb_tld and the python feature controls remain.
+- What changed: inputs and JS handlers removed; POST/validation edits.
+- Verification results: php -l / grep / pytest output.
+- Watch-outs and any deviation from this prompt the next agent must know.
+- Go-ahead for Phase 3: the core can collapse branches knowing the UI is clean.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/03_Core_Remove_Native.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/03_Core_Remove_Native.txt
@@ -1,0 +1,116 @@
+================================================================================
+PHASE 3 PROMPT — Core: delete native blocking + the queries daemon
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md  (read §2 in full — the deletion rule
+     and the KEPT list are load-bearing)
+================================================================================
+
+ROLE
+You are on the `edge` branch performing Phase 3 of ADR-02 — the largest phase.
+Phases 1–2 pinned Python-only and removed the UI controls. Now delete the native
+Unbound DNSBL machinery from src/usr/local/pkg/pfblockerng/pfblockerng.inc. This
+is mechanical but high-volume (~50 branch sites); work methodically and keep the
+package coherent at the end.
+
+THE DELETION RULE (apply literally — ADR §2)
+$pfb['dnsbl_py_blacklist'] is now always TRUE (Phase 1). Therefore:
+  - `if (!$pfb['dnsbl_py_blacklist']) { BLOCK }`         → delete BLOCK (dead).
+  - `if (!$pfb['dnsbl_py_blacklist'] && COND) { BLOCK }` → delete BLOCK (dead;
+        COND can't make a false-AND true). If there's an `else`, keep+unwrap it.
+  - `if ($pfb['dnsbl_py_blacklist']) { BLOCK }`          → unwrap BLOCK (always runs).
+  - `if ($pfb['dnsbl_py_blacklist'] && COND) { BLOCK }`  → reduce to `if (COND)`.
+  - ternary `$pfb['dnsbl_py_blacklist'] ? A : B`         → A.
+  - `!$pfb['dnsbl_py_blacklist'] ? A : B`                → B.
+After collapsing all sites, delete the $pfb['dnsbl_py_blacklist'] definition.
+Also collapse inc-internal `$pfb['dnsbl_mode'] == 'dnsbl_python'` guards to
+unconditional (always true now). LEAVE the Phase-1 keystone assignment
+`$pfb['dnsbl_mode'] = 'dnsbl_python';` in place for now — alerts/widget still read
+it cross-file; Phase 5 removes it once those are converted.
+
+KEEP — DO NOT DELETE (ADR §2 "kept" — common traps)
+- lighttpd webserver, DNSBL VIP, NAT rules, pfb_dnsbl service, pfb_create_lighttpd().
+  These serve the Python block page + logging. NOT native-only.
+- pfb_tld / $pfb['dnsbl_tld'] (Wildcard Blocking TLD) — used in Python mode too.
+- pfb_py_reply / pfb_py_nolog and the webserver-vs-python logging selection.
+- The `python_blocking = on` emission in the resolver-config generation.
+
+PURE-NATIVE ARTIFACTS TO REMOVE (regardless of branch form)
+- pfb_dnsbl.conf (the "<dnsbl_file>.conf") local-zone/local-data generation and
+  the code that includes it in the resolver config; the `pfb_dnsbl.*conf`
+  include manipulation that pertains to the native local-data file (keep python
+  data file handling).
+- Native safesearch/youtube/doh `.conf` writes — the `!$pfb['dnsbl_py_blacklist']`
+  branches in the safesearch section. Keep the python-side safesearch handling.
+- The "queries" log-tailing daemon:
+    * in pfb_dnsbl_service() the rc script: remove the `unbound_mode` read and the
+      `if [ "${unbound_mode}" == 'dnsbl_unbound' ]; then php ... queries &` branch
+      (the daemon is never started now). Keep the lighttpd start.
+    * remove the `queries` dispatch in this file and pfb_dnsbl_parse('daemon', …)
+      and any helper used ONLY by that daemon path. VERIFY callers first: if
+      pfb_dnsbl_parse is also used by the webserver path, keep the function and
+      remove only the 'daemon' branch/loop and the `queries` invocation.
+- Live-update-without-reload: the `dnsbl_sync` / dnsbl_livesync feature is native-
+  only (gated by !dnsbl_py_blacklist, ~L3412 and ~L3501). Remove those branches,
+  including `exec("{$pfb['script']} dnsbl_livesync …")` (~L3418). (The shell
+  function itself is removed in Phase 4.)
+- Builder selection: at the domaintld/domaintldpy fork (~L3136–3151), keep only
+  `exec("{$pfb['script']} domaintldpy …")` and remove the native
+  `exec("{$pfb['script']} domaintld x x x …")` branch.
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/02_Results.txt — it states the actual
+  post-Phase-2 code state and any deviations from plan. If it is missing, Phase 2
+  is not complete; STOP and report.
+- .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc — grep your worklist first:
+    grep -n "dnsbl_py_blacklist\|dnsbl_mode\|pfb_dnsbl.conf\|pfb_dnsbl.\*conf\|queries\|dnsbl_livesync\|dnsbl_sync\|domaintld" src/usr/local/pkg/pfblockerng/pfblockerng.inc
+  Work through every hit and classify it by the deletion rule above.
+- CLAUDE.md — PHP standards.
+
+ACTION PLAN
+1. Build the worklist via the grep above; tag each line: delete / unwrap / keep.
+2. Collapse all dnsbl_py_blacklist and inc-internal dnsbl_mode sites.
+3. Remove the pure-native artifacts listed above (conf gen, native safesearch/
+   youtube/doh writes, queries daemon + parser path, livesync, native builder exec).
+4. Delete the $pfb['dnsbl_py_blacklist'] definition (~L861–863, now reduced).
+5. Confirm `python_blocking = on` still emitted and lighttpd/VIP/NAT/pfb_tld intact.
+6. Lint + sanity.
+
+CONSTRAINTS
+- PHP: tabs; PHP 8.3; no die()/exit(); pfSense fns via stubs/pfsense/.
+- Do NOT remove webserver/VIP/NAT, pfb_tld, or python feature handling.
+- Do NOT remove the Phase-1 keystone `$pfb['dnsbl_mode']='dnsbl_python';` yet.
+- Do NOT touch the shell functions yet (Phase 4) — only the PHP exec call sites.
+
+VERIFICATION
+- `php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc` → clean.
+- grep: zero `dnsbl_py_blacklist`; zero inc-internal `dnsbl_mode == 'dnsbl_python'`
+  guards remaining; no `queries` daemon launch; no `domaintld ` / `dnsbl_livesync`
+  exec; no `pfb_dnsbl.conf` local-data generation.
+- grep confirms still present: pfb_create_lighttpd, VIP/NAT logic, $pfb['dnsbl_tld'],
+  `python_blocking`, `domaintldpy` exec.
+- `python -m pytest` → green (sanity).
+
+EXPECTED RESULT
+- pfblockerng.inc contains a single DNSBL code path (Python). Native conf
+  generation, the queries daemon, live-sync, and native safesearch writes are gone.
+  Webserver/VIP/NAT and wildcard-TLD blocking remain.
+
+COMMIT
+    pfblockerng: remove native Unbound DNSBL blocking and queries daemon (ADR-02 P3)
+Land on `edge`. Push directly; PR only if rejected. PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/03_Results.txt`
+This file is a HANDOFF for the agent that will perform the NEXT phase
+(04_Shell_Remove_domaintld.txt) — NOT merely a changelog of this phase. Write it
+as plain text (.txt, not markdown), self-sufficient for the next agent. Include:
+- State after this phase: pfblockerng.inc has a single (Python) DNSBL path;
+  $pfb['dnsbl_py_blacklist'] is deleted; webserver/VIP/NAT and pfb_tld retained;
+  `python_blocking = on` still emitted.
+- What changed: count of branch sites collapsed; native artifacts removed.
+- Which shell execs were removed (domaintld, dnsbl_livesync) so Phase 4 can
+  delete the matching shell functions + dispatch cases; confirm domaintldpy is
+  the only builder invocation left.
+- Verification results: php -l / grep / pytest output.
+- Watch-outs and any deviation from this prompt the next agent must know.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/04_Shell_Remove_domaintld.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/04_Shell_Remove_domaintld.txt
@@ -1,0 +1,83 @@
+================================================================================
+PHASE 4 PROMPT — Shell: drop the native conf builder + live-sync
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
+================================================================================
+
+ROLE
+You are on the `edge` branch performing Phase 4 of ADR-02. Phase 3 removed the
+PHP exec calls to the native shell functions. Now delete those now-unreachable
+functions and their dispatch cases from
+src/usr/local/pkg/pfblockerng/pfblockerng.sh, keeping the Python builder.
+
+WHY THIS PHASE EXISTS
+The shell has two DNSBL data builders: domaintld() emits Unbound
+local-zone/local-data (native, removed) and domaintldpy() emits the Python data
+files (kept). dnsbl_livesync() implements native live-update-without-reload
+(removed). Phase 3 stopped PHP from invoking domaintld and dnsbl_livesync; this
+phase removes the dead shell code.
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/03_Results.txt — it states the actual
+  post-Phase-3 code state and which shell execs were removed. If it is missing,
+  Phase 3 is not complete; STOP and report.
+- .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
+- src/usr/local/pkg/pfblockerng/pfblockerng.sh
+    * domaintld()      — ~L474 (native local-zone/local-data builder — REMOVE)
+    * domaintldpy()    — ~L581 (Python data/zone builder — KEEP)
+    * dnsbl_livesync() — ~L643 (native live-sync — REMOVE)
+    * the dispatch `case "${1}" in … esac` (~L1304–1368): the `domaintld)`,
+      `domaintldpy)`, `dnsbl_livesync)` arms.
+    * top-of-file variable definitions for any temp files used ONLY by domaintld /
+      dnsbl_livesync (e.g. native local-zone/local-data add/remove temp paths).
+- CLAUDE.md — POSIX sh only; quote expansions; absolute binary paths; ShellCheck.
+
+ACTION PLAN
+1. Confirm (grep the whole repo) that nothing still invokes `domaintld` (the
+   native one, distinct from `domaintldpy`) or `dnsbl_livesync`:
+     grep -rn "domaintld\b\|dnsbl_livesync" src/   # expect: only definitions/dispatch in the .sh
+   If any PHP exec remains, STOP — Phase 3 was incomplete; report it.
+2. Delete the domaintld() function body and its `domaintld)` dispatch arm.
+   KEEP domaintldpy() and its `domaintldpy)` arm untouched.
+3. Delete the dnsbl_livesync() function body and its `dnsbl_livesync)` dispatch arm.
+4. Remove top-of-file variables and any helper used ONLY by the deleted functions
+   (verify each is unused elsewhere via grep before removing — domaintldpy may
+   share some temp files; do NOT remove anything domaintldpy still uses).
+5. Re-check the dispatch `case` is still well-formed (no empty arms, `esac` intact).
+
+CONSTRAINTS
+- POSIX sh only (#!/bin/sh): no bash-isms ([[, arrays, $RANDOM). Quote all
+  expansions. Absolute paths for binaries.
+- Be conservative on shared temp-file vars: when in doubt, leave the variable
+  (an unused var is harmless; removing one domaintldpy needs breaks DNSBL builds).
+
+VERIFICATION
+- ShellCheck clean: `shellcheck -s sh src/usr/local/pkg/pfblockerng/pfblockerng.sh`
+  (only the .shellcheckrc-sanctioned SC1091/SC2154 may remain). If shellcheck is
+  unavailable in the env, say so and diff-read carefully for sh syntax.
+- `sh -n src/usr/local/pkg/pfblockerng/pfblockerng.sh` → parses (no syntax error).
+- grep: no remaining `domaintld\b` (native) or `dnsbl_livesync` definition/dispatch;
+  `domaintldpy` definition + dispatch still present.
+- `python -m pytest` → green (sanity).
+
+EXPECTED RESULT
+- pfblockerng.sh builds only the Python DNSBL data files; native builder and
+  live-sync functions are gone; dispatch handles domaintldpy (+ other surviving
+  commands) only.
+
+COMMIT
+    pfblockerng: remove native DNSBL shell builders domaintld and dnsbl_livesync (ADR-02 P4)
+Land on `edge`. Push directly; PR only if rejected. PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/04_Results.txt`
+This file is a HANDOFF for the agent that will perform the NEXT phase
+(05_Alerts_Widget_Finalize.txt) — NOT merely a changelog of this phase. Write it
+as plain text (.txt, not markdown), self-sufficient for the next agent. Include:
+- State after this phase: pfblockerng.sh builds only the Python data files;
+  domaintld() and dnsbl_livesync() and their dispatch arms are gone; domaintldpy
+  retained.
+- What changed: functions / dispatch arms / variables removed.
+- Verification results: ShellCheck / `sh -n` / grep / pytest output.
+- Watch-outs and any deviation from this prompt the next agent must know.
+- Go-ahead for Phase 5: shell is Python-only; only alerts/widget + final sweep remain.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/05_Alerts_Widget_Finalize.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/05_Alerts_Widget_Finalize.txt
@@ -1,0 +1,99 @@
+================================================================================
+PHASE 5 PROMPT — Alerts/widget collapse + finalize
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md  (§2 deletion rule, §7 done criteria)
+================================================================================
+
+ROLE
+You are on the `edge` branch performing the final phase of ADR-02. Collapse the
+remaining mode branches in the alerts page and the dashboard widget, drop the
+now-unread keystone mode variable, and verify the whole package is Python-only
+with no stray references. This phase closes the ADR.
+
+WHY THIS PHASE EXISTS
+pfblockerng_alerts.php (~30 sites) and pfblockerng.widget.php (3 sites) still
+branch on `$pfb['dnsbl_mode'] == 'dnsbl_python'` and `$pfb['dnsbl_py_blacklist']`.
+With Python the only mode these are constants. Once these readers are gone, the
+Phase-1 keystone `$pfb['dnsbl_mode'] = 'dnsbl_python';` and the `pfb_py_block`
+read in pfblockerng.inc can be removed too.
+
+THE DELETION RULE (same as Phase 3)
+- `$pfb['dnsbl_mode'] == 'dnsbl_python'` → TRUE: unwrap the guarded block; if it's
+  an `else`/ternary, take the python side. `!= 'dnsbl_python'` → FALSE: delete.
+- `$pfb['dnsbl_py_blacklist']` → TRUE; `!$pfb['dnsbl_py_blacklist']` → FALSE.
+  Collapse ternaries to the python side (e.g. column titles "Blocking Type" vs
+  "Top User-Agent" → keep the py label; "DNSBL Webserver/VIP" vs "Not available
+  for HTTPS alerts" → keep the py label).
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/04_Results.txt — it states the actual
+  post-Phase-4 code state and any deviations from plan. If it is missing, Phase 4
+  is not complete; STOP and report.
+- .ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
+- src/usr/local/www/pfblockerng/pfblockerng_alerts.php — grep first:
+    grep -n "dnsbl_mode\|dnsbl_py_blacklist\|dnsbl_python" src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+- src/usr/local/www/widgets/widgets/pfblockerng.widget.php — grep first:
+    grep -n "dnsbl_mode\|dnsbl_py_blacklist\|dnsbl_python" src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc — the Phase-1 keystone
+  `$pfb['dnsbl_mode'] = 'dnsbl_python';` and the `$pfb['dnsbl_py_block']` read.
+- CLAUDE.md — PHP standards.
+
+ACTION PLAN
+1. Collapse every mode/py_blacklist site in pfblockerng_alerts.php per the rule.
+   Watch the dnsbl_stat python-vs-not guard (~L4492) and the column/label
+   ternaries — keep the python-side text.
+2. Collapse the 3 widget guards (~L613, L640, L648) to unconditional.
+3. In pfblockerng.inc: now that no file reads $pfb['dnsbl_mode'] or
+   $pfb['dnsbl_py_block'] for behavior, remove the Phase-1 keystone assignment
+   `$pfb['dnsbl_mode'] = 'dnsbl_python';` and the `$pfb['dnsbl_py_block']` read.
+   (Re-grep the repo to confirm no remaining readers before deleting.)
+   KEEP emitting `python_blocking = on` in the resolver-config generation.
+4. Package-wide sweep — there must be ZERO matches:
+     grep -rn "dnsbl_unbound\|pfb_py_block\|dnsbl_py_blacklist" src/
+   And no behavioral `dnsbl_mode` guards remain (the config key may still appear
+   in migration code in pfblockerng_install.inc — that's expected and correct).
+5. README.md: update only if it documents the DNSBL modes / a min-version or
+   workflow fact that this ADR changed. If nothing applies, leave it.
+
+CONSTRAINTS
+- PHP: tabs; no die()/exit(); pfSense fns via stubs/pfsense/.
+- Do NOT remove the migration in pfblockerng_install.inc (it legitimately
+  references the old key names to rewrite them).
+- KEEP `python_blocking = on` emission, webserver/VIP/NAT, pfb_tld.
+
+VERIFICATION (Definition of Done — ADR §7)
+- `php -l` clean on pfblockerng_alerts.php, pfblockerng.widget.php, pfblockerng.inc.
+- `grep -rn "dnsbl_unbound\|pfb_py_block\|dnsbl_py_blacklist" src/` → no matches.
+- `grep -rn "dnsbl_mode" src/` → matches only inside the install.inc migration.
+- `python -m pytest` → green; `ruff check .` / `ruff format .` clean; ShellCheck
+  clean; intelephense/`php -l` clean.
+- Confirm `python_blocking` still emitted as `on`.
+
+EXPECTED RESULT
+- Alerts page and widget render with no mode branching and no PHP notices.
+- The entire package has a single DNSBL implementation (Python). The only
+  surviving reference to the legacy keys is the one-time config migration.
+
+MANUAL SMOKE (owner: maintainer — record in RESULTS; cannot be automated)
+Run the ADR §7 checklist on a clean install AND a box upgraded from
+dnsbl_unbound (deploy via scripts/deploy.sh). Only after it passes, set ADR
+Status to Accepted.
+
+COMMIT
+    pfblockerng: collapse DNSBL mode branches in alerts/widget and finalize (ADR-02 P5)
+Land on `edge`. Push directly; PR only if rejected. PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/05_Results.txt`
+This is the FINAL phase, so the handoff recipient is the MAINTAINER who runs the
+manual smoke test and closes the ADR — there is no next-phase agent. Write it as
+plain text (.txt, not markdown), self-sufficient. Include:
+- State after this phase: the package has a single (Python) DNSBL implementation;
+  the only surviving legacy-key reference is the install.inc migration;
+  `python_blocking = on` still emitted.
+- What changed: sites collapsed in alerts/widget; the keystone assignment and the
+  pfb_py_block read removed.
+- Full verification output: grep sweep, php -l, ruff, ShellCheck, pytest.
+- The OUTSTANDING manual smoke items (ADR §7) the maintainer must run, and where
+  to record their results before moving Status to Accepted.
+Also update the ADR header Status to "IMPLEMENTED (pending smoke test)".

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
@@ -1,0 +1,168 @@
+# ADR-02: Drop the non-Python (native Unbound) DNSBL mode
+
+- **Status:** **PROPOSED** (2026-05-31)
+- **Date:** 2026-05-31
+- **Component:** DNSBL subsystem — PHP glue (`pfblockerng.inc`, `pfblockerng_install.inc`), Web UI (`pfblockerng_dnsbl.php`, `pfblockerng_alerts.php`, `pfblockerng.widget.php`), shell (`pfblockerng.sh`); the Python plugin (`pfb_unbound.py`) is barely touched.
+- **Target runtime:** pfSense CE 2.8 (PHP 8.3, FreeBSD 15), Unbound `pythonmod` + embedded Python 3.11+.
+
+---
+
+## 1. Context
+
+DNSBL blocking has shipped in two implementations:
+
+1. **Native Unbound mode** — domains are written into Unbound as `local-zone` / `local-data` entries (`pfb_dnsbl.conf`); Unbound itself answers blocked queries with the DNSBL VIP, and a separate PHP **`queries` daemon** tails the Unbound query log to produce DNSBL alerts.
+2. **Unbound Python mode** — `pfb_unbound.py` (loaded via `python_enable` in the resolver config) performs matching per query and returns the DNSBL VIP (→ lighttpd block page + logging) or a null/NXDOMAIN answer. This is the modern path; ADR-01 work pinned its matcher semantics with tests.
+
+### The mode isn't one flag — it's two keys collapsing into one boolean
+
+Config keys (`installedpackages/pfblockerngdnsblsettings/config/0`):
+
+- `dnsbl_mode` ∈ { `dnsbl_unbound`, `dnsbl_python` }
+- `pfb_py_block` ∈ { `on`, off }
+
+Resolved in `pfblockerng.inc` (~L844–863):
+
+```php
+$pfb['dnsbl_py_blacklist'] = ($pfb['dnsbl_mode'] == 'dnsbl_python' && $pfb['dnsbl_py_block'] == 'on');
+```
+
+`dnsbl_py_blacklist` is the **real switch**: TRUE ⇒ Python does the blocking; FALSE ⇒ Unbound-native blocking. There are therefore **three** states today, not two:
+
+| State | `dnsbl_mode` | `pfb_py_block` | `dnsbl_py_blacklist` | Who blocks |
+| --- | --- | --- | --- | --- |
+| 1 | `dnsbl_unbound` | n/a | FALSE | Unbound (native) |
+| 2 | `dnsbl_python` | off | FALSE | Unbound (native); py loaded only for DNS-reply logging |
+| 3 | `dnsbl_python` | on | TRUE | **Python** ← the only state we keep |
+
+States 1 and 2 share **all** native-blocking code, gated throughout by `!$pfb['dnsbl_py_blacklist']` (~50 sites in `pfblockerng.inc`, more in `pfblockerng_alerts.php`).
+
+### Motivation
+
+Python mode is now fast and correct (ADR-01 hardened and benchmarked the matcher). Maintaining the native path doubles the surface of nearly every DNSBL code site, keeps a second blocklist file format (`local-zone`/`local-data`) and a log-tailing daemon alive, and forces every UI/alert site to branch on mode. The native path no longer earns its keep.
+
+---
+
+## 2. Decision
+
+**If DNSBL is enabled, the only implementation is the Unbound Python integration.** Remove the native Unbound DNSBL mechanism entirely, remove the mode selector and the `pfb_py_block` sub-toggle, and auto-migrate existing installs. After this ADR, `dnsbl_py_blacklist` is effectively a constant TRUE and is removed as a variable.
+
+### The safe deletion rule (load-bearing — apply literally)
+
+> Delete **only**: (a) code reachable solely on the FALSE side of `$pfb['dnsbl_py_blacklist']`, and (b) the pure-native artifacts — the `local-zone`/`local-data` conf format, its shell builder, and the `queries` log-tailing daemon. Keep everything that is unconditional or on the TRUE side.
+
+Concretely:
+
+- `dnsbl_py_blacklist` becomes always-true ⇒ every `if (!$pfb['dnsbl_py_blacklist']) { … }` block is **dead** (delete it); every `if ($pfb['dnsbl_py_blacklist'])` becomes **unconditional** (unwrap it); every ternary `X ? py : native` collapses to `py`.
+
+### What is removed
+
+| File | Removed |
+| --- | --- |
+| `pfblockerng_dnsbl.php` | `dnsbl_mode` `Form_Select` + `$options_dnsbl_mode`; `pfb_py_block` `Form_Checkbox`; `.dnsbl_unbound_tld` infoblocks + their JS show/hide; the TLD **Whitelist** UI; `dnsbl_mode => 'dnsbl_unbound'` validation default; POST handling for both removed fields. |
+| `pfblockerng.inc` | the `dnsbl_mode`/`pfb_py_block`/`dnsbl_py_blacklist` reads (replace with constant true at the keystone); all `!$pfb['dnsbl_py_blacklist']` branches; `pfb_dnsbl.conf` (`.conf`) `local-zone`/`local-data` generation; unbound-mode `safesearch`/`youtube`/`doh` `.conf` writes (the py path writes its own data); the `queries` daemon launch in `pfb_dnsbl_service()` (~L1038) and the `pfb_dnsbl_parse('daemon', …)` log-tailing path; live-update-without-reload (`dnsbl_sync` / `dnsbl_livesync`, FALSE-side only). |
+| `pfblockerng.sh` | `domaintld()` (native `local-zone`/`local-data` builder) and any native-only TLD-remove plumbing it owns; **keep** `domaintldpy()`. |
+| `pfblockerng_alerts.php` | every `dnsbl_mode == 'dnsbl_python'` guard becomes unconditional; every `!$pfb['dnsbl_py_blacklist']` branch/ternary collapses to the py side (column titles, "DNSBL Webserver/VIP" labels, suppression handling, agent vs blocking-type, etc.). |
+| `pfblockerng.widget.php` | `dnsbl_mode == 'dnsbl_python'` guards become unconditional. |
+| `pfblockerng_install.inc` | **add** the config migration (see §6). |
+| `pfb_unbound.py` | near-zero — see "kept" note below. |
+
+### What is explicitly KEPT (do NOT delete — common traps)
+
+- **lighttpd webserver, DNSBL VIP, NAT rules, `pfb_dnsbl` service** — these are **not** native-only. Python blocking returns the DNSBL VIP, so the browser still hits lighttpd for the block page and for event logging (unless null-blocking or `pfb_py_nolog`). `pfb_create_lighttpd()` stays.
+- **`pfb_tld` / `$pfb['dnsbl_tld']` (Wildcard Blocking TLD)** — used in **both** modes (e.g. `pfblockerng.inc` ~L8895 sits inside the `dnsbl_py_blacklist` TRUE branch). Only the TLD **Whitelist** (the `tld_seg` / `dnsbl_tld_remove` consolidation surfaced by `.dnsbl_unbound_tld`) is native-specific. Keep the wildcard-blocking feature; remove only the whitelist UI/plumbing tied to the native consolidation.
+- **`pfb_py_reply` (DNS-reply logging), `pfb_py_nolog`, `pfb_noaaaa`, `pfb_pytld`, `pfb_hsts`, `pfb_cname`, `pfb_gp`, `pfb_regex`, `pfb_control`** — Python-mode features; keep.
+- **`python_blocking` `.ini` key** — `pfb_unbound.py` reads it (default `False`, L306). PHP must keep emitting `python_blocking = on` unconditionally, or the plugin would block nothing. (Alternatively flip the py default to True and drop the option — a larger py change; default to the minimal "always emit on".)
+
+---
+
+## 3. Consequences
+
+**Positive**
+- One DNSBL code path. ~50 `!dnsbl_py_blacklist` branches and a parallel blocklist file format disappear; the `queries` log-tailing daemon and its parser disappear.
+- UI/alerts stop branching on mode → simpler pages, fewer states to reason about and test.
+- Removes a class of "works in one mode, broken in the other" bugs.
+
+**Negative / risks**
+- **No automated PHP tests** in this repo. Correctness of the deletion is verified by `intelephense`/lint and **manual smoke on a live pfSense box** (`scripts/deploy.sh`). The smoke checklist (§7) is therefore non-negotiable.
+- **Config migration must be idempotent and safe** for the population currently on `dnsbl_unbound` (or `dnsbl_python` + `pfb_py_block=off`). A botched migration silently changes blocking behavior on upgrade.
+- Risk of over-deletion: removing something on the TRUE side or an unconditional dependency (lighttpd/VIP, `pfb_tld`). Mitigated by the §2 deletion rule and the "kept" list.
+- Large multi-file diff; review in phases.
+
+---
+
+## 4. Action plan (recommended order)
+
+Each phase is an independent commit that leaves the package installable and `python -m pytest` green (the py suite barely moves). **Phase 1 is the keystone**: pin the switch to TRUE first, so the package becomes Python-only behaviorally while the native branches go dead-but-present. Phases 2–5 are then mechanical dead-code deletion that can be reviewed in isolation.
+
+### Phase 1 — Keystone: force Python + migrate config
+Prompt: `01_Keystone_Force_Python.txt`
+- `pfblockerng_install.inc`: add migration — rewrite `dnsbl_unbound` → `dnsbl_python`, set `pfb_py_block = on`, drop the now-meaningless keys; idempotent; follows the existing VIP-migration precedent (`pfblockerng_install.inc` L35–106).
+- `pfblockerng.inc`: at the keystone read (~L844–863), hard-set `$pfb['dnsbl_mode'] = 'dnsbl_python'` and `$pfb['dnsbl_py_blacklist'] = TRUE` (still emit `python_blocking = on`). No branch deletion yet.
+- Result: every install behaves as state 3; native branches are unreachable but still in the tree.
+
+### Phase 2 — Web UI: remove the selector + native-only controls
+Prompt: `02_UI_Remove_Toggle.txt`
+- `pfblockerng_dnsbl.php`: remove `dnsbl_mode` select, `$options_dnsbl_mode`, `pfb_py_block` checkbox, `.dnsbl_unbound_tld` infoblocks + JS, TLD-Whitelist UI, validation default, and POST handling for the removed fields.
+
+### Phase 3 — Core: delete native blocking + the queries daemon
+Prompt: `03_Core_Remove_Native.txt`
+- `pfblockerng.inc`: collapse all `dnsbl_py_blacklist` branches per the §2 rule; delete `pfb_dnsbl.conf` `local-zone`/`local-data` generation, native safesearch/youtube/doh `.conf` writes, the `queries` daemon launch and `pfb_dnsbl_parse('daemon',…)`, and native-only `dnsbl_sync`/`dnsbl_livesync`. Keep lighttpd/VIP/NAT and `pfb_tld`. Remove the `dnsbl_py_blacklist` variable itself.
+
+### Phase 4 — Shell: drop the native conf builder
+Prompt: `04_Shell_Remove_domaintld.txt`
+- `pfblockerng.sh`: delete `domaintld()` and native-only TLD-remove plumbing; keep `domaintldpy()`. Update any PHP call sites/arguments that selected the native builder. ShellCheck clean (POSIX sh).
+
+### Phase 5 — Alerts/widget + finalize
+Prompt: `05_Alerts_Widget_Finalize.txt`
+- `pfblockerng_alerts.php` + `pfblockerng.widget.php`: collapse mode guards to unconditional. Ensure PHP still emits `python_blocking = on`. Update `README.md` if any workflow/min-version text references the modes; sweep for stray `dnsbl_unbound` / `pfb_py_block` references package-wide. `python -m pytest`, `ruff`, ShellCheck, and intelephense clean.
+
+---
+
+## 5. Constraints (from `CLAUDE.md`)
+
+- **PHP**: tabs; PHP 8.3; no `die()`/`exit()` in library code; pfSense functions come from `stubs/pfsense/` — add new ones there rather than expanding suppressions.
+- **Shell**: POSIX `sh` only (no bash-isms); quote all expansions; absolute binary paths; ShellCheck clean (`.shellcheckrc` covers SC1091/SC2154 only).
+- **Python**: 4-space; stdlib only; run `python -m pytest` + `ruff check .` / `ruff format .` after any `pfb_unbound.py`/`tests/` change.
+- **Commits**: `<scope>: <imperative summary>`, no trailing period; land on `devel`. Push directly to `devel`; open a PR only if the push is rejected by branch protection. PR bodies via `--body-file`.
+- **Docs**: update `README.md` only if a workflow/min-version/tooling fact changes.
+
+---
+
+## 6. Config migration (Phase 1 detail)
+
+Existing installs may hold:
+- `dnsbl_mode = dnsbl_unbound` (state 1), or
+- `dnsbl_mode = dnsbl_python` + `pfb_py_block` ≠ `on` (state 2).
+
+On package upgrade, in `pfblockerng_install.inc` (idempotent, guarded so it no-ops on already-migrated configs):
+- set `dnsbl_mode = dnsbl_python`;
+- set `pfb_py_block = on`;
+- optionally drop keys that only ever fed the native path (TLD-Whitelist settings), leaving the wildcard-blocking `pfb_tld` intact;
+- `write_config('pfBlockerNG: migrated DNSBL to Python-only mode')` and trigger the standard DNSBL rebuild so the resolver config and python data files regenerate.
+
+A force-reload is required after migration (the resolver config flips from `local-zone` blocking to `python_enable` blocking).
+
+---
+
+## 7. Definition of done
+
+- Mode selector and `pfb_py_block` toggle gone from the UI; no `dnsbl_unbound` / `pfb_py_block` / `dnsbl_py_blacklist` references remain package-wide (grep clean).
+- Native `pfb_dnsbl.conf` generation, `domaintld()`, and the `queries` daemon removed; lighttpd/VIP/NAT and `pfb_tld` retained.
+- Migration converts both legacy states to Python-only and no-ops on re-run.
+- `python -m pytest` green; `ruff` / ShellCheck / intelephense clean.
+- Status moved to **Accepted** after the manual smoke below passes on a live box.
+
+### Manual smoke test (owner: **maintainer** — no live Unbound in CI)
+
+Deploy via `scripts/deploy.sh`, then on a clean install **and** on a box upgraded from `dnsbl_unbound`:
+
+- [ ] **Upgrade migration:** box previously on `dnsbl_unbound` → after upgrade, DNSBL is enabled, Python integration is active (`python_enable` in resolver config), and blocking still works without manual intervention.
+- [ ] **Exact block:** query a domain that is an exact DNSBL entry → blocked (DNSBL VIP response) and logged via the webserver.
+- [ ] **Wildcard block:** query a subdomain of a wildcard/zone entry → blocked.
+- [ ] **Whitelist:** a whitelisted domain (and a `www.` case) resolves normally.
+- [ ] **TLD wildcard blocking (`pfb_tld` on):** still consolidates/blocks correctly in Python mode (confirms we kept the right TLD code).
+- [ ] **DNS-reply logging (`pfb_py_reply` on) and `pfb_py_nolog`:** both still log as expected.
+- [ ] **Alerts UI + widget:** DNSBL alerts render (blocking-type column, VIP labels) with no PHP notices; unblock/whitelist actions work.
+
+Once all pass, set **Status: Accepted** and record results in `RESULTS/`.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/ADR.md
@@ -1,6 +1,6 @@
 # ADR-02: Drop the non-Python (native Unbound) DNSBL mode
 
-- **Status:** **PROPOSED** (2026-05-31)
+- **Status:** **IMPLEMENTED (pending smoke test)** (2026-05-31) — Phases 1–5 complete on branch `edge`; code is Python-only DNSBL with auto-migration. Acceptance is blocked on the manual smoke test (§7 / `RESULTS/05_Results.txt`), which cannot be automated (no live Unbound in CI).
 - **Date:** 2026-05-31
 - **Component:** DNSBL subsystem — PHP glue (`pfblockerng.inc`, `pfblockerng_install.inc`), Web UI (`pfblockerng_dnsbl.php`, `pfblockerng_alerts.php`, `pfblockerng.widget.php`), shell (`pfblockerng.sh`); the Python plugin (`pfb_unbound.py`) is barely touched.
 - **Target runtime:** pfSense CE 2.8 (PHP 8.3, FreeBSD 15), Unbound `pythonmod` + embedded Python 3.11+.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/01_Results.txt
@@ -1,0 +1,97 @@
+ADR-02 Phase 1 Results — Force Python-only DNSBL + Migrate Config
+=================================================================
+
+STATE AFTER THIS PHASE
+-----------------------
+$pfb['dnsbl_py_blacklist'] is now constant TRUE — assigned unconditionally at
+runtime regardless of stored config. Both legacy config states (dnsbl_unbound
+with any pfb_py_block, or dnsbl_python + pfb_py_block=off) are migrated at
+install/upgrade time to dnsbl_mode=dnsbl_python + pfb_py_block=on.
+Native Unbound code branches remain in-tree but are unreachable.
+
+EXACT CHANGES
+--------------
+
+File: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+1. Line 844 — force dnsbl_mode at runtime (was: read from stored config):
+   BEFORE:
+       $pfb['dnsbl_mode']  = $pfb['dnsblconfig']['dnsbl_mode'];  // DNSBL Mode (Unbound/python mode)
+   AFTER:
+       $pfb['dnsbl_mode']  = 'dnsbl_python';                     // ADR-02: DNSBL is Python-only; native Unbound mode removed.
+
+2. Lines 860-864 — replace conditional with unconditional TRUE (was: FALSE + if-set-TRUE):
+   BEFORE:
+       // DNSBL Resolver mode (Unbound/Python)
+       $pfb['dnsbl_py_blacklist'] = FALSE;
+       if ($pfb['dnsbl_mode'] == 'dnsbl_python' && $pfb['dnsbl_py_block'] == 'on') {
+           $pfb['dnsbl_py_blacklist'] = TRUE;
+       }
+   AFTER:
+       // DNSBL Resolver mode (Unbound/Python)
+       // ADR-02: DNSBL is Python-only; native Unbound mode removed.
+       $pfb['dnsbl_py_blacklist'] = TRUE;
+
+File: src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+
+3. Lines 109-121 — migration block inserted after VIP migration block (after line 107):
+   // ADR-02: Migrate DNSBL mode to Python-only.
+   $cfg = config_get_path('installedpackages/pfblockerngdnsblsettings/config/0', []);
+   if (!empty($cfg) && ($cfg['dnsbl_mode'] !== 'dnsbl_python' || ($cfg['pfb_py_block'] ?? '') !== 'on')) {
+       $cfg['dnsbl_mode']    = 'dnsbl_python';
+       $cfg['pfb_py_block']  = 'on';
+       config_set_path('installedpackages/pfblockerngdnsblsettings/config/0', $cfg);
+       write_config('pfBlockerNG: migrated DNSBL to Python-only mode');
+   }
+   unset($cfg);
+
+VERIFICATION RESULTS
+--------------------
+
+php -l: NOT AVAILABLE in this environment (command not found: php).
+Correctness verified by careful diff-read. Both files have matching braces and no
+unclosed constructs. The conditional block was cleanly replaced with a single
+assignment; the migration block is syntactically simple.
+
+pytest: 163 passed in 0.14s (all green). pfb_unbound.py untouched; test suite
+confirms no regressions.
+
+python_blocking emission confirmed at pfblockerng.inc lines 2429-2432:
+    $python_blocking = 'off';
+    if ($pfb['dnsbl_py_blacklist']) {
+        $python_blocking = 'on';
+    }
+With $pfb['dnsbl_py_blacklist'] = TRUE unconditionally, $python_blocking will
+always be 'on'. Emitted at line 2496: "python_blocking = {$python_blocking}".
+
+MIGRATION REASONING
+--------------------
+State A: dnsbl_mode=dnsbl_unbound, pfb_py_block=anything
+  -> condition ($cfg['dnsbl_mode'] !== 'dnsbl_python') is TRUE -> migrate -> on.
+
+State B: dnsbl_mode=dnsbl_python, pfb_py_block=off
+  -> condition (($cfg['pfb_py_block'] ?? '') !== 'on') is TRUE -> migrate -> on.
+
+State C: dnsbl_mode=dnsbl_python, pfb_py_block=on
+  -> both conditions FALSE -> if-block skipped -> no-op. Idempotent.
+
+WATCH-OUTS / DEVIATIONS
+------------------------
+- php not available in dev environment; syntax verified by inspection only.
+- pfblockerng_install.inc line 520 still reads $pfb['dnsbl_mode'] == 'dnsbl_python'
+  to decide whether to copy pfb_unbound.py into unbound chroot. Since dnsbl_mode
+  is now always 'dnsbl_python' at runtime (pinned at line 844 of pfblockerng.inc),
+  that branch always evaluates TRUE at runtime. The install.inc migration block
+  at line 109 runs BEFORE pfb_global() is called in the normal install flow, so
+  stored config will be correct before the copy-decision check at line 520.
+- No UI, shell scripts, alerts, widget, or pfb_unbound.py touched.
+- $pfb['dnsbl_py_block'] is still read from stored config at pfblockerng.inc line
+  846; left intact per instructions (later phases prune it).
+
+GO-AHEAD FOR PHASE 2
+---------------------
+The UI selector/toggle (dnsbl_mode dropdown, pfb_py_block toggle) can now be
+safely removed from the DNSBL settings page. Both the runtime pin (pfblockerng.inc
+line 844 + 862) and the stored-config migration (pfblockerng_install.inc lines
+109-121) ensure no install can be in native Unbound mode. Removing the UI controls
+will not affect any live system behavior.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/02_Results.txt
@@ -1,0 +1,111 @@
+ADR-02 Phase 2 Results — Web UI: remove mode selector + native-only controls
+=============================================================================
+
+File changed: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php  (only this file)
+
+STATE AFTER THIS PHASE
+-----------------------
+The DNSBL settings page no longer posts dnsbl_mode or pfb_py_block, and no longer
+renders any mode selector, the "DNSBL Blocking (py)" (pfb_py_block) checkbox, the
+.dnsbl_unbound_tld native-only help spans, or the TLD Whitelist field. pfb_tld
+("Wildcard Blocking (TLD)") and all python feature controls remain. The page
+saves and renders with no dependency on the removed config keys.
+
+IMPORTANT for Phase 3 — dnsbl_py_blacklist handling changed plan:
+  dnsbl.php READ $pfb['dnsbl_py_blacklist'] in two spots. I collapsed both to the
+  TRUE (python) branch here (it is always TRUE since Phase 1). This was a
+  deliberate extension beyond the literal Phase-2 list, because Phase 3 plans to
+  DELETE the $pfb['dnsbl_py_blacklist'] variable, which would otherwise break
+  dnsbl.php mid-sequence.
+  => CONSEQUENCE: do NOT remove the $pfb['dnsbl_py_blacklist'] variable DEFINITION
+     in Phase 3. alerts.php and widget.php still read it and are not collapsed
+     until Phase 5. Keep the definition (constant TRUE, set in pfblockerng.inc
+     pfb_global) alive through Phases 3 and 4; remove the definition only in
+     Phase 5 after alerts/widget are collapsed. Collapse each file's USES as you
+     touch that file. (Rule: collapse uses per-file; delete the variable last.)
+
+EXACT CHANGES (25 edits, applied via a count-asserted script; see WATCH-OUTS)
+----------------------------------------------------------------------------
+Removed (PHP):
+- pconfig: the dnsbl_mode block + legacy `pfb_python` shim (old L57-64); the
+  pfb_py_block pconfig line (old L67); the tldwhitelist pconfig line (old L114).
+- $options_dnsbl_mode definition (old L118).
+- global_log help: collapsed `if ($pfb['dnsbl_py_blacklist']) {…} else {…}`
+  (old L125-147) to the TRUE branch, de-indented.
+- POST: the "Remove DNSBL blocking files, when user changes blocking mode" block
+  and the pfb_py_block + dnsbl_mode assignments (old L610-622); the tldwhitelist
+  base64 save (old L594).
+- select_options validation array: the `'dnsbl_mode' => 'dnsbl_unbound'` entry
+  (old L356).
+- customlist validation: the `'tldwhitelist' => 'tldwhite'` foreach entry and the
+  `case 'tldwhite':` switch arm.
+- Form_Select 'dnsbl_mode' (old L769-783); Form_Checkbox 'pfb_py_block'
+  (old L833-846).
+- $dnsbl_text (help for the KEPT pfb_tld checkbox): removed the 4
+  `<span class="dnsbl_unbound_tld">…</span>` native-only spans (low-mem warning,
+  resolver-reload warning, TLD-Whitelist mention, TLD-domain-limit/RAM table).
+  Renamed its container div id `dnsbl_unbound_tld_info` -> `dnsbl_tld_info`.
+- TLD section: renamed Form_Section title 'TLD Blacklist/Whitelist' ->
+  'TLD Blacklist' (id 'TLD_BW_list' kept to avoid JS churn); removed the
+  whitelist-only note sentences; removed $tld_whitelist_text + its
+  `if ($pfb['dnsbl_py_blacklist'])` warning; removed the 'tldwhitelist'
+  Form_Textarea.
+
+JS rewrites:
+- enable_python(): now just `hideCheckbox('pfb_dnsbl_sync', true);` (python is the
+  only mode, so the per-field hideCheckbox(...,!python) gating is gone — fields
+  render shown by default; the `.dnsbl_unbound_tld` and #tldwhitelist toggles are
+  gone).
+- enable_python_pytld / _regex / _noaaaa / _gp: unwrapped the
+  `dnsbl_mode == 'dnsbl_python'` guard (always true).
+- events: removed the `$('#dnsbl_mode').click(...)` and `$('#pfb_py_block').click(...)`
+  handlers; kept the standalone `enable_python();` on-load call.
+
+KEPT (verified present): pfb_tld, pfb_control, pfb_py_reply, pfb_hsts, pfb_idn,
+pfb_regex(+list), pfb_noaaaa(+list), pfb_cname, pfb_gp(+bypass list), pfb_pytld
+(+sort, pfb_python multiclass, dnsbl_python_tld_allow_text), pfb_py_nolog,
+tldblacklist, tldexclusion, and the DNSBL VIP/IP/webpage controls.
+
+VERIFICATION RESULTS
+--------------------
+- php -l: NOT AVAILABLE (no php in env; not installed — Phase 1 was the same).
+  Mitigations used instead:
+    * All 25 edits applied by a script that ASSERTS each pattern matched exactly
+      the expected count (1, except the 4 spans) and refuses to write otherwise.
+    * Brace balance gate: `{}` delta unchanged (0) and `[]` delta unchanged (0)
+      before vs after — code blocks intact. (`()` file-delta shifted +3, fully
+      explained by removed help-text string literals with deliberately unbalanced
+      parens, e.g. the old `(Replace x.x.x.x …` line; not a code change.)
+    * Every edited region re-read by eye for syntactic integrity.
+- grep sweep: ZERO matches for dnsbl_mode, pfb_py_block, options_dnsbl_mode,
+  dnsbl_unbound_tld, dnsbl_py_blacklist, tldwhitelist, #dnsbl_mode, #pfb_py_block.
+- pytest: 163 passed (sanity; no python touched).
+
+WATCH-OUTS / DEVIATIONS
+------------------------
+1. dnsbl_py_blacklist: collapsed in dnsbl.php this phase (see "IMPORTANT for
+   Phase 3" above). Variable definition must NOT be deleted until Phase 5.
+2. pfb_dnsbl_sync ("Resolver Live Sync") field was NOT removed — out of this
+   phase's stated scope. It is native-only (live update without reload) and is
+   now ALWAYS hidden via enable_python() (matching prior python-block behavior).
+   Recommend removing the field in a later phase alongside the dnsbl_sync backend
+   removal (Phase 3 removes the backend; the UI field can be dropped then or in 5).
+3. TLD Whitelist: only the UI is removed here. The backend plumbing (static
+   local-zone generation, gated by !dnsbl_py_blacklist) is still in
+   pfblockerng.inc and is Phase 3's job. The stored `tldwhitelist` config value is
+   intentionally left untouched (no POST save now writes it, so existing data is
+   preserved, not wiped).
+4. TLD Blacklist (tldblacklist) was KEPT — confirmed honored in python mode
+   (pfblockerng.inc ~L2815 "DNSBL python - TLD Blacklist").
+5. Minor stale help wording: the TLD section StaticText still reads
+   "TLD Blacklist/Whitelist: A static zone entry … no Alerts will be generated."
+   Left as-is (informational only); fold into a help-text pass with Phase 3 if
+   desired.
+6. A few cosmetic double-blank-lines remain where blocks were removed (harmless).
+
+GO-AHEAD FOR PHASE 3
+---------------------
+UI is clean and mode-free. The core can now collapse the native branches in
+pfblockerng.inc per the §2 deletion rule. Remember constraint (1): collapse
+dnsbl_py_blacklist USES in inc, but keep the variable DEFINITION (constant TRUE)
+until Phase 5.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/03_Results.txt
@@ -1,0 +1,88 @@
+ADR-02 Phase 3 Results — Core: remove native DNSBL blocking from pfblockerng.inc
+================================================================================
+
+Landed as FOUR verified sub-commits on `edge` (per user request to split P3):
+  3a  pfblockerng: remove native DNSBL resolver-queries daemon
+  3b  pfblockerng: collapse native branches in tld_analysis()
+  3c  pfblockerng: remove native DNSBL config from resolver/lighttpd builders
+  3d  pfblockerng: collapse remaining native DNSBL branches in pfblockerng.inc
+
+STATE AFTER THIS PHASE
+-----------------------
+pfblockerng.inc now has a SINGLE (Python) DNSBL path. Every
+`$pfb['dnsbl_py_blacklist']` and `$pfb['dnsbl_mode'] == 'dnsbl_python'`
+conditional has been collapsed (python branch kept/unwrapped, native branch
+deleted, native-only conjuncts dropped). The ONLY remaining reference to
+dnsbl_py_blacklist is its DEFINITION:
+    L862:  $pfb['dnsbl_py_blacklist'] = TRUE;
+This definition is intentionally RETAINED — alerts.php and widget.php still read
+$pfb['dnsbl_py_blacklist'] and $pfb['dnsbl_mode'] and are not collapsed until P5.
+Likewise the P1 keystone `$pfb['dnsbl_mode'] = 'dnsbl_python';` is still in place.
+=> P5 removes both definitions AFTER alerts/widget are converted.
+
+What was removed:
+- The native resolver-queries daemon: rc start/stop wiring, the `queries` argv
+  entry, and pfb_daemon_queries(). (pfb_dnsbl_parse retained — shared with the
+  webserver collectors and alerts.php's pfb_dnsbl_parse('alerts',...).)
+- tld_analysis(): native local-zone/local-data parsing & writes, the native
+  TLD-Blacklist skip, the native `domaintld` exec, and 69 lines of dead native
+  fall-through in the TLD-blacklist loop.
+- Resolver/lighttpd config: native `server:include: pfb_dnsbl.*conf` add/remove
+  and module-config/python-script mode guards; lighttpd event logging now gated
+  only on pfb_py_nolog.
+- pfb_reload_unbound / pfb_update_unbound: the Resolver Live Sync path (incl. the
+  `dnsbl_livesync` exec) -> always a full reload; native .raw->.conf rename,
+  native unbound-checkconf, pfb_dnsbl.conf backup/clear, native count check.
+- top1m / SafeSearch / feed-build: native local-data formats -> python CSV.
+
+SHELL EXECS (for Phase 4)
+-------------------------
+pfblockerng.inc now invokes ONLY:
+    L2906:  exec("{$pfb['script']} domaintldpy >> {$pfb['log']} 2>&1");
+The native `domaintld` exec (removed in 3b) and `dnsbl_livesync` exec (removed in
+3d) are GONE from PHP. => Phase 4 can safely delete the domaintld() and
+dnsbl_livesync() shell functions + their `case` dispatch arms in
+pfblockerng.sh; KEEP domaintldpy(). (Verify with:
+    grep -rn "domaintld\b\|dnsbl_livesync" src/   # expect only the .sh definitions/dispatch)
+
+KEPT INTACT (do NOT remove)
+---------------------------
+- lighttpd webserver / DNSBL VIP / NAT / pfb_create_lighttpd() (Python returns
+  the VIP -> webserver serves block page + logs).
+- pfb_tld / $pfb['dnsbl_tld'] (Wildcard Blocking TLD) — used in Python mode.
+- SafeSearch CNAME path: still writes/serves a native pfb_dnsbl.<type>.conf
+  (DDG/PIX) static-zone include in Python mode (documented "to be removed when
+  SafeSearch CNAME python mode is fixed"). Its safesearch_enable branches were
+  deliberately preserved.
+- `python_blocking = on` still emitted (resolver config, ~L2427).
+
+VERIFICATION RESULTS
+--------------------
+- php is now INSTALLED (Homebrew, php 8.5; `brew uninstall php` to revert).
+  `php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc` -> No syntax errors.
+- Delimiter balance (string/heredoc/comment-aware checker): BALANCED ({}/()/[]
+  deltas unchanged vs. pre-edit valid file).
+- `python -m pytest` -> 163 passed (pfb_unbound.py untouched).
+- grep: zero dnsbl_py_blacklist conditionals (only the L862 def); zero
+  dnsbl_mode == 'dnsbl_python' guards.
+- Collapses were applied by a string/heredoc-aware brace-matching tool
+  (/tmp/pfcollapse.py) + literal substring simplifications, each count-asserted;
+  the full diff was reviewed hunk-by-hunk.
+
+WATCH-OUTS / DEVIATIONS
+------------------------
+1. dnsbl_py_blacklist var def (L862) and dnsbl_mode keystone retained until P5
+   (see above). Do NOT remove them in P4.
+2. $pfb['dnsbl_sync'] (config read, ~L841) is now effectively unused (Live Sync
+   removed). Harmless leftover; can be dropped with the Resolver Live Sync UI
+   field (pfb_dnsbl_sync) in a later cleanup. The UI field is still present but
+   hidden (per P2).
+3. Minor cosmetic: a redundant `$python_blocking = 'off';` immediately followed
+   by `$python_blocking = 'on';` (the 'on' is now unconditional). Harmless.
+4. A few cosmetic double-blank-lines remain where blocks were removed.
+
+GO-AHEAD FOR PHASE 4
+---------------------
+The shell is now the only place the native builder/live-sync functions live.
+Proceed to delete domaintld() and dnsbl_livesync() (+ dispatch arms) from
+pfblockerng.sh; keep domaintldpy(). No PHP caller invokes them anymore.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/04_Results.txt
@@ -1,0 +1,65 @@
+ADR-02 Phase 4 Results — Shell: remove native DNSBL builders from pfblockerng.sh
+================================================================================
+
+File changed: src/usr/local/pkg/pfblockerng/pfblockerng.sh (only this file; -198 lines)
+
+STATE AFTER THIS PHASE
+-----------------------
+pfblockerng.sh now builds ONLY the Python DNSBL data files. The native
+Unbound builders are gone:
+- domaintld()      (native local-zone/local-data builder) — REMOVED.
+- dnsbl_livesync() (native live-update-without-reload)    — REMOVED.
+- domaintldpy()    (Python data/zone builder)             — KEPT, untouched.
+The `case "${1}"` dispatch keeps the `domaintldpy)` arm (and all other
+commands: dnsbl_scrub, cidr_aggregate, whoisconvert, iptoasn, asn_table,
+suppress, dmax, pmax, et, xlsx, remove, aliastables, closing, _* …); the
+`domaintld)` and `dnsbl_livesync)` arms were removed. No PHP code invokes the
+removed functions (Phase 3 dropped those execs).
+
+WHAT CHANGED
+-------------
+- Removed function domaintld() and its `domaintld)` dispatch arm.
+- Removed function dnsbl_livesync() and its `dnsbl_livesync)` dispatch arm.
+- Removed 6 top-of-file temp vars used ONLY by dnsbl_livesync:
+    dnsbl_add, dnsbl_add_zone, dnsbl_add_data,
+    dnsbl_remove, dnsbl_remove_zone, dnsbl_remove_data.
+- Removed 3 vars that became orphaned once domaintld/dnsbl_livesync were gone
+  (each was used ONLY by those functions; verified by word-boundary grep, and
+  the original committed file had no SC2034 for them):
+    DEBUG (=0), dnsbl_file (=/var/unbound/pfb_dnsbl), dnsbl_tmp (=/tmp/DNSBL_TMP/).
+- Removed a dead `dnsbl_files="${cc}";` assignment (+ its "# List of Feeds"
+  comment) at the top of domaintldpy(): it was set but never read (the global
+  was only consumed by the removed domaintld()); confirmed unused by grep.
+  domaintldpy()'s actual logic is unchanged.
+
+VERIFICATION RESULTS
+--------------------
+- `sh -n src/usr/local/pkg/pfblockerng/pfblockerng.sh` -> parses, no errors.
+- `shellcheck -s sh src/usr/local/pkg/pfblockerng/pfblockerng.sh` -> CLEAN
+  (zero findings after the .shellcheckrc-sanctioned SC1091/SC2154; the 3 SC2034
+  warnings introduced by the function removal were resolved by deleting the now-
+  orphaned vars above).
+- grep: no `domaintld`/`dnsbl_livesync` definition or dispatch remains;
+  `domaintldpy` definition + `domaintldpy)` arm present.
+- `python -m pytest` -> 163 passed (sanity; no python changed).
+
+WATCH-OUTS / DEVIATIONS
+------------------------
+- Removing DEBUG/dnsbl_file/dnsbl_tmp/dnsbl_files goes slightly beyond "delete
+  the two functions": they were dead solely because those functions were
+  removed, and leaving them broke the ShellCheck-clean requirement. All four
+  were proven unused (word-boundary grep returned only the definition line).
+- pfblockerng.inc still defines $pfb['dnsbl_sync'] (config read) which is now
+  unused (Live Sync gone); harmless. The Resolver Live Sync UI field
+  (pfb_dnsbl_sync) is still present but hidden (per P2). These can be dropped in
+  a later cleanup.
+
+GO-AHEAD FOR PHASE 5
+---------------------
+Shell is Python-only. Only the final phase remains: collapse the mode branches
+in pfblockerng_alerts.php and pfblockerng.widget.php, then REMOVE the now-unused
+definitions in pfblockerng.inc — $pfb['dnsbl_py_blacklist'] = TRUE (L862) and the
+P1 keystone $pfb['dnsbl_mode'] = 'dnsbl_python' — and the $pfb['dnsbl_py_block']
+read, once no file reads them. Keep emitting `python_blocking = on`. Final
+package-wide grep must show zero dnsbl_unbound / pfb_py_block / dnsbl_py_blacklist
+(except the install.inc migration) and no behavioral dnsbl_mode guards.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/05_Results.txt
@@ -1,0 +1,99 @@
+ADR-02 Phase 5 Results — Alerts/widget collapse + finalize (FINAL PHASE)
+========================================================================
+
+Recipient: the MAINTAINER. Code work for ADR-02 is complete; acceptance is
+blocked ONLY on the manual smoke test below (no live Unbound in CI). No next
+agent phase.
+
+STATE AFTER THIS PHASE
+-----------------------
+The entire package now has a SINGLE DNSBL implementation (Unbound Python
+integration). Every dnsbl_mode / dnsbl_py_blacklist conditional is gone, and the
+defining variables have been removed. The ONLY surviving reference to the legacy
+keys is the one-time config migration in pfblockerng_install.inc (which rewrites
+dnsbl_unbound / pfb_py_block!=on -> dnsbl_python + pfb_py_block=on). `python_blocking
+= on` is still emitted in the resolver config.
+
+WHAT CHANGED (this phase)
+-------------------------
+- pfblockerng_alerts.php: collapsed ~28 sites — pure if(py) unwrapped; if(!py)
+  deleted/else-kept; the two mixed `(... && !py && ...) || py` guards reduced to
+  always-true (unwrapped); the `py ? A : B` ternaries (column titles, "DNSBL
+  Webserver/VIP" labels) taken to the python side; the `dnsbl_mode == 'dnsbl_python'`
+  standalone guards unwrapped; the `dnsbl' == 'on' && dnsbl_mode==python` conjunct
+  reduced; the dnsbl_stat `&& dnsbl_mode != 'dnsbl_python'` elseif (always false)
+  deleted.
+- pfblockerng.widget.php: 3 sites — `if(dnsbl_mode==python){py}else{unbound}`
+  unwrapped to the Python branch; two `dnsbl_mode==python && filesize` conjuncts
+  reduced.
+- ALSO collapsed (found by the package-wide sweep — not in the original P5 prompt
+  list): pfblockerng_category.php (2), pfblockerng_category_edit.php (2),
+  pfblockerng_log.php (1) — all read $pfb['dnsbl_py_blacklist'].
+- pfblockerng_install.inc: collapsed L520 `($pfb['dnsbl_mode'] == 'dnsbl_python') &&
+  is_dir(...)` -> `is_dir(...)` (the chroot-copy guard) so it no longer depends on
+  the keystone. The migration block is unchanged.
+- pfblockerng.inc: REMOVED the P1 keystone `$pfb['dnsbl_mode'] = 'dnsbl_python'`,
+  the `$pfb['dnsbl_py_block']` read, and the `$pfb['dnsbl_py_blacklist'] = TRUE`
+  definition. Simplified the leftover `$python_blocking='off'; $python_blocking='on';`
+  to a single `$python_blocking = 'on';`.
+
+VERIFICATION RESULTS (Definition of Done — ADR §7)
+--------------------------------------------------
+- `php -l` (Homebrew php 8.5): clean on all changed files — pfblockerng.inc,
+  pfblockerng_install.inc, pfblockerng_alerts.php, pfblockerng_category.php,
+  pfblockerng_category_edit.php, pfblockerng_log.php, pfblockerng.widget.php.
+- Delimiter-balance checker: BALANCED on the PHP files.
+- `grep -rn "dnsbl_unbound\|pfb_py_block\|dnsbl_py_blacklist" src/` -> ONLY the
+  install.inc migration (L111, L113). No other matches.
+- `grep -rn "dnsbl_mode" src/` -> ONLY the install.inc migration (L111, L112).
+- `python -m pytest` -> 163 passed.  `ruff check .` -> All checks passed.
+- `shellcheck -s sh pfblockerng.sh` -> 0 findings (beyond sanctioned SC1091/SC2154).
+- `python_blocking = on` confirmed still emitted (pfblockerng.inc ~L2415).
+- README.md: no DNSBL-mode / min-version / workflow references — nothing to update.
+
+Phase 5 collapses were applied with the string/heredoc-aware brace-matching tool
+(/tmp/pfcollapse.py) + literal count-asserted substring replacements; the two
+mixed-boolean guards and all dnsbl_mode/elseif cases were verified by reading and
+by full-diff review.
+
+COMMIT LAYOUT FOR ADR-02 (branch `edge`)
+----------------------------------------
+  P1  f6df43c  force Python-only DNSBL + migrate legacy mode config
+  P2  9b051d3  remove DNSBL mode selector and native-only UI
+  P3a 463af59  remove native resolver-queries daemon
+  P3b 1bc2ee6  collapse native branches in tld_analysis()
+  P3c c0c3331  remove native config from resolver/lighttpd builders
+  P3d 158f9d2  collapse remaining native branches in pfblockerng.inc
+  P4  964ab65  remove native shell builders domaintld/dnsbl_livesync
+  P5  (this commit) collapse alerts/widget/category/log + remove definitions
+
+WATCH-OUTS / KNOWN RESIDUALS (harmless; optional later cleanup)
+---------------------------------------------------------------
+- $pfb['dnsbl_sync'] (pfblockerng.inc) and the Resolver Live Sync UI field
+  (pfb_dnsbl_sync, currently hidden) are now dead (Live Sync removed in P3/P4).
+  Safe to drop in a follow-up; left in place to keep P5 scoped.
+- alerts.php: `if ($logtype == 'DNSBL Block') { continue 2; break; }` — the
+  `break;` is unreachable after the unconditional `continue 2;` (cosmetic).
+- A few orphaned comments / double-blank-lines where native blocks were removed.
+
+================================================================================
+OUTSTANDING — MANUAL SMOKE TEST (owner: MAINTAINER)  ** required before Accept **
+================================================================================
+No live Unbound exists in dev/CI, so these cannot be automated. Deploy with
+scripts/deploy.sh to a live pfSense box and run on BOTH a clean install AND a box
+upgraded from a `dnsbl_unbound` config. Record results here, then set ADR Status
+to **Accepted**.
+
+[ ] Upgrade migration: box previously on dnsbl_unbound -> after pkg upgrade, DNSBL
+    enabled, Python integration active (python_enable + pfb_unbound.py in the
+    resolver config), blocking works with no manual step.
+[ ] Exact block: query an exact DNSBL entry -> blocked (DNSBL VIP) and logged.
+[ ] Wildcard block: query a subdomain of a wildcard/zone entry -> blocked.
+[ ] Whitelist: a whitelisted domain (and a www. case) resolves normally.
+[ ] TLD wildcard blocking (pfb_tld on): still consolidates/blocks in Python mode.
+[ ] DNS-reply logging (pfb_py_reply) and pfb_py_nolog: both log as expected.
+[ ] SafeSearch (incl. CNAME DDG/PIX) still works in Python mode.
+[ ] Alerts UI + dashboard widget: render with no PHP notices; blocking-type
+    column + "DNSBL Webserver/VIP" labels correct; unblock/whitelist actions work.
+
+Once all pass: set ADR header Status to "Accepted" and record the date/result.

--- a/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/05_Results.txt
@@ -76,6 +76,34 @@ WATCH-OUTS / KNOWN RESIDUALS (harmless; optional later cleanup)
   `break;` is unreachable after the unconditional `continue 2;` (cosmetic).
 - A few orphaned comments / double-blank-lines where native blocks were removed.
 
+UPDATE (post-P5 follow-up — commit acb31a7): the residuals listed above are RESOLVED
+-------------------------------------------------------------------------------------
+The "KNOWN RESIDUALS" text above is left intact as originally written. After P5, a
+dedicated follow-up commit (acb31a7) cleaned all three items:
+- Removed the dead $pfb['dnsbl_sync'] read and the "Resolver Live Sync"
+  (pfb_dnsbl_sync) UI field — its pconfig seed, POST save, and the now-empty
+  enable_python() JS function + its call.
+- Removed the unreachable `break;` after `continue 2;` in the DNSBL Block log filter
+  (and a stray blank line).
+- Removed the orphaned "// DEBUG Live Sync" comment.
+Re-verified after acb31a7: php -l clean, delimiter-balanced, ruff clean, pytest 163;
+`grep -rn "pfb_dnsbl_sync\|dnsbl_sync" src/` -> no matches.
+
+Why this divergence existed (the residuals were known but deferred, not missed):
+Each ADR-02 phase was committed atomically and verified strictly against its own
+phase prompt's scope, to keep the history reviewable and bisectable. The P5 prompt
+scoped the phase to "collapse the dnsbl_mode / dnsbl_py_blacklist branches in
+alerts/widget, then remove the now-unread definitions." These three items were NOT
+mode branches — they were code that became DEAD as a side effect of EARLIER phases
+(the Live Sync feature was deleted in P3/P4; the `break;` only went dead once P5
+made the preceding `continue 2;` unconditional). Folding that unrelated dead-code
+removal into P5 would have widened the commit past its stated contract and mixed two
+concerns, and the Resolver Live Sync UI removal also touched a different file region
+(the DNSBL settings form) than P5's targets. So they were deliberately deferred,
+recorded here as residuals, and then cleaned in a separate single-purpose commit at
+the maintainer's request. Net effect on the package is identical; only the commit
+boundary differs.
+
 ================================================================================
 OUTSTANDING — MANUAL SMOKE TEST (owner: MAINTAINER)  ** required before Accept **
 ================================================================================

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -841,7 +841,7 @@ function pfb_global() {
 	$pfb['dnsbl_sync']	= $pfb['dnsblconfig']['pfb_dnsbl_sync'];								// Live Updates to Resolver without a Reload
 	$pfb['dnsbl_global_log']= isset($pfb['dnsblconfig']['global_log']) 	? $pfb['dnsblconfig']['global_log']	 : '';		// Global Logging/Blocking mode
 
-	$pfb['dnsbl_mode']	= $pfb['dnsblconfig']['dnsbl_mode'];			// DNSBL Mode (Unbound/python mode)
+	$pfb['dnsbl_mode']	= 'dnsbl_python';					// ADR-02: DNSBL is Python-only; native Unbound mode removed.
 	$pfb['dnsbl_py_reply']	= $pfb['dnsblconfig']['pfb_py_reply'];			// DNSBL Resolver python DNS Reply logging
 	$pfb['dnsbl_py_block']	= $pfb['dnsblconfig']['pfb_py_block'];			// DNSBL Resolver python blocking mode
 	$pfb['dnsbl_hsts']	= $pfb['dnsblconfig']['pfb_hsts'];			// DNSBL Resolver python block HSTS via Null Block mode
@@ -858,10 +858,8 @@ function pfb_global() {
 	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'];	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
 
 	// DNSBL Resolver mode (Unbound/Python)
-	$pfb['dnsbl_py_blacklist'] = FALSE;
-	if ($pfb['dnsbl_mode'] == 'dnsbl_python' && $pfb['dnsbl_py_block'] == 'on') {
-		$pfb['dnsbl_py_blacklist'] = TRUE;
-	}
+	// ADR-02: DNSBL is Python-only; native Unbound mode removed.
+	$pfb['dnsbl_py_blacklist'] = TRUE;
 
 	// SafeSearch
 	$pfb['safesearch_enable']	= config_get_path('installedpackages/pfblockerngsafesearch/safesearch_enable', 'Disable');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2625,9 +2625,7 @@ function tld_analysis() {
 	$pfb_found = FALSE;				// Flag to determine if TLD 'redirect' zones found
 
 	rmdir_recursive("{$pfb['dnsbl_tmpdir']}");
-	if (!$pfb['dnsbl_py_blacklist']) {
-		safe_mkdir("{$pfb['dnsbl_tmpdir']}");
-	}
+
 	unlink_if_exists("{$pfb['dnsbl_file']}.tsp");
 	unlink_if_exists("{$pfb['dnsbl_tld_txt']}.*");
 	unlink_if_exists("{$pfb['dnsbl_tld_remove']}.tsp");
@@ -2655,23 +2653,21 @@ function tld_analysis() {
 	}
 
 	// DNSBL python - create file handles for data, zone, and remove files
-	if ($pfb['dnsbl_py_blacklist']) {
-		$p_data = @fopen("{$pfb['unbound_py_data']}.raw", 'w');
-		$p_zone = @fopen("{$pfb['unbound_py_zone']}.raw", 'w');
-		$p_tsp = @fopen("{$pfb['dnsbl_tld_remove']}", 'w');
+	$p_data = @fopen("{$pfb['unbound_py_data']}.raw", 'w');
+	$p_zone = @fopen("{$pfb['unbound_py_zone']}.raw", 'w');
+	$p_tsp = @fopen("{$pfb['dnsbl_tld_remove']}", 'w');
 
-		if ((get_resource_type($p_data) != 'stream') ||
-		    (get_resource_type($p_zone) != 'stream') ||
-		    (get_resource_type($p_tsp) != 'stream')) {
+	if ((get_resource_type($p_data) != 'stream') ||
+	    (get_resource_type($p_zone) != 'stream') ||
+	    (get_resource_type($p_tsp) != 'stream')) {
 
-			pfb_logger("\nFailed to create DNSBL python data|zone|remove file handles! Exiting\n", 1);
-			foreach (array($p_data, $p_zone, $p_tsp) as $handlex) {
-				if ($handlex) {
-					@fclose($handlex);
-				}
+		pfb_logger("\nFailed to create DNSBL python data|zone|remove file handles! Exiting\n", 1);
+		foreach (array($p_data, $p_zone, $p_tsp) as $handlex) {
+			if ($handlex) {
+				@fclose($handlex);
 			}
-			return;
 		}
+		return;
 	}
 
 	// Collect TLD Blacklist(s). If configured the whole TLD will be blocked
@@ -2682,10 +2678,7 @@ function tld_analysis() {
 
 	// Collect TLD Whitelist(s). If configured, create a 'static local-zone' Resolver entry (Not required for python mode blocking)
 	$whitelist = array();
-	if (!$pfb['dnsbl_py_blacklist']) {
-		$whitelist = pfbng_text_area_decode($pfb['dnsblconfig']['tldwhitelist'], TRUE, FALSE, TRUE);
-		$tld_whitelist = array();
-	}
+
 
 	$extdns_esc = escapeshellarg("@{$pfb['extdns']}");
 
@@ -2746,102 +2739,25 @@ function tld_analysis() {
 			$tld_blacklist[$tld] = '';			// Add new TLD entry
 
 			// DNSBL python - TLD Blacklist (Set logging type to enabled '1')
-			if ($pfb['dnsbl_py_blacklist']) {
-				$tld_cnt++;
-				$pfb_found = TRUE;
-				$tld_segments = @max((array((substr_count($tld, '.') +1), $tld_segments) ?: 1));
+			$tld_cnt++;
+			$pfb_found = TRUE;
+			$tld_segments = @max((array((substr_count($tld, '.') +1), $tld_segments) ?: 1));
 
-				pfb_logger("{$tld}|", 1);
-				@fwrite($p_zone, ",{$tld},,1,DNSBL_TLD,DNSBL_TLD\n");
+			pfb_logger("{$tld}|", 1);
+			@fwrite($p_zone, ",{$tld},,1,DNSBL_TLD,DNSBL_TLD\n");
 
-				// Add TLD to remove file
-				@fwrite($p_tsp, ".{$tld},,\n");
+			// Add TLD to remove file
+			@fwrite($p_tsp, ".{$tld},,\n");
 
-				// Collect List of TLDs and save to DNSBL folder
-				$tld_list .= ",{$tld},,\n";
+			// Collect List of TLDs and save to DNSBL folder
+			$tld_list .= ",{$tld},,\n";
 
-				// Remove any 'TLD Blacklists' from the 'TLD master list'
-				if (isset($tlds[$tld])) {
-					unset($tlds[$tld]);
-				}
-				continue;
+			// Remove any 'TLD Blacklists' from the 'TLD master list'
+			if (isset($tlds[$tld])) {
+				unset($tlds[$tld]);
 			}
+			continue;
 
-			// (Unbound mode only. Cannot have duplicate zones defined
-			elseif (!empty($pfb['safesearch_tlds']) && isset($pfb['safesearch_tlds'][$tld])) {
-				pfb_logger("\n{$tld}(Removed due to SafeSearch conflict)", 1);
-				continue;
-			}
-
-			$dnsbl_file = "{$pfb['dnsbl_tmpdir']}/DNSBL_{$tld}.txt";
-			if (!file_exists($dnsbl_file)) {
-
-				$tld_cnt++;
-				$pfb_found = TRUE;
-				$tld_segments = @max((array((substr_count($tld, '.') +1), $tld_segments) ?: 1));
-
-				// If a 'TLD Whitelist' exists, use 'static local-zone'
-				if (isset($tld_whitelist[$tld])) {
-
-					pfb_logger("{$tld}(static)|", 1);
-					$dnsbl_line = "local-zone: \"{$tld}\" \"static\"\n";
-					$whitelist = $tld_whitelist[$tld];
-
-					foreach ($whitelist as $list) {
-						$ip_type = is_ipaddr($list[1]);
-						$ip_esc = escapeshellarg($list[0]);
-
-						switch ($ip_type) {
-							case 4:
-								$dnsbl_line .= "local-data: \"{$list[0]} A {$list[1]}\"\n";
-								$tld_list .= "{$tld} | {$list[0]} A {$list[1]}\n";
-								if (!empty($pfb['dnsbl_vip6'])) {
-									$r = exec("/usr/bin/drill {$extdns_esc} AAAA {$ip_esc} | grep -v '^;\|^\$' | head -1 | cut -f5 2>&1");
-									if (is_ipaddrv6($r)) {
-										$dnsbl_line .= "local-data: \"{$list[0]} AAAA {$r}\"\n";
-										$tld_list .= "{$list[0]} AAAA {$r}\"\n";
-									}
-								}
-								break;
-							case 6:
-								$r = exec("/usr/bin/drill {$extdns_esc} A {$ip_esc} | grep -v '^;\|^\$' | head -1 | cut -f5 2>&1");
-								if (is_ipaddrv4($r)) {
-									$dnsbl_line .= "local-data: \"{$list[0]} A {$r}\"\n";
-									$tld_list .= "{$tld} | {$list[0]} A {$r}\"\n";
-								}
-								$dnsbl_line .= "local-data: \"{$list[0]} AAAA {$list[1]}\"\n";
-								$tld_list .= "{$tld} | {$list[0]} AAAA {$list[1]}\"\n";
-								break;
-							default:
-								break;
-						}
-					}
-				}
-
-				// Create 'redirect' zone for whole TLD
-				else {
-					pfb_logger("{$tld}|", 1);
-
-					$ipv6_dnsbl = '';
-					if (!empty($pfb['dnsbl_vip6'])) {
-						$ipv6_dnsbl = " local-data: \"{$tld} 60 IN AAAA {$pfb['dnsbl_vip6']}\"";
-					}
-					$dnsbl_line = "local-zone: \"{$tld}\" redirect local-data: \"{$tld} 60 IN A {$pfb['dnsbl_vip4']}\"{$ipv6_dnsbl}\n";
-
-					// Collect List of TLDs and save to DNSBL folder
-					$tld_list .= "{$tld}\n";
-				}
-
-				@file_put_contents($dnsbl_file, $dnsbl_line, LOCK_EX);
-
-				// Add TLD to remove file (To be removed from 'transparent' zone)
-				@file_put_contents("{$pfb['dnsbl_tld_remove']}.tsp", ".{$tld} 60\n", FILE_APPEND | LOCK_EX);
-
-				// Remove any 'TLD Blacklists' from the 'TLD master list'
-				if (isset($tlds[$tld])) {
-					unset($tlds[$tld]);
-				}
-			}
 		}
 
 		// Save a list of TLDs in DNSBL folder (DNSBL total line count verification)
@@ -3061,13 +2977,11 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE) {
 
 	$final = array();
 	$type = '';
-	if ($mode == 'enabled' && $pfb['dnsbl_py_blacklist']) {
+	if ($mode == 'enabled') {
 		$type = ' (DNSBL python)';
 	}
 
-	if (!$pfb['dnsbl_py_blacklist'] && file_exists("{$pfb['dnsbl_file']}.raw")) {
-		@rename("{$pfb['dnsbl_file']}.raw", "{$pfb['dnsbl_file']}.conf");
-	}
+
 
 	$cache_dumpfile = tempnam('/var/tmp/', 'unbound_cache_');
 	if ($mode == 'enabled' && is_process_running('unbound') && !$pfb['dnsbl_python_unmount'] && !$pfbpython) {
@@ -3088,31 +3002,9 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE) {
 
 		@copy("{$pfb['dnsbldir']}/unbound.conf", "{$pfb['dnsbldir']}/unbound.conf.error");
 		if ($mode == 'enabled') {
-			if (!$pfb['dnsbl_py_blacklist']) {
-				$log = "\nDNSBL {$mode} FAIL - restoring Unbound conf *** Fix error(s) and a Force Reload required! ***\n";
-
-				// Try to restore previous DNSBL database
-				if (file_exists("{$pfb['dnsbl_file']}.bk")) {
-					@rename("{$pfb['dnsbl_file']}.bk", "{$pfb['dnsbl_file']}.conf");
-				}
-
-				// Wipe DNSBL database
-				else {
-					$log .= ' Restore previous database Failed!';
-					unlink_if_exists("{$pfb['dnsbl_file']}.conf");
-					touch("{$pfb['dnsbl_file']}.conf");
-
-					// Restore previous unbound.conf
-					if (file_exists("{$pfb['dnsbldir']}/unbound.bk")) {
-						@rename("{$pfb['dnsbldir']}/unbound.bk", "{$pfb['dnsbldir']}/unbound.conf");
-					}
-				}
-			}
-			else {
-				$log = "\nDNSBL {$mode} FAIL  *** Fix error(s) and a Force Reload required! ***\n";
-				if (file_exists("{$pfb['dnsbldir']}/unbound.bk")) {
-					@rename("{$pfb['dnsbldir']}/unbound.bk", "{$pfb['dnsbldir']}/unbound.conf");
-				}
+			$log = "\nDNSBL {$mode} FAIL  *** Fix error(s) and a Force Reload required! ***\n";
+			if (file_exists("{$pfb['dnsbldir']}/unbound.bk")) {
+				@rename("{$pfb['dnsbldir']}/unbound.bk", "{$pfb['dnsbldir']}/unbound.conf");
 			}
 			pfb_logger("{$log}", 2);
 		}
@@ -3244,55 +3136,7 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 	if (is_service_running('unbound')) {
 
 		// 'Live sync' new DNSBL updates utilizing unbound-control
-		if (!$pfb['dnsbl_py_blacklist'] && $pfb['dnsbl_sync'] && !$pfbpython &&
-		    file_exists("{$pfb['dnsbl_file']}.conf") && filesize("{$pfb['dnsbl_file']}.conf") > 0) {
-
-			$sync_fail = FALSE;
-
-			pfb_logger("\nResolver Live Sync analysis", 1);
-			exec("{$pfb['script']} dnsbl_livesync >> {$pfb['log']} 2>&1");
-			pfb_logger(" completed [ NOW ]", 1);
-
-			$ucsync = array(array(	'dnsbl_remove_zone',	'local_zones_remove',	'Remove local-zone(s)' ),
-					array(	'dnsbl_remove_data',	'local_datas_remove',	'Remove local-data(s)' ),
-					array(	'dnsbl_add_zone',	'local_zones',		'Add local-zone(s)' ),
-					array(	'dnsbl_add_data',	'local_datas',		'Add local-data(s)' ));
-
-			// Disable zone updates when TLD is disabled
-			if (!$pfb['dnsbl_tld']) {
-				unset($ucsync[0], $ucsync[2]);
-			}
-
-			pfb_logger("\nResolver Live Sync finalizing:", 1);
-			foreach ($ucsync as $skey => $sync) {
-				$file = $pfb[$sync[0]];
-
-				if (filesize("{$file}") > 0) {
-					$result = array();
-					exec("{$pfb['chroot_cmd']} {$sync[1]} < {$file}", $result, $retval);
-					$result	= implode("\n", $result);
-					$log	= "\n\t{$sync[2]}:\t\t{$result}";
-				}
-				else {
-					$log	= "\n\t{$sync[2]}:\t\tno changes";
-				}
-				pfb_logger("{$log}", 1);
-
-				if (!$sync_fail && !empty($retval)) {
-					$sync_fail = TRUE;
-				}
-			}
-
-			if ($sync_fail) {
-				pfb_logger("\nResolver Live Sync ... FAILED!", 1);
-				pfb_reload_unbound('reload', FALSE, $pfbpython);
-			}
-		}
-
-		// Do a full Reload of Unbound
-		else {
-			pfb_reload_unbound($mode, TRUE, $pfbpython);
-		}
+		pfb_reload_unbound($mode, TRUE, $pfbpython);
 	}
 
 	// Start Unbound Service with new DNSBL Updates
@@ -3309,52 +3153,18 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 	$dnsbl_cnt = exec("/bin/cat {$pfb['dnsdir']}/*.txt | {$pfb['grep']} -c ^ 2>&1");
 
 	// Unbound blocking mode enabled
-	if (!$pfb['dnsbl_py_blacklist']) {
-		$final_cnt = exec("{$pfb['grep']} -v '\"transparent\"\|\"static\"' {$pfb['dnsbl_file']}.conf | {$pfb['grep']} -c ^ 2>&1");
-		if ($final_cnt == $dnsbl_cnt) {
-			$log = "\nDNSBL update [ {$final_cnt} | PASSED  ]... completed [ NOW ]";
-		} else {
-			$log = "\n*** DNSBL update [ {$final_cnt} ] [ {$dnsbl_cnt} ] ... OUT OF SYNC ! *** [ NOW ]";
-		}
-		pfb_logger("{$log}", 1);
+	$tld_cnt = @file_get_contents($pfb['unbound_py_count']);
+	$dnsbl_cnt = $dnsbl_cnt - $tld_cnt;
+	$final_cnt = exec("/usr/bin/find {$pfb['unbound_py_data']} {$pfb['unbound_py_zone']} -type f 2>/dev/null | xargs cat | {$pfb['grep']} -c ^ 2>&1");
+	if ($final_cnt == $dnsbl_cnt) {
+		$log = "\nDNSBL update [ {$final_cnt} | PASSED  ]... completed [ NOW ]";
+	} else {
+		$log = "\n*** DNSBL update [ {$final_cnt} ] [ {$dnsbl_cnt} ] ... OUT OF SYNC ! *** [ NOW ]";
 	}
-
-	// Python blocking mode enabled
-	else {
-		$tld_cnt = @file_get_contents($pfb['unbound_py_count']);
-		$dnsbl_cnt = $dnsbl_cnt - $tld_cnt;
-		$final_cnt = exec("/usr/bin/find {$pfb['unbound_py_data']} {$pfb['unbound_py_zone']} -type f 2>/dev/null | xargs cat | {$pfb['grep']} -c ^ 2>&1");
-		if ($final_cnt == $dnsbl_cnt) {
-			$log = "\nDNSBL update [ {$final_cnt} | PASSED  ]... completed [ NOW ]";
-		} else {
-			$log = "\n*** DNSBL update [ {$final_cnt} ] [ {$dnsbl_cnt} ] ... OUT OF SYNC ! *** [ NOW ]";
-		}
-		pfb_logger("{$log}", 1);
-	}
+	pfb_logger("{$log}", 1);
 
 	// DEBUG Live Sync
-	if (!$pfb['dnsbl_py_blacklist'] && $pfb['enable'] == 'on' && $pfb['dnsbl'] == 'on' && $pfb['dnsbl_sync'] && !$pfbupdate && !$pfbpython && !$sync_fail) {
-		pfb_logger("\n\nDNSBL DEBUG", 1);
-		$datacnt = $zonecnt = 0;
 
-		exec("{$pfb['chroot_cmd']} list_local_data | {$pfb['grep']} '{$pfb['dnsbl_vip4']}\|0\.0\.0\.0\$' | {$pfb['grep']} -v 'AAAA' | {$pfb['grep']} -c ^ 2>&1", $datacnt, $retval);
-		$datacnt = implode($datacnt);
-		pfb_logger('.', 1);
-
-		if ($pfb['dnsbl_tld']) {
-			exec("{$pfb['chroot_cmd']} list_local_zones | {$pfb['grep']} \"redirect\" | {$pfb['grep']} -c ^ 2>&1", $zonecnt, $retval);
-			pfb_logger('.', 1);
-			$zonecnt = implode($zonecnt);
-
-			$tldcnt = array('0');
-			if (file_exists('/var/db/pfblockerng/dnsbl/DNSBL_TLD.txt')) {
-				exec("{$pfb['grep']} -c ' A \| AAAA ' /var/db/pfblockerng/dnsbl/DNSBL_TLD.txt 2>&1", $tldcnt, $retval);
-			}
-			$tldcnt = implode($tldcnt);
-			$datacnt = $datacnt + $tldcnt;
-		}
-		pfb_logger("[ Data(s): {$datacnt}\tZone(s): {$zonecnt} | NOW ]", 1);
-	}
 
 	// Clear work files
 	pfb_unbound_clear_work_files();
@@ -3405,11 +3215,7 @@ function pfblockerng_top1m() {
 				$x++;
 
 				// Create three whitelist options per TOP1M whitelisted Domain
-				if ($pfb['dnsbl_py_blacklist']) {
-					@fwrite($pfb_output, ".{$csvline[1]},,\n,{$csvline[1]},,\n,www.{$csvline[1]},,\n");
-				} else {
-					@fwrite($pfb_output, ".{$csvline[1]} 60\n\"{$csvline[1]} 60\n\"www.{$csvline[1]} 60\n");
-				}
+				@fwrite($pfb_output, ".{$csvline[1]},,\n,{$csvline[1]},,\n,www.{$csvline[1]},,\n");
 			}
 
 			if ($x >= $pfb['dnsbl_alexa_cnt']) {
@@ -5687,86 +5493,41 @@ function pfb_dnsbl_parse($mode='daemon', $domain, $src_ip, $req_agent) {
 		while (TRUE) {
 
 			$domainparse = str_replace('.', '\.', $domain);
-			if ($pfb['dnsbl_py_blacklist']) {
-				$dquery_esc	= escapeshellarg(",{$domainparse},,");
-				$pfb_feed	= exec("{$pfb['grep']} -shm1 {$dquery_esc} {$pfb['unbound_py_data']} 2>&1");
-			} else {
-				$dquery_esc	= escapeshellarg(" \"{$domainparse} 60");
-				$pfb_feed	= pfb_parse_line(exec("{$pfb['grep']} -sHm1 {$dquery_esc} {$pfb['dnsdir']}/*.txt 2>&1"));
-			}
+			$dquery_esc	= escapeshellarg(",{$domainparse},,");
+			$pfb_feed	= exec("{$pfb['grep']} -shm1 {$dquery_esc} {$pfb['unbound_py_data']} 2>&1");
 			$pfb_group = $pfb_mode = $pfb_final = 'Unknown';
 
 			// Exact Domain match found
 			if (!empty($pfb_feed)) {
 
-				if ($pfb['dnsbl_py_blacklist']) {
-					list($dummy, $pfb_final, $empty_placeholder, $log_type, $pfb_feed, $pfb_group) = explode(',', $pfb_feed);
-					$pfb_mode = 'DNSBL';
-				}
-				else {
-					$pfb_group = pfb_parse_line(exec("{$pfb['grep']} -sHm1 {$dquery_esc} {$pfb['dnsalias']}/* 2>&1"));
-
-					// Determine DNSBL Type
-					$pfb_mode = 'DNSBL';
-					$ip = gethostbyname("dnsbl.test.{$domain}");
-					if ($ip == $pfb['dnsbl_vip4'] || text_to_compressed_ip6($ip) == text_to_compressed_ip6("{$pfb['dnsbl_vip6']}") || $ip == '0.0.0.0') {
-						$pfb_mode = 'TLD';
-					}
-					$pfb_final = $domain;
-				}
+				list($dummy, $pfb_final, $empty_placeholder, $log_type, $pfb_feed, $pfb_group) = explode(',', $pfb_feed);
+				$pfb_mode = 'DNSBL';
 			}
 
 			else {
 				$dparts = explode('.', $domain);
-				if (!$pfb['dnsbl_py_blacklist']) {
-					unset($dparts[0]);
-				}
+
 				$dcnt = count($dparts);
 
 				for ($i=0; $i <= $dcnt; $i++) {
 
 					$domainparse		= str_replace('.', '\.', implode('.', $dparts));
 					$domainparse_esc	= escapeshellarg("^{$domainparse}$");
-					if (!$pfb['dnsbl_py_blacklist']) {
-						$dquery_esc = escapeshellarg(" \"{$domainparse} 60");
 
-						// Determine if TLD exists in TLD Blacklist
-						if (file_exists("{$pfb['dnsbl_tld_txt']}")) {
-							exec("/usr/bin/grep -l {$domainparse_esc} {$pfb['dnsbl_tld_txt']} 2>&1", $match);
-							if (!empty($match[0])) {
-								$pfb_group = $pfb_feed = $pfb_mode = 'DNSBL_TLD';
-								$pfb_final = $domainparse;
-								break;
-							}
+
+					$dquery_esc	= escapeshellarg(",{$domainparse},,");
+					$pfb_feed	= exec("{$pfb['grep']} -shm1 {$dquery_esc} {$pfb['unbound_py_zone']} 2>&1");
+
+					// Collect Alias Group name
+					if (!empty($pfb_feed)) {
+						list($dummy, $d_found, $empty_placeholder, $log_type, $pfb_feed, $pfb_group) = explode(',', $pfb_feed);
+
+						$pfb_final = str_replace('\.', '.', $domainparse);
+						$pfb_mode = 'TLD';
+						if ($pfb_feed == 'DNSBL_TLD') {
+							$pfb_mode = 'DNSBL_TLD';
 						}
-					}
-
-					if ($pfb['dnsbl_py_blacklist']) {
-						$dquery_esc	= escapeshellarg(",{$domainparse},,");
-						$pfb_feed	= exec("{$pfb['grep']} -shm1 {$dquery_esc} {$pfb['unbound_py_zone']} 2>&1");
-
-						// Collect Alias Group name
-						if (!empty($pfb_feed)) {
-							list($dummy, $d_found, $empty_placeholder, $log_type, $pfb_feed, $pfb_group) = explode(',', $pfb_feed);
-
-							$pfb_final = str_replace('\.', '.', $domainparse);
-							$pfb_mode = 'TLD';
-							if ($pfb_feed == 'DNSBL_TLD') {
-								$pfb_mode = 'DNSBL_TLD';
-							}
-							break;
-						}
-					}
-					else {
-						$pfb_feed = pfb_parse_line(exec("{$pfb['grep']} -sHm1 {$dquery_esc} {$pfb['dnsdir']}/*.txt 2>&1"));
-					
-						// Collect Alias Group name
-						if (!empty($pfb_feed)) {
-							$pfb_group	= pfb_parse_line(exec("{$pfb['grep']} -sHm1 {$dquery_esc} {$pfb['dnsalias']}/* 2>&1"));
-							$pfb_mode	= 'TLD';
-							$pfb_final	= str_replace('\.', '.', $domainparse);
-							break;
-						}
+						break;
 					}
 					unset($dparts[$i]);
 				}
@@ -6945,11 +6706,9 @@ function sync_package_pfblockerng($cron='') {
 		'32000' => '8000000'
 	];
 
-	if ($pfb['dnsbl_py_blacklist']) {
-		array_walk($pfb['pfs_mem'], function (&$value) {
-			$value = $value * 3;
-		});
-	}
+	array_walk($pfb['pfs_mem'], function (&$value) {
+		$value = $value * 3;
+	});
 
 	foreach ($pfb['pfs_mem'] as $pfb_mem => $domain_max) {
 		if ($pfs_memory >= $pfb_mem) {
@@ -7334,37 +7093,33 @@ function sync_package_pfblockerng($cron='') {
 				$dnsbl_missing = TRUE;
 			}
 
-			if ($pfb['dnsbl_py_blacklist']) {
 
-				// When DNSBL python blocking mode is enabled, zone should not exist, and data should exist
-				if (!$pfb['dnsbl_tld']) {
-					if (file_exists($pfb['unbound_py_zone'])) {
-						$dnsbl_missing = TRUE;
-					}
-					if (!file_exists($pfb['unbound_py_data'])) {
-						$dnsbl_missing = TRUE;
-					}
+			// When DNSBL python blocking mode is enabled, zone should not exist, and data should exist
+			if (!$pfb['dnsbl_tld']) {
+				if (file_exists($pfb['unbound_py_zone'])) {
+					$dnsbl_missing = TRUE;
 				}
+				if (!file_exists($pfb['unbound_py_data'])) {
+					$dnsbl_missing = TRUE;
+				}
+			}
 
-				// When DNSBL python blocking mode is enabled, atleast one 'data or zone' file must exist
-				else {
-					$found = FALSE;
-					if (file_exists($pfb['unbound_py_data'])) {
-						$found = TRUE;
-					}
-					if (file_exists($pfb['unbound_py_zone'])) {
-						$found = TRUE;
-					} 
-					if (!$found) {
-						$dnsbl_missing = TRUE;
-					}
+			// When DNSBL python blocking mode is enabled, atleast one 'data or zone' file must exist
+			else {
+				$found = FALSE;
+				if (file_exists($pfb['unbound_py_data'])) {
+					$found = TRUE;
+				}
+				if (file_exists($pfb['unbound_py_zone'])) {
+					$found = TRUE;
+				} 
+				if (!$found) {
+					$dnsbl_missing = TRUE;
 				}
 			}
 
 			// Check if DNSBL database is missing, when DNSBL python blocking mode is not enabled
-			if (!$pfb['dnsbl_py_blacklist'] && !file_exists("{$pfb['dnsbl_file']}.conf")) {
-				$dnsbl_missing = TRUE;
-			}
+
 
 			if ($dnsbl_missing) {
 				$log = "\n Missing DNSBL stats and/or Unbound DNSBL files - Rebuilding\n";
@@ -7427,151 +7182,66 @@ function sync_package_pfblockerng($cron='') {
 						}
 					}
 
-					if ($pfb['dnsbl_py_blacklist']) {
 
-						// Python Mode determine if user manually entered these SafeSearch CNAMES to avoid duplicate zone errors
-						if ($safe_type[0] == 'safesearch_enable') {
-							$DDG = $PIX = $ss_cname = FALSE;
-							if (file_exists('/var/unbound/unbound.conf')) {
-								$pfb_py_conf_ex = @file_get_contents('/var/unbound/unbound.conf');
-								if (strstr($pfb_py_conf_ex, 'duckduckgo.com')) {
-									$CNAME_LOG = "\n *** Found manual Resolver entry for duckduckgo.com. This manual entry should be removed in future!\n";
-									$DDG = TRUE;
-								}
-								if (strstr($pfb_py_conf_ex, 'pixabay.com')) {
-									$CNAME_LOG .= "\n *** Found manual Resolver entry for pixabay.com. This manual entry should be removed in future!\n";
-									$PIX = TRUE;
-								}
+					// Python Mode determine if user manually entered these SafeSearch CNAMES to avoid duplicate zone errors
+					if ($safe_type[0] == 'safesearch_enable') {
+						$DDG = $PIX = $ss_cname = FALSE;
+						if (file_exists('/var/unbound/unbound.conf')) {
+							$pfb_py_conf_ex = @file_get_contents('/var/unbound/unbound.conf');
+							if (strstr($pfb_py_conf_ex, 'duckduckgo.com')) {
+								$CNAME_LOG = "\n *** Found manual Resolver entry for duckduckgo.com. This manual entry should be removed in future!\n";
+								$DDG = TRUE;
 							}
-							$ss_ex = @file_get_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf");
-						}
-						unlink_if_exists("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf"); // Remove Unbound mode file
-
-						$safesearch_file = file($pfb["dnsbl_{$safe_type[2]}"]);
-						if (!empty($safesearch_file)) {
-							foreach ($safesearch_file as $host) {
-
-								if (substr($host, 0, 1) == '#') {
-									continue;
-								}
-
-								$line = str_replace('"', '', strstr($host, '"', False));
-								$host_ip = trim(str_replace('A ', '', strstr($line, 'A ', FALSE)));
-								$domain = strstr($line, ' ', TRUE);
-								if (substr($domain, 0, 4) == 'www.') {
-									$domain = substr($domain, 4);
-								}
-
-								if (strpos($line, ' A ') !== FALSE) {
-									$safesearch_hosts[$domain]['A'] = $host_ip;
-								} elseif (strpos($line, ' AAAA ') !== FALSE) {
-									$safesearch_hosts[$domain]['AAAA'] = $host_ip;
-
-								# CNAME SafeSearch is not compatible in Python Mode, use Unbound mode for now
-								} elseif (strpos($line, ' CNAME ') !== FALSE) {
-									$ss_cname = TRUE;
-									if (!$DDG && strpos($line, 'duckduckgo.com') !== FALSE) {
-										@file_put_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf", "{$host}", FILE_APPEND);
-									}
-									if (!$PIX && strpos($line, 'pixabay.com') !== FALSE) {
-										@file_put_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf", "{$host}", FILE_APPEND);
-									}
-									# $cname = trim(str_replace('CNAME ', '', strstr($line, 'CNAME', FALSE)));
-									# $safesearch_hosts[$domain]['A'] = 'cname';
-									# $safesearch_hosts[$domain]['AAAA'] = $cname;
-								} elseif (strpos($line, 'always_nxdomain') !== FALSE) {
-									$safesearch_hosts[$domain]['nxdomain'] = '';
-								}
+							if (strstr($pfb_py_conf_ex, 'pixabay.com')) {
+								$CNAME_LOG .= "\n *** Found manual Resolver entry for pixabay.com. This manual entry should be removed in future!\n";
+								$PIX = TRUE;
 							}
 						}
+						$ss_ex = @file_get_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf");
+					}
+					unlink_if_exists("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf"); // Remove Unbound mode file
 
-						if ($safe_type[2] == 'safesearch' && ($ss_cname && $ss_ex !== @file_get_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf")) ||
-						    (($DDG || $PIX) && !$ss_cname)) {
-							$safesearch_update = TRUE;
+					$safesearch_file = file($pfb["dnsbl_{$safe_type[2]}"]);
+					if (!empty($safesearch_file)) {
+						foreach ($safesearch_file as $host) {
+
+							if (substr($host, 0, 1) == '#') {
+								continue;
+							}
+
+							$line = str_replace('"', '', strstr($host, '"', False));
+							$host_ip = trim(str_replace('A ', '', strstr($line, 'A ', FALSE)));
+							$domain = strstr($line, ' ', TRUE);
+							if (substr($domain, 0, 4) == 'www.') {
+								$domain = substr($domain, 4);
+							}
+
+							if (strpos($line, ' A ') !== FALSE) {
+								$safesearch_hosts[$domain]['A'] = $host_ip;
+							} elseif (strpos($line, ' AAAA ') !== FALSE) {
+								$safesearch_hosts[$domain]['AAAA'] = $host_ip;
+
+							# CNAME SafeSearch is not compatible in Python Mode, use Unbound mode for now
+							} elseif (strpos($line, ' CNAME ') !== FALSE) {
+								$ss_cname = TRUE;
+								if (!$DDG && strpos($line, 'duckduckgo.com') !== FALSE) {
+									@file_put_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf", "{$host}", FILE_APPEND);
+								}
+								if (!$PIX && strpos($line, 'pixabay.com') !== FALSE) {
+									@file_put_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf", "{$host}", FILE_APPEND);
+								}
+								# $cname = trim(str_replace('CNAME ', '', strstr($line, 'CNAME', FALSE)));
+								# $safesearch_hosts[$domain]['A'] = 'cname';
+								# $safesearch_hosts[$domain]['AAAA'] = $cname;
+							} elseif (strpos($line, 'always_nxdomain') !== FALSE) {
+								$safesearch_hosts[$domain]['nxdomain'] = '';
+							}
 						}
 					}
-					else {
-						unlink_if_exists("/var/unbound/pfb_py_ss.*"); // Remove Python mode file
-						$ss_cname = FALSE;
 
-						// Determine if user manually entered these SafeSearch CNAMES to avoid duplicate zone errors
-						if ($safe_type[0] == 'safesearch_enable') {
-
-							// Step one - See if DDG and PIX are manually configured
-							$DDG = $PIX = FALSE;
-							if (file_exists('/var/unbound/unbound.conf')) {
-								$pfb_py_conf_ex = @file_get_contents('/var/unbound/unbound.conf');
-								if (strstr($pfb_py_conf_ex, 'duckduckgo.com')) {
-									$CNAME_LOG = "\n *** Found manual Resolver entry for duckduckgo.com. This manual entry should be removed in future!\n";
-									$DDG = TRUE;
-								}
-								if (strstr($pfb_py_conf_ex, 'pixabay.com')) {
-									$CNAME_LOG .= "\n *** Found manual Resolver entry for pixabay.com. This manual entry should be removed in future!\n";
-									$PIX = TRUE;
-								}
-							}
-
-							// Step two - If they are configured rebuild SafeSearch file
-							$safesearch_file = file($pfb["dnsbl_{$safe_type[2]}"]);
-							$ss_lines = '';
-							if (!empty($safesearch_file)) {
-								foreach ($safesearch_file as $host) {
-									if ($DDG && strpos($host, 'duckduckgo.com') !== FALSE) {
-										$ss_lines .= "# {$host}";
-										$ss_cname = TRUE;
-									}
-									elseif ($PIX && strpos($host, 'pixabay.com') !== FALSE) {
-										$ss_lines .= "# {$host}";
-										$ss_cname = TRUE;
-									}
-									else {
-										$ss_lines .= "{$host}";
-									}
-								}
-							}
-
-							// Step three - Compare previous SafeSearch file to new and update if changes are found 
-							if ($ss_cname) {
-								if (file_exists("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf")) {
-									$ss_lines_ex = @file_get_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf");
-
-									if ($ss_lines !== $ss_lines_ex) {
-										@file_put_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf", $ss_lines, LOCK_EX);
-										$safesearch_update = TRUE;
-									}
-								}
-								else {
-									@file_put_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf", $ss_lines, LOCK_EX);
-									$safesearch_update = TRUE;
-								}
-							}
-						}
-
-						// Copy file if not exists or has been updated
-						if (!file_exists("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf") ||
-							@md5_file($pfb["dnsbl_{$safe_type[2]}"]) !==
-							@md5_file("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf")) {
-
-							// Temp Workaround for Duplicate CNAME Zone issue:
-							if (!$ss_cname) {
-								@copy($pfb["dnsbl_{$safe_type[2]}"], "{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf");
-								$safesearch_update = TRUE;
-							}
-						}
-
-						// Collect SafeSearch domains for wildcard whitelisting
-						exec("cut -d '\"' -f2 {$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf | cut -d ' ' -f1", $safesearch_hosts);
-
-						// Collect all Domains/TLDs for 'TLD Blacklist' validation (Unbound mode only. Cannot have duplicate zones)
-						if (!$pfb['dnsbl_py_blacklist'] && !empty($safesearch_hosts)) {
-							foreach ($safesearch_hosts as $host) {
-								$safesearch_tlds[$host] = '';
-								for ($i= substr_count($host, '.'); $i > 0; $i--) {
-									$host = ltrim(strstr($host, '.', FALSE), '.');
-									$pfb['safesearch_tlds'][$host] = '';
-								}
-							}
-						}
+					if ($safe_type[2] == 'safesearch' && ($ss_cname && $ss_ex !== @file_get_contents("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf")) ||
+					    (($DDG || $PIX) && !$ss_cname)) {
+						$safesearch_update = TRUE;
 					}
 				}
 				elseif (file_exists("{$pfb['dnsbldir']}/pfb_dnsbl.{$safe_type[2]}.conf")) {
@@ -7581,7 +7251,7 @@ function sync_package_pfblockerng($cron='') {
 			}
 
 			// Python mode create a CSV list of SafeSearch hosts
-			if ($pfb['dnsbl_py_blacklist'] && !empty($safesearch_hosts)) {
+			if (!empty($safesearch_hosts)) {
 				foreach ($safesearch_hosts as $host => $data) {
 					if (isset($data['nxdomain'])) {
 						$line = "{$host},nxdomain,nxdomain\n";
@@ -7608,24 +7278,7 @@ function sync_package_pfblockerng($cron='') {
 
 			// Wildcard whitelist SafeSearch domains (Unbound mode only)
 			$pfb_whitelist = '';
-			if (!$pfb['dnsbl_py_blacklist'] && !empty($safesearch_hosts)) {
-				$safesearch_hosts = array_unique($safesearch_hosts);
-				foreach ($safesearch_hosts as $line) {
-					if (!empty($line)) {
 
-						// Remove 'www.' prefix
-						if (substr($line, 0, 4) == 'www.') {
-							$line = substr($line, 4);
-						}
-
-						if ($pfb['dnsbl_py_blacklist']) {
-							$pfb_whitelist .= ".{$line},,\n,{$line},,\n";
-						} else {
-							$pfb_whitelist .= ".{$line} 60\n\"{$line} 60\n";
-						}
-					}
-				}
-			}
 
 			$s_log = ' disabled';
 			if ($pfb_found) {
@@ -7651,38 +7304,21 @@ function sync_package_pfblockerng($cron='') {
 						}
 
 						if ($wildcard) {
-							if ($pfb['dnsbl_py_blacklist']) {
-								$pfb_whitelist .= ".{$line},,\n,{$line},,\n";
-							} else {
-								$pfb_whitelist .= ".{$line} 60\n\"{$line} 60\n";
-							}
+							$pfb_whitelist .= ".{$line},,\n,{$line},,\n";
 						} else {
-							if ($pfb['dnsbl_py_blacklist']) {
-								$pfb_whitelist .= ",{$line},,\n,www.{$line},,\n";
-							} else {
-								$pfb_whitelist .= "\"{$line} 60\n\"www.{$line} 60\n";
-							}
+							$pfb_whitelist .= ",{$line},,\n,www.{$line},,\n";
 						}
 					}
 				}
 			}
 
 			//  Added due to SWC Feed
-			if ($pfb['dnsbl_py_blacklist']) {
-				$pfb_whitelist .= ",localhost.localdomain,,\n";
-			} else {
-				$pfb_whitelist .= "\"localhost.localdomain 60\n";
-			}
+			$pfb_whitelist .= ",localhost.localdomain,,\n";
 
 			@file_put_contents("{$pfb['dnsbl_supptxt']}", $pfb_whitelist, LOCK_EX);
 			pfb_logger(" completed", 1);
 
-			if (!$pfb['dnsbl_py_blacklist'] && $safesearch_update) {
-				$log = "\n DNSBL - SafeSearch changes found - Rebuilding!\n";
-				pfb_logger("{$log}", 1);
-				$pfb['reuse_dnsbl'] = 'on';
-				touch("{$pfb['dnsbl_file']}.reload");
-			}
+
 
 			// Call TOP1M whitelist process
 			if ($pfb['dnsbl_alexa'] == 'on') {
@@ -7924,9 +7560,7 @@ function sync_package_pfblockerng($cron='') {
 							}
 
 							// Force Unbound mode Logging for 'disabled_log' to 'enabled'
-							if (!$pfb['dnsbl_py_blacklist'] && $list['logging'] == 'disabled_log') {
-								$list['logging'] = 'enabled';
-							}
+
 
 							// If Null Blocking mode is selected, use '0.0.0.0|::0', otherwise utilize DNSBL WebServer/DNSBL VIP
 							if ($list['logging'] == 'disabled') {
@@ -8373,19 +8007,8 @@ function sync_package_pfblockerng($cron='') {
 											}
 
 											// For DNSBL python, save domain and Logging type
-											if ($pfb['dnsbl_py_blacklist']) {
-												$domain_data = ',' . strtolower($line)
-													. ",,{$logging_type},{$header},{$alias}\n";
-											}
-											else {
-												$ipv6_dnsbl = "\n";
-												if (!empty($pfb['dnsbl_vip6']) && !$pfb['dnsbl_tld']) {
-													$ipv6_dnsbl = " local-data: \"" . strtolower($line)
-															. " 60 IN AAAA {$sinkhole_type6}\"\n";
-												}
-												$domain_data = "local-data: \"" . strtolower($line)
-														. " 60 IN A {$sinkhole_type4}\"{$ipv6_dnsbl}";
-											}
+											$domain_data = ',' . strtolower($line)
+												. ",,{$logging_type},{$header},{$alias}\n";
 											@fwrite($dhandle, $domain_data);
 										}
 									}
@@ -8433,9 +8056,7 @@ function sync_package_pfblockerng($cron='') {
 
 									// DNSBL python requires a different deduplication process
 									$dup_mode = '';
-									if ($pfb['dnsbl_py_blacklist']) {
-										$dup_mode = 'python';
-									}
+									$dup_mode = 'python';
 
 									// Call script to process DNSBL 'De-Duplication / Whitelisting / TOP1M Whitelisting'
 									exec("{$pfb['script']} dnsbl_scrub {$header_esc} {$pfb_alexa} {$dup_mode} {$elog}");
@@ -8444,12 +8065,7 @@ function sync_package_pfblockerng($cron='') {
 										pfb_logger("  IPv4 count={$ip_cnt}\n", 1);
 									}
 
-									if (!$pfb['dnsbl_py_blacklist']) {
-										$result = array();
-										exec("/usr/local/sbin/unbound-checkconf {$pfb['dnsbldir']}/check.conf 2>&1", $result);
-									} else {
-										$result = array('unbound-checkconf: no errors');
-									}
+									$result = array('unbound-checkconf: no errors');
 									unlink_if_exists("{$pfb['dnsbldir']}/check.conf");
 								}
 								else {
@@ -8465,16 +8081,7 @@ function sync_package_pfblockerng($cron='') {
 								}
 
 								// If parse error found, use previously downloaded file if available
-								if (!$pfb['dnsbl_py_blacklist'] && !preg_grep("/unbound-checkconf: no errors/", $result)) {
-									unlink_if_exists("{$pfbfolder}/{$header}.bk");
 
-									pfb_logger("\n  DNSBL FAIL - Skipped! Use previous data, if found:\n", 2);
-									$log = htmlspecialchars(implode("\n", $result));
-									pfb_logger("{$log}\n", 1);
-
-									// Create failed marker file
-									touch("{$pfbfolder}/{$header}.fail");
-								}
 
 								// Save DNSBL feed info for next steps
 								$pfb['domain_update']	= $pfb['aliasupdate'] = $pfb['summary'] = TRUE;
@@ -8532,34 +8139,32 @@ function sync_package_pfblockerng($cron='') {
 		}
 
 		// Add DNSBL Python options to widget statistics
-		if ($pfb['dnsbl_mode'] == 'dnsbl_python') {
-			if ($pfb['dnsbl_idn'] == 'on') {
-				$idn_cnt = 1;
-				$pfb['alias_dnsbl_all'][] = 'DNSBL_IDN';
-				dnsbl_alias_update('update', 'DNSBL_IDN', '', '', $idn_cnt);
-			}
-			if ($pfb['dnsbl_pytld'] == 'on') {
-				$pytld_cnt = 0;
-				foreach (array('gtld', 'cctld', 'itld', 'bgtld') as $pytld) {
-					if (isset($pfb['dnsblconfig']['pfb_pytlds_' . $pytld]) && !empty($pfb['dnsblconfig']['pfb_pytlds_' . $pytld])) {
-						$p_cnt = count(explode(',', $pfb['dnsblconfig']['pfb_pytlds_' . $pytld]));
-						if (is_numeric($p_cnt) && $p_cnt > 0) {
-							$pytld_cnt += $p_cnt;
-						}
+		if ($pfb['dnsbl_idn'] == 'on') {
+			$idn_cnt = 1;
+			$pfb['alias_dnsbl_all'][] = 'DNSBL_IDN';
+			dnsbl_alias_update('update', 'DNSBL_IDN', '', '', $idn_cnt);
+		}
+		if ($pfb['dnsbl_pytld'] == 'on') {
+			$pytld_cnt = 0;
+			foreach (array('gtld', 'cctld', 'itld', 'bgtld') as $pytld) {
+				if (isset($pfb['dnsblconfig']['pfb_pytlds_' . $pytld]) && !empty($pfb['dnsblconfig']['pfb_pytlds_' . $pytld])) {
+					$p_cnt = count(explode(',', $pfb['dnsblconfig']['pfb_pytlds_' . $pytld]));
+					if (is_numeric($p_cnt) && $p_cnt > 0) {
+						$pytld_cnt += $p_cnt;
 					}
 				}
+			}
 
-				$pfb['alias_dnsbl_all'][] = 'DNSBL_TLD_Allow';
-				dnsbl_alias_update('update', 'DNSBL_TLD_Allow', '', '', $pytld_cnt);
+			$pfb['alias_dnsbl_all'][] = 'DNSBL_TLD_Allow';
+			dnsbl_alias_update('update', 'DNSBL_TLD_Allow', '', '', $pytld_cnt);
+		}
+		if ($pfb['dnsbl_regex'] == 'on') {
+			$regex_cnt = 0;
+			if (isset($pfb['dnsbl_regex_list'])) {
+				$regex_cnt = count(pfbng_text_area_decode($pfb['dnsbl_regex_list'], TRUE, FALSE, FALSE)) ?: 0;
 			}
-			if ($pfb['dnsbl_regex'] == 'on') {
-				$regex_cnt = 0;
-				if (isset($pfb['dnsbl_regex_list'])) {
-					$regex_cnt = count(pfbng_text_area_decode($pfb['dnsbl_regex_list'], TRUE, FALSE, FALSE)) ?: 0;
-				}
-				$pfb['alias_dnsbl_all'][] = 'DNSBL_Regex';
-				dnsbl_alias_update('update', 'DNSBL_Regex', '', '', $regex_cnt);
-			}
+			$pfb['alias_dnsbl_all'][] = 'DNSBL_Regex';
+			dnsbl_alias_update('update', 'DNSBL_Regex', '', '', $regex_cnt);
 		}
 
 		// Save DNSBL Alias statistics (Not for TLD mode)
@@ -8630,7 +8235,7 @@ function sync_package_pfblockerng($cron='') {
 			pfb_logger("... completed [ NOW ]", 1);
 
 			// DNSBL Python blocking mode, if TLD is not enabled
-			if ($pfb['dnsbl_py_blacklist'] && !$pfb['dnsbl_tld']) {
+			if (!$pfb['dnsbl_tld']) {
 				unlink_if_exists($pfb['unbound_py_data']);
 				unlink_if_exists($pfb['unbound_py_zone']);
 				unlink_if_exists($pfb['unbound_py_count']);
@@ -8652,19 +8257,10 @@ function sync_package_pfblockerng($cron='') {
 				$pfb['domain_clear'] = TRUE;
 
 				// Clear out Unbound pfb_dnsbl.conf file
-				if (!$pfb['dnsbl_py_blacklist']) {
-					$pfb_output = @fopen("{$pfb['dnsbl_file']}.conf", 'w');
-					@fwrite($pfb_output, '');
-					@fclose($pfb_output);
-				}
-
-				// Remove DNSBL Python files
-				else {
-					unlink_if_exists($pfb['unbound_py_data']);
-					unlink_if_exists($pfb['unbound_py_zone']);
-					unlink_if_exists($pfb['unbound_py_wh']);
-					unlink_if_exists($pfb['unbound_py_count']);
-				}
+				unlink_if_exists($pfb['unbound_py_data']);
+				unlink_if_exists($pfb['unbound_py_zone']);
+				unlink_if_exists($pfb['unbound_py_wh']);
+				unlink_if_exists($pfb['unbound_py_count']);
 			}
 		}
 		else {
@@ -8702,9 +8298,7 @@ function sync_package_pfblockerng($cron='') {
 	if ($pfb['domain_update'] || $pfbupdate || $pfbpython ||$pfb['domain_clear'] || $safesearch_update) {
 
 		// Create backup of existing DNSBL Unbound database
-		if (!$pfb['dnsbl_py_blacklist'] && file_exists("{$pfb['dnsbl_file']}.conf")) {
-			@copy("{$pfb['dnsbl_file']}.conf", "{$pfb['dnsbl_file']}.bk");
-		}
+
 
 		pfb_update_unbound($mode, $pfbupdate, $pfbpython);
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -838,7 +838,6 @@ function pfb_global() {
 	$pfb['dnsbl_alexa']	= $pfb['dnsblconfig']['alexa_enable'];									// TOP1M whitelist
 	$pfb['dnsbl_alexatype'] = isset($pfb['dnsblconfig']['alexa_type'])	? $pfb['dnsblconfig']['alexa_type'] 	 : 'tranco';	// TOP1M type (Tranco, Alexa or Cisco)
 	$pfb['dnsbl_res_cache']	= $pfb['dnsblconfig']['pfb_cache'];									// DNSBL Option to backup/restore Resolver cache
-	$pfb['dnsbl_sync']	= $pfb['dnsblconfig']['pfb_dnsbl_sync'];								// Live Updates to Resolver without a Reload
 	$pfb['dnsbl_global_log']= isset($pfb['dnsblconfig']['global_log']) 	? $pfb['dnsblconfig']['global_log']	 : '';		// Global Logging/Blocking mode
 
 	$pfb['dnsbl_py_reply']	= $pfb['dnsblconfig']['pfb_py_reply'];			// DNSBL Resolver python DNS Reply logging
@@ -3155,9 +3154,6 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 		$log = "\n*** DNSBL update [ {$final_cnt} ] [ {$dnsbl_cnt} ] ... OUT OF SYNC ! *** [ NOW ]";
 	}
 	pfb_logger("{$log}", 1);
-
-	// DEBUG Live Sync
-
 
 	// Clear work files
 	pfb_unbound_clear_work_files();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -841,9 +841,7 @@ function pfb_global() {
 	$pfb['dnsbl_sync']	= $pfb['dnsblconfig']['pfb_dnsbl_sync'];								// Live Updates to Resolver without a Reload
 	$pfb['dnsbl_global_log']= isset($pfb['dnsblconfig']['global_log']) 	? $pfb['dnsblconfig']['global_log']	 : '';		// Global Logging/Blocking mode
 
-	$pfb['dnsbl_mode']	= 'dnsbl_python';					// ADR-02: DNSBL is Python-only; native Unbound mode removed.
 	$pfb['dnsbl_py_reply']	= $pfb['dnsblconfig']['pfb_py_reply'];			// DNSBL Resolver python DNS Reply logging
-	$pfb['dnsbl_py_block']	= $pfb['dnsblconfig']['pfb_py_block'];			// DNSBL Resolver python blocking mode
 	$pfb['dnsbl_hsts']	= $pfb['dnsblconfig']['pfb_hsts'];			// DNSBL Resolver python block HSTS via Null Block mode
 	$pfb['dnsbl_idn']	= $pfb['dnsblconfig']['pfb_idn'];			// DNSBL Resolver python block IDN domains
 	$pfb['dnsbl_regex']	= $pfb['dnsblconfig']['pfb_regex'];			// DNSBL Resolver python regex
@@ -856,10 +854,6 @@ function pfb_global() {
 
 	$pfb['dnsbl_gp']		= $pfb['dnsblconfig']['pfb_gp'];		// DNSBL Resolver python - DNSBL Bypass
 	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'];	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
-
-	// DNSBL Resolver mode (Unbound/Python)
-	// ADR-02: DNSBL is Python-only; native Unbound mode removed.
-	$pfb['dnsbl_py_blacklist'] = TRUE;
 
 	// SafeSearch
 	$pfb['safesearch_enable']	= config_get_path('installedpackages/pfblockerngsafesearch/safesearch_enable', 'Disable');
@@ -2359,7 +2353,6 @@ function pfb_unbound_python($mode) {
 			$python_reply = 'on';
 		}
 
-		$python_blocking = 'off';
 		$python_blocking = 'on';
 
 		$python_hsts = 'off';

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1023,19 +1023,14 @@ function pfb_dnsbl_service() {
 	# Ensure all processes are stopped
 	rc_stop
 
-	# Start DNSBL Lighttpd webserver (Unbound/Python mode) and DNSBL HTTPS Daemon (Unbound mode only)
+	# Start DNSBL Lighttpd webserver (Python mode)
 	if [ -e '/var/unbound/pfb_dnsbl_lighty.conf' ]; then
 		/usr/bin/logger -p daemon.info -t lighttpd_pfb "INFO [{$LOG_PREFIX_PKG_PFBLOCKERNG}] DNSBL Webserver started"
 		/usr/local/sbin/lighttpd_pfb -f /var/unbound/pfb_dnsbl_lighty.conf
 	fi
 
-	# Check if Unbound mode is enabled
-	unbound_mode="\$(/usr/local/sbin/read_xml_tag.sh string installedpackages/pfblockerngdnsblsettings/config/dnsbl_mode)"
-
-	# Start DNSBL Resolver queries Daemon
-	if [ "\${unbound_mode}" == 'dnsbl_unbound' ]; then
-		/usr/local/bin/php -f /usr/local/pkg/pfblockerng/pfblockerng.inc queries &
-	elif [ ! -e '/var/unbound/pfb_unbound.py' ]; then
+	# Warn if the DNSBL python script is missing
+	if [ ! -e '/var/unbound/pfb_unbound.py' ]; then
 		/usr/bin/logger -p daemon.err -t php_pfb "ERROR [{$LOG_PREFIX_PKG_PFBLOCKERNG}] DNSBL missing python script - forced reload required"
 	fi
 
@@ -1047,14 +1042,6 @@ EOF;
 	pidnum="\$(/bin/pgrep lighttpd_pfb)"
 	if [ ! -z "\${pidnum}" ]; then
 		/usr/bin/killall lighttpd_pfb
-	fi
-
-	# Terminate DNSBL queries Daemon, if found
-	pidnum="\$(/bin/ps -wax | /usr/bin/grep '[p]fblockerng.inc queries' | /usr/bin/awk '{print \$1}')"
-	if [ ! -z "\${pidnum}" ]; then
-		for i in \${pidnum}; do
-			/bin/kill -9 "\${i}"
-		done
 	fi
 
 EOF;
@@ -1098,15 +1085,6 @@ if (isset($argv[1])) {
 			ignore_user_abort(TRUE);
 			set_time_limit(0);
 			pfb_daemon_dnsbl_index();
-			exit;
-	}
-
-	// DNSBL daemon to monitor Resolver queries and manage SQLite3 database
-	elseif ($argv[1] == 'queries') {
-			pfb_global();
-			ignore_user_abort(TRUE);
-			set_time_limit(0);
-			pfb_daemon_queries();
 			exit;
 	}
 
@@ -6434,103 +6412,6 @@ function pfb_dnsbl_lastevent($p_group, $p_entry, $p_details) {
 
 
 // Function to collect and update the Unbound Resolver query/pid entries into SQLite3 database
-function pfb_daemon_queries() {
-	global $g, $pfb;
-
-	$sleep_freq	= config_get_path('installedpackages/pfblockerngglobal/widget-dnsblquery', 5);
-
-	$nice		= '/usr/bin/nice -n20';
-	$unbound_pid	= "{$g['varrun_path']}/unbound.pid";
-
-	while (TRUE) {
-		sleep($sleep_freq);
-
-		// If 'Live Sync' file marker exists skip DNSBL Queries daemon to avoid unbound-control collisions
-		if (is_platform_booting() || $g['pfblockerng_install'] || file_exists("{$pfb['dnsbl_file']}.sync")) {
-			continue;
-		}
-
-		// Collect Unbound Resolver pid
-		$pid = exec("{$nice} /usr/bin/pgrep -anx 'unbound' 2>&1");
-		if (!empty($pid)) {
-			$output	= exec("{$pfb['chroot_cmd']} stats_noreset | {$nice} {$pfb['grep']} 'total.num.queries=' | cut -d '=' -f2 2>&1");
-			$query	= intval($output);
-			if (!is_numeric($query)) {
-				$query = '';
-			}
-
-			// On an Unbound Reload, the query stat is reset, therefore reuse previous query value
-			if ($query < $p_query) {
-				$t_query	= $query;
-				$query		= $query + $p_query;
-				$pid		= '';
-			}
-		}
-
-		// On initial daemon load
-		if (empty($p_pid)) {
-			$p_pid = $pid;
-			continue;
-		}
-
-		$pfb_found		= FALSE;
-		$stats			= array();
-		$stats['totalqueries']	= 0;
-		$stats['queries']	= 0;
-
-		$db_handle = pfb_open_sqlite(3, 'Resolver collect queries');
-		if ($db_handle) {
-			$result = $db_handle->query("SELECT * FROM resolver WHERE row = 0;");
-			if ($result) {
-				while ($res = $result->fetchArray(SQLITE3_ASSOC)) {
-					$stats = $res;
-					$pfb_found = TRUE;
-				}
-			}
-
-			// Create new row
-			if (!$pfb_found) {
-				$db_update = "INSERT INTO resolver ( row, totalqueries, queries ) VALUES ( 0, 0, 0 );";
-				$db_handle->exec("BEGIN TRANSACTION;"
-						. "{$db_update}"
-						. "END TRANSACTION;");
-			}
-		}
-		pfb_close_sqlite($db_handle);
-
-		// If Unbound Resolver pid has changed, clear SQLite database 'queries' entry, and update 'totalqueries/pid' entries
-		if ($pfb_found && $pid != $p_pid) {
-			$totalqueries = ($stats['totalqueries'] ?: 0) + ($query ?: 0);
-			pfBlockerNG_clearsqlite('update_totalqueries', $totalqueries);
-		}
-		else {
-			if ($query != '' && $query != $p_query && is_numeric($query)) {
-
-				// Update existing row
-				$db_handle = pfb_open_sqlite(3, 'Widget update queries');
-				if ($db_handle) {
-					$db_update = "UPDATE resolver SET queries = :query WHERE row = 0";
-					$stmt = $db_handle->prepare($db_update);
-					if ($stmt) {
-						$stmt->bindValue(':query', $query, SQLITE3_INTEGER);
-						$stmt->execute();
-					}
-				}
-				pfb_close_sqlite($db_handle);
-			}
-		}
-
-		$p_pid = $pid;
-		if (isset($t_query)) {
-			$p_query = $t_query;
-			unset($t_query);
-		} else {
-			$p_query = $query;
-		}
-	}
-}
-
-
 // Read logfile in realtime (livetail)
 // Reference: http://stackoverflow.com/questions/3218895/php-how-to-read-a-file-live-that-is-constantly-being-written-to
 function pfb_livetail($logfile, $mode) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2955,50 +2955,15 @@ function tld_analysis() {
 			}
 
 			// DNSBL python blocking mode
-			if ($pfb['dnsbl_py_blacklist']) {
-				$eparts = explode(',', $line, 3);
-				$domain = $eparts[1];
-				$dparts = explode('.', $domain);
-				$dcnt   = count($dparts);
-				$tld    = end($dparts);
-				$d_info = $eparts[2]; // Logging Type/Header/Alias group details
-				$dfound	= '';
-			}
+			$eparts = explode(',', $line, 3);
+			$domain = $eparts[1];
+			$dparts = explode('.', $domain);
+			$dcnt   = count($dparts);
+			$tld    = end($dparts);
+			$d_info = $eparts[2]; // Logging Type/Header/Alias group details
+			$dfound	= '';
 
-			// DNSBL Unbound blocking mode
-			else {
-				$eparts = explode(' ', str_replace('"', '', $line), 3);
-				$domain = $eparts[1];
-				$s_info = trim($eparts[2]);
 
-				if (!empty($pfb['dnsbl_vip6'])) {
-					// Determine if DNSBL Logging is disabled and switch to '::0'
-					if (strpos($s_info, ' A 0.0.0.0') !== FALSE) {
-						$s_info6 = str_replace(' A 0.0.0.0', ' AAAA ::0', $s_info);
-					} else {
-						$s_info6 = str_replace(' A ', ' AAAA ::', $s_info);
-					}
-				}
-
-				$dparts = explode('.', $domain);
-				$dcnt	= count($dparts);
-				$tld	= end($dparts);
-				$dfound = '';
-			}
-
-			// Determine if TLD exists in TLD Blacklist (skip for DNSBL python)
-			if (!$pfb['dnsbl_py_blacklist'] && !empty($tld_blacklist)) {
-
-				// Determine minimum 'tld level' for loop efficiency
-				$min_cnt = @min(array($tld_segments, ($dcnt -1)));
-
-				for ($i=1; $i <= $min_cnt; $i++) {
-					$d_query = implode('.', array_slice($dparts, -$i, $i, TRUE));
-					if (isset($tld_blacklist[$d_query])) {
-						continue 2;			// Whole TLD being blocked
-					}
-				}
-			}
 
 			if ($domain_cnt <= $pfb['domain_max_cnt']) {
 
@@ -3032,58 +2997,16 @@ function tld_analysis() {
 				$pfb_found = TRUE;
 
 				// DNSBL python blocking mode
-				if ($pfb['dnsbl_py_blacklist']) {
-					@fwrite($p_zone, ",{$dfound},{$d_info}");
+				@fwrite($p_zone, ",{$dfound},{$d_info}");
 
-					// TLD remove files - See below for description
-					@fwrite($p_tsp, ".{$dfound},,\n");
-				}
-				else {
-					$ipv6_dnsbl = '';
-					if (!empty($pfb['dnsbl_vip6'])) {
-						$ipv6_dnsbl = " local-data: \"{$dfound} {$s_info6}\"";
-					}
-					$domain_line = "local-zone: \"{$dfound}\" redirect local-data: \"{$dfound} {$s_info}\"{$ipv6_dnsbl}\n";
-					@file_put_contents("{$pfb['dnsbl_file']}.tsp", $domain_line, FILE_APPEND | LOCK_EX);
-
-					// Add Domain to remove file for [ 1- 'redirect zone' Domains 2- Unbound memory domains ]
-					// This removes any of these domains and sub-domains
-					@file_put_contents("{$pfb['dnsbl_tld_remove']}", ".{$dfound} 60\n\"{$dfound} 60\n", FILE_APPEND | LOCK_EX);
-
-					// Add Domain to remove file for 'transparent zone' domains
-					// This removes any of these sub-domains
-					@file_put_contents("{$pfb['dnsbl_tld_remove']}.tsp", ".{$dfound} 60\n", FILE_APPEND | LOCK_EX);
-				}
+				// TLD remove files - See below for description
+				@fwrite($p_tsp, ".{$dfound},,\n");
 			}
 
 			// Create 'transparent zone' for Sub-Domain
 			else {
 				// DNSBL python blocking mode
-				if ($pfb['dnsbl_py_blacklist']) {
-					@fwrite($p_data, ",{$domain},{$d_info}");
-				}
-				else {
-					if (!empty($tld)) {
-						$dnsbl_file = "{$pfb['dnsbl_tmpdir']}/DNSBL_{$tld}.txt";
-
-						// Create a temp file for each TLD. w/ 'transparent' header followed by each 'local-data' line
-						if (!file_exists($dnsbl_file)) {
-							$dnsbl_header = "local-zone: \"{$tld}\" \"transparent\"\n";
-							@file_put_contents($dnsbl_file, $dnsbl_header, LOCK_EX);
-						}
-
-						$ipv6_dnsbl = '';
-						if (!empty($pfb['dnsbl_vip6'])) {
-							$ipv6_dnsbl = " local-data: \"{$domain} {$s_info6}\"";
-						}
-						$domain_line = "local-data: \"{$domain} {$s_info}\"{$ipv6_dnsbl}\n";
-						@file_put_contents($dnsbl_file, $domain_line, FILE_APPEND | LOCK_EX);
-					}
-					else {
-						$oline = htmlentities($line);
-						pfb_logger("\nDebug: Missing TLD: {$oline}", 1);
-					}
-				}
+				@fwrite($p_data, ",{$domain},{$d_info}");
 			}
 
 			// Increment Domain counter
@@ -3109,26 +3032,7 @@ function tld_analysis() {
 		pfb_logger("{$log}", 1);
 
 		// Execute Domain De-duplication
-		if ($pfb['dnsbl_py_blacklist']) {
-			exec("{$pfb['script']} domaintldpy >> {$pfb['log']} 2>&1");
-		}
-		else {
-			// Create a csv list of 'recently updated' DNSBL Feeds, as ordered by User
-			$dnsbl_feeds = '';
-			if (!empty($pfb['tld_update'])) {
-				foreach ($pfb['tld_update'] as $alias => $data) {
-					foreach ($data['feeds'] as $feed) {
-						$dnsbl_feeds .= "{$feed},";
-					}
-				}
-			}
-
-			if (!empty(pfb_filter($dnsbl_feeds, PFB_FILTER_CSV, 'tld_analysis'))) {
-				exec("{$pfb['script']} domaintld x x x {$dnsbl_feeds} >> {$pfb['log']} 2>&1");
-			} else {
-				pfb_logger("\nFailed to create list of DNSBL Feeds", 1);
-			}
-		}
+		exec("{$pfb['script']} domaintldpy >> {$pfb['log']} 2>&1");
 		pfb_logger("\nTLD finalize... completed [ NOW ]\n", 1);
 
 		// Update DNSBL Alias and Widget Stats
@@ -3151,7 +3055,7 @@ function tld_analysis() {
 	// Save DNSBL Alias statistics
 	dnsbl_save_stats();
 
-	if ($pfb['dnsbl_py_blacklist'] && file_exists("{$pfb['dnsbl_file']}.raw")) {
+	if (file_exists("{$pfb['dnsbl_file']}.raw")) {
 		unlink_if_exists("{$pfb['dnsbl_file']}.raw");
 	}
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1739,7 +1739,7 @@ server.pid-file			= "/var/run/dnsbl.pid"
 
 EOF;
 
-if (!$pfb['dnsbl_py_blacklist'] || $pfb['dnsbl_py_nolog'] == 'on') {
+if ($pfb['dnsbl_py_nolog'] == 'on') {
 	$pfb_conf .= <<<EOF
 server.errorlog			= "|/usr/local/bin/php -f /usr/local/pkg/pfblockerng/pfblockerng.inc dnsbl"
 
@@ -1747,13 +1747,13 @@ EOF;
 }
 
 	if (file_exists('/usr/local/lib/lighttpd/mod_openssl.so')) {
-		if (!$pfb['dnsbl_py_blacklist'] || $pfb['dnsbl_py_nolog'] == 'on') {
+		if ($pfb['dnsbl_py_nolog'] == 'on') {
 			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_auth", "mod_accesslog", "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
 		} else {
 			$pfb_conf .= 'server.modules			= ( "mod_auth", "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
 		}
 	} else {
-		if (!$pfb['dnsbl_py_blacklist'] || $pfb['dnsbl_py_nolog'] == 'on') {
+		if ($pfb['dnsbl_py_nolog'] == 'on') {
 			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_auth", "mod_accesslog", "mod_fastcgi", "mod_rewrite" )';
 		} else {
 			$pfb_conf .= 'server.modules			= ( "mod_auth", "mod_fastcgi", "mod_rewrite" )';
@@ -1768,7 +1768,7 @@ url.access-deny			= ( "~", ".inc" )
 fastcgi.server			= ( ".php" => ( "localhost" => ( "socket" => "/var/run/php-fpm.socket", "broken-scriptfilename" => "enable" ) ) )
 
 EOF;
-	if (!$pfb['dnsbl_py_blacklist'] || $pfb['dnsbl_py_nolog'] == 'on') {
+	if ($pfb['dnsbl_py_nolog'] == 'on') {
 
 	$pfb_conf .= <<<EOF
 debug.log-condition-handling	= "enable"
@@ -1780,7 +1780,7 @@ EOF;
 }
 	// Lighttpd v1.4.58+ conditional error log with 'ssl.verifyclient.activate' to collect the domain name
 	$lighty_ver = exec('/usr/local/sbin/lighttpd -v 2>&1');
-	if ((!$pfb['dnsbl_py_blacklist'] || $pfb['dnsbl_py_nolog'] == 'on') &&
+	if (($pfb['dnsbl_py_nolog'] == 'on') &&
   	    (strpos($lighty_ver, 'lighttpd/1.4.58') !== FALSE ||
 	    strpos($lighty_ver, 'lighttpd/1.4.59') !== FALSE ||
 	    strpos($lighty_ver, 'lighttpd/1.4.60') !== FALSE ||
@@ -2078,14 +2078,7 @@ function pfb_unbound_dnsbl($mode) {
 		// Append DNSBL Unbound pfSense conf integration
 		if (!strstr($unbound_custom, 'pfb_dnsbl.*conf')) {
 			if ($mode == 'enabled') {
-				if (!$pfb['dnsbl_py_blacklist']) {
-					$pfbupdate = TRUE;
-					$unbound_custom .= "\n{$unbound_include}";
-					$log = "\nAdding DNSBL Unbound mode (Resolver adv. setting)";
-				}
-
-				// To be removed when SafeSearch CNAME python mode has been fixed
-				elseif ($pfb['safesearch_enable'] !== 'Disable') {
+				if ($pfb['safesearch_enable'] !== 'Disable') {
 					$pfbupdate = TRUE;
 					$unbound_custom .= "\n{$unbound_include}";
 					$log = "\nAdding DNSBL SafeSearch CNAME mode (Resolver adv. setting)";
@@ -2095,43 +2088,27 @@ function pfb_unbound_dnsbl($mode) {
 		else {
 			// Remove DNSBL Unbound pfSense conf integration when disabled
 			// or when DNSBL python mode is enabled but not when SafeSearch is enabled
-			if ($mode == 'disabled' || $pfb['dnsbl_py_blacklist']) {
-				$custom = explode ("\n", $unbound_custom);
-				foreach ($custom as $key => $line) {
-					if (strpos($line, 'pfb_dnsbl.*conf') !== FALSE) {
-						if (!$pfb['dnsbl_py_blacklist']) {
-							$log = "\nRemoving DNSBL SafeSearch mode (Resolver adv. setting)";
-							unset($custom[$key]);
-							$pfbupdate = TRUE;
-						}
+			$custom = explode ("\n", $unbound_custom);
+			foreach ($custom as $key => $line) {
+				if (strpos($line, 'pfb_dnsbl.*conf') !== FALSE) {
+					if ($mode == 'enabled' && $pfb['safesearch_enable'] !== 'Disable') {
+						//
+					}
 
-						// To be removed when SafeSearch CNAME python mode has been fixed
-						elseif ($mode == 'enabled' && $pfb['safesearch_enable'] !== 'Disable') {
-							//
-						}
-
-						else {
-							$log = "\nRemoving DNSBL Unbound mode and/or DNSBL SafeSearch CNAME mode (Resolver adv. setting)";
-							unset($custom[$key]);
-							$pfbupdate = TRUE;
-						}
+					else {
+						$log = "\nRemoving DNSBL Unbound mode and/or DNSBL SafeSearch CNAME mode (Resolver adv. setting)";
+						unset($custom[$key]);
+						$pfbupdate = TRUE;
 					}
 				}
-				$unbound_custom = implode("\n", $custom);
 			}
+			$unbound_custom = implode("\n", $custom);
 		}
 	}
 	else {
 		// Add DNSBL Unbound pfSense conf integration
 		if ($mode == 'enabled') {
-			if (!$pfb['dnsbl_py_blacklist']) {
-				$pfbupdate = TRUE;
-				$unbound_custom = "{$unbound_include}";
-				$log = "\nAdding DNSBL Unbound mode (Resolver adv. setting)";
-			}
-
-			// To be removed when SafeSearch CNAME python mode has been fixed
-			elseif ($pfb['safesearch_enable'] !== 'Disable') {
+			if ($pfb['safesearch_enable'] !== 'Disable') {
 				$pfbupdate = TRUE;
 				$unbound_custom = "{$unbound_include}";
 				$log = "\nAdding DNSBL SafeSearch CNAME mode (Resolver adv. setting)";
@@ -2179,12 +2156,7 @@ function pfb_unbound_dnsbl($mode) {
 
 			elseif (strpos($line, 'pfb_dnsbl.*conf') !== FALSE) {
 				if ($mode == 'enabled') {
-					if (!$pfb['dnsbl_py_blacklist']) {
-						$unbound = TRUE;
-					}
-
-					// To be removed when SafeSearch CNAME python mode has been fixed
-					elseif ($mode == 'enabled' && $pfb['safesearch_enable'] !== 'Disable') {
+					if ($mode == 'enabled' && $pfb['safesearch_enable'] !== 'Disable') {
 						$unbound = TRUE;
 					}
 
@@ -2201,7 +2173,7 @@ function pfb_unbound_dnsbl($mode) {
 			}
 
 			elseif (strpos($line, 'module-config:') !== FALSE) {
-				if ($mode == 'enabled' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
+				if ($mode == 'enabled') {
 					if (strpos($line, 'module-config: "python') !== FALSE) {
 						$unbound_py = TRUE;
 					} else {
@@ -2229,7 +2201,7 @@ function pfb_unbound_dnsbl($mode) {
 			}
 
 			elseif (strpos($line, 'python-script: pfb_unbound.py') !== FALSE) {
-				if ($mode == 'enabled' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
+				if ($mode == 'enabled') {
 					$unbound_py = TRUE;
 				} else {
 					$u_update = TRUE;
@@ -2242,14 +2214,7 @@ function pfb_unbound_dnsbl($mode) {
 
 		// Add Unbound include line
 		if (!$unbound && $mode == 'enabled') {
-			if (!$pfb['dnsbl_py_blacklist']) {
-				$u_update = TRUE;
-				$u_msg .= "  Added DNSBL Unbound mode\n";
-				$conf[] = "\nserver:include: {$pfb['dnsbl_file']}.*conf\n";
-			}
-
-			// To be removed when SafeSearch CNAME python mode has been fixed
-			elseif ($mode == 'enabled' && $pfb['safesearch_enable'] !== 'Disable') {
+			if ($mode == 'enabled' && $pfb['safesearch_enable'] !== 'Disable') {
 				$u_update = TRUE;
 				$u_msg .= "  Added DNSBL SafeSearch CNAME mode\n";
 				$conf[] = "\nserver:include: {$pfb['dnsbl_file']}.*conf\n";
@@ -2257,13 +2222,13 @@ function pfb_unbound_dnsbl($mode) {
 		}
 
 		// Add python script line
-		if (!$unbound_py && $mode == 'enabled' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
+		if (!$unbound_py && $mode == 'enabled') {
 			$u_update = TRUE;
 			$u_msg .= "  Added DNSBL Unbound Python mode script\n";
 			$conf[] = "\npython:\npython-script: pfb_unbound.py\n";
 		}
 
-		if ($mode == 'enabled' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
+		if ($mode == 'enabled') {
 			if (!file_exists("{$g['unbound_chroot_path']}/pfb_unbound.py")) {
 				@copy("/usr/local/pkg/pfblockerng/pfb_unbound.py", "{$g['unbound_chroot_path']}/pfb_unbound.py");
 			}
@@ -2357,7 +2322,7 @@ function pfb_unbound_python($mode) {
 
 	// Add python settings to DNS Resolver configuration
 	$python_enable = 'off';
-	if ($mode == 'enabled' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
+	if ($mode == 'enabled') {
 		$python_enable = 'on';
 
 		if (!config_path_enabled('unbound', 'python') ||
@@ -2374,23 +2339,15 @@ function pfb_unbound_python($mode) {
 		}
 
 		// If DNSBL python blocking mode enabled
-		if ($pfb['dnsbl_py_blacklist']) {
 
-			// Create DNSBL Whitelist
-			$dnsbl_whitelist = pfb_unbound_python_whitelist();
+		// Create DNSBL Whitelist
+		$dnsbl_whitelist = pfb_unbound_python_whitelist();
 
-			// Compare previous DNSBL Whitelist to new Whitelist
-			$pfb_py_whitelist_ex = @file_get_contents($pfb['unbound_py_wh']);
-			if ($dnsbl_whitelist !== $pfb_py_whitelist_ex) {
-				$pfbpython = TRUE;
-				@file_put_contents($pfb['unbound_py_wh'], $dnsbl_whitelist, LOCK_EX);
-			}
-		}
-
-		// Remove previous whitelist and reload
-		elseif (file_exists($pfb['unbound_py_wh'])) {
-			unlink_if_exists($pfb['unbound_py_wh']);
+		// Compare previous DNSBL Whitelist to new Whitelist
+		$pfb_py_whitelist_ex = @file_get_contents($pfb['unbound_py_wh']);
+		if ($dnsbl_whitelist !== $pfb_py_whitelist_ex) {
 			$pfbpython = TRUE;
+			@file_put_contents($pfb['unbound_py_wh'], $dnsbl_whitelist, LOCK_EX);
 		}
 
 		if (!isset($tld_segments)) {
@@ -2403,9 +2360,7 @@ function pfb_unbound_python($mode) {
 		}
 
 		$python_blocking = 'off';
-		if ($pfb['dnsbl_py_blacklist']) {
-			$python_blocking = 'on';
-		}
+		$python_blocking = 'on';
 
 		$python_hsts = 'off';
 		if ($pfb['dnsbl_hsts'] == 'on') {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -13,7 +13,6 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-DEBUG=0
 
 now=$(/bin/date +%m/%d/%y' '%T)
 
@@ -49,12 +48,10 @@ mastercat=/var/db/pfblockerng/mastercat
 geoiplog=/var/log/pfblockerng/geoip.log
 errorlog=/var/log/pfblockerng/error.log
 extraslog=/var/log/pfblockerng/extras.log
-dnsbl_file=/var/unbound/pfb_dnsbl
 
 # Folder Locations
 etdir=/var/db/pfblockerng/ET
 tmpxlsx=/tmp/xlsx/
-dnsbl_tmp=/tmp/DNSBL_TMP/
 pfbdb=/var/db/pfblockerng/
 pfbdeny=/var/db/pfblockerng/deny/
 pfborig=/var/db/pfblockerng/original/
@@ -82,12 +79,6 @@ domainmaster=/tmp/pfbtemp9_$rvar
 
 dnsbl_tld_remove=/tmp/dnsbl_tld_remove
 
-dnsbl_add=/tmp/dnsbl_add
-dnsbl_add_zone=/tmp/dnsbl_add_zone
-dnsbl_add_data=/tmp/dnsbl_add_data
-dnsbl_remove=/tmp/dnsbl_remove
-dnsbl_remove_zone=/tmp/dnsbl_remove_zone
-dnsbl_remove_data=/tmp/dnsbl_remove_data
 
 dnsbl_python_data=/var/unbound/pfb_py_data.txt
 dnsbl_python_zone=/var/unbound/pfb_py_zone.txt
@@ -471,116 +462,10 @@ dnsbl_scrub() {
 
 
 # Function to process TLD
-domaintld() {
-	# List of Feeds
-	dnsbl_files="${cc}";
-
-	: > "${tempfile}"; : > "${tempfile2}"; : > "${dupfile}"
-
-	if [ -s "${dnsbl_file}.raw" ]; then
-		sort -u "${dnsbl_file}.raw" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_file}.raw"
-		countto="$(grep -v '"transparent"\|\"static\"' ${dnsbl_file}.raw | grep -c ^)"
-	else
-		countto=0
-	fi
-
-	if [ -s "${dnsbl_tld_remove}" ]; then
-		sort -u "${dnsbl_tld_remove}" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_tld_remove}"
-		counttm="$(grep -c '^\.' ${dnsbl_tld_remove})"
-	else
-		counttm=0
-	fi
-
-	if [ "${DEBUG}" = 1 ] && [ -e "${dnsbl_file}.raw" ]; then
-		cp "${dnsbl_file}.raw" "${dnsbl_file}.raw.orig"
-	fi
-
-	printf "."
-
-	# 'Redirect zone'
-	# Collect DNSBL TLD files (by smallest line count first) and merge
-	dnsbl_tmp_files="$(grep -Hc ^ ${dnsbl_tmp}DNSBL_*.txt | sort -t : -k 2,2n | cut -d':' -f1)"
-	if [ ! -z "${dnsbl_tmp_files}" ]; then
-		for file in ${dnsbl_tmp_files}; do
-			# For each file, place 'local-zone' before 'local-data'
-			head -1 "${file}" >> "${dupfile}"
-			tail -n +2 "${file}" | sort -u >> "${dupfile}"
-		done
-
-		# Remove redundant Domains (in 'redirect zone')
-		if [ -s "${dnsbl_tld_remove}" ] && [ -s "${dupfile}" ]; then
-
-			if [ "${DEBUG}" = 1 ]; then
-				cp "${dupfile}" "${dnsbl_file}.dup"
-			fi
-
-			/usr/local/bin/ggrep -vF -f "${dnsbl_tld_remove}" "${dupfile}" > "${tempfile}"
-		else
-			mv -f "${dupfile}" "${tempfile}"
-		fi
-	fi
-
-	# 'Transparent zone'
-	# Remove redundant Domains (in 'transparent zone')
-	if [ -s "${dnsbl_tld_remove}.tsp" ] && [ -s "${dnsbl_file}.tsp" ]; then
-		/usr/local/bin/ggrep -vF -f "${dnsbl_tld_remove}.tsp" "${dnsbl_file}.tsp" | sort -u > "${tempfile2}"
-	else
-		echo "XXX"
-		# XXXX to be confirmed!
-		# mv -f "${dnsbl_tld_remove}.tsp" "${tempfile2}"
-
-	fi
-
-	# Merge all TLD files
-	if [ -f "${tempfile}" ] || [ -f "${tempfile2}" ]; then
-		: > "${dnsbl_file}.raw"
-		cat "${tempfile}" "${tempfile2}" >> "${dnsbl_file}.raw"
-	fi
-
-	if [ "${DEBUG}" = 1 ] && [ -e "${dnsbl_file}.raw" ]; then
-		cp "${dnsbl_file}.raw" "${dnsbl_file}.raw.final"
-	fi
-
-	# Sort 'Transparent zone' remove file
-	if [ -s "${dnsbl_tld_remove}.tsp" ]; then
-		sort -u "${dnsbl_tld_remove}.tsp" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_tld_remove}.tsp"
-	fi
-
-	# Remove redundant Domains in DNSBL files
-	# Need to re-process all Feeds for TLD (Remove any recently added TLD Domains)
-	if [ -s "${dnsbl_tld_remove}.tsp" ]; then
-		for i in ${dnsbl_files}; do
-			alias="${i%*,}"
-			printf "."
-
-			if [ "${DEBUG}" = 1 ] && [ -f "${pfbdomain}${alias}.txt" ]; then
-				cp "${pfbdomain}${alias}.txt" "${pfbdomain}${alias}.xxx"
-			fi
-
-			# Remove redundant TLD Domains
-			if [ -s "${pfbdomain}${alias}.txt" ]; then
-				/usr/local/bin/ggrep -vF -f "${dnsbl_tld_remove}.tsp" "${pfbdomain}${alias}.txt" > "${tempfile}"
-				mv -f "${tempfile}" "${pfbdomain}${alias}.txt"
-			fi
-		done
-	fi
-
-	counttf="$(grep -v '"transparent"\|\"static\"' ${dnsbl_file}.raw | grep -c ^)"
-	counttr="$((countto - counttf))"
-
-	echo
-	echo ' ----------------------------------------'
-	printf "%-12s %-10s %-10s %-10s\n" ' Original' 'Matches' 'Removed' 'Final'
-	echo ' ----------------------------------------'
-	printf "%-12s %-10s %-10s %-10s\n" " ${countto}" "${counttm}" "${counttr}" "${counttf}"
-	printf ' -----------------------------------------'
-}
 
 
 # Function to process TLD python
 domaintldpy() {
-	# List of Feeds
-	dnsbl_files="${cc}";
 
 	if [ -s "${dnsbl_python_data}.raw" ]; then
 		sort -u "${dnsbl_python_data}.raw" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_python_data}.raw"
@@ -640,83 +525,6 @@ domaintldpy() {
 
 
 # Function to compare previous and current DNSBL Unbound conf file, and create Add/Remove files for unbound-control cmds
-dnsbl_livesync() {
-
-	if [ "${DEBUG}" = 1 ]; then
-		if [ -e "${dnsbl_file}.conf" ]; then
-			cp "${dnsbl_file}.conf" "${dnsbl_file}.bkr"
-		fi
-		if [ -e "${dnsbl_file}.raw" ]; then
-			cp "${dnsbl_file}.raw" "${dnsbl_file}.bkraw"
-		fi
-	fi
-
-	rm -f "${dnsbl_add}"*
-	rm -f "${dnsbl_remove}"*
-
-	: > "${dnsbl_add}"
-	: > "${dnsbl_add_zone}"
-	: > "${dnsbl_add_data}"
-	: > "${dnsbl_remove}"
-	: > "${dnsbl_remove_zone}"
-	: > "${dnsbl_remove_data}"
-
-	if [ -s "${dnsbl_file}.conf" ] && [ -s "${dnsbl_file}.raw" ]; then
-		# Collect all changes to DNSBL (add/remove)
-		printf "."
-		awk 'FNR==NR{a[$0];next}!($0 in a)' "${dnsbl_file}.conf" "${dnsbl_file}.raw" > "${dnsbl_add}"
-		printf "."
-		awk 'FNR==NR{a[$0];next}!($0 in a)' "${dnsbl_file}.raw" "${dnsbl_file}.conf" > "${dnsbl_remove}"
-		printf "."
-	elif [ -s "${dnsbl_file}.raw" ]; then
-		printf "."
-		cp "${dnsbl_file}.raw" "${dnsbl_add}"
-
-		# Add a file marker to instruct Unbound to do a reload
-		: > "${dnsbl_file}.reload"
-	else
-		printf "."
-		# Add a file marker to instruct Unbound to do a reload
-		: > "${dnsbl_file}.reload"
-	fi
-
-	# Example Unbound sinkhole lines:
-	# local-zone: "example.com" redirect local-data: "example.com 60 IN A 10.10.10.1"
-	# local-data: "example.com 60 IN A 10.10.10.1"
-	# local-zone: "com" "transparent"
-	# local-zone: "ru" "static"
-
-	# Read 'Remove' file and format local-zone/local-data removal files
-	if [ -s "${dnsbl_remove}" ]; then
-
-		# Collect any local-zone removals
-		grep "local-zone:" "${dnsbl_remove}" | cut -d '"' -f2 > "${dnsbl_remove_zone}"
-
-		# Collect any local-data removals
-		grep "^local-data:" "${dnsbl_remove}" | cut -d ' ' -f2 | tr -d '"' > "${dnsbl_remove_data}"
-	fi
-
-	# Read 'Add' file and format local-zone/local-data addition files
-	if [ -s "${dnsbl_add}" ]; then
-
-		# Collect local-zone additions
-		grep '"transparent"\|\"static\"' "${dnsbl_add}" | cut -d '"' -f2,4 | tr '"', ' ' > "${dnsbl_add_zone}"
-		grep "^local-zone:" "${dnsbl_add}" | cut -d ' ' -f2-3 | tr -d '"' >> "${dnsbl_add_zone}"
-
-		# Collect local-data additions
-		grep -v '"transparent"\|\"static\"' "${dnsbl_add}" | grep "^local-zone:" | cut -d ' ' -f5-9 | tr -d '"' >> "${dnsbl_add_data}"
-		grep "^local-data:" "${dnsbl_add}" | awk '{gsub (/" local/,"\nlocal")}1' | cut -d ' ' -f2-6 | tr -d '"' >> "${dnsbl_add_data}"
-
-		# Create 'transparent' TLD zone for any local-data
-		if [ -s "${dnsbl_add_data}" ]; then
-			cut -d ' ' -f1 "${dnsbl_add_data}" | rev | cut -d '.' -f1 | rev | sed 's/$/ transparent/' >> "${dnsbl_add_zone}"
-		fi
-	fi
-
-	if [ -e "${dnsbl_file}.raw" ]; then
-		mv -f "${dnsbl_file}.raw" "${dnsbl_file}.conf"
-	fi
-}
 
 
 # Function to convert Domains/ASs to its respective IP addresses
@@ -1314,14 +1122,8 @@ case "${1}" in
 	dnsbl_scrub)
 		dnsbl_scrub
 		;;
-	domaintld)
-		domaintld
-		;;
 	domaintldpy)
 		domaintldpy
-		;;
-	dnsbl_livesync)
-		dnsbl_livesync
 		;;
 	cidr_aggregate)
 		agg_folder=true

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -517,7 +517,7 @@ unlink_if_exists('/var/db/pfblockerng/dnsbl.sqlite');
 /* Update unbound python files.
  * The target directory may not exist yet e.g. after an upgrade with
  * RAM Disks enabled; defer the file copy to pfb_unbound_dnsbl(). */
-if (($pfb['dnsbl_mode'] == 'dnsbl_python') && is_dir(g_get('unbound_chroot_path'))) {
+if (is_dir(g_get('unbound_chroot_path'))) {
 	@copy("/usr/local/pkg/pfblockerng/pfb_unbound.py", "{$g['unbound_chroot_path']}/pfb_unbound.py");
 	@copy("/usr/local/pkg/pfblockerng/pfb_unbound_include.inc", "{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
 	@copy("/usr/local/pkg/pfblockerng/pfb_py_hsts.txt", "{$g['unbound_chroot_path']}/pfb_py_hsts.txt");

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -106,6 +106,16 @@ if (
 	pfb_global();
 }
 
+// ADR-02: Migrate DNSBL mode to Python-only.
+$cfg = config_get_path('installedpackages/pfblockerngdnsblsettings/config/0', []);
+if (!empty($cfg) && ($cfg['dnsbl_mode'] !== 'dnsbl_python' || ($cfg['pfb_py_block'] ?? '') !== 'on')) {
+	$cfg['dnsbl_mode']    = 'dnsbl_python';
+	$cfg['pfb_py_block']  = 'on';
+	config_set_path('installedpackages/pfblockerngdnsblsettings/config/0', $cfg);
+	write_config('pfBlockerNG: migrated DNSBL to Python-only mode');
+}
+unset($cfg);
+
 // MaxMind Database is no longer pre-installed during package installation
 if (empty($pfb['maxmind_key'])) {
 	update_status("\nMaxMind GeoIP databases are not pre-installed during installation.\nTo utilize the MaxMind GeoIP functionalities, you will be required to register for a free MaxMind user account and access key. Review the IP tab: MaxMind Settings for more details.\n\n");

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -429,7 +429,7 @@ $options_pfbdnsblstat	= [	'dnsblchart'	=> 'DNSBL Event Timeline',
 				'dnsblgpblock'	=> 'Top Blocked Group',
 				'dnsblfeed'	=> 'Top Blocked Feed',
 				'dnsblip'	=> 'Top Source IP',
-				'dnsblagent'	=> $pfb['dnsbl_py_blacklist'] ? 'Top Blocking mode' : 'Top User-Agent',
+				'dnsblagent'	=> 'Top Blocking mode',
 				'dnsbltld'	=> 'Top TLD',
 				'dnsblwebtype'	=> 'Top Webpage Types',
 				'dnsblmode'	=> 'Top DNSBL Modes',
@@ -941,17 +941,9 @@ if (isset($_POST) && !empty($_POST)) {
 
 			// Collect Domains/Sub-Domains to Whitelist (used by grep -vF -f cmd to remove Domain/Sub-Domains)
 			if ($wildcard) {
-				if ($pfb['dnsbl_py_blacklist']) {
-					$dnsbl_remove = ".{$domain},,\n,{$domain},,\n";
-				} else {
-					$dnsbl_remove = ".{$domain} 60\n\"{$domain} 60\n";
-				}
+				$dnsbl_remove = ".{$domain},,\n,{$domain},,\n";
 			} else {
-				if ($pfb['dnsbl_py_blacklist']) {
-					$dnsbl_remove = ",{$domain},,\n,www.{$domain},,\n";
-				} else {
-					$dnsbl_remove = "\"{$domain} 60\n\"www.{$domain} 60\n";
-				}
+				$dnsbl_remove = ",{$domain},,\n,www.{$domain},,\n";
 			}
 
 			if (!empty($descr)) {
@@ -985,20 +977,12 @@ if (isset($_POST) && !empty($_POST)) {
 
 					$removed .= "{$cname} | ";
 
-					if ($pfb['dnsbl_py_blacklist']) {
-						$dnsbl_remove .= ",{$cname},,\n";
-					} else {
-						$dnsbl_remove .= "\"{$cname} 60\n";
-					}
+					$dnsbl_remove .= ",{$cname},,\n";
 
 					if ($wildcard) {
 						$whitelist .= '.';
 
-						if ($pfb['dnsbl_py_blacklist']) {
-							$dnsbl_remove .= ".{$cname},,\n";
-						} else {
-							$dnsbl_remove .= ".{$cname} 60\n";
-						}
+						$dnsbl_remove .= ".{$cname},,\n";
 					}
 					$whitelist .= "{$cname} # CNAME for ({$domain})";
 
@@ -1034,41 +1018,16 @@ if (isset($_POST) && !empty($_POST)) {
 			@file_put_contents("{$tmp}.adup", $dnsbl_remove, LOCK_EX);
 
 			if (file_exists("{$tmp}.adup") && filesize("{$tmp}.adup") > 0) {
-				if ($pfb['dnsbl_py_blacklist']) {
-					exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$pfb['unbound_py_data']} > "
-						. escapeshellarg("{$tmp}.tmp") . "; mv -f " . escapeshellarg("{$tmp}.tmp") . " {$pfb['unbound_py_data']}"); 
-					exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$pfb['unbound_py_zone']} > " . escapeshellarg("{$tmp}.tmp")
-						. "; mv -f " . escapeshellarg("{$tmp}.tmp") . " {$pfb['unbound_py_zone']}");
-					pfb_unbound_python_whitelist('alerts');
-					pfb_reload_unbound('enabled', FALSE);
-				} else {
-					// Collect all matching whitelisted Domain/CNAME(s)
-					exec("{$pfb['ggrep']} -F -f " . escapeshellarg("{$tmp}.adup") . " {$pfb['dnsbl_file']}.conf > " . escapeshellarg("{$tmp}.supp") . " 2>&1");
-
-					// Remove Whitelisted Domain from Unbound database
-					exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$pfb['dnsbl_file']}.conf > " . escapeshellarg("{$tmp}.tmp")
-						. "; mv -f " . escapeshellarg("{$tmp}.tmp") . " {$pfb['dnsbl_file']}.conf");
-
-					// Remove Whitelisted Domain from DNSBL Feed
-					$table_esc = escapeshellarg("{$pfb['dnsdir']}/{$table}.txt");
-					exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$table_esc} > " . escapeshellarg("{$tmp}.tmp")
-						. "; mv -f " . escapeshellarg("{$tmp}.tmp") . " {$table_esc}");
-				}
+				exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$pfb['unbound_py_data']} > "
+					. escapeshellarg("{$tmp}.tmp") . "; mv -f " . escapeshellarg("{$tmp}.tmp") . " {$pfb['unbound_py_data']}"); 
+				exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$pfb['unbound_py_zone']} > " . escapeshellarg("{$tmp}.tmp")
+					. "; mv -f " . escapeshellarg("{$tmp}.tmp") . " {$pfb['unbound_py_zone']}");
+				pfb_unbound_python_whitelist('alerts');
+				pfb_reload_unbound('enabled', FALSE);
 			}
 
 			// Remove all Whitelisted Domain/CNAME(s) from Unbound using unbound-control
-			if (!$pfb['dnsbl_py_blacklist'] && file_exists("{$tmp}.supp") && filesize("{$tmp}.supp") > 0) {
 
-				exec("{$pfb['grep']} 'local-zone:' " . escapeshellarg("{$tmp}.supp") . " | {$pfb['cut']} -d '\"' -f2 > " . escapeshellarg("{$tmp}.zone") . " 2>&1");
-				exec("{$pfb['grep']} '^local-data:' " . escapeshellarg("{$tmp}.supp") . " | {$pfb['cut']} -d ' ' -f2 | tr -d '\"' > " . escapeshellarg("{$tmp}.data") . " 2>&1");
-
-				if (file_exists("{$tmp}.zone") && filesize("{$tmp}.zone") > 0) {
-					exec("{$pfb['chroot_cmd']} local_zones_remove < " . escapeshellarg("{$tmp}.zone") . " 2>&1");
-				}
-				if (file_exists("{$tmp}.data") && filesize("{$tmp}.data") > 0) {
-					exec("{$pfb['chroot_cmd']} local_datas_remove < " . escapeshellarg("{$tmp}.data") . " 2>&1");
-				}
-			}
 			unlink_if_exists("{$tmp}*");
 
 			// Flush any Domain/CNAME(s) entries in Unbound Resolver Cache
@@ -1179,13 +1138,8 @@ if (isset($_POST) && !empty($_POST)) {
 						unset($clists['dnsblwhitelist']['data']['www' . $entry]);
 					}
 
-					if ($pfb['dnsbl_py_blacklist']) {
-						@file_put_contents($pfb['unbound_py_data'], ",{$entry},,1,,\n", FILE_APPEND);
-						$dnsbl_py_changes = TRUE;
-					} elseif ($pfb['dnsbl'] == 'on') {
-						$domain_esc = escapeshellarg($entry);
-						exec("{$pfb['chroot_cmd']} local_data {$domain_esc} '60 IN A {$pfb['dnsbl_vip4']}' 2>&1");
-					}
+					@file_put_contents($pfb['unbound_py_data'], ",{$entry},,1,,\n", FILE_APPEND);
+					$dnsbl_py_changes = TRUE;
 				}
 			case 'delete_domainwildcard':
 				$type = 'DNSBL Whitelist';
@@ -1202,14 +1156,8 @@ if (isset($_POST) && !empty($_POST)) {
 							unset($clists['dnsblwhitelist']['data'][$entry]);
 						}
 
-						if ($pfb['dnsbl_py_blacklist']) {
-							@file_put_contents($pfb['unbound_py_zone'], ",{$entry},,1,,\n", FILE_APPEND);
-							$dnsbl_py_changes = TRUE;
-						} elseif ($pfb['dnsbl'] == 'on') {
-							$domain_esc = escapeshellarg($entry);
-							exec("{$pfb['chroot_cmd']} local_zone {$domain_esc} redirect 2>&1");
-							exec("{$pfb['chroot_cmd']} local_data {$domain_esc} '60 IN A {$pfb['dnsbl_vip4']}' 2>&1");
-						}
+						@file_put_contents($pfb['unbound_py_zone'], ",{$entry},,1,,\n", FILE_APPEND);
+						$dnsbl_py_changes = TRUE;
 					}
 				}
 
@@ -1357,7 +1305,7 @@ if (isset($_POST) && !empty($_POST)) {
 		}
 
 		// For DNSBL python - Lock/unlock - Collect missing Feed/Group Name
-		if ($pfb['dnsbl_py_blacklist'] && $_POST['dnsbl_remove'] != 'unlock' && $dnsbl_type != 'python') {
+		if ($_POST['dnsbl_remove'] != 'unlock' && $dnsbl_type != 'python') {
 			$log_type = '1';
 			$pfb_feed = $pfb_group = 'Unknown';
 			if (file_exists("{$pfb['dnsbl_unlock']}.data")) {
@@ -1379,22 +1327,18 @@ if (isset($_POST) && !empty($_POST)) {
 				$py_file = $pfb['unbound_py_zone'];
 			}
 
-			if ($pfb['dnsbl_py_blacklist']) {
-				if ($dnsbl_type == 'python') {
-					@file_put_contents($pfb['unbound_py_wh'], "{$domain},0\n", FILE_APPEND | LOCK_EX);
-				}
-				else {
-					$tmp = tempnam('/tmp', 'dnsbl_alert_');
-					@file_put_contents("{$tmp}.adup", ",{$domain},,\n", LOCK_EX);
-					exec("{$pfb['ggrep']} -F -f " . escapeshellarg("{$tmp}.adup") . " {$py_file} >> {$pfb['dnsbl_unlock']}.data"); // Store DNSBL Feed/Group Data
-					exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$py_file} > " . escapeshellarg("{$tmp}.tmp") . "; mv -f "
-						. escapeshellarg("{$tmp}.tmp") . " {$py_file}");
-					unlink_if_exists("{$tmp}*");
-				}
-				pfb_reload_unbound('enabled', FALSE);
-			} else {
-				exec("{$pfb['chroot_cmd']} {$cmd} {$domain_esc} 2>&1");
+			if ($dnsbl_type == 'python') {
+				@file_put_contents($pfb['unbound_py_wh'], "{$domain},0\n", FILE_APPEND | LOCK_EX);
 			}
+			else {
+				$tmp = tempnam('/tmp', 'dnsbl_alert_');
+				@file_put_contents("{$tmp}.adup", ",{$domain},,\n", LOCK_EX);
+				exec("{$pfb['ggrep']} -F -f " . escapeshellarg("{$tmp}.adup") . " {$py_file} >> {$pfb['dnsbl_unlock']}.data"); // Store DNSBL Feed/Group Data
+				exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$py_file} > " . escapeshellarg("{$tmp}.tmp") . "; mv -f "
+					. escapeshellarg("{$tmp}.tmp") . " {$py_file}");
+				unlink_if_exists("{$tmp}*");
+			}
+			pfb_reload_unbound('enabled', FALSE);
 
 			exec("{$pfb['chroot_cmd']} flush {$domain_esc} 2>&1");
 
@@ -1420,28 +1364,19 @@ if (isset($_POST) && !empty($_POST)) {
 
 		// Lock Domain
 		elseif ($_POST['dnsbl_remove'] == 'lock') {
-			if ($pfb['dnsbl_py_blacklist']) {
-				if ($dnsbl_type == 'python') {
-					pfb_unbound_python_whitelist('alerts');
-				}
-				else {
-					if ($dnsbl_type == 'TLD') {
-						$py_file = $pfb['unbound_py_zone'];
-					} else {
-						$py_file = $pfb['unbound_py_data'];
-					}
-
-					@file_put_contents($py_file, ",{$domain},,{$log_type},{$pfb_feed},{$pfb_group}\n", FILE_APPEND);
-				}
-				pfb_reload_unbound('enabled', FALSE);
+			if ($dnsbl_type == 'python') {
+				pfb_unbound_python_whitelist('alerts');
 			}
-			elseif ($pfb['dnsbl'] == 'on') {
-
+			else {
 				if ($dnsbl_type == 'TLD') {
-					exec("{$pfb['chroot_cmd']} local_zone {$domain_esc} redirect 2>&1");
+					$py_file = $pfb['unbound_py_zone'];
+				} else {
+					$py_file = $pfb['unbound_py_data'];
 				}
-				exec("{$pfb['chroot_cmd']} local_data {$domain_esc} '60 IN A {$pfb['dnsbl_vip4']}' 2>&1");
+
+				@file_put_contents($py_file, ",{$domain},,{$log_type},{$pfb_feed},{$pfb_group}\n", FILE_APPEND);
 			}
+			pfb_reload_unbound('enabled', FALSE);
 
 			// Remove Domain from unlock file
 			pfb_unlock('lock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
@@ -1449,27 +1384,18 @@ if (isset($_POST) && !empty($_POST)) {
 		}
 		elseif ($_POST['dnsbl_remove'] == 'relock') {
 
-			if ($pfb['dnsbl_py_blacklist']) {
-				if ($dnsbl_type == 'python') {
-					pfb_unbound_python_whitelist('alerts');
-				}
-				else {
-					if ($dnsbl_type == 'TLD') {
-						$py_file = $pfb['unbound_py_zone'];
-					} else {
-						$py_file = $pfb['unbound_py_data'];
-					}
-					@file_put_contents($py_file, ",{$domain},,{$log_type},{$pfb_feed},{$pfb_group}\n", FILE_APPEND);
-				}
-				pfb_reload_unbound('enabled', FALSE);
+			if ($dnsbl_type == 'python') {
+				pfb_unbound_python_whitelist('alerts');
 			}
-			elseif ($pfb['dnsbl'] == 'on') {
-
+			else {
 				if ($dnsbl_type == 'TLD') {
-					exec("{$pfb['chroot_cmd']} local_zone {$domain_esc} redirect 2>&1");
+					$py_file = $pfb['unbound_py_zone'];
+				} else {
+					$py_file = $pfb['unbound_py_data'];
 				}
-				exec("{$pfb['chroot_cmd']} local_data {$domain_esc} '60 IN A {$pfb['dnsbl_vip4']}' 2>&1");
+				@file_put_contents($py_file, ",{$domain},,{$log_type},{$pfb_feed},{$pfb_group}\n", FILE_APPEND);
 			}
+			pfb_reload_unbound('enabled', FALSE);
 
 			// Add Domain to unlock file
 			pfb_unlock('unlock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
@@ -1477,28 +1403,18 @@ if (isset($_POST) && !empty($_POST)) {
 		}
 		elseif ($_POST['dnsbl_remove'] == 'reunlock') {
 
-			if ($pfb['dnsbl_py_blacklist']) {
-				if ($dnsbl_type == 'python') {
-					pfb_unbound_python_whitelist('alerts');
-				}
-				else {
-					if ($dnsbl_type == 'TLD') {
-						$py_file = $pfb['unbound_py_zone'];
-					} else {
-						$py_file = $pfb['unbound_py_data'];
-					}
-					@file_put_contents($py_file, ",{$domain},,{$log_type},{$pfb_feed},{$pfb_group}\n", FILE_APPEND);
-				}
-				pfb_reload_unbound('enabled', FALSE);
+			if ($dnsbl_type == 'python') {
+				pfb_unbound_python_whitelist('alerts');
 			}
 			else {
-				$cmd = 'local_data_remove';
 				if ($dnsbl_type == 'TLD') {
-					$cmd = 'local_zone_remove';
+					$py_file = $pfb['unbound_py_zone'];
+				} else {
+					$py_file = $pfb['unbound_py_data'];
 				}
-				exec("{$pfb['chroot_cmd']} {$cmd} {$domain_esc} 2>&1");
-				exec("{$pfb['chroot_cmd']} flush {$domain_esc} 2>&1");
+				@file_put_contents($py_file, ",{$domain},,{$log_type},{$pfb_feed},{$pfb_group}\n", FILE_APPEND);
 			}
+			pfb_reload_unbound('enabled', FALSE);
 
 			// Remove Domain from unlock file
 			pfb_unlock('lock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
@@ -1820,7 +1736,7 @@ if ($alert_summary) {
 			if ($alert_view != 'dnsbl_stat') {
 				$unknown_msg = 'Unknown';
 			} else {
-				$unknown_msg = $pfb['dnsbl_py_blacklist'] ? 'DNSBL Webserver/VIP' : 'Not available for HTTPS alerts';
+				$unknown_msg = 'DNSBL Webserver/VIP';
 			}
 
 			$agent_cmd = '';
@@ -2064,25 +1980,14 @@ function dnsbl_whitelist_type($fields, $clists, $isExclusion, $isTLD, $qdomain) 
 			. "DNSBL Groupname:&emsp;[ {$fields[6]} ]\n"
 			. "DNSBL Feedname:&emsp;&nbsp;&nbsp;[ {$fields[8]} ]\n\n";
 
-		if ($pfb['dnsbl_py_blacklist']) {
-			$s_txt .= "Whitelist [ {$fields[2]} ]\n\n"
-				. "Note:&emsp;This will immediately remove the blocked Domain\n"
-				. "&emsp;&emsp;&emsp;&nbsp;and associated CNAMES from DNSBL.\n" 
-				. "&emsp;&emsp;&emsp;&nbsp;(CNAMES: Define the external DNS server in Alert settings\n"
-				. "&emsp;&emsp;&emsp;&nbsp;&nbsp;and ensure that the Resolver has access to the External DNS server.)\n\n"
-				. "Whitelisting Options:\n\n"
-				. "1) Wildcard whitelist [ .{$fields[2]} ]\n"
-				. "2) Whitelist only [ {$fields[2]} ]\n";
-		} else {
-			$s_txt .= "Whitelisting Options:\n\n"
-				. "1) Wildcard whitelist [ .{$fields[7]} ]\n"
-				. "&emsp;This will immediately remove the blocked Domain/CNAMES from DNSBL.\n"
-				. "&emsp;(CNAMES: Define the external DNS server in Alert settings\n"
-				. "&emsp;&nbsp;and ensure that the Resolver has access to the External DNS server.)\n\n"
-				. "2) Add [ {$fields[7]} ] to the 'TLD Exclusion customlist'\n"
-				. "&emsp;A Force Reload-DNSBL is Required!\n"
-				. "&emsp;After a Reload any new blocked Domains can be Whitelisted at that time.";
-		}
+		$s_txt .= "Whitelist [ {$fields[2]} ]\n\n"
+			. "Note:&emsp;This will immediately remove the blocked Domain\n"
+			. "&emsp;&emsp;&emsp;&nbsp;and associated CNAMES from DNSBL.\n" 
+			. "&emsp;&emsp;&emsp;&nbsp;(CNAMES: Define the external DNS server in Alert settings\n"
+			. "&emsp;&emsp;&emsp;&nbsp;&nbsp;and ensure that the Resolver has access to the External DNS server.)\n\n"
+			. "Whitelisting Options:\n\n"
+			. "1) Wildcard whitelist [ .{$fields[2]} ]\n"
+			. "2) Whitelist only [ {$fields[2]} ]\n";
 	}
 	else {
 		$s_txt = "Whitelist [ {$fields[2]} ]\n\n"
@@ -2434,51 +2339,47 @@ function convert_dnsbl_log($mode, $fields) {
 	// Lock/Unlock Domain Icon
 	$s_txt = '';
 	$unlock_dom = '&nbsp;&nbsp;&nbsp;';
-	if (($fields[6] != 'Unknown' && !$pfb['dnsbl_py_blacklist'] && $isMatch) || ($pfb['dnsbl_py_blacklist'])) {
 
-		if ((!$pfb['dnsbl_py_blacklist'] && $fields[5] != 'DNSBL_TLD') || $pfb['dnsbl_py_blacklist']) {
 
-			$tnote = "\n\nNote:&emsp;&#8226; Unlocking Domain(s) is temporary and may be automatically\n"
-				. "&emsp;&emsp;&emsp;&emsp;re-locked on a Cron or Force command with an Unbound Reload!\n"
-				. "&emsp;&emsp;&emsp;&nbsp;&#8226; Review Threat Source ( i ) Icon for Domain details.\n"
-				. "&emsp;&emsp;&emsp;&nbsp;&#8226; Clear your Browser and OS cache after each Lock/Unlock!";
+	$tnote = "\n\nNote:&emsp;&#8226; Unlocking Domain(s) is temporary and may be automatically\n"
+		. "&emsp;&emsp;&emsp;&emsp;re-locked on a Cron or Force command with an Unbound Reload!\n"
+		. "&emsp;&emsp;&emsp;&nbsp;&#8226; Review Threat Source ( i ) Icon for Domain details.\n"
+		. "&emsp;&emsp;&emsp;&nbsp;&#8226; Clear your Browser and OS cache after each Lock/Unlock!";
 
-			if ($isPython) {
-				$unlock_type = 'python';
-			} else {
-				$unlock_type = $fields[5];
-			}
+	if ($isPython) {
+		$unlock_type = 'python';
+	} else {
+		$unlock_type = $fields[5];
+	}
 
-			if (!isset($dnsbl_unlock[$qdomain])) {
-				if ($isWhitelist_found) {
-					$s_txt = "\n\nNote:&emsp;The following Domain exists in the DNSBL Whitelist:\n\n"
-						. "Whitelisted:&emsp;[ {$qdomain} ]\n\n"
-						. "This Domain can be temporarily Relocked into DNSBL\n"
-						. "by selecting the Unlock Icon!";
+	if (!isset($dnsbl_unlock[$qdomain])) {
+		if ($isWhitelist_found) {
+			$s_txt = "\n\nNote:&emsp;The following Domain exists in the DNSBL Whitelist:\n\n"
+				. "Whitelisted:&emsp;[ {$qdomain} ]\n\n"
+				. "This Domain can be temporarily Relocked into DNSBL\n"
+				. "by selecting the Unlock Icon!";
 
-					$unlock_dom = '<i class="fa-solid fa-unlock text-warning" id="DNSBL_RELCK|'
-							. $qdomain . '|' . $unlock_type . '" title="' . $s_txt . '"></i>';
-				}
-				else {
-					$unlock_dom = '<i class="fa-solid fa-lock text-danger" id="DNSBL_ULCK|'
-							. $qdomain . '|' . $unlock_type
-							. '" title="Unlock Domain: [ ' . $qdomain . '] from DNSBL?' . $tnote . '" ></i>';
-				}
-			} else {
-				if ($isWhitelist_found) {
-					$s_txt = "\n\nNote:&emsp;The following Domain exists in the DNSBL Whitelist:\n\n"
-						. "Whitelisted:&emsp;[ {$wt_line} ]\n\n"
-						. "Unlock this Domain by selecting the Unlock Icon!";
+			$unlock_dom = '<i class="fa-solid fa-unlock text-warning" id="DNSBL_RELCK|'
+					. $qdomain . '|' . $unlock_type . '" title="' . $s_txt . '"></i>';
+		}
+		else {
+			$unlock_dom = '<i class="fa-solid fa-lock text-danger" id="DNSBL_ULCK|'
+					. $qdomain . '|' . $unlock_type
+					. '" title="Unlock Domain: [ ' . $qdomain . '] from DNSBL?' . $tnote . '" ></i>';
+		}
+	} else {
+		if ($isWhitelist_found) {
+			$s_txt = "\n\nNote:&emsp;The following Domain exists in the DNSBL Whitelist:\n\n"
+				. "Whitelisted:&emsp;[ {$wt_line} ]\n\n"
+				. "Unlock this Domain by selecting the Unlock Icon!";
 
-					$unlock_dom = '<i class="fa-solid fa-lock text-warning" id="DNSBL_REULCK|'
-						. $qdomain . '|' . $unlock_type . '" title="' . $s_txt . '"></i>';
-				}
-				else {
-					$unlock_dom = '<i class="fa-solid fa-unlock text-primary" id="DNSBL_LCK|'
-						. $qdomain . '|' . $unlock_type . '" title="Re-Lock Domain: ['
-						. $qdomain . ' ] back into DNSBL?' . $tnote . '" ></i>';
-				}
-			}
+			$unlock_dom = '<i class="fa-solid fa-lock text-warning" id="DNSBL_REULCK|'
+				. $qdomain . '|' . $unlock_type . '" title="' . $s_txt . '"></i>';
+		}
+		else {
+			$unlock_dom = '<i class="fa-solid fa-unlock text-primary" id="DNSBL_LCK|'
+				. $qdomain . '|' . $unlock_type . '" title="Re-Lock Domain: ['
+				. $qdomain . ' ] back into DNSBL?' . $tnote . '" ></i>';
 		}
 	}
 
@@ -3219,10 +3120,8 @@ $tab_array[] = array(gettext('IP Block Stats'),		$active['ip_block'],	'/pfblocke
 $tab_array[] = array(gettext('IP Permit Stats'),	$active['ip_permit'],	'/pfblockerng/pfblockerng_alerts.php?view=ip_permit_stat');
 $tab_array[] = array(gettext('IP Match Stats'),		$active['ip_match'],	'/pfblockerng/pfblockerng_alerts.php?view=ip_match_stat');
 
-if ($pfb['dnsbl_mode'] == 'dnsbl_python') {
-	$tab_array[] = array(gettext('DNS Reply'),		$active['reply'],		'/pfblockerng/pfblockerng_alerts.php?view=reply');
-	$tab_array[] = array(gettext('DNS Reply Stats'),	$active['dnsbl_reply_stat'],	'/pfblockerng/pfblockerng_alerts.php?view=dnsbl_reply_stat');
-}
+$tab_array[] = array(gettext('DNS Reply'),		$active['reply'],		'/pfblockerng/pfblockerng_alerts.php?view=reply');
+$tab_array[] = array(gettext('DNS Reply Stats'),	$active['dnsbl_reply_stat'],	'/pfblockerng/pfblockerng_alerts.php?view=dnsbl_reply_stat');
 $tab_array[] = array(gettext('DNSBL Block Stats'),	$active['dnsbl'],	'/pfblockerng/pfblockerng_alerts.php?view=dnsbl_stat');
 display_top_tabs($tab_array, true);
 
@@ -3486,7 +3385,7 @@ if ($pfb['dnsbl'] == 'on') {
 }
 $section->add($group);
 
-if ($pfb['dnsbl'] == 'on' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
+if ($pfb['dnsbl'] == 'on') {
 	$group = new Form_Group('DNS Reply Log Options');
 	$group->add(new Form_Select(
 		'pfbreplytypes',
@@ -3786,7 +3685,7 @@ if (!$alert_summary && ($alert_title != 'DNS Reply')) {
 		))->setAttribute('title', 'Enter filter \'Group name\'.');
 		$section->add($group);
 
-		$f19_title = ($pfb['dnsbl_mode'] == 'dnsbl_python' ? gettext("DNSBL: Blocking Type") : gettext("DNSBL: Domain/Referer|URI|Agent"));
+		$f19_title = (gettext("DNSBL: Blocking Type"));
 		$group = new Form_Group(NULL);
 		$group->add(new Form_Input(
 			'filterlogentries_dnsbltype',
@@ -3807,77 +3706,75 @@ if (!$alert_summary && ($alert_title != 'DNS Reply')) {
 
 if (!$alert_summary && ($alert_title == 'DNS Reply' || $alert_title == 'Unified Logs')) {
 
-	if ($pfb['dnsbl_mode'] == 'dnsbl_python') {
-		$group = new Form_Group('DNS Reply');
-		$group->add(new Form_Input(
-			'filterlogentries_replydate',
-			'Reply - Date',
-			'text',
-			$filterfieldsarray[2][89]
-		))->setAttribute('title', 'Enter filter \'DNS Reply Date\'.');
+	$group = new Form_Group('DNS Reply');
+	$group->add(new Form_Input(
+		'filterlogentries_replydate',
+		'Reply - Date',
+		'text',
+		$filterfieldsarray[2][89]
+	))->setAttribute('title', 'Enter filter \'DNS Reply Date\'.');
 
-		$group->add(new Form_Input(
-			'filterlogentries_replydomain',
-			'Reply - Domain',
-			'text',
-			$filterfieldsarray[2][85]
-		))->setAttribute('title', 'Enter filter \'DNS Reply Domain\'.');
-		$section->add($group);
+	$group->add(new Form_Input(
+		'filterlogentries_replydomain',
+		'Reply - Domain',
+		'text',
+		$filterfieldsarray[2][85]
+	))->setAttribute('title', 'Enter filter \'DNS Reply Domain\'.');
+	$section->add($group);
 
-		$group = new Form_Group(NULL);
-		$group->add(new Form_Input(
-			'filterlogentries_replysrcip',
-			'Reply - Source IP',
-			'text',
-			$filterfieldsarray[2][86]
-		))->setAttribute('title', 'Enter filter \'DNS Reply SRC IP\'.');
+	$group = new Form_Group(NULL);
+	$group->add(new Form_Input(
+		'filterlogentries_replysrcip',
+		'Reply - Source IP',
+		'text',
+		$filterfieldsarray[2][86]
+	))->setAttribute('title', 'Enter filter \'DNS Reply SRC IP\'.');
 
-		$group->add(new Form_Input(
-			'filterlogentries_replydstip',
-			'Reply - Resolved IP',
-			'text',
-			$filterfieldsarray[2][87]
-		))->setAttribute('title', 'Enter filter \'DNS Resolved IP\'.');
+	$group->add(new Form_Input(
+		'filterlogentries_replydstip',
+		'Reply - Resolved IP',
+		'text',
+		$filterfieldsarray[2][87]
+	))->setAttribute('title', 'Enter filter \'DNS Resolved IP\'.');
 
-		$group->add(new Form_Input(
-			'filterlogentries_replygeoip',
-			'Reply - GeoIP',
-			'text',
-			$filterfieldsarray[2][88]
-		))->setAttribute('title', 'Enter filter \'DNS Reply GeoIP\'.')
-		  ->setwidth(2);
-		$section->add($group);
+	$group->add(new Form_Input(
+		'filterlogentries_replygeoip',
+		'Reply - GeoIP',
+		'text',
+		$filterfieldsarray[2][88]
+	))->setAttribute('title', 'Enter filter \'DNS Reply GeoIP\'.')
+	  ->setwidth(2);
+	$section->add($group);
 
-		$group = new Form_Group(NULL);
-		$group->add(new Form_Input(
-			'filterlogentries_replytype',
-			'Reply - Type',
-			'text',
-			$filterfieldsarray[2][81]
-		))->setAttribute('title', 'Enter filter \'DNS Reply Type\'.');
+	$group = new Form_Group(NULL);
+	$group->add(new Form_Input(
+		'filterlogentries_replytype',
+		'Reply - Type',
+		'text',
+		$filterfieldsarray[2][81]
+	))->setAttribute('title', 'Enter filter \'DNS Reply Type\'.');
 
-		$group->add(new Form_Input(
-			'filterlogentries_replyorec',
-			'Reply - Original Record',
-			'text',
-			$filterfieldsarray[2][82]
-		))->setAttribute('title', 'Enter filter \'DNS Reply Orig Record\'.');
+	$group->add(new Form_Input(
+		'filterlogentries_replyorec',
+		'Reply - Original Record',
+		'text',
+		$filterfieldsarray[2][82]
+	))->setAttribute('title', 'Enter filter \'DNS Reply Orig Record\'.');
 
-		$group->add(new Form_Input(
-			'filterlogentries_replyrec',
-			'Reply - DNS Record',
-			'text',
-			$filterfieldsarray[2][83]
-		))->setAttribute('title', 'Enter filter \'DNS Reply Record\'.');
+	$group->add(new Form_Input(
+		'filterlogentries_replyrec',
+		'Reply - DNS Record',
+		'text',
+		$filterfieldsarray[2][83]
+	))->setAttribute('title', 'Enter filter \'DNS Reply Record\'.');
 
-		$group->add(new Form_Input(
-			'filterlogentries_replyttl',
-			'Reply - TTL',
-			'text',
-			$filterfieldsarray[2][84]
-		))->setAttribute('title', 'Enter filter \'DNS Reply TTL\'.');
-		$section->add($group);
-	}
+	$group->add(new Form_Input(
+		'filterlogentries_replyttl',
+		'Reply - TTL',
+		'text',
+		$filterfieldsarray[2][84]
+	))->setAttribute('title', 'Enter filter \'DNS Reply TTL\'.');
+	$section->add($group);
 }
 
 if (!$alert_summary) {
@@ -4040,15 +3937,11 @@ if (!$alert_summary):
 					}
 
 					if ($logtype == 'DNSBL Block') {
-						if ($pfb['dnsbl_py_blacklist']) {
-							continue 2;
-						}
+						continue 2;
 						break;
 					}
 					elseif ($logtype == 'DNSBL Python') {
-						if (!$pfb['dnsbl_py_blacklist']) {
-							continue 2;
-						}
+
 						break;
 					}
 				}
@@ -4441,8 +4334,8 @@ $stats = array( 'dnsblchart'	=> array("DNSBL Event Timeline&emsp;<small>(Last <s
 		'dnsblgpblock'	=> array('Top Blocked Group',			'Found', 'DNSBL Group(s)',	FALSE, ''),
 		'dnsblfeed'	=> array('Top Feed',				'Found', 'Feed(s)',		FALSE, ''),
 		'dnsblip'	=> array('Top Source IP',			'Found', 'Source IP(s)',	FALSE, ''),
-		'dnsblagent'	=> array($pfb['dnsbl_py_blacklist'] ? 'Blocking Type' : 'Top User-Agent', 'Found',
-					$pfb['dnsbl_py_blacklist'] ? 'Type(s)' : 'User-Agent(s)',		FALSE, ''),
+		'dnsblagent'	=> array('Blocking Type', 'Found',
+					'Type(s)',		FALSE, ''),
 		'dnsbltld'	=> array('Top TLD',				'Found', 'TLD(s)',		FALSE, ''),
 		'dnsblwebtype'	=> array('Top Blocked Webpage Types',		'Found', 'Blocked Webpage Type(s)',	FALSE, ''),
 		'dnsblmode'	=> array('Top DNSBL Modes',			'Found', 'Blocked DNSBL Mode(s)',	FALSE, ''),
@@ -4489,9 +4382,7 @@ foreach ($stats as $stat_type => $stype):
 	if ($stat_type == 'ipasn' && $pfb['asn_reporting'] == 'disabled') {
 		continue;
 	}
-	elseif ($alert_view == 'dnsbl_stat' && substr($stat_type, 0,6) == 'python' && $pfb['dnsbl_mode'] != 'dnsbl_python') {
-		continue;
-	}
+
 
 	$topcount = $sumlines = 0;
 	if (!empty($alert_stats[$alert_view][$stat_type])) {
@@ -4695,7 +4586,7 @@ foreach ($stats as $stat_type => $stype):
 							}
 
 							if ($stat_type == 'dnsblagent' && $data == 'Unknown') {
-								$data = $pfb['dnsbl_py_blacklist'] ? 'DNSBL Webserver/VIP' : 'Not available for HTTPS alerts';
+								$data = 'DNSBL Webserver/VIP';
 							}
 
 							if ($stat_type == 'ipdstport') {

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -3938,10 +3938,8 @@ if (!$alert_summary):
 
 					if ($logtype == 'DNSBL Block') {
 						continue 2;
-						break;
 					}
 					elseif ($logtype == 'DNSBL Python') {
-
 						break;
 					}
 				}

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -497,25 +497,14 @@ if (isset($savemsg)) {
 
 						$log_error = '';
 						if ($gtype == 'dnsbl') {
-							if ($pfb['dnsbl_py_blacklist']) {
-								$log_options = ['enabled'	=> 'DNSBL WebServer/VIP',
-										'disabled'	=> 'Null Block (no logging)',
-										'disabled_log'	=> 'Null Block (logging)'];
-							} else {
-								$log_options = ['enabled'	=> 'DNSBL WebServer/VIP',
-										'disabled'	=> 'Null Block (no logging)'];
-							}
+							$log_options = ['enabled'	=> 'DNSBL WebServer/VIP',
+									'disabled'	=> 'Null Block (no logging)',
+									'disabled_log'	=> 'Null Block (logging)'];
 
 							// Global DNSBL Logging/Blocking mode
 							if (!empty($pfb['dnsbl_global_log'])) {
-								if (!$pfb['dnsbl_py_blacklist'] && $pfb['dnsbl_global_log'] == 'disabled_log') {
-									$logtype		= 'enabled';
-									$log_error		= "Global Log 'Null Block (logging)' not available in Unbound Mode."
-												. " Re-configure Global Log option!";
-								} else {
-									$logtype		= $pfb['dnsbl_global_log'];
-									$log_options[$logtype]	= "{$log_options[$logtype]} (Global)";
-								}
+								$logtype		= $pfb['dnsbl_global_log'];
+								$log_options[$logtype]	= "{$log_options[$logtype]} (Global)";
 							}
 						}
 						else {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -418,14 +418,9 @@ $options_agateway_in		= $options_agateway_out		= pfb_get_gateways();
 
 $options_order			= [ 'default' => 'Default', 'primary' => 'Primary' ];
 
-if ($pfb['dnsbl_py_blacklist']) {
-	$options_logging	= [	'enabled'	=> 'DNSBL WebServer/VIP',
-					'disabled'	=> 'Null Blocking (no logging)',
-					'disabled_log'	=> 'Null Blocking (logging)' ];
-} else {
-	$options_logging	= [	'enabled'	=> 'DNSBL WebServer/VIP',
-					'disabled'	=> 'Null Blocking (no logging)' ];
-}
+$options_logging	= [	'enabled'	=> 'DNSBL WebServer/VIP',
+				'disabled'	=> 'Null Blocking (no logging)',
+				'disabled_log'	=> 'Null Blocking (logging)' ];
 
 $options_suppression_cidr	= [ 'Disabled' => 'Disabled' ] + array_combine(range(1, 17, 1), range(1, 17, 1));
 
@@ -1508,21 +1503,13 @@ if ($gtype == 'dnsbl') {
 			. 'When set as \'Primary\', this DNSBL Group will be processed before all other DNSBL Groups/Category(s)')
 	  ->setAttribute('style', 'width: auto');
 
-	if ($pfb['dnsbl_py_blacklist']) {
-		$log_text = 'Default: <strong>DNSBL WebServer/VIP</strong><br />'
-				. '&#8226 <strong>DNSBL WebServer/VIP</strong>, Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
-				. '&#8226 <strong>Null Blocking (no logging)</strong>, Utilize \'0.0.0.0\' with no logging.<br />'
-				. '&#8226 <strong>Null Blocking (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br /><br />'
-				. 'Blocked domains will be reported to the Alert/Python Block Table.<br />'
-				. 'Enabling the "Global Logging/Blocking mode" in the DNSBL Tab will override this setting!<br />'
-				. 'A \'Force Reload - DNSBL\' is required for changes to take effect';
-	} else {
-		$log_text = 'Default: <strong>Enabled</strong><br />'
-				. '&#8226 When \'Enabled\', Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
-				. '&#8226 When \'Disabled\', <strong>\'0.0.0.0\'</strong> will be used instead of the DNSBL VIP.<br />'
-				. 'Enabling the "Global Logging/Blocking mode" in the DNSBL Tab will override this setting!<br />'
-				. 'A \'Force Reload - DNSBL\' is required for changes to take effect';
-	}
+	$log_text = 'Default: <strong>DNSBL WebServer/VIP</strong><br />'
+			. '&#8226 <strong>DNSBL WebServer/VIP</strong>, Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
+			. '&#8226 <strong>Null Blocking (no logging)</strong>, Utilize \'0.0.0.0\' with no logging.<br />'
+			. '&#8226 <strong>Null Blocking (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br /><br />'
+			. 'Blocked domains will be reported to the Alert/Python Block Table.<br />'
+			. 'Enabling the "Global Logging/Blocking mode" in the DNSBL Tab will override this setting!<br />'
+			. 'A \'Force Reload - DNSBL\' is required for changes to take effect';
 
 	$section->addInput(new Form_Select(
 		'logging',

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -52,7 +52,6 @@ $pconfig['dnsbl_allow_int']	= explode(',', $pfb['dconfig']['dnsbl_allow_int'])	?
 $pconfig['global_log']		= $pfb['dconfig']['global_log']				?: '';
 $pconfig['dnsbl_webpage']	= $pfb['dconfig']['dnsbl_webpage']			?: 'dnsbl_default.php';
 $pconfig['pfb_cache']		= isset($pfb['dconfig']['pfb_cache'])			? $pfb['dconfig']['pfb_cache'] : 'on';
-$pconfig['pfb_dnsbl_sync']	= $pfb['dconfig']['pfb_dnsbl_sync']			?: '';
 
 $pconfig['pfb_py_reply']	= isset($pfb['dconfig']['pfb_py_reply'])		? $pfb['dconfig']['pfb_py_reply'] : 'on';
 $pconfig['pfb_hsts']		= isset($pfb['dconfig']['pfb_hsts'])			? $pfb['dconfig']['pfb_hsts'] : 'on';
@@ -500,7 +499,6 @@ if ($_POST) {
 			$pfb['dconfig']['dnsbl_allow_int']	= implode(',', (array)$_POST['dnsbl_allow_int'])			?: '';
 			$pfb['dconfig']['global_log']		= $_POST['global_log']							?: '';
 			$pfb['dconfig']['pfb_cache']		= pfb_filter($_POST['pfb_cache'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
-			$pfb['dconfig']['pfb_dnsbl_sync']	= pfb_filter($_POST['pfb_dnsbl_sync'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 
 			$pfb['dconfig']['pfb_py_reply']		= pfb_filter($_POST['pfb_py_reply'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_hsts']		= pfb_filter($_POST['pfb_hsts'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
@@ -743,17 +741,6 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['pfb_py_reply'] === 'on' ? true:false,
 	'on'
 ))->setHelp('Enable the logging of all DNS Replies that were not blocked via DNSBL.');
-
-$section->addInput(new Form_Checkbox(
-	'pfb_dnsbl_sync',
-	gettext('Resolver Live Sync'),
-	'Enable',
-	$pconfig['pfb_dnsbl_sync'] === 'on' ? true:false,
-	'on'
-))->setHelp('When enabled, updates to the DNS Resolver DNSBL database will be performed Live without reloading the Resolver.<br />'
-	. 'This will allow for more frequent DNSBL Updates (ie: Hourly) without losing DNS Resolution.<br />'
-	. 'This option is not required when DNSBL python blocking mode is enabled.<br />'
-	. '<span class="text-danger">Note:</span> A Force Reload will run a full Reload of Unbound');
 
 $section->addInput(new Form_Checkbox(
 	'pfb_hsts',
@@ -2963,10 +2950,6 @@ function enable_ports() {
 	}
 }
 
-function enable_python() {
-	hideCheckbox('pfb_dnsbl_sync', true);
-}
-
 function enable_python_pytld() {
 	if ($('#pfb_pytld').prop('checked')) {
 		hideCheckbox('pfb_pytld_sort', false);
@@ -3025,8 +3008,6 @@ events.push(function(){
 		enable_ports();
 	});
 	enable_ports();
-
-	enable_python();
 
 	$('#pfb_pytld').click(function() {
 		enable_python_pytld();

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -54,17 +54,7 @@ $pconfig['dnsbl_webpage']	= $pfb['dconfig']['dnsbl_webpage']			?: 'dnsbl_default
 $pconfig['pfb_cache']		= isset($pfb['dconfig']['pfb_cache'])			? $pfb['dconfig']['pfb_cache'] : 'on';
 $pconfig['pfb_dnsbl_sync']	= $pfb['dconfig']['pfb_dnsbl_sync']			?: '';
 
-$pconfig['dnsbl_mode']		= $pfb['dconfig']['dnsbl_mode']				?: '';
-if (isset($pfb['dconfig']['pfb_python'])) {
-	if ($pfb['dconfig']['pfb_python'] == 'on') {
-		$pconfig['dnsbl_mode'] = 'dnsbl_python';
-	} else {
-		$pconfig['dnsbl_mode'] = 'dnsbl_unbound';
-	}
-}
-
 $pconfig['pfb_py_reply']	= isset($pfb['dconfig']['pfb_py_reply'])		? $pfb['dconfig']['pfb_py_reply'] : 'on';
-$pconfig['pfb_py_block']	= isset($pfb['dconfig']['pfb_py_block'])		? $pfb['dconfig']['pfb_py_block'] : 'on';
 $pconfig['pfb_hsts']		= isset($pfb['dconfig']['pfb_hsts'])			? $pfb['dconfig']['pfb_hsts'] : 'on';
 $pconfig['pfb_idn']		= $pfb['dconfig']['pfb_idn']				?: '';
 $pconfig['pfb_regex']		= $pfb['dconfig']['pfb_regex']				?: '';
@@ -111,40 +101,27 @@ $pconfig['alexa_inclusion']	= explode(',', $pfb['dconfig']['alexa_inclusion'])	?
 
 $pconfig['tldexclusion']	= base64_decode($pfb['dconfig']['tldexclusion'])	?: '';
 $pconfig['tldblacklist']	= base64_decode($pfb['dconfig']['tldblacklist'])	?: '';
-$pconfig['tldwhitelist']	= base64_decode($pfb['dconfig']['tldwhitelist'])	?: '';
 
 // Select field options
 
-$options_dnsbl_mode		= [ 'dnsbl_unbound' => 'Unbound mode', 'dnsbl_python' => 'Unbound python mode' ];
 $options_dnsbl_interface	= pfb_build_if_list(FALSE, FALSE);
 $options_dnsbl_interface_all	= array_merge(array('lo0' => 'Localhost'), $options_dnsbl_interface);
 $options_dnsbl_interface_cnt	= count($options_dnsbl_interface) ?: '1';
 
 $options_dnsbl_allow_int	= $options_dnsbl_interface;
 
-if ($pfb['dnsbl_py_blacklist']) {
-	$options_global_log_txt = 'Default: <strong>No Global mode</strong><br />'
-				. 'Enabling this option will overide the individual DNSBL Group "Logging/Blocking" settings!<br /><br />'
-				. '&#8226 <strong>Null Block (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br />'
-				. '&#8226 <strong>DNSBL WebServer/VIP</strong>, Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
-				. '&#8226 <strong>Null Block (no logging)</strong>, Utilize \'0.0.0.0\' with no logging.<br />'
-				. 'Blocked domains will be reported to the Alert/Python Block Table.<br /><br />'
-				. 'A \'Force Reload - DNSBL\' is required for changes to take effect';
+$options_global_log_txt = 'Default: <strong>No Global mode</strong><br />'
+			. 'Enabling this option will overide the individual DNSBL Group "Logging/Blocking" settings!<br /><br />'
+			. '&#8226 <strong>Null Block (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br />'
+			. '&#8226 <strong>DNSBL WebServer/VIP</strong>, Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
+			. '&#8226 <strong>Null Block (no logging)</strong>, Utilize \'0.0.0.0\' with no logging.<br />'
+			. 'Blocked domains will be reported to the Alert/Python Block Table.<br /><br />'
+			. 'A \'Force Reload - DNSBL\' is required for changes to take effect';
 
-	$options_global_log	= [	''		=> 'No Global mode',
-					'disabled_log'	=> 'Null Block (logging)',
-					'enabled'	=> 'DNSBL WebServer/VIP',
-					'disabled'	=> 'Null Block (no logging)'];
-} else {
-	$options_global_log_txt = 'Default: <strong>No Global mode</strong><br />'
-					. '&#8226 When \'Enabled\', Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
-					. '&#8226 When \'Disabled\', <strong>\'0.0.0.0\'</strong> will be used instead of the DNSBL VIP.<br />'
-					. 'A \'Force Reload - DNSBL\' is required for changes to take effect';
-
-	$options_global_log	= [	''		=> 'No Global mode',
-					'enabled'	=> 'DNSBL WebServer/VIP',
-					'disabled'	=> 'Null Block (no logging)'];
-}
+$options_global_log	= [	''		=> 'No Global mode',
+				'disabled_log'	=> 'Null Block (logging)',
+				'enabled'	=> 'DNSBL WebServer/VIP',
+				'disabled'	=> 'Null Block (no logging)'];
 
 $options_dnsbl_webpage = array();
 $indexdir = '/usr/local/www/pfblockerng/www';
@@ -353,8 +330,7 @@ if ($_POST) {
 		}
 
 		// Validate Select field options
-		$select_options = array(	'dnsbl_mode'		=> 'dnsbl_unbound',
-						'dnsbl_interface'	=> 'lo0',
+		$select_options = array(						'dnsbl_interface'	=> 'lo0',
 						'global_log'		=> '',
 						'dnsbl_webpage'		=> 'dnsbl_default.php',
 						'alexa_type'		=> 'tranco',
@@ -441,8 +417,7 @@ if ($_POST) {
 				'pfb_gp_bypass_list'	=> 'ip',
 				'suppression'		=> 'domain',
 				'tldexclusion'		=> 'hostname',
-				'tldblacklist'		=> 'tld',
-				'tldwhitelist'		=> 'tldwhite' ) as $custom_type => $custom_format) {
+				'tldblacklist'		=> 'tld' ) as $custom_type => $custom_format) {
 
 				if (!empty($_POST[$custom_type])) {
 					$customlist = explode("\r\n", $_POST[$custom_type]);
@@ -476,17 +451,6 @@ if ($_POST) {
 									}
 									break;
 								case 'tld':
-									if (empty(pfb_filter($value[0], PFB_FILTER_TLD, 'dnsbl'))) {
-										$input_errors[] = "Customlist {$custom_type}: Invalid TLD entry: [ " . htmlspecialchars($line) . " ]";
-									}
-									break;
-								case 'tldwhite':
-									if (strpos($value[0], '|') !== FALSE) {
-										list($value[0], $host) = array_map('trim', explode('|', $value[0]));
-										if (empty(pfb_filter($host, PFB_FILTER_IP, 'dnsbl'))) {
-											$input_errors[] = "Customlist {$custom_type}: Invalid TLD IP entry: [ " . htmlspecialchars($line) . " ]"; 
-										}
-									}
 									if (empty(pfb_filter($value[0], PFB_FILTER_TLD, 'dnsbl'))) {
 										$input_errors[] = "Customlist {$custom_type}: Invalid TLD entry: [ " . htmlspecialchars($line) . " ]";
 									}
@@ -591,7 +555,6 @@ if ($_POST) {
 			$pfb['dconfig']['suppression']		= base64_encode($_POST['suppression'])					?: '';
 			$pfb['dconfig']['tldexclusion']		= base64_encode($_POST['tldexclusion'])					?: '';
 			$pfb['dconfig']['tldblacklist']		= base64_encode($_POST['tldblacklist'])					?: '';
-			$pfb['dconfig']['tldwhitelist']		= base64_encode($_POST['tldwhitelist'])					?: '';
 
 			// Reset TOP1M Database/Whitelist on user changes
 			if ($pfb['dconfig']['alexa_type'] != $_POST['alexa_type']) {
@@ -607,19 +570,6 @@ if ($_POST) {
 			}
 			$pfb['dconfig']['alexa_count']		= $_POST['alexa_count']							?: '1000';
 
-			// Remove DNSBL blocking files, when user changes blocking mode
-			if (($pfb['dconfig']['pfb_py_block'] != $_POST['pfb_py_block']) ||
-			    ($pfb['dconfig']['dnsbl_mode'] !== $_POST['dnsbl_mode'] && $_POST['pfb_py_block'] == 'on')) {
-
-				unlink_if_exists("{$pfb['dnsbl_file']}.conf");
-				unlink_if_exists($pfb['unbound_py_data']);
-				unlink_if_exists($pfb['unbound_py_zone']);
-				unlink_if_exists($pfb['unbound_py_wh']);
-				unlink_if_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt");
-				$savemsg = "A Force Reload DNSBL must be run to complete the blocking mode changes! The previous DNSBL database has been deleted!";
-			}
-			$pfb['dconfig']['pfb_py_block']		= pfb_filter($_POST['pfb_py_block'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
-			$pfb['dconfig']['dnsbl_mode']		= $_POST['dnsbl_mode']							?: 'dnsbl_unbound';
 
 			$pfb['dconfig']['pfb_dnsvip4']		= $_POST['pfb_dnsvip4']							?: '';
 			$pfb['dconfig']['dnsbl_interface']	= $_POST['dnsbl_interface']						?: 'lo0';
@@ -721,15 +671,11 @@ $section->addInput(new Form_Checkbox(
 
 $dnsbl_text = 'This is an <strong>Advanced process</strong> to determine if all Sub-Domains should be wildcard blocked for each listed Domain.<br />
 		<span class="text-danger">Click infoblock</span> before enabling this feature!&emsp;
-		<div id="dnsbl_unbound_tld_info" class="infoblock">
+		<div id="dnsbl_tld_info" class="infoblock">
 
-		<span class="dnsbl_unbound_tld"><strong>This Feature is not recommended for Low-Perfomance/Low-Memory installations!</strong><br /></span>
 		<strong>Definition: TLD</strong> -
 		&emsp;represents the last segment of a domain name. IE: example.com (TLD = com), example.uk.com (TLD = uk.com)<br /><br />
 
-		<span class="dnsbl_unbound_tld">The \'Unbound Resolver Reloads\' can take several seconds or more to complete and may temporarily interrupt
-		DNS Resolution until the Resolver has been fully Reloaded with the updated Domain changes.
-		Consider updating the DNSBL Feeds <strong>\'Once per Day\'</strong>, if network issues arise.<br /><br /></span>
 
 		When enabled and after all downloads for DNSBL Feeds have completed; TLD will process the Domains.<br />
 		TLD uses a predetermined list of TLDs, to determine if the listed Domains should be wildcard blocked (Block all sub-Domains).<br />
@@ -745,42 +691,10 @@ $dnsbl_text = 'This is an <strong>Advanced process</strong> to determine if all 
 		&emsp;&emsp;&emsp;&emsp;Either add the domain to the TLD Exclusion, or wildcard Whitelist the whole domain.<br /><br />
 
 		<strong>TLD Blacklist</strong>, can be used to block whole TLDs. &emsp;IE: <strong>xyz</strong><br />
-		<span class="dnsbl_unbound_tld"><strong>TLD Whitelist</strong> is <strong><u>only</u></strong> used in conjunction with
-		<strong> TLD Blacklist</strong> and is used to allow access to a Domain that is being blocked by a TLD Blacklist.<br /><br /></span>
 
 		When Enabling/Disabling this option, a <strong>Force Reload - DNSBL</strong> is required.<br /><br />
 
-		<span class="dnsbl_unbound_tld">Once the TLD Domain limit below is exceeded, the balance of the Domains will be listed as-is.
-		IE: Blocking only the listed Domain (Not Sub-Domains)<br /><strong>TLD Domain Limit Restrictions:</strong><br />
-		<ul>
-			<li>< 1.0GB RAM - Max 100k Domains</li>
-			<li>< 1.5GB RAM - Max 150k Domains</li>
-			<li>< 2.0GB RAM - Max 200k Domains</li>
-			<li>< 2.5GB RAM - Max 250k Domains</li>
-			<li>< 3.0GB RAM - Max 400k Domains</li>
-			<li>< 4.0GB RAM - Max 600k Domains</li>
-			<li>< 5.0GB RAM - Max 1.0M Domains</li>
-			<li>< 6.0GB RAM - Max 1.5M Domains</li>
-			<li>< 7.0GB RAM - Max 2.5M Domains</li>
-			<li>> 7.0GB RAM - > 2.5M Domains</li>
-		</ul></span>
 	</div>';
-
-$section->addInput(new Form_Select(
-	'dnsbl_mode',
-	gettext('DNSBL Mode'),
-	$pconfig['dnsbl_mode'],
-	$options_dnsbl_mode
-))->setHelp('Select the DNSBL mode.&emsp;'
-		. '<div class="infoblock">'
-		. '<strong>Unbound Mode</strong>:<br />'
-		. '&emsp;&emsp;&emsp;&emsp;This mode will utilize Unbound local-zone/local-data entries for DNSBL (requires more memory).<br />'
-		. '<strong>Unbound Python Mode</strong>:<br />'
-		. '&emsp;&emsp;&emsp;&emsp;This mode is only available for pfSense version 2.4.5 and above.<br />'
-		. '&emsp;&emsp;&emsp;&emsp;This mode will utilize the python integration of Unbound for DNSBL.<br />'
-		. '&emsp;&emsp;&emsp;&emsp;This mode will allow logging of DNS Replies, and more advanced DNSBL Blocking features.<br />'
-		. '&emsp;&emsp;&emsp;&emsp;This mode requires substantially less memory </div>'
-);
 
 $section->addInput(new Form_Checkbox(
 	'pfb_tld',
@@ -829,21 +743,6 @@ $section->addInput(new Form_Checkbox(
 	$pconfig['pfb_py_reply'] === 'on' ? true:false,
 	'on'
 ))->setHelp('Enable the logging of all DNS Replies that were not blocked via DNSBL.');
-
-$section->addInput(new Form_Checkbox(
-	'pfb_py_block',
-	gettext('DNSBL Blocking') . '(py)',
-	'Enable',
-	$pconfig['pfb_py_block'] === 'on' ? true:false,
-	'on'
-))->setHelp('Enable the DNSBL python blocking mode.<div class="infoblock">'
-	. '<strong>DNSBL python blocking order</strong>:<br /><br />'
-	. '1) DNSBL python blocking mode option (Block any domains listed in the Feeds via DNSBL/TLD/DNSBL_TLD)<br />'
-	. '2) TLD Allow option (Only allow these TLDs to the next validation steps)<br />'
-	. '3) IDN Blocking option (Block any IDN domain or IDNs in punycode (ascii) format)<br />'
-	. '4) Regex Blocking option (User defined regular expression rules)<br /><br />'
-	. 'Blocked events (#2-4) will be <strong title="Utilizes 0.0.0.0 instead of the DNSBL VIP">Null Blocked</strong> and reported in the python log</div>'
-);
 
 $section->addInput(new Form_Checkbox(
 	'pfb_dnsbl_sync',
@@ -2841,16 +2740,13 @@ $section->addInput(new Form_Textarea(
 
 $form->add($section);
 
-$section = new Form_Section('TLD Blacklist/Whitelist', 'TLD_BW_list', COLLAPSIBLE|SEC_CLOSED);
+$section = new Form_Section('TLD Blacklist', 'TLD_BW_list', COLLAPSIBLE|SEC_CLOSED);
 
 $section->addInput(new Form_StaticText(
 	'Note:',
 	'The TLD Blacklist is used to block a whole TLD (IE: pw).<br /><br />'
 	. '<span class="text-danger">Note:</span><br />'
-	. 'DO NOT add domains to the TLD Whitelist, Instead, add them to any DNSBL Group Customlist or to a Source URL (Feed) that you manage.<br /><br />'
-	. 'The TLD Whitelist is used to allow access to the specific domain/sub-domains that is blocked by a TLD Blacklist; while blocking all others.<br />'
 	. 'TLD Blacklist/Whitelist: A <strong>static</strong> zone entry is used in the DNS Resolver for this feature, therefore no Alerts will be generated.<br />'
-	. '<br />When the \'python Blocking mode\' feature is enabled. The TLD Whitelist is not utilized and instead uses the DNSBL Whitelist.'
 ));
 
 $tld_blacklist_text = 'Enter TLD(s) to be blacklisted.&emsp;
@@ -2872,39 +2768,6 @@ $section->addInput(new Form_Textarea(
   ->setAttribute('wrap', 'off')
   ->setAttribute('style', 'background:#fafafa; width: 100%')
   ->setHelp($tld_blacklist_text);
-
-$tld_whitelist_text = 'Enter <strong>each specific</strong> Domain and/or Sub-Domains to be Whitelisted.
-			(Used in conjunction with <strong>TLD Blacklist only</strong>)&emsp;
-			<div class="infoblock">
-				Enter one &emsp;<strong>Domain</strong>&emsp;per line<br />Examples:<br />
-				<ul>
-					<li>example.com</li>
-					<li>example.com|x.x.x.x&emsp;&emsp;(Replace x.x.x.x with associated Domain/Sub-Domain IP Address.</li>
-				</ul>
-				The First option above will collect the IP Address on each Cron run,
-				while the second option will define a Static IP Address.<br /><br />
-
-				You must Whitelist every Domain or Sub-Domain individually.<br />
-				No Regex Entries and no leading/trailing \'dot\' allowed!<br />
-				You may use "<strong>#</strong>" after any Domain/Sub-Domain to add comments. IE: (example.com|x.x.x.x # TLD Whitelist)<br />
-				This List is stored as \'Base64\' format in the config.xml file.<br /><br />
-			</div>';
-
-if ($pfb['dnsbl_py_blacklist']) {
-	$tld_whitelist_text = "<span class=\"text-danger\">TLD Whitelist is not utilized for Unbound python mode! Use DNSBL Whitelist instead.</span><br /><br />{$tld_whitelist_text}";
-}
-
-$section->addInput(new Form_Textarea(
-	'tldwhitelist',
-	'TLD Whitelist',
-	$pconfig['tldwhitelist']
-))->removeClass('form-control')
-  ->addClass('row-fluid col-sm-12')
-  ->setAttribute('columns', '90')
-  ->setAttribute('rows', '15')
-  ->setAttribute('wrap', 'off')
-  ->setAttribute('style', 'background:#fafafa; width: 100%')
-  ->setHelp($tld_whitelist_text);
 
 $form->add($section);
 
@@ -3101,66 +2964,23 @@ function enable_ports() {
 }
 
 function enable_python() {
-
-	var python = true;
-	if ($('#dnsbl_mode').val() == 'dnsbl_unbound') {
-		var python = false;
-	};
-
-	if (python && $('#pfb_py_block').prop('checked')) {
-		hideCheckbox('pfb_dnsbl_sync', true);
-	} else {
-		hideCheckbox('pfb_dnsbl_sync', false);
-	}
-
-	hideCheckbox('pfb_control', !python);
-	hideCheckbox('pfb_py_reply', !python);
-	hideCheckbox('pfb_py_block', !python);
-	hideCheckbox('pfb_hsts', !python);
-	hideCheckbox('pfb_idn', !python);
-	hideCheckbox('pfb_regex', !python);
-	hideCheckbox('pfb_noaaaa', !python);
-	hideCheckbox('pfb_cname', !python);
-	hideCheckbox('pfb_gp', !python);
-	hideInput('pfb_regex_list', !python);
-	hideInput('pfb_noaaaa_list', !python);
-	hideInput('pfb_gp_bypass_list', !python);
-	hideCheckbox('pfb_pytld', !python);
-	hideCheckbox('pfb_pytld_sort', !python);
-	hideMultiClass('pfb_python', !python);
-	hideCheckbox('pfb_py_nolog', !python);
-
-	if (!python) {
-		$('.dnsbl_unbound_tld').show();
-		$('#tldwhitelist').attr('readonly', false).css('background-color', '#FAFAFA');
-	} else {
-		$('.dnsbl_unbound_tld').hide();
-		$('#tldwhitelist').attr('readonly', true).css('background-color', '#DEDEDE');
-	}
-
-	if ($('#dnsbl_mode').val() == 'dnsbl_python' && $('#pfb_py_block').prop('checked') == false) {
-		$('.dnsbl_unbound_tld').show();
-	}
+	hideCheckbox('pfb_dnsbl_sync', true);
 }
 
 function enable_python_pytld() {
-	if ($('#dnsbl_mode').val() == 'dnsbl_python') {
-		if ($('#pfb_pytld').prop('checked')) {
-			hideCheckbox('pfb_pytld_sort', false);
-			hideMultiClass('pfb_python', false);
-			$('#dnsbl_python_tld_allow_text').show();
-		} else {
-			hideCheckbox('pfb_pytld_sort', true);
-			hideMultiClass('pfb_python', true);
-			$('#dnsbl_python_tld_allow_text').hide();
-		}
+	if ($('#pfb_pytld').prop('checked')) {
+		hideCheckbox('pfb_pytld_sort', false);
+		hideMultiClass('pfb_python', false);
+		$('#dnsbl_python_tld_allow_text').show();
 	} else {
+		hideCheckbox('pfb_pytld_sort', true);
 		hideMultiClass('pfb_python', true);
+		$('#dnsbl_python_tld_allow_text').hide();
 	}
 }
 
 function enable_python_regex() {
-	if ($('#dnsbl_mode').val() == 'dnsbl_python' && $('#pfb_regex').prop('checked')) {
+	if ($('#pfb_regex').prop('checked')) {
 		$('#Python_regex_list').show();
 	} else {
 		$('#Python_regex_list').hide();
@@ -3168,7 +2988,7 @@ function enable_python_regex() {
 }
 
 function enable_python_noaaaa() {
-	if ($('#dnsbl_mode').val() == 'dnsbl_python' && $('#pfb_noaaaa').prop('checked')) {
+	if ($('#pfb_noaaaa').prop('checked')) {
 		$('#Python_noaaaa_list').show();
 	} else {
 		$('#Python_noaaaa_list').hide();
@@ -3176,7 +2996,7 @@ function enable_python_noaaaa() {
 }
 
 function enable_python_gp() {
-	if ($('#dnsbl_mode').val() == 'dnsbl_python' && $('#pfb_gp').prop('checked')) {
+	if ($('#pfb_gp').prop('checked')) {
 		$('#Python_Group_Policy').show();
 	} else {
 		$('#Python_Group_Policy').hide();
@@ -3206,19 +3026,7 @@ events.push(function(){
 	});
 	enable_ports();
 
-	$('#dnsbl_mode').click(function() {
-		enable_python();
-		enable_python_pytld();
-		enable_python_regex();
-		enable_python_noaaaa();
-		enable_python_gp();
-	});
 	enable_python();
-
-	$('#pfb_py_block').click(function() {
-		enable_python();
-		enable_python_pytld();
-	});
 
 	$('#pfb_pytld').click(function() {
 		enable_python_pytld();

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -185,11 +185,7 @@ $pfb_logtypes = array(	'defaultlogs'	=> array('name'		=> 'Log Files',
 						)
 		);
 
-if ($pfb['dnsbl_py_blacklist']) {
-	unset($pfb_logtypes['unbound']);
-} else {
-	unset($pfb_logtypes['python']);
-}
+unset($pfb_logtypes['unbound']);
 
 // Dynamically add any configured DNSBL Categeory Feeds
 if ($pfb['blconfig'] &&

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -610,16 +610,9 @@ function pfBlockerNG_get_header($mode='') {
 
 	$unbound_validate = FALSE;
 	if (file_exists("{$pfb['dnsbldir']}/unbound.conf")) {
-		if ($pfb['dnsbl_mode'] == 'dnsbl_python') {
-			$py_mode = '(Python mode)';
-			if (strpos(file_get_contents("{$pfb['dnsbldir']}/unbound.conf"), 'pfb_unbound.py') !== FALSE) {
-				$unbound_validate = TRUE;
-			}
-		} else {
-			$py_mode = '(Unbound mode)';
-			if (strpos(file_get_contents("{$pfb['dnsbldir']}/unbound.conf"), 'pfb_dnsbl') !== FALSE) {
-				$unbound_validate = TRUE;
-			}
+		$py_mode = '(Python mode)';
+		if (strpos(file_get_contents("{$pfb['dnsbldir']}/unbound.conf"), 'pfb_unbound.py') !== FALSE) {
+			$unbound_validate = TRUE;
 		}
 	}
 
@@ -637,7 +630,7 @@ function pfBlockerNG_get_header($mode='') {
 		}
 
 		// Check for any Python Integration errors
-		if ($pfb['dnsbl_mode'] == 'dnsbl_python' && (int)@filesize($pfb['pyerrlog']) > 0) {
+		if ((int)@filesize($pfb['pyerrlog']) > 0) {
 			$dnsbl_status	= 'fa-solid fa-exclamation-circle text-warning';
 			$dnsbl_msg	= "DNSBL {$py_mode} errors Found! Review py_error.log";
 		}
@@ -645,7 +638,7 @@ function pfBlockerNG_get_header($mode='') {
 		$dnsbl_status		= 'fa-solid fa-times-circle text-danger';
 
 		// Check for any Python Integration errors
-		if ($pfb['dnsbl_mode'] == 'dnsbl_python' && (int)@filesize($pfb['pyerrlog']) > 0) {
+		if ((int)@filesize($pfb['pyerrlog']) > 0) {
 			$dnsbl_msg = "DNSBL {$py_mode} is Disabled with errors! Review py_error.log";
 		} else {
 			$dnsbl_msg = "DNSBL {$py_mode} is Disabled.";


### PR DESCRIPTION
## ADR-02 — Drop the non-Python (native Unbound) DNSBL mode

Makes the Unbound **Python integration** the only DNSBL implementation and removes the legacy native Unbound (`local-zone`/`local-data`) path end to end, with automatic config migration for existing installs.

Full decision record + per-phase prompts/results live in `.ADRs/ADR_02_Drop_Unbound_Mode/`.

> Targets **`next`** (incubation branch), not `devel` — this is innovative work that isn't ready to land on `devel` yet.

### What changes
- **Force Python-only + migrate** (`pfblockerng_install.inc`): existing `dnsbl_unbound` (or `dnsbl_python` + `pfb_py_block != on`) configs are migrated to `dnsbl_python` + `pfb_py_block = on`.
- **UI** (`pfblockerng_dnsbl.php`): remove the DNSBL Mode selector, the Python-blocking checkbox, the native-only TLD Whitelist, and the now-dead Resolver Live Sync field.
- **Core** (`pfblockerng.inc`): remove the native resolver-queries daemon, native `pfb_dnsbl.conf` `local-zone`/`local-data` generation, the resolver/lighttpd native config branches, the live-update-without-reload path, and every `dnsbl_mode` / `dnsbl_py_blacklist` conditional.
- **Shell** (`pfblockerng.sh`): remove `domaintld()` and `dnsbl_livesync()`; keep `domaintldpy()`.
- **Alerts / widget / category / log**: collapse all mode branches to the Python path.

### Kept intentionally
lighttpd webserver / DNSBL VIP / NAT, Wildcard Blocking (`pfb_tld`), the SafeSearch-CNAME native-include (still required in Python mode), and `python_blocking = on`. `pfb_unbound.py` is essentially untouched.

### Commit layout
P1 force+migrate → P2 UI → P3a–d core → P4 shell → P5 alerts/widget + finalize → residual cleanup (+ ADR docs).

### Verification
- `php -l` clean on all production PHP; `pfb_unbound.py` compiles; ShellCheck clean; `ruff` clean; `python -m pytest` → **163 passed**.
- Package-wide grep: `dnsbl_unbound` / `pfb_py_block` / `dnsbl_py_blacklist` / `dnsbl_mode` appear **only** in the install.inc migration.
- Static review confirmed intact: the producer ↔ `pfb_unbound.py` data-format contract (6-col data/zone, 3-col safesearch, 2-col whitelist), unbound reload/restart, and the dashboard resolver-query widget.

### ⚠️ Not yet accepted — manual smoke test required
No live Unbound exists in CI. Before this is promoted toward `devel`, run the checklist in `.ADRs/ADR_02_Drop_Unbound_Mode/RESULTS/05_Results.txt` on a clean install **and** a box upgraded from `dnsbl_unbound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
