### PR TITLE
pfblockerng: fix continue in switch warning in pfb_get_vips (#24)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -684,7 +684,7 @@ function pfb_get_vips(): array {
 				$vips6[$vip_id] = $vips[$vip_address];
 				break;
 			default:
-				continue;
+				break;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #24. `pfb_get_vips()` used `continue;` in the `default:` branch of the `is_ipaddr()` `switch`. PHP 8.3 treats that as `break` and warns on every call:

```
PHP Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
```

## Change

`pfblockerng.inc` — `continue;` → `break;` in the `default:` case.

Behaviour is unchanged: `default` is the last case and nothing follows the `switch` inside the `foreach`, so `break` (exit switch → next loop iteration) and `continue 2` are equivalent here. `break` is the idiomatic switch terminator and clears the warning.

## Verification

- `php -l` — no syntax errors; the compile-time switch/continue warning is gone
- PHPStan (`--memory-limit=1G`) — no errors
- PHPUnit — 83 tests, 106 assertions, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid Virtual IP addresses during configuration processing, reducing potential misinterpretation and increasing robustness.
  * No visible change to existing configurations or workflows; updates are internal and aim to prevent rare processing anomalies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->