### PR TITLE
ci: resolve the smoke image from SMOKE_IMAGE_REPO/NAME/TAG vars

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -32,11 +32,10 @@ name: Build pfSense CE image (ADR-04 P2)
 #                       read:packages (verify pull)
 #   SMOKE_SSH_PRIV_KEY  guest SSH private key; its public half is     (secret)
 #                       baked into the image's root authorized_keys
-#   SMOKE_IMAGE         GHCR image ref WITHOUT tag (var or secret;    (var/secret)
-#                       default ghcr.io/<owner>/pfsense-ce)
-#   SMOKE_IMAGE_REF     verify-only fallback: the seed/base OCI ref   (var/secret)
-#                       by digest, used when verifying without a freshly
-#                       published :version tag.
+#   SMOKE_IMAGE_REPO    GHCR namespace, e.g. ghcr.io/pfblockerng      (variable)
+#                       (default ghcr.io/<owner-lowercased>); the untagged image
+#                       is ${SMOKE_IMAGE_REPO}/${SMOKE_IMAGE_NAME}.
+#   SMOKE_IMAGE_NAME    image name appended to it (default pfsense-ce) (variable)
 
 on:
   workflow_dispatch:
@@ -210,11 +209,15 @@ jobs:
       - name: Resolve the GHCR image ref
         id: ref
         env:
-          SMOKE_IMAGE: ${{ secrets.SMOKE_IMAGE || vars.SMOKE_IMAGE }}
+          SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
+          SMOKE_IMAGE_NAME: ${{ vars.SMOKE_IMAGE_NAME }}
         run: |
           set -eu
-          # Default to ghcr.io/<owner>/pfsense-ce when SMOKE_IMAGE is unset.
-          IMAGE="${SMOKE_IMAGE:-ghcr.io/${GITHUB_REPOSITORY_OWNER}/pfsense-ce}"
+          # Compose the untagged image from the namespace + name vars (org-transfer
+          # scheme; one namespace, many images). Fallback: lowercased owner —
+          # GHCR/OCI refs MUST be lowercase (a literal pfBlockerNG owner would 400).
+          REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
+          IMAGE="${REPO%/}/${SMOKE_IMAGE_NAME:-pfsense-ce}"
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
           echo "publishing target: ${IMAGE}:${{ inputs.pfsense_ce_version }}"
 
@@ -226,13 +229,13 @@ jobs:
         # the secret), waits for the new version, powers off, compresses, and
         # pushes the new tag. The source tag is left untouched (snapshot kept).
         env:
-          SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
           SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
           SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER }}
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_TOKEN }}
         run: |
           set -eu
           sh scripts/image-upgrade.sh \
+            --image "${{ steps.ref.outputs.image }}" \
             --from "${{ inputs.from_version }}" \
             --to "${{ inputs.pfsense_ce_version }}" \
             --compression "${{ inputs.compression }}" \
@@ -305,10 +308,12 @@ jobs:
       - name: Resolve the GHCR image ref
         id: ref
         env:
-          SMOKE_IMAGE: ${{ secrets.SMOKE_IMAGE || vars.SMOKE_IMAGE }}
+          SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
+          SMOKE_IMAGE_NAME: ${{ vars.SMOKE_IMAGE_NAME }}
         run: |
           set -eu
-          IMAGE="${SMOKE_IMAGE:-ghcr.io/${GITHUB_REPOSITORY_OWNER}/pfsense-ce}"
+          REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
+          IMAGE="${REPO%/}/${SMOKE_IMAGE_NAME:-pfsense-ce}"
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
 
       - name: Pull the freshly published image from private GHCR

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -31,8 +31,10 @@ name: CI image refresh (ADR-09 P5)
 #   SMOKE_GHCR_USER     username for `oras login ghcr.io`                  (secret)
 #   SMOKE_GHCR_TOKEN    token with write:packages (publish) / read:packages (secret)
 #   SMOKE_SSH_PRIV_KEY  guest SSH private key baked into the image          (secret)
-#   SMOKE_IMAGE         GHCR image ref WITHOUT tag (var or secret;          (var/secret)
-#                       default ghcr.io/<owner>/pfsense-ce)
+#   SMOKE_IMAGE_REPO    GHCR namespace, e.g. ghcr.io/pfblockerng            (variable)
+#                       (default ghcr.io/<owner-lowercased>); the untagged image
+#                       is ${SMOKE_IMAGE_REPO}/${SMOKE_IMAGE_NAME}.
+#   SMOKE_IMAGE_NAME    image name appended to it (default pfsense-ce)        (variable)
 #
 # INVARIANT: this workflow NEVER writes to main/devel/next or any channel branch.
 # It writes ONLY to GHCR (packages). The tracker dispatches it; it publishes or fails.
@@ -188,10 +190,14 @@ jobs:
       - name: Resolve the GHCR image ref
         id: ref
         env:
-          SMOKE_IMAGE: ${{ secrets.SMOKE_IMAGE || vars.SMOKE_IMAGE }}
+          SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
+          SMOKE_IMAGE_NAME: ${{ vars.SMOKE_IMAGE_NAME }}
         run: |
           set -eu
-          IMAGE="${SMOKE_IMAGE:-ghcr.io/${GITHUB_REPOSITORY_OWNER}/pfsense-ce}"
+          # Compose the untagged image from the namespace + name vars (org-transfer
+          # scheme). Fallback: lowercased owner (GHCR refs MUST be lowercase).
+          REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
+          IMAGE="${REPO%/}/${SMOKE_IMAGE_NAME:-pfsense-ce}"
           printf 'image=%s\n' "$IMAGE" >> "$GITHUB_OUTPUT"
           printf 'Image base ref: %s\n' "$IMAGE"
 

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -24,7 +24,11 @@ on:
   workflow_dispatch:
     inputs:
       image_ref:
-        description: "GHCR pfSense CE image ref (blank = SMOKE_IMAGE_REF secret/variable). Pin by @sha256:<digest>."
+        description: "Full GHCR image ref override (blank = compose from the SMOKE_IMAGE_REPO/NAME/TAG vars). Pin by @sha256:<digest>."
+        required: false
+        default: ""
+      pfsense_version:
+        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Ignored when image_ref is set."
         required: false
         default: ""
   schedule:
@@ -83,5 +87,6 @@ jobs:
     uses: ./.github/workflows/smoke.yml
     with:
       image_ref: ${{ inputs.image_ref }}
+      pfsense_version: ${{ inputs.pfsense_version }}
       pytest_marker: repo
     secrets: inherit

--- a/.github/workflows/smoke-fanout.yml
+++ b/.github/workflows/smoke-fanout.yml
@@ -103,13 +103,10 @@ jobs:
   # whether another leg has already failed.
   #
   # IMAGE REF RESOLUTION:
-  # The CI matrix entry carries pfsense_version (e.g. "2.8.x").  The GHCR
-  # image tag for that version is:
-  #   ghcr.io/<owner>/pfsense-ce:<pfsense_version>
-  # The SMOKE_IMAGE_REF secret/variable used by smoke.yml can be overridden
-  # per-leg via the `image_ref` input — we pass the version-specific tag here.
-  # If SMOKE_IMAGE_BASE_URL is set (org/repo variable), that base is used;
-  # otherwise it defaults to the repository owner's GHCR namespace.
+  # The CI matrix entry carries pfsense_version (e.g. "2.8.x"). We pass it to
+  # smoke.yml as `pfsense_version`; smoke.yml composes the GHCR ref from the
+  # SMOKE_IMAGE_REPO / SMOKE_IMAGE_NAME / SMOKE_IMAGE_TAG repo variables, with
+  # pfsense_version overriding the tag.
   smoke:
     name: Smoke (${{ matrix.pfsense_version }})
     needs: prepare
@@ -121,12 +118,11 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.ci_matrix) }}
     uses: ./.github/workflows/smoke.yml
     with:
-      # Construct the per-version GHCR image ref.
-      # Format: ghcr.io/<owner>/pfsense-ce:<pfsense_version>
-      # e.g.   ghcr.io/myorg/pfsense-ce:2.8.x
-      # The smoke.yml callee falls back to SMOKE_IMAGE_REF secret/variable when
-      # image_ref is blank; passing a version-specific tag here overrides that.
-      image_ref: "ghcr.io/${{ github.repository_owner }}/pfsense-ce:${{ matrix.pfsense_version }}"
+      # Pass only the per-leg version; smoke.yml composes the ref from the
+      # SMOKE_IMAGE_{REPO,NAME,TAG} vars (pfsense_version overrides the tag). This
+      # keeps the namespace/name in one place (the repo vars) instead of hardcoding
+      # ghcr.io/<owner>/pfsense-ce here.
+      pfsense_version: ${{ matrix.pfsense_version }}
     secrets: inherit
 
   # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,11 +22,13 @@ name: Smoke (pfSense VM, ADR-04)
 # single-version, parameterised callee.
 #
 # Required config (Actions secrets/variables — see RESULTS/02_Results.txt):
-#   SMOKE_IMAGE_REF      private GHCR OCI ref of the qcow2, ideally by digest,
-#                        e.g. ghcr.io/<org>/pfsense-ce@sha256:<digest>. Accepted
-#                        as a repo/org *variable* OR *secret* (not sensitive; a
-#                        secret wins if both are set). Overridable per-run via
-#                        the image_ref input.
+#   SMOKE_IMAGE_REPO     GHCR namespace (variable), e.g. ghcr.io/pfblockerng
+#                        (default ghcr.io/<owner-lowercased>).
+#   SMOKE_IMAGE_NAME     image name appended to it (variable, default pfsense-ce).
+#   SMOKE_IMAGE_TAG      default tag (variable, default 2.8.1). The pull ref is
+#                        ${SMOKE_IMAGE_REPO}/${SMOKE_IMAGE_NAME}:${SMOKE_IMAGE_TAG};
+#                        the image_ref input (full ref) or pfsense_version input
+#                        (tag) override it.
 #   SMOKE_GHCR_USER      username for `oras login ghcr.io` (secret)
 #   SMOKE_GHCR_TOKEN     PAT/token with read:packages for the GHCR pull (secret)
 #   SMOKE_SSH_PRIV_KEY   private SSH key; matching public key is baked into the
@@ -39,7 +41,11 @@ on:
   workflow_dispatch:
     inputs:
       image_ref:
-        description: "GHCR pfSense CE image ref (blank = SMOKE_IMAGE_REF secret/variable). Pin by @sha256:<digest>."
+        description: "Full GHCR image ref override (blank = compose from the SMOKE_IMAGE_REPO/NAME/TAG vars). Pin by @sha256:<digest>."
+        required: false
+        default: ""
+      pfsense_version:
+        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Ignored when image_ref is set."
         required: false
         default: ""
       pytest_marker:
@@ -49,7 +55,12 @@ on:
   workflow_call:
     inputs:
       image_ref:
-        description: "GHCR pfSense CE image ref (blank = SMOKE_IMAGE_REF secret/variable)."
+        description: "Full GHCR image ref override (blank = compose from the SMOKE_IMAGE_REPO/NAME/TAG vars)."
+        required: false
+        type: string
+        default: ""
+      pfsense_version:
+        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Ignored when image_ref is set."
         required: false
         type: string
         default: ""
@@ -114,22 +125,31 @@ jobs:
           # Harmless for the default `smoke` marker (the helper just isn't called).
           sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils openssh-client python3 python3-pip python3-venv zstd
 
-      - name: Resolve the pfSense image ref (input overrides secret/variable)
+      - name: Resolve the pfSense image ref (image_ref input overrides the SMOKE_IMAGE_* vars)
         id: ref
         env:
-          # The image ref is not sensitive: accept it as a variable, falling
-          # back-compatibly to a secret if one is set (secret wins). The
-          # workflow input wins over both, for ADR-09's per-version callers.
+          # image_ref input (full ref) wins. Otherwise compose from the
+          # SMOKE_IMAGE_{REPO,NAME,TAG} repo vars; the pfsense_version input (the
+          # per-version caller, e.g. smoke-fanout) overrides the TAG. None are
+          # sensitive, so they are variables, not secrets.
           INPUT_REF: ${{ inputs.image_ref }}
-          SMOKE_IMAGE_REF: ${{ secrets.SMOKE_IMAGE_REF || vars.SMOKE_IMAGE_REF }}
+          INPUT_VERSION: ${{ inputs.pfsense_version }}
+          SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
+          SMOKE_IMAGE_NAME: ${{ vars.SMOKE_IMAGE_NAME }}
+          SMOKE_IMAGE_TAG: ${{ vars.SMOKE_IMAGE_TAG }}
         run: |
           set -eu
-          REF="${INPUT_REF:-${SMOKE_IMAGE_REF:-}}"
-          if [ -z "$REF" ]; then
-            echo "::error::no image ref (set the image_ref input, or the SMOKE_IMAGE_REF secret/variable)"
-            exit 1
+          if [ -n "$INPUT_REF" ]; then
+            REF="$INPUT_REF"
+          else
+            # Fallback for REPO: lowercased owner (GHCR refs MUST be lowercase).
+            REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
+            NAME="${SMOKE_IMAGE_NAME:-pfsense-ce}"
+            TAG="${INPUT_VERSION:-${SMOKE_IMAGE_TAG:-2.8.1}}"
+            REF="${REPO%/}/${NAME}:${TAG}"
           fi
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "resolved image ref: ${REF}"
 
       - name: Install oras
         uses: oras-project/setup-oras@v2

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -36,8 +36,9 @@ name: UI tests (pfSense VM, ADR-14)
 #
 # Required config (Actions secrets/variables) — same set as smoke.yml, plus the
 # baked admin password the UI tier needs to log in:
-#   SMOKE_IMAGE_REF      GHCR OCI ref of the qcow2 (variable OR secret; secret wins;
-#                        input overrides both). Pin by @sha256:<digest>.
+#   SMOKE_IMAGE_REPO/_NAME/_TAG  compose the GHCR ref (variables): the pull ref is
+#                        ${SMOKE_IMAGE_REPO}/${SMOKE_IMAGE_NAME}:${SMOKE_IMAGE_TAG};
+#                        the image_ref input (full ref) or version input (tag) override it.
 #   SMOKE_GHCR_USER      username for `oras login ghcr.io` (secret)
 #   SMOKE_GHCR_TOKEN     PAT/token with read:packages for the GHCR pull (secret)
 #   SMOKE_SSH_PRIV_KEY   private SSH key matching the image's baked authorized_keys (secret)
@@ -52,7 +53,7 @@ on:
   workflow_call:
     inputs:
       image_ref:
-        description: "GHCR pfSense CE image ref (blank = SMOKE_IMAGE_REF secret/variable)."
+        description: "Full GHCR image ref override (blank = compose from the SMOKE_IMAGE_REPO/NAME/TAG vars; `version` sets the tag)."
         required: false
         type: string
         default: ""
@@ -69,11 +70,11 @@ on:
   workflow_dispatch:
     inputs:
       image_ref:
-        description: "GHCR pfSense CE image ref (blank = SMOKE_IMAGE_REF secret/variable). Pin by @sha256:<digest>."
+        description: "Full GHCR image ref override (blank = compose from the SMOKE_IMAGE_REPO/NAME/TAG vars; `version` sets the tag). Pin by @sha256:<digest>."
         required: false
         default: ""
       version:
-        description: "Version label for the matrix leg / screenshot dir (blank = the default CE version)."
+        description: "Version label for the matrix leg / screenshot dir AND the image tag (blank = the default CE version)."
         required: false
         default: ""
       tier:
@@ -244,22 +245,30 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils openssh-client python3 python3-pip python3-venv
 
-      - name: Resolve the pfSense image ref (input overrides secret/variable)
+      - name: Resolve the pfSense image ref (image_ref input overrides the SMOKE_IMAGE_* vars)
         id: ref
         env:
-          # The image ref is not sensitive: accept it as a variable, falling
-          # back to a secret if one is set (secret wins). The workflow input
-          # wins over both. Same resolution order as smoke.yml.
+          # image_ref input (full ref) wins; else compose from the
+          # SMOKE_IMAGE_{REPO,NAME,TAG} repo vars, with the `version` input
+          # overriding the TAG. Same resolution as smoke.yml.
           INPUT_REF: ${{ inputs.image_ref }}
-          SMOKE_IMAGE_REF: ${{ secrets.SMOKE_IMAGE_REF || vars.SMOKE_IMAGE_REF }}
+          INPUT_VERSION: ${{ inputs.version }}
+          SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
+          SMOKE_IMAGE_NAME: ${{ vars.SMOKE_IMAGE_NAME }}
+          SMOKE_IMAGE_TAG: ${{ vars.SMOKE_IMAGE_TAG }}
         run: |
           set -eu
-          REF="${INPUT_REF:-${SMOKE_IMAGE_REF:-}}"
-          if [ -z "$REF" ]; then
-            echo "::error::no image ref (set the image_ref input, or the SMOKE_IMAGE_REF secret/variable)"
-            exit 1
+          if [ -n "$INPUT_REF" ]; then
+            REF="$INPUT_REF"
+          else
+            # Fallback for REPO: lowercased owner (GHCR refs MUST be lowercase).
+            REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
+            NAME="${SMOKE_IMAGE_NAME:-pfsense-ce}"
+            TAG="${INPUT_VERSION:-${SMOKE_IMAGE_TAG:-2.8.1}}"
+            REF="${REPO%/}/${NAME}:${TAG}"
           fi
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "resolved image ref: ${REF}"
 
       - name: Install oras
         uses: oras-project/setup-oras@v2

--- a/scripts/image-publish.sh
+++ b/scripts/image-publish.sh
@@ -33,8 +33,9 @@
 # Options:
 #   --vmid N         Proxmox VM id (default: 103)
 #   --disk KEY       disk config key to export (default: scsi0)
-#   --image REF      GHCR image ref without tag
-#                    (default: $SMOKE_IMAGE or ghcr.io/andrebrait/pfsense-ce)
+#   --image REF      GHCR image ref without tag (default composed from the
+#                    SMOKE_IMAGE_REPO + SMOKE_IMAGE_NAME env vars:
+#                    ${SMOKE_IMAGE_REPO:-ghcr.io/pfblockerng}/${SMOKE_IMAGE_NAME:-pfsense-ce})
 #   --compression T  qcow2 compression: zstd | zlib | off (default: zstd)
 #   --out FILE       local working qcow2 path (default: a temp file, removed after)
 #   --keep           keep the local qcow2 after publishing
@@ -52,7 +53,10 @@ die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 VMID=103
 DISK=scsi0
-IMAGE="${SMOKE_IMAGE:-ghcr.io/andrebrait/pfsense-ce}"
+# Compose the untagged image ref from the namespace + name vars (org-transfer
+# scheme; supports pfsense-ce, pfsense-plus, … under one namespace). --image overrides.
+IMAGE="${SMOKE_IMAGE_REPO:-ghcr.io/pfblockerng}"
+IMAGE="${IMAGE%/}/${SMOKE_IMAGE_NAME:-pfsense-ce}"
 COMPRESSION=zstd
 OUT=""
 KEEP=0

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -38,8 +38,9 @@
 # Options:
 #   --from VERSION   current published tag to upgrade (required)
 #   --to VERSION     tag to publish as (default: auto-detected from the upgraded box)
-#   --image REF      GHCR image ref without tag
-#                    (default: $SMOKE_IMAGE or ghcr.io/andrebrait/pfsense-ce)
+#   --image REF      GHCR image ref without tag (default composed from the
+#                    SMOKE_IMAGE_REPO + SMOKE_IMAGE_NAME env vars:
+#                    ${SMOKE_IMAGE_REPO:-ghcr.io/pfblockerng}/${SMOKE_IMAGE_NAME:-pfsense-ce})
 #   --ssh-key PATH   GUEST SSH private key (default: $SMOKE_SSH_KEY) — its public
 #                    half is baked into the image's root authorized_keys
 #   --ssh-port N     Proxmox-local port forwarded to the guest's :22 (default: 2222)
@@ -68,7 +69,10 @@ die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 FROM=""
 TO=""
-IMAGE="${SMOKE_IMAGE:-ghcr.io/andrebrait/pfsense-ce}"
+# Compose the untagged image ref from the namespace + name vars (org-transfer
+# scheme; supports pfsense-ce, pfsense-plus, … under one namespace). --image overrides.
+IMAGE="${SMOKE_IMAGE_REPO:-ghcr.io/pfblockerng}"
+IMAGE="${IMAGE%/}/${SMOKE_IMAGE_NAME:-pfsense-ce}"
 GUEST_KEY="${SMOKE_SSH_KEY:-}"
 GUEST_PORT=2222
 MAC="BC:24:11:37:9C:AC"


### PR DESCRIPTION
## What

Org-transfer fallout for the **smoke-VM GHCR image**. The image moved to
`ghcr.io/pfblockerng/pfsense-ce` (private) and `SMOKE_IMAGE_REF` was dropped, so
this consolidates image-ref resolution onto **three repo variables**:

| var | meaning | default |
| --- | --- | --- |
| `SMOKE_IMAGE_REPO` | GHCR namespace | `ghcr.io/<owner-lowercased>` |
| `SMOKE_IMAGE_NAME` | image name appended | `pfsense-ce` |
| `SMOKE_IMAGE_TAG` | default tag | `2.8.1` |

Ref = `${SMOKE_IMAGE_REPO}/${SMOKE_IMAGE_NAME}:${SMOKE_IMAGE_TAG}`. Scales to
`pfsense-plus` later (one namespace, many images). Repo vars are already set.

## Changes

- **Pull side** (`smoke.yml`, `ui-tests.yml`, `repo-install.yml`): `image_ref`
  input stays a full-ref override; otherwise compose, with the `pfsense_version`
  (smoke/repo-install) / `version` (ui-tests) input overriding the tag.
  `smoke-fanout.yml` now passes `pfsense_version` instead of a hand-built ref.
- **Build side** (`build-image.yml`, `image-refresh.yml`, `scripts/image-upgrade.sh`,
  `scripts/image-publish.sh`): compose the untagged image from `REPO`/`NAME`.
- **OCI casing fix**: the `REPO` fallback lowercases the owner — a literal
  `ghcr.io/pfBlockerNG/...` is rejected by GHCR (refs must be lowercase).
- `build-image.yml` now passes `--image` to `image-upgrade.sh` (the script no
  longer reads the removed `SMOKE_IMAGE` env).

## Validation

`actionlint` clean on all 6 workflows; `shellcheck`/`sh -n` clean on both scripts;
`python -m pytest` unaffected. No `src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
