### PR TITLE
scripts: fix ShellCheck SC2016 false positives in probe-pfsense-env.sh

### DIFF
--- a/scripts/probe-pfsense-env.sh
+++ b/scripts/probe-pfsense-env.sh
@@ -26,24 +26,26 @@ date
 sep "OS IDENTITY (uname / sysctl)"
 uname -a
 printf '\nOS fields pkg uses for URL variable expansion:\n'
-printf '  ${OSNAME}:         %s\n' "$(uname -s)"
-printf '  ${RELEASE}:        %s\n' "$(uname -r)"
-printf '  ${VERSION_MAJOR}:  %s\n' "$(uname -r | cut -d. -f1)"
-printf '  ${VERSION_MINOR}:  %s\n' "$(uname -r | cut -d. -f2 | cut -d- -f1)"
-printf '  ${ARCH}:           %s\n' "$(uname -m)"
+# \${VAR} labels are intentionally literal — these show pkg's variable names.
+printf "  \${OSNAME}:         %s\n" "$(uname -s)"
+printf "  \${RELEASE}:        %s\n" "$(uname -r)"
+printf "  \${VERSION_MAJOR}:  %s\n" "$(uname -r | cut -d. -f1)"
+printf "  \${VERSION_MINOR}:  %s\n" "$(uname -r | cut -d. -f2 | cut -d- -f1)"
+printf "  \${ARCH}:           %s\n" "$(uname -m)"
 printf '\nsysctl kern.*:\n'
 sysctl kern.ostype kern.osrelease kern.osrevision kern.version 2>/dev/null
 
 # ── 3. pkg built-in variable values ─────────────────────────────────────────
 sep "PKG BUILT-IN VARIABLES"
-printf '  ${ABI}:       %s\n' "$(pkg config ABI 2>/dev/null || echo 'ERROR')"
-printf '  ${OSVERSION}: %s\n' "$(pkg config OSVERSION 2>/dev/null || echo 'not supported')"
+printf "  \${ABI}:       %s\n" "$(pkg config ABI 2>/dev/null || echo 'ERROR')"
+printf "  \${OSVERSION}: %s\n" "$(pkg config OSVERSION 2>/dev/null || echo 'not supported')"
 
 sub "pkg -vv (full effective configuration)"
 pkg -vv 2>/dev/null || echo "pkg -vv failed"
 
 # ── 4. pfSense product identity (PHP globals) ────────────────────────────────
 sep "PFSENSE PRODUCT IDENTITY (globals.inc)"
+# shellcheck disable=SC2016  # PHP variables ($g, $k, $v) must not expand in shell
 php -r '
 require_once("/etc/inc/globals.inc");
 $keys = [
@@ -58,6 +60,7 @@ foreach ($keys as $k) {
 ' 2>/dev/null || echo "PHP globals read failed"
 
 sub "HTTP_USER_AGENT pkg will send (product_label/product_version[:uniqueid])"
+# shellcheck disable=SC2016  # PHP variables ($env) must not expand in shell
 php -r '
 require_once("/etc/inc/globals.inc");
 require_once("/etc/inc/pkg-utils.inc");

--- a/tests/test_adr10_watcher.py
+++ b/tests/test_adr10_watcher.py
@@ -247,6 +247,15 @@ class _Harness:
                     return
             time.sleep(0.01)
 
+    def wait_snapshot_changed(self, old: Any, timeout: float = 3.0) -> None:
+        # wait_builds returns when a build is RECORDED (before the builder returns),
+        # so P._snapshot may not be swapped yet. Poll until the swap completes.
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if P._snapshot is not old:
+                return
+            time.sleep(0.005)
+
     def stop_join(self, timeout: float = 5.0) -> None:
         P.pfb_reload_stop.set()
         self._gate.set()  # release a blocked build so the thread can exit promptly
@@ -267,6 +276,7 @@ class TestWatcherLoop:
 
             h.publish(1)  # ADVANCE.
             h.wait_builds(1)
+            h.wait_snapshot_changed(old)  # wait_builds returns before the swap completes.
             # AFTER: a new snapshot for generation 1 is installed.
             assert "gen1.example.com" in P._snapshot.data_db
             assert P._snapshot is not old
@@ -379,6 +389,7 @@ class TestWatcherLoop:
             assert P._snapshot is old  # BEFORE.
             h.publish(1)
             h.wait_builds(1)
+            h.wait_snapshot_changed(old)  # wait_builds returns before the swap completes.
             assert "gen1.example.com" in P._snapshot.data_db  # AFTER: swapped via poll path.
         finally:
             h.stop_join()
@@ -399,6 +410,7 @@ class TestWatcherLoop:
             assert P._snapshot is old  # BEFORE: failed-kqueue waiter, old snapshot live.
             h.publish(1)
             h.wait_builds(1)
+            h.wait_snapshot_changed(old)  # wait_builds returns before the swap completes.
             assert "gen1.example.com" in P._snapshot.data_db  # AFTER: swapped via the poll downgrade.
         finally:
             h.stop_join()


### PR DESCRIPTION
## Summary

- `scripts/probe-pfsense-env.sh`: SC2016 ("expressions don't expand in single quotes") was firing on two intentionally literal patterns — `printf` format labels like `${OSNAME}` (displayed as-is to show pkg's own variable names) and `php -r '...'` blocks (single quotes correctly suppress shell expansion of PHP variables). Fix: convert `printf` format strings to double-quoted `\${VAR}`, and annotate each `php -r` block with `# shellcheck disable=SC2016`.
- `tests/test_adr10_watcher.py`: while fixing the ShellCheck issue, the pre-commit hook caught a latent race in `_Harness`. `wait_builds()` returns the moment a build is *recorded* (before the builder returns), so `P._snapshot` may not be swapped yet when the next line asserts on it. Added `wait_snapshot_changed(old)` to `_Harness` and used it in the three tests that set an `old` snapshot and assert after `wait_builds()`.

## Test plan

- [ ] `python -m pytest` green (1458 tests, 0 failures)
- [ ] ShellCheck job in CI green (was failing with exit 123 on `scripts/probe-pfsense-env.sh` lines 29–33, 39–40, 47, 61)
- [ ] `ruff check . && ruff format .` clean
- [ ] `mypy tests/` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPFmEe2iRdVJN1ifdmpEj7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pfSense environment detection script formatting and validation.
  * Enhanced test reliability for watcher loop transitions with improved state verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->