### PR TITLE
tests: ADR-08 cover the full Japanese Han+Hiragana+Katakana 3-script label

### DIFF
--- a/tests/fixtures/adr08_corpus/corpus.json
+++ b/tests/fixtures/adr08_corpus/corpus.json
@@ -84,6 +84,18 @@
       "note": "Japanese 'domain name', Han+Katakana (Highly-Restrictive legit)"
     },
     {
+      "a_label": "xn--w8jxqd8946c",
+      "decoded": "メモ書き",
+      "label_class": "japanese-han+hiragana+katakana",
+      "resolved_scripts": [
+        "Han",
+        "Hiragana",
+        "Katakana"
+      ],
+      "expected_severity": "legit",
+      "note": "Japanese 'memo writing', ALL THREE scripts in one label (Katakana メモ + Han 書 + Hiragana き) -> Highly-Restrictive legit; the canonical real-Japanese 0-FP case"
+    },
+    {
       "a_label": "xn--3e0bk47br7k",
       "decoded": "한국어",
       "label_class": "korean-hangul",

--- a/tests/fixtures/adr08_spec/decision_table.json
+++ b/tests/fixtures/adr08_spec/decision_table.json
@@ -111,6 +111,16 @@
       "intent": "Latin+CJK FP-guard: Han+Katakana (Japanese 'domain name') is UTS#39 Highly Restrictive -> legit. The single most important non-block case: a naive 'any multi-script -> block' would FALSE-POSITIVE here."
     },
     {
+      "id": "japanese_han_hiragana_katakana",
+      "a_label": "xn--w8jxqd8946c",
+      "decoded": "メモ書き",
+      "resolved_scripts": ["Han", "Hiragana", "Katakana"],
+      "restriction_level": "highly_restrictive",
+      "severity": "legit",
+      "action": "none",
+      "intent": "Latin+CJK FP-guard, full Japanese: ALL THREE scripts (Katakana メモ + Han 書 + Hiragana き) co-occur in ONE label -> UTS#39 Highly Restrictive -> legit. Real Japanese routinely mixes kanji + okurigana hiragana + katakana; this must NOT false-positive."
+    },
+    {
       "id": "korean_han_hangul",
       "a_label": "xn--eqr704t9deq8o",
       "decoded": "도메인名",

--- a/tests/test_adr08_analyzer.py
+++ b/tests/test_adr08_analyzer.py
@@ -136,6 +136,8 @@ class TestScriptOf:
             ("α", "Greek"),  # U+03B1
             ("中", "Han"),
             ("テ", "Katakana"),
+            ("の", "Hiragana"),  # U+306E
+            ("き", "Hiragana"),  # U+304D
             ("한", "Hangul"),
             ("ا", "Arabic"),
         ],
@@ -180,6 +182,7 @@ class TestResolvedScriptSet:
     def test_single_script_label(self) -> None:
         assert A.resolved_script_set("münchen") == {"Latin"}
         assert A.resolved_script_set("россия") == {"Cyrillic"}
+        assert A.resolved_script_set("ひらがな") == {"Hiragana"}  # all-Hiragana
 
     def test_digits_and_hyphen_are_transparent(self) -> None:
         # ASCII letters+digits+hyphen -> only Latin (Common digits/hyphen dropped).
@@ -189,6 +192,8 @@ class TestResolvedScriptSet:
         # Han + Katakana legit CJK mix; Latin + Cyrillic homograph mix.
         assert A.resolved_script_set("ドメイン名") == {"Han", "Katakana"}
         assert A.resolved_script_set("аpple") == {"Cyrillic", "Latin"}
+        # Full Japanese: Katakana (メモ) + Han (書) + Hiragana (き) all in one label.
+        assert A.resolved_script_set("メモ書き") == {"Han", "Hiragana", "Katakana"}
 
     def test_scriptless_label_is_empty_set(self) -> None:
         # Empty, control char, emoji: no letter-script -> empty set (flagged later).
@@ -216,6 +221,8 @@ class TestRestrictionLevel:
         # Latin/Han + CJK companions -> Highly Restrictive (the legit multi allow-set).
         assert A.restriction_level({"Han", "Katakana"}) == A.LEVEL_HIGHLY_RESTRICTIVE
         assert A.restriction_level({"Han", "Hangul"}) == A.LEVEL_HIGHLY_RESTRICTIVE
+        # Full Japanese: Han + Hiragana + Katakana together is still Highly Restrictive.
+        assert A.restriction_level({"Han", "Hiragana", "Katakana"}) == A.LEVEL_HIGHLY_RESTRICTIVE
 
     def test_non_restrictive_mix(self) -> None:
         # A non-allow-set multi-script mix -> Non Restrictive.
@@ -256,6 +263,19 @@ class TestCjkLegitIsZeroFalsePositive:
         scripts = A.resolved_script_set(decoded)
         assert scripts == {"Han", "Hangul"} and len(scripts) >= 2
         assert A.severity_of(decoded) == A.SEV_LEGIT
+
+    def test_japanese_all_three_scripts_is_legit(self) -> None:
+        # Given メモ書き ('memo writing') -- Katakana (メモ) + Han (書) + Hiragana (き)
+        # in ONE label, the canonical real-Japanese form (kanji + okurigana hiragana +
+        # katakana that appears in countless legitimate .jp domains).
+        decoded = A.decode_idn_label("xn--w8jxqd8946c")
+        scripts = A.resolved_script_set(decoded)
+        # When we observe all THREE Japanese scripts co-occur (a naive any-mix rule blocks)...
+        assert scripts == {"Han", "Hiragana", "Katakana"} and len(scripts) == 3
+        # Then it is UTS#39 Highly Restrictive -> legit, end-to-end through classify_idn.
+        assert A.restriction_level(scripts) == A.LEVEL_HIGHLY_RESTRICTIVE
+        assert A.severity_of(decoded) == A.SEV_LEGIT
+        assert A.classify_idn("xn--w8jxqd8946c").severity == A.SEV_LEGIT
 
 
 class TestMaliciousConfusablePairs:

--- a/tests/test_adr08_decision_spec.py
+++ b/tests/test_adr08_decision_spec.py
@@ -187,12 +187,14 @@ SCRIPT_MAP: dict[int, list[str]] = {
     0x0E44: ["Thai"],
     0x13A0: ["Cherokee"],  # Ꭰ
     0x2C81: ["Coptic"],  # ⲁ
+    0x304D: ["Hiragana"],  # き
     0x30A4: ["Katakana"],
     0x30B9: ["Katakana"],
     0x30C6: ["Katakana"],
     0x30C8: ["Katakana"],
     0x30C9: ["Katakana"],
     0x30E1: ["Katakana"],
+    0x30E2: ["Katakana"],  # モ
     0x30F3: ["Katakana"],
     0x4E2D: ["Han"],
     0x456E: ["Han"],  # xn--google junk ideograph
@@ -203,6 +205,7 @@ SCRIPT_MAP: dict[int, list[str]] = {
     0x56FD: ["Han"],
     0x6587: ["Han"],
     0x65E5: ["Han"],
+    0x66F8: ["Han"],  # 書
     0x672C: ["Han"],
     0x8A9E: ["Han"],
     0xAD6D: ["Hangul"],


### PR DESCRIPTION
## What

Closes a CJK test-coverage gap in ADR-08. The suite covered **Han+Katakana** (Japanese) and **Han+Hangul** (Korean), but **Hiragana appeared nowhere**, and no single label exercised **all three Japanese scripts together** — the canonical real-Japanese form (kanji + okurigana hiragana + katakana) that shows up in countless legitimate `.jp` domains.

The production analyzer already classifies this correctly (all three ∈ UTS#39 Highly Restrictive → legit); this PR **pins** it so a future change can't regress the 0-FP guarantee on real Japanese.

## Changes (test-only, additive)

- **Direct analyzer assertions** (`tests/test_adr08_analyzer.py`): Hiragana in `script_of`; a pure-Hiragana single-script case; and `resolved_script_set` / `restriction_level` / `severity_of` / `classify_idn` for **メモ書き** (Katakana メモ + Han 書 + Hiragana き) → Highly Restrictive → legit, end-to-end.
- **Corpus + oracle** (`adr08_corpus/corpus.json`, `adr08_spec/decision_table.json`, oracle `SCRIPT_MAP`): a new `legit_single_label` / `single_label` entry (`xn--w8jxqd8946c`) + its three code points in `SCRIPT_MAP` (`き` U+304D is the **first Hiragana entry**). So the oracle cross-check and the FP/TP measurement now include the 3-script case.

## Result

`measure_fp_tp.py`: **FP 0/21** (was 0/20), **CJK FP 0**, **TP 6/6** — GO. Full suite **1312 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test fixtures and cases for Japanese script handling and resolution
  * Extended test coverage for mixed Hiragana, Katakana, and Han character combinations
  * Updated character mapping data for improved validation accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->