### PR TITLE
tests: add ADR-13 auto-VIP UI coverage (DNSBL form + checkbox UX)

### DIFF
--- a/tests/smoke/ui/test_browser.py
+++ b/tests/smoke/ui/test_browser.py
@@ -75,6 +75,10 @@ ADVANCED_IP_EDITOR = "/pfblockerng/pfblockerng_category_edit.php?type=ipv4"
 # The dashboard widget renders standalone (auth-gated, $nocsrf) with its hidden
 # ack input + status icons + table body.
 WIDGET_PAGE = "/widgets/widgets/pfblockerng.widget.php"
+# The DNSBL settings page hosts the ADR-13 "Create VIPs automatically" checkbox
+# (#pfb_dnsvip_auto) whose click handler (enable_dnsvip_auto) disables the manual
+# VIP dropdowns (#pfb_dnsvip4/#pfb_dnsvip6).
+DNSBL_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
 
 # A short, explicit timeout (ms) for the JS-driven DOM transitions: the handlers
 # fire synchronously on load/click, so this is a flake ceiling, not a wait knob.
@@ -257,3 +261,51 @@ def test_dashboard_widget_renders(
     expect(page.locator("#pfBNG-table")).to_be_attached(timeout=JS_TIMEOUT_MS)
     expect(page.locator(".PFBSTATUS").first).to_be_attached(timeout=JS_TIMEOUT_MS)
     _shot(page, screenshot_dir, "dashboard_widget")
+
+
+def test_dnsvip_auto_checkbox_disables_manual_dropdowns(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """ADR-13: ticking 'Create VIPs automatically' disables the manual VIP dropdowns.
+
+    `#pfb_dnsvip_auto`'s click handler (enable_dnsvip_auto, pfblockerng_dnsbl.php)
+    disables `#pfb_dnsvip4`/`#pfb_dnsvip6` when checked and re-enables them when
+    unchecked. Branch coverage with the before-state asserted (CLAUDE.md): start
+    unchecked -> dropdowns ENABLED, check -> DISABLED, uncheck -> ENABLED again.
+    Drive the native el.click() (it fires the bound jQuery handler regardless of
+    the checkbox's panel visibility -- see the enable_change toggle test).
+    """
+    page = browser_page
+    _open(page, webui, DNSBL_PAGE)
+
+    auto = page.locator("#pfb_dnsvip_auto")
+    v4 = page.locator("#pfb_dnsvip4")
+    v6 = page.locator("#pfb_dnsvip6")
+    expect(auto).to_be_attached(timeout=JS_TIMEOUT_MS)
+    expect(v4).to_be_attached(timeout=JS_TIMEOUT_MS)
+
+    # Normalize to a known start (unchecked) so the before-state is deterministic
+    # regardless of the saved pfb_dnsvip_auto config the page rendered with.
+    if auto.is_checked():
+        auto.evaluate("el => el.click()")
+        expect(auto).not_to_be_checked(timeout=JS_TIMEOUT_MS)
+
+    # BEFORE: auto off -> the manual dropdowns are enabled.
+    expect(v4).to_be_enabled(timeout=JS_TIMEOUT_MS)
+    expect(v6).to_be_enabled(timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "dnsvip_auto_before_off")
+
+    # CHECK -> the handler disables both manual dropdowns.
+    auto.evaluate("el => el.click()")
+    expect(auto).to_be_checked(timeout=JS_TIMEOUT_MS)
+    expect(v4).to_be_disabled(timeout=JS_TIMEOUT_MS)
+    expect(v6).to_be_disabled(timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "dnsvip_auto_after_on")
+
+    # UNCHECK -> re-enabled (proves it is a real two-way branch).
+    auto.evaluate("el => el.click()")
+    expect(auto).not_to_be_checked(timeout=JS_TIMEOUT_MS)
+    expect(v4).to_be_enabled(timeout=JS_TIMEOUT_MS)
+    expect(v6).to_be_enabled(timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -232,13 +232,26 @@ def test_dnsvip_auto_form_provisions_and_removes_marked_vip(
     Oracle = effective box state (marked_vip_subnet / ifconfig), never the HTTP
     response. The manual VIP at 10.10.10.1 (dnsbl_vip_ready) is untouched. Left
     clean (auto off, marked VIP gone) for the sibling flows in `finally`.
+
+    A DNSBL alias must be configured (write_local_feed + inject) for the Force
+    Update to actually run pfb_create_dnsbl('enabled') -> pfb_manage_dnsbl_vip: a
+    bare `update` with no DNSBL list does NOT reach the VIP-provisioning pass (the
+    same setup the smoke matrix uses via CaseContext). The feed is a LOCAL file
+    under /var/db/pfblockerng, so the update needs no egress. reload uses the full
+    `update` scope (not the targeted `updatednsbl`, which skips the VIP pass), with
+    egress open -- so this drives inject()+reload() directly rather than via
+    CaseContext (whose body runs with egress BLOCKED).
     """
     vm = smoke_vm
+    # A DNSBL list so the Force Update has work and runs the VIP-provisioning pass.
+    domain = helpers.unique_domain("uiautovip")
+    feed_path = helpers.write_local_feed(vm, "ui_autovip.txt", f"{domain}\n")
+    spec = helpers.DnsblCase(aliasname="uiautovip", feed_url=feed_path, header="uiautovip", mode=helpers.DnsblMode.VIP)
     # DNSBL must be enabled so the Force Update runs pfb_create_dnsbl in 'enabled'
-    # mode; start from a known baseline (auto off, no marked VIP).
+    # mode; configure the alias; start from a known baseline (auto off).
     helpers.set_dnsbl_enabled(vm, True)
     helpers.set_dnsvip_auto(vm, False)
-    helpers.reload(vm, "update")
+    helpers.inject(vm, spec)
     try:
         # BEFORE.
         assert helpers.config_get(vm, AUTO_VIP_CFG) != "on", "pfb_dnsvip_auto already on before the form POST"
@@ -252,7 +265,7 @@ def test_dnsvip_auto_form_provisions_and_removes_marked_vip(
         assert helpers.config_get(vm, AUTO_VIP_CFG) == "on", (
             "the DNSBL form POST did not persist pfb_dnsvip_auto=on to config.xml"
         )
-        # The next Force Update provisions the marked VIP (same path as the matrix).
+        # The next full Force Update provisions the marked VIP (same path as the matrix).
         helpers.reload(vm, "update")
         assert helpers.marked_vip_subnet(vm, helpers.AUTO_VIP_DESCR_V4) == helpers.AUTO_VIP_IP4, (
             f"auto VIP not created at {helpers.AUTO_VIP_IP4} after the form enabled it: "
@@ -262,7 +275,7 @@ def test_dnsvip_auto_form_provisions_and_removes_marked_vip(
             f"auto VIP {helpers.AUTO_VIP_IP4} not live on lo0 (ifconfig) after the form enabled it"
         )
 
-        # DISABLE through the form; persisted off, then the VIP is removed.
+        # DISABLE through the form; persisted off, then the Force Update removes it.
         resp = webui.post(DNSBL_PAGE, {"pfb_dnsvip_auto": ""}, timeout=300.0)
         assert not looks_like_login_page(resp.text), "DNSBL un-POST returned the login form"
         assert helpers.config_get(vm, AUTO_VIP_CFG) != "on", "the DNSBL form POST did not clear pfb_dnsvip_auto"
@@ -274,6 +287,7 @@ def test_dnsvip_auto_form_provisions_and_removes_marked_vip(
             f"auto VIP {helpers.AUTO_VIP_IP4} still live on lo0 after the form disabled it"
         )
     finally:
-        # Leave the box clean for the sibling flows: auto off, marked VIP gone.
+        # Leave the box clean for the sibling flows: auto off + drop the test alias
+        # and rebuild from baseline (reset = clearip/cleardnsbl + a forced update).
         helpers.set_dnsvip_auto(vm, False)
-        helpers.reload(vm, "update")
+        helpers.reset(vm)

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -189,3 +189,91 @@ def test_toggle_flow_changes_effective_config(
         if helpers.config_get(smoke_vm, flow.config_path) != original:
             overrides = {flow.field: flow.on} if original == flow.on else {flow.field: flow.off}
             webui.post(flow.page, overrides, timeout=flow.post_timeout)
+
+
+# --------------------------------------------------------------------------- #
+# ADR-13 "Create VIPs automatically" (pfb_dnsvip_auto) -- driven via the DNSBL FORM
+#
+# The auto-VIP LIFECYCLE (config toggle -> VIP created/removed -> DNS sinks) is
+# already covered by the smoke matrix (test_smoke_matrix.py) via the config helper
+# `set_dnsvip_auto`. The UI tier's DISTINCT value is proving the DNSBL settings
+# PAGE persists pfb_dnsvip_auto through a real CSRF form POST, with the same
+# package machinery (pfb_create_dnsbl -> pfb_manage_dnsbl_vip) then provisioning
+# the marked VIP end-to-end. Auto picks 10.10.10.53, free alongside the manual VIP
+# at 10.10.10.1 (dnsbl_vip_ready), so the two coexist on one VM.
+#
+# TODO(ADR-12): add update-hooks UI coverage (add/toggle/remove a hook row + its
+# config persistence) once ADR-12 lands on devel -- it is not merged there yet.
+# --------------------------------------------------------------------------- #
+
+DNSBL_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
+AUTO_VIP_CFG = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto"
+
+
+def test_dnsvip_auto_form_provisions_and_removes_marked_vip(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready: None,
+) -> None:
+    """Ticking 'Create VIPs automatically' in the DNSBL FORM provisions the marked VIP.
+
+    UI-faithful end-to-end with the CLAUDE.md transition rule (assert before-state,
+    then prove the form POST caused the change):
+
+    * BEFORE: pfb_dnsvip_auto is off in config and no package-owned pfB_AUTO_VIP_v4
+      exists.
+    * ENABLE via the form: the CSRF POST must PERSIST pfb_dnsvip_auto=on (the
+      UI-specific assertion -- config.xml, not the HTTP body); the next Force
+      Update runs pfb_create_dnsbl('enabled') -> pfb_manage_dnsbl_vip, which
+      creates the marked VIP at 10.10.10.53 and brings it up live on lo0.
+    * DISABLE via the form: the POST persists it off; a Force Update removes the
+      marked VIP from config AND lo0.
+
+    Oracle = effective box state (marked_vip_subnet / ifconfig), never the HTTP
+    response. The manual VIP at 10.10.10.1 (dnsbl_vip_ready) is untouched. Left
+    clean (auto off, marked VIP gone) for the sibling flows in `finally`.
+    """
+    vm = smoke_vm
+    # DNSBL must be enabled so the Force Update runs pfb_create_dnsbl in 'enabled'
+    # mode; start from a known baseline (auto off, no marked VIP).
+    helpers.set_dnsbl_enabled(vm, True)
+    helpers.set_dnsvip_auto(vm, False)
+    helpers.reload(vm, "update")
+    try:
+        # BEFORE.
+        assert helpers.config_get(vm, AUTO_VIP_CFG) != "on", "pfb_dnsvip_auto already on before the form POST"
+        assert helpers.marked_vip_subnet(vm, helpers.AUTO_VIP_DESCR_V4) == "", (
+            "pfB_AUTO_VIP_v4 present before auto-create was enabled via the form"
+        )
+
+        # ENABLE through the real DNSBL form; the PAGE must persist the setting.
+        resp = webui.post(DNSBL_PAGE, {"pfb_dnsvip_auto": "on"}, timeout=300.0)
+        assert not looks_like_login_page(resp.text), "DNSBL POST returned the login form (session lost)"
+        assert helpers.config_get(vm, AUTO_VIP_CFG) == "on", (
+            "the DNSBL form POST did not persist pfb_dnsvip_auto=on to config.xml"
+        )
+        # The next Force Update provisions the marked VIP (same path as the matrix).
+        helpers.reload(vm, "update")
+        assert helpers.marked_vip_subnet(vm, helpers.AUTO_VIP_DESCR_V4) == helpers.AUTO_VIP_IP4, (
+            f"auto VIP not created at {helpers.AUTO_VIP_IP4} after the form enabled it: "
+            f"got {helpers.marked_vip_subnet(vm, helpers.AUTO_VIP_DESCR_V4)!r}"
+        )
+        assert helpers.vip_alias_live(vm, helpers.AUTO_VIP_IP4), (
+            f"auto VIP {helpers.AUTO_VIP_IP4} not live on lo0 (ifconfig) after the form enabled it"
+        )
+
+        # DISABLE through the form; persisted off, then the VIP is removed.
+        resp = webui.post(DNSBL_PAGE, {"pfb_dnsvip_auto": ""}, timeout=300.0)
+        assert not looks_like_login_page(resp.text), "DNSBL un-POST returned the login form"
+        assert helpers.config_get(vm, AUTO_VIP_CFG) != "on", "the DNSBL form POST did not clear pfb_dnsvip_auto"
+        helpers.reload(vm, "update")
+        assert helpers.marked_vip_subnet(vm, helpers.AUTO_VIP_DESCR_V4) == "", (
+            "auto VIP not removed from config after unticking the form setting"
+        )
+        assert not helpers.vip_alias_live(vm, helpers.AUTO_VIP_IP4), (
+            f"auto VIP {helpers.AUTO_VIP_IP4} still live on lo0 after the form disabled it"
+        )
+    finally:
+        # Leave the box clean for the sibling flows: auto off, marked VIP gone.
+        helpers.set_dnsvip_auto(vm, False)
+        helpers.reload(vm, "update")


### PR DESCRIPTION
## ADR-13 auto-VIP — UI coverage (DNSBL form + checkbox UX)

Extends the (currently non-blocking) UI tiers to cover the **"Create VIPs automatically"** (`pfb_dnsvip_auto`) feature **through the WebUI**. The auto-VIP *lifecycle* is already covered by the smoke matrix via the config helper `set_dnsvip_auto`; this adds the **WebUI-path** coverage the harness exists for.

### `ui_e2e` — DNSBL form provisions/removes the marked VIP

Drives `pfb_dnsvip_auto` through the **real DNSBL CSRF form POST** (not the config helper), as a full transition (before-state asserted):

- **before:** auto off in config, no `pfB_AUTO_VIP_v4`;
- **enable via the form:** the POST must **persist** `pfb_dnsvip_auto=on` (the UI-specific assertion — config.xml, not the HTTP body); a Force Update then runs `pfb_create_dnsbl('enabled') → pfb_manage_dnsbl_vip`, creating the marked VIP at `10.10.10.53` **live on lo0**;
- **disable via the form:** persisted off → Force Update removes it from config + lo0.

Oracle = effective box state (`marked_vip_subnet` / `ifconfig`). Auto picks `10.10.10.53`, free alongside the manual VIP at `10.10.10.1` (`dnsbl_vip_ready`), so the two coexist on one VM; left clean in `finally`.

### `ui_browser` — checkbox disables the manual dropdowns

Checking `#pfb_dnsvip_auto` disables `#pfb_dnsvip4`/`#pfb_dnsvip6` (and unchecking re-enables them) — before-state asserted, both branches, driven via native `el.click()` so the bound jQuery handler fires regardless of panel visibility.

### Notes

- **ADR-12 update hooks** UI coverage is **queued** (a `TODO` in `test_functional.py`) — that feature isn't on `devel` yet.
- `python -m pytest` byte-identical (1019); new tests collect under the smoke/ui override; ruff/mypy clean. Live validation is the next `ui-tests.yml` dispatch. UI tier remains **non-blocking**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * New UI test verifies the "Create VIPs automatically" checkbox disables and re-enables manual VIP selectors and captures screenshots of each state.
  * New functional end-to-end test verifies toggling automatic VIP creation persists in configuration, provisions/removes the marked VIP on update, and cleans up system state afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->