### PR TITLE
fix: info.xml <name> must be the prefix-stripped pfSense registration name

### DIFF
--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -200,8 +200,10 @@ class Makefile:
 
     @staticmethod
     def _apply_mods(val: str, mods: str) -> str:
-        # Minimal :H (dirname), :T (basename), :R (root), :E (ext). Enough for the
-        # recipes we run; extend if a port starts using more.
+        # Minimal :H (dirname), :T (basename), :R (root), :E (ext), and :S/old/new/[g]
+        # (string substitution — used to strip the pfSense-pkg- prefix for the info.xml
+        # registration <name>). Enough for the recipes we run; extend if a port needs more.
+        # Split on ':' but keep an :S/.../.../ group intact (its body has no ':').
         for mod in mods.split(":"):
             if mod == "H":
                 val = os.path.dirname(val)
@@ -211,6 +213,27 @@ class Makefile:
                 val = os.path.splitext(val)[0]
             elif mod == "E":
                 val = os.path.splitext(val)[1].lstrip(".")
+            elif mod.startswith("S") and len(mod) >= 4:
+                # :S<delim>old<delim>new<delim>[1g]  (make string substitution). Supports
+                # a leading ^ / trailing $ anchor in <old> and the g (global) flag.
+                delim = mod[1]
+                parts = mod[2:].split(delim)
+                if len(parts) >= 2:
+                    old, new = parts[0], parts[1]
+                    flags = parts[2] if len(parts) > 2 else ""
+                    anchor_start, anchor_end = old.startswith("^"), old.endswith("$")
+                    pat = old[1:] if anchor_start else old
+                    pat = pat[:-1] if anchor_end else pat
+                    if not pat:
+                        pass
+                    elif "g" in flags and not (anchor_start or anchor_end):
+                        val = val.replace(pat, new)
+                    elif anchor_start and val.startswith(pat):
+                        val = new + val[len(pat) :]
+                    elif anchor_end and val.endswith(pat):
+                        val = val[: -len(pat)] + new
+                    elif not (anchor_start or anchor_end):
+                        val = val.replace(pat, new, 1)
         return val
 
     def get(self, name: str, default: str = "") -> str:

--- a/tests/smoke/test_install_hook.py
+++ b/tests/smoke/test_install_hook.py
@@ -1,0 +1,119 @@
+"""The rc.packages install-hook MUST succeed (info.xml <name> regression guard).
+
+Closes a false-pass: ``test_repo_install.py`` only checks files-landed / ``%R`` /
+deps, never whether ``rc.packages`` (``install_package_xml``) actually SUCCEEDED.
+A regression had templated ``info.xml <name>`` to the FULL ``${PORTNAME}``
+(``pfSense-pkg-pfBlockerNG-devel``), but pfSense looks it up by the
+``pfSense-pkg-``-PREFIX-STRIPPED name (``get_package_id``) — so the full name made
+the hook ABORT ("The pfBlockerNG-devel package is not installed. Installation
+aborted."), leaving the menu/config UNregistered while DNSBL (wired from the
+on-disk python module) still worked. Netgate ships the SHORT ``<name>``; the fix
+(``${PORTNAME:S/pfSense-pkg-//}``) restores it. This test ships the branch
+``.pkg`` to the guest, installs it, and asserts the hook ran the FULL pfBlockerNG
+install with NO abort.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from .conftest import SmokeVM
+
+pytestmark = pytest.mark.repo
+
+_ABORT_PHRASES = ("is not installed", "Installation aborted", "Failed to install package")
+_SUCCESS_PHRASES = ("Executing custom_php_install_command", "Menu items")
+
+_REMOTE_PKG = "/tmp/pfb-hook-verify.pkg"
+
+# One self-contained script over STDIN (ssh_argv is unquoted — never `sh -c "A; B"`).
+# The .pkg is scp'd to a fixed path first; derive its registered NAME from the file so
+# the clean-slate delete + the final cleanup target the right package regardless of
+# channel (-devel / -nightly / stable).
+_HOOK_SH = r"""
+set -u
+P=/tmp/pfb-hook-verify.pkg
+echo "PKG=$P"
+NAME=$(pkg query -F "$P" %n 2>/dev/null)
+echo "NAME=$NAME"
+# Clean slate so the rc.packages POST-INSTALL hook runs FRESH (ignore errors).
+env ASSUME_ALWAYS_YES=yes pkg delete -y "$NAME" >/dev/null 2>&1 || true
+sleep 2
+echo "=== pkg add (runs rc.packages POST-INSTALL) ==="
+env ASSUME_ALWAYS_YES=yes pkg add "$P" 2>&1
+echo "rc=$?"
+# Leave the VM clean for the repo-install module (which expects the pkg ABSENT).
+env ASSUME_ALWAYS_YES=yes pkg delete -y "$NAME" >/dev/null 2>&1 || true
+"""
+
+
+def _scp_to_guest(vm: SmokeVM, local: Path, remote: str, *, timeout: float = 120.0) -> None:
+    """Copy a local file to the guest via ``scp`` (mirrors test_repo_install)."""
+    argv = [
+        "scp",
+        "-i",
+        vm.ssh_key_path,
+        "-P",
+        str(vm.ssh_port),
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "BatchMode=yes",
+        str(local),
+        f"{vm.ssh_target}:{remote}",
+    ]
+    result = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"scp {local} -> {remote} failed: rc={result.returncode} {result.stderr!r}")
+
+
+@pytest.mark.timeout(600)
+def test_install_hook_succeeds(smoke_vm: SmokeVM) -> None:
+    """The branch install runs the full pfBlockerNG setup hook (no abort).
+
+    Scenario: a fresh install of the branch .pkg.
+      Given the short-name info.xml fix (ports + the builder :S modifier),
+      When ``pkg add`` of the branch .pkg runs rc.packages POST-INSTALL,
+      Then the hook SUCCEEDS — it runs custom_php_install_command + registers the
+        menu (NO "is not installed"/"Installation aborted"/"Failed to install").
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    if not pkg or not Path(pkg).is_file():
+        pytest.skip("SMOKE_PKG not set / not a file — no built .pkg to install")
+    assert pkg  # for the type-checker: pytest.skip above is NoReturn
+    vm = smoke_vm
+    _scp_to_guest(vm, Path(pkg), _REMOTE_PKG)
+
+    r = subprocess.run(
+        vm.ssh_argv("/bin/sh"),
+        input=_HOOK_SH,
+        capture_output=True,
+        text=True,
+        timeout=540,
+        check=False,
+    )
+    out = r.stdout
+    subprocess.run(
+        vm.ssh_argv("/usr/bin/tee", "/var/log/pfb_install_hook_verify.txt"),
+        input=out,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    print("\n\n##### ADR-18 INSTALL-HOOK VERIFY #####\n" + out + "\n#####\n")
+
+    assert "NAME=pfSense-pkg-pfBlockerNG" in out, f"branch .pkg not queryable on the VM:\n{out}"
+    aborted = [p for p in _ABORT_PHRASES if p in out]
+    assert not aborted, (
+        f"rc.packages install hook ABORTED ({aborted}) — the full-name info.xml regression "
+        f"is NOT fixed (get_package_id looks up the prefix-stripped name):\n{out}"
+    )
+    ran = [p for p in _SUCCESS_PHRASES if p in out]
+    assert ran, f"the install hook did not run the full pfBlockerNG setup:\n{out}"

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -527,3 +527,24 @@ def test_end_to_end_plist_drift_aborts(tmp_path: Path) -> None:
     )
     assert rc == 1
     assert not list(out.glob("*.pkg")) if out.exists() else True
+
+
+@pytest.mark.parametrize(
+    "val, mods, expected",
+    [
+        # :S/old/new/ — the post-extract recipe uses ${PORTNAME:S/pfSense-pkg-//} to
+        # template info.xml's <name> to the SHORT (prefix-stripped) registration name.
+        # That is the name rc.packages (install_package_xml -> get_package_id) looks up;
+        # the FULL ${PORTNAME} aborts the install hook (live-VM proven — Netgate ships the
+        # short name; our fork had regressed to the full one). The builder must evaluate
+        # :S so it reproduces the make-package recipe faithfully.
+        ("pfSense-pkg-pfBlockerNG-devel", "S/pfSense-pkg-//", "pfBlockerNG-devel"),
+        ("pfSense-pkg-pfBlockerNG", "S/pfSense-pkg-//", "pfBlockerNG"),
+        ("pfSense-pkg-pfBlockerNG-devel", "S/^pfSense-pkg-//", "pfBlockerNG-devel"),  # ^ anchor
+        ("aXbXc", "S/X/-/g", "a-b-c"),  # g (global) flag
+        ("no-match", "S/zzz/q/", "no-match"),  # no occurrence → unchanged
+        ("/usr/local/share/x.txt", "T", "x.txt"),  # pre-existing :T still works
+    ],
+)
+def test_makefile_apply_mods_substitution(val: str, mods: str, expected: str) -> None:
+    assert bpp.Makefile._apply_mods(val, mods) == expected


### PR DESCRIPTION
## Fix: `info.xml <name>` must be the prefix-stripped pfSense registration name

### Problem (a shipped regression on `-devel`/`-stable`)

Our fork's `post-extract` recipe templated `info.xml`'s `<name>` to the **full**
`${PORTNAME}` (e.g. `pfSense-pkg-pfBlockerNG-devel`). But pfSense's `rc.packages`
(`install_package_xml` → `get_package_id`) looks the package up by the
**`pfSense-pkg-`-prefix-stripped** name. The full name therefore made the install
hook **abort**:

```text
The pfBlockerNG-devel package is not installed. Installation aborted.
```

…leaving the **menu/config unregistered**. DNSBL still worked (it's wired from the
on-disk Python module, independent of the hook), which is why this went unnoticed.
Netgate ships the **short** `<name>`.

### Fix (two repos)

1. **FreeBSD-ports** (both Makefiles, already on the CI build ref
   `pfBlockerNG/FreeBSD-ports@pfblockerng/use-github`): the `post-extract` `sed`
   now emits `${PORTNAME:S/pfSense-pkg-//}`.
2. **This repo** — `scripts/build-pkg-portable.py`: teach the recipe evaluator
   make's `:S/old/new/[g]` string substitution (+ `^`/`$` anchors) so the portable
   builder reproduces that recipe faithfully; otherwise the portable `.pkg` keeps
   the full name. Unit-pinned in `tests/test_build_pkg_portable.py`.

### Guard

`tests/smoke/test_install_hook.py` (marker `repo`) installs the branch `.pkg` on a
live pfSense VM and asserts the `rc.packages` POST-INSTALL hook ran the **full**
pfBlockerNG setup (`custom_php_install_command` + menu registration) with **no**
abort phrase — closing the false-pass where the existing repo-install checks
(files-landed / `%R` / deps) missed the silent hook abort.

### Scope

This is a **universal correctness fix** — it repairs the shipped `-devel`/`-stable`
install hook and is **independent of the nightly-channel work (ADR-18)**, which now
follows as a separate PR built on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
