### PR TITLE
pfblockerng: unify DNSBL block-mode label to "Null Blocking"

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1224,7 +1224,7 @@ function pfb_global() {
 	$pfb['dnsbl_global_log']= isset($pfb['dnsblconfig']['global_log']) 	? $pfb['dnsblconfig']['global_log']	 : '';		// Global Logging/Blocking mode
 
 	$pfb['dnsbl_py_reply']	= $pfb['dnsblconfig']['pfb_py_reply'];			// DNSBL Resolver python DNS Reply logging
-	$pfb['dnsbl_hsts']	= $pfb['dnsblconfig']['pfb_hsts'];			// DNSBL Resolver python block HSTS via Null Block mode
+	$pfb['dnsbl_hsts']	= $pfb['dnsblconfig']['pfb_hsts'];			// DNSBL Resolver python block HSTS via Null Blocking mode
 	$pfb['dnsbl_idn']	= $pfb['dnsblconfig']['pfb_idn'];			// DNSBL Resolver python block IDN domains
 	$pfb['dnsbl_regex']	= $pfb['dnsblconfig']['pfb_regex'];			// DNSBL Resolver python regex
 	$pfb['dnsbl_regex_list']= $pfb['dnsblconfig']['pfb_regex_list'];		// DNSBL Resolver python regex list

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -505,8 +505,8 @@ if (isset($savemsg)) {
 						$log_error = '';
 						if ($gtype == 'dnsbl') {
 							$log_options = ['enabled'	=> 'DNSBL WebServer/VIP',
-									'disabled_log'	=> 'Null Block (logging)',
-									'disabled'	=> 'Null Block (no logging)',
+									'disabled_log'	=> 'Null Blocking (logging)',
+									'disabled'	=> 'Null Blocking (no logging)',
 									'nxdomain_log'	=> 'NXDOMAIN (logging)',
 									'nxdomain'	=> 'NXDOMAIN (no logging)'];
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -116,8 +116,8 @@ $options_dnsbl_allow_int	= $options_dnsbl_interface;
 $options_global_log_txt = 'Default: <strong>No Global mode</strong><br />'
 			. 'Enabling this option will override the individual DNSBL Group "Logging/Blocking" settings!<br /><br />'
 			. '&#8226 <strong>DNSBL WebServer/VIP</strong>, Domains are sinkholed to the DNSBL VIP and logged via the DNSBL WebServer.<br />'
-			. '&#8226 <strong>Null Block (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br />'
-			. '&#8226 <strong>Null Block (no logging)</strong>, Utilize \'0.0.0.0\' with no logging.<br />'
+			. '&#8226 <strong>Null Blocking (logging)</strong>, Utilize \'0.0.0.0\' with logging.<br />'
+			. '&#8226 <strong>Null Blocking (no logging)</strong>, Utilize \'0.0.0.0\' with no logging.<br />'
 			. '&#8226 <strong>NXDOMAIN (logging)</strong>, Reply NXDOMAIN with logging. The DNSBL block page is bypassed.<br />'
 			. '&#8226 <strong>NXDOMAIN (no logging)</strong>, Reply NXDOMAIN with no logging. The DNSBL block page is bypassed.<br />'
 			. 'Blocked domains will be reported to the Alert/Block Table.<br /><br />'
@@ -125,8 +125,8 @@ $options_global_log_txt = 'Default: <strong>No Global mode</strong><br />'
 
 $options_global_log	= [	''		=> 'No Global mode',
 				'enabled'	=> 'DNSBL WebServer/VIP',
-				'disabled_log'	=> 'Null Block (logging)',
-				'disabled'	=> 'Null Block (no logging)',
+				'disabled_log'	=> 'Null Blocking (logging)',
+				'disabled'	=> 'Null Blocking (no logging)',
 				'nxdomain_log'	=> 'NXDOMAIN (logging)',
 				'nxdomain'	=> 'NXDOMAIN (no logging)'];
 
@@ -787,10 +787,10 @@ $section->addInput(new Form_Checkbox(
 	'Enable',
 	$pconfig['pfb_hsts'] === 'on' ? true:false,
 	'on'
-))->setHelp('Enable the DNSBL <strong title="Utilizes 0.0.0.0 instead of the DNSBL VIP">Null Block mode</strong> for HSTS domains.<br />'
+))->setHelp('Enable the DNSBL <strong title="Utilizes 0.0.0.0 instead of the DNSBL VIP">Null Blocking mode</strong> for HSTS domains.<br />'
 	. 'Blocked domains that are in the <a target=_"blank" href="https://hstspreload.org/">HSTS preload</a> browser'
 	. ' <a target=_"blank" href="https://raw.githubusercontent.com/chromium/chromium/master/net/http/transport_security_state_static.json">list</a>'
-	. ' will use the Null Block Mode which *may* prevent Browser Certificate Errors.<br />'
+	. ' will use the Null Blocking Mode which *may* prevent Browser Certificate Errors.<br />'
 	. '<span class="text-danger">Note:</span> This option will not block HSTS domains, unless those Domains are added via the Feeds/Customlists.'
 );
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -249,7 +249,7 @@ class DnsblCase:
     # to the queried name, b_type '_CNAME'). Off (default): only the queried name is
     # checked, so a name whose CNAME target is blocked still resolves.
     cname_validation: bool = False
-    # hsts -> the "HSTS via Null Block mode" toggle (CFG_DNSBL_SETTINGS/pfb_hsts,
+    # hsts -> the "HSTS via Null Blocking mode" toggle (CFG_DNSBL_SETTINGS/pfb_hsts,
     # inc:847 -> ini python_hsts). When on, pfb_unbound.py loads pfb_py_hsts.txt into
     # hstsDB; a VIP-mode (logging='enabled', log_type '1') block on an HSTS-preload
     # name keeps null_blocking=True -> NULL instead of the VIP (evaluate_domain:
@@ -1165,7 +1165,7 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         # CNAME chain and block the original name if a target is blocklisted.
         settings["pfb_cname"] = "on"
     if spec.hsts is not None:
-        # "HSTS via Null Block mode" (inc:847 -> ini python_hsts). On: a VIP-mode
+        # "HSTS via Null Blocking mode" (inc:847 -> ini python_hsts). On: a VIP-mode
         # block on an HSTS-preload name is forced to NULL (pfb_unbound.py loads
         # pfb_py_hsts.txt -> hstsDB). Only emitted when the case sets it explicitly,
         # so the default matrix stays byte-for-byte unchanged. See add_hsts_name.


### PR DESCRIPTION
## Summary

Cosmetic follow-up to #134: unify the DNSBL **Logging/Blocking** mode label on **"Null Blocking"**.

The same null-block mode was labeled inconsistently across pages:

- `pfblockerng_dnsbl.php` (global) + `pfblockerng_category.php` (inline) → **"Null Block"**
- `pfblockerng_category_edit.php` (per-group) → **"Null Blocking"**

Converged on **"Null Blocking"** because it matches both:

- The repo's own sibling labels — every other `<X> Blocking` mode on the DNSBL page is a gerund: *Wildcard / IDN / Regex / DNSBL / DoQ / DoT / QUIC Blocking*.
- DNS-tooling convention — Pi-hole's `BLOCKINGMODE` (the canonical "blocking mode" framing). The `NXDOMAIN` label is already the RFC-exact term and is unchanged.

## Changes

- `pfblockerng_dnsbl.php`: global dropdown labels + help bullets, and the HSTS help text (`Null Block mode` → `Null Blocking mode`).
- `pfblockerng_category.php`: inline dropdown labels.
- `pfblockerng.inc` + `tests/smoke/helpers.py`: the internal comments that quoted "Null Block mode", for coherence.

**Display-only.** The stored config keys (`enabled` / `disabled` / `disabled_log` / `nxdomain_log` / `nxdomain`) are untouched, so existing configs need **no migration**.

Part of the review feedback on #134 (deferred there as out-of-scope; this is the standalone cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology and help text throughout the interface and codebase for consistency: "Null Block" renamed to "Null Blocking" in logging/blocking mode options and HSTS-related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->