### PR TITLE
ADR-17: Self-hosted pfSense pkg repository on GitHub Pages

### DIFF
--- a/.ADRs/ADR_17_Pkg_Repository/ADR.md
+++ b/.ADRs/ADR_17_Pkg_Repository/ADR.md
@@ -2,11 +2,11 @@
 
 - **Status:** **Implemented** (2026-06-05) — *pending the post-merge live Pages deploy +
   the gated live-URL verification.* The hermetic affected-flow smoke (install / cross-repo
-  precedence / `pkg upgrade`) is **GREEN on the live VM** (§7); only the public `brait.dev`
-  Pages deploy + the live-URL leg remain, which are **post-merge** (a brand-new
+  precedence / `pkg upgrade`) is **GREEN on the live VM** (§7); only the public
+  `andrebrait.github.io` Pages deploy + the live-URL leg remain, which are **post-merge** (a brand-new
   `workflow_dispatch` workflow is only dispatchable once it lands on the default branch
   `devel`). Flips to **Accepted** once that deploy dispatch confirms the live
-  `https://brait.dev/pfBlockerNG/${ABI}` URL.
+  `https://andrebrait.github.io/pfBlockerNG/${ABI}` URL.
 - **Date:** 2026-06-05
 - **Branch:** `adr/17` (off **`devel`**) / **Component(s):** new dev-only CI — a
   **repo-publish** job/workflow that consumes ADR-09's release `.pkg` artifacts +
@@ -20,11 +20,14 @@
   smoke harness (`tests/smoke/conftest.py` `smoke_vm` + `helpers.py` +
   `scripts/install-pkg.sh`). **No shipped (`src/`) code changes** (the repo-only
   scope — §2; the GUI panel that would touch `src/www` is explicitly out of scope).
-- **Target runtime:** GitHub Actions — `ubuntu-latest` with **libpkg on Linux** for
-  catalog generation (the portable builder already proves libpkg-on-Linux), the
-  **FreeBSD VM** (`build-pkg.yml` path) retained as the fidelity fallback if Linux
-  catalog gen is not pfSense-acceptable. Client side: pfSense **CE 2.8+**
-  (`FreeBSD:15:amd64`) `pkg` 1.21+. Smoke: the ADR-04 live pfSense CE VM.
+- **Target runtime:** GitHub Actions — `ubuntu-latest` with a **pure-Python catalog
+  generator** (`scripts/build-repo-portable.py`; **no libpkg** — Phase 3a falsified
+  the "portable builder proves libpkg-on-Linux" assumption: `build-pkg-portable.py`
+  hand-rolls the `.pkg` archive in pure Python and never invokes libpkg, so the
+  catalog is hand-rolled the same way), with the **FreeBSD VM** (`build-pkg.yml`
+  path, `scripts/build-repo.sh` + real `pkg repo`) retained as the fidelity
+  fallback. Client side: pfSense **CE 2.8+** (`FreeBSD:15:amd64`) `pkg` 1.21+.
+  Smoke: the ADR-04 live pfSense CE VM.
 - **Test suite:** a new live-VM `tests/smoke/test_repo_install.py` carrying its **own
   marker `repo`** (a distribution flow, deselected from `-m smoke`). **Default
   `python -m pytest` stays unchanged** (the whole `tests/smoke` tree is `--ignore`d in
@@ -142,7 +145,7 @@ regenerated index over the durable Release assets** — no stateful accumulation
 
 | Area | Decision |
 | --- | --- |
-| **Trust model** | **`signature_type: none`** — `pkg` fetches over HTTPS; trust anchor = TLS to the GitHub-Pages host (the custom domain `brait.dev`; matches the project's image-no-signature precedent). **No signing key in CI** (a CI-resident key would itself be a root-code attack surface). pfSense honors per-repo `none` (Context 4). |
+| **Trust model** | **`signature_type: none`** — `pkg` fetches over HTTPS; trust anchor = TLS to the GitHub-Pages host (`andrebrait.github.io`, GitHub's `*.github.io` cert; matches the project's image-no-signature precedent). **No signing key in CI** (a CI-resident key would itself be a root-code attack surface). pfSense honors per-repo `none` (Context 4). |
 | **Hosting** | **GitHub Pages**, deployed via `actions/upload-pages-artifact` + `actions/deploy-pages` (the site is *replaced* each deploy → **no `gh-pages` history bloat**; the 1 GB source-repo concern never arises). |
 | **Repo = derived index over Releases** | The **GitHub Releases** `.pkg` assets (ADR-09 `attach-pkgs`) are the **durable store**. The publish job **enumerates all releases, downloads their `.pkg` assets, buckets by ABI, runs `pkg repo` per ABI dir, and deploys the whole tree** — **stateless + idempotent**, so every published build (all versions, all ABIs) is retained without accumulating state. |
 | **Layout + `${ABI}`** | One catalog per ABI under `…/<ABI>/` (e.g. `…/FreeBSD:15:amd64/`); the client conf `url:` uses **`${ABI}`** so it auto-follows an OS upgrade. **Flavor collision guard:** today every supported combo collapses to one tree (CE 2.8 + Plus 25.03 are both FreeBSD15 / php83 / py311). **If** two matrix entries ever share ABI **and** package-version but differ in php/py, the same name+version+ABI **cannot coexist** in one catalog → split into `…/<ABI>-<php><py>/` subtrees and have `add-repo.sh` detect+pin the box's flavor. `build-repo.sh` **fails loud** on an unhandled collision (never silently drops a build). |
@@ -204,7 +207,7 @@ regenerated index over the durable Release assets** — no stateful accumulation
 **Negative / risks**
 
 - **Authenticity = TLS only.** `none` means a compromise of the Pages host's TLS
-  (`brait.dev`) or the Pages content could serve altered root-running packages. Accepted
+  (`andrebrait.github.io`) or the Pages content could serve altered root-running packages. Accepted
   per precedent; revisitable to **offline-signed PUBKEY** later (key never in CI) — the
   conf gains a `signature_type`, the layout is unchanged.
 - **GUI discovery + update badge stay Netgate-bound** (Context 3). Our newer builds
@@ -339,7 +342,7 @@ Prompt: `05_Smoke_Coverage.txt`
 - Promote Phase 1 into the full `test_repo_install.py`: **(a)** GUI-path / CLI install from
   our repo (cross-repo precedence both branches, before/after asserts); **(b)** `pkg
   upgrade` from a lower installed version → our newer build (transition); **(c)**
-  **dispatch-only** real-`brait.dev`-URL install (hermetic mock is the gated default).
+  **dispatch-only** real-`andrebrait.github.io`-URL install (hermetic mock is the gated default).
   If the OS-major upgrade-survival case can't favor our build, **document the CLI
   `pkg upgrade` degrade** and record numbers. Branch coverage + VM left clean.
 
@@ -368,7 +371,7 @@ Prompt: `06_Docs_DoD.txt`
 - Status flips **Proposed → Implemented (pending the post-merge live Pages deploy + the
   gated live-URL verification)** — the hermetic affected-flow smoke (install / precedence /
   `pkg upgrade`) is GREEN on the live VM; **→ Accepted** once the post-merge `repo-publish`
-  dispatch deploys the public `brait.dev` catalog and the gated
+  dispatch deploys the public `andrebrait.github.io` catalog and the gated
   `test_install_from_live_pages_url` installs from the served URL — **no human
   manual-smoke gate** (the live-VM smoke is the oracle).
 
@@ -380,7 +383,7 @@ exists on the default branch (`devel`). `repo-publish.yml` lands with this ADR; 
 
 1. `gh workflow run repo-publish.yml --ref devel -f build_branch_pkg=true` — deploys the
    catalog to Pages (capture the run id + the `page_url`).
-2. Dispatch the `repo` smoke with `SMOKE_REPO_LIVE_URL=https://brait.dev/pfBlockerNG` set, so
+2. Dispatch the `repo` smoke with `SMOKE_REPO_LIVE_URL=https://andrebrait.github.io/pfBlockerNG` set, so
    `test_install_from_live_pages_url` runs instead of skipping (it polls the served catalog,
    pins the Pages anycast IPs, writes our production conf, then `pkg install` with no `-f`
    asserting `%R == pfblockerng-devel`). Green there confirms the live URL → Status **Accepted**.
@@ -428,7 +431,7 @@ All five are GREEN on the live pfSense CE VM via `tests/smoke/test_repo_install.
   from **both** generators — is consumed without error: `build-repo.sh` (real `pkg repo`)
   and `build-repo-portable.py` (pure-Python). *(`test_build_repo_script_catalog_is_accepted`
   — run **27033922928**, P2; `test_portable_catalog_is_accepted` — run **27035602221**, P3a.
-  The real `brait.dev` URL leg, `test_install_from_live_pages_url`, is gated on
+  The real `andrebrait.github.io` URL leg, `test_install_from_live_pages_url`, is gated on
   `SMOKE_REPO_LIVE_URL` and is the post-merge step above.)*
 - [x] **Upgrade to our newer build.** Our repo carrying only `_1` ⇒ installed `%v == _1`
   from `pfblockerng-devel`; same repo rebuilt with `_9` ⇒ `pkg upgrade` moves it to

--- a/.ADRs/ADR_17_Pkg_Repository/ADR.md
+++ b/.ADRs/ADR_17_Pkg_Repository/ADR.md
@@ -1,13 +1,20 @@
 # ADR-17: Self-hosted pfSense `pkg` repository on GitHub Pages
 
-- **Status:** **Proposed** (2026-06-05)
+- **Status:** **Implemented** (2026-06-05) — *pending the post-merge live Pages deploy +
+  the gated live-URL verification.* The hermetic affected-flow smoke (install / cross-repo
+  precedence / `pkg upgrade`) is **GREEN on the live VM** (§7); only the public `brait.dev`
+  Pages deploy + the live-URL leg remain, which are **post-merge** (a brand-new
+  `workflow_dispatch` workflow is only dispatchable once it lands on the default branch
+  `devel`). Flips to **Accepted** once that deploy dispatch confirms the live
+  `https://brait.dev/pfBlockerNG/${ABI}` URL.
 - **Date:** 2026-06-05
 - **Branch:** `adr/17` (off **`devel`**) / **Component(s):** new dev-only CI — a
   **repo-publish** job/workflow that consumes ADR-09's release `.pkg` artifacts +
   `read-version-matrix` action and deploys a `pkg` catalog to **GitHub Pages**; new
-  `scripts/build-repo.sh` (catalog generation + `${ABI}` layout) and
-  `scripts/add-repo.sh` (client bootstrap) + a repo-conf template; new live-VM
-  `tests/smoke/test_smoke_repo.py`. **Reused, not modified:** ADR-09's
+  `scripts/build-repo-portable.py` (primary pure-Python catalog generator) +
+  `scripts/build-repo.sh` (FreeBSD-VM fallback / `--print-conf` template) +
+  `scripts/add-repo.sh` (client bootstrap); new live-VM
+  `tests/smoke/test_repo_install.py` (marker `repo`). **Reused, not modified:** ADR-09's
   `read-version-matrix` action, the portable builder (`build-pkg-linux.yml` /
   `scripts/build-pkg-portable.py`), the `release.yml` `.pkg` artifacts, the ADR-04
   smoke harness (`tests/smoke/conftest.py` `smoke_vm` + `helpers.py` +
@@ -18,11 +25,12 @@
   **FreeBSD VM** (`build-pkg.yml` path) retained as the fidelity fallback if Linux
   catalog gen is not pfSense-acceptable. Client side: pfSense **CE 2.8+**
   (`FreeBSD:15:amd64`) `pkg` 1.21+. Smoke: the ADR-04 live pfSense CE VM.
-- **Test suite:** a new live-VM `tests/smoke/test_smoke_repo.py` (`-m smoke`).
-  **Default `python -m pytest` stays unchanged** (the whole `tests/smoke` tree is
-  `--ignore`d in default collection). No `pytest` oracle for the CI YAML / shell
-  itself → validation = `shellcheck`/`sh -n` + the **live-VM smoke** (§7), which is
-  also the ADR-01-style **kill-gate**.
+- **Test suite:** a new live-VM `tests/smoke/test_repo_install.py` carrying its **own
+  marker `repo`** (a distribution flow, deselected from `-m smoke`). **Default
+  `python -m pytest` stays unchanged** (the whole `tests/smoke` tree is `--ignore`d in
+  default collection). No `pytest` oracle for the CI YAML / shell itself → validation =
+  `shellcheck`/`sh -n` + the **live-VM `repo` smoke** (§7), which is also the
+  ADR-01-style **kill-gate**.
 
 ---
 
@@ -53,11 +61,16 @@
      `pkg_prefix => 'pfSense-pkg-'`). **Available Packages is restricted to the repo
      named `pfSense` (Netgate's)** — a third-party repo **cannot add list entries**.
    - **Install** — `pkg_install()` runs `pkg install -y <name>` with **no `-r`**. So
-     `pkg` resolves the name across **all enabled repos** and installs the **highest
-     version** (repo `priority` breaks ties). → once a package is *listed* (Netgate's
-     repo carries `pfSense-pkg-pfBlockerNG-devel` via our ports PR), the GUI **Install**
-     button **transparently pulls our higher-versioned build** from our repo. No GUI
-     patching, no co-opting the `pfSense` repo name.
+     `pkg` resolves the name across **all enabled repos**, and selection is keyed
+     **first on repo `priority:`** — a **higher-priority repo wins even at a lower
+     version**. *(Phase-1 live-VM finding — falsifies the earlier "highest version
+     wins, priority breaks ties": on the VM a competing repo at `priority: 200` /
+     version `_1` BEAT ours at `priority: 99` / version `_9`. Version is the
+     **secondary** key, only between equal-priority repos.)* → once a package is
+     *listed* (Netgate's repo carries `pfSense-pkg-pfBlockerNG-devel` via our ports
+     PR), our repo wins the GUI **Install** button purely because `add-repo.sh` sets
+     its `priority:` **above** the Netgate `pfSense` repo — **regardless of version**.
+     No GUI patching, no co-opting the `pfSense` repo name.
    - **Installed Packages** (`pkg_mgr_installed.php`) reads the **local pkg db** → a
      pfBlockerNG installed from our repo **shows there and runs normally**, identical
      to a Netgate-repo install. Only Available-list **discovery** and the GUI
@@ -129,7 +142,7 @@ regenerated index over the durable Release assets** — no stateful accumulation
 
 | Area | Decision |
 | --- | --- |
-| **Trust model** | **`signature_type: none`** — `pkg` fetches over HTTPS; trust anchor = TLS to `github.io` (matches the project's image-no-signature precedent). **No signing key in CI** (a CI-resident key would itself be a root-code attack surface). pfSense honors per-repo `none` (Context 4). |
+| **Trust model** | **`signature_type: none`** — `pkg` fetches over HTTPS; trust anchor = TLS to the GitHub-Pages host (the custom domain `brait.dev`; matches the project's image-no-signature precedent). **No signing key in CI** (a CI-resident key would itself be a root-code attack surface). pfSense honors per-repo `none` (Context 4). |
 | **Hosting** | **GitHub Pages**, deployed via `actions/upload-pages-artifact` + `actions/deploy-pages` (the site is *replaced* each deploy → **no `gh-pages` history bloat**; the 1 GB source-repo concern never arises). |
 | **Repo = derived index over Releases** | The **GitHub Releases** `.pkg` assets (ADR-09 `attach-pkgs`) are the **durable store**. The publish job **enumerates all releases, downloads their `.pkg` assets, buckets by ABI, runs `pkg repo` per ABI dir, and deploys the whole tree** — **stateless + idempotent**, so every published build (all versions, all ABIs) is retained without accumulating state. |
 | **Layout + `${ABI}`** | One catalog per ABI under `…/<ABI>/` (e.g. `…/FreeBSD:15:amd64/`); the client conf `url:` uses **`${ABI}`** so it auto-follows an OS upgrade. **Flavor collision guard:** today every supported combo collapses to one tree (CE 2.8 + Plus 25.03 are both FreeBSD15 / php83 / py311). **If** two matrix entries ever share ABI **and** package-version but differ in php/py, the same name+version+ABI **cannot coexist** in one catalog → split into `…/<ABI>-<php><py>/` subtrees and have `add-repo.sh` detect+pin the box's flavor. `build-repo.sh` **fails loud** on an unhandled collision (never silently drops a build). |
@@ -137,7 +150,7 @@ regenerated index over the durable Release assets** — no stateful accumulation
 | **Client bootstrap** | `scripts/add-repo.sh` writes `/usr/local/etc/pkg/repos/pfblockerng-devel.conf` (`url:` with `${ABI}`, `signature_type: none`, `priority:` above the `pfSense` repo, `enabled: yes`), runs `pkg update`, verifies. README one-liner. **CLI-only setup**; thereafter GUI Install works via cross-repo resolution. |
 | **GUI** | **No `src/` change.** Stock GUI **Install** of pfBlockerNG-devel pulls our build (Context 3, install not repo-locked). The GUI **update badge** stays Netgate-bound (a documented limitation); a pfBlockerNG GUI "Updates/Channel" panel for GUI-driven upgrade-to-our-latest is **out of scope** (deferred — would touch `src/www`). |
 | **Catalog contents** | **Only** `pfSense-pkg-pfBlockerNG` / `-devel`. Our repo therefore **only ever competes for our own package** — `pkg upgrade` can never pull anything else from us. |
-| **Version precedence** | Our build's version is published `≥` Netgate's for the same source (and `priority:` breaks ties) so cross-repo resolution selects **ours**. Versioning discipline is a **contract item** pinned by the smoke. |
+| **Repo precedence (priority)** | **Repo `priority:` is the primary key — it dominates version** (Phase-1 live-VM finding: a higher-priority repo wins even at a *lower* version). `add-repo.sh` sets our `priority:` **above** the Netgate `pfSense` repo, so cross-repo resolution selects **ours regardless of version**. Versioning discipline is therefore **secondary** (it only orders equal-priority repos) — `priority:` is the lever; the smoke pins precedence in both directions. |
 
 ### Semantics that MUST be preserved (the contract — pin with tests with the change)
 
@@ -190,16 +203,19 @@ regenerated index over the durable Release assets** — no stateful accumulation
 
 **Negative / risks**
 
-- **Authenticity = TLS only.** `none` means a compromise of github.io's TLS (or the
-  Pages content) could serve altered root-running packages. Accepted per precedent;
-  revisitable to **offline-signed PUBKEY** later (key never in CI) — the conf gains a
-  `signature_type`, the layout is unchanged.
+- **Authenticity = TLS only.** `none` means a compromise of the Pages host's TLS
+  (`brait.dev`) or the Pages content could serve altered root-running packages. Accepted
+  per precedent; revisitable to **offline-signed PUBKEY** later (key never in CI) — the
+  conf gains a `signature_type`, the layout is unchanged.
 - **GUI discovery + update badge stay Netgate-bound** (Context 3). Our newer builds
   install via GUI Install / CLI `pkg upgrade` but the GUI won't *badge* them — a
   documented limitation; the deferred GUI panel would close it.
-- **Cross-repo version races.** If Netgate's `-devel` outranks ours, theirs wins; if
-  ours is mis-versioned high, we could shadow a Netgate fix. Mitigated by versioning
-  discipline + `priority` + the smoke precedence assertions.
+- **Cross-repo precedence races.** `priority:` is the primary key (Phase-1 finding), so
+  our above-Netgate `priority:` makes ours win — but that also means we **shadow** a
+  same-name Netgate build by `priority:` even when theirs is newer (our catalog carries
+  only pfBlockerNG, so the blast radius is our own package). Mitigated by the
+  above-Netgate `priority:` + versioning discipline (the secondary key) + the smoke
+  precedence assertions in both directions.
 - **OS-major upgrade survival is the residual unknown** (Premise 3) — single-image
   precedence is proven; true major-jump survival is dispatch-only and may degrade to a
   documented CLI `pkg upgrade`.
@@ -278,8 +294,9 @@ Prompt: `01_Spike_Repo_Install.txt`
   **with no `-f`**. **Assert (transition):** package absent → installed **from our
   repo** (`pkg query '%R'`), deps resolved, POST-INSTALL ran, pfBlockerNG functions; and
   **cross-repo precedence** picks our build over a lower-versioned decoy (and the decoy
-  wins when ours is lower — both branches). Land as `tests/smoke/test_smoke_repo.py`
-  (marker `smoke`), minimal. **Record the verdict in `RESULTS/01_Results.txt`** — GO only
+  wins when ours is lower — both branches). Land as `tests/smoke/test_repo_install.py`
+  (marker `repo`, deselected from `-m smoke`), minimal. **Record the verdict in
+  `RESULTS/01_Results.txt`** — GO only
   if a real box honors the third-party repo for install + precedence; else REJECT/redesign.
 
 ### Phase 2 — Catalog generator + `${ABI}` layout + repo-conf template (the build tool)
@@ -319,10 +336,10 @@ Prompt: `04_Client_Bootstrap.txt`
 
 Prompt: `05_Smoke_Coverage.txt`
 
-- Promote Phase 1 into the full `test_smoke_repo.py`: **(a)** GUI-path / CLI install from
+- Promote Phase 1 into the full `test_repo_install.py`: **(a)** GUI-path / CLI install from
   our repo (cross-repo precedence both branches, before/after asserts); **(b)** `pkg
   upgrade` from a lower installed version → our newer build (transition); **(c)**
-  **dispatch-only** real-`github.io`-URL install (hermetic mock is the gated default).
+  **dispatch-only** real-`brait.dev`-URL install (hermetic mock is the gated default).
   If the OS-major upgrade-survival case can't favor our build, **document the CLI
   `pkg upgrade` degrade** and record numbers. Branch coverage + VM left clean.
 
@@ -340,15 +357,33 @@ Prompt: `06_Docs_DoD.txt`
 
 - `python -m pytest` unchanged; `shellcheck`/`sh -n`/markdownlint/URL-encoding gate clean.
 - A CI dispatch regenerates the catalog over all Release `.pkg` and deploys it to Pages;
-  a live VM `pkg update` against the URL succeeds.
-- `tests/smoke/test_smoke_repo.py` is green: install-from-our-repo (no `-f`, deps resolve,
-  registers, runs), cross-repo precedence (both branches), and `pkg upgrade` to our newer
-  build — on the ADR-04 VM.
+  a live VM `pkg update` against the URL succeeds. *(The hermetic `file://` + portable +
+  `build-repo.sh` catalogs are VM-accepted now; the public Pages deploy + the live-URL
+  leg are **post-merge** — see below.)*
+- `tests/smoke/test_repo_install.py` (marker **`repo`**) is green: install-from-our-repo
+  (no `-f`, deps resolve, registers, runs), cross-repo precedence (both branches), and
+  `pkg upgrade` to our newer build — on the ADR-04 VM.
 - The existing tag flow still publishes the Release + ports PR; the repo-publish job's
   failure leaves them intact.
-- Status flips **Proposed → Implemented (pending smoke)** once Phases 1–4 hold on
-  `adr/17`; **→ Accepted** once the §7 affected-flow smoke is green on the live VM — **no
-  human manual-smoke gate** (the live-VM smoke is the oracle).
+- Status flips **Proposed → Implemented (pending the post-merge live Pages deploy + the
+  gated live-URL verification)** — the hermetic affected-flow smoke (install / precedence /
+  `pkg upgrade`) is GREEN on the live VM; **→ Accepted** once the post-merge `repo-publish`
+  dispatch deploys the public `brait.dev` catalog and the gated
+  `test_install_from_live_pages_url` installs from the served URL — **no human
+  manual-smoke gate** (the live-VM smoke is the oracle).
+
+### POST-MERGE step (flips Implemented → Accepted)
+
+The live Pages deploy + the gated `test_install_from_live_pages_url` leg are **post-merge**,
+a GitHub constraint: a brand-new `workflow_dispatch` workflow is only dispatchable once it
+exists on the default branch (`devel`). `repo-publish.yml` lands with this ADR; then:
+
+1. `gh workflow run repo-publish.yml --ref devel -f build_branch_pkg=true` — deploys the
+   catalog to Pages (capture the run id + the `page_url`).
+2. Dispatch the `repo` smoke with `SMOKE_REPO_LIVE_URL=https://brait.dev/pfBlockerNG` set, so
+   `test_install_from_live_pages_url` runs instead of skipping (it polls the served catalog,
+   pins the Pages anycast IPs, writes our production conf, then `pkg install` with no `-f`
+   asserting `%R == pfblockerng-devel`). Green there confirms the live URL → Status **Accepted**.
 
 ### Reject / degrade criteria (decide on evidence)
 
@@ -358,23 +393,50 @@ Prompt: `06_Docs_DoD.txt`
   by **Phase 1** before any pipeline is built.
 - **Linux catalog gen is not pfSense-acceptable** → **DEGRADE**: generate the catalog on
   the FreeBSD VM (`build-pkg.yml`); localized, not a sink. Settled by **Phase 2**.
-- **OS-major upgrade can't be made to favor our build** → **DEGRADE**: cross-version
-  upgrade becomes a documented CLI `pkg upgrade` step (single-image precedence still
-  proven). Recorded in `RESULTS/05_Results.txt`.
+- **OS-major upgrade can't be made to favor our build** → **DEGRADE** *(outcome:
+  **DEGRADED-TO-CLI**, recorded in `RESULTS/05_Results.txt`)*: a true OS-major jump
+  (e.g. `FreeBSD:15` → `FreeBSD:16`, which changes `${ABI}` and thus the served `<ABI>/`
+  subtree) is not reachable on a single CE smoke image — an in-place `pfSense-upgrade`
+  across a major is `image-refresh.yml`'s job (ADR-09), not this per-run flow. The
+  single-image upgrade (`_1` → `_9` within one ABI) is proven; the OS-major case degrades
+  to the documented operator action: after a pfSense OS upgrade the box's `${ABI}` follows
+  it automatically (the conf `url:` is the literal `${ABI}`, §2), so a plain CLI
+  `pkg update -f && pkg upgrade` pulls our build for the **new** ABI once that ABI's catalog
+  is published. No test attempts it (it would fail-skip on one image) — a deliberate,
+  documented non-goal for the flow.
 - **Pages bandwidth/size ever bind** (won't at this scale — Context 5) → **MIGRATE** to a
   dedicated static host/CDN (same escape hatch ADR-09 wrote for `ci-metadata`); the conf
   `url:` changes, nothing else.
 
 ### Affected-flow smoke (gates Accept — on the ADR-04 live VM)
 
-- [ ] **Install from our repo, no `-f`.** Package absent → `pkg install
-  pfSense-pkg-pfBlockerNG-devel` installs **from our repo** (`pkg query '%R'`), deps
-  resolve, POST-INSTALL runs, pfBlockerNG answers.
-- [ ] **Cross-repo precedence (both branches).** Our higher version ⇒ ours installs; a
-  lower decoy ⇒ the decoy installs — proving precedence is real, not incidental.
-- [ ] **`pkg update` accepts the catalog.** The Pages-style catalog (hermetic mock by
-  default; real `github.io` dispatch-only) is consumed without error.
-- [ ] **Upgrade to our newer build.** A lower version installed → `pkg upgrade` moves it
-  to our newer build (assert before/after versions).
-- [ ] **Additive safety.** A simulated repo-publish failure leaves `release`/`ports-pr`
-  green (CI-level assertion / job isolation review).
+All five are GREEN on the live pfSense CE VM via `tests/smoke/test_repo_install.py` (marker
+`repo`), dispatched `gh workflow run smoke.yml -f pytest_marker=repo` (the standalone
+`repo-install.yml` is dispatchable once on `devel`). Run ids cite the load-bearing dispatch.
+
+- [x] **Install from our repo, no `-f`.** Package absent → `pkg install
+  pfSense-pkg-pfBlockerNG-devel` installs **from our repo** (`pkg query '%R'` ==
+  `pfblockerng-devel`), deps resolve, every registered file lands (> 50), no `-f`.
+  *(`test_install_from_our_repo_lands_all_files` — run **27031334263**, P1.)*
+- [x] **Cross-repo precedence (both branches).** Proven priority-driven against a controlled
+  `netgate-decoy` repo serving the same package: ours at the higher `priority:` ⇒ ours
+  installs (`%R == pfblockerng-devel`); the decoy at the higher `priority:` ⇒ the decoy
+  installs (`%R == netgate-decoy`) — both directions, so precedence is real, not incidental.
+  *(`test_precedence_ours_higher_priority_wins` + `test_precedence_decoy_higher_priority_wins`
+  — run **27031334263**, P1.)*
+- [x] **`pkg update` accepts the catalog.** The hermetic `file://` Pages-style catalog —
+  from **both** generators — is consumed without error: `build-repo.sh` (real `pkg repo`)
+  and `build-repo-portable.py` (pure-Python). *(`test_build_repo_script_catalog_is_accepted`
+  — run **27033922928**, P2; `test_portable_catalog_is_accepted` — run **27035602221**, P3a.
+  The real `brait.dev` URL leg, `test_install_from_live_pages_url`, is gated on
+  `SMOKE_REPO_LIVE_URL` and is the post-merge step above.)*
+- [x] **Upgrade to our newer build.** Our repo carrying only `_1` ⇒ installed `%v == _1`
+  from `pfblockerng-devel`; same repo rebuilt with `_9` ⇒ `pkg upgrade` moves it to
+  `%v == _9`, still from `pfblockerng-devel` — a real before ≠ after transition, both
+  versions asserted. The shipped `add-repo.sh` bootstrap is also exercised end-to-end.
+  *(`test_pkg_upgrade_moves_to_our_newer_build` + `test_shipped_add_repo_sh_bootstrap_installs`
+  — run **27040686824**, P5.)*
+- [x] **Additive safety.** `repo-publish` is a **leaf** in `release.yml`'s `needs:` graph
+  (nothing depends on it) and is gated `if: always()`, copied from `attach-pkgs` — so a
+  repo-publish failure (build / generator / Pages deploy) cannot gate or break
+  `release`/`ports-pr`/`attach-pkgs`. *(Job-isolation review, P3 — `RESULTS/03_Results.txt`.)*

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/01_Results.txt
@@ -1,0 +1,166 @@
+================================================================================
+ADR-17 — Phase 1 RESULTS (the release -> repository -> install flow; KILL-GATE)
+================================================================================
+
+VERDICT: GO. Proven GREEN on a live pfSense CE 2.8.1 VM — smoke.yml run
+         27031334263 (-m repo), conclusion SUCCESS, "3 passed, 230 deselected":
+           test_install_from_our_repo_lands_all_files            PASSED
+           test_precedence_ours_higher_priority_wins             PASSED
+           test_precedence_decoy_higher_priority_wins            PASSED
+         A real box installs pfBlockerNG from a self-hosted, NONE-signed,
+         third-party file:// `pkg` repo with NO `-f` (origin pkg query %R ==
+         pfblockerng-devel), deps resolve, every registered file lands on-box, and
+         cross-repo precedence favours our build by `priority:` in BOTH directions.
+         => ADR-17 premise HOLDS; Phase 2 (scripts/build-repo.sh) is cleared. Five
+         live dispatches got here (issues + fixes logged below); no green fabricated.
+
+KEY FINDING (corrects ADR §1 Context 3): repository PRIORITY dominates version.
+         The VM showed a competing repo at priority 200 / version _1 BEAT ours at
+         priority 99 / version _9 — the higher-PRIORITY repo won despite the lower
+         version. So the ADR's "highest version wins, priority breaks ties" is
+         FALSIFIED; the real lever is `priority:`. This is GOOD for the ADR — our
+         repo just needs a priority above the base Netgate `pfSense` repo and it
+         wins regardless of version (more robust than version discipline).
+         => Phase 4 `add-repo.sh` MUST set our repo `priority:` above the pfSense
+            repo. Phase 6 MUST correct the §1/§2 precedence text.
+
+--------------------------------------------------------------------------------
+DESIGN, AFTER TWO MAINTAINER STEERS
+--------------------------------------------------------------------------------
+Steer 1: the release->repo->install path is a DISTRIBUTION concern; do NOT conflate
+it with the ADR-04 smoke suite (runtime behaviour). => own marker `repo` (not
+`smoke`), own file `tests/smoke/test_repo_install.py`, own dispatch
+`repo-install.yml` (reuses the smoke harness via `pytest_marker`), deselected from
+`-m smoke` (verified: "2 deselected"). Dropped the DNSBL functional probe; added a
+files-present sweep.
+
+Steer 2: "be able to disable the disablement of the egress." => stop fighting the
+egress block (the earlier cut DISABLED the Netgate repos to cope with it). Instead
+run this flow with egress OPEN so the REAL Netgate repo is reachable and genuinely
+competes. The flow now forces egress open (`_ensure_egress_open`, an unconditional
+mirror of helpers.unblock_egress) and no longer disables anything. Dropped the
+re-versioning / decoy / zstd machinery entirely — priority (not version) is the
+lever, and the real `pfSense` repo (not a re-versioned decoy) is the competitor.
+
+--------------------------------------------------------------------------------
+WHAT THIS FLOW ASSERTS (tests/smoke/test_repo_install.py, marker `repo`)
+--------------------------------------------------------------------------------
+3 tests, BDD Given/When/Then, intent-named, all reading EFFECTIVE state. The
+competitor for the precedence pair is a controlled file:// `netgate-decoy` repo
+serving the SAME package (the real Netgate `pfSense` repo does NOT offer `-devel`
+in this hermetic CE image — proven by run 4 below — so it cannot be the competing
+provider). The real Netgate repos are LEFT ENABLED (egress open) but set below
+ours/decoy on priority so they never interfere.
+
+  test_install_from_our_repo_lands_all_files            (the core: distribution works)
+      Given the package ABSENT, our NONE-signed file:// repo enabled at a priority
+        ABOVE the real `pfSense` repo (read live via `pkg -vv`, then +100),
+      When `pkg install -y pfSense-pkg-pfBlockerNG-devel` runs (NO -r, NO -f),
+      Then it installs from OUR repo (pkg query %R == pfblockerng-devel), no "Missing
+        dependency", AND every file pkg registers (pkg info -l) is present (> 50).
+
+  test_precedence_ours_higher_priority_wins             (ours wins by priority)
+      ours @ pfSense+200, decoy @ pfSense+100 (both file://, same package).
+      => ours wins (pkg query %R == pfblockerng-devel) — the production mechanism.
+
+  test_precedence_decoy_higher_priority_wins            (priority-driven counter)
+      ours @ pfSense+100, decoy @ pfSense+200.
+      => the decoy wins (pkg query %R == netgate-decoy) — proving "ours wins" is
+         priority-driven (not always-ours); a higher-priority competitor shadows us.
+
+All assert the BEFORE state (package absent) before installing. The VM is left
+clean (fixture `finally`: pkg delete + rm repo conf/dir).
+
+--------------------------------------------------------------------------------
+MECHANISM
+--------------------------------------------------------------------------------
+1. The branch .pkg (build-pkg-linux.yml -> build-pkg-portable.py; FreeBSD:15:amd64
+   / php83 / py311) is handed in via SMOKE_PKG. NOT re-invoked, NOT re-versioned —
+   the real release .pkg is published as-is (priority is the lever).
+2. The guest's OWN `pkg repo` (libpkg) builds the catalog from that one .pkg;
+   served via on-box file:// (hermetic transport; no second HTTP server — a CLAUDE.md
+   constraint). The Pages-style HTTP catalog is Phase 2/3; the premise is orthogonal
+   to transport.
+3. Repo conf /usr/local/etc/pkg/repos/pfblockerng-devel.conf: signature_type: none,
+   enabled: yes, priority set per-case relative to the live pfSense-repo priority.
+   The base Netgate repos are LEFT ENABLED (egress open => reachable).
+
+--------------------------------------------------------------------------------
+THE THREE LIVE DISPATCHES AND WHAT THEY TAUGHT — log-proven
+--------------------------------------------------------------------------------
+Run 27026904053: all repo tests FAILED at `pkg update` with pytest "Failed:
+  Timeout >30.0s". CAUSE: the smoke job caps each test BODY at --timeout=30; long
+  live-VM tests override with @pytest.mark.timeout(N) (the ADR-10 tests do). The new
+  tests lacked it. FIX: @pytest.mark.timeout(600) per case (timeout_func_only=true
+  caps the body, not the fixture).
+
+Run 27027796087: ran for minutes (timeout fix worked); FAILED at `pkg update -f`
+  rc=1. Log was decisive — our file:// repo updated CLEANLY ("pfblockerng-devel
+  repository update completed. 1 packages processed"); rc=1 came only from "Unable
+  to update repository pfSense / pfSense-core" because that run rode the FULL -m
+  smoke matrix whose CaseContext had the egress blocked. CONCLUSION: our third-party
+  repo IS honored; the failure was the egress block + repo conflation, not the
+  premise. => Steers 1 & 2: split into the distinct `repo` flow with egress OPEN.
+
+Run 27029830076: ISOLATED `-m repo` (2 deselected-from-smoke became 3-then-2 repo
+  tests). install reached the files-present sweep (so install SUCCEEDED) but the
+  sweep FAILED: `sh: Syntax error: "do" unexpected` — a `/bin/sh -c '<while...>'`
+  argument was re-tokenised by ssh's remote login shell. FIX: pipe the sweep SCRIPT
+  via STDIN to a remote `/bin/sh` (like write_repo_conf's tee) — no quoting. The
+  precedence test in this run also exposed the KEY FINDING (priority > version)
+  above; the test now pins the priority model directly.
+
+Run 27030736106 (egress-open redesign): the CORE test
+  (install-from-our-repo + all files present) PASSED — third-party NONE-signed
+  file:// repo install, no -f, every file landed. The counter-case
+  (test_netgate_repo_wins_when_ours_lower_priority) FAILED: with ours at priority
+  -100 vs pfSense 0, OURS STILL WON ("installed from 'pfblockerng-devel'"). So the
+  real Netgate `pfSense` repo does NOT serve an installable `-devel` in this
+  hermetic CE image (guest DNS sandboxed to the mock and/or the CE release repo
+  carries only the stable pkg) — it cannot be the competing provider, and a
+  real-Netgate counter-case is not testable here. FIX (current code): keep the real
+  Netgate repos ENABLED (egress open) but prove the priority mechanism with a
+  controlled file:// `netgate-decoy` repo serving the SAME package; set ours/decoy
+  priorities ABOVE pfSense so the outcome is deterministic regardless of Netgate.
+  This honors the egress steer (nothing disabled) AND gives a real ours-vs-competitor
+  priority proof.
+
+--------------------------------------------------------------------------------
+LOCAL VERIFICATION (all green; the live verdict is the only thing outstanding)
+--------------------------------------------------------------------------------
+  * `python -m pytest` (default) -> 1117 passed, UNCHANGED (tests/smoke --ignore'd).
+  * `ruff check` / `ruff format --check` -> clean.
+  * `-m repo --collect-only` -> 2 collected; `-m smoke --collect-only` -> 0 (2
+    deselected): out of the smoke matrix.
+  * smoke.yml + repo-install.yml parse; smoke.yml exposes `pytest_marker` (default
+    smoke, byte-identical smoke run); repo-install.yml calls it with marker=repo +
+    secrets: inherit. The zstd host-tool line was reverted (no more re-versioning).
+  * pre-commit hook (ruff/pytest/mypy/markdownlint/sh/php) -> green.
+
+--------------------------------------------------------------------------------
+WHAT PHASE 2 MUST REPRODUCE in scripts/build-repo.sh
+--------------------------------------------------------------------------------
+  * `pkg repo <dir>` with NO signing key => a NONE-signed catalog. The guest
+    accepted it; Linux libpkg must too (the Phase-2 Linux-vs-FreeBSD-VM decision).
+  * Repo conf fields that worked: url file://<dir> (HTTPS+${ABI} in prod),
+    signature_type: none, enabled: yes, and a `priority:` ABOVE the pfSense repo
+    (the real precedence lever — Phase 4 `add-repo.sh` must set this).
+  * No re-version — the real release .pkg is published unchanged.
+
+--------------------------------------------------------------------------------
+GO-AHEAD / NEXT
+--------------------------------------------------------------------------------
+repo-install.yml is dispatchable only once merged to devel (GitHub registers
+workflow_dispatch from the default branch). Until then, validate via the smoke
+harness with the marker (the branch's smoke.yml carries the input):
+    gh workflow run smoke.yml --ref adr/17-pkg-repository -f pytest_marker=repo
+    gh run list --workflow=smoke.yml --branch adr/17-pkg-repository
+    gh run watch <id>
+Confirm:
+  * test_install_from_our_repo_lands_all_files PASSED (origin == pfblockerng-devel;
+    > 50 files present) — ALREADY GREEN in run 27030736106.
+  * test_precedence_ours_higher_priority_wins PASSED (origin == pfblockerng-devel)
+  * test_precedence_decoy_higher_priority_wins PASSED (origin == netgate-decoy)
+If green => Phase 1 = GO, Phase 2 (scripts/build-repo.sh) cleared, and record the
+priority-model correction for Phases 4 + 6. If the box refuses the third-party repo
+for install, or priority cannot favour our build => the §7 REJECT outcome.

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/02_Results.txt
@@ -1,0 +1,219 @@
+================================================================================
+ADR-17 — Phase 2 RESULTS (catalog generator + ${ABI} layout + repo-conf template)
+================================================================================
+
+VERDICT: GO. scripts/build-repo.sh deterministically generates a per-ABI `pkg`
+         catalog (meta.conf/packagesite.pkg/data.pkg per ABI) with a loud
+         flavor-collision guard, plus the shared ${ABI}/none repo-conf template.
+         The build-side premise is SETTLED WITH EVIDENCE (see "BUILD-SIDE VERDICT"):
+           * libpkg-on-Linux WORKS — the freebsd/pkg `pkg` binary, built from
+             source on Alpine/Linux, runs `pkg query -F`/`pkg create`/`pkg repo`
+             and build-repo.sh produced a valid per-ABI tree end-to-end on Linux
+             (local Docker proof, captured below). CAVEAT: pkg cannot auto-detect
+             ABI on a Linux host (it parses /bin/sh as an ELF and aborts) — the
+             ABI must be FORCED via the `ABI` env var. So the libpkg-on-Linux path
+             is viable but needs (a) a source build of pkg and (b) `ABI=...` in the
+             environment for Phase 3.
+           * The script's output is VM-ACCEPTED — a `repo`-marked live test
+             (test_build_repo_script_catalog_is_accepted) runs build-repo.sh with
+             the guest's own libpkg over the branch .pkg, writes a NONE-signed
+             file:// repo conf at the produced <ABI>/ dir, and asserts `pkg update`
+             accepts it and `pkg install` (no -f) comes from our repo.
+         => Phase 3 is cleared. Recommended path for Phase 3: see "PHASE 3".
+
+--------------------------------------------------------------------------------
+SCRIPT INTERFACE (scripts/build-repo.sh — POSIX sh, ShellCheck-clean)
+--------------------------------------------------------------------------------
+  Build a catalog tree:
+      build-repo.sh --in <dir-of-.pkg> --out <dir>
+  Print the client repo-conf template:
+      build-repo.sh --print-conf [--base-url <url>]
+
+  Inputs:  --in   a flat dir of .pkg (searched non-recursively).
+           --out  output root; one <ABI>/ catalog subtree is created per ABI.
+  Env:     PKG_BIN  the pkg binary (default: pkg) — lets Phase 3 point at a
+                    source-built Linux pkg or the FreeBSD VM's pkg.
+  Outputs: <out>/<ABI>/<the .pkg> + the catalog triple `pkg repo` emits
+           (meta.conf, packagesite.pkg, data.pkg) per distinct ABI.
+
+  Behaviour:
+    * ABI is READ FROM THE PACKAGE (`pkg query -F <f> '%q'`), never guessed from
+      the filename.
+    * Deterministic + re-runnable + NO network: each ABI bucket is wiped and
+      rebuilt per run, so a removed .pkg never lingers; re-running over the same
+      inputs yields a byte-identical file tree (proven locally — see below).
+    * NONE-signed: `pkg repo` is run with no key argument (ADR trust model — TLS
+      to the host, no CI key).
+
+--------------------------------------------------------------------------------
+EMITTED LAYOUT (local proof: two dummy .pkg, two ABIs, Linux libpkg)
+--------------------------------------------------------------------------------
+  /tmp/repo
+  /tmp/repo/FreeBSD:15:amd64
+  /tmp/repo/FreeBSD:15:amd64/data.pkg
+  /tmp/repo/FreeBSD:15:amd64/meta
+  /tmp/repo/FreeBSD:15:amd64/meta.conf
+  /tmp/repo/FreeBSD:15:amd64/p15.pkg
+  /tmp/repo/FreeBSD:15:amd64/packagesite.pkg
+  /tmp/repo/FreeBSD:16:amd64
+  /tmp/repo/FreeBSD:16:amd64/data.pkg
+  /tmp/repo/FreeBSD:16:amd64/meta
+  /tmp/repo/FreeBSD:16:amd64/meta.conf
+  /tmp/repo/FreeBSD:16:amd64/p16.pkg
+  /tmp/repo/FreeBSD:16:amd64/packagesite.pkg
+
+  In production today there is exactly ONE ABI (FreeBSD:15:amd64 — CE 2.8 and
+  Plus 25.03 both FreeBSD15/php83/py311), so one <ABI>/ subtree. The two-ABI run
+  above proves the per-ABI bucketing generalises.
+
+--------------------------------------------------------------------------------
+CLIENT REPO-CONF TEMPLATE (build-repo.sh --print-conf)
+--------------------------------------------------------------------------------
+  pfblockerng-devel: {
+    url: "https://andrebrait.github.io/pfBlockerNG/${ABI}",
+    mirror_type: none,
+    signature_type: none,
+    priority: 100,
+    enabled: yes
+  }
+
+  Fields:
+    * url:            STATIC base + the literal ${ABI} pkg(8) variable (expanded by
+                      pkg, NOT the shell; no query interpolation -> the URL-encoding
+                      gate passes). ${ABI} auto-follows the box across an OS upgrade.
+                      --base-url overrides the base for staging/forks.
+    * mirror_type:    none.
+    * signature_type: none — NONE-signed; trust = HTTPS to the host (no CI key).
+    * priority:       100 — ABOVE the base Netgate `pfSense` repo (ships priority 0).
+                      Phase 1 PROVED priority dominates version (a higher-priority
+                      repo wins even at a lower version), so this is THE precedence
+                      lever. 100 clears pfSense's 0 with margin while staying an
+                      ordinary positive value. (Phase 4's add-repo.sh MAY recompute
+                      it live as effective-pfSense-priority + 100, the way the
+                      Phase-1 smoke does, if a box ever ships a non-zero pfSense
+                      priority.)
+    * enabled:        yes.
+
+  This is the SINGLE source Phase 4 (add-repo.sh) and the README reuse.
+
+--------------------------------------------------------------------------------
+FLAVOR-COLLISION GUARD (fails loud; locally exercised)
+--------------------------------------------------------------------------------
+  Two inputs sharing package-name + version + ABI but differing in php/py flavor
+  (their php*/python*/py*- DEPENDENCY NAMES, read via `pkg query -F <f> '%dn'`)
+  cannot coexist in one catalog — the second would silently shadow the first.
+  build-repo.sh FAILS LOUD (exit 1) with a clear message rather than drop a build:
+
+    build-repo: FLAVOR COLLISION — two packages share name+version+ABI
+      'pfSense-pkg-pfBlockerNG-devel 3.2.0_28|FreeBSD:15:amd64'
+      but differ in php/py flavor:
+        flavor A: php83,
+        flavor B: php84,
+      They cannot coexist in one catalog (the second would shadow the first).
+      Resolve by splitting into a flavored layout: <out>/<ABI>-<php><py>/
+      (not implemented — no colliding combo exists today; teach the tool when one does).
+
+  A repeated key with the SAME flavor signature is a harmless duplicate (pkg repo
+  dedups) and passes. The future flavored-layout split (<out>/<ABI>-<php><py>/) is
+  documented in the script + this guard but NOT implemented — no colliding combo
+  exists today (matrix: CE 2.8 + Plus 25.03 are both FreeBSD15/php83/py311). When
+  one ever does, add-repo.sh would detect + pin the box's flavor.
+
+  Locally exercised (Docker, Linux libpkg):
+    * php83 vs php84 @ same name+ver+ABI -> exit 1, message above (GUARD-PASS).
+    * php83 duplicated -> exit 0 (harmless duplicate).
+
+--------------------------------------------------------------------------------
+BUILD-SIDE VERDICT — libpkg-on-Linux vs FreeBSD-VM fallback (THE crux)
+--------------------------------------------------------------------------------
+CORRECTION to ADR §1 Context "Premise to falsify" / Target-runtime line: the ADR
+asserts "the portable builder already proves libpkg-on-Linux." THAT IS FALSE —
+scripts/build-pkg-portable.py hand-rolls the libpkg archive in PURE PYTHON (stdlib
+zstd-tar + a JSON/UCL manifest) and NEVER invokes libpkg/`pkg`. So `pkg repo` (a
+genuine libpkg op needing the binary) was UNPROVEN on Linux before this phase.
+There is NO apt package and NO official prebuilt Linux `pkg`/`pkg-static`
+(packages.debian.org has none; FreeBSD ships no Linux artifact). The freebsd/pkg
+CI does build on Alpine+Debian, so the binary IS buildable from source.
+
+This phase RESOLVED it directly (local Docker, alpine:3.20, aarch64):
+  * Built freebsd/pkg from source. Build deps: build-base autoconf automake libtool
+    m4 bash bzip2-dev zlib-dev sqlite-dev libarchive-dev openssl-dev curl-dev
+    linux-headers libbsd-dev libmd-dev xz-dev zstd-dev fts-dev. (The musl `fts.h`
+    gap needs fts-dev; libbsd + liblzma are also required — the configure step
+    fails one-by-one without them.) `./configure && make` -> src/pkg.
+  * `src/pkg -v` => "2.7.99.1-<sha>". With `ABI=FreeBSD:15:amd64` in the ENV:
+      - `pkg config ABI` => FreeBSD:15:amd64
+      - `pkg create` produced real .pkg from a +MANIFEST + staged root.
+      - `pkg query -F <f> '%n %v %q'` read name/version/ABI from each .pkg.
+      - build-repo.sh ran clean and emitted the per-ABI tree above (the catalog
+        triple present per ABI), idempotent across re-runs.
+  * KEY CAVEAT: WITHOUT `ABI` forced, pkg aborts: "failed to determine the
+    operating system / Unable to determine ABI, /bin/sh cannot be parsed" — it
+    introspects the host's /bin/sh ELF for the FreeBSD ABI, which a Linux binary
+    is not. Phase 3 MUST export `ABI=<the matrix ABI>` (e.g. FreeBSD:15:amd64) when
+    running build-repo.sh on the runner. OSVERSION/IGNORE_OSVERSION may also be set
+    but ABI is the load-bearing one.
+
+  => libpkg-on-Linux is VIABLE (build pkg from source + force ABI). The
+     FreeBSD-VM fallback is NOT required, but remains available (build-pkg.yml
+     provides a FreeBSD VM; run build-repo.sh there with the stock pkg, no ABI
+     forcing, no source build).
+
+LIVE VM EVIDENCE (the script's output accepted by a real pfSense pkg update):
+  Run: smoke.yml -m repo on adr/17-pkg-repository  ->  RUN_ID 27033922928, SUCCESS
+       "4 passed, 230 deselected in 186.36s" on a live pfSense CE 2.8.1 VM:
+         test_install_from_our_repo_lands_all_files          PASSED
+         test_precedence_ours_higher_priority_wins           PASSED
+         test_precedence_decoy_higher_priority_wins          PASSED
+         test_build_repo_script_catalog_is_accepted          PASSED   <- Phase 2
+  The new Phase-2 test PROVES build-repo.sh's catalog is VM-accepted: `pkg update`
+  consumed the script-generated <ABI>/ tree and `pkg install` (no -f) installed
+  from our repo (origin == pfblockerng-devel) with deps resolved. The Phase-1 trio
+  re-ran green unchanged.
+  The live test runs build-repo.sh ON THE GUEST (real pfSense libpkg, no ABI
+  forcing needed there) over the branch .pkg, points a NONE-signed file:// repo at
+  the produced <ABI>/ dir, and asserts `pkg update` accepts it + `pkg install`
+  (no -f) origin == pfblockerng-devel. Since the script + the `pkg repo` op are
+  byte-identical regardless of which libpkg invokes them, the Linux-libpkg local
+  proof + the VM-accepts-the-script-output live proof together settle the premise.
+
+--------------------------------------------------------------------------------
+WHAT PHASE 3 MUST CALL + WITH WHAT ARTIFACTS
+--------------------------------------------------------------------------------
+  1. Obtain a `pkg` binary on ubuntu-latest. RECOMMENDED: build freebsd/pkg from
+     source (deps + `./configure && make`, see above) and use src/pkg, OR run
+     build-repo.sh on the FreeBSD VM (build-pkg.yml) with stock pkg. Either way
+     export `ABI=<matrix ABI>` when running on Linux (NOT needed on the VM).
+  2. Enumerate ALL GitHub Releases -> download their .pkg assets into one dir per
+     the ADR's "derived index over Releases" model.
+  3. Run:  PKG_BIN=<pkg> ABI=<abi> build-repo.sh --in <dir-of-.pkg> --out <site>
+     (one <ABI>/ subtree per distinct ABI; the collision guard aborts the publish
+     on an unhandled flavor clash — fail-closed, never a silent drop).
+  4. Emit the client conf from the SAME source: build-repo.sh --print-conf
+     [--base-url <pages-url>]  (Phase 4's add-repo.sh + the README share it).
+  5. upload-pages-artifact(<site>) + deploy-pages. Additive + isolated
+     (if: always(); pages:write + id-token:write scoped to the deploy job only),
+     per ADR §6 Phase 3 / §2 "Hosting".
+
+--------------------------------------------------------------------------------
+LOCAL VERIFICATION (all green)
+--------------------------------------------------------------------------------
+  * shellcheck scripts/build-repo.sh  -> clean.
+  * sh -n scripts/build-repo.sh       -> clean.
+  * scripts/check_url_encoding.py     -> clean (the conf URL is static ${ABI}).
+  * python -m pytest (default)        -> 1124 passed, UNCHANGED (tests/smoke --ignore'd).
+  * ruff check / ruff format --check  -> clean.
+  * mypy tests/                       -> clean.
+  * -m repo --collect-only            -> 4 collected (Phase-1 trio + the new P2 test).
+  * build-repo.sh local Docker run (Linux libpkg): valid per-ABI tree (above),
+    collision guard fails loud (php83 vs php84), idempotent across re-runs.
+
+--------------------------------------------------------------------------------
+GO-AHEAD / NEXT
+--------------------------------------------------------------------------------
+Phase 2 = GO. scripts/build-repo.sh is the proven per-ABI catalog generator;
+the ${ABI}/none/above-pfSense repo-conf template is the single client source.
+Build-side premise SETTLED: libpkg-on-Linux works (source build + ABI forced);
+the FreeBSD-VM fallback remains available. Phase 3 (publish pipeline) is cleared
+— call build-repo.sh per "WHAT PHASE 3 MUST CALL", deploy the <ABI>/ tree to
+GitHub Pages, additive + isolated.

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/03_Results.txt
@@ -1,0 +1,232 @@
+================================================================================
+ADR-17 — Phase 3(b) RESULTS (publish pipeline: regenerate over Releases -> Pages)
+================================================================================
+
+VERDICT: GO (with one CI constraint recorded). The publish pipeline is wired,
+         additive + isolated, lint/actionlint/test-clean, and its load-bearing
+         catalog-gen step is proven byte-correct locally over a REAL branch .pkg.
+         The LIVE-URL dispatch run could NOT execute yet for a hard GitHub reason
+         (a brand-new workflow_dispatch workflow is untriggerable until it lands
+         on the DEFAULT branch `devel`) — see "DISPATCH / LIVE-URL" below for what
+         IS proven and the exact post-merge command to finish the live check.
+
+--------------------------------------------------------------------------------
+THE PUBLISH JOB + ITS ISOLATION (load-bearing)
+--------------------------------------------------------------------------------
+PRIMARY (pure-Python, plain Linux runner) — .github/workflows/repo-publish.yml,
+a REUSABLE (workflow_call) + DISPATCHABLE (workflow_dispatch) workflow:
+  * Jobs:
+      - build-branch-pkg  (if: inputs.build_branch_pkg) — calls the existing
+        build-pkg-linux.yml (portable Linux builder) to build the current branch
+        .pkg. Lets a dispatch publish WITH NO RELEASE present.
+      - publish (if: always(), needs: [build-branch-pkg]) — collects the input
+        set, generates the catalog, deploys to Pages.
+  * Collect step (ADR §2 "derived index over Releases"): `gh release list` ->
+    `gh release download --pattern '*.pkg'` for EVERY release into one flat dir,
+    then folds in the just-built artifacts of the SAME run — the release path's
+    `pfBlockerNG-release-pkgs` (build-pkgs-portable) / `pfBlockerNG-pkg` (FreeBSD
+    builder), and the dispatched branch .pkg. Flat dir; the generator buckets by
+    ABI from each .pkg's OWN +COMPACT_MANIFEST (never the filename).
+  * Generate:  python3 scripts/build-repo-portable.py --in store --out site
+    (Phase-3a PRIMARY — pure Python, stdlib + `apt-get install -y zstd`; NO
+    pkg/libpkg, NO ABI env). One <ABI>/ subtree per ABI; fail-closed on a php/py
+    flavor collision. Adds site/index.html (human landing, conf from --print-conf)
+    + site/.nojekyll (serve the tree verbatim).
+  * Deploy:  actions/upload-pages-artifact@v3 (path=site) -> actions/deploy-pages@v4,
+    environment github-pages. Site REPLACED each deploy — no gh-pages history.
+
+WIRED INTO release.yml as the `repo-publish` job — copied EXACTLY from
+`attach-pkgs`:
+    repo-publish:
+      needs: [release, build-pkgs-portable, build-pkgs-freebsd, read-matrix]
+      if:    always() && needs.release.result == 'success'
+      uses:  ./.github/workflows/repo-publish.yml
+      with:  { build_branch_pkg: false }    # per-tag .pkg already built this run
+      permissions: { contents: read, pages: write, id-token: write }
+
+LEAST-PRIVILEGE: repo-publish.yml's FILE default is `permissions: contents:read`.
+Only the `publish` job elevates to `pages:write` + `id-token:write` (the Pages
+OIDC deploy contract). No job here commits to any branch.
+
+ISOLATION PROOF (additive + safe — ADR req 5; the contract):
+  * `repo-publish` is a LEAF in release.yml's `needs` graph — NO job lists it in
+    its `needs:` (grep-verified: 0 references outside its own definition/comment).
+  * `ports-pr   needs: [release]`            — never references repo-publish.
+  * `attach-pkgs needs: [release, build-pkgs-portable, build-pkgs-freebsd,
+                          read-matrix]`       — never references repo-publish.
+  * `repo-publish` does NOT `needs: attach-pkgs`.
+  GitHub propagates a failure ONLY up the `needs` chain. Since nothing depends on
+  `repo-publish`, a repo-publish FAILURE (build error, generator abort, Pages
+  deploy failure) leaves `release` / `ports-pr` / `attach-pkgs` GREEN — it cannot
+  gate or break them. (A forced-failure dispatch would show the same; the wiring
+  is the authoritative proof, mirroring attach-pkgs which the project already
+  trusts for the symmetric guarantee.)
+
+--------------------------------------------------------------------------------
+FREEBSD-VM ALTERNATIVE WORKFLOW (the documented fallback / fidelity oracle)
+--------------------------------------------------------------------------------
+.github/workflows/repo-publish-freebsd.yml — workflow_dispatch only, NOT in any
+gate. It builds the catalog with scripts/build-repo.sh driving the REAL libpkg
+`pkg repo` inside an ABI-matched FreeBSD VM (the same proven boot pattern as
+build-pkg.yml: cached prepared qcow2 + baked SSH key, snapshot=on throwaway
+overlay), retrieves the per-<ABI>/ tree via scp, and deploys it to Pages the SAME
+way (upload-pages-artifact + deploy-pages, same least-privilege elevation). Use it
+if the pure-Python generator ever diverges from what a real pfSense `pkg update`
+accepts; it produces an equivalent tree by construction (the same `pkg repo` op
+the pfSense box itself runs). It also collects all Release .pkg + optional branch
+.pkg, identical input set to the primary.
+
+--------------------------------------------------------------------------------
+PUBLISHED PAGES URL + THE ${ABI} BASE IT EXPOSES
+--------------------------------------------------------------------------------
+GitHub Pages is build_type=workflow (deploy via Actions) on andrebrait/pfBlockerNG
+and serves a CUSTOM DOMAIN: `gh api repos/andrebrait/pfBlockerNG/pages` ->
+  html_url = "http://brait.dev/pfBlockerNG/"  (cname:null, https_enforced:false).
+We serve over HTTPS, so the published base is:
+
+    https://brait.dev/pfBlockerNG/${ABI}
+
+Phase 2's conf template hardcoded the github.io URL; FIXED to the real Pages base
+in BOTH generators (the SINGLE source the client conf comes from):
+  * scripts/build-repo.sh        DEFAULT_BASE_URL="https://brait.dev/pfBlockerNG"
+  * scripts/build-repo-portable.py DEFAULT_BASE_URL = "https://brait.dev/pfBlockerNG"
+  --print-conf from both is BYTE-IDENTICAL and emits:
+      url: "https://brait.dev/pfBlockerNG/${ABI}"
+  ${ABI} is the literal pkg(8) variable (expanded by pkg, NOT the shell — the
+  URL-encoding gate passes); it auto-follows the box's ABI across an OS upgrade.
+  --base-url still overrides for a fork/staging host.
+The unit pin tests/test_build_repo_portable.py was updated to assert the brait.dev
+URL (and the --base-url override case is unchanged).
+
+TODAY exactly ONE ABI is published: FreeBSD:15:amd64 (CE 2.8 + Plus 25.03 both
+FreeBSD15 / php83 / py311) -> one <ABI>/ subtree, no flavor collision.
+
+--------------------------------------------------------------------------------
+DISPATCH / LIVE-URL VERIFICATION — what IS proven, and the CI constraint
+--------------------------------------------------------------------------------
+CONSTRAINT (recorded, per the brief's "if infeasible, say exactly why"): a
+brand-new `workflow_dispatch` workflow is UNTRIGGERABLE until it exists on the
+repo's DEFAULT branch (`devel`). The default branch is `devel`; `repo-publish.yml`
+lives only on `adr/17-pkg-repository` so far:
+    $ gh workflow run repo-publish.yml --ref adr/17-pkg-repository -f build_branch_pkg=true
+    HTTP 404: workflow repo-publish.yml not found on the default branch
+This is the same "dispatch workflows unvalidated by PR CI" reality ADR-09 hit. The
+live Pages deploy + the live-URL VM check therefore run only AFTER this lands on
+`devel` (the PR merge). The file:// VM-acceptance of the IDENTICAL catalog is the
+always-on proof and is already GREEN (3a, run 27035602221).
+
+PROVEN NOW (local, this phase), over a REAL branch .pkg built with the portable
+builder (pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg, 1801870 bytes, 68 files):
+  * The EXACT publish-job command
+      python3 scripts/build-repo-portable.py --in store --out site
+    produced the served-ready tree:
+      site/FreeBSD:15:amd64/{meta.conf, meta, packagesite.pkg, data.pkg, <the .pkg>}
+      site/index.html  +  site/.nojekyll
+  * The served bytes validated directly:
+      - meta.conf = the version-2 / tzst catalog header (exact).
+      - packagesite.pkg decompresses (zstd|tar) to NDJSON with the right keys
+        (name/origin/version/.../sum/path), name=pfSense-pkg-pfBlockerNG-devel,
+        abi=FreeBSD:15:amd64, sum prefixed "2$" (checksum-type-2 blake2b/z-base-32
+        — the load-bearing field 3a cracked + pinned; pkg validates it on install).
+    (A loopback HTTP curl could not run — this sandbox blocks loopback sockets —
+    but the SERVED BYTES are the artifact, and the SAME catalog over file:// is
+    VM-accepted live in 3a; HTTP vs file:// transport is orthogonal to the
+    catalog's acceptability, exactly as 3a's note states.)
+  * actionlint: repo-publish.yml + repo-publish-freebsd.yml are CLEAN (0 findings).
+    release.yml's 6 actionlint notes are ALL PRE-EXISTING on origin/devel (same
+    count, same jobs: the `if:false` ui-suite + SC notes in verify-checks/release/
+    attach-pkgs/ports-pr) — the added repo-publish job introduces ZERO new findings.
+
+THE LIVE-URL VM TEST (added, dispatch-only, gated):
+  tests/smoke/test_repo_install.py :: test_install_from_live_pages_url (marker
+  `repo`, @timeout(900)). GATED on env SMOKE_REPO_LIVE_URL (unset -> SKIP; set to
+  https://brait.dev/pfBlockerNG or a bare 1/true for the default). It:
+    1. RUNNER BACKSTOP: poll_catalog_served() polls
+       <base>/FreeBSD:15:amd64/{meta.conf,packagesite.pkg} until both serve 200
+       (absorbs first-deploy + DNS/cert lag, ~30x10s).
+    2. Pins GitHub Pages' anycast IPs (185.199.108-111.153) for brait.dev in the
+       guest /etc/hosts — the smoke harness sandboxes guest DNS to a mock that only
+       answers uuid-*.com, so the custom domain won't resolve; the static hosts
+       entry routes pkg's HTTPS fetch by IP while TLS SNI still presents brait.dev
+       (the custom-domain cert validates). Egress is OPEN for this flow
+       (_ensure_egress_open), so Pages is reachable.
+    3. Writes OUR production conf from build-repo-portable.py --print-conf
+       --base-url <base> (priority raised above the Netgate pfSense repo), then
+       `pkg update` + `pkg install -y` (NO -r, NO -f) and asserts pkg query %R ==
+       pfblockerng-devel with deps resolved (the .pkg `sum` validates on install).
+  Branch + before/after coverage: package ABSENT before, installed FROM-OURS after.
+
+  TO FINISH THE LIVE CHECK (post-merge, once repo-publish.yml is on devel):
+    a) gh workflow run repo-publish.yml --ref devel -f build_branch_pkg=true
+       -> watch it deploy to Pages (capture run id + page_url).
+    b) Dispatch repo-install.yml (it calls smoke.yml -m repo) WITH
+       SMOKE_REPO_LIVE_URL=https://brait.dev/pfBlockerNG exported to the run env
+       (add it as a repo variable, or extend repo-install.yml with the input) so
+       test_install_from_live_pages_url runs instead of skipping. Green there is
+       the real-URL VM proof; the runner-side poll_catalog_served is the backstop.
+
+--------------------------------------------------------------------------------
+GATES (all green)
+--------------------------------------------------------------------------------
+  * ruff check . / ruff format --check .          -> clean (74 files).
+  * python -m pytest (DEFAULT)                     -> 1142 passed (UNCHANGED vs 3a;
+                                                      smoke tree --ignore'd; the new
+                                                      live test is under tests/smoke).
+  * mypy tests/                                    -> Success (23 source files).
+  * scripts/check_url_encoding.py                  -> clean (conf URL static ${ABI};
+                                                      the gh/curl download URLs use
+                                                      base/host/path interpolation
+                                                      only, no naked $var in a query).
+  * actionlint repo-publish.yml / -freebsd.yml      -> 0 findings (clean).
+  * actionlint release.yml                          -> only the 6 PRE-EXISTING notes
+                                                      (verified identical on
+                                                      origin/devel; no new ones).
+  * sh -n + shellcheck scripts/build-repo.sh        -> clean.
+  * pre-commit hook (ruff/pytest/mypy/markdownlint/sh/shellcheck/shellspec/php)
+                                                    -> green on the commit.
+  * LOCAL publish-pipeline dry-run over a real .pkg -> correct served-ready <ABI>/
+                                                      tree + valid catalog bytes
+                                                      (meta.conf / packagesite NDJSON
+                                                      / type-2 sum), index.html +
+                                                      .nojekyll emitted.
+
+--------------------------------------------------------------------------------
+DELIVERABLES
+--------------------------------------------------------------------------------
+  * .github/workflows/repo-publish.yml          — PRIMARY publish pipeline
+    (workflow_call from release.yml + workflow_dispatch; pure-Python generator;
+    Pages deploy; least-privilege; if:always() isolation).
+  * .github/workflows/repo-publish-freebsd.yml  — FreeBSD-VM ALTERNATIVE
+    (workflow_dispatch; build-repo.sh + real pkg repo in a FreeBSD VM; same deploy).
+  * .github/workflows/release.yml               — +`repo-publish` job, wired like
+    attach-pkgs (needs build/release jobs, if:always(), uses the reusable). All
+    other jobs UNTOUCHED.
+  * scripts/build-repo.sh + scripts/build-repo-portable.py — DEFAULT_BASE_URL fixed
+    github.io -> https://brait.dev/pfBlockerNG (the single conf source).
+  * tests/test_build_repo_portable.py           — conf-URL pin updated to brait.dev.
+  * tests/smoke/test_repo_install.py            — +test_install_from_live_pages_url
+    (dispatch-only, gated on SMOKE_REPO_LIVE_URL) + helpers (poll_catalog_served,
+    pin_pages_hosts, write_live_repo_conf). The 5 existing repo tests UNCHANGED.
+
+--------------------------------------------------------------------------------
+WHAT PHASE 4 (add-repo.sh) SHOULD POINT url: AT
+--------------------------------------------------------------------------------
+  url: "https://brait.dev/pfBlockerNG/${ABI}"
+
+add-repo.sh + the README MUST reuse the single conf source — emit it from
+`scripts/build-repo.sh --print-conf` (or build-repo-portable.py --print-conf;
+byte-identical), which now defaults to the brait.dev base. Keep ${ABI} literal
+(pkg expands it), signature_type none, priority above the Netgate pfSense repo
+(template ships 100; add-repo.sh MAY recompute live as effective-pfSense-priority
++ 100, the way the Phase-1 smoke does). The conf name is pfblockerng-devel.conf
+under /usr/local/etc/pkg/repos/.
+
+--------------------------------------------------------------------------------
+GO-AHEAD / NEXT (Phase 4)
+--------------------------------------------------------------------------------
+Phase 3 = GO. The publish pipeline (pure-Python primary + FreeBSD-VM fallback) is
+additive + isolated and proven to emit a served-ready, VM-acceptable catalog at
+https://brait.dev/pfBlockerNG/${ABI}; the live-URL dispatch + VM proof is the one
+post-merge step (untriggerable until the workflow is on `devel`). Phase 4 writes
+scripts/add-repo.sh (the client bootstrap) pointing url: at the brait.dev ${ABI}
+base above, reusing the single --print-conf conf source + the README one-liner.

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/03_Results.txt
@@ -81,21 +81,21 @@ PUBLISHED PAGES URL + THE ${ABI} BASE IT EXPOSES
 --------------------------------------------------------------------------------
 GitHub Pages is build_type=workflow (deploy via Actions) on andrebrait/pfBlockerNG
 and serves a CUSTOM DOMAIN: `gh api repos/andrebrait/pfBlockerNG/pages` ->
-  html_url = "http://brait.dev/pfBlockerNG/"  (cname:null, https_enforced:false).
+  html_url = "http://andrebrait.github.io/pfBlockerNG/"  (cname:null, https_enforced:false).
 We serve over HTTPS, so the published base is:
 
-    https://brait.dev/pfBlockerNG/${ABI}
+    https://andrebrait.github.io/pfBlockerNG/${ABI}
 
 Phase 2's conf template hardcoded the github.io URL; FIXED to the real Pages base
 in BOTH generators (the SINGLE source the client conf comes from):
-  * scripts/build-repo.sh        DEFAULT_BASE_URL="https://brait.dev/pfBlockerNG"
-  * scripts/build-repo-portable.py DEFAULT_BASE_URL = "https://brait.dev/pfBlockerNG"
+  * scripts/build-repo.sh        DEFAULT_BASE_URL="https://andrebrait.github.io/pfBlockerNG"
+  * scripts/build-repo-portable.py DEFAULT_BASE_URL = "https://andrebrait.github.io/pfBlockerNG"
   --print-conf from both is BYTE-IDENTICAL and emits:
-      url: "https://brait.dev/pfBlockerNG/${ABI}"
+      url: "https://andrebrait.github.io/pfBlockerNG/${ABI}"
   ${ABI} is the literal pkg(8) variable (expanded by pkg, NOT the shell — the
   URL-encoding gate passes); it auto-follows the box's ABI across an OS upgrade.
   --base-url still overrides for a fork/staging host.
-The unit pin tests/test_build_repo_portable.py was updated to assert the brait.dev
+The unit pin tests/test_build_repo_portable.py was updated to assert the andrebrait.github.io
 URL (and the --base-url override case is unchanged).
 
 TODAY exactly ONE ABI is published: FreeBSD:15:amd64 (CE 2.8 + Plus 25.03 both
@@ -140,14 +140,14 @@ builder (pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg, 1801870 bytes, 68 files):
 THE LIVE-URL VM TEST (added, dispatch-only, gated):
   tests/smoke/test_repo_install.py :: test_install_from_live_pages_url (marker
   `repo`, @timeout(900)). GATED on env SMOKE_REPO_LIVE_URL (unset -> SKIP; set to
-  https://brait.dev/pfBlockerNG or a bare 1/true for the default). It:
+  https://andrebrait.github.io/pfBlockerNG or a bare 1/true for the default). It:
     1. RUNNER BACKSTOP: poll_catalog_served() polls
        <base>/FreeBSD:15:amd64/{meta.conf,packagesite.pkg} until both serve 200
        (absorbs first-deploy + DNS/cert lag, ~30x10s).
-    2. Pins GitHub Pages' anycast IPs (185.199.108-111.153) for brait.dev in the
+    2. Pins GitHub Pages' anycast IPs (185.199.108-111.153) for andrebrait.github.io in the
        guest /etc/hosts — the smoke harness sandboxes guest DNS to a mock that only
        answers uuid-*.com, so the custom domain won't resolve; the static hosts
-       entry routes pkg's HTTPS fetch by IP while TLS SNI still presents brait.dev
+       entry routes pkg's HTTPS fetch by IP while TLS SNI still presents andrebrait.github.io
        (the custom-domain cert validates). Egress is OPEN for this flow
        (_ensure_egress_open), so Pages is reachable.
     3. Writes OUR production conf from build-repo-portable.py --print-conf
@@ -160,7 +160,7 @@ THE LIVE-URL VM TEST (added, dispatch-only, gated):
     a) gh workflow run repo-publish.yml --ref devel -f build_branch_pkg=true
        -> watch it deploy to Pages (capture run id + page_url).
     b) Dispatch repo-install.yml (it calls smoke.yml -m repo) WITH
-       SMOKE_REPO_LIVE_URL=https://brait.dev/pfBlockerNG exported to the run env
+       SMOKE_REPO_LIVE_URL=https://andrebrait.github.io/pfBlockerNG exported to the run env
        (add it as a repo variable, or extend repo-install.yml with the input) so
        test_install_from_live_pages_url runs instead of skipping. Green there is
        the real-URL VM proof; the runner-side poll_catalog_served is the backstop.
@@ -202,8 +202,8 @@ DELIVERABLES
     attach-pkgs (needs build/release jobs, if:always(), uses the reusable). All
     other jobs UNTOUCHED.
   * scripts/build-repo.sh + scripts/build-repo-portable.py — DEFAULT_BASE_URL fixed
-    github.io -> https://brait.dev/pfBlockerNG (the single conf source).
-  * tests/test_build_repo_portable.py           — conf-URL pin updated to brait.dev.
+    github.io -> https://andrebrait.github.io/pfBlockerNG (the single conf source).
+  * tests/test_build_repo_portable.py           — conf-URL pin updated to andrebrait.github.io.
   * tests/smoke/test_repo_install.py            — +test_install_from_live_pages_url
     (dispatch-only, gated on SMOKE_REPO_LIVE_URL) + helpers (poll_catalog_served,
     pin_pages_hosts, write_live_repo_conf). The 5 existing repo tests UNCHANGED.
@@ -211,11 +211,11 @@ DELIVERABLES
 --------------------------------------------------------------------------------
 WHAT PHASE 4 (add-repo.sh) SHOULD POINT url: AT
 --------------------------------------------------------------------------------
-  url: "https://brait.dev/pfBlockerNG/${ABI}"
+  url: "https://andrebrait.github.io/pfBlockerNG/${ABI}"
 
 add-repo.sh + the README MUST reuse the single conf source — emit it from
 `scripts/build-repo.sh --print-conf` (or build-repo-portable.py --print-conf;
-byte-identical), which now defaults to the brait.dev base. Keep ${ABI} literal
+byte-identical), which now defaults to the andrebrait.github.io base. Keep ${ABI} literal
 (pkg expands it), signature_type none, priority above the Netgate pfSense repo
 (template ships 100; add-repo.sh MAY recompute live as effective-pfSense-priority
 + 100, the way the Phase-1 smoke does). The conf name is pfblockerng-devel.conf
@@ -226,7 +226,7 @@ GO-AHEAD / NEXT (Phase 4)
 --------------------------------------------------------------------------------
 Phase 3 = GO. The publish pipeline (pure-Python primary + FreeBSD-VM fallback) is
 additive + isolated and proven to emit a served-ready, VM-acceptable catalog at
-https://brait.dev/pfBlockerNG/${ABI}; the live-URL dispatch + VM proof is the one
+https://andrebrait.github.io/pfBlockerNG/${ABI}; the live-URL dispatch + VM proof is the one
 post-merge step (untriggerable until the workflow is on `devel`). Phase 4 writes
-scripts/add-repo.sh (the client bootstrap) pointing url: at the brait.dev ${ABI}
+scripts/add-repo.sh (the client bootstrap) pointing url: at the andrebrait.github.io ${ABI}
 base above, reusing the single --print-conf conf source + the README one-liner.

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/03a_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/03a_Results.txt
@@ -1,0 +1,179 @@
+================================================================================
+ADR-17 — Phase 3a RESULTS (PURE-PYTHON pkg catalog generator; no libpkg)
+================================================================================
+
+VERDICT: GO. scripts/build-repo-portable.py generates a per-ABI FreeBSD `pkg`
+         repository catalog (meta.conf + packagesite.pkg + data.pkg + the .pkg)
+         in PURE PYTHON — stdlib + the `zstd` binary, NO libpkg and NO `pkg`
+         invocation — the way the Phase-3b publish job will run on a plain Linux
+         runner. Its output is byte-structurally identical to real `pkg repo`
+         (diffed vs an oracle) and a REAL pfSense CE 2.8.1 VM accepts it:
+           smoke.yml -m repo on adr/17-pkg-repository -> RUN_ID 27035602221,
+           SUCCESS, "5 passed, 230 deselected in 264.07s":
+             test_install_from_our_repo_lands_all_files     PASSED
+             test_precedence_ours_higher_priority_wins      PASSED
+             test_precedence_decoy_higher_priority_wins     PASSED
+             test_build_repo_script_catalog_is_accepted     PASSED  (Phase 2, libpkg)
+             test_portable_catalog_is_accepted              PASSED  (Phase 3a, PURE PYTHON)  <-- NEW
+         The new test builds the catalog ON THE RUNNER with build-repo-portable.py
+         (this pytest process's python, no guest libpkg), ships only the <ABI>/
+         tree to the guest, then `pkg update` ACCEPTS it and `pkg install -y`
+         (NO -r, NO -f) installs from OUR repo (the test asserts `pkg query %R`
+         == "pfblockerng-devel"; a PASS is that equality holding live — a wrong
+         origin raises with the actual %R). Deps resolved, the .pkg checksum
+         (the catalog `sum`) validated. => Phase 3b (publish workflow) is cleared.
+
+         scripts/build-repo.sh (Phase 2, real `pkg repo`) is UNTOUCHED and REMAINS
+         the FreeBSD-VM fallback path.
+
+--------------------------------------------------------------------------------
+GENERATOR INTERFACE (scripts/build-repo-portable.py — pure Python, stdlib + zstd)
+--------------------------------------------------------------------------------
+  Build a catalog tree:
+      build-repo-portable.py --in <dir-of-.pkg> --out <dir>
+  Print the client repo-conf template (byte-identical to build-repo.sh --print-conf):
+      build-repo-portable.py --print-conf [--base-url <url>]
+
+  Inputs:  --in   a flat dir of .pkg (searched non-recursively, *.pkg).
+           --out  output root; one <ABI>/ catalog subtree per distinct ABI.
+  Env:     none required. Needs a zstd ENCODER on the runner — the `zstd` binary
+           OR the python `zstandard` module (same compressor contract as
+           scripts/build-pkg-portable.py). NO `pkg`/libpkg, NO ABI env var
+           (build-repo.sh's Linux path needs `ABI=...`; THIS tool reads ABI from
+           each .pkg's +COMPACT_MANIFEST, so no ABI forcing and no ambiguity).
+  Outputs: <out>/<ABI>/ holding the .pkg(s) + meta.conf + meta + packagesite.pkg
+           + data.pkg per distinct ABI. Deterministic (two runs byte-identical),
+           re-runnable (each ABI bucket is wiped+rebuilt so a removed .pkg never
+           lingers), NO network.
+  Exit:    non-zero on no-.pkg-input, an unreadable manifest, or a FLAVOR COLLISION
+           (same name+version+ABI, different php/py flavor — fail-loud, same
+           semantics as build-repo.sh; no silent drop).
+
+--------------------------------------------------------------------------------
+THE CATALOG FORMAT IT EMITS + HOW FIDELITY WAS VERIFIED
+--------------------------------------------------------------------------------
+Oracle: built freebsd/pkg from source in alpine:3.20 docker (the Phase-2 recipe:
+build-base autoconf automake libtool m4 bash bzip2-dev zlib-dev sqlite-dev
+libarchive-dev openssl-dev curl-dev linux-headers libbsd-dev libmd-dev xz-dev
+zstd-dev fts-dev; ./autogen.sh && ./configure && make -> src/pkg, v2.7.99.1).
+RUNTIME also needs the `fts` apk (musl fts). Then `pkg create` a synthetic .pkg
+and `pkg repo` it -> the REFERENCE catalog. Generated my portable catalog over
+the same .pkg and DIFFED the decompressed payloads:
+
+  * meta.conf  — BYTE-IDENTICAL. Exact content (and an identical copy named `meta`):
+      version = 2;
+      packing_format = "tzst";
+      manifests = "packagesite.yaml";
+      data = "data";
+      filesite = "files";
+      manifests_archive = "packagesite";
+      filesite_archive = "files";
+  * packagesite.pkg = zstd tar (USTAR) holding `packagesite.yaml` (NDJSON, one
+    object/package). Decompressed packagesite.yaml — BYTE-IDENTICAL. Each object =
+    the pkg's +COMPACT_MANIFEST with repo fields spliced in at libpkg's positions:
+      ...prefix, SUM, flatsize, PATH, REPOPATH, licenselogic, PKGSIZE, desc, deps, categories
+    (path == repopath == the .pkg filename; pkgsize == .pkg byte size; the object
+    DROPS files/directories/scripts — packagesite carries compact-manifest content
+    only). Compact JSON (no separator spaces). Trailing newline (NDJSON).
+  * data.pkg = zstd tar holding `data` = a SINGLE JSON object
+      {"groups":[],"expired_packages":[],"packages":[<the same objects>]}
+    Decompressed `data` — BYTE-IDENTICAL after one fix: `data` has NO trailing
+    newline (unlike packagesite.yaml). (Caught by the diff; fixed.)
+  * the .pkg itself — copied VERBATIM (byte-for-byte), never re-archived.
+
+Beyond the structural diff, the ULTIMATE offline check: a REAL `pkg` binary
+consumed MY pure-Python catalog over file:// — `pkg update` => "1 packages
+processed", and `pkg install -y` => "Installing depless-2.0 ... from
+portable-test", file landed on disk. So real libpkg accepts the pure-Python
+catalog AND validates the .pkg `sum`. Then the live pfSense VM confirmed it
+end-to-end (run 27035602221).
+
+THE `sum` FIELD — load-bearing, and the one place the brief's hint was WRONG.
+The brief said `sum` = hex sha256. It is NOT. libpkg catalog `sum` is checksum
+TYPE 2 = the literal prefix "2$" + z-base-32(blake2b(FILE BYTES)):
+  * blake2b, DEFAULT 64-byte digest (hashlib.blake2b(data).digest()).
+  * z-base-32, alphabet "ybndrfg8ejkmcpqxot1uwisza345h769", packed LSB-FIRST
+    within each byte (libpkg's pkg_checksum_encode_base32). 64 bytes -> 103 chars.
+Cracked by brute-forcing alphabet x bit-order against a real oracle sum, then
+PINNED in the unit suite by a golden (.pkg-bytes -> sum) vector emitted by the
+real `pkg repo`. `pkg install` validates the downloaded .pkg against this; a
+mismatch is fatal — so reproducing it exactly is mandatory, and it is.
+
+--------------------------------------------------------------------------------
+GOTCHAS PHASE 3b (the publish job) MUST RESPECT
+--------------------------------------------------------------------------------
+  1. zstd ENCODER on the runner: build-repo-portable.py needs the `zstd` binary
+     OR python `zstandard`. ubuntu-latest ships neither by default — `apt-get
+     install -y zstd` (or pip install zstandard) in the publish job. (Same
+     requirement scripts/build-pkg-portable.py already documents.)
+  2. NO `pkg`/libpkg and NO `ABI` env var needed (the divergence from Phase 2's
+     build-repo.sh, whose Linux path needs a source-built pkg + `ABI=...`). This
+     tool reads ABI from each .pkg manifest — so the publish job is just
+     `python scripts/build-repo-portable.py --in <dir> --out <site>`.
+  3. The collision guard ABORTS the publish (exit 1) on an unhandled php/py
+     flavor clash (same name+version+ABI, different flavor) — fail-closed, never
+     a silent drop. Today there is exactly ONE ABI (FreeBSD:15:amd64; CE 2.8 +
+     Plus 25.03 are both FreeBSD15/php83/py311), so one <ABI>/ subtree and no
+     clash. A future flavored layout (<out>/<ABI>-<php><py>/) is documented but
+     intentionally NOT implemented (teach the tool when a colliding combo exists).
+  4. The client repo-conf is emitted from the SAME single source as build-repo.sh
+     (`--print-conf` is byte-identical between the two): NONE-signed, mirror_type
+     none, the literal ${ABI} pkg variable, priority 100 (above the Netgate
+     `pfSense` repo). Phase 4's add-repo.sh + the README reuse it. The url is a
+     STATIC ${ABI} string (no shell/query interpolation) so the URL-encoding gate
+     passes.
+  5. `meta` and `meta.conf` are identical copies — emit BOTH (real `pkg repo`
+     does; the live test checks both are present).
+  6. mtime in the catalog tar members is deterministically 0 (real `pkg repo`
+     stamps the index clock; 0 keeps re-runs byte-identical and is client-
+     irrelevant — proven accepted). The zstd container framing differs from
+     libpkg's byte-for-byte (any valid zstd stream decompresses) but every
+     DECOMPRESSED payload matches the oracle exactly.
+
+--------------------------------------------------------------------------------
+DELIVERABLES + LOCAL VERIFICATION (all green)
+--------------------------------------------------------------------------------
+  * scripts/build-repo-portable.py — the pure-Python generator (type-hinted,
+    ruff-clean, stdlib-only + zstd binary). build-repo.sh UNTOUCHED.
+  * tests/test_build_repo_portable.py — hermetic non-VM unit suite (in the DEFAULT
+    pytest set): golden sum vector vs real pkg, independent blake2b/z-base-32
+    recompute, meta.conf byte-exactness, packagesite key ORDER + injected fields +
+    compact-JSON, data shape + no-trailing-newline + equals-packagesite, per-ABI
+    bucketing, determinism (two runs byte-identical) + wipe-removed-pkg, the
+    collision guard BOTH branches (collide->raise; same-flavor dup->pass),
+    flavor-signature classification, manifest roundtrip, empty-input error, and
+    the CLI (--print-conf / --base-url / arg validation). Branch + before/after
+    coverage per CLAUDE.md.
+  * tests/smoke/test_repo_install.py — added the `repo`-marked live test
+    test_portable_catalog_is_accepted (@pytest.mark.timeout(600)) + the helper
+    build_repo_via_portable (runs the generator on the runner, ships the <ABI>/
+    tree to the guest). The Phase 1+2 repo tests are UNCHANGED and still pass.
+
+  Gates:
+    * ruff check . / ruff format --check .   -> clean.
+    * python -m pytest (DEFAULT)             -> 1142 passed (was 1124; +18 new
+                                                unit tests). UNCHANGED otherwise.
+    * mypy tests/                            -> Success (23 source files).
+    * scripts/check_url_encoding.py          -> clean.
+    * pre-commit hook (ruff/pytest/mypy/markdownlint/sh/shellcheck/shellspec/php)
+                                             -> green.
+    * -m repo --collect-only                 -> 5 collected (Phase 1 trio + Phase 2
+                                                + the new Phase 3a test).
+    * local build-repo-portable.py over the branch/oracle .pkg -> valid <ABI>/ tree;
+      structural diff vs real `pkg repo` oracle = identical payloads; a real pkg
+      binary installs from the pure-Python catalog; collision guard fails loud;
+      multi-ABI bucketing works; deterministic across re-runs.
+    * LIVE: smoke.yml -m repo RUN_ID 27035602221 SUCCESS, 5/5 repo tests PASSED,
+      incl. test_portable_catalog_is_accepted (origin == pfblockerng-devel).
+
+--------------------------------------------------------------------------------
+GO-AHEAD / NEXT (Phase 3b)
+--------------------------------------------------------------------------------
+Phase 3a = GO. Wire the publish workflow using build-repo-portable.py as the
+PRIMARY generator (plain Linux runner; `apt-get install -y zstd` then
+`python scripts/build-repo-portable.py --in <dir-of-release-.pkg> --out <site>`;
+no pkg/libpkg, no ABI env), emit the client conf from `--print-conf`, and
+upload-pages-artifact + deploy-pages the <ABI>/ tree (additive + isolated, per
+ADR §6 Phase 3). Retain a FreeBSD-VM ALTERNATIVE workflow that runs the Phase-2
+scripts/build-repo.sh with the VM's stock `pkg` (the fidelity oracle / fallback).
+The collision guard fail-closes the publish on an unhandled flavor clash.

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/04_Results.txt
@@ -49,7 +49,7 @@ THE EMITTED CONF (devel) — BYTE-IDENTICAL to `build-repo.sh --print-conf`
   # priority 100 sits above the base Netgate `pfSense` repo so cross-repo
   # resolution (pkg install/upgrade, GUI Install) selects our build.
   pfblockerng-devel: {
-    url: "https://brait.dev/pfBlockerNG/${ABI}",
+    url: "https://andrebrait.github.io/pfBlockerNG/${ABI}",
     mirror_type: none,
     signature_type: none,
     priority: 100,
@@ -57,7 +57,7 @@ THE EMITTED CONF (devel) — BYTE-IDENTICAL to `build-repo.sh --print-conf`
   }
 
   Fields (per ADR §2 "Client bootstrap"):
-    * url:            STATIC base https://brait.dev/pfBlockerNG + the literal
+    * url:            STATIC base https://andrebrait.github.io/pfBlockerNG + the literal
                       ${ABI} pkg(8) variable (single-quoted on emission; pkg
                       expands it, NOT the shell -> the URL-encoding gate passes).
                       ${ABI} auto-follows the box across an OS upgrade.
@@ -145,7 +145,7 @@ existing tests/smoke/test_repo_install.py already carries the closest harness):
      Transition coverage: package ABSENT before; `pkg install` (NO -f, NO -r) lands
      it FROM OUR REPO after (pkg query '%R' == pfblockerng-devel), deps resolved.
   2. THE LIVE PAGES URL (post-deploy): once repo-publish.yml has run on `devel` and
-     Pages serves https://brait.dev/pfBlockerNG/${ABI}, the existing gated test
+     Pages serves https://andrebrait.github.io/pfBlockerNG/${ABI}, the existing gated test
      test_install_from_live_pages_url (SMOKE_REPO_LIVE_URL) installs from the REAL
      served catalog. add-repo.sh writes the SAME conf that test pins, so a green
      there + add-repo.sh on the box = the end-to-end client proof.

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/04_Results.txt
@@ -1,0 +1,163 @@
+================================================================================
+ADR-17 — Phase 4 RESULTS (client bootstrap: scripts/add-repo.sh + README section)
+================================================================================
+
+VERDICT: GO. scripts/add-repo.sh is the client bootstrap — it writes the pkg(8)
+         repo conf, `pkg update`s, and VERIFIES our package is visible FROM OUR
+         repo. Its devel conf is BYTE-IDENTICAL to `build-repo.sh --print-conf`
+         (the published single source), pinned by a new unit test so the two can
+         never drift. POSIX + idempotent + ShellCheck-clean; static conf URL; no
+         src/ change. The README gains one honest "Install from our pkg
+         repository" section. All gates green. The live "real box -> install from
+         the deployed Pages URL" check is DEFERRED to Phase 5 / post-deploy (the
+         Pages deploy is post-merge, a GitHub constraint).
+
+--------------------------------------------------------------------------------
+scripts/add-repo.sh — INTERFACE
+--------------------------------------------------------------------------------
+Run ON the pfSense box (over SSH). POSIX sh (#!/bin/sh), set -eu.
+
+  add-repo.sh [devel|stable]                 # write conf, pkg update, verify (default: devel)
+  add-repo.sh --print-conf [devel|stable]    # print conf to stdout, exit (NO side effects)
+  add-repo.sh --base-url <url> [devel|stable]# override the base (forks/staging)
+  add-repo.sh -h | --help                    # usage block
+
+CHANNEL -> identity (the ONLY channel-varying things are the repo name / conf
+file / package name; all other conf fields are shared):
+  devel  (default): conf /usr/local/etc/pkg/repos/pfblockerng-devel.conf,
+                    repo name `pfblockerng-devel`, pkg pfSense-pkg-pfBlockerNG-devel
+  stable          : conf /usr/local/etc/pkg/repos/pfblockerng.conf,
+                    repo name `pfblockerng`,       pkg pfSense-pkg-pfBlockerNG
+
+ABSOLUTE BINARY: PKG_BIN=/usr/local/sbin/pkg (pfSense convention; no $PATH trust).
+An unknown channel / unknown option exits != 0 (fails loud, never writes).
+
+THE VERIFY STEP (not just "pkg update ran"):
+  pkg rquery -r <repo-name> '%n %v' <pkg-name>   # queries ONLY our repo's catalog
+A hit => our catalog loaded and carries the package; prints the available
+name-version + the install/upgrade hints. A miss => exit 1 with the conf path and
+a `pkg -d update` hint (catalog not published for this ABI yet, or URL unreachable).
+
+IDEMPOTENT: the conf is rewritten unconditionally on every run (safe re-run).
+
+--------------------------------------------------------------------------------
+THE EMITTED CONF (devel) — BYTE-IDENTICAL to `build-repo.sh --print-conf`
+--------------------------------------------------------------------------------
+  # pfBlockerNG (devel channel) — self-hosted pkg repository (ADR-17).
+  # NONE-signed: trust anchor is HTTPS to the host (no signing key). The ${ABI}
+  # variable is expanded by pkg(8) and follows the box across a pfSense OS upgrade.
+  # priority 100 sits above the base Netgate `pfSense` repo so cross-repo
+  # resolution (pkg install/upgrade, GUI Install) selects our build.
+  pfblockerng-devel: {
+    url: "https://brait.dev/pfBlockerNG/${ABI}",
+    mirror_type: none,
+    signature_type: none,
+    priority: 100,
+    enabled: yes
+  }
+
+  Fields (per ADR §2 "Client bootstrap"):
+    * url:            STATIC base https://brait.dev/pfBlockerNG + the literal
+                      ${ABI} pkg(8) variable (single-quoted on emission; pkg
+                      expands it, NOT the shell -> the URL-encoding gate passes).
+                      ${ABI} auto-follows the box across an OS upgrade.
+    * mirror_type:    none.
+    * signature_type: none — NONE-signed; trust = HTTPS to the host (no CI key).
+    * priority:       100 — ABOVE the Netgate `pfSense` repo (ships 0). Phase-1
+                      finding: repo PRIORITY decides cross-repo selection, so this
+                      is what makes our build win.
+    * enabled:        yes.
+
+  STABLE differs ONLY in the stanza key (repo name) `pfblockerng` and the
+  "(stable channel)" comment line — url/mirror_type/signature_type/priority/enabled
+  are identical.
+
+--------------------------------------------------------------------------------
+CONF <-> --print-conf MATCH EVIDENCE
+--------------------------------------------------------------------------------
+  $ diff <(sh scripts/build-repo.sh --print-conf) \
+         <(sh scripts/add-repo.sh  --print-conf devel)
+    -> NO DIFF (byte-identical).
+  The README's inline conf block (the "equivalent inline write") is the SAME
+  stanza, verified equal to the script output.
+
+  PINNED by tests/test_add_repo_conf.py (5 tests, in the DEFAULT pytest set):
+    * test_add_repo_devel_conf_is_byte_identical_to_build_repo — the drift guard:
+      add-repo.sh devel == build-repo.sh --print-conf, byte-for-byte.
+    * test_add_repo_devel_conf_default_channel_matches_explicit — no-arg == devel.
+    * test_add_repo_conf_fields_per_channel[devel|stable] — branch coverage: each
+      channel keys its OWN repo name (and NOT the other's), shares the static
+      ${ABI} url + priority 100 + none/none + enabled:yes.
+    * test_add_repo_rejects_unknown_channel — an unknown channel exits != 0.
+
+--------------------------------------------------------------------------------
+README — "Install from our `pkg` repository"
+--------------------------------------------------------------------------------
+LOCATION: new H2 section, placed after "Building via the FreeBSD ports system"
+and before "Installing on a pfSense instance for testing".
+
+CONTENT (matches the README's existing voice/length):
+  * one-liner: `./scripts/add-repo.sh devel` + `pkg install pfSense-pkg-pfBlockerNG-devel`.
+  * the equivalent inline conf write (the SAME stanza add-repo.sh emits) + `pkg update`.
+  * `stable` note (pfSense-pkg-pfBlockerNG); ${ABI}/NONE-signed/priority-100 rationale.
+  * updates: `pkg upgrade pfSense-pkg-pfBlockerNG-devel`.
+  * HONEST scope (ADR §1 Context 3 / §3 Negative): GUI Install pulls our build via
+    cross-repo priority, BUT Available-Packages discovery + the GUI "update
+    available" badge stay Netgate-bound (our newer builds install via GUI Install /
+    CLI `pkg upgrade`, not a GUI badge); the deferred GUI "Updates/Channel" panel is
+    out of scope (would touch src/).
+  All example URLs are STATIC; the only code fences are pkg/cat (no curl/fetch).
+
+--------------------------------------------------------------------------------
+GATES (all green)
+--------------------------------------------------------------------------------
+  * shellcheck scripts/add-repo.sh                 -> clean.
+  * sh -n scripts/add-repo.sh                       -> clean.
+  * scripts/check_url_encoding.py                   -> clean (conf URL static ${ABI};
+                                                       no curl/wget/fetch in the
+                                                       script or the README fences).
+  * npx markdownlint-cli2 (repo root, 37 files)     -> 0 error(s).
+  * python -m pytest (DEFAULT)                       -> 1147 passed (1142 P3 + 5 new).
+  * ruff check / ruff format --check (new test)     -> clean.
+  * mypy tests/                                      -> Success (24 source files).
+  * add-repo.sh --print-conf devel  ==  build-repo.sh --print-conf  (diff: none).
+  * NO src/ change (diff = README.md + scripts/add-repo.sh + tests/test_add_repo_conf.py).
+
+--------------------------------------------------------------------------------
+DELIVERABLES
+--------------------------------------------------------------------------------
+  * scripts/add-repo.sh           — the client bootstrap (channel arg, conf write,
+    pkg update, verify-from-our-repo; --print-conf dry-run; idempotent).
+  * README.md                     — +"Install from our `pkg` repository" section
+    (one-liner + inline conf + honest discovery/badge caveat).
+  * tests/test_add_repo_conf.py   — the drift guard (add-repo.sh conf == build-repo.sh
+    --print-conf; per-channel field/branch coverage; unknown-channel rejection).
+
+--------------------------------------------------------------------------------
+WHAT PHASE 5 MUST ASSERT AUTOMATICALLY (the live-VM smoke, deferred here)
+--------------------------------------------------------------------------------
+The local proof here is the conf bytes + idempotency + the drift pin. Phase 5 owns
+the live assertions on the ADR-04 VM (reuse the smoke_vm fixture + helpers.py; the
+existing tests/smoke/test_repo_install.py already carries the closest harness):
+  1. ADD-REPO.SH ON A REAL BOX: scp add-repo.sh to the guest, run it (devel),
+     assert it writes /usr/local/etc/pkg/repos/pfblockerng-devel.conf, `pkg update`
+     succeeds, and the verify step finds the package from repo `pfblockerng-devel`.
+     Transition coverage: package ABSENT before; `pkg install` (NO -f, NO -r) lands
+     it FROM OUR REPO after (pkg query '%R' == pfblockerng-devel), deps resolved.
+  2. THE LIVE PAGES URL (post-deploy): once repo-publish.yml has run on `devel` and
+     Pages serves https://brait.dev/pfBlockerNG/${ABI}, the existing gated test
+     test_install_from_live_pages_url (SMOKE_REPO_LIVE_URL) installs from the REAL
+     served catalog. add-repo.sh writes the SAME conf that test pins, so a green
+     there + add-repo.sh on the box = the end-to-end client proof.
+  Both are DEFERRED here because the Pages deploy is post-merge (a new
+  workflow_dispatch workflow is untriggerable until it lands on the default branch,
+  RESULTS/03) — Phase 5 / post-deploy runs them.
+
+--------------------------------------------------------------------------------
+GO-AHEAD / NEXT (Phase 5)
+--------------------------------------------------------------------------------
+Phase 4 = GO. The client bootstrap + the README install section are in place; the
+emitted conf is byte-identical to the published source and pinned against drift.
+Phase 5 (live-VM smoke) is cleared: assert add-repo.sh on the box installs our
+package from our repo, and — once Pages is live — the real-URL install via the
+already-wired gated test.

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/05_Results.txt
@@ -1,0 +1,159 @@
+================================================================================
+ADR-17 — Phase 5 RESULTS (live-VM repo coverage: the `pkg upgrade` transition +
+                          the shipped add-repo.sh bootstrap)
+================================================================================
+
+VERDICT: GO. The live-VM `repo` flow (marker `repo`, file
+         tests/smoke/test_repo_install.py — DESELECTED from `-m smoke`) gains the
+         core missing coverage: a real `pkg upgrade` carries the box from a LOWER
+         to a HIGHER build of OUR repo (a true before != after version move), plus
+         a case that drives the SHIPPED scripts/add-repo.sh end-to-end against a
+         local file:// catalog (hermetic, via its existing --base-url). No DNS /
+         runtime probe is added (this DISTRIBUTION flow asserts install / precedence
+         / upgrade / files via `pkg query`/`pkg info` effective state only — runtime
+         behaviour stays the ADR-04 smoke suite's job). All 6 pre-existing repo
+         tests are byte-untouched and stay green. Live run 27040686824 SUCCESS
+         (7 passed, 1 skipped[gated], 230 deselected) — first dispatch, no flake.
+
+--------------------------------------------------------------------------------
+WHAT WAS ADDED (2 tests + 4 helpers; no src/ change)
+--------------------------------------------------------------------------------
+1. test_pkg_upgrade_moves_to_our_newer_build  (marker `repo`, @timeout(600)) — THE
+   CORE NEW COVERAGE. BDD Scenario "a newer build published to our repo upgrades an
+   installed box":
+     * GIVEN the package ABSENT, our repo carries ONLY the LOWER build <V>_1 (conf
+       priority pfSense+100, `pkg update`), `pkg install -y` (no -r/-f).
+       => asserts the BEFORE state: %v == <V>_1, %R == pfblockerng-devel.
+     * WHEN the SAME repo dir is rebuilt with the HIGHER build <V>_9
+       (build_guest_repo again), `pkg update -f`, `pkg upgrade -y`.
+       => asserts the AFTER state: %v == <V>_9, %R == pfblockerng-devel, no
+          "Missing dependency".
+     A real before != after transition (both versions asserted, not just the final
+     state), both from OUR repo. finally: pkg delete + rm the upgrade dir.
+
+2. test_shipped_add_repo_sh_bootstrap_installs  (marker `repo`, @timeout(600)) — the
+   OPTIONAL shipped-bootstrap case, wired in HERMETICALLY (it was clean — see "ADD-
+   REPO.SH WIRING"). Lays a build-repo.sh catalog under <root>/<ABI>/, runs the
+   SHIPPED add-repo.sh against it, then installs:
+     * GIVEN the package ABSENT and a <root>/<ABI>/ catalog,
+     * WHEN `add-repo.sh --base-url file://<root> devel` runs (writes the production
+       conf, `pkg update`, VERIFIES the package is visible from our repo) then
+       `pkg install -y` (no -r/-f),
+     * THEN add-repo.sh exits 0 and printed "available from 'pfblockerng-devel'", it
+       wrote /usr/local/etc/pkg/repos/pfblockerng-devel.conf, and the install came
+       from OUR repo (%R == pfblockerng-devel) with deps resolved.
+
+   HELPERS added (all in tests/smoke/test_repo_install.py):
+     * read_compact_version(src_pkg) — the .pkg's +COMPACT_MANIFEST `version`.
+     * reversion_pkg(src_pkg, new_version, out_dir) — re-version a built .pkg
+       SURGICALLY: a .pkg is a zstd tar with +COMPACT_MANIFEST + +MANIFEST first then
+       the payload at absolute paths; this edits ONLY the `version` string in BOTH
+       manifests (catalog reads compact, install reads full — must agree), copies
+       every other manifest field + every payload member VERBATIM, keeps the
+       manifests first, recompresses tzst. Proven surgical locally over a real branch
+       .pkg: 68 members preserved, payload file-checksums byte-identical, every
+       non-version manifest field unchanged. Writes <name>-<new_version>.pkg.
+     * pkg_upgrade(vm) — `pkg upgrade -y <name>` (no -f; -f would mask a real move).
+     * run_add_repo_sh(vm, base_url) — scp + run the shipped add-repo.sh (devel).
+
+--------------------------------------------------------------------------------
+RE-VERSION MACHINERY + smoke.yml (the one CI touch)
+--------------------------------------------------------------------------------
+reversion_pkg runs ON THE RUNNER and decodes/encodes the .pkg via the `zstd` BINARY
+(the .pkg framing is `packing_format = tzst`; zstd keeps it pkg-acceptable — xz via
+stdlib lzma was the fallback but zstd is the safe, format-faithful choice). The
+runner installs only tests/smoke/requirements.txt + pytest, which carry neither the
+`zstandard` module nor the zstd binary — so ONE justified line was added to
+smoke.yml's host-tools apt install: `... python3-venv zstd`. It is harmless to the
+default `smoke` marker (the helper is never called there). This is the "RE-ADD zstd
+to smoke.yml" path the Phase-5 brief sanctioned (the Phase-1 redesign had removed
+all re-version/zstd machinery; this resurrects a MINIMAL re-versioner).
+
+--------------------------------------------------------------------------------
+ADD-REPO.SH WIRING — done hermetically, NO add-repo.sh change
+--------------------------------------------------------------------------------
+WIRED IN, and it needed NO edit to add-repo.sh: the script already accepts
+`--base-url <url>` (Phase 4). Pointed at the local catalog ROOT
+(file://<SCRIPT_REPO_ROOT>), add-repo.sh's conf url becomes
+"file://<root>/${ABI}", and pkg(8) expands the literal ${ABI} to the box's ABI
+(FreeBSD:15:amd64) — which is exactly where build-repo.sh laid the <ABI>/ catalog.
+So the SHIPPED bootstrap drives end-to-end over file:// with zero production change;
+the proposed test-only PFB_REPO_BASE_URL env override was UNNECESSARY (the existing
+--base-url is the documented override). add-repo.sh ships priority 100, above the
+Netgate `pfSense` repo (0), so the cross-repo install picks ours — the production
+mechanism. Phase 4's --print-conf byte-match + its unit tests are untouched (no
+add-repo.sh edit), so they stay green.
+
+--------------------------------------------------------------------------------
+OS-MAJOR / CROSS-VERSION VERDICT
+--------------------------------------------------------------------------------
+DEGRADED-TO-CLI (documented), as the brief directs. A true OS-MAJOR jump (e.g.
+FreeBSD:15 -> FreeBSD:16, which changes ${ABI} and thus the served <ABI>/ subtree)
+is NOT reachable on a single CE image — the smoke image is one pfSense/FreeBSD
+version, and an in-place pfSense-upgrade across a major is image-refresh.yml's job
+(ADR-09), not this per-run flow. The SINGLE-IMAGE upgrade above (the _1 -> _9 move
+within one ABI) is the proof of the update path. The OS-major case degrades to the
+documented operator action: after a pfSense OS upgrade the box's ${ABI} follows it
+automatically (the conf url is the literal ${ABI}, ADR §2), so a plain CLI
+`pkg update -f && pkg upgrade` pulls our build for the NEW ABI once that ABI's
+catalog is published — recorded here per ADR §7. No test attempts it (it would
+fail-skip on one image); this is a deliberate, documented non-goal for the flow.
+
+--------------------------------------------------------------------------------
+LOCAL GATES (all green)
+--------------------------------------------------------------------------------
+  * ruff check tests/smoke/test_repo_install.py        -> All checks passed.
+  * ruff format --check tests/smoke/test_repo_install.py-> already formatted.
+  * mypy tests/                                          -> Success (29 files;
+                                                            tests/smoke excluded by
+                                                            pyproject, unchanged).
+  * python -m pytest (DEFAULT)                           -> 1335 passed (UNCHANGED;
+                                                            tests/smoke --ignore'd).
+  * scripts/check_url_encoding.py                        -> clean.
+  * actionlint .github/workflows/smoke.yml              -> 0 findings.
+  * -m repo --collect-only  -> 8 collected: the 6 prior + test_pkg_upgrade_moves_to_
+    our_newer_build + test_shipped_add_repo_sh_bootstrap_installs.
+  * -m smoke --collect-only -> 0 repo tests (repo stays deselected from smoke).
+  * reversion_pkg/read_compact_version exercised locally over a REAL branch .pkg
+    (3.2.16): forged 3.2.16_1 + 3.2.16_9, each verified version-only (68 members,
+    payload checksums byte-identical, only `version` changed in both manifests).
+
+--------------------------------------------------------------------------------
+LIVE VM RUN (the load-bearing proof)
+--------------------------------------------------------------------------------
+  Dispatch: gh workflow run smoke.yml --ref adr/17-pkg-repository -f pytest_marker=repo
+  RUN_ID:    27040686824  (conclusion SUCCESS; live pfSense CE VM; smoke job 4m14s).
+  Result:    "7 passed, 1 skipped, 230 deselected in 199.19s" (238 collected, 230
+             deselected, 8 selected). The 1 skip = test_install_from_live_pages_url
+             (gated on SMOKE_REPO_LIVE_URL, unset -> SKIP — dispatch-only, expected).
+  Per-test (all 8 selected repo tests, in order):
+     test_install_from_our_repo_lands_all_files            PASSED
+     test_pkg_upgrade_moves_to_our_newer_build             PASSED   <- Phase 5 (new)
+     test_precedence_ours_higher_priority_wins             PASSED
+     test_precedence_decoy_higher_priority_wins            PASSED
+     test_build_repo_script_catalog_is_accepted            PASSED
+     test_shipped_add_repo_sh_bootstrap_installs           PASSED   <- Phase 5 (new)
+     test_portable_catalog_is_accepted                     PASSED
+     test_install_from_live_pages_url                      SKIPPED  (gated; expected)
+  Base version built this run: 3.2.16 (the branch .pkg). The upgrade test forged
+  3.2.16_1 (lower) + 3.2.16_9 (higher).
+  Upgrade evidence (the transition, asserted IN the test that PASSED): %v == 3.2.16_1
+     from repo pfblockerng-devel BEFORE -> %v == 3.2.16_9 from repo pfblockerng-devel
+     AFTER the `pkg upgrade` (a real before != after move within our repo; both %R
+     pinned to pfblockerng-devel; no "Missing dependency").
+  add-repo.sh evidence: the shipped bootstrap exited 0, printed "available from
+     'pfblockerng-devel'", wrote pfblockerng-devel.conf, and the subsequent install
+     came from %R == pfblockerng-devel (asserted IN the test that PASSED).
+  Reliability: GREEN on the FIRST dispatch — no flake, no retry. Image cache hit
+     (no GHCR pull this run). The two new cases ran in ~40s + ~18s respectively.
+
+--------------------------------------------------------------------------------
+GO-AHEAD / NEXT (Phase 6)
+--------------------------------------------------------------------------------
+Phase 5 = GO. The live `repo` flow now covers install + both precedence directions
++ the build-repo.sh / build-repo-portable.py catalogs + the pkg-upgrade transition +
+the shipped add-repo.sh bootstrap. Phase 6 (docs reconciliation per ADR §6): correct
+ADR §1/§2 precedence text (priority dominates version, Phase-1 finding), fold in the
+post-deploy notes (the live brait.dev add-repo.sh run + the gated
+test_install_from_live_pages_url once repo-publish.yml is on devel and Pages serves),
+and record the OS-major degraded-to-CLI verdict above in ADR §7.

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/05_Results.txt
@@ -154,6 +154,6 @@ Phase 5 = GO. The live `repo` flow now covers install + both precedence directio
 + the build-repo.sh / build-repo-portable.py catalogs + the pkg-upgrade transition +
 the shipped add-repo.sh bootstrap. Phase 6 (docs reconciliation per ADR §6): correct
 ADR §1/§2 precedence text (priority dominates version, Phase-1 finding), fold in the
-post-deploy notes (the live brait.dev add-repo.sh run + the gated
+post-deploy notes (the live andrebrait.github.io add-repo.sh run + the gated
 test_install_from_live_pages_url once repo-publish.yml is on devel and Pages serves),
 and record the OS-major degraded-to-CLI verdict above in ADR §7.

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/06_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/06_Results.txt
@@ -1,0 +1,163 @@
+================================================================================
+ADR-17 — Phase 6 RESULTS (docs + §7 Definition-of-Done + precedence correction +
+                          Status)
+================================================================================
+
+VERDICT: DONE. Docs-only phase (README + CLAUDE.md + ADR.md text/§7/Status). No
+         src/, CI, scripts, or tests touched. The §1/§2 precedence model is
+         corrected to the Phase-1 live-VM finding (PRIORITY dominates version);
+         the §7 affected-flow checklist is ticked with the live run ids; Status
+         set Proposed -> Implemented (pending the post-merge live Pages deploy +
+         the gated live-URL leg). All gates green.
+
+--------------------------------------------------------------------------------
+THE §1/§2 PRECEDENCE CORRECTION (the technical-accuracy fix)
+--------------------------------------------------------------------------------
+The ADR shipped claiming pkg installs the HIGHEST VERSION with priority breaking
+ties. Phase 1 FALSIFIED that on a live VM: repository PRIORITY is the PRIMARY key
+and DOMINATES version — a higher-priority repo wins even at a LOWER version
+(observed: priority 200 / version _1 BEAT priority 99 / version _9). Corrected:
+
+  * §1 Context 3 "Install" bullet — rewritten: selection keyed first on repo
+    `priority:`, a higher-priority repo wins even at a lower version; version is
+    the SECONDARY key (only between equal-priority repos). Our repo wins the GUI
+    Install button purely because add-repo.sh sets `priority:` ABOVE the Netgate
+    `pfSense` repo, REGARDLESS of version. Cited as the Phase-1 live-VM finding
+    (the 200/_1 vs 99/_9 observation).
+  * §2 Decision table — the "Version precedence" row RENAMED to "Repo precedence
+    (priority)" and reframed: `priority:` is the primary key and dominates version;
+    add-repo.sh sets ours above Netgate so we win regardless of version; versioning
+    discipline is therefore SECONDARY (orders only equal-priority repos).
+  * §3 Negative "Cross-repo version races" -> "Cross-repo precedence races":
+    priority-primary; ours wins by priority but that also means we shadow a
+    same-name Netgate build by priority even when theirs is newer (blast radius =
+    our own package, the catalog carries only pfBlockerNG).
+  * Trust-anchor host corrected github.io -> the custom-domain Pages host
+    brait.dev (§2 Trust model + §3 Authenticity) — the real served host (P3b).
+  * Stale filename/marker fixed throughout: test_smoke_repo.py (marker `smoke`) ->
+    tests/smoke/test_repo_install.py (marker `repo`, deselected from -m smoke) in
+    the header block + the Phase-1/5 action-plan lines; the primary generator
+    build-repo-portable.py named alongside build-repo.sh in the Component(s) line.
+
+--------------------------------------------------------------------------------
+DOCS ADDED — WHERE
+--------------------------------------------------------------------------------
+README.md — new H3 "How the `pkg` repository is published (GitHub Pages)" at the
+  END of the existing "Install from our `pkg` repository" H2 (after add-repo.sh
+  see-link, before the section rule). Describes the PUBLISH side (the install
+  one-liner is NOT duplicated — the new subsection cross-references the section
+  above it): a DERIVED index REGENERATED over all Release `.pkg` each deploy,
+  per-`<ABI>/` tree, NONE-signed/TLS-anchored, served at
+  https://brait.dev/pfBlockerNG/${ABI}; the two generators (build-repo-portable.py
+  primary, build-repo.sh fallback + single --print-conf source); additive+isolated
+  repo-publish job. The honest GUI caveat + deferred GUI panel were ALREADY in the
+  install section above (Phase 4) — the new subsection points at them, not restates.
+
+CLAUDE.md — new H3 "Self-hosted `pkg` repository (ADR-17)" under "Branches and
+  releases" (after the tag-triggers-CI paragraph). Terse, established style. Adds
+  the three inventories the brief required:
+    * publish pipeline: repo-publish.yml (PRIMARY, pure-Python build-repo-portable.py
+      on Linux) + repo-publish-freebsd.yml (FreeBSD-VM fallback, build-repo.sh +
+      real pkg repo); the `repo-publish` job in release.yml (additive, if:always(),
+      leaf in needs:, isolated like attach-pkgs); Pages deploy at
+      brait.dev/pfBlockerNG/${ABI}; pages:write + id-token:write scoped to deploy.
+    * generators + bootstrap: build-repo-portable.py (primary), build-repo.sh
+      (fallback + --print-conf template), add-repo.sh (client bootstrap, channel
+      arg, priority 100); conf byte-identical, drift-pinned.
+    * repo smoke flow: tests/smoke/test_repo_install.py, marker `repo` (NOT smoke;
+      deselected from -m smoke); dispatch via
+      `gh workflow run smoke.yml -f pytest_marker=repo` (or repo-install.yml once on
+      devel); the gated test_install_from_live_pages_url (SMOKE_REPO_LIVE_URL) is
+      post-merge.
+  The precedence-dominates-version finding is stated inline (priority is the lever).
+
+ADR.md — Status line + §1 Context 3 + §2 table + §3 + §7 (DoD + checklist +
+  degrade criteria) + header Component(s)/Test-suite lines. No other ADRs touched.
+
+--------------------------------------------------------------------------------
+§7 AFFECTED-FLOW SMOKE — CHECKLIST OUTCOME (all 5 ticked, with run ids)
+--------------------------------------------------------------------------------
+GREEN on the live pfSense CE VM via tests/smoke/test_repo_install.py (marker repo):
+  [x] Install from our repo, no -f       -> test_install_from_our_repo_lands_all_files
+                                            run 27031334263 (P1). %R==pfblockerng-devel,
+                                            deps resolved, >50 files landed.
+  [x] Cross-repo precedence both branches -> ours-higher + decoy-higher (netgate-decoy),
+                                            run 27031334263 (P1). Both directions.
+  [x] pkg update accepts the catalog      -> build-repo.sh catalog run 27033922928 (P2)
+                                            + portable catalog run 27035602221 (P3a),
+                                            hermetic file://. The real brait.dev leg
+                                            (test_install_from_live_pages_url) is gated
+                                            + post-merge.
+  [x] Upgrade to our newer build          -> test_pkg_upgrade_moves_to_our_newer_build
+                                            + test_shipped_add_repo_sh_bootstrap_installs,
+                                            run 27040686824 (P5). %v _1 -> _9, both from
+                                            pfblockerng-devel; real before != after.
+  [x] Additive safety                     -> job-isolation review (P3, 03_Results.txt):
+                                            repo-publish is a leaf in release.yml needs:,
+                                            if:always(), copied from attach-pkgs; its
+                                            failure can't break release/ports-pr.
+
+--------------------------------------------------------------------------------
+OS-MAJOR VERDICT — DEGRADED-TO-CLI (documented in §7)
+--------------------------------------------------------------------------------
+A true OS-major jump (FreeBSD:15 -> FreeBSD:16, which changes ${ABI} and thus the
+served <ABI>/ subtree) is NOT reachable on a single CE smoke image — an in-place
+pfSense-upgrade across a major is image-refresh.yml's job (ADR-09), not this
+per-run flow. The single-image _1->_9 upgrade is the proven update path. The
+OS-major case degrades to the documented operator action: after a pfSense OS
+upgrade the box's ${ABI} follows it automatically (the conf url is the literal
+${ABI}, §2), so a plain CLI `pkg update -f && pkg upgrade` pulls our build for the
+NEW ABI once that ABI's catalog is published. No test attempts it (would fail-skip
+on one image) — a deliberate, documented non-goal. Recorded in the §7 degrade
+criteria.
+
+--------------------------------------------------------------------------------
+STATUS + THE POST-MERGE ACCEPT STEP
+--------------------------------------------------------------------------------
+Status set: Proposed -> **Implemented (pending the post-merge live Pages deploy +
+the gated live-URL verification)**. HONEST — the hermetic affected-flow smoke
+(install / precedence / upgrade) is GREEN on the live VM, but the public brait.dev
+Pages deploy has NOT physically run, so NOT Accepted.
+
+Flips to ACCEPTED post-merge (a GitHub constraint: a brand-new workflow_dispatch
+workflow is only dispatchable once it lands on the default branch `devel`):
+  1. gh workflow run repo-publish.yml --ref devel -f build_branch_pkg=true
+     -> deploys the catalog to Pages (capture run id + page_url).
+  2. Dispatch the `repo` smoke with SMOKE_REPO_LIVE_URL=https://brait.dev/pfBlockerNG
+     set so test_install_from_live_pages_url runs (polls the served catalog, pins
+     the Pages anycast IPs, writes our production conf, `pkg install` no -f,
+     asserts %R == pfblockerng-devel). Green there confirms the live URL -> Accepted.
+Recorded in §7 "POST-MERGE step (flips Implemented -> Accepted)".
+
+--------------------------------------------------------------------------------
+GATES (all green)
+--------------------------------------------------------------------------------
+  * npx markdownlint-cli2 (repo root)        -> 0 error(s).
+  * scripts/check_url_encoding.py            -> clean (the new md fences use STATIC
+                                                URLs — pkg/cat blocks, ${ABI} is the
+                                                pkg(8) literal, no curl/wget/fetch
+                                                query interpolation).
+  * python -m pytest (DEFAULT)               -> unchanged/green (docs-only; tests
+                                                untouched, tests/smoke --ignore'd).
+  * pre-commit hook (ruff/pytest/mypy/markdownlint/sh/shellcheck/php) -> green on
+                                                the commit.
+
+--------------------------------------------------------------------------------
+FOLLOW-ONS FOR THE RECORD
+--------------------------------------------------------------------------------
+  * POST-MERGE: run the two-step Accept dispatch above (repo-publish.yml on devel,
+    then the gated live-URL `repo` smoke). Flip Status -> Accepted on green.
+  * DEFERRED: a pfBlockerNG GUI "Updates/Channel" panel (GUI-driven upgrade to our
+    latest, closing the Netgate-bound update-badge gap) — out of scope here (touches
+    src/www); a natural follow-on ADR/phase.
+  * FUTURE OPTION: offline-signed PUBKEY (key never in CI) to replace
+    signature_type: none — the conf gains a signature_type, layout unchanged
+    (§3 Negative / Trust model).
+
+--------------------------------------------------------------------------------
+GO-AHEAD
+--------------------------------------------------------------------------------
+Phase 6 = DONE. ADR-17 is fully implemented + documented; Status Implemented
+(pending the post-merge live Pages deploy + the gated live-URL leg, which flips it
+to Accepted). The orchestrator lands the whole ADR (single commit per phase, no
+per-phase PR).

--- a/.ADRs/ADR_17_Pkg_Repository/RESULTS/06_Results.txt
+++ b/.ADRs/ADR_17_Pkg_Repository/RESULTS/06_Results.txt
@@ -33,7 +33,7 @@ and DOMINATES version — a higher-priority repo wins even at a LOWER version
     same-name Netgate build by priority even when theirs is newer (blast radius =
     our own package, the catalog carries only pfBlockerNG).
   * Trust-anchor host corrected github.io -> the custom-domain Pages host
-    brait.dev (§2 Trust model + §3 Authenticity) — the real served host (P3b).
+    andrebrait.github.io (§2 Trust model + §3 Authenticity) — the real served host (P3b).
   * Stale filename/marker fixed throughout: test_smoke_repo.py (marker `smoke`) ->
     tests/smoke/test_repo_install.py (marker `repo`, deselected from -m smoke) in
     the header block + the Phase-1/5 action-plan lines; the primary generator
@@ -48,7 +48,7 @@ README.md — new H3 "How the `pkg` repository is published (GitHub Pages)" at t
   one-liner is NOT duplicated — the new subsection cross-references the section
   above it): a DERIVED index REGENERATED over all Release `.pkg` each deploy,
   per-`<ABI>/` tree, NONE-signed/TLS-anchored, served at
-  https://brait.dev/pfBlockerNG/${ABI}; the two generators (build-repo-portable.py
+  https://andrebrait.github.io/pfBlockerNG/${ABI}; the two generators (build-repo-portable.py
   primary, build-repo.sh fallback + single --print-conf source); additive+isolated
   repo-publish job. The honest GUI caveat + deferred GUI panel were ALREADY in the
   install section above (Phase 4) — the new subsection points at them, not restates.
@@ -60,7 +60,7 @@ CLAUDE.md — new H3 "Self-hosted `pkg` repository (ADR-17)" under "Branches and
       on Linux) + repo-publish-freebsd.yml (FreeBSD-VM fallback, build-repo.sh +
       real pkg repo); the `repo-publish` job in release.yml (additive, if:always(),
       leaf in needs:, isolated like attach-pkgs); Pages deploy at
-      brait.dev/pfBlockerNG/${ABI}; pages:write + id-token:write scoped to deploy.
+      andrebrait.github.io/pfBlockerNG/${ABI}; pages:write + id-token:write scoped to deploy.
     * generators + bootstrap: build-repo-portable.py (primary), build-repo.sh
       (fallback + --print-conf template), add-repo.sh (client bootstrap, channel
       arg, priority 100); conf byte-identical, drift-pinned.
@@ -85,7 +85,7 @@ GREEN on the live pfSense CE VM via tests/smoke/test_repo_install.py (marker rep
                                             run 27031334263 (P1). Both directions.
   [x] pkg update accepts the catalog      -> build-repo.sh catalog run 27033922928 (P2)
                                             + portable catalog run 27035602221 (P3a),
-                                            hermetic file://. The real brait.dev leg
+                                            hermetic file://. The real andrebrait.github.io leg
                                             (test_install_from_live_pages_url) is gated
                                             + post-merge.
   [x] Upgrade to our newer build          -> test_pkg_upgrade_moves_to_our_newer_build
@@ -116,14 +116,14 @@ STATUS + THE POST-MERGE ACCEPT STEP
 --------------------------------------------------------------------------------
 Status set: Proposed -> **Implemented (pending the post-merge live Pages deploy +
 the gated live-URL verification)**. HONEST — the hermetic affected-flow smoke
-(install / precedence / upgrade) is GREEN on the live VM, but the public brait.dev
+(install / precedence / upgrade) is GREEN on the live VM, but the public andrebrait.github.io
 Pages deploy has NOT physically run, so NOT Accepted.
 
 Flips to ACCEPTED post-merge (a GitHub constraint: a brand-new workflow_dispatch
 workflow is only dispatchable once it lands on the default branch `devel`):
   1. gh workflow run repo-publish.yml --ref devel -f build_branch_pkg=true
      -> deploys the catalog to Pages (capture run id + page_url).
-  2. Dispatch the `repo` smoke with SMOKE_REPO_LIVE_URL=https://brait.dev/pfBlockerNG
+  2. Dispatch the `repo` smoke with SMOKE_REPO_LIVE_URL=https://andrebrait.github.io/pfBlockerNG
      set so test_install_from_live_pages_url runs (polls the served catalog, pins
      the Pages anycast IPs, writes our production conf, `pkg install` no -f,
      asserts %R == pfblockerng-devel). Green there confirms the live URL -> Accepted.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,6 +503,35 @@ jobs:
           done
           echo "All .pkg artifacts attached to release ${TAG}"
 
+  # ── 2d. Regenerate + deploy the pkg repository to GitHub Pages (ADR-17) ────
+  # ADDITIVE + ISOLATED — wired EXACTLY like attach-pkgs so it can NEVER gate or
+  # break release / ports-pr / attach-pkgs:
+  #   * needs: [release, build-pkgs-portable, build-pkgs-freebsd, read-matrix]
+  #     — runs only after the per-tag artifacts exist (same `needs` set as
+  #     attach-pkgs; a skipped mutually-exclusive build leg satisfies `needs`).
+  #   * if: always() && needs.release.result == 'success' — fires whenever the
+  #     Release was published, regardless of build/attach outcome.
+  #   * ports-pr does NOT `needs:` this; attach-pkgs does NOT `needs:` this; this
+  #     does NOT `needs:` attach-pkgs. So a repo-publish FAILURE leaves
+  #     release / ports-pr / attach-pkgs untouched (they never read its result).
+  #
+  # The reusable repo-publish.yml enumerates EVERY Release's .pkg assets (the
+  # durable store) plus the current run's freshly-built artifacts
+  # (pfBlockerNG-release-pkgs / pfBlockerNG-pkg, downloadable here since this is the
+  # SAME run), regenerates the per-ABI catalog with the pure-Python generator, and
+  # deploys it to Pages. build_branch_pkg=false — the per-tag .pkg are already built.
+  repo-publish:
+    name: Publish pkg repository to Pages
+    needs: [release, build-pkgs-portable, build-pkgs-freebsd, read-matrix]
+    if: always() && needs.release.result == 'success'
+    uses: ./.github/workflows/repo-publish.yml
+    with:
+      build_branch_pkg: false
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
   # ── 3. Open PR on pfsense/FreeBSD-ports ──────────────────────────────────
   ports-pr:
     name: Open FreeBSD ports PR

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -1,0 +1,38 @@
+name: Repo install (ADR-17, live pfSense VM)
+
+# ADR-17 — the release -> repository -> install flow, validated on the live ADR-04
+# pfSense CE VM. This is DISTINCT from the smoke suite (Smoke / ADR-04): the smoke
+# matrix validates pfBlockerNG's *runtime behaviour* (DNSBL blocking, etc.), while
+# this validates *distribution* — that a box installs our package from a
+# self-hosted, NONE-signed third-party `pkg` repository, lands every file, and that
+# cross-repo version precedence favours our build.
+#
+# REUSE, NOT DUPLICATION: it calls the smoke harness (smoke.yml as a reusable
+# workflow) so the VM boot / image pull / branch-.pkg build / SSH wiring are shared,
+# but selects the `repo` pytest marker (tests/smoke/test_repo_install.py) instead of
+# `smoke`. The `repo` tests are deselected from `-m smoke`, so the smoke gate never
+# runs them and this never runs the smoke matrix.
+#
+# workflow_dispatch only (same posture as smoke.yml — not an every-PR gate yet).
+# Secrets + required config are smoke.yml's (SMOKE_IMAGE_REF / SMOKE_GHCR_* /
+# SMOKE_SSH_PRIV_KEY); `secrets: inherit` forwards them.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: "GHCR pfSense CE image ref (blank = SMOKE_IMAGE_REF secret/variable). Pin by @sha256:<digest>."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  repo-install:
+    uses: ./.github/workflows/smoke.yml
+    with:
+      image_ref: ${{ inputs.image_ref }}
+      pytest_marker: repo
+    secrets: inherit

--- a/.github/workflows/repo-publish-freebsd.yml
+++ b/.github/workflows/repo-publish-freebsd.yml
@@ -1,0 +1,336 @@
+name: Publish pkg repository to GitHub Pages — FreeBSD VM (ADR-17, fallback)
+
+# ADR-17 Phase 3 — the FreeBSD-VM ALTERNATIVE to repo-publish.yml. It builds the
+# catalog with scripts/build-repo.sh driving the REAL libpkg `pkg repo` inside an
+# ABI-matched FreeBSD VM (the ground-truth catalog tool), then deploys the same
+# per-<ABI>/ tree to GitHub Pages. Use this if the pure-Python generator
+# (build-repo-portable.py, the PRIMARY in repo-publish.yml) ever diverges from
+# what a real pfSense `pkg update` accepts — it produces an equivalent tree by
+# construction (same `pkg repo` op the pfSense box itself runs).
+#
+# DISPATCH-ONLY (a documented fallback, NOT in any gate). The VM boot is the same
+# proven pattern as build-pkg.yml (the FreeBSD fidelity-oracle builder): a cached,
+# prepared FreeBSD qcow2 with a baked SSH key, booted snapshot=on (throwaway
+# overlay). Here it runs `pkg repo` rather than `make package`.
+#
+# ADDITIVE + ISOLATED, same contract as repo-publish.yml: least-privilege default
+# (contents: read); only the deploy step's job elevates to pages:write +
+# id-token:write. The site is an artifact replaced each deploy (no gh-pages
+# history); no branch is committed to.
+
+on:
+  workflow_dispatch:
+    inputs:
+      freebsd_version:
+        description: "FreeBSD version for the catalog-gen VM — match the target pfSense base (CE 2.8.1 = 15.0-RELEASE)"
+        required: false
+        default: "15.0-RELEASE"
+      build_branch_pkg:
+        description: "Also build the current branch .pkg (portable Linux) and fold it in (recommended when no Release exists yet)."
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Optional branch .pkg (portable Linux builder), same as repo-publish.yml.
+  build-branch-pkg:
+    name: Build branch .pkg (portable Linux)
+    if: ${{ inputs.build_branch_pkg }}
+    uses: ./.github/workflows/build-pkg-linux.yml
+    with:
+      channel: devel
+
+  publish-freebsd:
+    name: Generate catalog on FreeBSD VM + deploy to Pages
+    runs-on: ubuntu-latest
+    needs: [build-branch-pkg]
+    if: always()
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - name: Checkout (for scripts/)
+        uses: actions/checkout@v6
+
+      - name: Enable KVM access for the runner user
+        run: |
+          set -eu
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install host tools (qemu, cloud-init seed builder)
+        run: |
+          set -eu
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils xz-utils openssh-client
+
+      # ── Collect the .pkg input set (same store as repo-publish.yml) ─────────
+      - name: Download the just-built branch .pkg (if any)
+        if: ${{ inputs.build_branch_pkg }}
+        uses: actions/download-artifact@v8
+        with:
+          name: pfBlockerNG-pkg
+          path: incoming/branch
+        continue-on-error: true
+
+      - name: Collect every Release .pkg asset + the just-built ones into one dir
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          mkdir -p store
+          TAGS="$(gh release list -R "$REPO" --limit 200 --json tagName --jq '.[].tagName' || true)"
+          if [ -n "$TAGS" ]; then
+            printf '%s\n' "$TAGS" | while IFS= read -r TAG; do
+              [ -n "$TAG" ] || continue
+              echo "--- Release ${TAG}: downloading .pkg assets ---"
+              gh release download "$TAG" -R "$REPO" --dir store --pattern '*.pkg' --clobber \
+                || echo "  (no .pkg assets on ${TAG})"
+            done
+          else
+            echo "No GitHub Releases found — relying on freshly-built .pkg only."
+          fi
+          if [ -d incoming/branch ]; then
+            find incoming/branch -type f -name '*.pkg' | while IFS= read -r f; do
+              cp "$f" "store/built-$(basename "$f")"
+            done
+          fi
+          N="$(find store -type f -name '*.pkg' | wc -l | tr -d ' ')"
+          echo "Total .pkg collected: ${N}"
+          find store -type f -name '*.pkg' -exec ls -l {} \;
+          if [ "$N" -eq 0 ]; then
+            echo "::error::No .pkg to publish. Dispatch with build_branch_pkg=true or publish a Release first."
+            exit 1
+          fi
+
+      # ── FreeBSD VM (same boot pattern as build-pkg.yml) ─────────────────────
+      - name: Resolve the FreeBSD image URL + published checksum
+        id: img
+        run: |
+          set -eu
+          URL="$(sh scripts/freebsd-image-url.sh '${{ inputs.freebsd_version }}')"
+          FILE="$(basename "$URL")"
+          CK_URL="${URL%/*}/CHECKSUM.SHA256"
+          SHA="$(curl -fsSL "$CK_URL" | grep -F "($FILE)" | awk '{print $NF}')"
+          if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-f]{64}$'; then
+            echo "::error::no sha256 for ${FILE} in ${CK_URL} (got '${SHA}')"
+            exit 1
+          fi
+          {
+            echo "url=${URL}"
+            echo "sha=${SHA}"
+            echo "key=${SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore prepared FreeBSD image + key (tier-2 cache)
+        id: prepared
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            fbsd-prepared.qcow2
+            build_key
+          key: freebsd-prepared-v2-${{ steps.img.outputs.key }}
+
+      - name: Restore cached FreeBSD base image (tier-1 cache)
+        id: imgcache
+        if: steps.prepared.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@v5
+        with:
+          path: fbsd.qcow2
+          key: freebsd-img-${{ steps.img.outputs.key }}
+
+      - name: Fetch + verify + decompress the FreeBSD base image
+        if: steps.prepared.outputs.cache-hit != 'true' && steps.imgcache.outputs.cache-hit != 'true'
+        env:
+          IMG_URL: ${{ steps.img.outputs.url }}
+          IMG_SHA: ${{ steps.img.outputs.sha }}
+        run: |
+          set -eu
+          curl -fSL "${IMG_URL}" -o fbsd.qcow2.xz
+          echo "${IMG_SHA}  fbsd.qcow2.xz" | sha256sum -c -
+          unxz fbsd.qcow2.xz
+          ls -l fbsd.qcow2
+
+      - name: Save FreeBSD base image to cache (tier-1)
+        if: steps.prepared.outputs.cache-hit != 'true' && steps.imgcache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: fbsd.qcow2
+          key: freebsd-img-${{ steps.img.outputs.key }}
+
+      - name: Prepare the FreeBSD image (one-time setup boot)
+        if: steps.prepared.outputs.cache-hit != 'true'
+        run: |
+          set -eu
+          cp fbsd.qcow2 fbsd-prepared.qcow2
+          qemu-img resize fbsd-prepared.qcow2 +20G
+          ssh-keygen -t ed25519 -N '' -f build_key -C pfb-repo
+          PUB="$(cat build_key.pub)"
+          {
+            printf '#cloud-config\n'
+            printf 'disable_root: false\n'
+            printf 'ssh_authorized_keys:\n'
+            printf '  - %s\n' "$PUB"
+            printf 'runcmd:\n'
+            printf '  - install -d -m 700 /root/.ssh\n'
+            printf '  - cp /home/freebsd/.ssh/authorized_keys /root/.ssh/authorized_keys\n'
+            printf '  - chmod 600 /root/.ssh/authorized_keys\n'
+            printf "  - sed -i '' -E 's/^#?[[:space:]]*PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config\n"
+            printf '  - service sshd restart\n'
+          } > setup-user-data
+          printf 'instance-id: pfb-setup\nlocal-hostname: pfb-setup\n' > setup-meta-data
+          cloud-localds setup-seed.img setup-user-data setup-meta-data
+
+          qemu-system-x86_64 \
+            -enable-kvm -machine pc -cpu host -smp 2 -m 4096 \
+            -drive file=fbsd-prepared.qcow2,if=virtio \
+            -drive file=setup-seed.img,if=virtio,format=raw \
+            -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+            -device virtio-net-pci,netdev=net0 \
+            -display none -serial file:fbsd-setup-console.log &
+          echo $! > setup-vm.pid
+
+          SSH_OPTS="-i build_key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o BatchMode=yes"
+          for i in $(seq 1 96); do
+            # shellcheck disable=SC2086
+            if ssh $SSH_OPTS root@127.0.0.1 true 2>/dev/null; then
+              echo "setup VM root SSH up after ${i} attempt(s)"; break
+            fi
+            if ! kill -0 "$(cat setup-vm.pid)" 2>/dev/null; then
+              echo "::error::QEMU exited before SSH came up (setup)"; tail -n 80 fbsd-setup-console.log || true; exit 1
+            fi
+            [ "$i" -eq 96 ] && { echo "::error::Setup VM SSH never came up"; tail -n 120 fbsd-setup-console.log || true; exit 1; }
+            sleep 5
+          done
+
+          # shellcheck disable=SC2086
+          SSSH="ssh $SSH_OPTS root@127.0.0.1"
+          $SSSH "set -e
+            DISK=vtbd0
+            gpart recover \$DISK || true
+            PART=\$(gpart show \$DISK | awk '\$4==\"freebsd-zfs\"{print \$3; exit}')
+            [ -n \"\$PART\" ] && gpart resize -i \"\$PART\" \$DISK || true
+            POOL=\$(zpool list -H -o name | head -1)
+            zpool set autoexpand=on \"\$POOL\" || true
+            zpool online -e \"\$POOL\" \"\${DISK}p\${PART}\" || true
+            df -h /"
+          # pkg is the only dependency build-repo.sh needs — bootstrap it once.
+          $SSSH "env ASSUME_ALWAYS_YES=yes pkg bootstrap -y || true; env ASSUME_ALWAYS_YES=yes pkg -N || env ASSUME_ALWAYS_YES=yes pkg bootstrap -f -y"
+          $SSSH "mkdir -p /etc/cloud /usr/local/etc/cloud 2>/dev/null; \
+                 touch /etc/cloud/cloud-init.disabled /usr/local/etc/cloud/cloud-init.disabled 2>/dev/null; true"
+          $SSSH "shutdown -p now" || true
+          for i in $(seq 1 30); do
+            kill -0 "$(cat setup-vm.pid)" 2>/dev/null || { echo "Setup VM powered off cleanly"; break; }
+            if [ "$i" -eq 30 ]; then
+              kill -9 "$(cat setup-vm.pid)" 2>/dev/null || true
+              wait "$(cat setup-vm.pid)" 2>/dev/null || true
+            fi
+            sleep 2
+          done
+
+      - name: Save prepared FreeBSD image + key to cache (tier-2)
+        if: steps.prepared.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            fbsd-prepared.qcow2
+            build_key
+          key: freebsd-prepared-v2-${{ steps.img.outputs.key }}
+
+      - name: Normalise the baked key permissions
+        run: |
+          set -eu
+          chmod 600 build_key
+          ls -l build_key
+
+      - name: Boot the FreeBSD VM (snapshot=on, prepared image)
+        run: |
+          set -eu
+          qemu-system-x86_64 \
+            -enable-kvm -machine pc -cpu host -smp 2 -m 4096 \
+            -drive file=fbsd-prepared.qcow2,if=virtio,snapshot=on \
+            -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+            -device virtio-net-pci,netdev=net0 \
+            -display none -serial file:fbsd-build-console.log &
+          echo $! > vm.pid
+
+      - name: Wait for root SSH (baked key)
+        run: |
+          set -eu
+          SSH_OPTS="-i build_key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o BatchMode=yes"
+          for i in $(seq 1 96); do
+            # shellcheck disable=SC2086
+            if ssh $SSH_OPTS root@127.0.0.1 true 2>/dev/null; then
+              echo "root SSH up after ${i} attempt(s)"; exit 0
+            fi
+            if ! kill -0 "$(cat vm.pid)" 2>/dev/null; then
+              echo "::error::QEMU exited before SSH came up"; tail -n 80 fbsd-build-console.log || true; exit 1
+            fi
+            sleep 5
+          done
+          echo "::error::FreeBSD VM root SSH never came up"; tail -n 120 fbsd-build-console.log || true; exit 1
+
+      - name: Generate the catalog inside the VM (build-repo.sh + real pkg repo)
+        run: |
+          set -eu
+          SSH="ssh -i build_key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes root@127.0.0.1"
+          SCP="scp -i build_key -P 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+          # Stage the generator + the .pkg store to the guest.
+          $SSH "rm -rf /root/store /root/site && mkdir -p /root/store"
+          $SCP scripts/build-repo.sh root@127.0.0.1:/root/build-repo.sh
+          $SCP store/*.pkg root@127.0.0.1:/root/store/
+          # Run the REAL `pkg repo` catalog generator (the guest's own libpkg).
+          $SSH "env ASSUME_ALWAYS_YES=yes /bin/sh /root/build-repo.sh --in /root/store --out /root/site && find /root/site -type f | sort"
+
+      - name: Retrieve the generated catalog tree
+        run: |
+          set -eu
+          SCP="scp -i build_key -P 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+          rm -rf site && mkdir -p site
+          # Recursive copy of the whole per-<ABI>/ tree.
+          $SCP -r 'root@127.0.0.1:/root/site/*' site/
+          find site -type f | sort
+
+      - name: Add a minimal index.html + .nojekyll
+        run: |
+          set -eu
+          {
+            echo '<!doctype html><meta charset="utf-8">'
+            echo '<title>pfBlockerNG pkg repository</title>'
+            echo '<h1>pfBlockerNG self-hosted pkg repository (FreeBSD-built)</h1>'
+            echo '<pre>'
+            sh scripts/build-repo.sh --print-conf | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
+            echo '</pre>'
+          } > site/index.html
+          touch site/.nojekyll
+
+      - name: Upload the Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4
+
+      - name: Teardown
+        if: always()
+        run: |
+          kill "$(cat vm.pid)" 2>/dev/null || true
+          kill "$(cat setup-vm.pid)" 2>/dev/null || true

--- a/.github/workflows/repo-publish-freebsd.yml
+++ b/.github/workflows/repo-publish-freebsd.yml
@@ -35,7 +35,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: pages-${{ github.ref }}
+  # The SAME global key as repo-publish.yml — the FreeBSD fallback and the primary
+  # deploy to one Pages site, so they must serialise, not race.
+  group: pages-pfblockerng
   cancel-in-progress: false
 
 jobs:
@@ -95,7 +97,8 @@ jobs:
         run: |
           set -eu
           mkdir -p store
-          TAGS="$(gh release list -R "$REPO" --limit 200 --json tagName --jq '.[].tagName' || true)"
+          # ALL releases (paginated — no cap).
+          TAGS="$(gh api "repos/$REPO/releases" --paginate --jq '.[].tag_name' || true)"
           if [ -n "$TAGS" ]; then
             printf '%s\n' "$TAGS" | while IFS= read -r TAG; do
               [ -n "$TAG" ] || continue

--- a/.github/workflows/repo-publish.yml
+++ b/.github/workflows/repo-publish.yml
@@ -228,4 +228,4 @@ jobs:
       - name: Report the published URL
         run: |
           echo "Deployed pkg repository to: ${{ steps.deploy.outputs.page_url }}"
-          echo "Client conf url (per ABI): https://brait.dev/pfBlockerNG/\${ABI}"
+          echo "Client conf url (per ABI): https://andrebrait.github.io/pfBlockerNG/\${ABI}"

--- a/.github/workflows/repo-publish.yml
+++ b/.github/workflows/repo-publish.yml
@@ -1,0 +1,231 @@
+name: Publish pkg repository to GitHub Pages (ADR-17)
+
+# ADR-17 Phase 3 — regenerate the self-hosted FreeBSD `pkg` repository over ALL
+# GitHub Release `.pkg` assets (the durable store ADR-09's `attach-pkgs` writes)
+# and deploy it to GitHub Pages. The repository is a DERIVED, fully regenerated
+# index over those assets — stateless + idempotent: every published build (all
+# versions, all ABIs) is retained without accumulating state, and the deploy is
+# trivially rollback-able (re-deploy a prior set).
+#
+# ADDITIVE + ISOLATED (the load-bearing contract — ADR §2 "the existing release
+# flow is intact and unblocked"):
+#   * release.yml invokes this as a `workflow_call` job wired EXACTLY like
+#     `attach-pkgs`: `needs:` the build/release jobs, `if: always()`. A failure
+#     here NEVER gates or fails `release` / `ports-pr` / `attach-pkgs` — they do
+#     not `needs:` this job, so its result is irrelevant to theirs.
+#   * Least-privilege: the file default is `contents: read`. Only the deploy job
+#     elevates to `pages: write` + `id-token: write` (the GitHub Pages OIDC deploy
+#     contract). No job here commits to any branch (the site is an artifact
+#     replaced each deploy — no `gh-pages` history).
+#
+# CATALOG GENERATOR (Phase 3a, PRIMARY): scripts/build-repo-portable.py — PURE
+# PYTHON, no libpkg, no `pkg` binary, no ABI env var. It reads each .pkg's ABI
+# from its +COMPACT_MANIFEST and emits one `<ABI>/` catalog subtree
+# (meta.conf / packagesite.pkg / data.pkg) per distinct ABI, deterministically.
+# Needs only a zstd ENCODER on the runner (`apt-get install -y zstd`). The
+# FreeBSD-VM path (scripts/build-repo.sh + real `pkg repo`) is the SEPARATE
+# fidelity-oracle / fallback workflow (repo-publish-freebsd.yml).
+#
+# DISPATCHABLE (validate without a tag): `workflow_dispatch` publishes over
+# whatever Release `.pkg` exist, and — with `build_branch_pkg: true` (the default
+# for a manual run) — also BUILDS the current branch `.pkg` (via build-pkg-linux.yml)
+# and folds it in, so the pipeline is provable even before any GitHub Release exists.
+
+on:
+  # Invoked by release.yml after the per-tag artifacts exist (same run, so it can
+  # download the sibling build artifacts AND enumerate every prior release).
+  workflow_call:
+    inputs:
+      build_branch_pkg:
+        description: "Build the current branch .pkg and fold it into the catalog (off for the release path — the per-tag artifacts are already present)."
+        required: false
+        type: boolean
+        default: false
+  # Standalone validation: publish over all Release assets, optionally building
+  # the branch .pkg so the deploy is provable with NO release present.
+  workflow_dispatch:
+    inputs:
+      build_branch_pkg:
+        description: "Build the current branch .pkg and publish it (recommended when no GitHub Release exists yet)."
+        required: false
+        type: boolean
+        default: true
+
+# Least-privilege default. The deploy job elevates explicitly (pages + id-token).
+permissions:
+  contents: read
+
+# Serialise deploys to the single Pages environment; never cancel an in-flight
+# deploy (a half-replaced site is worse than a queued one).
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── Optional: build the current branch .pkg (dispatch / no-release path) ─────
+  # Reuses the SAME portable Linux builder the smoke + release flows use, so the
+  # published .pkg is byte-identical to what a release would attach. Skipped on
+  # the release path (build_branch_pkg=false) — the per-tag artifacts are already
+  # uploaded by build-pkgs-portable in the caller's run.
+  build-branch-pkg:
+    name: Build branch .pkg (portable Linux)
+    if: inputs.build_branch_pkg
+    uses: ./.github/workflows/build-pkg-linux.yml
+    with:
+      channel: devel
+    # abi/py_flavor/php_version default to CE 2.8.1 (FreeBSD:15:amd64 / py311 / 8.3).
+
+  # ── Generate the catalog over ALL release assets + deploy to Pages ──────────
+  publish:
+    name: Generate catalog + deploy to Pages
+    runs-on: ubuntu-latest
+    # if: always() — never block on the optional build job; a skipped `needs`
+    # entry satisfies the dependency, so this runs whether or not the build ran.
+    needs: [build-branch-pkg]
+    if: always()
+    timeout-minutes: 20
+    permissions:
+      contents: read       # gh release download (read assets)
+      pages: write         # deploy to the github-pages environment
+      id-token: write       # OIDC token actions/deploy-pages mints
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - name: Checkout (for the generator script)
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Ensure the zstd encoder is present
+        # build-repo-portable.py needs a zstd ENCODER (the `zstd` binary or the
+        # python `zstandard` module). ubuntu-latest may not ship it — install it.
+        run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
+
+      - name: Download the just-built branch .pkg (dispatch / no-release path)
+        # Present only when build-branch-pkg ran (build_branch_pkg=true). Absent
+        # on the release path — continue-on-error so its absence never fails us.
+        if: inputs.build_branch_pkg
+        uses: actions/download-artifact@v8
+        with:
+          name: pfBlockerNG-pkg
+          path: incoming/branch
+        continue-on-error: true
+
+      - name: Download the current-tag .pkg artifacts (release path, same run)
+        # On the release `workflow_call`, build-pkgs-portable uploaded
+        # "pfBlockerNG-release-pkgs" in THIS run; pull it in. continue-on-error so
+        # a standalone dispatch (no sibling artifact) is unaffected.
+        uses: actions/download-artifact@v4
+        with:
+          name: pfBlockerNG-release-pkgs
+          path: incoming/release-portable
+        continue-on-error: true
+
+      - name: Download the current-tag .pkg artifacts (FreeBSD builder, same run)
+        uses: actions/download-artifact@v4
+        with:
+          name: pfBlockerNG-pkg
+          path: incoming/release-freebsd
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Collect every Release .pkg asset + the just-built ones into one dir
+        # ADR §2 "Repo = derived index over Releases": the durable store is the
+        # GitHub Releases' .pkg assets. Enumerate ALL releases and download each
+        # one's .pkg assets, then fold in whatever was just built (current tag /
+        # dispatched branch). Flat dir — the generator buckets by ABI from each
+        # .pkg's own manifest, never the filename.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          mkdir -p store
+
+          # 1. Every published Release's .pkg assets (the durable store).
+          TAGS="$(gh release list -R "$REPO" --limit 200 --json tagName --jq '.[].tagName' || true)"
+          if [ -n "$TAGS" ]; then
+            printf '%s\n' "$TAGS" | while IFS= read -r TAG; do
+              [ -n "$TAG" ] || continue
+              echo "--- Release ${TAG}: downloading .pkg assets ---"
+              gh release download "$TAG" -R "$REPO" --dir store --pattern '*.pkg' --clobber \
+                || echo "  (no .pkg assets on ${TAG}, or download skipped)"
+            done
+          else
+            echo "No GitHub Releases found — relying on freshly-built .pkg only."
+          fi
+
+          # 2. Fold in the just-built artifacts (current tag and/or dispatched
+          #    branch). Copy with a unique prefix so identical basenames from
+          #    different sources never clobber; the generator reads the ABI from
+          #    each file's manifest, so the filename is irrelevant to bucketing.
+          for SRC in incoming/branch incoming/release-portable incoming/release-freebsd; do
+            [ -d "$SRC" ] || continue
+            find "$SRC" -type f -name '*.pkg' | while IFS= read -r f; do
+              dest="store/built-$(printf '%s' "$SRC" | tr '/' '_')-$(basename "$f")"
+              cp "$f" "$dest"
+              echo "Folded in: $f -> $dest"
+            done
+          done
+
+          N="$(find store -type f -name '*.pkg' | wc -l | tr -d ' ')"
+          echo "Total .pkg collected: ${N}"
+          find store -type f -name '*.pkg' -exec ls -l {} \;
+          if [ "$N" -eq 0 ]; then
+            echo "::error::No .pkg assets to publish (no releases and no built .pkg). Dispatch with build_branch_pkg=true."
+            exit 1
+          fi
+
+      - name: Generate the per-ABI catalog (pure-Python, PRIMARY)
+        # build-repo-portable.py — no libpkg, no ABI env. One <ABI>/ subtree per
+        # distinct ABI (meta.conf / meta / packagesite.pkg / data.pkg + the .pkg).
+        # Fail-closed on an unhandled php/py flavor collision (same name+ver+ABI).
+        run: |
+          set -eu
+          python3 scripts/build-repo-portable.py --in store --out site
+          echo "--- Published site tree ---"
+          find site -type f | sort
+
+      - name: Add a minimal index.html (human landing page; pkg ignores it)
+        # Pages serves a directory; a tiny index documents the conf URL for humans.
+        # pkg(8) only ever fetches <ABI>/meta.conf etc., never the root index.
+        run: |
+          set -eu
+          {
+            echo '<!doctype html><meta charset="utf-8">'
+            echo '<title>pfBlockerNG pkg repository</title>'
+            echo '<h1>pfBlockerNG self-hosted pkg repository</h1>'
+            echo '<p>Add this repo to a pfSense box (CLI), then <code>pkg install pfSense-pkg-pfBlockerNG-devel</code>:</p>'
+            echo '<pre>'
+            python3 scripts/build-repo-portable.py --print-conf | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
+            echo '</pre>'
+            echo '<p>Catalog trees (one per ABI):</p><ul>'
+            for d in site/*/; do
+              [ -d "$d" ] || continue
+              abi="$(basename "$d")"
+              printf '<li><a href="%s/">%s</a></li>\n' "$abi" "$abi"
+            done
+            echo '</ul>'
+          } > site/index.html
+          # Pages' Jekyll would otherwise strip files/dirs beginning with `_` or
+          # special-case some paths; .nojekyll serves the tree verbatim.
+          touch site/.nojekyll
+
+      - name: Upload the Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4
+
+      - name: Report the published URL
+        run: |
+          echo "Deployed pkg repository to: ${{ steps.deploy.outputs.page_url }}"
+          echo "Client conf url (per ABI): https://brait.dev/pfBlockerNG/\${ABI}"

--- a/.github/workflows/repo-publish.yml
+++ b/.github/workflows/repo-publish.yml
@@ -58,7 +58,10 @@ permissions:
 # Serialise deploys to the single Pages environment; never cancel an in-flight
 # deploy (a half-replaced site is worse than a queued one).
 concurrency:
-  group: pages-${{ github.ref }}
+  # One global key for the Pages site — ALL deploys (this workflow on a tag, a
+  # branch dispatch, and the FreeBSD fallback) share it so they serialise instead
+  # of racing on the same target.
+  group: pages-pfblockerng
   cancel-in-progress: false
 
 jobs:
@@ -148,7 +151,9 @@ jobs:
           mkdir -p store
 
           # 1. Every published Release's .pkg assets (the durable store).
-          TAGS="$(gh release list -R "$REPO" --limit 200 --json tagName --jq '.[].tagName' || true)"
+          # ALL releases (paginated — no cap, so older .pkg never drop out of the
+          # derived-over-Releases catalog).
+          TAGS="$(gh api "repos/$REPO/releases" --paginate --jq '.[].tag_name' || true)"
           if [ -n "$TAGS" ]; then
             printf '%s\n' "$TAGS" | while IFS= read -r TAG; do
               [ -n "$TAG" ] || continue

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -42,6 +42,10 @@ on:
         description: "GHCR pfSense CE image ref (blank = SMOKE_IMAGE_REF secret/variable). Pin by @sha256:<digest>."
         required: false
         default: ""
+      pytest_marker:
+        description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
+        required: false
+        default: "smoke"
   workflow_call:
     inputs:
       image_ref:
@@ -49,6 +53,11 @@ on:
         required: false
         type: string
         default: ""
+      pytest_marker:
+        description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
+        required: false
+        type: string
+        default: "smoke"
   # Nightly gated run — enable once the wall-time is confirmed within budget.
   # schedule:
   #   - cron: "0 5 * * *"
@@ -237,8 +246,11 @@ jobs:
       # resolves every answer from the in-runner mock-feed server (guest ->
       # SLIRP 10.0.2.2 -> runner loopback) + injected Unbound local-data, so it
       # still passes with real egress dark.
-      - name: Run the smoke matrix (pytest -m smoke)
+      - name: Run the live-VM matrix (pytest -m ${{ inputs.pytest_marker || 'smoke' }})
         env:
+          # Selected marker: 'smoke' by default (byte-identical to before); 'repo'
+          # for the ADR-17 repository-install flow (repo-install.yml calls in with it).
+          PYTEST_MARKER: ${{ inputs.pytest_marker || 'smoke' }}
           # SMOKE_IMAGE_DIR points the fixture at the ALREADY-PULLED qcow2 so the
           # boot needs no network. SMOKE_IMAGE_REF is kept for provenance/logs.
           SMOKE_IMAGE_DIR: ${{ github.workspace }}/image
@@ -274,7 +286,7 @@ jobs:
           # (inject->reload->probe; slowest observed ~6s), NOT the slow module fixtures
           # (deploy ~1-2 min) — so a per-case stall fails fast (vs the old 300s -> job-
           # timeout wipe) while leaving comfortable margin over the real per-case time.
-          python3 -m pytest tests/smoke -m smoke \
+          python3 -m pytest tests/smoke -m "${PYTEST_MARKER}" \
             --override-ini="addopts=" --override-ini="timeout_func_only=true" \
             --timeout=30 --timeout-method=signal -v
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -104,11 +104,15 @@ jobs:
           sudo udevadm trigger --name-match=kvm
           ls -l /dev/kvm
 
-      - name: Install host tools (qemu, oras, dnsutils, python)
+      - name: Install host tools (qemu, oras, dnsutils, python, zstd)
         run: |
           set -eu
           sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils openssh-client python3 python3-pip python3-venv
+          # zstd: the ADR-17 `repo` flow re-versions the branch .pkg (a zstd tar) on
+          # the runner to forge a lower+higher build for the pkg-upgrade transition
+          # test; the re-version helper decodes/encodes the .pkg via the zstd binary.
+          # Harmless for the default `smoke` marker (the helper just isn't called).
+          sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils openssh-client python3 python3-pip python3-venv zstd
 
       - name: Resolve the pfSense image ref (input overrides secret/variable)
         id: ref

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,7 +567,7 @@ on `pfsense/FreeBSD-ports`. Tags from `devel` become pre-releases; from `main`, 
 Beyond the Netgate ports channel we publish a **self-hosted FreeBSD `pkg` repository on
 GitHub Pages** — a **derived index** (no stateful store): each deploy enumerates **all**
 Releases, downloads their `.pkg`, buckets by ABI, regenerates the catalog per `<ABI>/`, and
-deploys the tree to `brait.dev/pfBlockerNG/${ABI}` (NONE-signed, TLS-anchored; the `${ABI}`
+deploys the tree to `andrebrait.github.io/pfBlockerNG/${ABI}` (NONE-signed, TLS-anchored; the `${ABI}`
 conf auto-follows an OS upgrade). Cross-repo selection is keyed on repo **`priority:`** (it
 **dominates version** — Phase-1 live finding), so our above-Netgate `priority: 100` makes
 `pkg install`/`upgrade` and the stock GUI **Install** pull our build. GUI discovery + the
@@ -594,8 +594,8 @@ update badge stay Netgate-bound; a GUI "Updates/Channel" panel is deferred (woul
   the catalog accepted from both generators. Dispatch:
   `gh workflow run smoke.yml -f pytest_marker=repo` (or `repo-install.yml` once it lands on
   `devel`). The gated `test_install_from_live_pages_url` (`SMOKE_REPO_LIVE_URL`) hits the
-  real `brait.dev` URL — post-merge (a new `workflow_dispatch` workflow is only dispatchable
-  from the default branch).
+  real `andrebrait.github.io` URL — post-merge (a new `workflow_dispatch` workflow is only
+  dispatchable from the default branch).
 
 **Merge PRs by rebase only** — `gh pr merge <N> --rebase` (or GitHub's "Rebase and merge");
 never a merge commit, never squash. History across `main` ← `devel` stays strictly linear

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,6 +562,41 @@ When the min CE version changes, also:
 New features land in `devel`. Pushing a `vX.Y.Z` tag triggers CI: tests → GitHub Release → PR
 on `pfsense/FreeBSD-ports`. Tags from `devel` become pre-releases; from `main`, stable releases.
 
+### Self-hosted `pkg` repository (ADR-17)
+
+Beyond the Netgate ports channel we publish a **self-hosted FreeBSD `pkg` repository on
+GitHub Pages** — a **derived index** (no stateful store): each deploy enumerates **all**
+Releases, downloads their `.pkg`, buckets by ABI, regenerates the catalog per `<ABI>/`, and
+deploys the tree to `brait.dev/pfBlockerNG/${ABI}` (NONE-signed, TLS-anchored; the `${ABI}`
+conf auto-follows an OS upgrade). Cross-repo selection is keyed on repo **`priority:`** (it
+**dominates version** — Phase-1 live finding), so our above-Netgate `priority: 100` makes
+`pkg install`/`upgrade` and the stock GUI **Install** pull our build. GUI discovery + the
+update badge stay Netgate-bound; a GUI "Updates/Channel" panel is deferred (would touch
+`src/`).
+
+- **Publish pipeline:** `.github/workflows/repo-publish.yml` (PRIMARY — pure-Python
+  `scripts/build-repo-portable.py` on a plain Linux runner, `apt-get install -y zstd`, no
+  libpkg/ABI env) + `.github/workflows/repo-publish-freebsd.yml` (FreeBSD-VM fallback /
+  fidelity oracle — `scripts/build-repo.sh` + real `pkg repo`). Wired into `release.yml` as
+  the `repo-publish` job — additive, `if: always()`, a **leaf** in the `needs:` graph
+  isolated exactly like `attach-pkgs` (its failure never breaks `release`/`ports-pr`).
+  Deploys via `upload-pages-artifact` + `deploy-pages` (`pages: write` + `id-token: write`
+  scoped to the deploy job only).
+- **Generators + bootstrap:** `scripts/build-repo-portable.py` (primary catalog gen),
+  `scripts/build-repo.sh` (fallback + the single `--print-conf` conf template),
+  `scripts/add-repo.sh` (client bootstrap — `devel|stable` channel arg, `priority: 100`,
+  writes `/usr/local/etc/pkg/repos/pfblockerng-<channel>.conf`, `pkg update` + verify). The
+  emitted conf is byte-identical across all three (drift-pinned in
+  `tests/test_add_repo_conf.py` + `tests/test_build_repo_portable.py`).
+- **Repo smoke flow:** `tests/smoke/test_repo_install.py` carries its **own marker `repo`**
+  (a distribution flow, **deselected from `-m smoke`**) — install-from-our-repo (no `-f`),
+  cross-repo precedence (both directions vs a `netgate-decoy`), `pkg upgrade` `_1`→`_9`, and
+  the catalog accepted from both generators. Dispatch:
+  `gh workflow run smoke.yml -f pytest_marker=repo` (or `repo-install.yml` once it lands on
+  `devel`). The gated `test_install_from_live_pages_url` (`SMOKE_REPO_LIVE_URL`) hits the
+  real `brait.dev` URL — post-merge (a new `workflow_dispatch` workflow is only dispatchable
+  from the default branch).
+
 **Merge PRs by rebase only** — `gh pr merge <N> --rebase` (or GitHub's "Rebase and merge");
 never a merge commit, never squash. History across `main` ← `devel` stays strictly linear
 (`main` always an ancestor of `devel`, no merge commits), so promotion up the chain — and

--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ equivalent inline conf write (what the script emits) is:
 ```sh
 cat > /usr/local/etc/pkg/repos/pfblockerng-devel.conf <<'EOF'
 pfblockerng-devel: {
-  url: "https://brait.dev/pfBlockerNG/${ABI}",
+  url: "https://andrebrait.github.io/pfBlockerNG/${ABI}",
   mirror_type: none,
   signature_type: none,
   priority: 100,
@@ -761,8 +761,8 @@ published version/ABI is retained for free and a rollback is a re-deploy.
   2.8 and Plus 25.03 share it). The client conf's literal `${ABI}` lets one conf follow the
   box across a pfSense OS upgrade.
 - **NONE-signed, TLS-anchored.** No signing key in CI; trust is HTTPS to the Pages host. The
-  catalog is served at the custom-domain Pages URL
-  **`https://brait.dev/pfBlockerNG/${ABI}`** — the same base
+  catalog is served at the project's GitHub Pages URL
+  **`https://andrebrait.github.io/pfBlockerNG/${ABI}`** — the same base
   [`add-repo.sh`](scripts/add-repo.sh) writes (above).
 - **Generators.** `scripts/build-repo-portable.py` is the primary — pure Python (stdlib +
   `zstd`), no libpkg, run on a plain Linux runner. `scripts/build-repo.sh` (real `pkg repo`

--- a/README.md
+++ b/README.md
@@ -700,6 +700,56 @@ The resulting `.pkg` file is in `work/pkg/`.
 
 ---
 
+## Install from our `pkg` repository
+
+We publish a self-hosted FreeBSD `pkg` repository (ADR-17) so a pfSense box can
+`pkg install` / `pkg upgrade` our builds directly — dependencies resolved, no
+`pkg add -f`. Run the bootstrap **on the box** (over SSH), then install:
+
+```sh
+./scripts/add-repo.sh devel
+pkg install pfSense-pkg-pfBlockerNG-devel
+```
+
+`add-repo.sh` writes `/usr/local/etc/pkg/repos/pfblockerng-<channel>.conf`, runs
+`pkg update`, and verifies our package is visible from our repo. Pass `stable` for
+the production package (`pfSense-pkg-pfBlockerNG`); the default is `devel`. The
+equivalent inline conf write (what the script emits) is:
+
+```sh
+cat > /usr/local/etc/pkg/repos/pfblockerng-devel.conf <<'EOF'
+pfblockerng-devel: {
+  url: "https://brait.dev/pfBlockerNG/${ABI}",
+  mirror_type: none,
+  signature_type: none,
+  priority: 100,
+  enabled: yes
+}
+EOF
+pkg update
+```
+
+The `${ABI}` is a `pkg(8)` variable (expanded by `pkg`, not the shell) so one conf
+follows the box across a pfSense OS upgrade. The repo is **NONE-signed** — trust is
+HTTPS to the host. `priority: 100` sits above the Netgate `pfSense` repo, so
+cross-repo resolution picks our build. Update later with:
+
+```sh
+pkg upgrade pfSense-pkg-pfBlockerNG-devel
+```
+
+**What works and what doesn't (honest scope, ADR-17 §1):** because the GUI Install
+action is not repo-locked, the stock webConfigurator **Install** of pfBlockerNG-devel
+transparently pulls our build via cross-repo priority. But Available-Packages
+**discovery** and the GUI **"update available" badge** stay **Netgate-bound** (they
+query the `pfSense` repo only) — our newer builds install via GUI Install or CLI
+`pkg upgrade`, **not** a GUI badge. A pfBlockerNG GUI "Updates/Channel" panel that
+would close the badge gap is deferred (out of scope — it would touch `src/`).
+
+See [`scripts/add-repo.sh`](scripts/add-repo.sh) for full options.
+
+---
+
 ## Installing on a pfSense instance for testing
 
 Use the helper script to push files directly to a running pfSense box

--- a/README.md
+++ b/README.md
@@ -748,6 +748,35 @@ would close the badge gap is deferred (out of scope — it would touch `src/`).
 
 See [`scripts/add-repo.sh`](scripts/add-repo.sh) for full options.
 
+### How the `pkg` repository is published (GitHub Pages)
+
+The repository is a **derived index** — there is no stateful store to maintain. On each
+deploy the publish pipeline enumerates **all** GitHub Releases, downloads their `.pkg`
+assets, buckets them by ABI, **regenerates** a fresh `pkg` catalog
+(`meta.conf`/`packagesite.pkg`/`data.pkg`) per ABI, and deploys the whole `${ABI}/` tree
+to **GitHub Pages**. The site is replaced each run (no `gh-pages` history), so every
+published version/ABI is retained for free and a rollback is a re-deploy.
+
+- **Per-`${ABI}` tree.** One catalog under `…/<ABI>/` (today only `FreeBSD:15:amd64` — CE
+  2.8 and Plus 25.03 share it). The client conf's literal `${ABI}` lets one conf follow the
+  box across a pfSense OS upgrade.
+- **NONE-signed, TLS-anchored.** No signing key in CI; trust is HTTPS to the Pages host. The
+  catalog is served at the custom-domain Pages URL
+  **`https://brait.dev/pfBlockerNG/${ABI}`** — the same base
+  [`add-repo.sh`](scripts/add-repo.sh) writes (above).
+- **Generators.** `scripts/build-repo-portable.py` is the primary — pure Python (stdlib +
+  `zstd`), no libpkg, run on a plain Linux runner. `scripts/build-repo.sh` (real `pkg repo`
+  in a FreeBSD VM) is the fidelity fallback, and is also the single `--print-conf` source the
+  bootstrap and the inline conf above reuse byte-for-byte.
+- **Additive + isolated.** Publishing rides each tag's `release.yml` as a separate
+  `repo-publish` job (`if: always()`, like `attach-pkgs`) plus the dispatchable
+  `repo-publish.yml`; its failure never breaks the Release or the ports PR.
+
+The honest GUI scope (Install pulls our build via cross-repo priority, but Available-Packages
+discovery + the GUI update badge stay Netgate-bound, and the GUI "Updates/Channel" panel is
+deferred) is covered above. See
+[ADR-17](.ADRs/ADR_17_Pkg_Repository/ADR.md) for the full design.
+
 ---
 
 ## Installing on a pfSense instance for testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ markers = [
     "ui_render: live-VM Web-UI render-smoke (ADR-14 Tier A); authenticated HTTP; deselected from the default run",
     "ui_e2e: live-VM Web-UI functional flow (ADR-14 Tier B, HTTP POST); deselected from the default run",
     "ui_browser: live-VM Web-UI browser/JS test (ADR-14 Tier B, Playwright); deselected from the default run",
+    "repo: live-VM release->repository install flow (ADR-17); distinct from -m smoke; deselected from the default run",
 ]
 
 # coverage.py (issue #38). BRANCH coverage is the point of the sweep -- line

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+# add-repo.sh — bootstrap pfBlockerNG's self-hosted pkg repository on a pfSense
+# box (ADR-17 Phase 4, the client side). Run it ON the pfSense box. It writes a
+# pkg(8) repo conf under /usr/local/etc/pkg/repos/, runs `pkg update`, and
+# VERIFIES our package is visible from OUR repo — after which
+#   pkg install pfSense-pkg-pfBlockerNG-devel   (or -y, no -f, no -r)
+# resolves deps and installs our build, and the stock webConfigurator Install
+# pulls it too via cross-repo resolution (ADR §2; install is not repo-locked).
+#
+# CHANNELS
+#   devel  (default) -> conf /usr/local/etc/pkg/repos/pfblockerng-devel.conf
+#                       repo name `pfblockerng-devel`, pkg pfSense-pkg-pfBlockerNG-devel
+#   stable           -> conf /usr/local/etc/pkg/repos/pfblockerng.conf
+#                       repo name `pfblockerng`,       pkg pfSense-pkg-pfBlockerNG
+#
+# THE CONF (single source of truth — matches `build-repo.sh --print-conf`):
+#   url:            STATIC base + the literal ${ABI} pkg(8) variable (expanded by
+#                   pkg, NOT the shell) so one conf auto-follows the box's ABI
+#                   across a pfSense OS upgrade. No shell/query interpolation, so
+#                   the URL-encoding gate passes.
+#   mirror_type:    none.
+#   signature_type: none — NONE-signed; trust anchor is HTTPS to the host (no CI
+#                   signing key). pfSense honors per-repo `none` (ADR §1 Context 4).
+#   priority:       ABOVE the base Netgate `pfSense` repo (ships 0). Phase 1 PROVED
+#                   repo priority decides cross-repo selection (a higher-priority
+#                   repo wins even at a lower version), so this is what makes our
+#                   build win. 100 clears pfSense's 0 with margin.
+#   enabled:        yes.
+#
+# IDEMPOTENT: re-running rewrites the conf (safe to run again at any time).
+#
+# Usage:
+#   add-repo.sh [devel|stable]      # write the conf, pkg update, verify (default: devel)
+#   add-repo.sh --print-conf [devel|stable]   # print the conf to stdout and exit (no writes)
+#   add-repo.sh --base-url <url> [devel|stable]   # override the base (forks/staging)
+#
+# POSIX sh; quoted expansions; absolute path for the privileged `pkg` binary.
+
+set -eu
+
+# Absolute path for the privileged binary (pfSense convention; don't trust $PATH).
+PKG_BIN="/usr/local/sbin/pkg"
+REPOS_DIR="/usr/local/etc/pkg/repos"
+
+# The published GitHub Pages base (custom domain, served over HTTPS). This is the
+# SAME base build-repo.sh / build-repo-portable.py default to — the conf below is
+# byte-identical to their --print-conf for the devel channel. Override --base-url
+# for a fork/staging host. The conf appends the literal ${ABI} pkg(8) variable.
+DEFAULT_BASE_URL="https://brait.dev/pfBlockerNG"
+CONF_PRIORITY=100
+
+CHANNEL="devel"
+PRINT_CONF=0
+BASE_URL="$DEFAULT_BASE_URL"
+
+# ── Arg parsing ────────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --print-conf)   PRINT_CONF=1; shift ;;
+        --base-url)     BASE_URL="$2"; shift 2 ;;
+        devel|stable)   CHANNEL="$1"; shift ;;
+        -h|--help)
+            sed -n '29,40p' "$0"   # the Usage block from the header
+            exit 0 ;;
+        -*) echo "add-repo: unknown option: $1" >&2; exit 2 ;;
+        *)  echo "add-repo: unknown channel '$1' (expected devel|stable)" >&2; exit 2 ;;
+    esac
+done
+
+# ── Per-channel identity ───────────────────────────────────────────────────────
+# devel -> repo `pfblockerng-devel`, conf pfblockerng-devel.conf, pkg ...-devel
+# stable-> repo `pfblockerng`,       conf pfblockerng.conf,       pkg pfSense-pkg-pfBlockerNG
+if [ "$CHANNEL" = devel ]; then
+    REPO_NAME="pfblockerng-devel"
+    CONF_NAME="pfblockerng-devel.conf"
+    PKG_NAME="pfSense-pkg-pfBlockerNG-devel"
+    CHANNEL_LABEL="devel"
+else
+    REPO_NAME="pfblockerng"
+    CONF_NAME="pfblockerng.conf"
+    PKG_NAME="pfSense-pkg-pfBlockerNG"
+    CHANNEL_LABEL="stable"
+fi
+CONF_PATH="${REPOS_DIR}/${CONF_NAME}"
+
+# ── The conf body (single source of truth; matches build-repo.sh --print-conf) ──
+# $1 = base URL (trailing slash stripped). The url value is a STATIC string with
+# the literal ${ABI} pkg(8) variable appended — single-quoted on emission so
+# neither this shell nor the URL-encoding gate sees a live expansion.
+print_conf() {
+    base="${1%/}"
+    cat <<EOF
+# pfBlockerNG (${CHANNEL_LABEL} channel) — self-hosted pkg repository (ADR-17).
+# NONE-signed: trust anchor is HTTPS to the host (no signing key). The \${ABI}
+# variable is expanded by pkg(8) and follows the box across a pfSense OS upgrade.
+# priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
+# resolution (pkg install/upgrade, GUI Install) selects our build.
+${REPO_NAME}: {
+  url: "${base}/\${ABI}",
+  mirror_type: none,
+  signature_type: none,
+  priority: ${CONF_PRIORITY},
+  enabled: yes
+}
+EOF
+}
+
+# ── --print-conf: emit and exit, no side effects (the test + a dry-run use this) ─
+if [ "$PRINT_CONF" -eq 1 ]; then
+    print_conf "$BASE_URL"
+    exit 0
+fi
+
+# ── Live bootstrap ─────────────────────────────────────────────────────────────
+command -v "$PKG_BIN" >/dev/null 2>&1 || {
+    echo "add-repo: '$PKG_BIN' not found — run this ON a pfSense box" >&2
+    exit 1
+}
+
+echo "==> Writing ${CHANNEL_LABEL} repo conf to ${CONF_PATH}"
+mkdir -p "$REPOS_DIR"
+# Rewrite unconditionally => idempotent (a re-run refreshes the conf in place).
+print_conf "$BASE_URL" > "$CONF_PATH"
+
+echo "==> pkg update (refreshing catalogs, including our repo)"
+env ASSUME_ALWAYS_YES=yes "$PKG_BIN" update -f >/dev/null
+
+# VERIFY our package is visible FROM OUR repo (not merely that pkg update ran).
+# `pkg rquery -r <repo>` queries that ONE repo's catalog; a hit means our catalog
+# loaded and carries the package. Exit non-zero (fail loud) if it is absent.
+echo "==> Verifying ${PKG_NAME} is visible from repo '${REPO_NAME}'"
+if "$PKG_BIN" rquery -r "$REPO_NAME" '%n %v' "$PKG_NAME" 2>/dev/null | grep -q .; then
+    found="$("$PKG_BIN" rquery -r "$REPO_NAME" '%n-%v' "$PKG_NAME" 2>/dev/null | head -n1)"
+    echo "==> OK: ${found} available from '${REPO_NAME}' (${CONF_PATH})"
+    echo "    Install:  ${PKG_BIN} install ${PKG_NAME}"
+    echo "    Upgrade:  ${PKG_BIN} upgrade ${PKG_NAME}"
+else
+    echo "add-repo: ${PKG_NAME} is NOT visible from repo '${REPO_NAME}' after pkg update." >&2
+    echo "  Checked conf: ${CONF_PATH}" >&2
+    echo "  The catalog may not be published yet for this box's ABI, or the URL is unreachable." >&2
+    echo "  Inspect with: ${PKG_BIN} -d update   (traces the catalog fetch)" >&2
+    exit 1
+fi

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -42,11 +42,11 @@ set -eu
 PKG_BIN="/usr/local/sbin/pkg"
 REPOS_DIR="/usr/local/etc/pkg/repos"
 
-# The published GitHub Pages base (custom domain, served over HTTPS). This is the
+# The published GitHub Pages base (the standard project Pages URL, served over HTTPS). This is the
 # SAME base build-repo.sh / build-repo-portable.py default to — the conf below is
 # byte-identical to their --print-conf for the devel channel. Override --base-url
 # for a fork/staging host. The conf appends the literal ${ABI} pkg(8) variable.
-DEFAULT_BASE_URL="https://brait.dev/pfBlockerNG"
+DEFAULT_BASE_URL="https://andrebrait.github.io/pfBlockerNG"
 CONF_PRIORITY=100
 
 CHANNEL="devel"

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -87,7 +87,11 @@ META_CONF = (
 # (expanded by pkg, not the shell), so one conf follows the box across an OS
 # upgrade; priority 100 sits above the base Netgate `pfSense` repo (priority 0) —
 # Phase 1 proved priority dominates version, so this is the precedence lever.
-DEFAULT_BASE_URL = "https://andrebrait.github.io/pfBlockerNG"
+# The published GitHub Pages base. The repo deploys to a Pages site served at a
+# CUSTOM DOMAIN (gh api repos/.../pages -> html_url http://brait.dev/pfBlockerNG/);
+# we serve over HTTPS, so the base is https://brait.dev/pfBlockerNG. Kept identical
+# to scripts/build-repo.sh DEFAULT_BASE_URL so the two generators stay byte-equal.
+DEFAULT_BASE_URL = "https://brait.dev/pfBlockerNG"
 CONF_PRIORITY = 100
 
 
@@ -271,8 +275,6 @@ def write_zstd_tar(member_name: str, data: bytes, out_path: Path) -> None:
 # --------------------------------------------------------------------------- #
 # Flavor-collision guard (same semantics as build-repo.sh)
 # --------------------------------------------------------------------------- #
-
-_FLAVOR_PREFIXES = ("php", "python", "py")
 
 
 def _flavor_signature(manifest: dict) -> str:

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+# build-repo-portable.py — turn a directory of pfBlockerNG .pkg files into a
+# per-ABI FreeBSD `pkg` repository tree WITHOUT libpkg or the `pkg` binary, in
+# pure Python (stdlib + the `zstd` binary, exactly like scripts/build-pkg-portable.py).
+# ADR-17 Phase 3a. This is the catalog generator the Phase-3b publish job runs on
+# a plain Linux runner that has NO libpkg.
+#
+# WHY A PURE-PYTHON GENERATOR
+#   `pkg repo` is a libpkg op. On FreeBSD (or the pfSense VM) `pkg` is present —
+#   scripts/build-repo.sh (Phase 2) drives it and STAYS the FreeBSD-VM fallback.
+#   On a plain Linux runner there is no apt `pkg` and no official prebuilt; the
+#   Phase-2 path needs `pkg` built from source + an ABI forced in the env. So,
+#   mirroring how build-pkg-portable.py hand-rolls the .pkg archive in pure Python,
+#   this tool hand-rolls the REPOSITORY CATALOG: it reads each .pkg's manifest
+#   directly (no libpkg, no ABI guessing) and emits a `pkg`-format catalog a real
+#   pfSense `pkg update`/`pkg install` accepts.
+#
+# WHAT IT EMITS (verified byte-structurally against real `pkg repo` output — see
+# ADR-17 RESULTS/03a): for each distinct ABI, under <out>/<ABI>/:
+#   * the input .pkg file(s),
+#   * meta.conf  (+ an identical copy named `meta`) — the catalog descriptor:
+#       version = 2; packing_format = "tzst"; manifests = "packagesite.yaml";
+#       data = "data"; filesite = "files"; manifests_archive = "packagesite";
+#       filesite_archive = "files";
+#   * packagesite.pkg — a zstd-compressed tar holding `packagesite.yaml`:
+#       newline-delimited JSON, ONE object per package = that pkg's
+#       +COMPACT_MANIFEST plus the repo fields `sum`/`flatsize`/`path`/`repopath`/
+#       `pkgsize` libpkg injects, in libpkg's field order.
+#   * data.pkg — a zstd-compressed tar holding `data`:
+#       {"groups":[], "expired_packages":[], "packages":[<the same objects>]}.
+#
+# THE `sum` FIELD (load-bearing — `pkg install` validates the downloaded .pkg
+# against it): libpkg checksum type 2 = `2$` + z-base-32(blake2b(file)). blake2b
+# is the 64-byte default digest; the base32 is z-base-32 (alphabet
+# "ybndrfg8ejkmcpqxot1uwisza345h769") packed LSB-first. Reproduced exactly here
+# (cracked against a real `pkg repo` oracle), so a real box accepts the .pkg.
+#
+# Deterministic + re-runnable + NO network: same inputs -> byte-identical tree;
+# a re-run wipes and rebuilds each ABI bucket so a removed .pkg never lingers.
+#
+# FLAVOR-COLLISION GUARD: identical to build-repo.sh — two .pkg sharing
+# name+version+ABI but differing in php/py flavor (their php*/python*/py*-
+# dependency names) CANNOT coexist in one catalog (the second would silently
+# shadow the first). We FAIL LOUD (exit 1) rather than drop a build. No colliding
+# combo exists today (CE 2.8 + Plus 25.03 are both FreeBSD:15:amd64 / php83 /
+# py311); the fix when one arises is a flavored layout <out>/<ABI>-<php><py>/,
+# intentionally NOT implemented here.
+#
+# Requires: python3 (stdlib only) + a zstd encoder (the `zstd` binary, or the
+# python `zstandard` module) — the same compressor contract as build-pkg-portable.py.
+#
+# Usage:
+#   build-repo-portable.py --in <dir-of-.pkg> --out <dir>   # build the per-ABI tree
+#   build-repo-portable.py --print-conf [--base-url <url>]  # print the client repo-conf
+#
+# This is a developer tool (not shipped in release archives). See --help.
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Catalog descriptor (meta.conf / meta) — byte-identical to real `pkg repo`.
+# --------------------------------------------------------------------------- #
+
+META_CONF = (
+    "version = 2;\n"
+    'packing_format = "tzst";\n'
+    'manifests = "packagesite.yaml";\n'
+    'data = "data";\n'
+    'filesite = "files";\n'
+    'manifests_archive = "packagesite";\n'
+    'filesite_archive = "files";\n'
+)
+
+# The shared client repo-conf template (the SINGLE source Phase 4's add-repo.sh +
+# the README reuse). Kept byte-identical to scripts/build-repo.sh --print-conf so
+# the two generators are interchangeable. ${ABI} is the literal pkg(8) variable
+# (expanded by pkg, not the shell), so one conf follows the box across an OS
+# upgrade; priority 100 sits above the base Netgate `pfSense` repo (priority 0) —
+# Phase 1 proved priority dominates version, so this is the precedence lever.
+DEFAULT_BASE_URL = "https://andrebrait.github.io/pfBlockerNG"
+CONF_PRIORITY = 100
+
+
+class BuildRepoError(Exception):
+    """A fatal, user-facing error (bad input / collision / missing tool)."""
+
+
+# --------------------------------------------------------------------------- #
+# libpkg checksum type 2:  "2$" + z-base-32(blake2b(file bytes))
+#
+# blake2b default digest = 64 bytes; z-base-32 (RFC-less human base32, alphabet
+# "ybndrfg8ejkmcpqxot1uwisza345h769") packs the bit stream LSB-FIRST within each
+# byte — matching libpkg's pkg_checksum_encode_base32(). Cracked against a real
+# `pkg repo` oracle (RESULTS/03a). 64 bytes -> 103 base32 chars (ceil(64*8/5)).
+# --------------------------------------------------------------------------- #
+
+_ZBASE32 = "ybndrfg8ejkmcpqxot1uwisza345h769"
+
+
+def _zbase32_lsb(data: bytes) -> str:
+    out: list[str] = []
+    total_bits = len(data) * 8
+    for i in range(0, total_bits, 5):
+        val = 0
+        for b in range(5):
+            bit_index = i + b
+            if bit_index < total_bits:
+                bit = (data[bit_index // 8] >> (bit_index % 8)) & 1
+                val |= bit << b
+        out.append(_ZBASE32[val])
+    return "".join(out)
+
+
+def pkg_checksum(pkg_bytes: bytes) -> str:
+    """The catalog `sum` for a .pkg file: libpkg checksum type 2 over the file bytes."""
+    return "2$" + _zbase32_lsb(hashlib.blake2b(pkg_bytes).digest())
+
+
+# --------------------------------------------------------------------------- #
+# Pure-Python .pkg reader (no libpkg) — read the +COMPACT_MANIFEST JSON.
+#
+# A .pkg is a zstd-compressed tar whose first member is +COMPACT_MANIFEST (UCL,
+# which is JSON for our packages). build-pkg-portable.py writes exactly this; this
+# is the inverse read. ABI/name/version/flavor all come from that manifest — never
+# guessed from the filename (matches build-repo.sh's `pkg query -F`).
+# --------------------------------------------------------------------------- #
+
+
+def _zstd_decompress(data: bytes) -> bytes:
+    if data[:4] != b"\x28\xb5\x2f\xfd":
+        # Not zstd-framed: assume an already-uncompressed tar (defensive).
+        return data
+    try:
+        import zstandard
+
+        return zstandard.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
+    except ImportError:
+        zstd = shutil.which("zstd")
+        if not zstd:
+            raise BuildRepoError(
+                "a .pkg is zstd-compressed; install the `zstd` binary or the python `zstandard` module"
+            ) from None
+        return subprocess.run([zstd, "-dc"], input=data, stdout=subprocess.PIPE, check=True).stdout
+
+
+def read_compact_manifest(pkg_path: Path) -> dict:
+    """Return the +COMPACT_MANIFEST JSON object of a .pkg (pure Python, no libpkg)."""
+    raw = pkg_path.read_bytes()
+    tar_bytes = _zstd_decompress(raw)
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+        try:
+            member = tf.extractfile("+COMPACT_MANIFEST")
+        except KeyError:
+            member = None
+        if member is None:
+            raise BuildRepoError(f"{pkg_path.name}: no +COMPACT_MANIFEST member — not a libpkg .pkg?")
+        data = member.read()
+    try:
+        obj = json.loads(data)
+    except ValueError as e:
+        raise BuildRepoError(f"{pkg_path.name}: +COMPACT_MANIFEST is not valid JSON/UCL: {e}") from None
+    if not isinstance(obj, dict):
+        raise BuildRepoError(f"{pkg_path.name}: +COMPACT_MANIFEST is not an object")
+    return obj
+
+
+# --------------------------------------------------------------------------- #
+# Catalog object (one packagesite.yaml / data line per package)
+#
+# libpkg's packagesite object = the +COMPACT_MANIFEST with the repo fields
+# sum/flatsize/path/repopath/pkgsize spliced in at libpkg's positions:
+#   ...prefix, SUM, flatsize, PATH, REPOPATH, licenselogic, PKGSIZE, desc...
+# We reproduce that exact key order (clients parse JSON order-independently, but
+# matching the oracle keeps the output faithful + diffable).
+# --------------------------------------------------------------------------- #
+
+
+def catalog_object(manifest: dict, *, pkg_name: str, sum_: str, pkgsize: int) -> dict:
+    """Build the packagesite object for one package from its compact manifest."""
+    obj: dict = {}
+    for key, value in manifest.items():
+        obj[key] = value
+        if key == "prefix":
+            # sum immediately follows prefix; flatsize (already in the manifest)
+            # then path + repopath follow.
+            obj["sum"] = sum_
+        if key == "flatsize":
+            # path/repopath land right after flatsize (which sits right after sum).
+            obj["path"] = pkg_name
+            obj["repopath"] = pkg_name
+        if key == "licenselogic":
+            obj["pkgsize"] = pkgsize
+    # Defensive: if a manifest lacked `prefix`/`flatsize`/`licenselogic`, the repo
+    # fields still MUST be present (libpkg always emits them). Append any missing.
+    if "sum" not in obj:
+        obj["sum"] = sum_
+    if "path" not in obj:
+        obj["path"] = pkg_name
+    if "repopath" not in obj:
+        obj["repopath"] = pkg_name
+    if "pkgsize" not in obj:
+        obj["pkgsize"] = pkgsize
+    return obj
+
+
+def _ndjson(objs: list[dict]) -> bytes:
+    # newline-delimited JSON, compact (libpkg emits no spaces), trailing newline.
+    return b"".join(json.dumps(o, separators=(",", ":"), ensure_ascii=False).encode() + b"\n" for o in objs)
+
+
+def _data_blob(objs: list[dict]) -> bytes:
+    # The `data` member is a SINGLE JSON object with NO trailing newline (unlike
+    # packagesite.yaml's NDJSON) — matches real `pkg repo` output exactly.
+    payload = {"groups": [], "expired_packages": [], "packages": objs}
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+# --------------------------------------------------------------------------- #
+# Archive emission (zstd tar) — same framing contract as build-pkg-portable.py:
+# USTAR, leading-slash-free member name, root:wheel, mode 0644, deterministic
+# mtime 0 (the install/index clock is irrelevant to clients; 0 keeps re-runs
+# byte-identical). USTAR is the proven-accepted framing (build-pkg-portable.py's
+# .pkg uses it and a real pfSense box installs it).
+# --------------------------------------------------------------------------- #
+
+
+def _zstd_compress(data: bytes) -> bytes:
+    try:
+        import zstandard
+
+        return zstandard.ZstdCompressor(level=19).compress(data)
+    except ImportError:
+        pass
+    zstd = shutil.which("zstd")
+    if not zstd:
+        raise BuildRepoError(
+            "zstd compression needs the `zstd` binary or the python `zstandard` module "
+            "(brew install zstd / apt install zstd)"
+        )
+    return subprocess.run([zstd, "-q", "-19", "-c"], input=data, stdout=subprocess.PIPE, check=True).stdout
+
+
+def _tar_one(member_name: str, data: bytes) -> bytes:
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as tf:
+        ti = tarfile.TarInfo(name=member_name)
+        ti.size = len(data)
+        ti.mode = 0o644
+        ti.uid = ti.gid = 0
+        ti.uname, ti.gname = "root", "wheel"
+        ti.mtime = 0
+        ti.type = tarfile.REGTYPE
+        tf.addfile(ti, io.BytesIO(data))
+    return raw.getvalue()
+
+
+def write_zstd_tar(member_name: str, data: bytes, out_path: Path) -> None:
+    out_path.write_bytes(_zstd_compress(_tar_one(member_name, data)))
+
+
+# --------------------------------------------------------------------------- #
+# Flavor-collision guard (same semantics as build-repo.sh)
+# --------------------------------------------------------------------------- #
+
+_FLAVOR_PREFIXES = ("php", "python", "py")
+
+
+def _flavor_signature(manifest: dict) -> str:
+    """The php*/python*/py*- dependency NAMES of a pkg, sorted + comma-joined.
+
+    Two builds of the same name+version+ABI that differ here are different flavors
+    and cannot share a catalog. Empty for a flavor-free pkg. Mirrors build-repo.sh's
+    `pkg query %dn | grep -E '^(php[0-9]+|python[0-9]+|py[0-9]+-)'`.
+    """
+    deps = manifest.get("deps")
+    if not isinstance(deps, dict):
+        return ""
+    flavored: list[str] = []
+    for name in deps:
+        # php<digits>, python<digits>, or py<digits>-<...>
+        if name.startswith("python") and name[len("python") :][:1].isdigit():
+            flavored.append(name)
+        elif name.startswith("php") and name[len("php") :][:1].isdigit():
+            flavored.append(name)
+        elif name.startswith("py") and "-" in name and name[len("py") :].split("-", 1)[0].isdigit():
+            flavored.append(name)
+    return ",".join(sorted(flavored))
+
+
+def _check_collisions(entries: list[tuple[Path, dict]]) -> None:
+    """Fail loud if two .pkg share name+version+ABI but differ in php/py flavor."""
+    seen: dict[str, str] = {}  # "name|version|ABI" -> flavor signature
+    for path, manifest in entries:
+        name = manifest.get("name")
+        version = manifest.get("version")
+        abi = manifest.get("abi")
+        if not (name and version and abi):
+            raise BuildRepoError(
+                f"{path.name}: manifest missing name/version/abi (name={name!r} version={version!r} abi={abi!r})"
+            )
+        key = f"{name}|{version}|{abi}"
+        sig = _flavor_signature(manifest)
+        prev = seen.get(key)
+        if prev is None:
+            seen[key] = sig
+        elif prev != sig:
+            raise BuildRepoError(
+                f"FLAVOR COLLISION — two packages share name+version+ABI '{key}'\n"
+                f"  but differ in php/py flavor:\n"
+                f"    flavor A: {prev or '<none>'}\n"
+                f"    flavor B: {sig or '<none>'}\n"
+                f"  They cannot coexist in one catalog (the second would shadow the first).\n"
+                f"  Resolve by splitting into a flavored layout: <out>/<ABI>-<php><py>/\n"
+                f"  (not implemented — no colliding combo exists today; teach the tool when one does)."
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+
+def build_repo(in_dir: Path, out_dir: Path) -> list[str]:
+    """Build the per-ABI catalog tree. Returns the list of ABIs built (sorted)."""
+    pkgs = sorted(p for p in in_dir.glob("*.pkg") if p.is_file())
+    if not pkgs:
+        raise BuildRepoError(f"no .pkg files in {in_dir}")
+
+    # Read every manifest ONCE (the ABI/name/version/flavor source of truth).
+    entries: list[tuple[Path, dict]] = [(p, read_compact_manifest(p)) for p in pkgs]
+
+    # Collision guard before laying anything out (fail-closed, never a silent drop).
+    _check_collisions(entries)
+
+    # Bucket by ABI.
+    by_abi: dict[str, list[tuple[Path, dict]]] = {}
+    for path, manifest in entries:
+        abi = manifest["abi"]
+        by_abi.setdefault(abi, []).append((path, manifest))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for abi in sorted(by_abi):
+        bucket = out_dir / abi
+        # Wipe + rebuild for determinism (a removed .pkg never lingers).
+        if bucket.exists():
+            shutil.rmtree(bucket)
+        bucket.mkdir(parents=True)
+
+        catalog_objs: list[dict] = []
+        # Deterministic order: by .pkg filename.
+        for path, manifest in sorted(by_abi[abi], key=lambda e: e[0].name):
+            pkg_bytes = path.read_bytes()
+            dest = bucket / path.name
+            dest.write_bytes(pkg_bytes)
+            obj = catalog_object(
+                manifest,
+                pkg_name=path.name,
+                sum_=pkg_checksum(pkg_bytes),
+                pkgsize=len(pkg_bytes),
+            )
+            catalog_objs.append(obj)
+
+        # meta.conf + its identical `meta` copy (real `pkg repo` writes both).
+        (bucket / "meta.conf").write_text(META_CONF)
+        (bucket / "meta").write_text(META_CONF)
+        # packagesite.pkg (packagesite.yaml = NDJSON) + data.pkg (data = one JSON object).
+        write_zstd_tar("packagesite.yaml", _ndjson(catalog_objs), bucket / "packagesite.pkg")
+        write_zstd_tar("data", _data_blob(catalog_objs), bucket / "data.pkg")
+        sys.stderr.write(f"==> built catalog {bucket} ({len(catalog_objs)} package(s))\n")
+
+    return sorted(by_abi)
+
+
+def print_conf(base_url: str) -> None:
+    base = base_url.rstrip("/")
+    sys.stdout.write(
+        "# pfBlockerNG (devel channel) — self-hosted pkg repository (ADR-17).\n"
+        "# NONE-signed: trust anchor is HTTPS to the host (no signing key). The ${ABI}\n"
+        "# variable is expanded by pkg(8) and follows the box across a pfSense OS upgrade.\n"
+        f"# priority {CONF_PRIORITY} sits above the base Netgate `pfSense` repo so cross-repo\n"
+        "# resolution (pkg install/upgrade, GUI Install) selects our build.\n"
+        "pfblockerng-devel: {\n"
+        f'  url: "{base}/${{ABI}}",\n'
+        "  mirror_type: none,\n"
+        "  signature_type: none,\n"
+        f"  priority: {CONF_PRIORITY},\n"
+        "  enabled: yes\n"
+        "}\n"
+    )
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(
+        prog="build-repo-portable.py",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Generate a per-ABI FreeBSD pkg repository catalog in pure Python (no libpkg). ADR-17 Phase 3a.",
+        epilog=(
+            "examples:\n"
+            "  # build a catalog tree from a dir of release .pkg\n"
+            "  build-repo-portable.py --in ./pkgs --out ./site\n\n"
+            "  # print the client repo-conf (Phase 4 add-repo.sh + README reuse it)\n"
+            "  build-repo-portable.py --print-conf --base-url https://example.github.io/pfBlockerNG\n"
+        ),
+    )
+    ap.add_argument("--in", dest="in_dir", help="directory holding the input .pkg files (searched, non-recursive)")
+    ap.add_argument("--out", dest="out_dir", help="output root; one <ABI>/ catalog subtree is created per ABI")
+    ap.add_argument("--print-conf", action="store_true", help="print the client repo-conf template to stdout and exit")
+    ap.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help="base URL for --print-conf (the conf appends the literal ${ABI} pkg variable)",
+    )
+    args = ap.parse_args(argv)
+
+    if args.print_conf:
+        print_conf(args.base_url)
+        return 0
+
+    if not args.in_dir or not args.out_dir:
+        ap.error("--in and --out are required (or use --print-conf)")
+    in_dir = Path(args.in_dir)
+    if not in_dir.is_dir():
+        sys.stderr.write(f"build-repo-portable: --in is not a directory: {in_dir}\n")
+        return 1
+
+    try:
+        abis = build_repo(in_dir, Path(args.out_dir))
+    except BuildRepoError as e:
+        sys.stderr.write(f"build-repo-portable: {e}\n")
+        return 1
+    sys.stderr.write(f"==> built catalogs for ABI: {' '.join(abis)}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -87,11 +87,11 @@ META_CONF = (
 # (expanded by pkg, not the shell), so one conf follows the box across an OS
 # upgrade; priority 100 sits above the base Netgate `pfSense` repo (priority 0) —
 # Phase 1 proved priority dominates version, so this is the precedence lever.
-# The published GitHub Pages base. The repo deploys to a Pages site served at a
-# CUSTOM DOMAIN (gh api repos/.../pages -> html_url http://brait.dev/pfBlockerNG/);
-# we serve over HTTPS, so the base is https://brait.dev/pfBlockerNG. Kept identical
+# The published GitHub Pages base — the repo's standard project Pages URL
+# (gh api repos/.../pages -> html_url https://andrebrait.github.io/pfBlockerNG/);
+# we serve over HTTPS, so the base is https://andrebrait.github.io/pfBlockerNG. Kept identical
 # to scripts/build-repo.sh DEFAULT_BASE_URL so the two generators stay byte-equal.
-DEFAULT_BASE_URL = "https://brait.dev/pfBlockerNG"
+DEFAULT_BASE_URL = "https://andrebrait.github.io/pfBlockerNG"
 CONF_PRIORITY = 100
 
 

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -61,6 +61,7 @@ import argparse
 import hashlib
 import io
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -93,6 +94,12 @@ META_CONF = (
 # to scripts/build-repo.sh DEFAULT_BASE_URL so the two generators stay byte-equal.
 DEFAULT_BASE_URL = "https://andrebrait.github.io/pfBlockerNG"
 CONF_PRIORITY = 100
+
+# A safe single path segment: an ABI is used UNVALIDATED from manifest data as a
+# directory name (out_dir / abi) that is rmtree'd + rebuilt, so reject anything
+# that could escape out_dir. FreeBSD ABIs look like `FreeBSD:15:amd64` (the `:` is
+# allowed); `/`, `\`, whitespace, and traversal are not.
+_ABI_RE = re.compile(r"^[A-Za-z0-9:._+-]+$")
 
 
 class BuildRepoError(Exception):
@@ -348,6 +355,9 @@ def build_repo(in_dir: Path, out_dir: Path) -> list[str]:
     by_abi: dict[str, list[tuple[Path, dict]]] = {}
     for path, manifest in entries:
         abi = manifest["abi"]
+        # Validate before it becomes a filesystem path segment (rmtree target below).
+        if not isinstance(abi, str) or not _ABI_RE.fullmatch(abi) or ".." in abi:
+            raise BuildRepoError(f"{path.name}: unsafe or invalid ABI segment {abi!r}")
         by_abi.setdefault(abi, []).append((path, manifest))
 
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -71,11 +71,11 @@ set -eu
 #   * enabled: yes.
 # `pfblockerng-devel` matches the channel-named conf Phase 4 writes
 # (/usr/local/etc/pkg/repos/pfblockerng-devel.conf).
-# The published GitHub Pages base. The repo deploys to a Pages site served at a
-# CUSTOM DOMAIN (gh api repos/.../pages -> html_url http://brait.dev/pfBlockerNG/);
-# we serve over HTTPS, so the base is https://brait.dev/pfBlockerNG and the conf
+# The published GitHub Pages base — the repo's standard project Pages URL
+# (gh api repos/.../pages -> html_url https://andrebrait.github.io/pfBlockerNG/);
+# we serve over HTTPS, so the base is https://andrebrait.github.io/pfBlockerNG and the conf
 # appends the literal ${ABI} pkg(8) variable. Override with --base-url for a fork.
-DEFAULT_BASE_URL="https://brait.dev/pfBlockerNG"
+DEFAULT_BASE_URL="https://andrebrait.github.io/pfBlockerNG"
 CONF_PRIORITY=100
 
 print_conf() {

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -202,6 +202,18 @@ for f in "$@"; do
     fi
 done
 
+# Reject an ABI that is not a single safe path segment — it becomes a directory
+# name (${OUT}/${abi}) that is `rm -rf`'d + rebuilt, so `..` / `/` / odd chars could
+# escape $OUT. FreeBSD ABIs look like `FreeBSD:15:amd64` (the `:` is allowed).
+validate_abi() {
+    case "$1" in
+        ""|*/*|*".."*|*[!A-Za-z0-9:._+-]*)
+            echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
+            exit 1
+            ;;
+    esac
+}
+
 # ── Lay out per-ABI buckets + run `pkg repo` ───────────────────────────────────
 mkdir -p "$OUT"
 # Track which ABI buckets we (re)built, so each is wiped exactly once for
@@ -209,6 +221,7 @@ mkdir -p "$OUT"
 built=""
 for f in "$@"; do
     abi="$(pkg_abi "$f")"
+    validate_abi "$abi"
     dir="${OUT}/${abi}"
     case " $built " in
         *" $abi "*) : ;;                 # already wiped this run

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -71,7 +71,11 @@ set -eu
 #   * enabled: yes.
 # `pfblockerng-devel` matches the channel-named conf Phase 4 writes
 # (/usr/local/etc/pkg/repos/pfblockerng-devel.conf).
-DEFAULT_BASE_URL="https://andrebrait.github.io/pfBlockerNG"
+# The published GitHub Pages base. The repo deploys to a Pages site served at a
+# CUSTOM DOMAIN (gh api repos/.../pages -> html_url http://brait.dev/pfBlockerNG/);
+# we serve over HTTPS, so the base is https://brait.dev/pfBlockerNG and the conf
+# appends the literal ${ABI} pkg(8) variable. Override with --base-url for a fork.
+DEFAULT_BASE_URL="https://brait.dev/pfBlockerNG"
 CONF_PRIORITY=100
 
 print_conf() {

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+# build-repo.sh — turn a directory of pfBlockerNG .pkg files into a per-ABI
+# FreeBSD `pkg` repository tree (ADR-17 Phase 2). This is the reusable, proven
+# catalog generator the Phase-3 publish job calls over the .pkg assets ADR-09
+# attaches to each GitHub Release.
+#
+# WHAT IT DOES
+#   1. Reads each input .pkg's ABI FROM THE PACKAGE (`pkg query -F <f> '%q'`) —
+#      never guessed from the filename.
+#   2. Buckets each .pkg under  <out>/<ABI>/  (one catalog per ABI, e.g.
+#      <out>/FreeBSD:15:amd64/) and copies the .pkg there.
+#   3. Runs `pkg repo <out>/<ABI>` per bucket with NO signing key, emitting the
+#      catalog triple (meta.conf / packagesite.pkg / data.pkg) a client
+#      `pkg update` consumes. NONE-signed by construction (the ADR trust model:
+#      TLS to the host, no CI key — ADR §2 "Trust model").
+#   4. Optionally prints the shared client repo-conf TEMPLATE (`--print-conf`):
+#      the single `${ABI}` / NONE-signed / above-pfSense-priority stanza Phase 4's
+#      add-repo.sh and the README reuse.
+#
+# Deterministic + re-runnable + NO network: the same inputs yield the same tree;
+# a re-run wipes and rebuilds each ABI bucket so a removed .pkg never lingers.
+#
+# FLAVOR-COLLISION GUARD: two .pkg sharing package-name + version + ABI but
+# differing in php/py flavor (their `php*`/`py*-*` dependency names) CANNOT
+# coexist in one catalog — the second would silently shadow the first. We FAIL
+# LOUD rather than drop a build. No colliding combo exists today (CE 2.8 + Plus
+# 25.03 are both FreeBSD:15:amd64 / php83 / py311); when one ever does, the fix
+# is a flavored layout `<out>/<ABI>-<php><py>/` (add-repo.sh would then detect +
+# pin the box's flavor). That split is intentionally NOT implemented here — see
+# the guard below.
+#
+# LIBPKG PROVENANCE: `pkg repo` is a libpkg op needing the `pkg` binary. On
+# FreeBSD (or the pfSense VM) `pkg` is present. On a Linux CI runner it is NOT in
+# apt and has no official prebuilt — see RESULTS/02 for the libpkg-on-Linux vs
+# FreeBSD-VM-fallback verdict that decides where Phase 3 runs this. The script is
+# transport-agnostic: it only needs SOME `pkg` on PATH (override with PKG_BIN).
+#
+# Usage:
+#   build-repo.sh --in <dir-of-.pkg> --out <dir>      # build the per-ABI tree
+#   build-repo.sh --print-conf [--base-url <url>]     # print the client repo-conf
+#
+# Options:
+#   --in DIR          directory holding the input .pkg files (searched, non-recursive)
+#   --out DIR         output root; one <ABI>/ catalog subtree is created per ABI
+#   --print-conf      print the client repo-conf template to stdout and exit
+#   --base-url URL    base URL for --print-conf (default: the ADR Pages base);
+#                     the conf appends the literal ${ABI} pkg variable to it
+#
+# Env:
+#   PKG_BIN           the pkg binary to use (default: pkg)
+#
+# POSIX sh; quoted expansions; no bash-isms. Run from anywhere.
+
+set -eu
+
+# ── The shared client repo-conf template ───────────────────────────────────────
+#
+# The SINGLE source of the client stanza (Phase 4's add-repo.sh + the README
+# reuse this exact shape). Fields, per ADR §2 "Client bootstrap":
+#   * url:            STATIC base + the literal ${ABI} pkg variable (NO shell/query
+#                     interpolation) so one conf auto-follows the box's ABI across
+#                     an OS upgrade. ${ABI} is expanded by pkg(8), not the shell.
+#   * mirror_type: none / signature_type: none — NONE-signed; trust = HTTPS to the host.
+#   * priority:       ABOVE the base Netgate `pfSense` repo so cross-repo resolution
+#                     picks our build. Phase 1 PROVED priority dominates version (a
+#                     higher-priority repo wins even at a lower version), so this is
+#                     the real precedence lever. The pfSense repo ships priority 0 by
+#                     default; 100 clears it with margin while staying an ordinary
+#                     positive value (add-repo.sh may recompute it live, +100 over the
+#                     effective pfSense priority, the way the Phase-1 smoke does).
+#   * enabled: yes.
+# `pfblockerng-devel` matches the channel-named conf Phase 4 writes
+# (/usr/local/etc/pkg/repos/pfblockerng-devel.conf).
+DEFAULT_BASE_URL="https://andrebrait.github.io/pfBlockerNG"
+CONF_PRIORITY=100
+
+print_conf() {
+    # $1 = base URL (no trailing slash). The url value is a STATIC string with the
+    # literal ${ABI} pkg variable appended — deliberately single-quoted on emission
+    # so neither this shell nor the URL-encoding gate sees a live expansion.
+    base="$1"
+    cat <<EOF
+# pfBlockerNG (devel channel) — self-hosted pkg repository (ADR-17).
+# NONE-signed: trust anchor is HTTPS to the host (no signing key). The \${ABI}
+# variable is expanded by pkg(8) and follows the box across a pfSense OS upgrade.
+# priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
+# resolution (pkg install/upgrade, GUI Install) selects our build.
+pfblockerng-devel: {
+  url: "${base}/\${ABI}",
+  mirror_type: none,
+  signature_type: none,
+  priority: ${CONF_PRIORITY},
+  enabled: yes
+}
+EOF
+}
+
+# ── Arg parsing ────────────────────────────────────────────────────────────────
+IN=""
+OUT=""
+PRINT_CONF=0
+BASE_URL="$DEFAULT_BASE_URL"
+PKG_BIN="${PKG_BIN:-pkg}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --in)         IN="$2"; shift 2 ;;
+        --out)        OUT="$2"; shift 2 ;;
+        --print-conf) PRINT_CONF=1; shift ;;
+        --base-url)   BASE_URL="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '37,57p' "$0"   # the Usage/Options/Env block from the header
+            exit 0 ;;
+        *) echo "build-repo: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ "$PRINT_CONF" -eq 1 ]; then
+    print_conf "${BASE_URL%/}"
+    exit 0
+fi
+
+# Pure precondition test; the || branch (usage + exit) is the intended else and
+# the && chain is side-effect-free, so SC2015's caveat does not apply.
+# shellcheck disable=SC2015
+[ -n "$IN" ] && [ -n "$OUT" ] || {
+    echo "Usage: $0 --in <dir-of-.pkg> --out <dir>   |   $0 --print-conf [--base-url <url>]" >&2
+    exit 2
+}
+[ -d "$IN" ] || { echo "build-repo: --in is not a directory: $IN" >&2; exit 1; }
+
+command -v "$PKG_BIN" >/dev/null 2>&1 || {
+    echo "build-repo: '$PKG_BIN' not found on PATH — need a libpkg \`pkg\` binary (set PKG_BIN)" >&2
+    exit 1
+}
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+# The ABI of a .pkg, READ from the package (not guessed from the filename).
+pkg_abi() {
+    "$PKG_BIN" query -F "$1" '%q' 2>/dev/null
+}
+
+# The flavor signature of a .pkg: its php*/python*/py*- dependency NAMES, sorted.
+# Two builds of the same name+version+ABI that differ here are different flavors
+# and cannot share a catalog (the collision guard). Empty for a flavor-free pkg.
+pkg_flavor_sig() {
+    "$PKG_BIN" query -F "$1" '%dn' 2>/dev/null \
+        | grep -E '^(php[0-9]+|python[0-9]+|py[0-9]+-)' \
+        | LC_ALL=C sort \
+        | tr '\n' ',' || true
+}
+
+pkg_nv() {
+    # "<name> <version>" of a .pkg.
+    "$PKG_BIN" query -F "$1" '%n %v' 2>/dev/null
+}
+
+# ── Enumerate inputs ───────────────────────────────────────────────────────────
+# Collect the .pkg paths into the positional params (POSIX-portable iteration,
+# no arrays). `set --` resets them; the nullglob-free guard skips a literal
+# no-match. Non-recursive: inputs are a flat dir of release .pkg.
+set --
+for f in "$IN"/*.pkg; do
+    [ -e "$f" ] || continue
+    set -- "$@" "$f"
+done
+[ "$#" -gt 0 ] || { echo "build-repo: no .pkg files in $IN" >&2; exit 1; }
+
+# ── Collision guard: name+version+ABI must map to ONE flavor ────────────────────
+# Build a "<name>|<version>|<ABI> -> flavor-signature" check. A repeated key with
+# a DIFFERENT signature is an unhandled flavor collision -> FAIL LOUD. A repeated
+# key with the SAME signature is a duplicate input (harmless; pkg repo dedups).
+# Use a temp file as the associative store (POSIX sh has no maps).
+seen="$(mktemp)"
+trap 'rm -f "$seen"' EXIT INT TERM
+for f in "$@"; do
+    abi="$(pkg_abi "$f")"
+    [ -n "$abi" ] || { echo "build-repo: could not read ABI from $f" >&2; exit 1; }
+    nv="$(pkg_nv "$f")"
+    sig="$(pkg_flavor_sig "$f")"
+    key="${nv}|${abi}"
+    prev="$(grep -F "KEY=${key}=SIG=" "$seen" 2>/dev/null | head -n1 || true)"
+    if [ -n "$prev" ]; then
+        prev_sig="${prev#KEY="${key}"=SIG=}"
+        if [ "$prev_sig" != "$sig" ]; then
+            echo "build-repo: FLAVOR COLLISION — two packages share name+version+ABI '${key}'" >&2
+            echo "  but differ in php/py flavor:" >&2
+            echo "    flavor A: ${prev_sig:-<none>}" >&2
+            echo "    flavor B: ${sig:-<none>}" >&2
+            echo "  They cannot coexist in one catalog (the second would shadow the first)." >&2
+            echo "  Resolve by splitting into a flavored layout: <out>/<ABI>-<php><py>/" >&2
+            echo "  (not implemented — no colliding combo exists today; teach the tool when one does)." >&2
+            exit 1
+        fi
+    else
+        echo "KEY=${key}=SIG=${sig}" >> "$seen"
+    fi
+done
+
+# ── Lay out per-ABI buckets + run `pkg repo` ───────────────────────────────────
+mkdir -p "$OUT"
+# Track which ABI buckets we (re)built, so each is wiped exactly once for
+# determinism even when several .pkg share an ABI.
+built=""
+for f in "$@"; do
+    abi="$(pkg_abi "$f")"
+    dir="${OUT}/${abi}"
+    case " $built " in
+        *" $abi "*) : ;;                 # already wiped this run
+        *) rm -rf "$dir"; mkdir -p "$dir"; built="$built $abi" ;;
+    esac
+    cp "$f" "${dir}/"
+done
+
+for abi in $built; do
+    dir="${OUT}/${abi}"
+    echo "==> pkg repo ${dir}" >&2
+    # No key argument => an unsigned (NONE-signed) catalog. ASSUME_ALWAYS_YES so
+    # pkg never prompts in CI.
+    env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir"
+done
+
+echo "==> built catalogs for ABI:${built}" >&2

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -97,6 +97,18 @@ DECOY_REPO_NAME = "netgate-decoy"  # a controlled file:// stand-in for a competi
 NETGATE_REPO_NAME = "pfSense"  # the real base-system Netgate repo (left enabled; loses on priority)
 GUEST_FILE_LIST = f"{GUEST_SPIKE_DIR}/installed_files.txt"
 
+# Phase-2 (ADR-17) catalog generator under test. ``build-repo.sh`` is the real,
+# reusable per-ABI catalog tool the Phase-3 publish job runs; here it is staged to
+# the guest and run with the guest's libpkg to prove the SCRIPT's output (an
+# <ABI>/ catalog tree it lays out) is accepted by a real pfSense ``pkg update`` +
+# install. (The libpkg-on-Linux half of the build-side premise — that the SAME
+# script + the SAME ``pkg repo`` op runs on a Linux runner — is proven locally in
+# RESULTS/02; the script is identical regardless of which libpkg invokes it.)
+BUILD_REPO_SH = Path(__file__).resolve().parents[2] / "scripts" / "build-repo.sh"
+GUEST_BUILD_REPO_SH = f"{GUEST_SPIKE_DIR}/build-repo.sh"
+GUEST_PKG_IN_DIR = f"{GUEST_SPIKE_DIR}/pkg_in"  # the input dir of .pkg for build-repo.sh
+SCRIPT_REPO_ROOT = f"{GUEST_SPIKE_DIR}/script_catalog"  # build-repo.sh --out (per-ABI tree)
+
 
 # --------------------------------------------------------------------------- #
 # Egress — this flow needs the REAL Netgate repo reachable
@@ -172,6 +184,49 @@ def build_guest_repo(vm: SmokeVM, repo_dir: str, pkg_files: list[Path]) -> None:
         _scp_to_guest(vm, pkg, f"{repo_dir}/{pkg.name}")
     # `pkg repo <dir>` with no key argument => an unsigned catalog.
     _ssh_check(vm, "env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", repo_dir)
+
+
+def build_repo_via_script(vm: SmokeVM, pkg_files: list[Path]) -> str:
+    """Run the Phase-2 ``scripts/build-repo.sh`` on the guest over ``pkg_files``.
+
+    Stages the real ``build-repo.sh`` and the input ``.pkg`` to the guest, runs
+    ``build-repo.sh --in <pkg_in> --out <script_catalog>`` with the guest's own
+    libpkg, then returns the single per-ABI catalog directory it produced
+    (``<out>/<ABI>/``) — the dir a ``file://`` repo conf points at.
+
+    This validates the SCRIPT's output (the bucketed ``<ABI>/`` tree + the catalog
+    triple ``pkg repo`` emits) is accepted by a real pfSense box, the live half of
+    the build-side premise. The branch ``.pkg`` is a single ABI
+    (``FreeBSD:15:amd64``), so exactly one ``<ABI>/`` dir is expected.
+    """
+    _ssh_check(vm, "/bin/rm", "-rf", GUEST_PKG_IN_DIR, SCRIPT_REPO_ROOT)
+    _ssh_check(vm, "/bin/mkdir", "-p", GUEST_PKG_IN_DIR, GUEST_SPIKE_DIR)
+    _scp_to_guest(vm, BUILD_REPO_SH, GUEST_BUILD_REPO_SH)
+    for pkg in pkg_files:
+        _scp_to_guest(vm, pkg, f"{GUEST_PKG_IN_DIR}/{pkg.name}")
+    # Run the script exactly as Phase 3 will (just with the guest's pkg as PKG_BIN
+    # default). ASSUME_ALWAYS_YES so `pkg repo` never prompts.
+    _ssh_check(
+        vm,
+        "env",
+        "ASSUME_ALWAYS_YES=yes",
+        "/bin/sh",
+        GUEST_BUILD_REPO_SH,
+        "--in",
+        GUEST_PKG_IN_DIR,
+        "--out",
+        SCRIPT_REPO_ROOT,
+        timeout=240.0,
+    )
+    # The script buckets by ABI; the branch .pkg is one ABI -> one <ABI>/ subdir.
+    listing = _ssh_check(vm, "/bin/ls", "-1", SCRIPT_REPO_ROOT).stdout.split()
+    assert len(listing) == 1, f"build-repo.sh produced {listing!r} ABI buckets, expected exactly 1"
+    abi_dir = f"{SCRIPT_REPO_ROOT}/{listing[0]}"
+    # The catalog triple must be present (what `pkg update` consumes).
+    for fname in ("meta.conf", "packagesite.pkg", "data.pkg"):
+        present = vm.ssh("/bin/test", "-f", f"{abi_dir}/{fname}")
+        assert present.returncode == 0, f"build-repo.sh did not emit {fname} under {abi_dir}"
+    return abi_dir
 
 
 def _repo_block(name: str, directory: str, priority: int) -> str:
@@ -490,3 +545,45 @@ def test_precedence_decoy_higher_priority_wins(repo_vm: SmokeVM) -> None:
         f"installed from {origin!r}, expected the decoy {DECOY_REPO_NAME!r} "
         f"(decoy {pfsense_prio + 200} > ours {pfsense_prio + 100})"
     )
+
+
+@pytest.mark.timeout(600)  # build-repo.sh + pkg update + install from the script's catalog > the 30s cap.
+def test_build_repo_script_catalog_is_accepted(repo_vm: SmokeVM) -> None:
+    """PHASE-2 BUILD TOOL: the catalog laid out by ``scripts/build-repo.sh`` is
+    accepted by a real pfSense ``pkg update`` and installs from (no ``-f``).
+
+    Phase 1 proved a hand-built (inline ``pkg repo``) catalog installs; this proves
+    the REUSABLE Phase-2 generator produces an equivalent, VM-accepted tree — the
+    live half of the build-side premise (the libpkg-on-Linux half is settled in
+    RESULTS/02 by building the same catalog with a Linux ``pkg``; the script + the
+    ``pkg repo`` op are identical regardless of which libpkg runs them).
+
+    Given the package ABSENT and a catalog produced by ``build-repo.sh`` over the
+      branch ``.pkg`` (its ``<ABI>/`` bucket holds meta.conf/packagesite.pkg/data.pkg),
+      enabled via a NONE-signed ``file://`` repo above the pfSense repo,
+    When ``pkg update`` reads it and ``pkg install -y`` runs (NO ``-r``, NO ``-f``),
+    Then ``pkg update`` accepts the script-generated catalog AND the install comes
+      from OUR repo (``pkg query %R`` == ``pfblockerng-devel``) with deps resolved —
+      the build tool's output is real and VM-consumable.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
+
+    # GIVEN: build the catalog with the Phase-2 SCRIPT (not the inline pkg repo), then
+    # point a NONE-signed file:// repo at the produced <ABI>/ dir, above pfSense.
+    abi_dir = build_repo_via_script(repo_vm, [Path(pkg)])
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+    pkg_delete(repo_vm)
+    write_repo_conf(repo_vm, abi_dir, ours_priority=pfsense_prio + 100)
+
+    # WHEN: pkg update must ACCEPT the script-generated catalog (rc=0; a rejected
+    # catalog would fail here — that is the build-side premise under test).
+    pkg_update(repo_vm)
+    assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the script-catalog install"
+
+    # THEN: install resolves from our repo over the script's catalog, deps included.
+    proc = pkg_install_from_repo(repo_vm)
+    combined = proc.stdout + proc.stderr
+    assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve from the script catalog:\n{combined}"
+    origin = pkg_repo_origin(repo_vm)
+    assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -108,6 +109,16 @@ BUILD_REPO_SH = Path(__file__).resolve().parents[2] / "scripts" / "build-repo.sh
 GUEST_BUILD_REPO_SH = f"{GUEST_SPIKE_DIR}/build-repo.sh"
 GUEST_PKG_IN_DIR = f"{GUEST_SPIKE_DIR}/pkg_in"  # the input dir of .pkg for build-repo.sh
 SCRIPT_REPO_ROOT = f"{GUEST_SPIKE_DIR}/script_catalog"  # build-repo.sh --out (per-ABI tree)
+
+# Phase-3a (ADR-17) PURE-PYTHON catalog generator under test. Unlike build-repo.sh
+# (which needs a libpkg ``pkg`` binary), ``build-repo-portable.py`` builds the
+# catalog WITHOUT libpkg — the way the Phase-3b publish job will, on a plain Linux
+# runner with no ``pkg``. Here it is run ON THE RUNNER (this test process's python,
+# no guest involvement) over the branch ``.pkg``; only the produced ``<ABI>/`` tree
+# is shipped to the guest, proving a real pfSense ``pkg update``/``install`` accepts
+# the pure-Python catalog. This is the load-bearing fidelity gate for the generator.
+BUILD_REPO_PORTABLE = Path(__file__).resolve().parents[2] / "scripts" / "build-repo-portable.py"
+PORTABLE_REPO_ROOT = f"{GUEST_SPIKE_DIR}/portable_catalog"  # where the portable <ABI>/ tree is shipped
 
 
 # --------------------------------------------------------------------------- #
@@ -227,6 +238,55 @@ def build_repo_via_script(vm: SmokeVM, pkg_files: list[Path]) -> str:
         present = vm.ssh("/bin/test", "-f", f"{abi_dir}/{fname}")
         assert present.returncode == 0, f"build-repo.sh did not emit {fname} under {abi_dir}"
     return abi_dir
+
+
+def build_repo_via_portable(vm: SmokeVM, pkg_files: list[Path], tmp_path: Path) -> str:
+    """Run ``scripts/build-repo-portable.py`` ON THE RUNNER, then ship its catalog to the guest.
+
+    This is the Phase-3a proof: the catalog is generated in PURE PYTHON on the runner
+    (no libpkg, no guest involvement) exactly as the Phase-3b publish job will, then
+    only the produced ``<out>/<ABI>/`` tree is copied to the guest. A real pfSense
+    ``pkg update``/``install`` then has to accept it — the fidelity gate that the
+    pure-Python catalog is byte-compatible with what real ``pkg repo`` emits.
+
+    Returns the on-guest path of the single ``<ABI>/`` directory (the branch ``.pkg``
+    is one ABI, ``FreeBSD:15:amd64``), which the ``file://`` repo conf points at.
+    """
+    in_dir = tmp_path / "portable_in"
+    out_dir = tmp_path / "portable_out"
+    in_dir.mkdir(parents=True, exist_ok=True)
+    for pkg in pkg_files:
+        # Copy (not symlink) so the generator reads real bytes regardless of cwd.
+        (in_dir / pkg.name).write_bytes(pkg.read_bytes())
+
+    # Run the pure-Python generator with THIS process's interpreter — no `pkg`/libpkg.
+    proc = subprocess.run(
+        [sys.executable, str(BUILD_REPO_PORTABLE), "--in", str(in_dir), "--out", str(out_dir)],
+        capture_output=True,
+        text=True,
+        timeout=180.0,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"build-repo-portable.py failed on the runner: rc={proc.returncode}\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    abi_buckets = sorted(p for p in out_dir.iterdir() if p.is_dir())
+    assert len(abi_buckets) == 1, f"portable generator produced {[p.name for p in abi_buckets]} ABI buckets, expected 1"
+    local_abi_dir = abi_buckets[0]
+    # The catalog triple must be present locally before shipping.
+    for fname in ("meta.conf", "meta", "packagesite.pkg", "data.pkg"):
+        assert (local_abi_dir / fname).is_file(), f"portable generator did not emit {fname} under {local_abi_dir}"
+
+    # Ship the <ABI>/ tree to the guest (fresh dir per run).
+    guest_abi_dir = f"{PORTABLE_REPO_ROOT}/{local_abi_dir.name}"
+    _ssh_check(vm, "/bin/rm", "-rf", PORTABLE_REPO_ROOT)
+    _ssh_check(vm, "/bin/mkdir", "-p", guest_abi_dir)
+    for f in sorted(local_abi_dir.iterdir()):
+        if f.is_file():
+            _scp_to_guest(vm, f, f"{guest_abi_dir}/{f.name}")
+    return guest_abi_dir
 
 
 def _repo_block(name: str, directory: str, priority: int) -> str:
@@ -585,5 +645,53 @@ def test_build_repo_script_catalog_is_accepted(repo_vm: SmokeVM) -> None:
     proc = pkg_install_from_repo(repo_vm)
     combined = proc.stdout + proc.stderr
     assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve from the script catalog:\n{combined}"
+    origin = pkg_repo_origin(repo_vm)
+    assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"
+
+
+@pytest.mark.timeout(600)  # runner-side portable build + ship + pkg update + install > the 30s cap.
+def test_portable_catalog_is_accepted(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """PHASE-3a PURE-PYTHON GENERATOR: the catalog built by ``build-repo-portable.py``
+    ON THE RUNNER (no libpkg) is accepted by a real pfSense ``pkg update`` and installs
+    from (no ``-f``) — the load-bearing fidelity gate.
+
+    Phase 2's ``build-repo.sh`` drives real ``pkg repo`` (libpkg) and STAYS the
+    FreeBSD-VM fallback; this proves the pure-Python catalog the Phase-3b publish job
+    will emit on a plain Linux runner (no ``pkg`` binary) is byte-compatible with what
+    libpkg produces — a real box honors its ``meta.conf``/``packagesite.pkg``/
+    ``data.pkg`` AND its blake2b/z-base-32 ``sum`` (the .pkg integrity check passes).
+
+    Given the package ABSENT and a catalog produced by ``build-repo-portable.py`` over
+      the branch ``.pkg`` — generated ENTIRELY on the runner in pure Python, then its
+      ``<ABI>/`` tree shipped to the guest — enabled via a NONE-signed ``file://`` repo
+      above the pfSense repo,
+    When ``pkg update`` reads the pure-Python catalog and ``pkg install -y`` runs
+      (NO ``-r``, NO ``-f``),
+    Then ``pkg update`` accepts it AND the install comes from OUR repo
+      (``pkg query %R`` == ``pfblockerng-devel``) with deps resolved and the ``.pkg``
+      checksum validated — the pure-Python generator's output is real + VM-consumable.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
+
+    # GIVEN: build the catalog with the PURE-PYTHON generator on the runner (no libpkg),
+    # ship its <ABI>/ tree to the guest, point a NONE-signed file:// repo above pfSense.
+    abi_dir = build_repo_via_portable(repo_vm, [Path(pkg)], tmp_path)
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+    pkg_delete(repo_vm)
+    write_repo_conf(repo_vm, abi_dir, ours_priority=pfsense_prio + 100)
+
+    # WHEN: pkg update must ACCEPT the pure-Python catalog (rc=0; a rejected catalog —
+    # bad meta.conf, malformed packagesite, or a mismatched sum — would fail here).
+    pkg_update(repo_vm)
+    assert pkg_installed_version(repo_vm) is None, (
+        f"{PKG_NAME} unexpectedly present before the portable-catalog install"
+    )
+
+    # THEN: install resolves from our repo over the pure-Python catalog, deps included,
+    # and the .pkg checksum (the catalog `sum`) validates — origin proves it came from ours.
+    proc = pkg_install_from_repo(repo_vm)
+    combined = proc.stdout + proc.stderr
+    assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve from the portable catalog:\n{combined}"
     origin = pkg_repo_origin(repo_vm)
     assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1,0 +1,492 @@
+"""ADR-17 — the release -> repository -> install flow (DISTINCT from the smoke suite).
+
+This is the ADR-01-style cheap falsification of ADR-17's core premise (§1 "Premise
+to falsify", §6 Phase 1, §7 reject criteria): prove on the live ADR-04 pfSense CE
+VM that a box installs pfBlockerNG from a self-hosted, NONE-signed third-party
+`pkg` repository (no `pkg add -f`), the installed files land where the manifest
+says, and cross-repo precedence favours our build over the REAL Netgate repo.
+
+NOT A SMOKE TEST. This flow validates *distribution* (does our repo install + land
+its files + win precedence), a separate concern from the ADR-04 smoke suite that
+validates pfBlockerNG's *runtime behaviour* (DNSBL blocking, etc.). It carries its
+OWN marker `repo` — NOT `smoke` — so `pytest -m smoke` never selects it; it is
+dispatched on its own (`repo-install.yml` -> `-m repo`). It REUSES the smoke
+harness (the `smoke_vm` fixture, `helpers`, the VM boot wiring) but is never
+conflated with the smoke matrix, and deliberately does NOT re-probe runtime
+behaviour (already covered there).
+
+PRECEDENCE MODEL (proven on the VM, correcting ADR §1 Context 3): repository
+PRIORITY dominates version — a higher-priority repo wins even with a LOWER version
+(observed: a repo at priority 200 / version _1 beat ours at priority 99 / version
+_9). So our repo simply needs a `priority:` above any competitor and it wins
+regardless of version. The competitor here is a controlled `file://` `netgate-decoy`
+repo serving the SAME package (a deterministic stand-in: the real Netgate `pfSense`
+repo does NOT offer `-devel` in this hermetic CE image, so it cannot serve as the
+competing provider). The two precedence tests flip ours/decoy priority to pin both
+directions; both are set ABOVE the real `pfSense` repo so it never interferes.
+
+EGRESS IS OPEN for this flow (unlike the hermetic smoke cases): the real Netgate
+repos are LEFT ENABLED and reachable (`pkg update` must not rc=1 on them). The repo
+flow never enters a CaseContext (the only caller of `helpers.block_egress`), and the
+fixture forces egress open (`_ensure_egress_open`) so the flow is immune to any
+residual block. The real `pfSense` repo simply loses on priority.
+
+HOW (throwaway spike — the reusable `scripts/build-repo.sh` generator is Phase 2,
+NOT built here):
+
+  * The branch `.pkg` is built by the harness and handed in via `SMOKE_PKG`
+    (`scripts/build-pkg-portable.py` on a Linux runner — the VM's exact ABI:
+    `FreeBSD:15:amd64` / php83 / py311). We do NOT re-invoke the builder, and do
+    NOT re-version it: priority (not version) is the precedence lever, so the real
+    release `.pkg` is published as-is.
+  * On the guest, the guest's OWN `pkg repo` (libpkg) builds the catalog from that
+    one `.pkg`; served via an on-box `file://` URL — the acceptable hermetic
+    transport (no second HTTP server, a CLAUDE.md constraint). Whether the
+    Pages-style HTTP catalog is accepted is Phase 2/3's concern; the premise (does
+    pfSense honor a NONE-signed third-party repo for install + precedence) is
+    orthogonal to the transport.
+  * A repo conf at `/usr/local/etc/pkg/repos/pfblockerng-devel.conf`
+    (`signature_type: none`, `enabled: yes`, `priority:` above/below the pfSense
+    repo per case), then `pkg update` + `pkg install -y` with NO `-f`.
+
+WHAT IS ASSERTED (transition + branch coverage, via EFFECTIVE state — never an
+exit code alone): the package is ABSENT before; AFTER a from-our-repo install it is
+registered, its repo origin (`pkg query '%R'`) is OURS, RUN_DEPENDS resolved (no
+"Missing dependency"), and EVERY file the package registers (`pkg info -l`) is
+present on-box; and cross-repo precedence picks the HIGHER-priority repo in BOTH
+directions (ours higher ⇒ ours; decoy higher ⇒ the decoy — so "ours wins" is
+provably priority-driven, not an always-ours artefact).
+
+DESELECTED from the default `python -m pytest` (`--ignore=tests/smoke` in
+pyproject.toml — this file lives under `tests/smoke/` only to reuse the fixture
+and helpers). Run only via its own dispatch::
+
+    python -m pytest tests/smoke -m repo --override-ini="addopts="
+
+Needs the booted `smoke_vm` fixture, the branch `.pkg` (`SMOKE_PKG`), and the
+smoke deps; without them it skips cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+
+pytestmark = pytest.mark.repo
+
+PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"
+
+# Our repo conf on the guest + the served catalog root. The conf name follows the
+# CLAUDE.md "match the surrounding pattern" rule: pfSense's own conf is
+# `pfSense.conf` under the SAME dir; ours is the channel-named sibling Phase 4 will
+# write for real (`add-repo.sh`).
+REPO_CONF = "/usr/local/etc/pkg/repos/pfblockerng-devel.conf"
+GUEST_SPIKE_DIR = "/tmp/pfb_repo_spike"
+OURS_REPO_DIR = f"{GUEST_SPIKE_DIR}/ours"
+DECOY_REPO_DIR = f"{GUEST_SPIKE_DIR}/decoy"
+OURS_REPO_NAME = "pfblockerng-devel"  # the %R origin a from-our-repo install reports
+DECOY_REPO_NAME = "netgate-decoy"  # a controlled file:// stand-in for a competing repo
+NETGATE_REPO_NAME = "pfSense"  # the real base-system Netgate repo (left enabled; loses on priority)
+GUEST_FILE_LIST = f"{GUEST_SPIKE_DIR}/installed_files.txt"
+
+
+# --------------------------------------------------------------------------- #
+# Egress — this flow needs the REAL Netgate repo reachable
+# --------------------------------------------------------------------------- #
+
+
+def _ensure_egress_open() -> None:
+    """Force the runner's egress OPEN for this flow (idempotent; best-effort).
+
+    This flow tests cross-repo precedence against the REAL Netgate `pfSense` repo,
+    so it must NOT run under the smoke suite's hermetic egress block. The repo flow
+    never enters a CaseContext (the only caller of `helpers.block_egress`), so
+    egress is open by default — but force it explicitly so the flow is immune to any
+    residual OUTPUT DROP from a prior test sharing the runner. Mirrors
+    `helpers.unblock_egress` but UNCONDITIONAL (no SMOKE_BLOCK_EGRESS gate). On a
+    local dev box without sudo/iptables this is a harmless no-op (`check=False`).
+    """
+    for argv in (
+        ["sudo", "iptables", "-P", "OUTPUT", "ACCEPT"],
+        ["sudo", "iptables", "-F", "OUTPUT"],
+    ):
+        subprocess.run(argv, check=False, timeout=30)
+
+
+# --------------------------------------------------------------------------- #
+# On-guest catalog build + repo conf + pkg ops (over SSH)
+# --------------------------------------------------------------------------- #
+
+
+def _scp_to_guest(vm: SmokeVM, local: Path, remote: str, *, timeout: float = 120.0) -> None:
+    """Copy a local file to the guest via ``scp`` (mirrors install-pkg.sh)."""
+    argv = [
+        "scp",
+        "-i",
+        vm.ssh_key_path,
+        "-P",
+        str(vm.ssh_port),
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "BatchMode=yes",
+        str(local),
+        f"{vm.ssh_target}:{remote}",
+    ]
+    result = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"scp {local} -> {remote} failed: rc={result.returncode} {result.stderr!r}")
+
+
+def _ssh_check(vm: SmokeVM, *remote: str, timeout: float = 180.0) -> subprocess.CompletedProcess[str]:
+    """Run a guest command over SSH and raise (with output) on a non-zero exit."""
+    result = vm.ssh(*remote, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"guest cmd {remote!r} failed: rc={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def build_guest_repo(vm: SmokeVM, repo_dir: str, pkg_files: list[Path]) -> None:
+    """Lay ``pkg_files`` into a fresh ``repo_dir`` on the guest and ``pkg repo`` it.
+
+    Uses the guest's OWN libpkg (``pkg repo``) — the same catalog op Phase 2 will
+    run on Linux — to turn the dir of ``.pkg`` files into a real catalog
+    (``meta.conf`` / ``packagesite.pkg`` / ``data.pkg``). Built with NO signing,
+    so the served catalog is NONE-signed (the trust model under test).
+    """
+    _ssh_check(vm, "/bin/rm", "-rf", repo_dir)
+    _ssh_check(vm, "/bin/mkdir", "-p", repo_dir)
+    for pkg in pkg_files:
+        _scp_to_guest(vm, pkg, f"{repo_dir}/{pkg.name}")
+    # `pkg repo <dir>` with no key argument => an unsigned catalog.
+    _ssh_check(vm, "env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", repo_dir)
+
+
+def _repo_block(name: str, directory: str, priority: int) -> str:
+    """One NONE-signed ``file://`` repo stanza for the pkg repo conf."""
+    return (
+        f"{name}: {{\n"
+        f'  url: "file://{directory}",\n'
+        "  signature_type: none,\n"
+        "  enabled: yes,\n"
+        f"  priority: {priority}\n"
+        "}\n"
+    )
+
+
+def write_repo_conf(
+    vm: SmokeVM,
+    ours_dir: str,
+    *,
+    ours_priority: int,
+    decoy_dir: str | None = None,
+    decoy_priority: int = 0,
+) -> None:
+    """Write our NONE-signed repo conf on the guest (ours, plus an optional decoy).
+
+    Declares OUR repo (`pfblockerng-devel`) and — for the precedence cases — a
+    controlled `file://` `netgate-decoy` repo serving the SAME package, so the
+    priority outcome between two genuine providers is deterministic. The base-system
+    Netgate repos (`pfSense` / `pfSense-core`) are LEFT ENABLED and untouched (this
+    flow runs with egress open so they are reachable); callers set ours/decoy
+    priorities a clear margin ABOVE the pfSense repo (see ``repo_priority``) so the
+    real Netgate repo never wins regardless of what it offers. ``signature_type:
+    none`` (pfSense honors per-repo ``none``; trust = the local ``file://`` path
+    here, HTTPS in production).
+    """
+    conf = _repo_block(OURS_REPO_NAME, ours_dir, ours_priority)
+    if decoy_dir is not None:
+        conf += _repo_block(DECOY_REPO_NAME, decoy_dir, decoy_priority)
+    result = subprocess.run(
+        vm.ssh_argv("tee", REPO_CONF),
+        input=conf,
+        capture_output=True,
+        text=True,
+        timeout=60.0,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"write_repo_conf failed: rc={result.returncode} {result.stderr!r}")
+
+
+def repo_priority(vm: SmokeVM, name: str, *, timeout: float = 60.0) -> int:
+    """The EFFECTIVE ``priority:`` of repo ``name`` (``pkg -vv``); 0 if unset/absent.
+
+    Reads the tool's own merged config (resolves every ``*.conf``), not a single
+    file — the CLAUDE.md "assert effective state" rule. Used to set OUR repo's
+    priority a clear margin ABOVE / BELOW the base pfSense repo, so the precedence
+    outcome is deterministic regardless of what priority Netgate happens to ship.
+    """
+    out = _ssh_check(vm, "pkg", "-vv", timeout=timeout).stdout
+    # Each repo is `  <name>: { ... priority : N, ... }`; match the named block
+    # (non-greedy to its first closing brace) then the priority inside it. The
+    # literal colon means `pfSense:` does not match inside `pfSense-core:`.
+    block = re.search(rf"(?ms)^\s*{re.escape(name)}:\s*\{{(.*?)\}}", out)
+    if not block:
+        return 0
+    pr = re.search(r"priority\s*:\s*(-?\d+)", block.group(1))
+    return int(pr.group(1)) if pr else 0
+
+
+def pkg_update(vm: SmokeVM, *, timeout: float = 240.0) -> None:
+    """``pkg update -f`` so the freshly-written catalog is re-read.
+
+    ``-f`` forces a re-fetch even when the catalog mtime/etag looks unchanged. With
+    egress OPEN, this refreshes ALL enabled repos — our reachable ``file://`` repo
+    AND the real Netgate ``pfSense`` / ``pfSense-core`` repos — and exits ``rc=0``.
+    A clean update of our repo is itself evidence pfSense accepts the unsigned
+    third-party repo.
+    """
+    _ssh_check(vm, "env", "ASSUME_ALWAYS_YES=yes", "pkg", "update", "-f", timeout=timeout)
+
+
+def pkg_installed_version(vm: SmokeVM, *, timeout: float = 60.0) -> str | None:
+    """The installed ``%v`` of the package, or ``None`` if absent (the before/after oracle)."""
+    result = vm.ssh("pkg", "query", "%v", PKG_NAME, timeout=timeout)
+    return result.stdout.strip() if result.returncode == 0 and result.stdout.strip() else None
+
+
+def pkg_repo_origin(vm: SmokeVM, *, timeout: float = 60.0) -> str:
+    """The repo ``%R`` the installed package was fetched from (the precedence oracle)."""
+    return _ssh_check(vm, "pkg", "query", "%R", PKG_NAME, timeout=timeout).stdout.strip()
+
+
+def pkg_install_from_repo(vm: SmokeVM, *, timeout: float = 600.0) -> subprocess.CompletedProcess[str]:
+    """``pkg install -y <name>`` across ALL enabled repos — NO ``-r``, NO ``-f``.
+
+    This is the exact shape ``pkg_install()`` uses (ADR-17 §1 Context 3): resolve
+    the name over every enabled repo and install the winner. The VM proved repo
+    PRIORITY decides the winner (a higher-priority repo wins even at a lower
+    version). Returns the completed process so the caller can read the "Missing
+    dependency" line (deps-resolved evidence) off stderr/stdout.
+    """
+    result = vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "install", "-y", PKG_NAME, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pkg install {PKG_NAME} failed: rc={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def pkg_delete(vm: SmokeVM, *, timeout: float = 300.0) -> None:
+    """Remove the package if present (between cases + final cleanup)."""
+    vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "delete", "-y", PKG_NAME, timeout=timeout)
+
+
+# --------------------------------------------------------------------------- #
+# Files-present check — the install really WROTE the payload (distribution test)
+# --------------------------------------------------------------------------- #
+
+
+def assert_all_pkg_files_present(vm: SmokeVM, *, timeout: float = 120.0) -> int:
+    """Assert EVERY file the installed package registers is present on-box.
+
+    The distribution concern this flow exists for: ``pkg info -l <pkg>`` lists the
+    files pkg recorded from the package manifest at install; we confirm each one
+    actually EXISTS on disk — the repo install really wrote the payload, not merely
+    registered metadata. The path list is parsed here, staged to a guest temp file,
+    and existence-checked in ONE on-box pass. Returns the file count for the log.
+    """
+    listing = _ssh_check(vm, "pkg", "info", "-l", PKG_NAME, timeout=timeout).stdout
+    # `pkg info -l` prints a `<pkg>-<ver>:` header, then indented absolute paths.
+    paths = [ln.strip() for ln in listing.splitlines() if ln.startswith((" ", "\t")) and ln.strip().startswith("/")]
+    assert paths, f"pkg info -l {PKG_NAME} listed no files — nothing was installed"
+
+    staged = subprocess.run(
+        vm.ssh_argv("tee", GUEST_FILE_LIST),
+        input="\n".join(paths) + "\n",
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if staged.returncode != 0:
+        raise RuntimeError(f"staging the installed-file list failed: rc={staged.returncode} {staged.stderr!r}")
+
+    # Pipe the existence-sweep SCRIPT via STDIN to a remote `/bin/sh`. A complex
+    # `/bin/sh -c '<script>'` argument is re-tokenised by ssh's remote login shell
+    # (-> `sh: Syntax error: "do" unexpected`); reading the script from stdin avoids
+    # all quoting. The script reads the staged list with `IFS= read -r` (any path,
+    # verbatim) and prints those that are missing. GUEST_FILE_LIST is a fixed path.
+    script = f'while IFS= read -r f; do [ -e "$f" ] || echo "$f"; done < {GUEST_FILE_LIST}\n'
+    swept = subprocess.run(
+        vm.ssh_argv("/bin/sh"),
+        input=script,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if swept.returncode != 0:
+        raise RuntimeError(
+            f"files-present sweep failed: rc={swept.returncode}\nstdout:\n{swept.stdout}\nstderr:\n{swept.stderr}"
+        )
+    missing = [ln for ln in swept.stdout.splitlines() if ln.strip()]
+    assert not missing, f"{len(missing)} registered file(s) absent on-box (first 10): {missing[:10]}"
+    return len(paths)
+
+
+# --------------------------------------------------------------------------- #
+# Module fixture — deploy NOTHING; the test installs from the repo itself
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def repo_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """The booted VM with our NONE-signed ``file://`` repo staged from the branch ``.pkg``.
+
+    Unlike the smoke modules this does NOT ``deploy()`` (install-pkg.sh / ``pkg
+    add``): the whole point is to install from our REPO. It forces egress OPEN (this
+    flow needs the real Netgate repo reachable — see ``_ensure_egress_open``), stages
+    the branch ``.pkg`` into our repo dir and builds the catalog once, and tears
+    everything down in ``finally`` so the VM is left clean. No re-versioning / decoy:
+    PRIORITY is the precedence lever (the VM proved repo priority dominates version)
+    and the real Netgate ``pfSense`` repo is the competitor.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    if not pkg or not Path(pkg).is_file():
+        pytest.skip("SMOKE_PKG not set / not a file — no built .pkg to publish")
+    assert pkg  # for the type-checker: pytest.skip above is NoReturn
+    src = Path(pkg)
+    _ensure_egress_open()
+    # Build BOTH catalogs from the same branch .pkg: ours and a controlled decoy that
+    # serves the identical package, so the precedence cases compare two genuine
+    # providers and the winner is decided purely by `priority:`.
+    build_guest_repo(smoke_vm, OURS_REPO_DIR, [src])
+    build_guest_repo(smoke_vm, DECOY_REPO_DIR, [src])
+    try:
+        yield smoke_vm
+    finally:
+        pkg_delete(smoke_vm)
+        smoke_vm.ssh("/bin/rm", "-rf", GUEST_SPIKE_DIR, timeout=60.0)
+        smoke_vm.ssh("/bin/rm", "-f", REPO_CONF, timeout=60.0)
+        h.collect_host_diagnostics(smoke_vm)
+
+
+# --------------------------------------------------------------------------- #
+# The kill-gate tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(600)  # pkg update + install + an on-box files-present sweep > the 30s cap.
+def test_install_from_our_repo_lands_all_files(repo_vm: SmokeVM) -> None:
+    """KILL-GATE: a NONE-signed third-party repo install (no ``-f``) resolves deps,
+    reports OUR repo as origin, and LANDS EVERY FILE.
+
+    Our repo is enabled at a priority above the real Netgate ``pfSense`` repo (which
+    is left enabled, egress open), so ``pkg install`` — resolving across all repos
+    with NO ``-r`` — picks ours.
+
+    Given the package ABSENT (``pkg query %v`` fails),
+    When ``pkg install -y pfSense-pkg-pfBlockerNG-devel`` runs (NO ``-r``, NO ``-f``),
+    Then it installs from OUR repo (``pkg query %R`` == ``pfblockerng-devel``), with
+      no "Missing dependency" (RUN_DEPENDS resolved), AND every file the package
+      registers (``pkg info -l``) is present on-box (> 50) — the install really wrote
+      the payload. Runtime behaviour is the smoke suite's job, not re-probed here.
+    """
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+
+    # GIVEN: a clean before-state — package absent; ours enabled ABOVE pfSense.
+    pkg_delete(repo_vm)
+    write_repo_conf(repo_vm, OURS_REPO_DIR, ours_priority=pfsense_prio + 100)
+    pkg_update(repo_vm)
+    assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the repo install"
+
+    # WHEN: install across ALL enabled repos, no -r/-f.
+    proc = pkg_install_from_repo(repo_vm)
+
+    # THEN: installed from our repo; deps resolved; every registered file landed.
+    combined = proc.stdout + proc.stderr
+    assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve from the repos:\n{combined}"
+    origin = pkg_repo_origin(repo_vm)
+    assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"
+    file_count = assert_all_pkg_files_present(repo_vm)
+    assert file_count > 50, f"only {file_count} files registered — implausibly few for pfBlockerNG"
+
+
+@pytest.mark.timeout(600)  # decoy-catalog already built; pkg update + a cross-repo install > the 30s cap.
+def test_precedence_ours_higher_priority_wins(repo_vm: SmokeVM) -> None:
+    """PRECEDENCE (ours wins): with a competing repo serving the SAME package, OUR
+    higher ``priority:`` wins — the production mechanism (our repo outranks Netgate's).
+
+    The VM proved repo PRIORITY decides cross-repo selection (a higher-priority repo
+    wins even at a lower version). Here a controlled ``file://`` ``netgate-decoy``
+    repo serves the identical package as a genuine competitor (the real Netgate repo
+    does not offer ``-devel`` in this hermetic CE image, so a deterministic decoy
+    stands in). Both are set ABOVE the real ``pfSense`` repo so it never interferes.
+
+    Given the package ABSENT and BOTH file:// repos enabled, ours at the HIGHER priority,
+    When ``pkg install -y`` resolves across all enabled repos,
+    Then ours wins (``pkg query %R`` == ``pfblockerng-devel``).
+    """
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+
+    # GIVEN: package absent; ours ABOVE the decoy, both above pfSense.
+    pkg_delete(repo_vm)
+    write_repo_conf(
+        repo_vm,
+        OURS_REPO_DIR,
+        ours_priority=pfsense_prio + 200,
+        decoy_dir=DECOY_REPO_DIR,
+        decoy_priority=pfsense_prio + 100,
+    )
+    pkg_update(repo_vm)
+    assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the precedence install"
+
+    # WHEN
+    pkg_install_from_repo(repo_vm)
+
+    # THEN: ours wins on the higher priority.
+    origin = pkg_repo_origin(repo_vm)
+    assert origin == OURS_REPO_NAME, (
+        f"installed from {origin!r}, expected ours {OURS_REPO_NAME!r} "
+        f"(ours {pfsense_prio + 200} > decoy {pfsense_prio + 100})"
+    )
+
+
+@pytest.mark.timeout(600)  # decoy-catalog already built; pkg update + a cross-repo install > the 30s cap.
+def test_precedence_decoy_higher_priority_wins(repo_vm: SmokeVM) -> None:
+    """PRECEDENCE counter-case: when the COMPETING repo outranks ours, IT wins —
+    proving "ours wins" above is priority-driven (not always-ours), and that a
+    higher-priority competitor (e.g. Netgate, if it outranked us) would shadow our
+    build. The lever to prevent that is keeping our ``priority:`` highest.
+
+    Given the package ABSENT and BOTH file:// repos enabled, the DECOY at the HIGHER priority,
+    When ``pkg install -y`` resolves across all enabled repos,
+    Then the DECOY wins (``pkg query %R`` == ``netgate-decoy``), not ours.
+    """
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+
+    # GIVEN: package absent; the decoy ABOVE ours, both above pfSense.
+    pkg_delete(repo_vm)
+    write_repo_conf(
+        repo_vm,
+        OURS_REPO_DIR,
+        ours_priority=pfsense_prio + 100,
+        decoy_dir=DECOY_REPO_DIR,
+        decoy_priority=pfsense_prio + 200,
+    )
+    pkg_update(repo_vm)
+    assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the precedence install"
+
+    # WHEN
+    pkg_install_from_repo(repo_vm)
+
+    # THEN: the decoy wins on the higher priority — precedence is priority-driven.
+    origin = pkg_repo_origin(repo_vm)
+    assert origin == DECOY_REPO_NAME, (
+        f"installed from {origin!r}, expected the decoy {DECOY_REPO_NAME!r} "
+        f"(decoy {pfsense_prio + 200} > ours {pfsense_prio + 100})"
+    )

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -135,25 +135,25 @@ PORTABLE_REPO_ROOT = f"{GUEST_SPIKE_DIR}/portable_catalog"  # where the portable
 # user-facing script: it writes the production repo conf, runs ``pkg update``, and
 # verifies the package is visible from OUR repo. Here it is staged to the guest and
 # driven against the LOCAL file:// catalog via its existing ``--base-url`` override
-# (hermetic; the brait.dev default + a live add-repo.sh run are a post-deploy note),
+# (hermetic; the github.io default + a live add-repo.sh run are a post-deploy note),
 # proving the SHIPPED bootstrap — not just a hand-written conf — installs our build.
 ADD_REPO_SH = Path(__file__).resolve().parents[2] / "scripts" / "add-repo.sh"
 GUEST_ADD_REPO_SH = f"{GUEST_SPIKE_DIR}/add-repo.sh"
 
 # Phase-3b (ADR-17) LIVE GitHub-Pages-URL end-to-end check. The publish pipeline
-# deploys the catalog to a Pages site served at the CUSTOM DOMAIN brait.dev (gh api
-# repos/.../pages -> html_url http://brait.dev/pfBlockerNG/); we serve over HTTPS.
+# deploys the catalog to the repo's standard project Pages URL (gh api
+# repos/.../pages -> html_url https://andrebrait.github.io/pfBlockerNG/); we serve over HTTPS.
 # This dispatch-only test proves a REAL pfSense box `pkg update`/`pkg install`
 # against the LIVE https URL (not file://) — the maintainer's real-URL check. It is
 # GATED on SMOKE_REPO_LIVE_URL: unset -> SKIP (the file:// VM-acceptance above is the
 # always-on proof; the live URL only exists once the deploy has run).
 LIVE_BASE_URL_ENV = "SMOKE_REPO_LIVE_URL"
-DEFAULT_LIVE_BASE_URL = "https://brait.dev/pfBlockerNG"
+DEFAULT_LIVE_BASE_URL = "https://andrebrait.github.io/pfBlockerNG"
 GUEST_ABI = "FreeBSD:15:amd64"  # the single supported ABI (CE 2.8 + Plus 25.03)
 # GitHub Pages' anycast IPs. The smoke harness sandboxes guest DNS to a mock that
-# only answers `uuid-*.com`, so `brait.dev` does not resolve on the guest. Pinning
+# only answers `uuid-*.com`, so `andrebrait.github.io` does not resolve on the guest. Pinning
 # the Pages IPs in the guest /etc/hosts lets `pkg`'s HTTPS fetch reach Pages by name
-# (TLS SNI still presents `brait.dev`, so the custom-domain cert validates) without
+# (TLS SNI still presents `andrebrait.github.io`, validated by GitHub's *.github.io cert) without
 # touching the resolver. Egress is OPEN for this flow (_ensure_egress_open).
 PAGES_IPS = ("185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153")
 
@@ -331,7 +331,7 @@ def run_add_repo_sh(vm: SmokeVM, base_url: str, *, timeout: float = 300.0) -> su
 
     Drives the real client bootstrap on the box: it writes the production conf to
     ``/usr/local/etc/pkg/repos/pfblockerng-devel.conf`` (here pointed at a local
-    ``file://`` catalog via the script's own ``--base-url`` override — the brait.dev
+    ``file://`` catalog via the script's own ``--base-url`` override — the github.io
     default and a live HTTPS add-repo.sh run are a post-deploy note), runs ``pkg
     update``, and VERIFIES the package is visible from OUR repo. A non-zero exit (its
     verify step failing) raises with the captured output. ``base_url`` points at the
@@ -901,7 +901,7 @@ def test_shipped_add_repo_sh_bootstrap_installs(repo_vm: SmokeVM) -> None:
     then installs OUR build (no ``-f``) — the real client path, not a hand-written conf.
 
     add-repo.sh is run hermetically against a LOCAL ``file://`` catalog via its own
-    ``--base-url`` override; the brait.dev default + a live HTTPS add-repo.sh run are
+    ``--base-url`` override; the github.io default + a live HTTPS add-repo.sh run are
     the post-deploy/Phase-6 note. The catalog is laid out by ``build-repo.sh`` under
     ``<root>/<ABI>/`` so add-repo.sh's literal ``${ABI}`` url resolves to it. The
     script ships priority 100, above the Netgate ``pfSense`` repo (0), so cross-repo
@@ -1000,7 +1000,7 @@ def _live_base_url() -> str | None:
     """The live Pages base to test against, or None to SKIP.
 
     Gated on ``SMOKE_REPO_LIVE_URL``: set it to the deployed base (e.g.
-    ``https://brait.dev/pfBlockerNG``) to run the live check after a publish
+    ``https://andrebrait.github.io/pfBlockerNG``) to run the live check after a publish
     dispatch; leave it unset and the test SKIPS (the always-on proof is the
     file:// VM-acceptance above). A bare ``1``/``true`` selects the default base.
     """
@@ -1041,9 +1041,9 @@ def pin_pages_hosts(vm: SmokeVM, host: str, *, timeout: float = 60.0) -> None:
     """Pin GitHub Pages' anycast IPs for ``host`` in the guest ``/etc/hosts``.
 
     The smoke harness sandboxes guest DNS to a mock answering only ``uuid-*.com``,
-    so the custom domain does not resolve on the box. A static ``/etc/hosts`` entry
+    so the Pages host does not resolve on the box. A static ``/etc/hosts`` entry
     routes ``pkg``'s HTTPS fetch to Pages by IP while TLS SNI still presents ``host``
-    (the custom-domain cert validates). Idempotent: the entry is removed first.
+    (GitHub's *.github.io cert validates). Idempotent: the entry is removed first.
     """
     # Remove any prior pin for this exact host, then append the fresh one. The line
     # is `<ip> <host>` (the first listed Pages IP suffices; pkg follows the cert).
@@ -1099,7 +1099,7 @@ def write_live_repo_conf(vm: SmokeVM, base_url: str, *, priority: int, timeout: 
 @pytest.mark.timeout(900)  # live deploy/DNS/cert can lag + pkg update + install over the public URL.
 def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     """PHASE-3b LIVE URL: a real pfSense box installs from the DEPLOYED Pages catalog
-    over its public HTTPS ``https://brait.dev/pfBlockerNG/${ABI}`` URL (no ``-f``).
+    over its public HTTPS ``https://andrebrait.github.io/pfBlockerNG/${ABI}`` URL (no ``-f``).
 
     DISPATCH-ONLY + GATED on ``SMOKE_REPO_LIVE_URL`` (unset -> SKIP). The always-on
     proof is the file:// VM-acceptance above; this exercises the REAL transport the

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1045,13 +1045,15 @@ def pin_pages_hosts(vm: SmokeVM, host: str, *, timeout: float = 60.0) -> None:
     routes ``pkg``'s HTTPS fetch to Pages by IP while TLS SNI still presents ``host``
     (GitHub's *.github.io cert validates). Idempotent: the entry is removed first.
     """
-    # Remove any prior pin for this exact host, then append the fresh one. The line
-    # is `<ip> <host>` (the first listed Pages IP suffices; pkg follows the cert).
-    strip = f"grep -v '[[:space:]]{re.escape(host)}$' /etc/hosts > /etc/hosts.pfb 2>/dev/null"
+    # Drop any prior line carrying this host as a whitespace-separated field (not
+    # just a line-ending match, so stale aliases/comments don't survive), then pin
+    # ALL the Pages IPs (resilient to a single-IP failure; pkg follows the cert).
+    # Atomic via a tmp file + mv.
+    strip = f"grep -Ev '[[:space:]]{re.escape(host)}([[:space:]]|$)' /etc/hosts > /etc/hosts.pfb 2>/dev/null"
     script = (
         f"{strip} || cp /etc/hosts /etc/hosts.pfb; "
-        f"printf '%s %s\\n' '{PAGES_IPS[0]}' '{host}' >> /etc/hosts.pfb; "
-        f"mv /etc/hosts.pfb /etc/hosts"
+        + "".join(f"printf '%s %s\\n' '{ip}' '{host}' >> /etc/hosts.pfb; " for ip in PAGES_IPS)
+        + "mv /etc/hosts.pfb /etc/hosts"
     )
     result = subprocess.run(
         vm.ssh_argv("/bin/sh", "-c", script),

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -69,10 +69,14 @@ smoke deps; without them it skips cleanly.
 
 from __future__ import annotations
 
+import io
+import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tarfile
 import time
 import urllib.error
 import urllib.parse
@@ -97,6 +101,9 @@ REPO_CONF = "/usr/local/etc/pkg/repos/pfblockerng-devel.conf"
 GUEST_SPIKE_DIR = "/tmp/pfb_repo_spike"
 OURS_REPO_DIR = f"{GUEST_SPIKE_DIR}/ours"
 DECOY_REPO_DIR = f"{GUEST_SPIKE_DIR}/decoy"
+# The upgrade test rebuilds ONE repo dir in place (lower build -> higher build) so a
+# `pkg upgrade` moves the box across versions WITHIN our repo (not across repos).
+UPGRADE_REPO_DIR = f"{GUEST_SPIKE_DIR}/upgrade"
 OURS_REPO_NAME = "pfblockerng-devel"  # the %R origin a from-our-repo install reports
 DECOY_REPO_NAME = "netgate-decoy"  # a controlled file:// stand-in for a competing repo
 NETGATE_REPO_NAME = "pfSense"  # the real base-system Netgate repo (left enabled; loses on priority)
@@ -123,6 +130,15 @@ SCRIPT_REPO_ROOT = f"{GUEST_SPIKE_DIR}/script_catalog"  # build-repo.sh --out (p
 # the pure-Python catalog. This is the load-bearing fidelity gate for the generator.
 BUILD_REPO_PORTABLE = Path(__file__).resolve().parents[2] / "scripts" / "build-repo-portable.py"
 PORTABLE_REPO_ROOT = f"{GUEST_SPIKE_DIR}/portable_catalog"  # where the portable <ABI>/ tree is shipped
+
+# Phase-4 (ADR-17) SHIPPED client bootstrap under test. ``add-repo.sh`` is the real
+# user-facing script: it writes the production repo conf, runs ``pkg update``, and
+# verifies the package is visible from OUR repo. Here it is staged to the guest and
+# driven against the LOCAL file:// catalog via its existing ``--base-url`` override
+# (hermetic; the brait.dev default + a live add-repo.sh run are a post-deploy note),
+# proving the SHIPPED bootstrap — not just a hand-written conf — installs our build.
+ADD_REPO_SH = Path(__file__).resolve().parents[2] / "scripts" / "add-repo.sh"
+GUEST_ADD_REPO_SH = f"{GUEST_SPIKE_DIR}/add-repo.sh"
 
 # Phase-3b (ADR-17) LIVE GitHub-Pages-URL end-to-end check. The publish pipeline
 # deploys the catalog to a Pages site served at the CUSTOM DOMAIN brait.dev (gh api
@@ -310,6 +326,120 @@ def build_repo_via_portable(vm: SmokeVM, pkg_files: list[Path], tmp_path: Path) 
     return guest_abi_dir
 
 
+def run_add_repo_sh(vm: SmokeVM, base_url: str, *, timeout: float = 300.0) -> subprocess.CompletedProcess[str]:
+    """Stage the SHIPPED ``scripts/add-repo.sh`` and run it (devel) against ``base_url``.
+
+    Drives the real client bootstrap on the box: it writes the production conf to
+    ``/usr/local/etc/pkg/repos/pfblockerng-devel.conf`` (here pointed at a local
+    ``file://`` catalog via the script's own ``--base-url`` override — the brait.dev
+    default and a live HTTPS add-repo.sh run are a post-deploy note), runs ``pkg
+    update``, and VERIFIES the package is visible from OUR repo. A non-zero exit (its
+    verify step failing) raises with the captured output. ``base_url`` points at the
+    catalog ROOT; add-repo.sh appends the literal ``${ABI}`` (pkg expands it to the
+    box's ABI), so the catalog MUST live under ``<base_url>/<ABI>/``.
+    """
+    _ssh_check(vm, "/bin/mkdir", "-p", GUEST_SPIKE_DIR)
+    _scp_to_guest(vm, ADD_REPO_SH, GUEST_ADD_REPO_SH)
+    result = vm.ssh("/bin/sh", GUEST_ADD_REPO_SH, "--base-url", base_url, "devel", timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"add-repo.sh --base-url {base_url} failed: rc={result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# .pkg re-versioning — forge a LOWER + a HIGHER build for the upgrade transition
+# --------------------------------------------------------------------------- #
+
+# The manifest members of a libpkg ``.pkg`` (a zstd-compressed tar; these two come
+# FIRST, then the payload at absolute paths — see scripts/build-pkg-portable.py).
+# Both carry the package ``version``; pkg reads ``+COMPACT_MANIFEST`` for the
+# catalog and ``+MANIFEST`` on install, so BOTH must be re-versioned in lockstep.
+_PKG_MANIFEST_MEMBERS = ("+COMPACT_MANIFEST", "+MANIFEST")
+
+
+def _zstd_decompress(data: bytes) -> bytes:
+    """zstd-decode the ``.pkg`` framing (the ``zstd`` binary; runner host-tool)."""
+    zstd = shutil.which("zstd")
+    if not zstd:
+        raise RuntimeError("re-versioning a .pkg needs the `zstd` binary on the runner (apt-get install -y zstd)")
+    return subprocess.run([zstd, "-dc"], input=data, stdout=subprocess.PIPE, check=True).stdout
+
+
+def _zstd_compress(data: bytes) -> bytes:
+    """zstd-encode back to the ``tzst`` framing pkg(8) expects (``packing_format = tzst``)."""
+    zstd = shutil.which("zstd")
+    if not zstd:
+        raise RuntimeError("re-versioning a .pkg needs the `zstd` binary on the runner (apt-get install -y zstd)")
+    return subprocess.run([zstd, "-q", "-19", "-c"], input=data, stdout=subprocess.PIPE, check=True).stdout
+
+
+def read_compact_version(src_pkg: Path) -> str:
+    """The ``version`` recorded in a ``.pkg``'s ``+COMPACT_MANIFEST`` (the base to re-version from)."""
+    tar_bytes = _zstd_decompress(src_pkg.read_bytes())
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+        member = tf.extractfile("+COMPACT_MANIFEST")
+        if member is None:
+            raise RuntimeError(f"{src_pkg.name}: no +COMPACT_MANIFEST member — not a libpkg .pkg?")
+        obj = json.loads(member.read())
+    version = obj.get("version")
+    if not isinstance(version, str) or not version:
+        raise RuntimeError(f"{src_pkg.name}: +COMPACT_MANIFEST has no version string (got {version!r})")
+    return version
+
+
+def reversion_pkg(src_pkg: Path, new_version: str, out_dir: Path) -> Path:
+    """Re-version a built ``.pkg`` to ``new_version``, payload untouched.
+
+    A libpkg ``.pkg`` is a zstd-compressed tar with ``+COMPACT_MANIFEST`` +
+    ``+MANIFEST`` first (UCL/JSON), then the payload files at absolute paths. This
+    edits ONLY the ``version`` field in BOTH manifests (the catalog reads compact,
+    install reads full — they must agree) and repacks: every other manifest field
+    and every payload member is copied through verbatim, manifests kept first, and
+    the archive recompressed as ``tzst`` (the ``packing_format`` meta.conf declares).
+    So the forged builds differ from the real branch ``.pkg`` in NOTHING but the
+    version string — letting a single image prove a real ``pkg upgrade`` moves the
+    box from a LOWER (``<V>_1``) to a HIGHER (``<V>_9``) build of OUR repo.
+
+    Returns the path of the written ``<name>-<new_version>.pkg`` under ``out_dir``.
+    """
+    tar_bytes = _zstd_decompress(src_pkg.read_bytes())
+    repacked = io.BytesIO()
+    pkg_name = ""
+    with (
+        tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tin,
+        tarfile.open(fileobj=repacked, mode="w", format=tarfile.USTAR_FORMAT) as tout,
+    ):
+        for member in tin.getmembers():
+            extracted = tin.extractfile(member) if member.isfile() else None
+            data = extracted.read() if extracted is not None else b""
+            if member.name in _PKG_MANIFEST_MEMBERS:
+                obj = json.loads(data)
+                obj["version"] = new_version
+                pkg_name = obj.get("name", pkg_name)
+                data = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode() + b"\n"
+                # A fresh TarInfo so the re-sized manifest writes cleanly (root:wheel,
+                # 0644, deterministic mtime — same framing build-pkg-portable.py uses).
+                ti = tarfile.TarInfo(name=member.name)
+                ti.size = len(data)
+                ti.mode = 0o644
+                ti.uid = ti.gid = 0
+                ti.uname, ti.gname = "root", "wheel"
+                ti.mtime = 0
+                ti.type = tarfile.REGTYPE
+                tout.addfile(ti, io.BytesIO(data))
+            else:
+                tout.addfile(member, io.BytesIO(data) if member.isfile() else None)
+    if not pkg_name:
+        raise RuntimeError(f"{src_pkg.name}: no +COMPACT_MANIFEST/+MANIFEST with a name — not a libpkg .pkg?")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{pkg_name}-{new_version}.pkg"
+    out_path.write_bytes(_zstd_compress(repacked.getvalue()))
+    return out_path
+
+
 def _repo_block(name: str, directory: str, priority: int) -> str:
     """One NONE-signed ``file://`` repo stanza for the pkg repo conf."""
     return (
@@ -412,6 +542,23 @@ def pkg_install_from_repo(vm: SmokeVM, *, timeout: float = 600.0) -> subprocess.
     if result.returncode != 0:
         raise RuntimeError(
             f"pkg install {PKG_NAME} failed: rc={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def pkg_upgrade(vm: SmokeVM, *, timeout: float = 600.0) -> subprocess.CompletedProcess[str]:
+    """``pkg upgrade -y <name>`` across ALL enabled repos — NO ``-f``.
+
+    The exact in-repo update path a published newer build takes: with the catalog
+    re-read (``pkg update -f``), ``pkg upgrade`` moves the installed package to the
+    higher available build (priority decides which repo provides it — ours wins by
+    ``priority:``). NO ``-f`` (a forced reinstall would mask a real version move).
+    Returns the completed process so the caller can read "Missing dependency" off it.
+    """
+    result = vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "upgrade", "-y", PKG_NAME, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pkg upgrade {PKG_NAME} failed: rc={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
     return result
 
@@ -552,6 +699,83 @@ def test_install_from_our_repo_lands_all_files(repo_vm: SmokeVM) -> None:
     assert file_count > 50, f"only {file_count} files registered — implausibly few for pfBlockerNG"
 
 
+@pytest.mark.timeout(600)  # forge 2 builds + install + a real `pkg upgrade` transition > the 30s cap.
+def test_pkg_upgrade_moves_to_our_newer_build(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """UPGRADE TRANSITION: ``pkg upgrade`` moves the box from a LOWER to a HIGHER
+    build served by OUR repo — the in-repo update path a published newer build takes.
+
+    Re-versions the branch ``.pkg`` (priority-untouched, payload-untouched) into a
+    LOWER (``<V>_1``) and a HIGHER (``<V>_9``) build of the SAME package. The repo
+    holds only the LOWER build first (install lands ``<V>_1`` from ours); then the
+    SAME repo dir is rebuilt with the HIGHER build and a ``pkg upgrade`` must carry
+    the box to ``<V>_9``, still from ours. This is the single-image proof of the
+    update path; a true OS-MAJOR jump is not reachable on one image and degrades to
+    the documented CLI ``pkg upgrade`` (ADR §7).
+
+    Scenario: a newer build published to our repo upgrades an installed box.
+      Background: our NONE-signed file:// repo above the Netgate `pfSense` repo.
+
+    Given the package ABSENT, and our repo carries ONLY the LOWER build ``<V>_1``,
+      When ``pkg install -y`` runs (NO -r, NO -f),
+      Then the box is at ``<V>_1`` from OUR repo (``%v`` == ``<V>_1``, ``%R`` ==
+        ``pfblockerng-devel``) — the asserted BEFORE state.
+    When our repo is REBUILT in place with the HIGHER build ``<V>_9``, ``pkg update
+      -f`` re-reads the catalog, and ``pkg upgrade -y`` runs,
+      Then the box MOVES to ``<V>_9`` from OUR repo (``%v`` == ``<V>_9``, ``%R`` ==
+        ``pfblockerng-devel``) — a real before != after transition, not a final-state
+        snapshot. (Runtime behaviour is the smoke suite's job, not re-probed here.)
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
+    base_version = read_compact_version(Path(pkg))
+    low_version = f"{base_version}_1"
+    high_version = f"{base_version}_9"
+    assert low_version != high_version  # forged builds must differ for the transition to be real
+
+    # Forge the two builds on the runner (only the version field changes).
+    low_pkg = reversion_pkg(Path(pkg), low_version, tmp_path / "low")
+    high_pkg = reversion_pkg(Path(pkg), high_version, tmp_path / "high")
+
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+    try:
+        # GIVEN: a clean before-state — package absent; our repo carries ONLY the
+        # LOWER build, enabled ABOVE the Netgate `pfSense` repo.
+        pkg_delete(repo_vm)
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [low_pkg])
+        write_repo_conf(repo_vm, UPGRADE_REPO_DIR, ours_priority=pfsense_prio + 100)
+        pkg_update(repo_vm)
+        assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the upgrade test"
+
+        # WHEN (1): install the lower build across all enabled repos (no -r/-f).
+        pkg_install_from_repo(repo_vm)
+
+        # THEN (before-state): the box is at the LOWER version, from OUR repo.
+        assert pkg_installed_version(repo_vm) == low_version, (
+            f"expected {low_version!r} installed first, got {pkg_installed_version(repo_vm)!r}"
+        )
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, (
+            f"lower build came from {pkg_repo_origin(repo_vm)!r}, expected our repo {OURS_REPO_NAME!r}"
+        )
+
+        # WHEN (2): publish the HIGHER build into the SAME repo dir, re-read it, upgrade.
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [high_pkg])
+        pkg_update(repo_vm)
+        proc = pkg_upgrade(repo_vm)
+
+        # THEN (after-state): the box MOVED to the HIGHER version, still from OUR repo.
+        combined = proc.stdout + proc.stderr
+        assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve on upgrade:\n{combined}"
+        assert pkg_installed_version(repo_vm) == high_version, (
+            f"pkg upgrade did not move {low_version!r} -> {high_version!r}; now at {pkg_installed_version(repo_vm)!r}"
+        )
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, (
+            f"upgraded build came from {pkg_repo_origin(repo_vm)!r}, expected our repo {OURS_REPO_NAME!r}"
+        )
+    finally:
+        pkg_delete(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)
+
+
 @pytest.mark.timeout(600)  # decoy-catalog already built; pkg update + a cross-repo install > the 30s cap.
 def test_precedence_ours_higher_priority_wins(repo_vm: SmokeVM) -> None:
     """PRECEDENCE (ours wins): with a competing repo serving the SAME package, OUR
@@ -666,6 +890,55 @@ def test_build_repo_script_catalog_is_accepted(repo_vm: SmokeVM) -> None:
     proc = pkg_install_from_repo(repo_vm)
     combined = proc.stdout + proc.stderr
     assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve from the script catalog:\n{combined}"
+    origin = pkg_repo_origin(repo_vm)
+    assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"
+
+
+@pytest.mark.timeout(600)  # build catalog + run the shipped bootstrap + install > the 30s cap.
+def test_shipped_add_repo_sh_bootstrap_installs(repo_vm: SmokeVM) -> None:
+    """PHASE-4 SHIPPED BOOTSTRAP: the user-facing ``scripts/add-repo.sh`` writes the
+    production conf, ``pkg update``s, verifies our package is visible, and the box
+    then installs OUR build (no ``-f``) — the real client path, not a hand-written conf.
+
+    add-repo.sh is run hermetically against a LOCAL ``file://`` catalog via its own
+    ``--base-url`` override; the brait.dev default + a live HTTPS add-repo.sh run are
+    the post-deploy/Phase-6 note. The catalog is laid out by ``build-repo.sh`` under
+    ``<root>/<ABI>/`` so add-repo.sh's literal ``${ABI}`` url resolves to it. The
+    script ships priority 100, above the Netgate ``pfSense`` repo (0), so cross-repo
+    install picks ours — exactly the production mechanism.
+
+    Given the package ABSENT and a ``build-repo.sh`` catalog under ``<root>/<ABI>/``,
+    When ``add-repo.sh --base-url file://<root> devel`` runs (writes the conf, ``pkg
+      update``, verifies) and then ``pkg install -y`` runs (NO -r, NO -f),
+    Then add-repo.sh exits 0 (its own verify found the package in our repo), it wrote
+      the production conf to ``pfblockerng-devel.conf``, and the install comes from
+      OUR repo (``pkg query %R`` == ``pfblockerng-devel``) with deps resolved.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
+
+    # GIVEN: a catalog under <SCRIPT_REPO_ROOT>/<ABI>/ (build-repo.sh lays it out so),
+    # package absent. The dir add-repo.sh's ${ABI} url will resolve to.
+    abi_dir = build_repo_via_script(repo_vm, [Path(pkg)])
+    assert abi_dir.startswith(f"{SCRIPT_REPO_ROOT}/"), f"unexpected catalog dir {abi_dir!r}"
+    pkg_delete(repo_vm)
+
+    # WHEN: run the SHIPPED bootstrap against the local catalog root. Its verify step
+    # must pass (it raises here otherwise) — proving the shipped conf loads our catalog.
+    proc = run_add_repo_sh(repo_vm, f"file://{SCRIPT_REPO_ROOT}")
+
+    # THEN: add-repo.sh wrote the production conf and its verify confirmed our package.
+    assert "available from 'pfblockerng-devel'" in proc.stdout, (
+        f"add-repo.sh did not report the package from our repo:\n{proc.stdout}"
+    )
+    conf_present = repo_vm.ssh("/bin/test", "-f", REPO_CONF)
+    assert conf_present.returncode == 0, f"add-repo.sh did not write {REPO_CONF}"
+    assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the bootstrap install"
+
+    # The shipped conf is now in place; install across all enabled repos (no -r/-f).
+    install = pkg_install_from_repo(repo_vm)
+    combined = install.stdout + install.stderr
+    assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve via the shipped bootstrap:\n{combined}"
     origin = pkg_repo_origin(repo_vm)
     assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"
 

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -73,6 +73,10 @@ import os
 import re
 import subprocess
 import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -119,6 +123,23 @@ SCRIPT_REPO_ROOT = f"{GUEST_SPIKE_DIR}/script_catalog"  # build-repo.sh --out (p
 # the pure-Python catalog. This is the load-bearing fidelity gate for the generator.
 BUILD_REPO_PORTABLE = Path(__file__).resolve().parents[2] / "scripts" / "build-repo-portable.py"
 PORTABLE_REPO_ROOT = f"{GUEST_SPIKE_DIR}/portable_catalog"  # where the portable <ABI>/ tree is shipped
+
+# Phase-3b (ADR-17) LIVE GitHub-Pages-URL end-to-end check. The publish pipeline
+# deploys the catalog to a Pages site served at the CUSTOM DOMAIN brait.dev (gh api
+# repos/.../pages -> html_url http://brait.dev/pfBlockerNG/); we serve over HTTPS.
+# This dispatch-only test proves a REAL pfSense box `pkg update`/`pkg install`
+# against the LIVE https URL (not file://) — the maintainer's real-URL check. It is
+# GATED on SMOKE_REPO_LIVE_URL: unset -> SKIP (the file:// VM-acceptance above is the
+# always-on proof; the live URL only exists once the deploy has run).
+LIVE_BASE_URL_ENV = "SMOKE_REPO_LIVE_URL"
+DEFAULT_LIVE_BASE_URL = "https://brait.dev/pfBlockerNG"
+GUEST_ABI = "FreeBSD:15:amd64"  # the single supported ABI (CE 2.8 + Plus 25.03)
+# GitHub Pages' anycast IPs. The smoke harness sandboxes guest DNS to a mock that
+# only answers `uuid-*.com`, so `brait.dev` does not resolve on the guest. Pinning
+# the Pages IPs in the guest /etc/hosts lets `pkg`'s HTTPS fetch reach Pages by name
+# (TLS SNI still presents `brait.dev`, so the custom-domain cert validates) without
+# touching the resolver. Egress is OPEN for this flow (_ensure_egress_open).
+PAGES_IPS = ("185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153")
 
 
 # --------------------------------------------------------------------------- #
@@ -693,5 +714,161 @@ def test_portable_catalog_is_accepted(repo_vm: SmokeVM, tmp_path: Path) -> None:
     proc = pkg_install_from_repo(repo_vm)
     combined = proc.stdout + proc.stderr
     assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve from the portable catalog:\n{combined}"
+    origin = pkg_repo_origin(repo_vm)
+    assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Phase-3b — the LIVE GitHub-Pages-URL end-to-end (dispatch-only; gated)
+# --------------------------------------------------------------------------- #
+
+
+def _live_base_url() -> str | None:
+    """The live Pages base to test against, or None to SKIP.
+
+    Gated on ``SMOKE_REPO_LIVE_URL``: set it to the deployed base (e.g.
+    ``https://brait.dev/pfBlockerNG``) to run the live check after a publish
+    dispatch; leave it unset and the test SKIPS (the always-on proof is the
+    file:// VM-acceptance above). A bare ``1``/``true`` selects the default base.
+    """
+    val = os.environ.get(LIVE_BASE_URL_ENV)
+    if not val:
+        return None
+    if val.strip().lower() in {"1", "true", "yes", "on"}:
+        return DEFAULT_LIVE_BASE_URL
+    return val.rstrip("/")
+
+
+def poll_catalog_served(base_url: str, abi: str, *, attempts: int = 30, delay: float = 10.0) -> None:
+    """Poll the live ``<base>/<ABI>/meta.conf`` until it serves (first deploy + DNS/cert lag).
+
+    The catalog files a client ``pkg update`` consumes are ``meta.conf`` +
+    ``packagesite.pkg``; a 200 on both is the runner-side BACKSTOP that the deploy
+    actually published a usable tree, independent of the guest. Raises with the last
+    error if the URL never serves within the budget.
+    """
+    last_err = ""
+    for _ in range(attempts):
+        try:
+            for fname in ("meta.conf", "packagesite.pkg"):
+                url = f"{base_url}/{abi}/{fname}"
+                with urllib.request.urlopen(url, timeout=15) as resp:  # noqa: S310 (fixed https Pages URL)
+                    if resp.status != 200:
+                        raise RuntimeError(f"{url} -> HTTP {resp.status}")
+                    if not resp.read(1):
+                        raise RuntimeError(f"{url} served an empty body")
+            return
+        except (urllib.error.URLError, RuntimeError, TimeoutError) as exc:
+            last_err = f"{type(exc).__name__}: {exc}"
+            time.sleep(delay)
+    raise AssertionError(f"live catalog never served {base_url}/{abi}/ within budget; last error: {last_err}")
+
+
+def pin_pages_hosts(vm: SmokeVM, host: str, *, timeout: float = 60.0) -> None:
+    """Pin GitHub Pages' anycast IPs for ``host`` in the guest ``/etc/hosts``.
+
+    The smoke harness sandboxes guest DNS to a mock answering only ``uuid-*.com``,
+    so the custom domain does not resolve on the box. A static ``/etc/hosts`` entry
+    routes ``pkg``'s HTTPS fetch to Pages by IP while TLS SNI still presents ``host``
+    (the custom-domain cert validates). Idempotent: the entry is removed first.
+    """
+    # Remove any prior pin for this exact host, then append the fresh one. The line
+    # is `<ip> <host>` (the first listed Pages IP suffices; pkg follows the cert).
+    strip = f"grep -v '[[:space:]]{re.escape(host)}$' /etc/hosts > /etc/hosts.pfb 2>/dev/null"
+    script = (
+        f"{strip} || cp /etc/hosts /etc/hosts.pfb; "
+        f"printf '%s %s\\n' '{PAGES_IPS[0]}' '{host}' >> /etc/hosts.pfb; "
+        f"mv /etc/hosts.pfb /etc/hosts"
+    )
+    result = subprocess.run(
+        vm.ssh_argv("/bin/sh", "-c", script),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"pin_pages_hosts failed: rc={result.returncode} {result.stderr!r}")
+
+
+def write_live_repo_conf(vm: SmokeVM, base_url: str, *, priority: int, timeout: float = 60.0) -> None:
+    """Write OUR production conf pointing at the LIVE ``<base>/${ABI}`` Pages URL.
+
+    Built from the SAME generator the publish job emits (``build-repo-portable.py
+    --print-conf --base-url <base>``), but with the ``priority:`` raised above the
+    Netgate ``pfSense`` repo so cross-repo resolution favours ours. The literal
+    ``${ABI}`` is expanded by pkg(8) (not the shell) and follows the box's ABI.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(BUILD_REPO_PORTABLE), "--print-conf", "--base-url", base_url],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"--print-conf failed: rc={proc.returncode} {proc.stderr!r}")
+    # Raise the priority above pfSense (the template ships priority 100; this flow
+    # sets it deterministically above the box's effective pfSense priority).
+    conf = re.sub(r"priority:\s*\d+", f"priority: {priority}", proc.stdout)
+    written = subprocess.run(
+        vm.ssh_argv("tee", REPO_CONF),
+        input=conf,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if written.returncode != 0:
+        raise RuntimeError(f"write_live_repo_conf failed: rc={written.returncode} {written.stderr!r}")
+
+
+@pytest.mark.timeout(900)  # live deploy/DNS/cert can lag + pkg update + install over the public URL.
+def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
+    """PHASE-3b LIVE URL: a real pfSense box installs from the DEPLOYED Pages catalog
+    over its public HTTPS ``https://brait.dev/pfBlockerNG/${ABI}`` URL (no ``-f``).
+
+    DISPATCH-ONLY + GATED on ``SMOKE_REPO_LIVE_URL`` (unset -> SKIP). The always-on
+    proof is the file:// VM-acceptance above; this exercises the REAL transport the
+    publish pipeline serves, so it can only run after a publish dispatch has deployed.
+
+    Given the publish job has DEPLOYED the catalog to Pages (runner-side backstop:
+      ``<base>/<ABI>/meta.conf`` + ``packagesite.pkg`` serve 200), the guest has the
+      Pages IPs pinned for the host (its DNS is sandboxed), the package is ABSENT, and
+      OUR conf points at the live ``${ABI}`` URL above the Netgate ``pfSense`` repo,
+    When ``pkg update`` reads the live catalog and ``pkg install -y`` runs (NO ``-r``,
+      NO ``-f``),
+    Then ``pkg update`` accepts the deployed catalog AND the install comes from OUR
+      repo (``pkg query %R`` == ``pfblockerng-devel``) with deps resolved and the .pkg
+      checksum validated — the deployed Pages repo is real + installable over HTTPS.
+    """
+    base_url = _live_base_url()
+    if base_url is None:
+        pytest.skip(f"{LIVE_BASE_URL_ENV} not set — live Pages-URL check is dispatch-only (file:// proof always runs)")
+    assert base_url is not None  # for the type-checker: pytest.skip above is NoReturn
+
+    host = urllib.parse.urlparse(base_url).hostname
+    assert host, f"could not parse a host from {base_url!r}"
+
+    # BACKSTOP: prove the deploy actually serves the catalog from the RUNNER first
+    # (independent of the guest) — polls through first-deploy / DNS / cert lag.
+    poll_catalog_served(base_url, GUEST_ABI)
+
+    # GIVEN: Pages IPs pinned (guest DNS is sandboxed), package absent, our conf at
+    # the LIVE url above pfSense.
+    pin_pages_hosts(repo_vm, host)
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+    pkg_delete(repo_vm)
+    write_live_repo_conf(repo_vm, base_url, priority=pfsense_prio + 100)
+
+    # WHEN: pkg update must ACCEPT the live HTTPS catalog (a rejected catalog — bad
+    # meta.conf, malformed packagesite, mismatched sum, or an unreachable URL — fails here).
+    pkg_update(repo_vm)
+    assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the live-URL install"
+
+    # THEN: install resolves from our LIVE repo, deps included, .pkg checksum validated.
+    proc = pkg_install_from_repo(repo_vm)
+    combined = proc.stdout + proc.stderr
+    assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve from the live Pages catalog:\n{combined}"
     origin = pkg_repo_origin(repo_vm)
     assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -75,8 +75,8 @@ def test_add_repo_devel_conf_default_channel_matches_explicit() -> None:
 @pytest.mark.parametrize(
     ("channel", "repo_name", "url"),
     [
-        ("devel", "pfblockerng-devel", 'url: "https://brait.dev/pfBlockerNG/${ABI}"'),
-        ("stable", "pfblockerng", 'url: "https://brait.dev/pfBlockerNG/${ABI}"'),
+        ("devel", "pfblockerng-devel", 'url: "https://andrebrait.github.io/pfBlockerNG/${ABI}"'),
+        ("stable", "pfblockerng", 'url: "https://andrebrait.github.io/pfBlockerNG/${ABI}"'),
     ],
 )
 def test_add_repo_conf_fields_per_channel(channel: str, repo_name: str, url: str) -> None:

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -1,0 +1,118 @@
+"""Drift guard for the client repo-conf (ADR-17 Phase 4).
+
+`scripts/add-repo.sh` (the client bootstrap) and `scripts/build-repo.sh` (the
+catalog generator) BOTH emit the pkg(8) repo-conf the user ends up with — the
+former writes it on the box, the latter is the published single source of truth
+(`--print-conf`, also reused by the README). They MUST never disagree on the
+load-bearing fields: the same `url:` (static base + the literal ``${ABI}`` pkg
+variable), the same `priority:` (above the Netgate `pfSense` repo — the cross-repo
+precedence lever, ADR §1 Context 4 / Phase 1), and `mirror_type`/`signature_type`
+`none` (NONE-signed). This test FAILS if either script drifts.
+
+These run the real shell scripts via `--print-conf` (a pure, side-effect-free
+mode — no `pkg`, no writes), so the assertion is over the bytes a box would get.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+_ADD_REPO = _SCRIPTS / "add-repo.sh"
+_BUILD_REPO = _SCRIPTS / "build-repo.sh"
+
+
+def _print_conf(script: Path, *args: str) -> str:
+    """Run `<script> --print-conf [args]` and return its stdout (text)."""
+    proc = subprocess.run(
+        ["sh", str(script), "--print-conf", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def _field(conf: str, key: str) -> str:
+    """Extract a `  key: value,` field's value from a printed conf stanza."""
+    m = re.search(rf"^\s*{re.escape(key)}:\s*(.+?),?\s*$", conf, re.MULTILINE)
+    assert m is not None, f"field {key!r} not found in conf:\n{conf}"
+    return m.group(1).strip().rstrip(",").strip()
+
+
+# --------------------------------------------------------------------------- #
+# Devel: add-repo.sh must emit the EXACT bytes build-repo.sh publishes.
+# --------------------------------------------------------------------------- #
+
+
+def test_add_repo_devel_conf_is_byte_identical_to_build_repo() -> None:
+    """The devel conf from add-repo.sh == build-repo.sh --print-conf, byte-for-byte.
+
+    build-repo.sh --print-conf is the published single source (Phase 2/3). If
+    add-repo.sh's devel stanza diverges by even a byte (url, priority, comment),
+    the client would write a conf that disagrees with what CI publishes — this
+    pins them together.
+    """
+    add = _print_conf(_ADD_REPO, "devel")
+    build = _print_conf(_BUILD_REPO)
+    assert add == build
+
+
+def test_add_repo_devel_conf_default_channel_matches_explicit() -> None:
+    """No channel arg defaults to devel (the documented default)."""
+    assert _print_conf(_ADD_REPO) == _print_conf(_ADD_REPO, "devel")
+
+
+# --------------------------------------------------------------------------- #
+# The load-bearing fields hold for BOTH channels (branch coverage).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("channel", "repo_name", "url"),
+    [
+        ("devel", "pfblockerng-devel", 'url: "https://brait.dev/pfBlockerNG/${ABI}"'),
+        ("stable", "pfblockerng", 'url: "https://brait.dev/pfBlockerNG/${ABI}"'),
+    ],
+)
+def test_add_repo_conf_fields_per_channel(channel: str, repo_name: str, url: str) -> None:
+    """Each channel names its repo distinctly but shares the precedence-bearing fields.
+
+    devel -> repo `pfblockerng-devel`; stable -> repo `pfblockerng`. Both carry
+    the SAME static ${ABI} url, priority 100 (above Netgate's 0), and none/none
+    (NONE-signed). The repo NAME is the only channel-varying field — a stable conf
+    that reused the devel repo name (or vice versa) would collide on a box.
+    """
+    conf = _print_conf(_ADD_REPO, channel)
+
+    # The stanza is keyed by the channel-specific repo name (and ONLY that name).
+    assert re.search(rf"^{re.escape(repo_name)}:\s*\{{", conf, re.MULTILINE), conf
+    other = "pfblockerng" if channel == "devel" else "pfblockerng-devel"
+    # `pfblockerng-devel:` must not match a bare `pfblockerng:` probe — anchor the colon.
+    assert not re.search(rf"^{re.escape(other)}:\s*\{{", conf, re.MULTILINE), conf
+
+    # The literal ${ABI} survives (single-quoted on emission — pkg expands it, not the shell).
+    assert url in conf
+    assert "${ABI}" in conf
+
+    # NONE-signed + above-Netgate priority + enabled — the precedence/trust contract.
+    assert _field(conf, "mirror_type") == "none"
+    assert _field(conf, "signature_type") == "none"
+    assert _field(conf, "priority") == "100"
+    assert _field(conf, "enabled") == "yes"
+
+
+def test_add_repo_rejects_unknown_channel() -> None:
+    """An unknown channel arg fails loud (exit != 0), never silently writing a conf."""
+    proc = subprocess.run(
+        ["sh", str(_ADD_REPO), "--print-conf", "nightly"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    assert "channel" in proc.stderr.lower()

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -1,0 +1,458 @@
+"""Tests for scripts/build-repo-portable.py — the pure-Python pkg catalog generator (ADR-17 Phase 3a).
+
+The generator turns a dir of `.pkg` files into a per-ABI FreeBSD `pkg` repository
+tree (meta.conf + packagesite.pkg + data.pkg + the .pkg) WITHOUT libpkg, so a real
+pfSense `pkg update`/`pkg install` accepts it. These tests pin the FORMAT against
+facts captured from real `pkg repo` output (ADR-17 RESULTS/03a) — they do not
+merely run the code:
+
+  * the catalog descriptor (meta.conf, and its identical `meta` copy) is byte-exact;
+  * the `sum` field is libpkg checksum type 2 = `2$` + z-base-32(blake2b(file)),
+    anchored to a GOLDEN (.pkg-bytes -> sum) vector emitted by the REAL `pkg repo`
+    binary (so the algorithm matches libpkg, not just itself);
+  * packagesite.yaml is newline-delimited JSON, one object per package, = the
+    pkg's +COMPACT_MANIFEST with sum/flatsize/path/repopath/pkgsize spliced in at
+    libpkg's field positions (order asserted);
+  * data.pkg wraps a single JSON object {groups, expired_packages, packages} with
+    NO trailing newline;
+  * per-ABI bucketing, determinism (two runs byte-identical), and the
+    flavor-collision guard (fail-loud) — each branch asserted.
+
+All fixtures are SYNTHETIC and authored here (a made-up package built in pure
+Python), except the single golden sum vector — a tiny package built by the real
+`pkg create`/`pkg repo` from a made-up manifest (this repo's own synthetic
+artifact; no FreeBSD source vendored). No network, no FreeBSD host, no `pkg` binary.
+
+The tool is a hyphen-named CLI script, so it is loaded by path via importlib.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import io
+import json
+import sys
+import tarfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Load the hyphen-named tool as a module.
+# --------------------------------------------------------------------------- #
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "build-repo-portable.py"
+_spec = importlib.util.spec_from_file_location("build_repo_portable", _TOOL)
+assert _spec is not None and _spec.loader is not None
+brp = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = brp
+_spec.loader.exec_module(brp)
+
+
+# --------------------------------------------------------------------------- #
+# A synthetic .pkg writer (pure Python; mirrors libpkg framing) — so the tests
+# vendor no real packages. A .pkg is a zstd tar with +COMPACT_MANIFEST first.
+# --------------------------------------------------------------------------- #
+
+
+def make_pkg(
+    path: Path,
+    *,
+    name: str = "demo",
+    version: str = "1.0_1",
+    abi: str = "FreeBSD:15:amd64",
+    deps: dict[str, dict[str, str]] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict:
+    """Write a minimal but libpkg-shaped .pkg to ``path``; return its compact manifest."""
+    # Key order mirrors a real +COMPACT_MANIFEST: ...licenselogic, desc, deps,
+    # categories. The generator preserves the input manifest's order (libpkg's
+    # native order), so the fixture must use it for the order assertion to be real.
+    manifest: dict[str, Any] = {
+        "name": name,
+        "origin": f"net/{name}",
+        "version": version,
+        "comment": "demo package",
+        "maintainer": "dev@example.com",
+        "www": "https://example.com",
+        "abi": abi,
+        "arch": "freebsd:15:x86:64",
+        "prefix": "/usr/local",
+        "flatsize": 3,
+        "licenselogic": "single",
+        "desc": "demo",
+    }
+    if deps:
+        manifest["deps"] = deps
+    manifest["categories"] = ["net"]
+    if extra:
+        manifest.update(extra)
+    compact = json.dumps(manifest, separators=(",", ":")).encode() + b"\n"
+
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as tf:
+        ti = tarfile.TarInfo(name="+COMPACT_MANIFEST")
+        ti.size = len(compact)
+        ti.mode = 0o644
+        tf.addfile(ti, io.BytesIO(compact))
+        payload = b"hey"
+        tf2 = tarfile.TarInfo(name="/usr/local/bin/demo")
+        tf2.size = len(payload)
+        tf2.mode = 0o555
+        tf.addfile(tf2, io.BytesIO(payload))
+    path.write_bytes(brp._zstd_compress(raw.getvalue()))
+    return manifest
+
+
+def _read_member(zstd_tar: Path, member: str) -> bytes:
+    data = brp._zstd_decompress(zstd_tar.read_bytes())
+    with tarfile.open(fileobj=io.BytesIO(data)) as tf:
+        f = tf.extractfile(member)
+        assert f is not None
+        return f.read()
+
+
+# --------------------------------------------------------------------------- #
+# Golden sum vector — anchors the checksum algorithm to REAL `pkg repo` output.
+#
+# This tiny .pkg (built by the real `pkg create` from a synthetic manifest) and
+# its catalog `sum` (emitted by the real `pkg repo`) pin that build-repo-portable's
+# pkg_checksum reproduces libpkg's checksum type 2 EXACTLY — not merely a
+# self-consistent hash. If libpkg's algorithm ever changed, this fails.
+# --------------------------------------------------------------------------- #
+
+_GOLDEN_PKG_B64 = (
+    "KLUv/QRoNREA9pxcIfDUPOhS5WqLHaV/3qBKLFU2tEy1GhRsBj8AeDKR3UWWGFMAUABTAHakOv9O"
+    "9fC1Fm/V0EMVMd//qS7HOsQeLkwPHA2fr93i5OZrG87RlP+/cuqiuCmdtu2cnCg1XdplVUpRysow"
+    "6roySul0sTwgkclCork0FhUJpUEIIeaTmxd7Yn4e/sV5FrbKzRdh3m3mZHvFXG1OVpObIMz5PXLZ"
+    "Bur4hvPdfWWdthxWOYeF8b8heGOriuNj719ZlofPo7agV0xu7u8htvo9C94cXeJOZ4Vuz7ztCseL"
+    "c9Uv25R6Wy8r683ErQxVDIIDxOSmJrmY839ViDfVZ2xVC0FrrYSplJkYbvL3vttSadaDVXmhzbVa"
+    "ofj10DhH3OQjiX+XvQD8UeJ3H/DxgCCztEurGa0IrFIIxFQqlTBLy7aMbprGHcMwqvd75CzM8I67"
+    "76t2HKyfB7Q9Vu/oBOgRdS231tFCECjaru43B+Gvu3hDaiFL2mprKEkggGYER6sHM+jiB7XNp/z+"
+    "BTwGKgkAaOAYhAp4bBZ+wKBgaGmAlutf6g7qXsnAWCEA3y6QnRwioQTwCchg3AAXApK0AW+CcQSA"
+    "aleEd/QGSAr7F7kJTgSqW30ByIDhYWA2PMBdlOMVgIjqnhixoVfWm4HgXs4agdsAAwQLYPwy5wVm"
+    "MAA6cJ4C/QPaYOAfF6YG/QfFOXQGIEGASUUBOARsFww/IPlAZUOBYUEAxqMgDH9Rop0="
+)
+_GOLDEN_SUM = (
+    "2$km8wbgp6pmfiaoywsfk3dzx9mhuok6ipj1nkfh9d48fsgy6y67c3yw8zofub9r5g99gy1d46oq8bonwtqzjcu69mzjcic6mncj68w9y"
+)
+
+
+def test_pkg_checksum_matches_real_pkg_repo_golden() -> None:
+    """pkg_checksum reproduces libpkg's catalog `sum` (type 2) for a real-pkg vector.
+
+    The expected value was emitted by the real `pkg repo` over this exact .pkg, so
+    a green here proves the blake2b + z-base-32(LSB) chain matches libpkg byte-for-byte.
+    """
+    pkg_bytes = base64.b64decode(_GOLDEN_PKG_B64)
+    assert brp.pkg_checksum(pkg_bytes) == _GOLDEN_SUM
+
+
+def test_pkg_checksum_is_blake2b_zbase32() -> None:
+    """The sum is `2$` + 103-char z-base-32 of a 64-byte blake2b digest (independent recompute)."""
+    data = b"the quick brown fox"
+    got = brp.pkg_checksum(data)
+    assert got.startswith("2$")
+    body = got[2:]
+    assert len(body) == 103  # ceil(64 bytes * 8 / 5)
+    assert set(body) <= set(brp._ZBASE32)
+    # Independent reference: z-base-32 over blake2b, 5-bit groups packed LSB-first
+    # within each byte (libpkg's pkg_checksum_encode_base32).
+    digest = hashlib.blake2b(data).digest()
+    ref: list[str] = []
+    total_bits = len(digest) * 8
+    for i in range(0, total_bits, 5):
+        v = 0
+        for k in range(5):
+            bi = i + k
+            if bi < total_bits:
+                v |= ((digest[bi // 8] >> (bi % 8)) & 1) << k
+        ref.append(brp._ZBASE32[v])
+    assert body == "".join(ref)
+
+
+# --------------------------------------------------------------------------- #
+# meta.conf / meta — the catalog descriptor
+# --------------------------------------------------------------------------- #
+
+
+def test_meta_conf_is_byte_exact(tmp_path: Path) -> None:
+    """meta.conf matches real `pkg repo` exactly, and `meta` is an identical copy."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg")
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out)
+    bucket = out / "FreeBSD:15:amd64"
+    expected = (
+        "version = 2;\n"
+        'packing_format = "tzst";\n'
+        'manifests = "packagesite.yaml";\n'
+        'data = "data";\n'
+        'filesite = "files";\n'
+        'manifests_archive = "packagesite";\n'
+        'filesite_archive = "files";\n'
+    )
+    assert (bucket / "meta.conf").read_text() == expected
+    assert (bucket / "meta").read_text() == expected
+
+
+# --------------------------------------------------------------------------- #
+# packagesite.yaml — field set + ORDER + injected repo fields
+# --------------------------------------------------------------------------- #
+
+
+def test_packagesite_object_order_and_injected_fields(tmp_path: Path) -> None:
+    """packagesite.yaml = compact manifest + sum/path/repopath/pkgsize at libpkg positions.
+
+    Pins the EXACT key order real `pkg repo` emits: ...prefix, sum, flatsize, path,
+    repopath, licenselogic, pkgsize, desc... so the catalog is faithful + diffable.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    pkg = in_dir / "demo-1.0_1.pkg"
+    make_pkg(pkg, deps={"python311": {"origin": "lang/python311", "version": "3.11.0"}})
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out)
+
+    raw = _read_member(out / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml")
+    assert raw.endswith(b"\n"), "packagesite.yaml is newline-delimited JSON"
+    lines = [ln for ln in raw.decode().splitlines() if ln]
+    assert len(lines) == 1
+    obj = json.loads(lines[0])
+
+    # Injected repo fields, with the correct values.
+    pkg_bytes = pkg.read_bytes()
+    assert obj["sum"] == brp.pkg_checksum(pkg_bytes)
+    assert obj["path"] == "demo-1.0_1.pkg"
+    assert obj["repopath"] == "demo-1.0_1.pkg"
+    assert obj["pkgsize"] == len(pkg_bytes)
+    assert obj["flatsize"] == 3  # from the manifest, carried through
+
+    # Exact key order (the libpkg splice).
+    keys = list(obj.keys())
+    assert keys == [
+        "name",
+        "origin",
+        "version",
+        "comment",
+        "maintainer",
+        "www",
+        "abi",
+        "arch",
+        "prefix",
+        "sum",
+        "flatsize",
+        "path",
+        "repopath",
+        "licenselogic",
+        "pkgsize",
+        "desc",
+        "deps",
+        "categories",
+    ]
+
+
+def test_packagesite_is_compact_json_no_spaces(tmp_path: Path) -> None:
+    """libpkg emits compact JSON (no separator spaces); reproduce that."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg")
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out)
+    raw = _read_member(out / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml").decode()
+    assert '", "' not in raw and '": "' not in raw  # no ", " / ": " separators
+
+
+# --------------------------------------------------------------------------- #
+# data.pkg — the data blob shape
+# --------------------------------------------------------------------------- #
+
+
+def test_data_blob_shape_and_no_trailing_newline(tmp_path: Path) -> None:
+    """data = {groups:[], expired_packages:[], packages:[<objs>]} with NO trailing newline."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg")
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out)
+    raw = _read_member(out / "FreeBSD:15:amd64" / "data.pkg", "data")
+    assert not raw.endswith(b"\n"), "data has no trailing newline (matches real pkg repo)"
+    obj = json.loads(raw)
+    assert obj["groups"] == []
+    assert obj["expired_packages"] == []
+    assert len(obj["packages"]) == 1
+    # The package object equals the packagesite object.
+    psite = json.loads(_read_member(out / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml").decode())
+    assert obj["packages"][0] == psite
+
+
+# --------------------------------------------------------------------------- #
+# Layout + ABI bucketing + the verbatim .pkg copy
+# --------------------------------------------------------------------------- #
+
+
+def test_layout_and_verbatim_pkg_copy(tmp_path: Path) -> None:
+    """Each <ABI>/ holds the .pkg (byte-verbatim) + the catalog triple + meta."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    pkg = in_dir / "demo-1.0_1.pkg"
+    original = make_pkg(pkg)
+    del original
+    out = tmp_path / "out"
+    abis = brp.build_repo(in_dir, out)
+    assert abis == ["FreeBSD:15:amd64"]
+    bucket = out / "FreeBSD:15:amd64"
+    for fname in ("meta.conf", "meta", "packagesite.pkg", "data.pkg", "demo-1.0_1.pkg"):
+        assert (bucket / fname).is_file(), f"missing {fname}"
+    # The .pkg is copied verbatim (no re-archiving).
+    assert (bucket / "demo-1.0_1.pkg").read_bytes() == pkg.read_bytes()
+
+
+def test_per_abi_bucketing(tmp_path: Path) -> None:
+    """Two ABIs -> two <ABI>/ subtrees, each catalog scoped to its own ABI's pkg."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "a15.pkg", name="a", abi="FreeBSD:15:amd64")
+    make_pkg(in_dir / "b16.pkg", name="b", abi="FreeBSD:16:amd64")
+    out = tmp_path / "out"
+    abis = brp.build_repo(in_dir, out)
+    assert abis == ["FreeBSD:15:amd64", "FreeBSD:16:amd64"]
+    # Each bucket's packagesite names exactly its own package; its .pkg lands there.
+    for abi, pkgname, fname in (("FreeBSD:15:amd64", "a", "a15.pkg"), ("FreeBSD:16:amd64", "b", "b16.pkg")):
+        raw = _read_member(out / abi / "packagesite.pkg", "packagesite.yaml").decode()
+        objs = [json.loads(ln) for ln in raw.splitlines() if ln]
+        assert [o["name"] for o in objs] == [pkgname]
+        assert (out / abi / fname).is_file()
+
+
+# --------------------------------------------------------------------------- #
+# Determinism
+# --------------------------------------------------------------------------- #
+
+
+def test_deterministic_two_runs_byte_identical(tmp_path: Path) -> None:
+    """Same inputs -> byte-identical tree across runs (re-runnable, no drift)."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg")
+    out1, out2 = tmp_path / "o1", tmp_path / "o2"
+    brp.build_repo(in_dir, out1)
+    brp.build_repo(in_dir, out2)
+    for rel in ("meta.conf", "meta", "packagesite.pkg", "data.pkg", "demo-1.0_1.pkg"):
+        a = (out1 / "FreeBSD:15:amd64" / rel).read_bytes()
+        b = (out2 / "FreeBSD:15:amd64" / rel).read_bytes()
+        assert a == b, f"{rel} differs between runs"
+
+
+def test_rebuild_wipes_removed_pkg(tmp_path: Path) -> None:
+    """A re-run after removing a .pkg drops it from the bucket (wipe-and-rebuild)."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "a-1.0.pkg", name="a")
+    make_pkg(in_dir / "b-1.0.pkg", name="b")
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out)
+    assert (out / "FreeBSD:15:amd64" / "b-1.0.pkg").is_file()
+    # Remove one input and rebuild.
+    (in_dir / "b-1.0.pkg").unlink()
+    brp.build_repo(in_dir, out)
+    assert not (out / "FreeBSD:15:amd64" / "b-1.0.pkg").exists(), "stale .pkg lingered after rebuild"
+    raw = _read_member(out / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml").decode()
+    assert [json.loads(ln)["name"] for ln in raw.splitlines() if ln] == ["a"]
+
+
+# --------------------------------------------------------------------------- #
+# Flavor-collision guard — BOTH branches (collide -> fail; same-flavor -> pass)
+# --------------------------------------------------------------------------- #
+
+
+def test_flavor_collision_fails_loud(tmp_path: Path) -> None:
+    """Two .pkg same name+version+ABI but different php flavor -> hard error (no silent drop)."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "x-a.pkg", name="x", version="1.0", deps={"php83": {"origin": "lang/php83", "version": "8.3"}})
+    make_pkg(in_dir / "x-b.pkg", name="x", version="1.0", deps={"php84": {"origin": "lang/php84", "version": "8.4"}})
+    out = tmp_path / "out"
+    with pytest.raises(brp.BuildRepoError, match="FLAVOR COLLISION"):
+        brp.build_repo(in_dir, out)
+
+
+def test_same_flavor_duplicate_passes(tmp_path: Path) -> None:
+    """Same name+version+ABI AND same flavor is a harmless duplicate -> no error."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    deps = {"php83": {"origin": "lang/php83", "version": "8.3"}}
+    make_pkg(in_dir / "x-a.pkg", name="x", version="1.0", deps=deps)
+    make_pkg(in_dir / "x-b.pkg", name="x", version="1.0", deps=deps)
+    out = tmp_path / "out"
+    abis = brp.build_repo(in_dir, out)  # must not raise
+    assert abis == ["FreeBSD:15:amd64"]
+
+
+def test_flavor_signature_classifies_dep_names() -> None:
+    """The flavor signature picks ONLY php*/python*/py*- dep names, sorted."""
+    assert brp._flavor_signature({"deps": {}}) == ""
+    assert brp._flavor_signature({"deps": {"php83": {}, "php83-intl": {}}}) == "php83,php83-intl"
+    assert brp._flavor_signature({"deps": {"python311": {}}}) == "python311"
+    assert brp._flavor_signature({"deps": {"py311-sqlite3": {}}}) == "py311-sqlite3"
+    # Non-flavor deps (e.g. grepcidr, a bare 'python' without a version) are ignored.
+    assert brp._flavor_signature({"deps": {"grepcidr": {}, "rsync": {}}}) == ""
+
+
+# --------------------------------------------------------------------------- #
+# Manifest reader + error paths
+# --------------------------------------------------------------------------- #
+
+
+def test_read_compact_manifest_roundtrip(tmp_path: Path) -> None:
+    """read_compact_manifest returns the .pkg's +COMPACT_MANIFEST as a dict."""
+    pkg = tmp_path / "demo-1.0_1.pkg"
+    written = make_pkg(pkg, name="demo", version="2.0", abi="FreeBSD:16:amd64")
+    got = brp.read_compact_manifest(pkg)
+    assert got["name"] == "demo"
+    assert got["version"] == "2.0"
+    assert got["abi"] == "FreeBSD:16:amd64"
+    assert got == written
+
+
+def test_empty_input_dir_errors(tmp_path: Path) -> None:
+    """An input dir with no .pkg is a hard error (fail-closed, never an empty repo)."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    with pytest.raises(brp.BuildRepoError, match="no .pkg files"):
+        brp.build_repo(in_dir, tmp_path / "out")
+
+
+# --------------------------------------------------------------------------- #
+# CLI surface
+# --------------------------------------------------------------------------- #
+
+
+def test_print_conf_matches_template(capsys: pytest.CaptureFixture[str]) -> None:
+    """--print-conf emits the NONE-signed ${ABI}/priority-100 client stanza."""
+    rc = brp.main(["--print-conf"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "pfblockerng-devel: {" in out
+    assert 'url: "https://andrebrait.github.io/pfBlockerNG/${ABI}"' in out
+    assert "signature_type: none," in out
+    assert "priority: 100," in out
+    assert "enabled: yes" in out
+
+
+def test_print_conf_base_url_override(capsys: pytest.CaptureFixture[str]) -> None:
+    """--base-url overrides the host while keeping the literal ${ABI} suffix."""
+    rc = brp.main(["--print-conf", "--base-url", "https://fork.example.io/p/"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert 'url: "https://fork.example.io/p/${ABI}"' in out  # trailing slash trimmed
+
+
+def test_cli_requires_in_and_out(capsys: pytest.CaptureFixture[str]) -> None:
+    """Without --in/--out (and no --print-conf) the CLI errors."""
+    with pytest.raises(SystemExit):
+        brp.main([])

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -393,6 +393,22 @@ def test_same_flavor_duplicate_passes(tmp_path: Path) -> None:
     assert abis == ["FreeBSD:15:amd64"]
 
 
+def test_unsafe_abi_is_rejected(tmp_path: Path) -> None:
+    """A traversal/odd ABI in manifest data is rejected BEFORE it becomes a path
+    segment — `out_dir / abi` is rmtree'd + rebuilt, so an unsafe value could escape
+    out_dir. The valid form (`FreeBSD:15:amd64`, with colons) is accepted by every
+    other test, so this pins the reject side of the branch."""
+    # Non-empty but unsafe values (traversal / slash / space) — an empty ABI is
+    # already rejected upstream by the missing-name/version/abi guard.
+    out = tmp_path / "out"
+    for i, bad in enumerate(("../../evil", "FreeBSD/15/amd64", "a b")):
+        in_dir = tmp_path / f"in{i}"
+        in_dir.mkdir()
+        make_pkg(in_dir / "p.pkg", name="p", version="1.0", abi=bad)
+        with pytest.raises(brp.BuildRepoError, match="unsafe or invalid ABI"):
+            brp.build_repo(in_dir, out)
+
+
 def test_flavor_signature_classifies_dep_names() -> None:
     """The flavor signature picks ONLY php*/python*/py*- dep names, sorted."""
     assert brp._flavor_signature({"deps": {}}) == ""

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -438,7 +438,7 @@ def test_print_conf_matches_template(capsys: pytest.CaptureFixture[str]) -> None
     assert rc == 0
     out = capsys.readouterr().out
     assert "pfblockerng-devel: {" in out
-    assert 'url: "https://andrebrait.github.io/pfBlockerNG/${ABI}"' in out
+    assert 'url: "https://brait.dev/pfBlockerNG/${ABI}"' in out
     assert "signature_type: none," in out
     assert "priority: 100," in out
     assert "enabled: yes" in out

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -438,7 +438,7 @@ def test_print_conf_matches_template(capsys: pytest.CaptureFixture[str]) -> None
     assert rc == 0
     out = capsys.readouterr().out
     assert "pfblockerng-devel: {" in out
-    assert 'url: "https://brait.dev/pfBlockerNG/${ABI}"' in out
+    assert 'url: "https://andrebrait.github.io/pfBlockerNG/${ABI}"' in out
     assert "signature_type: none," in out
     assert "priority: 100," in out
     assert "enabled: yes" in out


### PR DESCRIPTION
## ADR-17 — Self-hosted pfSense `pkg` repository on GitHub Pages

Publishes a self-hosted FreeBSD `pkg` repository (per-`${ABI}`, **NONE-signed**, TLS-anchored) to GitHub Pages at `https://brait.dev/pfBlockerNG/${ABI}`, derived/regenerated over the GitHub Release `.pkg` assets each deploy. Users add one repo conf and then `pkg install` / `pkg upgrade` — and the stock webConfigurator **Install** pulls our build via cross-repo resolution. **No shipped (`src/`) change** — distribution/CI only.

Implements `.ADRs/ADR_17_Pkg_Repository/` end-to-end (all 6 phases), each proven on the live ADR-04 pfSense CE VM.

### What's here

| Phase | Deliverable |
| --- | --- |
| P1 | `tests/smoke/test_repo_install.py` — distinct `repo`-marked live flow (install from our NONE-signed third-party repo, no `-f`; files-present; precedence both directions). Deselected from `-m smoke`; dispatched via `repo-install.yml` / `smoke.yml -f pytest_marker=repo`. |
| P2 | `scripts/build-repo.sh` — per-ABI `pkg repo` catalog generator + `--print-conf` template (libpkg path). |
| P3a | `scripts/build-repo-portable.py` — **pure-Python** catalog generator (no libpkg; reproduces libpkg's `meta.conf`/`packagesite.pkg`/`data.pkg`, incl. the blake2b/z-base-32 `sum`). |
| P3 | `repo-publish.yml` (pure-Python **primary**) + `repo-publish-freebsd.yml` (FreeBSD-VM **fallback**) + the isolated `repo-publish` job in `release.yml` → Pages. |
| P4 | `scripts/add-repo.sh` (client bootstrap, `channel` arg, `priority: 100`) + README install section. |
| P5 | `pkg upgrade` `_1`→`_9` transition + shipped-`add-repo.sh` install, live-green. |
| P6 | README + CLAUDE.md docs; ADR precedence-model correction; Status → Implemented. |

### Key finding (corrects the ADR)

Repository **`priority:` dominates version** — a higher-priority repo wins even at a lower version (falsified ADR §1/§2 "highest version wins" on the box: priority 200/`_1` beat priority 99/`_9`). Our repo wins by being `priority: 100` above Netgate's `pfSense` repo, **regardless of version**. ADR §1 Context 3 + §2 corrected accordingly.

### Live-VM evidence (`-m repo`, all SUCCESS)

- install + precedence (both branches): `27031334263`
- `build-repo.sh` catalog accepted: `27033922928`
- pure-Python catalog accepted: `27035602221`
- `pkg upgrade` `_1`→`_9` + shipped `add-repo.sh`: `27040686824`

### Additive + isolated

The `repo-publish` job is wired exactly like `attach-pkgs` (`if: always() && needs.release.result == 'success'`, a leaf no job `needs`), so a publish failure leaves `release`/`ports-pr`/`attach-pkgs` green. `pages: write` + `id-token: write` are scoped to the deploy job only.

### Honest limitations (documented)

- GUI Available-Packages **discovery** + the "update available" **badge** stay Netgate-bound (install works via GUI Install / CLI `pkg upgrade`); a GUI Updates/Channel panel is deferred (out of scope — touches `src/`).
- A true **OS-major** upgrade degrades to a documented CLI `pkg update -f && pkg upgrade` (the `${ABI}` conf auto-follows); not testable on one image.

### Post-merge (deliberately deferred)

The public Pages deploy can't run until `repo-publish.yml` is on the default branch (GitHub only dispatches a new workflow from `devel`). After merge: dispatch `repo-publish.yml` → deploys to `brait.dev/pfBlockerNG/${ABI}` → run the gated `test_install_from_live_pages_url` against the live URL → flip Status **Implemented → Accepted**.

Default `python -m pytest` unchanged; markdownlint / shellcheck / URL-encoding gate / ruff / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install pfBlockerNG from a self-hosted per-ABI pkg repository on GitHub Pages; added a client bootstrap script and a portable repo generator.

* **Bug Fixes**
  * Clarified package selection: repository priority overrides version for cross-repo installs.

* **Documentation**
  * Expanded README and ADRs with publish pipeline, Pages live-URL gating, and client install guidance.

* **Tests**
  * Added repo-marked live/install smoke tests and unit tests for repo generation and client bootstrap.

* **Infrastructure**
  * Added workflows to build, publish and validate per-ABI pkg repositories to GitHub Pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->