### PR TITLE
smoke: fix SafeSearch CNAME test isolation (force recursive resolver)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -873,6 +873,38 @@ def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
         )
 
 
+def use_recursive_resolver(vm: SmokeVM, *, timeout: float = 120.0) -> None:
+    """Force Unbound into RECURSIVE mode (forwarding OFF), undoing any prior
+    :func:`use_system_dns_upstream` left on the SHARED session VM by another module.
+
+    The SafeSearch CNAME redirect (issue #149) needs recursion: it plants the
+    ``orig -> CNAME -> target`` in the cache and restarts the iterator to chase the
+    target, but a catch-all ``forward-zone: "."`` (what use_system_dns_upstream
+    installs) RE-FORWARDS the source name on MODULE_RESTART_NEXT, so the chase never
+    runs. Recursive is also pfSense's default and what the #1 mechanism targets.
+    Calling this in the SafeSearch fixture makes that smoke order-independent in the
+    full ``-m smoke`` matrix (where a matrix module may have set forwarding first).
+
+    Idempotent; written + ``services_unbound_configure`` (which restarts Unbound).
+    pfBlockerNG's own reloads never call services_unbound_configure, so this base
+    config survives the later inject()/reload().
+    """
+    snippet = (
+        "$u = config_get_path('unbound', array());\n"
+        "unset($u['forwarding']);\n"  # recursive (no upstream forward)
+        "unset($u['custom_options']);\n"  # drop any leftover forward-zone
+        "config_set_path('unbound', $u);\n"
+        "write_config('pfBlockerNG smoke: recursive resolver (forwarding off)');\n"
+        "services_unbound_configure();\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"use_recursive_resolver failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+    # services_unbound_configure restarts Unbound — wait for it before any probe.
+    wait_unbound_ready(vm)
+
+
 # --------------------------------------------------------------------------- #
 # Update hooks (ADR-12) — pre/post command hooks fired from the update pass
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/test_smoke_safesearch.py
+++ b/tests/smoke/test_smoke_safesearch.py
@@ -57,6 +57,10 @@ def safesearch_vm(smoke_vm: SmokeVM) -> Iterator[tuple[SmokeVM, h.DnsAnswer, h.D
     h.deploy(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
     h.unblock_egress()  # recursive resolution for the chase + the BEFORE probe
+    # Force recursive mode: a prior matrix module on the SHARED VM may have set
+    # use_system_dns_upstream (catch-all forward-zone), which re-forwards the source
+    # name on the iterator restart and defeats the cache-planted chase (issue #149).
+    h.use_recursive_resolver(smoke_vm)
 
     # Enable DNSBL (so the python module is loaded) with a dummy local feed. SafeSearch
     # is still OFF here, so the CNAME names resolve to their real sites.


### PR DESCRIPTION
## Summary

Test-only follow-up to #152 (issue #149). The SafeSearch CNAME smoke passed in isolation (`-m safesearch`) but **failed in the full `-m smoke` matrix** — an order-dependence I introduced.

`test_smoke_matrix`'s `deployed_vm` fixture calls `use_system_dns_upstream` on the **shared session VM**, installing a catch-all `forward-zone: "."`. On `MODULE_RESTART_NEXT` the iterator **re-forwards the source name** to the stub instead of chasing the cache-planted CNAME, so the redirect never runs (both `duckduckgo.com` and `safe.duckduckgo.com` collapse to the stub's `203.0.113.99`). My `safesearch_vm` fixture only *stopped calling* `use_system_dns_upstream`; it didn't *undo* a forward config left by an earlier module.

## Fix

- `helpers.use_recursive_resolver()` — unset `unbound/forwarding` (+ stray `custom_options`) + `services_unbound_configure` → recursive mode. pfBlockerNG's own reloads never call `services_unbound_configure`, so this base config survives the later `inject()`/`reload()`.
- The `safesearch_vm` fixture calls it, making the redirect smoke **order-independent** in the full matrix.

No production change. The #1 chase itself is unaffected (proven green in #152).

## Validation

Will dispatch the full `-m smoke` matrix on this branch and confirm green before merge.
