### PR TITLE
pfblockerng_ip: define $input_errors on every path (#88 burn-down)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1027,12 +1027,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
 
 		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
-
-		-
 			message: '#^Variable \$v4suppression in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -77,13 +77,14 @@ $options_pass_order		= [	'order_0' => '| pfB_Pass/Match/Block/Reject | All other
 
 $options_autorule_suffix = [ 'autorule' => 'auto rule', 'standard' => 'Null (no suffix)', 'ar' => 'AR' ];
 
+// $input_errors is read unconditionally in the render section below, so it must be
+// defined on every request path (incl. a POST without 'save'). Initialise it once.
+$input_errors = array();
+
 // Validate input fields and save
 if ($_POST) {
 	if (isset($_POST['save'])) {
 
-		if (isset($input_errors)) {
-			unset($input_errors);
-		}
 		if (isset($savemsg)) {
 			unset($savemsg);
 		}
@@ -215,9 +216,6 @@ if ($_POST) {
 			$pconfig = $_POST;
 		}
 	}
-}
-else {
-	$input_errors = '';
 }
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('IP'));


### PR DESCRIPTION
Part of #88 — first PHPStan baseline **burn-down** on a Tier-A-rendered page, building on the level-1 ratchet from #92. Converts a baselined blind spot into real fast-tier coverage.

## What level 1 found here (a genuine latent bug, not cosmetic)

`pfblockerng_ip.php` reads `$input_errors` unconditionally in the render section:

```php
if ($input_errors) {
    print_input_errors($input_errors);
}
```

But it was only *set* inside `isset($_POST['save'])` and in the GET `else`. A **POST without `save`** falls through both → `$input_errors` is undefined at that read → a PHP 8 **"Undefined variable" warning** in `php_error.log` — the exact diagnostic shape ADR-14 Tier A watches for. This is precisely the "cheap tier could have caught it in seconds" case #88 is about.

## Fix (behaviour-identical)

- Initialise `$input_errors = array();` **once** at the top, before the `$_POST` branch — so it's defined on every path (POST+save, POST-without-save, GET).
- Drop the two now-redundant assignments: the save-block reset and the GET `else { $input_errors = ''; }`.

On every path the observable behaviour is unchanged (`''` and `array()` are both falsy at the `if ($input_errors)` check; errors still print only after a failed save) — the only difference is the removed undefined-variable warning.

## Burn-down

PHPStan baseline **487 → 484** (the 3-site `$input_errors` block removed). The one remaining `pfblockerng_ip.php` entry is a cosmetic always-true `empty($v4suppression)` on an `explode()` result (no predictive value) — left for a later cleanup pass.

## Verification

PHPStan **green at level 1**; `php -l` clean; PHPUnit 127; full Python suite (1019) + linters green.

Next pages (smallest-high-render first): `pfblockerng_general.php`, `pfblockerng_dnsbl.php`, then the larger `_alerts.php` / `_category_edit.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code analysis tooling configuration across multiple modules
  * Improved form input handling robustness to ensure consistent behavior across all request types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->