### PR TITLE
pfblockerng: rawurlencode the IPinfo ASN token in the download URL

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -579,8 +579,12 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 			$feed['username'] = $pfb['maxmind_account'];
 			$feed['password'] = $pfb['maxmind_key'];
 		}
-		elseif ($feed['type'] == 'asn') { 
-			$feed['url'] = "{$feed['url']}{$pfb['asn_token']}";
+		elseif ($feed['type'] == 'asn') {
+			// rawurlencode the token so URL correctness does not depend on the input
+			// validator's strictness. Today's tokens are word chars only (rawurlencode
+			// is a no-op on them), but encoding here keeps the query well-formed if the
+			// token format ever changes (e.g. base64/JWT with '=' '.' '/').
+			$feed['url'] = "{$feed['url']}" . rawurlencode($pfb['asn_token']);
 		}
 		else {
 			$feed['username'] = $feed['username'] ?: '';


### PR DESCRIPTION
## rawurlencode the IPinfo ASN token in the download URL

`pfblockerng.php` appends the IPinfo ASN token onto `https://ipinfo.io/data/free/asn.{mmdb,csv.gz}?token=` before fetching it. Today that's safe **only** because `PFB_FILTER_WORD` rejects any non-word char at save — i.e. URL safety is coupled to the input validator's strictness.

This encodes the token at the point of use so the query is well-formed regardless of what's stored:

```php
$feed['url'] = "{$feed['url']}" . rawurlencode($pfb['asn_token']);
```

- **Zero behavior change today.** `rawurlencode` leaves RFC 3986 unreserved chars (`A-Za-z0-9_.~-`) untouched, and current tokens are word-chars only — so the result is byte-identical for every token that can currently be saved.
- **Removes the coupling.** Output encoding now lives at URL construction, not bolted onto input validation. If IPinfo ever moves to a base64/JWT-style token (`=`, `.`, `/`), the query stays correct.
- **Leaves the shared validator alone.** `PFB_FILTER_WORD` also guards Category alias names (which become `pfB_*`/`DNSBL_*` pf-table names) and MaxMind creds — relaxing it would be unsafe. Accepting a new token charset, if ever needed, belongs in a token-specific filter, not here.

No functional test reaches the WebUI download URL-build path; the change is provably a no-op for all currently-acceptable tokens. `php -l` + PHPStan + the PHPUnit/pytest suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed download reliability by encoding authentication tokens in feed URLs, reducing failures during automated retrieval and updates.

* **Documentation**
  * Added inline comments clarifying when and why URL encoding is required for tokens to aid future maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->