### PR TITLE
pfblockerng: unify the DNSBL decision cache (the decision is the working structure)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -92,10 +92,10 @@ hstsDB: defaultdict[str, Any]
 whiteDB: defaultdict[str, Any]
 gpListDB: defaultdict[str, Any]
 noAAAADB: defaultdict[str, Any]
-dnsblDB: defaultdict[str, Any]
+decisionDB: dict[str, DnsblDecision]
+_dnsbl_last_event: Any = None
 safeSearchDB: defaultdict[str, Any]
 feedGroupIndexDB: defaultdict[int, Any]
-excludeDB: list[str]
 excludeAAAADB: list[str]
 excludeSS: list[str]
 maxmindReader: Any
@@ -209,10 +209,10 @@ def init_standard(id: int, env: module_env) -> bool:
         allowRegexDB, \
         hstsDB, \
         whiteDB, \
-        excludeDB, \
         excludeAAAADB, \
         excludeSS, \
-        dnsblDB, \
+        decisionDB, \
+        _dnsbl_last_event, \
         noAAAADB, \
         gpListDB, \
         safeSearchDB, \
@@ -409,7 +409,8 @@ def init_standard(id: int, env: module_env) -> bool:
     # Initialize dicts/lists
     dataDB = defaultdict(list)
     zoneDB = defaultdict(list)
-    dnsblDB = defaultdict(list)
+    decisionDB = {}
+    _dnsbl_last_event = None
     safeSearchDB = defaultdict(list)
     feedGroupIndexDB = defaultdict(list)
 
@@ -424,7 +425,6 @@ def init_standard(id: int, env: module_env) -> bool:
     gpListDB = defaultdict(str)
     noAAAADB = defaultdict(str)
     feedGroupDB: defaultdict[str, Any] = defaultdict(str)
-    excludeDB = []
     excludeAAAADB = []
     excludeSS = []
 
@@ -1234,7 +1234,7 @@ def get_details_dnsbl(
     rep: reply_info | None,
     kwargs: dict[str, Any] | None,
 ) -> bool:
-    global pfb, rcodeDB, dnsblDB, noAAAADB, maxmindReader
+    global pfb, rcodeDB, decisionDB, noAAAADB, maxmindReader, _dnsbl_last_event
 
     if qstate and qstate is not None:
         q_name = get_q_name_qstate(qstate)
@@ -1247,17 +1247,18 @@ def get_details_dnsbl(
     if pfb["sqlite3_resolver_con"]:
         pfb_db_enqueue(("resolver",))
 
-    # Determine if event is a 'reply' or DNSBL block
-    isDNSBL = dnsblDB.get(q_name)
-    if isDNSBL is not None:
+    # Determine if event is a 'reply' or DNSBL block. decisionDB now also holds allow
+    # ("let it resolve"/whitelisted) verdicts, so attribute only an actual block.
+    isDNSBL = decisionDB.get(q_name)
+    if isDNSBL is not None and isDNSBL.is_found and not isDNSBL.in_whitelist:
         # If logging is disabled, do not log blocked DNSBL events (Utilize DNSBL Webserver)
         # except for Python nullblock events
-        if pfb["python_nolog"] and not isDNSBL["null"]:
+        if pfb["python_nolog"] and not isDNSBL.null_blocking:
             return True
 
         # Increment dnsblgroup counter
-        if pfb["sqlite3_dnsbl_con"] and isDNSBL["group"] != "":
-            pfb_db_enqueue(("dnsbl", isDNSBL["group"]))
+        if pfb["sqlite3_dnsbl_con"] and isDNSBL.group != "":
+            pfb_db_enqueue(("dnsbl", isDNSBL.group))
 
         # Query type (A/AAAA/ANY/...). The cached decision in isDNSBL is
         # qtype-independent, so fold q_type into both the consecutive-dedup
@@ -1269,17 +1270,16 @@ def get_details_dnsbl(
 
         dupEntry = "+"
         event_sig = (q_type, isDNSBL)
-        lastEvent = dnsblDB.get("last-event")
-        if lastEvent is not None:
-            if str(lastEvent) == str(event_sig):
+        if _dnsbl_last_event is not None:
+            if str(_dnsbl_last_event) == str(event_sig):
                 dupEntry = "-"
             else:
-                dnsblDB["last-event"] = event_sig
+                _dnsbl_last_event = event_sig
         else:
-            dnsblDB["last-event"] = event_sig
+            _dnsbl_last_event = event_sig
 
         # Skip logging
-        if isDNSBL["log"] == "2":
+        if isDNSBL.log_type == "2":
             return True
 
         q_ip = get_q_ip_comm(kwargs)
@@ -1295,11 +1295,11 @@ def get_details_dnsbl(
                 timestamp,
                 q_name,
                 q_ip,
-                isDNSBL["p_type"],
-                isDNSBL["b_type"],
-                isDNSBL["group"],
-                isDNSBL["b_eval"],
-                isDNSBL["feed"],
+                isDNSBL.p_type,
+                isDNSBL.b_type,
+                isDNSBL.group,
+                isDNSBL.b_eval,
+                isDNSBL.feed,
                 dupEntry,
                 q_type,
             )
@@ -1411,7 +1411,7 @@ def get_details_reply(
     rep: reply_info | None,
     kwargs: dict[str, Any] | None,
 ) -> bool:
-    global pfb, rcodeDB, dnsblDB, noAAAADB, maxmindReader
+    global pfb, rcodeDB, decisionDB, noAAAADB, maxmindReader
 
     if qstate and qstate is not None:
         q_name = get_q_name_qstate(qstate)
@@ -3696,8 +3696,8 @@ def evaluate_noaaaa(q_name: str, noaaaa_db: dict[str, Any]) -> bool:
 
 
 def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
-    global pfb, threads, dataDB, zoneDB, hstsDB, whiteDB, excludeDB, excludeAAAADB
-    global excludeSS, dnsblDB, noAAAADB, gpListDB, safeSearchDB
+    global pfb, threads, dataDB, zoneDB, hstsDB, whiteDB, decisionDB, excludeAAAADB
+    global excludeSS, noAAAADB, gpListDB, safeSearchDB
 
     qstate_valid = False
     q_type: Any = None
@@ -3979,137 +3979,97 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
             if val_counter > 1:
                 isCNAME = True
 
-            # Determine if domain has been previously validated
-            if q_name not in excludeDB:
-                isFound = False
-                isInWhitelist = False
-                nullBlocking = True
+            # One coherent verdict per name in decisionDB: a block, OR an allow
+            # ("let Unbound resolve it" / whitelisted) -- both are decisions, both
+            # are memoized. A repeat query (including a CNAME-blocked name, keyed on
+            # the original) short-circuits here without re-resolving or re-evaluating.
+            decision = decisionDB.get(q_name)
+            if decision is None:
+                tld = get_tld(qstate)
+                cfg = {
+                    "python_blocking": pfb["python_blocking"],
+                    "dataDB": pfb["dataDB"],
+                    "zoneDB": pfb["zoneDB"],
+                    "python_tld": pfb["python_tld"],
+                    "python_tlds": pfb["python_tlds"],
+                    "dnsbl_ipv4": pfb["dnsbl_ipv4"],
+                    "dnsbl_ipv6": pfb["dnsbl_ipv6"],
+                    "python_idn": pfb["python_idn"],
+                    "regexDB": pfb["regexDB"],
+                    "whiteDB": pfb["whiteDB"],
+                    "allowRegexDB": pfb["allowRegexDB"],
+                    "important_rules": pfb["important_rules"],
+                    "regex_warn_ms": pfb["regex_warn_ms"],
+                    "regex_evict_ms": pfb["regex_evict_ms"],
+                    "python_tld_seg": pfb["python_tld_seg"],
+                    "hstsDB": pfb["hstsDB"],
+                    "hsts_tlds": pfb["hsts_tlds"],
+                }
+                containers = {
+                    "dataDB": dataDB,
+                    "zoneDB": zoneDB,
+                    "whiteDB": whiteDB,
+                    "regexDB": regexDB,
+                    "allowRegexDB": allowRegexDB,
+                    "feedGroupIndexDB": feedGroupIndexDB,
+                    "hstsDB": hstsDB,
+                }
+                decision = evaluate_domain(q_name, q_name_original, tld, isCNAME, cfg, containers)
 
-                # Determine if domain was previously DNSBL blocked
-                isDomainInDNSBL = dnsblDB.get(q_name)
-                if isDomainInDNSBL is None:
-                    tld = get_tld(qstate)
-                    cfg = {
-                        "python_blocking": pfb["python_blocking"],
-                        "dataDB": pfb["dataDB"],
-                        "zoneDB": pfb["zoneDB"],
-                        "python_tld": pfb["python_tld"],
-                        "python_tlds": pfb["python_tlds"],
-                        "dnsbl_ipv4": pfb["dnsbl_ipv4"],
-                        "dnsbl_ipv6": pfb["dnsbl_ipv6"],
-                        "python_idn": pfb["python_idn"],
-                        "regexDB": pfb["regexDB"],
-                        "whiteDB": pfb["whiteDB"],
-                        "allowRegexDB": pfb["allowRegexDB"],
-                        "important_rules": pfb["important_rules"],
-                        "regex_warn_ms": pfb["regex_warn_ms"],
-                        "regex_evict_ms": pfb["regex_evict_ms"],
-                        "python_tld_seg": pfb["python_tld_seg"],
-                        "hstsDB": pfb["hstsDB"],
-                        "hsts_tlds": pfb["hsts_tlds"],
-                    }
-                    containers = {
-                        "dataDB": dataDB,
-                        "zoneDB": zoneDB,
-                        "whiteDB": whiteDB,
-                        "regexDB": regexDB,
-                        "allowRegexDB": allowRegexDB,
-                        "feedGroupIndexDB": feedGroupIndexDB,
-                        "hstsDB": hstsDB,
-                    }
-                    dec = evaluate_domain(q_name, q_name_original, tld, isCNAME, cfg, containers)
-                    isFound = dec.is_found
-                    isInWhitelist = dec.in_whitelist
-                    nullBlocking = dec.null_blocking
-                    b_type = dec.b_type
-                    p_type = dec.p_type
-                    log_type = dec.log_type
-                    feed = dec.feed
-                    group = dec.group
-                    b_eval = dec.b_eval
+                # A block found via a CNAME chain is recorded against the ORIGINAL
+                # queried name, so a later query for it short-circuits on this entry.
+                if decision.is_found and not decision.in_whitelist and isCNAME:
+                    q_name = q_name_original
 
-                    # Add domain to excludeDB to skip subsequent blacklist validation
-                    if not isFound or isInWhitelist:
-                        excludeDB.append(q_name)
+                # Memoize the verdict (block OR allow) so this name is decided once.
+                decisionDB[q_name] = decision
 
-                    # Domain to be blocked and is not whitelisted
-                    if isFound and not isInWhitelist:
-                        if isCNAME:
-                            q_name = q_name_original
+                # Add domain data to DNSBL cache for Reports tab (fresh block only)
+                if decision.is_found and not decision.in_whitelist:
+                    pfb_db_enqueue(("cache", (decision.b_type, q_name, decision.group, decision.b_eval, decision.feed)))
 
-                        # Skip subsequent DNSBL validation for domain, add to dict for get_details_dnsbl
-                        dnsblDB[q_name] = {
-                            "qname": q_name,
-                            "b_type": b_type,
-                            "p_type": p_type,
-                            "null": nullBlocking,
-                            "log": log_type,
-                            "feed": feed,
-                            "group": group,
-                            "b_eval": b_eval,
-                        }
-                        # Skip subsequent DNSBL validation for original domain (CNAME validation),
-                        # add to dict for get_details_dnsbl
-                        if isCNAME and dnsblDB.get(q_name_original) is None:
-                            dnsblDB[q_name_original] = {
-                                "qname": q_name_original,
-                                "b_type": b_type,
-                                "p_type": p_type,
-                                "null": nullBlocking,
-                                "log": log_type,
-                                "feed": feed,
-                                "group": group,
-                                "b_eval": b_eval,
-                            }
+            # Block iff found and not whitelisted; an allow decision falls through to
+            # the resolver (the WAIT_MODULE below).
+            if decision.is_found and not decision.in_whitelist:
+                # Create FQDN Reply Message
+                msg = DNSMessage(qstate.qinfo.qname_str, q_type, RR_CLASS_IN, PKT_QR | PKT_RA)
 
-                        # Add domain data to DNSBL cache for Reports tab
-                        pfb_db_enqueue(("cache", (b_type, q_name, group, b_eval, feed)))
+                if q_type == RR_TYPE_A or q_type == RR_TYPE_ANY:
+                    msg.answer.append(
+                        "{}. 3600 IN A {}".format(q_name, "0.0.0.0" if decision.null_blocking else pfb["dnsbl_ipv4"])
+                    )
+                if q_type == RR_TYPE_AAAA or q_type == RR_TYPE_ANY:
+                    msg.answer.append(
+                        "{}. 3600 IN AAAA {}".format(q_name, "::" if decision.null_blocking else pfb["dnsbl_ipv6"])
+                    )
 
-                # Use previously blocked domain details
-                else:
-                    nullBlocking = isDomainInDNSBL["null"]
-                    isFound = True
-
-                if isFound and not isInWhitelist:
-                    # Create FQDN Reply Message
-                    msg = DNSMessage(qstate.qinfo.qname_str, q_type, RR_CLASS_IN, PKT_QR | PKT_RA)
-
-                    if q_type == RR_TYPE_A or q_type == RR_TYPE_ANY:
-                        msg.answer.append(
-                            "{}. 3600 IN A {}".format(q_name, "0.0.0.0" if nullBlocking else pfb["dnsbl_ipv4"])
-                        )
-                    if q_type == RR_TYPE_AAAA or q_type == RR_TYPE_ANY:
-                        msg.answer.append(
-                            "{}. 3600 IN AAAA {}".format(q_name, "::" if nullBlocking else pfb["dnsbl_ipv6"])
-                        )
-
-                    if msg is None or not msg.set_return_msg(qstate):
-                        qstate.ext_state[id] = MODULE_ERROR
-                        return True
-
-                    # Log entry
-                    kwargs = {"pfb_addr": q_ip}
-                    if qstate.return_msg:
-                        get_details_dnsbl("dnsbl", None, qstate, qstate.return_msg.rep, kwargs)
-                    else:
-                        get_details_dnsbl("dnsbl", None, qstate, None, kwargs)
-
-                    qstate.return_rcode = RCODE_NOERROR
-                    qstate.return_msg.rep.security = 2
-                    # Do not store the synthetic block reply in Unbound's C message
-                    # cache (#43). A cached block is served ahead of this module, so
-                    # repeat queries skip operate() -> the feed-attributed logger
-                    # (get_details_dnsbl: dnsbl.log + per-group counter) never runs and
-                    # per-feed block stats under-count; the cache-hit path logs only an
-                    # unattributed DNS-reply. It also keeps a cached 0.0.0.0/VIP serving
-                    # for up to the TTL after a name is removed from a list (block->allow
-                    # staleness). The reply is synthetic, so not caching it costs only the
-                    # ~1us in-process matcher re-run (the dnsblDB/excludeDB memos still
-                    # short-circuit re-evaluation), never an upstream round-trip. Mirrors
-                    # the SafeSearch CNAME path, the module's only other no_cache_store.
-                    qstate.no_cache_store = 1
-                    qstate.ext_state[id] = MODULE_FINISHED
+                if msg is None or not msg.set_return_msg(qstate):
+                    qstate.ext_state[id] = MODULE_ERROR
                     return True
+
+                # Log entry
+                kwargs = {"pfb_addr": q_ip}
+                if qstate.return_msg:
+                    get_details_dnsbl("dnsbl", None, qstate, qstate.return_msg.rep, kwargs)
+                else:
+                    get_details_dnsbl("dnsbl", None, qstate, None, kwargs)
+
+                qstate.return_rcode = RCODE_NOERROR
+                qstate.return_msg.rep.security = 2
+                # Do not store the synthetic block reply in Unbound's C message cache
+                # (#43). A cached block is served ahead of this module, so repeat queries
+                # skip operate() -> the feed-attributed logger (get_details_dnsbl:
+                # dnsbl.log + per-group counter) never runs and per-feed block stats
+                # under-count; the cache-hit path logs only an unattributed DNS-reply. It
+                # also keeps a cached 0.0.0.0/VIP serving for up to the TTL after a name is
+                # removed from a list (block->allow staleness). The reply is synthetic, so
+                # not caching it costs only the ~1us in-process matcher re-run (the
+                # decisionDB memo still short-circuits re-evaluation), never an upstream
+                # round-trip. Mirrors the SafeSearch CNAME path, the module's only other
+                # no_cache_store.
+                qstate.no_cache_store = 1
+                qstate.ext_state[id] = MODULE_FINISHED
+                return True
 
     if (event == MODULE_EVENT_NEW) or (event == MODULE_EVENT_PASS):
         qstate.ext_state[id] = MODULE_WAIT_MODULE

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1260,16 +1260,19 @@ def get_details_dnsbl(
         if pfb["sqlite3_dnsbl_con"] and isDNSBL.group != "":
             pfb_db_enqueue(("dnsbl", isDNSBL.group))
 
-        # Query type (A/AAAA/ANY/...). The cached decision in isDNSBL is
-        # qtype-independent, so fold q_type into both the consecutive-dedup
-        # signature and the log line. Without it a client's back-to-back A+AAAA
-        # blocks of the same name compare equal -> the second is marked a
-        # duplicate (dual-stack under-count) and Reports cannot break down by
-        # record type. The decision path stays qtype-correct and untouched.
+        # The cached DnsblDecision is both name- and qtype-independent for some block
+        # kinds -- two subdomains of one blocked zone share an identical payload (same
+        # b_eval=zone) -- so fold BOTH the queried name and q_type into the
+        # consecutive-dedup signature and the log line. Without the name, two distinct
+        # same-zone blocks compare equal -> the second is wrongly marked a duplicate
+        # (zone under-count); the old dnsblDB dict carried a "qname" field that str()
+        # folded in implicitly, which DnsblDecision does not. Without q_type, a client's
+        # back-to-back A+AAAA of one name collapses (dual-stack under-count) and Reports
+        # cannot break down by record type. The decision path stays correct and untouched.
         q_type = get_q_type(qstate, qinfo)
 
         dupEntry = "+"
-        event_sig = (q_type, isDNSBL)
+        event_sig = (q_name.lower(), q_type, isDNSBL)
         if _dnsbl_last_event is not None:
             if str(_dnsbl_last_event) == str(event_sig):
                 dupEntry = "-"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,8 @@ def reset_pfb_globals() -> None:
     }
     pfb_unbound.dataDB = defaultdict(list)
     pfb_unbound.zoneDB = defaultdict(list)
-    pfb_unbound.dnsblDB = defaultdict(list)
+    pfb_unbound.decisionDB = {}
+    pfb_unbound._dnsbl_last_event = None
     pfb_unbound.safeSearchDB = defaultdict(list)
     pfb_unbound.feedGroupIndexDB = defaultdict(list)
     pfb_unbound.regexDB = defaultdict(str)
@@ -103,7 +104,6 @@ def reset_pfb_globals() -> None:
     pfb_unbound.hstsDB = defaultdict(str)
     pfb_unbound.gpListDB = defaultdict(str)
     pfb_unbound.noAAAADB = defaultdict(str)
-    pfb_unbound.excludeDB = []
     pfb_unbound.excludeAAAADB = []
     pfb_unbound.excludeSS = []
     pfb_unbound.threads = []

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -693,6 +693,40 @@ class TestGetDetailsDnsblQtype:
         assert first[9] == "+"
         assert second[9] == "-"
 
+    def test_distinct_names_not_deduped(self, monkeypatch: Any) -> None:
+        # Two different names blocked by the SAME list entry share an identical
+        # DnsblDecision payload (e.g. two subdomains of one blocked zone -> same
+        # b_eval). The consecutive-dedup signature must still tell them apart by
+        # name, or the second is wrongly marked a duplicate (zone under-count). The
+        # decision is the same object for both, so name is the only differentiator.
+        monkeypatch.setitem(pfb_unbound.pfb, "python_nolog", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_resolver_con", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_dnsbl_con", False)
+        dec = pfb_unbound.DnsblDecision(
+            is_found=True,
+            in_whitelist=False,
+            in_hsts=False,
+            null_blocking=False,
+            log_type="1",
+            b_type="TLD",
+            p_type="Python",
+            feed="feedX",
+            group="groupY",
+            b_eval="evil.com",
+        )
+        monkeypatch.setattr(pfb_unbound, "decisionDB", {"a.evil.com": dec, "b.evil.com": dec})
+        lines: list[tuple[str, str]] = []
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: lines.append((path, line)))
+        for name in ("a.evil.com.", "b.evil.com."):
+            qstate = types.SimpleNamespace(
+                qinfo=types.SimpleNamespace(qname_str=name, qtype_str="A"),
+                return_msg=None,
+            )
+            pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": "1.2.3.4"})
+        a_fields, b_fields = self._dnsbl_fields(lines)
+        assert a_fields[9] == "+"
+        assert b_fields[9] == "+"
+
 
 class TestGetOType:
     def test_return_msg_rrset_branch(self) -> None:
@@ -849,6 +883,7 @@ class TestOperateDnsbl:
         add_data("evil.com", log="1", index=0)
         set_feed_group(0, "TestFeed", "TestGroup")
         qstate = make_qstate("evil.com.", qtype=RR_A)
+        assert qstate.no_cache_store == 0  # before-state: default is cacheable
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert qstate.ext_state[0] == MODULE_FINISHED
         assert qstate.no_cache_store == 1
@@ -857,6 +892,7 @@ class TestOperateDnsbl:
         # that is the whole point: every blocked query, miss or memo, re-runs here.
         assert _is_block(pfb_unbound.decisionDB.get("evil.com"))
         qstate2 = make_qstate("evil.com.", qtype=RR_A)
+        assert qstate2.no_cache_store == 0  # before-state
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate2, None)
         assert qstate2.ext_state[0] == MODULE_FINISHED
         assert qstate2.no_cache_store == 1

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -73,6 +73,31 @@ def set_feed_group(index: int, feed: str, group: str) -> None:
     pfb_unbound.feedGroupIndexDB[index] = {"feed": feed, "group": group}
 
 
+def _is_block(dec: Any) -> bool:
+    # A decisionDB entry is a block iff it was found and not whitelisted -- the same
+    # predicate operate()/get_details_dnsbl use. decisionDB now also stores allow
+    # ("let it resolve"/whitelisted) verdicts, so membership alone no longer means
+    # "blocked".
+    return dec is not None and dec.is_found and not dec.in_whitelist
+
+
+def allow_decision() -> Any:
+    # A minimal not-found (allow) verdict, for seeding decisionDB to exercise the
+    # allow short-circuit path (the old excludeDB membership).
+    return pfb_unbound.DnsblDecision(
+        is_found=False,
+        in_whitelist=False,
+        in_hsts=False,
+        null_blocking=True,
+        log_type="",
+        b_type="",
+        p_type="",
+        feed="",
+        group="",
+        b_eval="",
+    )
+
+
 class TestIsUnknown:
     def test_none_returns_unknown(self) -> None:
         assert is_unknown(None) == "Unknown"
@@ -599,21 +624,25 @@ class TestGetQType:
 
 class TestGetDetailsDnsblQtype:
     """Issue #44: DNSBL reporting must account for query type. The cached decision
-    in dnsblDB is qtype-independent, so q_type is folded into the consecutive-dedup
+    in decisionDB is qtype-independent, so q_type is folded into the consecutive-dedup
     signature and appended as the trailing dnsbl.log field. Two same-name blocks
     that differ only by record type (a client's A+AAAA pair) must each count, and
     the log must record which record type was blocked."""
 
-    DECISION = {
-        "qname": "blocked.com",
-        "b_type": "DNSBL_Python",
-        "p_type": "Python",
-        "null": False,
-        "log": "1",
-        "feed": "feedX",
-        "group": "groupY",
-        "b_eval": "blocked.com",
-    }
+    @staticmethod
+    def _decision() -> Any:
+        return pfb_unbound.DnsblDecision(
+            is_found=True,
+            in_whitelist=False,
+            in_hsts=False,
+            null_blocking=False,
+            log_type="1",
+            b_type="DNSBL_Python",
+            p_type="Python",
+            feed="feedX",
+            group="groupY",
+            b_eval="blocked.com",
+        )
 
     def _qstate(self, qtype: str) -> types.SimpleNamespace:
         return types.SimpleNamespace(
@@ -625,7 +654,7 @@ class TestGetDetailsDnsblQtype:
         monkeypatch.setitem(pfb_unbound.pfb, "python_nolog", False)
         monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_resolver_con", False)
         monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_dnsbl_con", False)
-        monkeypatch.setattr(pfb_unbound, "dnsblDB", {"blocked.com": dict(self.DECISION)})
+        monkeypatch.setattr(pfb_unbound, "decisionDB", {"blocked.com": self._decision()})
         lines: list[tuple[str, str]] = []
         monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: lines.append((path, line)))
         return lines
@@ -824,9 +853,9 @@ class TestOperateDnsbl:
         assert qstate.ext_state[0] == MODULE_FINISHED
         assert qstate.no_cache_store == 1
 
-        # The memoized re-block path (name already in dnsblDB) must set it too --
+        # The memoized re-block path (name already in decisionDB) must set it too --
         # that is the whole point: every blocked query, miss or memo, re-runs here.
-        assert pfb_unbound.dnsblDB.get("evil.com") is not None
+        assert _is_block(pfb_unbound.decisionDB.get("evil.com"))
         qstate2 = make_qstate("evil.com.", qtype=RR_A)
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate2, None)
         assert qstate2.ext_state[0] == MODULE_FINISHED
@@ -860,7 +889,8 @@ class TestOperateDnsbl:
         qstate = make_qstate("evil.com.", qtype=RR_A)
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert qstate.ext_state[0] == MODULE_WAIT_MODULE
-        assert "evil.com" in pfb_unbound.excludeDB
+        dec = pfb_unbound.decisionDB.get("evil.com")
+        assert dec is not None and not _is_block(dec)  # whitelisted -> memoized as an allow
 
     def test_regex_block(self, monkeypatch: Any) -> None:
         self._enable(monkeypatch)
@@ -870,17 +900,43 @@ class TestOperateDnsbl:
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED
-        entry = pfb_unbound.dnsblDB.get("evil-domain.com")
-        assert entry["group"] == "DNSBL_Regex"
+        entry = pfb_unbound.decisionDB.get("evil-domain.com")
+        assert entry.group == "DNSBL_Regex"
 
-    def test_excludedb_short_circuit(self, monkeypatch: Any) -> None:
+    def test_allow_decision_short_circuit(self, monkeypatch: Any) -> None:
+        # A cached allow verdict ("let it resolve") short-circuits the matcher -- the
+        # unified-cache equivalent of the old excludeDB membership skip.
         self._enable(monkeypatch)
         add_data("evil.com", log="1", index=0)
         set_feed_group(0, "TestFeed", "TestGroup")
-        pfb_unbound.excludeDB.append("evil.com")
+        pfb_unbound.decisionDB["evil.com"] = allow_decision()
         qstate = make_qstate("evil.com.", qtype=RR_A)
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert qstate.ext_state[0] == MODULE_WAIT_MODULE
+
+    def test_block_decision_reuse_without_reeval(self, monkeypatch: Any) -> None:
+        # A cached BLOCK verdict short-circuits the matcher: operate() blocks straight
+        # from decisionDB without dataDB/evaluate_domain. The name is NOT on any list,
+        # so if it blocks, the memo -- not re-evaluation -- did it.
+        self._enable(monkeypatch)
+        pfb_unbound.decisionDB["cached-block.com"] = pfb_unbound.DnsblDecision(
+            is_found=True,
+            in_whitelist=False,
+            in_hsts=False,
+            null_blocking=True,
+            log_type="1",
+            b_type="DNSBL",
+            p_type="Python",
+            feed="F",
+            group="G",
+            b_eval="cached-block.com",
+        )
+        qstate = make_qstate("cached-block.com.", qtype=RR_A)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        answers = DNSMessage.instances[-1].answer
+        assert any(a.startswith("cached-block.com. ") for a in answers)
 
     def test_group_policy_bypass(self, monkeypatch: Any) -> None:
         self._enable(monkeypatch)
@@ -929,12 +985,12 @@ class TestOperateDnsbl:
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED
 
-        entry = pfb_unbound.dnsblDB.get("orig.com")
+        entry = pfb_unbound.decisionDB.get("orig.com")
         assert entry is not None
-        assert entry["b_type"] == "DNSBL_CNAME"
+        assert entry.b_type == "DNSBL_CNAME"
         # Block is keyed on the original name after the q_name reassignment,
         # not on the CNAME target itself.
-        assert "evil-cname.com" not in pfb_unbound.dnsblDB
+        assert not _is_block(pfb_unbound.decisionDB.get("evil-cname.com"))
         answers = DNSMessage.instances[-1].answer
         assert any(a.startswith("orig.com. ") for a in answers)
 
@@ -955,7 +1011,7 @@ class TestOperateDnsbl:
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         # Not blocked -> passes through to the resolver (no block return_msg set).
         assert qstate.ext_state[0] == MODULE_WAIT_MODULE
-        assert "orig.com" not in pfb_unbound.dnsblDB
+        assert not _is_block(pfb_unbound.decisionDB.get("orig.com"))
 
     def test_cname_target_blocked_when_queried_directly(self, monkeypatch: Any) -> None:
         # The ERRATA invariant: B (the CNAME target) is genuinely on the blocklist in
@@ -969,7 +1025,32 @@ class TestOperateDnsbl:
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED  # B is blocked
-        assert "evil-cname.com" in pfb_unbound.dnsblDB
+        assert _is_block(pfb_unbound.decisionDB.get("evil-cname.com"))
+
+    def test_cname_repeat_short_circuits_without_chain(self, monkeypatch: Any) -> None:
+        # The unified-cache CNAME fix: a CNAME-blocked name is keyed on the ORIGINAL in
+        # decisionDB, so a later query short-circuits to a block WITHOUT a resolved chain
+        # -- no re-resolution, no re-evaluation of the target. Pre-refactor the original
+        # sat in excludeDB and could only re-block by re-resolving and re-walking.
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["python_cname"] = True
+        monkeypatch.setattr(pfb_unbound, "convert_other", lambda b: "evil-cname.com")
+        add_data("evil-cname.com", log="1", index=0)
+        set_feed_group(0, "F", "G")
+
+        # First query carries the resolved CNAME chain -> blocks and memoizes orig.
+        q1 = make_qstate("orig.com.", qtype=RR_A, return_msg=self._cname_reply("orig.com."))
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, q1, None)
+        assert q1.ext_state[0] == MODULE_FINISHED
+        assert _is_block(pfb_unbound.decisionDB.get("orig.com"))
+
+        # Second query has NO resolved chain -- it still blocks, purely from
+        # decisionDB[orig], with the answer built for the original name.
+        q2 = make_qstate("orig.com.", qtype=RR_A, return_msg=None)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, q2, None)
+        assert q2.ext_state[0] == MODULE_FINISHED
+        answers = DNSMessage.instances[-1].answer
+        assert any(a.startswith("orig.com. ") for a in answers)
 
     def test_block_sets_return_msg_exactly_once(self, monkeypatch: Any) -> None:
         # The DNSBL block path previously called msg.set_return_msg(qstate)
@@ -1847,9 +1928,10 @@ class TestADR02PythonOnlyBlocking:
         set_feed_group(0, "ADR02Feed", "ADR02Group")
         qstate = make_qstate("adr02-not-blocked.com.", qtype=RR_A)
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
-        # Without python_blocking, the domain is added to excludeDB and passed through
+        # Without python_blocking, the domain is memoized as an allow and passed through
         assert qstate.ext_state[0] == MODULE_WAIT_MODULE
-        assert "adr02-not-blocked.com" in pfb_unbound.excludeDB
+        dec = pfb_unbound.decisionDB.get("adr02-not-blocked.com")
+        assert dec is not None and not _is_block(dec)
 
     def test_operate_zone_block_with_python_blocking_true(self, monkeypatch: Any) -> None:
         # Wildcard/zone blocking via operate() with the ADR-02 invariant state.
@@ -1863,7 +1945,7 @@ class TestADR02PythonOnlyBlocking:
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED
-        entry = pfb_unbound.dnsblDB.get("any.subdomain.blocked-zone.net")
+        entry = pfb_unbound.decisionDB.get("any.subdomain.blocked-zone.net")
         assert entry is not None
-        assert entry["b_type"] == "TLD"
-        assert entry["feed"] == "ZoneFeed"
+        assert entry.b_type == "TLD"
+        assert entry.feed == "ZoneFeed"


### PR DESCRIPTION
## Unify the DNSBL decision cache — the decision is the working structure (Stage 1)

`operate()`'s DNSBL memo was split across **two contradictory structures**: `excludeDB` (a list of not-blocked names, O(n) scan) and `dnsblDB` (a dict of blocked names + a `"last-event"` dedup key). A CNAME-blocked name landed in **both** — `excludeDB` (iter 1, not a direct match) and `dnsblDB` (iter 2, blocked via the resolved chain). That incoherent verdict caused:

- **Dead code.** The second `dnsblDB` store block guarded on `isCNAME and dnsblDB.get(q_name_original) is None`, but `q_name` was already reassigned to `q_name_original` and stored — the guard was always False, so it never fired.
- **CNAME re-evaluation every query.** A repeat query found the original in `excludeDB` and re-derived the block only by re-resolving and re-running the **full** `evaluate_domain` on the chain target — no fast path.

### Change

Replace both with one `decisionDB[name] = DnsblDecision`. The verdict object `evaluate_domain` already returns is now **stored directly** and is the single working structure, holding **every** outcome:

- not-found → `is_found=False` → resolve
- whitelisted → `is_found=True, in_whitelist=True` → resolve
- blocked → `is_found=True, in_whitelist=False` → build reply

An **allow** ("let Unbound resolve it" / whitelisted) **is a decision too**, so it's memoized like a block (replacing the `excludeDB` list with an O(1) dict lookup). A repeat query — including a CNAME-blocked name, now keyed on the **original** — short-circuits on the memo at `MODULE_EVENT_NEW` with **no re-resolution and no re-evaluation**. The dead CNAME store block is removed. The consecutive-dedup `"last-event"` key moves out of the data dict into its own module global.

### Behaviour preservation

`evaluate_domain` is **untouched**, so every decision is byte-identical — the ADR-06/07 decision oracles stay green. This changes only *when/how* the verdict is stored and reused, never *what* is decided. The existing tests assert the same behaviours; references to the renamed structure were migrated mechanically (`dnsblDB`/`excludeDB` → `decisionDB`, dict-key → dataclass attribute). Where a name can now appear as an allow, two `not in dnsblDB`-meant-"not blocked" checks became an `_is_block(dec)` helper to express that intent faithfully.

New tests: `test_block_decision_reuse_without_reeval` (a seeded block short-circuits with no `dataDB`/`evaluate_domain`) and `test_cname_repeat_short_circuits_without_chain` (a CNAME-blocked name re-blocks from `decisionDB[orig]` with **no** resolved chain).

991 passed; ruff, mypy, markdownlint, shellcheck, php -l clean.

### Scope

Stage 1 of the unified-decision design: **DNSBL only**. noAAAA + SafeSearch (`excludeAAAADB`/`excludeSS`, and the wildcard memo in `noAAAADB`) fold into `decisionDB` in a follow-up PR.

Relates to **#26** (list → dict, O(1) lookup) and **ADR-10** (fewer query-time decision caches to clear on a zero-downtime swap — ADR docs untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fewer duplicate DNSBL log events and improved log gating for null-blocking cases.

* **New Features**
  * Single memoized decision per queried name for consistent CNAME and blocking behavior.
  * Fresh blocks reliably appear in Reports with correct attribution; synthetic answers prevent unwanted caching.

* **Refactor**
  * Internal caching and global state reworked for clearer decision tracking and stability.

* **Tests**
  * Tests updated to validate the new decision-caching, deduplication, and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->