### PR TITLE
tests: fix two ADR-11 aggregate smoke assertions (race + CIDR-collapse)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2134,6 +2134,28 @@ def member_present(members: list[str], ip: str) -> bool:
     return ip in members or any(m.split("/", 1)[0] == ip for m in members)
 
 
+def member_covers(members: list[str], ip: str) -> bool:
+    """True iff ``ip`` is CONTAINED in any member entry, treating each as a network.
+
+    Stronger than :func:`member_present` (which matches an exact IP or a member's network
+    *address*): this tests CIDR containment, needed when an aggregate's ``iprange`` collapse
+    has folded ``ip`` into a SUPERNET. E.g. an aggregate holding ``198.51.100.16/31`` covers
+    both ``.16`` and ``.17`` — an exact check for ``.17`` misses it, but ``.17`` is genuinely
+    in the set. Malformed members / a bad ``ip`` are skipped (return False), never raise.
+    """
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    for m in members:
+        try:
+            if addr in ipaddress.ip_network(m, strict=False):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
 # --------------------------------------------------------------------------- #
 # Diagnostics — dump live box state on a failed case (printed to the CI log)
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/test_smoke_aggregate.py
+++ b/tests/smoke/test_smoke_aggregate.py
@@ -156,8 +156,10 @@ def test_aggregate_none_selected_is_noop(deployed_vm: SmokeVM) -> None:
     h.reload(deployed_vm, "update")
 
     # The member table DID build (the denydir has content) — so the aggregate's absence
-    # is a real OFF-branch result, not just "nothing ran".
-    assert spec.alias in h.pfctl_tables(deployed_vm), f"member table {spec.alias} missing — injection did not build"
+    # is a real OFF-branch result, not just "nothing ran". Poll: the member pf table lands
+    # via filter_configure slightly AFTER the update CLI returns (issue #35), so a synchronous
+    # pfctl_tables read races it; wait_pfctl_table polls until it is present + non-empty.
+    assert h.wait_pfctl_table(deployed_vm, spec.alias), f"member table {spec.alias} missing — injection did not build"
     assert agg not in h.pfctl_tables(deployed_vm), f"aggregate {agg} built with NOTHING selected (OFF branch broken)"
     assert deployed_vm.ssh("test", "-f", consumer).returncode != 0, (
         f"aggregate consumer {consumer} exists with NOTHING selected (OFF branch broken)"
@@ -194,8 +196,9 @@ def test_aggregate_deny_builds_table_native_no_rule(deployed_vm: SmokeVM) -> Non
     assert h.member_present(members, fed_ip), f"fed Deny IP {fed_ip} not in aggregate {agg}: {members}"
     # Native ⇒ no firewall rule references the aggregate alias.
     assert not h.rule_references(deployed_vm, agg), f"aggregate {agg} is referenced by a pf rule — Native must add NONE"
-    # Additive: the per-feed member table is untouched/present alongside the aggregate.
-    assert spec.alias in h.pfctl_tables(deployed_vm), f"member table {spec.alias} vanished — aggregate not additive"
+    # Additive: the per-feed member table is untouched/present alongside the aggregate
+    # (poll — the member table can land via filter_configure after the CLI returns, issue #35).
+    assert h.wait_pfctl_table(deployed_vm, spec.alias), f"member table {spec.alias} vanished — aggregate not additive"
     assert h.member_present(h.pfctl_table_members(deployed_vm, spec.alias), fed_ip), (
         f"member table {spec.alias} lost {fed_ip} — aggregate perturbed the source table"
     )
@@ -499,6 +502,8 @@ def test_aggregate_deny_includes_dnsblip(deployed_vm: SmokeVM) -> None:
     assert h.member_present(dnsblip_members, dnsblip), (
         f"DNSBLIP {dnsblip} not collected into pfB_DNSBLIP_v4: {dnsblip_members}"
     )
-    # The Deny aggregate folds the denydir (incl. DNSBLIP) in.
+    # The Deny aggregate folds the denydir (incl. DNSBLIP) in. Use CIDR COVERAGE, not exact
+    # membership: the aggregate is iprange-collapsed, so the DNSBLIP IP can be folded into a
+    # supernet (e.g. .16 + .17 -> .16/31) — present in the set, but not as its bare literal.
     agg_members = h.wait_pfctl_table(deployed_vm, agg)
-    assert h.member_present(agg_members, dnsblip), f"DNSBLIP {dnsblip} did not fold into {agg}: {agg_members}"
+    assert h.member_covers(agg_members, dnsblip), f"DNSBLIP {dnsblip} did not fold into {agg}: {agg_members}"


### PR DESCRIPTION
## Fix two ADR-11 aggregate smoke assertions

The first real live-VM run of `test_smoke_aggregate.py` surfaced two **test-assertion** bugs (the aggregate feature itself is correct — 7/9 of the cases, incl. the post-hook-freshness journey, pass):

- **`none_selected`** (and the analogous member-table check in `additive_across_combination`) read `pfctl_tables` **synchronously**, but the member pf table lands via `filter_configure` slightly *after* the `pfblockerng.php update` CLI returns (issue #35). Switched to `wait_pfctl_table` (bounded poll), matching every other member-table check in the file.
- **`deny_includes_dnsblip`** asserted the DNSBLIP IP with `member_present` (exact / network-address match). The aggregate is `iprange`-collapsed, so the DNSBLIP literal got folded into a **supernet** (`.16` + `.17` → `.16/31`) — genuinely in the set, but not as its bare literal. Added `member_covers` (CIDR containment) and assert coverage.

No production code change. These are dispatch-only `smoke`-marked tests (not a PR gate); validated green by a `smoke.yml` re-run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved smoke test stability and reliability by implementing polling-based assertion checks for member table presence, reducing intermittent test failures from timing issues
  * Enhanced address aggregation testing to accurately reflect network address collapsing and CIDR coverage behavior, ensuring test assertions align with actual production system behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->