### PR TITLE
ci: tighten ShellCheck to --severity=info (regression guard for the shell audit)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -129,7 +129,7 @@ fi
 if have shellcheck; then
 	step 'shellcheck'
 	find src scripts -name '*.sh' | sort \
-		| xargs shellcheck --severity=warning || failed 'shellcheck'
+		| xargs shellcheck --severity=info || failed 'shellcheck'
 else
 	skip shellcheck
 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,9 @@ jobs:
       - name: Run ShellCheck
         # .shellcheckrc in the repo root configures suppressions. Scoped to src+scripts;
         # tests/ shellspec specs trip SC2034 false-positives (separate cleanup).
-        run: find src scripts -name '*.sh' | sort | xargs shellcheck --severity=warning
+        # --severity=info also gates the unquoted-variable class (SC2086) so the
+        # quoting / word-splitting bugs the shell audit found cannot silently regress.
+        run: find src scripts -name '*.sh' | sort | xargs shellcheck --severity=info
 
       - name: Forbid naked $var in curl/wget/fetch URLs
         # Preventative: a query value jammed straight into a URL (`?ip=$VAR`) breaks

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -42,6 +42,10 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# Pure precondition tests; the || branch (usage + exit) is the intended else and
+# the && chain is side-effect-free, so SC2015's "C may run when A is true" caveat
+# does not apply here.
+# shellcheck disable=SC2015
 [ -n "$PORTS" ] && [ -n "$GH_TAGNAME" ] || {
     echo "Usage: $0 --ports <freebsd-ports> --gh-tagname <commit-sha> [--channel devel|stable] [--out <dir>]" >&2
     exit 2

--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -39,6 +39,8 @@ while [ $# -gt 0 ]; do
 done
 
 [ -n "$SSH_TARGET" ] || { echo "Usage: $0 <ssh-target> --pkg <file> [--port N] [--ssh-key PATH]" >&2; exit 1; }
+# Pure precondition tests; the || branch is the intended else (SC2015 N/A).
+# shellcheck disable=SC2015
 [ -n "$PKGFILE" ] && [ -f "$PKGFILE" ] || { echo "install-pkg: --pkg file not found: ${PKGFILE}" >&2; exit 1; }
 
 SSH_OPTS="-p ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"

--- a/scripts/setup-dev-shell.sh
+++ b/scripts/setup-dev-shell.sh
@@ -102,7 +102,11 @@ ensure_block() {
 log "wiring shell init files:"
 
 # zsh (every invocation) + login sh: just source the snippet.
+# The single quotes are intentional: this is literal shell text written verbatim
+# into the user's init files, NOT meant to expand here.
+# shellcheck disable=SC2016
 printf '%s\n' '[ -r "$HOME/.brew_path.sh" ] && . "$HOME/.brew_path.sh"' | ensure_block "$HOME/.zshenv"
+# shellcheck disable=SC2016
 printf '%s\n' '[ -r "$HOME/.brew_path.sh" ] && . "$HOME/.brew_path.sh"' | ensure_block "$HOME/.profile"
 
 # bash: re-exec an old interactive/login bash to Homebrew's, then source the snippet.


### PR DESCRIPTION
Part 3 of 3 from the shell-script audit — the regression safeguard.

> 🔗 **Merge order: this lands LAST.** It depends on **#126** (`pfblockerng.sh` quoting) and **#127** (AWS scripts) being on `devel`. Rebase this PR after both merge. **Until then the ShellCheck job here is expected red** on `pfblockerng.sh`'s pre-existing `SC2086` sites — those are fixed by #126, not by this PR.

## What & why

Raises the CI (`test.yml`) and `.githooks/pre-commit` ShellCheck gate on `src`+`scripts` from `--severity=warning` to **`--severity=info`**. The practical effect is that **`SC2086` (unquoted variable → word-splitting/globbing)** becomes a hard failure.

`SC2086` is the root class behind the audit findings — the AWS `jq | iprange` quoting fragility and the `reputation_max`/`dmax` `case` empty-pattern bug both live in unquoted-expansion territory. Gating it means that whole class can't silently come back. ShellCheck has no rule for the two specific logic bugs (the empty-`case`-pattern and `tail +2`), so those are guarded by the shellspec tests added in #126/#127; this PR locks down the surrounding quoting discipline.

## Keeping it green

The three intentional dev-script idioms get reasoned inline disables (not a global suppression):
- `build-pkg.sh`, `install-pkg.sh` — `SC2015` on the side-effect-free `A && B || { usage; exit }` preconditions (the `||` *is* the intended else; the `&&` chain is pure tests).
- `setup-dev-shell.sh` — `SC2016` on the deliberately **literal** single-quoted shell written verbatim into the user's init files (it must *not* expand at author time).

Verified: with #126 + #127 applied, `find src scripts -name '*.sh' | xargs shellcheck --severity=info` is **0 findings**. On this branch alone, the only remaining findings are `pfblockerng.sh`'s 29 `SC2086` sites that #126 resolves.

https://claude.ai/code/session_01KfaKTd724hVCiuHVZ57aDr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfaKTd724hVCiuHVZ57aDr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened shell script linting severity in CI and local hooks to enforce stricter checks.
  * Added clarifying comments and inline directives across build and setup scripts to improve lint compatibility and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->