### PR TITLE
pfblockerng: ensure DNSBL python-script block is added when module already loaded

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2191,7 +2191,7 @@ function pfb_unbound_dnsbl($mode) {
 		}
 
 		$unbound = FALSE;	// Unbound mode
-		$unbound_py = FALSE;	// Unbound python mode
+		$unbound_py_script = FALSE;	// pfb_unbound.py 'python:' script block present
 
 		$u_update = FALSE;
 		$u_msg = '';
@@ -2226,9 +2226,10 @@ function pfb_unbound_dnsbl($mode) {
 
 			elseif (strpos($line, 'module-config:') !== FALSE) {
 				if ($mode == 'enabled' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
-					if (strpos($line, 'module-config: "python') !== FALSE) {
-						$unbound_py = TRUE;
-					} else {
+					// Ensure the python module is loaded. The pfb_unbound.py script
+					// block is tracked separately ($unbound_py_script) and ensured
+					// after the loop, so do NOT infer its presence from this line.
+					if (strpos($line, 'module-config: "python') === FALSE) {
 						$u_update = TRUE;
 						$u_msg .= "  Added DNSBL Unbound Python mode\n";
 						$conf[$key] = str_replace('module-config: "', 'module-config: "python ', $line);
@@ -2254,7 +2255,7 @@ function pfb_unbound_dnsbl($mode) {
 
 			elseif (strpos($line, 'python-script: pfb_unbound.py') !== FALSE) {
 				if ($mode == 'enabled' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
-					$unbound_py = TRUE;
+					$unbound_py_script = TRUE;
 				} else {
 					$u_update = TRUE;
 					$u_msg .= "  Removed DNSBL Unbound Python mode script\n";
@@ -2281,7 +2282,7 @@ function pfb_unbound_dnsbl($mode) {
 		}
 
 		// Add python script line
-		if (!$unbound_py && $mode == 'enabled' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
+		if (!$unbound_py_script && $mode == 'enabled' && $pfb['dnsbl_mode'] == 'dnsbl_python') {
 			$u_update = TRUE;
 			$u_msg .= "  Added DNSBL Unbound Python mode script\n";
 			$conf[] = "\npython:\npython-script: pfb_unbound.py\n";


### PR DESCRIPTION
## Problem

`pfb_modify_unbound()` (the `unbound.conf` sync) used a single `$unbound_py` flag that was set `TRUE` by **either**:

- the `module-config: "python ..."` line (python module loaded), **or**
- the `python-script: pfb_unbound.py` line (pfBlockerNG script registered)

These are two independent pieces of unbound config. When `module-config` already enabled python but the `python:` / `python-script:` block was missing — e.g. a partially-migrated or externally-edited `unbound.conf` — the flag flipped `TRUE` on the module-config match alone, so the post-loop guard **skipped re-adding the script block**. Unbound then restarted with the python module loaded but **without pfBlockerNG's script**, silently disabling DNSBL.

## Fix

Track the script block independently of module-config detection:

- Rename the flag to `$unbound_py_script`; set it **only** from the actual `python-script: pfb_unbound.py` line.
- The `module-config:` branch now just ensures the `python ` token is present (no longer infers script presence).
- The post-loop guard appends the full `"\npython:\npython-script: pfb_unbound.py\n"` unit whenever the script line is missing, regardless of module-config state.

Because the appended unit always contains both the `python:` clause and the `python-script:` line, the fix never produces a bare `python-script:` without its clause.

## Note on the CodeRabbit suggestion

This was surfaced by CodeRabbit on the ADR-02 PR (#12). CodeRabbit's proposed two-flag diff gated the `python:` *clause* on `$has_python_module` (the `module-config` line) while gating `python-script:` separately — which can emit a bare `python-script:` with **no preceding `python:` clause** (malformed unbound config) when the module is present but the clause is missing. This PR instead keeps the `python:`+`python-script:` block as one atomic unit, decoupled only from module-config detection.

## Scope

Pre-existing on `devel`/`main` — **not** an ADR-02 regression. ADR-02 only drops the `&& $pfb['dnsbl_mode'] == 'dnsbl_python'` sub-condition (mode is always python post-ADR-02); the conflation is identical here. Fixing on `devel` so it flows to `adr/02` and `main`.

## Testing

- `php -l` clean (pre-existing deprecation notices unrelated to the change).
- No PHP test harness exists for this migration logic; verified by reasoning over the enable/disable + present/absent matrix. Recommend a live-box smoke test (enable DNSBL with a `unbound.conf` that has `module-config: "python ..."` but no `python:` block → confirm the script block is re-added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS filtering rule configuration to ensure more reliable detection and proper application of advanced filtering policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->