### PR TITLE
pfblockerng: default loop-carried $country/$isocode in GeoIP scan (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -427,21 +427,9 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
-			message: '#^Variable \$country might not be defined\.$#'
-			identifier: variable.undefined
-			count: 8
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
 			message: '#^Variable \$et_options might not be defined\.$#'
 			identifier: variable.undefined
 			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Variable \$isocode might not be defined\.$#'
-			identifier: variable.undefined
-			count: 19
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1384,6 +1384,11 @@ function pfblockerng_get_countries() {
 			$pfb['complete']	= FALSE;
 			$linenum		= 1;
 			$total			= 0;
+			// $country/$isocode are carried across lines and read in the
+			// `$pfb['complete']` flush block below; default them so they are
+			// always defined (the flush only runs after a header has set them).
+			$country		= '';
+			$isocode		= '';
 
 			if (($handle = @fopen("{$file}", 'r')) !== FALSE) {
 				while (($line = @fgets($handle)) !== FALSE) {


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down on `pfblockerng.php` (the most-rendered Tier-A page). −27 errors.

## Pattern

In the GeoIP country-list scan, `$country` and `$isocode` are **loop-carried**: set when a `# Country:` / `# ISO Code:` header line is seen, then read in the `if ($pfb['complete'])` flush block when the *next* header arrives. PHPStan flagged all 27 reads as possibly-undefined because it can't prove a header set them before the flush runs (and on the very first header / a fresh file, they'd be undefined → PHP 8 warning).

## Fix

Default `$country = ''; $isocode = '';` alongside the existing `$total = 0;` reset (per `(file, type)` iteration, before the line loop). Behaviour-preserving: the flush block only runs once `$pfb['complete']` is true, which only happens after a header has set both — so the defaults are always overwritten before any flush read; they just guarantee the variables are defined.

Baseline −27 (`$isocode` ×19, `$country` ×8). The page's remaining residuals (`$et_options`, the dynamic `${'coptions'.$type}` variable-variables) are a different class, left baselined.

PHPStan green at level 1; `php -l` clean; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed undefined variable issues in the country page builder to ensure proper processing of continent data.

* **Chores**
  * Updated static analysis configuration baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->