### PR TITLE
ci: sanitize PKG_DISPATCH_TOKEN before use (strip stray whitespace)

### DIFF
--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -30,9 +30,13 @@ jobs:
           GH_TOKEN: ${{ secrets.PKG_DISPATCH_TOKEN }}
         run: |
           set -eu
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::PKG_DISPATCH_TOKEN secret is empty or unset on this repo."
-            exit 1
-          fi
+          # Sanitize the PAT before use: a stray newline/whitespace in the secret
+          # value corrupts gh's Authorization header ("invalid header field value
+          # for Authorization"). A GitHub PAT is whitespace-free, so stripping all
+          # whitespace is lossless and removes any set/paste artifact.
+          GH_TOKEN="$(printf '%s' "${GH_TOKEN:-}" | tr -d '[:space:]')"
+          export GH_TOKEN
+          [ -n "$GH_TOKEN" ] || { echo "::error::PKG_DISPATCH_TOKEN secret is empty or unset on this repo."; exit 1; }
+          echo "::add-mask::$GH_TOKEN"
           gh workflow run publish.yml -R pfBlockerNG/pkg
           echo "Dispatched pfBlockerNG/pkg publish.yml — PKG_DISPATCH_TOKEN auth OK."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,6 +527,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PKG_DISPATCH_TOKEN }}
         run: |
+          set -eu
+          # Sanitize the PAT before use: a stray newline/whitespace in the secret
+          # value corrupts gh's Authorization header ("invalid header field value
+          # for Authorization"). A GitHub PAT is whitespace-free, so stripping all
+          # whitespace is lossless and removes any set/paste artifact.
+          GH_TOKEN="$(printf '%s' "${GH_TOKEN:-}" | tr -d '[:space:]')"
+          export GH_TOKEN
+          echo "::add-mask::$GH_TOKEN"
           gh workflow run publish.yml -R pfBlockerNG/pkg
 
   # ── 3. Open PR on pfsense/FreeBSD-ports ──────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,6 +534,7 @@ jobs:
           # whitespace is lossless and removes any set/paste artifact.
           GH_TOKEN="$(printf '%s' "${GH_TOKEN:-}" | tr -d '[:space:]')"
           export GH_TOKEN
+          [ -n "$GH_TOKEN" ] || { echo "::error::PKG_DISPATCH_TOKEN secret is empty or unset on this repo."; exit 1; }
           echo "::add-mask::$GH_TOKEN"
           gh workflow run publish.yml -R pfBlockerNG/pkg
 


### PR DESCRIPTION
## Sanitize `PKG_DISPATCH_TOKEN` before use

The just-rotated PAT was tested via the new `pkg-republish.yml` (run 27069210822)
and **failed** at the `gh` dispatch:

```text
unable to determine default branch for pfBlockerNG/pkg:
  Post ".../graphql": net/http: invalid header field value for "Authorization"
```

That is the textbook symptom of a **stray newline/whitespace in the token value** —
the secret is set and non-empty (the run logged `GH_TOKEN: ***`), so `gh` choked
building the `Authorization` header, before any permission check.

**Fix:** both PAT consumers — `release.yml`'s `repo-publish` and `pkg-republish.yml`
— now `tr -d '[:space:]'` the value before handing it to `gh`, then re-`::add-mask::`
it. A GitHub PAT is whitespace-free, so stripping all whitespace is lossless and
removes any set/paste artifact.

**Confirms the hypothesis:** once this lands, re-dispatching `pkg-republish.yml`
should succeed — proving the value was malformed (and fixing it regardless of how
the secret was re-set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow security and reliability by sanitizing dispatch tokens (stripping whitespace), validating they are set, and masking them in logs to prevent accidental exposure and reduce deployment failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->