### PR TITLE
ci: Cloudflare Worker for version-keyed pkg routing (ADR-20 P5)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,37 @@
+name: Deploy Cloudflare Worker
+
+# Deploys the pfBlockerNG pkg-routing Worker (scripts/worker/) to Cloudflare.
+#
+# Auth: CLOUDFLARE_API_TOKEN secret (Workers:Edit scope on the account).
+# The Worker reads User-Agent, fetches routing.json from Pages (edge-cached
+# 5 min), and 302-redirects to the correct version-keyed catalog dir.
+#
+# Triggers:
+#   - workflow_call:   called by release.yml after a successful release
+#   - workflow_dispatch: ad-hoc redeploy (e.g. after updating wrangler.toml)
+#   - push to devel/main with changes under scripts/worker/: keeps the live
+#     Worker in sync with the source without requiring a full release
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches: [devel, main]
+    paths:
+      - "scripts/worker/**"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Workers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: scripts/worker

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -14,6 +14,9 @@ name: Deploy Cloudflare Worker
 
 on:
   workflow_call:
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        required: true
   workflow_dispatch:
   push:
     branches: [devel, main]
@@ -29,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -549,7 +549,8 @@ jobs:
     needs: [release]
     if: always() && needs.release.result == 'success'
     uses: ./.github/workflows/deploy-worker.yml
-    secrets: inherit
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
   # ── 3. Open PR on pfsense/FreeBSD-ports ──────────────────────────────────
   ports-pr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -539,6 +539,18 @@ jobs:
         run: |
           gh workflow run publish.yml -R pfBlockerNG/pkg
 
+  # ── 2e. Redeploy the Cloudflare routing Worker (ADR-20) ─────────────────────
+  # The Worker reads routing.json from Pages and 302-redirects pkg to the
+  # correct variant catalog.  Redeployed on every release so the live Worker
+  # always matches the current wrangler.toml / source.  ADDITIVE + ISOLATED —
+  # same pattern as repo-publish: only needs: [release], never blocks ports-pr.
+  deploy-worker:
+    name: Deploy Cloudflare routing Worker
+    needs: [release]
+    if: always() && needs.release.result == 'success'
+    uses: ./.github/workflows/deploy-worker.yml
+    secrets: inherit
+
   # ── 3. Open PR on pfsense/FreeBSD-ports ──────────────────────────────────
   ports-pr:
     name: Open FreeBSD ports PR

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ coverage/
 .shellspec-quick.log
 report/
 
+# ── Node / Cloudflare Worker (scripts/worker/) ────────────────────────────────
+node_modules/
+.wrangler/
+
 # ── Build / release artefacts ─────────────────────────────────────────────────
 *.tar.gz
 *.tar.bz2

--- a/scripts/worker/package.json
+++ b/scripts/worker/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pfblockerng-pkg-router",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  },
+  "devDependencies": {
+    "wrangler": "^3"
+  }
+}

--- a/scripts/worker/src/index.js
+++ b/scripts/worker/src/index.js
@@ -47,7 +47,8 @@ async function getRoutes(ctx) {
     if (!resp.ok) return null;
     const ttlResp = new Response(resp.body, resp);
     ttlResp.headers.set("Cache-Control", `s-maxage=${CACHE_TTL}`);
-    ctx.waitUntil(cache.put(cacheKey, ttlResp));
+    ctx.waitUntil(cache.put(cacheKey, ttlResp.clone()));
+    resp = ttlResp;
   }
   const data = await resp.clone().json();
   return data.routes ?? null;

--- a/scripts/worker/src/index.js
+++ b/scripts/worker/src/index.js
@@ -1,0 +1,54 @@
+// Cloudflare Worker — pfBlockerNG pkg routing (ADR-20 Phase 5).
+//
+// Reads User-Agent, fetches routing.json from Pages (edge-cached 5 min),
+// matches the UA against route patterns (first match wins), and 302-redirects
+// to the version-keyed catalog dir on Pages.
+//
+// Failure modes are explicit, never a silent wrong install:
+//   - routing.json unavailable  → 502
+//   - no matching route (unsupported pfSense version) → 404
+
+const ROUTING_MANIFEST_URL = "https://pfblockerng.github.io/pkg/routing.json";
+const CACHE_TTL = 300; // seconds — edge cache for routing.json
+
+export default {
+  async fetch(request, env, ctx) {
+    const ua = request.headers.get("User-Agent") ?? "";
+    const url = new URL(request.url);
+
+    const routes = await getRoutes(ctx);
+    if (!routes) {
+      return new Response("Routing manifest unavailable", { status: 502 });
+    }
+
+    // First match wins; list more-specific patterns before less-specific ones
+    // in routing.json (e.g. "pfSense/2.9" before a "pfSense/2" catch-all).
+    const route = routes.find((r) => ua.includes(r.pattern));
+    if (!route) {
+      return new Response(`Unsupported pfSense version (UA: ${ua})`, {
+        status: 404,
+      });
+    }
+
+    // 302 redirect to the version-keyed catalog dir on Pages.
+    // Input path:  /FreeBSD:15:amd64/packagesite.yaml.pkg
+    // Output path: https://pfblockerng.github.io/pkg/ce-2.8/FreeBSD:15:amd64/...
+    const target = `https://pfblockerng.github.io/pkg/${route.catalog}${url.pathname}`;
+    return Response.redirect(target, 302);
+  },
+};
+
+async function getRoutes(ctx) {
+  const cache = caches.default;
+  const cacheKey = new Request(ROUTING_MANIFEST_URL);
+  let resp = await cache.match(cacheKey);
+  if (!resp) {
+    resp = await fetch(ROUTING_MANIFEST_URL);
+    if (!resp.ok) return null;
+    const ttlResp = new Response(resp.body, resp);
+    ttlResp.headers.set("Cache-Control", `s-maxage=${CACHE_TTL}`);
+    ctx.waitUntil(cache.put(cacheKey, ttlResp));
+  }
+  const data = await resp.clone().json();
+  return data.routes ?? null;
+}

--- a/scripts/worker/wrangler.toml
+++ b/scripts/worker/wrangler.toml
@@ -1,0 +1,10 @@
+name = "pkg"
+main = "src/index.js"
+compatibility_date = "2024-11-01"
+
+# Custom domain (once pfblockerng.io is registered in the Cloudflare account):
+#   [routes]
+#   pattern = "pkg.pfblockerng.io/*"
+#   zone_name = "pfblockerng.io"
+#
+# Until then the Worker is reachable at pkg.<account>.workers.dev.


### PR DESCRIPTION
## Summary

ADR-20 Phase 5 — deploys the Cloudflare Worker that routes `pkg` requests to the correct variant catalog based on `User-Agent`.

- **`scripts/worker/src/index.js`** — stateless Worker: fetches `routing.json` from Pages (5-min edge cache), matches UA prefix (first match wins), 302-redirects to `pfblockerng.github.io/pkg/<catalog>/<path>`. Explicit failures: 502 if manifest unavailable, 404 for unrecognised UA.
- **`scripts/worker/wrangler.toml`** — `name = "pkg"` (→ `pkg.<account>.workers.dev`); custom-domain config (`pkg.pfblockerng.io`) commented for when the domain is registered.
- **`scripts/worker/package.json`** — wrangler devDep for local `npm run deploy` / `npm run dev`.
- **`.github/workflows/deploy-worker.yml`** — standalone deploy workflow using `cloudflare/wrangler-action@v3` + `CLOUDFLARE_API_TOKEN` secret. Triggers: `workflow_call` (from release), `workflow_dispatch`, push to `devel`/`main` with changes under `scripts/worker/**`.
- **`release.yml`** — additive `deploy-worker` job (same isolated pattern as `repo-publish`): calls `deploy-worker.yml` after every successful release.
- **`.gitignore`** — `node_modules/` + `.wrangler/` for the worker subtree.

## Pre-merge checklist

- [x] `CLOUDFLARE_API_TOKEN` secret added (Workers:Edit scope)
- [ ] `routing.json` still needs to be published to Pages by `pfBlockerNG/pkg publish.yml` — until it is, `test_routing_url_delivers_ce_catalog` remains `xfail`

## Test plan

- [ ] CI passes (pytest 3×, ruff, mypy, PHPStan, markdownlint, ShellCheck)
- [ ] After merge: `deploy-worker.yml` runs automatically (push to devel triggers `scripts/worker/**` path filter) — verify Worker deploys at `pkg.<account>.workers.dev`
- [ ] After `routing.json` goes live on Pages: remove `xfail` from `test_routing_url_delivers_ce_catalog` and re-run smoke `-m repo`

---
🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApekJ5tz5FdVLuUEFoijaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated package-routing service that inspects User-Agent and redirects requests to the appropriate package catalog, with caching and clear error responses when unavailable.

* **Chores**
  * CI/CD now automatically deploys the routing service as part of releases.
  * Repository ignores local build/artifact files for the routing service and includes tooling scripts to run/deploy it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->