### PR TITLE
pfblockerng_general/dnsbl: define $input_errors + $savemsg on every path (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -913,18 +913,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
 
 		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-
-		-
-			message: '#^Variable \$savemsg might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-
-		-
 			message: '#^Deprecated in PHP 8\.0\: Required parameter \$a_key follows optional parameter \$alt_register\.$#'
 			identifier: parameter.requiredAfterOptional
 			count: 1
@@ -953,12 +941,6 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
 
 		-
 			message: '#^Variable \$options_log_max_dnsbl_parse_err might not be defined\.$#'

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -324,13 +324,14 @@ $options_aliasaddr_in		= $options_aliasaddr_out	= explode(',', $networks_list);
 $options_autoproto_in		= $options_autoproto_out	= get_ipprotocols();
 $options_agateway_in		= $options_agateway_out		= pfb_get_gateways();
 
+// $input_errors and $savemsg are read unconditionally in the render section below,
+// so they must be defined on every request path. Initialise them once.
+$input_errors = array();
+$savemsg = '';
+
 // Validate input fields and save
 if ($_POST) {
 	if (isset($_POST['save'])) {
-
-		if (isset($input_errors)) {
-			unset($input_errors);
-		}
 
 		// Validate Select field options
 		$select_options = array(						'dnsbl_interface'	=> 'lo0',

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -83,6 +83,10 @@ $options_log_types	= [	'100' => '100', '1000' => '1,000', '2000' => '2,000', '40
 				'nolimit' => 'No Limit - Not recommended' ];
 
 
+// $input_errors is read unconditionally in the render section below, so it must be
+// defined on every request path (incl. a POST without 'save'). Initialise it once.
+$input_errors = array();
+
 // Validate input fields and save
 if ($_POST) {
 	if (isset($_POST['save'])) {


### PR DESCRIPTION
Part of #88 — second PHPStan baseline burn-down batch (follows #94), on the next two Tier-A-rendered settings pages.

## Same bug class as #94 (undefined `$input_errors`/`$savemsg` on some request paths)

Both pages read their error/message variable unconditionally in the render section but set it only on some paths — so a POST-without-`save` (or, for `$savemsg`, any save) hit an undefined variable → a PHP 8 warning in `php_error.log`, the diagnostic shape ADR-14 Tier A watches.

- **`pfblockerng_general.php`** — `$input_errors` was *never* initialised (no reset, no GET `else`). Added one top-level `$input_errors = array();`.
- **`pfblockerng_dnsbl.php`** — same top-level init; **plus** `$savemsg`, read at the save-path redirect (`if ($savemsg)`) but never set there (only in the render section from `$_REQUEST`) → always undefined. Initialised `$savemsg = '';` (preserves the existing always-plain-redirect behaviour). Dropped the now-redundant `unset($input_errors)`.

Behaviour is identical on every path; only the undefined-variable warnings go away.

## Burn-down

PHPStan baseline **484 → 479** (5 errors across 3 message-blocks).

## Left baselined (deliberately — not undefined-variable bugs)

- `pfblockerng_general.php` ×10 `$options_log_max_*`: PHPStan over-approximates the dynamic `${"options_$s_option"}` access — the `strpos('log_max_')` guard already routes those keys to `$options_log_types`, so the flagged names are never actually reached. A dynamic-variable refactor (replace with an explicit map), not a bug — its own follow-up.
- `pfblockerng_dnsbl.php` ×1 cosmetic always-true `empty($customlist)`.

## Verification

PHPStan green at level 1; `php -l` clean on both; PHPUnit 127; full Python suite (1019) + linters green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential undefined variable errors in pfBlockerNG pages that could occur in certain request scenarios, improving application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->