### PR TITLE
dev: forbid naked $var interpolation into curl/wget/fetch URLs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -114,6 +114,16 @@ find src scripts tests -name '*.sh' | sort | while IFS= read -r f; do
 	sh -n "$f" || exit 1
 done || failed 'sh -n'
 
+# --- Shell + docs: forbid naked $var interpolation into curl/wget/fetch URLs.
+#     Reuses the python found above for pytest (CI is the hard gate when absent).
+#     Scans tracked src shell + Markdown shell fences via the checker's defaults. ---
+if [ -n "$py_bin" ]; then
+	step 'url-encoding (no naked $var in curl URLs)'
+	"$py_bin" scripts/check_url_encoding.py || failed 'url-encoding'
+else
+	skip url-encoding
+fi
+
 # --- Shell: shellcheck (src + scripts only; tests/ shellspec specs trip SC2034
 #     false-positives — tracked as a separate cleanup) ---
 if have shellcheck; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,13 @@ jobs:
         # tests/ shellspec specs trip SC2034 false-positives (separate cleanup).
         run: find src scripts -name '*.sh' | sort | xargs shellcheck --severity=warning
 
+      - name: Forbid naked $var in curl/wget/fetch URLs
+        # Preventative: a query value jammed straight into a URL (`?ip=$VAR`) breaks
+        # on empty/space-bearing values (e.g. pfBlockerNG's PFB_CHANGED_IP_ALIASES).
+        # Use `--data-urlencode` instead. Scans tracked src shell + Markdown shell
+        # fences (the checker's defaults). ubuntu-latest ships python3.
+        run: python3 scripts/check_url_encoding.py
+
   shell-tests:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -566,6 +566,20 @@ ShellCheck via VS Code extension. All scripts use `#!/bin/sh` (POSIX sh, not bas
 `.shellcheckrc` suppresses SC1091 (pfSense source files unreachable locally) and
 SC2154 (rc(8)-injected variables). Do not suppress other rules without justification.
 
+**URL-encoding check (`scripts/check_url_encoding.py`).** A preventative gate that
+forbids naked shell-variable interpolation into an HTTP-client (`curl`/`wget`/`fetch`)
+URL query — e.g. `curl "http://h/cb?ip=$VAR"`. A space-separated or empty value (such
+as pfBlockerNG's `PFB_CHANGED_IP_ALIASES`) jammed into the URL breaks: the space
+re-tokenises the command and the parameter collapses. The fix is to let the value ride
+its own option so curl percent-encodes it: `curl --data-urlencode "ip=$VAR" http://h/cb`
+(NOT flagged). With no args it scans every tracked `*.sh` script (the `src/**`
+hook/pre-script surface plus dev `scripts`/`tests` shell, mirroring the shebang/`sh -n`
+checks) AND the `sh`/`bash`/`shell`-tagged fenced code blocks in tracked Markdown docs
+(so the hook/webhook recipe examples are guarded too); static query params (`?fixed=1`)
+and base/host/path interpolation are out of scope. Enforced in both `.githooks/pre-commit` and CI (`test.yml` ShellCheck job);
+pure detection lives in `find_violations()` and is unit-tested in
+`tests/test_url_encoding_check.py`.
+
 ### Markdown
 
 markdownlint via the VS Code "markdownlint" extension and the CLI. Run from repo root:

--- a/scripts/check_url_encoding.py
+++ b/scripts/check_url_encoding.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Forbid naked shell-variable interpolation into an HTTP-client URL query.
+
+PROBLEM
+-------
+A query parameter whose value is a shell variable jammed straight into the URL —
+
+    curl "http://host/cb?ip=$PFB_CHANGED_IP_ALIASES"
+
+— breaks the moment that value is empty or contains whitespace. pfBlockerNG's
+``PFB_CHANGED_IP_ALIASES`` (and similar hook payloads) are *space-separated*
+lists that may also be empty: the space splits the URL, the shell re-tokenises
+the command, and the parameter silently collapses or the request fails. The
+value must be percent-encoded, which curl/wget do for you when the value rides
+its own option rather than the literal URL:
+
+    curl --data-urlencode "ip=$PFB_CHANGED_IP_ALIASES" http://host/cb
+
+This check is PREVENTATIVE — there are no offenders in shipped code today. It
+guards future shell scripts and the user-facing hook/webhook recipe examples in
+the docs against re-introducing the naked-interpolation footgun.
+
+HEURISTIC (deliberately low false-positive)
+-------------------------------------------
+* Only *logical* lines that invoke an HTTP client are considered: a word-boundary
+  ``curl``, ``wget`` or ``fetch``. Backslash-continued shell lines are joined into
+  one logical line first, so a URL sitting on a continuation is still seen.
+* Within such a line we inspect URL-looking TOKENS only — a token containing
+  ``://``, or a quoted token that begins with ``http``/``https``, or a token that
+  contains a ``?`` query separator. A violation is a query parameter assigned a
+  shell variable inside that token: ``[?&]<key>=$`` (e.g. ``?ip=$VAR`` /
+  ``&k=${VAR}``), including ``$`` immediately after ``?``/``&``/``=``.
+* The CORRECT form ``--data-urlencode "k=$VAR"`` is NOT flagged: that value rides
+  its own flag token, which has no ``://`` and no leading ``?``/``&`` query
+  separator, so it never qualifies as a URL token. (Pinned by a test.)
+* NOT flagged: static query params (``?fixed=1``), and a variable used only as
+  base/host/path with no query value (``"$BASE/path"``, ``"http://h/$ID"``).
+  Path-segment interpolation is INTENTIONALLY out of scope — it is lower
+  confidence (a path segment rarely carries whitespace-bearing list payloads)
+  and scoping to query values keeps the noise floor near zero.
+
+The detection logic lives in :func:`find_violations` (pure, importable) so it is
+unit-tested directly without a subprocess. The :func:`main` CLI, with no args,
+resolves the file list via ``git ls-files`` — every tracked ``*.sh`` script (the
+``src/**`` hook/pre-script surface, plus dev ``scripts``/``tests`` shell, mirroring
+the pre-commit shebang/`sh -n` checks that also scan all tracked shell) and every
+tracked ``*.md`` (scanning only the shell-tagged fenced blocks) — or it scans the
+explicit paths passed as args. It prints ``path:line: <message>`` to stderr,
+exiting 1 if any violation is found.
+
+This is dev-only tooling (release archives contain only ``src/``); it lives under
+``scripts/`` and is wired into ``.githooks/pre-commit`` and CI.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from typing import NamedTuple
+
+# HTTP clients whose URL argument is the footgun surface.
+_HTTP_CLIENT_RE = re.compile(r"(?<![\w-])(?:curl|wget|fetch)(?![\w-])")
+
+# A query parameter assigned a shell variable: `?key=$VAR`, `&key=$VAR`, or a
+# bare `$` right after the `?`/`&`/`=` separator. `[^=&\s"']*` keeps the key on
+# the same token (no spaces); the trailing `\$` is the shell expansion.
+_NAKED_QUERY_VAR_RE = re.compile(r"[?&][^=&\s\"']*=\$")
+
+# Fix hint surfaced in every message (asserted by the tests).
+_FIX_HINT = 'use `curl --data-urlencode "key=$VAR"` so the value is percent-encoded'
+
+# Markdown fenced-block opener with a shell language tag (sh/bash/shell).
+_SHELL_FENCE_RE = re.compile(r"^(\s*)(`{3,}|~{3,})\s*(sh|bash|shell)\s*$", re.IGNORECASE)
+# A generic fence opener/closer (any or no language) — to detect fence boundaries.
+_FENCE_RE = re.compile(r"^(\s*)(`{3,}|~{3,})\s*([^\s`~]*)\s*$")
+
+
+class Violation(NamedTuple):
+    """One naked-interpolation finding."""
+
+    source: str  # file path (or path with a fence note for Markdown)
+    line: int  # 1-based line number within the source file
+    snippet: str  # the offending logical line (trimmed)
+    message: str  # actionable description incl. the --data-urlencode fix
+
+
+def _looks_like_url_token(token: str) -> bool:
+    """True if a shell token looks like an HTTP URL or a query string.
+
+    Confines the naked-variable match to URL-bearing tokens, so option values
+    such as ``--data-urlencode "k=$V"`` (a separate, non-URL token) are excluded.
+    """
+    stripped = token.strip("\"'")
+    if "://" in stripped:
+        return True
+    if stripped.startswith(("http", "https")):
+        return True
+    # A bare query string token (rare, but `?k=$V` with no scheme still encodes).
+    return stripped.startswith("?")
+
+
+def _split_tokens(line: str) -> list[str]:
+    """Whitespace-split a logical line, keeping quoted spans intact.
+
+    Not a full shell parser — it only needs to keep a quoted URL (which may
+    contain ``&`` and ``?``) as one token and keep an option's quoted value as a
+    token distinct from the URL. Unmatched quotes degrade gracefully to a plain
+    whitespace split of the remainder.
+    """
+    tokens: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    for ch in line:
+        if quote is not None:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            buf.append(ch)
+            continue
+        if ch.isspace():
+            if buf:
+                tokens.append("".join(buf))
+                buf = []
+            continue
+        buf.append(ch)
+    if buf:
+        tokens.append("".join(buf))
+    return tokens
+
+
+def _join_continuations(lines: list[str]) -> list[tuple[int, str]]:
+    """Fold ``\\``-continued shell lines into logical lines.
+
+    Returns ``(line_number, logical_line)`` pairs where ``line_number`` is the
+    1-based line on which the logical line STARTS — so a violation on a
+    continuation is reported at the ``curl`` invocation's own line.
+    """
+    logical: list[tuple[int, str]] = []
+    pending: list[str] = []
+    start_no = 0
+    for line_no, raw in enumerate(lines, start=1):
+        stripped = raw.rstrip("\n")
+        if not pending:
+            start_no = line_no
+        if stripped.endswith("\\"):
+            pending.append(stripped[:-1])
+            continue
+        pending.append(stripped)
+        logical.append((start_no, " ".join(p.strip() for p in pending)))
+        pending = []
+    if pending:
+        logical.append((start_no, " ".join(p.strip() for p in pending)))
+    return logical
+
+
+def _scan_logical_line(line: str) -> bool:
+    """True if a logical line naked-interpolates a var into an HTTP-client URL."""
+    if not _HTTP_CLIENT_RE.search(line):
+        return False
+    for token in _split_tokens(line):
+        if _looks_like_url_token(token) and _NAKED_QUERY_VAR_RE.search(token):
+            return True
+    return False
+
+
+def _iter_shell_fence_blocks(lines: list[str]) -> list[tuple[int, list[str]]]:
+    """Yield ``(start_line, block_lines)`` for each ```sh/```bash/```shell fence.
+
+    ``start_line`` is the 1-based file line of the fence's FIRST content line, so
+    offsets within the returned block map back to absolute file lines. Only the
+    block content is returned (fence markers excluded). Non-shell fences are
+    skipped entirely.
+    """
+    blocks: list[tuple[int, list[str]]] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        m = _SHELL_FENCE_RE.match(lines[i].rstrip("\n"))
+        if not m:
+            # If this is some other fence opener, skip to its close so a
+            # `?k=$V` inside e.g. a ```python block is never scanned.
+            fm = _FENCE_RE.match(lines[i].rstrip("\n"))
+            if fm and fm.group(3) != "":
+                fence = fm.group(2)[0]
+                i += 1
+                while i < n and not _is_fence_close(lines[i], fence):
+                    i += 1
+                i += 1
+                continue
+            i += 1
+            continue
+        fence = m.group(2)[0]
+        content_start = i + 2  # 1-based line of first content line
+        body: list[str] = []
+        j = i + 1
+        while j < n and not _is_fence_close(lines[j], fence):
+            body.append(lines[j])
+            j += 1
+        blocks.append((content_start, body))
+        i = j + 1
+    return blocks
+
+
+def _is_fence_close(line: str, fence_char: str) -> bool:
+    """True if ``line`` closes a fence opened with ``fence_char`` (` or ~)."""
+    s = line.strip()
+    return len(s) >= 3 and set(s) == {fence_char}
+
+
+def find_violations(text: str, source: str) -> list[Violation]:
+    """Find naked-interpolation violations in shell ``text`` from ``source``.
+
+    ``text`` is treated as shell script content. Backslash continuations are
+    joined first; each logical line is scanned and, on a hit, reported at the
+    line where the invocation starts.
+    """
+    violations: list[Violation] = []
+    for line_no, logical in _join_continuations(text.splitlines()):
+        if _scan_logical_line(logical):
+            violations.append(
+                Violation(
+                    source=source,
+                    line=line_no,
+                    snippet=logical.strip(),
+                    message=(f"naked shell variable in an HTTP-client URL query parameter; {_FIX_HINT}"),
+                )
+            )
+    return violations
+
+
+def find_violations_in_markdown(text: str, source: str) -> list[Violation]:
+    """Find violations inside the shell-tagged fenced code blocks of Markdown.
+
+    Only ```sh / ```bash / ```shell fences are scanned; other fences (and prose)
+    are ignored. Reported line numbers are absolute within the Markdown file.
+    """
+    violations: list[Violation] = []
+    lines = text.splitlines()
+    for content_start, body in _iter_shell_fence_blocks(lines):
+        for rel_no, logical in _join_continuations(body):
+            if _scan_logical_line(logical):
+                abs_line = content_start + (rel_no - 1)
+                violations.append(
+                    Violation(
+                        source=source,
+                        line=abs_line,
+                        snippet=logical.strip(),
+                        message=(
+                            "naked shell variable in an HTTP-client URL query "
+                            f"parameter (in a shell code block); {_FIX_HINT}"
+                        ),
+                    )
+                )
+    return violations
+
+
+def _git_tracked(patterns: list[str]) -> list[str]:
+    """Return git-tracked files matching the given pathspecs (sorted, unique)."""
+    try:
+        out = subprocess.run(
+            ["git", "ls-files", "-z", *patterns],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    return sorted({p for p in out.split("\0") if p})
+
+
+def _default_files() -> tuple[list[str], list[str]]:
+    """Resolve the default scan set: (shell files, markdown files)."""
+    shell = _git_tracked(["*.sh"])
+    markdown = _git_tracked(["*.md"])
+    return shell, markdown
+
+
+def _scan_path(path: str) -> list[Violation]:
+    """Scan one file by extension; unreadable files are skipped silently."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        return []
+    if path.endswith(".md"):
+        return find_violations_in_markdown(text, path)
+    return find_violations(text, path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns 0 (clean) or 1 (violations found)."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args:
+        paths = args
+    else:
+        shell, markdown = _default_files()
+        paths = shell + markdown
+
+    violations: list[Violation] = []
+    for path in paths:
+        violations.extend(_scan_path(path))
+
+    for v in violations:
+        print(f"{v.source}:{v.line}: {v.message}", file=sys.stderr)
+        print(f"    {v.snippet}", file=sys.stderr)
+
+    if violations:
+        print(
+            f"\n{len(violations)} naked-URL-interpolation violation(s). "
+            "Percent-encode the value with curl/wget --data-urlencode instead "
+            "of jamming a shell variable into the URL query.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_url_encoding.py
+++ b/scripts/check_url_encoding.py
@@ -159,6 +159,11 @@ def _join_continuations(lines: list[str]) -> list[tuple[int, str]]:
 
 def _scan_logical_line(line: str) -> bool:
     """True if a logical line naked-interpolates a var into an HTTP-client URL."""
+    # A comment-only line (e.g. a "# curl ...?ip=$VAR" anti-pattern shown in a doc
+    # or recipe) is not executed, so it must not be flagged -- otherwise a legitimate
+    # "don't do this" example would fail pre-commit/CI.
+    if line.lstrip().startswith("#"):
+        return False
     if not _HTTP_CLIENT_RE.search(line):
         return False
     for token in _split_tokens(line):

--- a/tests/test_url_encoding_check.py
+++ b/tests/test_url_encoding_check.py
@@ -1,0 +1,210 @@
+"""Tests for scripts/check_url_encoding.py.
+
+Covers BOTH branches per dimension per CLAUDE.md's test-coverage rules: every
+case that flags a violation is paired with the corresponding correct form that
+must stay clean, so a green proves the heuristic discriminates rather than always
+firing (or never firing).
+
+The checker is a hyphen-free, underscore-named script under scripts/, so it is
+importable directly by path via importlib.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Load the script as a module.
+# --------------------------------------------------------------------------- #
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_url_encoding.py"
+_spec = importlib.util.spec_from_file_location("check_url_encoding", _TOOL)
+assert _spec is not None and _spec.loader is not None
+cue = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = cue
+_spec.loader.exec_module(cue)
+
+
+def _find(text: str, source: str = "t.sh") -> list[Any]:
+    return cue.find_violations(text, source)
+
+
+def _find_md(text: str, source: str = "t.md") -> list[Any]:
+    return cue.find_violations_in_markdown(text, source)
+
+
+# --------------------------------------------------------------------------- #
+# Shell — bad (flagged) vs good (clean)
+# --------------------------------------------------------------------------- #
+
+
+def test_shell_curl_naked_query_var_is_flagged() -> None:
+    v = _find('curl "http://h/x?ip=$VAR"')
+    assert len(v) == 1
+    assert v[0].line == 1
+    assert v[0].source == "t.sh"
+    assert "--data-urlencode" in v[0].message
+
+
+def test_shell_wget_naked_query_var_with_ampersand_is_flagged() -> None:
+    v = _find('wget "http://h?a=1&k=$V"')
+    assert len(v) == 1
+    assert v[0].line == 1
+    assert "--data-urlencode" in v[0].message
+
+
+def test_shell_fetch_naked_query_var_is_flagged() -> None:
+    v = _find('fetch "https://h/cb?ip=$IP"')
+    assert len(v) == 1
+    assert "--data-urlencode" in v[0].message
+
+
+def test_shell_braced_var_is_flagged() -> None:
+    v = _find('curl "http://h/x?ip=${PFB_CHANGED_IP_ALIASES}"')
+    assert len(v) == 1
+
+
+def test_shell_data_urlencode_correct_form_is_clean() -> None:
+    # The GOOD form: value rides its own flag token, not the URL token.
+    assert _find('curl --data-urlencode "ip=$VAR" http://h/x') == []
+
+
+def test_shell_data_urlencode_unquoted_is_clean() -> None:
+    assert _find("curl --data-urlencode ip=$VAR http://h/x") == []
+
+
+def test_shell_data_urlencode_alongside_static_query_is_clean() -> None:
+    # A static query on the URL plus the variable carried by --data-urlencode.
+    assert _find('curl "http://h/x?fixed=1" --data-urlencode "ip=$VAR"') == []
+
+
+def test_shell_static_query_param_is_clean() -> None:
+    assert _find('curl "http://h/x?fixed=1"') == []
+
+
+def test_shell_base_var_no_query_is_clean() -> None:
+    assert _find('curl "$BASE/path"') == []
+
+
+def test_shell_path_segment_var_is_clean() -> None:
+    # Path-segment interpolation is intentionally out of scope.
+    assert _find('curl "http://h/$ID"') == []
+
+
+def test_non_http_client_line_with_query_var_is_clean() -> None:
+    # Same `?k=$V` shape, but not a curl/wget/fetch invocation.
+    assert _find('echo "http://h/x?ip=$VAR"') == []
+
+
+def test_curl_substring_word_is_not_an_http_client() -> None:
+    # `curling` / `mycurl` must not match (word-boundary).
+    assert _find('curling "http://h/x?ip=$VAR"') == []
+
+
+# --------------------------------------------------------------------------- #
+# Continuation handling — bad vs good
+# --------------------------------------------------------------------------- #
+
+
+def test_shell_continuation_url_is_flagged_at_start_line() -> None:
+    text = 'curl \\\n  "http://h/cb?ip=$VAR"'
+    v = _find(text)
+    assert len(v) == 1
+    # Reported at the curl line (logical line start), not the continuation.
+    assert v[0].line == 1
+
+
+def test_shell_continuation_data_urlencode_is_clean() -> None:
+    text = 'curl \\\n  --data-urlencode "ip=$VAR" \\\n  http://h/cb'
+    assert _find(text) == []
+
+
+def test_shell_before_state_static_then_var_transition() -> None:
+    # Before-state: the static-query line alone is clean.
+    static_only = 'curl "http://h/cb?fixed=1"'
+    assert _find(static_only) == []
+    # After swapping the static value for a naked variable, it is flagged —
+    # proving the variable interpolation (not merely the query) is the cause.
+    naked = 'curl "http://h/cb?fixed=$VAR"'
+    assert len(_find(naked)) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Markdown fenced blocks — bad vs good vs non-shell
+# --------------------------------------------------------------------------- #
+
+
+def test_markdown_shell_fence_naked_var_is_flagged_with_right_line() -> None:
+    md = '# Title\n\nText.\n\n```sh\ncurl "http://h/cb?ip=$VAR"\n```\n'
+    v = _find_md(md)
+    assert len(v) == 1
+    # The curl line is line 6 (1-based) in the file.
+    assert v[0].line == 6
+    assert "--data-urlencode" in v[0].message
+
+
+def test_markdown_bash_fence_naked_var_is_flagged() -> None:
+    md = '```bash\nwget "http://h?k=$V"\n```\n'
+    v = _find_md(md)
+    assert len(v) == 1
+    assert v[0].line == 2
+
+
+def test_markdown_shell_fence_data_urlencode_is_clean() -> None:
+    md = '```sh\ncurl --data-urlencode "ip=$VAR" http://h/cb\n```\n'
+    assert _find_md(md) == []
+
+
+def test_markdown_non_shell_fence_is_not_scanned() -> None:
+    # A ```python block with the naked pattern must NOT be scanned.
+    md = '```python\nrequests.get("http://h/x?ip=$VAR")\n```\n'
+    assert _find_md(md) == []
+
+
+def test_markdown_prose_outside_fence_is_not_scanned() -> None:
+    # The pattern in prose (no fence) is ignored.
+    md = 'Run curl "http://h/x?ip=$VAR" to break things.\n'
+    assert _find_md(md) == []
+
+
+def test_markdown_before_state_good_then_bad_fence() -> None:
+    good = '```sh\ncurl --data-urlencode "ip=$VAR" http://h/cb\n```\n'
+    assert _find_md(good) == []
+    bad = '```sh\ncurl "http://h/cb?ip=$VAR"\n```\n'
+    assert len(_find_md(bad)) == 1
+
+
+# --------------------------------------------------------------------------- #
+# CLI (main) over real temp files — exit codes both ways
+# --------------------------------------------------------------------------- #
+
+
+def test_main_returns_1_on_violation_and_prints_fix(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    f = tmp_path / "hook.sh"
+    f.write_text('#!/bin/sh\ncurl "http://h/cb?ip=$VAR"\n')
+    rc = cue.main([str(f)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--data-urlencode" in err
+    assert f"{f}:2:" in err
+
+
+def test_main_returns_0_on_clean_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    f = tmp_path / "hook.sh"
+    f.write_text('#!/bin/sh\ncurl --data-urlencode "ip=$VAR" http://h/cb\n')
+    rc = cue.main([str(f)])
+    assert rc == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_main_scans_markdown_by_extension(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    f = tmp_path / "recipe.md"
+    f.write_text('```sh\ncurl "http://h/cb?ip=$VAR"\n```\n')
+    rc = cue.main([str(f)])
+    assert rc == 1
+    assert "--data-urlencode" in capsys.readouterr().err

--- a/tests/test_url_encoding_check.py
+++ b/tests/test_url_encoding_check.py
@@ -106,6 +106,15 @@ def test_curl_substring_word_is_not_an_http_client() -> None:
     assert _find('curling "http://h/x?ip=$VAR"') == []
 
 
+def test_shell_comment_only_line_is_clean() -> None:
+    # A "don't do this" anti-pattern shown in a comment is not executed, so it must
+    # not be flagged. Paired with the uncommented form (flagged) to prove the leading
+    # `#` is the reason, not the absence of the pattern.
+    assert len(_find('curl "http://h/x?ip=$VAR"')) == 1
+    assert _find('# curl "http://h/x?ip=$VAR"') == []
+    assert _find('   # curl "http://h/x?ip=$VAR"') == []  # leading whitespace too
+
+
 # --------------------------------------------------------------------------- #
 # Continuation handling — bad vs good
 # --------------------------------------------------------------------------- #
@@ -158,6 +167,13 @@ def test_markdown_bash_fence_naked_var_is_flagged() -> None:
 def test_markdown_shell_fence_data_urlencode_is_clean() -> None:
     md = '```sh\ncurl --data-urlencode "ip=$VAR" http://h/cb\n```\n'
     assert _find_md(md) == []
+
+
+def test_markdown_shell_fence_comment_only_line_is_clean() -> None:
+    # A commented anti-pattern inside a shell fence (illustrating what NOT to do)
+    # must not be flagged; the uncommented form on its own would be.
+    assert len(_find_md('```sh\ncurl "http://h/cb?ip=$VAR"\n```\n')) == 1
+    assert _find_md('```sh\n# curl "http://h/cb?ip=$VAR"  # BAD\n```\n') == []
 
 
 def test_markdown_non_shell_fence_is_not_scanned() -> None:


### PR DESCRIPTION
## Forbid naked `$var` interpolation into curl/wget/fetch URLs

A preventative lint check: flags shell that interpolates a variable as a **query-parameter value** straight into an HTTP-client URL — e.g. `curl "http://h/x?ip=$VAR"` — and points the author at `curl --data-urlencode "ip=$VAR"`.

**Why:** values like pfBlockerNG's `PFB_CHANGED_IP_ALIASES` / `PFB_CHANGED_DNSBL_GROUPS` are space-separated (and may be empty); jammed naked into a URL the embedded space makes curl reject it and the param can collapse. ShellCheck has no URL-encoding awareness, so this is a custom check.

### Heuristic (low false-positive)

Per logical line (backslash-continuations joined), require a word-boundary `curl`/`wget`/`fetch`, then flag only **URL-looking tokens** (contain `://`, start `http`, or start `?`) that carry `[?&]key=$…`. The correct form `--data-urlencode "k=$VAR"` is **excluded** — its value rides a separate flag token with no `://`/`?`, so the URL-token confinement never matches it (pinned by a dedicated test). Static params (`?fixed=1`), base/host (`"$BASE/path"`) and path-segment interpolation are out of scope.

### Scope

Scans every tracked `*.sh` **and** the ` ```sh `/` ```bash `/` ```shell ` fenced blocks in `*.md` (the hook/webhook recipes users copy). Currently **zero offenders** in the tree.

### Wiring + tests

- `scripts/check_url_encoding.py` — importable `find_violations()` + a CLI.
- Pre-commit: a new `url-encoding` step mirroring the existing shebang-policy idiom.
- CI: a step in the shellcheck job (feeds the merge-gating aggregate).
- `tests/test_url_encoding_check.py` — 24 cases, both branches per dimension (shell good/bad, markdown good/bad, continuation, `--data-urlencode` clean, non-shell fence ignored, CLI exit codes).
- CLAUDE.md Linting section documents it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safety check that flags unencoded shell-variable usage in HTTP-client URLs and suggests URL-encoding fixes.

* **Tests**
  * Added comprehensive unit and CLI tests covering flagged/allowed cases, continued lines, and Markdown fenced blocks.

* **Chores**
  * Integrated the check into pre-commit and CI shell linting.

* **Documentation**
  * Added guidance on the check, scanning scope, and recommended safe usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->