### PR TITLE
tests: fix pkg_query_deps format (%d → %dn/%dv); ci: fix smoke-fanout wildcard tag

### DIFF
--- a/.github/workflows/smoke-fanout.yml
+++ b/.github/workflows/smoke-fanout.yml
@@ -104,9 +104,13 @@ jobs:
   #
   # IMAGE REF RESOLUTION:
   # The CI matrix entry carries pfsense_version (e.g. "2.8.x"). We pass it to
-  # smoke.yml as `pfsense_version`; smoke.yml composes the GHCR ref from the
-  # SMOKE_IMAGE_REPO / SMOKE_IMAGE_NAME / SMOKE_IMAGE_TAG repo variables, with
-  # pfsense_version overriding the tag.
+  # smoke.yml as `pfsense_version` so smoke.yml can compose the GHCR ref.
+  # IMPORTANT: pfsense_version entries ending in ".x" are WILDCARD PATTERNS (e.g.
+  # "2.8.x" covers the whole 2.8 release line). A ".x" pattern does NOT exist as a
+  # GHCR image tag — only the specific patch release does (e.g. "2.8.1"), which is
+  # stored in the SMOKE_IMAGE_TAG repo variable. In that case pass empty string so
+  # smoke.yml falls back to SMOKE_IMAGE_TAG. For exact-version entries (e.g. "26.03")
+  # pass the version directly — it matches the GHCR tag verbatim.
   smoke:
     name: Smoke (${{ matrix.pfsense_version }})
     needs: prepare
@@ -118,11 +122,10 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.ci_matrix) }}
     uses: ./.github/workflows/smoke.yml
     with:
-      # Pass only the per-leg version; smoke.yml composes the ref from the
-      # SMOKE_IMAGE_{REPO,NAME,TAG} vars (pfsense_version overrides the tag). This
-      # keeps the namespace/name in one place (the repo vars) instead of hardcoding
-      # ghcr.io/<owner>/pfsense-ce here.
-      pfsense_version: ${{ matrix.pfsense_version }}
+      # Wildcard-pattern versions (ending in .x, e.g. "2.8.x") are NOT valid GHCR
+      # tags — pass empty so smoke.yml uses the SMOKE_IMAGE_TAG repo variable (which
+      # holds the actual patch tag, e.g. "2.8.1"). Exact-version entries pass through.
+      pfsense_version: ${{ endsWith(matrix.pfsense_version, '.x') && '' || matrix.pfsense_version }}
     secrets: inherit
 
   # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1646,7 +1646,7 @@ def test_routing_url_delivers_ce_catalog(repo_vm: SmokeVM) -> None:
     Given a CE VM with the conf pointing at the Worker URL (``${ABI}`` suffix added
       by pkg), ``pkg update -r pfblockerng-devel`` fetches from the Worker.
     Then the fetched catalog contains the CE package (not Plus) — confirmed by
-      ``pkg rquery -r pfblockerng-devel '%d %v' <pkgname>`` showing ``php83`` dep.
+      ``pkg rquery -r pfblockerng-devel '%dn %dv' <pkgname>`` showing ``php83`` dep.
 
     XFAIL: the Cloudflare Worker is live but routing.json has not yet been deployed
     to Pages (Phase 5 RESULTS: Worker returns 502 when routing.json absent).  Once
@@ -1682,10 +1682,10 @@ def test_routing_url_delivers_ce_catalog(repo_vm: SmokeVM) -> None:
 
     # If pkg update succeeded (routing.json live), assert the catalog contains the CE package.
     if update_result.returncode == 0:
-        rquery = repo_vm.ssh("pkg", "rquery", "-r", OURS_REPO_NAME, "%d %v", PKG_NAME, timeout=60.0)
+        rquery = repo_vm.ssh("pkg", "rquery", "-r", OURS_REPO_NAME, "%dn %dv", PKG_NAME, timeout=60.0)
         rquery_out = rquery.stdout.strip()
         assert "php83" in rquery_out, (
-            f"Worker URL catalog does not contain CE php83 dep; pkg rquery '%d %v' output:\n{rquery_out}"
+            f"Worker URL catalog does not contain CE php83 dep; pkg rquery '%dn %dv' output:\n{rquery_out}"
         )
         assert "php85" not in rquery_out, (
             f"Worker URL returned Plus (php85) catalog to a CE box; pkg rquery output:\n{rquery_out}"

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1348,8 +1348,13 @@ def forge_plus_pkg(src_pkg: Path, out_dir: Path) -> Path:
 
 
 def pkg_query_deps(vm: SmokeVM, *, timeout: float = 60.0) -> str:
-    """Return the raw ``pkg query '%d %v' <PKG_NAME>`` output (dep names + versions)."""
-    result = vm.ssh("pkg", "query", "%d %v", PKG_NAME, timeout=timeout)
+    """Return the raw ``pkg query '%dn %dv' <PKG_NAME>`` output (dep names + versions).
+
+    Uses ``%dn`` (dep name) and ``%dv`` (dep version) — the correct per-dependency
+    sub-field specifiers in libpkg's query format. ``%d`` alone is an iterator
+    marker with no output; ``%v`` is the package's own version (not the dep's).
+    """
+    result = vm.ssh("pkg", "query", "%dn %dv", PKG_NAME, timeout=timeout)
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
@@ -1369,7 +1374,7 @@ def test_ce_install_from_variant_ce_catalog(repo_vm: SmokeVM, tmp_path: Path) ->
     Given the package ABSENT and a variant-keyed catalog under ``ce-2.8/${ABI}/``
       built from the branch .pkg by the pure-Python generator,
     When ``pkg install -y <pkgname>`` resolves from this CE catalog,
-    Then ``pkg query '%d %v' <pkgname>`` shows ``php83`` in the dep list (CE dep
+    Then ``pkg query '%dn %dv' <pkgname>`` shows ``php83`` in the dep list (CE dep
       satisfied), the version matches the branch .pkg, and the origin is our repo.
     Assert BEFORE: ``pkg query '%n' <pkgname>`` returns empty (package absent).
     Assert AFTER: dep list contains ``php83``; version and origin correct.
@@ -1403,10 +1408,10 @@ def test_ce_install_from_variant_ce_catalog(repo_vm: SmokeVM, tmp_path: Path) ->
     # THEN: dep list contains php83 (CE dep), origin is ours.
     deps_out = pkg_query_deps(repo_vm)
     assert "php83" in deps_out, (
-        f"php83 dep not satisfied after CE variant install; pkg query '%d %v' output:\n{deps_out}"
+        f"php83 dep not satisfied after CE variant install; pkg query '%dn %dv' output:\n{deps_out}"
     )
     assert "php85" not in deps_out, (
-        f"Plus dep php85 should not appear in CE install; pkg query '%d %v' output:\n{deps_out}"
+        f"Plus dep php85 should not appear in CE install; pkg query '%dn %dv' output:\n{deps_out}"
     )
     origin = pkg_repo_origin(repo_vm)
     assert origin == OURS_REPO_NAME, f"CE variant install: came from {origin!r}, expected {OURS_REPO_NAME!r}"
@@ -1466,7 +1471,7 @@ def test_wrong_variant_plus_catalog_fails_on_ce_vm(repo_vm: SmokeVM, tmp_path: P
     ce_combined = ce_install.stdout + ce_install.stderr
     assert "Missing dependency" not in ce_combined, f"Control (CE) install: RUN_DEPENDS did not resolve:\n{ce_combined}"
     ce_deps = pkg_query_deps(repo_vm)
-    assert "php83" in ce_deps, f"Control (CE) install: php83 not in deps; pkg query '%d %v':\n{ce_deps}"
+    assert "php83" in ce_deps, f"Control (CE) install: php83 not in deps; pkg query '%dn %dv':\n{ce_deps}"
     # CE install succeeded — this is the before-state anchor.
 
     # ---- Forge Plus .pkg (php85 dep, FreeBSD:16 ABI) ----


### PR DESCRIPTION
## Summary

Two bugs surfaced from the first `-m repo` CI run (runs #27268377464 and #27268609244):

- **`pkg_query_deps` wrong format spec** (`tests/smoke/test_repo_install.py`): used `pkg query '%d %v'` where `%d` alone is a dep-iteration marker that emits nothing, and `%v` is the package's own version — not the dep's. Correct sub-field specifiers in libpkg are `%dn` (dep name) and `%dv` (dep version). Result: `assert 'php83' in ''` always failed for both ADR-20 CE variant install tests.

- **smoke-fanout wildcard tag** (`.github/workflows/smoke-fanout.yml`): passed `pfsense_version` (e.g. `"2.8.x"`) directly as the GHCR image tag. Wildcard-pattern versions ending in `.x` are NOT GHCR tags — only the specific patch release exists (e.g. `2.8.1`, held in `SMOKE_IMAGE_TAG`). Previous fanout runs only succeeded when the image was cached on the runner; a cold runner fails at `oras resolve`. Fix: pass empty string for `.x`-pattern versions so smoke.yml falls back to `SMOKE_IMAGE_TAG`. Exact-version entries (e.g. `"26.03"`) pass through unchanged.

## Test plan

- [ ] Unit tests: `python -m pytest` — 1478 passed (pre-commit hook verified in CI)
- [ ] Re-run smoke `-m repo` after merge: `test_ce_install_from_variant_ce_catalog` and `test_wrong_variant_plus_catalog_fails_on_ce_vm` should pass
- [ ] Re-run smoke-fanout: should resolve `ghcr.io/pfblockerng/pfsense-ce:2.8.1` (via `SMOKE_IMAGE_TAG`) instead of the non-existent `2.8.x` tag

---
🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApekJ5tz5FdVLuUEFoijaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow handling for wildcard-style version patterns and clarified in-file documentation about wildcard vs exact-tag behavior.

* **Tests**
  * Updated package dependency tests and assertions to validate name+version output and adjusted failure messages for variant-specific installation and routing-related checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->