### PR TITLE
pfblockerng_category_edit: default per-type vars ($type/$active/$suffix) (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -817,12 +817,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
 
 		-
-			message: '#^Variable \$active might not be defined\.$#'
-			identifier: variable.undefined
-			count: 5
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
 			message: '#^Variable \$customlist in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
@@ -868,18 +862,6 @@ parameters:
 			message: '#^Variable \$pre might not be defined\.$#'
 			identifier: variable.undefined
 			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$suffix might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$type might not be defined\.$#'
-			identifier: variable.undefined
-			count: 18
 			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
 
 		-

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -150,14 +150,14 @@ if (isset($_POST)) {
 }
 
 // Define variables for page
-// Default so $conf_type is defined even when $gtype is empty (the switch below, which
-// sets it for every type, runs only inside this guard). Behaviour-preserving: an
-// undefined $conf_type already interpolated to '' in the config paths.
-$conf_type = '';
+// Default the per-type variables so they are defined even when $gtype is empty (the
+// switch below, which sets them for every type, runs only inside this guard).
+// Behaviour-preserving: an undefined value already read as '' / the all-FALSE tab set.
+$conf_type	= '';
+$type		= '';
+$suffix		= '';
+$active		= array('ip' => FALSE, 'ipv4' => FALSE, 'ipv6' => FALSE, 'dnsbl' => FALSE, 'feeds' => FALSE);
 if (!empty($gtype)) {
-
-	// Set 'active' GUI Tabs
-	$active = array('ip' => FALSE, 'ipv4' => FALSE, 'ipv6' => FALSE, 'dnsbl' => FALSE, 'feeds' => FALSE);
 
 	switch ($gtype) {
 		case 'ipv4':


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down. Follow-up to #100 on the same file: the remaining per-type variables. −25 errors.

`pfblockerng_category_edit.php` sets `$type`, `$conf_type`, `$suffix`, `$active` inside `if (!empty($gtype)) { switch ($gtype) … }`, then reads them throughout the page. When `$gtype` is empty the block is skipped and all of them are undefined — PHPStan flagged 25 such reads (#100 already handled `$conf_type`).

## Fix

Generalize the `$conf_type = '';` default from #100 into a small default block covering all the per-type vars (`$type`/`$suffix`/`$active`) before the `if`, and hoist `$active`'s all-FALSE default out of the guard. Behaviour-preserving (these defaults are exactly the values an undefined read already produced — `''` and the all-FALSE tab set); the switch overwrites them for every real `$gtype`.

Baseline −25. The page's remaining residuals (`$a_*` edit-fields, `$input_errors`, `$options_aliasaddr_*`, etc.) are a different, heterogeneous class — left baselined for separate passes.

PHPStan green at level 1; `php -l` clean; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved undefined variable errors in the category editing interface. The system now properly initializes all required variables before use, ensuring they are available throughout the configuration workflow. This prevents unexpected errors when managing category settings, improving overall system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->