### PR TITLE
smoke: cover SafeSearch CNAME redirect in recursive + forwarding mode (#149)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -873,34 +873,47 @@ def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
         )
 
 
-def use_recursive_resolver(vm: SmokeVM, *, timeout: float = 120.0) -> None:
-    """Force Unbound into RECURSIVE mode (forwarding OFF), undoing any prior
-    :func:`use_system_dns_upstream` left on the SHARED session VM by another module.
+def set_unbound_forwarding(vm: SmokeVM, on: bool, *, upstream: str = "1.1.1.1", timeout: float = 120.0) -> None:
+    """Set Unbound to RECURSIVE (``on=False``) or FORWARDING (``on=True``) mode.
 
-    The SafeSearch CNAME redirect (issue #149) needs recursion: it plants the
-    ``orig -> CNAME -> target`` in the cache and restarts the iterator to chase the
-    target, but a catch-all ``forward-zone: "."`` (what use_system_dns_upstream
-    installs) RE-FORWARDS the source name on MODULE_RESTART_NEXT, so the chase never
-    runs. Recursive is also pfSense's default and what the #1 mechanism targets.
-    Calling this in the SafeSearch fixture makes that smoke order-independent in the
-    full ``-m smoke`` matrix (where a matrix module may have set forwarding first).
+    Toggles ``unbound/forwarding`` while holding the System DNS server CONSTANT
+    (``system/dnsserver = [upstream]``) and DNSSEC OFF, so a recursive-vs-forwarding
+    comparison of the SafeSearch CNAME redirect (issue #149) varies exactly one thing.
+    ``on=False`` = recursive (the constant dnsserver is then unused); ``on=True`` =
+    forward every query to ``upstream`` (a REAL resolver — the redirect chase then
+    resolves the real SafeSearch target, unlike the mock stub which answers every name
+    identically and would mask the result).
 
-    Idempotent; written + ``services_unbound_configure`` (which restarts Unbound).
-    pfBlockerNG's own reloads never call services_unbound_configure, so this base
-    config survives the later inject()/reload().
+    The redirect works in BOTH modes (the iterator checks the message cache — where the
+    module plants the CNAME — before forwarding or recursing; the chase then forwards/
+    recurses the TARGET). Forcing the mode in the SafeSearch fixture only makes the
+    smoke order-independent on the SHARED session VM (a prior matrix module may have
+    set use_system_dns_upstream's catch-all forward-to-stub, which masks the result by
+    answering every name identically).
+
+    Idempotent; written + ``services_unbound_configure`` (restarts Unbound). NOTE: that
+    regenerates the base unbound.conf WITHOUT pfBlockerNG's python module, so the caller
+    MUST run a pfBlockerNG reload afterwards to re-add the module + reload safeSearchDB.
     """
     snippet = (
+        "$s = config_get_path('system', array());\n"
+        f"$s['dnsserver'] = array({_php_str(upstream)});\n"
+        "unset($s['dnsallowoverride']);\n"
+        "config_set_path('system', $s);\n"
         "$u = config_get_path('unbound', array());\n"
-        "unset($u['forwarding']);\n"  # recursive (no upstream forward)
+        + ("$u['forwarding'] = 'on';\n" if on else "unset($u['forwarding']);\n")
+        + "unset($u['dnssec']);\n"  # held OFF in both states (unsigned upstream answers)
         "unset($u['custom_options']);\n"  # drop any leftover forward-zone
         "config_set_path('unbound', $u);\n"
-        "write_config('pfBlockerNG smoke: recursive resolver (forwarding off)');\n"
+        "write_config('pfBlockerNG smoke: set unbound forwarding');\n"
         "services_unbound_configure();\n"
         "echo 'OK';"
     )
     result = php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(f"use_recursive_resolver failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+        raise RuntimeError(
+            f"set_unbound_forwarding({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
     # services_unbound_configure restarts Unbound — wait for it before any probe.
     wait_unbound_ready(vm)
 

--- a/tests/smoke/test_smoke_safesearch.py
+++ b/tests/smoke/test_smoke_safesearch.py
@@ -10,13 +10,17 @@ the iterator so the iterator chases the target (working around NLnetLabs/unbound
 hop is not bogus. A #2 baked-IP fallback (resolved at list-build, kept fresh by the
 15-min cron) answers if the chase ever yields no address.
 
-This is the make-or-break gate for the #1 live-chase mechanism, which can only be
-proven on a real Unbound. The resolver runs RECURSIVE (pfSense's default and what
-the chase targets) — deliberately NOT use_system_dns_upstream, whose catch-all
-``forward-zone: "."`` re-forwards the SOURCE name on the iterator restart and
-defeats the cache-planted chase. The chase therefore resolves the real
-``safe.duckduckgo.com`` / ``safesearch.pixabay.com`` (unsigned in DNS, so no DNSSEC
-angle), and the test asserts ``duckduckgo.com`` ends up at that same address.
+Run in BOTH resolver modes (the fixture is parametrized on ``unbound/forwarding``):
+RECURSIVE and FORWARDING to a real upstream. The redirect works in both — the
+iterator checks the message cache (where the module plants the CNAME) before it
+forwards/recurses, then chases the TARGET. Forwarding uses a REAL upstream so the
+SafeSearch target resolves to its own distinct address (the mock stub answers every
+name identically and would mask the result; that — NOT a broken chase — is why the
+smoke must not run against the stub). Targets are unsigned in DNS, so no DNSSEC angle.
+
+The slow per-mode setup (Unbound reconfigure + pfBlockerNG reloads) lives in the
+FIXTURE, so the 30s per-test-body cap (smoke.yml: ``timeout_func_only``) does not bite
+and no per-test timeout override is needed.
 
 Probed ON-BOX (``drill @127.0.0.1``); SafeSearch redirects have no localhost
 exemption, so the redirect shows there.
@@ -42,77 +46,89 @@ PIX_TARGET = "safesearch.pixabay.com"
 
 
 @pytest.fixture(scope="module")
-def safesearch_vm(smoke_vm: SmokeVM) -> Iterator[tuple[SmokeVM, h.DnsAnswer, h.DnsAnswer]]:
-    """Deploy, enable DNSBL + SafeSearch (recursive resolver), capture the BEFORE answers.
-
-    Egress stays OPEN: the resolver is recursive, so the redirect chase resolves the
-    real SafeSearch target, and the SafeSearch-off BEFORE probe resolves the real site.
-
-    Yields ``(vm, ddg_before, pix_before)`` — the pre-redirect answers, so each test
-    proves the redirect CHANGED them.
-    """
+def _ss_deployed(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """One-time deploy + DNSBL VIP (shared by both resolver-mode parametrizations)."""
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
-
     h.deploy(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
-    h.unblock_egress()  # recursive resolution for the chase + the BEFORE probe
-    # Force recursive mode: a prior matrix module on the SHARED VM may have set
-    # use_system_dns_upstream (catch-all forward-zone), which re-forwards the source
-    # name on the iterator restart and defeats the cache-planted chase (issue #149).
-    h.use_recursive_resolver(smoke_vm)
+    yield smoke_vm
 
-    # Enable DNSBL (so the python module is loaded) with a dummy local feed. SafeSearch
-    # is still OFF here, so the CNAME names resolve to their real sites.
-    feed = h.write_local_feed(smoke_vm, "smoke_ss_dummy.txt", f"{h.unique_domain('ssdummy')}\n")
+
+@pytest.fixture(scope="module", params=[False, True], ids=["recursive", "forwarding"])
+def safesearch_vm(
+    _ss_deployed: SmokeVM, request: pytest.FixtureRequest
+) -> Iterator[tuple[SmokeVM, bool, h.DnsAnswer, h.DnsAnswer]]:
+    """Enable DNSBL + SafeSearch in one resolver mode; capture the pre-redirect answers.
+
+    Parametrized on ``forwarding`` — the ONLY difference between the two runs is
+    ``unbound/forwarding`` off (recursive) vs on (forward to a real upstream). Egress
+    stays open so both recursion and the real-upstream forward resolve. All reloads are
+    here in the fixture (not the test body), so no per-test timeout override is needed.
+
+    Yields ``(vm, forwarding_on, ddg_before, pix_before)`` — the SafeSearch-off answers,
+    so each test proves the redirect CHANGED them.
+    """
+    vm = _ss_deployed
+    forwarding_on: bool = request.param
+    h.unblock_egress()
+
+    # The single toggled variable. services_unbound_configure here regenerates the base
+    # unbound.conf WITHOUT pfBlockerNG's python module; the reloads below re-add it.
+    h.set_unbound_forwarding(vm, on=forwarding_on)
+
+    # Enable DNSBL (python module loaded) with a dummy local feed; SafeSearch still OFF,
+    # so the CNAME names resolve to their real sites for the BEFORE capture.
+    feed = h.write_local_feed(vm, "smoke_ss_dummy.txt", f"{h.unique_domain('ssdummy')}\n")
     spec = h.DnsblCase(aliasname="smokess", feed_url=feed, header="smokess")
-    h.set_safesearch_enabled(smoke_vm, False)
-    h.inject(smoke_vm, spec)
-    h.reload(smoke_vm, "update")
+    h.set_safesearch_enabled(vm, False)
+    h.inject(vm, spec)
+    h.reload(vm, "update")
 
-    ddg_before = h.dns_probe(smoke_vm, DDG, "A")
-    pix_before = h.dns_probe(smoke_vm, PIX, "A")
+    ddg_before = h.dns_probe(vm, DDG, "A")
+    pix_before = h.dns_probe(vm, PIX, "A")
 
     # WHEN: enable SafeSearch and rebuild -> the redirect rows enter pfb_py_ss.txt and
     # pfb_unbound.py reloads safeSearchDB on the unbound restart (issue #149 forces the
     # restart, since the data swap alone does not reload safeSearchDB).
-    h.set_safesearch_enabled(smoke_vm, True)
-    h.reload(smoke_vm, "update")
+    h.set_safesearch_enabled(vm, True)
+    h.reload(vm, "update")
     # The BEFORE probe cached the real site answer; clear it so the AFTER probe is
-    # evaluated fresh through the module (belt-and-braces; the config-change reload
-    # already restarts Unbound).
-    h.flush_unbound_cache(smoke_vm)
+    # evaluated fresh through the module (belt-and-braces; the reload already restarted).
+    h.flush_unbound_cache(vm)
 
     try:
-        yield smoke_vm, ddg_before, pix_before
+        yield vm, forwarding_on, ddg_before, pix_before
     finally:
         h.unblock_egress()
-        h.collect_host_diagnostics(smoke_vm)
+        h.collect_host_diagnostics(vm)
 
 
 def test_safesearch_cname_redirect_takes_effect(
-    safesearch_vm: tuple[SmokeVM, h.DnsAnswer, h.DnsAnswer],
+    safesearch_vm: tuple[SmokeVM, bool, h.DnsAnswer, h.DnsAnswer],
 ) -> None:
     """The gate: enabling SafeSearch REDIRECTS duckduckgo.com away from its real site.
 
     When SafeSearch is enabled, Then the on-box answer becomes a clean NOERROR with
     records, is NOT a SERVFAIL (which would mean the synthesized hop went
     DNSSEC-bogus), and DIFFERS from the SafeSearch-off baseline — the redirect took
-    effect.
+    effect. Asserted in BOTH recursive and forwarding mode (the fixture parametrization).
     """
-    vm, ddg_before, _ = safesearch_vm
+    vm, forwarding_on, ddg_before, _ = safesearch_vm
 
     after = h.dns_probe(vm, DDG, "A")
-    assert after.rcode != "SERVFAIL", f"{DDG} SERVFAIL after redirect (synthesized hop went bogus?) — {after}"
-    assert after.rcode == "NOERROR" and after.records, f"{DDG} should still resolve after redirect, got {after}"
+    assert after.rcode != "SERVFAIL", f"[forwarding={forwarding_on}] {DDG} SERVFAIL after redirect — {after}"
+    assert after.rcode == "NOERROR" and after.records, (
+        f"[forwarding={forwarding_on}] {DDG} should still resolve after redirect, got {after}"
+    )
     assert set(after.records) != set(ddg_before.records), (
-        f"{DDG} answer unchanged by SafeSearch — redirect did not take effect "
-        f"(before={ddg_before.records}, after={after.records})"
+        f"[forwarding={forwarding_on}] {DDG} answer unchanged by SafeSearch — redirect did not take "
+        f"effect (before={ddg_before.records}, after={after.records})"
     )
 
 
 def test_safesearch_cname_chase_reaches_target(
-    safesearch_vm: tuple[SmokeVM, h.DnsAnswer, h.DnsAnswer],
+    safesearch_vm: tuple[SmokeVM, bool, h.DnsAnswer, h.DnsAnswer],
 ) -> None:
     """#1 live chase: duckduckgo.com resolves to safe.duckduckgo.com's own address.
 
@@ -121,17 +137,18 @@ def test_safesearch_cname_chase_reaches_target(
     comparing duckduckgo.com's answer to a direct lookup of safe.duckduckgo.com: the
     chase populated the target's cache entry, so the direct lookup is a cache hit and
     the two share an address (rotation-proof). A second CNAME name (pixabay) shows the
-    redirect is general, not duckduckgo-special.
+    redirect is general, not duckduckgo-special. Asserted in BOTH recursive and
+    forwarding mode (the fixture parametrization).
     """
-    vm, _, _ = safesearch_vm
+    vm, forwarding_on, _, _ = safesearch_vm
 
     for name, target in ((DDG, DDG_TARGET), (PIX, PIX_TARGET)):
         redirected = h.dns_probe(vm, name, "A")
         assert redirected.rcode == "NOERROR" and redirected.records, (
-            f"{name} did not resolve after redirect: {redirected}"
+            f"[forwarding={forwarding_on}] {name} did not resolve after redirect: {redirected}"
         )
         target_ans = h.dns_probe(vm, target, "A")  # cache hit from the chase above
         assert set(redirected.records) & set(target_ans.records), (
-            f"{name} should resolve to {target}'s address (CNAME chase); "
+            f"[forwarding={forwarding_on}] {name} should resolve to {target}'s address (CNAME chase); "
             f"{name}={redirected.records} vs {target}={target_ans.records}"
         )

--- a/tests/smoke/test_smoke_safesearch.py
+++ b/tests/smoke/test_smoke_safesearch.py
@@ -139,6 +139,12 @@ def test_safesearch_cname_chase_reaches_target(
     the two share an address (rotation-proof). A second CNAME name (pixabay) shows the
     redirect is general, not duckduckgo-special. Asserted in BOTH recursive and
     forwarding mode (the fixture parametrization).
+
+    This asserts the OUTCOME — the queried name resolves to the safe target's address —
+    which the #1 live chase satisfies and (were it ever to fail) the #2 baked fallback
+    would too; the assertion does not distinguish them. That the #1 chase specifically
+    fires in BOTH modes was confirmed during bring-up via the module's phase log trace
+    (issue #149), not re-derived here.
     """
     vm, forwarding_on, _, _ = safesearch_vm
 
@@ -148,6 +154,9 @@ def test_safesearch_cname_chase_reaches_target(
             f"[forwarding={forwarding_on}] {name} did not resolve after redirect: {redirected}"
         )
         target_ans = h.dns_probe(vm, target, "A")  # cache hit from the chase above
+        assert target_ans.records, (
+            f"[forwarding={forwarding_on}] {target} did not resolve (expected the chase cache hit): {target_ans}"
+        )
         assert set(redirected.records) & set(target_ans.records), (
             f"[forwarding={forwarding_on}] {name} should resolve to {target}'s address (CNAME chase); "
             f"{name}={redirected.records} vs {target}={target_ans.records}"


### PR DESCRIPTION
## Summary

Follow-up to #149. Verifies — and adds regression coverage for — the SafeSearch CNAME redirect in **forwarding** mode, not just recursive.

A live-VM experiment (DBG trace) confirmed the #1 cache-plant chase fires identically with `unbound/forwarding` **off and on**: `phase1 plant → phase2 OK chased → address` in both. The iterator checks the message cache (where the module plants the CNAME) *before* it forwards/recurses, then chases the target. The earlier forwarding-mode "failure" was the mock stub answering every name with the same IP (masking source vs target) — **not** a broken chase.

## Changes (test-only)

- **Consolidate** `use_recursive_resolver` (added in #156, whose docstring wrongly claimed a forward-zone "defeats the chase") into one accurate helper `set_unbound_forwarding(on)` — toggles only `unbound/forwarding`, holding the System DNS server + DNSSEC constant.
- **Parametrize** the `safesearch_vm` fixture on `[recursive, forwarding]` so both redirect tests (`takes_effect`, `chase_reaches_target`) run in **each mode** (4 tests). Forwarding uses a real upstream so the target has a distinct address.
- All reloads stay in the fixture, so the 30s test-body cap (`timeout_func_only`) needs **no** override.

## Validation

Will dispatch the focused `-m safesearch` smoke (now 4 tests, both modes) and confirm green before merge.
