### PR TITLE
pfblockerng: default-init TLD-Allow keys in pfb_unbound init

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -316,6 +316,15 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["gpListDB"] = False
     pfb["noAAAADB"] = False
     pfb["python_idn"] = False
+    # TLD-Allow defaults. The PHP ini writer always emits these three MAIN keys, so
+    # the config.has_option() loads below normally populate them -- but default them
+    # here too so a hand-edited/corrupted ini that drops the keys can't KeyError on
+    # the unconditional reads (TLD-Allow check + manifest cfg). ``python_tlds`` is a
+    # list (line stores it via ``.split(",")``); the consumer ``tld not in
+    # cfg["python_tlds"]`` treats the empty list correctly.
+    pfb["python_tld"] = False
+    pfb["python_tlds"] = []
+    pfb["python_tld_seg"] = 0
     pfb["python_hsts"] = False
     pfb["python_reply"] = False
     pfb["python_cname"] = False

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2656,8 +2656,8 @@ function pfb_unbound_python($mode) {
 		}
 
 		$python_tld = 'off';
+		$python_tlds = '';
 		if ($pfb['dnsbl_pytld'] == 'on') {
-			$python_tlds = '';
 			if (!empty($pfb['dnsblconfig']['pfb_pytlds_gtld'])) {
 				$python_tld = 'on';
 				$python_tlds = $pfb['dnsblconfig']['pfb_pytlds_gtld'];


### PR DESCRIPTION
## Summary

Fixes #25 — defensive-consistency cleanup in the DNSBL TLD-Allow path.

### Python (`pfb_unbound.py`)

`init_standard()` default-initializes every `pfb[]` `[MAIN]` flag, but the three TLD-Allow flags were the only ones **set conditionally** (via `config.has_option(...)`) yet **read unconditionally** — the TLD-Allow check and the per-query manifest `cfg`. Added them to the default-init block:

```python
pfb["python_tld"]     = False
pfb["python_tlds"]    = []
pfb["python_tld_seg"] = 0
```

The PHP ini writer always emits these three keys, so the supported path could never `KeyError`; this guards a hand-edited/corrupted ini. `[]` matches the list the loader stores (`.split(",")`) and the consumer `tld not in cfg["python_tlds"]`.

### PHP (`pfblockerng.inc`)

`$python_tlds` was assigned only inside `if ($pfb['dnsbl_pytld'] == 'on')`, so with TLD-Allow off the ini heredoc interpolated an **undefined** `$python_tlds` → PHP 8.3 `Undefined variable` warning (empty value was already the intended output). Initialized `$python_tlds = ''` alongside `$python_tld = 'off'` and dropped the now-redundant inner init.

## Testing

- `ruff check` / `ruff format --check`: clean
- `pytest`: 985 passed
- `php -l`: no syntax errors
- `phpstan`: no errors
- `phpunit`: 83 passed

`init_standard()` is not unit-testable off-box (needs the Unbound env); the chosen defaults match the established conftest/test-helper conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration resilience by initializing default TLD-allow settings to avoid failures when configuration is missing or corrupted.
  * Fixed initialization of the TLD allowlist variable to a safe default to prevent undefined-value issues when the feature is turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->