### PR TITLE
pfblockerng: account for query type in DNSBL reporting (#44)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1250,15 +1250,24 @@ def get_details_dnsbl(
         if pfb["sqlite3_dnsbl_con"] and isDNSBL["group"] != "":
             pfb_db_enqueue(("dnsbl", isDNSBL["group"]))
 
+        # Query type (A/AAAA/ANY/...). The cached decision in isDNSBL is
+        # qtype-independent, so fold q_type into both the consecutive-dedup
+        # signature and the log line. Without it a client's back-to-back A+AAAA
+        # blocks of the same name compare equal -> the second is marked a
+        # duplicate (dual-stack under-count) and Reports cannot break down by
+        # record type. The decision path stays qtype-correct and untouched.
+        q_type = get_q_type(qstate, qinfo)
+
         dupEntry = "+"
+        event_sig = (q_type, isDNSBL)
         lastEvent = dnsblDB.get("last-event")
         if lastEvent is not None:
-            if str(lastEvent) == str(isDNSBL):
+            if str(lastEvent) == str(event_sig):
                 dupEntry = "-"
             else:
-                dnsblDB["last-event"] = isDNSBL
+                dnsblDB["last-event"] = event_sig
         else:
-            dnsblDB["last-event"] = isDNSBL
+            dnsblDB["last-event"] = event_sig
 
         # Skip logging
         if isDNSBL["log"] == "2":
@@ -1283,6 +1292,7 @@ def get_details_dnsbl(
                 isDNSBL["b_eval"],
                 isDNSBL["feed"],
                 dupEntry,
+                q_type,
             )
         )
         pfb_log("/var/log/pfblockerng/dnsbl.log", csv_line)

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2119,6 +2119,7 @@ function convert_dnsbl_log($mode, $fields) {
 		[7]	= Evaluated Domain/TLD
 		[8]	= Feed Name
 		[9]	= Duplicate ID indicator / Count
+		[10]	= Query Type - Python mode only: 'A', 'AAAA', 'ANY', ... (absent on older/Unbound-mode lines, where A/AAAA is carried in the b_type suffix [5])
 
 	pfbalertdnsbl fields array reference (Used for filter functionality)
 
@@ -2301,14 +2302,24 @@ function convert_dnsbl_log($mode, $fields) {
 	$pfbalertdnsbl[13]	= "{$p_group}{$fields[6]}";
 	$pfbalertdnsbl[15]	= "{$p_feed}{$fields[8]}";
 
+	// Query type suffix (Python mode logs the record type as field [10]; older
+	// Unbound-mode lines carry it in the b_type suffix [5] and lack field [10]).
+	$qtype_sfx = '';
+	if (isset($fields[10])) {
+		$qtype = trim($fields[10]);
+		if ($qtype != '' && $qtype != 'Unknown') {
+			$qtype_sfx = " | {$qtype}";
+		}
+	}
+
 	if (!empty($fields[4])) {
 		if (strlen($fields[4]) >= 25) {
 			$f4 = substr($fields[4], 0, 24) . "<small>...</small>";
 			$fields[4] = "<span title=\"{$fields[4]}\">{$f4}</span>";
 		}
-		$pfbalertdnsbl[19] = "{$fields[0]} | {$fields[4]}";
+		$pfbalertdnsbl[19] = "{$fields[0]} | {$fields[4]}{$qtype_sfx}";
 	} else {
-		$pfbalertdnsbl[19] = "{$fields[0]}";
+		$pfbalertdnsbl[19] = "{$fields[0]}{$qtype_sfx}";
 	}
 
 	if (!empty($p_mode)) {

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -593,6 +593,74 @@ class TestGetQType:
         assert pfb_unbound.get_q_type(qstate, qinfo) == "Unknown"
 
 
+class TestGetDetailsDnsblQtype:
+    """Issue #44: DNSBL reporting must account for query type. The cached decision
+    in dnsblDB is qtype-independent, so q_type is folded into the consecutive-dedup
+    signature and appended as the trailing dnsbl.log field. Two same-name blocks
+    that differ only by record type (a client's A+AAAA pair) must each count, and
+    the log must record which record type was blocked."""
+
+    DECISION = {
+        "qname": "blocked.com",
+        "b_type": "DNSBL_Python",
+        "p_type": "Python",
+        "null": False,
+        "log": "1",
+        "feed": "feedX",
+        "group": "groupY",
+        "b_eval": "blocked.com",
+    }
+
+    def _qstate(self, qtype):
+        return types.SimpleNamespace(
+            qinfo=types.SimpleNamespace(qname_str="blocked.com.", qtype_str=qtype),
+            return_msg=None,
+        )
+
+    def _prep(self, monkeypatch):
+        monkeypatch.setitem(pfb_unbound.pfb, "python_nolog", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_resolver_con", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_dnsbl_con", False)
+        monkeypatch.setattr(pfb_unbound, "dnsblDB", {"blocked.com": dict(self.DECISION)})
+        lines = []
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: lines.append((path, line)))
+        return lines
+
+    def _block(self, qtype):
+        pfb_unbound.get_details_dnsbl("dnsbl", None, self._qstate(qtype), None, {"pfb_addr": "1.2.3.4"})
+
+    @staticmethod
+    def _dnsbl_fields(lines):
+        # get_details_dnsbl writes the same csv_line to dnsbl.log and unified.log.
+        return [line.split(",") for path, line in lines if path.endswith("dnsbl.log")]
+
+    def test_qtype_is_trailing_log_field(self, monkeypatch):
+        lines = self._prep(monkeypatch)
+        self._block("AAAA")
+        (fields,) = self._dnsbl_fields(lines)
+        assert fields[0] == "DNSBL-python"
+        assert fields[10] == "AAAA"  # query type appended after dupEntry
+
+    def test_dual_stack_pair_both_count(self, monkeypatch):
+        # A then AAAA for the SAME name: the old qtype-blind dedup collapsed the
+        # AAAA into a duplicate of the A. Now both are non-duplicate ("+").
+        lines = self._prep(monkeypatch)
+        self._block("A")
+        self._block("AAAA")
+        a_fields, aaaa_fields = self._dnsbl_fields(lines)
+        assert (a_fields[9], a_fields[10]) == ("+", "A")
+        assert (aaaa_fields[9], aaaa_fields[10]) == ("+", "AAAA")
+
+    def test_same_qtype_repeat_is_duplicate(self, monkeypatch):
+        # A true consecutive repeat (same name AND same record type) still dedups.
+        lines = self._prep(monkeypatch)
+        self._block("AAAA")
+        self._block("AAAA")
+        first, second = self._dnsbl_fields(lines)
+        assert first[9] == "+"
+        assert second[9] == "-"
+
+
 class TestGetOType:
     def test_return_msg_rrset_branch(self):
         rk = types.SimpleNamespace(type_str="A")

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -4,6 +4,8 @@ import re
 import types
 from collections import defaultdict
 
+import pytest
+
 import pfb_unbound
 
 # Unbound injects these as module-level globals at runtime; conftest stubs them
@@ -611,37 +613,37 @@ class TestGetDetailsDnsblQtype:
         "b_eval": "blocked.com",
     }
 
-    def _qstate(self, qtype):
+    def _qstate(self, qtype: str) -> types.SimpleNamespace:
         return types.SimpleNamespace(
             qinfo=types.SimpleNamespace(qname_str="blocked.com.", qtype_str=qtype),
             return_msg=None,
         )
 
-    def _prep(self, monkeypatch):
+    def _prep(self, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
         monkeypatch.setitem(pfb_unbound.pfb, "python_nolog", False)
         monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_resolver_con", False)
         monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_dnsbl_con", False)
         monkeypatch.setattr(pfb_unbound, "dnsblDB", {"blocked.com": dict(self.DECISION)})
-        lines = []
+        lines: list[tuple[str, str]] = []
         monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: lines.append((path, line)))
         return lines
 
-    def _block(self, qtype):
+    def _block(self, qtype: str) -> None:
         pfb_unbound.get_details_dnsbl("dnsbl", None, self._qstate(qtype), None, {"pfb_addr": "1.2.3.4"})
 
     @staticmethod
-    def _dnsbl_fields(lines):
+    def _dnsbl_fields(lines: list[tuple[str, str]]) -> list[list[str]]:
         # get_details_dnsbl writes the same csv_line to dnsbl.log and unified.log.
         return [line.split(",") for path, line in lines if path.endswith("dnsbl.log")]
 
-    def test_qtype_is_trailing_log_field(self, monkeypatch):
+    def test_qtype_is_trailing_log_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
         lines = self._prep(monkeypatch)
         self._block("AAAA")
         (fields,) = self._dnsbl_fields(lines)
         assert fields[0] == "DNSBL-python"
         assert fields[10] == "AAAA"  # query type appended after dupEntry
 
-    def test_dual_stack_pair_both_count(self, monkeypatch):
+    def test_dual_stack_pair_both_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # A then AAAA for the SAME name: the old qtype-blind dedup collapsed the
         # AAAA into a duplicate of the A. Now both are non-duplicate ("+").
         lines = self._prep(monkeypatch)
@@ -651,7 +653,7 @@ class TestGetDetailsDnsblQtype:
         assert (a_fields[9], a_fields[10]) == ("+", "A")
         assert (aaaa_fields[9], aaaa_fields[10]) == ("+", "AAAA")
 
-    def test_same_qtype_repeat_is_duplicate(self, monkeypatch):
+    def test_same_qtype_repeat_is_duplicate(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # A true consecutive repeat (same name AND same record type) still dedups.
         lines = self._prep(monkeypatch)
         self._block("AAAA")


### PR DESCRIPTION
Fixes #44.

## Background

The DNSBL **decision** path is already query-type-correct here (no Redmine #14853 regression): `dnsblDB` stores only qtype-independent metadata and `operate()` rebuilds the reply per `q_type` (A -> `0.0.0.0`/VIP-v4, AAAA -> `::`/VIP-v6). The residual gap was entirely in **reporting**:

- `dnsblDB` keyed by `q_name` only; `dnsbl.log` carried no query-type field.
- The consecutive-dedup compared `str(isDNSBL)` (qtype-less), so two same-name blocks differing only by record type compared **equal**.

Consequences: a client's back-to-back A+AAAA pair collapsed into one event (**dual-stack under-count**, non-deterministic when another client's block interleaved), and Reports had **no A-vs-AAAA breakdown**.

## Change

Reporting path only — decision path untouched.

**Python (`pfb_unbound.py` `get_details_dnsbl`)**
- Derive `q_type` via the existing `get_q_type()`.
- Fold `q_type` into the consecutive-dedup signature (`event_sig = (q_type, isDNSBL)`) so A and AAAA of the same name each count; a true same-name + same-qtype repeat still dedups.
- Append `q_type` as the trailing `dnsbl.log`/`unified.log` field `[10]`.

**PHP (`pfblockerng_alerts.php` `convert_dnsbl_log`)**
- Document field `[10]` and surface the record type in the DNSBL **Type** column (`DNSBL-python | Python | A`).
- Guarded by `isset()` -> Unbound-mode lines (record type already in the `b_type` suffix) and pre-existing logs are unaffected. The regex filter keeps matching saved type filters and can now filter by `A`/`AAAA`.

**Tests** — new `TestGetDetailsDnsblQtype`: trailing-qtype field, dual-stack both-count, same-qtype dedup.

## Notes

- `dnsblDB` is intentionally **not** re-keyed by `(q_name, q_type)` (the issue's rejected alternative) — that would defeat the cross-qtype decision cache.
- Append-at-end keeps field `[9]` (dupEntry) and all positional parsers (`index.php` uses fields 5-8) intact.
- Broader reporting redesign (aggregated A-vs-AAAA counts, cached-block feed attribution on C-cache hits) stays with #43/#26.

## Verification

`985 passed`; `ruff` + `ruff format --check` + `php -l` + PHPStan clean (pre-commit hooks green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DNSBL alerts now show the queried record type (A, AAAA, etc.) alongside blocking info for clearer context.

* **Bug Fixes**
  * Events with different query types for the same domain are treated and logged separately, avoiding incorrect deduplication.

* **Documentation**
  * Updated field-mapping notes to describe the query-type suffix in DNSBL logs.

* **Tests**
  * Added tests verifying query-type is logged and deduplication behaves correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->