### PR TITLE
repo: clean published pkg catalog — canonical names + dedup (ADR-17 follow-up)

### DIFF
--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -351,14 +351,27 @@ def build_repo(in_dir: Path, out_dir: Path) -> list[str]:
     # Collision guard before laying anything out (fail-closed, never a silent drop).
     _check_collisions(entries)
 
-    # Bucket by ABI.
-    by_abi: dict[str, list[tuple[Path, dict]]] = {}
+    # Bucket by ABI, deduping by (name, version). The same package from multiple
+    # sources (e.g. the branch build + a release artifact) is interchangeable —
+    # `_check_collisions` already rejected a same-name+version+ABI/different-flavor
+    # clash — so keep ONE. The published .pkg is named CANONICALLY
+    # (`<name>-<version>.pkg`), never the staging input filename, so the catalog path
+    # is clean + stable regardless of how the publish job staged the inputs.
+    by_abi: dict[str, dict[tuple[str, str], tuple[Path, dict]]] = {}
     for path, manifest in entries:
         abi = manifest["abi"]
         # Validate before it becomes a filesystem path segment (rmtree target below).
         if not isinstance(abi, str) or not _ABI_RE.fullmatch(abi) or ".." in abi:
             raise BuildRepoError(f"{path.name}: unsafe or invalid ABI segment {abi!r}")
-        by_abi.setdefault(abi, []).append((path, manifest))
+        nv = (manifest["name"], manifest["version"])
+        bucket_nv = by_abi.setdefault(abi, {})
+        if nv in bucket_nv:
+            sys.stderr.write(
+                f"==> dedup: {path.name} duplicates {bucket_nv[nv][0].name} "
+                f"({nv[0]}-{nv[1]}, {abi}) — keeping the first\n"
+            )
+            continue
+        bucket_nv[nv] = (path, manifest)
 
     out_dir.mkdir(parents=True, exist_ok=True)
     for abi in sorted(by_abi):
@@ -369,14 +382,15 @@ def build_repo(in_dir: Path, out_dir: Path) -> list[str]:
         bucket.mkdir(parents=True)
 
         catalog_objs: list[dict] = []
-        # Deterministic order: by .pkg filename.
-        for path, manifest in sorted(by_abi[abi], key=lambda e: e[0].name):
+        # Deterministic order: by (name, version).
+        for (name, version), (path, manifest) in sorted(by_abi[abi].items()):
+            canonical = f"{name}-{version}.pkg"
             pkg_bytes = path.read_bytes()
-            dest = bucket / path.name
+            dest = bucket / canonical
             dest.write_bytes(pkg_bytes)
             obj = catalog_object(
                 manifest,
-                pkg_name=path.name,
+                pkg_name=canonical,
                 sum_=pkg_checksum(pkg_bytes),
                 pkgsize=len(pkg_bytes),
             )

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -227,7 +227,12 @@ for f in "$@"; do
         *" $abi "*) : ;;                 # already wiped this run
         *) rm -rf "$dir"; mkdir -p "$dir"; built="$built $abi" ;;
     esac
-    cp "$f" "${dir}/"
+    # Copy under the CANONICAL `<name>-<version>.pkg` name (never the staging input
+    # filename), so the catalog path is clean and an identical name+version from
+    # another source (branch + release artifact) overwrites to a single file (dedup;
+    # a different-flavor clash was already rejected above).
+    nv="$(pkg_nv "$f")"
+    cp "$f" "${dir}/${nv}.pkg"
 done
 
 for abi in $built; do

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -321,12 +321,41 @@ def test_per_abi_bucketing(tmp_path: Path) -> None:
     out = tmp_path / "out"
     abis = brp.build_repo(in_dir, out)
     assert abis == ["FreeBSD:15:amd64", "FreeBSD:16:amd64"]
-    # Each bucket's packagesite names exactly its own package; its .pkg lands there.
-    for abi, pkgname, fname in (("FreeBSD:15:amd64", "a", "a15.pkg"), ("FreeBSD:16:amd64", "b", "b16.pkg")):
+    # Each bucket's packagesite names exactly its own package; its .pkg lands there
+    # under the CANONICAL `<name>-<version>.pkg` (NOT the staging input filename
+    # `a15.pkg`/`b16.pkg`).
+    for abi, pkgname, fname in (("FreeBSD:15:amd64", "a", "a-1.0_1.pkg"), ("FreeBSD:16:amd64", "b", "b-1.0_1.pkg")):
         raw = _read_member(out / abi / "packagesite.pkg", "packagesite.yaml").decode()
         objs = [json.loads(ln) for ln in raw.splitlines() if ln]
         assert [o["name"] for o in objs] == [pkgname]
+        assert [o["path"] for o in objs] == [fname]
         assert (out / abi / fname).is_file()
+
+
+def test_duplicate_sources_dedup_to_one_canonical(tmp_path: Path) -> None:
+    """The SAME package staged from two sources (the publish job's `built-<source>-`
+    prefixed copies of the branch build + a release artifact) publishes exactly ONE
+    canonical `.pkg` + ONE catalog entry — not two prefixed duplicates (the bug the
+    first live deploy surfaced)."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    # Same name+version+ABI+flavor; different staging input filenames.
+    make_pkg(in_dir / "built-incoming_branch-pfb.pkg", name="pfb", version="3.2.16")
+    make_pkg(in_dir / "built-incoming_release-freebsd-pfb.pkg", name="pfb", version="3.2.16")
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out)
+    bucket = out / "FreeBSD:15:amd64"
+    # Exactly one package .pkg on disk, canonically named (no `built-incoming_*`
+    # prefix); the catalog files (packagesite.pkg/data.pkg) also end in `.pkg`.
+    catalog_files = {"packagesite.pkg", "data.pkg", "meta.pkg"}
+    pkgs = sorted(p.name for p in bucket.glob("*.pkg") if p.name not in catalog_files)
+    assert pkgs == ["pfb-3.2.16.pkg"]
+    # The catalog lists it once, at the canonical path/repopath.
+    raw = _read_member(bucket / "packagesite.pkg", "packagesite.yaml").decode()
+    objs = [json.loads(ln) for ln in raw.splitlines() if ln]
+    assert len(objs) == 1
+    assert objs[0]["path"] == "pfb-3.2.16.pkg"
+    assert objs[0]["repopath"] == "pfb-3.2.16.pkg"
 
 
 # --------------------------------------------------------------------------- #
@@ -356,11 +385,11 @@ def test_rebuild_wipes_removed_pkg(tmp_path: Path) -> None:
     make_pkg(in_dir / "b-1.0.pkg", name="b")
     out = tmp_path / "out"
     brp.build_repo(in_dir, out)
-    assert (out / "FreeBSD:15:amd64" / "b-1.0.pkg").is_file()
+    assert (out / "FreeBSD:15:amd64" / "b-1.0_1.pkg").is_file()  # canonical <name>-<version>
     # Remove one input and rebuild.
     (in_dir / "b-1.0.pkg").unlink()
     brp.build_repo(in_dir, out)
-    assert not (out / "FreeBSD:15:amd64" / "b-1.0.pkg").exists(), "stale .pkg lingered after rebuild"
+    assert not (out / "FreeBSD:15:amd64" / "b-1.0_1.pkg").exists(), "stale .pkg lingered after rebuild"
     raw = _read_member(out / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml").decode()
     assert [json.loads(ln)["name"] for ln in raw.splitlines() if ln] == ["a"]
 


### PR DESCRIPTION
## Clean up the published `pkg` catalog (canonical names + dedup)

The first live GitHub Pages deploy of the ADR-17 repo (PR #141) surfaced a messy catalog:

1. **Staging prefix leaked into the published filenames.** `repo-publish.yml` copies each input `.pkg` into `store/` with a `built-<source>-` prefix (to avoid basename collisions between the branch build and release artifacts), and the generators published the `.pkg` under that *staging* filename — so the live catalog served `built-incoming_branch-pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg`.
2. **The same package was published twice.** The job stages from three `incoming/` dirs; the same build arriving from two sources produced two catalog entries for one name+version+ABI.

Both served `200` and a `pkg install` would still function, but the catalog wasn't clean.

### Fix

Both generators now publish **one `.pkg` per (name, version, ABI)**, named **canonically** (`<name>-<version>.pkg`), independent of the staging input filename:

- **`scripts/build-repo-portable.py`** (primary, pure-Python): bucket-dedup by `(name, version)` — keep the first, log the drop — and write/catalog the `.pkg` under the canonical name.
- **`scripts/build-repo.sh`** (FreeBSD-VM fallback): copy under `${nv}.pkg` so an identical name+version overwrites to a single file (dedup) before `pkg repo`.

A different-flavor same-name+version+ABI clash is still hard-rejected by the existing collision guard.

### Tests

- New `test_duplicate_sources_dedup_to_one_canonical` pins the exact `built-incoming_*` two-source → one-canonical case.
- The bucketing / rebuild tests now assert the canonical published name (`<name>-<version>.pkg`) instead of the staging input filename.

Default suite 1379 passed; ruff/mypy/markdownlint/shellcheck/shellspec clean. After this merges I'll re-deploy and re-verify the live catalog is clean, then flip ADR-17 Status → Accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package repository building now deduplicates identical packages with matching name and version, retaining a single canonical copy and emitting deduplication notices.
  * Repository building is now deterministic, producing consistent results across multiple builds through sorted, canonical naming.

* **Tests**
  * Added tests to verify deduplication behavior and canonical package naming in repository builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->