### PR TITLE
ci-metadata: add variant + status fields (ADR-20 P2)

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -16,7 +16,8 @@
       "freebsd_major": "15",
       "php_version": "8.3",
       "py_flavor": "py311",
-      "status": "GA",
+      "variant": "CE",
+      "status": "active",
       "ci": true
     },
     {
@@ -26,7 +27,8 @@
       "freebsd_major": "16",
       "php_version": "8.5",
       "py_flavor": "py311",
-      "status": "GA",
+      "variant": "Plus",
+      "status": "active",
       "ci": false
     }
   ]


### PR DESCRIPTION
## Summary

- Adds `"variant"` field (`"CE"` / `"Plus"`) to each entry in `supported-versions.json`
- Adds `"status"` field (`"active"` / `"legacy"`) to each entry
- CE entries keep `ci: true`; Plus entries have `ci: false` (no licensed CI image)

These fields are consumed by `scripts/read-version-matrix.sh --variant CE|Plus` (ADR-20 P4) to filter the build matrix by variant, and by `scripts/build-repo-portable.py --generate-routing-json` (ADR-20 P3) to produce the Cloudflare Worker routing table.

## Test plan

- [ ] `scripts/read-version-matrix.sh --variant CE` returns only CE entries
- [ ] `scripts/read-version-matrix.sh --variant Plus` returns only Plus entries (CI matrix empty check skipped per policy)
- [ ] No workflow YAML changes needed — consumers read the matrix at runtime

Closes ADR-20 Phase 2 kill-gate (`ci-metadata` variant field).

https://github.com/pfblockerng/pfblockerng/pull/175

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApekJ5tz5FdVLuUEFoijaX)_