### PR TITLE
pfblockerng: add NXDOMAIN DNSBL block response + reorder modes (issue #31)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1777,8 +1777,10 @@ def get_details_dnsbl(
         else:
             _dnsbl_last_event = event_sig
 
-        # Skip logging
-        if dnsbl.log_type == "2":
+        # Skip logging: null-no-log ("2") and NXDOMAIN-no-log ("4"). The per-group
+        # counter above still increments (stats parity with the logged variants); only
+        # the dnsbl.log/unified.log line is suppressed.
+        if dnsbl.log_type in ("2", "4"):
             return True
 
         q_ip = get_q_ip_comm(kwargs)
@@ -3973,6 +3975,10 @@ class DnsblDecision:
     in_whitelist: bool
     in_hsts: bool
     null_blocking: bool
+    # issue #31: NXDOMAIN block shape (log_type "3"/"4"). Distinct from null_blocking
+    # (0.0.0.0/::) and VIP -- operate() returns a bare NXDOMAIN rcode with no answer
+    # records, so HSTS's null-override is irrelevant (no TLS handshake to guard).
+    nxdomain: bool
     log_type: Any
     b_type: str
     p_type: str
@@ -4285,6 +4291,7 @@ def evaluate_domain(
     in_whitelist = False
     in_hsts = False
     null_blocking = True
+    nxdomain = False
     b_type = "Python"
     p_type = "Python"
     feed: Any = "Unknown"
@@ -4433,6 +4440,12 @@ def evaluate_domain(
 
         if log_type == "1" and not in_hsts:
             null_blocking = False
+        # issue #31: NXDOMAIN block shape ("3" logged / "4" silent). It bypasses the
+        # synthesized A/AAAA reply entirely, so the HSTS null-override above does not
+        # apply (NXDOMAIN never triggers a TLS handshake). null_blocking stays True so
+        # the per-event logger does not treat it as a VIP block (get_details_dnsbl).
+        elif log_type in ("3", "4"):
+            nxdomain = True
 
         if is_cname:
             b_type = b_type + "_CNAME"
@@ -4442,6 +4455,7 @@ def evaluate_domain(
         in_whitelist=in_whitelist,
         in_hsts=in_hsts,
         null_blocking=null_blocking,
+        nxdomain=nxdomain,
         log_type=log_type,
         b_type=b_type,
         p_type=p_type,
@@ -4818,6 +4832,18 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
             # Block iff found and not whitelisted; an allow decision falls through to
             # the resolver (the WAIT_MODULE below).
             if dnsbl.is_found and not dnsbl.in_whitelist:
+                # issue #31: NXDOMAIN block shape ("3" logged / "4" silent). Return a
+                # bare NXDOMAIN rcode with NO answer records -- no DNSMessage, no
+                # sinkhole IP, no DNSBL webserver redirect. Still attributed and logged
+                # via get_details_dnsbl (which internally drops the log line for "4");
+                # not cached, for the same #43 reasons as the VIP/null path below.
+                if dnsbl.nxdomain:
+                    get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": q_ip})
+                    qstate.return_rcode = RCODE_NXDOMAIN
+                    qstate.no_cache_store = 1
+                    qstate.ext_state[id] = MODULE_FINISHED
+                    return True
+
                 # Create FQDN Reply Message
                 msg = DNSMessage(qstate.qinfo.qname_str, q_type, RR_CLASS_IN, PKT_QR | PKT_RA)
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4444,7 +4444,12 @@ def evaluate_domain(
         # synthesized A/AAAA reply entirely, so the HSTS null-override above does not
         # apply (NXDOMAIN never triggers a TLS handshake). null_blocking stays True so
         # the per-event logger does not treat it as a VIP block (get_details_dnsbl).
+        # HSTS played no part in this decision, so clear the attribution hsts_check_domain
+        # set above -- otherwise an NXDOMAIN block on an HSTS-listed name would mislog its
+        # p_type as HSTS / HSTS_TLD (the response shape is right, the "why" would be wrong).
         elif log_type in ("3", "4"):
+            in_hsts = False
+            p_type = "Python"
             nxdomain = True
 
         if is_cname:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8934,6 +8934,7 @@ function sync_package_pfblockerng($cron='') {
 
 
 							// If Null Blocking mode is selected, use '0.0.0.0|::0', otherwise utilize DNSBL WebServer/DNSBL VIP
+							// NXDOMAIN modes ('3'/'4', issue #31) emit a bare NXDOMAIN in pfb_unbound.py; no sinkhole IP applies.
 							if ($list['logging'] == 'disabled') {
 								$sinkhole_type4 = '0.0.0.0';
 								$sinkhole_type6 = '::0';
@@ -8941,6 +8942,12 @@ function sync_package_pfblockerng($cron='') {
 							}
 							elseif ($list['logging'] == 'disabled_log') {
 								$logging_type	= '0';	// Null Blocking logging
+							}
+							elseif ($list['logging'] == 'nxdomain_log') {
+								$logging_type	= '3';	// NXDOMAIN logging
+							}
+							elseif ($list['logging'] == 'nxdomain') {
+								$logging_type	= '4';	// NXDOMAIN no logging
 							} else {
 								$sinkhole_type4 = "{$pfb['dnsbl_vip4']}";
 								$sinkhole_type6 = "{$pfb['dnsbl_vip6']}";

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -193,10 +193,16 @@ if (!$alert_summary) {
 							$d_log = $g_log;
 						}
 
+						// Mirror the pfblockerng.inc logging_type mapping (issue #31 adds
+						// NXDOMAIN '3'/'4'); anything else falls through to null-no-log '2'.
 						if ($d_log == 'disabled_log') {
 							$d_type = '0';
 						} elseif ($d_log == 'enabled') {
 							$d_type = '1';
+						} elseif ($d_log == 'nxdomain_log') {
+							$d_type = '3';
+						} elseif ($d_log == 'nxdomain') {
+							$d_type = '4';
 						} else {
 							$d_type = '2';
 						}

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -207,7 +207,9 @@ if (!empty($action) && isset($gtype) && isset($rowid)) {
 
 				$aliaslog_values = array('enabled',
 							'disabled',
-							'disabled_log'
+							'disabled_log',
+							'nxdomain_log',	// issue #31: NXDOMAIN logging
+							'nxdomain'	// issue #31: NXDOMAIN no logging
 							);
 
 				// Parse POST and save new values
@@ -503,8 +505,10 @@ if (isset($savemsg)) {
 						$log_error = '';
 						if ($gtype == 'dnsbl') {
 							$log_options = ['enabled'	=> 'DNSBL WebServer/VIP',
+									'disabled_log'	=> 'Null Block (logging)',
 									'disabled'	=> 'Null Block (no logging)',
-									'disabled_log'	=> 'Null Block (logging)'];
+									'nxdomain_log'	=> 'NXDOMAIN (logging)',
+									'nxdomain'	=> 'NXDOMAIN (no logging)'];
 
 							// Global DNSBL Logging/Blocking mode
 							if (!empty($pfb['dnsbl_global_log'])) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -429,8 +429,10 @@ $options_agateway_in		= $options_agateway_out		= pfb_get_gateways();
 $options_order			= [ 'default' => 'Default', 'primary' => 'Primary' ];
 
 $options_logging	= [	'enabled'	=> 'DNSBL WebServer/VIP',
+				'disabled_log'	=> 'Null Blocking (logging)',
 				'disabled'	=> 'Null Blocking (no logging)',
-				'disabled_log'	=> 'Null Blocking (logging)' ];
+				'nxdomain_log'	=> 'NXDOMAIN (logging)',
+				'nxdomain'	=> 'NXDOMAIN (no logging)' ];
 
 $options_suppression_cidr	= [ 'Disabled' => 'Disabled' ] + array_combine(range(1, 17, 1), range(1, 17, 1));
 
@@ -1516,8 +1518,10 @@ if ($gtype == 'dnsbl') {
 
 	$log_text = 'Default: <strong>DNSBL WebServer/VIP</strong><br />'
 			. '&#8226 <strong>DNSBL WebServer/VIP</strong>, Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
+			. '&#8226 <strong>Null Blocking (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br />'
 			. '&#8226 <strong>Null Blocking (no logging)</strong>, Utilize \'0.0.0.0\' with no logging.<br />'
-			. '&#8226 <strong>Null Blocking (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br /><br />'
+			. '&#8226 <strong>NXDOMAIN (logging)</strong>, Reply NXDOMAIN with logging. The DNSBL block page is bypassed.<br />'
+			. '&#8226 <strong>NXDOMAIN (no logging)</strong>, Reply NXDOMAIN with no logging. The DNSBL block page is bypassed.<br /><br />'
 			. 'Blocked domains will be reported to the Alert/Block Table.<br />'
 			. 'Enabling the "Global Logging/Blocking mode" in the DNSBL Tab will override this setting!<br />'
 			. 'A \'Force Reload - DNSBL\' is required for changes to take effect';

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -115,16 +115,20 @@ $options_dnsbl_allow_int	= $options_dnsbl_interface;
 
 $options_global_log_txt = 'Default: <strong>No Global mode</strong><br />'
 			. 'Enabling this option will overide the individual DNSBL Group "Logging/Blocking" settings!<br /><br />'
-			. '&#8226 <strong>Null Block (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br />'
 			. '&#8226 <strong>DNSBL WebServer/VIP</strong>, Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
+			. '&#8226 <strong>Null Block (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br />'
 			. '&#8226 <strong>Null Block (no logging)</strong>, Utilize \'0.0.0.0\' with no logging.<br />'
+			. '&#8226 <strong>NXDOMAIN (logging)</strong>, Reply NXDOMAIN with logging. The DNSBL block page is bypassed.<br />'
+			. '&#8226 <strong>NXDOMAIN (no logging)</strong>, Reply NXDOMAIN with no logging. The DNSBL block page is bypassed.<br />'
 			. 'Blocked domains will be reported to the Alert/Block Table.<br /><br />'
 			. 'A \'Force Reload - DNSBL\' is required for changes to take effect';
 
 $options_global_log	= [	''		=> 'No Global mode',
-				'disabled_log'	=> 'Null Block (logging)',
 				'enabled'	=> 'DNSBL WebServer/VIP',
-				'disabled'	=> 'Null Block (no logging)'];
+				'disabled_log'	=> 'Null Block (logging)',
+				'disabled'	=> 'Null Block (no logging)',
+				'nxdomain_log'	=> 'NXDOMAIN (logging)',
+				'nxdomain'	=> 'NXDOMAIN (no logging)'];
 
 $options_dnsbl_webpage = array();
 $indexdir = '/usr/local/www/pfblockerng/www';

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -114,7 +114,7 @@ $options_dnsbl_interface_cnt	= count($options_dnsbl_interface) ?: '1';
 $options_dnsbl_allow_int	= $options_dnsbl_interface;
 
 $options_global_log_txt = 'Default: <strong>No Global mode</strong><br />'
-			. 'Enabling this option will overide the individual DNSBL Group "Logging/Blocking" settings!<br /><br />'
+			. 'Enabling this option will override the individual DNSBL Group "Logging/Blocking" settings!<br /><br />'
 			. '&#8226 <strong>DNSBL WebServer/VIP</strong>, Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
 			. '&#8226 <strong>Null Block (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br />'
 			. '&#8226 <strong>Null Block (no logging)</strong>, Utilize \'0.0.0.0\' with no logging.<br />'

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -154,21 +154,27 @@ def abp_feed(*lines: str) -> str:
 class DnsblMode(str, Enum):
     """The block shape a DNSBL case expects for a matched name.
 
-    On ``next`` (python-mode-only) the two shapes are:
+    On ``devel`` (python-mode-only) the shapes are:
 
     * ``NULL`` — NOERROR + ``0.0.0.0`` / ``::0``; per-list
       ``logging='disabled'`` → ``logging_type='2'`` → ``null_blocking=True``
       in ``pfb_unbound.py:evaluate_domain``.
     * ``VIP`` — NOERROR + the DNSBL sinkhole VIP (``pfb_dnsvip4``); per-list
       ``logging='enabled'`` → ``logging_type='1'`` → ``null_blocking=False``.
+    * ``NXDOMAIN`` — a bare NXDOMAIN rcode, no records (issue #31); per-list
+      ``logging='nxdomain_log'`` → ``logging_type='3'`` → ``operate()`` returns
+      ``RCODE_NXDOMAIN`` with no DNSMessage. (The ``nxdomain`` / no-logging
+      variant '4' yields the IDENTICAL shape — only the dnsbl.log line differs,
+      which this on-box DNS-shape probe cannot observe, so it is unit-pinned in
+      ``tests/test_pfb_unbound.py`` rather than duplicated here.)
 
-    NXDOMAIN is NOT a valid python-mode output for a normal feed match
-    (verified on the live box; the only NXDOMAIN path in pfb_unbound.py is
-    SafeSearch).  The ``NXDOMAIN`` entry has been removed on ``next``.
+    Before issue #31, NXDOMAIN was only reachable via SafeSearch; it is now a
+    selectable per-list DNSBL block response.
     """
 
     NULL = "null"
     VIP = "vip"
+    NXDOMAIN = "nxdomain"
 
 
 @dataclass
@@ -1102,8 +1108,13 @@ def _dnsbl_mode_settings(mode: DnsblMode) -> dict[str, str]:  # noqa: ARG001
 
 
 def _dnsbl_list_logging(mode: DnsblMode) -> str:
-    """Per-list ``logging`` value: 'disabled' → null 0.0.0.0; 'enabled' → VIP."""
-    return "disabled" if mode is DnsblMode.NULL else "enabled"
+    """Per-list ``logging`` value driving the block shape: 'disabled' → null
+    0.0.0.0; 'nxdomain_log' → NXDOMAIN rcode (issue #31); 'enabled' → VIP."""
+    return {
+        DnsblMode.NULL: "disabled",
+        DnsblMode.NXDOMAIN: "nxdomain_log",
+        DnsblMode.VIP: "enabled",
+    }[mode]
 
 
 def inject(vm: SmokeVM, spec: DnsblCase | IpCase, *, timeout: float = 90.0) -> None:

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -28,10 +28,12 @@ against source, not guessed):
     → NOERROR + A = DNSBL VIP (``pfb_dnsvip4``). (**VIP** shape.)
   - ``logging='disabled'`` → ``logging_type='2'`` → ``null_blocking=True``
     → NOERROR + A = ``0.0.0.0`` / AAAA = ``::0``. (**NULL** shape.)
+  - ``logging='nxdomain_log'`` → ``logging_type='3'`` → ``operate()`` returns a
+    bare ``RCODE_NXDOMAIN`` (no records). (**NXDOMAIN** shape, issue #31.)
 
   A matched subdomain is NOT in ``dataDB`` and is NOT blocked (exact match only).
-  NXDOMAIN is NEVER the response for a normal feed match (verified on the live
-  box); the only NXDOMAIN path is SafeSearch.
+  Before issue #31 NXDOMAIN was reachable only via SafeSearch; it is now also a
+  user-selectable DNSBL block response (the ``nxdomain``/``nxdomain_log`` modes).
 
   Probed ON-BOX (``drill @127.0.0.1`` over SSH): verified on a live box that
   python-mode DNSBL has NO localhost exemption — a blocked name returns its block
@@ -229,6 +231,34 @@ def test_dnsbl_exact_null(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> 
         assert h.is_null_ip(aaaa, null_ip="::0") or not aaaa.records, (
             f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
         )
+
+
+def test_dnsbl_exact_nxdomain(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """Python-mode NXDOMAIN block (issue #31): a bare NXDOMAIN, no records.
+
+    ``logging='nxdomain_log'`` → ``logging_type='3'`` → ``operate()`` returns
+    ``RCODE_NXDOMAIN`` with no DNSMessage (neither the VIP nor the 0.0.0.0 null
+    shape). The rcode is name-level, so BOTH the A and AAAA queries answer
+    NXDOMAIN. A unique non-HSTS-preload ``.com`` is used so the result is the
+    NXDOMAIN block path itself, not an Unbound built-in ``local-zone`` shadowing
+    an RFC-6761 TLD (which would also NXDOMAIN, ahead of DNSBL). Contrast the
+    VIP/null cases above: same feed match, different per-list ``logging`` →
+    different response shape, proving '3' is a distinct, live branch.
+    """
+    domain = h.unique_domain("nxdomain")
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_nxdomain.txt", f"{domain}\n")
+    spec = h.DnsblCase(
+        aliasname="smokenxd",
+        feed_url=feed_url,
+        header="smokenxd",
+        mode=h.DnsblMode.NXDOMAIN,
+    )
+    with h.CaseContext(deployed_vm, spec):
+        a = h.dns_probe(deployed_vm, domain, "A")
+        assert h.is_nxdomain(a), f"{domain} A expected NXDOMAIN (no records), got {a}"
+        assert not h.is_vip(a) and not h.is_null_ip(a), f"{domain} must be a bare NXDOMAIN, not a VIP/null record: {a}"
+        aaaa = h.dns_probe(deployed_vm, domain, "AAAA")
+        assert h.is_nxdomain(aaaa), f"{domain} AAAA expected NXDOMAIN (no records), got {aaaa}"
 
 
 def test_dnsbl_hsts_override_forces_null(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -56,6 +56,7 @@ def _seed_decision(name: str) -> P.Decision:
         in_whitelist=False,
         in_hsts=False,
         null_blocking=False,
+        nxdomain=False,
         log_type="1",
         b_type="DNSBL",
         p_type="DNSBL",

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -16,6 +16,7 @@ from unboundmodule import (
     MODULE_FINISHED,
     MODULE_WAIT_MODULE,
     RCODE_NOERROR,
+    RCODE_NXDOMAIN,
     DNSMessage,
 )
 
@@ -89,6 +90,7 @@ def _dnsbl_decision(**kw: Any) -> Any:
         "in_whitelist": False,
         "in_hsts": False,
         "null_blocking": True,
+        "nxdomain": False,
         "log_type": "",
         "b_type": "",
         "p_type": "",
@@ -654,6 +656,7 @@ class TestGetDetailsDnsblQtype:
                 in_whitelist=False,
                 in_hsts=False,
                 null_blocking=False,
+                nxdomain=False,
                 log_type="1",
                 b_type="DNSBL_Python",
                 p_type="Python",
@@ -726,6 +729,7 @@ class TestGetDetailsDnsblQtype:
             in_whitelist=False,
             in_hsts=False,
             null_blocking=False,
+            nxdomain=False,
             log_type="1",
             b_type="TLD",
             p_type="Python",
@@ -766,6 +770,51 @@ class TestGetDetailsDnsblQtype:
         )
         pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": "1.2.3.4"})
         assert len(self._dnsbl_fields(lines)) == 1  # attributed despite mixed-case query
+
+
+class TestGetDetailsDnsblNxdomain:
+    """Issue #31: the per-event logger must treat the two NXDOMAIN variants like the
+    two null variants -- "3" (NXDOMAIN logging) writes a dnsbl.log line, "4" (NXDOMAIN
+    no logging) is silenced, exactly as "0"/"2" are for null. Same skip gate
+    (log_type in ("2","4")), so the no-logging branch is shared and pinned here.
+    """
+
+    def _emit(self, monkeypatch: Any, log_type: str) -> list[tuple[str, str]]:
+        # Given a memoized NXDOMAIN block for blocked.com with the given log flag
+        monkeypatch.setitem(pfb_unbound.pfb, "python_nolog", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_resolver_con", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_dnsbl_con", False)
+        dnsbl = _dnsbl_decision(
+            is_found=True,
+            nxdomain=True,
+            log_type=log_type,
+            b_type="DNSBL",
+            p_type="Python",
+            feed="F",
+            group="G",
+            b_eval="blocked.com",
+        )
+        monkeypatch.setattr(pfb_unbound, "decisionDB", {"blocked.com": pfb_unbound.Decision(dnsbl=dnsbl)})
+        lines: list[tuple[str, str]] = []
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: lines.append((path, line)))
+        qstate = types.SimpleNamespace(
+            qinfo=types.SimpleNamespace(qname_str="blocked.com.", qtype_str="A"),
+            return_msg=None,
+        )
+        # When the logger runs for that block
+        pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": "1.2.3.4"})
+        return lines
+
+    def test_nxdomain_logging_writes_a_line(self, monkeypatch: Any) -> None:
+        # Then the "3" variant records the block to dnsbl.log + unified.log
+        lines = self._emit(monkeypatch, "3")
+        assert any(path.endswith("dnsbl.log") for path, _ in lines)
+
+    def test_nxdomain_no_logging_is_silent(self, monkeypatch: Any) -> None:
+        # Then the "4" variant writes nothing -- contrast the "3" case: same NXDOMAIN
+        # block, logging flag flipped, proves the skip gate is a real branch.
+        lines = self._emit(monkeypatch, "4")
+        assert lines == []
 
 
 class TestGetOType:
@@ -928,6 +977,41 @@ class TestOperateDnsbl:
         assert qstate.return_rcode == RCODE_NOERROR
         answers = DNSMessage.instances[-1].answer
         assert any(pfb_unbound.pfb["dnsbl_ipv4"] in a for a in answers)
+
+    def test_nxdomain_mode_returns_bare_nxdomain(self, monkeypatch: Any) -> None:
+        # Issue #31. Scenario: a DNSBL hit in NXDOMAIN-logging mode ("3").
+        #   Given evil.com on a feed whose Logging/Blocking mode is NXDOMAIN ("3")
+        #   When operate() handles an A query
+        #   Then it FINISHES with rcode NXDOMAIN, builds NO synthetic answer message,
+        #        and the reply is left uncached (#43) -- contrast the VIP test above,
+        #        which returns NOERROR + a dnsbl_ipv4 record.
+        self._enable(monkeypatch)
+        add_data("evil.com", log="3", index=0)
+        set_feed_group(0, "TestFeed", "TestGroup")
+        qstate = make_qstate("evil.com.", qtype=RR_A)
+        assert qstate.no_cache_store == 0  # before-state: cacheable by default
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        assert qstate.return_rcode == RCODE_NXDOMAIN
+        assert qstate.return_msg is None  # no A/AAAA reply synthesized
+        assert DNSMessage.instances == []  # the VIP/null DNSMessage path was NOT taken
+        assert qstate.no_cache_store == 1  # not cached, same as VIP/null blocks
+        assert pfb_unbound.decisionDB["evil.com"].dnsbl.nxdomain is True
+
+    def test_nxdomain_no_logging_mode_also_returns_nxdomain(self, monkeypatch: Any) -> None:
+        # The "4" (no-logging) variant produces the IDENTICAL block SHAPE as "3"; only
+        # the dnsbl.log line differs (covered in TestGetDetailsDnsblNxdomain). Pins that
+        # the response shape is logging-independent.
+        self._enable(monkeypatch)
+        add_data("evil.com", log="4", index=0)
+        set_feed_group(0, "TestFeed", "TestGroup")
+        qstate = make_qstate("evil.com.", qtype=RR_A)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        assert qstate.return_rcode == RCODE_NXDOMAIN
+        assert DNSMessage.instances == []
 
     def test_block_sets_no_cache_store(self, monkeypatch: Any) -> None:
         # #43: the synthetic block reply must NOT be stored in Unbound's C message
@@ -1753,6 +1837,7 @@ class TestEvaluateDomainGolden:
         assert dec.group == "BadGroup"
         assert dec.log_type == "1"
         assert dec.null_blocking is False  # log_type="1" and not in_hsts -> null_blocking=False
+        assert dec.nxdomain is False  # VIP is neither null nor NXDOMAIN (issue #31 contrast)
 
     def test_data_exact_does_not_match_subdomain(self) -> None:
         data_db: dict = {"evil.com": {"log": "1", "index": 0}}
@@ -1910,6 +1995,62 @@ class TestEvaluateDomainGolden:
         dec = evaluate_domain("evil.com", "evil.com", "com", False, cfg, containers)
         assert dec.is_found is True
         assert dec.null_blocking is True  # log_type="2" != "1" → no null_blocking flip
+        assert dec.nxdomain is False  # null block is not NXDOMAIN (issue #31 contrast)
+
+
+class TestEvaluateDomainNxdomain:
+    """Issue #31: log_type "3"/"4" select the NXDOMAIN block shape in evaluate_domain.
+
+    Scenario: a DNSBL data hit whose per-list Logging/Blocking mode is one of the two
+    new NXDOMAIN variants.
+      Background: a feed entry for evil.com mapped to feed F / group G.
+      Given the entry's log flag is "3" (NXDOMAIN logging) or "4" (NXDOMAIN no logging)
+      When evaluate_domain resolves the block
+      Then dec.nxdomain is True, dec.null_blocking stays True (no 0.0.0.0 reply), and
+           dec.log_type carries the raw flag through for the logger to branch on.
+    Branch coverage pairs these against the VIP ("1", nxdomain False) and null ("2",
+    nxdomain False) cases above, proving "3"/"4" is a real, distinct branch.
+    """
+
+    def _dec(self, log: str, **cfg_kw: Any) -> Any:
+        # Given a single-entry dataDB whose log flag is `log`
+        data_db: dict = {"evil.com": {"log": log, "index": 0}}
+        fgi_db: dict = {0: {"feed": "F", "group": "G"}}
+        containers = _make_containers(dataDB=data_db, feedGroupIndexDB=fgi_db)
+        cfg = _make_cfg(dataDB=True, **cfg_kw)
+        # When the domain is evaluated
+        return evaluate_domain("evil.com", "evil.com", "com", False, cfg, containers)
+
+    def test_log_type_3_selects_nxdomain_logging(self) -> None:
+        dec = self._dec("3")
+        # Then it is a block flagged NXDOMAIN, not a null/VIP reply
+        assert dec.is_found is True
+        assert dec.nxdomain is True
+        assert dec.null_blocking is True  # no synthesized 0.0.0.0 / VIP record
+        assert dec.log_type == "3"  # logger logs this variant
+
+    def test_log_type_4_selects_nxdomain_no_logging(self) -> None:
+        dec = self._dec("4")
+        assert dec.is_found is True
+        assert dec.nxdomain is True
+        assert dec.null_blocking is True
+        assert dec.log_type == "4"  # logger silences this variant
+
+    def test_nxdomain_is_immune_to_hsts(self) -> None:
+        # NXDOMAIN avoids the TLS handshake HSTS guards, so the HSTS null-override
+        # (which forces a VIP "1" block to null) must NOT touch an NXDOMAIN block.
+        # Given evil.com is an HSTS name AND its mode is NXDOMAIN-logging ("3")
+        data_db: dict = {"evil.com": {"log": "3", "index": 0}}
+        hsts_db: dict = {"evil.com": 0}
+        fgi_db: dict = {0: {"feed": "F", "group": "G"}}
+        containers = _make_containers(dataDB=data_db, hstsDB=hsts_db, feedGroupIndexDB=fgi_db)
+        cfg = _make_cfg(dataDB=True, hstsDB=True, hsts_tlds=())
+        # When evaluated
+        dec = evaluate_domain("evil.com", "evil.com", "com", False, cfg, containers)
+        # Then HSTS is detected but the block stays NXDOMAIN (not reshaped to null/VIP)
+        assert dec.in_hsts is True
+        assert dec.nxdomain is True
+        assert dec.null_blocking is True
 
 
 class TestEvaluateNoaaaGolden:

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1007,11 +1007,16 @@ class TestOperateDnsbl:
         add_data("evil.com", log="4", index=0)
         set_feed_group(0, "TestFeed", "TestGroup")
         qstate = make_qstate("evil.com.", qtype=RR_A)
+        assert qstate.no_cache_store == 0  # before-state: cacheable by default
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED
+        # IDENTICAL shape to the "3" case: bare NXDOMAIN, no message, uncached, nxdomain.
         assert qstate.return_rcode == RCODE_NXDOMAIN
+        assert qstate.return_msg is None
         assert DNSMessage.instances == []
+        assert qstate.no_cache_store == 1
+        assert pfb_unbound.decisionDB["evil.com"].dnsbl.nxdomain is True
 
     def test_block_sets_no_cache_store(self, monkeypatch: Any) -> None:
         # #43: the synthetic block reply must NOT be stored in Unbound's C message
@@ -2036,10 +2041,12 @@ class TestEvaluateDomainNxdomain:
         assert dec.null_blocking is True
         assert dec.log_type == "4"  # logger silences this variant
 
-    def test_nxdomain_is_immune_to_hsts(self) -> None:
+    def test_nxdomain_does_not_inherit_hsts_attribution(self) -> None:
         # NXDOMAIN avoids the TLS handshake HSTS guards, so the HSTS null-override
-        # (which forces a VIP "1" block to null) must NOT touch an NXDOMAIN block.
-        # Given evil.com is an HSTS name AND its mode is NXDOMAIN-logging ("3")
+        # (which forces a VIP "1" block to null) must NOT touch an NXDOMAIN block AND
+        # the block must not be MISreported as HSTS in the logs (issue #31 / PR review).
+        # Given evil.com is in the HSTS DB AND its mode is NXDOMAIN-logging ("3") --
+        # hsts_check_domain WILL match it, so without the clear it would set in_hsts/p_type.
         data_db: dict = {"evil.com": {"log": "3", "index": 0}}
         hsts_db: dict = {"evil.com": 0}
         fgi_db: dict = {0: {"feed": "F", "group": "G"}}
@@ -2047,10 +2054,12 @@ class TestEvaluateDomainNxdomain:
         cfg = _make_cfg(dataDB=True, hstsDB=True, hsts_tlds=())
         # When evaluated
         dec = evaluate_domain("evil.com", "evil.com", "com", False, cfg, containers)
-        # Then HSTS is detected but the block stays NXDOMAIN (not reshaped to null/VIP)
-        assert dec.in_hsts is True
+        # Then the block stays NXDOMAIN (not reshaped to null/VIP) AND reports as a clean
+        # Python block -- the HSTS attribution is cleared, not carried into the decision.
         assert dec.nxdomain is True
         assert dec.null_blocking is True
+        assert dec.in_hsts is False  # HSTS membership did not influence NXDOMAIN -> cleared
+        assert dec.p_type == "Python"  # mislabeled "HSTS"/"HSTS_TLD" before the fix
 
 
 class TestEvaluateNoaaaGolden:


### PR DESCRIPTION
## Summary

Implements issue #31: adds **NXDOMAIN** as a user-selectable Python-mode DNSBL block response, in two variants — **NXDOMAIN (logging)** and **NXDOMAIN (no logging)** — alongside the existing VIP and Null Block modes. Also reorders the Logging/Blocking dropdowns so the two near-identical Null Block entries (and the two NXDOMAIN entries) sit adjacent.

The default is **unchanged** (DNSBL WebServer/VIP).

## Behaviour

NXDOMAIN mode returns a bare `RCODE_NXDOMAIN` with no answer records — no `DNSMessage`, no sinkhole IP, no DNSBL webserver redirect. Consequences:

- The DNSBL block page is bypassed (documented in the field help text).
- HSTS's VIP→null override does not apply (NXDOMAIN never triggers a TLS handshake).
- The `nxdomain_log` variant logs to `dnsbl.log`; `nxdomain` is silent (same skip gate as null-no-log). Both still increment the per-group counter.

## Mode → config → matcher

| Dropdown | `logging` value | `logging_type` | Response |
|---|---|---|---|
| DNSBL WebServer/VIP (default) | `enabled` | `1` | NOERROR + VIP |
| Null Block (logging) | `disabled_log` | `0` | NOERROR + 0.0.0.0/::0, logged |
| Null Block (no logging) | `disabled` | `2` | NOERROR + 0.0.0.0/::0, silent |
| NXDOMAIN (logging) | `nxdomain_log` | `3` | NXDOMAIN, logged |
| NXDOMAIN (no logging) | `nxdomain` | `4` | NXDOMAIN, silent |

## Changes

- **`pfb_unbound.py`**: `DnsblDecision` gains an `nxdomain` axis; `evaluate_domain` sets it for `log_type` `"3"`/`"4"`; `operate()` emits NXDOMAIN ahead of the VIP/null path (uncached, #43); the logger drops the line for `"4"` like it does for `"2"`.
- **`pfblockerng.inc`**: map `nxdomain_log → '3'`, `nxdomain → '4'`.
- **Web UI** (`pfblockerng_dnsbl.php`, `pfblockerng_category.php`, `pfblockerng_category_edit.php`): the two new options + help text in the global, inline, and per-group dropdowns, reordered; the inline-save whitelist (`$aliaslog_values`) and the `pfblockerng_alerts.php` `logging_type` mirror updated.

## Tests

- Unit branch coverage in `tests/test_pfb_unbound.py`: `evaluate_domain` `"3"`/`"4"` → `nxdomain` (with VIP/null contrast + HSTS immunity); `operate()` NXDOMAIN shape (rcode, no `DNSMessage`, uncached); logger log vs no-log split.
- Live-VM NXDOMAIN case re-added to the ADR-04 smoke matrix (`tests/smoke/`), with the `DnsblMode.NXDOMAIN` shape wired into `helpers.py`.

Local gate green: pytest (1124), ruff, mypy, PHPStan, PHPUnit (153), `php -l`.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NXDOMAIN blocking response mode with two variants: "NXDOMAIN (logging)" and "NXDOMAIN (no logging)". When selected, blocked queries return a bare NXDOMAIN (no sinkhole IP), and caching behavior is adjusted accordingly. Options are available globally and per-DNSBL.

* **Tests**
  * Added comprehensive tests covering NXDOMAIN behavior and logging variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->