### PR TITLE
ADR-06: Move DNSBL list preprocessing out of shell/PHP into the Python plugin

### DIFF
--- a/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/ADR.md
+++ b/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/ADR.md
@@ -1,6 +1,6 @@
 # ADR-06: Move DNSBL list preprocessing out of shell/PHP into the Python plugin
 
-- **Status:** **Proposed** (2026-06-01)
+- **Status:** **Implemented — pending live smoke** (2026-06-01) — Phases 1–6 landed on `adr/06`; CI gates green and the init/memory kill-gate is met (see §7 build evidence). Flips to **Accepted** only after the maintainer runs the live manual smoke (§7).
 - **Date:** 2026-06-01
 - **Branch:** `adr/06` (off **`next`** — depends on ADR-02 "Python-only DNSBL" having landed) / **Component(s):** `src/usr/local/pkg/pfblockerng/pfb_unbound.py` (new build/parse layer + load path), `pfblockerng.inc` (`tld_analysis`, the download/parse loop, `pfb_unbound_python_whitelist`), `pfblockerng.sh` (`:470-523` finalize/dedup/count), `pfblockerng_dnsbl.php` / `pfblockerng_alerts.php` (UI reads of counts; whitelist entry points — preserved).
 - **Target runtime:** Python 3.11+ inside Unbound's `pythonmod`, **stdlib only**; PHP 8.3; POSIX `sh`.
@@ -171,16 +171,89 @@ Prompt: `06_Validation_DoD.txt`
 - The build is a pure reentrant function (zero-downtime-ready) and the parser is format-pluggable (ABP-ready) — neither feature implemented here.
 - Status → **Accepted** only after the manual smoke (below) passes on a live pfSense box.
 
+### Build evidence (Phase 6, recorded on `adr/06`)
+
+**Decision-equivalence — PASS.** Golden + build unit tests pin identical
+block/resolve/whitelist/HSTS/noAAAA/zone-subdomain decisions across **all** formats:
+
+- `tests/test_adr06_golden_oracle.py` — reference preprocessor → **production**
+  `pfb_unbound.evaluate_domain`/`evaluate_noaaaa` over the golden query set, both
+  TOP1M-disabled and TOP1M-enabled scenarios; the firewall-IP extraction set is
+  asserted (`GOLDEN_EXTRACTED_IPS`) and confirmed absent from the block lists.
+  Fixtures exercise **hosts / plain / basic-ABP / csv:pon** (`tests/fixtures/adr06_golden/`).
+- `tests/test_adr06_build_module.py` — the pure `parse`/`normalise`/`classify`/`build`
+  layer unit by unit.
+- `tests/test_adr06_init_from_raw.py` — the **production** `dnsbl_build_from_manifest`
+  over an on-box-shaped manifest, asserted decision-equal to **both** the golden map
+  **and** the reference pipeline (parametrised over both TOP1M scenarios), plus
+  feed/group attribution, the no-IP-leak invariant, and `dnsbl_emit_count` writing
+  the loaded-entry total to `pfb_py_count`.
+- `tests/test_adr06_php_boundary.py` — the shipped PHP "clean → emit as `plain`"
+  boundary, round-tripped through the production build, decision-equal with no IP leak.
+
+Full suite: **`python -m pytest` → 255 passed**; `ruff check .` / `ruff format --check .`
+clean; `php -l` + ShellCheck clean (Phase 5).
+
+**Init/memory kill-gate — GO (PASS, comfortable headroom).** Re-measured on `adr/06`
+at the agreed ≥1M-entry un-pruned corpus (CPython 3.14, macOS dev box; threshold
+build ≤ 8 s AND retained ≤ 410 B/entry vs the 274 B/entry ADR-05 §3a baseline):
+
+| build path | size | build wall-time (median, N≥5) | peak RAM | retained B/entry | verdict |
+| --- | --- | --- | --- | --- | --- |
+| production `dnsbl_build_from_manifest` | 1,000,000 | **2.28 s** (max 2.33) | 141.5 MiB | 281.5 (+3%) | **PASS** |
+| production `dnsbl_build_from_manifest` | 2,000,000 | **4.39 s** (max 4.43) | 266.8 MiB | 284.7 (+4%) | **PASS** |
+| Phase-1 spike prototype | 1,000,000 | 1.47 s | 193.8 MiB¹ | 274.9 (+0%) | PASS |
+
+Time is linear (~2.2 µs/raw-line); even 2M — the RESULTS/01 residual-risk size — is
+4.4 s, well under the cap. Memory is at baseline parity (the trie was never the lever).
+**Measurement note:** wall-time must be timed with `tracemalloc` **off** — instrumenting
+every allocation inflates the build ~3–4×. The committed spike (`spike_adr06_build.py`)
+and RESULTS/01 report the *instrumented* figure (5.3 s / 1M; 10.9 s / 2M); the
+un-instrumented production figures above are the real init cost and the ones this gate
+is decided on. ¹Spike peak RAM is higher because it materialises the full line list;
+the production build streams feeds lazily (`_dnsbl_file_line_reader`), so its peak is
+the dict floor.
+
 ### Reject criteria (decide cheaply, Phase 1, before the move)
 
-- **Init/memory blows the budget:** if building from raw inside Unbound exceeds the agreed reload-time/peak-RAM threshold on a large corpus and cannot be brought under it (streaming/iterative build) → do **not** ship a slow reload; fall back to the Moderate/Conservative boundary (keep dedup/classify in shell/PHP) or keep it as-is. Recorded in the ADR.
-- **Behaviour cannot be matched:** if the Python build cannot reproduce the current pipeline's decisions/attribution for some format → STOP and reconcile before deleting any shell/PHP.
+- **Init/memory blows the budget:** if building from raw inside Unbound exceeds the agreed reload-time/peak-RAM threshold on a large corpus and cannot be brought under it (streaming/iterative build) → do **not** ship a slow reload; fall back to the Moderate/Conservative boundary (keep dedup/classify in shell/PHP) or keep it as-is. Recorded in the ADR. **Outcome (Phase 6): NOT triggered** — the production build is 2.28 s / 1M (4.39 s / 2M), well under the 8 s cap, and 281.5 B/entry, well under the 410 B/entry ceiling. The streaming reader already gives the dict-floor peak RAM, so no boundary pivot is needed. (If a *future* deployment's raw line count is so large that the linear build pushes reload time past the maintainer's tolerance, the documented fallback remains: move dedup/classify back to shell/PHP, or stage the build off-thread per the reentrant seam.)
+- **Behaviour cannot be matched:** if the Python build cannot reproduce the current pipeline's decisions/attribution for some format → STOP and reconcile before deleting any shell/PHP. **Outcome (Phase 6): NOT triggered** — decisions are pinned identical across hosts/plain/basic-ABP/csv:pon (see Build evidence). Two *intended* behaviour changes are accepted by design (not regressions): cross-feed-duplicate attribution is now **last-wins** (was first-feed), and the TOP1M whitelist is a single **global** query-time `whiteDB` toggle (the old per-list `filter_alexa` build-time prune cannot be expressed query-time, so with TOP1M enabled popular domains are un-blocked across *all* lists). Both are called out in the smoke checklist below.
 
 ### Manual smoke (owner: maintainer) — required before Accept
 
-- [ ] Block decisions unchanged for a known feed set (exact, wildcard/zone, HSTS, noAAAA).
-- [ ] A domain whitelisted via the **settings textarea** resolves normally; ditto one added via the **alerts "add to whitelist" button**.
-- [ ] Alerts/stats/widget render correctly (Python-emitted `pfb_py_count`; counts may be higher than before — expected, lists un-pruned).
-- [ ] TLD blacklist (whole-TLD block) and TLD exclusion behave as before. With TOP1M **enabled**, a popular domain present in a feed resolves (un-blocked via `whiteDB`); with it **disabled**, it blocks.
-- [ ] A DNSBL feed containing IPs still populates the `DNSBLIP_v4` pf alias (with the configured action) and the firewall rule references it.
-- [ ] A reload picks up feed + whitelist changes correctly.
+> **Gate: Status flips to Accepted ONLY after every box below passes on a live
+> pfSense CE box.** CI cannot reach Unbound's Python loader or pf, so these are the
+> checks no automated test covers. Run after a full DNSBL update (so the manifest
+> `/var/unbound/pfb_py_sources.json` + `/var/unbound/pfb_py_raw/` and `pfb_py_count`
+> are freshly written) and a resolver reload.
+
+- [ ] **Block decisions unchanged** for a known feed set: an exact (data) block, a
+  wildcard/zone block *and a sub-domain of it*, an HSTS entry, and a noAAAA entry all
+  behave as before. A non-listed domain resolves.
+- [ ] **Whitelist — both entry points.** A domain whitelisted via the **settings
+  textarea** resolves normally; so does one added via the **alerts "add to whitelist"
+  button** (after the reload it triggers). Confirm a **wildcard** whitelist
+  (leading-dot) un-blocks sub-domains too. The domain now stays *in* the list and
+  shows as a whitelist hit (not absent) — expected.
+- [ ] **Counts/UI.** Alerts, stats widget, and per-alias counts render. `pfb_py_count`
+  (`/var/unbound/pfb_py_count`) is the **loaded-entry total** and may be **higher**
+  than the old value — expected (lists are no longer dedup/collapse/whitelist/TOP1M
+  pruned). No "OUT OF SYNC" log line; the update log shows `[ feed lines: N | loaded
+  entries: M ]`.
+- [ ] **TLD blacklist** (whole-TLD block) and **TLD exclusion** (forced exact) behave
+  as before. With **TOP1M enabled**, a popular domain present in a feed resolves
+  (un-blocked via `whiteDB`); with it **disabled**, the same domain blocks. **Note the
+  accepted change:** TOP1M is now **global** — when enabled it un-blocks popular
+  domains across *all* lists, not only the lists that had per-list `filter_alexa`.
+- [ ] **DNSBL-IP firewall feature.** A DNSBL feed containing embedded IPs still
+  populates the `DNSBLIP_v4` pf alias (with the configured action) and the firewall
+  rule references it. The IP set is unchanged and no IP leaks into DNS blocking.
+- [ ] **Reload** picks up both feed changes and whitelist changes correctly.
+- [ ] **Retained CSV consumers (RESULTS/05 §5).** The alerts-page features that still
+  read `pfb_py_data`/`pfb_py_zone` work: "add domain to group", "add to whitelist",
+  and unlock/detail. (These PHP-produced CSVs are intentionally kept this ADR;
+  migrating them onto the manifest/sqlite is a future follow-up.)
+- [ ] **Cross-feed duplicate attribution** is now **last-wins** (a domain in several
+  feeds is attributed to the last feed loaded, was first). Spot-check that a known
+  duplicated domain's reported feed/group is sane — its per-feed count shifting is
+  expected, not a regression.

--- a/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/01_Results.txt
@@ -1,0 +1,355 @@
+================================================================================
+ADR-06 — PHASE 1 RESULTS / HANDOFF FOR PHASE 2
+Inventory the DNSBL contract + spike & kill-gate (init-time / peak memory)
+Branch: adr/06   Commit: dev: ADR-06 P1 — inventory DNSBL contract + spike Python build init cost
+================================================================================
+
+VERDICT (headline): GO at the ADR's >=1M-entry target, with a documented
+time-scaling caveat above ~1.5M. Peak RAM is a NON-issue at every size (dead-on
+the ADR-05 274 B/entry baseline). The only risk axis is build wall-time, which is
+linear in raw-line count.
+
+--------------------------------------------------------------------------------
+0. WHAT WAS DONE / SCOPE
+--------------------------------------------------------------------------------
+* Inventory written below (the contract Phases 2-5 must preserve), with file:line
+  refs for every required path.
+* Standalone spike added under benchmarks/ (NOT wired into init, NOT production):
+    - benchmarks/_corpus_raw.py        un-pruned raw-feed corpus generator
+    - benchmarks/spike_adr06_build.py  pure-Python parse->normalise->classify->
+                                       build + measurement harness + GO/NO-GO gate
+* NO production file touched: pfblockerng.inc / pfblockerng.sh / pfb_unbound.py /
+  www/ UI all unchanged. tld_analysis, the shell finalize, the load path — all
+  untouched. Nothing deleted. Default `python -m pytest` = 184 passed (unchanged).
+  `ruff check .` clean, `ruff format` clean.
+
+Run the spike (dev box, pympler is a dev-only tool used for ADR-05 §3a parity):
+    python -m pip install pympler
+    SPIKE_N=5 SPIKE_SIZES=1000000 python benchmarks/spike_adr06_build.py
+
+================================================================================
+1. CURRENT PIPELINE — THE CONTRACT TO PRESERVE  (verified on `next`, post-ADR-02)
+================================================================================
+
+DATA FLOW (download -> tag -> assemble -> classify -> finalize -> load):
+
+  PHP download/parse loop (pfblockerng.inc:7600-8248)
+    -> per-feed `{header}.bk` then `{header}.txt`        [6-col CSV, per-line tag]
+    -> dnsbl_scrub (shell, pfblockerng.sh:357-461)       [DEDUP+WHITELIST+TOP1M]
+    -> assemble master `{dnsbl_file}.raw`  (inc:8221-8240)
+    -> tld_analysis (inc:2607-2925)                      [CLASSIFY data/zone]
+         -> writes pfb_py_data.raw / pfb_py_zone.raw + dnsbl_tld_remove
+         -> exec domaintldpy (shell, pfblockerng.sh:468-524) [sort -u + COLLAPSE]
+              -> final pfb_py_data / pfb_py_zone + writes pfb_py_count
+    -> pfb_unbound.py init (:535-639) loads CSVs into dataDB/zoneDB/whiteDB/...
+
+NOTE — TLD-mode branch only: tld_analysis + domaintldpy run ONLY when
+$pfb['dnsbl_tld'] is set. When TLD is NOT enabled, the assembled master raw is
+RENAMED DIRECTLY to pfb_py_data (inc:8244-8248) with NO data/zone split, NO
+collapse, and pfb_py_count is unlinked (inc:8247). So in non-TLD mode there is
+effectively no zone file and no count. ADR-06's Python classify must produce the
+data/zone split unconditionally (it replaces tld_analysis), which is fine — it is
+a superset of today's non-TLD behaviour and matches TLD-mode decisions.
+
+--- 1a. MASTER RAW LINE SHAPE -------------------------------------------------
+Per-feed line written at inc:8015-8018:
+    ,<domain>,,<logging_type>,<header>,<alias>\n      (6-col CSV, EMPTY col0/col2)
+    col0 = ''                  (empty)
+    col1 = domain (lower-cased) <- the KEY
+    col2 = ''                  (empty)
+    col3 = logging_type        <- the LOG FLAG ("0"/"1"/"2")
+    col4 = <header>            <- FEED  (the list/header name)
+    col5 = <alias>             <- GROUP (the DNSBL alias the feed belongs to)
+These per-feed files concatenate verbatim into `{dnsbl_file}.raw` (inc:8228-8237).
+tld_analysis re-reads that raw with explode(',', line, 3): eparts[1]=domain,
+eparts[2]="<log>,<feed>,<group>\n" (it keeps cols 3-5 as an opaque d_info tail,
+inc:2822-2827) and re-emits ,<key>,<d_info> into pfb_py_data.raw/pfb_py_zone.raw.
+=> The data/zone CSVs are ALSO 6-col with the SAME column meaning; the loader
+reads them as such (see 1f).
+
+--- 1b. FEED / GROUP / LOG ATTACHMENT -----------------------------------------
+* feed  = $header  (inc:8017 col4) — the individual list header name.
+* group = $alias   (inc:8017 col5) — the DNSBL alias grouping the feed.
+* log   = $logging_type (inc:8017 col3) — "0"/"1" log, "2" = block-but-skip-log
+          (pfb_unbound.py:1134 `if isDNSBL["log"] == "2": return True`).
+Attachment is PER LINE, written at parse time. TLD-blacklist entries get a
+synthetic tag ",<tld>,,1,DNSBL_TLD,DNSBL_TLD" (inc:2740).
+
+--- 1c. DATA vs ZONE CLASSIFICATION (tld_analysis, inc:2805-2877) -------------
+Rule (the decision that MUST be preserved):
+* Load the public-suffix MASTER list `{dnsbl_tld_data}` into $tlds[tld][suffix]
+  (inc:2630-2642). This is the registrable-suffix oracle.
+* For each domain split into labels (dcnt = label count):
+    - dcnt > 5            : no TLD search -> treated as data (transparent zone)
+    - dcnt 2..5          : tld_search() finds the registrable parent ($dfound)
+                           against $tlds (inc:2836-2851).
+    - dcnt == 2          : registrable parent = the 2 labels themselves -> ZONE.
+* If $dfound (a registrable parent found) -> ZONE: write ",<dfound>,<d_info>" to
+  pfb_py_zone.raw (wildcard-incl-self) AND ".<dfound>,," to dnsbl_tld_remove
+  (inc:2860-2868).  Else -> DATA: write ",<domain>,<d_info>" to pfb_py_data.raw
+  (inc:2871-2874).
+* TLD EXCLUSION (dnsblconfig['tldexclusion'], inc:2778-2795): if the WHOLE domain
+  is in the exclusion set, force $dfound='' -> DATA (transparent), i.e. exact-only,
+  not wildcarded (inc:2854-2857).  Excluded TLDs are also removed from $tlds.
+* TLD BLACKLIST (dnsblconfig['tldblacklist'], inc:2666-2773): whole-TLD block —
+  emits a ZONE entry ",<tld>,,1,DNSBL_TLD,DNSBL_TLD" so the entire TLD is wildcard-
+  blocked, and removes that TLD from $tlds.
+* domain_max_cnt cap (inc:2814/2832/2892): beyond the cap, domains are emitted
+  "as-is" (data) with no TLD search — a memory guard. ADR-06 drops this guard
+  (no per-domain redirect-zone limit in Python); behaviourally a superset.
+=> CONTRACT: registrable-parent -> wildcard ZONE; deeper sub-domain -> exact DATA;
+   TLD exclusion -> exact DATA; TLD blacklist -> whole-TLD ZONE. The public-suffix
+   master `{dnsbl_tld_data}` becomes a PYTHON build INPUT (Phase 3).
+
+--- 1d. SHELL DEDUP / FILTER / COUNT (the work ADR-06 DROPS) -------------------
+dnsbl_scrub (pfblockerng.sh:357-461), per feed, dup_mode='python':
+    :363  sort -u  (within-list dedup)
+    :379  awk -F',' '!($2 in a)'  (CROSS-list dedup vs master of other feeds —
+          a domain in several feeds kept ONCE, attributed to the FIRST feed seen)
+    :394  /usr/local/bin/ggrep -vF -f pfbdnsblsuppression  (USER-WHITELIST removal,
+          strips whitelisted domains AND subdomains)
+    :425  /usr/local/bin/ggrep -vF -f pfbalexa  (TOP1M removal; only when
+          dnsbl_alexa + list filter_alexa on)
+domaintldpy (pfblockerng.sh:468-524):
+    :471/:478  sort -u data.raw / zone.raw  (dedup again)
+    :499/:508  ggrep -vF -f dnsbl_tld_remove  (SUBDOMAIN COLLAPSE — drop data
+          entries already covered by a parent zone)
+    :523  echo "${counttr}" > dnsbl_python_count  (pfb_py_count, see 1e)
+ALL of dnsbl_scrub + domaintldpy's collapse are BUILD-TIME OPTIMISATIONS ADR-06
+deletes (the dict load dedups keys for free; redundant subdomains stay because the
+parent zone still matches them). The data/zone CLASSIFICATION (1c) is NOT an
+optimisation and is KEPT (moves to Python).
+
+--- 1e. THE COUNTS PATH (pfb_py_count) — SUBTLE -------------------------------
+* pfb_py_count file = /var/unbound/pfb_py_count (inc:113, sh:85).
+* WRITTEN by domaintldpy (sh:523) as `counttr` = number of entries REMOVED by the
+  subdomain-collapse (Original - Final), NOT the loaded blocklist size.
+* READ at inc:3149: `$tld_cnt = @file_get_contents(unbound_py_count)`, then
+  inc:3150 `$dnsbl_cnt = $dnsbl_cnt - $tld_cnt` and inc:3151-3156 a SYNC-CHECK:
+  (sum of *.txt lines) - removed == (data+zone final lines) ? "PASSED" : "OUT OF
+  SYNC". It is a verification/log line, not the number shown to the user.
+* CONTRACT for ADR-06: Python must EMIT pfb_py_count after the build in the same
+  file/format the UI reads. Because ADR-06 drops collapse, "removed" -> 0 (or the
+  semantics change). RECOMMENDATION (Phase 4): redefine pfb_py_count to the LOADED
+  entry total (len(dataDB)+len(zoneDB)) and adjust the inc:3149-3156 sync-check to
+  compare against that (its value legitimately rises — lists un-pruned). Flag this
+  to the maintainer; the UI's primary blocklist count comes from the per-alias
+  stats (dnsbl_alias_update / dnsbl_save_stats, see 1g), NOT from pfb_py_count.
+
+--- 1f. PYTHON LOADER FORMAT (pfb_unbound.py:535-639) — the LOAD CONTRACT ------
+* zoneDB (load :539-569) and dataDB (load :572-602): 6-col CSV, len(row)==6:
+      key = row[1]; payload = {"log": row[3], "index": final_index}
+      feed=row[4], group=row[5] folded into an INDEX via:
+        feedGroupDB[row[4]+row[5]] -> feedGroup_index (temp, CLEARED at :605)
+        feedGroupIndexDB[index] = {"feed": row[4], "group": row[5]}   (:551/:584)
+      LAST-WINS on a duplicate key (dict assignment) — see attribution note below.
+* whiteDB (load :609-624): 2-col CSV `domain,wildcard`; wildcard "1"->True else
+      False; whiteDB[row[0]] = wildcard.  Applied at QUERY TIME (per-query in the
+      matcher), NOT as a build subtraction.
+* hstsDB (:631-639): 1-col, hstsDB[line]=0.
+* safeSearchDB (:519-533): 3-col domain,A,AAAA.
+* GP_Bypass_List (:507-517), noAAAADB (above :501).
+=> THE STRUCTURES Phases 3-5 MUST REPRODUCE IDENTICALLY (decision-level):
+     dataDB[domain]  = {"log": <flag>, "index": <int>}
+     zoneDB[domain]  = {"log": <flag>, "index": <int>}
+     feedGroupIndexDB[index] = {"feed": <str>, "group": <str>}
+     whiteDB[domain] = <bool wildcard>
+   The matcher resolves index->(feed,group) at resolve_feed_group (:1647) and
+   builds dnsblDB[q_name] payload (:2126) with feed/group/b_type/b_eval/p_type;
+   get_details_dnsbl (:1091-1161) logs those. operate() is UNCHANGED by ADR-06 ->
+   reporting stays correct IFF these loaded structures + log flags are identical.
+
+ATTRIBUTION CHANGE (documented & accepted by the ADR): today a cross-feed
+duplicate is attributed to the FIRST feed (shell awk :379 keeps first). After
+ADR-06 the dict load keeps LAST (dict assignment overwrites). Per-feed counts for
+duplicated domains therefore change. This is by design (§2 contract).
+
+--- 1g. WHAT THE REPORTING PAGE READS (alerts / widget / stats) ---------------
+ALL query-time artifacts, written by operate()/get_details_* (UNCHANGED here):
+* sqlite DBs (pfb_unbound.py): table `resolver` (row,totalqueries,queries; :901),
+  table `dnsblcache` (type,domain,groupname,final,feed; :911/:991), and a `dnsbl`
+  group-counter enqueue (:1120-1121). These carry feed/group resolved through
+  feedGroupIndexDB — so correct IFF the loaded index<->feed/group map is correct.
+* LOG FILES: /var/log/pfblockerng/dnsbl.log + unified.log (:1158-1159), csv with
+  q_name, p_type, b_type, group, b_eval, feed (all from the matched entry's
+  payload). dns_reply.log similarly for replies.
+* PER-ALIAS stats (PHP, the user-visible blocklist counts): dnsbl_alias_update()
+  + dnsbl_save_stats() (called inc:2911/2920, inc:8118/8151/8165/8173/8178) write
+  per-alias summary files the widget/alerts read. These are driven by $alias_cnt
+  (line counts of *.txt, inc:8107-8108) — INDEPENDENT of pfb_py_count and largely
+  unaffected by the Python move (the *.txt feed files still exist; their line
+  counts simply no longer reflect post-dedup/collapse sizes).
+* pfb_py_count: see 1e — only the sync-check log, not a displayed total.
+=> CONTRACT: reporting is preserved as long as (a) the loaded dataDB/zoneDB/
+   feedGroupIndexDB + log flags are decision-identical, and (b) Python emits a
+   valid pfb_py_count. operate() is not touched.
+
+--- 1h. THE "DNSBL IP" FIREWALL PATH (must stay, ENTIRELY IN PHP) --------------
+Feed-embedded IPs -> pf alias, distinct from the standalone IP-feed pipeline:
+* Trigger: $pfb['dnsbl_ip'] = dnsblconfig['action'] (UI: pfblockerng_dnsbl.php,
+  `dnsbl_ip` class) != 'Disabled'.
+* Detection (two sites in the parse loop):
+    - GENERIC bare-IP: inc:7962-7973 — after line cleaning, is_ipaddrv4($line) ->
+      sanitize_ipaddr -> validate_ipv4 -> $domain_data_ip[] ; the IP line is
+      `continue`-skipped from the domain output.
+    - STRUCTURED CSV 'pon' (Ponmocup): inc:7819-7835 — csvline[2] is the domain
+      (col read by PHP) AND is_ipaddrv4(csvline[0]) routes col0 to $domain_data_ip.
+      i.e. for some structured threat-feeds the IP/domain surface via SPECIFIC
+      COLUMNS, which PHP must read first (the split is still uniform: an entry that
+      is an IP -> firewall; else domain -> Python).
+* Sink: inc:8032-8041 -> per-header `{header}_v4.ip` (array_unique).
+* Aggregate: inc:8182-8209 -> all *_v4.ip globbed into {dbdir}/DNSBLIP_v4.txt ->
+  DNSBLIP_v4 pf alias with the configured action; rules reference it (per ADR §1.7,
+  rules at inc:8574/:9171). Disabled -> files removed (inc:8211-8215).
+* CONTRACT: this is a pf/firewall op the Unbound Python plugin CANNOT and MUST NOT
+  do. It stays in PHP. RECOMMENDATION (Phase 5): refactor the IP detection OUT of
+  the domain-parse loop into an INDEPENDENT lightweight pass over each downloaded
+  raw feed (is_ipaddrv4 after minimal cleaning + the known CSV-IP columns like
+  'pon' csvline[0]), route IPs to the existing *_v4.ip -> DNSBLIP_v4 machinery, and
+  STRIP bare-IP lines from what Python receives. Python would skip stray IPs anyway
+  (they fail domain validation — confirmed in the spike: 20k IP lines -> 20k
+  skipped, 0 leaked into dicts).
+
+--- 1i. ONE-RAW-FILE <-> ONE-FEED/GROUP/LOG ASSUMPTION -------------------------
+CHECKED: FALSE at the file level, but the per-LINE tags already carry it.
+* Each per-feed `.bk`/`.txt` file is single-feed/single-group (feed=$header,
+  group=$alias for that list), BUT they are all CONCATENATED into ONE master
+  `{dnsbl_file}.raw` (inc:8228-8237), so the master raw is MULTI-feed.
+* The feed/group/log are encoded PER LINE (cols 3-5, see 1a), not per file.
+=> CONSEQUENCE FOR THE MANIFEST (Phase 2/4): a manifest mapping ONE raw file ->
+   ONE {feed,group,format_hint,log_flag} IS viable IF the boundary hands Python
+   the PER-FEED raw files (the downloaded `{header}.orig` or the per-feed `.txt`),
+   one manifest row each. It is NOT viable against the single concatenated master
+   raw. RECOMMENDATION: the manifest enumerates PER-FEED raw files (one row per
+   feed), and Python concatenates/streams them in build order. This also preserves
+   the format_hint per feed (needed for the CSV threat-feeds). If a future feed
+   ever needs per-line tags within one file, fall back to keeping the 6-col tagged
+   lines — but per-feed-file + manifest is cleaner and matches today's per-feed
+   structure.
+
+================================================================================
+2. PROPOSED NEW SHELL -> PYTHON CONTRACT  (for Phase 2 to pin, Phase 4 to wire)
+================================================================================
+Boundary (Aggressive, per ADR §2): shell/PHP = download each feed + run the
+independent DNSBL-IP pass (strip IPs) + write a manifest; Python = parse ->
+normalise -> classify -> build dicts + feed/group index + emit counts.
+
+MANIFEST (e.g. /var/unbound/pfb_py_sources.json) — one entry PER FEED raw file:
+    {
+      "version": 1,
+      "config": {
+        "tld_master": "/path/to/dnsbl_tld_data",     # public-suffix oracle (classify)
+        "tld_blacklist": ["<tld>", ...],              # whole-TLD ZONE block
+        "tld_exclusion": ["<domain>", ...],           # force exact DATA
+        "whitelist_src": "/var/unbound/pfb_py_whitelist",  # user whitelist (query-time whiteDB)
+        "top1m": {"enabled": false, "path": "/.../pfbalexawhitelist.txt"},  # query-time whiteDB when on
+        "log_default": "1",
+        "safesearch": "...", "hsts": "..."            # unchanged file inputs
+      },
+      "feeds": [
+        { "raw": "/.../<header>.txt",   # the per-feed raw (IP-stripped) file
+          "feed": "<header>",           # was col4
+          "group": "<alias>",           # was col5
+          "format_hint": "hosts|plain|abp|csv:pon|csv:otx|...",  # parse dispatch
+          "log_flag": "0|1|2" },        # was col3
+        ...
+      ]
+    }
+Versioned + pinned by tests. format_hint replaces the in-loop CSV-type sniffing;
+log_flag/feed/group move from per-line CSV cols to per-feed manifest rows (valid
+because each raw file is single-feed — see 1i).
+
+PYTHON BUILD OUTPUT (decision-equivalent to the loader contract, 1f):
+    build(manifest) -> { dataDB, zoneDB, feedGroupIndexDB, whiteDB, counts }
+  with EXACT payload shapes from 1f. Reentrant (returns a fresh structure-set;
+  no global mutation until an atomic swap — zero-downtime-ready, swap not built).
+  Kind-tagged entries (block|allow|regex) shaped now but only `block` emitted.
+
+WHITELIST: user whitelist normalisation (pfb_unbound_python_whitelist, inc:2259 —
+www-strip, smallest-tld-segment, leading-dot->wildcard "1" else "0") MOVES into the
+Python build and loads whiteDB; TOP1M loads whiteDB ONLY when enabled. No build-
+time list pruning. Net "resolves" preserved; whitelisted entries stay in lists and
+are un-blocked at query time (appear in counts/logs as whitelist hits).
+
+================================================================================
+3. SPIKE RESULTS — MEASURED  (CPython 3.14, macOS/darwin; N runs per size)
+================================================================================
+Corpus = UN-PRUNED raw feed lines (hosts ~40% / plain ~40% / basic-ABP ~20%),
+~18% cross-feed duplicates kept, +2% bare-IP lines (firewall path, build skips
+them). NO dedup / collapse / whitelist / TOP1M removal applied (ADR-06 drops them).
+Payload shapes identical to the production loader (1f). Retained size via
+pympler.asizeof (same method as ADR-05 §3a baseline).
+
+  size (domain lines)  build wall-time (s)            peak RAM     loaded     retained
+                       min / median / max  (N)        (tracemalloc) entries   B/entry
+  ----------------------------------------------------------------------------------
+  1,000,000            5.27 / 5.36 / 5.42  (N=5)       193.8 MiB    746,224    274.9  (+0% vs 274)
+  2,000,000            10.66 / 10.88 / 10.95 (N=5)     388.4 MiB  1,493,123    276.0  (+1% vs 274)
+
+* MEMORY: dead-on the ADR-05 §3a 274 B/entry baseline at BOTH sizes (+0% / +1%).
+  The Python build is NOT materially worse than today on RAM. This fully de-risks
+  the memory axis — confirms the ADR's premise that the lever was never a trie.
+* TIME: linear, ~5.4 microseconds per raw line. 1M -> ~5.4s; 2M -> ~10.9s.
+
+FAIR COMPARISON (net added time): the work ADR-06 DELETES from the shell, measured
+on an equivalent 1M-line master raw on the SAME box:
+    sort -u (dedup)             ~2.1s   (domaintldpy runs sort -u 2-3x)
+    awk -F',' cross-list dedup  ~2.7s   (dnsbl_scrub :379)
+    ggrep -vF whitelist/TOP1M   seconds more — pathologically slow with BSD grep
+                                here (>2min, killed); GNU ggrep on pfSense faster,
+                                but still grows with pattern-file size.
+=> today already spends ~4.8s+ of OUT-OF-PROCESS passes per build that the move
+   REMOVES. So the Python build's ~5.4s at 1M is roughly a WASH (net added ~+0.6s),
+   not a fresh 5.4s tax. The relevant budget is ADDED reload time, not the build in
+   isolation.
+
+================================================================================
+4. KILL-THRESHOLD + GATE
+================================================================================
+Proposed threshold (TUNE WITH MAINTAINER):
+  * build wall-time <= ~8s absolute  (= "a few seconds" ADDED over the ~4.8s+ of
+    shell passes it replaces; net added must stay within a few seconds), AND
+  * retained footprint not materially worse than 274 B/entry baseline
+    (ceiling ~410 B/entry = ~1.5x headroom).
+
+GATE RESULT:
+  * 1M entries (the ADR's stated >=1M target): GO.
+      time 5.36s median (<=8s PASS; net +0.6s), mem 274.9 B/entry (PASS).
+  * 2M entries: time 10.9s EXCEEDS the 8s cap (mem still PASS at 276 B/entry).
+      Linear time means very large deployments (>~1.5M raw lines) push reload time
+      up. This is the one residual risk to flag.
+
+================================================================================
+5. VERDICT FOR PHASE 2:  GO (build the golden oracle)
+================================================================================
+GO to proceed to Phase 2 (decision-level golden oracle) and the build. Rationale:
+  * Memory is a non-issue at every size (baseline parity) — the highest-cited risk
+    in ADR §3 ("peak RAM in the resolver") is RETIRED by measurement.
+  * At the ADR's >=1M target, build time is within budget and roughly a wash vs the
+    shell passes it deletes.
+  * Time scales linearly; the mitigation if a deployment is very large is
+    STREAMING/ITERATIVE build (read+parse+insert line-by-line rather than
+    materialising the full line list — the spike already inserts as it parses, so
+    the structure cost is the floor; the win is avoiding holding raw text). That is
+    a Phase-3/4 implementation detail, not a blocker.
+
+CARRY-OVER NOTES / DECISIONS FOR LATER PHASES:
+  * BUILD-TIME (dropped) removals: dedup (dnsbl_scrub :363/:379), user-whitelist
+    removal (:394), TOP1M removal (:425), subdomain collapse (domaintldpy
+    :499/:508). QUERY-TIME (kept) = whiteDB (user whitelist + TOP1M-when-enabled).
+    CLASSIFICATION (kept, moved to Python) = tld_analysis data/zone split.
+  * pfb_py_count semantics MUST be redefined (1e) — it currently means "entries
+    removed by collapse"; with collapse gone, emit the LOADED total and fix the
+    inc:3149-3156 sync-check. Confirm exact UI expectation with the maintainer.
+  * The manifest is PER-FEED-FILE (1i), not against the concatenated master raw.
+  * DNSBL-IP pass (1h) stays in PHP, refactored to an independent pass; the 'pon'
+    CSV-IP column (csvline[0]) and generic bare-IP both route to *_v4.ip. Confirmed
+    in the spike that Python skips IP lines cleanly (0 leaked).
+  * TLD-mode-only branch (1c note): today data/zone split only happens in TLD mode;
+    Python does it unconditionally — a decision-equivalent superset.
+  * domain_max_cnt redirect-zone cap (1c) is dropped — accepted (un-pruned by
+    design); watch only if a deployment's reload time becomes the binding limit.
+
+GATES (this phase): python -m pytest = 184 passed (unchanged); ruff check . clean;
+ruff format clean. No production code touched; nothing deleted.
+================================================================================

--- a/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/02_Results.txt
@@ -1,0 +1,162 @@
+================================================================================
+ADR-06 — PHASE 2 RESULTS / HANDOFF FOR PHASE 3
+Golden oracle harness — pin CURRENT DNSBL block/resolve decisions before any move
+Branch: adr/06   Commit: test: ADR-06 P2 — golden oracle for current DNSBL preprocessing behaviour
+================================================================================
+
+VERDICT: GO. The decision-level golden oracle is committed and green (194 passed,
+10 new). Phase 3 may build the pure `pfb_dnsbl_build` module against it.
+
+This phase added TESTS + FIXTURES ONLY. No production file was touched
+(pfb_unbound.py load/match logic, tld_analysis, the shell, the UI — all unchanged).
+`python -m pytest` = 194 passed (was 184). `ruff check .` clean. `ruff format` clean.
+
+--------------------------------------------------------------------------------
+0. WHERE THE FIXTURES / ORACLE LIVE + HOW TO RUN
+--------------------------------------------------------------------------------
+Oracle module:
+    tests/test_adr06_golden_oracle.py
+Fixtures (human-readable, each documented in its header / JSON _doc keys):
+    tests/fixtures/adr06_golden/
+        manifest.json    — per-feed rows {raw, feed, group, format_hint, log_flag}
+                           (the shell->Python boundary; one row per raw feed file,
+                           Phase 1 §1i / §2 contract).
+        config.json      — TLD blacklist/exclusion, user whitelist, TOP1M list,
+                           HSTS list, noAAAA list, tld_seg. Every key has a _doc.
+        tld_master.txt   — public-suffix oracle for data/zone classify
+                           ({com, net, org, co.uk}).
+        feed_hosts.txt   — hosts format (0.0.0.0/127.0.0.1 + domain), bare IP.
+        feed_plain.txt   — plain-domain format, leading-dot line, bare IP.
+        feed_abp.txt     — basic-ABP (||domain^) + the IGNORED lines (@@/##/$/*//,regex).
+        feed_csv_pon.txt — structured CSV 'pon': domain in col2 + embedded IP in col0.
+        feed_extra.txt   — config-interaction domains (excluded.com, hstslisted.com).
+        feed_nolog.txt   — a log_flag '2' feed (block-but-skip-log).
+
+Run:
+    python -m pytest tests/test_adr06_golden_oracle.py -v     # just the oracle
+    python -m pytest                                          # full suite (194)
+
+--------------------------------------------------------------------------------
+1. WHAT THE ORACLE ASSERTS (DECISIONS, not list contents/counts)
+--------------------------------------------------------------------------------
+Per ADR §2 the contract is at the level of NET DNS DECISIONS — NOT identical
+dataDB/zoneDB contents, counts, or cross-feed attribution (those change by design).
+The oracle drives the PRODUCTION matcher decision functions and asserts outcomes:
+
+  * pfb_unbound.evaluate_domain(...)  -> reduced to a stable label by _decision_label:
+      "pass"        not on any list -> resolves (pass-through)
+      "whitelist"   on a list but un-blocked via whiteDB -> resolves
+      "hsts"        on a list but HSTS-bypassed -> resolves real
+      "block-null"  blocked + null-routed (log '1', not HSTS)
+      "block-nolog" blocked but log '2' (null_blocking stays True; skip-log)
+    Also asserts b_type ("DNSBL" = exact DATA, "TLD" = wildcard ZONE) and group
+    (e.g. DNSBL_TLD for the whole-TLD block).
+  * pfb_unbound.evaluate_noaaaa(...)  -> AAAA-block decision (exact + wildcard-parent).
+
+Representative QUERY SET (all required categories covered):
+  - exact-block (DATA):   deep.host.cleandata.com, deep.path.cleanmal.com,
+                          sub.abpzone.net, deep.node.cleanpon.com, excluded.com
+  - zone-subdomain:       anything.tracker.org, x.y.tracker.org, www.shop.co.uk
+  - registrable ZONE:     tracker.org, malware.com, evilads.net, ponmocup.com,
+                          abpblocked.com, ponip.net, popularcdn.com, shop.co.uk
+  - user-whitelisted:     phishing.net (exact), adblock.com + www.adblock.com
+                          (www-strip), host.wildwhite.org (wildcard, not blocked)
+  - TOP1M-when-enabled:   popularcdn.com — blocks when disabled, resolves
+                          (whitelist) when enabled (BOTH scenarios asserted)
+  - HSTS:                 hstslisted.com -> hsts
+  - noAAAA:               noaaaa.com (exact), host.noaaaawild.net (wildcard) — TestGoldenNoAAAA
+  - pass-through:         totally-unrelated.com, good.net, cleandata.com, cleanmal.com,
+                          abpzone.net, deeper.deep.host.cleandata.com, and the IGNORED
+                          basic-ABP lines (abpallowed/abpoptions/abpwildcard/abppath .com)
+  - log '2' (skip-log):   silentblock.com -> block-nolog
+  - TLD blacklist:        anything.zip, another.sub.zip -> block, group DNSBL_TLD
+  - TLD exclusion:        excluded.com forced exact DATA; sub.excluded.com -> pass
+
+EXTRACTED-IP SET (the firewall handoff, part of the oracle):
+  GOLDEN_EXTRACTED_IPS = {198.51.100.23 (hosts bare-IP), 203.0.113.45 (plain bare-IP),
+                          198.51.100.77, 192.0.2.140 (csv:pon col0 IPs)}.
+  TestGoldenExtractedIPSet asserts the set AND that no IP leaked into dataDB/zoneDB.
+  Phase 5's independent DNSBL-IP pass must reproduce this exact set.
+
+HOW "CURRENT BEHAVIOUR" IS MODELLED (no live PHP/Unbound in CI):
+  tests/test_adr06_golden_oracle.py contains a pure-Python ReferencePipeline that
+  faithfully re-implements the inventoried current preprocessing (Phase 1), with
+  pfblockerng.inc:line anchors in the method docstrings: per-format parse, embedded-IP
+  extraction, domain validation, data/zone classify via tld_search, user-whitelist
+  normalisation, TOP1M->whiteDB-when-enabled. It loads the matcher's runtime
+  structures (dataDB/zoneDB/feedGroupIndexDB/whiteDB) and the oracle evaluates the
+  production decision fns over them. Phase 3's NEW build must yield the SAME decisions
+  over these fixtures even though the loaded lists differ (un-pruned).
+
+--------------------------------------------------------------------------------
+2. EXACT EXPECTED-OUTPUT SHAPES (Phase 3 build targets these)
+--------------------------------------------------------------------------------
+The build(manifest, config) must return structures decision-equivalent to (loader
+contract, Phase 1 §1f):
+    dataDB[domain]          = {"log": <"0"|"1"|"2">, "index": <int>}    # exact match
+    zoneDB[registrable]     = {"log": <flag>,        "index": <int>}    # wildcard
+    feedGroupIndexDB[index] = {"feed": <str>, "group": <str>}
+    whiteDB[domain]         = <bool wildcard>   # True if leading-dot/'1', else False
+    extracted_ips           = set[str]          # firewall handoff (NOT in the dicts)
+Plus counts (Phase 4 emits pfb_py_count; value legitimately rises — un-pruned).
+
+Decision-relevant rules the build MUST honour (verified against the live matcher
+in this phase):
+  * data/zone classify mirrors tld_analysis/tld_search exactly:
+      - 2-label domain -> its own registrable parent -> ZONE.
+      - co.uk-style multi-label public suffix (in tld_master) -> ZONE on the
+        registrable parent (e.g. shop.co.uk).
+      - deeper sub-domain whose registrable parent is NOT a known public suffix
+        -> exact DATA (only that exact name blocks).
+      - TLD exclusion forces a would-be-ZONE domain to exact DATA.
+      - TLD blacklist -> synthetic ZONE entry per TLD, feed/group = DNSBL_TLD.
+  * last-wins on a duplicate key (dict assignment) — the documented cross-feed
+    attribution change (tracker.org is in hosts+plain -> attributed to the LAST,
+    PlainFeed/Malware). Asserted in TestReferencePipelineSanity.
+  * whiteDB normalisation: www-strip; leading-dot -> wildcard True else False;
+    TOP1M loaded into whiteDB ONLY when enabled.
+
+--------------------------------------------------------------------------------
+3. FORMAT EDGE CASES THE FIXTURES ENCODE (Phase 3 parser must match)
+--------------------------------------------------------------------------------
+  * basic-ABP token-strip (pfblockerng.inc:7706-7717): keep ONLY a plain
+    "||domain^"; strip ||,^. IGNORE @@ exceptions, ## element rules, $options,
+    '*', '/', and standalone regex lines. (abpallowed/abpoptions/abpwildcard/
+    abppath all -> pass; abpblocked.com, sub.abpzone.net -> block.) THIS IS THE
+    CURRENT, NON-CONFORMANT behaviour — Phase 3 reproduces it; the future ABP ADR
+    changes it.
+  * hosts format: "<sinkhole-IP> <domain>" -> take the domain token; "0.0.0.0"
+    and "127.0.0.1" prefixes both handled.
+  * www-strip in the WHITELIST normalisation (not the feed parse): whitelist entry
+    'www.adblock.com' un-blocks 'adblock.com' AND 'www.adblock.com'.
+  * wildcard whitelist: a leading-dot entry ('.wildwhite.org') -> whiteDB wildcard
+    True (un-blocks subdomains).
+  * leading-dot feed line ('.wildcardish.org' in feed_plain) -> PHP trims the dot;
+    becomes a plain domain.
+  * embedded IPs: generic bare-IP lines (hosts/plain) -> firewall, line stripped
+    from the domain build; csv:pon col0-IP -> firewall AND col2 domain STILL kept
+    (the loop does NOT continue after the col0-IP extraction). Both pinned.
+  * TLD removals: tld_master has the blacklisted/excluded TLDs removed before
+    classify (mirrors inc:2749-2751 / 2791-2793).
+
+--------------------------------------------------------------------------------
+4. GO-AHEAD FOR PHASE 3
+--------------------------------------------------------------------------------
+GO — build the pure, stdlib-only, Unbound-symbol-free `pfb_dnsbl_build` module
+(parse / normalise / classify / build, reentrant, kind-tagged block|allow|regex but
+emit only `block`). Unit-test each function AND assert it reproduces the Phase-2
+golden DECISIONS over tests/fixtures/adr06_golden/ (re-run evaluate_domain over the
+build's dicts; the labels in GOLDEN_TOP1M_DISABLED / _ENABLED_OVERRIDES /
+GOLDEN_EXTRACTED_IPS must stay identical). The ReferencePipeline in the oracle module
+is a ready reference for the exact current semantics to match.
+
+Carry-over reminders (from Phase 1, still binding):
+  * No dedup / subdomain collapse / build-time whitelist / TOP1M removal.
+  * pfb_py_count to be redefined to the LOADED total in Phase 4 (collapse gone);
+    fix the inc:3149-3156 sync-check then.
+  * DNSBL-IP firewall pass stays in PHP (Phase 5), refactored independent; Python
+    skips stray IPs (the oracle's extracted-IP set is what PHP must produce).
+
+GATES (this phase): python -m pytest = 194 passed; ruff check . clean; ruff format
+clean. Tests/fixtures only — zero production code touched.
+================================================================================

--- a/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/03_Results.txt
@@ -1,0 +1,199 @@
+================================================================================
+ADR-06 — PHASE 3 RESULTS / HANDOFF FOR PHASE 4
+Pure pfb_unbound DNSBL build layer (parse -> normalise -> classify -> build)
+Branch: adr/06   Commit: pfb_unbound: ADR-06 P3 — pure DNSBL build layer (parse/dedup/classify/build)
+================================================================================
+
+VERDICT: GO. The pure, stdlib-only, Unbound-symbol-free build layer is committed and
+green (234 passed, +40 new). It reproduces the Phase-2 golden DECISIONS over the
+fixtures (both TOP1M scenarios + noAAAA + no-IP-leak). Phase 4 may now wire init().
+
+This phase is ADDITIVE. The build layer is NOT called by init() yet; tld_analysis,
+the shell finalize and the UI are untouched; nothing was deleted (the only removed
+production line is the `from collections.abc import ...` import, extended to add
+`Iterable`). `python -m pytest` = 234 passed (was 194). `ruff check .` clean.
+`ruff format` clean. No PHP/shell touched (no php -l / ShellCheck needed).
+
+--------------------------------------------------------------------------------
+0. WHAT / WHERE
+--------------------------------------------------------------------------------
+Build layer (NEW section in the plugin, between inform_super() and
+iter_domain_suffixes()):
+    src/usr/local/pkg/pfblockerng/pfb_unbound.py   (~lines 1607-1907)
+Unit tests (drive every fn + build() end-to-end vs the Phase-2 oracle):
+    tests/test_adr06_build_module.py   (40 tests)
+The tests REUSE the Phase-2 oracle's fixtures, golden tables and decision driver
+(import from tests/test_adr06_golden_oracle.py) so the two layers cannot diverge:
+    GOLDEN_TOP1M_DISABLED, GOLDEN_TOP1M_ENABLED_OVERRIDES, GOLDEN_EXTRACTED_IPS,
+    _build_cfg, _decision_label, _load_json, _read_lines.
+Fixtures unchanged: tests/fixtures/adr06_golden/ (manifest.json, config.json,
+tld_master.txt, feed_*.txt).
+
+Run:
+    python -m pytest tests/test_adr06_build_module.py -v   # just the build layer
+    python -m pytest                                       # full suite (234)
+
+--------------------------------------------------------------------------------
+1. PUBLIC API (function names / signatures) — what Phase 4 calls
+--------------------------------------------------------------------------------
+All in pfb_unbound.py, pure, stdlib-only (csv), NO Unbound symbol referenced.
+
+  parse(format_hint: str, line: str) -> ParsedEntry | None
+      Per-format dispatch (format_hint = "hosts" | "plain" | "abp" | "csv:pon";
+      hosts/plain share a handler). Reproduces today's parse incl. which lines are
+      IGNORED. Returns a kind-tagged ParsedEntry or None to skip. Bare-IP lines and
+      the csv:pon col-0 IP are NOT returned (IP extraction is PHP/firewall, Phase 5).
+      kind is ALWAYS DNSBL_KIND_BLOCK this phase.
+
+  normalise(value: str) -> str | None
+      Lower-case + PFB_FILTER_DOMAIN domain-shape gate (inc:7995-8016). Returns the
+      validated lower-cased domain or None. NOTE: an all-numeric dotted string passes
+      normalise() (digits are valid label chars — mirrors the Phase-2
+      ReferencePipeline._validate_domain); the bare-IP guard lives in parse() via
+      _dnsbl_is_ipv4, exactly as the current pipeline (is_ipaddrv4 before validation).
+
+  classify(domain: str, tlds: dict[str, dict[str, str]], exclusion: set[str])
+            -> tuple[str, str]
+      Returns (DNSBL_CLASS_ZONE, registrable-parent) or (DNSBL_CLASS_DATA, domain).
+      Mirrors tld_analysis/tld_search (inc:2832-2874): registrable parent -> wildcard
+      ZONE; deeper sub-domain whose parent is not a known public suffix -> exact DATA;
+      whole-domain TLD exclusion -> forced exact DATA. dcnt>5 -> DATA (no TLD search).
+
+  build(manifest: dict[str, Any],
+        config: dict[str, Any],
+        *,
+        line_reader: Callable[[str], Iterable[str]],
+        top1m_enabled: bool = False) -> BuildResult
+      The pure, reentrant end-to-end build (see SS2 for I/O). line_reader is INJECTED
+      (maps a feed_row["raw"] reference -> its raw lines) so the build stays pure and
+      filesystem-decoupled; the test passes _read_lines (fixture reader). Phase 4
+      supplies a file-backed reader (e.g. lambda path: open(path)...).
+
+Module-level helpers (used by the tests; available to Phase 4 if useful):
+  _dnsbl_load_tld_master(suffix_lines, tld_blacklist, tld_exclusion)
+        -> tlds[tld][full-suffix] public-suffix oracle, minus blacklisted/excluded.
+  _dnsbl_normalise_whitelist(user_whitelist, top1m_list, top1m_enabled)
+        -> whiteDB dict (www-strip; leading-dot -> wildcard True else False;
+           TOP1M loaded ONLY when enabled). build() calls this internally.
+  _dnsbl_is_ipv4, _dnsbl_parse_abp_line, _dnsbl_strip_hosts_prefix, _dnsbl_tld_search.
+
+Constants / dataclasses (the ABP-ready seam + entry model):
+  DNSBL_KIND_BLOCK="block", DNSBL_KIND_ALLOW="allow", DNSBL_KIND_REGEX="regex"
+  DNSBL_CLASS_DATA="data", DNSBL_CLASS_ZONE="zone"
+  @dataclass ParsedEntry(kind, value, feed, group, log)   # parse() output
+  @dataclass DnsblEntry(kind, cls, key, feed, group, log)  # shaped for ABP; not yet
+        emitted as a stream — build() inlines normalise+classify+assign. Available if
+        Phase 4/ABP wants an explicit entry stream.
+  @dataclass BuildResult(...)  # see SS2.
+
+--------------------------------------------------------------------------------
+2. build() I/O — the structure-set it RETURNS (Phase 4 loads these)
+--------------------------------------------------------------------------------
+INPUTS:
+  manifest = {"version": 1, "feeds": [ {raw, feed, group, format_hint, log_flag}, ...]}
+      (the per-feed boundary, RESULTS/01 SS1i). One row per raw feed file. build()
+      iterates feeds in manifest order (same order today concatenates them).
+  config  = {
+      "tld_master":    list[str],   # public-suffix oracle LINES (not a path) —
+                                     # build() takes the lines directly (pure; the
+                                     # test expands the fixture file to lines).
+      "tld_blacklist": list[str],   # whole-TLD ZONE block (-> DNSBL_TLD entries)
+      "tld_exclusion": list[str],   # force exact DATA
+      "user_whitelist":list[str],   # query-time whiteDB (normalised here)
+      "top1m_list":    list[str],   # query-time whiteDB ONLY when top1m_enabled
+  }
+  line_reader: Callable[[str], Iterable[str]]   # feed_row["raw"] -> raw lines
+  top1m_enabled: bool
+
+RETURNS BuildResult (a @dataclass), all dicts FRESH (no module global touched):
+  .data_db[domain]          = {"log": <"0"|"1"|"2">, "index": <int>}   # exact match
+  .zone_db[registrable]     = {"log": <flag>,        "index": <int>}   # wildcard
+  .feed_group_index_db[idx] = {"feed": <str>, "group": <str>}
+  .white_db[domain]         = <bool wildcard>
+  .counts                   = len(data_db) + len(zone_db)   # the LOADED total
+
+These shapes are IDENTICAL to what pfb_unbound init() loads today (RESULTS/01 SS1f):
+init() builds zoneDB[row[1]]={"log":row[3],"index":...}, dataDB likewise,
+feedGroupIndexDB[idx]={"feed":row[4],"group":row[5]}, whiteDB[row[0]]=wildcard-bool.
+=> Phase 4 wiring = call build(), then assign the four dicts into the module globals
+   (dataDB/zoneDB/feedGroupIndexDB/whiteDB) and write .counts to pfb_py_count. The
+   matcher decision fns (evaluate_domain) consume them unchanged.
+
+--------------------------------------------------------------------------------
+3. WHERE COUNTS / FEED-GROUP COME FROM
+--------------------------------------------------------------------------------
+COUNTS: BuildResult.counts = len(data_db)+len(zone_db) — the LOADED entry total, the
+RESULTS/01 SS1e recommendation. It legitimately RISES vs today (no dedup/collapse/
+whitelist/TOP1M pruning). Phase 4 must:
+  * write .counts to pfb_py_count (/var/unbound/pfb_py_count) in the format the UI
+    reads (inc:3149), AND
+  * fix the inc:3149-3156 sync-check (it currently means "entries removed by
+    collapse"; with collapse gone, redefine it against the LOADED total — see
+    RESULTS/01 SS1e). Flag the exact UI expectation to the maintainer.
+
+FEED/GROUP: build() folds each feed_row's (feed, group) into an integer index via an
+internal feed_group_db (cleared implicitly — it is a local), populating
+feed_group_index_db[idx] = {"feed", "group"} — mirroring init() lines 546-553/579-586
+exactly. The TLD-blacklist synthetic entries use feed=group="DNSBL_TLD" (inc:2740).
+LAST-WINS on a duplicate domain key (dict assignment) — the documented cross-feed
+attribution change (ADR.md SS2; tested: tracker.org in hosts+plain -> PlainFeed/Malware).
+
+LOG FLAG: per-feed manifest log_flag carried into every entry's payload {"log": ...}
+("0"/"1" log, "2" = block-but-skip-log). Tested (silentblock.com -> log "2").
+
+--------------------------------------------------------------------------------
+4. HOW THE ABP SEAM IS LEFT OPEN (and what is NOT done)
+--------------------------------------------------------------------------------
+  * Entries are kind-tagged (DNSBL_KIND_BLOCK | _ALLOW | _REGEX). This phase produces
+    ONLY block. parse() always sets kind=BLOCK; build() has an explicit guard
+    `if entry.kind != DNSBL_KIND_BLOCK: continue` so allow/regex kinds, once a future
+    ABP parser emits them, are routed separately rather than silently blocked.
+  * @@ exceptions, ## / #@# element-hiding, $options, '*', '/', standalone regex are
+    IGNORED exactly as today (parse() returns None for them). Tested explicitly
+    (TestParse.test_abp_ignored_lines covers all 8 line types).
+  * The DnsblEntry dataclass (kind, cls, key, feed, group, log) is shaped for a future
+    explicit entry stream / allow+regex application, but build() currently inlines the
+    normalise+classify+assign path; ABP ADR can switch to emitting DnsblEntry objects.
+  * NO build-time dedup, NO subdomain collapse, NO build-time whitelist/TOP1M removal
+    were implemented — verified by tests (last-wins, whitelisted domains stay in lists,
+    deep subdomain stays in data_db). The dict load dedups keys for free.
+
+--------------------------------------------------------------------------------
+5. PURE / REENTRANT — CONFIRMED
+--------------------------------------------------------------------------------
+build() returns a NEW structure-set and mutates no module global. Verified by tests
+(TestBuildPurity):
+  * test_two_calls_yield_equal_structures   — two calls -> equal data/zone/white/index/counts.
+  * test_returns_fresh_structures_not_aliased — the dicts are distinct objects each call.
+  * test_does_not_mutate_module_globals      — dataDB/zoneDB/whiteDB/feedGroupIndexDB
+    unchanged after a build, and the returned dicts are NOT the module globals.
+Also smoke-checked standalone (outside pytest) that the build layer imports and runs
+with no init()/operate() and no Unbound runtime. This is the seam a future
+zero-downtime reload swaps in (the swap itself is NOT built here).
+
+--------------------------------------------------------------------------------
+6. GO-AHEAD FOR PHASE 4 (wire init)
+--------------------------------------------------------------------------------
+GO. Wire pfb_unbound init() to consume the manifest + raw feeds via build():
+  * Read the manifest JSON + config; supply a file-backed line_reader over each
+    feed_row["raw"]; pass top1m_enabled from the dnsbl_alexa/filter_alexa config.
+  * Assign BuildResult.data_db/zone_db/feed_group_index_db/white_db into the module
+    globals dataDB/zoneDB/feedGroupIndexDB/whiteDB (replacing the current CSV load
+    path lines 535-628 for the DNSBL dicts — keep hsts/safesearch/noaaaa/gp loads).
+  * Write BuildResult.counts to pfb_py_count and fix the inc:3149-3156 sync-check.
+  * Python IGNORES stray IP lines (parse() skips them) and NEVER touches the
+    firewall/IP path (Phase 5 keeps that in PHP).
+  * Decision-equivalence is the gate: re-run the Phase-2 oracle (and these P3 tests)
+    against the wired init — same labels in GOLDEN_TOP1M_DISABLED/_ENABLED_OVERRIDES.
+
+Carry-over reminders (still binding):
+  * The manifest is PER-FEED-FILE (RESULTS/01 SS1i), not the concatenated master raw.
+  * pfb_py_count redefined to the LOADED total; fix the sync-check (RESULTS/01 SS1e).
+  * DNSBL-IP firewall pass stays in PHP (Phase 5); Python skips IPs (0 leak, tested).
+  * Streaming the line_reader (yield lines lazily) keeps peak RAM at the dict floor —
+    line_reader already returns an Iterable, so a generator-backed reader works.
+
+GATES (this phase): python -m pytest = 234 passed; ruff check . clean; ruff format
+clean. Build layer is additive, pure, Unbound-symbol-free; init NOT wired; no
+PHP/shell/UI touched; nothing deleted.
+================================================================================

--- a/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/04_Results.txt
@@ -1,0 +1,224 @@
+================================================================================
+ADR-06 -- PHASE 4 RESULTS / HANDOFF FOR PHASE 5
+Wire init to BUILD DNSBL structures from raw + emit counts (new contract)
+Branch: adr/06   Commit: pfb_unbound: ADR-06 P4 -- build DNSBL structures from raw at load + emit counts
+================================================================================
+
+VERDICT: GO. init now BUILDS dataDB/zoneDB/whiteDB/feedGroupIndexDB from the raw
+feeds via the Phase-3 build() layer when the per-feed manifest is present, assigns
+them into the matcher globals, and EMITS pfb_py_count (the LOADED total). New tests
+prove the init-from-raw path is decision-equivalent to BOTH the Phase-2 golden
+oracle AND the Phase-2 ReferencePipeline (old-loader stand-in), for both TOP1M
+scenarios + noAAAA + no-IP-leak. Old shell/PHP producers are UNTOUCHED (Phase 5
+removes them). `python -m pytest` = 252 passed (was 234, +18). ruff check + ruff
+format clean. No Unbound symbol added (no stub change). No PHP/shell touched.
+
+--------------------------------------------------------------------------------
+0. WHAT / WHERE
+--------------------------------------------------------------------------------
+Production change (ONE file): src/usr/local/pkg/pfblockerng/pfb_unbound.py
+  * NEW path keys in init_standard() (after the pfb_py_* file defs, ~line 328):
+        pfb["pfb_py_sources"] = "pfb_py_sources.json"   # the per-feed manifest
+        pfb["pfb_py_count"]   = "pfb_py_count"           # Python-emitted entry total
+    (bare filenames; the plugin runs with cwd=/var/unbound, matching the existing
+     pfb_py_* keys and the PHP-side /var/unbound/pfb_py_count at inc:113.)
+  * NEW build-wiring helpers (after build(), ~lines 2061-2175), pure, stdlib-only,
+    NO Unbound symbol:
+        _dnsbl_file_line_reader(base_dir) -> Callable[[str], Iterable[str]]
+            File-backed, LAZY (generator) line_reader for build(); resolves a feed
+            raw ref (absolute or relative-to-manifest-dir) and yields newline-
+            stripped lines. A single missing/unreadable feed is LOGGED + SKIPPED
+            (not fatal) so the other feeds still load.
+        _dnsbl_config_from_manifest(manifest, base_dir) -> config blob
+            Shapes manifest["config"] into the build() config: reads tld_master
+            (a FILE PATH on-box, or a list of lines) into suffix lines; passes
+            tld_blacklist/tld_exclusion/user_whitelist/top1m_list through as lists.
+        dnsbl_build_from_manifest(manifest_path) -> BuildResult | None
+            THE init swap point. Reads the manifest JSON, builds a file-backed
+            reader, calls build(); returns None when the manifest is absent or
+            unparseable (init then falls back to the legacy CSV load). top1m_enabled
+            is read from manifest["config"]["top1m_enabled"].
+        dnsbl_emit_count(count_path, count) -> bool
+            Writes the LOADED total to pfb_py_count in the UI's format ("<n>\n").
+  * WIRED into init_standard() DNSBL load block (~lines 543-571): BEFORE the legacy
+    zone/data CSV load, call dnsbl_build_from_manifest(pfb["pfb_py_sources"]); on a
+    non-None result, ATOMICALLY assign result.data_db/zone_db/feed_group_index_db/
+    white_db into the module globals dataDB/zoneDB/feedGroupIndexDB/whiteDB, set the
+    pfb["dataDB"/"zoneDB"/"whiteDB"/"python_blacklist"] flags, emit pfb_py_count,
+    and set dnsbl_built=True. The legacy zone CSV, data CSV and user-whitelist CSV
+    loads are each now gated `if not dnsbl_built and os.path.isfile(...)` -- they are
+    the FALLBACK only. HSTS load is unchanged (not part of the build).
+  * `import json` added at the top.
+
+New tests: tests/test_adr06_init_from_raw.py (18 tests). REUSES the Phase-2 oracle's
+fixtures, golden tables, decision driver AND the ReferencePipeline (old-loader
+stand-in) so the new path is validated against the EXACT same contract:
+    from tests.test_adr06_golden_oracle import (FIXTURES, GOLDEN_EXTRACTED_IPS,
+        GOLDEN_TOP1M_DISABLED, GOLDEN_TOP1M_ENABLED_OVERRIDES, ReferencePipeline,
+        _build_cfg, _decision_label, _evaluate, _load_json, _read_lines)
+Fixtures unchanged: tests/fixtures/adr06_golden/.
+
+Run:
+    python -m pytest tests/test_adr06_init_from_raw.py -v   # just the init wiring
+    python -m pytest                                        # full suite (252)
+
+--------------------------------------------------------------------------------
+1. THE EXACT NEW FILES init NOW CONSUMES (manifest + raw)
+--------------------------------------------------------------------------------
+init reads ONE manifest JSON: /var/unbound/pfb_py_sources.json (pfb["pfb_py_sources"]).
+Its shape (RESULTS/01 SS2, validated by the tests):
+
+    {
+      "version": 1,
+      "config": {
+        "tld_master":     "/var/unbound/<public-suffix-master>",  # PATH (read here)
+        "tld_blacklist":  ["<tld>", ...],     # whole-TLD ZONE block -> DNSBL_TLD
+        "tld_exclusion":  ["<domain>", ...],  # force exact DATA
+        "user_whitelist": ["<entry>", ...],   # query-time whiteDB (normalised here)
+        "top1m_list":     ["<domain>", ...],  # query-time whiteDB ONLY when enabled
+        "top1m_enabled":  false                # drives the TOP1M whiteDB load
+      },
+      "feeds": [
+        { "raw": "/var/unbound/<header>.txt",  # per-feed raw (IP-STRIPPED) file
+          "feed": "<header>", "group": "<alias>",
+          "format_hint": "hosts|plain|abp|csv:pon",
+          "log_flag": "0|1|2" },
+        ...
+      ]
+    }
+
+  * feeds[].raw : per-feed raw file (absolute, or relative to the manifest dir).
+    Read LAZILY by the file-backed reader. IP lines are skipped by the parser; the
+    DNSBL-IP firewall pass (Phase 5) must STRIP bare-IP lines from these before
+    Python sees them (Python ignores stray IPs, 0 leak -- pinned).
+  * config.tld_master : PATH to the public-suffix oracle (Python reads the lines).
+    A list of lines is also accepted (used by the Phase-3 unit tests).
+  * top1m_enabled lives in config (NOT a separate flag); Phase 5 sets it from
+    dnsbl_alexa + per-list filter_alexa.
+
+WHAT init NOW WRITES:
+  /var/unbound/pfb_py_count (pfb["pfb_py_count"]) -- the Python-emitted LOADED entry
+  total (len(dataDB)+len(zoneDB)), format "<n>\n". This is the ONLY count/tally file
+  Python produces (see SS3). No IP file, no pf alias, no per-feed tally file.
+
+--------------------------------------------------------------------------------
+2. CONFIRMATION: OLD == NEW (decision-equivalent) -- the gate
+--------------------------------------------------------------------------------
+Pinned by tests/test_adr06_init_from_raw.py:
+  * TestInitFromRawDecisionsTop1mDisabled / _Top1mEnabled: the init-from-raw
+    structures reproduce EVERY Phase-2 golden decision (block-null / block-nolog /
+    whitelist / hsts / pass / zone-subdomain / b_type / group), BOTH TOP1M scenarios.
+  * TestInitFromRawEqualsOldLoader[False,True]: every query's FULL decision dict
+    (decision/b_type/feed/group/b_eval) from the NEW build == the OLD loader
+    (ReferencePipeline) -- decision-for-decision, both scenarios.
+  * TestInitGlobalAssignment: mimics the init glue (assign BuildResult into the
+    module globals dataDB/zoneDB/whiteDB/feedGroupIndexDB) and evaluates THROUGH the
+    globals exactly as operate() builds its containers (pfb_unbound.py:2660-2667) --
+    proving the wiring, AND that the query-time whiteDB application is unchanged
+    (adblock.com listed-but-whitelisted -> "whitelist").
+  * TestInitFromRawNoAAAA: noAAAA decisions unchanged. TestInitFromRawNoIpLeak: no
+    GOLDEN_EXTRACTED_IPS leak into data_db/zone_db. TestInitFromRawCounts:
+    pfb_py_count == loaded total and is written in the UI's format.
+Decisions -- NOT list contents/counts -- are the contract (ADR.md SS2): the built
+dicts differ from today's pruned lists BY DESIGN (no dedup/collapse/whitelist/TOP1M
+removal); pfb_py_count legitimately RISES. Every block/resolve outcome is identical.
+
+--------------------------------------------------------------------------------
+3. COUNTS / FEED-GROUP TALLIES -- what Python writes vs what the UI reads
+--------------------------------------------------------------------------------
+  * pfb_py_count: Python now emits the LOADED total (len(dataDB)+len(zoneDB)) via
+    dnsbl_emit_count(). REDEFINED from "entries removed by collapse" -> "loaded
+    total" (RESULTS/01 SS1e). Its value legitimately RISES (lists un-pruned).
+  * The inc:3149-3156 SYNC-CHECK is STILL the old semantics
+    ($dnsbl_cnt = $dnsbl_cnt - $tld_cnt; compares to data+zone line counts) and will
+    read "OUT OF SYNC" against the new pfb_py_count value. THIS IS LEFT FOR PHASE 5
+    to reconcile (it owns shell/PHP edits): redefine the check against the LOADED
+    total, or drop the subtraction. Flagged here; no PHP touched in Phase 4.
+  * PER-FEED/GROUP TALLIES: Python does NOT write a per-feed tally file -- it never
+    did. The build POPULATES feedGroupIndexDB (feed/group<->index), which init
+    assigns into the global; the per-blocked-domain feed/group ATTRIBUTION then
+    flows at QUERY TIME through resolve_feed_group() into the sqlite rows + log
+    lines (operate() UNCHANGED). The UI's per-alias visible counts come from PHP's
+    dnsbl_alias_update()/dnsbl_save_stats() driven by the *.txt feed line counts
+    (RESULTS/01 SS1g) -- INDEPENDENT of pfb_py_count and unaffected by this phase.
+    So "emit the per-feed/group tallies the UI needs" = build+assign feedGroupIndexDB
+    (done) + emit pfb_py_count (done); there is no extra tally artifact to write.
+
+--------------------------------------------------------------------------------
+4. WHITELIST PATH STATUS
+--------------------------------------------------------------------------------
+  * INPUT NORMALISATION now runs in the build (_dnsbl_normalise_whitelist, Phase 3):
+    www-strip; leading-dot -> wildcard True else False; TOP1M loaded into whiteDB
+    ONLY when top1m_enabled. build() returns white_db; init assigns it to the global.
+  * APPLICATION is QUERY-TIME and UNCHANGED: the matcher's evaluate_domain whiteDB
+    check was NOT touched (diff-read confirms zero changes to evaluate_domain / the
+    matcher). Verified by TestInitGlobalAssignment::test_whitelist_unblocks_through_
+    globals (listed-but-whitelisted resolves) over the module globals.
+  * The legacy pfb_py_whitelist.txt CSV load is now FALLBACK only (gated by
+    `not dnsbl_built`). When the manifest is present, whiteDB comes from the build.
+
+--------------------------------------------------------------------------------
+5. WHICH SHELL/PHP PRODUCERS ARE NOW REDUNDANT / SAFE TO REMOVE (Phase 5)
+--------------------------------------------------------------------------------
+With init preferring the raw build, these producers of the OLD files become
+redundant ONCE Phase 5 makes PHP/shell WRITE the manifest (pfb_py_sources.json) +
+per-feed IP-stripped raw feeds. They are STILL PRESENT now (deliberate live
+fallback/cross-check) and MUST NOT be deleted until the manifest is emitted:
+
+  REDUNDANT (DROP in Phase 5 -- the build subsumes/deletes them):
+    * pfblockerng.sh dnsbl_scrub (:357-461): within/cross-feed dedup, user-whitelist
+      removal, TOP1M removal -- ALL build-time optimisations ADR-06 drops.
+    * pfblockerng.sh domaintldpy (:468-524): sort -u dedup + subdomain COLLAPSE
+      (ggrep -vF -f dnsbl_tld_remove) + the counttr -> pfb_py_count write (:523).
+    * pfblockerng.inc tld_analysis (:2607-2925) COLLAPSE/remove-file machinery
+      (dnsbl_tld_remove emission); the data/zone CLASSIFICATION moves to Python
+      (build) -- so tld_analysis's classify is also now redundant for the Python
+      path. Keep ONLY what feeds the manifest (the public-suffix master becomes a
+      Python build input via config.tld_master).
+    * The PHP basic-ABP $e_replace token-strip pass (:7665-7900) -- subsumed by
+      parse(format_hint="abp", ...). Native-mode leftovers (:2672).
+    * The PHP master-raw assembly + rename-to-pfb_py_data path (:8221-8248) and the
+      pfb_py_data.txt / pfb_py_zone.txt / pfb_py_whitelist.txt producers -- replaced
+      by the manifest + per-feed raw. (Legacy load stays as the fallback; once PHP
+      writes the manifest, the CSV producers can go.)
+
+  KEEP (Phase 5 must preserve):
+    * The DNSBL-IP firewall pass -> *_v4.ip -> DNSBLIP_v4 pf alias (inc:7962-7973,
+      :7819-7835 csv:pon col0, :8032-8215). Refactor it to an INDEPENDENT pass that
+      detects IPs and STRIPS bare-IP lines from the per-feed raw BEFORE Python reads
+      them. Python never produces firewall input (0 IP leak pinned).
+      Phase-5 IP set to reproduce = GOLDEN_EXTRACTED_IPS
+        {198.51.100.23, 203.0.113.45, 198.51.100.77, 192.0.2.140}.
+    * The download mechanism, feed catalog, scheduling, per-feed *.txt files (the
+      UI's per-alias line counts read them -- SS3), HSTS/SafeSearch/noAAAA inputs.
+    * The pfb_py_count READ (inc:3149) -- but FIX the sync-check semantics (SS3).
+
+--------------------------------------------------------------------------------
+6. GO-AHEAD FOR PHASE 5 (slim shell/PHP) + carry-over
+--------------------------------------------------------------------------------
+GO. Phase 5 should:
+  1. Make PHP/shell WRITE /var/unbound/pfb_py_sources.json (the manifest in SS1) +
+     the per-feed IP-stripped raw feeds, with config.top1m_enabled driven by
+     dnsbl_alexa + filter_alexa, config.tld_master = the public-suffix master path.
+  2. Run the INDEPENDENT DNSBL-IP pass (detect IPs -> *_v4.ip -> DNSBLIP_v4; strip
+     bare-IP lines from the per-feed raw). Reproduce GOLDEN_EXTRACTED_IPS.
+  3. DELETE the redundant producers in SS5 (dnsbl_scrub, domaintldpy, tld_analysis
+     collapse/remove-file, PHP basic-ABP $e_replace, native-mode leftovers, the
+     pfb_py_data/zone/whitelist CSV producers).
+  4. FIX the inc:3149-3156 pfb_py_count sync-check to compare against the LOADED
+     total (or drop the subtraction) -- it currently means "removed by collapse".
+  5. Run php -l + ShellCheck; keep the Phase-2 oracle + Phase-4 init-from-raw tests
+     green (decision-equivalence is the gate).
+
+Carry-over reminders (still binding):
+  * The manifest is PER-FEED-FILE (RESULTS/01 SS1i), not the concatenated master raw.
+  * No dedup / collapse / build-time whitelist / TOP1M removal -- Python drops them.
+  * DNSBL-IP firewall pass stays in PHP; Python skips IPs (0 leak, pinned).
+  * Last-wins cross-feed attribution (dict) is by design (ADR.md SS2).
+  * The build call site (dnsbl_build_from_manifest) is the future zero-downtime swap
+    point; NO background-thread/restart-free behaviour was added (out of scope).
+
+GATES (this phase): python -m pytest = 252 passed (+18); ruff check clean; ruff
+format clean. No Unbound symbol added (no stub change). No PHP/shell/UI touched;
+nothing deleted. init prefers the raw build, falls back to the legacy CSV load.
+================================================================================

--- a/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/05_Results.txt
@@ -1,0 +1,271 @@
+================================================================================
+ADR-06 -- PHASE 5 RESULTS / HANDOFF FOR PHASE 6
+Slim shell/PHP to download+tag+manifest/raw; drop dead native + build-time passes
+Branch: adr/06   Commit: pfblockerng: ADR-06 P5 -- slim shell/PHP DNSBL preprocessing; drop dead native logic
+================================================================================
+
+VERDICT: GO for Phase 6 (final validation + DoD + manual smoke). PHP/shell now
+WRITE the per-feed manifest (/var/unbound/pfb_py_sources.json) + per-feed IP-
+stripped raw that Phase-4 init builds from; the dropped build-time optimisations
+(dnsbl_scrub, domaintldpy, tld_analysis collapse/remove-file) and the native-mode
+TLD-whitelist-resolve leftover are REMOVED; the DNSBL-IP firewall pass is KEPT
+entirely in PHP and Python never sees an IP. Gates: python -m pytest = 255 passed
+(+3 new boundary tests); ruff check + ruff format clean; php -l clean on both
+changed PHP files; sh -n + shellcheck clean on the changed shell. The PHP-written
+manifest was round-tripped through the PRODUCTION pfb_unbound.dnsbl_build_from_
+manifest() and produced correct data/zone/whiteDB/feedGroupIndex/counts.
+
+--------------------------------------------------------------------------------
+0. THE BOUNDARY ACTUALLY SHIPPED (read this first -- it differs from RESULTS/01's
+   first-pass sketch, deliberately, and is decision-equivalent + lower-risk)
+--------------------------------------------------------------------------------
+RESULTS/01/04 sketched two viable shapes: (a) hand Python the ORIGINAL raw feed
+lines per format (format_hint hosts/abp/csv:pon), or (b) keep the per-line tagged
+files. Phase 5 ships a THIRD, strictly-safer variant of (a):
+
+  PHP keeps its per-feed download + MULTI-FORMAT domain-extraction loop (hosts /
+  plain / basic-ABP / the CSV threat-feed sniffers pt|bbc|h3x|otx|pon|et / IDN).
+  That loop already writes one cleaned, lower-cased, IP-stripped domain per line
+  into each per-feed '.txt' (col1 of the 6-col CSV). pfb_unbound_python_sources()
+  then extracts col1 of each '.txt' into a per-feed raw file and references it in
+  the manifest with format_hint = "plain" for EVERY feed. Python's parse("plain")
+  only re-validates + lower-cases.
+
+WHY this variant (the key decision):
+  * Python's frozen Phase-3 parse() implements ONLY hosts/plain/abp/csv:pon. The
+    catalog also ships pt/bbc/h3x/otx/et CSV threat-feeds. Handing Python the raw
+    of THOSE with no matching parser would REGRESS them (lost blocks). Keeping the
+    PHP extraction and emitting the already-bare domain as "plain" keeps ALL feed
+    formats working with ZERO regression, and is decision-equivalent because PHP's
+    cleaned domain == what Python's per-format parse would have produced for the
+    formats it does implement.
+  * It also satisfies ADR-06 SS3b for free: the loop's IP detection already routes
+    embedded IPs to the firewall and EXCLUDES them from '.txt', so the raw handed
+    to Python is inherently IP-free (0 leak -- pinned).
+
+PINNED by a NEW test, tests/test_adr06_php_boundary.py (+3):
+  Simulates EXACTLY what PHP writes (runs the Phase-2 ReferencePipeline's per-
+  format _extract + _validate_domain over each fixture feed -> the bare domains
+  PHP's '.txt' col1 would hold), writes them as "plain" per-feed raw, builds a
+  plain-ONLY manifest, runs PRODUCTION dnsbl_build_from_manifest + evaluate_domain,
+  and asserts EVERY golden decision (both TOP1M scenarios) + no GOLDEN_EXTRACTED_IPS
+  leak. Green. This is the end-to-end proof the new PHP path is decision-equivalent.
+
+CONSEQUENCE FOR PHASE 6: if you ever want PHP to hand Python the ORIGINAL raw per
+format (so Python owns ABP/CSV too -- the eventual ABP-ADR shape), parse() must
+first gain the missing CSV parsers; test_adr06_init_from_raw.py already pins that
+hosts/abp/csv:pon path. Until then, "plain"-over-PHP-cleaned is the contract.
+
+--------------------------------------------------------------------------------
+1. WHAT WAS REMOVED (files / functions / blocks)
+--------------------------------------------------------------------------------
+SHELL (pfblockerng.sh):
+  * dnsbl_scrub() (was :357-461) DELETED -- within/cross-feed sort -u dedup,
+    user-whitelist removal (ggrep -vF pfbdnsblsuppression), TOP1M removal (ggrep
+    -vF pfbalexa). Pure build-time optimisations; Python dedups dict keys for free
+    and the whitelist/TOP1M are query-time whiteDB now.
+  * domaintldpy() (was :468-524) DELETED -- sort -u dedup + subdomain COLLAPSE
+    (ggrep -vF dnsbl_tld_remove) + the pfb_py_count write. Collapse is unnecessary
+    (a redundant sub-domain is matched by its parent zone); pfb_py_count is now
+    Python-emitted.
+  * Their case-dispatch arms (dnsbl_scrub) / (domaintldpy) DELETED.
+  * Now-dead var defs DELETED: domainmaster, dnsbl_tld_remove, dnsbl_python_data,
+    dnsbl_python_zone, dnsbl_python_count, pfbdnsblsuppression, pfbalexa (each only
+    fed the two removed functions; ShellCheck SC2034-clean after removal).
+
+PHP (pfblockerng.inc):
+  * tld_analysis(): the COLLAPSE/remove-file machinery DELETED -- the $p_tsp
+    (dnsbl_tld_remove) handle, its open/resource-check/close, both ".{dfound},,"
+    /".{tld},," fwrites, the unlink_if_exists of dnsbl_tld_remove, and the
+    `exec domaintldpy` (replaced by a direct .raw -> final rename of pfb_py_data/
+    pfb_py_zone, since there is no longer a collapse step between).
+  * tld_analysis(): the NATIVE-MODE leftover DELETED -- the "static local-zone"
+    TLD-whitelist resolver block (drill-resolve a whitelisted domain to a real/
+    user IP into $tld_whitelist). '$whitelist' was always empty (dead since native
+    mode was removed); "Not required for python mode blocking" per its own comment.
+  * The download loop: the dnsbl_scrub call site DELETED -- the $pfb_alexa /
+    $dup_mode setup + `exec dnsbl_scrub ...`. (The per-feed .bk is now renamed to
+    .txt un-scrubbed; Python dedups on load.)
+  * pfb_update_unbound() count sync-check (was inc:3149-3156) REWRITTEN -- the
+    `$dnsbl_cnt - $tld_cnt` subtraction + (data+zone line count) == comparison +
+    "OUT OF SYNC" branch are GONE. It now reads the Python-emitted pfb_py_count
+    (the LOADED entry total) and logs `[ feed lines: N | loaded entries: M ]`.
+    (See SS3 -- this reconciles the RESULTS/04-flagged semantics mismatch.)
+
+NOTE on the basic-ABP $e_replace pass: it was NOT removed (see SS5 INTENTIONALLY-
+LEFT). It still extracts ABP "||domain^" lines into the per-feed '.txt' that the
+manifest is derived from; removing it would break the '.txt'/CSV producer that the
+alerts/detail consumers (SS5) still read. Python's parse("abp") is exercised by
+test_adr06_init_from_raw.py but is NOT on the production "plain"-boundary path.
+
+--------------------------------------------------------------------------------
+2. WHAT REMAINS IN SHELL/PHP (the slimmed responsibilities)
+--------------------------------------------------------------------------------
+PHP/shell now: download each feed (unchanged: pfb_download, feeds.json, auth,
+scheduling, reuse/fail markers), per-format CLEAN each feed to one bare domain
+per line in '{header}.txt' (kept -- it is the format-light tag step + the source
+the manifest raw is derived from), run the INDEPENDENT DNSBL-IP pass (kept --
+SS4), tag feed/group/log, and WRITE the manifest + per-feed raw (NEW -- SS3). The
+data/zone CLASSIFICATION now lives in the Python build; the PHP tld_analysis copy
+is RETAINED ONLY to keep producing the legacy pfb_py_data/pfb_py_zone CSVs that
+non-build consumers still read (SS5) -- it is no longer on the Python load path.
+
+--------------------------------------------------------------------------------
+3. THE MANIFEST + RAW THE PHP NOW WRITES (matches what Phase-4 init READS)
+--------------------------------------------------------------------------------
+NEW fns in pfblockerng.inc:
+  * pfb_dnsbl_whitelist_lines() -> the raw user-suppression lines (Python's build
+    does the www-strip / leading-dot->wildcard normalisation, so PHP passes them
+    through verbatim).
+  * pfb_unbound_python_sources($feeds) -> writes:
+      - /var/unbound/pfb_py_sources.json  ($pfb['unbound_py_sources'])  -- manifest
+      - /var/unbound/pfb_py_raw/<feed>.raw ($pfb['unbound_py_rawdir'])  -- per-feed
+        IP-stripped bare-domain raw (col1 of each {dnsdir}/<feed>.txt)
+    Manifest shape (EXACTLY the keys pfb_unbound.dnsbl_build_from_manifest reads,
+    verified by a PHP->Python round-trip in this phase):
+      { "version":1,
+        "config": { "tld_master": "/usr/local/pkg/pfblockerng/dnsbl_tld",  # PATH
+                    "tld_blacklist": [...], "tld_exclusion": [...],
+                    "user_whitelist": [...], "top1m_list": [...],
+                    "top1m_enabled": <bool> },
+        "feeds":  [ { "raw": "/var/unbound/pfb_py_raw/<feed>.raw",
+                      "feed": "<header>", "group": "<alias>",
+                      "format_hint": "plain", "log_flag": "0|1|2" }, ... ] }
+    top1m_enabled = ($pfb['dnsbl_alexa']=='on' && pfbalexawhitelist.txt exists);
+    top1m_list = the lines of pfbalexawhitelist.txt when enabled. (Per-list
+    filter_alexa is finer-grained than the single global whiteDB toggle, so the
+    global dnsbl_alexa drives it -- see SS5 residuals.)
+  * pfb_unbound_python_sources_whitelist() -> rewrites ONLY config.user_whitelist
+    in the existing manifest (for whitelist edits that don't re-enumerate feeds).
+
+WIRED:
+  * pfb_unbound_python_sources($pfb_py_feeds) is called in the domain-update branch
+    (after the per-feed .txt are finalised). $pfb_py_feeds is accumulated at BOTH
+    feed-finalise spots (reuse-exists + post-download) as {header,group(=alias),
+    log(=logging_type)}.
+  * Disabled / clear-all branches unlink the manifest + rmdir the raw dir.
+
+COUNTS (RESULTS/04 SS3 / SS5 follow-through):
+  * Python emits /var/unbound/pfb_py_count = LOADED total (len(data)+len(zone)) via
+    dnsbl_emit_count() (Phase 4). PHP NO LONGER writes pfb_py_count (domaintldpy
+    did; it's deleted). The inc sync-check now READS pfb_py_count and reports it
+    (loaded entries) alongside the *.txt feed-line count -- no subtraction, no
+    false "OUT OF SYNC". The UI's per-alias visible counts come from PHP's
+    dnsbl_alias_update()/dnsbl_save_stats() off the *.txt line counts (unchanged,
+    independent of pfb_py_count).
+
+--------------------------------------------------------------------------------
+4. DNSBL-IP FIREWALL FEATURE -- KEPT IN PHP, RAW IS IP-FREE (SS3b)
+--------------------------------------------------------------------------------
+UNCHANGED and fully functional: the per-feed loop's IP detection (generic
+is_ipaddrv4 at inc ~:7950-:7973 and the csv:pon col0 IP at ~:7935-:7945) -> per-
+header {header}_v4.ip -> globbed into {dbdir}/DNSBLIP_v4.txt -> DNSBLIP_v4 pf alias
+with the configured action (inc ~:8301-:8334). I did NOT touch any of it.
+
+Because that detection already EXCLUDES bare-IP lines from the per-feed '.txt'
+(the domain sink), the per-feed RAW the manifest derives from '.txt' is inherently
+IP-FREE -- so Python never receives an IP. test_adr06_php_boundary.py asserts the
+diverted firewall-IP set == GOLDEN_EXTRACTED_IPS
+{198.51.100.23, 203.0.113.45, 198.51.100.77, 192.0.2.140} AND none leak into
+data/zone. The csv:pon row that yields BOTH a domain (col2) and a firewall IP
+(col0) is preserved (domain kept, IP diverted).
+
+DEVIATION (intentional, decision-equivalent): SS3b suggested PHYSICALLY refactoring
+the IP detection into a SEPARATE pass over the raw. I did NOT relocate the code --
+it already runs as a self-contained branch inside the per-feed loop and the raw
+Python sees is IP-free regardless, so the observable contract (DNSBLIP_v4 identical;
+0 IP leak) is met without the relocation. Relocating would risk the pon-col0 /
+generic-bare-IP handling for no behavioural gain. Phase 6 may relocate it as pure
+cleanup if desired; it is not required for correctness.
+
+--------------------------------------------------------------------------------
+5. WHITELIST + COUNTS + FEED/GROUP + DNSBL-IP UI PATHS -- STILL WORK
+--------------------------------------------------------------------------------
+USER WHITELIST (settings textarea):
+  * The suppression config is unchanged; pfb_unbound_python() still regenerates
+    pfb_py_whitelist.txt on change AND now also calls
+    pfb_unbound_python_sources_whitelist() so the manifest's config.user_whitelist
+    (the source of the query-time whiteDB) tracks a settings edit even when no feed
+    update rewrites the full manifest. Application stays query-time (whiteDB),
+    unchanged matcher.
+USER WHITELIST (alerts "add to whitelist" button, pfblockerng_alerts.php:899+):
+  * Still writes the suppression config + pfb_unbound_python_whitelist('alerts');
+    NOW also calls pfb_unbound_python_sources_whitelist() before the reload so the
+    next build's whiteDB un-blocks the domain. The legacy ggrep -vF removal on the
+    pfb_py_data/zone CSVs is RETAINED (it still operates on the CSV consumers'
+    files; harmless, and the query-time whiteDB is the real un-block now).
+FEED/GROUP attribution: flows at QUERY TIME through feedGroupIndexDB -> sqlite
+  rows + log lines (operate() untouched). The build assigns feedGroupIndexDB from
+  the manifest feed/group rows (proven by the round-trip + tests).
+DNSBL-IP: SS4 -- pf alias path untouched, IP-free raw to Python.
+
+INTENTIONALLY-LEFT (per the CONSTRAINT "do not remove what RESULTS/04 did not
+confirm redundant; when in doubt leave it and note it"):
+  * The PHP tld_analysis data/zone CLASSIFICATION COPY (and the basic-ABP
+    $e_replace pass, and the master-raw -> pfb_py_data rename) are RETAINED, NOT
+    deleted, even though classification now also runs in Python. RATIONALE: these
+    PHP-produced pfb_py_data.txt / pfb_py_zone.txt 6-col CSVs are STILL READ/WRITTEN
+    by runtime consumers RESULTS/04 did NOT list as redundant:
+      - inc pfb_dnsbl_parse() greps pfb_py_data/zone for blocked-domain feed/group
+        detail (inc ~:5487/:5509);
+      - pfblockerng_alerts.php APPENDS to / ggreps / reads pfb_py_data/zone for the
+        live "add domain to group", whitelist-removal and unlock/detail features
+        (alerts ~:859-861, :1021-1024, :1141/:1159, :1324-1339).
+    Deleting the producers would break those observable UI features. They are also
+    the legacy CSV LOAD FALLBACK Phase 4 kept (init prefers the manifest, falls back
+    to the CSVs). So the classification PHP copy stays as a compatibility producer;
+    it is simply no longer on the Python LOAD path (the manifest build is).
+    => PHASE 6 / FUTURE: to fully retire the PHP classification + CSV producers,
+       migrate those alerts/detail consumers onto the manifest/whiteDB/sqlite (a
+       UI-side change, out of ADR-06 P5 scope -- operate()/matcher untouched here).
+  * Residual native remnant: $pfb['dnsbl_tld_remove'] path key def (inc:126) is now
+    unused (its only writer/readers were removed) but LEFT as a harmless global
+    path entry; /tmp cleanup is glob-based (pfb_unbound_clear_work_files :/tmp/
+    dnsbl_tld*). Safe to drop in a later cleanup.
+  * top1m_enabled is a single GLOBAL manifest flag (whiteDB is global). The old
+    per-list filter_alexa (which TOP1M-pruned only opted-in lists at build time)
+    cannot be expressed in a global query-time whiteDB; with TOP1M enabled, popular
+    domains are un-blocked across ALL lists. This is an accepted ADR-06 behaviour
+    change (query-time whiteDB is global), flagged for the maintainer smoke.
+
+--------------------------------------------------------------------------------
+6. WHAT WAS NOT TOUCHED (scope guard)
+--------------------------------------------------------------------------------
+NOT touched: pfb_download / feeds.json / auth / headers / scheduling / reuse-fail
+markers; the IP-feed (standalone) pipeline; GeoIP/ASN/MaxMind; SafeSearch/noAAAA/
+HSTS inputs; the matcher (evaluate_domain et al.) and operate(); pfb_unbound.py
+(NO production Python change this phase -- only a new test file added).
+
+--------------------------------------------------------------------------------
+7. GO-AHEAD FOR PHASE 6 (validation + DoD + manual smoke)
+--------------------------------------------------------------------------------
+GO. Phase 6 should:
+  1. Full golden equivalence across formats incl. basic-ABP (test_adr06_golden_
+     oracle + _init_from_raw + the NEW _php_boundary all green = decision contract
+     met). Re-run the Phase-1 init/mem benchmark on adr/06; record vs threshold.
+  2. Finalise README/CLAUDE.md if the build/contract changed (the manifest +
+     /var/unbound/pfb_py_raw are new on-box artifacts; pfb_py_count semantics
+     changed to LOADED total).
+  3. Manual smoke (live box) -- the binding ones for THIS phase:
+       - settings-textarea whitelist AND alerts-button whitelist both un-block
+         (whiteDB), with NO build-time list removal;
+       - counts/alerts/feed-group render; pfb_py_count is the loaded total and may
+         be HIGHER than the old number (un-pruned -- expected);
+       - a DNSBL feed with embedded IPs still populates DNSBLIP_v4 (same IP set);
+       - TLD blacklist (whole-TLD block) + TLD exclusion behave; TOP1M enabled ->
+         a popular domain in a feed resolves, disabled -> it blocks;
+       - a reload picks up feed + whitelist changes.
+     ALSO smoke the RETAINED CSV consumers (SS5): alerts "add domain to group",
+     "add to whitelist", unlock/detail -- they still operate on pfb_py_data/zone.
+  4. CONSIDER (optional follow-up ADR/phase, NOT required for DoD): migrate the
+     alerts/detail CSV consumers off pfb_py_data/zone so the PHP classification +
+     CSV producers can finally be deleted; and add the missing CSV parsers to
+     pfb_unbound.parse() if the boundary should hand Python the original raw.
+
+GATES (this phase): python -m pytest = 255 passed (+3); ruff check + ruff format
+clean; php -l clean (pfblockerng.inc, pfblockerng_alerts.php; pre-existing
+unrelated pfb_unlock() Deprecated notice only); sh -n + shellcheck clean
+(pfblockerng.sh). PHP-written manifest round-tripped through the PRODUCTION
+pfb_unbound.dnsbl_build_from_manifest() -> correct data/zone/whiteDB/feedGroup/
+counts. No pfb_unbound.py production change; no Unbound symbol added.
+================================================================================

--- a/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/06_Results.txt
+++ b/.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/RESULTS/06_Results.txt
@@ -1,0 +1,198 @@
+================================================================================
+ADR-06 -- PHASE 6 RESULTS / FINAL (validation, init/mem evidence, DoD, smoke)
+Validation + docs only; no runtime behaviour changed. Status NOT flipped to Accepted.
+Branch: adr/06   Commit: docs: ADR-06 P6 -- DNSBL preprocessing move validation + DoD
+================================================================================
+
+VERDICT: GO confirmed. The DNSBL-preprocessing-into-Python move is DECISION-
+EQUIVALENT across all formats and the init/memory kill-gate PASSES with comfortable
+headroom on the PRODUCTION build path (re-measured on adr/06). The §7 boundary pivot
+was NOT triggered. Status set to "Implemented -- pending live smoke"; it flips to
+Accepted only after the maintainer runs the live manual smoke (checklist below).
+
+--------------------------------------------------------------------------------
+0. SCOPE OF THIS PHASE
+--------------------------------------------------------------------------------
+Validation + docs ONLY. No production .py/.inc/.sh touched. Three files changed:
+  * .ADRs/.../ADR.md          -- Status line; §7 Build-evidence block; reject-criteria
+                                 outcomes; expanded maintainer manual-smoke checklist.
+  * README.md                 -- new "DNSBL list build (Python)" subsection (the new
+                                 shell->Python contract + how to run golden tests) and
+                                 the ADR-06 init/mem spike in the Benchmarks section.
+  * CLAUDE.md                 -- pfb_unbound.py now annotated as owning the DNSBL list
+                                 build; a "Running tests" note on the manifest contract
+                                 + where the golden tests / kill-gate live.
+No production code, no test code, no new behaviour. Status NOT "Accepted".
+
+--------------------------------------------------------------------------------
+1. EQUIVALENCE RESULT -- PASS (golden across hosts / plain / basic-ABP / csv:pon)
+--------------------------------------------------------------------------------
+`python -m pytest` => 255 passed (incl. 71 ADR-06 tests). ruff check + ruff
+format --check clean. markdownlint-cli2 => 0 errors on the 3 changed md files.
+(No PHP/shell touched this phase, so php -l / ShellCheck not re-run here; they were
+clean in Phase 5.)
+
+The decision-equivalence chain (decisions, NOT list contents/counts -- the ADR §2
+relaxation) is proven by four test modules, each mapped to an acceptance item:
+
+  * tests/test_adr06_golden_oracle.py -- the reference preprocessor loads the
+    PRODUCTION matcher's runtime structures and the oracle drives the PRODUCTION
+    decision fns pfb_unbound.evaluate_domain / evaluate_noaaaa over the golden query
+    set, for BOTH TOP1M scenarios (disabled + enabled overrides) and the noAAAA
+    surface. Fixtures (tests/fixtures/adr06_golden/) exercise ALL formats:
+    feed_hosts.txt (hosts), feed_plain.txt/feed_extra.txt/feed_nolog.txt (plain),
+    feed_abp.txt (basic-ABP), feed_csv_pon.txt (csv:pon). The firewall-IP extraction
+    set GOLDEN_EXTRACTED_IPS is asserted AND confirmed absent from the block lists.
+    => ACCEPTANCE 1 (decision-equivalent across formats) + 5 (DNSBL-IP set) + the
+       whitelist/TLD/TOP1M cases (ACCEPTANCE 3).
+
+  * tests/test_adr06_build_module.py -- the pure parse/normalise/classify/build
+    layer, unit by unit (the Phase-3 module). => the build primitives.
+
+  * tests/test_adr06_init_from_raw.py -- the PRODUCTION dnsbl_build_from_manifest()
+    over an on-box-shaped manifest JSON (config block + per-feed raw rows), asserted
+    decision-equal to BOTH the golden map AND the reference pipeline, parametrised
+    over both TOP1M scenarios. Also pins: feed/group attribution through
+    feedGroupIndexDB; top1m_enabled flowing from config; no IP leak into block lists;
+    and dnsbl_emit_count writing the LOADED total (len(data)+len(zone)) to
+    pfb_py_count -- cross-checked == the structures the matcher uses.
+    => ACCEPTANCE 1 + 3 + 4 (Python-emitted counts) + feed/group attribution.
+
+  * tests/test_adr06_php_boundary.py -- the SHIPPED PHP boundary ("clean each feed to
+    bare domains, emit as format_hint=plain"), simulated by running the reference
+    per-format extract/validate then round-tripping through the PRODUCTION build +
+    evaluate_domain; every golden decision holds (both TOP1M scenarios) and the
+    diverted firewall-IP set == GOLDEN_EXTRACTED_IPS with 0 leak.
+    => proves the actual shell/PHP path Phase 5 ships is decision-equivalent.
+
+Two behaviour changes are INTENDED (accepted by ADR §2, NOT regressions), each now
+called out in the smoke checklist:
+  * cross-feed-duplicate attribution is LAST-WINS (was first-feed) -- dict assignment.
+  * TOP1M is a single GLOBAL query-time whiteDB toggle (the old per-list filter_alexa
+    build-time prune cannot be expressed query-time) -> with TOP1M enabled, popular
+    domains un-block across ALL lists.
+
+--------------------------------------------------------------------------------
+2. INIT/MEMORY NUMBERS vs THRESHOLD -- RE-MEASURED ON adr/06 -- PASS (GO)
+--------------------------------------------------------------------------------
+Kill-threshold (RESULTS/01 §4): build wall-time <= ~8 s absolute AND retained dict
+footprint <= ~410 B/entry (vs the ADR-05 §3a 274 B/entry baseline), on a large
+(>=1M-entry) UN-PRUNED corpus.
+
+Re-measured on adr/06 (CPython 3.14, macOS dev box, N>=5):
+
+  build path                         size       build median (max)   peak RAM   B/entry  verdict
+  -------------------------------------------------------------------------------------------------
+  PRODUCTION dnsbl_build_from_manifest  1,000,000  2.28 s (2.33)       141.5 MiB  281.5 (+3%)  PASS
+  PRODUCTION dnsbl_build_from_manifest  2,000,000  4.39 s (4.43)       266.8 MiB  284.7 (+4%)  PASS
+  Phase-1 spike prototype               1,000,000  1.47 s              193.8 MiB  274.9 (+0%)  PASS
+
+  * Build wall-time is LINEAR (~2.2 us/raw-line). Even 2M -- the RESULTS/01 residual-
+    risk size -- is 4.4 s, well under the 8 s cap. The production fn is ~1.55x the
+    spike prototype (real parse() dispatch + per-label normalise() + public-suffix
+    classify() + ParsedEntry dataclass + file I/O), still comfortably within budget.
+  * Memory is at baseline parity (281-285 B/entry, +3-4%) -- the trie was never the
+    lever, confirmed again. Peak RAM is the dict floor because the production build
+    STREAMS feeds lazily (_dnsbl_file_line_reader); the spike's higher peak is only
+    because it materialises the full line list.
+
+MEASUREMENT NOTE (important -- fixes a misread that RESULTS/01 baked in):
+  Wall-time MUST be timed with tracemalloc OFF. tracemalloc instruments every
+  allocation and inflates this allocation-heavy build ~3-4x. The committed spike
+  (benchmarks/spike_adr06_build.py) and RESULTS/01 time the build INSIDE
+  tracemalloc.start(), so their reported figures are INSTRUMENTED, not real:
+      spike instrumented:  5.3 s / 1M ; 10.9 s / 2M  (RESULTS/01 -- and where its "2M
+                           exceeds the 8 s cap" residual-risk flag came from)
+      spike un-instrumented: 1.47 s / 1M
+      PRODUCTION un-instr.:  2.28 s / 1M ; 4.39 s / 2M  <- the real init cost, decided on
+  So RESULTS/01's "2M may exceed budget" caveat was an instrumentation artifact; the
+  un-instrumented production path is comfortably under the cap at BOTH 1M and 2M.
+  (The spike code was left UNCHANGED this phase -- validation/docs only, no behaviour
+  change. The methodology + both numbers are recorded in ADR §7 and README. A future
+  cleanup could split the spike's timing pass from its tracemalloc/asizeof pass; not
+  done here to stay in scope.)
+
+How to reproduce (production path) -- throwaway harness used this phase (NOT committed;
+the committed kill-gate is benchmarks/spike_adr06_build.py): write the un-pruned
+>=1M-line corpus from benchmarks/_corpus_raw.py to per-feed raw files + an on-box
+manifest with a real public-suffix tld_master, then time pfb_unbound.
+dnsbl_build_from_manifest() with tracemalloc OFF (timing) and a separate tracemalloc
+pass for peak RAM + pympler.asizeof for retained B/entry.
+
+GATE OUTCOME: GO confirmed on the production build path. No §7 boundary pivot taken.
+
+--------------------------------------------------------------------------------
+3. DOCS UPDATED
+--------------------------------------------------------------------------------
+  * ADR.md
+      - Status: Proposed -> "Implemented -- pending live smoke" (NOT Accepted).
+      - New "### Build evidence (Phase 6, recorded on adr/06)" block: the test->
+        acceptance mapping + the init/mem table + the tracemalloc measurement note.
+      - Reject-criteria: both criteria annotated "Outcome (Phase 6): NOT triggered"
+        with the recorded numbers + the two accepted-by-design behaviour changes.
+      - Manual-smoke checklist expanded (see §4) with an explicit Accept gate header.
+  * README.md
+      - New "### DNSBL list build (Python)" subsection: the shell->Python contract
+        (manifest /var/unbound/pfb_py_sources.json + per-feed raw; build ->
+        data/zone/whiteDB/feedGroupIndex + pfb_py_count; no dedup/collapse/build-time
+        whitelist/TOP1M removal), and the command to run the four golden test modules.
+      - Benchmarks section: added the ADR-06 init/mem spike invocation.
+  * CLAUDE.md
+      - pfb_unbound.py annotated as owning the DNSBL list build in the repo tree.
+      - "Running tests" note: the manifest contract + where the golden tests and the
+        kill-gate live.
+
+--------------------------------------------------------------------------------
+4. MAINTAINER MANUAL-SMOKE CHECKLIST (the gate CI cannot reach)
+--------------------------------------------------------------------------------
+*** ACCEPT GATE: Status flips Proposed/Implemented -> ACCEPTED ONLY after every box
+    below passes on a LIVE pfSense CE box. CI cannot reach Unbound's Python loader or
+    pf. Run after a full DNSBL update (so the manifest + per-feed raw + pfb_py_count
+    are freshly written) and a resolver reload. ***
+
+  [ ] Block decisions unchanged: exact (data) block, wildcard/zone block AND a
+      sub-domain of it, an HSTS entry, a noAAAA entry; a non-listed domain resolves.
+  [ ] Whitelist BOTH entry points: settings-textarea whitelist resolves; alerts
+      "add to whitelist" button resolves (after its reload). Wildcard (leading-dot)
+      un-blocks sub-domains. Whitelisted domain stays in-list as a whitelist hit.
+  [ ] Counts/UI: alerts/stats/widget + per-alias counts render. pfb_py_count is the
+      LOADED total, may be HIGHER than before (un-pruned -- expected). No "OUT OF
+      SYNC"; update log shows "[ feed lines: N | loaded entries: M ]".
+  [ ] TLD blacklist (whole-TLD block) + TLD exclusion (forced exact) behave. TOP1M
+      ENABLED -> a popular feed domain resolves; DISABLED -> it blocks. NOTE the
+      accepted change: TOP1M is now GLOBAL (un-blocks across all lists when enabled).
+  [ ] DNSBL-IP firewall feature: a feed with embedded IPs still populates DNSBLIP_v4
+      (configured action) + the rule references it; IP set unchanged; no IP in DNS.
+  [ ] Reload picks up feed AND whitelist changes.
+  [ ] Retained CSV consumers (RESULTS/05 §5): alerts "add domain to group", "add to
+      whitelist", unlock/detail still work off pfb_py_data/pfb_py_zone.
+  [ ] Cross-feed duplicate attribution is now LAST-WINS (was first-feed); spot-check a
+      known duplicated domain's reported feed/group is sane (count shift expected).
+
+--------------------------------------------------------------------------------
+5. RESIDUALS / FUTURE (out of ADR-06 scope -- noted, not done)
+--------------------------------------------------------------------------------
+  * Retire the PHP data/zone classification COPY + the pfb_py_data/zone CSV producers
+    by migrating the alerts/detail consumers (RESULTS/05 §5) onto the manifest/whiteDB/
+    sqlite -- a UI-side change. Until then the CSVs are intentionally kept.
+  * Add the missing CSV threat-feed parsers (pt/bbc/h3x/otx/et) to pfb_unbound.parse()
+    if the boundary should ever hand Python the ORIGINAL raw per format instead of the
+    PHP-cleaned "plain" (the eventual conformant-ABP ADR shape). test_adr06_init_from_
+    raw.py already pins the hosts/abp/csv:pon path for that direction.
+  * Optional: split the spike's timing pass from its tracemalloc/asizeof pass so its
+    reported wall-time is un-instrumented (cosmetic; the real numbers are in ADR §7).
+  * Residual native remnant $pfb['dnsbl_tld_remove'] path key (inc:126) is unused;
+    safe to drop in a later cleanup (RESULTS/05 §5).
+
+--------------------------------------------------------------------------------
+6. GATES (this phase)
+--------------------------------------------------------------------------------
+python -m pytest      => 255 passed (71 ADR-06: golden_oracle, build_module,
+                         init_from_raw, php_boundary -- all green).
+ruff check .          => All checks passed!
+ruff format --check . => 20 files already formatted.
+npx markdownlint-cli2 => 0 error(s) on README.md, CLAUDE.md, ADR.md.
+php -l / ShellCheck   => not re-run (no PHP/shell touched this phase; clean in P5).
+Init/mem kill-gate    => PASS (production build 2.28 s/1M, 4.39 s/2M; 281-285 B/entry).
+Status                => "Implemented -- pending live smoke" (NOT Accepted).
+================================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ pfBlockerNG/
 │       │   ├── pfblockerng_install.inc
 │       │   ├── pfblockerng_extra.inc
 │       │   ├── pfb_unbound_include.inc
-│       │   ├── pfb_unbound.py         # Unbound Python plugin
+│       │   ├── pfb_unbound.py         # Unbound Python plugin (matcher + DNSBL list build: parse/classify/build from the manifest)
 │       │   ├── pfblockerng.sh         # Shell script (POSIX sh)
 │       │   └── ip_pre_AWS_*.sh        # Per-region AWS IP-prefix pre-scripts (hand-maintained)
 │       ├── share/             # Package metadata (info.xml)
@@ -81,6 +81,15 @@ Run after **any** change to `src/usr/local/pkg/pfblockerng/pfb_unbound.py` or
 `tests/` — in-loop, for fast feedback; don't wait for the commit to find breakage.
 The pre-commit hook re-runs the suite at commit time and CI is the final authority,
 so a separate manual pre-commit run is not needed.
+
+DNSBL list preprocessing (parse → normalise → classify data/zone → build dicts +
+feed/group index + `whiteDB`, then emit `pfb_py_count`) lives in `pfb_unbound.py`'s
+pure `dnsbl_build_from_manifest()` / `build()`, fed by the PHP/shell-written
+manifest (`/var/unbound/pfb_py_sources.json` + per-feed raw). PHP/shell only
+download + tag + run the DNSBL-IP firewall pass. Decision-equivalence is pinned by
+`tests/test_adr06_*` (golden oracle, build module, init-from-raw, PHP boundary);
+the init/peak-RAM kill-gate is `benchmarks/spike_adr06_build.py`. See
+`.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,39 @@ python3 -m pytest
 
 Test paths and options are configured in `pyproject.toml`; no `cd` is required.
 
+### DNSBL list build (Python)
+
+DNSBL blocklist preprocessing lives in the Python plugin
+(`src/usr/local/pkg/pfblockerng/pfb_unbound.py`), not in shell/PHP. PHP/shell only
+**download** each feed, run the **DNSBL-IP firewall pass** (embedded IPs →
+`DNSBLIP_v4` pf alias, stripped from Python's input), and write a per-feed
+**manifest** that the plugin reads at `init`:
+
+- `/var/unbound/pfb_py_sources.json` — the manifest: a `config` block (TLD master
+  path, TLD blacklist/exclusion, user whitelist, TOP1M list + enabled flag) plus
+  one `feeds` row per raw file (`{raw, feed, group, format_hint, log_flag}`).
+- `/var/unbound/pfb_py_raw/<feed>.raw` — per-feed IP-stripped bare-domain raw.
+
+`pfb_unbound.dnsbl_build_from_manifest()` then does **parse → normalise → classify
+(data/zone via the public-suffix master) → build** `dataDB`/`zoneDB` +
+feed/group index + query-time `whiteDB`, and emits the loaded-entry total to
+`/var/unbound/pfb_py_count`. The build performs **no** dedup, subdomain collapse,
+or build-time whitelist/TOP1M removal (dict keys dedup for free; whitelist + TOP1M
+apply at query time via `whiteDB`). It is a pure, reentrant `(manifest, config) →
+BuildResult` function — no Unbound symbols, fully unit-testable. See
+[ADR-06](.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/ADR.md) for the full contract.
+
+The decision-equivalence of this move (block/resolve/whitelist/HSTS/noAAAA across
+hosts/plain/basic-ABP/csv:pon, plus feed/group attribution and the emitted count)
+is pinned by the golden + build unit tests in the default `pytest` run:
+
+```sh
+python -m pytest tests/test_adr06_golden_oracle.py \
+                 tests/test_adr06_build_module.py \
+                 tests/test_adr06_init_from_raw.py \
+                 tests/test_adr06_php_boundary.py
+```
+
 ### Benchmarks
 
 `benchmarks/` holds an opt-in suite comparing the domain-trie matcher against the
@@ -106,6 +139,15 @@ footprint). It is dev-only, not shipped, and not collected by the default
 python -m pip install -r benchmarks/requirements.txt
 python -m pytest benchmarks/test_bench_matching.py --benchmark-columns=min,mean,ops
 python -m pytest benchmarks/test_memory.py -s
+```
+
+It also holds the ADR-06 init-time / peak-RAM spike for the Python DNSBL build —
+the kill-gate that gated moving preprocessing into the plugin (build wall-time and
+retained dict footprint on a large, un-pruned ≥1M-entry corpus):
+
+```sh
+python -m pip install pympler    # dev-only retained-footprint tool (ADR-05 §3a)
+SPIKE_N=5 SPIKE_SIZES=1000000 python benchmarks/spike_adr06_build.py
 ```
 
 ### Linting

--- a/benchmarks/_corpus_raw.py
+++ b/benchmarks/_corpus_raw.py
@@ -75,6 +75,11 @@ def generate_raw_corpus(
     registrable-parent sharing), ~70/20/5/3/2 across label depth — but here every
     entry is emitted as raw text, un-classified and un-pruned.
     """
+    if n_domain_lines < 0:
+        raise ValueError(f"n_domain_lines must be >= 0, got {n_domain_lines}")
+    if n_feeds < 1:
+        raise ValueError(f"n_feeds must be >= 1, got {n_feeds}")
+
     rng = random.Random(seed)
     n_slds = max(1, n_domain_lines // 8)
     slds = ["{}{}.{}".format(rng.choice(LABELS), rng.randrange(100_000), rng.choice(TLDS)) for _ in range(n_slds)]

--- a/benchmarks/_corpus_raw.py
+++ b/benchmarks/_corpus_raw.py
@@ -1,0 +1,139 @@
+"""Un-pruned raw DNSBL corpus generator for the ADR-06 Phase-1 spike.
+
+ADR-06 moves parse -> normalise -> classify -> build into the Python plugin and
+*drops* the build-time list optimisations (dedup, subdomain collapse, user/TOP1M
+whitelist removal). The realistic init load is therefore the **un-pruned** raw
+feed text, which is LARGER than today's pruned `pfb_py_data`/`pfb_py_zone`. This
+module emits exactly that: literal downloaded feed lines, with duplicates kept,
+no whitelist/TOP1M removal, and no subdomain collapse.
+
+Three feed shapes are produced (a feed-shaped mix), matching the formats the PHP
+parse loop handles (`pfblockerng.inc:7665-7973`):
+
+* ``hosts``  -> ``0.0.0.0 ads3.x.com`` (hosts-file format; the leading IP is the
+  sinkhole address, NOT a feed-embedded firewall IP).
+* ``plain``  -> ``ads3.x.com`` (bare domain, one per line).
+* ``abp``    -> ``||ads3.x.com^`` (basic EasyList/ABP; PHP strips ``|| . ^``).
+
+It also injects:
+
+* ``bare-IP`` lines (``198.51.100.7``) — the "DNSBL IP" firewall feature. In the
+  real pipeline PHP extracts these into ``*_v4.ip`` -> ``DNSBLIP_v4`` and strips
+  them from Python's input (ADR-06 §2). The spike SKIPS them in the build (the
+  Python build never produces firewall input), but emits them so the corpus is
+  realistic and the skip cost is measured.
+* duplicates (a domain appearing in several feeds) — kept un-deduped; the dict
+  load dedups keys for free.
+
+Not shipped: lives under benchmarks/, excluded from release archives. stdlib only.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import random
+from dataclasses import dataclass, field
+
+from _corpus import LABELS, TLDS
+
+# Sinkhole address a hosts-format feed prepends to every domain. This is NOT a
+# feed-embedded firewall IP — it is stripped as "characters before the space".
+HOSTS_SINK = "0.0.0.0"
+
+
+@dataclass
+class RawCorpus:
+    """A flat list of literal raw feed lines + bookkeeping for the spike."""
+
+    lines: list[str] = field(default_factory=list)  # literal raw feed text lines
+    feeds: list[str] = field(default_factory=list)  # per-line feed header (parallel)
+    n_domain_lines: int = 0  # lines carrying a domain (hosts/plain/abp)
+    n_ip_lines: int = 0  # bare-IP lines (PHP firewall path; Python skips)
+    n_unique_domains: int = 0  # distinct domains across all domain lines
+
+    @property
+    def total_lines(self) -> int:
+        return len(self.lines)
+
+
+def generate_raw_corpus(
+    n_domain_lines: int,
+    seed: int = 1234,
+    dup_factor: float = 0.18,
+    ip_factor: float = 0.02,
+    n_feeds: int = 24,
+) -> RawCorpus:
+    """Generate ~``n_domain_lines`` un-pruned raw feed lines across mixed formats.
+
+    ``dup_factor`` of the domain lines are deliberate cross-feed duplicates (a
+    domain re-emitted under a different feed) so the build's free key-dedup and
+    last-wins feed/group attribution are exercised. ``ip_factor`` of the *extra*
+    lines are bare IPv4 (the firewall path the Python build skips).
+
+    The domain distribution mirrors `_corpus.generate_corpus`: many entries share
+    a smaller pool of second-level domains (so classification has realistic
+    registrable-parent sharing), ~70/20/5/3/2 across label depth — but here every
+    entry is emitted as raw text, un-classified and un-pruned.
+    """
+    rng = random.Random(seed)
+    n_slds = max(1, n_domain_lines // 8)
+    slds = ["{}{}.{}".format(rng.choice(LABELS), rng.randrange(100_000), rng.choice(TLDS)) for _ in range(n_slds)]
+    feeds = ["feed_{:02d}".format(i) for i in range(n_feeds)]
+
+    c = RawCorpus()
+    seen: set[str] = set()
+    emitted_domains: list[str] = []  # pool to draw duplicates from
+
+    def emit_domain(domain: str) -> None:
+        feed = rng.choice(feeds)
+        fmt = rng.random()
+        if fmt < 0.40:
+            line = "{} {}".format(HOSTS_SINK, domain)  # hosts format
+        elif fmt < 0.80:
+            line = domain  # plain
+        else:
+            line = "||{}^".format(domain)  # basic-ABP
+        c.lines.append(line)
+        c.feeds.append(feed)
+        c.n_domain_lines += 1
+        if domain not in seen:
+            seen.add(domain)
+            emitted_domains.append(domain)
+
+    for i in range(n_domain_lines):
+        # Decide whether this line is a duplicate of an already-emitted domain.
+        if emitted_domains and rng.random() < dup_factor:
+            emit_domain(rng.choice(emitted_domains))
+            continue
+
+        sld = rng.choice(slds)
+        bucket = rng.random()
+        if bucket < 0.70:  # deep label -> exact data after classify
+            emit_domain("{}{}.{}".format(rng.choice(LABELS), i, sld))
+        elif bucket < 0.90:  # registrable parent -> wildcard zone after classify
+            emit_domain(sld)
+        elif bucket < 0.95:  # would have been whitelisted (kept in-list now)
+            emit_domain("wl{}.{}".format(i, sld))
+        elif bucket < 0.98:  # hsts-ish host
+            emit_domain("hs{}.{}".format(i, sld))
+        else:  # noaaaa-ish host
+            emit_domain("na{}.{}".format(i, sld))
+
+    # Inject bare-IP lines (firewall path) interleaved at the end. These fail the
+    # domain validation in the Python build and are skipped (never become dicts).
+    n_ip = int(n_domain_lines * ip_factor)
+    ip_base = int(ipaddress.IPv4Address("198.51.100.0"))
+    for k in range(n_ip):
+        ip = str(ipaddress.IPv4Address((ip_base + rng.randrange(0, 65536)) & 0xFFFFFFFF))
+        c.lines.append(ip)
+        c.feeds.append(rng.choice(feeds))
+        c.n_ip_lines += 1
+
+    # Shuffle so IP/domain/format ordering is realistic (feeds interleave).
+    order = list(range(len(c.lines)))
+    rng.shuffle(order)
+    c.lines = [c.lines[i] for i in order]
+    c.feeds = [c.feeds[i] for i in order]
+
+    c.n_unique_domains = len(seen)
+    return c

--- a/benchmarks/spike_adr06_build.py
+++ b/benchmarks/spike_adr06_build.py
@@ -162,6 +162,9 @@ def build(lines: list[str], feeds: list[str], log_flag: str = "1") -> dict[str, 
     pruning -- dict keys dedup for free, last feed wins on a duplicate key (the
     documented attribution change). Reentrant: nothing global is touched.
     """
+    if len(lines) != len(feeds):
+        raise ValueError(f"lines and feeds must be equal length: {len(lines)} != {len(feeds)}")
+
     data_db: dict[str, dict[str, Any]] = {}
     zone_db: dict[str, dict[str, Any]] = {}
     feed_group_index_db: dict[int, dict[str, str]] = {}
@@ -237,6 +240,8 @@ def _retained_bytes(structures: dict[str, Any]) -> int | None:
 
 
 def run(n_domain_lines: int, n_runs: int) -> None:
+    if n_runs < 1:
+        raise ValueError(f"n_runs must be >= 1, got {n_runs}")
     print("=" * 78)
     print(
         "ADR-06 P1 SPIKE  Python DNSBL build cost  (CPython {}.{}, {})".format(

--- a/benchmarks/spike_adr06_build.py
+++ b/benchmarks/spike_adr06_build.py
@@ -1,0 +1,348 @@
+"""ADR-06 Phase-1 de-risking spike: cost of the Python DNSBL build inside Unbound.
+
+Question this answers (falsify-first, before ADR-06 moves any production code):
+does a pure-Python build (parse -> normalise -> classify data/zone -> build
+``dataDB``/``zoneDB`` + feed/group index + counts) run inside Unbound's ``init``
+within an init-time / peak-memory budget on a large (>=1M-entry) UN-PRUNED feed?
+
+Why un-pruned: ADR-06 drops the build-time optimisations (dedup, subdomain
+collapse, user/TOP1M whitelist removal), so Python loads MORE entries than today's
+pruned ``pfb_py_data``/``pfb_py_zone``. The realistic init cost is on the raw,
+un-pruned text -- which is what this spike feeds in (`_corpus_raw.py`).
+
+Scope (matches the Phase-1 prompt):
+* Build from the un-pruned raw -- NO dedup (dict keys dedup for free), NO subdomain
+  collapse, NO build-time whitelist/TOP1M removal.
+* The build SKIPS bare-IP lines (IP extraction stays in PHP, Phase 5) -> no IP
+  handoff is emitted here.
+* stdlib only, no Unbound symbols. Payload shapes match the production loader
+  (`pfb_unbound.py:535-602`): ``{"log": str, "index": int}`` per entry,
+  ``feedGroupIndexDB[index] = {"feed", "group"}``, ``whiteDB`` is separate.
+
+Measures (N>=3 runs at >=1M entries):
+* build wall-time (``time.perf_counter``) -- distribution (min/median/max/mean).
+* peak RAM during build (stdlib ``tracemalloc``) -- the init high-water mark.
+* retained dict bytes/entry (``pympler.asizeof``, same method as ADR-05 §3a) vs
+  the ~274 B/entry baseline.
+
+Then prints an explicit GO / NO-GO against the proposed kill-threshold.
+
+Run from the repo root (dev-only; not shipped, not in the default pytest run)::
+
+    python -m pip install pympler          # dev-only, ADR-05 §3a baseline tool
+    SPIKE_N=5 SPIKE_SIZES=1000000 python benchmarks/spike_adr06_build.py
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+import re
+import statistics
+import sys
+import time
+import tracemalloc
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _corpus_raw import HOSTS_SINK, generate_raw_corpus  # noqa: E402
+
+try:
+    from pympler import asizeof  # type: ignore
+except ImportError:  # pragma: no cover - dev tool only
+    asizeof = None  # type: ignore[assignment]
+
+# --------------------------------------------------------------------------- #
+# Kill-threshold (proposed in Phase 1; tune with the maintainer in the handoff).
+# --------------------------------------------------------------------------- #
+# The budget is "added reload time <= a few seconds" and "peak RAM not materially
+# worse than today" -- NOT an absolute wall-clock cap on the build in isolation.
+# The fair comparison is NET: the work today's shell/PHP already spends per build
+# that ADR-06 DELETES. Measured on this box, an equivalent 1M-line master raw:
+#   * sort -u (dedup)            ~2.1s   (domaintldpy runs it 2-3x)
+#   * awk cross-list dedup       ~2.7s   (dnsbl_scrub :379)
+#   * ggrep -vF whitelist/TOP1M  seconds more (grows with pattern-file size)
+# i.e. today already costs ~5s+ of out-of-process passes that the move REMOVES.
+# So the threshold is read as: build <= ~8s absolute (a few seconds ADDED over the
+# shell time it replaces) AND retained footprint not materially worse than the
+# ADR-05 §3a 274 B/entry baseline (<= ~410 B/entry, ~1.5x headroom for the
+# un-pruned build's extra entries). Tune both with the maintainer.
+THRESH_BUILD_SECONDS = 8.0  # absolute build budget (a few seconds over removed shell passes)
+THRESH_BYTES_PER_ENTRY = 410.0  # retained dict footprint ceiling
+BASELINE_BYTES_PER_ENTRY = 274.0  # ADR-05 §3a steady-state dict baseline
+SHELL_PASSES_REMOVED_SECONDS = 4.8  # measured sort -u + awk cross-dedup on 1M lines (excl. ggrep)
+
+# ICANN-style "registrable parent = last two labels" rule. The production
+# classifier (tld_analysis) consults the public-suffix master list; for an
+# init-COST spike the exact suffix set is irrelevant -- what matters is the
+# per-line split/classify work + the dict build at scale. Two labels is the
+# dominant case and keeps the data/zone split realistic (~deep labels -> data).
+_REGISTRABLE_LABELS = 2
+
+
+# --------------------------------------------------------------------------- #
+# The build under test -- pure, stdlib-only, no Unbound symbols, reentrant
+# (returns a fresh structure-set; mutates nothing global). This prototypes the
+# Phase-3 `pfb_dnsbl_build` shape: parse -> normalise -> classify -> build.
+# --------------------------------------------------------------------------- #
+
+
+def parse_line(line: str) -> str | None:
+    """Parse one raw feed line to a bare host, or None if it carries no domain.
+
+    Subsumes the basic-ABP token strip and the hosts/plain handling the PHP loop
+    does today (`pfblockerng.inc:7665-7960`). Returns None for blank/comment/IP
+    lines -- the IP case is the firewall path (PHP), which the Python build skips.
+    """
+    line = line.strip()
+    if not line or line[0] in "#!/":
+        return None
+
+    # basic-ABP: ||domain^  (ignore @@ exceptions, $options, *, /, element rules)
+    if line.startswith("||"):
+        if line.endswith("^") and "$" not in line and "*" not in line and "/" not in line:
+            return line[2:-1]
+        return None
+
+    # hosts format: "<sink-ip> <domain>" -> take the token after the space.
+    if " " in line:
+        first, _, rest = line.partition(" ")
+        rest = rest.strip()
+        # A hosts line begins with the sinkhole IP; the domain is the remainder.
+        line = rest if (first == HOSTS_SINK or _is_ipv4(first)) else first
+
+    if _is_ipv4(line):
+        return None  # bare-IP -> firewall path (PHP); Python build skips it.
+
+    return line or None
+
+
+# Domain-shape gate. The production `PFB_FILTER_DOMAIN` is a single regex match;
+# a compiled pattern is the representative per-line cost (one C-level call), not a
+# per-character Python membership loop.
+_DOMAIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
+
+
+def normalise(host: str) -> str | None:
+    """Lower-case, strip stray dots, reject anything that is not a plain domain."""
+    host = host.strip(".").lower()
+    if "." not in host or not _DOMAIN_RE.match(host):
+        return None
+    return host
+
+
+def classify(host: str) -> tuple[str, str]:
+    """Return (kind, key): ('zone', registrable-parent) or ('data', host).
+
+    Mirrors `tld_analysis`: a domain that *is* its registrable parent becomes a
+    wildcard zone; a deeper sub-domain becomes an exact data entry.
+    """
+    labels = host.split(".")
+    if len(labels) <= _REGISTRABLE_LABELS:
+        return "zone", host
+    return "data", host
+
+
+def _is_ipv4(token: str) -> bool:
+    parts = token.split(".")
+    if len(parts) != 4:
+        return False
+    for p in parts:
+        if not p.isdigit() or not (0 <= int(p) <= 255) or (len(p) > 1 and p[0] == "0"):
+            return False
+    return True
+
+
+def build(lines: list[str], feeds: list[str], log_flag: str = "1") -> dict[str, Any]:
+    """Pure build: raw lines (+ parallel per-line feed) -> structure-set.
+
+    Returns ``dataDB``/``zoneDB`` (key -> {"log", "index"}), ``feedGroupIndexDB``
+    (index -> {"feed", "group"}) and ``counts``. No dedup / collapse / whitelist
+    pruning -- dict keys dedup for free, last feed wins on a duplicate key (the
+    documented attribution change). Reentrant: nothing global is touched.
+    """
+    data_db: dict[str, dict[str, Any]] = {}
+    zone_db: dict[str, dict[str, Any]] = {}
+    feed_group_index_db: dict[int, dict[str, str]] = {}
+    feed_group_db: dict[str, int] = {}
+    next_index = 0
+    n_skipped = 0
+
+    for line, feed in zip(lines, feeds):
+        host = parse_line(line)
+        if host is None:
+            n_skipped += 1
+            continue
+        host = normalise(host)
+        if host is None:
+            n_skipped += 1
+            continue
+
+        group = feed  # in the real pipeline group=$alias; one per feed here.
+        fg_key = feed + group
+        index = feed_group_db.get(fg_key)
+        if index is None:
+            index = next_index
+            feed_group_db[fg_key] = index
+            feed_group_index_db[index] = {"feed": feed, "group": group}
+            next_index += 1
+
+        kind, key = classify(host)
+        payload = {"log": log_flag, "index": index}
+        if kind == "zone":
+            zone_db[key] = payload
+        else:
+            data_db[key] = payload
+
+    feed_group_db.clear()  # mirrors loader :605 -- temporary, dropped after build
+    total = len(data_db) + len(zone_db)
+    return {
+        "dataDB": data_db,
+        "zoneDB": zone_db,
+        "feedGroupIndexDB": feed_group_index_db,
+        "counts": {
+            "data": len(data_db),
+            "zone": len(zone_db),
+            "total": total,
+            "skipped": n_skipped,
+            "feedgroups": len(feed_group_index_db),
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Measurement harness.
+# --------------------------------------------------------------------------- #
+
+
+def _measure_one(lines: list[str], feeds: list[str]) -> tuple[float, int, dict[str, Any]]:
+    """One build: return (wall_seconds, peak_bytes, structures)."""
+    gc.collect()
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    t0 = time.perf_counter()
+    structures = build(lines, feeds)
+    dt = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return dt, peak, structures
+
+
+def _retained_bytes(structures: dict[str, Any]) -> int | None:
+    """Deep retained footprint of the loaded dicts (asizeof, all together)."""
+    if asizeof is None:
+        return None
+    return asizeof.asizeof(structures["dataDB"], structures["zoneDB"], structures["feedGroupIndexDB"])
+
+
+def run(n_domain_lines: int, n_runs: int) -> None:
+    print("=" * 78)
+    print(
+        "ADR-06 P1 SPIKE  Python DNSBL build cost  (CPython {}.{}, {})".format(
+            sys.version_info.major, sys.version_info.minor, sys.platform
+        )
+    )
+    print("-" * 78)
+    corpus = generate_raw_corpus(n_domain_lines)
+    print(
+        "raw corpus: total lines={:,}  domain lines={:,}  bare-IP lines={:,}  unique domains={:,}".format(
+            corpus.total_lines, corpus.n_domain_lines, corpus.n_ip_lines, corpus.n_unique_domains
+        )
+    )
+
+    times: list[float] = []
+    peaks: list[int] = []
+    last: dict[str, Any] = {}
+    for r in range(n_runs):
+        dt, peak, structures = _measure_one(corpus.lines, corpus.feeds)
+        times.append(dt)
+        peaks.append(peak)
+        last = structures
+        print(
+            "  run {}/{}: build={:.3f}s  peak={:.1f} MiB  data={:,} zone={:,} skipped={:,}".format(
+                r + 1,
+                n_runs,
+                dt,
+                peak / 2**20,
+                structures["counts"]["data"],
+                structures["counts"]["zone"],
+                structures["counts"]["skipped"],
+            )
+        )
+        del structures
+        gc.collect()
+
+    counts = last["counts"]
+    total = counts["total"]
+    retained = _retained_bytes(last)
+
+    t_min, t_med, t_max = min(times), statistics.median(times), max(times)
+    t_mean = statistics.mean(times)
+    peak_med = statistics.median(peaks)
+
+    print("-" * 78)
+    print(
+        "build wall-time (N={}):  min={:.3f}s  median={:.3f}s  mean={:.3f}s  max={:.3f}s".format(
+            n_runs, t_min, t_med, t_mean, t_max
+        )
+    )
+    print("build peak RAM:          median={:.1f} MiB  max={:.1f} MiB".format(peak_med / 2**20, max(peaks) / 2**20))
+    print(
+        "loaded entries:          {:,}  (data={:,} zone={:,} feedgroups={:,})".format(
+            total, counts["data"], counts["zone"], counts["feedgroups"]
+        )
+    )
+    if retained is not None:
+        bpe = retained / total if total else float("nan")
+        print(
+            "retained dict footprint: {:.1f} MiB  ({:.1f} B/entry vs {:.0f} B/entry baseline, {:+.0f}%)".format(
+                retained / 2**20, bpe, BASELINE_BYTES_PER_ENTRY, (bpe / BASELINE_BYTES_PER_ENTRY - 1) * 100
+            )
+        )
+    else:
+        bpe = float("nan")
+        print("retained dict footprint: (pympler not installed -- run: python -m pip install pympler)")
+
+    # ----------------------------------------------------------------------- #
+    # GATE
+    # ----------------------------------------------------------------------- #
+    print("-" * 78)
+    time_ok = t_max <= THRESH_BUILD_SECONDS
+    mem_ok = (retained is None) or (bpe <= THRESH_BYTES_PER_ENTRY)
+    net_added = t_med - SHELL_PASSES_REMOVED_SECONDS
+    print(
+        "net vs today: build {:.1f}s replaces ~{:.1f}s of removed shell passes "
+        "(sort -u + awk dedup; ggrep extra) -> net added ~{:+.1f}s".format(
+            t_med, SHELL_PASSES_REMOVED_SECONDS, net_added
+        )
+    )
+    print(
+        "threshold: build <= {:.1f}s  AND  retained <= {:.0f} B/entry".format(
+            THRESH_BUILD_SECONDS, THRESH_BYTES_PER_ENTRY
+        )
+    )
+    print("  build time  : {:.3f}s (max)  -> {}".format(t_max, "PASS" if time_ok else "FAIL"))
+    if retained is not None:
+        print("  bytes/entry : {:.1f}            -> {}".format(bpe, "PASS" if mem_ok else "FAIL"))
+    else:
+        print("  bytes/entry : (skipped, pympler absent) -> treated as PASS")
+    verdict = "GO" if (time_ok and mem_ok) else "NO-GO"
+    print("=" * 78)
+    print(
+        "VERDICT: {}  (build {:.1f}s threshold, {:.0f} B/entry threshold)".format(
+            verdict, THRESH_BUILD_SECONDS, THRESH_BYTES_PER_ENTRY
+        )
+    )
+    print("=" * 78)
+
+
+def main() -> None:
+    n_runs = int(os.environ.get("SPIKE_N", "3"))
+    sizes = [int(s) for s in os.environ.get("SPIKE_SIZES", "1000000").split(",") if s.strip()]
+    for n in sizes:
+        run(n, n_runs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -27,7 +27,7 @@ import os
 import re
 import sys
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -1602,6 +1602,420 @@ def deinit(id: int) -> bool:
 
 def inform_super(id: int, qstate: module_qstate, superqstate: module_qstate, qdata: Any) -> bool:
     return True
+
+
+# --------------------------------------------------------------------------- #
+# DNSBL build layer (ADR-06) -- pure, stdlib-only, Unbound-symbol-free.
+#
+# Moves the DNSBL list preprocessing (parse -> normalise -> classify data/zone ->
+# build dicts) out of shell/PHP into this plugin. The boundary is "shell/PHP fetch
+# + tag; Python parse -> normalise -> classify -> build dicts -> emit counts"
+# (ADR.md SS2). This phase introduces the layer and unit-tests it against the
+# Phase-2 decision oracle; it is NOT yet wired into init() (Phase 4) and removes no
+# shell/PHP (Phase 5).
+#
+# Design notes the contract pins (RESULTS/01_Results.txt, RESULTS/02_Results.txt):
+#   * Build-time OPTIMISATIONS are dropped, not reimplemented: no within/cross-feed
+#     dedup, no subdomain collapse, no build-time user-whitelist or TOP1M removal.
+#     The dict load dedups keys for free (last-wins) and redundant subdomains stay
+#     because the parent zone still matches them.
+#   * Data/zone CLASSIFICATION is kept (it is not an optimisation) and mirrors
+#     tld_analysis/tld_search exactly: a registrable parent -> wildcard ZONE; a
+#     deeper sub-domain whose parent is not a known public suffix -> exact DATA;
+#     TLD exclusion forces exact DATA; a blacklisted TLD -> a whole-TLD ZONE entry.
+#   * Whitelisting is QUERY-TIME: build() loads the user whitelist into whiteDB
+#     (input normalisation moves here) and loads the TOP1M list into whiteDB ONLY
+#     when enabled. No list pruning at build time.
+#   * IP extraction is NOT Python's job -- it stays in PHP (Phase 5). The parser
+#     SKIPS non-domain lines (bare IPs fail domain validation); it never produces
+#     firewall input.
+#   * ENTRY MODEL: every entry carries a ``kind`` tag (block | allow | regex) so the
+#     model is ABP-ready, BUT this phase produces ONLY ``block`` and still IGNORES
+#     ``@@`` exceptions, regex rules, element-hiding (``##`` / ``#@#``), path/URL
+#     rules and non-domain ``$options`` -- exactly as today. The allow/regex kinds
+#     and their query-time matching are the future ABP ADR, not here.
+#   * build() is REENTRANT: it returns a NEW structure-set and mutates no module
+#     global, so a future zero-downtime reload can run it on a background thread and
+#     atomically swap the result in (the swap itself is not built here).
+#
+# No Unbound symbol is referenced below; only the stdlib (csv) is used.
+# --------------------------------------------------------------------------- #
+
+# Entry kinds (ABP-ready seam). This phase emits ONLY BLOCK; ALLOW/REGEX are
+# shaped for the future ABP ADR and are never produced or applied here.
+DNSBL_KIND_BLOCK = "block"
+DNSBL_KIND_ALLOW = "allow"
+DNSBL_KIND_REGEX = "regex"
+
+# Classification outcomes for an entry's key.
+DNSBL_CLASS_DATA = "data"  # exact match  (loaded into dataDB)
+DNSBL_CLASS_ZONE = "zone"  # wildcard-incl-self match (loaded into zoneDB)
+
+# Lower-cased label alphabet for the domain-shape gate (mirrors PFB_FILTER_DOMAIN,
+# pfblockerng.inc:7995-8016: labels of [a-z0-9-], not edge-hyphenated, with a dot).
+_DNSBL_LABEL_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-")
+
+
+@dataclass
+class ParsedEntry:
+    """One parsed feed line, pre-normalisation.
+
+    ``kind`` is the ABP-ready tag; this phase only ever sets ``DNSBL_KIND_BLOCK``.
+    ``value`` is the raw domain token extracted from the line (not yet validated /
+    lower-cased). ``feed`` / ``group`` / ``log`` come from the per-feed manifest row.
+    """
+
+    kind: str
+    value: str
+    feed: str
+    group: str
+    log: str
+
+
+@dataclass
+class DnsblEntry:
+    """A normalised, classified blocklist entry ready to load into the matcher dicts.
+
+    ``cls`` is ``DNSBL_CLASS_DATA`` (exact) or ``DNSBL_CLASS_ZONE`` (wildcard); ``key``
+    is the registrable parent for a ZONE or the exact domain for DATA.
+    """
+
+    kind: str
+    cls: str
+    key: str
+    feed: str
+    group: str
+    log: str
+
+
+@dataclass
+class BuildResult:
+    """The structure-set build() returns -- decision-equivalent to the loader
+    contract (RESULTS/01_Results.txt SS1f). All dicts are FRESH (no module global
+    is mutated), so the result is safe to atomically swap in later.
+
+    Shapes (identical to what pfb_unbound init() loads today):
+        data_db[domain]          = {"log": <"0"|"1"|"2">, "index": <int>}
+        zone_db[registrable]     = {"log": <flag>,        "index": <int>}
+        feed_group_index_db[idx] = {"feed": <str>, "group": <str>}
+        white_db[domain]         = <bool wildcard>
+    ``counts`` is the LOADED total (len(data_db) + len(zone_db)); Phase 4 emits it as
+    pfb_py_count (its value legitimately rises -- lists are un-pruned).
+    """
+
+    data_db: dict[str, dict[str, Any]]
+    zone_db: dict[str, dict[str, Any]]
+    feed_group_index_db: dict[int, dict[str, str]]
+    white_db: dict[str, bool]
+    counts: int
+
+
+def _dnsbl_is_ipv4(token: str) -> bool:
+    """Mirror is_ipaddrv4: dotted-quad, each octet 0-255, no leading zeros.
+
+    Used only to RECOGNISE and SKIP bare-IP lines (the firewall path stays in PHP);
+    Python never emits IPs.
+    """
+    parts = token.split(".")
+    if len(parts) != 4:
+        return False
+    for p in parts:
+        if not p.isdigit() or not (0 <= int(p) <= 255) or (len(p) > 1 and p[0] == "0"):
+            return False
+    return True
+
+
+def _dnsbl_parse_abp_line(line: str) -> str | None:
+    """Current basic-ABP token-strip (pfblockerng.inc:7706-7717).
+
+    Keep ONLY a plain ``||domain^`` network line and strip the ``||`` / ``^`` tokens
+    to a bare domain. IGNORE everything else exactly as today: ``@@`` exceptions,
+    ``##`` / ``#@#`` element-hiding, ``$options``, ``*`` and ``/`` (path / regex).
+    Returns the bare domain or ``None``. (The future ABP ADR replaces this.)
+    """
+    if not line.startswith("||") or not line.endswith("^"):
+        return None
+    if "$" in line or "*" in line or "/" in line:
+        return None
+    return line[2:-1]
+
+
+def _dnsbl_strip_hosts_prefix(line: str) -> str:
+    """Hosts format: ``<sink-ip> <domain>`` -> take the domain token (inc:7899-7907).
+
+    Handles ``0.0.0.0 domain`` and ``127.0.0.1 domain``; a non-IP first token keeps
+    the chars before the space (PHP's behaviour).
+    """
+    if " " in line:
+        first, _, rest = line.partition(" ")
+        rest = rest.strip()
+        if _dnsbl_is_ipv4(first):
+            return rest
+        return first
+    return line
+
+
+def parse(format_hint: str, line: str) -> ParsedEntry | None:
+    """Parse one raw feed line into a kind-tagged block entry, or ``None`` to skip.
+
+    ``format_hint`` dispatches the per-format handler (the manifest replaces the old
+    in-loop CSV-type sniffing). This subsumes the current basic-ABP token-strip and
+    reproduces today's per-format behaviour, including which lines are IGNORED.
+
+    Bare-IP lines and the csv:pon col-0 IP are NOT returned here -- IP extraction is
+    a PHP/firewall concern (Phase 5); a stray bare IP simply yields ``None`` (and
+    would fail domain validation anyway). ``feed`` / ``group`` / ``log`` are attached
+    by build() from the manifest row, so parse() only resolves the domain token.
+
+    NOTE: the ABP-ready ``kind`` field is always ``DNSBL_KIND_BLOCK`` in this phase;
+    ``@@`` / regex / element / ``$options`` lines are dropped, not emitted as allow /
+    regex kinds (that is the future ABP ADR).
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    if format_hint == "abp":
+        # ABP control / comment lines (header, '!', '[') are dropped first.
+        if stripped.startswith("!") or stripped.startswith("["):
+            return None
+        host = _dnsbl_parse_abp_line(stripped)
+        if host is None:
+            return None
+        return ParsedEntry(kind=DNSBL_KIND_BLOCK, value=host, feed="", group="", log="")
+
+    if format_hint == "csv:pon":
+        # 9-col CSV: domain = col2 (always kept). col0 is handled by the PHP DNSBL-IP
+        # pass (Phase 5); Python ignores it here.
+        if stripped.startswith("!") or stripped.lower().startswith("timestamp"):
+            return None
+        try:
+            row = next(csv.reader([stripped]))
+        except (csv.Error, StopIteration):
+            return None
+        if len(row) != 9:
+            return None
+        domain = row[2]
+        if not domain:
+            return None
+        return ParsedEntry(kind=DNSBL_KIND_BLOCK, value=domain, feed="", group="", log="")
+
+    # hosts / plain
+    if stripped.startswith("#") or stripped.startswith("!"):
+        return None
+    token = _dnsbl_strip_hosts_prefix(stripped)
+    token = token.strip().strip(".")
+    if not token:
+        return None
+    # Bare IP -> firewall path (PHP); skipped from the domain build.
+    if _dnsbl_is_ipv4(token):
+        return None
+    return ParsedEntry(kind=DNSBL_KIND_BLOCK, value=token, feed="", group="", log="")
+
+
+def normalise(value: str) -> str | None:
+    """Lower-case + PFB_FILTER_DOMAIN domain-shape gate (inc:7995-8016).
+
+    Returns the validated, lower-cased domain or ``None`` when the token is not a
+    valid domain (which is how stray non-domain entries -- including any IP that
+    slipped past parse() -- are dropped without ever reaching the dicts).
+    """
+    host = value.strip().strip(".").lower()
+    if "." not in host:
+        return None
+    for label in host.split("."):
+        if not label or label[0] == "-" or label[-1] == "-":
+            return None
+        if any(c not in _DNSBL_LABEL_CHARS for c in label):
+            return None
+    return host
+
+
+def _dnsbl_load_tld_master(
+    suffix_lines: Iterable[str],
+    tld_blacklist: Iterable[str],
+    tld_exclusion: Iterable[str],
+) -> dict[str, dict[str, str]]:
+    """Build the public-suffix oracle tlds[tld][full-suffix] (tld_analysis:2630-2642),
+    minus any blacklisted or excluded TLD (inc:2749-2751 / 2791-2793)."""
+    blacklist = {t.strip(".") for t in tld_blacklist}
+    exclusion_keys = {e.strip(".") for e in tld_exclusion}
+    tlds: dict[str, dict[str, str]] = {}
+    for line in suffix_lines:
+        suffix = line.strip()
+        if not suffix or suffix.startswith("#"):
+            continue
+        tld = suffix.rsplit(".", 1)[-1]
+        if tld in blacklist or tld in exclusion_keys:
+            continue
+        tlds.setdefault(tld, {})[suffix] = ""
+    return tlds
+
+
+def _dnsbl_tld_search(tlds: dict[str, dict[str, str]], tld: str, dparts: list[str], j: int, k: int) -> str | None:
+    """tld_search (inc:2595-2603): if the j-label suffix is a known public suffix,
+    the registrable parent is the k-label slice."""
+    tld_query = ".".join(dparts[-j:])
+    if tld_query in tlds.get(tld, {}):
+        return ".".join(dparts[-k:])
+    return None
+
+
+def classify(domain: str, tlds: dict[str, dict[str, str]], exclusion: set[str]) -> tuple[str, str]:
+    """Return ``(DNSBL_CLASS_ZONE, registrable-parent)`` or ``(DNSBL_CLASS_DATA, domain)``.
+
+    Mirrors tld_analysis:2832-2874 exactly: a registrable parent -> wildcard ZONE; a
+    deeper sub-domain whose parent is not a known public suffix -> exact DATA; a
+    whole-domain TLD exclusion forces exact DATA (transparent, not wildcarded).
+    """
+    dparts = domain.split(".")
+    dcnt = len(dparts)
+    tld = dparts[-1]
+    dfound = ""
+
+    if dcnt > 5:
+        dfound = ""
+    elif dcnt == 5:
+        dfound = _dnsbl_tld_search(tlds, tld, dparts, 4, 5) or ""
+    elif dcnt == 4:
+        dfound = _dnsbl_tld_search(tlds, tld, dparts, 3, 4) or ""
+    elif dcnt == 3:
+        dfound = _dnsbl_tld_search(tlds, tld, dparts, 2, 3) or ""
+    elif dcnt == 2:
+        dfound = ".".join(dparts[-2:])
+
+    # TLD exclusion: whole domain in the exclusion set -> force exact DATA.
+    if domain in exclusion:
+        dfound = ""
+
+    if dfound:
+        return DNSBL_CLASS_ZONE, dfound
+    return DNSBL_CLASS_DATA, domain
+
+
+def _dnsbl_normalise_whitelist(
+    user_whitelist: Iterable[str],
+    top1m_list: Iterable[str],
+    top1m_enabled: bool,
+) -> dict[str, bool]:
+    """User-whitelist normalisation (pfb_unbound_python_whitelist, inc:2259) into the
+    query-time whiteDB shape (inc:609-619): www-strip; leading-dot -> wildcard True
+    else False. TOP1M entries are loaded ONLY when enabled (bare domains -> False).
+    No build-time list pruning -- this only populates whiteDB."""
+    white_db: dict[str, bool] = {}
+    for raw in user_whitelist:
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("www."):
+            line = line[4:]
+        if line.startswith("."):
+            white_db[line.lstrip(".")] = True
+        else:
+            white_db[line] = False
+
+    if top1m_enabled:
+        for raw in top1m_list:
+            dom = raw.strip()
+            if dom:
+                white_db.setdefault(dom, False)
+
+    return white_db
+
+
+def build(
+    manifest: dict[str, Any],
+    config: dict[str, Any],
+    *,
+    line_reader: Callable[[str], Iterable[str]],
+    top1m_enabled: bool = False,
+) -> BuildResult:
+    """Pure, reentrant DNSBL build: raw feeds + config -> matcher structure-set.
+
+    ``manifest`` is the per-feed boundary (RESULTS/01_Results.txt SS1i): one row per
+    raw feed file mapping it to ``{raw, feed, group, format_hint, log_flag}``.
+    ``config`` carries the classification + whitelist inputs (``tld_master`` suffix
+    lines, ``tld_blacklist``, ``tld_exclusion``, ``user_whitelist``, ``top1m_list``).
+    ``line_reader`` yields the raw lines for a feed's ``raw`` reference -- injected so
+    this stays pure and side-effect-free (no filesystem coupling, unit-testable; the
+    init wiring in Phase 4 supplies a file-backed reader).
+
+    Returns a FRESH ``BuildResult`` and mutates no module global -- calling it twice
+    yields equal structures (reentrant / zero-downtime-ready). It performs NO dedup,
+    NO subdomain collapse and NO build-time whitelist/TOP1M removal: duplicate keys
+    are simply overwritten last-wins by dict assignment (the documented attribution
+    change, ADR.md SS2), and redundant subdomains stay because their parent zone still
+    matches them.
+    """
+    suffix_lines = list(config.get("tld_master", []))
+    tld_blacklist = list(config.get("tld_blacklist", []))
+    tld_exclusion = list(config.get("tld_exclusion", []))
+    exclusion = {e.strip(".") for e in tld_exclusion}
+
+    tlds = _dnsbl_load_tld_master(suffix_lines, tld_blacklist, tld_exclusion)
+
+    data_db: dict[str, dict[str, Any]] = {}
+    zone_db: dict[str, dict[str, Any]] = {}
+    feed_group_index_db: dict[int, dict[str, str]] = {}
+    feed_group_db: dict[str, int] = {}
+    next_index = 0
+
+    def index_for(feed: str, group: str) -> int:
+        nonlocal next_index
+        key = feed + group
+        idx = feed_group_db.get(key)
+        if idx is None:
+            idx = next_index
+            feed_group_db[key] = idx
+            feed_group_index_db[idx] = {"feed": feed, "group": group}
+            next_index += 1
+        return idx
+
+    # Whole-TLD block: a blacklisted TLD becomes a synthetic DNSBL_TLD zone entry
+    # (inc:2740 ``,<tld>,,1,DNSBL_TLD,DNSBL_TLD``).
+    for raw_tld in tld_blacklist:
+        tld = raw_tld.strip(".")
+        if not tld:
+            continue
+        idx = index_for("DNSBL_TLD", "DNSBL_TLD")
+        zone_db[tld] = {"log": "1", "index": idx}
+
+    white_db = _dnsbl_normalise_whitelist(
+        config.get("user_whitelist", []),
+        config.get("top1m_list", []),
+        top1m_enabled,
+    )
+
+    for feed_row in manifest.get("feeds", []):
+        feed = feed_row["feed"]
+        group = feed_row["group"]
+        fmt = feed_row["format_hint"]
+        log_flag = feed_row["log_flag"]
+        for raw_line in line_reader(feed_row["raw"]):
+            entry = parse(fmt, raw_line)
+            if entry is None:
+                continue
+            domain = normalise(entry.value)
+            if domain is None:
+                continue
+            # Only BLOCK is produced this phase (ABP-ready seam; see module header).
+            if entry.kind != DNSBL_KIND_BLOCK:
+                continue
+            idx = index_for(feed, group)
+            cls, key = classify(domain, tlds, exclusion)
+            payload = {"log": log_flag, "index": idx}
+            if cls == DNSBL_CLASS_ZONE:
+                zone_db[key] = payload  # last-wins (dict; ADR-06 SS2 attribution change)
+            else:
+                data_db[key] = payload
+
+    return BuildResult(
+        data_db=data_db,
+        zone_db=zone_db,
+        feed_group_index_db=feed_group_index_db,
+        white_db=white_db,
+        counts=len(data_db) + len(zone_db),
+    )
 
 
 def iter_domain_suffixes(name: str) -> Iterator[str]:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import csv
+import json
 import logging
 import logging.handlers
 import os
@@ -324,6 +325,13 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["pfb_py_data"] = "pfb_py_data.txt"
     pfb["pfb_py_hsts"] = "pfb_py_hsts.txt"
     pfb["pfb_py_ss"] = "pfb_py_ss.txt"
+    # ADR-06: per-feed manifest (the new shell->Python boundary) and the
+    # Python-emitted entry count. When the manifest is present, init builds the
+    # DNSBL structures from the raw feeds via the pure build() layer (ADR-06 P4);
+    # otherwise it falls back to the legacy data/zone CSV load (shell/PHP still
+    # produce those files until Phase 5 removes the duplication).
+    pfb["pfb_py_sources"] = "pfb_py_sources.json"
+    pfb["pfb_py_count"] = "pfb_py_count"
     pfb["pfb_py_dnsbl"] = "pfb_py_dnsbl.sqlite"
     pfb["pfb_py_cache"] = "pfb_py_cache.sqlite"
     pfb["pfb_py_resolver"] = "pfb_py_resolver.sqlite"
@@ -532,11 +540,42 @@ def init_standard(id: int, env: module_env) -> bool:
                     sys.stderr.write("[pfBlockerNG]: Failed to load: {}: {}".format(pfb["pfb_py_zone"], e))
                     pass
 
+            # ADR-06 P4: prefer BUILDING the DNSBL structures from the raw feeds via
+            # the pure build() layer (the new shell->Python boundary). When the
+            # per-feed manifest is present, Python parses -> normalises -> classifies
+            # (data/zone) -> builds dataDB/zoneDB/feedGroupIndexDB/whiteDB and emits
+            # the entry count -- it is now the source of truth for the built
+            # structures. The legacy data/zone/whitelist CSV load below is the
+            # FALLBACK (shell/PHP still produce those files until Phase 5 removes the
+            # duplication), used only when no manifest is present. Python ignores
+            # stray IP lines and never touches the firewall/IP path (DNSBL-IP stays
+            # in PHP). The build call site is the future zero-downtime swap point;
+            # no background-thread/restart-free behaviour is added here.
+            dnsbl_built = False
+            build_result = dnsbl_build_from_manifest(pfb["pfb_py_sources"])
+            if build_result is not None:
+                # Atomic assign of the freshly-built structures into the module
+                # globals (build() mutated nothing global; this is the swap).
+                dataDB = build_result.data_db
+                zoneDB = build_result.zone_db
+                feedGroupIndexDB = build_result.feed_group_index_db
+                whiteDB = build_result.white_db
+
+                pfb["zoneDB"] = bool(zoneDB)
+                pfb["dataDB"] = bool(dataDB)
+                pfb["whiteDB"] = bool(whiteDB)
+                if dataDB or zoneDB:
+                    pfb["python_blacklist"] = True
+
+                # Emit pfb_py_count (the LOADED total) for the UI (inc:3149).
+                dnsbl_emit_count(pfb["pfb_py_count"], build_result.counts)
+                dnsbl_built = True
+
             # While reading 'data|zone' CSV files: Replace 'Feed/Group' pairs with an index value (Memory performance)
             feedGroup_index = 0
 
             # Zone dicts
-            if os.path.isfile(pfb["pfb_py_zone"]):
+            if not dnsbl_built and os.path.isfile(pfb["pfb_py_zone"]):
                 try:
                     with open(pfb["pfb_py_zone"]) as csv_file:
                         csv_reader = csv.reader(csv_file, delimiter=",")
@@ -569,7 +608,7 @@ def init_standard(id: int, env: module_env) -> bool:
                     pass
 
             # Data dicts
-            if os.path.isfile(pfb["pfb_py_data"]):
+            if not dnsbl_built and os.path.isfile(pfb["pfb_py_data"]):
                 try:
                     with open(pfb["pfb_py_data"]) as csv_file:
                         csv_reader = csv.reader(csv_file, delimiter=",")
@@ -605,8 +644,9 @@ def init_standard(id: int, env: module_env) -> bool:
             feedGroupDB.clear()
 
             if pfb["python_blacklist"]:
-                # Collect user-defined Whitelist
-                if os.path.isfile(pfb["pfb_py_whitelist"]):
+                # Collect user-defined Whitelist (legacy CSV path -- the build()
+                # already loaded whiteDB from the manifest config when dnsbl_built).
+                if not dnsbl_built and os.path.isfile(pfb["pfb_py_whitelist"]):
                     try:
                         with open(pfb["pfb_py_whitelist"]) as csv_file:
                             csv_reader = csv.reader(csv_file, delimiter=",")
@@ -2016,6 +2056,122 @@ def build(
         white_db=white_db,
         counts=len(data_db) + len(zone_db),
     )
+
+
+def _dnsbl_file_line_reader(base_dir: str) -> Callable[[str], Iterable[str]]:
+    """A file-backed ``line_reader`` for build(): map a feed_row["raw"] reference to
+    its raw lines, streamed lazily so peak RAM stays at the dict floor (RESULTS/01).
+
+    ``raw`` may be an absolute path or a name relative to ``base_dir`` (the directory
+    holding the manifest). Yields stripped-of-newline lines; a missing/unreadable feed
+    yields nothing (and is logged by the caller) rather than aborting the whole build.
+    """
+
+    def reader(raw: str) -> Iterable[str]:
+        path = raw if os.path.isabs(raw) else os.path.join(base_dir, raw)
+        try:
+            fh = open(path, encoding="utf-8", errors="replace")
+        except OSError as e:
+            # A single missing/unreadable feed is logged and skipped -- it must not
+            # abort the whole build (the other feeds still load).
+            sys.stderr.write("[pfBlockerNG]: Failed to read DNSBL feed '{}': {}".format(path, e))
+            return
+        with fh:
+            for line in fh:
+                yield line.rstrip("\r\n")
+
+    return reader
+
+
+def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict[str, Any]:
+    """Shape the manifest's ``config`` block into the build() config blob.
+
+    The on-box manifest carries ``tld_master`` as a FILE PATH (the public-suffix
+    oracle); the build takes the suffix LINES directly (pure, filesystem-decoupled),
+    so read the file here. ``tld_blacklist`` / ``tld_exclusion`` / ``user_whitelist``
+    / ``top1m_list`` are passed through as lists. Missing keys default empty so a
+    partial manifest still builds.
+    """
+    config = manifest.get("config", {})
+
+    tld_master_lines: list[str] = []
+    tld_master = config.get("tld_master")
+    if isinstance(tld_master, list):
+        tld_master_lines = list(tld_master)
+    elif isinstance(tld_master, str) and tld_master:
+        path = tld_master if os.path.isabs(tld_master) else os.path.join(base_dir, tld_master)
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                tld_master_lines = fh.read().splitlines()
+        except OSError as e:
+            sys.stderr.write("[pfBlockerNG]: Failed to read tld_master '{}': {}".format(path, e))
+
+    return {
+        "tld_master": tld_master_lines,
+        "tld_blacklist": list(config.get("tld_blacklist", [])),
+        "tld_exclusion": list(config.get("tld_exclusion", [])),
+        "user_whitelist": list(config.get("user_whitelist", [])),
+        "top1m_list": list(config.get("top1m_list", [])),
+    }
+
+
+def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
+    """Read the per-feed manifest JSON and BUILD the DNSBL structure-set from raw.
+
+    This is the ADR-06 P4 init swap point: a pure ``(manifest+raw) -> BuildResult``
+    step (build() mutates no global) that a future zero-downtime reload can run on a
+    background thread and atomically swap in. This phase only calls it synchronously
+    at init and assigns the result into the module globals -- no background/restart-
+    free behaviour is added here.
+
+    The manifest carries ``feeds`` (one row per raw feed file) and a ``config`` block
+    (RESULTS/01 SS2). ``top1m_enabled`` is taken from ``config["top1m_enabled"]``.
+    Returns ``None`` when the manifest is absent or cannot be parsed (init then falls
+    back to the legacy CSV load -- shell/PHP still produce those files until Phase 5).
+    """
+    if not os.path.isfile(manifest_path):
+        return None
+
+    try:
+        with open(manifest_path, encoding="utf-8") as fh:
+            manifest = json.load(fh)
+    except (OSError, ValueError) as e:
+        sys.stderr.write("[pfBlockerNG]: Failed to load DNSBL manifest '{}': {}".format(manifest_path, e))
+        return None
+
+    base_dir = os.path.dirname(os.path.abspath(manifest_path))
+    config = _dnsbl_config_from_manifest(manifest, base_dir)
+    top1m_enabled = bool(manifest.get("config", {}).get("top1m_enabled", False))
+
+    try:
+        return build(
+            manifest,
+            config,
+            line_reader=_dnsbl_file_line_reader(base_dir),
+            top1m_enabled=top1m_enabled,
+        )
+    except Exception as e:
+        sys.stderr.write("[pfBlockerNG]: Failed to build DNSBL structures from raw: {}".format(e))
+        return None
+
+
+def dnsbl_emit_count(count_path: str, count: int) -> bool:
+    """Write the Python-emitted entry total to ``pfb_py_count`` (the UI reads it at
+    pfblockerng.inc:3149).
+
+    ADR-06 redefines ``pfb_py_count`` to the LOADED entry total (len(dataDB)+len(
+    zoneDB)); its value legitimately RISES vs today because the lists are no longer
+    dedup/collapse/whitelist/TOP1M-pruned (RESULTS/01 SS1e). The sync-check at
+    inc:3149-3156 still subtracts this value -- it must be reconciled when shell/PHP
+    is slimmed (Phase 5); flagged in the handoff. Returns True on success.
+    """
+    try:
+        with open(count_path, "w", encoding="utf-8") as fh:
+            fh.write("{}\n".format(count))
+        return True
+    except OSError as e:
+        sys.stderr.write("[pfBlockerNG]: Failed to write DNSBL count '{}': {}".format(count_path, e))
+        return False
 
 
 def iter_domain_suffixes(name: str) -> Iterator[str]:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1650,9 +1650,9 @@ def inform_super(id: int, qstate: module_qstate, superqstate: module_qstate, qda
 # Moves the DNSBL list preprocessing (parse -> normalise -> classify data/zone ->
 # build dicts) out of shell/PHP into this plugin. The boundary is "shell/PHP fetch
 # + tag; Python parse -> normalise -> classify -> build dicts -> emit counts"
-# (ADR.md SS2). This phase introduces the layer and unit-tests it against the
-# Phase-2 decision oracle; it is NOT yet wired into init() (Phase 4) and removes no
-# shell/PHP (Phase 5).
+# (ADR.md SS2). The layer is wired into init() via dnsbl_build_from_manifest()
+# (Phase 4), and the duplicated shell/PHP preprocessing has since been removed
+# (Phase 5); decision-equivalence is pinned against the Phase-2 oracle.
 #
 # Design notes the contract pins (RESULTS/01_Results.txt, RESULTS/02_Results.txt):
 #   * Build-time OPTIMISATIONS are dropped, not reimplemented: no within/cross-feed

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2361,6 +2361,10 @@ function pfb_unbound_python_sources($feeds) {
 		// (IPs went to the firewall path) and already cleaned/validated by the loop.
 		$rawpath	= "{$pfb['unbound_py_rawdir']}/{$header}.raw";
 		$raw_h		= @fopen($rawpath, 'w');
+		if ($raw_h === FALSE) {
+			pfb_logger("\nFailed to create DNSBL python raw feed [ {$rawpath} ]", 2);
+			continue;
+		}
 		if (($in_h = @fopen($src, 'r')) !== FALSE) {
 			while (($line = @fgets($in_h)) !== FALSE) {
 				$cols = explode(',', $line, 3);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -111,6 +111,8 @@ $pfb['unbound_py_data']	= '/var/unbound/pfb_py_data.txt';
 $pfb['unbound_py_zone'] = '/var/unbound/pfb_py_zone.txt';
 $pfb['unbound_py_ss']	= '/var/unbound/pfb_py_ss.txt';
 $pfb['unbound_py_count']= '/var/unbound/pfb_py_count';
+$pfb['unbound_py_sources']= '/var/unbound/pfb_py_sources.json';	// ADR-06: per-feed manifest consumed by pfb_unbound.py init
+$pfb['unbound_py_rawdir']= '/var/unbound/pfb_py_raw';		// ADR-06: per-feed IP-stripped raw feeds referenced by the manifest
 
 $pfb['dnsbl_safesearch']		= '/usr/local/pkg/pfblockerng/pfb_dnsbl.safesearch.conf';
 $pfb['dnsbl_youtube_restrict']		= '/usr/local/pkg/pfblockerng/pfb_dnsbl.youtube_restrict.conf';
@@ -2293,6 +2295,172 @@ function pfb_unbound_python_whitelist($mode='') {
 }
 
 
+// ADR-06: Collect the user DNSBL whitelist as a normalised list of source lines
+// for the Python build manifest (config.user_whitelist). The Python build performs
+// the www-strip / leading-dot->wildcard normalisation itself (pfb_unbound.py
+// _dnsbl_normalise_whitelist), so this hands the RAW suppression lines through.
+function pfb_dnsbl_whitelist_lines() {
+	global $pfb;
+
+	$lines = pfbng_text_area_decode($pfb['dnsblconfig']['suppression'], TRUE, FALSE, TRUE);
+	$out = array();
+	if (!empty($lines)) {
+		foreach ($lines as $line) {
+			$line = trim($line);
+			if ($line !== '') {
+				$out[] = $line;
+			}
+		}
+	}
+	return $out;
+}
+
+
+// ADR-06: Build the shell->Python contract. Writes the per-feed manifest
+// ($pfb['unbound_py_sources']) plus a per-feed IP-stripped raw file (one bare,
+// lower-cased domain per line) referenced by the manifest. The Python plugin's
+// init (pfb_unbound.py dnsbl_build_from_manifest) consumes this to build the
+// DNSBL structures from raw -- replacing the previous data/zone CSV load.
+//
+// The per-feed raw is the bare-domain extraction of the already-parsed per-feed
+// '.txt' (col1 of the 6-col CSV produced by the download loop). The download loop
+// already routes embedded IPs to the firewall '*_v4.ip' path and excludes them
+// from '.txt', so the raw handed to Python carries NO bare-IP lines (ADR-06 §3b;
+// Python would ignore stray IPs anyway). format_hint is 'plain' for every feed:
+// PHP has already done all per-format extraction (hosts/CSV/basic-ABP/IDN), so
+// Python only revalidates + lower-cases the bare domains -- decision-equivalent.
+//
+// $feeds: array of rows [ 'header' => <feed>, 'group' => <alias>, 'log' => <flag> ].
+function pfb_unbound_python_sources($feeds) {
+	global $pfb;
+
+	if (!is_array($feeds)) {
+		$feeds = array();
+	}
+
+	// Per-feed raw directory (recreated each build)
+	rmdir_recursive("{$pfb['unbound_py_rawdir']}");
+	safe_mkdir("{$pfb['unbound_py_rawdir']}");
+
+	$manifest_feeds = array();
+	foreach ($feeds as $feed) {
+		$header	= isset($feed['header']) ? $feed['header'] : '';
+		$group	= isset($feed['group'])  ? $feed['group']  : '';
+		$logf	= isset($feed['log'])    ? (string) $feed['log'] : '1';
+
+		if ($header === '') {
+			continue;
+		}
+
+		$src	= "{$pfb['dnsdir']}/{$header}.txt";
+		if (!file_exists($src)) {
+			continue;
+		}
+
+		// Extract bare domains (col1) from the 6-col CSV; this is already IP-free
+		// (IPs went to the firewall path) and already cleaned/validated by the loop.
+		$rawpath	= "{$pfb['unbound_py_rawdir']}/{$header}.raw";
+		$raw_h		= @fopen($rawpath, 'w');
+		if (($in_h = @fopen($src, 'r')) !== FALSE) {
+			while (($line = @fgets($in_h)) !== FALSE) {
+				$cols = explode(',', $line, 3);
+				if (isset($cols[1]) && $cols[1] !== '') {
+					@fwrite($raw_h, "{$cols[1]}\n");
+				}
+			}
+			@fclose($in_h);
+		}
+		if ($raw_h) {
+			@fclose($raw_h);
+		}
+
+		$manifest_feeds[] = array(
+			'raw'		=> $rawpath,
+			'feed'		=> $header,
+			'group'		=> $group,
+			'format_hint'	=> 'plain',
+			'log_flag'	=> $logf
+		);
+	}
+
+	// Synthetic whole-TLD blacklist feed (DNSBL_TLD): the Python build emits these
+	// as whole-TLD ZONE entries from config.tld_blacklist, so no raw file is needed.
+
+	// TOP1M (Alexa/Tranco) popularity whitelist -> query-time whiteDB only when on.
+	$top1m_enabled	= ($pfb['dnsbl_alexa'] == 'on' &&
+			   file_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt"));
+	$top1m_list	= array();
+	if ($top1m_enabled) {
+		$alexa = @file("{$pfb['dbdir']}/pfbalexawhitelist.txt", FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		if (is_array($alexa)) {
+			$top1m_list = $alexa;
+		}
+	}
+
+	$tld_blacklist	= pfbng_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE) ?: array();
+	$tld_exclusion	= pfbng_text_area_decode($pfb['dnsblconfig']['tldexclusion'], TRUE, FALSE, TRUE) ?: array();
+
+	$manifest = array(
+		'version'	=> 1,
+		'config'	=> array(
+			'tld_master'	=> $pfb['dnsbl_tld_data'],
+			'tld_blacklist'	=> array_values($tld_blacklist),
+			'tld_exclusion'	=> array_values($tld_exclusion),
+			'user_whitelist'=> pfb_dnsbl_whitelist_lines(),
+			'top1m_list'	=> array_values($top1m_list),
+			'top1m_enabled'	=> $top1m_enabled
+		),
+		'feeds'		=> $manifest_feeds
+	);
+
+	$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+	if ($json !== FALSE) {
+		@file_put_contents($pfb['unbound_py_sources'], $json, LOCK_EX);
+		@chown($pfb['unbound_py_sources'], 'unbound');
+		@chgrp($pfb['unbound_py_sources'], 'unbound');
+	}
+
+	return $manifest;
+}
+
+
+// ADR-06: Update only the manifest's config.user_whitelist in place (used by the
+// alerts "add to whitelist" button, which changes the suppression config without a
+// full feed re-enumeration). The query-time whiteDB is rebuilt from this on reload.
+function pfb_unbound_python_sources_whitelist() {
+	global $pfb;
+
+	if (!file_exists($pfb['unbound_py_sources'])) {
+		return FALSE;
+	}
+
+	$json = @file_get_contents($pfb['unbound_py_sources']);
+	if ($json === FALSE) {
+		return FALSE;
+	}
+
+	$manifest = json_decode($json, TRUE);
+	if (!is_array($manifest)) {
+		return FALSE;
+	}
+
+	if (!isset($manifest['config']) || !is_array($manifest['config'])) {
+		$manifest['config'] = array();
+	}
+	$manifest['config']['user_whitelist'] = pfb_dnsbl_whitelist_lines();
+
+	$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+	if ($json !== FALSE) {
+		@file_put_contents($pfb['unbound_py_sources'], $json, LOCK_EX);
+		@chown($pfb['unbound_py_sources'], 'unbound');
+		@chgrp($pfb['unbound_py_sources'], 'unbound');
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
+
 // Unbound python configuration file
 function pfb_unbound_python($mode) {
 	global $pfb;
@@ -2342,6 +2510,11 @@ function pfb_unbound_python($mode) {
 		if ($dnsbl_whitelist !== $pfb_py_whitelist_ex) {
 			$pfbpython = TRUE;
 			@file_put_contents($pfb['unbound_py_wh'], $dnsbl_whitelist, LOCK_EX);
+
+			// ADR-06: keep the manifest's config.user_whitelist (the source for the
+			// query-time whiteDB) in sync with a settings-textarea whitelist edit, so
+			// the change applies even when no feed update rewrites the full manifest.
+			pfb_unbound_python_sources_whitelist();
 		}
 
 		if (!isset($tld_segments)) {
@@ -2621,8 +2794,6 @@ function tld_analysis() {
 
 	unlink_if_exists("{$pfb['dnsbl_file']}.tsp");
 	unlink_if_exists("{$pfb['dnsbl_tld_txt']}.*");
-	unlink_if_exists("{$pfb['dnsbl_tld_remove']}.tsp");
-	unlink_if_exists("{$pfb['dnsbl_tld_remove']}");
 	unlink_if_exists("{$pfb['dnsbl_tmp']}.sup");
 	unlink_if_exists("{$pfb['dnsbl_tmp']}.adup");
 
@@ -2645,15 +2816,14 @@ function tld_analysis() {
 		return;
 	}
 
-	// DNSBL python - create file handles for data, zone, and remove files
+	// DNSBL python - create file handles for data and zone files
 	$p_data = @fopen("{$pfb['unbound_py_data']}.raw", 'w');
 	$p_zone = @fopen("{$pfb['unbound_py_zone']}.raw", 'w');
-	$p_tsp = @fopen("{$pfb['dnsbl_tld_remove']}", 'w');
 
-	if ($p_data === FALSE || $p_zone === FALSE || $p_tsp === FALSE) {
+	if ($p_data === FALSE || $p_zone === FALSE) {
 
-		pfb_logger("\nFailed to create DNSBL python data|zone|remove file handles! Exiting\n", 1);
-		foreach (array($p_data, $p_zone, $p_tsp) as $handlex) {
+		pfb_logger("\nFailed to create DNSBL python data|zone file handles! Exiting\n", 1);
+		foreach (array($p_data, $p_zone) as $handlex) {
 			if ($handlex) {
 				@fclose($handlex);
 			}
@@ -2667,53 +2837,10 @@ function tld_analysis() {
 		$tld_blacklist = array_flip($tld_blacklist);
 	}
 
-	// Collect TLD Whitelist(s). If configured, create a 'static local-zone' Resolver entry (Not required for python mode blocking)
-	$whitelist = array();
-
-
-	$extdns_esc = escapeshellarg("@{$pfb['extdns']}");
-
-	if (!empty($tld_blacklist) && !empty($whitelist)) {
-		foreach ($whitelist as $domain) {
-
-			// Use user-defined IP address
-			if (strpos($domain, '|') !== FALSE) {
-				list($domain, $resolved_host) = array_map('trim', explode('|', $domain));
-			}
-
-			// Resolve Domain IP address
-			else {
-				$domain_esc = escapeshellarg($domain);
-				$resolved_host = exec("/usr/bin/drill {$extdns_esc} {$domain_esc} | grep -v '^;\|^\$' | head -1 | cut -f5 2>&1");
-			}
-
-			$tld = '';
-			if (strpos($domain, '.') !== FALSE && is_ipaddr($resolved_host)) {
-				$dparts = explode('.', $domain);
-				$dcnt	= count($dparts);
-				$tld	= end($dparts);
-
-				for ($i=($dcnt-1); $i > 0; $i--) {
-					$d_query = implode('.', array_slice($dparts, -$i, $i, TRUE));
-					if (isset($tlds[$tld][$d_query])) {
-						$tld = $d_query;
-						break;
-					}
-				}
-			}
-
-			$resolved_host = pfb_filter($resolved_host, PFB_FILTER_IP, 'tld_analysis');
-			if (!empty($tld) && !empty($resolved_host)) {
-				if (!is_array($tld_whitelist[$tld])) {
-					$tld_whitelist[$tld] = array();
-				}
-				$tld_whitelist[$tld][] = array($domain, $resolved_host);
-				pfb_logger(" TLD Whitelist {$domain}|{$resolved_host}\n", 1);
-			} elseif (!empty($resolved_host)) {
-				pfb_logger("\n TLD Whitelist - Missing data | {$domain} | {$resolved_host} |\n", 1);
-			}
-		}
-	}
+	// ADR-06: The native-mode 'static local-zone' TLD-whitelist resolver block
+	// (drill-resolve a whitelisted domain to a user/real IP) was a leftover from
+	// the removed native Unbound mode -- '$whitelist' was always empty and it is
+	// not required for python-mode blocking. It has been removed.
 
 	// Process TLD Blacklist(s). If configured the whole TLD will be blocked
 	if (!empty($tld_blacklist)) {
@@ -2736,9 +2863,6 @@ function tld_analysis() {
 
 			pfb_logger("{$tld}|", 1);
 			@fwrite($p_zone, ",{$tld},,1,DNSBL_TLD,DNSBL_TLD\n");
-
-			// Add TLD to remove file
-			@fwrite($p_tsp, ".{$tld},,\n");
 
 			// Collect List of TLDs and save to DNSBL folder
 			$tld_list .= ",{$tld},,\n";
@@ -2794,11 +2918,7 @@ function tld_analysis() {
 
 	pfb_logger("TLD analysis", 1);
 
-	// [ $pfb['dnsbl_file']}.tsp	] Final DNSBL output file (using 'transparent' zone)
-	// [ $pfb['dnsbl_tld_remove']	] File of Sub-Domains to be removed (from 'redirect' zone)
-
-	// DNSBL Unbound: Analyse DNSBL: 1) 'redirect' zone for whole Domain 2) 'transparent' zone only
-	// DNSBL python: Analyse DNSBL into local and zone files
+	// DNSBL python: Analyse DNSBL into data (transparent/exact) and zone (wildcard) files
 
 	if (($fhandle = @fopen("{$pfb['dnsbl_file']}.raw", 'r')) !== FALSE) {
 		while (($line = @fgets($fhandle)) !== FALSE) {
@@ -2860,9 +2980,6 @@ function tld_analysis() {
 
 				// DNSBL python blocking mode
 				@fwrite($p_zone, ",{$dfound},{$d_info}");
-
-				// TLD remove files - See below for description
-				@fwrite($p_tsp, ".{$dfound},,\n");
 			}
 
 			// Create 'transparent zone' for Sub-Domain
@@ -2876,7 +2993,7 @@ function tld_analysis() {
 		}
 	}
 
-	foreach (array($fhandle, $p_data, $p_zone, $p_tsp) as $handlex) {
+	foreach (array($fhandle, $p_data, $p_zone) as $handlex) {
 		if ($handlex) {
 			@fclose($handlex);
 		}
@@ -2893,8 +3010,16 @@ function tld_analysis() {
 		$log .= "TLD finalize";
 		pfb_logger("{$log}", 1);
 
-		// Execute Domain De-duplication
-		exec("{$pfb['script']} domaintldpy >> {$pfb['log']} 2>&1");
+		// ADR-06: The shell domaintldpy pass (sort -u dedup + subdomain COLLAPSE via
+		// ggrep -vF dnsbl_tld_remove + pfb_py_count write) is DROPPED -- the Python
+		// dict load dedups keys for free and a redundant sub-domain is matched by its
+		// parent zone, so no collapse is needed. Promote the classified .raw files to
+		// their final paths directly; Python emits pfb_py_count itself at load.
+		foreach (array($pfb['unbound_py_data'], $pfb['unbound_py_zone']) as $py_final) {
+			if (file_exists("{$py_final}.raw")) {
+				@rename("{$py_final}.raw", $py_final);
+			}
+		}
 		pfb_logger("\nTLD finalize... completed [ NOW ]\n", 1);
 
 		// Update DNSBL Alias and Widget Stats
@@ -3143,15 +3268,15 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 
 	$dnsbl_cnt = exec("/bin/cat {$pfb['dnsdir']}/*.txt | {$pfb['grep']} -c ^ 2>&1");
 
-	// Unbound blocking mode enabled
-	$tld_cnt = @file_get_contents($pfb['unbound_py_count']);
-	$dnsbl_cnt = $dnsbl_cnt - $tld_cnt;
-	$final_cnt = exec("/usr/bin/find {$pfb['unbound_py_data']} {$pfb['unbound_py_zone']} -type f 2>/dev/null | xargs cat | {$pfb['grep']} -c ^ 2>&1");
-	if ($final_cnt == $dnsbl_cnt) {
-		$log = "\nDNSBL update [ {$final_cnt} | PASSED  ]... completed [ NOW ]";
-	} else {
-		$log = "\n*** DNSBL update [ {$final_cnt} ] [ {$dnsbl_cnt} ] ... OUT OF SYNC ! *** [ NOW ]";
-	}
+	// ADR-06: pfb_py_count is now Python-emitted and means the LOADED entry total
+	// (len(dataDB)+len(zoneDB)), written by pfb_unbound.py dnsbl_emit_count(). The
+	// lists are no longer dedup/collapse/whitelist/TOP1M-pruned at build time, so
+	// this value legitimately differs from (and is typically >=) the raw '*.txt'
+	// feed line count. The old subtract-and-compare sync-check (which assumed the
+	// count meant 'entries removed by subdomain collapse') no longer applies; just
+	// report both numbers for visibility.
+	$loaded_cnt = trim((string) @file_get_contents($pfb['unbound_py_count']));
+	$log = "\nDNSBL update [ feed lines: {$dnsbl_cnt} | loaded entries: {$loaded_cnt} ]... completed [ NOW ]";
 	pfb_logger("{$log}", 1);
 
 	// Clear work files
@@ -7050,6 +7175,7 @@ function sync_package_pfblockerng($cron='') {
 	$pfb['tld_update']		= array();	// Array of all DNSBL Aliases/Feeds used for TLD Function
 	$pfb['domain_update']		= FALSE;	// Flag to signal update Unbound
 	$pfb['updateip']		= FALSE;	// Flag to signal updates to DNSBL IP lists
+	$pfb_py_feeds			= array();	// ADR-06: per-feed manifest rows [header,group,log] for pfb_unbound_python_sources()
 
 	$dnsbl_error = FALSE;
 	if ($pfb['enable'] == 'on' && $pfb['dnsbl'] == 'on' && !$pfb['save']) {
@@ -7605,6 +7731,7 @@ function sync_package_pfblockerng($cron='') {
 								// Collect existing list stats
 								$lists_dnsbl_all[]	= "{$row['header']}.txt";
 								$lists_dnsbl_current[]	= "{$row['header']}";
+								$pfb_py_feeds[]		= array('header' => $header, 'group' => $alias, 'log' => $logging_type);
 								$file_esc		= escapeshellarg("{$pfbfolder}/{$header}.txt");
 								$list_cnt		= exec("{$pfb['grep']} -c ^ {$file_esc}");
 								$alias_cnt		= $alias_cnt + $list_cnt;
@@ -8082,20 +8209,12 @@ function sync_package_pfblockerng($cron='') {
 
 									pfb_logger(".\n", 1);
 
-									// Bypass TOP1M whitelist, if user configured
-									$pfb_alexa = 'Disabled';
-									if ($pfb['dnsbl_alexa'] == 'on' &&
-									    $list['filter_alexa'] == 'on' &&
-									    file_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt")) {
-										$pfb_alexa = 'on';
-									}
-
-									// DNSBL python requires a different deduplication process
-									$dup_mode = '';
-									$dup_mode = 'python';
-
-									// Call script to process DNSBL 'De-Duplication / Whitelisting / TOP1M Whitelisting'
-									exec("{$pfb['script']} dnsbl_scrub {$header_esc} {$pfb_alexa} {$dup_mode} {$elog}");
+									// ADR-06: The build-time De-Duplication / user-whitelist /
+									// TOP1M removal passes (dnsbl_scrub) are DROPPED. The Python
+									// dict load dedups keys for free, the user whitelist + TOP1M
+									// are applied at QUERY TIME via the whiteDB, and redundant
+									// subdomains are matched by their parent zone -- so no
+									// build-time list pruning is performed here anymore.
 
 									if ($ip_cnt > 0) {
 										pfb_logger("  IPv4 count={$ip_cnt}\n", 1);
@@ -8126,6 +8245,7 @@ function sync_package_pfblockerng($cron='') {
 								$pfb['domain_update']	= $pfb['aliasupdate'] = $pfb['summary'] = TRUE;
 								$lists_dnsbl_all[]	= "{$row['header']}.txt";
 								$lists_dnsbl_current[]	= "{$row['header']}";
+								$pfb_py_feeds[]		= array('header' => $header, 'group' => $alias, 'log' => $logging_type);
 
 								// Rename newly downloaded file to final location
 								if (file_exists("{$pfbfolder}/{$header}.bk")) {
@@ -8315,6 +8435,12 @@ function sync_package_pfblockerng($cron='') {
 				unlink_if_exists($pfb['unbound_py_count']);
 				rename("{$pfb['dnsbl_file']}.raw", $pfb['unbound_py_data']);
 			}
+
+			// ADR-06: Write the per-feed manifest + IP-stripped raw that the Python
+			// plugin's init builds the DNSBL structures from. Python then owns
+			// parse/normalise/classify (the dropped shell/PHP passes) and emits
+			// pfb_py_count itself.
+			pfb_unbound_python_sources($pfb_py_feeds);
 		}
 
 		else {
@@ -8335,6 +8461,8 @@ function sync_package_pfblockerng($cron='') {
 				unlink_if_exists($pfb['unbound_py_zone']);
 				unlink_if_exists($pfb['unbound_py_wh']);
 				unlink_if_exists($pfb['unbound_py_count']);
+				unlink_if_exists($pfb['unbound_py_sources']);
+				rmdir_recursive("{$pfb['unbound_py_rawdir']}");
 			}
 		}
 		else {
@@ -8344,6 +8472,8 @@ function sync_package_pfblockerng($cron='') {
 					@unlink($pfb_file);
 				}
 			}
+			unlink_if_exists($pfb['unbound_py_sources']);
+			rmdir_recursive("{$pfb['unbound_py_rawdir']}");
 		}
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -41,8 +41,8 @@ pathasndat="/usr/local/share/GeoIP/asn.mmdb"
 pathasncsv="/usr/local/share/GeoIP/asn.csv"
 pathasntable="/usr/local/www/pfblockerng/pfblockerng_asn.txt"
 pfbsuppression=/var/db/pfblockerng/pfbsuppression.txt
-pfbdnsblsuppression=/var/db/pfblockerng/pfbdnsblsuppression.txt
-pfbalexa=/var/db/pfblockerng/pfbalexawhitelist.txt
+# ADR-06: pfbdnsblsuppression / pfbalexa removed (only used by the dropped
+# dnsbl_scrub build-time whitelist/TOP1M removal; now applied at query time).
 masterfile=/var/db/pfblockerng/masterfile
 mastercat=/var/db/pfblockerng/mastercat
 geoiplog=/var/log/pfblockerng/geoip.log
@@ -75,14 +75,9 @@ dedupfile=/tmp/pfbtemp4_$rvar
 addfile=/tmp/pfbtemp5_$rvar
 matchfile=/tmp/pfbtemp7_$rvar
 tempmatchfile=/tmp/pfbtemp8_$rvar
-domainmaster=/tmp/pfbtemp9_$rvar
 
-dnsbl_tld_remove=/tmp/dnsbl_tld_remove
-
-
-dnsbl_python_data=/var/unbound/pfb_py_data.txt
-dnsbl_python_zone=/var/unbound/pfb_py_zone.txt
-dnsbl_python_count=/var/unbound/pfb_py_count
+# ADR-06: domainmaster / dnsbl_tld_remove / dnsbl_python_{data,zone,count} removed
+# along with dnsbl_scrub + domaintldpy (the dropped build-time DNSBL passes).
 
 ip_placeholder="$(/usr/local/sbin/read_xml_tag.sh string installedpackages/pfblockerngipsettings/config/ip_placeholder)"
 if [ -z "${ip_placeholder}" ]; then
@@ -353,175 +348,14 @@ duplicate() {
 
 
 
-# Function for DNSBL (De-Duplication, Whitelist, and Alexa Whitelist)
-dnsbl_scrub() {
-
-	counto="$(grep -c ^ "${pfbdomain}${alias}.bk")"
-	alexa_enable="${max}"
-
-	# Process De-Duplication
-	sort -u "${pfbdomain}${alias}.bk" > "${pfbdomain}${alias}.bk2"
-	countu="$(grep -c ^ "${pfbdomain}${alias}.bk2")"
-
-	if [ -d "${pfbdomain}" ] && [ "$(ls -A ${pfbdomain}*.txt 2>/dev/null)" ]; then
-		find "${pfbdomain}"*.txt ! -name "${alias}.txt" | xargs cat > "${domainmaster}"
-
-		# Only execute awk command, if master domain file contains data.
-		query_size="$(grep -c ^ "${domainmaster}")"
-		if [ "${query_size}" -gt 0 ]; then
-
-			# Unbound blocking mode dedup
-			if [ "${dedup}" = '' ]; then
-				awk 'FNR==NR{a[$2];next}!($2 in a)' "${domainmaster}" "${pfbdomain}${alias}.bk2" > "${pfbdomain}${alias}.bk"
-
-			# Unbound python blocking mode dedup
-			else
-				awk -F',' 'FNR==NR{a[$2];next}!($2 in a)' "${domainmaster}" "${pfbdomain}${alias}.bk2" > "${pfbdomain}${alias}.bk"
-			fi
-		fi
-
-		rm -f "${domainmaster}"
-	else
-		mv -f "${pfbdomain}${alias}.bk2" "${pfbdomain}${alias}.bk"
-	fi
-
-	countf="$(grep -c ^ "${pfbdomain}${alias}.bk")"
-	countd="$((countu - countf))"
-	rm -f "${pfbdomain}${alias}.bk2"
-
-	# Remove Whitelisted Domains and Sub-Domains, if configured
-	if [ -s "${pfbdnsblsuppression}" ] && [ -s "${pfbdomain}${alias}.bk" ]; then
-		/usr/local/bin/ggrep -vF -f "${pfbdnsblsuppression}" "${pfbdomain}${alias}.bk" > "${pfbdomain}${alias}.bk2"
-		countx="$(grep -c ^ "${pfbdomain}${alias}.bk2")"
-		countw="$((countf - countx))"
-
-		if [ "${countw}" -gt 0 ]; then
-			if [ "${dedup}" = '' ]; then
-				data="$(awk 'FNR==NR{a[$0];next}!($0 in a)' "${pfbdomain}${alias}.bk2" "${pfbdomain}${alias}.bk" | \
-					cut -d '"' -f2 | cut -d ' ' -f1 | sort -u | tr '\n' '|')"
-			else
-				data="$(awk 'FNR==NR{a[$0];next}!($0 in a)' "${pfbdomain}${alias}.bk2" "${pfbdomain}${alias}.bk" | \
-					cut -d ',' -f2 | sort -u | tr '\n' '|')"
-			fi
-
-			if [ -z "${data}" ]; then
-				if [ "${dedup}" = '' ]; then
-					data="$(cut -d '"' -f2 "${pfbdomain}${alias}.bk" | cut -d ' ' -f1 | sort -u | tr '\n' '|')"
-				else
-					data="$(cut -d ',' -f2 "${pfbdomain}${alias}.bk" | sort -u | tr '\n' '|')"
-				fi
-			fi
-
-			echo "  Whitelist: ${data}"
-			mv -f "${pfbdomain}${alias}.bk2" "${pfbdomain}${alias}.bk"
-		fi
-	else
-		countw=0
-	fi
-
-	# Process TOP1M Whitelist
-	if [ "${alexa_enable}" = "on" ] && [ -s "${pfbalexa}" ] && [ -s "${pfbdomain}${alias}.bk" ]; then
-		countf="$(grep -c ^ "${pfbdomain}${alias}.bk")"
-		/usr/local/bin/ggrep -vF -f "${pfbalexa}" "${pfbdomain}${alias}.bk" > "${pfbdomain}${alias}.bk2"
-		countx="$(grep -c ^ "${pfbdomain}${alias}.bk2")"
-		counta="$((countf - countx))"
-
-		if [ "${counta}" -gt 0 ]; then
-			if [ "${dedup}" = '' ]; then
-				data="$(awk 'FNR==NR{a[$0];next}!($0 in a)' "${pfbdomain}${alias}.bk2" "${pfbdomain}${alias}.bk" | \
-					cut -d '"' -f2 | cut -d ' ' -f1 | sort -u | tr '\n' '|')"
-			else
-				data="$(awk 'FNR==NR{a[$0];next}!($0 in a)' "${pfbdomain}${alias}.bk2" "${pfbdomain}${alias}.bk" | \
-					cut -d ',' -f2 | sort -u | tr '\n' '|')"
-			fi
-
-			if [ -z "${data}" ]; then
-				if [ "${dedup}" = '' ]; then
-					data="$(cut -d '"' -f2 "${pfbdomain}${alias}.bk" | cut -d ' ' -f1 | sort -u | tr '\n' '|')"
-				else
-					data="$(cut -d ',' -f2 "${pfbdomain}${alias}.bk" | sort -u | tr '\n' '|')"
-				fi
-			fi
-
-			echo "  TOP1M Whitelist: ${data}"
-			mv -f "${pfbdomain}${alias}.bk2" "${pfbdomain}${alias}.bk"
-		fi
-	else
-		counta=0
-	fi
-
-	countf="$(grep -c ^ "${pfbdomain}${alias}.bk")"
-	rm -f "${pfbdomain}${alias}.bk2"
-
-	echo '  ----------------------------------------------------------------------'
-	printf "%-10s %-10s %-10s %-10s %-10s %-10s\n" '  Orig.' 'Unique' '# Dups' '# White' '# TOP1M' 'Final'
-	echo '  ----------------------------------------------------------------------'
-	printf "%-10s %-10s %-10s %-10s %-10s %-10s\n" "  ${counto}" "${countu}" "${countd}" "${countw}" "${counta}" "${countf}"
-	echo '  ----------------------------------------------------------------------'
-}
-
-
-# Function to process TLD
-
-
-# Function to process TLD python
-domaintldpy() {
-
-	if [ -s "${dnsbl_python_data}.raw" ]; then
-		sort -u "${dnsbl_python_data}.raw" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_python_data}.raw"
-		countd="$(grep -c ^ ${dnsbl_python_data}.raw)"
-	else
-		countd=0
-	fi
-
-	if [ -s "${dnsbl_python_zone}.raw" ]; then
-		sort -u "${dnsbl_python_zone}.raw" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_python_zone}.raw"
-		countz="$(grep -c ^ ${dnsbl_python_zone}.raw)"
-	else
-		countz=0
-	fi
-
-	printf "."
-
-	countto="$((countd + countz))"
-
-	if [ -s "${dnsbl_tld_remove}" ]; then
-		sort -u "${dnsbl_tld_remove}" > "${tempfile}" && mv -f "${tempfile}" "${dnsbl_tld_remove}"
-		counttm="$(grep -c '^\.' ${dnsbl_tld_remove})"
-	else
-		counttm=0
-	fi
-
-	printf "."
-
-	# Remove redundant Domains (in data)
-	if [ -s "${dnsbl_tld_remove}" ] && [ -s "${dnsbl_python_data}.raw" ]; then
-		/usr/local/bin/ggrep -vF -f "${dnsbl_tld_remove}" "${dnsbl_python_data}.raw" > "${dnsbl_python_data}"
-	elif [ -e "${dnsbl_python_data}.raw" ]; then
-		mv "${dnsbl_python_data}.raw" "${dnsbl_python_data}"
-	fi
-
-	printf "."
-
-	# Remove redundant Domains (in zone)
-	if [ -s "${dnsbl_tld_remove}" ] && [ -s "${dnsbl_python_zone}.raw" ]; then
-		/usr/local/bin/ggrep -vF -f "${dnsbl_tld_remove}" "${dnsbl_python_zone}.raw" > "${dnsbl_python_zone}"
-	elif [ -e "${dnsbl_python_zone}.raw" ]; then
-		mv "${dnsbl_python_zone}.raw" "${dnsbl_python_zone}"
-	fi
-
-	counttf="$(cat ${dnsbl_python_data} ${dnsbl_python_zone} | grep -c ^)"
-	counttr="$((countto - counttf))"
-
-	echo
-	echo ' ----------------------------------------'
-	printf "%-12s %-10s %-10s %-10s\n" ' Original' 'Matches' 'Removed' 'Final'
-	echo ' ----------------------------------------'
-	printf "%-12s %-10s %-10s %-10s\n" " ${countto}" "${counttm}" "${counttr}" "${counttf}"
-	printf ' -----------------------------------------'
-
-	echo "${counttr}" > "${dnsbl_python_count}"
-}
+# ADR-06: dnsbl_scrub (build-time within/cross-feed De-Duplication + user-
+# whitelist removal + TOP1M removal) and domaintldpy (sort -u dedup + subdomain
+# COLLAPSE via ggrep -vF dnsbl_tld_remove + pfb_py_count write) have been REMOVED.
+# They were build-time list optimisations the Python plugin no longer needs: the
+# dict load dedups keys for free, a redundant sub-domain is matched by its parent
+# zone, and the user whitelist + TOP1M are applied at QUERY TIME via the whiteDB.
+# The Python build (pfb_unbound.py) owns this and emits pfb_py_count itself; PHP
+# hands it the per-feed raw via pfblockerng.inc pfb_unbound_python_sources().
 
 
 # Function to compare previous and current DNSBL Unbound conf file, and create Add/Remove files for unbound-control cmds
@@ -1118,12 +952,6 @@ case "${1}" in
 		;;
 	continent)
 		duplicate
-		;;
-	dnsbl_scrub)
-		dnsbl_scrub
-		;;
-	domaintldpy)
-		domaintldpy
 		;;
 	cidr_aggregate)
 		agg_folder=true

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1019,10 +1019,15 @@ if (isset($_POST) && !empty($_POST)) {
 
 			if (file_exists("{$tmp}.adup") && filesize("{$tmp}.adup") > 0) {
 				exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$pfb['unbound_py_data']} > "
-					. escapeshellarg("{$tmp}.tmp") . "; mv -f " . escapeshellarg("{$tmp}.tmp") . " {$pfb['unbound_py_data']}"); 
+					. escapeshellarg("{$tmp}.tmp") . "; mv -f " . escapeshellarg("{$tmp}.tmp") . " {$pfb['unbound_py_data']}");
 				exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$pfb['unbound_py_zone']} > " . escapeshellarg("{$tmp}.tmp")
 					. "; mv -f " . escapeshellarg("{$tmp}.tmp") . " {$pfb['unbound_py_zone']}");
+
+				// ADR-06: the user whitelist is now applied at QUERY TIME via the
+				// Python whiteDB. Refresh the legacy whitelist input AND the manifest's
+				// config.user_whitelist so the next build's whiteDB un-blocks this domain.
 				pfb_unbound_python_whitelist('alerts');
+				pfb_unbound_python_sources_whitelist();
 				pfb_reload_unbound('enabled', FALSE);
 			}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1279,6 +1279,7 @@ if (isset($_POST) && !empty($_POST)) {
 			write_config("pfBlockerNG: Deleted [ {$entry} ] from {$type} customlist", false);
 			if ($dnsbl_py_changes) {
 				pfb_unbound_python_whitelist('alerts');
+				pfb_unbound_python_sources_whitelist();
 				pfb_reload_unbound('enabled', FALSE);
 			}
 		}

--- a/tests/fixtures/adr06_golden/config.json
+++ b/tests/fixtures/adr06_golden/config.json
@@ -1,0 +1,24 @@
+{
+  "_doc": "Config inputs to the CURRENT DNSBL pipeline for the golden oracle. These mirror dnsblconfig keys read by tld_analysis / pfb_unbound_python_whitelist and the python init flags. The oracle loads two scenarios off this single config: TOP1M disabled (default) and TOP1M enabled.",
+
+  "tld_blacklist": ["zip"],
+  "_tld_blacklist_doc": "Whole-TLD block: every domain under .zip is wildcard-blocked via a synthetic DNSBL_TLD zone entry (inc:2740). .zip is also removed from the TLD master.",
+
+  "tld_exclusion": ["excluded.com"],
+  "_tld_exclusion_doc": "Force exact DATA (transparent) classification for this whole domain even though as a 2-label registrable domain it would otherwise be a wildcard ZONE (inc:2855). Present in feed_extra.txt.",
+
+  "user_whitelist": ["www.adblock.com", ".wildwhite.org", "phishing.net"],
+  "_user_whitelist_doc": "User DNSBL whitelist (dnsblconfig['suppression']). Normalised by pfb_unbound_python_whitelist (inc:2259): www-strip, leading-dot -> wildcard '1' else '0'. Applied at QUERY TIME via whiteDB (un-blocks), never as a build-time removal in ADR-06's target.",
+
+  "top1m_list": ["popularcdn.com"],
+  "_top1m_doc": "TOP1M (Alexa/Tranco) popularity whitelist. Loaded into whiteDB ONLY when TOP1M is enabled; un-blocks popular domains at query time. When disabled, these domains block normally.",
+
+  "hsts_domains": ["hstslisted.com"],
+  "_hsts_doc": "HSTS exclusion list (pfb_py_hsts). A blocked domain on this list (or under an hsts_tld) resolves real (HSTS bypass) instead of being null-blocked.",
+
+  "noaaaa_domains": [["noaaaa.com", "0"], ["noaaaawild.net", "1"]],
+  "_noaaaa_doc": "noAAAA list: [domain, wildcard]. An AAAA query for a listed domain (or subdomain when wildcard='1') is blocked (NODATA), independent of the DNSBL blocklist.",
+
+  "log_default": "1",
+  "python_tld_seg": 1
+}

--- a/tests/fixtures/adr06_golden/feed_abp.txt
+++ b/tests/fixtures/adr06_golden/feed_abp.txt
@@ -1,0 +1,16 @@
+[Adblock Plus 2.0]
+! Title: Test basic-ABP feed
+! Basic-ABP feed. Feed=AbpFeed Group=AbpAds  log_flag=1
+! The current PHP basic-ABP pass (pfblockerng.inc:7706-7717) keeps ONLY
+! "||domain^" network lines and strips the ||, ^ tokens to a bare domain.
+! Everything below that is NOT a plain "||domain^" is IGNORED today:
+!   @@ exceptions, ## element-hiding, $options, *, /, regex.
+! This fixture pins that current (non-conformant) behaviour.
+||abpblocked.com^
+||sub.abpzone.net^
+||abpoptions.com^$third-party
+@@||abpallowed.com^
+example.com##.ad-banner
+||abpwildcard.*^
+||abppath.com/ads^
+/regex-rule[0-9]/

--- a/tests/fixtures/adr06_golden/feed_csv_pon.txt
+++ b/tests/fixtures/adr06_golden/feed_csv_pon.txt
@@ -1,0 +1,10 @@
+timestamp,ignored,domain,c3,c4,c5,c6,c7,c8
+! Structured CSV "pon" (Ponmocup) feed. Feed=PonFeed Group=Threat log_flag=1
+! Per the current loop (pfblockerng.inc:7819-7835): a 9-column row uses
+! csvline[2] as the DOMAIN handed to Python AND, when csvline[0] is an IPv4,
+! ALSO routes that IP to the firewall path (DNSBLIP_v4) -- it does NOT skip the
+! domain. So this feed exercises BOTH the domain sink AND the embedded-IP
+! handoff from a CSV column, on the SAME row.
+2026-01-01T00:00:00Z,x,ponmocup.com,a,b,c,d,e,f
+198.51.100.77,x,ponip.net,a,b,c,d,e,f
+192.0.2.140,x,deep.node.cleanpon.com,a,b,c,d,e,f

--- a/tests/fixtures/adr06_golden/feed_extra.txt
+++ b/tests/fixtures/adr06_golden/feed_extra.txt
@@ -1,0 +1,7 @@
+# Plain-domain feed carrying config-interaction cases.
+# Feed=ExtraFeed Group=Extra  log_flag=1
+# excluded.com  -> 2-label registrable; normally ZONE, but TLD-exclusion forces
+#                  it to exact DATA (transparent). A subdomain must NOT block.
+# hstslisted.com-> on the blocklist AND on the HSTS list -> resolves real (HSTS).
+excluded.com
+hstslisted.com

--- a/tests/fixtures/adr06_golden/feed_hosts.txt
+++ b/tests/fixtures/adr06_golden/feed_hosts.txt
@@ -1,0 +1,12 @@
+# Hosts-file format feed (sinkhole-IP + domain per line).
+# Feed=HostsFeed Group=Ads  log_flag=1
+# Exercises: hosts "0.0.0.0 domain" + "127.0.0.1 domain" shapes; a 2-label
+# registrable domain (-> ZONE wildcard, blocks itself + every subdomain); a deep
+# sub-domain whose registrable parent is NOT otherwise listed (-> exact DATA, so
+# only that exact name blocks); an embedded bare IPv4 (-> firewall path, stripped
+# from Python); a www-prefixed domain; and a comment line (ignored).
+0.0.0.0 tracker.org
+127.0.0.1 evilads.net
+0.0.0.0 deep.host.cleandata.com
+0.0.0.0 198.51.100.23
+0.0.0.0 www.bannerfarm.com

--- a/tests/fixtures/adr06_golden/feed_nolog.txt
+++ b/tests/fixtures/adr06_golden/feed_nolog.txt
@@ -1,0 +1,7 @@
+# Plain-domain feed with log_flag '2' (block-but-skip-log).
+# Feed=NoLogFeed Group=NoLog  log_flag=2
+# Per Phase 1 (1b) + the matcher: log '2' still BLOCKS the domain, but
+# null_blocking stays True (only log '1' flips it to a null-route reply) and
+# get_details_dnsbl skips the log line (pfb_unbound.py:1134). This pins the
+# distinct "blocked, log '2'" decision shape.
+silentblock.com

--- a/tests/fixtures/adr06_golden/feed_plain.txt
+++ b/tests/fixtures/adr06_golden/feed_plain.txt
@@ -1,0 +1,19 @@
+# Plain-domain format feed (one bare domain per line).
+# Feed=PlainFeed Group=Malware  log_flag=1
+# Exercises: a 2-label registrable domain (-> ZONE); a deep sub-domain whose
+# parent is NOT listed (-> exact DATA); a multi-label public-suffix domain
+# shop.co.uk (-> ZONE on the co.uk suffix); adblock.com (blocked here, but the
+# user whitelist un-blocks it at query time -> resolves); a domain ALSO present
+# in the hosts feed (cross-feed duplicate: last-wins attribution after ADR-06);
+# a popular domain in TOP1M (un-blocked at query time only when TOP1M enabled);
+# a leading-dot wildcard-style line (PHP strips the dot to a bare domain); and a
+# bare IP (-> firewall).
+malware.com
+phishing.net
+deep.path.cleanmal.com
+shop.co.uk
+adblock.com
+tracker.org
+popularcdn.com
+.wildcardish.org
+203.0.113.45

--- a/tests/fixtures/adr06_golden/manifest.json
+++ b/tests/fixtures/adr06_golden/manifest.json
@@ -1,0 +1,12 @@
+{
+  "_doc": "Per-feed manifest (Phase 1 §1i / §2 contract). One row per raw feed file mapping it to {feed, group, format_hint, log_flag}. This is the shell->Python boundary the build consumes; the oracle uses it to drive the reference preprocessor in the same order the current pipeline concatenates feeds.",
+  "version": 1,
+  "feeds": [
+    { "raw": "feed_hosts.txt",   "feed": "HostsFeed", "group": "Ads",     "format_hint": "hosts", "log_flag": "1" },
+    { "raw": "feed_plain.txt",   "feed": "PlainFeed", "group": "Malware", "format_hint": "plain", "log_flag": "1" },
+    { "raw": "feed_abp.txt",     "feed": "AbpFeed",   "group": "AbpAds",  "format_hint": "abp",   "log_flag": "1" },
+    { "raw": "feed_csv_pon.txt", "feed": "PonFeed",   "group": "Threat",  "format_hint": "csv:pon", "log_flag": "1" },
+    { "raw": "feed_extra.txt",   "feed": "ExtraFeed", "group": "Extra",   "format_hint": "plain", "log_flag": "1" },
+    { "raw": "feed_nolog.txt",   "feed": "NoLogFeed", "group": "NoLog",   "format_hint": "plain", "log_flag": "2" }
+  ]
+}

--- a/tests/fixtures/adr06_golden/tld_master.txt
+++ b/tests/fixtures/adr06_golden/tld_master.txt
@@ -1,0 +1,4 @@
+com
+net
+org
+co.uk

--- a/tests/test_adr06_build_module.py
+++ b/tests/test_adr06_build_module.py
@@ -1,0 +1,438 @@
+"""ADR-06 Phase 3 -- unit tests for the pure ``pfb_unbound`` DNSBL build layer.
+
+WHY THIS FILE EXISTS
+--------------------
+Phase 3 introduces the pure, stdlib-only, Unbound-symbol-free build layer
+(``parse`` -> ``normalise`` -> ``classify`` -> ``build``) that reproduces today's
+DNSBL preprocessing pipeline at the level of net DNS *decisions* (ADR.md SS2). This
+module unit-tests every build function AND drives ``build()`` end-to-end against the
+Phase-2 DECISION oracle: the SAME representative query set, the SAME golden labels
+(``GOLDEN_TOP1M_DISABLED`` / ``GOLDEN_TOP1M_ENABLED_OVERRIDES``) and the SAME
+extracted-IP expectations -- but now over the structures the NEW build produces.
+
+The contract is decisions, NOT list contents/counts. ADR-06 drops the build-time
+optimisations (dedup, subdomain collapse, user-whitelist removal, TOP1M removal),
+so ``data_db`` / ``zone_db`` contents and the counts change BY DESIGN. The tests
+therefore assert identical block/resolve/whitelist/HSTS/noAAAA/zone-subdomain
+DECISIONS, reusing the same Phase-2 golden tables from
+``tests/test_adr06_golden_oracle.py`` so the two layers cannot silently diverge.
+
+WHAT THE TESTS COVER
+--------------------
+  * ``parse`` per format (hosts / plain / abp / csv:pon), incl. every IGNORED line
+    type (``@@`` / ``##`` / ``$options`` / ``*`` / ``/`` / regex), comments, the
+    hosts sink-IP strip, the leading-dot strip, and bare-IP skip (firewall path).
+  * the ABP-ready ``kind`` seam: parse only ever emits ``DNSBL_KIND_BLOCK``.
+  * ``normalise`` domain-shape gate (lower-case, label rules, IP/garbage rejected).
+  * ``classify`` data/zone via the public-suffix oracle, incl. the multi-label
+    public suffix (``co.uk``), deep-subdomain -> exact DATA, and TLD-exclusion ->
+    forced exact DATA.
+  * whitelist normalisation (www-strip, leading-dot wildcard, TOP1M-when-enabled).
+  * ``build()`` end-to-end == the Phase-2 decision oracle, BOTH TOP1M scenarios,
+    plus the noAAAA decisions and the no-IP-leak guarantee.
+  * ``build()`` is PURE / REENTRANT: two calls yield equal structures and mutate
+    no module global.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pfb_unbound
+
+# Reuse the Phase-2 oracle's fixtures, golden decision tables and decision driver so
+# the new build layer is validated against the EXACT same contract, not a copy.
+from tests.test_adr06_golden_oracle import (
+    GOLDEN_EXTRACTED_IPS,
+    GOLDEN_TOP1M_DISABLED,
+    GOLDEN_TOP1M_ENABLED_OVERRIDES,
+    _build_cfg,
+    _decision_label,
+    _load_json,
+    _read_lines,
+)
+
+# --------------------------------------------------------------------------- #
+# Helpers: drive build() over the golden fixtures, then evaluate the PRODUCTION
+# matcher decision functions over the build's structures (the Phase-2 oracle).
+# --------------------------------------------------------------------------- #
+
+
+def _build_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Shape the golden config.json into the build() config blob.
+
+    The golden config.json carries ``tld_master`` as a fixture file name; the build
+    takes the suffix lines directly (no filesystem coupling), so expand it here.
+    """
+    return {
+        "tld_master": _read_lines("tld_master.txt"),
+        "tld_blacklist": config.get("tld_blacklist", []),
+        "tld_exclusion": config.get("tld_exclusion", []),
+        "user_whitelist": config.get("user_whitelist", []),
+        "top1m_list": config.get("top1m_list", []),
+    }
+
+
+def _run_build(*, top1m_enabled: bool) -> tuple[pfb_unbound.BuildResult, dict[str, Any]]:
+    manifest = _load_json("manifest.json")
+    config = _load_json("config.json")
+    result = pfb_unbound.build(
+        manifest,
+        _build_config(config),
+        line_reader=_read_lines,
+        top1m_enabled=top1m_enabled,
+    )
+    return result, config
+
+
+def _evaluate_build(result: pfb_unbound.BuildResult, config: dict[str, Any], q_name: str) -> dict[str, Any]:
+    """Run the PRODUCTION ``evaluate_domain`` over the BUILD's structures."""
+    containers = {
+        "dataDB": result.data_db,
+        "zoneDB": result.zone_db,
+        "whiteDB": result.white_db,
+        "regexDB": {},
+        "feedGroupIndexDB": result.feed_group_index_db,
+        "hstsDB": {d: 0 for d in config.get("hsts_domains", [])},
+    }
+    cfg = _build_cfg(config, has_white=bool(result.white_db))
+    tld = q_name.rsplit(".", 1)[-1] if "." in q_name else q_name
+    decision = pfb_unbound.evaluate_domain(q_name, q_name, tld, False, cfg, containers)
+    return {
+        "decision": _decision_label(decision),
+        "b_type": decision.b_type,
+        "feed": decision.feed,
+        "group": decision.group,
+        "b_eval": decision.b_eval,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# parse()
+# --------------------------------------------------------------------------- #
+
+
+class TestParse:
+    def test_hosts_sink_ip_stripped(self) -> None:
+        for line in ("0.0.0.0 tracker.org", "127.0.0.1 tracker.org"):
+            entry = pfb_unbound.parse("hosts", line)
+            assert entry is not None
+            assert entry.value == "tracker.org"
+            assert entry.kind == pfb_unbound.DNSBL_KIND_BLOCK
+
+    def test_hosts_comment_skipped(self) -> None:
+        assert pfb_unbound.parse("hosts", "# a comment") is None
+
+    def test_hosts_bare_ip_skipped(self) -> None:
+        # Bare IP -> firewall path (PHP); parse() must NOT return it.
+        assert pfb_unbound.parse("hosts", "0.0.0.0 198.51.100.23") is None
+        assert pfb_unbound.parse("plain", "203.0.113.45") is None
+
+    def test_plain_domain(self) -> None:
+        entry = pfb_unbound.parse("plain", "malware.com")
+        assert entry is not None and entry.value == "malware.com"
+
+    def test_plain_leading_dot_stripped(self) -> None:
+        entry = pfb_unbound.parse("plain", ".wildcardish.org")
+        assert entry is not None and entry.value == "wildcardish.org"
+
+    def test_blank_line_skipped(self) -> None:
+        assert pfb_unbound.parse("plain", "   ") is None
+        assert pfb_unbound.parse("abp", "") is None
+
+    def test_abp_block_line(self) -> None:
+        entry = pfb_unbound.parse("abp", "||abpblocked.com^")
+        assert entry is not None
+        assert entry.value == "abpblocked.com"
+        assert entry.kind == pfb_unbound.DNSBL_KIND_BLOCK
+
+    def test_abp_deep_block_line(self) -> None:
+        entry = pfb_unbound.parse("abp", "||sub.abpzone.net^")
+        assert entry is not None and entry.value == "sub.abpzone.net"
+
+    def test_abp_ignored_lines(self) -> None:
+        # Each of these is IGNORED today and must yield None (NOT an allow/regex kind).
+        ignored = [
+            "[Adblock Plus 2.0]",  # control header
+            "! Title: comment",  # comment
+            "@@||abpallowed.com^",  # exception
+            "||abpoptions.com^$third-party",  # $options
+            "example.com##.ad-banner",  # element-hiding
+            "||abpwildcard.*^",  # wildcard '*'
+            "||abppath.com/ads^",  # path '/'
+            "/regex-rule[0-9]/",  # standalone regex
+        ]
+        for line in ignored:
+            assert pfb_unbound.parse("abp", line) is None, line
+
+    def test_csv_pon_domain_from_col2(self) -> None:
+        line = "2026-01-01T00:00:00Z,x,ponmocup.com,a,b,c,d,e,f"
+        entry = pfb_unbound.parse("csv:pon", line)
+        assert entry is not None and entry.value == "ponmocup.com"
+
+    def test_csv_pon_col0_ip_row_still_yields_col2_domain(self) -> None:
+        # col0 is an IP (PHP firewall path) but the col2 domain is STILL kept.
+        line = "198.51.100.77,x,ponip.net,a,b,c,d,e,f"
+        entry = pfb_unbound.parse("csv:pon", line)
+        assert entry is not None and entry.value == "ponip.net"
+
+    def test_csv_pon_header_and_comment_skipped(self) -> None:
+        assert pfb_unbound.parse("csv:pon", "timestamp,ignored,domain,c3,c4,c5,c6,c7,c8") is None
+        assert pfb_unbound.parse("csv:pon", "! comment") is None
+
+    def test_csv_pon_wrong_column_count_skipped(self) -> None:
+        assert pfb_unbound.parse("csv:pon", "a,b,c") is None
+
+    def test_kind_is_always_block_this_phase(self) -> None:
+        # The ABP-ready seam exists but only BLOCK is ever produced.
+        for fmt, line in [
+            ("hosts", "0.0.0.0 tracker.org"),
+            ("plain", "malware.com"),
+            ("abp", "||abpblocked.com^"),
+            ("csv:pon", "x,x,ponmocup.com,a,b,c,d,e,f"),
+        ]:
+            entry = pfb_unbound.parse(fmt, line)
+            assert entry is not None and entry.kind == pfb_unbound.DNSBL_KIND_BLOCK
+
+
+# --------------------------------------------------------------------------- #
+# normalise()
+# --------------------------------------------------------------------------- #
+
+
+class TestNormalise:
+    def test_lowercases_and_trims(self) -> None:
+        assert pfb_unbound.normalise(" Tracker.ORG. ") == "tracker.org"
+
+    def test_rejects_single_label(self) -> None:
+        assert pfb_unbound.normalise("localhost") is None
+
+    def test_bare_ip_rejection_is_parse_not_normalise(self) -> None:
+        # Mirroring the current pipeline (inc:7962-7973): an all-numeric dotted
+        # string is rejected at PARSE via the is_ipaddrv4 check, before validation.
+        # normalise() alone treats digits as valid label chars (matches the Phase-2
+        # ReferencePipeline._validate_domain), so the IP guard MUST live in parse().
+        assert pfb_unbound.parse("plain", "198.51.100.23") is None
+        assert pfb_unbound.normalise("198.51.100.23") == "198.51.100.23"
+
+    def test_rejects_edge_hyphen_and_bad_chars(self) -> None:
+        assert pfb_unbound.normalise("-bad.com") is None
+        assert pfb_unbound.normalise("bad-.com") is None
+        assert pfb_unbound.normalise("under_score.com") is None
+        assert pfb_unbound.normalise("emp..ty") is None
+
+    def test_accepts_valid_domain(self) -> None:
+        assert pfb_unbound.normalise("deep.host.cleandata.com") == "deep.host.cleandata.com"
+
+
+# --------------------------------------------------------------------------- #
+# classify()
+# --------------------------------------------------------------------------- #
+
+
+class TestClassify:
+    def _tlds(self) -> dict[str, dict[str, str]]:
+        return pfb_unbound._dnsbl_load_tld_master(_read_lines("tld_master.txt"), [], [])
+
+    def test_two_label_is_zone(self) -> None:
+        cls, key = pfb_unbound.classify("tracker.org", self._tlds(), set())
+        assert (cls, key) == (pfb_unbound.DNSBL_CLASS_ZONE, "tracker.org")
+
+    def test_multi_label_public_suffix_is_zone_on_registrable(self) -> None:
+        # co.uk is a public suffix -> shop.co.uk is the registrable parent.
+        cls, key = pfb_unbound.classify("shop.co.uk", self._tlds(), set())
+        assert (cls, key) == (pfb_unbound.DNSBL_CLASS_ZONE, "shop.co.uk")
+
+    def test_deep_subdomain_unknown_parent_is_data(self) -> None:
+        # cleandata.com is NOT a public suffix -> only the exact name is DATA.
+        cls, key = pfb_unbound.classify("deep.host.cleandata.com", self._tlds(), set())
+        assert (cls, key) == (pfb_unbound.DNSBL_CLASS_DATA, "deep.host.cleandata.com")
+
+    def test_tld_exclusion_forces_exact_data(self) -> None:
+        cls, key = pfb_unbound.classify("excluded.com", self._tlds(), {"excluded.com"})
+        assert (cls, key) == (pfb_unbound.DNSBL_CLASS_DATA, "excluded.com")
+
+
+# --------------------------------------------------------------------------- #
+# whitelist normalisation
+# --------------------------------------------------------------------------- #
+
+
+class TestWhitelistNormalisation:
+    def test_www_strip_and_exact(self) -> None:
+        wl = pfb_unbound._dnsbl_normalise_whitelist(["www.adblock.com"], [], False)
+        assert wl == {"adblock.com": False}
+
+    def test_leading_dot_wildcard(self) -> None:
+        wl = pfb_unbound._dnsbl_normalise_whitelist([".wildwhite.org"], [], False)
+        assert wl == {"wildwhite.org": True}
+
+    def test_top1m_only_when_enabled(self) -> None:
+        disabled = pfb_unbound._dnsbl_normalise_whitelist([], ["popularcdn.com"], False)
+        assert "popularcdn.com" not in disabled
+        enabled = pfb_unbound._dnsbl_normalise_whitelist([], ["popularcdn.com"], True)
+        assert enabled.get("popularcdn.com") is False
+
+
+# --------------------------------------------------------------------------- #
+# build() end-to-end vs the Phase-2 DECISION oracle
+# --------------------------------------------------------------------------- #
+
+
+class TestBuildDecisionsTop1mDisabled:
+    """The build's structures reproduce EVERY Phase-2 golden decision (TOP1M off).
+    Decisions -- not list contents/counts -- are the oracle (ADR.md SS2)."""
+
+    def test_decisions(self) -> None:
+        result, config = _run_build(top1m_enabled=False)
+        failures: list[str] = []
+        for q_name, expected in GOLDEN_TOP1M_DISABLED.items():
+            got = _evaluate_build(result, config, q_name)
+            for k, v in expected.items():
+                if got[k] != v:
+                    failures.append(f"{q_name}: {k} expected {v!r} got {got[k]!r}")
+        assert not failures, "Build decision mismatch:\n" + "\n".join(failures)
+
+
+class TestBuildDecisionsTop1mEnabled:
+    """With TOP1M enabled the popular domain flips to 'whitelist'; all other
+    decisions are unchanged -- identical to the Phase-2 oracle."""
+
+    def test_decisions(self) -> None:
+        result, config = _run_build(top1m_enabled=True)
+        expected_map = dict(GOLDEN_TOP1M_DISABLED)
+        expected_map.update(GOLDEN_TOP1M_ENABLED_OVERRIDES)
+        failures: list[str] = []
+        for q_name, expected in expected_map.items():
+            got = _evaluate_build(result, config, q_name)
+            for k, v in expected.items():
+                if got[k] != v:
+                    failures.append(f"{q_name}: {k} expected {v!r} got {got[k]!r}")
+        assert not failures, "Build decision mismatch (TOP1M enabled):\n" + "\n".join(failures)
+
+    def test_top1m_disabled_blocks_popular_domain(self) -> None:
+        result, config = _run_build(top1m_enabled=False)
+        got = _evaluate_build(result, config, "popularcdn.com")
+        assert got["decision"] == "block-null"
+
+
+class TestBuildNoAAAA:
+    """noAAAA decisions are independent of the blocklist; the build does not touch
+    the noAAAA list, but the matcher decision over the golden noAAAA list is pinned
+    here too so the full decision surface is covered by the build-module tests."""
+
+    def _noaaaa_db(self, config: dict[str, Any]) -> dict[str, Any]:
+        return {dom: wild == "1" for dom, wild in config.get("noaaaa_domains", [])}
+
+    def test_noaaaa_decisions(self) -> None:
+        _, config = _run_build(top1m_enabled=False)
+        db = self._noaaaa_db(config)
+        assert pfb_unbound.evaluate_noaaaa("noaaaa.com", db) is True
+        assert pfb_unbound.evaluate_noaaaa("host.noaaaawild.net", db) is True
+        assert pfb_unbound.evaluate_noaaaa("noaaaawild.net", db) is True
+        assert pfb_unbound.evaluate_noaaaa("sub.noaaaa.com", db) is False
+        assert pfb_unbound.evaluate_noaaaa("totally-unrelated.com", db) is False
+
+
+class TestBuildNoIpLeak:
+    """The build never emits firewall input: no extracted IP leaks into the dicts.
+    (IP extraction stays in PHP -- Phase 5.) Same IP set the Phase-2 oracle records."""
+
+    def test_no_ip_leaked_into_block_lists(self) -> None:
+        result, _ = _run_build(top1m_enabled=False)
+        for ip in GOLDEN_EXTRACTED_IPS:
+            assert ip not in result.data_db
+            assert ip not in result.zone_db
+
+
+# --------------------------------------------------------------------------- #
+# build() structure-set sanity (NOT the oracle -- guards a broken build model)
+# --------------------------------------------------------------------------- #
+
+
+class TestBuildStructureSanity:
+    def test_zone_and_data_populated(self) -> None:
+        result, _ = _run_build(top1m_enabled=False)
+        assert "tracker.org" in result.zone_db
+        assert "malware.com" in result.zone_db
+        assert "shop.co.uk" in result.zone_db
+        assert "deep.host.cleandata.com" in result.data_db
+        assert "deep.path.cleanmal.com" in result.data_db
+        # TLD-exclusion forces a would-be-zone 2-label into data_db (exact).
+        assert "excluded.com" in result.data_db
+        assert "excluded.com" not in result.zone_db
+        # TLD-blacklist synthetic zone entry, attributed to DNSBL_TLD.
+        assert "zip" in result.zone_db
+        idx = result.zone_db["zip"]["index"]
+        assert result.feed_group_index_db[idx] == {"feed": "DNSBL_TLD", "group": "DNSBL_TLD"}
+
+    def test_cross_feed_duplicate_last_wins(self) -> None:
+        # tracker.org is in BOTH the hosts feed (Ads) and the plain feed (Malware);
+        # the build keeps LAST (dict assignment; ADR-06 SS2 attribution change).
+        result, _ = _run_build(top1m_enabled=False)
+        idx = result.zone_db["tracker.org"]["index"]
+        assert result.feed_group_index_db[idx] == {"feed": "PlainFeed", "group": "Malware"}
+
+    def test_log_flag_carried_per_feed(self) -> None:
+        # The log_flag '2' feed (NoLog) carries through to the entry payload.
+        result, _ = _run_build(top1m_enabled=False)
+        assert result.zone_db["silentblock.com"]["log"] == "2"
+
+    def test_counts_is_loaded_total(self) -> None:
+        # ADR-06 redefines pfb_py_count to the LOADED total (no dedup/collapse).
+        result, _ = _run_build(top1m_enabled=False)
+        assert result.counts == len(result.data_db) + len(result.zone_db)
+        assert result.counts > 0
+
+    def test_no_build_time_whitelist_pruning(self) -> None:
+        # Whitelisted domains STAY in the lists (un-blocked at query time only).
+        result, _ = _run_build(top1m_enabled=False)
+        assert "phishing.net" in result.zone_db  # whitelisted but still listed
+        assert "adblock.com" in result.zone_db
+
+    def test_no_build_time_subdomain_collapse(self) -> None:
+        # An exact DATA entry under a listed ZONE is NOT collapsed away at build time.
+        # (deep.host.cleandata.com stays in data_db even though no parent zone covers
+        # it; and a redundant subdomain of a zone would also stay -- no collapse pass.)
+        result, _ = _run_build(top1m_enabled=False)
+        assert "deep.host.cleandata.com" in result.data_db
+
+
+# --------------------------------------------------------------------------- #
+# build() purity / reentrancy
+# --------------------------------------------------------------------------- #
+
+
+class TestBuildPurity:
+    def test_two_calls_yield_equal_structures(self) -> None:
+        r1, _ = _run_build(top1m_enabled=False)
+        r2, _ = _run_build(top1m_enabled=False)
+        assert r1.data_db == r2.data_db
+        assert r1.zone_db == r2.zone_db
+        assert r1.feed_group_index_db == r2.feed_group_index_db
+        assert r1.white_db == r2.white_db
+        assert r1.counts == r2.counts
+
+    def test_returns_fresh_structures_not_aliased(self) -> None:
+        r1, _ = _run_build(top1m_enabled=False)
+        r2, _ = _run_build(top1m_enabled=False)
+        # Distinct objects (a future zero-downtime swap relies on this).
+        assert r1.data_db is not r2.data_db
+        assert r1.zone_db is not r2.zone_db
+        assert r1.feed_group_index_db is not r2.feed_group_index_db
+        assert r1.white_db is not r2.white_db
+
+    def test_does_not_mutate_module_globals(self) -> None:
+        # build() must touch no module global (it operates only on locals it returns).
+        before_data = dict(pfb_unbound.dataDB)
+        before_zone = dict(pfb_unbound.zoneDB)
+        before_white = dict(pfb_unbound.whiteDB)
+        before_fgi = dict(pfb_unbound.feedGroupIndexDB)
+        result, _ = _run_build(top1m_enabled=False)
+        assert pfb_unbound.dataDB == before_data
+        assert pfb_unbound.zoneDB == before_zone
+        assert pfb_unbound.whiteDB == before_white
+        assert pfb_unbound.feedGroupIndexDB == before_fgi
+        # And the returned structures are NOT the module globals.
+        assert result.data_db is not pfb_unbound.dataDB
+        assert result.zone_db is not pfb_unbound.zoneDB

--- a/tests/test_adr06_golden_oracle.py
+++ b/tests/test_adr06_golden_oracle.py
@@ -1,0 +1,670 @@
+"""ADR-06 Phase 2 -- golden oracle for the CURRENT DNSBL preprocessing behaviour.
+
+WHY THIS FILE EXISTS
+--------------------
+ADR-06 moves DNSBL list preprocessing (parse -> normalise -> classify data/zone
+-> build dicts) out of shell/PHP into ``pfb_unbound.py``. That is the DNS
+*blocking* path, so the move (Phases 3-5) must be provably equivalent **at the
+level of net DNS decisions** (ADR.md §2). This module pins TODAY's decisions as a
+committed golden oracle, captured while the old shell/PHP path is still
+authoritative, so a silent regression in a later phase goes red here.
+
+The contract is decisions, NOT list contents/counts. ADR-06 deliberately drops the
+build-time optimisations (dedup, subdomain collapse, user-whitelist removal, TOP1M
+removal), so ``dataDB``/``zoneDB`` contents and ``pfb_py_count`` change BY DESIGN.
+What MUST stay invariant is every block/resolve outcome. Accordingly this oracle:
+
+  * asserts DECISIONS (block shape / resolve / whitelist / HSTS / noAAAA /
+    zone-subdomain / pass-through) via the production matcher decision functions
+    ``pfb_unbound.evaluate_domain`` and ``pfb_unbound.evaluate_noaaaa`` -- the same
+    pure functions the rest of ``tests/test_pfb_unbound.py`` exercises; and
+  * records the **extracted-IP set** (the ``*_v4.ip`` / DNSBLIP_v4 firewall input)
+    that the parse step hands off to PHP -- so the IP handoff is part of the oracle.
+
+It does NOT assert identical dict contents or counts (those change by design).
+
+WHAT MODELS "THE CURRENT PIPELINE"
+----------------------------------
+There is no live PHP/Unbound in CI (every prior ADR). So this file contains a
+pure-Python *reference preprocessor* (``ReferencePipeline``) that faithfully
+re-implements the CURRENT shell/PHP preprocessing semantics inventoried in
+Phase 1 (``RESULTS/01_Results.txt``), with file:line anchors in the docstrings:
+
+  * per-format parse (hosts / plain / basic-ABP / csv:pon), incl. the current
+    basic-ABP token-strip and the rule that ``@@`` / ``##`` / ``$options`` / ``*``
+    / ``/`` / regex lines are IGNORED today (``pfblockerng.inc:7706-7717``);
+  * embedded-IP extraction -> firewall handoff set (generic bare-IP at
+    ``inc:7962-7973`` and the csv:pon column-0 IP at ``inc:7824-7833``), with IP
+    lines stripped from what the domain build receives;
+  * domain validation + lower-casing (``inc:7995-8016``);
+  * data/zone classification via the public-suffix TLD master (``tld_analysis`` /
+    ``tld_search``, ``inc:2805-2877``), incl. TLD blacklist (whole-TLD zone,
+    ``inc:2740``) and TLD exclusion (force exact data, ``inc:2855``);
+  * user-whitelist normalisation (``pfb_unbound_python_whitelist``, ``inc:2259``:
+    www-strip, leading-dot -> wildcard) feeding the query-time ``whiteDB``; and
+  * TOP1M -> ``whiteDB`` only when enabled.
+
+The reference preprocessor then loads the production matcher's runtime structures
+(``dataDB`` / ``zoneDB`` / ``feedGroupIndexDB`` / ``whiteDB``) and the oracle drives
+the production decision functions over a representative query set. Phase 3's new
+pure build module must reproduce these SAME decisions even though the loaded lists
+differ (un-pruned).
+
+Fixtures live in ``tests/fixtures/adr06_golden/`` and are human-readable +
+documented (each ``feed_*.txt`` header says what it encodes; ``config.json`` /
+``manifest.json`` document every key).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+from collections import defaultdict
+from typing import Any
+
+import pfb_unbound
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "adr06_golden")
+
+
+# --------------------------------------------------------------------------- #
+# Fixture loading
+# --------------------------------------------------------------------------- #
+
+
+def _fixture_path(name: str) -> str:
+    return os.path.join(FIXTURES, name)
+
+
+def _read_lines(name: str) -> list[str]:
+    with open(_fixture_path(name), encoding="utf-8") as fh:
+        return fh.read().splitlines()
+
+
+def _load_json(name: str) -> dict[str, Any]:
+    with open(_fixture_path(name), encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+# --------------------------------------------------------------------------- #
+# Reference model of the CURRENT preprocessing pipeline (shell + PHP).
+#
+# Pure, stdlib-only. Re-implements the inventoried semantics so the oracle can run
+# in CI without live PHP/Unbound. Anchors to pfblockerng.inc / .sh line ranges are
+# in the method docstrings. This is the authoritative-today behaviour Phase 3 must
+# match at the DECISION level.
+# --------------------------------------------------------------------------- #
+
+
+def _is_ipv4(token: str) -> bool:
+    """Mirror is_ipaddrv4: dotted-quad, each octet 0-255, no leading zeros."""
+    parts = token.split(".")
+    if len(parts) != 4:
+        return False
+    for p in parts:
+        if not p.isdigit() or not (0 <= int(p) <= 255) or (len(p) > 1 and p[0] == "0"):
+            return False
+    return True
+
+
+class ReferencePipeline:
+    """Faithful pure-Python stand-in for the current shell/PHP DNSBL preprocessing.
+
+    Produces the runtime structures the matcher consumes (``dataDB`` / ``zoneDB`` /
+    ``feedGroupIndexDB`` / ``whiteDB``) plus the extracted-IP firewall set, from the
+    raw feed fixtures + config. Decisions over these structures are the oracle.
+    """
+
+    def __init__(self, manifest: dict[str, Any], config: dict[str, Any], *, top1m_enabled: bool) -> None:
+        self.manifest = manifest
+        self.config = config
+        self.top1m_enabled = top1m_enabled
+
+        self.data_db: dict[str, Any] = {}
+        self.zone_db: dict[str, Any] = {}
+        self.feed_group_index_db: dict[int, Any] = {}
+        self.white_db: dict[str, bool] = {}
+        self.extracted_ips: set[str] = set()
+
+        self._feed_group_db: dict[str, int] = {}
+        self._next_index = 0
+        # Public-suffix oracle: tlds[tld][full-suffix] = '' (tld_analysis:2630-2642),
+        # minus any TLD that is blacklisted or excluded.
+        self._tlds: dict[str, dict[str, str]] = defaultdict(dict)
+
+    # -- parse layer -------------------------------------------------------- #
+
+    @staticmethod
+    def _parse_abp_line(line: str) -> str | None:
+        """Current basic-ABP pass (pfblockerng.inc:7706-7717).
+
+        Keep ONLY a plain ``||domain^`` network line; strip the ``||`` and ``^``
+        tokens. IGNORE everything else: ``@@`` exceptions, ``##`` element rules,
+        ``$options``, ``*`` and ``/`` (path/regex). Returns the bare domain or None.
+        """
+        if not line.startswith("||") or not line.endswith("^"):
+            return None
+        if "$" in line or "*" in line or "/" in line:
+            return None
+        return line[2:-1]  # str_replace(['||', '.^', '^'], '', ...)
+
+    @staticmethod
+    def _strip_hosts_prefix(line: str) -> str:
+        """Hosts format: "<sink-ip> <domain>" -> take the domain token (inc:7899-7907)."""
+        if " " in line:
+            first, _, rest = line.partition(" ")
+            rest = rest.strip()
+            if _is_ipv4(first):
+                return rest
+            # plain "domain something" -> PHP keeps the chars before the space
+            return first
+        return line
+
+    def _extract(self, raw_line: str, fmt: str) -> tuple[str | None, str | None]:
+        """Return ``(domain, firewall_ip)`` for one raw line; either may be None.
+
+        Implements the per-format dispatch + the embedded-IP firewall detection of
+        the current parse loop. A generic bare-IP line yields ``(None, ip)`` -- the
+        IP goes to the firewall and the line is stripped from the domain build
+        (inc:7962-7973). The csv:pon format yields BOTH a domain (col2) AND, when
+        col0 is an IPv4, a firewall IP -- the current loop keeps both (it does NOT
+        ``continue`` after the col0-IP extraction; inc:7819-7835).
+        """
+        line = raw_line.strip()
+        if not line:
+            return None, None
+
+        if fmt == "abp":
+            # ABP control/comment lines (header, '!', '[') are dropped first.
+            if line.startswith("!") or line.startswith("["):
+                return None, None
+            host = self._parse_abp_line(line)
+            return (host or None), None
+
+        if fmt == "csv:pon":
+            # 9-col CSV: domain=col2 (always kept); col0 IP -> firewall ALSO.
+            if line.startswith("!") or line.lower().startswith("timestamp"):
+                return None, None
+            row = next(csv.reader(io.StringIO(line)))
+            if len(row) != 9:
+                return None, None
+            firewall_ip = row[0] if _is_ipv4(row[0]) else None
+            domain = row[2] or None
+            return domain, firewall_ip
+
+        # hosts / plain
+        if line.startswith("#") or line.startswith("!"):
+            return None, None
+        line = self._strip_hosts_prefix(line)
+        line = line.strip().strip(".")
+        if not line:
+            return None, None
+        # Embedded bare-IP -> firewall path (inc:7962-7973); stripped from Python.
+        if _is_ipv4(line):
+            return None, line
+        return line, None
+
+    @staticmethod
+    def _validate_domain(host: str) -> str | None:
+        """Lower-case + PFB_FILTER_DOMAIN shape gate (inc:7995-8016)."""
+        host = host.strip().strip(".").lower()
+        if "." not in host:
+            return None
+        # Representative domain-shape gate (labels of [a-z0-9-], not all-numeric).
+        for label in host.split("."):
+            if not label or label[0] == "-" or label[-1] == "-":
+                return None
+            if any(c not in "abcdefghijklmnopqrstuvwxyz0123456789-" for c in label):
+                return None
+        return host
+
+    # -- classify layer ----------------------------------------------------- #
+
+    def _load_tld_master(self) -> None:
+        """Load the public-suffix master, minus blacklisted/excluded TLDs.
+
+        tld_analysis:2630-2642 builds tlds[tld][full-suffix]; the TLD blacklist
+        (inc:2749-2751) and TLD exclusion (inc:2791-2793) remove entries.
+        """
+        blacklist = {t.strip(".") for t in self.config.get("tld_blacklist", [])}
+        # Exclusions remove the WHOLE-domain key from tlds (inc:2791); only
+        # single-label exclusions would match a tld key, but we mirror the unset.
+        exclusion_keys = {e.strip(".") for e in self.config.get("tld_exclusion", [])}
+        for line in _read_lines("tld_master.txt"):
+            suffix = line.strip()
+            if not suffix or suffix.startswith("#"):
+                continue
+            tld = suffix.rsplit(".", 1)[-1]
+            if tld in blacklist or tld in exclusion_keys:
+                continue
+            self._tlds[tld][suffix] = ""
+
+    def _tld_search(self, tld: str, dparts: list[str], j: int, k: int) -> str | None:
+        """tld_search (inc:2595-2603): if the j-label suffix is a known public
+        suffix, the registrable parent is the k-label slice."""
+        tld_query = ".".join(dparts[-j:])
+        if tld_query in self._tlds.get(tld, {}):
+            return ".".join(dparts[-k:])
+        return None
+
+    def _classify(self, domain: str) -> tuple[str, str]:
+        """Return ('zone', registrable-parent) or ('data', domain).
+
+        Mirrors tld_analysis:2832-2874: registrable-parent -> wildcard ZONE;
+        deeper sub-domain -> exact DATA; TLD-exclusion -> force exact DATA.
+        """
+        dparts = domain.split(".")
+        dcnt = len(dparts)
+        tld = dparts[-1]
+        dfound = ""
+
+        if dcnt > 5:
+            pass
+        elif dcnt == 5:
+            dfound = self._tld_search(tld, dparts, 4, 5) or ""
+        elif dcnt == 4:
+            dfound = self._tld_search(tld, dparts, 3, 4) or ""
+        elif dcnt == 3:
+            dfound = self._tld_search(tld, dparts, 2, 3) or ""
+        elif dcnt == 2:
+            dfound = ".".join(dparts[-2:])
+
+        # TLD exclusion: whole-domain in the exclusion set -> transparent (data).
+        exclusion = {e.strip(".") for e in self.config.get("tld_exclusion", [])}
+        if domain in exclusion:
+            dfound = ""
+
+        if dfound:
+            return "zone", dfound
+        return "data", domain
+
+    # -- whitelist layer ---------------------------------------------------- #
+
+    def _build_whitelist(self) -> None:
+        """User-whitelist normalisation (pfb_unbound_python_whitelist, inc:2259):
+        www-strip, leading-dot -> wildcard '1' else '0'. TOP1M -> whiteDB only when
+        enabled. whiteDB value is the wildcard bool the loader stores (inc:609-619)."""
+        for line in self.config.get("user_whitelist", []):
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("www."):
+                line = line[4:]
+            if line.startswith("."):
+                self.white_db[line.lstrip(".")] = True  # wildcard '1'
+            else:
+                self.white_db[line] = False  # exact '0'
+
+        if self.top1m_enabled:
+            for dom in self.config.get("top1m_list", []):
+                dom = dom.strip()
+                if dom:
+                    # TOP1M entries are exact bare domains -> wildcard '0'.
+                    self.white_db.setdefault(dom, False)
+
+    # -- build -------------------------------------------------------------- #
+
+    def _index_for(self, feed: str, group: str) -> int:
+        key = feed + group
+        idx = self._feed_group_db.get(key)
+        if idx is None:
+            idx = self._next_index
+            self._feed_group_db[key] = idx
+            self.feed_group_index_db[idx] = {"feed": feed, "group": group}
+            self._next_index += 1
+        return idx
+
+    def _emit_tld_blacklist_zones(self) -> None:
+        """Whole-TLD block: a blacklisted TLD becomes a synthetic DNSBL_TLD zone
+        entry (inc:2740 ``,<tld>,,1,DNSBL_TLD,DNSBL_TLD``)."""
+        for tld in self.config.get("tld_blacklist", []):
+            tld = tld.strip(".")
+            if not tld:
+                continue
+            idx = self._index_for("DNSBL_TLD", "DNSBL_TLD")
+            self.zone_db[tld] = {"log": "1", "index": idx}
+
+    def run(self) -> None:
+        self._load_tld_master()
+        self._emit_tld_blacklist_zones()
+        self._build_whitelist()
+
+        for feed_row in self.manifest["feeds"]:
+            feed = feed_row["feed"]
+            group = feed_row["group"]
+            fmt = feed_row["format_hint"]
+            log_flag = feed_row["log_flag"]
+            for raw_line in _read_lines(feed_row["raw"]):
+                value, firewall_ip = self._extract(raw_line, fmt)
+                if firewall_ip is not None:
+                    self.extracted_ips.add(firewall_ip)  # firewall handoff
+                if value is None:
+                    continue
+                domain = self._validate_domain(value)
+                if domain is None:
+                    continue
+                idx = self._index_for(feed, group)
+                ckind, key = self._classify(domain)
+                payload = {"log": log_flag, "index": idx}
+                if ckind == "zone":
+                    self.zone_db[key] = payload  # last-wins (dict; ADR-06 §2)
+                else:
+                    self.data_db[key] = payload
+
+
+# --------------------------------------------------------------------------- #
+# Decision driver -- run the PRODUCTION matcher decision functions over the
+# reference-built structures and reduce to a stable decision label.
+# --------------------------------------------------------------------------- #
+
+
+def _build_cfg(config: dict[str, Any], *, has_white: bool) -> dict[str, Any]:
+    """Config blob shaped like pfb_unbound.pfb, for evaluate_domain()."""
+    return {
+        "python_blocking": True,
+        "dataDB": True,
+        "zoneDB": True,
+        "whiteDB": has_white,
+        "hstsDB": True,
+        "regexDB": False,
+        "python_tld": False,
+        "python_idn": False,
+        "python_tld_seg": int(config.get("python_tld_seg", 1)),
+        "python_tlds": [],
+        "dnsbl_ipv4": "10.10.10.1",
+        "dnsbl_ipv6": "::1",
+        "hsts_tlds": ("app", "dev", "page"),
+    }
+
+
+def _decision_label(d: pfb_unbound.DnsblDecision) -> str:
+    """Reduce a DnsblDecision to a stable, human-readable outcome label.
+
+    These are the net DNS decisions the contract pins (ADR.md §2):
+      * "pass"        -> not on any list; resolves normally (pass-through).
+      * "whitelist"   -> on a list but un-blocked via whiteDB (resolves).
+      * "hsts"        -> on a list but bypassed via HSTS (resolves real).
+      * "block-null"  -> blocked and null-routed to the DNSBL sinkhole IP
+                         (log_flag '1', not HSTS -> null_blocking flips to False).
+      * "block-nolog" -> blocked, but log_flag '2' (block-but-skip-log):
+                         null_blocking STAYS True (only log '1' flips it), so the
+                         reply is built but not null-routed and the hit is not
+                         logged (pfb_unbound.py:1134). Still a block, distinct
+                         from HSTS (which sets in_hsts) and from whitelist.
+    """
+    if not d.is_found:
+        return "pass"
+    if d.in_whitelist:
+        return "whitelist"
+    if d.in_hsts:
+        return "hsts"
+    if not d.null_blocking:
+        return "block-null"
+    return "block-nolog"
+
+
+def _evaluate(pipeline: ReferencePipeline, config: dict[str, Any], q_name: str) -> dict[str, Any]:
+    """Run evaluate_domain for q_name; return the decision label + key attributes."""
+    containers = {
+        "dataDB": pipeline.data_db,
+        "zoneDB": pipeline.zone_db,
+        "whiteDB": pipeline.white_db,
+        "regexDB": {},
+        "feedGroupIndexDB": pipeline.feed_group_index_db,
+        "hstsDB": {d: 0 for d in config.get("hsts_domains", [])},
+    }
+    cfg = _build_cfg(config, has_white=bool(pipeline.white_db))
+    tld = q_name.rsplit(".", 1)[-1] if "." in q_name else q_name
+    decision = pfb_unbound.evaluate_domain(q_name, q_name, tld, False, cfg, containers)
+    return {
+        "decision": _decision_label(decision),
+        "b_type": decision.b_type,
+        "feed": decision.feed,
+        "group": decision.group,
+        "b_eval": decision.b_eval,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Golden expected decisions (committed, human-readable).
+#
+# Representative query set covering: exact-block (data), zone-subdomain (wildcard),
+# user-whitelisted, TOP1M-when-enabled, HSTS bypass, noAAAA, pass-through, basic-ABP
+# blocked, basic-ABP IGNORED (@@/##/$options/path/regex), TLD-blacklist whole-TLD
+# block, TLD-exclusion forced-exact, and a cross-feed duplicate.
+#
+# Each entry documents WHAT it asserts. ``b_type`` distinguishes exact DATA ("DNSBL")
+# from wildcard ZONE ("TLD"). Decisions -- NOT list contents/counts -- are the oracle.
+# --------------------------------------------------------------------------- #
+
+# TOP1M DISABLED (default scenario).
+#
+# Classification reminder (given tld_master.txt = {com, net, org, co.uk}): a
+# 2-label domain (its own registrable parent) -> wildcard ZONE (b_type "TLD"); a
+# deeper sub-domain whose registrable parent is NOT a known suffix -> exact DATA
+# (b_type "DNSBL"); a 3-label co.uk domain matches the multi-label public suffix
+# -> ZONE on the registrable parent.
+GOLDEN_TOP1M_DISABLED: dict[str, dict[str, Any]] = {
+    # 2-label registrable in hosts feed -> ZONE wildcard, exact name blocks...
+    "tracker.org": {"decision": "block-null", "b_type": "TLD"},
+    # ...and a child of that ZONE entry stays blocked (wildcard coverage).
+    "anything.tracker.org": {"decision": "block-null", "b_type": "TLD"},
+    "x.y.tracker.org": {"decision": "block-null", "b_type": "TLD"},
+    # another 2-label ZONE (hosts feed).
+    "evilads.net": {"decision": "block-null", "b_type": "TLD"},
+    # deep sub-domain in hosts feed whose parent (cleandata.com) is NOT listed ->
+    # exact DATA. Only that exact name blocks; a deeper child does NOT.
+    "deep.host.cleandata.com": {"decision": "block-null", "b_type": "DNSBL"},
+    "cleandata.com": {"decision": "pass"},
+    "deeper.deep.host.cleandata.com": {"decision": "pass"},
+    # plain-feed 2-label -> ZONE.
+    "malware.com": {"decision": "block-null", "b_type": "TLD"},
+    # deep sub-domain in plain feed (parent cleanmal.com NOT listed) -> exact DATA.
+    "deep.path.cleanmal.com": {"decision": "block-null", "b_type": "DNSBL"},
+    "cleanmal.com": {"decision": "pass"},
+    # multi-label public suffix co.uk: shop.co.uk is the registrable parent -> ZONE,
+    # and a subdomain of it blocks via the wildcard.
+    "shop.co.uk": {"decision": "block-null", "b_type": "TLD"},
+    "www.shop.co.uk": {"decision": "block-null", "b_type": "TLD"},
+    # user-whitelisted exact (phishing.net listed verbatim in plain feed) -> the
+    # domain IS blocked but whiteDB un-blocks it -> resolves.
+    "phishing.net": {"decision": "whitelist"},
+    # adblock.com is BLOCKED (plain feed ZONE) but the user whitelist normalises
+    # 'www.adblock.com' -> 'adblock.com' (www-strip) and un-blocks it -> resolves.
+    "adblock.com": {"decision": "whitelist"},
+    # ...and the www form is un-blocked via whiteDB's www-strip rule too.
+    "www.adblock.com": {"decision": "whitelist"},
+    # user-whitelisted wildcard ('.wildwhite.org' -> wildcard) but NOT on any
+    # blocklist -> still "pass" (whitelist only un-blocks; never blocks).
+    "host.wildwhite.org": {"decision": "pass"},
+    # TOP1M domain, TOP1M DISABLED -> blocks normally (present in plain feed, ZONE).
+    "popularcdn.com": {"decision": "block-null", "b_type": "TLD"},
+    # HSTS-listed blocked domain (ZONE, feed_extra) -> resolves real (HSTS bypass).
+    "hstslisted.com": {"decision": "hsts"},
+    # TLD-exclusion: excluded.com forced to exact DATA -> blocks exactly, but a
+    # subdomain does NOT block (transparent, not wildcard).
+    "excluded.com": {"decision": "block-null", "b_type": "DNSBL"},
+    "sub.excluded.com": {"decision": "pass"},
+    # log_flag '2' feed (block-but-skip-log) -> blocked but NOT null-routed/logged.
+    "silentblock.com": {"decision": "block-nolog", "b_type": "TLD"},
+    # basic-ABP "||domain^" 2-label -> blocked ZONE.
+    "abpblocked.com": {"decision": "block-null", "b_type": "TLD"},
+    # basic-ABP deep "||sub.abpzone.net^" (parent abpzone.net NOT listed) -> DATA.
+    "sub.abpzone.net": {"decision": "block-null", "b_type": "DNSBL"},
+    "abpzone.net": {"decision": "pass"},
+    # basic-ABP IGNORED lines -> NOT blocked (pass-through):
+    "abpallowed.com": {"decision": "pass"},  # @@ exception ignored
+    "abpoptions.com": {"decision": "pass"},  # $options line ignored
+    "abpwildcard.com": {"decision": "pass"},  # * line ignored
+    "abppath.com": {"decision": "pass"},  # /path line ignored
+    # csv:pon domain (col2) 2-label -> blocked ZONE.
+    "ponmocup.com": {"decision": "block-null", "b_type": "TLD"},
+    # csv:pon deep domain (parent cleanpon.com NOT listed) -> exact DATA.
+    "deep.node.cleanpon.com": {"decision": "block-null", "b_type": "DNSBL"},
+    # csv:pon col0-IP row STILL contributes its col2 domain to the block lists.
+    "ponip.net": {"decision": "block-null", "b_type": "TLD"},
+    # TLD-blacklist: any domain under blacklisted '.zip' -> whole-TLD ZONE block.
+    "anything.zip": {"decision": "block-null", "b_type": "TLD", "group": "DNSBL_TLD"},
+    "another.sub.zip": {"decision": "block-null", "b_type": "TLD", "group": "DNSBL_TLD"},
+    # pass-through: never listed anywhere -> resolves.
+    "totally-unrelated.com": {"decision": "pass"},
+    "good.net": {"decision": "pass"},
+}
+
+# TOP1M ENABLED scenario: ONLY the TOP1M domain flips to whitelist; everything else
+# is identical. Asserting both scenarios pins the TOP1M-when-enabled decision.
+GOLDEN_TOP1M_ENABLED_OVERRIDES: dict[str, dict[str, Any]] = {
+    "popularcdn.com": {"decision": "whitelist"},
+}
+
+# The extracted-IP firewall handoff set (the *_v4.ip -> DNSBLIP_v4 input). Comes
+# from generic bare-IP lines AND the csv:pon col-0 IPs. This is part of the oracle:
+# Phase 5's independent DNSBL-IP pass must produce the SAME set.
+GOLDEN_EXTRACTED_IPS: set[str] = {
+    "198.51.100.23",  # hosts feed bare IP
+    "203.0.113.45",  # plain feed bare IP
+    "198.51.100.77",  # csv:pon col0 IP (row 2)
+    "192.0.2.140",  # csv:pon col0 IP (row 3)
+}
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def _make_pipeline(*, top1m_enabled: bool) -> tuple[ReferencePipeline, dict[str, Any]]:
+    manifest = _load_json("manifest.json")
+    config = _load_json("config.json")
+    pipeline = ReferencePipeline(manifest, config, top1m_enabled=top1m_enabled)
+    pipeline.run()
+    return pipeline, config
+
+
+class TestGoldenDecisionsTop1mDisabled:
+    """Every query in the representative set reproduces its golden DECISION
+    (block shape / resolve / whitelist / HSTS / zone-subdomain / pass-through),
+    TOP1M disabled. This is the net-DNS-decision oracle Phase 3 diffs against."""
+
+    def test_decisions(self) -> None:
+        pipeline, config = _make_pipeline(top1m_enabled=False)
+        failures: list[str] = []
+        for q_name, expected in GOLDEN_TOP1M_DISABLED.items():
+            got = _evaluate(pipeline, config, q_name)
+            for k, v in expected.items():
+                if got[k] != v:
+                    failures.append(f"{q_name}: {k} expected {v!r} got {got[k]!r}")
+        assert not failures, "Golden decision mismatch:\n" + "\n".join(failures)
+
+
+class TestGoldenDecisionsTop1mEnabled:
+    """Same set with TOP1M enabled: the popular domain flips to 'whitelist'
+    (un-blocked via whiteDB); all other decisions are unchanged."""
+
+    def test_decisions(self) -> None:
+        pipeline, config = _make_pipeline(top1m_enabled=True)
+        expected_map = dict(GOLDEN_TOP1M_DISABLED)
+        expected_map.update(GOLDEN_TOP1M_ENABLED_OVERRIDES)
+        failures: list[str] = []
+        for q_name, expected in expected_map.items():
+            got = _evaluate(pipeline, config, q_name)
+            for k, v in expected.items():
+                if got[k] != v:
+                    failures.append(f"{q_name}: {k} expected {v!r} got {got[k]!r}")
+        assert not failures, "Golden decision mismatch (TOP1M enabled):\n" + "\n".join(failures)
+
+    def test_top1m_disabled_blocks_popular_domain(self) -> None:
+        """Guard the flip is real: with TOP1M disabled the popular domain blocks."""
+        pipeline, config = _make_pipeline(top1m_enabled=False)
+        got = _evaluate(pipeline, config, "popularcdn.com")
+        assert got["decision"] == "block-null"
+
+
+class TestGoldenNoAAAA:
+    """noAAAA decisions (independent of the DNSBL blocklist): an AAAA query for a
+    listed domain (exact or wildcard-parent) is blocked; others pass."""
+
+    def _noaaaa_db(self, config: dict[str, Any]) -> dict[str, Any]:
+        db: dict[str, Any] = {}
+        for dom, wild in config.get("noaaaa_domains", []):
+            db[dom] = wild == "1"
+        return db
+
+    def test_noaaaa_decisions(self) -> None:
+        _, config = _make_pipeline(top1m_enabled=False)
+        db = self._noaaaa_db(config)
+        # exact listed -> blocked
+        assert pfb_unbound.evaluate_noaaaa("noaaaa.com", db) is True
+        # wildcard parent listed -> subdomain blocked
+        assert pfb_unbound.evaluate_noaaaa("host.noaaaawild.net", db) is True
+        # wildcard-parent itself is also an exact key -> blocked.
+        assert pfb_unbound.evaluate_noaaaa("noaaaawild.net", db) is True
+        # exact non-wildcard entry: a subdomain is NOT covered -> not blocked.
+        assert pfb_unbound.evaluate_noaaaa("sub.noaaaa.com", db) is False
+        # unrelated -> not blocked (AAAA resolves normally)
+        assert pfb_unbound.evaluate_noaaaa("totally-unrelated.com", db) is False
+
+
+class TestGoldenExtractedIPSet:
+    """The embedded-IP firewall handoff (*_v4.ip -> DNSBLIP_v4 input) matches the
+    golden set, from BOTH generic bare-IP lines and the csv:pon col-0 IPs. IP lines
+    are stripped from the domain build (none leak into dataDB/zoneDB)."""
+
+    def test_extracted_ip_set(self) -> None:
+        pipeline, _ = _make_pipeline(top1m_enabled=False)
+        assert pipeline.extracted_ips == GOLDEN_EXTRACTED_IPS
+
+    def test_no_ip_leaked_into_block_lists(self) -> None:
+        pipeline, _ = _make_pipeline(top1m_enabled=False)
+        for ip in GOLDEN_EXTRACTED_IPS:
+            assert ip not in pipeline.data_db
+            assert ip not in pipeline.zone_db
+
+
+class TestReferencePipelineSanity:
+    """Sanity checks on the reference preprocessor itself (so a broken model is
+    caught, not silently green): the data/zone split and feed/group attribution
+    are populated as expected from the fixtures."""
+
+    def test_zone_and_data_populated(self) -> None:
+        pipeline, _ = _make_pipeline(top1m_enabled=False)
+        # 2-label registrable domains land in zone_db
+        assert "tracker.org" in pipeline.zone_db
+        assert "malware.com" in pipeline.zone_db
+        # multi-label public-suffix registrable parent -> zone_db
+        assert "shop.co.uk" in pipeline.zone_db
+        # deep sub-domains (parent not listed) land in data_db (exact)
+        assert "deep.host.cleandata.com" in pipeline.data_db
+        assert "deep.path.cleanmal.com" in pipeline.data_db
+        # TLD-exclusion forces a would-be-zone 2-label into data_db (exact)
+        assert "excluded.com" in pipeline.data_db
+        assert "excluded.com" not in pipeline.zone_db
+        # TLD-blacklist synthetic zone entry present, attributed to DNSBL_TLD
+        assert "zip" in pipeline.zone_db
+        tld_idx = pipeline.zone_db["zip"]["index"]
+        assert pipeline.feed_group_index_db[tld_idx] == {"feed": "DNSBL_TLD", "group": "DNSBL_TLD"}
+
+    def test_cross_feed_duplicate_last_wins(self) -> None:
+        """tracker.org is in BOTH the hosts feed (Ads) and the plain feed (Malware);
+        the dict load keeps LAST (ADR-06 §2 attribution change) -> PlainFeed/Malware."""
+        pipeline, _ = _make_pipeline(top1m_enabled=False)
+        idx = pipeline.zone_db["tracker.org"]["index"]
+        fg = pipeline.feed_group_index_db[idx]
+        assert fg == {"feed": "PlainFeed", "group": "Malware"}
+
+    def test_whitelist_normalisation(self) -> None:
+        pipeline, _ = _make_pipeline(top1m_enabled=False)
+        # www. stripped, exact (wildcard False)
+        assert pipeline.white_db.get("adblock.com") is False
+        # leading-dot -> wildcard True
+        assert pipeline.white_db.get("wildwhite.org") is True
+        # plain exact entry
+        assert pipeline.white_db.get("phishing.net") is False
+        # TOP1M domain NOT in whiteDB when disabled
+        assert "popularcdn.com" not in pipeline.white_db
+
+    def test_top1m_loads_whitelist_when_enabled(self) -> None:
+        pipeline, _ = _make_pipeline(top1m_enabled=True)
+        assert pipeline.white_db.get("popularcdn.com") is False

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -1,0 +1,416 @@
+"""ADR-06 Phase 4 -- init builds the DNSBL structures from RAW + emits counts.
+
+WHY THIS FILE EXISTS
+--------------------
+Phase 4 switches ``pfb_unbound`` init to BUILD the DNSBL structures from the raw
+feeds via the Phase-3 ``build()`` layer (the new shell->Python boundary), assign
+them into the matcher globals, and EMIT ``pfb_py_count``. This module proves the
+new init-from-raw path is decision-equivalent to BOTH:
+
+  * the Phase-2 golden oracle (the pinned current decisions), AND
+  * the Phase-2 ReferencePipeline (a faithful stand-in for the OLD loader),
+
+over the golden fixtures -- for both TOP1M scenarios, the noAAAA surface, and the
+no-IP-leak guarantee. It also pins the on-box wiring:
+
+  * ``dnsbl_build_from_manifest`` reads a per-feed manifest JSON whose ``config``
+    block carries ``tld_master`` as a FILE PATH (read here, not a Python list) and
+    whose feeds reference raw files relative to the manifest dir;
+  * ``top1m_enabled`` is driven by ``config["top1m_enabled"]`` in the manifest;
+  * ``dnsbl_emit_count`` writes the LOADED total (len(dataDB)+len(zoneDB)) to
+    ``pfb_py_count`` in the format the UI reads (pfblockerng.inc:3149); and
+  * a missing/broken manifest yields ``None`` (init falls back to the legacy CSV
+    load -- shell/PHP still produce those files until Phase 5).
+
+The contract is DECISIONS, not list contents/counts (ADR.md SS2): the build's
+dicts differ from today's pruned lists by design (no dedup/collapse/whitelist/
+TOP1M removal), but every block/resolve/whitelist/HSTS/noAAAA/zone-subdomain
+outcome is identical.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+
+import pfb_unbound
+
+# Reuse the Phase-2 oracle's fixtures, golden decision tables, decision driver AND
+# the ReferencePipeline (the old-loader stand-in) so the new init path is validated
+# against the EXACT same contract -- never a copy.
+from tests.test_adr06_golden_oracle import (
+    FIXTURES,
+    GOLDEN_EXTRACTED_IPS,
+    GOLDEN_TOP1M_DISABLED,
+    GOLDEN_TOP1M_ENABLED_OVERRIDES,
+    ReferencePipeline,
+    _build_cfg,
+    _decision_label,
+    _evaluate,
+    _load_json,
+    _read_lines,
+)
+
+# --------------------------------------------------------------------------- #
+# Build an ON-BOX-shaped manifest JSON on disk (feeds + a ``config`` block) so the
+# wiring is exercised exactly as init() will read it: ``tld_master`` is a FILE PATH
+# (relative to the manifest dir), feed ``raw`` references are relative, and
+# ``top1m_enabled`` lives in the config block.
+# --------------------------------------------------------------------------- #
+
+
+def _write_onbox_manifest(tmp_path: Any, *, top1m_enabled: bool) -> str:
+    """Write a single manifest JSON (feeds + config) next to the fixture raw feeds.
+
+    The manifest is written INTO the fixtures dir is avoided -- instead the feed
+    ``raw`` / ``tld_master`` are made ABSOLUTE (pointing at the committed fixtures)
+    so the manifest can live in a tmp dir without copying the feeds.
+    """
+    src_manifest = _load_json("manifest.json")
+    src_config = _load_json("config.json")
+
+    feeds = []
+    for row in src_manifest["feeds"]:
+        feeds.append(
+            {
+                "raw": os.path.join(FIXTURES, row["raw"]),  # absolute -> reader resolves
+                "feed": row["feed"],
+                "group": row["group"],
+                "format_hint": row["format_hint"],
+                "log_flag": row["log_flag"],
+            }
+        )
+
+    manifest = {
+        "version": 1,
+        "config": {
+            "tld_master": os.path.join(FIXTURES, "tld_master.txt"),  # PATH, read on build
+            "tld_blacklist": src_config.get("tld_blacklist", []),
+            "tld_exclusion": src_config.get("tld_exclusion", []),
+            "user_whitelist": src_config.get("user_whitelist", []),
+            "top1m_list": src_config.get("top1m_list", []),
+            "top1m_enabled": top1m_enabled,
+        },
+        "feeds": feeds,
+    }
+
+    path = os.path.join(str(tmp_path), "pfb_py_sources.json")
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh)
+    return path
+
+
+def _build_from_manifest(tmp_path: Any, *, top1m_enabled: bool) -> pfb_unbound.BuildResult:
+    manifest_path = _write_onbox_manifest(tmp_path, top1m_enabled=top1m_enabled)
+    result = pfb_unbound.dnsbl_build_from_manifest(manifest_path)
+    assert result is not None
+    return result
+
+
+def _evaluate_result(result: pfb_unbound.BuildResult, config: dict[str, Any], q_name: str) -> dict[str, Any]:
+    """Run the PRODUCTION ``evaluate_domain`` over the init-from-raw structures."""
+    containers = {
+        "dataDB": result.data_db,
+        "zoneDB": result.zone_db,
+        "whiteDB": result.white_db,
+        "regexDB": {},
+        "feedGroupIndexDB": result.feed_group_index_db,
+        "hstsDB": {d: 0 for d in config.get("hsts_domains", [])},
+    }
+    cfg = _build_cfg(config, has_white=bool(result.white_db))
+    tld = q_name.rsplit(".", 1)[-1] if "." in q_name else q_name
+    decision = pfb_unbound.evaluate_domain(q_name, q_name, tld, False, cfg, containers)
+    return {
+        "decision": _decision_label(decision),
+        "b_type": decision.b_type,
+        "feed": decision.feed,
+        "group": decision.group,
+        "b_eval": decision.b_eval,
+    }
+
+
+def _old_pipeline(*, top1m_enabled: bool) -> tuple[ReferencePipeline, dict[str, Any]]:
+    manifest = _load_json("manifest.json")
+    config = _load_json("config.json")
+    pipeline = ReferencePipeline(manifest, config, top1m_enabled=top1m_enabled)
+    pipeline.run()
+    return pipeline, config
+
+
+# --------------------------------------------------------------------------- #
+# init-from-raw == the Phase-2 DECISION oracle (the pinned current behaviour).
+# --------------------------------------------------------------------------- #
+
+
+class TestInitFromRawDecisionsTop1mDisabled:
+    def test_decisions(self, tmp_path: Any) -> None:
+        result = _build_from_manifest(tmp_path, top1m_enabled=False)
+        config = _load_json("config.json")
+        failures: list[str] = []
+        for q_name, expected in GOLDEN_TOP1M_DISABLED.items():
+            got = _evaluate_result(result, config, q_name)
+            for k, v in expected.items():
+                if got[k] != v:
+                    failures.append(f"{q_name}: {k} expected {v!r} got {got[k]!r}")
+        assert not failures, "init-from-raw decision mismatch:\n" + "\n".join(failures)
+
+
+class TestInitFromRawDecisionsTop1mEnabled:
+    def test_decisions(self, tmp_path: Any) -> None:
+        result = _build_from_manifest(tmp_path, top1m_enabled=True)
+        config = _load_json("config.json")
+        expected_map = dict(GOLDEN_TOP1M_DISABLED)
+        expected_map.update(GOLDEN_TOP1M_ENABLED_OVERRIDES)
+        failures: list[str] = []
+        for q_name, expected in expected_map.items():
+            got = _evaluate_result(result, config, q_name)
+            for k, v in expected.items():
+                if got[k] != v:
+                    failures.append(f"{q_name}: {k} expected {v!r} got {got[k]!r}")
+        assert not failures, "init-from-raw decision mismatch (TOP1M enabled):\n" + "\n".join(failures)
+
+    def test_top1m_enabled_flows_from_manifest_config(self, tmp_path: Any) -> None:
+        # The manifest's config.top1m_enabled drives the whiteDB load: enabled ->
+        # the popular domain is un-blocked; disabled -> it blocks.
+        enabled = _build_from_manifest(tmp_path, top1m_enabled=True)
+        assert enabled.white_db.get("popularcdn.com") is False
+        disabled = _build_from_manifest(tmp_path, top1m_enabled=False)
+        assert "popularcdn.com" not in disabled.white_db
+
+
+# --------------------------------------------------------------------------- #
+# init-from-raw == the OLD loader (the ReferencePipeline), decision-for-decision.
+# --------------------------------------------------------------------------- #
+
+
+class TestInitFromRawEqualsOldLoader:
+    @pytest.mark.parametrize("top1m_enabled", [False, True])
+    def test_decisions_match_old_loader(self, tmp_path: Any, top1m_enabled: bool) -> None:
+        result = _build_from_manifest(tmp_path, top1m_enabled=top1m_enabled)
+        pipeline, config = _old_pipeline(top1m_enabled=top1m_enabled)
+
+        expected_map = dict(GOLDEN_TOP1M_DISABLED)
+        if top1m_enabled:
+            expected_map.update(GOLDEN_TOP1M_ENABLED_OVERRIDES)
+
+        failures: list[str] = []
+        for q_name in expected_map:
+            new = _evaluate_result(result, config, q_name)
+            old = _evaluate(pipeline, config, q_name)
+            if new != old:
+                failures.append(f"{q_name}: new {new!r} != old {old!r}")
+        assert not failures, "init-from-raw vs old-loader decision mismatch:\n" + "\n".join(failures)
+
+
+# --------------------------------------------------------------------------- #
+# noAAAA decisions + no-IP-leak (the firewall handoff stays in PHP).
+# --------------------------------------------------------------------------- #
+
+
+class TestInitFromRawNoAAAA:
+    def test_noaaaa_decisions(self) -> None:
+        config = _load_json("config.json")
+        db = {dom: wild == "1" for dom, wild in config.get("noaaaa_domains", [])}
+        assert pfb_unbound.evaluate_noaaaa("noaaaa.com", db) is True
+        assert pfb_unbound.evaluate_noaaaa("host.noaaaawild.net", db) is True
+        assert pfb_unbound.evaluate_noaaaa("noaaaawild.net", db) is True
+        assert pfb_unbound.evaluate_noaaaa("sub.noaaaa.com", db) is False
+        assert pfb_unbound.evaluate_noaaaa("totally-unrelated.com", db) is False
+
+
+class TestInitFromRawNoIpLeak:
+    def test_no_ip_leaked_into_block_lists(self, tmp_path: Any) -> None:
+        result = _build_from_manifest(tmp_path, top1m_enabled=False)
+        for ip in GOLDEN_EXTRACTED_IPS:
+            assert ip not in result.data_db
+            assert ip not in result.zone_db
+
+
+# --------------------------------------------------------------------------- #
+# Counts: pfb_py_count is the LOADED total and is written in the UI's format.
+# --------------------------------------------------------------------------- #
+
+
+class TestInitFromRawCounts:
+    def test_counts_is_loaded_total(self, tmp_path: Any) -> None:
+        result = _build_from_manifest(tmp_path, top1m_enabled=False)
+        assert result.counts == len(result.data_db) + len(result.zone_db)
+        assert result.counts > 0
+
+    def test_emit_count_writes_loaded_total(self, tmp_path: Any) -> None:
+        result = _build_from_manifest(tmp_path, top1m_enabled=False)
+        count_path = os.path.join(str(tmp_path), "pfb_py_count")
+        assert pfb_unbound.dnsbl_emit_count(count_path, result.counts) is True
+        with open(count_path, encoding="utf-8") as fh:
+            written = fh.read().strip()
+        assert written == str(result.counts)
+        # The emitted total must equal the actually-loaded entry count.
+        assert int(written) == len(result.data_db) + len(result.zone_db)
+
+    def test_count_matches_loaded_entries(self, tmp_path: Any) -> None:
+        # Cross-check the emitted count against the structures the matcher will use.
+        result = _build_from_manifest(tmp_path, top1m_enabled=False)
+        loaded = len(result.data_db) + len(result.zone_db)
+        assert result.counts == loaded
+
+
+# --------------------------------------------------------------------------- #
+# Wiring robustness: absent / broken manifest -> None (init falls back to legacy).
+# --------------------------------------------------------------------------- #
+
+
+class TestManifestFallback:
+    def test_missing_manifest_returns_none(self, tmp_path: Any) -> None:
+        assert pfb_unbound.dnsbl_build_from_manifest(os.path.join(str(tmp_path), "nope.json")) is None
+
+    def test_broken_manifest_returns_none(self, tmp_path: Any) -> None:
+        bad = os.path.join(str(tmp_path), "bad.json")
+        with open(bad, "w", encoding="utf-8") as fh:
+            fh.write("{ this is not json")
+        assert pfb_unbound.dnsbl_build_from_manifest(bad) is None
+
+    def test_missing_feed_file_is_skipped_not_fatal(self, tmp_path: Any) -> None:
+        # One feed references a non-existent raw file; the build must still load the
+        # OTHER feeds rather than aborting (the bad feed is logged + skipped).
+        path = os.path.join(str(tmp_path), "m.json")
+        manifest = {
+            "version": 1,
+            "config": {"tld_master": os.path.join(FIXTURES, "tld_master.txt")},
+            "feeds": [
+                {
+                    "raw": os.path.join(str(tmp_path), "does_not_exist.txt"),
+                    "feed": "Gone",
+                    "group": "Gone",
+                    "format_hint": "plain",
+                    "log_flag": "1",
+                },
+                {
+                    "raw": os.path.join(FIXTURES, "feed_plain.txt"),
+                    "feed": "PlainFeed",
+                    "group": "Malware",
+                    "format_hint": "plain",
+                    "log_flag": "1",
+                },
+            ],
+        }
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(manifest, fh)
+        result = pfb_unbound.dnsbl_build_from_manifest(path)
+        assert result is not None
+        # The good feed's entries are present despite the missing one.
+        assert "malware.com" in result.zone_db
+
+    def test_empty_feeds_manifest_builds_empty(self, tmp_path: Any) -> None:
+        # A manifest with no feeds still builds (TLD-blacklist zones + whiteDB only).
+        path = os.path.join(str(tmp_path), "m.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump({"version": 1, "config": {}, "feeds": []}, fh)
+        result = pfb_unbound.dnsbl_build_from_manifest(path)
+        assert result is not None
+        assert result.counts == 0
+        assert result.data_db == {}
+        assert result.zone_db == {}
+
+
+# --------------------------------------------------------------------------- #
+# tld_master accepted as a PATH (on-box) -- read into suffix lines by the build.
+# --------------------------------------------------------------------------- #
+
+
+class TestInitGlobalAssignment:
+    """The init glue assigns the BuildResult into the matcher's module globals
+    (dataDB/zoneDB/whiteDB/feedGroupIndexDB) -- the exact dicts ``operate()`` builds
+    its ``containers`` from at query time (pfb_unbound.py:2660-2667). Mimic that
+    assignment and evaluate THROUGH the globals to prove the wiring + that the
+    query-time whiteDB application path is unchanged."""
+
+    def test_decisions_through_module_globals(self, tmp_path: Any) -> None:
+        result = _build_from_manifest(tmp_path, top1m_enabled=False)
+        config = _load_json("config.json")
+
+        # Exactly what init_standard does after a successful build.
+        pfb_unbound.dataDB = result.data_db
+        pfb_unbound.zoneDB = result.zone_db
+        pfb_unbound.feedGroupIndexDB = result.feed_group_index_db
+        pfb_unbound.whiteDB = result.white_db
+        pfb_unbound.hstsDB = {d: 0 for d in config.get("hsts_domains", [])}
+
+        cfg = _build_cfg(config, has_white=bool(result.white_db))
+        # Build containers from the GLOBALS, mirroring operate().
+        containers = {
+            "dataDB": pfb_unbound.dataDB,
+            "zoneDB": pfb_unbound.zoneDB,
+            "whiteDB": pfb_unbound.whiteDB,
+            "regexDB": pfb_unbound.regexDB,
+            "feedGroupIndexDB": pfb_unbound.feedGroupIndexDB,
+            "hstsDB": pfb_unbound.hstsDB,
+        }
+        failures: list[str] = []
+        for q_name, expected in GOLDEN_TOP1M_DISABLED.items():
+            tld = q_name.rsplit(".", 1)[-1] if "." in q_name else q_name
+            dec = pfb_unbound.evaluate_domain(q_name, q_name, tld, False, cfg, containers)
+            label = _decision_label(dec)
+            if label != expected["decision"]:
+                failures.append(f"{q_name}: expected {expected['decision']!r} got {label!r}")
+        assert not failures, "global-assignment decision mismatch:\n" + "\n".join(failures)
+
+    def test_whitelist_unblocks_through_globals(self, tmp_path: Any) -> None:
+        # The query-time whiteDB application is unchanged: a listed domain whose
+        # parent/self is in whiteDB resolves (whitelist), not blocked.
+        result = _build_from_manifest(tmp_path, top1m_enabled=False)
+        config = _load_json("config.json")
+        pfb_unbound.dataDB = result.data_db
+        pfb_unbound.zoneDB = result.zone_db
+        pfb_unbound.feedGroupIndexDB = result.feed_group_index_db
+        pfb_unbound.whiteDB = result.white_db
+
+        cfg = _build_cfg(config, has_white=True)
+        containers = {
+            "dataDB": pfb_unbound.dataDB,
+            "zoneDB": pfb_unbound.zoneDB,
+            "whiteDB": pfb_unbound.whiteDB,
+            "regexDB": {},
+            "feedGroupIndexDB": pfb_unbound.feedGroupIndexDB,
+            "hstsDB": {},
+        }
+        # adblock.com is BLOCKED (zone) but whiteDB un-blocks it -> resolves.
+        dec = pfb_unbound.evaluate_domain("adblock.com", "adblock.com", "com", False, cfg, containers)
+        assert _decision_label(dec) == "whitelist"
+
+
+class TestTldMasterPath:
+    def test_tld_master_path_is_read(self, tmp_path: Any) -> None:
+        # With the public-suffix master read from the PATH, co.uk classifies as a
+        # multi-label public suffix -> shop.co.uk is a ZONE (registrable parent).
+        result = _build_from_manifest(tmp_path, top1m_enabled=False)
+        assert "shop.co.uk" in result.zone_db
+        assert "tracker.org" in result.zone_db
+
+    def test_tld_master_lines_also_supported(self) -> None:
+        # The build config also accepts tld_master as a list of lines directly
+        # (used by the Phase-3 unit tests); the path form must be equivalent.
+        manifest = {
+            "version": 1,
+            "config": {
+                "tld_master": _read_lines("tld_master.txt"),
+                "tld_blacklist": [],
+                "tld_exclusion": [],
+                "user_whitelist": [],
+                "top1m_list": [],
+            },
+            "feeds": [
+                {
+                    "raw": os.path.join(FIXTURES, "feed_plain.txt"),
+                    "feed": "PlainFeed",
+                    "group": "Malware",
+                    "format_hint": "plain",
+                    "log_flag": "1",
+                }
+            ],
+        }
+        # Reach into the helper that shapes config so the list path is exercised.
+        config = pfb_unbound._dnsbl_config_from_manifest(manifest, FIXTURES)
+        assert config["tld_master"] == _read_lines("tld_master.txt")

--- a/tests/test_adr06_php_boundary.py
+++ b/tests/test_adr06_php_boundary.py
@@ -1,0 +1,185 @@
+"""ADR-06 Phase 5 -- the PHP/shell boundary hands Python a 'plain' per-feed raw.
+
+WHY THIS FILE EXISTS
+--------------------
+Phase 5 slims the shell/PHP DNSBL pipeline. The chosen boundary is:
+
+  * PHP keeps the per-feed download + multi-format domain extraction loop (hosts /
+    plain / basic-ABP / the CSV threat-feed sniffers / IDN) -- it already produces
+    one cleaned, lower-cased, IP-stripped domain per line in each per-feed ``.txt``
+    (the 6-col CSV's col1). The DNSBL-IP firewall pass already routes embedded IPs
+    to the ``*_v4.ip`` / ``DNSBLIP_v4`` path and excludes them from ``.txt``.
+  * ``pfb_unbound_python_sources()`` (pfblockerng.inc) then extracts col1 of each
+    ``.txt`` into a per-feed raw file and references it in the manifest with
+    ``format_hint: "plain"`` -- because PHP has ALREADY done the per-format work,
+    Python's ``parse("plain")`` only has to re-validate + lower-case.
+
+This test proves that boundary is DECISION-EQUIVALENT: it simulates exactly what
+PHP writes (run the reference per-format extractor over each fixture feed to get
+the bare domains, exactly as the PHP loop would, dropping embedded IPs), writes
+them as ``plain`` per-feed raw files, builds a ``plain``-ONLY manifest, runs the
+PRODUCTION ``dnsbl_build_from_manifest`` + ``evaluate_domain`` over it, and asserts
+EVERY golden decision is reproduced -- for both TOP1M scenarios -- and that no
+firewall IP leaks into the domain build.
+
+If a future change makes PHP hand Python the ORIGINAL raw feed lines per format
+instead (format_hint hosts/abp/csv:pon), the existing test_adr06_init_from_raw.py
+already pins that path; this file pins the Phase-5 ``plain``-only boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pfb_unbound
+from tests.test_adr06_golden_oracle import (
+    FIXTURES,
+    GOLDEN_EXTRACTED_IPS,
+    GOLDEN_TOP1M_DISABLED,
+    GOLDEN_TOP1M_ENABLED_OVERRIDES,
+    ReferencePipeline,
+    _build_cfg,
+    _decision_label,
+    _load_json,
+    _read_lines,
+)
+
+
+def _php_cleaned_feed_domains(feed_row: dict[str, Any]) -> tuple[list[str], set[str]]:
+    """Reproduce the per-feed PHP '.txt' col1 = the cleaned, IP-stripped, lower-cased
+    domains PHP writes for a feed, plus the firewall IPs it diverts.
+
+    Uses the reference extractor (the authoritative model of the current PHP parse
+    loop) so this test mirrors the PHP boundary EXACTLY rather than guessing.
+    """
+    pipeline = ReferencePipeline({"feeds": []}, _load_json("config.json"), top1m_enabled=False)
+    domains: list[str] = []
+    firewall_ips: set[str] = set()
+    for raw_line in _read_lines(feed_row["raw"]):
+        value, firewall_ip = pipeline._extract(raw_line, feed_row["format_hint"])
+        if firewall_ip is not None:
+            firewall_ips.add(firewall_ip)
+        if value is None:
+            continue
+        domain = pipeline._validate_domain(value)
+        if domain is None:
+            continue
+        domains.append(domain.lower())  # inc:8016 strtolower
+    return domains, firewall_ips
+
+
+def _write_plain_boundary_manifest(tmp_path: Any, *, top1m_enabled: bool) -> tuple[str, set[str]]:
+    """Write per-feed PLAIN raw files (PHP-cleaned col1) + a plain-only manifest.
+
+    Returns the manifest path and the union of firewall IPs PHP diverted (which must
+    NOT appear in the domain build).
+    """
+    src_manifest = _load_json("manifest.json")
+    src_config = _load_json("config.json")
+
+    raw_dir = os.path.join(str(tmp_path), "pfb_py_raw")
+    os.makedirs(raw_dir, exist_ok=True)
+
+    feeds = []
+    all_firewall_ips: set[str] = set()
+    for row in src_manifest["feeds"]:
+        domains, firewall_ips = _php_cleaned_feed_domains(row)
+        all_firewall_ips |= firewall_ips
+        raw_path = os.path.join(raw_dir, "{}.raw".format(row["feed"]))
+        with open(raw_path, "w", encoding="utf-8") as fh:
+            fh.write("".join("{}\n".format(d) for d in domains))
+        feeds.append(
+            {
+                "raw": raw_path,
+                "feed": row["feed"],
+                "group": row["group"],
+                "format_hint": "plain",  # ADR-06 P5: PHP already extracted the domain
+                "log_flag": row["log_flag"],
+            }
+        )
+
+    manifest = {
+        "version": 1,
+        "config": {
+            "tld_master": os.path.join(FIXTURES, "tld_master.txt"),
+            "tld_blacklist": src_config.get("tld_blacklist", []),
+            "tld_exclusion": src_config.get("tld_exclusion", []),
+            "user_whitelist": src_config.get("user_whitelist", []),
+            "top1m_list": src_config.get("top1m_list", []),
+            "top1m_enabled": top1m_enabled,
+        },
+        "feeds": feeds,
+    }
+    manifest_path = os.path.join(str(tmp_path), "pfb_py_sources.json")
+    with open(manifest_path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh)
+    return manifest_path, all_firewall_ips
+
+
+def _build(tmp_path: Any, *, top1m_enabled: bool) -> tuple[pfb_unbound.BuildResult, set[str]]:
+    manifest_path, firewall_ips = _write_plain_boundary_manifest(tmp_path, top1m_enabled=top1m_enabled)
+    result = pfb_unbound.dnsbl_build_from_manifest(manifest_path)
+    assert result is not None
+    return result, firewall_ips
+
+
+def _evaluate(result: pfb_unbound.BuildResult, config: dict[str, Any], q_name: str) -> dict[str, Any]:
+    containers = {
+        "dataDB": result.data_db,
+        "zoneDB": result.zone_db,
+        "whiteDB": result.white_db,
+        "regexDB": {},
+        "feedGroupIndexDB": result.feed_group_index_db,
+        "hstsDB": {d: 0 for d in config.get("hsts_domains", [])},
+    }
+    cfg = _build_cfg(config, has_white=bool(result.white_db))
+    tld = q_name.rsplit(".", 1)[-1] if "." in q_name else q_name
+    decision = pfb_unbound.evaluate_domain(q_name, q_name, tld, False, cfg, containers)
+    return {
+        "decision": _decision_label(decision),
+        "b_type": decision.b_type,
+        "feed": decision.feed,
+        "group": decision.group,
+        "b_eval": decision.b_eval,
+    }
+
+
+class TestPlainBoundaryDecisionsTop1mDisabled:
+    def test_decisions(self, tmp_path: Any) -> None:
+        result, _ = _build(tmp_path, top1m_enabled=False)
+        config = _load_json("config.json")
+        failures: list[str] = []
+        for q_name, expected in GOLDEN_TOP1M_DISABLED.items():
+            got = _evaluate(result, config, q_name)
+            for k, v in expected.items():
+                if got[k] != v:
+                    failures.append(f"{q_name}: {k} expected {v!r} got {got[k]!r}")
+        assert not failures, "plain-boundary decision mismatch:\n" + "\n".join(failures)
+
+
+class TestPlainBoundaryDecisionsTop1mEnabled:
+    def test_decisions(self, tmp_path: Any) -> None:
+        result, _ = _build(tmp_path, top1m_enabled=True)
+        config = _load_json("config.json")
+        expected_map = dict(GOLDEN_TOP1M_DISABLED)
+        expected_map.update(GOLDEN_TOP1M_ENABLED_OVERRIDES)
+        failures: list[str] = []
+        for q_name, expected in expected_map.items():
+            got = _evaluate(result, config, q_name)
+            for k, v in expected.items():
+                if got[k] != v:
+                    failures.append(f"{q_name}: {k} expected {v!r} got {got[k]!r}")
+        assert not failures, "plain-boundary decision mismatch (TOP1M enabled):\n" + "\n".join(failures)
+
+
+class TestPlainBoundaryNoIpLeak:
+    def test_firewall_ips_absent_from_domain_build(self, tmp_path: Any) -> None:
+        # The PHP DNSBL-IP pass diverts these to the firewall (*_v4.ip / DNSBLIP_v4)
+        # and strips them from the per-feed raw -- they must never reach data/zone.
+        result, firewall_ips = _build(tmp_path, top1m_enabled=False)
+        assert firewall_ips == GOLDEN_EXTRACTED_IPS
+        keys = set(result.data_db) | set(result.zone_db)
+        leaked = firewall_ips & keys
+        assert not leaked, f"firewall IPs leaked into the domain build: {sorted(leaked)}"


### PR DESCRIPTION
## ADR-06 — Move DNSBL list preprocessing out of shell/PHP into the Python plugin

Moves DNSBL list preprocessing (parse → normalise → classify data/zone → build dicts + feed/group index + `whiteDB`, then emit `pfb_py_count`) **out of the shell/PHP pipeline and into the `pfb_unbound.py` Python plugin**. PHP/shell are slimmed to download + feed/group tagging + the DNSBL-IP firewall pass + writing the manifest/raw + user-whitelist input. The build-time optimisations being dropped (within/cross-list dedup, subdomain collapse, build-time whitelist/TOP1M pruning) are **not** reimplemented — the dict load dedups keys for free, the parent zone still matches redundant subdomains, and whitelist/TOP1M application stays query-time.

Full design, contract, and per-phase rationale: `.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/` (ADR.md + RESULTS/01–06).

### Phases (6 commits, oracle-gated)

| P | Commit | What |
|---|--------|------|
| 1 | `54acd74` | Inventory the shell/PHP→Python contract + de-risking spike & init/memory kill-gate (**GO**) |
| 2 | `f8899df` | Golden DECISION oracle pinning current behaviour (hosts/plain/basic-ABP/csv:pon + extracted-IP set) |
| 3 | `10e5c54` | Pure, stdlib-only, reentrant `build()` layer (parse/classify/build), unit-tested vs the oracle |
| 4 | `242d18b` | Wire init to build from raw via the manifest + emit `pfb_py_count`; old shell/PHP kept as live fallback |
| 5 | `979d871` | Slim shell/PHP to download+tag+manifest+whitelist input; drop dead native-mode + duplicated preprocessing; DNSBL-IP firewall stays in PHP |
| 6 | `32f6a17` | Validation, init/mem re-measurement, docs (README/CLAUDE.md/ADR §7), DoD + manual-smoke checklist |

### Equivalence — PASS

Decision-equivalence (block / resolve / whitelist / HSTS / noAAAA / zone-subdomain) is pinned across **all** formats through the **production** matcher (`evaluate_domain`/`evaluate_noaaaa`): golden oracle + init-from-raw (`dnsbl_build_from_manifest`, both TOP1M scenarios) + PHP-boundary round-trip. Feed/group attribution, no-IP-leak, and `pfb_py_count` = loaded total are all asserted. **255 passed**; ruff / php -l / ShellCheck / markdownlint clean.

### Init/memory — RE-MEASURED on this branch's production build path, GO confirmed

| size | build median (max) | peak RAM | B/entry | verdict |
|------|--------------------|----------|---------|---------|
| 1M | 2.28s (2.33) | 141.5 MiB | 281.5 (+3% vs 274 baseline) | PASS |
| 2M | 4.39s (4.43) | 266.8 MiB | 284.7 (+4%) | PASS |

Threshold: build ≤8s AND ≤410 B/entry — both pass with headroom; time linear (~2.2µs/line); §7 boundary pivot **not** triggered. (Methodology fix: wall-time must be timed with `tracemalloc` **off** — instrumentation inflated the Phase-1 spike figures ~3–4×; documented in ADR §7.)

### Not done here — maintainer gate

**Status stays "Implemented — pending live smoke"** — no live Unbound in CI. Maintainer must run the §7 manual-smoke checklist on a live box (block decisions; whitelist both entry points + wildcard; counts/UI; TLD blacklist/exclusion + TOP1M now global; DNSBL-IP → `DNSBLIP_v4`; reload; retained CSV consumers; last-wins cross-feed attribution) before flipping to Accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - DNSBL list preprocessing architecture documented with comprehensive validation evidence
  - Development guide expanded detailing build process implementation

* **Tests**
  - Comprehensive decision-equivalence test coverage across all feed formats (hosts/plain/ABP/CSV)
  - Performance and memory benchmarks validated on production-scale datasets
  - Golden oracle fixtures and regression test suites established

* **Chores**
  - Architecture validation status updated to "Implemented — pending live smoke testing"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->