### PR TITLE
test: un-skip the CNAME-validation live smoke (controlled stub CNAME chain)

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -436,14 +436,35 @@ class _MockFeedServer:
 
 
 class _StubDnsServer:
-    """A minimal dnspython-backed DNS server: any A/AAAA -> a sentinel address.
+    """A controlled, OBSERVABLE DNS upstream for the guest's Unbound (over SLIRP).
 
-    Gives the guest's Unbound a REACHABLE, controlled upstream over SLIRP
-    (10.0.2.2:<port>) so it never recurses to the (egress-blocked) root and hangs
-    — pfSense Unbound cannot service a query, not even a local DNSBL block, while
-    its recursion path is dark. Nothing leaks to the real internet: the stub
-    answers everything itself. Listens UDP+TCP on one ephemeral port; non-A/AAAA
-    queries get an empty NOERROR.
+    This is the smoke matrix's upstream: Unbound forwards every non-local query here
+    (``helpers.use_stub_upstream`` points its sole ``forward-zone "."`` at
+    10.0.2.2:<port>), so what reaches this server is EXACTLY what Unbound did not
+    answer locally. That makes blocking VERIFIABLE from the upstream side rather than
+    inferred from a bare SERVFAIL: every query is recorded (:meth:`received`), so a
+    DNSBL-blocked name must NEVER appear here, while a not-blocked name DOES — and
+    resolves to a known sentinel, distinct from every block shape. Nothing leaks to
+    the real internet; the server answers everything itself. Listens UDP+TCP on one
+    ephemeral port.
+
+    Per-domain answers are explicit and observable. Default (unregistered name): the
+    sentinel A/AAAA (``STUB_DNS_A`` / ``STUB_DNS_AAAA``). Overrides:
+
+      * :meth:`set_records` — give a name its OWN ``A`` (IPv4) and/or ``AAAA`` (IPv6)
+        addresses, one or many each; omit a family to serve NODATA for it (to test a
+        missing record). Families are validated (A must be IPv4, AAAA IPv6).
+      * :meth:`register_cname` — ``src -> target``; an ``A``/``AAAA`` query returns
+        ``CNAME + the TARGET's A/AAAA`` in one response, so the chain resolves
+        CONSISTENTLY to the target's own addresses (sentinel if the target is
+        unregistered). That 2-rrset shape (``an_numrrsets > 1``) is what
+        ``pfb_unbound.py``'s CNAME walk reads — a raw Unbound ``local-data`` CNAME
+        can't stand in (Unbound returns the bare CNAME, a single rrset).
+      * :meth:`register_nxdomain` — deny the name exists.
+
+    Because every domain has its OWN addresses, a probe can assert the EXACT IPs and
+    know which name was forwarded at each stage (no inference); :meth:`received` /
+    :meth:`queries` are the query log.
     """
 
     def __init__(self) -> None:
@@ -455,6 +476,15 @@ class _StubDnsServer:
         self._tcp.bind(("0.0.0.0", self._port))
         self._tcp.listen(16)
         self._stop = threading.Event()
+        self._lock = threading.Lock()
+        # fqdn (lowercased, trailing dot) -> a record dict, one of:
+        #   {"cname": target_fqdn}
+        #   {"a": [ipv4,...], "aaaa": [ipv6,...]}   (either key optional => NODATA)
+        #   {"nxdomain": True}
+        # Absent => the sentinel default (STUB_DNS_A / STUB_DNS_AAAA).
+        self._records: dict[str, dict[str, object]] = {}
+        # Every received query, in order: {"name", "type", "client"}.
+        self._queries: list[dict[str, str]] = []
         self._threads = [
             threading.Thread(target=self._serve_udp, daemon=True),
             threading.Thread(target=self._serve_tcp, daemon=True),
@@ -465,8 +495,94 @@ class _StubDnsServer:
         return self._port
 
     @staticmethod
-    def _build_response(data: bytes) -> bytes | None:
+    def _fqdn(name: str) -> str:
+        return name.rstrip(".").lower() + "."
+
+    @staticmethod
+    def _check_family(ips: tuple[str, ...], want_v6: bool) -> list[str]:
+        import ipaddress
+
+        out = []
+        for ip in ips:
+            addr = ipaddress.ip_address(ip)  # raises on a non-IP
+            if (addr.version == 6) != want_v6:
+                raise ValueError(f"{'AAAA' if want_v6 else 'A'} record needs an IPv{6 if want_v6 else 4} address: {ip}")
+            out.append(ip)
+        return out
+
+    def set_records(self, name: str, *, a: tuple[str, ...] = (), aaaa: tuple[str, ...] = ()) -> None:
+        """Give ``name`` its own A (IPv4) and/or AAAA (IPv6) addresses (one or many each).
+
+        Omit a family to serve NODATA (empty NOERROR) for it — e.g. ``a=(...)`` only
+        makes the name AAAA-less. Replaces any prior record for the name.
+        """
+        rec: dict[str, object] = {}
+        if a:
+            rec["a"] = self._check_family(a, want_v6=False)
+        if aaaa:
+            rec["aaaa"] = self._check_family(aaaa, want_v6=True)
+        with self._lock:  # _records is read by the server threads — guard every write
+            self._records[self._fqdn(name)] = rec
+
+    def register_a(self, name: str, *ips: str) -> None:
+        """Answer A for ``name`` with the given IPv4(s) (convenience for set_records)."""
+        self.set_records(name, a=ips)
+
+    def register_cname(self, src: str, target: str) -> None:
+        """Answer ``src`` with a CNAME to ``target``; the chain resolves to the target's
+        own A/AAAA (or the sentinel if the target is unregistered)."""
+        with self._lock:
+            self._records[self._fqdn(src)] = {"cname": self._fqdn(target)}
+
+    def register_nxdomain(self, name: str) -> None:
+        """Answer NXDOMAIN for ``name`` (an upstream that denies the name exists)."""
+        with self._lock:
+            self._records[self._fqdn(name)] = {"nxdomain": True}
+
+    def clear_cname(self) -> None:
+        """Drop ALL per-name records (back to the sentinel default for everything)."""
+        with self._lock:
+            self._records.clear()
+
+    def received(self, name: str | None = None, rtype: str | None = None) -> list[dict[str, str]]:
+        """Queries this upstream got, optionally filtered by name and/or rtype.
+
+        A blocked name must return an EMPTY list (it never reached the upstream); a
+        forwarded name returns its hits. The authoritative, log-free signal for
+        "was this name answered locally or forwarded?".
+        """
+        target = self._fqdn(name) if name else None
+        with self._lock:
+            return [
+                dict(q)
+                for q in self._queries
+                if (target is None or q["name"] == target) and (rtype is None or q["type"] == rtype)
+            ]
+
+    def queries(self) -> list[dict[str, str]]:
+        """A snapshot of the whole received-query log (for failure diagnostics)."""
+        with self._lock:
+            return [dict(q) for q in self._queries]
+
+    def reset_queries(self) -> None:
+        """Clear the received-query log (call between cases for clean assertions)."""
+        with self._lock:
+            self._queries.clear()
+
+    @staticmethod
+    def _addrs(rec: dict[str, object] | None, want_v6: bool) -> list[str] | None:
+        """Addresses to emit for a record of this family, or None for NODATA.
+
+        rec None (unregistered) -> the sentinel (a single default address). Registered
+        with the family -> its list. Registered WITHOUT the family -> None (NODATA).
+        """
+        if rec is None:
+            return [STUB_DNS_AAAA if want_v6 else STUB_DNS_A]
+        return rec.get("aaaa" if want_v6 else "a")  # type: ignore[return-value]
+
+    def _build_response(self, data: bytes, client: str = "") -> bytes | None:
         import dns.message
+        import dns.rcode
         import dns.rdatatype
         import dns.rrset
 
@@ -475,12 +591,34 @@ class _StubDnsServer:
         except Exception:
             return None
         resp = dns.message.make_response(req)
-        if req.question:
-            q = req.question[0]
-            if q.rdtype == dns.rdatatype.A:
-                resp.answer.append(dns.rrset.from_text(q.name, 60, "IN", "A", STUB_DNS_A))
-            elif q.rdtype == dns.rdatatype.AAAA:
-                resp.answer.append(dns.rrset.from_text(q.name, 60, "IN", "AAAA", STUB_DNS_AAAA))
+        if not req.question:
+            return resp.to_wire()
+        q = req.question[0]
+        name = q.name.to_text().lower()
+        # Snapshot the query log AND the record(s) this answer needs atomically, so a
+        # concurrent register_*/clear_cname on the test thread can't change the override
+        # map mid-request (which would make the smoke assertions nondeterministic).
+        with self._lock:
+            self._queries.append({"name": name, "type": dns.rdatatype.to_text(q.rdtype), "client": client})
+            rec = self._records.get(name)
+            target_rec = self._records.get(str(rec["cname"])) if (rec is not None and "cname" in rec) else None
+        if rec is not None and rec.get("nxdomain"):
+            resp.set_rcode(dns.rcode.NXDOMAIN)
+            return resp.to_wire()
+        if q.rdtype not in (dns.rdatatype.A, dns.rdatatype.AAAA):
+            return resp.to_wire()  # other qtypes: empty NOERROR
+        want_v6 = q.rdtype == dns.rdatatype.AAAA
+        rtype = "AAAA" if want_v6 else "A"
+        if rec is not None and "cname" in rec:
+            target = str(rec["cname"])
+            resp.answer.append(dns.rrset.from_text(q.name, 60, "IN", "CNAME", target))
+            ips = self._addrs(target_rec, want_v6)
+            if ips:
+                resp.answer.append(dns.rrset.from_text(target, 60, "IN", rtype, *ips))
+            return resp.to_wire()
+        ips = self._addrs(rec, want_v6)
+        if ips:
+            resp.answer.append(dns.rrset.from_text(q.name, 60, "IN", rtype, *ips))
         return resp.to_wire()
 
     def _serve_udp(self) -> None:
@@ -490,7 +628,7 @@ class _StubDnsServer:
                 data, addr = self._udp.recvfrom(65535)
             except OSError:
                 continue
-            wire = self._build_response(data)
+            wire = self._build_response(data, addr[0])
             if wire is not None:
                 with contextlib.suppress(OSError):
                     self._udp.sendto(wire, addr)
@@ -499,7 +637,7 @@ class _StubDnsServer:
         self._tcp.settimeout(0.5)
         while not self._stop.is_set():
             try:
-                conn, _ = self._tcp.accept()
+                conn, peer = self._tcp.accept()
             except OSError:
                 continue
             with contextlib.suppress(Exception):
@@ -513,7 +651,7 @@ class _StubDnsServer:
                         if not chunk:
                             break
                         data += chunk
-                    wire = self._build_response(data)
+                    wire = self._build_response(data, peer[0])
                     if wire is not None:
                         conn.sendall(len(wire).to_bytes(2, "big") + wire)
             with contextlib.suppress(OSError):
@@ -526,7 +664,8 @@ class _StubDnsServer:
     def stop(self) -> None:
         self._stop.set()
         for thread in self._threads:
-            thread.join(timeout=5)
+            if thread.ident is not None:  # joinable only once started — stop() is idempotent
+                thread.join(timeout=5)
         with contextlib.suppress(OSError):
             self._udp.close()
         with contextlib.suppress(OSError):
@@ -645,6 +784,13 @@ def _dump_vm_on_failure(request: pytest.FixtureRequest) -> Iterator[None]:
     rep = getattr(request.node, "_rep_call", None)
     if rep is None or not rep.failed:
         return
+    # The mock DNS query log — what reached the upstream, READ not inferred.
+    stub = request.node.funcargs.get("stub_dns")
+    if isinstance(stub, _StubDnsServer):
+        print("\n========== STUB DNS UPSTREAM — received queries ==========")
+        for entry in stub.queries():
+            print(f"  {entry['client']:>15}  {entry['type']:<5} {entry['name']}")
+        print("========== END STUB DNS UPSTREAM ==========")
     vm = request.node.funcargs.get("deployed_vm") or request.node.funcargs.get("smoke_vm")
     if vm is None:
         return

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -39,6 +39,7 @@ so importing this module does not require the smoke deps.
 
 from __future__ import annotations
 
+import base64
 import ipaddress
 import os
 import re
@@ -328,14 +329,36 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
 # --------------------------------------------------------------------------- #
 
 
+PFB_DBDIR = "/var/db/pfblockerng"
+
+
 def write_local_feed(vm: SmokeVM, name: str, contents: str, *, timeout: float = 30.0) -> str:
     """Write ``contents`` to /var/db/pfblockerng/<name> on the guest; return the path.
 
     The file goes DIRECTLY under /var/db/pfblockerng (NOT the deny/permit/native
     subdirs — those are pfBlockerNG's own reload output). The path is then used
     as the feed source's URL field.
+
+    ``mkdir -p`` the data dir first: pfBlockerNG's POST-INSTALL does NOT create it
+    (only a reload/update does), so a case that writes its feed BEFORE its first
+    reload — e.g. the whole ABP matrix's first test — would otherwise hit
+    ``tee: …: No such file or directory``.
     """
-    path = f"/var/db/pfblockerng/{name}"
+    path = f"{PFB_DBDIR}/{name}"
+    # Ensure the data dir exists FIRST, as its own simple round-trip. Do NOT fold it
+    # into the tee with `sh -c "mkdir … && tee …"`: ssh space-joins the remote argv
+    # and the remote LOGIN shell (tcsh for pfSense root) re-parses it, so `sh -c`
+    # would capture only the first token (and tcsh chokes on the POSIX `'\''` idiom).
+    # A bare `mkdir -p <dir>` argv (no &&/redirect/nested quotes) is shell-agnostic.
+    mk = subprocess.run(
+        vm.ssh_argv("/bin/mkdir", "-p", PFB_DBDIR),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if mk.returncode != 0:
+        raise RuntimeError(f"write_local_feed({path}): mkdir {PFB_DBDIR} failed: rc={mk.returncode} {mk.stderr!r}")
     result = subprocess.run(
         vm.ssh_argv("tee", path),
         input=contents,
@@ -494,6 +517,19 @@ def _php_kv_array(data: dict[str, str]) -> str:
     return f"array({items})"
 
 
+def _b64_textarea(lines: list[str]) -> str:
+    """Base64-encode a CRLF-joined textarea value — the shape pfBlockerNG stores.
+
+    pfBlockerNG TEXTAREA settings (``suppression``, ``pfb_regex_list``, ``custom``, …)
+    are kept base64-encoded in config (the GUI base64_encodes on save) and decoded by
+    ``pfbng_text_area_decode()`` (``base64_decode`` then ``explode("\\r\\n", …)``). A
+    PLAIN value injected here would be base64_decoded into GARBAGE — invalid bytes that
+    crash the python module's INI load (``Failed to load ini configuration: 'utf-8'
+    codec can't decode byte``) and silently disable DNSBL. Encode with CRLF separators
+    so the decode splits into the right lines. Empty list -> '' (no entries)."""
+    return base64.b64encode("\r\n".join(lines).encode()).decode()
+
+
 # --------------------------------------------------------------------------- #
 # Control records — DNS-Resolver Host Overrides, set IN CONFIG before update
 # --------------------------------------------------------------------------- #
@@ -624,37 +660,52 @@ def ensure_dnsbl_vip(vm: SmokeVM, *, ip4: str = DEFAULT_DNSBL_VIP4, timeout: flo
         raise RuntimeError(f"ensure_dnsbl_vip failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
-def configure_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
-    """Put Unbound in forwarding mode pointed at the runner-side stub.
+def use_stub_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
+    """Make the runner-side stub DNS (``_StubDnsServer``) Unbound's SOLE upstream.
 
-    Maintainer's recipe: forwarding mode + a reachable upstream + DNSSEC off. If
-    Unbound cannot establish a working forward/recursion path it stalls/SERVFAILs
-    EVERY query (even a local DNSBL block or host override), which is what times
-    out the per-case probe. So force forwarding of EVERYTHING to the stub.
+    The whole matrix forwards through one CONTROLLED, observable server: every query
+    Unbound does not answer locally (block shape / host override) lands on the stub,
+    which records it (``stub.received(...)``) and answers a known sentinel. That turns
+    "was this blocked?" into a fact read off the upstream — a blocked name must never
+    reach the stub — instead of an inference from a bare SERVFAIL against a dark relay
+    (QEMU's SLIRP DNS at 10.0.2.3, which egress-block makes unreachable).
 
-    Implemented as a raw Unbound ``forward-zone: "."`` in Custom Options rather
-    than System>General DNS servers, because the stub listens on a custom port
-    and System DNS is :53-only; ``forward-tcp-upstream`` reuses the proven
-    guest->host SLIRP path (mock_feeds is TCP). DNSSEC is disabled (the stub's
-    answers are unsigned) and ``unbound/forwarding`` is enabled to match the
-    documented mode. Written to CONFIG so every ``services_unbound_configure``
-    regenerates it; pfBlockerNG's reload only appends its DNSBL python on top.
+    Wiring (once per deploy; the stub is reachable over SLIRP and survives the per-case
+    egress block):
+
+      * A custom ``forward-zone: "."`` -> ``10.0.2.2:<stub port>`` in Unbound Custom
+        Options. To make it the SOLE ``"."`` zone, pfSense forwarding mode is turned
+        OFF (``unset unbound/forwarding``) so pfSense does not ALSO emit its own
+        ``forward-zone "."`` (from the System DNS servers) — Unbound rejects a duplicate
+        (``error: duplicate forward zone . ignored``) and would keep the wrong one (the
+        breakage the ADR-04 matrix recorded). In resolver mode our custom zone is the
+        only one, and it still forwards everything.
+      * ``unset unbound/dnssec`` — the stub's answers are unsigned, so a validator would
+        mark them bogus (SERVFAIL).
+      * ``log-queries: yes`` — the resolver logs each client query too, so guest-side
+        diagnostics corroborate the stub's record.
+
+    Written to CONFIG so ``services_unbound_configure`` bakes it into unbound.conf;
+    pfBlockerNG's reload read-modifies that file in place (only the wizard regenerates
+    it), so the upstream survives every DNSBL reload.
     """
     port = vm.upstream_dns_port
     if not port:
-        raise RuntimeError("configure_upstream: vm.upstream_dns_port unset (stub_dns fixture not active)")
+        raise RuntimeError("use_stub_upstream: vm.upstream_dns_port unset (stub_dns fixture not active)")
     custom_options = (
         "server:\n"
-        "forward-tcp-upstream: yes\n"
         "do-not-query-localhost: no\n"
+        "log-queries: yes\n"
         "forward-zone:\n"
         'name: "."\n'
         f"forward-addr: {GUEST_TO_HOST_ALIAS}@{port}\n"
+        "forward-tcp-upstream: yes\n"
     )
     snippet = (
         "$u = config_get_path('unbound', array());\n"
         f"$u['custom_options'] = base64_encode({_php_str(custom_options)});\n"
-        "$u['forwarding'] = 'on';\n"
+        # Resolver mode (forwarding OFF) so our custom zone is the only 'forward-zone: \".\"'.
+        "unset($u['forwarding']);\n"
         "unset($u['dnssec']);\n"
         "config_set_path('unbound', $u);\n"
         "write_config('pfBlockerNG smoke: stub upstream');\n"
@@ -663,7 +714,9 @@ def configure_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     )
     result = php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(f"configure_upstream failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+        raise RuntimeError(f"use_stub_upstream failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+    # services_unbound_configure restarts Unbound — wait for it before any probe.
+    wait_unbound_ready(vm)
 
 
 # --------------------------------------------------------------------------- #
@@ -710,19 +763,22 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
     settings = _dnsbl_mode_settings(spec.mode)
     settings["pfb_dnsbl"] = "on"
     if spec.whitelist:
-        settings["suppression"] = "\n".join(spec.whitelist)
+        # suppression is a pfBlockerNG TEXTAREA field: config stores it base64-encoded
+        # (GUI pfblockerng_dnsbl.php:555) and pfbng_text_area_decode() base64_decodes +
+        # splits on CRLF. A PLAIN value here decodes to GARBAGE — so encode it.
+        settings["suppression"] = _b64_textarea(spec.whitelist)
     if spec.dnsbl_ip_action:
         # The "DNSBL IP" firewall feature: collect IP literals from the DNSBL
         # feed into the pfB_DNSBLIP_{v4,v6} alias tables (inc:7022 reads this
         # from CFG_DNSBL_SETTINGS/action; != 'Disabled' enables it).
         settings["action"] = spec.dnsbl_ip_action
     if spec.user_regex:
-        # The user "Python Regex List" (inc:849-850,2711). pfb_regex must be 'on'
-        # AND pfb_regex_list non-empty for the [REGEX] ini section to be written;
-        # a plain newline list mirrors the suppression textarea the matrix already
-        # uses. User regex are sovereign block patterns (band 5).
+        # The user "Python Regex List" (inc:849-850,2711). pfb_regex must be 'on' AND
+        # pfb_regex_list non-empty for the [REGEX] ini section to be written. Like
+        # suppression it is a base64 TEXTAREA field — a PLAIN value decodes to garbage
+        # and crashes the ini load. User regex are sovereign block patterns (band 5).
         settings["pfb_regex"] = "on"
-        settings["pfb_regex_list"] = "\n".join(spec.user_regex)
+        settings["pfb_regex_list"] = _b64_textarea(spec.user_regex)
     if spec.regex_cap:
         # Opt-in static cap (inc:2685 -> ini regex_cap=on). Drops over-cap feed AND
         # user regex at load (pfb_unbound.py:_regex_exceeds_static_cap).
@@ -1045,6 +1101,21 @@ def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 30, delay: float = 2.0) -
             return
         time.sleep(delay)
     raise RuntimeError("Unbound did not become ready after reload")
+
+
+def flush_unbound_cache(vm: SmokeVM, *, timeout: float = 30.0) -> None:
+    """Flush Unbound's whole cache so the NEXT probe is evaluated FRESH by the module.
+
+    Unbound answers a message-cache HIT directly, AHEAD of the pfBlockerNG python
+    module — so a name cached as a side effect of an earlier query is served from
+    cache and skips the DNSBL block check. This bites the CNAME case: resolving the
+    SOURCE (A→CNAME→B) caches B's chained A record, so a later DIRECT query for B is
+    served that cached value instead of being blocked. Flush between such probes to
+    keep each one independent. (``flush_zone .`` drops every cached name.)
+    """
+    result = vm.ssh("/usr/local/sbin/unbound-control", "-c", UNBOUND_CONF, "flush_zone", ".", timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(f"flush_unbound_cache failed: rc={result.returncode} {result.stderr!r}")
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -77,13 +77,16 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     """Deploy the branch .pkg once for the ABP matrix (mirrors the ADR-04 matrix).
 
     Egress is managed per-case by ``CaseContext``; the DNSBL VIP is injected once
-    (DNSBL force-disables itself without one). A full guest snapshot is collected on
-    teardown for the workflow to upload.
+    (DNSBL force-disables itself without one). The runner-side stub DNS is wired as
+    Unbound's sole upstream (``use_stub_upstream``) so a not-blocked name resolves to
+    a known sentinel AND is recorded on the stub. A full guest snapshot is collected
+    on teardown for the workflow to upload.
     """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
+    h.use_stub_upstream(smoke_vm)
     try:
         yield smoke_vm
     finally:
@@ -378,44 +381,94 @@ def test_custom_list_block_beats_feed_important_allow(deployed_vm: SmokeVM, mock
 # --------------------------------------------------------------------------- #
 
 
-def test_cname_validation_on_off(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_cname_validation_on_off(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer, stub_dns: _StubDnsServer) -> None:
     """A→CNAME→B with B blocklisted: A blocks IFF CNAME validation is ON; B always blocks.
 
-    DEFERRED (documented). The decision logic is fully covered by the runnable unit
-    tests (`tests/test_pfb_unbound.py::TestOperateDnsbl::test_cname_*` — enabled blocks
-    A, disabled does not, B blocks when queried directly). What this live test would
-    add is proof that a REAL Unbound populates ``qstate.return_msg.rep`` with the CNAME
-    chain the module walks. It is deferred because the harness cannot yet put a
-    CONTROLLED CNAME chain on the box hermetically:
+    Proves a REAL Unbound populates ``qstate.return_msg.rep`` with the CNAME chain
+    ``pfb_unbound.py``'s validation walk reads (``an_numrrsets > 1``, the CNAME rrset
+    carrying the blocked target) — the one thing the pure unit oracle
+    (`tests/test_pfb_unbound.py::TestOperateDnsbl::test_cname_*`) cannot, since it
+    hand-builds that ``return_msg``.
 
-      * The CNAME chain must come from the resolver's answer. A pfSense Host Override
-        (the harness's `set_control_records`) only expresses A/AAAA, never a CNAME.
-      * Pointing Unbound at the runner stub (`configure_upstream`) + extending
-        `_StubDnsServer` to answer ``A → CNAME B`` + ``B → sentinel`` is the natural
-        path — but the matrix records that `configure_upstream`'s extra
-        ``forward-zone "."`` *broke Unbound* on the baked image, and a raw `local-data`
-        CNAME in Custom Options is *not re-applied* across the pfBlockerNG reload. Both
-        need harness work to make a controlled CNAME chain survive a DNSBL reload.
+    Controlled-chain delivery (issue #41). The chain MUST come from the resolver's
+    answer, and a pfSense Host Override only expresses A/AAAA — never a CNAME. A raw
+    Unbound ``local-data`` CNAME does NOT work either: Unbound returns the bare CNAME
+    without chasing it (a single rrset, so ``an_numrrsets`` stays 1 and the walk never
+    runs). So the stub — already Unbound's sole upstream (``use_stub_upstream``) —
+    crafts the 2-rrset chain: ``stub_dns.register_cname(A, B)`` answers a forwarded
+    query for A with ``A CNAME B`` + ``B A <sentinel>``, which Unbound forwards whole.
 
-    INTENDED matrix once a controlled CNAME chain exists (B = `unique_domain('cnametgt')`
-    on the DNSBL list; A = `unique_domain('cnamesrc')` resolving CNAME→B via the stub):
+    Only A's fate differs between the runs; B (= `unique_domain('cnametgt')`, a plain
+    exact-match feed entry) is listed in both — the invariant:
 
-      * ``cname_validation=False`` (default): probe A → RESOLVES (sentinel) — the chain
-        is not walked; probe B → VIP (B is listed).
-      * ``cname_validation=True``: probe A → VIP (blocked via its CNAME target, b_type
-        '_CNAME'); probe B → VIP. The ONLY delta between the two runs is A's fate — B
-        is listed in both (the invariant).
+      * ``cname_validation=False`` (default): probe A → RESOLVES to the stub sentinel
+        (the chain is not walked, so A is forwarded — and recorded on the stub);
+        probe B → VIP (and B never reaches the stub).
+      * ``cname_validation=True``: probe A → VIP (blocked via its CNAME target,
+        re-attributed to A with b_type ``DNSBL_CNAME``); probe B → VIP.
 
-    The `DnsblCase.cname_validation` toggle (-> `pfb_cname`/ini `python_cname`) is wired
-    and unit-pinned (`test_smoke_helpers.py`); only the stub-CNAME + upstream plumbing
-    remains. Tracked: https://github.com/andrebrait/pfBlockerNG/issues/41
+    The chase of B during A's resolution does NOT independently block A — pfBlockerNG's
+    module only inspects the resolved chain at MODDONE, and only when CNAME validation
+    is on; that opt-in is the whole point of the feature (else OFF could never resolve A).
     """
-    pytest.skip(
-        "needs a controlled CNAME chain on the box (stub-CNAME + upstream); "
-        "configure_upstream conflicts on the baked image, custom-options local-data is "
-        "not re-applied across the DNSBL reload — decision logic covered by the unit "
-        "tests test_pfb_unbound.py::TestOperateDnsbl::test_cname_* (un-skip: #41)"
-    )
+    src = h.unique_domain("cnamesrc")  # A — resolves CNAME→B via the stub
+    tgt = h.unique_domain("cnametgt")  # B — the blocklisted CNAME target
+    tgt_ip = "198.51.100.42"  # B's OWN address (distinct from VIP / control / sentinel)
+    # The stub (Unbound's upstream) gives B its own A, and answers A with the chain
+    # A→CNAME→B (+ B's A). So A resolves to B's exact address — known, not a generic
+    # sentinel. B is blocked by the DNSBL python before any forward, so a DIRECT query
+    # for B never reaches the stub.
+    stub_dns.register_a(tgt, tgt_ip)
+    stub_dns.register_cname(src, tgt)
+    feed_url = h.write_local_feed(deployed_vm, "smoke_cname.txt", f"{tgt}\n")
+    try:
+        # --- CNAME validation OFF (default): chain not walked → A resolves. ---
+        spec_off = h.DnsblCase(
+            aliasname="smokecnameoff",
+            feed_url=feed_url,
+            header="smokecnameoff",
+            mode=h.DnsblMode.VIP,
+            cname_validation=False,
+        )
+        with h.CaseContext(deployed_vm, spec_off):
+            stub_dns.reset_queries()
+            ans_src = h.dns_probe(deployed_vm, src, "A")
+            assert h.resolves_to(ans_src, tgt_ip), (
+                f"CNAME validation OFF: {src} should resolve to its CNAME target's address {tgt_ip}, got {ans_src}"
+            )
+            assert not h.is_vip(ans_src), f"CNAME validation OFF: {src} wrongly VIP-blocked: {ans_src}"
+            # Upstream-side proof (no inference): A WAS forwarded (not blocked locally).
+            assert stub_dns.received(src), f"{src} should have been forwarded to the stub upstream"
+            # The DIRECT B query is blocked BEFORE any forward. FLUSH first: resolving A
+            # above cached B's chained A record, and Unbound serves a cache hit ahead of
+            # the python module — without the flush B is served the cached sentinel.
+            # Reset the stub log too, so received(B) reflects only this direct query.
+            h.flush_unbound_cache(deployed_vm)
+            stub_dns.reset_queries()
+            ans_tgt = h.dns_probe(deployed_vm, tgt, "A")
+            assert h.is_vip(ans_tgt), f"listed target {tgt} expected VIP block (validation OFF), got {ans_tgt}"
+            assert not stub_dns.received(tgt), f"blocked {tgt} must NOT reach the upstream: {stub_dns.received(tgt)}"
+
+        # --- CNAME validation ON: chain walked → A blocked via its target. ---
+        spec_on = h.DnsblCase(
+            aliasname="smokecnameon",
+            feed_url=feed_url,
+            header="smokecnameon",
+            mode=h.DnsblMode.VIP,
+            cname_validation=True,
+        )
+        with h.CaseContext(deployed_vm, spec_on):
+            h.flush_unbound_cache(deployed_vm)
+            ans_src = h.dns_probe(deployed_vm, src, "A")
+            assert h.is_vip(ans_src), (
+                f"CNAME validation ON: {src} must be VIP-blocked via its CNAME target {tgt}, got {ans_src}"
+            )
+            # Flush so the direct B probe is evaluated fresh (not served A's cached chain).
+            h.flush_unbound_cache(deployed_vm)
+            ans_tgt = h.dns_probe(deployed_vm, tgt, "A")
+            assert h.is_vip(ans_tgt), f"listed target {tgt} expected VIP block (validation ON), got {ans_tgt}"
+    finally:
+        stub_dns.clear_cname()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -23,17 +23,18 @@ import os
 import pytest
 
 from . import helpers as h
-from .conftest import SmokeVM, expected_control_answer
+from .conftest import STUB_DNS_A, SmokeVM, _StubDnsServer, expected_control_answer
 
 pytestmark = pytest.mark.smoke
 
 
 @pytest.fixture(scope="module")
-def deployed_vm(smoke_vm: SmokeVM) -> SmokeVM:
-    """Deploy the branch .pkg once for the helper self-tests."""
+def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> SmokeVM:
+    """Deploy the branch .pkg once for the helper self-tests; wire the stub upstream."""
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
+    h.use_stub_upstream(smoke_vm)
     return smoke_vm
 
 
@@ -130,17 +131,19 @@ def test_false_green_guard() -> None:
     assert not h.is_nxdomain(real_pass)
 
 
-def test_dns_probe_nxdomain_shape(deployed_vm: SmokeVM) -> None:
-    """A name with no local-data and egress blocked is NOT a false A answer.
+def test_dns_probe_absent_resolves_via_stub(deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+    """An otherwise-unknown name resolves to the STUB SENTINEL and is recorded upstream.
 
-    Probes a guaranteed-absent name: it must NOT return a spurious A record
-    (would indicate a leaking upstream / wrong probe), proving the probe reads
-    the real resolver state.
+    With the stub as Unbound's sole upstream, a name with no local-data / block is
+    forwarded and answered by a server WE control — it returns the sentinel (never a
+    leaked real-internet A) and logs the query. This pins the upstream wiring: the
+    probe reads real resolver state, and "forwarded vs answered locally" is observable.
     """
-    answer = h.dns_probe(deployed_vm, h.unique_domain("definitely-absent"), "A")
-    assert not answer.records or answer.rcode != "NOERROR", (
-        f"absent name returned records {answer.records} rcode {answer.rcode}"
-    )
+    name = h.unique_domain("definitely-absent")
+    stub_dns.reset_queries()
+    answer = h.dns_probe(deployed_vm, name, "A")
+    assert h.resolves_to(answer, STUB_DNS_A), f"absent name should resolve to the stub sentinel, got {answer}"
+    assert stub_dns.received(name), f"{name} should have been forwarded to the stub upstream"
 
 
 # --------------------------------------------------------------------------- #
@@ -180,20 +183,27 @@ def test_abp_feed_body_has_header_and_lines() -> None:
 
 
 def test_abp_inject_snippet_emits_user_regex_and_cap() -> None:
-    """A DnsblCase carrying user_regex + regex_cap renders the matching config keys."""
+    """A DnsblCase carrying user_regex + regex_cap renders the matching config keys.
+
+    pfb_regex_list is a base64 TEXTAREA field (CRLF-joined) — a PLAIN value would be
+    base64_decoded into garbage that crashes the python INI load — so the snippet must
+    carry the base64 of the CRLF-joined patterns, NOT the raw regex text.
+    """
+    patterns = [r"ad[0-9]+\.example\.net", r"(a+)+\.evil\.example"]
     spec = h.DnsblCase(
         aliasname="smokeabp",
         feed_url="/var/db/pfblockerng/smokeabp.txt",
         header="smokeabp",
-        user_regex=[r"ad[0-9]+\.example\.net", r"(a+)+\.evil\.example"],
+        user_regex=patterns,
         regex_cap=True,
     )
     snippet = h._dnsbl_inject_snippet(spec)
     assert "'pfb_regex' => 'on'" in snippet
     assert "'pfb_regex_cap' => 'on'" in snippet
-    assert "'pfb_regex_list' =>" in snippet
-    # Both user patterns ride along in the newline-joined list value.
-    assert r"ad[0-9]+\\.example\\.net" in snippet or r"ad[0-9]+\.example\.net" in snippet
+    expected_b64 = h._b64_textarea(patterns)
+    assert f"'pfb_regex_list' => '{expected_b64}'" in snippet
+    # Raw regex text must NOT appear (it is base64-encoded, not plain).
+    assert "ad[0-9]+" not in snippet
 
 
 def test_abp_inject_snippet_emits_extra_rows() -> None:
@@ -251,3 +261,145 @@ def test_abp_inject_snippet_emits_custom_list() -> None:
     assert "$list['custom'] = base64_encode(" in snippet
     # The domains ride along CRLF-joined inside the base64-encoded literal.
     assert "evil.example.com" in snippet
+
+
+# --------------------------------------------------------------------------- #
+# 7) Stub CNAME chain (issue #41) — PURE, no VM
+#    Pin the stub's CNAME-chain answer so a regression goes RED without a booted
+#    VM: a registered name must answer with a 2-rrset chain (CNAME + the target's
+#    sentinel) so a forwarding Unbound surfaces an_numrrsets > 1; an UNregistered
+#    name still gets the plain single-rrset sentinel.
+# --------------------------------------------------------------------------- #
+
+
+def _stub_answer(server: _StubDnsServer, name: str, rtype: str) -> object:
+    """Build a wire query for (name, rtype), feed it to the stub, parse the reply."""
+    import dns.message
+    import dns.rdatatype
+
+    query = dns.message.make_query(name, dns.rdatatype.from_text(rtype))
+    wire = server._build_response(query.to_wire())
+    assert wire is not None
+    return dns.message.from_wire(wire)
+
+
+def test_stub_cname_chain_is_two_rrsets_and_consistent() -> None:
+    """A CNAME chain answers ``src CNAME tgt`` + the TARGET's own A/AAAA (2 rrsets).
+
+    That 2-rrset answer is what makes a forwarding Unbound expose ``an_numrrsets > 1``
+    to pfb_unbound.py's CNAME walk (a raw Unbound ``local-data`` CNAME would yield a
+    single rrset — Unbound does not chase it). And it must be CONSISTENT: the A query
+    chains to the target's IPv4, the AAAA query to the target's IPv6 — the target's
+    OWN registered addresses, not a generic sentinel.
+    """
+    import dns.rdatatype
+
+    src, tgt = h.unique_domain("stubsrc"), h.unique_domain("stubtgt")
+    server = _StubDnsServer()
+    try:
+        server.set_records(tgt, a=("198.51.100.5",), aaaa=("2001:db8::5",))
+        server.register_cname(src, tgt)
+
+        reply = _stub_answer(server, src, "A")
+        assert [rr.rdtype for rr in reply.answer] == [dns.rdatatype.CNAME, dns.rdatatype.A]  # type: ignore[attr-defined]
+        cname_rr, a_rr = reply.answer  # type: ignore[attr-defined]
+        assert cname_rr[0].target.to_text().lower() == f"{tgt}."
+        assert a_rr.name.to_text().lower() == f"{tgt}."
+        assert a_rr[0].address == "198.51.100.5"
+
+        reply6 = _stub_answer(server, src, "AAAA")
+        assert [rr.rdtype for rr in reply6.answer] == [dns.rdatatype.CNAME, dns.rdatatype.AAAA]  # type: ignore[attr-defined]
+        assert reply6.answer[1][0].address == "2001:db8::5"  # type: ignore[attr-defined]
+    finally:
+        server.stop()
+
+
+def test_stub_unregistered_name_is_plain_sentinel() -> None:
+    """An UNregistered name (and a cleared registration) gets the single-rrset sentinel."""
+    import dns.rdatatype
+
+    src, tgt = h.unique_domain("stubsrc"), h.unique_domain("stubtgt")
+    server = _StubDnsServer()
+    try:
+        server.register_cname(src, tgt)
+        server.clear_cname()
+        reply = _stub_answer(server, src, "A")
+        assert [rr.rdtype for rr in reply.answer] == [dns.rdatatype.A]  # type: ignore[attr-defined]
+        assert reply.answer[0][0].address == STUB_DNS_A  # type: ignore[attr-defined]
+    finally:
+        server.stop()
+
+
+def test_stub_records_queries() -> None:
+    """The stub records every query it answers — the observability the matrix asserts on.
+
+    ``received(name)`` is the upstream-side signal that a name was FORWARDED (not blocked
+    locally); a name the stub never saw returns an empty list. ``reset_queries`` clears it.
+    """
+    seen, never = h.unique_domain("stubseen"), h.unique_domain("stubnever")
+    server = _StubDnsServer()
+    try:
+        _stub_answer(server, seen, "A")
+        assert server.received(seen), "answered query must be recorded"
+        assert server.received(seen, "A")
+        assert not server.received(never), "a name the stub never saw must be absent"
+        server.reset_queries()
+        assert not server.received(seen), "reset_queries clears the log"
+    finally:
+        server.stop()
+
+
+def test_stub_register_a_and_nxdomain() -> None:
+    """register_a overrides the sentinel; register_nxdomain denies the name."""
+    import dns.rcode
+
+    pinned, gone = h.unique_domain("stubpinned"), h.unique_domain("stubgone")
+    server = _StubDnsServer()
+    try:
+        server.register_a(pinned, "192.0.2.7")
+        reply = _stub_answer(server, pinned, "A")
+        assert reply.answer[0][0].address == "192.0.2.7"  # type: ignore[attr-defined]
+        server.register_nxdomain(gone)
+        reply = _stub_answer(server, gone, "A")
+        assert reply.rcode() == dns.rcode.NXDOMAIN  # type: ignore[attr-defined]
+        assert not reply.answer  # type: ignore[attr-defined]
+    finally:
+        server.stop()
+
+
+def test_stub_set_records_families_multi_and_nodata() -> None:
+    """set_records gives a name its own A/AAAA: multiple IPs, missing family -> NODATA,
+    and wrong-family addresses are rejected."""
+    import dns.rcode
+
+    multi, v4only, bad = h.unique_domain("stubmulti"), h.unique_domain("stubv4"), h.unique_domain("stubbad")
+    server = _StubDnsServer()
+    try:
+        # Multiple A, one AAAA.
+        server.set_records(multi, a=("203.0.113.1", "203.0.113.2"), aaaa=("2001:db8::1",))
+        a_reply = _stub_answer(server, multi, "A")
+        assert {r.address for r in a_reply.answer[0]} == {"203.0.113.1", "203.0.113.2"}  # type: ignore[attr-defined]
+        aaaa_reply = _stub_answer(server, multi, "AAAA")
+        assert aaaa_reply.answer[0][0].address == "2001:db8::1"  # type: ignore[attr-defined]
+
+        # A only -> AAAA is NODATA (empty NOERROR), not the sentinel.
+        server.set_records(v4only, a=("203.0.113.9",))
+        no6 = _stub_answer(server, v4only, "AAAA")
+        assert no6.rcode() == dns.rcode.NOERROR and not no6.answer  # type: ignore[attr-defined]
+
+        # Family is validated.
+        with pytest.raises(ValueError):
+            server.set_records(bad, a=("2001:db8::bad",))  # IPv6 in an A
+    finally:
+        server.stop()
+
+
+def test_b64_textarea_matches_pfblockerng_decode() -> None:
+    """``_b64_textarea`` produces what ``pfbng_text_area_decode`` expects: base64 of a
+    CRLF-joined list (so base64_decode + explode("\\r\\n") returns the lines back)."""
+    import base64
+
+    lines = [r"trackerx-", r"ad[0-9]+\.example\.net"]
+    encoded = h._b64_textarea(lines)
+    assert base64.b64decode(encoded).decode().split("\r\n") == lines
+    assert h._b64_textarea([]) == "", "empty list -> empty value (no entries)"

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -78,9 +78,10 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     DNS probe. The probe stays hermetic because every name the matrix asserts
     resolves LOCALLY — a blocked name is intercepted by the python module before
     the forwarder, and a control/whitelist name answers from its injected host
-    override — so the probe never needs upstream egress. (``configure_upstream``
-    is intentionally NOT called: the baked image already forwards on its own;
-    injecting a second ``forward-zone "."`` broke Unbound.) deploy() needs no
+    override — so the probe never needs the real internet. A not-blocked,
+    no-control name resolves via the runner-side stub (``use_stub_upstream``), the
+    sole controlled upstream — a known sentinel, AND recorded, so "was it blocked?"
+    is read off the upstream, not inferred from a SERVFAIL. deploy() needs no
     egress for dependencies either — the pre-baked image ships pfBlockerNG's
     RUN_DEPENDS, so ``pkg add`` resolves them from the local pkg db offline.
     unblock on teardown as a safety net.
@@ -97,6 +98,10 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     # sinkhole VIP once for the matrix. dns_probe queries on-box (drill
     # @127.0.0.1) — no localhost exemption — so no WAN/ACL plumbing is needed.
     h.ensure_dnsbl_vip(smoke_vm)
+    # Point Unbound's sole upstream at the controlled stub BEFORE any per-test
+    # unbound-config snapshot (test_dnsbl_unbound_config_immutable), so the stub
+    # forward-zone is part of the baseline and the DNSBL reload still adds only python.
+    h.use_stub_upstream(smoke_vm)
     h.snap_state(smoke_vm, "vip")
     try:
         yield smoke_vm


### PR DESCRIPTION
## Un-skip the CNAME-validation live smoke + a controlled mock DNS upstream (#41)

Un-skips `tests/smoke/test_smoke_abp.py::test_cname_validation_on_off`. Verified
**GREEN on the live pfSense VM smoke** (`38 passed, 3 skipped, 1 xfailed`) — this is
also the **first green run of the ADR-07 ABP matrix**, which had never run on a box
before and surfaced two real harness bugs (below).

### Controlled, observable mock DNS upstream

`_StubDnsServer` is now Unbound's **sole** upstream (`helpers.use_stub_upstream`: lone
`forward-zone "."` → `10.0.2.2:<port>`; forwarding mode off so pfSense doesn't emit a
duplicate `"."` zone Unbound rejects; dnssec off for the unsigned mock; `log-queries`
on). It is a real per-domain DNS mock:

- `set_records(name, a=…, aaaa=…)` — each name gets its **own** A (IPv4) / AAAA (IPv6),
  one or many; omit a family for NODATA; families are validated. `register_cname`
  resolves the chain **consistently** to the target's own A/AAAA. `register_nxdomain`
  denies. So a probe asserts **exact IPs** and knows which name resolved to what.
- **Every query is recorded** (`received()` / `queries()`, dumped on failure): "was
  this name blocked?" is now **read off the upstream** — a blocked name must never
  reach the mock — instead of inferred from a SERVFAIL against the dark SLIRP relay
  (`10.0.2.3`). The CNAME case asserts exactly that (A forwarded → B's IP; blocked B
  never forwarded).

Why our own mock, not dnsmasq: exact wire control + an in-process query log that's more
reliable than parsing a daemon logfile, and no runner dependency. Wiring note: System
DNS would be the "realistic" path but is `:53`-only while the mock is on an ephemeral
port; the `forward-zone "."` routes all queries to the mock identically.

### Why the stub, not `local-data`

Verified against a real Unbound: it **never chases a `local-data` CNAME** (returns the
bare CNAME — one rrset), so `an_numrrsets` stays 1 and the validation walk never runs.
The mock crafts the 2-rrset chain and Unbound forwards it whole.

### Two pre-existing harness bugs the first live run exposed

- **base64 textarea injection** (the actual cascade): `suppression` and `pfb_regex_list`
  are stored base64-encoded (GUI `base64_encode`s; `pfbng_text_area_decode` decodes).
  The harness injected them **plain**, so `base64_decode` produced invalid bytes that
  crashed the python INI load (`py_error.log`: `'utf-8' codec can't decode byte 0xb6`),
  silently disabling DNSBL for that and every later reload. `_b64_textarea()` now encodes
  them CRLF-joined.
- **`write_local_feed`** now `mkdir -p`s `/var/db/pfblockerng` — POST-INSTALL doesn't
  create it, and the ABP module writes a feed before its first reload.

### Cache caveat → relates to #43

Unbound answers a **message-cache hit ahead of the python module**, so resolving A
(`A→CNAME→B`) caches B's address and a later **direct** B query would skip the block.
`flush_unbound_cache()` between probes works around it in the test; the proper fix
(`no_cache_store` on block responses) is **#43** (DNSBL report under-counts cached
blocks — same root). The mock's "did it hit upstream?" signal is the hook to test that
fix. #35 (DNSBL-IP dual-stack) is unrelated (async pf-table polling).

### Verification

Live smoke green (above). Mechanics also checked locally against a real Unbound
(forward-mode passes the 2-rrset chain; chain resolves to the target's exact registered
IP; name-specific A/AAAA, multiple IPs, NODATA, query recording). Repo gates green
(ruff, `mypy tests/`, 985 pytest, smoke pure-test subset, full pre-commit hook). Decision
logic stays pinned by `tests/test_pfb_unbound.py::TestOperateDnsbl`.

Closes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced DNS upstream stub server with configurable per-name behavior, CNAME forwarding, and detailed query logging for improved test reliability.
  * Expanded test coverage for DNS query handling, CNAME validation, and Unbound cache management.
  * Strengthened ABP helper validation with base64 encoding verification for injection configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->