### PR TITLE
pfblockerng: fix IPv6 DNSBL-IP literals dropped by host:port strip

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3270,6 +3270,22 @@ function pfb_dnsbl_abp_extract_ip($line) {
 }
 
 
+// Strip a trailing ":<port>" from a host:port feed line (e.g. 'evil.com:8080' ->
+// 'evil.com'), but NEVER from an IPv6 literal: an address like '2001:db8:5::7' ends
+// in ':<hextet>', so the naive /:[0-9]{1,5}$/ rewrite would mangle it into the
+// invalid '2001:db8:5:' -- is_ipaddrv6() then rejects it and the IP is dropped,
+// leaving pfB_DNSBLIP_v6 with only the '::<placeholder>' sentinel (the dual-stack
+// partition smoke regression, ex-issue #35). A valid IPv6 literal carries no
+// host:port, so guarding on is_ipaddrv6() is safe and leaves every non-v6 line
+// (domains, domain:port, IPv4, IPv4:port) stripped exactly as before.
+function pfb_strip_trailing_port($line) {
+	if (!is_ipaddrv6($line) && strpos($line, ':') !== FALSE) {
+		return preg_replace("/:[0-9]{1,5}$/", '', $line);
+	}
+	return $line;
+}
+
+
 // ADR-10 P5: atomically publish a file to the chroot (/var/unbound). Stage into a
 // temp file ON THE SAME FILESYSTEM (same directory) -> flush + fsync the data ->
 // fix ownership -> atomic rename() over the final path. The plugin only ever reads
@@ -9617,10 +9633,9 @@ function sync_package_pfblockerng($cron='') {
 													}
 												}
 
-												// Remove any Port numbers at end of line
-												if (strpos($line, ':') !== FALSE) {
-													$line = preg_replace("/:[0-9]{1,5}$/", '', $line);
-												}
+												// Remove any Port numbers at end of line (IPv6-safe:
+												// never mangle a bare IPv6 literal's trailing hextet).
+												$line = pfb_strip_trailing_port($line);
 											}
 											$line = trim($line);
 

--- a/tests/php/StripTrailingPortTest.php
+++ b/tests/php/StripTrailingPortTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_strip_trailing_port() — strip a ":<port>" from a host:port DNSBL feed line
+ * WITHOUT mangling a bare IPv6 literal.
+ *
+ * Regression for the DNSBL-IP dual-stack partition (ex-issue #35): the old inline
+ * /:[0-9]{1,5}$/ rewrite fired on every colon-bearing line, so an IPv6 literal like
+ * '2001:db8:5::7' (which ends in ':<hextet>') was rewritten to the invalid
+ * '2001:db8:5:'. is_ipaddrv6() then rejected it and the IP was dropped, leaving
+ * pfB_DNSBLIP_v6 holding only the '::<placeholder>' sentinel. The guard preserves
+ * every valid IPv6 literal while stripping ports from all non-v6 lines exactly as
+ * before.
+ */
+#[CoversFunction('pfb_strip_trailing_port')]
+final class StripTrailingPortTest extends TestCase
+{
+	public static function provider(): array
+	{
+		return [
+			// The bug: an IPv6 literal whose trailing hextet the old regex mangled.
+			'v6 trailing :hextet preserved'  => ['2001:db8:5::7', '2001:db8:5::7'],
+			'v6 :: + single digit preserved' => ['2001:db8::1', '2001:db8::1'],
+			'v6 full form preserved'         => ['2001:db8:0:0:0:0:0:1', '2001:db8:0:0:0:0:0:1'],
+			'v4-mapped v6 preserved'         => ['::ffff:1.2.3.4', '::ffff:1.2.3.4'],
+			// Non-v6 lines: the port IS stripped, exactly as before the guard.
+			'host:port stripped'             => ['evil.com:8080', 'evil.com'],
+			'ipv4:port stripped'             => ['1.2.3.4:8080', '1.2.3.4'],
+			'host:port max 5 digits'         => ['evil.com:65535', 'evil.com'],
+			// No trailing :port -> untouched.
+			'bare ipv4 untouched'            => ['203.0.113.7', '203.0.113.7'],
+			'bare domain untouched'          => ['example.com', 'example.com'],
+			'six-digit suffix not a port'    => ['evil.com:123456', 'evil.com:123456'],
+		];
+	}
+
+	#[DataProvider('provider')]
+	public function testStrip(string $line, string $expected): void
+	{
+		$this->assertSame($expected, pfb_strip_trailing_port($line));
+	}
+
+	/**
+	 * The partition invariant end-to-end through is_ipaddrv6(): the v6 literal must
+	 * STILL validate as IPv6 after the strip (the old regex broke exactly this, so the
+	 * v6 IP never reached pfB_DNSBLIP_v6). Asserts the before-state (input is v6) and
+	 * the after-state (output is still v6) so green proves the guard caused the fix.
+	 */
+	public function testIpv6SurvivesStripAndStillValidates(): void
+	{
+		$v6 = '2001:db8:5::7';
+		$this->assertTrue(is_ipaddrv6($v6), 'precondition: input is a valid IPv6 literal');
+		$out = pfb_strip_trailing_port($v6);
+		$this->assertSame($v6, $out, 'IPv6 literal must pass through unchanged');
+		$this->assertTrue(is_ipaddrv6($out), 'IPv6 literal must STILL validate after the strip');
+	}
+}


### PR DESCRIPTION
## Summary

Fixes an IPv6 DNSBL-IP bug: a DNSBL feed line carrying a bare **IPv6** literal was
dropped from `pfB_DNSBLIP_v6`, so a dual-family feed populated `pfB_DNSBLIP_v4` but
left the v6 table holding only its `::<placeholder>` sentinel.

## Root cause

The DNSBL download loop stripped a trailing `:<port>` from every colon-bearing feed
line:

```php
if (strpos($line, ':') !== FALSE) {
    $line = preg_replace("/:[0-9]{1,5}$/", '', $line);
}
```

An IPv6 literal ends in `:<hextet>`, so `2001:db8:5::7` was rewritten to the invalid
`2001:db8:5:`. `is_ipaddrv6()` then rejected it, the IP never reached a `*_v6.ip`
file, and `DNSBLIP_v6.txt` fell back to the `::{$pfb['ip_ph']}` placeholder.

> Note on the reported symptom: the `::127.1.7.7` seen in `pfB_DNSBLIP_v6` is that
> **intentional placeholder** (`ip_ph` defaults to `127.1.7.7`; the `::` prefix makes
> a syntactically-valid IPv4-compatible IPv6 sentinel), not a converted address. It
> showed up *because* the real v6 IP was dropped — fixing the drop is the fix.

Demonstration:

```text
2001:db8:5::7   -> 2001:db8:5:    (was v6, after: invalid)   <-- dropped
2001:db8::1     -> 2001:db8:      (was v6, after: invalid)   <-- dropped
1.2.3.4:8080    -> 1.2.3.4        (non-v6, port stripped — correct)
evil.com:8080   -> evil.com       (non-v6, port stripped — correct)
```

## Fix

Extract the strip into an IPv6-safe helper and call it from the loop:

```php
function pfb_strip_trailing_port($line) {
    if (!is_ipaddrv6($line) && strpos($line, ':') !== FALSE) {
        return preg_replace("/:[0-9]{1,5}$/", '', $line);
    }
    return $line;
}
```

A valid IPv6 literal never carries a `host:port`, so guarding on `is_ipaddrv6()` is
safe and leaves **every** non-v6 line (domain, `domain:port`, IPv4, `IPv4:port`)
stripped exactly as before.

## Tests

- **Integration:** the now-active smoke test `test_dnsblip_dual_stack_partition`
  (ex-#35) is the end-to-end regression — it asserts a both-families feed populates
  *both* per-family tables. This bug is what made it red.
- **Fast unit (added):** `tests/php/StripTrailingPortTest.php` pins both sides —
  v6 literals pass through and **still validate as IPv6** after the strip; non-v6
  `host:port` / `IPv4:port` still strip; `:123456` (6 digits) is not a port.

## Test plan

- `vendor/bin/phpunit` — 176 passed (11 new).
- `vendor/bin/phpstan analyse` — no errors.
- `php -l` on `pfblockerng.inc` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IPv6 address corruption in DNSBL feed parsing when removing trailing port information.

* **Tests**
  * Added comprehensive test coverage for port-stripping logic across IPv4, IPv6 addresses, and hostname inputs, ensuring IPv6 addresses remain valid after processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->