### PR TITLE
build-repo: nightly channel CE/Plus variant split

### DIFF
--- a/.ADRs/ADR_20_CE_Plus_Variant_Distribution/ADR.md
+++ b/.ADRs/ADR_20_CE_Plus_Variant_Distribution/ADR.md
@@ -442,3 +442,90 @@ explicitly open as a deferred complement.
 - **STOP Phase 5** if `wrangler deploy` cannot be integrated cleanly into
   `pfBlockerNG/pkg publish.yml` (auth, token scope, or Node.js toolchain constraints)
   — document the blocker in `05_Results.txt` and fall back to Phase 4's static URL.
+
+---
+
+## Amendment (2026-06-10): nightly channel CE/Plus variant split
+
+**All three channels (stable, devel, nightly) carry a CE/Plus variant split.**
+This was implicit in the catalog-structure decision above ("Nightly likewise:
+`.../nightly/ce-2.8/${ABI}/`…") but the implementation details were not spelled out.
+
+### How stable and devel work (no channel prefix in path)
+
+Both `stable` and `devel` write the Worker URL without any path prefix:
+
+```text
+url: "https://pkg.pfblockerng.workers.dev/${ABI}"
+```
+
+- `add-repo.sh devel` → conf `pfblockerng-devel.conf`, `URL_SUBPATH=""`
+  → URL: `https://pkg.pfblockerng.workers.dev/${ABI}`
+- `add-repo.sh stable` → conf `pfblockerng.conf`, `URL_SUBPATH=""`
+  → URL: `https://pkg.pfblockerng.workers.dev/${ABI}`
+
+The Worker receives a request like `/FreeBSD:15:amd64/packagesite.pkg`, reads the
+`User-Agent`, finds the catalog (`ce-2.8` or `plus-26.03`), and redirects to:
+
+```text
+pfblockerng.github.io/pkg/ce-2.8/FreeBSD:15:amd64/packagesite.pkg
+```
+
+Channel distinction lives entirely in the **package name** and **repo conf name**,
+never in the catalog URL. Both channels coexist in the same variant-keyed catalog dir.
+
+### How nightly works (nightly/ prefix in path)
+
+`add-repo.sh nightly` → conf `pfblockerng-nightly.conf`, `URL_SUBPATH="nightly/"`
+→ URL: `https://pkg.pfblockerng.workers.dev/nightly/${ABI}`
+
+The Worker receives `/nightly/FreeBSD:15:amd64/packagesite.pkg`. Without special
+handling it would produce the wrong target (prepending `ce-2.8` before the `nightly/`
+segment). The Worker must strip the channel prefix before routing.
+
+### Worker path-stripping for nightly
+
+The Cloudflare Worker must detect the `/nightly/` path prefix and strip it before
+constructing the redirect target:
+
+```javascript
+// Strip channel prefix (nightly) so catalog + ABI path are constructed correctly.
+let channelPrefix = '';
+let abiPath = url.pathname;
+const m = url.pathname.match(/^\/(nightly)\//);
+if (m) {
+    channelPrefix = m[1] + '/';                    // "nightly/"
+    abiPath = url.pathname.slice(m[0].length - 1); // strip prefix, keep leading /
+}
+// route.catalog = "ce-2.8" or "plus-26.03" (routing.json has no channel knowledge)
+const target = `https://pfblockerng.github.io/pkg/${channelPrefix}${route.catalog}${abiPath}`;
+```
+
+Result for a nightly CE box (`pfSense/2.8.1` UA, ABI `FreeBSD:15:amd64`):
+
+```text
+/nightly/FreeBSD:15:amd64/packagesite.pkg
+  channelPrefix="nightly/"  abiPath="/FreeBSD:15:amd64/packagesite.pkg"
+  → pfblockerng.github.io/pkg/nightly/ce-2.8/FreeBSD:15:amd64/packagesite.pkg
+```
+
+`routing.json` remains channel-agnostic — catalog names are `"ce-2.8"`,
+`"plus-26.03"` with no `"nightly/"` prefix. The channel prefix is a path concern
+handled at the Worker edge.
+
+### `catalog_name_from_version` API extension
+
+`catalog_name_from_version(pfsense_version, variant, *, channel="")` gains an
+optional keyword-only `channel` argument. When supplied (e.g. `channel="nightly"`),
+the returned string is prefixed: `"nightly/ce-2.8"`. `build_repo(catalog_name=)`
+already accepts slash-containing strings, placing the ABI subtree under
+`<out>/nightly/ce-2.8/<ABI>/`.
+
+### Test coverage (added in same commit)
+
+- `test_catalog_name_from_version_nightly` — nightly prefix for CE and Plus; no-channel
+  unchanged; patch stripping with nightly.
+- `test_nightly_catalog_under_versioned_subdir` — CE nightly build lands at
+  `nightly/ce-2.8/<ABI>/`; release path and legacy root untouched.
+- `test_nightly_plus_catalog_under_versioned_subdir` — CE + Plus nightly coexist under
+  `nightly/`; no cross-contamination between the two variant dirs.

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -365,17 +365,22 @@ def _check_collisions(entries: list[tuple[Path, dict]]) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def catalog_name_from_version(pfsense_version: str, variant: str) -> str:
+def catalog_name_from_version(pfsense_version: str, variant: str, *, channel: str = "") -> str:
     """Derive catalog dir name: major.minor only, prefixed by variant.
 
     Both CE and Plus strip any trailing patch component:
-      "2.8.1"  + "CE"   -> "ce-2.8"
-      "2.8.x"  + "CE"   -> "ce-2.8"
-      "26.03"  + "Plus" -> "plus-26.03"
-      "26.03.1"+ "Plus" -> "plus-26.03"
+      "2.8.1"  + "CE"             -> "ce-2.8"
+      "2.8.x"  + "CE"             -> "ce-2.8"
+      "26.03"  + "Plus"           -> "plus-26.03"
+      "26.03.1"+ "Plus"           -> "plus-26.03"
+
+    When channel is supplied (e.g. "nightly"), it is prepended as a path prefix:
+      "2.8.1"  + "CE"   + "nightly" -> "nightly/ce-2.8"
+      "26.03.1"+ "Plus" + "nightly" -> "nightly/plus-26.03"
     """
     major_minor = ".".join(pfsense_version.split(".")[:2])
-    return f"{variant.lower()}-{major_minor}"
+    name = f"{variant.lower()}-{major_minor}"
+    return f"{channel}/{name}" if channel else name
 
 
 def generate_routing_json(entries: list[dict], output_path: str) -> None:

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -724,3 +724,99 @@ def test_routing_json_legacy_retained(tmp_path: Path) -> None:
     assert len(routes) == 1
     assert routes[0]["status"] == "legacy"
     assert routes[0]["catalog"] == "ce-2.7"
+
+
+# --------------------------------------------------------------------------- #
+# Nightly channel: CE/Plus variant split with nightly/ path prefix
+# --------------------------------------------------------------------------- #
+
+
+def test_catalog_name_from_version_nightly() -> None:
+    """catalog_name_from_version with channel="nightly" prepends "nightly/" prefix.
+
+    CE and Plus both get the nightly/ prefix; the variant-keyed name is unchanged:
+      "2.8.1"  + "CE"   + channel="nightly" -> "nightly/ce-2.8"
+      "26.03.1"+ "Plus" + channel="nightly" -> "nightly/plus-26.03"
+    Without channel= the behaviour is unchanged (no prefix):
+      "2.8.1"  + "CE"                       -> "ce-2.8"
+    """
+    # Nightly CE: prefix applied
+    assert brp.catalog_name_from_version("2.8.1", "CE", channel="nightly") == "nightly/ce-2.8"
+    # Nightly Plus: prefix applied
+    assert brp.catalog_name_from_version("26.03.1", "Plus", channel="nightly") == "nightly/plus-26.03"
+    # No channel: unchanged
+    assert brp.catalog_name_from_version("2.8.1", "CE") == "ce-2.8"
+    # Patch stripping still works with nightly
+    assert brp.catalog_name_from_version("2.8.x", "CE", channel="nightly") == "nightly/ce-2.8"
+
+
+def test_nightly_catalog_under_versioned_subdir(tmp_path: Path) -> None:
+    """build_repo with catalog_name="nightly/ce-2.8" writes tree under nightly/ce-2.8/<ABI>/.
+
+    Scenario: nightly CE build
+      Given no nightly/ dir exists in <out>
+      When build_repo(catalog_name="nightly/ce-2.8") with a CE pkg (ABI=FreeBSD:15:amd64)
+      Then meta.conf exists at nightly/ce-2.8/FreeBSD:15:amd64/meta.conf
+       And no meta.conf exists at ce-2.8/FreeBSD:15:amd64/meta.conf (release path untouched)
+       And no meta.conf exists at FreeBSD:15:amd64/meta.conf (legacy root untouched)
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "nightly-ce.pkg", name="pfBlockerNG-nightly", abi="FreeBSD:15:amd64")
+    out = tmp_path / "out"
+    out.mkdir()
+
+    # Before-state: no nightly/ dir
+    assert not (out / "nightly").exists()
+
+    brp.build_repo(in_dir, out, catalog_name="nightly/ce-2.8")
+
+    # Nightly versioned path exists
+    assert (out / "nightly" / "ce-2.8" / "FreeBSD:15:amd64" / "meta.conf").is_file()
+    # Release path NOT created as side-effect
+    assert not (out / "ce-2.8").exists()
+    # Legacy root-level ABI path NOT created
+    assert not (out / "FreeBSD:15:amd64" / "meta.conf").exists()
+
+
+def test_nightly_plus_catalog_under_versioned_subdir(tmp_path: Path) -> None:
+    """build_repo with catalog_name="nightly/plus-26.03" writes under nightly/plus-26.03/<ABI>/.
+
+    Scenario: nightly Plus build, nightly CE build in same output tree
+      Given no nightly/ dir exists
+      When build_repo(catalog_name="nightly/ce-2.8") with CE pkg (FreeBSD:15:amd64)
+       And build_repo(catalog_name="nightly/plus-26.03") with Plus pkg (FreeBSD:16:amd64)
+      Then nightly/ce-2.8/FreeBSD:15:amd64/meta.conf exists
+       And nightly/plus-26.03/FreeBSD:16:amd64/meta.conf exists
+       And the CE and Plus nightly packagesite contents do not cross-contaminate
+    """
+    ce_dir = tmp_path / "ce_in"
+    ce_dir.mkdir()
+    plus_dir = tmp_path / "plus_in"
+    plus_dir.mkdir()
+    make_pkg(ce_dir / "ce-nightly.pkg", name="pfBlockerNG-nightly-ce", abi="FreeBSD:15:amd64")
+    make_pkg(plus_dir / "plus-nightly.pkg", name="pfBlockerNG-nightly-plus", abi="FreeBSD:16:amd64")
+    out = tmp_path / "out"
+
+    # Before-state: no nightly dir
+    assert not (out / "nightly").exists()
+
+    brp.build_repo(ce_dir, out, catalog_name="nightly/ce-2.8")
+    brp.build_repo(plus_dir, out, catalog_name="nightly/plus-26.03")
+
+    assert (out / "nightly" / "ce-2.8" / "FreeBSD:15:amd64" / "meta.conf").is_file()
+    assert (out / "nightly" / "plus-26.03" / "FreeBSD:16:amd64" / "meta.conf").is_file()
+
+    ce_raw = _read_member(
+        out / "nightly" / "ce-2.8" / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml"
+    ).decode()
+    ce_names = {json.loads(ln)["name"] for ln in ce_raw.splitlines() if ln}
+    assert "pfBlockerNG-nightly-ce" in ce_names
+    assert "pfBlockerNG-nightly-plus" not in ce_names
+
+    plus_raw = _read_member(
+        out / "nightly" / "plus-26.03" / "FreeBSD:16:amd64" / "packagesite.pkg", "packagesite.yaml"
+    ).decode()
+    plus_names = {json.loads(ln)["name"] for ln in plus_raw.splitlines() if ln}
+    assert "pfBlockerNG-nightly-plus" in plus_names
+    assert "pfBlockerNG-nightly-ce" not in plus_names


### PR DESCRIPTION
## Summary

- `catalog_name_from_version(v, variant, *, channel="")` gains an optional `channel` kwarg: `channel="nightly"` prefixes the result with `"nightly/"` (e.g. `"nightly/ce-2.8"`), matching the catalog-structure decision in ADR-20 ("Nightly likewise: `.../nightly/ce-2.8/${ABI}/`…").
- `build_repo(catalog_name="nightly/ce-2.8")` already handles slash-containing names — no further generator changes needed.
- Cloudflare Worker path-stripping for `/nightly/` is documented in the ADR-20 amendment (deployed separately by maintainer).
- ADR-20 amended in the same commit: documents how all three channels (stable, devel, nightly) work, the Worker patch, and the `catalog_name_from_version` API extension.

## Test plan

- [ ] `python -m pytest` green (1478 tests, 3 new: `test_catalog_name_from_version_nightly`, `test_nightly_catalog_under_versioned_subdir`, `test_nightly_plus_catalog_under_versioned_subdir`)
- [ ] `ruff`, `mypy`, ShellCheck, markdownlint all clean (pre-commit passed)
- [ ] Live nightly routing verified on real pfSense box after publish pipeline builds nightly catalog

https://claude.ai/code/session_01ApekJ5tz5FdVLuUEFoijaX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApekJ5tz5FdVLuUEFoijaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly channel now supported alongside stable and devel, with dedicated routing and preserved nightly path prefixes for nightly builds.

* **Documentation**
  * Clarified CE/Plus variant distribution and Worker request/redirect behavior including channel-prefixed catalog names.

* **Tests**
  * Added tests ensuring nightly catalogs land under nightly/<variant>-<version>/<ABI>/, preserve normal release paths, and prevent CE/Plus cross-contamination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->