### PR TITLE
tests: add ADR-12 Update Hooks UI coverage (render + browser screenshot)

### DIFF
--- a/tests/smoke/ui/test_browser.py
+++ b/tests/smoke/ui/test_browser.py
@@ -79,6 +79,10 @@ WIDGET_PAGE = "/widgets/widgets/pfblockerng.widget.php"
 # (#pfb_dnsvip_auto) whose click handler (enable_dnsvip_auto) disables the manual
 # VIP dropdowns (#pfb_dnsvip4/#pfb_dnsvip6).
 DNSBL_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
+# The ADR-12 Update Hooks page: a `.repeatable` hook-row list (pfSense's
+# client-side row helper) with an Add button (#addrow) and per-row fields
+# (hook_command-<id>, ...).
+HOOKS_PAGE = "/pfblockerng/pfblockerng_hooks.php"
 
 # A short, explicit timeout (ms) for the JS-driven DOM transitions: the handlers
 # fire synchronously on load/click, so this is a flake ceiling, not a wait knob.
@@ -309,3 +313,34 @@ def test_dnsvip_auto_checkbox_disables_manual_dropdowns(
     expect(auto).not_to_be_checked(timeout=JS_TIMEOUT_MS)
     expect(v4).to_be_enabled(timeout=JS_TIMEOUT_MS)
     expect(v6).to_be_enabled(timeout=JS_TIMEOUT_MS)
+
+
+def test_update_hooks_section_renders_and_adds_a_row(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """ADR-12 Update Hooks page renders, and the repeatable-row Add control adds a row.
+
+    Screenshots the section, asserts its key controls render, then clicks Add
+    (pfSense's client-side `.repeatable` row helper) and asserts a new hook row
+    appears. Each row carries exactly one ``hook_command-<id>`` input, so the count
+    of those inputs is the row count (before+after is the transition). The Add /
+    Delete buttons skip server validation, so this never persists or errors.
+    """
+    page = browser_page
+    _open(page, webui, HOOKS_PAGE)
+
+    # Render assertions: the section + the Add button + at least one hook row.
+    expect(page.get_by_text("Hook Entries").first).to_be_visible(timeout=JS_TIMEOUT_MS)
+    add_btn = page.locator("#addrow")
+    expect(add_btn).to_be_visible(timeout=JS_TIMEOUT_MS)
+    rows = page.locator('input[name^="hook_command-"]')
+    expect(rows.first).to_be_attached(timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "update_hooks")
+
+    # BEFORE -> exercise the client-side row clone -> AFTER (one more row).
+    before = rows.count()
+    add_btn.click()
+    expect(page.locator('input[name^="hook_command-"]')).to_have_count(before + 1, timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "update_hooks_added")

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -91,6 +91,8 @@ PAGE_TABLE: tuple[Page, ...] = (
     # The {domain} placeholder is filled per run with helpers.unique_domain() (uuid-*.com) -- the
     # smoke-domain rule (never a fixed/RFC-6761 name, avoids environment coupling).
     Page("threats", "/pfblockerng/pfblockerng_threats.php?domain={domain}", ("Threat Domain", "Source IP")),
+    # ADR-12 Update Hooks (pre/post update-command list). $pgtitle + the section titles are stable.
+    Page("hooks", "/pfblockerng/pfblockerng_hooks.php", ("Update Hooks", "Hook Entries")),
     # The dashboard widget (auth-gated; $nocsrf=true). A direct GET renders the alias-table panel
     # whose hidden inputs (id="pfblockerngack") are a stable marker; the AJAX getNew* paths need a
     # query param, so the plain GET exercises the full-render branch.
@@ -188,15 +190,15 @@ def test_page_table_covers_every_pfblockerng_page() -> None:
     """Guard: the table (plus the recorded exclusions) covers the on-disk page set.
 
     A new pfBlockerNG .php page added to src/ without a Tier-A entry should fail
-    this -- the count is asserted so the sweep can't silently skip a page. 14
+    this -- the count is asserted so the sweep can't silently skip a page. 15
     servable main pages: general, ip, dnsbl, feeds, alerts, log, sync,
-    safesearch, update, blacklist, category, category_edit, threats, plus the
-    pfblockerng.php template (excluded). The widget + 2 DNSBL-VIP pages round it
-    out; the VIP pages + the GeoIP/Reputation views are the recorded exclusions.
+    safesearch, update, blacklist, category, category_edit, threats, hooks, plus
+    the pfblockerng.php template (excluded). The widget + 2 DNSBL-VIP pages round
+    it out; the VIP pages + the GeoIP/Reputation views are the recorded exclusions.
     """
     covered_paths = {p.path.split("?", 1)[0] for p in PAGE_TABLE}
-    # 13 distinct main .php files are render-smoked here (pfblockerng.php is the
-    # excluded template), plus the widget = 14 distinct paths.
+    # 14 distinct main .php files are render-smoked here (pfblockerng.php is the
+    # excluded template), plus the widget = 15 distinct paths.
     expected_main = {
         "/pfblockerng/pfblockerng_general.php",
         "/pfblockerng/pfblockerng_ip.php",
@@ -211,6 +213,7 @@ def test_page_table_covers_every_pfblockerng_page() -> None:
         "/pfblockerng/pfblockerng_category.php",
         "/pfblockerng/pfblockerng_category_edit.php",
         "/pfblockerng/pfblockerng_threats.php",
+        "/pfblockerng/pfblockerng_hooks.php",
         "/widgets/widgets/pfblockerng.widget.php",
     }
     missing = expected_main - covered_paths


### PR DESCRIPTION
## Add ADR-12 Update Hooks UI coverage (render-smoke + browser screenshot)

ADR-12's **Update Hooks** page (`pfblockerng_hooks.php`) shipped to devel, but the UI harness never touched it — no render check, no screenshot. This adds both (and gets us the first screenshot of the section).

### Changes (`tests/` only)

- **Tier A (render-smoke):** add the Update Hooks page to `PAGE_TABLE` (markers "Update Hooks" / "Hook Entries"), and to the coverage-guard's `expected_main` set (+ bumped the counts) so the guard now *requires* it — a future page can't silently skip the sweep.
- **Tier B (browser):** open the page, assert its key controls render, **capture `update_hooks.png`**, then click **Add** and assert a new hook row appears — exercising pfSense's client-side `.repeatable` row helper (`#addrow` clones a `hook_command-<id>` row). A second shot `update_hooks_added.png` captures the added row. Add/Delete skip server validation, so this never persists or errors.

### Notes

- Default `python -m pytest` unaffected (`tests/smoke/ui` is excluded); the coverage guard passes locally with the page added; ruff / mypy / php -l / PHPStan / PHPUnit / markdownlint all green.
- Labeled `ui-tests` so the live suite runs and produces the screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated UI test coverage for the Update Hooks page, including render and interaction checks.
  * Added verification that the "Add" control inserts a new hook row and updates inputs accordingly, with screenshots before and after.
  * Expanded smoke test registry to include the Update Hooks page in overall page render coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->