### PR TITLE
dev: optional macOS dev-shell setup script + rebase-before-push rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,16 @@ so promotion up the chain — and landing any PR — is a rebase/replay, not a m
 a PR branch is behind its base, rebase it onto the base first so the merge is a clean
 fast-forward.
 
+**`devel` advances out of band — rebase onto the latest remote before every push.**
+Multiple agents work in parallel and their commits are rebased on top of `devel`, so the
+remote tip moves under you between operations. Before **any** commit or push — to `devel`
+*or* to a PR branch — `git fetch origin` and rebase your local branch onto the latest
+remote tip (`git rebase origin/devel`, or `origin/<pr-base>` for a PR), resolve, then push
+(`--force-with-lease` if the branch was rewritten). New work always replays **after** what
+is already on the remote; never reconcile with a merge commit. This keeps the chain
+strictly linear (above) and every PR a clean fast-forward — the same rule applies to each
+follow-up commit you push onto an open PR.
+
 ---
 
 ## Commit style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,11 @@ those conflicts.
   stale tip needs a rebase onto the base before it can land (PRs are
   rebase-only — see "Branches and releases").
 - The primary checkout stays free for the human; each agent gets its own tree.
+- **Reuse, don't recreate.** A worktree is keyed to its branch/task: if you are already
+  in the worktree for this branch — e.g. an ADR's `adr/NN` worktree mid-implementation —
+  work there, don't spin up a second one. `/adr-all` and `/adr-phase` **reuse the per-ADR
+  `adr/NN` worktree across all phases**; create it (off the latest `devel`) only when it
+  doesn't already exist.
 - Gotchas (both hit in practice): `git worktree remove` fails when run from
   *inside* the tree being removed — run it from the primary checkout. And
   `gh pr merge --delete-branch` can't check out a base branch that another

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,13 @@ active. Reason: multiple agents operating on the same checkout race on the
 filesystem, the index, `HEAD`, and branch/ref state; isolated worktrees prevent
 those conflicts.
 
+**Exception — pure ADR docs need no PR.** ADR text (the `ADR.md` plus the `/adr-phase`
+prompt `.txt` files under `.ADRs/`) still goes through a **worktree** (the worktree rule
+always holds), but needs **no PR** — commit it there and push **directly to `devel`**
+(fetch + rebase first, as always). The carve-out is the PR only, and only for ADR *docs*;
+ADR *implementation* that touches `src/`, `tests/`, or CI still uses the full worktree +
+rebase-only-PR flow.
+
 - Create one at the start of a task and remove it when done:
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ sh scripts/setup-dev-shell.sh
 ```
 
 It writes a small idempotent managed block into `~/.brew_path.sh`, `~/.zshenv`,
-`~/.bashrc`, `~/.bash_profile`, and `~/.profile` (macOS-only; a no-op without
-Homebrew). It does not change your login shell or `/etc/shells` — it only prints
-the optional `sudo` commands for those.
+`~/.bashrc`, `~/.bash_profile`, and `~/.profile`. It's macOS-only (it exits doing
+nothing on other systems); if Homebrew isn't installed it prints an install hint and
+exits **without changing any dotfiles**. It does not change your login shell or
+`/etc/shells` — it only prints the optional `sudo` commands for those.
 
 ### Running the test suite locally
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ These are local client-side guards. CI enforces the same checks (and the tag
 rules) server-side, so anything that bypasses a hook is still caught by GitHub
 Actions.
 
+### Shell setup (macOS, optional)
+
+On macOS, Homebrew's `bin` is on `PATH` only for **login** shells (`brew shellenv`
+lives in `~/.zprofile`), so the pre-commit hook's tools (`node`/`npx` for
+markdownlint, `php`, `shellcheck`) can go missing in the non-login shells that
+editors and agents spawn. The hook self-bootstraps Homebrew's `PATH` regardless,
+but to make the same tools resolve in your own interactive/manual shells — and to
+upgrade Apple's ancient `/bin/bash` 3.2 to Homebrew's bash — run once:
+
+```sh
+sh scripts/setup-dev-shell.sh
+```
+
+It writes a small idempotent managed block into `~/.brew_path.sh`, `~/.zshenv`,
+`~/.bashrc`, `~/.bash_profile`, and `~/.profile` (macOS-only; a no-op without
+Homebrew). It does not change your login shell or `/etc/shells` — it only prints
+the optional `sudo` commands for those.
+
 ### Running the test suite locally
 
 Python (the bulk of the suite):

--- a/scripts/setup-dev-shell.sh
+++ b/scripts/setup-dev-shell.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+# setup-dev-shell.sh — OPTIONAL, macOS-only contributor convenience.
+#
+# Makes Homebrew CLIs (node/npx for markdownlint, php, shellcheck, …) resolve in EVERY
+# shell — including the non-login sub-shells that tooling/editors spawn, where ~/.zprofile
+# (which runs `brew shellenv`) is NOT sourced. Also upgrades an old interactive/login
+# bash (Apple's /bin/bash 3.2) to Homebrew's bash 5.x.
+#
+# NOTE: the pre-commit hook ALREADY self-bootstraps Homebrew on PATH, so you do NOT need
+# this for the hook to work — it only improves your interactive/manual shell ergonomics
+# (e.g. running `npx markdownlint-cli2` by hand). Safe to re-run: each file gets a single
+# managed block, skipped if already present.
+#
+# What it changes in your HOME:
+#   ~/.brew_path.sh   (created)  shared PATH-prepend snippet (also exports BASH_ENV/ENV)
+#   ~/.zshenv         (block)    source the snippet for every zsh
+#   ~/.profile        (block)    source the snippet for login sh
+#   ~/.bashrc         (block)    bash<4 -> Homebrew re-exec + source the snippet
+#   ~/.bash_profile   (block)    bash<4 -> Homebrew re-exec + source the snippet
+# It does NOT touch /etc/shells or your login shell (it only prints the optional sudo
+# commands for those).
+
+set -u
+
+MARK_BEGIN='# >>> pfBlockerNG dev shell (managed) >>>'
+MARK_END='# <<< pfBlockerNG dev shell (managed) <<<'
+
+log() { printf '%s\n' "$*"; }
+
+# macOS only — the login-only brew PATH and ancient /bin/bash are macOS problems.
+if [ "$(uname -s)" != Darwin ]; then
+	log "Not macOS ($(uname -s)) — nothing to do (brew tools are normally already on PATH)."
+	exit 0
+fi
+
+# Locate Homebrew (Apple Silicon first, then Intel).
+brew_bin=''
+for p in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+	if [ -x "$p" ]; then brew_bin=$p; break; fi
+done
+if [ -z "$brew_bin" ]; then
+	log "Homebrew not found under /opt/homebrew or /usr/local. Install it first: https://brew.sh"
+	exit 1
+fi
+log "Homebrew: $brew_bin"
+
+# 1) The shared PATH snippet (overwritten — it is fully managed by this script).
+snippet="$HOME/.brew_path.sh"
+cat > "$snippet" <<'SNIPPET'
+# Shared Homebrew PATH bootstrap — POSIX-sh compatible (works in sh, bash, zsh).
+# Managed by pfBlockerNG scripts/setup-dev-shell.sh. Puts Homebrew bin/sbin on PATH so
+# CLIs like node/npx resolve even in a non-login shell spawned by tooling. Idempotent +
+# deduped + subprocess-free; a no-op unless Homebrew is installed.
+for _bp in /opt/homebrew /usr/local; do
+	if [ -x "$_bp/bin/brew" ]; then
+		case ":$PATH:" in
+			*":$_bp/bin:"*) ;;
+			*) PATH="$_bp/bin:$_bp/sbin:$PATH"; export PATH ;;
+		esac
+		break
+	fi
+done
+unset _bp
+
+# Non-interactive bash sources $BASH_ENV; interactive sh sources $ENV. (`sh -c` reads
+# nothing — it inherits the PATH set above.) This propagates the fix to child shells.
+export BASH_ENV="$HOME/.brew_path.sh"
+export ENV="$HOME/.brew_path.sh"
+SNIPPET
+log "wrote $snippet"
+
+# Append a managed block (read from stdin) to a file unless one is already present.
+# Reading from stdin avoids a here-doc inside $(...), which Apple's bash 3.2 mishandles.
+ensure_block() {
+	_file=$1
+	if [ -f "$_file" ] && grep -qF "$MARK_BEGIN" "$_file" 2>/dev/null; then
+		log "  $_file: managed block present — skipped"
+		return 0
+	fi
+	if [ -s "$_file" ]; then printf '\n' >> "$_file"; fi
+	{
+		printf '%s\n' "$MARK_BEGIN"
+		cat
+		printf '%s\n' "$MARK_END"
+	} >> "$_file"
+	log "  $_file: managed block added"
+}
+
+log "wiring shell init files:"
+
+# zsh (every invocation) + login sh: just source the snippet.
+printf '%s\n' '[ -r "$HOME/.brew_path.sh" ] && . "$HOME/.brew_path.sh"' | ensure_block "$HOME/.zshenv"
+printf '%s\n' '[ -r "$HOME/.brew_path.sh" ] && . "$HOME/.brew_path.sh"' | ensure_block "$HOME/.profile"
+
+# bash: re-exec an old interactive/login bash to Homebrew's, then source the snippet.
+# Build the block in a temp file so it can be fed to ensure_block twice without a
+# here-doc inside $(...).
+bash_block_file=$(mktemp)
+cat > "$bash_block_file" <<'BASHBLOCK'
+# Upgrade a REAL interactive/login bash <4 (e.g. Apple's /bin/bash 3.2) to Homebrew's,
+# preserving login/interactive flags. Skips -c/script invocations (never drops a command
+# or hijacks a script) and is guarded against re-exec loops.
+if [ -z "${BASH_UPGRADED:-}" ] && [ "${BASH_VERSINFO:-0}" -lt 4 ] && [ -z "${BASH_EXECUTION_STRING:-}" ]; then
+	for _bh in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+		[ -x "$_bh" ] || continue
+		_login=0; shopt -q login_shell && _login=1
+		case $- in *i*) _int=1 ;; *) _int=0 ;; esac
+		if [ "$_int" = 1 ] || [ "$_login" = 1 ]; then
+			export BASH_UPGRADED=1; _a=''
+			[ "$_login" = 1 ] && _a="$_a -l"
+			[ "$_int" = 1 ] && _a="$_a -i"
+			exec "$_bh" $_a
+		fi
+		break
+	done
+	unset _bh _login _int _a
+fi
+[ -r "$HOME/.brew_path.sh" ] && . "$HOME/.brew_path.sh"
+BASHBLOCK
+ensure_block "$HOME/.bashrc"       < "$bash_block_file"
+ensure_block "$HOME/.bash_profile" < "$bash_block_file"
+rm -f "$bash_block_file"
+
+# Optional, manual (needs sudo): register + adopt Homebrew bash as a login shell.
+brew_bash="${brew_bin%/brew}/bash"
+if [ -x "$brew_bash" ] && ! grep -qxF "$brew_bash" /etc/shells 2>/dev/null; then
+	log ""
+	log "Optional — register Homebrew bash as a sanctioned login shell (needs sudo):"
+	log "  echo $brew_bash | sudo tee -a /etc/shells"
+	log "  # then, only if you want bash (not zsh) as your login shell: chsh -s $brew_bash"
+fi
+
+log ""
+log "Done. Open a new terminal, or run:  . ~/.brew_path.sh"


### PR DESCRIPTION
## What

Two dev-workflow changes (no `src/` impact — tooling + docs only):

1. **`scripts/setup-dev-shell.sh`** (new, optional, macOS-only) — idempotently wires
   Homebrew onto `PATH` for **every** shell, not just login shells. On macOS `brew
   shellenv` lives in `~/.zprofile` (login-only), so the non-login shells that editors
   and agents spawn start without `/opt/homebrew/bin` and can't find `node`/`npx`
   (markdownlint), `php`, or `shellcheck`. The script writes a small managed block into
   `~/.brew_path.sh`, `~/.zshenv`, `~/.bashrc`, `~/.bash_profile`, `~/.profile`, and
   also re-execs Apple's ancient `/bin/bash` 3.2 to Homebrew's bash for real
   interactive/login shells. Re-run safe (one marker-guarded block per file); a no-op
   without Homebrew; never touches the login shell or `/etc/shells` (only prints the
   optional `sudo` commands).

2. **CLAUDE.md** — codify the rule that `devel` (and PR branches) advance **out of
   band**, so you `git fetch` + rebase onto the latest remote tip before **every**
   commit/push (including follow-up commits on an open PR); new work always replays
   after the remote, never a merge commit.

Plus a README pointer under *Development workflow → Shell setup*.

## Why

The pre-commit hook already self-bootstraps Homebrew's `PATH`, so this is **not**
required for the hook to work — it's a contributor-ergonomics convenience so the same
tools resolve in interactive/manual shells, and so old-bash quirks (e.g. SDKMAN's
bash-4 syntax) stop biting. Surfaced while debugging "markdownlint could not run" in
non-login shells.

## Validation

- `scripts/setup-dev-shell.sh`: `sh -n` under macOS `/bin/sh` (bash 3.2) **and** `dash`
  (the CI `sh`), `shellcheck --severity=warning` clean, run twice in a throwaway `HOME`
  (idempotent — second run skips every block), generated files parse, and a fresh
  non-login `zsh -c` resolves `npx`.
- Pre-commit hooks green in the worktree (markdownlint, shebang policy, `sh -n`,
  shellcheck, shellspec, `php -l`, PHPStan, pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added macOS shell setup instructions for contributor environments.
  * Clarified branching/workflow: require updating local branches to the latest remote tip before committing/pushing; ADR documentation may be committed directly to the main branch (skipping PR); enforce reusing existing branch/task worktrees instead of creating duplicates.

* **Chores**
  * Added a macOS helper to bootstrap Homebrew PATH handling and update shell init files for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->