### PR TITLE
pfblockerng: fix $extdns typo dropping custom DNS resolver in CNAME lookups

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -965,7 +965,7 @@ if (isset($_POST) && !empty($_POST)) {
 		if (!empty(pfb_filter($pfb['extdns'], PFB_FILTER_IP, 'alerts addwhitelistdom'))) {
 			$domain_esc	= escapeshellarg($domain);
 			$ext_dns 	= escapeshellarg("@{$pfb['extdns']}");
-			exec("/usr/bin/drill {$domain_esc} {$extdns} | /usr/bin/awk '/CNAME/ {sub(\"\.\$\", \"\", \$5); print \$5;}' 2>&1", $cname_list);
+			exec("/usr/bin/drill {$domain_esc} {$ext_dns} | /usr/bin/awk '/CNAME/ {sub(\"\.\$\", \"\", \$5); print \$5;}' 2>&1", $cname_list);
 		}
 
 		// Remove 'www.' prefix
@@ -1411,7 +1411,7 @@ if (isset($_POST) && !empty($_POST)) {
 			// Query for CNAME(s)
 			if (!empty(pfb_filter($pfb['extdns'], PFB_FILTER_IP, 'alerts dnsbl_remove'))) {
 				$ext_dns = escapeshellarg("@{$pfb['extdns']}");
-				exec("/usr/bin/drill {$domain_esc} {$extdns} | /usr/bin/awk '/CNAME/ {sub(\"\.\$\", \"\", \$5); print \$5;}' 2>&1", $cname_list);
+				exec("/usr/bin/drill {$domain_esc} {$ext_dns} | /usr/bin/awk '/CNAME/ {sub(\"\.\$\", \"\", \$5); print \$5;}' 2>&1", $cname_list);
 				if (!empty($cname_list)) {
 					foreach ($cname_list as $cname) {
 						$cname = pfb_filter($cname, PFB_FILTER_DOMAIN, 'alerts dnsbl_remove', '', TRUE);


### PR DESCRIPTION
## Summary

Fixes #23. In `pfblockerng_alerts.php` the escaped resolver value is assigned to `$ext_dns` but interpolated into the `drill` command as `{$extdns}` (no underscore). The undefined variable expands to an empty string, so the `@<resolver>` argument is silently dropped and `drill` falls back to the system default DNS server instead of the user-configured one — no error, no log entry.

## Fix

Replace `{$extdns}` with `{$ext_dns}` at both CNAME-lookup sites:

- `addwhitelistdom` path
- `dnsbl_remove` path

`pfblockerng.inc` (the main package include) already uses the correct `$extdns_esc` and is unaffected. No security impact — the validated value was unused rather than misused.

## Verification

- `php -l` clean
- repo-wide grep confirms no remaining `{$extdns}` interpolation and no `$extdns` variable assigned anywhere
- pre-commit hooks (pytest, shellspec, php -l, markdownlint, shellcheck) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external DNS lookups when adding DNSBL whitelist domains and unlocking DNSBL domains to ensure correct CNAME record queries are performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->