### PR TITLE
pfblockerng: carry the winning block entry in the numeric matcher (#47)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3355,22 +3355,42 @@ def _scan_block_band(
     data_db: dict[str, Any],
     zone_db: dict[str, Any],
     regex_db: dict[str, Any],
-) -> int:
+) -> tuple[int, dict[str, Any] | None]:
     """Highest block band that matches ``q_name`` across dataDB (exact), zoneDB (the
-    suffix walk) and the block-regex DB; 0 if none match. Used by the numeric 6-band
-    resolution to take the max block band (decide() semantics) -- the fast-path
-    discovery short-circuits on the first hit, which is wrong for the max. Snapshot-
-    iterates the regex DB (Phase-7 eviction safety)."""
+    suffix walk) and the block-regex DB, AND the winning entry that carries it.
+
+    Returns ``(best_band, best_meta)``: ``best_band`` is the max matching band (0 if
+    none match), and ``best_meta`` describes the entry whose band IS that max so the
+    caller can RE-ATTRIBUTE feed/group/log_type/b_type/b_eval to the rule that
+    actually won (issue #47). Returning only the band lost that identity, so a
+    higher-band rule decided correctly but the response was shaped/reported from the
+    first-discovered entry. ``best_meta`` is one of:
+
+    * ``{"kind": "data", "entry": <payload>}`` -> b_type "DNSBL", b_eval q_name
+    * ``{"kind": "zone", "entry": <payload>, "matched": <suffix>}`` -> b_type "TLD"
+    * ``{"kind": "regex", "key": <name>}`` -> feed=key, group "DNSBL_Regex"
+
+    ``None`` when nothing matched. The numeric 6-band resolution takes the max block
+    band (decide() semantics) -- the fast-path discovery short-circuits on the first
+    hit, which is wrong for the max. Snapshot-iterates the regex DB (Phase-7 eviction
+    safety). On a tie the first scanned kind (data -> zone -> regex) holds best_meta,
+    but the caller only re-attributes when this band strictly exceeds the discovered
+    one, so a tie never disturbs the discovered attribution."""
     best = 0
+    best_meta: dict[str, Any] | None = None
     if cfg.get("dataDB"):
         entry = data_db.get(q_name)
         if entry is not None:
-            best = max(best, _block_entry_band(entry))
+            band = _block_entry_band(entry)
+            if band > best:
+                best, best_meta = band, {"kind": "data", "entry": entry}
     if cfg.get("zoneDB"):
         for q in iter_domain_suffixes(q_name):
             entry = zone_db.get(q)
             if entry is not None:
-                best = max(best, _block_entry_band(entry))
+                band = _block_entry_band(entry)
+                if band > best:
+                    best, best_meta = band, {"kind": "zone", "entry": entry, "matched": q}
     if cfg.get("regexDB") and q_name:
         # Snapshot-iterate + time each match (ADR-07 P7), same warn/evict policy as the
         # fast-path discovery scan; collect evicted names and pop AFTER the loop.
@@ -3384,10 +3404,12 @@ def _scan_block_band(
                 to_evict.append(_k)
                 continue
             if match:
-                best = max(best, _block_entry_band(r))
+                band = _block_entry_band(r)
+                if band > best:
+                    best, best_meta = band, {"kind": "regex", "key": _k}
         if to_evict:
             _regex_evict_names(regex_db, to_evict)
-    return best
+    return best, best_meta
 
 
 def _scan_allow_regex_band(
@@ -3608,11 +3630,31 @@ def evaluate_domain(
             # matching allow band, so augment the first-discovered block's band with a
             # full scan over every matching block (data/zone-suffix/block-regex) -- the
             # discovery above short-circuits on the first hit (right for metadata, but
-            # the resolution needs the max band).
-            block_band = max(
-                block_band,
-                _scan_block_band(q_name, cfg, data_db, zone_db, regex_db),
-            )
+            # the resolution needs the max band). When a STRICTLY higher band wins,
+            # re-attribute feed/group/log_type/b_type/b_eval to that entry (issue #47):
+            # the band decides priority, but reporting AND the response shape (log_type
+            # -> null_blocking below) must follow the rule that actually won, not the
+            # first discovered. A tie keeps the discovered attribution (block bands are
+            # distinct odds, so a tie is the same entry / same priority).
+            scan_band, scan_meta = _scan_block_band(q_name, cfg, data_db, zone_db, regex_db)
+            if scan_meta is not None and scan_band > block_band:
+                block_band = scan_band
+                if scan_meta["kind"] == "regex":
+                    feed = scan_meta["key"]
+                    group = "DNSBL_Regex"
+                    log_type = "1"
+                    b_type = "Python"
+                    b_eval = q_name
+                else:
+                    entry = scan_meta["entry"]
+                    log_type = entry["log"]
+                    feed, group = resolve_feed_group(entry["index"], feed_group_index_db)
+                    if scan_meta["kind"] == "zone":
+                        b_type = "TLD"
+                        b_eval = scan_meta["matched"]
+                    else:  # data
+                        b_type = "DNSBL"
+                        b_eval = q_name
             in_whitelist = _resolve_numeric_allow(
                 q_name,
                 q_name_original,

--- a/tests/test_adr07_matcher_strata.py
+++ b/tests/test_adr07_matcher_strata.py
@@ -324,6 +324,94 @@ class TestUserRegexSovereign:
         assert self._decide(white_db={"evil.com": {"wildcard": False, "important": True}}, allow_regex_db={}) is True
 
 
+class TestWinningEntryAttribution:
+    """Issue #47: when blocks match the same name at DIFFERENT bands, the numeric branch
+    must carry the WINNING (max-band) entry's feed/group/log_type/b_type/b_eval -- not
+    just its band. The band decides priority; reporting AND the response shape
+    (``log_type`` -> ``null_blocking``) must follow the rule that actually won.
+
+    The bug: discovery short-circuits (data -> zone -> regex) and binds the metadata to
+    the FIRST block; ``_scan_block_band`` returned only an int, so a higher-band rule
+    decided correctly but the name was shaped/attributed from the first-discovered one
+    (e.g. a band-1 feed NULL block shadowing a band-5 user-regex VIP block)."""
+
+    def test_user_regex_band5_wins_over_feed_data_band1_vip_and_attribution(self) -> None:
+        import re
+
+        # The exact issue scenario: name in a band-1 feed block (log='2' -> NULL) AND a
+        # band-5 user regex (log='1' -> VIP). The regex wins (5 > 1): VIP, attributed to
+        # DNSBL_Regex -- NOT sinkholed NULL and blamed on the feed.
+        cfg = _cfg(dataDB=True, regexDB=True, important_rules=True)
+        containers = _containers(
+            dataDB={"evil.com": {"log": "2", "index": 7, "important": False, "band": PRIO_FEED_BLOCK}},
+            regexDB={"Regex_1": {"re": re.compile(r"evil"), "important": False, "band": PRIO_USER_BLOCK}},
+            feedGroupIndexDB={7: {"feed": "FeedA", "group": "GroupA"}},
+        )
+        dec = evaluate_domain("evil.com", "evil.com", "com", False, cfg, containers)
+        assert dec.is_found is True and dec.in_whitelist is False
+        assert dec.null_blocking is False  # VIP (log_type '1'), the user-regex shape -- not NULL
+        assert dec.log_type == "1"
+        assert dec.group == "DNSBL_Regex"
+        assert dec.feed == "Regex_1"
+        assert dec.b_type == "Python"  # a regex block reports b_type "Python" (as discovery would)
+        assert dec.b_eval == "evil.com"
+
+    def test_important_zone_band3_wins_over_feed_data_band1_reattributes_to_zone(self) -> None:
+        # data exact (band 1, log='2' NULL) is discovered first; an $important zone block
+        # (band 3, log='1' VIP) on a parent suffix wins. Re-attribute to the zone: b_type
+        # 'TLD', b_eval the matched suffix, feed/group from the zone entry's index, VIP.
+        cfg = _cfg(dataDB=True, zoneDB=True, important_rules=True)
+        containers = _containers(
+            dataDB={"sub.evil.com": {"log": "2", "index": 1, "important": False, "band": PRIO_FEED_BLOCK}},
+            zoneDB={"evil.com": {"log": "1", "index": 2, "important": True, "band": PRIO_FEED_BLOCK_IMPORTANT}},
+            feedGroupIndexDB={
+                1: {"feed": "DataFeed", "group": "DataGroup"},
+                2: {"feed": "ZoneFeed", "group": "ZoneGroup"},
+            },
+        )
+        dec = evaluate_domain("sub.evil.com", "sub.evil.com", "com", False, cfg, containers)
+        assert dec.is_found is True and dec.in_whitelist is False
+        assert dec.null_blocking is False  # zone log='1' -> VIP, not the data's NULL
+        assert dec.log_type == "1"
+        assert dec.b_type == "TLD"
+        assert dec.b_eval == "evil.com"  # the matched suffix, not the queried name
+        assert dec.feed == "ZoneFeed" and dec.group == "ZoneGroup"
+
+    def test_tie_keeps_first_discovered_attribution(self) -> None:
+        import re
+
+        # A higher-or-equal discovered band must NOT be re-attributed: a band-5 data block
+        # (user Custom_List, log='1') discovered first, plus a band-1 feed regex. The regex
+        # does NOT win (1 < 5), so the data entry's feed/group/b_type stand.
+        cfg = _cfg(dataDB=True, regexDB=True, important_rules=True)
+        containers = _containers(
+            dataDB={"evil.com": {"log": "1", "index": 3, "important": False, "band": PRIO_USER_BLOCK}},
+            regexDB={"Regex_1": {"re": re.compile(r"evil"), "important": False, "band": PRIO_FEED_BLOCK}},
+            feedGroupIndexDB={3: {"feed": "UserFeed", "group": "Custom_List"}},
+        )
+        dec = evaluate_domain("evil.com", "evil.com", "com", False, cfg, containers)
+        assert dec.is_found is True and dec.in_whitelist is False
+        assert dec.null_blocking is False
+        assert dec.b_type == "DNSBL"  # data attribution retained, NOT re-attributed to the regex
+        assert dec.feed == "UserFeed" and dec.group == "Custom_List"
+
+    def test_winning_regex_still_loses_to_user_whitelist_band6(self) -> None:
+        import re
+
+        # The winning-entry carry must not change the DECISION: a band-5 regex wins the
+        # block scan and re-attributes, but a band-6 user whitelist still overrides ->
+        # the name resolves (in_whitelist True), regardless of attribution.
+        cfg = _cfg(dataDB=True, regexDB=True, whiteDB=True, important_rules=True)
+        containers = _containers(
+            dataDB={"evil.com": {"log": "2", "index": 7, "important": False, "band": PRIO_FEED_BLOCK}},
+            regexDB={"Regex_1": {"re": re.compile(r"evil"), "important": False, "band": PRIO_USER_BLOCK}},
+            whiteDB={"evil.com": {"wildcard": False, "important": True}},
+            feedGroupIndexDB={7: {"feed": "FeedA", "group": "GroupA"}},
+        )
+        dec = evaluate_domain("evil.com", "evil.com", "com", False, cfg, containers)
+        assert dec.in_whitelist is True  # band 6 user allow > band 5 user block
+
+
 class TestNumericBranchUnreachableInProduction:
     """The numeric branch only fires when pfb['important_rules'] is True, which Phase 3
     never sets (no ABP rule parsed). Defaults stay False so production stays on the

--- a/tests/test_adr07_matcher_strata.py
+++ b/tests/test_adr07_matcher_strata.py
@@ -380,13 +380,14 @@ class TestWinningEntryAttribution:
     def test_tie_keeps_first_discovered_attribution(self) -> None:
         import re
 
-        # A higher-or-equal discovered band must NOT be re-attributed: a band-5 data block
-        # (user Custom_List, log='1') discovered first, plus a band-1 feed regex. The regex
-        # does NOT win (1 < 5), so the data entry's feed/group/b_type stand.
+        # A genuine TIE must NOT re-attribute. A band-5 data block (user Custom_List,
+        # log='1') is discovered first AND a band-5 user regex also matches: the scan band
+        # EQUALS the discovered band, so the strict ``>`` guard keeps the first-discovered
+        # (data) attribution -- the co-equal regex does not steal feed/group/b_type.
         cfg = _cfg(dataDB=True, regexDB=True, important_rules=True)
         containers = _containers(
             dataDB={"evil.com": {"log": "1", "index": 3, "important": False, "band": PRIO_USER_BLOCK}},
-            regexDB={"Regex_1": {"re": re.compile(r"evil"), "important": False, "band": PRIO_FEED_BLOCK}},
+            regexDB={"Regex_1": {"re": re.compile(r"evil"), "important": False, "band": PRIO_USER_BLOCK}},
             feedGroupIndexDB={3: {"feed": "UserFeed", "group": "Custom_List"}},
         )
         dec = evaluate_domain("evil.com", "evil.com", "com", False, cfg, containers)


### PR DESCRIPTION
## Summary

Fixes #47. The numeric 6-band branch of `evaluate_domain` (`pfb_unbound.py`) resolved a multi-block match with the **max band**, but `feed` / `group` / `log_type` / `b_type` / `b_eval` stayed bound to the **first block discovered** (data → zone → regex short-circuit). `_scan_block_band` returned only the band (an `int`), discarding which entry won.

So a higher-band rule decided correctly while **reporting and the response shape used the wrong entry**. Concretely: a name in a feed block (band 1, `log='2'` → NULL) that's also matched by a user regex (band 5, `log='1'` → VIP) blocked correctly (band 5 wins) but was **sinkholed as NULL and attributed to the feed**, not the sovereign user regex — undercutting the user-sovereignty reporting/shape ADR-07 added.

## Fix

- `_scan_block_band` now returns `(best_band, best_meta)`. `best_meta` identifies the max-band entry: `{"kind": "data"|"zone"|"regex", ...}` (the data/zone payload, or the regex key), or `None` when nothing matched.
- In `evaluate_domain`, when the scan band **strictly exceeds** the discovered band, re-attribute `feed`/`group`/`log_type`/`b_type`/`b_eval` to the winning entry — exactly as discovery would have bound them:
  - **data** → `b_type='DNSBL'`, `b_eval=q_name`, feed/group via `resolve_feed_group(entry['index'])`, `log_type=entry['log']`
  - **zone** → `b_type='TLD'`, `b_eval=` the matched suffix, feed/group + log as above
  - **regex** → `feed=key`, `group='DNSBL_Regex'`, `log_type='1'`, `b_type='Python'`
- A **tie keeps the discovered attribution** (block bands are distinct odds {1,3,5}, so a tie is the same priority). The **decision** (block vs allow) is unchanged — only attribution + response shape follow the winner now.

There is a single `_scan_block_band` call site in the current tree (the discovery binding stays as the fast-path start; only the numeric augmentation re-attributes).

## Tests

`test_adr07_matcher_strata.py::TestWinningEntryAttribution`:

- band-1 feed block + band-5 user regex → **VIP + `DNSBL_Regex`** attribution (the issue's exact case; the regression guard).
- `$important` zone block (band 3) over feed data (band 1) → re-attribute to the zone (`b_type='TLD'`, `b_eval` = matched suffix, zone feed/group, VIP).
- tie (band-5 data + band-1 regex) → keeps the first-discovered data attribution (guards against over-eager re-attribution).
- a band-6 user whitelist still overrides the re-attributed band-5 block (the decision is unchanged).

## Verification

- Full suite **989 passed** (ADR-06/07 golden oracles + `evaluate_domain` golden tests confirm no regression); ruff + format + `mypy tests/` clean; pre-commit hooks green.

## Deferred

The related spike `benchmarks/spike_adr07_regex.py` `categorise()` / `_strip_slashes()` trailing-`$options` handling (informational Phase-1 reference, always exits 0) is **left to #42** per the issue — keeping this PR focused on the matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected rule attribution when multiple rules match a domain — the decision now uses the highest-priority matching entry; ties preserve the original attribution and whitelist entries still override blocks.

* **Tests**
  * Added tests covering multi-match attribution, priority re‑attribution, tie behavior, and whitelist override scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->