### PR TITLE
pfblockerng widget: default last-clear timestamps (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1021,18 +1021,6 @@ parameters:
 			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
 
 		-
-			message: '#^Variable \$dnsbl_last_clear might not be defined\.$#'
-			identifier: variable.undefined
-			count: 4
-			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
-
-		-
-			message: '#^Variable \$ip_last_clear might not be defined\.$#'
-			identifier: variable.undefined
-			count: 6
-			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
-
-		-
 			message: '#^Variable \$key might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -759,6 +759,11 @@ function pfBlockerNG_get_header($mode='') {
 		unset($pfb_table['counts']);
 	}
 
+	// Default the last-clear timestamps so they are defined when the stats below print
+	// them even if the lookup finds no row (or the component is off). Behaviour-preserving.
+	$ip_last_clear		= '';
+	$dnsbl_last_clear	= '';
+
 	// Collect Last packet clear timestamps
 	if ($pfb['enable'] == 'on') {
 		$db_handle = pfb_open_sqlite(6, 'Last Clear Stats');


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down. pfBlockerNG dashboard widget, −10.

`$ip_last_clear` / `$dnsbl_last_clear` are set only inside `if ($pfb['enable'] == 'on') { … while($res…) { if ($res['lastipclear'] !== NULL) { … } } }` (the Last-Clear sqlite lookup), but read unconditionally in the widget's title `print` lines below. When the component is off, the DB handle is null, or the lookup returns no row, they were undefined → PHP 8 warnings.

Fix: default both to `''` before the lookup block. Behaviour-identical — the prints already showed an empty "Last clear: " when the variable was undefined; now they show the same empty string without the warning. The lookup still overwrites them when a row exists.

Baseline −10. The widget's other residuals (`$temp_array`, `$p_alias`, `$widgetname`, …) are separate and left baselined; `www/dnsbl_default.php`'s `$ptype` is an externally-injected template variable (never assigned in-file) — deferred, not a safe in-file fix.

PHPStan green at level 1; `php -l` clean; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable initialization issues in the widget to ensure proper operation and prevent undefined variable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->