### PR TITLE
skill: add /pr-merge to rebase-and-land a PR

### DIFF
--- a/.claude/skills/pr-merge/SKILL.md
+++ b/.claude/skills/pr-merge/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: pr-merge
+description: >
+  Land a pull request the repo's way: rebase its head branch onto the target
+  branch, push, wait for CI to go green (EXCLUDING CodeRabbit — never block on
+  the bot), then merge with `--rebase` (never a merge commit, never squash) and
+  delete the remote branch. Refuses to merge a draft, a conflicting/unmergeable
+  PR, or one whose CI is red. Args: [PR number] (defaults to the current
+  branch's PR). Use when the user says "merge this PR", "land PR N", "rebase and
+  merge", "merge it once CI passes", or invokes /pr-merge. Companion to
+  /pr-comments — handle review feedback first, then /pr-merge.
+---
+
+You land a PR. The non-negotiable rules, all from this repo's `CLAUDE.md`:
+
+- **Rebase only.** Merge with `gh pr merge --rebase` — **never** a merge commit,
+  **never** squash. History across `main` ← `devel` is strictly linear, so every
+  landing is a rebase/replay.
+- **Rebase onto the live base first.** `devel` advances out of band (parallel
+  agents). Fetch and rebase the head branch onto the **current** remote base, push
+  `--force-with-lease`, and let CI re-run on the rebased commits — *that* is the CI
+  you wait on. A PR behind its base must be made a clean fast-forward before it
+  lands.
+- **Never block on CodeRabbit.** Wait for the real CI checks; treat any check whose
+  name matches `coderabbit` (case-insensitive) as advisory — its state (pending,
+  pass, "Review skipped") never gates the merge. Review feedback is `/pr-comments`'
+  job, not this skill's.
+- **Never merge a red, draft, or unmergeable PR.** Abort and report instead.
+- **Work in a dedicated worktree** (repo rule for AI agents) — never rebase/push
+  from the primary checkout.
+
+Args: `{{ args }}`
+
+## Step 1 — Identify the PR and branch
+
+- If a PR number was given in the args, use it. Otherwise resolve the current
+  branch's PR: `gh pr view --json number,headRefName,baseRefName,state,isDraft,mergeable,url`.
+  If there is none, stop and ask.
+- Resolve `OWNER/REPO`: `gh repo view --json nameWithOwner -q .nameWithOwner`.
+- Record `HEAD` (`headRefName`) and `BASE` (`baseRefName`).
+
+## Step 2 — Preflight: refuse the cases that must not merge
+
+Read the PR state once and bail early (report, do not proceed) if:
+
+- `state != OPEN` (already merged or closed).
+- `isDraft == true` — tell the user to mark it ready first.
+- `mergeable == CONFLICTING` — it needs conflict resolution; that is not this
+  skill's job. (`UNKNOWN` just means GitHub is still computing — re-read after a
+  few seconds.)
+
+Only continue when the PR is OPEN, ready, and mergeable.
+
+## Step 3 — Rebase the head branch onto its base, push
+
+Do this in a **dedicated worktree** (never the primary checkout). Reuse the PR's
+worktree if one already exists for `HEAD`; otherwise create one:
+
+```sh
+git fetch origin
+git worktree add <path> "$HEAD"          # checks out the PR head branch
+# inside <path>:
+git rebase "origin/$BASE"                # replay onto the LIVE base tip
+```
+
+- Resolve any conflicts the rebase surfaces. If they are non-trivial or ambiguous,
+  stop and hand back to the user — do not guess a resolution just to land the PR.
+- Push the rebased branch: `git push --force-with-lease`. (If the rebase was a
+  no-op because the branch was already on the base tip, the push is a no-op too —
+  fine.)
+- The force-push re-triggers CI on the rebased commits. Step 4 waits on that run,
+  not a stale one.
+
+## Step 4 — Wait for CI to pass (excluding CodeRabbit)
+
+Poll `gh pr checks` until every **non-CodeRabbit** check has completed, then decide.
+Run the loop as a **Bash command with `run_in_background: true`** (a background
+`until`-style loop that self-exits gives a single wake — do not foreground-`sleep`),
+then read `$RESULT`:
+
+```sh
+# Set first: PR  EXCLUDE(regex, default 'coderabbit')  RESULT(tmpfile)
+i=0
+while [ "$i" -lt 80 ]; do                                  # ~40 min at 30s/poll
+  json=$(gh pr checks "$PR" --json name,bucket 2>/dev/null)
+  rel=$(printf '%s' "$json" | jq -c "[.[] | select((.name|ascii_downcase|test(\"$EXCLUDE\"))|not)]")
+  total=$(printf '%s' "$rel" | jq 'length')
+  fail=$(printf '%s' "$rel" | jq '[.[]|select(.bucket=="fail" or .bucket=="cancel")]|length')
+  pend=$(printf '%s' "$rel" | jq '[.[]|select(.bucket=="pending")]|length')
+  if [ "$fail" -gt 0 ]; then { echo FAIL;    printf '%s\n' "$rel"; } > "$RESULT"; exit 0; fi
+  if [ "$total" -gt 0 ] && [ "$pend" -eq 0 ]; then { echo PASS; printf '%s\n' "$rel"; } > "$RESULT"; exit 0; fi
+  i=$((i + 1)); sleep 30
+done
+echo TIMEOUT > "$RESULT"
+```
+
+`bucket` is one of `pass` / `fail` / `pending` / `skipping` / `cancel`; `skipping`
+counts as done-not-failed. Requiring `total > 0` avoids declaring PASS before any
+check has registered. When it wakes you, read `$RESULT`:
+
+- **`PASS`** → every required check is green. Go to Step 5.
+- **`FAIL`** → a real check failed (the body lists which). **Do not merge.** Report
+  the failing checks and their run URLs (`gh pr checks "$PR"`) and stop.
+- **`TIMEOUT`** → checks did not finish in the window. Report and ask whether to
+  keep waiting or stop. Never merge on a timeout.
+
+## Step 5 — Merge with rebase
+
+```sh
+gh pr merge "$PR" --rebase
+```
+
+- **Do not** pass `--delete-branch` here. Known repo gotcha: `gh pr merge
+  --delete-branch` runs a local post-merge step that checks out the base branch,
+  which **fails when another worktree already holds that base** — even though the
+  remote merge succeeded. So merge first, verify, then delete the branch in Step 6.
+- Never substitute `--merge` or `--squash`.
+
+## Step 6 — Verify, then clean up
+
+- **Confirm the merge actually landed** (the local step above can error while the
+  remote merge succeeded): `gh pr view "$PR" --json state,mergedAt -q '.state'`
+  must be `MERGED`.
+- **Delete the remote branch separately** (avoids the Step 5 gotcha):
+  `git push origin --delete "$HEAD"`.
+- **Remove the worktree from the PRIMARY checkout** (it errors if run from *inside*
+  the tree): `git worktree remove <path>`. If you created a throwaway branch only
+  to hold the worktree, delete it too.
+
+## Step 7 — Report back
+
+State plainly: the PR number and title, whether a rebase was needed (and onto which
+base tip), the CI verdict (which checks passed; that CodeRabbit was intentionally
+not waited on), the merge result (`MERGED`, rebased), and that the remote branch and
+worktree were cleaned up. If you aborted at any step, say exactly why and what the
+user needs to do.


### PR DESCRIPTION
## Summary

Adds `/pr-merge` — a companion to `/pr-comments` that lands a PR the repo's way.

## What it does

1. Identifies the PR (arg `N`, or the current branch's PR).
2. Preflight: refuses a draft / conflicting / non-OPEN PR.
3. Rebases the head branch onto the **live** target tip, pushes `--force-with-lease` (in a dedicated worktree) — so CI re-runs on the rebased commits.
4. Waits for CI to go green, **excluding CodeRabbit** (its check name matches `coderabbit` and is treated as advisory — never gating).
5. Merges with `gh pr merge --rebase` (never a merge commit, never squash).
6. Verifies `state == MERGED`, deletes the remote branch separately, removes the worktree.

## Repo rules baked in

- Rebase-only landings; fetch + rebase onto the live base before push (`devel` advances out of band).
- The `gh pr merge --delete-branch` gotcha (local post-merge checkout fails when a worktree holds the base) → merge, verify, then `git push origin --delete`.
- Dedicated worktree for all git work.

## Verification

- `markdownlint-cli2` — 0 errors
- Full pre-commit hook (pytest 985, mypy, shellspec, shellcheck, php -l, markdownlint) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new skill documentation detailing an end-to-end PR landing workflow. Includes PR identification, validation for mergeable states, automated rebasing via git worktrees, force-push execution, CI check monitoring with custom filtering logic, merge operations using rebase strategy, and cleanup of remote branches and local resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->