### PR TITLE
tests: add Tier-B CRUD-config flows (Batch 3: category/category_edit/blacklist)

### DIFF
--- a/tests/smoke/ui/test_blacklist.py
+++ b/tests/smoke/ui/test_blacklist.py
@@ -1,0 +1,398 @@
+"""Tier-B functional flows for the DNSBL Category / blacklist page (ADR-14 Phase 3).
+
+Marker ``ui_e2e`` -- daily / on-demand, NOT in the default run nor the PR gate
+(the whole ``tests/smoke`` tree is ``--ignore``d in the default
+``python -m pytest``; this tier is run with
+``pytest tests/smoke -m ui_e2e --override-ini="addopts="``).
+
+Page under test: ``pfblockerng_blacklist.php`` -- the squidguard-style "blacklist
+provider" categories page. Its config root is the BARE node
+``installedpackages/pfblockerngblacklist`` (NO ``/config/0`` array), holding the
+scalar selects (``blacklist_enable`` / ``blacklist_lang`` / ``blacklist_selected``
+/ ``blacklist_freq`` / ``blacklist_logging``) and the per-provider ``item`` list
+(one entry per ``*_global_usage`` provider: ``{xml, title, feed, size, selected,
+...}``). The smoke image ships exactly ONE live provider, ``ut1`` (XML ``ut1``,
+TITLE ``UT1``, NO ``REG:`` line -> no subscription, so no username/password
+fields); ``shallalist`` is unconditionally dropped by the page (inc note
+"Temporarily Discontinue Shallalist"). So ``item/0`` is always ut1's entry and
+its categories (``adult``, ``publicite``, ...) are the validated selection set.
+
+As with the sibling Tier-B suites the oracle is the box's EFFECTIVE state --
+``config.xml`` read via :func:`tests.smoke.helpers.config_get` (or, for the
+``item`` list, a faithful PHP read that walks ``item`` exactly as the page's own
+``foreach`` does, immune to single-element list-collapse) -- NEVER the HTTP
+response body. Every flow is a TRUE transition test (CLAUDE.md): it asserts the
+ORIGINAL value, drives the POST, asserts the NEW value, then restores in a
+``finally`` so a mid-test failure cannot poison the session-scoped VM, and a
+green proves the POST CAUSED the change rather than the end-state holding already.
+
+Two POST mechanics are needed, and the page forces the choice (Batch-2 lesson:
+the form-scrape ``webui.post`` cannot faithfully reproduce a browser's multi-value
+same-name POST, and here it would also collide with the ``blacklist_selected``
+multi-select and re-check whatever category boxes the form currently renders):
+
+* the SAVE-button path (``isset($_POST['save'])`` -> the full validate/persist
+  block, lines 178-296) -- driven with a FULLY-CONTROLLED direct
+  ``session.post`` payload (GET for the ``__csrf_magic`` token, then
+  ``webui.session.post`` with every required field enumerated), so the test owns
+  the exact field set and no scraped checkbox/multi-select sneaks in. This mirrors
+  the direct-post pattern the alerts/AJAX flows use for ``act=`` handlers.
+* the ENABLE/LANG AUTO-SUBMIT path -- the page's JS ``$('form').submit()`` on a
+  ``blacklist_enable`` / ``blacklist_lang`` change fires a POST WITHOUT the Save
+  button, and the handler writes those two scalars on ``isset($_POST[field])``
+  alone (lines 160-176) then ``write_config()`` at line 288 (``$config_mod &&
+  !$input_errors``) -- a config-mod path with NO ``save``. ``webui.post`` always
+  appends ``save=save`` so it cannot reproduce that arm; the direct payload OMITS
+  ``save`` to exercise it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .webui import extract_csrf_token, looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+# Page + config roots (bare node -- NO /config/0).
+BLACKLIST_PAGE = "/pfblockerng/pfblockerng_blacklist.php"
+CFG_ROOT = "installedpackages/pfblockerngblacklist"
+CFG_ENABLE = f"{CFG_ROOT}/blacklist_enable"
+CFG_LANG = f"{CFG_ROOT}/blacklist_lang"
+CFG_LOGGING = f"{CFG_ROOT}/blacklist_logging"
+
+# The single live provider on the smoke image (ut1_global_usage). shallalist is
+# dropped by the page, and ut1 has no REG: line -> no username/password fields.
+PROVIDER_XML = "ut1"
+# A valid ut1 category token (NAME: adult) and a token that is NOT a ut1 category.
+# 'adult' is a real category (it is also a "large" category that triggers the
+# page's savemsg redirect AFTER write_config -- the config still persists first).
+VALID_CATEGORY = "adult"
+BOGUS_CATEGORY = "definitely-not-a-ut1-category"
+
+# Generous POST timeout: the blacklist save only write_config()s (no reload, no
+# feed download -- feeds fetch on Force Update/CRON only), but match the sibling
+# suites' headroom so a slow round-trip never trips pytest-timeout spuriously.
+SAVE_TIMEOUT = 120.0
+
+
+def _csrf_token(webui: WebUI) -> str:
+    """GET the blacklist page and return its freshly-injected ``__csrf_magic`` token.
+
+    The csrf-magic output filter rewrites the token per render, so it MUST be
+    re-extracted from a current GET (never cached). Raises via
+    :func:`extract_csrf_token` if the page did not render the token (e.g. the
+    session lapsed and the login form came back instead).
+    """
+    resp = webui.get(BLACKLIST_PAGE)
+    assert not looks_like_login_page(resp.text), "GET blacklist page returned the login form (session lost)"
+    return extract_csrf_token(resp.text)
+
+
+def _direct_post(webui: WebUI, data: dict[str, str], *, timeout: float = SAVE_TIMEOUT) -> None:
+    """POST a FULLY-CONTROLLED payload to the blacklist page (token added here).
+
+    Bypasses the form-scrape ``webui.post`` so the caller owns the EXACT field set
+    -- no scraped multi-select / checkbox can perturb a field the test is not
+    asserting. The ``__csrf_magic`` token is fetched from a current GET and
+    prepended; the caller supplies everything else (``save`` is included only when
+    the SAVE path is wanted -- the auto-submit path omits it deliberately). The
+    response body is NOT the oracle: callers re-read config.xml.
+    """
+    token = _csrf_token(webui)
+    payload = {"__csrf_magic": token, **data}
+    resp = webui.session.post(
+        webui.url(BLACKLIST_PAGE),
+        data=payload,
+        verify=webui._verify,
+        timeout=timeout,
+        allow_redirects=True,
+    )
+    assert not looks_like_login_page(resp.text), "blacklist POST returned the login form (session lost)"
+
+
+def _save_payload(**fields: str) -> dict[str, str]:
+    """A minimal SAVE-path payload: the five scalar selects + ``save`` + overrides.
+
+    The save handler writes ``blacklist_selected`` on the ELSE arm when the field
+    is ABSENT (line 212 -> stores ''), so it must always be present to avoid an
+    accidental clear; the other scalars are written only on ``isset`` and a sane
+    value keeps the select-validator (lines 187-194) from coercing them. Callers
+    add the per-provider ``blacklist_<xml>[]`` category field (or omit it to clear
+    that provider's selection). Defaults keep a quiet, valid baseline; pass
+    keyword overrides to change a specific field.
+    """
+    base = {
+        "blacklist_enable": "Disable",
+        "blacklist_lang": "EN",
+        "blacklist_selected": PROVIDER_XML,
+        "blacklist_freq": "Never",
+        "blacklist_logging": "enabled",
+        "save": "save",
+    }
+    base.update(fields)
+    return base
+
+
+def _provider_selected(vm: helpers.SmokeVM, xml: str = PROVIDER_XML) -> str:
+    """The ``selected`` category CSV stored for provider ``xml``, read the inc's way.
+
+    Walks ``installedpackages/pfblockerngblacklist/item`` exactly as the page and
+    ``pfblockerng.inc`` do (``foreach ($item) if ($item['xml'] == $xml)``), so the
+    oracle is immune to whether a single-element ``item`` list serialised as a
+    1-element list or collapsed to a bare assoc -- either way the matching entry's
+    ``selected`` is returned. '' when no entry matches / none is stored.
+    """
+    pre = (
+        f"$items = config_get_path({helpers._php_str(CFG_ROOT + '/item')}, array());\n"
+        "if (isset($items['xml'])) { $items = array($items); }\n"  # tolerate single-assoc collapse
+        "$out = '';\n"
+        "foreach ($items as $it) {\n"
+        f"  if (($it['xml'] ?? '') === {helpers._php_str(xml)}) {{ $out = (string) ($it['selected'] ?? ''); break; }}\n"
+        "}"
+    )
+    return helpers._php_read_scalar(vm, pre, "$out")
+
+
+# --------------------------------------------------------------------------- #
+# 1) Settings select toggle -- blacklist_logging (enabled <-> disabled).
+#    A pure write_config() select on the SAVE path; branch coverage drives BOTH
+#    values and the transition proves each POST caused the change. Driven with a
+#    controlled payload so the scrape can't disturb blacklist_selected / item.
+# --------------------------------------------------------------------------- #
+
+
+def test_blacklist_logging_select_toggles_both_ways(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``blacklist_logging`` stores 'enabled' and 'disabled' -- both save-path arms.
+
+    Options map ``{enabled, disabled}`` (node default 'enabled'). A valid key is
+    stored verbatim (line 221 ``?:''`` keeps a truthy key). True transition: assert
+    the original, flip to the OTHER value (assert), flip back (assert), restore.
+    """
+    vm = smoke_vm
+    original = helpers.config_get(vm, CFG_LOGGING)
+    # The read default is 'enabled'; treat an unset ('') original as 'enabled'.
+    baseline = original or "enabled"
+    other = "disabled" if baseline == "enabled" else "enabled"
+    try:
+        # BEFORE: a known value of the two-option set.
+        assert baseline in ("enabled", "disabled"), f"unexpected blacklist_logging baseline {original!r}"
+        # Flip to the other value.
+        _direct_post(webui, _save_payload(blacklist_logging=other))
+        assert helpers.config_get(vm, CFG_LOGGING) == other, f"blacklist_logging did not flip to {other!r}"
+        # Flip back.
+        _direct_post(webui, _save_payload(blacklist_logging=baseline))
+        assert helpers.config_get(vm, CFG_LOGGING) == baseline, f"blacklist_logging did not return to {baseline!r}"
+    finally:
+        _direct_post(webui, _save_payload(blacklist_logging=baseline))
+
+
+def test_blacklist_logging_select_coerces_bogus_to_default(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A bogus ``blacklist_logging`` value coerces to the default 'enabled' (save succeeds).
+
+    Select-validator (lines 187-194): a value that is not a key of
+    ``$options_blacklist_logging`` is replaced with the field default '' -> the
+    trailing ``?:''`` at line 221 leaves it '' as stored... but the validator's
+    default for this field is 'enabled' (``$select_options['blacklist_logging'] =>
+    'enabled'``), so a bogus value becomes 'enabled' and is written. SOFT coerce,
+    NOT an abort: config holds 'enabled' (the default), not the bogus token.
+
+    Transition: drive a valid 'disabled' (assert), THEN a bogus value (assert it
+    coerced to 'enabled') -- so the green proves the bogus POST was coerced, not
+    that the box already held 'enabled'.
+    """
+    vm = smoke_vm
+    original = helpers.config_get(vm, CFG_LOGGING)
+    baseline = original or "enabled"
+    try:
+        # VALID 'disabled' first so the coercion target ('enabled') is a real change.
+        _direct_post(webui, _save_payload(blacklist_logging="disabled"))
+        assert helpers.config_get(vm, CFG_LOGGING) == "disabled", "valid 'disabled' did not persist"
+        # BOGUS -> coerced to the default 'enabled' (save still succeeds).
+        _direct_post(webui, _save_payload(blacklist_logging="bogus_value"))
+        got = helpers.config_get(vm, CFG_LOGGING)
+        assert got == "enabled", f"bogus blacklist_logging should coerce to default 'enabled', got {got!r}"
+    finally:
+        _direct_post(webui, _save_payload(blacklist_logging=baseline))
+
+
+# --------------------------------------------------------------------------- #
+# 2) Per-provider category save -- enable a ut1 category, then clear it.
+#    The save builds item[] (one entry per provider) and stores the selected CSV.
+#    VALID category -> stored; clearing (omit the provider field) -> ''.
+# --------------------------------------------------------------------------- #
+
+
+def test_blacklist_provider_category_enable_and_clear(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Enabling a valid ut1 category stores it in ``item``; clearing stores ''.
+
+    The Form_Checkbox name is ``blacklist_ut1[]`` -> PHP parses it as the array
+    ``$_POST['blacklist_ut1']``. With one value it validates (line 238 is_array
+    arm), and ``$list['selected'] = implode(',', (array)...)`` stores 'adult' on
+    ``item``'s ut1 entry. Clearing OMITS the ``blacklist_ut1[]`` field entirely (a
+    browser sends nothing for an unchecked box) -> ``$_POST['blacklist_ut1']``
+    unset -> selected ''. (Posting an EMPTY value would instead make is_array
+    ``['']`` validate '' -> a bogus-selection input_error that aborts the save, so
+    the clear MUST omit the field, which the controlled payload does.)
+
+    True transition: establish a known clear baseline, assert selected is '', POST
+    'adult' (assert 'adult'), POST the clear (assert '' again).
+    """
+    vm = smoke_vm
+    cat_field = f"blacklist_{PROVIDER_XML}[]"
+    original = _provider_selected(vm)
+    try:
+        # BEFORE: drive to a known clear state (no category for ut1) and assert ''.
+        _direct_post(webui, _save_payload())  # no blacklist_ut1[] -> selection cleared
+        assert _provider_selected(vm) == "", "ut1 selection should be empty after the clearing baseline POST"
+        # ENABLE a valid category -> stored on item.
+        _direct_post(webui, _save_payload(**{cat_field: VALID_CATEGORY}))
+        got = _provider_selected(vm)
+        assert got == VALID_CATEGORY, f"ut1 selection should be {VALID_CATEGORY!r} after enabling it, got {got!r}"
+        # CLEAR again (omit the field) -> back to ''.
+        _direct_post(webui, _save_payload())
+        assert _provider_selected(vm) == "", "ut1 selection should be empty again after the clearing POST"
+    finally:
+        # Restore the original selection (CSV). An empty original clears it; a
+        # non-empty original re-sends each token under the array field.
+        if original:
+            _direct_post(webui, _save_payload(**{cat_field: original}))
+        else:
+            _direct_post(webui, _save_payload())
+
+
+# --------------------------------------------------------------------------- #
+# 3) Category validation reject -- a bogus category aborts the WHOLE save.
+#    The save is all-or-nothing: a category not in the provider's CATEGORIES set
+#    appends to $input_errors -> the `if ($config_mod && !isset($input_errors))`
+#    guard skips write_config -> config UNCHANGED (the bad POST does not persist).
+# --------------------------------------------------------------------------- #
+
+
+def test_blacklist_bogus_category_rejected_config_unchanged(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A bogus ut1 category triggers an input_error -> the whole save aborts (config unchanged).
+
+    ``$validate_categories = array_flip($blacklist_types['ut1']['CATEGORIES'])`` is
+    the valid set. A submitted token absent from it -> ``$input_errors[]`` (line
+    242/249) -> the trailing ``if ($config_mod && !isset($input_errors))`` (line
+    288) is false -> NO write_config -> ``item`` keeps its prior value. So the
+    reject oracle is "selected == the pre-POST value", NOT the bogus token and NOT
+    cleared.
+
+    Transition with a real before-state: first store a VALID category ('adult')
+    and assert it; THEN POST the bogus category and assert ``item`` still holds
+    'adult' (the bogus POST changed nothing).
+    """
+    vm = smoke_vm
+    cat_field = f"blacklist_{PROVIDER_XML}[]"
+    original = _provider_selected(vm)
+    try:
+        # Seed a known-good selection so "unchanged" is observable (not just '').
+        _direct_post(webui, _save_payload(**{cat_field: VALID_CATEGORY}))
+        seeded = _provider_selected(vm)
+        assert seeded == VALID_CATEGORY, f"failed to seed a valid ut1 category, got {seeded!r}"
+        # REJECT: a bogus category aborts the whole save -> item UNCHANGED.
+        _direct_post(webui, _save_payload(**{cat_field: BOGUS_CATEGORY}))
+        got = _provider_selected(vm)
+        assert got == VALID_CATEGORY, (
+            f"bogus category must abort the save and leave ut1 selection unchanged at {VALID_CATEGORY!r}, got {got!r}"
+        )
+    finally:
+        if original:
+            _direct_post(webui, _save_payload(**{cat_field: original}))
+        else:
+            _direct_post(webui, _save_payload())
+
+
+# --------------------------------------------------------------------------- #
+# 4) enable / lang AUTO-SUBMIT path -- config_mod WITHOUT the Save button.
+#    The page's JS submits the form on a blacklist_enable/blacklist_lang change;
+#    that POST carries NO `save`, yet the handler writes those scalars on
+#    `isset($_POST[field])` (lines 160-176) and write_config()s at line 288. The
+#    direct payload OMITS `save` to exercise exactly this arm (webui.post can't).
+# --------------------------------------------------------------------------- #
+
+
+def test_blacklist_enable_autosubmit_persists_without_save(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``blacklist_enable`` persists via the auto-submit (no-``save``) path, both ways.
+
+    With ``isset($_POST['blacklist_enable'])`` and NO ``save``, lines 160-167 set
+    the node and config_mod=TRUE; the ``save`` block is skipped; line 288 writes
+    config. So the scalar persists with NO ``save`` in the payload. Options map
+    ``{Disable, Enable}``; an unknown value coerces to 'Disable' (line 161-162).
+
+    Transition + branch coverage: drive 'Enable' (assert), drive 'Disable'
+    (assert), and a bogus value (assert it coerced to 'Disable'). The restore
+    target is 'Disable' -- equivalent to the read default ('' ``?: 'Disable'``),
+    so an originally-unset node is left in its effective default.
+    """
+    vm = smoke_vm
+    original = helpers.config_get(vm, CFG_ENABLE)
+    # '' (unset) reads as 'Disable' on the page; restore there.
+    restore = original or "Disable"
+    try:
+        assert restore in ("Disable", "Enable"), f"unexpected blacklist_enable baseline {original!r}"
+        # AUTO-SUBMIT 'Enable' (NO save in the payload) -> persists 'Enable'.
+        _direct_post(webui, {"blacklist_enable": "Enable"})
+        got_enable = helpers.config_get(vm, CFG_ENABLE)
+        assert got_enable == "Enable", f"blacklist_enable did not persist 'Enable' (no-save path), got {got_enable!r}"
+        # AUTO-SUBMIT 'Disable' -> persists 'Disable'.
+        _direct_post(webui, {"blacklist_enable": "Disable"})
+        assert helpers.config_get(vm, CFG_ENABLE) == "Disable", "blacklist_enable did not return to 'Disable'"
+        # BOGUS value -> coerced to 'Disable' (line 161-162), still written.
+        _direct_post(webui, {"blacklist_enable": "Bogus"})
+        got = helpers.config_get(vm, CFG_ENABLE)
+        assert got == "Disable", f"bogus blacklist_enable should coerce to 'Disable', got {got!r}"
+    finally:
+        _direct_post(webui, {"blacklist_enable": restore})
+
+
+def test_blacklist_lang_autosubmit_persists_without_save(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``blacklist_lang`` persists via the auto-submit (no-``save``) path; bogus coerces to 'EN'.
+
+    Same no-``save`` arm as ``blacklist_enable`` (lines 169-176): the scalar is
+    written on ``isset`` alone, an unknown value coerces to the default 'EN' (line
+    170-171). Options include EN/DE/FR/... -- a valid 'DE' is a real change from
+    the 'EN' default.
+
+    Transition: assert the original, drive a VALID 'DE' (assert), drive a bogus
+    value (assert it coerced to 'EN'), restore.
+    """
+    vm = smoke_vm
+    original = helpers.config_get(vm, CFG_LANG)
+    restore = original or "EN"
+    try:
+        assert restore != "DE" or original == "DE", "baseline sanity for blacklist_lang"
+        # VALID 'DE' via the no-save path.
+        _direct_post(webui, {"blacklist_lang": "DE"})
+        assert helpers.config_get(vm, CFG_LANG) == "DE", "blacklist_lang did not persist 'DE' (no-save path)"
+        # BOGUS -> coerced to the default 'EN'.
+        _direct_post(webui, {"blacklist_lang": "ZZ"})
+        got = helpers.config_get(vm, CFG_LANG)
+        assert got == "EN", f"bogus blacklist_lang should coerce to default 'EN', got {got!r}"
+    finally:
+        _direct_post(webui, {"blacklist_lang": restore})

--- a/tests/smoke/ui/test_category.py
+++ b/tests/smoke/ui/test_category.py
@@ -1,0 +1,282 @@
+"""Tier-B functional flows for the IP/DNSBL Category SUMMARY page (ADR-14).
+
+Marker ``ui_e2e`` -- daily / on-demand, NOT in the default run nor the PR gate
+(the whole ``tests/smoke`` tree is ``--ignore``d in the default
+``python -m pytest``; this tier is run with
+``pytest tests/smoke -m ui_e2e --override-ini="addopts="``).
+
+Subject: ``pfblockerng_category.php`` (the IPv4/IPv6/GeoIP/DNSBL summary table).
+Unlike the settings pages exercised by ``test_functional.py``, this page's row
+mutations are NOT a normal form save -- they are AJAX ``act=``-dispatched
+operations the page's own JavaScript fires (``act=update`` for a per-row
+action/cron/log save and an optional drag-reorder ``ids[]``; ``act=del`` for a
+row delete). So these tests do NOT use the form-scrape ``webui.post`` helper:
+they GET the page to harvest the per-render ``__csrf_magic`` token, then drive a
+DIRECT ``webui.session.post`` with a fully-controlled payload (the same pattern
+the alerts AJAX flows use), which is the only way to reproduce the AJAX envelope
+faithfully (a fully-enumerated payload, no same-name multi-value collision).
+
+Handler facts pinned from the PHP source (read end to end):
+
+* ``act=update`` (pfblockerng_category.php:35-37,174-314): the page does
+  ``$_POST = $_REQUEST`` for ``act=update`` then reads ``$_POST['postdata']`` --
+  itself a urlencoded query string -- via ``parse_str`` into ``$post_data``.
+  Each key shaped ``<var>-<rowid>`` (``var`` in {action,cron,aliaslog,logging})
+  is validated against that field's whitelist; on success it writes
+  ``config_set_path("{$rowdata_path}/{$rowid}/{$variable}", ...)``. ANY invalid
+  key/value appends to ``$input_errors`` and the ``if (!$input_errors)`` guard
+  skips the ENTIRE write (config UNCHANGED) and the handler echoes
+  ``json_encode($input_errors)``. ``$rowdata_path`` for ``type=ipv4`` is
+  ``installedpackages/pfblockernglistsv4/config``.
+* ``act=del`` (pfblockerng_category.php:82-83,158-172): reads the top-level
+  ``$_POST['rowid']``, requires the row's ``aliasname`` to be a clean word
+  (``PFB_FILTER_WORD``), then ``config_del_path("{$rowdata_path}/{$rowid}")`` and
+  302-redirects. Deletes the addressed numeric row.
+* The action whitelist for an IP list (pfblockerng_category.php:179-194):
+  Disabled, Deny_Inbound, Deny_Outbound, Deny_Both, Permit_*, Match_*, Alias_*,
+  unbound.
+
+Every flow is a TRUE transition test (CLAUDE.md): it seeds a known row, asserts
+the ORIGINAL effective value, drives the AJAX op, asserts the NEW effective
+value, and restores -- the oracle is ALWAYS ``config.xml`` read over SSH
+(``helpers.config_get``), NEVER the HTTP response body. The seeded row is removed
+in a ``finally`` so a mid-test failure cannot poison the session-scoped VM.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import urlencode
+
+import pytest
+
+from .. import helpers
+from .webui import extract_csrf_token, looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+# The Category page and the config root it edits for ?type=ipv4 (the page's
+# documented default tab). pfblockerng_category.php:99-101 sets
+# $conf_type='pfblockernglistsv4' for gtype 'ipv4', so $rowdata_path is this node.
+CATEGORY_PAGE = "/pfblockerng/pfblockerng_category.php"
+IPV4_PAGE = f"{CATEGORY_PAGE}?type=ipv4"
+IPV4_LISTS = "installedpackages/pfblockernglistsv4/config"
+
+# Generous round-trip bound: the AJAX ops only write_config() (no reload / no
+# egress), but the box is shared and pfSsh.php seeding adds latency.
+AJAX_TIMEOUT = 120.0
+
+# A snapshot delimiter for round-tripping the whole IPv4-lists array through PHP
+# serialize/base64 (config_get only reads scalar leaves, so capture/restore the
+# node as a blob to leave the box exactly as found).
+_SNAP_OPEN = "<<<SNAP>>>"
+_SNAP_CLOSE = "<<<SNAPEND>>>"
+
+
+def _snapshot_lists(vm: helpers.SmokeVM) -> str:
+    """Return a base64(serialize()) blob of the whole IPv4-lists config node.
+
+    Used to restore the node byte-for-byte in teardown -- the seed below replaces
+    the node with a single known row, so the original (possibly empty) array must
+    be captured first and rewritten after, leaving the shared VM as found.
+    """
+    snippet = (
+        f"echo {helpers._php_str(_SNAP_OPEN)} . "
+        f"base64_encode(serialize(config_get_path({helpers._php_str(IPV4_LISTS)}, array()))) . "
+        f"{helpers._php_str(_SNAP_CLOSE)};"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=AJAX_TIMEOUT)
+    out = result.stdout
+    start = out.find(_SNAP_OPEN)
+    end = out.find(_SNAP_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"_snapshot_lists: no delimited blob: rc={result.returncode} out={out!r}")
+    return out[start + len(_SNAP_OPEN) : end]
+
+
+def _restore_lists(vm: helpers.SmokeVM, blob: str) -> None:
+    """Rewrite the IPv4-lists config node from a :func:`_snapshot_lists` blob."""
+    snippet = (
+        f"config_set_path({helpers._php_str(IPV4_LISTS)}, "
+        f"unserialize(base64_decode({helpers._php_str(blob)})));\n"
+        "write_config('pfBlockerNG smoke: restore IPv4 lists');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=AJAX_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_restore_lists failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _seed_single_ipv4_row(vm: helpers.SmokeVM, aliasname: str, action: str) -> None:
+    """Replace the IPv4-lists node with exactly ONE known row (index 0).
+
+    A single deterministic row makes ``rowid=0`` address THIS row for both
+    ``act=update`` and ``act=del``. ``aliasname`` must be word-only
+    (``PFB_FILTER_WORD``) -- the del handler rejects a non-word alias
+    (pfblockerng_category.php:160). The row carries a feed row so it is a valid,
+    fully-formed list entry.
+    """
+    row = {
+        "aliasname": aliasname,
+        "action": action,
+        "cron": "Never",
+        "aliaslog": "enabled",
+        "description": "pfBlockerNG smoke category row",
+    }
+    feed = {"header": "smoketest", "url": f"{helpers.PFB_DBDIR}/{aliasname}", "state": "Enabled", "format": "auto"}
+    snippet = (
+        f"$list = {helpers._php_kv_array(row)};\n"
+        f"$list['row'] = array({helpers._php_kv_array(feed)});\n"
+        f"config_set_path({helpers._php_str(IPV4_LISTS)}, array($list));\n"
+        "write_config('pfBlockerNG smoke: seed IPv4 category row');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=AJAX_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_seed_single_ipv4_row failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _ajax_post(webui: WebUI, data: dict[str, str]) -> str:
+    """Drive a DIRECT CSRF-authenticated POST to the Category AJAX endpoint.
+
+    GET the page for a fresh ``__csrf_magic`` token (csrf-magic injects it per
+    render -- never cache it), then ``session.post`` the supplied ``data`` with
+    the token at top level so csrf-magic validates the request. Returns the
+    response body (callers assert EFFECTIVE config state, never this text).
+    """
+    page = webui.get(IPV4_PAGE)
+    assert not looks_like_login_page(page.text), "Category GET returned the login form (session lost)"
+    token = extract_csrf_token(page.text)
+    payload = dict(data)
+    payload["__csrf_magic"] = token
+    resp = webui.session.post(
+        webui.url(CATEGORY_PAGE),
+        data=payload,
+        verify=webui._verify,
+        timeout=AJAX_TIMEOUT,
+    )
+    assert not looks_like_login_page(resp.text), "Category POST returned the login form (session lost)"
+    return resp.text
+
+
+def _update_action(webui: WebUI, rowid: int, action: str) -> str:
+    """Fire ``act=update`` setting ``action-<rowid>=<action>`` via ``postdata``.
+
+    ``postdata`` is itself a urlencoded query string the handler ``parse_str``s,
+    so a minimal one-field payload is sent (avoids the multi-value same-name
+    collision a full form scrape would introduce). Returns the response body.
+    """
+    postdata = urlencode({f"action-{rowid}": action})
+    return _ajax_post(webui, {"act": "update", "type": "ipv4", "rowid": "0", "postdata": postdata})
+
+
+def test_category_update_row_action_changes_config(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``act=update`` saves a valid per-row action; a bogus action leaves config UNCHANGED.
+
+    Branch coverage of the action validator (pfblockerng_category.php:238-243):
+
+    * VALID: ``Deny_Outbound`` is a key of ``$action_values`` -> the handler writes
+      ``installedpackages/pfblockernglistsv4/config/0/action`` -> config holds the
+      new value. The seed starts at ``Deny_Inbound`` so the change is a real
+      transition (before != after), proving the POST caused it.
+    * REJECT: ``BogusAction`` is NOT a key -> ``$input_errors`` -> the
+      ``if (!$input_errors)`` guard skips the whole write -> config UNCHANGED
+      (stays at the prior valid value, NOT coerced, NOT the bogus token).
+
+    Oracle is config.xml over SSH, never the AJAX response body.
+    """
+    vm = smoke_vm
+    alias = "pfbcatupd"
+    cfg = f"{IPV4_LISTS}/0/action"
+    snap = _snapshot_lists(vm)
+    try:
+        _seed_single_ipv4_row(vm, alias, "Deny_Inbound")
+        # BEFORE: the seeded row holds the original action.
+        assert helpers.config_get(vm, cfg) == "Deny_Inbound", "seed did not land Deny_Inbound at row 0"
+        # VALID: a different whitelisted action is written through.
+        _update_action(webui, 0, "Deny_Outbound")
+        assert helpers.config_get(vm, cfg) == "Deny_Outbound", "valid act=update did not change the row action"
+        # Restore the row to its original valid action (reverse transition).
+        _update_action(webui, 0, "Deny_Inbound")
+        assert helpers.config_get(vm, cfg) == "Deny_Inbound", "restore act=update did not revert the row action"
+        # REJECT: a non-whitelisted action aborts the whole save -> config UNCHANGED.
+        _update_action(webui, 0, "BogusAction")
+        got = helpers.config_get(vm, cfg)
+        assert got == "Deny_Inbound", f"bogus action must leave config unchanged at 'Deny_Inbound', got {got!r}"
+    finally:
+        _restore_lists(vm, snap)
+
+
+def test_category_update_row_cron_valid_and_reject_unchanged(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``act=update`` saves a valid per-row cron frequency; a bogus value leaves config UNCHANGED.
+
+    Branch coverage of the cron validator (pfblockerng_category.php:244-248): the
+    value must be a key of ``$cron_values`` (Never,01hour,...,Weekly). A valid
+    ``12hours`` is written to
+    ``installedpackages/pfblockernglistsv4/config/0/cron``; a bogus ``99hours``
+    is not a key -> ``$input_errors`` -> the whole save aborts -> config
+    UNCHANGED. The seed starts at ``Never`` so ``12hours`` is a real transition.
+    """
+    vm = smoke_vm
+    alias = "pfbcatcron"
+    cfg = f"{IPV4_LISTS}/0/cron"
+    snap = _snapshot_lists(vm)
+    try:
+        _seed_single_ipv4_row(vm, alias, "Deny_Both")
+        # BEFORE: seeded cron is 'Never'.
+        assert helpers.config_get(vm, cfg) == "Never", "seed did not land cron 'Never' at row 0"
+        # VALID cron key -> written through.
+        postdata = urlencode({"cron-0": "12hours"})
+        _ajax_post(webui, {"act": "update", "type": "ipv4", "rowid": "0", "postdata": postdata})
+        assert helpers.config_get(vm, cfg) == "12hours", "valid act=update did not change the row cron"
+        # Restore (reverse transition).
+        postdata = urlencode({"cron-0": "Never"})
+        _ajax_post(webui, {"act": "update", "type": "ipv4", "rowid": "0", "postdata": postdata})
+        assert helpers.config_get(vm, cfg) == "Never", "restore act=update did not revert the row cron"
+        # REJECT: a non-whitelisted cron aborts the whole save -> config UNCHANGED.
+        postdata = urlencode({"cron-0": "99hours"})
+        _ajax_post(webui, {"act": "update", "type": "ipv4", "rowid": "0", "postdata": postdata})
+        got = helpers.config_get(vm, cfg)
+        assert got == "Never", f"bogus cron must leave config unchanged at 'Never', got {got!r}"
+    finally:
+        _restore_lists(vm, snap)
+
+
+def test_category_delete_row_removes_config_node(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``act=del`` deletes the addressed row; the row's config node is gone afterward.
+
+    True lifecycle transition: seed one row, assert it is PRESENT
+    (``installedpackages/pfblockernglistsv4/config/0/aliasname`` == the seeded
+    name), POST ``act=del`` with ``rowid=0``, then assert the node is GONE
+    (config_get returns '' for the removed leaf). The del handler
+    (pfblockerng_category.php:158-172) requires the row's aliasname to be a clean
+    word and then ``config_del_path("{$rowdata_path}/0")``; it 302-redirects, so
+    requests follows to the post-delete page (the oracle is config, not that body).
+    """
+    vm = smoke_vm
+    alias = "pfbcatdel"
+    cfg = f"{IPV4_LISTS}/0/aliasname"
+    snap = _snapshot_lists(vm)
+    try:
+        _seed_single_ipv4_row(vm, alias, "Deny_Both")
+        # BEFORE: the seeded row is present at index 0.
+        assert helpers.config_get(vm, cfg) == alias, "seed did not land the row aliasname at index 0"
+        # DELETE the row via the AJAX del op.
+        _ajax_post(webui, {"act": "del", "type": "ipv4", "rowid": "0"})
+        # AFTER: the row's config node is gone (the only row was at index 0).
+        got = helpers.config_get(vm, cfg)
+        assert got == "", f"act=del must remove the row node (aliasname now ''), got {got!r}"
+    finally:
+        _restore_lists(vm, snap)

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -103,7 +103,7 @@ def _post_form(webui: WebUI, payload: dict[str, str]) -> None:
     data = dict(payload)
     data["__csrf_magic"] = token
     data["save"] = "save"
-    resp = webui.session.post(CATEGORY_PAGE, data=data, verify=webui._verify, timeout=SAVE_TIMEOUT)
+    resp = webui.session.post(webui.url(CATEGORY_PAGE), data=data, verify=webui._verify, timeout=SAVE_TIMEOUT)
     assert not looks_like_login_page(resp.text), "category POST returned the login form (session lost)"
 
 

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -1,0 +1,414 @@
+"""Tier-B functional WebUI flows for the alias CRUD page (ADR-14 Phase 3).
+
+Marker ``ui_e2e`` -- daily / on-demand, NOT in the default run nor the PR gate
+(the whole ``tests/smoke`` tree is ``--ignore``d in the default
+``python -m pytest``; this tier is run with
+``pytest tests/smoke -m ui_e2e --override-ini="addopts="``).
+
+This file drives ``pfblockerng_category_edit.php`` -- the alias add/edit form
+that is the CRUD heart of pfBlockerNG. Its save handler (gated on
+``isset($_POST['save'])``) dispatches on ``$_POST['type']`` (``ipv4`` / ``ipv6``
+/ ``dnsbl`` -> ``$conf_type`` ``pfblockernglistsv4`` / ``pfblockernglistsv6`` /
+``pfblockerngdnsbl``) and ``$_POST['rowid']``, and writes the alias under
+``installedpackages/{conf_type}/config/{rowid}/...`` (aliasname, action, the
+source ``row/<n>`` table, plus the DNSBL scalars logging/order/filter_alexa).
+
+As in ``test_functional.py`` the oracle is ALWAYS the box's EFFECTIVE state --
+``config.xml`` read via :func:`tests.smoke.helpers.config_get` -- never the HTTP
+response body. Every flow is a TRUE transition test (CLAUDE.md): it asserts the
+BEFORE-state, drives the POST, asserts the AFTER-state, and restores in a
+``finally`` so a mid-test failure cannot poison the session-scoped VM.
+
+POST strategy (Batch-2 learning): the page's source table is a JS rowhelper whose
+multi-row ``state-<n>`` / ``url-<n>`` / ``header-<n>`` collision the form-scrape
+cannot faithfully reproduce, so these flows do NOT route through
+:meth:`WebUI.post` (the scrape "save" helper). Instead -- like
+``test_alerts.py``'s ``act=`` pattern -- each GETs the page to harvest a fresh
+``__csrf_magic`` token, then POSTs a FULLY-enumerated payload via
+``webui.session.post`` (every field the handler reads is supplied a valid value,
+so no select coerces and no rowhelper row is dropped). The single placeholder
+source row is posted ``state-0='Disabled'`` so the URL/header validation arm
+(``$value != 'Disabled'``) is skipped -- a clean, hermetic save with no feed
+download.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .webui import extract_csrf_token, looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+CATEGORY_PAGE = "/pfblockerng/pfblockerng_category_edit.php"
+
+# config roots the save handler writes (mirrors $conf_type in the PHP).
+CFG_DNSBL = "installedpackages/pfblockerngdnsbl/config"
+CFG_IPV4 = "installedpackages/pfblockernglistsv4/config"
+
+# Generous POST timeout: the save only write_config()s (no reload / no egress),
+# but pfSsh.php-backed config reads around it can run long on a busy box.
+SAVE_TIMEOUT = 120.0
+
+
+def _free_rowid(vm: helpers.SmokeVM, cfg_root: str) -> int:
+    """Return an index under ``cfg_root`` that does NOT clobber an existing alias.
+
+    The save handler writes ``{cfg_root}/{rowid}/...`` straight from
+    ``$_POST['rowid']``. Other suites (and prior cases) may have left aliases in
+    ``cfg_root``, so picking ``rowid=0`` blindly could overwrite a real one.
+    Compute ``max(existing numeric keys) + 1`` (or 0 when the list is empty) via
+    the pfSense config API -- a fresh, guaranteed-free slot we own and delete.
+    """
+    pre = (
+        f"$c = config_get_path({helpers._php_str(cfg_root)}, array());\n"
+        "$max = -1;\n"
+        "foreach (array_keys($c) as $k) { if (is_numeric($k) && (int)$k > $max) { $max = (int)$k; } }\n"
+        "$free = $max + 1;"
+    )
+    return int(helpers._php_read_scalar(vm, pre, "$free", timeout=SAVE_TIMEOUT))
+
+
+def _del_rowid(vm: helpers.SmokeVM, cfg_root: str, rowid: int) -> None:
+    """Delete ``{cfg_root}/{rowid}`` (cleanup of an alias slot this test created)."""
+    snippet = (
+        f"config_del_path({helpers._php_str(f'{cfg_root}/{rowid}')});\n"
+        "write_config('pfBlockerNG smoke: drop test alias');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=SAVE_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_del_rowid({cfg_root}/{rowid}) failed: rc={result.returncode} {result.stdout!r}")
+
+
+def _post_form(webui: WebUI, payload: dict[str, str]) -> None:
+    """POST a fully-enumerated category-edit payload (token harvested fresh).
+
+    GETs the page to obtain a current ``__csrf_magic`` (the csrf-magic output
+    filter rotates it per render), injects it + the ``save`` submit button into
+    ``payload``, and POSTs directly via the raw session -- NOT the form-scrape
+    (the rowhelper table cannot be reproduced by the scrape). Mirrors the
+    ``test_alerts.py`` direct-post pattern.
+    """
+    get = webui.get(CATEGORY_PAGE, params={"type": payload.get("type", "dnsbl")})
+    assert not looks_like_login_page(get.text), "category GET returned the login form (session lost)"
+    token = extract_csrf_token(get.text)
+    data = dict(payload)
+    data["__csrf_magic"] = token
+    data["save"] = "save"
+    resp = webui.session.post(CATEGORY_PAGE, data=data, verify=webui._verify, timeout=SAVE_TIMEOUT)
+    assert not looks_like_login_page(resp.text), "category POST returned the login form (session lost)"
+
+
+def _dnsbl_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, str]:
+    """A complete, valid DNSBL alias save payload (one Disabled placeholder row).
+
+    Every <select> the validator inspects (action/cron/dow/sort/order/logging +
+    the ip-only ones) is given a value that is a KEY of its options map, so the
+    select-coercion loop (lines 478-488) never rewrites it; the lone source row is
+    ``state-0='Disabled'`` so the URL/header validation arm is skipped. ``custom``
+    is empty so the custom-list validator is skipped and ``pfb_determine_list_detail``
+    is NOT triggered (the base64('')=='' "unchanged" branch).
+    """
+    payload = {
+        "type": "dnsbl",
+        "rowid": str(rowid),
+        "aliasname": aliasname,
+        "description": "smoke category-edit",
+        "action": "unbound",
+        "cron": "Never",
+        "dow": "",
+        "sort": "sort",
+        "order": "default",
+        "logging": "enabled",
+        "filter_alexa": "",
+        "srcint": "",
+        "script_pre": "",
+        "script_post": "",
+        "custom": "",
+        # Single placeholder source row: Disabled -> source validation skipped.
+        "format-0": "auto",
+        "state-0": "Disabled",
+        "url-0": "",
+        "header-0": "",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# Representative full SAVE: create a DNSBL alias, assert the KEY persisted nodes.
+# --------------------------------------------------------------------------- #
+
+
+def test_dnsbl_alias_full_save_persists_key_nodes(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A DNSBL alias save persists aliasname + action + one source row + logging.
+
+    The CRUD heart: drive a complete CSRF form POST for a brand-new DNSBL alias at
+    a free rowid and assert the handler wrote the key config nodes
+    (``aliasname`` / ``action`` / ``row/0/state`` / ``logging``) under
+    ``installedpackages/pfblockerngdnsbl/config/{rowid}``. Transition rule: the
+    rowid is FREE first (every target node reads '' before the POST), then the
+    POST creates them. Oracle = config.xml over SSH; the slot is deleted in
+    ``finally`` so the box is left clean.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    base = f"{CFG_DNSBL}/{rowid}"
+    aliasname = "smokecatedit"
+    try:
+        # BEFORE: the free slot is empty (the POST must CAUSE every node below).
+        assert helpers.config_get(vm, f"{base}/aliasname") == "", f"rowid {rowid} not free (aliasname already set)"
+        assert helpers.config_get(vm, f"{base}/action") == "", f"rowid {rowid} not free (action already set)"
+
+        _post_form(webui, _dnsbl_payload(rowid, aliasname))
+
+        # AFTER: the key alias nodes landed in config.xml.
+        assert helpers.config_get(vm, f"{base}/aliasname") == aliasname, "aliasname not persisted by the save"
+        assert helpers.config_get(vm, f"{base}/action") == "unbound", "action not persisted by the save"
+        assert helpers.config_get(vm, f"{base}/logging") == "enabled", "logging not persisted by the save"
+        assert helpers.config_get(vm, f"{base}/row/0/state") == "Disabled", "source row state not persisted"
+    finally:
+        _del_rowid(vm, CFG_DNSBL, rowid)
+
+
+# --------------------------------------------------------------------------- #
+# Negative SAVE: a bad aliasname aborts the whole save (config UNCHANGED).
+# --------------------------------------------------------------------------- #
+
+
+def test_dnsbl_alias_bad_name_rejected_leaves_config_unchanged(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """An aliasname with a non-word char aborts the save -> the alias is UNCHANGED.
+
+    ``preg_match("/\\W/", $_POST['aliasname'])`` (and the empty-name guard) append
+    to ``$input_errors``; the ``if (!$input_errors)`` block is then skipped, so NO
+    config node is written. Transition: first establish a KNOWN-GOOD alias at the
+    rowid (a valid save, aliasname asserted), THEN POST a bad name (a space ->
+    ``\\W``) to the SAME rowid and assert the aliasname is UNCHANGED (the save
+    aborted) -- proving the reject is a real branch, not an always-unchanged path.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    base = f"{CFG_DNSBL}/{rowid}"
+    good = "smokecatok"
+    try:
+        # Seed a valid alias through the form so the rowid holds a known good name.
+        _post_form(webui, _dnsbl_payload(rowid, good))
+        assert helpers.config_get(vm, f"{base}/aliasname") == good, "precondition: valid alias did not persist"
+
+        # REJECT: a space makes aliasname match /\W/ -> the whole save aborts.
+        _post_form(webui, _dnsbl_payload(rowid, "bad name"))
+        assert helpers.config_get(vm, f"{base}/aliasname") == good, (
+            "a bad aliasname must abort the save (alias unchanged), but it changed"
+        )
+    finally:
+        _del_rowid(vm, CFG_DNSBL, rowid)
+
+
+# --------------------------------------------------------------------------- #
+# DNSBL scalar selects/toggle: logging (valid + bogus-coerce), order, filter_alexa.
+# --------------------------------------------------------------------------- #
+
+
+def test_dnsbl_logging_select_valid_and_bogus_coerces_to_default(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``logging`` stores a valid key, and a bogus value coerces to the default.
+
+    ``$options_logging`` keys are enabled / disabled / disabled_log. The
+    select-coercion loop replaces a non-key value with ``$select_options['logging']``
+    -- which is the literal ``'Enabled'`` (capital E; NOT itself a key of
+    ``$options_logging``), and the save SUCCEEDS storing that default. Branch
+    coverage: drive a valid 'enabled', then a valid 'disabled' (the distinct second
+    key), then a bogus 'bogus' that coerces to 'Enabled'. Transition: each step
+    asserts the value differs before it is driven.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    base = f"{CFG_DNSBL}/{rowid}"
+    cfg = f"{base}/logging"
+    try:
+        # Create the alias with logging=enabled.
+        _post_form(webui, _dnsbl_payload(rowid, "smokelog", logging="enabled"))
+        assert helpers.config_get(vm, cfg) == "enabled", "logging not stored as 'enabled'"
+        # VALID second key -> stored verbatim (a real transition).
+        _post_form(webui, _dnsbl_payload(rowid, "smokelog", logging="disabled"))
+        assert helpers.config_get(vm, cfg) == "disabled", "logging not stored as 'disabled'"
+        # BOGUS -> coerced to the default 'Enabled' (save SUCCEEDS, value != bogus).
+        _post_form(webui, _dnsbl_payload(rowid, "smokelog", logging="bogus"))
+        got = helpers.config_get(vm, cfg)
+        assert got == "Enabled", f"bogus logging should coerce to default 'Enabled', got {got!r}"
+    finally:
+        _del_rowid(vm, CFG_DNSBL, rowid)
+
+
+def test_dnsbl_order_select_transition(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``order`` stores both option keys (default / primary) across a transition.
+
+    ``$options_order`` = {default, primary}. Branch coverage drives each key:
+    create with 'default' (assert), then flip to 'primary' (assert), then back to
+    'default' (assert) -- proving the POST causes each change.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    cfg = f"{CFG_DNSBL}/{rowid}/order"
+    try:
+        _post_form(webui, _dnsbl_payload(rowid, "smokeord", order="default"))
+        assert helpers.config_get(vm, cfg) == "default", "order not stored as 'default'"
+        _post_form(webui, _dnsbl_payload(rowid, "smokeord", order="primary"))
+        assert helpers.config_get(vm, cfg) == "primary", "order not stored as 'primary'"
+        _post_form(webui, _dnsbl_payload(rowid, "smokeord", order="default"))
+        assert helpers.config_get(vm, cfg) == "default", "order not restored to 'default'"
+    finally:
+        _del_rowid(vm, CFG_DNSBL, rowid)
+
+
+def test_dnsbl_filter_alexa_checkbox_both_ways(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``filter_alexa`` (TOP1M Whitelist checkbox) stores 'on' when set, '' when clear.
+
+    Written via ``pfb_filter($_POST['filter_alexa'], PFB_FILTER_ON_OFF, ...)`` ->
+    'on' iff the POST value is 'on', else ''. Branch coverage: create with it ON
+    (assert 'on'), then save with it cleared (assert ''), then ON again. A browser
+    omits an unchecked box; the cleared POST sends the empty value, which the
+    PFB_FILTER_ON_OFF filter stores as ''.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    cfg = f"{CFG_DNSBL}/{rowid}/filter_alexa"
+    try:
+        _post_form(webui, _dnsbl_payload(rowid, "smokealexa", filter_alexa="on"))
+        assert helpers.config_get(vm, cfg) == "on", "filter_alexa not stored 'on'"
+        _post_form(webui, _dnsbl_payload(rowid, "smokealexa", filter_alexa=""))
+        assert helpers.config_get(vm, cfg) == "", "filter_alexa not cleared to ''"
+        _post_form(webui, _dnsbl_payload(rowid, "smokealexa", filter_alexa="on"))
+        assert helpers.config_get(vm, cfg) == "on", "filter_alexa not re-set 'on'"
+    finally:
+        _del_rowid(vm, CFG_DNSBL, rowid)
+
+
+# --------------------------------------------------------------------------- #
+# IPv4 alias: a valid Deny_Both save persists, and the Permit_Inbound + 'Any'
+# protocol guard aborts the save (config UNCHANGED).
+# --------------------------------------------------------------------------- #
+
+
+def _ipv4_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, str]:
+    """A complete IPv4 alias save payload (one Disabled placeholder row).
+
+    IPv4 ($conf_type pfblockernglistsv4) carries the advanced-firewall fields the
+    Permit guard inspects (autoproto_in / aliasports_in / aliasaddr_in). Defaults
+    here keep adv-inbound OFF and a concrete-but-unused protocol so a plain
+    Deny_Both save is clean; tests override ``action`` / ``autoproto_in`` to drive
+    the guard. aliasname stays <= 24 chars (the PF length cap).
+    """
+    payload = {
+        "type": "ipv4",
+        "rowid": str(rowid),
+        "aliasname": aliasname,
+        "description": "smoke ipv4 category-edit",
+        "action": "Deny_Both",
+        "cron": "Never",
+        "dow": "",
+        "sort": "sort",
+        "aliaslog": "enabled",
+        "stateremoval": "enabled",
+        "autoproto_in": "any",
+        "agateway_in": "default",
+        "autoproto_out": "any",
+        "agateway_out": "default",
+        "suppression_cidr": "Disabled",
+        "srcint": "",
+        "script_pre": "",
+        "script_post": "",
+        "custom": "",
+        "format-0": "auto",
+        "state-0": "Disabled",
+        "url-0": "",
+        "header-0": "",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_ipv4_alias_permit_any_guard_rejects_and_valid_persists(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Permit_Inbound with protocol 'Any' aborts the IPv4 save; Deny_Both persists.
+
+    The guard (lines 623-640): ``action`` in {Permit_Inbound, Permit_Both} AND
+    (``autoproto_in`` empty or 'any') OR (no custom port/dest) -> ``$input_errors``
+    -> the whole save aborts -> config UNCHANGED. Transition: first a VALID
+    Deny_Both save establishes ``action='Deny_Both'`` at the rowid (asserted), then
+    a Permit_Inbound + autoproto_in='any' POST (with no custom port/dest) is
+    REJECTED, leaving ``action`` UNCHANGED at 'Deny_Both' -- proving the guard is a
+    real reject branch, not an always-unchanged path.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_IPV4)
+    cfg = f"{CFG_IPV4}/{rowid}/action"
+    try:
+        # BEFORE: free slot, no action stored.
+        assert helpers.config_get(vm, cfg) == "", f"ipv4 rowid {rowid} not free (action already set)"
+        # VALID Deny_Both -> persisted.
+        _post_form(webui, _ipv4_payload(rowid, "smokeip4", action="Deny_Both"))
+        assert helpers.config_get(vm, cfg) == "Deny_Both", "valid Deny_Both action did not persist"
+        # REJECT: Permit_Inbound + proto 'Any' + no custom port/dest -> save aborts.
+        _post_form(webui, _ipv4_payload(rowid, "smokeip4", action="Permit_Inbound", autoproto_in="any"))
+        assert helpers.config_get(vm, cfg) == "Deny_Both", (
+            "Permit_Inbound + 'Any' must abort the save (action unchanged at Deny_Both)"
+        )
+    finally:
+        _del_rowid(vm, CFG_IPV4, rowid)
+
+
+# --------------------------------------------------------------------------- #
+# ASN autocomplete JSON endpoint (?term=...) -- read-only GET, assert JSON shape.
+# --------------------------------------------------------------------------- #
+
+
+def test_asn_autocomplete_term_returns_json_list(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The ASN autocomplete (``isAjax`` + ``?term=...``) returns a JSON array.
+
+    The page's top branch (lines 34-66) serves an AJAX JSON list when
+    ``isAjax()`` AND ``$_GET['term']`` has length > 2: it filters the cached ASN
+    list (``pfblockerng_asn.txt``) by the term and ``echo json_encode($result)``;
+    when the file is absent the cache is ``[]`` -> an empty JSON array. Either way
+    the RESPONSE SHAPE is a JSON list -- this is read-only (no config write), so
+    it is safe to assert directly. ``isAjax()`` keys on the
+    ``X-Requested-With: XMLHttpRequest`` header, which we send.
+    """
+    resp = webui.get(
+        CATEGORY_PAGE,
+        params={"term": "AS3"},
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
+    assert resp.status_code == 200, f"ASN autocomplete -> HTTP {resp.status_code} (expected 200)"
+    assert not looks_like_login_page(resp.text), "ASN autocomplete returned the login form (session lost)"
+    parsed = json.loads(resp.text)
+    assert isinstance(parsed, list), f"ASN autocomplete must return a JSON list, got {type(parsed).__name__}"
+    # Each returned entry (if any) is a string ASN line from the cached list.
+    assert all(isinstance(item, str) for item in parsed), "ASN autocomplete list entries must be strings"


### PR DESCRIPTION
## Batch 3 — CRUD config-row flows (category / category_edit / blacklist)

Third back-to-back hermetic batch (audit `/private/tmp/ui_coverage_audit.md`).
Where Batch 1 was settings-form saves and Batch 2 was action/utility pages, Batch
3 covers the pages that **write config rows** — the AJAX `act=` row handlers and
the big alias save form.

### What (one new file per page)

- **category** (`test_category.py`, 3): `act=update` per-row **action** save
  (valid whitelisted action persists to config; bogus action → `$input_errors` →
  whole save aborts → config unchanged), the same for the **cron** select, and
  `act=del` row delete (seed a row, assert present, delete, assert gone). Direct
  `session.post` for the `act=` AJAX (the Batch-2 pattern).
- **category_edit** (`test_category_edit.py`, 7): a DNSBL alias **full save** at a
  free rowid (aliasname + action + logging + source-row state persisted),
  bad-aliasname **reject** (config unchanged), logging/order select transitions +
  bogus-coercion, `filter_alexa` checkbox both ways, the IPv4 **Permit_Inbound +
  "Any"-protocol guard** reject, and the **ASN autocomplete** JSON endpoint
  (read-only GET shape).
- **blacklist** (`test_blacklist.py`, 6): logging select both ways + bogus-coerce,
  per-provider category **enable/clear**, bogus-category reject, and the
  **enable/lang auto-submit** saves (config_mod path, no `save` button).

### Conventions held

Every flow is a transition test (assert before-state, then prove the POST caused
the change), branch coverage (accept **and** reject / off **and** on),
`finally`-restore so the session VM stays clean. Oracle is always effective
`config.xml` (`helpers.config_get`), never the HTTP body.

### Deferred (noted, not silently skipped)

Drag-reorder (`ids[]`), row move (`Lmove`/`Xmove`), `act=add`/`addgroup` feed
prefill, and GeoIP per-continent saves — these need browser-tier interaction or
egress; deferred to Batch 4 / a VM-only leg.

### Validation

- Default `python -m pytest`: **1089 passed (unchanged)** — `tests/smoke` ignored.
- `ruff check` clean; `tests/smoke/ui` collects without import error.
- Carries the **`ui-tests`** label so the live-VM suite validates all flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added 16 end-to-end UI smoke tests for pfBlockerNG covering blacklist/DNSBL category management, category summary operations, and alias editing. Tests verify valid and invalid form submissions, persistence of config changes, rejection of bad inputs, automatic coercion to defaults, autosubmit behaviors, and cleanup to avoid test-state leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->