### PR TITLE
ci: map pfsense_ce_version to FreeBSD/PHP in build-image (reject unknown)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -88,9 +88,52 @@ permissions:
   packages: write
 
 jobs:
+  # ── 0. Map the target CE version to its FreeBSD base + PHP runtime ────────
+  # The branch .pkg MUST be built against the FreeBSD ABI + PHP runtime of the
+  # target pfSense CE version (else `pkg add` ABI-mismatches / the wrong PHP is
+  # pinned). This job is the single source of truth for that mapping: it derives
+  # freebsd_version + php_version from inputs.pfsense_ce_version and HARD-FAILS on
+  # any unmapped version, so the build-pkg job can never silently inherit defaults
+  # that match only CE 2.8.1 (issue #22). It runs first and is cheap (no KVM), so
+  # an unknown version fails in seconds — before the 90-min publish job starts.
+  resolve-version:
+    name: Resolve FreeBSD/PHP for CE ${{ inputs.pfsense_ce_version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      freebsd_version: ${{ steps.map.outputs.freebsd_version }}
+      php_version: ${{ steps.map.outputs.php_version }}
+    steps:
+      - name: Map pfsense_ce_version -> (freebsd_version, php_version)
+        id: map
+        env:
+          CE_VERSION: ${{ inputs.pfsense_ce_version }}
+        run: |
+          set -eu
+          # Adding a new supported CE version REQUIRES a new case arm here.
+          # Keep in sync with docs/misc/pfSense_versions.md (the per-version base
+          # facts: FreeBSD base + PHP). 2.8.0 and 2.8.1 share the same toolchain,
+          # so the whole 2.8.x line maps to one base.
+          case "$CE_VERSION" in
+            2.8.*)
+              FREEBSD_VERSION="15.0-RELEASE"
+              PHP_VERSION="8.3"
+              ;;
+            *)
+              echo "::error::no FreeBSD/PHP mapping for pfSense CE '${CE_VERSION}'. Add a case arm in build-image.yml (resolve-version job) and update docs/misc/pfSense_versions.md before publishing this version."
+              exit 1
+              ;;
+          esac
+          {
+            echo "freebsd_version=${FREEBSD_VERSION}"
+            echo "php_version=${PHP_VERSION}"
+          } >> "$GITHUB_OUTPUT"
+          echo "CE ${CE_VERSION} -> FreeBSD ${FREEBSD_VERSION}, PHP ${PHP_VERSION}"
+
   # ── 1. Publish the version-tagged qcow2 to private GHCR ──────────────────
   publish-image:
     name: Publish pfSense CE ${{ inputs.pfsense_ce_version }} to GHCR
+    needs: resolve-version
     runs-on: ubuntu-latest
     timeout-minutes: 90
     outputs:
@@ -203,11 +246,14 @@ jobs:
   # exactly as the smoke spike does, so it needs the .pkg.
   build-pkg:
     name: Build branch .pkg (FreeBSD)
-    needs: publish-image
+    needs: [resolve-version, publish-image]
     uses: ./.github/workflows/build-pkg.yml
     with:
       channel: devel
-    # freebsd_version defaults to 15.0-RELEASE (matches pfSense CE 2.8.1)
+      # Pass the CE-version-derived base EXPLICITLY (issue #22) — never rely on
+      # build-pkg.yml's defaults, which match CE 2.8.1 only.
+      freebsd_version: ${{ needs.resolve-version.outputs.freebsd_version }}
+      php_version: ${{ needs.resolve-version.outputs.php_version }}
 
   # ── 3. Verify the published image passes the Phase-1 round-trip ──────────
   verify-image:

--- a/docs/misc/pfSense_versions.md
+++ b/docs/misc/pfSense_versions.md
@@ -25,6 +25,13 @@ Observed on a CE **2.8.1** box; 2.8.0 shares the same base toolchain.
 | pkg | 1.21.x |
 | Unbound | 1.24.x |
 
+> **The FreeBSD base + PHP row above is also encoded in CI.** The
+> `resolve-version` job in `.github/workflows/build-image.yml` maps
+> `pfsense_ce_version → (freebsd_version, php_version)` so the branch `.pkg` is
+> built against the right ABI/runtime, and hard-fails on any unmapped version.
+> When adding a new supported CE version, add a `case` arm there alongside the
+> table here (issue #22).
+
 ### pfBlockerNG runtime dependencies (port `RUN_DEPENDS`)
 
 These must be present for pfBlockerNG to function. By convention the ADR-04


### PR DESCRIPTION
## What

`build-image.yml`'s `build-pkg` job built the branch `.pkg` with only `channel: devel`, inheriting `build-pkg.yml`'s `freebsd_version` (`15.0-RELEASE`) and `php_version` (`8.3`) defaults. Those defaults match **CE 2.8.1 only** — adding a second CE version would silently build against the wrong FreeBSD ABI / PHP runtime, so `pkg add` could ABI-mismatch (or the wrong PHP gets pinned) on the published image.

## How

- New cheap `resolve-version` job (no KVM, 5 min cap) that maps `pfsense_ce_version → (freebsd_version, php_version)` via a `case` statement and **hard-fails** (`::error::` + `exit 1`) on any unmapped version.
- It gates **both** `publish-image` and `build-pkg` (`needs:`), so an unknown version fails in seconds — before the 90-min publish job spins up.
- `build-pkg` now passes the derived base **explicitly** instead of relying on the reusable workflow's defaults.
- `docs/misc/pfSense_versions.md` gains a cross-reference so a maintainer bumping the version updates the CI map alongside the base-facts table.

## Acceptance criteria (from #22)

- ✅ Adding a new CE version requires explicitly updating the version map; silently inheriting wrong defaults is no longer possible (the `*)` arm hard-fails).
- ✅ The default CE 2.8.1 path is unaffected — `2.8.*` maps to the same `15.0-RELEASE` / `8.3` the defaults already used.

## Test

Workflow is `workflow_dispatch`-only (ADR-04 image publish), not in the PR gate. Validated YAML parse + markdownlint locally; all pre-commit hooks green.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build pipeline now resolves and validates pfSense CE versions to their FreeBSD and PHP counterparts, fails early on unsupported mappings, and ensures downstream steps wait for and receive the resolved runtime versions.

* **Documentation**
  * Clarified version compatibility docs to explain CI mapping behavior and how to add support for new pfSense CE versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->