### PR TITLE
tests: POST the pfSense login submit field in the WebUI harness (ADR-14)

### DIFF
--- a/tests/smoke/ui/webui.py
+++ b/tests/smoke/ui/webui.py
@@ -56,6 +56,12 @@ CSRF_FIELD = "__csrf_magic"
 # Login form field names (src/etc/inc/authgui.inc display_login_form()).
 USERNAME_FIELD = "usernamefld"
 PASSWORD_FIELD = "passwordfld"
+# The submit button. pfSense GATES the credential check on this field's presence
+# -- `if (isset($_POST['login']))` in authgui.inc -- so a POST of only the
+# username/password/CSRF is NEVER authenticated; the form just re-renders at 200.
+# The value is immaterial (isset, not a value compare); send the button's label.
+LOGIN_FIELD = "login"
+LOGIN_VALUE = "Sign In"
 
 # PHP session cookie. pfSense uses PHP's default session name; the cookie the
 # webConfigurator sets on a successful login is PHPSESSID.
@@ -305,6 +311,10 @@ class WebUI:
                 CSRF_FIELD: token,
                 USERNAME_FIELD: self._username,
                 PASSWORD_FIELD: self._password,
+                # Without the submit field pfSense's `isset($_POST['login'])` gate
+                # is false -> it skips auth and re-renders the form (a silent
+                # "bad credentials" that is really "auth never attempted").
+                LOGIN_FIELD: LOGIN_VALUE,
             },
             verify=self._verify,
             timeout=self._timeout,


### PR DESCRIPTION
## Fix the ADR-14 WebUI harness login (missing submit field)

The first all-tiers live-VM dispatch run ([run 26974043908](https://github.com/andrebrait/pfBlockerNG/actions/runs/26974043908)) failed in **every** tier — not on assertions, but in the authenticated `webui` fixture: login was rejected, so each test that needs a session errored.

```
WebUILoginError: login POST to http://127.0.0.1:8080/index.php still returned the
login form (status 200) -- bad credentials or no session established
render: 12 passed, 19 errors   |   functional + browser: same shared-session cause
```

### Root cause

The login POST sent only `__csrf_magic` + `usernamefld` + `passwordfld`. pfSense's webConfigurator **gates the credential check on the submit button field** — `if (isset($_POST['login']))` in `src/etc/inc/authgui.inc` (button: `<input type="submit" name="login" value="Sign In" />`). With `login` absent, pfSense never authenticates and just re-renders the form at HTTP 200 — exactly the symptom. (Phase-1 recon confirmed the field *names* from upstream source but not the auth *gate*; the live run is what surfaced it.)

### Fix

POST `login=Sign In` alongside the credentials (pfSense checks presence, not value). One-line data-dict addition in `tests/smoke/ui/webui.py`, plus the `LOGIN_FIELD`/`LOGIN_VALUE` constants with the upstream citation.

### Verification

`python -m pytest` byte-identical (1019); ruff/mypy/markdownlint/shellcheck clean. The live confirmation is the re-run of the dispatch workflow (Tier-A login should now succeed and the render sweep run for real).

**Note:** this fixes "auth never attempted." If `SMOKE_ADMIN_PASSWORD` doesn't match the image's baked admin password, login would still be rejected (now a genuine bad-creds rejection) — worth confirming the secret value if the re-run still fails on login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved WebUI login authentication failure caused by a missing required field in authentication requests. The login process now includes all necessary server-side validation parameters, ensuring successful user authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->