### PR TITLE
pfblockerng_category/category_edit: default $conf_type on every path (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -745,12 +745,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
 
 		-
-			message: '#^Variable \$conf_type might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
-
-		-
 			message: '#^Variable \$input_errors might not be defined\.$#'
 			identifier: variable.undefined
 			count: 3
@@ -838,12 +832,6 @@ parameters:
 			message: '#^Variable \$active might not be defined\.$#'
 			identifier: variable.undefined
 			count: 5
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$conf_type might not be defined\.$#'
-			identifier: variable.undefined
-			count: 44
 			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
 
 		-

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -90,6 +90,10 @@ if (isset($_POST)) {
 // Set 'active' GUI Tabs
 $active = array('ip' => FALSE, 'ipv4' => FALSE, 'ipv6' => FALSE, 'dnsbl' => FALSE, 'geoip' => FALSE);
 
+// Default so $conf_type is defined on every path. The GeoIP case below doesn't set it;
+// it is only ever used under the `$type != 'GeoIP'` guard, where the switch always sets it.
+$conf_type = '';
+
 switch ($gtype) {
 	case 'ipv4':
 		$type		= 'IPv4';

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -150,6 +150,10 @@ if (isset($_POST)) {
 }
 
 // Define variables for page
+// Default so $conf_type is defined even when $gtype is empty (the switch below, which
+// sets it for every type, runs only inside this guard). Behaviour-preserving: an
+// undefined $conf_type already interpolated to '' in the config paths.
+$conf_type = '';
 if (!empty($gtype)) {
 
 	// Set 'active' GUI Tabs


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down. **45 errors** across the two category pages, the largest single variable pattern remaining.

## False positive, real latent warning

`pfblockerng_category.php` and `pfblockerng_category_edit.php` set `$conf_type` (the `installedpackages/<type>/config` path segment) inside a `switch ($gtype)` / `if (!empty($gtype))` block, then use it widely afterward. PHPStan flagged all 45 uses as possibly-undefined because it can't correlate the guards (`$type != 'GeoIP'`, `!empty($gtype)`) with the branches that set it. At runtime an undefined `$conf_type` already interpolated to `''` in the config paths — so these were PHP 8 undefined-variable warnings on the GeoIP / empty-`$gtype` edges.

## Fix

A file-scope `$conf_type = '';` default before each conditional. Behaviour-identical (the switch overwrites it for every real type; the only paths that leave it `''` are exactly the ones that already treated an undefined `$conf_type` as `''`), and it removes the warnings.

Baseline reduced by 45. No new errors introduced.

PHPStan green at level 1; `php -l` clean on both; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed potential undefined variable issues in configuration handling modules, improving code reliability and eliminating quality warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->