### PR TITLE
pfblockerng.inc: default $csvline in the CSV feed parser (#88)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -145,12 +145,6 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$csvline might not be defined\.$#'
-			identifier: variable.undefined
-			count: 14
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$customlist in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9103,6 +9103,10 @@ function sync_package_pfblockerng($cron='') {
 													$line = strstr($line, ' #', TRUE);
 												}
 
+												// Default per line so $csvline is defined for the count()/index reads below;
+												// str_getcsv overwrites it whenever the CSV path runs. Behaviour-preserving.
+												$csvline = array();
+
 												// Convert CSV line into array
 												if ($csv_parser) {
 													$csvline = str_getcsv($line, ',', '"', '"');


### PR DESCRIPTION
Part of #88 — PHPStan level-1 burn-down, `pfblockerng.inc` CSV feed parser. −14.

In the feed line loop, `$csvline` is assigned by `str_getcsv()` only inside `if ($csv_parser)` / the first-line `elseif (!$run_once)` branch, then read (`count($csvline)`, `$csvline[1]`, …) inside the **matching** `if ($csv_parser)` block later in the same iteration. So whenever the read block runs, `$csvline` was assigned earlier in that iteration — but PHPStan can't correlate the two `$csv_parser` guards, so it flagged all 14 reads.

## Fix

Default `$csvline = array();` once per line, before the assignment block. Behaviour-preserving: it is overwritten by `str_getcsv` on every line that reaches the read path (so the read always sees the parsed line), and it is **safer** than the status quo — `count($csvline)` on the default is `0`, whereas an undefined `$csvline` would be `count(null)` → a PHP 8 `TypeError` (a path the runtime control flow currently just never reaches).

Baseline −14. The remaining `pfblockerng.inc` residuals (`$mode` in the DNSBL management sequence, plus ~25 scattered singletons) are separate, each needing its own per-function check.

PHPStan green at level 1; `php -l` clean; PHPUnit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of feed and domain parsing by ensuring proper variable initialization before CSV data processing begins, providing more robust and consistent handling of feed entries across different scenarios and edge cases

* **Chores**
  * Updated static analysis baseline configuration to better reflect the current code implementation, removing unnecessary suppressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->