### PR TITLE
scripts: portable off-FreeBSD .pkg builder (build-pkg-portable.py)

### DIFF
--- a/docs/build-pkg-portable.md
+++ b/docs/build-pkg-portable.md
@@ -1,0 +1,321 @@
+# `build-pkg-portable.py` — off-FreeBSD `.pkg` builder
+
+Build a pfSense-installable FreeBSD package (`.pkg`) for the pfBlockerNG port on
+**Linux or macOS, with no FreeBSD host and no ports framework**. It is the
+off-box counterpart to [`scripts/build-pkg.sh`](../scripts/build-pkg.sh), which
+runs the port's real `make package` on an ABI-matched FreeBSD VM.
+
+It exists because pfBlockerNG is a `NO_BUILD` port: nothing is compiled.
+"Building" the package is just (a) laying the production files out at their
+install paths, (b) applying the port's textual substitutions, and (c) emitting a
+libpkg-format archive with the right manifest. This tool does exactly that.
+
+**Dev-only.** Like the rest of `scripts/`, it is not shipped — release archives
+contain only `src/`.
+
+## Contents
+
+- [How it works](#how-it-works)
+- [Requirements](#requirements)
+- [Quick start](#quick-start)
+- [Options reference](#options-reference)
+- [The two port layouts](#the-two-port-layouts)
+- [Target facts (ABI / Python / PHP)](#target-facts-abi--python--php)
+- [Dependency resolution](#dependency-resolution)
+- [Fidelity vs `make package`](#fidelity-vs-make-package)
+- [Output format](#output-format)
+- [Exit status and output streams](#exit-status-and-output-streams)
+- [Examples](#examples)
+- [Troubleshooting](#troubleshooting)
+- [See also](#see-also)
+
+## How it works
+
+The tool reads the **same files the real `make package` reads** and replays the
+port's own build steps — it does **not** hardcode pfBlockerNG's current file list
+or dependencies, so it tracks changes to the port automatically:
+
+1. **Evaluate the port `Makefile`.** A small FreeBSD-ports variable evaluator
+   handles `=` / `?=` / `+=` / `:=`, line continuations, `#` comments,
+   `${VAR}`/`$(VAR)` expansion and a couple of `:modifiers`. Framework variables
+   the port relies on (`PREFIX`, `DATADIR`, `WRKSRC`, `FILESDIR`, the install
+   macros, the Python prefix, …) are seeded; `.include <bsd.port.mk>` is ignored.
+2. **Acquire the source** (USE_GITHUB ports): fetch the GitHub tarball for
+   `GH_TAGNAME`, or use a local checkout (`--local-src`). Classic ports install
+   from the port's embedded `files/` directory, so nothing is fetched.
+3. **Replay the recipe.** The tool interprets the port's `do-extract`,
+   `post-extract` and `do-install` targets with a small command vocabulary
+   (`MKDIR`, `INSTALL_DATA`, `INSTALL_SCRIPT`, `INSTALL_PROGRAM`, `MV`, `CP`,
+   `LN`, `RM`, `REINPLACE_CMD`/`SED`) into a controlled staging directory — the
+   same effect `make` would have, minus the shell. An **unknown recipe command
+   is a hard error** (a signal that the port changed in a way the tool must be
+   taught — rather than silently producing a broken package).
+4. **Validate against `pkg-plist`.** The staged file set must equal the plist's
+   file set (a mismatch aborts the build); the plist's `@dir` entries become the
+   manifest's directories.
+5. **Build the manifest and archive.** Emit `+COMPACT_MANIFEST` and `+MANIFEST`
+   (UCL/JSON) plus the payload, as a zstd- (or xz-) compressed tar — a real
+   libpkg `.pkg` that `pkg add` installs and registers on pfSense, running the
+   package's POST-INSTALL hook just like a port-built `.pkg`.
+
+## Requirements
+
+- **Python 3.11+** (standard library only — no third-party Python packages).
+- A **zstd encoder** for the default output compression: either the `zstd`
+  binary (`brew install zstd` / `apt install zstd`) or the Python `zstandard`
+  module. `--compression xz` uses the standard-library `lzma` and needs neither.
+- Network access only when fetching from GitHub (no `--local-src`) or when using
+  `--repo-catalogue` with a URL or `auto`.
+
+A clone of [`pfsense/FreeBSD-ports`](https://github.com/pfsense/FreeBSD-ports)
+(or the fork carrying the port under test) is required — passed via `--ports`.
+It supplies the port directory **and** the dependency ports used to resolve
+dependency names/origins.
+
+## Quick start
+
+```sh
+# from the pfBlockerNG repo root, building the working tree for pfSense CE 2.8
+python3 scripts/build-pkg-portable.py \
+    --ports ../FreeBSD-ports \
+    --local-src . \
+    --abi FreeBSD:15:amd64 \
+    --py-flavor py311 \
+    --php 8.3 \
+    --out /tmp
+# -> /tmp/pfSense-pkg-pfBlockerNG-devel-<version>.pkg
+```
+
+The built path is printed to stdout; progress goes to stderr. Add `--dry-run` to
+print the build plan (files, modes, dependencies) without writing an archive.
+
+## Options reference
+
+### Required
+
+| Option | Description |
+| --- | --- |
+| `--ports PATH` | FreeBSD-ports checkout. Must contain `net/pfSense-pkg-pfBlockerNG[-devel]` and the dependency ports (e.g. `textproc/jq`, `lang/php83`) used to resolve dependency names. |
+
+### Port selection
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `--channel devel\|stable` | `devel` | Which port to build: `devel` → `net/pfSense-pkg-pfBlockerNG-devel`, `stable` → `net/pfSense-pkg-pfBlockerNG`. |
+| `--port-dir PATH` | — | Build an explicit port directory instead, overriding `--channel`. |
+
+### Target facts (version-dependent; asked if omitted)
+
+These describe the **target pfSense edition/version**, not the ports checkout.
+They are never inferred from the ports tree (see
+[Target facts](#target-facts-abi--python--php)). If omitted and the terminal is
+interactive, the tool prompts; otherwise it exits with an error naming the flag.
+
+| Option | Example | Description |
+| --- | --- | --- |
+| `--abi ABI` | `FreeBSD:15:amd64` | The package ABI. CE 2.8 = `FreeBSD:15:amd64`; Plus = `FreeBSD:16:amd64`. Sets the manifest `abi`. |
+| `--arch TRIPLET` | `freebsd:15:x86:64` | The manifest `arch` triplet. Default: derived from `--abi` (`amd64` → `x86:64`, etc.). |
+| `--py-flavor FLAVOR` | `py311` | The Python flavor used in dependency names (`py311-sqlite3`, …) and the `python<XY>` dep. |
+| `--php VERSION` | `8.3` | The PHP version for the `USES=php` dependency (`php83`, `php83-intl`). Asked **only** when the port uses PHP. |
+| `--freebsd-version N` | `1500068` | The build host's `__FreeBSD_version`, written to the manifest `annotations` block. Optional; the block is omitted if unset. |
+
+### Source (USE_GITHUB ports)
+
+| Option | Description |
+| --- | --- |
+| `--local-src PATH` | Build from a local pfBlockerNG checkout (its `src/` tree) instead of fetching the GitHub tag. Fast for iterating on code under test. The working tree is never modified (it is copied into the staging area first). |
+| `--gh-tagname REF` | Override `GH_TAGNAME` — fetch this commit SHA, tag, or branch from GitHub. Default: the Makefile's `v${PORTVERSION}`. The ref must contain a `src/` tree (see [Troubleshooting](#troubleshooting)). |
+
+### Dependency versions
+
+| Option | Description |
+| --- | --- |
+| `--repo-catalogue SRC` | Pin exact dependency versions from a binary-repo `packagesite`. `SRC` may be a path or URL to a `packagesite.yaml` or `packagesite.pkg`/`.txz`, or the literal `auto` to fetch FreeBSD.org's catalogue for `--abi`. Without it, versions are best-effort from the ports tree. See [Dependency resolution](#dependency-resolution). |
+
+### Output
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `--out DIR` | `.` | Directory to write `<pkgname>.pkg` into (created if needed). |
+| `--compression zstd\|xz` | `zstd` | Archive compression. `zstd` is the native pkg format; `xz` uses the Python standard library (no external encoder). `pkg add` accepts either regardless of the `.pkg` extension. |
+| `--keep-work` | off | Keep the temporary work/staging directory (printed on exit) for inspection. |
+| `--dry-run` | off | Print the build plan (metadata, dependency list, file count and sample modes) and exit without writing a `.pkg`. |
+
+## The two port layouts
+
+pfBlockerNG's port has existed in two shapes; the tool detects which from the
+`Makefile` and handles both:
+
+| Layout | Branch | Source of files | Build source |
+| --- | --- | --- | --- |
+| `USE_GITHUB` | `pfblockerng/use-github` | fetched from GitHub (`GH_ACCOUNT`/`GH_PROJECT`/`GH_TAGNAME`), `WRKSRC = <project>-<ver>/src` | the fetched tag, or `--local-src` |
+| classic | `devel` (pre-`src/` move) | embedded in the port's `files/` directory (`${FILESDIR}`) | the ports checkout itself |
+
+For the `USE_GITHUB` layout, `--local-src` substitutes a local checkout for the
+GitHub fetch — useful to package code under test without cutting a tag.
+`--local-src` does not apply to the classic layout (its source is the embedded
+`files/`).
+
+## Target facts (ABI / Python / PHP)
+
+The ABI, Python flavor and PHP version are properties of the **target pfSense
+release**, not of the ports checkout. They are taken from the command line (or
+asked for) and are **never** read from the ports tree's
+`Mk/bsd.default-versions.mk`, because that is a single snapshot whose defaults
+can differ from what a given pfSense release actually ships — e.g. the fork tree
+may default to `PHP_DEFAULT=8.4` while pfSense CE 2.8 ships PHP 8.3, and
+`build-pkg.sh` pins `php=8.3` for exactly that reason.
+
+The per-version facts (FreeBSD major / PHP / Python for each pfSense edition) are
+recorded in [`misc/pfSense_versions.md`](misc/pfSense_versions.md). Pass the
+values for the edition you are targeting.
+
+## Dependency resolution
+
+The manifest's dependencies are what `make package` records, in two parts:
+
+1. **Declared dependencies** — the port's `RUN_DEPENDS` and `LIB_DEPENDS`. Each
+   `target:origin[@flavor]` entry is resolved to a package **name** and
+   **origin**:
+   - A name-form left side (`py311-sqlite3>0`) yields the name directly.
+   - A file-form left side (`${LOCALBASE}/bin/ggrep`) is resolved against the
+     dependency port's `Makefile` in the ports tree
+     (`PKGNAMEPREFIX` + `PORTNAME` + `PKGNAMESUFFIX`) — e.g.
+     `textproc/gnugrep` → `gnugrep`, not `grep`.
+   - **Flavors** are honoured: the dependency spec's `@flavor` (or the port's
+     default `FLAVORS:[1]`) selects the flavored name — `net/rsync` default →
+     `rsync`, `net/rsync@python` → `rsync-python`.
+2. **`USES`-injected dependencies** — those the ports framework adds and the
+   built package records even though they are not in `RUN_DEPENDS`:
+   - `USES=python` → `python<XY>` (`lang/python<XY>`).
+   - `USES=php` with `USE_PHP=<ext> …` → `php<XY>` (`lang/php<XY>`) and one
+     `php<XY>-<ext>` per extension (origin found by globbing the ports tree,
+     e.g. `devel/php83-intl`).
+
+### Dependency versions
+
+The version `make package` records for a dependency is the version of the
+**installed binary package** on the build host — which tracks the build host's
+repo, not the ports tree (the tree may even be behind, e.g. `rsync 3.4.1_6` in
+the tree vs `3.4.3` installed). Therefore:
+
+- **Names and origins are always exact** (derived from the port files).
+- **Versions are best-effort** from the ports tree by default (correct for most
+  ports, including the `PORTREVISION`, e.g. `grepcidr 2.0_1`).
+- For **exact** versions, pass `--repo-catalogue` — the tool reads each
+  dependency's version (and origin) from the repo `packagesite`, the same source
+  `pkg` installs from. `auto` fetches FreeBSD.org's catalogue for `--abi`.
+
+Note that `pkg add` checks that a dependency is **present**, not its exact
+version, so dependency versions do not affect installability — they affect
+manifest fidelity only.
+
+## Fidelity vs `make package`
+
+The output has been diffed field-by-field against a real `make package` build
+(on a FreeBSD CI VM) for the **same commit**. Everything derivable from the port
+files matches exactly:
+
+- scalar metadata: `name`, `origin`, `version`, `comment`, `maintainer`, `www`,
+  `abi`, `arch`, `prefix`, `flatsize`, `licenselogic`, `licenses`, `categories`,
+  `desc`, `annotations`;
+- every payload file: path, `sha256` checksum, and **permissions**
+  (`INSTALL_DATA` → `0644`, `INSTALL_SCRIPT`/`INSTALL_PROGRAM` → `0555` — FreeBSD
+  `BINMODE`);
+- `directories`; the `install` and `deinstall` scripts (byte-identical, with the
+  trailing newline stripped as `pkg create` does);
+- the full dependency set: **names and origins**.
+
+Two values are **not derivable from the port files** and so will not match a
+specific past build:
+
+1. **File `mtime`** — the install clock. It differs between any two real builds;
+   the tool records `0`.
+2. **A few dependency versions** — read from the build host's installed binary
+   packages (see [above](#dependency-versions)). `--repo-catalogue` pins them.
+
+## Output format
+
+A `.pkg` is a compressed tar archive (zstd by default; `pkg add` sniffs the
+format regardless of extension). Member order matters and is reproduced exactly:
+
+```text
++COMPACT_MANIFEST     # UCL/JSON: metadata only (no files/dirs/scripts)
++MANIFEST             # UCL/JSON: full manifest
+/etc/inc/priv/...     # payload files, at absolute paths, root:wheel
+/usr/local/pkg/...
+...
+```
+
+File entries carry `sum` (`1$<sha256hex>`), `uname`/`gname` (`root`/`wheel`),
+`perm`, `fflags` and `mtime`; directories carry `uname`/`gname`/`perm`/`fflags`.
+The output filename is `<PORTNAME>-<PKGVERSION>.pkg`, where `PKGVERSION` is
+`PORTVERSION[_PORTREVISION][,PORTEPOCH]`.
+
+## Exit status and output streams
+
+- **stdout**: on success, the absolute path of the written `.pkg` (nothing else),
+  so it is safe to capture in a script (`PKG=$(build-pkg-portable.py …)`). With
+  `--dry-run`, stdout carries the plan instead.
+- **stderr**: progress (`==> …`) and warnings.
+- **exit code**: `0` on success; `1` on a build error (with a
+  `build-pkg-portable: <reason>` message on stderr); `2` on bad command-line
+  arguments.
+
+## Examples
+
+```sh
+# 1) Build the local working tree for CE 2.8 (devel channel), into /tmp.
+python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports --local-src . \
+    --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --out /tmp
+
+# 2) Build the stable channel from the FreeBSD-ports embedded files (classic
+#    layout — no --local-src needed; the ports tree carries the code).
+python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports --channel stable \
+    --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3
+
+# 3) Build a specific commit (must have a src/ tree) and pin exact dep versions
+#    from FreeBSD.org's repo for the ABI.
+python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports \
+    --gh-tagname 3b4b27eb18c12a371d0b80366b8d3f20d201d1d1 \
+    --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --repo-catalogue auto
+
+# 4) Target pfSense Plus (FreeBSD 16), xz compression, keep the work dir.
+python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports --local-src . \
+    --abi FreeBSD:16:amd64 --py-flavor py311 --php 8.3 \
+    --compression xz --keep-work
+
+# 5) Just inspect the plan.
+python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports --local-src . \
+    --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --dry-run
+```
+
+## Troubleshooting
+
+- **`fetched tarball has no src/ dir under <project>-<ref>`** — the fetched ref
+  predates the `src/` reorganization (e.g. the `v3.2.x` release tags). Fetch a
+  ref that has `src/` (`--gh-tagname <branch-or-commit>`) or build from a working
+  tree with `--local-src`.
+- **`plist lists files the recipe did not stage` / `recipe staged files not in
+  the plist`** — the port's `pkg-plist` and `do-install` disagree (drift). Fix
+  the port so the two match; the tool deliberately refuses to guess.
+- **`unsupported recipe command ${X}`** — the port's recipe uses a command the
+  interpreter does not model yet. Add a handler for it (`_cmd_<x>`); do not work
+  around it, so the staging stays faithful.
+- **`--abi`/`--py-flavor`/`--php not provided`** in a non-interactive context —
+  pass the flag; see [`misc/pfSense_versions.md`](misc/pfSense_versions.md) for
+  the right value per target.
+- **`repo catalogue is zstd; install zstd …`** — a `packagesite.pkg` is
+  zstd-compressed; install the `zstd` binary or the Python `zstandard` module, or
+  point `--repo-catalogue` at a plain `packagesite.yaml`.
+
+## See also
+
+- [`scripts/build-pkg.sh`](../scripts/build-pkg.sh) — the on-FreeBSD builder
+  (real `make package`), used by CI.
+- [`scripts/README.md`](../scripts/README.md) — overview of the dev scripts and
+  the two install paths (rsync overlay vs `.pkg`).
+- [`misc/pfSense_versions.md`](misc/pfSense_versions.md) — per-version base facts
+  (FreeBSD major, PHP, Python) and the runtime dependencies.
+- `tests/test_build_pkg_portable.py` — unit tests for the evaluator, recipe
+  interpreter, dependency resolution, and archive emission.

--- a/docs/misc/pfSense_versions.md
+++ b/docs/misc/pfSense_versions.md
@@ -32,10 +32,19 @@ smoke image **bakes** them so the harness `pkg add` of the branch `.pkg` resolve
 them from the local pkg db **offline** (see `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`
 §3). A missing dep → `pkg add` "Missing dependency" → bad image, re-bake.
 
-Exactly the port's `RUN_DEPENDS` (9 packages), verified against
+These are the port's explicit `RUN_DEPENDS` (9 packages), verified against
 `net/pfSense-pkg-pfBlockerNG-devel/Makefile`. To bake them onto an image, run
 [`scripts/misc/install_deps_CE_2.8.sh`](../../scripts/misc/install_deps_CE_2.8.sh)
 on the box (as root):
+
+> **The built `.pkg` records 12 dependencies, not 9.** Besides these 9,
+> `make package` records the three that `USES=php` (`USE_PHP=intl`) and
+> `USES=python` inject: `php83` (`lang/php83`), `php83-intl` (`devel/php83-intl`)
+> and `python311` (`lang/python311`) on 2.8.x. They are *not* literal
+> `RUN_DEPENDS`, but they are real package dependencies (confirmed by diffing a
+> real `make package` artifact). pfSense already ships PHP/Python, so they need no
+> extra baking — but the table below is the **explicit run-deps**, not the package's
+> full dependency set.
 
 | Package (origin) | Binary probed | Purpose |
 | --- | --- | --- |
@@ -57,5 +66,7 @@ Notes:
 - **`rsync` IS a hard run-dep** (not merely a deploy transport): the port declares
   `net/rsync` and pfBlockerNG shells out to it for rsync-format feeds. It must be
   baked like the rest.
-- Base components pfBlockerNG also uses (PHP, Unbound, the Python interpreter)
-  ship with pfSense itself and are not in `RUN_DEPENDS`.
+- **PHP and the Python interpreter ship with pfSense and are not in `RUN_DEPENDS`**,
+  but the built `.pkg` still depends on `php83` + `php83-intl` + `python311`
+  because `USES=php`/`USES=python` inject them (see the note above). Unbound is a
+  base component and is not a package dependency at all.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -74,6 +74,9 @@ Needs only python3 (stdlib) + a zstd encoder (`zstd` / `brew install zstd` /
 `apt install zstd`); `--compression xz` needs neither. `--dry-run` prints the
 plan (files, modes, deps) without writing the archive.
 
+Full reference (every option, the fidelity comparison, troubleshooting):
+[`../docs/build-pkg-portable.md`](../docs/build-pkg-portable.md).
+
 ## Image pipeline (ADR-04 smoke base)
 
 The CI smoke harness — see [`../.ADRs/ADR_04_VM_Smoke_Tests/`](../.ADRs/ADR_04_VM_Smoke_Tests/) —

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,62 @@ none of this ships in the release archive (which contains only `src/`).
 It is **all local: no internet, no Netgate pkg**, so it works even with egress blocked
 (and is also handy for installing onto a local dev VM).
 
+## Build the `.pkg`
+
+Two ways to produce the installable FreeBSD package:
+
+| Script | Runs on | How |
+| --- | --- | --- |
+| [`build-pkg.sh`](build-pkg.sh) | a FreeBSD VM (ABI-matched) | the port's real `make package` (pins `GH_TAGNAME` to the commit under test). |
+| [`build-pkg-portable.py`](build-pkg-portable.py) | **Linux or macOS** (no FreeBSD) | reads the port files and emits the libpkg archive directly. |
+
+`build-pkg-portable.py` exploits the fact that pfBlockerNG is a `NO_BUILD` port:
+it executes the port's own `do-extract`/`post-extract`/`do-install` recipe and
+reads its `pkg-plist` — so it tracks new files and dependency changes
+automatically, rather than hardcoding pfBlockerNG's current layout — then writes
+a real `.pkg` (zstd tar: `+COMPACT_MANIFEST` + `+MANIFEST` + payload). It handles
+**both** ports layouts: `USE_GITHUB` (branch `pfblockerng/use-github`, source
+fetched from GitHub) and the classic embedded-`files/` layout (branch `devel`).
+
+Its output was **diffed field-by-field against a real `make package` build** (CI,
+FreeBSD VM) for the same commit: metadata, file set + checksums + perms
+(`INSTALL_DATA` `0644`, `INSTALL_SCRIPT` `0555`), directories, the `install`/
+`deinstall` scripts, and the **dependency set** all match exactly. Deps are the
+9 `RUN_DEPENDS`/`LIB_DEPENDS` **plus** the ones `USES` injects, which `make
+package` also records: `USES=python` → `python<XY>`, `USES=php`+`USE_PHP=intl` →
+`php<XY>` + `php<XY>-intl` (12 total). Flavored ports are resolved from the dep
+spec (`net/rsync` default → `rsync`, `@python` → `rsync-python`).
+
+Two things are **not** derivable from the port files and so are *not* expected to
+match a specific build: file `mtime` (the install clock — even two real builds
+differ), and a few dep **versions** that `make package` reads from the build
+host's *installed binary packages* (e.g. `rsync 3.4.3` from the repo vs `3.4.1_6`
+in the ports tree). Dep **names/origins** are always exact; for exact **versions**
+pass `--repo-catalogue` — a path/URL to a repo `packagesite.yaml`/`.pkg`, or
+`auto` to fetch FreeBSD.org's catalogue for the ABI (the same source `pkg`
+installs from). Without it, versions are best-effort from the ports tree.
+
+Version-dependent **target** facts are never guessed from the ports tree (a
+single, possibly-mismatched snapshot — e.g. its `PHP_DEFAULT=8.4` need not match
+the target's PHP): the ABI, Python flavor and PHP version are passed in, or asked
+for if omitted — see
+[`../docs/misc/pfSense_versions.md`](../docs/misc/pfSense_versions.md).
+`--freebsd-version` sets the `annotations` block.
+
+```sh
+# build from a local working tree (fast dev iteration), targeting CE 2.8
+python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports \
+    --local-src . --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --out /tmp
+
+# or build exactly what the port fetches (a commit/tag with a src/ tree), targeting Plus
+python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports \
+    --gh-tagname <commit> --abi FreeBSD:16:amd64 --py-flavor py311 --php 8.3
+```
+
+Needs only python3 (stdlib) + a zstd encoder (`zstd` / `brew install zstd` /
+`apt install zstd`); `--compression xz` needs neither. `--dry-run` prints the
+plan (files, modes, deps) without writing the archive.
+
 ## Image pipeline (ADR-04 smoke base)
 
 The CI smoke harness — see [`../.ADRs/ADR_04_VM_Smoke_Tests/`](../.ADRs/ADR_04_VM_Smoke_Tests/) —

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -527,8 +527,10 @@ def parse_plist(text: str, plist_sub: dict[str, str], prefix: str) -> tuple[list
     """Return (file install paths absolute, directory paths absolute) from a plist.
 
     Entries are PREFIX-relative unless they start with '/'. %%TOKEN%% are PLIST_SUB
-    substitutions; @dir gives an explicit owned directory; other @keywords we skip
-    with a warning (none are used by the pfSense pkg ports today).
+    substitutions; @dir gives an explicit owned directory. An unknown @keyword
+    (@mode, @sample, @owner, …) aborts the build — like an unknown recipe command,
+    silently dropping it would emit a subtly wrong package instead of forcing the
+    tool to be taught the keyword.
     """
     files: list[str] = []
     dirs: list[str] = []
@@ -544,10 +546,10 @@ def parse_plist(text: str, plist_sub: dict[str, str], prefix: str) -> tuple[list
             arg = arg.strip()
             if kw == "dir":
                 dirs.append(_abspath(arg, prefix))
-            elif kw in ("comment",):
+            elif kw == "comment":
                 continue
             else:
-                sys.stderr.write(f"warning: ignoring unhandled plist keyword @{kw} {arg}\n")
+                raise BuildError(f"unsupported pkg-plist keyword @{kw} (teach the tool to handle it): {raw!r}")
             continue
         files.append(_abspath(line, prefix))
     return files, dirs
@@ -855,12 +857,14 @@ def _urlopen(url: str):
 
 
 def _safe_extract(tf: tarfile.TarFile, dest: Path) -> None:
-    base = dest.resolve()
-    for m in tf.getmembers():
-        target = (dest / m.name).resolve()
-        if not str(target).startswith(str(base)):
-            raise BuildError(f"unsafe path in tarball: {m.name}")
-    tf.extractall(dest)
+    # Use the stdlib 'data' filter (PEP 706, Python 3.11.4+): it rejects absolute
+    # paths, parent-dir traversal, AND symlinks/hardlinks that escape dest — the
+    # link-based escapes a manual path-prefix check (str.startswith) silently lets
+    # through.
+    try:
+        tf.extractall(dest, filter="data")
+    except tarfile.FilterError as e:
+        raise BuildError(f"unsafe member in fetched tarball: {e}") from None
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -394,8 +394,8 @@ class Recipe:
         return paths[:-1], paths[-1]
 
     def _cmd_ln(self, args: list[str]) -> None:
-        args = [a for a in args if not a.startswith("-")]
-        target, link = args[-2], args[-1]
+        srcs, link = self._copy_args(args)  # validates: raises on too few paths
+        target = srcs[-1]
         Path(link).parent.mkdir(parents=True, exist_ok=True)
         if Path(link).exists() or Path(link).is_symlink():
             Path(link).unlink()
@@ -766,11 +766,21 @@ def _catalogue_text(raw: bytes, source: str) -> str:
         return raw.decode("utf-8", "replace")
     tar_bytes = _decompress(raw)
     with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
-        member = "packagesite.yaml"
+        # extractfile() returns None for a non-regular member (dir/symlink) and
+        # raises KeyError for a missing name — fall back to the first regular file.
         try:
-            data = tf.extractfile(member).read()
+            fobj = tf.extractfile("packagesite.yaml")
         except KeyError:
-            data = tf.extractfile(tf.getmembers()[0]).read()
+            fobj = None
+        if fobj is None:
+            for m in tf.getmembers():
+                if m.isfile():
+                    fobj = tf.extractfile(m)
+                    if fobj is not None:
+                        break
+        if fobj is None:
+            raise BuildError("no readable packagesite file in the repo catalogue archive")
+        data = fobj.read()
     return data.decode("utf-8", "replace")
 
 

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1,0 +1,1321 @@
+#!/usr/bin/env python3
+# build-pkg-portable.py — build a pfSense-installable FreeBSD .pkg for the
+# pfBlockerNG port WITHOUT a FreeBSD host or the ports framework.
+#
+# pfBlockerNG is a NO_BUILD port: nothing is compiled. "Building" the package is
+# just (a) laying the production files out at their install paths, (b) doing the
+# port's textual substitutions, and (c) emitting a libpkg-format archive with the
+# right manifest. This tool replicates exactly that, portably (Linux + macOS),
+# by *executing the port's own do-extract/post-extract/do-install recipe* and
+# *reading its pkg-plist* — never a hardcoded, pfBlockerNG-specific file list. So
+# when the port gains files or changes dependencies, this tool keeps up: it reads
+# the same Makefile/plist the real `make package` reads.
+#
+# It supports BOTH port layouts:
+#   * USE_GITHUB  (FreeBSD-ports branch pfblockerng/use-github): source fetched
+#     from GitHub into ${WRKSRC} (= <project>-<ver>/src); do-install copies thence.
+#   * classic     (FreeBSD-ports branch devel, pre-src/ move): source embedded in
+#     the port's files/ dir (${FILESDIR}); do-install copies thence.
+# It picks the right one from the Makefile (USE_GITHUB present or not). For the
+# USE_GITHUB variant you can pass --local-src to build from a local pfBlockerNG
+# working tree instead of fetching the GitHub tag — handy for iterating on code
+# under test, the way scripts/build-pkg.sh pins GH_TAGNAME on a FreeBSD VM.
+#
+# The result is a real libpkg archive: zstd-compressed tar with +COMPACT_MANIFEST
+# and +MANIFEST first, then payload files at their absolute paths. `pkg add` on
+# pfSense registers it and runs the POST-INSTALL hook (rc.packages), same as a
+# port-built .pkg. Dependencies are recorded from RUN_DEPENDS/LIB_DEPENDS so
+# `pkg add` resolves them from the local pkg db (pre-baked on the smoke image).
+#
+# Requires: python3 (stdlib only) + a zstd encoder (the `zstd` binary, or the
+# python `zstandard` module). `--compression xz` needs neither (stdlib lzma).
+#
+# This is a developer tool (not shipped in release archives). See --help.
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Small FreeBSD-ports Makefile evaluator
+#
+# Just enough of bsd.port.mk's variable semantics to read a pfSense pkg port:
+# =/?=/+=/:= assignments, line continuations, # comments, ${VAR}/$(VAR) and a
+# couple of :modifiers. .include lines are ignored — we seed the framework
+# variables the port relies on (PREFIX, DATADIR, PYTHON_*, install macros, …).
+# Target recipes (do-install, post-extract, …) are captured verbatim, joined on
+# backslash-continuation, and run later by the recipe interpreter.
+# --------------------------------------------------------------------------- #
+
+
+class Makefile:
+    _ASSIGN = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*(\?=|\+=|:=|=)\s*(.*)$")
+
+    def __init__(self, path: Path, seed: dict[str, str]):
+        self.vars: dict[str, str] = dict(seed)
+        # Assignment order matters for ?= (only set if unset). Keep raw values;
+        # expand lazily so later-defined vars are visible (ports are order-tolerant
+        # for our reads because we expand at access time).
+        self.recipes: dict[str, list[str]] = {}
+        self._raw: dict[str, tuple[str, str]] = {}  # name -> (op, value) last write
+        self._parse(path)
+
+    def _parse(self, path: Path) -> None:
+        lines = path.read_text().splitlines()
+        # Join backslash continuations into logical lines, but keep recipe lines
+        # (TAB-indented) separate from assignments.
+        i = 0
+        cur_target: str | None = None
+        logical: list[tuple[bool, str]] = []  # (is_recipe, text)
+        while i < len(lines):
+            raw = lines[i]
+            # Recipe line: starts with a literal TAB.
+            is_recipe = raw.startswith("\t")
+            text = raw
+            # Gather continuations.
+            while text.rstrip().endswith("\\"):
+                text = text.rstrip()[:-1]
+                i += 1
+                if i < len(lines):
+                    text += " " + lines[i].strip() if not is_recipe else " " + lines[i].lstrip("\t")
+            logical.append((is_recipe, text))
+            i += 1
+
+        for is_recipe, text in logical:
+            if is_recipe:
+                if cur_target is not None:
+                    body = text[1:] if text.startswith("\t") else text
+                    if body.strip():
+                        self.recipes.setdefault(cur_target, []).append(body)
+                continue
+            stripped = text.strip()
+            if not stripped or stripped.startswith("#"):
+                cur_target = None
+                continue
+            if stripped.startswith(".include") or stripped.startswith("."):
+                cur_target = None
+                continue
+            # Target header:  name:  (possibly with deps after the colon)
+            m_t = re.match(r"^([A-Za-z0-9_\-./]+):(?!=)\s*(.*)$", stripped)
+            m_a = self._ASSIGN.match(stripped)
+            if m_a:
+                cur_target = None
+                name, op, val = m_a.group(1), m_a.group(2), m_a.group(3)
+                val = self._strip_comment(val).strip()
+                self._assign(name, op, val)
+            elif m_t:
+                cur_target = m_t.group(1)
+                self.recipes.setdefault(cur_target, [])
+            else:
+                cur_target = None
+
+    @staticmethod
+    def _strip_comment(val: str) -> str:
+        # Strip an unescaped trailing # comment (e.g. `DISTFILES= # empty`).
+        out = []
+        prev = ""
+        for ch in val:
+            if ch == "#" and prev != "\\":
+                break
+            out.append(ch)
+            prev = ch
+        return "".join(out)
+
+    def _assign(self, name: str, op: str, val: str) -> None:
+        if op == "?=":
+            if name not in self._raw and name not in self.vars:
+                self._raw[name] = ("=", val)
+        elif op == "+=":
+            old = self._raw.get(name, ("=", self.vars.get(name, "")))[1]
+            self._raw[name] = ("=", (old + " " + val).strip())
+        else:  # = or :=
+            self._raw[name] = ("=", val)
+
+    def _lookup(self, name: str) -> str | None:
+        if name in self._raw:
+            return self._raw[name][1]
+        return self.vars.get(name)
+
+    def expand(self, s: str, _depth: int = 0) -> str:
+        if _depth > 40 or "$" not in s:
+            return s
+        out = []
+        i = 0
+        while i < len(s):
+            ch = s[i]
+            if ch == "$" and i + 1 < len(s) and s[i + 1] in "{(":
+                close = "}" if s[i + 1] == "{" else ")"
+                depth = 1
+                j = i + 2
+                while j < len(s) and depth:
+                    if s[j] == s[i + 1]:
+                        depth += 1
+                    elif s[j] == close:
+                        depth -= 1
+                    if depth:
+                        j += 1
+                inner = s[i + 2 : j]
+                out.append(self._expand_ref(inner, _depth))
+                i = j + 1
+            else:
+                out.append(ch)
+                i += 1
+        return "".join(out)
+
+    def _expand_ref(self, inner: str, depth: int) -> str:
+        # Support  NAME  and  NAME:modifier...  (only the modifiers ports here use).
+        inner = self.expand(inner, depth + 1)
+        if ":" in inner:
+            name, _, mods = inner.partition(":")
+            val = self._lookup(name)
+            val = self.expand(val, depth + 1) if val is not None else ""
+            return self._apply_mods(val, mods)
+        val = self._lookup(inner)
+        if val is None:
+            return ""
+        return self.expand(val, depth + 1)
+
+    @staticmethod
+    def _apply_mods(val: str, mods: str) -> str:
+        # Minimal :H (dirname), :T (basename), :R (root), :E (ext). Enough for the
+        # recipes we run; extend if a port starts using more.
+        for mod in mods.split(":"):
+            if mod == "H":
+                val = os.path.dirname(val)
+            elif mod == "T":
+                val = os.path.basename(val)
+            elif mod == "R":
+                val = os.path.splitext(val)[0]
+            elif mod == "E":
+                val = os.path.splitext(val)[1].lstrip(".")
+        return val
+
+    def get(self, name: str, default: str = "") -> str:
+        v = self._lookup(name)
+        return self.expand(v) if v is not None else default
+
+    def has(self, name: str) -> bool:
+        return self._lookup(name) is not None
+
+
+# --------------------------------------------------------------------------- #
+# Data model
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Dep:
+    name: str
+    origin: str
+    version: str
+
+
+@dataclass
+class StagedFile:
+    install_path: str  # absolute, e.g. /usr/local/pkg/pfblockerng/pfblockerng.inc
+    src_in_stage: Path  # actual file under STAGEDIR
+    perm: str  # "0644" (INSTALL_DATA) / "0555" (INSTALL_SCRIPT)
+
+
+@dataclass
+class Build:
+    portname: str
+    pkgversion: str
+    origin: str
+    comment: str
+    maintainer: str
+    categories: list[str]
+    licenses: list[str]
+    www: str
+    desc: str
+    prefix: str
+    abi: str
+    arch: str
+    deps: list[Dep] = field(default_factory=list)
+    files: list[StagedFile] = field(default_factory=list)
+    directories: list[str] = field(default_factory=list)
+    scripts: dict[str, str] = field(default_factory=dict)
+    annotations: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def pkgname(self) -> str:
+        return f"{self.portname}-{self.pkgversion}"
+
+
+# --------------------------------------------------------------------------- #
+# Recipe interpreter
+#
+# Runs the port's do-extract/post-extract/do-install recipe with a tiny command
+# vocabulary. Every command maps to a real filesystem effect into a controlled
+# WRKDIR/STAGEDIR — exactly what `make` would do, minus the shell. An unknown
+# command is a hard error (rather than a silently broken package): that is the
+# signal that the port changed in a way the tool must be taught.
+# --------------------------------------------------------------------------- #
+
+
+class Recipe:
+    SED_S = re.compile(r"^s(.)(.*)$")
+
+    def __init__(self, mk: Makefile):
+        self.mk = mk
+        # Record (install_path -> perm) as INSTALL_DATA/INSTALL_SCRIPT run, so the
+        # manifest knows each file's mode (the plist does not encode it).
+        self.modes: dict[str, str] = {}
+        self.stagedir = Path(mk.get("STAGEDIR"))
+
+    def run(self, target: str) -> None:
+        for line in self.mk.recipes.get(target, []):
+            self._exec(line)
+
+    def _exec(self, line: str) -> None:
+        line = line.strip()
+        while line[:1] in ("@", "-"):
+            line = line[1:].lstrip()
+        if not line:
+            return
+        # A recipe command is either a ${MACRO} (e.g. ${INSTALL_DATA}) or a bare
+        # command word (e.g. post-extract's literal `mv`). Both map to _cmd_<name>.
+        m = re.match(r"^\$[{(]([A-Za-z_][A-Za-z0-9_]*)[})]\s*(.*)$", line)
+        if m:
+            cmd, rest = m.group(1), m.group(2)
+        else:
+            parts = line.split(None, 1)
+            cmd = parts[0]
+            rest = parts[1] if len(parts) > 1 else ""
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", cmd):
+                raise BuildError(f"recipe line is neither a ${{MACRO}} nor a bare command: {line!r}")
+        rest = self.mk.expand(rest)
+        args = shlex.split(rest)
+        handler = getattr(self, f"_cmd_{cmd.lower()}", None)
+        if handler is None:
+            raise BuildError(
+                f"unsupported recipe command ${{{cmd}}} — teach build-pkg-portable.py this command (line: {line!r})"
+            )
+        handler(args)
+
+    # --- commands ---------------------------------------------------------- #
+
+    def _cmd_mkdir(self, args: list[str]) -> None:
+        for a in args:
+            if a == "-p":
+                continue
+            Path(a).mkdir(parents=True, exist_ok=True)
+
+    def _install(self, args: list[str], default_perm: str) -> None:
+        perm = default_perm
+        i = 0
+        positional: list[str] = []
+        while i < len(args):
+            a = args[i]
+            if a == "-m":
+                perm = self._normperm(args[i + 1])
+                i += 2
+                continue
+            if a in ("-o", "-g"):  # owner/group flags: irrelevant, files go in as root
+                i += 2
+                continue
+            if a.startswith("-"):
+                i += 1
+                continue
+            positional.append(a)
+            i += 1
+        if len(positional) < 2:
+            raise BuildError(f"INSTALL with too few paths: {args!r}")
+        dest = positional[-1]
+        srcs = positional[:-1]
+        dest_p = Path(dest)
+        dest_is_dir = dest_p.is_dir() or dest.endswith("/") or len(srcs) > 1
+        for s in srcs:
+            sp = Path(s)
+            if not sp.exists():
+                raise BuildError(f"install source missing: {s}")
+            target = dest_p / sp.name if dest_is_dir else dest_p
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(sp, target)
+            os.chmod(target, int(perm, 8))
+            self.modes[self._install_path(target)] = perm
+
+    def _cmd_install_data(self, args: list[str]) -> None:
+        self._install(args, "0644")
+
+    def _cmd_install_script(self, args: list[str]) -> None:
+        # INSTALL_SCRIPT installs with ${BINMODE}, which is 0555 on FreeBSD
+        # (installed scripts/binaries are not writable) — NOT 0755.
+        self._install(args, "0555")
+
+    def _cmd_install_lib(self, args: list[str]) -> None:
+        self._install(args, "0644")
+
+    def _cmd_install_man(self, args: list[str]) -> None:
+        self._install(args, "0644")
+
+    def _cmd_mv(self, args: list[str]) -> None:
+        args = [a for a in args if not a.startswith("-")]
+        *srcs, dest = args
+        for s in srcs:
+            shutil.move(s, dest)
+
+    def _cmd_cp(self, args: list[str]) -> None:
+        args = [a for a in args if not a.startswith("-")]
+        *srcs, dest = args
+        dest_p = Path(dest)
+        for s in srcs:
+            if Path(s).is_dir():
+                shutil.copytree(s, dest_p / Path(s).name, dirs_exist_ok=True)
+            else:
+                (dest_p if dest_p.is_dir() else dest_p.parent).mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(s, dest_p / Path(s).name if dest_p.is_dir() else dest_p)
+
+    def _cmd_ln(self, args: list[str]) -> None:
+        args = [a for a in args if not a.startswith("-")]
+        target, link = args[-2], args[-1]
+        Path(link).parent.mkdir(parents=True, exist_ok=True)
+        if Path(link).exists() or Path(link).is_symlink():
+            Path(link).unlink()
+        os.symlink(target, link)
+
+    def _cmd_rm(self, args: list[str]) -> None:
+        for a in args:
+            if a.startswith("-"):
+                continue
+            p = Path(a)
+            if p.is_dir():
+                shutil.rmtree(p, ignore_errors=True)
+            elif p.exists():
+                p.unlink()
+
+    def _cmd_reinplace_cmd(self, args: list[str]) -> None:
+        self._sed_inplace(args)
+
+    def _cmd_sed(self, args: list[str]) -> None:
+        self._sed_inplace(args)
+
+    def _sed_inplace(self, args: list[str]) -> None:
+        # REINPLACE_CMD == `sed -i ''`. Parse: -i [suffix], -e EXPR (repeatable) or
+        # a bare leading EXPR, then file(s). Only the `s` command is implemented —
+        # which is all the pfSense pkg ports use (placeholder substitution).
+        exprs: list[str] = []
+        files: list[str] = []
+        i = 0
+        seen_expr = False
+        while i < len(args):
+            a = args[i]
+            if a == "-i":
+                # FreeBSD sed: -i takes a (possibly empty) backup suffix argument.
+                if i + 1 < len(args) and (args[i + 1] == "" or not args[i + 1].startswith("-")) and not seen_expr:
+                    # Treat next as the (empty) suffix only when it looks like one.
+                    if args[i + 1] == "":
+                        i += 2
+                        continue
+                i += 1
+                continue
+            if a == "-e":
+                exprs.append(args[i + 1])
+                seen_expr = True
+                i += 2
+                continue
+            if a.startswith("-"):
+                i += 1
+                continue
+            if not seen_expr and not exprs:
+                exprs.append(a)
+                seen_expr = True
+                i += 1
+                continue
+            files.append(a)
+            i += 1
+        for f in files:
+            self._apply_sed(Path(f), exprs)
+
+    def _apply_sed(self, path: Path, exprs: list[str]) -> None:
+        if not path.exists():
+            raise BuildError(f"sed target missing: {path}")
+        text = path.read_text()
+        for expr in exprs:
+            text = self._sed_s(text, expr)
+        path.write_text(text)
+
+    def _sed_s(self, text: str, expr: str) -> str:
+        m = self.SED_S.match(expr)
+        if not m:
+            raise BuildError(f"unsupported sed expression (only s/// is handled): {expr!r}")
+        delim = m.group(1)
+        body = m.group(2)
+        parts = _split_unescaped(body, delim)
+        if len(parts) < 2:
+            raise BuildError(f"malformed sed s expression: {expr!r}")
+        pattern, repl = parts[0], parts[1]
+        flags = parts[2] if len(parts) > 2 else ""
+        # The pfSense ports only substitute literal %%TOKEN%% placeholders, so a
+        # literal replace is faithful and avoids BRE/ERE ambiguity. 'g' => all.
+        if "g" in flags:
+            return text.replace(pattern, repl)
+        out = []
+        for ln in text.splitlines(keepends=True):
+            out.append(ln.replace(pattern, repl, 1))
+        return "".join(out)
+
+    # --- helpers ----------------------------------------------------------- #
+
+    def _install_path(self, staged: Path) -> str:
+        rel = os.path.relpath(staged, self.stagedir)
+        return "/" + rel
+
+    @staticmethod
+    def _normperm(p: str) -> str:
+        p = p.strip()
+        if not p.startswith("0"):
+            p = "0" + p
+        return p
+
+
+def _split_unescaped(s: str, delim: str) -> list[str]:
+    out, cur, esc = [], [], False
+    for ch in s:
+        if esc:
+            cur.append(ch)
+            esc = False
+        elif ch == "\\":
+            esc = True
+            cur.append(ch)
+        elif ch == delim:
+            out.append("".join(cur))
+            cur = []
+        else:
+            cur.append(ch)
+    out.append("".join(cur))
+    return out
+
+
+class BuildError(Exception):
+    pass
+
+
+# --------------------------------------------------------------------------- #
+# pkg-plist + pkg-descr parsing
+# --------------------------------------------------------------------------- #
+
+
+def parse_plist(text: str, plist_sub: dict[str, str], prefix: str) -> tuple[list[str], list[str]]:
+    """Return (file install paths absolute, directory paths absolute) from a plist.
+
+    Entries are PREFIX-relative unless they start with '/'. %%TOKEN%% are PLIST_SUB
+    substitutions; @dir gives an explicit owned directory; other @keywords we skip
+    with a warning (none are used by the pfSense pkg ports today).
+    """
+    files: list[str] = []
+    dirs: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        line = _sub_tokens(line, plist_sub)
+        if "%%" in line:
+            raise BuildError(f"unresolved %%token%% in pkg-plist: {raw!r}")
+        if line.startswith("@"):
+            kw, _, arg = line[1:].partition(" ")
+            arg = arg.strip()
+            if kw == "dir":
+                dirs.append(_abspath(arg, prefix))
+            elif kw in ("comment",):
+                continue
+            else:
+                sys.stderr.write(f"warning: ignoring unhandled plist keyword @{kw} {arg}\n")
+            continue
+        files.append(_abspath(line, prefix))
+    return files, dirs
+
+
+def _abspath(p: str, prefix: str) -> str:
+    if p.startswith("/"):
+        return os.path.normpath(p)
+    return os.path.normpath(prefix.rstrip("/") + "/" + p)
+
+
+def _sub_tokens(s: str, sub: dict[str, str]) -> str:
+    def repl(m: re.Match) -> str:
+        key = m.group(1)
+        return sub.get(key, m.group(0))
+
+    return re.sub(r"%%([A-Za-z0-9_]+)%%", repl, s)
+
+
+def parse_descr(text: str) -> tuple[str, str]:
+    """Return (desc, www_from_descr). Modern `make package` records the pkg-descr
+    VERBATIM as `desc` (trailing whitespace trimmed) — it no longer strips the
+    `WWW:` line. The `WWW:` line is parsed only as a *fallback* www source (the
+    Makefile WWW / USE_GITHUB default takes precedence; see resolve_www)."""
+    www = ""
+    for line in text.splitlines():
+        m = re.match(r"^WWW:\s*(\S+)", line.strip())
+        if m:
+            www = m.group(1)
+    return text.rstrip(), www
+
+
+# --------------------------------------------------------------------------- #
+# Dependency resolution (offline, from the ports tree)
+# --------------------------------------------------------------------------- #
+
+_VEROP = re.compile(r"(>=|<=|>|<|=|!=)")
+
+
+def resolve_deps(mk: Makefile, ports_root: Path, seed: dict[str, str]) -> list[Dep]:
+    entries: list[str] = []
+    for var in ("LIB_DEPENDS", "RUN_DEPENDS"):
+        raw = mk.get(var)
+        if raw.strip():
+            entries.extend(raw.split())
+    deps: dict[str, Dep] = {}
+    for ent in entries:
+        lhs, _, origin_spec = ent.partition(":")
+        if not origin_spec:
+            continue
+        # A dep spec is origin[@flavor]; the flavor (already var-expanded, e.g.
+        # net/rsync@python or databases/py-sqlite3@py311) selects which flavored
+        # package name to record. No @flavor => the port's default flavor.
+        origin, _, flavor = origin_spec.partition("@")
+        name, ver = _dep_name_version(lhs, origin, flavor, ports_root, seed)
+        if name and name not in deps:
+            deps[name] = Dep(name=name, origin=origin, version=ver or "0")
+    return list(deps.values())
+
+
+def _dep_name_version(lhs: str, origin: str, flavor: str, ports_root: Path, seed: dict[str, str]) -> tuple[str, str]:
+    # If the LHS carries a version operator it is a package-name dependency
+    # (e.g. py311-sqlite3>0); the name is the part before the operator.
+    op = _VEROP.search(lhs)
+    name_from_lhs = ""
+    if op and not lhs.startswith("/") and "${" not in lhs[: op.start()]:
+        name_from_lhs = lhs[: op.start()].strip()
+    # Resolve the dep port's PKGBASE + PORTVERSION from the ports tree when present;
+    # that yields the real recorded version and the canonical name for file-exists
+    # dependencies (e.g. ${LOCALBASE}/bin/ggrep -> gnugrep, not the path basename),
+    # honouring the selected flavor (net/rsync default -> rsync, @python -> rsync-python).
+    pkgbase, portver = _read_dep_port(ports_root / origin / "Makefile", flavor, seed)
+    name = name_from_lhs or pkgbase
+    if not name:
+        # Last resort: basename of origin (rarely correct, but better than empty).
+        name = origin.split("/")[-1]
+    return name, portver
+
+
+def _read_dep_port(makefile: Path, flavor: str, seed: dict[str, str]) -> tuple[str, str]:
+    if not makefile.is_file():
+        return "", ""
+    try:
+        mk = Makefile(makefile, seed)
+    except Exception:
+        return "", ""
+    portname = mk.get("PORTNAME")
+    if not portname:
+        return "", ""
+    # Flavored ports build PKGBASE from per-flavor name parts (FLAVORS_SUB): the
+    # chosen flavor's ${flavor}_PKGNAMEPREFIX is prepended and ${flavor}_PKGNAMESUFFIX
+    # appended to the base prefix/suffix. Default flavor = first in FLAVORS.
+    flavors = mk.get("FLAVORS").split()
+    fl = flavor or (flavors[0] if flavors else "")
+    prefix = mk.get("PKGNAMEPREFIX")
+    suffix = mk.get("PKGNAMESUFFIX")
+    if fl:
+        prefix = mk.get(f"{fl}_PKGNAMEPREFIX") + prefix
+        suffix = suffix + mk.get(f"{fl}_PKGNAMESUFFIX")
+    pkgbase = prefix + portname + suffix
+    # PKGVERSION = PORTVERSION[_PORTREVISION][,PORTEPOCH] — same as the package
+    # records (e.g. grepcidr 2.0_1). Note: the version make package ACTUALLY
+    # records is the installed BINARY package's, which tracks the build host's
+    # repo and can be newer than the ports tree (e.g. rsync 3.4.3 vs tree 3.4.1_6);
+    # this is the best the port files alone can give. Use a repo catalogue for exact.
+    ver = compute_pkgversion(mk) if (mk.get("PORTVERSION") or mk.get("DISTVERSION")) else ""
+    return pkgbase, ver
+
+
+def resolve_www(mk: Makefile, descr_www: str) -> str:
+    """Manifest www: the Makefile's WWW, else the USE_GITHUB default
+    (https://github.com/<acct>/<proj>/), else the pkg-descr WWW: line."""
+    w = mk.get("WWW")
+    if w:
+        return w
+    if _truthy(mk.get("USE_GITHUB")):
+        return f"https://github.com/{mk.get('GH_ACCOUNT')}/{mk.get('GH_PROJECT')}/"
+    return descr_www
+
+
+def synthesize_uses_deps(
+    mk: Makefile, ports_root: Path, php_ver: str, py_flavor: str, seed: dict[str, str]
+) -> list[Dep]:
+    """Dependencies injected by USES that `make package` records but that are not
+    in RUN_DEPENDS: USES=python -> python<XY>; USES=php (+USE_PHP=<exts>) ->
+    php<XY> and php<XY>-<ext>. Versions are best-effort from the ports tree."""
+    bases = {u.split(":")[0] for u in mk.get("USES").split()}
+    out: list[Dep] = []
+    if "python" in bases:
+        pyv = py_flavor[2:] if py_flavor.startswith("py") else py_flavor
+        origin = f"lang/python{pyv}"
+        _, ver = _read_dep_port(ports_root / origin / "Makefile", "", seed)
+        out.append(Dep(f"python{pyv}", origin, ver or "0"))
+    if "php" in bases:
+        phpv = php_ver.replace(".", "")
+        php_origin = f"lang/php{phpv}"
+        _, phpver = _read_dep_port(ports_root / php_origin / "Makefile", "", seed)
+        phpver = phpver or "0"
+        out.append(Dep(f"php{phpv}", php_origin, phpver))
+        for tok in mk.get("USE_PHP").split():
+            ext = tok.split(":")[0]
+            name = f"php{phpv}-{ext}"
+            origin = _glob_origin(ports_root, name)
+            ver = ""
+            if origin:
+                _, ver = _read_dep_port(ports_root / origin / "Makefile", "", seed)
+            # A php extension's version tracks the php base port — fall back to it.
+            out.append(Dep(name, origin or f"lang/{name}", ver or phpver))
+    return out
+
+
+def _glob_origin(ports_root: Path, pkgdir: str) -> str:
+    """Find a port's <category>/<pkgdir> origin by globbing the ports tree (php
+    extensions live in assorted categories, e.g. devel/php83-intl)."""
+    for p in ports_root.glob(f"*/{pkgdir}/Makefile"):
+        return f"{p.parent.parent.name}/{p.parent.name}"
+    return ""
+
+
+def apply_repo_catalogue(deps: list[Dep], source: str, abi: str) -> None:
+    """Pin each dep's version/origin to the binary repo's — the exact source
+    `make package` records (the INSTALLED package versions). `source` is a path to
+    a packagesite.yaml or packagesite.pkg/.txz, a URL to one, or 'auto' to fetch
+    FreeBSD.org's repo for the ABI. Mutates `deps` in place."""
+    wanted = {d.name for d in deps}
+    cat = load_catalogue(source, abi, wanted)
+    for d in deps:
+        hit = cat.get(d.name)
+        if not hit:
+            sys.stderr.write(f"warning: dep {d.name} not in repo catalogue; keeping version {d.version!r}\n")
+            continue
+        origin, version = hit
+        if version:
+            d.version = version
+        if origin and origin != d.origin:
+            sys.stderr.write(f"warning: catalogue origin {origin} != {d.origin} for {d.name}; keeping {d.origin}\n")
+
+
+def load_catalogue(source: str, abi: str, wanted: set[str]) -> dict[str, tuple[str, str]]:
+    if source == "auto":
+        source = f"https://pkg.freebsd.org/{abi}/latest/packagesite.pkg"
+    if source.startswith(("http://", "https://")):
+        req = urllib.request.Request(source, headers={"User-Agent": "build-pkg-portable"})
+        with urllib.request.urlopen(req) as r:
+            raw = r.read()
+    else:
+        raw = Path(source).read_bytes()
+    text = _catalogue_text(raw, source)
+    out: dict[str, tuple[str, str]] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        name = obj.get("name")
+        if name in wanted:
+            out[name] = (obj.get("origin", ""), obj.get("version", ""))
+            if len(out) == len(wanted):
+                break
+    return out
+
+
+def _catalogue_text(raw: bytes, source: str) -> str:
+    # A bare packagesite.yaml (newline-delimited JSON), else a tar (packagesite.pkg
+    # = tar.zst, .txz = tar.xz, .tgz = tar.gz) containing packagesite.yaml.
+    if source.endswith((".yaml", ".json")) or raw[:1] in (b"{", b"["):
+        return raw.decode("utf-8", "replace")
+    tar_bytes = _decompress(raw)
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+        member = "packagesite.yaml"
+        try:
+            data = tf.extractfile(member).read()
+        except KeyError:
+            data = tf.extractfile(tf.getmembers()[0]).read()
+    return data.decode("utf-8", "replace")
+
+
+def _decompress(data: bytes) -> bytes:
+    if data[:4] == b"\x28\xb5\x2f\xfd":  # zstd
+        try:
+            import zstandard
+
+            return zstandard.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
+        except ImportError:
+            zstd = shutil.which("zstd")
+            if not zstd:
+                raise BuildError("repo catalogue is zstd; install `zstd` or the python `zstandard` module")
+            return subprocess.run([zstd, "-dc"], input=data, stdout=subprocess.PIPE, check=True).stdout
+    if data[:6] == b"\xfd7zXZ\x00":  # xz
+        import lzma
+
+        return lzma.decompress(data)
+    if data[:2] == b"\x1f\x8b":  # gzip
+        import gzip
+
+        return gzip.decompress(data)
+    return data  # already an uncompressed tar
+
+
+# --------------------------------------------------------------------------- #
+# Source acquisition
+# --------------------------------------------------------------------------- #
+
+
+def acquire_source(mk: Makefile, workdir: Path, args: argparse.Namespace) -> Path | None:
+    """Populate ${WRKSRC} for a USE_GITHUB port; return the WRKSRC path, or None
+    for a classic port (which installs from ${FILESDIR}, nothing to fetch)."""
+    if not _truthy(mk.get("USE_GITHUB")):
+        return None
+
+    wrksrc = Path(mk.get("WRKSRC"))
+    wrksrc.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.local_src:
+        local = Path(args.local_src).resolve()
+        src_root = local / "src" if (local / "src").is_dir() else local
+        if not (src_root / "usr").is_dir():
+            raise BuildError(
+                f"--local-src {local} does not look like a pfBlockerNG checkout (expected a src/ tree containing usr/)"
+            )
+        # Copy into WRKSRC so post-extract's sed/mv never mutate the working tree.
+        shutil.copytree(src_root, wrksrc, dirs_exist_ok=True)
+        sys.stderr.write(f"==> source: local working tree {src_root}\n")
+        return wrksrc
+
+    account = mk.get("GH_ACCOUNT")
+    project = mk.get("GH_PROJECT")
+    tagname = args.gh_tagname or mk.get("GH_TAGNAME")
+    url = f"https://codeload.github.com/{account}/{project}/tar.gz/{tagname}"
+    sys.stderr.write(f"==> source: fetching {url}\n")
+    tgz = workdir / "src.tar.gz"
+    _download(url, tgz)
+    extract_root = workdir / "gh-extract"
+    extract_root.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tgz, "r:gz") as tf:
+        _safe_extract(tf, extract_root)
+    tops = [p for p in extract_root.iterdir() if p.is_dir()]
+    if len(tops) != 1:
+        raise BuildError(f"unexpected GitHub tarball layout: {[p.name for p in tops]}")
+    fetched_src = tops[0] / "src"
+    if not fetched_src.is_dir():
+        raise BuildError(f"fetched tarball has no src/ dir under {tops[0].name}")
+    shutil.copytree(fetched_src, wrksrc, dirs_exist_ok=True)
+    return wrksrc
+
+
+def _download(url: str, dest: Path) -> None:
+    req = urllib.request.Request(url, headers={"User-Agent": "build-pkg-portable"})
+    with urllib.request.urlopen(req) as r, open(dest, "wb") as f:
+        shutil.copyfileobj(r, f)
+
+
+def _safe_extract(tf: tarfile.TarFile, dest: Path) -> None:
+    base = dest.resolve()
+    for m in tf.getmembers():
+        target = (dest / m.name).resolve()
+        if not str(target).startswith(str(base)):
+            raise BuildError(f"unsafe path in tarball: {m.name}")
+    tf.extractall(dest)
+
+
+# --------------------------------------------------------------------------- #
+# Scripts (pkg-install / pkg-deinstall -> manifest scripts)
+# --------------------------------------------------------------------------- #
+
+# How ports' SUB_FILES script names map to libpkg manifest script keys. pfSense's
+# pkg-install checks $2 (PRE-INSTALL/POST-INSTALL) -> the combined `install`
+# script libpkg runs at both phases; likewise pkg-deinstall -> `deinstall`.
+_SCRIPT_KEYS = {
+    "pkg-install": "install",
+    "pkg-deinstall": "deinstall",
+    "pkg-pre-install": "pre-install",
+    "pkg-post-install": "post-install",
+    "pkg-pre-deinstall": "pre-deinstall",
+    "pkg-post-deinstall": "post-deinstall",
+}
+
+
+def build_scripts(mk: Makefile, filesdir: Path) -> dict[str, str]:
+    sub_files = mk.get("SUB_FILES").split()
+    sub_list = _parse_sub_list(mk)
+    scripts: dict[str, str] = {}
+    for name in sub_files:
+        key = _SCRIPT_KEYS.get(name)
+        if key is None:
+            continue
+        src = filesdir / f"{name}.in"
+        if not src.is_file():
+            raise BuildError(f"SUB_FILES references {name} but {src} is missing")
+        body = src.read_text()
+        body = _sub_tokens(body, sub_list)
+        # pkg create embeds the script without its trailing newline.
+        scripts[key] = body.rstrip("\n")
+    return scripts
+
+
+def _parse_sub_list(mk: Makefile) -> dict[str, str]:
+    sub: dict[str, str] = {
+        "PREFIX": mk.get("PREFIX"),
+        "LOCALBASE": mk.get("LOCALBASE"),
+        "DATADIR": mk.get("DATADIR"),
+        "PORTNAME": mk.get("PORTNAME"),
+        "PORTVERSION": mk.get("PORTVERSION"),
+    }
+    for tok in mk.get("SUB_LIST").split():
+        if "=" in tok:
+            k, _, v = tok.partition("=")
+            sub[k] = mk.expand(v)
+    return sub
+
+
+# --------------------------------------------------------------------------- #
+# Manifest + archive emission
+# --------------------------------------------------------------------------- #
+
+
+def make_manifest(b: Build, *, compact: bool) -> dict:
+    m: dict = {
+        "name": b.portname,
+        "origin": b.origin,
+        "version": b.pkgversion,
+        "comment": b.comment,
+        "maintainer": b.maintainer,
+        "www": b.www,
+        "abi": b.abi,
+        "arch": b.arch,
+        "prefix": b.prefix,
+        "flatsize": sum(f.src_in_stage.stat().st_size for f in b.files),
+        "licenselogic": "single" if len(b.licenses) <= 1 else "and",
+        "licenses": b.licenses,
+        "desc": b.desc,
+        "categories": b.categories,
+    }
+    if b.deps:
+        m["deps"] = {d.name: {"origin": d.origin, "version": d.version} for d in sorted(b.deps, key=lambda d: d.name)}
+    # annotations appear in BOTH manifests (real `make package` emits at least
+    # {"FreeBSD_version": <__FreeBSD_version of the build host>}).
+    if b.annotations:
+        m["annotations"] = b.annotations
+    if compact:
+        return m
+    # `fflags: 0` matches `pkg create` (no file flags set). mtime is the staged
+    # file's install time in real pkg — inherently per-build, so we record 0
+    # (deterministic; install-irrelevant).
+    m["files"] = {}
+    for f in sorted(b.files, key=lambda x: x.install_path):
+        digest = _sha256(f.src_in_stage)
+        m["files"][f.install_path] = {
+            "sum": f"1${digest}",
+            "uname": "root",
+            "gname": "wheel",
+            "perm": f.perm,
+            "fflags": 0,
+            "mtime": 0,
+        }
+    if b.directories:
+        m["directories"] = {
+            d: {"uname": "root", "gname": "wheel", "perm": "0755", "fflags": 0}
+            for d in sorted(b.directories, key=len, reverse=True)
+        }
+    if b.scripts:
+        m["scripts"] = b.scripts
+    return m
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _ucl_dump(manifest: dict) -> bytes:
+    # libpkg reads UCL; JSON is valid UCL. Compact, stable key order.
+    return json.dumps(manifest, separators=(",", ":"), ensure_ascii=False).encode() + b"\n"
+
+
+def write_pkg(b: Build, out_path: Path, compression: str) -> None:
+    compact = _ucl_dump(make_manifest(b, compact=True))
+    full = _ucl_dump(make_manifest(b, compact=False))
+
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as tf:
+        _add_meta(tf, "+COMPACT_MANIFEST", compact)
+        _add_meta(tf, "+MANIFEST", full)
+        for f in sorted(b.files, key=lambda x: x.install_path):
+            ti = tarfile.TarInfo(name=f.install_path)  # leading-slash, as libpkg stores
+            data = f.src_in_stage.read_bytes()
+            ti.size = len(data)
+            ti.mode = int(f.perm, 8)
+            ti.uid = ti.gid = 0
+            ti.uname, ti.gname = "root", "wheel"
+            ti.mtime = 0
+            ti.type = tarfile.REGTYPE
+            tf.addfile(ti, io.BytesIO(data))
+    tar_bytes = raw.getvalue()
+
+    if compression == "xz":
+        import lzma
+
+        out_path.write_bytes(lzma.compress(tar_bytes, preset=6))
+    else:
+        out_path.write_bytes(_zstd_compress(tar_bytes))
+
+
+def _add_meta(tf: tarfile.TarFile, name: str, data: bytes) -> None:
+    ti = tarfile.TarInfo(name=name)
+    ti.size = len(data)
+    ti.mode = 0o644
+    ti.uid = ti.gid = 0
+    ti.uname, ti.gname = "root", "wheel"
+    ti.mtime = 0
+    tf.addfile(ti, io.BytesIO(data))
+
+
+def _zstd_compress(data: bytes) -> bytes:
+    try:
+        import zstandard
+
+        return zstandard.ZstdCompressor(level=19).compress(data)
+    except ImportError:
+        pass
+    zstd = shutil.which("zstd")
+    if not zstd:
+        raise BuildError(
+            "zstd compression needs the `zstd` binary or the python `zstandard` "
+            "module (brew install zstd / apt install zstd), or pass --compression xz"
+        )
+    p = subprocess.run([zstd, "-q", "-19", "-c"], input=data, stdout=subprocess.PIPE, check=True)
+    return p.stdout
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+
+def _truthy(v: str) -> bool:
+    return v.strip().lower() in ("yes", "true", "1", "on")
+
+
+def _ask_or_die(flag: str, question: str, examples: str) -> str:
+    """Honour 'if not provided, ask': prompt on a TTY, else fail telling the user
+    to pass the flag. Never guesses a version."""
+    if sys.stdin.isatty() and sys.stderr.isatty():
+        sys.stderr.write(f"{question}\n  ({examples})\n{flag} = ")
+        sys.stderr.flush()
+        ans = sys.stdin.readline().strip()
+        if ans:
+            return ans
+    raise BuildError(f"{flag} not provided and no value to ask for — pass {flag}. {examples}")
+
+
+def abi_to_arch(abi: str) -> str:
+    # FreeBSD:15:amd64 -> freebsd:15:x86:64  (the manifest's `arch` triplet).
+    cpu_map = {
+        "amd64": "x86:64",
+        "i386": "x86:32",
+        "aarch64": "aarch64:64",
+        "armv7": "armv7:32",
+        "powerpc64": "powerpc:64",
+        "powerpc64le": "powerpc:64:eb",
+    }
+    parts = abi.split(":")
+    if len(parts) != 3:
+        raise BuildError(f"--abi must look like FreeBSD:15:amd64, got {abi!r}")
+    _os, major, cpu = parts
+    return f"{_os.lower()}:{major}:{cpu_map.get(cpu, cpu)}"
+
+
+def compute_pkgversion(mk: Makefile) -> str:
+    ver = mk.get("PORTVERSION") or mk.get("DISTVERSION")
+    rev = mk.get("PORTREVISION").strip()
+    epoch = mk.get("PORTEPOCH").strip()
+    if rev and rev != "0":
+        ver += f"_{rev}"
+    if epoch and epoch != "0":
+        ver += f",{epoch}"
+    return ver
+
+
+def seed_vars(portdir: Path, workdir: Path, py_flavor: str) -> dict[str, str]:
+    prefix = "/usr/local"
+    stagedir = str(workdir / "stage")
+    py_prefix = f"{py_flavor}-" if py_flavor else ""
+    return {
+        "PREFIX": prefix,
+        "LOCALBASE": prefix,
+        "DATADIR": "${PREFIX}/share/${PORTNAME}",
+        "FILESDIR": str(portdir / "files"),
+        "WRKDIR": str(workdir / "work"),
+        "WRKSRC": "${WRKDIR}/${DISTNAME}",
+        "DISTNAME": "${PORTNAME}-${DISTVERSION}",
+        "DISTVERSION": "${PORTVERSION}",
+        "STAGEDIR": stagedir,
+        "PORTREVISION": "0",
+        "PORTEPOCH": "0",
+        "PYTHON_PKGNAMEPREFIX": py_prefix,
+        "PY_FLAVOR": py_flavor,
+        "PYTHON_CMD": "python3",
+    }
+
+
+def run_build(args: argparse.Namespace) -> Build:
+    ports_root = Path(args.ports).resolve()
+    if args.port_dir:
+        portdir = Path(args.port_dir).resolve()
+    else:
+        sub = "pfSense-pkg-pfBlockerNG" if args.channel == "stable" else "pfSense-pkg-pfBlockerNG-devel"
+        portdir = ports_root / "net" / sub
+    makefile = portdir / "Makefile"
+    if not makefile.is_file():
+        raise BuildError(f"port Makefile not found: {makefile}")
+
+    # Version-dependent TARGET facts. These are properties of the target pfSense
+    # edition+version, NOT of the --ports checkout: that fork tree is a single
+    # snapshot whose default versions (e.g. PHP 8.4) need not match what a given
+    # pfSense release ships (CE 2.8 = PHP 8.3, Python 3.11). So never derive them
+    # from the tree — take them explicitly and ask if missing. The repo's
+    # docs/misc/pfSense_versions.md is the authoritative per-version mirror.
+    #
+    # Three such facts affect this tool's output: the ABI (manifest abi/arch), the
+    # Python flavor, and the PHP version. `make package` records 12 deps for
+    # pfBlockerNG, not just the 9 RUN_DEPENDS: USES=php + USE_PHP=intl inject
+    # php<XY> + php<XY>-intl, and USES=python injects python<XY> (verified against a
+    # real make-package .pkg). Those carry the TARGET's php/python version, which is
+    # NOT the ports tree default (build-pkg.sh pins php=8.3 though the fork tree
+    # defaults to 8.4) — so php is asked for too (only when USES=php).
+    abi = args.abi or _ask_or_die(
+        "--abi",
+        "Which target ABI? (FreeBSD major differs per pfSense edition/version)",
+        "e.g. FreeBSD:15:amd64 (CE 2.8) or FreeBSD:16:amd64 (Plus) — see docs/misc/pfSense_versions.md",
+    )
+    arch = args.arch or abi_to_arch(abi)
+    py_flavor = args.py_flavor or _ask_or_die(
+        "--py-flavor",
+        "Which Python flavor? (sets the py3xx- dep names; tracks the target's base Python, not the ports tree)",
+        "e.g. py311 for pfSense CE 2.8 (Python 3.11) — see docs/misc/pfSense_versions.md",
+    )
+
+    workdir = Path(tempfile.mkdtemp(prefix="pfbng-pkg-"))
+    args._workdir = workdir
+    seed = seed_vars(portdir, workdir, py_flavor)
+    mk = Makefile(makefile, seed)
+
+    prefix = mk.get("PREFIX")
+    portname = mk.get("PORTNAME")
+    pkgversion = compute_pkgversion(mk)
+    # PKGVERSION/PKGNAME are framework-derived, not assigned in the Makefile, but
+    # the recipe references them (e.g. the info.xml %%PKGVERSION%% reinplace). Seed
+    # them so they expand to real values instead of empty.
+    mk.vars["PKGVERSION"] = pkgversion
+    mk.vars["PKGNAME"] = f"{portname}-{pkgversion}"
+    categories = mk.get("CATEGORIES").split()
+    origin = f"{categories[0]}/{portname}" if categories else portname
+
+    # PHP version is a target fact, asked only when the port USES php.
+    uses_bases = {u.split(":")[0] for u in mk.get("USES").split()}
+    php_ver = ""
+    if "php" in uses_bases:
+        php_ver = args.php or _ask_or_die(
+            "--php",
+            "Which target PHP version? (USES=php injects a php<XY>[-ext] dep)",
+            "e.g. 8.3 for pfSense CE 2.8 — see docs/misc/pfSense_versions.md",
+        )
+
+    descr_path = portdir / "pkg-descr"
+    desc, descr_www = parse_descr(descr_path.read_text()) if descr_path.is_file() else ("", "")
+    www = resolve_www(mk, descr_www)
+
+    b = Build(
+        portname=portname,
+        pkgversion=pkgversion,
+        origin=origin,
+        comment=mk.get("COMMENT"),
+        maintainer=mk.get("MAINTAINER"),
+        categories=categories,
+        licenses=mk.get("LICENSE").split() or [],
+        www=www,
+        desc=desc,
+        prefix=prefix,
+        abi=abi,
+        arch=arch,
+    )
+
+    # --- source + recipe -------------------------------------------------- #
+    Path(seed["STAGEDIR"]).mkdir(parents=True, exist_ok=True)
+    Path(mk.get("WRKDIR")).mkdir(parents=True, exist_ok=True)
+    acquire_source(mk, workdir, args)
+
+    recipe = Recipe(mk)
+    # do-extract only matters for the classic port (mkdir WRKSRC); harmless for GH.
+    if "do-extract" in mk.recipes and not _truthy(mk.get("USE_GITHUB")):
+        recipe.run("do-extract")
+    if "post-extract" in mk.recipes:
+        recipe.run("post-extract")
+    if "do-install" not in mk.recipes:
+        raise BuildError("port has no do-install target — unexpected for a pfSense pkg port")
+    recipe.run("do-install")
+    if "post-install" in mk.recipes:
+        recipe.run("post-install")
+
+    # --- collect staged files, validate against the plist ----------------- #
+    stagedir = Path(seed["STAGEDIR"])
+    staged_paths = {"/" + os.path.relpath(p, stagedir): p for p in stagedir.rglob("*") if p.is_file()}
+
+    plist_path = portdir / "pkg-plist"
+    plist_sub = {"DATADIR": "share/" + portname, "PORTNAME": portname, "PORTVERSION": mk.get("PORTVERSION")}
+    plist_files, plist_dirs = parse_plist(plist_path.read_text(), plist_sub, prefix)
+
+    plist_set = set(plist_files)
+    staged_set = set(staged_paths)
+    missing = plist_set - staged_set
+    extra = staged_set - plist_set
+    if missing:
+        raise BuildError("plist lists files the recipe did not stage:\n  " + "\n  ".join(sorted(missing)))
+    if extra:
+        raise BuildError("recipe staged files not in the plist:\n  " + "\n  ".join(sorted(extra)))
+
+    for ip in sorted(plist_set):
+        perm = recipe.modes.get(ip, "0644")
+        if ip not in recipe.modes:
+            sys.stderr.write(f"warning: no mode recorded for {ip}; defaulting 0644\n")
+        b.files.append(StagedFile(install_path=ip, src_in_stage=staged_paths[ip], perm=perm))
+
+    b.directories = plist_dirs
+    b.scripts = build_scripts(mk, portdir / "files")
+    # Declared RUN_DEPENDS/LIB_DEPENDS + the deps USES injects (php/python), as
+    # `make package` records them. Dedup by name (declared win).
+    deps: dict[str, Dep] = {}
+    for d in resolve_deps(mk, ports_root, seed) + synthesize_uses_deps(mk, ports_root, php_ver, py_flavor, seed):
+        deps.setdefault(d.name, d)
+    b.deps = list(deps.values())
+    # Best-effort dep versions come from the ports tree; the version make package
+    # actually records is the INSTALLED binary package's. Pin those exactly from
+    # the target repo catalogue when asked.
+    if args.repo_catalogue:
+        sys.stderr.write(f"==> pinning dep versions from repo catalogue ({args.repo_catalogue})\n")
+        apply_repo_catalogue(b.deps, args.repo_catalogue, abi)
+    if args.freebsd_version:
+        b.annotations = {"FreeBSD_version": args.freebsd_version}
+    return b
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(
+        prog="build-pkg-portable.py",
+        description="Build a pfSense-installable pfBlockerNG .pkg off-FreeBSD, from the FreeBSD ports files.",
+    )
+    ap.add_argument(
+        "--ports", required=True, help="FreeBSD-ports checkout (contains net/pfSense-pkg-pfBlockerNG[-devel])"
+    )
+    ap.add_argument("--channel", choices=("devel", "stable"), default="devel", help="which port (default: devel)")
+    ap.add_argument("--port-dir", help="explicit port directory (overrides --channel)")
+    ap.add_argument("--out", default=".", help="output directory for the .pkg (default: cwd)")
+    ap.add_argument(
+        "--abi",
+        default="",
+        help="target ABI, e.g. FreeBSD:15:amd64 (CE 2.8) or FreeBSD:16:amd64 (Plus); asked if omitted",
+    )
+    ap.add_argument("--arch", default="", help="manifest arch triplet (default: derived from --abi)")
+    ap.add_argument(
+        "--py-flavor",
+        default="",
+        help="py3xx- flavor for dep names, e.g. py311 (CE 2.8); asked if omitted (see docs/misc/pfSense_versions.md)",
+    )
+    ap.add_argument(
+        "--php",
+        default="",
+        help="target PHP version for the USES=php dep, e.g. 8.3 (CE 2.8); asked if the port USES php and omitted",
+    )
+    ap.add_argument(
+        "--freebsd-version",
+        default="",
+        help="build host __FreeBSD_version for the annotations block, e.g. 1500068 (optional; omitted if unset)",
+    )
+    ap.add_argument(
+        "--repo-catalogue",
+        default="",
+        help="pin exact dep versions from a repo packagesite (.yaml/.pkg path/URL, or 'auto'); see README",
+    )
+    ap.add_argument(
+        "--local-src",
+        help="USE_GITHUB ports only: build from this local pfBlockerNG checkout instead of fetching the GitHub tag",
+    )
+    ap.add_argument(
+        "--gh-tagname", help="override GH_TAGNAME (commit/tag) when fetching (default: the Makefile's v${PORTVERSION})"
+    )
+    ap.add_argument("--compression", choices=("zstd", "xz"), default="zstd", help="output compression (default: zstd)")
+    ap.add_argument("--keep-work", action="store_true", help="keep the temporary work/staging dir")
+    ap.add_argument("--dry-run", action="store_true", help="print the build plan; do not write a .pkg")
+    args = ap.parse_args(argv)
+
+    try:
+        b = run_build(args)
+    except BuildError as e:
+        sys.stderr.write(f"build-pkg-portable: {e}\n")
+        return 1
+
+    workdir = getattr(args, "_workdir", None)
+    try:
+        if args.dry_run:
+            _print_plan(b)
+            return 0
+        out_dir = Path(args.out).resolve()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{b.pkgname}.pkg"
+        write_pkg(b, out_path, args.compression)
+        sys.stderr.write(f"==> wrote {out_path}  ({out_path.stat().st_size} bytes, {len(b.files)} files)\n")
+        print(out_path)
+        return 0
+    finally:
+        if workdir and not args.keep_work:
+            shutil.rmtree(workdir, ignore_errors=True)
+        elif workdir:
+            sys.stderr.write(f"==> kept work dir {workdir}\n")
+
+
+def _print_plan(b: Build) -> None:
+    print(f"name        {b.portname}")
+    print(f"version     {b.pkgversion}")
+    print(f"origin      {b.origin}")
+    print(f"abi/arch    {b.abi}  /  {b.arch}")
+    print(f"comment     {b.comment}")
+    print(f"www         {b.www}")
+    print(f"licenses    {b.licenses} ({'single' if len(b.licenses) <= 1 else 'and'})")
+    print(f"files       {len(b.files)}")
+    print(f"directories {b.directories}")
+    print(f"scripts     {sorted(b.scripts)}")
+    print(f"flatsize    {sum(f.src_in_stage.stat().st_size for f in b.files)} bytes")
+    print(f"deps        {len(b.deps)}")
+    for d in sorted(b.deps, key=lambda x: x.name):
+        print(f"  - {d.name:24s} {d.origin:28s} {d.version}")
+    print("sample files (path  perm):")
+    for f in sorted(b.files, key=lambda x: x.install_path)[:8]:
+        print(f"  {f.perm}  {f.install_path}")
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -24,8 +24,16 @@
 # The result is a real libpkg archive: zstd-compressed tar with +COMPACT_MANIFEST
 # and +MANIFEST first, then payload files at their absolute paths. `pkg add` on
 # pfSense registers it and runs the POST-INSTALL hook (rc.packages), same as a
-# port-built .pkg. Dependencies are recorded from RUN_DEPENDS/LIB_DEPENDS so
-# `pkg add` resolves them from the local pkg db (pre-baked on the smoke image).
+# port-built .pkg. Dependencies are RUN_DEPENDS/LIB_DEPENDS plus the ones USES
+# injects (USES=php + USE_PHP -> php<XY>[-ext]; USES=python -> python<XY>), which
+# `make package` also records; their exact versions can be pinned from a repo
+# catalogue (--repo-catalogue).
+#
+# Fidelity: the output was diffed field-by-field against a real `make package`
+# build for the same commit and matches it (metadata, files+checksums+perms,
+# directories, scripts, dep names/origins). The only values not derivable from
+# the port files are file mtime (the install clock) and a few dep versions that
+# make package reads from the build host's installed packages.
 #
 # Requires: python3 (stdlib only) + a zstd encoder (the `zstd` binary, or the
 # python `zstandard` module). `--compression xz` needs neither (stdlib lzma).
@@ -86,9 +94,10 @@ class Makefile:
             # Recipe line: starts with a literal TAB.
             is_recipe = raw.startswith("\t")
             text = raw
-            # Gather continuations.
+            # Gather continuations (backslash-newline collapses to a single space,
+            # like make: drop the trailing space before the backslash too).
             while text.rstrip().endswith("\\"):
-                text = text.rstrip()[:-1]
+                text = text.rstrip()[:-1].rstrip()
                 i += 1
                 if i < len(lines):
                     text += " " + lines[i].strip() if not is_recipe else " " + lines[i].lstrip("\t")
@@ -207,9 +216,6 @@ class Makefile:
     def get(self, name: str, default: str = "") -> str:
         v = self._lookup(name)
         return self.expand(v) if v is not None else default
-
-    def has(self, name: str) -> bool:
-        return self._lookup(name) is not None
 
 
 # --------------------------------------------------------------------------- #
@@ -357,28 +363,35 @@ class Recipe:
         # (installed scripts/binaries are not writable) — NOT 0755.
         self._install(args, "0555")
 
-    def _cmd_install_lib(self, args: list[str]) -> None:
-        self._install(args, "0644")
-
-    def _cmd_install_man(self, args: list[str]) -> None:
-        self._install(args, "0644")
+    def _cmd_install_program(self, args: list[str]) -> None:
+        # INSTALL_PROGRAM also uses ${BINMODE} = 0555.
+        self._install(args, "0555")
 
     def _cmd_mv(self, args: list[str]) -> None:
-        args = [a for a in args if not a.startswith("-")]
-        *srcs, dest = args
+        srcs, dest = self._copy_args(args)
         for s in srcs:
             shutil.move(s, dest)
 
     def _cmd_cp(self, args: list[str]) -> None:
-        args = [a for a in args if not a.startswith("-")]
-        *srcs, dest = args
+        srcs, dest = self._copy_args(args)
         dest_p = Path(dest)
+        multi = len(srcs) > 1 or dest_p.is_dir()
         for s in srcs:
-            if Path(s).is_dir():
-                shutil.copytree(s, dest_p / Path(s).name, dirs_exist_ok=True)
-            else:
-                (dest_p if dest_p.is_dir() else dest_p.parent).mkdir(parents=True, exist_ok=True)
-                shutil.copyfile(s, dest_p / Path(s).name if dest_p.is_dir() else dest_p)
+            sp = Path(s)
+            if sp.is_dir():
+                shutil.copytree(sp, dest_p / sp.name, dirs_exist_ok=True)
+                continue
+            target = dest_p / sp.name if multi else dest_p
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(sp, target)
+
+    @staticmethod
+    def _copy_args(args: list[str]) -> tuple[list[str], str]:
+        # Drop flags (e.g. -R, -p), then split into (sources, dest).
+        paths = [a for a in args if not a.startswith("-")]
+        if len(paths) < 2:
+            raise BuildError(f"copy/move with too few paths: {args!r}")
+        return paths[:-1], paths[-1]
 
     def _cmd_ln(self, args: list[str]) -> None:
         args = [a for a in args if not a.startswith("-")]
@@ -717,10 +730,14 @@ def load_catalogue(source: str, abi: str, wanted: set[str]) -> dict[str, tuple[s
     if source == "auto":
         source = f"https://pkg.freebsd.org/{abi}/latest/packagesite.pkg"
     if source.startswith(("http://", "https://")):
-        req = urllib.request.Request(source, headers={"User-Agent": "build-pkg-portable"})
-        with urllib.request.urlopen(req) as r:
-            raw = r.read()
+        try:
+            with _urlopen(source) as r:
+                raw = r.read()
+        except OSError as e:
+            raise BuildError(f"failed to fetch repo catalogue {source}: {e}") from None
     else:
+        if not Path(source).is_file():
+            raise BuildError(f"--repo-catalogue file not found: {source}")
         raw = Path(source).read_bytes()
     text = _catalogue_text(raw, source)
     out: dict[str, tuple[str, str]] = {}
@@ -764,7 +781,7 @@ def _decompress(data: bytes) -> bytes:
         except ImportError:
             zstd = shutil.which("zstd")
             if not zstd:
-                raise BuildError("repo catalogue is zstd; install `zstd` or the python `zstandard` module")
+                raise BuildError("repo catalogue is zstd; install `zstd` or the python `zstandard` module") from None
             return subprocess.run([zstd, "-dc"], input=data, stdout=subprocess.PIPE, check=True).stdout
     if data[:6] == b"\xfd7zXZ\x00":  # xz
         import lzma
@@ -825,9 +842,16 @@ def acquire_source(mk: Makefile, workdir: Path, args: argparse.Namespace) -> Pat
 
 
 def _download(url: str, dest: Path) -> None:
+    try:
+        with _urlopen(url) as r, open(dest, "wb") as f:
+            shutil.copyfileobj(r, f)
+    except OSError as e:
+        raise BuildError(f"failed to fetch {url}: {e}") from None
+
+
+def _urlopen(url: str):
     req = urllib.request.Request(url, headers={"User-Agent": "build-pkg-portable"})
-    with urllib.request.urlopen(req) as r, open(dest, "wb") as f:
-        shutil.copyfileobj(r, f)
+    return urllib.request.urlopen(req)
 
 
 def _safe_extract(tf: tarfile.TarFile, dest: Path) -> None:
@@ -1226,50 +1250,68 @@ def run_build(args: argparse.Namespace) -> Build:
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(
         prog="build-pkg-portable.py",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Build a pfSense-installable pfBlockerNG .pkg off-FreeBSD, from the FreeBSD ports files.",
+        epilog=(
+            "examples:\n"
+            "  # build from a local working tree, targeting pfSense CE 2.8\n"
+            "  build-pkg-portable.py --ports ../FreeBSD-ports --local-src . \\\n"
+            "      --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --out /tmp\n\n"
+            "  # build a specific commit (with a src/ tree) and pin exact dep versions\n"
+            "  build-pkg-portable.py --ports ../FreeBSD-ports --gh-tagname <sha> \\\n"
+            "      --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --repo-catalogue auto\n\n"
+            "  # inspect the plan without writing a .pkg\n"
+            "  build-pkg-portable.py --ports ../FreeBSD-ports --local-src . \\\n"
+            "      --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --dry-run\n\n"
+            "See docs/build-pkg-portable.md for the full reference."
+        ),
     )
     ap.add_argument(
         "--ports", required=True, help="FreeBSD-ports checkout (contains net/pfSense-pkg-pfBlockerNG[-devel])"
     )
-    ap.add_argument("--channel", choices=("devel", "stable"), default="devel", help="which port (default: devel)")
-    ap.add_argument("--port-dir", help="explicit port directory (overrides --channel)")
-    ap.add_argument("--out", default=".", help="output directory for the .pkg (default: cwd)")
-    ap.add_argument(
-        "--abi",
-        default="",
-        help="target ABI, e.g. FreeBSD:15:amd64 (CE 2.8) or FreeBSD:16:amd64 (Plus); asked if omitted",
+
+    g_port = ap.add_argument_group("port selection")
+    g_port.add_argument("--channel", choices=("devel", "stable"), default="devel", help="which port (default: devel)")
+    g_port.add_argument("--port-dir", help="explicit port directory (overrides --channel)")
+
+    g_target = ap.add_argument_group(
+        "target facts (version-dependent; asked if omitted — never read from the ports tree)"
     )
-    ap.add_argument("--arch", default="", help="manifest arch triplet (default: derived from --abi)")
-    ap.add_argument(
-        "--py-flavor",
-        default="",
-        help="py3xx- flavor for dep names, e.g. py311 (CE 2.8); asked if omitted (see docs/misc/pfSense_versions.md)",
+    g_target.add_argument(
+        "--abi", default="", help="target ABI, e.g. FreeBSD:15:amd64 (CE 2.8) or FreeBSD:16:amd64 (Plus)"
     )
-    ap.add_argument(
-        "--php",
-        default="",
-        help="target PHP version for the USES=php dep, e.g. 8.3 (CE 2.8); asked if the port USES php and omitted",
+    g_target.add_argument("--arch", default="", help="manifest arch triplet (default: derived from --abi)")
+    g_target.add_argument("--py-flavor", default="", help="py3xx- flavor for dep names, e.g. py311 (CE 2.8)")
+    g_target.add_argument(
+        "--php", default="", help="PHP version for the USES=php dep, e.g. 8.3 (asked only if USES php)"
     )
-    ap.add_argument(
-        "--freebsd-version",
-        default="",
-        help="build host __FreeBSD_version for the annotations block, e.g. 1500068 (optional; omitted if unset)",
+    g_target.add_argument(
+        "--freebsd-version", default="", help="build host __FreeBSD_version for annotations, e.g. 1500068 (optional)"
     )
-    ap.add_argument(
-        "--repo-catalogue",
-        default="",
-        help="pin exact dep versions from a repo packagesite (.yaml/.pkg path/URL, or 'auto'); see README",
+
+    g_src = ap.add_argument_group("source (USE_GITHUB ports)")
+    g_src.add_argument(
+        "--local-src", help="build from this local pfBlockerNG checkout instead of fetching the GitHub tag"
     )
-    ap.add_argument(
-        "--local-src",
-        help="USE_GITHUB ports only: build from this local pfBlockerNG checkout instead of fetching the GitHub tag",
-    )
-    ap.add_argument(
+    g_src.add_argument(
         "--gh-tagname", help="override GH_TAGNAME (commit/tag) when fetching (default: the Makefile's v${PORTVERSION})"
     )
-    ap.add_argument("--compression", choices=("zstd", "xz"), default="zstd", help="output compression (default: zstd)")
-    ap.add_argument("--keep-work", action="store_true", help="keep the temporary work/staging dir")
-    ap.add_argument("--dry-run", action="store_true", help="print the build plan; do not write a .pkg")
+
+    g_deps = ap.add_argument_group("dependency versions")
+    g_deps.add_argument(
+        "--repo-catalogue",
+        default="",
+        help="pin exact dep versions from a repo packagesite (.yaml/.pkg path/URL, or 'auto')",
+    )
+
+    g_out = ap.add_argument_group("output")
+    g_out.add_argument("--out", default=".", help="output directory for the .pkg (default: cwd)")
+    g_out.add_argument(
+        "--compression", choices=("zstd", "xz"), default="zstd", help="output compression (default: zstd)"
+    )
+    g_out.add_argument("--keep-work", action="store_true", help="keep the temporary work/staging dir")
+    g_out.add_argument("--dry-run", action="store_true", help="print the build plan; do not write a .pkg")
+
     args = ap.parse_args(argv)
 
     try:

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -169,11 +169,10 @@ def test_parse_plist_unresolved_token_raises():
         bpp.parse_plist("%%NOPE%%/x\n", {}, "/usr/local")
 
 
-def test_parse_plist_unknown_keyword_warns(capsys):
-    files, dirs = bpp.parse_plist("@sample foo.conf.sample\nbin/x\n", {}, "/usr/local")
-    assert files == ["/usr/local/bin/x"]
-    assert dirs == []
-    assert "@sample" in capsys.readouterr().err
+def test_parse_plist_unknown_keyword_raises():
+    # Fail closed on an unhandled @keyword (don't silently emit a wrong package).
+    with pytest.raises(bpp.BuildError, match="@sample"):
+        bpp.parse_plist("@sample foo.conf.sample\nbin/x\n", {}, "/usr/local")
 
 
 @pytest.mark.parametrize(
@@ -243,6 +242,20 @@ def test_recipe_bare_mv_and_unknown_command(tmp_path):
     bad = make_mk(tmp_path, "do-install:\n\t${FROBNICATE} a b\n")
     with pytest.raises(bpp.BuildError, match="unsupported recipe command"):
         bpp.Recipe(bad).run("do-install")
+
+
+def test_safe_extract_rejects_traversal(tmp_path):
+    # A path-traversal member must be rejected (the stdlib 'data' filter).
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        for name in ("ok.txt", "../escape.txt"):
+            data = b"x"
+            ti = tarfile.TarInfo(name)
+            ti.size = len(data)
+            tf.addfile(ti, io.BytesIO(data))
+    buf.seek(0)
+    with tarfile.open(fileobj=buf) as tf2, pytest.raises(bpp.BuildError):
+        bpp._safe_extract(tf2, tmp_path / "dest")
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -1,0 +1,506 @@
+"""Tests for scripts/build-pkg-portable.py.
+
+All fixtures here are SYNTHETIC and authored in this repository — a tiny made-up
+"port" and ports tree — so the suite vendors no FreeBSD ports/pkg source, no real
+`packagesite`, and no compiled artifacts. That keeps the test data unambiguously
+Apache-2.0 (this repo's licence) and lets the tests run with no network and no
+FreeBSD host.
+
+The tool is a hyphen-named CLI script, so it is loaded by path via importlib.
+"""
+
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import io
+import json
+import lzma
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Load the hyphen-named tool as a module.
+# --------------------------------------------------------------------------- #
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "build-pkg-portable.py"
+_spec = importlib.util.spec_from_file_location("build_pkg_portable", _TOOL)
+bpp = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = bpp
+_spec.loader.exec_module(bpp)
+
+
+def make_mk(tmp_path: Path, text: str, seed: dict | None = None) -> "bpp.Makefile":
+    p = tmp_path / "Makefile"
+    p.write_text(text)
+    return bpp.Makefile(p, seed or {})
+
+
+# --------------------------------------------------------------------------- #
+# Makefile evaluator
+# --------------------------------------------------------------------------- #
+
+
+def test_makefile_assignment_ops(tmp_path):
+    mk = make_mk(
+        tmp_path,
+        "A=\t1\n"
+        "A?=\t2\n"  # ignored: A already set
+        "B?=\t3\n"  # set: B unset
+        "C=\tx\n"
+        "C+=\ty\n"  # append
+        "D:=\tz\n",
+    )
+    assert mk.get("A") == "1"
+    assert mk.get("B") == "3"
+    assert mk.get("C") == "x y"
+    assert mk.get("D") == "z"
+
+
+def test_makefile_seed_default_and_override(tmp_path):
+    mk = make_mk(tmp_path, "PREFIX=\t/somewhere\n", seed={"PREFIX": "/usr/local", "LOCALBASE": "/usr/local"})
+    assert mk.get("PREFIX") == "/somewhere"  # Makefile overrides seed
+    assert mk.get("LOCALBASE") == "/usr/local"  # seed default survives
+
+
+def test_makefile_expansion_and_modifiers(tmp_path):
+    mk = make_mk(
+        tmp_path,
+        "PORTNAME=\tfoo\nPORTVERSION=\t1.2\nDISTNAME=\t${PORTNAME}-${PORTVERSION}\nWRKSRC=\t/w/${DISTNAME}/src\n",
+    )
+    assert mk.get("DISTNAME") == "foo-1.2"
+    assert mk.get("WRKSRC") == "/w/foo-1.2/src"
+    # :H (dirname) and :T (basename) modifiers
+    mk2 = make_mk(tmp_path, "P=\t/a/b/c\nH=\t${P:H}\nT=\t${P:T}\n")
+    assert mk2.get("H") == "/a/b"
+    assert mk2.get("T") == "c"
+
+
+def test_makefile_comment_stripping(tmp_path):
+    mk = make_mk(tmp_path, "DISTFILES=\t# empty\nX=\tvalue # trailing\n")
+    assert mk.get("DISTFILES") == ""
+    assert mk.get("X") == "value"
+
+
+def test_makefile_line_continuation_and_recipe_capture(tmp_path):
+    mk = make_mk(
+        tmp_path,
+        "RUN_DEPENDS=\ta:cat/a \\\n\t\tb:cat/b\n"
+        "do-install:\n"
+        "\t${MKDIR} ${STAGEDIR}/x\n"
+        "\t${INSTALL_DATA} a b\n"
+        ".include <bsd.port.mk>\n",
+        seed={"STAGEDIR": "/stage"},
+    )
+    assert mk.get("RUN_DEPENDS") == "a:cat/a b:cat/b"
+    assert "do-install" in mk.recipes
+    assert mk.recipes["do-install"] == ["${MKDIR} ${STAGEDIR}/x", "${INSTALL_DATA} a b"]
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "ver,rev,epoch,expected",
+    [("1.0", "", "", "1.0"), ("1.0", "2", "", "1.0_2"), ("1.0", "0", "", "1.0"), ("1.0", "2", "3", "1.0_2,3")],
+)
+def test_compute_pkgversion(tmp_path, ver, rev, epoch, expected):
+    text = f"PORTVERSION=\t{ver}\n"
+    if rev:
+        text += f"PORTREVISION=\t{rev}\n"
+    if epoch:
+        text += f"PORTEPOCH=\t{epoch}\n"
+    mk = make_mk(tmp_path, text, seed={"PORTREVISION": "0", "PORTEPOCH": "0"})
+    assert bpp.compute_pkgversion(mk) == expected
+
+
+@pytest.mark.parametrize(
+    "abi,arch",
+    [
+        ("FreeBSD:15:amd64", "freebsd:15:x86:64"),
+        ("FreeBSD:16:amd64", "freebsd:16:x86:64"),
+        ("FreeBSD:14:aarch64", "freebsd:14:aarch64:64"),
+        ("FreeBSD:13:i386", "freebsd:13:x86:32"),
+    ],
+)
+def test_abi_to_arch(abi, arch):
+    assert bpp.abi_to_arch(abi) == arch
+
+
+def test_abi_to_arch_malformed():
+    with pytest.raises(bpp.BuildError):
+        bpp.abi_to_arch("nonsense")
+
+
+def test_parse_descr_keeps_www_line_verbatim():
+    descr = "Line one.\nLine two.\n\nWWW: https://example.org/p\n"
+    desc, www = bpp.parse_descr(descr)
+    assert www == "https://example.org/p"
+    # desc is the whole file (incl. the WWW line), trailing whitespace trimmed.
+    assert desc == "Line one.\nLine two.\n\nWWW: https://example.org/p"
+
+
+def test_resolve_www_precedence(tmp_path):
+    explicit = make_mk(tmp_path, "WWW=\thttps://explicit/\n")
+    assert bpp.resolve_www(explicit, "https://descr/") == "https://explicit/"
+
+    gh = make_mk(tmp_path, "USE_GITHUB=\tyes\nGH_ACCOUNT=\tacc\nGH_PROJECT=\tProj\n")
+    assert bpp.resolve_www(gh, "https://descr/") == "https://github.com/acc/Proj/"
+
+    plain = make_mk(tmp_path, "PORTNAME=\tx\n")
+    assert bpp.resolve_www(plain, "https://descr/") == "https://descr/"
+
+
+def test_parse_plist_files_dirs_and_datadir():
+    plist = "/etc/inc/priv/x.inc\nbin/y.sh\n%%DATADIR%%/info.xml\n@dir /etc/inc/priv\n@dir /etc/inc\n"
+    sub = {"DATADIR": "share/portx"}
+    files, dirs = bpp.parse_plist(plist, sub, "/usr/local")
+    assert files == ["/etc/inc/priv/x.inc", "/usr/local/bin/y.sh", "/usr/local/share/portx/info.xml"]
+    assert dirs == ["/etc/inc/priv", "/etc/inc"]
+
+
+def test_parse_plist_unresolved_token_raises():
+    with pytest.raises(bpp.BuildError):
+        bpp.parse_plist("%%NOPE%%/x\n", {}, "/usr/local")
+
+
+def test_parse_plist_unknown_keyword_warns(capsys):
+    files, dirs = bpp.parse_plist("@sample foo.conf.sample\nbin/x\n", {}, "/usr/local")
+    assert files == ["/usr/local/bin/x"]
+    assert dirs == []
+    assert "@sample" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "expr,text,expected",
+    [
+        ("s|A|B|", "A A\nA", "B A\nB"),  # first per line (no g)
+        ("s|A|B|g", "A A\nA", "B B\nB"),  # all (g)
+        ("s/x/y/", "x", "y"),  # slash delimiter
+    ],
+)
+def test_sed_s(expr, text, expected):
+    r = bpp.Recipe.__new__(bpp.Recipe)
+    assert r._sed_s(text, expr) == expected
+
+
+def test_sed_s_unsupported():
+    r = bpp.Recipe.__new__(bpp.Recipe)
+    with pytest.raises(bpp.BuildError):
+        r._sed_s("text", "y|a|b|")  # only the s command is supported
+
+
+# --------------------------------------------------------------------------- #
+# Recipe interpreter (modes, mv, sed) on a synthetic source tree
+# --------------------------------------------------------------------------- #
+
+
+def test_recipe_install_modes_mv_sed(tmp_path):
+    src = tmp_path / "src"
+    (src).mkdir()
+    (src / "data.txt").write_text("data")
+    (src / "script.sh").write_text("#!/bin/sh\necho hi\n")
+    (src / "tpl.xml").write_text("v=%%PKGVERSION%%\n")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+
+    text = (
+        f"SRC=\t{src}\nSTAGEDIR=\t{stage}\nPREFIX=\t/usr/local\nPKGVERSION=\t9.9\n"
+        "do-install:\n"
+        "\t${MKDIR} ${STAGEDIR}${PREFIX}/bin\n"
+        "\t${MKDIR} ${STAGEDIR}${PREFIX}/etc\n"
+        "\t${INSTALL_DATA} ${SRC}/data.txt ${STAGEDIR}${PREFIX}/etc\n"
+        "\t${INSTALL_SCRIPT} ${SRC}/script.sh ${STAGEDIR}${PREFIX}/bin\n"
+        "\t${INSTALL_DATA} ${SRC}/tpl.xml ${STAGEDIR}${PREFIX}/etc\n"
+        "\t@${REINPLACE_CMD} -i '' -e \"s|%%PKGVERSION%%|${PKGVERSION}|\" ${STAGEDIR}${PREFIX}/etc/tpl.xml\n"
+    )
+    mk = make_mk(tmp_path, text)
+    r = bpp.Recipe(mk)
+    r.run("do-install")
+
+    assert (stage / "usr/local/etc/data.txt").read_text() == "data"
+    assert r.modes["/usr/local/etc/data.txt"] == "0644"
+    assert r.modes["/usr/local/bin/script.sh"] == "0555"  # INSTALL_SCRIPT == BINMODE 0555
+    assert (stage / "usr/local/etc/tpl.xml").read_text() == "v=9.9\n"  # reinplace applied to staged file
+
+
+def test_recipe_bare_mv_and_unknown_command(tmp_path):
+    src = tmp_path / "w"
+    (src / "a").mkdir(parents=True)
+    (src / "a" / "f").write_text("x")
+    mk = make_mk(
+        tmp_path,
+        f"WRKSRC=\t{src}\npost-extract:\n\t@mv ${{WRKSRC}}/a ${{WRKSRC}}/b\n",
+    )
+    bpp.Recipe(mk).run("post-extract")
+    assert (src / "b" / "f").read_text() == "x"
+
+    bad = make_mk(tmp_path, "do-install:\n\t${FROBNICATE} a b\n")
+    with pytest.raises(bpp.BuildError, match="unsupported recipe command"):
+        bpp.Recipe(bad).run("do-install")
+
+
+# --------------------------------------------------------------------------- #
+# Dependency resolution (synthetic ports tree)
+# --------------------------------------------------------------------------- #
+
+
+def write_port(ports: Path, origin: str, body: str) -> None:
+    d = ports / origin
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "Makefile").write_text(body)
+
+
+def test_read_dep_port_flavor(tmp_path):
+    ports = tmp_path / "ports"
+    write_port(
+        ports,
+        "net/rsync",
+        "PORTNAME=\trsync\nPORTVERSION=\t3.4.1\nPORTREVISION=\t6\n"
+        "FLAVORS=\tdefault python\npython_PKGNAMESUFFIX=\t-python\n",
+    )
+    seed = {"PORTREVISION": "0", "PORTEPOCH": "0"}
+    mkf = ports / "net/rsync/Makefile"
+    assert bpp._read_dep_port(mkf, "", seed) == ("rsync", "3.4.1_6")  # default flavor
+    assert bpp._read_dep_port(mkf, "python", seed) == ("rsync-python", "3.4.1_6")
+    assert bpp._read_dep_port(mkf, "default", seed) == ("rsync", "3.4.1_6")
+
+
+def test_resolve_deps_name_and_file_forms(tmp_path):
+    ports = tmp_path / "ports"
+    write_port(ports, "textproc/gnugrep", "PORTNAME=\tgrep\nPKGNAMEPREFIX=\tgnu\nPORTVERSION=\t3.12\n")
+    write_port(ports, "databases/py-sqlite3", "PORTNAME=\tsqlite3\nPKGNAMEPREFIX=\t${PYTHON_PKGNAMEPREFIX}\n")
+    seed = {
+        "LOCALBASE": "/usr/local",
+        "PYTHON_PKGNAMEPREFIX": "py311-",
+        "PY_FLAVOR": "py311",
+        "PORTREVISION": "0",
+        "PORTEPOCH": "0",
+    }
+    mk = make_mk(
+        tmp_path,
+        "RUN_DEPENDS=\t${LOCALBASE}/bin/ggrep:textproc/gnugrep \\\n"
+        "\t\t${PYTHON_PKGNAMEPREFIX}sqlite3>0:databases/py-sqlite3@${PY_FLAVOR}\n",
+        seed=seed,
+    )
+    deps = {d.name: d for d in bpp.resolve_deps(mk, ports, seed)}
+    assert deps["gnugrep"].origin == "textproc/gnugrep"
+    assert deps["gnugrep"].version == "3.12"  # file-form name resolved via ports tree
+    assert "py311-sqlite3" in deps  # name-form (left side) wins
+    assert deps["py311-sqlite3"].origin == "databases/py-sqlite3"
+
+
+def test_synthesize_uses_deps(tmp_path):
+    ports = tmp_path / "ports"
+    write_port(ports, "lang/php83", "PORTNAME=\tphp83\nPORTVERSION=\t8.3.30\n")
+    write_port(ports, "devel/php83-intl", "PORTNAME=\tphp83-intl\n")  # version inherited; falls back to php base
+    write_port(ports, "lang/python311", "PORTNAME=\tpython311\nPORTVERSION=\t3.11.15\n")
+    seed = {"PORTREVISION": "0", "PORTEPOCH": "0"}
+    mk = make_mk(tmp_path, "USES=\tphp python\nUSE_PHP=\tintl\n", seed=seed)
+    deps = {d.name: d for d in bpp.synthesize_uses_deps(mk, ports, "8.3", "py311", seed)}
+    assert deps["php83"].origin == "lang/php83"
+    assert deps["php83"].version == "8.3.30"
+    assert deps["php83-intl"].origin == "devel/php83-intl"  # origin found by globbing the tree
+    assert deps["php83-intl"].version == "8.3.30"  # falls back to the php base version
+    assert deps["python311"].origin == "lang/python311"
+
+
+# --------------------------------------------------------------------------- #
+# Repo catalogue
+# --------------------------------------------------------------------------- #
+
+_CATALOGUE = (
+    '{"name":"rsync","origin":"net/rsync","version":"3.4.3"}\n'
+    '{"name":"jq","origin":"textproc/jq","version":"1.8.1"}\n'
+    '{"name":"other","origin":"x/other","version":"9"}\n'
+)
+
+
+def test_load_catalogue_plain_yaml(tmp_path):
+    f = tmp_path / "packagesite.yaml"
+    f.write_text(_CATALOGUE)
+    cat = bpp.load_catalogue(str(f), "FreeBSD:15:amd64", {"rsync", "jq"})
+    assert cat == {"rsync": ("net/rsync", "3.4.3"), "jq": ("textproc/jq", "1.8.1")}
+
+
+def test_load_catalogue_gzipped_tar(tmp_path):
+    # A packagesite.pkg-like archive: a gzip-compressed tar holding packagesite.yaml
+    # (gzip via stdlib, so no zstd needed in the test environment).
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        data = _CATALOGUE.encode()
+        ti = tarfile.TarInfo("packagesite.yaml")
+        ti.size = len(data)
+        tf.addfile(ti, io.BytesIO(data))
+    archive = tmp_path / "packagesite.pkg"
+    archive.write_bytes(gzip.compress(buf.getvalue()))
+    cat = bpp.load_catalogue(str(archive), "FreeBSD:15:amd64", {"rsync"})
+    assert cat["rsync"] == ("net/rsync", "3.4.3")
+
+
+def test_apply_repo_catalogue_overrides_versions(tmp_path, capsys):
+    f = tmp_path / "packagesite.yaml"
+    f.write_text(_CATALOGUE)
+    deps = [bpp.Dep("rsync", "net/rsync", "0"), bpp.Dep("missing", "x/missing", "1.0")]
+    bpp.apply_repo_catalogue(deps, str(f), "FreeBSD:15:amd64")
+    by_name = {d.name: d for d in deps}
+    assert by_name["rsync"].version == "3.4.3"
+    assert by_name["missing"].version == "1.0"  # kept; warned
+    assert "not in repo catalogue" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: build a real .pkg from a synthetic classic port, then inspect it
+# --------------------------------------------------------------------------- #
+
+
+def _make_classic_port(tmp_path: Path) -> tuple[Path, Path]:
+    """A minimal classic (embedded-files) port + a one-entry ports tree."""
+    ports = tmp_path / "ports"
+    portdir = ports / "net" / "testpkg"
+    files = portdir / "files"
+    # embedded source tree (mirrors the install filesystem under files/)
+    (files / "etc/inc/priv").mkdir(parents=True)
+    (files / "etc/inc/priv/test.priv.inc").write_text("<?php // priv\n")
+    (files / "usr/local/bin").mkdir(parents=True)
+    (files / "usr/local/bin/hello.sh").write_text("#!/bin/sh\necho hi\n")
+    (files / "usr/local/etc").mkdir(parents=True)
+    (files / "usr/local/etc/testpkg.conf").write_text("key = value\n")
+    (files / "usr/local/share/testpkg").mkdir(parents=True)
+    (files / "usr/local/share/testpkg/info.xml").write_text("<version>%%PKGVERSION%%</version>\n")
+    # SUB_FILES install scripts
+    (files / "pkg-install.in").write_text(
+        '#!/bin/sh\nif [ "${2}" != "POST-INSTALL" ]; then\n\texit 0\nfi\n'
+        "/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}\n"
+    )
+    (files / "pkg-deinstall.in").write_text("#!/bin/sh\n/usr/local/bin/php -f /etc/rc.packages %%PORTNAME%% ${2}\n")
+
+    portdir.joinpath("pkg-descr").write_text("A tiny test port.\n\nWWW: https://example.org/testpkg\n")
+    portdir.joinpath("pkg-plist").write_text(
+        "/etc/inc/priv/test.priv.inc\n"
+        "bin/hello.sh\n"
+        "etc/testpkg.conf\n"
+        "%%DATADIR%%/info.xml\n"
+        "@dir /etc/inc/priv\n"
+        "@dir /etc/inc\n"
+    )
+    portdir.joinpath("Makefile").write_text(
+        "PORTNAME=\ttestpkg\nPORTVERSION=\t1.0\nPORTREVISION=\t2\nCATEGORIES=\tnet\n"
+        "MAINTAINER=\tdev@example.org\nCOMMENT=\tTest port\nLICENSE=\tAPACHE20\n"
+        "RUN_DEPENDS=\t${LOCALBASE}/bin/foo:misc/foo\n"
+        "NO_BUILD=\tyes\nSUB_FILES=\tpkg-install pkg-deinstall\nSUB_LIST=\tPORTNAME=${PORTNAME}\n"
+        "do-extract:\n\t${MKDIR} ${WRKSRC}\n"
+        "do-install:\n"
+        "\t${MKDIR} ${STAGEDIR}/etc/inc/priv\n"
+        "\t${MKDIR} ${STAGEDIR}${PREFIX}/bin\n"
+        "\t${MKDIR} ${STAGEDIR}${PREFIX}/etc\n"
+        "\t${MKDIR} ${STAGEDIR}${DATADIR}\n"
+        "\t${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/test.priv.inc ${STAGEDIR}/etc/inc/priv\n"
+        "\t${INSTALL_SCRIPT} ${FILESDIR}${PREFIX}/bin/hello.sh ${STAGEDIR}${PREFIX}/bin\n"
+        "\t${INSTALL_DATA} ${FILESDIR}${PREFIX}/etc/testpkg.conf ${STAGEDIR}${PREFIX}/etc\n"
+        "\t${INSTALL_DATA} ${FILESDIR}${DATADIR}/info.xml ${STAGEDIR}${DATADIR}\n"
+        "\t@${REINPLACE_CMD} -i '' -e \"s|%%PKGVERSION%%|${PKGVERSION}|\" ${STAGEDIR}${DATADIR}/info.xml\n"
+        ".include <bsd.port.mk>\n"
+    )
+    write_port(ports, "misc/foo", "PORTNAME=\tfoo\nPORTVERSION=\t1.2\nPORTREVISION=\t3\n")
+    return ports, portdir
+
+
+def _read_pkg(path: Path) -> tuple[dict, dict, tarfile.TarFile]:
+    raw = lzma.decompress(path.read_bytes())  # built with --compression xz (stdlib)
+    tf = tarfile.open(fileobj=io.BytesIO(raw))
+    full = json.loads(tf.extractfile("+MANIFEST").read())
+    compact = json.loads(tf.extractfile("+COMPACT_MANIFEST").read())
+    return full, compact, tf
+
+
+def test_end_to_end_classic_build(tmp_path):
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports",
+            str(ports),
+            "--port-dir",
+            str(portdir),
+            "--abi",
+            "FreeBSD:15:amd64",
+            "--py-flavor",
+            "py311",
+            "--compression",
+            "xz",
+            "--freebsd-version",
+            "1500068",
+            "--out",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    pkg = out / "testpkg-1.0_2.pkg"
+    assert pkg.is_file()
+
+    full, compact, tf = _read_pkg(pkg)
+    names = tf.getnames()
+    # archive layout
+    assert names[:2] == ["+COMPACT_MANIFEST", "+MANIFEST"]
+    assert all(n.startswith("/") for n in names[2:])
+    # metadata
+    assert full["name"] == "testpkg"
+    assert full["version"] == "1.0_2"
+    assert full["origin"] == "net/testpkg"
+    assert full["www"] == "https://example.org/testpkg"  # classic -> pkg-descr WWW line
+    assert full["desc"].endswith("WWW: https://example.org/testpkg")  # verbatim
+    assert full["abi"] == "FreeBSD:15:amd64" and full["arch"] == "freebsd:15:x86:64"
+    assert full["licenselogic"] == "single" and full["licenses"] == ["APACHE20"]
+    assert full["annotations"] == {"FreeBSD_version": "1500068"}
+    assert "files" not in compact and "scripts" not in compact  # compact is metadata-only
+    # files + perms
+    perms = {p: e["perm"] for p, e in full["files"].items()}
+    assert perms["/usr/local/bin/hello.sh"] == "0555"  # INSTALL_SCRIPT
+    assert perms["/usr/local/etc/testpkg.conf"] == "0644"  # INSTALL_DATA
+    assert perms["/usr/local/share/testpkg/info.xml"] == "0644"
+    assert set(perms) == set(p for p in names if not p.startswith("+"))
+    for p, e in full["files"].items():
+        assert e["sum"].startswith("1$") and e["uname"] == "root" and e["gname"] == "wheel"
+    # directories from @dir
+    assert set(full["directories"]) == {"/etc/inc/priv", "/etc/inc"}
+    # scripts: install/deinstall, %%PORTNAME%% substituted, trailing newline stripped
+    assert set(full["scripts"]) == {"install", "deinstall"}
+    assert "testpkg" in full["scripts"]["install"]
+    assert not full["scripts"]["install"].endswith("\n")
+    # dep resolved + PKGVERSION-with-revision from the ports tree
+    assert full["deps"] == {"foo": {"origin": "misc/foo", "version": "1.2_3"}}
+    # info.xml %%PKGVERSION%% substituted in the staged payload
+    info = tf.extractfile("/usr/local/share/testpkg/info.xml").read().decode()
+    assert info == "<version>1.0_2</version>\n"
+
+
+def test_end_to_end_plist_drift_aborts(tmp_path):
+    ports, portdir = _make_classic_port(tmp_path)
+    # Add a plist entry with no corresponding staged file -> must abort.
+    plist = portdir / "pkg-plist"
+    plist.write_text(plist.read_text() + "bin/ghost\n")
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports",
+            str(ports),
+            "--port-dir",
+            str(portdir),
+            "--abi",
+            "FreeBSD:15:amd64",
+            "--py-flavor",
+            "py311",
+            "--compression",
+            "xz",
+            "--out",
+            str(out),
+        ]
+    )
+    assert rc == 1
+    assert not list(out.glob("*.pkg")) if out.exists() else True


### PR DESCRIPTION
## What

`scripts/build-pkg-portable.py` — builds a pfSense-installable FreeBSD `.pkg` for the pfBlockerNG port **on Linux/macOS, with no FreeBSD host**. Off-box counterpart to `scripts/build-pkg.sh` (which runs the real `make package` on a FreeBSD VM), exploiting pfBlockerNG being a `NO_BUILD` port.

## How

A small FreeBSD-ports Makefile-variable evaluator + recipe interpreter that **executes the port's own `do-extract`/`post-extract`/`do-install`** (MKDIR/INSTALL_DATA/INSTALL_SCRIPT/REINPLACE_CMD/SED/MV) and reads `pkg-plist` — so it tracks new files and dependency changes automatically rather than hardcoding pfBlockerNG's layout. Unknown recipe command → hard error (drift signal). Emits a real libpkg archive (zstd, or `--compression xz`).

Handles **both** ports layouts: `USE_GITHUB` (source fetched from GitHub; `--local-src` to build a working tree instead) and the classic embedded-`files/` layout. Dependencies = the 9 `RUN_DEPENDS`/`LIB_DEPENDS` **plus** the ones `USES` injects (`php83`, `php83-intl`, `python311`), flavor-aware (`net/rsync` default → `rsync`, `@python` → `rsync-python`).

## Validated against real `make package`

Diffed field-by-field against a real CI `make package` build at the **same commit**: scalar metadata (name/version/www/desc/flatsize/annotations/…), all 66 files' sha256 + perms (`INSTALL_DATA` 0644, `INSTALL_SCRIPT` **0555**), directories, `install`/`deinstall` scripts, and the full 12-dep set (names + origins) **all match**. The only differences are the two values not derivable from the port files:

- file `mtime` (the install clock — non-reproducible across builds);
- a few dep **versions** that `make package` reads from the build host's installed binary packages — `--repo-catalogue` (path/URL/`auto`) pins those from a repo `packagesite`.

## Notes

- Version-dependent **target** facts (ABI, Python flavor, PHP version) are passed in or **asked** — never derived from the `--ports` fork tree, whose `*_DEFAULT`s can differ from the target (CE 2.8 = PHP 8.3 though the tree defaults to 8.4). See `docs/misc/pfSense_versions.md`.
- Dev-only tool; release archives still contain only `src/`.
- Requires python3 (stdlib) + a zstd encoder (`zstd`/`brew install zstd`/`apt install zstd`).

Linear history: please **rebase/FF-merge** (this branch is `next` + one commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capability to build installable system packages on Linux and macOS, eliminating the need for a FreeBSD environment.

* **Documentation**
  * Added extensive guides covering package generation configuration, examples, and troubleshooting.
  * Added pfSense version and runtime dependency reference documentation.
  * Updated build instructions with new packaging method details.

* **Tests**
  * Added comprehensive test suite for package generation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->