### PR TITLE
smoke: run live-VM suites locally + in parallel (cross-platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,25 +671,70 @@ config (see `.ADRs/ADR_04_VM_Smoke_Tests/RESULTS/02_Results.txt`):
 (and, to match the baked image, `SMOKE_DNSBL_VIP4` / `SMOKE_CONTROL_NAME` /
 `SMOKE_CONTROL_IP`).
 
-### Running it locally
+### Running it locally (Linux, macOS, Windows — incl. in parallel)
 
-Needs `/dev/kvm`, `qemu-system-x86_64` + `qemu-img`, `oras`, `ssh`, and a built
-`.pkg`. Then:
+The suite runs on a developer machine — no GitHub runner needed. You need a
+built `.pkg`, the private pfSense qcow2, and the matching guest SSH key. The
+**accelerator is auto-detected** per host (override with `SMOKE_QEMU_ACCEL`):
+
+| Host | Accelerator | Speed |
+| --- | --- | --- |
+| Linux + `/dev/kvm` | `kvm` | fast |
+| macOS (Intel) | `hvf` | fast |
+| macOS (Apple Silicon) | `tcg` | **slow** — pfSense is amd64-only, so there is no x86 hardware virt on ARM and QEMU falls back to full emulation. Raise `SMOKE_BOOT_TIMEOUT` (e.g. `1800`). |
+| Windows | WSL2 → `kvm` (recommended) or native `whpx` | fast |
+
+Prerequisites: `qemu-system-x86_64` + `qemu-img`, `ssh`, the smoke Python deps
+(`pip install -r tests/smoke/requirements.txt`), and `oras` **only if** the
+fixture has to pull the image (skip it by pointing at a pre-pulled dir, below).
 
 ```sh
 python -m pip install -r tests/smoke/requirements.txt
-export SMOKE_IMAGE_REF=ghcr.io/<org>/pfsense-ce@sha256:<digest>   # private GHCR
-export SMOKE_SSH_KEY=/path/to/guest_priv_key                      # mode 600
-export SMOKE_PKG=/path/to/pfBlockerNG-*.pkg                       # from build-pkg
-oras login ghcr.io                                                # for the pull
+# Pull the image ONCE, then point every run at the pulled dir (no re-pull, and
+# safe to share read-only across parallel runs — the base qcow2 is never mutated):
+oras login ghcr.io
+oras pull ghcr.io/<org>/pfsense-ce@sha256:<digest> --output /tmp/pfb-image
+export SMOKE_IMAGE_DIR=/tmp/pfb-image          # one .qcow2 inside (or SMOKE_IMAGE_REF to pull)
+export SMOKE_SSH_KEY=/path/to/guest_priv_key   # mode 600
+export SMOKE_PKG=/path/to/pfBlockerNG-*.pkg    # from build-pkg
+export SMOKE_DNS_UPSTREAM=mock                 # ephemeral-port DNS upstream (see below)
+export SMOKE_BOOT_TIMEOUT=1800                 # only needed for tcg (Apple Silicon)
 python -m pytest tests/smoke -m smoke --override-ini="addopts="
 ```
 
-The fixture pulls the image by `SMOKE_IMAGE_REF` and boots an ephemeral overlay
-(the base qcow2 is never mutated). Missing KVM/secrets/deps → the suite **skips**
-cleanly, never errors. (CI sets `SMOKE_IMAGE_DIR` instead, pointing at the
-pre-pulled image, so the fixture blocks egress after `deploy()` without
-needing another network pull.)
+`SMOKE_DNS_UPSTREAM=mock` is the key local/parallel switch. The CI default
+(`system`) forwards System DNS to the mock on host `:53`, which needs root and
+binds a single host port; `mock` instead wires Unbound to forward the root zone
+to the mock on an **ephemeral** port via a custom forward-zone — no `sudo`, no
+`:53`, so concurrent runs never clash. Leave it unset to reproduce the CI path.
+
+**Web-UI tiers** (ADR-14) run the same way against the same VM — set
+`SMOKE_ADMIN_PASSWORD` and select the tier marker; the browser tier also needs
+`python -m playwright install chromium`:
+
+```sh
+export SMOKE_ADMIN_PASSWORD=<baked admin password>
+python -m pytest tests/smoke/ui -m ui_render  --override-ini="addopts="
+python -m pytest tests/smoke/ui -m ui_browser --override-ini="addopts="   # needs chromium
+```
+
+**Several at once (parallel):** just launch multiple invocations. Each session
+self-allocates its own ephemeral SSH/web/DNS host ports, its own copy-on-write
+overlay, and its own mock-feed/stub-DNS ports, so N runs on one host never
+collide — point them all at the same read-only `SMOKE_IMAGE_DIR`:
+
+```sh
+python -m pytest tests/smoke -m smoke --override-ini="addopts=" &
+python -m pytest tests/smoke/ui -m ui_render --override-ini="addopts=" &
+wait
+```
+
+A missing accelerator is **not** a skip — `tcg` always works (just slowly).
+Missing image/key/deps → the suite **skips** cleanly, never errors. On Windows,
+run inside **WSL2** (its nested KVM gives the Linux `kvm` path plus real Unix
+tooling for the POSIX-`sh` harness); native QEMU+WHPX works but then needs Git
+Bash/MSYS for `sh`. (CI keeps `SMOKE_DNS_UPSTREAM` unset and adds
+`SMOKE_BLOCK_EGRESS=1` for a hermetic run; a local run leaves egress alone.)
 
 ### Rebuilding the image on a CE bump
 

--- a/tests/smoke/boot_vm.sh
+++ b/tests/smoke/boot_vm.sh
@@ -1,17 +1,27 @@
 #!/bin/sh
-# boot_vm.sh — boot a hand-built pfSense CE qcow2 headless under QEMU/KVM
-# for the ADR-04 Phase-1 de-risking spike.
+# boot_vm.sh — boot a hand-built pfSense CE qcow2 headless under QEMU
+# for the ADR-04 live-VM smoke suite.
 #
 # Usage:
 #   tests/smoke/boot_vm.sh <base-image.qcow2> [overlay.qcow2]
 #
-# Boots the image headless with KVM acceleration and a QEMU user-net
-# (SLIRP) host-forward map so the runner can reach the guest:
-#   host 2222/tcp -> guest 22   (SSH)
-#   host 8080/tcp -> guest 80   (WebUI, HTTP)
-#   host 5353/tcp -> guest 53   (DNS, TCP)
-#   host 5353/udp -> guest 53   (DNS, UDP)
+# Boots the image headless with a hardware accelerator (auto-detected, see
+# below) and a QEMU user-net (SLIRP) host-forward map so the runner can reach
+# the guest. The forwarded host ports default to the historical fixed values
+# but are overridable via env so multiple VMs can run in PARALLEL on one host:
+#   host ${SMOKE_SSH_PORT:-2222}/tcp -> guest 22   (SSH)
+#   host ${SMOKE_WEB_PORT:-8080}/tcp -> guest 80   (WebUI, HTTP)
+#   host ${SMOKE_DNS_PORT:-5353}/tcp -> guest 53   (DNS, TCP)
+#   host ${SMOKE_DNS_PORT:-5353}/udp -> guest 53   (DNS, UDP)
 # The guest reaches the runner at the SLIRP host alias 10.0.2.2.
+#
+# Accelerator (cross-platform): SMOKE_QEMU_ACCEL overrides; otherwise it is
+# auto-detected per host — kvm (Linux + /dev/kvm), hvf (macOS, x86 guest only
+# on an Intel Mac), whpx (Windows), else tcg. pfSense ships amd64 ONLY, so an
+# arm64 host (Apple Silicon) has no hardware virt for the x86 guest and falls
+# back to tcg = full emulation: correct but slow (raise SMOKE_BOOT_TIMEOUT).
+# The CPU model pairs with the accel (-cpu host needs kvm/hvf; tcg/whpx use max);
+# SMOKE_QEMU_CPU overrides.
 #
 # Hardware MIRRORS the source Proxmox VM (qm showcmd 103 --pretty) so the
 # published qcow2 boots without pfSense re-detecting hardware and dropping
@@ -19,7 +29,7 @@
 #   - single virtio-net-pci NIC, MAC pinned to BC:24:11:37:9C:AC
 #     (the source VM's MAC; a MAC is not sensitive, so it is hardcoded)
 #   - VirtIO-SCSI disk (guest sees da0)
-#   - machine type pc (i440fx; Proxmox pc+pve0), -cpu host, 2 vCPU, 4 GB RAM
+#   - machine type pc (i440fx; Proxmox pc+pve0), 2 vCPU, 4 GB RAM
 #
 # The base image is NEVER mutated: an ephemeral copy-on-write overlay is
 # created over it and the guest writes only to the overlay. The overlay is
@@ -81,9 +91,16 @@ if [ -z "$QEMU_IMG" ] || [ ! -x "$QEMU_IMG" ]; then
 fi
 
 # Create the ephemeral copy-on-write overlay over the read-only base.
+# The caller (conftest) normally passes a per-instance overlay path under its
+# own pytest tmp dir (parallel isolation + the tmp dir reaps it). For standalone
+# use we mktemp one — with a TRAILING-X template only: BSD/macOS mktemp leaves a
+# non-trailing run of X's literal (a ".XXXXXX.qcow2" template yields a junk name),
+# whereas a trailing-X template is portable across GNU and BSD. The qcow2 format
+# is forced explicitly on both create (-f) and the -drive (format=), so the
+# overlay needs no ".qcow2" suffix for format detection.
 CLEANUP_OVERLAY=0
 if [ -z "$OVERLAY" ]; then
-    OVERLAY="$(mktemp -t pfb-smoke-overlay.XXXXXX.qcow2)"
+    OVERLAY="$(mktemp -t pfb-smoke-overlay.XXXXXX)"
     CLEANUP_OVERLAY=1
 fi
 
@@ -98,25 +115,56 @@ trap cleanup EXIT INT TERM
 # never written. (Equivalent to -snapshot, but explicit + inspectable.)
 "$QEMU_IMG" create -q -f qcow2 -b "$BASE_IMG" -F qcow2 "$OVERLAY" >/dev/null
 
-echo "boot_vm: booting $BASE_IMG via overlay $OVERLAY" >&2
-echo "boot_vm: hostfwd ssh=2222->22 web=8080->80 dns=5353->53(tcp+udp)" >&2
+# Host-forward ports (env-overridable so parallel VMs don't collide; the
+# defaults preserve the historical fixed map for standalone use).
+SSH_PORT="${SMOKE_SSH_PORT:-2222}"
+WEB_PORT="${SMOKE_WEB_PORT:-8080}"
+DNS_PORT="${SMOKE_DNS_PORT:-5353}"
 
-# KVM acceleration is required for a FreeBSD guest at usable speed. The
-# caller (workflow) asserts /dev/kvm before invoking this helper.
-#
+# Pick the accelerator + CPU model. SMOKE_QEMU_ACCEL/SMOKE_QEMU_CPU override;
+# otherwise detect per host. `-accel <name>` generalises the old `-enable-kvm`
+# (which is just `-accel kvm`). Probe the binary's own `-accel help` for hvf/whpx
+# so an arm64 macOS host (x86 binary lists tcg only) correctly falls back to tcg.
+ACCEL="${SMOKE_QEMU_ACCEL:-}"
+if [ -z "$ACCEL" ]; then
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        Linux)
+            if [ -e /dev/kvm ]; then ACCEL=kvm; else ACCEL=tcg; fi ;;
+        Darwin)
+            if "$QEMU" -accel help 2>/dev/null | grep -qw hvf; then ACCEL=hvf; else ACCEL=tcg; fi ;;
+        CYGWIN*|MINGW*|MSYS*|Windows_NT)
+            if "$QEMU" -accel help 2>/dev/null | grep -qw whpx; then ACCEL=whpx; else ACCEL=tcg; fi ;;
+        *)
+            ACCEL=tcg ;;
+    esac
+fi
+# `-cpu host` is only valid with a hardware accelerator (kvm/hvf); tcg/whpx need
+# a concrete model (max = every feature the accel can emulate).
+CPU="${SMOKE_QEMU_CPU:-}"
+if [ -z "$CPU" ]; then
+    case "$ACCEL" in
+        kvm|hvf) CPU=host ;;
+        *) CPU=max ;;
+    esac
+fi
+
+echo "boot_vm: booting $BASE_IMG via overlay $OVERLAY" >&2
+echo "boot_vm: accel=$ACCEL cpu=$CPU hostfwd ssh=${SSH_PORT}->22 web=${WEB_PORT}->80 dns=${DNS_PORT}->53(tcp+udp)" >&2
+[ "$ACCEL" = tcg ] && echo "boot_vm: WARNING tcg (no hardware virt) — boots are SLOW; raise SMOKE_BOOT_TIMEOUT" >&2
+
 # Build the arg list incrementally so the control/diagnostic channel is
 # optional. If QMP_SOCK is set in the environment, expose a QMP control socket
 # there (used by screendump.py to capture the VGA framebuffer of a wedged,
 # headless boot) and keep the serial console on stdio for the run log. If it is
 # unset (local interactive use), mux the monitor + serial on stdio as before.
 set -- \
-    -enable-kvm -machine pc -cpu host \
+    -accel "$ACCEL" -machine pc -cpu "$CPU" \
     -smp "$VM_SMP" -m "$VM_MEM" \
     -smbios "type=1,uuid=${VM_SMBIOS_UUID}" \
     -device virtio-scsi-pci,id=virtioscsi0 \
     -drive "file=${OVERLAY},if=none,id=drive-scsi0,format=qcow2,cache=unsafe,discard=unmap,detect-zeroes=unmap" \
     -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
-    -netdev user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::8080-:80,hostfwd=tcp::5353-:53,hostfwd=udp::5353-:53 \
+    -netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22,hostfwd=tcp::${WEB_PORT}-:80,hostfwd=tcp::${DNS_PORT}-:53,hostfwd=udp::${DNS_PORT}-:53" \
     -device "virtio-net-pci,mac=${VM_MAC},netdev=net0,id=nic0" \
     -display none
 

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -196,6 +196,28 @@ class BootHandle:
     log_file: object = field(repr=False)
 
 
+def _free_ports(n: int, host: str = DEFAULT_HOST) -> list[int]:
+    """Allocate ``n`` distinct free ephemeral TCP ports on ``host``.
+
+    Bind ``:0`` for all ``n`` at once (held open until every port is read) so the
+    kernel hands out distinct ports, then close them. There is a small TOCTOU
+    window between the close and qemu binding the hostfwd, so the caller allocates
+    immediately before boot. This is what lets parallel VMs each get their own
+    ssh/web/dns host ports instead of the fixed 2222/8080/5353 (which collide).
+    """
+    socks: list[socket.socket] = []
+    try:
+        for _ in range(n):
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind((host, 0))
+            socks.append(s)
+        return [s.getsockname()[1] for s in socks]
+    finally:
+        for s in socks:
+            s.close()
+
+
 def boot_and_probe(
     base_image: Path,
     ssh_key_path: str,
@@ -205,6 +227,7 @@ def boot_and_probe(
     ssh_port: int = DEFAULT_SSH_PORT,
     web_port: int = DEFAULT_WEB_PORT,
     dns_port: int = DEFAULT_DNS_PORT,
+    overlay_path: Path | None = None,
     boot_timeout: int = DEFAULT_BOOT_TIMEOUT,
 ) -> BootHandle:
     """Boot ``base_image`` and block until the guest is usable.
@@ -223,10 +246,24 @@ def boot_and_probe(
     log_file = log_path.open("wb")
     # boot_vm.sh backgrounds nothing itself (it execs qemu); we background it
     # via Popen and pass its PID to wait_ready.sh so a dead boot is caught fast.
+    # The host ports ride in via env (boot_vm.sh reads SMOKE_{SSH,WEB,DNS}_PORT)
+    # so each parallel VM forwards on its own ports. overlay_path (when given) is
+    # boot_vm.sh's arg 2 — a per-instance CoW overlay under the caller's tmp dir
+    # (parallel isolation + portable: avoids boot_vm.sh's own mktemp).
+    argv = ["sh", str(BOOT_VM_SH), str(base_image)]
+    if overlay_path is not None:
+        argv.append(str(overlay_path))
+    boot_env = {
+        **os.environ,
+        "SMOKE_SSH_PORT": str(ssh_port),
+        "SMOKE_WEB_PORT": str(web_port),
+        "SMOKE_DNS_PORT": str(dns_port),
+    }
     process: subprocess.Popen[bytes] = subprocess.Popen(
-        ["sh", str(BOOT_VM_SH), str(base_image)],
+        argv,
         stdout=log_file,
         stderr=subprocess.STDOUT,
+        env=boot_env,
     )
 
     vm = SmokeVM(
@@ -333,8 +370,13 @@ def smoke_vm(tmp_path_factory: pytest.TempPathFactory) -> Iterator[SmokeVM]:
     if not ssh_key_path or not Path(ssh_key_path).is_file():
         pytest.skip("SMOKE_SSH_KEY not set or not a file — no guest SSH key")
 
-    if not Path("/dev/kvm").exists():
-        pytest.skip("/dev/kvm absent — KVM acceleration required for the smoke VM")
+    # No hard /dev/kvm gate: boot_vm.sh auto-detects the accelerator (kvm on
+    # Linux+/dev/kvm, hvf on an Intel Mac, whpx on Windows, else tcg). tcg (full
+    # emulation — the only option for an x86 guest on an arm64 host such as Apple
+    # Silicon) is correct but slow, so a missing hardware accel makes the boot
+    # SLOW, not impossible. A developer who wants the old clean-skip behaviour on
+    # a box without virt can still skip by not setting SMOKE_IMAGE_DIR/REF above.
+    # Raise SMOKE_BOOT_TIMEOUT for tcg (see DEFAULT_BOOT_TIMEOUT).
 
     # `oras` is only needed when we have to pull; a pre-pulled SMOKE_IMAGE_DIR
     # run (egress blocked) does not require it.
@@ -354,10 +396,17 @@ def smoke_vm(tmp_path_factory: pytest.TempPathFactory) -> Iterator[SmokeVM]:
     else:
         base_image = oras_pull_image(image_ref, work / "image")
 
+    # Allocate distinct ephemeral host ports immediately before boot so parallel
+    # smoke sessions on one host never collide on the fixed 2222/8080/5353.
+    ssh_port, web_port, dns_port = _free_ports(3)
     handle = boot_and_probe(
         base_image,
         ssh_key_path,
         log_path=work / "vm.log",
+        ssh_port=ssh_port,
+        web_port=web_port,
+        dns_port=dns_port,
+        overlay_path=work / "overlay.qcow2",
         boot_timeout=DEFAULT_BOOT_TIMEOUT,
     )
     try:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -831,6 +831,99 @@ def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
         )
 
 
+def _mock_dns_upstream_snippet(port: int) -> str:
+    """Build the PHP that wires Unbound's root forward-zone to the mock at ``port``.
+
+    Pure (no VM) so it is unit-testable. pfSense ``base64_decode``s
+    ``unbound/custom_options`` (unbound.inc ``unbound_generate_config_text``), so the
+    forward-zone text is base64-encoded here — a PLAIN value would decode to garbage.
+    Unbound ``forward-addr`` accepts an explicit ``@port``; that is what frees the mock
+    from host ``:53`` and makes parallel sessions (each its own ephemeral port) safe.
+    """
+    forward_zone = f'forward-zone:\n  name: "."\n  forward-addr: {GUEST_TO_HOST_ALIAS}@{port}\n'
+    return (
+        "$u = config_get_path('unbound', array());\n"
+        f"$u['custom_options'] = base64_encode({_php_str(forward_zone)});\n"
+        "unset($u['forwarding']);\n"
+        "unset($u['dnssec']);\n"
+        "config_set_path('unbound', $u);\n"
+        "write_config('pfBlockerNG smoke: mock DNS upstream (custom forward-zone @ephemeral port)');\n"
+        "services_unbound_configure();\n"
+        "echo 'OK';"
+    )
+
+
+def use_mock_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
+    """Point pfSense at the runner-side mock via a custom forward-zone on an EPHEMERAL port.
+
+    The parallel-safe / no-root sibling of :func:`use_system_dns_upstream`. The
+    System-DNS path pins the mock to host ``:53`` (libslirp's port-preserving NAT of
+    ``10.0.2.2:53`` -> runner ``127.0.0.1:53``), which needs root to bind :53 and
+    collides between concurrent VMs. Here the ``stub_dns`` fixture binds an EPHEMERAL
+    port (``vm.upstream_dns_port``) and Unbound forwards the root zone to
+    ``10.0.2.2@<that-port>`` via a custom ``forward-zone`` — the SAME SLIRP host-alias
+    path the mock-feed HTTP server already rides on an arbitrary port:
+
+        guest Unbound --(forward ".")--> 10.0.2.2@<port> (SLIRP host alias)
+            --(NAT, port-preserving)--> 127.0.0.1:<port> (mock)
+
+    So N parallel sessions each use their own ephemeral DNS port and never clash, and
+    no sysctl/sudo is needed. Selected by :func:`wire_dns_upstream` when
+    ``SMOKE_DNS_UPSTREAM=mock`` (the local-run default).
+
+    Config set (idempotent; written + ``services_unbound_configure``):
+      * ``unbound/custom_options`` = a ``forward-zone: name: "."`` to ``10.0.2.2@<port>``.
+        pfSense ``base64_decode``s this field (unbound.inc ``unbound_generate_config_text``),
+        so it is base64-encoded here — a PLAIN value would decode to garbage.
+      * ``unset unbound/forwarding`` — so pfSense does NOT also emit its OWN
+        ``forward-zone "."`` (to the System DNS servers); a duplicate root forward-zone
+        is ambiguous. Our custom "." zone is the sole forwarder.
+      * ``unset unbound/dnssec`` — the mock's answers are unsigned (a validator would
+        mark them bogus / SERVFAIL).
+    """
+    port = vm.upstream_dns_port
+    if not port:
+        raise RuntimeError("use_mock_dns_upstream needs vm.upstream_dns_port — activate the stub_dns fixture first")
+    result = php_eval(vm, _mock_dns_upstream_snippet(port), timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"use_mock_dns_upstream failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+    # services_unbound_configure restarts Unbound — wait for it before any probe.
+    wait_unbound_ready(vm)
+    # RELAY SELF-CHECK (fail fast): a throwaway name MUST come back as the sentinel
+    # (forward "." -> 10.0.2.2@port -> mock). The FIRST response is authoritative; if it
+    # isn't the sentinel the relay isn't wired — raise NOW rather than time out per-case.
+    probe = unique_domain("mockdnsselfcheck")
+    ans = dns_probe(vm, probe, "A", timeout=10.0, attempts=3, delay=3.0)
+    if not resolves_to(ans, STUB_DNS_A):
+        raise RuntimeError(
+            f"Mock-DNS relay self-check FAILED: {probe} -> {ans} (expected the mock sentinel "
+            f"{STUB_DNS_A}). Unbound forward-zone -> {GUEST_TO_HOST_ALIAS}@{port} (SLIRP host alias) "
+            f"-> runner 127.0.0.1:{port} mock path is not working."
+        )
+
+
+def wire_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
+    """Wire pfSense's DNS upstream to the runner-side mock, choosing the path by env.
+
+    ``SMOKE_DNS_UPSTREAM`` selects the wiring (both make the guest resolve every
+    non-local name via the in-runner mock, so the matrix's block/allow assertions hold
+    identically — only the runner-side port binding differs):
+
+      * ``system`` (DEFAULT) — :func:`use_system_dns_upstream`: System DNS = 10.0.2.2,
+        mock on host ``:53``. The CI path; preserved exactly (CI sets nothing, so it
+        keeps using this).
+      * ``mock`` — :func:`use_mock_dns_upstream`: custom forward-zone to an EPHEMERAL
+        port. Parallel-safe and root-free; the LOCAL-run default (README sets it).
+    """
+    mode = (os.environ.get("SMOKE_DNS_UPSTREAM") or "system").strip().lower()
+    if mode == "mock":
+        use_mock_dns_upstream(vm, timeout=timeout)
+    elif mode == "system":
+        use_system_dns_upstream(vm, timeout=timeout)
+    else:
+        raise RuntimeError(f"SMOKE_DNS_UPSTREAM must be 'system' or 'mock', got {mode!r}")
+
+
 # --------------------------------------------------------------------------- #
 # Update hooks (ADR-12) — pre/post command hooks fired from the update pass
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -87,7 +87,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
-    h.use_system_dns_upstream(smoke_vm)
+    h.wire_dns_upstream(smoke_vm)
     try:
         yield smoke_vm
     finally:

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -74,7 +74,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
-    h.use_system_dns_upstream(smoke_vm)
+    h.wire_dns_upstream(smoke_vm)
     try:
         yield smoke_vm
     finally:

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -30,12 +30,12 @@ pytestmark = pytest.mark.smoke
 
 @pytest.fixture(scope="module")
 def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> SmokeVM:
-    """Deploy the branch .pkg once for the helper self-tests; configure the System-DNS
-    upstream (``use_system_dns_upstream`` -> the mock via the 10.0.2.2 host alias)."""
+    """Deploy the branch .pkg once for the helper self-tests; configure the DNS upstream
+    (``wire_dns_upstream`` -> the mock via the 10.0.2.2 host alias; path chosen by env)."""
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
-    h.use_system_dns_upstream(smoke_vm)
+    h.wire_dns_upstream(smoke_vm)
     return smoke_vm
 
 
@@ -404,3 +404,63 @@ def test_b64_textarea_matches_pfblockerng_decode() -> None:
     encoded = h._b64_textarea(lines)
     assert base64.b64decode(encoded).decode().split("\r\n") == lines
     assert h._b64_textarea([]) == "", "empty list -> empty value (no entries)"
+
+
+def test_mock_dns_upstream_snippet_base64_encodes_forward_zone() -> None:
+    """The mock-DNS wiring forwards the ROOT zone to 10.0.2.2@<ephemeral-port>.
+
+    ``unbound/custom_options`` is a base64 field (pfSense ``base64_decode``s it in
+    ``unbound_generate_config_text``), so the forward-zone must ride INSIDE
+    ``base64_encode(...)`` — never a raw assign that would decode to garbage. forwarding
+    and dnssec are dropped so there is no competing root forward-zone and the mock's
+    unsigned answers are not marked bogus. The explicit ``@port`` is what frees the mock
+    from host :53 (the parallel-safety lever)."""
+    snippet = h._mock_dns_upstream_snippet(5399)
+    assert f"forward-addr: {h.GUEST_TO_HOST_ALIAS}@5399" in snippet
+    assert 'name: "."' in snippet
+    # Forward-zone text is base64-encoded by PHP at RUNTIME (not pre-encoded in Python),
+    # so it rides as the literal argument to base64_encode — assert the wrapper.
+    assert "$u['custom_options'] = base64_encode(" in snippet
+    assert "unset($u['forwarding']);" in snippet  # no competing root forward-zone
+    assert "unset($u['dnssec']);" in snippet  # unsigned mock answers
+    assert "services_unbound_configure();" in snippet
+
+
+def test_wire_dns_upstream_dispatches_on_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``wire_dns_upstream`` picks the upstream path by SMOKE_DNS_UPSTREAM — every value asserted.
+
+    Scenario: the dispatcher must DEFAULT to the System-DNS path (so CI, which sets
+    nothing, stays on :53 unchanged) and select the parallel-safe mock path only on
+    explicit opt-in; an unknown value must fail loudly, not silently pick a wrong upstream.
+
+      Given the two upstream helpers are stubbed to record which one ran
+      When  SMOKE_DNS_UPSTREAM is {unset, 'system', 'mock', 'MOCK', 'bogus'}
+      Then  the call routes to {system, system, mock, mock, RuntimeError} respectively
+    """
+    called: list[str] = []
+    monkeypatch.setattr(h, "use_system_dns_upstream", lambda vm, *, timeout=120.0: called.append("system"))
+    monkeypatch.setattr(h, "use_mock_dns_upstream", lambda vm, *, timeout=120.0: called.append("mock"))
+    vm = object()  # the stubs ignore it
+
+    # Given no env (CI) — Then default to the System-DNS path (preserves :53).
+    monkeypatch.delenv("SMOKE_DNS_UPSTREAM", raising=False)
+    h.wire_dns_upstream(vm)  # type: ignore[arg-type]
+    assert called == ["system"]
+
+    # Given explicit 'system' — Then system.
+    called.clear()
+    monkeypatch.setenv("SMOKE_DNS_UPSTREAM", "system")
+    h.wire_dns_upstream(vm)  # type: ignore[arg-type]
+    assert called == ["system"]
+
+    # Given 'mock' (case-insensitively) — Then the ephemeral-port path.
+    for value in ("mock", "MOCK"):
+        called.clear()
+        monkeypatch.setenv("SMOKE_DNS_UPSTREAM", value)
+        h.wire_dns_upstream(vm)  # type: ignore[arg-type]
+        assert called == ["mock"], value
+
+    # Given an unknown value — Then RAISE (no silent fallback to a wrong upstream).
+    monkeypatch.setenv("SMOKE_DNS_UPSTREAM", "bogus")
+    with pytest.raises(RuntimeError, match="SMOKE_DNS_UPSTREAM"):
+        h.wire_dns_upstream(vm)  # type: ignore[arg-type]

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -98,7 +98,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     h.deploy(smoke_vm)
     h.snapshot_unbound_conf(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
-    h.use_system_dns_upstream(smoke_vm)
+    h.wire_dns_upstream(smoke_vm)
     # Defensive: start from a known-clean hook list so nothing left over from an
     # earlier module/run can fire during this module's reloads.
     h.clear_update_hooks(smoke_vm)

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -99,10 +99,11 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     # lo0 sinkhole VIP once for the matrix. dns_probe queries on-box (drill
     # @127.0.0.1) — no localhost exemption — so no WAN/ACL plumbing is needed.
     h.ensure_dnsbl_vip(smoke_vm)
-    # Point pfSense at the controlled mock via its System-DNS path BEFORE any per-test
-    # unbound-config snapshot (test_dnsbl_unbound_config_immutable), so the forwarding
-    # config is part of the baseline and the DNSBL reload still adds only python.
-    h.use_system_dns_upstream(smoke_vm)
+    # Point pfSense at the controlled mock (env-selected upstream path: System-DNS on
+    # :53 in CI, or a custom forward-zone on an ephemeral port for local/parallel) BEFORE
+    # any per-test unbound-config snapshot (test_dnsbl_unbound_config_immutable), so the
+    # forwarding config is part of the baseline and the DNSBL reload still adds only python.
+    h.wire_dns_upstream(smoke_vm)
     h.snap_state(smoke_vm, "vip")
     try:
         yield smoke_vm


### PR DESCRIPTION
## What

Make the live-pfSense-VM suites — `tests/smoke` (ADR-04) and `tests/smoke/ui`
(ADR-14) — runnable on a **developer machine** (Linux, macOS, Windows via WSL2)
and with **multiple pytest instances in parallel** on one host. Previously they
were wired to a single GitHub Linux runner (hard `/dev/kvm` gate, fixed host
ports, a stub DNS pinned to host `:53` needing `sudo`).

**CI behaviour is preserved** — the defaults reproduce the old fixed-port +
System-DNS-on-`:53` path byte-for-byte; nothing in the workflows changes.

## Changes

- **`boot_vm.sh`** — auto-detect the accelerator (`SMOKE_QEMU_ACCEL` overrides):
  `kvm` (Linux+`/dev/kvm`), `hvf` (Intel Mac), `whpx` (Windows), else `tcg`;
  pair the CPU model with it. Host-forward ports from `SMOKE_{SSH,WEB,DNS}_PORT`
  (defaults preserve `2222/8080/5353`, so `build-image.yml` is unaffected).
  Portable overlay tempfile.
- **`conftest.py`** — `_free_ports()` gives each session 3 distinct ephemeral
  host ports + a per-instance CoW overlay, so parallel VMs never collide. The
  hard `/dev/kvm` skip is gone (`tcg` always works; raise `SMOKE_BOOT_TIMEOUT`).
- **`helpers.py`** — `use_mock_dns_upstream()` + `wire_dns_upstream()` dispatcher
  (`SMOKE_DNS_UPSTREAM=mock|system`, default `system`). The `mock` path forwards
  Unbound's root zone to the stub on an **ephemeral** port via a custom
  forward-zone (base64-encoded — pfSense `base64_decode`s `custom_options`), so
  no `sudo`/`:53`/host-global state. The 5 live fixtures call the dispatcher.
- **tests** — pure unit coverage for the new builder + dispatcher branches.
- **README** — per-platform accelerator table (incl. the Apple-Silicon `tcg`
  slow caveat), the `SMOKE_DNS_UPSTREAM=mock` switch, the parallel recipe, the
  UI tiers, and Windows=WSL2.

## Platform note

pfSense ships **amd64 only**, so an arm64 host (Apple Silicon) has no x86
hardware virt and runs under `tcg` (full emulation): functionally correct,
just slow. Linux/KVM, Intel-Mac/HVF, and Windows/WHPX (or WSL2) are fast.

## Validation

Static gate green locally (ruff, ruff format, mypy `tests/`, full `pytest`
1115 passed, markdownlint, shellcheck, shellspec, `php -l`). End-to-end live-VM
boot validated separately on a real image (the smoke matrix is dispatch-only;
PR CI runs only the non-VM gate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded local smoke test running instructions for Linux/macOS/Windows with accelerator auto-detection, updated prerequisites, and parallel execution guidance using environment variables.

* **Tests**
  * Enhanced cross-platform test support with improved QEMU accelerator detection (kvm/hvf/whpx/tcg).
  * Added flexible DNS upstream configuration with ephemeral port allocation for isolated test sessions and parallel execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->