### PR TITLE
dev: codify GitHub issue-label lifecycle (WIP / Waiting PR)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,6 +504,25 @@ follow-up commit you push onto an open PR.
 
 ---
 
+## GitHub issue labels (lifecycle)
+
+Keep an issue's labels in sync with its stage in the workflow (the labels already
+exist in the repo — see `gh label list`). Apply them with
+`gh issue edit <N> --add-label <l>` / `--remove-label <l>`:
+
+- **Creating an issue** — apply the appropriate descriptive label(s) for what it is
+  (`bug`, `enhancement`, `documentation`, …).
+- **Picking it up** (starting work) — add `WIP`.
+- **It reaches the PR stage** (a PR that fixes it is open) — remove `WIP`, add
+  `Waiting PR`.
+- **That PR is merged** — remove `Waiting PR`.
+- **Resolved/closed without a PR** (e.g. fixed by a direct push, or closed as
+  invalid) — remove `WIP`.
+- **Dropped / can't fix** (won't-fix, not reproducible, …) — remove `WIP`/`Waiting
+  PR` and leave a status-update comment explaining why.
+
+---
+
 ## Commit style
 
 Follow existing log: `<scope>: <imperative summary>`.


### PR DESCRIPTION
## Summary

Adds a **GitHub issue labels (lifecycle)** section to `CLAUDE.md` documenting how an issue's labels should track its workflow stage:

- Descriptive label(s) on creation (`bug`/`enhancement`/`documentation`/…)
- `WIP` when picked up
- swap `WIP` → `Waiting PR` when a fixing PR opens
- drop `Waiting PR` once that PR merges
- drop `WIP` if the issue is resolved/closed without a PR
- on drop / can't-fix: remove `WIP`/`Waiting PR` and leave a status-update comment

The `WIP` and `Waiting PR` labels already exist in the repo; this just codifies when to apply them. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GitHub issue label lifecycle documentation detailing when to add or remove labels based on issue workflow stages, including guidance for applying repo labels via command-line tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->