### PR TITLE
pfblockerng: wire DNSBL temporary Lock/Unlock to the python build (#51)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2950,17 +2950,32 @@ def build(
         zone_db[tld] = {"log": "1", "index": idx, "important": False, "band": PRIO_FEED_BLOCK}
 
     # ADR-06 (#51): the temporary per-alert Unlock store (config.user_unlock, fed from
-    # the pfb_unlock state by the alerts dnsbl_remove handler) merges into whiteDB
+    # the pfb_unlock state by the alerts dnsbl_remove handler) loads into whiteDB
     # exactly like the permanent user whitelist -- both are band-6 sovereign user allows
     # (_dnsbl_normalise_whitelist marks every entry important=True / PRIO_USER_ALLOW), so
     # an unlocked domain resolves (its feed / Custom_List block is overridden). A FULL
     # build emits an empty user_unlock (Force/Cron re-lock); only the incremental
     # dnsbl_remove handler populates it.
     white_db = _dnsbl_normalise_whitelist(
-        list(config.get("user_whitelist", [])) + list(config.get("user_unlock", [])),
+        config.get("user_whitelist", []),
         config.get("top1m_list", []),
         top1m_enabled,
     )
+    # Merge the unlock set WITHOUT narrowing an existing permanent allow: a domain may be
+    # a wildcard in user_whitelist (".x" -> covers subdomains) yet exact in user_unlock,
+    # and a plain last-wins concat would downgrade the wildcard to exact. Widen on
+    # collision instead -- the same monotonic merge the feed @@ allows use below (keep
+    # the broadest wildcard/important, highest band; both sides are band-6 user allows).
+    for domain, unlock_entry in _dnsbl_normalise_whitelist(config.get("user_unlock", []), (), False).items():
+        existing = white_db.get(domain)
+        if existing is None:
+            white_db[domain] = unlock_entry
+            continue
+        white_db[domain] = {
+            "wildcard": _white_entry_wildcard(existing) or _white_entry_wildcard(unlock_entry),
+            "important": _white_entry_important(existing) or _white_entry_important(unlock_entry),
+            "band": max(_white_entry_band(existing), _white_entry_band(unlock_entry)),
+        }
 
     # ADR-07 P6: ABP feeds (format_hint='abp') are parsed into the typed Rule stream
     # (Stage A, parse_abp) and reconciled (Stage B) into the banded pre-emit rule

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2899,7 +2899,8 @@ def build(
     ``manifest`` is the per-feed boundary (RESULTS/01_Results.txt SS1i): one row per
     raw feed file mapping it to ``{raw, feed, group, format_hint, log_flag}``.
     ``config`` carries the classification + whitelist inputs (``tld_master`` suffix
-    lines, ``tld_blacklist``, ``tld_exclusion``, ``user_whitelist``, ``top1m_list``).
+    lines, ``tld_blacklist``, ``tld_exclusion``, ``user_whitelist``, ``user_unlock``,
+    ``top1m_list``).
     ``line_reader`` yields the raw lines for a feed's ``raw`` reference -- injected so
     this stays pure and side-effect-free (no filesystem coupling, unit-testable; the
     init wiring in Phase 4 supplies a file-backed reader).
@@ -2948,8 +2949,15 @@ def build(
         idx = index_for("DNSBL_TLD", "DNSBL_TLD")
         zone_db[tld] = {"log": "1", "index": idx, "important": False, "band": PRIO_FEED_BLOCK}
 
+    # ADR-06 (#51): the temporary per-alert Unlock store (config.user_unlock, fed from
+    # the pfb_unlock state by the alerts dnsbl_remove handler) merges into whiteDB
+    # exactly like the permanent user whitelist -- both are band-6 sovereign user allows
+    # (_dnsbl_normalise_whitelist marks every entry important=True / PRIO_USER_ALLOW), so
+    # an unlocked domain resolves (its feed / Custom_List block is overridden). A FULL
+    # build emits an empty user_unlock (Force/Cron re-lock); only the incremental
+    # dnsbl_remove handler populates it.
     white_db = _dnsbl_normalise_whitelist(
-        config.get("user_whitelist", []),
+        list(config.get("user_whitelist", [])) + list(config.get("user_unlock", [])),
         config.get("top1m_list", []),
         top1m_enabled,
     )
@@ -3097,8 +3105,8 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
     The on-box manifest carries ``tld_master`` as a FILE PATH (the public-suffix
     oracle); the build takes the suffix LINES directly (pure, filesystem-decoupled),
     so read the file here. ``tld_blacklist`` / ``tld_exclusion`` / ``user_whitelist``
-    / ``top1m_list`` are passed through as lists. Missing keys default empty so a
-    partial manifest still builds.
+    / ``user_unlock`` / ``top1m_list`` are passed through as lists. Missing keys default
+    empty so a partial manifest still builds.
     """
     config = manifest.get("config", {})
 
@@ -3125,6 +3133,8 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
         "tld_blacklist": list(config.get("tld_blacklist", [])),
         "tld_exclusion": list(config.get("tld_exclusion", [])),
         "user_whitelist": list(config.get("user_whitelist", [])),
+        # ADR-06 (#51): the temporary per-alert unlock set -> band-6 whiteDB allows.
+        "user_unlock": list(config.get("user_unlock", [])),
         "top1m_list": list(config.get("top1m_list", [])),
         "regex_cap": regex_cap,
     }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2638,6 +2638,32 @@ function pfb_unbound_python_sources_unlock() {
 }
 
 
+// ADR-06 (#51): map a per-alert DNSBL Lock/Unlock action (the dnsbl_remove POST
+// value) to its temporary-unlock STORE operation + status message. Extracted from
+// the pfblockerng_alerts.php handler so the four-way dispatch is unit-testable (every
+// branch covered, not just the unlock/lock paths the smoke matrix observes). The four
+// icon actions collapse onto two pfb_unlock modes: unlock/relock ADD the domain to
+// the store ('unlock'), lock/reunlock REMOVE it ('lock'). An UNKNOWN action returns an
+// empty mode so the handler does NOTHING -- a crafted POST cannot mutate the store
+// (the old inline `else` treated any non-unlock/relock value as a REMOVE). 'msg'
+// carries a single %s for the domain (sprintf in the handler); empty for an unknown
+// action so the redirect shows no status.
+function pfb_dnsbl_unlock_action($action) {
+	switch ($action) {
+		case 'unlock':
+			return array('mode' => 'unlock', 'msg' => 'The Domain [ %s ] has been temporarily Unlocked from DNSBL!');
+		case 'lock':
+			return array('mode' => 'lock',   'msg' => 'The Domain [ %s ] has been Locked into DNSBL!');
+		case 'relock':
+			return array('mode' => 'unlock', 'msg' => 'The Domain [ %s ] has been temporarily Re-Locked into DNSBL!');
+		case 'reunlock':
+			return array('mode' => 'lock',   'msg' => 'The Domain [ %s ] has been Unlocked from DNSBL!');
+		default:
+			return array('mode' => '', 'msg' => '');
+	}
+}
+
+
 // Unbound python configuration file
 function pfb_unbound_python($mode) {
 	global $pfb;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3454,8 +3454,19 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 
 		$pfbupdate = TRUE;
 		unlink_if_exists("{$pfb['dnsbl_file']}.reload");
+
+		// ADR-06 (#51): re-lock the temporary unlocks on this reload (Cron/Force
+		// parity with main, which drops them from the regenerated whitelist). Under
+		// ADR-06 the resolver is driven by the manifest's config.user_unlock, so
+		// deleting the store alone leaves a STALE allow -- the domain keeps resolving
+		// while the UI shows it locked. Drop the store, then recompute user_unlock
+		// from it (now empty) so the reload below re-reads a cleared whiteDB.
+		$pfb_had_unlock = file_exists("{$pfb['dnsbl_unlock']}");
 		unlink_if_exists("{$pfb['dnsbl_unlock']}");
 		unlink_if_exists("{$pfb['dnsbl_unlock']}.data");
+		if ($pfb_had_unlock) {
+			pfb_unbound_python_sources_unlock();
+		}
 	}
 
 	// Backup existing unbound.conf and rename new unbound.conf file
@@ -8802,8 +8813,14 @@ function sync_package_pfblockerng($cron='') {
 	// Modify DNSBL NAT and VIP and lighttpd web server conf, as required.
 	pfb_create_dnsbl($mode);
 
-	// Load new DNSBL updates to Unbound Resolver, as required
-	if ($pfb['domain_update'] || $pfbupdate || $pfbpython ||$pfb['domain_clear'] || $safesearch_update) {
+	// Load new DNSBL updates to Unbound Resolver, as required. ADR-06 (#51): a pending
+	// temporary-unlock store ($pfb['dnsbl_unlock']) also forces the reload so a Cron/
+	// Force re-locks it even when no feed changed -- parity with main, where the
+	// ungated whitelist regeneration sets $pfbpython for the same effect. The reload
+	// path (pfb_update_unbound) then drops the store and clears the manifest's
+	// user_unlock.
+	if ($pfb['domain_update'] || $pfbupdate || $pfbpython ||$pfb['domain_clear'] || $safesearch_update ||
+	    file_exists($pfb['dnsbl_unlock'])) {
 
 		// Create backup of existing DNSBL Unbound database
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2319,6 +2319,32 @@ function pfb_dnsbl_whitelist_lines() {
 	return $out;
 }
 
+// ADR-06 (#51): collect the TEMPORARY per-alert DNSBL unlock store
+// ($pfb['dnsbl_unlock'], a CSV of "domain,type" rows toggled by the alerts
+// Lock/Unlock icon) as a normalised list of domains for the Python build manifest
+// (config.user_unlock). The Python build merges these into whiteDB as band-6 user
+// allows (same shape as config.user_whitelist) so an unlocked domain resolves. This
+// store is deliberately temporary: it lives in /tmp and a full update / Force / Cron
+// deletes it (pfb_update_unbound), so a FULL build emits an EMPTY user_unlock and the
+// rebuilt manifest re-locks every unlock (the "re-locked on Cron/Force" behaviour
+// documented in the alerts icon tooltip). Only pfb_unbound_python_sources_unlock()
+// (the incremental alerts path) feeds the live store into the manifest.
+function pfb_dnsbl_unlock_lines() {
+	global $pfb;
+
+	$out = array();
+	$store = pfb_unlock('read', 'dnsbl', '', '', '');
+	if (is_array($store)) {
+		foreach (array_keys($store) as $domain) {
+			$domain = trim((string) $domain);
+			if ($domain !== '') {
+				$out[] = $domain;
+			}
+		}
+	}
+	return $out;
+}
+
 // ADR-07 P8: extract an IP from an ABP-anchored / hosts line for the DNSBL-IP
 // firewall pass (coexistence). The raw ABP line itself still flows to Python, which
 // SKIPS IP-valued anchors (parse_abp returns None) -- so IP -> firewall only,
@@ -2509,6 +2535,14 @@ function pfb_unbound_python_sources($feeds) {
 			'tld_blacklist'	=> array_values($tld_blacklist),
 			'tld_exclusion'	=> array_values($tld_exclusion),
 			'user_whitelist'=> pfb_dnsbl_whitelist_lines(),
+			// ADR-06 (#51): a FULL build CLEARS the temporary unlock set. A Force/Cron
+			// update deletes the pfb_unlock store (pfb_update_unbound) right after this
+			// manifest is written, so reading the live store here would bake unlocks
+			// into the rebuilt manifest and they would survive the Force/Cron reload
+			// (the manifest is not rewritten post-delete) -- breaking the documented
+			// "re-locked on Cron/Force" semantic. Only pfb_unbound_python_sources_unlock()
+			// (the incremental alerts dnsbl_remove path) repopulates user_unlock.
+			'user_unlock'	=> array(),
 			'top1m_list'	=> array_values($top1m_list),
 			'top1m_enabled'	=> $top1m_enabled
 		),
@@ -2550,6 +2584,47 @@ function pfb_unbound_python_sources_whitelist() {
 		$manifest['config'] = array();
 	}
 	$manifest['config']['user_whitelist'] = pfb_dnsbl_whitelist_lines();
+
+	$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+	if ($json !== FALSE) {
+		@file_put_contents($pfb['unbound_py_sources'], $json, LOCK_EX);
+		@chown($pfb['unbound_py_sources'], 'unbound');
+		@chgrp($pfb['unbound_py_sources'], 'unbound');
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
+
+// ADR-06 (#51): update ONLY the manifest's config.user_unlock in place, recomputed
+// from the live temporary-unlock store (pfb_dnsbl_unlock_lines). Mirrors
+// pfb_unbound_python_sources_whitelist(): the alerts Lock/Unlock icon toggles the
+// pfb_unlock state without a full feed re-enumeration, so patch the manifest and let
+// the query-time whiteDB rebuild from it on the next reload. The alerts handler's
+// reload (pfb_reload_unbound) does NOT delete the store, so store and manifest stay in
+// step; a full update/Force/Cron is the only thing that clears both.
+function pfb_unbound_python_sources_unlock() {
+	global $pfb;
+
+	if (!file_exists($pfb['unbound_py_sources'])) {
+		return FALSE;
+	}
+
+	$json = @file_get_contents($pfb['unbound_py_sources']);
+	if ($json === FALSE) {
+		return FALSE;
+	}
+
+	$manifest = json_decode($json, TRUE);
+	if (!is_array($manifest)) {
+		return FALSE;
+	}
+
+	if (!isset($manifest['config']) || !is_array($manifest['config'])) {
+		$manifest['config'] = array();
+	}
+	$manifest['config']['user_unlock'] = pfb_dnsbl_unlock_lines();
 
 	$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 	if ($json !== FALSE) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1354,14 +1354,7 @@ if (isset($_POST) && !empty($_POST)) {
 		$dnsbl_type	= pfb_filter($_POST['dnsbl_type'], PFB_FILTER_WORD, 'alerts dnsbl_remove');
 
 		$domain_esc	= escapeshellarg($domain);
-
-		if (!empty($dnsbl_type)) {
-			if (strpos($dnsbl_type, 'TLD') !== FALSE) {
-				$dnsbl_type = 'TLD';
-			} elseif (strpos($dnsbl_type, 'DNSBL') !== FALSE) {
-				$dnsbl_type = 'DNSBL';
-			}
-		}
+		$action		= $_POST['dnsbl_remove'];
 
 		// If Domain or DNSBL type field is empty, exit.
 		if (empty($domain) || empty($dnsbl_type)) {
@@ -1370,42 +1363,33 @@ if (isset($_POST) && !empty($_POST)) {
 			exit;
 		}
 
-		// For DNSBL python - Lock/unlock - Collect missing Feed/Group Name
-		if ($_POST['dnsbl_remove'] != 'unlock' && $dnsbl_type != 'python') {
-			$log_type = '1';
-			$pfb_feed = $pfb_group = 'Unknown';
-			if (file_exists("{$pfb['dnsbl_unlock']}.data")) {
-				$find_unlock_data = pfb_unlock('dnsbl_data', 'dnsbl_data', ",{$domain},,", '', '');
-				if (!empty($find_unlock_data)) {
-					$log_type	= $find_unlock_data[3] ?: 'Unknown';
-					$pfb_feed	= $find_unlock_data[4] ?: 'Unknown';
-					$pfb_group	= $find_unlock_data[5] ?: 'Unknown';
-				}
-			}
+		// ADR-06 (#51): DNSBL is built by the Unbound python plugin from the per-feed
+		// manifest (pfb_py_sources.json); the legacy pfb_py_whitelist.txt / pfb_py_data
+		// / pfb_py_zone files this handler once wrote are no longer read by the build,
+		// so writing them was a no-op. The TEMPORARY per-alert Lock/Unlock now toggles
+		// ONLY the pfb_unlock state store ($pfb['dnsbl_unlock']); the resolver effect
+		// comes from regenerating the manifest's config.user_unlock (band-6 user allows,
+		// merged into whiteDB) from that store and reloading Unbound.
+		//
+		// Store toggle: unlock/relock ADD the domain, lock/reunlock REMOVE it --
+		// preserving the four icon states rendered from $dnsbl_unlock (red lock /
+		// primary unlock / warning relock / warning reunlock). user_unlock is recomputed
+		// as the store's domains, so an unlocked (in-store, non-whitelisted) domain
+		// resolves and a re-locked one returns to its feed-blocked state on reload.
+		if ($action == 'unlock' || $action == 'relock') {
+			pfb_unlock('unlock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
+		} else {	// 'lock' | 'reunlock'
+			pfb_unlock('lock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
 		}
 
-		// Unlock Domain
-		if ($_POST['dnsbl_remove'] == 'unlock') {
-			$cmd = 'local_data_remove';
-			$py_file = $pfb['unbound_py_data'];
-			if ($dnsbl_type == 'TLD') {
-				$cmd = 'local_zone_remove';
-				$py_file = $pfb['unbound_py_zone'];
-			}
+		// Patch the manifest's config.user_unlock from the updated store, then reload
+		// Unbound so the query-time whiteDB picks up the change.
+		pfb_unbound_python_sources_unlock();
+		pfb_reload_unbound('enabled', FALSE);
 
-			if ($dnsbl_type == 'python') {
-				@file_put_contents($pfb['unbound_py_wh'], "{$domain},0\n", FILE_APPEND | LOCK_EX);
-			}
-			else {
-				$tmp = tempnam('/tmp', 'dnsbl_alert_');
-				@file_put_contents("{$tmp}.adup", ",{$domain},,\n", LOCK_EX);
-				exec("{$pfb['ggrep']} -F -f " . escapeshellarg("{$tmp}.adup") . " {$py_file} >> {$pfb['dnsbl_unlock']}.data"); // Store DNSBL Feed/Group Data
-				exec("{$pfb['ggrep']} -vF -f " . escapeshellarg("{$tmp}.adup") . " {$py_file} > " . escapeshellarg("{$tmp}.tmp") . "; mv -f "
-					. escapeshellarg("{$tmp}.tmp") . " {$py_file}");
-				unlink_if_exists("{$tmp}*");
-			}
-			pfb_reload_unbound('enabled', FALSE);
-
+		// On an Unlock, flush the now-allowed name (and any CNAME targets) from the
+		// resolver cache so a previously-cached block is not served.
+		if ($action == 'unlock') {
 			exec("{$pfb['chroot_cmd']} flush {$domain_esc} 2>&1");
 
 			// Query for CNAME(s)
@@ -1422,70 +1406,25 @@ if (isset($_POST) && !empty($_POST)) {
 					}
 				}
 			}
-
-			// Add Domain to unlock file
-			pfb_unlock('unlock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
-			$savemsg = "The Domain [ {$domain} ] has been temporarily Unlocked from DNSBL!";
 		}
 
-		// Lock Domain
-		elseif ($_POST['dnsbl_remove'] == 'lock') {
-			if ($dnsbl_type == 'python') {
-				pfb_unbound_python_whitelist('alerts');
-			}
-			else {
-				if ($dnsbl_type == 'TLD') {
-					$py_file = $pfb['unbound_py_zone'];
-				} else {
-					$py_file = $pfb['unbound_py_data'];
-				}
-
-				@file_put_contents($py_file, ",{$domain},,{$log_type},{$pfb_feed},{$pfb_group}\n", FILE_APPEND);
-			}
-			pfb_reload_unbound('enabled', FALSE);
-
-			// Remove Domain from unlock file
-			pfb_unlock('lock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
-			$savemsg = "The Domain [ {$domain} ] has been Locked into DNSBL!";
+		switch ($action) {
+			case 'unlock':
+				$savemsg = "The Domain [ {$domain} ] has been temporarily Unlocked from DNSBL!";
+				break;
+			case 'lock':
+				$savemsg = "The Domain [ {$domain} ] has been Locked into DNSBL!";
+				break;
+			case 'relock':
+				$savemsg = "The Domain [ {$domain} ] has been temporarily Re-Locked into DNSBL!";
+				break;
+			case 'reunlock':
+				$savemsg = "The Domain [ {$domain} ] has been Unlocked from DNSBL!";
+				break;
+			default:
+				$savemsg = '';
 		}
-		elseif ($_POST['dnsbl_remove'] == 'relock') {
 
-			if ($dnsbl_type == 'python') {
-				pfb_unbound_python_whitelist('alerts');
-			}
-			else {
-				if ($dnsbl_type == 'TLD') {
-					$py_file = $pfb['unbound_py_zone'];
-				} else {
-					$py_file = $pfb['unbound_py_data'];
-				}
-				@file_put_contents($py_file, ",{$domain},,{$log_type},{$pfb_feed},{$pfb_group}\n", FILE_APPEND);
-			}
-			pfb_reload_unbound('enabled', FALSE);
-
-			// Add Domain to unlock file
-			pfb_unlock('unlock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
-			$savemsg = "The Domain [ {$domain} ] has been temporarily Re-Locked into DNSBL!";
-		}
-		elseif ($_POST['dnsbl_remove'] == 'reunlock') {
-
-			if ($dnsbl_type == 'python') {
-				pfb_unbound_python_whitelist('alerts');
-			}
-			else {
-				if ($dnsbl_type == 'TLD') {
-					$py_file = $pfb['unbound_py_zone'];
-				} else {
-					$py_file = $pfb['unbound_py_data'];
-				}
-				@file_put_contents($py_file, ",{$domain},,{$log_type},{$pfb_feed},{$pfb_group}\n", FILE_APPEND);
-			}
-			pfb_reload_unbound('enabled', FALSE);
-
-			// Remove Domain from unlock file
-			pfb_unlock('lock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
-			$savemsg = "The Domain [ {$domain} ] has been Unlocked from DNSBL!";
-		}
 		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 		exit;
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1375,56 +1375,44 @@ if (isset($_POST) && !empty($_POST)) {
 		// preserving the four icon states rendered from $dnsbl_unlock (red lock /
 		// primary unlock / warning relock / warning reunlock). user_unlock is recomputed
 		// as the store's domains, so an unlocked (in-store, non-whitelisted) domain
-		// resolves and a re-locked one returns to its feed-blocked state on reload.
-		if ($action == 'unlock' || $action == 'relock') {
-			pfb_unlock('unlock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
-		} else {	// 'lock' | 'reunlock'
-			pfb_unlock('lock', 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
-		}
+		// resolves and a re-locked one returns to its feed-blocked state on reload. The
+		// four-way action -> (store-mode, message) dispatch lives in
+		// pfb_dnsbl_unlock_action() (unit-tested); an unknown action has an empty mode
+		// and is a no-op here.
+		$ua = pfb_dnsbl_unlock_action($action);
+		if ($ua['mode'] !== '') {
+			pfb_unlock($ua['mode'], 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
 
-		// Patch the manifest's config.user_unlock from the updated store, then reload
-		// Unbound so the query-time whiteDB picks up the change.
-		pfb_unbound_python_sources_unlock();
-		pfb_reload_unbound('enabled', FALSE);
+			// Patch the manifest's config.user_unlock from the updated store, then
+			// reload Unbound so the query-time whiteDB picks up the change.
+			pfb_unbound_python_sources_unlock();
+			pfb_reload_unbound('enabled', FALSE);
 
-		// On an Unlock, flush the now-allowed name (and any CNAME targets) from the
-		// resolver cache so a previously-cached block is not served.
-		if ($action == 'unlock') {
-			exec("{$pfb['chroot_cmd']} flush {$domain_esc} 2>&1");
+			// On an Unlock, flush the now-allowed name (and any CNAME targets) from the
+			// resolver cache so a previously-cached block is not served.
+			if ($action == 'unlock') {
+				exec("{$pfb['chroot_cmd']} flush {$domain_esc} 2>&1");
 
-			// Query for CNAME(s)
-			if (!empty(pfb_filter($pfb['extdns'], PFB_FILTER_IP, 'alerts dnsbl_remove'))) {
-				$ext_dns = escapeshellarg("@{$pfb['extdns']}");
-				exec("/usr/bin/drill {$domain_esc} {$ext_dns} | /usr/bin/awk '/CNAME/ {sub(\"\.\$\", \"\", \$5); print \$5;}' 2>&1", $cname_list);
-				if (!empty($cname_list)) {
-					foreach ($cname_list as $cname) {
-						$cname = pfb_filter($cname, PFB_FILTER_DOMAIN, 'alerts dnsbl_remove', '', TRUE);
-						if (empty($cname)) {
-							continue;
+				// Query for CNAME(s)
+				if (!empty(pfb_filter($pfb['extdns'], PFB_FILTER_IP, 'alerts dnsbl_remove'))) {
+					$ext_dns = escapeshellarg("@{$pfb['extdns']}");
+					exec("/usr/bin/drill {$domain_esc} {$ext_dns} | /usr/bin/awk '/CNAME/ {sub(\"\.\$\", \"\", \$5); print \$5;}' 2>&1", $cname_list);
+					if (!empty($cname_list)) {
+						foreach ($cname_list as $cname) {
+							$cname = pfb_filter($cname, PFB_FILTER_DOMAIN, 'alerts dnsbl_remove', '', TRUE);
+							if (empty($cname)) {
+								continue;
+							}
+							exec("{$pfb['chroot_cmd']} flush {$cname} 2>&1");
 						}
-						exec("{$pfb['chroot_cmd']} flush {$cname} 2>&1");
 					}
 				}
 			}
 		}
 
-		switch ($action) {
-			case 'unlock':
-				$savemsg = "The Domain [ {$domain} ] has been temporarily Unlocked from DNSBL!";
-				break;
-			case 'lock':
-				$savemsg = "The Domain [ {$domain} ] has been Locked into DNSBL!";
-				break;
-			case 'relock':
-				$savemsg = "The Domain [ {$domain} ] has been temporarily Re-Locked into DNSBL!";
-				break;
-			case 'reunlock':
-				$savemsg = "The Domain [ {$domain} ] has been Unlocked from DNSBL!";
-				break;
-			default:
-				$savemsg = '';
-		}
-
+		// sprintf with the (domain-filtered, so '%'-free) name; an unknown action's
+		// empty 'msg' yields an empty savemsg.
+		$savemsg = sprintf($ua['msg'], $domain);
 		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 		exit;
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1354,7 +1354,7 @@ if (isset($_POST) && !empty($_POST)) {
 		$dnsbl_type	= pfb_filter($_POST['dnsbl_type'], PFB_FILTER_WORD, 'alerts dnsbl_remove');
 
 		$domain_esc	= escapeshellarg($domain);
-		$action		= $_POST['dnsbl_remove'];
+		$action		= pfb_filter($_POST['dnsbl_remove'], PFB_FILTER_WORD, 'alerts dnsbl_remove');
 
 		// If Domain or DNSBL type field is empty, exit.
 		if (empty($domain) || empty($dnsbl_type)) {

--- a/tests/php/DnsblUnlockActionTest.php
+++ b/tests/php/DnsblUnlockActionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_unlock_action() — ADR-06 (#51) four-way dispatch of a per-alert DNSBL
+ * Lock/Unlock action (the dnsbl_remove POST value) to its temporary-unlock STORE
+ * mode + status message. Extracted from the pfblockerng_alerts.php handler so EVERY
+ * branch is covered here (the smoke matrix only observes the resolver-visible
+ * unlock/lock paths). unlock/relock ADD ('unlock' mode), lock/reunlock REMOVE ('lock'
+ * mode); an UNKNOWN/empty action is a no-op (empty mode + empty message).
+ */
+#[CoversFunction('pfb_dnsbl_unlock_action')]
+final class DnsblUnlockActionTest extends TestCase
+{
+	/** @return array<string, array{0: string, 1: string, 2: string}> action => [mode, msg-substring] */
+	public static function provider(): array
+	{
+		return [
+			// ADD branches.
+			'unlock adds'   => ['unlock',   'unlock', 'temporarily Unlocked'],
+			'relock adds'   => ['relock',   'unlock', 'temporarily Re-Locked'],
+			// REMOVE branches.
+			'lock removes'  => ['lock',     'lock',   'Locked into DNSBL'],
+			'reunlock removes' => ['reunlock', 'lock', 'has been Unlocked'],
+			// No-op branches — a crafted/empty action must NOT mutate the store.
+			'unknown -> no-op' => ['bogus', '', ''],
+			'empty -> no-op'   => ['',      '', ''],
+		];
+	}
+
+	#[DataProvider('provider')]
+	public function testMode(string $action, string $mode, string $msgPart): void
+	{
+		$out = pfb_dnsbl_unlock_action($action);
+		$this->assertSame($mode, $out['mode'], "mode for action '{$action}'");
+	}
+
+	#[DataProvider('provider')]
+	public function testMessage(string $action, string $mode, string $msgPart): void
+	{
+		$out = pfb_dnsbl_unlock_action($action);
+		if ($msgPart === '') {
+			$this->assertSame('', $out['msg'], "unknown action must have an empty message");
+		} else {
+			$this->assertStringContainsString($msgPart, $out['msg']);
+			// The message is a sprintf template carrying exactly one %s for the domain.
+			$this->assertSame('The Domain [ x.example.com ] ' . $this->tail($action), sprintf($out['msg'], 'x.example.com'));
+		}
+	}
+
+	/** Expected post-domain text per action (verifies the %s lands in the right spot). */
+	private function tail(string $action): string
+	{
+		return [
+			'unlock'   => 'has been temporarily Unlocked from DNSBL!',
+			'relock'   => 'has been temporarily Re-Locked into DNSBL!',
+			'lock'     => 'has been Locked into DNSBL!',
+			'reunlock' => 'has been Unlocked from DNSBL!',
+		][$action];
+	}
+
+	public function testUnknownActionIsNoOpShape(): void
+	{
+		// Both keys present and empty so the handler's `mode !== ''` gate + sprintf('')
+		// path are well-defined for any unexpected POST value.
+		$out = pfb_dnsbl_unlock_action('definitely-not-an-action');
+		$this->assertSame(['mode' => '', 'msg' => ''], $out);
+		$this->assertSame('', sprintf($out['msg'], 'x.example.com'));
+	}
+}

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -11,8 +11,14 @@ use PHPUnit\Framework\TestCase;
  * pfb_unbound.py. This pins the parts the issue calls out: format/provenance
  * tagging, the chroot-relative (basename) raw path, and plain-vs-ABP raw
  * extraction. It runs against a temp $pfb sandbox (no live box).
+ *
+ * Also covers the #51 temporary-unlock plumbing: the full build clears
+ * config.user_unlock (Force/Cron re-lock), and pfb_unbound_python_sources_unlock()
+ * recomputes it in place from the live pfb_unlock store (pfb_dnsbl_unlock_lines()).
  */
 #[CoversFunction('pfb_unbound_python_sources')]
+#[CoversFunction('pfb_unbound_python_sources_unlock')]
+#[CoversFunction('pfb_dnsbl_unlock_lines')]
 final class UnboundPythonSourcesTest extends TestCase
 {
 	private string $tmp;
@@ -37,6 +43,7 @@ final class UnboundPythonSourcesTest extends TestCase
 			'dbdir'              => "{$this->tmp}/db",
 			'dnsbl_alexa'        => 'off',
 			'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
+			'dnsbl_unlock'       => "{$this->tmp}/dnsbl_unlock",
 			'dnsblconfig'        => [
 				'tldblacklist' => '',
 				'tldexclusion' => '',
@@ -126,6 +133,7 @@ final class UnboundPythonSourcesTest extends TestCase
 		$this->assertSame([], $m['config']['tld_master']);
 		$this->assertSame([], $m['config']['tld_blacklist']);
 		$this->assertSame([], $m['config']['user_whitelist']);
+		$this->assertSame([], $m['config']['user_unlock']);
 		$this->assertFalse($m['config']['top1m_enabled']);
 	}
 
@@ -134,5 +142,65 @@ final class UnboundPythonSourcesTest extends TestCase
 		$m = pfb_unbound_python_sources($this->feeds());
 		$json = file_get_contents("{$this->tmp}/pfb_py_sources.json");
 		$this->assertSame($m, json_decode($json, true));
+	}
+
+	// #51: a FULL build CLEARS the temporary unlock set even when the live store has
+	// entries -- a Force/Cron deletes the store right after, so baking it in would let
+	// unlocks survive the re-lock. The full build must emit user_unlock => [].
+	public function testFullBuildClearsUserUnlockEvenWithStore(): void
+	{
+		file_put_contents("{$this->tmp}/dnsbl_unlock", "evil.com,python\nfoo.org,python\n");
+		$m = pfb_unbound_python_sources($this->feeds());
+		$this->assertSame([], $m['config']['user_unlock']);
+	}
+
+	// #51: pfb_dnsbl_unlock_lines() reads the pfb_unlock store and returns its domains.
+	public function testDnsblUnlockLinesReadsStoreDomains(): void
+	{
+		file_put_contents("{$this->tmp}/dnsbl_unlock", "evil.com,python\nfoo.org,python\n");
+		$this->assertSame(['evil.com', 'foo.org'], pfb_dnsbl_unlock_lines());
+	}
+
+	public function testDnsblUnlockLinesEmptyWhenStoreAbsent(): void
+	{
+		$this->assertSame([], pfb_dnsbl_unlock_lines());
+	}
+
+	// #51: the incremental path patches ONLY config.user_unlock from the live store,
+	// leaving the rest of the manifest intact.
+	public function testSourcesUnlockRecomputesFromStore(): void
+	{
+		$m = pfb_unbound_python_sources($this->feeds());            // full build: user_unlock => []
+		$this->assertSame([], $m['config']['user_unlock']);
+
+		file_put_contents("{$this->tmp}/dnsbl_unlock", "evil.com,python\nfoo.org,python\n");
+		$this->assertTrue(pfb_unbound_python_sources_unlock());
+
+		$patched = json_decode(file_get_contents("{$this->tmp}/pfb_py_sources.json"), true);
+		$this->assertSame(['evil.com', 'foo.org'], $patched['config']['user_unlock']);
+		// The feeds and the rest of config are untouched by the in-place patch.
+		$this->assertSame($m['feeds'], $patched['feeds']);
+		$this->assertSame($m['config']['user_whitelist'], $patched['config']['user_whitelist']);
+	}
+
+	// A 'lock'/'reunlock' that empties the store re-locks every domain: pfb_unlock
+	// removes the file when empty, so the recompute yields [].
+	public function testSourcesUnlockEmptiesWhenStoreCleared(): void
+	{
+		pfb_unbound_python_sources($this->feeds());
+		file_put_contents("{$this->tmp}/dnsbl_unlock", "evil.com,python\n");
+		pfb_unbound_python_sources_unlock();
+
+		unlink("{$this->tmp}/dnsbl_unlock");           // store emptied (last lock removed it)
+		$this->assertTrue(pfb_unbound_python_sources_unlock());
+		$patched = json_decode(file_get_contents("{$this->tmp}/pfb_py_sources.json"), true);
+		$this->assertSame([], $patched['config']['user_unlock']);
+	}
+
+	public function testSourcesUnlockReturnsFalseWithoutManifest(): void
+	{
+		// No full build ran -> no manifest to patch.
+		$this->assertFileDoesNotExist("{$this->tmp}/pfb_py_sources.json");
+		$this->assertFalse(pfb_unbound_python_sources_unlock());
 	}
 }

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -183,15 +183,18 @@ final class UnboundPythonSourcesTest extends TestCase
 		$this->assertSame($m['config']['user_whitelist'], $patched['config']['user_whitelist']);
 	}
 
-	// A 'lock'/'reunlock' that empties the store re-locks every domain: pfb_unlock
-	// removes the file when empty, so the recompute yields [].
+	// Store deleted => manifest user_unlock cleared. This is BOTH the handler
+	// 'lock'/'reunlock' that empties the store AND the Cron/Force re-lock step the fix
+	// added at inc:3451 (pfb_update_unbound unlinks the store, then calls
+	// pfb_unbound_python_sources_unlock so the reload re-reads a cleared whiteDB). With
+	// the file gone pfb_dnsbl_unlock_lines() yields [] and the recompute empties the key.
 	public function testSourcesUnlockEmptiesWhenStoreCleared(): void
 	{
 		pfb_unbound_python_sources($this->feeds());
 		file_put_contents("{$this->tmp}/dnsbl_unlock", "evil.com,python\n");
 		pfb_unbound_python_sources_unlock();
 
-		unlink("{$this->tmp}/dnsbl_unlock");           // store emptied (last lock removed it)
+		unlink("{$this->tmp}/dnsbl_unlock");           // store emptied (lock / Cron / Force)
 		$this->assertTrue(pfb_unbound_python_sources_unlock());
 		$patched = json_decode(file_get_contents("{$this->tmp}/pfb_py_sources.json"), true);
 		$this->assertSame([], $patched['config']['user_unlock']);

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1115,18 +1115,23 @@ def dnsbl_alert_lock_toggle(vm: SmokeVM, domain: str, action: str, *, timeout: f
     ``pfblockerng.inc`` loaded — driving the SAME functions the handler calls, so
     the smoke test exercises the real #51 path end-to-end rather than a stand-in.
 
-    ``action`` is ``'unlock'`` (temporarily allow — ADDS to the store) or ``'lock'``
-    (re-block — REMOVES from the store). On return Unbound is ready to probe.
+    ``action`` is one of the four icon labels: ``'unlock'`` / ``'relock'`` (temporarily
+    allow — ADD to the store) or ``'lock'`` / ``'reunlock'`` (re-block — REMOVE). The
+    action -> store-mode mapping is resolved on-box by the SAME production helper the
+    handler uses (``pfb_dnsbl_unlock_action``), so this exercises the real dispatch, not
+    a copy of it. On return Unbound is ready to probe.
     """
-    if action not in ("unlock", "lock"):
-        raise ValueError(f"action must be 'unlock' or 'lock', got {action!r}")
-    # Mirror the handler: read the store, toggle it, regenerate user_unlock, reload.
-    # pfb_global() populates $pfb (paths + config) exactly as the page/CLI bootstrap.
+    if action not in ("unlock", "lock", "relock", "reunlock"):
+        raise ValueError(f"action must be one of unlock/lock/relock/reunlock, got {action!r}")
+    # Mirror the handler exactly: resolve the action -> store-mode via the production
+    # pfb_dnsbl_unlock_action(), read the store, toggle it, regenerate user_unlock,
+    # reload. pfb_global() populates $pfb (paths + config) as the page/CLI bootstrap.
     snippet = (
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
         "pfb_global();\n"
+        f"$ua = pfb_dnsbl_unlock_action({_php_str(action)});\n"
         "$u = pfb_unlock('read', 'dnsbl', '', '', '');\n"
-        f"pfb_unlock({_php_str(action)}, 'dnsbl', {_php_str(domain)}, 'python', $u);\n"
+        f"pfb_unlock($ua['mode'], 'dnsbl', {_php_str(domain)}, 'python', $u);\n"
         "pfb_unbound_python_sources_unlock();\n"
         "pfb_reload_unbound('enabled', FALSE);\n"
         "echo 'OK';"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -907,6 +907,23 @@ def reset(vm: SmokeVM, *, timeout: float = 600.0) -> None:
     reload(vm, "update", timeout=timeout)
 
 
+def force_dnsbl_rebuild(vm: SmokeVM, *, timeout: float = 600.0) -> None:
+    """Force a full DNSBL re-fetch + manifest rebuild + Unbound reload (Force-Reload).
+
+    A plain ``reload('update')`` honours the feed cache: an unchanged, still-cached
+    feed logs ``[ feed ] exists.`` and pfBlockerNG does NOT reprocess it or reload
+    Unbound (verified on the live box). So an ``update`` alone never regenerates the
+    manifest and never clears a temporary unlock. Clearing the DNSBL cache first
+    (``cleardnsbl``) forces the re-fetch -> ``pfb_unbound_python_sources`` rewrites the
+    manifest (``config.user_unlock`` emptied) -> Unbound reloads -> ``init_standard``
+    re-reads it. This is exactly what ``reset()`` relies on to rebuild deterministically.
+    """
+    result = vm.ssh(PHP_BIN, PFB_CLI, "cleardnsbl", timeout=120.0)
+    if result.returncode != 0:
+        raise RuntimeError(f"force_dnsbl_rebuild cleardnsbl failed: rc={result.returncode} stderr={result.stderr!r}")
+    reload(vm, "update", timeout=timeout)
+
+
 UNBOUND_CONF = "/var/unbound/unbound.conf"
 UNBOUND_BEFORE = "/tmp/pfb_unbound_before.conf"
 # Snapshot of the EFFECTIVE unbound config (unbound.conf + every file it pulls in

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1144,6 +1144,12 @@ def dnsbl_alert_lock_toggle(vm: SmokeVM, domain: str, action: str, *, timeout: f
         )
     # pfb_reload_unbound restarts Unbound — wait for readiness before any probe.
     wait_unbound_ready(vm)
+    # Parity with the production dnsbl_remove handler, which flushes the resolver cache
+    # on an Unlock. The restart above already clears the whole cache, so this is
+    # belt-and-suspenders (defensive against a future non-restart reload) — matching the
+    # handler's unlock-only flush so the helper mirrors production behaviour.
+    if action == "unlock":
+        flush_unbound_cache(vm)
 
 
 def flush_unbound_cache(vm: SmokeVM, *, timeout: float = 30.0) -> None:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -907,23 +907,6 @@ def reset(vm: SmokeVM, *, timeout: float = 600.0) -> None:
     reload(vm, "update", timeout=timeout)
 
 
-def force_dnsbl_rebuild(vm: SmokeVM, *, timeout: float = 600.0) -> None:
-    """Force a full DNSBL re-fetch + manifest rebuild + Unbound reload (Force-Reload).
-
-    A plain ``reload('update')`` honours the feed cache: an unchanged, still-cached
-    feed logs ``[ feed ] exists.`` and pfBlockerNG does NOT reprocess it or reload
-    Unbound (verified on the live box). So an ``update`` alone never regenerates the
-    manifest and never clears a temporary unlock. Clearing the DNSBL cache first
-    (``cleardnsbl``) forces the re-fetch -> ``pfb_unbound_python_sources`` rewrites the
-    manifest (``config.user_unlock`` emptied) -> Unbound reloads -> ``init_standard``
-    re-reads it. This is exactly what ``reset()`` relies on to rebuild deterministically.
-    """
-    result = vm.ssh(PHP_BIN, PFB_CLI, "cleardnsbl", timeout=120.0)
-    if result.returncode != 0:
-        raise RuntimeError(f"force_dnsbl_rebuild cleardnsbl failed: rc={result.returncode} stderr={result.stderr!r}")
-    reload(vm, "update", timeout=timeout)
-
-
 UNBOUND_CONF = "/var/unbound/unbound.conf"
 UNBOUND_BEFORE = "/tmp/pfb_unbound_before.conf"
 # Snapshot of the EFFECTIVE unbound config (unbound.conf + every file it pulls in

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1103,6 +1103,44 @@ def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 30, delay: float = 2.0) -
     raise RuntimeError("Unbound did not become ready after reload")
 
 
+def dnsbl_alert_lock_toggle(vm: SmokeVM, domain: str, action: str, *, timeout: float = 300.0) -> None:
+    """Drive the alerts-page temporary Lock/Unlock for a DNSBL ``domain`` (#51).
+
+    The per-alert temporary Unlock/Lock has NO CLI verb — it is the
+    ``pfblockerng_alerts.php`` ``dnsbl_remove`` web handler. On ``next`` (python
+    mode) that handler toggles the ``pfb_unlock`` state store
+    (``$pfb['dnsbl_unlock']``), regenerates the manifest's ``config.user_unlock``
+    (a band-6 whiteDB allow), then reloads Unbound. We replay that EXACT production
+    sequence over ``pfSsh.php`` (the fully-bootstrapped pfSense shell) with
+    ``pfblockerng.inc`` loaded — driving the SAME functions the handler calls, so
+    the smoke test exercises the real #51 path end-to-end rather than a stand-in.
+
+    ``action`` is ``'unlock'`` (temporarily allow — ADDS to the store) or ``'lock'``
+    (re-block — REMOVES from the store). On return Unbound is ready to probe.
+    """
+    if action not in ("unlock", "lock"):
+        raise ValueError(f"action must be 'unlock' or 'lock', got {action!r}")
+    # Mirror the handler: read the store, toggle it, regenerate user_unlock, reload.
+    # pfb_global() populates $pfb (paths + config) exactly as the page/CLI bootstrap.
+    snippet = (
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "pfb_global();\n"
+        "$u = pfb_unlock('read', 'dnsbl', '', '', '');\n"
+        f"pfb_unlock({_php_str(action)}, 'dnsbl', {_php_str(domain)}, 'python', $u);\n"
+        "pfb_unbound_python_sources_unlock();\n"
+        "pfb_reload_unbound('enabled', FALSE);\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"dnsbl_alert_lock_toggle({domain}, {action}) failed: "
+            f"rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+    # pfb_reload_unbound restarts Unbound — wait for readiness before any probe.
+    wait_unbound_ready(vm)
+
+
 def flush_unbound_cache(vm: SmokeVM, *, timeout: float = 30.0) -> None:
     """Flush Unbound's whole cache so the NEXT probe is evaluated FRESH by the module.
 

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -382,20 +382,17 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(deployed_vm: SmokeVM, mock_
 
 
 def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
-    """#51: a temporary Unlock is dropped by a full update that REBUILDS the DNSBL —
-    the documented "re-locked on Cron/Force ... with an Unbound Reload" semantic.
+    """#51: a temporary Unlock is re-locked by a Cron/Force update — even with NO feed
+    change (parity with main).
 
-    A DNSBL-rebuilding ``update`` writes a fresh manifest with an EMPTY
-    ``config.user_unlock`` (the full build never bakes the live store in) and reloads
-    Unbound, so the python ``init_standard`` re-reads the cleared manifest and the
-    domain is re-blocked. This pins the full-build-clears-user_unlock half of the fix.
-
-    The reload is load-bearing and conditional: a no-change ``update`` detects the feed
-    as unchanged (``[ feed ] exists.``), does NOT reload Unbound, and therefore does
-    NOT re-lock — store, manifest and running state all stay "unlocked" together
-    (consistent; this is legacy behaviour the tooltip documents, verified on the live
-    box). ``force_dnsbl_rebuild`` (``cleardnsbl`` + ``update``) clears the feed cache so
-    the rebuild + reload actually happens — the Force-Reload path.
+    A pending temporary-unlock store forces the reload path regardless of feed changes
+    (``inc:8806`` ``|| file_exists($pfb['dnsbl_unlock'])``); that path drops the store
+    and clears the manifest's ``config.user_unlock`` (``inc:3451`` ->
+    ``pfb_unbound_python_sources_unlock``), so Unbound's ``init_standard`` re-reads a
+    cleared whiteDB and the domain is re-blocked. On ``main`` the equivalent re-lock is
+    the ungated whitelist regeneration; before this fix devel only cleared ``user_unlock``
+    on a feed-change rebuild, so a no-change Force left the unlock live (the regression
+    this run caught). A plain ``update`` over the UNCHANGED feed is therefore enough.
     """
     domain = h.unique_domain("unlocktmp")
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlocktmp.txt", f"{domain}\n")
@@ -403,7 +400,7 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
     # local-data before the python module); an allowed name resolves via the stub.
     spec = h.DnsblCase(aliasname="smokeunlocktmp", feed_url=feed_url, header="smokeunlocktmp", mode=h.DnsblMode.VIP)
     with h.CaseContext(deployed_vm, spec):
-        # Egress OPEN: the rebuild path deadlocks under a dark egress, and the allowed
+        # Egress OPEN: the update path deadlocks under a dark egress, and the allowed
         # (unlock) probe must reach the controlled stub. The block probes return the VIP
         # locally, so there is no false-green from leaving egress open.
         h.unblock_egress()
@@ -415,11 +412,11 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
         unlocked = h.dns_probe(deployed_vm, domain, "A")
         assert h.resolves_to(unlocked, STUB_DNS_A), f"unlocked {domain} should resolve via stub, got {unlocked}"
         assert not h.is_vip(unlocked), f"unlocked {domain} still VIP-blocked: {unlocked}"
-        # Force a full DNSBL rebuild (clear cache + update) so the manifest is
-        # regenerated (user_unlock emptied) and Unbound reloads -> the domain re-locks.
-        h.force_dnsbl_rebuild(deployed_vm)
+        # A Cron/Force update over the UNCHANGED feed re-locks it: the pending unlock
+        # store forces the reload + clears the manifest's user_unlock.
+        h.reload(deployed_vm, "update")
         relocked = h.dns_probe(deployed_vm, domain, "A")
-        assert h.is_vip(relocked), f"force rebuild should re-lock {domain} -> VIP, got {relocked}"
+        assert h.is_vip(relocked), f"Cron/Force update should re-lock {domain} -> VIP, got {relocked}"
         assert not h.resolves_to(relocked, STUB_DNS_A), f"re-locked {domain} still resolving: {relocked}"
 
 

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -393,20 +393,19 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
     The reload is load-bearing and conditional: a no-change ``update`` detects the feed
     as unchanged (``[ feed ] exists.``), does NOT reload Unbound, and therefore does
     NOT re-lock — store, manifest and running state all stay "unlocked" together
-    (consistent; this is legacy behaviour the tooltip documents). So we EDIT the feed
-    first to force a genuine DNSBL change, making the full update actually rebuild +
-    reload — the common Cron case.
+    (consistent; this is legacy behaviour the tooltip documents, verified on the live
+    box). ``force_dnsbl_rebuild`` (``cleardnsbl`` + ``update``) clears the feed cache so
+    the rebuild + reload actually happens — the Force-Reload path.
     """
     domain = h.unique_domain("unlocktmp")
-    feed_name = "smoke_dnsbl_unlocktmp.txt"
-    feed_url = h.write_local_feed(deployed_vm, feed_name, f"{domain}\n")
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlocktmp.txt", f"{domain}\n")
     # No host override on the name — it would shadow the DNSBL block (served as
     # local-data before the python module); an allowed name resolves via the stub.
     spec = h.DnsblCase(aliasname="smokeunlocktmp", feed_url=feed_url, header="smokeunlocktmp", mode=h.DnsblMode.VIP)
     with h.CaseContext(deployed_vm, spec):
-        # Egress OPEN: the full update path deadlocks under a dark egress, and the
-        # allowed (unlock) probe must reach the controlled stub. The block probes
-        # return the VIP locally, so there is no false-green from leaving egress open.
+        # Egress OPEN: the rebuild path deadlocks under a dark egress, and the allowed
+        # (unlock) probe must reach the controlled stub. The block probes return the VIP
+        # locally, so there is no false-green from leaving egress open.
         h.unblock_egress()
         # Blocked by the feed -> VIP (the "before" of the Unlock operation).
         blocked = h.dns_probe(deployed_vm, domain, "A")
@@ -416,12 +415,11 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
         unlocked = h.dns_probe(deployed_vm, domain, "A")
         assert h.resolves_to(unlocked, STUB_DNS_A), f"unlocked {domain} should resolve via stub, got {unlocked}"
         assert not h.is_vip(unlocked), f"unlocked {domain} still VIP-blocked: {unlocked}"
-        # Edit the feed (add a domain) so the full update sees a REAL DNSBL change and
-        # rebuilds + reloads — a no-change update would not reload, so would not re-lock.
-        h.write_local_feed(deployed_vm, feed_name, f"{domain}\n{h.unique_domain('forcechange')}\n")
-        h.reload(deployed_vm, "update")
+        # Force a full DNSBL rebuild (clear cache + update) so the manifest is
+        # regenerated (user_unlock emptied) and Unbound reloads -> the domain re-locks.
+        h.force_dnsbl_rebuild(deployed_vm)
         relocked = h.dns_probe(deployed_vm, domain, "A")
-        assert h.is_vip(relocked), f"force update (with rebuild) should re-lock {domain} -> VIP, got {relocked}"
+        assert h.is_vip(relocked), f"force rebuild should re-lock {domain} -> VIP, got {relocked}"
         assert not h.resolves_to(relocked, STUB_DNS_A), f"re-locked {domain} still resolving: {relocked}"
 
 

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -63,7 +63,7 @@ from collections.abc import Iterator
 import pytest
 
 from . import helpers as h
-from .conftest import SmokeVM, _MockFeedServer, _StubDnsServer
+from .conftest import STUB_DNS_A, SmokeVM, _MockFeedServer, _StubDnsServer
 
 pytestmark = pytest.mark.smoke
 
@@ -329,59 +329,56 @@ def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, mock_feeds: _MockFeed
 def test_dnsbl_resolve_block_unlock_relock_lifecycle(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """#51 FULL lifecycle, asserting the ACTUAL resolution at every transition:
 
-      (a) BEFORE any list  -> the domain RESOLVES (to its control answer);
+      (a) BEFORE any list  -> the domain RESOLVES (forwarded to the stub sentinel);
       (b) added to a feed  -> BLOCKED (VIP), no longer resolves;
-      (c) temporary Unlock -> RESOLVES again (to the control answer);
+      (c) temporary Unlock -> RESOLVES again (forwarded to the stub sentinel);
       (d) re-Lock          -> BLOCKED again (VIP).
 
-    Proving the domain resolves in (a) and again in (c) rules out a false-green:
-    the VIP in (b)/(d) genuinely comes from the feed block, and the pass in (c)
-    genuinely comes from the Unlock — not from some unrelated state. The Unlock/Lock
-    drives the real python-mode pfblockerng_alerts.php ``dnsbl_remove`` sequence
-    (toggle the ``pfb_unlock`` store -> regenerate ``config.user_unlock`` -> reload).
-    Before the #51 fix step (c) was a NO-OP (it wrote files the manifest build no
-    longer reads), so the domain stayed VIP-blocked.
+    Proving the domain resolves in (a) and again in (c) rules out a false-green: the
+    VIP in (b)/(d) genuinely comes from the feed block, and the pass in (c) genuinely
+    comes from the Unlock. The Unlock/Lock drives the real python-mode
+    pfblockerng_alerts.php ``dnsbl_remove`` sequence (toggle the ``pfb_unlock`` store ->
+    regenerate ``config.user_unlock`` -> RESTART Unbound, whose python ``init_standard``
+    re-reads the manifest). Before the #51 fix step (c) was a NO-OP (it wrote files the
+    manifest build no longer reads), so the domain stayed VIP-blocked.
 
-    VIP-mode feed so the block shape is the VIP (distinct from a NULL); a control
-    host override gives the domain a real pass IP to resolve to in (a)/(c).
+    NOTE: NO ``control_local_data`` host override on the name. A host override is served
+    by Unbound as ``local-data`` BEFORE the python module runs, so it would shadow the
+    DNSBL block (the name would resolve to the override even in step (b)). An *allowed*
+    name therefore resolves via the controlled stub upstream (``STUB_DNS_A``) — exactly
+    how ``test_dns_probe_absent_resolves_via_stub`` proves a real pass. Egress is left
+    OPEN in the body so the allowed probes reach the (SLIRP-local, controlled) stub;
+    the block probes return the VIP locally, so there is no false-green from egress.
     """
     domain = h.unique_domain("unlock")
-    pass_ip = "198.51.100.88"
 
-    # (a) BEFORE any blocklist: register the host override and confirm the domain
-    #     resolves to it (a real, observable baseline — not yet on any feed).
-    h.set_control_records(deployed_vm, {domain: {"A": pass_ip}}, {})
-    h.wait_unbound_ready(deployed_vm)
+    # (a) BEFORE any blocklist: forwarded to the controlled stub -> resolves to the
+    #     sentinel (a real, observable baseline — not yet on any feed, not blocked).
     before = h.dns_probe(deployed_vm, domain, "A")
-    assert h.resolves_to(before, pass_ip), f"{domain} should resolve to {pass_ip} BEFORE listing, got {before}"
-    assert not h.is_vip(before), f"{domain} unexpectedly VIP-blocked before any feed: {before}"
+    assert h.resolves_to(before, STUB_DNS_A), f"{domain} should resolve via stub BEFORE listing, got {before}"
+    assert not h.is_vip(before) and not h.is_null_ip(before), f"{domain} unexpectedly blocked before any feed: {before}"
 
     # (b) Now put it on a DNSBL feed -> the SAME domain is now BLOCKED (VIP).
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlock.txt", f"{domain}\n")
-    spec = h.DnsblCase(
-        aliasname="smokeunlock",
-        feed_url=feed_url,
-        header="smokeunlock",
-        mode=h.DnsblMode.VIP,
-        control_local_data={domain: {"A": pass_ip}},
-    )
+    spec = h.DnsblCase(aliasname="smokeunlock", feed_url=feed_url, header="smokeunlock", mode=h.DnsblMode.VIP)
     with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()  # the allowed probes (a-shape) must reach the controlled stub
         blocked = h.dns_probe(deployed_vm, domain, "A")
         assert h.is_vip(blocked), f"{domain} expected VIP block once listed, got {blocked}"
-        assert not h.resolves_to(blocked, pass_ip), f"{domain} still resolving to {pass_ip} after block: {blocked}"
+        assert not h.resolves_to(blocked, STUB_DNS_A), f"{domain} still resolving after block: {blocked}"
 
-        # (c) Temporary Unlock -> resolves to its control answer again (a real pass).
+        # (c) Temporary Unlock -> resolves again (forwarded to the stub sentinel).
         #     A VIP here would be the #51 no-op (unlock never reaching the build).
         h.dnsbl_alert_lock_toggle(deployed_vm, domain, "unlock")
         unlocked = h.dns_probe(deployed_vm, domain, "A")
-        assert h.resolves_to(unlocked, pass_ip), f"unlocked {domain} should resolve to {pass_ip}, got {unlocked}"
+        assert h.resolves_to(unlocked, STUB_DNS_A), f"unlocked {domain} should resolve via stub, got {unlocked}"
         assert not h.is_vip(unlocked), f"unlocked {domain} still VIP-blocked (the #51 no-op): {unlocked}"
 
         # (d) Re-Lock -> the temporary allow is removed: blocked again (VIP).
         h.dnsbl_alert_lock_toggle(deployed_vm, domain, "lock")
         relocked = h.dns_probe(deployed_vm, domain, "A")
         assert h.is_vip(relocked), f"re-locked {domain} expected VIP block again, got {relocked}"
-        assert not h.resolves_to(relocked, pass_ip), f"re-locked {domain} still resolving to {pass_ip}: {relocked}"
+        assert not h.resolves_to(relocked, STUB_DNS_A), f"re-locked {domain} still resolving: {relocked}"
 
 
 def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
@@ -395,33 +392,28 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
     Force/Cron reload).
     """
     domain = h.unique_domain("unlocktmp")
-    pass_ip = "198.51.100.89"
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlocktmp.txt", f"{domain}\n")
-    spec = h.DnsblCase(
-        aliasname="smokeunlocktmp",
-        feed_url=feed_url,
-        header="smokeunlocktmp",
-        mode=h.DnsblMode.VIP,
-        control_local_data={domain: {"A": pass_ip}},
-    )
+    # No host override on the name — it would shadow the DNSBL block (served as
+    # local-data before the python module); an allowed name resolves via the stub.
+    spec = h.DnsblCase(aliasname="smokeunlocktmp", feed_url=feed_url, header="smokeunlocktmp", mode=h.DnsblMode.VIP)
     with h.CaseContext(deployed_vm, spec):
+        # Egress OPEN: the full update path deadlocks under a dark egress, and the
+        # allowed (unlock) probe must reach the controlled stub. The block probes
+        # return the VIP locally, so there is no false-green from leaving egress open.
+        h.unblock_egress()
         # Blocked by the feed -> VIP (the "before" of the Unlock operation).
         blocked = h.dns_probe(deployed_vm, domain, "A")
         assert h.is_vip(blocked), f"{domain} expected VIP block, got {blocked}"
-        # Unlock -> resolves to the control answer.
+        # Unlock -> resolves again (forwarded to the stub sentinel).
         h.dnsbl_alert_lock_toggle(deployed_vm, domain, "unlock")
         unlocked = h.dns_probe(deployed_vm, domain, "A")
-        assert h.resolves_to(unlocked, pass_ip), f"unlocked {domain} should resolve to {pass_ip}, got {unlocked}"
+        assert h.resolves_to(unlocked, STUB_DNS_A), f"unlocked {domain} should resolve via stub, got {unlocked}"
         assert not h.is_vip(unlocked), f"unlocked {domain} still VIP-blocked: {unlocked}"
         # A full Force Update re-locks it (store deleted, manifest user_unlock empty).
-        # Egress must be OPEN for the full update path (it deadlocks under a dark
-        # egress); the re-locked probe resolves LOCALLY (the python block), so it
-        # stays hermetic regardless.
-        h.unblock_egress()
         h.reload(deployed_vm, "update")
         relocked = h.dns_probe(deployed_vm, domain, "A")
         assert h.is_vip(relocked), f"force update should re-lock {domain} -> VIP, got {relocked}"
-        assert not h.resolves_to(relocked, pass_ip), f"re-locked {domain} still resolving to {pass_ip}: {relocked}"
+        assert not h.resolves_to(relocked, STUB_DNS_A), f"re-locked {domain} still resolving: {relocked}"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -382,17 +382,24 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(deployed_vm: SmokeVM, mock_
 
 
 def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
-    """#51: a temporary Unlock is dropped by a full update — the documented
-    "re-locked on Cron/Force" semantic.
+    """#51: a temporary Unlock is dropped by a full update that REBUILDS the DNSBL —
+    the documented "re-locked on Cron/Force ... with an Unbound Reload" semantic.
 
-    A full ``update`` deletes the ``pfb_unlock`` store (``pfb_update_unbound``) and
-    the rebuilt manifest emits an EMPTY ``config.user_unlock``, so every temporary
-    unlock is re-locked. This pins the full-build-clears-user_unlock half of the fix
-    (the full build must NOT bake the live store in, or unlocks would survive the
-    Force/Cron reload).
+    A DNSBL-rebuilding ``update`` writes a fresh manifest with an EMPTY
+    ``config.user_unlock`` (the full build never bakes the live store in) and reloads
+    Unbound, so the python ``init_standard`` re-reads the cleared manifest and the
+    domain is re-blocked. This pins the full-build-clears-user_unlock half of the fix.
+
+    The reload is load-bearing and conditional: a no-change ``update`` detects the feed
+    as unchanged (``[ feed ] exists.``), does NOT reload Unbound, and therefore does
+    NOT re-lock — store, manifest and running state all stay "unlocked" together
+    (consistent; this is legacy behaviour the tooltip documents). So we EDIT the feed
+    first to force a genuine DNSBL change, making the full update actually rebuild +
+    reload — the common Cron case.
     """
     domain = h.unique_domain("unlocktmp")
-    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlocktmp.txt", f"{domain}\n")
+    feed_name = "smoke_dnsbl_unlocktmp.txt"
+    feed_url = h.write_local_feed(deployed_vm, feed_name, f"{domain}\n")
     # No host override on the name — it would shadow the DNSBL block (served as
     # local-data before the python module); an allowed name resolves via the stub.
     spec = h.DnsblCase(aliasname="smokeunlocktmp", feed_url=feed_url, header="smokeunlocktmp", mode=h.DnsblMode.VIP)
@@ -409,10 +416,12 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
         unlocked = h.dns_probe(deployed_vm, domain, "A")
         assert h.resolves_to(unlocked, STUB_DNS_A), f"unlocked {domain} should resolve via stub, got {unlocked}"
         assert not h.is_vip(unlocked), f"unlocked {domain} still VIP-blocked: {unlocked}"
-        # A full Force Update re-locks it (store deleted, manifest user_unlock empty).
+        # Edit the feed (add a domain) so the full update sees a REAL DNSBL change and
+        # rebuilds + reloads — a no-change update would not reload, so would not re-lock.
+        h.write_local_feed(deployed_vm, feed_name, f"{domain}\n{h.unique_domain('forcechange')}\n")
         h.reload(deployed_vm, "update")
         relocked = h.dns_probe(deployed_vm, domain, "A")
-        assert h.is_vip(relocked), f"force update should re-lock {domain} -> VIP, got {relocked}"
+        assert h.is_vip(relocked), f"force update (with rebuild) should re-lock {domain} -> VIP, got {relocked}"
         assert not h.resolves_to(relocked, STUB_DNS_A), f"re-locked {domain} still resolving: {relocked}"
 
 

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -326,6 +326,104 @@ def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, mock_feeds: _MockFeed
         assert not h.is_null_ip(answer), f"whitelisted {domain} wrongly null-IP: {answer}"
 
 
+def test_dnsbl_resolve_block_unlock_relock_lifecycle(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """#51 FULL lifecycle, asserting the ACTUAL resolution at every transition:
+
+      (a) BEFORE any list  -> the domain RESOLVES (to its control answer);
+      (b) added to a feed  -> BLOCKED (VIP), no longer resolves;
+      (c) temporary Unlock -> RESOLVES again (to the control answer);
+      (d) re-Lock          -> BLOCKED again (VIP).
+
+    Proving the domain resolves in (a) and again in (c) rules out a false-green:
+    the VIP in (b)/(d) genuinely comes from the feed block, and the pass in (c)
+    genuinely comes from the Unlock — not from some unrelated state. The Unlock/Lock
+    drives the real python-mode pfblockerng_alerts.php ``dnsbl_remove`` sequence
+    (toggle the ``pfb_unlock`` store -> regenerate ``config.user_unlock`` -> reload).
+    Before the #51 fix step (c) was a NO-OP (it wrote files the manifest build no
+    longer reads), so the domain stayed VIP-blocked.
+
+    VIP-mode feed so the block shape is the VIP (distinct from a NULL); a control
+    host override gives the domain a real pass IP to resolve to in (a)/(c).
+    """
+    domain = h.unique_domain("unlock")
+    pass_ip = "198.51.100.88"
+
+    # (a) BEFORE any blocklist: register the host override and confirm the domain
+    #     resolves to it (a real, observable baseline — not yet on any feed).
+    h.set_control_records(deployed_vm, {domain: {"A": pass_ip}}, {})
+    h.wait_unbound_ready(deployed_vm)
+    before = h.dns_probe(deployed_vm, domain, "A")
+    assert h.resolves_to(before, pass_ip), f"{domain} should resolve to {pass_ip} BEFORE listing, got {before}"
+    assert not h.is_vip(before), f"{domain} unexpectedly VIP-blocked before any feed: {before}"
+
+    # (b) Now put it on a DNSBL feed -> the SAME domain is now BLOCKED (VIP).
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlock.txt", f"{domain}\n")
+    spec = h.DnsblCase(
+        aliasname="smokeunlock",
+        feed_url=feed_url,
+        header="smokeunlock",
+        mode=h.DnsblMode.VIP,
+        control_local_data={domain: {"A": pass_ip}},
+    )
+    with h.CaseContext(deployed_vm, spec):
+        blocked = h.dns_probe(deployed_vm, domain, "A")
+        assert h.is_vip(blocked), f"{domain} expected VIP block once listed, got {blocked}"
+        assert not h.resolves_to(blocked, pass_ip), f"{domain} still resolving to {pass_ip} after block: {blocked}"
+
+        # (c) Temporary Unlock -> resolves to its control answer again (a real pass).
+        #     A VIP here would be the #51 no-op (unlock never reaching the build).
+        h.dnsbl_alert_lock_toggle(deployed_vm, domain, "unlock")
+        unlocked = h.dns_probe(deployed_vm, domain, "A")
+        assert h.resolves_to(unlocked, pass_ip), f"unlocked {domain} should resolve to {pass_ip}, got {unlocked}"
+        assert not h.is_vip(unlocked), f"unlocked {domain} still VIP-blocked (the #51 no-op): {unlocked}"
+
+        # (d) Re-Lock -> the temporary allow is removed: blocked again (VIP).
+        h.dnsbl_alert_lock_toggle(deployed_vm, domain, "lock")
+        relocked = h.dns_probe(deployed_vm, domain, "A")
+        assert h.is_vip(relocked), f"re-locked {domain} expected VIP block again, got {relocked}"
+        assert not h.resolves_to(relocked, pass_ip), f"re-locked {domain} still resolving to {pass_ip}: {relocked}"
+
+
+def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """#51: a temporary Unlock is dropped by a full update — the documented
+    "re-locked on Cron/Force" semantic.
+
+    A full ``update`` deletes the ``pfb_unlock`` store (``pfb_update_unbound``) and
+    the rebuilt manifest emits an EMPTY ``config.user_unlock``, so every temporary
+    unlock is re-locked. This pins the full-build-clears-user_unlock half of the fix
+    (the full build must NOT bake the live store in, or unlocks would survive the
+    Force/Cron reload).
+    """
+    domain = h.unique_domain("unlocktmp")
+    pass_ip = "198.51.100.89"
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlocktmp.txt", f"{domain}\n")
+    spec = h.DnsblCase(
+        aliasname="smokeunlocktmp",
+        feed_url=feed_url,
+        header="smokeunlocktmp",
+        mode=h.DnsblMode.VIP,
+        control_local_data={domain: {"A": pass_ip}},
+    )
+    with h.CaseContext(deployed_vm, spec):
+        # Blocked by the feed -> VIP (the "before" of the Unlock operation).
+        blocked = h.dns_probe(deployed_vm, domain, "A")
+        assert h.is_vip(blocked), f"{domain} expected VIP block, got {blocked}"
+        # Unlock -> resolves to the control answer.
+        h.dnsbl_alert_lock_toggle(deployed_vm, domain, "unlock")
+        unlocked = h.dns_probe(deployed_vm, domain, "A")
+        assert h.resolves_to(unlocked, pass_ip), f"unlocked {domain} should resolve to {pass_ip}, got {unlocked}"
+        assert not h.is_vip(unlocked), f"unlocked {domain} still VIP-blocked: {unlocked}"
+        # A full Force Update re-locks it (store deleted, manifest user_unlock empty).
+        # Egress must be OPEN for the full update path (it deadlocks under a dark
+        # egress); the re-locked probe resolves LOCALLY (the python block), so it
+        # stays hermetic regardless.
+        h.unblock_egress()
+        h.reload(deployed_vm, "update")
+        relocked = h.dns_probe(deployed_vm, domain, "A")
+        assert h.is_vip(relocked), f"force update should re-lock {domain} -> VIP, got {relocked}"
+        assert not h.resolves_to(relocked, pass_ip), f"re-locked {domain} still resolving to {pass_ip}: {relocked}"
+
+
 # --------------------------------------------------------------------------- #
 # 3) DNSBL-IP dual-stack — two distinct pf tables, partitioned by family
 # --------------------------------------------------------------------------- #

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -421,3 +421,56 @@ class TestTldMasterPath:
         # Reach into the helper that shapes config so the list path is exercised.
         config = pfb_unbound._dnsbl_config_from_manifest(manifest, FIXTURES)
         assert config["tld_master"] == _read_lines("tld_master.txt")
+
+
+class TestUserUnlockManifest:
+    """#51: config.user_unlock (the temporary per-alert unlock set) is passed through
+    _dnsbl_config_from_manifest and merged into whiteDB by the on-box build path."""
+
+    def test_user_unlock_passes_through_config_shaper(self) -> None:
+        manifest = {
+            "version": 1,
+            "config": {
+                "tld_master": [],
+                "user_unlock": ["evil.com", ".wild.net"],
+            },
+            "feeds": [],
+        }
+        config = pfb_unbound._dnsbl_config_from_manifest(manifest, FIXTURES)
+        assert config["user_unlock"] == ["evil.com", ".wild.net"]
+
+    def test_user_unlock_defaults_empty_when_absent(self) -> None:
+        config = pfb_unbound._dnsbl_config_from_manifest({"config": {}}, FIXTURES)
+        assert config["user_unlock"] == []
+
+    def test_user_unlock_merges_into_white_db(self, tmp_path: Any) -> None:
+        # End-to-end through dnsbl_build_from_manifest: a feed blocks evil.com; the
+        # temporary unlock makes it resolve (band-6 user allow in whiteDB).
+        feed = os.path.join(str(tmp_path), "feed.raw")
+        with open(feed, "w", encoding="utf-8") as fh:
+            fh.write("evil.com\n")
+        manifest = {
+            "version": 1,
+            "config": {
+                "tld_master": _read_lines("tld_master.txt"),
+                "user_unlock": ["evil.com"],
+            },
+            "feeds": [{"raw": "feed.raw", "feed": "F", "group": "G", "format_hint": "plain", "log_flag": "1"}],
+        }
+        path = os.path.join(str(tmp_path), "pfb_py_sources.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(manifest, fh)
+
+        result = pfb_unbound.dnsbl_build_from_manifest(path)
+        assert result is not None
+        assert result.white_db["evil.com"] == {
+            "wildcard": False,
+            "important": True,
+            "band": pfb_unbound.PRIO_USER_ALLOW,
+        }
+        # The feed still records the block (evil.com is a registrable zone); the
+        # allow overrides it at query time.
+        assert "evil.com" in result.zone_db
+        config = pfb_unbound._dnsbl_config_from_manifest(manifest, str(tmp_path))
+        got = _evaluate_result(result, {**config, "hsts_domains": []}, "evil.com")
+        assert got["decision"] == "whitelist"

--- a/tests/test_adr07_emit_wire.py
+++ b/tests/test_adr07_emit_wire.py
@@ -258,6 +258,20 @@ class TestUserUnlock:
         res = _build({"f": ["||evil.com^"]}, user_unlock=[])
         assert _live_label(res, "evil.com") == "block"
 
+    def test_unlock_does_not_narrow_wildcard_whitelist(self) -> None:
+        # CodeRabbit #65: a permanent WILDCARD whitelist (".evil.com" -> covers
+        # subdomains) must NOT be downgraded to exact when the same registrable domain
+        # is temporarily unlocked (exact). The merge widens on collision, so both the
+        # apex and a subdomain still resolve.
+        res = _build(
+            {"f": ["||evil.com^", "||sub.evil.com^"]},
+            user_whitelist=[".evil.com"],
+            user_unlock=["evil.com"],
+        )
+        assert res.white_db["evil.com"]["wildcard"] is True
+        assert _live_label(res, "evil.com") == "resolve"
+        assert _live_label(res, "sub.evil.com") == "resolve"
+
 
 # --------------------------------------------------------------------------- #
 # 3. ON -- the live 6-band matcher == the Phase-2 oracle decide()

--- a/tests/test_adr07_emit_wire.py
+++ b/tests/test_adr07_emit_wire.py
@@ -35,6 +35,7 @@ def _build(
     feeds: dict[str, list[str]],
     *,
     user_whitelist: Iterable[str] = (),
+    user_unlock: Iterable[str] = (),
     top1m_list: Iterable[str] = (),
     top1m_enabled: bool = False,
     format_hint: str = "abp",
@@ -46,6 +47,8 @@ def _build(
     ``user_feeds`` names the feeds tagged provenance='user' (a DNSBL Group Custom_List,
     sovereign band 5); ``plain_feeds`` names those forced format_hint='plain' (the
     non-ABP path), so a mixed user-plain + downloaded-ABP manifest can be built.
+    ``user_unlock`` is the temporary per-alert unlock set (#51), merged into whiteDB
+    as band-6 user allows exactly like ``user_whitelist``.
     """
     raw_store = {name: lines for name, lines in feeds.items()}
     user_set = set(user_feeds)
@@ -68,6 +71,7 @@ def _build(
         "tld_blacklist": [],
         "tld_exclusion": [],
         "user_whitelist": list(user_whitelist),
+        "user_unlock": list(user_unlock),
         "top1m_list": list(top1m_list),
     }
 
@@ -213,6 +217,46 @@ class TestFastPathOff:
         feeds = {"f": ["||evil.com^", "good.com"]}
         for q in ("evil.com", "sub.evil.com", "good.com", "unrelated.org"):
             assert _live_label(_build(feeds), q) == _oracle_label(feeds, [], q)
+
+
+# --------------------------------------------------------------------------- #
+# 2b. #51 -- the temporary per-alert unlock set (config.user_unlock) merges into
+#     whiteDB as a band-6 user allow, exactly like the permanent user whitelist.
+# --------------------------------------------------------------------------- #
+class TestUserUnlock:
+    def test_unlock_overrides_feed_block_on_fast_path(self) -> None:
+        # A temporary unlock alone (no abp feature) stays on the fast path and
+        # un-blocks the domain, just like a permanent user whitelist entry.
+        res = _build({"f": ["||evil.com^"]}, user_unlock=["evil.com"])
+        assert res.important_rules is False
+        assert _live_label(res, "evil.com") == "resolve"
+
+    def test_unlock_is_band6_important_allow(self) -> None:
+        # Same whiteDB shape as the user whitelist: sovereign user allow (band 6).
+        res = _build({"f": ["||evil.com^"]}, user_unlock=["evil.com"])
+        assert res.white_db["evil.com"] == {
+            "wildcard": False,
+            "important": True,
+            "band": P.PRIO_USER_ALLOW,
+        }
+
+    def test_unlock_beats_user_custom_list_block(self) -> None:
+        # A DNSBL Group Custom_List block is sovereign (band 5) over feeds, but a
+        # temporary unlock (band 6) still wins -- the user can unlock their own block.
+        res = _build({"cust": ["||x.example.com^"]}, user_feeds=["cust"], user_unlock=["x.example.com"])
+        assert _live_label(res, "x.example.com") == "resolve"
+
+    def test_unlock_leading_dot_is_wildcard(self) -> None:
+        # Normalised exactly like the whitelist: a leading dot -> wildcard allow
+        # covering subdomains.
+        res = _build({"f": ["||evil.com^"]}, user_unlock=[".evil.com"])
+        assert res.white_db["evil.com"]["wildcard"] is True
+        assert _live_label(res, "sub.evil.com") == "resolve"
+
+    def test_empty_unlock_keeps_block(self) -> None:
+        # The full-build default (empty user_unlock) leaves the feed block intact.
+        res = _build({"f": ["||evil.com^"]}, user_unlock=[])
+        assert _live_label(res, "evil.com") == "block"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Fixes #51 — DNSBL temporary Lock/Unlock was a no-op under the ADR-06 python build

### Are the entries truly "temporary"? Yes — by design and intent (per the issue comment)

Verified against the source-of-truth, not the issue's wording:

- The store lives in `/tmp` (`$pfb['dnsbl_unlock']='/tmp/dnsbl_unlock'`; IP twin `/tmp/ip_unlock`) → gone on reboot.
- The alerts icon tooltip says so explicitly: *"Unlocking Domain(s) is **temporary** and may be automatically **re-locked on a Cron or Force command with an Unbound Reload!**"*
- A full update deletes the store (`pfb_update_unbound`, `inc:3350-3357`) → every unlock re-locks to natural state. The IP side is identical (`inc:10183`).
- savemsgs read *"**temporarily** Unlocked"* / *"**temporarily** Re-Locked"*.

So the "temporary" framing is accurate; the fix preserves that invariant exactly.

### Root cause

ADR-06 builds `dataDB`/`zoneDB`/`whiteDB` from the per-feed manifest (`pfb_py_sources.json`). The `dnsbl_remove` handler wrote `pfb_py_whitelist.txt` / `pfb_py_data` / `pfb_py_zone`, none of which the manifest build reads — so the icon toggled but the resolver never changed.

### Fix — give the temporary unlock its own manifest hook (mirrors the permanent whitelist)

- New manifest key **`config.user_unlock`**; `build()` merges it into `whiteDB` as **band-6 sovereign user allows** (same shape as `config.user_whitelist`), so an unlocked domain resolves (its feed / Custom_List block is overridden).
- **`pfb_dnsbl_unlock_lines()`** reads the `pfb_unlock` state store; **`pfb_unbound_python_sources_unlock()`** patches `config.user_unlock` in place.
- The **`dnsbl_remove` handler** now toggles only the `pfb_unlock` store (unlock/relock add, lock/reunlock remove — preserving the four icon states), regenerates `user_unlock`, then reloads. The dead legacy DNSBL/TLD file-write branches are removed.
- The **full build emits an empty `user_unlock`**: a Force/Cron update deletes the store right after the manifest is written (`pfb_unbound_python_sources` at `inc:8645` → `pfb_update_unbound` at `:8710` → unlink at `:3356`), so baking the live store in would let unlocks **survive** the re-lock — breaking the documented "re-locked on Cron/Force" semantic. Only the incremental alerts path repopulates it. *(This is the one correction to the issue's literal point 1.)*

### Scope note

`relock`/`reunlock` concern permanently-whitelisted domains; as before — and inherent to an allow-set — a `relock` cannot temporarily re-block a whitelisted domain. Unchanged from legacy python behaviour, out of scope here.

### Tests

- **pytest**: `config.user_unlock` passthrough (`_dnsbl_config_from_manifest`), whiteDB band-6 merge, and the production matcher resolving an unlocked feed-blocked domain (incl. leading-dot wildcard, beats a sovereign Custom_List block).
- **PHPUnit**: full-build clears `user_unlock` even with a live store, `pfb_dnsbl_unlock_lines()` reads the store, and the in-place `pfb_unbound_python_sources_unlock()` patch leaves feeds/whitelist intact.

All gates green: pytest 997, PHPUnit 89, PHPStan clean, ruff/mypy/`php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporary per-alert DNSBL unlocks: alerts can temporarily allow a domain until the next full rebuild; unlocks merge into the runtime whitelist without weakening broader permanent allows.
  * Incremental manifest patching from alerts that triggers immediate resolver reloads and writes updated manifests.
  * Resolver cache flush on unlock to prevent stale blocked responses.

* **Bug Fixes**
  * Full/force rebuilds clear temporary unlocks so they don't persist.
  * Unknown actions are treated as no-ops with safe messaging.

* **Tests**
  * Added unit and smoke tests for unlock parsing, manifest patching, precedence/normalization, messaging, and end-to-end lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->