### PR TITLE
smoke: cover the HSTS VIP→null block override in the ADR-04 matrix

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -241,6 +241,13 @@ class DnsblCase:
     # to the queried name, b_type '_CNAME'). Off (default): only the queried name is
     # checked, so a name whose CNAME target is blocked still resolves.
     cname_validation: bool = False
+    # hsts -> the "HSTS via Null Block mode" toggle (CFG_DNSBL_SETTINGS/pfb_hsts,
+    # inc:847 -> ini python_hsts). When on, pfb_unbound.py loads pfb_py_hsts.txt into
+    # hstsDB; a VIP-mode (logging='enabled', log_type '1') block on an HSTS-preload
+    # name keeps null_blocking=True -> NULL instead of the VIP (evaluate_domain:
+    # ``log_type == '1' and not in_hsts``). ``None`` (default) emits nothing -> the
+    # existing matrix is byte-for-byte unchanged; True/False forces pfb_hsts on/off.
+    hsts: bool | None = None
 
     @property
     def alias(self) -> str:
@@ -340,6 +347,56 @@ def write_local_feed(vm: SmokeVM, name: str, contents: str, *, timeout: float = 
     if result.returncode != 0:
         raise RuntimeError(f"write_local_feed({path}) failed: rc={result.returncode} {result.stderr!r}")
     return path
+
+
+# --------------------------------------------------------------------------- #
+# HSTS preload set — pin a name into the in-chroot list pfb_unbound.py reads
+# --------------------------------------------------------------------------- #
+# pfb_unbound.py loads /var/unbound/pfb_py_hsts.txt (chroot-relative
+# ``pfb_py_hsts.txt``, init line ~752) into hstsDB on every reload. pfBlockerNG
+# copies the shipped list into the chroot ONLY when it is missing
+# (inc:2238 ``if (!file_exists(...))``), so a name appended here SURVIVES a DNSBL
+# reload — letting a test put an arbitrary domain into the EFFECTIVE HSTS set
+# instead of coupling to whatever the shipped preload list happens to contain.
+
+UNBOUND_HSTS_FILE = "/var/unbound/pfb_py_hsts.txt"
+UNBOUND_PFB_INI = "/var/unbound/pfb_unbound.ini"
+
+
+def add_hsts_name(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> None:
+    """Append ``name`` (one line) to the in-chroot HSTS preload list.
+
+    Use AFTER the case's first reload has (re)created ``pfb_py_hsts.txt`` from the
+    shipped list, then reload again so the module re-reads hstsDB with ``name``
+    included (copy-if-missing won't clobber the now-existing file). ``tee -a``
+    appends and creates the file if absent (mirrors :func:`write_local_feed`).
+    """
+    result = subprocess.run(
+        vm.ssh_argv("tee", "-a", UNBOUND_HSTS_FILE),
+        input=f"{name}\n",
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"add_hsts_name({name}) failed: rc={result.returncode} {result.stderr!r}")
+
+
+def assert_hsts_loaded(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> None:
+    """Precondition guard: ``name`` is in the effective HSTS set the module loads.
+
+    Confirms BOTH halves of the load path so a failed end-to-end assertion can be
+    attributed to the HSTS branch and not to a load miss: ``name`` is an exact line
+    in ``pfb_py_hsts.txt`` (the file the chrooted module reads), AND ``python_hsts``
+    is ``on`` in the generated ini (else pfb_unbound.py never opens the file).
+    """
+    in_file = vm.ssh("grep", "-Fxq", name, UNBOUND_HSTS_FILE, timeout=timeout)
+    if in_file.returncode != 0:
+        raise AssertionError(f"{name} not a line in {UNBOUND_HSTS_FILE} (rc={in_file.returncode})")
+    ini = vm.ssh("cat", UNBOUND_PFB_INI, timeout=timeout)
+    if not re.search(r"(?im)^\s*python_hsts\s*=\s*on\b", ini.stdout):
+        raise AssertionError(f"python_hsts not 'on' in {UNBOUND_PFB_INI}:\n{ini.stdout}")
 
 
 # --------------------------------------------------------------------------- #
@@ -674,6 +731,12 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         # "CNAME Validation" (inc:852 -> ini python_cname). Walk a resolved answer's
         # CNAME chain and block the original name if a target is blocklisted.
         settings["pfb_cname"] = "on"
+    if spec.hsts is not None:
+        # "HSTS via Null Block mode" (inc:847 -> ini python_hsts). On: a VIP-mode
+        # block on an HSTS-preload name is forced to NULL (pfb_unbound.py loads
+        # pfb_py_hsts.txt -> hstsDB). Only emitted when the case sets it explicitly,
+        # so the default matrix stays byte-for-byte unchanged. See add_hsts_name.
+        settings["pfb_hsts"] = "on" if spec.hsts else "off"
     # The primary feed row + any ABP extra rows, all in ONE DNSBL list group. Each
     # row is downloaded + header-sniffed independently (inc:7934), so an ABP body
     # per row yields one ABP feed per row whose rules the Python build merges.

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -1,7 +1,10 @@
 """ADR-04 Phase 5 — the first landed smoke matrix (a THIN vertical slice).
 
-This is NOT the broad knob space (SafeSearch/regex/HSTS/TLD/GeoIP/full-AAAA are
-out of scope, ADR §2). It is the minimum that proves the Phase-4 harness asserts
+This is NOT the broad knob space (SafeSearch/TLD/GeoIP/full-AAAA are out of scope,
+ADR §2). The one knob added beyond the original thin slice is the **HSTS VIP→null
+override** (``test_dnsbl_hsts_*``): an HSTS-preload name on a VIP-mode list blocks
+NULL, not the VIP — a load-bearing default branch (``pfb_hsts``) the rest of the
+matrix deliberately avoids. It is the minimum that proves the Phase-4 harness asserts
 REAL pfBlockerNG behaviour end-to-end on BOTH paths — the IP path (``pfctl``
 alias table + rule) and the DNS path (``dig`` rcode/record shape) — hermetically
 (mock feeds + baked Unbound ``local-data`` only) and guarded against false-green.
@@ -220,6 +223,78 @@ def test_dnsbl_exact_null(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> 
         assert h.is_null_ip(aaaa, null_ip="::0") or not aaaa.records, (
             f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
         )
+
+
+def test_dnsbl_hsts_override_forces_null(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """HSTS override: a VIP-mode block on an HSTS-preload name is forced to NULL.
+
+    The load-bearing branch the rest of the matrix deliberately avoids. For a
+    ``logging='enabled'`` (VIP, ``log_type == '1'``) list, ``evaluate_domain``
+    sets ``null_blocking=False`` (→ VIP) ONLY when the name is NOT in HSTS; an
+    HSTS-preload name keeps ``null_blocking=True`` → NULL (``0.0.0.0`` / ``::0``).
+    HSTS is on by default (``pfb_hsts`` → ini ``python_hsts``); we set it
+    explicitly. Rationale: a browser refuses the plaintext VIP sinkhole for an
+    HSTS host, so NULL is the correct block.
+
+    Self-contained: we pin a unique ``.com`` into the in-chroot HSTS set
+    (``add_hsts_name``) rather than depend on the shipped preload list. The case's
+    first reload (in ``CaseContext``) recreates ``pfb_py_hsts.txt`` from the shipped
+    list; we then append our name and reload again — copy-if-missing leaves the now-
+    existing file alone, so the module reloads hstsDB WITH our name. Paired with
+    ``test_dnsbl_hsts_disabled_keeps_vip`` (same name, same VIP list, HSTS off →
+    VIP) to prove this is the override, not an always-null path.
+    """
+    domain = h.unique_domain("hstsnull")
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_hsts.txt", f"{domain}\n")
+    spec = h.DnsblCase(
+        aliasname="smokehsts",
+        feed_url=feed_url,
+        header="smokehsts",
+        mode=h.DnsblMode.VIP,  # logging='enabled' → would be VIP UNLESS HSTS forces NULL
+        hsts=True,  # pfb_hsts on — the override under test
+    )
+    with h.CaseContext(deployed_vm, spec):
+        # hstsDB after enter = shipped list (no our name). Pin it, reload so the
+        # module re-reads, and confirm it is in the effective set before probing.
+        h.add_hsts_name(deployed_vm, domain)
+        h.reload(deployed_vm, "updatednsbl")
+        h.assert_hsts_loaded(deployed_vm, domain)
+        a = h.dns_probe(deployed_vm, domain, "A")
+        assert h.is_null_ip(a), f"HSTS override should force A=0.0.0.0, got {a} (VIP leak?)"
+        assert not h.is_vip(a), f"HSTS-preload VIP-list block must NOT be the VIP {h.DEFAULT_DNSBL_VIP4}: {a}"
+        aaaa = h.dns_probe(deployed_vm, domain, "AAAA")
+        assert h.is_null_ip(aaaa, null_ip="::0") or not aaaa.records, (
+            f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
+        )
+
+
+def test_dnsbl_hsts_disabled_keeps_vip(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """Non-tautology guard: the SAME VIP-list HSTS-listed name, HSTS OFF → VIP.
+
+    With ``pfb_hsts`` off → ini ``python_hsts=off``, pfb_unbound.py never loads
+    hstsDB (``cfg["hstsDB"]`` False), so ``in_hsts`` stays False and the
+    ``logging='enabled'`` (VIP) list yields the VIP even for a name we pinned into
+    ``pfb_py_hsts.txt``. The name IS added to the HSTS file (then ignored) so the
+    ONLY difference from ``test_dnsbl_hsts_override_forces_null`` is the toggle —
+    proving that test exercises the HSTS branch, not an always-null path.
+    """
+    domain = h.unique_domain("hstsvip")
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_hstsoff.txt", f"{domain}\n")
+    spec = h.DnsblCase(
+        aliasname="smokehstsoff",
+        feed_url=feed_url,
+        header="smokehstsoff",
+        mode=h.DnsblMode.VIP,
+        hsts=False,  # pfb_hsts off → HSTS branch disabled
+    )
+    with h.CaseContext(deployed_vm, spec):
+        # Pin the name into the HSTS file too — with HSTS off it is IGNORED, so the
+        # only delta vs the positive case is pfb_hsts.
+        h.add_hsts_name(deployed_vm, domain)
+        h.reload(deployed_vm, "updatednsbl")
+        blocked = h.dns_probe(deployed_vm, domain, "A")
+        assert h.is_vip(blocked), f"HSTS off: VIP-list block should be the VIP {h.DEFAULT_DNSBL_VIP4}, got {blocked}"
+        assert not h.is_null_ip(blocked), f"HSTS off must NOT force NULL: {blocked}"
 
 
 def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:


### PR DESCRIPTION
## Summary

Fixes #34. Adds end-to-end smoke coverage for the **HSTS VIP→null block override** in the ADR-04 live-VM matrix.

The matrix verified the two per-list block shapes — **VIP** (`logging='enabled'`) and **null** (`logging='disabled'`) — but never the HSTS override: a domain on a *VIP-mode* list that is also HSTS-preload must be blocked with **null** (`0.0.0.0` / `::0`), not the VIP. That branch is on by default (`pfb_hsts` → ini `python_hsts`) and is load-bearing:

```python
# pfb_unbound.py::evaluate_domain
if is_found and not in_whitelist:
    if cfg["hstsDB"]:
        in_hsts, p_type = hsts_check_domain(q_name, hsts_db, cfg["hsts_tlds"], tld)
    if log_type == "1" and not in_hsts:   # VIP list ...
        null_blocking = False             # ... but NOT if HSTS → stays null
```

A regression in `hsts_check_domain`, the `pfb_py_hsts.txt` load, or the `log_type == '1' and not in_hsts` condition would silently turn HSTS-preload blocks back into VIP responses (or break blocking) and CI would not catch it — the existing cases use non-HSTS `unique_domain()` names *precisely to avoid* the flip, so the flip itself was untested.

## What's added

Two cases in `tests/smoke/test_smoke_matrix.py`, mirroring the maintainer's manual ADR-04 HSTS drill:

- **`test_dnsbl_hsts_override_forces_null`** — pin a unique `.com` into the in-chroot `pfb_py_hsts.txt`, confirm it is in the effective HSTS set, block it on a **VIP-mode** list, assert **NULL** (`is_null_ip`, not `is_vip`) for both A and AAAA.
- **`test_dnsbl_hsts_disabled_keeps_vip`** — same name, same VIP list, `pfb_hsts=off` → **VIP**. The non-tautology guard proving the override is what's exercised, not an always-null path.

Self-contained, not coupled to the shipped preload list: `add_hsts_name` appends to the chroot HSTS file, which **survives the reload** because pfBlockerNG copies the shipped list into the chroot only when missing (`inc:2238` `if (!file_exists(...))`). The case's first reload recreates the file; we then append our name and reload again so the module re-reads `hstsDB` with it included.

## Helper changes (`tests/smoke/helpers.py`)

- `DnsblCase.hsts: bool | None` — `None` default emits nothing, so the existing matrix is **byte-for-byte unchanged**; `True`/`False` forces `pfb_hsts` on/off in `_dnsbl_inject_snippet`.
- `add_hsts_name(vm, name)` — append a name to `/var/unbound/pfb_py_hsts.txt` (`tee -a`, mirrors `write_local_feed`).
- `assert_hsts_loaded(vm, name)` — precondition guard: confirms the name is an exact line in the file **and** `python_hsts=on` in the generated ini, so a failed end-to-end assert is attributable to the HSTS branch, not a load miss.

## Verification

- `ruff check` / `ruff format --check` clean on both files; AST parse OK.
- Pre-commit gates (pytest, mypy `tests/`, markdownlint, shellspec, php -l) pass. `tests/smoke` is deselected from the default suite (needs a live VM); the runtime authority is the ADR-04 smoke workflow on CI.
- Block-shape semantics verified against `pfb_unbound.py` (`evaluate_domain`, `hsts_check_domain`) and the `pfb_py_hsts.txt` copy-if-missing path in `pfblockerng.inc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for HSTS override behavior in DNS blocklist scenarios, including cases that force a NULL sinkhole and cases that preserve VIP behavior.
  * Extended test infrastructure with helpers to manage and validate the HSTS preload list and its effect on DNSBL reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->