### PR TITLE
ci: adopt floating Major.Minor GHCR tag scheme; drop .x suffix everywhere

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -41,9 +41,9 @@ on:
   workflow_dispatch:
     inputs:
       pfsense_ce_version:
-        description: "Target pfSense CE version tag to publish (e.g. 2.8.1)"
+        description: "Target pfSense CE floating tag to publish (e.g. 2.8)"
         required: true
-        default: "2.8.1"
+        default: "2.8"
       base_source:
         description: "Base source: 'upgrade' (boot a prior tag + pfSense-upgrade in place) or 'seed' (re-verify an existing maintainer seed; seeds are created off-runner via image-publish.sh)"
         required: true
@@ -118,24 +118,18 @@ jobs:
           git fetch origin ci-metadata
           MATRIX_JSON="$(git show origin/ci-metadata:supported-versions.json)"
 
-          # Find the CE entry whose pfsense_version pattern matches CE_VERSION.
-          # "2.8.x" matches "2.8.0", "2.8.1", etc.: strip trailing ".x" from the
-          # matrix key to get a prefix, then test CE_VERSION starts with it.
-          # An exact match (no ".x" suffix) is also accepted.
-          # Exit 2 = no matching entry -> hard-fail with actionable error message.
+          # Find the CE entry whose pfsense_version exactly matches CE_VERSION.
+          # pfsense_version is now the floating Major.Minor tag (e.g. "2.8"), so
+          # build-image.yml inputs must use the same tag (not a patch version like
+          # "2.8.1"). Exit 2 = no match -> hard-fail with actionable error.
           MATCH="$(printf '%s' "$MATRIX_JSON" | jq -e --arg ver "$CE_VERSION" '
             .versions[]
-            | select(.channel == "CE")
-            | . as $e
-            | select(
-                ($e.pfsense_version | endswith(".x") and ($ver | startswith($e.pfsense_version[:-1])))
-                or $e.pfsense_version == $ver
-              )
+            | select(.channel == "CE" and .pfsense_version == $ver)
           ' 2>/dev/null | jq -s '.[0] // empty')" || true
 
           if [ -z "$MATCH" ] || [ "$MATCH" = "null" ]; then
-            printf '::error::no FreeBSD/PHP mapping for pfSense CE '"'"'%s'"'"' in supported-versions.json on ci-metadata. Add a CE entry with a matching pfsense_version (e.g. '"'"'%s.x'"'"') and update docs/misc/pfSense_versions.md before publishing this version.\n' \
-              "$CE_VERSION" "$(printf '%s' "$CE_VERSION" | cut -d. -f1,2)"
+            printf '::error::no FreeBSD/PHP mapping for pfSense CE '"'"'%s'"'"' in supported-versions.json on ci-metadata. Add a CE entry with pfsense_version='"'"'%s'"'"' and update docs/misc/pfSense_versions.md before publishing this version.\n' \
+              "$CE_VERSION" "$CE_VERSION"
             exit 1
           fi
 

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -18,7 +18,7 @@ name: build-pkg (Linux, portable)
 # `make package` fidelity oracle (dispatch-only) — not deleted.
 #
 # TARGET facts (ABI, py-flavor, PHP) are INPUTS, never read from this fork's tree:
-# they describe the pfSense the .pkg installs onto (CE 2.8.1 = FreeBSD 15 / py311 /
+# they describe the pfSense the .pkg installs onto (CE 2.8 = FreeBSD 15 / py311 /
 # php 8.3).
 #
 # workflow_dispatch (iterate on the build) + workflow_call (smoke consumes it).
@@ -31,15 +31,15 @@ on:
         required: false
         default: "devel"
       abi:
-        description: "Target ABI — match the pfSense base (CE 2.8.1 = FreeBSD:15:amd64; Plus = FreeBSD:16:amd64)"
+        description: "Target ABI — match the pfSense base (CE 2.8 = FreeBSD:15:amd64; Plus = FreeBSD:16:amd64)"
         required: false
         default: "FreeBSD:15:amd64"
       py_flavor:
-        description: "Python flavor for dep names (CE 2.8.1 = py311)"
+        description: "Python flavor for dep names (CE 2.8 = py311)"
         required: false
         default: "py311"
       php_version:
-        description: "PHP version for dep names (CE 2.8.1 = 8.3)"
+        description: "PHP version for dep names (CE 2.8 = 8.3)"
         required: false
         default: "8.3"
       variant:

--- a/.github/workflows/build-pkg.yml
+++ b/.github/workflows/build-pkg.yml
@@ -12,7 +12,7 @@ name: build-pkg (FreeBSD)
 # pkg ABI matches and the artifact installs on pfSense with `pkg add` (properly
 # registered, so rc.packages POST-INSTALL runs the package's hooks):
 #
-#   pfSense CE 2.8.1 -> FreeBSD 15  (releases/VM-IMAGES/15.0-RELEASE/...)
+#   pfSense CE 2.8 -> FreeBSD 15  (releases/VM-IMAGES/15.0-RELEASE/...)
 #   pfSense Plus     -> FreeBSD 16  (snapshots/VM-IMAGES/16.0-CURRENT/...)
 #
 # Two-tier image cache to minimise per-run setup:
@@ -45,7 +45,7 @@ on:
   workflow_dispatch:
     inputs:
       freebsd_version:
-        description: "FreeBSD version for the build env — match the pfSense base (CE 2.8.1 = 15.0-RELEASE; Plus = 16.0-CURRENT)"
+        description: "FreeBSD version for the build env — match the pfSense base (CE 2.8 = 15.0-RELEASE; Plus = 16.0-CURRENT)"
         required: false
         default: "15.0-RELEASE"
       channel:
@@ -53,7 +53,7 @@ on:
         required: false
         default: "devel"
       php_version:
-        description: "PHP default to pin (match the target pfSense: CE 2.8.1 = 8.3)"
+        description: "PHP default to pin (match the target pfSense: CE 2.8 = 8.3)"
         required: false
         default: "8.3"
       ports_repo:

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -226,11 +226,11 @@ jobs:
           SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
           SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_USER || github.actor }}
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          FROM_TAG: ${{ needs.resolve-from.outputs.from_tag }}
+          TARGET: ${{ inputs.pfsense_version }}
+          FORCE_FLAG: ${{ needs.resolve-from.outputs.force_flag }}
         run: |
           set -eu
-          FROM_TAG="${{ needs.resolve-from.outputs.from_tag }}"
-          TARGET="${{ inputs.pfsense_version }}"
-          FORCE_FLAG="${{ needs.resolve-from.outputs.force_flag }}"
           sh scripts/image-upgrade.sh \
             ${FORCE_FLAG:+"$FORCE_FLAG"} \
             --from "$FROM_TAG" \

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -43,7 +43,7 @@ on:
   workflow_dispatch:
     inputs:
       pfsense_version:
-        description: "Target pfSense CE version (e.g. 2.8.1). The tracker passes the exact version from supported-versions.json."
+        description: "Target pfSense CE floating tag (e.g. 2.8). The tracker passes the exact version from supported-versions.json."
         required: true
         type: string
       freebsd_version:
@@ -51,7 +51,7 @@ on:
         required: true
         type: string
       from_version:
-        description: "Prior published CE tag to upgrade from (e.g. 2.8.0). Leave empty to auto-detect from the matrix (the most recent prior CE tag)."
+        description: "Prior published CE floating tag to upgrade from (e.g. 2.7). Leave empty to auto-detect from the matrix (the most recent prior CE tag, or self for a patch refresh)."
         required: false
         default: ""
         type: string
@@ -82,15 +82,21 @@ permissions:
 
 jobs:
   # ── Resolve prior published tag (from_version) ─────────────────────────────
-  # Determine which existing GHCR tag to upgrade FROM. The tracker always passes
-  # pfsense_version + freebsd_version; from_version is optional (the tracker does
-  # not currently pass it, so we auto-detect from the matrix here).
+  # Determine which existing GHCR tag to upgrade FROM, and whether --force is
+  # needed (patch refresh: target tag already exists and will be overwritten).
+  #
+  # With the floating-tag scheme, pfsense_version IS the GHCR tag (e.g. "2.8").
+  # Two cases:
+  #   New minor/major (e.g. "2.9"): upgrade FROM the previous version (e.g. "2.8").
+  #   Patch refresh (e.g. "2.8" is the only/oldest entry): upgrade FROM itself,
+  #     overwriting :2.8 in place (--force required since the tag already exists).
   resolve-from:
     name: Resolve upgrade source tag
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       from_tag: ${{ steps.resolve.outputs.from_tag }}
+      force_flag: ${{ steps.resolve.outputs.force_flag }}
     steps:
       - name: Checkout (for read-version-matrix action)
         uses: actions/checkout@v6
@@ -104,45 +110,45 @@ jobs:
           set -eu
           if [ -n "$FROM_VERSION" ]; then
             # Caller supplied an explicit prior tag — use it directly.
+            # Self-refresh (same tag) still needs --force.
+            FORCE=""
+            [ "$FROM_VERSION" = "$TARGET_VERSION" ] && FORCE="--force"
             printf 'from_tag=%s\n' "$FROM_VERSION" >> "$GITHUB_OUTPUT"
-            printf 'Using caller-supplied from_version: %s\n' "$FROM_VERSION"
+            printf 'force_flag=%s\n' "$FORCE" >> "$GITHUB_OUTPUT"
+            printf 'Using caller-supplied from_version: %s%s\n' "$FROM_VERSION" \
+              "${FORCE:+ (self-refresh, --force)}"
             exit 0
           fi
 
-          # Auto-detect: read the matrix for the most recent prior CE GA entry.
+          # Auto-detect: read all CE entries sorted by version, find the one
+          # immediately before TARGET_VERSION. Uses sort -V (version sort) so
+          # "2.9" < "2.10" is handled correctly regardless of jq string ordering.
           git fetch origin ci-metadata
           MATRIX_JSON="$(git show origin/ci-metadata:supported-versions.json)"
 
-          # Strip trailing ".x" suffix from pfsense_version inputs (e.g. "2.8.x" -> "2.8").
-          TARGET_PREFIX="$(printf '%s' "$TARGET_VERSION" | sed 's/\.x$//')"
+          ALL_CE="$(printf '%s' "$MATRIX_JSON" | jq -r '
+            .versions[] | select(.channel == "CE") | .pfsense_version
+          ' | sort -V)"
 
-          # Find all CE GA entries whose version prefix is strictly less than the
-          # target prefix (older versions), pick the latest by sorted order.
-          FROM_TAG="$(printf '%s' "$MATRIX_JSON" | jq -r --arg target "$TARGET_PREFIX" '
-            .versions[]
-            | select(.channel == "CE" and .status == "GA")
-            | . as $e
-            | ($e.pfsense_version | gsub("\\.x$"; "")) as $pfx
-            | select($pfx < $target)
-            | $pfx
-          ' | sort -V | tail -1)"
+          FROM_TAG="$(printf '%s\n' "$ALL_CE" | awk -v target="$TARGET_VERSION" '
+            prev != "" && $0 == target { print prev; exit }
+            { prev = $0 }
+          ')"
 
+          # Patch-refresh fallback: target is the oldest/only CE entry — upgrade
+          # in-place, overwriting the floating tag (--force required).
+          FORCE=""
           if [ -z "$FROM_TAG" ] || [ "$FROM_TAG" = "null" ]; then
-            printf '::error::Cannot determine from_version: no prior CE GA entry in the matrix older than %s. Pass from_version explicitly or add a prior GA entry to supported-versions.json on ci-metadata.\n' \
-              "$TARGET_VERSION"
-            exit 1
+            FROM_TAG="$TARGET_VERSION"
+            FORCE="--force"
+            printf 'Patch refresh: self-upgrade %s -> %s (--force)\n' \
+              "$FROM_TAG" "$TARGET_VERSION"
+          else
+            printf 'New-version upgrade: %s -> %s\n' "$FROM_TAG" "$TARGET_VERSION"
           fi
 
-          # Reconstruct the published tag from the matrix entry for this prefix.
-          FROM_FULL_TAG="$(printf '%s' "$MATRIX_JSON" | jq -r --arg pfx "${FROM_TAG}" '
-            .versions[]
-            | select(.channel == "CE" and .status == "GA")
-            | select((.pfsense_version | gsub("\\.x$"; "")) == $pfx)
-            | .pfsense_version | gsub("\\.x$"; "")
-          ' | head -1)"
-
-          printf 'Auto-detected from_version: %s (target: %s)\n' "$FROM_FULL_TAG" "$TARGET_VERSION"
-          printf 'from_tag=%s\n' "$FROM_FULL_TAG" >> "$GITHUB_OUTPUT"
+          printf 'from_tag=%s\n' "$FROM_TAG" >> "$GITHUB_OUTPUT"
+          printf 'force_flag=%s\n' "$FORCE" >> "$GITHUB_OUTPUT"
 
   # ── Upgrade in place → health gate → publish; then non-blocking smoke ──────
   refresh:
@@ -222,9 +228,13 @@ jobs:
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eu
+          FROM_TAG="${{ needs.resolve-from.outputs.from_tag }}"
+          TARGET="${{ inputs.pfsense_version }}"
+          FORCE_FLAG="${{ needs.resolve-from.outputs.force_flag }}"
           sh scripts/image-upgrade.sh \
-            --from "${{ needs.resolve-from.outputs.from_tag }}" \
-            --to "${{ inputs.pfsense_version }}" \
+            ${FORCE_FLAG:+"$FORCE_FLAG"} \
+            --from "$FROM_TAG" \
+            --to "$TARGET" \
             --image "${{ steps.ref.outputs.image }}" \
             --ssh-key "$PWD/smoke_key" \
             --compression "${{ inputs.compression }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
         # Also emits first_* scalar outputs for the FreeBSD-builder reusable-workflow
         # call (which cannot use strategy.matrix alongside uses:) — these are the
         # first deduped entry's fields. Today there is exactly one deduped entry
-        # (both CE 2.8.x and Plus 25.03 share FreeBSD 15); when a second major is
+        # (both CE 2.8 and Plus 26.03 share FreeBSD 15); when a second major is
         # added, build-pkgs-portable's inline loop handles all of them, and the
         # FreeBSD-builder path would need extending to multiple calls.
         run: |

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -28,7 +28,7 @@ on:
         required: false
         default: ""
       pfsense_version:
-        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Ignored when image_ref is set."
+        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8). Ignored when image_ref is set."
         required: false
         default: ""
   schedule:

--- a/.github/workflows/smoke-fanout.yml
+++ b/.github/workflows/smoke-fanout.yml
@@ -103,14 +103,10 @@ jobs:
   # whether another leg has already failed.
   #
   # IMAGE REF RESOLUTION:
-  # The CI matrix entry carries pfsense_version (e.g. "2.8.x"). We pass it to
-  # smoke.yml as `pfsense_version` so smoke.yml can compose the GHCR ref.
-  # IMPORTANT: pfsense_version entries ending in ".x" are WILDCARD PATTERNS (e.g.
-  # "2.8.x" covers the whole 2.8 release line). A ".x" pattern does NOT exist as a
-  # GHCR image tag — only the specific patch release does (e.g. "2.8.1"), which is
-  # stored in the SMOKE_IMAGE_TAG repo variable. In that case pass empty string so
-  # smoke.yml falls back to SMOKE_IMAGE_TAG. For exact-version entries (e.g. "26.03")
-  # pass the version directly — it matches the GHCR tag verbatim.
+  # The CI matrix entry carries pfsense_version (e.g. "2.8"). We pass it to
+  # smoke.yml as `pfsense_version`; smoke.yml composes the GHCR ref from the
+  # SMOKE_IMAGE_REPO / SMOKE_IMAGE_NAME / SMOKE_IMAGE_TAG repo variables, with
+  # pfsense_version overriding the tag.
   smoke:
     name: Smoke (${{ matrix.pfsense_version }})
     needs: prepare
@@ -122,10 +118,10 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.ci_matrix) }}
     uses: ./.github/workflows/smoke.yml
     with:
-      # Wildcard-pattern versions (ending in .x, e.g. "2.8.x") are NOT valid GHCR
-      # tags — pass empty so smoke.yml uses the SMOKE_IMAGE_TAG repo variable (which
-      # holds the actual patch tag, e.g. "2.8.1"). Exact-version entries pass through.
-      pfsense_version: ${{ endsWith(matrix.pfsense_version, '.x') && '' || matrix.pfsense_version }}
+      # Pass the per-leg version directly — pfsense_version IS the GHCR floating tag
+      # (e.g. "2.8"), so no transformation needed. smoke.yml uses it to override the
+      # SMOKE_IMAGE_TAG repo variable.
+      pfsense_version: ${{ matrix.pfsense_version }}
     secrets: inherit
 
   # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -25,7 +25,7 @@ name: Smoke (pfSense VM, ADR-04)
 #   SMOKE_IMAGE_REPO     GHCR namespace (variable), e.g. ghcr.io/pfblockerng
 #                        (default ghcr.io/<owner-lowercased>).
 #   SMOKE_IMAGE_NAME     image name appended to it (variable, default pfsense-ce).
-#   SMOKE_IMAGE_TAG      default tag (variable, default 2.8.1). The pull ref is
+#   SMOKE_IMAGE_TAG      default tag (variable, default 2.8). The pull ref is
 #                        ${SMOKE_IMAGE_REPO}/${SMOKE_IMAGE_NAME}:${SMOKE_IMAGE_TAG};
 #                        the image_ref input (full ref) or pfsense_version input
 #                        (tag) override it.
@@ -45,7 +45,7 @@ on:
         required: false
         default: ""
       pfsense_version:
-        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Wildcard patterns (e.g. '2.8.x') are cleared to blank. Ignored when image_ref is set."
+        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8). Ignored when image_ref is set."
         required: false
         default: ""
       pytest_marker:
@@ -64,7 +64,7 @@ on:
         type: string
         default: ""
       pfsense_version:
-        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8.1). Wildcard patterns (e.g. '2.8.x') are cleared to blank. Ignored when image_ref is set."
+        description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8). Ignored when image_ref is set."
         required: false
         type: string
         default: ""
@@ -99,7 +99,7 @@ jobs:
     uses: ./.github/workflows/build-pkg-linux.yml
     with:
       channel: devel
-    # abi/py_flavor/php_version default to CE 2.8.1 (FreeBSD:15:amd64 / py311 / 8.3).
+    # abi/py_flavor/php_version default to CE 2.8 (FreeBSD:15:amd64 / py311 / 8.3).
 
   smoke:
     name: pytest -m smoke (live pfSense VM)
@@ -154,14 +154,7 @@ jobs:
             # Fallback for REPO: lowercased owner (GHCR refs MUST be lowercase).
             REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
             NAME="${SMOKE_IMAGE_NAME:-pfsense-ce}"
-            # Strip wildcard-style version inputs (e.g. "2.8.x") — the CI
-            # matrix uses ".x" as a range marker, not a literal GHCR tag.
-            # Fall back to SMOKE_IMAGE_TAG (the concrete build tag, e.g.
-            # "2.8.1") or the hardcoded default.
-            case "$INPUT_VERSION" in
-              *.x|*.X) INPUT_VERSION="" ;;
-            esac
-            TAG="${INPUT_VERSION:-${SMOKE_IMAGE_TAG:-2.8.1}}"
+            TAG="${INPUT_VERSION:-${SMOKE_IMAGE_TAG:-2.8}}"
             REF="${REPO%/}/${NAME}:${TAG}"
           fi
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"
@@ -171,7 +164,7 @@ jobs:
         uses: oras-project/setup-oras@v2
 
       # Key the image cache on the RESOLVED MANIFEST DIGEST, not the ref string.
-      # SMOKE_IMAGE_REF is typically a MOVING tag (e.g. :2.8.1); a re-push to the
+      # SMOKE_IMAGE_REF is a MOVING (floating) tag (e.g. :2.8); a re-push to the
       # same tag changes the content (digest) but not the ref string. Keying on
       # the digest makes a new image invalidate the cache automatically — a fresh
       # pull, no manual cache bust. Needs a GHCR login (private repo) first; the

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -44,34 +44,34 @@ jobs:
           COUNT="$(printf '%s' "$CI_MATRIX" | jq 'length')"
           printf '\n%s CI entries\n' "$COUNT"
 
-      - name: Verify build matrix contains expected CE 2.8.x entry
+      - name: Verify build matrix contains expected CE 2.8 entry
         env:
           BUILD_MATRIX: ${{ steps.matrices.outputs.build_matrix }}
         run: |
           set -eu
-          # Sanity: the seed must have the 2.8.x CE entry with FreeBSD 15 + PHP 8.3.
+          # Sanity: the seed must have the 2.8 CE entry with FreeBSD 15 + PHP 8.3.
           ENTRY="$(printf '%s' "$BUILD_MATRIX" | jq -e '
-            .[] | select(.channel == "CE" and .pfsense_version == "2.8.x")
+            .[] | select(.channel == "CE" and .pfsense_version == "2.8")
           ')" || {
-            printf '::error::BUILD matrix is missing the expected CE 2.8.x entry\n'
+            printf '::error::BUILD matrix is missing the expected CE 2.8 entry\n'
             exit 1
           }
           FB="$(printf '%s' "$ENTRY" | jq -r '.freebsd_version')"
           PHP="$(printf '%s' "$ENTRY" | jq -r '.php_version')"
           CI_FLAG="$(printf '%s' "$ENTRY" | jq -r '.ci')"
           if [ "$FB" != "15.0-RELEASE" ]; then
-            printf '::error::CE 2.8.x freebsd_version expected 15.0-RELEASE, got %s\n' "$FB"
+            printf '::error::CE 2.8 freebsd_version expected 15.0-RELEASE, got %s\n' "$FB"
             exit 1
           fi
           if [ "$PHP" != "8.3" ]; then
-            printf '::error::CE 2.8.x php_version expected 8.3, got %s\n' "$PHP"
+            printf '::error::CE 2.8 php_version expected 8.3, got %s\n' "$PHP"
             exit 1
           fi
           if [ "$CI_FLAG" != "true" ]; then
-            printf '::error::CE 2.8.x ci expected true, got %s\n' "$CI_FLAG"
+            printf '::error::CE 2.8 ci expected true, got %s\n' "$CI_FLAG"
             exit 1
           fi
-          printf 'CE 2.8.x entry OK: FreeBSD %s, PHP %s, ci=%s\n' "$FB" "$PHP" "$CI_FLAG"
+          printf 'CE 2.8 entry OK: FreeBSD %s, PHP %s, ci=%s\n' "$FB" "$PHP" "$CI_FLAG"
 
       - name: Verify Plus entry is ci:false
         env:
@@ -105,15 +105,10 @@ jobs:
           # must fail non-zero. Simulate it by running the lookup script with a
           # clearly unknown version string.
           MATRIX_JSON="$(git fetch origin ci-metadata && git show origin/ci-metadata:supported-versions.json)"
-          UNKNOWN="9.9.9"
+          UNKNOWN="9.9"
           MATCH="$(printf '%s' "$MATRIX_JSON" | jq -e --arg ver "$UNKNOWN" '
             .versions[]
-            | select(.channel == "CE")
-            | . as $e
-            | select(
-                ($e.pfsense_version | endswith(".x") and ($ver | startswith($e.pfsense_version[:-1])))
-                or $e.pfsense_version == $ver
-              )
+            | select(.channel == "CE" and .pfsense_version == $ver)
           ' 2>/dev/null | jq -s '.[0] // empty')" || true
 
           if [ -n "$MATCH" ] && [ "$MATCH" != "null" ]; then

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -105,7 +105,7 @@ jobs:
           # must fail non-zero. Simulate it by running the lookup script with a
           # clearly unknown version string.
           MATRIX_JSON="$(git fetch origin ci-metadata && git show origin/ci-metadata:supported-versions.json)"
-          UNKNOWN="9.9"
+          UNKNOWN="__invalid__"
           MATCH="$(printf '%s' "$MATRIX_JSON" | jq -e --arg ver "$UNKNOWN" '
             .versions[]
             | select(.channel == "CE" and .pfsense_version == $ver)

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -111,7 +111,7 @@ jobs:
     uses: ./.github/workflows/build-pkg-linux.yml
     with:
       channel: devel
-    # abi/py_flavor/php_version default to CE 2.8.1 (FreeBSD:15:amd64 / py311 / 8.3).
+    # abi/py_flavor/php_version default to CE 2.8 (FreeBSD:15:amd64 / py311 / 8.3).
 
   # Compute the (tier × version) matrix and the nightly no-commit guard. Emits a
   # JSON `include` list so each leg is a distinct, independently-re-runnable job.
@@ -264,7 +264,7 @@ jobs:
             # Fallback for REPO: lowercased owner (GHCR refs MUST be lowercase).
             REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
             NAME="${SMOKE_IMAGE_NAME:-pfsense-ce}"
-            TAG="${INPUT_VERSION:-${SMOKE_IMAGE_TAG:-2.8.1}}"
+            TAG="${INPUT_VERSION:-${SMOKE_IMAGE_TAG:-2.8}}"
             REF="${REPO%/}/${NAME}:${TAG}"
           fi
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -38,7 +38,7 @@ on:
         default: "false"
       target_version:
         description: >
-          Restrict reactions to a specific pfsense_version (e.g. "2.8.x").
+          Restrict reactions to a specific pfsense_version (e.g. "2.8").
           Leave empty to react to all matrix entries.
         required: false
         default: ""

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -22,9 +22,9 @@
 #   ./scripts/image-upgrade.sh --from <current-version> [options]
 #
 # Examples:
-#   ./scripts/image-upgrade.sh --from 2.8.1 --proxmox root@pve.lan --ssh-key ~/.ssh/smoke_ed25519
-#   ./scripts/image-upgrade.sh --from 2.8.1 --to 2.8.2 --proxmox pve.lan --proxmox-port 2222 --force
-#   ./scripts/image-upgrade.sh --from 2.8.1 --to 2.8.2 --upgrade-pkgs   # also upgrades baked deps
+#   ./scripts/image-upgrade.sh --from 2.8 --proxmox root@pve.lan --ssh-key ~/.ssh/smoke_ed25519
+#   ./scripts/image-upgrade.sh --from 2.8 --to 2.9 --proxmox pve.lan --proxmox-port 2222
+#   ./scripts/image-upgrade.sh --from 2.8 --to 2.8 --force --upgrade-pkgs   # patch refresh
 #
 # Proxmox connection (the KVM host that boots the VM):
 #   --proxmox [USER@]HOST   SSH target of the Proxmox/KVM host. If omitted (and


### PR DESCRIPTION
## Summary

- **`smoke.yml`**: remove the wildcard-stripping `case` block (PR #182 workaround); update default tag fallback from `2.8.1` → `2.8`; update comments
- **`smoke-fanout.yml`**: pass `pfsense_version` directly (remove `endsWith(.x)` conditional); simplify IMAGE REF RESOLUTION comment
- **`image-refresh.yml`**: replace the `status == "GA"` / `.x`-prefix resolve-from logic with a version-sorted lookup across all CE entries (`sort -V` handles `2.9 < 2.10` correctly); add self-refresh fallback when target is oldest/only entry; emit `force_flag` output so patch refreshes pass `--force` to `image-upgrade.sh` (the floating tag already exists); wire `force_flag` in the refresh job
- **`build-image.yml`**: drop `.x`-prefix matching; exact `pfsense_version` match; update default input to `"2.8"`
- **`test-version-matrix.yml`**: update assertions to `"2.8"`; simplify reject-unknown test to exact match
- **`ui-tests.yml`**, **`repo-install.yml`**: update default tag fallback to `"2.8"`
- **`build-pkg.yml`**, **`build-pkg-linux.yml`**, **`version-tracker.yml`**, **`release.yml`**: update comments
- **`scripts/image-upgrade.sh`**: update example comments to floating-tag style

## How the new resolve-from works

| Scenario | `FROM_TAG` | `--force`? |
|---|---|---|
| Patch refresh: `2.8` is only CE entry | `2.8` (self) | yes |
| New minor: `2.9` added, `2.8` exists | `2.8` (prior) | no |
| New major: `26.03` added, `2.8` exists | `2.8` (prior CE) | no |

## ⚠️ Merge ordering

**This PR must land after the companion `ci-metadata` PR** that changes `"2.8.x"` → `"2.8"` in `supported-versions.json`. Landing this one first would remove the `.x`-stripping before the matrix is updated, breaking `smoke-fanout`.

## Operational steps (maintainer action, after both PRs land)

1. Re-tag GHCR: `docker buildx imagetools create -t ghcr.io/pfblockerng/pfsense-ce:2.8 ghcr.io/pfblockerng/pfsense-ce:2.8.1`
2. Update `SMOKE_IMAGE_TAG` repo variable: `2.8.1` → `2.8`
3. Dispatch `smoke-fanout.yml` to validate end-to-end

---
🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApekJ5tz5FdVLuUEFoijaX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image refresh can auto-detect the prior CE floating tag and supports explicit in-place patch refreshes via a resolved force flag.

* **Chores**
  * Unified CI workflows and examples to use floating Major.Minor tags (e.g., 2.8).
  * Enforced exact-version matching for CE tags and simplified tag pass-through/fallback behavior across workflows.

* **Documentation**
  * Updated workflow and script usage text and examples to reflect the floating-tag model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->