### PR TITLE
tests: flush the pre-resolved name before the DNSBL HTTP block probe (ADR-16 Part C)

### DIFF
--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -167,8 +167,13 @@ def test_dnsbl_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
         # The "resolves" probes must reach the controlled stub: leave egress OPEN. The
         # member's VIP block returns locally regardless, so this is no false-green.
         h.unblock_egress()
-        blocked = h.dns_probe(deployed_vm, member, "A")
-        assert h.is_vip(blocked), f"listed {member} expected VIP block, got {blocked}"
+        # The `before` probe pre-resolved `member` via the stub (TTL 60s). A feed/cron
+        # allow->block swap is TTL-bounded BY DESIGN (ADR-10) and does NOT flush the
+        # C-cache, so that cached real answer would serve past the swap. Clear the one
+        # name (as test_smoke_matrix.py's unlock lifecycle does), then poll until the
+        # async swap's VIP block lands.
+        h.flush_unbound_name(deployed_vm, member)
+        blocked = h.dns_probe_until(deployed_vm, member, h.is_vip)
         assert not h.resolves_to(blocked, STUB_DNS_A), f"{member} still resolving after the feed block: {blocked}"
         passed = h.dns_probe(deployed_vm, non_member, "A")
         assert h.resolves_to(passed, STUB_DNS_A), f"non-member {non_member} should resolve via stub, got {passed}"
@@ -255,8 +260,9 @@ def test_dnsbl_http_hosts_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeed
 
     with h.CaseContext(deployed_vm, spec):
         h.unblock_egress()  # the non-member "resolves" probe must reach the stub upstream
-        blocked = h.dns_probe(deployed_vm, member, "A")
-        assert h.is_vip(blocked), f"listed {member} (hosts line) expected VIP block, got {blocked}"
+        # before-probe warmed the C-cache; a feed swap is TTL-bounded (see kill-gate) -> flush + poll.
+        h.flush_unbound_name(deployed_vm, member)
+        blocked = h.dns_probe_until(deployed_vm, member, h.is_vip)
         assert not h.resolves_to(blocked, STUB_DNS_A), f"{member} still resolving after the feed block: {blocked}"
         passed = h.dns_probe(deployed_vm, non_member, "A")
         assert h.resolves_to(passed, STUB_DNS_A), f"non-member {non_member} should resolve via stub, got {passed}"
@@ -299,8 +305,9 @@ def test_dnsbl_http_abp_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedSe
         # controlled stub: leave egress OPEN. The || block returns the VIP locally, so
         # this is no false-green.
         h.unblock_egress()
-        ans_blocked = h.dns_probe(deployed_vm, blocked_name, "A")
-        assert h.is_vip(ans_blocked), f"ABP ||-blocked {blocked_name} expected VIP, got {ans_blocked}"
+        # before-probe warmed the C-cache; a feed swap is TTL-bounded (see kill-gate) -> flush + poll.
+        h.flush_unbound_name(deployed_vm, blocked_name)
+        ans_blocked = h.dns_probe_until(deployed_vm, blocked_name, h.is_vip)
         assert not h.resolves_to(ans_blocked, STUB_DNS_A), (
             f"{blocked_name} still resolving after the || block: {ans_blocked}"
         )


### PR DESCRIPTION
## Fix the DNSBL HTTP feed-load smoke cases (ADR-16 Part C)

The 3 DNSBL cases in `test_smoke_feeds.py` (plain/hosts/abp) failed on the live VM:
the listed member kept resolving to the stub (`203.0.113.99`) instead of blocking.

### Root cause — a DNS cache effect, not a load/parse/format bug

The feeds **load correctly** — the build logs show `loaded entries: 1` (hosts) and
`loaded entries: 2` (abp) with the zero-downtime swap completing. The failure was the
test's own `before` probe: it pre-resolves the member via the stub (TTL 60s), and per
ADR-10 a **feed/cron `allow→block` swap is TTL-bounded by design** — only the #51
single-domain user path flushes the C-cache immediately. So the cached real answer
served past the swap and the after-probe saw it. (`plain` passed only by luck: the
*first* DNSBL case restarts Unbound to enable DNSBL, flushing the cache; later cases are
pure data swaps.)

This is exactly what the already-passing `test_smoke_matrix.py` unlock lifecycle handles
(`helpers.py` comment at the unlock case): `flush_unbound_name(name)` then
`dns_probe_until(name, is_vip)`. These 3 cases simply omitted it.

### Fix

Mirror the proven pattern on the 3 DNSBL cases: flush the pre-resolved name, then poll
for the async swap's VIP block. **Test-only — no product change.**

### Validation

Confirmed by a live smoke dispatch on this branch: **all 6 `test_smoke_feeds.py` cases
pass** (`61 passed, 0 failed`). The off-box build was already proven correct (hosts strip
+ ABP tag both block); the diagnosis ruled out fetch/parse/format and the reload verb
(`scope="update"` was tried and made no difference — the feeds always loaded).

Part of the ADR-16 Part-C kill-gate (`.ADRs/ADR_16_Feeds_Tabs_And_Feed_Smoke`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced DNSBL HTTP smoke tests to better handle DNS cache timing behavior. Tests now properly validate DNS blocking functionality by flushing cached entries and polling for expected blocking conditions, ensuring more reliable test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->