### PR TITLE
ADR-16: Feeds IPv4/IPv6/DNSBL tabs + type-scoped save + live mock-feed load smoke

### DIFF
--- a/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/ADR.md
+++ b/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/ADR.md
@@ -1,6 +1,6 @@
 # ADR-16: Feeds page IPv4/IPv6/DNSBL tabs + live mock-feed load smoke
 
-- **Status:** **Proposed** (2026-06-05)
+- **Status:** **Implemented (pending smoke test)** (2026-06-05)
 - **Date:** 2026-06-05
 - **Branch:** `adr/16` (off **`devel`**) / **Component(s):**
   `src/usr/local/www/pfblockerng/pfblockerng_feeds.php` (the split + the type-scoped
@@ -287,15 +287,17 @@ Prompt: `06_Docs_DoD.txt`
 
 ## 7. Definition of done
 
-- `python -m pytest` unchanged; `ruff`/`php -l`/ShellCheck/PHPStan clean; the ADR-14 UI tiers
-  (retargeted to the typed URLs) green.
+- `python -m pytest` unchanged (1115 passed); `ruff`/`php -l`/ShellCheck/PHPStan clean; the
+  ADR-14 UI tiers (retargeted to the typed URLs) green.
 - `pfblockerng_feeds.php` serves IPv4/IPv6/DNSBL sub-tabs; the save is type-scoped; the cross-type
-  non-clobber test + the 3 `?type` render entries are green on the live VM.
-- The HTTP-feed load smoke is green for the representative formats (or Part C is demoted to
-  dispatch-only with the gap recorded).
-- Status flips **Proposed → Implemented (pending smoke test)** once Part A + its tests hold on
-  `adr/16`; it flips to **Accepted** once the affected-flow UI tests below are green on the live VM
-  (the `ui-tests`-labeled suite) — **no human manual-smoke gate**.
+  non-clobber test + the 3 `?type` render entries are authored on `adr/16`.
+- The HTTP-feed load smoke is authored for all 6 representative formats (Part C: OPTIMISTIC-GO,
+  PENDING-CI — see below and `RESULTS/05_Results.txt`).
+- **Status: Implemented (pending smoke test).** Part A (the split + save + functional/render
+  tests) and Part C (the HTTP-feed load smoke + the `ui_browser` tabs test) are all authored
+  in-repo on `adr/16`. Status flips to **Accepted** once the affected-flow UI tests below are
+  confirmed green on the live VM (the `ui-tests`-labeled CI suite) — **there is no human
+  manual-smoke gate; Accept rides on the automated tests.**
 
 ### Reject / demote criteria (decide on evidence)
 
@@ -309,23 +311,61 @@ Prompt: `06_Docs_DoD.txt`
 - **`_MockFeedServer` can't serve a needed format faithfully** (curl rejects it) → drop that format
   from the smoke set with a note; keep the rest.
 
-### Affected-flow UI tests (replace the manual smoke; land as a post-initial-merge step)
+### Affected-flow UI tests (replace the manual smoke — NO human manual-smoke gate)
 
 > The old maintainer live-box manual smoke is **replaced by automated UI tests** on the ADR-04
-> live VM (`ui-tests`-labeled). They may land as a **fast-follow after Part A's initial merge** —
-> the split + the functional/render tests merge first; these complete the picture and **gate
-> Accept**. (An optional human glance at the browser-tier screenshot artifact is review, not a gate.)
+> live VM (`ui-tests`-labeled). **There is no human manual-smoke gate** — Accept rides entirely
+> on these automated tests being green on the live VM. An optional human glance at the
+> browser-tier screenshot artifact is review, not a gate.
+>
+> All tests listed below are **authored in-repo** on `adr/16`. The items marked
+> "PENDING live-VM green" have been locally verified to collect under their markers
+> (no VM here — the live CI run confirms pass/fail).
 
-- [ ] **Tabs render (each type, incl. visual).** `feeds_ipv4`/`feeds_ipv6`/`feeds_dnsbl` pass the
-  Tier-A render oracle (Phase 3, with the merge), AND a **`ui_browser` test screenshots each tab +
-  asserts the second sub-tab row `[IPv4 | IPv6 | DNSBL]`** and that each tab lists only its type
-  (Phase 5, post-merge) — the visual replacement for the old eyeball.
-- [ ] **Type-scoped save / no clobber.** The cross-type non-clobber `ui_e2e` test (Phase 3): saving
-  the IPv4 tab leaves DNSBL renames intact, and vice-versa.
-- [ ] **Custom feed loads.** The HTTP-feed load smoke (Phase 5, post-merge): representative IP +
-  DNSBL feeds served over the mock load via Force Update and are asserted on the box
-  (`pfctl_table_members` / `dns_probe`).
-- [ ] **No regressions.** The retargeted per-type rename/alt-URL `ui_e2e`/`ui_browser` tests
-  (Phases 2–3) stay green on the typed URLs.
+- [x] **Tabs render (each type) — Tier-A render oracle.**
+  `tests/smoke/ui/test_render_smoke.py` entries `feeds_ipv4` / `feeds_ipv6` /
+  `feeds_dnsbl` (marker `ui_render`): authenticated GET of
+  `pfblockerng_feeds.php?type=ipv4|ipv6|dnsbl` → 200, body free of PHP errors, the
+  type-specific marker present, no new `php_error.log` line. **PENDING live-VM green.**
 
-All run in CI on the live VM; **Accept is when they pass** — there is no human manual-smoke gate.
+- [x] **Tabs render (visual, incl. screenshots) — `ui_browser` tabs test.**
+  `tests/smoke/ui/test_browser_feeds.py::test_feeds_subtab_row_active_and_type_scoped`
+  (marker `ui_browser`, parametrized `gtype = ipv4 / ipv6 / dnsbl`): headless
+  Chromium opens `pfblockerng_feeds.php?type=<gtype>`, asserts the second sub-tab row
+  `[IPv4 | IPv6 | DNSBL]` is present + the active tab is highlighted and the other two
+  are not + the type's Feed Settings label is in the DOM while the other two are absent,
+  and writes `feeds_subtab_<gtype>.png` screenshots. **PENDING live-VM green.**
+
+- [x] **Type-scoped save / no clobber.**
+  `tests/smoke/ui/test_feeds.py::test_feed_rename_cross_type_save_does_not_clobber`
+  (marker `ui_e2e`): saves the IPv4 tab → confirms DNSBL renames intact; then saves
+  the DNSBL tab → confirms IPv4 renames intact. Transition test (asserts before AND
+  after each save). **PENDING live-VM green.**
+
+- [x] **HTTP-feed load smoke (Part C kill-gate + format matrix).**
+  `tests/smoke/test_smoke_feeds.py` (marker `smoke`), 6 cases:
+  - `test_ip_http_feed_loads` — `ip_plain_cidr.txt`, v4 (KILL-GATE — first proof)
+  - `test_ip_http_range_feed_loads` — `ip_range.txt`, v4 range
+  - `test_ipv6_http_feed_loads` — `ip_ipv6.txt`, v6
+  - `test_dnsbl_http_feed_loads` — `dnsbl_plain.txt` (KILL-GATE — first DNSBL proof)
+  - `test_dnsbl_http_hosts_feed_loads` — `dnsbl_hosts.txt`
+  - `test_dnsbl_http_abp_feed_loads` — `dnsbl_abp.txt` (ABP `@@` allow proven)
+
+  Each case: before-state asserted (alias absent / domain resolves), then
+  `CaseContext` runs Force Update over `mock_feeds.feed_url(<fixture>)`, then
+  after-state asserted (`pfctl_table_members` / `rule_references` for IP;
+  `dns_probe` block-shape + non-member resolves for DNSBL).
+
+  **Part-C outcome: all 6 representative formats authored; none dropped. ZERO
+  formats silently omitted from the Phase-4 set. GO/DEMOTE is PENDING-CI
+  (OPTIMISTIC-GO — ≥ 4/5 bar; fast-follow demote switch documented). If < 4/5
+  clean on the live CI run, demote `test_smoke_feeds.py` to dispatch-only and
+  record here.** PENDING live-VM green.
+
+- [x] **No regressions — per-type rename + alt-URL flows.**
+  `tests/smoke/ui/test_feeds.py` (marker `ui_e2e`): per-type rename and alt-URL
+  round-trip tests on the typed URLs (`?type=ipv4 / ipv6 / dnsbl`), retargeted from
+  the old single-page URL in Phase 2 + 3. **PENDING live-VM green.**
+
+All run in CI on the live VM under the `ui-tests` label; **Accept is when they pass**
+— there is no human manual-smoke gate.

--- a/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/01_Results.txt
@@ -1,0 +1,118 @@
+ADR-16 — Phase 1 Results
+PREP (behaviour-preserving): extract per-type Feeds rendering helpers
+
+STATUS: DONE. Pure refactor. Only src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+changed. No UX/save/test/parser change. Full all-types page renders identically.
+
+================================================================================
+HELPER SIGNATURES (both new, file-scope in pfblockerng_feeds.php)
+================================================================================
+
+1) pfb_feeds_render_aliasname_inputs($section, $type, $feeds_list, $pconfig)
+   - Location: just above url_compare() (~line 138).
+   - $section : the open Form_Section('Feed Settings','feedsettings',...) object.
+   - $type    : 'ipv4' | 'ipv6' | 'dnsbl'.
+   - $feeds_list, $pconfig : passed BY VALUE; helper only READS them (no mutation).
+   - Emits that type's StaticText label ("IPv4/IPv6/DNSBL Alias name(s):" + its
+     help line) followed by its feed_<lower(alias)> Form_Input set (->setWidth(3)),
+     byte-identical to the three inline loops it replaced.
+   - Page call sites (~605-607): called for 'ipv4', then 'ipv6', then 'dnsbl', in
+     that order, into the single shared $section. Phase 3 = call it for the active
+     type only (one line).
+
+2) pfb_feeds_render_predefined_type($ftype, $info)
+   - Location: just above the $pgtitle assignment, after url_compare() (~line 262).
+   - $ftype : 'ipv4' | 'ipv6' | 'dnsbl'.
+   - $info  : $feed_info[$ftype] (the per-type slice of convert_feeds_json()).
+   - Renders that type's <tr> rows for the "Pre-defined Alias/Group/Feeds" table,
+     including the alt-URL radio group, the hidden alt_<header> input, the per-row
+     icons/links, the blank-separator <tr> between categories, and the alternating
+     row background — verbatim move of the former per-type body of
+     `foreach ($feed_info as $ftype => $info):`. The empty-$info `continue` became a
+     `return` (one type = one call).
+   - Page call site (~734-736): still wrapped in `foreach ($feed_info as $ftype =>
+     $info) { pfb_feeds_render_predefined_type($ftype, $info); }`. Phase 3 = drop the
+     foreach and call once with the active $ftype.
+
+================================================================================
+HOISTED SHARED STATE (the table helper) — and Phase-3 interaction
+================================================================================
+The predefined-feeds table threads several variables ACROSS the three type
+iterations. They stay at PAGE (global) scope, initialised before the loop exactly
+as before, and the helper binds them with `global` (mirroring url_compare, which
+already does `global $ex_feeds, $alt_feeds, $icon`). Two `global` lines in the helper:
+
+    global $ex_feeds, $alt_feeds, $icon, $fconfig, $feed_alt_selected;
+    global $alt_selected, $feed_info_row, $aliasname_found;
+
+Cross-type accumulators (must persist between calls — they DO, via global):
+  - $alt_selected     : CSV of all feeds with Alternate URLs; built across all
+                        types, rtrim'd + emitted ONCE in the hidden
+                        <input name="alt_selected"> after the loop (unchanged).
+  - $feed_info_row     : running row counter; gates the blank separator <tr> before
+                        the first row of types 2 and 3.
+  - $aliasname_found   : accumulates matched aliasnames across types.
+  - $feed_alt_selected : default-radio selections; appended to inside the helper.
+url_compare-shared / read-only state (also bound via global):
+  - $ex_feeds, $alt_feeds : built by url_compare()'s `global`; helper reads them.
+  - $icon                 : the per-feed icon (set in helper, mirrors original).
+  - $fconfig              : read for the feed_alt_<header> saved-default check.
+
+Within-type locals ($p_type, $p_aliasname, $p_tr_style, $tr_style, $status,
+$feed_header, $feed_radio, $feed_alternate, $alt_feed, $counter, $i) stay local to
+the helper. NOTE: $p_type was ALREADY reset to '' at the top of each type iteration
+in the original (line was inside the type foreach), so making it helper-local is
+faithful — the first row of every type still prints the bold "<TYPE> Category"
+header and the leading blank separator. The accumulators above are the ONLY state
+that needed to remain page-global.
+
+PHASE-3 INTERACTION (single active type): because all the cross-type accumulators
+are page-global and `$alt_selected` is emitted by the page after the loop, rendering
+ONE type is simply: keep the page-scope init (`$alt_selected=''`, `$feed_info_row=0`,
+`$aliasname_found=[]`), and call pfb_feeds_render_predefined_type($active, $feed_info
+[$active]) once instead of the 3-iteration foreach. The hidden alt_selected CSV then
+naturally scopes to the rendered type (exactly what A3's type-scoped save relies on,
+per ADR §2 A3 / "the alt_selected CSV is naturally scoped to the rendered type").
+The aliasname-inputs helper is likewise a one-arg change (call only for $active).
+
+================================================================================
+ONE BEHAVIOUR-PRESERVING ADJUSTMENT (not a logic change)
+================================================================================
+The first table's `switch ($ftype)` assigns $type for ipv4/ipv6/dnsbl with no
+default. Originally this ran in PAGE scope, so $type "leaked" and PHPStan inferred it
+defined. Now it lives inside the helper, so PHPStan (correctly) flagged $type as
+possibly-undefined for an out-of-range $ftype (2 NEW errors). Fixed by defaulting the
+guarded var: `$type = '';` immediately before the switch (the documented safe pattern;
+the three real cases always assign, so no render change for any real $ftype).
+Verified this does NOT affect the SECOND table ("Unknown user defined Feeds"): that
+table sets its own $type via `foreach (... as $feedtype => $type)`, and its $p_type
+first-row branch (`$type != $p_type`) is taken in BOTH old (leaked $p_type='dnsbl',
+case-mismatched) and new ($p_type undefined) — identical output; $p_type is then
+reassigned each row. No baseline edit; baseline file untouched.
+
+================================================================================
+VERIFICATION GATES (all green)
+================================================================================
+- php -l pfblockerng_feeds.php : "No syntax errors detected." (the 4 url_compare
+  required-after-optional DEPRECATIONS are PRE-EXISTING on devel — that function was
+  only relocated, not changed; confirmed by stashing the diff: same 4 on baseline).
+- vendor/bin/phpstan analyse --memory-limit=1G : [OK] No errors (no NEW vs baseline;
+  baseline has 4 pre-existing feeds.php entries, all still valid, none added).
+- python -m pytest -q : 1115 passed (unchanged; smoke tree --ignore'd by default).
+- ruff check . / ruff format --check . : clean / 69 files already formatted
+  (no Python touched this phase).
+
+Tier-A render marker for the page — "Pre-defined Alias/Group/Feeds" (the panel
+heading, test_render_smoke.py PAGE_TABLE "feeds" entry) — is untouched and intact.
+
+Scope: `git diff --stat` = 1 file (pfblockerng_feeds.php), +358/-343, net helper
+extraction. No other src/ file, no parser, no test change.
+
+================================================================================
+GO-AHEAD FOR PHASE 2
+================================================================================
+Cleared. Phase 1 leaves the all-types page rendering identically with per-type
+rendering now in two type-keyed helpers. Phase 2 (test-first) pins the CURRENT
+per-type save semantics (DNSBL + IPv6 rename round-trip on the single page) — no
+src/ change required there; the save handler is unchanged by this phase. Phase 3 can
+then make the body type-filtering a one-argument change against these helpers.

--- a/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/02_Results.txt
@@ -1,0 +1,132 @@
+ADR-16 — Phase 2 Results
+PREP (test-first): pin the CURRENT per-type Feeds save semantics
+
+STATUS: DONE (local gates green; live ui-tests CI run PENDING — see below).
+Tests only. Only tests/smoke/ui/test_feeds.py changed (+151/-3). NO src/ change.
+
+================================================================================
+WHAT THIS PHASE PINS
+================================================================================
+The CURRENT (pre-split) single all-types Feeds page persists a per-type rename for
+EACH type to config.xml. These live-VM ui_e2e oracle tests are the green bar that
+Phase 3's type-scoped save MUST keep green. They pin TODAY's behaviour ONLY — they
+do NOT pre-encode the Phase-3 sub-tab split (no ?type, no partial single-type POST).
+
+On the current page the save loops EVERY type, and WebUI.post() re-scrapes + re-POSTs
+every other feed_* field at its present value, so a one-field override here does NOT
+clobber the other types. The cross-type NON-clobber case only becomes possible once
+Phase 3's split makes a partial, single-type POST exist — it is added BESIDE these
+in Phase 3 (save IPv4 tab -> DNSBL renames intact, and vice-versa).
+
+================================================================================
+EXACT CONFIG NODES TARGETED (the oracle reads these via helpers.config_get)
+================================================================================
+Aliasnames are the per-type top-level keys in pfblockerng_feeds.json; the page
+renders feed_<lower(aliasname)> and the save writes
+installedpackages/pfblockerngglobal/feed_<lower(aliasname)>.
+
+  IPv4  (pre-existing, unchanged):
+    alias  PRI1
+    field  feed_pri1
+    node   installedpackages/pfblockerngglobal/feed_pri1
+
+  IPv6  (NEW this phase):
+    alias  PRI1_6   (IPv6 Primary Tier collection — IPv6 sibling of PRI1; no status flag)
+    field  feed_pri1_6
+    node   installedpackages/pfblockerngglobal/feed_pri1_6
+
+  DNSBL (NEW this phase):
+    alias  ADs      (collection of advertisement domain feeds; no status flag, plain word)
+    field  feed_ads
+    node   installedpackages/pfblockerngglobal/feed_ads
+
+Both new aliases are stable across the support matrix (shipped in the JSON, no
+"discontinued" status). PRI1_6 mirrors the already-pinned IPv4 PRI1 exactly; ADs is
+a stable DNSBL group.
+
+================================================================================
+NEW TEST FUNCTION NAMES (tests/smoke/ui/test_feeds.py, marker ui_e2e)
+================================================================================
+  test_feed_rename_ipv6_save_changes_effective_config
+      IPv6 PRI1_6 rename round-trip (empty -> word-only name -> empty), both ways.
+
+  test_feed_rename_dnsbl_save_changes_effective_config
+      DNSBL ADs rename round-trip (empty -> word-only name -> empty), both ways.
+
+  test_feed_rename_dnsbl_invalid_alias_is_rejected_config_unchanged
+      DNSBL reject branch: seed a valid override, POST "ADs bad" (space -> /\W/),
+      assert config UNCHANGED (save aborts before write_config).
+
+Pre-existing (unchanged) IPv4 oracles, kept green:
+  test_feed_rename_save_changes_effective_config
+  test_feed_rename_invalid_alias_is_rejected_config_unchanged
+
+Each NEW test is a TRUE transition test (CLAUDE.md): asserts the BEFORE-state
+(empty/default, or the seeded value for the reject case) FIRST, drives the CSRF
+form POST, asserts the AFTER-state via config.xml, then RESTORES in finally
+(_config_del). The oracle is config.xml over SSH, never the POST response body.
+
+Branch coverage: per-type accept path (valid rename persists) for IPv6 + DNSBL,
+PLUS the DNSBL reject path (invalid alias rejected, config unchanged). The IPv6
+reject path is NOT separately re-pinned — the rename validator (preg_match "/\W/")
+is shared verbatim across all three types and is already pinned by the IPv4 and
+DNSBL reject cases; a third copy would be redundant, not a distinct branch.
+
+================================================================================
+SAVE-HANDLER QUIRKS OBSERVED (read END TO END, pfblockerng_feeds.php :69-130)
+================================================================================
+- TYPE-BLIND save (the Phase-3 trap): the save loops
+  `foreach ($pfb['feeds_list'] as $type => $data)` over ALL types and writes each
+  rename as `$_POST['feed_'.$l] ?: ''` -> config_set_path. An ABSENT field is
+  written as ''. So a future per-type tab POSTing only its own fields would reset
+  every OTHER type's rename to empty — this is exactly what Phase 3 fixes and what
+  the cross-type non-clobber test will catch. On the CURRENT page this is harmless
+  because WebUI.post re-POSTs all fields at present value.
+
+- LENGTH GUARD is per-type: the >24-char "Alternate Aliasname" length check is
+  SKIPPED for DNSBL aliases via `!in_array(..., $feeds_list['dnsbl'])`. So the DNSBL
+  reject branch is exercised via the shared `preg_match "/\W/"` (non-word char) path,
+  NOT a length error. The new DNSBL valid value ("ADsRenamed") and IPv6 value
+  ("PRI16renamed") are both word-only and <=24 chars to stay clear of both guards.
+
+- ALT-URL save (alt_selected CSV) is intentionally NOT covered here (as in the
+  pre-existing file) — it needs a browser-faithful multi-value same-name POST
+  (hidden "" + checked radio) that scrape_form_fields cannot reproduce; it is the
+  browser tier's job. NOTE for Phase 3: the hidden `alt_selected` <input> is emitted
+  by the page AFTER the predefined-feeds loop (Phase-1 handoff §HOISTED STATE), so
+  when the body renders ONE type the CSV is naturally scoped to that type — that is
+  what A3's type-scoped save relies on. No "alt_selected always present" surprise
+  observed; the save's alt block is gated on `isset($_POST['alt_selected'])`.
+
+================================================================================
+VERIFICATION GATES
+================================================================================
+- python -m pytest -q : 1115 passed (UNCHANGED — the whole tests/smoke tree is
+  --ignore'd in default collection, so the new smoke tests don't perturb it).
+- ruff check . : All checks passed.
+- ruff format --check . : 69 files already formatted (the new test file formatted).
+- pytest --collect-only tests/smoke/ui/test_feeds.py -m ui_e2e --override-ini="addopts="
+  : 5 tests collected cleanly (3 new + 2 pre-existing), no syntax/import error.
+
+LIVE-VM PASS STATUS: **PENDING** the `ui-tests`-labeled CI run on the ADR-04 live
+pfSense VM. The live VM is NOT available on the implementer's machine, so the
+authoritative pass was NOT produced locally and is NOT fabricated here. The new
+DNSBL + IPv6 rename oracles describe TODAY's behaviour on the current page; the
+ui-tests CI leg is the authoritative green and is a DoD step. Best-effort local
+validation (default suite unchanged + ruff clean + well-formed collect) is green.
+
+================================================================================
+GO-AHEAD FOR PHASE 3
+================================================================================
+Cleared. The per-type save (IPv4 already pinned; IPv6 PRI1_6 + DNSBL ADs pinned now)
+round-trips to config.xml on the single all-types page — the oracle Phase 3's
+type-scoped save must preserve. Phase 3:
+  - split into ?type sub-tabs (copy category.php), type-filter the body via the
+    Phase-1 helpers (one-arg change), and TYPE-SCOPE the save (hidden `type` field;
+    loop only $pfb['feeds_list'][$type]);
+  - retarget test_render_smoke.py PAGE_TABLE -> feeds_ipv4/feeds_ipv6/feeds_dnsbl
+    and test_feeds.py / test_browser_misc.py to the typed URLs;
+  - ADD the cross-type non-clobber ui_e2e test BESIDE these five (save IPv4 tab ->
+    PRI1_6 + ADs renames intact; save DNSBL tab -> PRI1 intact), now possible because
+    a partial single-type POST exists. Keep all five Phase-2 oracles green on the
+    typed URLs.

--- a/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/03_Results.txt
@@ -1,0 +1,183 @@
+ADR-16 — Phase 3 Results
+THE SPLIT: IPv4/IPv6/DNSBL sub-tabs + type-scoped save + UI-test retarget
+
+STATUS: DONE (local gates green; live ui-tests CI run PENDING — see LIVE PASS below).
+Part A ships here. One src/ file changed (pfblockerng_feeds.php); three smoke test
+files retargeted/extended. NO parser/.inc/.sh/pfb_unbound.py change.
+
+================================================================================
+WHAT SHIPPED (Part A)
+================================================================================
+pfblockerng_feeds.php is now three ?type sub-tabs (IPv4/IPv6/DNSBL), mirroring
+pfblockerng_category.php exactly:
+  - a second display_top_tabs row [IPv4 | IPv6 | DNSBL] -> pfblockerng_feeds.php?type=…
+  - the Feeds TOP tab stays active; breadcrumb is Firewall ▸ pfBlockerNG ▸ Feeds ▸ <type>
+  - only the ACTIVE type renders (Feed Settings alias inputs + predefined-feeds table +
+    the "Unknown user defined Feeds" table), via the Phase-1 helpers called once for $gtype
+  - the save is TYPE-SCOPED (the load-bearing clobber fix).
+
+================================================================================
+?type VALUES + DEFAULT
+================================================================================
+$gtype read from $_REQUEST['type'] via pfb_filter(…, PFB_FILTER_HTML, 'feeds'),
+accepted ONLY if in_array($gtype, array('ipv4','ipv6','dnsbl')); else DEFAULT 'ipv4'.
+  ?type=ipv4   -> IPv4 tab  (DEFAULT; a bare URL with no ?type lands here)
+  ?type=ipv6   -> IPv6 tab
+  ?type=dnsbl  -> DNSBL tab
+Bare URL CONFIRMED to default to ipv4: $gtype is initialised to 'ipv4' before the
+$_REQUEST guard, and the guard only overrides it on a valid value. The other ~12
+pages' plain "/pfblockerng/pfblockerng_feeds.php" links therefore keep working (A4)
+— those pages were NOT edited.
+
+Self-refs all preserve ?type: the form action (action="…?type=<gtype>"), the hidden
+'type' field, the post-save redirect (header Location …?type={$gtype}), $pglinks
+(the Feeds crumb -> …?type={$gtype}), and the second sub-tab row entries. The page's
+OWN top $tab_array Feeds entry stays bare (true) — that is the canonical tab link,
+matching how the IP/DNSBL top tabs link to their canonical pages without ?type.
+
+================================================================================
+TYPE MARKERS USED IN PAGE_TABLE (test_render_smoke.py)
+================================================================================
+The single `feeds` entry was replaced by feeds_ipv4 / feeds_ipv6 / feeds_dnsbl,
+each path "?type=…". Per-entry markers (both must be present in the body):
+  shared : "Pre-defined Alias/Group/Feeds"   (the predefined-feeds panel title)
+  type-specific (the distinguishing marker — derived from the ACTIVE type's Feed
+  Settings alias-name StaticText label, which renders ONLY for the active type):
+    feeds_ipv4  -> "IPv4 Alias name(s):"
+    feeds_ipv6  -> "IPv6 Alias name(s):"
+    feeds_dnsbl -> "DNSBL Alias name(s):"
+The second sub-tab row prints all three labels (IPv4/IPv6/DNSBL) on EVERY tab, so a
+bare "IPv4" would NOT distinguish the views — the "<TYPE> Alias name(s):" StaticText
+label is emitted by pfb_feeds_render_aliasname_inputs($section, $gtype, …) for the
+active type only, making it the correct type-specific oracle marker.
+
+COVERAGE GUARD (test_page_table_covers_every_pfblockerng_page) STILL PASSES:
+the guard does {p.path.split("?",1)[0]} — it strips the query string and counts BASE
+paths. All three typed entries collapse to "/pfblockerng/pfblockerng_feeds.php", the
+one base path already in expected_main. Verified locally: the guard test passes
+(1 passed), and the three feeds_* params collect.
+
+================================================================================
+HOW THE SAVE WAS SCOPED (the fix) + NON-CLOBBER RESULT
+================================================================================
+Hidden field: <input type="hidden" name="type" id="type" value="<gtype>"/> inside
+the form; the active type therefore rides every POST. The save re-derives $gtype
+from $_REQUEST['type'] (which includes $_POST) with the same validate-or-default
+'ipv4' guard.
+
+Loop change: the rename loop NO LONGER loops `foreach ($pfb['feeds_list'] as $type)`
+over ALL types. It now builds
+    $type_data = $pfb['feeds_list'][$gtype] (guarded; [] if absent)
+and loops ONLY `foreach ($type_data as $o_aliasname => $aliasname)`. So the
+config_set_path("…/feed_{$l_aliasname}", …) write only ever touches the ACTIVE
+type's feed_<alias> nodes; an absent type's fields are never iterated, so they are
+never reset to ''. The alt_selected CSV is emitted AFTER the (single-type) predefined
+loop, so it is naturally scoped to the rendered type (Phase-1/Phase-2 handoff note);
+the alt save block is unchanged and gated on isset($_POST['alt_selected']).
+
+Length-guard correctness under scoping: $feeds_list is initialised with all three
+keys empty and only the ACTIVE type is populated. The >24-char guard's
+`!in_array(…, $feeds_list['dnsbl'])` check therefore: on the IPv4/IPv6 tabs
+$feeds_list['dnsbl'] is [] -> the guard APPLIES (correct, those are PF aliases); on
+the DNSBL tab $feeds_list['dnsbl'] holds the DNSBL aliases -> the guard is SKIPPED
+(correct, DNSBL group names have no 24-char PF cap). Behaviour preserved.
+
+NON-CLOBBER TEST (the headline contract guarantee), BOTH DIRECTIONS:
+  tests/smoke/ui/test_feeds.py::test_feed_rename_cross_type_save_does_not_clobber
+  (marker ui_e2e). True transition asserting before AND after, both ways:
+   - GIVEN seed an IPv4 rename (PRI1, feed_pri1) on ?type=ipv4 AND a DNSBL rename
+     (ADs, feed_ads) on ?type=dnsbl; assert BOTH present (the before-state).
+   - WHEN POST the IPv4 tab changing ONLY feed_pri1 -> THEN feed_pri1 took the new
+     value AND feed_ads is UNCHANGED (IPv4 save did not touch DNSBL).
+   - WHEN POST the DNSBL tab changing ONLY feed_ads -> THEN feed_ads took the new
+     value AND feed_pri1 is UNCHANGED (DNSBL save did not touch IPv4).
+  Restore in finally (_config_del both nodes). Oracle is config.xml over SSH, never
+  the POST body. This case is only possible because the split makes a partial,
+  single-type POST exist (WebUI.post GETs the typed page, re-scrapes only that type's
+  fields + the hidden 'type', and re-POSTs to the typed URL).
+  RESULT: PENDING the live ui-tests CI run (the live VM is not available on this
+  machine; not fabricated). Logic verified by trace + the scoped-loop self-review;
+  collects cleanly.
+
+================================================================================
+RETARGETED + NEW TEST FUNCTIONS
+================================================================================
+test_render_smoke.py (ui_render):
+  feeds_ipv4 / feeds_ipv6 / feeds_dnsbl PAGE_TABLE entries (replacing `feeds`).
+  test_page_table_covers_every_pfblockerng_page — UNCHANGED, still passes.
+
+test_feeds.py (ui_e2e) — the five Phase-2 oracles RETARGETED to the typed URLs
+(constants FEEDS_PAGE_IPV4/IPV6/DNSBL = "…?type=…"), MUST stay green:
+  test_feed_rename_save_changes_effective_config                 -> ?type=ipv4
+  test_feed_rename_invalid_alias_is_rejected_config_unchanged    -> ?type=ipv4
+  test_feed_rename_ipv6_save_changes_effective_config            -> ?type=ipv6
+  test_feed_rename_dnsbl_save_changes_effective_config           -> ?type=dnsbl
+  test_feed_rename_dnsbl_invalid_alias_is_rejected_config_unchanged -> ?type=dnsbl
+  NEW: test_feed_rename_cross_type_save_does_not_clobber (above).
+
+test_browser_misc.py (ui_browser):
+  the Feeds alt-URL flow (test_feeds_alt_radio_submit_wiring) now targets
+  FEEDS_PAGE = "/pfblockerng/pfblockerng_feeds.php?type=ipv4" — the IPv4 tab carries
+  the bulk of the pre-defined feeds (and so any Alternate-URL radios). Still skips
+  cleanly when no alt radios render (data-dependent, no false pass).
+
+================================================================================
+LIVE RENDER / FUNCTIONAL / BROWSER PASS STATUS
+================================================================================
+PENDING the `ui-tests`-labeled CI run on the ADR-04 live pfSense VM. The live VM is
+NOT available on the implementer's machine, so the authoritative green is NOT
+produced locally and is NOT fabricated here:
+  - render  (feeds_ipv4/ipv6/dnsbl, Tier-A oracle + type marker)  : PENDING ui-tests CI
+  - functional (per-type rename round-trips + the cross-type non-clobber, both dirs) : PENDING ui-tests CI
+  - browser (alt-URL flow on the typed URL)                       : PENDING ui-tests CI
+Best-effort local validation (below) is green.
+
+================================================================================
+UX NOTE
+================================================================================
+Counts per type (ADR §1): IPv4 17 groups / 88 feeds, IPv6 8 / 10, DNSBL 21 / 134.
+IPv6's 10 feeds now live on their own ?type=ipv6 tab (previously buried in the middle
+of one long all-types scroll). Each tab shows only its type's Feed Settings alias
+inputs, its predefined-feeds table, and its unknown-user-defined-feeds table — the
+same clear IPv4/IPv6/DNSBL organisation as the IP/DNSBL/Reports pages. The aggregate
+"Number of Feeds per Category Type" dl (all three counts) still prints on every tab,
+so the per-type totals stay visible.
+
+================================================================================
+VERIFICATION GATES (local)
+================================================================================
+- php -l pfblockerng_feeds.php : "No syntax errors detected" (exit 0). The PHP 8.5
+  local "Deprecated: url_compare() optional-before-required param" notices are
+  PRE-EXISTING (untouched function signature) and do not fail php -l.
+- vendor/bin/phpstan analyse --no-progress --memory-limit=1G : [OK] No errors.
+- python -m pytest -q : 1115 passed (UNCHANGED — the whole tests/smoke tree is
+  --ignore'd in default collection).
+- ruff check . : All checks passed!   ruff format --check . : 69 files already formatted.
+- mypy tests/ : Success: no issues found in 22 source files.
+- pytest --collect-only on the 3 changed smoke files (override addopts): collects
+  cleanly — feeds_ipv4/ipv6/dnsbl present, the new non-clobber ui_e2e present
+  (6 ui_e2e total). test_browser_misc collects 0 (playwright importorskip — clean
+  skip, not a code error).
+
+================================================================================
+SELF-REVIEW (read the FULL diff)
+================================================================================
+- Only pfblockerng_feeds.php changed in src/ (the other ~12 pages untouched; A4 OK).
+- The save loop is genuinely scoped to ONE type ($type_data = $pfb['feeds_list'][$gtype]);
+  NO remaining `foreach ($pfb['feeds_list'] as $type)` over-all-types `?: ''` write.
+- Form_Section id ('feedsettings'), field names (feed_<alias>, alt_<header>,
+  alt_selected), and config keys (installedpackages/pfblockerngglobal/feed_*,
+  feed_alt_*) are UNCHANGED. Only the tab chrome, the active-type body, and the save
+  SCOPE changed.
+- Non-clobber test asserts BEFORE and AFTER in BOTH directions; restore in finally.
+- PAGE_TABLE coverage-guard logic still holds (strip-? collapse to the one base path).
+- Bare-URL default path ('ipv4') intact.
+VERDICT: PASS.
+
+================================================================================
+GO-AHEAD FOR PHASE 4
+================================================================================
+Cleared. Part A is complete and shippable independent of Parts B/C. Phase 4 authors
+the representative inert sample feeds under tests/smoke/fixtures/ (IP {plain+CIDR,
+range, IPv6}, DNSBL {plain-domain, hosts, ABP/EasyList}); no test wiring yet
+(Phase 5 falsifies the HTTP-fetch path first, then expands).

--- a/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/04_Results.txt
@@ -1,0 +1,152 @@
+ADR-16 — Phase 4 Results
+SAMPLE FEEDS: representative inert fixtures for the supported IP + DNSBL formats
+
+STATUS: DONE. Fixtures only — NO src/ change, NO test wiring, NO new server.
+Local gates green (pytest unchanged 1115 passed; ruff clean; markdownlint clean).
+Phase 5 (the live HTTP-feed load smoke that REGISTERS + asserts these) is CI-only.
+
+================================================================================
+WHERE THE FIXTURES LIVE (the served dir)
+================================================================================
+FIXTURES_DIR = tests/smoke/conftest.py :: SMOKE_DIR / "fixtures"
+             = tests/smoke/fixtures/        (SMOKE_DIR = the tests/smoke/ dir)
+
+_MockFeedServer (conftest.py:379) serves this directory by filename via
+SimpleHTTPRequestHandler (registered in-memory names intercept first, else the
+file is served). The `mock_feeds` fixture (conftest.py:817) stands the server up
+on an OS-picked port bound to 0.0.0.0, mkdir -p's FIXTURES_DIR, and sets
+SmokeVM.feed_base_url.
+
+GUEST URL SHAPE (what the pfSense guest fetches over SLIRP):
+    http://10.0.2.2:<port>/<filename>
+e.g. http://10.0.2.2:<port>/ip_plain_cidr.txt  (GUEST_TO_HOST_ALIAS = 10.0.2.2).
+Phase 5 gets a per-name URL from mock_feeds.feed_url("<filename>") and passes it as
+IpCase.feed_url / DnsblCase.feed_url. (.register(name, content) is the in-memory
+alternative; the files give reviewable, on-disk format coverage.)
+
+================================================================================
+THE 6 SAMPLE FEEDS + the EXACT member / non-member Phase 5 must assert
+================================================================================
+Each file = the raw body curl fetches. Line shapes verified against the real
+parsers: IP 'auto' in pfblockerng.inc (~:10410-10560); DNSBL plain/hosts/ABP in
+pfb_unbound.py (parse / parse_abp, ~:2675-2900). Every file has a '#' (IP / DNSBL
+plain+hosts) or '!'/'[' (ABP) comment line to exercise comment handling.
+
+IP feeds (format 'auto', IpCase; assert via pfctl_table_members(pfB_<alias>_<fam>),
+CIDR-tolerant helpers.member_present):
+
+1) tests/smoke/fixtures/ip_plain_cidr.txt   — plain IPv4 + CIDR, IpCase family="v4"
+   body: 203.0.113.5 / 198.51.100.0/24   (RFC 5737 TEST-NET-2/3)
+   MEMBER (in table):      203.0.113.5      (the plain host)
+   MEMBER (covered by /24): 198.51.100.7    (any host in 198.51.100.0/24)
+   NON-MEMBER (must NOT):    203.0.113.250   (in 203.0.113.x but NOT listed)
+
+2) tests/smoke/fixtures/ip_range.txt        — IPv4 range 'a-b', IpCase family="v4"
+   body: 198.51.100.10-198.51.100.20   (RFC 5737 TEST-NET-3)
+   ip_range_to_subnet_array() expands it to EXACTLY .10..20 inclusive
+   (CIDRs .10/31, .12/30, .16/30, .20/32 — verified with ipaddress).
+   MEMBER (inside):           198.51.100.15
+   NON-MEMBER (just past):    198.51.100.21    (deliberately one past the top)
+   NON-MEMBER (well outside):  198.51.100.200
+
+3) tests/smoke/fixtures/ip_ipv6.txt          — IPv6 single + CIDR, IpCase family="v6"
+   body: 2001:db8::1 / 2001:db8:1::/48   (RFC 3849 documentation prefix)
+   compare IPv6 BY VALUE (:: == ::0).
+   MEMBER (single host):       2001:db8::1
+   MEMBER (covered by /48):    2001:db8:1::99   (any host in 2001:db8:1::/48)
+   NON-MEMBER (must NOT):       2001:db8:dead::1 (outside the /48 AND != 2001:db8::1)
+
+DNSBL feeds (DnsblCase; assert via dns_probe block-shape on the box — NOERROR+VIP or
+NULL per list 'logging'; a non-member / allow-exception must RESOLVE, not block).
+All domains are uuid-<hex>.com (smoke-domain rule: never RFC-6761 .test/.example/
+.invalid — Unbound built-in local-zones shadow them; never HSTS-preload — HSTS
+forces a VIP block to NULL). All pass pfb_unbound normalise()'s label gate.
+
+4) tests/smoke/fixtures/dnsbl_plain.txt       — plain domain list
+   body: uuid-a344db4286a4.com
+   MEMBER (must BLOCK):      uuid-a344db4286a4.com
+   NON-MEMBER (must RESOLVE): uuid-06cf362c2890.com
+
+5) tests/smoke/fixtures/dnsbl_hosts.txt        — hosts '0.0.0.0 <domain>'
+   body: 0.0.0.0 uuid-947e69114606.com   (sink IP stripped -> domain blocks)
+   MEMBER (must BLOCK):      uuid-947e69114606.com
+   NON-MEMBER (must RESOLVE): uuid-55ca85f92f34.com
+
+6) tests/smoke/fixtures/dnsbl_abp.txt           — ABP / EasyList (format_hint='abp')
+   body: '[Adblock Plus 2.0]' header + '!' comment +
+         ||uuid-22f166f56cca.com^         (BLOCK)
+         ||uuid-f26156c6df69.com^         (BLOCK …)
+         @@||uuid-f26156c6df69.com^       (… then ALLOW exception on the SAME name)
+   The feed allow (@@, band 2) BEATS the feed block (||, band 1) — verified against
+   pfb_unbound.py's 6-band priority (PRIO_FEED_ALLOW=2 > PRIO_FEED_BLOCK=1) — so the
+   @@'d name resolves; the un-excepted name blocks.
+   MEMBER (|| only -> must BLOCK):              uuid-22f166f56cca.com
+   ALLOW-EXCEPTION (|| then @@ -> must RESOLVE): uuid-f26156c6df69.com
+   NON-MEMBER (not in feed -> must RESOLVE):     uuid-8ed2df53e469.com
+
+Each file's header comments document its format + the member/non-member; the dir
+README (tests/smoke/fixtures/README.md) tabulates all six.
+
+================================================================================
+PARSER LINE-SHAPE NOTES (so Phase 5 wires the right family/format/case)
+================================================================================
+- IP family split: pfBlockerNG separates v4 / v6 lists. ip_plain_cidr + ip_range are
+  IpCase family="v4" (table pfB_<alias>_v4); ip_ipv6 is family="v6" (pfB_<alias>_v6).
+  IpCase default format is 'auto' (helpers.py:1165 'format':'auto') — all three IP
+  fixtures are 'auto'; no per-case format override needed.
+- IP comment handling proven by the parser read: a full-line '#' (line[0]=='#') and
+  blank lines are skipped; an INLINE '#' truncates (chars after '#' dropped). The
+  fixtures use full-line '#' comments only.
+- DNSBL plain/hosts go through the DEFAULT build (format_hint plain/hosts); the ABP
+  file needs the feed header-sniffed as ABP (format_hint='abp') — pfBlockerNG sniffs
+  the '[Adblock Plus 2.0]' first line automatically, so no DnsblCase override is
+  required for that to trigger (confirm on the live box in Phase 5).
+- ABP '||domain^' and 'hosts'/'plain' are WILDCARD (block name + subdomains); the
+  fixtures assert on the bare name, but Phase 5 MAY also probe a subdomain of a
+  blocked name to exercise the wildcard.
+
+================================================================================
+FORMATS OMITTED (and why) — for Phase 5 scoping
+================================================================================
+- CSV / iblocklist, regex, ABP IP-anchors (||1.2.3.4^), hosts '<ip> <ip>': out of the
+  representative set — they either duplicate plain/hosts/range coverage or divert to
+  the PHP DNSBL-IP FIREWALL pass (not the domain build). Add later if a gap shows.
+- geoip / asn / whois / rsync: explicitly OUT of the hermetic smoke (ADR-16 §2 out-of
+  -scope) — they need MaxMind / egress / binaries. The smoke set is body-only HTTP
+  formats, which is exactly what these fixtures cover.
+- The pre-existing tests/smoke/fixtures/sample_ip_feed.txt is the ADR-04 scaffolding
+  placeholder; left untouched (not one of this phase's six).
+
+================================================================================
+VERIFICATION GATES (local)
+================================================================================
+- python -m pytest -q : 1115 passed (UNCHANGED — tests/smoke is --ignore'd in default
+  collection; this phase adds zero collectable Python).
+- ruff check . : All checks passed!   ruff format --check . : 69 files already formatted.
+  (No .py added — fixtures only — but run for completeness.)
+- npx markdownlint-cli2 tests/smoke/fixtures/README.md : 0 error(s).
+- Range/CIDR math verified with python ipaddress: range expands to exactly .10..20;
+  .21/.200 outside; 198.51.100.7 in /24; 2001:db8:1::99 in /48; 2001:db8:dead::1 out.
+- Domain shapes verified against pfb_unbound normalise() label rules: all 7 OK.
+
+================================================================================
+SELF-REVIEW
+================================================================================
+- git status: 7 NEW untracked files under tests/smoke/fixtures/ ONLY
+  (ip_plain_cidr.txt, ip_range.txt, ip_ipv6.txt, dnsbl_plain.txt, dnsbl_hosts.txt,
+  dnsbl_abp.txt, README.md). NO src/ change, NO test .py change, NO server change.
+- Data lines match the formats (plain IP+CIDR, IPv4 range, IPv6 single+CIDR; DNSBL
+  plain, hosts '0.0.0.0 d', ABP '[Adblock Plus 2.0]' + '||d^' + '@@||d^').
+- Inert only: RFC 5737 / RFC 3849 ranges; uuid-<hex>.com (no RFC-6761, no HSTS).
+- Each file documents format + member + non-member (header comments + README).
+VERDICT: PASS.
+
+================================================================================
+GO-AHEAD FOR PHASE 5
+================================================================================
+Cleared. Phase 5 (kill-gate first): register one IP + one DNSBL fixture via
+mock_feeds.feed_url("<name>") (or .register()), wire an IpCase/DnsblCase(feed_url=…),
+Force Update, assert load (pfctl_table_members / dns_probe block-shape) using the
+member / non-member listed above. Confirm HTTP-fetch reliability (§7 bar ≥4/5);
+only then extend to the remaining four formats. If the HTTP path can't hit the bar,
+demote Part C to dispatch-only and record the numbers in 05_Results.txt.

--- a/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/05_Results.txt
@@ -1,0 +1,221 @@
+ADR-16 — Phase 5 Results
+LIVE HTTP-FEED LOAD SMOKE (Part-C kill-gate) + the Feeds-tabs ui_browser test
+
+STATUS: DONE in code. Tests + fixture WIRING only — NO src/ change, NO new HTTP
+server, NO second VM path. Local gates green (pytest unchanged 1115 passed; ruff
+check + format clean; mypy tests/ clean; the 6 smoke cases + the parametrized
+ui_browser test collect under their markers). The kill-gate reliability and the live
+ui_browser pass are PENDING the live CI run (no VM on this machine — see KILL-GATE).
+
+================================================================================
+WHAT WAS ADDED (two new files, both OUT of default collection)
+================================================================================
+1) tests/smoke/test_smoke_feeds.py        (marker: smoke)
+   The live HTTP feed-fetch path: each case points an IpCase/DnsblCase at
+   mock_feeds.feed_url("<Phase-4 fixture>") (the _MockFeedServer serving
+   tests/smoke/fixtures/ at http://10.0.2.2:<port>/<name> over SLIRP), runs a real
+   Force Update via CaseContext, and asserts the feed loaded on the box. This is the
+   FIRST suite coverage of pfBlockerNG's curl path (gzip/redirects/no-304) — every
+   other smoke case feeds a LOCAL file (write_local_feed). Mirrors
+   test_smoke_matrix.py exactly: same asserts, feed_url = the mock URL instead of
+   write_local_feed.
+
+2) tests/smoke/ui/test_browser_feeds.py   (marker: ui_browser)
+   The visual replacement for the old manual smoke (ADR §7): a headless Chromium
+   opens pfblockerng_feeds.php?type=ipv4|ipv6|dnsbl (reusing the ADR-14 browser-tier
+   _open/_shot/browser_page + screenshot_dir), asserts the second sub-tab row + the
+   active highlight + per-type listing, and writes a per-tab screenshot.
+
+================================================================================
+KILL-GATE RESULT — PENDING THE LIVE CI RUN (NOT measured locally)
+================================================================================
+The Part-C premise ("a Force Update reliably FETCHES an HTTP feed from the mock over
+SLIRP and LOADS it, in CI") is the falsifiable kill-gate. It CANNOT be measured on
+this machine: there is NO pfSense VM here, so no live drill/pfctl/curl evidence
+exists. No reliability number is fabricated.
+
+  * The two proof cases (test_ip_http_feed_loads + test_dnsbl_http_feed_loads) are
+    authored FIRST (the kill-gate ordering, §7), the four format-expansion cases
+    after them.
+  * Reliability bar (ADR §7): >= 4/5 clean runs at a sane per-leg budget.
+  * DECISION: OPTIMISTIC-GO, PENDING-CI. All representative formats are authored
+    (no format silently dropped — see FORMATS below). The PR the orchestrator opens
+    carries the `ui-tests` label, so the live VM run is the actual kill-gate
+    evidence.
+  * IF CI shows < 4/5 clean ⇒ DEMOTE test_smoke_feeds.py to dispatch-only (drop it
+    from the gated smoke set) as a fast-follow — Part A still ships and the
+    local-file load coverage (test_smoke_matrix.py / test_smoke_abp.py) remains. The
+    numbers + the GO/DEMOTE flip go here when CI reports them.
+
+GO/DEMOTE STATUS: PENDING-CI (optimistic GO authored; demote switch documented).
+
+================================================================================
+FORMATS COVERED vs DROPPED
+================================================================================
+COVERED (all 6 representative Phase-4 fixtures, one case each):
+
+  IP (IpCase, pfctl_table_members(pfB_<alias>_<fam>) + rule_references):
+    test_ip_http_feed_loads        ip_plain_cidr.txt  family=v4  (KILL-GATE)
+      member 203.0.113.5 (host) + 198.51.100.7 (in /24); non-member 203.0.113.250
+    test_ip_http_range_feed_loads  ip_range.txt       family=v4
+      inside 198.51.100.15; NOT .21 (one past) / .200 (well outside)
+    test_ipv6_http_feed_loads      ip_ipv6.txt        family=v6
+      member 2001:db8::1 + 2001:db8:1::99 (in /48); non-member 2001:db8:dead::1
+
+  DNSBL (DnsblCase, dns_probe block-shape on the box; mode=VIP):
+    test_dnsbl_http_feed_loads     dnsbl_plain.txt    (KILL-GATE)
+      member uuid-a344db4286a4.com -> VIP; non-member uuid-06cf362c2890.com resolves
+    test_dnsbl_http_hosts_feed_loads dnsbl_hosts.txt
+      member uuid-947e69114606.com -> VIP; non-member uuid-55ca85f92f34.com resolves
+    test_dnsbl_http_abp_feed_loads dnsbl_abp.txt      (ABP / EasyList, header-sniffed)
+      ||uuid-22f166f56cca.com -> VIP; @@||uuid-f26156c6df69.com RESOLVES (@@ beats ||);
+      non-member uuid-8ed2df53e469.com resolves
+
+DROPPED: none from the Phase-4 representative set. (Phase 4 already scoped OUT
+CSV/iblocklist, regex, ABP IP-anchors, hosts '<ip> <ip>', and geoip/asn/whois/rsync —
+duplicate coverage or egress/binary, ADR §2 out-of-scope. Those remain out.)
+
+================================================================================
+TRANSITION / BRANCH COVERAGE (CLAUDE.md test-coverage rules)
+================================================================================
+* IP cases: BEFORE — the per-case alias table (unique name) is NOT in pfctl_tables()
+  (proven absent first). AFTER (in CaseContext) — listed member covered, non-member
+  NOT covered, rule references the alias. CaseContext resets the box on exit.
+* DNSBL cases: BEFORE (outside the with) — the member RESOLVES via the controlled
+  stub upstream (STUB_DNS_A), proving the later VIP comes from the feed, not a
+  pre-existing block. AFTER — member -> VIP and no longer resolves; non-member (and,
+  for ABP, the @@ allow-exception) still RESOLVES via the stub. Both sides of "member
+  blocks / non-member doesn't" asserted; ABP additionally proves the @@ allow branch.
+* CIDR/range/IPv6 membership is CIDR-AWARE by value via a small test-local helper
+  `_covered_by` (stdlib ipaddress). helpers.member_present is NOT containment-tolerant
+  (only exact host / member-network-address == ip) — the Phase-4 "CIDR-tolerant
+  member_present" note over-claimed — so a host INSIDE a listed network/range needs
+  the ipaddress containment test. _covered_by compares by value (:: == ::0). The plain
+  listed host still uses member_present (matches the matrix).
+
+RESOLVE-PROOF — why NO host override on DNSBL "resolves" names:
+  The DNSBL cases deliberately do NOT use control_local_data. Unbound serves a Host
+  Override as local-data BEFORE the python module, so an override would SHADOW the
+  matcher: it cannot prove a name is unblocked BY THE MATCHER (the ABP @@ especially
+  — it would resolve regardless of @@, a false-green), and on a blocked member it
+  masks the block. Instead the cases mirror the matrix #51 lifecycle: leave egress
+  OPEN in the probe body (unblock_egress) so a not-blocked name forwards to the
+  controlled SLIRP stub (use_system_dns_upstream) and resolves to STUB_DNS_A — a
+  KNOWN, observable pass. The member VIP block returns locally regardless of egress,
+  so leaving egress open is no false-green.
+
+================================================================================
+THE ui_browser FEEDS-TABS TEST — PENDING THE LIVE CI RUN
+================================================================================
+tests/smoke/ui/test_browser_feeds.py ::
+  test_feeds_subtab_row_active_and_type_scoped  (parametrized gtype = ipv4/ipv6/dnsbl)
+
+For each type it opens pfblockerng_feeds.php?type=<gtype> via the cookie-authed
+browser_page (no second login) and asserts:
+  * the SECOND sub-tab row is present — all three [IPv4|IPv6|DNSBL] anchors
+    (a[href*="pfblockerng_feeds.php?type=..."], to_have_count(1) each);
+  * the requested type's sub-tab is ACTIVE — its ancestor <li> carries the `active`
+    class display_top_tabs puts on the highlighted tab, and the OTHER two are NOT
+    active (a real ?type branch, not always-active);
+  * the body lists ONLY that type — its Feed Settings alias-name label
+    ("IPv4/IPv6/DNSBL Alias name(s):", rendered for the active type only by
+    pfb_feeds_render_aliasname_inputs($gtype), Phase 3) is in the DOM and the other
+    two types' labels are ABSENT;
+  * a per-tab screenshot is written to screenshot_dir (feeds_subtab_<gtype>.png).
+The parametrization exercises all three tabs => full branch coverage of the ?type
+switch. PENDING the live ui-tests CI leg for the actual pass (and the screenshots).
+
+DOM-fragility handled: the version-tolerant handles are the anchor href (carries
+?type) and the `active` class — not a brittle DOM path. The Feed Settings section is
+COLLAPSIBLE|SEC_CLOSED (collapsed on load), so the per-type label is asserted by DOM
+PRESENCE (count), not visibility.
+
+Playwright is imported lazily via pytest.importorskip, so this dev venv (no
+playwright) SKIPs the module cleanly at collection — it runs on the live ui-tests VM
+where Chromium is installed.
+
+================================================================================
+HOW EACH TEST IS GATED (markers)
+================================================================================
+* smoke      — the 6 feed-load cases in test_smoke_feeds.py (module pytestmark).
+* ui_browser — the parametrized tabs test in ui/test_browser_feeds.py (module
+               pytestmark).
+Both markers are OUT of default `python -m pytest` (tests/smoke is --ignore'd in
+pyproject.toml). The feed-load cases run via `pytest tests/smoke -m smoke
+--override-ini="addopts="`; the tabs test via `pytest tests/smoke/ui -m ui_browser
+--override-ini="addopts="` on a VM with SMOKE_ADMIN_PASSWORD + Chromium. The PR
+carries the `ui-tests` label so the live VM runs both.
+
+================================================================================
+HTTP-FETCH GOTCHAS ANTICIPATED (Part-C kill-gate risks)
+================================================================================
+* Egress timing — the mock (_MockFeedServer) is SLIRP-internal (10.0.2.2), so it
+  survives the egress block; CaseContext keeps egress OPEN across inject + the Force
+  Update (the curl fetch) and only blocks for the probe. The DNSBL "resolves" probes
+  additionally re-open egress in the body so they reach the SLIRP stub. If a future
+  egress sequencing change blocks 10.0.2.2 during the fetch, the curl would fail —
+  watch the smoke-diagnostics (pfblockerng.log fetch lines) on a red leg.
+* gzip — pfBlockerNG's curl requests gzip; the stdlib handler serves the fixture body
+  UNcompressed with Content-Length, no Content-Encoding. curl does not add
+  Accept-Encoding decompression expectations the server must honor, so a plain body is
+  fine (the curl contract ignores Content-Disposition/Type and sends no
+  If-Modified-Since). No gzip handling needed on the mock.
+* timeouts / re-fetch — reload() defaults to a 600s budget and waits on
+  wait_unbound_ready (DNSBL) or filter_configure (IP); rule_references polls
+  (filter_configure lands the rule slightly after the CLI returns). The first
+  post-reload DNS answer is authoritative (no looping). If the fetch is slow/flaky in
+  CI, that is exactly the >= 4/5 bar the kill-gate measures.
+* per-feed cache — these are FIRST-time injects of a unique alias each, so there is no
+  cached '.txt' to invalidate (unlike the matrix feed-update cases). No
+  force_dnsbl_refetch needed.
+
+================================================================================
+AFFECTED-FLOW UI TESTS (§7) — NOW ALL IN PLACE (in code)
+================================================================================
+[x] Tabs render (each type, incl. visual): Tier-A render oracle feeds_ipv4/ipv6/dnsbl
+    (Phase 3) + the new ui_browser test_browser_feeds.py (sub-tab row + active
+    highlight + per-type listing + screenshots).  <-- this phase
+[x] Type-scoped save / no clobber: the cross-type non-clobber ui_e2e test (Phase 3).
+[x] Custom feed loads: the HTTP-feed load smoke test_smoke_feeds.py (this phase).
+[x] No regressions: the retargeted per-type rename/alt-URL ui_e2e/ui_browser tests
+    (Phases 2-3) on the typed URLs.
+All four are authored; ACCEPT rides on them being green on the live VM (the
+ui-tests-labeled suite) — there is no human manual-smoke gate. The HTTP-feed-load
+leg's GO/DEMOTE is the one item PENDING the live evidence (>= 4/5).
+
+================================================================================
+LOCAL VERIFICATION GATES
+================================================================================
+* python -m pytest -q : 1115 passed (UNCHANGED — tests/smoke is --ignore'd; this
+  phase adds zero collectable-by-default Python).
+* ruff check . : All checks passed!   ruff format --check . : 71 files formatted.
+* mypy tests/ : Success (tests/smoke excluded from mypy per pyproject.toml).
+* pytest --collect-only tests/smoke/test_smoke_feeds.py -m smoke : 6 cases collected.
+* test_browser_feeds.py: py_compile OK; structure verified (marker ui_browser,
+  parametrized ipv4/ipv6/dnsbl, correct TYPE_LABELS). It is SKIPped at collection
+  here only because playwright is absent in this dev venv (smoke-only dep) — runs on
+  the live ui-tests VM.
+
+================================================================================
+SELF-REVIEW
+================================================================================
+* git status: 2 NEW untracked files ONLY (test_smoke_feeds.py, ui/test_browser_feeds.py).
+  NO src/ change, NO existing test modified, NO server/helper change.
+* Feed-load cases mirror test_smoke_matrix.py — same asserts, feed_url =
+  mock_feeds.feed_url(<fixture>) instead of write_local_feed.
+* Real transition tests: IP table absent-before / member+rule after; DNSBL
+  resolves-before / blocks-after; ABP @@ resolves. CaseContext/finally resets the box.
+* Correct markers (smoke / ui_browser), both out of default collection.
+* ui_browser test asserts the sub-tab row + active highlight + per-type listing and
+  writes per-tab screenshots; reuses the ADR-14 _open/_shot/browser_page/screenshot_dir.
+VERDICT: PASS.
+
+================================================================================
+GO-AHEAD FOR PHASE 6
+================================================================================
+Cleared. Phase 6 (docs + DoD): update README/CLAUDE.md (the Feeds-page tabs; the
+smoke feed-set + how to add a format), finalise §7's affected-flow UI-test list (all
+four now in code), and set Status — Accept rides on those automated tests being green
+on the live VM. Carry forward the ONE open item: the Part-C HTTP-load kill-gate
+GO/DEMOTE is PENDING the live CI run (>= 4/5); if < 4/5, demote test_smoke_feeds.py to
+dispatch-only as a fast-follow and record the numbers here.

--- a/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/06_Results.txt
+++ b/.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/06_Results.txt
@@ -1,0 +1,113 @@
+ADR-16 — Phase 6 Results
+DOCS + DEFINITION OF DONE (final phase)
+
+STATUS: DONE. Documentation updated; ADR-16 §7 finalised; Status set.
+No src/ or test behaviour change. markdownlint 0 errors; pytest 1115 passed (unchanged).
+
+================================================================================
+DOCS CHANGED
+================================================================================
+1) README.md
+   - Added "### HTTP feed-load smoke (ADR-16)" subsection under "Smoke tests"
+     → "Adding a matrix case": documents the fixtures dir, the six sample files,
+     how _MockFeedServer.register() serves them, how cases call
+     mock_feeds.feed_url("<name>"), how to add a new format fixture, and the
+     Part-C kill-gate / gate status (OPTIMISTIC-GO, PENDING-CI; demote switch).
+   - Added "### Feeds page — IPv4 / IPv6 / DNSBL sub-tabs (ADR-16)" subsection
+     inside "## Web UI tests (live pfSense VM)": documents that
+     pfblockerng_feeds.php is now organized into IPv4/IPv6/DNSBL sub-tabs
+     (?type=), matching IP/DNSBL/Reports; the Tier-A render entries are
+     feeds_ipv4/feeds_ipv6/feeds_dnsbl; the ui_browser tabs test is
+     tests/smoke/ui/test_browser_feeds.py.
+
+2) CLAUDE.md
+   - Added "### HTTP mock-feed load smoke (ADR-16 Part C)" subsection after the
+     Web UI tiers section under "## Smoke tests": documents the six fixture files
+     (tests/smoke/fixtures/), how _MockFeedServer.register() stores and serves
+     content, how the mock_feeds fixture auto-registers all files in fixtures/,
+     how to add a new format fixture (3-step: drop file, update README, add case),
+     and the kill-gate / gate status (OPTIMISTIC-GO, PENDING-CI).
+
+3) .ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/ADR.md
+   - Status changed: Proposed → Implemented (pending smoke test).
+   - §7 Definition of Done: updated to reflect all tests authored in-repo;
+     explicit statement that Accept rides on automated tests, no human gate.
+   - §7 Affected-flow UI tests: all four items ticked [x] with concrete test
+     names, markers, and PENDING-live-VM-green annotations (see below).
+
+================================================================================
+FINAL STATUS
+================================================================================
+Implemented (pending smoke test)
+
+Accept flips once the affected-flow UI tests below are confirmed green on the
+live VM (the ui-tests-labeled CI suite). There is NO human manual-smoke gate —
+Accept rides on the automated tests entirely.
+
+================================================================================
+PART-C OUTCOME
+================================================================================
+All 6 representative Phase-4 formats covered; none dropped.
+
+COVERED:
+  IP (IpCase):
+    test_ip_http_feed_loads         ip_plain_cidr.txt  v4  (KILL-GATE)
+    test_ip_http_range_feed_loads   ip_range.txt       v4 range
+    test_ipv6_http_feed_loads       ip_ipv6.txt        v6
+
+  DNSBL (DnsblCase):
+    test_dnsbl_http_feed_loads      dnsbl_plain.txt    (KILL-GATE)
+    test_dnsbl_http_hosts_feed_loads dnsbl_hosts.txt
+    test_dnsbl_http_abp_feed_loads  dnsbl_abp.txt      (ABP @@ allow proven)
+
+DROPPED: none from the Phase-4 representative set.
+
+GO/DEMOTE STATUS: OPTIMISTIC-GO, PENDING-CI.
+  Bar: >= 4/5 clean runs. If < 4/5 on the live CI run, demote
+  test_smoke_feeds.py to dispatch-only as a fast-follow (Part A still ships;
+  local-file load coverage in test_smoke_matrix.py / test_smoke_abp.py remains).
+  Update RESULTS/05_Results.txt with the numbers when CI reports them.
+
+================================================================================
+AFFECTED-FLOW UI TESTS THAT GATE ACCEPT
+================================================================================
+All authored in-repo on adr/16. PENDING live-VM green (no VM on this machine).
+
+[x] Tier-A render oracle (marker: ui_render) — PENDING live-VM green
+    tests/smoke/ui/test_render_smoke.py
+    Entries: feeds_ipv4 / feeds_ipv6 / feeds_dnsbl
+    Each: GET pfblockerng_feeds.php?type=<t> → 200, PHP-error-free, type marker
+    present, no new php_error.log line.
+
+[x] ui_browser tabs test (marker: ui_browser) — PENDING live-VM green
+    tests/smoke/ui/test_browser_feeds.py
+    ::test_feeds_subtab_row_active_and_type_scoped (parametrized ipv4/ipv6/dnsbl)
+    Asserts: second sub-tab row present; active tab highlighted, others not;
+    type's Feed Settings label in DOM, others absent; screenshots per tab.
+
+[x] Cross-type non-clobber (marker: ui_e2e) — PENDING live-VM green
+    tests/smoke/ui/test_feeds.py
+    ::test_feed_rename_cross_type_save_does_not_clobber
+    Save IPv4 tab → DNSBL renames intact; save DNSBL tab → IPv4 renames intact.
+    Transition test (before + after asserted).
+
+[x] HTTP-feed load smoke (marker: smoke) — PENDING live-VM green
+    tests/smoke/test_smoke_feeds.py (6 cases listed above under Part-C outcome)
+    Each: before-state proven, Force Update over mock_feeds.feed_url(<fixture>),
+    after-state proven (pfctl_table_members/rule_references or dns_probe).
+
+[x] Per-type rename/alt-URL regressions (marker: ui_e2e) — PENDING live-VM green
+    tests/smoke/ui/test_feeds.py
+    Retargeted per-type save flows on the typed URLs (?type=ipv4/ipv6/dnsbl).
+
+================================================================================
+IMPLEMENTATION COMPLETENESS
+================================================================================
+ADR-16 is FULLY IMPLEMENTED in-repo on adr/16. All six phases committed.
+No human manual-smoke gate remains — Accept rides on the automated tests above
+being green on the live VM (ui-tests label). The orchestrator opens the PR.
+
+LOCAL VERIFICATION GATES (Phase 6):
+  * markdownlint-cli2 README.md CLAUDE.md ADR.md : 0 errors
+  * python -m pytest -q : 1115 passed (UNCHANGED — docs-only phase)
+  * git diff --name-only HEAD : ADR.md CLAUDE.md README.md ONLY (no src/ no tests/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,6 +483,55 @@ numbers are **CI-pending**; the browser leg has a one-line demote/drop switch
 (drop `browser` from `DEFAULT_SCHEDULE_TIERS` + run release `ui-suite` as
 `tier: functional`). Full design: `.ADRs/ADR_14_UI_UX_Testing/`.
 
+### HTTP mock-feed load smoke (ADR-16 Part C) — `tests/smoke/test_smoke_feeds.py`
+
+`test_smoke_feeds.py` (marker `smoke`) is the **only suite file that drives the
+real HTTP fetch path**: each case points an `IpCase`/`DnsblCase` at a URL served
+by `_MockFeedServer` (the in-runner stdlib HTTP server reachable by the guest at
+`http://10.0.2.2:<port>/<name>` over SLIRP — survives the egress block), runs a
+real Force Update, and asserts the feed loaded on the box. Every other smoke case
+supplies a local file via `write_local_feed`.
+
+**Sample fixtures** live under `tests/smoke/fixtures/` (committed to the repo):
+
+| File | Format | Type |
+| --- | --- | --- |
+| `ip_plain_cidr.txt` | plain IPv4 + CIDR | IP v4 |
+| `ip_range.txt` | IPv4 range `a-b` | IP v4 |
+| `ip_ipv6.txt` | IPv6 single + CIDR | IP v6 |
+| `dnsbl_plain.txt` | plain domain | DNSBL |
+| `dnsbl_hosts.txt` | hosts `0.0.0.0 domain` | DNSBL |
+| `dnsbl_abp.txt` | ABP / EasyList (\|\|d^ block, @@ allow) | DNSBL |
+
+All data is inert (RFC 5737 / RFC 3849 IPs; `uuid-<hex>.com` domains). The
+`mock_feeds` fixture auto-registers every file in `tests/smoke/fixtures/` when it
+starts; individual cases call `mock_feeds.feed_url("<name>")` to get the guest URL.
+
+**How `_MockFeedServer.register()` works.** `register(name, body)` stores the body
+in an in-memory dict; the HTTP handler serves it verbatim (plain body, no
+`Content-Encoding`, no `Content-Disposition`) at `GET /<name>`. The fixture
+directory variant (`mock_feeds.feed_url("<filename>")`) reads the file on first
+access and registers it under its basename. `curl` does not send
+`Accept-Encoding: gzip` nor `If-Modified-Since`, so the mock needs no compression
+or ETag/304 logic — plain body is fine.
+
+**Adding a new format fixture.**
+
+1. Drop the fixture file into `tests/smoke/fixtures/` (inert data — TEST-NET IPs
+   / `uuid-*.com` domains; never RFC 6761 TLDs or HSTS-preload names).
+2. Update `tests/smoke/fixtures/README.md` with the member/non-member set.
+3. Add a case in `test_smoke_feeds.py` using `mock_feeds.feed_url("<filename>")`.
+
+**Kill-gate / gate status (ADR-16 §7).** The Part-C premise is falsifiable:
+"a Force Update reliably fetches an HTTP feed from the mock over SLIRP and loads
+it, in CI". The reliability bar is **≥ 4/5 clean runs**. This test is
+`OPTIMISTIC-GO, PENDING-CI` — all 6 representative formats are authored; the live
+CI run (the `ui-tests`-labeled PR suite) decides GO vs DEMOTE. If < 4/5 clean,
+`test_smoke_feeds.py` is demoted to dispatch-only (Part A still ships; the
+local-file load coverage in `test_smoke_matrix.py` / `test_smoke_abp.py`
+remains). The final decision is recorded in
+`.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/05_Results.txt`.
+
 ---
 
 ## Test coverage (mandatory)

--- a/README.md
+++ b/README.md
@@ -746,6 +746,45 @@ Cases live in `tests/smoke/test_smoke_matrix.py` and compose the Phase-4 helpers
    `h.resolves_to`, and `h.pfctl_table_members` / `h.member_present` /
    `h.rule_references` for the IP side. `__exit__` resets to baseline.
 
+### HTTP feed-load smoke (ADR-16)
+
+`tests/smoke/test_smoke_feeds.py` (marker `smoke`) exercises the **real
+HTTP fetch path** — pfBlockerNG's `curl` over SLIRP to the `_MockFeedServer`
+— across the representative IP + DNSBL formats. This is the only place in the
+suite where a feed arrives over HTTP rather than a local file (`write_local_feed`).
+
+**Fixture files** live under `tests/smoke/fixtures/` and are committed to the
+repo. Each file is the verbatim body `curl` fetches; the guest reaches it at
+`http://10.0.2.2:<port>/<filename>` over SLIRP (survives the egress block):
+
+| File | Format | Type |
+|------|--------|------|
+| `ip_plain_cidr.txt` | plain IPv4 + CIDR | IP v4 |
+| `ip_range.txt` | IPv4 range `a-b` | IP v4 |
+| `ip_ipv6.txt` | IPv6 single + CIDR | IP v6 |
+| `dnsbl_plain.txt` | plain domain | DNSBL |
+| `dnsbl_hosts.txt` | hosts `0.0.0.0 domain` | DNSBL |
+| `dnsbl_abp.txt` | ABP / EasyList (\|\|d^ block, @@ allow) | DNSBL |
+
+All data is inert: IP files use RFC 5737 / RFC 3849 documentation ranges;
+DNSBL files use `uuid-<hex>.com` names.
+
+**How cases register a fixture.** In a test, pass `mock_feeds.feed_url("<name>")`
+as the `feed_url` to `IpCase`/`DnsblCase`. `_MockFeedServer.register()` is
+called automatically for each file in `tests/smoke/fixtures/` when the
+`mock_feeds` fixture starts. To add a new format:
+
+1. Drop a fixture file into `tests/smoke/fixtures/` (follow the inert-data rule).
+2. Update `tests/smoke/fixtures/README.md` to document its member/non-member set.
+3. Add a case in `test_smoke_feeds.py` using `mock_feeds.feed_url("<name>")`.
+
+**Kill-gate / gate status.** The HTTP-fetch reliability is the ADR-16 Part-C
+kill-gate (≥ 4/5 clean runs). The test is authored in the `smoke` marker and
+gated as part of the `ui-tests`-labeled PR suite; the GO/DEMOTE decision is
+recorded in `.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/05_Results.txt`
+(status: OPTIMISTIC-GO, pending the live CI run). If the live run shows
+&lt; 4/5 clean, `test_smoke_feeds.py` is demoted to dispatch-only as a fast-follow.
+
 ## Web UI tests (live pfSense VM)
 
 The UI suite (ADR-14, `tests/smoke/ui/`) drives the **webConfigurator** on the
@@ -765,6 +804,18 @@ cost/frequency:
 The pass/fail oracle is **never HTTP 200 alone** (a 200 can carry a rendered PHP
 warning or a blank body) — Tier A reads the body + the page marker + the on-box
 `php_error.log`; Tier B asserts the effective state.
+
+### Feeds page — IPv4 / IPv6 / DNSBL sub-tabs (ADR-16)
+
+The **Feeds** page (`pfblockerng_feeds.php`) is organized into **IPv4 / IPv6 /
+DNSBL sub-tabs** (`?type=ipv4|ipv6|dnsbl`, default `ipv4`), matching the IP /
+DNSBL / Reports top-level structure. Each sub-tab renders only its own type's
+Feed Settings alias-name inputs and predefined-feeds table; a bare URL defaults
+to the IPv4 tab. The Tier-A render entries are `feeds_ipv4`, `feeds_ipv6`, and
+`feeds_dnsbl` (three `ui_render` cases, one per `?type`). A `ui_browser` test
+(`tests/smoke/ui/test_browser_feeds.py`, marker `ui_browser`) screenshots all
+three tabs and asserts the second sub-tab row (`[IPv4 | IPv6 | DNSBL]`), the
+active-tab highlight, and that each tab lists only its type.
 
 ### Running it in CI
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -35,21 +35,37 @@ $feed_info	= convert_feeds_json();
 $feed_count	= $feed_info['count'];
 unset($feed_info['count']);
 
+// Active sub-tab type (?type=ipv4|ipv6|dnsbl, default ipv4). The page is split into
+// IPv4/IPv6/DNSBL sub-tabs (mirroring pfblockerng_category.php): only the active type
+// renders, and the save is scoped to it. A bare URL (no ?type) defaults to ipv4, so the
+// other pages' plain "Feeds" links keep working.
+$gtype = 'ipv4';
+if (isset($_REQUEST['type']) && !empty($_REQUEST['type'])) {
+	$temp_value = pfb_filter($_REQUEST['type'], PFB_FILTER_HTML, 'feeds');
+	if (in_array($temp_value, array('ipv4', 'ipv6', 'dnsbl'))) {
+		$gtype = $temp_value;
+	}
+}
+
+// 'active' GUI sub-tab map (the second [IPv4 | IPv6 | DNSBL] row).
+$active = array('ipv4' => FALSE, 'ipv6' => FALSE, 'dnsbl' => FALSE);
+$active[$gtype] = TRUE;
+
 $pconfig = $feeds_list = array();
 $feeds_list['ipv4'] = $feeds_list['ipv6'] = $feeds_list['dnsbl'] = array();
 
-// $pfb['feeds_list'] created by load_feeds_json() function
-if (is_array($pfb['feeds_list'])) {
-	foreach ($pfb['feeds_list'] as $type => $data) {
-		foreach ($data as $o_aliasname => $aliasname) {
-			$l_aliasname = strtolower($o_aliasname);
+// $pfb['feeds_list'] created by load_feeds_json() function. Collect only the active
+// type's aliasnames/overrides (the body and the save are type-scoped); the 'dnsbl' key
+// is left present-but-empty for the non-DNSBL tabs so the length guard below behaves.
+if (is_array($pfb['feeds_list']) && isset($pfb['feeds_list'][$gtype]) && is_array($pfb['feeds_list'][$gtype])) {
+	foreach ($pfb['feeds_list'][$gtype] as $o_aliasname => $aliasname) {
+		$l_aliasname = strtolower($o_aliasname);
 
-			// Collect any user-defined alternate aliasname(s)
-			$pconfig['feed_' . $l_aliasname] = $fconfig['feed_' . $l_aliasname] ?: '';
+		// Collect any user-defined alternate aliasname(s)
+		$pconfig['feed_' . $l_aliasname] = $fconfig['feed_' . $l_aliasname] ?: '';
 
-			// Collect list of original aliasnames/type (ipv4, ipv4 and dnsbl)
-			$feeds_list[$type][] = $o_aliasname;
-		}
+		// Collect list of original aliasnames for the active type
+		$feeds_list[$gtype][] = $o_aliasname;
 	}
 }
 
@@ -71,28 +87,37 @@ if ($_POST) {
 	if (isset($_POST['save'])) {
 
 		$config_mod = FALSE;
-		foreach ($pfb['feeds_list'] as $type => $data) {
-			foreach ($data as $o_aliasname => $aliasname) {
-				$l_aliasname = strtolower($o_aliasname);
 
-				if (preg_match("/\W/", $_POST['feed_' . $l_aliasname])) {
-					$input_errors[] = "Feed Settings: [ {$aliasname} ]"
-							. 'Alias/Group name cannot contain spaces, special or international characters.';
+		// Type-scoped save: only the active type's feed_<alias> nodes are ever
+		// written. The hidden 'type' form field carries the active sub-tab, validated
+		// into $gtype above (via $_REQUEST, which includes $_POST). Looping only
+		// $pfb['feeds_list'][$gtype] means a per-type tab never touches another type's
+		// feed_*/feed_alt_* nodes (the cross-type non-clobber guarantee).
+		$type_data = (is_array($pfb['feeds_list']) && isset($pfb['feeds_list'][$gtype])
+			&& is_array($pfb['feeds_list'][$gtype])) ? $pfb['feeds_list'][$gtype] : array();
 
-					$pconfig['feed_' . $l_aliasname] = htmlspecialchars($_POST['feed_' . $l_aliasname]) ?: '';
-				}
-				else {
-					$fconfig['feed_' . $l_aliasname] = $_POST['feed_' . $l_aliasname] ?: '';
-					config_set_path("installedpackages/pfblockerngglobal/feed_{$l_aliasname}", $fconfig['feed_' . $l_aliasname]);
-					$config_mod = TRUE;
+		foreach ($type_data as $o_aliasname => $aliasname) {
+			$l_aliasname = strtolower($o_aliasname);
 
-					// IPv4/6 Aliasnames cannot exceed 31 characters in PF. ( pfB_ + aliasname + _v? )
-					if (!in_array(str_replace('feed_', '', $fconfig['feed_' . $l_aliasname]), $feeds_list['dnsbl'])) {
-						$len_post = strlen($fconfig['feed_' . $l_aliasname]);
-						if ($len_post > 24) {
-							$input_errors[] = "Alternate Aliasname : [ {$o_aliasname} -> {$aliasname} ]"
-									. " Field cannot exceed 24 characters. [ {$len_post} characters submitted. ]";
-						}
+			if (preg_match("/\W/", $_POST['feed_' . $l_aliasname])) {
+				$input_errors[] = "Feed Settings: [ {$aliasname} ]"
+						. 'Alias/Group name cannot contain spaces, special or international characters.';
+
+				$pconfig['feed_' . $l_aliasname] = htmlspecialchars($_POST['feed_' . $l_aliasname]) ?: '';
+			}
+			else {
+				$fconfig['feed_' . $l_aliasname] = $_POST['feed_' . $l_aliasname] ?: '';
+				config_set_path("installedpackages/pfblockerngglobal/feed_{$l_aliasname}", $fconfig['feed_' . $l_aliasname]);
+				$config_mod = TRUE;
+
+				// IPv4/6 Aliasnames cannot exceed 31 characters in PF. ( pfB_ + aliasname + _v? )
+				// $feeds_list['dnsbl'] is only populated on the DNSBL tab, so this length
+				// guard correctly applies on IPv4/IPv6 tabs and is skipped on the DNSBL tab.
+				if (!in_array(str_replace('feed_', '', $fconfig['feed_' . $l_aliasname]), $feeds_list['dnsbl'])) {
+					$len_post = strlen($fconfig['feed_' . $l_aliasname]);
+					if ($len_post > 24) {
+						$input_errors[] = "Alternate Aliasname : [ {$o_aliasname} -> {$aliasname} ]"
+								. " Field cannot exceed 24 characters. [ {$len_post} characters submitted. ]";
 					}
 				}
 			}
@@ -124,7 +149,7 @@ if ($_POST) {
 		if ($config_mod) {
 			if (!$input_errors) {
 				write_config('[pfBlockerNG] save Feed settings');
-				header('Location: /pfblockerng/pfblockerng_feeds.php');
+				header("Location: /pfblockerng/pfblockerng_feeds.php?type={$gtype}");
 				exit;
 			}
 		}
@@ -568,8 +593,11 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 		endforeach;
 }
 
-$pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Feeds'));
-$pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblockerng_feeds.php', '@self');
+// Breadcrumb label for the active sub-tab type.
+$type_label = array('ipv4' => 'IPv4', 'ipv6' => 'IPv6', 'dnsbl' => 'DNSBL');
+
+$pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Feeds'), gettext($type_label[$gtype]));
+$pglinks = array('', '/pfblockerng/pfblockerng_general.php', "/pfblockerng/pfblockerng_feeds.php?type={$gtype}", '@self');
 include_once('head.inc');
 
 if ($input_errors) {
@@ -591,8 +619,16 @@ $tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php')
 $tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
 display_top_tabs($tab_array, true);
 
+// Second sub-tab row: [IPv4 | IPv6 | DNSBL] -> pfblockerng_feeds.php?type=...
+$tab_array	= array();
+$tab_array[]	= array(gettext('IPv4'),	$active['ipv4'],	'/pfblockerng/pfblockerng_feeds.php?type=ipv4');
+$tab_array[]	= array(gettext('IPv6'),	$active['ipv6'],	'/pfblockerng/pfblockerng_feeds.php?type=ipv6');
+$tab_array[]	= array(gettext('DNSBL'),	$active['dnsbl'],	'/pfblockerng/pfblockerng_feeds.php?type=dnsbl');
+display_top_tabs($tab_array, true);
+
 ?>
-<form action="/pfblockerng/pfblockerng_feeds.php" method="post" name="iform" id="iform" class="form-horizontal">
+<form action="/pfblockerng/pfblockerng_feeds.php?type=<?=$gtype?>" method="post" name="iform" id="iform" class="form-horizontal">
+<input type="hidden" name="type" id="type" value="<?=$gtype?>" />
 <?php
 
 $section = new Form_Section('Feed Settings', 'feedsettings', COLLAPSIBLE|SEC_CLOSED);
@@ -602,9 +638,8 @@ $section->addInput(new Form_StaticText(
 	. ' combine multiple Alias/Groups together by using a duplicate Alias/Group name.'
 ));
 
-pfb_feeds_render_aliasname_inputs($section, 'ipv4', $feeds_list, $pconfig);
-pfb_feeds_render_aliasname_inputs($section, 'ipv6', $feeds_list, $pconfig);
-pfb_feeds_render_aliasname_inputs($section, 'dnsbl', $feeds_list, $pconfig);
+// Render only the active type's alias-name override inputs (type-scoped UI).
+pfb_feeds_render_aliasname_inputs($section, $gtype, $feeds_list, $pconfig);
 
 $btn_save = new Form_Button(
 	'save',
@@ -703,36 +738,39 @@ print ($section);
 			<tbody>
 
 			<?php
-			$list_type = array( 'pfblockernglistsv4' => 'ipv4', 'pfblockernglistsv6' => 'ipv6', 'pfblockerngdnsbl' => 'dnsbl');
-			foreach ($list_type as $type => $feedtype) {
-				foreach (config_get_path("installedpackages/{$type}/config", []) as $rowid => $list) {
-					if (isset($list['row'])) {
-						foreach ($list['row'] as $row) {
-							if (!empty($row['url']) && !empty($row['header'])) {
+			// Build $ex_feeds for the active type only (the body is type-scoped).
+			$list_type = array( 'ipv4' => 'pfblockernglistsv4', 'ipv6' => 'pfblockernglistsv6', 'dnsbl' => 'pfblockerngdnsbl');
+			$conf_type = $list_type[$gtype];
+			$feedtype  = $gtype;
 
-								$ex_feeds[$feedtype][] = array(	'aliasname'	=>	$list['aliasname'],
-												'action'	=>	$list['action'],
-												'state'		=>	$row['state'],
-												'url'		=>	$row['url'],
-												'header'	=>	$row['header'],
-												'rowid'		=>	$rowid
-												);
-							}
+			foreach (config_get_path("installedpackages/{$conf_type}/config", []) as $rowid => $list) {
+				if (isset($list['row'])) {
+					foreach ($list['row'] as $row) {
+						if (!empty($row['url']) && !empty($row['header'])) {
+
+							$ex_feeds[$feedtype][] = array(	'aliasname'	=>	$list['aliasname'],
+											'action'	=>	$list['action'],
+											'state'		=>	$row['state'],
+											'url'		=>	$row['url'],
+											'header'	=>	$row['header'],
+											'rowid'		=>	$rowid
+											);
 						}
 					}
 				}
+			}
 
-				if (!isset($ex_feeds[$feedtype])) {
-					$ex_feeds[$feedtype][] = array();
-				}
+			if (!isset($ex_feeds[$feedtype])) {
+				$ex_feeds[$feedtype][] = array();
 			}
 
 			$alt_selected = '';		// CSV list of all Feeds which have 'Alternate URLs' (Used in POST/save)
 			$feed_info_row = 0;
 			$aliasname_found = array();
 
-			foreach ($feed_info as $ftype => $info) {
-				pfb_feeds_render_predefined_type($ftype, $info);
+			// Render only the active type's predefined feeds.
+			if (isset($feed_info[$gtype])) {
+				pfb_feeds_render_predefined_type($gtype, $feed_info[$gtype]);
 			}
 			?>
 
@@ -766,8 +804,9 @@ print ($section);
 
 				<?php
 				$p_aliasname = '';
+				// Only the active type's unknown user-defined feeds (type-scoped body).
 				if (!empty($ex_feeds)):
-					foreach (array('ipv4' => 'IPv4', 'ipv6' => 'IPv6', 'dnsbl' => 'DNSBL') as $feedtype => $type):
+					foreach (array($gtype => $type_label[$gtype]) as $feedtype => $type):
 
 						if (!empty($ex_feeds[$feedtype])):
 							foreach ($ex_feeds[$feedtype] as $row):

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -131,6 +131,41 @@ if ($_POST) {
 	}
 }
 
+// Render the Feed Settings alias-name override inputs for a single $type
+// ('ipv4'|'ipv6'|'dnsbl'). Emits that type's StaticText label + its 'feed_<alias>'
+// Form_Input set into $section, identical to the inline loops it replaces. The page
+// calls it for ipv4, ipv6, dnsbl in turn (Phase 3 calls it for the active type only).
+function pfb_feeds_render_aliasname_inputs($section, $type, $feeds_list, $pconfig) {
+
+	$labels = array(
+		'ipv4'	=> array(
+			'IPv4 Alias name(s):',
+			'To change the default IPv4 Alias name(s), enter new Alias name(s) as desired.'),
+		'ipv6'	=> array(
+			'IPv6 Alias name(s):',
+			'To change the default IPv6 Alias name(s), enter new Alias name(s) as desired.'),
+		'dnsbl'	=> array(
+			'DNSBL Alias name(s):',
+			'To change the default DNSBL Group name(s), enter new Group name(s) as desired.'),
+	);
+
+	if (!isset($labels[$type])) {
+		return;
+	}
+
+	$section->addInput(new Form_StaticText($labels[$type][0], $labels[$type][1]));
+
+	foreach ($feeds_list[$type] as $aliasname) {
+		$l_aliasname = strtolower($aliasname);
+		$section->addInput(new Form_Input(
+			'feed_' . $l_aliasname,
+			$aliasname,
+			'text',
+			$pconfig['feed_' . $l_aliasname]
+		))->setWidth(3);
+	}
+}
+
 function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url, $feed_url, $row_state,
 	    $feed_header, $alternate=FALSE, $alt_header='', $alt_info='', $alt_register='', $a_key) {
 
@@ -216,6 +251,323 @@ function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url,
 	}
 }
 
+// Render the predefined-feeds table rows for a single $type ('ipv4'|'ipv6'|'dnsbl'),
+// given $info = $feed_info[$type]. Emits that type's <tr> rows (incl. the alt-URL radio
+// group + the hidden alt_<header> input + the per-row icons), identical to the inline
+// per-type block it replaces. The cross-type accumulators ($alt_selected CSV,
+// $feed_info_row separator counter, $aliasname_found) and the state shared with
+// url_compare ($ex_feeds, $alt_feeds, $icon) live at page (global) scope and are bound
+// via `global` so calling this once per type reproduces the original interleaved render.
+// The page loops it for ipv4+ipv6+dnsbl today; Phase 3 calls it for the active type only.
+function pfb_feeds_render_predefined_type($ftype, $info) {
+
+	global $ex_feeds, $alt_feeds, $icon, $fconfig, $feed_alt_selected;
+	global $alt_selected, $feed_info_row, $aliasname_found;
+
+	if (empty($info)) {
+		print ("<td class=\"bg-danger\"><br /><strong>No feeds definitions found!</strong><br /><br /></td>");
+		return;
+	}
+
+	$p_type = '';
+	foreach ($info as $aliasname => $data):
+		$p_aliasname = '';
+		if (!isset($data['feeds'])) {
+			continue;
+		}
+
+		foreach ($data['feeds'] as $feed):
+			$status = $icon = '';
+
+			if (!empty($ex_feeds[$ftype])) {
+				foreach ($ex_feeds[$ftype] as $key => $row) {
+
+					if (empty($row)) {
+						continue;
+					}
+
+					if (isset($row['aliasname']) && $aliasname == $row['aliasname'] && !isset($aliasname_found[$aliasname])) {
+						$aliasname_found[$aliasname] = $aliasname;
+
+						if ($row['action'] == 'Disabled') {
+							$status = "&emsp;"
+								. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
+								. "&rowid={$row['rowid']}\"<span class=\"text-danger\""
+								. "title=\"Alias/Group exists but is currently Disabled\">"
+								. "<i class=\"fa-solid fa-check\"></i></span>"
+								. "</a>";
+						} else {
+							$status = "&emsp;"
+								. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
+								. "&rowid={$row['rowid']}\""
+								. "title=\"Alias/Group exists\">"
+								. "<i class=\"fa-solid fa-check\"></i>"
+								. "</a>";
+						}
+					}
+
+					// Determine all Aliases that reference the Feed URL
+					url_compare($ftype, $key, $row['rowid'], $aliasname, $row['aliasname'], $row['url'], $feed['url'],
+							$row['state'], $feed['header'], FALSE, '', '', '', 0);
+
+					// Determine all Aliases that reference the 'Alternate' Feed URLs
+					if (isset($feed['alternate'])) {
+						foreach ($feed['alternate'] as $a_key => $alt) {
+							url_compare($ftype, $key, $row['rowid'], $aliasname, $row['aliasname'], $row['url'],
+								$alt['url'], $row['state'], $feed['header'], TRUE, $alt['header'],
+								isset($alt['info']) ? $alt['info'] : '', isset($alt['register']) ? 'register' : '', $a_key);
+						}
+					}
+				}
+
+				if (!isset($aliasname_found[$aliasname])) {
+					$aliasname_found[$aliasname] = $aliasname;
+					$status = "&emsp;"
+						. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
+						. "&act=addgroup&atype={$aliasname}\""
+						. "title=\"Add Alias/Group: {$aliasname}\">"
+						. "<i class=\"fa-solid fa-plus-circle\"></i>"
+						. "</a>";
+				}
+			}
+
+			if (isset($feed['feed'])):
+
+				// Print table/row of Feeds and consecutive rows for all 'Alternate' URLs available.
+				$counter = 0;
+				if (isset($alt_feeds[$ftype][$aliasname][$feed['header']])) {
+					$counter = count($alt_feeds[$ftype][$aliasname][$feed['header']]);
+				}
+
+				for ($i=0; $i <= $counter; $i++):
+
+					// Print blank seperator line between Categories (skip first row)
+					if ($feed_info_row > 0 && $ftype != $p_type) {
+						print ("<tr><td><br /></td><td></td><td></td><td></td><td></td><td></td></tr>");
+					}
+
+					// Print applicable alternating background color
+					if ($data['action'] == 'permit') {
+						if ($aliasname == $p_aliasname) {
+							$tr_style = 'background-color: #F5FBF6;';		// Light green 1
+							if ($tr_style == $p_tr_style) {
+								$tr_style = 'background-color: #EEF7EE;';	// Light green 2
+							}
+						} else {
+							// Dark green (New Alias/Group)
+							$tr_style = 'background-color: #A0B8A0;';	// #C8E6C9;';
+						}
+					}
+					else {
+						$tr_style = '';
+						if ($aliasname != $p_aliasname) {
+							// Grey - (New Alias/Group)
+							$tr_style = 'background-color: #B8B8B8;';	//#D8D8D8;';
+						}
+					}
+				?>
+
+		<tr style="<?=$tr_style;?>">
+			<td>
+					<?php
+						// $ftype is always one of ipv4/ipv6/dnsbl here; the default keeps
+						// $type defined for the static analyser (no behaviour change).
+						$type = '';
+						switch ($ftype) {
+							case 'ipv4':
+								$type = 'IPv4';
+								break;
+							case 'ipv6':
+								$type = 'IPv6';
+								break;
+							case 'dnsbl':
+								$type = 'DNSBL';
+								break;
+						}
+						if ($ftype != $p_type) {
+							print ("<strong>{$type} Category</strong>");
+						} else {
+							print ("<p style=\"font-size: 75%\">{$type}<p>");
+						}
+					?>
+			</td>
+
+			<td>
+					<?php
+						if ($aliasname != $p_aliasname) {
+							// Add Line break (bullet)
+							$data['info'] = str_replace('-LB-', "\n&emsp;&#9679;&emsp;", $data['info']);
+							print ("<i title=\"{$data['info']}\" class=\"fa-solid fa-info-circle\"></i>{$status}");
+						}
+
+						if ($i == 0) {
+
+							// If alternative URLs are available, print radio checkbox options. Default to first radio.
+							if (isset($alt_feeds[$ftype][$aliasname][$feed['header']])) {
+
+								// Add first radio option as default if not previously saved
+								if (!isset($fconfig['feed_alt_' . strtolower($feed['header']) ])) {
+									$feed_alt_selected[] = $feed['header'];
+								}
+
+								// Collect all 'Alternative' Feed Header names. (POST/save)
+								$alt_selected .= $feed['header'] . ',';
+
+								if (in_array($feed['header'], $feed_alt_selected) && empty($icon)) {
+									$icon = "&emsp;"
+										. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
+										. "&act=add&atype={$feed['header']}\""
+										. "title=\"Add feed: [ {$feed['header']} ]\">"
+										. "<i class=\"fa-solid fa-plus-circle\"></i>"
+										. "</a>";
+								}
+								elseif (empty($icon)) {
+									$pfb_found = FALSE;
+									foreach ($alt_feeds[$ftype][$aliasname][$feed['header']] as $a_header) {
+										if (!empty($a_header['icon']) ||
+										    in_array($a_header['header'], $feed_alt_selected)) {
+											$pfb_found = TRUE;
+											break;
+										}
+									}
+
+									if (!$pfb_found) {
+										$icon = "&emsp;"
+										. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
+										. "&act=add&atype={$feed['header']}\""
+										. "title=\"Add feed: [ {$feed['header']} ]\">"
+										. "<i class=\"fa-solid fa-plus-circle\"></i>"
+										. "</a>";
+									}
+								}
+
+								$feed_alternate	= '';
+								$feed_header	= $feed['header'];
+								$feed_radio	= "&emsp;<input type=\"radio\" name=\"alt_{$feed['header']}\""
+										. " value=\"alt_{$feed['header']}\" checked=\"checked\" />&emsp;";
+
+								print ("<input type=\"hidden\" name=\"alt_" . "{$feed['header']}" . "\" id=\"alt_"
+									. "{$feed['header']}" . "\" value=\"\" />");
+							}
+							else {
+								if (empty($icon)) {
+									$icon = "&emsp;"
+										. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
+										. "&act=add&atype={$feed['header']}\""
+										. "title=\"Add feed: [ {$feed['header']} ]\">"
+										. "<i class=\"fa-solid fa-plus-circle\"></i>"
+										. "</a>";
+								}
+
+								$feed_alternate	= '';
+								$feed_header	= $feed['header'];
+								$feed_radio	= '';
+							}
+						}
+
+						// Extract 'Alternate Feed' details from alt_feed array.
+						else {
+							$status = '';
+							$alt_feed	= $alt_feeds[$ftype][$aliasname][$feed['header']][$i -1];
+							$icon 		= $alt_feed['icon'];
+
+							if (in_array($alt_feed['header'], $feed_alt_selected)) {
+								$checked = 'checked=\"checked\"';
+								if (empty($icon)) {
+									$icon = "&emsp;"
+										. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
+										. "&act=add&atype={$alt_feed['header']}\""
+										. "title=\"Add feed: [ {$alt_feed['header']} ]\">"
+										. "<i class=\"fa-solid fa-plus-circle\"></i>"
+										. "</a>";
+								}
+							}
+							else {
+								$checked = '';
+							}
+
+							$feed['url']	= $alt_feed['url'];
+							$feed_alternate = "&emsp;<i class=\"fa-solid fa-angle-right\" style=\"cursor: default\""
+									. " title=\"Alternate Feed option\"></i>&emsp;";
+							$feed_header	= $alt_feed['header'];
+							$feed_radio	= "&emsp;<input type=\"radio\" name=\"alt_{$feed['header']}\""
+									. " value=\"alt_{$alt_feed['header']}\" {$checked} />&emsp;";
+						}
+					?>
+			</td>
+
+			<td>
+					<?php
+						if ($aliasname != $p_aliasname) {
+							print ("{$aliasname}");
+						} else {
+							print ("<p style=\"font-size: 75%\">{$aliasname}<p>");
+						}
+					?>
+			</td>
+
+			<td>
+				<?=$feed_alternate;?>
+				<a target="_blank" href="<?=$feed['website'];?>"><?=$feed['feed'];?></a>
+					<?php
+						// Add any Alternate Feed icons
+						if (!empty($feed_alternate)) {
+							if (isset($alt_feed['status'])) {
+								$feed['status']		= $alt_feed['status'];
+							}
+							if (isset($alt_feed['info'])) {
+								$feed['info']		= $alt_feed['info'];
+							}
+							if (isset($alt_feed['register'])) {
+								$feed['register']	= $alt_feed['register'];
+							}
+						}
+
+						// Print info about Feed if available
+						if (isset($feed['info']) && !empty($feed['info'])) {
+							print ("&emsp;<i class=\"fa-solid fa-info-circle\" title=\"{$feed['info']}\"></i>");
+						}
+
+						// Print Feed offline status
+						if (isset($feed['status'])) {
+							print ("&emsp;<i class=\"fa-solid fa-bug text-danger\" title=\"Feed temporarily unavailable\"></i>");
+						}
+
+						// Add link to Donate/support link
+						if (isset($feed['donate'])) {
+							print ("&emsp;<a target=\"_blank\" href=\"{$feed['donate']}\" title=\"Click to donation/support page.\">
+							<i class=\"fa-solid fa-cart-plus\"></i></a>");
+						}
+
+						// Add link to Feed registration
+						if ($feed['register']) {
+							print ("&emsp;<a target=\"_blank\" href=\"{$feed['register']}\" title=\"Click to register\">
+								<i class=\"fa-solid fa-right-to-bracket\"></i></a>");
+						}
+					?>
+			</td>
+
+			<td>
+				<?=$feed_radio;?>
+				<a target="_blank" href="<?=$feed['url'];?>"
+					onclick="return confirm('Download feed [ <?=$feed['url'];?> ] ?')"><?=$feed_header;?>
+				</a>
+			</td>
+
+			<td><?=$icon;?></td>
+		</tr>
+					<?php
+						// Collect previous values
+						$p_type		= $ftype;
+						$p_aliasname	= $aliasname;
+						$p_tr_style	= $tr_style;
+						$feed_info_row++;
+					endfor;
+				endif;
+			endforeach;
+		endforeach;
+}
+
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Feeds'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblockerng_feeds.php', '@self');
 include_once('head.inc');
@@ -250,47 +602,9 @@ $section->addInput(new Form_StaticText(
 	. ' combine multiple Alias/Groups together by using a duplicate Alias/Group name.'
 ));
 
-$section->addInput(new Form_StaticText(
-	'IPv4 Alias name(s):',
-	'To change the default IPv4 Alias name(s), enter new Alias name(s) as desired.'));
-
-foreach ($feeds_list['ipv4'] as $aliasname) {
-	$l_aliasname = strtolower($aliasname);
-	$section->addInput(new Form_Input(
-		'feed_' . $l_aliasname,
-		$aliasname,
-		'text',
-		$pconfig['feed_' . $l_aliasname]
-	))->setWidth(3);
-}
-
-$section->addInput(new Form_StaticText(
-	'IPv6 Alias name(s):',
-	'To change the default IPv6 Alias name(s), enter new Alias name(s) as desired.'));
-
-foreach ($feeds_list['ipv6'] as $aliasname) {
-	$l_aliasname = strtolower($aliasname);
-	$section->addInput(new Form_Input(
-		'feed_' . $l_aliasname,
-		$aliasname,
-		'text',
-		$pconfig['feed_' . $l_aliasname]
-	))->setWidth(3);
-}
-
-$section->addInput(new Form_StaticText(
-	'DNSBL Alias name(s):',
-	'To change the default DNSBL Group name(s), enter new Group name(s) as desired.'));
-
-foreach ($feeds_list['dnsbl'] as $aliasname) {
-	$l_aliasname = strtolower($aliasname);
-	$section->addInput(new Form_Input(
-		'feed_' . $l_aliasname,
-		$aliasname,
-		'text',
-		$pconfig['feed_' . $l_aliasname]
-	))->setWidth(3);
-}
+pfb_feeds_render_aliasname_inputs($section, 'ipv4', $feeds_list, $pconfig);
+pfb_feeds_render_aliasname_inputs($section, 'ipv6', $feeds_list, $pconfig);
+pfb_feeds_render_aliasname_inputs($section, 'dnsbl', $feeds_list, $pconfig);
 
 $btn_save = new Form_Button(
 	'save',
@@ -417,308 +731,9 @@ print ($section);
 			$feed_info_row = 0;
 			$aliasname_found = array();
 
-			foreach ($feed_info as $ftype => $info):
-
-				if (empty($info)) {
-					print ("<td class=\"bg-danger\"><br /><strong>No feeds definitions found!</strong><br /><br /></td>");
-					continue;
-				}
-
-				$p_type = '';
-				foreach ($info as $aliasname => $data):
-					$p_aliasname = '';
-					if (!isset($data['feeds'])) {
-						continue;
-					}
-
-					foreach ($data['feeds'] as $feed):
-						$status = $icon = '';
-
-						if (!empty($ex_feeds[$ftype])) {
-							foreach ($ex_feeds[$ftype] as $key => $row) {
-
-								if (empty($row)) {
-									continue;
-								}
-
-								if (isset($row['aliasname']) && $aliasname == $row['aliasname'] && !isset($aliasname_found[$aliasname])) {
-									$aliasname_found[$aliasname] = $aliasname;
-
-									if ($row['action'] == 'Disabled') {
-										$status = "&emsp;"
-											. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
-											. "&rowid={$row['rowid']}\"<span class=\"text-danger\""
-											. "title=\"Alias/Group exists but is currently Disabled\">"
-											. "<i class=\"fa-solid fa-check\"></i></span>"
-											. "</a>";
-									} else {
-										$status = "&emsp;"
-											. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}" 
-											. "&rowid={$row['rowid']}\""
-											. "title=\"Alias/Group exists\">"
-											. "<i class=\"fa-solid fa-check\"></i>"
-											. "</a>";
-									}
-								}
-
-								// Determine all Aliases that reference the Feed URL
-								url_compare($ftype, $key, $row['rowid'], $aliasname, $row['aliasname'], $row['url'], $feed['url'],
-										$row['state'], $feed['header'], FALSE, '', '', '', 0);
-
-								// Determine all Aliases that reference the 'Alternate' Feed URLs
-								if (isset($feed['alternate'])) {
-									foreach ($feed['alternate'] as $a_key => $alt) {
-										url_compare($ftype, $key, $row['rowid'], $aliasname, $row['aliasname'], $row['url'],
-											$alt['url'], $row['state'], $feed['header'], TRUE, $alt['header'],
-											isset($alt['info']) ? $alt['info'] : '', isset($alt['register']) ? 'register' : '', $a_key); 
-									}
-								}
-							}
-
-							if (!isset($aliasname_found[$aliasname])) {
-								$aliasname_found[$aliasname] = $aliasname;
-								$status = "&emsp;"
-									. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
-									. "&act=addgroup&atype={$aliasname}\""
-									. "title=\"Add Alias/Group: {$aliasname}\">"
-									. "<i class=\"fa-solid fa-plus-circle\"></i>"
-									. "</a>";
-							}
-						}
-
-						if (isset($feed['feed'])):
-
-							// Print table/row of Feeds and consecutive rows for all 'Alternate' URLs available.
-							$counter = 0;
-							if (isset($alt_feeds[$ftype][$aliasname][$feed['header']])) {
-								$counter = count($alt_feeds[$ftype][$aliasname][$feed['header']]);
-							}
-
-							for ($i=0; $i <= $counter; $i++):
-
-								// Print blank seperator line between Categories (skip first row)
-								if ($feed_info_row > 0 && $ftype != $p_type) {
-									print ("<tr><td><br /></td><td></td><td></td><td></td><td></td><td></td></tr>");
-								}
-
-								// Print applicable alternating background color
-								if ($data['action'] == 'permit') {
-									if ($aliasname == $p_aliasname) {
-										$tr_style = 'background-color: #F5FBF6;';		// Light green 1
-										if ($tr_style == $p_tr_style) {
-											$tr_style = 'background-color: #EEF7EE;';	// Light green 2
-										}
-									} else {
-										// Dark green (New Alias/Group)
-										$tr_style = 'background-color: #A0B8A0;';	// #C8E6C9;';
-									}
-								}
-								else {
-									$tr_style = '';
-									if ($aliasname != $p_aliasname) {
-										// Grey - (New Alias/Group)
-										$tr_style = 'background-color: #B8B8B8;';	//#D8D8D8;';
-									}
-								}
-							?>
-
-				<tr style="<?=$tr_style;?>">
-					<td>
-							<?php
-								switch ($ftype) {
-									case 'ipv4':
-										$type = 'IPv4';
-										break;
-									case 'ipv6':
-										$type = 'IPv6';
-										break;
-									case 'dnsbl':
-										$type = 'DNSBL';
-										break;
-								}
-								if ($ftype != $p_type) {
-									print ("<strong>{$type} Category</strong>");
-								} else {
-									print ("<p style=\"font-size: 75%\">{$type}<p>");
-								}
-							?>
-					</td>
-
-					<td>
-							<?php
-								if ($aliasname != $p_aliasname) {
-									// Add Line break (bullet)
-									$data['info'] = str_replace('-LB-', "\n&emsp;&#9679;&emsp;", $data['info']);
-									print ("<i title=\"{$data['info']}\" class=\"fa-solid fa-info-circle\"></i>{$status}");
-								}
-
-								if ($i == 0) {
-
-									// If alternative URLs are available, print radio checkbox options. Default to first radio.
-									if (isset($alt_feeds[$ftype][$aliasname][$feed['header']])) {
-
-										// Add first radio option as default if not previously saved 
-										if (!isset($fconfig['feed_alt_' . strtolower($feed['header']) ])) {
-											$feed_alt_selected[] = $feed['header'];
-										}
-
-										// Collect all 'Alternative' Feed Header names. (POST/save)
-										$alt_selected .= $feed['header'] . ',';
-
-										if (in_array($feed['header'], $feed_alt_selected) && empty($icon)) {
-											$icon = "&emsp;"
-												. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
-												. "&act=add&atype={$feed['header']}\""
-												. "title=\"Add feed: [ {$feed['header']} ]\">"
-												. "<i class=\"fa-solid fa-plus-circle\"></i>"
-												. "</a>";
-										}
-										elseif (empty($icon)) {
-											$pfb_found = FALSE;
-											foreach ($alt_feeds[$ftype][$aliasname][$feed['header']] as $a_header) {
-												if (!empty($a_header['icon']) || 
-												    in_array($a_header['header'], $feed_alt_selected)) {
-													$pfb_found = TRUE;
-													break;
-												}
-											}
-
-											if (!$pfb_found) {
-												$icon = "&emsp;"
-												. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
-												. "&act=add&atype={$feed['header']}\""
-												. "title=\"Add feed: [ {$feed['header']} ]\">"
-												. "<i class=\"fa-solid fa-plus-circle\"></i>"
-												. "</a>";
-											}
-										}
-
-										$feed_alternate	= '';
-										$feed_header	= $feed['header'];
-										$feed_radio	= "&emsp;<input type=\"radio\" name=\"alt_{$feed['header']}\""
-												. " value=\"alt_{$feed['header']}\" checked=\"checked\" />&emsp;";
-
-										print ("<input type=\"hidden\" name=\"alt_" . "{$feed['header']}" . "\" id=\"alt_"
-											. "{$feed['header']}" . "\" value=\"\" />");
-									}
-									else {
-										if (empty($icon)) {
-											$icon = "&emsp;"
-												. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
-												. "&act=add&atype={$feed['header']}\""
-												. "title=\"Add feed: [ {$feed['header']} ]\">"
-												. "<i class=\"fa-solid fa-plus-circle\"></i>"
-												. "</a>";
-										}
-
-										$feed_alternate	= '';
-										$feed_header	= $feed['header'];
-										$feed_radio	= '';
-									}
-								}
-
-								// Extract 'Alternate Feed' details from alt_feed array.
-								else {
-									$status = '';
-									$alt_feed	= $alt_feeds[$ftype][$aliasname][$feed['header']][$i -1];
-									$icon 		= $alt_feed['icon'];
-	
-									if (in_array($alt_feed['header'], $feed_alt_selected)) {
-										$checked = 'checked=\"checked\"';
-										if (empty($icon)) {
-											$icon = "&emsp;"
-												. "<a href=\"/pfblockerng/pfblockerng_category_edit.php?type={$ftype}"
-												. "&act=add&atype={$alt_feed['header']}\""
-												. "title=\"Add feed: [ {$alt_feed['header']} ]\">"
-												. "<i class=\"fa-solid fa-plus-circle\"></i>"
-												. "</a>";
-										}
-									}
-									else {
-										$checked = '';
-									}
-
-									$feed['url']	= $alt_feed['url'];
-									$feed_alternate = "&emsp;<i class=\"fa-solid fa-angle-right\" style=\"cursor: default\""
-											. " title=\"Alternate Feed option\"></i>&emsp;";
-									$feed_header	= $alt_feed['header'];
-									$feed_radio	= "&emsp;<input type=\"radio\" name=\"alt_{$feed['header']}\""
-											. " value=\"alt_{$alt_feed['header']}\" {$checked} />&emsp;";
-								}
-							?>
-					</td>
-
-					<td>
-							<?php
-								if ($aliasname != $p_aliasname) {
-									print ("{$aliasname}");
-								} else {
-									print ("<p style=\"font-size: 75%\">{$aliasname}<p>");
-								}
-							?>
-					</td>
-
-					<td>
-						<?=$feed_alternate;?>
-						<a target="_blank" href="<?=$feed['website'];?>"><?=$feed['feed'];?></a>
-							<?php
-								// Add any Alternate Feed icons
-								if (!empty($feed_alternate)) {
-									if (isset($alt_feed['status'])) {
-										$feed['status']		= $alt_feed['status'];
-									}
-									if (isset($alt_feed['info'])) {
-										$feed['info']		= $alt_feed['info'];
-									}
-									if (isset($alt_feed['register'])) {
-										$feed['register']	= $alt_feed['register'];
-									}
-								}
-
-								// Print info about Feed if available
-								if (isset($feed['info']) && !empty($feed['info'])) {
-									print ("&emsp;<i class=\"fa-solid fa-info-circle\" title=\"{$feed['info']}\"></i>");
-								}
-
-								// Print Feed offline status
-								if (isset($feed['status'])) {
-									print ("&emsp;<i class=\"fa-solid fa-bug text-danger\" title=\"Feed temporarily unavailable\"></i>");
-								}
-
-								// Add link to Donate/support link
-								if (isset($feed['donate'])) {
-									print ("&emsp;<a target=\"_blank\" href=\"{$feed['donate']}\" title=\"Click to donation/support page.\">
-									<i class=\"fa-solid fa-cart-plus\"></i></a>");
-								}
-
-								// Add link to Feed registration
-								if ($feed['register']) {
-									print ("&emsp;<a target=\"_blank\" href=\"{$feed['register']}\" title=\"Click to register\">
-										<i class=\"fa-solid fa-right-to-bracket\"></i></a>");
-								}
-							?>
-					</td>
-
-					<td>
-						<?=$feed_radio;?>
-						<a target="_blank" href="<?=$feed['url'];?>"
-							onclick="return confirm('Download feed [ <?=$feed['url'];?> ] ?')"><?=$feed_header;?>
-						</a>
-					</td>
-
-					<td><?=$icon;?></td>
-				</tr>
-							<?php
-								// Collect previous values
-								$p_type		= $ftype;
-								$p_aliasname	= $aliasname;
-								$p_tr_style	= $tr_style;
-								$feed_info_row++;
-							endfor;
-						endif;
-					endforeach;
-				endforeach;
-			endforeach;
+			foreach ($feed_info as $ftype => $info) {
+				pfb_feeds_render_predefined_type($ftype, $info);
+			}
 			?>
 
 			</tbody>

--- a/tests/smoke/fixtures/README.md
+++ b/tests/smoke/fixtures/README.md
@@ -1,0 +1,50 @@
+# Smoke feed fixtures (ADR-16 Part C)
+
+Inert sample feed bodies served to the live pfSense smoke VM by `_MockFeedServer`
+(`tests/smoke/conftest.py`, the `mock_feeds` fixture). Each file is the raw body
+`curl` fetches; the guest reaches it at `http://10.0.2.2:<port>/<filename>` over
+SLIRP. **Phase 4 authors these fixtures only** — Phase 5 registers them on an
+`IpCase`/`DnsblCase`, runs Force Update, and asserts the load on the box.
+
+All data is inert: IP files use RFC 5737 / RFC 3849 documentation ranges; DNSBL
+files use `uuid-<hex>.com` names. Per the smoke-domain rule, DNSBL fixtures NEVER
+use RFC-6761 TLDs (`.test`/`.example`/`.invalid` — Unbound's built-in local-zones
+shadow them) and NEVER HSTS-preload names (HSTS forces a VIP block to NULL).
+
+Line shapes match the real parsers — IP `auto` in `pfblockerng.inc`
+(`~:10410-10560`), DNSBL plain/hosts/ABP in `pfb_unbound.py`
+(`parse` / `parse_abp`, `~:2675-2900`). A leading `#` (IP, DNSBL plain/hosts) or
+`!` / `[` (ABP) is a comment, exercised in every file.
+
+## IP feeds (format `auto`, `IpCase`)
+
+| File | Format | Family | Member (loads) | Non-member (must NOT) |
+| --- | --- | --- | --- | --- |
+| `ip_plain_cidr.txt` | plain IPv4 + CIDR | v4 | `203.0.113.5`; `198.51.100.7` (in `198.51.100.0/24`) | `203.0.113.250` |
+| `ip_range.txt` | IPv4 range `a-b` | v4 | `198.51.100.15` (in `198.51.100.10-198.51.100.20`) | `198.51.100.21`, `198.51.100.200` |
+| `ip_ipv6.txt` | IPv6 single + CIDR | v6 | `2001:db8::1`; `2001:db8:1::99` (in `2001:db8:1::/48`) | `2001:db8:dead::1` |
+
+IP assertion: `pfctl_table_members(pfB_<alias>_<family>)` with the CIDR-tolerant
+`member_present`. The v4 range expands via `ip_range_to_subnet_array()` into the
+CIDRs that exactly cover `.10`–`.20`, so `.21` is intentionally just outside.
+
+## DNSBL feeds (`DnsblCase`)
+
+| File | Format | Member (blocks) | Allow-exception (resolves) | Non-member (resolves) |
+| --- | --- | --- | --- | --- |
+| `dnsbl_plain.txt` | plain domain | `uuid-a344db4286a4.com` | — | `uuid-06cf362c2890.com` |
+| `dnsbl_hosts.txt` | hosts `0.0.0.0 d` | `uuid-947e69114606.com` | — | `uuid-55ca85f92f34.com` |
+| `dnsbl_abp.txt` | ABP / EasyList | `uuid-22f166f56cca.com` | `uuid-f26156c6df69.com` (block then `@@` allow) | `uuid-8ed2df53e469.com` |
+
+DNSBL assertion: `dns_probe` block-shape on the box (NOERROR + VIP, or NULL per the
+list's `logging`); the non-member (and the ABP allow-exception, where a feed `@@`
+allow band 2 beats the `||` block band 1) must RESOLVE, not block.
+
+## Omitted formats (and why)
+
+CSV/iblocklist, regex, and the ABP IP-anchor (`||1.2.3.4^`) variants are out of the
+Phase 5 representative set: they either duplicate the plain/hosts/range coverage or
+divert to the PHP DNSBL-IP firewall path rather than the domain build. The
+egress/binary formats (geoip/asn/whois/rsync) are explicitly out of the hermetic
+smoke (ADR-16 §2) — they need MaxMind/egress. The pre-existing
+`sample_ip_feed.txt` is the ADR-04 scaffolding placeholder, left in place.

--- a/tests/smoke/fixtures/dnsbl_abp.txt
+++ b/tests/smoke/fixtures/dnsbl_abp.txt
@@ -1,0 +1,17 @@
+[Adblock Plus 2.0]
+! DNSBL feed fixture - ABP / EasyList format (DnsblCase, format_hint='abp').
+! pfb_unbound.py parse_abp (~:2675-2779): the '[Adblock Plus 2.0]' header line and
+! '!' comment lines are dropped; '||domain^' is a BLOCK (wildcard: name + subdomains);
+! '@@||domain^' is an ALLOW exception (feed allow band 2 BEATS feed block band 1, so
+! a name that is also '||'-blocked resolves). uuid-style '.com' names ONLY
+! (smoke-domain rule: never RFC-6761 / HSTS-preload).
+!
+! Served by mock_feeds at http://10.0.2.2:<port>/dnsbl_abp.txt
+!
+! Phase 5 asserts (dns_probe block-shape on the box):
+!   MEMBER (||  -> must BLOCK):                      uuid-22f166f56cca.com
+!   ALLOW-EXCEPTION (|| then @@ -> must RESOLVE):    uuid-f26156c6df69.com
+!   NON-MEMBER (not in feed -> must RESOLVE):        uuid-8ed2df53e469.com
+||uuid-22f166f56cca.com^
+||uuid-f26156c6df69.com^
+@@||uuid-f26156c6df69.com^

--- a/tests/smoke/fixtures/dnsbl_hosts.txt
+++ b/tests/smoke/fixtures/dnsbl_hosts.txt
@@ -1,0 +1,13 @@
+# DNSBL feed fixture - hosts format (DnsblCase, default DNSBL build).
+# pfb_unbound.py _dnsbl_strip_hosts_prefix (~:2830-2842) + parse hosts path: a
+# '<sink-ip> <domain>' line keeps the DOMAIN token (the leading 0.0.0.0/127.0.0.1
+# sink IP is stripped); the resulting domain blocks (wildcard) name + subdomains.
+# A full-line '#' comment and blank lines are dropped.
+# uuid-style '.com' names ONLY (smoke-domain rule, see dnsbl_plain.txt).
+#
+# Served by mock_feeds at http://10.0.2.2:<port>/dnsbl_hosts.txt
+#
+# Phase 5 asserts (dns_probe block-shape on the box):
+#   MEMBER (must BLOCK - VIP/NULL per list logging):  uuid-947e69114606.com
+#   NON-MEMBER (must RESOLVE, not block):             uuid-55ca85f92f34.com
+0.0.0.0 uuid-947e69114606.com

--- a/tests/smoke/fixtures/dnsbl_plain.txt
+++ b/tests/smoke/fixtures/dnsbl_plain.txt
@@ -1,0 +1,13 @@
+# DNSBL feed fixture - plain domain list (DnsblCase, default DNSBL build).
+# pfb_unbound.py parse('plain'/hosts path, ~:2890-2900): a bare 'domain' is kept
+# (lower-cased, domain-shape gated, wildcard -> blocks the name + subdomains); a
+# full-line '#' or '!' comment and blank lines are dropped.
+# uuid-style '.com' names ONLY (smoke-domain rule: never RFC-6761 .test/.example/
+# .invalid -> Unbound built-in local-zones shadow them; never HSTS-preload names).
+#
+# Served by mock_feeds at http://10.0.2.2:<port>/dnsbl_plain.txt
+#
+# Phase 5 asserts (dns_probe block-shape on the box):
+#   MEMBER (must BLOCK - VIP/NULL per list logging):  uuid-a344db4286a4.com
+#   NON-MEMBER (must RESOLVE, not block):             uuid-06cf362c2890.com
+uuid-a344db4286a4.com

--- a/tests/smoke/fixtures/ip_ipv6.txt
+++ b/tests/smoke/fixtures/ip_ipv6.txt
@@ -1,0 +1,14 @@
+# IP feed fixture - IPv6 (format 'auto', IpCase family='v6').
+# pfblockerng.inc IP 'auto' v6 parser (~:10520-10534): a line containing ':' is
+# validated with validate_ipv6() (single address or CIDR) into the pfB_<alias>_v6
+# table; an inline '#' truncates the line, and a full-line '#'/blank is skipped.
+# RFC 3849 documentation prefix (2001:db8::/32) ONLY; never a real host.
+#
+# Served by mock_feeds at http://10.0.2.2:<port>/ip_ipv6.txt
+#
+# Phase 5 asserts (pfctl_table_members(pfB_<alias>_v6), compare by value, ::==::0):
+#   MEMBER (single host):              2001:db8::1
+#   MEMBER (covered by the /48):       2001:db8:1::/48  (e.g. 2001:db8:1::99)
+#   NON-MEMBER (must NOT be present):  2001:db8:dead::1
+2001:db8::1
+2001:db8:1::/48

--- a/tests/smoke/fixtures/ip_plain_cidr.txt
+++ b/tests/smoke/fixtures/ip_plain_cidr.txt
@@ -1,0 +1,14 @@
+# IP feed fixture - plain IPv4 + CIDR (format 'auto', IpCase family='v4').
+# pfblockerng.inc IP 'auto' parser (~:10410-10477): a full-line '#' (line[0]=='#')
+# and blank lines are skipped; a single IP or IP/CIDR is taken verbatim
+# (sanitize_ipaddr + validate_ipv4) into the pfB_<alias>_v4 table.
+# RFC 5737 documentation ranges ONLY (TEST-NET-2/3); never a real/abusable host.
+#
+# Served by mock_feeds at http://10.0.2.2:<port>/ip_plain_cidr.txt
+#
+# Phase 5 asserts (pfctl_table_members(pfB_<alias>_v4)):
+#   MEMBER (must be in the table):     203.0.113.5      (the plain host)
+#   MEMBER (covered by the CIDR):      198.51.100.0/24  (e.g. 198.51.100.7)
+#   NON-MEMBER (must NOT be present):  203.0.113.250
+203.0.113.5
+198.51.100.0/24

--- a/tests/smoke/fixtures/ip_range.txt
+++ b/tests/smoke/fixtures/ip_range.txt
@@ -1,0 +1,15 @@
+# IP feed fixture - IPv4 range (format 'auto', IpCase family='v4').
+# pfblockerng.inc IP 'auto' range parser (~:10440-10465): a line 'a-b' is exploded
+# on '-' and expanded by ip_range_to_subnet_array() into the minimal set of CIDR
+# blocks that exactly covers a..b; those CIDRs populate the pfB_<alias>_v4 table.
+# RFC 5737 documentation range (TEST-NET-3) ONLY; never a real/abusable host.
+#
+# Served by mock_feeds at http://10.0.2.2:<port>/ip_range.txt
+#
+# 198.51.100.10-198.51.100.20 expands to 10/31,12/30,16/30,20/32 -> covers exactly
+# .10 through .20 inclusive.
+# Phase 5 asserts (pfctl_table_members(pfB_<alias>_v4), CIDR-tolerant member_present):
+#   MEMBER (inside the range):         198.51.100.15
+#   NON-MEMBER (just past the range):  198.51.100.21
+#   NON-MEMBER (well outside):         198.51.100.200
+198.51.100.10-198.51.100.20

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -1,0 +1,314 @@
+"""ADR-16 Part C — the live HTTP-feed load smoke (the Part-C kill-gate).
+
+Every other smoke case (``test_smoke_matrix.py`` / ``test_smoke_abp.py``) feeds a
+LOCAL file (``write_local_feed``) — chosen partly for HTTP-fetch reliability (ADR-16
+Context 5). This module is the one place the suite drives the REAL HTTP feed-fetch
+path: each case points a ``IpCase``/``DnsblCase`` at a ``mock_feeds.feed_url(<name>)``
+URL (the stdlib ``_MockFeedServer`` serving ``tests/smoke/fixtures/``, reachable by
+the guest at ``http://10.0.2.2:<port>/<name>`` over SLIRP — survives the egress
+block), runs a real Force Update, and asserts the feed loaded on the box. This
+exercises pfBlockerNG's ``curl`` contract (gzip / redirects / no-304) end-to-end —
+the gap Part C closes.
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke`` in
+pyproject.toml). Run only by the smoke workflow::
+
+    python -m pytest tests/smoke -m smoke --override-ini="addopts="
+
+KILL-GATE (ADR-16 §7). The Part-C premise — "a Force Update reliably FETCHES an HTTP
+feed from the mock over SLIRP and LOADS it, in CI" — is falsifiable. The two proof
+cases (``test_ip_http_feed_loads`` + ``test_dnsbl_http_feed_loads``) come FIRST; the
+format expansion follows. The reliability bar is **>= 4/5 clean runs at a sane
+per-leg budget**: if the live CI run cannot hit it, ``test_smoke_feeds.py`` is
+DEMOTED to dispatch-only (dropped from the gated smoke set) — Part A still ships and
+the local-file load coverage (the matrix) remains. The numbers + GO/DEMOTE decision
+are recorded in ``.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/RESULTS/05_Results.txt``;
+this run is OPTIMISTIC-GO (all formats authored) pending the live evidence.
+
+Fixture members / non-members are the Phase-4 RESULTS contract (RESULTS/04 §"THE 6
+SAMPLE FEEDS"); the IP CIDR/range membership is asserted CIDR-aware (``_covered_by``)
+because the listed forms are networks, not the probe host.
+
+RESOLVE-PROOF NOTE (mirrors the matrix #51 lifecycle, NOT a host override): a DNSBL
+name that must RESOLVE is asserted to resolve to the controlled stub sentinel
+(``STUB_DNS_A``) with egress left OPEN in the probe body (``unblock_egress``) —
+pfSense forwards a not-blocked name to the SLIRP stub (``use_system_dns_upstream``),
+so the pass is a KNOWN, observable answer (never a loose "not blocked"). A control
+Host-Override is deliberately AVOIDED here: Unbound serves a host override as
+``local-data`` BEFORE the python module, so an override would SHADOW the matcher —
+it cannot prove a name is unblocked by the matcher (the ABP ``@@`` allow-exception
+especially), and on a BLOCKED member it would mask the block. The member block
+returns its VIP shape locally regardless of egress, so leaving egress open is no
+false-green.
+
+These need the booted ``smoke_vm`` fixture, the branch ``.pkg`` (``SMOKE_PKG``), the
+``mock_feeds`` server, and the smoke deps; without them they skip cleanly.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import STUB_DNS_A, SmokeVM, _MockFeedServer, _StubDnsServer
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg once for the HTTP-feed-load matrix (mirrors the ADR-04
+    matrix / ABP modules).
+
+    Egress is managed per-case by ``CaseContext`` (OPEN across inject + the Force
+    Update so the mock HTTP fetch is reachable; BLOCKED for the probe). The DNSBL VIP
+    is injected once (DNSBL force-disables itself without one), and System DNS is
+    pointed at the controlled stub so a not-blocked name has a known answer. A full
+    guest snapshot is collected on teardown for the workflow to upload.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.unblock_egress()
+        h.collect_host_diagnostics(smoke_vm)
+
+
+def _covered_by(members: list[str], ip: str) -> bool:
+    """True iff ``ip`` is covered by any pf table member, CIDR-aware (by value).
+
+    ``helpers.member_present`` only matches an exact host or a member whose network
+    ADDRESS equals ``ip``; the IP fixtures list NETWORKS (``198.51.100.0/24``) and a
+    range expands to covering CIDRs (``.10/31`` …), so a host INSIDE them needs a real
+    ``ipaddress`` containment test. Compares by value (``::`` == ``::0``), so the
+    member's textual form never matters.
+    """
+    target = ipaddress.ip_address(ip)
+    for member in members:
+        try:
+            if target in ipaddress.ip_network(member, strict=False):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# KILL-GATE — the two proof cases (one IP, one DNSBL) over real HTTP.
+# These run FIRST (§7): they falsify the Part-C premise before the format matrix.
+# --------------------------------------------------------------------------- #
+
+
+def test_ip_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """KILL-GATE (IP): a plain-IP+CIDR feed served over HTTP loads into the pf table.
+
+    Scenario: the Phase-4 ``ip_plain_cidr.txt`` fixture is fetched by a real Force
+    Update over the mock (``feed_url`` = the HTTP URL, NOT a local file) and its
+    entries land in ``pfB_<alias>_v4`` with a referencing rule.
+
+    Given the feed is NOT yet configured, the alias table does not exist (the
+    transition's before-state — proven via ``pfctl_tables``).
+    When the case injects + Force-Updates over the HTTP feed,
+    Then the listed plain host (``203.0.113.5``) and a host covered by the listed
+    CIDR (``198.51.100.7`` in ``198.51.100.0/24``) are table members, a never-listed
+    host (``203.0.113.250``) is NOT, and a loaded pf rule references the alias —
+    proving the HTTP fetch reached the matcher (member + non-member + wiring).
+    """
+    member_host = "203.0.113.5"  # the plain listed host
+    member_in_cidr = "198.51.100.7"  # inside the listed 198.51.100.0/24
+    non_member = "203.0.113.250"  # in 203.0.113.x but NOT listed
+    feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
+    spec = h.IpCase(aliasname="smokefeedip4", feed_url=feed_url, header="smokefeedip4", family="v4")
+
+    # BEFORE: the alias table does not exist until the feed is loaded.
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the feed was ever loaded"
+
+    with h.CaseContext(deployed_vm, spec):
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
+        assert h.member_present(members, member_host), f"{member_host} not in {spec.alias}: {members}"
+        assert _covered_by(members, member_in_cidr), f"{member_in_cidr} not covered by {spec.alias}: {members}"
+        assert not _covered_by(members, non_member), f"{non_member} unexpectedly in {spec.alias}: {members}"
+        assert h.rule_references(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
+
+
+def test_dnsbl_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """KILL-GATE (DNSBL): a plain-domain feed served over HTTP loads into the matcher.
+
+    Scenario: the Phase-4 ``dnsbl_plain.txt`` fixture is fetched by a real Force
+    Update over the mock and its single domain blocks on the box.
+
+    Given the listed member is NOT yet on any feed, it RESOLVES via the controlled
+    stub upstream (``STUB_DNS_A``) — a real, observable before-state.
+    When the case injects + Force-Updates over the HTTP feed,
+    Then the listed domain (``uuid-a344db4286a4.com``) returns the VIP block shape and
+    no longer resolves, while a non-member (``uuid-06cf362c2890.com``) still RESOLVES
+    via the stub — proving the HTTP fetch loaded the feed and ONLY the listed name
+    blocks (member + non-member, both observed).
+    """
+    member = "uuid-a344db4286a4.com"  # listed -> must BLOCK
+    non_member = "uuid-06cf362c2890.com"  # not listed -> must RESOLVE
+    feed_url = mock_feeds.feed_url("dnsbl_plain.txt")
+    spec = h.DnsblCase(aliasname="smokefeeddnsbl", feed_url=feed_url, header="smokefeeddnsbl", mode=h.DnsblMode.VIP)
+
+    # BEFORE: the member is not on any feed yet -> it resolves via the stub sentinel.
+    before = h.dns_probe(deployed_vm, member, "A")
+    assert h.resolves_to(before, STUB_DNS_A), f"{member} should resolve via stub BEFORE listing, got {before}"
+    assert not h.is_vip(before), f"{member} unexpectedly VIP-blocked before any feed: {before}"
+
+    with h.CaseContext(deployed_vm, spec):
+        # The "resolves" probes must reach the controlled stub: leave egress OPEN. The
+        # member's VIP block returns locally regardless, so this is no false-green.
+        h.unblock_egress()
+        blocked = h.dns_probe(deployed_vm, member, "A")
+        assert h.is_vip(blocked), f"listed {member} expected VIP block, got {blocked}"
+        assert not h.resolves_to(blocked, STUB_DNS_A), f"{member} still resolving after the feed block: {blocked}"
+        passed = h.dns_probe(deployed_vm, non_member, "A")
+        assert h.resolves_to(passed, STUB_DNS_A), f"non-member {non_member} should resolve via stub, got {passed}"
+        assert not h.is_vip(passed), f"non-member {non_member} wrongly VIP-blocked: {passed}"
+
+
+# --------------------------------------------------------------------------- #
+# EXPAND — one case per remaining representative Phase-4 format (gate held):
+#   IP    {range, IPv6}
+#   DNSBL {hosts, ABP/EasyList}
+# Same shape as the kill-gate, fixtures served over HTTP via mock_feeds.feed_url.
+# --------------------------------------------------------------------------- #
+
+
+def test_ip_http_range_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """IP range over HTTP: ``ip_range.txt`` (``198.51.100.10-198.51.100.20``) loads.
+
+    The range expands to the covering CIDRs (``.10/31``, ``.12/30``, ``.16/30``,
+    ``.20/32``). Before-state: the alias table does not exist. After a Force Update
+    over the HTTP feed, a host INSIDE the range (``.15``) is covered, a host just past
+    the top (``.21``) and one well outside (``.200``) are NOT, and a rule references
+    the alias — proving the range expansion loaded via the HTTP fetch.
+    """
+    inside = "198.51.100.15"  # inside .10..20
+    just_past = "198.51.100.21"  # one past the top (must NOT be covered)
+    outside = "198.51.100.200"  # well outside
+    feed_url = mock_feeds.feed_url("ip_range.txt")
+    spec = h.IpCase(aliasname="smokefeedrange", feed_url=feed_url, header="smokefeedrange", family="v4")
+
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the feed was ever loaded"
+
+    with h.CaseContext(deployed_vm, spec):
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
+        assert _covered_by(members, inside), f"{inside} not covered by the range in {spec.alias}: {members}"
+        assert not _covered_by(members, just_past), (
+            f"{just_past} (one past the range) unexpectedly in {spec.alias}: {members}"
+        )
+        assert not _covered_by(members, outside), f"{outside} unexpectedly in {spec.alias}: {members}"
+        assert h.rule_references(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
+
+
+def test_ipv6_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """IPv6 over HTTP: ``ip_ipv6.txt`` (single + /48) loads into the v6 alias table.
+
+    Before-state: the ``pfB_<alias>_v6`` table does not exist. After a Force Update
+    over the HTTP feed, the single host (``2001:db8::1``) and a host covered by the
+    listed /48 (``2001:db8:1::99`` in ``2001:db8:1::/48``) are members, a host
+    outside both (``2001:db8:dead::1``) is NOT, and a rule references the alias.
+    IPv6 membership is compared BY VALUE (``::`` == ``::0``) via ``_covered_by``.
+    """
+    member_host = "2001:db8::1"  # the single listed host
+    member_in_prefix = "2001:db8:1::99"  # inside the listed 2001:db8:1::/48
+    non_member = "2001:db8:dead::1"  # outside the /48 AND != the single host
+    feed_url = mock_feeds.feed_url("ip_ipv6.txt")
+    spec = h.IpCase(aliasname="smokefeedip6", feed_url=feed_url, header="smokefeedip6", family="v6")
+
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the feed was ever loaded"
+
+    with h.CaseContext(deployed_vm, spec):
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
+        assert _covered_by(members, member_host), f"{member_host} not in {spec.alias}: {members}"
+        assert _covered_by(members, member_in_prefix), f"{member_in_prefix} not covered by {spec.alias}: {members}"
+        assert not _covered_by(members, non_member), f"{non_member} unexpectedly in {spec.alias}: {members}"
+        assert h.rule_references(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
+
+
+def test_dnsbl_http_hosts_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """DNSBL hosts format over HTTP: ``dnsbl_hosts.txt`` (``0.0.0.0 <domain>``) blocks.
+
+    The leading sink IP is stripped, leaving the domain to block. Before-state: the
+    member RESOLVES via the stub upstream. After a Force Update over the HTTP feed,
+    the listed domain (``uuid-947e69114606.com``) returns the VIP block shape and no
+    longer resolves, while a non-member (``uuid-55ca85f92f34.com``) still RESOLVES via
+    the stub.
+    """
+    member = "uuid-947e69114606.com"  # listed (hosts line) -> must BLOCK
+    non_member = "uuid-55ca85f92f34.com"  # not listed -> must RESOLVE
+    feed_url = mock_feeds.feed_url("dnsbl_hosts.txt")
+    spec = h.DnsblCase(aliasname="smokefeedhosts", feed_url=feed_url, header="smokefeedhosts", mode=h.DnsblMode.VIP)
+
+    before = h.dns_probe(deployed_vm, member, "A")
+    assert h.resolves_to(before, STUB_DNS_A), f"{member} should resolve via stub BEFORE listing, got {before}"
+    assert not h.is_vip(before), f"{member} unexpectedly VIP-blocked before any feed: {before}"
+
+    with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()  # the non-member "resolves" probe must reach the stub upstream
+        blocked = h.dns_probe(deployed_vm, member, "A")
+        assert h.is_vip(blocked), f"listed {member} (hosts line) expected VIP block, got {blocked}"
+        assert not h.resolves_to(blocked, STUB_DNS_A), f"{member} still resolving after the feed block: {blocked}"
+        passed = h.dns_probe(deployed_vm, non_member, "A")
+        assert h.resolves_to(passed, STUB_DNS_A), f"non-member {non_member} should resolve via stub, got {passed}"
+        assert not h.is_vip(passed), f"non-member {non_member} wrongly VIP-blocked: {passed}"
+
+
+def test_dnsbl_http_abp_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """DNSBL ABP/EasyList over HTTP: ``dnsbl_abp.txt`` is header-sniffed ABP and loads.
+
+    The body starts with ``[Adblock Plus 2.0]`` -> pfBlockerNG sniffs it as ABP
+    (``format_hint='abp'``) and the Python ABP parser runs. The feed BLOCKs
+    ``||uuid-22f166f56cca.com^`` and contains a ``||``/``@@`` pair on
+    ``uuid-f26156c6df69.com`` — the feed-allow ``@@`` (band 2) BEATS the feed-block
+    ``||`` (band 1), so that name RESOLVES.
+
+    Before-state: the ``||``-only member RESOLVES via the stub upstream. After a Force
+    Update over the HTTP feed:
+      * ``uuid-22f166f56cca.com`` (``||`` only) -> VIP block;
+      * ``uuid-f26156c6df69.com`` (``||`` then ``@@``) -> RESOLVES (allow exception);
+      * ``uuid-8ed2df53e469.com`` (not in the feed) -> RESOLVES (non-member).
+    The allow-exception is asserted to resolve via the stub WITHOUT a host override
+    (no ``control_local_data``) — an override would be served as ``local-data`` ahead
+    of the matcher and resolve the name regardless of ``@@``, a false-green. Resolving
+    via the matcher's allow path is the load-bearing branch: it proves the ABP ``@@``
+    parsed and BEAT the ``||`` block, not merely that a block loaded.
+    """
+    blocked_name = "uuid-22f166f56cca.com"  # || only -> must BLOCK
+    allow_exception = "uuid-f26156c6df69.com"  # || then @@ -> must RESOLVE
+    non_member = "uuid-8ed2df53e469.com"  # not in the feed -> must RESOLVE
+    feed_url = mock_feeds.feed_url("dnsbl_abp.txt")
+    spec = h.DnsblCase(aliasname="smokefeedabp", feed_url=feed_url, header="smokefeedabp", mode=h.DnsblMode.VIP)
+
+    # BEFORE: the ||-only name is not yet on any feed -> it resolves via the stub.
+    before = h.dns_probe(deployed_vm, blocked_name, "A")
+    assert h.resolves_to(before, STUB_DNS_A), f"{blocked_name} should resolve via stub BEFORE listing, got {before}"
+    assert not h.is_vip(before), f"{blocked_name} unexpectedly VIP-blocked before any feed: {before}"
+
+    with h.CaseContext(deployed_vm, spec):
+        # The two "resolves" probes (the @@ exception + the non-member) must reach the
+        # controlled stub: leave egress OPEN. The || block returns the VIP locally, so
+        # this is no false-green.
+        h.unblock_egress()
+        ans_blocked = h.dns_probe(deployed_vm, blocked_name, "A")
+        assert h.is_vip(ans_blocked), f"ABP ||-blocked {blocked_name} expected VIP, got {ans_blocked}"
+        assert not h.resolves_to(ans_blocked, STUB_DNS_A), (
+            f"{blocked_name} still resolving after the || block: {ans_blocked}"
+        )
+        ans_allow = h.dns_probe(deployed_vm, allow_exception, "A")
+        assert h.resolves_to(ans_allow, STUB_DNS_A), (
+            f"ABP @@ allow-exception {allow_exception} must RESOLVE via the stub (@@ beats ||), got {ans_allow}"
+        )
+        assert not h.is_vip(ans_allow), f"ABP @@ allow-exception {allow_exception} wrongly VIP-blocked: {ans_allow}"
+        ans_non = h.dns_probe(deployed_vm, non_member, "A")
+        assert h.resolves_to(ans_non, STUB_DNS_A), f"non-member {non_member} should resolve via stub, got {ans_non}"
+        assert not h.is_vip(ans_non), f"non-member {non_member} wrongly VIP-blocked: {ans_non}"

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -26,9 +26,14 @@ cheap/hermetic half). No ``src/`` change here.
 DOM-FRAGILITY NOTE: ``display_top_tabs`` renders pfSense's standard ``nav-pills``
 list; the load-bearing, version-tolerant handles are the anchor ``href`` (carries
 ``?type=``) and the ``active`` class on the highlighted ``<li>`` — NOT a brittle
-DOM path. The Feed Settings section is ``COLLAPSIBLE|SEC_CLOSED`` (collapsed on
-load), so its alias-name label is in the DOM but not visible — we assert DOM
-PRESENCE (``count()``), not visibility, for the per-type label.
+DOM path. An ``href*="?type="`` match alone is NOT unique, though: by ADR-16 A4 the
+main top bar's own "Feeds" tab AND the breadcrumb also carry ``?type=<active>``, so
+the active type's query string appears in THREE anchors. The sub-tab row is the only
+``<ul class="nav …">`` that contains ALL THREE type anchors at once — so we locate
+that row first (``_subtab_nav``) and scope the presence/active assertions to it. The
+Feed Settings section is ``COLLAPSIBLE|SEC_CLOSED`` (collapsed on load), so its
+alias-name label is in the DOM but not visible — we assert DOM PRESENCE (``count()``),
+not visibility, for the per-type label.
 
 NO fixed sleeps: every assertion uses Playwright auto-waiting / ``count()`` after
 ``networkidle``. Playwright is imported lazily via ``pytest.importorskip`` so
@@ -47,7 +52,7 @@ sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not ins
 expect = sync_api.expect
 
 if TYPE_CHECKING:
-    from playwright.sync_api import Page
+    from playwright.sync_api import Locator, Page
 
     from .webui import WebUI
 
@@ -88,13 +93,26 @@ def _shot(page: Page, screenshot_dir: Path, name: str) -> None:
     page.screenshot(path=str(screenshot_dir / f"{name}.png"), full_page=True)
 
 
-def _subtab_anchor(page: Page, gtype: str):  # type: ignore[no-untyped-def]
-    """The sub-tab row anchor whose href targets ``?type=<gtype>``.
+def _subtab_nav(page: Page) -> Locator:
+    """The SECOND ``display_top_tabs`` row -- the ``[IPv4 | IPv6 | DNSBL]`` sub-tab ``<ul>``.
 
-    Matched by href (``pfblockerng_feeds.php?type=<gtype>``) -- the version-tolerant
-    handle for a ``display_top_tabs`` tab, independent of the surrounding markup.
+    ``display_top_tabs`` renders every tab row as ``<ul class="nav nav-…">``; the page
+    has TWO (the main top bar + this sub-tab row), and -- since ADR-16 A4 -- the main
+    bar's own "Feeds" tab AND the breadcrumb also carry ``?type=<active>``. So a bare
+    ``href*="?type="`` match is NOT unique (three hits for the active type). The sub-tab
+    row is the ONLY nav that contains ALL THREE type anchors at once; filter on that.
+    Version-tolerant (works for ``nav-pills`` or ``nav-tabs``, independent of the
+    surrounding markup).
     """
-    return page.locator(f'a[href*="pfblockerng_feeds.php?type={gtype}"]')
+    nav = page.locator("ul.nav")
+    for t in ("ipv4", "ipv6", "dnsbl"):
+        nav = nav.filter(has=page.locator(f'a[href*="{FEEDS_BASE}?type={t}"]'))
+    return nav
+
+
+def _subtab_anchor(nav: Locator, gtype: str) -> Locator:
+    """The ``?type=<gtype>`` anchor WITHIN the sub-tab row ``nav`` (scoped, so unique)."""
+    return nav.locator(f'a[href*="{FEEDS_BASE}?type={gtype}"]')
 
 
 @pytest.mark.parametrize("gtype", ["ipv4", "ipv6", "dnsbl"])
@@ -125,18 +143,23 @@ def test_feeds_subtab_row_active_and_type_scoped(
     page = browser_page
     _open(page, webui, f"{FEEDS_BASE}?type={gtype}")
 
-    # The second sub-tab row exists: all three anchors are present.
+    # The second sub-tab row exists exactly once -- the only nav carrying all three
+    # type anchors (A4 makes the top "Feeds" tab + the breadcrumb also carry ?type, so
+    # a bare href match is not unique; scope to the sub-tab <ul>).
+    nav = _subtab_nav(page)
+    expect(nav).to_have_count(1, timeout=JS_TIMEOUT_MS)
     for t in ("ipv4", "ipv6", "dnsbl"):
-        expect(_subtab_anchor(page, t)).to_have_count(1, timeout=JS_TIMEOUT_MS)
+        expect(_subtab_anchor(nav, t)).to_have_count(1, timeout=JS_TIMEOUT_MS)
 
     # The requested type's sub-tab is ACTIVE; the other two are not. pfSense's
     # display_top_tabs puts the `active` class on the highlighted tab's <li> (the
     # anchor's parent). Assert via the ancestor <li>'s class -- the version-tolerant
-    # handle (the <li> wraps the <a>).
-    active_li = _subtab_anchor(page, gtype).locator("xpath=ancestor::li[1]")
+    # handle (the <li> wraps the <a>) -- scoped to the sub-tab row so the A4 self-links
+    # in the top bar/breadcrumb don't confuse the match.
+    active_li = _subtab_anchor(nav, gtype).locator("xpath=ancestor::li[1]")
     expect(active_li).to_have_class(re.compile(r"\bactive\b"), timeout=JS_TIMEOUT_MS)
     for other in (t for t in ("ipv4", "ipv6", "dnsbl") if t != gtype):
-        other_li = _subtab_anchor(page, other).locator("xpath=ancestor::li[1]")
+        other_li = _subtab_anchor(nav, other).locator("xpath=ancestor::li[1]")
         expect(other_li).not_to_have_class(re.compile(r"\bactive\b"), timeout=JS_TIMEOUT_MS)
 
     # The body lists ONLY this type: its Feed Settings alias-name label is in the DOM

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -1,0 +1,154 @@
+"""Tier-B browser test (ADR-16 Phase 5): the Feeds IPv4/IPv6/DNSBL sub-tabs.
+
+The visual replacement for the OLD maintainer manual smoke (ADR-16 §7): instead of
+a human eyeballing the split Feeds page, a headless Chromium on the live ADR-04
+smoke VM opens ``pfblockerng_feeds.php?type=ipv4|ipv6|dnsbl`` (reusing the Phase-1
+authenticated session — the injected ``PHPSESSID`` cookie, no second login) and
+asserts, per type:
+
+* the SECOND sub-tab row ``[IPv4 | IPv6 | DNSBL]`` is present (all three sub-tab
+  anchors, pointing at ``pfblockerng_feeds.php?type=...``), and
+* the requested type's sub-tab is the ACTIVE one (its ``<li>`` carries pfSense's
+  ``active`` class — emitted by ``display_top_tabs`` for the highlighted tab), and
+* the page lists ONLY that type's feeds — proven by the type-scoped Feed Settings
+  alias-name label (``IPv4/IPv6/DNSBL Alias name(s):``), which ``pfblockerng_feeds.php``
+  renders for the ACTIVE type only (``pfb_feeds_render_aliasname_inputs($gtype)``,
+  Phase 3) — so the other two types' labels are ABSENT from this tab's DOM, and
+
+a per-tab full-page screenshot is written to the ``screenshot_dir`` artifact tree
+(the visual record for review — an artifact, not an asserted baseline).
+
+The split is the only ``src/`` change in ADR-16 (Phase 3); this test is the
+``ui_browser`` half of its affected-flow coverage (the Tier-A render oracle —
+``test_render_smoke.py`` ``feeds_ipv4``/``feeds_ipv6``/``feeds_dnsbl`` — is the
+cheap/hermetic half). No ``src/`` change here.
+
+DOM-FRAGILITY NOTE: ``display_top_tabs`` renders pfSense's standard ``nav-pills``
+list; the load-bearing, version-tolerant handles are the anchor ``href`` (carries
+``?type=``) and the ``active`` class on the highlighted ``<li>`` — NOT a brittle
+DOM path. The Feed Settings section is ``COLLAPSIBLE|SEC_CLOSED`` (collapsed on
+load), so its alias-name label is in the DOM but not visible — we assert DOM
+PRESENCE (``count()``), not visibility, for the per-type label.
+
+NO fixed sleeps: every assertion uses Playwright auto-waiting / ``count()`` after
+``networkidle``. Playwright is imported lazily via ``pytest.importorskip`` so
+collecting this module without it installed does not hard-error.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
+expect = sync_api.expect
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_browser
+
+# The Feeds page, split into ?type sub-tabs (ADR-16 Phase 3). The base path the three
+# sub-tab anchors all point at (with a distinct ?type query each).
+FEEDS_BASE = "/pfblockerng/pfblockerng_feeds.php"
+
+# The three sub-tab types + the per-type Feed Settings alias-name label that renders
+# for the ACTIVE type only (the type-scoped body) -- the "lists only its type" signal.
+TYPE_LABELS = {
+    "ipv4": "IPv4 Alias name(s):",
+    "ipv6": "IPv6 Alias name(s):",
+    "dnsbl": "DNSBL Alias name(s):",
+}
+
+# A short, explicit timeout (ms): the page renders server-side, so this is a flake
+# ceiling for the post-load DOM, not a wait knob.
+JS_TIMEOUT_MS = 10_000
+
+
+def _open(page: Page, webui: WebUI, path: str) -> None:
+    """Navigate the (cookie-authenticated) page to ``path`` and settle the DOM.
+
+    Asserts the load did NOT bounce to the login form -- proving the injected
+    session cookie authenticated the browser (no second login). Waits on
+    ``networkidle`` so the page is fully rendered before any assertion.
+    """
+    page.goto(webui.url(path), wait_until="domcontentloaded", timeout=JS_TIMEOUT_MS * 3)
+    page.wait_for_load_state("networkidle", timeout=JS_TIMEOUT_MS * 3)
+    # The login form carries #usernamefld; its absence proves we are authed.
+    assert page.locator("#usernamefld").count() == 0, f"GET {path} showed the login form -- cookie not authenticated"
+
+
+def _shot(page: Page, screenshot_dir: Path, name: str) -> None:
+    """Write a full-page screenshot artifact ``<screenshot_dir>/<name>.png``."""
+    page.screenshot(path=str(screenshot_dir / f"{name}.png"), full_page=True)
+
+
+def _subtab_anchor(page: Page, gtype: str):  # type: ignore[no-untyped-def]
+    """The sub-tab row anchor whose href targets ``?type=<gtype>``.
+
+    Matched by href (``pfblockerng_feeds.php?type=<gtype>``) -- the version-tolerant
+    handle for a ``display_top_tabs`` tab, independent of the surrounding markup.
+    """
+    return page.locator(f'a[href*="pfblockerng_feeds.php?type={gtype}"]')
+
+
+@pytest.mark.parametrize("gtype", ["ipv4", "ipv6", "dnsbl"])
+def test_feeds_subtab_row_active_and_type_scoped(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+    gtype: str,
+) -> None:
+    """Each ``?type`` Feeds tab shows the [IPv4|IPv6|DNSBL] row, highlights itself,
+    and lists ONLY its own type.
+
+    Scenario (one parametrization per type -- all three sub-tabs are exercised, so
+    this is full branch coverage of the ``?type`` switch, not just one tab):
+
+    Given the Feeds page opened at ``?type=<gtype>``,
+    Then all THREE sub-tab anchors (``?type=ipv4|ipv6|dnsbl``) are present (the second
+      ``[IPv4 | IPv6 | DNSBL]`` row rendered),
+    And the requested type's sub-tab is the ACTIVE one (its ``<li>`` carries the
+      ``active`` class ``display_top_tabs`` puts on the highlighted tab) while the
+      other two are NOT active -- so the highlight tracks ``?type`` (a real branch,
+      not an always-active tab),
+    And the page's Feed Settings shows the ``<gtype>`` alias-name label and NEITHER of
+      the other two types' labels -- proving the body lists only the active type
+      (the type-scoped render, ADR-16 Phase 3).
+    A per-tab screenshot is written for the visual record (the manual-smoke replacement).
+    """
+    page = browser_page
+    _open(page, webui, f"{FEEDS_BASE}?type={gtype}")
+
+    # The second sub-tab row exists: all three anchors are present.
+    for t in ("ipv4", "ipv6", "dnsbl"):
+        expect(_subtab_anchor(page, t)).to_have_count(1, timeout=JS_TIMEOUT_MS)
+
+    # The requested type's sub-tab is ACTIVE; the other two are not. pfSense's
+    # display_top_tabs puts the `active` class on the highlighted tab's <li> (the
+    # anchor's parent). Assert via the ancestor <li>'s class -- the version-tolerant
+    # handle (the <li> wraps the <a>).
+    active_li = _subtab_anchor(page, gtype).locator("xpath=ancestor::li[1]")
+    expect(active_li).to_have_class(re.compile(r"\bactive\b"), timeout=JS_TIMEOUT_MS)
+    for other in (t for t in ("ipv4", "ipv6", "dnsbl") if t != gtype):
+        other_li = _subtab_anchor(page, other).locator("xpath=ancestor::li[1]")
+        expect(other_li).not_to_have_class(re.compile(r"\bactive\b"), timeout=JS_TIMEOUT_MS)
+
+    # The body lists ONLY this type: its Feed Settings alias-name label is in the DOM
+    # (the section is COLLAPSIBLE|SEC_CLOSED, so present-but-collapsed -> assert
+    # PRESENCE, not visibility), and the other two types' labels are ABSENT.
+    own_label = page.get_by_text(TYPE_LABELS[gtype], exact=False)
+    assert own_label.count() >= 1, f"{gtype} tab missing its own '{TYPE_LABELS[gtype]}' label (type-scoped body)"
+    for other, label in TYPE_LABELS.items():
+        if other == gtype:
+            continue
+        assert page.get_by_text(label, exact=False).count() == 0, (
+            f"{gtype} tab wrongly shows the {other} label '{label}' -- the body is not type-scoped"
+        )
+
+    _shot(page, screenshot_dir, f"feeds_subtab_{gtype}")

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -66,7 +66,9 @@ UPDATE_PAGE = "/pfblockerng/pfblockerng_update.php"
 # The Sync page hosts the `.repeatable` XMLRPC Replication Targets rowhelper.
 SYNC_PAGE = "/pfblockerng/pfblockerng_sync.php"
 # The Feeds page hosts the per-feed Alternate-URL radio group (auto-submit wiring).
-FEEDS_PAGE = "/pfblockerng/pfblockerng_feeds.php"
+# Split into ?type sub-tabs (ADR-16 Phase 3); the IPv4 tab carries the bulk of the
+# pre-defined feeds (and so any Alternate-URL radios), so the alt-URL flow targets it.
+FEEDS_PAGE = "/pfblockerng/pfblockerng_feeds.php?type=ipv4"
 
 # A short, explicit timeout (ms) for the JS-driven DOM transitions: the handlers
 # fire synchronously on load/click, so this is a flake ceiling, not a wait knob.

--- a/tests/smoke/ui/test_feeds.py
+++ b/tests/smoke/ui/test_feeds.py
@@ -49,12 +49,19 @@ keep green): the IPv4 alias ``PRI1`` (field ``feed_pri1``), the IPv6 alias ``PRI
 (field ``feed_pri1_6``), and the DNSBL group ``ADs`` (field ``feed_ads``). All three
 are written to ``installedpackages/pfblockerngglobal/feed_<lower(aliasname)>``.
 
-These tests pin TODAY's behaviour on the CURRENT single all-types Feeds page (the
-save loops EVERY type, and :meth:`WebUI.post` re-scrapes and re-POSTs every other
-``feed_*`` field at its present value, so a one-field override here does NOT clobber
-the others). They are the oracle; they must NOT pre-encode the Phase-3 sub-tab split.
-The cross-type non-clobber case (which only becomes possible once a partial,
-single-type POST exists) is added beside these in Phase 3.
+ADR-16 Phase 3 -- the split + type-scoped save. ``pfblockerng_feeds.php`` is now three
+``?type=ipv4|ipv6|dnsbl`` sub-tabs: only the active type renders, and the save loops
+ONLY ``$pfb['feeds_list'][$type]`` (the active type, carried in a hidden ``type`` form
+field). The per-type rename oracles below are retargeted to the typed URL of the type
+they pin (IPv4 -> ``?type=ipv4``, IPv6 -> ``?type=ipv6``, DNSBL -> ``?type=dnsbl``); the
+type-scoped save must keep them green. :meth:`WebUI.post` re-scrapes the typed page, so
+it re-POSTs only that type's fields plus the hidden ``type`` -- a partial, single-type
+POST, which is what makes the cross-type non-clobber test below possible.
+
+``test_feed_rename_cross_type_save_does_not_clobber`` is the headline contract guarantee
+(ADR §2 A3): saving the IPv4 tab leaves a DNSBL rename intact, and saving the DNSBL tab
+leaves an IPv4 rename intact -- proven a real transition in BOTH directions (seed both,
+assert both present, POST one type, assert the OTHER unchanged; and vice-versa).
 
 Save-handler quirk pinned here: the >24-char "Alternate Aliasname" length guard is
 skipped for DNSBL aliases (``!in_array(..., $feeds_list['dnsbl'])``), so the DNSBL
@@ -76,7 +83,13 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.ui_e2e
 
+# The Feeds page is split into ?type sub-tabs (ADR-16 Phase 3); each rename oracle posts
+# to the typed URL of the type it pins, so the page renders that type's fields and the
+# save is scoped to it.
 FEEDS_PAGE = "/pfblockerng/pfblockerng_feeds.php"
+FEEDS_PAGE_IPV4 = f"{FEEDS_PAGE}?type=ipv4"
+FEEDS_PAGE_IPV6 = f"{FEEDS_PAGE}?type=ipv6"
+FEEDS_PAGE_DNSBL = f"{FEEDS_PAGE}?type=dnsbl"
 
 # A pre-defined IPv4 alias shipped in pfblockerng_feeds.json. The page renders its
 # rename input as feed_<lower(aliasname)>, and the save writes the override to
@@ -147,8 +160,8 @@ def test_feed_rename_save_changes_effective_config(webui: WebUI, smoke_vm: helpe
             f"{RENAME_CFG} is not empty before the rename POST (expected the default-name state)"
         )
 
-        # RENAME via the real CSRF form; the page must persist the override.
-        resp = webui.post(FEEDS_PAGE, {RENAME_FIELD: RENAME_VALID}, timeout=120.0)
+        # RENAME via the real CSRF form (IPv4 tab); the page must persist the override.
+        resp = webui.post(FEEDS_PAGE_IPV4, {RENAME_FIELD: RENAME_VALID}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "Feeds rename POST returned the login form (session lost)"
         assert helpers.config_get(vm, RENAME_CFG) == RENAME_VALID, (
             f"{RENAME_CFG} did not become {RENAME_VALID!r} after the rename POST (oracle: config.xml, not HTTP body)"
@@ -156,7 +169,7 @@ def test_feed_rename_save_changes_effective_config(webui: WebUI, smoke_vm: helpe
 
         # RESTORE via the form: clear the override (empty value is accepted and
         # writes the default-name state back) -- proves the reverse transition.
-        resp = webui.post(FEEDS_PAGE, {RENAME_FIELD: ""}, timeout=120.0)
+        resp = webui.post(FEEDS_PAGE_IPV4, {RENAME_FIELD: ""}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "Feeds rename-restore POST returned the login form"
         assert helpers.config_get(vm, RENAME_CFG) == "", (
             f"{RENAME_CFG} did not return to the default-name state after clearing the override"
@@ -182,7 +195,7 @@ def test_feed_rename_invalid_alias_is_rejected_config_unchanged(webui: WebUI, sm
     seeded = "PRI1seed"
     # Seed a known, valid override via the form so there is a concrete before-value
     # that a (wrongly) accepted bad POST would overwrite.
-    resp = webui.post(FEEDS_PAGE, {RENAME_FIELD: seeded}, timeout=120.0)
+    resp = webui.post(FEEDS_PAGE_IPV4, {RENAME_FIELD: seeded}, timeout=120.0)
     assert not looks_like_login_page(resp.text), "Feeds seed POST returned the login form (session lost)"
     try:
         # BEFORE: the seeded override is in effect.
@@ -191,7 +204,7 @@ def test_feed_rename_invalid_alias_is_rejected_config_unchanged(webui: WebUI, sm
         )
 
         # REJECT: a space makes the alias invalid -> the save aborts with no write.
-        resp = webui.post(FEEDS_PAGE, {RENAME_FIELD: RENAME_INVALID}, timeout=120.0)
+        resp = webui.post(FEEDS_PAGE_IPV4, {RENAME_FIELD: RENAME_INVALID}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "Feeds invalid-alias POST returned the login form"
 
         # AFTER: config.xml is UNCHANGED -- the invalid POST wrote nothing.
@@ -223,8 +236,8 @@ def test_feed_rename_ipv6_save_changes_effective_config(webui: WebUI, smoke_vm: 
             f"{RENAME6_CFG} is not empty before the rename POST (expected the default-name state)"
         )
 
-        # RENAME via the real CSRF form; the page must persist the override.
-        resp = webui.post(FEEDS_PAGE, {RENAME6_FIELD: RENAME6_VALID}, timeout=120.0)
+        # RENAME via the real CSRF form (IPv6 tab); the page must persist the override.
+        resp = webui.post(FEEDS_PAGE_IPV6, {RENAME6_FIELD: RENAME6_VALID}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "IPv6 rename POST returned the login form (session lost)"
         assert helpers.config_get(vm, RENAME6_CFG) == RENAME6_VALID, (
             f"{RENAME6_CFG} did not become {RENAME6_VALID!r} after the rename POST (oracle: config.xml, not HTTP body)"
@@ -232,7 +245,7 @@ def test_feed_rename_ipv6_save_changes_effective_config(webui: WebUI, smoke_vm: 
 
         # RESTORE via the form: clearing the override writes the default-name state
         # back -- proves the reverse transition.
-        resp = webui.post(FEEDS_PAGE, {RENAME6_FIELD: ""}, timeout=120.0)
+        resp = webui.post(FEEDS_PAGE_IPV6, {RENAME6_FIELD: ""}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "IPv6 rename-restore POST returned the login form"
         assert helpers.config_get(vm, RENAME6_CFG) == "", (
             f"{RENAME6_CFG} did not return to the default-name state after clearing the override"
@@ -261,8 +274,8 @@ def test_feed_rename_dnsbl_save_changes_effective_config(webui: WebUI, smoke_vm:
             f"{DNSBL_RENAME_CFG} is not empty before the rename POST (expected the default-name state)"
         )
 
-        # RENAME via the real CSRF form; the page must persist the override.
-        resp = webui.post(FEEDS_PAGE, {DNSBL_RENAME_FIELD: DNSBL_RENAME_VALID}, timeout=120.0)
+        # RENAME via the real CSRF form (DNSBL tab); the page must persist the override.
+        resp = webui.post(FEEDS_PAGE_DNSBL, {DNSBL_RENAME_FIELD: DNSBL_RENAME_VALID}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "DNSBL rename POST returned the login form (session lost)"
         assert helpers.config_get(vm, DNSBL_RENAME_CFG) == DNSBL_RENAME_VALID, (
             f"{DNSBL_RENAME_CFG} did not become {DNSBL_RENAME_VALID!r} after the rename POST "
@@ -271,7 +284,7 @@ def test_feed_rename_dnsbl_save_changes_effective_config(webui: WebUI, smoke_vm:
 
         # RESTORE via the form: clearing the override writes the default-name state
         # back -- proves the reverse transition.
-        resp = webui.post(FEEDS_PAGE, {DNSBL_RENAME_FIELD: ""}, timeout=120.0)
+        resp = webui.post(FEEDS_PAGE_DNSBL, {DNSBL_RENAME_FIELD: ""}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "DNSBL rename-restore POST returned the login form"
         assert helpers.config_get(vm, DNSBL_RENAME_CFG) == "", (
             f"{DNSBL_RENAME_CFG} did not return to the default-name state after clearing the override"
@@ -296,7 +309,7 @@ def test_feed_rename_dnsbl_invalid_alias_is_rejected_config_unchanged(webui: Web
     seeded = "ADsSeed"
     # Seed a known, valid override via the form so there is a concrete before-value
     # that a (wrongly) accepted bad POST would overwrite.
-    resp = webui.post(FEEDS_PAGE, {DNSBL_RENAME_FIELD: seeded}, timeout=120.0)
+    resp = webui.post(FEEDS_PAGE_DNSBL, {DNSBL_RENAME_FIELD: seeded}, timeout=120.0)
     assert not looks_like_login_page(resp.text), "DNSBL seed POST returned the login form (session lost)"
     try:
         # BEFORE: the seeded override is in effect.
@@ -305,7 +318,7 @@ def test_feed_rename_dnsbl_invalid_alias_is_rejected_config_unchanged(webui: Web
         )
 
         # REJECT: a space makes the alias invalid -> the save aborts with no write.
-        resp = webui.post(FEEDS_PAGE, {DNSBL_RENAME_FIELD: DNSBL_RENAME_INVALID}, timeout=120.0)
+        resp = webui.post(FEEDS_PAGE_DNSBL, {DNSBL_RENAME_FIELD: DNSBL_RENAME_INVALID}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "DNSBL invalid-alias POST returned the login form"
 
         # AFTER: config.xml is UNCHANGED -- the invalid POST wrote nothing.
@@ -314,4 +327,81 @@ def test_feed_rename_dnsbl_invalid_alias_is_rejected_config_unchanged(webui: Web
             f"the handler should abort write_config when an alias contains a non-word char"
         )
     finally:
+        _config_del(vm, DNSBL_RENAME_CFG)
+
+
+def test_feed_rename_cross_type_save_does_not_clobber(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Saving one type's Feeds tab leaves the OTHER types' renames UNCHANGED (ADR-16 A3).
+
+    Scenario (the headline contract guarantee of the split): the page is three
+    ``?type`` sub-tabs and the save is type-scoped -- it loops only
+    ``$pfb['feeds_list'][$type]`` (the active type, carried in the hidden ``type``
+    field). A per-type tab therefore POSTs only its own ``feed_*`` fields, and the
+    handler must NOT reset any other type's ``feed_<alias>`` node to ''.
+
+    Background: on the OLD single all-types page the save looped EVERY type and wrote
+    each absent field as '' -- a partial single-type POST there would have clobbered
+    the other types. That regression is exactly what this test forbids.
+
+    True transition in BOTH directions (CLAUDE.md): seed an IPv4 rename AND a DNSBL
+    rename and assert BOTH are present (the before-state). Then:
+      * POST the IPv4 tab changing ONLY the IPv4 field  -> assert the DNSBL rename is
+        STILL its seeded value (IPv4 save did not touch DNSBL).
+      * POST the DNSBL tab changing ONLY the DNSBL field -> assert the IPv4 rename is
+        STILL its (new) value (DNSBL save did not touch IPv4).
+    Asserting the before-state first proves a green is the non-clobber guarantee, not
+    a value that happened to already hold. Both overrides are dropped in ``finally``.
+    Oracle is config.xml read over SSH, never the POST response body.
+    """
+    vm = smoke_vm
+    ipv4_seed = "PRI1cross"
+    ipv4_new = "PRI1cross2"
+    dnsbl_seed = "ADsCross"
+    dnsbl_new = "ADsCross2"
+
+    # Known baseline: drop any stray override on both nodes.
+    _config_del(vm, RENAME_CFG)
+    _config_del(vm, DNSBL_RENAME_CFG)
+    try:
+        # GIVEN: seed an IPv4 rename (on the IPv4 tab) and a DNSBL rename (on the
+        # DNSBL tab); each save is scoped to its own type.
+        resp = webui.post(FEEDS_PAGE_IPV4, {RENAME_FIELD: ipv4_seed}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "IPv4 seed POST returned the login form (session lost)"
+        resp = webui.post(FEEDS_PAGE_DNSBL, {DNSBL_RENAME_FIELD: dnsbl_seed}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "DNSBL seed POST returned the login form (session lost)"
+
+        # BEFORE: BOTH renames are present (the cross-type starting state).
+        assert helpers.config_get(vm, RENAME_CFG) == ipv4_seed, (
+            f"{RENAME_CFG} was not seeded to {ipv4_seed!r} before the cross-type POSTs"
+        )
+        assert helpers.config_get(vm, DNSBL_RENAME_CFG) == dnsbl_seed, (
+            f"{DNSBL_RENAME_CFG} was not seeded to {dnsbl_seed!r} before the cross-type POSTs"
+        )
+
+        # WHEN: POST the IPv4 tab changing ONLY the IPv4 field.
+        resp = webui.post(FEEDS_PAGE_IPV4, {RENAME_FIELD: ipv4_new}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "IPv4 cross-type POST returned the login form"
+        # THEN: the IPv4 node took the new value AND the DNSBL node is UNCHANGED
+        # (the IPv4 tab's POST carries no DNSBL field, and the save is type-scoped).
+        assert helpers.config_get(vm, RENAME_CFG) == ipv4_new, (
+            f"{RENAME_CFG} did not become {ipv4_new!r} after the IPv4 tab POST"
+        )
+        assert helpers.config_get(vm, DNSBL_RENAME_CFG) == dnsbl_seed, (
+            f"{DNSBL_RENAME_CFG} was CLOBBERED by an IPv4-tab save (it must stay {dnsbl_seed!r}); "
+            f"the type-scoped save must not touch another type's feed_<alias> nodes"
+        )
+
+        # WHEN: POST the DNSBL tab changing ONLY the DNSBL field.
+        resp = webui.post(FEEDS_PAGE_DNSBL, {DNSBL_RENAME_FIELD: dnsbl_new}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "DNSBL cross-type POST returned the login form"
+        # THEN: the DNSBL node took the new value AND the IPv4 node is UNCHANGED.
+        assert helpers.config_get(vm, DNSBL_RENAME_CFG) == dnsbl_new, (
+            f"{DNSBL_RENAME_CFG} did not become {dnsbl_new!r} after the DNSBL tab POST"
+        )
+        assert helpers.config_get(vm, RENAME_CFG) == ipv4_new, (
+            f"{RENAME_CFG} was CLOBBERED by a DNSBL-tab save (it must stay {ipv4_new!r}); "
+            f"the type-scoped save must not touch another type's feed_<alias> nodes"
+        )
+    finally:
+        _config_del(vm, RENAME_CFG)
         _config_del(vm, DNSBL_RENAME_CFG)

--- a/tests/smoke/ui/test_feeds.py
+++ b/tests/smoke/ui/test_feeds.py
@@ -42,9 +42,24 @@ RESTORES the box (asserting the reverse where it applies). Restore runs in a
 sibling flows. Branch coverage: the rename validator gets a VALID case (accepted,
 config changes) AND a REJECTING case (config stays unchanged).
 
-Target alias is a pre-defined entry shipped in ``pfblockerng_feeds.json`` and
-stable across the support matrix: the IPv4 alias ``PRI1`` (field ``feed_pri1``)
-for the rename flows.
+Target aliases are pre-defined entries shipped in ``pfblockerng_feeds.json`` and
+stable across the support matrix, one per type so EACH type's rename round-trip is
+pinned independently (ADR-16 Phase 2 -- the oracle the Phase-3 type-scoped save must
+keep green): the IPv4 alias ``PRI1`` (field ``feed_pri1``), the IPv6 alias ``PRI1_6``
+(field ``feed_pri1_6``), and the DNSBL group ``ADs`` (field ``feed_ads``). All three
+are written to ``installedpackages/pfblockerngglobal/feed_<lower(aliasname)>``.
+
+These tests pin TODAY's behaviour on the CURRENT single all-types Feeds page (the
+save loops EVERY type, and :meth:`WebUI.post` re-scrapes and re-POSTs every other
+``feed_*`` field at its present value, so a one-field override here does NOT clobber
+the others). They are the oracle; they must NOT pre-encode the Phase-3 sub-tab split.
+The cross-type non-clobber case (which only becomes possible once a partial,
+single-type POST exists) is added beside these in Phase 3.
+
+Save-handler quirk pinned here: the >24-char "Alternate Aliasname" length guard is
+skipped for DNSBL aliases (``!in_array(..., $feeds_list['dnsbl'])``), so the DNSBL
+reject branch is exercised via the ``preg_match "/\\W/"`` (non-word char) path, the
+same validator the IPv4/IPv6 fields use.
 """
 
 from __future__ import annotations
@@ -75,6 +90,25 @@ RENAME_VALID = "PRI1renamed"
 # A value containing a space -> preg_match "/\\W/" matches -> input error ->
 # the whole save aborts before write_config, so config.xml stays unchanged.
 RENAME_INVALID = "PRI1 bad"
+
+# A pre-defined IPv6 alias shipped in pfblockerng_feeds.json (the IPv6 Primary Tier
+# collection, the IPv6 sibling of PRI1). Rename round-trip via feed_<lower(aliasname)>.
+RENAME6_ALIAS = "PRI1_6"
+RENAME6_FIELD = "feed_pri1_6"
+RENAME6_CFG = "installedpackages/pfblockerngglobal/feed_pri1_6"
+# Word-only (<=24 chars, per the non-DNSBL length guard) -> accepted, stored verbatim.
+RENAME6_VALID = "PRI16renamed"
+
+# A pre-defined DNSBL group shipped in pfblockerng_feeds.json. Same rename mechanism;
+# the >24-char "Alternate Aliasname" length guard does NOT apply to DNSBL aliases.
+DNSBL_RENAME_ALIAS = "ADs"
+DNSBL_RENAME_FIELD = "feed_ads"
+DNSBL_RENAME_CFG = "installedpackages/pfblockerngglobal/feed_ads"
+# Word-only value -> accepted and stored verbatim (no length cap for DNSBL).
+DNSBL_RENAME_VALID = "ADsRenamed"
+# A value containing a space -> preg_match "/\\W/" matches -> input error -> the whole
+# save aborts before write_config; pins the reject branch for the DNSBL field too.
+DNSBL_RENAME_INVALID = "ADs bad"
 
 
 def _config_del(vm: helpers.SmokeVM, path: str, *, timeout: float = 60.0) -> None:
@@ -167,3 +201,117 @@ def test_feed_rename_invalid_alias_is_rejected_config_unchanged(webui: WebUI, sm
         )
     finally:
         _config_del(vm, RENAME_CFG)
+
+
+def test_feed_rename_ipv6_save_changes_effective_config(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """An IPv6 group rename in the current Feeds form persists feed_<alias>, both ways.
+
+    ADR-16 Phase 2 oracle: pins the per-type save for the IPv6 type on the CURRENT
+    single all-types page, so Phase 3's type-scoped save (the IPv6 sub-tab POSTing
+    only its own fields) must keep this green. True transition (CLAUDE.md): the
+    PRI1_6 override starts empty (default-name state), the form POST sets it to a
+    word-only name and config.xml holds that name, then a second POST clears it back
+    to empty and config.xml returns to the default-name state. Oracle is config.xml
+    read over SSH, never the POST response body.
+    """
+    vm = smoke_vm
+    # Known baseline: no rename override for PRI1_6 (the default-name state).
+    _config_del(vm, RENAME6_CFG)
+    try:
+        # BEFORE: the override is empty (default name in effect).
+        assert helpers.config_get(vm, RENAME6_CFG) == "", (
+            f"{RENAME6_CFG} is not empty before the rename POST (expected the default-name state)"
+        )
+
+        # RENAME via the real CSRF form; the page must persist the override.
+        resp = webui.post(FEEDS_PAGE, {RENAME6_FIELD: RENAME6_VALID}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "IPv6 rename POST returned the login form (session lost)"
+        assert helpers.config_get(vm, RENAME6_CFG) == RENAME6_VALID, (
+            f"{RENAME6_CFG} did not become {RENAME6_VALID!r} after the rename POST (oracle: config.xml, not HTTP body)"
+        )
+
+        # RESTORE via the form: clearing the override writes the default-name state
+        # back -- proves the reverse transition.
+        resp = webui.post(FEEDS_PAGE, {RENAME6_FIELD: ""}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "IPv6 rename-restore POST returned the login form"
+        assert helpers.config_get(vm, RENAME6_CFG) == "", (
+            f"{RENAME6_CFG} did not return to the default-name state after clearing the override"
+        )
+    finally:
+        _config_del(vm, RENAME6_CFG)
+
+
+def test_feed_rename_dnsbl_save_changes_effective_config(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A DNSBL group rename in the current Feeds form persists feed_<alias>, both ways.
+
+    ADR-16 Phase 2 oracle: pins the per-type save for the DNSBL type on the CURRENT
+    single all-types page, so Phase 3's type-scoped save (the DNSBL sub-tab POSTing
+    only its own fields) must keep this green. True transition (CLAUDE.md): the ADs
+    override starts empty (default-name state), the form POST sets it to a word-only
+    name and config.xml holds that name, then a second POST clears it back to empty
+    and config.xml returns to the default-name state. Oracle is config.xml read over
+    SSH, never the POST response body.
+    """
+    vm = smoke_vm
+    # Known baseline: no rename override for ADs (the default-name state).
+    _config_del(vm, DNSBL_RENAME_CFG)
+    try:
+        # BEFORE: the override is empty (default name in effect).
+        assert helpers.config_get(vm, DNSBL_RENAME_CFG) == "", (
+            f"{DNSBL_RENAME_CFG} is not empty before the rename POST (expected the default-name state)"
+        )
+
+        # RENAME via the real CSRF form; the page must persist the override.
+        resp = webui.post(FEEDS_PAGE, {DNSBL_RENAME_FIELD: DNSBL_RENAME_VALID}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "DNSBL rename POST returned the login form (session lost)"
+        assert helpers.config_get(vm, DNSBL_RENAME_CFG) == DNSBL_RENAME_VALID, (
+            f"{DNSBL_RENAME_CFG} did not become {DNSBL_RENAME_VALID!r} after the rename POST "
+            f"(oracle: config.xml, not HTTP body)"
+        )
+
+        # RESTORE via the form: clearing the override writes the default-name state
+        # back -- proves the reverse transition.
+        resp = webui.post(FEEDS_PAGE, {DNSBL_RENAME_FIELD: ""}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "DNSBL rename-restore POST returned the login form"
+        assert helpers.config_get(vm, DNSBL_RENAME_CFG) == "", (
+            f"{DNSBL_RENAME_CFG} did not return to the default-name state after clearing the override"
+        )
+    finally:
+        _config_del(vm, DNSBL_RENAME_CFG)
+
+
+def test_feed_rename_dnsbl_invalid_alias_is_rejected_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """An invalid DNSBL alias name is rejected and config.xml stays UNCHANGED.
+
+    Branch coverage for the DNSBL field, paired with the valid DNSBL case: a value
+    containing a space hits ``preg_match "/\\W/"`` -> ``$input_errors`` -> the save
+    aborts before ``write_config`` (a single bad field blocks the whole save). The
+    transition rule still applies: the test seeds a KNOWN valid override first and
+    asserts it, drives the rejecting POST, then asserts the override is STILL the
+    seeded value -- so the green proves the bad POST did NOT mutate config (not that
+    it merely happened to already hold the expected value). This pins the reject
+    branch for the DNSBL type, where the >24-char length guard does not apply.
+    """
+    vm = smoke_vm
+    seeded = "ADsSeed"
+    # Seed a known, valid override via the form so there is a concrete before-value
+    # that a (wrongly) accepted bad POST would overwrite.
+    resp = webui.post(FEEDS_PAGE, {DNSBL_RENAME_FIELD: seeded}, timeout=120.0)
+    assert not looks_like_login_page(resp.text), "DNSBL seed POST returned the login form (session lost)"
+    try:
+        # BEFORE: the seeded override is in effect.
+        assert helpers.config_get(vm, DNSBL_RENAME_CFG) == seeded, (
+            f"{DNSBL_RENAME_CFG} was not seeded to {seeded!r} before the reject POST"
+        )
+
+        # REJECT: a space makes the alias invalid -> the save aborts with no write.
+        resp = webui.post(FEEDS_PAGE, {DNSBL_RENAME_FIELD: DNSBL_RENAME_INVALID}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "DNSBL invalid-alias POST returned the login form"
+
+        # AFTER: config.xml is UNCHANGED -- the invalid POST wrote nothing.
+        assert helpers.config_get(vm, DNSBL_RENAME_CFG) == seeded, (
+            f"{DNSBL_RENAME_CFG} changed after a rejected invalid-alias POST (it must stay {seeded!r}); "
+            f"the handler should abort write_config when an alias contains a non-word char"
+        )
+    finally:
+        _config_del(vm, DNSBL_RENAME_CFG)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -67,7 +67,26 @@ PAGE_TABLE: tuple[Page, ...] = (
     Page("general", "/pfblockerng/pfblockerng_general.php", ("pfBlockerNG", "General Settings")),
     Page("ip", "/pfblockerng/pfblockerng_ip.php", ("IP Configuration", "ASN configuration")),
     Page("dnsbl", "/pfblockerng/pfblockerng_dnsbl.php", ("DNSBL Webserver Configuration", "DNSBL Configuration")),
-    Page("feeds", "/pfblockerng/pfblockerng_feeds.php", ("Pre-defined Alias/Group/Feeds",)),
+    # feeds.php is split into IPv4/IPv6/DNSBL ?type sub-tabs (ADR-16 Phase 3). Each type
+    # is probed; the type-specific marker is the active type's "Feed Settings" alias-name
+    # StaticText label ("IPv4 Alias name(s):" etc.), which renders ONLY for the active
+    # type -- so it distinguishes the three views (the panel title is shared by all). The
+    # coverage guard strips "?", so all three collapse to the one base path.
+    Page(
+        "feeds_ipv4",
+        "/pfblockerng/pfblockerng_feeds.php?type=ipv4",
+        ("Pre-defined Alias/Group/Feeds", "IPv4 Alias name(s):"),
+    ),
+    Page(
+        "feeds_ipv6",
+        "/pfblockerng/pfblockerng_feeds.php?type=ipv6",
+        ("Pre-defined Alias/Group/Feeds", "IPv6 Alias name(s):"),
+    ),
+    Page(
+        "feeds_dnsbl",
+        "/pfblockerng/pfblockerng_feeds.php?type=dnsbl",
+        ("Pre-defined Alias/Group/Feeds", "DNSBL Alias name(s):"),
+    ),
     Page("alerts", "/pfblockerng/pfblockerng_alerts.php", ("Alert Settings",)),
     Page("log", "/pfblockerng/pfblockerng_log.php", ("Log/File Browser selections",)),
     Page("sync", "/pfblockerng/pfblockerng_sync.php", ("XMLRPC Sync Settings",)),


### PR DESCRIPTION
## ADR-16: Feeds page IPv4/IPv6/DNSBL tabs + live mock-feed load smoke

Splits the Feeds page into **IPv4 / IPv6 / DNSBL sub-tabs** (`?type=`, default `ipv4`) —
mirroring the `pfblockerng_category.php` idiom (IP/DNSBL/Reports) — and **type-scopes the
save handler** so a tab only ever writes its own type's nodes. Then adds representative
sample feeds served by the existing `_MockFeedServer` and a live-VM smoke that loads them
over HTTP via Force Update, exercising the real curl feed-fetch path the suite has never
covered.

Full design + rationale: `.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke/ADR.md`.

### The load-bearing fix (Part A)

The old save looped **all** types and wrote `$_POST['feed_x'] ?: ''`, so a per-type tab
that POSTs only its own fields would reset every other type's rename to `''`. The split is
impossible without type-scoping the save: a hidden `type` field carries the active sub-tab,
validated into `$gtype`, and the rename loop is scoped to `$pfb['feeds_list'][$gtype]` only.
Saving one tab never touches another type's `feed_*` / `feed_alt_*` nodes. Pinned by a
cross-type non-clobber test (both directions).

### Phases (one commit each)

1. **`6760b22`** — PREP: extract per-type rendering helpers (behaviour-preserving; full
   all-types page renders identically).
2. **`e98cff6`** — PREP: pin the current per-type save semantics (DNSBL + IPv6 rename
   round-trip oracle) before the rewrite.
3. **`d904bb6`** — The split: `?type` sub-tabs + second sub-tab row + type-filtered body +
   **type-scoped save**; retarget the ADR-14 render/functional/browser tests to the typed
   URLs; **add the cross-type non-clobber `ui_e2e` test**. (Only `pfblockerng_feeds.php`
   changes in `src/`.) **Part A ships here.**
4. **`dc4528e`** — Representative inert sample feed fixtures (IP {plain/CIDR, range, IPv6} +
   DNSBL {plain, hosts, ABP}) under `tests/smoke/fixtures/`.
5. **`9543187`** — Live HTTP-feed load smoke (`test_smoke_feeds.py`, 6 cases) + a
   `ui_browser` Feeds-tabs render/screenshot test (`test_browser_feeds.py`).
6. **`9e78d2a`** — Docs (README/CLAUDE.md) + finalise ADR §7 + Status.

### Scope

- Exactly **one** shipped file changes: `src/usr/local/www/pfblockerng/pfblockerng_feeds.php`
  (the split + the type-scoped save). Field names, `Form_Section` ids, config keys, and the
  `alt_selected` mechanism are unchanged — only the save scope and the tab chrome change.
- The other ~12 pages are **not** edited — their bare `pfblockerng_feeds.php` links default
  to `ipv4` (A4). No parser / `.inc` / `.sh` / `pfb_unbound.py` change.

### Validation

- Local gates green: `python -m pytest` (1115, unchanged — the smoke tree is `--ignore`d in
  default collection), `ruff`, `php -l`, PHPStan, PHPUnit (153), mypy, markdownlint.
- **This PR carries `ui-tests`** so the blocking live-VM suite runs the affected-flow tests
  that gate Accept (no human manual-smoke gate):
  - `feeds_ipv4` / `feeds_ipv6` / `feeds_dnsbl` — per-type Tier-A render (`ui_render`).
  - `test_feed_rename_cross_type_save_does_not_clobber` — the non-clobber contract (`ui_e2e`).
  - `test_smoke_feeds.py` (6 cases) — HTTP feed load via Force Update (`smoke`); Part-C
    kill-gate is **optimistic-GO pending this CI evidence** (≥ 4/5 clean bar; < 4/5 ⇒
    fast-follow demote to dispatch-only, local-file load coverage already exists).
  - `test_browser_feeds.py` — the tabs render/screenshot test (`ui_browser`).

### Status

**Implemented (pending smoke test)** → flips to **Accepted** once the affected-flow UI tests
above are green on the live VM.

> Note: this PR is preceded on `devel` by a small standalone tooling fix
> (`1cd0ab6`, untrack two broken self-referential `.venv`/`vendor` symlinks) that is not part
> of ADR-16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feeds page split into IPv4, IPv6 and DNSBL sub‑tabs; actions (rename/save) now apply to the active tab and preserve other types.

* **Bug Fixes**
  * Prevented cross‑type rename/save clobbering so changes on one tab no longer overwrite others.

* **Tests**
  * Added live HTTP feed‑load smoke tests (IP plain/CIDR/range/IPv6 and DNSBL plain/hosts/ABP).
  * Added browser UI smoke tests for sub‑tab highlighting and type‑scoped content.

* **Documentation**
  * Expanded ADRs, README, fixture docs and test guidance describing tab behavior, fixtures and smoke‑test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->