### PR TITLE
phpstan: raise to level 1; stub pfSense constants (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Variable \$folder_ex in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
+
+		-
 			message: '#^Call to function unset\(\) contains undefined variable \$output\.$#'
 			identifier: unset.variable
 			count: 3
@@ -103,6 +109,276 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
+			message: '#^Variable \$DDG might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$PIX might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$alias might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$asn_cache might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$asn_ex in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$cname_cnt might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$csvline might not be defined\.$#'
+			identifier: variable.undefined
+			count: 14
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$customlist in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$database might not be defined\.$#'
+			identifier: variable.undefined
+			count: 7
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$db_create might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$db_handle might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$db_table might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$details might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$folder might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$iplog might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$l_type might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$labels in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$lastdnsblclear might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$lastipclear might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$line in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$log might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$logtab might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$mode might not be defined\.$#'
+			identifier: variable.undefined
+			count: 5
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$new_rules_nocreated might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$orig_rules_nocreated might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$output in isset\(\) is never defined\.$#'
+			identifier: isset.variable
+			count: 3
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$pfb_include in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$pfb_localsub might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$pfb_output might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$pfb_suffix_match in empty\(\) always exists and is always falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$pfb_tables in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$pfbfolder might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$result in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$result in isset\(\) is never defined\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$retval in isset\(\) is never defined\.$#'
+			identifier: isset.variable
+			count: 4
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$retval might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$rs in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$rsync might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$safesearch_update might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$src_ip in empty\(\) is never defined\.$#'
+			identifier: empty.variable
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$ss_cname might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$ss_ex might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$tld_list in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$tld_segments in isset\(\) is never defined\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$u_msg might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+
+		-
 			message: '#^Undefined variable\: \$coptions4$#'
 			identifier: variable.undefined
 			count: 3
@@ -145,6 +421,366 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
+			message: '#^Variable \$argv might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+
+		-
+			message: '#^Variable \$country might not be defined\.$#'
+			identifier: variable.undefined
+			count: 8
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+
+		-
+			message: '#^Variable \$et_options might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+
+		-
+			message: '#^Variable \$isocode might not be defined\.$#'
+			identifier: variable.undefined
+			count: 19
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+
+		-
+			message: '#^Variable \$pflex might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+
+		-
+			message: '#^Variable \$remote_stamp_raw might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+
+		-
+			message: '#^Variable \$remote_tds might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+
+		-
+			message: '#^Variable \$_GET in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$_POST in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$_REQUEST in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$alert_log might not be defined\.$#'
+			identifier: variable.undefined
+			count: 19
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$alert_stats might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$alert_view in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$atype might not be defined\.$#'
+			identifier: variable.undefined
+			count: 4
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$bg might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$clists might not be defined\.$#'
+			identifier: variable.undefined
+			count: 6
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$colspan might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$column_title might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$dnsblfilterlimitentries might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$dnsfilterlimitentries might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$dstport might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$entry in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$extra_txt might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$fcounter might not be defined\.$#'
+			identifier: variable.undefined
+			count: 4
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$filter_unified in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$folder might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$ipfilterlimitentries might not be defined\.$#'
+			identifier: variable.undefined
+			count: 4
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$max_table_entries might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$p_query_port might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfb_found might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbdenycnt might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbdnscnt might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbdnsreplycnt might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbentries might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbfilterlimit might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbmatchcnt might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbpermitcnt might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbreplyrec in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbreplytypes in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbunicnt might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$pfbupdate might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$rtype might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$savemsg might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$table might not be defined\.$#'
+			identifier: variable.undefined
+			count: 9
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$title_hostname might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$v4suppression_dat might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$w_line might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
+			message: '#^Variable \$blacklist_types in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+
+		-
+			message: '#^Variable \$cat might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+
+		-
+			message: '#^Variable \$savemsg might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+
+		-
+			message: '#^Variable \$_GET in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
+			message: '#^Variable \$_POST in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
+			message: '#^Variable \$_REQUEST in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
+			message: '#^Variable \$conf_type might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
+			message: '#^Variable \$maxmind_verify might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
+			message: '#^Variable \$r_id might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
+			message: '#^Variable \$rowid in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
+			message: '#^Variable \$variable might not be defined\.$#'
+			identifier: variable.undefined
+			count: 6
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
 			message: '#^Function phpsession_begin not found\.$#'
 			identifier: function.notFound
 			count: 2
@@ -157,10 +793,328 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
 
 		-
+			message: '#^Variable \$_GET in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$_POST in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$a_aliasname might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$a_cron might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$a_description might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$a_header might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$a_url might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$active might not be defined\.$#'
+			identifier: variable.undefined
+			count: 5
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$conf_type might not be defined\.$#'
+			identifier: variable.undefined
+			count: 44
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$customlist in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$final might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$geoip_isos might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$options_aliasaddr_in might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$options_aliasaddr_out might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$pfbarr might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$pre might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$suffix might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$type might not be defined\.$#'
+			identifier: variable.undefined
+			count: 18
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
+			message: '#^Variable \$customlist in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+
+		-
+			message: '#^Variable \$savemsg might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+
+		-
 			message: '#^Deprecated in PHP 8\.0\: Required parameter \$a_key follows optional parameter \$alt_register\.$#'
 			identifier: parameter.requiredAfterOptional
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+
+		-
+			message: '#^Variable \$alt_feeds might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+
+		-
+			message: '#^Variable \$p_tr_style might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+
+		-
+			message: '#^Variable \$p_type might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_dnsbl_parse_err might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_dnslog might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_dnsreplylog might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_errlog might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_extraslog might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_ip_blocklog might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_ip_matchlog might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_ip_permitlog might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_log might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$options_log_max_unilog might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
+
+		-
+			message: '#^Variable \$v4suppression in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
+
+		-
+			message: '#^Variable \$_REQUEST in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
+
+		-
+			message: '#^Variable \$data in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
+
+		-
+			message: '#^Variable \$pfb might not be defined\.$#'
+			identifier: variable.undefined
+			count: 17
+			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+
+		-
+			message: '#^Variable \$input_errors might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_sync.php
+
+		-
+			message: '#^Variable \$_REQUEST in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_threats.php
+
+		-
+			message: '#^Variable \$_GET in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
+
+		-
+			message: '#^Variable \$cronreal might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
+
+		-
+			message: '#^Variable \$nextcron might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
+
+		-
+			message: '#^Variable \$pfb might not be defined\.$#'
+			identifier: variable.undefined
+			count: 21
+			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
+
+		-
+			message: '#^Variable \$ptype might not be defined\.$#'
+			identifier: variable.undefined
+			count: 8
+			path: src/usr/local/www/pfblockerng/www/dnsbl_default.php
+
+		-
+			message: '#^Variable \$ts might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/www/dnsbl_default.php
+
+		-
+			message: '#^Variable \$data in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/www/pfblockerng/www/index.php
 
 		-
 			message: '#^Deprecated in PHP 8\.0\: Required parameter \$pfb_table follows optional parameter \$mode\.$#'
@@ -171,5 +1125,47 @@ parameters:
 		-
 			message: '#^Function pfSense_get_pf_rules not found\.$#'
 			identifier: function.notFound
+			count: 1
+			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+
+		-
+			message: '#^Variable \$dnsbl_last_clear might not be defined\.$#'
+			identifier: variable.undefined
+			count: 4
+			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+
+		-
+			message: '#^Variable \$ip_last_clear might not be defined\.$#'
+			identifier: variable.undefined
+			count: 6
+			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+
+		-
+			message: '#^Variable \$key might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+
+		-
+			message: '#^Variable \$p_alias might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+
+		-
+			message: '#^Variable \$temp_array might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+
+		-
+			message: '#^Variable \$type might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+
+		-
+			message: '#^Variable \$widgetname might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
 			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,14 @@ includes:
 parameters:
     paths:
         - src
-    level: 0
+    # Climbing incrementally above level 0 (issue #88): each level statically
+    # catches more of the class the live Tier-A/UI run catches at runtime
+    # (undefined variables/constants, bad arg counts, return shapes). The
+    # phpstan-baseline.neon entries are the pre-existing legacy debt at the
+    # current level — an acknowledged blind-spot list to BURN DOWN, not grow.
+    # Next steps: stub the remaining function/class.notFound baseline entries,
+    # burn down variable.undefined in the www page controllers, then level 2.
+    level: 1
     fileExtensions:
         - php
         - inc

--- a/stubs/pfsense/globals.php
+++ b/stubs/pfsense/globals.php
@@ -49,3 +49,20 @@ $config = [];
  */
 global $priv_list;
 $priv_list = [];
+
+/*
+ * pfSense-provided constants used by our WebUI pages. Values resolved from
+ * upstream pfSense source (faithful, so higher PHPStan levels infer the right
+ * types). Symbol existence is what PHPStan needs; the values match upstream.
+ */
+
+// Collapsible Form_Section flags (etc/inc/globals.inc).
+define('COLLAPSIBLE', 0x08);
+define('SEC_CLOSED', 0x04);
+define('SEC_OPEN', 0x00);
+
+// Placeholder shown in the WebUI for an already-saved password (etc/inc/globals.inc).
+define('DMYPWD', '********');
+
+// "special network" token for Virtual IPs in address-selector logic (etc/inc/util.inc).
+define('SPECIALNET_VIPS', 12);


### PR DESCRIPTION
Part of #88 — the "Raise PHPStan above `level: 0`" task (the biggest lever for making the fast PHP tier predict the live Tier-A/UI runs). This is a partial, incremental step: **level 0 → 1**.

## What level 1 buys

PHPStan now statically catches **undefined variables and undefined constants** across all our PHP — the exact class Tier A catches at runtime on a real page, now caught in seconds. Any *new* PHP change that references an undefined variable/constant fails CI.

## Changes

- **Stubbed the pfSense-provided constants** our WebUI pages use, in the hand-maintained `stubs/pfsense/globals.php`, with values resolved from upstream pfSense source (faithful, so higher levels infer the right types):
  | Constant | Value | Source |
  | -------- | ----- | ------ |
  | `COLLAPSIBLE` | `0x08` | `etc/inc/globals.inc` |
  | `SEC_CLOSED` | `0x04` | `etc/inc/globals.inc` |
  | `SEC_OPEN` | `0x00` | `etc/inc/globals.inc` |
  | `DMYPWD` | `'********'` | `etc/inc/globals.inc` |
  | `SPECIALNET_VIPS` | `12` | `etc/inc/util.inc` |

  This **fixes** 36 `constant.notFound` errors (real symbol-existence fixes) rather than baselining them.
- **`phpstan.neon`:** `level: 0` → `1`, with a comment documenting the climb + burn-down intent.
- **`phpstan-baseline.neon`:** regenerated. The remaining **487** level-1 errors are all **pre-existing legacy** `variable.undefined` / `isset.variable` / `empty.variable` in the `www/` page controllers and `pfblockerng.inc` — the acknowledged blind-spot list to burn down over time (#88's framing). None are new; the ratchet locks in the gain.

## Tradeoff (deliberate)

The baseline grows 29 → 195 message-blocks (487 errors). That's the standard "ratchet a level, baseline existing debt, block new debt" move — the alternative (hand-fixing 400+ undefined-variable sites in shipped pages) is a large, behavior-sensitive effort, not a safe single increment. The legacy debt is now *visible and tracked* instead of silently uncaught.

## Next increments (not in this PR)

1. Burn down the 5 remaining `function.notFound` / `class.notFound` baseline entries by stubbing them (`phpsession_begin/end`, `pfSense_get_pf_rules`, `Net_IPv6`, `pfsense_xmlrpc_client`) — `pfsense_xmlrpc_client` needs its two called methods stubbed to avoid `method.notFound`, so it wants a careful pass.
2. Burn down `variable.undefined` in the page controllers (chip away per file).
3. Climb to level 2.

## Verification

PHPStan **green at level 1**; PHPUnit **127 tests** pass; `php -l` clean; full Python suite (1019) + linters green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated static analysis baseline: expanded ignore entries and raised baseline level to address many reported warnings.
  * Added development stubs declaring several WebUI/global constants for analysis tools.
  * No user-facing or runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->