### PR TITLE
pfblockerng: break IDN Confusable help onto two lines

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2454,7 +2454,7 @@ $section->addInput(new Form_Select(
 ))->setHelp('IDN handling (not Regex based).<ul>'
 		. '<li><strong>Off</strong> - no IDN action.</li>'
 		. '<li><strong>Confusable</strong> - block only cross-script homoglyphs (Latin/Cyrillic/Greek mixes, '
-		. 'including Cyrillic+Greek). Does not catch whole-script confusables or pure-ASCII typosquats.</li>'
+		. 'including Cyrillic+Greek).<br />Does not catch whole-script confusables or pure-ASCII typosquats.</li>'
 		. '<li><strong>Always</strong> - block every IDN/\'xn--\' domain (blunt).</li></ul>');
 
 $section->addInput(new Form_Checkbox(


### PR DESCRIPTION
Tiny UI text tweak on the DNSBL "IDN Blocking" help: a `<br />` after "…Cyrillic+Greek)." so the "Does not catch whole-script confusables or pure-ASCII typosquats." caveat renders on its own line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of the IDN Blocking → Confusable option help text for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->