### PR TITLE
benchmarks: enforce ReDoS + build/RAM kill-gates via exit code + CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,11 +270,54 @@ jobs:
         # Reads .markdownlint.jsonc (rules) + .markdownlint-cli2.jsonc (globs/ignores).
         run: npx --yes markdownlint-cli2
 
+  benchmarks:
+    name: Benchmark kill-gates (ReDoS + build RAM)
+    runs-on: ubuntu-latest
+    # The spikes carry their GO/NO-GO verdict in their EXIT CODE (issue #42), so a
+    # regression past the regex-latency / build-time / peak-RAM thresholds fails
+    # THIS job. INFORMATIONAL phase: deliberately NOT yet in the required
+    # `all-tests-passed.needs` list — it runs and reports red/green on every PR to
+    # establish a stable on-runner baseline (shared CI runners are slower/noisier
+    # than dev boxes, and the build-seconds gate has the least headroom), without
+    # blocking merges. Flip to ENFORCING by adding `benchmarks` to that `needs`
+    # list + a result check below, once the baseline is shown stable.
+    # Job-specific timeout (issue #42 follow-up): the 1M-entry build spike is the
+    # slow step; bound it here rather than touching any shared/default timeout.
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install benchmark dependencies
+        # pympler drives the retained-bytes/entry RAM gate in spike_adr06_build.py;
+        # without it that gate is skipped (treated as PASS), so install it to keep
+        # the RAM kill-gate live in CI.
+        run: pip install pympler
+
+      - name: ReDoS / regex-latency kill-gate (ADR-07)
+        # Non-zero exit on NO-GO (reduction-floor / per-pattern-latency / worst
+        # first-hit). No `|| true` — the exit code IS the gate.
+        run: python benchmarks/spike_adr07_regex.py
+
+      - name: Build init-time / peak-RAM kill-gate (ADR-06)
+        # Non-zero exit on NO-GO (build seconds / retained B/entry) at the default
+        # 1M-entry un-pruned corpus.
+        run: python benchmarks/spike_adr06_build.py
+
   # Single stable job name for branch-protection required-status-checks.
   # Must use if: always() so it runs (and fails) even when 'test' fails.
   all-tests-passed:
     name: All tests passed
     if: always()
+    # NOTE: `benchmarks` is intentionally absent while it is informational-only
+    # (issue #42). Add it here + a result check below to make the kill-gates
+    # required once their on-runner baseline is stable.
     needs: [test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-unit, markdownlint]
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,7 +307,9 @@ pure `dnsbl_build_from_manifest()` / `build()`, fed by the PHP/shell-written
 manifest (`/var/unbound/pfb_py_sources.json` + per-feed raw). PHP/shell only
 download + tag + run the DNSBL-IP firewall pass. Decision-equivalence is pinned by
 `tests/test_adr06_*` (golden oracle, build module, init-from-raw, PHP boundary);
-the init/peak-RAM kill-gate is `benchmarks/spike_adr06_build.py`. See
+the init/peak-RAM kill-gate is `benchmarks/spike_adr06_build.py` — a real gate: it
+exits non-zero on NO-GO and runs in CI (the `benchmarks` job, informational until its
+on-runner baseline is stable; `--report-only` forces exit 0 locally). See
 `.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/`.
 
 ABP/EasyList feeds are parsed **entirely in Python** (ADR-07): PHP header-sniffs an
@@ -323,8 +325,9 @@ cap (drops over-long/nested-quantifier patterns at load) plus an always-on runti
 warn/evict timer (warn 10 ms / evict 100 ms thread-CPU; snapshot-iterate,
 evict-after-loop). Pinned by `tests/test_adr07_*` (decision spec/oracle, parser,
 reconcile, matcher strata, emit/wire, regex safety, PHP boundary); the regex/ReDoS
-kill-gate is `benchmarks/spike_adr07_regex.py`. See
-`.ADRs/ADR_07_ABP_DNSBL_Support/`.
+kill-gate is `benchmarks/spike_adr07_regex.py` — a real gate: it exits non-zero on
+NO-GO and runs in CI (the `benchmarks` job; `--report-only` forces exit 0 locally).
+See `.ADRs/ADR_07_ABP_DNSBL_Support/`.
 
 ---
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -5,6 +5,32 @@ for DNSBL/noAAAA matching: latency on positive *and* negative (bypass-to-Unbound
 queries, plus memory footprint. Dev-only — not shipped (release archives contain
 only `src/`), and not collected by the default `pytest` run (`testpaths=["tests"]`).
 
+## Kill-gates (enforced via exit code — issue #42)
+
+Two spikes are **enforced gates**, not advisory prints: each prints its full report
+**and** carries its GO/NO-GO verdict in the **process exit code** (`0` = GO, non-zero
+= NO-GO). A regression past a threshold fails the run. Pass `--report-only` for a
+human-readable local run that always exits `0`.
+
+| Spike | Guards | Pinned thresholds (the enforced values) |
+| ----- | ------ | --------------------------------------- |
+| `spike_adr07_regex.py` | ABP regex latency / ReDoS (ADR-07) | reduction ratio `>= 30%` (`REDUCTION_FLOOR`); per-pattern scan `<= LATENCY_BUDGET_US/50` (i.e. `>=50` irreducible patterns fit the `50 us` `LATENCY_BUDGET_US`); worst cap-passing first-hit `<= 0.5 s` (`WORST_FIRSTHIT_CEIL_S`) |
+| `spike_adr06_build.py` | DNSBL build init-time + peak RAM (ADR-06) | build `<= 8.0 s` at 1M un-pruned entries (`THRESH_BUILD_SECONDS`); retained `<= 410 B/entry` (`THRESH_BYTES_PER_ENTRY`, vs the 274 B/entry ADR-05 baseline). RAM gate needs `pympler`; absent → skipped (treated as PASS) |
+
+```sh
+python benchmarks/spike_adr07_regex.py        # exit 1 on NO-GO
+python benchmarks/spike_adr06_build.py        # exit 1 on NO-GO (needs pympler for the RAM gate)
+python benchmarks/spike_adr06_build.py --report-only   # always exit 0 (local inspection)
+```
+
+**CI.** Both run in the `benchmarks` job (`.github/workflows/test.yml`). It is
+**informational** at first — it reports red/green on every PR but is deliberately
+**not** in the required `all-tests-passed` check, so a flaky on-runner timing reading
+can't block merges while the baseline is established. Flip to **enforcing** by adding
+`benchmarks` to that job's `needs` list once the baseline is shown stable. The job
+sets its own `timeout-minutes` (the 1M-entry build is the slow step) rather than
+relying on any shared/default timeout.
+
 ## Install
 
 ```sh

--- a/benchmarks/spike_adr06_build.py
+++ b/benchmarks/spike_adr06_build.py
@@ -25,16 +25,20 @@ Measures (N>=3 runs at >=1M entries):
 * retained dict bytes/entry (``pympler.asizeof``, same method as ADR-05 §3a) vs
   the ~274 B/entry baseline.
 
-Then prints an explicit GO / NO-GO against the proposed kill-threshold.
+Then prints an explicit GO / NO-GO against the kill-threshold AND propagates it to
+the process exit code (0 = GO, non-zero = NO-GO) so CI / the hooks can enforce it.
+Pass ``--report-only`` for a human-readable local run that always exits 0.
 
 Run from the repo root (dev-only; not shipped, not in the default pytest run)::
 
     python -m pip install pympler          # dev-only, ADR-05 §3a baseline tool
     SPIKE_N=5 SPIKE_SIZES=1000000 python benchmarks/spike_adr06_build.py
+    python benchmarks/spike_adr06_build.py --report-only   # never fails (local)
 """
 
 from __future__ import annotations
 
+import argparse
 import gc
 import os
 import re
@@ -239,7 +243,8 @@ def _retained_bytes(structures: dict[str, Any]) -> int | None:
     return asizeof.asizeof(structures["dataDB"], structures["zoneDB"], structures["feedGroupIndexDB"])
 
 
-def run(n_domain_lines: int, n_runs: int) -> None:
+def run(n_domain_lines: int, n_runs: int) -> bool:
+    """One full spike at ``n_domain_lines``. Returns True on GO, False on NO-GO."""
     if n_runs < 1:
         raise ValueError(f"n_runs must be >= 1, got {n_runs}")
     print("=" * 78)
@@ -332,7 +337,8 @@ def run(n_domain_lines: int, n_runs: int) -> None:
         print("  bytes/entry : {:.1f}            -> {}".format(bpe, "PASS" if mem_ok else "FAIL"))
     else:
         print("  bytes/entry : (skipped, pympler absent) -> treated as PASS")
-    verdict = "GO" if (time_ok and mem_ok) else "NO-GO"
+    go = time_ok and mem_ok
+    verdict = "GO" if go else "NO-GO"
     print("=" * 78)
     print(
         "VERDICT: {}  (build {:.1f}s threshold, {:.0f} B/entry threshold)".format(
@@ -340,14 +346,34 @@ def run(n_domain_lines: int, n_runs: int) -> None:
         )
     )
     print("=" * 78)
+    return go
 
 
-def main() -> None:
+def main() -> int:
+    """Run the spike at every requested size; exit non-zero if any size is NO-GO.
+
+    This is a KILL-GATE: the process exit code carries the verdict (0 = GO,
+    1 = NO-GO) so CI / the hooks can enforce it. Pass --report-only to print the
+    full report but always exit 0 (a human-readable local run that never fails).
+    """
+    parser = argparse.ArgumentParser(description="ADR-06 Python DNSBL build init-time / peak-RAM kill-gate.")
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="print the report but always exit 0 (do not propagate NO-GO to the exit code)",
+    )
+    args = parser.parse_args()
+
     n_runs = int(os.environ.get("SPIKE_N", "3"))
     sizes = [int(s) for s in os.environ.get("SPIKE_SIZES", "1000000").split(",") if s.strip()]
+    ok = True
     for n in sizes:
-        run(n, n_runs)
+        ok = run(n, n_runs) and ok
+    if not ok and args.report_only:
+        print("NOTE: --report-only set -> NO-GO not propagated to the exit code.")
+        return 0
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/benchmarks/spike_adr07_regex.py
+++ b/benchmarks/spike_adr07_regex.py
@@ -28,6 +28,7 @@ Run from the repo root (dev-only; not shipped, not in the default pytest run)::
 
 from __future__ import annotations
 
+import argparse
 import os
 import re
 import statistics
@@ -353,6 +354,20 @@ def demo_thread_timeout_cannot_interrupt() -> tuple[float, float, float]:
 # Driver.
 # --------------------------------------------------------------------------- #
 def main() -> int:
+    """Run the ReDoS/regex spike; exit non-zero on NO-GO so CI can enforce it.
+
+    This is a KILL-GATE: the verdict is carried by the process exit code (0 = GO,
+    1 = NO-GO). Pass --report-only to print the full report but always exit 0 (a
+    human-readable local run that never fails).
+    """
+    parser = argparse.ArgumentParser(description="ADR-07 regex/ReDoS latency + reduction kill-gate.")
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="print the report but always exit 0 (do not propagate NO-GO to the exit code)",
+    )
+    args = parser.parse_args()
+
     print("=" * 78)
     print("ADR-07 Phase-1 spike: ABP corpus inventory + regex/ReDoS measurement")
     print("=" * 78)
@@ -488,7 +503,10 @@ def main() -> int:
     verdict = "GO (with mitigations)" if gates_ok else "NO-GO -> PIVOT"
     print(f"  VERDICT: {verdict}")
     print(f"  budget-bounded irreducible count: ~{budget_count} patterns at {LATENCY_BUDGET_US:.0f} us")
-    return 0
+    if not gates_ok and args.report_only:
+        print("NOTE: --report-only set -> NO-GO not propagated to the exit code.")
+        return 0
+    return 0 if gates_ok else 1
 
 
 def _safe_compile(pat: str) -> bool:


### PR DESCRIPTION
Fixes #42.

The two spikes documented as **kill-gates** in CLAUDE.md/the ADRs always returned exit 0, so a regression past the regex-latency/ReDoS or build-time/peak-RAM thresholds was caught by **nothing** automated — the "gate" was an advisory print.

## What changed

**Gate the exit code (the real fix).**

- `spike_adr07_regex.py` — `main()` returns `0` only on GO, `1` on NO-GO.
- `spike_adr06_build.py` — `run()` now returns the per-size verdict; `main()` aggregates over all sizes and exits non-zero if any size is NO-GO.
- Both gain a `--report-only` flag (argparse, `--help` included) for a human-readable local run that always exits 0. The full report is unchanged in every mode.

**Wire into CI — informational first.**

- New `benchmarks` job in `test.yml` runs both gates (no `|| true` — the exit code *is* the gate).
- Deliberately **not** in the required `all-tests-passed` check yet: it reports red/green on every PR to establish a stable on-runner baseline (shared runners are slower/noisier; the build-seconds gate has the least headroom), without blocking merges. Flip to enforcing later by adding `benchmarks` to that job's `needs` — documented inline.
- The job sets its own `timeout-minutes` (the 1M-entry build is the slow step) rather than touching any shared/default timeout.

**Pin + reconcile docs.** Thresholds documented as the enforced values in `benchmarks/README.md`; the CLAUDE.md "kill-gate" wording now matches reality.

## Verification (local)

| Case | spike07 | spike06 |
| ---- | ------- | ------- |
| Normal run (GO) | exit 0 | exit 0 |
| Forced NO-GO | exit 1 | exit 1 |
| `--report-only` on NO-GO | exit 0 | exit 0 |

Both GO on the dev box with headroom (regex: 46% reduction vs 30% floor, 0.06 ms worst first-hit vs 500 ms ceil; build: 5.75 s vs 8 s, 274.9 B/entry vs 410 B/entry). ADR-06/07 test suites (which import the spikes as oracles) unaffected — full pre-commit suite green (1019 pytest, mypy, markdownlint, shell, php-l).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmark kill-gates for ADR-06 (build) and ADR-07 (regex) that report GO/NO-GO via process exit codes; run in CI as informational (non-blocking) initially.
  * Added a --report-only option to run benchmarks locally without enforcing the exit-code verdict.

* **Documentation**
  * Expanded docs with kill-gate thresholds, CI behavior, and usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->