### PR TITLE
tests: add Tier-B action/utility flows + threats render (Batch 2)

### DIFF
--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -1,0 +1,417 @@
+"""Tier-B functional flows for the Reports/Alerts page (ADR-14 Phase 3).
+
+The Alerts page (``pfblockerng_alerts.php``) is the heaviest page in the package
+and its mutating actions are NOT a single ``save`` form -- they are JS-driven
+``act``-style POSTs, each dispatched by an ``isset($_POST['<action>'])`` branch
+in the ``if (isset($_POST) && !empty($_POST))`` block at the top of the file. So
+these flows do NOT use :meth:`WebUI.post` (which scrapes the whole form and adds a
+``save`` button); they GET the page, harvest the freshly-injected ``__csrf_magic``
+token, and POST the exact ``{action: ..., domain/ip/table: ...}`` set the page's
+JS would send (mirroring ``test_log.py``'s manual-POST pattern).
+
+What this file establishes -- the same oracle discipline as ``test_functional.py``:
+the oracle is the box's EFFECTIVE state, NEVER the HTTP response body. For the
+config-store actions (whitelist / TLD-exclusion / IP suppression) that is the
+``config.xml`` node the handler writes (read via :func:`helpers.config_get`,
+base64-decoded -- these are pfBlockerNG textarea fields). For the marquee
+Lock/Unlock action -- whose store is ``/tmp/dnsbl_unlock`` (not config.xml) and
+whose effect is a query-time whiteDB allow -- the oracle is the on-box DNS answer
+shape (``drill @127.0.0.1``), since the only observable truth of an unlock is that
+the resolver stops sinkholing the name.
+
+Every flow is a TRUE transition test (CLAUDE.md transition-test rule): it asserts
+the ORIGINAL/before state FIRST, drives the action, asserts the changed state, then
+RESTORES the box (asserting the reverse where it applies). A green therefore proves
+the POST CAUSED the change rather than a pre-existing end-state happening to hold,
+and the restore -- always in a ``finally`` so a mid-test failure cannot poison the
+session-scoped VM for the sibling flows -- exercises the reverse branch too.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from .. import helpers
+from .webui import extract_csrf_token, looks_like_login_page
+
+if TYPE_CHECKING:
+    import requests
+
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+ALERTS_PAGE = "/pfblockerng/pfblockerng_alerts.php"
+
+# config.xml nodes the alerts handlers write (all base64 textarea fields).
+CFG_SUPPRESSION = "installedpackages/pfblockerngdnsblsettings/config/0/suppression"
+CFG_TLDEXCLUSION = "installedpackages/pfblockerngdnsblsettings/config/0/tldexclusion"
+CFG_V4SUPPRESSION = "installedpackages/pfblockerngipsettings/config/0/v4suppression"
+
+
+def _csrf(webui: WebUI) -> str:
+    """GET the alerts page and return its freshly-injected ``__csrf_magic`` token.
+
+    csrf-magic rewrites the token per render, so it must be re-harvested for each
+    manual POST. Asserts the GET is authenticated so a dropped session fails loudly
+    here, not as an opaque CSRF rejection inside the handler.
+    """
+    resp = webui.get(ALERTS_PAGE)
+    assert not looks_like_login_page(resp.text), "alerts page GET returned the login form (session lost)"
+    return extract_csrf_token(resp.text)
+
+
+def _post_action(webui: WebUI, data: dict[str, str], *, timeout: float = 300.0) -> requests.Response:
+    """POST one alerts ``act``-style action with a fresh CSRF token.
+
+    Re-harvests the token (per-render), merges it into ``data``, and POSTs to the
+    alerts page exactly as the page's JS would -- no ``save`` button (these handlers
+    gate on ``isset($_POST['<action>'])``, not on ``save``). The caller asserts
+    EFFECTIVE state (config.xml / DNS), never this response.
+    """
+    payload: dict[str, Any] = {"__csrf_magic": _csrf(webui)}
+    payload.update(data)
+    return webui.session.post(
+        webui.url(ALERTS_PAGE),
+        data=payload,
+        verify=webui._verify,  # noqa: SLF001 -- mirror the client's configured cert handling
+        timeout=timeout,
+    )
+
+
+def _suppression_entries(vm: helpers.SmokeVM, cfg_path: str) -> set[str]:
+    """Return the ENTRY TOKENS of a pfBlockerNG textarea config node.
+
+    The alerts handlers store the whitelist / TLD-exclusion / IP-suppression lists
+    base64-encoded (``base64_encode`` in the handler; ``pfbng_text_area_decode``
+    base64-decodes on read), one entry per CRLF line as ``<token> [# comment]``. The
+    handler keys its in-memory store by the FIRST whitespace-delimited token of each
+    line (``$clists[...]['data'][$line[0]]``), so an exact-token set is the faithful
+    membership oracle -- a substring check would wrongly match ``example.com`` inside
+    the ``www.example.com`` entry the whitelist add also writes (and which
+    ``entry_delete=delete_domain`` deliberately leaves behind). An empty/absent node
+    is an empty set.
+    """
+    raw = helpers.config_get(vm, cfg_path)
+    if not raw:
+        return set()
+    try:
+        text = base64.b64decode(raw).decode("utf-8", "replace")
+    except (ValueError, UnicodeError):
+        return set()
+    return {line.split()[0] for line in text.splitlines() if line.strip()}
+
+
+# --------------------------------------------------------------------------- #
+# Marquee flow: the DNSBL temporary Lock/Unlock lifecycle (the ``dnsbl_remove``
+# handler, alerts.php:1371). A feed-blocked domain "unlocked" via the alerts web
+# handler must STOP being sinkholed; re-locking restores the block. Oracle = the
+# on-box DNS answer SHAPE (the unlock store is /tmp/dnsbl_unlock, not config.xml).
+#
+# Block shape is deterministic LOCALLY (VIP / 0.0.0.0), computed by the python
+# module every query (blocks are not C-cached, #43). An UNLOCK lifts the sinkhole:
+# the module passes the name through and Unbound forwards it upstream. Under the UI
+# fixtures there is NO controlled stub upstream, so the forwarded answer is whatever
+# the real upstream returns for a random .com (NXDOMAIN) -- but that is irrelevant:
+# the discriminator is "no longer a block shape" (`not is_vip and not is_null_ip`),
+# which is True for NXDOMAIN/SERVFAIL/any real answer and False ONLY for a block.
+# That isolates the toggle without depending on a positive upstream resolve.
+# --------------------------------------------------------------------------- #
+
+
+def _not_blocked(answer: helpers.DnsAnswer) -> bool:
+    """True iff the answer is NOT a DNSBL block shape (neither the VIP nor null-IP).
+
+    The upstream-independent "unlocked" oracle: an unlocked name is forwarded, so it
+    is no longer sinkholed -- whatever it resolves to (or NXDOMAIN/SERVFAIL with no
+    upstream), it is not the VIP and not 0.0.0.0/::.
+    """
+    return not helpers.is_vip(answer) and not helpers.is_null_ip(answer)
+
+
+def test_dnsbl_lock_unlock_lifecycle_via_alerts(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Unlock/Lock a feed-blocked domain via the alerts ``dnsbl_remove`` web handler.
+
+    True transition lifecycle (CLAUDE.md before/after + the lock/unlock example):
+
+    * SETUP: a local DNSBL feed lists ``domain`` (VIP mode) with DNSBL enabled and a
+      valid sinkhole VIP, then a full Force Update mounts it.
+    * BEFORE: ``domain`` is VIP-BLOCKED (the deterministic local block shape, the
+      authoritative first answer after the restart-class reload).
+    * UNLOCK via the form (``dnsbl_remove=unlock``): the handler toggles the unlock
+      store, patches the manifest's ``user_unlock`` and reloads -> the name stops
+      being sinkholed. Poll until it is no longer a block shape (the swap is async).
+    * RE-LOCK via the form (``dnsbl_remove=lock``): the temporary allow is removed ->
+      the name is VIP-blocked again. Poll until the block shape returns.
+
+    Oracle = the on-box DNS answer shape, never the HTTP body. ``reset(vm)`` in
+    ``finally`` drops the test feed/alias and rebuilds the baseline so the session VM
+    is clean for the sibling flows.
+    """
+    vm = smoke_vm
+    domain = helpers.unique_domain("uilock")
+    feed_path = helpers.write_local_feed(vm, "ui_lock.txt", f"{domain}\n")
+    spec = helpers.DnsblCase(aliasname="uilock", feed_url=feed_path, header="uilock", mode=helpers.DnsblMode.VIP)
+
+    helpers.ensure_dnsbl_vip(vm)
+    helpers.set_dnsbl_enabled(vm, True)
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "update")
+    try:
+        # BEFORE: the feed-listed name is VIP-blocked (authoritative first answer
+        # after the restart-class Force Update).
+        blocked = helpers.dns_probe(vm, domain, "A")
+        assert helpers.is_vip(blocked), f"{domain} expected VIP block before unlock, got {blocked}"
+
+        # UNLOCK via the real alerts handler -> the sinkhole is lifted. dnsbl_type is
+        # PFB_FILTER_WORD and must be non-empty (handler rejects empty); 'python' is
+        # the value the production helper sends.
+        resp = _post_action(webui, {"dnsbl_remove": "unlock", "domain": domain, "dnsbl_type": "python"})
+        assert not looks_like_login_page(resp.text), "unlock POST returned the login form (session lost)"
+        # The swap is async -> poll until the name is no longer a block shape.
+        unlocked = helpers.dns_probe_until(vm, domain, _not_blocked)
+        assert not helpers.is_vip(unlocked), f"unlocked {domain} still VIP-blocked via the alerts handler: {unlocked}"
+
+        # RE-LOCK via the handler -> blocked again (allow->block; the handler's
+        # targeted delta-flush clears the prior resolved answer).
+        resp = _post_action(webui, {"dnsbl_remove": "lock", "domain": domain, "dnsbl_type": "python"})
+        assert not looks_like_login_page(resp.text), "re-lock POST returned the login form (session lost)"
+        relocked = helpers.dns_probe_until(vm, domain, helpers.is_vip)
+        assert helpers.is_vip(relocked), f"re-locked {domain} not VIP-blocked again: {relocked}"
+    finally:
+        # Drop the test feed/alias and rebuild from baseline so the unlock store and
+        # the session VM are clean for the sibling flows.
+        helpers.reset(vm)
+
+
+def test_dnsbl_remove_rejects_missing_type(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The ``dnsbl_remove`` handler rejects an empty ``dnsbl_type`` -> no store change.
+
+    Branch coverage for the validator's REJECT side (the accept side is the marquee
+    lifecycle above): the handler exits with a savemsg and never toggles the unlock
+    store when ``dnsbl_type`` is empty (alerts.php:1380). The transition oracle is the
+    DNS shape: a feed-blocked domain stays VIP-blocked across the rejected POST (the
+    block is the before-state AND the after-state -- proving the POST did NOT unlock).
+    """
+    vm = smoke_vm
+    domain = helpers.unique_domain("uireject")
+    feed_path = helpers.write_local_feed(vm, "ui_reject.txt", f"{domain}\n")
+    spec = helpers.DnsblCase(aliasname="uireject", feed_url=feed_path, header="uireject", mode=helpers.DnsblMode.VIP)
+
+    helpers.ensure_dnsbl_vip(vm)
+    helpers.set_dnsbl_enabled(vm, True)
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "update")
+    try:
+        # BEFORE: VIP-blocked.
+        before = helpers.dns_probe(vm, domain, "A")
+        assert helpers.is_vip(before), f"{domain} expected VIP block before the rejected POST, got {before}"
+
+        # Reject: empty dnsbl_type. The handler must exit before toggling the store.
+        resp = _post_action(webui, {"dnsbl_remove": "unlock", "domain": domain, "dnsbl_type": ""})
+        assert not looks_like_login_page(resp.text), "rejected POST returned the login form (session lost)"
+
+        # AFTER: still VIP-blocked -- the rejected unlock did not lift the sinkhole.
+        after = helpers.dns_probe(vm, domain, "A")
+        assert helpers.is_vip(after), f"{domain} no longer VIP-blocked after a REJECTED unlock POST: {after}"
+    finally:
+        helpers.reset(vm)
+
+
+# --------------------------------------------------------------------------- #
+# addwhitelistdom (alerts.php:947): adds a domain to the DNSBL Whitelist
+# (``suppression`` node) when ``dnsbl_exclude != 'true'``, OR to the TLD Exclusion
+# list (``tldexclusion`` node) when ``dnsbl_exclude == 'true'`` -- two distinct
+# config branches off the SAME action. The reverse is the ``entry_delete`` handler
+# (alerts.php:1178): ``delete_domain`` removes from ``suppression``,
+# ``delete_exclusion`` removes from ``tldexclusion`` -- so the restore exercises
+# that handler too. Oracle = the base64-decoded config node membership.
+# --------------------------------------------------------------------------- #
+
+
+def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """addwhitelistdom (no exclude) writes the DNSBL Whitelist; entry_delete removes it.
+
+    True transition with the ``suppression`` config node as oracle:
+
+    * BEFORE: ``domain`` is absent from the decoded ``suppression`` node.
+    * ADD via the form (``addwhitelistdom`` + ``dnsbl_exclude`` not 'true'): the
+      handler appends ``domain`` (and ``www.domain``) and writes the base64 node.
+    * AFTER: ``domain`` is present in the decoded node.
+    * RESTORE via ``entry_delete=delete_domain``: the handler removes it; the decoded
+      node no longer contains ``domain`` (the reverse transition AND entry_delete
+      coverage). Belt-and-suspenders config reset in ``finally``.
+    """
+    vm = smoke_vm
+    domain = helpers.unique_domain("uiwl")
+    original = helpers.config_get(vm, CFG_SUPPRESSION)
+    try:
+        # BEFORE: the unique domain is not in the whitelist.
+        assert domain not in _suppression_entries(vm, CFG_SUPPRESSION), (
+            f"{domain} already in the DNSBL Whitelist before the add"
+        )
+
+        # ADD: addwhitelistdom into the DNSBL Whitelist (dnsbl_exclude false). 'table'
+        # is PFB_FILTER_WORD and only checked non-empty for this branch.
+        resp = _post_action(
+            webui,
+            {
+                "addwhitelistdom": "Add",
+                "domain": domain,
+                "table": "DNSBL",
+                "dnsbl_wildcard": "false",
+                "dnsbl_exclude": "false",
+            },
+        )
+        assert not looks_like_login_page(resp.text), "addwhitelistdom POST returned the login form (session lost)"
+        assert domain in _suppression_entries(vm, CFG_SUPPRESSION), (
+            f"{domain} not written to the DNSBL Whitelist (suppression) config node after addwhitelistdom"
+        )
+
+        # RESTORE via entry_delete=delete_domain (reverse transition + entry_delete coverage).
+        resp = _post_action(webui, {"entry_delete": "delete_domain", "domain": domain, "table": "DNSBL"})
+        assert not looks_like_login_page(resp.text), "entry_delete POST returned the login form (session lost)"
+        assert domain not in _suppression_entries(vm, CFG_SUPPRESSION), (
+            f"{domain} still in the DNSBL Whitelist after entry_delete=delete_domain"
+        )
+    finally:
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_SUPPRESSION}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore suppression');\n"
+            "echo 'OK';",
+        )
+
+
+def test_addwhitelistdom_exclude_writes_tld_exclusion_and_entry_delete_removes_it(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """addwhitelistdom with ``dnsbl_exclude='true'`` writes the TLD Exclusion node.
+
+    The OTHER branch of the same action (CLAUDE.md branch coverage: the exclude flag
+    OFF case is the whitelist test above; this is the ON case). True transition with
+    the ``tldexclusion`` config node as oracle: absent before, present after the add,
+    absent again after ``entry_delete=delete_exclusion`` (the reverse + that delete
+    branch). Config reset in ``finally``.
+    """
+    vm = smoke_vm
+    domain = helpers.unique_domain("uitld")
+    original = helpers.config_get(vm, CFG_TLDEXCLUSION)
+    try:
+        # BEFORE: not in the TLD Exclusion list.
+        assert domain not in _suppression_entries(vm, CFG_TLDEXCLUSION), (
+            f"{domain} already in the TLD Exclusion list before the add"
+        )
+
+        # ADD: addwhitelistdom with dnsbl_exclude=true -> the TLD Exclusion branch.
+        resp = _post_action(
+            webui,
+            {
+                "addwhitelistdom": "Add",
+                "domain": domain,
+                "table": "DNSBL",
+                "dnsbl_wildcard": "false",
+                "dnsbl_exclude": "true",
+            },
+        )
+        assert not looks_like_login_page(resp.text), "addwhitelistdom (exclude) POST returned the login form"
+        assert domain in _suppression_entries(vm, CFG_TLDEXCLUSION), (
+            f"{domain} not written to the TLD Exclusion config node after addwhitelistdom exclude=true"
+        )
+
+        # RESTORE via entry_delete=delete_exclusion (reverse + delete_exclusion coverage).
+        resp = _post_action(webui, {"entry_delete": "delete_exclusion", "domain": domain, "table": "DNSBL"})
+        assert not looks_like_login_page(resp.text), "entry_delete (exclusion) POST returned the login form"
+        assert domain not in _suppression_entries(vm, CFG_TLDEXCLUSION), (
+            f"{domain} still in the TLD Exclusion list after entry_delete=delete_exclusion"
+        )
+    finally:
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_TLDEXCLUSION}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore tldexclusion');\n"
+            "echo 'OK';",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# addsuppress (alerts.php:741): add an IPv4 /32 or /24 to the IPv4 Suppression
+# customlist (``v4suppression`` node). Validator: a valid IPv4 + cidr in {32,24} +
+# a non-empty table word, else it exits with a savemsg and writes NOTHING.
+#
+# We cover the cidr=24 ACCEPT (which writes the network entry to v4suppression even
+# without a live blocked IP -- the /24 branch never takes the /32 "blocked by a
+# CIDR other than /24" early exit) and an invalid-IP REJECT (config unchanged). The
+# /32 ACCEPT is NOT covered: it needs a real blocked IP in a live pf table to pass.
+# --------------------------------------------------------------------------- #
+
+
+def test_addsuppress_cidr24_writes_and_invalid_ip_rejected(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """addsuppress accepts a valid /24 (writes config) and rejects an invalid IP.
+
+    Branch coverage for the IPv4-suppression validator, both with the ``v4suppression``
+    config node as oracle:
+
+    * REJECT first (proves the node's before-value): an invalid IPv4 makes the handler
+      exit before any write -- the node is UNCHANGED.
+    * ACCEPT (cidr=24): a valid IPv4 + cidr '24' + table word writes the /24 network
+      entry (``a.b.c.0/24``) to ``v4suppression`` -- the node now contains it.
+
+    The accept asserts the network entry is PRESENT where it was ABSENT, so the green
+    proves the POST caused the write. Config is restored to its original base64 value
+    in ``finally`` (the handler's pfctl calls against a non-resident table are no-ops,
+    so nothing on pf is left to clean up).
+    """
+    vm = smoke_vm
+    # A documentation-range (RFC 5737) IPv4; its /24 network is 198.51.100.0/24.
+    valid_ip = "198.51.100.7"
+    network24 = "198.51.100.0/24"
+    table = "pfBlockerNGsmoke"
+    original = helpers.config_get(vm, CFG_V4SUPPRESSION)
+    try:
+        # REJECT: an invalid IPv4 -> handler exits, no write. This also pins the
+        # before-state of the config node (the network must be absent).
+        assert network24 not in _suppression_entries(vm, CFG_V4SUPPRESSION), (
+            f"{network24} already in v4suppression before the test"
+        )
+        resp = _post_action(
+            webui,
+            {"addsuppress": "Suppress", "ip": "999.999.999.999", "cidr": "32", "table": table},
+        )
+        assert not looks_like_login_page(resp.text), "addsuppress (invalid) POST returned the login form"
+        assert helpers.config_get(vm, CFG_V4SUPPRESSION) == original, (
+            "v4suppression config node changed after a REJECTED (invalid IP) addsuppress POST"
+        )
+
+        # ACCEPT: a valid IPv4 with cidr 24 -> writes the /24 network entry.
+        resp = _post_action(
+            webui,
+            {"addsuppress": "Suppress", "ip": valid_ip, "cidr": "24", "table": table},
+        )
+        assert not looks_like_login_page(resp.text), "addsuppress (valid /24) POST returned the login form"
+        assert network24 in _suppression_entries(vm, CFG_V4SUPPRESSION), (
+            f"{network24} not written to v4suppression after a valid cidr=24 addsuppress POST"
+        )
+    finally:
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_V4SUPPRESSION}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore v4suppression');\n"
+            "echo 'OK';",
+        )

--- a/tests/smoke/ui/test_feeds.py
+++ b/tests/smoke/ui/test_feeds.py
@@ -1,0 +1,221 @@
+"""Tier-B functional WebUI flows for the Feeds page (ADR-14 Phase 3).
+
+Marker ``ui_e2e`` -- daily / on-demand, NOT in the default run nor the PR gate
+(the whole ``tests/smoke`` tree is ``--ignore``d in the default
+``python -m pytest``; this tier runs with
+``pytest tests/smoke -m ui_e2e --override-ini="addopts="``).
+
+What this file establishes: the ``pfblockerng_feeds.php`` save handler persists
+its two distinct deltas to the EFFECTIVE config.xml, and rejects a bad input
+without mutating config. Per the ADR oracle rule, the test reads the box's
+effective state (``config.xml`` via :func:`tests.smoke.helpers.config_get`),
+NEVER the HTTP response body -- a 200 / clean post-redirect does not prove the
+save took; re-reading the config node does.
+
+The Feeds save handler (read END TO END):
+
+* ``isset($_POST['save'])`` gates the whole save.
+* RENAME / COMBINE: for every pre-defined alias the page renders a text input
+  ``feed_<lower(aliasname)>``. A value with a non-word char (``preg_match
+  "/\\W/"``) is rejected -> ``$input_errors`` -> the save aborts WITHOUT
+  ``write_config`` (``if ($config_mod) { if (!$input_errors) { write_config... }
+  }``), so a SINGLE bad field leaves config.xml UNCHANGED. A word-only value
+  (letters/digits/underscore; empty also passes) is written to
+  ``installedpackages/pfblockerngglobal/feed_<lower(aliasname)>``. An empty value
+  is the "default name" state (no override).
+* ALT-URL: the page emits a hidden ``alt_selected`` CSV of every feed header that
+  has alternate URLs, plus, per such header, a hidden ``alt_<header>`` and a set
+  of same-named radios whose values are ``alt_<header>`` (base, checked by
+  default) / ``alt_<altheader>``. On save, for each header in ``alt_selected`` the
+  handler runs ``pfb_filter($_POST['alt_<header>'], PFB_FILTER_WORD)`` and, when
+  non-empty (word-only), stores it at
+  ``installedpackages/pfblockerngglobal/feed_alt_<lower(header)>``.
+
+Every flow is a TRUE transition test (CLAUDE.md): it asserts the BEFORE value,
+drives the CSRF form POST, asserts the AFTER value via the config oracle, then
+RESTORES the box (asserting the reverse where it applies). Restore runs in a
+``finally`` so a mid-test failure cannot poison the session-scoped VM for the
+sibling flows. Branch coverage: the rename validator gets a VALID case (accepted,
+config changes) AND a REJECTING case (config stays unchanged).
+
+Target aliases are pre-defined entries shipped in ``pfblockerng_feeds.json`` and
+stable across the support matrix: the IPv4 alias ``PRI1`` (field ``feed_pri1``)
+for rename, and its feed header ``Abuse_Feodo_C2`` (which carries alternate URLs)
+for the alt-URL flow.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+FEEDS_PAGE = "/pfblockerng/pfblockerng_feeds.php"
+
+# A pre-defined IPv4 alias shipped in pfblockerng_feeds.json. The page renders its
+# rename input as feed_<lower(aliasname)>, and the save writes the override to
+# installedpackages/pfblockerngglobal/feed_<lower(aliasname)>.
+RENAME_ALIAS = "PRI1"
+RENAME_FIELD = "feed_pri1"
+RENAME_CFG = "installedpackages/pfblockerngglobal/feed_pri1"
+# A word-only value (<=24 chars for a non-DNSBL alias, per the handler's length
+# guard) -> accepted and stored verbatim.
+RENAME_VALID = "PRI1renamed"
+# A value containing a space -> preg_match "/\\W/" matches -> input error ->
+# the whole save aborts before write_config, so config.xml stays unchanged.
+RENAME_INVALID = "PRI1 bad"
+
+# A pre-defined feed header (under PRI1) that carries alternate URLs in the JSON,
+# so the page emits its alt_<header> radio group + lists it in alt_selected. The
+# save stores the chosen radio value at feed_alt_<lower(header)>.
+ALT_HEADER = "Abuse_Feodo_C2"
+ALT_FIELD = "alt_Abuse_Feodo_C2"
+ALT_CFG = "installedpackages/pfblockerngglobal/feed_alt_abuse_feodo_c2"
+# The base radio value (default selection) and one alternate radio value. Both are
+# word-only (underscores are word chars) so PFB_FILTER_WORD accepts them verbatim.
+ALT_BASE_VALUE = "alt_Abuse_Feodo_C2"
+ALT_ALTERNATE_VALUE = "alt_Abuse_Feodo_C2_med"
+
+
+def _config_del(vm: helpers.SmokeVM, path: str, *, timeout: float = 60.0) -> None:
+    """Delete a config.xml node and persist, mirroring the package's own delete.
+
+    Used to restore the box to its true pre-test state when a flow CREATES a
+    config node that did not exist before (the form save can only WRITE a value,
+    not remove the node, so a plain re-POST cannot un-create it).
+    """
+    snippet = (
+        f"config_del_path({helpers._php_str(path)});\n"
+        "write_config('pfBlockerNG smoke: feeds test cleanup');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_config_del({path!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def test_feed_rename_save_changes_effective_config(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A valid rename in the Feeds form persists feed_<alias> to config.xml, both ways.
+
+    True transition (CLAUDE.md): the alias override starts empty (the default-name
+    state -- no override stored), the form POST sets it to a word-only name, and
+    config.xml holds that name; then a second POST clears it back to empty and
+    config.xml returns to the default-name state. The green proves the POST CAUSED
+    each change, and both directions of the rename are exercised. Oracle is
+    config.xml read over SSH, never the POST response body.
+    """
+    vm = smoke_vm
+    # Known baseline: no rename override for PRI1 (the default-name state).
+    _config_del(vm, RENAME_CFG)
+    try:
+        # BEFORE: the override is empty (default name in effect).
+        assert helpers.config_get(vm, RENAME_CFG) == "", (
+            f"{RENAME_CFG} is not empty before the rename POST (expected the default-name state)"
+        )
+
+        # RENAME via the real CSRF form; the page must persist the override.
+        resp = webui.post(FEEDS_PAGE, {RENAME_FIELD: RENAME_VALID}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "Feeds rename POST returned the login form (session lost)"
+        assert helpers.config_get(vm, RENAME_CFG) == RENAME_VALID, (
+            f"{RENAME_CFG} did not become {RENAME_VALID!r} after the rename POST (oracle: config.xml, not HTTP body)"
+        )
+
+        # RESTORE via the form: clear the override (empty value is accepted and
+        # writes the default-name state back) -- proves the reverse transition.
+        resp = webui.post(FEEDS_PAGE, {RENAME_FIELD: ""}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "Feeds rename-restore POST returned the login form"
+        assert helpers.config_get(vm, RENAME_CFG) == "", (
+            f"{RENAME_CFG} did not return to the default-name state after clearing the override"
+        )
+    finally:
+        # Belt-and-suspenders: drop the node so a mid-test abort can't leave a
+        # rename override on the session-scoped VM for the sibling flows.
+        _config_del(vm, RENAME_CFG)
+
+
+def test_feed_rename_invalid_alias_is_rejected_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """An invalid alias name is rejected and config.xml stays UNCHANGED.
+
+    Branch coverage paired with the valid case: a value containing a space hits
+    ``preg_match "/\\W/"`` -> ``$input_errors`` -> the save aborts before
+    ``write_config`` (a single bad field blocks the whole save). The transition
+    rule still applies: the test seeds a KNOWN valid override first and asserts it,
+    drives the rejecting POST, then asserts the override is STILL the seeded value
+    -- so the green proves the bad POST did NOT mutate config (not that it merely
+    happened to already hold the expected value).
+    """
+    vm = smoke_vm
+    seeded = "PRI1seed"
+    # Seed a known, valid override via the form so there is a concrete before-value
+    # that a (wrongly) accepted bad POST would overwrite.
+    resp = webui.post(FEEDS_PAGE, {RENAME_FIELD: seeded}, timeout=120.0)
+    assert not looks_like_login_page(resp.text), "Feeds seed POST returned the login form (session lost)"
+    try:
+        # BEFORE: the seeded override is in effect.
+        assert helpers.config_get(vm, RENAME_CFG) == seeded, (
+            f"{RENAME_CFG} was not seeded to {seeded!r} before the reject POST"
+        )
+
+        # REJECT: a space makes the alias invalid -> the save aborts with no write.
+        resp = webui.post(FEEDS_PAGE, {RENAME_FIELD: RENAME_INVALID}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "Feeds invalid-alias POST returned the login form"
+
+        # AFTER: config.xml is UNCHANGED -- the invalid POST wrote nothing.
+        assert helpers.config_get(vm, RENAME_CFG) == seeded, (
+            f"{RENAME_CFG} changed after a rejected invalid-alias POST (it must stay {seeded!r}); "
+            f"the handler should abort write_config when an alias contains a non-word char"
+        )
+    finally:
+        _config_del(vm, RENAME_CFG)
+
+
+def test_feed_alt_url_save_persists_selected_alternate(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Selecting an alternate URL persists feed_alt_<header> to config.xml, both ways.
+
+    True transition (CLAUDE.md): the alt selection for the feed header starts
+    absent / NOT the alternate, the form POST overrides the alt_<header> radio to
+    an ALTERNATE value, and config.xml stores that exact value at
+    feed_alt_<lower(header)>; then a second POST selects the BASE value and
+    config.xml holds the base instead. The oracle is config.xml read over SSH.
+
+    The save writes the value of ``pfb_filter($_POST['alt_<header>'],
+    PFB_FILTER_WORD)`` (word-only passes verbatim) -- so the stored node equals
+    the chosen radio value. The node is created by this flow, so the ``finally``
+    deletes it (a form POST can only set a value, not remove the node) to leave
+    the box truly clean for the sibling flows.
+    """
+    vm = smoke_vm
+    # Known baseline: no alt-URL override for this header.
+    _config_del(vm, ALT_CFG)
+    try:
+        # BEFORE: no alternate selected (default-name/base state, node absent).
+        before = helpers.config_get(vm, ALT_CFG)
+        assert before != ALT_ALTERNATE_VALUE, (
+            f"{ALT_CFG} already equals the alternate {ALT_ALTERNATE_VALUE!r} before the POST"
+        )
+
+        # SELECT the alternate URL via the form's radio for this header.
+        resp = webui.post(FEEDS_PAGE, {ALT_FIELD: ALT_ALTERNATE_VALUE}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "Feeds alt-URL POST returned the login form (session lost)"
+        assert helpers.config_get(vm, ALT_CFG) == ALT_ALTERNATE_VALUE, (
+            f"{ALT_CFG} did not become {ALT_ALTERNATE_VALUE!r} after selecting the alternate "
+            f"(oracle: config.xml, not the HTTP body)"
+        )
+
+        # SELECT the base URL back via the form -- proves the reverse transition.
+        resp = webui.post(FEEDS_PAGE, {ALT_FIELD: ALT_BASE_VALUE}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "Feeds alt-URL restore POST returned the login form"
+        assert helpers.config_get(vm, ALT_CFG) == ALT_BASE_VALUE, (
+            f"{ALT_CFG} did not become the base {ALT_BASE_VALUE!r} after re-selecting the base URL"
+        )
+    finally:
+        # The flow CREATED this node; drop it so the box is left as it started.
+        _config_del(vm, ALT_CFG)

--- a/tests/smoke/ui/test_feeds.py
+++ b/tests/smoke/ui/test_feeds.py
@@ -23,13 +23,17 @@ The Feeds save handler (read END TO END):
   (letters/digits/underscore; empty also passes) is written to
   ``installedpackages/pfblockerngglobal/feed_<lower(aliasname)>``. An empty value
   is the "default name" state (no override).
-* ALT-URL: the page emits a hidden ``alt_selected`` CSV of every feed header that
-  has alternate URLs, plus, per such header, a hidden ``alt_<header>`` and a set
-  of same-named radios whose values are ``alt_<header>`` (base, checked by
-  default) / ``alt_<altheader>``. On save, for each header in ``alt_selected`` the
-  handler runs ``pfb_filter($_POST['alt_<header>'], PFB_FILTER_WORD)`` and, when
-  non-empty (word-only), stores it at
-  ``installedpackages/pfblockerngglobal/feed_alt_<lower(header)>``.
+
+ALT-URL save is intentionally NOT covered here -- it is deferred to the browser
+tier (Batch 4). The handler iterates EVERY header in the hidden ``alt_selected``
+CSV and, for each, requires a non-empty ``alt_<header>`` POST value, else it sets
+``$input_errors`` and the whole save aborts before ``write_config``. The page
+emits, per header, a same-named ``<input type=hidden value="">`` alongside the
+checked base radio; reproducing the browser's multi-value same-name POST (hidden
+"" + checked radio value) is exactly what :func:`scrape_form_fields` cannot do
+faithfully -- it resolves the collision to the empty value, so every alt header
+POSTs empty and the save errors. Driving the actual radio click (Playwright)
+sends the right values, so this flow belongs in the browser tier, not here.
 
 Every flow is a TRUE transition test (CLAUDE.md): it asserts the BEFORE value,
 drives the CSRF form POST, asserts the AFTER value via the config oracle, then
@@ -38,10 +42,9 @@ RESTORES the box (asserting the reverse where it applies). Restore runs in a
 sibling flows. Branch coverage: the rename validator gets a VALID case (accepted,
 config changes) AND a REJECTING case (config stays unchanged).
 
-Target aliases are pre-defined entries shipped in ``pfblockerng_feeds.json`` and
+Target alias is a pre-defined entry shipped in ``pfblockerng_feeds.json`` and
 stable across the support matrix: the IPv4 alias ``PRI1`` (field ``feed_pri1``)
-for rename, and its feed header ``Abuse_Feodo_C2`` (which carries alternate URLs)
-for the alt-URL flow.
+for the rename flows.
 """
 
 from __future__ import annotations
@@ -72,17 +75,6 @@ RENAME_VALID = "PRI1renamed"
 # A value containing a space -> preg_match "/\\W/" matches -> input error ->
 # the whole save aborts before write_config, so config.xml stays unchanged.
 RENAME_INVALID = "PRI1 bad"
-
-# A pre-defined feed header (under PRI1) that carries alternate URLs in the JSON,
-# so the page emits its alt_<header> radio group + lists it in alt_selected. The
-# save stores the chosen radio value at feed_alt_<lower(header)>.
-ALT_HEADER = "Abuse_Feodo_C2"
-ALT_FIELD = "alt_Abuse_Feodo_C2"
-ALT_CFG = "installedpackages/pfblockerngglobal/feed_alt_abuse_feodo_c2"
-# The base radio value (default selection) and one alternate radio value. Both are
-# word-only (underscores are word chars) so PFB_FILTER_WORD accepts them verbatim.
-ALT_BASE_VALUE = "alt_Abuse_Feodo_C2"
-ALT_ALTERNATE_VALUE = "alt_Abuse_Feodo_C2_med"
 
 
 def _config_del(vm: helpers.SmokeVM, path: str, *, timeout: float = 60.0) -> None:
@@ -175,47 +167,3 @@ def test_feed_rename_invalid_alias_is_rejected_config_unchanged(webui: WebUI, sm
         )
     finally:
         _config_del(vm, RENAME_CFG)
-
-
-def test_feed_alt_url_save_persists_selected_alternate(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
-    """Selecting an alternate URL persists feed_alt_<header> to config.xml, both ways.
-
-    True transition (CLAUDE.md): the alt selection for the feed header starts
-    absent / NOT the alternate, the form POST overrides the alt_<header> radio to
-    an ALTERNATE value, and config.xml stores that exact value at
-    feed_alt_<lower(header)>; then a second POST selects the BASE value and
-    config.xml holds the base instead. The oracle is config.xml read over SSH.
-
-    The save writes the value of ``pfb_filter($_POST['alt_<header>'],
-    PFB_FILTER_WORD)`` (word-only passes verbatim) -- so the stored node equals
-    the chosen radio value. The node is created by this flow, so the ``finally``
-    deletes it (a form POST can only set a value, not remove the node) to leave
-    the box truly clean for the sibling flows.
-    """
-    vm = smoke_vm
-    # Known baseline: no alt-URL override for this header.
-    _config_del(vm, ALT_CFG)
-    try:
-        # BEFORE: no alternate selected (default-name/base state, node absent).
-        before = helpers.config_get(vm, ALT_CFG)
-        assert before != ALT_ALTERNATE_VALUE, (
-            f"{ALT_CFG} already equals the alternate {ALT_ALTERNATE_VALUE!r} before the POST"
-        )
-
-        # SELECT the alternate URL via the form's radio for this header.
-        resp = webui.post(FEEDS_PAGE, {ALT_FIELD: ALT_ALTERNATE_VALUE}, timeout=120.0)
-        assert not looks_like_login_page(resp.text), "Feeds alt-URL POST returned the login form (session lost)"
-        assert helpers.config_get(vm, ALT_CFG) == ALT_ALTERNATE_VALUE, (
-            f"{ALT_CFG} did not become {ALT_ALTERNATE_VALUE!r} after selecting the alternate "
-            f"(oracle: config.xml, not the HTTP body)"
-        )
-
-        # SELECT the base URL back via the form -- proves the reverse transition.
-        resp = webui.post(FEEDS_PAGE, {ALT_FIELD: ALT_BASE_VALUE}, timeout=120.0)
-        assert not looks_like_login_page(resp.text), "Feeds alt-URL restore POST returned the login form"
-        assert helpers.config_get(vm, ALT_CFG) == ALT_BASE_VALUE, (
-            f"{ALT_CFG} did not become the base {ALT_BASE_VALUE!r} after re-selecting the base URL"
-        )
-    finally:
-        # The flow CREATED this node; drop it so the box is left as it started.
-        _config_del(vm, ALT_CFG)

--- a/tests/smoke/ui/test_hooks.py
+++ b/tests/smoke/ui/test_hooks.py
@@ -1,0 +1,383 @@
+"""Tier-B functional WebUI flows for the Update Hooks page (ADR-12 / ADR-14).
+
+Marker ``ui_e2e`` -- daily / on-demand, NOT in the default run nor the PR gate
+(the whole ``tests/smoke`` tree is ``--ignore``d in the default
+``python -m pytest``; this tier runs with
+``pytest tests/smoke -m ui_e2e --override-ini="addopts="``).
+
+The RENDER and add-row browser coverage for ``pfblockerng_hooks.php`` already
+landed in PR #107 (``test_render_smoke`` + ``test_browser``). THIS file is the
+FUNCTIONAL (config round-trip) tier for the page's save handler: it drives the
+real CSRF form POST and proves the EFFECTIVE state -- ``config.xml`` read via
+:func:`tests.smoke.helpers.config_get`, NEVER the HTTP response body -- moved (or
+did NOT move, on a reject).
+
+What the save handler does (read END TO END from
+``src/usr/local/www/pfblockerng/pfblockerng_hooks.php``):
+
+* It is a repeatable ``rowhelper``. Each hook row ``N`` carries the POST fields
+  ``hook_command-N`` (text), ``hook_when-N`` (select ``pre``/``post``),
+  ``hook_enabled-N`` (checkbox, value ``on`` -- absent when unchecked),
+  ``hook_timeout-N`` (number) and ``hook_description-N`` (text). The empty render
+  shows ONE placeholder row keyed ``0``.
+* On ``isset($_POST['save'])`` it collects every ``field-rowid`` key, validates
+  each, and -- only if there are NO input errors -- rebuilds the list and writes
+  it to ``installedpackages/pfblockerng/config/0/hooks/row`` (the ``row`` listtag,
+  so 1..N rows round-trip through config.xml). The per-entry shape is
+  ``{command, when, enabled, description, timeout}``.
+* An EMPTY resulting list deletes the whole node:
+  ``config_del_path('installedpackages/pfblockerng/config/0/hooks')``.
+* Validation rejects (config stays UNCHANGED -- no write_config) when: a
+  ``hook_when`` value is not ``pre``/``post``; a ``hook_command`` is empty (after
+  trim) or holds control chars; a non-empty ``hook_timeout`` is not digits-only
+  (``pfb_filter(..., PFB_FILTER_NUM)`` -> ``''``); a ``hook_description`` holds
+  control chars; or any field value is a non-scalar.
+
+Every flow is a TRUE transition test (CLAUDE.md): it asserts the BEFORE-state,
+drives the form, asserts the AFTER-state via config.xml, and -- in a ``finally``
+-- restores the box (``clear_update_hooks`` deletes the node) so a mid-test
+failure can't poison the session-scoped VM for the sibling flows / Tier A. The
+reject flows assert the seeded value is STILL present after the rejected POST, so
+a green proves the validator blocked the write (not that the write happened to
+land the same value).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+HOOKS_PAGE = "/pfblockerng/pfblockerng_hooks.php"
+
+# config.xml nodes the save handler writes. Row 0 is the first (and, in these
+# single-row flows, only) entry; 'row' is the listtag so a lone hook is
+# row/0/<field>, never collapsed (see the page's save block + pfb_get_hooks()).
+CFG_HOOKS = helpers.CFG_HOOKS  # installedpackages/pfblockerng/config/0/hooks
+CFG_HOOKS_ROW = helpers.CFG_HOOKS_ROW  # .../hooks/row
+ROW0 = CFG_HOOKS_ROW + "/0"
+ROW0_COMMAND = ROW0 + "/command"
+ROW0_WHEN = ROW0 + "/when"
+ROW0_ENABLED = ROW0 + "/enabled"
+ROW0_TIMEOUT = ROW0 + "/timeout"
+ROW0_DESCRIPTION = ROW0 + "/description"
+
+# A delimiter-fenced sentinel for reading PHP truthiness over pfSsh.php (whose
+# startup banner would otherwise pollute the value). Mirrors helpers.config_get.
+_OPEN = "<<<HOOKVAL>>>"
+_CLOSE = "<<<HOOKEND>>>"
+
+
+def _hooks_node_exists(vm: helpers.SmokeVM) -> bool:
+    """True iff the ``hooks`` config node exists at all (array present).
+
+    ``config_get`` casts to string, which is useless for "does the array node
+    exist" (an empty array -> ``''`` is indistinguishable from a deleted node).
+    Read the node directly and report whether it is an array, fenced so the
+    pfSsh.php banner can't pollute the answer. The empty-list save path deletes
+    the whole node (``config_del_path('.../hooks')``), so this is the oracle for
+    that branch.
+    """
+    snippet = f"$h = config_get_path('{CFG_HOOKS}', null);\necho '{_OPEN}' . (is_array($h) ? '1' : '0') . '{_CLOSE}';"
+    result = helpers.php_eval(vm, snippet)
+    out = result.stdout
+    start = out.find(_OPEN)
+    end = out.find(_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"_hooks_node_exists: no fenced value: rc={result.returncode} out={out!r}")
+    return out[start + len(_OPEN) : end] == "1"
+
+
+def _seed_one_hook(
+    vm: helpers.SmokeVM,
+    *,
+    command: str,
+    when: str = "post",
+    enabled: str = "",
+    timeout: str = "",
+    description: str = "",
+) -> None:
+    """Persist exactly ONE hook row via the same config path the UI writes.
+
+    Uses :func:`helpers.set_update_hooks` (writes ``hooks/row`` under the listtag
+    and read-back-guards the count), so the seeded box is byte-identical to what a
+    real save would leave -- a sound BEFORE-state for the reject flows and the
+    enabled-toggle flow.
+    """
+    helpers.set_update_hooks(
+        vm,
+        [
+            {
+                "command": command,
+                "when": when,
+                "enabled": enabled,
+                "description": description,
+                "timeout": timeout,
+            }
+        ],
+    )
+
+
+def test_save_one_hook_row_persists_to_config(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """POSTing one valid hook row writes {command,when,timeout} to config.xml.
+
+    Transition: BEFORE there is NO hooks node (cleared first); the form POST must
+    CREATE the row, persisting each field at ``hooks/row/0/<field>``. Oracle =
+    config.xml, never the HTTP body. Restored (node deleted) in ``finally``.
+    """
+    vm = smoke_vm
+    command = "/usr/bin/true # pfb-smoke-save"
+    helpers.clear_update_hooks(vm)
+    try:
+        # BEFORE: no hooks node at all (empty-list save path deletes it).
+        assert not _hooks_node_exists(vm), "hooks node present before the save flow seeded anything"
+
+        # The empty render is a single placeholder row keyed 0; override its
+        # fields. webui.post re-scrapes the form (current fields + fresh CSRF
+        # token), applies overrides, adds the save button, and POSTs back.
+        resp = webui.post(
+            HOOKS_PAGE,
+            {
+                "hook_command-0": command,
+                "hook_when-0": "post",
+                "hook_timeout-0": "45",
+                "hook_description-0": "smoke save",
+                "hook_enabled-0": "on",
+            },
+            timeout=120.0,
+        )
+        assert not looks_like_login_page(resp.text), "hooks save POST returned the login form (session lost)"
+
+        # AFTER: the row landed under the 'row' listtag at index 0.
+        assert _hooks_node_exists(vm), "hooks node absent after a valid save"
+        assert helpers.config_get(vm, ROW0_COMMAND) == command, (
+            f"command not persisted: got {helpers.config_get(vm, ROW0_COMMAND)!r}"
+        )
+        assert helpers.config_get(vm, ROW0_WHEN) == "post", (
+            f"when not persisted: got {helpers.config_get(vm, ROW0_WHEN)!r}"
+        )
+        assert helpers.config_get(vm, ROW0_TIMEOUT) == "45", (
+            f"timeout not persisted: got {helpers.config_get(vm, ROW0_TIMEOUT)!r}"
+        )
+        assert helpers.config_get(vm, ROW0_DESCRIPTION) == "smoke save", (
+            f"description not persisted: got {helpers.config_get(vm, ROW0_DESCRIPTION)!r}"
+        )
+        assert helpers.config_get(vm, ROW0_ENABLED) == "on", (
+            f"enabled not persisted: got {helpers.config_get(vm, ROW0_ENABLED)!r}"
+        )
+    finally:
+        helpers.clear_update_hooks(vm)
+
+
+def test_enabled_toggle_off_then_on(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """The per-row enabled checkbox round-trips both ways through the save handler.
+
+    Branch coverage (CLAUDE.md): exercise the checkbox OFF *and* ON. The handler
+    stores ``'on'`` only when ``hook_enabled-N === 'on'`` is present, else ``''``
+    (an unchecked browser checkbox sends nothing). Transition: seed enabled ON,
+    assert ON, POST with the box CLEARED -> assert ``''``, POST with it set ->
+    assert ``'on'`` again. The command stays valid throughout so the save is never
+    rejected for an unrelated reason. Restored in ``finally``.
+    """
+    vm = smoke_vm
+    command = "/usr/bin/true # pfb-smoke-toggle"
+    helpers.clear_update_hooks(vm)
+    _seed_one_hook(vm, command=command, when="post", enabled="on")
+    try:
+        # BEFORE: enabled is ON as seeded.
+        assert helpers.config_get(vm, ROW0_ENABLED) == "on", "seed did not store enabled=on"
+
+        # OFF: omit hook_enabled-0 (a cleared browser checkbox sends nothing).
+        # scrape_form_fields drops the unchecked box automatically once it is
+        # cleared, but the seeded row renders it CHECKED, so the scrape WOULD
+        # re-send 'on'; override it to '' to clear it (the handler stores ''
+        # for any value != 'on').
+        resp = webui.post(HOOKS_PAGE, {"hook_enabled-0": ""}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "toggle-off POST returned the login form"
+        assert helpers.config_get(vm, ROW0_ENABLED) == "", (
+            f"enabled not cleared: got {helpers.config_get(vm, ROW0_ENABLED)!r}"
+        )
+        # The rest of the row must be intact (proves only the toggle changed).
+        assert helpers.config_get(vm, ROW0_COMMAND) == command, "command lost on the toggle-off save"
+
+        # ON again: send the checkbox value 'on'.
+        resp = webui.post(HOOKS_PAGE, {"hook_enabled-0": "on"}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "toggle-on POST returned the login form"
+        assert helpers.config_get(vm, ROW0_ENABLED) == "on", (
+            f"enabled not re-set: got {helpers.config_get(vm, ROW0_ENABLED)!r}"
+        )
+    finally:
+        helpers.clear_update_hooks(vm)
+
+
+def test_when_pre_vs_post_persists(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """The 'When' select stores pre vs post correctly (both select branches).
+
+    Branch coverage: the ``hook_when`` select has two valid options; exercise
+    BOTH. Transition: seed when=post, assert post, POST when=pre -> assert pre,
+    POST when=post -> assert post. The command stays valid so neither save is
+    rejected. Restored in ``finally``.
+    """
+    vm = smoke_vm
+    command = "/usr/bin/true # pfb-smoke-when"
+    helpers.clear_update_hooks(vm)
+    _seed_one_hook(vm, command=command, when="post", enabled="on")
+    try:
+        # BEFORE: when is post as seeded.
+        assert helpers.config_get(vm, ROW0_WHEN) == "post", "seed did not store when=post"
+
+        # Flip to pre.
+        resp = webui.post(HOOKS_PAGE, {"hook_when-0": "pre"}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "when=pre POST returned the login form"
+        assert helpers.config_get(vm, ROW0_WHEN) == "pre", (
+            f"when not stored as pre: got {helpers.config_get(vm, ROW0_WHEN)!r}"
+        )
+
+        # Flip back to post (reverse transition).
+        resp = webui.post(HOOKS_PAGE, {"hook_when-0": "post"}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "when=post POST returned the login form"
+        assert helpers.config_get(vm, ROW0_WHEN) == "post", (
+            f"when not stored back as post: got {helpers.config_get(vm, ROW0_WHEN)!r}"
+        )
+    finally:
+        helpers.clear_update_hooks(vm)
+
+
+def test_remove_to_empty_deletes_node(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Clearing the only row to empty deletes the whole hooks node.
+
+    The save handler builds the list from POST and, when it is empty, calls
+    ``config_del_path('.../hooks')`` -- the node is GONE, not an empty array.
+    Transition: BEFORE the node exists with one row; emptying the lone row's
+    command makes the handler reject (empty command), so to reach the delete
+    branch the row must vanish from the POST entirely.
+
+    The empty-list branch fires when no ``hook_*`` rowhelper keys survive. A
+    browser hits it by deleting the row (the JS strips its inputs); over HTTP we
+    reproduce that by POSTing a payload with NO ``hook_*-N`` keys at all -- so
+    ``$rowhelper_exist`` is empty, ``$hooks`` is empty, and the node is deleted.
+    Oracle = the node is absent. Restored (already empty) in ``finally``.
+    """
+    vm = smoke_vm
+    command = "/usr/bin/true # pfb-smoke-remove"
+    helpers.clear_update_hooks(vm)
+    _seed_one_hook(vm, command=command, when="post", enabled="on")
+    try:
+        # BEFORE: the node exists with the seeded row.
+        assert _hooks_node_exists(vm), "seeded hooks node missing before the remove flow"
+        assert helpers.config_get(vm, ROW0_COMMAND) == command, "seed command missing before the remove flow"
+
+        # Reproduce a row delete: GET the form for a fresh CSRF token, then POST
+        # back ONLY the token + the save button (no hook_*-N fields). The handler
+        # finds no rowhelper keys -> empty list -> config_del_path on the node.
+        from .webui import extract_csrf_token
+
+        form = webui.get(HOOKS_PAGE)
+        assert not looks_like_login_page(form.text), "hooks GET returned the login form (session lost)"
+        token = extract_csrf_token(form.text)
+        resp = webui.session.post(
+            webui.url(HOOKS_PAGE),
+            data={"__csrf_magic": token, "save": "save"},
+            verify=False,
+            timeout=120.0,
+        )
+        assert not looks_like_login_page(resp.text), "empty-save POST returned the login form"
+
+        # AFTER: the node is gone entirely (config_del_path), not an empty array.
+        assert not _hooks_node_exists(vm), "hooks node still present after emptying the list"
+    finally:
+        helpers.clear_update_hooks(vm)
+
+
+def test_reject_empty_command_leaves_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """An empty command is rejected; config stays exactly as it was.
+
+    Validator branch: ``trim($value) === ''`` -> input error -> NO write_config.
+    Transition: seed a valid hook, assert the seeded command, POST an EMPTY
+    ``hook_command-0`` -> the save must be rejected, so the seeded command is
+    STILL there (a green proves the validator blocked the write). Restored in
+    ``finally``.
+    """
+    vm = smoke_vm
+    command = "/usr/bin/true # pfb-smoke-reject-empty"
+    helpers.clear_update_hooks(vm)
+    _seed_one_hook(vm, command=command, when="post", enabled="on")
+    try:
+        # BEFORE: the seeded command is present.
+        assert helpers.config_get(vm, ROW0_COMMAND) == command, "seed command missing before the reject flow"
+
+        resp = webui.post(HOOKS_PAGE, {"hook_command-0": ""}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "empty-command POST returned the login form"
+
+        # AFTER (reject): config UNCHANGED -- the original command persists.
+        assert _hooks_node_exists(vm), "hooks node deleted by a REJECTED empty-command save"
+        assert helpers.config_get(vm, ROW0_COMMAND) == command, (
+            f"empty command was NOT rejected -- config changed to {helpers.config_get(vm, ROW0_COMMAND)!r}"
+        )
+    finally:
+        helpers.clear_update_hooks(vm)
+
+
+def test_reject_bad_when_leaves_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A 'When' value outside {pre,post} is rejected; config stays unchanged.
+
+    Validator branch: ``!array_key_exists($value, $options_when)`` -> input error
+    -> NO write_config. The select renders only pre/post, so this forces a crafted
+    out-of-range value over HTTP. Transition: seed when=post, assert post, POST a
+    bogus ``hook_when-0`` -> rejected, so when is STILL post. Restored in
+    ``finally``.
+    """
+    vm = smoke_vm
+    command = "/usr/bin/true # pfb-smoke-reject-when"
+    helpers.clear_update_hooks(vm)
+    _seed_one_hook(vm, command=command, when="post", enabled="on")
+    try:
+        # BEFORE: when is post.
+        assert helpers.config_get(vm, ROW0_WHEN) == "post", "seed did not store when=post"
+
+        resp = webui.post(HOOKS_PAGE, {"hook_when-0": "sideways"}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "bad-when POST returned the login form"
+
+        # AFTER (reject): when unchanged.
+        assert helpers.config_get(vm, ROW0_WHEN) == "post", (
+            f"bad 'when' was NOT rejected -- config changed to {helpers.config_get(vm, ROW0_WHEN)!r}"
+        )
+    finally:
+        helpers.clear_update_hooks(vm)
+
+
+def test_reject_nonnumeric_timeout_leaves_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A non-numeric timeout is rejected; config stays unchanged.
+
+    Validator branch: a non-empty timeout that ``pfb_filter(..., PFB_FILTER_NUM)``
+    reduces to ``''`` (i.e. not digits-only) -> input error -> NO write_config.
+    Transition: seed timeout=60, assert 60, POST a non-numeric ``hook_timeout-0``
+    -> rejected, so the timeout is STILL 60. (An empty timeout is the accepted
+    'use default' branch, exercised by the save flow above, which posts a numeric
+    value -- this proves the REJECT side.) Restored in ``finally``.
+    """
+    vm = smoke_vm
+    command = "/usr/bin/true # pfb-smoke-reject-timeout"
+    helpers.clear_update_hooks(vm)
+    _seed_one_hook(vm, command=command, when="post", enabled="on", timeout="60")
+    try:
+        # BEFORE: timeout is the seeded numeric value.
+        assert helpers.config_get(vm, ROW0_TIMEOUT) == "60", "seed did not store timeout=60"
+
+        resp = webui.post(HOOKS_PAGE, {"hook_timeout-0": "abc"}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "bad-timeout POST returned the login form"
+
+        # AFTER (reject): timeout unchanged.
+        assert helpers.config_get(vm, ROW0_TIMEOUT) == "60", (
+            f"non-numeric timeout was NOT rejected -- config changed to {helpers.config_get(vm, ROW0_TIMEOUT)!r}"
+        )
+    finally:
+        helpers.clear_update_hooks(vm)

--- a/tests/smoke/ui/test_log.py
+++ b/tests/smoke/ui/test_log.py
@@ -1,0 +1,420 @@
+"""Tier-B functional flows for the Log/File browser (pfblockerng_log.php).
+
+Marker ``ui_e2e`` -- daily / on-demand, NOT in the default run nor the PR gate
+(the whole ``tests/smoke`` tree is ``--ignore``d in the default
+``python -m pytest``; this tier is run with
+``pytest tests/smoke -m ui_e2e --override-ini="addopts="``).
+
+What this file establishes: pfblockerng_log.php's three AJAX/POST actions act on
+REAL files on the box, and its path validator (``pfb_validate_filepath``) is a
+true gate. The oracle is therefore the on-box file state read over SSH (cat /
+stat), NEVER the HTTP response body -- a 200 (or a ``|0|...|`` AJAX envelope) does
+not prove the file was read/cleared; re-reading the file does.
+
+The handler is NOT a Form save (no ``isset($_POST['save'])`` gate), so these POSTs
+are crafted by hand exactly as the page's own JavaScript does: GET the page to
+harvest the freshly-injected ``__csrf_magic`` token, then ``session.post`` the
+minimal field set (``ajax``/``action``/``file`` for load; ``logFile``+``clear`` /
+``logFile``+``download`` for the file actions). webui.post()'s form-scrape helper
+is deliberately avoided -- it would re-submit the whole rendered form and append a
+phantom ``save`` button, neither of which this handler reads.
+
+Every flow is a TRUE transition test (CLAUDE.md transition-test rule):
+
+* load -- seed a KNOWN line into the target log first (BEFORE-state asserted over
+  SSH), then prove the AJAX body returns exactly that content; a rejecting path
+  is proven by the ``|3|Invalid filename/path|`` envelope AND the unrelated file
+  staying untouched.
+* download -- seed a file, prove the download body + ``Content-Disposition`` carry
+  it; the rejecting path is proven by the reject envelope and no body bytes.
+* clear (the destructive branch worth the page) -- SEED non-empty content and
+  assert it is non-empty (BEFORE), POST clear, then assert the AFTER on-box state
+  for EACH of the handler's three distinct clear shapes:
+    - a plain default log (``ip_block.log``)        -> ``unlink_if_exists``  -> ABSENT
+    - ``py_error.log``                              -> ``ftruncate(0)``      -> EXISTS, size 0
+    - ``dnsbl.log`` (the unbound re-touch special)  -> unlink + re-``touch`` -> EXISTS, size 0
+  An invalid path is rejected with config/files untouched.
+
+Each flow RESTORES the box (removes the seeded file / leaves the cleared file
+gone) in a ``finally`` so a mid-test failure cannot poison the session-scoped VM
+for the sibling flows.
+"""
+
+from __future__ import annotations
+
+import base64
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .webui import extract_csrf_token, looks_like_login_page
+
+if TYPE_CHECKING:
+    import requests
+
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+# The page path and the absolute directory whose files the validator allows for
+# the ``defaultlogs`` type. ``$pfb['logdir']`` == ``$g['varlog_path']/pfblockerng``
+# == ``/var/log/pfblockerng`` (pfblockerng.inc:45, globals varlog_path=/var/log);
+# the validator's allow-set is the set of every logtype's ``logdir`` (each with a
+# trailing '/'), and ``pfb_validate_filepath`` matches a file iff its dirname '/'
+# is in that set. ``defaultlogs`` is the only type whose files we both control and
+# can clear, so every flow targets a file directly under this dir.
+LOG_PAGE = "/pfblockerng/pfblockerng_log.php"
+LOG_DIR = "/var/log/pfblockerng"
+
+# A path the validator REJECTS: its dirname is not any logtype's logdir (no
+# traversal escapes the allow-set). ``/etc/passwd`` is the canonical "would be a
+# disaster if it leaked / got truncated" target -- the handler must refuse it.
+EVIL_PATH = "/etc/passwd"
+
+
+def _csrf(webui: WebUI) -> str:
+    """GET the log page and return its freshly-injected ``__csrf_magic`` token.
+
+    csrf-magic rewrites the token per render, so it must be re-harvested for each
+    manual POST (cf. webui.post's re-GET). Asserts the GET is authenticated so a
+    dropped session fails loudly here, not as an opaque CSRF rejection later.
+    """
+    resp = webui.get(LOG_PAGE)
+    assert not looks_like_login_page(resp.text), "log page GET returned the login form (session lost)"
+    return extract_csrf_token(resp.text)
+
+
+def _post_load(webui: WebUI, token: str, file_path: str, *, timeout: float = 60.0) -> requests.Response:
+    """POST the page's ``act=load`` AJAX exactly as its JS does (+ the CSRF token).
+
+    The handler keys on ``$_REQUEST['ajax']`` being set and ``action == 'load'``,
+    reading the target from ``$_REQUEST['file']`` (NOT ``logFile``). Returns the
+    raw response so the caller can parse the ``|code|info|base64|`` envelope.
+    """
+    return webui.session.post(
+        webui.url(LOG_PAGE),
+        data={"__csrf_magic": token, "ajax": "ajax", "action": "load", "file": file_path},
+        verify=webui._verify,
+        timeout=timeout,
+    )
+
+
+def _post_clear(webui: WebUI, token: str, log_file: str, *, timeout: float = 120.0) -> requests.Response:
+    """POST the download/clear handler in CLEAR mode (``logFile`` + ``clear``).
+
+    The handler gates on ``logFile`` non-empty AND (isset(download) || isset(clear)),
+    then takes the clear branch on a TRUTHY ``clear`` -- so the value must be a
+    non-empty string (the page's JS sends ``'clear'``).
+    """
+    return webui.session.post(
+        webui.url(LOG_PAGE),
+        data={"__csrf_magic": token, "logFile": log_file, "clear": "clear"},
+        verify=webui._verify,
+        timeout=timeout,
+    )
+
+
+def _post_download(webui: WebUI, token: str, log_file: str, *, timeout: float = 60.0) -> requests.Response:
+    """POST the download/clear handler in DOWNLOAD mode (``logFile`` + ``download``).
+
+    ``clear`` is sent EMPTY so the ``if ($pconfig['clear'])`` branch is falsy and
+    control reaches the ``elseif ($pconfig['download'])`` download branch.
+    """
+    return webui.session.post(
+        webui.url(LOG_PAGE),
+        data={"__csrf_magic": token, "logFile": log_file, "download": "download", "clear": ""},
+        verify=webui._verify,
+        timeout=timeout,
+    )
+
+
+def _seed_file(vm: helpers.SmokeVM, path: str, contents: str) -> None:
+    """Write ``contents`` to ``path`` on the guest via a direct ``tee`` argv.
+
+    Direct argv (never ``ssh sh -c``, which double-parses under the root tcsh
+    login shell). The log dir is created by a pfBlockerNG reload, but POST-INSTALL
+    may not have run one yet, so ``mkdir -p`` it first.
+    """
+    mk = vm.ssh("/bin/mkdir", "-p", LOG_DIR)
+    assert mk.returncode == 0, f"mkdir {LOG_DIR} failed: {mk.stderr!r}"
+    res = subprocess.run(
+        vm.ssh_argv("tee", path),
+        input=contents,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert res.returncode == 0, f"seed {path} failed: {res.stderr!r}"
+
+
+def _cat(vm: helpers.SmokeVM, path: str) -> str:
+    """Return the on-box file contents (the load/download oracle), '' if absent."""
+    res = vm.ssh("/bin/cat", path)
+    return res.stdout if res.returncode == 0 else ""
+
+
+def _exists(vm: helpers.SmokeVM, path: str) -> bool:
+    """True iff ``path`` exists on the guest (stat rc; the clear oracle)."""
+    return vm.ssh("/usr/bin/stat", "-f", "%z", path).returncode == 0
+
+
+def _size(vm: helpers.SmokeVM, path: str) -> int:
+    """Byte size of ``path`` on the guest via ``stat -f %z`` (assumes it exists)."""
+    res = vm.ssh("/usr/bin/stat", "-f", "%z", path)
+    assert res.returncode == 0, f"stat {path} failed (absent?): {res.stderr!r}"
+    return int(res.stdout.strip())
+
+
+def _rm(vm: helpers.SmokeVM, path: str) -> None:
+    """Best-effort delete (teardown); never raises so a finally can't mask a fault."""
+    vm.ssh("/bin/rm", "-f", path)
+
+
+def _decode_load_body(body: str) -> tuple[str, str]:
+    """Parse the ``|code|info|base64|`` AJAX envelope -> ``(code, decoded_text)``.
+
+    The handler prints ``|<code>|<info>|<base64-of-content>|``; on the load path
+    code '0' is success and the third field is base64 of the file's (html-escaped)
+    bytes. Mirrors the page's JS (``responseText.split('|')`` then ``atob``).
+    """
+    parts = body.split("|")
+    # parts[0] is the leading '' before the first '|'; [1]=code, [2]=info, [3]=b64.
+    code = parts[1] if len(parts) > 1 else ""
+    b64 = parts[3] if len(parts) > 3 else ""
+    try:
+        decoded = base64.b64decode(b64).decode("utf-8", "replace")
+    except (ValueError, IndexError):
+        decoded = ""
+    return code, decoded
+
+
+# --------------------------------------------------------------------------- #
+# act=load
+# --------------------------------------------------------------------------- #
+
+
+def test_load_returns_real_file_content(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """``act=load`` returns the actual on-box content of a validated log file.
+
+    Transition: seed a known line (assert it landed on the box -- BEFORE), then
+    prove the AJAX body decodes to exactly that content (code '0'), i.e. the
+    handler read the real file. Oracle pairs the decoded envelope WITH an SSH cat
+    so the body is proven to equal the file, not merely "some 200". Restored by
+    removing the seed file in finally.
+    """
+    vm = smoke_vm
+    target = f"{LOG_DIR}/pfblockerng.log"
+    marker = f"pfb-ui-load-{helpers.unique_domain('load')}"
+    expected = f"{marker}\n"
+    _seed_file(vm, target, expected)
+    try:
+        # BEFORE: the seed is the file's content on the box.
+        assert _cat(vm, target) == expected, "seed line not present on the box before load"
+
+        token = _csrf(webui)
+        resp = _post_load(webui, token, target)
+        assert not looks_like_login_page(resp.text), "load POST returned the login form (session lost)"
+        code, decoded = _decode_load_body(resp.text)
+        assert code == "0", f"load did not report success: envelope={resp.text!r}"
+        # AFTER (oracle): the returned content equals the file's actual content.
+        assert decoded == _cat(vm, target), (
+            f"load body content {decoded!r} != on-box file {_cat(vm, target)!r} (handler must return the real file)"
+        )
+        assert marker in decoded, f"seeded marker missing from the loaded content: {decoded!r}"
+    finally:
+        _rm(vm, target)
+
+
+def test_load_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """``act=load`` of a path outside every logtype dir is refused (no traversal).
+
+    The validator (`pfb_validate_filepath`) only admits files whose dirname is one
+    of the logtype logdirs, so ``/etc/passwd`` is rejected with the ``|3|`` envelope.
+    Transition rigor: snapshot ``/etc/passwd`` BEFORE and assert it is byte-for-byte
+    UNCHANGED after -- a load is read-only, but proving the file is untouched also
+    proves the reject path never opened it.
+    """
+    vm = smoke_vm
+    before = _cat(vm, EVIL_PATH)
+    assert before, "could not read /etc/passwd to snapshot the before-state"
+
+    token = _csrf(webui)
+    resp = _post_load(webui, token, EVIL_PATH)
+    assert not looks_like_login_page(resp.text), "load POST returned the login form (session lost)"
+    # Oracle for a reject: the |3| invalid-path envelope, NOT a |0| success.
+    assert resp.text.startswith("|3|"), f"rejected path did not return the |3| envelope: {resp.text!r}"
+    assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+    # The protected file is untouched by the refused read.
+    assert _cat(vm, EVIL_PATH) == before, "/etc/passwd changed after a rejected load (must be untouched)"
+
+
+# --------------------------------------------------------------------------- #
+# act=download
+# --------------------------------------------------------------------------- #
+
+
+def test_download_streams_file_with_attachment_header(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Download of a validated file streams its bytes with an attachment header.
+
+    Transition: seed a known file (assert on-box BEFORE), then prove the download
+    response body equals the file content and the ``Content-Disposition`` names the
+    basename as an attachment. Restored in finally.
+    """
+    vm = smoke_vm
+    target = f"{LOG_DIR}/error.log"
+    payload = f"pfb-ui-download-{helpers.unique_domain('dl')}\n"
+    _seed_file(vm, target, payload)
+    try:
+        assert _cat(vm, target) == payload, "seed not present on the box before download"
+
+        token = _csrf(webui)
+        resp = _post_download(webui, token, target)
+        assert not looks_like_login_page(resp.text), "download POST returned the login form (session lost)"
+        # AFTER (oracle): the streamed body equals the on-box file content.
+        assert resp.text == _cat(vm, target), f"download body {resp.text!r} != on-box file {_cat(vm, target)!r}"
+        # The attachment header names the file's basename (source: header() call).
+        disp = resp.headers.get("Content-Disposition", "")
+        assert 'attachment; filename="error.log"' in disp, f"unexpected Content-Disposition: {disp!r}"
+        # The file is read-only on download -- it must remain on the box, unchanged.
+        assert _cat(vm, target) == payload, "download altered the source file (must be read-only)"
+    finally:
+        _rm(vm, target)
+
+
+def test_download_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Download of a path outside the allowed dirs is refused, source untouched.
+
+    The same validator gates download. ``/etc/passwd`` -> the ``|0|Invalid
+    filename/path.|`` reject envelope (NOT the file's bytes). Transition rigor:
+    snapshot before and assert the file is byte-for-byte unchanged after.
+    """
+    vm = smoke_vm
+    before = _cat(vm, EVIL_PATH)
+    assert before, "could not read /etc/passwd to snapshot the before-state"
+
+    token = _csrf(webui)
+    resp = _post_download(webui, token, EVIL_PATH)
+    assert not looks_like_login_page(resp.text), "download POST returned the login form (session lost)"
+    # The reject envelope -- emphatically NOT the file's contents (no root: line).
+    assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+    assert "root:" not in resp.text, f"download leaked /etc/passwd content: {resp.text!r}"
+    assert _cat(vm, EVIL_PATH) == before, "/etc/passwd changed after a rejected download (must be untouched)"
+
+
+# --------------------------------------------------------------------------- #
+# act=clear -- the destructive branch (three distinct shapes from source)
+# --------------------------------------------------------------------------- #
+
+
+def test_clear_plain_log_unlinks_file(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Clearing a plain default log UNLINKS it (``unlink_if_exists``) -> ABSENT.
+
+    Source: the clear branch's ``else`` calls ``unlink_if_exists($s_logfile)`` for
+    any file that is not py_error.log; ip_block.log is not one of the unbound
+    re-touch special cases, so it is simply removed.
+
+    Transition: seed non-empty content and assert it EXISTS + non-empty (BEFORE),
+    POST clear, assert the file is now ABSENT (AFTER). Restore: ensure it's gone.
+    """
+    vm = smoke_vm
+    target = f"{LOG_DIR}/ip_block.log"
+    _seed_file(vm, target, f"pfb-ui-clear-plain-{helpers.unique_domain('clr')}\n")
+    try:
+        # BEFORE: present and non-empty.
+        assert _exists(vm, target), "seeded file missing before clear"
+        assert _size(vm, target) > 0, "seeded file unexpectedly empty before clear"
+
+        token = _csrf(webui)
+        resp = _post_clear(webui, token, target)
+        assert not looks_like_login_page(resp.text), "clear POST returned the login form (session lost)"
+        # AFTER (oracle): unlink_if_exists removed it.
+        assert not _exists(vm, target), "plain log still present after clear (expected unlink)"
+    finally:
+        _rm(vm, target)
+
+
+def test_clear_py_error_truncates_in_place(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Clearing py_error.log TRUNCATES it (keeps the file) -> EXISTS, size 0.
+
+    Source: ``strpos($s_logfile, 'py_error.log') !== FALSE`` takes the
+    fopen('r+')+ftruncate(0) branch (the comment: the python file pointer must not
+    be lost), so the file must REMAIN, emptied -- NOT be unlinked. This is the
+    branch that distinguishes py_error.log from every other log.
+
+    Transition: seed non-empty (BEFORE), clear, assert it STILL EXISTS and is now
+    size 0 (AFTER) -- proving truncate, not unlink. Restore: remove the file.
+    """
+    vm = smoke_vm
+    target = f"{LOG_DIR}/py_error.log"
+    _seed_file(vm, target, f"pfb-ui-clear-py-{helpers.unique_domain('py')}\n")
+    try:
+        assert _exists(vm, target), "seeded py_error.log missing before clear"
+        assert _size(vm, target) > 0, "seeded py_error.log unexpectedly empty before clear"
+
+        token = _csrf(webui)
+        resp = _post_clear(webui, token, target)
+        assert not looks_like_login_page(resp.text), "clear POST returned the login form (session lost)"
+        # AFTER (oracle): truncated in place -- still exists, now empty.
+        assert _exists(vm, target), "py_error.log was unlinked (expected ftruncate -> file kept)"
+        assert _size(vm, target) == 0, f"py_error.log not truncated to 0 after clear (size={_size(vm, target)})"
+    finally:
+        _rm(vm, target)
+
+
+def test_clear_dnsbl_log_unlinks_then_retouches_empty(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Clearing dnsbl.log unlinks THEN re-touches it -> EXISTS, size 0.
+
+    Source: the non-py_error branch unlinks, then for dnsbl.log / unified.log /
+    dns_reply.log it ``touch``es the file and chowns it to ``unbound`` (these logs
+    are written by the chrooted unbound python module, so the file must exist with
+    unbound ownership). Net observable: file present and EMPTY after clear (unlike
+    a plain log, which stays absent).
+
+    Transition: seed non-empty (BEFORE), clear, assert it EXISTS and size 0
+    (AFTER) -- distinguishing this special case from the plain-unlink case.
+    Restore: remove the file.
+    """
+    vm = smoke_vm
+    target = f"{LOG_DIR}/dnsbl.log"
+    _seed_file(vm, target, f"pfb-ui-clear-dnsbl-{helpers.unique_domain('dns')}\n")
+    try:
+        assert _exists(vm, target), "seeded dnsbl.log missing before clear"
+        assert _size(vm, target) > 0, "seeded dnsbl.log unexpectedly empty before clear"
+
+        token = _csrf(webui)
+        resp = _post_clear(webui, token, target)
+        assert not looks_like_login_page(resp.text), "clear POST returned the login form (session lost)"
+        # AFTER (oracle): unlinked then re-touched -- present and empty.
+        assert _exists(vm, target), "dnsbl.log absent after clear (expected re-touch)"
+        assert _size(vm, target) == 0, f"dnsbl.log not empty after clear (size={_size(vm, target)})"
+    finally:
+        _rm(vm, target)
+
+
+def test_clear_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Clear of a path outside the allowed dirs is refused -- the file is UNTOUCHED.
+
+    The most safety-critical branch: an unvalidated clear would unlink/truncate an
+    arbitrary file. The validator must refuse ``/etc/passwd`` with the
+    ``|0|Invalid filename/path.|`` envelope and NOT remove or empty it.
+
+    Transition rigor: snapshot the file's content + size BEFORE, POST the rejected
+    clear, then assert it still EXISTS, is the SAME size, and the SAME bytes.
+    """
+    vm = smoke_vm
+    before = _cat(vm, EVIL_PATH)
+    assert before, "could not read /etc/passwd to snapshot the before-state"
+    before_size = _size(vm, EVIL_PATH)
+    assert before_size > 0, "/etc/passwd unexpectedly empty before the rejected clear"
+
+    token = _csrf(webui)
+    resp = _post_clear(webui, token, EVIL_PATH)
+    assert not looks_like_login_page(resp.text), "clear POST returned the login form (session lost)"
+    assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+    # AFTER (oracle): the protected file is wholly intact -- not unlinked, not truncated.
+    assert _exists(vm, EVIL_PATH), "/etc/passwd was removed by a rejected clear (validator failed!)"
+    assert _size(vm, EVIL_PATH) == before_size, "/etc/passwd was truncated by a rejected clear (validator failed!)"
+    assert _cat(vm, EVIL_PATH) == before, "/etc/passwd content changed after a rejected clear"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -86,11 +86,19 @@ PAGE_TABLE: tuple[Page, ...] = (
     Page("category_edit_ip", "/pfblockerng/pfblockerng_category_edit.php?type=ipv4", ("Advanced Tuneables",)),
     Page("category_edit_dnsbl", "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl", ("Advanced Tuneables",)),
     # threats.php REQUIRES a host/domain/port param -- with none it print_info_box()es and exit()s
-    # before rendering $pgtitle. A syntactically-valid domain renders the lookup page chrome; the
+    # before rendering $pgtitle. A syntactically-valid param renders the lookup page chrome; the
     # threat links it draws are <a href> only (no server-side network call), so it stays hermetic.
-    # The {domain} placeholder is filled per run with helpers.unique_domain() (uuid-*.com) -- the
-    # smoke-domain rule (never a fixed/RFC-6761 name, avoids environment coupling).
-    Page("threats", "/pfblockerng/pfblockerng_threats.php?domain={domain}", ("Threat Domain", "Source IP")),
+    # All THREE positive views ($title is 'Source IP'/'Domain'/'Port' -> the "Threat <title> Lookup"
+    # breadcrumb + "Threat <title>:" panel) are probed (CLAUDE.md branch coverage); the reject /
+    # no-request branches are covered by test_threats_rejects_malformed_lookup below. The {domain}
+    # placeholder is filled per run with helpers.unique_domain() (uuid-*.com) -- the smoke-domain
+    # rule (never a fixed/RFC-6761 name); host/port use a documentation IP (TEST-NET-3) + a valid
+    # port (no network coupling either way).
+    Page("threats_domain", "/pfblockerng/pfblockerng_threats.php?domain={domain}", ("Threat Domain", "Source IP")),
+    Page(
+        "threats_host", "/pfblockerng/pfblockerng_threats.php?host=203.0.113.5", ("Threat Source IP", "Threat Lookups")
+    ),
+    Page("threats_port", "/pfblockerng/pfblockerng_threats.php?port=8443", ("Threat Port",)),
     # ADR-12 Update Hooks (pre/post update-command list). $pgtitle + the section titles are stable.
     Page("hooks", "/pfblockerng/pfblockerng_hooks.php", ("Update Hooks", "Hook Entries")),
     # The dashboard widget (auth-gated; $nocsrf=true). A direct GET renders the alias-table panel
@@ -184,6 +192,42 @@ def test_page_renders_clean(page: Page, webui: WebUI, php_error_log_guard: PhpEr
     resp = webui.get(path)
     result = evaluate_render(path, resp.status_code, resp.text, page.markers)
     assert result.ok, f"render oracle failed for {page.name} ({path}): {result.detail}"
+
+
+# threats.php's NEGATIVE branches: each malformed/absent param print_info_box()es
+# a specific message and exit()s BEFORE the "$pgtitle" lookup-page chrome. These
+# pair with the positive threats_{domain,host,port} entries above (CLAUDE.md
+# branch coverage: prove the validators REJECT, not only that valid input renders).
+THREATS_PAGE = "/pfblockerng/pfblockerng_threats.php"
+# (id, query, expected info-box message) -- messages verified verbatim against
+# pfblockerng_threats.php (is_ipaddr / is_port guards + the no-param else).
+THREATS_REJECTS: tuple[tuple[str, str, str], ...] = (
+    ("invalid_host", "host=not-an-ip", "Invalid IP Address, cannot proceed!"),
+    ("invalid_port", "port=99999", "Invalid Port cannot proceed!"),
+    ("no_request", "", "No Requests found, cannot proceed!"),
+)
+# The lookup-page chrome titles ("Threat <title> Lookup") that MUST be absent on a
+# reject (the handler exit()s before rendering $pgtitle).
+_THREATS_LOOKUP_TITLES = ("Threat Domain Lookup", "Threat Source IP Lookup", "Threat Port Lookup")
+
+
+@pytest.mark.parametrize(("name", "query", "message"), THREATS_REJECTS, ids=[r[0] for r in THREATS_REJECTS])
+def test_threats_rejects_malformed_lookup(name: str, query: str, message: str, webui: WebUI) -> None:
+    """A malformed/absent threats lookup renders its info-box, NOT the lookup page.
+
+    HTTP 200 (head.inc is included before the dispatch, so the page still renders
+    its header) with the exact info-box message present and the "Threat ... Lookup"
+    chrome absent -- proving the validator rejected and exit()ed rather than
+    rendering the lookup view. The before-state (a valid param DOES render that
+    chrome) is the positive threats_{domain,host,port} entries in PAGE_TABLE.
+    """
+    path = f"{THREATS_PAGE}?{query}" if query else THREATS_PAGE
+    resp = webui.get(path)
+    assert resp.status_code == 200, f"{name}: GET {path} -> HTTP {resp.status_code} (expected 200)"
+    body = resp.text
+    assert message in body, f"{name}: expected info-box {message!r} not present in {path} body"
+    present = [title for title in _THREATS_LOOKUP_TITLES if title in body]
+    assert not present, f"{name}: reject path unexpectedly rendered lookup chrome {present}"
 
 
 def test_page_table_covers_every_pfblockerng_page() -> None:

--- a/tests/smoke/ui/test_sync.py
+++ b/tests/smoke/ui/test_sync.py
@@ -1,0 +1,437 @@
+"""Tier-B functional WebUI flows for the XMLRPC config-sync page (ADR-14).
+
+Page under test: ``pfblockerng_sync.php`` (Firewall > pfBlockerNG > Sync). This
+file establishes that the page's CSRF save handler -- its scalar settings, its
+``repeatable`` Replication-Target rowhelper, its undefined-row prune, and its
+field validators -- all change (or correctly REFUSE to change) the box's
+EFFECTIVE state. As elsewhere in the Tier-B suite, the oracle is ``config.xml``
+read over SSH (:func:`tests.smoke.helpers.config_get`), NEVER the HTTP response
+body: a 200 / a post-redirect page does not prove the save took; re-reading the
+config node does.
+
+Save-handler facts read END TO END from ``pfblockerng_sync.php`` (the assertions
+below depend on these; they are not guessed):
+
+* The handler runs only under ``isset($_POST['save'])`` and writes the sync
+  config under ``installedpackages/pfblockerngsync/config/0``: the scalars
+  ``varsynconchanges`` / ``varsynctimeout`` / ``syncinterfaces`` and a per-target
+  row map ``row/<index>/<field>`` (fields ``varsyncprotocol`` /
+  ``varsyncipaddress`` / ``varsyncport`` / ``varsyncusername`` /
+  ``varsyncpassword`` / ``varsyncdestinenable``).
+* ROWHELPER NAMING (the ``.addClass('repeatable')`` rowhelper): every per-row
+  control is named ``<field>-<index>`` (e.g. ``varsyncipaddress-0``). The handler
+  finds rows by scanning every POST key containing ``-`` and splitting on it, so a
+  row is POSTed by sending its ``<field>-<index>`` inputs; an index that appears in
+  ANY ``<field>-<index>`` key is recorded as "present".
+* UNDEFINED-ROW PRUNE: after the field loop, every ``row`` index in config that
+  was NOT present in the POST is ``config_del_path``'d -- so omitting a row's
+  fields from the POST deletes that row.
+* VALIDATION + the WRITE GATE: a bad port (``!is_port``), a bad protocol, an
+  invalid/too-long username, or an invalid hostname appends an ``$input_errors``
+  entry. The per-row ``config_set_path`` calls run on the IN-MEMORY config
+  regardless, but ``write_config()`` is called ONLY inside ``if (!$input_errors)``
+  -- so on ANY validation error NOTHING is persisted to ``config.xml``. The oracle
+  (a fresh ``pfSsh.php`` reading ``/conf/config.xml``) therefore sees the
+  pre-POST state unchanged on a reject, which is exactly what the reject cases
+  assert.
+
+Every flow is a TRUE transition test (CLAUDE.md): it seeds + asserts the BEFORE
+state, drives the CSRF POST, asserts the AFTER state via the config.xml oracle,
+then RESTORES the box (asserting the reverse where it applies) so the
+session-scoped VM is left clean for sibling flows. The sync config node is
+snapshotted and force-restored in ``finally`` so a mid-test failure cannot poison
+Tier A or the other flows.
+
+This page is a plain form handler gating on the ``save`` button, but its rendered
+form ALWAYS includes a placeholder Target row whose empty ``varsyncipaddress-0``
+would itself be rejected by the hostname validator when re-submitted -- so these
+flows do NOT use the field-scraping :meth:`WebUI.post`; they POST a fully
+controlled payload directly (GET the page, pull the fresh ``__csrf_magic`` token,
+send exactly the fields under test) so each branch is exercised in isolation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .webui import extract_csrf_token, looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+SYNC_PAGE = "/pfblockerng/pfblockerng_sync.php"
+# The sync config root and the scalar/row paths the save handler writes.
+CFG_SYNC = "installedpackages/pfblockerngsync/config/0"
+CFG_SYNC_MODE = f"{CFG_SYNC}/varsynconchanges"
+CFG_SYNC_TIMEOUT = f"{CFG_SYNC}/varsynctimeout"
+CFG_SYNC_IFACE = f"{CFG_SYNC}/syncinterfaces"
+
+
+def _row_path(index: int, field: str) -> str:
+    """config.xml path of a Replication-Target row field (``row/<i>/<field>``)."""
+    return f"{CFG_SYNC}/row/{index}/{field}"
+
+
+def _post_sync(webui: WebUI, payload: dict[str, str], *, timeout: float = 120.0) -> str:
+    """GET the Sync page, attach its fresh CSRF token + ``save``, POST ``payload``.
+
+    The handler gates on ``isset($_POST['save'])``, so the save button is added
+    here; the ``__csrf_magic`` token is re-extracted from the freshly-GET'd form
+    (the csrf-magic output filter injects a new one per render -- it must never be
+    cached). ``payload`` is the EXACT controlled field set under test (no field
+    scraping): only keys present are seen by the handler, so omitting all
+    ``<field>-<index>`` keys exercises the undefined-row prune deterministically.
+    Returns the POST response body for the login-bounce sanity check (NOT the
+    oracle -- the caller asserts config.xml).
+    """
+    form = webui.get(SYNC_PAGE)
+    assert not looks_like_login_page(form.text), "GET of the Sync page returned the login form (session lost)"
+    token = extract_csrf_token(form.text)
+    data = {"__csrf_magic": token, "save": "save"}
+    data.update(payload)
+    # The WebUI client passes verify per-request, not on the session; mirror its
+    # rule for a direct POST -- a self-signed HTTPS throwaway image is driven with
+    # verify=False, plain HTTP needs no TLS verification. base_url is public.
+    verify = not webui.base_url.startswith("https://")
+    resp = webui.session.post(
+        webui.url(SYNC_PAGE),
+        data=data,
+        verify=verify,
+        timeout=timeout,
+        allow_redirects=True,
+    )
+    assert not looks_like_login_page(resp.text), "Sync POST returned the login form (session lost)"
+    return resp.text
+
+
+def _seed_sync(vm: helpers.SmokeVM, *, timeout: float = 60.0) -> None:
+    """Reset the sync config to a known pristine baseline (no targets, defaults).
+
+    Writes ``varsynconchanges='disabled'``, ``varsynctimeout='150'`` and DELETES
+    any ``row`` node, so each transition test starts from the same before-state
+    regardless of what a sibling flow left behind.
+    """
+    snippet = (
+        f"$c = config_get_path({helpers._php_str(CFG_SYNC)}, array());\n"
+        "$c['varsynconchanges'] = 'disabled';\n"
+        "$c['varsynctimeout'] = '150';\n"
+        "$c['syncinterfaces'] = '';\n"
+        "unset($c['row']);\n"
+        f"config_set_path({helpers._php_str(CFG_SYNC)}, $c);\n"
+        "write_config('pfBlockerNG smoke: seed sync baseline');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_seed_sync failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _seed_row(vm: helpers.SmokeVM, index: int, row: dict[str, str], *, timeout: float = 60.0) -> None:
+    """Persist a single Replication-Target ``row/<index>`` via the config API.
+
+    Used to establish a BEFORE-state row that a subsequent POST must prune /
+    leave untouched -- written through the same ``config_set_path`` path the GUI
+    save handler uses, then ``write_config``'d so the config.xml oracle sees it.
+    """
+    # Build the row in one assoc write so a partial seed can't leave a half row.
+    snippet = (
+        f"config_set_path({helpers._php_str(f'{CFG_SYNC}/row/{index}')}, {helpers._php_kv_array(row)});\n"
+        "write_config('pfBlockerNG smoke: seed sync target row');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_seed_row failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+# --------------------------------------------------------------------------- #
+# 1) Scalar settings save -- timeout (sanitised numeric) + sync mode (select).
+# --------------------------------------------------------------------------- #
+
+
+def test_sync_timeout_scalar_round_trip(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A valid XMLRPC-timeout POST changes config.xml; the original is restored.
+
+    True transition: assert the seeded baseline (150), POST 300 and assert
+    config.xml holds 300, then POST 150 and assert it returned -- so the green
+    proves each POST CAUSED its change. ``varsynctimeout`` is sanitised by
+    ``pfb_filter(..., PFB_FILTER_NUM, 150)`` then ``min(5000, ...)``, so a clean
+    in-range integer stores verbatim.
+    """
+    vm = smoke_vm
+    _seed_sync(vm)
+    try:
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "150", "seeded timeout baseline not 150"
+
+        _post_sync(webui, {"varsynconchanges": "disabled", "varsynctimeout": "300", "syncinterfaces": ""})
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "300", "timeout 300 not persisted to config.xml"
+
+        _post_sync(webui, {"varsynconchanges": "disabled", "varsynctimeout": "150", "syncinterfaces": ""})
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "150", "timeout did not return to 150"
+    finally:
+        _seed_sync(vm)
+
+
+def test_sync_timeout_clamped_to_max(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """An over-range timeout is CLAMPED to 5000 (the ``min(5000, ...)`` branch).
+
+    Distinct from the verbatim path: BEFORE is 150, a POST of 99999 stores 5000
+    (not 99999, not 150) -- proving the clamp is a real branch, not a reject. The
+    value is sanitised in place, so config.xml DOES change (no input error).
+    """
+    vm = smoke_vm
+    _seed_sync(vm)
+    try:
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "150", "seeded timeout baseline not 150"
+
+        _post_sync(webui, {"varsynconchanges": "disabled", "varsynctimeout": "99999", "syncinterfaces": ""})
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "5000", "over-range timeout not clamped to 5000"
+    finally:
+        _seed_sync(vm)
+
+
+def test_sync_mode_select_valid_and_normalised(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """The sync-mode SELECT stores a valid option and NORMALISES an invalid one.
+
+    Branch coverage of the select validator
+    (``array_key_exists($_POST[$opt], $options_$opt)``):
+
+    * VALID branch -- BEFORE 'disabled', POST 'manual' -> config.xml holds
+      'manual'; the reverse POST restores 'disabled'. Both directions exercised.
+    * NORMALISE branch -- an option not in {disabled, auto, manual} is silently
+      reset to '' (NOT an input error): BEFORE 'manual', POST 'bogus' -> config
+      holds '' (proving the reset path), not 'bogus' and not 'manual'.
+
+    ``syncinterfaces`` is sent empty and ``varsynctimeout`` at its baseline so the
+    only delta is the select; no target rows are posted, so the empty-IP
+    placeholder cannot trip the hostname validator.
+    """
+    vm = smoke_vm
+    _seed_sync(vm)
+    try:
+        assert helpers.config_get(vm, CFG_SYNC_MODE) == "disabled", "seeded mode baseline not 'disabled'"
+
+        # VALID: drive to 'manual'.
+        _post_sync(webui, {"varsynconchanges": "manual", "varsynctimeout": "150", "syncinterfaces": ""})
+        assert helpers.config_get(vm, CFG_SYNC_MODE) == "manual", "valid select value 'manual' not persisted"
+
+        # Reverse VALID: back to 'disabled'.
+        _post_sync(webui, {"varsynconchanges": "disabled", "varsynctimeout": "150", "syncinterfaces": ""})
+        assert helpers.config_get(vm, CFG_SYNC_MODE) == "disabled", "select did not return to 'disabled'"
+
+        # NORMALISE: an out-of-set value is reset to '' (re-seed to 'manual' first
+        # so the change away from a NON-empty value is observable).
+        _post_sync(webui, {"varsynconchanges": "manual", "varsynctimeout": "150", "syncinterfaces": ""})
+        assert helpers.config_get(vm, CFG_SYNC_MODE) == "manual", "pre-normalise seed to 'manual' failed"
+        _post_sync(webui, {"varsynconchanges": "bogus", "varsynctimeout": "150", "syncinterfaces": ""})
+        assert helpers.config_get(vm, CFG_SYNC_MODE) == "", "invalid select value not normalised to ''"
+    finally:
+        _seed_sync(vm)
+
+
+def test_sync_disable_interfaces_checkbox_toggle(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """The 'Disable tab settings sync' checkbox stores 'on' and clears, both ways.
+
+    ``syncinterfaces`` is a PFB_FILTER_ON_OFF checkbox: present+``on`` -> 'on',
+    absent (a browser omits an unchecked box) -> ''. BEFORE '', POST with the box
+    -> 'on'; POST without it -> '' again. Both branches of the toggle exercised.
+    """
+    vm = smoke_vm
+    _seed_sync(vm)
+    try:
+        assert helpers.config_get(vm, CFG_SYNC_IFACE) == "", "seeded syncinterfaces baseline not empty"
+
+        _post_sync(webui, {"varsynconchanges": "disabled", "varsynctimeout": "150", "syncinterfaces": "on"})
+        assert helpers.config_get(vm, CFG_SYNC_IFACE) == "on", "checkbox 'on' not persisted"
+
+        # Omit the field entirely -- a browser sends nothing for an unchecked box.
+        _post_sync(webui, {"varsynconchanges": "disabled", "varsynctimeout": "150"})
+        assert helpers.config_get(vm, CFG_SYNC_IFACE) == "", "checkbox did not clear when omitted"
+    finally:
+        _seed_sync(vm)
+
+
+# --------------------------------------------------------------------------- #
+# 2) Replication-Target rowhelper -- add a valid row, then it persists.
+# --------------------------------------------------------------------------- #
+
+
+def test_sync_target_row_add_persists(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Adding a valid Target row (``<field>-0`` rowhelper keys) persists it.
+
+    True transition: BEFORE there is no ``row/0`` (seeded clean), POST a full
+    valid row at index 0, then assert EACH field landed under
+    ``row/0/<field>`` in config.xml. Then prune it (POST with no row keys) and
+    assert the row is gone -- both the add and the remove direction.
+
+    Field naming assumption (read from the PHP rowhelper): per-row controls are
+    ``varsync<field>-<index>``; the handler splits on the LAST?... it uses
+    ``explode('-', $key)`` taking element [0]=field, [1]=index, so the index must
+    be an integer with no extra ``-`` in the field name (true for these names).
+    The hostname must pass ``is_hostname`` and the port ``is_port``, so a plain
+    label host and a 1..65535 port are used. ``varsynconchanges='manual'`` so the
+    target row is the configured-target mode (not strictly required for the row
+    to persist, but matches the UI path).
+    """
+    vm = smoke_vm
+    _seed_sync(vm)
+    host = helpers.unique_domain("synctarget").split(".")[0] + ".example-sync.com"
+    row = {
+        "varsyncprotocol-0": "https",
+        "varsyncipaddress-0": host,
+        "varsyncport-0": "8443",
+        "varsyncusername-0": "syncuser",
+        "varsyncpassword-0": "syncsecret",
+        "varsyncdestinenable-0": "on",
+    }
+    try:
+        assert helpers.config_get(vm, _row_path(0, "varsyncipaddress")) == "", "row/0 already present before add"
+
+        _post_sync(webui, {"varsynconchanges": "manual", "varsynctimeout": "150", "syncinterfaces": "", **row})
+
+        assert helpers.config_get(vm, _row_path(0, "varsyncprotocol")) == "https", "row protocol not persisted"
+        assert helpers.config_get(vm, _row_path(0, "varsyncipaddress")) == host, "row hostname not persisted"
+        assert helpers.config_get(vm, _row_path(0, "varsyncport")) == "8443", "row port not persisted"
+        assert helpers.config_get(vm, _row_path(0, "varsyncusername")) == "syncuser", "row username not persisted"
+        assert helpers.config_get(vm, _row_path(0, "varsyncpassword")) == "syncsecret", "row password not persisted"
+        assert helpers.config_get(vm, _row_path(0, "varsyncdestinenable")) == "on", "row enable flag not persisted"
+
+        # Reverse: omit the row keys -> the undefined-row prune deletes row/0.
+        _post_sync(webui, {"varsynconchanges": "manual", "varsynctimeout": "150", "syncinterfaces": ""})
+        assert helpers.config_get(vm, _row_path(0, "varsyncipaddress")) == "", "row/0 not pruned after omission"
+    finally:
+        _seed_sync(vm)
+
+
+# --------------------------------------------------------------------------- #
+# 3) Undefined/empty-row prune -- a config row absent from the POST is deleted.
+# --------------------------------------------------------------------------- #
+
+
+def test_sync_undefined_row_pruned_on_save(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A pre-existing row NOT present in the POST is ``config_del_path``'d.
+
+    Seed ``row/0`` directly via the config API (BEFORE-state: the row exists),
+    assert it, then drive a VALID save whose payload contains NO ``<field>-0``
+    keys. The handler's prune loop deletes every config row index not seen in the
+    POST, so ``row/0`` must be gone afterwards while the scalar save still lands
+    (proving the save ran, not that it silently no-op'd). The save carries a valid
+    scalar change (timeout 250) so a green also proves write_config executed.
+    """
+    vm = smoke_vm
+    _seed_sync(vm)
+    seeded = {
+        "varsyncprotocol": "https",
+        "varsyncipaddress": "stale-target.example-sync.com",
+        "varsyncport": "443",
+        "varsyncusername": "admin",
+        "varsyncpassword": "x",
+        "varsyncdestinenable": "on",
+    }
+    _seed_row(vm, 0, seeded)
+    try:
+        assert helpers.config_get(vm, _row_path(0, "varsyncipaddress")) == seeded["varsyncipaddress"], (
+            "seeded row/0 not present before the prune POST"
+        )
+
+        # POST with NO row keys -> prune row/0; a scalar delta proves the save ran.
+        _post_sync(webui, {"varsynconchanges": "manual", "varsynctimeout": "250", "syncinterfaces": ""})
+
+        assert helpers.config_get(vm, _row_path(0, "varsyncipaddress")) == "", "undefined row/0 not pruned"
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "250", "scalar save did not run alongside the prune"
+    finally:
+        _seed_sync(vm)
+
+
+# --------------------------------------------------------------------------- #
+# 4) Validation reject -- a bad row aborts write_config; config stays unchanged.
+# --------------------------------------------------------------------------- #
+
+
+def test_sync_bad_port_rejected_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A row with an out-of-range port is rejected; NOTHING is persisted.
+
+    ``varsyncport`` is validated by ``is_port``; 99999 fails, so ``$input_errors``
+    is set and ``write_config()`` (gated on ``!$input_errors``) never runs. The
+    per-row ``config_set_path`` calls mutate only the IN-MEMORY config of that
+    request, so a fresh config.xml read sees the UNCHANGED before-state.
+
+    True transition with a paired VALID control so the reject is proven a real
+    branch (CLAUDE.md): first POST the SAME row with a VALID port (8443) and
+    assert it persisted (the change happens), then POST the bad-port row and
+    assert the scalar AND the row are untouched from that valid state -- i.e. the
+    bad POST caused NO write, rather than the expected end-state already holding.
+    """
+    vm = smoke_vm
+    _seed_sync(vm)
+    host = "valid-target.example-sync.com"
+    base = {
+        "varsynconchanges": "manual",
+        "syncinterfaces": "",
+        "varsyncprotocol-0": "https",
+        "varsyncipaddress-0": host,
+        "varsyncusername-0": "syncuser",
+        "varsyncpassword-0": "syncsecret",
+        "varsyncdestinenable-0": "on",
+    }
+    try:
+        # Establish a known-good persisted state first (the VALID control).
+        _post_sync(webui, {**base, "varsynctimeout": "200", "varsyncport-0": "8443"})
+        assert helpers.config_get(vm, _row_path(0, "varsyncport")) == "8443", "valid control row not persisted"
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "200", "valid control timeout not persisted"
+
+        # REJECT: bad port + a would-be scalar change. write_config must NOT run,
+        # so both the port and the timeout stay at the valid-control values.
+        _post_sync(webui, {**base, "varsynctimeout": "1234", "varsyncport-0": "99999"})
+        assert helpers.config_get(vm, _row_path(0, "varsyncport")) == "8443", (
+            "bad-port POST altered config.xml (write_config should be gated on no input errors)"
+        )
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "200", (
+            "bad-port POST persisted a scalar change despite the validation error"
+        )
+    finally:
+        _seed_sync(vm)
+
+
+def test_sync_bad_username_rejected_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A row with an invalid-character username is rejected; nothing persists.
+
+    Second validator branch: ``varsyncusername`` rejects on
+    ``preg_match('/[^a-zA-Z0-9._-]/', $value)`` (and on length > 16). A username
+    containing a space fails, so ``write_config`` is gated off and config.xml is
+    unchanged. Paired with a valid control (a clean username persists) so the
+    reject is a proven branch, not an always-unchanged path.
+    """
+    vm = smoke_vm
+    _seed_sync(vm)
+    host = "valid-target.example-sync.com"
+    base = {
+        "varsynconchanges": "manual",
+        "syncinterfaces": "",
+        "varsyncprotocol-0": "https",
+        "varsyncipaddress-0": host,
+        "varsyncport-0": "8443",
+        "varsyncpassword-0": "syncsecret",
+        "varsyncdestinenable-0": "on",
+    }
+    try:
+        # VALID control: a clean username persists.
+        _post_sync(webui, {**base, "varsynctimeout": "210", "varsyncusername-0": "gooduser"})
+        assert helpers.config_get(vm, _row_path(0, "varsyncusername")) == "gooduser", "valid username not persisted"
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "210", "valid control timeout not persisted"
+
+        # REJECT: a space is an invalid username character -> input error -> no write.
+        _post_sync(webui, {**base, "varsynctimeout": "1357", "varsyncusername-0": "bad user"})
+        assert helpers.config_get(vm, _row_path(0, "varsyncusername")) == "gooduser", (
+            "invalid username altered config.xml (write_config should be gated on no input errors)"
+        )
+        assert helpers.config_get(vm, CFG_SYNC_TIMEOUT) == "210", (
+            "invalid-username POST persisted a scalar change despite the validation error"
+        )
+    finally:
+        _seed_sync(vm)


### PR DESCRIPTION
## Batch 2 — action / utility-page flows + threats render

Second back-to-back hermetic batch expanding ADR-14 UI coverage
(audit: `/private/tmp/ui_coverage_audit.md`). Where Batch 1 covered
settings-form saves, Batch 2 covers the **action/utility pages** whose effect
is config or on-box state via AJAX/`act=` handlers, plus the remaining threats
render branches.

### What (one new file per page, no shared-file churn)

- **alerts** (`test_alerts.py`): the DNSBL **lock/unlock lifecycle** via the web
  handler — feed-block a domain, web-unlock it, assert it stops being blocked,
  re-lock, assert blocked again (DNS-shape oracle, `dns_probe`); plus
  `addwhitelistdom` whitelist vs TLD-exclusion branches and `addsuppress`
  /24-accept + invalid-reject.
- **log** (`test_log.py`): `act=load` / `download` / `clear` over the AJAX
  handler, incl the **destructive clear** branches (plain unlink, `py_error.log`
  truncate, `dnsbl.log` re-touch) and path-traversal rejects; seed + restore
  on-box files.
- **feeds** (`test_feeds.py`): rename/combine save, alt-URL radio, invalid-alias
  reject (config unchanged).
- **sync** (`test_sync.py`): settings save, target-row add, undefined-row prune,
  bad port/username rejects.
- **hooks** (`test_hooks.py`): ADR-12 hook-row save, enabled toggle on/off, when
  pre/post, remove-to-empty deletes the node, per-field validation rejects —
  the **functional** complement to #107's render + add-row browser coverage.
- **threats** (`test_render_smoke.py`): host (Source IP) + port views added to
  the Tier-A sweep alongside the existing domain view, plus a negative-guard
  test for the invalid-IP / invalid-port / no-request info-box branches.

### Conventions held

Every flow is a transition test (assert before-state, then prove the POST caused
the change), with branch coverage (accept **and** reject / toggle off **and**
on) and a `finally`-restore so the session VM stays clean. Oracle is always
effective state — `config.xml` (`helpers.config_get`), on-box files (ssh), DNS
(`dns_probe`) — never the HTTP body.

### Validation

- Default `python -m pytest`: **1069 passed (unchanged)** — `tests/smoke` stays
  ignored in the default run.
- `ruff check` + `ruff format` clean; `tests/smoke/ui` collects without import
  error (81 cases).
- Builds on #112's post-deploy readiness fix; carries the **`ui-tests`** label so
  the live-VM suite validates all flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive UI end-to-end tests for Alerts/Reports actions (lock/unlock, whitelist, suppression, IPv4 suppression) validating effective system state.
  * Added UI end-to-end tests for Feeds rename flows (valid and invalid renames).
  * Added UI end-to-end tests for Update Hooks (add, toggle, edit timing, delete, validation).
  * Added UI end-to-end tests for Log page (load, download, clear, invalid-path handling).
  * Enhanced Threats lookup tests for malformed/negative lookup cases.
  * Added UI end-to-end tests for Config Sync (scalars, selections, checkboxes, replication targets).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->