### PR TITLE
ci: make benchmark kill-gates manual-dispatch only (#76)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,17 @@ on:
       - '**/*.md'
       - '*.md'
       - 'docs/**'
+  # Manual trigger to opt INTO the benchmark kill-gates (issue #76). They are OFF in
+  # the automated push/PR flow: a synthetic corpus on a generic runner is not the
+  # number that matters — the production-faithful build-time/RAM measurement belongs
+  # on the live smoke VM, timing `updatednsbl` start→finish + unbound RSS. Dispatch
+  # Tests with this box ticked to run the offline spikes on demand.
+  workflow_dispatch:
+    inputs:
+      run_benchmarks:
+        description: 'Run the ReDoS + build/RAM benchmark kill-gates (offline spike scripts)'
+        type: boolean
+        default: false
 
 # Least-privilege GITHUB_TOKEN: every job only reads the repo (checkout, tests,
 # lint) — upload-artifact uses the Actions runtime token, not GITHUB_TOKEN — so
@@ -275,17 +286,18 @@ jobs:
 
   benchmarks:
     name: Benchmark kill-gates (ReDoS + build RAM)
+    # MANUAL-ONLY (issue #76). The spikes carry their GO/NO-GO verdict in their EXIT
+    # CODE (issue #42), but the build-time/RAM number is a synthetic `build()` on a
+    # generic runner — NOT what a user experiences. So this job is OFF in the
+    # automated push/PR flow and runs only when Tests is dispatched with the
+    # `run_benchmarks` input ticked. The production-faithful build-time/RAM
+    # regression gate is being moved to the live smoke VM (timing `updatednsbl`
+    # start→finish + unbound RSS, baked synthetic fixture) — tracked in #76. The
+    # ReDoS gate stays a useful offline check here. Never in `all-tests-passed.needs`.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
     runs-on: ubuntu-latest
-    # The spikes carry their GO/NO-GO verdict in their EXIT CODE (issue #42), so a
-    # regression past the regex-latency / build-time / peak-RAM thresholds fails
-    # THIS job. INFORMATIONAL phase: deliberately NOT yet in the required
-    # `all-tests-passed.needs` list — it runs and reports red/green on every PR to
-    # establish a stable on-runner baseline (shared CI runners are slower/noisier
-    # than dev boxes, and the build-seconds gate has the least headroom), without
-    # blocking merges. Flip to ENFORCING by adding `benchmarks` to that `needs`
-    # list + a result check below, once the baseline is shown stable.
-    # Job-specific timeout (issue #42 follow-up): the 1M-entry build spike is the
-    # slow step; bound it here rather than touching any shared/default timeout.
+    # Job-specific timeout: the 1M-entry build spike is the slow step; bound it here
+    # rather than touching any shared/default timeout.
     timeout-minutes: 15
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,10 +310,12 @@ pure `dnsbl_build_from_manifest()` / `build()`, fed by the PHP/shell-written
 manifest (`/var/unbound/pfb_py_sources.json` + per-feed raw). PHP/shell only
 download + tag + run the DNSBL-IP firewall pass. Decision-equivalence is pinned by
 `tests/test_adr06_*` (golden oracle, build module, init-from-raw, PHP boundary);
-the init/peak-RAM kill-gate is `benchmarks/spike_adr06_build.py` — a real gate: it
-exits non-zero on NO-GO and runs in CI (the `benchmarks` job, informational until its
-on-runner baseline is stable; `--report-only` forces exit 0 locally). See
-`.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/`.
+the init/peak-RAM kill-gate is `benchmarks/spike_adr06_build.py` — it exits non-zero
+on NO-GO (`--report-only` forces exit 0). Its synthetic `build()` on a generic runner
+is NOT the production number, so the CI `benchmarks` job is **manual-only** (dispatch
+Tests with `run_benchmarks`, default off); the real build-time/RAM regression gate is
+moving to the live smoke VM (timing `updatednsbl` start→finish + unbound RSS) — see
+issue #76 and `.ADRs/ADR_06_DNSBL_Preprocessing_To_Python/`.
 
 ABP/EasyList feeds are parsed **entirely in Python** (ADR-07): PHP header-sniffs an
 ABP feed, tags it `format_hint='abp'`, and passes its raw lines through verbatim
@@ -328,9 +330,10 @@ cap (drops over-long/nested-quantifier patterns at load) plus an always-on runti
 warn/evict timer (warn 10 ms / evict 100 ms thread-CPU; snapshot-iterate,
 evict-after-loop). Pinned by `tests/test_adr07_*` (decision spec/oracle, parser,
 reconcile, matcher strata, emit/wire, regex safety, PHP boundary); the regex/ReDoS
-kill-gate is `benchmarks/spike_adr07_regex.py` — a real gate: it exits non-zero on
-NO-GO and runs in CI (the `benchmarks` job; `--report-only` forces exit 0 locally).
-See `.ADRs/ADR_07_ABP_DNSBL_Support/`.
+kill-gate is `benchmarks/spike_adr07_regex.py` — it exits non-zero on NO-GO
+(`--report-only` forces exit 0), runnable via the manual-only CI `benchmarks` job
+(dispatch Tests with `run_benchmarks`, default off — see issue #76). See
+`.ADRs/ADR_07_ABP_DNSBL_Support/`.
 
 ---
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,13 +23,18 @@ python benchmarks/spike_adr06_build.py        # exit 1 on NO-GO (needs pympler f
 python benchmarks/spike_adr06_build.py --report-only   # always exit 0 (local inspection)
 ```
 
-**CI.** Both run in the `benchmarks` job (`.github/workflows/test.yml`). It is
-**informational** at first — it reports red/green on every PR but is deliberately
-**not** in the required `all-tests-passed` check, so a flaky on-runner timing reading
-can't block merges while the baseline is established. Flip to **enforcing** by adding
-`benchmarks` to that job's `needs` list once the baseline is shown stable. The job
-sets its own `timeout-minutes` (the 1M-entry build is the slow step) rather than
-relying on any shared/default timeout.
+**CI — manual only (issue #76).** Both can run in the `benchmarks` job
+(`.github/workflows/test.yml`), but that job is **off in the automated push/PR flow**:
+dispatch the *Tests* workflow with the `run_benchmarks` input ticked to run them on
+demand. It is never in the required `all-tests-passed` check. Why not automatic: the
+build-time/RAM number here is a synthetic `build()` on a generic runner, which is *not*
+what a user experiences — measured on `ubuntu-latest` the 1M build lands ~9.1–10.4s
+(vs ~5.75s on a dev box), so an absolute-seconds gate there only tracks runner speed.
+The **production-faithful** build-time/RAM regression gate is moving to the live smoke
+VM (ADR-04): time `pfblockerng.php updatednsbl` start→finish and sample the chrooted
+`unbound` process RSS, with a baked synthetic feed fixture so it is repeatable. The
+ReDoS gate (`spike_adr07_regex.py`) stays a useful environment-independent offline
+check. The job sets its own `timeout-minutes` (the 1M-entry build is the slow step).
 
 ## Install
 


### PR DESCRIPTION
Part of #76.

Takes the benchmark kill-gates **out of the automated push/PR flow** and puts them behind a manual `workflow_dispatch` toggle. Does **not** close #76 — the production-faithful build-time/RAM gate (smoke VM) is still to come and stays tracked there.

## Why

The `benchmarks` job was running on every PR and red-flagging on the build-time gate. Root cause isn't a regression — it's that `spike_adr06_build.py` times a **synthetic `build()` on a generic `ubuntu-latest` CPU**. Baseline collected for #76 (12 samples, the max-of-3 the gate checks):

```text
9.13  9.58  9.64  9.75  9.75  9.82  9.88  9.90  9.93  10.12  10.26  10.41   (median/mean 9.85s)
```

The whole distribution sits above the 8.0s cap (calibrated on a ~5.75s dev box), so an absolute-seconds gate there just tracks runner speed — not what a user experiences. The number that matters is the real reload on a ready pfSense box, which belongs on the live smoke VM.

## Change

- `test.yml`: add `workflow_dispatch` input `run_benchmarks` (boolean, default **false**); gate the `benchmarks` job with `if: github.event_name == 'workflow_dispatch' && inputs.run_benchmarks`. It no longer runs on push/PR; dispatch *Tests* with the box ticked to run the offline spikes on demand. Still never in the required `all-tests-passed` check.
- The exit-code gates (#42) and `--report-only` are unchanged — the spikes are still real gates when you choose to run them.
- Reconcile `CLAUDE.md` + `benchmarks/README.md` to "manual-only", and record where the real gate is headed (smoke VM: time `pfblockerng.php updatednsbl` start→finish + chrooted `unbound` RSS, baked synthetic fixture).

## Verification

YAML parses; `if:` evaluates false on push/PR (job skipped) and true only on dispatch with the input set. Full pre-commit suite green (1019 pytest, mypy, markdownlint, shell, php-l).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Benchmark job now runs only via a manual workflow dispatch with an optional "run_benchmarks" toggle (default: off); it no longer runs in automated push/PR flows.

* **Documentation**
  * Updated documentation to reflect the manual-only benchmark gating, revised ADR notes for the two benchmark spikes, and README guidance on timing, timeout behavior, and offline vs. production-faithful checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->