### PR TITLE
pfblockerng: rename wizard suppress checkbox field to pfb_wizard_disable (follows #119)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1730,7 +1730,7 @@ function pfb_wizard_skip_action(array $post): ?string {
 	if (!isset($post['skip'])) {
 		return null;
 	}
-	return !empty($post['pfb_wizard_suppress']) ? 'disable' : 'skip';
+	return !empty($post['pfb_wizard_disable']) ? 'disable' : 'skip';
 }
 
 /*

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -121,7 +121,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>pfb_wizard_suppress</name>
+			<name>pfb_wizard_disable</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
@@ -169,7 +169,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>pfb_wizard_suppress</name>
+			<name>pfb_wizard_disable</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
@@ -231,7 +231,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>pfb_wizard_suppress</name>
+			<name>pfb_wizard_disable</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
@@ -310,7 +310,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>pfb_wizard_suppress</name>
+			<name>pfb_wizard_disable</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>
@@ -345,7 +345,7 @@
 			<type>submit</type>
 		</field>
 		<field>
-			<name>pfb_wizard_suppress</name>
+			<name>pfb_wizard_disable</name>
 			<displayname>Do not show this again</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;skip-&gt;noshow</bindstofield>
 			<description>Tick this and press Skip to exit and never launch this wizard automatically again.</description>

--- a/tests/php/WizardDecisionTest.php
+++ b/tests/php/WizardDecisionTest.php
@@ -37,14 +37,14 @@ final class WizardDecisionTest extends TestCase
 	public function testSkipWithSuppressIsDisable(): void
 	{
 		// Skip pressed, checkbox ticked ('on') -> persist disable.
-		$this->assertSame('disable', pfb_wizard_skip_action(['skip' => 'Skip', 'pfb_wizard_suppress' => 'on']));
+		$this->assertSame('disable', pfb_wizard_skip_action(['skip' => 'Skip', 'pfb_wizard_disable' => 'on']));
 	}
 
 	public function testSuppressCheckboxFalseyValuesStaySkip(): void
 	{
 		// An empty / unchecked value must not count as ticked.
-		$this->assertSame('skip', pfb_wizard_skip_action(['skip' => 'Skip', 'pfb_wizard_suppress' => '']));
-		$this->assertSame('skip', pfb_wizard_skip_action(['skip' => 'Skip', 'pfb_wizard_suppress' => '0']));
+		$this->assertSame('skip', pfb_wizard_skip_action(['skip' => 'Skip', 'pfb_wizard_disable' => '']));
+		$this->assertSame('skip', pfb_wizard_skip_action(['skip' => 'Skip', 'pfb_wizard_disable' => '0']));
 	}
 
 	// --- pfb_wizard_get_action(): ?wizard=<action> normalisation --- //


### PR DESCRIPTION
Follow-up to #119 — rename the setup-wizard suppress checkbox field `pfb_wizard_suppress` → `pfb_wizard_disable` (it maps to the `'disable'` action, so the name now matches what ticking it does).

- `pfblockerng_wizard.xml`: the field `<name>` on all **5** skip steps (the wizard `<name>` drives the `$_POST` key; `<displayname>` keeps the "Do not show this again" label).
- `pfblockerng.inc`: `pfb_wizard_skip_action()` reads `$post['pfb_wizard_disable']`.
- `tests/php/WizardDecisionTest.php`: the corresponding test keys.

Token-precise — the predicate function **`pfb_wizard_suppress_autolaunch()` is intentionally unchanged** (it describes *suppressing the auto-launch*, still the right verb). No behaviour change.

PHPStan level 1 clean; PHPUnit 153; `php -l` clean; `xmllint` well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Standardized internal wizard field naming across wizard decision handling to improve code consistency and clarity.

* **Tests**
  * Updated test coverage to reflect internal naming updates while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->