### PR TITLE
pfblockerng: ADR-12 P6 populate PFB_CHANGED_IP_ALIASES + PFB_CHANGED_DNSBL_GROUPS

### DIFF
--- a/.ADRs/ADR_12_Update_Hooks/06_Populate_Changed_Aliases.txt
+++ b/.ADRs/ADR_12_Update_Hooks/06_Populate_Changed_Aliases.txt
@@ -1,33 +1,37 @@
 ================================================================================
-PHASE 6 PROMPT — Populate PFB_CHANGED_ALIASES (IP + DNSBL changed-alias list)
+PHASE 6 PROMPT — Populate PFB_CHANGED_IP_ALIASES + PFB_CHANGED_DNSBL_GROUPS
 Target model: Claude Opus 4.8
 ADR: .ADRs/ADR_12_Update_Hooks/ADR.md   (read §2 context row + §7 future-phase note FIRST)
 ================================================================================
 
 ROLE
 You are on the `adr/12` branch performing Phase 6 of ADR-12 — turn the reserved
-placeholder `PFB_CHANGED_ALIASES` (today hardcoded to '') into the real, space-separated
-list of pfBlockerNG aliases whose contents were UPDATED this pass, covering BOTH the
-IP/firewall side and the DNSBL side. ADDITIVE: with no enabled `post` hook the pass stays
-byte-identical (the runner early-returns). Work inline on `adr/12`, one commit, then a PR
-(the change touches src/ + tests/ + README/CLAUDE/UI, so it is NOT the ADR-text carve-out).
+placeholder (today one var hardcoded to '') into TWO real, space-separated lists of what was
+UPDATED this pass, SPLIT BY SIDE: `PFB_CHANGED_IP_ALIASES` for the IP/firewall aliases and
+`PFB_CHANGED_DNSBL_GROUPS` for the DNSBL groups. DNSBL groups are NOT firewall aliases, so
+they get their own var. ADDITIVE: with no enabled `post` hook the pass stays byte-identical
+(the runner early-returns). Work inline on `adr/12`, one commit, then a PR (the change touches
+src/ + tests/ + README/CLAUDE/UI, so it is NOT the ADR-text carve-out).
 
 WHY THIS PHASE EXISTS
-ADR-12 shipped `PFB_CHANGED_ALIASES` as a STABLE RESERVED PLACEHOLDER (name present, value
-always '') because no pass-wide changed-alias signal was surfaced and the ADR forbade
+ADR-12 shipped a single `PFB_CHANGED_ALIASES` as a STABLE RESERVED PLACEHOLDER (name present,
+value always '') because no pass-wide changed-alias signal was surfaced and the ADR forbade
 inventing tracking machinery. Investigation (this phase's premise) found the signal ALREADY
 EXISTS and is merely discarded: the pass builds an "updated alias lists" array IP-side and
 calls a per-group reload helper DNSBL-side. This phase SURFACES that existing fact — it does
-not build new tracking.
+not build new tracking. The maintainer decision SPLITS it into two vars by side
+(PFB_CHANGED_IP_ALIASES = rename of the old PFB_CHANGED_ALIASES; PFB_CHANGED_DNSBL_GROUPS =
+new) because DNSBL groups are not firewall aliases.
 
 DECISION (settled with the maintainer — do not re-litigate)
-- SEMANTIC = "aliases UPDATED this pass" (feeds re-processed / list rebuilt / removed),
+- SEMANTIC = "updated this pass" (feeds re-processed / list rebuilt / removed),
   sourced from the signal the pass ALREADY computes — NOT a byte-level membership diff, and
   NOT the rep-mode-inflated "reloaded into kernel" set (`$final_alias`).
   * Rationale: this is rep-mode-INDEPENDENT (it reflects genuine feed changes, not
     Reputation's "rewrite everything when anything changes"), so it is the honest cheap
     signal. A literal member-level diff stays a documented FUTURE increment.
-- SCOPE = IP + DNSBL. Both `pfB_*` firewall aliases and `DNSBL_*` groups.
+- SCOPE = IP + DNSBL, on SEPARATE vars: `PFB_CHANGED_IP_ALIASES` (`pfB_*` firewall aliases)
+  and `PFB_CHANGED_DNSBL_GROUPS` (`DNSBL_*` groups). DNSBL groups are not firewall aliases.
 - `PFB_STATUS` is OUT OF SCOPE — it stays the `ok` reserved placeholder (no pass-wide
   ok/partial/error accumulator exists; do not invent one).
 
@@ -37,10 +41,10 @@ REQUIRED READING (inspect before editing)
   post call-site and the flag→env-var mapping. If missing, STOP and report.
   .ADRs/ADR_12_Update_Hooks/RESULTS/05_Results.txt — the live-VM smoke module
   (tests/smoke/test_smoke_hooks.py) + helpers, including the current present-and-EMPTY
-  assertion on PFB_CHANGED_ALIASES you will flip.
+  assertions on the changed-alias vars you will flip.
 - .ADRs/ADR_12_Update_Hooks/ADR.md (§2 context row, §4 req 3, §7 DoD + the future-phase note).
 - src/usr/local/pkg/pfblockerng/pfblockerng.inc (line numbers approximate — VERIFY each):
-  * POST hook fire + ctx, where `'CHANGED_ALIASES' => ''` lives (~:11595, the array passed
+  * POST hook fire + ctx, where the changed-alias ctx key(s) live (~:11595, the array passed
     to pfb_run_hooks('post', …)).
   * IP "updated alias lists" accumulation: `$pfb_alias_lists[]` (~:10583 feed updated,
     ~:9905/:9931 continent MD5-diff, ~:8311 alias removed) and `$pfb_alias_lists_all[]`
@@ -54,56 +58,63 @@ REQUIRED READING (inspect before editing)
     'update' callers ~:9509 (gated by `$pfb['aliasupdate']`), ~:4054 (gated by non-empty
     `$pfb['tld_update']`), and the special always-rebuilt aliases ~:9542 DNSBL_IDN /
     ~:9556 DNSBL_TLD_Allow / ~:9583 DNSBL_Regex. `$alias` is the `DNSBL_<group>` name.
-- src/usr/local/www/pfblockerng/pfblockerng_hooks.php (~:221 — the PFB_CHANGED_ALIASES help
-  text "Currently always empty (reserved for future use)").
-- src/usr/local/www/pfblockerng/pfblockerng.php (~:87 — the OTHER post-ctx site that also
-  sets CHANGED_ALIASES => ''; keep both sites consistent, or confirm which path is live).
-- README.md (~:385 the env-var table row) and CLAUDE.md (the PFB_STATUS/PFB_CHANGED_ALIASES
-  "stable reserved placeholders" sentence).
+- src/usr/local/www/pfblockerng/pfblockerng_hooks.php (~:221 — the changed-alias help text).
+- src/usr/local/www/pfblockerng/pfblockerng.php (~:87 — the OTHER post-ctx site, the synthetic
+  runhooks manual-test path; keep both sites consistent, or confirm which path is live).
+- README.md (~:385 the env-var table row) and CLAUDE.md (the env-var contract sentence; only
+  PFB_STATUS stays a reserved placeholder).
 - tests/php/ (the PHPUnit hook-context test, if one exists) and tests/smoke/test_smoke_hooks.py
   + tests/smoke/helpers.py (read_hook_env, the hooks fixture).
 - CLAUDE.md (worktree/PR flow, test-coverage rules: branch coverage + before/after).
 
 ACTION PLAN (ordered)
-1. CENTRAL ACCUMULATOR: introduce ONE pass-scoped list of changed alias names (e.g.
-   `$pfb['changed_aliases']`), initialised empty near the top of sync_package_pfblockerng
-   (so it is always defined at the hook). This is the single source the post ctx reads.
-2. IP side: populate it from the EXISTING updated-alias set. VERIFY whether
-   `$pfb_alias_lists` is populated independent of Reputation mode (the population sites at
-   ~:10583/:9905/:9931/:8311 appear unconditional within the "updated" branch — confirm by
+1. TWO ACCUMULATORS: introduce TWO pass-scoped lists, split by side —
+   `$pfb['changed_ip_aliases']` (IP firewall aliases) and `$pfb['changed_dnsbl_groups']`
+   (DNSBL groups) — both initialised empty near the top of sync_package_pfblockerng (so each
+   is always defined at the hook). Each is the single source its post ctx key reads.
+2. IP side: populate `$pfb['changed_ip_aliases']` from the EXISTING updated-alias set. VERIFY
+   whether `$pfb_alias_lists` is populated independent of Reputation mode (the population sites
+   at ~:10583/:9905/:9931/:8311 appear unconditional within the "updated" branch — confirm by
    reading). Use `$pfb_alias_lists` (the genuinely-updated set), NOT `$final_alias`. If — and
    only if — you find `$pfb_alias_lists` is itself rep-gated, fall back to recording at the
    two pfctl-replace sites and DOCUMENT the rep-mode inflation; otherwise the updated set is
    the answer. De-dup; names are already `pfB_*_v4/_v6`.
-3. DNSBL side: record each `DNSBL_<group>` that genuinely changed. Cleanest: inside
-   `dnsbl_alias_update()` when `$mode == 'update'`, append `$alias` to the accumulator
-   (this centralises all 'update' callers). CONFIRM every 'update' caller is change-gated
-   (the IDN/TLD_Allow/Regex specials rebuild when those features change — acceptable as
-   "changed"); if any 'update' call fires every pass regardless of change, exclude it or
-   note it. De-dup.
-4. WIRE THE CTX: at the post fire site, `'CHANGED_ALIASES' => implode(' ',
-   array_unique($pfb['changed_aliases']))`. Apply the SAME to the second ctx site in
-   pfblockerng.php:~87 (or document why only one is live). Leave `'STATUS' => 'ok'` as-is.
-5. UI: pfblockerng_hooks.php:~221 — replace "Currently always empty (reserved for future
-   use)" with an accurate description, e.g. "space-separated list of pfBlockerNG aliases
-   (pfB_* and DNSBL_*) updated this pass; empty when nothing changed." Leave the PFB_STATUS
-   help line unchanged (still reserved).
-6. DOCS: README.md:~385 table row for PFB_CHANGED_ALIASES → real description (drop "reserved
-   placeholder"). CLAUDE.md — narrow the "stable reserved placeholders" sentence to
-   PFB_STATUS only (PFB_CHANGED_ALIASES is now populated). Keep markdownlint clean.
+3. DNSBL side: record each `DNSBL_<group>` that genuinely changed into
+   `$pfb['changed_dnsbl_groups']`. Cleanest: inside `dnsbl_alias_update()` when
+   `$mode == 'update'`, append `$alias` to the DNSBL accumulator (this centralises all
+   'update' callers). CONFIRM every 'update' caller is change-gated (the IDN/TLD_Allow/Regex
+   specials rebuild when those features change — acceptable as "changed"); if any 'update'
+   call fires every pass regardless of change, exclude it or note it. De-dup.
+4. WIRE THE CTX: at the post fire site, replace the single changed-alias key with TWO keys:
+   `'CHANGED_IP_ALIASES' => implode(' ', array_unique($pfb['changed_ip_aliases']))` and
+   `'CHANGED_DNSBL_GROUPS' => implode(' ', array_unique($pfb['changed_dnsbl_groups']))`. The
+   runner prepends `PFB_` to ctx keys, so these yield exactly PFB_CHANGED_IP_ALIASES /
+   PFB_CHANGED_DNSBL_GROUPS. Apply the SAME two keys to the second ctx site in
+   pfblockerng.php:~87 (value '' there — no pass runs). Leave `'STATUS' => 'ok'` as-is.
+5. UI: pfblockerng_hooks.php:~221 — replace the single changed-alias help line with TWO lines:
+   PFB_CHANGED_IP_ALIASES ("space-separated list of IP firewall aliases (pfB_*) updated this
+   pass; empty when none") and PFB_CHANGED_DNSBL_GROUPS ("space-separated list of DNSBL groups
+   (DNSBL_*) updated this pass; empty when none"). Leave the PFB_STATUS help line unchanged
+   (still reserved).
+6. DOCS: README.md:~385 — split the single env-var table row into two rows (IP aliases +
+   DNSBL groups). CLAUDE.md — update the contract sentence to name both new vars (PFB_STATUS
+   remains the sole reserved placeholder). ADR.md §2/§6/§7 — reference the two vars. Keep
+   markdownlint clean.
 
 TESTS (branch coverage + before/after — both REQUIRED by CLAUDE.md)
-- PHPUnit (tests/php/): if the helpers reach the ctx builder, assert PFB_CHANGED_ALIASES is
-  EMPTY on a no-op pass AND contains the expected alias name(s) on a changed pass — both an
-  IP alias and a DNSBL alias. If the ctx build is not unit-reachable, state that and rely on
-  smoke (below). Add a faithful double to tests/php/pfsense_doubles.php only if a newly
-  reached pfSense fn needs one.
-- Smoke (tests/smoke/test_smoke_hooks.py): the module currently asserts PFB_CHANGED_ALIASES
-  PRESENT-and-EMPTY. Add/extend a case that (a) asserts EMPTY after a no-op reload (before
-  state), then (b) makes a known IP feed (and/or DNSBL group) change and asserts the
-  corresponding `pfB_*` / `DNSBL_*` token APPEARS in PFB_CHANGED_ALIASES (after state).
+- PHPUnit (tests/php/): the DNSBL recording seam `dnsbl_alias_update()` IS unit-reachable —
+  assert `$pfb['changed_dnsbl_groups']` is EMPTY before, collects `DNSBL_<group>` on 'update',
+  and records NOTHING on 'disabled' (branch coverage + before/after). The IP merge + ctx
+  implode live inside sync_package_pfblockerng (not unit-reachable off-appliance) and are
+  covered by smoke below. Add a faithful double to tests/php/pfsense_doubles.php only if a
+  newly reached pfSense fn needs one.
+- Smoke (tests/smoke/test_smoke_hooks.py): the module asserts the changed-alias vars
+  PRESENT-and-EMPTY. Add/extend a case that (a) asserts BOTH PFB_CHANGED_IP_ALIASES and
+  PFB_CHANGED_DNSBL_GROUPS present-and-EMPTY after a no-op reload (before state), then (b)
+  changes a known IP feed AND a DNSBL group and asserts the `pfB_*` token APPEARS in
+  PFB_CHANGED_IP_ALIASES and the `DNSBL_*` token in PFB_CHANGED_DNSBL_GROUPS (after state).
   Reuse the existing hooks fixture + read_hook_env helper. Keep the present-and-empty
-  no-op assertion as the OFF/before branch.
+  no-op assertions as the OFF/before branch.
 
 CONSTRAINTS
 - ADDITIVE: do not alter any existing update/reload logic; only read the existing
@@ -117,24 +128,25 @@ VERIFICATION (must all pass before the phase is done)
 - python -m pytest → green/unchanged.
 - php -l + PHPStan (--memory-limit=1G) → clean. vendor/bin/phpunit → green.
 - npx markdownlint-cli2 → 0 errors (README/CLAUDE/ADR touched).
-- diff-read: the accumulator is initialised once, fed only from existing updated-alias
-  signals (IP) and the 'update' path of dnsbl_alias_update (DNSBL), and read only at the
-  post ctx site(s); no existing update logic changed; STATUS untouched.
+- diff-read: the TWO accumulators are initialised once each, fed only from existing
+  updated-alias signals (IP `$pfb_alias_lists`) and the 'update' path of dnsbl_alias_update
+  (DNSBL), and read only at the post ctx site(s); no existing update logic changed; STATUS
+  untouched. A grep proves zero remaining `CHANGED_ALIASES`/`changed_aliases` (old name).
 
 EXPECTED RESULT
 A `post` hook on a pass that updates feed "MyList" and DNSBL group "ads" receives
-`PFB_CHANGED_ALIASES="pfB_MyList_v4 pfB_MyList_v6 DNSBL_ads"` (order/spacing not
-contractual); on a no-op pass it receives `PFB_CHANGED_ALIASES=""`. With no enabled hook the
-pass is byte-identical to today.
+`PFB_CHANGED_IP_ALIASES="pfB_MyList_v4 pfB_MyList_v6"` and
+`PFB_CHANGED_DNSBL_GROUPS="DNSBL_ads"` (order/spacing not contractual); on a no-op pass it
+receives both as `""`. With no enabled hook the pass is byte-identical to today.
 
 COMMIT (single)
-    pfblockerng: ADR-12 P6 populate PFB_CHANGED_ALIASES (IP + DNSBL updated aliases)
+    pfblockerng: ADR-12 P6 populate PFB_CHANGED_IP_ALIASES + PFB_CHANGED_DNSBL_GROUPS
 Push `adr/12` and open the PR (--body-file; seed from this prompt + ADR §2/§7). Rebase onto
 origin/devel first if behind.
 
 HANDOFF — write `.ADRs/ADR_12_Update_Hooks/RESULTS/06_Results.txt` (plain .txt)
-State: where the accumulator is declared; the IP source actually used (and the rep-mode
+State: where the two accumulators are declared; the IP source actually used (and the rep-mode
 verification result); the DNSBL recording point + which 'update' callers were counted; the
-ctx wiring site(s); the UI/README/CLAUDE edits; the PHPUnit + smoke cases added (before/after
-+ both IP and DNSBL); confirmation of the additive no-op; and a note that PFB_STATUS remains
-the sole reserved placeholder.
+two ctx wiring keys + site(s); the UI/README/CLAUDE edits; the PHPUnit + smoke cases added
+(before/after + both IP and DNSBL); confirmation of the additive no-op; and a note that
+PFB_STATUS remains the sole reserved placeholder.

--- a/.ADRs/ADR_12_Update_Hooks/ADR.md
+++ b/.ADRs/ADR_12_Update_Hooks/ADR.md
@@ -45,7 +45,7 @@ Add **admin-configurable pre/post update command hooks**: a list of hook entries
 | --- | --- |
 | **Hook model** | A **list of hook entries** in the pfBlockerNG config: `{ command, when: pre\|post, enabled: bool, description, timeout? }`. Mirrors pfSense `shellcmd`'s `{cmd, cmdtype}` shape; supports multiple hooks, ordering (list order), and enable/disable. |
 | **Fire points (whole-cycle)** | **`pre`** runs at the **top** of `sync_package_pfblockerng` (before any feed processing); **`post`** runs at the **end** (after IP/DNSBL reloads + `filter_configure`, at the closing tail `:10293`). **Two points only** — granularity beyond this is out of scope (the context flags make per-type points unnecessary). Fire on **every** trigger (cron, manual Update, Force Update/Reload); `PFB_TRIGGER` distinguishes them. |
-| **Context (env vars)** | Hooks receive env vars. **pre:** `PFB_TRIGGER` (cron\|update\|force-update\|force-reload), `PFB_WHEN=pre`. **post:** the above plus `PFB_IP_CHANGED`, `PFB_DNSBL_CHANGED` (0\|1, from `$pfbupdate`/`$pfbpython`), `PFB_STATUS` (ok\|partial\|error), and `PFB_CHANGED_ALIASES` (space-separated). Documented + stable. (pre can't know what changed yet — nothing downloaded.) |
+| **Context (env vars)** | Hooks receive env vars. **pre:** `PFB_TRIGGER` (cron\|update\|force-update\|force-reload), `PFB_WHEN=pre`. **post:** the above plus `PFB_IP_CHANGED`, `PFB_DNSBL_CHANGED` (0\|1, from `$pfbupdate`/`$pfbpython`), `PFB_STATUS` (ok\|partial\|error), and the split changed lists `PFB_CHANGED_IP_ALIASES` (space-separated `pfB_*`) + `PFB_CHANGED_DNSBL_GROUPS` (space-separated `DNSBL_*` — DNSBL groups are not firewall aliases). Documented + stable. (pre can't know what changed yet — nothing downloaded.) |
 | **Execution** | Run as **root** via `mwexec` **synchronously with a per-hook timeout** (sane default, e.g. 60 s, overridable); stdout/stderr captured to the pfBlockerNG log with a clear header. Synchronous + timeout (not detached) so failures are logged in order and a quick reload completes before the pass returns. |
 | **Failure semantics** | A hook's **non-zero exit or timeout is logged and the update CONTINUES** — pre **and** post. A bad/hung/typo'd hook can **never** brick or stall updates. (No "abort on failure"; if a hook is a hard precondition, that's the user's script's problem to signal — we still don't abort.) |
 | **Security / UI** | An **admin-only** settings table (add/edit/enable/reorder/delete; command, when, description, timeout) with help text documenting the env vars. Same root-command trust class as pfSense `shellcmd`; the field is clearly labelled as running as root. |
@@ -94,7 +94,7 @@ Add **admin-configurable pre/post update command hooks**: a list of hook entries
 
 1. **Additive:** no enabled hooks ⇒ byte-identical update pass.
 2. **Fires correctly:** `pre` at the start, `post` at the end, on cron + manual + force triggers; correct `PFB_TRIGGER`.
-3. **Context:** `post` hooks receive accurate `PFB_IP_CHANGED`/`PFB_DNSBL_CHANGED`/`PFB_STATUS`/`PFB_CHANGED_ALIASES`; `pre` receives `PFB_TRIGGER`/`PFB_WHEN`.
+3. **Context:** `post` hooks receive accurate `PFB_IP_CHANGED`/`PFB_DNSBL_CHANGED`/`PFB_STATUS`/`PFB_CHANGED_IP_ALIASES`/`PFB_CHANGED_DNSBL_GROUPS`; `pre` receives `PFB_TRIGGER`/`PFB_WHEN`.
 4. **Safe:** a failing hook (non-zero) is logged and the update continues; a hanging hook is killed at its timeout and the update continues — pre and post.
 5. **Admin-only UI:** the hooks table adds/edits/enables/reorders/deletes entries; help documents the env vars + the run-as-root caveat.
 6. **HAProxy recipe works end-to-end** (manual smoke): an IP update → post hook → graceful HAProxy reload → fresh `ipalias_*.lst` → a header ACL blocks a listed IP.
@@ -126,7 +126,7 @@ Prompt: `01_Hook_Runner_Prep.txt`
 
 Prompt: `02_Wire_Fire_Points.txt`
 
-- In `sync_package_pfblockerng`: call `pfb_run_hooks('pre', $ctx)` at the **top** (ctx = trigger), and `pfb_run_hooks('post', $ctx)` at the **closing tail** (`:10293`) with ctx built from `$pfbupdate`/`$pfbpython`/`$pfb['filter_configure']`/`$cron` → `PFB_IP_CHANGED`/`PFB_DNSBL_CHANGED`/`PFB_STATUS`/`PFB_CHANGED_ALIASES`. **Additive:** no enabled hooks ⇒ no-op ⇒ byte-identical. Fires on cron + manual + force.
+- In `sync_package_pfblockerng`: call `pfb_run_hooks('pre', $ctx)` at the **top** (ctx = trigger), and `pfb_run_hooks('post', $ctx)` at the **closing tail** (`:10293`) with ctx built from `$pfbupdate`/`$pfbpython`/`$pfb['filter_configure']`/`$cron` → `PFB_IP_CHANGED`/`PFB_DNSBL_CHANGED`/`PFB_STATUS`/`PFB_CHANGED_IP_ALIASES`/`PFB_CHANGED_DNSBL_GROUPS`. **Additive:** no enabled hooks ⇒ no-op ⇒ byte-identical. Fires on cron + manual + force.
 
 ### Phase 3 — Settings UI (hooks table, admin-only)
 
@@ -144,11 +144,11 @@ Prompt: `04_Recipe_Docs_Smoke_DoD.txt`
 
 No prompt (`RESULTS/05_Results.txt` only). Added the automated live-VM smoke module `tests/smoke/test_smoke_hooks.py` + the "Update hooks" helpers, mapping §7's no-op / pre-post-context / trigger-value / IP-DNSBL-changed / safety items to assertions. No production code touched.
 
-### Phase 6 — Populate `PFB_CHANGED_ALIASES` (IP + DNSBL)
+### Phase 6 — Populate `PFB_CHANGED_IP_ALIASES` + `PFB_CHANGED_DNSBL_GROUPS`
 
 Prompt: `06_Populate_Changed_Aliases.txt`
 
-- Turn the reserved-placeholder `PFB_CHANGED_ALIASES` into the real space-separated list of aliases **updated this pass**, both `pfB_*` (IP) and `DNSBL_*`. **Decision:** semantic = "updated this pass" (the signal the pass already computes — IP `$pfb_alias_lists`, DNSBL the `dnsbl_alias_update('update', …)` per-group seam), **not** a byte-level membership diff and **not** the rep-mode-inflated reloaded set (`$final_alias`); so it is Reputation-mode-independent. **Additive** — a single accumulator collecting names the pass already decided were updated; no new tracking. `PFB_STATUS` stays the reserved `ok` placeholder. A literal member-level diff remains a possible future increment.
+- Turn the reserved placeholder into the real space-separated lists of what was **updated this pass**, **split by side**: `PFB_CHANGED_IP_ALIASES` carries the IP firewall aliases (`pfB_*`) and `PFB_CHANGED_DNSBL_GROUPS` carries the DNSBL groups (`DNSBL_*`), each on its own var because DNSBL groups are not firewall aliases. **Decision:** semantic = "updated this pass" (the signal the pass already computes — IP `$pfb_alias_lists`, DNSBL the `dnsbl_alias_update('update', …)` per-group seam), **not** a byte-level membership diff and **not** the rep-mode-inflated reloaded set (`$final_alias`); so both are Reputation-mode-independent. **Additive** — two accumulators (`$pfb['changed_ip_aliases']` / `$pfb['changed_dnsbl_groups']`) collecting names the pass already decided were updated; no new tracking. `PFB_STATUS` stays the reserved `ok` placeholder. A literal member-level diff remains a possible future increment.
 
 ---
 
@@ -156,7 +156,7 @@ Prompt: `06_Populate_Changed_Aliases.txt`
 
 **Implementation status (2026-06-04): code + docs complete (Phases 1-4 landed on
 `adr/12`, Phase 5 smoke add-on merged); Status stays Proposed pending the maintainer
-live smoke below. Phase 6 (populate `PFB_CHANGED_ALIASES`) is a later additive follow-up.**
+live smoke below. Phase 6 (populate `PFB_CHANGED_IP_ALIASES` + `PFB_CHANGED_DNSBL_GROUPS`) is a later additive follow-up.**
 
 - No enabled hooks ⇒ byte-identical update pass; with hooks, `pre`/`post` fire on all triggers with correct context; a failing/hanging hook is logged + timed out and the update continues. **(Done — `pfb_run_hooks` early-returns with no enabled hooks; `/usr/bin/timeout -s TERM -k 5 <to> /bin/sh -c …` kills a hung hook as a process group, non-zero/timeout log-and-continue. Phase 1.)**
 - `php -l` + PHPStan + ShellCheck clean; `python -m pytest` untouched/green. **(Done — green every phase; ShellCheck N/A, no shell file shipped.)**
@@ -167,7 +167,7 @@ live smoke below. Phase 6 (populate `PFB_CHANGED_ALIASES`) is a later additive f
 
 - `PFB_WHEN` = `pre` | `post` (always). `PFB_TRIGGER` ∈ **`cron` | `update` | `force-reload`** — the §2-nominal `force-update` **collapses to `cron`** (GUI Force Update and scheduled cron arrive with an identical `$cron` and are indistinguishable). `update` = a settings save; `force-reload` = a GUI IP-only / DNSBL-only Force Reload.
 - post adds `PFB_IP_CHANGED` / `PFB_DNSBL_CHANGED` (`0`|`1`, **accurate** — derived from `$pfb['filter_configure']` and `$pfbupdate`/`$pfbpython`; these are the flags a recipe guards on).
-- `PFB_CHANGED_ALIASES` — **Phase 1-5: `''` reserved placeholder. Phase 6: populated** with the space-separated list of aliases updated this pass (`pfB_*` IP + `DNSBL_*`), sourced from the signal the pass already computes (IP `$pfb_alias_lists`; DNSBL the `dnsbl_alias_update('update', …)` per-group seam) — semantic = "updated this pass", Reputation-mode-independent, **not** a byte-level membership diff. Empty on a no-op pass.
+- `PFB_CHANGED_IP_ALIASES` / `PFB_CHANGED_DNSBL_GROUPS` — **Phase 1-5: a single `''` reserved placeholder. Phase 6: split + populated** as two space-separated lists of what was updated this pass — `PFB_CHANGED_IP_ALIASES` = the IP firewall aliases (`pfB_*`, from `$pfb_alias_lists`), `PFB_CHANGED_DNSBL_GROUPS` = the DNSBL groups (`DNSBL_*`, from the `dnsbl_alias_update('update', …)` per-group seam). Split because DNSBL groups are not firewall aliases. Both: semantic = "updated this pass", Reputation-mode-independent, **not** a byte-level membership diff; empty on a no-op pass.
 - `PFB_STATUS` = `ok` remains a **stable reserved placeholder**: no pass-wide error/partial accumulator exists and the ADR forbids inventing one. Its **name** is stable and always present; **do not branch a recipe on its value**. A future phase may add real status accumulation without changing the name.
 
 ### Reject / pivot criteria (decided)
@@ -203,7 +203,7 @@ live smoke below. Phase 6 (populate `PFB_CHANGED_ALIASES`) is a later additive f
 > `cron`), so it remains a manual-only check.
 
 - [x] **No-op.** With no enabled hooks, an update behaves exactly as before (no hook-runner log lines; pass output unchanged). *(automated: `tests/smoke/test_smoke_hooks.py::test_hooks_noop_no_marker`; plus the enabled-flag branch in `test_hooks_disabled_entry_not_run_then_enabled_runs`.)*
-- [x] **Pre/post fire + context.** Add a `pre` hook `command='env | grep ^PFB_'` and a `post` hook the same; run an update. `pre` logs `PFB_WHEN=pre` + `PFB_TRIGGER`; `post` logs `PFB_WHEN=post` + `PFB_TRIGGER` + `PFB_IP_CHANGED`/`PFB_DNSBL_CHANGED` (0|1) + `PFB_STATUS=ok` + `PFB_CHANGED_ALIASES=` (empty). Repeat across **scheduled cron** (`PFB_TRIGGER=cron`), **a settings save** (`update`), **GUI Force Update / Force Reload All** (also `cron`), and **GUI Force Reload of IP-only or DNSBL-only** (`force-reload`); confirm `PFB_IP_CHANGED`/`PFB_DNSBL_CHANGED` track what actually changed (e.g. an IP-only Force Reload that changes a table ⇒ `PFB_IP_CHANGED=1`). *(automated: `test_hooks_pre_and_post_fire_with_context` (pre-vs-post ctx + full env), `test_hooks_trigger_values` (`update`→`cron`, `updatednsbl`→`force-reload`), `test_hooks_ip_changed_reflects_pass` (IP pass ⇒ `PFB_IP_CHANGED=1`; DNSBL-only reload ⇒ `0` + `PFB_DNSBL_CHANGED=1`). Manual-only: the settings-save `PFB_TRIGGER=update` value, not reachable via a smoke verb.)*
+- [x] **Pre/post fire + context.** Add a `pre` hook `command='env | grep ^PFB_'` and a `post` hook the same; run an update. `pre` logs `PFB_WHEN=pre` + `PFB_TRIGGER`; `post` logs `PFB_WHEN=post` + `PFB_TRIGGER` + `PFB_IP_CHANGED`/`PFB_DNSBL_CHANGED` (0|1) + `PFB_STATUS=ok` + `PFB_CHANGED_IP_ALIASES`/`PFB_CHANGED_DNSBL_GROUPS` (empty on a no-op). Repeat across **scheduled cron** (`PFB_TRIGGER=cron`), **a settings save** (`update`), **GUI Force Update / Force Reload All** (also `cron`), and **GUI Force Reload of IP-only or DNSBL-only** (`force-reload`); confirm `PFB_IP_CHANGED`/`PFB_DNSBL_CHANGED` track what actually changed (e.g. an IP-only Force Reload that changes a table ⇒ `PFB_IP_CHANGED=1`). *(automated: `test_hooks_pre_and_post_fire_with_context` (pre-vs-post ctx + full env), `test_hooks_trigger_values` (`update`→`cron`, `updatednsbl`→`force-reload`), `test_hooks_ip_changed_reflects_pass` (IP pass ⇒ `PFB_IP_CHANGED=1`; DNSBL-only reload ⇒ `0` + `PFB_DNSBL_CHANGED=1`). Manual-only: the settings-save `PFB_TRIGGER=update` value, not reachable via a smoke verb.)*
 - [x] **Safety — non-zero.** A `post` hook `command='exit 7'` is logged with its non-zero exit and the update **completes** (test the same as a `pre` hook). *(automated: `test_hooks_failing_hook_does_not_abort_update` — a non-zero `pre` hook runs but does not abort; the later `post` hook still fires.)*
 - [x] **Safety — timeout.** A hook `command='sleep 30'` with `timeout=2` is killed (logged "timed out … continuing") and the update **completes** — verify both `pre` and `post`. *(automated: `test_hooks_timeout_killed_update_continues` — a `pre` hook is killed mid-run (marker has `START`, not `DONE`) and the `post` hook still fires.)*
 - [ ] **HA sync** (maintainer-manual; no CARP pair on the smoke image). On a CARP pair, the hooks replicate to the secondary's config and run on whichever node performs the update (a hook with an external side effect runs once per updating node — expected).

--- a/.ADRs/ADR_12_Update_Hooks/RESULTS/06_Results.txt
+++ b/.ADRs/ADR_12_Update_Hooks/RESULTS/06_Results.txt
@@ -1,0 +1,188 @@
+ADR-12 PHASE 6 RESULTS — Populate PFB_CHANGED_IP_ALIASES + PFB_CHANGED_DNSBL_GROUPS
+==================================================================================
+
+STATUS: DONE. The single reserved-placeholder PFB_CHANGED_ALIASES is SPLIT BY SIDE
+into TWO post-only env vars, because DNSBL groups are not firewall aliases:
+  - PFB_CHANGED_IP_ALIASES   = space-separated pfB_*_v4/_v6 IP firewall aliases updated
+                               this pass (the RENAME of the old PFB_CHANGED_ALIASES).
+  - PFB_CHANGED_DNSBL_GROUPS = space-separated DNSBL_<group> groups updated this pass.
+Each is sourced from the signal the pass already computes (Reputation-mode-independent,
+NOT a byte-level diff, NOT the rep-inflated $final_alias). Additive no-op preserved.
+The two booleans PFB_IP_CHANGED / PFB_DNSBL_CHANGED are UNCHANGED; PFB_STATUS stays the
+sole reserved 'ok' placeholder; PFB_TRIGGER / PFB_WHEN unchanged.
+
+Files changed (single commit):
+  - src/usr/local/pkg/pfblockerng/pfblockerng.inc            (two accumulator inits,
+        DNSBL seam append into the DNSBL accumulator, IP merge + two ctx keys + comments)
+  - src/usr/local/www/pfblockerng/pfblockerng.php            (synthetic runhooks test
+        path -- NOT the live ctx; both keys stay '' because no pass runs)
+  - src/usr/local/www/pfblockerng/pfblockerng_hooks.php      (UI help: two lines)
+  - README.md, CLAUDE.md, .ADRs/ADR_12_Update_Hooks/ADR.md, 06_Populate_Changed_Aliases.txt
+                                                             (env-var docs + the prompt)
+  - tests/smoke/test_smoke_hooks.py, tests/smoke/helpers.py  (two-var smoke case + ctx
+        test flipped to assert both keys; helper comments)
+  - tests/php/DnsblAliasUpdateChangedTest.php                (PHPUnit, 4 tests, renamed
+        accumulator)
+
+
+1. THE TWO ACCUMULATORS — where declared
+----------------------------------------
+$pfb['changed_ip_aliases'] = array();  and  $pfb['changed_dnsbl_groups'] = array();
+BOTH initialised together at the TOP of sync_package_pfblockerng (pfblockerng.inc,
+immediately after $pfb['filter_configure'] = FALSE, ~:7739) so each is ALWAYS defined
+at the post hook, even on a pass that processes nothing. Each is the single source its
+post ctx key reads. They live in $pfb (global), so the DNSBL seam (which uses
+`global $pfb`) appends to the SAME changed_dnsbl_groups accumulator the post fire reads.
+
+
+2. IP SOURCE USED + REP-MODE VERIFICATION
+-----------------------------------------
+SOURCE = $pfb_alias_lists (the genuinely-UPDATED set), NOT $final_alias.
+
+Rep-mode verification (read each population site): $pfb_alias_lists[] is appended ONLY
+inside per-feed "changed"/"removed" branches and is rep-mode-INDEPENDENT:
+  - :8311  alias removed (SKIP-list purge), inside `if ($pfb['enable']=='on' && ...)`
+  - :9905  continent table empty-and-recopied; :9931 continent MD5 changed
+  - :10583 IP feed updated (the main per-feed "Changes found... Updating" branch)
+Each of these ALSO appends to $pfb_alias_lists_all, but $pfb_alias_lists_all is the
+REPUTATION set (all active aliases). The post-fire `$final_alias` is built FROM
+$pfb_alias_lists_all under rep mode (array_intersect with active aliases) => it inflates
+to all active aliases when rep is on, and the no-rule branch's $final_alias is guarded
+by `if (!$pfb['save'])` => unreliable at the hook. So $final_alias was correctly
+REJECTED; $pfb_alias_lists is the honest cheap signal.
+
+WIRING: $pfb_alias_lists is a LOCAL of sync_package_pfblockerng, in scope only at the
+closing tail, so it is merged into $pfb['changed_ip_aliases'] right before the post fire
+(guarded `if (!empty($pfb_alias_lists) && is_array(...))`). Names are already
+pfB_<aliasname>_v4/_v6.
+
+
+3. DNSBL RECORDING POINT + 'update' CALLERS COUNTED
+---------------------------------------------------
+RECORDING POINT = inside dnsbl_alias_update() (def :2167), at the END of the
+`$mode == 'update'` block: `$pfb['changed_dnsbl_groups'][] = $alias;` (guarded by
+isset()+is_array() so a caller outside the pass is a no-op, never a fatal). This
+CENTRALISES every 'update' caller — recording $alias (always "DNSBL_<group>") into the
+DNSBL accumulator only (groups never reach the IP var).
+
+All FIVE 'update' callers counted, each confirmed change-gated:
+  - :9509  per-group feed loop — gated by `if ($pfb['aliasupdate'] && !$pfb['dnsbl_tld'])`
+           ($pfb['aliasupdate'] = the per-list "this list changed" flag).
+  - :4054  TLD-finalize loop — gated by `if (!empty($pfb['tld_update']))`, and
+           $pfb['tld_update'][$alias] is populated only under the same $pfb['aliasupdate']
+           gate => fires only for TLD groups that changed.
+  - :9542  DNSBL_IDN  — under `if ($pfb['dnsbl_idn'] == 'on')` (feature rebuilt).
+  - :9556  DNSBL_TLD_Allow — under `if ($pfb['dnsbl_pytld'] == 'on')`.
+  - :9583  DNSBL_Regex — under `if ($pfb['dnsbl_regex']=='on' || py-admitted regex>0)`.
+The three specials rebuild when their feature is enabled — acceptable as "updated this
+pass"; none fires unconditionally every pass. The 'disabled' mode records NOTHING
+(a disabled alias is not an update).
+
+
+4. THE TWO CTX WIRING KEYS + SITE(S)
+------------------------------------
+LIVE site (the only real one): pfblockerng.inc post fire (~:11637), the array passed to
+pfb_run_hooks('post', ...):
+  'CHANGED_IP_ALIASES'   => implode(' ', array_unique($pfb['changed_ip_aliases']))
+  'CHANGED_DNSBL_GROUPS' => implode(' ', array_unique($pfb['changed_dnsbl_groups']))
+Each de-duped via array_unique. 'STATUS' => 'ok' left as-is. The runner builds env vars
+as `'PFB_' . strtoupper($name) . '=' . escapeshellarg($value)` (pfb_run_hooks ~:1825),
+so these two keys yield exactly PFB_CHANGED_IP_ALIASES / PFB_CHANGED_DNSBL_GROUPS.
+
+SECOND ctx site (pfblockerng.php:~87, the `runhooks <pre|post>` MANUAL test path): this
+is NOT the live update ctx — it does not run sync_package_pfblockerng, so nothing is
+updated and there are no accumulators to read. Its post keys are FIXED SYNTHETIC values
+for exercising the runner without a pass. Both CHANGED_IP_ALIASES and CHANGED_DNSBL_GROUPS
+left => '' (correct: no update performed); a comment documents that the live, populated
+values are built only in pfblockerng.inc's tail. Both sites are consistent and documented.
+
+
+5. UI / README / CLAUDE / ADR / PROMPT EDITS
+--------------------------------------------
+- pfblockerng_hooks.php (~:221): the single changed-alias help line replaced by TWO:
+  PFB_CHANGED_IP_ALIASES ("space-separated list of IP firewall aliases (pfB_*) updated
+  this pass; empty when none") and PFB_CHANGED_DNSBL_GROUPS ("space-separated list of
+  DNSBL groups (DNSBL_*) updated this pass; empty when none"). PFB_STATUS help line
+  LEFT unchanged (still "reserved for future use").
+- README.md (~:385): the single env-var table row split into TWO rows (IP aliases +
+  DNSBL groups); prose updated to name both vars; PFB_STATUS kept as the reserved
+  placeholder.
+- CLAUDE.md: the env-var contract sentence now names both new vars; PFB_STATUS is the
+  sole remaining stable reserved placeholder.
+- ADR.md: §2 context row, §4 req 3, the Phase 2 wiring bullet, the §6 Phase 6 heading +
+  description, the §7 shipped-contract note, and the §7 DoD manual-smoke checklist item
+  all reference the two split vars.
+- 06_Populate_Changed_Aliases.txt: the phase prompt rewritten to the final two-var
+  design (title, role, decision, action plan, tests, expected result, commit message).
+
+
+6. TESTS ADDED (branch coverage + before/after, both required)
+--------------------------------------------------------------
+PHPUnit — tests/php/DnsblAliasUpdateChangedTest.php (4 tests; the DNSBL recording SEAM
+dnsbl_alias_update() IS a standalone function and is pinned here; the IP merge + final
+implode/array_unique live inside sync_package_pfblockerng and are NOT unit-reachable
+off-appliance, so they ride the live smoke below):
+  - testUpdateModeRecordsGroupWithBeforeState: asserts $pfb['changed_dnsbl_groups'] EMPTY
+    before, then 'update' => ['DNSBL_ads'] (before/after transition).
+  - testDisabledModeRecordsNothing: the OFF branch — 'disabled' records nothing.
+  - testMultipleUpdatesAccumulateInOrder: three 'update' calls fold in call order.
+  - testUpdateIsToleratedWhenAccumulatorUnset: guarded no-op when key unset (no fatal).
+
+Smoke — tests/smoke/test_smoke_hooks.py:
+  - test_hooks_changed_aliases_ip_and_dnsbl: BEFORE = a second update over the SAME,
+    unchanged IP+DNSBL feeds => BOTH PFB_CHANGED_IP_ALIASES and PFB_CHANGED_DNSBL_GROUPS
+    present-and-EMPTY (the no-op/empty branch, hook enabled); AFTER = rewrite BOTH feeds
+    => the updated IP table pfB_smokehookchgip_v4 appears in PFB_CHANGED_IP_ALIASES and
+    the DNSBL group DNSBL_smokehookchgd in PFB_CHANGED_DNSBL_GROUPS (each on its own var).
+    The empty-first-then-populated ordering proves the feed change CAUSED the report.
+  - test_hooks_pre_and_post_fire_with_context: this case injects an IpCase feed and runs
+    `updateip` (IP-only), which re-processes the feed => PFB_CHANGED_IP_ALIASES contains
+    pfB_smokehookctx_v4 (asserted present) while PFB_CHANGED_DNSBL_GROUPS is
+    present-and-EMPTY (asserted — the DNSBL side's empty branch under an IP-only reload).
+  - Module docstring "WHAT THIS FILE AUTOMATES" + the helpers.py ctx-set comment updated
+    to the two-var names.
+  test_hooks_noop_no_marker (no hook at all => marker ABSENT) remains the no-hook OFF
+  branch.
+
+
+7. ADDITIVE NO-OP CONFIRMATION
+------------------------------
+With no enabled 'post' hook, pfb_run_hooks('post', ...) returns at its
+`if (empty($hooks))` guard BEFORE touching the environment => byte-identical pass.
+The new statements are: (a) the two accumulator inits (new $pfb keys, read only by the
+post ctx); (b) the DNSBL seam append (mutates only changed_dnsbl_groups, guarded); (c)
+the IP array_merge (pure local op on changed_ip_aliases); (d) the two implode/array_unique
+inside the ctx ARRAY ARGUMENT passed to pfb_run_hooks (built but never consumed when
+hooks are empty). No existing update/reload/filter_configure logic was changed, moved, or
+duplicated. php -l / PHPStan / PHPUnit / pytest all green.
+
+
+8. PFB_STATUS / BOOLEANS
+------------------------
+PFB_STATUS UNTOUCHED — still 'ok' at the post fire and described as the SOLE remaining
+stable reserved placeholder in the UI help, README, CLAUDE.md, and ADR. The two booleans
+PFB_IP_CHANGED / PFB_DNSBL_CHANGED are UNCHANGED. PFB_TRIGGER / PFB_WHEN unchanged. No
+pass-wide ok/partial/error accumulator was invented (out of scope).
+
+
+9. GREP — ZERO STALE OLD-NAME REFERENCES
+----------------------------------------
+A worktree grep for `CHANGED_ALIASES` / `changed_aliases` (the old single name) finds NO
+stale reference in live code/tests/UI/README/CLAUDE/ADR.md. Remaining hits are
+intentional: the prior-phase frozen handoffs (RESULTS/01-05, prompts 02/03) describe what
+phases 1-5 shipped (the single placeholder) and are historically accurate; this phase's
+prompt deliberately names "the old PFB_CHANGED_ALIASES" when describing the rename; the
+smoke test function NAME test_hooks_changed_aliases_ip_and_dnsbl is a generic descriptor
+(not an env-var reference).
+
+
+10. GATE RESULTS
+----------------
+  python -m pytest                 PASS  (unchanged; smoke deselected as usual)
+  ruff check . / ruff format        PASS  (All checks passed)
+  php -l (inc / php / hooks.php)    PASS  (only the pre-existing pfb_unlock E_DEPRECATED)
+  PHPStan (--memory-limit=1G)       PASS  ([OK] No errors)
+  PHPUnit (full)                    PASS  (4 Phase-6 tests among them)
+  smoke collect (test_smoke_hooks)  PASS  (8 tests collected)
+  markdownlint-cli2                 PASS  (0 error(s))
+  ShellCheck                        N/A   (no shell file touched)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,8 +374,13 @@ enabled hooks ⇒ byte-identical pass). Admin-only **Update Hooks** settings tab
 Exported env (only these are promised): `PFB_WHEN` (`pre`|`post`), `PFB_TRIGGER`
 (`cron`|`update`|`force-reload` — the ADR's `force-update` collapses to `cron`),
 and post-only `PFB_IP_CHANGED`/`PFB_DNSBL_CHANGED` (`0`|`1`, accurate — guard on
-these) plus `PFB_STATUS`/`PFB_CHANGED_ALIASES` (stable reserved placeholders:
-`ok` / empty — do not branch on their value). The `post` hook sees the new DNSBL
+these), `PFB_CHANGED_IP_ALIASES` (post-only, space-separated `pfB_*` IP firewall
+aliases **updated this pass**) and `PFB_CHANGED_DNSBL_GROUPS` (post-only,
+space-separated `DNSBL_*` groups **updated this pass** — split from the IP aliases
+because DNSBL groups are not firewall aliases) — both sourced from the signal the
+pass already computes, Reputation-mode-independent, empty on a no-op pass; ADR-12
+Phase 6 — plus `PFB_STATUS` (the sole remaining stable reserved placeholder: always
+`ok` — do not branch on its value). The `post` hook sees the new DNSBL
 state live (ADR-10's bounded wait-for-apply above runs before the pass returns). Hooks
 live in config ⇒ replicate to a CARP/HA secondary and run on whichever node updates.
 The shipped **HAProxy recipe** (README) is a `post` hook guarded on

--- a/README.md
+++ b/README.md
@@ -382,16 +382,22 @@ no other value is promised):
 | `PFB_IP_CHANGED` | post | `0` \| `1` — IP-side (firewall) data changed this pass |
 | `PFB_DNSBL_CHANGED` | post | `0` \| `1` — DNSBL data changed this pass |
 | `PFB_STATUS` | post | reserved placeholder — currently always `ok` |
-| `PFB_CHANGED_ALIASES` | post | reserved placeholder — currently always empty |
+| `PFB_CHANGED_IP_ALIASES` | post | space-separated list of IP firewall aliases (`pfB_*`) updated this pass; empty when none |
+| `PFB_CHANGED_DNSBL_GROUPS` | post | space-separated list of DNSBL groups (`DNSBL_*`) updated this pass; empty when none |
 
 `PFB_IP_CHANGED` / `PFB_DNSBL_CHANGED` are **accurate** and are the flags a hook
 should guard on. `PFB_TRIGGER` emits exactly `cron | update | force-reload`:
 `update` is a settings save, `force-reload` is a GUI IP-only / DNSBL-only Force
 Reload, and `cron` covers scheduled cron **and** GUI Force Update / Force
 Reload (All) — the ADR's nominal `force-update` collapses to `cron` because both
-arrive identically. `PFB_STATUS` / `PFB_CHANGED_ALIASES` are stable reserved
-placeholders today (no pass-wide error or changed-alias accumulator exists);
-their **names** are stable, but do not branch a recipe on their value.
+arrive identically. `PFB_CHANGED_IP_ALIASES` and `PFB_CHANGED_DNSBL_GROUPS` list
+what the pass **updated** this run (feeds re-processed / list rebuilt / removed) —
+the IP firewall aliases (`pfB_*`) and the DNSBL groups (`DNSBL_*`) respectively, on
+their own vars because DNSBL groups are not firewall aliases — sourced from the
+signal the pass already computes; both are Reputation-mode-independent and are
+**not** a byte-level membership diff. `PFB_STATUS` remains a stable reserved
+placeholder (no pass-wide error accumulator exists); its **name** is stable, but do
+not branch a recipe on its value.
 Hooks live in `config.xml`, so they **replicate to a CARP/HA secondary and run on
 whichever node performs the update** — correct for the HAProxy recipe (the
 secondary's HAProxy needs its own reload), but be aware a hook with an external

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2203,6 +2203,19 @@ function dnsbl_alias_update($mode, $alias, $pfbfolder, $lists_dnsbl_current, $al
 		if (!$pfbfound) {
 			$pfb['dnsbl_info_stats'][] = array ( 'groupname' => $alias, 'timestamp' => $dns_now, 'entries' => $alias_cnt, 'counter' => 0);
 		}
+
+		// ADR-12 Phase 6: this is the central DNSBL changed-group seam. Every
+		// 'update' caller is change-gated -- the per-group feed loop fires it under
+		// $pfb['aliasupdate'] (inc:~9509), the TLD-finalize loop under non-empty
+		// $pfb['tld_update'] (inc:~4054), and the IDN/TLD_Allow/Regex specials rebuild
+		// when those features are enabled (inc:~9542/:9556/:9583). Recording $alias
+		// here (DNSBL_<group>) folds all of them into PFB_CHANGED_DNSBL_GROUPS with no
+		// new tracking. De-dup happens when the post hook emits the list. DNSBL groups
+		// are NOT firewall aliases, so they ride their own accumulator/env var (split
+		// from the IP-side $pfb['changed_ip_aliases']).
+		if (isset($pfb['changed_dnsbl_groups']) && is_array($pfb['changed_dnsbl_groups'])) {
+			$pfb['changed_dnsbl_groups'][] = $alias;
+		}
 	}
 	elseif ($mode == 'disabled') {
 		// Record disabled alias statistics
@@ -7723,6 +7736,23 @@ function sync_package_pfblockerng($cron='') {
 	$pfb['conf_mod']		= FALSE;	// Flag to check for mods to the config.xml file. ('$pfb_config' array to hold changes)
 	$pfb['filter_configure']	= FALSE;	// Flag to call filter_configure once
 
+	// ADR-12 Phase 6: TWO pass-scoped accumulators of the names UPDATED this pass,
+	// split by side because DNSBL groups are NOT firewall aliases. They feed the
+	// 'post' hook's PFB_CHANGED_IP_ALIASES and PFB_CHANGED_DNSBL_GROUPS. Both are
+	// initialised empty here so they are always defined at the hook (even on a pass
+	// that processes nothing); each is the SINGLE source its post key reads, and each
+	// collects names the pass ALREADY decided were updated -- no new tracking
+	// machinery. Fed from two existing signals:
+	//   * changed_ip_aliases <- the IP-side updated set ($pfb_alias_lists, pfB_*_v4/_v6)
+	//     copied in at the tail below.
+	//   * changed_dnsbl_groups <- the DNSBL-side dnsbl_alias_update('update', ...) seam
+	//     (DNSBL_<group>), appended as it runs.
+	// Each is de-duped when emitted. Semantic = "updated this pass" (feeds re-processed
+	// / list rebuilt / removed), Reputation-mode-INDEPENDENT (it is NOT $final_alias,
+	// which rep mode inflates to all active aliases).
+	$pfb['changed_ip_aliases']	= array();
+	$pfb['changed_dnsbl_groups']	= array();
+
 	// Detect boot process or package installation
 	if (is_platform_booting() || $g['pfblockerng_install']) {
 		// Create DNSBL NAT, VIP, Lighttpd service and certs if required on reboot.
@@ -11588,16 +11618,33 @@ function sync_package_pfblockerng($cron='') {
 	//       clear, SafeSearch) that leave the builders untouched. !empty() reads as 0
 	//       for any flag whose block did not run -- no undefined-variable warning.
 	//   PFB_TRIGGER       = pfb_hook_trigger($cron).
-	// PFB_STATUS and PFB_CHANGED_ALIASES have no clean pass-wide signal today, so they
-	// are reported as 'ok' / '' (the ADR forbids inventing tracking machinery). No
-	// enabled 'post' hook => pfb_run_hooks() returns immediately (byte-identical pass).
+	//   PFB_CHANGED_IP_ALIASES = the space-separated list of IP firewall aliases UPDATED
+	//       this pass (ADR-12 Phase 6) = $pfb_alias_lists (the genuinely-updated set --
+	//       pfB_*_v4/_v6 -- populated only inside the per-feed "changed"/"removed"
+	//       branches; NOT $final_alias, which rep mode inflates to all active aliases).
+	//       The IP locals are in scope only at this tail, so they are merged into
+	//       $pfb['changed_ip_aliases'] here, then de-duped at emit.
+	//   PFB_CHANGED_DNSBL_GROUPS = the space-separated list of DNSBL groups UPDATED this
+	//       pass (ADR-12 Phase 6) = the DNSBL_<group> names appended at the
+	//       dnsbl_alias_update() 'update' seam into $pfb['changed_dnsbl_groups'], de-duped
+	//       at emit. DNSBL groups are NOT firewall aliases, so they ride their own var.
+	//       Both lists are empty on a no-op pass. Semantic = "updated this pass",
+	//       Reputation-mode-INDEPENDENT; a member-level diff stays a future increment.
+	// PFB_STATUS has no clean pass-wide ok/partial/error signal today, so it is reported
+	// as 'ok' (a stable reserved placeholder; the ADR forbids inventing an accumulator
+	// for it -- do not branch a recipe on its value). No enabled 'post' hook =>
+	// pfb_run_hooks() returns immediately (byte-identical pass).
+	if (!empty($pfb_alias_lists) && is_array($pfb_alias_lists)) {
+		$pfb['changed_ip_aliases'] = array_merge($pfb['changed_ip_aliases'], $pfb_alias_lists);
+	}
 	pfb_run_hooks('post', array(
 		'TRIGGER'		=> pfb_hook_trigger($cron),
 		'IP_CHANGED'		=> !empty($pfb['filter_configure'])	? '1' : '0',
 		'DNSBL_CHANGED'		=> (!empty($pfbupdate) || !empty($pfbpython) || !empty($pfb['domain_update']) ||
 						!empty($pfb['domain_clear']) || !empty($safesearch_update)) ? '1' : '0',
 		'STATUS'		=> 'ok',
-		'CHANGED_ALIASES'	=> '',
+		'CHANGED_IP_ALIASES'	=> implode(' ', array_unique($pfb['changed_ip_aliases'])),
+		'CHANGED_DNSBL_GROUPS'	=> implode(' ', array_unique($pfb['changed_dnsbl_groups'])),
 	));
 }
 

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -77,14 +77,24 @@ if (isset($argv[1])) {
 	// pass). Usage: pfblockerng.php runhooks <pre|post> [trigger]
 	// Runs the configured 'pre'/'post' hooks with a synthetic context so the
 	// runner can be exercised live without performing an update.
+	//
+	// This path does NOT run sync_package_pfblockerng, so NOTHING is updated --
+	// the LIVE post context (incl. the real PFB_CHANGED_IP_ALIASES /
+	// PFB_CHANGED_DNSBL_GROUPS populated from $pfb['changed_ip_aliases'] /
+	// $pfb['changed_dnsbl_groups'], ADR-12 Phase 6) is built only in
+	// pfblockerng.inc's closing tail. Here every post key is a fixed synthetic
+	// value, and both changed lists are '' BECAUSE no pass ran (no alias/group was
+	// updated) -- not a reserved placeholder. PFB_STATUS stays the reserved 'ok'
+	// placeholder there too.
 	elseif ($argv[1] == 'runhooks') {
 		$when = ($argv[2] ?? '') === 'post' ? 'post' : 'pre';
 		$ctx  = array('TRIGGER' => ($argv[3] ?? 'manual-test'));
 		if ($when == 'post') {
-			$ctx['IP_CHANGED']      = '0';
-			$ctx['DNSBL_CHANGED']   = '0';
-			$ctx['STATUS']          = 'ok';
-			$ctx['CHANGED_ALIASES'] = '';
+			$ctx['IP_CHANGED']           = '0';
+			$ctx['DNSBL_CHANGED']        = '0';
+			$ctx['STATUS']               = 'ok';
+			$ctx['CHANGED_IP_ALIASES']   = '';	// no update performed by this test path
+			$ctx['CHANGED_DNSBL_GROUPS'] = '';	// no update performed by this test path
 		}
 		pfb_run_hooks($when, $ctx);
 		exit;

--- a/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
@@ -218,8 +218,10 @@ $section->addInput(new Form_StaticText(
 		. '<code>0</code>.') . '<br />'
 	. '<code>PFB_STATUS</code> &mdash; ' . gettext('overall pass status. Currently always <code>ok</code> (reserved '
 		. 'for future use).') . '<br />'
-	. '<code>PFB_CHANGED_ALIASES</code> &mdash; ' . gettext('space-separated list of changed aliases. Currently '
-		. 'always empty (reserved for future use).')
+	. '<code>PFB_CHANGED_IP_ALIASES</code> &mdash; ' . gettext('space-separated list of IP firewall aliases '
+		. '(<code>pfB_*</code>) updated this pass; empty when none.') . '<br />'
+	. '<code>PFB_CHANGED_DNSBL_GROUPS</code> &mdash; ' . gettext('space-separated list of DNSBL groups '
+		. '(<code>DNSBL_*</code>) updated this pass; empty when none.')
 	. '</small>'
 ));
 

--- a/tests/php/DnsblAliasUpdateChangedTest.php
+++ b/tests/php/DnsblAliasUpdateChangedTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-12 Phase 6: dnsbl_alias_update() is the central DNSBL changed-group seam.
+ * On $mode == 'update' it must append the DNSBL_<group> $alias to the pass-scoped
+ * accumulator $pfb['changed_dnsbl_groups'] (the single source the 'post' hook reads
+ * to build PFB_CHANGED_DNSBL_GROUPS); on $mode == 'disabled' it must NOT record
+ * anything. DNSBL groups are NOT firewall aliases, so they ride their own
+ * accumulator/env var, split from the IP-side $pfb['changed_ip_aliases'].
+ *
+ * Branch coverage (both modes) + before/after (assert the accumulator is empty
+ * BEFORE the 'update' call, then non-empty after, so the green proves the call
+ * caused the change). The 'update' call here passes an empty $lists_dnsbl_current
+ * ('') so the master-file fopen block is skipped -- only the stats + the accumulator
+ * append run, which is exactly the recording behaviour under test (no live config).
+ */
+#[CoversFunction('dnsbl_alias_update')]
+final class DnsblAliasUpdateChangedTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		// Reset the pass-scoped state these tests inspect (the real pass clears
+		// $pfb['changed_dnsbl_groups'] at the top of sync_package_pfblockerng).
+		$GLOBALS['pfb']['changed_dnsbl_groups'] = array();
+		$GLOBALS['pfb']['dnsbl_info_stats'] = array();
+	}
+
+	public function testUpdateModeRecordsGroupWithBeforeState(): void
+	{
+		global $pfb;
+
+		// BEFORE: nothing updated yet.
+		$this->assertSame(array(), $pfb['changed_dnsbl_groups']);
+
+		dnsbl_alias_update('update', 'DNSBL_ads', '', '', 7);
+
+		// AFTER: the 'update' call recorded exactly this DNSBL group.
+		$this->assertSame(array('DNSBL_ads'), $pfb['changed_dnsbl_groups']);
+	}
+
+	public function testDisabledModeRecordsNothing(): void
+	{
+		global $pfb;
+
+		$this->assertSame(array(), $pfb['changed_dnsbl_groups']);
+
+		dnsbl_alias_update('disabled', 'DNSBL_ads', '', '', '');
+
+		// The OFF branch: a disabled alias is NOT an update, so it must not appear.
+		$this->assertSame(array(), $pfb['changed_dnsbl_groups']);
+	}
+
+	public function testMultipleUpdatesAccumulateInOrder(): void
+	{
+		global $pfb;
+
+		dnsbl_alias_update('update', 'DNSBL_ads', '', '', 1);
+		dnsbl_alias_update('update', 'DNSBL_IDN', '', '', 1);
+		dnsbl_alias_update('update', 'DNSBL_Regex', '', '', 1);
+
+		// All three 'update' callers fold into the accumulator in call order.
+		// (De-dup happens only when the post hook emits the list.)
+		$this->assertSame(array('DNSBL_ads', 'DNSBL_IDN', 'DNSBL_Regex'), $pfb['changed_dnsbl_groups']);
+	}
+
+	public function testUpdateIsToleratedWhenAccumulatorUnset(): void
+	{
+		global $pfb;
+
+		// Defensive: if the accumulator was never initialised (e.g. a caller
+		// outside the pass), the 'update' append is a guarded no-op, not a fatal.
+		unset($pfb['changed_dnsbl_groups']);
+		dnsbl_alias_update('update', 'DNSBL_ads', '', '', 1);
+		$this->assertArrayNotHasKey('changed_dnsbl_groups', $pfb);
+	}
+}

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -847,7 +847,7 @@ def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
 # which is exactly how these smoke tests observe a hook's environment and that it
 # ran. The env carries PFB_WHEN plus one PFB_<UPPER(key)> per ctx entry
 # (inc:1797): pre ⇒ {WHEN, TRIGGER}; post ⇒ {WHEN, TRIGGER, IP_CHANGED,
-# DNSBL_CHANGED, STATUS, CHANGED_ALIASES}. reload(vm, scope) fires the hooks
+# DNSBL_CHANGED, STATUS, CHANGED_IP_ALIASES, CHANGED_DNSBL_GROUPS}. reload(vm, scope) fires the hooks
 # because it runs the same ``pfblockerng.php <scope>`` CLI the GUI/cron use.
 
 HOOK_MARKER_DIR = "/tmp"
@@ -986,7 +986,7 @@ def read_hook_env(vm: SmokeVM, path: str, *, timeout: float = 30.0) -> dict[str,
     ``cat`` the marker; a non-zero rc (file missing ⇒ the hook never ran) returns
     None so callers can distinguish "did not fire" from "fired with empty PFB_*".
     Only ``PFB_*`` lines are kept (the rest of root's env is noise); each is split
-    on the FIRST ``=`` so an empty value (``PFB_CHANGED_ALIASES=``) parses to ''
+    on the FIRST ``=`` so an empty value (``PFB_CHANGED_DNSBL_GROUPS=``) parses to ''
     and a value containing ``=`` is preserved.
     """
     result = vm.ssh("cat", path, timeout=timeout)

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -20,7 +20,7 @@ WHAT THIS FILE AUTOMATES (ADR §7 manual-smoke checklist):
 * **No-op** — no enabled hooks ⇒ no marker, update succeeds (the OFF branch + the
   byte-identical baseline).
 * **Pre/post fire + context** — both fire points with their full exported context;
-  the pre-vs-post context branch (pre has no IP/DNSBL/STATUS/CHANGED_ALIASES keys).
+  the pre-vs-post context branch (pre has no IP/DNSBL/STATUS/changed-list keys).
 * **Trigger values** — ``PFB_TRIGGER`` for both reachable verbs (``update`` ⇒
   ``cron``; ``updateip``/``updatednsbl`` ⇒ ``force-reload``).
 * **IP/DNSBL-changed** — both sides of ``PFB_IP_CHANGED`` (1 on an IP-affecting
@@ -29,6 +29,9 @@ WHAT THIS FILE AUTOMATES (ADR §7 manual-smoke checklist):
   continues (the next/other hooks still run).
 * **Safety — timeout** — a hook that overruns its ``timeout`` is killed mid-run and
   the pass continues.
+* **Changed aliases/groups** — ``PFB_CHANGED_IP_ALIASES`` + ``PFB_CHANGED_DNSBL_GROUPS``
+  (ADR-12 P6) are empty on a no-op pass; the updated ``pfB_*`` IP table appears in the
+  former and the updated ``DNSBL_*`` group in the latter when feeds change.
 
 WHAT STAYS MAINTAINER-MANUAL (the smoke image has neither package): **HA sync** (no
 CARP pair on the single-NIC image) and the **HAProxy recipe end-to-end** (no HAProxy
@@ -178,7 +181,10 @@ def test_hooks_pre_and_post_fire_with_context(deployed_vm: SmokeVM, mock_feeds: 
       ``PFB_TRIGGER=force-reload``, and NO ``PFB_IP_CHANGED`` key.
     * ``post`` ctx is the full set ⇒ ``PFB_WHEN=post``, ``PFB_TRIGGER=force-reload``,
       ``PFB_IP_CHANGED`` present, ``PFB_DNSBL_CHANGED`` present, ``PFB_STATUS=ok``, and
-      ``PFB_CHANGED_ALIASES`` present-and-EMPTY (a stable reserved placeholder).
+      both changed-list keys present (ADR-12 P6: this ``updateip`` re-processes the
+      injected IP feed, so the updated table ``pfB_smokehookctx_v4`` appears in
+      ``PFB_CHANGED_IP_ALIASES``; no DNSBL group changes, so ``PFB_CHANGED_DNSBL_GROUPS``
+      is present-and-empty — the DNSBL side's empty branch).
 
     The absence of ``PFB_IP_CHANGED`` on pre AND its presence on post is the proof
     the two fire points carry different contexts, not one shared blob.
@@ -218,9 +224,18 @@ def test_hooks_pre_and_post_fire_with_context(deployed_vm: SmokeVM, mock_feeds: 
     assert "PFB_IP_CHANGED" in post_env, f"post ctx missing PFB_IP_CHANGED: {post_env}"
     assert "PFB_DNSBL_CHANGED" in post_env, f"post ctx missing PFB_DNSBL_CHANGED: {post_env}"
     assert post_env.get("PFB_STATUS") == "ok", f"post PFB_STATUS wrong: {post_env}"
-    # CHANGED_ALIASES is a reserved placeholder: present-and-empty, not absent.
-    assert "PFB_CHANGED_ALIASES" in post_env, f"post ctx missing PFB_CHANGED_ALIASES: {post_env}"
-    assert post_env["PFB_CHANGED_ALIASES"] == "", f"post PFB_CHANGED_ALIASES not empty: {post_env}"
+    # PFB_STATUS stays the sole reserved placeholder (always 'ok').
+    # Both changed-list keys (ADR-12 P6) are always PRESENT; this updateip re-processed
+    # the injected IP feed, so the updated table appears in PFB_CHANGED_IP_ALIASES while
+    # PFB_CHANGED_DNSBL_GROUPS stays present-and-empty (no DNSBL group changed).
+    assert "PFB_CHANGED_IP_ALIASES" in post_env, f"post ctx missing PFB_CHANGED_IP_ALIASES: {post_env}"
+    assert spec.alias in post_env["PFB_CHANGED_IP_ALIASES"].split(), (
+        f"updated IP table {spec.alias} not in PFB_CHANGED_IP_ALIASES: {post_env}"
+    )
+    assert "PFB_CHANGED_DNSBL_GROUPS" in post_env, f"post ctx missing PFB_CHANGED_DNSBL_GROUPS: {post_env}"
+    assert post_env["PFB_CHANGED_DNSBL_GROUPS"] == "", (
+        f"post PFB_CHANGED_DNSBL_GROUPS should be empty (no DNSBL change): {post_env}"
+    )
 
     h.clear_update_hooks(deployed_vm)
 
@@ -432,5 +447,82 @@ def test_hooks_timeout_killed_update_continues(deployed_vm: SmokeVM) -> None:
     )
     if "TIMED OUT" not in log_grep.stdout:
         print(f"[smoke] note: no 'TIMED OUT' line found in the pfBlockerNG log (non-fatal): {log_grep.stdout!r}")
+
+    h.clear_update_hooks(deployed_vm)
+
+
+# --------------------------------------------------------------------------- #
+# 8) PFB_CHANGED_IP_ALIASES + PFB_CHANGED_DNSBL_GROUPS — empty on a no-op pass,
+#    the updated alias/group on a change (split by side)
+# --------------------------------------------------------------------------- #
+
+
+def test_hooks_changed_aliases_ip_and_dnsbl(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """``PFB_CHANGED_IP_ALIASES`` / ``PFB_CHANGED_DNSBL_GROUPS`` (ADR-12 P6) list what was
+    UPDATED this pass, split by side (DNSBL groups are not firewall aliases).
+
+    Both branches of the changed signal, with the no-op state asserted FIRST so a green
+    proves the feed change CAUSED the alias/group to be reported (CLAUDE.md before/after
+    rule):
+
+    * **BEFORE (no-op).** After a first full ``update`` that processes the injected IP
+      + DNSBL feeds, a SECOND full ``update`` over the SAME, UNCHANGED feeds re-reads
+      nothing new ⇒ neither the IP ``$pfb_alias_lists`` site nor the DNSBL
+      ``dnsbl_alias_update('update', …)`` seam fires for them ⇒ BOTH
+      ``PFB_CHANGED_IP_ALIASES`` and ``PFB_CHANGED_DNSBL_GROUPS`` are EMPTY (the post
+      hook is enabled, so present-and-empty, not absent).
+    * **AFTER (changed).** Rewriting BOTH feeds with new content and running a full
+      ``update`` re-processes both ⇒ the IP table ``pfB_<ip>_v4`` appears in
+      ``PFB_CHANGED_IP_ALIASES`` and the DNSBL group ``DNSBL_<dnsbl>`` in
+      ``PFB_CHANGED_DNSBL_GROUPS`` (each space-separated, on its own var).
+
+    Reputation-mode-independent by construction: it is the updated set
+    (``$pfb_alias_lists`` + the DNSBL seam), NOT the rep-inflated ``$final_alias``.
+    """
+    token = "chgali"
+    marker = h.hook_marker_path(token, "post")
+
+    fed_ip = "198.51.100.7"
+    ip_feed = h.write_local_feed(deployed_vm, "smoke_hook_chgali_ip.txt", f"{fed_ip}\n")
+    ip_spec = h.IpCase(aliasname="smokehookchgip", feed_url=ip_feed, header="smokehookchgip")
+    domain = h.unique_domain("hookchg")
+    dnsbl_feed = h.write_local_feed(deployed_vm, "smoke_hook_chgali_dnsbl.txt", f"{domain}\n")
+    dnsbl_spec = h.DnsblCase(
+        aliasname="smokehookchgd", feed_url=dnsbl_feed, header="smokehookchgd", mode=h.DnsblMode.NULL
+    )
+    h.inject(deployed_vm, ip_spec)
+    h.inject(deployed_vm, dnsbl_spec)
+    h.set_update_hooks(deployed_vm, [h.env_dump_hook(token, "post")])
+
+    # Settle: a first full update processes both feeds (their aliases ARE updated here).
+    h.clear_hook_markers(deployed_vm, token)
+    h.reload(deployed_vm, "update")
+
+    # BEFORE: a second update over the UNCHANGED feeds updates nothing ⇒ both lists empty.
+    h.clear_hook_markers(deployed_vm, token)
+    h.reload(deployed_vm, "update")
+    env_noop = h.read_hook_env(deployed_vm, marker)
+    assert env_noop is not None, "post hook did not run for the no-op update"
+    assert env_noop.get("PFB_CHANGED_IP_ALIASES", None) == "", (
+        f"PFB_CHANGED_IP_ALIASES should be EMPTY when no IP alias was updated, got {env_noop}"
+    )
+    assert env_noop.get("PFB_CHANGED_DNSBL_GROUPS", None) == "", (
+        f"PFB_CHANGED_DNSBL_GROUPS should be EMPTY when no DNSBL group was updated, got {env_noop}"
+    )
+
+    # AFTER: rewrite BOTH feeds with new content ⇒ both are re-processed.
+    domain2 = h.unique_domain("hookchg2")
+    h.write_local_feed(deployed_vm, "smoke_hook_chgali_ip.txt", f"{fed_ip}\n203.0.113.9\n")
+    h.write_local_feed(deployed_vm, "smoke_hook_chgali_dnsbl.txt", f"{domain}\n{domain2}\n")
+    h.clear_hook_markers(deployed_vm, token)
+    h.reload(deployed_vm, "update")
+    env_chg = h.read_hook_env(deployed_vm, marker)
+    assert env_chg is not None, "post hook did not run for the changed update"
+    changed_ip = env_chg.get("PFB_CHANGED_IP_ALIASES", "").split()
+    changed_dnsbl = env_chg.get("PFB_CHANGED_DNSBL_GROUPS", "").split()
+    assert ip_spec.alias in changed_ip, f"updated IP table {ip_spec.alias} not in PFB_CHANGED_IP_ALIASES: {env_chg}"
+    assert dnsbl_spec.alias in changed_dnsbl, (
+        f"updated DNSBL group {dnsbl_spec.alias} not in PFB_CHANGED_DNSBL_GROUPS: {env_chg}"
+    )
 
     h.clear_update_hooks(deployed_vm)


### PR DESCRIPTION
## ADR-12 Phase 6 — populate the changed-alias hook env vars

Turns the reserved-placeholder changed-alias context (formerly `PFB_CHANGED_ALIASES`, always `''`) into **two** populated `post`-hook env vars, surfacing a signal the update pass already computes:

| Env var | Contents |
| --- | --- |
| `PFB_CHANGED_IP_ALIASES` | space-separated IP firewall aliases updated this pass (`pfB_*_v4/_v6`) |
| `PFB_CHANGED_DNSBL_GROUPS` | space-separated DNSBL groups updated this pass (`DNSBL_<group>`) |

Both empty on a no-op pass. The booleans `PFB_IP_CHANGED` / `PFB_DNSBL_CHANGED` and the reserved `PFB_STATUS` placeholder are unchanged.

### Design decisions

- **Two vars, split by side.** DNSBL groups are not firewall aliases, so they get their own var rather than being mixed into an alias list.
- **DNSBL var named `PFB_CHANGED_DNSBL_GROUPS`**, not `PFB_CHANGED_DNSBL` — the latter is one word-swap from the existing boolean `PFB_DNSBL_CHANGED` and a recipe footgun.
- **Semantic = "updated this pass"**, sourced from what the pass already decides changed — IP from `$pfb_alias_lists` (the updated-set, **Reputation-mode-independent**, *not* the rep-inflated `$final_alias`); DNSBL from the `dnsbl_alias_update('update', …)` per-group seam. Not a byte-level membership diff (a possible future increment).
- **Additive:** with no enabled `post` hook, `pfb_run_hooks` early-returns ⇒ the pass is byte-identical to today. No new tracking machinery — just two accumulators collecting names the pass already flagged.

### Tests

- PHPUnit `DnsblAliasUpdateChangedTest` — the DNSBL accumulator collects `DNSBL_<group>` on `'update'`, nothing on `'disabled'` (before/after + branch coverage).
- Smoke `test_smoke_hooks.py` — both vars present-and-empty on a no-op pass (before), then the changed `pfB_*` token appears in `PFB_CHANGED_IP_ALIASES` and the changed `DNSBL_*` token in `PFB_CHANGED_DNSBL_GROUPS` after a real feed/group change (after).

### Docs

UI help (`pfblockerng_hooks.php`), `README.md`, `CLAUDE.md`, and `.ADRs/ADR_12_Update_Hooks/ADR.md` (§2 context row, §6 Phase 6, §7 contract) all updated to the two-var design. `RESULTS/06_Results.txt` records the phase.

ADR-12 Status stays **Proposed** pending the maintainer's live-box manual smoke (§7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Update Hooks environment variable contract for post-hooks: `PFB_CHANGED_ALIASES` is now split into `PFB_CHANGED_IP_ALIASES` (updated IP firewall aliases) and `PFB_CHANGED_DNSBL_GROUPS` (updated DNSBL groups), enabling more granular hook actions.

* **Tests**
  * Added comprehensive test coverage for tracking and reporting updated IP aliases and DNSBL groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->