### PR TITLE
ci: fix read-version-matrix action path (../../.. not ../..)

### DIFF
--- a/.github/actions/read-version-matrix/action.yml
+++ b/.github/actions/read-version-matrix/action.yml
@@ -44,7 +44,7 @@ runs:
         MATRIX_REF: ${{ inputs.ref }}
         MATRIX_FILE: ${{ inputs.matrix_file }}
       run: |
-        sh "${{ github.action_path }}/../../scripts/read-version-matrix.sh" \
+        sh "${{ github.action_path }}/../../../scripts/read-version-matrix.sh" \
           --ref "$MATRIX_REF" \
           --file "$MATRIX_FILE" \
           --github-output


### PR DESCRIPTION
## Summary

- Fixes `scripts/read-version-matrix.sh: No such file` error crashing every `version-tracker.yml` run since the workflow was introduced.

## Root cause

`github.action_path` for `.github/actions/read-version-matrix` points to
`<workspace>/.github/actions/read-version-matrix/`. Two `..` levels land at
`.github/` (not the repo root), so the runner looked for
`.github/scripts/read-version-matrix.sh` which doesn't exist. Three levels up
reaches the workspace root where `scripts/` lives.

## Test plan

- [ ] CI green on this PR
- [ ] Dispatch `version-tracker.yml` dry-run to confirm it reaches the `react` step

https://claude.ai/code/session_01TPFmEe2iRdVJN1ifdmpEj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPFmEe2iRdVJN1ifdmpEj7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration path. Action functionality and outputs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->