### PR TITLE
pfblockerng.inc: default pfb_open_sqlite locals for unknown $table (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -157,27 +157,9 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$database might not be defined\.$#'
-			identifier: variable.undefined
-			count: 7
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$db_create might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$db_handle might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$db_table might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7092,6 +7092,12 @@ function pfb_daemon_dnsbl_index() {
 function pfb_open_sqlite($table, $message) {
 	global $pfb;
 
+	// $table is always 1-7 from callers, but the if/elseif chain below has no else;
+	// default these so they are defined for any value. Behaviour-preserving.
+	$database	= '';
+	$db_table	= '';
+	$db_create	= '';
+
 	if ($table == 1) {
 		$database	= $pfb['dnsbl_info'];
 		$db_table	= 'dnsbl';


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down, **first `pfblockerng.inc` (core library) pass** — deliberately a small, fully function-scoped change. −11.

`pfb_open_sqlite($table, $message)` selects the DB path/table/DDL via an `if/elseif` chain on `$table` (1–7) with **no `else`**, then uses `$database`/`$db_table`/`$db_create` below (`new SQLite3($database)`, the `CREATE TABLE`, etc.). Callers only ever pass 1–7, but PHPStan can't prove that, so it flagged all 11 reads as possibly-undefined.

## Fix

Default `$database`/`$db_table`/`$db_create` to `''` at the top of the function (after `global $pfb;`). Behaviour-preserving: for every real `$table` the chain overwrites them; the only path that keeps the defaults is an out-of-range `$table` that never occurs (and which previously hit undefined variables / a `new SQLite3(<undef>)` anyway). Blast radius is one function.

Baseline −11. The other `pfblockerng.inc` residuals (`$csvline` in the CSV feed parser, `$mode` in the DNSBL handlers, and ~25 scattered singletons) are being looked at individually in later passes — none folded in here.

PHPStan green at level 1; `php -l` clean; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved potential undefined variable issues in database operations that could occur in edge cases.

* **Chores**
  * Updated code quality baseline configuration to reflect improved error handling standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->