### PR TITLE
ci: replace PKG_DISPATCH_TOKEN with GitHub App token

### DIFF
--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -1,12 +1,12 @@
 name: Trigger pkg repository republish
 
-# Manual dispatch that fires pfBlockerNG/pkg's publish.yml via the
-# PKG_DISPATCH_TOKEN PAT — the SAME cross-repo dispatch release.yml's repo-publish
-# job runs on a release. Two uses: republish the self-hosted pkg catalog on demand
-# (the pkg repo also runs daily on its own schedule), and verify PKG_DISPATCH_TOKEN
-# works — a FAILED run means the PAT is missing / expired / lacks Actions:write on
-# pfBlockerNG/pkg. Least-privilege: the PAT (an env secret) starts a workflow in the
-# other repo; nothing from this repo's contents is needed.
+# Manual dispatch that fires pfBlockerNG/pkg's publish.yml via a GitHub App token.
+# The SAME cross-repo dispatch release.yml's repo-publish job runs on a release.
+# Two uses: republish the self-hosted pkg catalog on demand (the pkg repo also runs
+# daily on its own schedule), and verify the GitHub App credentials work — a FAILED
+# run means the App ID / private key is missing, misconfigured, or lacks
+# Actions:write on pfBlockerNG/pkg. Least-privilege: the generated token starts a
+# workflow in the other repo; nothing from this repo's contents is needed.
 
 on:
   workflow_dispatch:
@@ -19,7 +19,16 @@ jobs:
     name: Dispatch pfBlockerNG/pkg publish.yml
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger publish.yml via PKG_DISPATCH_TOKEN
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
+          owner: pfBlockerNG
+          repositories: pkg
+
+      - name: Trigger publish.yml via GitHub App token
         env:
-          GH_TOKEN: ${{ secrets.PKG_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh workflow run publish.yml -R pfBlockerNG/pkg

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
           owner: pfBlockerNG
           repositories: pkg
+          permission-actions: write
 
       - name: Trigger publish.yml via GitHub App token
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -521,11 +521,20 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
+          owner: pfBlockerNG
+          repositories: pkg
+
       - name: Dispatch pfBlockerNG/pkg publish.yml
-        # PKG_DISPATCH_TOKEN: a fine-grained PAT scoped to pfBlockerNG/pkg with
-        # Actions:write — only enough to start a workflow there (cannot push code).
+        # GitHub App scoped to pfBlockerNG/pkg with Actions:write — only enough to
+        # start a workflow there (cannot push code).
         env:
-          GH_TOKEN: ${{ secrets.PKG_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh workflow run publish.yml -R pfBlockerNG/pkg
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -529,6 +529,7 @@ jobs:
           private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
           owner: pfBlockerNG
           repositories: pkg
+          permission-actions: write
 
       - name: Dispatch pfBlockerNG/pkg publish.yml
         # GitHub App scoped to pfBlockerNG/pkg with Actions:write — only enough to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,8 +584,9 @@ update badge stay Netgate-bound; a GUI "Updates/Channel" panel is deferred (woul
   OIDC `actions/deploy-pages` → served at `pfblockerng.github.io/pkg`. **No deploy key, no
   cross-repo secret** — everything it reads from here is public. Triggers: a daily
   `schedule` + `workflow_dispatch`. This repo's `release.yml` `repo-publish` job just fires
-  `gh workflow run publish.yml -R pfBlockerNG/pkg` (auth: the **`PKG_DISPATCH_TOKEN`**
-  fine-grained PAT — `Actions:write` on `pfBlockerNG/pkg` only) so a release publishes
+  `gh workflow run publish.yml -R pfBlockerNG/pkg` (auth: a GitHub App token via
+  `actions/create-github-app-token@v3`, secrets **`PKG_GITHUB_APP_ID`** +
+  **`PKG_GITHUB_APP_PRIVATE_KEY`** — `Actions:write` on `pfBlockerNG/pkg` only) so a release publishes
   within seconds; additive + isolated (only `needs: [release]`), so its failure never
   breaks `release`/`ports-pr`/`attach-pkgs`. The FreeBSD `pkg repo` fidelity path
   (`scripts/build-repo.sh`) is retained as a script only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -742,8 +742,9 @@ is retained for free and a rollback is a re-deploy.
   bootstrap (`scripts/add-repo.sh`) and the inline conf in the README reuse byte-for-byte.
 - **Triggers.** `pfBlockerNG/pkg`'s `publish.yml` runs on a daily `schedule` +
   `workflow_dispatch`, and `release.yml`'s `repo-publish` job fires it on each release
-  (`gh workflow run`, auth via the `PKG_DISPATCH_TOKEN` fine-grained PAT — `Actions:write`
-  on `pfBlockerNG/pkg` only). That job is additive + isolated (only `needs: [release]`), so
+  (`gh workflow run`, auth via a GitHub App token from `actions/create-github-app-token@v3` —
+  secrets `PKG_GITHUB_APP_ID` + `PKG_GITHUB_APP_PRIVATE_KEY`, `Actions:write` on
+  `pfBlockerNG/pkg` only). That job is additive + isolated (only `needs: [release]`), so
   its failure never breaks the Release or the ports PR.
 
 See [ADR-17](.ADRs/ADR_17_Pkg_Repository/ADR.md) for the full design.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes the `PKG_DISPATCH_TOKEN` fine-grained PAT from both cross-repo dispatch sites
- Adds `actions/create-github-app-token@v3` to generate a short-lived token scoped to `pfBlockerNG/pkg` (`Actions:write` only)
- Updates `CLAUDE.md` and `CONTRIBUTING.md` to reflect the new auth approach

## Changes

- `.github/workflows/pkg-republish.yml` — new `Generate GitHub App token` step before dispatch; `GH_TOKEN` sourced from `steps.app-token.outputs.token`
- `.github/workflows/release.yml` (`repo-publish` job) — same pattern
- `CLAUDE.md` / `CONTRIBUTING.md` — doc refs updated from `PKG_DISPATCH_TOKEN` to `PKG_GITHUB_APP_ID` + `PKG_GITHUB_APP_PRIVATE_KEY`

## Secrets required

| Secret | Purpose |
|--------|---------|
| `PKG_GITHUB_APP_ID` | GitHub App ID |
| `PKG_GITHUB_APP_PRIVATE_KEY` | GitHub App private key |

`PKG_DISPATCH_TOKEN` can be removed from repo secrets once this is confirmed working.

## Test plan

- [ ] Ensure `PKG_GITHUB_APP_ID` and `PKG_GITHUB_APP_PRIVATE_KEY` are set as repo secrets
- [ ] Dispatch `pkg-republish.yml` manually — verify it triggers `publish.yml` in `pfBlockerNG/pkg`
- [ ] Cut a release — verify `repo-publish` job completes successfully

Closes #164

https://claude.ai/code/session_0195ptoaKTYMzooiSBceQJaf
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0195ptoaKTYMzooiSBceQJaf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched automated package publishing to authenticate with GitHub App installation tokens instead of personal access tokens, improving CI/CD security and credential handling.

* **Documentation**
  * Updated contributor and internal docs to reflect the new GitHub App–based publishing authentication and related instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->