### PR TITLE
ci: strip wildcard version suffix before GHCR tag resolution

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -154,6 +154,13 @@ jobs:
             # Fallback for REPO: lowercased owner (GHCR refs MUST be lowercase).
             REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
             NAME="${SMOKE_IMAGE_NAME:-pfsense-ce}"
+            # Strip wildcard-style version inputs (e.g. "2.8.x") — the CI
+            # matrix uses ".x" as a range marker, not a literal GHCR tag.
+            # Fall back to SMOKE_IMAGE_TAG (the concrete build tag, e.g.
+            # "2.8.1") or the hardcoded default.
+            case "$INPUT_VERSION" in
+              *.x) INPUT_VERSION="" ;;
+            esac
             TAG="${INPUT_VERSION:-${SMOKE_IMAGE_TAG:-2.8.1}}"
             REF="${REPO%/}/${NAME}:${TAG}"
           fi

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -45,7 +45,7 @@ on:
         required: false
         default: ""
       pfsense_version:
-        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Ignored when image_ref is set."
+        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Wildcard patterns (e.g. '2.8.x') are cleared to blank. Ignored when image_ref is set."
         required: false
         default: ""
       pytest_marker:
@@ -64,7 +64,7 @@ on:
         type: string
         default: ""
       pfsense_version:
-        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Ignored when image_ref is set."
+        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Wildcard patterns (e.g. '2.8.x') are cleared to blank. Ignored when image_ref is set."
         required: false
         type: string
         default: ""
@@ -159,7 +159,7 @@ jobs:
             # Fall back to SMOKE_IMAGE_TAG (the concrete build tag, e.g.
             # "2.8.1") or the hardcoded default.
             case "$INPUT_VERSION" in
-              *.x) INPUT_VERSION="" ;;
+              *.x|*.X) INPUT_VERSION="" ;;
             esac
             TAG="${INPUT_VERSION:-${SMOKE_IMAGE_TAG:-2.8.1}}"
             REF="${REPO%/}/${NAME}:${TAG}"


### PR DESCRIPTION
## Summary

- `smoke-fanout.yml` passes `pfsense_version=2.8.x` (the CI matrix range marker) to `smoke.yml`, which used it verbatim as the GHCR image tag
- `:2.8.x` does not exist on GHCR — the real tag is `:2.8.1` — so `oras resolve` failed and every smoke-fanout leg aborted at the "Resolve image digest" step
- Fix: strip the `.x` wildcard suffix from `INPUT_VERSION`, resetting it to `""`, so the existing `${SMOKE_IMAGE_TAG:-2.8.1}` fallback chain picks up the concrete build tag

## Test plan

- [ ] `smoke-fanout.yml` dispatched after merge — all legs should reach the pfSense VM (no longer abort at image resolution)
- [ ] `smoke.yml` dispatched directly with no `pfsense_version` input — tag resolves via `SMOKE_IMAGE_TAG` as before
- [ ] `smoke.yml` dispatched with explicit `pfsense_version=2.8.1` — still resolves to `:2.8.1` (non-wildcard input unchanged)

---
🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApekJ5tz5FdVLuUEFoijaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wildcard-style version inputs (e.g., ending in “.x”) are now cleared to avoid creating invalid image tags and to ensure fallback to the default image tag when appropriate.
* **Documentation**
  * Updated input descriptions to note that wildcard patterns are cleared and that this behavior is ignored when an explicit image reference is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->