### PR TITLE
pfblockerng: fix two pre-existing DNSBL attribution bugs (casing + CNAME TLD)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -951,6 +951,15 @@ def get_tld(qstate: module_qstate) -> str:
     return tld
 
 
+def get_tld_from_name(q_name: str) -> str:
+    # The same second-level label get_tld() reads from qstate.qinfo.qname_list, but
+    # derived from a name STRING -- for a CNAME target evaluated mid-chain, whose TLD
+    # differs from the original query's. evaluate_domain() uses it for the TLD-Allow
+    # and HSTS checks, so each evaluated name must be checked against its own TLD.
+    parts = q_name.rstrip(".").split(".")
+    return parts[-2] if len(parts) > 1 else ""
+
+
 def convert_ipv4(x: Any) -> str:
     ipv4 = ""
     if x:
@@ -1249,7 +1258,11 @@ def get_details_dnsbl(
 
     # Determine if event is a 'reply' or DNSBL block. decisionDB now also holds allow
     # ("let it resolve"/whitelisted) verdicts, so attribute only an actual block.
-    isDNSBL = decisionDB.get(q_name)
+    # operate() stores decisionDB keys lowercased, so normalize the lookup -- otherwise
+    # a mixed-case query is blocked but its block is not attributed here (the log/counter
+    # path silently misses it -> per-feed under-count).
+    q_name_key = q_name.lower()
+    isDNSBL = decisionDB.get(q_name_key)
     if isDNSBL is not None and isDNSBL.is_found and not isDNSBL.in_whitelist:
         # If logging is disabled, do not log blocked DNSBL events (Utilize DNSBL Webserver)
         # except for Python nullblock events
@@ -1272,7 +1285,7 @@ def get_details_dnsbl(
         q_type = get_q_type(qstate, qinfo)
 
         dupEntry = "+"
-        event_sig = (q_name.lower(), q_type, isDNSBL)
+        event_sig = (q_name_key, q_type, isDNSBL)
         if _dnsbl_last_event is not None:
             if str(_dnsbl_last_event) == str(event_sig):
                 dupEntry = "-"
@@ -3988,7 +4001,10 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
             # the original) short-circuits here without re-resolving or re-evaluating.
             decision = decisionDB.get(q_name)
             if decision is None:
-                tld = get_tld(qstate)
+                # The original query's TLD comes from qstate; a CNAME target (isCNAME)
+                # has its own TLD, so derive it from the target name being evaluated --
+                # else the TLD-Allow / HSTS checks use the wrong TLD for the target.
+                tld = get_tld_from_name(q_name) if isCNAME else get_tld(qstate)
                 cfg = {
                     "python_blocking": pfb["python_blocking"],
                     "dataDB": pfb["dataDB"],

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -727,6 +727,23 @@ class TestGetDetailsDnsblQtype:
         assert a_fields[9] == "+"
         assert b_fields[9] == "+"
 
+    def test_mixed_case_query_is_attributed(self, monkeypatch: Any) -> None:
+        # operate() stores decisionDB keys lowercased; a mixed-case query must still
+        # be attributed here (lookup normalized), or the block is silently dropped from
+        # dnsbl.log / the per-group counter (per-feed under-count).
+        monkeypatch.setitem(pfb_unbound.pfb, "python_nolog", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_resolver_con", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_dnsbl_con", False)
+        monkeypatch.setattr(pfb_unbound, "decisionDB", {"blocked.com": self._decision()})
+        lines: list[tuple[str, str]] = []
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: lines.append((path, line)))
+        qstate = types.SimpleNamespace(
+            qinfo=types.SimpleNamespace(qname_str="Blocked.COM.", qtype_str="A"),
+            return_msg=None,
+        )
+        pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": "1.2.3.4"})
+        assert len(self._dnsbl_fields(lines)) == 1  # attributed despite mixed-case query
+
 
 class TestGetOType:
     def test_return_msg_rrset_branch(self) -> None:
@@ -763,6 +780,20 @@ class TestGetTld:
 
     def test_none_qstate_returns_empty(self) -> None:
         assert pfb_unbound.get_tld(None) == ""
+
+
+class TestGetTldFromName:
+    def test_multilabel(self) -> None:
+        # Same second-level label get_tld() yields, but from a name string.
+        assert pfb_unbound.get_tld_from_name("sub.example.com") == "example"
+        assert pfb_unbound.get_tld_from_name("evil.net") == "evil"
+
+    def test_trailing_dot_ignored(self) -> None:
+        assert pfb_unbound.get_tld_from_name("evil.net.") == "evil"
+
+    def test_single_label_returns_empty(self) -> None:
+        assert pfb_unbound.get_tld_from_name("com") == ""
+        assert pfb_unbound.get_tld_from_name("") == ""
 
 
 class TestGetQIp:
@@ -1062,6 +1093,25 @@ class TestOperateDnsbl:
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED  # B is blocked
         assert _is_block(pfb_unbound.decisionDB.get("evil-cname.com"))
+
+    def test_cname_target_uses_target_tld_not_original(self, monkeypatch: Any) -> None:
+        # operate() must derive the TLD-Allow tld from the CNAME TARGET being evaluated,
+        # not the original query. python_tld allows the SLD "orig"; the original
+        # (orig.com) passes, but its CNAME target (evil.net, SLD "evil") is NOT allowed
+        # -> the chain must block. With the bug (tld taken from the original query) the
+        # target was checked against "orig" and slipped through.
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["python_cname"] = True
+        pfb_unbound.pfb["python_tld"] = True
+        pfb_unbound.pfb["python_tlds"] = ["orig"]
+        monkeypatch.setattr(pfb_unbound, "convert_other", lambda b: "evil.net")
+        qstate = make_qstate("orig.com.", qtype=RR_A, return_msg=self._cname_reply("orig.com."))
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED  # blocked via the TARGET's TLD
+        entry = pfb_unbound.decisionDB.get("orig.com")
+        assert entry is not None
+        assert entry.group == "DNSBL_TLD_Allow"
 
     def test_cname_repeat_short_circuits_without_chain(self, monkeypatch: Any) -> None:
         # The unified-cache CNAME fix: a CNAME-blocked name is keyed on the ORIGINAL in


### PR DESCRIPTION
## Fix two pre-existing DNSBL attribution bugs (casing + CNAME TLD)

Both were **deferred from PR #67's CodeRabbit review** — pre-existing (verified identical on `b7a371c`, the pre-#67 tip), not introduced by the decision-cache refactor.

### 1. Mixed-case query → blocked but unattributed

`operate()` stores `decisionDB` keys **lowercased** (`q_name_original = …lower()`, CNAME targets `convert_other(…).lower()`), but `get_details_dnsbl` looked them up with the **raw query casing** (`get_q_name_qstate` does not lowercase). So a mixed-case query (e.g. `Blocked.COM`) is still blocked, but its block is **silently dropped** from `dnsbl.log` and the per-group counter → per-feed under-count.

**Fix:** normalize the lookup key (`q_name_key = q_name.lower()`) for the `decisionDB` lookup and the dedup `event_sig`; the log line keeps the original casing.

### 2. CNAME target evaluated against the wrong TLD

In the validate loop, `tld = get_tld(qstate)` is the **original** query's second-level label, but `evaluate_domain` uses `tld` for the **TLD-Allow** (`python_tld`) and **HSTS** checks on the *name being evaluated*. A CNAME target whose TLD differs from the original's was checked against the original's TLD — so a target whose TLD is **not** in the allowlist could slip past TLD-Allow (or be mis-HSTS'd).

**Fix:** add `get_tld_from_name()` (the same second-level label, derived from a name string) and use it for CNAME targets; the original-query path is unchanged (still `get_tld(qstate)`).

### Tests

Each fix is pinned by a test that **fails without it** (verified by stashing the production change):

- `test_mixed_case_query_is_attributed` — a `Blocked.COM` query produces a `dnsbl.log` line.
- `test_cname_target_uses_target_tld_not_original` — `orig.com` (allowed SLD) → CNAME `evil.net` (disallowed SLD) blocks via the **target's** TLD.
- `TestGetTldFromName` units (multilabel, trailing dot, single label).

999 passed; ruff, mypy, markdownlint, shellcheck, php -l clean.

Closes the two follow-ups noted on #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of domain name attribution in DNSBL decision tracking by properly handling different case variations.
  * Enhanced CNAME chain validation to correctly apply TLD-based filtering rules based on the target domain's TLD rather than the original query's TLD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->