### PR TITLE
ci-metadata: Plus 25.03 → 26.03 (FreeBSD 16, php85, py311)

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -20,11 +20,11 @@
       "ci": true
     },
     {
-      "pfsense_version": "25.03",
+      "pfsense_version": "26.03",
       "channel": "Plus",
-      "freebsd_version": "15.0-RELEASE",
-      "freebsd_major": "15",
-      "php_version": "8.3",
+      "freebsd_version": "16.0-RELEASE",
+      "freebsd_major": "16",
+      "php_version": "8.5",
       "py_flavor": "py311",
       "status": "GA",
       "ci": false


### PR DESCRIPTION
## Summary

- Corrects the stale Plus `25.03` entry to the current GA release `26.03`
- Updates all four diverged fields; `py_flavor` stays `py311` (unchanged)

| Field | Before | After | Source |
|---|---|---|---|
| `pfsense_version` | `25.03` | `26.03` | Netgate versions page (ADR-09 probe) |
| `freebsd_version` | `15.0-RELEASE` | `16.0-RELEASE` | `pkg config ABI = FreeBSD:16:amd64` on live Plus 26.03.1 box |
| `freebsd_major` | `15` | `16` | same |
| `php_version` | `8.3` | `8.5` | `pkg info php85` on live Plus 26.03.1 box |
| `py_flavor` | `py311` | `py311` | unchanged — both variants are on 3.11 today |

## Evidence

Probe script `scripts/probe-pfsense-env.sh` run on a live **Plus 26.03.1** box (2026-06-09):

```text
${ABI}: FreeBSD:16:amd64
INSTALLED PHP PACKAGES
php85-8.5.5                    ...
INSTALLED PYTHON PACKAGES
py311-...
```

CE 2.8.x entry (`freebsd_major: 15`, `php_version: 8.3`) is correct and unchanged.

## Context

This is the data-fix companion to ADR-20 (`adr: create ADR-20 CE/Plus variant-aware pkg distribution`, `6ce77be` on `devel`), which documented the CE/Plus discovery findings and defined the two-variant catalog design. ADR-20 Phase 2 will later add a `variant` field to both entries; this PR corrects the factual errors first.

https://claude.ai/code/session_01TPFmEe2iRdVJN1ifdmpEj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPFmEe2iRdVJN1ifdmpEj7)_