### PR TITLE
ci: skip CI for documentation-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,30 @@ name: Tests
 # (Settings → Actions → "Require approval for all outside collaborators")
 # gates the run: any repository collaborator can approve via the
 # "Approve and run" button on the PR page.
+#
+# paths-ignore: documentation-only changes skip CI entirely (nothing here builds
+# or tests docs). A run is skipped only when EVERY changed file matches a pattern
+# below, so any commit that also touches code still runs the full suite.
+# Caveat: `devel` is not branch-protected today; if the "All tests passed" check is
+# ever made a *required* status check, paths-ignore would leave docs-only PRs with a
+# never-reported required check (GitHub treats a skipped workflow's check as missing,
+# not passing) — at that point pair this with a companion workflow that reports the
+# same check name as a success for the ignored paths.
 on:
   push:
     branches:
       - main
       - devel
+    paths-ignore:
+      - '**/*.md'
+      - '*.md'
+      - 'docs/**'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
+      - '*.md'
+      - 'docs/**'
 
 # Least-privilege GITHUB_TOKEN: every job only reads the repo (checkout, tests,
 # lint) — upload-artifact uses the Actions runtime token, not GITHUB_TOKEN — so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,6 +430,14 @@ pre-commit hook and in CI (`test.yml`) alongside ShellCheck/PHP; run
 
 ## Updating documentation
 
+**Documentation-only changes skip CI.** A commit/PR that touches *only* Markdown
+(`**/*.md` — includes `CLAUDE.md` and `README.md`) or `docs/` is excluded from the
+`test.yml` workflow via `paths-ignore` — there is nothing in the suite to exercise
+for docs. The moment a change also touches code (anything outside those paths), the
+full suite runs again. The local pre-commit hook still lints Markdown regardless, so
+docs stay clean. This is a CI carve-out only: such changes still go through a
+worktree and the normal PR/landing flow ("Worktrees", "Branches and releases").
+
 Update `README.md` when:
 
 - Workflow steps change (test command, deploy command, release steps)


### PR DESCRIPTION
## Summary

Documentation-only changes now skip CI.

Adds `paths-ignore` to `test.yml`'s `push` and `pull_request` triggers:

```yaml
paths-ignore:
  - '**/*.md'
  - '*.md'
  - 'docs/**'
```

A workflow run is skipped only when **every** changed file matches a pattern, so any commit that also touches code still runs the full suite. The local `pre-commit` hook continues to lint Markdown regardless, so docs stay clean.

Also documents the carve-out under **Updating documentation** in `CLAUDE.md`.

### Caveat (documented in the workflow)

`devel` is **not** branch-protected today, so a skipped run is harmless. If the `All tests passed` job is ever made a *required* status check, `paths-ignore` would leave docs-only PRs with a never-reported required check (GitHub treats a skipped workflow's check as missing, not passing) — at which point this should be paired with a companion workflow reporting the same check name as success for the ignored paths. Noted in the `on:` comment block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to skip running tests for documentation-only changes (Markdown and docs files). This accelerates the CI pipeline when documentation is updated without affecting code, while maintaining the standard PR review process for all changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->