### PR TITLE
ci: pass CLOUDFLARE_ACCOUNT_ID to wrangler-action

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -2,7 +2,7 @@ name: Deploy Cloudflare Worker
 
 # Deploys the pfBlockerNG pkg-routing Worker (scripts/worker/) to Cloudflare.
 #
-# Auth: CLOUDFLARE_API_TOKEN secret (Workers:Edit scope on the account).
+# Auth: CLOUDFLARE_API_TOKEN (Workers:Edit scope) and CLOUDFLARE_ACCOUNT_ID secrets.
 # The Worker reads User-Agent, fetches routing.json from Pages (edge-cached
 # 5 min), and 302-redirects to the correct version-keyed catalog dir.
 #

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -17,6 +17,8 @@ on:
     secrets:
       CLOUDFLARE_API_TOKEN:
         required: true
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
   workflow_dispatch:
   push:
     branches: [devel, main]
@@ -39,4 +41,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: scripts/worker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,6 +551,7 @@ jobs:
     uses: ./.github/workflows/deploy-worker.yml
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   # ── 3. Open PR on pfsense/FreeBSD-ports ──────────────────────────────────
   ports-pr:


### PR DESCRIPTION
## Summary

Fixes the `deploy-worker.yml` failure introduced by PR #180.

Without `account_id`, wrangler calls `/memberships` to auto-discover the account, which requires `User: Memberships: Read` scope. The token has only `Workers Scripts: Edit`, so the call fails with code 9106.

- Pass `accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}` to `wrangler-action@v3` → wrangler skips the membership lookup
- Declare `CLOUDFLARE_ACCOUNT_ID` in `deploy-worker.yml`'s `workflow_call.secrets` (least-privilege, consistent with existing pattern)
- Add the explicit mapping in `release.yml`'s `deploy-worker` job secrets

## Test plan

- [ ] CI passes
- [ ] After merge: `deploy-worker.yml` auto-triggers on the devel push and succeeds — Worker live at `pkg.<subdomain>.workers.dev`

---
🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andre-brait's account on their behalf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApekJ5tz5FdVLuUEFoijaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflows updated to require and pass an additional account identifier secret during worker deployment.
  * Release workflow now forwards that secret to the reusable deployment workflow, improving credential handling for deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->