### PR TITLE
smoke: match vip_alias_live on exact inet token, not substring

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -749,9 +749,21 @@ def dnsvip4_address(vm: SmokeVM, *, timeout: float = 60.0) -> str:
 
 
 def vip_alias_live(vm: SmokeVM, ip: str, iface: str = "lo0", *, timeout: float = 30.0) -> bool:
-    """True iff ``ip`` is a live alias on ``iface`` per ``ifconfig`` (the realized VIP)."""
+    """True iff ``ip`` is a live alias on ``iface`` per ``ifconfig`` (the realized VIP).
+
+    Matches the address as a whole ``inet``/``inet6`` token, NOT a bare substring:
+    ``ip in stdout`` would prefix-false-positive (e.g. ``10.10.10.53`` reported live
+    because the iface carries ``10.10.10.530`` or ``110.10.10.53``). ``ifconfig``
+    prints ``inet <ip> netmask ...`` / ``inet6 <ip> prefixlen ...``, so an exact
+    token right after ``inet``/``inet6`` is the address itself.
+    """
     result = vm.ssh("/sbin/ifconfig", iface, timeout=timeout)
-    return ip in result.stdout
+    for line in result.stdout.splitlines():
+        toks = line.split()
+        for i, tok in enumerate(toks[:-1]):
+            if tok in ("inet", "inet6") and toks[i + 1] == ip:
+                return True
+    return False
 
 
 def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:


### PR DESCRIPTION
## What

Tightens the smoke helper `vip_alias_live` (`tests/smoke/helpers.py`) to match the
realized VIP as a whole `inet`/`inet6` token instead of a bare substring.

Before:

```python
return ip in result.stdout
```

`ip in <ifconfig output>` can **prefix/substring false-positive** — `10.10.10.53`
reads as "live" if the interface merely carries `10.10.10.530` or `110.10.10.53`,
or any line that happens to contain the digits. `ifconfig` prints
`inet <ip> netmask …` / `inet6 <ip> prefixlen …`, so the fix scans each line's
tokens and matches the address only when it is the exact token right after
`inet`/`inet6`.

## Why a token split (not a regex)

A `\b`-anchored regex is unreliable for IPv6 — a trailing `:` (e.g. `2001:db8::`)
is a non-word char, so `\b` after it doesn't fire. Splitting on whitespace and
comparing the post-`inet`/`inet6` token by equality is exact for both families and
needs no special-casing.

## Scope

`vip_alias_live` is ADR-13 code (introduced by #69, commit `c87013c`); this is the
follow-up deferred from #71's CodeRabbit re-review. It exercises the realized-VIP
assertion in `test_dnsbl_autovip_lifecycle`; behaviour in the happy path is
unchanged (the exact `inet <ip>` token is present iff the alias is live), only the
false-positive edge is closed.

## Validation

- ruff (lint + format) clean; pre-commit gates green.
- Logic checked against real `ifconfig` output: exact v4 + v6 → live; prefix /
  suffix / superstring → not live; absent → not live.
- A live smoke run (which runs `test_dnsbl_autovip_lifecycle`) gates the merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of virtual IP alias detection by using exact address matching instead of substring matching, eliminating false positives from similar IP patterns.
  * Reduces incorrect VIP detections in interface listings, improving reliability of network checks and related automated validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->