### PR TITLE
pfblockerng_alerts: default $clists before the summary guard (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -493,12 +493,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
-			message: '#^Variable \$clists might not be defined\.$#'
-			identifier: variable.undefined
-			count: 6
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
 			message: '#^Variable \$colspan might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -158,10 +158,13 @@ if (isset($_GET) && isset($_GET['view']) || isset($_REQUEST) && isset($_REQUEST[
 	}
 }
 
+// $clists is read later in contexts PHPStan can't prove are guarded; default it so it is
+// defined even when the (!$alert_summary) collection block below is skipped (empty = no lists).
+$clists = array();
+
 // Collect all Whitelist/Suppression/Permit/Exclusion customlists
 if (!$alert_summary) {
 
-	$clists = array();
 	foreach (array('ipwhitelist4' => 4, 'ipwhitelist6' => 6, 'dnsbl' => 'dnsbl') as $type => $vtype) {
 		$c_config = $clists[$type] = array();
 


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down. `pfblockerng_alerts.php`, −6.

`$clists` is initialised (`$clists = array()`) inside `if (!$alert_summary) { … }`, but read later (`$clists['ipwhitelist'.$vtype]…`) in contexts PHPStan can't prove are also summary-guarded → undefined when `$alert_summary` is true.

Fix: hoist the `$clists = array()` default to before the guard (and drop the now-redundant inner init). Behaviour-preserving — an empty `$clists` is exactly what the skipped block would have left, and the collection still populates it when `!$alert_summary`.

Baseline −6. The page's `$table` (set across many per-action POST handlers) and `$atype` (foreach-loop variable read after the loop) are genuinely heterogeneous / behaviour-sensitive — **left baselined** rather than risk a wrong fix.

PHPStan green at level 1; `php -l` clean; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced variable initialization in the alerting system to ensure consistent definition across all execution paths, improving code reliability and robustness.

* **Chores**
  * Updated code quality configuration to reflect recent improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->