### PR TITLE
test: shell-test tooling (shellspec) + fix #27/#28/#30 (#40)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -92,6 +92,14 @@ else
 	skip shellcheck
 fi
 
+# --- Shell: shellspec functional suite (gated on the tool, like shellcheck) ---
+if have shellspec; then
+	step 'shellspec'
+	shellspec || failed 'shellspec'
+else
+	skip shellspec
+fi
+
 # --- PHP: php -l syntax check (output shown only for files that fail) ---
 if have php; then
 	step 'php -l'

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -80,13 +80,13 @@ else
 	skip markdownlint
 fi
 
-# --- Shell: sh -n parse gate + shellcheck (generated ip_pre_AWS_*.sh excluded) ---
+# --- Shell: sh -n parse gate + shellcheck ---
 if have shellcheck; then
 	step 'shell (sh -n + shellcheck)'
-	find src scripts -name '*.sh' ! -name 'ip_pre_AWS_*.sh' | sort | while IFS= read -r f; do
+	find src scripts -name '*.sh' | sort | while IFS= read -r f; do
 		sh -n "$f" || exit 1
 	done || failed 'sh -n'
-	find src scripts -name '*.sh' ! -name 'ip_pre_AWS_*.sh' | sort \
+	find src scripts -name '*.sh' | sort \
 		| xargs shellcheck --severity=warning || failed 'shellcheck'
 else
 	skip shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,47 @@ jobs:
         # .shellcheckrc in the repo root configures suppressions.
         run: find src scripts -name '*.sh' ! -name 'ip_pre_AWS_*.sh' | sort | xargs shellcheck --severity=warning
 
+  shell-tests:
+    name: shellspec (POSIX sh)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install jq
+        # jq drives the ip_pre_AWS_*.sh region filters (required).
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Install shellspec
+        # Pinned release tarball; the executable runs from its extracted tree.
+        run: |
+          curl -fsSL https://github.com/shellspec/shellspec/archive/refs/tags/0.28.1.tar.gz | tar -xz
+          echo "$PWD/shellspec-0.28.1" >> "$GITHUB_PATH"
+
+      - name: Run shellspec
+        # Config in .shellspec (--shell sh). Functional gate for the shell scripts.
+        run: shellspec
+
+      - name: Install kcov (coverage; best-effort)
+        # Coverage is informational; if kcov is unavailable on the runner, skip it
+        # rather than fail the gating job.
+        continue-on-error: true
+        run: sudo apt-get install -y kcov
+
+      - name: Coverage (kcov) — informational
+        # Informational only (no floor yet, mirroring #38); never gates CI.
+        continue-on-error: true
+        run: shellspec --kcov
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shell-coverage
+          path: coverage/
+          if-no-files-found: ignore
+
   php-syntax:
     name: PHP syntax check (php -l)
     runs-on: ubuntu-latest
@@ -172,7 +213,7 @@ jobs:
   all-tests-passed:
     name: All tests passed
     if: always()
-    needs: [test, test-typing, ruff, shellcheck, php-syntax, php-static-analysis, markdownlint]
+    needs: [test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, markdownlint]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
@@ -191,6 +232,10 @@ jobs:
           fi
           if [ "${{ needs.shellcheck.result }}" != "success" ]; then
             echo "ShellCheck failed or was cancelled."
+            exit 1
+          fi
+          if [ "${{ needs.shell-tests.result }}" != "success" ]; then
+            echo "shellspec shell tests failed or were cancelled."
             exit 1
           fi
           if [ "${{ needs.php-syntax.result }}" != "success" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,13 +102,11 @@ jobs:
       - name: Parse-check all shell scripts (sh -n)
         # Cheap syntax gate (shell analogue of php -l). Catches unterminated
         # quotes and other parse errors even if ShellCheck is ever disabled.
-        # ip_pre_AWS_*.sh files are auto-generated — excluded.
-        run: find src scripts -name '*.sh' ! -name 'ip_pre_AWS_*.sh' | sort | xargs -n1 sh -n
+        run: find src scripts -name '*.sh' | sort | xargs -n1 sh -n
 
       - name: Run ShellCheck
-        # ip_pre_AWS_*.sh files are auto-generated — excluded from analysis.
         # .shellcheckrc in the repo root configures suppressions.
-        run: find src scripts -name '*.sh' ! -name 'ip_pre_AWS_*.sh' | sort | xargs shellcheck --severity=warning
+        run: find src scripts -name '*.sh' | sort | xargs shellcheck --severity=warning
 
   shell-tests:
     name: shellspec (POSIX sh)

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ venv/
 # ── PHP ───────────────────────────────────────────────────────────────────────
 vendor/
 
+# ── Shell tests (shellspec / kcov) ────────────────────────────────────────────
+coverage/
+.shellspec-quick.log
+report/
+
 # ── Build / release artefacts ─────────────────────────────────────────────────
 *.tar.gz
 *.tar.bz2

--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,6 @@
+--shell sh
+--default-path tests/shell
+--load-path tests/shell
+--require spec_helper
+# Coverage (shellspec --kcov): only the shipped pfBlockerNG shell scripts.
+--kcov-options "--include-path=src/usr/local/pkg/pfblockerng"

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ shared and reviewed (the default `.git/hooks` is local-only and cannot be
 committed):
 
 - **`pre-commit`** runs the fast linters and the unit suite (Ruff, pytest,
-  markdownlint, ShellCheck + `sh -n`, `php -l`; PHPStan only when `vendor/` is
-  present) and blocks the commit on any failure. A check whose tool is not
-  installed is skipped (CI is the hard gate); bypass with `git commit --no-verify`.
+  markdownlint, ShellCheck + `sh -n`, shellspec, `php -l`; PHPStan only when
+  `vendor/` is present) and blocks the commit on any failure. A check whose tool is
+  not installed is skipped (CI is the hard gate); bypass with `git commit --no-verify`.
 - **`pre-push`** enforces the tag naming convention before anything is pushed:
 
 | Commit reachable from | Required tag form  |
@@ -100,6 +100,24 @@ python3 -m pytest
 ```
 
 Test paths and options are configured in `pyproject.toml`; no `cd` is required.
+
+### Shell tests (shellspec)
+
+The POSIX `sh` — the `ip_pre_AWS_*.sh` region pre-scripts and the testable
+functions in `pfblockerng.sh` — has a functional suite under `tests/shell/`, run
+with [shellspec](https://shellspec.info/) (pure POSIX, native kcov coverage):
+
+```sh
+shellspec            # from the repo root; reads ./.shellspec
+shellspec --kcov     # with coverage (informational; needs kcov)
+```
+
+Install with `brew install shellspec` (macOS) or the official installer
+(`curl -fsSL https://git.io/shellspec | sh`). The pre-commit hook and CI run it
+automatically when `shellspec` is present (coverage is informational, no floor).
+See [`tests/shell/README.md`](tests/shell/README.md) for the harness contracts
+(the `iprange` PATH shim, the AWS fixture, and the `PFB_SOURCED` source-for-test
+pattern).
 
 ### DNSBL list build (Python)
 
@@ -250,7 +268,8 @@ vendor/bin/phpstan analyse
 
 [ShellCheck](https://www.shellcheck.net/) is available as a VS Code extension
 (see IDE setup above) and is also enforced in CI at `--severity=warning`.
-Configuration is in `.shellcheckrc`.
+Configuration is in `.shellcheckrc`. Functional shell tests (shellspec) live in
+`tests/shell/` — see [Shell tests (shellspec)](#shell-tests-shellspec) above.
 
 #### Markdown
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AF.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AF.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_ALL_REGIONS.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_ALL_REGIONS.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP.sh
@@ -15,10 +15,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_EAST.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_EAST.sh
@@ -15,10 +15,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_NORTHEAST.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_NORTHEAST.sh
@@ -15,10 +15,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTH.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTH.sh
@@ -15,10 +15,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTHEAST.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_AP_SOUTHEAST.sh
@@ -15,10 +15,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_CA.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_CA.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_CN.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_CN.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTH.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTH.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTHWEST.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_CN_NORTHWEST.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_CENTRAL.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_CENTRAL.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_NORTH.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_NORTH.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_SOUTH.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_SOUTH.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_WEST.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_EU_WEST.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_IL.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_IL.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_ME.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_ME.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_CENTRAL.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_CENTRAL.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_SOUTH.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_ME_SOUTH.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_SA.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_SA.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_US.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_US.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_US_EAST.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_US_EAST.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_US_GOV.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_US_GOV.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/ip_pre_AWS_US_WEST.sh
+++ b/src/usr/local/pkg/pfblockerng/ip_pre_AWS_US_WEST.sh
@@ -14,10 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
-
-tempfile=/tmp/pfbtemp1_$rvar
+tempfile="$(mktemp "${TMPDIR:-/tmp}/pfbtemp1.XXXXXXXX")" || exit 1
 alias="${1}"
 prefix="${2}"
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -14,95 +14,108 @@
 # GNU General Public License for more details.
 
 
-now=$(/bin/date +%m/%d/%y' '%T)
+# Create a private per-run temp directory and define the temp file paths beneath
+# it. Using mktemp(1) instead of a low-entropy PRNG (jot) closes the predictable
+# /tmp-path TOCTOU/symlink hole for this root-run script (issue #30). exitnow()
+# removes the whole directory on exit.
+pfb_make_tmpdir() {
+	tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/pfb.XXXXXXXX")" || exit 1
+	tempfile="${tmpdir}/pfbtemp1"
+	tempfile2="${tmpdir}/pfbtemp2"
+	dupfile="${tmpdir}/pfbtemp3"
+	dedupfile="${tmpdir}/pfbtemp4"
+	addfile="${tmpdir}/pfbtemp5"
+	matchfile="${tmpdir}/pfbtemp7"
+	tempmatchfile="${tmpdir}/pfbtemp8"
+}
 
-# Application Locations
-pathgrepcidr="/usr/local/bin/grepcidr"
-pathaggregate="/usr/local/bin/iprange"
-pathgeoip="/usr/local/bin/mmdblookup"
-pathhost=/usr/bin/host
-pathtar=/usr/bin/tar
-pathpfctl=/sbin/pfctl
+# Top-level initialisation. Guarded so the script can be sourced for unit tests
+# (PFB_SOURCED=1) to exercise the functions below in isolation without running
+# any of this; the executable path runs it because PFB_SOURCED is unset. The
+# function definitions further down are always defined on source.
+if [ -z "${PFB_SOURCED:-}" ]; then
+	now=$(/bin/date +%m/%d/%y' '%T)
 
-# Script Arguments
-alias="${2}"
-max="${3}"
-dedup="${4}"
-cc="$(echo "${5}" | sed 's/,/, /g')"
-ccwhite="$(echo "${6}" | tr '[:upper:]' '[:lower:]')"
-ccblack="$(echo "${7}" | tr '[:upper:]' '[:lower:]')"
-etblock="$(echo "${8}" | sed 's/,/, /g')"
-etmatch="$(echo "${9}" | sed 's/,/, /g')"
+	# Application Locations
+	pathgrepcidr="/usr/local/bin/grepcidr"
+	pathaggregate="/usr/local/bin/iprange"
+	pathgeoip="/usr/local/bin/mmdblookup"
+	pathhost=/usr/bin/host
+	pathtar=/usr/bin/tar
+	pathpfctl=/sbin/pfctl
 
-# File Locations
-aliasarchive="/usr/local/etc/aliastables.tar.bz2"
-pathgeoipdat="/usr/local/share/GeoIP/GeoLite2-Country.mmdb"
-pathasndat="/usr/local/share/GeoIP/asn.mmdb"
-pathasncsv="/usr/local/share/GeoIP/asn.csv"
-pathasntable="/usr/local/www/pfblockerng/pfblockerng_asn.txt"
-pfbsuppression=/var/db/pfblockerng/pfbsuppression.txt
-# ADR-06: pfbdnsblsuppression / pfbalexa removed (only used by the dropped
-# dnsbl_scrub build-time whitelist/TOP1M removal; now applied at query time).
-masterfile=/var/db/pfblockerng/masterfile
-mastercat=/var/db/pfblockerng/mastercat
-geoiplog=/var/log/pfblockerng/geoip.log
-errorlog=/var/log/pfblockerng/error.log
-extraslog=/var/log/pfblockerng/extras.log
+	# Script Arguments
+	alias="${2}"
+	max="${3}"
+	dedup="${4}"
+	cc="$(echo "${5}" | sed 's/,/, /g')"
+	ccwhite="$(echo "${6}" | tr '[:upper:]' '[:lower:]')"
+	ccblack="$(echo "${7}" | tr '[:upper:]' '[:lower:]')"
+	etblock="$(echo "${8}" | sed 's/,/, /g')"
+	etmatch="$(echo "${9}" | sed 's/,/, /g')"
 
-# Folder Locations
-etdir=/var/db/pfblockerng/ET
-tmpxlsx=/tmp/xlsx/
-pfbdb=/var/db/pfblockerng/
-pfbdeny=/var/db/pfblockerng/deny/
-pfborig=/var/db/pfblockerng/original/
-pfbmatch=/var/db/pfblockerng/match/
-pfbpermit=/var/db/pfblockerng/permit/
-pfbnative=/var/db/pfblockerng/native/
-pfsensealias=/var/db/aliastables/
-pfbdomain=/var/db/pfblockerng/dnsbl/
-pfbdomainorig=/var/db/pfblockerng/dnsblorig/
+	# File Locations
+	aliasarchive="/usr/local/etc/aliastables.tar.bz2"
+	pathgeoipdat="/usr/local/share/GeoIP/GeoLite2-Country.mmdb"
+	pathasndat="/usr/local/share/GeoIP/asn.mmdb"
+	pathasncsv="/usr/local/share/GeoIP/asn.csv"
+	pathasntable="/usr/local/www/pfblockerng/pfblockerng_asn.txt"
+	pfbsuppression=/var/db/pfblockerng/pfbsuppression.txt
+	# ADR-06: pfbdnsblsuppression / pfbalexa removed (only used by the dropped
+	# dnsbl_scrub build-time whitelist/TOP1M removal; now applied at query time).
+	masterfile=/var/db/pfblockerng/masterfile
+	mastercat=/var/db/pfblockerng/mastercat
+	geoiplog=/var/log/pfblockerng/geoip.log
+	errorlog=/var/log/pfblockerng/error.log
+	extraslog=/var/log/pfblockerng/extras.log
 
-# Store 'Match' d-dedups in matchdedup.txt file
-matchdedup=matchdedup_v4.txt
+	# Folder Locations
+	etdir=/var/db/pfblockerng/ET
+	tmpxlsx=/tmp/xlsx/
+	pfbdb=/var/db/pfblockerng/
+	pfbdeny=/var/db/pfblockerng/deny/
+	pfborig=/var/db/pfblockerng/original/
+	pfbmatch=/var/db/pfblockerng/match/
+	pfbpermit=/var/db/pfblockerng/permit/
+	pfbnative=/var/db/pfblockerng/native/
+	pfsensealias=/var/db/aliastables/
+	pfbdomain=/var/db/pfblockerng/dnsbl/
+	pfbdomainorig=/var/db/pfblockerng/dnsblorig/
 
-# Randomize temporary variables
-rvar="$(/usr/bin/jot -r 1 1000 100000)"
+	# Store 'Match' d-dedups in matchdedup.txt file
+	matchdedup=matchdedup_v4.txt
 
-tempfile=/tmp/pfbtemp1_$rvar
-tempfile2=/tmp/pfbtemp2_$rvar
-dupfile=/tmp/pfbtemp3_$rvar
-dedupfile=/tmp/pfbtemp4_$rvar
-addfile=/tmp/pfbtemp5_$rvar
-matchfile=/tmp/pfbtemp7_$rvar
-tempmatchfile=/tmp/pfbtemp8_$rvar
+	# Create a private per-run temp directory (sets tempfile, tempfile2, ...).
+	pfb_make_tmpdir
 
-# ADR-06: domainmaster / dnsbl_tld_remove / dnsbl_python_{data,zone,count} removed
-# along with dnsbl_scrub + domaintldpy (the dropped build-time DNSBL passes).
+	# ADR-06: domainmaster / dnsbl_tld_remove / dnsbl_python_{data,zone,count} removed
+	# along with dnsbl_scrub + domaintldpy (the dropped build-time DNSBL passes).
 
-ip_placeholder="$(/usr/local/sbin/read_xml_tag.sh string installedpackages/pfblockerngipsettings/config/ip_placeholder)"
-if [ -z "${ip_placeholder}" ]; then
-	ip_placeholder=127.1.7.7
+	ip_placeholder="$(/usr/local/sbin/read_xml_tag.sh string installedpackages/pfblockerngipsettings/config/ip_placeholder)"
+	if [ -z "${ip_placeholder}" ]; then
+		ip_placeholder=127.1.7.7
+	fi
+	ip_placeholder2="$(echo "${ip_placeholder}" | sed 's/\./\\\./g')"
+	ip_placeholder3="$(echo "${ip_placeholder}" | cut -d '.' -f 1-3)"
+
+	USE_MFS_TMPVAR="$(/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml)"
+	DISK_NAME="$(/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}')"
+	DISK_TYPE="$(/usr/bin/basename "${DISK_NAME}" | /usr/bin/cut -c1-2)"
+
+	if [ ! -d "${pfbdb}" ]; then mkdir "${pfbdb}"; fi
+	if [ ! -d "${pfsensealias}" ]; then mkdir "${pfsensealias}"; fi
+	if [ ! -d "${pfbmatch}" ]; then mkdir "${pfbmatch}"; fi
+	if [ ! -d "${etdir}" ]; then mkdir "${etdir}"; fi
+	if [ ! -d "${tmpxlsx}" ]; then mkdir "${tmpxlsx}"; fi
+
+	if [ ! -f "${masterfile}" ]; then touch "${masterfile}"; fi
+	if [ ! -f "${mastercat}" ]; then touch "${mastercat}"; fi
 fi
-ip_placeholder2="$(echo "${ip_placeholder}" | sed 's/\./\\\./g')"
-ip_placeholder3="$(echo "${ip_placeholder}" | cut -d '.' -f 1-3)"
-
-USE_MFS_TMPVAR="$(/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml)"
-DISK_NAME="$(/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}')"
-DISK_TYPE="$(/usr/bin/basename "${DISK_NAME}" | /usr/bin/cut -c1-2)"
-
-if [ ! -d "${pfbdb}" ]; then mkdir "${pfbdb}"; fi
-if [ ! -d "${pfsensealias}" ]; then mkdir "${pfsensealias}"; fi
-if [ ! -d "${pfbmatch}" ]; then mkdir "${pfbmatch}"; fi
-if [ ! -d "${etdir}" ]; then mkdir "${etdir}"; fi
-if [ ! -d "${tmpxlsx}" ]; then mkdir "${tmpxlsx}"; fi
-
-if [ ! -f "${masterfile}" ]; then touch "${masterfile}"; fi
-if [ ! -f "${mastercat}" ]; then touch "${mastercat}"; fi
 
 
-# Remove temp files before exiting.
+# Remove the private per-run temp directory before exiting (issue #30).
 exitnow() {
-	rm -f /tmp/pfbtemp*_"${rvar}"
+	rm -rf "${tmpdir}"
 	exit
 }
 
@@ -470,7 +483,9 @@ iptoasn() {
 	ip="${alias}"
 	asn="$(${pathgeoip} -f ${pathasndat} -i "${ip}" 2>&1 | tr -d '"{},' | grep -v '^[[:space:]]*$' | cut -d '<' -f1 | tr -s ' ' | tr '\n' '|' | sed -e 's/: |/: /g' -e 's/asn:/ ASN:/g')"
 
-	if [ ! -s "${asn}" ]; then
+	# $asn is the lookup result string, not a filename: test its contents with
+	# -n, not the file-exists test -s (issue #28).
+	if [ -n "${asn}" ]; then
 		echo "${asn}"
 	else
 		echo ""
@@ -554,8 +569,12 @@ reputation_max() {
 	fi
 
 	# If no matches found remove previous matchoutfile if exists.
+	# Derive header from $alias (in scope), matching reputation_dmax/pmax; do not
+	# rely on a stale $header global, and operate on the absolute ${pfbmatch}
+	# path rather than a relative one (issue #27).
+	header="$(echo "${alias##*/}" | cut -d '.' -f1)"
 	matchoutfile="match${header}.txt"
-	if [ ! -s "${tempmatchfile}" ] && [ -f "${matchoutfile}" ]; then rm -r "${matchoutfile}"; fi
+	if [ ! -s "${tempmatchfile}" ] && [ -f "${pfbmatch}${matchoutfile}" ]; then rm -f "${pfbmatch}${matchoutfile}"; fi
 	# Move match file to the match folder by individual blocklist name
 	if [ -s "${tempmatchfile}" ]; then mv -f "${tempmatchfile}" "${pfbmatch}${matchoutfile}"; fi
 
@@ -941,6 +960,12 @@ closingprocess() {
 	pfctlcount="$(${pathpfctl} -vvsTables | awk '/Addresses/ {s+=$2}; END {print s}')"
 	echo "Table Usage Count         ${pfctlcount}"
 }
+
+# When sourced for unit testing (PFB_SOURCED=1) stop here: only the function
+# definitions above are wanted, not the init/dispatch below. `return` is valid at
+# the top level of a sourced script and is never reached on direct execution
+# (PFB_SOURCED is unset, so the && short-circuits).
+[ -n "${PFB_SOURCED:-}" ] && return 0 2>/dev/null
 
 # Call appropriate processes using script argument $1.
 case "${1}" in

--- a/tests/shell/README.md
+++ b/tests/shell/README.md
@@ -1,0 +1,59 @@
+# Shell test suite (shellspec)
+
+Functional tests for the project's POSIX `sh` — the `ip_pre_AWS_*.sh` region
+pre-scripts and the testable functions in `pfblockerng.sh`. This complements the
+existing static gating (ShellCheck + `sh -n`) with behavioural coverage, and locks
+in the fixes for issues #27, #28, and #30.
+
+Framework: [shellspec](https://shellspec.info/) (pure POSIX, BDD-style, native
+kcov coverage). Tests run under `/bin/sh`.
+
+## Running
+
+```sh
+shellspec                     # from the repo root; reads ./.shellspec
+shellspec tests/shell/ip_pre_aws_spec.sh   # a single spec
+shellspec --kcov              # with coverage (writes ./coverage/, needs kcov)
+```
+
+Install: `brew install shellspec` (macOS) or the official installer
+(`curl -fsSL https://git.io/shellspec | sh`); `kcov` is only needed for `--kcov`.
+The pre-commit hook and CI run the suite automatically when `shellspec` is present.
+
+## Layout
+
+```text
+tests/shell/
+├── spec_helper.sh                       # shared setup (loaded via --require)
+├── bin/iprange                          # PATH shim for the FreeBSD aggregator
+├── fixtures/aws-ip-ranges.json          # AWS ip-ranges.json shape, 1 prefix/region
+├── ip_pre_aws_spec.sh                   # region-filter family (the headline target)
+├── pfblockerng_reputation_max_spec.sh   # issue #27
+├── pfblockerng_iptoasn_spec.sh          # issue #28
+└── pfblockerng_tempfile_spec.sh         # issue #30
+```
+
+Config lives in the repo-root `.shellspec` (`--shell sh`, `--default-path`/
+`--load-path tests/shell`, `--require spec_helper`, kcov include path).
+
+## How it works — three contracts to know
+
+- **`iprange` shim (`bin/iprange`).** The AWS pre-scripts pipe their v4 prefixes
+  through `iprange`, a FreeBSD-only CIDR aggregator not installable on the CI/dev
+  hosts. `spec_helper.sh` prepends `tests/shell/bin` to `PATH` so a `sort -u` shim
+  stands in (`jq` stays the real binary). The fixture uses one **non-adjacent** /24
+  per region, so there is nothing to coalesce and the shim is faithful. Do not rely
+  on the shim for aggregation behaviour.
+
+- **AWS fixture + per-region assertion.** `aws_filter <script> <_v4|_v6>` copies
+  `fixtures/aws-ip-ranges.json` (each region has a unique prefix), runs the script
+  over the copy — which it overwrites in place — and emits the result sorted and
+  space-joined. The spec asserts the exact surviving set per script. The
+  `us-`/`us-gov-` overlap is pinned intentionally (see the spec's header comment).
+
+- **Sourcing `pfblockerng.sh` for unit tests.** The script is *library on source,
+  run on exec*: it defines its functions, then `[ -n "${PFB_SOURCED:-}" ] && return`
+  before running any top-level init or the argument dispatch. `pfb_source` (in
+  `spec_helper.sh`) sets `PFB_SOURCED=1` and dot-sources it, so a spec can set the
+  globals a function reads and call it directly — with **no** system side effects.
+  GeoIP lookups are replaced by a stub (`make_geoip_stub`).

--- a/tests/shell/bin/iprange
+++ b/tests/shell/bin/iprange
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Test shim for the FreeBSD `iprange` CIDR aggregator, which the
+# ip_pre_AWS_*.sh pre-scripts pipe their v4 prefixes through (`jq ... | iprange`).
+#
+# The real tool is FreeBSD-only and not installable on the Linux CI runner or a
+# macOS dev box, so this stand-in provides just enough behaviour for the region
+# pre-scripts' tests: read CIDRs on stdin, emit them sorted + de-duplicated.
+#
+# This is faithful for the suite because tests/shell/fixtures/aws-ip-ranges.json
+# uses one non-adjacent /24 per region — there is nothing for the real iprange to
+# coalesce, so `sort -u` yields the identical set. Do NOT rely on this shim for
+# aggregation semantics; it only stands in for the pass-through case.
+exec sort -u

--- a/tests/shell/fixtures/aws-ip-ranges.json
+++ b/tests/shell/fixtures/aws-ip-ranges.json
@@ -1,0 +1,260 @@
+{
+  "syncToken": "1700000000",
+  "createDate": "2024-01-01-00-00-00",
+  "prefixes": [
+    {
+      "ip_prefix": "10.10.0.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON",
+      "network_border_group": "af-south-1"
+    },
+    {
+      "ip_prefix": "10.11.0.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-east-1"
+    },
+    {
+      "ip_prefix": "10.12.0.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "10.13.0.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-1"
+    },
+    {
+      "ip_prefix": "10.14.0.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ip_prefix": "10.15.0.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-central-1"
+    },
+    {
+      "ip_prefix": "10.16.0.0/24",
+      "region": "cn-north-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-north-1"
+    },
+    {
+      "ip_prefix": "10.17.0.0/24",
+      "region": "cn-northwest-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-northwest-1"
+    },
+    {
+      "ip_prefix": "10.18.0.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
+      "ip_prefix": "10.19.0.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-north-1"
+    },
+    {
+      "ip_prefix": "10.20.0.0/24",
+      "region": "eu-south-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "10.21.0.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "10.22.0.0/24",
+      "region": "il-central-1",
+      "service": "AMAZON",
+      "network_border_group": "il-central-1"
+    },
+    {
+      "ip_prefix": "10.23.0.0/24",
+      "region": "me-central-1",
+      "service": "AMAZON",
+      "network_border_group": "me-central-1"
+    },
+    {
+      "ip_prefix": "10.24.0.0/24",
+      "region": "me-south-1",
+      "service": "AMAZON",
+      "network_border_group": "me-south-1"
+    },
+    {
+      "ip_prefix": "10.25.0.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON",
+      "network_border_group": "sa-east-1"
+    },
+    {
+      "ip_prefix": "10.26.0.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "10.27.0.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-west-1"
+    },
+    {
+      "ip_prefix": "10.28.0.0/24",
+      "region": "us-gov-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-east-1"
+    },
+    {
+      "ip_prefix": "10.29.0.0/24",
+      "region": "us-gov-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-west-1"
+    },
+    {
+      "ip_prefix": "10.30.0.0/24",
+      "region": "GLOBAL",
+      "service": "AMAZON",
+      "network_border_group": "GLOBAL"
+    }
+  ],
+  "ipv6_prefixes": [
+    {
+      "ipv6_prefix": "2001:db8:10::/48",
+      "region": "af-south-1",
+      "service": "AMAZON",
+      "network_border_group": "af-south-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:11::/48",
+      "region": "ap-east-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-east-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:12::/48",
+      "region": "ap-northeast-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:13::/48",
+      "region": "ap-south-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:14::/48",
+      "region": "ap-southeast-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:15::/48",
+      "region": "ca-central-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-central-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:16::/48",
+      "region": "cn-north-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-north-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:17::/48",
+      "region": "cn-northwest-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-northwest-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:18::/48",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:19::/48",
+      "region": "eu-north-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-north-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:20::/48",
+      "region": "eu-south-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:21::/48",
+      "region": "eu-west-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:22::/48",
+      "region": "il-central-1",
+      "service": "AMAZON",
+      "network_border_group": "il-central-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:23::/48",
+      "region": "me-central-1",
+      "service": "AMAZON",
+      "network_border_group": "me-central-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:24::/48",
+      "region": "me-south-1",
+      "service": "AMAZON",
+      "network_border_group": "me-south-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:25::/48",
+      "region": "sa-east-1",
+      "service": "AMAZON",
+      "network_border_group": "sa-east-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:26::/48",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:27::/48",
+      "region": "us-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-west-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:28::/48",
+      "region": "us-gov-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-east-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:29::/48",
+      "region": "us-gov-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-west-1"
+    },
+    {
+      "ipv6_prefix": "2001:db8:30::/48",
+      "region": "GLOBAL",
+      "service": "AMAZON",
+      "network_border_group": "GLOBAL"
+    }
+  ]
+}

--- a/tests/shell/ip_pre_aws_spec.sh
+++ b/tests/shell/ip_pre_aws_spec.sh
@@ -1,0 +1,62 @@
+#shellcheck shell=sh
+# ip_pre_AWS_*.sh — per-region AWS prefix pre-scripts.
+#
+# These 25 scripts are near-identical and hand-maintained, differing only by a jq
+# `startswith()` region filter (CLAUDE.md), and they are excluded from ShellCheck
+# / `sh -n` in CI. That makes them prime candidates for silent per-file drift —
+# exactly what this suite guards. Each script is run over the SAME fixture and the
+# exact surviving prefix set is asserted.
+#
+# Mechanics: aws_filter (spec_helper) copies fixtures/aws-ip-ranges.json, runs the
+# script against the copy (which it overwrites in place), and emits the result
+# sorted + space-joined. The real FreeBSD `iprange` aggregator is replaced by a
+# `sort -u` shim (tests/shell/bin/iprange); the fixture uses one non-adjacent /24
+# per region so there is nothing to coalesce and the shim is faithful.
+#
+# NOTE on the us-/us-gov- overlap: ip_pre_AWS_US.sh filters `startswith("us-")`,
+# which by design also matches the `us-gov-*` regions — so US includes the two
+# us-gov prefixes below, while US_GOV (`us-gov-`) and US_EAST/US_WEST (`us-east-`/
+# `us-west-`) stay disjoint from each other. These rows pin that behaviour.
+
+Describe 'ip_pre_AWS_*.sh region filters'
+  Parameters
+    # script                        proto  expected (sorted, space-joined)
+    "ip_pre_AWS_AF.sh"              _v4    "10.10.0.0/24"
+    "ip_pre_AWS_ALL_REGIONS.sh"     _v4    "10.10.0.0/24 10.11.0.0/24 10.12.0.0/24 10.13.0.0/24 10.14.0.0/24 10.15.0.0/24 10.16.0.0/24 10.17.0.0/24 10.18.0.0/24 10.19.0.0/24 10.20.0.0/24 10.21.0.0/24 10.22.0.0/24 10.23.0.0/24 10.24.0.0/24 10.25.0.0/24 10.26.0.0/24 10.27.0.0/24 10.28.0.0/24 10.29.0.0/24 10.30.0.0/24"
+    "ip_pre_AWS_AP.sh"              _v4    "10.11.0.0/24 10.12.0.0/24 10.13.0.0/24 10.14.0.0/24"
+    "ip_pre_AWS_AP_EAST.sh"         _v4    "10.11.0.0/24"
+    "ip_pre_AWS_AP_NORTHEAST.sh"    _v4    "10.12.0.0/24"
+    "ip_pre_AWS_AP_SOUTH.sh"        _v4    "10.13.0.0/24"
+    "ip_pre_AWS_AP_SOUTHEAST.sh"    _v4    "10.14.0.0/24"
+    "ip_pre_AWS_CA.sh"              _v4    "10.15.0.0/24"
+    "ip_pre_AWS_CN.sh"              _v4    "10.16.0.0/24 10.17.0.0/24"
+    "ip_pre_AWS_CN_NORTH.sh"        _v4    "10.16.0.0/24"
+    "ip_pre_AWS_CN_NORTHWEST.sh"    _v4    "10.17.0.0/24"
+    "ip_pre_AWS_EU.sh"              _v4    "10.18.0.0/24 10.19.0.0/24 10.20.0.0/24 10.21.0.0/24"
+    "ip_pre_AWS_EU_CENTRAL.sh"      _v4    "10.18.0.0/24"
+    "ip_pre_AWS_EU_NORTH.sh"        _v4    "10.19.0.0/24"
+    "ip_pre_AWS_EU_SOUTH.sh"        _v4    "10.20.0.0/24"
+    "ip_pre_AWS_EU_WEST.sh"         _v4    "10.21.0.0/24"
+    "ip_pre_AWS_IL.sh"              _v4    "10.22.0.0/24"
+    "ip_pre_AWS_ME.sh"              _v4    "10.23.0.0/24 10.24.0.0/24"
+    "ip_pre_AWS_ME_CENTRAL.sh"      _v4    "10.23.0.0/24"
+    "ip_pre_AWS_ME_SOUTH.sh"        _v4    "10.24.0.0/24"
+    "ip_pre_AWS_SA.sh"              _v4    "10.25.0.0/24"
+    "ip_pre_AWS_US.sh"              _v4    "10.26.0.0/24 10.27.0.0/24 10.28.0.0/24 10.29.0.0/24"
+    "ip_pre_AWS_US_EAST.sh"         _v4    "10.26.0.0/24"
+    "ip_pre_AWS_US_GOV.sh"          _v4    "10.28.0.0/24 10.29.0.0/24"
+    "ip_pre_AWS_US_WEST.sh"         _v4    "10.27.0.0/24"
+    # IPv6 path (no iprange): a representative subset incl. the overlaps.
+    "ip_pre_AWS_ALL_REGIONS.sh"     _v6    "2001:db8:10::/48 2001:db8:11::/48 2001:db8:12::/48 2001:db8:13::/48 2001:db8:14::/48 2001:db8:15::/48 2001:db8:16::/48 2001:db8:17::/48 2001:db8:18::/48 2001:db8:19::/48 2001:db8:20::/48 2001:db8:21::/48 2001:db8:22::/48 2001:db8:23::/48 2001:db8:24::/48 2001:db8:25::/48 2001:db8:26::/48 2001:db8:27::/48 2001:db8:28::/48 2001:db8:29::/48 2001:db8:30::/48"
+    "ip_pre_AWS_EU.sh"              _v6    "2001:db8:18::/48 2001:db8:19::/48 2001:db8:20::/48 2001:db8:21::/48"
+    "ip_pre_AWS_US.sh"              _v6    "2001:db8:26::/48 2001:db8:27::/48 2001:db8:28::/48 2001:db8:29::/48"
+    "ip_pre_AWS_US_GOV.sh"          _v6    "2001:db8:28::/48 2001:db8:29::/48"
+    "ip_pre_AWS_AP_SOUTH.sh"        _v6    "2001:db8:13::/48"
+    "ip_pre_AWS_AP_SOUTHEAST.sh"    _v6    "2001:db8:14::/48"
+  End
+
+  Example "$1 ($2) selects only its region prefixes"
+    When call aws_filter "$1" "$2"
+    The output should equal "$3"
+  End
+End

--- a/tests/shell/pfblockerng_iptoasn_spec.sh
+++ b/tests/shell/pfblockerng_iptoasn_spec.sh
@@ -1,0 +1,45 @@
+#shellcheck shell=sh
+# iptoasn() result handling — locks the issue #28 fix (the pre-fix code ran the
+# file-exists test -s against $asn, a string variable, instead of -n).
+
+Describe 'iptoasn() result test (issue #28)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/iptoasn.XXXXXX")"
+    pathgeoip="${work}/mmdblookup"
+    pathasndat="${work}/asn.mmdb"
+    touch "$pathasndat"            # skip the on-first-use download branch
+    errorlog="${work}/error.log"
+    extraslog="${work}/extras.log"
+    now="now"
+    alias="203.0.113.1"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'echoes the ASN string when the lookup is non-empty'
+    make_geoip_stub "$pathgeoip" 'AS64500 Example'
+    When call iptoasn
+    The output should include "AS64500"
+  End
+
+  It 'echoes nothing when the lookup is empty'
+    make_geoip_stub "$pathgeoip" ''
+    When call iptoasn
+    The output should equal ""
+  End
+
+  It 'echoes a result that is also an existing filename (proves -n, not -s)'
+    # Pre-fix, -s "${asn}" treats the result as a path: an existing non-empty
+    # file makes -s true and the function wrongly echoes "". -n tests contents.
+    # The pipeline appends a trailing '|' (grep re-terminates the line, then
+    # tr '\n' '|'), so the result — and the file we create to match it — is
+    # "<stub output>|".
+    expected="${work}/asnentry|"
+    printf 'data\n' > "${expected}"
+    make_geoip_stub "$pathgeoip" "${work}/asnentry"
+    When call iptoasn
+    The output should equal "${expected}"
+  End
+End

--- a/tests/shell/pfblockerng_reputation_max_spec.sh
+++ b/tests/shell/pfblockerng_reputation_max_spec.sh
@@ -1,0 +1,47 @@
+#shellcheck shell=sh
+# reputation_max() match-output filename — locks the issue #27 fix (the pre-fix
+# code built the match filename from a stale $header global and removed a stale
+# file via a relative path instead of the absolute ${pfbmatch} path).
+
+Describe 'reputation_max() match output (issue #27)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/repmax.XXXXXX")"
+    pfbdeny="${work}/deny/"
+    pfbmatch="${work}/match/"
+    mkdir -p "$pfbdeny" "$pfbmatch"
+    tempfile="${work}/t1"; tempfile2="${work}/t2"
+    dupfile="${work}/t3"; matchfile="${work}/t7"; tempmatchfile="${work}/t8"
+    pathgeoip="${work}/mmdblookup"
+    pathgeoipdat="${work}/geo.mmdb"; touch "$pathgeoipdat"
+    now="now"
+    count=0; countb=0; counts=0; countr=0
+    dedup="off"; ccwhite="match"; ccblack="off"; cc="US"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'cleans a stale match file by alias-derived name under ${pfbmatch} (no repeat offenders)'
+    alias="MYLIST"
+    max=999999
+    printf '1.2.3.4\n1.2.3.5\n9.9.9.9\n' > "${pfbdeny}${alias}.txt"
+    # Stale match output the run must clean up at its absolute ${pfbmatch} path.
+    printf 'old\n' > "${pfbmatch}match${alias}.txt"
+    When call reputation_max
+    The status should be success
+    The path "${pfbmatch}match${alias}.txt" should not be exist
+  End
+
+  It 'writes match output to ${pfbmatch}match<alias>.txt (repeat offenders, ccwhite=match)'
+    alias="MYLIST"
+    max=1
+    make_geoip_stub "$pathgeoip" 'xx iso_code: "US" xx'
+    printf '1.2.3.4\n1.2.3.5\n1.2.3.6\n' > "${pfbdeny}${alias}.txt"
+    When call reputation_max
+    The status should be success
+    The path "${pfbmatch}match${alias}.txt" should be file
+    The contents of file "${pfbmatch}match${alias}.txt" should include "1.2.3.0/24"
+    The stdout should include "Reputation -Max Stats"
+  End
+End

--- a/tests/shell/pfblockerng_tempfile_spec.sh
+++ b/tests/shell/pfblockerng_tempfile_spec.sh
@@ -1,0 +1,29 @@
+#shellcheck shell=sh
+# pfblockerng.sh secure temp-file handling — locks the issue #30 fix (predictable
+# /tmp paths replaced by a private mktemp -d directory).
+
+Describe 'pfblockerng.sh secure temp files (issue #30)'
+  BeforeAll 'pfb_source'
+
+  Describe 'pfb_make_tmpdir'
+    It 'creates a private mktemp directory and points the temp vars inside it'
+      When call pfb_make_tmpdir
+      The variable tmpdir should match pattern "*/pfb.*"
+      The path "$tmpdir" should be directory
+      The variable tempfile should equal "${tmpdir}/pfbtemp1"
+      The variable tempmatchfile should equal "${tmpdir}/pfbtemp8"
+      # mktemp -d must create the directory mode 0700 (no group/other access).
+      The value "$(ls -ld "$tmpdir" | cut -c1-10)" should equal "drwx------"
+    End
+  End
+
+  Describe 'exitnow'
+    It 'removes its per-run temp directory'
+      dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbexit.XXXXXX")"
+      touch "${dir}/pfbtemp1"
+      When run run_exitnow_on "$dir"
+      The status should be success
+      The path "$dir" should not be exist
+    End
+  End
+End

--- a/tests/shell/spec_helper.sh
+++ b/tests/shell/spec_helper.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# shellcheck shell=sh
+# shellspec spec_helper — shared setup for the POSIX-sh test suite.
+#
+# Loaded via `--require spec_helper` (see .shellspec). SHELLSPEC_PROJECT_ROOT is
+# the directory holding .shellspec, i.e. the repo root.
+
+PFB_ROOT="${SHELLSPEC_PROJECT_ROOT}"
+PFB_PKGDIR="${PFB_ROOT}/src/usr/local/pkg/pfblockerng"
+PFB_FIXTURES="${PFB_ROOT}/tests/shell/fixtures"
+PFB_SHIMS="${PFB_ROOT}/tests/shell/bin"
+
+# Put the iprange shim ahead of the real PATH so the AWS pre-scripts (which call
+# `iprange` by bare name) pick up the deterministic stand-in. jq stays the real
+# system binary.
+PATH="${PFB_SHIMS}:${PATH}"
+export PATH PFB_ROOT PFB_PKGDIR PFB_FIXTURES PFB_SHIMS
+
+# Run one ip_pre_AWS_*.sh over a private copy of the fixture (the script
+# overwrites its input file in place) and echo the resulting prefixes, sorted and
+# space-joined on a single line for easy equality assertions.
+aws_filter() {
+	_aws_script="$1"
+	_aws_proto="$2"
+	_aws_work="$(mktemp "${SHELLSPEC_TMPBASE:-/tmp}/awsfix.XXXXXX")"
+	cp "${PFB_FIXTURES}/aws-ip-ranges.json" "${_aws_work}"
+	( cd "${PFB_PKGDIR}" && sh "${_aws_script}" "${_aws_work}" "${_aws_proto}" ) >/dev/null 2>&1
+	sort "${_aws_work}" | tr '\n' ' ' | sed 's/ *$//'
+	rm -f "${_aws_work}"
+}
+
+# Source pfblockerng.sh as a library: PFB_SOURCED=1 makes it define its functions
+# and return before running any top-level init or the argument dispatch.
+pfb_source() {
+	# shellcheck disable=SC2034  # read by pfblockerng.sh's source guard
+	PFB_SOURCED=1
+	# shellcheck disable=SC1091
+	. "${PFB_PKGDIR}/pfblockerng.sh"
+}
+
+# Write an executable mmdblookup stand-in at $1 that prints $2 verbatim (no
+# trailing newline) and ignores its arguments. Used by the reputation_max /
+# iptoasn specs to avoid the real GeoIP binary + databases.
+make_geoip_stub() {
+	cat > "$1" <<EOF
+#!/bin/sh
+printf '%s' '$2'
+EOF
+	chmod +x "$1"
+}
+
+# Call exitnow() against a caller-supplied tmpdir. Always run via \`When run\` so
+# the exit() lands in a subshell; afterwards the directory should be gone.
+run_exitnow_on() {
+	# shellcheck disable=SC2034  # read by the sourced exitnow()
+	tmpdir="$1"
+	exitnow
+}


### PR DESCRIPTION
## What

Adds a fast, CI-runnable **functional shell-test layer** (shellspec) for the
project's POSIX `sh`, and fixes + locks the three motivating bugs. Completes the
coverage trio with #38 (Python) and #39 (PHP). Closes #40.

Before this, the only shell gating was ShellCheck + `sh -n` (lint/syntax) — no
functional tests, no coverage.

## Bug fixes (each locked by a regression spec)

- **#27** — `reputation_max()` built the match-output filename from a stale
  `$header` global and `rm -r`'d a *relative* path. Now derives the name from
  `$alias` (in scope, like `reputation_dmax`/`pmax`) and `rm -f`'s the absolute
  `${pfbmatch}` path.
- **#28** — `iptoasn()` ran the file-exists test `-s` on `$asn`, a string. Now
  uses `-n`.
- **#30** — predictable `jot`-based `/tmp` paths (TOCTOU/symlink risk for a
  root-run script) replaced by a private `mktemp -d` dir in `pfblockerng.sh` and
  all 25 `ip_pre_AWS_*.sh`; `exitnow()` `rm -rf`'s it.

Each spec was confirmed to **fail on the pre-fix code** and pass after.

## Test tooling (#40)

- **shellspec** harness under `tests/shell/` — `.shellspec`, `spec_helper.sh`, an
  `iprange` PATH shim (the FreeBSD aggregator isn't installable on the runners;
  the fixture uses non-coalescing prefixes so a `sort -u` shim is faithful), and
  an AWS `ip-ranges.json` fixture.
- **`ip_pre_aws_spec.sh`** — runs every region pre-script over one fixture and
  asserts the exact per-region prefix set. Direct guard against the per-file
  drift these hand-maintained, lint-excluded scripts invite — including the
  intentional `us-` ⊃ `us-gov-` filter overlap.
- **Sourceability** — `pfblockerng.sh` is now *library-on-source, run-on-exec*:
  it guards top-level init + the argument dispatch behind `PFB_SOURCED`, so specs
  can source it and call functions in isolation with no system side effects. The
  executed path is unchanged.
- **CI** — a `shell-tests` job (shellspec + informational kcov coverage; no floor
  yet, mirroring #38), wired into the `all-tests-passed` required check.
- **pre-commit** — a `shellspec` step gated on the tool (like shellcheck/phpstan).
- **Docs** — README + `tests/shell/README.md`.

## Verification

- `shellspec` → 38 examples, 0 failures; the 4 locking specs fail if any fix is reverted.
- `shellcheck --severity=warning` + `sh -n` clean (incl. the edited AWS scripts).
- `python -m pytest` → 985 passed (no Python touched).
- `markdownlint-cli2` → 0 errors. pre-commit hook passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POSIX sh functional tests integrated into CI and pre-commit (shellcheck + shellspec gates)

* **Bug Fixes**
  * Safer, fail-fast temp-file handling and cleanup across scripts
  * Fixed ASN/result handling and reputation output behavior
  * Guard to allow sourcing library without running top-level initialization

* **Documentation**
  * README updated with shell tests and ShellCheck guidance

* **Tests**
  * Added fixtures, shims, helpers, and multiple shellspec suites

* **Chores**
  * Ignored shell test artifacts and coverage outputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->