### PR TITLE
ci: anchor the nightly repo-smoke gate on the last successful run

### DIFF
--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -37,8 +37,9 @@ permissions:
   packages: read
 
 jobs:
-  # On a `schedule`, run only if `devel` got a commit in the lookback window — skip an
-  # otherwise-wasted ~15-min VM run when nothing changed. A manual dispatch always runs.
+  # On a `schedule`, run only if `devel` got a commit since the last SUCCESSFUL run of
+  # this workflow — skip an otherwise-wasted ~15-min VM run when nothing changed, while
+  # a failed/missed nightly's commits stay in scope next time. A manual dispatch always runs.
   gate:
     name: Gate (skip nightly if devel unchanged)
     runs-on: ubuntu-latest
@@ -55,15 +56,25 @@ jobs:
             echo "Event '${{ github.event_name }}' — always runs."
             exit 0
           fi
-          # 25h lookback (> the 24h cron interval, a margin against scheduler jitter).
-          since="$(date -u -d '25 hours ago' '+%Y-%m-%dT%H:%M:%SZ')"
+          # Anchor on the LAST SUCCESSFUL run of THIS workflow on this branch — NOT a
+          # fixed window: a failed or dropped nightly then never lets its commits age
+          # out unvalidated, since the anchor only advances when a run actually
+          # succeeded. (A skip-run also "succeeds", but harmlessly — it only happens
+          # when nothing changed.) No prior success (first run) -> run unconditionally.
+          since="$(gh run list --workflow=repo-install.yml --branch="${{ github.ref_name }}" \
+                     --status=success --limit 1 --json createdAt --jq '.[0].createdAt // ""')"
+          if [ -z "$since" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "No prior successful run — running (bootstrap)."
+            exit 0
+          fi
           n="$(gh api "repos/${{ github.repository }}/commits?sha=${{ github.ref_name }}&since=${since}" --jq 'length')"
           if [ "${n:-0}" -gt 0 ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "${n} commit(s) to ${{ github.ref_name }} since ${since} — running the nightly repo smoke."
+            echo "${n} commit(s) to ${{ github.ref_name }} since the last successful run (${since}) — running."
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No commits to ${{ github.ref_name }} since ${since} — skipping the nightly repo smoke."
+            echo "::notice::No commits to ${{ github.ref_name }} since the last successful run (${since}) — skipping."
           fi
 
   repo-install:


### PR DESCRIPTION
Refines #147's gate per review: anchor the nightly's change-check on the createdAt of the last **successful** `repo-install` run instead of a fixed 25h window.

Why: `now-25h` only equals "since the last nightly" when every nightly completes. A **failed** run (smoke red / infra) or a **dropped/delayed** GitHub schedule lets commits older than 25h age out of the window **unvalidated**. Anchoring on the last success means a failed run doesn't advance the anchor, so its commits are re-checked next run; a skip-run (gate found no commits) concludes `success` but is a harmless anchor (only happens when nothing changed); the first run with no prior success runs unconditionally. Manual dispatch still always runs.

YAML parses; actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated workflow scheduling efficiency. The system now performs intelligent run-skipping when there are no new commits since the last successful execution, reducing unnecessary resource consumption. Manual triggers continue to execute immediately, while scheduled runs only proceed when code changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->