### PR TITLE
test: add PHPUnit unit suite for the pure PHP helpers (#39)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -116,6 +116,12 @@ if [ -x vendor/bin/phpstan ]; then
 	vendor/bin/phpstan analyse --no-progress --memory-limit=1G || failed 'phpstan'
 fi
 
+# --- PHP: PHPUnit (only when the Composer vendor tree is installed) ---
+if [ -x vendor/bin/phpunit ]; then
+	step 'phpunit'
+	vendor/bin/phpunit || failed 'phpunit'
+fi
+
 [ -n "$skipped" ] && printf '[pre-commit] skipped (tool not found):%s\n' "$skipped" >&2
 
 if [ "$fail" != 0 ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,6 +195,35 @@ jobs:
         # suppressed; new errors introduced by future changes will fail CI.
         run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
 
+  php-unit:
+    name: PHPUnit unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          # Target CE 2.8 (PHP 8.3). pcov drives informational coverage.
+          php-version: '8.3'
+          extensions: curl, intl, mbstring, ctype, filter
+          coverage: pcov
+          tools: composer
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run PHPUnit
+        # Config in phpunit.xml. tests/php/bootstrap.php loads the real
+        # pfblockerng.inc via include shims + pfSense doubles — no live box.
+        run: vendor/bin/phpunit
+
+      - name: Coverage (informational)
+        # No enforced floor yet (see issue #39 / #38); text summary only.
+        run: vendor/bin/phpunit --coverage-text || true
+
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-latest
@@ -217,7 +246,7 @@ jobs:
   all-tests-passed:
     name: All tests passed
     if: always()
-    needs: [test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, markdownlint]
+    needs: [test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-unit, markdownlint]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
@@ -248,6 +277,10 @@ jobs:
           fi
           if [ "${{ needs.php-static-analysis.result }}" != "success" ]; then
             echo "PHPStan static analysis failed or was cancelled."
+            exit 1
+          fi
+          if [ "${{ needs.php-unit.result }}" != "success" ]; then
+            echo "PHPUnit unit tests failed or were cancelled."
             exit 1
           fi
           if [ "${{ needs.markdownlint.result }}" != "success" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -215,14 +215,13 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
 
-      - name: Run PHPUnit
+      - name: Run PHPUnit (with coverage)
         # Config in phpunit.xml. tests/php/bootstrap.php loads the real
         # pfblockerng.inc via include shims + pfSense doubles — no live box.
-        run: vendor/bin/phpunit
-
-      - name: Coverage (informational)
-        # No enforced floor yet (see issue #39 / #38); text summary only.
-        run: vendor/bin/phpunit --coverage-text || true
+        # Single run: still gates on test failure AND prints the informational
+        # coverage text (no enforced floor yet — see issue #39 / #38; pcov drives
+        # it). NOT suffixed with `|| true` — that would mask a failing suite.
+        run: vendor/bin/phpunit --coverage-text
 
   markdownlint:
     name: markdownlint

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ venv/
 
 # ── PHP ───────────────────────────────────────────────────────────────────────
 vendor/
+.phpunit.cache/
+.phpunit.result.cache
 
 # ── Shell tests (shellspec / kcov) ────────────────────────────────────────────
 coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,8 +136,14 @@ pfBlockerNG/
 ├── .markdownlint.jsonc    # markdownlint rule set (VS Code extension + markdownlint-cli2)
 ├── .markdownlint-cli2.jsonc  # markdownlint-cli2 globs + ignores
 ├── pyproject.toml         # pytest + ruff + mypy config
+├── phpunit.xml            # PHPUnit config (PHP unit suite; tests/php/)
+├── composer.json          # PHP dev deps: phpstan + phpunit
 └── README.md
 ```
+
+`tests/` holds the Python suite (pytest) plus `tests/php/` — the PHPUnit suite
+for the pure/extractable PHP helpers (bootstrap loads the real `pfblockerng.inc`
+off-appliance via include shims + pfSense doubles; see `tests/php/README.md`).
 
 Release archives contain only `src/`. Everything else (stubs, scripts, tests, CI, pyproject.toml, `.githooks/`) is dev-only.
 
@@ -159,13 +165,14 @@ first.** Have the workflow run `sh scripts/setup-hooks.sh` before its commit/pus
 steps (after checkout) so automated commits go through the same `pre-commit` /
 `pre-push` checks — subject to which tools the runner has installed.
 
-- **`.githooks/pre-commit`** runs the fast linters (and the unit suite) and blocks
+- **`.githooks/pre-commit`** runs the fast linters (and the unit suites) and blocks
   the commit on any failure: `ruff check`/`ruff format --check`, `python -m pytest`,
   `mypy tests/` (the test suite is fully typed — `tests.*` is `disallow_untyped_defs`
   in pyproject.toml; `tests/smoke` is excluded), `markdownlint-cli2`, `sh -n` +
   `shellcheck`, and `php -l`. Each check runs only when its tool is installed (a
-  missing tool is reported and skipped — CI is the hard gate); PHPStan runs only
-  when `vendor/bin/phpstan` exists. Bypass in an emergency with `git commit --no-verify`.
+  missing tool is reported and skipped — CI is the hard gate); PHPStan and PHPUnit
+  run only when `vendor/bin/phpstan` / `vendor/bin/phpunit` exist. Bypass in an
+  emergency with `git commit --no-verify`.
 - **`.githooks/pre-push`** enforces tag naming before pushes reach the remote.
 
 ---
@@ -182,6 +189,24 @@ Run after **any** change to `src/usr/local/pkg/pfblockerng/pfb_unbound.py` or
 `tests/` — in-loop, for fast feedback; don't wait for the commit to find breakage.
 The pre-commit hook re-runs the suite at commit time and CI is the final authority,
 so a separate manual pre-commit run is not needed.
+
+PHP side — the fast PHPUnit suite for the pure/extractable helpers of
+`pfblockerng.inc` (issue #39):
+
+```sh
+composer install      # once — installs phpunit/phpunit into vendor/
+vendor/bin/phpunit     # config in phpunit.xml
+```
+
+It loads the **real** `pfblockerng.inc` off-appliance — `tests/php/bootstrap.php`
+satisfies the file's pfSense `require_once` with empty shims (`tests/php/shims/`)
+and provides behavioural doubles (`tests/php/pfsense_doubles.php`) for the pfSense
+runtime functions; **no production code is moved or modified**. The PHPStan stubs
+in `stubs/pfsense/` are empty-bodied (symbol existence only) so they cannot serve
+as runtime doubles — add a faithful/no-op `function_exists()`-guarded double to
+`pfsense_doubles.php` (and an empty shim if it's a required include) when a tested
+path reaches a new pfSense function. Deep pfSense-runtime integration stays the
+live-VM smoke's job (ADR-04). See `tests/php/README.md`.
 
 DNSBL list preprocessing (parse → normalise → classify data/zone → build dicts +
 feed/group index + `whiteDB`, then emit `pfb_py_count`) lives in `pfb_unbound.py`'s
@@ -285,6 +310,12 @@ Intelephense in VS Code. `.inc` files are PHP — `files.associations` handles t
 Stubs in `stubs/pfsense/` resolve pfSense-provided functions. If Intelephense flags
 a pfSense function as undefined, add it to the appropriate stub file rather than
 expanding the `undefinedFunctions` suppression in `.vscode/settings.json`.
+
+PHPStan (static analysis, `vendor/bin/phpstan`) and PHPUnit (functional unit
+tests, `vendor/bin/phpunit`) are the PHP gates — both pulled by `composer install`
+and enforced in CI (`test.yml`) and the pre-commit hook. See "Running tests" for
+the PHPUnit suite; the `stubs/pfsense/` empty-bodied stubs are for PHPStan, NOT
+runtime test doubles (those live in `tests/php/pfsense_doubles.php`).
 
 ### Shell
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ The repository ships hooks in `.githooks/` — a tracked directory, so they are
 shared and reviewed (the default `.git/hooks` is local-only and cannot be
 committed):
 
-- **`pre-commit`** runs the fast linters and the unit suite (Ruff, pytest,
-  markdownlint, ShellCheck + `sh -n`, shellspec, `php -l`; PHPStan only when
-  `vendor/` is present) and blocks the commit on any failure. A check whose tool is
-  not installed is skipped (CI is the hard gate); bypass with `git commit --no-verify`.
+- **`pre-commit`** runs the fast linters and the unit suites (Ruff, pytest,
+  markdownlint, ShellCheck + `sh -n`, shellspec, `php -l`; PHPStan and PHPUnit
+  only when `vendor/` is present) and blocks the commit on any failure. A check
+  whose tool is not installed is skipped (CI is the hard gate); bypass with
+  `git commit --no-verify`.
 - **`pre-push`** enforces the tag naming convention before anything is pushed:
 
 | Commit reachable from | Required tag form  |
@@ -95,11 +96,28 @@ Actions.
 
 ### Running the test suite locally
 
+Python (the bulk of the suite):
+
 ```sh
 python3 -m pytest
 ```
 
 Test paths and options are configured in `pyproject.toml`; no `cd` is required.
+
+PHP unit tests (PHPUnit) cover the pure/extractable PHP helpers
+(input filtering, IDN/textarea decode, ABP-IP extraction, IPv4 normalisation,
+the Python manifest writer). Install the dev dependencies once, then run:
+
+```sh
+composer install      # pulls phpunit/phpunit into vendor/
+vendor/bin/phpunit     # config in phpunit.xml; no live pfSense needed
+```
+
+The suite loads the **real** `pfblockerng.inc` off-appliance via
+`tests/php/bootstrap.php` (empty shims for the pfSense `require_once` includes
+plus behavioural doubles for the pfSense runtime functions) — see
+[`tests/php/README.md`](tests/php/README.md). Deep pfSense-runtime integration
+stays the live-VM smoke's job (ADR-04).
 
 ### Shell tests (shellspec)
 
@@ -263,6 +281,12 @@ Then run the analysis:
 ```sh
 vendor/bin/phpstan analyse
 ```
+
+The same `composer install` provides [PHPUnit](https://phpunit.de/) for the PHP
+unit suite (`vendor/bin/phpunit`, config in `phpunit.xml`) — the fast functional
+layer beneath the live-VM smoke. See
+[Running the test suite locally](#running-the-test-suite-locally) and
+[`tests/php/README.md`](tests/php/README.md).
 
 #### Shell
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,13 @@
 {
     "require-dev": {
-        "phpstan/phpstan": "^2.0"
+        "phpstan/phpstan": "^2.0",
+        "phpunit/phpunit": "^11.5"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "scripts": {
+        "test": "phpunit",
+        "phpstan": "phpstan analyse --no-progress --memory-limit=1G"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,245 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b58308a8fdaa607107d5b89691af6064",
+    "content-hash": "0f5f76293d0120bd647e0a4f29b0d19f",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
         {
             "name": "phpstan/phpstan",
             "version": "2.2.1",
@@ -70,6 +306,1551 @@
                 }
             ],
             "time": "2026-05-28T14:44:12+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],
@@ -79,5 +1860,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/php/bootstrap.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         failOnRisky="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerErrors="true">
+    <testsuites>
+        <testsuite name="pfBlockerNG PHP unit suite">
+            <directory>tests/php</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <!-- The behavioural target: the core package include. Coverage is
+                 informational for now (no enforced floor — see issue #39 / #38). -->
+            <file>src/usr/local/pkg/pfblockerng/pfblockerng.inc</file>
+        </include>
+    </source>
+</phpunit>

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1115,6 +1115,8 @@ function pfbng_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 
 	if ($mode) {
 		$custom = array();
+	} else {
+		$custom = '';	// string accumulator; '' (not undef) when no lines match
 	}
 
 	$customlist = explode("\r\n", base64_decode($text));
@@ -1248,7 +1250,7 @@ function pfb_logger($log, $logtype) {
 	// Only log timestamp if new
 	if (strpos($log, 'NOW') !== FALSE) {
 		$elog = str_replace('NOW', $now, "{$log}");	// Always report timestamp to errorlog
-		if ($now == $pfb['pnow']) {
+		if ($now == ($pfb['pnow'] ?? '')) {
 			$log = str_replace(' [ NOW ]', '', "{$log}");
 		} else {
 			$log = str_replace('NOW', $now, "{$log}");
@@ -3496,7 +3498,9 @@ function pfblockerng_top1m() {
 function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 	global $pfb;
 
-	list ($subnet, $mask) = explode('/', $ipaddr);
+	$parts	= explode('/', $ipaddr);
+	$subnet	= $parts[0];
+	$mask	= $parts[1] ?? '';	// '' (not undef) when no CIDR -> avoids str_replace(null) below
 	$iparr = explode('.', $subnet);
 
 	foreach ($iparr as $key => $octet) {

--- a/tests/php/AbpExtractIpTest.php
+++ b/tests/php/AbpExtractIpTest.php
@@ -14,28 +14,29 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_dnsbl_abp_extract_ip')]
 final class AbpExtractIpTest extends TestCase
 {
-    public static function provider(): array
-    {
-        return [
-            'abp anchor v4'            => ['||192.0.2.4^', '192.0.2.4'],
-            'abp anchor v4 + options'  => ['||192.0.2.4^$third-party', '192.0.2.4'],
-            'abp anchor v4 no caret'   => ['||192.0.2.4', '192.0.2.4'],
-            'abp anchor v6'            => ['||2001:db8::1^', '2001:db8::1'],
-            'abp anchor domain -> none' => ['||example.com^', ''],
-            'hosts sink + ip target'   => ['0.0.0.0 192.0.2.9', '192.0.2.9'],
-            'hosts tab-delimited'      => ["127.0.0.1\t192.0.2.9", '192.0.2.9'],
-            'hosts domain target -> none' => ['127.0.0.1 example.com', ''],
-            'hosts single ip -> none'  => ['192.0.2.9', ''],
-            'plain domain -> none'     => ['example.com', ''],
-            'empty -> none'            => ['', ''],
-            'whitespace only -> none'  => ['   ', ''],
-            'leading/trailing trim'    => ['  ||192.0.2.4^  ', '192.0.2.4'],
-        ];
-    }
+	public static function provider(): array
+	{
+		return [
+			'abp anchor v4'            => ['||192.0.2.4^', '192.0.2.4'],
+			'abp anchor v4 + options'  => ['||192.0.2.4^$third-party', '192.0.2.4'],
+			'abp anchor v4 no caret'   => ['||192.0.2.4', '192.0.2.4'],
+			'abp anchor v6'            => ['||2001:db8::1^', '2001:db8::1'],
+			'abp anchor domain -> none' => ['||example.com^', ''],
+			'hosts sink + ip target'   => ['0.0.0.0 192.0.2.9', '192.0.2.9'],
+			'hosts v6 sink + ip target' => ['::1 2001:db8::1', '2001:db8::1'],
+			'hosts tab-delimited'      => ["127.0.0.1\t192.0.2.9", '192.0.2.9'],
+			'hosts domain target -> none' => ['127.0.0.1 example.com', ''],
+			'hosts single ip -> none'  => ['192.0.2.9', ''],
+			'plain domain -> none'     => ['example.com', ''],
+			'empty -> none'            => ['', ''],
+			'whitespace only -> none'  => ['   ', ''],
+			'leading/trailing trim'    => ['  ||192.0.2.4^  ', '192.0.2.4'],
+		];
+	}
 
-    #[DataProvider('provider')]
-    public function testExtract(string $line, string $expected): void
-    {
-        $this->assertSame($expected, pfb_dnsbl_abp_extract_ip($line));
-    }
+	#[DataProvider('provider')]
+	public function testExtract(string $line, string $expected): void
+	{
+		$this->assertSame($expected, pfb_dnsbl_abp_extract_ip($line));
+	}
 }

--- a/tests/php/AbpExtractIpTest.php
+++ b/tests/php/AbpExtractIpTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_abp_extract_ip() — ADR-07 P8 extraction of an IP from an ABP network
+ * anchor (||ip^[$opts]) or a hosts line (<sink-ip> <ip>) for the DNSBL-IP
+ * firewall pass. Returns '' when the line carries no IP-valued target.
+ */
+#[CoversFunction('pfb_dnsbl_abp_extract_ip')]
+final class AbpExtractIpTest extends TestCase
+{
+    public static function provider(): array
+    {
+        return [
+            'abp anchor v4'            => ['||192.0.2.4^', '192.0.2.4'],
+            'abp anchor v4 + options'  => ['||192.0.2.4^$third-party', '192.0.2.4'],
+            'abp anchor v4 no caret'   => ['||192.0.2.4', '192.0.2.4'],
+            'abp anchor v6'            => ['||2001:db8::1^', '2001:db8::1'],
+            'abp anchor domain -> none' => ['||example.com^', ''],
+            'hosts sink + ip target'   => ['0.0.0.0 192.0.2.9', '192.0.2.9'],
+            'hosts tab-delimited'      => ["127.0.0.1\t192.0.2.9", '192.0.2.9'],
+            'hosts domain target -> none' => ['127.0.0.1 example.com', ''],
+            'hosts single ip -> none'  => ['192.0.2.9', ''],
+            'plain domain -> none'     => ['example.com', ''],
+            'empty -> none'            => ['', ''],
+            'whitespace only -> none'  => ['   ', ''],
+            'leading/trailing trim'    => ['  ||192.0.2.4^  ', '192.0.2.4'],
+        ];
+    }
+
+    #[DataProvider('provider')]
+    public function testExtract(string $line, string $expected): void
+    {
+        $this->assertSame($expected, pfb_dnsbl_abp_extract_ip($line));
+    }
+}

--- a/tests/php/BootstrapSmokeTest.php
+++ b/tests/php/BootstrapSmokeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Sanity check that the bootstrap loaded the real pfblockerng.inc and its
+ * constants/functions are reachable. If this fails, every other test is moot.
+ */
+final class BootstrapSmokeTest extends TestCase
+{
+    public function testProductionFunctionsAreDefined(): void
+    {
+        foreach ([
+            'pfb_filter',
+            'pfbng_text_area_decode',
+            'pfb_dnsbl_abp_extract_ip',
+            'sanitize_ipaddr',
+            'pfb_validate_domain_labels',
+            'pfb_strtolower',
+            'pfb_unbound_python_sources',
+        ] as $fn) {
+            $this->assertTrue(function_exists($fn), "missing production function {$fn}()");
+        }
+    }
+
+    public function testFilterConstantsAreDefined(): void
+    {
+        $this->assertSame(6, PFB_FILTER_DOMAIN);
+        $this->assertSame(9, PFB_FILTER_IP);
+        $this->assertSame(21, PFB_FILTER_ON_OFF);
+    }
+}

--- a/tests/php/BootstrapSmokeTest.php
+++ b/tests/php/BootstrapSmokeTest.php
@@ -10,25 +10,25 @@ use PHPUnit\Framework\TestCase;
  */
 final class BootstrapSmokeTest extends TestCase
 {
-    public function testProductionFunctionsAreDefined(): void
-    {
-        foreach ([
-            'pfb_filter',
-            'pfbng_text_area_decode',
-            'pfb_dnsbl_abp_extract_ip',
-            'sanitize_ipaddr',
-            'pfb_validate_domain_labels',
-            'pfb_strtolower',
-            'pfb_unbound_python_sources',
-        ] as $fn) {
-            $this->assertTrue(function_exists($fn), "missing production function {$fn}()");
-        }
-    }
+	public function testProductionFunctionsAreDefined(): void
+	{
+		foreach ([
+			'pfb_filter',
+			'pfbng_text_area_decode',
+			'pfb_dnsbl_abp_extract_ip',
+			'sanitize_ipaddr',
+			'pfb_validate_domain_labels',
+			'pfb_strtolower',
+			'pfb_unbound_python_sources',
+		] as $fn) {
+			$this->assertTrue(function_exists($fn), "missing production function {$fn}()");
+		}
+	}
 
-    public function testFilterConstantsAreDefined(): void
-    {
-        $this->assertSame(6, PFB_FILTER_DOMAIN);
-        $this->assertSame(9, PFB_FILTER_IP);
-        $this->assertSame(21, PFB_FILTER_ON_OFF);
-    }
+	public function testFilterConstantsAreDefined(): void
+	{
+		$this->assertSame(6, PFB_FILTER_DOMAIN);
+		$this->assertSame(9, PFB_FILTER_IP);
+		$this->assertSame(21, PFB_FILTER_ON_OFF);
+	}
 }

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -14,138 +14,138 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_filter')]
 final class PfbFilterTest extends TestCase
 {
-    public static function domainProvider(): array
-    {
-        return [
-            'plain domain'        => ['example.com', 'example.com'],
-            'subdomain'           => ['a.b.example.com', 'a.b.example.com'],
-            'mixed case kept'     => ['Example.Com', 'Example.Com'],
-            'underscore/dash ok'  => ['my_host-1.example.com', 'my_host-1.example.com'],
-            'no dot rejected'     => ['localhost', ''],
-            'double dot rejected' => ['bad..com', ''],
-            'bad char rejected'   => ['ex+ample.com', ''],
-            'space rejected'      => ['ex ample.com', ''],
-        ];
-    }
+	public static function domainProvider(): array
+	{
+		return [
+			'plain domain'        => ['example.com', 'example.com'],
+			'subdomain'           => ['a.b.example.com', 'a.b.example.com'],
+			'mixed case kept'     => ['Example.Com', 'Example.Com'],
+			'underscore/dash ok'  => ['my_host-1.example.com', 'my_host-1.example.com'],
+			'no dot rejected'     => ['localhost', ''],
+			'double dot rejected' => ['bad..com', ''],
+			'bad char rejected'   => ['ex+ample.com', ''],
+			'space rejected'      => ['ex ample.com', ''],
+		];
+	}
 
-    #[DataProvider('domainProvider')]
-    public function testDomainFilter(string $input, string $expected): void
-    {
-        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_DOMAIN));
-    }
+	#[DataProvider('domainProvider')]
+	public function testDomainFilter(string $input, string $expected): void
+	{
+		$this->assertSame($expected, pfb_filter($input, PFB_FILTER_DOMAIN));
+	}
 
-    public function testDomainLabelTooLongRejected(): void
-    {
-        $label = str_repeat('a', 64);
-        $this->assertSame('', pfb_filter("{$label}.com", PFB_FILTER_DOMAIN));
-    }
+	public function testDomainLabelTooLongRejected(): void
+	{
+		$label = str_repeat('a', 64);
+		$this->assertSame('', pfb_filter("{$label}.com", PFB_FILTER_DOMAIN));
+	}
 
-    public static function ipProvider(): array
-    {
-        return [
-            'ipv4'            => ['192.0.2.10', '192.0.2.10'],
-            'ipv6'            => ['2001:db8::1', '2001:db8::1'],
-            'ipv6 loopback'   => ['::1', '::1'],
-            'not an ip'       => ['999.1.1.1', ''],
-            'word'            => ['nope', ''],
-        ];
-    }
+	public static function ipProvider(): array
+	{
+		return [
+			'ipv4'            => ['192.0.2.10', '192.0.2.10'],
+			'ipv6'            => ['2001:db8::1', '2001:db8::1'],
+			'ipv6 loopback'   => ['::1', '::1'],
+			'not an ip'       => ['999.1.1.1', ''],
+			'word'            => ['nope', ''],
+		];
+	}
 
-    #[DataProvider('ipProvider')]
-    public function testIpFilter(string $input, string $expected): void
-    {
-        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_IP));
-    }
+	#[DataProvider('ipProvider')]
+	public function testIpFilter(string $input, string $expected): void
+	{
+		$this->assertSame($expected, pfb_filter($input, PFB_FILTER_IP));
+	}
 
-    public function testIpv4FilterRejectsV6(): void
-    {
-        $this->assertSame('192.0.2.1', pfb_filter('192.0.2.1', PFB_FILTER_IPV4));
-        $this->assertSame('', pfb_filter('2001:db8::1', PFB_FILTER_IPV4));
-    }
+	public function testIpv4FilterRejectsV6(): void
+	{
+		$this->assertSame('192.0.2.1', pfb_filter('192.0.2.1', PFB_FILTER_IPV4));
+		$this->assertSame('', pfb_filter('2001:db8::1', PFB_FILTER_IPV4));
+	}
 
-    public static function wordProvider(): array
-    {
-        return [
-            'alnum + underscore' => ['abc_123', 'abc_123'],
-            'space rejected'     => ['a b', ''],
-            'dot rejected'       => ['a.b', ''],
-            'dash rejected'      => ['a-b', ''],
-        ];
-    }
+	public static function wordProvider(): array
+	{
+		return [
+			'alnum + underscore' => ['abc_123', 'abc_123'],
+			'space rejected'     => ['a b', ''],
+			'dot rejected'       => ['a.b', ''],
+			'dash rejected'      => ['a-b', ''],
+		];
+	}
 
-    #[DataProvider('wordProvider')]
-    public function testWordFilter(string $input, string $expected): void
-    {
-        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_WORD));
-    }
+	#[DataProvider('wordProvider')]
+	public function testWordFilter(string $input, string $expected): void
+	{
+		$this->assertSame($expected, pfb_filter($input, PFB_FILTER_WORD));
+	}
 
-    public static function hexColorProvider(): array
-    {
-        return [
-            'six hex'      => ['#a1b2c3', '#a1b2c3'],
-            'three hex'    => ['#abc', '#abc'],
-            'uppercase'    => ['#ABCDEF', '#ABCDEF'],
-            'literal none' => ['none', 'none'],
-            'missing hash' => ['a1b2c3', ''],
-            'bad hex'      => ['#xyzxyz', ''],
-            'wrong length' => ['#a1b2', ''],
-        ];
-    }
+	public static function hexColorProvider(): array
+	{
+		return [
+			'six hex'      => ['#a1b2c3', '#a1b2c3'],
+			'three hex'    => ['#abc', '#abc'],
+			'uppercase'    => ['#ABCDEF', '#ABCDEF'],
+			'literal none' => ['none', 'none'],
+			'missing hash' => ['a1b2c3', ''],
+			'bad hex'      => ['#xyzxyz', ''],
+			'wrong length' => ['#a1b2', ''],
+		];
+	}
 
-    #[DataProvider('hexColorProvider')]
-    public function testHexColorFilter(string $input, string $expected): void
-    {
-        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_HEX_COLOR));
-    }
+	#[DataProvider('hexColorProvider')]
+	public function testHexColorFilter(string $input, string $expected): void
+	{
+		$this->assertSame($expected, pfb_filter($input, PFB_FILTER_HEX_COLOR));
+	}
 
-    public static function onOffProvider(): array
-    {
-        return [
-            'on'              => ['on', 'on'],
-            'empty'           => ['', ''],
-            'off -> default'  => ['off', ''],
-            'junk -> default' => ['enabled', ''],
-        ];
-    }
+	public static function onOffProvider(): array
+	{
+		return [
+			'on'              => ['on', 'on'],
+			'empty'           => ['', ''],
+			'off -> default'  => ['off', ''],
+			'junk -> default' => ['enabled', ''],
+		];
+	}
 
-    #[DataProvider('onOffProvider')]
-    public function testOnOffFilter(string $input, string $expected): void
-    {
-        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_ON_OFF));
-    }
+	#[DataProvider('onOffProvider')]
+	public function testOnOffFilter(string $input, string $expected): void
+	{
+		$this->assertSame($expected, pfb_filter($input, PFB_FILTER_ON_OFF));
+	}
 
-    public static function numProvider(): array
-    {
-        return [
-            'digits'              => ['12345', '12345'],
-            'alpha -> default'    => ['12a', ''],
-            'negative -> default' => ['-5', ''],
-            // Quirk worth pinning: '0' validates, but the final
-            // `return $result == FALSE ? $default : $result` treats the string
-            // '0' as loosely == FALSE, so NUM can never return '0' -> default.
-            'zero is loose-false' => ['0', ''],
-        ];
-    }
+	public static function numProvider(): array
+	{
+		return [
+			'digits'              => ['12345', '12345'],
+			'alpha -> default'    => ['12a', ''],
+			'negative -> default' => ['-5', ''],
+			// Quirk worth pinning: '0' validates, but the final
+			// `return $result == FALSE ? $default : $result` treats the string
+			// '0' as loosely == FALSE, so NUM can never return '0' -> default.
+			'zero is loose-false' => ['0', ''],
+		];
+	}
 
-    #[DataProvider('numProvider')]
-    public function testNumFilter(string $input, string $expected): void
-    {
-        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_NUM));
-    }
+	#[DataProvider('numProvider')]
+	public function testNumFilter(string $input, string $expected): void
+	{
+		$this->assertSame($expected, pfb_filter($input, PFB_FILTER_NUM));
+	}
 
-    public function testControlCharactersRejected(): void
-    {
-        // A control char anywhere makes the whole input fail, returning default.
-        $this->assertSame('', pfb_filter("abc\x01def", PFB_FILTER_WORD));
-    }
+	public function testControlCharactersRejected(): void
+	{
+		// A control char anywhere makes the whole input fail, returning default.
+		$this->assertSame('', pfb_filter("abc\x01def", PFB_FILTER_WORD));
+	}
 
-    public function testCustomDefaultReturnedOnFailure(): void
-    {
-        $this->assertSame('FALLBACK', pfb_filter('not a domain', PFB_FILTER_DOMAIN, 'ref', 'FALLBACK'));
-    }
+	public function testCustomDefaultReturnedOnFailure(): void
+	{
+		$this->assertSame('FALLBACK', pfb_filter('not a domain', PFB_FILTER_DOMAIN, 'ref', 'FALLBACK'));
+	}
 
-    public function testEmptyInputReturnsDefault(): void
-    {
-        $this->assertSame('DEF', pfb_filter('', PFB_FILTER_DOMAIN, 'ref', 'DEF'));
-    }
+	public function testEmptyInputReturnsDefault(): void
+	{
+		$this->assertSame('DEF', pfb_filter('', PFB_FILTER_DOMAIN, 'ref', 'DEF'));
+	}
 }

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_filter() — the input sanitiser used throughout the UI/config paths.
+ * Only the pure validation types are exercised here; URL/MIME types need
+ * host resolution or /usr/bin/file and belong to the live-VM smoke (ADR-04).
+ */
+#[CoversFunction('pfb_filter')]
+final class PfbFilterTest extends TestCase
+{
+    public static function domainProvider(): array
+    {
+        return [
+            'plain domain'        => ['example.com', 'example.com'],
+            'subdomain'           => ['a.b.example.com', 'a.b.example.com'],
+            'mixed case kept'     => ['Example.Com', 'Example.Com'],
+            'underscore/dash ok'  => ['my_host-1.example.com', 'my_host-1.example.com'],
+            'no dot rejected'     => ['localhost', ''],
+            'double dot rejected' => ['bad..com', ''],
+            'bad char rejected'   => ['ex+ample.com', ''],
+            'space rejected'      => ['ex ample.com', ''],
+        ];
+    }
+
+    #[DataProvider('domainProvider')]
+    public function testDomainFilter(string $input, string $expected): void
+    {
+        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_DOMAIN));
+    }
+
+    public function testDomainLabelTooLongRejected(): void
+    {
+        $label = str_repeat('a', 64);
+        $this->assertSame('', pfb_filter("{$label}.com", PFB_FILTER_DOMAIN));
+    }
+
+    public static function ipProvider(): array
+    {
+        return [
+            'ipv4'            => ['192.0.2.10', '192.0.2.10'],
+            'ipv6'            => ['2001:db8::1', '2001:db8::1'],
+            'ipv6 loopback'   => ['::1', '::1'],
+            'not an ip'       => ['999.1.1.1', ''],
+            'word'            => ['nope', ''],
+        ];
+    }
+
+    #[DataProvider('ipProvider')]
+    public function testIpFilter(string $input, string $expected): void
+    {
+        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_IP));
+    }
+
+    public function testIpv4FilterRejectsV6(): void
+    {
+        $this->assertSame('192.0.2.1', pfb_filter('192.0.2.1', PFB_FILTER_IPV4));
+        $this->assertSame('', pfb_filter('2001:db8::1', PFB_FILTER_IPV4));
+    }
+
+    public static function wordProvider(): array
+    {
+        return [
+            'alnum + underscore' => ['abc_123', 'abc_123'],
+            'space rejected'     => ['a b', ''],
+            'dot rejected'       => ['a.b', ''],
+            'dash rejected'      => ['a-b', ''],
+        ];
+    }
+
+    #[DataProvider('wordProvider')]
+    public function testWordFilter(string $input, string $expected): void
+    {
+        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_WORD));
+    }
+
+    public static function hexColorProvider(): array
+    {
+        return [
+            'six hex'      => ['#a1b2c3', '#a1b2c3'],
+            'three hex'    => ['#abc', '#abc'],
+            'uppercase'    => ['#ABCDEF', '#ABCDEF'],
+            'literal none' => ['none', 'none'],
+            'missing hash' => ['a1b2c3', ''],
+            'bad hex'      => ['#xyzxyz', ''],
+            'wrong length' => ['#a1b2', ''],
+        ];
+    }
+
+    #[DataProvider('hexColorProvider')]
+    public function testHexColorFilter(string $input, string $expected): void
+    {
+        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_HEX_COLOR));
+    }
+
+    public static function onOffProvider(): array
+    {
+        return [
+            'on'              => ['on', 'on'],
+            'empty'           => ['', ''],
+            'off -> default'  => ['off', ''],
+            'junk -> default' => ['enabled', ''],
+        ];
+    }
+
+    #[DataProvider('onOffProvider')]
+    public function testOnOffFilter(string $input, string $expected): void
+    {
+        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_ON_OFF));
+    }
+
+    public static function numProvider(): array
+    {
+        return [
+            'digits'              => ['12345', '12345'],
+            'alpha -> default'    => ['12a', ''],
+            'negative -> default' => ['-5', ''],
+            // Quirk worth pinning: '0' validates, but the final
+            // `return $result == FALSE ? $default : $result` treats the string
+            // '0' as loosely == FALSE, so NUM can never return '0' -> default.
+            'zero is loose-false' => ['0', ''],
+        ];
+    }
+
+    #[DataProvider('numProvider')]
+    public function testNumFilter(string $input, string $expected): void
+    {
+        $this->assertSame($expected, pfb_filter($input, PFB_FILTER_NUM));
+    }
+
+    public function testControlCharactersRejected(): void
+    {
+        // A control char anywhere makes the whole input fail, returning default.
+        $this->assertSame('', pfb_filter("abc\x01def", PFB_FILTER_WORD));
+    }
+
+    public function testCustomDefaultReturnedOnFailure(): void
+    {
+        $this->assertSame('FALLBACK', pfb_filter('not a domain', PFB_FILTER_DOMAIN, 'ref', 'FALLBACK'));
+    }
+
+    public function testEmptyInputReturnsDefault(): void
+    {
+        $this->assertSame('DEF', pfb_filter('', PFB_FILTER_DOMAIN, 'ref', 'DEF'));
+    }
+}

--- a/tests/php/PfbStrtolowerTest.php
+++ b/tests/php/PfbStrtolowerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_strtolower() — lower-case + trim a line UNLESS it contains a '#', in which
+ * case only trim (comment text is preserved verbatim). Used by the array-map in
+ * pfbng_text_area_decode()'s comment-split path.
+ */
+#[CoversFunction('pfb_strtolower')]
+final class PfbStrtolowerTest extends TestCase
+{
+    public function testLowercasesAndTrimsPlainLine(): void
+    {
+        $this->assertSame('example.com', pfb_strtolower('  EXAMPLE.COM  '));
+    }
+
+    public function testPreservesCaseWhenHashPresent(): void
+    {
+        $this->assertSame('Foo.COM # Note', pfb_strtolower('  Foo.COM # Note  '));
+    }
+}

--- a/tests/php/PfbStrtolowerTest.php
+++ b/tests/php/PfbStrtolowerTest.php
@@ -13,13 +13,13 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_strtolower')]
 final class PfbStrtolowerTest extends TestCase
 {
-    public function testLowercasesAndTrimsPlainLine(): void
-    {
-        $this->assertSame('example.com', pfb_strtolower('  EXAMPLE.COM  '));
-    }
+	public function testLowercasesAndTrimsPlainLine(): void
+	{
+		$this->assertSame('example.com', pfb_strtolower('  EXAMPLE.COM  '));
+	}
 
-    public function testPreservesCaseWhenHashPresent(): void
-    {
-        $this->assertSame('Foo.COM # Note', pfb_strtolower('  Foo.COM # Note  '));
-    }
+	public function testPreservesCaseWhenHashPresent(): void
+	{
+		$this->assertSame('Foo.COM # Note', pfb_strtolower('  Foo.COM # Note  '));
+	}
 }

--- a/tests/php/README.md
+++ b/tests/php/README.md
@@ -1,0 +1,82 @@
+# PHP unit tests (PHPUnit)
+
+Fast, off-appliance unit tests for the **pure / extractable** PHP logic in
+`src/usr/local/pkg/pfblockerng/pfblockerng.inc` — the functional layer beneath
+the live-VM smoke (ADR-04). Added for issue #39; mirrors the Python suite's
+"test the pure functions in isolation" philosophy.
+
+## Running
+
+```sh
+composer install      # once — pulls phpunit/phpunit into vendor/
+vendor/bin/phpunit     # config: phpunit.xml at the repo root
+```
+
+Requires PHP 8.3+ (CE 2.8 baseline) with the `curl`, `intl`, `mbstring`,
+`ctype` and `filter` extensions. The pre-commit hook and CI (`test.yml`,
+`php-unit` job) run the same command; CI additionally prints an informational
+`--coverage-text` summary (no enforced floor yet — see issues #38/#39).
+
+## How it works — testing the *real* code, no live box
+
+`pfblockerng.inc` is mostly pfSense-integration code: it opens with
+`require_once` of eight pfSense core includes, calls a handful of pfSense
+runtime functions at load time, and defines the helpers we want to test. We load
+that **real file unmodified** (so tests exercise shipped code, not copies) by
+making it resolvable off-appliance. `tests/php/bootstrap.php`:
+
+1. **Include shims** — `tests/php/shims/` holds empty files named after the
+   eight pfSense includes (`util.inc`, `config.lib.inc`, …). Prepending that dir
+   to `include_path` satisfies the top-of-file `require_once` as no-ops.
+2. **pfSense doubles** — `tests/php/pfsense_doubles.php` defines the pfSense
+   runtime functions the code reaches. The PHPStan stubs in `stubs/pfsense/`
+   only assert symbol *existence* (empty bodies), so they are useless as
+   behavioural doubles; the doubles here implement faithful behaviour where a
+   tested result depends on it (`is_ipaddrv4`/`is_ipaddrv6`/`is_ipaddr` mirror
+   pfSense `util.inc`; `safe_mkdir`/`rmdir_recursive` really touch the temp
+   sandbox) and no-ops where it does not (`write_rcfile`, `system_get_uniqueid`,
+   host-resolution helpers reached only by URL/MIME paths the suite skips).
+   Each is `function_exists()`-guarded.
+3. **Sandbox `$g`/`$pfb`** — load-time `$pfb[...]` path assignments are pointed
+   at a writable temp dir so any `pfb_logger` (`@file_put_contents`) writes are
+   harmless.
+4. **Dormant dispatch** — `$argv` is cleared so the bottom-of-file daemon
+   dispatch (`if (isset($argv[1]))`) does not fire under PHPUnit.
+
+Pre-existing legacy `E_DEPRECATED`/`E_WARNING` notices emitted while *loading*
+the file are silenced narrowly around the include and full reporting is restored
+for test execution.
+
+## What's covered (seed)
+
+| Test file | Function under test |
+| --------- | ------------------- |
+| `PfbFilterTest` | `pfb_filter` (DOMAIN/IP/IPV4/WORD/HEX_COLOR/ON_OFF/NUM) |
+| `TextAreaDecodeTest` | `pfbng_text_area_decode` (base64/CRLF/comment/IDN) |
+| `AbpExtractIpTest` | `pfb_dnsbl_abp_extract_ip` (ADR-07 DNSBL-IP extraction) |
+| `SanitizeIpaddrTest` | `sanitize_ipaddr` (IPv4 normalise + suppression) |
+| `ValidateDomainLabelsTest` | `pfb_validate_domain_labels` (63-char labels) |
+| `PfbStrtolowerTest` | `pfb_strtolower` |
+| `UnboundPythonSourcesTest` | `pfb_unbound_python_sources` (ADR-06/07 manifest writer) |
+| `BootstrapSmokeTest` | bootstrap sanity (functions/constants loaded) |
+
+A few tests pin **real production quirks** (e.g. `pfb_filter` NUM returns the
+default for `'0'` because of the final loose `== FALSE` comparison) — these are
+regression anchors, not endorsements.
+
+## Out of scope
+
+Deep pfSense-runtime integration (config apply, service reloads, pf/Unbound
+wiring, URL/MIME validation that shells out to `/usr/bin/file` or resolves
+hosts) stays the live-VM smoke's job — see `.ADRs/ADR_04_VM_Smoke_Tests/`.
+
+## Adding a test
+
+- Put `*Test.php` here; it is picked up automatically (`phpunit.xml` testsuite
+  is this directory).
+- The function under test is already defined by the bootstrap — just call it.
+- Need a pfSense runtime function not yet doubled? Add a faithful (or no-op)
+  `function_exists()`-guarded double to `pfsense_doubles.php`; if it's an
+  include the production file requires, add an empty shim under `shims/`.
+- Reads/writes via `$pfb[...]`? Set the relevant keys on `$GLOBALS['pfb']` in the
+  test's `setUp()` and use a temp dir.

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -14,70 +14,70 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('sanitize_ipaddr')]
 final class SanitizeIpaddrTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        // Default: suppression OFF (no reserved/private filtering).
-        $GLOBALS['pfb']['supp'] = 'off';
-    }
+	protected function setUp(): void
+	{
+		// Default: suppression OFF (no reserved/private filtering).
+		$GLOBALS['pfb']['supp'] = 'off';
+	}
 
-    // --- Normalisation (suppression off) -------------------------------------
+	// --- Normalisation (suppression off) -------------------------------------
 
-    public function testStripsSlash32(): void
-    {
-        $this->assertSame('192.0.2.5', sanitize_ipaddr('192.0.2.5/32', false, 'Disabled'));
-    }
+	public function testStripsSlash32(): void
+	{
+		$this->assertSame('192.0.2.5', sanitize_ipaddr('192.0.2.5/32', false, 'Disabled'));
+	}
 
-    public function testKeepsExplicitSubnet(): void
-    {
-        $this->assertSame('10.0.0.0/24', sanitize_ipaddr('10.0.0.0/24', false, 'Disabled'));
-    }
+	public function testKeepsExplicitSubnet(): void
+	{
+		$this->assertSame('10.0.0.0/24', sanitize_ipaddr('10.0.0.0/24', false, 'Disabled'));
+	}
 
-    public function testAutoSlash24WhenTrailingOctetZeroAndNoMask(): void
-    {
-        $this->assertSame('192.0.2.0/24', sanitize_ipaddr('192.0.2.0', false, 'Disabled'));
-    }
+	public function testAutoSlash24WhenTrailingOctetZeroAndNoMask(): void
+	{
+		$this->assertSame('192.0.2.0/24', sanitize_ipaddr('192.0.2.0', false, 'Disabled'));
+	}
 
-    public function testSlash24ForcesFourthOctetToZero(): void
-    {
-        $this->assertSame('192.0.2.0/24', sanitize_ipaddr('192.0.2.7/24', false, 'Disabled'));
-    }
+	public function testSlash24ForcesFourthOctetToZero(): void
+	{
+		$this->assertSame('192.0.2.0/24', sanitize_ipaddr('192.0.2.7/24', false, 'Disabled'));
+	}
 
-    public function testStripsLeadingZeroOctets(): void
-    {
-        $this->assertSame('192.0.2.5', sanitize_ipaddr('192.000.002.005/32', false, 'Disabled'));
-    }
+	public function testStripsLeadingZeroOctets(): void
+	{
+		$this->assertSame('192.0.2.5', sanitize_ipaddr('192.000.002.005/32', false, 'Disabled'));
+	}
 
-    // --- Suppression on (reserved/private dropped unless custom) --------------
+	// --- Suppression on (reserved/private dropped unless custom) --------------
 
-    public function testSuppressionKeepsPublicIp(): void
-    {
-        $GLOBALS['pfb']['supp'] = 'on';
-        $this->assertSame('192.0.2.5', sanitize_ipaddr('192.0.2.5/32', false, 'Disabled'));
-    }
+	public function testSuppressionKeepsPublicIp(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('192.0.2.5', sanitize_ipaddr('192.0.2.5/32', false, 'Disabled'));
+	}
 
-    public function testSuppressionDropsPrivateIp(): void
-    {
-        $GLOBALS['pfb']['supp'] = 'on';
-        $this->assertNull(sanitize_ipaddr('10.0.0.5/32', false, 'Disabled'));
-    }
+	public function testSuppressionDropsPrivateIp(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('10.0.0.5/32', false, 'Disabled'));
+	}
 
-    public function testSuppressionDropsLoopback(): void
-    {
-        $GLOBALS['pfb']['supp'] = 'on';
-        $this->assertNull(sanitize_ipaddr('127.0.0.1/32', false, 'Disabled'));
-    }
+	public function testSuppressionDropsLoopback(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('127.0.0.1/32', false, 'Disabled'));
+	}
 
-    public function testCustomListBypassesSuppression(): void
-    {
-        $GLOBALS['pfb']['supp'] = 'on';
-        // $custom = true -> private IP retained.
-        $this->assertSame('10.0.0.5', sanitize_ipaddr('10.0.0.5/32', true, 'Disabled'));
-    }
+	public function testCustomListBypassesSuppression(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// $custom = true -> private IP retained.
+		$this->assertSame('10.0.0.5', sanitize_ipaddr('10.0.0.5/32', true, 'Disabled'));
+	}
 
-    public function testAdvancedCidrFloorClampsToSlash32(): void
-    {
-        $GLOBALS['pfb']['supp'] = 'on';
-        // mask 8 < floor 24 -> clamped to /32 (public TEST-NET-2 survives the filter).
-        $this->assertSame('198.51.100.0/32', sanitize_ipaddr('198.51.100.0/8', false, 24));
-    }
+	public function testAdvancedCidrFloorClampsToSlash32(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// mask 8 < floor 24 -> clamped to /32 (public TEST-NET-2 survives the filter).
+		$this->assertSame('198.51.100.0/32', sanitize_ipaddr('198.51.100.0/8', false, 24));
+	}
 }

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * sanitize_ipaddr() — normalise an IPv4(/mask): strip leading zeros, drop a /32,
+ * auto-/24 a trailing-zero host, force the 4th octet to 0 on /24, and (when
+ * $pfb['supp']=='on' and not a custom list) drop loopback/reserved/private and
+ * apply the Advanced CIDR floor.
+ */
+#[CoversFunction('sanitize_ipaddr')]
+final class SanitizeIpaddrTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Default: suppression OFF (no reserved/private filtering).
+        $GLOBALS['pfb']['supp'] = 'off';
+    }
+
+    // --- Normalisation (suppression off) -------------------------------------
+
+    public function testStripsSlash32(): void
+    {
+        $this->assertSame('192.0.2.5', sanitize_ipaddr('192.0.2.5/32', false, 'Disabled'));
+    }
+
+    public function testKeepsExplicitSubnet(): void
+    {
+        $this->assertSame('10.0.0.0/24', sanitize_ipaddr('10.0.0.0/24', false, 'Disabled'));
+    }
+
+    public function testAutoSlash24WhenTrailingOctetZeroAndNoMask(): void
+    {
+        $this->assertSame('192.0.2.0/24', sanitize_ipaddr('192.0.2.0', false, 'Disabled'));
+    }
+
+    public function testSlash24ForcesFourthOctetToZero(): void
+    {
+        $this->assertSame('192.0.2.0/24', sanitize_ipaddr('192.0.2.7/24', false, 'Disabled'));
+    }
+
+    public function testStripsLeadingZeroOctets(): void
+    {
+        $this->assertSame('192.0.2.5', sanitize_ipaddr('192.000.002.005/32', false, 'Disabled'));
+    }
+
+    // --- Suppression on (reserved/private dropped unless custom) --------------
+
+    public function testSuppressionKeepsPublicIp(): void
+    {
+        $GLOBALS['pfb']['supp'] = 'on';
+        $this->assertSame('192.0.2.5', sanitize_ipaddr('192.0.2.5/32', false, 'Disabled'));
+    }
+
+    public function testSuppressionDropsPrivateIp(): void
+    {
+        $GLOBALS['pfb']['supp'] = 'on';
+        $this->assertNull(sanitize_ipaddr('10.0.0.5/32', false, 'Disabled'));
+    }
+
+    public function testSuppressionDropsLoopback(): void
+    {
+        $GLOBALS['pfb']['supp'] = 'on';
+        $this->assertNull(sanitize_ipaddr('127.0.0.1/32', false, 'Disabled'));
+    }
+
+    public function testCustomListBypassesSuppression(): void
+    {
+        $GLOBALS['pfb']['supp'] = 'on';
+        // $custom = true -> private IP retained.
+        $this->assertSame('10.0.0.5', sanitize_ipaddr('10.0.0.5/32', true, 'Disabled'));
+    }
+
+    public function testAdvancedCidrFloorClampsToSlash32(): void
+    {
+        $GLOBALS['pfb']['supp'] = 'on';
+        // mask 8 < floor 24 -> clamped to /32 (public TEST-NET-2 survives the filter).
+        $this->assertSame('198.51.100.0/32', sanitize_ipaddr('198.51.100.0/8', false, 24));
+    }
+}

--- a/tests/php/TextAreaDecodeTest.php
+++ b/tests/php/TextAreaDecodeTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfbng_text_area_decode() — the Custom_List/whitelist textarea decoder: base64
+ * in, CRLF-split, '#'-comment handling, lower-casing, optional IDN->punycode.
+ *
+ * $mode: FALSE => newline-joined string; TRUE => array.
+ * $type (mode only): TRUE => per-line [value(, '#comment')]; FALSE => bare value.
+ * $idn:  TRUE  => convert non-ASCII hostnames to punycode (idn_to_ascii).
+ */
+#[CoversFunction('pfbng_text_area_decode')]
+final class TextAreaDecodeTest extends TestCase
+{
+    /** Encode like a browser textarea: lines joined by CRLF, then base64. */
+    private static function enc(string ...$lines): string
+    {
+        return base64_encode(implode("\r\n", $lines));
+    }
+
+    public function testStringModeLowercasesJoinsAndStripsComments(): void
+    {
+        $in = self::enc('EXAMPLE.COM', 'foo.com', '# whole-line comment', 'bar.com # inline');
+        // Whole-line comment dropped; inline comment trimmed off; all lower-cased.
+        $this->assertSame("example.com\nfoo.com\nbar.com\n", pfbng_text_area_decode($in));
+    }
+
+    public function testStringModeSkipsEmptyLines(): void
+    {
+        $in = self::enc('a.com', '', 'b.com');
+        $this->assertSame("a.com\nb.com\n", pfbng_text_area_decode($in));
+    }
+
+    public function testArrayModeBareValues(): void
+    {
+        $in = self::enc('Foo.com', '# c', 'bar.com # x');
+        // mode=TRUE, type=FALSE => array of bare, comment-stripped, lower values.
+        $this->assertSame(['foo.com', 'bar.com'], pfbng_text_area_decode($in, true, false));
+    }
+
+    public function testArrayModeTypedNonCommentWrapsInArray(): void
+    {
+        $in = self::enc('Foo.com');
+        // mode=TRUE, type=TRUE => each non-comment line becomes [value].
+        $this->assertSame([['foo.com']], pfbng_text_area_decode($in, true, true));
+    }
+
+    public function testArrayModeTypedCommentSplit(): void
+    {
+        $in = self::enc('bar.com # note');
+        // Comment line splits into [value, '#comment'] via pfb_strtolower: the
+        // value is trimmed+lowered, the '#'-bearing token kept (trimmed) verbatim.
+        $this->assertSame([['bar.com', '# note']], pfbng_text_area_decode($in, true, true));
+    }
+
+    public function testIdnConversionToPunycode(): void
+    {
+        // The IDN branch is gated on !ctype_print(), which is locale-sensitive.
+        // pfSense's PHP CLI runs under the C locale (high bytes non-printable),
+        // so pin that to make the conversion deterministic on any host.
+        $prev = setlocale(LC_CTYPE, '0');
+        setlocale(LC_CTYPE, 'C');
+        try {
+            $in = self::enc('bücher.de');
+            $this->assertSame("xn--bcher-kva.de\n", pfbng_text_area_decode($in, false, true, true));
+        } finally {
+            setlocale(LC_CTYPE, $prev);
+        }
+    }
+
+    public function testEmptyInputReturnsNull(): void
+    {
+        // base64('') => '' => explode gives [''] => nothing appended => $custom
+        // never initialised in string mode => implicit null return.
+        $this->assertNull(pfbng_text_area_decode(''));
+    }
+}

--- a/tests/php/TextAreaDecodeTest.php
+++ b/tests/php/TextAreaDecodeTest.php
@@ -72,10 +72,10 @@ final class TextAreaDecodeTest extends TestCase
         }
     }
 
-    public function testEmptyInputReturnsNull(): void
+    public function testEmptyInputReturnsEmptyString(): void
     {
-        // base64('') => '' => explode gives [''] => nothing appended => $custom
-        // never initialised in string mode => implicit null return.
-        $this->assertNull(pfbng_text_area_decode(''));
+        // base64('') => '' => explode gives [''] => nothing appended. String mode
+        // initialises $custom to '' up front, so empty input yields '' (not null).
+        $this->assertSame('', pfbng_text_area_decode(''));
     }
 }

--- a/tests/php/TextAreaDecodeTest.php
+++ b/tests/php/TextAreaDecodeTest.php
@@ -16,66 +16,66 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfbng_text_area_decode')]
 final class TextAreaDecodeTest extends TestCase
 {
-    /** Encode like a browser textarea: lines joined by CRLF, then base64. */
-    private static function enc(string ...$lines): string
-    {
-        return base64_encode(implode("\r\n", $lines));
-    }
+	/** Encode like a browser textarea: lines joined by CRLF, then base64. */
+	private static function enc(string ...$lines): string
+	{
+		return base64_encode(implode("\r\n", $lines));
+	}
 
-    public function testStringModeLowercasesJoinsAndStripsComments(): void
-    {
-        $in = self::enc('EXAMPLE.COM', 'foo.com', '# whole-line comment', 'bar.com # inline');
-        // Whole-line comment dropped; inline comment trimmed off; all lower-cased.
-        $this->assertSame("example.com\nfoo.com\nbar.com\n", pfbng_text_area_decode($in));
-    }
+	public function testStringModeLowercasesJoinsAndStripsComments(): void
+	{
+		$in = self::enc('EXAMPLE.COM', 'foo.com', '# whole-line comment', 'bar.com # inline');
+		// Whole-line comment dropped; inline comment trimmed off; all lower-cased.
+		$this->assertSame("example.com\nfoo.com\nbar.com\n", pfbng_text_area_decode($in));
+	}
 
-    public function testStringModeSkipsEmptyLines(): void
-    {
-        $in = self::enc('a.com', '', 'b.com');
-        $this->assertSame("a.com\nb.com\n", pfbng_text_area_decode($in));
-    }
+	public function testStringModeSkipsEmptyLines(): void
+	{
+		$in = self::enc('a.com', '', 'b.com');
+		$this->assertSame("a.com\nb.com\n", pfbng_text_area_decode($in));
+	}
 
-    public function testArrayModeBareValues(): void
-    {
-        $in = self::enc('Foo.com', '# c', 'bar.com # x');
-        // mode=TRUE, type=FALSE => array of bare, comment-stripped, lower values.
-        $this->assertSame(['foo.com', 'bar.com'], pfbng_text_area_decode($in, true, false));
-    }
+	public function testArrayModeBareValues(): void
+	{
+		$in = self::enc('Foo.com', '# c', 'bar.com # x');
+		// mode=TRUE, type=FALSE => array of bare, comment-stripped, lower values.
+		$this->assertSame(['foo.com', 'bar.com'], pfbng_text_area_decode($in, true, false));
+	}
 
-    public function testArrayModeTypedNonCommentWrapsInArray(): void
-    {
-        $in = self::enc('Foo.com');
-        // mode=TRUE, type=TRUE => each non-comment line becomes [value].
-        $this->assertSame([['foo.com']], pfbng_text_area_decode($in, true, true));
-    }
+	public function testArrayModeTypedNonCommentWrapsInArray(): void
+	{
+		$in = self::enc('Foo.com');
+		// mode=TRUE, type=TRUE => each non-comment line becomes [value].
+		$this->assertSame([['foo.com']], pfbng_text_area_decode($in, true, true));
+	}
 
-    public function testArrayModeTypedCommentSplit(): void
-    {
-        $in = self::enc('bar.com # note');
-        // Comment line splits into [value, '#comment'] via pfb_strtolower: the
-        // value is trimmed+lowered, the '#'-bearing token kept (trimmed) verbatim.
-        $this->assertSame([['bar.com', '# note']], pfbng_text_area_decode($in, true, true));
-    }
+	public function testArrayModeTypedCommentSplit(): void
+	{
+		$in = self::enc('bar.com # note');
+		// Comment line splits into [value, '#comment'] via pfb_strtolower: the
+		// value is trimmed+lowered, the '#'-bearing token kept (trimmed) verbatim.
+		$this->assertSame([['bar.com', '# note']], pfbng_text_area_decode($in, true, true));
+	}
 
-    public function testIdnConversionToPunycode(): void
-    {
-        // The IDN branch is gated on !ctype_print(), which is locale-sensitive.
-        // pfSense's PHP CLI runs under the C locale (high bytes non-printable),
-        // so pin that to make the conversion deterministic on any host.
-        $prev = setlocale(LC_CTYPE, '0');
-        setlocale(LC_CTYPE, 'C');
-        try {
-            $in = self::enc('bücher.de');
-            $this->assertSame("xn--bcher-kva.de\n", pfbng_text_area_decode($in, false, true, true));
-        } finally {
-            setlocale(LC_CTYPE, $prev);
-        }
-    }
+	public function testIdnConversionToPunycode(): void
+	{
+		// The IDN branch is gated on !ctype_print(), which is locale-sensitive.
+		// pfSense's PHP CLI runs under the C locale (high bytes non-printable),
+		// so pin that to make the conversion deterministic on any host.
+		$prev = setlocale(LC_CTYPE, '0');
+		setlocale(LC_CTYPE, 'C');
+		try {
+			$in = self::enc('bücher.de');
+			$this->assertSame("xn--bcher-kva.de\n", pfbng_text_area_decode($in, false, true, true));
+		} finally {
+			setlocale(LC_CTYPE, $prev);
+		}
+	}
 
-    public function testEmptyInputReturnsEmptyString(): void
-    {
-        // base64('') => '' => explode gives [''] => nothing appended. String mode
-        // initialises $custom to '' up front, so empty input yields '' (not null).
-        $this->assertSame('', pfbng_text_area_decode(''));
-    }
+	public function testEmptyInputReturnsEmptyString(): void
+	{
+		// base64('') => '' => explode gives [''] => nothing appended. String mode
+		// initialises $custom to '' up front, so empty input yields '' (not null).
+		$this->assertSame('', pfbng_text_area_decode(''));
+	}
 }

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -15,111 +15,124 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_unbound_python_sources')]
 final class UnboundPythonSourcesTest extends TestCase
 {
-    private string $tmp;
+	private string $tmp;
+	private bool $hadPfb = false;
+	private array $originalPfb = [];
 
-    protected function setUp(): void
-    {
-        $this->tmp = sys_get_temp_dir() . '/pfb_sources_' . uniqid('', true);
-        mkdir("{$this->tmp}/dnsbl", 0777, true);
-        mkdir("{$this->tmp}/db", 0777, true);
+	protected function setUp(): void
+	{
+		// Snapshot the global so this class's heavy $pfb mutations (temp paths,
+		// replaced dnsblconfig subtree) don't leak into later test classes.
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
 
-        $GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
-            'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
-            'dnsdir'             => "{$this->tmp}/dnsbl",
-            'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
-            'dbdir'              => "{$this->tmp}/db",
-            'dnsbl_alexa'        => 'off',
-            'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
-            'dnsblconfig'        => [
-                'tldblacklist' => '',
-                'tldexclusion' => '',
-                'suppression'  => '',
-            ],
-        ]);
+		$this->tmp = sys_get_temp_dir() . '/pfb_sources_' . uniqid('', true);
+		mkdir("{$this->tmp}/dnsbl", 0777, true);
+		mkdir("{$this->tmp}/db", 0777, true);
 
-        // Plain feed: 6-col CSV, bare domain in column index 1.
-        file_put_contents("{$this->tmp}/dnsbl/feed1.txt",
-            "1,example.com,a,b,c,d\n" .
-            "1,foo.com,a,b,c,d\n" .
-            "1,,a,b,c,d\n");                 // empty col1 => skipped
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
+			'dnsdir'             => "{$this->tmp}/dnsbl",
+			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
+			'dbdir'              => "{$this->tmp}/db",
+			'dnsbl_alexa'        => 'off',
+			'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
+			'dnsblconfig'        => [
+				'tldblacklist' => '',
+				'tldexclusion' => '',
+				'suppression'  => '',
+			],
+		]);
 
-        // ABP feed: raw ABP lines passed through verbatim.
-        file_put_contents("{$this->tmp}/dnsbl/abpfeed.txt",
-            "||ads.example^\n@@||good.example^\n");
-    }
+		// Plain feed: 6-col CSV, bare domain in column index 1.
+		file_put_contents("{$this->tmp}/dnsbl/feed1.txt",
+			"1,example.com,a,b,c,d\n" .
+			"1,foo.com,a,b,c,d\n" .
+			"1,,a,b,c,d\n");                 // empty col1 => skipped
 
-    protected function tearDown(): void
-    {
-        rmdir_recursive($this->tmp);
-    }
+		// ABP feed: raw ABP lines passed through verbatim.
+		file_put_contents("{$this->tmp}/dnsbl/abpfeed.txt",
+			"||ads.example^\n@@||good.example^\n");
+	}
 
-    private function feeds(): array
-    {
-        return [
-            ['header' => 'feed1',   'group' => 'pfb_grp', 'log' => '1', 'format' => 'plain', 'provenance' => 'feed'],
-            ['header' => 'abpfeed', 'group' => 'pfb_abp', 'log' => '0', 'format' => 'abp',   'provenance' => 'user'],
-            ['header' => 'missing', 'group' => 'pfb_x',   'log' => '1'],   // no .txt => skipped
-        ];
-    }
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
 
-    public function testManifestStructureAndTagging(): void
-    {
-        $m = pfb_unbound_python_sources($this->feeds());
+		rmdir_recursive($this->tmp);
+	}
 
-        $this->assertSame(1, $m['version']);
-        $this->assertCount(2, $m['feeds'], 'feed without a .txt must be skipped');
+	private function feeds(): array
+	{
+		return [
+			['header' => 'feed1',   'group' => 'pfb_grp', 'log' => '1', 'format' => 'plain', 'provenance' => 'feed'],
+			['header' => 'abpfeed', 'group' => 'pfb_abp', 'log' => '0', 'format' => 'abp',   'provenance' => 'user'],
+			['header' => 'missing', 'group' => 'pfb_x',   'log' => '1'],   // no .txt => skipped
+		];
+	}
 
-        $plain = $m['feeds'][0];
-        $this->assertSame('feed1', $plain['feed']);
-        $this->assertSame('pfb_grp', $plain['group']);
-        $this->assertSame('plain', $plain['format_hint']);
-        $this->assertSame('feed', $plain['provenance']);
-        $this->assertSame('1', $plain['log_flag']);
-        // chroot-relative: basename(rawdir)/<feed>.raw, never host-absolute.
-        $this->assertSame('pfb_py_raw/feed1.raw', $plain['raw']);
+	public function testManifestStructureAndTagging(): void
+	{
+		$m = pfb_unbound_python_sources($this->feeds());
 
-        $abp = $m['feeds'][1];
-        $this->assertSame('abp', $abp['format_hint']);
-        $this->assertSame('user', $abp['provenance']);
-        $this->assertSame('0', $abp['log_flag']);
-        $this->assertSame('pfb_py_raw/abpfeed.raw', $abp['raw']);
-    }
+		$this->assertSame(1, $m['version']);
+		$this->assertCount(2, $m['feeds'], 'feed without a .txt must be skipped');
 
-    public function testProvenanceDefaultsToFeedWhenUnset(): void
-    {
-        $m = pfb_unbound_python_sources([
-            ['header' => 'feed1', 'group' => 'g', 'log' => '1', 'format' => 'plain'],
-        ]);
-        $this->assertSame('feed', $m['feeds'][0]['provenance']);
-    }
+		$plain = $m['feeds'][0];
+		$this->assertSame('feed1', $plain['feed']);
+		$this->assertSame('pfb_grp', $plain['group']);
+		$this->assertSame('plain', $plain['format_hint']);
+		$this->assertSame('feed', $plain['provenance']);
+		$this->assertSame('1', $plain['log_flag']);
+		// chroot-relative: basename(rawdir)/<feed>.raw, never host-absolute.
+		$this->assertSame('pfb_py_raw/feed1.raw', $plain['raw']);
 
-    public function testPlainRawIsBareDomainColumn(): void
-    {
-        pfb_unbound_python_sources($this->feeds());
-        $raw = file_get_contents("{$this->tmp}/pfb_py_raw/feed1.raw");
-        $this->assertSame("example.com\nfoo.com\n", $raw);
-    }
+		$abp = $m['feeds'][1];
+		$this->assertSame('abp', $abp['format_hint']);
+		$this->assertSame('user', $abp['provenance']);
+		$this->assertSame('0', $abp['log_flag']);
+		$this->assertSame('pfb_py_raw/abpfeed.raw', $abp['raw']);
+	}
 
-    public function testAbpRawIsVerbatim(): void
-    {
-        pfb_unbound_python_sources($this->feeds());
-        $raw = file_get_contents("{$this->tmp}/pfb_py_raw/abpfeed.raw");
-        $this->assertSame("||ads.example^\n@@||good.example^\n", $raw);
-    }
+	public function testProvenanceDefaultsToFeedWhenUnset(): void
+	{
+		$m = pfb_unbound_python_sources([
+			['header' => 'feed1', 'group' => 'g', 'log' => '1', 'format' => 'plain'],
+		]);
+		$this->assertSame('feed', $m['feeds'][0]['provenance']);
+	}
 
-    public function testConfigBlockEmptyWhenUnconfigured(): void
-    {
-        $m = pfb_unbound_python_sources($this->feeds());
-        $this->assertSame([], $m['config']['tld_master']);
-        $this->assertSame([], $m['config']['tld_blacklist']);
-        $this->assertSame([], $m['config']['user_whitelist']);
-        $this->assertFalse($m['config']['top1m_enabled']);
-    }
+	public function testPlainRawIsBareDomainColumn(): void
+	{
+		pfb_unbound_python_sources($this->feeds());
+		$raw = file_get_contents("{$this->tmp}/pfb_py_raw/feed1.raw");
+		$this->assertSame("example.com\nfoo.com\n", $raw);
+	}
 
-    public function testManifestIsWrittenAsJson(): void
-    {
-        $m = pfb_unbound_python_sources($this->feeds());
-        $json = file_get_contents("{$this->tmp}/pfb_py_sources.json");
-        $this->assertSame($m, json_decode($json, true));
-    }
+	public function testAbpRawIsVerbatim(): void
+	{
+		pfb_unbound_python_sources($this->feeds());
+		$raw = file_get_contents("{$this->tmp}/pfb_py_raw/abpfeed.raw");
+		$this->assertSame("||ads.example^\n@@||good.example^\n", $raw);
+	}
+
+	public function testConfigBlockEmptyWhenUnconfigured(): void
+	{
+		$m = pfb_unbound_python_sources($this->feeds());
+		$this->assertSame([], $m['config']['tld_master']);
+		$this->assertSame([], $m['config']['tld_blacklist']);
+		$this->assertSame([], $m['config']['user_whitelist']);
+		$this->assertFalse($m['config']['top1m_enabled']);
+	}
+
+	public function testManifestIsWrittenAsJson(): void
+	{
+		$m = pfb_unbound_python_sources($this->feeds());
+		$json = file_get_contents("{$this->tmp}/pfb_py_sources.json");
+		$this->assertSame($m, json_decode($json, true));
+	}
 }

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_unbound_python_sources() — ADR-06/07 shell->Python manifest writer. Builds
+ * the per-feed manifest + per-feed IP-stripped raw files consumed by
+ * pfb_unbound.py. This pins the parts the issue calls out: format/provenance
+ * tagging, the chroot-relative (basename) raw path, and plain-vs-ABP raw
+ * extraction. It runs against a temp $pfb sandbox (no live box).
+ */
+#[CoversFunction('pfb_unbound_python_sources')]
+final class UnboundPythonSourcesTest extends TestCase
+{
+    private string $tmp;
+
+    protected function setUp(): void
+    {
+        $this->tmp = sys_get_temp_dir() . '/pfb_sources_' . uniqid('', true);
+        mkdir("{$this->tmp}/dnsbl", 0777, true);
+        mkdir("{$this->tmp}/db", 0777, true);
+
+        $GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+            'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
+            'dnsdir'             => "{$this->tmp}/dnsbl",
+            'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
+            'dbdir'              => "{$this->tmp}/db",
+            'dnsbl_alexa'        => 'off',
+            'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
+            'dnsblconfig'        => [
+                'tldblacklist' => '',
+                'tldexclusion' => '',
+                'suppression'  => '',
+            ],
+        ]);
+
+        // Plain feed: 6-col CSV, bare domain in column index 1.
+        file_put_contents("{$this->tmp}/dnsbl/feed1.txt",
+            "1,example.com,a,b,c,d\n" .
+            "1,foo.com,a,b,c,d\n" .
+            "1,,a,b,c,d\n");                 // empty col1 => skipped
+
+        // ABP feed: raw ABP lines passed through verbatim.
+        file_put_contents("{$this->tmp}/dnsbl/abpfeed.txt",
+            "||ads.example^\n@@||good.example^\n");
+    }
+
+    protected function tearDown(): void
+    {
+        rmdir_recursive($this->tmp);
+    }
+
+    private function feeds(): array
+    {
+        return [
+            ['header' => 'feed1',   'group' => 'pfb_grp', 'log' => '1', 'format' => 'plain', 'provenance' => 'feed'],
+            ['header' => 'abpfeed', 'group' => 'pfb_abp', 'log' => '0', 'format' => 'abp',   'provenance' => 'user'],
+            ['header' => 'missing', 'group' => 'pfb_x',   'log' => '1'],   // no .txt => skipped
+        ];
+    }
+
+    public function testManifestStructureAndTagging(): void
+    {
+        $m = pfb_unbound_python_sources($this->feeds());
+
+        $this->assertSame(1, $m['version']);
+        $this->assertCount(2, $m['feeds'], 'feed without a .txt must be skipped');
+
+        $plain = $m['feeds'][0];
+        $this->assertSame('feed1', $plain['feed']);
+        $this->assertSame('pfb_grp', $plain['group']);
+        $this->assertSame('plain', $plain['format_hint']);
+        $this->assertSame('feed', $plain['provenance']);
+        $this->assertSame('1', $plain['log_flag']);
+        // chroot-relative: basename(rawdir)/<feed>.raw, never host-absolute.
+        $this->assertSame('pfb_py_raw/feed1.raw', $plain['raw']);
+
+        $abp = $m['feeds'][1];
+        $this->assertSame('abp', $abp['format_hint']);
+        $this->assertSame('user', $abp['provenance']);
+        $this->assertSame('0', $abp['log_flag']);
+        $this->assertSame('pfb_py_raw/abpfeed.raw', $abp['raw']);
+    }
+
+    public function testProvenanceDefaultsToFeedWhenUnset(): void
+    {
+        $m = pfb_unbound_python_sources([
+            ['header' => 'feed1', 'group' => 'g', 'log' => '1', 'format' => 'plain'],
+        ]);
+        $this->assertSame('feed', $m['feeds'][0]['provenance']);
+    }
+
+    public function testPlainRawIsBareDomainColumn(): void
+    {
+        pfb_unbound_python_sources($this->feeds());
+        $raw = file_get_contents("{$this->tmp}/pfb_py_raw/feed1.raw");
+        $this->assertSame("example.com\nfoo.com\n", $raw);
+    }
+
+    public function testAbpRawIsVerbatim(): void
+    {
+        pfb_unbound_python_sources($this->feeds());
+        $raw = file_get_contents("{$this->tmp}/pfb_py_raw/abpfeed.raw");
+        $this->assertSame("||ads.example^\n@@||good.example^\n", $raw);
+    }
+
+    public function testConfigBlockEmptyWhenUnconfigured(): void
+    {
+        $m = pfb_unbound_python_sources($this->feeds());
+        $this->assertSame([], $m['config']['tld_master']);
+        $this->assertSame([], $m['config']['tld_blacklist']);
+        $this->assertSame([], $m['config']['user_whitelist']);
+        $this->assertFalse($m['config']['top1m_enabled']);
+    }
+
+    public function testManifestIsWrittenAsJson(): void
+    {
+        $m = pfb_unbound_python_sources($this->feeds());
+        $json = file_get_contents("{$this->tmp}/pfb_py_sources.json");
+        $this->assertSame($m, json_decode($json, true));
+    }
+}

--- a/tests/php/ValidateDomainLabelsTest.php
+++ b/tests/php/ValidateDomainLabelsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_validate_domain_labels() — rejects a domain if any dot-separated label
+ * exceeds the 63-char DNS label limit. (pfb_filter PFB_FILTER_DOMAIN leans on it.)
+ */
+#[CoversFunction('pfb_validate_domain_labels')]
+final class ValidateDomainLabelsTest extends TestCase
+{
+    public function testAllShortLabelsPass(): void
+    {
+        $this->assertTrue(pfb_validate_domain_labels('a.b.example.com'));
+    }
+
+    public function testLabelExactly63Passes(): void
+    {
+        $this->assertTrue(pfb_validate_domain_labels(str_repeat('a', 63) . '.com'));
+    }
+
+    public function testLabel64Fails(): void
+    {
+        $this->assertFalse(pfb_validate_domain_labels(str_repeat('a', 64) . '.com'));
+    }
+
+    public function testLastLabelTooLongFails(): void
+    {
+        $this->assertFalse(pfb_validate_domain_labels('example.' . str_repeat('z', 70)));
+    }
+
+    public function testNoDotSingleLabel(): void
+    {
+        // A single sub-64 label has no over-long label -> TRUE.
+        $this->assertTrue(pfb_validate_domain_labels('localhost'));
+    }
+}

--- a/tests/php/ValidateDomainLabelsTest.php
+++ b/tests/php/ValidateDomainLabelsTest.php
@@ -12,29 +12,29 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_validate_domain_labels')]
 final class ValidateDomainLabelsTest extends TestCase
 {
-    public function testAllShortLabelsPass(): void
-    {
-        $this->assertTrue(pfb_validate_domain_labels('a.b.example.com'));
-    }
+	public function testAllShortLabelsPass(): void
+	{
+		$this->assertTrue(pfb_validate_domain_labels('a.b.example.com'));
+	}
 
-    public function testLabelExactly63Passes(): void
-    {
-        $this->assertTrue(pfb_validate_domain_labels(str_repeat('a', 63) . '.com'));
-    }
+	public function testLabelExactly63Passes(): void
+	{
+		$this->assertTrue(pfb_validate_domain_labels(str_repeat('a', 63) . '.com'));
+	}
 
-    public function testLabel64Fails(): void
-    {
-        $this->assertFalse(pfb_validate_domain_labels(str_repeat('a', 64) . '.com'));
-    }
+	public function testLabel64Fails(): void
+	{
+		$this->assertFalse(pfb_validate_domain_labels(str_repeat('a', 64) . '.com'));
+	}
 
-    public function testLastLabelTooLongFails(): void
-    {
-        $this->assertFalse(pfb_validate_domain_labels('example.' . str_repeat('z', 70)));
-    }
+	public function testLastLabelTooLongFails(): void
+	{
+		$this->assertFalse(pfb_validate_domain_labels('example.' . str_repeat('z', 70)));
+	}
 
-    public function testNoDotSingleLabel(): void
-    {
-        // A single sub-64 label has no over-long label -> TRUE.
-        $this->assertTrue(pfb_validate_domain_labels('localhost'));
-    }
+	public function testNoDotSingleLabel(): void
+	{
+		// A single sub-64 label has no over-long label -> TRUE.
+		$this->assertTrue(pfb_validate_domain_labels('localhost'));
+	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * PHPUnit bootstrap for the pfBlockerNG PHP unit suite.
+ *
+ * Strategy (see tests/php/README.md): load the REAL production include
+ * src/usr/local/pkg/pfblockerng/pfblockerng.inc unmodified, so the tests
+ * exercise shipped code rather than copies. pfblockerng.inc opens with
+ * require_once() of eight pfSense core includes and runs a little top-level
+ * code; we make that resolvable off-appliance without touching production:
+ *
+ *   1. Prepend tests/php/shims/ to include_path — empty files named after the
+ *      eight required pfSense includes satisfy require_once() as no-ops.
+ *   2. Provide behavioural doubles (pfsense_doubles.php) for the pfSense
+ *      runtime functions the load-time code and the tested functions call.
+ *   3. Seed $g / $pfb so load-time $pfb[...] path assignments point at a
+ *      writable temp sandbox (pfb_logger uses @file_put_contents — harmless).
+ *   4. Clear $argv so the bottom-of-file daemon dispatch (if (isset($argv[1])))
+ *      stays dormant under PHPUnit.
+ *
+ * The two top-level service installers (pfb_filter_service/pfb_dnsbl_service)
+ * only build an rc array and call write_rcfile(), which we double to a no-op.
+ */
+
+require_once __DIR__ . '/pfsense_doubles.php';
+
+// 1. Shims for the eight pfSense includes required at the top of pfblockerng.inc.
+set_include_path(__DIR__ . '/shims' . PATH_SEPARATOR . get_include_path());
+
+// 3. Writable sandbox for any load-time/log file writes.
+$pfb_test_tmp = sys_get_temp_dir() . '/pfb_php_unit_' . getmypid();
+@mkdir($pfb_test_tmp, 0777, true);
+@mkdir("{$pfb_test_tmp}/db", 0777, true);
+@mkdir("{$pfb_test_tmp}/log", 0777, true);
+@mkdir("{$pfb_test_tmp}/tmp", 0777, true);
+
+$GLOBALS['g'] = [
+	'vardb_path'  => "{$pfb_test_tmp}/db",
+	'varlog_path' => "{$pfb_test_tmp}/log",
+	'tmp_path'    => "{$pfb_test_tmp}/tmp",
+	'pfblockerng_install' => false,
+];
+$GLOBALS['pfb'] = [];
+
+// 4. Keep the daemon dispatch dormant. Save/replace argv (PHPUnit has already
+//    parsed its own arguments by now, so this is safe).
+$GLOBALS['argv'] = ['pfblockerng.inc'];
+$GLOBALS['argc'] = 1;
+
+// 2 + load. Define the production functions by including the real source.
+// pfblockerng.inc is legacy code that emits some load-time E_DEPRECATED/E_WARNING
+// notices (e.g. an optional-before-required parameter, a switch `continue`) that
+// are pre-existing and unrelated to the tests. Silence them around the include
+// only, then restore full reporting so test execution stays strict.
+$pfb_prev_er = error_reporting();
+error_reporting($pfb_prev_er & ~E_DEPRECATED & ~E_WARNING);
+require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+error_reporting($pfb_prev_er);

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -56,22 +56,12 @@ if (!function_exists('is_ipaddr')) {
 }
 
 if (!function_exists('is_hostname')) {
-	// Faithful-enough RFC-1123 hostname check (labels 1-63 of [a-z0-9-], not
-	// starting/ending '-', total <= 255). The seed suite does not assert
-	// PFB_FILTER_HOSTNAME edge cases; this only needs to be plausible.
+	// Reached only by PFB_FILTER_HOSTNAME, which the seed suite does not exercise.
+	// Fail fast rather than guess pfSense's semantics (a guessed double could let a
+	// future test pass against behaviour pfSense never had). Port the real
+	// util.inc is_hostname() here when a HOSTNAME path is first tested.
 	function is_hostname($hostname, $allow_wildcard = false) {
-		if (!is_string($hostname) || $hostname === '' || strlen($hostname) > 255) {
-			return false;
-		}
-		if ($allow_wildcard && strpos($hostname, '*') === 0) {
-			$hostname = substr($hostname, 2);
-		}
-		foreach (explode('.', $hostname) as $label) {
-			if (!preg_match('/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i', $label)) {
-				return false;
-			}
-		}
-		return true;
+		throw new LogicException(__FUNCTION__ . '() double not implemented — port the real pfSense is_hostname() before testing this path');
 	}
 }
 
@@ -127,15 +117,17 @@ if (!function_exists('unlink_if_exists')) {
 }
 
 if (!function_exists('resolve_host_addresses')) {
-	// Only reached by PFB_FILTER_URL, which the seed suite does not exercise.
+	// Only reached by PFB_FILTER_URL, which the seed suite does not exercise. Fail
+	// fast rather than return a guessed [] that could hide a missing real double.
 	function resolve_host_addresses($host, $records = [], $dnscache = false) {
-		return [];
+		throw new LogicException(__FUNCTION__ . '() double not implemented — add a real one before testing this path');
 	}
 }
 
 if (!function_exists('is_ipaddr_configured')) {
-	// Only reached by PFB_FILTER_URL, which the seed suite does not exercise.
+	// Only reached by PFB_FILTER_URL, which the seed suite does not exercise. Fail
+	// fast rather than return a guessed false that could hide a missing real double.
 	function is_ipaddr_configured($ipaddr, $ignore_if = '', $check_localip = false, $check_subnets = false, $cidrprefix = '') {
-		return false;
+		throw new LogicException(__FUNCTION__ . '() double not implemented — add a real one before testing this path');
 	}
 }

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -1,0 +1,141 @@
+<?php
+/*
+ * pfsense_doubles.php — runtime doubles for the pfSense-provided functions that
+ * pfblockerng.inc references but that don't exist off-appliance.
+ *
+ * The PHPStan stubs in stubs/pfsense/ only assert symbol existence (empty
+ * bodies) — useless as behavioural doubles. Here we define the small set the
+ * unit-tested code paths (and pfblockerng.inc's load-time top-level code)
+ * actually invoke, with FAITHFUL behaviour where a tested function's result
+ * depends on it:
+ *
+ *   - is_ipaddrv4 / is_ipaddrv6 / is_ipaddr — mirror pfSense util.inc exactly
+ *     (ip2long round-trip for v4; filter_var for v6). pfb_filter (IP/IPV4) and
+ *     pfb_dnsbl_abp_extract_ip depend on their precise accept/reject behaviour.
+ *
+ * Everything else is a minimal no-op/throwaway double: it exists only so the
+ * symbol resolves. Functions reached only by code paths the seed suite does NOT
+ * exercise (URL/HOSTNAME validation, host resolution) get a conservative stub.
+ *
+ * Each double is guarded by function_exists() so a future real include never
+ * collides with it.
+ */
+
+if (!function_exists('is_ipaddrv4')) {
+	// pfSense util.inc: a string whose ip2long round-trips back to itself.
+	// Rejects '1.2.3', leading-zero octets, out-of-range, non-strings.
+	function is_ipaddrv4($ipaddr) {
+		if (!is_string($ipaddr) || empty($ipaddr)) {
+			return false;
+		}
+		$ip_long = ip2long($ipaddr);
+		$ip_reverse = long2ip($ip_long);
+		return ($ipaddr === $ip_reverse);
+	}
+}
+
+if (!function_exists('is_ipaddrv6')) {
+	// pfSense util.inc: strip a zone id (%scope), then FILTER_VALIDATE_IP v6.
+	function is_ipaddrv6($ipaddr) {
+		if (!is_string($ipaddr) || empty($ipaddr)) {
+			return false;
+		}
+		if (strstr($ipaddr, '%') !== false) {
+			$parts = explode('%', $ipaddr);
+			$ipaddr = $parts[0];
+		}
+		return (filter_var($ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false);
+	}
+}
+
+if (!function_exists('is_ipaddr')) {
+	// pfSense util.inc: v4 OR v6.
+	function is_ipaddr($ipaddr) {
+		return (is_ipaddrv4($ipaddr) || is_ipaddrv6($ipaddr));
+	}
+}
+
+if (!function_exists('is_hostname')) {
+	// Faithful-enough RFC-1123 hostname check (labels 1-63 of [a-z0-9-], not
+	// starting/ending '-', total <= 255). The seed suite does not assert
+	// PFB_FILTER_HOSTNAME edge cases; this only needs to be plausible.
+	function is_hostname($hostname, $allow_wildcard = false) {
+		if (!is_string($hostname) || $hostname === '' || strlen($hostname) > 255) {
+			return false;
+		}
+		if ($allow_wildcard && strpos($hostname, '*') === 0) {
+			$hostname = substr($hostname, 2);
+		}
+		foreach (explode('.', $hostname) as $label) {
+			if (!preg_match('/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i', $label)) {
+				return false;
+			}
+		}
+		return true;
+	}
+}
+
+if (!function_exists('system_get_uniqueid')) {
+	// Called at pfblockerng.inc load time (cURL user-agent). Any stable string.
+	function system_get_uniqueid() {
+		return 'phpunit-0000000000000000';
+	}
+}
+
+if (!function_exists('write_rcfile')) {
+	// pfb_filter_service()/pfb_dnsbl_service() call this at load time. No-op:
+	// we never assert rc.d generation in unit tests.
+	function write_rcfile($rc) {
+		return true;
+	}
+}
+
+if (!function_exists('safe_mkdir')) {
+	// pfSense util.inc: recursive mkdir if absent. Faithful — pfb_unbound_python_sources
+	// uses it to (re)create the per-feed raw dir, which the manifest test relies on.
+	function safe_mkdir($path, $mode = 0755) {
+		if (!is_dir($path)) {
+			return @mkdir($path, $mode, true);
+		}
+		return true;
+	}
+}
+
+if (!function_exists('rmdir_recursive')) {
+	// pfSense util.inc: delete a tree. Faithful — used to reset the raw dir.
+	function rmdir_recursive($path) {
+		if (!is_dir($path) || is_link($path)) {
+			return @unlink($path);
+		}
+		foreach (scandir($path) ?: [] as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			rmdir_recursive("{$path}/{$entry}");
+		}
+		return @rmdir($path);
+	}
+}
+
+if (!function_exists('unlink_if_exists')) {
+	function unlink_if_exists($path) {
+		if (is_file($path) || is_link($path)) {
+			return @unlink($path);
+		}
+		return false;
+	}
+}
+
+if (!function_exists('resolve_host_addresses')) {
+	// Only reached by PFB_FILTER_URL, which the seed suite does not exercise.
+	function resolve_host_addresses($host, $records = [], $dnscache = false) {
+		return [];
+	}
+}
+
+if (!function_exists('is_ipaddr_configured')) {
+	// Only reached by PFB_FILTER_URL, which the seed suite does not exercise.
+	function is_ipaddr_configured($ipaddr, $ignore_if = '', $check_localip = false, $check_subnets = false, $cidrprefix = '') {
+		return false;
+	}
+}

--- a/tests/php/shims/config.lib.inc
+++ b/tests/php/shims/config.lib.inc
@@ -1,0 +1,3 @@
+<?php
+// Empty shim: satisfies require_once('config.lib.inc') from pfblockerng.inc under PHPUnit.
+// pfSense runtime functions are provided as doubles in pfsense_doubles.php.

--- a/tests/php/shims/functions.inc
+++ b/tests/php/shims/functions.inc
@@ -1,0 +1,3 @@
+<?php
+// Empty shim: satisfies require_once('functions.inc') from pfblockerng.inc under PHPUnit.
+// pfSense runtime functions are provided as doubles in pfsense_doubles.php.

--- a/tests/php/shims/globals.inc
+++ b/tests/php/shims/globals.inc
@@ -1,0 +1,3 @@
+<?php
+// Empty shim: satisfies require_once('globals.inc') from pfblockerng.inc under PHPUnit.
+// pfSense runtime functions are provided as doubles in pfsense_doubles.php.

--- a/tests/php/shims/pfsense-utils.inc
+++ b/tests/php/shims/pfsense-utils.inc
@@ -1,0 +1,3 @@
+<?php
+// Empty shim: satisfies require_once('pfsense-utils.inc') from pfblockerng.inc under PHPUnit.
+// pfSense runtime functions are provided as doubles in pfsense_doubles.php.

--- a/tests/php/shims/pkg-utils.inc
+++ b/tests/php/shims/pkg-utils.inc
@@ -1,0 +1,3 @@
+<?php
+// Empty shim: satisfies require_once('pkg-utils.inc') from pfblockerng.inc under PHPUnit.
+// pfSense runtime functions are provided as doubles in pfsense_doubles.php.

--- a/tests/php/shims/service-utils.inc
+++ b/tests/php/shims/service-utils.inc
@@ -1,0 +1,3 @@
+<?php
+// Empty shim: satisfies require_once('service-utils.inc') from pfblockerng.inc under PHPUnit.
+// pfSense runtime functions are provided as doubles in pfsense_doubles.php.

--- a/tests/php/shims/services.inc
+++ b/tests/php/shims/services.inc
@@ -1,0 +1,3 @@
+<?php
+// Empty shim: satisfies require_once('services.inc') from pfblockerng.inc under PHPUnit.
+// pfSense runtime functions are provided as doubles in pfsense_doubles.php.

--- a/tests/php/shims/util.inc
+++ b/tests/php/shims/util.inc
@@ -1,0 +1,3 @@
+<?php
+// Empty shim: satisfies require_once('util.inc') from pfblockerng.inc under PHPUnit.
+// pfSense runtime functions are provided as doubles in pfsense_doubles.php.


### PR DESCRIPTION
## Summary

Closes #39 — adds the missing **fast PHP unit layer** beneath the live-VM smoke
(ADR-04), mirroring how the Python suite tests pure functions without a live box.

PHPUnit (981-test Python suite already exists; PHP had only `php -l` + PHPStan).

## Approach — test the real code, no extraction

`pfblockerng.inc` is mostly pfSense-integration code: it opens with `require_once`
of eight pfSense core includes and runs a little top-level code. Rather than copy
functions out (which would mean a parallel FreeBSD-ports `pkg-plist` change), the
suite loads the **real, unmodified** `pfblockerng.inc` off-appliance via
`tests/php/bootstrap.php`:

- **Include shims** (`tests/php/shims/`) — empty files named after the eight
  pfSense includes satisfy `require_once` as no-ops.
- **pfSense doubles** (`tests/php/pfsense_doubles.php`) — the PHPStan stubs in
  `stubs/pfsense/` are empty-bodied (symbol existence only) and useless as
  behavioural doubles, so this provides faithful ones where a result depends on
  them (`is_ipaddrv4`/`is_ipaddrv6`/`is_ipaddr` mirror pfSense `util.inc`;
  `safe_mkdir`/`rmdir_recursive` touch the temp sandbox) and no-ops where it does
  not (`write_rcfile`, `system_get_uniqueid`, …).
- `$g`/`$pfb` point at a temp sandbox; `$argv` is cleared so the bottom-of-file
  daemon dispatch stays dormant.

The test harness moves/changes no production logic.

## What's added

- `composer.json`: `phpunit/phpunit` dev dep (target PHP 8.3 / CE 2.8)
- `phpunit.xml`: bootstrap + testsuite + informational coverage source
- CI: new **`php-unit`** job in `test.yml` (pcov coverage, informational), wired
  into the `all-tests-passed` gate
- `.githooks/pre-commit`: runs `vendor/bin/phpunit` when the vendor tree is
  present (mirrors the PHPStan gating)
- Docs: `tests/php/README.md`, plus README / CLAUDE.md updates

## Seed coverage — 82 tests, green

`pfb_filter` (DOMAIN/IP/IPV4/WORD/HEX_COLOR/ON_OFF/NUM), `pfbng_text_area_decode`
(base64/CRLF/comment/IDN), `pfb_dnsbl_abp_extract_ip` (ADR-07 DNSBL-IP),
`sanitize_ipaddr`, `pfb_validate_domain_labels`, `pfb_strtolower`, and the
ADR-06/07 `pfb_unbound_python_sources` manifest writer (format/provenance tagging,
chroot-relative raw path, plain-vs-ABP extraction). A few tests deliberately pin
real production quirks (e.g. `pfb_filter` NUM returns the default for `'0'`) as
regression anchors.

## Latent notices the suite surfaced — now fixed (commit `5719155`)

Run under strict `E_ALL`, the suite caught three pre-existing undefined-symbol
notices in `pfblockerng.inc` (undefined `$pfb['pnow']` on first log, a maskless
`list()`, an uninitialised string-mode `$custom`) plus a downstream
`str_replace(null)` deprecation on the common bare-IP path. They are **benign on
a live box** — pfSense's php.ini masks `E_WARNING`/`E_NOTICE`/`E_DEPRECATED` with
`display_errors=off` (`src/etc/rc.php_ini_setup`), so they're never shown or
logged — but the second commit guards all three (behaviour-preserving) so the
suite reads clean and the `str_replace` path is PHP-9-safe (null → `TypeError`).

## Out of scope

Deep pfSense-runtime integration (config apply, service reloads, pf/Unbound
wiring, URL/MIME validation that shells out or resolves hosts) stays the live-VM
smoke's job — see `.ADRs/ADR_04_VM_Smoke_Tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive PHP unit test suite, bootstrap, runtime shims/doubles and CI job to run PHPUnit on PHP 8.3; workflow now gates on these tests.

* **Bug Fixes**
  * Improved robustness in input handling, CIDR parsing defaults, and logger timestamp checks.

* **Hooks**
  * Pre-commit hook now conditionally runs PHPUnit when the PHPUnit binary is present.

* **Documentation**
  * Expanded developer docs and added a PHP test-suite README.

* **Chores**
  * Added PHPUnit to dev tooling, composer scripts, and ignored PHPUnit cache files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->