### PR TITLE
pfblockerng_hooks/safesearch/sync: define $input_errors on every path (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1003,12 +1003,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
 
 		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
-
-		-
 			message: '#^Variable \$v4suppression in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
@@ -1031,18 +1025,6 @@ parameters:
 			identifier: variable.undefined
 			count: 17
 			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
-
-		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
-
-		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_sync.php
 
 		-
 			message: '#^Variable \$_REQUEST in isset\(\) always exists and is not nullable\.$#'

--- a/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
@@ -42,13 +42,13 @@ $pfb['gconfig'] = config_get_path('installedpackages/pfblockerng/config/0', []);
 // Select field options
 $options_when = [ 'pre' => 'Pre', 'post' => 'Post' ];
 
+// $input_errors is read unconditionally in the render section below, so it must be
+// defined on every request path. Initialise it once.
+$input_errors = array();
+
 // Validate input fields and save
 if ($_POST) {
 	if (isset($_POST['save'])) {
-
-		if (isset($input_errors)) {
-			unset($input_errors);
-		}
 
 		// Parse the repeatable 'rowhelper' hook fields (field-<rowid>) and save
 		// new values into the hooks list, validating each as it is collected.

--- a/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
@@ -182,11 +182,11 @@ $options_safesearch_doh_list	= [
 					'zero.dns0.eu' => 'European public DNS DoH/DoT/DoQ [zero.dns0.eu]'
 					];
 
-if (isset($_POST['save'])) {
+// $input_errors is read unconditionally in the render section below, so it must be
+// defined on every request path. Initialise it once.
+$input_errors = array();
 
-	if (isset($input_errors)) {
-		unset($input_errors);
-	}
+if (isset($_POST['save'])) {
 
 	if (($_POST['safesearch_doh'] == 'Enable') && empty($_POST['safesearch_doh_list'])) {
 		$input_errors[] = 'Warning: With DoH/DoT Blocking enabled, you must select at least one List';

--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -37,13 +37,13 @@ $pconfig['syncinterfaces']	= $pfb['sconfig']['syncinterfaces']	?: '';
 // Select field options
 $options_varsynconchanges	= [ 'disabled' => 'Do not sync this package configuration', 'auto' => 'Sync to configured system backup server', 'manual' => 'Sync to host(s) defined below' ];
 
+// $input_errors is read unconditionally in the render section below, so it must be
+// defined on every request path. Initialise it once.
+$input_errors = array();
+
 // Validate input fields and save
 if ($_POST) {
 	if (isset($_POST['save'])) {
-
-		if (isset($input_errors)) {
-			unset($input_errors);
-		}
 
 		// Validate varsynctimeout. Default 150 and max at 5000
 		$_POST['varsynctimeout'] = min(5000, pfb_filter($_POST['varsynctimeout'], PFB_FILTER_NUM, 'Sync', 150));


### PR DESCRIPTION
Part of #88 — third PHPStan baseline burn-down batch (follows #94, #95). Three small Tier-A-rendered pages that were **100%** the proven `$input_errors` pattern, so they drop **entirely** out of the baseline.

## Same bug class as #94/#95

`pfblockerng_hooks.php`, `pfblockerng_safesearch.php`, `pfblockerng_sync.php` each read `$input_errors` unconditionally in the render section (`if ($input_errors)`) but set it only inside the save validations — so a POST-without-`save` / GET path hit an undefined variable (PHP 8 warning in `php_error.log`, the Tier-A signal).

Fix per page: one top-level `$input_errors = array();`, drop the redundant `unset($input_errors)`. Behaviour identical on every path.

## Burn-down

Baseline **479 → 473**; all three pages removed from `phpstan-baseline.neon` completely.

## Aside (not touched)

`php -l` emits two pre-existing `"continue" targeting switch is equivalent to "break"` warnings in `pfblockerng_sync.php` (L97/L117) — a genuine latent gotcha, but pre-existing, behaviour-sensitive, and unrelated to this change (and `php -l` still passes). Flagging it for a separate look, not fixing it here.

## Verification

PHPStan green at level 1; `php -l` clean (no syntax errors); PHPUnit 127; full Python suite (1019) + linters green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation error handling in configuration pages to reliably display error messages when configuration issues are detected across different request types.

* **Refactor**
  * Improved variable initialization to ensure consistent state across all request paths and prevent undefined variable errors during error display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->