### PR TITLE
ci: re-add manual pkg-repo republish dispatch (exercise the PAT)

### DIFF
--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -1,0 +1,25 @@
+name: Trigger pkg repository republish
+
+# Manual dispatch that fires pfBlockerNG/pkg's publish.yml via the
+# PKG_DISPATCH_TOKEN PAT — the SAME cross-repo dispatch release.yml's repo-publish
+# job runs on a release. Two uses: republish the self-hosted pkg catalog on demand
+# (the pkg repo also runs daily on its own schedule), and verify PKG_DISPATCH_TOKEN
+# works — a FAILED run means the PAT is missing / expired / lacks Actions:write on
+# pfBlockerNG/pkg. Least-privilege: the PAT (an env secret) starts a workflow in the
+# other repo; nothing from this repo's contents is needed.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch pfBlockerNG/pkg publish.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger publish.yml via PKG_DISPATCH_TOKEN
+        env:
+          GH_TOKEN: ${{ secrets.PKG_DISPATCH_TOKEN }}
+        run: gh workflow run publish.yml -R pfBlockerNG/pkg


### PR DESCRIPTION
## Re-add the manual pkg-repo republish dispatch (exercise/health-check the PAT)

Re-adds the `workflow_dispatch` that fires `pfBlockerNG/pkg`'s `publish.yml` via
`PKG_DISPATCH_TOKEN` — the **only isolated way to exercise the PAT**. (A `release.yml`
dispatch would also re-cut the GitHub Release, open a `pfsense/FreeBSD-ports` PR, and
rebuild pkgs — far too much for a token check.)

Kept as a permanent on-demand **republish button + PAT health-check**. Bare dispatch,
**no sanitize** (the token is now corrected at the source); a failed run means the PAT
is missing / expired / lacks `Actions: write` on `pfBlockerNG/pkg`. Once merged I'll
dispatch it to confirm the new token works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow configuration for internal package publishing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->