### PR TITLE
pfblockerng: stop caching DNSBL block replies (#43)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4096,6 +4096,18 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
 
                     qstate.return_rcode = RCODE_NOERROR
                     qstate.return_msg.rep.security = 2
+                    # Do not store the synthetic block reply in Unbound's C message
+                    # cache (#43). A cached block is served ahead of this module, so
+                    # repeat queries skip operate() -> the feed-attributed logger
+                    # (get_details_dnsbl: dnsbl.log + per-group counter) never runs and
+                    # per-feed block stats under-count; the cache-hit path logs only an
+                    # unattributed DNS-reply. It also keeps a cached 0.0.0.0/VIP serving
+                    # for up to the TTL after a name is removed from a list (block->allow
+                    # staleness). The reply is synthetic, so not caching it costs only the
+                    # ~1us in-process matcher re-run (the dnsblDB/excludeDB memos still
+                    # short-circuit re-evaluation), never an upstream round-trip. Mirrors
+                    # the SafeSearch CNAME path, the module's only other no_cache_store.
+                    qstate.no_cache_store = 1
                     qstate.ext_state[id] = MODULE_FINISHED
                     return True
 

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -736,6 +736,7 @@ def make_qstate(
         return_msg=return_msg,
         return_rcode=return_rcode,
         ext_state={},
+        no_cache_store=0,
     )
 
 
@@ -809,6 +810,38 @@ class TestOperateDnsbl:
         assert qstate.return_rcode == RCODE_NOERROR
         answers = DNSMessage.instances[-1].answer
         assert any(pfb_unbound.pfb["dnsbl_ipv4"] in a for a in answers)
+
+    def test_block_sets_no_cache_store(self, monkeypatch: Any) -> None:
+        # #43: the synthetic block reply must NOT be stored in Unbound's C message
+        # cache. A cached block is served ahead of this module, so repeat queries
+        # skip operate() -> the feed-attributed logger never runs (per-feed
+        # under-count) and a removed name keeps serving the stale block until TTL.
+        self._enable(monkeypatch)
+        add_data("evil.com", log="1", index=0)
+        set_feed_group(0, "TestFeed", "TestGroup")
+        qstate = make_qstate("evil.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        assert qstate.no_cache_store == 1
+
+        # The memoized re-block path (name already in dnsblDB) must set it too --
+        # that is the whole point: every blocked query, miss or memo, re-runs here.
+        assert pfb_unbound.dnsblDB.get("evil.com") is not None
+        qstate2 = make_qstate("evil.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate2, None)
+        assert qstate2.ext_state[0] == MODULE_FINISHED
+        assert qstate2.no_cache_store == 1
+
+    def test_pass_through_leaves_cache_store_enabled(self, monkeypatch: Any) -> None:
+        # A non-blocked name falls through to the resolver and MUST stay cacheable
+        # -- no_cache_store is the block path's alone.
+        self._enable(monkeypatch)
+        add_data("evil.com", log="1", index=0)
+        set_feed_group(0, "TestFeed", "TestGroup")
+        qstate = make_qstate("good.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert qstate.ext_state[0] == MODULE_WAIT_MODULE
+        assert qstate.no_cache_store == 0
 
     def test_zone_lookup_matches_subdomain(self, monkeypatch: Any) -> None:
         self._enable(monkeypatch)


### PR DESCRIPTION
## Fix #43 — DNSBL block report under-counts cached blocks

### Root cause

DNSBL block replies (`NOERROR` + `A 0.0.0.0`/VIP) were built at TTL 3600 **without** `no_cache_store`, so Unbound stored them in its C message cache and served repeat queries from there — **ahead of** the pfBlockerNG python module. Two consequences:

- **Per-feed block stats under-count.** The feed-attributed logger (`get_details_dnsbl` → `dnsbl.log` + per-group counter, using the `dnsblDB` feed/group) runs **only on a cache miss** from `operate()`. On a cache hit `get_details_reply("cache")` fires instead → an **unattributed** `DNS-reply` in `dns_reply.log` (no feed/group, no counter). A name blocked once then served N times from cache logs **one** attributed event; the other N-1 are invisible to the Reports DNSBL view for up to the block TTL (3600 s).
- **(Related) block→allow staleness.** A name removed from a list keeps serving the cached `0.0.0.0`/VIP until the TTL expires.

### Fix (issue option 2 — `no_cache_store` on blocks)

Set `qstate.no_cache_store = 1` on the block path. Every blocked query then re-runs `operate()` → it is **always** attributed/logged, and a delisting takes effect immediately.

Chosen over option 1 (wire the cache-hit path to re-attribute via `dnsblDB`) because the block reply is **synthetic**: not caching it costs only the ~1 µs in-process matcher re-run (the `dnsblDB`/`excludeDB` decision memos still short-circuit re-evaluation), **never** an upstream round-trip. It fixes **both** the under-count and the block→allow staleness, and mirrors the SafeSearch CNAME path — the module's only other `no_cache_store`.

**ADR-10 interaction:** ADR-10 (Proposed) documented blocks-are-cached and a *bidirectional* C-cache delta-flush. With blocks no longer cached, block→allow is immediate, so ADR-10's C-cache flip simplifies to **unidirectional** (allow→block only, for cached real answers). ADR-10 docs left untouched here.

### Tests

- `test_block_sets_no_cache_store` — block sets `no_cache_store == 1`, on both the first (miss) and the memoized (`dnsblDB`) re-block paths.
- `test_pass_through_leaves_cache_store_enabled` — a non-blocked name stays cacheable (`no_cache_store == 0`).
- Full suite green (991 passed), ruff + mypy clean.

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked DNS responses are no longer cached, ensuring repeated queries do not bypass per-feed/per-group logging or DNSBL counters.

* **Tests**
  * Added tests validating that blocked queries disable caching and that non-blocked queries continue to allow caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->