### PR TITLE
ADR-18: opt-in nightly pkg build channel (pfSense-pkg-pfBlockerNG-nightly)

### DIFF
--- a/.ADRs/ADR_18_Nightly_Channel/ADR.md
+++ b/.ADRs/ADR_18_Nightly_Channel/ADR.md
@@ -1,6 +1,7 @@
 # ADR-18: Publish a nightly `pkg` build channel
 
-- **Status:** **Proposed** (2026-06-06)
+- **Status:** **Implemented** (2026-06-06; pending the post-merge live `…/nightly`
+  Pages deploy + the gated live-URL leg — see §7)
 - **Date:** 2026-06-06
 - **Branch:** `adr/18-nightly-channel` (off **`devel`**; `{slug}` = sanitised
   ADR-title slug per CLAUDE.md "Branch naming") / **Component(s):** dev-only
@@ -23,6 +24,49 @@
   `tests/smoke` tree is `--ignore`d in default collection). No `pytest` oracle for
   the CI YAML itself → validation = `shellcheck`/`sh -n` + the **live-VM `repo`
   smoke** (§7), which is also the ADR-01-style **kill-gate**.
+
+---
+
+## 0. AS-BUILT — design corrections (authoritative; supersede the Proposed text below)
+
+The Phase-1 live-VM kill-gate (and a deep follow-up) overturned three premises the
+Proposed text below still states. The implementation follows THIS section; the
+original prose is retained for the decision record.
+
+- **The distinct `-nightly` rename is a DEEP package rename, not a "single-field"
+  one (§1.3 is wrong), and it was the blocker — resolved by a real bug fix.** The
+  pfSense registration name lives in `info.xml <name>`, which `rc.packages`
+  (`install_package_xml` → `get_package_id`) looks up by the **`pfSense-pkg-`-prefix-
+  stripped** name. Our fork had regressed `<name>` to the FULL `${PORTNAME}` → the
+  install hook ABORTED ("…is not installed. Installation aborted."), which also broke
+  the shipped `-devel`/`-stable` hook. **Fix (PR #151, landed): the post-extract sed
+  emits `${PORTNAME:S/pfSense-pkg-//}` (short name) + the portable builder evaluates
+  make's `:S`.** With that, a dedicated **`net/pfSense-pkg-pfBlockerNG-nightly` port**
+  cascades the whole rename from `PORTNAME` (manifest `name`, the `share/<name>/`
+  dir, the short `info.xml <name>`, the `%%PORTNAME%%` rc.packages hook args) — the
+  same machinery `-devel`/`-stable` use.
+- **NO `conflicts` manifest key (§1.4 / §2 "Conflicts" / Phase 2 are wrong) —
+  file-overlap only.** An explicit `conflicts:` array naming an un-installed sibling
+  **crashes CE libpkg** (`pkgdb.c:1892`, exact-name NULL). `-nightly` and the release
+  packages install the SAME `src/` paths, so they mutually exclude + replace cleanly
+  by **file overlap** alone (the portable builder emits no `conflicts` key). The
+  builder gained `--channel nightly` + `--pkgversion`/`--annotate`, NOT `--conflicts`.
+- **Version = pkg-safe `<target>.YYYYMMDD.N` (not a bare date; §1.5 / §2 refined),
+  pretty string in metadata.** Distinct name ⇒ compared nightly-to-nightly only; the
+  comparable version is `.`-separated, no `-` (e.g. `3.2.16.20260606.7`, target = the
+  `-nightly` port PORTVERSION, `.N` = the publish run number). The source commit rides
+  a manifest **annotation + the COMMENT** (`pkg info -A`), never the version.
+- **Hosting is the SEPARATE `pfBlockerNG/pkg` repo's `publish.yml` (§1.6 / §2
+  "Hosting" are pre-org-transfer).** Post-transfer, that repo self-deploys the unified
+  Pages site at `pfblockerng.github.io/pkg`; the nightly is a `nightly/${ABI}` subtree
+  built there (stateless, one deploy) — not an extension of this repo's
+  `repo-publish.yml`, and not `andrebrait.github.io`.
+
+**As-built surface:** `net/pfSense-pkg-pfBlockerNG-nightly` (FreeBSD-ports); builder
+`--channel nightly` + `--pkgversion`/`--annotate` + unit oracle; `add-repo.sh nightly`
+(+ README) → `nightly/${ABI}` conf; `pfBlockerNG/pkg` `publish.yml` nightly subtree;
+the live-VM `repo`-marker smoke `tests/smoke/test_nightly_install.py`
+(install+hook+provenance / file-overlap replace both directions / monotonic upgrade).
 
 ---
 
@@ -130,11 +174,11 @@ with pre-releases as the durable store in place of Releases. Users opt in with
 
 | Area | Decision |
 | --- | --- |
-| **Package identity** | A **separate package name** `pfSense-pkg-pfBlockerNG-NIGHTLY` (single-field override of `PORTNAME` — Context 3), **built from the `-devel` port** (identical recipe/plist/deps). A separate name means its version is compared **only nightly-to-nightly**, so a bare date orders correctly and it never shadows a release by version (Context 5). |
-| **Version** | **`YYYYMMDD`** (UTC build date); a same-day rebuild appends **`.HHMMSS`** (UTC) → monotonic, stateless, no counter to track. The comparable version contains **no `-` and no hash** (Context 5). New `--pkgversion` builder override (CI passes the date). |
+| **Package identity** | *(§0)* A **separate, lowercase package** `pfSense-pkg-pfBlockerNG-nightly` from a **dedicated `-nightly` port** (mirrors `-devel`). This is a **DEEP rename** cascaded from `PORTNAME` (manifest `name`, `share/<name>/` dir, the **short** `info.xml <name>` via `${PORTNAME:S/pfSense-pkg-//}`, the `%%PORTNAME%%` hook args) — NOT a single field. Enabled by the `info.xml` short-name fix (PR #151). A separate name means its version is compared only nightly-to-nightly. |
+| **Version** | *(§0)* **`<target>.YYYYMMDD.N`** — pkg-safe + monotonic (`.`-separated, **no `-`**), e.g. `3.2.16.20260606.7` (target = the `-nightly` port PORTVERSION; date dominates; `.N` = the publish run number breaks same-day ties). New `--pkgversion` builder override (CI passes it). The pretty string + commit ride a manifest **annotation + COMMENT** (`pkg info -A`), never the version. |
 | **Commit provenance** | The source `devel` HEAD sha rides as a **manifest annotation** `commit=<sha>` (already-supported `annotations` dict, Context 4) + appended to the package **COMMENT**; surfaced by `pkg info -A pfSense-pkg-pfBlockerNG-NIGHTLY`. **Not** in the version, **not** in the `.pkg` filename (ADR-17 canonical `<name>-<version>.pkg` + dedup is preserved). New repeatable `--annotate K=V` builder override. |
-| **Conflicts** | Emit an explicit **`conflicts: [pfSense-pkg-pfBlockerNG, pfSense-pkg-pfBlockerNG-devel]`** in the nightly manifest (new `conflicts` key, Context 4) — a *named* conflict + clean replace prompt **on top of** the file-overlap conflict the three packages already share. New repeatable `--conflicts <glob>` builder override (default empty → release builds unchanged). |
-| **Hosting (forced by Context 6)** | **Unify into ADR-17's `repo-publish.yml`** — one Pages deploy emits **both** `…/${ABI}/` (release, over Releases) **and** `…/nightly/${ABI}/` (nightly, over the last-14 nightly pre-releases). A second deploy workflow is **impossible** (it would clobber the site). The nightly **schedule** triggers this unified deploy; a release tag also triggers it (the release catalog regenerated each time — stateless, harmless). |
+| **Conflicts** | *(§0)* **NO `conflicts` manifest key** — an explicit `conflicts:` array naming an un-installed sibling **crashes CE libpkg** (`pkgdb.c:1892`). `-nightly` and the release packages share identical `src/` paths, so they mutually exclude + replace cleanly by **file overlap** alone (the portable builder emits no `conflicts` key). No `--conflicts` flag. |
+| **Hosting** | *(§0)* The **separate `pfBlockerNG/pkg` repo's `publish.yml`** (post-org-transfer) builds devel HEAD as a nightly `.pkg` and generates a **`nightly/${ABI}` subtree** in the SAME Pages deploy as the release catalog — served at `pfblockerng.github.io/pkg/nightly/${ABI}`. Stateless (one current nightly per run, no pre-release store). NOT an extension of this repo's `repo-publish.yml`. |
 | **Catalog = derived index over pre-releases** | The nightly `.pkg` per ABI is attached to a **dated GitHub pre-release `nightly-YYYYMMDD`** (the durable store, mirroring ADR-17's Releases). The unified publish enumerates the **last 14** nightly pre-releases, downloads their assets, buckets by ABI, runs `build-repo-portable.py` into `nightly/<ABI>/`. **Stateless + idempotent** (Pages holds no state of its own). |
 | **Retention** | **Keep the last 14 nightly pre-releases** (≈ 14 build-days; within a day the `nightly-YYYYMMDD` tag is updated in place). The nightly build job **prunes** pre-releases older than the newest 14 after staging. ~28 MB/ABI retained (Context 7). |
 | **Catalog gen** | **`scripts/build-repo-portable.py` reused unchanged** (pure-Python, no libpkg, ADR-17 Phase 3a). It already dedups per `(name,version,ABI)` and canonical-names — the nightly subtree gets the same treatment for free. |
@@ -308,6 +352,13 @@ make it usable + pinned; docs/DoD close it (Phase 6).
 ### Phase 1 — KILL-GATE: falsify date-version ordering + conflict-and-replace on the smoke VM
 
 Prompt: `01_Kill_Gate_Pkg_Mechanics.txt`
+
+> **DONE (verdict in §0).** The kill-gate ran and reshaped the design: the explicit
+> `conflicts` key crashes CE libpkg (→ file-overlap only), the rename is deep (→ the
+> `info.xml` short-name fix + a dedicated `-nightly` port), and the version is
+> `<target>.YYYYMMDD.N`. All three `pkg` mechanics are now pinned GREEN on the live VM
+> by `tests/smoke/test_nightly_install.py` (install+hook+provenance / file-overlap
+> replace both directions / monotonic upgrade). The bullets below are the original plan.
 
 - Cheaply prove the two `pkg` premises **before** building any tooling. Hand-build a
   minimal `pfSense-pkg-pfBlockerNG-NIGHTLY` `.pkg` at versions `20260605`, `20260606`,

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -258,6 +258,25 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r tests/smoke/requirements.txt pytest
 
+      # ADR-18: the `repo` flow's nightly cases (test_nightly_install.py) need a
+      # builder-produced -nightly .pkg (the deep rename can't be cheaply forged).
+      # Build it here from devel HEAD via the portable builder + the new --channel
+      # nightly, off the SAME ports ref build-pkg-linux uses; export its path.
+      # Only for the `repo` marker (the default `smoke` flow doesn't read it).
+      - name: Build a nightly .pkg (repo-flow nightly smoke)
+        if: ${{ (inputs.pytest_marker || 'smoke') == 'repo' }}
+        run: |
+          set -eu
+          git clone --depth 1 -b pfblockerng/use-github \
+            https://github.com/pfBlockerNG/FreeBSD-ports "${{ runner.temp }}/ports-nightly"
+          mkdir -p out-nightly
+          python3 scripts/build-pkg-portable.py \
+            --ports "${{ runner.temp }}/ports-nightly" --channel nightly \
+            --local-src . --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 \
+            --pkgversion 3.2.16.20260606.2 --annotate commit=${{ github.sha }} \
+            --out out-nightly
+          echo "SMOKE_NIGHTLY_PKG=$(find "$PWD/out-nightly" -name '*.pkg' | head -1)" >> "$GITHUB_ENV"
+
       # HERMETICITY (ADR §2/§4): the egress block is done INSIDE pytest, by the
       # matrix's `deployed_vm` fixture, after deploy() and before the per-case
       # assertions (helpers.block_egress, gated by SMOKE_BLOCK_EGRESS=1 below;
@@ -281,6 +300,9 @@ jobs:
           SMOKE_IMAGE_REF: ${{ steps.ref.outputs.ref }}
           SMOKE_SSH_KEY: smoke_key
           SMOKE_PKG: ${{ steps.paths.outputs.pkg }}
+          # The builder-produced -nightly .pkg (set above for the `repo` marker; the
+          # nightly cases SKIP when unset). Propagated via $GITHUB_ENV from that step.
+          SMOKE_NIGHTLY_PKG: ${{ env.SMOKE_NIGHTLY_PKG }}
           # Turn on the in-test hermetic egress block (after deploy, see fixture).
           SMOKE_BLOCK_EGRESS: "1"
           # Per-step state snapshots/diffs (config.xml + unbound.conf + logs +

--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ Two channels track two branches of this repository:
 |---------|--------|---------|-----|
 | **Stable** | `main` | `pfSense-pkg-pfBlockerNG` | Production use |
 | **Development** | `devel` | `pfSense-pkg-pfBlockerNG-devel` | Latest features, early testing |
+| **Nightly** | `devel` (HEAD, built nightly) | `pfSense-pkg-pfBlockerNG-nightly` | Bleeding edge; self-hosted repo only |
 
 New work lands on `devel` first; once it has settled it is promoted to `main` to
-cut a stable release. The two packages are mutually exclusive — install **one**.
-Choose **stable** unless you specifically want to track development builds.
+cut a stable release. **Nightly** rebuilds the `devel` tip each night as a separate,
+opt-in package available **only** from this fork's self-hosted repository (Option 2).
+The three packages are mutually exclusive — install **one**. Choose **stable** unless
+you specifically want to track development builds.
 
 ## Installation
 
@@ -102,6 +105,23 @@ pfblockerng-devel: {
 
 > **Note:** Installs and updates work via the **Install** button or `pkg upgrade`,
 > but pfSense's GUI won't show an "update available" badge for our builds.
+
+#### Nightly channel (bleeding edge)
+
+To track the **`devel` tip rebuilt every night**, opt into the separate `nightly`
+channel — a distinct package `pfSense-pkg-pfBlockerNG-nightly` served from a
+`nightly/` catalog subtree:
+
+```sh
+./scripts/add-repo.sh nightly
+pkg install pfSense-pkg-pfBlockerNG-nightly
+```
+
+It **conflicts with the stable and `-devel` packages** (they install the same files),
+so it replaces whichever you had; switch back any time with `./scripts/add-repo.sh devel`
+(or `stable`) and `pkg install` the release package. Nightly versions order as
+`<target>.YYYYMMDD.N`, so `pkg upgrade` always moves to the newest build, and the
+source commit rides the package — `pkg info -A pfSense-pkg-pfBlockerNG-nightly` shows it.
 
 ### Updating
 

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -12,6 +12,8 @@
 #                       repo name `pfblockerng-devel`, pkg pfSense-pkg-pfBlockerNG-devel
 #   stable           -> conf /usr/local/etc/pkg/repos/pfblockerng.conf
 #                       repo name `pfblockerng`,       pkg pfSense-pkg-pfBlockerNG
+#   nightly          -> conf /usr/local/etc/pkg/repos/pfblockerng-nightly.conf
+#                       repo name `pfblockerng-nightly`, pkg ...-nightly (bleeding edge, nightly/ subtree)
 #
 # THE CONF (single source of truth — matches `build-repo.sh --print-conf`):
 #   url:            STATIC base + the literal ${ABI} pkg(8) variable (expanded by
@@ -30,9 +32,9 @@
 # IDEMPOTENT: re-running rewrites the conf (safe to run again at any time).
 #
 # Usage:
-#   add-repo.sh [devel|stable]      # write the conf, pkg update, verify (default: devel)
-#   add-repo.sh --print-conf [devel|stable]   # print the conf to stdout and exit (no writes)
-#   add-repo.sh --base-url <url> [devel|stable]   # override the base (forks/staging)
+#   add-repo.sh [devel|stable|nightly]      # write the conf, pkg update, verify (default: devel)
+#   add-repo.sh --print-conf [devel|stable|nightly]   # print the conf to stdout and exit (no writes)
+#   add-repo.sh --base-url <url> [devel|stable|nightly]   # override the base (forks/staging)
 #
 # POSIX sh; quoted expansions; absolute path for the privileged `pkg` binary.
 
@@ -58,29 +60,44 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --print-conf)   PRINT_CONF=1; shift ;;
         --base-url)     BASE_URL="$2"; shift 2 ;;
-        devel|stable)   CHANNEL="$1"; shift ;;
+        devel|stable|nightly)   CHANNEL="$1"; shift ;;
         -h|--help)
-            sed -n '29,40p' "$0"   # the Usage block from the header
+            sed -n '34,39p' "$0"   # the Usage block from the header
             exit 0 ;;
         -*) echo "add-repo: unknown option: $1" >&2; exit 2 ;;
-        *)  echo "add-repo: unknown channel '$1' (expected devel|stable)" >&2; exit 2 ;;
+        *)  echo "add-repo: unknown channel '$1' (expected devel|stable|nightly)" >&2; exit 2 ;;
     esac
 done
 
 # ── Per-channel identity ───────────────────────────────────────────────────────
-# devel -> repo `pfblockerng-devel`, conf pfblockerng-devel.conf, pkg ...-devel
-# stable-> repo `pfblockerng`,       conf pfblockerng.conf,       pkg pfSense-pkg-pfBlockerNG
-if [ "$CHANNEL" = devel ]; then
-    REPO_NAME="pfblockerng-devel"
-    CONF_NAME="pfblockerng-devel.conf"
-    PKG_NAME="pfSense-pkg-pfBlockerNG-devel"
-    CHANNEL_LABEL="devel"
-else
-    REPO_NAME="pfblockerng"
-    CONF_NAME="pfblockerng.conf"
-    PKG_NAME="pfSense-pkg-pfBlockerNG"
-    CHANNEL_LABEL="stable"
-fi
+# devel  -> repo `pfblockerng-devel`,   conf pfblockerng-devel.conf,   pkg ...-devel
+# stable -> repo `pfblockerng`,         conf pfblockerng.conf,         pkg pfSense-pkg-pfBlockerNG
+# nightly-> repo `pfblockerng-nightly`, conf pfblockerng-nightly.conf, pkg ...-nightly
+# URL_SUBPATH: nightly is served from the `nightly/` catalog subtree; the release
+# channels from the Pages root. The literal ${ABI} pkg(8) variable follows it.
+case "$CHANNEL" in
+    devel)
+        REPO_NAME="pfblockerng-devel"
+        CONF_NAME="pfblockerng-devel.conf"
+        PKG_NAME="pfSense-pkg-pfBlockerNG-devel"
+        CHANNEL_LABEL="devel"
+        URL_SUBPATH=""
+        ;;
+    stable)
+        REPO_NAME="pfblockerng"
+        CONF_NAME="pfblockerng.conf"
+        PKG_NAME="pfSense-pkg-pfBlockerNG"
+        CHANNEL_LABEL="stable"
+        URL_SUBPATH=""
+        ;;
+    nightly)
+        REPO_NAME="pfblockerng-nightly"
+        CONF_NAME="pfblockerng-nightly.conf"
+        PKG_NAME="pfSense-pkg-pfBlockerNG-nightly"
+        CHANNEL_LABEL="nightly"
+        URL_SUBPATH="nightly/"
+        ;;
+esac
 CONF_PATH="${REPOS_DIR}/${CONF_NAME}"
 
 # ── The conf body (single source of truth; matches build-repo.sh --print-conf) ──
@@ -96,7 +113,7 @@ print_conf() {
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
 # resolution (pkg install/upgrade, GUI Install) selects our build.
 ${REPO_NAME}: {
-  url: "${base}/\${ABI}",
+  url: "${base}/${URL_SUBPATH}\${ABI}",
   mirror_type: none,
   signature_type: none,
   priority: ${CONF_PRIORITY},

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1121,6 +1121,39 @@ def compute_pkgversion(mk: Makefile) -> str:
     return ver
 
 
+def validate_pkgversion(ver: str) -> str:
+    """Validate a `--pkgversion` override (the nightly's comparable version).
+
+    `pkg` orders versions component-wise on `.`/`_`/`,`. The nightly carries a
+    pkg-safe `<target>.YYYYMMDD.N` (e.g. `3.2.16.20260606.1`), compared only
+    nightly-to-nightly (separate package name) so a later build always supersedes.
+    A `-` is the pkg name/version separator (`<name>-<version>.pkg`), so it MUST NOT
+    appear in the version — the commit / pretty string rides the annotation + comment.
+    """
+    ver = ver.strip()
+    if not ver:
+        raise BuildError("--pkgversion was empty")
+    if "-" in ver:
+        raise BuildError(f"--pkgversion must not contain '-' (the pkg name/version separator): {ver!r}")
+    return ver
+
+
+def parse_annotations(items: list[str]) -> dict[str, str]:
+    """Parse repeatable `--annotate K=V` items into an ordered {K: V} dict.
+
+    Each item is `K=V` (V may itself contain `=`); a later K wins. Used to MERGE
+    into the manifest `annotations` and to append `K=V` tokens to `comment`.
+    """
+    out: dict[str, str] = {}
+    for item in items:
+        key, sep, value = item.partition("=")
+        key = key.strip()
+        if not sep or not key:
+            raise BuildError(f"--annotate must be K=V (got {item!r})")
+        out[key] = value.strip()
+    return out
+
+
 def seed_vars(portdir: Path, workdir: Path, py_flavor: str) -> dict[str, str]:
     prefix = "/usr/local"
     stagedir = str(workdir / "stage")
@@ -1148,7 +1181,11 @@ def run_build(args: argparse.Namespace) -> Build:
     if args.port_dir:
         portdir = Path(args.port_dir).resolve()
     else:
-        sub = "pfSense-pkg-pfBlockerNG" if args.channel == "stable" else "pfSense-pkg-pfBlockerNG-devel"
+        sub = {
+            "stable": "pfSense-pkg-pfBlockerNG",
+            "devel": "pfSense-pkg-pfBlockerNG-devel",
+            "nightly": "pfSense-pkg-pfBlockerNG-nightly",
+        }[args.channel]
         portdir = ports_root / "net" / sub
     makefile = portdir / "Makefile"
     if not makefile.is_file():
@@ -1187,7 +1224,10 @@ def run_build(args: argparse.Namespace) -> Build:
 
     prefix = mk.get("PREFIX")
     portname = mk.get("PORTNAME")
-    pkgversion = compute_pkgversion(mk)
+    # The version is computed from the Makefile by default; a nightly build overrides
+    # it with `--pkgversion <target>.YYYYMMDD.N` (CI passes it). Must be pkg-safe (no
+    # '-'); the commit / pretty string rides the annotation + comment, not the version.
+    pkgversion = validate_pkgversion(args.pkgversion) if args.pkgversion else compute_pkgversion(mk)
     # PKGVERSION/PKGNAME are framework-derived, not assigned in the Makefile, but
     # the recipe references them (e.g. the info.xml %%PKGVERSION%% reinplace). Seed
     # them so they expand to real values instead of empty.
@@ -1210,11 +1250,19 @@ def run_build(args: argparse.Namespace) -> Build:
     desc, descr_www = parse_descr(descr_path.read_text()) if descr_path.is_file() else ("", "")
     www = resolve_www(mk, descr_www)
 
+    # Nightly provenance: `--annotate K=V` merges into the manifest `annotations`
+    # AND appends `(K=V, …)` to the comment, so both `pkg info` and `pkg info -A`
+    # surface it (e.g. commit=<sha>). Default empty -> release build unchanged.
+    extra_annotations = parse_annotations(args.annotate)
+    comment = mk.get("COMMENT")
+    if extra_annotations:
+        comment += " (" + ", ".join(f"{k}={v}" for k, v in extra_annotations.items()) + ")"
+
     b = Build(
         portname=portname,
         pkgversion=pkgversion,
         origin=origin,
-        comment=mk.get("COMMENT"),
+        comment=comment,
         maintainer=mk.get("MAINTAINER"),
         categories=categories,
         licenses=mk.get("LICENSE").split() or [],
@@ -1281,6 +1329,8 @@ def run_build(args: argparse.Namespace) -> Build:
         apply_repo_catalogue(b.deps, args.repo_catalogue, abi)
     if args.freebsd_version:
         b.annotations = {"FreeBSD_version": args.freebsd_version}
+    # `--annotate K=V` merges on top (e.g. commit=<sha>); release build adds nothing.
+    b.annotations.update(extra_annotations)
     return b
 
 
@@ -1308,7 +1358,12 @@ def main(argv: list[str]) -> int:
     )
 
     g_port = ap.add_argument_group("port selection")
-    g_port.add_argument("--channel", choices=("devel", "stable"), default="devel", help="which port (default: devel)")
+    g_port.add_argument(
+        "--channel",
+        choices=("devel", "stable", "nightly"),
+        default="devel",
+        help="which port: devel/stable release, or nightly (default: devel)",
+    )
     g_port.add_argument("--port-dir", help="explicit port directory (overrides --channel)")
 
     g_target = ap.add_argument_group(
@@ -1324,6 +1379,26 @@ def main(argv: list[str]) -> int:
     )
     g_target.add_argument(
         "--freebsd-version", default="", help="build host __FreeBSD_version for annotations, e.g. 1500068 (optional)"
+    )
+
+    g_snap = ap.add_argument_group("nightly overrides (ADR-18; default off — release build byte-identical)")
+    g_snap.add_argument(
+        "--pkgversion",
+        default="",
+        help=(
+            "override the computed package version with the nightly's pkg-safe comparable "
+            "version, e.g. 3.2.16.20260606.1 (must not contain '-')."
+        ),
+    )
+    g_snap.add_argument(
+        "--annotate",
+        action="append",
+        default=[],
+        metavar="K=V",
+        help=(
+            "add a manifest annotation K=V (repeatable; e.g. --annotate commit=<sha>). "
+            "Merged into `annotations` and appended to `comment` (surfaced by pkg info -A)."
+        ),
     )
 
     g_src = ap.add_argument_group("source (USE_GITHUB ports)")

--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -1,0 +1,308 @@
+"""ADR-18 — the distinct ``-nightly`` package installs, registers, conflicts, upgrades.
+
+The nightly channel ships a SEPARATE package ``pfSense-pkg-pfBlockerNG-nightly``
+(distinct name, built from the new ``-nightly`` port, short ``info.xml <name>``
+``pfBlockerNG-nightly`` via the ``${PORTNAME:S/pfSense-pkg-//}`` recipe). This
+live-VM flow proves, on a real pfSense CE VM, the three ``pkg`` mechanics the
+distinct-name design rests on — the ones the earlier same-name detour could not
+settle:
+
+  1. INSTALL + REGISTER + provenance — ``pkg install pfSense-pkg-pfBlockerNG-nightly``
+     (no ``-f``) from a hermetic ``file://`` nightly catalog resolves deps, the
+     rc.packages POST-INSTALL hook runs the FULL pfBlockerNG setup (NO abort — the
+     short ``info.xml`` name is what ``get_package_id`` looks up), ``%R`` is our
+     nightly repo, and the source commit rides ``pkg info -A`` (the annotation).
+  2. CONFLICT-AND-REPLACE (both directions) — ``-nightly`` and ``-devel`` install
+     the SAME ``src/`` paths, so they mutually exclude by FILE OVERLAP (no
+     ``conflicts`` manifest key — that crashes CE libpkg). Installing one over the
+     other replaces it cleanly; the reverse step replaces back.
+  3. MONOTONIC ``pkg upgrade`` — the pkg-safe ``<target>.YYYYMMDD.N`` version orders
+     component-wise, so ``pkg upgrade`` walks an installed nightly forward across
+     successive builds.
+
+NOT a unit test (the builder/manifest shape is pinned off-box in
+``tests/test_build_pkg_portable.py``). Like ``test_repo_install.py`` this validates
+DISTRIBUTION + pfSense behaviour and carries the ``repo`` marker (deselected from
+``-m smoke``). It REUSES that file's proven harness (the ``smoke_vm`` fixture, the
+egress-open wiring, ``build_guest_repo``, ``reversion_pkg``). Needs the booted VM
+plus a builder-produced nightly ``.pkg`` (``SMOKE_NIGHTLY_PKG``) and the branch
+``-devel`` ``.pkg`` (``SMOKE_PKG``); without either it SKIPS cleanly.
+
+Run: ``gh workflow run smoke.yml -f pytest_marker=repo``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+from .test_repo_install import (
+    _ensure_egress_open,
+    _ssh_check,
+    build_guest_repo,
+    read_compact_version,
+    repo_priority,
+    reversion_pkg,
+)
+
+pytestmark = pytest.mark.repo
+
+NIGHTLY_NAME = "pfSense-pkg-pfBlockerNG-nightly"
+DEVEL_NAME = "pfSense-pkg-pfBlockerNG-devel"
+NIGHTLY_REPO = "pfblockerng-nightly"  # the %R origin a nightly install reports
+DEVEL_REPO = "pfblockerng-devel"  # the %R origin the controlled -devel install reports
+
+SPIKE = "/tmp/pfb_nightly_spike"
+NIGHTLY_DIR = f"{SPIKE}/nightly"  # the file:// nightly catalog
+DEVEL_DIR = f"{SPIKE}/devel"  # a controlled file:// -devel catalog (for the conflict leg)
+CONF = "/usr/local/etc/pkg/repos/pfb_nightly_smoke.conf"
+
+# The rc.packages install hook aborts with one of these when the registration name
+# is wrong (the short-name regression test_install_hook.py guards); the nightly must
+# show NEITHER — its hook runs the full setup. Asserted on the raw install output.
+_ABORT = ("is not installed", "Installation aborted", "Failed to install package")
+_HOOK_OK = ("Executing custom_php_install_command", "Menu items")
+
+# Three ascending pkg-safe nightly versions (<target>.YYYYMMDD.N) for the upgrade
+# walk; `.N` is the same-day build counter, so .1 < .2 < .3 orders component-wise.
+V1 = "3.2.16.20260606.1"
+V2 = "3.2.16.20260606.2"
+V3 = "3.2.16.20260606.3"
+
+
+# --------------------------------------------------------------------------- #
+# Conf + pkg helpers (by NAME — the release helpers in test_repo_install are
+# hardcoded to the -devel name; the nightly flow drives two distinct names).
+# --------------------------------------------------------------------------- #
+
+
+def _stanza(name: str, directory: str, priority: int) -> str:
+    return (
+        f"{name}: {{\n"
+        f'  url: "file://{directory}",\n'
+        "  signature_type: none,\n"
+        "  enabled: yes,\n"
+        f"  priority: {priority}\n"
+        "}\n"
+    )
+
+
+def write_conf(vm: SmokeVM, stanzas: list[tuple[str, str, int]]) -> None:
+    """Write a NONE-signed ``file://`` repo conf naming each (repo, dir, priority)."""
+    conf = "".join(_stanza(n, d, p) for n, d, p in stanzas)
+    r = subprocess.run(vm.ssh_argv("tee", CONF), input=conf, capture_output=True, text=True, timeout=60.0, check=False)
+    if r.returncode != 0:
+        raise RuntimeError(f"write_conf failed: rc={r.returncode} {r.stderr!r}")
+
+
+def pkg_present(vm: SmokeVM, name: str, *, timeout: float = 60.0) -> bool:
+    return vm.ssh("pkg", "query", "%n", name, timeout=timeout).returncode == 0
+
+
+def pkg_q(vm: SmokeVM, fmt: str, name: str, *, timeout: float = 60.0) -> str:
+    """``pkg query <fmt> <name>`` (e.g. ``%v``/``%R``) — empty string if absent."""
+    r = vm.ssh("pkg", "query", fmt, name, timeout=timeout)
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
+def pkg_annotation(vm: SmokeVM, name: str, key: str, *, timeout: float = 60.0) -> str | None:
+    """The value of annotation ``key`` from ``pkg info -A`` (the provenance oracle)."""
+    out = _ssh_check(vm, "pkg", "info", "-A", name, timeout=timeout).stdout
+    for line in out.splitlines():
+        # `pkg info -A` prints `  <key>         : <value>`.
+        k, sep, v = line.partition(":")
+        if sep and k.strip() == key:
+            return v.strip()
+    return None
+
+
+def pkg_update(vm: SmokeVM, *, timeout: float = 240.0) -> None:
+    _ssh_check(vm, "env", "ASSUME_ALWAYS_YES=yes", "pkg", "update", "-f", timeout=timeout)
+
+
+def pkg_install(vm: SmokeVM, name: str, *, timeout: float = 600.0) -> str:
+    """``pkg install -y <name>`` across all enabled repos (no ``-r``/``-f``); return its output.
+
+    Output combines stdout+stderr so the caller can read the rc.packages POST-INSTALL
+    hook text (the install-hook success oracle) and any "Missing dependency" line.
+    """
+    r = vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "install", "-y", name, timeout=timeout)
+    if r.returncode != 0:
+        raise RuntimeError(f"pkg install {name} failed: rc={r.returncode}\n{r.stdout}\n{r.stderr}")
+    return r.stdout + r.stderr
+
+
+def pkg_upgrade(vm: SmokeVM, name: str, *, timeout: float = 600.0) -> str:
+    r = vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "upgrade", "-y", name, timeout=timeout)
+    if r.returncode != 0:
+        raise RuntimeError(f"pkg upgrade {name} failed: rc={r.returncode}\n{r.stdout}\n{r.stderr}")
+    return r.stdout + r.stderr
+
+
+def pkg_delete(vm: SmokeVM, name: str, *, timeout: float = 300.0) -> None:
+    vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "delete", "-y", name, timeout=timeout)
+
+
+def assert_hook_succeeded(install_out: str, *, name: str) -> None:
+    """The rc.packages POST-INSTALL hook ran the FULL setup — NO abort phrase, markers present."""
+    aborted = [p for p in _ABORT if p in install_out]
+    assert not aborted, f"{name} rc.packages hook ABORTED ({aborted}):\n{install_out}"
+    ran = [p for p in _HOOK_OK if p in install_out]
+    assert ran, f"{name} install hook did not run the full pfBlockerNG setup:\n{install_out}"
+
+
+# --------------------------------------------------------------------------- #
+# Module fixture — a hermetic file:// nightly (+ controlled -devel) catalog.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def nightly_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """The booted VM with a hermetic ``file://`` nightly catalog (+ a controlled -devel one).
+
+    Builds two NONE-signed ``file://`` catalogs from the handed-in ``.pkg`` files
+    (the builder-produced nightly via ``SMOKE_NIGHTLY_PKG``; the branch ``-devel``
+    via ``SMOKE_PKG`` for the conflict leg) and writes one conf naming both repos a
+    clear margin ABOVE the Netgate ``pfSense`` repo. Egress is OPEN (the ADR-17 repo
+    model); deps resolve from the baked image db, so ``pkg install`` needs no fetch.
+    Leaves the VM clean in ``finally``.
+    """
+    nightly = os.environ.get("SMOKE_NIGHTLY_PKG")
+    devel = os.environ.get("SMOKE_PKG")
+    if not nightly or not Path(nightly).is_file():
+        pytest.skip("SMOKE_NIGHTLY_PKG not set / not a file — no built -nightly .pkg")
+    if not devel or not Path(devel).is_file():
+        pytest.skip("SMOKE_PKG not set / not a file — no branch -devel .pkg")
+    assert nightly and devel  # for the type-checker (skip above is NoReturn)
+    _ensure_egress_open()
+    prio = repo_priority(smoke_vm, "pfSense") + 100
+    build_guest_repo(smoke_vm, NIGHTLY_DIR, [Path(nightly)])
+    build_guest_repo(smoke_vm, DEVEL_DIR, [Path(devel)])
+    write_conf(smoke_vm, [(NIGHTLY_REPO, NIGHTLY_DIR, prio), (DEVEL_REPO, DEVEL_DIR, prio)])
+    pkg_update(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        pkg_delete(smoke_vm, NIGHTLY_NAME)
+        pkg_delete(smoke_vm, DEVEL_NAME)
+        smoke_vm.ssh("/bin/rm", "-rf", SPIKE, timeout=60.0)
+        smoke_vm.ssh("/bin/rm", "-f", CONF, timeout=60.0)
+        h.collect_host_diagnostics(smoke_vm)
+
+
+def _ensure_absent(vm: SmokeVM) -> None:
+    """Both packages removed, so each test starts from a known clean slate."""
+    pkg_delete(vm, NIGHTLY_NAME)
+    pkg_delete(vm, DEVEL_NAME)
+
+
+# --------------------------------------------------------------------------- #
+# The kill-gate tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(900)
+def test_nightly_installs_registers_and_carries_commit(nightly_vm: SmokeVM) -> None:
+    """The nightly installs (no -f), its rc.packages hook SUCCEEDS, and it carries provenance.
+
+    Scenario: a fresh install of the distinct ``-nightly`` package.
+      Given the nightly catalog and the package ABSENT,
+      When ``pkg install -y pfSense-pkg-pfBlockerNG-nightly`` runs (NO -f),
+      Then the rc.packages POST-INSTALL hook runs the FULL pfBlockerNG setup (no
+        abort — the short info.xml name resolves), ``%R`` is our nightly repo, ``%v``
+        is the nightly version, and ``pkg info -A`` surfaces the ``commit`` annotation.
+    """
+    vm = nightly_vm
+    _ensure_absent(vm)
+    assert not pkg_present(vm, NIGHTLY_NAME), "precondition: -nightly absent"
+
+    out = pkg_install(vm, NIGHTLY_NAME)
+
+    assert_hook_succeeded(out, name=NIGHTLY_NAME)
+    assert pkg_present(vm, NIGHTLY_NAME)
+    assert pkg_q(vm, "%R", NIGHTLY_NAME) == NIGHTLY_REPO, f"%R should be our nightly repo:\n{out}"
+    assert pkg_q(vm, "%v", NIGHTLY_NAME), "installed nightly has a version"
+    commit = pkg_annotation(vm, NIGHTLY_NAME, "commit")
+    assert commit, f"the source commit must ride pkg info -A (provenance); got {commit!r}"
+
+
+@pytest.mark.timeout(1200)
+def test_nightly_conflicts_and_replaces_devel_both_directions(nightly_vm: SmokeVM) -> None:
+    """-nightly and -devel mutually exclude by FILE OVERLAP — each replaces the other cleanly.
+
+    Scenario: switching channels in place.
+      Given -devel installed from the controlled devel repo (and -nightly absent),
+      When ``pkg install -y …-nightly`` runs,
+      Then it is a conflict-and-replace: -nightly is now installed (%R our nightly
+        repo) and -devel is GONE — proven a transition by asserting -devel present
+        BEFORE. When -devel is then installed again, -nightly is GONE in turn.
+    """
+    vm = nightly_vm
+    _ensure_absent(vm)
+
+    # Given: -devel installed, -nightly absent.
+    pkg_install(vm, DEVEL_NAME)
+    assert pkg_present(vm, DEVEL_NAME) and not pkg_present(vm, NIGHTLY_NAME), "before: only -devel"
+    assert pkg_q(vm, "%R", DEVEL_NAME) == DEVEL_REPO
+
+    # When: install -nightly over it → file-overlap replace.
+    out = pkg_install(vm, NIGHTLY_NAME)
+    assert_hook_succeeded(out, name=NIGHTLY_NAME)
+    # Then: -nightly present, -devel replaced (gone).
+    assert pkg_present(vm, NIGHTLY_NAME), f"-nightly should be installed:\n{out}"
+    assert not pkg_present(vm, DEVEL_NAME), f"-devel should have been REPLACED by the file overlap:\n{out}"
+    assert pkg_q(vm, "%R", NIGHTLY_NAME) == NIGHTLY_REPO
+
+    # And back: install -devel → -nightly replaced in turn (the reverse direction).
+    out_back = pkg_install(vm, DEVEL_NAME)
+    assert_hook_succeeded(out_back, name=DEVEL_NAME)
+    assert pkg_present(vm, DEVEL_NAME), f"-devel should be reinstalled:\n{out_back}"
+    assert not pkg_present(vm, NIGHTLY_NAME), f"-nightly should have been REPLACED back:\n{out_back}"
+
+
+@pytest.mark.timeout(1200)
+def test_nightly_pkg_upgrade_is_monotonic(nightly_vm: SmokeVM, tmp_path: Path) -> None:
+    """``pkg upgrade`` walks an installed nightly forward across ascending builds.
+
+    Scenario: the nightly version scheme orders.
+      Given the nightly catalog at V1 and -nightly installed at V1,
+      When the catalog is rebuilt at V2 (then V3) and ``pkg upgrade`` runs,
+      Then the installed ``%v`` MOVES V1 -> V2 -> V3 — three real before != after
+        transitions, proving ``<target>.YYYYMMDD.N`` is monotonically comparable.
+    """
+    vm = nightly_vm
+    _ensure_absent(vm)
+    nightly_src = Path(os.environ["SMOKE_NIGHTLY_PKG"])
+    base = read_compact_version(nightly_src)
+    assert base, "the built nightly .pkg must carry a version to re-version from"
+
+    prio = repo_priority(vm, "pfSense") + 100
+
+    def _serve(version: str) -> None:
+        pkg = reversion_pkg(nightly_src, version, tmp_path / version)
+        build_guest_repo(vm, NIGHTLY_DIR, [pkg])
+        # Keep the controlled -devel repo in the conf so the box state is unchanged
+        # except the nightly catalog version.
+        write_conf(vm, [(NIGHTLY_REPO, NIGHTLY_DIR, prio), (DEVEL_REPO, DEVEL_DIR, prio)])
+        pkg_update(vm)
+
+    # Given: catalog at V1, install -> %v == V1.
+    _serve(V1)
+    pkg_install(vm, NIGHTLY_NAME)
+    assert pkg_q(vm, "%v", NIGHTLY_NAME) == V1, "before: installed nightly at V1"
+
+    # When/Then: rebuild at V2, upgrade moves it (before != after).
+    _serve(V2)
+    pkg_upgrade(vm, NIGHTLY_NAME)
+    assert pkg_q(vm, "%v", NIGHTLY_NAME) == V2, "pkg upgrade must move V1 -> V2"
+
+    # And again V2 -> V3.
+    _serve(V3)
+    pkg_upgrade(vm, NIGHTLY_NAME)
+    assert pkg_q(vm, "%v", NIGHTLY_NAME) == V3, "pkg upgrade must move V2 -> V3"

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -77,23 +77,28 @@ def test_add_repo_devel_conf_default_channel_matches_explicit() -> None:
     [
         ("devel", "pfblockerng-devel", 'url: "https://pfblockerng.github.io/pkg/${ABI}"'),
         ("stable", "pfblockerng", 'url: "https://pfblockerng.github.io/pkg/${ABI}"'),
+        # nightly is served from a DISTINCT `nightly/` catalog subtree (so it never
+        # collides with the release tree on Pages) — its url carries the extra path.
+        ("nightly", "pfblockerng-nightly", 'url: "https://pfblockerng.github.io/pkg/nightly/${ABI}"'),
     ],
 )
 def test_add_repo_conf_fields_per_channel(channel: str, repo_name: str, url: str) -> None:
     """Each channel names its repo distinctly but shares the precedence-bearing fields.
 
-    devel -> repo `pfblockerng-devel`; stable -> repo `pfblockerng`. Both carry
-    the SAME static ${ABI} url, priority 100 (above Netgate's 0), and none/none
-    (NONE-signed). The repo NAME is the only channel-varying field — a stable conf
-    that reused the devel repo name (or vice versa) would collide on a box.
+    devel -> `pfblockerng-devel`; stable -> `pfblockerng`; nightly ->
+    `pfblockerng-nightly` (and a `nightly/${ABI}` url subtree). All carry priority 100
+    (above Netgate's 0) and none/none (NONE-signed). The repo NAME (and, for nightly,
+    the url subpath) is the only channel-varying field — a conf that reused another
+    channel's repo name would collide on a box.
     """
     conf = _print_conf(_ADD_REPO, channel)
 
     # The stanza is keyed by the channel-specific repo name (and ONLY that name).
     assert re.search(rf"^{re.escape(repo_name)}:\s*\{{", conf, re.MULTILINE), conf
-    other = "pfblockerng" if channel == "devel" else "pfblockerng-devel"
-    # `pfblockerng-devel:` must not match a bare `pfblockerng:` probe — anchor the colon.
-    assert not re.search(rf"^{re.escape(other)}:\s*\{{", conf, re.MULTILINE), conf
+    # No OTHER channel's repo name appears as a stanza key (each conf names exactly one;
+    # the anchored `:` keeps `pfblockerng:` from matching `pfblockerng-devel:` etc.).
+    for other in {"pfblockerng", "pfblockerng-devel", "pfblockerng-nightly"} - {repo_name}:
+        assert not re.search(rf"^{re.escape(other)}:\s*\{{", conf, re.MULTILINE), conf
 
     # The literal ${ABI} survives (single-quoted on emission — pkg expands it, not the shell).
     assert url in conf
@@ -107,9 +112,12 @@ def test_add_repo_conf_fields_per_channel(channel: str, repo_name: str, url: str
 
 
 def test_add_repo_rejects_unknown_channel() -> None:
-    """An unknown channel arg fails loud (exit != 0), never silently writing a conf."""
+    """An unknown channel arg fails loud (exit != 0), never silently writing a conf.
+
+    (devel/stable/nightly are the three valid channels; anything else is rejected.)
+    """
     proc = subprocess.run(
-        ["sh", str(_ADD_REPO), "--print-conf", "nightly"],
+        ["sh", str(_ADD_REPO), "--print-conf", "bogus"],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -548,3 +548,91 @@ def test_end_to_end_plist_drift_aborts(tmp_path: Path) -> None:
 )
 def test_makefile_apply_mods_substitution(val: str, mods: str, expected: str) -> None:
     assert bpp.Makefile._apply_mods(val, mods) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Nightly overrides (ADR-18 --channel nightly): --pkgversion / --annotate.
+# The pair below is the branch contrast — OFF (release build, default flags) vs
+# ON (nightly overrides) — proving the overrides are a real branch, not an
+# always-on path. Neither ever emits a `conflicts` key (the portable builder
+# never does — mutual exclusion with the release builds is by file overlap).
+# --------------------------------------------------------------------------- #
+
+
+def test_overrides_off_release_build_is_plain(tmp_path: Path) -> None:
+    """OFF: with no --pkgversion/--annotate the manifest is the plain release shape.
+
+    Given the synthetic port built with default flags,
+    When no nightly override is passed,
+    Then version comes from PORTVERSION(_PORTREVISION), the comment is verbatim, the
+      only annotation is the FreeBSD_version, and there is no `conflicts` key.
+    """
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        ["--ports", str(ports), "--port-dir", str(portdir), "--abi", "FreeBSD:15:amd64",
+         "--py-flavor", "py311", "--compression", "xz", "--freebsd-version", "1500068", "--out", str(out)]
+    )  # fmt: skip
+    assert rc == 0
+    full, compact, _ = _read_pkg(out / "testpkg-1.0_2.pkg")
+    assert full["version"] == "1.0_2"  # from PORTVERSION(_PORTREVISION), not an override
+    assert full["comment"] == "Test port"  # verbatim
+    assert full["annotations"] == {"FreeBSD_version": "1500068"}  # no commit
+    assert "conflicts" not in full and "conflicts" not in compact
+
+
+def test_overrides_on_nightly_version_and_annotation(tmp_path: Path) -> None:
+    """ON: --pkgversion sets the comparable version; --annotate rides annotations + comment.
+
+    Given the SAME synthetic port,
+    When --pkgversion <target>.YYYYMMDD.N and repeatable --annotate K=V are passed,
+    Then the manifest version is the override (NOT PORTVERSION), each K=V merges into
+      `annotations` (on top of FreeBSD_version) AND appends to `comment` (so both
+      `pkg info` and `pkg info -A` surface the provenance) — still NO `conflicts` key.
+    """
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        ["--ports", str(ports), "--port-dir", str(portdir), "--abi", "FreeBSD:15:amd64",
+         "--py-flavor", "py311", "--compression", "xz", "--freebsd-version", "1500068",
+         "--pkgversion", "3.2.16.20260606.1", "--annotate", "commit=deadbeef", "--annotate", "build=ci",
+         "--out", str(out)]
+    )  # fmt: skip
+    assert rc == 0
+    full, compact, _ = _read_pkg(out / "testpkg-3.2.16.20260606.1.pkg")
+    assert full["version"] == "3.2.16.20260606.1"  # the override, NOT 1.0_2
+    assert full["annotations"] == {"FreeBSD_version": "1500068", "commit": "deadbeef", "build": "ci"}
+    assert full["comment"] == "Test port (commit=deadbeef, build=ci)"
+    assert "conflicts" not in full and "conflicts" not in compact
+
+
+@pytest.mark.parametrize("ver", ["20260606", "3.2.16.20260606.1", "4.0.0.20260606.10"])
+def test_validate_pkgversion_accepts_pkg_safe_dotted(ver: str) -> None:
+    assert bpp.validate_pkgversion(ver) == ver
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "3.2-nightly", "3.2.16-20260606"])
+def test_validate_pkgversion_rejects_empty_or_dash(bad: str) -> None:
+    # '-' is the pkg name/version delimiter (<name>-<version>.pkg); empty is meaningless.
+    with pytest.raises(bpp.BuildError):
+        bpp.validate_pkgversion(bad)
+
+
+@pytest.mark.parametrize(
+    "items, expected",
+    [
+        ([], {}),
+        (["commit=abc"], {"commit": "abc"}),
+        (["a=1", "b=2"], {"a": "1", "b": "2"}),
+        (["k=v=w"], {"k": "v=w"}),  # value may itself contain '='
+        (["k=1", "k=2"], {"k": "2"}),  # a later key wins
+    ],
+)
+def test_parse_annotations(items: list[str], expected: dict[str, str]) -> None:
+    assert bpp.parse_annotations(items) == expected
+
+
+@pytest.mark.parametrize("bad", ["noequals", "=v", "  =v"])
+def test_parse_annotations_rejects_malformed(bad: str) -> None:
+    with pytest.raises(bpp.BuildError):
+        bpp.parse_annotations([bad])


### PR DESCRIPTION
## ADR-18 — opt-in nightly `pkg` build channel

A separate, opt-in package **`pfSense-pkg-pfBlockerNG-nightly`** that tracks the
`devel` tip, installed `pkg`-natively (no `pkg add -f`) from a `nightly/${ABI}`
catalog subtree. Built on top of the PR #151 `info.xml` short-name fix.

### As-built design (the Phase-1 kill-gate overturned the original premises)

- **Distinct, lowercase `-nightly` from a dedicated port** — the rename is **deep**
  (manifest `name`, `share/<name>/` dir, short `info.xml <name>`, `%%PORTNAME%%` hook
  args), cascaded from `PORTNAME` exactly like `-devel`/`-stable`. Enabled by the
  short-name fix; the new port is companion change `pfBlockerNG/FreeBSD-ports@pfblockerng/use-github` (`8d68d10`).
- **File-overlap conflict only** — no `conflicts` manifest key (it crashes CE libpkg).
  `-nightly` and the release packages share `src/` paths, so they replace cleanly.
- **Version `<target>.YYYYMMDD.N`** (pkg-safe, monotonic); the commit rides a manifest
  annotation + COMMENT (`pkg info -A`).
- **Hosting** — the separate `pfBlockerNG/pkg` repo's `publish.yml` builds devel HEAD
  as a nightly `.pkg` and deploys a `nightly/${ABI}` subtree in the same Pages deploy
  (companion change `pfBlockerNG/pkg@main` `6de5240`).

### This PR (pfBlockerNG repo)

- `build-pkg-portable.py`: `--channel nightly` + `--pkgversion`/`--annotate` (default
  off → release build byte-identical), unit oracle.
- `add-repo.sh nightly` channel (+ README) → `nightly/${ABI}` conf; release confs stay
  byte-identical (drift guard holds).
- `tests/smoke/test_nightly_install.py` (marker `repo`) + the smoke job builds the
  nightly `.pkg` in-CI.
- ADR-18 reconciled to the as-built design (§0); Status → Implemented.

### Validation

Live-VM `repo` smoke **GREEN** (run 27063566374) — the three nightly cases plus the
ADR-17 repo-install suite: **12 passed, 1 skipped** on a real pfSense CE 2.8.1 VM.
- `test_nightly_installs_registers_and_carries_commit` — install (no `-f`), rc.packages
  hook runs the full setup (no abort), `%R == pfblockerng-nightly`, `pkg info -A` commit.
- `test_nightly_conflicts_and_replaces_devel_both_directions` — file-overlap replace, both ways.
- `test_nightly_pkg_upgrade_is_monotonic` — `pkg upgrade` walks V1→V2→V3.

**Post-merge (per ADR §7):** dispatch `pfBlockerNG/pkg` `publish.yml` to deploy the
public `…/pkg/nightly/${ABI}` catalog, then the gated live-URL leg — a new
`workflow_dispatch` is only dispatchable from the default branch.

Part of ADR-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Nightly release channel for bleeding-edge builds (`pfSense-pkg-pfBlockerNG-nightly`)
  * Nightly packages installable via `./scripts/add-repo.sh nightly`
  * Nightly packages automatically replace stable/devel installations using version format `<target>.YYYYMMDD.N`

* **Documentation**
  * Updated README with Nightly channel installation and upgrade instructions
  * Enhanced repository configuration scripts to support nightly channel

* **Tests**
  * Added comprehensive smoke tests validating nightly installation, channel switching, and monotonic upgrades

<!-- end of auto-generated comment: release notes by coderabbit.ai -->