### PR TITLE
ci: bump actions/setup-python to v6 in build-pkg-linux (latest major)

### DIFF
--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python (match the target runtime, py 3.11+)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Bumps the one lagging GitHub Action to its latest major and confirms every other action is already current.

## Audit

Surveyed every `uses:` across all workflows and checked each against its latest release:

| Action | Latest major | In repo | Action |
| ------ | ------------ | ------- | ------ |
| `actions/setup-python` | v6 (v6.2.0) | **v5** in `build-pkg-linux.yml` (v6 elsewhere) | **bumped → v6** |
| `actions/checkout` | v6 (v6.0.3) | v6 | already current |
| `actions/setup-node` | v6 (v6.4.0) | v6 | already current |
| `actions/upload-artifact` | v7 (v7.0.1) | v7 | already current |
| `actions/download-artifact` | v8 (v8.0.1) | v8 | already current |
| `actions/cache` | v5 (v5.0.5) | v5 | already current |
| `oras-project/setup-oras` | v2 (v2.0.0) | v2 | already current |
| `shivammathur/setup-php` | v2 (2.37.1) | v2 | already current |
| `softprops/action-gh-release` | v3 (v3.0.0) | v3 | already current |

## Change

`build-pkg-linux.yml`: `actions/setup-python@v5` → `@v6` — the only out-of-date pin (the source of the build-pkg deprecation warning). Local reusable-workflow `uses: ./…` refs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling for the Linux portable package to use the latest version of the Python setup action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->