### PR TITLE
pfblockerng_alerts: default $alert_log before the view handler (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -469,12 +469,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
-			message: '#^Variable \$alert_log might not be defined\.$#'
-			identifier: variable.undefined
-			count: 19
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
 			message: '#^Variable \$alert_stats might not be defined\.$#'
 			identifier: variable.undefined
 			count: 2

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -95,6 +95,11 @@ foreach (array(81,82,83,84,85,86,87,88,89) as $field_2) {
 	$filterfieldsarray[1][$field_2] = '';
 }
 
+// $alert_log is set by the view handler below but read in the stats section much later;
+// default it so it is defined when that section runs without a view request. file_exists('')
+// is false, so the stats block is skipped exactly as it was when $alert_log was undefined.
+$alert_log = '';
+
 if (isset($_GET) && isset($_GET['view']) || isset($_REQUEST) && isset($_REQUEST['alert_view'])) {
 	switch($_GET['view'] != '' ? $_GET['view'] : $_REQUEST['alert_view']) {
 		case 'dnsbl_stat':


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down. `pfblockerng_alerts.php`, −19.

`$alert_log` is set inside the `if (isset($_GET['view']) …)` view handler (a switch with cases per log type plus an `''` default), but read much later in the stats `foreach` (`if (file_exists($alert_log))` + the `exec` chain). When the stats section runs without a view request, `$alert_log` is undefined → PHP 8 warning.

Fix: a top-level `$alert_log = '';` before the view handler. Behaviour-identical — `file_exists('')` is false, so the stats block is skipped exactly as it was when the variable was undefined; the handler still overwrites it for a real view.

Baseline −19. The page's other residuals (`$table`, `$clists`, `$atype`) are separate and left baselined.

PHPStan green at level 1; `php -l` clean; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where alert log statistics processing could be affected by an undefined variable, ensuring the system handles alerts consistently and reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->