### PR TITLE
pfblockerng: extract + unit-test wizard skip/auto-launch decisions (#88, follows #111)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1715,6 +1715,47 @@ if (!defined('PFB_HOOK_KILL_GRACE')) {
 }
 
 /*
+ * Setup-wizard decision helpers (pure; pinned by tests/php/WizardDecisionTest.php).
+ * The pfblockerng_wizard.inc / pfblockerng_general.php controllers do the impure work
+ * (read $_POST/$_GET/config, redirect, write_config, set $pfb_wizard); the branchy
+ * decisions live here so the fast PHPUnit tier covers them (issue #88).
+ */
+
+/*
+ * From a submitted Skip on the setup wizard, decide the exit action: 'disable' (also
+ * stop future auto-launch) when the suppress checkbox is ticked, 'skip' (this session
+ * only) otherwise, or NULL when Skip was not pressed.
+ */
+function pfb_wizard_skip_action(array $post): ?string {
+	if (!isset($post['skip'])) {
+		return null;
+	}
+	return !empty($post['pfb_wizard_suppress']) ? 'disable' : 'skip';
+}
+
+/*
+ * Normalise the ?wizard=<action> query parameter to the recognised set ('skip' |
+ * 'disable'); NULL for anything else. Drives the persist-on-'disable' write and the
+ * auto-launch suppression.
+ */
+function pfb_wizard_get_action(array $get): ?string {
+	$action = $get['wizard'] ?? '';
+	return in_array($action, array('skip', 'disable'), true) ? $action : null;
+}
+
+/*
+ * TRUE if the setup wizard must NOT auto-launch: an explicit ?wizard=skip this
+ * request, the persisted disable flag ($wizard_skip_flag === 'on'), or the package
+ * already configured ($config_zero non-empty). A fresh, unconfigured install with no
+ * skip/disable returns FALSE (the wizard does auto-launch).
+ */
+function pfb_wizard_suppress_autolaunch(?string $get_action, $wizard_skip_flag, $config_zero): bool {
+	return $get_action === 'skip'
+		|| $wizard_skip_flag === 'on'
+		|| !empty($config_zero);
+}
+
+/*
  * Return the enabled hook entries matching $when ('pre'|'post'), in list order.
  *
  * Pure helper: takes the pfBlockerNG config array (config/0) so it can be unit

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -30,19 +30,21 @@ pfb_global();
 // Add Wizard tab on new installations only
 $pfb_wizard = TRUE;
 
+$wizard_action = pfb_wizard_get_action($_GET ?: array());
+
 // "Do not show this again": persist the choice so the setup wizard never auto-launches
 // again. Stored outside config/0 so a fresh, unconfigured install still reads as
 // unconfigured (config/0 == null) for the upgrade-migration paths in pfblockerng_install.inc.
-if ($_GET && isset($_GET['wizard']) && $_GET['wizard'] == 'disable') {
+if ($wizard_action === 'disable') {
 	config_set_path('installedpackages/pfblockerng/pfb_wizard_skip', 'on');
 	write_config('[pfBlockerNG] Disable setup wizard auto-launch');
 }
 
 // Skip the auto-launch for this request ('skip'), permanently ('disable' persisted),
 // or once the package has been configured.
-if (($_GET && isset($_GET['wizard']) && $_GET['wizard'] == 'skip') ||
-    config_get_path('installedpackages/pfblockerng/pfb_wizard_skip') == 'on' ||
-    !empty(config_get_path('installedpackages/pfblockerng/config/0'))) {
+if (pfb_wizard_suppress_autolaunch($wizard_action,
+    config_get_path('installedpackages/pfblockerng/pfb_wizard_skip'),
+    config_get_path('installedpackages/pfblockerng/config/0'))) {
 	$pfb_wizard = FALSE;
 }
 

--- a/src/usr/local/www/wizards/pfblockerng_wizard.inc
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.inc
@@ -36,11 +36,11 @@ $pfb_wizard['interface_list_cnt']	= count($pfb_wizard['interface_list']) ?: '1';
 // wizard never auto-launches again ('disable'); otherwise skip for this
 // session only ('skip'). pfblockerng_general.php applies both actions.
 function pfb_wizard_skip_check() {
-	if (!$_POST || !isset($_POST['skip'])) {
+	$action = pfb_wizard_skip_action($_POST ?: array());
+	if ($action === null) {
 		return;
 	}
 
-	$action = !empty($_POST['donotshowthisagain']) ? 'disable' : 'skip';
 	header("Location: /pfblockerng/pfblockerng_general.php?wizard={$action}");
 	exit;
 }

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -121,7 +121,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>Do not show this again</name>
+			<name>pfb_wizard_suppress</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
@@ -169,7 +169,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>Do not show this again</name>
+			<name>pfb_wizard_suppress</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
@@ -231,7 +231,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>Do not show this again</name>
+			<name>pfb_wizard_suppress</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
@@ -310,7 +310,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>Do not show this again</name>
+			<name>pfb_wizard_suppress</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
@@ -345,7 +345,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>Do not show this again</name>
+			<name>pfb_wizard_suppress</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>

--- a/tests/php/WizardDecisionTest.php
+++ b/tests/php/WizardDecisionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Setup-wizard decision helpers (issue #88) — the pure logic behind the Skip button
+ * and the auto-launch guard added in #111. The pfblockerng_wizard.inc /
+ * pfblockerng_general.php controllers do the impure work (read $_POST/$_GET/config,
+ * redirect, write_config, set $pfb_wizard); these pure deciders are what determines
+ * behaviour, so they are pinned here in the fast tier. Branch coverage: every input
+ * class of all three functions, including the "fresh unconfigured install still
+ * auto-launches" case the general.php comment explicitly worries about.
+ */
+#[CoversFunction('pfb_wizard_skip_action')]
+#[CoversFunction('pfb_wizard_get_action')]
+#[CoversFunction('pfb_wizard_suppress_autolaunch')]
+final class WizardDecisionTest extends TestCase
+{
+	// --- pfb_wizard_skip_action(): Skip button + suppress checkbox -> action --- //
+
+	public function testSkipNotPressedReturnsNull(): void
+	{
+		$this->assertNull(pfb_wizard_skip_action([]));
+		// A POST without the Skip button (e.g. Next/Back) is not a skip.
+		$this->assertNull(pfb_wizard_skip_action(['back' => 'Back']));
+	}
+
+	public function testSkipWithoutSuppressIsSessionSkip(): void
+	{
+		// Skip pressed, checkbox absent -> skip for this session only.
+		$this->assertSame('skip', pfb_wizard_skip_action(['skip' => 'Skip']));
+	}
+
+	public function testSkipWithSuppressIsDisable(): void
+	{
+		// Skip pressed, checkbox ticked ('on') -> persist disable.
+		$this->assertSame('disable', pfb_wizard_skip_action(['skip' => 'Skip', 'pfb_wizard_suppress' => 'on']));
+	}
+
+	public function testSuppressCheckboxFalseyValuesStaySkip(): void
+	{
+		// An empty / unchecked value must not count as ticked.
+		$this->assertSame('skip', pfb_wizard_skip_action(['skip' => 'Skip', 'pfb_wizard_suppress' => '']));
+		$this->assertSame('skip', pfb_wizard_skip_action(['skip' => 'Skip', 'pfb_wizard_suppress' => '0']));
+	}
+
+	// --- pfb_wizard_get_action(): ?wizard=<action> normalisation --- //
+
+	public function testGetActionRecognisedValues(): void
+	{
+		$this->assertSame('skip', pfb_wizard_get_action(['wizard' => 'skip']));
+		$this->assertSame('disable', pfb_wizard_get_action(['wizard' => 'disable']));
+	}
+
+	public function testGetActionUnrecognisedOrAbsentIsNull(): void
+	{
+		$this->assertNull(pfb_wizard_get_action([]));
+		$this->assertNull(pfb_wizard_get_action(['wizard' => '']));
+		$this->assertNull(pfb_wizard_get_action(['wizard' => 'bogus']));
+		$this->assertNull(pfb_wizard_get_action(['other' => 'skip']));
+	}
+
+	// --- pfb_wizard_suppress_autolaunch(): the three OR'd suppression triggers --- //
+
+	public function testFreshUnconfiguredInstallAutoLaunches(): void
+	{
+		// THE case the general.php comment guards: no skip, no persisted flag, and
+		// config/0 unset (null) or empty -> the wizard MUST auto-launch (not suppressed).
+		$this->assertFalse(pfb_wizard_suppress_autolaunch(null, null, null));
+		$this->assertFalse(pfb_wizard_suppress_autolaunch(null, '', []));
+	}
+
+	public function testExplicitSkipSuppresses(): void
+	{
+		$this->assertTrue(pfb_wizard_suppress_autolaunch('skip', null, null));
+	}
+
+	public function testPersistedDisableFlagSuppresses(): void
+	{
+		$this->assertTrue(pfb_wizard_suppress_autolaunch(null, 'on', null));
+	}
+
+	public function testAlreadyConfiguredSuppresses(): void
+	{
+		// config/0 non-empty means the package is configured -> no auto-launch.
+		$this->assertTrue(pfb_wizard_suppress_autolaunch(null, null, ['enable_cb' => 'on']));
+	}
+
+	public function testDisableActionAloneDoesNotSuppressThisRequest(): void
+	{
+		// ?wizard=disable is NOT a per-request suppressor by itself (only 'skip' is);
+		// it suppresses via the flag it persists, which general.php reads back as 'on'.
+		$this->assertFalse(pfb_wizard_suppress_autolaunch('disable', null, null));
+		$this->assertTrue(pfb_wizard_suppress_autolaunch('disable', 'on', null));
+	}
+}


### PR DESCRIPTION
Follow-up to #111 (and part of #88's "pure-decision / impure-apply split, pinned by the #39 PHPUnit pattern"). #111 added the wizard **Skip** button + **"do not show again"** with **no test coverage** — the show/skip decision logic lived inline in the www/wizard controllers (UI-only), exactly the blind spot #88 targets. (The `PHPUnit unit tests` check passing on #111 only meant the *existing* suite still passed.)

## What changed

**Extracted 3 pure deciders into `pfblockerng.inc`** (where `tests/php` loads the real include; both controllers already `require` it):
- `pfb_wizard_skip_action(array $post): ?string` — Skip + suppress checkbox → `'skip'` / `'disable'` / `null`.
- `pfb_wizard_get_action(array $get): ?string` — normalises `?wizard=<action>` to the recognised set.
- `pfb_wizard_suppress_autolaunch(?string $get_action, $flag, $config0): bool` — the three OR'd auto-launch suppressors (explicit skip / persisted disable flag / already-configured).

`pfblockerng_wizard.inc` (`pfb_wizard_skip_check`) and `pfblockerng_general.php` now just read the superglobals/config and apply the side effects (redirect, `write_config`, `$pfb_wizard`). **Behaviour-identical** — each branch maps 1:1 to the prior inline logic.

**Pinned with `tests/php/WizardDecisionTest.php`** — branch coverage of every input class, including the **"fresh, unconfigured install still auto-launches"** case the `general.php` comment explicitly guards (the config/0-vs-flag distinction).

**Renamed** the suppress checkbox field `donotshowthisagain` → `pfb_wizard_suppress` (the wizard `<name>` drives the `$_POST` key — verified pfSense preserves underscores; `<displayname>` keeps the visible label).

## Verification

PHPUnit **153** (incl. the new cases); **PHPStan level 1 clean** (the typed helpers need no baseline entry — and they pass the ratchet from the #88 work); `php -l` clean; `xmllint` well-formed; full Python suite (1089) + linters green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified setup-wizard decision logic to consistently handle "Skip" vs "Do not show this again" and when the wizard auto-launches.

* **Tests**
  * Added comprehensive unit tests covering skip/disable resolution, persistent suppression, query normalization, and auto-launch behavior across fresh and configured installs.

* **Chore**
  * Minor wizard UI metadata adjusted to standardize checkbox naming across steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->