### PR TITLE
pfblockerng wizard: add Skip button + "do not show again" checkbox

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -29,10 +29,20 @@ pfb_global();
 
 // Add Wizard tab on new installations only
 $pfb_wizard = TRUE;
-if ($_GET && isset($_GET['wizard']) && $_GET['wizard'] == 'skip') {
-	$pfb_wizard = FALSE;
+
+// "Do not show this again": persist the choice so the setup wizard never auto-launches
+// again. Stored outside config/0 so a fresh, unconfigured install still reads as
+// unconfigured (config/0 == null) for the upgrade-migration paths in pfblockerng_install.inc.
+if ($_GET && isset($_GET['wizard']) && $_GET['wizard'] == 'disable') {
+	config_set_path('installedpackages/pfblockerng/pfb_wizard_skip', 'on');
+	write_config('[pfBlockerNG] Disable setup wizard auto-launch');
 }
-elseif (!empty(config_get_path('installedpackages/pfblockerng/config/0'))) {
+
+// Skip the auto-launch for this request ('skip'), permanently ('disable' persisted),
+// or once the package has been configured.
+if (($_GET && isset($_GET['wizard']) && $_GET['wizard'] == 'skip') ||
+    config_get_path('installedpackages/pfblockerng/pfb_wizard_skip') == 'on' ||
+    !empty(config_get_path('installedpackages/pfblockerng/config/0'))) {
 	$pfb_wizard = FALSE;
 }
 

--- a/src/usr/local/www/wizards/pfblockerng_wizard.inc
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.inc
@@ -31,6 +31,20 @@ global $pfb_wizard;
 $pfb_wizard['interface_list']		= pfb_build_if_list(TRUE, FALSE);
 $pfb_wizard['interface_list_cnt']	= count($pfb_wizard['interface_list']) ?: '1';
 
+// Exit the wizard when the 'Skip' button is pressed on any step. If the
+// 'Do not show this again' checkbox is ticked, persist the choice so the
+// wizard never auto-launches again ('disable'); otherwise skip for this
+// session only ('skip'). pfblockerng_general.php applies both actions.
+function pfb_wizard_skip_check() {
+	if (!$_POST || !isset($_POST['skip'])) {
+		return;
+	}
+
+	$action = !empty($_POST['donotshowthisagain']) ? 'disable' : 'skip';
+	header("Location: /pfblockerng/pfblockerng_general.php?wizard={$action}");
+	exit;
+}
+
 function step2_stepbeforeformdisplay() {
 	global $pkg, $stepid, $pfb_wizard;
 
@@ -49,6 +63,8 @@ function step2_stepbeforeformdisplay() {
 
 function step2_submitphpaction() {
 	global $stepid, $input_errors, $pfb_wizard;
+
+	pfb_wizard_skip_check();
 
 	if ($_POST) {
 		if ($_POST['back'] == 'Back') {
@@ -86,6 +102,8 @@ function step2_submitphpaction() {
 function step3_submitphpaction() {
 	global $stepid, $input_errors;
 
+	pfb_wizard_skip_check();
+
 	if ($_POST) {
 		if ($_POST['back'] == 'Back') {
 			$stepid = 0;
@@ -117,6 +135,8 @@ function step3_submitphpaction() {
 
 function step4_submitphpaction() {
 	global $pfb, $input_errors;
+
+	pfb_wizard_skip_check();
 
 	// Load all pfBlockerNG Feeds
 	$feed_info_raw = json_decode(@file_get_contents("{$pfb['feeds']}"), TRUE);

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -31,8 +31,7 @@
 		<div style="width: 75%; height: 170px; float: left;">
 			<p><h4>Welcome to pfBlockerNG!</h4></p>
 			<p>This wizard will configure an entry level configuration of pfBlockerNG for IP and DNSBL.</p>
-			<p>You can opt-out of this wizard and manually configure pfBlockerNG as required!</p>
-			<p><strong>pfBlockerNG</strong> is developed and maintained by 
+			<p><strong>pfBlockerNG</strong> is developed and maintained by
 				<a target="_blank" href="https://forum.netgate.com/user/bbcan177">BBcan177</a><br />
 
 			<ul class="list-inline" style="margin-top: 4px; margin-bottom: -2px; border-style: outset; border-bottom-color: #8B181B; border-right-color: #8B181B; border-width: 2px;">
@@ -114,22 +113,28 @@
 		<line id="XMLID_7_" class="st4" x1="260.4" y1="425.6" x2="390.9" y2="425.6"/>
 		</g></g></svg></a>
 		</div>
-
-		<div style="width: 100%; float: left;">
-			<br />
-			<a class="btn btn-sm btn-default" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=skip">
-				<i class="fa-solid fa-forward icon-embed-btn"></i>Skip</a>
-			<a class="btn btn-sm btn-warning" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=disable">
-				<i class="fa-solid fa-ban icon-embed-btn"></i>Do not show this again</a>
-		</div>
 		]]>
 	</description>
 	<fields>
+		<field>
+			<name>Skip</name>
+			<type>submit</type>
+		</field>
+		<field>
+			<name>Do not show this again</name>
+			<displayname>Do not show this again</displayname>
+			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
+			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
+			<type>checkbox</type>
+			<value>on</value>
+		</field>
 		<field>
 			<name>Next</name>
 			<type>submit</type>
 		</field>
 	</fields>
+	<stepsubmitphpaction>pfb_wizard_skip_check();</stepsubmitphpaction>
+	<includefile>/usr/local/www/wizards/pfblockerng_wizard.inc</includefile>
 </step>
 <step>
 	<id>2</id>
@@ -156,22 +161,28 @@
 				<li>A VIP on the Localhost interface <strong>must be configured first</strong> at <a target="_blank" href="/firewall_virtual_ip.php">Firewall > Virtual IPs</a>.</li>
 			</ul>
 		</div>
-		<div class="col-sm-11">
-			<br />
-			<a class="btn btn-sm btn-default" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=skip">
-				<i class="fa-solid fa-forward icon-embed-btn"></i>Skip</a>
-			<a class="btn btn-sm btn-warning" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=disable">
-				<i class="fa-solid fa-ban icon-embed-btn"></i>Do not show this again</a>
-		</div>
 		]]>
 	</description>
 	<fields>
+		<field>
+			<name>Skip</name>
+			<type>submit</type>
+		</field>
+		<field>
+			<name>Do not show this again</name>
+			<displayname>Do not show this again</displayname>
+			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
+			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
+			<type>checkbox</type>
+			<value>on</value>
+		</field>
 		<field>
 			<name>Next</name>
 			<type>submit</type>
 		</field>
 	</fields>
 	<stepsubmitbeforesave>step2_stepbeforeformdisplay();</stepsubmitbeforesave>
+	<stepsubmitphpaction>pfb_wizard_skip_check();</stepsubmitphpaction>
 	<includefile>/usr/local/www/wizards/pfblockerng_wizard.inc</includefile>
 </step>
 <step>
@@ -214,6 +225,18 @@
 		<field>
 			<name>Back</name>
 			<type>submit</type>
+		</field>
+		<field>
+			<name>Skip</name>
+			<type>submit</type>
+		</field>
+		<field>
+			<name>Do not show this again</name>
+			<displayname>Do not show this again</displayname>
+			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
+			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
+			<type>checkbox</type>
+			<value>on</value>
 		</field>
 		<field>
 			<name>Next</name>
@@ -283,6 +306,18 @@
 			<type>submit</type>
 		</field>
 		<field>
+			<name>Skip</name>
+			<type>submit</type>
+		</field>
+		<field>
+			<name>Do not show this again</name>
+			<displayname>Do not show this again</displayname>
+			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
+			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
+			<type>checkbox</type>
+			<value>on</value>
+		</field>
+		<field>
 			<name>Next</name>
 			<type>submit</type>
 		</field>
@@ -303,13 +338,20 @@
 			<span style="color: red;"> wiped!</span>
 			<br/><br/>
 			To save this default configuration and apply these changes, press the <strong>Finish</strong> button!
-			<br/><br/>
-			<a class="btn btn-sm btn-default" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=skip">
-				<i class="fa-solid fa-forward icon-embed-btn"></i>Skip</a>
-			<a class="btn btn-sm btn-warning" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=disable">
-				<i class="fa-solid fa-ban icon-embed-btn"></i>Do not show this again</a>
 	]]></description>
 	<fields>
+		<field>
+			<name>Skip</name>
+			<type>submit</type>
+		</field>
+		<field>
+			<name>Do not show this again</name>
+			<displayname>Do not show this again</displayname>
+			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
+			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
+			<type>checkbox</type>
+			<value>on</value>
+		</field>
 		<field>
 			<name>Finish</name>
 			<type>submit</type>

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -116,8 +116,11 @@
 		</div>
 
 		<div style="width: 100%; float: left;">
-			<br /><p>Click&emsp;<a href="/pfblockerng/pfblockerng_general.php?wizard=skip">
-				<span style="color: red;">Here</span></a>&emsp;to exit this Wizard!</p>
+			<br />
+			<a class="btn btn-sm btn-default" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=skip">
+				<i class="fa-solid fa-forward icon-embed-btn"></i>Skip</a>
+			<a class="btn btn-sm btn-warning" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=disable">
+				<i class="fa-solid fa-ban icon-embed-btn"></i>Do not show this again</a>
 		</div>
 		]]>
 	</description>
@@ -155,8 +158,10 @@
 		</div>
 		<div class="col-sm-11">
 			<br />
-			<p>Click&emsp;<a href="/pfblockerng/pfblockerng_general.php?wizard=skip">
-				<span style="color: red;">Here</span></a>&emsp;to exit this Wizard!</p>
+			<a class="btn btn-sm btn-default" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=skip">
+				<i class="fa-solid fa-forward icon-embed-btn"></i>Skip</a>
+			<a class="btn btn-sm btn-warning" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=disable">
+				<i class="fa-solid fa-ban icon-embed-btn"></i>Do not show this again</a>
 		</div>
 		]]>
 	</description>
@@ -292,16 +297,18 @@
 		<name>Save pfBlockerNG wizard settings</name>
 		<type>listtopic</type>
 	</field>
-	<description>All configuration parameters have been successfully collected.
-			&lt;br/&gt;&lt;br/&gt;
+	<description><![CDATA[All configuration parameters have been successfully collected.
+			<br/><br/>
 			Upon completion of this Wizard, any previously configured settings in pfBlockerNG, including any downloaded feeds will be
-			&lt;span style=&quot;color: red;&quot;&gt; wiped!&lt;/span&gt;
-			&lt;br/&gt;&lt;br/&gt;
-			To save this default configuration and apply these changes, press the &lt;strong&gt;Finish&lt;/strong&gt; button!
-			&lt;br/&gt;&lt;br/&gt;
-			Click&#160;&#160;&#160;&lt;a href=&quot;/pfblockerng/pfblockerng_general.php?wizard=skip&quot;&gt;
-			&lt;span style=&quot;color: red;&quot;&gt;Here&lt;/span&gt;&lt;/a&gt;&#160;&#160;&#160;to exit this Wizard!
-	</description>
+			<span style="color: red;"> wiped!</span>
+			<br/><br/>
+			To save this default configuration and apply these changes, press the <strong>Finish</strong> button!
+			<br/><br/>
+			<a class="btn btn-sm btn-default" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=skip">
+				<i class="fa-solid fa-forward icon-embed-btn"></i>Skip</a>
+			<a class="btn btn-sm btn-warning" role="button" href="/pfblockerng/pfblockerng_general.php?wizard=disable">
+				<i class="fa-solid fa-ban icon-embed-btn"></i>Do not show this again</a>
+	]]></description>
 	<fields>
 		<field>
 			<name>Finish</name>


### PR DESCRIPTION
## Summary

The setup wizard auto-launches on every visit to the General tab until pfBlockerNG is configured, and the only way out was a small "Click Here to exit this Wizard" text link buried in each step's description — a one-shot skip that re-triggered the redirect on the next visit. This adds a proper way to skip, including permanently.

Each wizard step now has:

- a real **Skip** submit button placed beside Next/Finish (in the button bar), and
- a **"Do not show this again"** checkbox.

Skip behaviour reads the checkbox:

- checkbox **ticked** → redirects to `pfblockerng_general.php?wizard=disable` — persists the choice so the wizard never auto-launches again
- checkbox **unticked** → `?wizard=skip` — skips for this page load only (prior behaviour)

The Wizard tab stays available, so it can still be re-entered manually.

## Implementation

- `pfblockerng_general.php`: handle `?wizard=disable` by persisting a flag, and skip the auto-launch when it is set. The flag lives at `installedpackages/pfblockerng/pfb_wizard_skip` — deliberately **outside** `config/0`, because the upgrade-migration guards in `pfblockerng_install.inc` treat a non-null `config/0` as "already configured". Storing it there would falsely trip those paths on a fresh install.
- `pfblockerng_wizard.xml`: per-step Skip submit + "Do not show this again" checkbox; dropped the old exit-link markup and the step 1 "opt-out" mention.
- `pfblockerng_wizard.inc`: new `pfb_wizard_skip_check()` runs at the top of each step's submit action; on Skip it redirects to `general.php` with the right action (`disable`/`skip`) and exits. Persistence/redirect logic stays in one place (`general.php`).

## Testing

- `php -l` on the changed PHP/inc, `xmllint` on the wizard XML — clean
- `ruff check .` clean; full pytest suite (1068) green (no Python changed)

FreeBSD-ports: only existing files were modified (no new/renamed/deleted files), and both port `pkg-plist`s on `pfblockerng/use-github` already list all three — no plist change required.

https://claude.ai/code/session_01KfaKTd724hVCiuHVZ57aDr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfaKTd724hVCiuHVZ57aDr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Do not show again" checkbox that persists wizard skip preference across sessions.
  * Unified Skip controls on all wizard steps; Skip now exits the wizard immediately and respects the persisted preference.
  * Wizard is now also suppressed for already-configured installs.

* **Bug Fixes**
  * Prevented further step processing when a user chooses Skip, avoiding unintended validation or configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->