### PR TITLE
smoke: wire pfSense System DNS to the mock via the 10.0.2.2 host alias

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -254,11 +254,29 @@ jobs:
           SMOKE_DNSBL_VIP4: ${{ secrets.SMOKE_DNSBL_VIP4 || vars.SMOKE_DNSBL_VIP4 }}
           SMOKE_CONTROL_NAME: ${{ secrets.SMOKE_CONTROL_NAME || vars.SMOKE_CONTROL_NAME }}
           SMOKE_CONTROL_IP: ${{ secrets.SMOKE_CONTROL_IP || vars.SMOKE_CONTROL_IP }}
+          # System-DNS upstream wiring: the mock binds the runner loopback :53, and
+          # pfSense forwards to the SLIRP host alias 10.0.2.2 which libslirp NATs
+          # (port-preserving) straight to that mock — no /etc/resolv.conf involvement.
+          SMOKE_STUB_DNS_ADDR: "127.0.0.1"
+          SMOKE_STUB_DNS_PORT: "53"
         run: |
           set -eu
+          # pfSense's System DNS is 10.0.2.2 (libslirp's host alias); libslirp NATs
+          # guest->10.0.2.2:53 to the runner's 127.0.0.1:53 (the mock), the SAME host-alias
+          # path the mock-feed HTTP server already rides. So the ONLY runner-side prep is
+          # lowering the privileged-port floor so the non-root mock (in pytest) can bind
+          # :53 — the runner's /etc/resolv.conf is left untouched (host DNS keeps working
+          # throughout; nothing to restore, and immune to how the runner does resolution).
+          sudo sysctl -w net.ipv4.ip_unprivileged_port_start=53
           # The smoke package is --ignore'd by the default addopts; re-enable it
           # with --override-ini and select the marker (see tests/smoke/conftest).
-          python3 -m pytest tests/smoke -m smoke --override-ini="addopts=" --timeout=300 --timeout-method=signal -v
+          # --timeout=30 + timeout_func_only=true: 30s applies to the TEST BODY only
+          # (inject->reload->probe; slowest observed ~6s), NOT the slow module fixtures
+          # (deploy ~1-2 min) — so a per-case stall fails fast (vs the old 300s -> job-
+          # timeout wipe) while leaving comfortable margin over the real per-case time.
+          python3 -m pytest tests/smoke -m smoke \
+            --override-ini="addopts=" --override-ini="timeout_func_only=true" \
+            --timeout=30 --timeout-method=signal -v
 
       - name: Upload smoke diagnostics
         if: always()

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -438,15 +438,18 @@ class _MockFeedServer:
 class _StubDnsServer:
     """A controlled, OBSERVABLE DNS upstream for the guest's Unbound (over SLIRP).
 
-    This is the smoke matrix's upstream: Unbound forwards every non-local query here
-    (``helpers.use_stub_upstream`` points its sole ``forward-zone "."`` at
-    10.0.2.2:<port>), so what reaches this server is EXACTLY what Unbound did not
-    answer locally. That makes blocking VERIFIABLE from the upstream side rather than
-    inferred from a bare SERVFAIL: every query is recorded (:meth:`received`), so a
-    DNSBL-blocked name must NEVER appear here, while a not-blocked name DOES — and
-    resolves to a known sentinel, distinct from every block shape. Nothing leaks to
-    the real internet; the server answers everything itself. Listens UDP+TCP on one
-    ephemeral port.
+    This is the smoke matrix's upstream: pfSense forwards every non-local query to its
+    System DNS server ``10.0.2.2`` (QEMU/libslirp's host alias — see
+    ``helpers.use_system_dns_upstream``), and libslirp NATs guest->10.0.2.2:53 straight
+    to this server on the RUNNER's loopback (``127.0.0.1:53``), port-preserving — the
+    same host-alias path the mock-feed HTTP server already rides, and the runner's own
+    ``/etc/resolv.conf`` is never touched. So what reaches this server is EXACTLY what
+    Unbound did not answer locally. That makes
+    blocking VERIFIABLE from the upstream side rather than inferred from a bare
+    SERVFAIL: every query is recorded (:meth:`received`), so a DNSBL-blocked name must
+    NEVER appear here, while a not-blocked name DOES — and resolves to a known answer,
+    distinct from every block shape. Nothing leaks to the real internet; the server
+    answers everything itself. Listens UDP+TCP on one (configurable) port.
 
     Per-domain answers are explicit and observable. Default (unregistered name): the
     sentinel A/AAAA (``STUB_DNS_A`` / ``STUB_DNS_AAAA``). Overrides:
@@ -467,13 +470,25 @@ class _StubDnsServer:
     :meth:`queries` are the query log.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, port: int | None = None) -> None:
+        # Bind address/port are env-overridable so the smoke workflow can put the session
+        # mock on the runner's loopback :53 — the System-DNS host-alias path: pfSense
+        # forwards to 10.0.2.2 (libslirp's host alias), which NATs guest->10.0.2.2:53 to
+        # the runner's 127.0.0.1:53 (this mock), port-preserving. The runner's own
+        # /etc/resolv.conf is NEVER touched. ``net.ipv4.ip_unprivileged_port_start`` is
+        # lowered by the workflow so this non-root process can bind :53; binding
+        # 127.0.0.1 (not 0.0.0.0) avoids clashing with systemd-resolved on 127.0.0.53:53.
+        # ``port`` overrides the env (the pure unit tests pass ``port=0`` to force an
+        # ephemeral port, so they never collide with the session mock holding :53).
+        addr = os.environ.get("SMOKE_STUB_DNS_ADDR") or "127.0.0.1"
+        if port is None:
+            port = int(os.environ.get("SMOKE_STUB_DNS_PORT") or "0")
         self._udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self._udp.bind(("0.0.0.0", 0))
+        self._udp.bind((addr, port))
         self._port = self._udp.getsockname()[1]
         self._tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._tcp.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._tcp.bind(("0.0.0.0", self._port))
+        self._tcp.bind((addr, self._port))
         self._tcp.listen(16)
         self._stop = threading.Event()
         self._lock = threading.Lock()

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -51,7 +51,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
-from .conftest import GUEST_TO_HOST_ALIAS, SMOKE_DIR, SmokeVM, resolve_a
+from .conftest import GUEST_TO_HOST_ALIAS, SMOKE_DIR, STUB_DNS_A, SmokeVM, resolve_a
 
 # --------------------------------------------------------------------------- #
 # Paths / constants
@@ -754,63 +754,71 @@ def vip_alias_live(vm: SmokeVM, ip: str, iface: str = "lo0", *, timeout: float =
     return ip in result.stdout
 
 
-def use_stub_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
-    """Make the runner-side stub DNS (``_StubDnsServer``) Unbound's SOLE upstream.
+SLIRP_HOST_ALIAS = "10.0.2.2"  # QEMU/libslirp's host alias — NATs guest->10.0.2.2:P to the runner's 127.0.0.1:P
 
-    The whole matrix forwards through one CONTROLLED, observable server: every query
-    Unbound does not answer locally (block shape / host override) lands on the stub,
-    which records it (``stub.received(...)``) and answers a known sentinel. That turns
-    "was this blocked?" into a fact read off the upstream — a blocked name must never
-    reach the stub — instead of an inference from a bare SERVFAIL against a dark relay
-    (QEMU's SLIRP DNS at 10.0.2.3, which egress-block makes unreachable).
 
-    Wiring (once per deploy; the stub is reachable over SLIRP and survives the per-case
-    egress block):
+def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
+    """Point pfSense at the runner-side mock via its REAL System-DNS path (no custom zone).
 
-      * A custom ``forward-zone: "."`` -> ``10.0.2.2:<stub port>`` in Unbound Custom
-        Options. To make it the SOLE ``"."`` zone, pfSense forwarding mode is turned
-        OFF (``unset unbound/forwarding``) so pfSense does not ALSO emit its own
-        ``forward-zone "."`` (from the System DNS servers) — Unbound rejects a duplicate
-        (``error: duplicate forward zone . ignored``) and would keep the wrong one (the
-        breakage the ADR-04 matrix recorded). In resolver mode our custom zone is the
-        only one, and it still forwards everything.
-      * ``unset unbound/dnssec`` — the stub's answers are unsigned, so a validator would
+    The realistic wiring: pfSense forwards (forwarding mode) to its System DNS server
+    ``10.0.2.2`` — QEMU/libslirp's host alias — which NATs ``guest->10.0.2.2:53`` straight
+    to the mock on the runner's loopback (``127.0.0.1:53``), port-preserving. This is the
+    SAME host-alias path the in-runner mock-feed HTTP server already rides
+    (``http://10.0.2.2:<port>/...``), so the chain is:
+
+        guest Unbound --(forward)--> 10.0.2.2:53 (SLIRP host alias) --(NAT)--> 127.0.0.1:53 (mock)
+
+    Crucially this needs NO ``/etc/resolv.conf`` override on the runner (the SLIRP virtual
+    DNS at 10.0.2.3 would read resolv.conf; the 10.0.2.2 host alias does not) — the runner's
+    own resolver is left fully intact, so nothing on the host loses DNS during the run and
+    there is no teardown to restore. No custom ``forward-zone`` and no guestfwd either. The
+    mock records every query (``stub.received(...)``), so blocking is read off the upstream.
+    Loopback survives the per-case egress block (``-o lo ACCEPT``), so it stays hermetic.
+
+    Config set (idempotent; written + ``services_unbound_configure``):
+      * ``system/dnsserver = [10.0.2.2]`` and DHCP-override OFF — so ``10.0.2.2`` is the
+        SOLE forwarder (drops the baked image's dead 1.1.1.1/1.0.0.1, which egress-block
+        makes unreachable and would only add forward timeouts).
+      * ``unbound/forwarding = on`` — forward to the System DNS server.
+      * ``unset unbound/dnssec`` — the mock's answers are unsigned; a validator would
         mark them bogus (SERVFAIL).
-      * ``log-queries: yes`` — the resolver logs each client query too, so guest-side
-        diagnostics corroborate the stub's record.
-
-    Written to CONFIG so ``services_unbound_configure`` bakes it into unbound.conf;
-    pfBlockerNG's reload read-modifies that file in place (only the wizard regenerates
-    it), so the upstream survives every DNSBL reload.
+      * ``unset unbound/custom_options`` — drop any prior custom forward-zone.
     """
-    port = vm.upstream_dns_port
-    if not port:
-        raise RuntimeError("use_stub_upstream: vm.upstream_dns_port unset (stub_dns fixture not active)")
-    custom_options = (
-        "server:\n"
-        "do-not-query-localhost: no\n"
-        "log-queries: yes\n"
-        "forward-zone:\n"
-        'name: "."\n'
-        f"forward-addr: {GUEST_TO_HOST_ALIAS}@{port}\n"
-        "forward-tcp-upstream: yes\n"
-    )
     snippet = (
+        "$s = config_get_path('system', array());\n"
+        f"$s['dnsserver'] = array({_php_str(SLIRP_HOST_ALIAS)});\n"
+        # Disable 'Allow DNS server list to be overridden by DHCP' so only 10.0.2.2 is used.
+        "unset($s['dnsallowoverride']);\n"
+        "config_set_path('system', $s);\n"
         "$u = config_get_path('unbound', array());\n"
-        f"$u['custom_options'] = base64_encode({_php_str(custom_options)});\n"
-        # Resolver mode (forwarding OFF) so our custom zone is the only 'forward-zone: \".\"'.
-        "unset($u['forwarding']);\n"
+        "$u['forwarding'] = 'on';\n"
         "unset($u['dnssec']);\n"
+        "unset($u['custom_options']);\n"
         "config_set_path('unbound', $u);\n"
-        "write_config('pfBlockerNG smoke: stub upstream');\n"
+        "write_config('pfBlockerNG smoke: system-DNS upstream (SLIRP host alias -> mock)');\n"
         "services_unbound_configure();\n"
         "echo 'OK';"
     )
     result = php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(f"use_stub_upstream failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+        raise RuntimeError(
+            f"use_system_dns_upstream failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
     # services_unbound_configure restarts Unbound — wait for it before any probe.
     wait_unbound_ready(vm)
+    # READINESS + RELAY SELF-CHECK (fail fast, don't let the matrix hang): resolve one
+    # throwaway name on-box. With the mock as upstream it MUST come back as the sentinel
+    # (pfSense -> 10.0.2.2 SLIRP host alias -> runner 127.0.0.1:53 mock). The FIRST response
+    # is authoritative; if it isn't the sentinel, the relay isn't wired — raise NOW with
+    # the answer, rather than letting every per-case forward time out (~300s each).
+    probe = unique_domain("sysdnsselfcheck")
+    ans = dns_probe(vm, probe, "A", timeout=10.0, attempts=3, delay=3.0)
+    if not resolves_to(ans, STUB_DNS_A):
+        raise RuntimeError(
+            f"System-DNS relay self-check FAILED: {probe} -> {ans} (expected the mock sentinel "
+            f"{STUB_DNS_A}). pfSense's 10.0.2.2 host alias -> runner 127.0.0.1:53 mock path is not "
+            f"working (libslirp not NATing the host alias to the mock, or unbound not forwarding)."
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -754,9 +754,6 @@ def vip_alias_live(vm: SmokeVM, ip: str, iface: str = "lo0", *, timeout: float =
     return ip in result.stdout
 
 
-SLIRP_HOST_ALIAS = "10.0.2.2"  # QEMU/libslirp's host alias — NATs guest->10.0.2.2:P to the runner's 127.0.0.1:P
-
-
 def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     """Point pfSense at the runner-side mock via its REAL System-DNS path (no custom zone).
 
@@ -786,7 +783,7 @@ def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     """
     snippet = (
         "$s = config_get_path('system', array());\n"
-        f"$s['dnsserver'] = array({_php_str(SLIRP_HOST_ALIAS)});\n"
+        f"$s['dnsserver'] = array({_php_str(GUEST_TO_HOST_ALIAS)});\n"
         # Disable 'Allow DNS server list to be overridden by DHCP' so only 10.0.2.2 is used.
         "unset($s['dnsallowoverride']);\n"
         "config_set_path('system', $s);\n"

--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -77,16 +77,17 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     """Deploy the branch .pkg once for the ABP matrix (mirrors the ADR-04 matrix).
 
     Egress is managed per-case by ``CaseContext``; the DNSBL VIP is injected once
-    (DNSBL force-disables itself without one). The runner-side stub DNS is wired as
-    Unbound's sole upstream (``use_stub_upstream``) so a not-blocked name resolves to
-    a known sentinel AND is recorded on the stub. A full guest snapshot is collected
-    on teardown for the workflow to upload.
+    (DNSBL force-disables itself without one). pfSense forwards to the runner-side mock
+    via its real System-DNS path (``use_system_dns_upstream``: System DNS = the SLIRP
+    host alias 10.0.2.2, which libslirp NATs to the runner-loopback mock) so a not-blocked name resolves to
+    a known answer AND is recorded on the mock. A full guest snapshot is collected on
+    teardown for the workflow to upload.
     """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
-    h.use_stub_upstream(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
     try:
         yield smoke_vm
     finally:
@@ -394,9 +395,10 @@ def test_cname_validation_on_off(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
     answer, and a pfSense Host Override only expresses A/AAAA — never a CNAME. A raw
     Unbound ``local-data`` CNAME does NOT work either: Unbound returns the bare CNAME
     without chasing it (a single rrset, so ``an_numrrsets`` stays 1 and the walk never
-    runs). So the stub — already Unbound's sole upstream (``use_stub_upstream``) —
-    crafts the 2-rrset chain: ``stub_dns.register_cname(A, B)`` answers a forwarded
-    query for A with ``A CNAME B`` + ``B A <sentinel>``, which Unbound forwards whole.
+    runs). So the mock — pfSense's upstream via its System-DNS path
+    (``use_system_dns_upstream``: forward to 10.0.2.2 → libslirp host-alias NAT → mock) — crafts
+    the 2-rrset chain: ``stub_dns.register_cname(A, B)`` answers a forwarded query for A
+    with ``A CNAME B`` + ``B A <addr>``, which Unbound forwards whole.
 
     Only A's fate differs between the runs; B (= `unique_domain('cnametgt')`, a plain
     exact-match feed entry) is listed in both — the invariant:

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -34,7 +34,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> SmokeVM:
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
-    h.use_stub_upstream(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
     return smoke_vm
 
 
@@ -295,7 +295,7 @@ def test_stub_cname_chain_is_two_rrsets_and_consistent() -> None:
     import dns.rdatatype
 
     src, tgt = h.unique_domain("stubsrc"), h.unique_domain("stubtgt")
-    server = _StubDnsServer()
+    server = _StubDnsServer(port=0)
     try:
         server.set_records(tgt, a=("198.51.100.5",), aaaa=("2001:db8::5",))
         server.register_cname(src, tgt)
@@ -319,7 +319,7 @@ def test_stub_unregistered_name_is_plain_sentinel() -> None:
     import dns.rdatatype
 
     src, tgt = h.unique_domain("stubsrc"), h.unique_domain("stubtgt")
-    server = _StubDnsServer()
+    server = _StubDnsServer(port=0)
     try:
         server.register_cname(src, tgt)
         server.clear_cname()
@@ -337,7 +337,7 @@ def test_stub_records_queries() -> None:
     locally); a name the stub never saw returns an empty list. ``reset_queries`` clears it.
     """
     seen, never = h.unique_domain("stubseen"), h.unique_domain("stubnever")
-    server = _StubDnsServer()
+    server = _StubDnsServer(port=0)
     try:
         _stub_answer(server, seen, "A")
         assert server.received(seen), "answered query must be recorded"
@@ -354,7 +354,7 @@ def test_stub_register_a_and_nxdomain() -> None:
     import dns.rcode
 
     pinned, gone = h.unique_domain("stubpinned"), h.unique_domain("stubgone")
-    server = _StubDnsServer()
+    server = _StubDnsServer(port=0)
     try:
         server.register_a(pinned, "192.0.2.7")
         reply = _stub_answer(server, pinned, "A")
@@ -373,7 +373,7 @@ def test_stub_set_records_families_multi_and_nodata() -> None:
     import dns.rcode
 
     multi, v4only, bad = h.unique_domain("stubmulti"), h.unique_domain("stubv4"), h.unique_domain("stubbad")
-    server = _StubDnsServer()
+    server = _StubDnsServer(port=0)
     try:
         # Multiple A, one AAAA.
         server.set_records(multi, a=("203.0.113.1", "203.0.113.2"), aaaa=("2001:db8::1",))

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -30,7 +30,8 @@ pytestmark = pytest.mark.smoke
 
 @pytest.fixture(scope="module")
 def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> SmokeVM:
-    """Deploy the branch .pkg once for the helper self-tests; wire the stub upstream."""
+    """Deploy the branch .pkg once for the helper self-tests; configure the System-DNS
+    upstream (``use_system_dns_upstream`` -> the mock via the 10.0.2.2 host alias)."""
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -79,12 +79,12 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     resolves LOCALLY — a blocked name is intercepted by the python module before
     the forwarder, and a control/whitelist name answers from its injected host
     override — so the probe never needs the real internet. A not-blocked,
-    no-control name resolves via the runner-side stub (``use_stub_upstream``), the
-    sole controlled upstream — a known sentinel, AND recorded, so "was it blocked?"
-    is read off the upstream, not inferred from a SERVFAIL. deploy() needs no
-    egress for dependencies either — the pre-baked image ships pfBlockerNG's
-    RUN_DEPENDS, so ``pkg add`` resolves them from the local pkg db offline.
-    unblock on teardown as a safety net.
+    no-control name resolves via the runner-side mock (``use_system_dns_upstream``:
+    pfSense forwards to the SLIRP host alias 10.0.2.2, which libslirp NATs to the mock) — a known
+    answer, AND recorded, so "was it blocked?" is read off the upstream, not inferred
+    from a SERVFAIL. deploy() needs no egress for dependencies either — the pre-baked
+    image ships pfBlockerNG's RUN_DEPENDS, so ``pkg add`` resolves them from the local
+    pkg db offline. unblock on teardown as a safety net.
     """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
@@ -99,10 +99,10 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     # lo0 sinkhole VIP once for the matrix. dns_probe queries on-box (drill
     # @127.0.0.1) — no localhost exemption — so no WAN/ACL plumbing is needed.
     h.ensure_dnsbl_vip(smoke_vm)
-    # Point Unbound's sole upstream at the controlled stub BEFORE any per-test
-    # unbound-config snapshot (test_dnsbl_unbound_config_immutable), so the stub
-    # forward-zone is part of the baseline and the DNSBL reload still adds only python.
-    h.use_stub_upstream(smoke_vm)
+    # Point pfSense at the controlled mock via its System-DNS path BEFORE any per-test
+    # unbound-config snapshot (test_dnsbl_unbound_config_immutable), so the forwarding
+    # config is part of the baseline and the DNSBL reload still adds only python.
+    h.use_system_dns_upstream(smoke_vm)
     h.snap_state(smoke_vm, "vip")
     try:
         yield smoke_vm


### PR DESCRIPTION
## What

Wires pfSense's **System DNS** to the runner-side mock through QEMU/libslirp's
**host alias `10.0.2.2`**, completing follow-up item 1 from #58 (the System-DNS-IP
wiring deferred from the CNAME live-smoke work).

pfSense forwards (forwarding mode) to System DNS `10.0.2.2`; libslirp NATs
`guest -> 10.0.2.2:53` straight to the runner's `127.0.0.1:53` mock,
port-preserving — the **same host-alias path the in-runner mock-feed HTTP server
already rides** (`http://10.0.2.2:<port>/...`).

```text
guest Unbound --(forward)--> 10.0.2.2:53 (SLIRP host alias) --(NAT)--> 127.0.0.1:53 (mock)
```

## Why this shape

The runner's `/etc/resolv.conf` is **never touched**, so:

- host DNS keeps working throughout the run (no mid-test outage, no artifact-upload hang);
- there is **nothing to restore** on teardown;
- it is **immune to how the runner does name resolution** (systemd-resolved or otherwise).

This replaces the earlier global-`resolv.conf`-override + restore scaffolding. The
`10.0.2.3` SLIRP *virtual DNS* was rejected precisely because it reads `resolv.conf`
(which is what forced the global override); `guestfwd` was rejected earlier (TCP-only +
chardev target — no UDP DNS). The only runner-side prep left is
`sysctl net.ipv4.ip_unprivileged_port_start=53` so the non-root mock can bind `:53`.

## Changes

- **`helpers.use_system_dns_upstream`**: System DNS = `10.0.2.2` (was `10.0.2.3`);
  forwarding / DNSSEC-off / readiness + relay self-check otherwise unchanged.
- **`conftest._StubDnsServer`**: add a `port` override so the standalone unit tests bind
  an ephemeral port (`port=0`) instead of inheriting the session mock's `:53` from the
  env — fixes the `OSError: [Errno 98] Address already in use` collisions.
- **`smoke.yml`**: drop the `resolv.conf` clobber and the restore step; keep only the
  unprivileged-port sysctl; run the **full matrix** at
  `--timeout=30 --timeout-method=signal` with `timeout_func_only=true` (times the test
  *body* only — not the ~1–2 min deploy fixture; slowest observed body ~6s).

## Validation

- Diagnostic CI run confirmed the matrix completes in ~165s (no stall — the earlier
  "hang" was the old 300s timeout × the 5 stub-unit-test port collisions, now fixed) and
  every real-VM test passed under the System-DNS path (CNAME validation, python-exact VIP,
  HSTS override on/off, exact-null, whitelist passthrough).
- Local gates green: `1012 passed`, ruff / mypy / markdownlint / shellcheck / shellspec /
  `php -l` all clean.
- A fresh smoke run against this branch gates the merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced smoke-suite DNS validation and self-checks using a runner-side mock as a known sentinel.
  * Smoke runs now execute smoke-marked tests only and use a 30s per-test-body timeout for faster feedback.

* **Refactor**
  * Switched test infrastructure to route guest DNS through the host-alias/NAT path instead of the prior stub-forwarding method.
  * Made the local mock DNS binding configurable so CI can run a non-root mock on the standard DNS port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->