### PR TITLE
pfblockerng_feeds: define $input_errors on every path (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -925,12 +925,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
 
 		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
 			message: '#^Variable \$p_tr_style might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -63,12 +63,12 @@ if (is_array($fconfig)) {
 	}
 }
 
+// $input_errors is read unconditionally in the render section below, so it must be
+// defined on every request path. Initialise it once.
+$input_errors = array();
+
 if ($_POST) {
 	if (isset($_POST['save'])) {
-
-		if (isset($input_errors)) {
-			unset($input_errors);
-		}
 
 		$config_mod = FALSE;
 		foreach ($pfb['feeds_list'] as $type => $data) {


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down, same proven `$input_errors` pattern as #94/#95/#96.

`pfblockerng_feeds.php` read `$input_errors` unconditionally at the render `if ($input_errors)` but set it only inside the save validations → POST-without-`save` / GET hit an undefined variable (PHP 8 warning in `php_error.log`). Added one top-level `$input_errors = array();`, dropped the redundant `unset($input_errors)`. Behaviour identical.

Baseline reduced by the two `$input_errors` entries. `feeds.php` keeps three unrelated residual entries (`$p_tr_style`/`$alt_feeds`/`$p_type`) for a later pass.

**Deferred deliberately** (not the simple pattern — need careful handling):
- `pfblockerng_blacklist.php` uses `isset($input_errors)` as **control flow** (`if ($config_mod && !isset($input_errors))`), so a top-level init would flip that branch — behaviour-sensitive.
- `pfblockerng_category.php` is AJAX-style (`print(json_encode($input_errors))`, no standard render) — different shape.

PHPStan green at level 1; `php -l` clean; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable initialization in error handling to ensure consistent and reliable behavior across all request paths, enhancing application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->