### PR TITLE
ADR-04 (next): python-mode-only live-VM smoke matrix + DNSBL chroot fix

### DIFF
--- a/.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md
+++ b/.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md
@@ -113,11 +113,14 @@ this gate across the version matrix.)*
 All of this MUST be baked at image-build time: a single-NIC WAN install is
 default-deny with no anti-lockout and Unbound refuses WAN-side recursion, so SSH
 / WebUI / DNS are unreachable until the config exists — it cannot be added later
-over SSH. `PFSENSE_CE_VERSION`-parameterised; pfBlockerNG is **NOT** baked.
+over SSH. `PFSENSE_CE_VERSION`-parameterised. The pfBlockerNG **package** is NOT
+baked (the harness `pkg add`s the branch `.pkg`), but its **dependencies ARE**
+(see below) so that install runs offline.
 
 | Baked item | Detail / source |
 | --- | --- |
 | Root SSH pubkey | `SMOKE_SSH_PUB_KEY` → root `authorized_keys`; root SSH enabled. Matching private half is the `SMOKE_SSH_PRIV_KEY` secret the workflows use. |
+| pfBlockerNG RUN_DEPENDS | **Convention (do not skip):** bake pfBlockerNG's runtime deps so the harness `pkg add` of the branch `.pkg` resolves them from the local pkg db **offline** (stable deploy; no repo round-trip). **Run [`scripts/misc/install_deps_CE_2.8.sh`](../../scripts/misc/install_deps_CE_2.8.sh) on the box** when preparing the image (one per supported CE version). Full per-version list + purpose: [`docs/misc/pfSense_versions.md`](../../docs/misc/pfSense_versions.md). CE 2.8.x set (9, = the port `RUN_DEPENDS`): `libmaxminddb`, `py311-maxminddb`, `py311-sqlite3`, `lighttpd`, `jq`, `rsync`, `grepcidr`, `iprange`, `gnugrep` (`py311-*` track the base Python — `py312-*` on a 3.12 base; `rsync` is a real run-dep — rsync-format feeds). Authoritative = the port Makefile `RUN_DEPENDS` / `pkg info -d <pkg>`. A missing dep → `pkg add` "Missing dependency" → bad image, re-bake. |
 | Admin password | `SMOKE_ADMIN_PASSWORD` (bcrypt) in `config.xml`. Not exercised by the round-trip (SSH = key, WebUI = reachability) — available if scope grows. |
 | WAN pass rules | host → **22 (SSH), 80 (WebUI HTTP), 53 (DNS)**. Required — SSH unreachable otherwise. |
 | Unbound access-control | `access-control: 10.0.2.0/24 allow` (the SLIRP subnet) — Unbound refuses WAN-side recursion by default (`REFUSED`). |

--- a/.ADRs/ADR_04_VM_Smoke_Tests/RESULTS/08_Results.txt
+++ b/.ADRs/ADR_04_VM_Smoke_Tests/RESULTS/08_Results.txt
@@ -1,0 +1,89 @@
+ADR-04 — Phase 8 results: python-mode-only smoke matrix GREEN on `next`
+=======================================================================
+
+Branch: next   Date: 2026-06-03
+Audience: maintainer + any future agent touching tests/smoke/.
+
+-------------------------------------------------------------------
+OUTCOME
+-------------------------------------------------------------------
+The live-VM smoke matrix is GREEN on `next` (python-mode-only DNSBL):
+  13 passed, 3 skipped, 1 xfailed  (run 26895418833, ~100s pytest).
+Passing: IP alias-table+rule; DNSBL config-immutability (include-aware +
+unbound-control); python exact block -> VIP; python exact block -> NULL
+(0.0.0.0 / ::); whitelist passthrough; all helper self-tests; strict
+false-green guard (xfail). Skipped: DNSBL-IP dual-stack (deferred, see below),
++ 2 env-gated helper skips.
+
+This phase adapted the devel matrix (which asserted UNBOUND mode + skipped the
+python shapes) to `next`, where Unbound mode is removed and python is the ONLY
+DNSBL mode.
+
+-------------------------------------------------------------------
+TWO PRODUCT FINDINGS THE LIVE SMOKE TEST SURFACED (unit tests could not)
+-------------------------------------------------------------------
+1. CHROOT FEED-LOAD BUG (FIXED, commit 69e5db8) — severe, next-only.
+   ADR-06 moved python DNSBL to a manifest build: pfblockerng.inc writes
+   pfb_py_sources.json with each feed's raw path; pfb_unbound.py builds dataDB
+   from it. The manifest stored HOST-ABSOLUTE paths
+   (/var/unbound/pfb_py_raw/<f>.raw, /usr/local/pkg/.../dnsbl_tld), but Unbound
+   runs CHROOTED at /var/unbound -> the module resolved them to
+   /var/unbound/var/unbound/... (and /usr/local/pkg is outside the chroot) ->
+   every feed failed to open -> dataDB empty -> DNSBL silently blocked NOTHING
+   (queries forwarded; SERVFAIL under the hermetic egress block).
+   python_enable/python_blocking were both 'on' — only the paths were wrong.
+   Fix: write the manifest 'raw' RELATIVE to the manifest dir (the chroot root;
+   pfb_unbound.py's _dnsbl_file_line_reader already joins relatives against it);
+   embed tld_master as LINES (the chrooted module can't read /usr/local/pkg).
+   *** PROPAGATION: confirm whether the ADR-06 manifest build is also on `devel`
+   *** (the bug would exist there too, just unexercised since devel's smoke used
+   *** unbound mode). If so, the fix belongs on devel and should cascade to next
+   *** per the linear-history dance. Raised for the maintainer to place.
+
+2. "(py)" / lightning-bolt UI markers removed (commit ec18247) — on `next`
+   python is the only mode, so the "Python-mode only" field markers + the JS
+   bolt substitution in pfblockerng_dnsbl.php are redundant; removed.
+
+-------------------------------------------------------------------
+HARD-WON SMOKE TRUTHS (now also in CLAUDE.md "Smoke tests" — read first)
+-------------------------------------------------------------------
+* NO localhost exemption: python DNSBL blocks a name even from 127.0.0.1.
+  Probe ON-BOX (drill @127.0.0.1 over SSH); the runner-side SLIRP WAN-hostfwd
+  DNS path is NOT answered in CI (that, not slow Unbound, caused the early
+  TIMEOUTs). First DNS response after wait_unbound_ready is authoritative —
+  assert it, never loop for the expected value.
+* Test domains: helpers.unique_domain() -> uuid-*.com. NEVER RFC 6761 TLDs
+  (.test/.example/...) — Unbound built-in local-zones shadow them before DNSBL
+  (this produced the "SOA test." red herring). NEVER HSTS-preload names — HSTS
+  (pfb_hsts, default ON) forces a VIP block to NULL.
+* Block shapes: NOERROR+VIP (dnsbl_ipv4) or NULL (0.0.0.0 / ::); never NXDOMAIN
+  for a feed match. Per-list `logging` is a LIST-level field ($list['logging']),
+  NOT per-row. Compare IPs by value (:: == ::0).
+* Unbound chroot = /var/unbound (HAProxy = /tmp/haproxy). Module-read paths must
+  be chroot-relative.
+* Enable chain: mode=='enabled' needs enable_cb=on + pfb_dnsbl=on + DNS Resolver
+  enabled (unbound_state). On next, dnsbl_mode/pfb_py_block are dead keys.
+* Image bakes only deps + qemu-guest-agent; harness injects the DNSBL VIP +
+  per-case config; pkg add is offline. Image caches are content-keyed (smoke
+  qcow2 by GHCR digest; FreeBSD base by published SHA256 + verified).
+* Every run uploads a full guest snapshot (smoke-diagnostics): all /var/log,
+  dmesg, pfctl -sa, unbound + pfBlockerNG state, /var/db/pfblockerng +
+  /var/db/aliastables, scrubbed config.xml. Read it on any failure.
+
+-------------------------------------------------------------------
+DEFERRED / FOLLOW-UPS
+-------------------------------------------------------------------
+* test_dnsblip_dual_stack_partition (SKIPPED): pfB_DNSBLIP_v4/v6 are populated
+  by filter_configure ASYNC after the CLI returns; needs a poll-based assertion
+  (like rule_references). The IP path itself is proven by
+  test_ip_alias_table_and_rule.
+* HSTS NULL test (not yet added): block a known HSTS-preload domain, assert it
+  flips VIP->NULL (0.0.0.0) with HSTS on. Recipe: point Unbound's forwarder at
+  the stub, assert the domain reaches the stub UNblocked; add to a block list;
+  Force Reload; assert 0.0.0.0. Two reloads; requires configure_upstream to
+  REPLACE (not append) the "." forward-zone.
+* Chroot-fix propagation to devel (see finding #1).
+
+-------------------------------------------------------------------
+MAINTAINER DoD (ADR.md §7) — still your call to flip Status -> Accepted.
+-------------------------------------------------------------------

--- a/.github/workflows/build-pkg.yml
+++ b/.github/workflows/build-pkg.yml
@@ -276,11 +276,17 @@ jobs:
                  touch /etc/cloud/cloud-init.disabled /usr/local/etc/cloud/cloud-init.disabled 2>/dev/null; \
                  true"
 
-          # Graceful shutdown — let the guest commit writes to the qcow2.
+          # Graceful shutdown — let the guest commit writes to the qcow2. On
+          # timeout, SIGKILL and REAP: the tier-2 cache save must not read
+          # fbsd-prepared.qcow2 while QEMU still holds it (partial/locked image).
           $SSSH "shutdown -p now" || true
           for i in $(seq 1 30); do
             kill -0 "$(cat setup-vm.pid)" 2>/dev/null || { echo "Setup VM powered off cleanly"; break; }
-            [ "$i" -eq 30 ] && { echo "::warning::Setup VM did not power off within 60s; killing"; kill "$(cat setup-vm.pid)" 2>/dev/null || true; }
+            if [ "$i" -eq 30 ]; then
+              echo "::warning::Setup VM did not power off within 60s; killing"
+              kill -9 "$(cat setup-vm.pid)" 2>/dev/null || true
+              wait "$(cat setup-vm.pid)" 2>/dev/null || true
+            fi
             sleep 2
           done
 

--- a/.github/workflows/build-pkg.yml
+++ b/.github/workflows/build-pkg.yml
@@ -8,10 +8,27 @@ name: build-pkg (FreeBSD)
 #   pfSense CE 2.8.1 -> FreeBSD 15  (releases/VM-IMAGES/15.0-RELEASE/...)
 #   pfSense Plus     -> FreeBSD 16  (snapshots/VM-IMAGES/16.0-CURRENT/...)
 #
-# We boot the BASIC-CLOUDINIT image under QEMU/KVM (cloud-init injects our SSH
-# key via a NoCloud seed) and drive it over SSH, running scripts/build-pkg.sh
-# inside it. This replaces the rsync-overlay install: less hacky, reproducible,
-# version-parameterised, and it tests the real packaged artifact.
+# Two-tier image cache to minimise per-run setup:
+#
+#   Tier 1  freebsd-img-{image_sha256}
+#           The raw BASIC-CLOUDINIT qcow2, unchanged from what FreeBSD publishes.
+#
+#   Tier 2  freebsd-prepared-v2-{image_sha256}  (qcow2 + matching SSH key)
+#           The same image after a one-time setup boot (R/W, no snapshot):
+#           disk resized +20 GB, ZFS expanded, pkg bootstrapped + git installed,
+#           and a persistent SSH key BAKED into root's authorized_keys (via a
+#           one-shot cloud-init), after which cloud-init is DISABLED. The build
+#           boot then needs no cloud-init and no seed — it boots the prepared
+#           image with snapshot=on (throwaway overlay; base never mutated) and
+#           SSHes straight in with the baked key. The private key is cached
+#           alongside the qcow2 under the same tier-2 key so they stay in
+#           lockstep; it grants root only to a throwaway localhost VM and rotates
+#           whenever the base image (cache key) changes.
+#
+#   Cache key for both tiers: the PUBLISHED image SHA-256 (from the FreeBSD
+#   CHECKSUM.SHA256 next to the image), not the URL string — so a re-spun image
+#   at the same URL (refreshed snapshot, new release) invalidates the cache
+#   automatically. The download is also verified against that checksum before use.
 #
 # workflow_dispatch-only; never runs on push/PR.
 
@@ -94,52 +111,105 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils xz-utils openssh-client
 
-      - name: Resolve the FreeBSD image URL (programmatic, from the version)
+      - name: Resolve the FreeBSD image URL + published checksum
         id: img
         run: |
           set -eu
           URL="$(sh scripts/freebsd-image-url.sh '${{ inputs.freebsd_version }}')"
-          echo "url=${URL}" >> "$GITHUB_OUTPUT"
-          echo "key=$(printf '%s' "$URL" | sha256sum | cut -c1-32)" >> "$GITHUB_OUTPUT"
+          FILE="$(basename "$URL")"
+          # FreeBSD publishes CHECKSUM.SHA256 next to the images. Read the hash
+          # for OUR file: it is the source of truth for the content, so we use it
+          # as the cache KEY (content, not the URL string) and to VERIFY the
+          # download. Keying on the content hash means a re-spun image at the same
+          # URL (e.g. a refreshed snapshot) invalidates the cache automatically.
+          CK_URL="${URL%/*}/CHECKSUM.SHA256"
+          SHA="$(curl -fsSL "$CK_URL" | grep -F "($FILE)" | awk '{print $NF}')"
+          if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-f]{64}$'; then
+            echo "::error::no sha256 for ${FILE} in ${CK_URL} (got '${SHA}')"
+            exit 1
+          fi
+          {
+            echo "url=${URL}"
+            echo "sha=${SHA}"
+            echo "key=${SHA}"
+          } >> "$GITHUB_OUTPUT"
           echo "Resolved ${{ inputs.freebsd_version }} -> ${URL}"
+          echo "Published sha256: ${SHA}"
 
-      - name: Restore cached FreeBSD image
+      # ── Tier 2: prepared image (base + ZFS expanded + git installed) ─────────
+      # Try this first — on a hit we skip the base download entirely.
+      # The cache holds the qcow2 AND the matching private SSH key: the key is
+      # BAKED into the image (root authorized_keys) during preparation, so the
+      # build boot needs no cloud-init. Image + key are cached together under the
+      # same key so they always stay in lockstep.
+
+      - name: Restore prepared FreeBSD image + key (tier-2 cache)
+        id: prepared
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            fbsd-prepared.qcow2
+            build_key
+          key: freebsd-prepared-v2-${{ steps.img.outputs.key }}
+
+      # ── Tier 1: raw base image (only needed when tier-2 is a miss) ───────────
+
+      - name: Restore cached FreeBSD base image (tier-1 cache)
         id: imgcache
+        if: steps.prepared.outputs.cache-hit != 'true'
         uses: actions/cache/restore@v5
         with:
           path: fbsd.qcow2
           key: freebsd-img-${{ steps.img.outputs.key }}
 
-      - name: Fetch + decompress the FreeBSD image
-        if: steps.imgcache.outputs.cache-hit != 'true'
+      - name: Fetch + verify + decompress the FreeBSD base image
+        if: steps.prepared.outputs.cache-hit != 'true' && steps.imgcache.outputs.cache-hit != 'true'
+        env:
+          IMG_URL: ${{ steps.img.outputs.url }}
+          IMG_SHA: ${{ steps.img.outputs.sha }}
         run: |
           set -eu
-          echo "Image: ${{ steps.img.outputs.url }}"
-          curl -fSL "${{ steps.img.outputs.url }}" -o fbsd.qcow2.xz
+          echo "Image: ${IMG_URL}"
+          curl -fSL "${IMG_URL}" -o fbsd.qcow2.xz
+          # Verify the download against the published checksum BEFORE decompressing
+          # — never assume the bytes are correct/complete.
+          echo "${IMG_SHA}  fbsd.qcow2.xz" | sha256sum -c -
           unxz fbsd.qcow2.xz
           ls -l fbsd.qcow2
 
-      # Save immediately after download — BEFORE the (possibly failing) build —
-      # so the image is cached even when a later step fails. A single
-      # actions/cache only saves in its post-step, which we observed not
-      # persisting on a failed job.
-      - name: Save FreeBSD image to cache
-        if: steps.imgcache.outputs.cache-hit != 'true'
+      # Save right after download so the base is cached even if the preparation
+      # step later fails.
+      - name: Save FreeBSD base image to cache (tier-1)
+        if: steps.prepared.outputs.cache-hit != 'true' && steps.imgcache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: fbsd.qcow2
           key: freebsd-img-${{ steps.img.outputs.key }}
 
-      - name: Build the cloud-init seed (inject SSH key, enable root login)
+      # ── One-time preparation: resize + ZFS expand + install git + BAKE KEY ───
+      # Runs only on a tier-2 cache miss. Boots the base image R/W (no
+      # snapshot=on) so changes persist to disk, installs the invariant build
+      # deps, and BAKES a persistent SSH key into root's authorized_keys (via a
+      # one-shot cloud-init), then DISABLES cloud-init so it never runs again.
+      # The build boot then needs no cloud-init and no seed — it just SSHes in
+      # with the baked key. The qcow2 AND the key are cached together (tier-2).
+
+      - name: Prepare the FreeBSD image (one-time setup boot)
+        if: steps.prepared.outputs.cache-hit != 'true'
         run: |
           set -eu
+
+          # Work from a copy so the tier-1 base stays untouched.
+          cp fbsd.qcow2 fbsd-prepared.qcow2
+          qemu-img resize fbsd-prepared.qcow2 +20G
+
+          # PERSISTENT key — baked into the image and cached alongside it (tier-2).
+          # Reused by every build boot off this prepared image; rotates only when
+          # the base image (and thus the cache key) changes.
           ssh-keygen -t ed25519 -N '' -f build_key -C pfb-build
           PUB="$(cat build_key.pub)"
-          # The official FreeBSD image has no sudo/doas in base, so we log in as
-          # root and run the build as root. cloud-init installs the key for the
-          # default user (freebsd); runcmd copies it to root and permits root key
-          # login. printf (not heredoc) keeps #cloud-config at byte 0 and the
-          # YAML indentation exact.
+
+          # One-shot cloud-init seed: inject the key + enable root login, ONCE.
           {
             printf '#cloud-config\n'
             printf 'disable_root: false\n'
@@ -151,60 +221,40 @@ jobs:
             printf '  - chmod 600 /root/.ssh/authorized_keys\n'
             printf "  - sed -i '' -E 's/^#?[[:space:]]*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config\n"
             printf '  - service sshd restart\n'
-          } > user-data
-          printf 'instance-id: pfb-build\nlocal-hostname: pfb-build\n' > meta-data
-          echo "---- user-data ----"; cat user-data
-          cloud-localds seed.img user-data meta-data
-          ls -l seed.img
+          } > setup-user-data
+          printf 'instance-id: pfb-setup\nlocal-hostname: pfb-setup\n' > setup-meta-data
+          cloud-localds setup-seed.img setup-user-data setup-meta-data
 
-      - name: Boot the FreeBSD VM (headless, KVM)
-        run: |
-          set -eu
-          # The cloud image's disk is ~5 GB — too small for the ports checkout.
-          # Grow the virtual disk; the guest pool is expanded after boot. (Safe
-          # with snapshot=on: writes go to a throwaway overlay, base untouched.)
-          qemu-img resize fbsd.qcow2 +20G
-          # snapshot=on: never mutate the downloaded base. seed.img is the
-          # NoCloud datasource cloud-init reads to install our key. Serial to a
-          # file for diagnosis if it wedges.
+          # Boot R/W — writes must persist to fbsd-prepared.qcow2.
           qemu-system-x86_64 \
             -enable-kvm -machine pc -cpu host -smp 2 -m 4096 \
-            -drive file=fbsd.qcow2,if=virtio,snapshot=on \
-            -drive file=seed.img,if=virtio,format=raw \
+            -drive file=fbsd-prepared.qcow2,if=virtio \
+            -drive file=setup-seed.img,if=virtio,format=raw \
             -netdev user,id=net0,hostfwd=tcp::2222-:22 \
             -device virtio-net-pci,netdev=net0 \
-            -display none -serial file:fbsd-console.log &
-          echo $! > vm.pid
-          echo "qemu pid $(cat vm.pid)"
+            -display none -serial file:fbsd-setup-console.log &
+          echo $! > setup-vm.pid
 
-      - name: Wait for root SSH (cloud-init runcmd done)
-        run: |
-          set -eu
-          # Poll root@ — it only answers AFTER cloud-init's runcmd has copied the
-          # key to root and permitted root login, so this also waits out
-          # cloud-init. (The freebsd user comes up earlier, but has no sudo.)
           SSH_OPTS="-i build_key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o BatchMode=yes"
           for i in $(seq 1 96); do
             # shellcheck disable=SC2086
             if ssh $SSH_OPTS root@127.0.0.1 true 2>/dev/null; then
-              echo "root SSH up after ${i} attempt(s)"; exit 0
+              echo "setup VM root SSH up after ${i} attempt(s)"; break
             fi
-            if ! kill -0 "$(cat vm.pid)" 2>/dev/null; then
-              echo "::error::QEMU exited before SSH came up"; tail -n 80 fbsd-console.log || true; exit 1
+            if ! kill -0 "$(cat setup-vm.pid)" 2>/dev/null; then
+              echo "::error::QEMU exited before SSH came up (setup)"
+              tail -n 80 fbsd-setup-console.log || true
+              exit 1
             fi
+            [ "$i" -eq 96 ] && { echo "::error::Setup VM SSH never came up"; tail -n 120 fbsd-setup-console.log || true; exit 1; }
             sleep 5
           done
-          echo "::error::FreeBSD VM root SSH never came up"; tail -n 120 fbsd-console.log || true; exit 1
 
-      - name: Expand the root ZFS pool to fill the grown disk
-        run: |
-          set -eu
-          SSH="ssh -i build_key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes root@127.0.0.1"
-          # Standard FreeBSD ZFS VM-IMAGE layout: single virtio disk (vtbd0) with
-          # a trailing freebsd-zfs partition backing pool 'zroot'. Recover the GPT
-          # to see the larger disk, grow the last partition, expand the pool.
-          # Best-effort: if the image already auto-grew, these are no-ops.
-          $SSH "set -e
+          # shellcheck disable=SC2086
+          SSSH="ssh $SSH_OPTS root@127.0.0.1"
+
+          # Expand ZFS to fill the grown disk.
+          $SSSH "set -e
             DISK=vtbd0
             gpart recover \$DISK || true
             PART=\$(gpart show \$DISK | awk '\$4==\"freebsd-zfs\"{print \$3; exit}')
@@ -214,19 +264,91 @@ jobs:
             zpool online -e \"\$POOL\" \"\${DISK}p\${PART}\" || true
             df -h /"
 
+          # Install the invariant build dependency.
+          $SSSH "env ASSUME_ALWAYS_YES=yes pkg install -y git"
+
+          # DISABLE cloud-init on all future boots (boot-speed only — the baked
+          # key + sshd config already make the build boot self-sufficient). The
+          # .disabled flag dir differs by platform: base layout uses /etc/cloud,
+          # the FreeBSD port uses /usr/local/etc/cloud. Drop the flag in both,
+          # best-effort — never fail the prep over a boot-speed optimisation.
+          $SSSH "mkdir -p /etc/cloud /usr/local/etc/cloud 2>/dev/null; \
+                 touch /etc/cloud/cloud-init.disabled /usr/local/etc/cloud/cloud-init.disabled 2>/dev/null; \
+                 true"
+
+          # Graceful shutdown — let the guest commit writes to the qcow2.
+          $SSSH "shutdown -p now" || true
+          for i in $(seq 1 30); do
+            kill -0 "$(cat setup-vm.pid)" 2>/dev/null || { echo "Setup VM powered off cleanly"; break; }
+            [ "$i" -eq 30 ] && { echo "::warning::Setup VM did not power off within 60s; killing"; kill "$(cat setup-vm.pid)" 2>/dev/null || true; }
+            sleep 2
+          done
+
+      - name: Save prepared FreeBSD image + key to cache (tier-2)
+        if: steps.prepared.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            fbsd-prepared.qcow2
+            build_key
+          key: freebsd-prepared-v2-${{ steps.img.outputs.key }}
+
+      # ── Build boot ───────────────────────────────────────────────────────────
+      # Always uses the prepared image with snapshot=on (writes go to a throwaway
+      # overlay; fbsd-prepared.qcow2 is never mutated). No cloud-init, no seed:
+      # the SSH key is already baked into root's authorized_keys and cloud-init
+      # is disabled, so the boot is fast and SSH is up as soon as sshd starts.
+
+      - name: Normalise the baked key permissions
+        run: |
+          set -eu
+          # actions/cache restore (tier-2 hit) does not guarantee 0600; ssh
+          # refuses a group/world-readable private key. Idempotent after setup.
+          chmod 600 build_key
+          ls -l build_key
+
+      - name: Boot the FreeBSD VM (snapshot=on, prepared image)
+        run: |
+          set -eu
+          # snapshot=on: all writes go to a throwaway in-memory overlay;
+          # fbsd-prepared.qcow2 is never written to during the build boot.
+          # No seed drive — the baked key + disabled cloud-init make it unneeded.
+          qemu-system-x86_64 \
+            -enable-kvm -machine pc -cpu host -smp 2 -m 4096 \
+            -drive file=fbsd-prepared.qcow2,if=virtio,snapshot=on \
+            -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+            -device virtio-net-pci,netdev=net0 \
+            -display none -serial file:fbsd-build-console.log &
+          echo $! > vm.pid
+          echo "qemu pid $(cat vm.pid)"
+
+      - name: Wait for root SSH (baked key)
+        run: |
+          set -eu
+          SSH_OPTS="-i build_key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o BatchMode=yes"
+          for i in $(seq 1 96); do
+            # shellcheck disable=SC2086
+            if ssh $SSH_OPTS root@127.0.0.1 true 2>/dev/null; then
+              echo "root SSH up after ${i} attempt(s)"; exit 0
+            fi
+            if ! kill -0 "$(cat vm.pid)" 2>/dev/null; then
+              echo "::error::QEMU exited before SSH came up"; tail -n 80 fbsd-build-console.log || true; exit 1
+            fi
+            sleep 5
+          done
+          echo "::error::FreeBSD VM root SSH never came up"; tail -n 120 fbsd-build-console.log || true; exit 1
+
       - name: Build the package inside the VM
         run: |
           set -eu
           SSH="ssh -i build_key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes root@127.0.0.1"
           REF="${{ github.ref_name }}"
           SHA="${{ github.sha }}"
-          # Running as root (no sudo on the base image). pkg may need bootstrap on
-          # a fresh image; ASSUME_ALWAYS_YES handles it. Clone the ports tree
-          # (port + Mk) for the build, and the branch (just to get build-pkg.sh).
-          # The build pins the port's USE_GITHUB fetch to $SHA (the branch HEAD
-          # commit), so `make package` packages that exact commit — not the tag.
+          # git is pre-installed in the prepared image; pkg bootstrap already done.
+          # Clone the ports tree (port + Mk) and the branch (for build-pkg.sh).
+          # The build pins the port's USE_GITHUB fetch to $SHA so `make package`
+          # packages that exact commit — not the tag.
           $SSH "set -e
-            env ASSUME_ALWAYS_YES=yes pkg install -y git
             git clone --depth 1 -b '${{ inputs.ports_ref }}' https://github.com/${{ inputs.ports_repo }} /root/ports
             git clone --depth 1 -b \"$REF\" https://github.com/${{ github.repository }} /root/src
             sh /root/src/scripts/build-pkg.sh --ports /root/ports --gh-tagname \"$SHA\" --channel '${{ inputs.channel }}' --php '${{ inputs.php_version }}' --out /tmp/out
@@ -240,7 +362,7 @@ jobs:
             'root@127.0.0.1:/tmp/out/*' out/
           ls -l out
 
-      - name: Upload package + console log
+      - name: Upload package + console logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
@@ -248,10 +370,13 @@ jobs:
           path: |
             out/*.pkg
             out/*.txz
-            fbsd-console.log
+            fbsd-build-console.log
+            fbsd-setup-console.log
           if-no-files-found: warn
           retention-days: 7
 
       - name: Teardown
         if: always()
-        run: kill "$(cat vm.pid)" 2>/dev/null || true
+        run: |
+          kill "$(cat vm.pid)" 2>/dev/null || true
+          kill "$(cat setup-vm.pid)" 2>/dev/null || true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -110,24 +110,19 @@ jobs:
             echo "::error::no image ref (set the image_ref input, or the SMOKE_IMAGE_REF secret/variable)"
             exit 1
           fi
-          {
-            echo "ref=${REF}"
-            echo "k=$(printf '%s' "$REF" | sha256sum | cut -c1-32)"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Restore cached pfSense image
-        id: pfcache
-        uses: actions/cache/restore@v5
-        with:
-          path: image
-          key: pfsense-img-${{ steps.ref.outputs.k }}
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
 
       - name: Install oras
-        if: steps.pfcache.outputs.cache-hit != 'true'
         uses: oras-project/setup-oras@v2
 
-      - name: Pull pfSense image from private GHCR
-        if: steps.pfcache.outputs.cache-hit != 'true'
+      # Key the image cache on the RESOLVED MANIFEST DIGEST, not the ref string.
+      # SMOKE_IMAGE_REF is typically a MOVING tag (e.g. :2.8.1); a re-push to the
+      # same tag changes the content (digest) but not the ref string. Keying on
+      # the digest makes a new image invalidate the cache automatically — a fresh
+      # pull, no manual cache bust. Needs a GHCR login (private repo) first; the
+      # login persists to the pull step below (same job).
+      - name: Resolve image digest (cache key)
+        id: digest
         env:
           IMAGE_REF: ${{ steps.ref.outputs.ref }}
           SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER }}
@@ -136,18 +131,49 @@ jobs:
           set -eu
           echo "$SMOKE_GHCR_TOKEN" | oras login ghcr.io \
             --username "$SMOKE_GHCR_USER" --password-stdin
+          DIGEST="$(oras resolve "$IMAGE_REF" 2>/dev/null || true)"
+          if [ -z "$DIGEST" ]; then
+            # Fallback for oras builds without `resolve`: read the descriptor.
+            DIGEST="$(oras manifest fetch "$IMAGE_REF" --descriptor | jq -r '.digest')"
+          fi
+          case "$DIGEST" in
+            sha256:*) ;;
+            *) echo "::error::could not resolve a sha256 digest for ${IMAGE_REF} (got '${DIGEST}')"; exit 1 ;;
+          esac
+          {
+            echo "digest=${DIGEST}"
+            echo "k=${DIGEST#sha256:}"   # cache-key-safe hex
+          } >> "$GITHUB_OUTPUT"
+          echo "resolved ${IMAGE_REF} -> ${DIGEST}"
+
+      - name: Restore cached pfSense image
+        id: pfcache
+        uses: actions/cache/restore@v5
+        with:
+          path: image
+          key: pfsense-img-${{ steps.digest.outputs.k }}
+
+      - name: Pull pfSense image from private GHCR (by digest)
+        if: steps.pfcache.outputs.cache-hit != 'true'
+        env:
+          IMAGE_REF: ${{ steps.ref.outputs.ref }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
+        run: |
+          set -eu
           mkdir -p image
-          oras pull "$IMAGE_REF" --output image
+          # Pull by digest (the login from the resolve step persists in-job) so
+          # the content matches the cache key exactly — no tag-race window.
+          oras pull "${IMAGE_REF%@*}@${DIGEST}" --output image
           ls -l image
 
-      # Save right after the pull (before the run) so the image is cached even
-      # if a later step fails. Pulled by immutable digest -> the key is stable.
+      # Save right after the pull (before the run) so the image is cached even if
+      # a later step fails. Key = the resolved digest, so it never serves stale.
       - name: Save pfSense image to cache
         if: steps.pfcache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: image
-          key: pfsense-img-${{ steps.ref.outputs.k }}
+          key: pfsense-img-${{ steps.digest.outputs.k }}
 
       - name: Write private SSH key (mode 600)
         env:
@@ -193,13 +219,15 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r tests/smoke/requirements.txt pytest
 
-      # HERMETICITY (ADR §2/§4): the egress block must happen AFTER pfBlockerNG
-      # is installed on the guest — `pkg add` pulls RUN_DEPENDS from the pfSense
-      # repo, and the guest reaches the internet THROUGH this runner's SLIRP NAT,
-      # so a pre-pytest block would hang the install. So the block is done INSIDE
-      # pytest, by the matrix's `deployed_vm` fixture, right after deploy() and
-      # before the per-case assertions (helpers.block_egress, gated by
-      # SMOKE_BLOCK_EGRESS=1 below; unblocked on teardown). The matrix then
+      # HERMETICITY (ADR §2/§4): the egress block is done INSIDE pytest, by the
+      # matrix's `deployed_vm` fixture, after deploy() and before the per-case
+      # assertions (helpers.block_egress, gated by SMOKE_BLOCK_EGRESS=1 below;
+      # unblocked on teardown). deploy() no longer needs egress for dependencies:
+      # the pre-baked image ships pfBlockerNG's RUN_DEPENDS, so `pkg add` of the
+      # branch .pkg resolves them from the local pkg db offline (convention — a
+      # missing dep means a bad image). The block is kept in-fixture (not pre-
+      # pytest) because the per-case pfBlockerNG reload still wants a working
+      # resolver, and it's unblocked only for the hermetic probe. The matrix then
       # resolves every answer from the in-runner mock-feed server (guest ->
       # SLIRP 10.0.2.2 -> runner loopback) + injected Unbound local-data, so it
       # still passes with real egress dark.
@@ -235,5 +263,6 @@ jobs:
             **/vm*.log
             **/screen-*.png
             **/screen-*.ppm
+            smoke-diag/**
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,104 @@
 
 ---
 
+## Investigating the live system (be thorough — read sources, not proxies)
+
+When debugging real pfSense/FreeBSD behaviour, **verify against the source of truth
+and the effective live state — never infer presence/absence from a single generated
+artifact.** A clean grep of one file is not proof. Specifically:
+
+- **Follow file inclusions.** *NIX config is routinely split across `include:`
+  directives and `*.d/` drop-in directories. Grep the whole tree, then follow the
+  chain — don't grep one top-level file and conclude. Example that bit us: Unbound's
+  DNS-Resolver ACLs are **not** in `/var/unbound/unbound.conf`; they're in the
+  included `/var/unbound/access_lists.conf` (alongside `host_entries.conf`,
+  `domainoverrides.conf`, `remotecontrol.conf`). `grep -rn … /var/unbound/` +
+  `grep include /var/unbound/unbound.conf` finds them; grepping `unbound.conf` alone
+  silently misses them.
+- **Some pfSense services run CHROOTED — account for it when they read files.** A
+  chrooted process resolves absolute paths against its chroot root, not `/`.
+  **Unbound** is chrooted at **`/var/unbound`** (e.g. `pfb_unbound.py` runs there:
+  a host-absolute `/var/unbound/pfb_py_raw/x` becomes `/var/unbound/var/unbound/pfb_py_raw/x`
+  inside and 404s — reference such files by their in-chroot path, or relative to the
+  chroot root; files outside the chroot like `/usr/local/pkg/...` are simply
+  unreachable unless mounted/copied in). **HAProxy** is chrooted at **`/tmp/haproxy`**.
+  A file that plainly exists on the host can be unreadable by the service purely
+  because of the chroot — this caused a real DNSBL feed-loading bug (manifest stored
+  host-absolute paths the chrooted module couldn't open).
+- **Ask the tool for its effective state via its own CLI.** It resolves includes and
+  shows what's actually loaded, not what a file says:
+  - **pf** → `pfctl` (`-sr` rules, `-sn` NAT, `-sTables`/`-t <t> -T show` tables,
+    `-ss` states).
+  - **Unbound** → `unbound-control` (`get_option <opt>` e.g. `access-control`,
+    `list_local_zones`, `status`); `unbound-checkconf` to validate.
+  - pfSense services in general: prefer the CLI/`pfSsh.php` over reading generated files.
+- **Turn on a tool's debug/verbose mode when unsure what it's actually doing** —
+  which URLs/hosts it hits, which files it reads/writes, cache/304 behaviour —
+  instead of guessing. E.g. `pkg -d update` traces the underlying `curl` (repo
+  catalogue `meta.conf`/`data.pkg`, the `If-Modified-Since` → "Simulate an HTTP
+  304" → "repository is up to date" path; local catalogue DB under
+  `/var/db/pkg/repos/<repo>/db`); `curl -v` for raw HTTP. Non-obvious gotcha this
+  revealed: pfSense's pkg uses the **`pkg+https`** scheme — a *mirror indirection*,
+  so `pkg.pfsense.org` does not resolve directly (a plain `dig` looks "broken")
+  while pkg resolves it to a Netgate mirror host (e.g. `pkg00-atx.netgate.com`)
+  and fetches fine. This is why the smoke harness keeps egress OPEN during
+  `deploy()`/reload — `pkg add` pulls RUN_DEPENDS from that mirror.
+- **Confirm what's actually installed with `pkg` — don't assume a tool is present
+  or absent.** Installed: `pkg info` (all), `pkg info <pkg>` (one), `pkg info -l
+  <pkg>` (its files), `pkg which <path>` (owning package). Available to install (repo
+  catalogue, not yet installed): `pkg search <name>` / `pkg rquery` — the answer to
+  "is dependency X available?". The smoke image ships `ldns` (→ `drill`),
+  `bind-tools` (→ `dig`/`host`/`nslookup`), `python311`, `unbound`, `php83`, and
+  `qemu-guest-agent` — so check before installing a dependency or coding a runtime
+  fallback. (`pkg help` / `pkg <cmd> -h` for the full command surface.)
+- **`/conf/config.xml` is the source of truth** for pfSense settings; the files under
+  `/var/…` are *generated* from it. To check whether something is configured, read the
+  relevant `config.xml` section (e.g. `<unbound><acls>`), not just the generated output.
+  If you cite config.xml in your reasoning, actually open that section — don't assume.
+- **"Everything is files" cuts both ways:** read the actual files (and diff
+  before/after a change), and when a value is set/empty, confirm it on the box rather
+  than trusting recollection.
+
+---
+
+## Resolving pfSense-provided PHP functions (read the real upstream source)
+
+When a pfSense-provided PHP function is missing, undocumented, ambiguous, or you
+can't tell whether it's implicated in a bug — and it isn't stubbed yet — **do NOT
+assume it can be worked around or guess its behaviour.** We depend on open-source
+software; the real implementation is available, so read it. Source of truth:
+<https://github.com/pfsense/pfSense>.
+
+A function's existence, signature, or behaviour can differ across releases, so
+treat the **full source trees at these refs** as the authority — check the
+function in each that's relevant:
+
+1. **Minimum supported CE** — youngest commit at or before the launch date of our
+   minimum pfSense CE version (currently **2.8.0**).
+2. **Every CE release since the oldest supported** — youngest commit at or before
+   each CE version's launch date.
+3. **Every pfSense Plus release since our oldest supported CE** — youngest commit
+   at or before each Plus version's launch date.
+4. **`master`** — current upstream tip.
+
+Resolve each ref at investigation time, don't hardcode hashes: find the version's
+release date, then take the youngest commit at/before it
+(`git log --before="<release-date>" -1 <branch>`, or the GitHub commits view
+filtered by date). The public mirror may lack release branches/tags (e.g. no
+`RELENG_2_8_0`), so dated commits on the available history are the reliable handle.
+Checking across this set shows whether behaviour is stable across our support
+matrix or version-specific.
+
+**Always prefer stubbing the real function — based on its actual upstream source
+— over making an exception** (a `phpstan-baseline.neon` suppression, an
+`undefinedFunctions` entry, or a code workaround). Stubs encode reality and keep
+PHPStan/Intelephense honest; exceptions hide it. This is the same principle as the
+stub guidance under "Updating documentation" — that section covers the bulk
+generator (`scripts/update-pfsense-stubs.py`); this covers investigating and
+stubbing a single function from upstream by hand.
+
+---
+
 ## Repository structure
 
 ```text
@@ -24,9 +122,11 @@ pfBlockerNG/
 │       ├── share/             # Package metadata (info.xml)
 │       └── www/               # Web UI (PHP pages, JS, widgets, wizards)
 ├── tests/                 # Python test suite (pytest)
+├── docs/misc/             # Dev-only reference notes (e.g. pfSense_versions.md — per-version base facts + pfBlockerNG deps)
 ├── scripts/               # Developer tooling (deploy, stub generation)
 │   ├── deploy.sh          # Push files to live pfSense over SSH
 │   ├── setup-hooks.sh     # One-time: point git at .githooks (core.hooksPath)
+│   ├── misc/              # Per-pfSense-version helpers (e.g. install_deps_CE_2.8.sh — bake RUN_DEPENDS on the image)
 │   └── update-pfsense-stubs.py  # Regenerate stubs from pfSense source
 ├── stubs/pfsense/         # PHP stubs for Intelephense (IDE only, not shipped)
 ├── stubs/python/          # unboundmodule.py stub for Pylance/mypy + tests (not shipped)
@@ -90,6 +190,44 @@ download + tag + run the DNSBL-IP firewall pass. Decision-equivalence is pinned 
 `tests/test_adr06_*` (golden oracle, build module, init-from-raw, PHP boundary);
 the init/peak-RAM kill-gate is `benchmarks/spike_adr06_build.py`. See
 `.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/`.
+
+---
+
+## Smoke tests (ADR-04 — live pfSense VM) — READ BEFORE TOUCHING `tests/smoke/`
+
+`tests/smoke/` installs the branch `.pkg` on a REAL pfSense CE VM in CI
+(`smoke.yml`, workflow_dispatch) and asserts pfBlockerNG end-to-end. These
+truths are non-obvious and each cost real debugging — internalise them first:
+
+- **Probe ON-BOX** (`drill @127.0.0.1` over SSH), NOT the runner-side SLIRP
+  hostfwd — the WAN-hostfwd DNS path is not answered in CI. Python-mode DNSBL has
+  **no localhost exemption**: a blocked name returns its block shape even from
+  `127.0.0.1`. After `reload()` → `wait_unbound_ready`, the **first** DNS response
+  is authoritative — assert it, never loop waiting for the expected value.
+- **Test domains MUST be `helpers.unique_domain()`** (`uuid-*.com`): never RFC 6761
+  TLDs (`.test`/`.example`/`.invalid`/…) — Unbound's built-in `local-zone`s shadow
+  them (NXDOMAIN/NODATA) before DNSBL — and never HSTS-preload names — HSTS
+  (`pfb_hsts`, default ON) forces a would-be VIP block to NULL.
+- **Block shapes (python mode):** NOERROR + VIP (`dnsbl_ipv4`) or NULL
+  (`0.0.0.0` / `::`); NEVER NXDOMAIN for a feed match (NXDOMAIN is SafeSearch-only).
+  Per-list `logging` selects VIP vs NULL and is a **LIST-level** field
+  (`$list['logging']`), not per-row. Compare IPs **by value** (`::` == `::0`).
+- **Unbound is chrooted at `/var/unbound`** — files its python module reads must be
+  chroot-relative (see the chroot note under "Investigating the live system"); a
+  host-absolute path silently fails to load.
+- **Enable chain:** DNSBL `mode=='enabled'` needs `enable_cb=on` + `pfb_dnsbl=on` +
+  the DNS Resolver enabled (`unbound_state`). On `next`, `dnsbl_mode`/`pfb_py_block`
+  are dead keys (python is the only mode); on `main` they're still required.
+- **The image bakes only the deps + qemu-guest-agent** — the harness injects the
+  DNSBL VIP (`ensure_dnsbl_vip`) and all per-case config; `pkg add` runs offline.
+  Image caches are content-keyed (smoke qcow2 by GHCR digest; FreeBSD base by
+  published SHA256, verified) so a same-tag re-push invalidates automatically.
+- **Every run uploads a full guest snapshot** (`smoke-diagnostics` artifact: all
+  `/var/log`, `dmesg`, `pfctl -sa`, unbound + pfBlockerNG state, `/var/db/pfblockerng`
+  + `/var/db/aliastables`, scrubbed `config.xml`). On any failure, read it first.
+
+Full journey, verified response model, and per-step instrument (`SMOKE_STATE_DIFF`):
+`.ADRs/ADR_04_VM_Smoke_Tests/RESULTS/`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,8 +223,9 @@ truths are non-obvious and each cost real debugging — internalise them first:
   Image caches are content-keyed (smoke qcow2 by GHCR digest; FreeBSD base by
   published SHA256, verified) so a same-tag re-push invalidates automatically.
 - **Every run uploads a full guest snapshot** (`smoke-diagnostics` artifact: all
-  `/var/log`, `dmesg`, `pfctl -sa`, unbound + pfBlockerNG state, `/var/db/pfblockerng`
-  + `/var/db/aliastables`, scrubbed `config.xml`). On any failure, read it first.
+  `/var/log`, `dmesg`, `pfctl -sa`, unbound + pfBlockerNG state,
+  `/var/db/pfblockerng` and `/var/db/aliastables`, scrubbed `config.xml`). On any
+  failure, read it first.
 
 Full journey, verified response model, and per-step instrument (`SMOKE_STATE_DIFF`):
 `.ADRs/ADR_04_VM_Smoke_Tests/RESULTS/`.

--- a/docs/misc/pfSense_versions.md
+++ b/docs/misc/pfSense_versions.md
@@ -1,0 +1,61 @@
+# pfSense version notes
+
+Dev-only reference (not shipped — release archives contain only `src/`).
+Per-version facts about pfSense CE/Plus that affect pfBlockerNG packaging, its
+dependencies, and the ADR-04 smoke-test base image.
+
+How these were obtained (and how to re-verify — see CLAUDE.md "Investigating the
+live system"): on a live box, `pkg info` (installed set), `pkg info -d <pkg>`
+(a package's declared deps), `php -v` / `python --version`. The authoritative
+dependency list is the port Makefile `RUN_DEPENDS`
+(`net/pfSense-pkg-pfBlockerNG-devel`); the tables below are a hand-maintained
+mirror — confirm against the port (or a built `.pkg`) when baking an image.
+
+## 2.8.x (CE)
+
+### Base facts
+
+Observed on a CE **2.8.1** box; 2.8.0 shares the same base toolchain.
+
+| Aspect | 2.8.x |
+| --- | --- |
+| FreeBSD base | 15.0-RELEASE (`FreeBSD:15:amd64` pkg ABI) |
+| PHP | 8.3 (`php83`) |
+| Python | 3.11 (`python311`) |
+| pkg | 1.21.x |
+| Unbound | 1.24.x |
+
+### pfBlockerNG runtime dependencies (port `RUN_DEPENDS`)
+
+These must be present for pfBlockerNG to function. By convention the ADR-04
+smoke image **bakes** them so the harness `pkg add` of the branch `.pkg` resolves
+them from the local pkg db **offline** (see `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`
+§3). A missing dep → `pkg add` "Missing dependency" → bad image, re-bake.
+
+Exactly the port's `RUN_DEPENDS` (9 packages), verified against
+`net/pfSense-pkg-pfBlockerNG-devel/Makefile`. To bake them onto an image, run
+[`scripts/misc/install_deps_CE_2.8.sh`](../../scripts/misc/install_deps_CE_2.8.sh)
+on the box (as root):
+
+| Package (origin) | Binary probed | Purpose |
+| --- | --- | --- |
+| `net/libmaxminddb` | `bin/mmdblookup` | GeoIP C library — GeoIP feeds / reports |
+| `net/py-maxminddb` (`py311-maxminddb`) | — | Python MaxMind reader — GeoIP in `pfb_unbound.py` |
+| `databases/py-sqlite3` (`py311-sqlite3`) | — | Python sqlite3 — DNSBL / reports database |
+| `www/lighttpd` | `sbin/lighttpd` | DNSBL sinkhole webserver (block page on the VIP) |
+| `textproc/jq` | `bin/jq` | JSON processing (feeds, the AWS IP-prefix pre-scripts) |
+| `net/rsync` | `bin/rsync` | **rsync-format feed lists** (`pfblockerng.inc` → `exec("/usr/local/bin/rsync …")`); also the rsync-overlay deploy transport |
+| `net-mgmt/grepcidr` | `bin/grepcidr` | CIDR matching on the IP path |
+| `net-mgmt/iprange` | `bin/iprange` | IP-range aggregation on the IP path |
+| `textproc/gnugrep` | `bin/ggrep` | GNU grep (vs base BSD grep) for the list-processing pipeline |
+
+Notes:
+
+- **`py311-*` are pinned to the base Python (3.11 on 2.8.x)** — the port uses
+  `${PYTHON_PKGNAMEPREFIX}…@${PY_FLAVOR}`, so a base that moves to Python 3.12
+  yields `py312-sqlite3` / `py312-maxminddb` automatically.
+- **`rsync` IS a hard run-dep** (not merely a deploy transport): the port declares
+  `net/rsync` and pfBlockerNG shells out to it for rsync-format feeds. It must be
+  baked like the rest.
+- Base components pfBlockerNG also uses (PHP, Unbound, the Python interpreter)
+  ship with pfSense itself and are not in `RUN_DEPENDS`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,7 +73,8 @@ set `NO_ARCH`, so the package is ABI-tagged `FreeBSD:<major>:<arch>` (e.g.
 
 - `pkg` gates installs on the **OS major**. A `FreeBSD:15` package on a `FreeBSD:16`
   system is **refused by default**; `pkg add -f` forces it — functionally safe here
-  (no binaries of ours; the `libmaxminddb` dep resolves from the target's own repo).
+  (no binaries of ours; the smoke image bakes pfBlockerNG's run-deps incl.
+  `libmaxminddb`, so `pkg add` resolves them locally/offline).
 - So **build one `.pkg` per distinct FreeBSD major**, on a FreeBSD VM pinned to that
   major. One build covers every pfSense version on that major. Rebuild only on a
   **FreeBSD-major jump** (rare; coincides with raising the minimum supported version).

--- a/scripts/install-from-repo.sh
+++ b/scripts/install-from-repo.sh
@@ -67,10 +67,11 @@ ssh_t() {
 
 echo "==> Installing pfBlockerNG ($PKG_NAME) onto $SSH_TARGET from repo"
 
-# 0a) rsync is REQUIRED for the transport below; a fresh pfSense ships none.
-#     Check-then-install (pfSense's pkg repo carries it). Needs egress (open
-#     during the smoke spike / image build; the test job blocks egress only
-#     AFTER install). Fatal if it can't be installed — without it nothing syncs.
+# 0a) rsync — needed twice over: it is a pfBlockerNG RUN_DEPENDS (net/rsync, for
+#     rsync-format feed lists) AND the transport for the overlay sync below; a
+#     fresh pfSense ships none. Check-then-install (pfSense's pkg repo carries it).
+#     Needs egress (open during the smoke spike / image build; the test job blocks
+#     egress only AFTER install). Fatal if it can't be installed — nothing syncs.
 if ! ssh_t 'command -v rsync >/dev/null 2>&1'; then
     echo "==> rsync missing on target — installing via pkg"
     ssh_t 'env ASSUME_ALWAYS_YES=yes pkg install -y rsync' \
@@ -81,8 +82,8 @@ fi
 #     pfSense-pkg-pfBlockerNG[-devel]` pulls per the port Makefile — so the
 #     installed package is actually functional (jq/grepcidr/iprange for the IP
 #     path, libmaxminddb/py-maxminddb for GeoIP, py-sqlite3 for the DNSBL DB,
-#     etc.). Best-effort: a renamed/absent dep shouldn't block the smoke
-#     install, so warn rather than abort.
+#     lighttpd for the sinkhole webserver; rsync is handled in 0a). Best-effort:
+#     a renamed/absent dep shouldn't block the smoke install, so warn not abort.
 echo "==> Installing pfBlockerNG runtime dependencies (mirrors port RUN_DEPENDS)"
 ssh_t 'env ASSUME_ALWAYS_YES=yes pkg install -y libmaxminddb gnugrep grepcidr iprange jq lighttpd py311-sqlite3 py311-maxminddb' \
     || echo "WARN: some pfBlockerNG runtime deps failed to install (continuing)" >&2

--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 # install-pkg.sh — install a locally-built pfBlockerNG .pkg onto a pfSense box
 # over SSH. Unlike the rsync overlay, `pkg add` registers the package in pkg's
-# database and runs its POST-INSTALL hooks (menus, services, Unbound wiring),
-# and resolves the RUN_DEPENDS from the configured repos. The .pkg is produced
-# by the FreeBSD build job (scripts/build-pkg.sh) for the exact branch commit.
+# database and runs its POST-INSTALL hooks (menus, services, Unbound wiring).
+# The .pkg is produced by the FreeBSD build job (scripts/build-pkg.sh) for the
+# exact branch commit.
 #
-# Needs egress on the target to fetch RUN_DEPENDS (open during the smoke spike).
+# RUN_DEPENDS: NOT fetched here. By convention the pre-baked smoke image ships
+# pfBlockerNG's runtime dependencies, so `pkg add` of the local .pkg resolves
+# them from the local pkg db and runs fully OFFLINE (no egress, no repo-catalogue
+# round-trip — a more stable deploy). If a dependency is missing, `pkg add` fails
+# loudly with "Missing dependency": that means the image is bad — fix the image
+# (re-bake with the deps), don't paper over it with a repo install here.
 #
 # Usage:
 #   install-pkg.sh <ssh-target> --pkg <local .pkg> [--port N] [--ssh-key PATH]
@@ -58,17 +63,11 @@ echo "==> Copying $(basename "$PKGFILE") to ${SSH_TARGET}:${REMOTE}"
 # shellcheck disable=SC2086
 scp ${SCP_OPTS} "$PKGFILE" "${SSH_TARGET}:${REMOTE}"
 
-# `pkg add` of a LOCAL file does not fetch the package's RUN_DEPENDS from the
-# repos (it just errors "Missing dependency"), so install them first — queried
-# straight from the package manifest (%dn) so the list always matches the .pkg —
-# then add the local file. `pkg add` then runs the package's POST-INSTALL hooks.
-echo "==> Installing the package's dependencies from the repos"
-DEPS="$(ssh_t "pkg query -F '${REMOTE}' '%dn'" 2>/dev/null | tr -d '\r' | tr '\n' ' ')"
-echo "deps: ${DEPS}"
-if [ -n "${DEPS}" ]; then
-    ssh_t "env ASSUME_ALWAYS_YES=yes pkg install -y ${DEPS}"
-fi
-echo "==> pkg add ${REMOTE}"
+# `pkg add` of a LOCAL file resolves RUN_DEPENDS from the LOCAL pkg db — it does
+# not reach the repos when the deps are already installed. The smoke image bakes
+# pfBlockerNG's RUN_DEPENDS (convention), so this runs offline and then executes
+# the package's POST-INSTALL hooks. A "Missing dependency" error here = bad image.
+echo "==> pkg add ${REMOTE} (deps pre-baked; offline)"
 ssh_t "env ASSUME_ALWAYS_YES=yes pkg add '${REMOTE}'"
 
 # POST-INSTALL restarts Unbound asynchronously; wait for it before the caller

--- a/scripts/misc/install_deps_CE_2.8.sh
+++ b/scripts/misc/install_deps_CE_2.8.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# install_deps_CE_2.8.sh — install pfBlockerNG's runtime dependencies on a
+# pfSense CE 2.8.x box, for preparing the ADR-04 smoke-test base image.
+#
+# Run this ON the pfSense box as root before snapshotting/publishing the image.
+# With these baked in, the harness `pkg add` of the branch .pkg resolves its
+# RUN_DEPENDS from the local pkg db OFFLINE (no repo round-trip) — a stable
+# deploy. A "Missing dependency" at `pkg add` means this step was skipped.
+#
+# The list is EXACTLY the port RUN_DEPENDS for
+# net/pfSense-pkg-pfBlockerNG[-devel] (see docs/misc/pfSense_versions.md and
+# .ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md §3). The py311-* packages are
+# pinned to CE 2.8.x's Python 3.11 — a pfSense base on a different Python needs
+# the matching py3XX-* (add a sibling install_deps_CE_<ver>.sh for it).
+#
+# POSIX sh.
+
+set -eu
+
+# Package names map 1:1 to the port RUN_DEPENDS origins:
+#   libmaxminddb     net/libmaxminddb        (mmdblookup — GeoIP)
+#   py311-maxminddb  net/py-maxminddb        (GeoIP reader in pfb_unbound.py)
+#   py311-sqlite3    databases/py-sqlite3    (DNSBL / reports DB)
+#   lighttpd         www/lighttpd            (DNSBL sinkhole webserver)
+#   jq               textproc/jq             (feeds, AWS IP-prefix pre-scripts)
+#   rsync            net/rsync               (rsync-format feed lists)
+#   grepcidr         net-mgmt/grepcidr       (IP path)
+#   iprange          net-mgmt/iprange        (IP path)
+#   gnugrep          textproc/gnugrep        (ggrep — list pipeline)
+env ASSUME_ALWAYS_YES=yes pkg install -y \
+    libmaxminddb \
+    py311-maxminddb \
+    py311-sqlite3 \
+    lighttpd \
+    jq \
+    rsync \
+    grepcidr \
+    iprange \
+    gnugrep
+
+echo "pfBlockerNG CE 2.8.x runtime dependencies installed."

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2378,8 +2378,15 @@ function pfb_unbound_python_sources($feeds) {
 			@fclose($raw_h);
 		}
 
+		// Store the raw path RELATIVE to the manifest's directory. pfb_unbound.py
+		// runs inside Unbound's chroot (/var/unbound), so an absolute HOST path
+		// like /var/unbound/pfb_py_raw/<f>.raw resolves to
+		// /var/unbound/var/unbound/pfb_py_raw/<f>.raw inside the chroot and is not
+		// found (feeds silently fail to load -> nothing blocked). The Python build
+		// joins a relative path against the manifest's dir (the chroot root), which
+		// resolves correctly both chrooted and not.
 		$manifest_feeds[] = array(
-			'raw'		=> $rawpath,
+			'raw'		=> basename($pfb['unbound_py_rawdir']) . "/{$header}.raw",
 			'feed'		=> $header,
 			'group'		=> $group,
 			'format_hint'	=> 'plain',
@@ -2404,10 +2411,22 @@ function pfb_unbound_python_sources($feeds) {
 	$tld_blacklist	= pfbng_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE) ?: array();
 	$tld_exclusion	= pfbng_text_area_decode($pfb['dnsblconfig']['tldexclusion'], TRUE, FALSE, TRUE) ?: array();
 
+	// Embed the public-suffix master list as LINES, not a path: pfb_unbound.py runs
+	// chrooted in /var/unbound and cannot read /usr/local/pkg/... (outside the
+	// chroot). _dnsbl_config_from_manifest() accepts tld_master as a list. Empty
+	// when the file is absent (the TLD feature then simply has no suffixes).
+	$tld_master_lines = array();
+	if (file_exists($pfb['dnsbl_tld_data'])) {
+		$tld_master_file = @file($pfb['dnsbl_tld_data'], FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		if (is_array($tld_master_file)) {
+			$tld_master_lines = $tld_master_file;
+		}
+	}
+
 	$manifest = array(
 		'version'	=> 1,
 		'config'	=> array(
-			'tld_master'	=> $pfb['dnsbl_tld_data'],
+			'tld_master'	=> array_values($tld_master_lines),
 			'tld_blacklist'	=> array_values($tld_blacklist),
 			'tld_exclusion'	=> array_values($tld_exclusion),
 			'user_whitelist'=> pfb_dnsbl_whitelist_lines(),

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -704,7 +704,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'pfb_control',
-	gettext('Python Control') . '(py)',
+	gettext('Python Control'),
 	'Enable',
 	$pconfig['pfb_control'] === 'on' ? true:false,
 	'on'
@@ -736,7 +736,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'pfb_py_reply',
-	gettext('DNS Reply Logging') . '(py)',
+	gettext('DNS Reply Logging'),
 	'Enable',
 	$pconfig['pfb_py_reply'] === 'on' ? true:false,
 	'on'
@@ -744,7 +744,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'pfb_hsts',
-	gettext('HSTS mode') . '(py)',
+	gettext('HSTS mode'),
 	'Enable',
 	$pconfig['pfb_hsts'] === 'on' ? true:false,
 	'on'
@@ -2334,7 +2334,7 @@ $tld_info['bgTLD']	= 'List of Branded Generic Top-Level-Domains (bgTLD)';
 
 $section->addInput(new Form_Checkbox(
 	'pfb_pytld',
-	gettext('TLD Allow') . '(py)',
+	gettext('TLD Allow'),
 	'Enable',
 	$pconfig['pfb_pytld'] === 'on' ? true:false,
 	'on'
@@ -2357,10 +2357,10 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ))->setHelp('Enable to sort TLDs alphabetically');
 
-$group = new Form_Group('TLD Group 1 (py)');
+$group = new Form_Group('TLD Group 1');
 foreach (array('gTLD', 'ccTLD', 'iTLD', 'bgTLD') as $key => $tld_type) {
 	if ($key == 2) {
-		$group = new Form_Group('TLD Group 2 (py)');
+		$group = new Form_Group('TLD Group 2');
 	}
 	$count = count($tld_list[$tld_type]);
 
@@ -2386,7 +2386,7 @@ foreach (array('gTLD', 'ccTLD', 'iTLD', 'bgTLD') as $key => $tld_type) {
 
 $section->addInput(new Form_Checkbox(
 	'pfb_idn',
-	gettext('IDN Blocking') . '(py)',
+	gettext('IDN Blocking'),
 	'Enable',
 	$pconfig['pfb_idn'] === 'on' ? true:false,
 	'on'
@@ -2394,7 +2394,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'pfb_regex',
-	gettext('Regex Blocking') . '(py)',
+	gettext('Regex Blocking'),
 	'Enable',
 	$pconfig['pfb_regex'] === 'on' ? true:false,
 	'on'
@@ -2402,7 +2402,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'pfb_cname',
-	gettext('CNAME Validation') . '(py)',
+	gettext('CNAME Validation'),
 	'Enable',
 	$pconfig['pfb_cname'] === 'on' ? true:false,
 	'on'
@@ -2411,7 +2411,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'pfb_noaaaa',
-	gettext('no AAAA') . '(py)',
+	gettext('no AAAA'),
 	'Enable',
 	$pconfig['pfb_noaaaa'] === 'on' ? true:false,
 	'on'
@@ -2419,7 +2419,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'pfb_gp',
-	gettext('Python Group Policy') . '(py)',
+	gettext('Python Group Policy'),
 	'Enable',
 	$pconfig['pfb_gp'] === 'on' ? true:false,
 	'on'
@@ -2546,7 +2546,7 @@ $section->addInput(new Form_Input(
 // Add option to disable DNSBL logging in python and utilize the DNSBL Webserver (excluding nullblocking events)
 $section->addInput(new Form_Checkbox(
 	'pfb_py_nolog',
-	gettext('DNSBL Event Logging') . '(py)',
+	gettext('DNSBL Event Logging'),
 	'Enable',
 	$pconfig['pfb_py_nolog'] === 'on' ? true:false,
 	'on'
@@ -3033,13 +3033,6 @@ events.push(function(){
 		enable_dnsblip();
 	});
 	enable_dnsblip();
-
-	$('label[class="col-sm-2 control-label"]').each(function() {
-		var found = $(this).text();
-		if (found.indexOf('(py)') >= 0) {
-			$(this).html(found.replace('(py)', '&emsp;<i class="fa-solid fa-bolt" title="DNSBL Python"></i>'));
-		}
-	});
 });
 
 //]]>

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -39,11 +39,13 @@ so importing this module does not require the smoke deps.
 
 from __future__ import annotations
 
+import ipaddress
 import os
 import re
 import shlex
 import subprocess
 import time
+import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -101,6 +103,20 @@ DNSBL_PORT_SSL = "8443"
 SMOKE_IP_IFACE = os.environ.get("SMOKE_IP_IFACE") or "wan"
 
 
+def unique_domain(label: str = "pfbsmoke") -> str:
+    """A collision-proof, NON-reserved test domain, e.g. ``blocked-<uuid4hex>.com``.
+
+    Test domains MUST avoid the RFC 6761 special-use TLDs (``.test``, ``.example``,
+    ``.invalid``, ``.localhost``, ``.onion``) and ``home.arpa``: Unbound serves
+    those as built-in ``local-zone``s and answers them (NXDOMAIN/NODATA) BEFORE the
+    pfBlockerNG python module runs — shadowing the DNSBL block entirely. A random
+    UUIDv4 under ``.com`` can't collide with a real domain and isn't on the HSTS
+    preload list (which would flip the block shape to NULL when HSTS is on). The
+    ``<label>-`` prefix keeps the first label from starting with a digit.
+    """
+    return f"{label}-{uuid.uuid4().hex}.com"
+
+
 # --------------------------------------------------------------------------- #
 # Case specification (declarative input the matrix fills in)
 # --------------------------------------------------------------------------- #
@@ -109,13 +125,19 @@ SMOKE_IP_IFACE = os.environ.get("SMOKE_IP_IFACE") or "wan"
 class DnsblMode(str, Enum):
     """The block shape a DNSBL case expects for a matched name.
 
-    Maps to pfBlockerNG config + the ``pfb_unbound.py`` response shapes
-    (ADR §1 fact 4): NXDOMAIN (python-block mode), a null IP (``0.0.0.0`` /
-    ``::0``, per-list ``logging='disabled'``), or the DNSBL webserver VIP
-    (per-list ``logging=''`` -> ``pfb_dnsvip4``).
+    On ``next`` (python-mode-only) the two shapes are:
+
+    * ``NULL`` — NOERROR + ``0.0.0.0`` / ``::0``; per-list
+      ``logging='disabled'`` → ``logging_type='2'`` → ``null_blocking=True``
+      in ``pfb_unbound.py:evaluate_domain``.
+    * ``VIP`` — NOERROR + the DNSBL sinkhole VIP (``pfb_dnsvip4``); per-list
+      ``logging='enabled'`` → ``logging_type='1'`` → ``null_blocking=False``.
+
+    NXDOMAIN is NOT a valid python-mode output for a normal feed match
+    (verified on the live box; the only NXDOMAIN path in pfb_unbound.py is
+    SafeSearch).  The ``NXDOMAIN`` entry has been removed on ``next``.
     """
 
-    NXDOMAIN = "nxdomain"
     NULL = "null"
     VIP = "vip"
 
@@ -129,9 +151,9 @@ class DnsblCase:
       aliasname     -> CFG_DNSBL_LISTS/<n>/aliasname  (alias = DNSBL_<aliasname>)
       feed_url      -> CFG_DNSBL_LISTS/<n>/row/0/url  (a mock_feeds.feed_url)
       header        -> CFG_DNSBL_LISTS/<n>/row/0/header
-      mode          -> response shape: NXDOMAIN/NULL/VIP, set via
-                       CFG_DNSBL_SETTINGS (dnsbl_mode/pfb_py_block) +
-                       per-list 'logging'
+      mode          -> response shape: NULL/VIP, set via per-list 'logging'
+                       (on ``next`` python mode is always on; dnsbl_mode /
+                       pfb_py_block are dead config keys)
       wildcard      -> feed entry style; a wildcard feed line blocks subdomains
       whitelist     -> CFG_DNSBL_SETTINGS/suppression (newline list; a leading
                        '.' suppresses the whole subtree)
@@ -147,7 +169,7 @@ class DnsblCase:
 
     aliasname: str
     feed_url: str
-    mode: DnsblMode = DnsblMode.NXDOMAIN
+    mode: DnsblMode = DnsblMode.VIP
     header: str = "smoketest"
     wildcard: bool = False
     whitelist: list[str] = field(default_factory=list)
@@ -527,20 +549,19 @@ def configure_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def _dnsbl_mode_settings(mode: DnsblMode) -> dict[str, str]:
-    """The DNSBL global-settings fields for a response mode."""
-    if mode is DnsblMode.NXDOMAIN:
-        # Python blocking mode synthesises NXDOMAIN for matched names.
-        return {"dnsbl_mode": "dnsbl_python", "pfb_py_block": "on"}
-    if mode is DnsblMode.NULL:
-        # Unbound mode + per-list logging='disabled' -> null IP 0.0.0.0 / ::0.
-        return {"dnsbl_mode": "dnsbl_unbound", "pfb_py_block": ""}
-    # VIP: Unbound mode, per-list logging='' -> sinkhole to pfb_dnsvip4.
-    return {"dnsbl_mode": "dnsbl_unbound", "pfb_py_block": ""}
+def _dnsbl_mode_settings(mode: DnsblMode) -> dict[str, str]:  # noqa: ARG001
+    """Global-settings fields for a response mode.
+
+    On ``next`` python mode is always on (pfblockerng.inc enforces it);
+    ``dnsbl_mode`` / ``pfb_py_block`` are dead config keys.  The response
+    shape (VIP vs null) is driven entirely by per-list ``logging`` —
+    see ``_dnsbl_list_logging``.
+    """
+    return {}
 
 
 def _dnsbl_list_logging(mode: DnsblMode) -> str:
-    """The per-list ``logging`` value that selects null vs VIP."""
+    """Per-list ``logging`` value: 'disabled' → null 0.0.0.0; 'enabled' → VIP."""
     return "disabled" if mode is DnsblMode.NULL else "enabled"
 
 
@@ -600,7 +621,10 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $s);\n"
         f"$list = {_php_kv_array(listcfg)};\n"
         f"$list['row'] = array({_php_kv_array(row)});\n"
-        f"$list['row'][0]['logging'] = {_php_str(_dnsbl_list_logging(spec.mode))};\n"
+        # 'logging' is a per-LIST field — pfBlockerNG reads $list['logging']
+        # (inc: 'if ($list[\\'logging\\'] == \\'disabled\\')'), NOT a per-row value.
+        # 'disabled' -> logging_type 2 -> null 0.0.0.0; else -> VIP.
+        f"$list['logging'] = {_php_str(_dnsbl_list_logging(spec.mode))};\n"
         f"config_set_path({_php_str(CFG_DNSBL_LISTS)}, array($list));\n"
         "write_config('pfBlockerNG smoke: DNSBL case');\n"
         "echo 'OK';"
@@ -678,6 +702,23 @@ def reset(vm: SmokeVM, *, timeout: float = 600.0) -> None:
 
 UNBOUND_CONF = "/var/unbound/unbound.conf"
 UNBOUND_BEFORE = "/tmp/pfb_unbound_before.conf"
+# Snapshot of the EFFECTIVE unbound config (unbound.conf + every file it pulls in
+# via `include:`) captured before any DNSBL reload; assert_unbound_adds_only_
+# python_config diffs the post-reload effective config against it. unbound.conf
+# alone is NOT enough: pfSense splits config across includes (access_lists.conf =
+# the DNS Resolver ACLs, host_entries.conf, domainoverrides.conf, remotecontrol.conf).
+UNBOUND_SETUP = "/tmp/pfb_unbound_setup.conf"
+# Dump the whole resolver config the daemon loads by FOLLOWING the actual
+# `include:` directives from unbound.conf (recursively), rather than assuming a
+# fixed `*.conf` glob — so an include outside /var/unbound, a non-.conf name, a
+# glob include, or a nested include is still covered. Handles quoted/unquoted and
+# glob targets; `echo` between files guards a missing trailing newline.
+UNBOUND_EFFECTIVE_CMD = (
+    '_dump() { cat "$1" 2>/dev/null; '
+    "awk '/^[[:space:]]*include:/{print $2}' \"$1\" 2>/dev/null | tr -d '\"' | "
+    'while read -r pat; do for inc in $pat; do [ -f "$inc" ] && { echo; _dump "$inc"; }; done; done; }; '
+    "_dump /var/unbound/unbound.conf"
+)
 CONFIG_XML = "/conf/config.xml"
 # Per-step state snapshots: config.xml + unbound.conf are copied here at each
 # harness step so dump_diagnostics can diff consecutive states and show EXACTLY
@@ -756,6 +797,83 @@ def dump_state_diffs(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     print("========== END PER-STEP STATE DIFFS ==========\n")
 
 
+def snapshot_unbound_effective(vm: SmokeVM, dest: str = UNBOUND_SETUP, *, timeout: float = 30.0) -> None:
+    """Snapshot the EFFECTIVE unbound config (unbound.conf + every *.conf include).
+
+    Capture this BEFORE a DNSBL reload so assert_unbound_adds_only_python_config
+    can diff the post-reload effective config against it. Reading unbound.conf
+    alone misses the ACLs (they live in the included access_lists.conf).
+    """
+    vm.ssh("/bin/sh", "-c", f"{UNBOUND_EFFECTIVE_CMD} > {dest}", timeout=timeout)
+
+
+def unbound_access_control(vm: SmokeVM, *, timeout: float = 30.0) -> set[str]:
+    """The ACLs the RUNNING daemon actually enforces, via ``unbound-control``.
+
+    This is the authoritative source (includes resolved, live state) — not a
+    grep of one generated file. Returns the normalised set of access-control
+    entries (e.g. ``{"10.0.2.0/24 allow", ...}``).
+    """
+    result = vm.ssh(
+        "/usr/local/sbin/unbound-control",
+        "-c",
+        UNBOUND_CONF,
+        "get_option",
+        "access-control",
+        timeout=timeout,
+    )
+    return {ln.strip() for ln in result.stdout.splitlines() if ln.strip()}
+
+
+def assert_unbound_adds_only_python_config(vm: SmokeVM, *, timeout: float = 30.0) -> None:
+    """Assert a DNSBL reload only adds python-module config to the EFFECTIVE config.
+
+    Compares ``UNBOUND_SETUP`` (the effective config — unbound.conf + all *.conf
+    includes — captured by snapshot_unbound_effective BEFORE the DNSBL reload)
+    against the current effective config. Reading the full include set is the
+    point: the DNS Resolver ACLs live in access_lists.conf, host overrides in
+    host_entries.conf, etc. — diffing unbound.conf alone would miss a dropped ACL.
+
+    1. **Nothing removed except module-config**: pfBlockerNG legitimately replaces
+       ``module-config: "iterator"`` with ``module-config: "python iterator"``.
+       Everything else (access-control, forward-zones, host entries, server
+       tuning) must be preserved.
+    2. **Only python additions**: added lines must be python module directives,
+       includes of pfBlockerNG-managed files, or the DNSBL VIP ``interface:`` entry.
+    """
+    setup_result = vm.ssh("cat", UNBOUND_SETUP, timeout=timeout)
+    current_result = vm.ssh("/bin/sh", "-c", UNBOUND_EFFECTIVE_CMD, timeout=timeout)
+    if setup_result.returncode != 0 or not setup_result.stdout:
+        return  # baseline snapshot not available (snapshot_unbound_effective not called)
+    setup_lines = {ln.strip() for ln in setup_result.stdout.splitlines() if ln.strip()}
+    current_lines = {ln.strip() for ln in current_result.stdout.splitlines() if ln.strip()}
+
+    # module-config is legitimately REPLACED (iterator → python iterator).
+    removed = {ln for ln in (setup_lines - current_lines) if "module-config" not in ln.lower()}
+    assert not removed, (
+        f"pfBlockerNG DNSBL reload REMOVED lines from the effective unbound config "
+        f"(access-control / forward-zone / host entries / server config must be preserved): {sorted(removed)}"
+    )
+
+    added = current_lines - setup_lines
+
+    # Allow: python module directives, pfBlockerNG managed includes, VIP interface.
+    def _is_allowed(line: str) -> bool:
+        low = line.lower()
+        return (
+            "python" in low
+            or "module-config" in low
+            or ("include:" in low and "pfb" in low)
+            or (low.startswith("interface:") and DEFAULT_DNSBL_VIP4 in low)
+        )
+
+    unexpected = [ln for ln in added if not _is_allowed(ln)]
+    assert not unexpected, (
+        f"pfBlockerNG DNSBL reload made unexpected changes to the effective unbound config "
+        f"(only python-module config is allowed): {sorted(unexpected)}"
+    )
+
+
 def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 30, delay: float = 2.0) -> None:
     """Poll ``unbound-control status`` until ready (mirrors install-pkg.sh)."""
     cmd = "/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status"
@@ -809,24 +927,39 @@ def _parse_drill(output: str, rtype: str) -> DnsAnswer:
 
 
 def dns_probe(
-    vm: SmokeVM, name: str, rtype: str = "A", *, timeout: float = 30.0, attempts: int = 3, delay: float = 2.0
+    vm: SmokeVM, name: str, rtype: str = "A", *, timeout: float = 30.0, attempts: int = 3, delay: float = 5.0
 ) -> DnsAnswer:
-    """Resolve (name, rtype) against the guest's Unbound, ON THE GUEST itself.
+    """Resolve (name, rtype) ON the guest via ``drill <name> <rtype> @127.0.0.1`` over SSH.
 
-    Runs ``drill <name> <rtype> @127.0.0.1`` over SSH rather than querying the
-    runner-side hostfwd (``dns.query.tcp`` to vm.dns_port). pfSense Unbound with
-    DNSBL active does NOT answer a WAN-sourced query — and the runner hostfwd
-    arrives on the guest's only NIC (WAN); the single-NIC smoke VM has no LAN. A
-    real client queries from the LAN/on-box, so the on-box query is the faithful
-    path (and the only one DNSBL services). Retries: right after a DNSBL reload
-    the python-mode resolver can be briefly slow.
+    Verified on a live box: python-mode DNSBL has **no localhost exemption** — a
+    blocked domain returns its block shape (VIP / NULL) even for a 127.0.0.1-sourced
+    query. So the on-box query is sufficient AND avoids the QEMU SLIRP WAN-hostfwd
+    path (which, unlike a real LAN client, does not get answered in CI — that path,
+    not Unbound being slow, is what produced the earlier transport TIMEOUTs).
+
+    Caller MUST use a non-RFC-6761, non-HSTS-preload domain (see ``unique_domain``):
+    Unbound's built-in ``local-zone``s for ``.test`` / ``.example`` / etc. shadow
+    those names (NXDOMAIN/NODATA) before DNSBL, and HSTS-preload names flip a VIP
+    block to NULL when HSTS is on (the default).
+
+    Probe semantics (load-bearing): the caller has already waited for Unbound to be
+    ready after the reload (``reload`` -> ``wait_unbound_ready``). The FIRST parsed
+    DNS response is therefore authoritative — whatever Unbound returns is the real
+    answer, so we return it and let the caller assert/error on it. We do NOT re-query
+    hoping the answer becomes the expected value (that could loop forever). The only
+    retry is a short settle for the window where ``drill`` got NO DNS response at all
+    (e.g. queried during the restart) — bounded at ``attempts`` x ``delay`` (~5s).
     """
     cmd = f"{DRILL_BIN} {shlex.quote(name)} {shlex.quote(rtype)} @127.0.0.1"
     last = ""
     for attempt in range(attempts):
         result = vm.ssh(cmd, timeout=timeout)
         if "rcode:" in result.stdout:
+            # A DNS response came back -> it IS Unbound's answer. Return it as-is;
+            # the caller asserts the shape. Never loop for a "better" answer.
             return _parse_drill(result.stdout, rtype)
+        # No DNS response at all (drill produced no rcode) — only here do we wait +
+        # retry, to ride out the brief post-restart window.
         last = f"rc={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
         if attempt < attempts - 1:
             time.sleep(delay)
@@ -839,8 +972,24 @@ def is_nxdomain(answer: DnsAnswer) -> bool:
 
 
 def is_null_ip(answer: DnsAnswer, null_ip: str = NULL_IP4) -> bool:
-    """True iff the answer is the null-block IP (default ``0.0.0.0``)."""
-    return null_ip in answer.records
+    """True iff the answer is the null-block IP (default ``0.0.0.0`` / ``::``).
+
+    Compares by VALUE, not string: pfb_unbound.py emits the IPv6 null as ``::``
+    and drill prints the canonical ``::``, but callers may pass ``::0`` — same
+    address, different text. Normalise both via ``ipaddress`` so representation
+    never matters (``::`` == ``::0``, ``0.0.0.0`` == ``0.0.0.0``).
+    """
+    try:
+        target = ipaddress.ip_address(null_ip)
+    except ValueError:
+        return null_ip in answer.records
+    for record in answer.records:
+        try:
+            if ipaddress.ip_address(record) == target:
+                return True
+        except ValueError:
+            continue
+    return False
 
 
 def is_vip(answer: DnsAnswer, vip: str = DEFAULT_DNSBL_VIP4) -> bool:
@@ -908,6 +1057,72 @@ def member_present(members: list[str], ip: str) -> bool:
 # --------------------------------------------------------------------------- #
 
 
+def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeout: float = 240.0) -> None:
+    """Tar a COMPREHENSIVE pfSense-GUEST snapshot and pull it to ``dest_dir/`` on
+    the runner, for the workflow to upload as an artifact.
+
+    Collected ALWAYS (even on a green run): we might need it to debug a failure,
+    and even when we don't, an after-the-fact analysis of the full logs can surface
+    issues we didn't know to look for. Best-effort — never raises (diagnostics, not
+    a gate). The guest VM is torn down at session end, so this must run in-process
+    before teardown; a workflow step after pytest can't reach the guest.
+
+    Captures: ALL of /var/log (system / filter(firewall) / resolver / pfBlockerNG /
+    …), dmesg + boot, full pf state (``pfctl -sa``), network (ifconfig / sockstat /
+    netstat), Unbound + pfBlockerNG runtime files (``*.conf`` / ``*.ini`` /
+    ``pfb_py_*``), the process table, and a SECRET-SCRUBBED config.xml (bcrypt hash,
+    cert private keys, authorized keys redacted before it leaves the box).
+    """
+    remote_tar = "/tmp/pfb_smoke_diag.tgz"
+    script = (
+        'set +e; D=/tmp/pfb_smoke_diag; rm -rf "$D"; mkdir -p "$D/unbound"; '
+        'tar czf "$D/var_log.tgz" -C /var log 2>/dev/null; '
+        '/sbin/dmesg > "$D/dmesg.txt" 2>&1; cp /var/run/dmesg.boot "$D/dmesg.boot" 2>/dev/null; '
+        '/sbin/pfctl -sa > "$D/pfctl_sa.txt" 2>&1; '
+        '/sbin/ifconfig -a > "$D/ifconfig.txt" 2>&1; '
+        '/usr/bin/sockstat > "$D/sockstat.txt" 2>&1; /usr/bin/netstat -rn > "$D/netstat_rn.txt" 2>&1; '
+        'cp /var/unbound/*.conf /var/unbound/*.ini "$D/unbound/" 2>/dev/null; '
+        'cp /var/unbound/pfb_py_* "$D/unbound/" 2>/dev/null; '
+        # pfBlockerNG database (feeds / masterfiles / orig / deny / dnsbl / …) and
+        # pfSense's pf alias-table files — the IP/domain state behind the rules.
+        'tar czf "$D/var_db_pfblockerng.tgz" -C /var/db pfblockerng 2>/dev/null; '
+        'tar czf "$D/var_db_aliastables.tgz" -C /var/db aliastables 2>/dev/null; '
+        '/bin/ps auxww > "$D/ps.txt" 2>&1; '
+        # Scrub secrets from config.xml BEFORE it leaves the box.
+        "sed -E 's#(<bcrypt-hash>)[^<]*#\\1REDACTED#g; s#(<prv>)[^<]*#\\1REDACTED#g; "
+        "s#(<authorizedkeys>)[^<]*#\\1REDACTED#g; s#(<tls_certificate>)[^<]*#\\1REDACTED#g' "
+        '/conf/config.xml > "$D/config.scrubbed.xml" 2>/dev/null; '
+        f"tar czf {remote_tar} -C /tmp pfb_smoke_diag 2>/dev/null; true"
+    )
+    try:
+        vm.ssh("/bin/sh", "-c", script, timeout=timeout)
+        os.makedirs(dest_dir, exist_ok=True)
+        scp_argv = [
+            "scp",
+            "-i",
+            vm.ssh_key_path,
+            "-P",
+            str(vm.ssh_port),
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "LogLevel=ERROR",
+            f"{vm.ssh_target}:{remote_tar}",
+            os.path.join(dest_dir, "pfb_smoke_diag.tgz"),
+        ]
+        result = subprocess.run(scp_argv, capture_output=True, text=True, timeout=timeout, check=False)
+        if result.returncode == 0:
+            print(f"[smoke] collected full guest diagnostics -> {dest_dir}/pfb_smoke_diag.tgz")
+        else:
+            print(f"[smoke] guest-diagnostics scp failed (non-fatal): {result.stderr!r}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[smoke] collect_host_diagnostics failed (non-fatal): {exc!r}")
+
+
 def dump_diagnostics(vm: SmokeVM) -> None:
     """Print key pfSense/pfBlockerNG/Unbound state for post-mortem on failure.
 
@@ -946,7 +1161,29 @@ def dump_diagnostics(vm: SmokeVM) -> None:
             "wc -l /var/unbound/pfb_py_data.txt /var/unbound/pfb_py_zone.txt 2>/dev/null; "
             "echo '--- data head ---'; head -8 /var/unbound/pfb_py_data.txt 2>/dev/null; "
             "echo '--- blocked refs ---'; "
-            "grep -nE 'blocked-' /var/unbound/pfb_py_data.txt /var/unbound/pfb_py_zone.txt 2>/dev/null | head",
+            "grep -nE 'blocked-|null-|guard-|allowed-' "
+            "/var/unbound/pfb_py_data.txt /var/unbound/pfb_py_zone.txt 2>/dev/null | head",
+        ),
+        (
+            # THE enable gate: pfb_unbound.ini drives the module. python_enable=on
+            # (mode=='enabled') is what makes operate() load the blocklist + block;
+            # if it's off, every name is forwarded (SERVFAIL under egress block).
+            "pfb_unbound.ini ([MAIN] — python_enable / python_blocking / VIPs)",
+            "cat /var/unbound/pfb_unbound.ini 2>/dev/null | head -60 || true",
+        ),
+        (
+            # ADR-06 manifest the module BUILDS dataDB from on next (not pfb_py_data
+            # directly) + the per-load count it emits + any python load/build error.
+            "DNSBL python manifest + count + py_error",
+            "echo '--- pfb_py_sources.json ---'; head -c 1200 /var/unbound/pfb_py_sources.json 2>/dev/null; echo; "
+            "echo '--- pfb_py_count ---'; cat /var/unbound/pfb_py_count 2>/dev/null; echo; "
+            "echo '--- py_error.log ---'; tail -n 40 /var/log/pfblockerng/py_error.log 2>/dev/null || true",
+        ),
+        (
+            # mode=='enabled' needs unbound_state == config_path_enabled('unbound').
+            "DNS Resolver enabled? (<unbound><enable>)",
+            "sed -n '/<unbound>/,/<\\/unbound>/p' /conf/config.xml 2>/dev/null "
+            "| grep -nE '<enable|<python|forwarding' | head || true",
         ),
         (
             "DNSBL unbound.conf blocks — what unbound mode builds (local-zone/data)",
@@ -955,7 +1192,9 @@ def dump_diagnostics(vm: SmokeVM) -> None:
         ),
         (
             "guest-local DNS query (does the resolver answer NON-quiet?)",
-            "/usr/local/bin/drill blocked-exact.pfb.test A @127.0.0.1 2>&1 | "
+            # localhost always resolves locally -> a clean liveness check, with no
+            # RFC 6761 local-zone or per-case-domain confusion.
+            "/usr/local/bin/drill localhost A @127.0.0.1 2>&1 | "
             "grep -iE 'rcode|ANSWER SECTION|^[a-z].*IN' | head -6 || true",
         ),
         (
@@ -1002,12 +1241,12 @@ def dump_diagnostics(vm: SmokeVM) -> None:
         probes += [
             (
                 f"guest -> stub directly (@{GUEST_TO_HOST_ALIAS} -p {p})",
-                f"/usr/local/bin/drill nonblocked-probe.example A @{GUEST_TO_HOST_ALIAS} -p {p} 2>&1 | "
+                f"/usr/local/bin/drill pfbsmoke-nonblocked-probe.com A @{GUEST_TO_HOST_ALIAS} -p {p} 2>&1 | "
                 "grep -iE 'rcode|ANSWER|IN.A' | head -5 || true",
             ),
             (
                 "forwarding resolves a non-blocked name to the sentinel?",
-                "/usr/local/bin/drill nonblocked-probe.example A @127.0.0.1 2>&1 | "
+                "/usr/local/bin/drill pfbsmoke-nonblocked-probe.com A @127.0.0.1 2>&1 | "
                 "grep -iE 'rcode|ANSWER|IN.A' | head -5 || true",
             ),
         ]

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -713,6 +713,10 @@ UNBOUND_SETUP = "/tmp/pfb_unbound_setup.conf"
 # fixed `*.conf` glob — so an include outside /var/unbound, a non-.conf name, a
 # glob include, or a nested include is still covered. Handles quoted/unquoted and
 # glob targets; `echo` between files guards a missing trailing newline.
+# `for inc in $pat` is UNQUOTED ON PURPOSE — word-splitting is what expands an
+# `include:` glob (e.g. `/var/unbound/*.conf`). pfSense/Unbound include paths
+# never contain whitespace, and this is read-only diagnostic code, so the
+# split-on-spaces tradeoff is safe here.
 UNBOUND_EFFECTIVE_CMD = (
     '_dump() { cat "$1" 2>/dev/null; '
     "awk '/^[[:space:]]*include:/{print $2}' \"$1\" 2>/dev/null | tr -d '\"' | "
@@ -844,7 +848,14 @@ def assert_unbound_adds_only_python_config(vm: SmokeVM, *, timeout: float = 30.0
     setup_result = vm.ssh("cat", UNBOUND_SETUP, timeout=timeout)
     current_result = vm.ssh("/bin/sh", "-c", UNBOUND_EFFECTIVE_CMD, timeout=timeout)
     if setup_result.returncode != 0 or not setup_result.stdout:
-        return  # baseline snapshot not available (snapshot_unbound_effective not called)
+        # No baseline => snapshot_unbound_effective() wasn't called before the
+        # DNSBL reload (a test-setup bug). Make it LOUD rather than silently
+        # "passing" — a missing baseline must never read as immutability proven.
+        print(
+            "[smoke] WARNING: assert_unbound_adds_only_python_config skipped — "
+            f"baseline {UNBOUND_SETUP} missing (snapshot_unbound_effective not called?)"
+        )
+        return
     setup_lines = {ln.strip() for ln in setup_result.stdout.splitlines() if ln.strip()}
     current_lines = {ln.strip() for ln in current_result.stdout.splitlines() if ln.strip()}
 

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -71,7 +71,7 @@ def test_inject_value_roundtrips(deployed_vm: SmokeVM) -> None:
 
 def test_inject_control_record_resolves(deployed_vm: SmokeVM) -> None:
     """A control local-data injected in CONFIG resolves after a reload."""
-    name = "selftest-control.pfb.test"
+    name = h.unique_domain("selftest-control")
     ip = "192.0.2.250"
     h.set_control_records(deployed_vm, {name: {"A": ip}}, {})
     # The reload regenerates unbound.conf; the config-baked record must survive.
@@ -137,7 +137,7 @@ def test_dns_probe_nxdomain_shape(deployed_vm: SmokeVM) -> None:
     (would indicate a leaking upstream / wrong probe), proving the probe reads
     the real resolver state.
     """
-    answer = h.dns_probe(deployed_vm, "definitely-absent.pfb.test", "A")
+    answer = h.dns_probe(deployed_vm, h.unique_domain("definitely-absent"), "A")
     assert not answer.records or answer.rcode != "NOERROR", (
         f"absent name returned records {answer.records} rcode {answer.rcode}"
     )

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -15,16 +15,31 @@ Every expected answer is pinned to the REAL matcher semantics in
 ``src/usr/local/pkg/pfblockerng/pfb_unbound.py`` + ``pfblockerng.inc`` (verified
 against source, not guessed):
 
-* DNSBL **python** mode (``dnsbl_python`` + ``pfb_py_block``): the whole feed is
-  written to ``pfb_py_data.txt`` as EXACT entries (``inc:8966-8970``; zone files
-  are only produced by the out-of-scope TLD feature). ``evaluate_domain``
-  (``pfb_unbound.py:1707``) looks the name up in ``dataDB`` EXACTLY — a matched
-  name yields NXDOMAIN; a SUBDOMAIN of it is NOT in ``dataDB`` and is NOT blocked.
-* DNSBL **unbound** mode (``dnsbl_unbound``): each domain becomes an Unbound
-  ``local-zone: "<d>" redirect`` (``inc:3069``/feed path ``inc:8670``), which is
-  a WILDCARD — it answers for ``<d>`` AND every subdomain. ``logging='disabled'``
-  sinkholes to ``0.0.0.0``/``::0`` (NULL); ``logging='enabled'`` sinkholes to the
-  DNSBL VIP (``pfb_dnsvip4``).
+* DNSBL **python** mode (the ONLY mode on ``next``): the feed is written to
+  ``pfb_py_data.txt`` as EXACT entries (``inc:8966-8970``; zone files are only
+  produced by the out-of-scope TLD feature). ``evaluate_domain``
+  (``pfb_unbound.py:evaluate_domain``) looks the name up in ``dataDB`` EXACTLY.
+  The response shape is:
+
+  - ``logging='enabled'`` → ``logging_type='1'`` → ``null_blocking=False``
+    → NOERROR + A = DNSBL VIP (``pfb_dnsvip4``). (**VIP** shape.)
+  - ``logging='disabled'`` → ``logging_type='2'`` → ``null_blocking=True``
+    → NOERROR + A = ``0.0.0.0`` / AAAA = ``::0``. (**NULL** shape.)
+
+  A matched subdomain is NOT in ``dataDB`` and is NOT blocked (exact match only).
+  NXDOMAIN is NEVER the response for a normal feed match (verified on the live
+  box); the only NXDOMAIN path is SafeSearch.
+
+  Probed ON-BOX (``drill @127.0.0.1`` over SSH): verified on a live box that
+  python-mode DNSBL has NO localhost exemption — a blocked name returns its block
+  shape even for a 127.0.0.1 query. (The QEMU SLIRP WAN-hostfwd path, unlike a real
+  LAN client, is not answered in CI — so we don't use it.)
+
+  Two domain constraints, both load-bearing (see ``helpers.unique_domain``):
+  test names must NOT use RFC 6761 TLDs (``.test`` / ``.example`` / …) — Unbound's
+  built-in ``local-zone``s shadow them (NXDOMAIN/NODATA) before DNSBL — and must
+  NOT be HSTS-preload — with HSTS on (the default ``pfb_hsts``), a preload domain's
+  VIP block is forced to NULL. A random ``uuid-*.com`` satisfies both.
 * WHITELIST (``suppression``): ``whitelist_check_domain`` short-circuits before
   any block shape, so a suppressed name resolves via its control ``local-data``.
 * DNSBL-IP dual-stack (``action != 'Disabled'``): IP literals in the DNSBL feed
@@ -49,16 +64,6 @@ from .conftest import SmokeVM, _MockFeedServer, _StubDnsServer
 
 pytestmark = pytest.mark.smoke
 
-# Python-mode DNSBL can't be exercised in this VM topology: verified on a live
-# box that the python block does NOT engage for the firewall's OWN (localhost)
-# query — and the single-NIC smoke VM has only localhost + WAN (no LAN client),
-# while the WAN path isn't served. (Module loaded, python_blocking=on, domain in
-# pfb_py_data, py_error empty — it's a source/topology limitation, not a bug.)
-# Unbound mode DOES block the on-box query, so the matrix asserts that here.
-# Deferred to the `next` branch, where Unbound mode is removed and ONLY python
-# mode remains — the matrix will be adapted to drive python mode there.
-_PY_MODE_SKIP = "python-mode DNSBL shape not testable on single-NIC VM (localhost-exempt, no LAN); covered in next"
-
 
 @pytest.fixture(scope="module")
 def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
@@ -67,11 +72,15 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
 
     Egress stays OPEN during a pfBlockerNG reload (the DNSBL update path needs a
     working resolver/network) and ``CaseContext`` blocks it only for the per-case
-    DNS probe. The probe stays hermetic because Unbound's only upstream is the
-    runner-side stub (configure_upstream), reachable over SLIRP even with egress
-    blocked — so a query resolves (block shape locally, or the sentinel) instead
-    of hanging on dark-root recursion. deploy() needs egress (`pkg add` pulls
-    RUN_DEPENDS via SLIRP). unblock on teardown as a safety net.
+    DNS probe. The probe stays hermetic because every name the matrix asserts
+    resolves LOCALLY — a blocked name is intercepted by the python module before
+    the forwarder, and a control/whitelist name answers from its injected host
+    override — so the probe never needs upstream egress. (``configure_upstream``
+    is intentionally NOT called: the baked image already forwards on its own;
+    injecting a second ``forward-zone "."`` broke Unbound.) deploy() needs no
+    egress for dependencies either — the pre-baked image ships pfBlockerNG's
+    RUN_DEPENDS, so ``pkg add`` resolves them from the local pkg db offline.
+    unblock on teardown as a safety net.
     """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
@@ -81,18 +90,19 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     h.snapshot_unbound_conf(smoke_vm)
     h.snap_state(smoke_vm, "deployed")
     # DNSBL force-disables itself without a VIP (pfb_validate_vips); pfBlockerNG
-    # never auto-creates one, so inject the lo0 sinkhole VIP once for the matrix.
+    # never auto-creates one and the image does NOT bake one, so inject the lo0
+    # sinkhole VIP once for the matrix. dns_probe queries on-box (drill
+    # @127.0.0.1) — no localhost exemption — so no WAN/ACL plumbing is needed.
     h.ensure_dnsbl_vip(smoke_vm)
     h.snap_state(smoke_vm, "vip")
-    # NOTE: configure_upstream() is intentionally NOT called — the image's Unbound
-    # already forwards (forward-zone . -> 10.0.2.3/1.1.1.1/1.0.0.1), so adding a
-    # second "." forward-zone broke Unbound outright. The DNSBL-active probe
-    # timeout is NOT an upstream problem; left for the config-XML analysis
-    # (suspected Unbound access-control for the WAN-sourced hostfwd query).
     try:
         yield smoke_vm
     finally:
         h.unblock_egress()
+        # ALWAYS collect a full guest snapshot (all /var/log, dmesg, pf, unbound,
+        # scrubbed config.xml) for the workflow to upload — for this debug and for
+        # after-the-fact analysis. Best-effort; never masks a test result.
+        h.collect_host_diagnostics(smoke_vm)
 
 
 # --------------------------------------------------------------------------- #
@@ -125,10 +135,49 @@ def test_ip_alias_table_and_rule(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
 # --------------------------------------------------------------------------- #
 
 
-def test_dnsbl_exact_nxdomain(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
-    """EXACT + NXDOMAIN (python mode) — DEFERRED to `next` (see _PY_MODE_SKIP)."""
-    pytest.skip(_PY_MODE_SKIP)
-    domain = "blocked-exact.pfb.test"
+def test_dnsbl_unbound_config_immutable(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """pfBlockerNG DNSBL reload only adds python-module config to unbound.conf.
+
+    When DNSBL is enabled, pfBlockerNG is allowed to make exactly ONE class of
+    change to Unbound's configuration: adding the python iterator module directives
+    (``module-config``, ``python-script``, and pfBlockerNG managed ``include``
+    lines, plus the DNSBL VIP ``interface:`` entry).  No other configuration —
+    access-control, forward-zones, server tuning — may be removed or altered.
+
+    This guards against pfBlockerNG silently clobbering custom Unbound config
+    (e.g. the DNS-Resolver ACLs in access_lists.conf) during a reload.
+    """
+    # Baseline the EFFECTIVE unbound config (unbound.conf + all *.conf includes,
+    # so access_lists.conf etc. are covered) AND the live ACLs, BEFORE DNSBL is
+    # applied. The case carries no control records, so the only legitimate delta
+    # is pfBlockerNG's python-module config.
+    h.snapshot_unbound_effective(deployed_vm)
+    acls_before = h.unbound_access_control(deployed_vm)
+    domain = h.unique_domain("cfgimmut")
+    feed_url = h.write_local_feed(deployed_vm, "smoke_cfgimmut.txt", f"{domain}\n")
+    spec = h.DnsblCase(aliasname="smokecfgimmut", feed_url=feed_url, header="smokecfgimmut")
+    with h.CaseContext(deployed_vm, spec):
+        h.assert_unbound_adds_only_python_config(deployed_vm)
+        # Authoritative ACL check via the daemon itself (unbound-control), not a
+        # file grep: the DNSBL reload must not drop/alter the resolver ACLs.
+        acls_after = h.unbound_access_control(deployed_vm)
+        assert acls_after == acls_before, (
+            f"DNSBL reload changed Unbound ACLs: before={sorted(acls_before)} after={sorted(acls_after)}"
+        )
+
+
+def test_dnsbl_python_exact_vip(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """Python-mode exact block: NOERROR + VIP for the listed domain; subdomain passes.
+
+    Verified on the live box: python mode writes the feed to ``pfb_py_data.txt``
+    as EXACT entries.  ``evaluate_domain`` looks the name up in ``dataDB`` EXACTLY
+    — ``logging='enabled'`` → ``null_blocking=False`` → NOERROR + A = DNSBL VIP.
+    A subdomain is NOT in ``dataDB`` and resolves normally (exact, not wildcard).
+    Probed on-box (``drill @127.0.0.1``); python-mode has no localhost exemption,
+    so the block shows there. Domain is a unique non-RFC-6761 ``.com`` so no
+    Unbound local-zone shadows it.
+    """
+    domain = h.unique_domain("blocked")
     sub = f"x.{domain}"
     sub_ip = "198.51.100.40"
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_exact.txt", f"{domain}\n")
@@ -136,27 +185,27 @@ def test_dnsbl_exact_nxdomain(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer)
         aliasname="smokeexact",
         feed_url=feed_url,
         header="smokeexact",
-        mode=h.DnsblMode.NXDOMAIN,
+        mode=h.DnsblMode.VIP,
         control_local_data={sub: {"A": sub_ip}},
     )
     with h.CaseContext(deployed_vm, spec):
         blocked = h.dns_probe(deployed_vm, domain, "A")
-        assert h.is_nxdomain(blocked), f"{domain} expected NXDOMAIN, got {blocked}"
-        # EXACT does NOT block the subdomain: it resolves to its control answer.
+        assert h.is_vip(blocked), f"{domain} expected VIP {h.DEFAULT_DNSBL_VIP4}, got {blocked}"
+        # EXACT match: subdomain NOT in dataDB, resolves to its control answer.
         passed = h.dns_probe(deployed_vm, sub, "A")
         assert h.resolves_to(passed, sub_ip), f"{sub} should resolve to {sub_ip} (exact != wildcard), got {passed}"
-        assert not h.is_nxdomain(passed), f"{sub} wrongly blocked as NXDOMAIN: {passed}"
+        assert not h.is_vip(passed), f"{sub} wrongly VIP-blocked (exact match, not wildcard): {passed}"
 
 
 def test_dnsbl_exact_null(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
-    """NULL sinkhole (0.0.0.0/::0) — a python-mode shape; DEFERRED to `next`.
+    """Python-mode null sinkhole: NOERROR + 0.0.0.0/::0 for a logging='disabled' feed.
 
-    Verified on the live box: Unbound mode ALWAYS sinkholes to the VIP (the
-    redirect local-data uses dnsbl_vip4, inc:2897) — null 0.0.0.0 only happens in
-    python mode (null_blocking), which isn't testable here (see _PY_MODE_SKIP).
+    ``logging='disabled'`` → ``logging_type='2'`` → ``null_blocking=True`` →
+    pfb_unbound.py answers NOERROR + A 0.0.0.0 / AAAA ::0. The domain is a unique
+    non-HSTS-preload ``.com`` so HSTS (on by default) does not also force NULL —
+    NULL here is purely the per-list ``logging='disabled'`` path.
     """
-    pytest.skip(_PY_MODE_SKIP)
-    domain = "blocked-null.pfb.test"
+    domain = h.unique_domain("null")
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_null.txt", f"{domain}\n")
     spec = h.DnsblCase(
         aliasname="smokenull",
@@ -173,56 +222,27 @@ def test_dnsbl_exact_null(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> 
         )
 
 
-def test_dnsbl_unbound_exact_block(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
-    """Unbound-mode block: the EXACT domain -> NOERROR + the DNSBL VIP; a
-    subdomain is NOT blocked.
-
-    Verified against the live box: Unbound mode writes EXACT
-    ``local-data: "<d> 60 IN A <vip>"`` (NOT a ``local-zone redirect`` wildcard,
-    contrary to the ADR's original reading) — so it sinkholes the listed domain
-    to the VIP and leaves subdomains untouched. Probed on-box (drill @127.0.0.1);
-    a real LAN client sees the same. This is the automatable DNSBL-blocking proof
-    in this VM topology; the python-mode NXDOMAIN/null shapes are deferred to
-    `next` (see _PY_MODE_SKIP).
-    """
-    domain = "blocked-wild.pfb.test"
-    deep = f"a.b.{domain}"
-    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unbound.txt", f"{domain}\n")
-    spec = h.DnsblCase(
-        aliasname="smokeunb",
-        feed_url=feed_url,
-        header="smokeunb",
-        mode=h.DnsblMode.VIP,
-    )
-    with h.CaseContext(deployed_vm, spec):
-        apex = h.dns_probe(deployed_vm, domain, "A")
-        assert h.is_vip(apex), f"{domain} (apex) expected VIP {h.DEFAULT_DNSBL_VIP4}, got {apex}"
-        # EXACT local-data, not a wildcard: the subdomain is NOT sinkholed to the VIP.
-        sub = h.dns_probe(deployed_vm, deep, "A")
-        assert not h.is_vip(sub), f"{deep} unexpectedly VIP-blocked (unbound mode is exact, not wildcard): {sub}"
-
-
 def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """WHITELIST: a domain on the whitelist AND in the block feed RESOLVES.
 
     ``suppression`` short-circuits before any block shape, so the name resolves
     via its control ``local-data`` (a true pass) — NOT NXDOMAIN/null/VIP.
     """
-    domain = "allowed.pfb.test"
+    domain = h.unique_domain("allowed")
     pass_ip = "198.51.100.77"
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_white.txt", f"{domain}\n")
     spec = h.DnsblCase(
         aliasname="smokewhite",
         feed_url=feed_url,
         header="smokewhite",
-        mode=h.DnsblMode.NXDOMAIN,
+        mode=h.DnsblMode.VIP,
         whitelist=[domain],
         control_local_data={domain: {"A": pass_ip}},
     )
     with h.CaseContext(deployed_vm, spec):
         answer = h.dns_probe(deployed_vm, domain, "A")
         assert h.resolves_to(answer, pass_ip), f"whitelisted {domain} should resolve to {pass_ip}, got {answer}"
-        assert not h.is_nxdomain(answer), f"whitelisted {domain} wrongly NXDOMAIN: {answer}"
+        assert not h.is_vip(answer), f"whitelisted {domain} wrongly VIP-blocked: {answer}"
         assert not h.is_null_ip(answer), f"whitelisted {domain} wrongly null-IP: {answer}"
 
 
@@ -240,13 +260,16 @@ def test_dnsblip_dual_stack_partition(deployed_vm: SmokeVM, mock_feeds: _MockFee
     inc:9306) — each holding ONLY its own family, never merged onto one table.
     The inet/inet6 rules must reference the matching table.
 
-    DEFERRED: pfB_DNSBLIP_* was not created on the live box from a raw-IP DNSBL
-    feed — the DNSBL-IP IP-extraction path needs investigation (likely tied to the
-    python-mode DNSBL processing that's also deferred). Revisit alongside the
-    `next` adaptation; the IP-firewall path itself is already proven by
-    test_ip_alias_table_and_rule.
+    DEFERRED: ``pfB_DNSBLIP_v4`` / ``pfB_DNSBLIP_v6`` are not present when
+    ``pfctl_tables()`` runs — the tables appear in teardown diagnostics, showing
+    that ``filter_configure`` populates them asynchronously after
+    ``pfblockerng.php update`` exits.  The assertion needs a polling helper (like
+    ``rule_references``).  Re-deferred; the IP-firewall path itself is already
+    proven by ``test_ip_alias_table_and_rule``.
     """
-    pytest.skip("DNSBL-IP table not populated from a raw-IP DNSBL feed; deferred (see docstring / `next`)")
+    pytest.skip(
+        "pfB_DNSBLIP_v4/v6 populated async by filter_configure; needs poll-based assertion — deferred (see docstring)"
+    )
     v4 = "203.0.113.7"  # RFC 5737 documentation range
     v6 = "2001:db8:5::7"  # RFC 3849 documentation range
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsblip_dual.txt", f"{v4}\n{v6}\n")
@@ -291,11 +314,11 @@ def _is_v4_literal(member: str) -> bool:
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(strict=True, reason="deliberately-wrong expectation: a real NXDOMAIN block is NOT a pass")
+@pytest.mark.xfail(strict=True, reason="deliberately-wrong expectation: a real VIP block is NOT a pass")
 def test_false_green_guard_vm(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """STRICT-xfail guard: assert a real block RESOLVES — it must NOT.
 
-    Blocks ``guard.pfb.test`` (NXDOMAIN) then asserts it resolves to a pass IP.
+    Blocks a unique domain (VIP) then asserts it resolves to a pass IP.
     That assertion is FALSE on a working harness, so the test fails -> the
     ``strict=True`` xfail turns the failure into the expected outcome (green
     overall). If a broken/lenient harness silently let the block "pass", this
@@ -303,15 +326,15 @@ def test_false_green_guard_vm(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer)
     catching a false-green at the VM level (on top of the pure-Python guard in
     test_smoke_helpers.py::test_false_green_guard).
     """
-    domain = "guard.pfb.test"
+    domain = h.unique_domain("guard")
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_guard.txt", f"{domain}\n")
     spec = h.DnsblCase(
         aliasname="smokeguard",
         feed_url=feed_url,
         header="smokeguard",
-        mode=h.DnsblMode.NXDOMAIN,
+        mode=h.DnsblMode.VIP,
     )
     with h.CaseContext(deployed_vm, spec):
         answer = h.dns_probe(deployed_vm, domain, "A")
-        # WRONG on purpose: a NXDOMAIN block does not resolve to a pass IP.
+        # WRONG on purpose: a VIP block does not resolve to a pass IP.
         assert h.resolves_to(answer, "198.51.100.250"), "expected (wrongly) to resolve — must fail"


### PR DESCRIPTION
## ADR-04 — phase 7 (next-only): python-mode-only live-VM smoke matrix

Adapts the ADR-04 smoke harness to `next`, where Unbound DNSBL mode is removed and
**python mode is the only DNSBL mode**. The live-VM matrix is **GREEN on `next`**:
`13 passed / 3 skipped / 1 xfailed` (run 26895418833).

### Product fixes (caught by the live smoke test — unit tests can't see them)

- **DNSBL python feeds never loaded under the Unbound chroot** (`pfblockerng.inc`).
  ADR-06's manifest stored host-absolute feed paths; Unbound runs chrooted at
  `/var/unbound`, so the module resolved `/var/unbound/pfb_py_raw/…` →
  `/var/unbound/var/unbound/…` and every feed failed to open → `dataDB` empty →
  **DNSBL silently blocked nothing**. Fix: relative manifest paths + `tld_master`
  embedded as lines. `main` is unaffected (legacy load). *Check whether `devel`'s
  ADR-06 manifest build needs the same fix.*
- Removed the now-redundant `(py)` / lightning-bolt DNSBL UI markers.

### Harness (`tests/smoke/`)

- On-box `drill @127.0.0.1` probe (python mode has **no localhost exemption**; the
  SLIRP WAN-hostfwd DNS path isn't answered in CI). First response after readiness
  is authoritative.
- `unique_domain()` → `uuid-*.com`: avoids RFC-6761 TLDs (Unbound local-zones
  shadow `.test`/`.example`) and HSTS-preload names (HSTS flips VIP→NULL).
- VIP/NULL via list-level `logging`; value-based IP compare (`::` == `::0`).
- Config-immutability reads the **effective** unbound config (all includes) +
  asserts ACLs via `unbound-control`.
- Always uploads a **full guest snapshot** artifact (all `/var/log`, `pfctl -sa`,
  unbound + pfBlockerNG state, `/var/db/pfblockerng` + `aliastables`, scrubbed
  `config.xml`).

### CI

- Image caches content-keyed (smoke qcow2 by GHCR digest; FreeBSD base by published
  SHA256 + verified). Two-tier FreeBSD build cache (prepared image with baked key).
  `setup-node` v4 → v6.

### Docs / convention

- CLAUDE.md: **"Smoke tests (ADR-04)" read-first** section + chrooted-services note
  + "Resolving pfSense PHP functions" (upstream-at-dated-refs / stub-over-exception).
- The smoke image ships pfBlockerNG's deps; `pkg add` is offline.
  `docs/misc/pfSense_versions.md` + `scripts/misc/install_deps_CE_2.8.sh`.
- `RESULTS/08_Results.txt`: full writeup + follow-ups.

### Deferred

- `test_dnsblip_dual_stack_partition` (tables populated async by `filter_configure`
  — needs a poll-based assertion).
- An explicit HSTS NULL test (block a preload domain; assert VIP→`0.0.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pfSense version-specific dependency and configuration guidance.
  * Enhanced smoke testing documentation with on-box probing expectations.

* **Bug Fixes**
  * Improved offline package installation reliability.

* **Tests**
  * Strengthened smoke test suite with immutability checks and enhanced diagnostics collection.

* **Refactor**
  * Improved CI/CD image caching and artifact handling.
  * Removed "(py)" notation from UI labels for cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->