### PR TITLE
pfblockerng: unify all query-time caches into one decisionDB (Stage 2)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -92,12 +92,10 @@ hstsDB: defaultdict[str, Any]
 whiteDB: defaultdict[str, Any]
 gpListDB: defaultdict[str, Any]
 noAAAADB: defaultdict[str, Any]
-decisionDB: dict[str, DnsblDecision]
+decisionDB: dict[str, Decision]
 _dnsbl_last_event: Any = None
 safeSearchDB: defaultdict[str, Any]
 feedGroupIndexDB: defaultdict[int, Any]
-excludeAAAADB: list[str]
-excludeSS: list[str]
 maxmindReader: Any
 
 # Background I/O worker (file + sqlite writes off the DNS response path)
@@ -209,8 +207,6 @@ def init_standard(id: int, env: module_env) -> bool:
         allowRegexDB, \
         hstsDB, \
         whiteDB, \
-        excludeAAAADB, \
-        excludeSS, \
         decisionDB, \
         _dnsbl_last_event, \
         noAAAADB, \
@@ -425,8 +421,6 @@ def init_standard(id: int, env: module_env) -> bool:
     gpListDB = defaultdict(str)
     noAAAADB = defaultdict(str)
     feedGroupDB: defaultdict[str, Any] = defaultdict(str)
-    excludeAAAADB = []
-    excludeSS = []
 
     # Read pfb_unbound.ini settings
     if os.path.isfile(pfb["pfb_unbound.ini"]):
@@ -1262,16 +1256,17 @@ def get_details_dnsbl(
     # a mixed-case query is blocked but its block is not attributed here (the log/counter
     # path silently misses it -> per-feed under-count).
     q_name_key = q_name.lower()
-    isDNSBL = decisionDB.get(q_name_key)
-    if isDNSBL is not None and isDNSBL.is_found and not isDNSBL.in_whitelist:
+    cached = decisionDB.get(q_name_key)
+    dnsbl = cached.dnsbl if cached is not None else UNSET
+    if dnsbl is not UNSET and dnsbl.is_found and not dnsbl.in_whitelist:
         # If logging is disabled, do not log blocked DNSBL events (Utilize DNSBL Webserver)
         # except for Python nullblock events
-        if pfb["python_nolog"] and not isDNSBL.null_blocking:
+        if pfb["python_nolog"] and not dnsbl.null_blocking:
             return True
 
         # Increment dnsblgroup counter
-        if pfb["sqlite3_dnsbl_con"] and isDNSBL.group != "":
-            pfb_db_enqueue(("dnsbl", isDNSBL.group))
+        if pfb["sqlite3_dnsbl_con"] and dnsbl.group != "":
+            pfb_db_enqueue(("dnsbl", dnsbl.group))
 
         # The cached DnsblDecision is both name- and qtype-independent for some block
         # kinds -- two subdomains of one blocked zone share an identical payload (same
@@ -1285,7 +1280,7 @@ def get_details_dnsbl(
         q_type = get_q_type(qstate, qinfo)
 
         dupEntry = "+"
-        event_sig = (q_name_key, q_type, isDNSBL)
+        event_sig = (q_name_key, q_type, dnsbl)
         if _dnsbl_last_event is not None:
             if str(_dnsbl_last_event) == str(event_sig):
                 dupEntry = "-"
@@ -1295,7 +1290,7 @@ def get_details_dnsbl(
             _dnsbl_last_event = event_sig
 
         # Skip logging
-        if isDNSBL.log_type == "2":
+        if dnsbl.log_type == "2":
             return True
 
         q_ip = get_q_ip_comm(kwargs)
@@ -1311,11 +1306,11 @@ def get_details_dnsbl(
                 timestamp,
                 q_name,
                 q_ip,
-                isDNSBL.p_type,
-                isDNSBL.b_type,
-                isDNSBL.group,
-                isDNSBL.b_eval,
-                isDNSBL.feed,
+                dnsbl.p_type,
+                dnsbl.b_type,
+                dnsbl.group,
+                dnsbl.b_eval,
+                dnsbl.feed,
                 dupEntry,
                 q_type,
             )
@@ -1452,7 +1447,7 @@ def get_details_reply(
         is_reply = False
         if q_name.startswith("python_control."):
             is_reply = True
-        if not is_reply and q_type == "AAAA" and noAAAADB.get(q_name) is not None:
+        if not is_reply and q_type == "AAAA" and evaluate_noaaaa(q_name, noAAAADB):
             is_reply = True
 
         if not is_reply:
@@ -1529,7 +1524,7 @@ def get_details_reply(
         q_name = "NS"
 
     # Determine if domain was noAAAA blocked
-    if r_addr == "NXDOMAIN" and q_type == "AAAA" and noAAAADB.get(q_name) is not None:
+    if r_addr == "NXDOMAIN" and q_type == "AAAA" and evaluate_noaaaa(q_name, noAAAADB):
         r_addr = "noAAAA"
 
     if pfb["python_maxmind"] and r_addr not in ("", "Unknown", "NXDOMAIN", "NODATA", "DNSSEC", "SOA", "NS"):
@@ -3341,6 +3336,37 @@ class DnsblDecision:
     b_eval: str
 
 
+class _Unset:
+    # Sentinel: a Decision axis has not been evaluated yet for this name -- distinct
+    # from an evaluated allow/no-match (dnsbl.is_found False / noaaaa False /
+    # safesearch None). One shared immutable instance, UNSET, below.
+    __slots__ = ()
+
+
+UNSET: Any = _Unset()
+
+
+@dataclass
+class Decision:
+    # The single per-domain verdict across every axis operate() decides. Each axis is
+    # filled lazily (its check runs at a different point in operate(): noAAAA + SafeSearch
+    # pre-resolution on q_name_original, DNSBL post-resolution on the chain) and cached
+    # in decisionDB, so repeat queries skip re-evaluation. This replaces the separate
+    # dnsblDB/excludeDB (Stage 1) AND excludeAAAADB/excludeSS/noAAAADB-memo (Stage 2).
+    dnsbl: Any = UNSET  # DnsblDecision once the DNSBL stratum evaluated the name
+    noaaaa: Any = UNSET  # bool (AAAA-only): True = block, False = allow
+    safesearch: Any = UNSET  # matched safeSearchDB {A,AAAA} entry, or None = no match
+
+
+def _decision_for(name: str) -> Decision:
+    # Get-or-create the one Decision entry for a name; axes are filled in by the caller.
+    dec = decisionDB.get(name)
+    if dec is None:
+        dec = Decision()
+        decisionDB[name] = dec
+    return dec
+
+
 # ADR-07 P3: the 6-band precedence scale (ADR.md SS2 / RESULTS-P2 SS2). Highest wins;
 # a block wins iff block_prio > allow_prio (no ties: block in {1,3,5}, allow in {2,4,6}).
 #   6 user allow   5 user block   4 feed allow+important
@@ -3757,15 +3783,16 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
         pass
 
     if (event == MODULE_EVENT_NEW) or (event == MODULE_EVENT_PASS):
-        # no AAAA validation
-        if qstate_valid and q_type == RR_TYPE_AAAA and pfb["noAAAADB"] and q_name_original not in excludeAAAADB:
-            isin_noAAAA = evaluate_noaaaa(q_name_original, noAAAADB)
+        # no AAAA validation. The verdict is memoized on the name's Decision (noaaaa
+        # axis): UNSET = not yet evaluated, True = block, False = allow (the old
+        # excludeAAAADB negative memo). No separate excludeAAAADB / noAAAADB-memo.
+        if qstate_valid and q_type == RR_TYPE_AAAA and pfb["noAAAADB"]:
+            dec = _decision_for(q_name_original)
+            if dec.noaaaa is UNSET:
+                dec.noaaaa = evaluate_noaaaa(q_name_original, noAAAADB)
 
             # Create FQDN Reply Message (AAAA -> A)
-            if isin_noAAAA:
-                if noAAAADB.get(q_name_original) is None:
-                    noAAAADB[q_name_original] = True
-
+            if dec.noaaaa:
                 msg = DNSMessage(qstate.qinfo.qname_str, RR_TYPE_A, RR_CLASS_IN, PKT_QR | PKT_RA)
                 if msg is None or not msg.set_return_msg(qstate):
                     qstate.ext_state[id] = MODULE_ERROR
@@ -3776,14 +3803,13 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                 qstate.ext_state[id] = MODULE_FINISHED
                 return True
 
-            # Add domain to excludeAAAADB to skip subsequent no AAAA validation
-            else:
-                excludeAAAADB.append(q_name_original)
-
         # SafeSearch Redirection validation
         if qstate_valid and pfb["safeSearchDB"]:
-            # Determine if domain has been previously validated
-            if q_name_original not in excludeSS:
+            # SafeSearch verdict memoized on the name's Decision (safesearch axis):
+            # UNSET = not yet evaluated, the matched {A,AAAA} entry = rewrite, None = no
+            # match (the old excludeSS negative memo). No separate excludeSS structure.
+            dec = _decision_for(q_name_original)
+            if dec.safesearch is UNSET:
                 isSafeSearch = safeSearchDB.get(q_name_original)
 
                 # Validate 'www.' Domains
@@ -3798,72 +3824,71 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                 #        and q_name_original.endswith('pixabay.com'):
                 #    isSafeSearch = safeSearchDB.get('pixabay.com')
 
-                if isSafeSearch is not None:
-                    ss_found = False
-                    msg = None
-                    cname_msg = None
-                    if isSafeSearch["A"] == "nxdomain":
-                        qstate.return_rcode = RCODE_NXDOMAIN
-                        qstate.ext_state[id] = MODULE_FINISHED
-                        return True
+                dec.safesearch = isSafeSearch
+            isSafeSearch = dec.safesearch
 
-                    # TODO: Wait for Unbound code changes to allow for this functionality,
-                    # using local-zone/local-data entries for CNAMES for now
-                    elif isSafeSearch["A"] == "cname":
-                        if isSafeSearch["AAAA"] is not None and isSafeSearch["AAAA"] != "":
-                            if q_type == RR_TYPE_A:
-                                cname_msg = DNSMessage(
-                                    qstate.qinfo.qname_str, RR_TYPE_A, RR_CLASS_IN, PKT_QR | PKT_RD | PKT_RA
-                                )
-                                cname_msg.answer.append(
-                                    "{} 3600 IN CNAME {}".format(qstate.qinfo.qname_str, isSafeSearch["AAAA"])
-                                )
-                                ss_found = True
-                            elif q_type == RR_TYPE_AAAA:
-                                cname_msg = DNSMessage(
-                                    qstate.qinfo.qname_str, RR_TYPE_AAAA, RR_CLASS_IN, PKT_QR | PKT_RD | PKT_RA
-                                )
-                                cname_msg.answer.append(
-                                    "{} 3600 IN CNAME {}".format(qstate.qinfo.qname_str, isSafeSearch["AAAA"])
-                                )
-                                ss_found = True
+            if isSafeSearch is not None:
+                ss_found = False
+                msg = None
+                cname_msg = None
+                if isSafeSearch["A"] == "nxdomain":
+                    qstate.return_rcode = RCODE_NXDOMAIN
+                    qstate.ext_state[id] = MODULE_FINISHED
+                    return True
 
-                            if ss_found:
-                                if cname_msg is None or not cname_msg.set_return_msg(qstate):
-                                    qstate.ext_state[id] = MODULE_ERROR
-                                    return True
-
-                                MODULE_RESTART_NEXT = 3
-                                qstate.no_cache_store = 1
-                                qstate.ext_state[id] = MODULE_RESTART_NEXT
-                                return True
-                    else:
-                        if (q_type == RR_TYPE_A and isSafeSearch["A"] != "") or (
-                            q_type == RR_TYPE_AAAA and isSafeSearch["AAAA"] == ""
-                        ):
-                            msg = DNSMessage(qstate.qinfo.qname_str, RR_TYPE_A, RR_CLASS_IN, PKT_QR | PKT_RA)
-                            msg.answer.append("{} 300 IN {} {}".format(qstate.qinfo.qname_str, "A", isSafeSearch["A"]))
+                # TODO: Wait for Unbound code changes to allow for this functionality,
+                # using local-zone/local-data entries for CNAMES for now
+                elif isSafeSearch["A"] == "cname":
+                    if isSafeSearch["AAAA"] is not None and isSafeSearch["AAAA"] != "":
+                        if q_type == RR_TYPE_A:
+                            cname_msg = DNSMessage(
+                                qstate.qinfo.qname_str, RR_TYPE_A, RR_CLASS_IN, PKT_QR | PKT_RD | PKT_RA
+                            )
+                            cname_msg.answer.append(
+                                "{} 3600 IN CNAME {}".format(qstate.qinfo.qname_str, isSafeSearch["AAAA"])
+                            )
                             ss_found = True
-                        elif q_type == RR_TYPE_AAAA and isSafeSearch["AAAA"] != "":
-                            msg = DNSMessage(qstate.qinfo.qname_str, RR_TYPE_AAAA, RR_CLASS_IN, PKT_QR | PKT_RA)
-                            msg.answer.append(
-                                "{} 300 IN {} {}".format(qstate.qinfo.qname_str, "AAAA", isSafeSearch["AAAA"])
+                        elif q_type == RR_TYPE_AAAA:
+                            cname_msg = DNSMessage(
+                                qstate.qinfo.qname_str, RR_TYPE_AAAA, RR_CLASS_IN, PKT_QR | PKT_RD | PKT_RA
+                            )
+                            cname_msg.answer.append(
+                                "{} 3600 IN CNAME {}".format(qstate.qinfo.qname_str, isSafeSearch["AAAA"])
                             )
                             ss_found = True
 
-                    if ss_found:
-                        if msg is None or not msg.set_return_msg(qstate):
-                            qstate.ext_state[id] = MODULE_ERROR
-                            return True
+                        if ss_found:
+                            if cname_msg is None or not cname_msg.set_return_msg(qstate):
+                                qstate.ext_state[id] = MODULE_ERROR
+                                return True
 
-                        qstate.return_rcode = RCODE_NOERROR
-                        qstate.return_msg.rep.security = 2
-                        qstate.ext_state[id] = MODULE_FINISHED
+                            MODULE_RESTART_NEXT = 3
+                            qstate.no_cache_store = 1
+                            qstate.ext_state[id] = MODULE_RESTART_NEXT
+                            return True
+                else:
+                    if (q_type == RR_TYPE_A and isSafeSearch["A"] != "") or (
+                        q_type == RR_TYPE_AAAA and isSafeSearch["AAAA"] == ""
+                    ):
+                        msg = DNSMessage(qstate.qinfo.qname_str, RR_TYPE_A, RR_CLASS_IN, PKT_QR | PKT_RA)
+                        msg.answer.append("{} 300 IN {} {}".format(qstate.qinfo.qname_str, "A", isSafeSearch["A"]))
+                        ss_found = True
+                    elif q_type == RR_TYPE_AAAA and isSafeSearch["AAAA"] != "":
+                        msg = DNSMessage(qstate.qinfo.qname_str, RR_TYPE_AAAA, RR_CLASS_IN, PKT_QR | PKT_RA)
+                        msg.answer.append(
+                            "{} 300 IN {} {}".format(qstate.qinfo.qname_str, "AAAA", isSafeSearch["AAAA"])
+                        )
+                        ss_found = True
+
+                if ss_found:
+                    if msg is None or not msg.set_return_msg(qstate):
+                        qstate.ext_state[id] = MODULE_ERROR
                         return True
 
-            # Add domain to excludeSS to skip subsequent SafeSearch validation
-            else:
-                excludeSS.append(q_name_original)
+                    qstate.return_rcode = RCODE_NOERROR
+                    qstate.return_msg.rep.security = 2
+                    qstate.ext_state[id] = MODULE_FINISHED
+                    return True
 
         # Python_control - Receive TXT commands from pfSense local IP
         if qstate_valid and q_type == RR_TYPE_TXT and q_name_original.startswith("python_control."):
@@ -4024,8 +4049,9 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
             # ("let Unbound resolve it" / whitelisted) -- both are decisions, both
             # are memoized. A repeat query (including a CNAME-blocked name, keyed on
             # the original) short-circuits here without re-resolving or re-evaluating.
-            decision = decisionDB.get(q_name)
-            if decision is None:
+            dec = decisionDB.get(q_name)
+            dnsbl = dec.dnsbl if dec is not None else UNSET
+            if dnsbl is UNSET:
                 # The original query's TLD comes from qstate; a CNAME target (isCNAME)
                 # has its own TLD, so derive it from the target name being evaluated --
                 # else the TLD-Allow / HSTS checks use the wrong TLD for the target.
@@ -4058,33 +4084,34 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                     "feedGroupIndexDB": feedGroupIndexDB,
                     "hstsDB": hstsDB,
                 }
-                decision = evaluate_domain(q_name, q_name_original, tld, isCNAME, cfg, containers)
+                dnsbl = evaluate_domain(q_name, q_name_original, tld, isCNAME, cfg, containers)
 
                 # A block found via a CNAME chain is recorded against the ORIGINAL
                 # queried name, so a later query for it short-circuits on this entry.
-                if decision.is_found and not decision.in_whitelist and isCNAME:
+                if dnsbl.is_found and not dnsbl.in_whitelist and isCNAME:
                     q_name = q_name_original
 
-                # Memoize the verdict (block OR allow) so this name is decided once.
-                decisionDB[q_name] = decision
+                # Memoize the DNSBL verdict on the name's Decision (block OR allow), so
+                # this name is decided once; the other axes share the same entry.
+                _decision_for(q_name).dnsbl = dnsbl
 
                 # Add domain data to DNSBL cache for Reports tab (fresh block only)
-                if decision.is_found and not decision.in_whitelist:
-                    pfb_db_enqueue(("cache", (decision.b_type, q_name, decision.group, decision.b_eval, decision.feed)))
+                if dnsbl.is_found and not dnsbl.in_whitelist:
+                    pfb_db_enqueue(("cache", (dnsbl.b_type, q_name, dnsbl.group, dnsbl.b_eval, dnsbl.feed)))
 
             # Block iff found and not whitelisted; an allow decision falls through to
             # the resolver (the WAIT_MODULE below).
-            if decision.is_found and not decision.in_whitelist:
+            if dnsbl.is_found and not dnsbl.in_whitelist:
                 # Create FQDN Reply Message
                 msg = DNSMessage(qstate.qinfo.qname_str, q_type, RR_CLASS_IN, PKT_QR | PKT_RA)
 
                 if q_type == RR_TYPE_A or q_type == RR_TYPE_ANY:
                     msg.answer.append(
-                        "{}. 3600 IN A {}".format(q_name, "0.0.0.0" if decision.null_blocking else pfb["dnsbl_ipv4"])
+                        "{}. 3600 IN A {}".format(q_name, "0.0.0.0" if dnsbl.null_blocking else pfb["dnsbl_ipv4"])
                     )
                 if q_type == RR_TYPE_AAAA or q_type == RR_TYPE_ANY:
                     msg.answer.append(
-                        "{}. 3600 IN AAAA {}".format(q_name, "::" if decision.null_blocking else pfb["dnsbl_ipv6"])
+                        "{}. 3600 IN AAAA {}".format(q_name, "::" if dnsbl.null_blocking else pfb["dnsbl_ipv6"])
                     )
 
                 if msg is None or not msg.set_return_msg(qstate):

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3836,8 +3836,13 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                     qstate.ext_state[id] = MODULE_FINISHED
                     return True
 
-                # TODO: Wait for Unbound code changes to allow for this functionality,
-                # using local-zone/local-data entries for CNAMES for now
+                # TODO: Unbound will not chase a CNAME we hand it (module-injected here,
+                # or via local-zone/local-data) to its target's A/AAAA -- it returns the
+                # bare CNAME. So we restart the module chain (module_restart_next, below)
+                # to get the target resolved, and the config side also wires SafeSearch
+                # CNAMEs as local-data. Revisit if Unbound gains native chasing of a
+                # supplied CNAME. Upstream defect (open, unfixed as of Unbound 1.25.x):
+                # https://github.com/NLnetLabs/unbound/issues/976
                 elif isSafeSearch["A"] == "cname":
                     if isSafeSearch["AAAA"] is not None and isSafeSearch["AAAA"] != "":
                         if q_type == RR_TYPE_A:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3763,8 +3763,8 @@ def evaluate_noaaaa(q_name: str, noaaaa_db: dict[str, Any]) -> bool:
 
 
 def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
-    global pfb, threads, dataDB, zoneDB, hstsDB, whiteDB, decisionDB, excludeAAAADB
-    global excludeSS, noAAAADB, gpListDB, safeSearchDB
+    global pfb, threads, dataDB, zoneDB, hstsDB, whiteDB, decisionDB
+    global noAAAADB, gpListDB, safeSearchDB
 
     qstate_valid = False
     q_type: Any = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,8 +104,6 @@ def reset_pfb_globals() -> None:
     pfb_unbound.hstsDB = defaultdict(str)
     pfb_unbound.gpListDB = defaultdict(str)
     pfb_unbound.noAAAADB = defaultdict(str)
-    pfb_unbound.excludeAAAADB = []
-    pfb_unbound.excludeSS = []
     pfb_unbound.threads = []
 
     # Reset the persistent sqlite connection cache between tests (the :memory:

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1223,10 +1223,12 @@ class TestGetDetailsReplyNoaaaa:
         # Stage 2: a wildcard-parent noAAAA child (not an exact entry) now passes the
         # gate via evaluate_noaaaa. Pre-Stage-2 the gate read noAAAADB.get(child), which
         # only saw the child once the (now-removed) query-time memo wrote it.
-        calls = []
+        calls: list[Any] = []
+        assert calls == []  # before-state: no side effect yet
         monkeypatch.setattr(pfb_unbound, "pfb_db_enqueue", lambda *a, **k: calls.append(a))
         pfb_unbound.pfb["sqlite3_resolver_con"] = True
         add_noaaaa("example.com", wildcard=True)
+        assert "sub.example.com" not in pfb_unbound.noAAAADB  # not exact -> gate must pass via wildcard
         qstate = self._aaaa_qstate("sub.example.com.")
         rcd = pfb_unbound.get_details_reply("reply-x", None, qstate, None, {"pfb_addr": "1.2.3.4"})
         assert rcd is True
@@ -1253,6 +1255,7 @@ class TestStage2UnifiedDecision:
         set_feed_group(0, "F", "G")
         add_noaaaa("unrelated.com", wildcard=False)  # enables the noAAAA path; multi.com unlisted
         pfb_unbound.pfb["safeSearchDB"] = True  # enables the SafeSearch path; multi.com unlisted
+        assert "multi.com" not in pfb_unbound.decisionDB  # before-state: no Decision yet
         qstate = make_qstate("multi.com.", qtype=RR_AAAA)
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert rcd is True
@@ -1267,6 +1270,7 @@ class TestStage2UnifiedDecision:
         # name NOT in the noAAAADB source -> the memo, not re-evaluation, did it.
         self._enable(monkeypatch)
         add_noaaaa("unrelated.com", wildcard=False)  # enable the path; x.com unlisted
+        assert "x.com" not in pfb_unbound.noAAAADB  # absent from source -> only the cache can block
         pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(noaaaa=True)
         qstate = make_qstate("x.com.", qtype=RR_AAAA)
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
@@ -1277,6 +1281,7 @@ class TestStage2UnifiedDecision:
         # NOT in the safeSearchDB source -> the memo did it.
         self._enable(monkeypatch)
         pfb_unbound.pfb["safeSearchDB"] = True
+        assert "x.com" not in pfb_unbound.safeSearchDB  # absent from source -> only the cache rewrites
         pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(safesearch={"A": "1.2.3.4", "AAAA": ""})
         qstate = make_qstate("x.com.", qtype=RR_A)
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -74,28 +74,43 @@ def set_feed_group(index: int, feed: str, group: str) -> None:
 
 
 def _is_block(dec: Any) -> bool:
-    # A decisionDB entry is a block iff it was found and not whitelisted -- the same
-    # predicate operate()/get_details_dnsbl use. decisionDB now also stores allow
-    # ("let it resolve"/whitelisted) verdicts, so membership alone no longer means
-    # "blocked".
-    return dec is not None and dec.is_found and not dec.in_whitelist
+    # A decisionDB entry's DNSBL axis is a block iff found and not whitelisted -- the
+    # same predicate operate()/get_details_dnsbl use. dec is a composed Decision (or
+    # None); the DNSBL verdict lives on dec.dnsbl (UNSET until the DNSBL stratum ran).
+    if dec is None or dec.dnsbl is pfb_unbound.UNSET:
+        return False
+    return dec.dnsbl.is_found and not dec.dnsbl.in_whitelist
+
+
+def _dnsbl_decision(**kw: Any) -> Any:
+    # A bare DnsblDecision; kw overrides defaults (a not-found/allow verdict by default).
+    fields: dict[str, Any] = {
+        "is_found": False,
+        "in_whitelist": False,
+        "in_hsts": False,
+        "null_blocking": True,
+        "log_type": "",
+        "b_type": "",
+        "p_type": "",
+        "feed": "",
+        "group": "",
+        "b_eval": "",
+    }
+    fields.update(kw)
+    return pfb_unbound.DnsblDecision(**fields)
 
 
 def allow_decision() -> Any:
-    # A minimal not-found (allow) verdict, for seeding decisionDB to exercise the
+    # A composed Decision whose DNSBL axis is a not-found (allow) verdict -- seeds the
     # allow short-circuit path (the old excludeDB membership).
-    return pfb_unbound.DnsblDecision(
-        is_found=False,
-        in_whitelist=False,
-        in_hsts=False,
-        null_blocking=True,
-        log_type="",
-        b_type="",
-        p_type="",
-        feed="",
-        group="",
-        b_eval="",
-    )
+    return pfb_unbound.Decision(dnsbl=_dnsbl_decision())
+
+
+def block_decision(**kw: Any) -> Any:
+    # A composed Decision whose DNSBL axis is a block; kw overrides DnsblDecision fields.
+    base = {"is_found": True, "log_type": "1", "b_type": "DNSBL", "p_type": "Python", "feed": "F", "group": "G"}
+    base.update(kw)
+    return pfb_unbound.Decision(dnsbl=_dnsbl_decision(**base))
 
 
 class TestIsUnknown:
@@ -631,17 +646,21 @@ class TestGetDetailsDnsblQtype:
 
     @staticmethod
     def _decision() -> Any:
-        return pfb_unbound.DnsblDecision(
-            is_found=True,
-            in_whitelist=False,
-            in_hsts=False,
-            null_blocking=False,
-            log_type="1",
-            b_type="DNSBL_Python",
-            p_type="Python",
-            feed="feedX",
-            group="groupY",
-            b_eval="blocked.com",
+        # A composed Decision whose DNSBL axis is a block (decisionDB values are
+        # Decision, the DNSBL verdict lives on .dnsbl).
+        return pfb_unbound.Decision(
+            dnsbl=pfb_unbound.DnsblDecision(
+                is_found=True,
+                in_whitelist=False,
+                in_hsts=False,
+                null_blocking=False,
+                log_type="1",
+                b_type="DNSBL_Python",
+                p_type="Python",
+                feed="feedX",
+                group="groupY",
+                b_eval="blocked.com",
+            )
         )
 
     def _qstate(self, qtype: str) -> types.SimpleNamespace:
@@ -714,7 +733,11 @@ class TestGetDetailsDnsblQtype:
             group="groupY",
             b_eval="evil.com",
         )
-        monkeypatch.setattr(pfb_unbound, "decisionDB", {"a.evil.com": dec, "b.evil.com": dec})
+        monkeypatch.setattr(
+            pfb_unbound,
+            "decisionDB",
+            {"a.evil.com": pfb_unbound.Decision(dnsbl=dec), "b.evil.com": pfb_unbound.Decision(dnsbl=dec)},
+        )
         lines: list[tuple[str, str]] = []
         monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: lines.append((path, line)))
         for name in ("a.evil.com.", "b.evil.com."):
@@ -855,9 +878,9 @@ class TestOperateNoAAAA:
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED
-        # The wildcard-parent hit memoizes an exact noAAAADB entry for the child,
-        # so a subsequent identical query short-circuits on the exact branch.
-        assert pfb_unbound.noAAAADB.get("sub.example.com") is True
+        # The wildcard-parent hit is memoized as the child's noaaaa verdict on its
+        # Decision, so a subsequent identical query short-circuits on the cache.
+        assert pfb_unbound.decisionDB["sub.example.com"].noaaaa is True
         assert evaluate_noaaaa("sub.example.com", pfb_unbound.noAAAADB) is True
         # Fast-path is unchanged: a subsequent identical query still blocks.
         qstate2 = make_qstate("sub.example.com.", qtype=RR_AAAA)
@@ -867,7 +890,8 @@ class TestOperateNoAAAA:
 
     def test_excluded_domain_not_blocked(self) -> None:
         add_noaaaa("example.com", wildcard=False)
-        pfb_unbound.excludeAAAADB.append("example.com")
+        # A cached allow verdict (noaaaa False) short-circuits -- the old excludeAAAADB.
+        pfb_unbound.decisionDB["example.com"] = pfb_unbound.Decision(noaaaa=False)
         qstate = make_qstate("example.com.", qtype=RR_AAAA)
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert qstate.ext_state[0] == MODULE_WAIT_MODULE
@@ -878,11 +902,11 @@ class TestOperateNoAAAA:
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert qstate.ext_state[0] == MODULE_WAIT_MODULE
 
-    def test_no_match_adds_to_exclude(self) -> None:
+    def test_no_match_caches_allow(self) -> None:
         add_noaaaa("other.com", wildcard=True)
         qstate = make_qstate("example.com.", qtype=RR_AAAA)
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
-        assert "example.com" in pfb_unbound.excludeAAAADB
+        assert pfb_unbound.decisionDB["example.com"].noaaaa is False
         assert qstate.ext_state[0] == MODULE_WAIT_MODULE
 
 
@@ -968,7 +992,7 @@ class TestOperateDnsbl:
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED
         entry = pfb_unbound.decisionDB.get("evil-domain.com")
-        assert entry.group == "DNSBL_Regex"
+        assert entry.dnsbl.group == "DNSBL_Regex"
 
     def test_allow_decision_short_circuit(self, monkeypatch: Any) -> None:
         # A cached allow verdict ("let it resolve") short-circuits the matcher -- the
@@ -986,18 +1010,7 @@ class TestOperateDnsbl:
         # from decisionDB without dataDB/evaluate_domain. The name is NOT on any list,
         # so if it blocks, the memo -- not re-evaluation -- did it.
         self._enable(monkeypatch)
-        pfb_unbound.decisionDB["cached-block.com"] = pfb_unbound.DnsblDecision(
-            is_found=True,
-            in_whitelist=False,
-            in_hsts=False,
-            null_blocking=True,
-            log_type="1",
-            b_type="DNSBL",
-            p_type="Python",
-            feed="F",
-            group="G",
-            b_eval="cached-block.com",
-        )
+        pfb_unbound.decisionDB["cached-block.com"] = block_decision(b_eval="cached-block.com")
         qstate = make_qstate("cached-block.com.", qtype=RR_A)
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert rcd is True
@@ -1054,7 +1067,7 @@ class TestOperateDnsbl:
 
         entry = pfb_unbound.decisionDB.get("orig.com")
         assert entry is not None
-        assert entry.b_type == "DNSBL_CNAME"
+        assert entry.dnsbl.b_type == "DNSBL_CNAME"
         # Block is keyed on the original name after the q_name reassignment,
         # not on the CNAME target itself.
         assert not _is_block(pfb_unbound.decisionDB.get("evil-cname.com"))
@@ -1111,7 +1124,7 @@ class TestOperateDnsbl:
         assert qstate.ext_state[0] == MODULE_FINISHED  # blocked via the TARGET's TLD
         entry = pfb_unbound.decisionDB.get("orig.com")
         assert entry is not None
-        assert entry.group == "DNSBL_TLD_Allow"
+        assert entry.dnsbl.group == "DNSBL_TLD_Allow"
 
     def test_cname_repeat_short_circuits_without_chain(self, monkeypatch: Any) -> None:
         # The unified-cache CNAME fix: a CNAME-blocked name is keyed on the ORIGINAL in
@@ -1174,8 +1187,10 @@ class TestOperateEvents:
 
 
 class TestGetDetailsReplyNoaaaa:
-    """The reply-x gate in get_details_reply only proceeds for an AAAA reply
-    whose name has an exact noAAAA entry (``noAAAADB.get(name) is not None``)."""
+    """The reply-x gate in get_details_reply proceeds for an AAAA reply whose name is
+    noAAAA-blocked -- exact OR via a wildcard parent. Stage 2 removed the noAAAADB
+    query-time memo, so this gate uses ``evaluate_noaaaa`` (exact + wildcard) rather
+    than a bare ``noAAAADB.get(name)``, which only saw exact (or memoized) names."""
 
     def _aaaa_qstate(self, qname: str) -> types.SimpleNamespace:
         qstate = make_qstate(qname, qtype=RR_AAAA)
@@ -1203,6 +1218,72 @@ class TestGetDetailsReplyNoaaaa:
         assert rcd is True
         # Gate failed -> early return before the resolver counter fires.
         assert calls == []
+
+    def test_reply_x_aaaa_wildcard_child_proceeds(self, monkeypatch: Any) -> None:
+        # Stage 2: a wildcard-parent noAAAA child (not an exact entry) now passes the
+        # gate via evaluate_noaaaa. Pre-Stage-2 the gate read noAAAADB.get(child), which
+        # only saw the child once the (now-removed) query-time memo wrote it.
+        calls = []
+        monkeypatch.setattr(pfb_unbound, "pfb_db_enqueue", lambda *a, **k: calls.append(a))
+        pfb_unbound.pfb["sqlite3_resolver_con"] = True
+        add_noaaaa("example.com", wildcard=True)
+        qstate = self._aaaa_qstate("sub.example.com.")
+        rcd = pfb_unbound.get_details_reply("reply-x", None, qstate, None, {"pfb_addr": "1.2.3.4"})
+        assert rcd is True
+        assert len(calls) == 1
+
+
+class TestStage2UnifiedDecision:
+    """Stage 2: one decisionDB[name] = Decision carries every axis (dnsbl / noaaaa /
+    safesearch), each filled lazily and cached -- replacing excludeAAAADB / excludeSS
+    and the noAAAADB query-time memo."""
+
+    def _enable(self, monkeypatch: Any) -> None:
+        pfb_unbound.pfb["python_blacklist"] = True
+        pfb_unbound.pfb["python_blocking"] = True
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda *a: None)
+        monkeypatch.setattr(pfb_unbound, "pfb_db_enqueue", lambda *a: None)
+
+    def test_one_decision_accumulates_axes(self, monkeypatch: Any) -> None:
+        # An AAAA query for a DNSBL-listed name that is noAAAA-allow + SafeSearch-no-match
+        # leaves ONE decisionDB entry with all three axes filled -- the unification end
+        # state (noaaaa False, safesearch None, dnsbl block).
+        self._enable(monkeypatch)
+        add_data("multi.com", log="1", index=0)
+        set_feed_group(0, "F", "G")
+        add_noaaaa("unrelated.com", wildcard=False)  # enables the noAAAA path; multi.com unlisted
+        pfb_unbound.pfb["safeSearchDB"] = True  # enables the SafeSearch path; multi.com unlisted
+        qstate = make_qstate("multi.com.", qtype=RR_AAAA)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED  # DNSBL blocked
+        dec = pfb_unbound.decisionDB["multi.com"]
+        assert dec.noaaaa is False  # noAAAA allow, evaluated + cached
+        assert dec.safesearch is None  # SafeSearch no-match, evaluated + cached
+        assert _is_block(dec)  # DNSBL block
+
+    def test_noaaaa_verdict_reused_without_reeval(self, monkeypatch: Any) -> None:
+        # A cached noaaaa=True blocks an AAAA query straight from the Decision, with the
+        # name NOT in the noAAAADB source -> the memo, not re-evaluation, did it.
+        self._enable(monkeypatch)
+        add_noaaaa("unrelated.com", wildcard=False)  # enable the path; x.com unlisted
+        pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(noaaaa=True)
+        qstate = make_qstate("x.com.", qtype=RR_AAAA)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert qstate.ext_state[0] == MODULE_FINISHED
+
+    def test_safesearch_verdict_reused_without_reeval(self, monkeypatch: Any) -> None:
+        # A cached safesearch entry rewrites straight from the Decision, with the name
+        # NOT in the safeSearchDB source -> the memo did it.
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["safeSearchDB"] = True
+        pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(safesearch={"A": "1.2.3.4", "AAAA": ""})
+        qstate = make_qstate("x.com.", qtype=RR_A)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        answers = DNSMessage.instances[-1].answer
+        assert any("1.2.3.4" in a for a in answers)
 
 
 # ---------------------------------------------------------------------------
@@ -2033,5 +2114,5 @@ class TestADR02PythonOnlyBlocking:
         assert qstate.ext_state[0] == MODULE_FINISHED
         entry = pfb_unbound.decisionDB.get("any.subdomain.blocked-zone.net")
         assert entry is not None
-        assert entry.b_type == "TLD"
-        assert entry.feed == "ZoneFeed"
+        assert entry.dnsbl.b_type == "TLD"
+        assert entry.dnsbl.feed == "ZoneFeed"


### PR DESCRIPTION
## Unify all query-time caches into one `decisionDB` (Stage 2)

Stage 1 (#67/#68) unified the **DNSBL** axis into `decisionDB`. Stage 2 folds the **remaining** query-time decision memos into the same structure, so the `Decision` is the single per-domain verdict across **every** axis:

- `excludeAAAADB` (list) — noAAAA "not blocked" negative memo
- `excludeSS` (list) — SafeSearch "not a SafeSearch domain" negative memo
- `noAAAADB[name] = True` — the noAAAA wildcard→exact query-time memo

### Design

`decisionDB` values become a composed `Decision` with three **lazily-filled** axes; an `UNSET` sentinel distinguishes "axis not yet evaluated" from an evaluated allow/no-match:

```python
@dataclass
class Decision:
    dnsbl: Any = UNSET       # DnsblDecision (Stage-1 struct)
    noaaaa: Any = UNSET      # bool (AAAA-only): True = block, False = allow
    safesearch: Any = UNSET  # matched {A,AAAA} entry, or None = no match
```

Each axis decides at a different point in `operate()` (noAAAA + SafeSearch pre-resolution on `q_name_original`; DNSBL post-resolution on the chain), so the entry is created on first touch (`_decision_for`) and each axis filled when its check runs, then reused on repeats. The leftover lists + the memo **dissolve** — their negative-memo role becomes a cached `noaaaa = False` / `safesearch = None`, so the "should've been sets" warts go away by removal, not by adding sets.

`get_details_reply`'s two noAAAA-label reads switch from the removed `noAAAADB` memo to `evaluate_noaaaa` (exact **+ wildcard**), so wildcard-child replies are labeled correctly (previously only after the memo had been written). The **source** `noAAAADB` is unchanged — its value (wildcard flag) is load-bearing in `find_noaaaa_wildcard_parent`, so it stays a `dict[str,bool]`, not a set.

### Behaviour preservation

`evaluate_domain` / `evaluate_noaaaa` / `safeSearchDB` lookups are **untouched** → every noAAAA / SafeSearch / DNSBL decision is byte-identical (ADR-06/07 oracles stay green). This changes only *when/how* a verdict is cached.

### Tests

- All existing noAAAA / SafeSearch / DNSBL behaviour tests preserved (migrated to the `Decision` axes).
- New: `test_one_decision_accumulates_axes` (one entry carries dnsbl + noaaaa + safesearch), noAAAA & SafeSearch **cache-reuse** (verdict served from the Decision with the name absent from the source), and `test_reply_x_aaaa_wildcard_child_proceeds` (the `get_details_reply` coupling — **proven** to fail without the `evaluate_noaaaa` switch).
- 1003 passed; ruff, mypy, markdownlint, shellcheck, php -l clean.

### Deferred (own follow-up)

Bound `decisionDB` with an **LRU** (hot/frequently-queried domains must stay resident) — it grows unbounded today (reset only at init/swap). Noted for a separate PR.

ADR docs untouched — note that ADR-10's zero-downtime swap now clears **one** structure instead of four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified per-name decision caching to make DNS-based verdicts, SafeSearch redirects, and IPv6 (AAAA) handling more consistent and efficient.
* **Bug Fixes**
  * More reliable SafeSearch redirection and no-AAAA detection on repeated queries.
  * DNSBL logging and counters now reflect cached verdict details more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->