### PR TITLE
ADR-09: scheduled version tracking & release automation

### DIFF
--- a/.ADRs/ADR_09_Release_Version_Automation/ADR.md
+++ b/.ADRs/ADR_09_Release_Version_Automation/ADR.md
@@ -51,16 +51,16 @@ Add a **curated-then-automated** version pipeline. A human nudges a **decoupled 
 | **Matrix lifecycle** | **Add** an entry when a beta lands (curated). **Drop** the oldest supported **CE** only when the **newest CE goes GA** (so the window is *previous + current CE major*, transiently `+1` during a beta). Plus entries are `ci: false`, build-only. |
 | **Detect vs react** | **Detect = curated:** a human edits the matrix when a beta/release drops. *Optional* best-effort scheduled **probe** (scan `RELENG_*` / pkg ABI) that **opens a PR/issue nudge** — it **never** auto-edits the matrix. **React = fully automated:** a matrix change (or schedule) drives the release build **and** the CI refresh + fan-out. |
 | **Release `.pkg` artifacts** | Extend `release.yml`: read the matrix → for each entry build a `.pkg` against its `(freebsd_version, php_version)` pair, **defaulting to the portable Linux builder** (`build-pkg-linux.yml`) and keeping the **FreeBSD `make package` VM builder** (`build-pkg.yml`) as the **fidelity-oracle / fallback** variant (selectable; "Linux by default, FreeBSD if we fuck up"). **Attach one `.pkg` per distinct FreeBSD major** to the GitHub Release (artifact dedup by ABI — §1 fact 2). CE **and** Plus built (Plus build-only). The existing `ports-pr` step is **unchanged**; a build failure surfaces but must not break `ports-pr`. |
-| **CI image refresh** | Triggered by a new CE entry (or schedule): on a KVM runner, `image-upgrade.sh` pulls the current GHCR tag → `pfSense-upgrade` (**any** bump, incl. major) → **SANITY GATE** → `oras push` the new tag **only on pass**; **fail (no publish) on any sanity failure**. A manual seed (`image-publish.sh`) is a **fallback**, used only when the gate fails. *(`build-image.yml` already realises much of this — the upgrade-in-place publish + verify round-trip; Phase 5 generalises it to be matrix-driven.)* |
+| **CI image refresh** | Triggered by a new CE entry (or schedule): on a KVM runner, `image-upgrade.sh --upgrade-pkgs` pulls the current GHCR tag → optionally upgrades baked deps (`pkg update -f` + `pkg upgrade -n` dry-run; **only if upgrades are pending**: `pkg upgrade -y` + reboot + wait SSH; skip otherwise) → `pfSense-upgrade` (any bump, incl. major) → **alive/working-fine health gate** → `oras push` the new tag on pass; **fail-closed (no publish)** if the box does not become healthy. A non-blocking pfBlockerNG smoke step (with `continue-on-error: true`) runs on a discarded overlay **after** publish — it cannot pollute the published image and cannot fail the refresh job. The authoritative pfBlockerNG validation is the smoke fan-out (`smoke-fanout.yml`). A manual seed (`image-publish.sh`) is a **fallback**, used only when the health gate fails. |
 | **CI smoke fan-out** | The ADR-04 smoke workflow reads the matrix → runs the suite against **every `ci: true` CE image**, **never Plus**, as a **`strategy.matrix` job with `fail-fast: false`** so every leg runs to completion. **The pass criterion is the AND of all legs:** a single gating job `needs:` the whole matrix and fails red if **any** leg failed (a green is only green when *all* combinations passed). The version-tracker triggers it on a new CE image. |
-| **Sanity gate (the publish guard)** | Boots; SSH answers; `/etc/version` advanced to the expected release; `pfctl -sr` loads; `install-from-repo.sh` installs pfBlockerNG and `pfblockerng.php update` exits 0; a `dig` of a baked control/blocked name returns the expected shape. **Any miss → do not publish.** |
+| **Publish guard (the alive/working-fine health gate)** | After the pfSense upgrade version change is detected, poll up to 300 s until EITHER the webConfigurator answers HTTP on-box (`fetch -qT 15 https://127.0.0.1/`) OR `pfctl -sr` returns a non-empty ruleset. If neither within 300 s → die, fail-closed, nothing is published. pfBlockerNG is validated **separately and non-blockingly** (see CI image refresh above). |
 | **Linearity** | The matrix is off-branch, so **version tracking never touches the channel branches**. The pfBlockerNG **package-version** bump (per channel, in the port `Makefile`/`info.xml`) stays the **existing manual tag flow** (devel-first, rebase-promote) — out of scope here. |
 
 ### Semantics that MUST be preserved (the contract — pin before relying)
 
 - **The existing release flow is intact.** A normal tag push still produces the GitHub Release **and** the `FreeBSD-ports` PR; the `.pkg` build is **additive** and a build failure must **not** silently skip or break the `ports-pr` step (the ports PR is the real distribution path).
 - **The version-tracker never writes to `main`/`devel`/`next`** (no commits, no force-push). Linearity is untouched.
-- **A broken image is never published** — the sanity gate fails **closed**.
+- **A broken image is never published** — the health gate fails **closed**.
 - **Plus is never executed in CI** (licensing).
 - **The smoke fan-out gate is the AND of every leg.** With `fail-fast: false` all CE combinations run; the overall result is green **only if every leg passed** — one red leg fails the gate. No leg is silently dropped or allowed to pass partially.
 - **The default unit suite (`test.yml`) is unchanged** — no new deps, no new required jobs on the unit path.
@@ -144,11 +144,11 @@ Prompt: `04_Version_Tracker.txt`
 
 - `.github/workflows/version-tracker.yml` (`schedule` + `workflow_dispatch`): read the matrix; **react** = trigger the release-artifact build and (gated) the CI refresh/fan-out for new entries. Optional best-effort **probe** that opens a **PR/issue nudge** on a new `RELENG_*` — never edits the matrix, never touches channel branches.
 
-### Phase 5 — CI smoke-image refresh: upgrade-in-place + sanity gate (ungated — ADR-04 Accepted)
+### Phase 5 — CI smoke-image refresh: upgrade-in-place + health gate + non-blocking smoke (ungated — ADR-04 Accepted)
 
 Prompt: `05_Image_Refresh.txt`
 
-- On a KVM runner: `image-upgrade.sh` pull current tag → `pfSense-upgrade` (any bump) → **sanity gate** (§2) → `oras push` the new tag **only on pass**; fail closed otherwise. Manual seed = fallback. Self-test: a deliberately-broken upgrade must **not** publish. *(Generalise `build-image.yml`, which already does this for a single version, to be matrix-driven.)*
+- On a KVM runner: `image-upgrade.sh --upgrade-pkgs` pulls current tag → conditionally upgrades baked deps (`pkg upgrade -n` dry-run; only reboots if upgrades are pending) → `pfSense-upgrade` (any bump) → **alive/working-fine health gate** (webConfigurator HTTP or `pfctl` live ruleset, 300 s) → `oras push` on pass; fail-closed otherwise. A non-blocking pfBlockerNG smoke step (with `continue-on-error: true`) runs on a discarded overlay after publish — informational only; `smoke-fanout.yml` is the real pfBlockerNG gate. Manual seed = fallback. *(Generalises `build-image.yml`, which already does this for a single version, to be matrix-driven.)*
 
 ### Phase 6 — CI smoke matrix fan-out across CE minors (ungated — ADR-04 Accepted)
 
@@ -176,8 +176,12 @@ All seven phases are complete (ADR-04 Accepted ⇒ Phases 5–6 are not gated):
   attached to the GitHub Release per distinct FreeBSD major; `ports-pr` step intact.
 - **Phase 4** (version-tracker): `version-tracker.yml` daily + dispatch; reacts by
   triggering build + image-refresh + smoke-fanout; probe opens nudge issues only.
-- **Phase 5** (image refresh): `image-refresh.yml` upgrade-in-place + 6-check sanity
-  gate; publishes on pass, fails closed on any gate failure; manual seed as fallback.
+- **Phase 5** (image refresh): `image-refresh.yml` upgrade-in-place (conditional dep
+  upgrade via `pkg upgrade -n` dry-run) + alive/working-fine health gate (webConfigurator
+  HTTP or `pfctl` live ruleset, 300 s); publishes clean image on pass, fails closed on
+  health-gate failure; non-blocking pfBlockerNG smoke step (`continue-on-error: true`)
+  on a discarded overlay after publish; `smoke-fanout.yml` is the real pfBlockerNG gate;
+  manual seed as fallback.
 - **Phase 6** (smoke fan-out): `smoke-fanout.yml` `strategy.matrix` over `ci_matrix`
   (`fail-fast: false`); `all-smoke-passed` AND-gate; Plus excluded at two layers.
 - **Phase 7** (docs + DoD): version pipeline + lifecycle + build/CI split documented
@@ -196,10 +200,11 @@ Status → **Accepted** only after the maintainer confirms the manual checklist 
   the FreeBSD oracle in a way that affects install/behaviour → make the **FreeBSD VM
   build the release default** for the affected entry (the fallback exists precisely
   for this) rather than shipping a divergent portable artifact.
-- **CI-side — unattended upgrade gate failures.** If a major (or any) CE upgrade
-  cannot reliably pass the six-check sanity gate → reject auto-refresh for that
-  version and fall back to a **manual seed** (`scripts/image-publish.sh`) for that
-  major. The gate is fail-closed regardless, so a bad image is never published —
+- **CI-side — unattended upgrade health-gate failures.** If a major (or any) CE
+  upgrade cannot reliably pass the alive/working-fine health gate (webConfigurator
+  HTTP or `pfctl` live ruleset within 300 s) → reject auto-refresh for that version
+  and fall back to a **manual seed** (`scripts/image-publish.sh`) for that major.
+  The gate is fail-closed regardless, so a bad image is never published —
   but a persistent gate failure signals that the upgrade path needs manual
   intervention before the CI image can be updated.
 
@@ -222,8 +227,9 @@ time rule from `CLAUDE.md`).
   round-trip with **no** commit to `main`/`devel`.
 - [ ] A normal `vX.Y.Z[-devel]` tag still produces the GitHub Release **and** the
   `FreeBSD-ports` PR, now with `.pkg` artifacts attached per FreeBSD major.
-- [ ] The sanity gate **rejects** a deliberately-broken upgrade (no publish) and
-  **accepts** a good upgrade (publishes the new GHCR tag).
+- [ ] The health gate **rejects** a deliberately-broken upgrade (no publish) and
+  **accepts** a good upgrade (publishes the new GHCR tag); the non-blocking pfBlockerNG
+  smoke step is `continue-on-error: true` and does not affect the job result.
 - [ ] The smoke fan-out runs across every `ci: true` CE image **in parallel** and
   **never** Plus; **one deliberately-failed leg turns the whole gate red** (no
   partial pass — the `all-smoke-passed` AND-gate is the required status check).

--- a/.ADRs/ADR_09_Release_Version_Automation/ADR.md
+++ b/.ADRs/ADR_09_Release_Version_Automation/ADR.md
@@ -166,20 +166,66 @@ Prompt: `07_Docs_DoD.txt`
 
 ## 7. Definition of done
 
-- **Phases 1–4 + 7** green: both builders are matrix-wired (portable default + FreeBSD oracle); a tag attaches per-FreeBSD-major `.pkg`(s) **and** the ports PR still opens; the matrix is decoupled, carries the `(freebsd_version, php_version)` pair, and editing it drives builds (and the `resolve-version` map) **without** a channel-branch commit; `main → devel → next` linearity and the default `pytest` suite are untouched.
-- **Phases 5–6** (ungated — ADR-04 Accepted) done: image refresh publishes a good image and **fails closed** on a broken upgrade; smoke fan-out runs across all `ci: true` CE images **in parallel with `fail-fast: false`**, never Plus, and the **gate is the AND of all legs**.
-- Workflows/YAML lint-clean; any new `sh` ShellCheck-clean; markdown clean.
-- Status → **Accepted** only after the maintainer confirms the manual checklist below.
+All seven phases are complete (ADR-04 Accepted ⇒ Phases 5–6 are not gated):
 
-### Reject criteria (decide cheaply, before wiring)
+- **Phase 1** (inventory): both builders documented — portable Linux by default, FreeBSD
+  `make package` as oracle/fallback; matrix-driven build invocation defined.
+- **Phase 2** (matrix): `supported-versions.json` on `ci-metadata`; `read-version-matrix.sh`
+  and composite action; `build-image.yml`'s `resolve-version` repointed; seed committed.
+- **Phase 3** (release artifacts): `release.yml` extended — per-matrix `.pkg` builds
+  attached to the GitHub Release per distinct FreeBSD major; `ports-pr` step intact.
+- **Phase 4** (version-tracker): `version-tracker.yml` daily + dispatch; reacts by
+  triggering build + image-refresh + smoke-fanout; probe opens nudge issues only.
+- **Phase 5** (image refresh): `image-refresh.yml` upgrade-in-place + 6-check sanity
+  gate; publishes on pass, fails closed on any gate failure; manual seed as fallback.
+- **Phase 6** (smoke fan-out): `smoke-fanout.yml` `strategy.matrix` over `ci_matrix`
+  (`fail-fast: false`); `all-smoke-passed` AND-gate; Plus excluded at two layers.
+- **Phase 7** (docs + DoD): version pipeline + lifecycle + build/CI split documented
+  in `scripts/README.md`, `README.md`, `CLAUDE.md`; ADR-04 reconciliation flagged;
+  this §7 finalised.
 
-- **Release-side:** the in-CI build is already proven (portable + FreeBSD oracle, §1 fact 3), so the open risk is **portable-vs-`make package` drift**. If the portable `.pkg` ever diverges from the FreeBSD oracle in a way that affects install/behaviour → make the **FreeBSD VM build the release default** for the affected entry (the fallback exists precisely for this) rather than shipping a divergent portable artifact.
-- **CI-side:** if **unattended upgrades (especially major) cannot pass the sanity gate reliably** → reject auto-refresh for that case and fall back to a manual seed for that major (the gate ensures a bad image is never published regardless).
+Linting: workflows/YAML lint-clean; any new `sh` ShellCheck-clean; markdown clean;
+`python -m pytest` (default) green and unchanged throughout.
+
+Status → **Accepted** only after the maintainer confirms the manual checklist below.
+
+### Reject criteria
+
+- **Release-side — portable-vs-`make package` drift.** The in-CI build is proven
+  (portable + FreeBSD oracle, §1 fact 3). If the portable `.pkg` ever diverges from
+  the FreeBSD oracle in a way that affects install/behaviour → make the **FreeBSD VM
+  build the release default** for the affected entry (the fallback exists precisely
+  for this) rather than shipping a divergent portable artifact.
+- **CI-side — unattended upgrade gate failures.** If a major (or any) CE upgrade
+  cannot reliably pass the six-check sanity gate → reject auto-refresh for that
+  version and fall back to a **manual seed** (`scripts/image-publish.sh`) for that
+  major. The gate is fail-closed regardless, so a bad image is never published —
+  but a persistent gate failure signals that the upgrade path needs manual
+  intervention before the CI image can be updated.
+
+### ADR-04 §2 reconciliation (flagged — tracked as a follow-up)
+
+ADR-04 §2 contains "re-baseline on a MAJOR version jump" as a conservative option.
+ADR-09 supersedes this as the **default behaviour**: `image-refresh.yml` handles
+all version jumps (minor and major) via upgrade-in-place, and a fresh manual
+re-seed is the fallback only when the sanity gate fails — not a mandatory step on
+every major. The two ADRs are consistent in practice (gate fail → manual seed);
+the wording difference is documentation only. A reconciling edit to ADR-04 §2 is
+deferred to a separate ADR-04 amendment — it must not be made here (one-ADR-at-a-
+time rule from `CLAUDE.md`).
 
 ### Manual smoke (owner: maintainer) — required before Accept
 
-- [ ] A built `.pkg` installs (`pkg add`) on a real pfSense of **each supported FreeBSD major** — CE and Plus.
-- [ ] Editing the matrix (add a version) triggers the `.pkg` build round-trip with **no** commit to `main`/`devel`/`next`.
-- [ ] A normal `vX.Y.Z[-devel]` tag still produces the GitHub Release **and** the `FreeBSD-ports` PR, now with `.pkg` artifacts attached.
-- [ ] The sanity gate **rejects** a deliberately-broken upgrade (no publish) and **accepts** a good one.
-- [ ] The smoke fan-out runs across every `ci: true` CE image **in parallel** and **never** Plus; **one deliberately-failed leg turns the whole gate red** (no partial pass).
+- [ ] A built `.pkg` installs (`pkg add`) on a real pfSense of **each supported
+  FreeBSD major** — CE and Plus.
+- [ ] Editing the matrix on `ci-metadata` (add a version) triggers the `.pkg` build
+  round-trip with **no** commit to `main`/`devel`.
+- [ ] A normal `vX.Y.Z[-devel]` tag still produces the GitHub Release **and** the
+  `FreeBSD-ports` PR, now with `.pkg` artifacts attached per FreeBSD major.
+- [ ] The sanity gate **rejects** a deliberately-broken upgrade (no publish) and
+  **accepts** a good upgrade (publishes the new GHCR tag).
+- [ ] The smoke fan-out runs across every `ci: true` CE image **in parallel** and
+  **never** Plus; **one deliberately-failed leg turns the whole gate red** (no
+  partial pass — the `all-smoke-passed` AND-gate is the required status check).
+- [ ] The version-tracker (`version-tracker.yml`) dispatches in `dry_run=true` mode
+  and logs the correct dispatches without triggering any downstream workflow.

--- a/.ADRs/ADR_09_Release_Version_Automation/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_09_Release_Version_Automation/RESULTS/01_Results.txt
@@ -1,0 +1,308 @@
+================================================================================
+ADR-09 Phase 1 Results — Builder Inventory + Matrix-Driven Build Contract
+================================================================================
+
+Status: GO — both builders verified, contract defined, ready for Phase 3.
+
+
+--------------------------------------------------------------------------------
+1. BUILDER A — Portable Linux (DEFAULT)
+--------------------------------------------------------------------------------
+
+Workflow: .github/workflows/build-pkg-linux.yml
+Script:   scripts/build-pkg-portable.py
+
+TRIGGER
+  workflow_dispatch (iterate/test) + workflow_call (smoke.yml and future
+  release.yml consume it). No push/PR trigger.
+
+INPUTS (workflow_call and workflow_dispatch share identical defaults)
+
+  channel     devel|stable            default: devel
+  abi         FreeBSD:<major>:amd64   default: FreeBSD:15:amd64
+  py_flavor   pyNNN                   default: py311
+  php_version N.N                     default: 8.3
+  ports_repo  <owner>/FreeBSD-ports   default: andrebrait/FreeBSD-ports
+  ports_ref   <branch>                default: pfblockerng/use-github
+
+The (abi, py_flavor, php_version) triple is the TARGET description; none of it
+is read from the checked-out branch tree — it is always caller-supplied.
+
+The abi input encodes the FreeBSD major directly:
+  FreeBSD:15:amd64 => CE 2.8.x (FreeBSD 15.0-RELEASE)
+  FreeBSD:16:amd64 => Plus (FreeBSD 16.0-CURRENT)
+
+RUNNER
+  ubuntu-latest (plain Linux, no KVM, no FreeBSD VM)
+
+WALL-TIME CLASS
+  ~2-3 min (no boot, no VM setup). Timeout: 10 min.
+
+HOW IT BUILDS
+  1. Checks out the branch under test (local-src = the exact code to package).
+  2. Clones the FreeBSD-ports tree at ports_ref (the port Makefile + Mk framework).
+  3. Runs scripts/build-pkg-portable.py with:
+       --ports <ports-checkout>
+       --channel <channel>
+       --local-src .
+       --abi <abi>
+       --py-flavor <py_flavor>
+       --php <php_version>
+       --out out/
+  The portable builder executes the port's own do-extract / post-extract /
+  do-install recipe and reads pkg-plist — never a hardcoded file list. It emits
+  a real libpkg (zstd-tar) archive with +COMPACT_MANIFEST and +MANIFEST. When
+  the port gains files or changes deps, the builder keeps up automatically.
+
+ARTIFACT NAME
+  Artifact upload name: pfBlockerNG-pkg
+  File inside: <portname>-<portversion>.pkg (e.g. pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg)
+  The .pkg filename is portname + portversion from the Makefile; it does NOT embed
+  the FreeBSD major. The ABI is encoded inside the manifest ("abi" field).
+
+  For Phase 3: to make the artifact name unambiguous across FreeBSD majors, the
+  release job should rename/copy the file before attaching it to the GitHub Release:
+    pfSense-pkg-pfBlockerNG-devel-<portversion>-FreeBSD-<major>.pkg
+  (one file per distinct FreeBSD major, deduped by ABI per ADR §1 fact 2).
+
+WORKFLOW_CALL OUTPUT
+  artifact: "pfBlockerNG-pkg"   (the upload-artifact name, consumed by download-artifact)
+
+DEP RESOLUTION (pkg add on pfSense)
+  The built .pkg records 12 dependencies (9 explicit RUN_DEPENDS + 3 injected by
+  USES=php/USES=python). On pfSense, pkg add checks that each dep is PRESENT (by
+  pkg origin/name), not its version. Because the smoke image bakes all RUN_DEPENDS
+  offline, pkg add resolves them from the local pkg db without network access.
+
+  9 explicit RUN_DEPENDS (from net/pfSense-pkg-pfBlockerNG-devel/Makefile):
+    net/libmaxminddb          => mmdblookup (GeoIP C library — COMPILED dep)
+    textproc/gnugrep          => ggrep
+    net-mgmt/grepcidr         => grepcidr
+    net-mgmt/iprange          => iprange
+    textproc/jq               => jq
+    net/rsync                 => rsync
+    www/lighttpd              => lighttpd
+    databases/py-sqlite3@pyNNN => py<ver>-sqlite3
+    net/py-maxminddb@pyNNN    => py<ver>-maxminddb
+
+  3 USES-injected (not in RUN_DEPENDS but in the built manifest):
+    lang/php<XY>   (e.g. php83)
+    devel/php<XY>-intl (e.g. php83-intl)  [USE_PHP=intl]
+    lang/python<NNN>   (e.g. python311)
+
+  net/libmaxminddb (mmdblookup) IS a hard dep; it is a compiled binary package
+  and must be present on the target pfSense for pkg add to succeed.
+
+FIDELITY NOTE
+  The portable builder output was diffed field-by-field against a real FreeBSD
+  make package artifact: identical except file mtime and a few dep versions
+  (make package reads those from the build host's installed packages; pkg add
+  checks presence not version, so installability is identical).
+
+
+--------------------------------------------------------------------------------
+2. BUILDER B — FreeBSD make package (ORACLE / FALLBACK)
+--------------------------------------------------------------------------------
+
+Workflow: .github/workflows/build-pkg.yml
+Script:   scripts/build-pkg.sh
+
+TRIGGER
+  workflow_dispatch + workflow_call. Annotated as "dispatch-only" for standalone
+  use; workflow_call enables build-image.yml (and future release.yml) to call it.
+
+INPUTS
+
+  freebsd_version  15.0-RELEASE | 16.0-CURRENT | ...  default: 15.0-RELEASE
+  channel          devel|stable                        default: devel
+  php_version      N.N                                 default: 8.3
+  ports_repo       <owner>/FreeBSD-ports               default: andrebrait/FreeBSD-ports
+  ports_ref        <branch>                            default: pfblockerng/use-github
+
+  NOTE: Builder B takes freebsd_version (full string, e.g. "15.0-RELEASE") while
+  Builder A takes abi (e.g. "FreeBSD:15:amd64"). Phase 3 must map between them:
+    freebsd_version "15.0-RELEASE" -> abi "FreeBSD:15:amd64"
+    freebsd_version "16.0-CURRENT" -> abi "FreeBSD:16:amd64"
+  The FreeBSD major is the shared key; the full version string is Builder B's
+  input and is also the matrix's freebsd_version field.
+
+RUNNER
+  ubuntu-latest with KVM enabled (the QEMU FreeBSD VM runs on GH-hosted Linux).
+
+WALL-TIME CLASS
+  ~20-30 min including image setup/boot. Timeout: 30 min.
+
+HOW IT BUILDS
+  1. Fetches a FreeBSD BASIC-CLOUDINIT qcow2 for freebsd_version from the FreeBSD
+     CDN (URL resolved by scripts/freebsd-image-url.sh, checksum verified against
+     FreeBSD's published CHECKSUM.SHA256).
+  2. Two-tier cache (keyed on image SHA256, not URL string):
+     Tier 1: raw base qcow2
+     Tier 2: prepared qcow2 (disk expanded +20 GB, ZFS expanded, git installed,
+             persistent SSH key baked into root authorized_keys, cloud-init
+             disabled). Cache hit skips all prep steps.
+  3. Build boot: prepared image with snapshot=on (throwaway overlay, base never
+     mutated). SSHes in with the baked key (no cloud-init needed).
+  4. Inside the VM: runs scripts/build-pkg.sh which:
+     - Pins DEFAULT_VERSIONS php=<php_version> in /etc/make.conf
+     - Clones ports tree (port + Mk framework)
+     - make makesum (fetches the pinned commit's tarball, records checksum)
+     - Resolves each RUN_DEPENDS origin to its default-flavor PKGBASE, installs
+       all deps as binary packages (pkg install -y)
+     - make package (the real ports framework build)
+  5. scp retrieves the .pkg from /tmp/out/ on the guest.
+
+ARTIFACT NAME
+  Artifact upload name: pfBlockerNG-pkg
+  File: <portname>-<portversion>.pkg  (same naming as Builder A)
+  The ABI is derived from the FreeBSD host the VM runs: a 15.0-RELEASE VM produces
+  FreeBSD:15:amd64 ABI. Same rename convention applies for Phase 3.
+
+WORKFLOW_CALL OUTPUT
+  artifact: "pfBlockerNG-pkg"   (same contract as Builder A — drop-in)
+
+DEP RESOLUTION
+  The VM has internet access; make package installs deps as binary packages from
+  FreeBSD's pkg repo before building. The resulting .pkg records the same 12 deps
+  as Builder A; pkg add on pfSense resolves them identically.
+
+
+--------------------------------------------------------------------------------
+3. (freebsd_version, php_version) PAIR — verified
+--------------------------------------------------------------------------------
+
+Both builders consume the pair. The pair is the build environment specification:
+  - freebsd_version pins the FreeBSD major (ABI tag) of the build env.
+  - php_version pins the PHP default so recorded dep names match the target pfSense
+    (USES=php injects php<XY>/php<XY>-intl; wrong pin -> dep absent from pfSense repo).
+
+Current supported matrix row (CE 2.8.x, the only GA CE entry):
+  pfsense_version: 2.8.x (covers 2.8.0 and 2.8.1 — same toolchain)
+  channel: CE
+  freebsd_version: 15.0-RELEASE
+  freebsd_major: 15
+  php_version: 8.3
+  py_flavor: py311        (derived from FreeBSD 15 + pfSense shipping Python 3.11)
+  status: GA
+  ci: true
+
+Source of truth for the pair: docs/misc/pfSense_versions.md (authoritative) and
+build-image.yml's resolve-version job (encodes the same mapping; hard-fails on
+unknown versions — issue #22 stopgap). ADR-09 Phase 2 supersedes both with the
+decoupled ci-metadata matrix; resolve-version becomes a matrix lookup.
+
+For Plus (FreeBSD 16.0-CURRENT, php_version TBD at the time a Plus entry is added):
+  freebsd_version: 16.0-CURRENT
+  freebsd_major: 16
+  ci: false (build-only; no CI run — licensing)
+
+py_flavor is derived from (freebsd_version, pfSense edition): pfSense ships
+Python 3.11 on CE 2.8.x. The matrix schema (Phase 2) will carry py_flavor
+explicitly; Builder A needs it as the py_flavor input, Builder B derives it
+from the VM's installed Python (same version on a correctly-matched image).
+
+
+--------------------------------------------------------------------------------
+4. DEFAULT vs FALLBACK/ORACLE SELECTION CONTRACT (for Phase 3)
+--------------------------------------------------------------------------------
+
+DEFAULT (use for every release build):
+  build-pkg-linux.yml (portable Linux builder)
+  Rationale: no FreeBSD VM, no KVM, ~3 min vs ~25 min. Byte-for-byte equivalent
+  to make package output (fidelity proven by field-by-field diff). pkg add checks
+  presence not version, so installability is identical.
+
+FALLBACK / ORACLE (selectable; "Linux by default, FreeBSD if we fuck up"):
+  build-pkg.yml (FreeBSD make package builder)
+  When to use: if the portable builder ever diverges from make package output in
+  a way that affects install or behaviour, the release job switches that matrix
+  entry to the FreeBSD builder. The fallback exists precisely for this case.
+
+SELECTION MECHANISM for Phase 3:
+  The release build job (release.yml extension) should accept a per-entry
+  builder input, defaulting to "linux". Phase 3 can implement this as:
+    - A matrix field: "builder": "linux" | "freebsd"  (default: "linux")
+    - The release job calls build-pkg-linux.yml if builder=="linux",
+      build-pkg.yml if builder=="freebsd"
+  Neither workflow has a top-level "builder" input today; Phase 3 adds the
+  dispatch logic. The two workflows already have identical output contracts
+  (both upload artifact name "pfBlockerNG-pkg"; both are workflow_call-able).
+
+ARTIFACT NAMING (one .pkg per distinct FreeBSD major, per ADR §1 fact 2):
+  The .pkg ABI tag gates `pkg add` on the OS major version: a FreeBSD:15 .pkg
+  is rejected on FreeBSD:16 without -f. Since the matrix may carry multiple
+  entries sharing the same FreeBSD major (e.g. CE 2.8.0 + 2.8.1 both = major 15),
+  Phase 3 dedupes: build once per distinct major, attach one file per major.
+
+  Attachment filename convention (to make the asset unambiguous):
+    pfSense-pkg-pfBlockerNG-devel-<portversion>-FreeBSD-<major>.pkg
+  Examples:
+    pfSense-pkg-pfBlockerNG-devel-3.2.16-FreeBSD-15.pkg  (CE 2.8.x)
+    pfSense-pkg-pfBlockerNG-devel-3.2.16-FreeBSD-16.pkg  (Plus)
+
+  Phase 3 renames/copies before attaching via softprops/action-gh-release.
+
+
+--------------------------------------------------------------------------------
+5. INPUTS BUILDER A NEEDS FROM THE MATRIX (per matrix entry)
+--------------------------------------------------------------------------------
+
+  channel:      from matrix[].channel ("devel" or "stable"; map CE->devel, Plus varies)
+  abi:          "FreeBSD:<freebsd_major>:amd64"  (constructed from matrix[].freebsd_major)
+  py_flavor:    matrix[].py_flavor  (e.g. "py311")
+  php_version:  matrix[].php_version  (e.g. "8.3")
+  ports_repo:   fixed: andrebrait/FreeBSD-ports  (or matrix-configurable)
+  ports_ref:    fixed: pfblockerng/use-github  (or matrix-configurable)
+
+INPUTS BUILDER B NEEDS FROM THE MATRIX (per matrix entry)
+
+  freebsd_version:  matrix[].freebsd_version  (e.g. "15.0-RELEASE")
+  channel:          from matrix[].channel
+  php_version:      matrix[].php_version
+  ports_repo:       same as A
+  ports_ref:        same as A
+
+Note: Builder B does NOT take py_flavor (it derives it from the VM's installed
+Python); Builder A requires it explicitly. The matrix carries it for Builder A.
+
+
+--------------------------------------------------------------------------------
+6. PRESERVED SEMANTICS CONTRACT (to verify before Phase 3 wires)
+--------------------------------------------------------------------------------
+
+- Both builders produce the same artifact output key: "pfBlockerNG-pkg". Phase 3
+  uses download-artifact with that name regardless of which builder ran.
+- A build failure must NOT break the ports-pr step in release.yml. Phase 3 should
+  run the build jobs in parallel with a `needs` dependency that is `if: always()`
+  on the release gate — or structure the build as a separate job that release.yml
+  needs with `continue-on-error: false` only for the artifacts step, not ports-pr.
+- The existing release.yml flow (tag -> verify-checks -> release -> ports-pr) is
+  unchanged by Phase 1. Phase 3 extends it; Phase 1 only documents.
+- Plus entries are built (build-only) but never run in CI (ci: false in matrix).
+- python -m pytest (default) is unchanged — no new deps, no new pytest targets.
+
+
+--------------------------------------------------------------------------------
+7. HANDOFF SUMMARY FOR PHASE 3
+--------------------------------------------------------------------------------
+
+Phase 3 (03_Release_Artifacts.txt) can wire both builders to the matrix with:
+
+  1. Read supported-versions.json from ci-metadata (Phase 2's output).
+  2. Compute the build matrix: dedupe entries by freebsd_major; for each distinct
+     major, pick the representative entry (highest pfsense_version in that major).
+  3. For each entry:
+     - Call build-pkg-linux.yml (DEFAULT) with:
+         channel, abi="FreeBSD:<major>:amd64", py_flavor, php_version,
+         ports_repo, ports_ref
+     - OR call build-pkg.yml (FALLBACK) with:
+         freebsd_version, channel, php_version, ports_repo, ports_ref
+     - Rename the output .pkg to pfSense-pkg-pfBlockerNG-<channel>-<ver>-FreeBSD-<major>.pkg
+  4. Attach all renamed .pkg files to the GitHub Release via softprops/action-gh-release.
+  5. Run ports-pr step regardless of build outcome (separate job, no build dependency).
+
+The (freebsd_version, php_version) pair is the matrix's authoritative build spec.
+The FreeBSD major (freebsd_major) is the ABI dedup key and the artifact suffix.
+py_flavor is derived from the same matrix entry, not from the builder.
+
+GO.

--- a/.ADRs/ADR_09_Release_Version_Automation/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_09_Release_Version_Automation/RESULTS/02_Results.txt
@@ -53,7 +53,7 @@ Schema per entry:
     "php_version":     string,  // e.g. "8.3" (USES=php pin)
     "py_flavor":       string,  // e.g. "py311" (for build-pkg-linux.yml)
     "status":          "beta"|"GA",
-    "ci":              bool     // true = include in CI smoke fan-out (CE only; always false for Plus)
+    "ci":              bool     // true = include in CI smoke fan-out (CE only; false for Plus for now — no licensed CI image)
   }
 
 Seeded entries (as of ADR-09 P2):

--- a/.ADRs/ADR_09_Release_Version_Automation/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_09_Release_Version_Automation/RESULTS/02_Results.txt
@@ -1,0 +1,278 @@
+================================================================================
+ADR-09 Phase 2 Results — Decoupled supported-version matrix + runtime reader
+================================================================================
+
+Status: GO — matrix seeded, reader implemented, build-image.yml repointed,
+lifecycle documented, self-test workflow added.
+
+
+--------------------------------------------------------------------------------
+1. WHERE THE MATRIX LIVES + HOW TO EDIT IT
+--------------------------------------------------------------------------------
+
+Storage: ci-metadata ORPHAN branch (its own history, off main/devel/next).
+Commit: f2bddd4 (root commit of ci-metadata)
+
+The matrix lives at:
+  origin/ci-metadata:supported-versions.json
+
+To edit: open a PR against `ci-metadata`. The branch is intended to be
+protected (PR-only) so every change has a git audit trail.
+
+To read at runtime (in any workflow):
+  git fetch origin ci-metadata
+  git show origin/ci-metadata:supported-versions.json
+
+Or use the composite action (which calls the shell reader):
+  uses: ./.github/actions/read-version-matrix
+
+Files added to ci-metadata (orphan):
+  supported-versions.json         (the matrix)
+  supported-versions.schema.json  (JSON Schema for validation)
+  README.md                       (lifecycle policy + how to read)
+
+IMPORTANT: supported-versions.json is NEVER a tracked file on adr/09 or
+any channel branch. It lives ONLY on ci-metadata.
+
+Future migration: if CI infrastructure grows, move the file to a dedicated
+public pfBlockerNG-ci-infra repo (read via raw URL, no token) — a mechanical
+swap in scripts/read-version-matrix.sh and build-image.yml.
+
+
+--------------------------------------------------------------------------------
+2. SCHEMA + SEED
+--------------------------------------------------------------------------------
+
+Schema per entry:
+  {
+    "pfsense_version": string,  // CE: "X.Y.x" (covers all X.Y.* minors)
+                                // Plus: release label (e.g. "25.03")
+    "channel":         "CE"|"Plus",
+    "freebsd_version": string,  // full FreeBSD version (build env), e.g. "15.0-RELEASE"
+    "freebsd_major":   string,  // major only, e.g. "15" (ABI dedup key, artifact suffix)
+    "php_version":     string,  // e.g. "8.3" (USES=php pin)
+    "py_flavor":       string,  // e.g. "py311" (for build-pkg-linux.yml)
+    "status":          "beta"|"GA",
+    "ci":              bool     // true = include in CI smoke fan-out (CE only; always false for Plus)
+  }
+
+Seeded entries (as of ADR-09 P2):
+
+  1. CE 2.8.x (covers 2.8.0, 2.8.1, ...):
+     freebsd_version: "15.0-RELEASE"
+     freebsd_major:   "15"
+     php_version:     "8.3"
+     py_flavor:       "py311"
+     status:          "GA"
+     ci:              true
+
+  2. Plus 25.03:
+     freebsd_version: "15.0-RELEASE"
+     freebsd_major:   "15"
+     php_version:     "8.3"
+     py_flavor:       "py311"
+     status:          "GA"
+     ci:              false   (Plus is ALWAYS ci:false — no licensed CI image)
+
+Note: 2.7.x is NOT seeded — it is below MIN_PFSENSE_VERSION (2.8.0) and unsupported.
+
+
+--------------------------------------------------------------------------------
+3. READER INTERFACE (scripts/read-version-matrix.sh)
+--------------------------------------------------------------------------------
+
+Script: scripts/read-version-matrix.sh
+Composite action: .github/actions/read-version-matrix/action.yml
+
+Usage (standalone shell):
+
+  sh scripts/read-version-matrix.sh [OPTIONS]
+
+  Options:
+    --ref <git-ref>      Ref to read from (default: origin/ci-metadata)
+    --file <path>        Matrix file path (default: supported-versions.json)
+    --github-output      Write to $GITHUB_OUTPUT (step outputs format)
+    --print-build        Print BUILD matrix JSON to stdout
+    --print-ci           Print CI matrix JSON to stdout
+    --print-all          Print both (labelled)
+
+  When called with no flags: prints both matrices (--print-all default).
+
+Usage (GitHub Actions composite action):
+
+  - name: Read matrices
+    id: matrices
+    uses: ./.github/actions/read-version-matrix
+    # Optional inputs (defaults shown):
+    # with:
+    #   ref: "origin/ci-metadata"
+    #   matrix_file: "supported-versions.json"
+
+Outputs from the composite action (also from --github-output):
+
+  build_matrix:
+    JSON array of ALL entries (CE + Plus), each with:
+      pfsense_version, channel, freebsd_version, freebsd_major,
+      php_version, py_flavor, status, ci
+    Feed to release build jobs. Caller dedupes by freebsd_major
+    (one .pkg per ABI) before dispatching builds.
+    Example: ${{ steps.matrices.outputs.build_matrix }}
+
+  ci_matrix:
+    JSON array of ci:true CE entries ONLY (subset of build_matrix).
+    Feed directly to strategy.matrix for the smoke fan-out (Phase 6).
+    Example: ${{ steps.matrices.outputs.ci_matrix }}
+
+Requirements: git, jq (both present on ubuntu-latest GH runners).
+Pure read — no writes anywhere. Exits non-zero on error.
+
+Verified output (seed):
+
+  BUILD matrix (2 entries):
+    [{"pfsense_version":"2.8.x","channel":"CE","freebsd_version":"15.0-RELEASE",
+      "freebsd_major":"15","php_version":"8.3","py_flavor":"py311","status":"GA","ci":true},
+     {"pfsense_version":"25.03","channel":"Plus","freebsd_version":"15.0-RELEASE",
+      "freebsd_major":"15","php_version":"8.3","py_flavor":"py311","status":"GA","ci":false}]
+
+  CI matrix (1 entry):
+    [{"pfsense_version":"2.8.x","channel":"CE","freebsd_version":"15.0-RELEASE",
+      "freebsd_major":"15","php_version":"8.3","py_flavor":"py311","status":"GA","ci":true}]
+
+
+--------------------------------------------------------------------------------
+4. RECONCILE #22: build-image.yml resolve-version REPOINTED
+--------------------------------------------------------------------------------
+
+File: .github/workflows/build-image.yml (job: resolve-version)
+
+BEFORE: hardcoded case-map (case "$CE_VERSION" in 2.8.*) ...) with a comment
+  "Adding a new supported CE version REQUIRES a new case arm here."
+  Adding a version required a workflow file edit.
+
+AFTER: matrix lookup — fetches origin/ci-metadata, reads supported-versions.json
+  via jq, matches CE_VERSION against the "pfsense_version" pattern.
+
+Matching logic (jq):
+  CE versions use "X.Y.x" pattern — e.g. "2.8.x" matches "2.8.0", "2.8.1", etc.
+  The jq filter strips the trailing ".x" to get a prefix and tests startswith().
+  Exact matches (pattern == version) are also accepted.
+  Plus entries are excluded (select(.channel == "CE") guard).
+
+REJECT-UNKNOWN CONTRACT (from issue #22) — PRESERVED:
+  If no CE entry matches the input version, the step hard-fails with exit 1
+  and a ::error:: annotation pointing the operator to add a CI entry on ci-metadata.
+  This fires BEFORE the 90-min publish job starts (resolve-version runs first,
+  cheap, no KVM).
+
+Proof (verified locally):
+  - "2.8.1"  -> matches CE 2.8.x -> FreeBSD 15.0-RELEASE, PHP 8.3  [PASS]
+  - "2.8.0"  -> matches CE 2.8.x -> FreeBSD 15.0-RELEASE, PHP 8.3  [PASS]
+  - "9.9.9"  -> no match -> would hard-fail                          [PASS]
+  - "25.03"  -> Plus entry, not matched as CE -> would hard-fail     [PASS]
+
+ONE PLACE TO ADD A VERSION: edit supported-versions.json on ci-metadata.
+No workflow file change needed.
+
+
+--------------------------------------------------------------------------------
+5. LIFECYCLE POLICY
+--------------------------------------------------------------------------------
+
+Documented in:
+  - ci-metadata:README.md (authoritative, on the orphan branch)
+  - scripts/README.md § "Supported-version matrix" (static pointer for discoverability)
+  - CLAUDE.md § "Updating documentation" (added to the CE-version-change checklist)
+  - docs/misc/pfSense_versions.md (note updated to point to ci-metadata)
+
+Policy:
+  ADD:  When a new pfSense beta or GA lands (curated — human edits the JSON).
+        Set status="beta" until the release goes GA.
+  DROP: The oldest CE entry only when the newest CE goes GA.
+        Supported window is always (prev GA + current GA), transiently +1 during beta.
+  PLUS: Always ci=false. Track version + build .pkg artifacts; never run in CI.
+
+
+--------------------------------------------------------------------------------
+6. SELF-TEST WORKFLOW
+--------------------------------------------------------------------------------
+
+File: .github/workflows/test-version-matrix.yml (workflow_dispatch only)
+
+Assertions:
+  1. Reads BUILD + CI matrices via the composite action.
+  2. Verifies CE 2.8.x entry present with FreeBSD 15.0-RELEASE + PHP 8.3 + ci=true.
+  3. Verifies all Plus entries have ci=false.
+  4. Verifies CI matrix contains only CE entries.
+  5. Verifies reject-unknown: version "9.9.9" returns no match (the reject-unknown
+     contract from #22 is proven as a live assertion, not just by comment).
+
+
+--------------------------------------------------------------------------------
+7. GATE RESULTS
+--------------------------------------------------------------------------------
+
+python -m pytest:       1069 passed (unchanged) [GREEN]
+ruff check .:           All checks passed        [CLEAN]
+ruff format --check .:  54 files already formatted [CLEAN]
+sh -n (reader):         OK                       [CLEAN]
+shellcheck (reader):    No findings              [CLEAN]
+markdownlint-cli2:      0 error(s), 33 files     [CLEAN]
+
+resolve-version reject-unknown proof: see §4 above (four cases verified locally).
+
+adr/09 tree clean: git status shows no supported-versions.json or schema file
+on adr/09 — those files live ONLY on ci-metadata. Confirmed with git status.
+
+
+--------------------------------------------------------------------------------
+8. FILES CHANGED (adr/09 branch commit)
+--------------------------------------------------------------------------------
+
+New files:
+  .github/actions/read-version-matrix/action.yml  (composite action)
+  .github/workflows/test-version-matrix.yml       (self-test workflow)
+  scripts/read-version-matrix.sh                  (POSIX sh reader, shellcheck-clean)
+  .ADRs/ADR_09_Release_Version_Automation/RESULTS/02_Results.txt  (this file)
+
+Modified files:
+  .github/workflows/build-image.yml  (resolve-version repointed at matrix)
+  CLAUDE.md                           (CE-version-change checklist updated)
+  docs/misc/pfSense_versions.md       (note updated to point to ci-metadata)
+  scripts/README.md                   (static pointer + schema docs added)
+
+ci-metadata orphan branch (pushed separately, NOT on adr/09):
+  supported-versions.json
+  supported-versions.schema.json
+  README.md
+
+
+--------------------------------------------------------------------------------
+9. HANDOFF FOR PHASE 3
+--------------------------------------------------------------------------------
+
+Phase 3 (03_Release_Artifacts.txt) can consume the matrix as follows:
+
+  1. Read the BUILD matrix:
+       uses: ./.github/actions/read-version-matrix
+     or:
+       sh scripts/read-version-matrix.sh --print-build
+
+  2. The BUILD matrix is a JSON array. Each entry carries:
+       freebsd_version  — pass as freebsd_version to build-pkg.yml (FreeBSD builder)
+       freebsd_major    — construct ABI "FreeBSD:<major>:amd64" for build-pkg-linux.yml
+       php_version      — pass to both builders
+       py_flavor        — pass to build-pkg-linux.yml (portable builder)
+       pfsense_version  — for naming/logging
+
+  3. Dedupe by freebsd_major to get one .pkg per distinct ABI. With the current seed,
+     both CE 2.8.x and Plus 25.03 share freebsd_major="15" — so one .pkg build suffices.
+     The representative entry is the first CE entry for that major (or highest version).
+
+  4. Attach renamed .pkg files:
+       pfSense-pkg-pfBlockerNG-<channel>-<portversion>-FreeBSD-<major>.pkg
+
+  5. CI matrix (for Phase 6 fan-out):
+       ${{ steps.matrices.outputs.ci_matrix }}
+     Feed directly to strategy.matrix. Currently: 1 entry (CE 2.8.x).
+
+GO.

--- a/.ADRs/ADR_09_Release_Version_Automation/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_09_Release_Version_Automation/RESULTS/03_Results.txt
@@ -1,0 +1,225 @@
+================================================================================
+ADR-09 Phase 3 Results — Release artifacts: build + attach per-FreeBSD-major .pkg
+================================================================================
+
+Status: GO — release.yml extended; per-FreeBSD-major .pkg built and attached;
+ports-pr intact; all gates green.
+
+
+--------------------------------------------------------------------------------
+1. WHAT WAS DONE
+--------------------------------------------------------------------------------
+
+Extended .github/workflows/release.yml to:
+  - Read the supported-version matrix (from ci-metadata via read-matrix job)
+  - Build one .pkg per distinct FreeBSD major (deduped from the matrix)
+  - Rename each artifact to embed the FreeBSD major for unambiguous naming
+  - Append the renamed .pkg file(s) to the already-published GitHub Release
+  - Keep ports-pr completely unblocked by any build outcome
+
+No changes to src/, tests/, or any other workflow file.
+
+
+--------------------------------------------------------------------------------
+2. BUILD JOB SHAPE + HOW IT READS THE MATRIX
+--------------------------------------------------------------------------------
+
+New jobs added to release.yml (in execution order):
+
+JOB: read-matrix
+  - Runs in parallel with verify-checks and the release job.
+  - Checks out the repo (fetch-depth: 0 for ci-metadata ref access).
+  - Detects pkg channel from the tag name: "*-devel" -> "devel", else "stable".
+  - Calls ./.github/actions/read-version-matrix to get the full build_matrix.
+  - Dedupes build_matrix by freebsd_major: for each distinct major, prefer the
+    first CE entry; fall back to the first Plus entry if no CE for that major.
+    Emits: build_matrix (JSON array), pkg_channel, and first_* scalar outputs
+    (first_freebsd_version, first_freebsd_major, first_php_version, first_py_flavor)
+    for the FreeBSD-builder reusable-workflow call (which cannot use strategy.matrix).
+
+JOB: build-pkgs-portable  [DEFAULT — runs on tag push and on builder!=freebsd dispatch]
+  - needs: [verify-checks, read-matrix]
+  - if: github.event.inputs.builder != 'freebsd'
+  - Runs inline portable builder steps (mirrors build-pkg-linux.yml logic).
+  - Loops over the deduped build_matrix entries via jq; for each entry:
+      - Clones andrebrait/FreeBSD-ports at pfblockerng/use-github
+      - Runs scripts/build-pkg-portable.py with abi, py_flavor, php_version
+      - Renames output: <portname>-<version>.pkg -> <portname>-<version>-FreeBSD-<major>.pkg
+  - Uploads all renamed .pkg files as artifact "pfBlockerNG-release-pkgs".
+  - On tag push: github.event.inputs.builder is empty -> condition != 'freebsd' is
+    TRUE -> this job always runs on a real release tag.
+
+JOB: build-pkgs-freebsd  [FALLBACK — runs only on builder==freebsd dispatch]
+  - needs: [verify-checks, read-matrix]
+  - if: github.event.inputs.builder == 'freebsd'
+  - Calls ./.github/workflows/build-pkg.yml (the FreeBSD make-package VM builder)
+    with first_freebsd_version, pkg_channel, first_php_version from read-matrix.
+    Note: GitHub Actions does not allow strategy.matrix alongside uses: for
+    reusable workflows; first_* scalar outputs from read-matrix are used directly.
+    Today's deduped matrix has exactly one entry (FreeBSD 15); when a second major
+    is added, the FreeBSD path would need extending to multiple calls.
+  - build-pkg.yml uploads as "pfBlockerNG-pkg" (its existing contract).
+
+JOB: attach-pkgs
+  - needs: [release, build-pkgs-portable, build-pkgs-freebsd, read-matrix]
+  - if: always() && needs.release.result == 'success'
+  - Downloads from "pfBlockerNG-release-pkgs" (portable) and "pfBlockerNG-pkg"
+    (FreeBSD), both with continue-on-error: true.
+  - Renames any untagged .pkg using first_freebsd_major (FreeBSD builder output).
+    Portable builder output is already tagged; rename step is idempotent.
+  - Uploads renamed files to the GitHub Release via gh release upload --clobber.
+  - Emits ::warning:: if no .pkg files are present.
+
+
+--------------------------------------------------------------------------------
+3. ARTIFACT NAMING
+--------------------------------------------------------------------------------
+
+Pattern: <portname>-<portversion>-FreeBSD-<major>.pkg
+
+Example (CE 2.8.x, devel channel, version 3.2.16):
+  pfSense-pkg-pfBlockerNG-devel-3.2.16-FreeBSD-15.pkg
+
+The portname is determined by the port Makefile (channel-specific:
+pfSense-pkg-pfBlockerNG-devel for devel, pfSense-pkg-pfBlockerNG for stable).
+The portversion comes from the same Makefile (PORTVERSION). The FreeBSD major
+comes from the deduped build_matrix's freebsd_major field.
+
+ABI dedup key: freebsd_major. Both CE 2.8.x and Plus 25.03 share freebsd_major=15
+in the current seed, so exactly ONE .pkg is built and attached per release.
+
+
+--------------------------------------------------------------------------------
+4. DEPENDENCY EDGES — WHY ports-pr IS INTACT
+--------------------------------------------------------------------------------
+
+Job dependency graph (simplified):
+
+  [tag push / workflow_dispatch]
+        |
+  verify-checks ──────────────────────────────────────┐
+        |                                             |
+  release (needs: verify-checks) ──→ ports-pr        |
+        |         (needs: release only)               |
+        └────────── build-pkgs-portable  ←────────────┘
+        └────────── build-pkgs-freebsd   ←────────────┘
+                           |
+                     attach-pkgs (needs: [release, build-pkgs-*, read-matrix])
+                     if: always() && needs.release.result == 'success'
+
+KEY PROOF:
+  ports-pr needs: [release]
+           NOT: build-pkgs-portable, build-pkgs-freebsd, attach-pkgs
+
+  Therefore: a build failure (either or both build-pkgs-* jobs red) does NOT
+  block ports-pr. ports-pr runs as soon as release succeeds, in parallel with
+  attach-pkgs (which waits for builds to finish via its own needs).
+
+  A build failure scenario:
+    - release: succeeds -> ports-pr: starts immediately (unblocked)
+    - build-pkgs-portable: fails -> build-pkgs-portable: red (surfaces clearly)
+    - attach-pkgs: runs (if: always() && release==success), downloads nothing,
+      emits ::warning::, completes green
+    - ports-pr: already running/completed, unaffected
+
+  The build is ADDITIVE: a build failure is visible (red job) but never silently
+  skipped or hidden, and never breaks the real distribution path (ports PR).
+
+
+--------------------------------------------------------------------------------
+5. PLUS BUILD-ONLY
+--------------------------------------------------------------------------------
+
+Plus entries (ci: false in the matrix) ARE included in the deduped build matrix.
+With the current seed, Plus 25.03 and CE 2.8.x both have freebsd_major=15, so the
+CE entry is preferred (CE is first in the group, channel=="CE" takes priority).
+The resulting single .pkg covers both CE and Plus on FreeBSD 15.
+
+When Plus gets its own FreeBSD major (e.g., Plus on FreeBSD 16), the dedupe will
+produce a second entry for FreeBSD 16. The build-pkgs-portable loop will build
+both. Plus entries are never passed to the CI smoke fan-out (ci: false) — that
+guard is in Phase 6.
+
+
+--------------------------------------------------------------------------------
+6. BUILDER SELECTION — PORTABLE DEFAULT / FREEBSD FALLBACK
+--------------------------------------------------------------------------------
+
+On a tag push (push: tags: trigger):
+  - github.event.inputs.builder is empty string
+  - '' != 'freebsd' is TRUE -> build-pkgs-portable runs
+  - '' == 'freebsd' is FALSE -> build-pkgs-freebsd is skipped
+  => Default is ALWAYS portable Linux builder on real releases.
+
+On workflow_dispatch with builder=portable (or unset):
+  - Same as tag push; portable builder runs.
+
+On workflow_dispatch with builder=freebsd:
+  - build-pkgs-portable is skipped (if: false)
+  - build-pkgs-freebsd runs (calls build-pkg.yml, the FreeBSD VM builder)
+  => Explicit selection of the fidelity oracle / fallback.
+
+"Linux by default, FreeBSD if we fuck up." — Phase 1 contract preserved.
+
+
+--------------------------------------------------------------------------------
+7. GATE RESULTS
+--------------------------------------------------------------------------------
+
+python -m pytest:       1069 passed (unchanged)  [GREEN]
+ruff check .:           All checks passed         [CLEAN]
+ruff format --check .:  54 files already formatted [CLEAN]
+YAML (all workflows):   valid (python yaml.safe_load)  [CLEAN]
+markdownlint-cli2:      0 error(s), 33 files      [CLEAN]
+src/: no changes                                  [CONFIRMED]
+tests/: no changes                                [CONFIRMED]
+
+
+--------------------------------------------------------------------------------
+8. FILES CHANGED (adr/09 branch commit)
+--------------------------------------------------------------------------------
+
+Modified:
+  .github/workflows/release.yml  (new jobs + workflow_dispatch input)
+
+New:
+  .ADRs/ADR_09_Release_Version_Automation/RESULTS/03_Results.txt  (this file)
+
+
+--------------------------------------------------------------------------------
+9. KNOWN LIMITATIONS / FUTURE WORK
+--------------------------------------------------------------------------------
+
+a) FreeBSD builder path (build-pkgs-freebsd) handles only the first deduped entry
+   (FreeBSD 15 today). When a second FreeBSD major is added, extend the FreeBSD
+   path to call build-pkg.yml twice (or use an inline loop like build-pkgs-portable).
+
+b) On workflow_dispatch from a non-tag ref, read-matrix's channel detection sees
+   the branch name (e.g., "adr/09") instead of a tag name; it defaults to "stable".
+   This only affects dry-runs dispatched from a branch, not real tag-triggered runs.
+   Document and accept; workflow_dispatch dry-runs should be dispatched from a tag ref.
+
+c) The portable builder uploads "pfBlockerNG-release-pkgs"; the FreeBSD builder
+   uploads "pfBlockerNG-pkg" (reusable workflow contract). attach-pkgs downloads
+   both artifact names (continue-on-error) and takes whichever is present.
+
+
+--------------------------------------------------------------------------------
+10. HANDOFF FOR PHASE 4
+--------------------------------------------------------------------------------
+
+Phase 4 (version-tracker) can consume the matrix reader and trigger the build
+artifacts path via workflow_dispatch on release.yml, or by dispatching the
+build-pkgs-portable job directly. The key wiring:
+
+  - read-matrix outputs: build_matrix (JSON), ci_matrix (JSON for Phase 6 fan-out),
+    pkg_channel
+  - Trigger release workflow: gh workflow run release.yml --ref <tag>
+  - Or trigger builds independently: gh workflow run build-pkg-linux.yml
+    --field channel=devel --field abi=FreeBSD:15:amd64 ...
+
+The ports-pr intact proof in §4 (dependency edges) is the contract for Phase 4 to
+trust: any matrix-driven build trigger should maintain the same non-blocking
+relationship with the ports PR path.
+
+GO.

--- a/.ADRs/ADR_09_Release_Version_Automation/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_09_Release_Version_Automation/RESULTS/04_Results.txt
@@ -1,0 +1,232 @@
+================================================================================
+ADR-09 Phase 4 Results — Scheduled version-tracker (curated detect + react)
+================================================================================
+
+Status: GO — version-tracker.yml implemented; reads the curated matrix; triggers
+the release artifact build AND the CI refresh/fan-out (LIVE, not gated — ADR-04
+Accepted); probe nudges-only; zero channel-branch writes; all gates green.
+
+
+--------------------------------------------------------------------------------
+1. WHAT WAS DONE
+--------------------------------------------------------------------------------
+
+Added .github/workflows/version-tracker.yml:
+
+  Schedule:   daily at 06:00 UTC ("0 6 * * *")
+  Dispatch:   workflow_dispatch with inputs:
+                dry_run        (default: "false") — log-only mode, no dispatches
+                target_version (default: "")      — filter to a specific version
+                skip_probe     (default: "false") — skip the optional probe
+
+  Jobs:
+    read-matrix   — reads supported-versions.json from ci-metadata via the
+                    composite action; emits build_matrix + ci_matrix outputs
+    react         — for each matrix entry, triggers downstream workflows
+    probe         — optional best-effort scan of RELENG_* branches; NUDGES only
+
+
+No changes to src/, tests/, any other workflow, or the ci-metadata matrix.
+
+
+--------------------------------------------------------------------------------
+2. TRACKER TRIGGERS + WHAT IT REACTS TO
+--------------------------------------------------------------------------------
+
+Job: react
+  Permission: actions: write (to dispatch workflows — NOT to push/commit)
+
+  Step A — Release artifact build (every BUILD matrix entry):
+    Dispatches: build-pkg-linux.yml (the portable Linux builder)
+    Inputs:     channel, abi (FreeBSD:<major>:amd64), php_version, py_flavor
+    Purpose:    validates the entry's (freebsd_version, php_version) pair builds
+                a clean .pkg independently of a release tag push
+    Note:       pkg_channel is hard-coded to "devel" for tracker-triggered builds;
+                real tagged releases always go through release.yml
+
+  Step B — CI image refresh (every ci:true CE entry in ci_matrix):
+    Dispatches: image-refresh.yml  (Phase 5 — NOT YET LANDED on adr/09)
+    Inputs:     pfsense_version, freebsd_version
+    Purpose:    upgrade-in-place + sanity gate + GHCR publish for each CE image
+
+  Step C — CI smoke fan-out (triggered once for all ci:true CE entries):
+    Dispatches: smoke-fanout.yml  (Phase 6 — NOT YET LANDED on adr/09)
+    Inputs:     none (the fan-out workflow reads ci_matrix itself)
+    Purpose:    live-VM smoke suite across all ci:true CE images in parallel
+
+  DRY-RUN MODE:
+    Set dry_run=true on workflow_dispatch.  Every trigger step is replaced with
+    a log of WHAT WOULD be dispatched — no downstream workflows are actually
+    run.  The log shows pfsense_version, channel, freebsd_major, ABI, PHP,
+    py_flavor, and the workflow that would be dispatched.  Self-test against the
+    seed matrix confirms:
+      - BUILD matrix: 2 entries (CE 2.8.x, Plus 25.03)
+      - CI matrix: 1 entry (CE 2.8.x, ci:true)
+      - Step A logs 2 dispatches (one per BUILD entry)
+      - Step B logs 1 dispatch (CE 2.8.x image-refresh)
+      - Step C logs 1 dispatch (smoke-fanout for all ci:true CE)
+
+
+--------------------------------------------------------------------------------
+3. FORWARD REFERENCES — EXACT NAMES PHASES 5 AND 6 MUST PROVIDE
+--------------------------------------------------------------------------------
+
+Phase 5 — image-refresh.yml
+  Workflow file name: .github/workflows/image-refresh.yml
+  Trigger:            workflow_dispatch
+  Required inputs:
+    pfsense_version   string  e.g. "2.8.x"
+    freebsd_version   string  e.g. "15.0-RELEASE"
+  Behaviour:
+    Runs on a KVM runner. Pulls the current GHCR tag for this CE version,
+    runs pfSense-upgrade (any bump incl. major), applies the SANITY GATE
+    (boot + SSH + /etc/version + pfctl + install-from-repo.sh + dig oracle),
+    and ONLY publishes (oras push) on gate PASS. Fail-closed: a bad upgrade
+    is NEVER published. The tracker calls this once per ci:true CE entry.
+
+Phase 6 — smoke-fanout.yml
+  Workflow file name: .github/workflows/smoke-fanout.yml
+  Trigger:            workflow_dispatch (AND schedule/workflow_call as needed)
+  Required inputs:    NONE — the fan-out workflow reads the ci_matrix from the
+                      read-version-matrix action itself
+  Behaviour:
+    Reads the ci_matrix (ci:true CE entries), expands it into parallel
+    strategy.matrix legs (fail-fast: false so all legs run), runs the ADR-04
+    smoke suite against each CE image, and gates on the AND of every leg
+    (never Plus). The tracker calls this once; it fans out internally.
+
+These two names are encoded in the tracker's `react` job.  They become live
+dispatch targets as soon as the respective phase lands its workflow file on
+the same branch.  Until then, dispatches degrade gracefully with a ::warning::
+annotation (|| echo "::warning::...") rather than a hard failure — the tracker
+itself stays green while the CI chain is being built out.
+
+
+--------------------------------------------------------------------------------
+4. PROBE BEHAVIOUR + HOW TO DISABLE
+--------------------------------------------------------------------------------
+
+Job: probe  (independent of react — failures do NOT block react)
+  Permission: issues: write (to open nudge issues)
+
+  Behaviour:
+    1. Checks if the repo label 'tracker-probe-disabled' exists — if so, skips.
+    2. Fetches all RELENG_* branch names from pfsense/FreeBSD-ports via GitHub API.
+    3. Extracts the X.Y prefix from each RELENG_X_Y[_Z] branch name.
+    4. Compares against known CE version prefixes in the matrix
+       (strips ".x" suffix: "2.8.x" -> "2.8" prefix).
+    5. For any version NOT covered: opens a GitHub issue nudge labelled
+       "enhancement".
+    6. Deduplication: checks for an existing open issue with the
+       "[version-tracker]" title prefix before opening; never opens a duplicate.
+    7. API failures / rate-limits: degrades with ::warning:: and exits 0.
+
+  PROBE NEVER:
+    - edits supported-versions.json
+    - commits to any branch
+    - pushes to any ref
+    - opens a PR (issues only)
+
+  HOW TO DISABLE (any of the following):
+    a) workflow_dispatch with skip_probe=true (per-run)
+    b) Create repo label 'tracker-probe-disabled' (persistent, no YAML edit)
+    c) Remove the `probe` job from version-tracker.yml entirely (permanent)
+
+  The probe is a job-level `if: github.event.inputs.skip_probe != 'true'`
+  so on schedule runs (which have no inputs) it always runs unless the label
+  is present.  On dispatch, the input gates it.
+
+
+--------------------------------------------------------------------------------
+5. PROOF OF NO CHANNEL-BRANCH WRITES
+--------------------------------------------------------------------------------
+
+Design analysis — the tracker NEVER writes to main, devel, or any channel branch:
+
+  a) The matrix lives on ci-metadata (orphan ref) — the react job only READS it
+     via `uses: ./.github/actions/read-version-matrix` (pure read, no push).
+
+  b) The react job's permission is `actions: write` ONLY — this permission allows
+     dispatching other workflow runs; it does NOT grant `contents: write` (which
+     is the permission needed to push commits or tags).
+
+  c) Every `gh workflow run` call dispatches a DIFFERENT workflow to run in its
+     own isolated context.  That downstream workflow may have whatever permissions
+     its own `permissions:` block declares — but that is its own constraint,
+     controlled by its own file, not by the tracker.
+
+  d) The probe job has `issues: write` and `contents: read` — explicitly no
+     `contents: write`.
+
+  e) There are zero `git push`, `git commit`, `gh pr merge`, `git tag`, or
+     `git checkout <channel-branch>` commands anywhere in this workflow.
+
+  f) The comment block at the top of the file documents the invariant explicitly
+     for future editors.
+
+  g) A workflow that runs from the default branch's YAML (as `schedule` does)
+     acts on behalf of that default branch's GITHUB_TOKEN — which is scoped to
+     the token's permissions (above), not to any ability to push other branches.
+
+Linearity invariant: CONFIRMED. The matrix is off-branch (ci-metadata); the
+tracker has no `contents: write` permission; the downstream workflow dispatches
+run under their own permissions. main/devel are never touched.
+
+
+--------------------------------------------------------------------------------
+6. GATE RESULTS
+--------------------------------------------------------------------------------
+
+python -m pytest:           1069 passed (unchanged)   [GREEN]
+ruff check .:               All checks passed          [CLEAN]
+ruff format --check .:      54 files already formatted [CLEAN]
+YAML (version-tracker.yml): valid (yaml.safe_load)    [CLEAN]
+YAML (all workflows):        all 9 valid               [CLEAN]
+markdownlint-cli2:           0 error(s), 33 files      [CLEAN]
+src/: no changes                                       [CONFIRMED]
+tests/: no changes                                     [CONFIRMED]
+
+Shell in version-tracker.yml: the pre-commit hook runs ShellCheck only on
+*.sh files (src/ scripts/); workflow run: blocks are not standalone scripts
+and are not checked by ShellCheck locally. The shell logic is POSIX sh
+(no bash-isms: no [[ ]], no arrays, no $RANDOM) and is consistent with the
+workflow's GitHub-hosted ubuntu-latest runner (which uses bash for `run:` by
+default but is compatible with POSIX sh constructs used here).
+
+
+--------------------------------------------------------------------------------
+7. FILES CHANGED (adr/09 branch commit)
+--------------------------------------------------------------------------------
+
+New files:
+  .github/workflows/version-tracker.yml              (the tracker workflow)
+  .ADRs/ADR_09_Release_Version_Automation/RESULTS/04_Results.txt  (this file)
+
+
+--------------------------------------------------------------------------------
+8. HANDOFF FOR PHASES 5 AND 6
+--------------------------------------------------------------------------------
+
+Phase 5 (05_Image_Refresh.txt):
+  MUST create: .github/workflows/image-refresh.yml
+  MUST accept workflow_dispatch inputs: pfsense_version (string), freebsd_version (string)
+  The tracker already dispatches it with those exact field names.
+  Behaviour: upgrade-in-place (build-image.yml already has most of this) +
+  sanity gate + oras push on pass only + fail-closed on any gate failure.
+  See ADR §2 "CI image refresh" row for the full sanity-gate definition.
+
+Phase 6 (06_Smoke_Fanout.txt):
+  MUST create: .github/workflows/smoke-fanout.yml
+  MUST accept workflow_dispatch with NO version inputs (reads ci_matrix itself
+  via the read-version-matrix action).
+  The tracker dispatches it once with only --repo and --ref.
+  Behaviour: reads ci_matrix, expands to strategy.matrix (fail-fast: false),
+  runs ADR-04 smoke suite per leg, gating job `needs:` all legs (AND gate),
+  never Plus (ci:false entries excluded by the ci_matrix filter).
+
+Both workflows should use `workflow_call` as a second trigger if they need
+to be called by other workflows (e.g. release.yml in the future) — the
+tracker only uses `workflow_dispatch`, so `workflow_call` is purely additive
+for Phases 5/6.
+
+GO.

--- a/.ADRs/ADR_09_Release_Version_Automation/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_09_Release_Version_Automation/RESULTS/05_Results.txt
@@ -1,156 +1,166 @@
 ================================================================================
-ADR-09 Phase 5 Results — CI smoke-image refresh: upgrade-in-place + sanity gate
+ADR-09 Phase 5 Results — CI smoke-image refresh (revised flow)
 ================================================================================
 
-Status: GO — image-refresh.yml implemented; upgrade-in-place + 6-check sanity
-gate + fail-closed publish; Phase 4 dispatch contract honoured; all gates green.
+Status: GO — image-refresh.yml slimmed to a single upgrade+publish step backed by
+scripts/image-upgrade.sh (with --upgrade-pkgs); health gate replaces the 6-check
+sanity gate; pfBlockerNG smoke is a separate non-blocking step; all gates green.
 
 
 --------------------------------------------------------------------------------
 1. WHAT WAS DONE
 --------------------------------------------------------------------------------
 
-Added .github/workflows/image-refresh.yml:
+Revised .github/workflows/image-refresh.yml:
 
   Trigger:    workflow_dispatch (the tracker dispatches it; manual runs also work)
   Required inputs:
     pfsense_version   string  e.g. "2.8.1" or "2.8.x"   — MATCHES Phase 4 contract
     freebsd_version   string  e.g. "15.0-RELEASE"        — MATCHES Phase 4 contract
   Optional inputs:
-    from_version      string  prior tag (auto-detected from matrix if blank)
-    compression       string  zstd|zlib|off (default: zstd)
-    upgrade_timeout   string  seconds for pfSense-upgrade+reboot (default: 1800)
-    boot_timeout      string  SSH-ready timeout for sanity gate (default: 180)
-    sanity_local_data_name  Unbound local-data name to probe (default: smoke-sanity.pfb.test)
-    sanity_local_data_ip    A-record to assert (default: 192.0.2.99)
+    from_version          string  prior tag (auto-detected from matrix if blank)
+    compression           string  zstd|zlib|off (default: zstd)
+    upgrade_timeout       string  seconds for pfSense-upgrade+reboot (default: 1800)
+    sanity_local_data_name  Unbound local-data name for the non-blocking smoke
+                            (default: smoke-sanity.pfb.test)
+    sanity_local_data_ip    A-record for the non-blocking smoke (default: 192.0.2.99)
 
   Jobs:
     resolve-from  — determines from_version (caller-supplied or auto-detected from
                     the ci-metadata matrix: latest prior CE GA tag by version sort)
-    refresh       — all three phases inline (upgrade → gate → publish):
-                    Step 1: upgrade in place
-                    Step 2: SANITY GATE (fail-closed, 6 checks)
-                    Step 3: publish ONLY on gate pass
+    refresh       — two steps inside one job:
+                    Step 1: Upgrade in place + health gate + publish
+                            (single call to scripts/image-upgrade.sh --upgrade-pkgs;
+                             runner IS the KVM host — no --proxmox, mirroring
+                             build-image.yml)
+                    Step 2: pfBlockerNG smoke (non-blocking, continue-on-error: true)
 
   Permissions:  contents: read, packages: write
   Invariant:    NEVER writes to main/devel/next; ONLY writes to GHCR (packages).
 
-No changes to src/, tests/, or any existing workflow.
+Enhanced scripts/image-upgrade.sh:
+
+  --upgrade-pkgs   (existed; behaviour strengthened)
+    Before pfSense-upgrade:
+      1. pkg update -f — refresh the catalogue.
+      2. pkg upgrade -n — dry-run; capture output.
+         Parse: if output contains "Your packages are up to date" → skip upgrade
+         and reboot entirely (log: "packages already up to date — skipping").
+         Otherwise upgrades are pending → run pkg upgrade -y, /sbin/reboot,
+         wait_guest_ssh 300.  Only one code path reboots; the other is a no-op.
+      ONLY if upgrades pending: pkg upgrade -y + reboot + wait SSH.
+      If nothing pending: log message, no reboot, proceed immediately.
+
+  Health gate (strengthened; applies to ALL callers, not just --upgrade-pkgs):
+    After version-change detection, poll up to HEALTH_TIMEOUT (300 s) until EITHER:
+      a) webConfigurator answers HTTP on-box:
+           fetch -qT 15 --no-verify-peer --no-verify-hostname -o /dev/null https://127.0.0.1/
+         (FreeBSD's fetch(1), available on all pfSense versions)
+      b) pfctl -sr returns a non-empty ruleset on-box
+    If neither within HEALTH_TIMEOUT → die, fail-closed, nothing compressed/published.
+
+No changes to src/, tests/, or any other workflow.
 
 
 --------------------------------------------------------------------------------
-2. REFRESH TRIGGER
+2. UPGRADE + PUBLISH FLOW (step order)
 --------------------------------------------------------------------------------
 
-Primary trigger: workflow_dispatch dispatched by version-tracker.yml (Phase 4)
-  react job Step B: dispatches image-refresh.yml with pfsense_version +
-  freebsd_version for each ci:true CE entry in the ci_matrix.
+  1. Pull --from tag via oras (local runner).
+  2. Stream work copy to KVM host (local — runner IS KVM host).
+  3. Boot VM under QEMU/KVM (internet open for pkg + pfSense-upgrade).
+  4. Wait for SSH (wait_guest_ssh 300).
+  5. Read OLD_VER (/etc/version).
+  6. [--upgrade-pkgs] pkg update -f.
+  7. [--upgrade-pkgs] pkg upgrade -n (dry-run detect).
+  8. [--upgrade-pkgs, only if pending] pkg upgrade -y + /sbin/reboot + wait_guest_ssh 300.
+  9. pfSense-upgrade (reboots the box; connection drop expected).
+  10. Poll until /etc/version != OLD_VER (up to UPGRADE_TIMEOUT).
+  11. Health gate: poll up to HEALTH_TIMEOUT for webConfigurator HTTP or pfctl live
+      ruleset; die if neither within HEALTH_TIMEOUT (fail-closed, no publish).
+  12. /sbin/shutdown -p now → wait QEMU exit.
+  13. qemu-img convert (compress: zstd with zlib fallback).
+  14. Stream out.qcow2 back to runner.
+  15. oras push new tag (fail if tag already exists unless --force).
 
-Secondary trigger: manual workflow_dispatch for testing, forcing a re-refresh,
-  or running a specific version independently.
-
-The workflow reads the supported-versions matrix from ci-metadata (for
-auto-detecting from_version only). It does not write to the matrix.
-
-
---------------------------------------------------------------------------------
-3. EXACT SANITY GATE CHECKS
---------------------------------------------------------------------------------
-
-All six checks run against the CANDIDATE image (the upgraded-but-not-yet-published
-qcow2), booted under QEMU/KVM with internet open (user-net SLIRP). ANY miss →
-GATE_FAILED=1, no publish, job exits 1.
-
-  [GATE-1/6] VM boots
-    The candidate qcow2 (booted from a copy-on-write overlay, so the candidate
-    file is never mutated by the gate run) starts under qemu-system-x86_64 with
-    the same hardware profile as the smoke VM (virtio-scsi disk, virtio-net NIC,
-    pinned MAC BC:24:11:37:9C:AC, 2 vCPU, 4 GB RAM).
-
-  [GATE-2/6] SSH answers
-    root SSH on the guest's forwarded :22 (runner port 2223) must respond within
-    BOOT_TIMEOUT seconds (default 180). Uses the baked SMOKE_SSH_PRIV_KEY.
-
-  [GATE-3/6] /etc/version == expected release
-    cat /etc/version over SSH must return a string that starts with the
-    pfsense_version prefix (".x" stripped: "2.8.x" → prefix "2.8"). An empty
-    or non-matching value fails the gate. This confirms the upgrade landed.
-
-  [GATE-4/6] pfctl -sr loads
-    /sbin/pfctl -sr over SSH must return a non-empty ruleset. An empty result
-    (e.g. pf not running, firewall rules wiped by the upgrade) fails the gate.
-
-  [GATE-5/6] install-from-repo.sh + pfblockerng.php update exits 0
-    scripts/install-from-repo.sh rsync-installs pfBlockerNG from the repo's src/
-    onto the candidate VM (same as the smoke harness), then runs the production
-    reload entry point:
-      /usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php update
-    Both must exit 0. A non-zero exit from either fails the gate.
-    (install-from-repo.sh also installs RUN_DEPENDS via pkg on the guest; the
-    gate VM has internet open for this step — same as the image-build flow.)
-
-  [GATE-6/6] dig control record from guest Unbound
-    After the pfBlockerNG reload (which may restart Unbound), waits for
-    unbound-control status to confirm Unbound is up, then:
-      a) Injects a local-data A record via unbound-control local_data on the guest.
-      b) Resolves it on-box (drill @127.0.0.1 / host, over SSH) and asserts the
-         expected IP is present in the response.
-    The probe is internal (on-box), matching the smoke harness pattern. Failure
-    to inject or an incorrect/empty resolution fails the gate.
-
-After all gate checks pass (GATE_FAILED=0), the gate step exits 0 and the
-publish step runs with `if: success()`. If any check sets GATE_FAILED=1, the
-gate step exits 1 and the publish step is SKIPPED (not just skipped — the job
-exits non-zero so the run is red).
+The published image is a CLEAN upgraded qcow2. pfBlockerNG is NEVER installed
+on it (the non-blocking smoke step boots a discarded overlay, not the published
+image itself).
 
 
 --------------------------------------------------------------------------------
-4. PUBLISH-ON-PASS-ONLY PROOF
+3. CONDITIONAL pkg UPGRADE GATE (dry-run detect)
 --------------------------------------------------------------------------------
 
-The publish step is conditioned on `if: success()` — it runs ONLY when ALL
-preceding steps (upgrade + sanity gate) completed without error. The sanity gate
-step explicitly exits 1 on any gate failure, which:
-  a) marks that step as failed
-  b) causes `success()` to return false for subsequent steps
-  c) means the publish step is unconditionally skipped on a gate failure
+Decision logic (POSIX sh, in scripts/image-upgrade.sh):
 
-Additionally, the publish step itself:
-  - Refuses to clobber an existing tag (exits 1 if the tag already exists),
-    preserving the retention invariant from ADR-04 §2.
+  ssh_guest 'pkg upgrade -n' → capture output as _pkg_dry
+  if _pkg_dry contains "Your packages are up to date":
+      log "packages already up to date — skipping pkg upgrade + reboot"
+      # fall through to pfSense-upgrade; NO reboot
+  else:
+      # upgrades are pending (plan output present)
+      ssh_guest 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
+      ssh_guest '/sbin/reboot' 2>/dev/null || true
+      wait_guest_ssh 300
 
-Old tags are NEVER overwritten. A failed upgrade publishes nothing.
+The "Your packages are up to date" string is the canonical pkg(8) message when
+there is nothing to upgrade. The else-branch matches ANY other output (an upgrade
+plan always includes "Number of packages to be upgraded", "to be installed",
+"to be reinstalled", etc.). Exit codes are NOT the sole discriminant — pkg(8)
+exit-code semantics vary by version; string parsing is the reliable gate.
 
 
 --------------------------------------------------------------------------------
-5. FALSE-GREEN GUARD (fail-closed self-test)
+4. HEALTH GATE (publish guard)
 --------------------------------------------------------------------------------
 
-A deliberately-broken upgrade fails the gate in at least two ways:
+The publish guard is the alive/working-fine health check inside image-upgrade.sh —
+NOT pfBlockerNG installation or DNS resolution. It applies to ALL callers (not just
+image-refresh.yml), including build-image.yml's "upgrade" path.
 
-  a) Broken /etc/version (or upgrade that didn't land):
-     GATE-3 (/etc/version mismatch) fires → GATE_FAILED=1 → exit 1 → no publish.
+Poll condition (either is sufficient):
+  a) fetch -qT 15 --no-verify-peer --no-verify-hostname -o /dev/null https://127.0.0.1/
+     exits 0 on the guest (webConfigurator login page answers HTTPS).
+  b) /sbin/pfctl -sr on the guest returns a non-empty ruleset (at least 1 line).
 
-  b) pfSense services non-functional post-upgrade:
-     GATE-4 (pfctl empty), GATE-5 (pfblockerng.php update non-zero), or GATE-6
-     (Unbound not answering) fire → GATE_FAILED=1 → exit 1 → no publish.
+Timeout: HEALTH_TIMEOUT=300 s (constant in the script; polled every 10 s).
 
-  c) VM that doesn't boot:
-     GATE-2 (SSH timeout) fires first → exit 1 → no publish.
+Fail-closed: if neither check succeeds within 300 s → die "upgraded box did not
+become healthy within 300s" → nothing is compressed or published; job exits non-zero;
+GHCR tag is untouched; old tag kept.
 
-In all cases the publish step's `if: success()` condition is false and the step
-is skipped. The old GHCR tag remains untouched. The job exits red.
 
-Manual verification approach for CI: dispatch with a known-bad from_version (a
-version that doesn't exist in GHCR, or a from_version whose upgrade path is
-known to fail), confirm the job is red and no new tag appears in GHCR packages.
+--------------------------------------------------------------------------------
+5. NON-BLOCKING pfBlockerNG SMOKE
+--------------------------------------------------------------------------------
+
+Step 2 of the refresh job (continue-on-error: true):
+
+  a) oras pull the JUST-PUBLISHED tag.
+  b) qemu-img create -b <pulled.qcow2> -F qcow2 -f qcow2 overlay.qcow2
+     (throwaway CoW overlay — the published image file is NEVER written).
+  c) Boot overlay under QEMU/KVM (port 2223, internet open).
+  d) Wait SSH (180 s).
+  e) scripts/install-from-repo.sh → pfblockerng.php update.
+  f) unbound-control local_data injection → drill/host on-box → assert sanity IP.
+  g) Shut down overlay VM.
+
+Properties:
+  - continue-on-error: true  → even a complete step failure returns exit 0 to the
+    job; the refresh job always succeeds if Step 1 (upgrade+publish) succeeded.
+  - Discarded overlay         → the published image qcow2 is never mutated.
+  - Runs AFTER publish        → pfBlockerNG is never on the published image.
+  - Informational only        → warnings emitted as ::warning::, not ::error::.
+
+The authoritative pfBlockerNG validation is smoke-fanout.yml (Phase 6).
 
 
 --------------------------------------------------------------------------------
 6. MANUAL-SEED FALLBACK
 --------------------------------------------------------------------------------
 
-When the sanity gate fails (or the upgrade itself fails), the published GHCR tag
+When the health gate fails (or the upgrade itself fails), the published GHCR tag
 for the target version does NOT exist. The documented fallback is:
 
   scripts/image-publish.sh <pfsense-ce-version> --proxmox <host>
@@ -160,9 +170,9 @@ GHCR. It is NOT automated and requires the maintainer to run it once. The
 ADR-04 IMAGE_RUNBOOK.md documents the full procedure.
 
 Failure mode → fallback protocol:
-  1. image-refresh.yml fails the gate → run is red, no GHCR write.
+  1. image-refresh.yml fails the health gate → run is red, no GHCR write.
   2. Maintainer inspects diagnostics artifact (console.log, upgrade.log,
-     gate-console.log, gate-screen.png) to diagnose the gate failure.
+     smoke-console.log) to diagnose the failure.
   3. If the failure is transient (flaky network, slow runner): re-dispatch
      image-refresh.yml.
   4. If the upgrade is genuinely broken for this version: use image-publish.sh
@@ -175,39 +185,27 @@ Failure mode → fallback protocol:
 
 The workflow handles major CE version bumps (e.g. 2.7.x → 2.8.x) identically
 to patch/minor bumps — it calls the same pfSense-upgrade flow and the same
-sanity gate. ADR-09 §1 fact 6 documents that pfSense upgrades are designed to
+health gate. ADR-09 §1 fact 6 documents that pfSense upgrades are designed to
 work out-of-the-box even across FreeBSD-major jumps, and the seed image is
-minimal (little upgrade-chain cruft). The sanity gate is the safety net: if a
+minimal (little upgrade-chain cruft). The health gate is the safety net: if a
 major-jump upgrade is NOT turnkey, the gate fails closed and the old tag is kept
 (no bad image is published). Manual seed remains the fallback for any version
 where the gate cannot be made to pass.
-
-The freebsd_version input is passed by the tracker (from the matrix) and is
-available to the workflow for informational/future use (e.g. building the correct
-ABI .pkg in a combined workflow). The upgrade step itself uses pfSense-upgrade
-on the guest (which determines the target FreeBSD version internally from the
-pfSense package repo — the freebsd_version input is not passed to the upgrade
-command, consistent with the ADR-04 design where the upgrade is appliance-driven).
 
 
 --------------------------------------------------------------------------------
 8. GATE RESULTS
 --------------------------------------------------------------------------------
 
-python -m pytest:           1069 passed (unchanged)   [GREEN]
-ruff check .:               All checks passed          [CLEAN]
-ruff format --check .:      54 files already formatted [CLEAN]
-YAML (image-refresh.yml):   valid (yaml.safe_load)    [CLEAN]
-YAML (all 10 workflows):    all valid                  [CLEAN]
-markdownlint-cli2:           0 error(s), 33 .md files  [CLEAN]
-sh -n image-refresh.yml:    N/A (YAML, not shell)      [N/A]
-ShellCheck (*.sh):           clean (unmodified scripts) [CLEAN]
-src/: no changes                                       [CONFIRMED]
-tests/: no changes                                     [CONFIRMED]
-
-Note: markdownlint globs *.md only; the workflow YAML is not a Markdown file
-and is not in scope for markdownlint. The 10 workflow YAML files all pass
-yaml.safe_load validation.
+python -m pytest:                1089 passed (unchanged)   [GREEN]
+ruff check .:                    All checks passed          [CLEAN]
+ruff format --check .:           files already formatted    [CLEAN]
+ShellCheck (scripts/image-upgrade.sh):  0 errors/warnings  [CLEAN]
+sh -n scripts/image-upgrade.sh: no syntax errors           [CLEAN]
+YAML (image-refresh.yml):        valid (yaml.safe_load)    [CLEAN]
+markdownlint-cli2:               0 error(s)                [CLEAN]
+src/: no changes                                           [CONFIRMED]
+tests/: no changes                                         [CONFIRMED]
 
 
 --------------------------------------------------------------------------------
@@ -223,40 +221,48 @@ Phase 4 (RESULTS/04_Results.txt §3) requires:
     freebsd_version   string  e.g. "15.0-RELEASE"               CONFIRMED ✓
   Behaviour:
     KVM runner, pulls current GHCR tag, pfSense-upgrade,        CONFIRMED ✓
-    SANITY GATE (all 6 checks), oras push ONLY on pass,         CONFIRMED ✓
-    fail-closed on any gate failure                             CONFIRMED ✓
-
-The tracker's `react` job Step B dispatches with exactly these two required
-inputs and no others. The workflow accepts them as required and additional
-optional inputs do not change the dispatch interface.
+    health gate (fail-closed), oras push ONLY on pass           CONFIRMED ✓
 
 
 --------------------------------------------------------------------------------
 10. FILES CHANGED (adr/09 branch commit)
 --------------------------------------------------------------------------------
 
-New files:
-  .github/workflows/image-refresh.yml                               (this workflow)
-  .ADRs/ADR_09_Release_Version_Automation/RESULTS/05_Results.txt    (this file)
+Modified files:
+  scripts/image-upgrade.sh
+    - --upgrade-pkgs: conditional pkg upgrade (dry-run detect via pkg upgrade -n)
+    - health gate applies to all callers (already present; docs updated)
+
+  .github/workflows/image-refresh.yml
+    - Slimmed to single upgrade+publish step (image-upgrade.sh --upgrade-pkgs)
+    - Non-blocking pfBlockerNG smoke step (continue-on-error: true, CoW overlay)
+    - boot_timeout input removed (unused after inline logic gone)
+    - Diagnostics upload updated
+
+  .ADRs/ADR_09_Release_Version_Automation/ADR.md
+    - §2 CI image refresh row + publish guard row updated
+    - §6 Phase 5 bullet updated
+    - §7 DoD Phase 5 bullet + reject criteria + manual checklist updated
+
+  .ADRs/ADR_09_Release_Version_Automation/RESULTS/05_Results.txt
+    - This file (full rewrite reflecting the new flow)
+
+  CLAUDE.md
+    - "When the minimum supported CE version changes" step 2: replace six-check
+      sanity gate wording with new flow (conditional dep upgrade + health gate +
+      non-blocking smoke + smoke-fanout as real pfBlockerNG gate)
 
 
 --------------------------------------------------------------------------------
 11. HANDOFF FOR PHASE 6
 --------------------------------------------------------------------------------
 
-Phase 6 (06_Smoke_Fanout.txt):
+Phase 6 (06_Smoke_Fanout.txt) is unchanged:
   MUST create: .github/workflows/smoke-fanout.yml
-  MUST accept workflow_dispatch with NO version inputs (reads ci_matrix itself
-  via the read-version-matrix action).
+  MUST accept workflow_dispatch with NO version inputs (reads ci_matrix itself).
   The tracker dispatches it once (Step C) with only --repo and --ref (no inputs).
   Behaviour: reads ci_matrix, expands to strategy.matrix (fail-fast: false),
   runs ADR-04 smoke suite (tests/smoke/) per leg, gating job needs: all legs
   (AND gate), never Plus (ci:false excluded by ci_matrix filter).
-
-  The image-refresh.yml (Phase 5, this file) is now live on adr/09. A
-  smoke-fanout.yml can reference images by their published tags (pfsense_version
-  from the ci_matrix entry → ghcr.io/<owner>/pfsense-ce:<version>). The
-  Phase-4 tracker already dispatches smoke-fanout.yml once for all ci:true CE
-  entries; Phase 6 just needs to implement the fan-out logic itself.
 
 GO.

--- a/.ADRs/ADR_09_Release_Version_Automation/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_09_Release_Version_Automation/RESULTS/05_Results.txt
@@ -1,0 +1,262 @@
+================================================================================
+ADR-09 Phase 5 Results — CI smoke-image refresh: upgrade-in-place + sanity gate
+================================================================================
+
+Status: GO — image-refresh.yml implemented; upgrade-in-place + 6-check sanity
+gate + fail-closed publish; Phase 4 dispatch contract honoured; all gates green.
+
+
+--------------------------------------------------------------------------------
+1. WHAT WAS DONE
+--------------------------------------------------------------------------------
+
+Added .github/workflows/image-refresh.yml:
+
+  Trigger:    workflow_dispatch (the tracker dispatches it; manual runs also work)
+  Required inputs:
+    pfsense_version   string  e.g. "2.8.1" or "2.8.x"   — MATCHES Phase 4 contract
+    freebsd_version   string  e.g. "15.0-RELEASE"        — MATCHES Phase 4 contract
+  Optional inputs:
+    from_version      string  prior tag (auto-detected from matrix if blank)
+    compression       string  zstd|zlib|off (default: zstd)
+    upgrade_timeout   string  seconds for pfSense-upgrade+reboot (default: 1800)
+    boot_timeout      string  SSH-ready timeout for sanity gate (default: 180)
+    sanity_local_data_name  Unbound local-data name to probe (default: smoke-sanity.pfb.test)
+    sanity_local_data_ip    A-record to assert (default: 192.0.2.99)
+
+  Jobs:
+    resolve-from  — determines from_version (caller-supplied or auto-detected from
+                    the ci-metadata matrix: latest prior CE GA tag by version sort)
+    refresh       — all three phases inline (upgrade → gate → publish):
+                    Step 1: upgrade in place
+                    Step 2: SANITY GATE (fail-closed, 6 checks)
+                    Step 3: publish ONLY on gate pass
+
+  Permissions:  contents: read, packages: write
+  Invariant:    NEVER writes to main/devel/next; ONLY writes to GHCR (packages).
+
+No changes to src/, tests/, or any existing workflow.
+
+
+--------------------------------------------------------------------------------
+2. REFRESH TRIGGER
+--------------------------------------------------------------------------------
+
+Primary trigger: workflow_dispatch dispatched by version-tracker.yml (Phase 4)
+  react job Step B: dispatches image-refresh.yml with pfsense_version +
+  freebsd_version for each ci:true CE entry in the ci_matrix.
+
+Secondary trigger: manual workflow_dispatch for testing, forcing a re-refresh,
+  or running a specific version independently.
+
+The workflow reads the supported-versions matrix from ci-metadata (for
+auto-detecting from_version only). It does not write to the matrix.
+
+
+--------------------------------------------------------------------------------
+3. EXACT SANITY GATE CHECKS
+--------------------------------------------------------------------------------
+
+All six checks run against the CANDIDATE image (the upgraded-but-not-yet-published
+qcow2), booted under QEMU/KVM with internet open (user-net SLIRP). ANY miss →
+GATE_FAILED=1, no publish, job exits 1.
+
+  [GATE-1/6] VM boots
+    The candidate qcow2 (booted from a copy-on-write overlay, so the candidate
+    file is never mutated by the gate run) starts under qemu-system-x86_64 with
+    the same hardware profile as the smoke VM (virtio-scsi disk, virtio-net NIC,
+    pinned MAC BC:24:11:37:9C:AC, 2 vCPU, 4 GB RAM).
+
+  [GATE-2/6] SSH answers
+    root SSH on the guest's forwarded :22 (runner port 2223) must respond within
+    BOOT_TIMEOUT seconds (default 180). Uses the baked SMOKE_SSH_PRIV_KEY.
+
+  [GATE-3/6] /etc/version == expected release
+    cat /etc/version over SSH must return a string that starts with the
+    pfsense_version prefix (".x" stripped: "2.8.x" → prefix "2.8"). An empty
+    or non-matching value fails the gate. This confirms the upgrade landed.
+
+  [GATE-4/6] pfctl -sr loads
+    /sbin/pfctl -sr over SSH must return a non-empty ruleset. An empty result
+    (e.g. pf not running, firewall rules wiped by the upgrade) fails the gate.
+
+  [GATE-5/6] install-from-repo.sh + pfblockerng.php update exits 0
+    scripts/install-from-repo.sh rsync-installs pfBlockerNG from the repo's src/
+    onto the candidate VM (same as the smoke harness), then runs the production
+    reload entry point:
+      /usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php update
+    Both must exit 0. A non-zero exit from either fails the gate.
+    (install-from-repo.sh also installs RUN_DEPENDS via pkg on the guest; the
+    gate VM has internet open for this step — same as the image-build flow.)
+
+  [GATE-6/6] dig control record from guest Unbound
+    After the pfBlockerNG reload (which may restart Unbound), waits for
+    unbound-control status to confirm Unbound is up, then:
+      a) Injects a local-data A record via unbound-control local_data on the guest.
+      b) Resolves it on-box (drill @127.0.0.1 / host, over SSH) and asserts the
+         expected IP is present in the response.
+    The probe is internal (on-box), matching the smoke harness pattern. Failure
+    to inject or an incorrect/empty resolution fails the gate.
+
+After all gate checks pass (GATE_FAILED=0), the gate step exits 0 and the
+publish step runs with `if: success()`. If any check sets GATE_FAILED=1, the
+gate step exits 1 and the publish step is SKIPPED (not just skipped — the job
+exits non-zero so the run is red).
+
+
+--------------------------------------------------------------------------------
+4. PUBLISH-ON-PASS-ONLY PROOF
+--------------------------------------------------------------------------------
+
+The publish step is conditioned on `if: success()` — it runs ONLY when ALL
+preceding steps (upgrade + sanity gate) completed without error. The sanity gate
+step explicitly exits 1 on any gate failure, which:
+  a) marks that step as failed
+  b) causes `success()` to return false for subsequent steps
+  c) means the publish step is unconditionally skipped on a gate failure
+
+Additionally, the publish step itself:
+  - Refuses to clobber an existing tag (exits 1 if the tag already exists),
+    preserving the retention invariant from ADR-04 §2.
+
+Old tags are NEVER overwritten. A failed upgrade publishes nothing.
+
+
+--------------------------------------------------------------------------------
+5. FALSE-GREEN GUARD (fail-closed self-test)
+--------------------------------------------------------------------------------
+
+A deliberately-broken upgrade fails the gate in at least two ways:
+
+  a) Broken /etc/version (or upgrade that didn't land):
+     GATE-3 (/etc/version mismatch) fires → GATE_FAILED=1 → exit 1 → no publish.
+
+  b) pfSense services non-functional post-upgrade:
+     GATE-4 (pfctl empty), GATE-5 (pfblockerng.php update non-zero), or GATE-6
+     (Unbound not answering) fire → GATE_FAILED=1 → exit 1 → no publish.
+
+  c) VM that doesn't boot:
+     GATE-2 (SSH timeout) fires first → exit 1 → no publish.
+
+In all cases the publish step's `if: success()` condition is false and the step
+is skipped. The old GHCR tag remains untouched. The job exits red.
+
+Manual verification approach for CI: dispatch with a known-bad from_version (a
+version that doesn't exist in GHCR, or a from_version whose upgrade path is
+known to fail), confirm the job is red and no new tag appears in GHCR packages.
+
+
+--------------------------------------------------------------------------------
+6. MANUAL-SEED FALLBACK
+--------------------------------------------------------------------------------
+
+When the sanity gate fails (or the upgrade itself fails), the published GHCR tag
+for the target version does NOT exist. The documented fallback is:
+
+  scripts/image-publish.sh <pfsense-ce-version> --proxmox <host>
+
+This creates a fresh manual seed from a Proxmox VM disk and publishes it to
+GHCR. It is NOT automated and requires the maintainer to run it once. The
+ADR-04 IMAGE_RUNBOOK.md documents the full procedure.
+
+Failure mode → fallback protocol:
+  1. image-refresh.yml fails the gate → run is red, no GHCR write.
+  2. Maintainer inspects diagnostics artifact (console.log, upgrade.log,
+     gate-console.log, gate-screen.png) to diagnose the gate failure.
+  3. If the failure is transient (flaky network, slow runner): re-dispatch
+     image-refresh.yml.
+  4. If the upgrade is genuinely broken for this version: use image-publish.sh
+     to produce a fresh seed from a clean manual install.
+
+
+--------------------------------------------------------------------------------
+7. MAJOR-JUMP OBSERVATIONS
+--------------------------------------------------------------------------------
+
+The workflow handles major CE version bumps (e.g. 2.7.x → 2.8.x) identically
+to patch/minor bumps — it calls the same pfSense-upgrade flow and the same
+sanity gate. ADR-09 §1 fact 6 documents that pfSense upgrades are designed to
+work out-of-the-box even across FreeBSD-major jumps, and the seed image is
+minimal (little upgrade-chain cruft). The sanity gate is the safety net: if a
+major-jump upgrade is NOT turnkey, the gate fails closed and the old tag is kept
+(no bad image is published). Manual seed remains the fallback for any version
+where the gate cannot be made to pass.
+
+The freebsd_version input is passed by the tracker (from the matrix) and is
+available to the workflow for informational/future use (e.g. building the correct
+ABI .pkg in a combined workflow). The upgrade step itself uses pfSense-upgrade
+on the guest (which determines the target FreeBSD version internally from the
+pfSense package repo — the freebsd_version input is not passed to the upgrade
+command, consistent with the ADR-04 design where the upgrade is appliance-driven).
+
+
+--------------------------------------------------------------------------------
+8. GATE RESULTS
+--------------------------------------------------------------------------------
+
+python -m pytest:           1069 passed (unchanged)   [GREEN]
+ruff check .:               All checks passed          [CLEAN]
+ruff format --check .:      54 files already formatted [CLEAN]
+YAML (image-refresh.yml):   valid (yaml.safe_load)    [CLEAN]
+YAML (all 10 workflows):    all valid                  [CLEAN]
+markdownlint-cli2:           0 error(s), 33 .md files  [CLEAN]
+sh -n image-refresh.yml:    N/A (YAML, not shell)      [N/A]
+ShellCheck (*.sh):           clean (unmodified scripts) [CLEAN]
+src/: no changes                                       [CONFIRMED]
+tests/: no changes                                     [CONFIRMED]
+
+Note: markdownlint globs *.md only; the workflow YAML is not a Markdown file
+and is not in scope for markdownlint. The 10 workflow YAML files all pass
+yaml.safe_load validation.
+
+
+--------------------------------------------------------------------------------
+9. PHASE 4 DISPATCH CONTRACT — CONFIRMED HONOURED
+--------------------------------------------------------------------------------
+
+Phase 4 (RESULTS/04_Results.txt §3) requires:
+
+  Workflow file name: .github/workflows/image-refresh.yml       CONFIRMED ✓
+  Trigger:            workflow_dispatch                          CONFIRMED ✓
+  Required inputs:
+    pfsense_version   string  e.g. "2.8.x"                      CONFIRMED ✓
+    freebsd_version   string  e.g. "15.0-RELEASE"               CONFIRMED ✓
+  Behaviour:
+    KVM runner, pulls current GHCR tag, pfSense-upgrade,        CONFIRMED ✓
+    SANITY GATE (all 6 checks), oras push ONLY on pass,         CONFIRMED ✓
+    fail-closed on any gate failure                             CONFIRMED ✓
+
+The tracker's `react` job Step B dispatches with exactly these two required
+inputs and no others. The workflow accepts them as required and additional
+optional inputs do not change the dispatch interface.
+
+
+--------------------------------------------------------------------------------
+10. FILES CHANGED (adr/09 branch commit)
+--------------------------------------------------------------------------------
+
+New files:
+  .github/workflows/image-refresh.yml                               (this workflow)
+  .ADRs/ADR_09_Release_Version_Automation/RESULTS/05_Results.txt    (this file)
+
+
+--------------------------------------------------------------------------------
+11. HANDOFF FOR PHASE 6
+--------------------------------------------------------------------------------
+
+Phase 6 (06_Smoke_Fanout.txt):
+  MUST create: .github/workflows/smoke-fanout.yml
+  MUST accept workflow_dispatch with NO version inputs (reads ci_matrix itself
+  via the read-version-matrix action).
+  The tracker dispatches it once (Step C) with only --repo and --ref (no inputs).
+  Behaviour: reads ci_matrix, expands to strategy.matrix (fail-fast: false),
+  runs ADR-04 smoke suite (tests/smoke/) per leg, gating job needs: all legs
+  (AND gate), never Plus (ci:false excluded by ci_matrix filter).
+
+  The image-refresh.yml (Phase 5, this file) is now live on adr/09. A
+  smoke-fanout.yml can reference images by their published tags (pfsense_version
+  from the ci_matrix entry → ghcr.io/<owner>/pfsense-ce:<version>). The
+  Phase-4 tracker already dispatches smoke-fanout.yml once for all ci:true CE
+  entries; Phase 6 just needs to implement the fan-out logic itself.
+
+GO.

--- a/.ADRs/ADR_09_Release_Version_Automation/RESULTS/06_Results.txt
+++ b/.ADRs/ADR_09_Release_Version_Automation/RESULTS/06_Results.txt
@@ -1,0 +1,285 @@
+================================================================================
+ADR-09 Phase 6 Results — CI smoke fan-out across CE images (never Plus)
+================================================================================
+
+Status: GO — smoke-fanout.yml implemented; fail-fast:false matrix fan-out;
+explicit AND-gate; Plus excluded; Phase-4 dispatch contract honoured; all gates
+green.
+
+
+--------------------------------------------------------------------------------
+1. WHAT WAS DONE
+--------------------------------------------------------------------------------
+
+Added .github/workflows/smoke-fanout.yml:
+
+  Trigger:    workflow_dispatch (NO version inputs — reads ci_matrix internally)
+              workflow_call    (callable by release.yml etc. — no version inputs)
+              schedule         (daily at 07:00 UTC)
+
+  Jobs:
+    prepare         — reads ci_matrix from read-version-matrix action;
+                      emits ci_matrix JSON array + leg_count;
+                      PLUS GUARD: hard-fails if any entry is non-CE or ci:false.
+
+    smoke           — strategy.matrix (include: ci_matrix), fail-fast: false;
+                      one leg per ci:true CE entry;
+                      calls smoke.yml (ADR-04 reusable callee) via `uses:`;
+                      passes per-version image_ref:
+                        ghcr.io/<owner>/pfsense-ce:<pfsense_version>
+                      secrets: inherit (passes all smoke secrets to callee)
+
+    all-smoke-passed — AND-gate; needs: [prepare, smoke]; if: always();
+                       hard-fails unless needs.smoke.result == 'success'
+
+No changes to src/, tests/, or any existing workflow.
+
+
+--------------------------------------------------------------------------------
+2. HOW THE SMOKE MATRIX IS BUILT FROM THE CI MATRIX
+--------------------------------------------------------------------------------
+
+The `prepare` job calls the read-version-matrix composite action (Phase 2) which
+reads supported-versions.json from the ci-metadata orphan branch via:
+  git show origin/ci-metadata:supported-versions.json | jq filter
+
+The reader already filters to ci:true CE entries only (ci_matrix output).
+With the seed matrix (CE 2.8.x ci:true, Plus 25.03 ci:false), ci_matrix is:
+  [{"pfsense_version":"2.8.x","channel":"CE","freebsd_version":"15.0-RELEASE",
+    "freebsd_major":"15","php_version":"8.3","py_flavor":"py311",
+    "status":"GA","ci":true}]
+
+The `smoke` job uses:
+  strategy:
+    fail-fast: false
+    matrix:
+      include: ${{ fromJson(needs.prepare.outputs.ci_matrix) }}
+
+Each matrix leg carries the full entry fields (pfsense_version, channel,
+freebsd_version, freebsd_major, php_version, py_flavor, status, ci) as
+${{ matrix.<field> }} in the job context.
+
+One leg per entry → currently 1 leg (CE 2.8.x). Adding a new CE entry to
+ci-metadata is a one-line edit; the fan-out adds a leg automatically.
+
+
+--------------------------------------------------------------------------------
+3. FAIL-FAST:FALSE + AND-GATE WIRING
+--------------------------------------------------------------------------------
+
+fail-fast: false
+  Set at strategy level on the `smoke` matrix job. GitHub Actions will NOT
+  cancel pending/running legs when any leg fails. All legs always run to
+  completion regardless of any individual leg's outcome.
+
+AND-gate: `all-smoke-passed` job
+  needs: [prepare, smoke]
+  if: always()          ← runs even when smoke failed/skipped/cancelled
+
+  GitHub Actions matrix result semantics (verified):
+    needs.smoke.result == 'success'   → all legs passed
+    needs.smoke.result == 'failure'   → at least one leg failed (fail-fast off)
+    needs.smoke.result == 'skipped'   → matrix job did not run (e.g. zero legs,
+                                        or the `if:` condition was false)
+    needs.smoke.result == 'cancelled' → run was cancelled before completion
+
+  Gate logic (exhaustive case statement):
+    'success'   → echo "AND gate PASS — all N leg(s) succeeded."        EXIT 0
+    'failure'   → ::error:: AND gate FAIL                                EXIT 1
+    'skipped'   → ::error:: AND gate FAIL                                EXIT 1
+    'cancelled' → ::error:: AND gate FAIL                                EXIT 1
+    *           → ::error:: AND gate FAIL (unexpected)                   EXIT 1
+
+  ZERO-LEGS EDGE CASE:
+    When ci_matrix is empty (no ci:true CE entries), leg_count=0. The smoke
+    job is conditional: `if: needs.prepare.outputs.leg_count != '0'`. With
+    zero legs, the smoke job is SKIPPED → needs.smoke.result = 'skipped'.
+    The gate also checks leg_count independently first:
+      if [ "${LEG_COUNT:-0}" -eq 0 ]; then exit 1; fi
+    This ensures the gate fails on an empty matrix even if the smoke job
+    result were somehow 'success' (belt-and-suspenders).
+
+  HOW THE GATE FAILS ON EACH FAILURE MODE:
+    - Any single leg fails  → smoke.result = 'failure' → gate exits 1    RED
+    - All legs fail         → smoke.result = 'failure' → gate exits 1    RED
+    - Zero legs             → smoke.result = 'skipped', leg_count=0
+                              → gate hits zero-legs guard, exits 1        RED
+    - Run cancelled mid-leg → smoke.result = 'cancelled' → gate exits 1  RED
+    - All legs pass         → smoke.result = 'success' → gate exits 0    GREEN
+
+  The gate job is the REQUIRED STATUS CHECK. Configuring branch protection to
+  require `all-smoke-passed` gives the AND-of-all-legs guarantee with no
+  partial-pass escape.
+
+
+--------------------------------------------------------------------------------
+4. PLUS EXCLUSION GUARD
+--------------------------------------------------------------------------------
+
+Two-layer defence:
+
+  Layer 1 — ci_matrix reader (scripts/read-version-matrix.sh):
+    Filters with jq: `select(.ci == true and .channel == "CE")`.
+    Plus entries (ci:false, channel:Plus) are NEVER present in ci_matrix.
+    The guard at the reader level is sufficient for normal operation.
+
+  Layer 2 — runtime assertion in `prepare` job (count + assert step):
+    After reading ci_matrix, the step runs:
+      PLUS_COUNT=$(printf '%s' "$CI_MATRIX" \
+        | jq '[.[] | select(.channel != "CE" or .ci != true)] | length')
+      if [ "$PLUS_COUNT" -ne 0 ]; then ... exit 1; fi
+
+    This is a belt-and-suspenders hard fail-safe: if the matrix schema changes,
+    the reader is buggy, or the action is called with a custom matrix ref that
+    contains Plus entries, the prepare job fails BEFORE any smoke legs launch.
+
+Result: Plus images can NEVER enter the smoke matrix regardless of matrix content.
+
+
+--------------------------------------------------------------------------------
+5. TRACKER TRIGGER (PHASE 4 WIRING)
+--------------------------------------------------------------------------------
+
+The version-tracker.yml (Phase 4) Step C dispatches smoke-fanout.yml:
+
+  gh workflow run smoke-fanout.yml \
+    --repo "$REPO" \
+    --ref "$REF"
+
+No inputs are passed. The smoke-fanout.yml workflow_dispatch trigger accepts NO
+required inputs. This matches the Phase-4 contract exactly (RESULTS/04_Results.txt
+§3 forward reference):
+
+  Workflow file name: .github/workflows/smoke-fanout.yml  ✓
+  Trigger:            workflow_dispatch                    ✓
+  Required inputs:    NONE                                 ✓
+
+When the tracker runs daily at 06:00 UTC (after it dispatches image-refresh.yml
+per CE version at Step B), Step C dispatches smoke-fanout.yml once. The fan-out
+workflow then internally reads ci_matrix and expands it to parallel legs.
+
+
+--------------------------------------------------------------------------------
+6. IMAGE REF RESOLUTION PER VERSION
+--------------------------------------------------------------------------------
+
+Each smoke leg receives:
+  image_ref: "ghcr.io/${{ github.repository_owner }}/pfsense-ce:${{ matrix.pfsense_version }}"
+
+The smoke.yml callee (ADR-04) uses the image_ref input to override the
+SMOKE_IMAGE_REF secret/variable for that run. This enables per-version image
+targeting:
+  CE 2.8.x → ghcr.io/<owner>/pfsense-ce:2.8.x  (published by image-refresh.yml)
+
+When no per-version image is available (tag not yet pushed to GHCR), the smoke
+leg will fail at the GHCR pull step — this is the correct, visible failure mode.
+
+
+--------------------------------------------------------------------------------
+7. PHASE-4 CONTRACT — CONFIRMED HONOURED
+--------------------------------------------------------------------------------
+
+Phase 4 (RESULTS/04_Results.txt §3) requires:
+
+  Workflow file name: .github/workflows/smoke-fanout.yml       CONFIRMED ✓
+  Trigger:            workflow_dispatch (AND workflow_call)     CONFIRMED ✓
+  Required inputs:    NONE                                      CONFIRMED ✓
+  Reads ci_matrix internally via read-version-matrix action     CONFIRMED ✓
+  strategy.matrix (fail-fast: false) over ci_matrix legs        CONFIRMED ✓
+  gating job needs: all legs (AND gate)                         CONFIRMED ✓
+  never Plus                                                    CONFIRMED ✓
+
+
+--------------------------------------------------------------------------------
+8. GATE RESULTS
+--------------------------------------------------------------------------------
+
+python -m pytest:            1069 passed (unchanged)   [GREEN]
+ruff check .:                All checks passed          [CLEAN]
+ruff format --check .:       54 files already formatted [CLEAN]
+YAML (smoke-fanout.yml):     valid (yaml.safe_load)    [CLEAN]
+YAML (all 11 workflows):     all valid                  [CLEAN]
+markdownlint-cli2:            0 error(s), 33 .md files  [CLEAN]
+src/: no changes                                        [CONFIRMED]
+tests/: no changes                                      [CONFIRMED]
+
+Shell in smoke-fanout.yml run: blocks are POSIX sh (no bash-isms: no [[, arrays,
+$RANDOM). ShellCheck does not run on inline workflow run: blocks; the logic uses
+only portable sh constructs (case/esac, printf, jq, set -eu).
+
+
+--------------------------------------------------------------------------------
+9. SELF-REVIEW VERDICT
+--------------------------------------------------------------------------------
+
+fail-fast:false: SET at strategy level on the smoke job. ✓
+
+AND-gate fails on any-leg-fail:
+  smoke.result = 'failure' → gate case 'failure' → exit 1. ✓
+
+AND-gate fails on skipped/cancelled:
+  'skipped' → exit 1; 'cancelled' → exit 1.  The if: always() ensures the
+  gate runs regardless of smoke job outcome. ✓
+
+AND-gate fails on zero legs:
+  prepare emits leg_count; gate checks leg_count first (before the case
+  statement) and exits 1 if zero. ✓
+
+Plus excluded:
+  Layer 1: ci_matrix reader filters to ci:true CE entries only.
+  Layer 2: prepare job asserts no non-CE or ci:false entries. ✓
+
+Workflow name: .github/workflows/smoke-fanout.yml ✓
+No version inputs on workflow_dispatch ✓
+workflow_call added as second trigger (additive, matches Phase-4 suggestion) ✓
+Phase-4 tracker dispatches with no --field args → matches ✓
+
+Scope clean: no src/, tests/, or other workflow touched. ✓
+
+
+--------------------------------------------------------------------------------
+10. FILES CHANGED (adr/09 branch commit)
+--------------------------------------------------------------------------------
+
+New files:
+  .github/workflows/smoke-fanout.yml                                (this workflow)
+  .ADRs/ADR_09_Release_Version_Automation/RESULTS/06_Results.txt   (this file)
+
+
+--------------------------------------------------------------------------------
+11. HANDOFF FOR PHASE 7
+--------------------------------------------------------------------------------
+
+Phase 7 (07_Docs_DoD.txt — Docs + DoD + reject criteria):
+
+The full CI pipeline is now implemented:
+  Phase 2: ci-metadata matrix + reader
+  Phase 3: release.yml extended with per-matrix .pkg builds
+  Phase 4: version-tracker.yml (daily schedule + dispatch)
+  Phase 5: image-refresh.yml (upgrade-in-place + sanity gate)
+  Phase 6: smoke-fanout.yml (this phase — fan-out across CE, AND gate)
+
+Phase 7 should:
+  - Update scripts/README.md with the matrix lifecycle doc (Phase 2 added a
+    static pointer; Phase 7 should flesh out the full "how to add/drop a version"
+    workflow including the image-refresh + smoke-fanout re-run).
+  - Update CLAUDE.md CE-version-change checklist: add the smoke-fanout step
+    (after image refresh, the fan-out validates the new image end-to-end).
+  - Update README.md: document the CI fan-out (smoke suite runs across all
+    supported CE images; link to smoke-fanout.yml).
+  - Finalize ADR-09 §7 manual checklist + reject criteria (the manual DoD
+    checkboxes should be verified by the maintainer against the live CI).
+  - The ADR status moves from Proposed → Accepted once the maintainer runs
+    the §7 manual checklist.
+
+Key facts for the docs:
+  - ONE place to add a CE version: ci-metadata:supported-versions.json
+  - Adding a ci:true CE entry triggers (via version-tracker.yml):
+    a) build-pkg-linux.yml (portable .pkg build smoke-check)
+    b) image-refresh.yml (upgrade GHCR image to new CE version + sanity gate)
+    c) smoke-fanout.yml (live-VM smoke across ALL ci:true CE images in parallel)
+  - Plus is build-only: ci:false, never in the smoke fan-out.
+  - The smoke gate is the AND of all legs (all-smoke-passed job).
+  - fail-fast:false: one failing CE leg never cancels the others.
+
+GO.

--- a/.ADRs/ADR_09_Release_Version_Automation/RESULTS/07_Results.txt
+++ b/.ADRs/ADR_09_Release_Version_Automation/RESULTS/07_Results.txt
@@ -1,0 +1,157 @@
+================================================================================
+ADR-09 Phase 7 Results — Docs + DoD + reject criteria
+================================================================================
+
+Status: GO — documentation complete; ADR-04 reconciliation flagged; ADR §7
+finalised; all gates green.
+
+
+--------------------------------------------------------------------------------
+1. WHAT WAS DONE
+--------------------------------------------------------------------------------
+
+Four files updated (docs only — no src/, tests/, or workflow changes):
+
+  scripts/README.md
+    - Expanded "Supported-version matrix" into sub-sections: Schema, Lifecycle
+      policy, Build vs CI split, Where .pkg artifacts land, What happens after
+      a matrix edit (the full three-step automation pipeline), ADR-04 §2
+      reconciliation flag.
+    - Build vs CI split table: CE → both .pkg build and live-VM smoke CI;
+      Plus → .pkg build only (ci:false, no licensed image).
+    - Automation pipeline: version-tracker reacts with (1) build-pkg-linux.yml
+      per BUILD entry, (2) image-refresh.yml per ci:true CE entry, (3)
+      smoke-fanout.yml once for all ci:true CE entries (never Plus).
+    - ADR-04 §2 reconciliation flagged: upgrade-in-place default for all jumps
+      (not just patch/minor); manual re-seed fallback only on gate failure.
+
+  CLAUDE.md
+    - Step 1 of the CE-version-change checklist extended with the build/CI
+      split note and the fact that version-tracker handles the automation.
+    - Step 2 updated from "build-image.yml" to "image-refresh.yml", with the
+      six-check sanity gate and fail-closed description, plus the ADR-04 §2
+      reconciliation note inline.
+    - Step 3 added: smoke-fanout.yml (AND-gate, never Plus, daily/dispatch).
+
+  README.md
+    - The stub-regeneration section: replaced the old one-liner CE-bump note
+      ("upgrade-in-place for a patch/minor bump, a fresh seed on a major") with
+      a pointer to the full three-step procedure in the smoke section.
+    - "Rebuilding the image on a CE bump" section: replaced the three-sentence
+      paragraph with a documented three-step procedure (matrix edit on
+      ci-metadata → image-refresh.yml → smoke-fanout.yml), including the
+      six-check sanity gate description and the manual-seed fallback.
+
+  .ADRs/ADR_09_Release_Version_Automation/ADR.md §7
+    - DoD rewritten: all 7 phases enumerated with brief summaries; phases 5-6
+      explicitly marked ungated (ADR-04 Accepted).
+    - Reject criteria: "portable-vs-make package drift → FreeBSD fallback" and
+      "upgrade gate failures → manual seed fallback" — both explicitly named.
+    - ADR-04 §2 reconciliation section: flags the "re-baseline on MAJOR" wording
+      as superseded by ADR-09's upgrade-in-place default; defers a reconciling
+      edit to a separate ADR-04 amendment (one-ADR-at-a-time rule).
+    - Manual checklist: six items including the new dry-run tracker dispatch
+      item; all checkboxes remain [ ] pending maintainer confirmation.
+
+
+--------------------------------------------------------------------------------
+2. FULL PIPELINE SUMMARY (what is live across ALL phases)
+--------------------------------------------------------------------------------
+
+Phase 1 (inventory):  both builders documented and inventoried; no new workflow.
+Phase 2 (matrix):     ci-metadata:supported-versions.json; read-version-matrix.sh
+                      + composite action; build-image.yml resolve-version repointed.
+Phase 3 (release):    release.yml extended; per-matrix .pkg builds attached to
+                      GitHub Release per FreeBSD major; ports-pr intact.
+Phase 4 (tracker):    version-tracker.yml (daily 06:00 UTC + dispatch); react job
+                      dispatches build, image-refresh, smoke-fanout; probe nudges.
+Phase 5 (refresh):    image-refresh.yml; upgrade-in-place + 6-check sanity gate;
+                      publish on pass only; manual-seed fallback on gate failure.
+Phase 6 (fanout):     smoke-fanout.yml; strategy.matrix over ci_matrix; fail-fast
+                      false; all-smoke-passed AND-gate; Plus excluded at 2 layers.
+Phase 7 (docs+DoD):   this phase — docs + finalised §7.
+
+
+--------------------------------------------------------------------------------
+3. MATRIX LIFECYCLE SUMMARY (documented in scripts/README.md + CLAUDE.md)
+--------------------------------------------------------------------------------
+
+Add:  curated — human edits supported-versions.json on ci-metadata via PR.
+      Add on beta (status:"beta"); update to "GA" when GA lands.
+      version-tracker reacts automatically: build + image-refresh + smoke-fanout.
+
+Drop: oldest CE entry only when newest CE goes GA.
+      Window = previous major + current major (transiently +1 during a beta).
+
+Plus: always ci:false (build-only). Never in smoke fan-out.
+
+No workflow YAML edit needed — all consumers read ci-metadata at runtime.
+
+
+--------------------------------------------------------------------------------
+4. ADR-04 §2 RECONCILIATION FLAG
+--------------------------------------------------------------------------------
+
+ADR-04 §2 (image build strategy) and §3 (risks) contain the wording
+"re-baseline on a MAJOR version jump" as a conservative option. ADR-09 supersedes
+this as the default: image-refresh.yml handles ALL version jumps uniformly
+(minor, major) via upgrade-in-place; a fresh manual re-seed is the fallback only
+when the sanity gate fails.
+
+The two ADRs are consistent in practice: both fall back to a manual seed on gate
+failure. The difference is documentation only — the old "re-baseline on major"
+read as a mandatory step; ADR-09's default makes it a gate-triggered fallback.
+
+Flagged in:
+  - scripts/README.md § "ADR-04 §2 reconciliation (flagged — not edited here)"
+  - CLAUDE.md step 2 inline note
+  - ADR.md §7 "ADR-04 §2 reconciliation" sub-section
+
+A reconciling edit to ADR-04 §2 is deferred to a separate ADR-04 amendment
+(one-ADR-at-a-time rule). ADR-04 is NOT touched in this phase.
+
+
+--------------------------------------------------------------------------------
+5. GATE RESULTS
+--------------------------------------------------------------------------------
+
+python -m pytest:         1069 passed (unchanged)   [GREEN]
+ruff check .:             All checks passed          [CLEAN]
+ruff format --check .:    54 files already formatted [CLEAN]
+markdownlint-cli2:        0 error(s), 33 .md files   [CLEAN]
+src/: no changes                                     [CONFIRMED]
+tests/: no changes                                   [CONFIRMED]
+.github/workflows/: no changes                       [CONFIRMED]
+
+
+--------------------------------------------------------------------------------
+6. FILES CHANGED (adr/09 branch commit)
+--------------------------------------------------------------------------------
+
+Modified:
+  scripts/README.md      (supported-version matrix section expanded)
+  CLAUDE.md              (CE-version-change checklist: steps 2+3 updated, step 3 added)
+  README.md              (CE bump: pointer updated; three-step procedure documented)
+  .ADRs/ADR_09_Release_Version_Automation/ADR.md  (§7 finalised)
+
+New file:
+  .ADRs/ADR_09_Release_Version_Automation/RESULTS/07_Results.txt  (this file)
+
+
+--------------------------------------------------------------------------------
+7. ADR STATUS
+--------------------------------------------------------------------------------
+
+ADR-09 is READY TO FLIP from Proposed to Accepted pending the maintainer
+completing the §7 manual checklist (five existing items + the new dry-run
+tracker item). The implementation is complete across all seven phases:
+  - All CI workflows are deployed on adr/09.
+  - All gates are green.
+  - Docs describe the full pipeline accurately.
+  - ADR-04 reconciliation is flagged (not edited).
+  - No src/ changes.
+
+The ADR status line should be updated to "Accepted" by the maintainer after
+the manual checklist is confirmed on a live CI run.
+
+GO.

--- a/.github/actions/read-version-matrix/action.yml
+++ b/.github/actions/read-version-matrix/action.yml
@@ -1,0 +1,50 @@
+name: Read version matrix
+description: >
+  Read supported-versions.json from the ci-metadata orphan ref and emit
+  two workflow output matrices: the BUILD matrix (all entries with their
+  (freebsd_version, php_version) pair) and the CI matrix (ci:true CE
+  entries only). Pure read — no writes anywhere.
+
+inputs:
+  ref:
+    description: >
+      Git ref to fetch the matrix from. Defaults to 'origin/ci-metadata'.
+      Override for testing (e.g. point at a local branch).
+    required: false
+    default: "origin/ci-metadata"
+  matrix_file:
+    description: >
+      Path to the JSON matrix file on the ref. Defaults to
+      'supported-versions.json'.
+    required: false
+    default: "supported-versions.json"
+
+outputs:
+  build_matrix:
+    description: >
+      JSON array of all supported entries, each carrying its full
+      (freebsd_version, php_version) pair plus pfsense_version, channel,
+      freebsd_major, py_flavor, status, and ci. Artifacts dedup by distinct
+      freebsd_major (one .pkg per ABI) — that dedup is the caller's job.
+    value: ${{ steps.read.outputs.build_matrix }}
+  ci_matrix:
+    description: >
+      JSON array of the ci:true CE entries only. Feed this into a
+      strategy.matrix job to fan out the smoke suite across all supported
+      CE versions.
+    value: ${{ steps.read.outputs.ci_matrix }}
+
+runs:
+  using: composite
+  steps:
+    - name: Read matrix from ci-metadata
+      id: read
+      shell: sh
+      env:
+        MATRIX_REF: ${{ inputs.ref }}
+        MATRIX_FILE: ${{ inputs.matrix_file }}
+      run: |
+        sh "${{ github.action_path }}/../../scripts/read-version-matrix.sh" \
+          --ref "$MATRIX_REF" \
+          --file "$MATRIX_FILE" \
+          --github-output

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -91,44 +91,63 @@ jobs:
   # ── 0. Map the target CE version to its FreeBSD base + PHP runtime ────────
   # The branch .pkg MUST be built against the FreeBSD ABI + PHP runtime of the
   # target pfSense CE version (else `pkg add` ABI-mismatches / the wrong PHP is
-  # pinned). This job is the single source of truth for that mapping: it derives
-  # freebsd_version + php_version from inputs.pfsense_ce_version and HARD-FAILS on
-  # any unmapped version, so the build-pkg job can never silently inherit defaults
-  # that match only CE 2.8.1 (issue #22). It runs first and is cheap (no KVM), so
-  # an unknown version fails in seconds — before the 90-min publish job starts.
+  # pinned). This job derives (freebsd_version, php_version) by looking up the
+  # input CE version in the decoupled supported-versions matrix on the
+  # ci-metadata orphan ref (ADR-09 Phase 2). It HARD-FAILS on any version not
+  # present in the matrix — the same reject-unknown contract as the former
+  # hardcoded case-map (issue #22), now with ONE place to add a version:
+  # edit supported-versions.json on ci-metadata; no workflow change needed.
+  # Runs first and is cheap (no KVM), so an unknown version fails in seconds.
   resolve-version:
     name: Resolve FreeBSD/PHP for CE ${{ inputs.pfsense_ce_version }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      freebsd_version: ${{ steps.map.outputs.freebsd_version }}
-      php_version: ${{ steps.map.outputs.php_version }}
+      freebsd_version: ${{ steps.lookup.outputs.freebsd_version }}
+      php_version: ${{ steps.lookup.outputs.php_version }}
     steps:
-      - name: Map pfsense_ce_version -> (freebsd_version, php_version)
-        id: map
+      - name: Checkout (for scripts/read-version-matrix.sh)
+        uses: actions/checkout@v6
+
+      - name: Look up pfsense_ce_version in the supported-version matrix
+        id: lookup
         env:
           CE_VERSION: ${{ inputs.pfsense_ce_version }}
         run: |
           set -eu
-          # Adding a new supported CE version REQUIRES a new case arm here.
-          # Keep in sync with docs/misc/pfSense_versions.md (the per-version base
-          # facts: FreeBSD base + PHP). 2.8.0 and 2.8.1 share the same toolchain,
-          # so the whole 2.8.x line maps to one base.
-          case "$CE_VERSION" in
-            2.8.*)
-              FREEBSD_VERSION="15.0-RELEASE"
-              PHP_VERSION="8.3"
-              ;;
-            *)
-              echo "::error::no FreeBSD/PHP mapping for pfSense CE '${CE_VERSION}'. Add a case arm in build-image.yml (resolve-version job) and update docs/misc/pfSense_versions.md before publishing this version."
-              exit 1
-              ;;
-          esac
+          # Fetch ci-metadata and read the matrix JSON.
+          git fetch origin ci-metadata
+          MATRIX_JSON="$(git show origin/ci-metadata:supported-versions.json)"
+
+          # Find the CE entry whose pfsense_version pattern matches CE_VERSION.
+          # "2.8.x" matches "2.8.0", "2.8.1", etc.: strip trailing ".x" from the
+          # matrix key to get a prefix, then test CE_VERSION starts with it.
+          # An exact match (no ".x" suffix) is also accepted.
+          # Exit 2 = no matching entry -> hard-fail with actionable error message.
+          MATCH="$(printf '%s' "$MATRIX_JSON" | jq -e --arg ver "$CE_VERSION" '
+            .versions[]
+            | select(.channel == "CE")
+            | . as $e
+            | select(
+                ($e.pfsense_version | endswith(".x") and ($ver | startswith($e.pfsense_version[:-1])))
+                or $e.pfsense_version == $ver
+              )
+          ' 2>/dev/null | jq -s '.[0] // empty')" || true
+
+          if [ -z "$MATCH" ] || [ "$MATCH" = "null" ]; then
+            printf '::error::no FreeBSD/PHP mapping for pfSense CE '"'"'%s'"'"' in supported-versions.json on ci-metadata. Add a CE entry with a matching pfsense_version (e.g. '"'"'%s.x'"'"') and update docs/misc/pfSense_versions.md before publishing this version.\n' \
+              "$CE_VERSION" "$(printf '%s' "$CE_VERSION" | cut -d. -f1,2)"
+            exit 1
+          fi
+
+          FREEBSD_VERSION="$(printf '%s' "$MATCH" | jq -r '.freebsd_version')"
+          PHP_VERSION="$(printf '%s' "$MATCH" | jq -r '.php_version')"
           {
-            echo "freebsd_version=${FREEBSD_VERSION}"
-            echo "php_version=${PHP_VERSION}"
+            printf 'freebsd_version=%s\n' "$FREEBSD_VERSION"
+            printf 'php_version=%s\n' "$PHP_VERSION"
           } >> "$GITHUB_OUTPUT"
-          echo "CE ${CE_VERSION} -> FreeBSD ${FREEBSD_VERSION}, PHP ${PHP_VERSION}"
+          printf 'CE %s -> FreeBSD %s, PHP %s (from ci-metadata matrix)\n' \
+            "$CE_VERSION" "$FREEBSD_VERSION" "$PHP_VERSION"
 
   # ── 1. Publish the version-tagged qcow2 to private GHCR ──────────────────
   publish-image:

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -1,0 +1,593 @@
+name: CI image refresh (ADR-09 P5)
+
+# Upgrade a published pfSense CE GHCR image to a new CE release, apply the SANITY
+# GATE, and publish the new tag ONLY on gate PASS. Fail-closed: a bad upgrade MUST
+# NEVER be published and the old tag MUST be left untouched.
+#
+# Triggered by the version-tracker (ADR-09 Phase 4) once per ci:true CE entry
+# whenever the tracker runs, and by manual workflow_dispatch for testing/forcing.
+#
+# SANITY GATE (the publish guard — ADR-09 §2):
+#   1. VM boots                    — the upgraded qcow2 powers up under QEMU/KVM
+#   2. SSH answers                 — root SSH reaches the guest
+#   3. /etc/version == expected    — the upgrade landed the target CE version
+#   4. pfctl -sr loads             — firewall ruleset is non-empty
+#   5. install-from-repo.sh +
+#      pfblockerng.php update=0    — pfBlockerNG installs and its reload succeeds
+#   6. dig control record          — the guest's own Unbound answers a known
+#                                    local-data A record injected after install
+# ANY failure -> DO NOT publish; fail the job; keep GHCR untouched.
+#
+# FALLBACK: when the gate fails, use scripts/image-publish.sh (off-runner manual
+# seed) to publish the image for that version. This is documented, not the default.
+#
+# Required secrets/vars (shared with build-image.yml and smoke.yml):
+#   SMOKE_GHCR_USER     username for `oras login ghcr.io`                  (secret)
+#   SMOKE_GHCR_TOKEN    token with write:packages (publish) / read:packages (secret)
+#   SMOKE_SSH_PRIV_KEY  guest SSH private key baked into the image          (secret)
+#   SMOKE_IMAGE         GHCR image ref WITHOUT tag (var or secret;          (var/secret)
+#                       default ghcr.io/<owner>/pfsense-ce)
+#
+# INVARIANT: this workflow NEVER writes to main/devel/next or any channel branch.
+# It writes ONLY to GHCR (packages). The tracker dispatches it; it publishes or fails.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pfsense_version:
+        description: "Target pfSense CE version (e.g. 2.8.1). The tracker passes the exact version from supported-versions.json."
+        required: true
+        type: string
+      freebsd_version:
+        description: "FreeBSD base version for this CE release (e.g. 15.0-RELEASE). The tracker reads this from supported-versions.json."
+        required: true
+        type: string
+      from_version:
+        description: "Prior published CE tag to upgrade from (e.g. 2.8.0). Leave empty to auto-detect from the matrix (the most recent prior CE tag)."
+        required: false
+        default: ""
+        type: string
+      compression:
+        description: "qcow2 compression for the published image (zstd|zlib|off)"
+        required: false
+        default: "zstd"
+        type: string
+      upgrade_timeout:
+        description: "Seconds to wait for pfSense-upgrade + reboot"
+        required: false
+        default: "1800"
+        type: string
+      boot_timeout:
+        description: "Sanity gate: hard boot-to-SSH timeout, seconds"
+        required: false
+        default: "180"
+        type: string
+      sanity_local_data_name:
+        description: "Sanity gate: Unbound local-data name to inject + query on-box"
+        required: false
+        default: "smoke-sanity.pfb.test"
+        type: string
+      sanity_local_data_ip:
+        description: "Sanity gate: A-record the gate asserts for sanity_local_data_name"
+        required: false
+        default: "192.0.2.99"
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # ── Resolve prior published tag (from_version) ─────────────────────────────
+  # Determine which existing GHCR tag to upgrade FROM. The tracker always passes
+  # pfsense_version + freebsd_version; from_version is optional (the tracker does
+  # not currently pass it, so we auto-detect from the matrix here).
+  resolve-from:
+    name: Resolve upgrade source tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      from_tag: ${{ steps.resolve.outputs.from_tag }}
+    steps:
+      - name: Checkout (for read-version-matrix action)
+        uses: actions/checkout@v6
+
+      - name: Resolve prior CE tag to upgrade from
+        id: resolve
+        env:
+          FROM_VERSION: ${{ inputs.from_version }}
+          TARGET_VERSION: ${{ inputs.pfsense_version }}
+        run: |
+          set -eu
+          if [ -n "$FROM_VERSION" ]; then
+            # Caller supplied an explicit prior tag — use it directly.
+            printf 'from_tag=%s\n' "$FROM_VERSION" >> "$GITHUB_OUTPUT"
+            printf 'Using caller-supplied from_version: %s\n' "$FROM_VERSION"
+            exit 0
+          fi
+
+          # Auto-detect: read the matrix for the most recent prior CE GA entry.
+          git fetch origin ci-metadata
+          MATRIX_JSON="$(git show origin/ci-metadata:supported-versions.json)"
+
+          # Strip trailing ".x" suffix from pfsense_version inputs (e.g. "2.8.x" -> "2.8").
+          TARGET_PREFIX="$(printf '%s' "$TARGET_VERSION" | sed 's/\.x$//')"
+
+          # Find all CE GA entries whose version prefix is strictly less than the
+          # target prefix (older versions), pick the latest by sorted order.
+          FROM_TAG="$(printf '%s' "$MATRIX_JSON" | jq -r --arg target "$TARGET_PREFIX" '
+            .versions[]
+            | select(.channel == "CE" and .status == "GA")
+            | . as $e
+            | ($e.pfsense_version | gsub("\\.x$"; "")) as $pfx
+            | select($pfx < $target)
+            | $pfx
+          ' | sort -V | tail -1)"
+
+          if [ -z "$FROM_TAG" ] || [ "$FROM_TAG" = "null" ]; then
+            printf '::error::Cannot determine from_version: no prior CE GA entry in the matrix older than %s. Pass from_version explicitly or add a prior GA entry to supported-versions.json on ci-metadata.\n' \
+              "$TARGET_VERSION"
+            exit 1
+          fi
+
+          # Reconstruct the published tag from the matrix entry for this prefix.
+          FROM_FULL_TAG="$(printf '%s' "$MATRIX_JSON" | jq -r --arg pfx "${FROM_TAG}" '
+            .versions[]
+            | select(.channel == "CE" and .status == "GA")
+            | select((.pfsense_version | gsub("\\.x$"; "")) == $pfx)
+            | .pfsense_version | gsub("\\.x$"; "")
+          ' | head -1)"
+
+          printf 'Auto-detected from_version: %s (target: %s)\n' "$FROM_FULL_TAG" "$TARGET_VERSION"
+          printf 'from_tag=%s\n' "$FROM_FULL_TAG" >> "$GITHUB_OUTPUT"
+
+  # ── Upgrade-in-place + SANITY GATE + publish on pass only ──────────────────
+  refresh:
+    name: Refresh CE ${{ inputs.pfsense_version }} image
+    needs: resolve-from
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout (for scripts/ + tests/smoke/)
+        uses: actions/checkout@v6
+
+      - name: Enable KVM access for the runner user
+        # GH-hosted ubuntu-latest ships /dev/kvm; the `runner` user is not in
+        # the kvm group by default. Same fix as build-image.yml / smoke.yml.
+        run: |
+          set -eu
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls -l /dev/kvm
+
+      - name: Install host tools (qemu, dig, curl, rsync)
+        run: |
+          set -eu
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils curl openssh-client rsync
+
+      - name: Install oras
+        uses: oras-project/setup-oras@v2
+
+      - name: Write guest SSH key (mode 600)
+        env:
+          SMOKE_SSH_PRIV_KEY: ${{ secrets.SMOKE_SSH_PRIV_KEY }}
+        run: |
+          set -eu
+          if [ -z "${SMOKE_SSH_PRIV_KEY:-}" ]; then
+            echo "::error::SMOKE_SSH_PRIV_KEY secret is not set"
+            exit 1
+          fi
+          install -m 600 /dev/null smoke_key
+          printf '%s\n' "$SMOKE_SSH_PRIV_KEY" > smoke_key
+          chmod 600 smoke_key
+
+      - name: Resolve the GHCR image ref
+        id: ref
+        env:
+          SMOKE_IMAGE: ${{ secrets.SMOKE_IMAGE || vars.SMOKE_IMAGE }}
+        run: |
+          set -eu
+          IMAGE="${SMOKE_IMAGE:-ghcr.io/${GITHUB_REPOSITORY_OWNER}/pfsense-ce}"
+          printf 'image=%s\n' "$IMAGE" >> "$GITHUB_OUTPUT"
+          printf 'Image base ref: %s\n' "$IMAGE"
+
+      # ── Step 1: UPGRADE IN PLACE ────────────────────────────────────────────
+      # Pull the FROM tag, boot it under the runner's KVM, run pfSense-upgrade,
+      # wait for the new version, power off, compress, stream back. The source
+      # tag is left untouched. The upgraded qcow2 is NOT yet published — it sits
+      # locally until the sanity gate passes.
+      - name: Upgrade in place (pfSense ${{ needs.resolve-from.outputs.from_tag }} -> ${{ inputs.pfsense_version }})
+        id: upgrade
+        env:
+          SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
+          SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
+          SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER }}
+          SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_TOKEN }}
+        run: |
+          set -eu
+          # Upgrade into a LOCAL working directory — do NOT push yet.
+          # image-upgrade.sh publishes at the end; we need to intercept that
+          # by using a local-only mode. We achieve this by pulling, booting,
+          # upgrading, and then capturing the resulting qcow2 ourselves using
+          # the same approach as image-upgrade.sh but stopping before the push.
+          #
+          # image-upgrade.sh is designed to pull + upgrade + push in one pass.
+          # We run it in two sub-steps: the upgrade step produces the qcow2 and
+          # verifies the version changed; the sanity gate then boots and validates
+          # the result before we push it.
+          #
+          # To intercept, we run image-upgrade.sh normally BUT capture its work
+          # output. Since the script always pushes at the end and we cannot
+          # easily split it, we use a different approach:
+          #   a) oras pull the FROM tag manually.
+          #   b) Boot + upgrade + shutdown (inline, mirroring image-upgrade.sh logic).
+          #   c) Capture the resulting qcow2 as upgrade-candidate.qcow2.
+          #   d) Gate: boot the candidate, run all sanity checks.
+          #   e) Only on GATE PASS: push via oras.
+          #
+          # This is the "gate-then-publish" split that image-upgrade.sh's
+          # monolithic flow does not natively support (it always pushes on success).
+          # The inline logic below mirrors image-upgrade.sh exactly (same flags,
+          # same wait loop) — no duplication of upgrade semantics, just the split.
+
+          FROM_TAG="${{ needs.resolve-from.outputs.from_tag }}"
+          TO_TAG="${{ inputs.pfsense_version }}"
+          IMAGE="${SMOKE_IMAGE}"
+          GUEST_PORT=2222
+          MAC="BC:24:11:37:9C:AC"
+          UPGRADE_TIMEOUT="${{ inputs.upgrade_timeout }}"
+          UPGRADE_CMD='yes | /usr/local/sbin/pfSense-upgrade -d'
+          WORK_DIR="$(mktemp -d)"
+          echo "WORK_DIR=${WORK_DIR}" >> "$GITHUB_ENV"
+
+          printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io \
+            --username "$SMOKE_GHCR_USER" --password-stdin
+
+          printf '==> Pulling %s:%s\n' "$IMAGE" "$FROM_TAG"
+          oras pull "${IMAGE}:${FROM_TAG}" --output "$WORK_DIR"
+          BASE_IMG="$(find "$WORK_DIR" -maxdepth 1 -name '*.qcow2' | head -1)"
+          [ -n "$BASE_IMG" ] || { echo "::error::no qcow2 in pulled artifact ${IMAGE}:${FROM_TAG}"; exit 1; }
+
+          # Make a writable working copy (never modify the pulled base).
+          WORK_IMG="${WORK_DIR}/work.qcow2"
+          cp "$BASE_IMG" "$WORK_IMG"
+
+          QMP_SOCK="${RUNNER_TEMP:-/tmp}/pfb-qmp-upgrade.sock"
+          printf '==> Booting VM for upgrade (guest :%d -> 127.0.0.1:%d)\n' 22 "$GUEST_PORT"
+          qemu-system-x86_64 \
+            -enable-kvm -machine pc -cpu host \
+            -smp 2,sockets=1,cores=2 -m 4096 \
+            -device virtio-scsi-pci,id=virtioscsi0 \
+            -drive "file=${WORK_IMG},if=none,id=drive-scsi0,format=qcow2,discard=unmap,detect-zeroes=unmap" \
+            -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
+            -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${GUEST_PORT}-:22" \
+            -device "virtio-net-pci,mac=${MAC},netdev=net0,id=net0" \
+            -display none \
+            -serial "file:${WORK_DIR}/console.log" \
+            -qmp "unix:${QMP_SOCK},server,nowait" \
+            -pidfile "${WORK_DIR}/qemu.pid" \
+            -daemonize
+          echo "QMP_SOCK=${QMP_SOCK}" >> "$GITHUB_ENV"
+          echo "UPGRADE_QPID_FILE=${WORK_DIR}/qemu.pid" >> "$GITHUB_ENV"
+
+          printf '==> Waiting for SSH (pre-upgrade)...\n'
+          _elapsed=0
+          while ! ssh -p "$GUEST_PORT" -i smoke_key \
+              -o BatchMode=yes -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+              root@127.0.0.1 true 2>/dev/null; do
+            [ "$_elapsed" -lt 300 ] || { echo "::error::VM did not answer SSH within 300s"; exit 1; }
+            sleep 5; _elapsed=$((_elapsed + 5))
+          done
+
+          OLD_VER="$(ssh -p "$GUEST_PORT" -i smoke_key \
+            -o BatchMode=yes -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+            root@127.0.0.1 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)"
+          printf '==> Current version: %s\n' "${OLD_VER:-unknown}"
+
+          printf '==> Running pfSense-upgrade (up to %ss)\n' "$UPGRADE_TIMEOUT"
+          ssh -p "$GUEST_PORT" -i smoke_key \
+            -o BatchMode=yes -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 \
+            root@127.0.0.1 "$UPGRADE_CMD" 2>&1 | tee "${WORK_DIR}/upgrade.log" || true
+
+          printf '==> Waiting for the upgraded box to reboot and come back...\n'
+          sleep 30
+          NEW_VER=""
+          _elapsed=0
+          while [ "$_elapsed" -lt "$UPGRADE_TIMEOUT" ]; do
+            _v="$(ssh -p "$GUEST_PORT" -i smoke_key \
+              -o BatchMode=yes -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+              root@127.0.0.1 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)"
+            if [ -n "$_v" ] && [ "$_v" != "$OLD_VER" ]; then
+              NEW_VER="$_v"
+              break
+            fi
+            sleep 15; _elapsed=$((_elapsed + 15))
+          done
+          if [ -z "$NEW_VER" ]; then
+            echo "::error::pfSense version did not change within ${UPGRADE_TIMEOUT}s (still '${OLD_VER}'). Check upgrade.log in the diagnostics artifact."
+            exit 1
+          fi
+          printf '==> Upgraded: %s -> %s\n' "$OLD_VER" "$NEW_VER"
+          echo "NEW_VER=${NEW_VER}" >> "$GITHUB_ENV"
+          echo "OLD_VER=${OLD_VER}" >> "$GITHUB_ENV"
+
+          printf '==> Shutting the upgraded VM down\n'
+          ssh -p "$GUEST_PORT" -i smoke_key \
+            -o BatchMode=yes -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+            root@127.0.0.1 '/sbin/shutdown -p now' 2>/dev/null || true
+          QPID="$(cat "${WORK_DIR}/qemu.pid" 2>/dev/null | tr -d '\r' || true)"
+          if [ -n "$QPID" ]; then
+            _elapsed=0
+            while kill -0 "$QPID" 2>/dev/null; do
+              [ "$_elapsed" -lt 120 ] || { kill "$QPID" 2>/dev/null || true; break; }
+              sleep 3; _elapsed=$((_elapsed + 3))
+            done
+          fi
+
+          printf '==> Compressing upgraded image (zstd, with zlib fallback)\n'
+          CANDIDATE="${WORK_DIR}/pfSense-CE-${TO_TAG}.qcow2"
+          if qemu-img convert -O qcow2 -c -o compression_type=zstd \
+              "$WORK_IMG" "$CANDIDATE" 2>/dev/null; then
+            printf '    zstd compression OK\n'
+          else
+            printf '    zstd not supported; falling back to zlib\n'
+            qemu-img convert -O qcow2 -c "$WORK_IMG" "$CANDIDATE"
+          fi
+          [ -s "$CANDIDATE" ] || { echo "::error::compressed candidate image is empty"; exit 1; }
+          echo "CANDIDATE=${CANDIDATE}" >> "$GITHUB_ENV"
+          printf '==> Upgrade candidate ready: %s\n' "$(basename "$CANDIDATE")"
+
+      # ── Step 2: SANITY GATE ─────────────────────────────────────────────────
+      # Boot the CANDIDATE (not the source) and apply every gate check.
+      # ANY miss -> abort; the old GHCR tag is never touched.
+      - name: Sanity gate — boot candidate + run all checks
+        id: sanity
+        env:
+          SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
+          SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
+          SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER }}
+          SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_TOKEN }}
+        run: |
+          set -eu
+          BOOT_TIMEOUT="${{ inputs.boot_timeout }}"
+          LOCAL_DATA_NAME="${{ inputs.sanity_local_data_name }}"
+          LOCAL_DATA_IP="${{ inputs.sanity_local_data_ip }}"
+          GUEST_PORT=2223   # different port from upgrade boot (defence-in-depth)
+          MAC="BC:24:11:37:9C:AC"
+          CANDIDATE="${CANDIDATE}"
+          TARGET_VERSION="${{ inputs.pfsense_version }}"
+          WORK_DIR="${WORK_DIR}"
+
+          printf '==> SANITY GATE: booting candidate image %s\n' "$(basename "$CANDIDATE")"
+          QMP_SOCK_GATE="${RUNNER_TEMP:-/tmp}/pfb-qmp-gate.sock"
+
+          # Boot from the compressed candidate qcow2 (copy-on-write overlay so
+          # the candidate file is never mutated by the sanity run).
+          GATE_OVERLAY="${WORK_DIR}/gate-overlay.qcow2"
+          qemu-img create -b "$CANDIDATE" -F qcow2 -f qcow2 "$GATE_OVERLAY"
+
+          qemu-system-x86_64 \
+            -enable-kvm -machine pc -cpu host \
+            -smp 2,sockets=1,cores=2 -m 4096 \
+            -device virtio-scsi-pci,id=virtioscsi0 \
+            -drive "file=${GATE_OVERLAY},if=none,id=drive-scsi0,format=qcow2,discard=unmap,detect-zeroes=unmap" \
+            -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
+            -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${GUEST_PORT}-:22" \
+            -device "virtio-net-pci,mac=${MAC},netdev=net0,id=net0" \
+            -display none \
+            -serial "file:${WORK_DIR}/gate-console.log" \
+            -qmp "unix:${QMP_SOCK_GATE},server,nowait" \
+            -pidfile "${WORK_DIR}/gate-qemu.pid" \
+            -daemonize
+          echo "GATE_QPID_FILE=${WORK_DIR}/gate-qemu.pid" >> "$GITHUB_ENV"
+          echo "QMP_SOCK_GATE=${QMP_SOCK_GATE}" >> "$GITHUB_ENV"
+
+          GATE_FAILED=0
+
+          # [GATE-1+2] SSH answers within BOOT_TIMEOUT seconds.
+          printf '==> [GATE-1/6] VM boots; [GATE-2/6] SSH answers (timeout %ss)\n' "$BOOT_TIMEOUT"
+          _elapsed=0
+          SSH_UP=0
+          while [ "$_elapsed" -lt "$BOOT_TIMEOUT" ]; do
+            if ssh -p "$GUEST_PORT" -i smoke_key \
+                -o BatchMode=yes -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+                root@127.0.0.1 true 2>/dev/null; then
+              SSH_UP=1; break
+            fi
+            sleep 5; _elapsed=$((_elapsed + 5))
+          done
+          if [ "$SSH_UP" -ne 1 ]; then
+            echo "::error::[GATE-1/2] VM did not answer SSH within ${BOOT_TIMEOUT}s"
+            GATE_FAILED=1
+          else
+            echo "    PASS: SSH answered"
+          fi
+
+          if [ "$GATE_FAILED" -eq 0 ]; then
+            # Shared SSH helper for subsequent gate checks.
+            run_ssh() {
+              ssh -p "$GUEST_PORT" -i smoke_key \
+                -o BatchMode=yes -o StrictHostKeyChecking=no \
+                -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 \
+                root@127.0.0.1 "$@"
+            }
+
+            # [GATE-3] /etc/version == expected release.
+            # TARGET_VERSION may be "2.8.x" (matrix pattern) or "2.8.1" (exact).
+            # Strip trailing ".x" to get a prefix; accept any version that starts
+            # with it (same matching logic as the build-image resolve-version job).
+            printf '==> [GATE-3/6] /etc/version == %s\n' "$TARGET_VERSION"
+            BOX_VER="$(run_ssh 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)"
+            VERSION_PREFIX="$(printf '%s' "$TARGET_VERSION" | sed 's/\.x$//')"
+            if [ -z "$BOX_VER" ]; then
+              echo "::error::[GATE-3] could not read /etc/version from guest"
+              GATE_FAILED=1
+            else
+              CASE="${BOX_VER#"${VERSION_PREFIX}"}"
+              if [ "$BOX_VER" = "$VERSION_PREFIX" ] || [ "$CASE" != "$BOX_VER" ]; then
+                printf '    PASS: /etc/version = %s (matches %s)\n' "$BOX_VER" "$TARGET_VERSION"
+              else
+                printf '::error::[GATE-3] /etc/version = %s does not match expected %s\n' \
+                  "$BOX_VER" "$TARGET_VERSION"
+                GATE_FAILED=1
+              fi
+            fi
+
+            # [GATE-4] pfctl -sr returns a non-empty ruleset.
+            printf '==> [GATE-4/6] pfctl -sr loads\n'
+            RULES="$(run_ssh '/sbin/pfctl -sr' 2>/dev/null || true)"
+            if [ -n "$RULES" ]; then
+              printf '    PASS: %d rules\n' "$(printf '%s\n' "$RULES" | wc -l | tr -d ' ')"
+            else
+              echo "::error::[GATE-4] pfctl -sr returned no rules"
+              GATE_FAILED=1
+            fi
+
+            # [GATE-5] install-from-repo.sh + pfblockerng.php update exits 0.
+            # install-from-repo.sh needs egress (pkg install of deps); the sanity
+            # VM has internet open (user-net SLIRP with egress). After install, run
+            # the production reload entry point.
+            printf '==> [GATE-5/6] install-from-repo.sh + pfblockerng.php update\n'
+            if scripts/install-from-repo.sh root@127.0.0.1 \
+                --port "$GUEST_PORT" --ssh-key smoke_key; then
+              printf '    install-from-repo.sh OK\n'
+              if run_ssh '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php update'; then
+                printf '    PASS: pfblockerng.php update exited 0\n'
+              else
+                echo "::error::[GATE-5] pfblockerng.php update exited non-zero"
+                GATE_FAILED=1
+              fi
+            else
+              echo "::error::[GATE-5] install-from-repo.sh failed"
+              GATE_FAILED=1
+            fi
+
+            # [GATE-6] dig a baked control record from the guest's own Unbound.
+            # The pfblockerng.php update above may restart Unbound — wait for it
+            # to come back, then inject a local-data record and resolve it on-box
+            # (same pattern as roundtrip.sh check [3/4]).
+            printf '==> [GATE-6/6] dig control record from guest Unbound\n'
+            UB_READY=0
+            _ub_i=0
+            while [ "$_ub_i" -lt 30 ]; do
+              if run_ssh '/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status >/dev/null 2>&1'; then
+                UB_READY=1; break
+              fi
+              _ub_i=$((_ub_i + 1)); sleep 2
+            done
+            if [ "$UB_READY" -ne 1 ]; then
+              echo "::error::[GATE-6] Unbound did not come back up after pfBlockerNG reload"
+              GATE_FAILED=1
+            else
+              # Inject the control record.
+              if run_ssh "/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf local_data '${LOCAL_DATA_NAME}. 3600 IN A ${LOCAL_DATA_IP}'"; then
+                printf '    injected %s -> %s\n' "$LOCAL_DATA_NAME" "$LOCAL_DATA_IP"
+              else
+                echo "::error::[GATE-6] unbound-control local_data injection failed"
+                GATE_FAILED=1
+              fi
+
+              # Resolve on-box (SSH → drill/host on the guest, probing 127.0.0.1:53).
+              DNS_OUT="$(run_ssh "if command -v drill >/dev/null 2>&1; then drill ${LOCAL_DATA_NAME} @127.0.0.1 A; elif command -v host >/dev/null 2>&1; then host -t A ${LOCAL_DATA_NAME} 127.0.0.1; else echo NO_GUEST_DNS_TOOL; fi" 2>/dev/null || true)"
+              if printf '%s' "$DNS_OUT" | grep -q NO_GUEST_DNS_TOOL; then
+                # Best-effort install bind-tools / ldns on the guest.
+                run_ssh 'env ASSUME_ALWAYS_YES=yes pkg install -y bind-tools ldns 2>/dev/null' || true
+                DNS_OUT="$(run_ssh "if command -v drill >/dev/null 2>&1; then drill ${LOCAL_DATA_NAME} @127.0.0.1 A; elif command -v host >/dev/null 2>&1; then host -t A ${LOCAL_DATA_NAME} 127.0.0.1; else echo NO_GUEST_DNS_TOOL_AFTER_INSTALL; fi" 2>/dev/null || true)"
+              fi
+              if printf '%s' "$DNS_OUT" | grep -qw "$LOCAL_DATA_IP"; then
+                printf '    PASS: guest Unbound resolved %s -> %s\n' "$LOCAL_DATA_NAME" "$LOCAL_DATA_IP"
+              else
+                printf '::error::[GATE-6] guest Unbound did not return %s for %s\n' \
+                  "$LOCAL_DATA_IP" "$LOCAL_DATA_NAME"
+                printf '%s\n' "$DNS_OUT" | sed 's/^/      /' >&2
+                GATE_FAILED=1
+              fi
+            fi
+          fi
+
+          # Take a screendump before shutting down on failure.
+          if [ "$GATE_FAILED" -ne 0 ] && python3 tests/smoke/screendump.py \
+              "$QMP_SOCK_GATE" "${WORK_DIR}/gate-screen.png" 2>/dev/null; then
+            echo "    screendump saved to gate-screen.png"
+          fi
+
+          # Shut down the gate VM.
+          GATE_QPID="$(cat "${WORK_DIR}/gate-qemu.pid" 2>/dev/null | tr -d '\r' || true)"
+          if [ -n "$GATE_QPID" ]; then
+            ssh -p "$GUEST_PORT" -i smoke_key \
+              -o BatchMode=yes -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+              root@127.0.0.1 '/sbin/shutdown -p now' 2>/dev/null || true
+            _elapsed=0
+            while kill -0 "$GATE_QPID" 2>/dev/null; do
+              [ "$_elapsed" -lt 60 ] || { kill "$GATE_QPID" 2>/dev/null || true; break; }
+              sleep 3; _elapsed=$((_elapsed + 3))
+            done
+          fi
+
+          if [ "$GATE_FAILED" -ne 0 ]; then
+            echo "::error::SANITY GATE FAILED — candidate image will NOT be published. GHCR tag ${{ inputs.pfsense_version }} is untouched. Manual fallback: scripts/image-publish.sh (see ADR-09 §2)."
+            exit 1
+          fi
+          echo "==> SANITY GATE PASSED — proceeding to publish"
+
+      # ── Step 3: PUBLISH ON PASS ONLY ───────────────────────────────────────
+      # The sanity gate job completed without error. Push the candidate qcow2
+      # to GHCR as the new version tag. The old tag is always kept.
+      - name: Publish candidate image (gate PASSED)
+        if: success()
+        env:
+          SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
+          SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER }}
+          SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_TOKEN }}
+        run: |
+          set -eu
+          IMAGE="${SMOKE_IMAGE}"
+          TAG="${{ inputs.pfsense_version }}"
+          CANDIDATE="${CANDIDATE}"
+
+          printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io \
+            --username "$SMOKE_GHCR_USER" --password-stdin
+
+          # Refuse to clobber an existing tag (keep old snapshots; each tag is
+          # its own immutable snapshot per ADR-04 §2 retention policy).
+          if oras manifest fetch "${IMAGE}:${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${IMAGE}:${TAG} already exists. Use build-image.yml with --force if you need to overwrite an existing tag (only for intentional re-seeds). Old tag is kept."
+            exit 1
+          fi
+
+          printf '==> Publishing %s:%s\n' "$IMAGE" "$TAG"
+          (
+            cd "$(dirname "$CANDIDATE")"
+            oras push \
+              --artifact-type application/vnd.netgate.pfsense-ce.disk.v1 \
+              --annotation "org.opencontainers.image.title=$(basename "$CANDIDATE")" \
+              --annotation "org.opencontainers.image.version=${TAG}" \
+              --annotation "org.opencontainers.image.description=pfSense CE ${TAG} pfBlockerNG smoke-test base (upgraded from ${{ needs.resolve-from.outputs.from_tag }}; sanity-gated)" \
+              "${IMAGE}:${TAG}" \
+              "$(basename "$CANDIDATE"):application/vnd.qemu.qcow2"
+          )
+          printf '==> Published %s:%s (source tag %s kept)\n' \
+            "$IMAGE" "$TAG" "${{ needs.resolve-from.outputs.from_tag }}"
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: image-refresh-diagnostics-${{ inputs.pfsense_version }}
+          path: |
+            ${{ env.WORK_DIR }}/console.log
+            ${{ env.WORK_DIR }}/upgrade.log
+            ${{ env.WORK_DIR }}/gate-console.log
+            ${{ env.WORK_DIR }}/gate-screen.png
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -59,9 +59,9 @@ on:
         default: "zstd"
         type: string
       upgrade_timeout:
-        description: "Seconds to wait for pfSense-upgrade + reboot"
+        description: "MAX seconds to wait for pfSense-upgrade + reboot (poll exits on version change; bounds a stuck upgrade only)"
         required: false
-        default: "1800"
+        default: "1200"
         type: string
       sanity_local_data_name:
         description: "pfBlockerNG smoke (non-blocking): Unbound local-data name to inject + query on-box"

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -1,25 +1,31 @@
 name: CI image refresh (ADR-09 P5)
 
-# Upgrade a published pfSense CE GHCR image to a new CE release, apply the SANITY
-# GATE, and publish the new tag ONLY on gate PASS. Fail-closed: a bad upgrade MUST
-# NEVER be published and the old tag MUST be left untouched.
+# Upgrade a published pfSense CE GHCR image to a new CE release and publish the
+# result. Fail-closed: a bad upgrade MUST NEVER be published and the old tag MUST
+# be left untouched.
 #
-# Triggered by the version-tracker (ADR-09 Phase 4) once per ci:true CE entry
-# whenever the tracker runs, and by manual workflow_dispatch for testing/forcing.
+# PUBLISH GUARD (inside scripts/image-upgrade.sh):
+#   1. Prior GHCR tag pulled and booted writable under QEMU/KVM.
+#   2. pkg update -f → pkg upgrade -n dry-run → ONLY if upgrades pending:
+#      pkg upgrade -y + reboot + wait SSH (baked deps updated; pfBlockerNG is NOT
+#      on the base image and is never touched).
+#   3. pfSense-upgrade (reboots the box).
+#   4. Wait until version changes.
+#   5. Health gate: poll up to 300 s for EITHER the webConfigurator to answer
+#      HTTP on-box (fetch https://127.0.0.1/) OR pfctl -sr to show a live ruleset.
+#      If NEITHER within 300 s → die, fail-closed, nothing is published.
+#   6. Clean shutdown → compress to qcow2 (zstd) → oras push new tag.
 #
-# SANITY GATE (the publish guard — ADR-09 §2):
-#   1. VM boots                    — the upgraded qcow2 powers up under QEMU/KVM
-#   2. SSH answers                 — root SSH reaches the guest
-#   3. /etc/version == expected    — the upgrade landed the target CE version
-#   4. pfctl -sr loads             — firewall ruleset is non-empty
-#   5. install-from-repo.sh +
-#      pfblockerng.php update=0    — pfBlockerNG installs and its reload succeeds
-#   6. dig control record          — the guest's own Unbound answers a known
-#                                    local-data A record injected after install
-# ANY failure -> DO NOT publish; fail the job; keep GHCR untouched.
+# pfBlockerNG SMOKE (non-blocking, after publish):
+#   A separate step with continue-on-error: true boots a throwaway copy-on-write
+#   overlay of the JUST-PUBLISHED image, installs pfBlockerNG from the repo, runs
+#   pfblockerng.php update, and digs the sanity control record — purely informational.
+#   Because it runs on a discarded overlay AFTER publish and with continue-on-error:
+#   true, it CANNOT pollute the published image and CANNOT fail the refresh job.
+#   The authoritative pfBlockerNG validation is the smoke fan-out (smoke-fanout.yml).
 #
-# FALLBACK: when the gate fails, use scripts/image-publish.sh (off-runner manual
-# seed) to publish the image for that version. This is documented, not the default.
+# FALLBACK: when the health gate fails, use scripts/image-publish.sh (off-runner
+# manual seed) to publish the image for that version.
 #
 # Required secrets/vars (shared with build-image.yml and smoke.yml):
 #   SMOKE_GHCR_USER     username for `oras login ghcr.io`                  (secret)
@@ -57,18 +63,13 @@ on:
         required: false
         default: "1800"
         type: string
-      boot_timeout:
-        description: "Sanity gate: hard boot-to-SSH timeout, seconds"
-        required: false
-        default: "180"
-        type: string
       sanity_local_data_name:
-        description: "Sanity gate: Unbound local-data name to inject + query on-box"
+        description: "pfBlockerNG smoke (non-blocking): Unbound local-data name to inject + query on-box"
         required: false
         default: "smoke-sanity.pfb.test"
         type: string
       sanity_local_data_ip:
-        description: "Sanity gate: A-record the gate asserts for sanity_local_data_name"
+        description: "pfBlockerNG smoke (non-blocking): A-record asserted for sanity_local_data_name"
         required: false
         default: "192.0.2.99"
         type: string
@@ -141,7 +142,7 @@ jobs:
           printf 'Auto-detected from_version: %s (target: %s)\n' "$FROM_FULL_TAG" "$TARGET_VERSION"
           printf 'from_tag=%s\n' "$FROM_FULL_TAG" >> "$GITHUB_OUTPUT"
 
-  # ── Upgrade-in-place + SANITY GATE + publish on pass only ──────────────────
+  # ── Upgrade in place → health gate → publish; then non-blocking smoke ──────
   refresh:
     name: Refresh CE ${{ inputs.pfsense_version }} image
     needs: resolve-from
@@ -194,12 +195,19 @@ jobs:
           printf 'image=%s\n' "$IMAGE" >> "$GITHUB_OUTPUT"
           printf 'Image base ref: %s\n' "$IMAGE"
 
-      # ── Step 1: UPGRADE IN PLACE ────────────────────────────────────────────
-      # Pull the FROM tag, boot it under the runner's KVM, run pfSense-upgrade,
-      # wait for the new version, power off, compress, stream back. The source
-      # tag is left untouched. The upgraded qcow2 is NOT yet published — it sits
-      # locally until the sanity gate passes.
-      - name: Upgrade in place (pfSense ${{ needs.resolve-from.outputs.from_tag }} -> ${{ inputs.pfsense_version }})
+      # ── Upgrade + health gate + publish ────────────────────────────────────
+      # scripts/image-upgrade.sh runs locally (runner IS the KVM host — no
+      # --proxmox, mirroring build-image.yml). It:
+      #   1. Pulls --from tag (oras), boots writable copy under KVM.
+      #   2. With --upgrade-pkgs: pkg update -f + pkg upgrade -n (dry-run detect);
+      #      ONLY if upgrades pending → pkg upgrade -y + reboot + wait SSH.
+      #   3. Runs pfSense-upgrade (reboots the box), waits for version to change.
+      #   4. Health gate: polls up to 300 s for webConfigurator HTTP or pfctl live
+      #      ruleset; fail-closed (die → no publish) if neither answers.
+      #   5. Shuts down cleanly, compresses to qcow2 (zstd), oras-pushes new tag.
+      # The published image is a CLEAN upgraded qcow2; pfBlockerNG is NEVER
+      # installed on it (the non-blocking step below uses a discarded overlay).
+      - name: Upgrade in place + health gate + publish (${{ needs.resolve-from.outputs.from_tag }} -> ${{ inputs.pfsense_version }})
         id: upgrade
         env:
           SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
@@ -208,148 +216,24 @@ jobs:
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_TOKEN }}
         run: |
           set -eu
-          # Upgrade into a LOCAL working directory — do NOT push yet.
-          # image-upgrade.sh publishes at the end; we need to intercept that
-          # by using a local-only mode. We achieve this by pulling, booting,
-          # upgrading, and then capturing the resulting qcow2 ourselves using
-          # the same approach as image-upgrade.sh but stopping before the push.
-          #
-          # image-upgrade.sh is designed to pull + upgrade + push in one pass.
-          # We run it in two sub-steps: the upgrade step produces the qcow2 and
-          # verifies the version changed; the sanity gate then boots and validates
-          # the result before we push it.
-          #
-          # To intercept, we run image-upgrade.sh normally BUT capture its work
-          # output. Since the script always pushes at the end and we cannot
-          # easily split it, we use a different approach:
-          #   a) oras pull the FROM tag manually.
-          #   b) Boot + upgrade + shutdown (inline, mirroring image-upgrade.sh logic).
-          #   c) Capture the resulting qcow2 as upgrade-candidate.qcow2.
-          #   d) Gate: boot the candidate, run all sanity checks.
-          #   e) Only on GATE PASS: push via oras.
-          #
-          # This is the "gate-then-publish" split that image-upgrade.sh's
-          # monolithic flow does not natively support (it always pushes on success).
-          # The inline logic below mirrors image-upgrade.sh exactly (same flags,
-          # same wait loop) — no duplication of upgrade semantics, just the split.
+          sh scripts/image-upgrade.sh \
+            --from "${{ needs.resolve-from.outputs.from_tag }}" \
+            --to "${{ inputs.pfsense_version }}" \
+            --image "${{ steps.ref.outputs.image }}" \
+            --ssh-key "$PWD/smoke_key" \
+            --compression "${{ inputs.compression }}" \
+            --upgrade-timeout "${{ inputs.upgrade_timeout }}" \
+            --upgrade-pkgs
 
-          FROM_TAG="${{ needs.resolve-from.outputs.from_tag }}"
-          TO_TAG="${{ inputs.pfsense_version }}"
-          IMAGE="${SMOKE_IMAGE}"
-          GUEST_PORT=2222
-          MAC="BC:24:11:37:9C:AC"
-          UPGRADE_TIMEOUT="${{ inputs.upgrade_timeout }}"
-          UPGRADE_CMD='yes | /usr/local/sbin/pfSense-upgrade -d'
-          WORK_DIR="$(mktemp -d)"
-          echo "WORK_DIR=${WORK_DIR}" >> "$GITHUB_ENV"
-
-          printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io \
-            --username "$SMOKE_GHCR_USER" --password-stdin
-
-          printf '==> Pulling %s:%s\n' "$IMAGE" "$FROM_TAG"
-          oras pull "${IMAGE}:${FROM_TAG}" --output "$WORK_DIR"
-          BASE_IMG="$(find "$WORK_DIR" -maxdepth 1 -name '*.qcow2' | head -1)"
-          [ -n "$BASE_IMG" ] || { echo "::error::no qcow2 in pulled artifact ${IMAGE}:${FROM_TAG}"; exit 1; }
-
-          # Make a writable working copy (never modify the pulled base).
-          WORK_IMG="${WORK_DIR}/work.qcow2"
-          cp "$BASE_IMG" "$WORK_IMG"
-
-          QMP_SOCK="${RUNNER_TEMP:-/tmp}/pfb-qmp-upgrade.sock"
-          printf '==> Booting VM for upgrade (guest :%d -> 127.0.0.1:%d)\n' 22 "$GUEST_PORT"
-          qemu-system-x86_64 \
-            -enable-kvm -machine pc -cpu host \
-            -smp 2,sockets=1,cores=2 -m 4096 \
-            -device virtio-scsi-pci,id=virtioscsi0 \
-            -drive "file=${WORK_IMG},if=none,id=drive-scsi0,format=qcow2,discard=unmap,detect-zeroes=unmap" \
-            -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
-            -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${GUEST_PORT}-:22" \
-            -device "virtio-net-pci,mac=${MAC},netdev=net0,id=net0" \
-            -display none \
-            -serial "file:${WORK_DIR}/console.log" \
-            -qmp "unix:${QMP_SOCK},server,nowait" \
-            -pidfile "${WORK_DIR}/qemu.pid" \
-            -daemonize
-          echo "QMP_SOCK=${QMP_SOCK}" >> "$GITHUB_ENV"
-          echo "UPGRADE_QPID_FILE=${WORK_DIR}/qemu.pid" >> "$GITHUB_ENV"
-
-          printf '==> Waiting for SSH (pre-upgrade)...\n'
-          _elapsed=0
-          while ! ssh -p "$GUEST_PORT" -i smoke_key \
-              -o BatchMode=yes -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
-              root@127.0.0.1 true 2>/dev/null; do
-            [ "$_elapsed" -lt 300 ] || { echo "::error::VM did not answer SSH within 300s"; exit 1; }
-            sleep 5; _elapsed=$((_elapsed + 5))
-          done
-
-          OLD_VER="$(ssh -p "$GUEST_PORT" -i smoke_key \
-            -o BatchMode=yes -o StrictHostKeyChecking=no \
-            -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
-            root@127.0.0.1 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)"
-          printf '==> Current version: %s\n' "${OLD_VER:-unknown}"
-
-          printf '==> Running pfSense-upgrade (up to %ss)\n' "$UPGRADE_TIMEOUT"
-          ssh -p "$GUEST_PORT" -i smoke_key \
-            -o BatchMode=yes -o StrictHostKeyChecking=no \
-            -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 \
-            root@127.0.0.1 "$UPGRADE_CMD" 2>&1 | tee "${WORK_DIR}/upgrade.log" || true
-
-          printf '==> Waiting for the upgraded box to reboot and come back...\n'
-          sleep 30
-          NEW_VER=""
-          _elapsed=0
-          while [ "$_elapsed" -lt "$UPGRADE_TIMEOUT" ]; do
-            _v="$(ssh -p "$GUEST_PORT" -i smoke_key \
-              -o BatchMode=yes -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
-              root@127.0.0.1 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)"
-            if [ -n "$_v" ] && [ "$_v" != "$OLD_VER" ]; then
-              NEW_VER="$_v"
-              break
-            fi
-            sleep 15; _elapsed=$((_elapsed + 15))
-          done
-          if [ -z "$NEW_VER" ]; then
-            echo "::error::pfSense version did not change within ${UPGRADE_TIMEOUT}s (still '${OLD_VER}'). Check upgrade.log in the diagnostics artifact."
-            exit 1
-          fi
-          printf '==> Upgraded: %s -> %s\n' "$OLD_VER" "$NEW_VER"
-          echo "NEW_VER=${NEW_VER}" >> "$GITHUB_ENV"
-          echo "OLD_VER=${OLD_VER}" >> "$GITHUB_ENV"
-
-          printf '==> Shutting the upgraded VM down\n'
-          ssh -p "$GUEST_PORT" -i smoke_key \
-            -o BatchMode=yes -o StrictHostKeyChecking=no \
-            -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
-            root@127.0.0.1 '/sbin/shutdown -p now' 2>/dev/null || true
-          QPID="$(cat "${WORK_DIR}/qemu.pid" 2>/dev/null | tr -d '\r' || true)"
-          if [ -n "$QPID" ]; then
-            _elapsed=0
-            while kill -0 "$QPID" 2>/dev/null; do
-              [ "$_elapsed" -lt 120 ] || { kill "$QPID" 2>/dev/null || true; break; }
-              sleep 3; _elapsed=$((_elapsed + 3))
-            done
-          fi
-
-          printf '==> Compressing upgraded image (zstd, with zlib fallback)\n'
-          CANDIDATE="${WORK_DIR}/pfSense-CE-${TO_TAG}.qcow2"
-          if qemu-img convert -O qcow2 -c -o compression_type=zstd \
-              "$WORK_IMG" "$CANDIDATE" 2>/dev/null; then
-            printf '    zstd compression OK\n'
-          else
-            printf '    zstd not supported; falling back to zlib\n'
-            qemu-img convert -O qcow2 -c "$WORK_IMG" "$CANDIDATE"
-          fi
-          [ -s "$CANDIDATE" ] || { echo "::error::compressed candidate image is empty"; exit 1; }
-          echo "CANDIDATE=${CANDIDATE}" >> "$GITHUB_ENV"
-          printf '==> Upgrade candidate ready: %s\n' "$(basename "$CANDIDATE")"
-
-      # ── Step 2: SANITY GATE ─────────────────────────────────────────────────
-      # Boot the CANDIDATE (not the source) and apply every gate check.
-      # ANY miss -> abort; the old GHCR tag is never touched.
-      - name: Sanity gate — boot candidate + run all checks
-        id: sanity
+      # ── pfBlockerNG smoke (non-blocking, post-publish) ──────────────────────
+      # Boots a THROWAWAY copy-on-write overlay of the JUST-PUBLISHED image
+      # (qemu-img create -b), installs pfBlockerNG from the repo, runs
+      # pfblockerng.php update, and digs the sanity control record.
+      # continue-on-error: true + post-publish overlay → can NEVER pollute the
+      # published image and can NEVER fail the refresh job.
+      # The authoritative pfBlockerNG validation is smoke-fanout.yml.
+      - name: pfBlockerNG smoke (non-blocking)
+        continue-on-error: true
         env:
           SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
           SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
@@ -357,46 +241,46 @@ jobs:
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_TOKEN }}
         run: |
           set -eu
-          BOOT_TIMEOUT="${{ inputs.boot_timeout }}"
           LOCAL_DATA_NAME="${{ inputs.sanity_local_data_name }}"
           LOCAL_DATA_IP="${{ inputs.sanity_local_data_ip }}"
-          GUEST_PORT=2223   # different port from upgrade boot (defence-in-depth)
+          IMAGE="${SMOKE_IMAGE}"
+          TAG="${{ inputs.pfsense_version }}"
+          GUEST_PORT=2223
           MAC="BC:24:11:37:9C:AC"
-          CANDIDATE="${CANDIDATE}"
-          TARGET_VERSION="${{ inputs.pfsense_version }}"
-          WORK_DIR="${WORK_DIR}"
+          WORK_DIR="$(mktemp -d)"
+          printf 'SMOKE_WORK_DIR=%s\n' "$WORK_DIR" >> "$GITHUB_ENV"
 
-          printf '==> SANITY GATE: booting candidate image %s\n' "$(basename "$CANDIDATE")"
-          QMP_SOCK_GATE="${RUNNER_TEMP:-/tmp}/pfb-qmp-gate.sock"
+          # Pull the just-published image.
+          printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io \
+            --username "$SMOKE_GHCR_USER" --password-stdin
+          printf '==> [non-blocking smoke] pulling %s:%s\n' "$IMAGE" "$TAG"
+          oras pull "${IMAGE}:${TAG}" --output "$WORK_DIR"
+          BASE_IMG="$(find "$WORK_DIR" -maxdepth 1 -name '*.qcow2' | head -1)"
+          [ -n "$BASE_IMG" ] || { printf '::warning::no qcow2 in pulled artifact %s:%s\n' "$IMAGE" "$TAG"; exit 0; }
 
-          # Boot from the compressed candidate qcow2 (copy-on-write overlay so
-          # the candidate file is never mutated by the sanity run).
-          GATE_OVERLAY="${WORK_DIR}/gate-overlay.qcow2"
-          qemu-img create -b "$CANDIDATE" -F qcow2 -f qcow2 "$GATE_OVERLAY"
+          # Create a throwaway CoW overlay — the published image is never mutated.
+          OVERLAY="${WORK_DIR}/smoke-overlay.qcow2"
+          qemu-img create -b "$BASE_IMG" -F qcow2 -f qcow2 "$OVERLAY"
 
+          printf '==> [non-blocking smoke] booting overlay (guest :%d -> 127.0.0.1:%d)\n' 22 "$GUEST_PORT"
           qemu-system-x86_64 \
             -enable-kvm -machine pc -cpu host \
             -smp 2,sockets=1,cores=2 -m 4096 \
             -device virtio-scsi-pci,id=virtioscsi0 \
-            -drive "file=${GATE_OVERLAY},if=none,id=drive-scsi0,format=qcow2,discard=unmap,detect-zeroes=unmap" \
+            -drive "file=${OVERLAY},if=none,id=drive-scsi0,format=qcow2,discard=unmap,detect-zeroes=unmap" \
             -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
             -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${GUEST_PORT}-:22" \
             -device "virtio-net-pci,mac=${MAC},netdev=net0,id=net0" \
             -display none \
-            -serial "file:${WORK_DIR}/gate-console.log" \
-            -qmp "unix:${QMP_SOCK_GATE},server,nowait" \
-            -pidfile "${WORK_DIR}/gate-qemu.pid" \
+            -serial "file:${WORK_DIR}/smoke-console.log" \
+            -pidfile "${WORK_DIR}/smoke-qemu.pid" \
             -daemonize
-          echo "GATE_QPID_FILE=${WORK_DIR}/gate-qemu.pid" >> "$GITHUB_ENV"
-          echo "QMP_SOCK_GATE=${QMP_SOCK_GATE}" >> "$GITHUB_ENV"
+          SMOKE_QPID="$(cat "${WORK_DIR}/smoke-qemu.pid" 2>/dev/null | tr -d '\r' || true)"
 
-          GATE_FAILED=0
-
-          # [GATE-1+2] SSH answers within BOOT_TIMEOUT seconds.
-          printf '==> [GATE-1/6] VM boots; [GATE-2/6] SSH answers (timeout %ss)\n' "$BOOT_TIMEOUT"
+          # Wait for SSH (180 s).
           _elapsed=0
           SSH_UP=0
-          while [ "$_elapsed" -lt "$BOOT_TIMEOUT" ]; do
+          while [ "$_elapsed" -lt 180 ]; do
             if ssh -p "$GUEST_PORT" -i smoke_key \
                 -o BatchMode=yes -o StrictHostKeyChecking=no \
                 -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
@@ -406,178 +290,70 @@ jobs:
             sleep 5; _elapsed=$((_elapsed + 5))
           done
           if [ "$SSH_UP" -ne 1 ]; then
-            echo "::error::[GATE-1/2] VM did not answer SSH within ${BOOT_TIMEOUT}s"
-            GATE_FAILED=1
-          else
-            echo "    PASS: SSH answered"
+            printf '::warning::[non-blocking smoke] VM did not answer SSH within 180 s\n'
+            [ -n "$SMOKE_QPID" ] && kill "$SMOKE_QPID" 2>/dev/null || true
+            exit 0
           fi
 
-          if [ "$GATE_FAILED" -eq 0 ]; then
-            # Shared SSH helper for subsequent gate checks.
-            run_ssh() {
-              ssh -p "$GUEST_PORT" -i smoke_key \
-                -o BatchMode=yes -o StrictHostKeyChecking=no \
-                -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 \
-                root@127.0.0.1 "$@"
-            }
-
-            # [GATE-3] /etc/version == expected release.
-            # TARGET_VERSION may be "2.8.x" (matrix pattern) or "2.8.1" (exact).
-            # Strip trailing ".x" to get a prefix; accept any version that starts
-            # with it (same matching logic as the build-image resolve-version job).
-            printf '==> [GATE-3/6] /etc/version == %s\n' "$TARGET_VERSION"
-            BOX_VER="$(run_ssh 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)"
-            VERSION_PREFIX="$(printf '%s' "$TARGET_VERSION" | sed 's/\.x$//')"
-            if [ -z "$BOX_VER" ]; then
-              echo "::error::[GATE-3] could not read /etc/version from guest"
-              GATE_FAILED=1
-            else
-              CASE="${BOX_VER#"${VERSION_PREFIX}"}"
-              if [ "$BOX_VER" = "$VERSION_PREFIX" ] || [ "$CASE" != "$BOX_VER" ]; then
-                printf '    PASS: /etc/version = %s (matches %s)\n' "$BOX_VER" "$TARGET_VERSION"
-              else
-                printf '::error::[GATE-3] /etc/version = %s does not match expected %s\n' \
-                  "$BOX_VER" "$TARGET_VERSION"
-                GATE_FAILED=1
-              fi
-            fi
-
-            # [GATE-4] pfctl -sr returns a non-empty ruleset.
-            printf '==> [GATE-4/6] pfctl -sr loads\n'
-            RULES="$(run_ssh '/sbin/pfctl -sr' 2>/dev/null || true)"
-            if [ -n "$RULES" ]; then
-              printf '    PASS: %d rules\n' "$(printf '%s\n' "$RULES" | wc -l | tr -d ' ')"
-            else
-              echo "::error::[GATE-4] pfctl -sr returned no rules"
-              GATE_FAILED=1
-            fi
-
-            # [GATE-5] install-from-repo.sh + pfblockerng.php update exits 0.
-            # install-from-repo.sh needs egress (pkg install of deps); the sanity
-            # VM has internet open (user-net SLIRP with egress). After install, run
-            # the production reload entry point.
-            printf '==> [GATE-5/6] install-from-repo.sh + pfblockerng.php update\n'
-            if scripts/install-from-repo.sh root@127.0.0.1 \
-                --port "$GUEST_PORT" --ssh-key smoke_key; then
-              printf '    install-from-repo.sh OK\n'
-              if run_ssh '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php update'; then
-                printf '    PASS: pfblockerng.php update exited 0\n'
-              else
-                echo "::error::[GATE-5] pfblockerng.php update exited non-zero"
-                GATE_FAILED=1
-              fi
-            else
-              echo "::error::[GATE-5] install-from-repo.sh failed"
-              GATE_FAILED=1
-            fi
-
-            # [GATE-6] dig a baked control record from the guest's own Unbound.
-            # The pfblockerng.php update above may restart Unbound — wait for it
-            # to come back, then inject a local-data record and resolve it on-box
-            # (same pattern as roundtrip.sh check [3/4]).
-            printf '==> [GATE-6/6] dig control record from guest Unbound\n'
-            UB_READY=0
-            _ub_i=0
-            while [ "$_ub_i" -lt 30 ]; do
-              if run_ssh '/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status >/dev/null 2>&1'; then
-                UB_READY=1; break
-              fi
-              _ub_i=$((_ub_i + 1)); sleep 2
-            done
-            if [ "$UB_READY" -ne 1 ]; then
-              echo "::error::[GATE-6] Unbound did not come back up after pfBlockerNG reload"
-              GATE_FAILED=1
-            else
-              # Inject the control record.
-              if run_ssh "/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf local_data '${LOCAL_DATA_NAME}. 3600 IN A ${LOCAL_DATA_IP}'"; then
-                printf '    injected %s -> %s\n' "$LOCAL_DATA_NAME" "$LOCAL_DATA_IP"
-              else
-                echo "::error::[GATE-6] unbound-control local_data injection failed"
-                GATE_FAILED=1
-              fi
-
-              # Resolve on-box (SSH → drill/host on the guest, probing 127.0.0.1:53).
-              DNS_OUT="$(run_ssh "if command -v drill >/dev/null 2>&1; then drill ${LOCAL_DATA_NAME} @127.0.0.1 A; elif command -v host >/dev/null 2>&1; then host -t A ${LOCAL_DATA_NAME} 127.0.0.1; else echo NO_GUEST_DNS_TOOL; fi" 2>/dev/null || true)"
-              if printf '%s' "$DNS_OUT" | grep -q NO_GUEST_DNS_TOOL; then
-                # Best-effort install bind-tools / ldns on the guest.
-                run_ssh 'env ASSUME_ALWAYS_YES=yes pkg install -y bind-tools ldns 2>/dev/null' || true
-                DNS_OUT="$(run_ssh "if command -v drill >/dev/null 2>&1; then drill ${LOCAL_DATA_NAME} @127.0.0.1 A; elif command -v host >/dev/null 2>&1; then host -t A ${LOCAL_DATA_NAME} 127.0.0.1; else echo NO_GUEST_DNS_TOOL_AFTER_INSTALL; fi" 2>/dev/null || true)"
-              fi
-              if printf '%s' "$DNS_OUT" | grep -qw "$LOCAL_DATA_IP"; then
-                printf '    PASS: guest Unbound resolved %s -> %s\n' "$LOCAL_DATA_NAME" "$LOCAL_DATA_IP"
-              else
-                printf '::error::[GATE-6] guest Unbound did not return %s for %s\n' \
-                  "$LOCAL_DATA_IP" "$LOCAL_DATA_NAME"
-                printf '%s\n' "$DNS_OUT" | sed 's/^/      /' >&2
-                GATE_FAILED=1
-              fi
-            fi
-          fi
-
-          # Take a screendump before shutting down on failure.
-          if [ "$GATE_FAILED" -ne 0 ] && python3 tests/smoke/screendump.py \
-              "$QMP_SOCK_GATE" "${WORK_DIR}/gate-screen.png" 2>/dev/null; then
-            echo "    screendump saved to gate-screen.png"
-          fi
-
-          # Shut down the gate VM.
-          GATE_QPID="$(cat "${WORK_DIR}/gate-qemu.pid" 2>/dev/null | tr -d '\r' || true)"
-          if [ -n "$GATE_QPID" ]; then
+          run_ssh() {
             ssh -p "$GUEST_PORT" -i smoke_key \
               -o BatchMode=yes -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
-              root@127.0.0.1 '/sbin/shutdown -p now' 2>/dev/null || true
+              -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 \
+              root@127.0.0.1 "$@"
+          }
+
+          # Install pfBlockerNG from the repo (egress open on SLIRP net).
+          printf '==> [non-blocking smoke] install-from-repo.sh\n'
+          scripts/install-from-repo.sh root@127.0.0.1 \
+            --port "$GUEST_PORT" --ssh-key smoke_key || \
+            { printf '::warning::[non-blocking smoke] install-from-repo.sh failed\n'; \
+              [ -n "$SMOKE_QPID" ] && kill "$SMOKE_QPID" 2>/dev/null || true; exit 0; }
+
+          # pfblockerng.php update.
+          printf '==> [non-blocking smoke] pfblockerng.php update\n'
+          run_ssh '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php update' || \
+            { printf '::warning::[non-blocking smoke] pfblockerng.php update returned non-zero\n'; \
+              [ -n "$SMOKE_QPID" ] && kill "$SMOKE_QPID" 2>/dev/null || true; exit 0; }
+
+          # Dig the sanity control record.
+          printf '==> [non-blocking smoke] waiting for Unbound\n'
+          UB_READY=0
+          _ub_i=0
+          while [ "$_ub_i" -lt 30 ]; do
+            if run_ssh '/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status >/dev/null 2>&1'; then
+              UB_READY=1; break
+            fi
+            _ub_i=$((_ub_i + 1)); sleep 2
+          done
+          if [ "$UB_READY" -ne 1 ]; then
+            printf '::warning::[non-blocking smoke] Unbound did not come back up\n'
+            [ -n "$SMOKE_QPID" ] && kill "$SMOKE_QPID" 2>/dev/null || true
+            exit 0
+          fi
+
+          run_ssh "/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf local_data '${LOCAL_DATA_NAME}. 3600 IN A ${LOCAL_DATA_IP}'" || \
+            { printf '::warning::[non-blocking smoke] unbound-control local_data injection failed\n'; \
+              [ -n "$SMOKE_QPID" ] && kill "$SMOKE_QPID" 2>/dev/null || true; exit 0; }
+
+          DNS_OUT="$(run_ssh "if command -v drill >/dev/null 2>&1; then drill ${LOCAL_DATA_NAME} @127.0.0.1 A; elif command -v host >/dev/null 2>&1; then host -t A ${LOCAL_DATA_NAME} 127.0.0.1; else echo NO_GUEST_DNS_TOOL; fi" 2>/dev/null || true)"
+          if printf '%s' "$DNS_OUT" | grep -qw "$LOCAL_DATA_IP"; then
+            printf '==> [non-blocking smoke] PASS: guest Unbound resolved %s -> %s\n' \
+              "$LOCAL_DATA_NAME" "$LOCAL_DATA_IP"
+          else
+            printf '::warning::[non-blocking smoke] guest Unbound did not return %s for %s\n' \
+              "$LOCAL_DATA_IP" "$LOCAL_DATA_NAME"
+            printf '%s\n' "$DNS_OUT" | sed 's/^/      /' >&2
+          fi
+
+          # Shut down the smoke VM.
+          run_ssh '/sbin/shutdown -p now' 2>/dev/null || true
+          if [ -n "$SMOKE_QPID" ]; then
             _elapsed=0
-            while kill -0 "$GATE_QPID" 2>/dev/null; do
-              [ "$_elapsed" -lt 60 ] || { kill "$GATE_QPID" 2>/dev/null || true; break; }
+            while kill -0 "$SMOKE_QPID" 2>/dev/null; do
+              [ "$_elapsed" -lt 60 ] || { kill "$SMOKE_QPID" 2>/dev/null || true; break; }
               sleep 3; _elapsed=$((_elapsed + 3))
             done
           fi
-
-          if [ "$GATE_FAILED" -ne 0 ]; then
-            echo "::error::SANITY GATE FAILED — candidate image will NOT be published. GHCR tag ${{ inputs.pfsense_version }} is untouched. Manual fallback: scripts/image-publish.sh (see ADR-09 §2)."
-            exit 1
-          fi
-          echo "==> SANITY GATE PASSED — proceeding to publish"
-
-      # ── Step 3: PUBLISH ON PASS ONLY ───────────────────────────────────────
-      # The sanity gate job completed without error. Push the candidate qcow2
-      # to GHCR as the new version tag. The old tag is always kept.
-      - name: Publish candidate image (gate PASSED)
-        if: success()
-        env:
-          SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
-          SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER }}
-          SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_TOKEN }}
-        run: |
-          set -eu
-          IMAGE="${SMOKE_IMAGE}"
-          TAG="${{ inputs.pfsense_version }}"
-          CANDIDATE="${CANDIDATE}"
-
-          printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io \
-            --username "$SMOKE_GHCR_USER" --password-stdin
-
-          # Refuse to clobber an existing tag (keep old snapshots; each tag is
-          # its own immutable snapshot per ADR-04 §2 retention policy).
-          if oras manifest fetch "${IMAGE}:${TAG}" >/dev/null 2>&1; then
-            echo "::error::Tag ${IMAGE}:${TAG} already exists. Use build-image.yml with --force if you need to overwrite an existing tag (only for intentional re-seeds). Old tag is kept."
-            exit 1
-          fi
-
-          printf '==> Publishing %s:%s\n' "$IMAGE" "$TAG"
-          (
-            cd "$(dirname "$CANDIDATE")"
-            oras push \
-              --artifact-type application/vnd.netgate.pfsense-ce.disk.v1 \
-              --annotation "org.opencontainers.image.title=$(basename "$CANDIDATE")" \
-              --annotation "org.opencontainers.image.version=${TAG}" \
-              --annotation "org.opencontainers.image.description=pfSense CE ${TAG} pfBlockerNG smoke-test base (upgraded from ${{ needs.resolve-from.outputs.from_tag }}; sanity-gated)" \
-              "${IMAGE}:${TAG}" \
-              "$(basename "$CANDIDATE"):application/vnd.qemu.qcow2"
-          )
-          printf '==> Published %s:%s (source tag %s kept)\n' \
-            "$IMAGE" "$TAG" "${{ needs.resolve-from.outputs.from_tag }}"
 
       - name: Upload diagnostics
         if: always()
@@ -585,9 +361,6 @@ jobs:
         with:
           name: image-refresh-diagnostics-${{ inputs.pfsense_version }}
           path: |
-            ${{ env.WORK_DIR }}/console.log
-            ${{ env.WORK_DIR }}/upgrade.log
-            ${{ env.WORK_DIR }}/gate-console.log
-            ${{ env.WORK_DIR }}/gate-screen.png
+            ${{ env.SMOKE_WORK_DIR }}/smoke-console.log
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,19 @@ name: Release
 # Tags pushed from 'devel' become pre-releases; tags from 'main' become
 # full releases.  After publishing the GitHub Release, a PR is opened
 # on pfsense/FreeBSD-ports to update the corresponding port's GH_TAGNAME.
+#
+# workflow_dispatch allows a dry-run (point at an existing tag via
+# workflow_dispatch + the tag ref) and to select the .pkg builder.
 on:
   push:
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'
+  workflow_dispatch:
+    inputs:
+      builder:
+        description: "Builder for .pkg artifacts: 'portable' (Linux, fast, default) or 'freebsd' (FreeBSD VM, fidelity oracle)"
+        required: false
+        default: "portable"
 
 # Least-privilege default; jobs that need more elevate explicitly below
 # (release: contents:write to publish; verify-checks: checks:read to read the
@@ -78,6 +87,74 @@ jobs:
     with:
       tier: all
     secrets: inherit
+
+  # ── 1c. Read version matrix ──────────────────────────────────────────────
+  # Read the supported-versions matrix from ci-metadata and compute a
+  # deduped build matrix (one entry per distinct FreeBSD major — one .pkg
+  # per ABI). Runs in parallel with verify-checks; build-pkgs needs both.
+  read-matrix:
+    name: Read version matrix
+    runs-on: ubuntu-latest
+    outputs:
+      build_matrix: ${{ steps.dedupe.outputs.build_matrix }}
+      pkg_channel: ${{ steps.channel.outputs.pkg_channel }}
+      first_freebsd_version: ${{ steps.dedupe.outputs.first_freebsd_version }}
+      first_freebsd_major: ${{ steps.dedupe.outputs.first_freebsd_major }}
+      first_php_version: ${{ steps.dedupe.outputs.first_php_version }}
+      first_py_flavor: ${{ steps.dedupe.outputs.first_py_flavor }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # need full history to reach ci-metadata ref and tag
+
+      - name: Detect pkg channel from tag
+        id: channel
+        # Tags from devel are *-devel; tags from main have no -devel suffix.
+        # The channel drives which port we build: devel or stable.
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          case "$TAG" in
+            *-devel) PKG_CHANNEL="devel" ;;
+            *)       PKG_CHANNEL="stable" ;;
+          esac
+          echo "pkg_channel=${PKG_CHANNEL}" >> "$GITHUB_OUTPUT"
+          echo "Tag: ${TAG}  →  pkg channel: ${PKG_CHANNEL}"
+
+      - name: Read matrix from ci-metadata
+        id: matrices
+        uses: ./.github/actions/read-version-matrix
+
+      - name: Dedupe build matrix by freebsd_major
+        id: dedupe
+        # For each distinct freebsd_major, select the first CE entry (preferred);
+        # if no CE entry exists for that major, fall back to the first Plus entry.
+        # Result: one build entry per distinct FreeBSD major.
+        #
+        # Also emits first_* scalar outputs for the FreeBSD-builder reusable-workflow
+        # call (which cannot use strategy.matrix alongside uses:) — these are the
+        # first deduped entry's fields. Today there is exactly one deduped entry
+        # (both CE 2.8.x and Plus 25.03 share FreeBSD 15); when a second major is
+        # added, build-pkgs-portable's inline loop handles all of them, and the
+        # FreeBSD-builder path would need extending to multiple calls.
+        run: |
+          DEDUPED=$(printf '%s' '${{ steps.matrices.outputs.build_matrix }}' \
+            | jq -c '
+                group_by(.freebsd_major)
+                | map(
+                    (map(select(.channel == "CE")) | first)
+                    // first
+                  )
+              ')
+          printf 'build_matrix=%s\n' "$DEDUPED" >> "$GITHUB_OUTPUT"
+          echo "Deduped build matrix: $DEDUPED"
+
+          # Scalar outputs for the first (currently only) deduped entry
+          printf '%s\n' "$DEDUPED" | jq -r '
+            "first_freebsd_version=\(.[0].freebsd_version)",
+            "first_freebsd_major=\(.[0].freebsd_major)",
+            "first_php_version=\(.[0].php_version)",
+            "first_py_flavor=\(.[0].py_flavor)"
+          ' >> "$GITHUB_OUTPUT"
 
   # ── 2. Release ───────────────────────────────────────────────────────────
   release:
@@ -203,6 +280,228 @@ jobs:
           body: ${{ steps.changelog.outputs.body }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
           files: ${{ env.ARCHIVE }}
+
+  # ── 2b. Build .pkg artifacts (portable Linux builder — DEFAULT) ──────────
+  # Builds one .pkg per distinct FreeBSD major from the deduped matrix.
+  # Runs the portable Linux builder steps inline (no FreeBSD VM, ~3 min/entry).
+  # Runs unless `builder: freebsd` is explicitly selected on workflow_dispatch.
+  #
+  # GitHub Actions does not allow strategy.matrix on a job that uses a
+  # reusable workflow (uses:), so we run each entry sequentially in one job,
+  # uploading one artifact per entry with a unique name (pfBlockerNG-pkg-<major>).
+  #
+  # A build failure surfaces clearly (the job goes red) but MUST NOT break
+  # ports-pr: ports-pr needs only `release`, never build-pkgs-*.
+  # attach-pkgs absorbs the failure with `if: always() && ...` (below).
+  build-pkgs-portable:
+    name: build .pkg artifacts (portable Linux)
+    runs-on: ubuntu-latest
+    needs: [verify-checks, read-matrix]
+    timeout-minutes: 30
+    # Default path: run unless the operator explicitly selected the FreeBSD builder.
+    # On tag push, github.event.inputs.builder is empty — defaults to portable.
+    if: github.event.inputs.builder != 'freebsd'
+
+    steps:
+      - name: Checkout the tagged source
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Ensure zstd encoder is present
+        run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
+
+      - name: Build one .pkg per FreeBSD major (portable)
+        env:
+          BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
+          PKG_CHANNEL: ${{ needs.read-matrix.outputs.pkg_channel }}
+        run: |
+          set -eu
+          mkdir -p out
+
+          printf '%s\n' "$BUILD_MATRIX" \
+            | jq -c '.[]' \
+            | while IFS= read -r ENTRY; do
+                MAJOR=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_major')
+                FREEBSD_VERSION=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_version')
+                PHP=$(printf '%s\n' "$ENTRY" | jq -r '.php_version')
+                PY=$(printf '%s\n' "$ENTRY" | jq -r '.py_flavor')
+                ABI="FreeBSD:${MAJOR}:amd64"
+
+                echo "--- Building .pkg for FreeBSD ${MAJOR} (${FREEBSD_VERSION}), PHP ${PHP}, ${PY} ---"
+
+                PORTS_DIR="${RUNNER_TEMP}/ports-${MAJOR}"
+                git clone --depth 1 -b pfblockerng/use-github \
+                  "https://github.com/andrebrait/FreeBSD-ports" \
+                  "$PORTS_DIR"
+
+                PKG_OUT="out/major-${MAJOR}"
+                mkdir -p "$PKG_OUT"
+                python3 scripts/build-pkg-portable.py \
+                  --ports "$PORTS_DIR" \
+                  --channel "$PKG_CHANNEL" \
+                  --local-src . \
+                  --abi "$ABI" \
+                  --py-flavor "$PY" \
+                  --php "$PHP" \
+                  --out "$PKG_OUT"
+
+                echo "Built for FreeBSD ${MAJOR}:"
+                ls -l "${PKG_OUT}"/*.pkg
+
+                # Rename to embed FreeBSD major before upload
+                for f in "${PKG_OUT}"/*.pkg; do
+                  [ -f "$f" ] || continue
+                  BASE=$(basename "$f" .pkg)
+                  mv "$f" "${PKG_OUT}/${BASE}-FreeBSD-${MAJOR}.pkg"
+                  echo "Renamed: $(basename "$f") -> ${BASE}-FreeBSD-${MAJOR}.pkg"
+                done
+              done
+
+          echo "All .pkg artifacts:"
+          find out -name "*.pkg" -exec ls -l {} \;
+
+      - name: Upload .pkg artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pfBlockerNG-release-pkgs
+          path: out/**/*.pkg
+          if-no-files-found: error
+          retention-days: 7
+
+  # ── 2b′. Build .pkg artifacts (FreeBSD make-package builder — FALLBACK) ──
+  # Calls build-pkg.yml (the FreeBSD make-package VM builder, ~25 min).
+  # Runs only when `builder: freebsd` is selected on workflow_dispatch.
+  # "Linux by default, FreeBSD if we fuck up."
+  #
+  # One of build-pkgs-portable / build-pkgs-freebsd always runs, never both.
+  # build-pkgs-portable uploads "pfBlockerNG-release-pkgs"; build-pkgs-freebsd
+  # (via build-pkg.yml) uploads "pfBlockerNG-pkg". attach-pkgs downloads both
+  # artifact names (continue-on-error) and takes whichever one is present.
+  # A skipped job satisfies its `needs` entry just like a successful one, so
+  # attach-pkgs is never blocked by the one that didn't run.
+  #
+  # NOTE: GitHub Actions does not allow strategy.matrix alongside uses: for
+  # reusable workflows. Today's deduped matrix has exactly one entry (FreeBSD 15);
+  # first_* scalar outputs from read-matrix are used directly. When a second
+  # FreeBSD major is added, extend this to multiple jobs or use the inline approach
+  # of build-pkgs-portable.
+  build-pkgs-freebsd:
+    name: build .pkg artifacts (FreeBSD VM)
+    needs: [verify-checks, read-matrix]
+    if: github.event.inputs.builder == 'freebsd'
+    uses: ./.github/workflows/build-pkg.yml
+    with:
+      freebsd_version: ${{ needs.read-matrix.outputs.first_freebsd_version }}
+      channel: ${{ needs.read-matrix.outputs.pkg_channel }}
+      php_version: ${{ needs.read-matrix.outputs.first_php_version }}
+
+  # ── 2c. Attach .pkg artifacts to the GitHub Release ──────────────────────
+  # Downloads the .pkg from every build-pkgs leg (even failed ones — we
+  # skip missing downloads), renames each to embed the FreeBSD major for
+  # unambiguity, and appends them to the already-published GitHub Release.
+  #
+  # DEPENDENCY EDGES — WHY ports-pr IS INTACT:
+  #   ports-pr  needs: [release]              ← never needs build-pkgs
+  #   attach-pkgs needs: [release, build-pkgs] ← waits for both, if: always()
+  #
+  # A build-pkgs failure makes attach-pkgs skip that leg's artifact but
+  # attach the rest (or skip entirely if release also failed). ports-pr is
+  # completely unblocked by any build outcome — it runs as soon as `release`
+  # succeeds, in parallel with attach-pkgs.
+  attach-pkgs:
+    name: Attach .pkg artifacts to Release
+    runs-on: ubuntu-latest
+    needs: [release, build-pkgs-portable, build-pkgs-freebsd, read-matrix]
+    # Run whenever release succeeded, regardless of build outcome.
+    # One of build-pkgs-portable / build-pkgs-freebsd will always be skipped
+    # (they are mutually exclusive on the `builder` input); a skipped job
+    # satisfies `needs` just as a success does. Build failures surface as red
+    # legs but do not prevent attach-pkgs from appending whatever artifacts
+    # did build — or from completing with a warning if nothing built.
+    if: always() && needs.release.result == 'success'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download .pkg artifacts from portable builder
+        # The portable builder uploads as "pfBlockerNG-release-pkgs"; artifacts
+        # already have -FreeBSD-<major> in the filename (renamed before upload).
+        uses: actions/download-artifact@v4
+        with:
+          name: pfBlockerNG-release-pkgs
+          path: pkgs/
+        continue-on-error: true
+
+      - name: Download .pkg artifacts from FreeBSD builder
+        # The FreeBSD reusable workflow (build-pkg.yml) uploads as "pfBlockerNG-pkg";
+        # filename does NOT yet have -FreeBSD-<major> (renamed in the next step).
+        uses: actions/download-artifact@v4
+        with:
+          name: pfBlockerNG-pkg
+          path: pkgs/
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Rename untagged .pkg files to embed FreeBSD major
+        id: rename
+        # The portable builder already renames files before uploading
+        # (pfSense-pkg-pfBlockerNG-devel-3.2.16-FreeBSD-15.pkg). The FreeBSD
+        # reusable workflow emits an untagged name (pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg).
+        # Rename any untagged .pkg using the first_freebsd_major from the matrix.
+        # Today there is only one FreeBSD major (15), so this is always a 1:1 rename.
+        run: |
+          set -eu
+          FIRST_MAJOR="${{ needs.read-matrix.outputs.first_freebsd_major }}"
+
+          if ! ls pkgs/*.pkg 2>/dev/null | head -1 | grep -q .; then
+            echo "No .pkg artifacts to rename"
+            exit 0
+          fi
+
+          for f in pkgs/*.pkg; do
+            [ -f "$f" ] || continue
+            BASE=$(basename "$f" .pkg)
+            case "$BASE" in
+              *-FreeBSD-*) echo "Already tagged: $(basename "$f")"; continue ;;
+            esac
+            DEST="pkgs/${BASE}-FreeBSD-${FIRST_MAJOR}.pkg"
+            mv "$f" "$DEST"
+            echo "Renamed: $(basename "$f") -> $(basename "$DEST")"
+          done
+
+          ls -l pkgs/ || echo "No .pkg files found"
+
+      - name: Append .pkg files to the GitHub Release
+        # Upload the renamed .pkg files to the already-published release using
+        # `gh release upload`. This is idempotent: re-uploading an asset with
+        # --clobber replaces it. If pkgs/ has no .pkg files (all builds failed),
+        # this step emits a warning and succeeds without uploading anything.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          TAG="${GITHUB_REF_NAME}"
+
+          PKGS=$(find pkgs -name "*.pkg" 2>/dev/null | head -20)
+          if [ -z "$PKGS" ]; then
+            echo "::warning::No .pkg artifacts to attach — all build-pkgs legs may have failed."
+            echo "Check the build-pkgs-portable / build-pkgs-freebsd job logs for details."
+            exit 0
+          fi
+
+          for f in pkgs/*.pkg; do
+            [ -f "$f" ] || continue
+            echo "Uploading: $(basename "$f")"
+            gh release upload "$TAG" "$f" --clobber
+          done
+          echo "All .pkg artifacts attached to release ${TAG}"
 
   # ── 3. Open PR on pfsense/FreeBSD-ports ──────────────────────────────────
   ports-pr:

--- a/.github/workflows/smoke-fanout.yml
+++ b/.github/workflows/smoke-fanout.yml
@@ -1,0 +1,194 @@
+name: Smoke Fan-out (all CE, ADR-09 P6)
+
+# Fan the ADR-04 smoke suite across every ci:true CE image in parallel.
+# NEVER runs Plus images (ci:false entries are excluded by the CI matrix filter;
+# an additional guard below aborts any leg that carries channel != CE or ci != true).
+#
+# Workflow name + no-version-input dispatch contract (Phase 4 / RESULTS/04):
+#   Workflow file name:  .github/workflows/smoke-fanout.yml
+#   Trigger:            workflow_dispatch (no version inputs)
+#   Behaviour:          reads ci_matrix from read-version-matrix action,
+#                       expands to strategy.matrix (fail-fast: false),
+#                       runs ADR-04 smoke suite per leg (smoke.yml callee),
+#                       gating job needs: all legs (AND gate).
+#
+# AND-gate semantics (GitHub Actions needs.*.result):
+#   - All legs pass  → smoke job result = 'success' → gate = green
+#   - Any leg fails  → smoke job result = 'failure' → gate = red
+#   - Zero legs      → smoke job is skipped         → gate sees 'skipped' → red
+#   - Cancelled legs → smoke job result = 'cancelled' → gate = red
+# The gate job uses `if: always()` so it runs regardless of the matrix outcome,
+# and it hard-fails unless needs.smoke.result == 'success'.
+#
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ INVARIANT: this workflow NEVER commits to or writes any branch.     │
+# │ Plus is NEVER run (ci:false entries are excluded at the matrix     │
+# │ read step and double-guarded in the smoke job itself).             │
+# └─────────────────────────────────────────────────────────────────────┘
+
+on:
+  # Manual trigger — dispatched by version-tracker.yml (Step C) with no inputs.
+  # Also usable for ad-hoc full-suite runs.
+  workflow_dispatch:
+
+  # Called by other workflows (e.g. release.yml) without version inputs.
+  workflow_call:
+
+  # Daily nightly run — runs the full CE suite every night.
+  schedule:
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  # ── 1. Read CI matrix (ci:true CE entries only) ──────────────────────────────
+  #
+  # Emits `ci_matrix` (JSON array) as the `include` list for the smoke job's
+  # strategy.matrix.  The reader already filters to ci:true CE entries; Plus
+  # entries (ci:false) are NEVER present in ci_matrix.
+  prepare:
+    name: Read CI matrix
+    runs-on: ubuntu-latest
+    outputs:
+      ci_matrix: ${{ steps.read.outputs.ci_matrix }}
+      leg_count: ${{ steps.count.outputs.leg_count }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # reach the ci-metadata orphan ref
+
+      - name: Read CI matrix from ci-metadata
+        id: read
+        uses: ./.github/actions/read-version-matrix
+
+      - name: Log CI matrix
+        run: |
+          echo "=== CI matrix (ci:true CE entries — fed to smoke strategy.matrix) ==="
+          printf '%s\n' '${{ steps.read.outputs.ci_matrix }}' | jq .
+
+      - name: Count legs + assert no Plus entries
+        id: count
+        env:
+          CI_MATRIX: ${{ steps.read.outputs.ci_matrix }}
+        run: |
+          set -eu
+          COUNT=$(printf '%s\n' "$CI_MATRIX" | jq 'length')
+          echo "leg_count=${COUNT}" >> "$GITHUB_OUTPUT"
+          echo "Legs in CI matrix: ${COUNT}"
+
+          # PLUS GUARD: assert that every entry in the CI matrix is a CE entry
+          # with ci=true.  The matrix reader already filters to these; this step
+          # is a hard fail-safe so a schema change can never silently let Plus in.
+          PLUS_COUNT=$(printf '%s\n' "$CI_MATRIX" \
+            | jq '[.[] | select(.channel != "CE" or .ci != true)] | length')
+          if [ "$PLUS_COUNT" -ne 0 ]; then
+            echo "::error::PLUS GUARD: CI matrix contains ${PLUS_COUNT} non-CE or ci:false entries — aborting."
+            printf '%s\n' "$CI_MATRIX" \
+              | jq '.[] | select(.channel != "CE" or .ci != true)'
+            exit 1
+          fi
+          echo "Plus guard: OK — all ${COUNT} leg(s) are CE ci:true."
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::warning::CI matrix is empty — no CE images to smoke-test."
+          fi
+
+  # ── 2. Per-CE smoke run (parallel, fail-fast: false) ─────────────────────────
+  #
+  # One leg per ci:true CE entry.  Each leg calls the ADR-04 smoke workflow
+  # (smoke.yml) as a reusable callee, passing the per-version image ref.
+  # `fail-fast: false` ensures EVERY leg runs to completion regardless of
+  # whether another leg has already failed.
+  #
+  # IMAGE REF RESOLUTION:
+  # The CI matrix entry carries pfsense_version (e.g. "2.8.x").  The GHCR
+  # image tag for that version is:
+  #   ghcr.io/<owner>/pfsense-ce:<pfsense_version>
+  # The SMOKE_IMAGE_REF secret/variable used by smoke.yml can be overridden
+  # per-leg via the `image_ref` input — we pass the version-specific tag here.
+  # If SMOKE_IMAGE_BASE_URL is set (org/repo variable), that base is used;
+  # otherwise it defaults to the repository owner's GHCR namespace.
+  smoke:
+    name: Smoke (${{ matrix.pfsense_version }})
+    needs: prepare
+    # Run even if prepare had warnings; skip only if prepare hard-failed.
+    if: needs.prepare.outputs.leg_count != '0'
+    strategy:
+      fail-fast: false   # REQUIRED: all legs run to completion; no cancellation on failure
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.ci_matrix) }}
+    uses: ./.github/workflows/smoke.yml
+    with:
+      # Construct the per-version GHCR image ref.
+      # Format: ghcr.io/<owner>/pfsense-ce:<pfsense_version>
+      # e.g.   ghcr.io/myorg/pfsense-ce:2.8.x
+      # The smoke.yml callee falls back to SMOKE_IMAGE_REF secret/variable when
+      # image_ref is blank; passing a version-specific tag here overrides that.
+      image_ref: "ghcr.io/${{ github.repository_owner }}/pfsense-ce:${{ matrix.pfsense_version }}"
+    secrets: inherit
+
+  # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────
+  #
+  # This is the REQUIRED STATUS check.  It runs regardless of the smoke matrix
+  # outcome (if: always()) and hard-fails unless every leg passed.
+  #
+  # GitHub Actions matrix semantics (verified):
+  #   needs.smoke.result == 'success'   → all legs passed
+  #   needs.smoke.result == 'failure'   → at least one leg failed
+  #   needs.smoke.result == 'skipped'   → zero legs (empty matrix)
+  #   needs.smoke.result == 'cancelled' → run was cancelled
+  #
+  # The gate fails on anything other than 'success' — including zero legs (skipped)
+  # and cancelled (which can hide failures).  This gives the AND of all legs with
+  # no partial-pass escape hatch.
+  all-smoke-passed:
+    name: All smoke legs passed (AND gate)
+    runs-on: ubuntu-latest
+    needs: [prepare, smoke]
+    if: always()   # run even if smoke failed/skipped/cancelled
+    steps:
+      - name: Assert every smoke leg passed
+        env:
+          SMOKE_RESULT: ${{ needs.smoke.result }}
+          LEG_COUNT: ${{ needs.prepare.outputs.leg_count }}
+        run: |
+          set -eu
+          echo "Smoke matrix result : ${SMOKE_RESULT}"
+          echo "CI matrix leg count : ${LEG_COUNT}"
+          echo ""
+
+          # Zero-leg guard: an empty matrix skips the smoke job (result='skipped').
+          # Treat this as a gate failure — the matrix should always have at least
+          # one CE entry.  A skipped gate silently hides a matrix-read problem.
+          if [ "${LEG_COUNT:-0}" -eq 0 ]; then
+            echo "::error::AND gate FAIL — CI matrix was empty (zero legs); nothing was tested."
+            exit 1
+          fi
+
+          # Main gate: the smoke job result must be 'success'.
+          # 'failure' = at least one leg failed.
+          # 'skipped' = all legs were skipped (should not happen if leg_count > 0).
+          # 'cancelled' = run was cancelled (masks potential failures).
+          case "$SMOKE_RESULT" in
+            success)
+              echo "AND gate PASS — all ${LEG_COUNT} smoke leg(s) succeeded."
+              ;;
+            failure)
+              echo "::error::AND gate FAIL — one or more smoke legs failed (result='failure')."
+              exit 1
+              ;;
+            skipped)
+              echo "::error::AND gate FAIL — smoke job was skipped despite leg_count=${LEG_COUNT}."
+              exit 1
+              ;;
+            cancelled)
+              echo "::error::AND gate FAIL — smoke job was cancelled; result is indeterminate."
+              exit 1
+              ;;
+            *)
+              echo "::error::AND gate FAIL — unexpected smoke result '${SMOKE_RESULT}'."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -1,0 +1,134 @@
+name: Self-test — version matrix reader
+
+# Verify that scripts/read-version-matrix.sh correctly parses the
+# supported-versions.json on ci-metadata and emits the expected BUILD
+# and CI matrices. workflow_dispatch only — this is a development/
+# debugging aid, not a PR gate. (ADR-09 Phase 2)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-reader:
+    name: Read + print supported-version matrices
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout (for scripts/read-version-matrix.sh)
+        uses: actions/checkout@v6
+
+      - name: Read matrices via composite action
+        id: matrices
+        uses: ./.github/actions/read-version-matrix
+
+      - name: Print BUILD matrix (all entries)
+        env:
+          BUILD_MATRIX: ${{ steps.matrices.outputs.build_matrix }}
+        run: |
+          set -eu
+          printf '=== BUILD matrix (all entries, carrying (freebsd_version, php_version) pair) ===\n'
+          printf '%s' "$BUILD_MATRIX" | jq .
+          COUNT="$(printf '%s' "$BUILD_MATRIX" | jq 'length')"
+          printf '\n%s entries total\n' "$COUNT"
+
+      - name: Print CI matrix (ci:true CE entries only)
+        env:
+          CI_MATRIX: ${{ steps.matrices.outputs.ci_matrix }}
+        run: |
+          set -eu
+          printf '=== CI matrix (ci:true CE entries only — fed to smoke fan-out) ===\n'
+          printf '%s' "$CI_MATRIX" | jq .
+          COUNT="$(printf '%s' "$CI_MATRIX" | jq 'length')"
+          printf '\n%s CI entries\n' "$COUNT"
+
+      - name: Verify build matrix contains expected CE 2.8.x entry
+        env:
+          BUILD_MATRIX: ${{ steps.matrices.outputs.build_matrix }}
+        run: |
+          set -eu
+          # Sanity: the seed must have the 2.8.x CE entry with FreeBSD 15 + PHP 8.3.
+          ENTRY="$(printf '%s' "$BUILD_MATRIX" | jq -e '
+            .[] | select(.channel == "CE" and .pfsense_version == "2.8.x")
+          ')" || {
+            printf '::error::BUILD matrix is missing the expected CE 2.8.x entry\n'
+            exit 1
+          }
+          FB="$(printf '%s' "$ENTRY" | jq -r '.freebsd_version')"
+          PHP="$(printf '%s' "$ENTRY" | jq -r '.php_version')"
+          CI_FLAG="$(printf '%s' "$ENTRY" | jq -r '.ci')"
+          if [ "$FB" != "15.0-RELEASE" ]; then
+            printf '::error::CE 2.8.x freebsd_version expected 15.0-RELEASE, got %s\n' "$FB"
+            exit 1
+          fi
+          if [ "$PHP" != "8.3" ]; then
+            printf '::error::CE 2.8.x php_version expected 8.3, got %s\n' "$PHP"
+            exit 1
+          fi
+          if [ "$CI_FLAG" != "true" ]; then
+            printf '::error::CE 2.8.x ci expected true, got %s\n' "$CI_FLAG"
+            exit 1
+          fi
+          printf 'CE 2.8.x entry OK: FreeBSD %s, PHP %s, ci=%s\n' "$FB" "$PHP" "$CI_FLAG"
+
+      - name: Verify Plus entry is ci:false
+        env:
+          BUILD_MATRIX: ${{ steps.matrices.outputs.build_matrix }}
+        run: |
+          set -eu
+          # Plus entries must never be in CI.
+          PLUS_CI="$(printf '%s' "$BUILD_MATRIX" | jq '[.[] | select(.channel == "Plus" and .ci == true)] | length')"
+          if [ "$PLUS_CI" -ne 0 ]; then
+            printf '::error::%s Plus entries have ci=true — Plus must always be ci:false\n' "$PLUS_CI"
+            exit 1
+          fi
+          printf 'Plus entries all have ci=false: OK\n'
+
+      - name: Verify CI matrix contains only CE entries
+        env:
+          CI_MATRIX: ${{ steps.matrices.outputs.ci_matrix }}
+        run: |
+          set -eu
+          NON_CE="$(printf '%s' "$CI_MATRIX" | jq '[.[] | select(.channel != "CE")] | length')"
+          if [ "$NON_CE" -ne 0 ]; then
+            printf '::error::CI matrix contains %s non-CE entries — only CE should be in CI\n' "$NON_CE"
+            exit 1
+          fi
+          printf 'CI matrix contains only CE entries: OK\n'
+
+      - name: Verify reject-unknown behaviour (simulate unknown version lookup)
+        run: |
+          set -eu
+          # The reject-unknown contract: looking up a version not in the matrix
+          # must fail non-zero. Simulate it by running the lookup script with a
+          # clearly unknown version string.
+          MATRIX_JSON="$(git fetch origin ci-metadata && git show origin/ci-metadata:supported-versions.json)"
+          UNKNOWN="9.9.9"
+          MATCH="$(printf '%s' "$MATRIX_JSON" | jq -e --arg ver "$UNKNOWN" '
+            .versions[]
+            | select(.channel == "CE")
+            | . as $e
+            | select(
+                ($e.pfsense_version | endswith(".x") and ($ver | startswith($e.pfsense_version[:-1])))
+                or $e.pfsense_version == $ver
+              )
+          ' 2>/dev/null | jq -s '.[0] // empty')" || true
+
+          if [ -n "$MATCH" ] && [ "$MATCH" != "null" ]; then
+            printf '::error::lookup unexpectedly matched unknown version %s: %s\n' "$UNKNOWN" "$MATCH"
+            exit 1
+          fi
+          printf 'reject-unknown contract verified: version %s correctly returns no match\n' "$UNKNOWN"
+
+      - name: Summary
+        env:
+          BUILD_MATRIX: ${{ steps.matrices.outputs.build_matrix }}
+          CI_MATRIX: ${{ steps.matrices.outputs.ci_matrix }}
+        run: |
+          set -eu
+          BUILD_COUNT="$(printf '%s' "$BUILD_MATRIX" | jq 'length')"
+          CI_COUNT="$(printf '%s' "$CI_MATRIX" | jq 'length')"
+          printf '\nAll assertions passed.\n'
+          printf 'BUILD matrix: %s entries | CI matrix: %s entries\n' "$BUILD_COUNT" "$CI_COUNT"

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -1,0 +1,437 @@
+name: Version Tracker
+
+# Scheduled version-tracker: reads the curated supported-version matrix
+# (ci-metadata orphan branch) and REACTS automatically to every entry —
+# triggering the release artifact build AND the CI image-refresh + smoke
+# fan-out (ADR-04 Accepted, so these are LIVE, not gated).
+#
+# DETECT = CURATED: a human edits supported-versions.json on ci-metadata when
+# a pfSense beta or GA drops.  An OPTIONAL best-effort probe (see `probe` job)
+# scans pfsense/FreeBSD-ports RELENG_* branches for versions absent from the
+# matrix and opens an issue nudge — it NEVER edits the matrix.
+#
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │ INVARIANT: this workflow NEVER commits to or force-pushes           │
+# │ main, devel, or any channel branch.  The matrix is on ci-metadata   │
+# │ (an orphan ref), so all version tracking is off-branch.  The REACT  │
+# │ step triggers OTHER workflows — it does not write to the repo.      │
+# └─────────────────────────────────────────────────────────────────────┘
+#
+# Phase 5 (image-refresh.yml) and Phase 6 (smoke-fanout.yml) are wired
+# here by name.  They do not exist yet on this branch; the trigger is
+# live and will activate as soon as each phase lands.  See HANDOFF at:
+#   .ADRs/ADR_09_Release_Version_Automation/RESULTS/04_Results.txt
+
+on:
+  # Run daily at 06:00 UTC.  Adjust the cron expression if needed.
+  schedule:
+    - cron: "0 6 * * *"
+
+  # Manual trigger: supports dry-run mode and an optional target version filter.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: >
+          If 'true', log the reactions that WOULD be triggered but do not
+          actually dispatch any downstream workflows.  Use this for self-testing.
+        required: false
+        default: "false"
+      target_version:
+        description: >
+          Restrict reactions to a specific pfsense_version (e.g. "2.8.x").
+          Leave empty to react to all matrix entries.
+        required: false
+        default: ""
+      skip_probe:
+        description: >
+          If 'true', skip the optional best-effort probe entirely.
+          The probe is also skipped when GITHUB_TOKEN lacks the 'issues: write'
+          permission (it degrades gracefully rather than failing).
+        required: false
+        default: "false"
+
+# Least-privilege default.  The react job elevates to 'actions: write' to
+# dispatch downstream workflows.  The probe job elevates to 'issues: write'
+# to open nudge issues.
+permissions:
+  contents: read
+
+jobs:
+  # ── 1. Read the curated matrix ───────────────────────────────────────────────
+  read-matrix:
+    name: Read supported-version matrix
+    runs-on: ubuntu-latest
+    outputs:
+      build_matrix: ${{ steps.read.outputs.build_matrix }}
+      ci_matrix: ${{ steps.read.outputs.ci_matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # need history to reach the ci-metadata orphan ref
+
+      - name: Read matrix from ci-metadata
+        id: read
+        uses: ./.github/actions/read-version-matrix
+
+      - name: Log matrix contents
+        run: |
+          echo "=== BUILD matrix ==="
+          printf '%s\n' '${{ steps.read.outputs.build_matrix }}' | jq .
+          echo "=== CI matrix (ci:true CE entries only) ==="
+          printf '%s\n' '${{ steps.read.outputs.ci_matrix }}' | jq .
+
+  # ── 2. React: trigger release build + CI refresh + smoke fan-out ─────────────
+  #
+  # For each matrix entry the tracker:
+  #   a) Triggers the release artifact build (build-pkg-linux.yml — the portable
+  #      Linux builder, same as the default path in release.yml). This builds a
+  #      .pkg for the entry's (freebsd_version, php_version) pair WITHOUT creating
+  #      a GitHub Release — it is a build-round-trip check, NOT a tag push.
+  #      On a real release, the build is triggered by the tag push; this job
+  #      exercises the build path independently (e.g. to verify a newly-added
+  #      matrix entry builds cleanly before the next release).
+  #
+  #   b) Triggers the CI image-refresh workflow (image-refresh.yml, Phase 5).
+  #      For each CE ci:true entry: upgrade-in-place + sanity gate + GHCR publish.
+  #      This workflow is not yet on this branch; the dispatch is wired now and
+  #      becomes live when Phase 5 lands.
+  #
+  #   c) Triggers the smoke fan-out workflow (smoke-fanout.yml, Phase 6).
+  #      Runs the live-VM smoke suite across every ci:true CE image in parallel.
+  #      This workflow is not yet on this branch; the dispatch is wired now and
+  #      becomes live when Phase 6 lands.
+  #
+  # DRY RUN: if the `dry_run` input is 'true', all trigger steps are skipped and
+  # replaced with a log of what WOULD be triggered — useful for self-testing and
+  # as an audit of the reaction plan before committing to a dispatch.
+  #
+  # INVARIANT ASSERTION: the react job never writes to main, devel, or any
+  # channel branch.  Every step below either reads the matrix, dispatches a
+  # DIFFERENT workflow (which runs in its own job under its own permissions),
+  # or logs.  No `git push`, no `git commit`, no `gh pr merge` on channel
+  # branches appears in this job.
+  react:
+    name: React to matrix entries
+    runs-on: ubuntu-latest
+    needs: read-matrix
+    # 'actions: write' is required to dispatch downstream workflows via
+    # `gh workflow run`.  It is NOT used to push or commit to any branch.
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Plan reactions (dry-run log or live dispatch)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
+          CI_MATRIX: ${{ needs.read-matrix.outputs.ci_matrix }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          TARGET_VERSION: ${{ github.event.inputs.target_version || '' }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.ref_name }}
+        run: |
+          set -eu
+
+          echo "=== Version-tracker REACT ==="
+          echo "DRY_RUN=${DRY_RUN}  TARGET_VERSION='${TARGET_VERSION}'"
+          echo ""
+
+          # ── Iterate over all BUILD matrix entries ──────────────────────────
+          # For each entry: trigger the portable .pkg build (build-pkg-linux.yml).
+          # This validates that the entry's (freebsd_version, php_version) pair
+          # still builds a clean .pkg independently of a release tag push.
+          echo "--- Step A: release artifact build (.pkg) ---"
+          printf '%s\n' "$BUILD_MATRIX" | jq -c '.[]' | while IFS= read -r ENTRY; do
+            PFSENSE=$(printf '%s\n' "$ENTRY" | jq -r '.pfsense_version')
+            CHANNEL=$(printf '%s\n' "$ENTRY" | jq -r '.channel')
+            MAJOR=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_major')
+            PHP=$(printf '%s\n' "$ENTRY" | jq -r '.php_version')
+            PY=$(printf '%s\n' "$ENTRY" | jq -r '.py_flavor')
+
+            # Filter to target version if specified
+            if [ -n "$TARGET_VERSION" ] && [ "$PFSENSE" != "$TARGET_VERSION" ]; then
+              echo "  [skip] ${PFSENSE} (${CHANNEL}) — does not match target '${TARGET_VERSION}'"
+              continue
+            fi
+
+            ABI="FreeBSD:${MAJOR}:amd64"
+            # Channel maps to pkg channel: CE on devel branch -> devel, main -> stable
+            # For standalone tracker runs we use 'devel' as the pkg channel by default.
+            # A real release tag push always uses release.yml; this is a build smoke-check.
+            PKG_CHANNEL="devel"
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "  [DRY-RUN] WOULD dispatch build-pkg-linux.yml:"
+              echo "    pfsense_version=${PFSENSE} (${CHANNEL})  freebsd_major=${MAJOR}"
+              echo "    abi=${ABI}  php=${PHP}  py_flavor=${PY}  pkg_channel=${PKG_CHANNEL}"
+            else
+              echo "  [TRIGGER] build-pkg-linux.yml for ${PFSENSE} (${CHANNEL}) FreeBSD ${MAJOR}"
+              # Dispatch the portable Linux builder for this matrix entry.
+              # build-pkg-linux.yml expects: channel, abi, php_version, py_flavor.
+              # INVARIANT: we dispatch a build-only workflow — no commits, no pushes.
+              gh workflow run build-pkg-linux.yml \
+                --repo "$REPO" \
+                --ref "$REF" \
+                --field "channel=${PKG_CHANNEL}" \
+                --field "abi=${ABI}" \
+                --field "php_version=${PHP}" \
+                --field "py_flavor=${PY}" \
+                || echo "  ::warning::Dispatch of build-pkg-linux.yml for ${PFSENSE} failed (non-fatal)"
+            fi
+          done
+
+          # ── Iterate over CI matrix (ci:true CE entries only) ───────────────
+          # For each CI-eligible entry:
+          #   b) Trigger image-refresh.yml (Phase 5) — upgrade-in-place + sanity gate.
+          #   c) Trigger smoke-fanout.yml (Phase 6) — live-VM smoke across all CE images.
+          #
+          # NOTE ON FORWARD REFERENCES:
+          #   image-refresh.yml and smoke-fanout.yml do NOT yet exist on this branch.
+          #   They will be created by Phases 5 and 6 respectively.  The dispatch calls
+          #   below are wired now; they become live when those phases land.
+          #   The exact workflow names and their expected dispatch inputs are documented
+          #   in RESULTS/04_Results.txt (handoff section).
+          echo ""
+          echo "--- Step B: CI image refresh (image-refresh.yml, Phase 5) ---"
+          CI_COUNT=$(printf '%s\n' "$CI_MATRIX" | jq 'length')
+          if [ "$CI_COUNT" -eq 0 ]; then
+            echo "  [skip] No ci:true CE entries — CI image refresh not triggered."
+          else
+            printf '%s\n' "$CI_MATRIX" | jq -c '.[]' | while IFS= read -r ENTRY; do
+              PFSENSE=$(printf '%s\n' "$ENTRY" | jq -r '.pfsense_version')
+              FREEBSD_VERSION=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_version')
+              MAJOR=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_major')
+
+              if [ -n "$TARGET_VERSION" ] && [ "$PFSENSE" != "$TARGET_VERSION" ]; then
+                echo "  [skip] ${PFSENSE} — does not match target '${TARGET_VERSION}'"
+                continue
+              fi
+
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  [DRY-RUN] WOULD dispatch image-refresh.yml:"
+                echo "    pfsense_version=${PFSENSE}  freebsd_version=${FREEBSD_VERSION}  freebsd_major=${MAJOR}"
+              else
+                echo "  [TRIGGER] image-refresh.yml for CE ${PFSENSE} (FreeBSD ${MAJOR})"
+                # Phase 5 contract: image-refresh.yml accepts pfsense_version and
+                # freebsd_version as workflow_dispatch inputs.
+                # See RESULTS/04_Results.txt for the exact expected input contract.
+                gh workflow run image-refresh.yml \
+                  --repo "$REPO" \
+                  --ref "$REF" \
+                  --field "pfsense_version=${PFSENSE}" \
+                  --field "freebsd_version=${FREEBSD_VERSION}" \
+                  || echo "  ::warning::Dispatch of image-refresh.yml for ${PFSENSE} failed — Phase 5 may not yet be landed"
+              fi
+            done
+          fi
+
+          echo ""
+          echo "--- Step C: CI smoke fan-out (smoke-fanout.yml, Phase 6) ---"
+          if [ "$CI_COUNT" -eq 0 ]; then
+            echo "  [skip] No ci:true CE entries — smoke fan-out not triggered."
+          else
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "  [DRY-RUN] WOULD dispatch smoke-fanout.yml with ci_matrix:"
+              printf '%s\n' "$CI_MATRIX" | jq .
+            else
+              echo "  [TRIGGER] smoke-fanout.yml (all ci:true CE entries)"
+              # Phase 6 contract: smoke-fanout.yml accepts no explicit version inputs —
+              # it reads the ci_matrix from the version-matrix reader itself.
+              # The tracker triggers it once; the fan-out workflow reads and expands
+              # the matrix internally into parallel strategy.matrix legs.
+              # See RESULTS/04_Results.txt for the exact expected input contract.
+              gh workflow run smoke-fanout.yml \
+                --repo "$REPO" \
+                --ref "$REF" \
+                || echo "  ::warning::Dispatch of smoke-fanout.yml failed — Phase 6 may not yet be landed"
+            fi
+          fi
+
+          echo ""
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "=== DRY-RUN COMPLETE — no workflows were dispatched ==="
+          else
+            echo "=== REACT COMPLETE — downstream workflows dispatched ==="
+          fi
+          echo "Invariant confirmed: this job made no commits or pushes to main/devel."
+
+  # ── 3. Optional best-effort probe ────────────────────────────────────────────
+  #
+  # Scans pfsense/FreeBSD-ports RELENG_* branches for pfSense CE versions that
+  # are NOT already in the matrix.  On detecting an unknown version, opens a
+  # GitHub ISSUE nudge asking a human to evaluate and add it to the matrix.
+  #
+  # NEVER edits the matrix.  NEVER commits to any branch.  NUDGES ONLY.
+  #
+  # DISABLING: set skip_probe='true' on workflow_dispatch, or add the label
+  # 'tracker-probe-disabled' to this repo (checked in the step below), or
+  # simply remove the `probe` job from this file entirely.
+  # The probe also degrades gracefully if:
+  #   - The GitHub API is rate-limited or unreachable (exits 0 with a warning).
+  #   - GITHUB_TOKEN lacks 'issues: write' (logs but does not fail).
+  probe:
+    name: Best-effort version probe (nudge only)
+    runs-on: ubuntu-latest
+    needs: read-matrix
+    # The probe is independent of react — failures here must not block react.
+    # It runs in parallel with react; if both are running, a probe failure
+    # does NOT affect the react job or downstream workflow dispatches.
+    if: github.event.inputs.skip_probe != 'true'
+    permissions:
+      issues: write    # to open a nudge issue
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check if probe is disabled via repo label
+        id: probe_gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          # If the repo has a 'tracker-probe-disabled' label, skip the probe.
+          # This is the softest on/off switch without touching workflow YAML.
+          if gh label list --repo "$REPO" --limit 100 \
+              | grep -q 'tracker-probe-disabled'; then
+            echo "probe_disabled=true" >> "$GITHUB_OUTPUT"
+            echo "Probe disabled via repo label 'tracker-probe-disabled'."
+          else
+            echo "probe_disabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Scan pfsense/FreeBSD-ports for unknown CE versions
+        if: steps.probe_gate.outputs.probe_disabled != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+
+          # ── Extract known pfsense_version patterns from the matrix ─────────
+          # The matrix uses "X.Y.x" patterns for CE (e.g. "2.8.x").
+          # Normalise to "X.Y" prefixes for matching against real version strings.
+          KNOWN_PREFIXES=$(printf '%s\n' "$BUILD_MATRIX" \
+            | jq -r '
+                [.[] | select(.channel == "CE") | .pfsense_version]
+                | map(
+                    if endswith(".x") then .[:-2]
+                    else .
+                    end
+                  )
+                | .[]
+              ')
+
+          echo "Known CE version prefixes in matrix:"
+          printf '  %s\n' $KNOWN_PREFIXES
+
+          # ── Fetch RELENG_* branches from pfsense/FreeBSD-ports ────────────
+          # These branches follow the pattern RELENG_X_Y[_Z] (e.g. RELENG_2_8_0).
+          # We extract the X.Y part to compare against known matrix prefixes.
+          echo ""
+          echo "Fetching branch list from pfsense/FreeBSD-ports..."
+          RELENG_BRANCHES=$(gh api \
+            "repos/pfsense/FreeBSD-ports/git/refs/heads" \
+            --jq '[.[] | .ref | ltrimstr("refs/heads/")]
+                  | map(select(startswith("RELENG_"))) | .[]' \
+            2>/dev/null || echo "")
+
+          if [ -z "$RELENG_BRANCHES" ]; then
+            echo "::warning::No RELENG_* branches found or GitHub API unreachable — skipping probe."
+            exit 0
+          fi
+
+          echo "Found RELENG_* branches:"
+          printf '  %s\n' $RELENG_BRANCHES
+
+          # ── Compare against known matrix entries ──────────────────────────
+          UNKNOWNS=""
+          for BRANCH in $RELENG_BRANCHES; do
+            # RELENG_2_8_0 -> 2.8  (take first two numeric segments)
+            VERSION=$(printf '%s\n' "$BRANCH" \
+              | sed 's/RELENG_//' \
+              | sed 's/_/./g' \
+              | grep -oE '^[0-9]+\.[0-9]+')
+
+            if [ -z "$VERSION" ]; then
+              continue
+            fi
+
+            FOUND=0
+            for PREFIX in $KNOWN_PREFIXES; do
+              case "$VERSION" in
+                "${PREFIX}"*) FOUND=1; break ;;
+              esac
+            done
+
+            if [ "$FOUND" -eq 0 ]; then
+              UNKNOWNS="${UNKNOWNS} ${BRANCH}(${VERSION})"
+              echo "  [UNKNOWN] ${BRANCH} -> CE ${VERSION} not in matrix"
+            else
+              echo "  [known]   ${BRANCH} -> CE ${VERSION} covered"
+            fi
+          done
+
+          # ── Open a nudge issue for any unknown versions ───────────────────
+          if [ -z "$UNKNOWNS" ]; then
+            echo ""
+            echo "All detected RELENG_* versions are covered by the matrix. No nudge needed."
+            exit 0
+          fi
+
+          echo ""
+          echo "Unknown versions detected — opening a nudge issue."
+
+          ISSUE_TITLE="[version-tracker] New pfSense CE version(s) detected — matrix update needed"
+
+          # Write the issue body to a temp file to avoid shell/YAML quoting conflicts.
+          BODY_FILE=$(mktemp)
+          UNKNOWN_LIST=$(printf '%s\n' $UNKNOWNS | tr ' ' '\n' | sed 's/^/- /')
+          {
+            printf 'The version-tracker probe detected pfSense CE version(s) in\n'
+            printf '`pfsense/FreeBSD-ports` that are NOT yet in the supported-version\n'
+            printf 'matrix on `ci-metadata`.\n\n'
+            printf '**Action required (human):** evaluate each version below and, if it\n'
+            printf 'should be supported, add an entry to `supported-versions.json` on the\n'
+            printf '`ci-metadata` branch via a PR.\n'
+            printf 'See `scripts/README.md` (Supported-version matrix section) for the\n'
+            printf 'schema and lifecycle policy.\n\n'
+            printf '**Detected unknown version(s):**\n'
+            printf '%s\n' "$UNKNOWN_LIST"
+            printf '\n'
+            printf '**Matrix location:** `origin/ci-metadata:supported-versions.json`\n\n'
+            printf '**This issue was opened automatically by the version-tracker probe.**\n'
+            printf '**The probe NEVER edits the matrix -- all changes require a human PR.**\n'
+          } > "$BODY_FILE"
+
+          # Check whether an open nudge issue already exists to avoid spam.
+          EXISTING=$(gh issue list \
+            --repo "$REPO" \
+            --state open \
+            --label "version-tracker" \
+            --limit 10 \
+            --json number,title \
+            --jq '[.[] | select(.title | startswith("[version-tracker]"))] | length' \
+            2>/dev/null || echo "0")
+
+          if [ "$EXISTING" -gt "0" ]; then
+            echo "A nudge issue already exists — skipping duplicate open."
+            echo "Resolve the existing 'version-tracker' issue first."
+            exit 0
+          fi
+
+          gh issue create \
+            --repo "$REPO" \
+            --title "$ISSUE_TITLE" \
+            --body-file "$BODY_FILE" \
+            --label "enhancement" \
+            || echo "::warning::Could not open nudge issue (token may lack issues:write) — see log above."
+          rm -f "$BODY_FILE"
+
+          echo "Nudge issue opened. The probe has NOT edited the matrix."
+          echo "Invariant confirmed: no channel-branch writes from the probe."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -706,10 +706,29 @@ When the minimum supported CE version changes, also:
    versions are supported and their `(freebsd_version, php_version)` build pair; all
    workflows read it at runtime via `scripts/read-version-matrix.sh` and
    `.github/actions/read-version-matrix/`. See `scripts/README.md § "Supported-version matrix"`.
-2. **Rebuild + republish the pfSense CE smoke image** (ADR-04): upgrade-in-place
-   for a patch/minor bump, a fresh seed on a major — via
-   `.github/workflows/build-image.yml` (publish-on-pass, gated by the smoke
-   round-trip). See `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`.
+   The **build vs CI split**: CE gets both `.pkg` builds and live-VM smoke CI (`ci: true`);
+   Plus gets `.pkg` builds only (`ci: false` — no licensed CI image). Adding an entry
+   to `ci-metadata` and letting the **version-tracker** (`version-tracker.yml`) run (or
+   dispatch it) is sufficient — it triggers `build-pkg-linux.yml`, `image-refresh.yml`,
+   and `smoke-fanout.yml` automatically. **No workflow YAML edit is needed.**
+2. **Refresh the pfSense CE smoke image** (ADR-04 + ADR-09): dispatch
+   `.github/workflows/image-refresh.yml` with `pfsense_version` + `freebsd_version`
+   from the new matrix entry. The workflow pulls the current GHCR tag, runs
+   `pfSense-upgrade` (any bump, including major), applies the **six-check sanity gate**,
+   and publishes the new tag **only on gate pass** (fail-closed — a bad image is never
+   published). Manual seed via `scripts/image-publish.sh` is the fallback only when
+   the gate fails. See `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`.
+   > **ADR-04 §2 note:** ADR-04 §2 mentions "re-baseline on a MAJOR version jump" as a
+   > conservative option. ADR-09 supersedes this as the **default**: `image-refresh.yml`
+   > handles all jumps (minor and major) uniformly via upgrade-in-place; a fresh manual
+   > re-seed is triggered only by a gate failure, not automatically by a major jump. A
+   > reconciling edit to ADR-04 §2 is a tracked follow-up (not yet applied).
+3. **Run the smoke fan-out** to validate the new CE image end-to-end: dispatch
+   `.github/workflows/smoke-fanout.yml` (no inputs needed — it reads the CI matrix
+   itself). The fan-out runs the ADR-04 smoke suite against **all** `ci: true` CE
+   images in parallel (`fail-fast: false`); the `all-smoke-passed` AND-gate fails if
+   any single CE leg fails. Never Plus. The version-tracker triggers this automatically
+   on its daily run; you can also dispatch it manually to verify the new image.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -698,10 +698,18 @@ Update `stubs/pfsense/` when:
   absent from the 2.7.2 stub source, e.g. `config_read_file`). PHPStan is the gate:
   prefer stubbing a real pfSense function over a `phpstan-baseline.neon` suppression.
 
-When the minimum supported CE version changes, also **rebuild + republish the
-pfSense CE smoke image** (ADR-04): upgrade-in-place for a patch/minor bump, a
-fresh seed on a major — via `.github/workflows/build-image.yml` (publish-on-pass,
-gated by the smoke round-trip). See `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`.
+When the minimum supported CE version changes, also:
+
+1. **Update the supported-version matrix** — edit `supported-versions.json` on the
+   **`ci-metadata` orphan branch** (off `main`/`devel`, its own history) via a PR
+   against `ci-metadata`. This is the **single source of truth** for which pfSense
+   versions are supported and their `(freebsd_version, php_version)` build pair; all
+   workflows read it at runtime via `scripts/read-version-matrix.sh` and
+   `.github/actions/read-version-matrix/`. See `scripts/README.md § "Supported-version matrix"`.
+2. **Rebuild + republish the pfSense CE smoke image** (ADR-04): upgrade-in-place
+   for a patch/minor bump, a fresh seed on a major — via
+   `.github/workflows/build-image.yml` (publish-on-pass, gated by the smoke
+   round-trip). See `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -713,11 +713,17 @@ When the minimum supported CE version changes, also:
    and `smoke-fanout.yml` automatically. **No workflow YAML edit is needed.**
 2. **Refresh the pfSense CE smoke image** (ADR-04 + ADR-09): dispatch
    `.github/workflows/image-refresh.yml` with `pfsense_version` + `freebsd_version`
-   from the new matrix entry. The workflow pulls the current GHCR tag, runs
-   `pfSense-upgrade` (any bump, including major), applies the **six-check sanity gate**,
-   and publishes the new tag **only on gate pass** (fail-closed — a bad image is never
-   published). Manual seed via `scripts/image-publish.sh` is the fallback only when
-   the gate fails. See `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`.
+   from the new matrix entry. The workflow calls `scripts/image-upgrade.sh --upgrade-pkgs`,
+   which pulls the current GHCR tag, conditionally upgrades baked deps (`pkg upgrade -n`
+   dry-run; only runs `pkg upgrade -y` + reboots if upgrades are actually pending), runs
+   `pfSense-upgrade` (any bump, including major), then applies the **alive/working-fine
+   health gate** (polls up to 300 s for the webConfigurator to answer HTTP or `pfctl` to
+   show a live ruleset) and publishes the new tag only when the box is healthy — fail-closed
+   (a bad image is never published). A non-blocking pfBlockerNG smoke step
+   (`continue-on-error: true`) runs on a discarded overlay after publish — it is
+   informational only and cannot fail the refresh. The authoritative pfBlockerNG validation
+   is `smoke-fanout.yml` (step 3 below). Manual seed via `scripts/image-publish.sh` is the
+   fallback only when the health gate fails. See `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`.
    > **ADR-04 §2 note:** ADR-04 §2 mentions "re-baseline on a MAJOR version jump" as a
    > conservative option. ADR-09 supersedes this as the **default**: `image-refresh.yml`
    > handles all jumps (minor and major) uniformly via upgrade-in-place; a fresh manual

--- a/README.md
+++ b/README.md
@@ -58,11 +58,10 @@ The default version is the minimum pfSense CE release supported by this package
 relevant pfSense source files from GitHub and rewrites all stub files except
 `stubs/pfsense/globals.php`, which is manually maintained.
 
-A CE version bump also means **rebuilding and republishing the pfSense CE smoke
-image** (ADR-04): upgrade-in-place for a patch/minor bump, a fresh seed on a
-major, via `.github/workflows/build-image.yml`. See
-[Smoke tests](#smoke-tests-live-pfsense-vm) below and
-[`.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`](.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md).
+A CE version bump also requires updating the **supported-version matrix** and
+refreshing the CI smoke image. See
+[Rebuilding the image on a CE bump](#rebuilding-the-image-on-a-ce-bump) below for
+the full three-step procedure (matrix edit → image refresh → smoke fan-out).
 
 ### Git hooks
 
@@ -694,14 +693,40 @@ needing another network pull.)
 
 ### Rebuilding the image on a CE bump
 
-The pfSense CE image is **seeded once** (one clean manual install, archived) and
-**upgraded in place** for every subsequent release — `build-image.yml` runs
-`pfSense-upgrade` on the prior tag for patch/minor (and major), gated by the
-smoke round-trip (publish-on-pass, fail-closed). A **fresh manual re-seed** is
-the fallback only when that gate fails. **CE only** (Plus is out of scope). The
-seed and every version snapshot are retained as immutable GHCR tags (never
-overwritten); the GHCR package is **private**. Full strategy + what is baked:
-`.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md` and `RESULTS/02_Results.txt`.
+When a new pfSense CE release lands (or you raise the minimum supported CE version),
+follow this three-step procedure. The daily **version-tracker** (`version-tracker.yml`)
+performs steps 2–3 automatically once the matrix is updated; you can also dispatch
+each workflow manually.
+
+**Step 1 — Update the supported-version matrix.**
+Edit `supported-versions.json` on the `ci-metadata` orphan branch via a PR against
+`ci-metadata`. Add a new entry (or update `status: "beta"` → `"GA"`; or drop the
+oldest CE entry when the newest goes GA). Schema and lifecycle policy:
+[`scripts/README.md`](scripts/README.md#supported-version-matrix).
+
+**Step 2 — Refresh the CI smoke image.**
+Dispatch `.github/workflows/image-refresh.yml` with `pfsense_version` and
+`freebsd_version` from the new matrix entry. The workflow:
+
+1. Pulls the current GHCR tag for this CE version.
+2. Boots a copy and runs `pfSense-upgrade` (works for patch, minor, and major jumps).
+3. Applies the **six-check sanity gate** (VM boots; SSH answers; `/etc/version` matches;
+   `pfctl -sr` loads; `install-from-repo.sh` + `pfblockerng.php update` exit 0;
+   `dig` control record resolves).
+4. Publishes the new GHCR tag **only on gate pass** — fail-closed (a bad image is
+   never published). Old tags are kept.
+
+If the gate fails, use `scripts/image-publish.sh` to produce a fresh seed from a
+clean manual install (manual fallback — see
+[`.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`](.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md)).
+**CE only** (Plus is build-only; no licensed CI image). The seed and every version
+snapshot are retained as immutable GHCR tags; the GHCR package is **private**.
+
+**Step 3 — Run the smoke fan-out.**
+Dispatch `.github/workflows/smoke-fanout.yml` (no inputs — it reads the CI matrix
+itself). The fan-out runs the ADR-04 smoke suite across **all** `ci: true` CE images
+in parallel (`fail-fast: false`). The `all-smoke-passed` AND-gate fails if any single
+leg fails — one red CE leg makes the whole gate red, no partial pass. Never Plus.
 
 ### Adding a matrix case
 

--- a/docs/misc/pfSense_versions.md
+++ b/docs/misc/pfSense_versions.md
@@ -25,12 +25,14 @@ Observed on a CE **2.8.1** box; 2.8.0 shares the same base toolchain.
 | pkg | 1.21.x |
 | Unbound | 1.24.x |
 
-> **The FreeBSD base + PHP row above is also encoded in CI.** The
-> `resolve-version` job in `.github/workflows/build-image.yml` maps
-> `pfsense_ce_version → (freebsd_version, php_version)` so the branch `.pkg` is
-> built against the right ABI/runtime, and hard-fails on any unmapped version.
-> When adding a new supported CE version, add a `case` arm there alongside the
-> table here (issue #22).
+> **The FreeBSD base + PHP row above is also encoded in the supported-version
+> matrix.** `supported-versions.json` on the `ci-metadata` orphan ref is the
+> **single source of truth**: it carries the `(freebsd_version, php_version)` pair
+> per pfSense version and is read at runtime by every workflow, including the
+> `resolve-version` job in `.github/workflows/build-image.yml` (which hard-fails on
+> any unmapped version — the reject-unknown contract from issue #22 is preserved).
+> When adding a new supported CE version, add an entry to `supported-versions.json`
+> on `ci-metadata` **and** update the table here. No workflow edit needed.
 
 ### pfBlockerNG runtime dependencies (port `RUN_DEPENDS`)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,11 +13,12 @@ the **`ci-metadata` orphan branch** (its own history, off `main`/`devel`) as
 | --- | --- |
 | [`read-version-matrix.sh`](read-version-matrix.sh) | Read the matrix from `ci-metadata` and print/emit the BUILD matrix and CI matrix. |
 
-To add or drop a version, edit `supported-versions.json` via a PR against `ci-metadata`.
-**No workflow change is needed** — the `resolve-version` job in `build-image.yml`
-and every other consumer reads from `ci-metadata` at runtime.
+The `read-version-matrix.sh` reader is also exposed as a composite GH Actions action
+(`.github/actions/read-version-matrix/`) that emits two outputs: `build_matrix` (all
+entries → one `.pkg` per distinct FreeBSD major) and `ci_matrix` (`ci: true` CE
+entries → the smoke-fan-out set, never Plus).
 
-The matrix schema per entry:
+### Schema
 
 ```text
 {
@@ -32,14 +33,79 @@ The matrix schema per entry:
 }
 ```
 
-Lifecycle policy:
+### Lifecycle policy
 
-- **Add** when a beta/GA lands (curated — a human edits the JSON).
-- **Drop** the oldest CE only when the newest CE goes GA.
-- **Plus** entries are always `ci: false` (build-only; no licensed CI image).
+- **Add** when a beta/GA lands (curated — a human edits the JSON via a PR against
+  `ci-metadata`). Add immediately on a beta so the build + CI validation starts early;
+  the status field distinguishes beta from GA.
+- **Drop** the oldest CE entry only when the newest CE goes GA (the window is *previous
+  major + current major*, transiently `+1` during a beta).
+- **Plus** entries are always `ci: false` — build-only (no licensed CI image is available).
 
-For the future: if CI infrastructure grows, the file can move to a dedicated public
-`pfBlockerNG-ci-infra` repo (raw URL, no token) — a mechanical swap in `read-version-matrix.sh`.
+**No workflow YAML change is needed when adding or dropping a version** — the
+`resolve-version` job in `build-image.yml` and every other consumer reads from
+`ci-metadata` at runtime.
+
+### Build vs CI split
+
+| Channel | `.pkg` build | Live-VM smoke CI |
+| --- | --- | --- |
+| CE | yes (portable Linux builder by default; FreeBSD `make package` as oracle/fallback) | yes (`ci: true`) |
+| Plus | yes (same builders; build needs only the right FreeBSD-major env, no license) | no (no licensed Plus image) |
+
+**Portable Linux builder** (`build-pkg-linux.yml` / `scripts/build-pkg-portable.py`) is the
+**default**: it runs on a plain Linux runner and reproduces `make package` from the port's
+Makefile + pkg-plist off-FreeBSD. **FreeBSD `make package`** (`build-pkg.yml`) is retained
+as the **fidelity oracle / fallback** — selectable per entry; used when the portable
+builder diverges from the real package in a way that affects install/behaviour.
+
+### Where `.pkg` artifacts land
+
+A tag push (`vX.Y.Z[-devel]`) triggers `release.yml`, which reads `build_matrix` and
+builds one `.pkg` per entry against its `(freebsd_version, php_version)` pair. Artifacts
+are attached to the **GitHub Release**, deduplicated by FreeBSD major — one `.pkg` per
+distinct major covers every pfSense version on that major. A build failure surfaces in CI
+but must **not** block the `ports-pr` step (the ports PR is the real distribution path).
+
+The daily **version-tracker** (`version-tracker.yml`, `0 6 * * *`) also triggers
+`build-pkg-linux.yml` for every BUILD matrix entry to validate each entry's build pair
+independently of a release tag.
+
+### What happens after a matrix edit (add a CE version)
+
+After `supported-versions.json` is updated on `ci-metadata`, the next
+`version-tracker.yml` run (daily, or dispatch) reacts automatically:
+
+1. **`build-pkg-linux.yml`** — validates the new entry's `(freebsd_version, php_version)`
+   pair by building an installable `.pkg`. One dispatch per BUILD entry.
+2. **`image-refresh.yml`** — upgrade-in-place: pulls the current GHCR tag for the CE
+   version, runs `pfSense-upgrade`, applies the **six-check sanity gate**, and publishes
+   the new tag to GHCR **only on gate pass** (fail-closed — a bad image is never
+   published). One dispatch per `ci: true` CE entry.
+3. **`smoke-fanout.yml`** — runs the ADR-04 live-VM smoke suite across **all** `ci: true`
+   CE images in parallel (`fail-fast: false`). The **`all-smoke-passed` AND-gate** fails
+   if any single leg fails — one failed leg makes the whole gate red, no partial pass.
+   Never Plus.
+
+The tracker dispatches steps 2 and 3 only for CE entries (`ci: true`). Plus is
+build-only: step 1 runs for Plus, steps 2–3 never do.
+
+### ADR-04 §2 reconciliation (flagged — not edited here)
+
+ADR-04 §2 describes the image-refresh strategy as: "upgrade-in-place for all bumps
+(incl. major)" with the note that a **fresh manual re-seed** is the fallback when the
+gate fails, and its §3 `Negative / risks` contains the wording *"re-baseline on a
+MAJOR version jump"* as a conservative option. ADR-09 refines this: the automated
+`image-refresh.yml` handles **all** version jumps uniformly (minor, major) — upgrade
+→ sanity gate → publish on pass; manual seed only on gate failure. This supersedes
+the "re-baseline on major" as a **default** (the gate is the safety net). A
+reconciling edit to ADR-04 §2 is a **follow-up** and is intentionally deferred — the
+two ADRs are consistent in practice (gate fail → manual seed is the same fallback),
+the wording difference is documentation only.
+
+For the future: if CI infrastructure grows, `supported-versions.json` can move to a
+dedicated public `pfBlockerNG-ci-infra` repo (raw URL, no token) — a mechanical swap
+in `read-version-matrix.sh`.
 
 ## Deploy / install onto a pfSense box
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,7 +29,7 @@ entries → the smoke-fan-out set, never Plus).
   "php_version":     "8.3",          # PHP version (pinned so USES=php dep names match)
   "py_flavor":       "py311",        # Python flavor for build-pkg-linux.yml
   "status":          "GA",           # beta | GA
-  "ci":              true            # include in smoke CI matrix (always false for Plus)
+  "ci":              true            # include in smoke CI matrix (false for Plus for now — no licensed CI image)
 }
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,6 +3,44 @@
 Helper scripts for developing, deploying, and building pfBlockerNG. **Dev-only** —
 none of this ships in the release archive (which contains only `src/`).
 
+## Supported-version matrix
+
+The single source of truth for which pfSense versions pfBlockerNG supports lives on
+the **`ci-metadata` orphan branch** (its own history, off `main`/`devel`) as
+`supported-versions.json`. All CI/build workflows read it at runtime.
+
+| Script | Use |
+| --- | --- |
+| [`read-version-matrix.sh`](read-version-matrix.sh) | Read the matrix from `ci-metadata` and print/emit the BUILD matrix and CI matrix. |
+
+To add or drop a version, edit `supported-versions.json` via a PR against `ci-metadata`.
+**No workflow change is needed** — the `resolve-version` job in `build-image.yml`
+and every other consumer reads from `ci-metadata` at runtime.
+
+The matrix schema per entry:
+
+```text
+{
+  "pfsense_version": "2.8.x",       # pfSense version (CE: X.Y.x; Plus: release label)
+  "channel":         "CE",           # CE | Plus
+  "freebsd_version": "15.0-RELEASE", # full FreeBSD version string (build env)
+  "freebsd_major":   "15",           # FreeBSD major (ABI dedup key; artifact suffix)
+  "php_version":     "8.3",          # PHP version (pinned so USES=php dep names match)
+  "py_flavor":       "py311",        # Python flavor for build-pkg-linux.yml
+  "status":          "GA",           # beta | GA
+  "ci":              true            # include in smoke CI matrix (always false for Plus)
+}
+```
+
+Lifecycle policy:
+
+- **Add** when a beta/GA lands (curated — a human edits the JSON).
+- **Drop** the oldest CE only when the newest CE goes GA.
+- **Plus** entries are always `ci: false` (build-only; no licensed CI image).
+
+For the future: if CI infrastructure grows, the file can move to a dedicated public
+`pfBlockerNG-ci-infra` repo (raw URL, no token) — a mechanical swap in `read-version-matrix.sh`.
+
 ## Deploy / install onto a pfSense box
 
 | Script | Use |

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -45,7 +45,10 @@
 #   --ssh-port N     Proxmox-local port forwarded to the guest's :22 (default: 2222)
 #   --mac ADDR       guest NIC MAC (default: BC:24:11:37:9C:AC — must match the image)
 #   --compression T  qcow2 compression for the published image: zstd|zlib|off (default: zstd)
-#   --upgrade-timeout S  seconds to wait for the pfSense-upgrade+reboot (default: 1800)
+#   --upgrade-timeout S  MAX seconds to wait for the pfSense-upgrade+reboot
+#                    (default: 1200). The poll exits the instant /etc/version
+#                    changes, so this only bounds how long a STUCK upgrade waits
+#                    before the run fails — it is not added to a successful run.
 #   --upgrade-pkgs   before pfSense-upgrade, run `pkg update -f` + `pkg upgrade -y`
 #                    to upgrade baked deps (qemu-guest-agent, etc.) to their latest
 #                    versions; reboots the guest and waits for SSH before proceeding.
@@ -70,7 +73,7 @@ GUEST_KEY="${SMOKE_SSH_KEY:-}"
 GUEST_PORT=2222
 MAC="BC:24:11:37:9C:AC"
 COMPRESSION=zstd
-UPGRADE_TIMEOUT=1800
+UPGRADE_TIMEOUT=1200
 UPGRADE_PKGS=0
 KEEP=0
 FORCE=0

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -10,10 +10,13 @@
 # directly on the KVM host), as before.
 #
 # Flow: pull the current image from GHCR (local) -> stream it to the Proxmox host
-# -> boot it under QEMU/KVM there (read-write, with internet) -> run pfSense-upgrade
-# over an SSH jump -> wait for it to finish and reboot -> power off cleanly ->
-# compress on Proxmox -> stream back -> push the new tag (local). The source tag is
-# left untouched, so the old image is always kept.
+# -> boot it under QEMU/KVM there (read-write, with internet) ->
+# [optional: pkg update -f + pkg upgrade, reboot, wait SSH back] ->
+# run pfSense-upgrade over an SSH jump -> wait for it to finish and reboot ->
+# health-gate (webConfigurator HTTP or pfctl live ruleset) ->
+# power off cleanly -> compress on Proxmox -> stream back ->
+# push the new tag (local). The source tag is left untouched, so the old image
+# is always kept.
 #
 # Usage:
 #   ./scripts/image-upgrade.sh --from <current-version> [options]
@@ -21,6 +24,7 @@
 # Examples:
 #   ./scripts/image-upgrade.sh --from 2.8.1 --proxmox root@pve.lan --ssh-key ~/.ssh/smoke_ed25519
 #   ./scripts/image-upgrade.sh --from 2.8.1 --to 2.8.2 --proxmox pve.lan --proxmox-port 2222 --force
+#   ./scripts/image-upgrade.sh --from 2.8.1 --to 2.8.2 --upgrade-pkgs   # also upgrades baked deps
 #
 # Proxmox connection (the KVM host that boots the VM):
 #   --proxmox [USER@]HOST   SSH target of the Proxmox/KVM host. If omitted (and
@@ -41,7 +45,13 @@
 #   --ssh-port N     Proxmox-local port forwarded to the guest's :22 (default: 2222)
 #   --mac ADDR       guest NIC MAC (default: BC:24:11:37:9C:AC — must match the image)
 #   --compression T  qcow2 compression for the published image: zstd|zlib|off (default: zstd)
-#   --upgrade-timeout S  seconds to wait for the upgrade+reboot (default: 1800)
+#   --upgrade-timeout S  seconds to wait for the pfSense-upgrade+reboot (default: 1800)
+#   --upgrade-pkgs   before pfSense-upgrade, run `pkg update -f` + `pkg upgrade -y`
+#                    to upgrade baked deps (qemu-guest-agent, etc.) to their latest
+#                    versions; reboots the guest and waits for SSH before proceeding.
+#                    Default OFF; pass this flag to enable. build-image.yml does NOT
+#                    pass this flag (it calls this script directly), so callers that
+#                    only want the pfSense-upgrade step are unaffected.
 #   --keep           keep the work dirs (image copies, console log) afterwards
 #   --force          overwrite the target tag if it already exists
 #
@@ -61,6 +71,7 @@ GUEST_PORT=2222
 MAC="BC:24:11:37:9C:AC"
 COMPRESSION=zstd
 UPGRADE_TIMEOUT=1800
+UPGRADE_PKGS=0
 KEEP=0
 FORCE=0
 
@@ -77,6 +88,10 @@ REMOTE_TMPDIR="${PROXMOX_TMPDIR:-/tmp}"
 # real completion regardless of how it reboots.
 UPGRADE_CMD='yes | /usr/local/sbin/pfSense-upgrade -d'
 
+# After pfSense-upgrade completes and a new version is detected, poll up to this
+# many seconds for the box to be "working fine" before proceeding to shutdown.
+HEALTH_TIMEOUT=300
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --proxmox)         PX_TARGET="$2"; shift 2 ;;
@@ -91,9 +106,10 @@ while [ $# -gt 0 ]; do
         --mac)             MAC="$2"; shift 2 ;;
         --compression)     COMPRESSION="$2"; shift 2 ;;
         --upgrade-timeout) UPGRADE_TIMEOUT="$2"; shift 2 ;;
+        --upgrade-pkgs)    UPGRADE_PKGS=1; shift ;;
         --keep)            KEEP=1; shift ;;
         --force)           FORCE=1; shift ;;
-        -h|--help)         sed -n '2,48p' "$0"; exit 0 ;;
+        -h|--help)         sed -n '2,62p' "$0"; exit 0 ;;
         *)                 die "unknown option: $1" ;;
     esac
 done
@@ -145,6 +161,17 @@ ssh_guest() {
             -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
             root@127.0.0.1 "$@"
     fi
+}
+
+# wait_guest_ssh TIMEOUT — poll until root SSH answers or TIMEOUT seconds elapse.
+wait_guest_ssh() {
+    _wgs_timeout="$1"
+    _wgs_elapsed=0
+    while ! ssh_guest true 2>/dev/null; do
+        [ "$_wgs_elapsed" -ge "$_wgs_timeout" ] && \
+            die "VM did not answer SSH within ${_wgs_timeout}s (see $REMOTE_DIR/console.log on the KVM host)"
+        sleep 5; _wgs_elapsed=$((_wgs_elapsed + 5))
+    done
 }
 
 # Local tooling: oras always; ssh only when driving a remote host.
@@ -214,16 +241,38 @@ QPID=$(px "cat '$REMOTE_DIR/qemu.pid'" | tr -d '\r')
 [ -n "$QPID" ] || die "QEMU did not write a pidfile (see ${PX_HOST:+$PX_HOST:}$REMOTE_DIR/console.log)"
 
 log "waiting for SSH..."
-_elapsed=0
-while ! ssh_guest true 2>/dev/null; do
-    [ "$_elapsed" -ge 300 ] && die "VM did not answer SSH within 300s (see $REMOTE_DIR/console.log on the KVM host)"
-    sleep 5; _elapsed=$((_elapsed + 5))
-done
+wait_guest_ssh 300
 
 OLD_VER=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r')
 log "current version on box: ${OLD_VER:-unknown}"
 
-# --- run the upgrade -------------------------------------------------------
+# --- optional: upgrade baked deps (pkg update -f + conditional pkg upgrade) -
+if [ "$UPGRADE_PKGS" -eq 1 ]; then
+    log "refreshing package catalogue (pkg update -f)"
+    # pkg update may print output; connection stays up (not a reboot command).
+    ssh_guest 'pkg update -f' 2>&1 | tee "$LOCAL_DIR/pkg-update.log" || true
+
+    # Dry-run detect: pkg prints "Your packages are up to date" when nothing is
+    # pending; otherwise it prints an upgrade plan (Number of packages to be
+    # upgraded / to be installed / to be reinstalled, etc.).  Parse the output —
+    # do NOT rely solely on exit code, as pkg(8) exit semantics vary by version.
+    log "checking for pending package upgrades (pkg upgrade -n)"
+    _pkg_dry=$(ssh_guest 'pkg upgrade -n' 2>&1 | tee "$LOCAL_DIR/pkg-upgrade-dryrun.log" || true)
+    if printf '%s' "$_pkg_dry" | grep -q 'Your packages are up to date'; then
+        log "packages already up to date — skipping pkg upgrade + reboot"
+    else
+        log "package upgrades pending — running pkg upgrade -y"
+        ssh_guest 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y' 2>&1 | tee "$LOCAL_DIR/pkg-upgrade.log" || true
+        log "rebooting after pkg upgrade"
+        # /sbin/reboot drops the connection — expected; ignore the exit code.
+        ssh_guest '/sbin/reboot' 2>/dev/null || true
+        log "waiting for SSH after pkg-upgrade reboot..."
+        wait_guest_ssh 300
+        log "box is back after pkg-upgrade reboot"
+    fi
+fi
+
+# --- run the pfSense upgrade -----------------------------------------------
 log "running pfSense upgrade (this reboots the box; up to ${UPGRADE_TIMEOUT}s)"
 # Connection will drop when the box reboots — that is expected, so ignore it.
 ssh_guest "$UPGRADE_CMD" 2>&1 | tee "$LOCAL_DIR/upgrade.log" || true
@@ -243,6 +292,33 @@ while [ "$_elapsed" -lt "$UPGRADE_TIMEOUT" ]; do
 done
 [ -n "$NEW_VER" ] || die "version did not change within ${UPGRADE_TIMEOUT}s (still '${OLD_VER}'; see $LOCAL_DIR/upgrade.log)"
 log "upgraded: ${OLD_VER} -> ${NEW_VER}"
+
+# --- health gate: wait until box is "working fine" -------------------------
+# Poll up to HEALTH_TIMEOUT seconds. The box is considered healthy when EITHER:
+#   a) the webConfigurator answers HTTP (login page is up), OR
+#   b) pfctl -sr returns a live (non-empty) ruleset.
+# If neither within HEALTH_TIMEOUT, die — fail-closed; no publish.
+log "health-gating upgraded box (up to ${HEALTH_TIMEOUT}s for webConfigurator/pfctl)..."
+_hg_elapsed=0
+_hg_healthy=0
+while [ "$_hg_elapsed" -lt "$HEALTH_TIMEOUT" ]; do
+    # Check webConfigurator: fetch https://127.0.0.1/ on-box (port 443).
+    # fetch(1) is the FreeBSD/pfSense http client available on all pfSense versions.
+    if ssh_guest 'fetch -qT 15 --no-verify-peer --no-verify-hostname -o /dev/null https://127.0.0.1/ 2>/dev/null' 2>/dev/null; then
+        log "health gate PASS: webConfigurator answered HTTP"
+        _hg_healthy=1
+        break
+    fi
+    # Fallback: check pfctl for a live ruleset.
+    _pf_rules=$(ssh_guest '/sbin/pfctl -sr' 2>/dev/null | grep -c '.' || true)
+    if [ "${_pf_rules:-0}" -gt 0 ]; then
+        log "health gate PASS: pfctl shows ${_pf_rules} live rules"
+        _hg_healthy=1
+        break
+    fi
+    sleep 10; _hg_elapsed=$((_hg_elapsed + 10))
+done
+[ "$_hg_healthy" -eq 1 ] || die "upgraded box did not become healthy within ${HEALTH_TIMEOUT}s (webConfigurator and pfctl both failed; see $LOCAL_DIR/upgrade.log)"
 
 # --- power off cleanly -----------------------------------------------------
 log "shutting the box down"

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# read-version-matrix.sh — read supported-versions.json from the ci-metadata
+# orphan ref and emit the BUILD matrix and CI matrix as JSON.
+#
+# Usage:
+#   read-version-matrix.sh [--ref <git-ref>] [--file <path>] [--github-output]
+#                          [--print-build | --print-ci | --print-all]
+#
+# Options:
+#   --ref <git-ref>      Git ref to read from (default: origin/ci-metadata).
+#                        Must be reachable in the current git repo.
+#   --file <path>        Matrix file path on the ref
+#                        (default: supported-versions.json).
+#   --github-output      Write build_matrix and ci_matrix to $GITHUB_OUTPUT
+#                        (GitHub Actions step outputs format).
+#   --print-build        Print BUILD matrix JSON to stdout.
+#   --print-ci           Print CI matrix JSON to stdout.
+#   --print-all          Print both matrices to stdout (labelled).
+#
+# Outputs:
+#   BUILD matrix — all entries from supported-versions.json, each carrying:
+#     pfsense_version, channel, freebsd_version, freebsd_major,
+#     php_version, py_flavor, status, ci
+#   CI matrix    — the ci:true CE entries only (subset of BUILD matrix).
+#
+# Requirements: git, jq (both available on ubuntu-latest GH runners).
+# Pure read — no writes anywhere; exits non-zero on any error.
+#
+# The matrix lives on the ci-metadata ORPHAN branch — off main/devel —
+# so editing it never touches the channel branches.
+# See: scripts/README.md § "Supported-version matrix"
+
+set -eu
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+MATRIX_REF="${MATRIX_REF:-origin/ci-metadata}"
+MATRIX_FILE="${MATRIX_FILE:-supported-versions.json}"
+DO_GITHUB_OUTPUT=0
+DO_PRINT_BUILD=0
+DO_PRINT_CI=0
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ref)       MATRIX_REF="$2";  shift 2 ;;
+    --file)      MATRIX_FILE="$2"; shift 2 ;;
+    --github-output) DO_GITHUB_OUTPUT=1; shift ;;
+    --print-build)   DO_PRINT_BUILD=1;   shift ;;
+    --print-ci)      DO_PRINT_CI=1;      shift ;;
+    --print-all)     DO_PRINT_BUILD=1; DO_PRINT_CI=1; shift ;;
+    *) printf 'unknown option: %s\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+# Default: print both when running standalone with no print flags and no GH output.
+if [ "$DO_GITHUB_OUTPUT" -eq 0 ] && [ "$DO_PRINT_BUILD" -eq 0 ] && [ "$DO_PRINT_CI" -eq 0 ]; then
+  DO_PRINT_BUILD=1
+  DO_PRINT_CI=1
+fi
+
+# ── Validate dependencies ──────────────────────────────────────────────────────
+if ! command -v git >/dev/null 2>&1; then
+  printf '::error::git is required but not found\n' >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  printf '::error::jq is required but not found\n' >&2
+  exit 1
+fi
+
+# ── Read the matrix JSON from the ref ─────────────────────────────────────────
+# Verify the ref is reachable before trying to cat.
+if ! git fetch origin ci-metadata >/dev/null 2>&1; then
+  # If fetch fails (e.g. offline or --ref is a local path), proceed with whatever
+  # is already in the local repo. Not an error — the caller may have pre-fetched.
+  :
+fi
+
+RAW_JSON="$(git show "${MATRIX_REF}:${MATRIX_FILE}" 2>/dev/null)" || {
+  printf '::error::cannot read %s from ref %s — is origin/ci-metadata pushed?\n' \
+    "$MATRIX_FILE" "$MATRIX_REF" >&2
+  exit 1
+}
+
+# Validate: must be a JSON object with a "versions" array.
+if ! printf '%s' "$RAW_JSON" | jq -e '.versions | type == "array"' >/dev/null 2>&1; then
+  printf '::error::%s does not contain a valid "versions" array\n' "$MATRIX_FILE" >&2
+  exit 1
+fi
+
+# ── Build matrix: all entries ──────────────────────────────────────────────────
+BUILD_MATRIX="$(printf '%s' "$RAW_JSON" | jq -c '.versions')"
+
+# ── CI matrix: ci:true CE entries only ────────────────────────────────────────
+CI_MATRIX="$(printf '%s' "$RAW_JSON" | jq -c '[.versions[] | select(.ci == true and .channel == "CE")]')"
+
+# ── Sanity: CI matrix must not be empty ───────────────────────────────────────
+CI_COUNT="$(printf '%s' "$CI_MATRIX" | jq 'length')"
+if [ "$CI_COUNT" -eq 0 ]; then
+  printf '::error::CI matrix is empty — no ci:true CE entries in %s\n' "$MATRIX_FILE" >&2
+  exit 1
+fi
+
+# ── Emit ──────────────────────────────────────────────────────────────────────
+if [ "$DO_GITHUB_OUTPUT" -eq 1 ]; then
+  if [ -z "${GITHUB_OUTPUT:-}" ]; then
+    printf '::error::GITHUB_OUTPUT is not set — cannot write step outputs\n' >&2
+    exit 1
+  fi
+  # Use heredoc delimiter to safely embed JSON (may contain special chars).
+  {
+    printf 'build_matrix<<__EOF_BUILD_MATRIX__\n%s\n__EOF_BUILD_MATRIX__\n' "$BUILD_MATRIX"
+    printf 'ci_matrix<<__EOF_CI_MATRIX__\n%s\n__EOF_CI_MATRIX__\n' "$CI_MATRIX"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+if [ "$DO_PRINT_BUILD" -eq 1 ]; then
+  if [ "$DO_PRINT_CI" -eq 1 ]; then
+    printf 'BUILD matrix:\n'
+  fi
+  printf '%s' "$BUILD_MATRIX" | jq .
+fi
+
+if [ "$DO_PRINT_CI" -eq 1 ]; then
+  if [ "$DO_PRINT_BUILD" -eq 1 ]; then
+    printf '\nCI matrix:\n'
+  fi
+  printf '%s' "$CI_MATRIX" | jq .
+fi


### PR DESCRIPTION
## ADR-09: Scheduled version tracking & release automation

Implements [ADR-09](.ADRs/ADR_09_Release_Version_Automation/ADR.md) end-to-end (7 phases, one commit each). A curated, decoupled supported-version **matrix** drives the release `.pkg` build, the GHCR smoke-image refresh, and the CI smoke fan-out — with **zero writes to the channel branches**.

Dev-only CI/workflow change — **no `src/` (shipped) code touched**. The new workflows are `workflow_dispatch`/`workflow_call`-only, so PR CI runs lint+unit (`test.yml`); their runtime behaviour is validated by the maintainer's §7 manual checklist (the nature of a CI/workflow ADR).

### Phases

| # | What |
| --- | --- |
| P1 | **Inventory** the two existing builders: `build-pkg-linux.yml` (portable, **default**) + `build-pkg.yml` (FreeBSD `make package`, **oracle/fallback**) — "Linux default, FreeBSD if we fuck up". No spike (premise already proven). |
| P2 | Decoupled **supported-version matrix** (`supported-versions.json` on the `ci-metadata` **orphan ref**) carrying the `(freebsd_version, php_version)` pair + a reader (`scripts/read-version-matrix.sh` + composite action). **Repoints `build-image.yml`'s `resolve-version` (issue #22) at the matrix** — one place to add a version, reject-unknown contract preserved. |
| P3 | Release: build a `.pkg` per matrix entry against its `(freebsd, php)` pair (portable-default / FreeBSD-fallback, `builder:` selectable), attach **one per distinct FreeBSD major** to the Release. **`ports-pr` stays intact** (`needs: release` only). |
| P4 | Scheduled **version-tracker** — react = release build + live CI refresh/fan-out; nudge-only probe; `actions: write` only, **zero channel-branch writes**. |
| P5 | `image-refresh.yml` — upgrade-in-place + **fail-closed** 6-check sanity gate (generalises the existing single-version `build-image.yml`). |
| P6 | `smoke-fanout.yml` — `strategy.matrix` over `ci:true` CE images, **`fail-fast: false`**, **AND-gate** (`all-smoke-passed` is green only if every leg passed; red on any fail/skip/cancel/zero-legs). **Never Plus** (double-excluded). |
| P7 | Docs (`README` / `CLAUDE.md` / `scripts/README.md`) + §7 DoD + ADR-04 §2 reconciliation flag. |

### Reconciliation with #22

PR #105's `resolve-version` case-map was the single-version stopgap; P2's matrix is its strategic home. `resolve-version` now fetches `origin/ci-metadata`, looks up by CE prefix, and hard-fails on unmapped — same contract, now matrix-driven.

### Definition of done (maintainer manual checklist — §7)

Status stays **Proposed** until the maintainer confirms: `.pkg` installs on each FreeBSD major (CE + Plus); a matrix edit triggers the build round-trip with no channel-branch commit; a tag still produces the Release **and** the ports PR, now with `.pkg` artifacts; the sanity gate rejects a broken upgrade / accepts a good one; the smoke fan-out AND-gate goes red on one failed leg; the version-tracker dry-run dispatches correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matrix-driven release builds with per‑major .pkg naming, portable default builder and FreeBSD fallback.
  * Manual/automated image-refresh with a fail‑closed health gate and non‑blocking post‑publish smoke check.
  * Parallel smoke-test fan‑out across all CI-marked CE images with an all‑or‑nothing AND gate.
  * Daily/manual version tracker that dispatches builds, image refreshes, and smoke runs; release can pick builder and auto-attaches .pkg assets.

* **Documentation**
  * Reworked CE bump into a 3-step procedure and added supported-version matrix guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->