### PR TITLE
pfblockerng: ADR-08 IDN 'Always' label/help polish + live-VM smoke & UI tiers

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2448,14 +2448,14 @@ $section->addInput(new Form_Select(
 	$pconfig['pfb_idn'],
 	array(
 		''		=> 'Off',
-		'all'		=> 'Always',
 		'confusable'	=> 'Confusable',
+		'all'		=> 'Always',
 	)
 ))->setHelp('IDN handling (not Regex based).<ul>'
 		. '<li><strong>Off</strong> - no IDN action.</li>'
-		. '<li><strong>Always</strong> - block every IDN/\'xn--\' domain (blunt).</li>'
 		. '<li><strong>Confusable</strong> - block only cross-script homoglyphs (Latin/Cyrillic/Greek mixes, '
-		. 'including Cyrillic+Greek). Does not catch whole-script confusables or pure-ASCII typosquats.</li></ul>');
+		. 'including Cyrillic+Greek). Does not catch whole-script confusables or pure-ASCII typosquats.</li>'
+		. '<li><strong>Always</strong> - block every IDN/\'xn--\' domain (blunt).</li></ul>');
 
 $section->addInput(new Form_Checkbox(
 	'pfb_idn_block_malicious',

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2448,12 +2448,14 @@ $section->addInput(new Form_Select(
 	$pconfig['pfb_idn'],
 	array(
 		''		=> 'Off',
-		'all'		=> 'All-IDN',
+		'all'		=> 'Always',
 		'confusable'	=> 'Confusable',
 	)
-))->setHelp('IDN handling (not Regex based). <strong>Off</strong>: no IDN action. <strong>All-IDN</strong>: block every IDN/\'xn--\' domain (blunt). '
-		. '<strong>Confusable</strong>: block only cross-script homoglyphs (Latin/Cyrillic/Greek mixes, including Cyrillic+Greek). '
-		. 'Does not catch whole-script confusables or pure-ASCII typosquats.');
+))->setHelp('IDN handling (not Regex based).<ul>'
+		. '<li><strong>Off</strong> - no IDN action.</li>'
+		. '<li><strong>Always</strong> - block every IDN/\'xn--\' domain (blunt).</li>'
+		. '<li><strong>Confusable</strong> - block only cross-script homoglyphs (Latin/Cyrillic/Greek mixes, '
+		. 'including Cyrillic+Greek). Does not catch whole-script confusables or pure-ASCII typosquats.</li></ul>');
 
 $section->addInput(new Form_Checkbox(
 	'pfb_idn_block_malicious',

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -256,6 +256,16 @@ class DnsblCase:
     # ``log_type == '1' and not in_hsts``). ``None`` (default) emits nothing -> the
     # existing matrix is byte-for-byte unchanged; True/False forces pfb_hsts on/off.
     hsts: bool | None = None
+    # idn_mode -> the "IDN Blocking" selector (CFG_DNSBL_SETTINGS/pfb_idn, ADR-08).
+    # 'off'/'' -> no IDN action; 'all' -> block every xn-- (legacy blunt); 'confusable'
+    # -> the TR39 mixed-script homoglyph analyzer (pfb_unbound.py classify_idn). ``None``
+    # (default) emits nothing -> the existing matrix is unchanged. The two sub-toggles
+    # apply only in Confusable mode (pfb_unbound.py idn_confusable_action): block_malicious
+    # (default ON) blocks a clearly-malicious homoglyph, else alerts; escalate_suspicious
+    # (default OFF) escalates the suspicious/flagged tier from alert to block.
+    idn_mode: str | None = None
+    idn_block_malicious: bool | None = None
+    idn_escalate_suspicious: bool | None = None
 
     @property
     def alias(self) -> str:
@@ -1287,6 +1297,16 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         # pfb_py_hsts.txt -> hstsDB). Only emitted when the case sets it explicitly,
         # so the default matrix stays byte-for-byte unchanged. See add_hsts_name.
         settings["pfb_hsts"] = "on" if spec.hsts else "off"
+    if spec.idn_mode is not None:
+        # "IDN Blocking" selector (ADR-08; CFG_DNSBL_SETTINGS/pfb_idn -> ini idn_mode).
+        # 'confusable' runs the TR39 homoglyph analyzer; the two sub-toggles map to the
+        # ini keys the matcher reads (python_idn_block_malicious / _escalate_suspicious).
+        # Only emitted when the case sets it, so the default matrix is unchanged.
+        settings["pfb_idn"] = spec.idn_mode
+    if spec.idn_block_malicious is not None:
+        settings["pfb_idn_block_malicious"] = "on" if spec.idn_block_malicious else ""
+    if spec.idn_escalate_suspicious is not None:
+        settings["pfb_idn_escalate_suspicious"] = "on" if spec.idn_escalate_suspicious else ""
     # The primary feed row + any ABP extra rows, all in ONE DNSBL list group. Each
     # row is downloaded + header-sniffed independently (inc:7934), so an ABP body
     # per row yields one ABP feed per row whose rules the Python build merges.

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -333,6 +333,85 @@ def test_dnsbl_hsts_disabled_keeps_vip(deployed_vm: SmokeVM, mock_feeds: _MockFe
         assert not h.is_null_ip(blocked), f"HSTS off must NOT force NULL: {blocked}"
 
 
+# IDN homoglyph protection — Confusable mode (ADR-08). The block comes from the
+# matcher's TR39 mixed-script analyzer (pfb_unbound.py classify_idn), NOT a feed
+# entry — the feed below is one innocuous filler so the DNSBL list/alias is real and
+# python mode is active; ``idn_mode='confusable'`` is what arms the analyzer.
+
+
+def test_dnsbl_idn_confusable_blocks_homoglyph_resolves_legit(
+    deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """Confusable mode blocks a cross-script homoglyph (VIP) but resolves a legit IDN.
+
+    Scenario: ``pfb_idn='confusable'`` + ``block_malicious`` ON (default). The
+    matcher decodes each ``xn--`` label, runs the TR39 analyzer per-label, and:
+      * ``xn--pple-43d`` (аpple — Cyrillic U+0430 + Latin) is a confusable Latin+
+        Cyrillic mix → MALICIOUS → blocked as feed ``Homoglyph`` (log_type '1',
+        not HSTS) → NOERROR + the DNSBL VIP.
+      * ``xn--mnchen-3ya`` (münchen — single-script Latin) is legit → NO IDN action,
+        so it resolves to its control answer (the before-state: green proves the
+        analyzer is the cause of the block, not an always-block path).
+    Probed on-box (``drill @127.0.0.1``); python-mode has no localhost exemption.
+    """
+    homoglyph = "xn--pple-43d.com"  # аpple — Latin+Cyrillic confusable → MALICIOUS
+    legit = "xn--mnchen-3ya.com"  # münchen — single-script Latin → legit
+    legit_ip = "198.51.100.60"
+    feed_url = h.write_local_feed(deployed_vm, "smoke_idn_confusable.txt", f"{h.unique_domain('idnfiller')}\n")
+    spec = h.DnsblCase(
+        aliasname="smokeidn",
+        feed_url=feed_url,
+        header="smokeidn",
+        mode=h.DnsblMode.VIP,
+        idn_mode="confusable",
+        idn_block_malicious=True,
+        idn_escalate_suspicious=False,
+        control_local_data={legit: {"A": legit_ip}},
+    )
+    with h.CaseContext(deployed_vm, spec):
+        # Before-state: the legit single-script IDN is NOT blocked — it resolves.
+        legit_ans = h.dns_probe(deployed_vm, legit, "A")
+        assert h.resolves_to(legit_ans, legit_ip), f"legit IDN {legit} should resolve to {legit_ip}, got {legit_ans}"
+        assert not h.is_vip(legit_ans), f"legit IDN {legit} must NOT be homoglyph-blocked (FALSE POSITIVE): {legit_ans}"
+        # The confusable homograph blocks with the DNSBL VIP.
+        blocked = h.dns_probe(deployed_vm, homoglyph, "A")
+        assert h.is_vip(blocked), (
+            f"homoglyph {homoglyph} (Latin+Cyrillic) expected VIP {h.DEFAULT_DNSBL_VIP4}, got {blocked}"
+        )
+
+
+def test_dnsbl_idn_confusable_block_malicious_off_alerts_only(
+    deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """The ``block_malicious`` sub-toggle is a real branch: OFF → the SAME homograph
+    only alerts (resolves), not blocks.
+
+    Same confusable ``xn--pple-43d`` (аpple) as the positive case, but with
+    ``block_malicious`` OFF: ``idn_confusable_action`` maps MALICIOUS → ALERT, so
+    ``is_found`` stays False and the name resolves to its control answer. Paired with
+    the block-on case above (same input, toggle flipped) this proves it is the toggle,
+    not an always-resolve path.
+    """
+    homoglyph = "xn--pple-43d.com"  # аpple — MALICIOUS, but block_malicious is OFF
+    homoglyph_ip = "198.51.100.61"
+    feed_url = h.write_local_feed(deployed_vm, "smoke_idn_alert.txt", f"{h.unique_domain('idnfiller')}\n")
+    spec = h.DnsblCase(
+        aliasname="smokeidnalert",
+        feed_url=feed_url,
+        header="smokeidnalert",
+        mode=h.DnsblMode.VIP,
+        idn_mode="confusable",
+        idn_block_malicious=False,  # malicious → ALERT only (no block)
+        control_local_data={homoglyph: {"A": homoglyph_ip}},
+    )
+    with h.CaseContext(deployed_vm, spec):
+        ans = h.dns_probe(deployed_vm, homoglyph, "A")
+        assert h.resolves_to(ans, homoglyph_ip), (
+            f"block_malicious OFF: {homoglyph} should resolve to {homoglyph_ip}, got {ans}"
+        )
+        assert not h.is_vip(ans), f"block_malicious OFF must NOT block the homograph (alert only): {ans}"
+
+
 def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """WHITELIST: a domain on the whitelist AND in the block feed RESOLVES.
 

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -289,3 +289,58 @@ def test_action_select_toggles_advanced_firewall_sections(
     expect(action).to_have_value("Disabled", timeout=JS_TIMEOUT_MS)
     expect(adv_in).to_be_hidden(timeout=JS_TIMEOUT_MS)
     expect(adv_out).to_be_hidden(timeout=JS_TIMEOUT_MS)
+
+
+def test_idn_mode_select_gates_confusable_subtoggles(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """`#pfb_idn` = "Confusable" SHOWS the two Confusable sub-toggle checkboxes; any
+    other mode HIDES them (ADR-08).
+
+    ``enable_idn_mode()`` (pfblockerng_dnsbl.php:3143, bound to ``#pfb_idn.change``)
+    ``hideCheckbox()``s ``#pfb_idn_block_malicious`` + ``#pfb_idn_escalate_suspicious``
+    -- shown ONLY when the select is "confusable". Three states are asserted
+    (Off -> Confusable -> All-IDN) so green proves the sub-toggles are confusable-
+    specific, not always-shown nor merely "anything but Off". Playwright ``to_be_hidden``
+    on the input holds when hideCheckbox sets ``display:none`` on the enclosing
+    ``.form-group`` row. A full-page screenshot is captured at each state.
+    """
+    page = browser_page
+    _open(page, webui, DNSBL_PAGE)
+
+    sel = page.locator("#pfb_idn")
+    block_mal = page.locator("#pfb_idn_block_malicious")
+    escalate = page.locator("#pfb_idn_escalate_suspicious")
+    expect(sel).to_be_attached(timeout=JS_TIMEOUT_MS)
+    expect(block_mal).to_be_attached(timeout=JS_TIMEOUT_MS)
+    expect(escalate).to_be_attached(timeout=JS_TIMEOUT_MS)
+
+    # Normalise to a deterministic start (Off) regardless of saved config.
+    if sel.input_value() != "":
+        sel.select_option("")
+        sel.dispatch_event("change")
+        expect(sel).to_have_value("", timeout=JS_TIMEOUT_MS)
+
+    # BEFORE: Off -> both sub-toggles hidden.
+    expect(sel).to_have_value("", timeout=JS_TIMEOUT_MS)
+    expect(block_mal).to_be_hidden(timeout=JS_TIMEOUT_MS)
+    expect(escalate).to_be_hidden(timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "dnsbl_idn_off_subtoggles_hidden")
+
+    # SELECT Confusable -> the handler shows both sub-toggles.
+    sel.select_option("confusable")
+    sel.dispatch_event("change")
+    expect(sel).to_have_value("confusable", timeout=JS_TIMEOUT_MS)
+    expect(block_mal).to_be_visible(timeout=JS_TIMEOUT_MS)
+    expect(escalate).to_be_visible(timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "dnsbl_idn_confusable_subtoggles_shown")
+
+    # SELECT All-IDN -> hidden again (third state: confusable-specific, not just != Off).
+    sel.select_option("all")
+    sel.dispatch_event("change")
+    expect(sel).to_have_value("all", timeout=JS_TIMEOUT_MS)
+    expect(block_mal).to_be_hidden(timeout=JS_TIMEOUT_MS)
+    expect(escalate).to_be_hidden(timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "dnsbl_idn_all_subtoggles_hidden")

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -219,6 +219,21 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="pfb_py_nolog",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_py_nolog",
     ),
+    # ADR-08 Confusable sub-toggles (on/off checkboxes). The DNSBL save only
+    # write_config()s, so config.xml is the oracle. block_malicious defaults 'on',
+    # escalate_suspicious defaults '' -- the flow flips from whatever is stored.
+    ToggleFlow(
+        name="dnsbl_idn_block_malicious",
+        page="/pfblockerng/pfblockerng_dnsbl.php",
+        field="pfb_idn_block_malicious",
+        config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_block_malicious",
+    ),
+    ToggleFlow(
+        name="dnsbl_idn_escalate_suspicious",
+        page="/pfblockerng/pfblockerng_dnsbl.php",
+        field="pfb_idn_escalate_suspicious",
+        config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_escalate_suspicious",
+    ),
 )
 
 
@@ -354,6 +369,37 @@ def _post_and_get(
         f"POST to {page} returned the login form (session lost) -- not a real save result"
     )
     return helpers.config_get(vm, config_path)
+
+
+# --------------------------------------------------------------------------- #
+# DNSBL settings — the ADR-08 "IDN Blocking" selector (a 3-value select, not the
+# on/off ToggleFlow shape, so it round-trips here explicitly).
+# --------------------------------------------------------------------------- #
+
+
+def test_dnsbl_idn_mode_select_round_trips_all_modes(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready: None,
+) -> None:
+    """The 'IDN Blocking' select (``pfb_idn``) round-trips all three modes via config.xml.
+
+    Off (``''``) / All-IDN (``'all'``) / Confusable (``'confusable'``) are the options;
+    the save stores the value verbatim for 'all'/'confusable', else '' (Off). Drives
+    EACH mode and asserts the effective config node (branch coverage: every selectable
+    value, not just one), restoring the original at the end. The DNSBL save only
+    write_config()s (config.xml is the oracle) and needs the sinkhole VIP -- supplied
+    by ``dnsbl_vip_ready``.
+    """
+    page = "/pfblockerng/pfblockerng_dnsbl.php"
+    cfg = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn"
+    original = helpers.config_get(smoke_vm, cfg)
+    try:
+        for mode in ("confusable", "all", ""):
+            got = _post_and_get(webui, smoke_vm, page, {"pfb_idn": mode}, cfg)
+            assert got == mode, f"pfb_idn select: POSTing {mode!r} stored {got!r} (expected {mode!r})"
+    finally:
+        _post_and_get(webui, smoke_vm, page, {"pfb_idn": original}, cfg)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -269,7 +269,8 @@ def test_dnsbl_idn_blocking_fields_render(webui: WebUI, php_error_log_guard: Php
         'name="pfb_idn_block_malicious"',
         'name="pfb_idn_escalate_suspicious"',
         "IDN Blocking",
-        "Confusable",
+        ">Always<",  # the 'all' mode option label (renamed from "All-IDN")
+        ">Confusable<",
     ):
         assert needle in body, f"DNSBL page is missing the IDN-mode marker {needle!r}"
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -249,6 +249,31 @@ def test_general_page_renders_aggregate_select(webui: WebUI) -> None:
     )
 
 
+def test_dnsbl_idn_blocking_fields_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The ADR-08 'IDN Blocking' selector + its two Confusable sub-toggles render
+    cleanly on the DNSBL page — so a regression that drops or breaks the field is
+    caught at the render tier (not just by the matcher smoke).
+
+    Asserts the page passes the clean-render oracle AND that the three POST field
+    names (``pfb_idn`` select + the two sub-toggle checkboxes) and the 'IDN Blocking'
+    / 'Confusable' option labels are present in the body. ``php_error_log_guard``
+    enrolls this GET in the module-level no-growth sweep.
+    """
+    path = "/pfblockerng/pfblockerng_dnsbl.php"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
+    assert result.ok, f"DNSBL render oracle failed: {result.detail}"
+    body = resp.text
+    for needle in (
+        'name="pfb_idn"',
+        'name="pfb_idn_block_malicious"',
+        'name="pfb_idn_escalate_suspicious"',
+        "IDN Blocking",
+        "Confusable",
+    ):
+        assert needle in body, f"DNSBL page is missing the IDN-mode marker {needle!r}"
+
+
 # threats.php's NEGATIVE branches: each malformed/absent param print_info_box()es
 # a specific message and exit()s BEFORE the "$pgtitle" lookup-page chrome. These
 # pair with the positive threats_{domain,host,port} entries above (CLAUDE.md


### PR DESCRIPTION
## What

Live-VM validation for ADR-08 IDN homoglyph **Confusable** mode (the §7 manual-smoke checklist, now automated) + full **UI tiers** for the new "IDN Blocking" selector.

### Live-VM smoke (`test_smoke_matrix.py`) — drives a real pfSense CE VM
- **blocks the homograph, resolves the legit IDN:** `xn--pple-43d` (аpple, Latin+Cyrillic) → VIP-block; `xn--mnchen-3ya` (münchen, single-script Latin) → resolves. The 0-FP guard on a real box.
- **sub-toggle is a real branch:** the same homograph with `block_malicious` OFF only alerts (resolves), not blocks.
- `helpers.DnsblCase` gains `idn_mode` / `idn_block_malicious` / `idn_escalate_suspicious` → the `pfb_idn` dnsbl config keys.

### UI tiers (ADR-14) for the `pfb_idn` selector + two Confusable sub-toggles
- **Tier A (`ui_render`):** the select + both checkboxes render cleanly (present in body, no PHP diagnostic, no new `php_error.log` line).
- **Tier B (`ui_e2e`):** `pfb_idn` round-trips Off/All-IDN/Confusable via `config.xml`; two `ToggleFlow`s for the checkboxes.
- **Tier B (`ui_browser`):** drives `enable_idn_mode()` (Off → Confusable → All-IDN), asserts the sub-toggles show **only** under Confusable, and captures a **screenshot** at each state.

## Testing
Main suite **1312 passed**, ruff/format clean, smoke collection green (209). The live tiers run on the VM via `smoke.yml` + `ui-tests.yml` (dispatched against this branch) — results to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IDN Blocking for DNSBL: selectable modes Off / Confusable / Always (Always shown instead of "All-IDN"); Confusable mode exposes two subtoggles to block malicious confusables and to escalate suspicious ones; selector help text reformatted for clarity.
* **Tests**
  * Added smoke, UI, render, and functional tests validating selector/toggle visibility, selector round-trips, screenshots, and confusable-blocking network behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->