### PR TITLE
pfblockerng: validate domains before the DNSBL C-cache flush exec

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4510,7 +4510,7 @@ function pfb_unbound_py_ccache_flush_cmds($names, $chroot_cmd) {
 	$seen = array();
 	foreach ($names as $name) {
 		// Drop anything that is not a valid domain BEFORE it can reach the command.
-		$name = pfb_filter(trim((string) $name), PFB_FILTER_DOMAIN, 'pfb_ccache_flush');
+		$name = pfb_filter(trim((string) $name), PFB_FILTER_DOMAIN, 'pfb_unbound_py_ccache_flush_cmds');
 		if (empty($name)) {
 			continue;
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4490,20 +4490,28 @@ function pfb_unbound_py_mode_active() {
 // Coalesced into ONE chroot unbound-control session and gated behind the DNSBL-queries
 // daemon's '.sync' suppression marker (touched by pfb_update_unbound / the fast path) so
 // the flush does not collide with the daemon on the control socket.
-function pfb_unbound_py_ccache_flush($names) {
-	global $pfb;
-
+// Build the coalesced unbound-control C-cache flush command list for the newly-blocked
+// names. Each name is VALIDATED as a domain via pfb_filter() (issue #153) before it can be
+// interpolated into a command: a non-domain / shell-metachar entry is DROPPED, never
+// reaching the exec() in pfb_unbound_py_ccache_flush() -- defence in depth atop the
+// escapeshellarg() below (the names already arrive PFB_FILTER_DOMAIN-filtered from the
+// alerts page, but this choke point must not trust its input). Returns the full command
+// strings (chroot_cmd-prefixed, each variant escapeshellarg'd), de-duplicated across each
+// name + its 'www.' sibling. Pure (no globals / side effects) so every branch is
+// unit-testable off-appliance (the exec lives in the wrapper below).
+function pfb_unbound_py_ccache_flush_cmds($names, $chroot_cmd) {
+	$cmds = array();
 	if (!is_array($names) || empty($names)) {
-		return;
+		return $cmds;
 	}
 
 	// One control session: flush each name + its 'www.' sibling (the alerts unlock path
 	// flushes the same pair) so the prior resolved A/AAAA cannot keep serving.
-	$cmds = array();
 	$seen = array();
 	foreach ($names as $name) {
-		$name = trim((string) $name);
-		if ($name === '') {
+		// Drop anything that is not a valid domain BEFORE it can reach the command.
+		$name = pfb_filter(trim((string) $name), PFB_FILTER_DOMAIN, 'pfb_ccache_flush');
+		if (empty($name)) {
 			continue;
 		}
 		foreach (array($name, "www.{$name}") as $variant) {
@@ -4511,10 +4519,17 @@ function pfb_unbound_py_ccache_flush($names) {
 				continue;
 			}
 			$seen[$variant] = TRUE;
-			$cmds[] = "{$pfb['chroot_cmd']} flush " . escapeshellarg($variant) . ' 2>&1';
+			$cmds[] = "{$chroot_cmd} flush " . escapeshellarg($variant) . ' 2>&1';
 		}
 	}
 
+	return $cmds;
+}
+
+function pfb_unbound_py_ccache_flush($names) {
+	global $pfb;
+
+	$cmds = pfb_unbound_py_ccache_flush_cmds($names, $pfb['chroot_cmd']);
 	if (empty($cmds)) {
 		return;
 	}

--- a/tests/php/CcacheFlushCmdsTest.php
+++ b/tests/php/CcacheFlushCmdsTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_unbound_py_ccache_flush_cmds() — issue #153.
+ *
+ * Builds the unbound-control C-cache flush command list for the allow->block delta
+ * (a #51 alert Lock / custom-list edit). Extracted from pfb_unbound_py_ccache_flush()
+ * so the validation + de-dup branches are covered off-appliance (the exec() side of the
+ * wrapper is the live-VM smoke's job, ADR-04).
+ *
+ * Scenario: a newly-blocked name is flushed from the resolver cache via exec().
+ *   Background: each name is interpolated into a `<chroot> flush <name> 2>&1` command.
+ *   Rule (the #153 fix): a name reaches the command ONLY if pfb_filter() accepts it as a
+ *     domain (PFB_FILTER_DOMAIN). escapeshellarg() is the second layer; validation is the
+ *     first — a non-domain / shell-metachar entry is DROPPED, never built into a command.
+ */
+#[CoversFunction('pfb_unbound_py_ccache_flush_cmds')]
+final class CcacheFlushCmdsTest extends TestCase
+{
+	/** The chroot_cmd is opaque to the builder — a fixed sentinel keeps expectations exact. */
+	private const CC = 'CHROOT';
+
+	private function cmds(array $names): array
+	{
+		return pfb_unbound_py_ccache_flush_cmds($names, self::CC);
+	}
+
+	private function flush(string $variant): string
+	{
+		// Mirror the production framing so the test pins the exact emitted command,
+		// including the escapeshellarg() second layer.
+		return self::CC . ' flush ' . escapeshellarg($variant) . ' 2>&1';
+	}
+
+	public function testValidDomainBuildsTheNameAndWwwPair(): void
+	{
+		// When a valid domain is passed
+		$out = $this->cmds(['example.com']);
+
+		// Then exactly its name + 'www.' sibling are flushed, each escapeshellarg'd.
+		$this->assertSame(
+			[$this->flush('example.com'), $this->flush('www.example.com')],
+			$out
+		);
+	}
+
+	public function testValidDomainKeepsCase(): void
+	{
+		// pfb_filter(PFB_FILTER_DOMAIN) preserves case (htmlspecialchars is a no-op on
+		// the valid domain charset) — the flush target must match what was resolved.
+		$out = $this->cmds(['Example.COM']);
+		$this->assertSame(
+			[$this->flush('Example.COM'), $this->flush('www.Example.COM')],
+			$out
+		);
+	}
+
+	/** @return array<string, array{0: string}> label => malicious/invalid name */
+	public static function rejectedProvider(): array
+	{
+		return [
+			'shell semicolon'   => ['evil.com; reboot'],
+			'command sub'       => ['$(reboot).com'],
+			'backtick'          => ['`id`.com'],
+			'pipe'              => ['a.com | nc x 1'],
+			'space'             => ['ex ample.com'],
+			'no dot (hostname)' => ['localhost'],
+			'double dot'        => ['bad..com'],
+			'plus char'         => ['ex+ample.com'],
+			'newline'           => ["a.com\nrm -rf /"],
+		];
+	}
+
+	/**
+	 * The core #153 assertion: a name pfb_filter() rejects yields NO command at all.
+	 *
+	 * Before the fix the loop only trim()'d + escapeshellarg()'d, so EVERY one of these
+	 * still produced a (shell-safe but pointless) flush command. The validation is what
+	 * drops them — proven by the contrast with the valid-domain cases above.
+	 */
+	#[DataProvider('rejectedProvider')]
+	public function testInvalidNameProducesNoCommand(string $name): void
+	{
+		$this->assertSame([], $this->cmds([$name]));
+	}
+
+	public function testInvalidIsDroppedButValidInTheSameListSurvives(): void
+	{
+		// Given a mix of one valid domain and several rejected names
+		$out = $this->cmds(['good.com', 'bad.com; rm -rf /', 'localhost', '']);
+
+		// Then ONLY the valid domain's pair is built — the bad entries are dropped, not
+		// merely neutralised, and they do not suppress the good one.
+		$this->assertSame(
+			[$this->flush('good.com'), $this->flush('www.good.com')],
+			$out
+		);
+	}
+
+	public function testWwwSiblingIsDeDuplicatedAcrossNames(): void
+	{
+		// Given a name and its explicit 'www.' form, the shared 'www.example.com' variant
+		// must be emitted once (coalesced single control session).
+		$out = $this->cmds(['example.com', 'www.example.com']);
+
+		$this->assertSame(
+			[
+				$this->flush('example.com'),
+				$this->flush('www.example.com'),
+				$this->flush('www.www.example.com'),
+			],
+			$out
+		);
+	}
+
+	public function testExactDuplicateNameCollapses(): void
+	{
+		// The same name twice must not double the commands.
+		$this->assertSame(
+			[$this->flush('example.com'), $this->flush('www.example.com')],
+			$this->cmds(['example.com', 'example.com'])
+		);
+	}
+
+	/** @return array<string, array{0: mixed}> label => empty/degenerate input */
+	public static function emptyProvider(): array
+	{
+		return [
+			'empty array'    => [[]],
+			'all rejected'   => [['localhost', 'no-dot']],
+			'whitespace only' => [['   ']],
+		];
+	}
+
+	#[DataProvider('emptyProvider')]
+	public function testNoBuildableNamesYieldsEmptyList(array $names): void
+	{
+		$this->assertSame([], $this->cmds($names));
+	}
+
+	public function testNonArrayIsSafe(): void
+	{
+		// The wrapper passes through whatever it received; the builder must not warn.
+		$this->assertSame([], pfb_unbound_py_ccache_flush_cmds('not-an-array', self::CC));
+	}
+}


### PR DESCRIPTION
## What

`pfb_unbound_py_ccache_flush()` interpolates the newly-blocked domain names
(the allow→block delta from a #51 alert Lock / custom-list edit) into an
`unbound-control flush <name>` command run via `exec()`. The names were only
`escapeshellarg()`'d at that point — never validated at the choke point that
builds the command.

This extracts a pure `pfb_unbound_py_ccache_flush_cmds($names, $chroot_cmd)`
that runs each name through `pfb_filter($name, PFB_FILTER_DOMAIN, ...)` first,
**dropping** any non-domain / shell-metachar entry before it can reach the
command — defence in depth atop the existing `escapeshellarg()`, and safe for
any future caller of this helper.

Today's two callers in `pfblockerng_alerts.php` already `pfb_filter()` the
domain before passing it, so this is a hardening of the exec-building choke
point per the issue, not a live exploit fix. All other behaviour is unchanged
(the `www.` sibling, de-duplication across the coalesced control session, the
empty/non-array guard).

## Why a pure helper

The validation lives where the command is built, and extracting it makes every
branch unit-testable off-appliance (the repo idiom — cf. `pfb_dnsbl_unlock_action`).
The `exec()` stays in the thin wrapper (live-VM smoke territory, ADR-04).

## Tests

`tests/php/CcacheFlushCmdsTest.php` (18 cases): a valid domain builds the
`name` + `www.` pair (case-preserving, `escapeshellarg`'d); every rejected
class (`; reboot`, `$(...)`, backtick, pipe, space, newline, no-dot,
double-dot, `+`) yields **no** command; a bad entry is dropped without
suppressing a valid sibling in the same list; `www.` de-dup; empty / all-rejected
/ non-array inputs → empty list.

Full PHPUnit 204/204, PHPStan clean.

Closes #153.
