### PR TITLE
tests: shape-match Tier-A PHP oracle + fix browser toggle click (ADR-14)

### DIFF
--- a/tests/smoke/ui/render_oracle.py
+++ b/tests/smoke/ui/render_oracle.py
@@ -5,10 +5,12 @@ rendered PHP ``Warning``/``Notice``, a fatal-error trace, or a blank/redirected
 body. So a page PASSES Tier A only when ALL of:
 
 * **(a)** the response is **HTTP 200**;
-* **(b)** the body contains **none** of the PHP error/warning signatures
-  (:data:`FORBIDDEN_SUBSTRINGS` -- ``Fatal error``/``Parse error``/``Warning``/
-  ``Notice``/``Uncaught``/``Stack trace``), so a page that rendered a PHP
-  diagnostic into its body fails;
+* **(b)** the body contains no rendered PHP diagnostic in its recognizable SHAPE
+  (:data:`_PHP_DIAGNOSTIC_RE` over :data:`PHP_ERROR_LEVELS` -- the ``PHP <Level>``
+  prefix, the ``<b><Level></b>`` HTML wrapper, a ``<Level>: ... on line N`` line,
+  an ``Uncaught …Error/Exception``, or a ``Stack trace:``), so a page that
+  rendered a PHP diagnostic fails -- WITHOUT false-positiving on the level words
+  in legitimate page copy;
 * **(c)** a **page-specific content marker** is present (so a blank body, a
   redirect to the dashboard, or the login form cannot false-pass a 200);
 * **(d)** the on-box ``php_error.log`` gained **no new bytes** across the sweep
@@ -18,7 +20,7 @@ body. So a page PASSES Tier A only when ALL of:
 This module is the reusable pure-logic core: :func:`evaluate_render` decides
 (a)-(c) for one fetched page and returns a structured :class:`RenderResult`;
 :class:`PhpErrorLogGuard` owns the (d) sweep-level ``php_error.log`` diff over
-SSH. Phases 3/4 reuse :data:`FORBIDDEN_SUBSTRINGS` / :func:`body_has_php_error`.
+SSH. Phases 3/4 reuse :func:`body_has_php_error` / :data:`PHP_ERROR_LEVELS`.
 
 It imports nothing third-party and does not touch the VM at module import time
 (the SSH calls live inside :class:`PhpErrorLogGuard`'s methods), so it is import-
@@ -28,6 +30,7 @@ pure-logic half is unit-testable off-box (``test_render_oracle.py``).
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -36,31 +39,53 @@ from .webui import looks_like_login_page
 if TYPE_CHECKING:
     from ..conftest import SmokeVM
 
-# PHP diagnostic signatures that must NEVER appear in a healthy page body. pfSense
-# renders display_errors on for the webConfigurator, so a Warning/Notice/Fatal
-# bleeds into the HTML -- exactly the regression class Tier A exists to catch.
-# Each is matched as a plain substring (case-sensitive: PHP emits these with this
-# exact casing -- "PHP Warning", "Fatal error", "Parse error", "Uncaught", ...).
-FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (
+# PHP diagnostic LEVELS (exact casing PHP emits). These are matched only in a
+# real diagnostic SHAPE (see _PHP_DIAGNOSTIC_RE) -- never as a bare word: pages
+# carry the level words in legitimate copy ("a pfSense Notice message", the
+# "Warning: ..." input-error strings on pfblockerng_ip.php), so a bare-substring
+# match false-positives. pfSense renders display_errors into the HTML, so a real
+# Warning/Notice/Fatal still bleeds into the body in one of the shapes below --
+# exactly the regression class Tier A exists to catch.
+PHP_ERROR_LEVELS: tuple[str, ...] = (
     "Fatal error",
     "Parse error",
+    "Recoverable fatal error",
     "Warning",
     "Notice",
-    "Uncaught",
-    "Stack trace",
+    "Deprecated",
+    "Strict Standards",
+)
+
+_LEVELS_ALT = "|".join(re.escape(level) for level in PHP_ERROR_LEVELS)
+
+# A rendered PHP diagnostic has an UNAMBIGUOUS shape; match that, not the bare
+# level word. Any one of:
+#   * error_log / CLI prefix      "PHP <Level>"          (prose never says this)
+#   * HTML display_errors wrapper "<b><Level></b>"       (prose never has this)
+#   * plain display form          "<Level>: ... on line <N>"  (the file/line trailer
+#                                  disambiguates from "Warning: When using ..." copy)
+#   * an uncaught throwable        "Uncaught <X>Error/Exception"
+#   * an exception stack trace     "Stack trace:\n#0"
+_PHP_DIAGNOSTIC_RE = re.compile(
+    rf"PHP\s+(?:{_LEVELS_ALT})\b"
+    rf"|<b>\s*(?:{_LEVELS_ALT})\s*</b>"
+    rf"|(?:{_LEVELS_ALT}):[^\n]*?\bon line\b\s*(?:<b>\s*)?\d+"
+    r"|\bUncaught\s+\w*(?:Error|Exception)\b"
+    r"|\bStack trace:\s*#0"
 )
 
 
 def body_has_php_error(body: str) -> str | None:
-    """Return the first :data:`FORBIDDEN_SUBSTRINGS` token present in ``body``, else ``None``.
+    """Return the matched PHP-diagnostic text in ``body`` (its shape), else ``None``.
 
-    A non-``None`` return is the proof a PHP diagnostic was rendered into the page
-    (oracle condition (b) fails). Reusable by later tiers that also fetch a body.
+    Matches the SHAPE of a rendered PHP diagnostic (:data:`_PHP_DIAGNOSTIC_RE`),
+    NOT the bare level word -- the level words appear in legitimate page copy, so
+    a substring match false-positives (this bit ``pfblockerng_ip.php``: "a pfSense
+    Notice message"). A non-``None`` return is the proof a PHP diagnostic was
+    rendered into the page (oracle condition (b) fails). Reusable by later tiers.
     """
-    for token in FORBIDDEN_SUBSTRINGS:
-        if token in body:
-            return token
-    return None
+    match = _PHP_DIAGNOSTIC_RE.search(body)
+    return match.group(0) if match else None
 
 
 @dataclass(frozen=True)
@@ -86,7 +111,7 @@ def evaluate_render(path: str, status_code: int, body: str, markers: tuple[str, 
     """Apply oracle conditions (a)-(c) to one fetched page; return a :class:`RenderResult`.
 
     * (a) ``status_code == 200``;
-    * (b) ``body`` contains no :data:`FORBIDDEN_SUBSTRINGS` token;
+    * (b) ``body`` contains no rendered PHP diagnostic shape (:func:`body_has_php_error`);
     * (c) at least one of ``markers`` is present AND the body is not the login
       form (a logged-out 200 renders the login page, which must never pass).
 

--- a/tests/smoke/ui/test_browser.py
+++ b/tests/smoke/ui/test_browser.py
@@ -132,21 +132,23 @@ def test_enable_change_toggle_disables_then_enables_target(
     expect(invert).to_be_disabled(timeout=JS_TIMEOUT_MS)
     _shot(page, screenshot_dir, "toggle_before_disabled")
 
-    # FLIP ON: a real (trusted) click flips .checked AND fires the jQuery click
-    # handler bound at pfBlockerNG.js:240-242 -> enable_change_in() enables the
-    # targets. `enable_change_in` is a closure-local (inside events.push), NOT a
-    # global, so it can only be reached through the real click binding -- drive
-    # the actual control. `force=True`: the checkbox sits in a COLLAPSIBLE panel
-    # that may be collapsed, so it is not "visible" to a normal actionability
-    # check, but the click + handler still fire.
-    toggle.click(force=True)
+    # FLIP ON: drive the element's native click(). This flips .checked AND fires
+    # the jQuery click handler bound at pfBlockerNG.js:240-242 -> enable_change_in()
+    # enables the targets (`enable_change_in` is a closure-local, reachable only
+    # through the real click binding -- so we must click the actual control, not
+    # set .checked). The checkbox sits in a Bootstrap panel that is collapsed
+    # (display:none -> zero-size), which defeats even Playwright `click(force=True)`
+    # ("Element is not visible" -- force can't click a zero-size box). The DOM
+    # `el.click()` needs no geometry/visibility, toggles the box, and fires the
+    # bound handler, so it is the robust driver here.
+    toggle.evaluate("el => el.click()")
     expect(toggle).to_be_checked(timeout=JS_TIMEOUT_MS)
     expect(addr).to_be_enabled(timeout=JS_TIMEOUT_MS)
     expect(invert).to_be_enabled(timeout=JS_TIMEOUT_MS)
     _shot(page, screenshot_dir, "toggle_after_enabled")
 
     # FLIP BACK OFF: re-click -> re-disabled -- proves it is a real two-way branch.
-    toggle.click(force=True)
+    toggle.evaluate("el => el.click()")
     expect(toggle).not_to_be_checked(timeout=JS_TIMEOUT_MS)
     expect(addr).to_be_disabled(timeout=JS_TIMEOUT_MS)
     expect(invert).to_be_disabled(timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_render_oracle.py
+++ b/tests/smoke/ui/test_render_oracle.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import pytest
 
-from .render_oracle import FORBIDDEN_SUBSTRINGS, body_has_php_error, evaluate_render
+from .render_oracle import PHP_ERROR_LEVELS, body_has_php_error, evaluate_render
 
 pytestmark = pytest.mark.ui_render
 
@@ -44,22 +44,64 @@ def test_good_body_passes() -> None:
     assert result.reasons == ()
 
 
-@pytest.mark.parametrize("token", FORBIDDEN_SUBSTRINGS)
-def test_php_diagnostic_in_body_is_rejected(token: str) -> None:
-    """(b): a body carrying any PHP diagnostic token fails, though it is HTTP 200 + has the marker.
+@pytest.mark.parametrize("level", PHP_ERROR_LEVELS)
+def test_php_diagnostic_in_body_is_rejected(level: str) -> None:
+    """(b): a body carrying any PHP diagnostic LEVEL (in shape) fails, though 200 + marker.
 
-    The SAME marker-bearing 200 body passes without the token (asserted here as
-    the before-state) and fails once the token is injected -- so the rejection is
-    caused by the diagnostic, not by anything else.
+    The SAME marker-bearing 200 body passes without the diagnostic (asserted here
+    as the before-state) and fails once a real ``PHP <Level>: ... on line N`` line
+    is injected -- so the rejection is caused by the diagnostic, not anything else.
     """
     # Before: identical body minus the diagnostic passes.
     assert evaluate_render("/p", 200, GOOD_BODY, (GOOD_MARKER,)).ok
     # After: inject a realistic PHP diagnostic line into the otherwise-good body.
-    broken = GOOD_BODY.replace("<body>", f"<body>PHP {token}: oops in pfblockerng.inc on line 1<br />")
+    broken = GOOD_BODY.replace("<body>", f"<body>PHP {level}: oops in pfblockerng.inc on line 1<br />")
     result = evaluate_render("/p", 200, broken, (GOOD_MARKER,))
-    assert not result.ok, f"oracle passed a body containing {token!r}"
+    assert not result.ok, f"oracle passed a body containing a PHP {level!r} diagnostic"
     assert body_has_php_error(broken) is not None
-    assert any(token in r for r in result.reasons)
+    assert any(level in r for r in result.reasons)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        "<br />\n<b>Notice</b>:  Undefined variable $x in <b>/usr/local/www/x.php</b> on line <b>42</b><br />",
+        "Warning: Invalid argument supplied for foreach() in /usr/local/www/x.php on line 99",
+        "Fatal error: Uncaught TypeError: bad in /x.php:7",
+        "Stack trace:\n#0 /usr/local/www/x.php(7): foo()",
+    ],
+    ids=["html-bold", "plain-on-line", "uncaught", "stack-trace"],
+)
+def test_real_diagnostic_shapes_are_rejected(shape: str) -> None:
+    """(b): each real rendered-diagnostic SHAPE (HTML wrap, plain on-line, uncaught, trace) fails."""
+    assert evaluate_render("/p", 200, GOOD_BODY, (GOOD_MARKER,)).ok  # before: clean body passes
+    broken = GOOD_BODY.replace("<body>", f"<body>{shape}")
+    result = evaluate_render("/p", 200, broken, (GOOD_MARKER,))
+    assert not result.ok, f"oracle passed a real diagnostic shape: {shape!r}"
+    assert any("PHP diagnostic" in r for r in result.reasons)
+
+
+@pytest.mark.parametrize(
+    "copy",
+    [
+        # Real legit copy from pfblockerng_ip.php -- level words in prose, NOT diagnostics.
+        "A pfSense Notice message will be submitted on completion.",
+        "Upon completion, a pfSense Notice will be generated.",
+        "Warning: When using an Action setting of 'Permit Inbound or Permit Both', ...",
+        "Warning: With DoH/DoT Blocking enabled, you must select at least one List",
+    ],
+)
+def test_level_words_in_legit_copy_are_not_rejected(copy: str) -> None:
+    """(b) false-positive guard: a level WORD in page copy (no diagnostic shape) PASSES.
+
+    This is the bug the shape-based oracle fixes: a bare-substring match flagged
+    "a pfSense Notice message" / the "Warning: ..." input-error strings as PHP
+    diagnostics. None of these carry the diagnostic shape, so the oracle must NOT
+    reject them.
+    """
+    body = GOOD_BODY.replace("<body>", f"<body><p>{copy}</p>")
+    assert body_has_php_error(body) is None, f"legit copy wrongly flagged as a PHP diagnostic: {copy!r}"
+    assert evaluate_render("/p", 200, body, (GOOD_MARKER,)).ok, f"oracle wrongly rejected legit copy: {copy!r}"
 
 
 def test_non_200_is_rejected() -> None:


### PR DESCRIPTION
## Tier-A oracle false-positive + Tier-B browser toggle — fixes from the first real run

With deploy + login + stat fixed (#81, #82), the first all-tiers run actually executed the tiers: **functional / ce went GREEN**, and render/browser surfaced two issues — both fixed here.

### Tier A (render) — 30 passed, 1 false-positive

`pfblockerng_ip.php` failed `body contains PHP diagnostic 'Notice'`. Not a real error — the oracle matched **bare level words** as substrings, flagging legit copy:

- help text: *"A pfSense **Notice** message will be submitted on completion."*
- input-error prose: *"**Warning:** When using an Action setting of 'Permit Both', …"*

(The `php_error.log` guard — condition (d) — passed, confirming no real diagnostic was logged.)

**Fix:** match the PHP-diagnostic **shape**, not the bare word: `PHP <Level>`, `<b><Level></b>`, `<Level>: … on line N`, `Uncaught …Error/Exception`, or `Stack trace:`. The pure-logic oracle tests grow **11 → 20**: every real shape is still caught, and a new false-positive guard pins the exact IP-page copy as **passing**.

### Tier B (browser) — checkbox in a collapsed panel

`#autoaddr_in` is inside a Bootstrap panel that's collapsed (`display:none` → zero-size). Even `click(force=True)` fails (`Element is not visible` — force can't click a zero-size box).

**Fix:** drive the element's native `el.click()` via `evaluate()` — no geometry/visibility needed; it toggles the checkbox *and* fires the jQuery `click` handler (`enable_change_in`).

### Verification

`python -m pytest` byte-identical (1019); oracle logic 20 passed; ruff/mypy/markdownlint/shellcheck clean. The render fix is **locally proven** (the false-positive guard feeds the real IP-page copy); the browser fix is validated by re-dispatching `ui-tests.yml`. UI tier remains **non-blocking**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved PHP error detection in the test suite by implementing intelligent pattern matching for more reliable diagnostic identification.
  * Enhanced test robustness for DOM element interactions and checkbox state management.
  * Added comprehensive test coverage for various diagnostic formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->