### PR TITLE
ci/probe: replace frozen RELENG scan with Netgate-page scraper

### DIFF
--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -7,8 +7,8 @@ name: Version Tracker
 #
 # DETECT = CURATED: a human edits supported-versions.json on ci-metadata when
 # a pfSense beta or GA drops.  An OPTIONAL best-effort probe (see `probe` job)
-# scans pfsense/FreeBSD-ports RELENG_* branches for versions absent from the
-# matrix and opens an issue nudge — it NEVER edits the matrix.
+# scrapes the Netgate docs versions page for CE + Plus versions absent from the
+# matrix and opens per-version nudge/tracking issues — it NEVER edits the matrix.
 #
 # ┌─────────────────────────────────────────────────────────────────────┐
 # │ INVARIANT: this workflow NEVER commits to or force-pushes           │
@@ -260,28 +260,24 @@ jobs:
 
   # ── 3. Optional best-effort probe ────────────────────────────────────────────
   #
-  # Scans pfsense/FreeBSD-ports RELENG_* branches for pfSense CE versions that
-  # are NOT already in the matrix.  On detecting an unknown version, opens a
-  # GitHub ISSUE nudge asking a human to evaluate and add it to the matrix.
+  # Scrapes docs.netgate.com for authoritative CE + Plus version coverage and
+  # compares against the BUILD matrix.  Opens one nudge issue per still-supported
+  # version absent from the matrix, and one tracking issue per upcoming/TBD version
+  # (updated in place as the stage advances).
   #
   # NEVER edits the matrix.  NEVER commits to any branch.  NUDGES ONLY.
+  # Best-effort: any fetch/parse failure → empty result, no issues, no job failure.
   #
   # DISABLING: set skip_probe='true' on workflow_dispatch, or add the label
-  # 'tracker-probe-disabled' to this repo (checked in the step below), or
-  # simply remove the `probe` job from this file entirely.
-  # The probe also degrades gracefully if:
-  #   - The GitHub API is rate-limited or unreachable (exits 0 with a warning).
-  #   - GITHUB_TOKEN lacks 'issues: write' (logs but does not fail).
+  # 'tracker-probe-disabled' to this repo, or remove this job entirely.
   probe:
     name: Best-effort version probe (nudge only)
     runs-on: ubuntu-latest
     needs: read-matrix
-    # The probe is independent of react — failures here must not block react.
-    # It runs in parallel with react; if both are running, a probe failure
-    # does NOT affect the react job or downstream workflow dispatches.
+    # Probe runs in parallel with react; failures here NEVER block react.
     if: github.event.inputs.skip_probe != 'true'
     permissions:
-      issues: write    # to open a nudge issue
+      issues: write
       contents: read
     steps:
       - uses: actions/checkout@v6
@@ -294,8 +290,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          # If the repo has a 'tracker-probe-disabled' label, skip the probe.
-          # This is the softest on/off switch without touching workflow YAML.
           if gh label list --repo "$REPO" --limit 100 \
               | grep -q 'tracker-probe-disabled'; then
             echo "probe_disabled=true" >> "$GITHUB_OUTPUT"
@@ -304,134 +298,162 @@ jobs:
             echo "probe_disabled=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Scan pfsense/FreeBSD-ports for unknown CE versions
+      - name: Detect pfSense versions via Netgate docs page
+        id: detect
         if: steps.probe_gate.outputs.probe_disabled != 'true'
+        continue-on-error: true
+        env:
+          BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
+        run: |
+          set -eu
+          # On any fetch/parse failure the script exits 0 with an empty result.
+          python3 scripts/check-pfsense-versions.py \
+            --matrix-json "$BUILD_MATRIX" \
+            > probe_result.json
+          echo "Probe result:"
+          python3 -m json.tool probe_result.json || cat probe_result.json
+
+      - name: Ensure version-tracker labels exist
+        if: steps.probe_gate.outputs.probe_disabled != 'true' && steps.detect.outcome == 'success'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-          BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "version-tracker" \
+            --color "0052CC" \
+            --description "Automated version tracking" \
+            --repo "$REPO" 2>/dev/null || true
+          gh label create "tracker-wontfix" \
+            --color "e4e669" \
+            --description "Suppress future version-tracker nudges for this version" \
+            --repo "$REPO" 2>/dev/null || true
+
+      - name: Open nudge issues for supported-but-missing versions
+        if: steps.probe_gate.outputs.probe_disabled != 'true' && steps.detect.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           set -eu
+          COUNT=$(jq '.supported_missing | length' probe_result.json)
+          echo "supported_missing count: ${COUNT}"
+          [ "$COUNT" -eq 0 ] && echo "No supported-but-missing versions detected." && exit 0
 
-          # ── Extract known pfsense_version patterns from the matrix ─────────
-          # The matrix uses "X.Y.x" patterns for CE (e.g. "2.8.x").
-          # Normalise to "X.Y" prefixes for matching against real version strings.
-          KNOWN_PREFIXES=$(printf '%s\n' "$BUILD_MATRIX" \
-            | jq -r '
-                [.[] | select(.channel == "CE") | .pfsense_version]
-                | map(
-                    if endswith(".x") then .[:-2]
-                    else .
-                    end
-                  )
-                | .[]
-              ')
+          i=0
+          while [ "$i" -lt "$COUNT" ]; do
+            VERSION=$(jq -r ".supported_missing[$i].version" probe_result.json)
+            CHANNEL=$(jq -r ".supported_missing[$i].channel" probe_result.json)
+            FREEBSD=$(jq -r ".supported_missing[$i].freebsd_major" probe_result.json)
+            i=$((i + 1))
 
-          echo "Known CE version prefixes in matrix:"
-          printf '  %s\n' $KNOWN_PREFIXES
+            TITLE="[version-tracker] pfSense ${CHANNEL} ${VERSION} still-supported — evaluate for matrix"
 
-          # ── Fetch RELENG_* branches from pfsense/FreeBSD-ports ────────────
-          # These branches follow the pattern RELENG_X_Y[_Z] (e.g. RELENG_2_8_0).
-          # We extract the X.Y part to compare against known matrix prefixes.
-          echo ""
-          echo "Fetching branch list from pfsense/FreeBSD-ports..."
-          RELENG_BRANCHES=$(gh api \
-            "repos/pfsense/FreeBSD-ports/git/refs/heads" \
-            --jq '[.[] | .ref | ltrimstr("refs/heads/")]
-                  | map(select(startswith("RELENG_"))) | .[]' \
-            2>/dev/null || echo "")
-
-          if [ -z "$RELENG_BRANCHES" ]; then
-            echo "::warning::No RELENG_* branches found or GitHub API unreachable — skipping probe."
-            exit 0
-          fi
-
-          echo "Found RELENG_* branches:"
-          printf '  %s\n' $RELENG_BRANCHES
-
-          # ── Compare against known matrix entries ──────────────────────────
-          UNKNOWNS=""
-          for BRANCH in $RELENG_BRANCHES; do
-            # RELENG_2_8_0 -> 2.8  (take first two numeric segments)
-            VERSION=$(printf '%s\n' "$BRANCH" \
-              | sed 's/RELENG_//' \
-              | sed 's/_/./g' \
-              | grep -oE '^[0-9]+\.[0-9]+')
-
-            if [ -z "$VERSION" ]; then
+            # Skip if an open issue with this exact title already exists.
+            EXISTING=$(gh issue list --repo "$REPO" --state open --json title 2>/dev/null \
+              | jq --arg t "$TITLE" '[.[] | select(.title == $t)] | length')
+            if [ "${EXISTING:-0}" -gt 0 ]; then
+              echo "  [skip] open issue already exists for ${CHANNEL} ${VERSION}"
               continue
             fi
 
-            FOUND=0
-            for PREFIX in $KNOWN_PREFIXES; do
-              case "$VERSION" in
-                "${PREFIX}"*) FOUND=1; break ;;
-              esac
-            done
-
-            if [ "$FOUND" -eq 0 ]; then
-              UNKNOWNS="${UNKNOWNS} ${BRANCH}(${VERSION})"
-              echo "  [UNKNOWN] ${BRANCH} -> CE ${VERSION} not in matrix"
-            else
-              echo "  [known]   ${BRANCH} -> CE ${VERSION} covered"
+            # Skip if a closed issue with tracker-wontfix mentions this version.
+            WONTFIX=$(gh issue list --repo "$REPO" --state closed --label "tracker-wontfix" \
+              --json title 2>/dev/null \
+              | jq --arg v "$VERSION" '[.[] | select(.title | contains($v))] | length')
+            if [ "${WONTFIX:-0}" -gt 0 ]; then
+              echo "  [wontfix] suppressed for ${CHANNEL} ${VERSION}"
+              continue
             fi
+
+            BODY_FILE=$(mktemp)
+            {
+              printf '## pfSense %s %s is still-supported but absent from the matrix\n\n' "$CHANNEL" "$VERSION"
+              printf 'pfSense **%s %s** (FreeBSD %s) appears as **still-supported** on the\n' "$CHANNEL" "$VERSION" "$FREEBSD"
+              printf '[Netgate versions page](https://docs.netgate.com/pfsense/en/latest/releases/versions.html)\n'
+              printf 'but is **not in the supported-version matrix** on `ci-metadata`.\n\n'
+              printf '**Action (human required):** if this version should be supported,\n'
+              printf 'add an entry to `supported-versions.json` on the `ci-metadata` branch\n'
+              printf 'via a PR. See `scripts/README.md` for the schema and lifecycle policy.\n\n'
+              printf 'To suppress future nudges for this version: close this issue and add\n'
+              printf 'the `tracker-wontfix` label.\n\n'
+              printf '_This issue was opened automatically by the version-tracker probe._\n'
+              printf '_The probe NEVER edits the matrix — all changes require a human PR._\n'
+            } > "$BODY_FILE"
+
+            echo "  [create] Opening nudge issue for ${CHANNEL} ${VERSION}"
+            gh issue create \
+              --repo "$REPO" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE" \
+              --label "version-tracker,enhancement" \
+              || echo "  ::warning::Could not open nudge issue for ${CHANNEL} ${VERSION}"
+            rm -f "$BODY_FILE"
           done
 
-          # ── Open a nudge issue for any unknown versions ───────────────────
-          if [ -z "$UNKNOWNS" ]; then
-            echo ""
-            echo "All detected RELENG_* versions are covered by the matrix. No nudge needed."
-            exit 0
-          fi
+          echo "Invariant confirmed: no channel-branch writes from the probe."
 
-          echo ""
-          echo "Unknown versions detected — opening a nudge issue."
+      - name: Open or update tracking issues for upcoming/TBD versions
+        if: steps.probe_gate.outputs.probe_disabled != 'true' && steps.detect.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          COUNT=$(jq '.future | length' probe_result.json)
+          echo "future count: ${COUNT}"
+          [ "$COUNT" -eq 0 ] && echo "No future/TBD versions detected." && exit 0
 
-          ISSUE_TITLE="[version-tracker] New pfSense CE version(s) detected — matrix update needed"
+          i=0
+          while [ "$i" -lt "$COUNT" ]; do
+            VERSION=$(jq -r ".future[$i].version" probe_result.json)
+            CHANNEL=$(jq -r ".future[$i].channel" probe_result.json)
+            RELEASED=$(jq -r ".future[$i].released" probe_result.json)
+            FREEBSD=$(jq -r ".future[$i].freebsd_major" probe_result.json)
+            i=$((i + 1))
 
-          # Write the issue body to a temp file to avoid shell/YAML quoting conflicts.
-          BODY_FILE=$(mktemp)
-          UNKNOWN_LIST=$(printf '%s\n' $UNKNOWNS | tr ' ' '\n' | sed 's/^/- /')
-          {
-            printf 'The version-tracker probe detected pfSense CE version(s) in\n'
-            printf '`pfsense/FreeBSD-ports` that are NOT yet in the supported-version\n'
-            printf 'matrix on `ci-metadata`.\n\n'
-            printf '**Action required (human):** evaluate each version below and, if it\n'
-            printf 'should be supported, add an entry to `supported-versions.json` on the\n'
-            printf '`ci-metadata` branch via a PR.\n'
-            printf 'See `scripts/README.md` (Supported-version matrix section) for the\n'
-            printf 'schema and lifecycle policy.\n\n'
-            printf '**Detected unknown version(s):**\n'
-            printf '%s\n' "$UNKNOWN_LIST"
-            printf '\n'
-            printf '**Matrix location:** `origin/ci-metadata:supported-versions.json`\n\n'
-            printf '**This issue was opened automatically by the version-tracker probe.**\n'
-            printf '**The probe NEVER edits the matrix -- all changes require a human PR.**\n'
-          } > "$BODY_FILE"
+            TITLE="[version-tracker] pfSense ${CHANNEL} ${VERSION} — upcoming version tracking"
 
-          # Check whether an open nudge issue already exists to avoid spam.
-          EXISTING=$(gh issue list \
-            --repo "$REPO" \
-            --state open \
-            --label "version-tracker" \
-            --limit 10 \
-            --json number,title \
-            --jq '[.[] | select(.title | startswith("[version-tracker]"))] | length' \
-            2>/dev/null || echo "0")
+            BODY_FILE=$(mktemp)
+            {
+              printf '## Upcoming pfSense %s %s\n\n' "$CHANNEL" "$VERSION"
+              printf '| Field | Value |\n'
+              printf '| --- | --- |\n'
+              printf '| Version | `%s` |\n' "$VERSION"
+              printf '| Channel | %s |\n' "$CHANNEL"
+              printf '| FreeBSD major | %s |\n' "$FREEBSD"
+              printf '| Released | %s |\n' "$RELEASED"
+              printf '\n'
+              printf 'pfSense **%s %s** is listed as an upcoming/TBD version on the\n' "$CHANNEL" "$VERSION"
+              printf '[Netgate versions page](https://docs.netgate.com/pfsense/en/latest/releases/versions.html).\n\n'
+              printf 'Once it reaches GA, evaluate adding an entry to `supported-versions.json`\n'
+              printf 'on the `ci-metadata` branch via a PR.\n\n'
+              printf '_This issue is updated automatically by the version-tracker probe as_\n'
+              printf '_the page signal changes (TBD → released date → GA)._\n'
+            } > "$BODY_FILE"
 
-          if [ "$EXISTING" -gt "0" ]; then
-            echo "A nudge issue already exists — skipping duplicate open."
-            echo "Resolve the existing 'version-tracker' issue first."
-            exit 0
-          fi
+            # Update an existing open tracking issue; create one if none exists.
+            EXISTING_NUM=$(gh issue list --repo "$REPO" --state open --json number,title \
+              2>/dev/null \
+              | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+              | head -1)
 
-          gh issue create \
-            --repo "$REPO" \
-            --title "$ISSUE_TITLE" \
-            --body-file "$BODY_FILE" \
-            --label "enhancement" \
-            || echo "::warning::Could not open nudge issue (token may lack issues:write) — see log above."
-          rm -f "$BODY_FILE"
+            if [ -n "$EXISTING_NUM" ]; then
+              echo "  [update] Updating tracking issue #${EXISTING_NUM} for ${CHANNEL} ${VERSION}"
+              gh issue edit "$EXISTING_NUM" --repo "$REPO" --body-file "$BODY_FILE" \
+                || echo "  ::warning::Could not update tracking issue #${EXISTING_NUM}"
+            else
+              echo "  [create] Opening tracking issue for ${CHANNEL} ${VERSION}"
+              gh issue create \
+                --repo "$REPO" \
+                --title "$TITLE" \
+                --body-file "$BODY_FILE" \
+                --label "version-tracker,enhancement" \
+                || echo "  ::warning::Could not create tracking issue for ${CHANNEL} ${VERSION}"
+            fi
+            rm -f "$BODY_FILE"
+          done
 
-          echo "Nudge issue opened. The probe has NOT edited the matrix."
           echo "Invariant confirmed: no channel-branch writes from the probe."

--- a/scripts/check-pfsense-versions.py
+++ b/scripts/check-pfsense-versions.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""
+check-pfsense-versions.py — detect pfSense versions missing from the supported-
+version matrix by scraping docs.netgate.com/pfsense/en/latest/releases/versions.html.
+
+Usage:
+  check-pfsense-versions.py [--html-file PATH] [--matrix-json JSON]
+  printf '%s' "$BUILD_MATRIX" | check-pfsense-versions.py
+
+Output (stdout): {"supported_missing": [...], "future": [...]}
+
+  supported_missing — families that appear as still-supported on the Netgate page
+                      but are absent from the BUILD matrix.
+  future            — families whose only rows are TBD/unreleased.
+
+Graceful: any fetch or parse failure → empty result + ::warning:: to stderr, exit 0.
+Pure detection — no gh calls, no matrix writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from collections import defaultdict
+from html.parser import HTMLParser
+from typing import NamedTuple
+
+VERSIONS_URL = "https://docs.netgate.com/pfsense/en/latest/releases/versions.html"
+
+_FETCH_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+}
+
+_EMPTY: dict[str, list[dict[str, str]]] = {"supported_missing": [], "future": []}
+
+
+# ── Data types ─────────────────────────────────────────────────────────────────
+
+
+class _Row(NamedTuple):
+    version: str
+    support: str  # "supported" | "eol" | "future"
+    released: str
+    freebsd_version: str
+    freebsd_major: str
+    channel: str  # "CE" | "Plus"
+    normalized: str  # family key: "2.8.x" (CE) or "26.03" (Plus)
+
+
+class _Family(NamedTuple):
+    version: str
+    channel: str
+    status: str  # "supported" | "future" | "eol"
+    freebsd_version: str
+    freebsd_major: str
+    released: str
+
+
+# ── HTML parser ────────────────────────────────────────────────────────────────
+
+
+class _TableParser(HTMLParser):
+    """Extract all <table> elements as list-of-rows (each row = list of cell texts)."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.tables: list[list[list[str]]] = []
+        self._depth = 0
+        self._in_cell = False
+        self._cur_table: list[list[str]] = []
+        self._cur_row: list[str] = []
+        self._cur_parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        t = tag.lower()
+        if t == "table":
+            if self._depth == 0:
+                self._cur_table = []
+            self._depth += 1
+        elif t == "tr" and self._depth == 1:
+            self._cur_row = []
+        elif t in ("td", "th") and self._depth == 1:
+            self._in_cell = True
+            self._cur_parts = []
+        elif t == "img" and self._in_cell:
+            alt = (dict(attrs).get("alt") or "").strip()
+            if alt:
+                self._cur_parts.append(alt)
+
+    def handle_endtag(self, tag: str) -> None:
+        t = tag.lower()
+        if t == "table":
+            self._depth -= 1
+            if self._depth == 0:
+                self.tables.append(self._cur_table)
+                self._cur_table = []
+        elif t == "tr" and self._depth == 1:
+            if self._cur_row:
+                self._cur_table.append(self._cur_row[:])
+        elif t in ("td", "th") and self._depth == 1 and self._in_cell:
+            self._cur_row.append(" ".join(self._cur_parts).strip())
+            self._in_cell = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_cell:
+            s = data.strip()
+            if s:
+                self._cur_parts.append(s)
+
+
+# ── Classification helpers ─────────────────────────────────────────────────────
+
+
+def _support_from_cell(cell: str) -> str:
+    """Map Support-column cell text to 'supported', 'eol', or 'future'.
+
+    The cell text is the <img alt="…"> value from the Netgate docs table:
+      fa-check → supported
+      fa-times → eol
+      fa-clock → future/TBD (unreleased)
+    Anything else defaults to 'future' (conservative — don't report as missing).
+    """
+    low = cell.lower()
+    if "fa-check" in low:
+        return "supported"
+    if "fa-times" in low:
+        return "eol"
+    return "future"
+
+
+def _freebsd_major(raw: str) -> str:
+    """'16.0-CURRENT@hash' or '15.0-RELEASE' → '16' / '15'."""
+    m = re.match(r"(\d+)\.", raw.strip())
+    return m.group(1) if m else ""
+
+
+def _channel_from_branch(branch: str) -> str | None:
+    """'plus-RELENG_*' → 'Plus', 'RELENG_*' → 'CE', else None."""
+    bl = branch.strip().lower()
+    if bl.startswith("plus-releng_"):
+        return "Plus"
+    if bl.startswith("releng_"):
+        return "CE"
+    return None
+
+
+def _normalize(raw: str, channel: str) -> str:
+    """Normalize a raw version string to its family key.
+
+    CE  '2.8.1'    → '2.8.x'
+    Plus '26.03.1' → '26.03'
+    """
+    parts = raw.strip().split(".")
+    if channel == "CE" and len(parts) >= 2:
+        return f"{parts[0]}.{parts[1]}.x"
+    if channel == "Plus" and len(parts) >= 2:
+        return f"{parts[0]}.{parts[1]}"
+    return raw
+
+
+# ── Table → _Row list ──────────────────────────────────────────────────────────
+
+
+def parse_tables(tables: list[list[list[str]]]) -> list[_Row]:
+    """Convert raw table data into typed _Row entries."""
+    rows: list[_Row] = []
+    for table in tables:
+        if not table:
+            continue
+        header = table[0]
+        col: dict[str, int] = {}
+        for i, cell in enumerate(header):
+            key = re.sub(r"\s+", " ", cell).strip().lower()
+            if key == "version":
+                col["version"] = i
+            elif key == "support":
+                col["support"] = i
+            elif key == "released":
+                col["released"] = i
+            elif "freebsd" in key:
+                col["freebsd"] = i
+            elif key == "branch":
+                col["branch"] = i
+
+        if not {"version", "support", "freebsd", "branch"}.issubset(col):
+            continue
+
+        max_idx = max(col.values())
+        for row in table[1:]:
+            if len(row) <= max_idx:
+                continue
+            ver_raw = row[col["version"]].strip()
+            branch_raw = row[col["branch"]].strip()
+            if not ver_raw or not branch_raw:
+                continue
+
+            channel = _channel_from_branch(branch_raw)
+            if channel is None:
+                continue
+
+            fbsd_raw = row[col["freebsd"]].strip()
+            released = row[col["released"]].strip() if "released" in col else ""
+
+            rows.append(
+                _Row(
+                    version=ver_raw,
+                    support=_support_from_cell(row[col["support"]]),
+                    released=released,
+                    freebsd_version=fbsd_raw,
+                    freebsd_major=_freebsd_major(fbsd_raw),
+                    channel=channel,
+                    normalized=_normalize(ver_raw, channel),
+                )
+            )
+    return rows
+
+
+# ── Family grouping ────────────────────────────────────────────────────────────
+
+
+def group_families(rows: list[_Row]) -> list[_Family]:
+    """Group rows by (normalized_version, channel) and classify each family."""
+    groups: dict[tuple[str, str], list[_Row]] = defaultdict(list)
+    for r in rows:
+        groups[(r.normalized, r.channel)].append(r)
+
+    result: list[_Family] = []
+    for (normalized, channel), members in groups.items():
+        supported = [r for r in members if r.support == "supported"]
+        future = [r for r in members if r.support == "future"]
+
+        if supported:
+            status, ref = "supported", supported[0]
+        elif future:
+            status, ref = "future", future[0]
+        else:
+            status, ref = "eol", members[0]
+
+        result.append(
+            _Family(
+                version=normalized,
+                channel=channel,
+                status=status,
+                freebsd_version=ref.freebsd_version,
+                freebsd_major=ref.freebsd_major,
+                released=ref.released,
+            )
+        )
+    return result
+
+
+# ── Diff ──────────────────────────────────────────────────────────────────────
+
+
+def diff(
+    families: list[_Family],
+    build_matrix: list[dict[str, str]],
+) -> dict[str, list[dict[str, str]]]:
+    """Produce the output JSON dict from the families + matrix comparison."""
+    in_matrix = {entry["pfsense_version"] for entry in build_matrix}
+
+    supported_missing: list[dict[str, str]] = []
+    future_list: list[dict[str, str]] = []
+
+    for fam in sorted(families, key=lambda f: (f.channel, f.version)):
+        if fam.status == "supported" and fam.version not in in_matrix:
+            supported_missing.append(
+                {
+                    "version": fam.version,
+                    "channel": fam.channel,
+                    "freebsd_major": fam.freebsd_major,
+                    "freebsd_version": fam.freebsd_version,
+                }
+            )
+        elif fam.status == "future":
+            future_list.append(
+                {
+                    "version": fam.version,
+                    "channel": fam.channel,
+                    "released": fam.released,
+                    "freebsd_major": fam.freebsd_major,
+                }
+            )
+
+    return {"supported_missing": supported_missing, "future": future_list}
+
+
+# ── I/O helpers ───────────────────────────────────────────────────────────────
+
+
+def _fetch(url: str) -> str | None:
+    req = urllib.request.Request(url, headers=_FETCH_HEADERS)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        print(f"::warning::fetch {url} failed: {exc}", file=sys.stderr)
+        return None
+
+
+def _load_matrix(matrix_arg: str | None) -> list[dict[str, str]]:
+    raw: str | None
+    if matrix_arg is not None:
+        raw = matrix_arg
+    elif not sys.stdin.isatty():
+        try:
+            raw = sys.stdin.read()
+        except Exception:
+            return []
+    else:
+        return []
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, list) else []
+    except json.JSONDecodeError:
+        return []
+
+
+# ── Entrypoint ────────────────────────────────────────────────────────────────
+
+
+def run(html_src: str | None, matrix_arg: str | None) -> int:
+    """Core logic; separated for testing. Returns exit code (always 0)."""
+    if html_src is None:
+        html_src = _fetch(VERSIONS_URL)
+        if html_src is None:
+            print(json.dumps(_EMPTY))
+            return 0
+
+    try:
+        p = _TableParser()
+        p.feed(html_src)
+        rows = parse_tables(p.tables)
+    except Exception as exc:  # noqa: BLE001
+        print(f"::warning::HTML parse error: {exc}", file=sys.stderr)
+        print(json.dumps(_EMPTY))
+        return 0
+
+    if not rows:
+        print(
+            "::warning::no version rows extracted — page structure may have changed",
+            file=sys.stderr,
+        )
+        print(json.dumps(_EMPTY))
+        return 0
+
+    families = group_families(rows)
+    build_matrix = _load_matrix(matrix_arg)
+    print(json.dumps(diff(families, build_matrix)))
+    return 0
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--html-file", metavar="PATH", help="Read HTML from file instead of fetching URL")
+    ap.add_argument("--matrix-json", metavar="JSON", help="BUILD matrix as a JSON string")
+    args = ap.parse_args()
+
+    html_src: str | None = None
+    if args.html_file:
+        try:
+            with open(args.html_file) as fh:
+                html_src = fh.read()
+        except OSError as exc:
+            print(f"::warning::cannot read {args.html_file}: {exc}", file=sys.stderr)
+            print(json.dumps(_EMPTY))
+            sys.exit(0)
+
+    sys.exit(run(html_src, args.matrix_json))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-pfsense-versions.py
+++ b/scripts/check-pfsense-versions.py
@@ -312,7 +312,7 @@ def _load_matrix(matrix_arg: str | None) -> list[dict[str, str]]:
     elif not sys.stdin.isatty():
         try:
             raw = sys.stdin.read()
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
     else:
         return []

--- a/tests/fixtures/netgate_versions_fixture.html
+++ b/tests/fixtures/netgate_versions_fixture.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Versions of pfSense software and FreeBSD — fixture</title></head>
+<body>
+<section id="pfsense-plus-software-version-history">
+<h2>pfSense Plus Software Version History</h2>
+
+<section id="plus-26-x">
+<h3>26.x</h3>
+<table class="docutils align-default">
+<thead>
+<tr class="row-odd"><th class="head"><p>Version</p></th>
+<th class="head"><p>Support</p></th>
+<th class="head"><p>Released</p></th>
+<th class="head"><p>Config Rev</p></th>
+<th class="head"><p>FreeBSD Version</p></th>
+<th class="head"><p>Branch</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p>26.07</p></td>
+<td><p><img alt="fa-clock" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-clock.png"></p></td>
+<td><p>TBD</p></td>
+<td><p>24.5</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/16.0R/hardware/">16.0-CURRENT@c215eef34550</a></p></td>
+<td><p>plus-RELENG_26_07</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="https://docs.netgate.com/pfsense/en/latest/releases/26-03-1.html"><span class="doc">26.03.1</span></a></p></td>
+<td><p><img alt="fa-check" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-check.png"></p></td>
+<td><p>2026-05-27</p></td>
+<td><p>24.5</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/16.0R/hardware/">16.0-CURRENT@c215eef34550</a></p></td>
+<td><p>plus-RELENG_26_03_1</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="https://docs.netgate.com/pfsense/en/latest/releases/26-03.html"><span class="doc">26.03</span></a></p></td>
+<td><p><img alt="fa-check" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-check.png"></p></td>
+<td><p>2026-04-01</p></td>
+<td><p>24.5</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/16.0R/hardware/">16.0-CURRENT@c215eef34550</a></p></td>
+<td><p>plus-RELENG_26_03</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+
+<section id="plus-25-x">
+<h3>25.x</h3>
+<table class="docutils align-default">
+<thead>
+<tr class="row-odd"><th class="head"><p>Version</p></th>
+<th class="head"><p>Support</p></th>
+<th class="head"><p>Released</p></th>
+<th class="head"><p>Config Rev</p></th>
+<th class="head"><p>FreeBSD Version</p></th>
+<th class="head"><p>Branch</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p><a class="reference internal" href="https://docs.netgate.com/pfsense/en/latest/releases/25-11-1.html"><span class="doc">25.11.1</span></a></p></td>
+<td><p><img alt="fa-times" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-times.png"></p></td>
+<td><p>2026-01-26</p></td>
+<td><p>24.2</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/16.0R/hardware/">16.0-CURRENT@44f3e9f7f6c9</a></p></td>
+<td><p>plus-RELENG_25_11_1</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="https://docs.netgate.com/pfsense/en/latest/releases/25-11.html"><span class="doc">25.11</span></a></p></td>
+<td><p><img alt="fa-times" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-times.png"></p></td>
+<td><p>2025-12-11</p></td>
+<td><p>24.1</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/16.0R/hardware/">16.0-CURRENT@44f3e9f7f6c9</a></p></td>
+<td><p>plus-RELENG_25_11</p></td>
+</tr>
+<tr class="row-even"><td><p><a class="reference internal" href="https://docs.netgate.com/pfsense/en/latest/releases/25-07-1.html"><span class="doc">25.07.1</span></a></p></td>
+<td><p><img alt="fa-times" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-times.png"></p></td>
+<td><p>2025-08-18</p></td>
+<td><p>24.0</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/15.0R/hardware/">15.0-CURRENT@bf06074106cf</a></p></td>
+<td><p>plus-RELENG_25_07_1</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="https://docs.netgate.com/pfsense/en/latest/releases/25-07.html"><span class="doc">25.07</span></a></p></td>
+<td><p><img alt="fa-times" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-times.png"></p></td>
+<td><p>2025-08-04</p></td>
+<td><p>24.0</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/15.0R/hardware/">15.0-CURRENT@bf06074106cf</a></p></td>
+<td><p>plus-RELENG_25_07</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+
+</section>
+<section id="pfsense-ce-software-version-history">
+<h2>pfSense CE Software Version History</h2>
+
+<section id="ce-2-9-x">
+<h3>2.9.x</h3>
+<table class="docutils align-default">
+<thead>
+<tr class="row-odd"><th class="head"><p>Version</p></th>
+<th class="head"><p>Support</p></th>
+<th class="head"><p>Released</p></th>
+<th class="head"><p>Config Rev</p></th>
+<th class="head"><p>FreeBSD Version</p></th>
+<th class="head"><p>Branch</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p>2.9.0</p></td>
+<td><p><img alt="fa-clock" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-clock.png"></p></td>
+<td><p>TBD</p></td>
+<td><p>24.1</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/16.0R/hardware/">16.0-CURRENT@3f5f52216f7e</a></p></td>
+<td><p>RELENG_2_9_0</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+
+<section id="ce-2-8-x">
+<h3>2.8.x</h3>
+<table class="docutils align-default">
+<thead>
+<tr class="row-odd"><th class="head"><p>Version</p></th>
+<th class="head"><p>Support</p></th>
+<th class="head"><p>Released</p></th>
+<th class="head"><p>Config Rev</p></th>
+<th class="head"><p>FreeBSD Version</p></th>
+<th class="head"><p>Branch</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p><a class="reference internal" href="https://docs.netgate.com/pfsense/en/latest/releases/2-8-1.html"><span class="doc">2.8.1</span></a></p></td>
+<td><p><img alt="fa-check" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-check.png"></p></td>
+<td><p>2025-09-04</p></td>
+<td><p>24.0</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/15.0R/hardware/">15.0-CURRENT@bf06074106cf</a></p></td>
+<td><p>RELENG_2_8_1</p></td>
+</tr>
+<tr class="row-odd"><td><p><a class="reference internal" href="https://docs.netgate.com/pfsense/en/latest/releases/2-8-0.html"><span class="doc">2.8.0</span></a></p></td>
+<td><p><img alt="fa-check" src="https://docs.netgate.com/pfsense/en/latest/_images/fa-check.png"></p></td>
+<td><p>2025-05-28</p></td>
+<td><p>24.0</p></td>
+<td><p><a class="reference external" href="https://www.freebsd.org/releases/15.0R/hardware/">15.0-CURRENT@bf06074106cf</a></p></td>
+<td><p>RELENG_2_8_0</p></td>
+</tr>
+</tbody>
+</table>
+</section>
+
+</section>
+</body>
+</html>

--- a/tests/test_version_probe.py
+++ b/tests/test_version_probe.py
@@ -1,0 +1,408 @@
+"""Tests for scripts/check-pfsense-versions.py.
+
+Branch coverage rules (CLAUDE.md):
+  every condition is tested in both directions; before-state is asserted
+  in transition tests.
+
+Scenario: Version probe against the Netgate docs page fixture
+  Background:
+    Given the fixture HTML contains Plus 26.x (supported + future),
+          Plus 25.x (all EOL), CE 2.9.x (future), CE 2.8.x (supported)
+    And the BUILD matrix represents the current ci-metadata state
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ── Load the hyphen-named script as a module ───────────────────────────────────
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check-pfsense-versions.py"
+_spec = importlib.util.spec_from_file_location("check_pfsense_versions", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+cvs = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = cvs
+_spec.loader.exec_module(cvs)
+
+# ── Fixture paths ─────────────────────────────────────────────────────────────
+
+FIXTURE_HTML = Path(__file__).resolve().parent / "fixtures" / "netgate_versions_fixture.html"
+
+
+def _fixture() -> str:
+    return FIXTURE_HTML.read_text(encoding="utf-8")
+
+
+# ── Minimal HTML helpers ──────────────────────────────────────────────────────
+
+
+def _make_table(rows: list[str]) -> str:
+    """Wrap row HTML strings in a minimal versions table."""
+    header = (
+        "<tr>"
+        "<th>Version</th>"
+        "<th>Support</th>"
+        "<th>Released</th>"
+        "<th>Config Rev</th>"
+        "<th>FreeBSD Version</th>"
+        "<th>Branch</th>"
+        "</tr>"
+    )
+    body = "\n".join(rows)
+    return f"<table><thead>{header}</thead><tbody>{body}</tbody></table>"
+
+
+def _make_row(
+    version: str,
+    support_alt: str,
+    released: str,
+    freebsd: str,
+    branch: str,
+) -> str:
+    """Build one <tr> matching the Netgate page format."""
+    support_cell = f'<img alt="{support_alt}" src="dummy.png">' if support_alt else ""
+    return (
+        f"<tr>"
+        f"<td>{version}</td>"
+        f"<td>{support_cell}</td>"
+        f"<td>{released}</td>"
+        f"<td>24.0</td>"
+        f"<td><a>{freebsd}</a></td>"
+        f"<td>{branch}</td>"
+        f"</tr>"
+    )
+
+
+# ── Support-cell classification ───────────────────────────────────────────────
+
+
+class TestSupportFromCell:
+    """Scenario: The Support cell text → support state mapping.
+
+    Given a Support cell value
+    When _support_from_cell() classifies it
+    Then the result matches the icon semantics from the Netgate page
+    """
+
+    def test_fa_check_yields_supported(self) -> None:
+        # Given the cell contains the 'fa-check' alt value
+        assert cvs._support_from_cell("fa-check") == "supported"
+
+    def test_fa_times_yields_eol(self) -> None:
+        # Given the cell contains the 'fa-times' alt value
+        assert cvs._support_from_cell("fa-times") == "eol"
+
+    def test_fa_clock_yields_future(self) -> None:
+        # Given the cell contains the 'fa-clock' alt value (TBD/unreleased row)
+        assert cvs._support_from_cell("fa-clock") == "future"
+
+    def test_empty_cell_defaults_to_future(self) -> None:
+        # Given an empty Support cell (no icon) — treated conservatively as future,
+        # not as missing-but-supported, so it never opens a false-positive nudge.
+        assert cvs._support_from_cell("") == "future"
+
+
+# ── Channel discriminator ─────────────────────────────────────────────────────
+
+
+class TestChannelFromBranch:
+    """Scenario: Branch column value → channel.
+
+    Given a Branch column value from the Netgate page
+    When _channel_from_branch() classifies it
+    Then Plus and CE are correctly identified from the prefix
+    """
+
+    def test_plus_releng_prefix_yields_plus(self) -> None:
+        # Given a branch name with 'plus-RELENG_' prefix
+        assert cvs._channel_from_branch("plus-RELENG_26_03") == "Plus"
+
+    def test_releng_prefix_yields_ce(self) -> None:
+        # Given a bare 'RELENG_' prefix (no 'plus-' prefix)
+        assert cvs._channel_from_branch("RELENG_2_8_0") == "CE"
+
+    def test_unrecognised_branch_yields_none(self) -> None:
+        # Given an unknown Branch value (e.g. main, HEAD)
+        assert cvs._channel_from_branch("main") is None
+
+    def test_channel_discrimination_is_case_insensitive(self) -> None:
+        # Given lowercase variants of the branch prefixes
+        assert cvs._channel_from_branch("plus-releng_26_03") == "Plus"
+        assert cvs._channel_from_branch("releng_2_8_0") == "CE"
+
+
+# ── Version normalization ─────────────────────────────────────────────────────
+
+
+class TestNormalize:
+    """Scenario: Raw version string → family key.
+
+    Given a raw version and channel
+    When _normalize() is called
+    Then CE is reduced to Major.Minor.x and Plus to Year.Month
+    """
+
+    def test_ce_patch_normalizes_to_family(self) -> None:
+        # Given CE version with patch component
+        assert cvs._normalize("2.8.1", "CE") == "2.8.x"
+
+    def test_ce_zero_patch_normalizes_to_family(self) -> None:
+        # Given CE version 2.9.0 (zero patch — same rule)
+        assert cvs._normalize("2.9.0", "CE") == "2.9.x"
+
+    def test_plus_patch_normalizes_to_year_month(self) -> None:
+        # Given Plus version with patch component
+        assert cvs._normalize("26.03.1", "Plus") == "26.03"
+
+    def test_plus_without_patch_is_idempotent(self) -> None:
+        # Given Plus version already at Year.Month level
+        assert cvs._normalize("26.07", "Plus") == "26.07"
+
+
+# ── FreeBSD major extraction ──────────────────────────────────────────────────
+
+
+class TestFreeBSDMajor:
+    """Scenario: FreeBSD Version column → major number.
+
+    Given a FreeBSD Version string from the Netgate page
+    When _freebsd_major() is called
+    Then only the leading major integer is returned, ignoring -CURRENT/@hash
+    """
+
+    def test_freebsd_16_current_with_hash(self) -> None:
+        assert cvs._freebsd_major("16.0-CURRENT@c215eef34550") == "16"
+
+    def test_freebsd_15_current_with_hash(self) -> None:
+        assert cvs._freebsd_major("15.0-CURRENT@bf06074106cf") == "15"
+
+    def test_freebsd_release_suffix_stripped(self) -> None:
+        # Ensure -RELEASE variants are also handled (the matrix uses -RELEASE)
+        assert cvs._freebsd_major("15.0-RELEASE") == "15"
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert cvs._freebsd_major("") == ""
+
+
+# ── Full parse + family grouping ──────────────────────────────────────────────
+
+
+class TestParseFixture:
+    """Scenario: Parse the real Netgate-page fixture HTML.
+
+    Given the fixture HTML extracted from the actual Netgate page snapshot
+    When parse_tables() + group_families() are called
+    Then all expected families are extracted with correct status, channel,
+         and FreeBSD major — proving Plus support (the old probe gap)
+    """
+
+    @pytest.fixture(autouse=True)
+    def _load(self) -> None:
+        p = cvs._TableParser()
+        p.feed(_fixture())
+        rows = cvs.parse_tables(p.tables)
+        self.families = {(f.version, f.channel): f for f in cvs.group_families(rows)}
+
+    def test_ce_2_8_x_is_supported(self) -> None:
+        fam = self.families[("2.8.x", "CE")]
+        assert fam.status == "supported"
+
+    def test_ce_2_8_x_has_freebsd_15(self) -> None:
+        fam = self.families[("2.8.x", "CE")]
+        assert fam.freebsd_major == "15"
+
+    def test_ce_2_9_x_is_future(self) -> None:
+        # Before-state: 2.9.x has no released row → future (not supported/EOL)
+        fam = self.families[("2.9.x", "CE")]
+        assert fam.status == "future"
+
+    def test_ce_2_9_x_released_is_tbd(self) -> None:
+        fam = self.families[("2.9.x", "CE")]
+        assert fam.released == "TBD"
+
+    def test_plus_26_03_is_supported(self) -> None:
+        # Plus family presence proves the old 'CE only' gap is fixed
+        fam = self.families[("26.03", "Plus")]
+        assert fam.status == "supported"
+
+    def test_plus_26_03_has_freebsd_16(self) -> None:
+        # FreeBSD major for Plus 26.03 is 16, distinct from CE 2.8.x (FreeBSD 15)
+        fam = self.families[("26.03", "Plus")]
+        assert fam.freebsd_major == "16"
+
+    def test_plus_26_07_is_future(self) -> None:
+        fam = self.families[("26.07", "Plus")]
+        assert fam.status == "future"
+
+    def test_plus_25_x_families_are_eol(self) -> None:
+        eol_fams = [f for f in self.families.values() if f.channel == "Plus" and f.version.startswith("25.")]
+        assert eol_fams, "expected Plus 25.x families in fixture"
+        for fam in eol_fams:
+            assert fam.status == "eol", f"{fam.version} should be eol"
+
+
+# ── Diff: supported_missing ───────────────────────────────────────────────────
+
+
+class TestDiffSupportedMissing:
+    """Scenario: Supported families absent from the matrix are reported.
+
+    Background:
+      Given the fixture has CE 2.8.x (supported) and Plus 26.03 (supported)
+
+    Tests prove both the positive case (missing → reported) and the negative
+    case (present → not reported), so a regression in either direction fails.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _parse(self) -> None:
+        p = cvs._TableParser()
+        p.feed(_fixture())
+        rows = cvs.parse_tables(p.tables)
+        self.families = cvs.group_families(rows)
+
+    def test_ce_2_8_x_present_in_matrix_not_reported(self) -> None:
+        # Given 2.8.x IS in the matrix
+        # Then it does NOT appear in supported_missing
+        matrix = [{"pfsense_version": "2.8.x", "channel": "CE"}]
+        result = cvs.diff(self.families, matrix)
+        versions = [e["version"] for e in result["supported_missing"]]
+        assert "2.8.x" not in versions
+
+    def test_plus_26_03_absent_from_matrix_is_reported(self) -> None:
+        # Given 26.03 is NOT in the matrix (matrix only has 2.8.x)
+        # Then 26.03 DOES appear in supported_missing
+        matrix = [{"pfsense_version": "2.8.x", "channel": "CE"}]
+        result = cvs.diff(self.families, matrix)
+        versions = [e["version"] for e in result["supported_missing"]]
+        assert "26.03" in versions
+
+    def test_channel_and_freebsd_major_in_missing_entry(self) -> None:
+        # Given Plus 26.03 is absent
+        # Then the entry carries channel=Plus and freebsd_major=16
+        matrix = [{"pfsense_version": "2.8.x", "channel": "CE"}]
+        result = cvs.diff(self.families, matrix)
+        entry = next(e for e in result["supported_missing"] if e["version"] == "26.03")
+        assert entry["channel"] == "Plus"
+        assert entry["freebsd_major"] == "16"
+
+    def test_eol_families_never_in_supported_missing(self) -> None:
+        # Given Plus 25.x families are all EOL
+        # Then they do NOT appear in supported_missing even with an empty matrix
+        result = cvs.diff(self.families, [])
+        versions = [e["version"] for e in result["supported_missing"]]
+        assert not any(v.startswith("25.") for v in versions)
+
+
+# ── Diff: future ─────────────────────────────────────────────────────────────
+
+
+class TestDiffFuture:
+    """Scenario: Future/TBD families land in the 'future' list, not supported_missing.
+
+    Background:
+      Given CE 2.9.0 and Plus 26.07 are TBD on the fixture page
+    """
+
+    @pytest.fixture(autouse=True)
+    def _parse(self) -> None:
+        p = cvs._TableParser()
+        p.feed(_fixture())
+        rows = cvs.parse_tables(p.tables)
+        self.families = cvs.group_families(rows)
+
+    def test_ce_2_9_x_in_future_not_missing(self) -> None:
+        result = cvs.diff(self.families, [])
+        future_versions = [e["version"] for e in result["future"]]
+        missing_versions = [e["version"] for e in result["supported_missing"]]
+        assert "2.9.x" in future_versions
+        assert "2.9.x" not in missing_versions
+
+    def test_plus_26_07_in_future_not_missing(self) -> None:
+        result = cvs.diff(self.families, [])
+        future_versions = [e["version"] for e in result["future"]]
+        missing_versions = [e["version"] for e in result["supported_missing"]]
+        assert "26.07" in future_versions
+        assert "26.07" not in missing_versions
+
+    def test_future_entry_has_tbd_released(self) -> None:
+        result = cvs.diff(self.families, [])
+        entry_29 = next(e for e in result["future"] if e["version"] == "2.9.x")
+        assert entry_29["released"] == "TBD"
+
+    def test_future_entry_includes_freebsd_major(self) -> None:
+        result = cvs.diff(self.families, [])
+        entry_29 = next(e for e in result["future"] if e["version"] == "2.9.x")
+        assert entry_29["freebsd_major"] == "16"
+
+
+# ── run() integration: graceful degradation ───────────────────────────────────
+
+
+class TestGracefulDegradation:
+    """Scenario: Any input failure → empty JSON result, exit 0, no exception.
+
+    Per the 'graceful' contract: the script must NEVER crash the workflow.
+    """
+
+    def _run_capture(self, html: str | None, matrix_arg: str | None) -> dict[str, Any]:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = cvs.run(html, matrix_arg)
+        assert rc == 0, "run() must return 0 (never fail the workflow)"
+        return json.loads(buf.getvalue())
+
+    def test_empty_html_yields_empty_result(self) -> None:
+        result = self._run_capture("", None)
+        assert result == {"supported_missing": [], "future": []}
+
+    def test_html_without_tables_yields_empty_result(self) -> None:
+        html = "<html><body><p>no tables here</p></body></html>"
+        result = self._run_capture(html, None)
+        assert result == {"supported_missing": [], "future": []}
+
+    def test_garbage_html_yields_empty_result(self) -> None:
+        # Even structurally broken HTML must not raise
+        html = "<<<NOT HTML AT ALL>>>"
+        result = self._run_capture(html, None)
+        assert result == {"supported_missing": [], "future": []}
+
+    def test_fixture_with_empty_matrix_returns_valid_json(self) -> None:
+        # Fixture with empty matrix: all supported families appear in supported_missing
+        result = self._run_capture(_fixture(), "[]")
+        assert isinstance(result["supported_missing"], list)
+        assert isinstance(result["future"], list)
+        # At least CE 2.8.x and Plus 26.03 should be missing
+        missing = [e["version"] for e in result["supported_missing"]]
+        assert "2.8.x" in missing
+        assert "26.03" in missing
+
+
+# ── Family status: mixed members ─────────────────────────────────────────────
+
+
+class TestFamilyStatusWithMixedMembers:
+    """Scenario: A family with both supported and future rows is 'supported'.
+
+    Background:
+      The 26.x family has 26.07 (future) AND 26.03/26.03.1 (supported).
+    """
+
+    def test_family_with_supported_member_is_supported(self) -> None:
+        rows = [
+            cvs._Row("26.03", "supported", "2026-04-01", "16.0-CURRENT@abc", "16", "Plus", "26.03"),
+            cvs._Row("26.07", "future", "TBD", "16.0-CURRENT@abc", "16", "Plus", "26.07"),
+        ]
+        # Before: 26.03 alone = supported family
+        fams = {(f.version, f.channel): f for f in cvs.group_families(rows)}
+        assert fams[("26.03", "Plus")].status == "supported"
+        # After: 26.07 alone = future family
+        assert fams[("26.07", "Plus")].status == "future"


### PR DESCRIPTION
## Summary

- Replaces the broken version-tracker `probe` job (was scanning `pfsense/FreeBSD-ports` RELENG branches, which are frozen at CE 2.3–2.7 and never covered Plus) with a Netgate-page scraper
- Adds `scripts/check-pfsense-versions.py`: stdlib Python 3.11, graceful degradation on any fetch/parse failure, detects both CE and Plus versions
- Adds 37 branch-covering unit tests (`tests/test_version_probe.py`) with real Netgate page markup as fixture (`tests/fixtures/netgate_versions_fixture.html`)
- Closes spam issues #168 and #169 (false positives from the old RELENG scan)
- ADR-09 amended on `devel` (commit b28a031) before this PR

## Key changes

**`scripts/check-pfsense-versions.py`** — pure detection, no `gh` calls:
- Fetches `docs.netgate.com/pfsense/en/latest/releases/versions.html` with browser headers; `--html-file PATH` for offline/test use
- Parses Support img alt: `fa-check` → supported, `fa-times` → EOL, `fa-clock` → future/TBD
- Channel from Branch column: `plus-RELENG_*` → Plus, `RELENG_*` → CE
- Normalises to family: CE `2.8.1` → `2.8.x`; Plus `26.03.1` → `26.03`
- Emits `{"supported_missing": [...], "future": [...]}` JSON; exits 0 on any failure

**`version-tracker.yml` probe job** — one issue per version:
- `supported_missing` → one nudge issue per version (dedup by exact title; `tracker-wontfix` suppression)
- `future` → one tracking issue per upcoming version (update body in place rather than reopen)
- Best-effort: `continue-on-error: true` on each issue step; detect step failure skips all issue steps

## Test plan

- [x] `python3 -m pytest tests/test_version_probe.py` — 37 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy tests/test_version_probe.py` — clean
- [ ] Post-merge: dispatch `version-tracker.yml` (`dry_run=true`, `skip_probe=false`) — confirm probe either detects correctly or degrades gracefully

https://claude.ai/code/session_01TPFmEe2iRdVJN1ifdmpEj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPFmEe2iRdVJN1ifdmpEj7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version tracking now sources official Netgate documentation and runs as a best-effort, non-blocking probe.
  * Improved issue management: creates one nudge per missing supported version and dedicated tracking issues for upcoming versions.

* **Tests**
  * Added comprehensive test suite validating parsing, classification, diffing, and graceful-degradation behavior.
  * Added HTML fixture with sample version history data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->