### PR TITLE
tests: fix ADR-14 UI harness deploy + php_error.log size read

### DIFF
--- a/tests/smoke/ui/conftest.py
+++ b/tests/smoke/ui/conftest.py
@@ -79,7 +79,25 @@ def webgui_protocol(smoke_vm: SmokeVM) -> str:
 
 
 @pytest.fixture(scope="session")
-def webui(smoke_vm: SmokeVM, admin_credentials: tuple[str, str], webgui_protocol: str) -> Iterator[WebUI]:
+def deployed_vm(smoke_vm: SmokeVM) -> SmokeVM:
+    """The smoke VM with the branch pfBlockerNG ``.pkg`` installed (once/session).
+
+    ``smoke_vm`` only pulls/boots the base pfSense image; the ADR-04 smoke matrix
+    tests each call :func:`tests.smoke.helpers.deploy` themselves. The UI tiers
+    need pfBlockerNG's webConfigurator pages PRESENT, so deploy here -- otherwise
+    every pfBlockerNG page 404s (pfSense core, e.g. the login page, still serves),
+    which reads as a UI failure but is really "the package was never installed".
+    ``pkg add`` resolves RUN_DEPENDS from the baked image offline (ADR-04), so no
+    egress is required.
+    """
+    from .. import helpers
+
+    helpers.deploy(smoke_vm)
+    return smoke_vm
+
+
+@pytest.fixture(scope="session")
+def webui(deployed_vm: SmokeVM, admin_credentials: tuple[str, str], webgui_protocol: str) -> Iterator[WebUI]:
     """A logged-in :class:`WebUI` against the smoke VM's webConfigurator.
 
     Honours the RECON'd protocol: HTTPS on the throwaway image is driven with
@@ -90,8 +108,8 @@ def webui(smoke_vm: SmokeVM, admin_credentials: tuple[str, str], webgui_protocol
     username, password = admin_credentials
     https = webgui_protocol == "https"
     client = WebUI(
-        host=smoke_vm.host,
-        port=smoke_vm.web_port,
+        host=deployed_vm.host,
+        port=deployed_vm.web_port,
         username=username,
         password=password,
         scheme="https" if https else "http",

--- a/tests/smoke/ui/render_oracle.py
+++ b/tests/smoke/ui/render_oracle.py
@@ -151,26 +151,30 @@ class PhpErrorLogGuard:
         """Current byte size of each candidate log (missing -> 0)."""
         sizes: dict[str, int] = {}
         for path in self._candidates:
-            # BSD stat: -f %z = size in bytes. `|| echo 0` makes a MISSING file 0
-            # while keeping the command's exit status 0, so a non-zero returncode
-            # here means the SSH transport itself failed -- fail fast rather than
-            # silently reading size 0 (which would mask oracle condition (d): a
-            # failed read before AND after a real error would show no growth).
-            result = self._vm.ssh("/bin/sh", "-c", f"/usr/bin/stat -f %z {path} 2>/dev/null || echo 0")
-            if result.returncode != 0:
+            # Pass a DIRECT argv (no `/bin/sh -c "..."` wrapper): ssh space-joins
+            # its remote args into ONE string the guest login shell re-parses, so
+            # `/bin/sh -c "stat -f %z P 2>/dev/null || echo 0"` would have `-c`
+            # consume only `stat` and stat would then read stdin (the classic
+            # double-parse -> "(stdin)" output). `stat -f %z <path>` (BSD stat:
+            # %z = size in bytes) runs cleanly as a direct argv, no shell needed.
+            result = self._vm.ssh("/usr/bin/stat", "-f", "%z", path)
+            if result.returncode == 0:
+                text = result.stdout.strip()
+                try:
+                    sizes[path] = int(text)
+                except ValueError as exc:
+                    raise AssertionError(f"unparseable php_error.log size for {path}: {result.stdout!r}") from exc
+            elif result.returncode == 255:
+                # 255 is ssh's OWN failure code (transport/auth) -- a real read
+                # fault, not a missing file; fail fast rather than masking oracle
+                # condition (d) (a failed read before AND after shows no growth).
                 raise AssertionError(
-                    f"failed to read php_error.log size for {path} "
-                    f"(ssh rc={result.returncode}): {(result.stderr or result.stdout).strip()!r}"
+                    f"ssh failed reading php_error.log size for {path}: {(result.stderr or result.stdout).strip()!r}"
                 )
-            text = result.stdout.strip().splitlines()
-            try:
-                if not text:
-                    raise ValueError("empty stat output")
-                sizes[path] = int(text[-1])
-            except ValueError as exc:
-                # Unparseable output is a real fault (a stat error leaking past the
-                # `|| echo 0`), not a transient blip -- fail rather than coerce to 0.
-                raise AssertionError(f"unparseable php_error.log size for {path}: {result.stdout!r}") from exc
+            else:
+                # stat exited non-zero (the log does not exist yet) -> size 0, so a
+                # file created mid-sweep still registers as growth (0 -> N).
+                sizes[path] = 0
         return sizes
 
     def snapshot(self) -> None:


### PR DESCRIPTION
## Fix the two live-only ADR-14 UI harness bugs (deploy + php_error.log size)

The first all-tiers dispatch run got past login (#81) and exposed two harness bugs — both root-caused (no further diagnostic run needed):

### 1. 404 on every pfBlockerNG page — the package was never installed

`smoke_vm` only pulls/boots the base pfSense image; the ADR-04 smoke matrix tests each call `helpers.deploy()` themselves to `pkg add` the branch build. The UI `webui` fixture depended on `smoke_vm` but **never deployed**, so the UI tiers ran against a VM with pfBlockerNG **not installed** — pfSense core (the login page) served, every package page 404'd.

**Fix:** a session-scoped `deployed_vm` fixture that calls `helpers.deploy()` once; `webui` now depends on it. `pkg add` resolves RUN_DEPENDS from the baked image offline (ADR-04), so no egress is needed.

### 2. `php_error.log` size read returned BSD `stat`'s `(stdin)` output

`_sizes()` wrapped the command in `/bin/sh -c "…"` and passed it as **separate** ssh args. `ssh host a b c` space-joins the remote args into one string the **guest** shell re-parses, so `/bin/sh -c stat -f %z …` had `-c` consume only `stat` → stat read stdin (the classic double-parse). This was masked until #77 made the read fail-fast.

**Fix:** direct argv (`stat -f %z <path>`, no shell wrapper); `rc==0` parse, `rc==255` (ssh failure) raise, other `rc` (missing log) → `0`.

### Verification

`python -m pytest` byte-identical (1019); oracle pure-logic tests stay green (11); ruff clean. Live confirmation is a re-dispatch of `ui-tests.yml`. Both files are under `tests/smoke/ui/`; the UI tier is currently **non-blocking** (made optional on devel while it stabilizes), so this cannot gate other pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for UI testing to ensure proper prerequisite deployment before test execution.
  * Improved error logging detection and SSH failure handling in test utilities for increased reliability.

* **Chores**
  * Updated test fixtures to streamline test initialization and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->