### PR TITLE
docs: add ADR-14 — web UI/UX testing on the live pfSense VM

### DIFF
--- a/.ADRs/ADR_14_UI_UX_Testing/01_Auth_Session_Prep.txt
+++ b/.ADRs/ADR_14_UI_UX_Testing/01_Auth_Session_Prep.txt
@@ -1,0 +1,77 @@
+================================================================================
+PHASE 1 PROMPT — PREP (behaviour-preserving): authenticated WebUI session helper + recon
+Target model: Claude Opus 4.8
+ADR: .ADRs/ADR_14_UI_UX_Testing/ADR.md   (read §1 facts 2-4, §2 table + contract FIRST)
+================================================================================
+
+ROLE
+You are on the `adr/14` branch performing Phase 1 of ADR-14. Behaviour-PRESERVING:
+land a reusable authenticated-WebUI session helper + the live-box recon it depends on,
+as an ISOLATED, lint-clean building block. NO src/ change; the default `python -m pytest`
+stays byte-identical. Standalone-valuable. Work in this ADR's `adr/14` worktree; one
+commit for this phase.
+
+WHY THIS PHASE EXISTS
+Every later tier needs an authenticated session against the live webConfigurator, and
+the exact login mechanics (protocol, CSRF field, login fields, cookie, creds source) are
+pfSense-core facts we must CONFIRM, not assume (CLAUDE.md investigation rigor; ADR §1
+fact 4). Landing + pinning the helper in isolation keeps Phases 2-4 to pure assertions.
+
+REQUIRED READING (inspect before editing)
+- .ADRs/ADR_14_UI_UX_Testing/ADR.md (§1 facts, §2 table, contract, §5).
+- tests/smoke/conftest.py — the `smoke_vm` SESSION-scoped fixture (:303), the `SmokeVM`
+  dataclass + `ssh()` helper (:144), how the VM exposes :8080 and how default collection
+  EXCLUDES the smoke suite (so UI tests inherit the exclusion).
+- tests/smoke/helpers.py — `config_get()` (:403) for reading config.xml on-box.
+- tests/smoke/boot_vm.sh:119 (hostfwd 8080->80), wait_ready.sh:102 (the http:// readiness
+  curl — evidence the WebUI answers plain HTTP, NOT forced HTTPS).
+- tests/smoke/requirements.txt — where dev-only test deps go.
+- CLAUDE.md (Python 4-space/3.11+/type hints; investigation rigor; smoke-harness truths).
+
+ACTION PLAN (ordered — recon FIRST, then the helper, then pin it)
+1. RECON on the live VM (source of truth — do NOT assume):
+   - webConfigurator protocol: read `config.xml <system><webgui><protocol>` (expect http;
+     confirm). If https, the helper must handle TLS (verify=False against the throwaway VM).
+   - The login form: fetch the live login page and read the ACTUAL field names
+     (`__csrf_magic`, `usernamefld`, `passwordfld`) + the session cookie name. Quote what
+     you find in the handoff — these are the contract for later phases.
+   - Creds: the baked admin user/password (`SMOKE_ADMIN_PASSWORD`); how the smoke
+     workflow supplies it. If it is not currently exposed to pytest, wire it through
+     (env/secret -> fixture), documented.
+2. HELPER `tests/smoke/ui/` subpackage (new): a `webui` client built on `requests`:
+   - GET the login page -> extract `__csrf_magic` -> POST creds -> persist the session
+     cookie. `get(path)` returns the authenticated response. Type-hinted, no bare except.
+   - Keep it a thin, reusable primitive (later phases inject this cookie into Playwright).
+3. PIN with a `ui_render`-marked test (reusing `smoke_vm`):
+   - login succeeds; an authenticated GET of a known pfBlockerNG page returns 200 + an
+     expected content marker; an UNAUTHENTICATED GET redirects to the login page.
+4. Add `requests` to tests/smoke/requirements.txt. Confirm the new tests are EXCLUDED
+   from default collection (same mechanism as smoke) -> `python -m pytest` byte-identical.
+
+CONSTRAINTS
+- NO src/ change. NO change to default pytest collection/behaviour. Reuse `smoke_vm`;
+  do NOT add a second VM boot path. Python 4-space, 3.11+, type hints, no bare except.
+- Do NOT build the render sweep / functional / browser tiers yet (Phases 2-4).
+
+VERIFICATION (must all pass before the phase is done)
+- python -m pytest        -> green, count UNCHANGED vs baseline (UI excluded by default).
+- ruff check . / ruff format .   -> clean.
+- Live: against the smoke VM, the pinned test logs in, fetches a page (200 + marker),
+  and an unauth GET redirects to login. Quote the measured login form/cookie names.
+
+EXPECTED RESULT
+A reusable, lint-clean authenticated `webui` session helper under tests/smoke/ui/,
+proven against the live VM, with the login mechanics CONFIRMED (not assumed) and recorded.
+
+COMMIT (single)
+    tests: add authenticated WebUI session helper + recon (ADR-14 P1)
+In this ADR's `adr/14` worktree (reuse it if already implementing this ADR, else create
+off the latest `origin/devel`): `git fetch` + rebase onto the latest `origin/devel`, then
+push `adr/14`. The ADR lands on `devel` via a rebase-only PR (never a merge). PR body via
+--body-file.
+
+HANDOFF — write `.ADRs/ADR_14_UI_UX_Testing/RESULTS/01_Results.txt` (plain .txt)
+State: the CONFIRMED protocol + exact login form/cookie/CSRF field names + creds source;
+the `webui` helper API (login + get signatures); where it lives; how creds reach pytest;
+confirmation the default suite is byte-identical; any gotcha (TLS, redirect quirks); the
+go-ahead for Phase 2.

--- a/.ADRs/ADR_14_UI_UX_Testing/02_Render_Smoke_Tier_A.txt
+++ b/.ADRs/ADR_14_UI_UX_Testing/02_Render_Smoke_Tier_A.txt
@@ -1,0 +1,70 @@
+================================================================================
+PHASE 2 PROMPT — Tier A: HTTP render-smoke sweep (all pages) + the real oracle
+Target model: Claude Opus 4.8
+ADR: .ADRs/ADR_14_UI_UX_Testing/ADR.md   (read §2 "Tier A" + fact 3 + contract FIRST)
+================================================================================
+
+ROLE
+You are on the `adr/14` branch performing Phase 2 of ADR-14. This lands the CHEAP,
+HERMETIC, standalone-valuable tier: an authenticated HTTP render-smoke sweep over every
+pfBlockerNG page with a REAL pass/fail oracle (not bare HTTP 200). NO src/ change;
+default `python -m pytest` unchanged. Work in this ADR's `adr/14` worktree; one commit for this phase.
+
+WHY THIS PHASE EXISTS
+This is the tier that gates PRs (Phase 5) and the highest signal-per-flake check: it
+catches pages that 500, render a PHP Warning/Notice, or come back blank — none of which
+`php -l`/PHPStan can see (ADR §1 fact 3). It must NOT trust HTTP 200 alone.
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_14_UI_UX_Testing/RESULTS/01_Results.txt — it must confirm the `webui` helper
+  API + the login mechanics. If it is missing, Phase 1 is not complete; STOP and report.
+- .ADRs/ADR_14_UI_UX_Testing/ADR.md (§2 Tier A row, fact 3, contract, §4.3).
+- The page set: src/usr/local/www/pfblockerng/*.php (the 18), the dashboard widget
+  (src/usr/local/www/widgets/widgets/pfblockerng.widget.php), and the DNSBL VIP pages
+  (src/usr/local/www/pfblockerng/www/index.php, www/dnsbl_default.php). Read each page's
+  top-of-file title/heading to choose a stable per-page content marker.
+- tests/smoke/helpers.py (SmokeVM.ssh for reading php_error.log on-box) + tests/smoke/ui/
+  (the Phase-1 helper).
+- CLAUDE.md.
+
+ACTION PLAN (ordered — oracle design FIRST)
+1. ORACLE (the load-bearing part): for a fetched page, PASS requires ALL of:
+   (a) HTTP 200; (b) body contains NONE of `Fatal error`, `Parse error`, `Warning`,
+   `Notice`, `Uncaught`, `Stack trace`; (c) a page-SPECIFIC content marker is present
+   (so a blank/redirected 200 is not a false pass); (d) the on-box php_error.log gained
+   NO new lines during the sweep (snapshot line count before, compare after, via
+   SmokeVM.ssh — source of truth, fact 3).
+2. PAGE TABLE: enumerate every pfBlockerNG page with its URL path + expected marker.
+   Pages that REQUIRE a feed download / network to render must be flagged and either
+   excluded from the hermetic Tier A or run with the egress the smoke harness already
+   allows — keep Tier A hermetic by default.
+3. PARAMETRIZE a `ui_render` test over the page table, reusing the authenticated session.
+4. PROVE THE ORACLE: add a check that a deliberately-broken/known-warning condition is
+   CAUGHT (the oracle fails it) — so we know a bare 200 can never pass. Document how.
+
+CONSTRAINTS
+- NO src/ change (do not "fix" a warning you find here — record it; a real fix is its own
+  change). Reuse the Phase-1 session + `smoke_vm`; no second VM boot. Python 4-space/3.11+.
+- Keep Tier A HERMETIC (no required feed fetches) so it is cheap enough to gate PRs.
+
+VERIFICATION (must all pass before the phase is done)
+- python -m pytest        -> green, default count UNCHANGED.
+- pytest -m ui_render (against the smoke VM) -> every page passes the full oracle.
+- The deliberately-broken probe -> FAILS the oracle (proves it).
+- ruff check . / ruff format .   -> clean.
+- diff-read: the page table covers all 18 pages + widget + 2 DNSBL VIP pages.
+
+EXPECTED RESULT
+A parametrized, hermetic Tier-A render sweep over every pfBlockerNG page with a
+body + marker + php_error.log oracle, proven to catch a broken page.
+
+COMMIT (single)
+    tests: add Tier-A HTTP render-smoke sweep for the WebUI (ADR-14 P2)
+In this ADR's `adr/14` worktree (reuse it if already implementing this ADR, else create off the latest `origin/devel`): `git fetch` + rebase onto the latest `origin/devel`, then push `adr/14`. The ADR lands on `devel` via a rebase-only PR (never a merge). PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_14_UI_UX_Testing/RESULTS/02_Results.txt`
+State: the page table (path + marker per page) and any pages excluded-from-hermetic +
+why; the exact oracle (the forbidden-strings list + the php_error.log diff mechanism);
+how the broken-page probe proves the oracle; any pages that rendered a real warning
+(recorded, NOT fixed); the go-ahead for Phase 3.

--- a/.ADRs/ADR_14_UI_UX_Testing/03_Functional_HTTP_Tier_B.txt
+++ b/.ADRs/ADR_14_UI_UX_Testing/03_Functional_HTTP_Tier_B.txt
@@ -1,0 +1,70 @@
+================================================================================
+PHASE 3 PROMPT — Tier B (functional, HTTP-POST): drive forms, assert EFFECTIVE state
+Target model: Claude Opus 4.8
+ADR: .ADRs/ADR_14_UI_UX_Testing/ADR.md   (read §2 "Tier B functional" + fact 3 FIRST)
+================================================================================
+
+ROLE
+You are on the `adr/14` branch performing Phase 3 of ADR-14. This adds a curated set of
+functional flows over CSRF POST that assert the EFFECTIVE state of the box (config.xml /
+pfctl / unbound) — NOT the HTTP response. Establishes the functional oracle BEFORE any
+browser code. NO src/ change; default pytest unchanged. Work in this ADR's `adr/14`
+worktree; one commit for this phase.
+
+WHY THIS PHASE EXISTS
+Render-smoke proves a page draws; it does NOT prove a form persists. A page can POST,
+return 200, and silently fail to write config. The only trustworthy oracle is the
+effective state (ADR §1 fact 3) — read via helpers.config_get / pfctl / unbound, exactly
+the CLAUDE.md "source of truth, not a proxy" rule. Doing this over HTTP (not a browser)
+keeps the functional oracle independent of browser flake.
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_14_UI_UX_Testing/RESULTS/02_Results.txt — it must confirm the render tier +
+  the oracle pattern. If missing, Phase 2 is not complete; STOP and report.
+- .ADRs/ADR_14_UI_UX_Testing/ADR.md (§2 Tier B functional row, fact 3, §4.4).
+- The target pages' forms: src/usr/local/www/pfblockerng/pfblockerng_general.php,
+  pfblockerng_ip.php (feed/alias add), pfblockerng_dnsbl.php — read the actual field
+  names + the POST/save action each uses.
+- tests/smoke/helpers.py — config_get (:403), config_set/write_config, and how the smoke
+  suite asserts effective unbound/pfctl state; the SmokeVM.ssh helper.
+- tests/smoke/ui/ (the Phase-1 session; CSRF must be re-extracted per POST target).
+- CLAUDE.md.
+
+ACTION PLAN (ordered)
+1. Pick a SMALL, high-value set of flows (start ~3): save a General setting; add/save an
+   IP feed or alias; toggle a DNSBL setting. For each, identify the exact POST endpoint,
+   the required fields, and the CSRF token handling (re-fetch the form -> extract
+   `__csrf_magic` -> POST).
+2. For each flow, the oracle asserts the EFFECTIVE result, not the response:
+   - read the relevant config.xml node via helpers.config_get and assert it changed to the
+     posted value; where the setting drives runtime, also assert pfctl/unbound effective
+     state (reuse the smoke suite's patterns).
+3. Mark these `ui_e2e`. Make them robust to ordering (each flow sets + asserts its own
+   state; restore/leave-clean so they don't poison Tier A or each other on a session VM).
+4. Keep them OFF the default collection + the PR gate (Tier B is daily/on-demand).
+
+CONSTRAINTS
+- NO src/ change. Reuse `smoke_vm` + the Phase-1 session; re-extract CSRF per POST.
+  Python 4-space/3.11+, type hints, no bare except. Assert EFFECTIVE state, never the
+  HTTP body alone.
+- Do NOT add the browser layer (Phase 4) or workflows (Phase 5) here.
+
+VERIFICATION (must all pass before the phase is done)
+- python -m pytest        -> green, default count UNCHANGED.
+- pytest -m ui_e2e (against the smoke VM) -> each flow changes the asserted effective
+  state (config.xml / pfctl / unbound), verified by re-reading the box.
+- ruff check . / ruff format .   -> clean.
+
+EXPECTED RESULT
+A small, robust set of functional CSRF-POST flows whose oracle is the box's effective
+state, independent of browser tooling.
+
+COMMIT (single)
+    tests: add Tier-B functional WebUI flows (effective-state oracle) (ADR-14 P3)
+In this ADR's `adr/14` worktree (reuse it if already implementing this ADR, else create off the latest `origin/devel`): `git fetch` + rebase onto the latest `origin/devel`, then push `adr/14`. The ADR lands on `devel` via a rebase-only PR (never a merge). PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_14_UI_UX_Testing/RESULTS/03_Results.txt`
+State: the flows + their POST endpoints/fields + the exact effective-state assertion per
+flow; the CSRF-per-POST pattern; how state is left clean for other tiers; any pfBlockerNG
+quirk in the save path worth knowing; the go-ahead for Phase 4.

--- a/.ADRs/ADR_14_UI_UX_Testing/04_Browser_Screenshots_Tier_B.txt
+++ b/.ADRs/ADR_14_UI_UX_Testing/04_Browser_Screenshots_Tier_B.txt
@@ -1,0 +1,77 @@
+================================================================================
+PHASE 4 PROMPT — Tier B (browser): headless Playwright layer + screenshots (GATED by §7)
+Target model: Claude Opus 4.8
+ADR: .ADRs/ADR_14_UI_UX_Testing/ADR.md   (read §2 "Tier B browser" + §3 risks + §7 FIRST)
+================================================================================
+
+ROLE
+You are on the `adr/14` branch performing Phase 4 of ADR-14. This adds the FLAKY/HEAVY
+tier: headless Chromium driving the JS-only UX + capturing per-page screenshots as
+artifacts. This is the ADR-01-analog risk tier — you MUST measure the §7 reliability/
+budget numbers and apply the demote/drop decision if it fails. NO src/ change; default
+pytest unchanged. Work in this ADR's `adr/14` worktree; one commit for this phase.
+
+WHY THIS PHASE EXISTS
+pfBlockerNG.js carries UX that HTTP cannot exercise: field enable/disable toggles
+(enable_change_in/out, enable_change_port_in/out, pfBlockerNG.js:213-230), autocomplete
+(pfb_autocomplete*, :36/:102), label removal (:115), row-move handlers ([name^=Lmove]/
+[name^=Xmove], :145-149), and the background AJAX state change pfb_chg_state_bkgd (:124),
+plus the dashboard widget JS. Screenshots (browser-only, decision A1) give a human a fast
+visual diff. Browser E2E over SLIRP-QEMU is the classic flaky/slow trap (§3) — hence the
+gate.
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_14_UI_UX_Testing/RESULTS/03_Results.txt — it must confirm the functional tier
+  + the effective-state oracle. If missing, Phase 3 is not complete; STOP and report.
+- .ADRs/ADR_14_UI_UX_Testing/ADR.md (§2 Tier B browser row, §3 negative/risks, §7 reject
+  criteria + thresholds).
+- src/usr/local/www/pfblockerng/pfBlockerNG.js + widgets/javascript/pfblockerng.js — the
+  exact element IDs/behaviours to drive.
+- tests/smoke/ui/ (the Phase-1 session — inject its cookie into the browser context to
+  skip a second login flake) + tests/smoke/conftest.py (smoke_vm).
+- CLAUDE.md.
+
+ACTION PLAN (ordered)
+1. Add Playwright (+ the Chromium download) to tests/smoke/requirements.txt (dev-only,
+   cached). Headless Chromium against http://127.0.0.1:8080.
+2. SESSION REUSE: inject the Phase-1 authenticated session cookie into the browser
+   context (do NOT re-implement login in the browser — that is a second flake source).
+3. Drive the JS-only behaviours on the relevant pages: assert a toggle disables/enables
+   its target field; autocomplete populates; pfb_chg_state_bkgd updates state; the widget
+   renders. Keep assertions on OBSERVABLE DOM/state, no fixed sleeps — wait on selectors/
+   network-idle (poll the right readiness signal, CLAUDE.md).
+4. SCREENSHOTS: capture a full-page screenshot per page into an artifact dir
+   (e.g. test-results/ui-screenshots/<version>/<page>.png). These are artifacts for human
+   review — NOT asserted pixel baselines (visual/a11y diff is out of scope, §2).
+5. Mark `ui_browser`. MEASURE the §7 numbers: run the browser leg repeatedly and record
+   pass-rate (target >= 4/5 clean) and per-leg wall time (target <= ~25 min). If it FAILS,
+   record the numbers and apply the demote (dispatch-only, non-blocking) or drop decision
+   in the handoff — the cheap tiers (P2/P3) already shipped and stand alone.
+
+CONSTRAINTS
+- NO src/ change. Reuse `smoke_vm` + the Phase-1 cookie. No fixed sleeps; wait on real
+  signals. Python 4-space/3.11+, type hints, no bare except. Screenshots are artifacts,
+  not pixel assertions.
+- Do NOT wire workflows (Phase 5) or release (Phase 6) here.
+
+VERIFICATION (must all pass before the phase is done)
+- python -m pytest        -> green, default count UNCHANGED.
+- pytest -m ui_browser (against the smoke VM) -> JS behaviours assert; screenshots written
+  for every page.
+- The §7 reliability/budget numbers MEASURED and recorded (pass-rate + wall time).
+- ruff check . / ruff format .   -> clean.
+
+EXPECTED RESULT
+A headless-browser tier exercising the JS-only UX and producing per-page screenshots,
+WITH the §7 reliability evidence and the demote/drop decision made on that evidence.
+
+COMMIT (single)
+    tests: add Tier-B headless-browser UX checks + screenshots (ADR-14 P4)
+In this ADR's `adr/14` worktree (reuse it if already implementing this ADR, else create off the latest `origin/devel`): `git fetch` + rebase onto the latest `origin/devel`, then push `adr/14`. The ADR lands on `devel` via a rebase-only PR (never a merge). PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_14_UI_UX_Testing/RESULTS/04_Results.txt`
+State: the JS behaviours driven + their selectors; the screenshot output path/layout;
+the MEASURED pass-rate + per-leg wall time vs the §7 thresholds; the BLOCKING-vs-demote-
+vs-drop decision for the browser tier (with the numbers that justify it); the go-ahead
+for Phase 5.

--- a/.ADRs/ADR_14_UI_UX_Testing/05_Workflows_Matrix_Tiers.txt
+++ b/.ADRs/ADR_14_UI_UX_Testing/05_Workflows_Matrix_Tiers.txt
@@ -1,0 +1,81 @@
+================================================================================
+PHASE 5 PROMPT — Workflows: reusable, matrix-parametric, tiered triggers, diagnostics
+Target model: Claude Opus 4.8
+ADR: .ADRs/ADR_14_UI_UX_Testing/ADR.md   (read §2 "Workflows/Re-run/PR gate" + C1/B1 FIRST)
+================================================================================
+
+ROLE
+You are on the `adr/14` branch performing Phase 5 of ADR-14. This wires the tiers into
+GitHub Actions: a reusable, matrix-parametric `ui-tests.yml`, the per-PR Tier-A gate, and
+the daily/on-demand Tier-B schedule, with per-(tier x version) jobs and diagnostics
+upload. NO src/ change; default pytest unchanged. Work in this ADR's `adr/14` worktree;
+one commit for this phase.
+
+WHY THIS PHASE EXISTS
+The tests are only useful if they run at the right cadence with the right isolation:
+Tier A blocks PRs touching PHP/JS (3a), Tier B runs daily/on-demand, every (tier x
+version) leg is independently re-runnable (C1), and screenshots+logs are always uploaded.
+The smoke harness already proves this shape (workflow_call + matrix + content-keyed image
+cache + smoke-diagnostics upload).
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_14_UI_UX_Testing/RESULTS/04_Results.txt — it must state the browser tier's
+  BLOCKING-vs-demote-vs-drop decision + the §7 numbers (this dictates how Tier B is wired
+  and whether it can ever gate). If missing, Phase 4 is not complete; STOP and report.
+- .ADRs/ADR_14_UI_UX_Testing/ADR.md (§2 Workflows/Re-run/PR gate rows; B1; C1; §4.6-4.7).
+- .github/workflows/smoke.yml — the template: on: workflow_dispatch + workflow_call (+
+  schedule); the build-pkg -> smoke job chain; image-ref resolution (input > secret >
+  variable); the content-keyed image cache; the `smoke-diagnostics` upload (if: always(),
+  :263-267).
+- .github/workflows/build-pkg-linux.yml — the branch .pkg build the UI jobs reuse.
+- .github/workflows/test.yml — the per-PR workflow + the "All tests passed" aggregate
+  that release.yml's verify-checks reads.
+- CLAUDE.md (the hooks-activation requirement for any workflow that commits code; here we
+  only run tests, but mirror the smoke conventions).
+
+ACTION PLAN (ordered)
+1. REUSABLE `ui-tests.yml`: on: workflow_call + workflow_dispatch + schedule. Inputs:
+   image-ref/version (matrix axis — built parametric, run the single existing CE image
+   now, B1) and `tier` (render | functional | browser | all). Build the branch .pkg via
+   build-pkg-linux.yml, boot the image (reuse the smoke boot path), install the deps
+   (incl. Playwright/Chromium for the browser tier), run `pytest -m <tier-marker>`.
+2. PER-(tier x version) JOBS (C1): one job per leg via the matrix, so GH "re-run failed
+   jobs" re-runs ONLY the flaky leg. NO auto-retry on assertions; a BOUNDED retry only on
+   infra steps (image pull / boot / login readiness — poll, don't sleep).
+3. DIAGNOSTICS: upload screenshots + logs (php_error.log, the page bodies on failure,
+   plus the existing smoke state snapshot) as a `ui-diagnostics` artifact, `if: always()`.
+4. PR GATE (3a): run Tier A on PRs touching `src/**/*.php`, `**/*.inc`, `src/**/*.js`
+   (paths filter), and fold it into the "All tests passed" aggregate so release.yml's
+   verify-checks already covers it. Tier A only on the PR path (cheap/hermetic).
+5. TIER B triggers: `schedule` (daily — guard to skip when there were no commits) +
+   `workflow_dispatch`. Wire its blocking-ness per the Phase-4 decision (default
+   non-blocking unless P4 proved it can gate).
+
+CONSTRAINTS
+- NO src/ change. Mirror smoke.yml conventions (image cache, secrets/inputs, KVM enable).
+  POSIX sh in any inline step; quote expansions. YAML must be valid. Do NOT touch the
+  release pipeline yet (Phase 6).
+- Keep default `python -m pytest` (and test.yml's existing jobs) byte-identical except the
+  added Tier-A gate job.
+
+VERIFICATION (must all pass before the phase is done)
+- YAML parses; `ui-tests.yml` exposes workflow_call inputs (image-ref/version, tier) and a
+  per-(tier x version) job matrix.
+- A workflow_dispatch run (or a documented dry-run) shows: Tier A green on the CE image;
+  diagnostics artifact present; a single forced leg failure is re-runnable in isolation.
+- The PR-path Tier-A job is paths-gated and part of the aggregate.
+- python -m pytest -> default count UNCHANGED; ruff/shellcheck clean on touched files.
+
+EXPECTED RESULT
+A reusable, matrix-parametric `ui-tests.yml` with per-leg re-run isolation and diagnostics
+upload; Tier A gating PHP/JS PRs; Tier B on schedule + dispatch.
+
+COMMIT (single)
+    ci: add reusable matrix-parametric UI test workflow + PR/schedule gates (ADR-14 P5)
+In this ADR's `adr/14` worktree (reuse it if already implementing this ADR, else create off the latest `origin/devel`): `git fetch` + rebase onto the latest `origin/devel`, then push `adr/14`. The ADR lands on `devel` via a rebase-only PR (never a merge). PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_14_UI_UX_Testing/RESULTS/05_Results.txt`
+State: the ui-tests.yml inputs + the job matrix shape (tier x version); how Tier A is
+paths-gated + folded into the aggregate; how Tier B is triggered + whether it gates; the
+diagnostics artifact contents; the measured/dry-run evidence; the go-ahead for Phase 6.

--- a/.ADRs/ADR_14_UI_UX_Testing/06_Release_Integration_Docs_DoD.txt
+++ b/.ADRs/ADR_14_UI_UX_Testing/06_Release_Integration_Docs_DoD.txt
@@ -1,0 +1,71 @@
+================================================================================
+PHASE 6 PROMPT — Release integration (D1) + docs + manual smoke + DoD
+Target model: Claude Opus 4.8
+ADR: .ADRs/ADR_14_UI_UX_Testing/ADR.md   (read §2 "Release gate" + §7 FIRST)
+================================================================================
+
+ROLE
+You are on the `adr/14` branch performing Phase 6 (final) of ADR-14. This wires the UI
+suite into the release pipeline (full suite before publishing, each leg re-runnable in
+isolation), updates the docs, and finalises §7 (manual smoke + reject criteria). NO src/
+change; default pytest unchanged. Work in this ADR's `adr/14` worktree; one commit for this phase.
+
+WHY THIS PHASE EXISTS
+A release must run the full UI suite first (maintainer requirement), but a not-our-fault
+flake must NOT force a full pipeline re-run — it must re-run as one isolated leg (D1).
+And the harness only earns Accept after a human reviews the screenshots + confirms reality
+on a live box (§7).
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_14_UI_UX_Testing/RESULTS/05_Results.txt — it must confirm `ui-tests.yml` is
+  reusable (workflow_call) + the job matrix + whether Tier B can gate. If missing, Phase 5
+  is not complete; STOP and report.
+- .ADRs/ADR_14_UI_UX_Testing/ADR.md (§2 Release gate row, §6 Phase 6, §7 in full).
+- .github/workflows/release.yml — the chain: verify-checks (reads the "All tests passed"
+  check-run for the tagged commit) -> release (publish) -> ports-pr (FreeBSD-ports PR).
+  Tag trigger `v[0-9]*.[0-9]*.[0-9]*`.
+- .github/workflows/ui-tests.yml (Phase 5) — the reusable workflow to call.
+- README.md + CLAUDE.md — where the test/CI docs live.
+
+ACTION PLAN (ordered)
+1. RELEASE WIRING (D1): make `release.yml` run the UI suite BEFORE `release`/`ports-pr`.
+   Either add a job that `uses: ./.github/workflows/ui-tests.yml` (workflow_call) with
+   `release` (and/or verify) `needs:`-depending on it, OR have verify-checks require the
+   UI legs — pick the option that keeps EACH (tier x version) leg a SEPARATE, in-isolation
+   re-runnable job and does NOT redo `release`/`ports-pr` when only a UI leg is re-run.
+   Document the exact behaviour.
+2. DOCS: update README.md + CLAUDE.md — the tiers (A render / B functional / B browser),
+   the markers (ui_render / ui_e2e / ui_browser), how to run each locally against a smoke
+   VM, the version-matrix axis (B1: parametric, single CE image today) + an IMAGE_RUNBOOK
+   pointer for adding images, and the screenshot artifact. Keep CLAUDE.md's smoke section
+   in sync (UI tests live under tests/smoke/ui/, reuse smoke_vm).
+3. FINALISE §7 in ADR.md: lock the manual smoke checklist + the reject/pivot criteria;
+   fold in the Phase-4 browser-tier decision + numbers. Set Status appropriately (leave
+   the final Accept to the maintainer after the live-box smoke + screenshot review).
+4. Markdown must be markdownlint-clean (npx markdownlint-cli2) for README/CLAUDE.md/ADR.md.
+
+CONSTRAINTS
+- NO src/ change. YAML valid; mirror release.yml + smoke.yml conventions. POSIX sh inline.
+  Markdown markdownlint-clean. Do NOT weaken the existing release gate — ADD to it.
+
+VERIFICATION (must all pass before the phase is done)
+- YAML parses; release.yml depends on the UI suite before publish; a single UI leg is
+  re-runnable WITHOUT redoing release/ports-pr (documented; dry-run if feasible).
+- npx markdownlint-cli2 -> clean on the docs touched.
+- python -m pytest -> default count UNCHANGED; ruff/shellcheck clean on touched files.
+- ADR.md §7 finalised; README/CLAUDE.md updated.
+
+EXPECTED RESULT
+The release pipeline runs the full UI suite first with per-leg re-run isolation; the docs
+describe the harness; §7 is final, awaiting only the maintainer's live-box smoke + the
+screenshot review to flip Status to Accepted.
+
+COMMIT (single)
+    ci: gate releases on the UI suite + document the UI test harness (ADR-14 P6)
+In this ADR's `adr/14` worktree (reuse it if already implementing this ADR, else create off the latest `origin/devel`): `git fetch` + rebase onto the latest `origin/devel`, then push `adr/14`. The ADR lands on `devel` via a rebase-only PR (never a merge). PR body via --body-file.
+
+HANDOFF — write `.ADRs/ADR_14_UI_UX_Testing/RESULTS/06_Results.txt`
+State: how release.yml now depends on the UI suite + the proven per-leg re-run isolation;
+the docs updated; the final §7 status; the complete manual-smoke checklist handed to the
+maintainer; the overall ADR-14 completion summary + the Accept criteria still outstanding.

--- a/.ADRs/ADR_14_UI_UX_Testing/ADR.md
+++ b/.ADRs/ADR_14_UI_UX_Testing/ADR.md
@@ -1,0 +1,189 @@
+# ADR-14: Web UI/UX testing on the live pfSense VM (tiered render + functional + browser)
+
+- **Status:** **Proposed** (2026-06-03)
+- **Date:** 2026-06-03
+- **Branch:** `adr/14` (off **`devel`** — this is **dev-only test/CI infra** that builds on the ADR-04 smoke harness (`tests/smoke/conftest.py` `smoke_vm`, `helpers.py` diagnostics), the portable Linux `.pkg` builder (`build-pkg-linux.yml`), and `smoke.yml`, all of which live on `devel`. (`next` was retired 2026-06-04 into a two-tier `main←devel` model; devel is the default/integration branch.) Nothing here ships in the release archive — `src/` is untouched.) / **Component(s):** `tests/smoke/` (new `ui/` subpackage reusing the `smoke_vm` fixture), `tests/smoke/requirements.txt` (add `requests` + Playwright), `.github/workflows/` (new reusable `ui-tests.yml`; wiring into `test.yml`, `smoke.yml`-style triggers, and `release.yml`), `README.md`/`CLAUDE.md` (docs).
+- **Target runtime:** **dev/CI only.** Python 3.11+ (pytest) on a GitHub `ubuntu-latest` runner, driving a live **pfSense CE** WebUI inside QEMU/KVM (the ADR-04 image). Non-stdlib test deps (`requests`, `playwright`) live in `tests/smoke/requirements.txt` — **not** shipped, same discipline as the existing smoke deps. **No `src/` change**; the Unbound plugin, PHP package, and shipped JS are untouched.
+- **Test suite:** new `tests/smoke/ui/` (markers `ui_render`, `ui_e2e`, `ui_browser`), reusing `tests/smoke/conftest.py`. **Default `python -m pytest` stays byte-identical** — UI tests are excluded from default collection by the same mechanism as the smoke suite. No `pytest` *oracle* for the PHP itself (it only runs inside pfSense); validation = the live-VM assertions below + a manual screenshot review.
+
+---
+
+## 1. Context
+
+### Today
+
+pfBlockerNG ships a substantial Web UI with **zero automated coverage**:
+
+1. **18 PHP pages** under `src/usr/local/www/pfblockerng/` (`pfblockerng.php`, `_general`, `_ip`, `_dnsbl`, `_feeds`, `_alerts`, `_log`, `_category`/`_category_edit`, `_sync`, `_safesearch`, `_threats`, `_update`, `_blacklist`, `_asn`-related), plus the DNSBL VIP webserver pages (`www/index.php`, `www/dnsbl_default.php`), a **dashboard widget** (`widgets/widgets/pfblockerng.widget.php` + `widgets/include/widget-pfblockerng.inc`), and **client-side JS**: `pfBlockerNG.js` (268 lines) and `widgets/javascript/pfblockerng.js` (198 lines).
+2. **The JS carries real UX logic** that static checks can't reach: field enable/disable toggles (`enable_change_in/out`, `enable_change_port_in/out`, `pfBlockerNG.js:213-230`), `pfb_autocomplete*` (`:36`/`:102`), label removal (`:115`), row move handlers (`[name^=Lmove]`/`[name^=Xmove]`, `:145-149`), and a background AJAX state change `pfb_chg_state_bkgd()` (`:124`).
+3. **Current automated coverage is structural only.** `python -m pytest` is **pure-logic** (`pfb_unbound.py` + ADR-06/07 + the portable builder). PHP/shell get `php -l` + PHPStan + ShellCheck (`test.yml`) — **symbol/syntax existence, not runtime rendering.** None of these catch a page that 500s, renders a PHP `Warning`/`Notice`, or breaks a form on a real box.
+4. **A live WebUI already exists in CI but is barely touched.** The ADR-04 smoke VM exposes the webConfigurator at host `127.0.0.1:8080` → guest `:80` (SLIRP hostfwd, `tests/smoke/boot_vm.sh:119`). `wait_ready.sh:102` polls it (`curl -fsSL http://…:8080/`); `roundtrip.sh` curls `/` → the login page — **unauthenticated reachability only.** The admin password is baked (`SMOKE_ADMIN_PASSWORD`) but **auth is never exercised**.
+5. **The harness it would build on is rich and reusable.** `smoke_vm` is a **session-scoped** fixture (`tests/smoke/conftest.py:303`) yielding a `SmokeVM` with an `ssh()` helper (`:144`); `helpers.py` already has `config_get()` (`:403`), `config_set`/`write_config`, and a full diagnostics collector (`snap_state`/`dump_state_diffs`/`dump_diagnostics`, `:829`/`:862`). `smoke.yml` is `workflow_dispatch` + `workflow_call` (+ a nightly `schedule`), builds the branch `.pkg` on Linux (`build-pkg-linux.yml`), runs `pytest -m smoke`, and uploads a `smoke-diagnostics` artifact `if: always()` (`smoke.yml:263`).
+6. **The release flow is a gated chain.** A `v[0-9]*.[0-9]*.[0-9]*` tag triggers `release.yml`: `verify-checks` (asserts the **"All tests passed"** check-run for the tagged commit is `success`) → `release` (publish GitHub Release) → `ports-pr` (open a PR on `pfsense/FreeBSD-ports`). There is **no UI gate** in this chain.
+
+### The need (maintainer-confirmed)
+
+Catch WebUI regressions that `php -l`/PHPStan miss — pages that error or render warnings on a real box, and forms that silently stop persisting — **before** they reach a release. Two tiers, by cost/frequency: a **cheap render-smoke that gates PRs touching PHP**, and a **heavier functional + browser pass** (with **screenshots as artifacts**) that runs daily/on-demand. Workflows must be **matrix-parametric over pfSense version** (smoke-style), every leg **re-runnable in isolation** (a not-our-fault flake shouldn't force a full re-run), and the **release pipeline must run the full suite first** while keeping that isolation.
+
+### Load-bearing facts (verify, don't assume — per `CLAUDE.md`)
+
+1. **Feature/infra ADR, not a perf premise (≈ ADR-12, not ADR-01).** The falsifiable risk is **flake & cost**, not speed. Browser E2E over SLIRP-QEMU in CI is the classic flaky/slow trap → §7 defines the kill gate.
+2. **These pages only run inside pfSense.** They `require_once` pfSense core (`guiconfig.inc`, …) → **cannot render under a standalone PHP server** without heavy stubbing. The ADR-04 VM is the **only** viable host; a separate harness is out.
+3. **The pass/fail oracle is NOT HTTP 200.** A 200 can carry a rendered PHP `Warning`/`Notice`, or a blank body. The oracle must read the **body** (no `Fatal error`/`Parse error`/`Warning`/`Notice`/`Uncaught`), a **page-specific content marker**, **and** the on-box `php_error.log` (source of truth) — and for functional tests the **effective** `config.xml`/`pfctl`/unbound state via `helpers.config_get`, never the HTTP response alone.
+4. **WebUI protocol must be confirmed on the image, not assumed.** Evidence says **HTTP** (`wait_ready.sh:102` `curl -fsSL http://…:8080/` succeeds → no forced HTTPS redirect), but Phase 1 confirms `config.xml <system><webgui><protocol>` and the exact login form (`__csrf_magic`, `usernamefld`/`passwordfld`, session cookie) against the **live** login page.
+5. **Only one smoke image exists today** (pfSense CE, GHCR by digest). The version axis is built **parametric** and run against that one image now; additional images (Plus / other CE) are a later IMAGE_RUNBOOK effort (B1).
+6. **Default `pytest` must stay untouched.** UI tests reuse the smoke fixtures and are excluded from default collection exactly as smoke is (markers + the existing ignore), so `python -m pytest` remains byte-identical.
+
+---
+
+## 2. Decision
+
+Add a **tiered Web-UI test harness on the ADR-04 smoke VM**, reusing the `smoke_vm` fixture and `helpers.py`, driven by **authenticated HTTP for breadth** and a **headless browser for JS-only UX + screenshots**, wired into PRs (cheap tier, blocking), a daily/on-demand schedule (heavy tier), and the release pipeline (full suite, re-runnable per leg).
+
+| Area | Decision |
+| --- | --- |
+| **Tier A — render-smoke** | **Authenticated HTTP** (`requests` + `__csrf_magic` login). GET **every** pfBlockerNG page (the 18 + widget + DNSBL VIP pages) → assert **200**, body free of `Fatal error`/`Parse error`/`Warning`/`Notice`/`Uncaught`, a **page-specific marker** present, **and** the on-box `php_error.log` gained no new lines during the sweep. Hermetic, fast. Marker `ui_render`. **Runs per-PR when PHP/JS files change; blocking.** |
+| **Tier B — functional (HTTP)** | A curated set of **CSRF POST** flows (save General; add/save an IP feed/alias; toggle a DNSBL setting) → assert the **effective state** via `helpers.config_get`/`pfctl`/unbound, not the HTTP response. Marker `ui_e2e`. Daily/on-demand. |
+| **Tier B — browser** | **Headless Playwright/Chromium** against `:8080`, reusing the auth session (inject the session cookie into the browser context to avoid a second login flake). Exercises the **JS-only** behaviours (`enable_change_*`, `pfb_autocomplete*`, `pfb_chg_state_bkgd`, the dashboard widget) and **captures per-page screenshots** uploaded as artifacts. Marker `ui_browser`. Daily/on-demand. **The flaky/heavy tier — gated by the §7 reliability threshold.** |
+| **Screenshots (A1)** | **Browser tier only** (HTTP can't screenshot). Tier A stays pure-HTTP/screenshot-less; on failure it captures the page body + `php_error.log` into the diagnostics artifact. |
+| **Test home** | `tests/smoke/ui/` subpackage, reusing `tests/smoke/conftest.py` `smoke_vm` + `helpers.py`. Excluded from default collection like the smoke suite → `python -m pytest` unchanged. |
+| **Oracle (fact 3)** | Body-content + page-marker + on-box `php_error.log` (Tier A); effective `config.xml`/`pfctl`/unbound (Tier B). **Never** HTTP 200 alone. |
+| **Workflows (matrix B1)** | A **reusable** `ui-tests.yml` (`workflow_call` + `workflow_dispatch` + `schedule`), parametric on **image-ref/version** (matrix axis built, single CE image run now) and **tier** (input). Builds the branch `.pkg` via the existing Linux builder, boots the image, runs the selected tier. |
+| **Re-run granularity (C1)** | **One GH job per (tier × version)** so "re-run failed jobs" re-runs only the flaky leg. **No silent auto-retry on assertions**; a **bounded retry only on infra steps** (boot/login). Screenshots + logs uploaded `if: always()`. |
+| **PR gate (3a)** | Tier A runs on PRs touching `src/**/*.php`, `*.inc`, `src/**/*.js`; folded into the **"All tests passed"** aggregate so `release.yml`'s `verify-checks` already covers it. Blocking. |
+| **Release gate (D1)** | `release.yml` `needs:` the reusable UI workflow (Tier A + Tier B) **before** `release`/`ports-pr`, each leg a separate job → the full suite gates a release, but a not-our-fault flake re-runs **in isolation** without redoing the release. |
+
+### Semantics that MUST be preserved (the contract — pin with tests before relying on them)
+
+- **Default suite untouched.** `python -m pytest` is byte-identical (UI excluded from default collection); the smoke suite (`-m smoke`) still passes unchanged.
+- **No `src/` change.** This ADR adds tests + CI only; the shipped package (PHP/Python/JS/shell) is not modified.
+- **Real oracle.** A page that renders a PHP `Warning`/`Notice`/`Fatal`, returns non-200, or leaves a blank body **fails** — a bare 200 is never a pass (fact 3, pinned in Phase 2 with a deliberately-broken-page check).
+- **Auth session is reusable + correct.** Login via the live CSRF form; an authenticated GET returns the page; an **unauthenticated** GET redirects to login (pinned in Phase 1).
+- **Hermetic where it claims to be.** Tier A asserts pure rendering and must not require feed downloads; any page that triggers network is either kept out of Tier A or runs with egress as the smoke harness already allows.
+- **Isolation.** Each (tier × version) leg is an independent job; a failure in one neither blocks nor masks the others, and is re-runnable alone.
+
+### Explicitly kept / out of scope
+
+- **Visual / pixel-diff / accessibility (a11y) regression** — out (1c). Most page chrome is pfSense-core, not ours; high maintenance, low ROI. Screenshots are **artifacts for human review**, not asserted pixel baselines.
+- **A standalone (non-VM) PHP-server harness** — out (fact 2); the pages need the pfSense runtime.
+- **Building a second pfSense image (Plus / other CE)** — out for v1 (B1); the matrix axis is built but runs the single existing CE image. New images are a separate IMAGE_RUNBOOK effort.
+- **`src/` refactors to make pages more testable** — out; behaviour-preserving test infra only.
+- **Silent auto-retry of UI assertions** (`pytest-rerunfailures` on the checks) — out (C1); it masks real flake. Retry is confined to infra setup (boot/login).
+- **Cross-browser (Firefox/WebKit) matrix** — out for v1; one headless Chromium.
+
+---
+
+## 3. Consequences
+
+**Positive**
+
+- Catches the class of regression `php -l`/PHPStan structurally cannot: runtime PHP errors/warnings, 500s, blank pages, and broken form persistence — on a **real** pfSense box, before release.
+- **Tiered cost:** the cheap HTTP render-smoke gates PRs without browser flake; the heavy browser + screenshot pass runs daily/on-demand and never blocks fast iteration.
+- **Reuses existing infra** (`smoke_vm`, `helpers.py`, the Linux `.pkg` build, the diagnostics artifact) → small new surface, consistent operational model.
+- **Screenshots-as-artifacts** give a human a fast visual diff across versions without a brittle pixel baseline.
+- **Release-gated + re-runnable per leg** → the full suite protects a release while a not-our-fault flake costs one job re-run, not a full pipeline.
+- Tiers A + B-HTTP have **standalone value** and are retained even if the browser tier is rejected (mirrors ADR-01's retained prep phases).
+
+**Negative / risks**
+
+- **Browser E2E over SLIRP-QEMU is flaky/slow** — the core risk. Mitigated: gated behind a §7 reliability threshold; cookie-injected sessions; no fixed sleeps (poll readiness); per-leg re-run; demote-or-drop on failure (§7).
+- **Per-PR VM boot cost.** Tier A boots a pfSense VM (~smoke-job cost) on every PHP-touching PR. Mitigated: `paths`-gated, image cache (content-keyed), single fast tier.
+- **No automated oracle for the PHP itself** (it only runs in pfSense) → screenshot/visual correctness needs a **human**; encoded as a manual smoke step (§7).
+- **Oracle false-confidence** if it checks only 200. Mitigated: body + marker + on-box `php_error.log`, pinned against a deliberately-broken page (Phase 2).
+- **Version matrix is structural, not yet real** (one image). Mitigated: documented (B1); adding images is a known IMAGE_RUNBOOK task.
+- **New test deps** (`requests`, Playwright + browser download) on the runner. Mitigated: dev-only (`tests/smoke/requirements.txt`), cached; never shipped.
+
+---
+
+## 4. Requirements (acceptance)
+
+1. **Default suite unchanged:** `python -m pytest` byte-identical; `pytest -m smoke` still green.
+2. **Auth works:** the harness logs into the live webConfigurator via CSRF; an authenticated GET returns the page; an unauthenticated GET redirects to login.
+3. **Tier A render-smoke:** every pfBlockerNG page returns 200 with no PHP error/warning in body **and** no new `php_error.log` line, with a page-specific marker present; a deliberately-broken page is **caught** (proves the oracle).
+4. **Tier B functional:** the curated CSRF-POST flows change the **effective** `config.xml`/`pfctl`/unbound state as asserted (not just the HTTP response).
+5. **Tier B browser:** the JS-only behaviours are exercised and per-page **screenshots** are produced and uploaded as artifacts.
+6. **Workflows:** a reusable `ui-tests.yml` is matrix-parametric (image-ref/version) and tier-selectable; one job per (tier × version); diagnostics (screenshots + logs) uploaded `if: always()`.
+7. **PR gate:** Tier A runs on PRs touching PHP/JS and is part of the "All tests passed" aggregate (blocking).
+8. **Release gate:** `release.yml` runs the UI suite before publishing, each leg re-runnable in isolation.
+9. **Lint-clean:** `ruff check`/`ruff format` clean on the new Python; `shellcheck` clean on any new shell; YAML valid.
+
+---
+
+## 5. Constraints (from `CLAUDE.md`)
+
+- **Python:** 4-space indent, 3.11+, type hints on new functions, no bare `except`. Ruff is the canonical linter; keep `.flake8` in sync if config changes. Non-stdlib test deps go in `tests/smoke/requirements.txt` (dev-only), never in `pfb_unbound.py`.
+- **No `src/` change** — the shipped PHP/Python/JS/shell are untouched; this is test/CI infra.
+- **Shell:** any helper is POSIX `sh`, quoted, absolute binary paths, ShellCheck-clean.
+- **Investigation rigor:** confirm the WebUI protocol, login form, and creds against the **live** box + `config.xml` (source of truth), not assumption; assert effective state via the tool/CLI, not a single generated artifact (fact 3/4).
+- **Smoke-harness truths still apply** (ADR-04): probe on-box where relevant, content-keyed image cache, `smoke_vm` is session-scoped, diagnostics uploaded on failure.
+- Commit style `<scope>: <imperative summary>`; **work in this ADR's `adr/14` worktree (reuse it across phases; create it off the latest `origin/devel` if absent), one commit per phase**; `git fetch` + rebase onto the latest `origin/devel` before every push; the ADR lands on `devel` via a **rebase-only PR** (never a merge); PR bodies via `--body-file`. Promote `devel`→`main` by rebase/replay + `--force-with-lease` (two-tier linear `main←devel`; `next` retired 2026-06-04).
+- **Docs:** README/CLAUDE.md updated when the harness lands (final phase) — tiers, markers, how to run locally, the matrix axis, the IMAGE_RUNBOOK note.
+
+---
+
+## 6. Action plan
+
+Each phase = one commit, leaves `python -m pytest` **byte-identical/green** and the tree lint-clean. The **cheap, hermetic tiers land first** (Phases 1–2, standalone value); the **flaky/heavy browser tier (Phase 4) lands behind the §7 reliability gate**; workflows + release wiring close it out.
+
+### Phase 1 — PREP (behaviour-preserving): authenticated WebUI session helper + recon
+
+Prompt: `01_Auth_Session_Prep.txt`
+
+- Reuse `smoke_vm`. Build a reusable `webui` helper (under `tests/smoke/ui/`): CSRF login (`__csrf_magic`, `usernamefld`/`passwordfld`), session-cookie persistence, an authenticated `get(path)`. **RECON & PIN (don't assume, fact 4):** confirm the webConfigurator protocol (`config.xml <system><webgui><protocol>`), the exact login form/cookie names against the **live** login page, and the creds source (baked `SMOKE_ADMIN_PASSWORD`). Pin with a `ui_render`-marked test: login succeeds; an authenticated GET of a known page returns 200 + marker; an **unauthenticated** GET redirects to login. Add `requests` to `tests/smoke/requirements.txt`. **No `src/` change; default suite untouched.**
+
+### Phase 2 — Tier A: HTTP render-smoke sweep (all pages) + the real oracle
+
+Prompt: `02_Render_Smoke_Tier_A.txt`
+
+- Enumerate every pfBlockerNG page (18 + widget + DNSBL VIP). Parametrized `ui_render` test: authenticated GET → 200, body free of `Fatal error`/`Parse error`/`Warning`/`Notice`/`Uncaught`, a **page-specific marker** present, **and** no new `php_error.log` line during the sweep (read on-box via `SmokeVM.ssh`). **Prove the oracle**: a deliberately-broken probe (e.g. a page known to warn, or an injected check) must FAIL the assertion — a bare 200 is never a pass. Standalone-valuable cheap tier.
+
+### Phase 3 — Tier B (functional, HTTP-POST): drive forms, assert effective state
+
+Prompt: `03_Functional_HTTP_Tier_B.txt`
+
+- A curated set of `ui_e2e` flows via CSRF POST: save General settings; add/save an IP feed or alias; toggle a DNSBL setting. After each, assert the **effective** state via `helpers.config_get` (+ `pfctl`/unbound where relevant), **not** the HTTP response. Establishes the functional oracle before any browser code.
+
+### Phase 4 — Tier B (browser): Playwright layer + screenshots (gated by §7)
+
+Prompt: `04_Browser_Screenshots_Tier_B.txt`
+
+- Headless Chromium against `:8080`, reusing the Phase-1 session (inject the cookie into the browser context). Exercise the **JS-only** behaviours (`enable_change_*`, `pfb_autocomplete*`, `pfb_chg_state_bkgd`, the dashboard widget) and capture **per-page screenshots** to an artifact dir. Marker `ui_browser`. Add Playwright to `tests/smoke/requirements.txt`. **Measure the §7 reliability/budget numbers here** — if the browser tier can't hit the threshold, record it and apply the demote/drop decision (the cheap tiers already shipped).
+
+### Phase 5 — Workflows: reusable, matrix-parametric, tiered triggers, diagnostics
+
+Prompt: `05_Workflows_Matrix_Tiers.txt`
+
+- A reusable `ui-tests.yml` (`workflow_call` + `workflow_dispatch` + `schedule`), parametric on image-ref/version (matrix axis built, single CE image run now) and tier (input); builds the branch `.pkg` via `build-pkg-linux.yml`, boots the image, runs the selected tier. **One job per (tier × version)** (C1); **no auto-retry on assertions**, bounded retry only on boot/login; screenshots + logs uploaded `if: always()` (extend the `smoke-diagnostics` pattern). Wire **Tier A** into the per-PR path gated on `paths` (PHP/JS) and into the "All tests passed" aggregate (blocking, 3a); **Tier B** on `schedule` (daily-if-commits) + `workflow_dispatch`.
+
+### Phase 6 — Release integration + docs + manual smoke + DoD
+
+Prompt: `06_Release_Integration_Docs_DoD.txt`
+
+- D1: make `release.yml` `needs:` the reusable UI workflow (Tier A + Tier B) before `release`/`ports-pr`, each leg a separate job re-runnable in isolation. Update README/CLAUDE.md (tiers, markers, local-run, the version-matrix axis + IMAGE_RUNBOOK note). Finalise §7 manual smoke + the explicit reject/pivot criteria; set Status accordingly after the maintainer confirms.
+
+---
+
+## 7. Definition of done
+
+- `python -m pytest` byte-identical; `pytest -m smoke` green; new Python ruff-clean; new shell ShellCheck-clean; YAML valid.
+- Tier A render-smoke passes on the live VM with the **real oracle** (body + marker + `php_error.log`), and the deliberately-broken probe is caught.
+- Tier B functional flows change the asserted **effective** state; Tier B browser produces per-page screenshots as artifacts.
+- The reusable `ui-tests.yml` runs matrix-parametric with one job per (tier × version) and uploads diagnostics on failure; Tier A gates PRs; the release pipeline runs the suite first, each leg re-runnable in isolation.
+- Status → **Accepted** only after the maintainer confirms the manual smoke below and reviews the screenshot artifacts on a live pfSense box.
+
+### Reject / pivot criteria (the ADR-01-analog kill gate — decide on evidence)
+
+- **Browser tier too flaky/slow:** if Phase 4 can't reach **≥ 4/5 clean** runs at **≤ ~25 min** per matrix leg (mirroring ADR-04's "≤ ~20 min AND ≥ 4/5"), it is **demoted to non-blocking dispatch-only** and never gates PRs or releases. If even on-demand it can't be made reliable, **drop the browser layer entirely** — Tiers A + B-HTTP retain standalone value and ship.
+- **Oracle can't be made meaningful:** if rendered PHP warnings can't be reliably detected (body + `php_error.log` both miss them) such that Tier A passes a known-broken page → the render tier is not trustworthy; pivot to a narrower, log-only oracle or reconsider the tier.
+- **Tier A too heavy for PRs:** if the per-PR VM boot + render sweep can't fit a sane budget (≤ ~15 min) reliably, demote Tier A to daily/on-demand (drop the PR gate); the cheaper checks still run pre-release.
+
+### Manual smoke (owner: maintainer) — required before Accept
+
+> CI can assert rendering/state but not *visual* correctness or true cross-version UX. Confirm on a live pfSense box / via the artifacts.
+
+- [ ] **Screenshot review.** Pull the Tier-B `ui-diagnostics` artifact; every pfBlockerNG page renders correctly (no broken layout, missing fields, or stray PHP output) — eyeball across the produced set.
+- [ ] **Functional reality.** A settings change made through the real GUI persists and takes effect (matches what Tier B asserts) — spot-check General + one IP feed + one DNSBL toggle.
+- [ ] **JS UX.** The field enable/disable toggles, autocomplete, and the dashboard widget behave in a real browser as the `ui_browser` tier drives them.
+- [ ] **Flake reality.** Re-run the browser leg several times; confirm the §7 threshold holds (or apply the demote/drop decision).
+- [ ] **Release dry-run.** A tag/release dry-run runs the UI suite first; a forced single-leg failure is re-runnable in isolation without redoing `release`/`ports-pr`.
+- [ ] **Multi-version (when a 2nd image exists).** The matrix runs green against an added pfSense image with no harness change beyond the image ref.


### PR DESCRIPTION
## What

Track the previously-uncommitted **ADR-14** draft (docs only — no `src/`, no code).

ADR-14 adds a **tiered Web-UI test harness on the ADR-04 smoke VM**:

- **Tier A** — authenticated HTTP render-smoke over every pfBlockerNG page; oracle = body free of PHP `Fatal/Parse/Warning/Notice/Uncaught` + a page marker + clean on-box `php_error.log` (never bare HTTP 200). PR-blocking.
- **Tier B** — functional CSRF-POST flows asserting effective `config.xml`/`pfctl`/unbound state, plus headless Playwright for the JS-only UX with per-page **screenshots**. Daily/on-demand.
- Wired into PRs, a schedule, and the release gate; browser tier behind a flake/cost **kill-gate** (demote → drop, Tiers A+B-HTTP retain standalone value).

Status: **Proposed** (pending the maintainer's manual smoke + Accept). Ships nothing.

## Why now

The 18 PHP pages + widget + `pfBlockerNG.js` UX have **zero** automated coverage — `php -l`/PHPStan catch syntax/symbols, not a page that 500s or renders a warning on a real box. No existing ADR covers this (ADR-04 only does unauthenticated reachability). Committing the draft makes it tracked and unblocks `/adr-phase`.

## De-staled before commit

The six `/adr-phase` prompt files (and ADR §6) carried the old *"work inline on `adr/14`, push directly, PR only if rejected"* workflow. Rewritten to today's rules: **work in this ADR's `adr/14` worktree (reused across phases), `git fetch` + rebase onto the latest `origin/devel` before every push, land via a rebase-only PR.**

## Validation

Pre-commit hooks green (markdownlint, pytest 985, mypy, shebang policy, `sh -n`, shellcheck, shellspec, `php -l`, PHPStan); default `python -m pytest` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a comprehensive, phased UI/UX testing framework for the web interface with multiple validation tiers
  * Planning covers authenticated page rendering, functional form workflows, and browser-based interaction testing with automated screenshot capture
  * Framework designed to integrate into CI/CD and release pipelines for continuous interface quality assurance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->