### PR TITLE
pfblockerng_log/update: declare global $pfb at file scope (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1015,12 +1015,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
 
 		-
-			message: '#^Variable \$pfb might not be defined\.$#'
-			identifier: variable.undefined
-			count: 17
-			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
-
-		-
 			message: '#^Variable \$_REQUEST in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
@@ -1042,12 +1036,6 @@ parameters:
 			message: '#^Variable \$nextcron might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
-
-		-
-			message: '#^Variable \$pfb might not be defined\.$#'
-			identifier: variable.undefined
-			count: 21
 			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
 
 		-

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -38,6 +38,7 @@ require_once('guiconfig.inc');
 require_once('globals.inc');
 require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 
+global $pfb;
 pfb_global();
 
 // Get log files from directory

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -38,6 +38,7 @@ require_once('functions.inc');
 require_once('util.inc');
 require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 
+global $pfb;
 pfb_global();
 
 // Collect pfBlockerNG log file and post live output to terminal window.


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down. **38 errors in one change** (the biggest single burn-down so far), and a real consistency fix.

## Root cause

`pfblockerng_log.php` and `pfblockerng_update.php` use `$pfb` (the package-wide config/path global, populated by `pfblockerng.inc`'s top-level init + `pfb_global()`) **without** declaring `global $pfb;` at file scope. Every other page does — e.g. `pfblockerng_general.php:27` has `global $pfb;` right after the inc require. PHPStan can't track a variable across the `require_once` / global-side-effect boundary, so it flagged all 38 `$pfb` uses on these two pages as possibly-undefined (false positives — `$pfb` is genuinely populated at runtime).

## Fix

Add `global $pfb;` after the `require_once('…/pfblockerng.inc')`, before `pfb_global()` — **identical to the existing convention in `pfblockerng_general.php`**. It's a runtime no-op at file scope (already global scope) but: (a) marks `$pfb` defined for PHPStan, and (b) makes these two pages consistent with the rest of the package.

Baseline reduced by 38 entries (across the two `$pfb` blocks). Confirmed the change introduces **no** new errors; the only residual entries on these pages are unrelated pre-existing ones (`$cronreal`/`$nextcron` and cosmetic `isset($_GET/$_REQUEST/$data)`), left baselined.

## Note

This is a different mechanism from the `$input_errors` burn-downs (it's a missing global declaration, not an init-on-every-path). I first tried declaring `$pfb` in the `globals.php` stub, but `scanDirectories` only discovers functions/classes/constants — not global variables — so that does nothing for PHPStan; the in-file `global $pfb;` is the recognized fix.

PHPStan green at level 1; `php -l` clean on both; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved variable declaration issues in core modules by properly declaring global variables, removing related code quality suppressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->