### PR TITLE
PFBL-01: enforce pfb_filter() input-validation contract (+ PHPCS gate)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -158,6 +158,14 @@ if [ -x vendor/bin/phpstan ]; then
 	vendor/bin/phpstan analyse --no-progress --memory-limit=1G || failed 'phpstan'
 fi
 
+# --- PHP: PHPCS PFBL-01 RequirePfbFilter sniff (only when the vendor tree is installed).
+#     Config auto-discovered from phpcs.xml.dist (the RequirePfbFilter rule over the
+#     in-scope package include). ---
+if [ -x vendor/bin/phpcs ]; then
+	step 'phpcs (PFBL-01)'
+	vendor/bin/phpcs || failed 'phpcs'
+fi
+
 # --- PHP: PHPUnit (only when the Composer vendor tree is installed) ---
 if [ -x vendor/bin/phpunit ]; then
 	step 'phpunit'

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -164,6 +164,8 @@ fi
 if [ -x vendor/bin/phpcs ]; then
 	step 'phpcs (PFBL-01)'
 	vendor/bin/phpcs || failed 'phpcs'
+else
+	skip phpcs
 fi
 
 # --- PHP: PHPUnit (only when the Composer vendor tree is installed) ---

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,6 +261,29 @@ jobs:
         # suppressed; new errors introduced by future changes will fail CI.
         run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
 
+  php-codesniffer:
+    name: PHPCS PFBL-01 RequirePfbFilter sniff
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run PHPCS
+        # Config auto-discovered from phpcs.xml.dist: the custom PfBlockerNG standard
+        # (the RequirePfbFilter sniff) over the in-scope package include.
+        # PFBL-01 Requirement 4 — the mechanical enforcement of the filter contract.
+        run: vendor/bin/phpcs
+
   php-unit:
     name: PHPUnit unit tests
     runs-on: ubuntu-latest
@@ -380,7 +403,7 @@ jobs:
     # The ADR-14 UI suite (`ui-suite`) IS folded in: it is skipped (== pass) on an
     # unlabeled PR / push, and only a `ui-tests`-labeled PR whose UI suite FAILS
     # blocks here — that is how the opt-in label gates a merge.
-    needs: [test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-unit, markdownlint, ui-suite]
+    needs: [test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, ui-suite]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
@@ -411,6 +434,10 @@ jobs:
           fi
           if [ "${{ needs.php-static-analysis.result }}" != "success" ]; then
             echo "PHPStan static analysis failed or was cancelled."
+            exit 1
+          fi
+          if [ "${{ needs.php-codesniffer.result }}" != "success" ]; then
+            echo "PHPCS PFBL-01 RequirePfbFilter sniff failed or was cancelled."
             exit 1
           fi
           if [ "${{ needs.php-unit.result }}" != "success" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,8 @@ pfBlockerNG/
 ├── .markdownlint-cli2.jsonc  # markdownlint-cli2 globs + ignores
 ├── pyproject.toml         # pytest + ruff + mypy config
 ├── phpunit.xml            # PHPUnit config (PHP unit suite; tests/php/)
-├── composer.json          # PHP dev deps: phpstan + phpunit
+├── phpcs.xml.dist         # PHPCS config (PFBL-01 RequirePfbFilter sniff over pfblockerng.inc)
+├── composer.json          # PHP dev deps: phpstan + phpunit + php_codesniffer
 └── README.md
 ```
 
@@ -199,6 +200,8 @@ helpers — bootstrap loads the real `pfblockerng.inc` off-appliance via include
 pfSense doubles; see `tests/php/README.md`), and `tests/smoke/` (the dispatch-only live-VM
 suite, ADR-04, which also holds `tests/smoke/ui/` — the ADR-14 Web-UI tiers
 `ui_render`/`ui_e2e`/`ui_browser` reusing the `smoke_vm` fixture + `helpers.py`).
+`tests/phpcs/` holds the custom PHP_CodeSniffer standard (the PFBL-01 `RequirePfbFilter`
+sniff) plus its `fixtures/` (driven by `tests/php/RequirePfbFilterSniffTest.php`).
 
 Release archives contain only `src/`. Everything else (stubs, scripts, tests, CI,
 `pyproject.toml`, `.githooks/`) is dev-only.
@@ -222,8 +225,8 @@ after checkout, before its commit/push steps** — so automated commits hit the 
   `ruff check`/`ruff format --check`, `python -m pytest`, `mypy tests/` (the suite is fully
   typed — `tests.*` is `disallow_untyped_defs`; `tests/smoke` excluded), `markdownlint-cli2`,
   `sh -n` + `shellcheck`, `php -l`. Each runs only when its tool is installed (missing =
-  reported + skipped; CI is the hard gate); PHPStan/PHPUnit run only when `vendor/bin/` has
-  them. Emergency bypass: `git commit --no-verify`.
+  reported + skipped; CI is the hard gate); PHPStan/PHPCS/PHPUnit run only when `vendor/bin/`
+  has them. Emergency bypass: `git commit --no-verify`.
 - **`.githooks/pre-push`** enforces tag naming before pushes reach the remote.
 
 ---
@@ -389,10 +392,24 @@ to 79 columns and whitespace checks Ruff delegates to `ruff format`). Keep them 
 
 Intelephense in VS Code (`.inc` = PHP via `files.associations`). `stubs/pfsense/` resolves
 pfSense-provided functions — if one is flagged undefined, add it to the right stub file rather
-than expanding `undefinedFunctions` in `.vscode/settings.json`. PHPStan + PHPUnit are the PHP
-gates (both pulled by `composer install`, enforced in CI `test.yml` + the pre-commit hook).
-The `stubs/pfsense/` stubs are for PHPStan, NOT runtime doubles (those live in
+than expanding `undefinedFunctions` in `.vscode/settings.json`. PHPStan + PHPUnit + PHPCS are
+the PHP gates (all pulled by `composer install`, enforced in CI `test.yml` + the pre-commit
+hook). The `stubs/pfsense/` stubs are for PHPStan, NOT runtime doubles (those live in
 `tests/php/pfsense_doubles.php`).
+
+**PHPCS — the PFBL-01 RequirePfbFilter sniff.** A single custom PHP_CodeSniffer rule
+(`PfBlockerNG.Validation.RequirePfbFilter`, in `tests/phpcs/PfBlockerNG/`) mechanically enforces
+PFBL-01: inside an **in-scope (allow-listed) function** — the ADR-06/07/10/13 input-handling
+surfaces — no `exec`-family call, `json_encode` manifest write, or dynamic filesystem-path
+build may appear **without a preceding semantic-validation call** (`pfb_filter()` /
+`pfb_sanitise_feed_header()` / `sanitize_ipaddr()`) in the same function scope. It enforces the
+*semantic* layer `escapeshellarg()` cannot — both layers are required. Scope is an explicit
+allow-list (the `scopeFunctions` property), so the ADR's "legacy code is out of scope"
+carve-out is encoded by **not listing** a function, never a blanket scan; add a function name
+there when a new in-scope surface lands. Run it: `vendor/bin/phpcs` (config auto-discovered
+from `phpcs.xml.dist`). The sniff's own behaviour — fires on each sink class, silent when a
+validator precedes the sink or the function is out of scope — is pinned by
+`tests/php/RequirePfbFilterSniffTest.php` against fixtures in `tests/phpcs/fixtures/`.
 
 ### Shell
 

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,15 @@
 {
     "require-dev": {
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": "^11.5",
+        "squizlabs/php_codesniffer": "^3.10"
     },
     "config": {
         "sort-packages": true
     },
     "scripts": {
         "test": "phpunit",
-        "phpstan": "phpstan analyse --no-progress --memory-limit=1G"
+        "phpstan": "phpstan analyse --no-progress --memory-limit=1G",
+        "phpcs": "phpcs"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f5f76293d0120bd647e0a4f29b0d19f",
+    "content-hash": "df07b3135b1b0c039bf8cb6806e84454",
     "packages": [],
     "packages-dev": [
         {
@@ -1751,6 +1751,85 @@
             "time": "2024-10-09T05:16:32+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
             "name": "staabm/side-effects-detector",
             "version": "1.0.5",
             "source": {
@@ -1860,5 +1939,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="pfBlockerNG-validation">
+    <description>
+        PFBL-01 input-validation gate. Runs the project's custom PfBlockerNG standard
+        (the RequirePfbFilter sniff) over the package include that holds the
+        ADR-06/07/10/13 in-scope surfaces. PHPStan + PHPUnit remain the broad PHP
+        gates; this is a single, targeted rule, not a style standard.
+    </description>
+
+    <!-- The in-scope surface lives in the main package include. -->
+    <file>src/usr/local/pkg/pfblockerng/pfblockerng.inc</file>
+
+    <!-- The bundled custom standard (its ruleset.xml references the sniff). -->
+    <rule ref="./tests/phpcs/PfBlockerNG/ruleset.xml"/>
+</ruleset>

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -985,9 +985,9 @@ function pfb_find_marked_vip(array $vips_config, string $marker, ?string $match_
 // interface_ipalias_configure(). Every legal friendly name is \w-only, so the WORD
 // filter passes all of them unchanged and rejects anything carrying separators,
 // spaces, quotes or other non-word characters. As a singular required parameter, a
-// value failing the filter is to ABORT VIP management for the run (log + return, no
-// config write). Enforcement lands with PFBL-01; the constant's accept/reject
-// behaviour is pinned by tests/php/PfbFilterContractTest.php.
+// value failing the filter ABORTS VIP management for the run (log + return, no
+// config read or write, no VIP operation). The constant's accept/reject behaviour
+// is pinned by tests/php/PfbFilterContractTest.php.
 function pfb_manage_dnsbl_vip(string $mode): void {
 	global $pfb;
 
@@ -998,6 +998,16 @@ function pfb_manage_dnsbl_vip(string $mode): void {
 
 	$auto      = ($pfb['dnsbl_vip_auto'] ?? '') == 'on';
 	$interface = $pfb['dnsbl_iface'] ?? 'lo0';
+
+	// PFBL-01: $interface is a singular required parameter -- validate it as a \w-only
+	// friendly interface name before anything else runs. On failure: log + abort the
+	// whole run (no config read/write, no VIP operation).
+	if (empty(pfb_filter($interface, PFB_FILTER_WORD, 'pfb_manage_dnsbl_vip'))) {
+		pfb_logger("\npfb_manage_dnsbl_vip: DNSBL VIP interface failed validation [ " .
+			substr(htmlspecialchars((string) $interface), 0, 100) . " ] *aborting*", 2);
+		return;
+	}
+
 	$dnsblcfg_path = 'installedpackages/pfblockerngdnsblsettings/config/0';
 
 	// NOTE: the enabled+auto-OFF case deliberately does NOT early-return. It falls through
@@ -2949,10 +2959,11 @@ function pfb_create_dnsbl($mode) {
 // that $target must ALSO validate as a domain via pfb_filter(PFB_FILTER_DOMAIN)
 // before any command is composed -- semantic validation and shell quoting are
 // two distinct layers (the pattern pfb_unbound_py_ccache_flush_cmds() already
-// follows). A value failing the filter is to be rejected: logged and returned
-// as array('', '') with no command run. Enforcement of that check at this
-// boundary lands with PFBL-01; the constant's accept/reject behaviour is pinned
-// by tests/php/PfbFilterContractTest.php.
+// follows). A value failing the filter is rejected: logged and returned as
+// array('', '') with no command run -- the same shape as the empty-target
+// guard, so pfb_ss_refresh_lines() keeps the prior baked IPs for a rejected
+// target exactly as it does for a failed resolution. The constant's
+// accept/reject behaviour is pinned by tests/php/PfbFilterContractTest.php.
 function pfb_ss_resolve_target($target) {
 	global $pfb;
 
@@ -2960,7 +2971,15 @@ function pfb_ss_resolve_target($target) {
 		return array('', '');
 	}
 
-	$target_esc = escapeshellarg($target);
+	// PFBL-01: validate the target as a domain before any command is composed.
+	$filtered = pfb_filter($target, PFB_FILTER_DOMAIN, 'pfb_ss_resolve_target');
+	if (empty($filtered)) {
+		pfb_logger("\npfb_ss_resolve_target: SafeSearch target failed validation [ " .
+			substr(htmlspecialchars((string) $target), 0, 100) . " ] *skipping*", 2);
+		return array('', '');
+	}
+
+	$target_esc = escapeshellarg($filtered);
 	$extdns_esc = escapeshellarg("@{$pfb['extdns']}");
 
 	$out4 = array();
@@ -3268,9 +3287,8 @@ function pfb_unbound_python_whitelist($mode='') {
 // each line lands in the manifest (config.user_whitelist) and from there in the
 // query-time whiteDB. Each line must validate via pfb_filter(PFB_FILTER_DOMAIN)
 // before it is returned -- the filter accepts the leading-dot wildcard form
-// ('.example.com') as well as plain domains. A line failing the filter is to be
-// SKIPPED + logged (list iteration), never silently dropped. Enforcement lands
-// with PFBL-01.
+// ('.example.com') as well as plain domains. A line failing the filter is
+// SKIPPED + logged (list iteration), never silently dropped.
 function pfb_dnsbl_whitelist_lines() {
 	global $pfb;
 
@@ -3279,9 +3297,17 @@ function pfb_dnsbl_whitelist_lines() {
 	if (!empty($lines)) {
 		foreach ($lines as $line) {
 			$line = trim($line);
-			if ($line !== '') {
-				$out[] = $line;
+			if ($line === '') {
+				continue;
 			}
+			// PFBL-01: only domain-valid lines (incl. '.example.com' wildcards) may
+			// enter the manifest; skip the line + log on failure.
+			if (empty(pfb_filter($line, PFB_FILTER_DOMAIN, 'pfb_dnsbl_whitelist_lines'))) {
+				pfb_logger("\npfb_dnsbl_whitelist_lines: Suppression line failed validation [ " .
+					substr(htmlspecialchars($line), 0, 100) . " ] *skipping*", 2);
+				continue;
+			}
+			$out[] = $line;
 		}
 	}
 	return $out;
@@ -3303,9 +3329,9 @@ function pfb_dnsbl_whitelist_lines() {
 // a plain file under /tmp re-read here later -- so this reader is a boundary of its
 // own and must not trust the file contents (same posture as
 // pfb_unbound_py_ccache_flush_cmds() towards its callers). Each domain read from
-// the store must re-validate via pfb_filter(PFB_FILTER_DOMAIN) before it is placed
-// into the manifest (config.user_unlock); a row failing the filter is to be SKIPPED
-// + logged. Enforcement lands with PFBL-01.
+// the store re-validates via pfb_filter(PFB_FILTER_DOMAIN) before it is placed
+// into the manifest (config.user_unlock); a row failing the filter is SKIPPED
+// + logged.
 function pfb_dnsbl_unlock_lines() {
 	global $pfb;
 
@@ -3314,9 +3340,17 @@ function pfb_dnsbl_unlock_lines() {
 	if (is_array($store)) {
 		foreach (array_keys($store) as $domain) {
 			$domain = trim((string) $domain);
-			if ($domain !== '') {
-				$out[] = $domain;
+			if ($domain === '') {
+				continue;
 			}
+			// PFBL-01: the store is re-read from a plain file; re-validate each
+			// domain before it enters the manifest (skip the row + log on failure).
+			if (empty(pfb_filter($domain, PFB_FILTER_DOMAIN, 'pfb_dnsbl_unlock_lines'))) {
+				pfb_logger("\npfb_dnsbl_unlock_lines: Unlock domain failed validation [ " .
+					substr(htmlspecialchars($domain), 0, 100) . " ] *skipping*", 2);
+				continue;
+			}
+			$out[] = $domain;
 		}
 	}
 	return $out;
@@ -3563,6 +3597,23 @@ function pfb_unbound_py_swap_fits_ram() {
 }
 
 
+// PFBL-01: validate a feed header / list label before it is used to derive a file
+// path or a manifest key. Returns the header UNCHANGED when it validates via
+// pfb_filter(PFB_FILTER_WORD); returns FALSE on rejection, after logging the
+// supplied $reference and a truncated (max 100 chars) htmlspecialchars()-encoded
+// copy of the offending value (never the raw bytes). Pure apart from the log
+// write. Callers MUST check the return strictly (=== FALSE) and SKIP the row when
+// iterating a list, or ABORT when the header is a singular required parameter.
+function pfb_sanitise_feed_header(string $header, string $reference = 'pfb_sanitise_feed_header'): string|false {
+	if (empty(pfb_filter($header, PFB_FILTER_WORD, $reference))) {
+		pfb_logger("\n{$reference}: Feed header failed validation [ " .
+			substr(htmlspecialchars($header), 0, 100) . " ] *skipping*", 2);
+		return FALSE;
+	}
+	return $header;
+}
+
+
 // ADR-06: Build the shell->Python contract. Writes the per-feed manifest
 // ($pfb['unbound_py_sources']) plus a per-feed IP-stripped raw file (one bare,
 // lower-cased domain per line) referenced by the manifest. The Python plugin's
@@ -3592,13 +3643,14 @@ function pfb_unbound_py_swap_fits_ram() {
 // '.txt' and staged '.raw' files and becomes the manifest 'feed'/'raw' keys. The
 // producing loops already validate headers with pfb_filter(PFB_FILTER_WORD) (e.g.
 // 'DNSBL - Processes'), but this writer is the choke point for every path derived
-// from a header and must RE-validate each one with the same constant before use --
-// it must not trust its callers (the posture pfb_unbound_py_ccache_flush_cmds()
-// documents). Note PFB_FILTER_WORD is the correct constant here, NOT
-// PFB_FILTER_DOMAIN: headers are \w-only list labels (no dots), so the DOMAIN
-// filter would reject every legal header. A row whose header fails the filter is
-// to be SKIPPED + logged. Enforcement lands with PFBL-01; the constant's
-// accept/reject behaviour is pinned by tests/php/PfbFilterContractTest.php.
+// from a header and RE-validates each one via pfb_sanitise_feed_header() before
+// use -- it must not trust its callers (the posture
+// pfb_unbound_py_ccache_flush_cmds() documents). Note PFB_FILTER_WORD is the
+// correct constant here, NOT PFB_FILTER_DOMAIN: headers are \w-only list labels
+// (no dots), so the DOMAIN filter would reject every legal header. A row whose
+// header fails the filter is SKIPPED + logged, before any file is touched. The
+// constant's accept/reject behaviour is pinned by
+// tests/php/PfbFilterContractTest.php.
 function pfb_unbound_python_sources($feeds) {
 	global $pfb;
 
@@ -3620,6 +3672,12 @@ function pfb_unbound_python_sources($feeds) {
 		$format	= (isset($feed['format']) && $feed['format'] === 'abp') ? 'abp' : 'plain';
 
 		if ($header === '') {
+			continue;
+		}
+
+		// PFBL-01: re-validate the header at this choke point, BEFORE it derives the
+		// source/raw paths or any manifest key (skip the row + log on failure).
+		if (pfb_sanitise_feed_header($header, 'pfb_unbound_python_sources') === FALSE) {
 			continue;
 		}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -977,6 +977,17 @@ function pfb_find_marked_vip(array $vips_config, string $marker, ?string $match_
 // apply): the vip entry is written into virtualip/vip and the dnsvip id into the DNSBL
 // settings, write_config fires ONCE iff anything changed, then interface_ipalias_configure()
 // brings the alias up live.
+//
+// Validation contract (PFBL-01): $interface (the stored dnsbl_interface setting; a
+// pfSense friendly interface name -- 'lo0', 'lan', 'optN', 'enc0', 'openvpn', 'l2tp',
+// per pfb_build_if_list()) must validate via pfb_filter(PFB_FILTER_WORD) before it is
+// written into a VIP entry or handed to interface_vip_bring_down() /
+// interface_ipalias_configure(). Every legal friendly name is \w-only, so the WORD
+// filter passes all of them unchanged and rejects anything carrying separators,
+// spaces, quotes or other non-word characters. As a singular required parameter, a
+// value failing the filter is to ABORT VIP management for the run (log + return, no
+// config write). Enforcement lands with PFBL-01; the constant's accept/reject
+// behaviour is pinned by tests/php/PfbFilterContractTest.php.
 function pfb_manage_dnsbl_vip(string $mode): void {
 	global $pfb;
 
@@ -2931,6 +2942,17 @@ function pfb_create_dnsbl($mode) {
 // when the live CNAME chase yields no address, and the SafeSearch freshness cron
 // re-runs this every 15 minutes to keep them current. Returns array($v4, $v6),
 // each '' when unresolved.
+//
+// Validation contract (PFBL-01): $target is built into an exec() command line
+// (escapeshellarg() supplies the quoting; $pfb['extdns'] is already
+// PFB_FILTER_IPV4-validated in pfb_global). The contract for this boundary is
+// that $target must ALSO validate as a domain via pfb_filter(PFB_FILTER_DOMAIN)
+// before any command is composed -- semantic validation and shell quoting are
+// two distinct layers (the pattern pfb_unbound_py_ccache_flush_cmds() already
+// follows). A value failing the filter is to be rejected: logged and returned
+// as array('', '') with no command run. Enforcement of that check at this
+// boundary lands with PFBL-01; the constant's accept/reject behaviour is pinned
+// by tests/php/PfbFilterContractTest.php.
 function pfb_ss_resolve_target($target) {
 	global $pfb;
 
@@ -3240,6 +3262,15 @@ function pfb_unbound_python_whitelist($mode='') {
 // for the Python build manifest (config.user_whitelist). The Python build performs
 // the www-strip / leading-dot->wildcard normalisation itself (pfb_unbound.py
 // _dnsbl_normalise_whitelist), so this hands the RAW suppression lines through.
+//
+// Validation contract (PFBL-01): the suppression textarea is free-form user input
+// and pfbng_text_area_decode() only normalises encoding (no domain validation), yet
+// each line lands in the manifest (config.user_whitelist) and from there in the
+// query-time whiteDB. Each line must validate via pfb_filter(PFB_FILTER_DOMAIN)
+// before it is returned -- the filter accepts the leading-dot wildcard form
+// ('.example.com') as well as plain domains. A line failing the filter is to be
+// SKIPPED + logged (list iteration), never silently dropped. Enforcement lands
+// with PFBL-01.
 function pfb_dnsbl_whitelist_lines() {
 	global $pfb;
 
@@ -3266,6 +3297,15 @@ function pfb_dnsbl_whitelist_lines() {
 // rebuilt manifest re-locks every unlock (the "re-locked on Cron/Force" behaviour
 // documented in the alerts icon tooltip). Only pfb_unbound_python_sources_unlock()
 // (the incremental alerts path) feeds the live store into the manifest.
+//
+// Validation contract (PFBL-01): the alerts handler filters the POSTed domain with
+// pfb_filter(PFB_FILTER_DOMAIN) before it enters the store, but the store itself is
+// a plain file under /tmp re-read here later -- so this reader is a boundary of its
+// own and must not trust the file contents (same posture as
+// pfb_unbound_py_ccache_flush_cmds() towards its callers). Each domain read from
+// the store must re-validate via pfb_filter(PFB_FILTER_DOMAIN) before it is placed
+// into the manifest (config.user_unlock); a row failing the filter is to be SKIPPED
+// + logged. Enforcement lands with PFBL-01.
 function pfb_dnsbl_unlock_lines() {
 	global $pfb;
 
@@ -3547,6 +3587,18 @@ function pfb_unbound_py_swap_fits_ram() {
 //         'format' => 'abp'|'plain', 'provenance' => 'user'|'feed' ]. ADR-07: a
 //         Custom_List ({alias}_custom) row is 'user' -> the Python build bands it as a
 //         sovereign user block (5); a downloaded feed is 'feed' -> band 1.
+//
+// Validation contract (PFBL-01): each row's 'header' names the per-feed source
+// '.txt' and staged '.raw' files and becomes the manifest 'feed'/'raw' keys. The
+// producing loops already validate headers with pfb_filter(PFB_FILTER_WORD) (e.g.
+// 'DNSBL - Processes'), but this writer is the choke point for every path derived
+// from a header and must RE-validate each one with the same constant before use --
+// it must not trust its callers (the posture pfb_unbound_py_ccache_flush_cmds()
+// documents). Note PFB_FILTER_WORD is the correct constant here, NOT
+// PFB_FILTER_DOMAIN: headers are \w-only list labels (no dots), so the DOMAIN
+// filter would reject every legal header. A row whose header fails the filter is
+// to be SKIPPED + logged. Enforcement lands with PFBL-01; the constant's
+// accept/reject behaviour is pinned by tests/php/PfbFilterContractTest.php.
 function pfb_unbound_python_sources($feeds) {
 	global $pfb;
 

--- a/tests/php/DnsblVipInterfaceValidationTest.php
+++ b/tests/php/DnsblVipInterfaceValidationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_manage_dnsbl_vip() — PFBL-01 interface-name boundary. $interface (the stored
+ * dnsbl_interface, a \w-only pfSense friendly name) is a singular required
+ * parameter: a value failing pfb_filter(PFB_FILTER_WORD) must ABORT the whole run —
+ * logged, with NO config write — while a valid name passes the boundary unchanged
+ * and the function proceeds exactly as before.
+ *
+ * Scenario: VIP management with a validated vs a rejected interface name
+ *   Background:
+ *     Given config holds no marked DNSBL VIP and auto-create is off
+ *       (so a run that passes validation is a no-change pass: no write_config)
+ *   Case A (valid):   When mode 'enabled' runs with interface 'lo0'
+ *                     Then no rejection is logged and config is untouched
+ *   Case B (invalid): When mode 'enabled' runs with a non-\w interface value
+ *                     Then a rejection log line is written, write_config is never
+ *                     called, and config is byte-identical (abort before any write)
+ *
+ * The full create/delete lifecycle remains lint + live-smoke territory (ADR-13);
+ * this pins only the validation boundary added by PFBL-01.
+ */
+#[CoversFunction('pfb_manage_dnsbl_vip')]
+final class DnsblVipInterfaceValidationTest extends TestCase
+{
+	private string $tmp;
+	private array $savedPfbKeys = [];
+	private bool $hadConfig = false;
+	private array $savedConfig = [];
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_vip_' . uniqid('', true);
+		mkdir($this->tmp, 0777, true);
+
+		// Fresh per-test log targets + the inputs pfb_manage_dnsbl_vip reads from $pfb.
+		foreach (['log', 'errlog', 'dnsbl_vip_auto', 'dnsbl_iface', 'dnsblconfig'] as $key) {
+			$this->savedPfbKeys[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? [])
+				? $GLOBALS['pfb'][$key] : null;
+		}
+		$GLOBALS['pfb']['log']    = "{$this->tmp}/log";
+		$GLOBALS['pfb']['errlog'] = "{$this->tmp}/errlog";
+
+		// Auto-create OFF, no marked VIP, resolver absent: a run that passes the
+		// validation boundary walks both family delete-branches, finds nothing to do
+		// and returns without writing config.
+		$GLOBALS['pfb']['dnsbl_vip_auto'] = '';
+		$GLOBALS['pfb']['dnsblconfig']    = [];
+
+		$this->hadConfig = array_key_exists('config', $GLOBALS);
+		$this->savedConfig = $GLOBALS['config'] ?? [];
+		$GLOBALS['config'] = [
+			'virtualip' => ['vip' => []],
+			'installedpackages' => [
+				'pfblockerngdnsblsettings' => ['config' => [0 => []]],
+			],
+		];
+
+		$GLOBALS['pfb_test_write_config_calls'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedPfbKeys as $key => $value) {
+			if ($value === null) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $value;
+			}
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+		unset($GLOBALS['pfb_test_write_config_calls']);
+		rmdir_recursive($this->tmp);
+	}
+
+	private function logContents(): string
+	{
+		$path = $GLOBALS['pfb']['log'];
+		return file_exists($path) ? (string) file_get_contents($path) : '';
+	}
+
+	public function testValidInterfacePassesTheBoundaryWithoutRejection(): void
+	{
+		// Given a legal friendly interface name and an empty log
+		$GLOBALS['pfb']['dnsbl_iface'] = 'lo0';
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		// When the lifecycle manager runs
+		pfb_manage_dnsbl_vip('enabled');
+
+		// Then no rejection is logged and the no-change pass writes no config
+		$this->assertStringNotContainsString('failed validation', $this->logContents());
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'],
+			'a no-change pass must not call write_config');
+	}
+
+	public function testRejectedInterfaceAbortsBeforeAnyConfigWrite(): void
+	{
+		// Given a non-\w interface value and an empty log
+		$GLOBALS['pfb']['dnsbl_iface'] = 'igb1.100; ls';
+		$configBefore = $GLOBALS['config'];
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		// When the lifecycle manager runs
+		pfb_manage_dnsbl_vip('enabled');
+
+		// Then the rejection is observable in the log (function name + encoded value) ...
+		$log = $this->logContents();
+		$this->assertStringContainsString('pfb_manage_dnsbl_vip', $log);
+		$this->assertStringContainsString('failed validation', $log);
+		$this->assertStringContainsString(htmlspecialchars('igb1.100; ls'), $log);
+
+		// ... and the run aborted with no config write of any kind.
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'],
+			'an aborted run must never call write_config');
+		$this->assertSame($configBefore, $GLOBALS['config'], 'config must be untouched');
+	}
+
+	public function testRejectedInterfaceAlsoAbortsTheDisabledPath(): void
+	{
+		// The delete branch ('disabled') runs the same singular-parameter boundary:
+		// both lifecycle modes must abort on a rejected interface name.
+		$GLOBALS['pfb']['dnsbl_iface'] = 'lo0 && reboot';
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		pfb_manage_dnsbl_vip('disabled');
+
+		$this->assertStringContainsString('failed validation', $this->logContents());
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls']);
+	}
+}

--- a/tests/php/DnsblVipInterfaceValidationTest.php
+++ b/tests/php/DnsblVipInterfaceValidationTest.php
@@ -30,6 +30,7 @@ final class DnsblVipInterfaceValidationTest extends TestCase
 {
 	private string $tmp;
 	private array $savedPfbKeys = [];
+	private array $hadPfbKeys = [];
 	private bool $hadConfig = false;
 	private array $savedConfig = [];
 
@@ -40,8 +41,8 @@ final class DnsblVipInterfaceValidationTest extends TestCase
 
 		// Fresh per-test log targets + the inputs pfb_manage_dnsbl_vip reads from $pfb.
 		foreach (['log', 'errlog', 'dnsbl_vip_auto', 'dnsbl_iface', 'dnsblconfig'] as $key) {
-			$this->savedPfbKeys[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? [])
-				? $GLOBALS['pfb'][$key] : null;
+			$this->hadPfbKeys[$key]   = array_key_exists($key, $GLOBALS['pfb'] ?? []);
+			$this->savedPfbKeys[$key] = $GLOBALS['pfb'][$key] ?? null;
 		}
 		$GLOBALS['pfb']['log']    = "{$this->tmp}/log";
 		$GLOBALS['pfb']['errlog'] = "{$this->tmp}/errlog";
@@ -67,10 +68,10 @@ final class DnsblVipInterfaceValidationTest extends TestCase
 	protected function tearDown(): void
 	{
 		foreach ($this->savedPfbKeys as $key => $value) {
-			if ($value === null) {
-				unset($GLOBALS['pfb'][$key]);
-			} else {
+			if ($this->hadPfbKeys[$key]) {
 				$GLOBALS['pfb'][$key] = $value;
+			} else {
+				unset($GLOBALS['pfb'][$key]);
 			}
 		}
 		if ($this->hadConfig) {

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_filter() — PFBL-01 validation-contract pins for the constants used at the
+ * feed/manifest, SafeSearch and VIP boundaries:
+ *
+ *   - PFB_FILTER_DOMAIN : SafeSearch CNAME targets, alert/unlock domains,
+ *                         suppression (whitelist) lines.
+ *   - PFB_FILTER_WORD   : feed headers (the per-feed file/manifest labels) and
+ *                         pfSense friendly interface names ('lo0'/'lan'/'optN').
+ *   - PFB_FILTER_IP(V4) : address-valued settings (e.g. the external DNS server).
+ *
+ * Branch coverage per the repo rules — every constant is pinned from BOTH sides:
+ * representative valid values pass through UNCHANGED (the filter must never
+ * mangle good data), and each documented invalid input class returns the default
+ * ('' here). PfbFilterTest covers the basics; this file adds the boundary-shaped
+ * inputs the PFBL-01 call sites must rely on being rejected: '..' sequences and
+ * separator characters, command-line metacharacters, embedded whitespace/quotes,
+ * and overlong values.
+ */
+#[CoversFunction('pfb_filter')]
+final class PfbFilterContractTest extends TestCase
+{
+	// --- PFB_FILTER_DOMAIN ------------------------------------------------------
+
+	/** @return array<string, array{0: string}> label => valid domain returned unchanged */
+	public static function domainAcceptedProvider(): array
+	{
+		// Longest legal shape: 63+63+63+61 char labels + 3 dots = 253 chars
+		// (< the 255 limit), every label at or under the 63-char label cap.
+		$longest = sprintf(
+			'%s.%s.%s.%s',
+			str_repeat('a', 63),
+			str_repeat('b', 63),
+			str_repeat('c', 63),
+			str_repeat('d', 61)
+		);
+
+		return [
+			'plain domain'            => ['example.com'],
+			'deep subdomain'          => ['a.b.c.d.example.com'],
+			'digits and dash'         => ['feed-01.example-cdn.net'],
+			'underscore label'        => ['_dmarc.example.com'],
+			'leading-dot wildcard'    => ['.example.com'],   // suppression wildcard form
+			'63-char label boundary'  => [str_repeat('a', 63) . '.com'],
+			'253-char total boundary' => [$longest],
+		];
+	}
+
+	#[DataProvider('domainAcceptedProvider')]
+	public function testDomainFilterReturnsValidValueUnchanged(string $domain): void
+	{
+		$this->assertSame($domain, pfb_filter($domain, PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
+	}
+
+	/** @return array<string, array{0: string}> label => value the DOMAIN filter must reject */
+	public static function domainRejectedProvider(): array
+	{
+		return [
+			'parent-dir sequence'        => ['../../etc/passwd'],
+			'dot-dot inside a name'      => ['example..com'],
+			'embedded slash'             => ['example.com/etc'],
+			'backslash'                  => ['example\\.com'],
+			'semicolon suffix'           => ['example.com;ls'],
+			'dollar-paren'               => ['$(hostname).com'],
+			'backtick'                   => ['`hostname`.com'],
+			'pipe'                       => ['a.com|b.com'],
+			'ampersand'                  => ['a.com&b.com'],
+			'redirection'                => ['a.com>out.com'],
+			'embedded space'             => ['exam ple.com'],
+			'single quote'               => ["exam'ple.com"],
+			'double quote'               => ['exam"ple.com'],
+			'embedded newline'           => ["example.com\nmore.com"],
+			'embedded tab'               => ["example\t.com"],
+			'embedded NUL'               => ["example.com\0"],
+			'at-sign'                    => ['user@example.com'],
+			'colon (host:port)'          => ['example.com:8080'],
+			'64-char label (overlong)'   => [str_repeat('a', 64) . '.com'],
+			// 63+63+63+63 char labels + 3 dots = 255 chars: every label is legal,
+			// the total length is what trips the < 255 limit.
+			'255-char total (overlong)'  => [str_repeat('a', 63) . '.' . str_repeat('b', 63) . '.' . str_repeat('c', 63) . '.' . str_repeat('d', 63)],
+		];
+	}
+
+	#[DataProvider('domainRejectedProvider')]
+	public function testDomainFilterRejectsToDefault(string $input): void
+	{
+		$this->assertSame('', pfb_filter($input, PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
+	}
+
+	// --- PFB_FILTER_WORD (feed headers + friendly interface names) ---------------
+
+	/** @return array<string, array{0: string}> label => valid \w-only value returned unchanged */
+	public static function wordAcceptedProvider(): array
+	{
+		return [
+			// Feed-header shapes (the '{header}{vtype}' file/manifest labels).
+			'plain header'         => ['EasyList'],
+			'header with vtype'    => ['Abuse_ch_v4'],
+			'custom-list header'   => ['MyAlias_custom'],
+			'dnsblip header'       => ['DNSBLIP_v6'],
+			// Friendly interface names as stored in dnsbl_interface
+			// (pfb_build_if_list: wan/lan/optN/lo0/enc0/openvpn/l2tp).
+			'localhost interface'  => ['lo0'],
+			'lan interface'        => ['lan'],
+			'optN interface'       => ['opt12'],
+			'ipsec interface'      => ['enc0'],
+			'openvpn interface'    => ['openvpn'],
+		];
+	}
+
+	#[DataProvider('wordAcceptedProvider')]
+	public function testWordFilterReturnsValidValueUnchanged(string $word): void
+	{
+		$this->assertSame($word, pfb_filter($word, PFB_FILTER_WORD, 'PFBL-01 contract'));
+	}
+
+	/** @return array<string, array{0: string}> label => value the WORD filter must reject */
+	public static function wordRejectedProvider(): array
+	{
+		return [
+			'parent-dir sequence'  => ['..'],
+			'relative path'        => ['../feed'],
+			'embedded slash'       => ['feeds/evil'],
+			'backslash'            => ['feed\\name'],
+			'dot (file suffix)'    => ['feed.txt'],
+			'dotted device name'   => ['igb1.100'],   // dnsbl_interface stores friendly names; dotted VLAN device names are out of contract
+			'dash'                 => ['feed-name'],
+			'embedded space'       => ['feed name'],
+			'semicolon'            => ['feed;name'],
+			'dollar-paren'         => ['$(feed)'],
+			'backtick'             => ['`feed`'],
+			'pipe'                 => ['feed|name'],
+			'single quote'         => ["feed'name"],
+			'double quote'         => ['feed"name'],
+			'embedded newline'     => ["feed\nname"],
+			'embedded NUL'         => ["feed\0name"],
+		];
+	}
+
+	#[DataProvider('wordRejectedProvider')]
+	public function testWordFilterRejectsToDefault(string $input): void
+	{
+		$this->assertSame('', pfb_filter($input, PFB_FILTER_WORD, 'PFBL-01 contract'));
+	}
+
+	// --- PFB_FILTER_IP / PFB_FILTER_IPV4 -----------------------------------------
+
+	public function testIpFilterReturnsValidAddressUnchanged(): void
+	{
+		$this->assertSame('192.0.2.53', pfb_filter('192.0.2.53', PFB_FILTER_IP, 'PFBL-01 contract'));
+		$this->assertSame('2001:db8::53', pfb_filter('2001:db8::53', PFB_FILTER_IP, 'PFBL-01 contract'));
+		$this->assertSame('198.51.100.4', pfb_filter('198.51.100.4', PFB_FILTER_IPV4, 'PFBL-01 contract'));
+	}
+
+	/** @return array<string, array{0: string}> label => value the IP filters must reject */
+	public static function ipRejectedProvider(): array
+	{
+		return [
+			'semicolon suffix'   => ['192.0.2.1;ls'],
+			'trailing token'     => ['192.0.2.1 extra'],
+			'backtick suffix'    => ['192.0.2.1`x`'],
+			'quoted'             => ["'192.0.2.1'"],
+			'cidr (not a host)'  => ['192.0.2.0/24'],
+		];
+	}
+
+	#[DataProvider('ipRejectedProvider')]
+	public function testIpFilterRejectsToDefault(string $input): void
+	{
+		$this->assertSame('', pfb_filter($input, PFB_FILTER_IP, 'PFBL-01 contract'));
+		$this->assertSame('', pfb_filter($input, PFB_FILTER_IPV4, 'PFBL-01 contract'));
+	}
+
+	// --- Rejection shape ----------------------------------------------------------
+
+	public function testRejectionReturnsCallerSuppliedDefault(): void
+	{
+		// Callers that abort on rejection key off the default return: it must be the
+		// caller-supplied default verbatim, for each constant used at these boundaries.
+		$this->assertSame('DEF', pfb_filter('../../etc/passwd', PFB_FILTER_DOMAIN, 'ref', 'DEF'));
+		$this->assertSame('DEF', pfb_filter('../feed', PFB_FILTER_WORD, 'ref', 'DEF'));
+		$this->assertSame('DEF', pfb_filter('192.0.2.1;ls', PFB_FILTER_IP, 'ref', 'DEF'));
+	}
+
+	public function testRejectionDefaultIsFalsyByDefault(): void
+	{
+		// The in-tree skip/abort idiom is `if (empty(pfb_filter(...)))` — the no-default
+		// rejection value must stay falsy or every guard at these boundaries breaks.
+		$rejected = pfb_filter('feed;name', PFB_FILTER_WORD, 'PFBL-01 contract');
+		$this->assertEmpty($rejected);
+	}
+}

--- a/tests/php/PfbSanitiseFeedHeaderTest.php
+++ b/tests/php/PfbSanitiseFeedHeaderTest.php
@@ -22,6 +22,7 @@ final class PfbSanitiseFeedHeaderTest extends TestCase
 {
 	private string $tmp;
 	private array $savedPfbKeys = [];
+	private array $hadPfbKeys = [];
 
 	protected function setUp(): void
 	{
@@ -29,6 +30,7 @@ final class PfbSanitiseFeedHeaderTest extends TestCase
 		$this->tmp = sys_get_temp_dir() . '/pfb_header_' . uniqid('', true);
 		mkdir($this->tmp, 0777, true);
 		foreach (['log', 'errlog'] as $key) {
+			$this->hadPfbKeys[$key]   = array_key_exists($key, $GLOBALS['pfb'] ?? []);
 			$this->savedPfbKeys[$key] = $GLOBALS['pfb'][$key] ?? null;
 			$GLOBALS['pfb'][$key] = "{$this->tmp}/{$key}";
 		}
@@ -37,10 +39,10 @@ final class PfbSanitiseFeedHeaderTest extends TestCase
 	protected function tearDown(): void
 	{
 		foreach ($this->savedPfbKeys as $key => $value) {
-			if ($value === null) {
-				unset($GLOBALS['pfb'][$key]);
-			} else {
+			if ($this->hadPfbKeys[$key]) {
 				$GLOBALS['pfb'][$key] = $value;
+			} else {
+				unset($GLOBALS['pfb'][$key]);
 			}
 		}
 		rmdir_recursive($this->tmp);

--- a/tests/php/PfbSanitiseFeedHeaderTest.php
+++ b/tests/php/PfbSanitiseFeedHeaderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_sanitise_feed_header() — the PFBL-01 feed-header validation helper used at
+ * the manifest choke point (pfb_unbound_python_sources). Contract, pinned from
+ * both sides:
+ *
+ *   - a PFB_FILTER_WORD-valid header is returned UNCHANGED (===) and writes
+ *     nothing to the log;
+ *   - any other value returns strict FALSE, after logging a line carrying the
+ *     caller-supplied $reference and a truncated (max 100 chars)
+ *     htmlspecialchars()-encoded copy of the value — a rejection is never silent.
+ */
+#[CoversFunction('pfb_sanitise_feed_header')]
+final class PfbSanitiseFeedHeaderTest extends TestCase
+{
+	private string $tmp;
+	private array $savedPfbKeys = [];
+
+	protected function setUp(): void
+	{
+		// Point the logger at fresh per-test files so log assertions are isolated.
+		$this->tmp = sys_get_temp_dir() . '/pfb_header_' . uniqid('', true);
+		mkdir($this->tmp, 0777, true);
+		foreach (['log', 'errlog'] as $key) {
+			$this->savedPfbKeys[$key] = $GLOBALS['pfb'][$key] ?? null;
+			$GLOBALS['pfb'][$key] = "{$this->tmp}/{$key}";
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedPfbKeys as $key => $value) {
+			if ($value === null) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $value;
+			}
+		}
+		rmdir_recursive($this->tmp);
+	}
+
+	private function logContents(): string
+	{
+		$path = $GLOBALS['pfb']['log'];
+		return file_exists($path) ? (string) file_get_contents($path) : '';
+	}
+
+	/** @return array<string, array{0: string}> label => header accepted unchanged */
+	public static function acceptedHeaderProvider(): array
+	{
+		return [
+			'plain header'       => ['EasyList'],
+			'header with vtype'  => ['Abuse_ch_v4'],
+			'custom-list header' => ['MyAlias_custom'],
+			'digits'             => ['Feed2024'],
+		];
+	}
+
+	#[DataProvider('acceptedHeaderProvider')]
+	public function testValidHeaderReturnedUnchangedWithoutLogging(string $header): void
+	{
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		$this->assertSame($header, pfb_sanitise_feed_header($header, 'unit_test'));
+
+		$this->assertSame('', $this->logContents(), 'a valid header must not be logged');
+	}
+
+	/** @return array<string, array{0: string}> label => header that must be rejected */
+	public static function rejectedHeaderProvider(): array
+	{
+		return [
+			'parent-dir sequence' => ['../feed'],
+			'embedded slash'      => ['feeds/evil'],
+			'dot (device-style)'  => ['igb1.100'],
+			'dash'                => ['feed-name'],
+			'embedded space'      => ['feed name'],
+			'semicolon'           => ['feed;ls'],
+			'quote'               => ["feed'x"],
+			'newline'             => ["feed\nx"],
+			'empty string'        => [''],
+		];
+	}
+
+	#[DataProvider('rejectedHeaderProvider')]
+	public function testInvalidHeaderReturnsStrictFalseAndLogs(string $header): void
+	{
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		$this->assertFalse(pfb_sanitise_feed_header($header, 'unit_test'));
+
+		$log = $this->logContents();
+		$this->assertStringContainsString('unit_test', $log, 'log line carries the caller reference');
+		$this->assertStringContainsString('Feed header failed validation', $log);
+		if ($header !== '') {
+			$this->assertStringContainsString(substr(htmlspecialchars($header), 0, 100), $log);
+		}
+	}
+
+	public function testRejectionLogTruncatesEncodedValueTo100Chars(): void
+	{
+		// 150 'a's plus a space (the space forces rejection; the value is metachar-free
+		// so the encoded copy equals the raw one and the cut point is unambiguous).
+		$header = str_repeat('a', 150) . ' x';
+
+		$this->assertFalse(pfb_sanitise_feed_header($header, 'unit_test'));
+
+		$log = $this->logContents();
+		$this->assertStringContainsString(str_repeat('a', 100), $log, 'first 100 encoded chars are logged');
+		$this->assertStringNotContainsString(str_repeat('a', 101), $log, 'nothing beyond 100 chars is logged');
+	}
+
+	public function testDefaultReferenceIsTheHelperName(): void
+	{
+		$this->assertFalse(pfb_sanitise_feed_header('bad header'));
+		$this->assertStringContainsString('pfb_sanitise_feed_header:', $this->logContents());
+	}
+}

--- a/tests/php/RequirePfbFilterSniffTest.php
+++ b/tests/php/RequirePfbFilterSniffTest.php
@@ -25,89 +25,98 @@ use PHPUnit\Framework\TestCase;
  */
 final class RequirePfbFilterSniffTest extends TestCase
 {
-    private const SOURCE = 'PfBlockerNG.Validation.RequirePfbFilter.MissingFilter';
+	private const SOURCE = 'PfBlockerNG.Validation.RequirePfbFilter.MissingFilter';
 
-    private static function repoRoot(): string
-    {
-        return dirname(__DIR__, 2);
-    }
+	private static function repoRoot(): string
+	{
+		return dirname(__DIR__, 2);
+	}
 
-    private static function phpcsBin(): string
-    {
-        return self::repoRoot() . '/vendor/bin/phpcs';
-    }
+	private static function phpcsBin(): string
+	{
+		return self::repoRoot() . '/vendor/bin/phpcs';
+	}
 
-    protected function setUp(): void
-    {
-        if (!is_file(self::phpcsBin())) {
-            $this->markTestSkipped('phpcs not installed (composer install) — CI php-codesniffer job is the gate.');
-        }
-    }
+	protected function setUp(): void
+	{
+		if (!is_file(self::phpcsBin())) {
+			$this->markTestSkipped('phpcs not installed (composer install) — CI php-codesniffer job is the gate.');
+		}
+	}
 
-    /**
-     * Run the custom standard over one fixture and return the MissingFilter findings.
-     *
-     * @return list<array<string, mixed>>
-     */
-    private function findingsFor(string $fixture): array
-    {
-        $root    = self::repoRoot();
-        $path    = $root . '/tests/phpcs/fixtures/' . $fixture;
-        $this->assertFileExists($path, "fixture {$fixture} must exist");
+	/**
+	 * Run the custom standard over one fixture and return the MissingFilter findings.
+	 *
+	 * @return list<array<string, mixed>>
+	 */
+	private function findingsFor(string $fixture): array
+	{
+		$root    = self::repoRoot();
+		$path    = $root . '/tests/phpcs/fixtures/' . $fixture;
+		$this->assertFileExists($path, "fixture {$fixture} must exist");
 
-        $cmd = escapeshellarg(self::phpcsBin())
-            . ' --standard=' . escapeshellarg($root . '/tests/phpcs/PfBlockerNG/ruleset.xml')
-            . ' --report=json'
-            . ' ' . escapeshellarg($path)
-            . ' 2>/dev/null';
+		$cmd = escapeshellarg(self::phpcsBin())
+			. ' --standard=' . escapeshellarg($root . '/tests/phpcs/PfBlockerNG/ruleset.xml')
+			. ' --report=json'
+			. ' ' . escapeshellarg($path)
+			. ' 2>/dev/null';
 
-        $json = shell_exec($cmd);
-        $this->assertIsString($json, 'phpcs must produce JSON output');
+		$json = shell_exec($cmd);
+		$this->assertIsString($json, 'phpcs must produce JSON output');
 
-        $report = json_decode((string) $json, true);
-        $this->assertIsArray($report, 'phpcs JSON report must decode');
+		$report = json_decode((string) $json, true);
+		$this->assertIsArray($report, 'phpcs JSON report must decode');
 
-        $messages = $report['files'][$path]['messages'] ?? [];
-        return array_values(array_filter(
-            $messages,
-            static fn (array $m): bool => ($m['source'] ?? '') === self::SOURCE
-        ));
-    }
+		$messages = $report['files'][$path]['messages'] ?? [];
+		return array_values(array_filter(
+			$messages,
+			static fn (array $m): bool => ($m['source'] ?? '') === self::SOURCE
+		));
+	}
 
-    public function testFlagsExecSinkWithoutValidator(): void
-    {
-        // When: an in-scope function reaches exec() with no preceding validator.
-        // Then: the sniff reports at least one MissingFilter error.
-        $findings = $this->findingsFor('violation_exec.php');
-        $this->assertNotEmpty($findings, 'an unfiltered exec sink in an in-scope function must be flagged');
-    }
+	public function testFlagsExecSinkWithoutValidator(): void
+	{
+		// When: an in-scope function reaches exec() with no preceding validator.
+		// Then: the sniff reports at least one MissingFilter error.
+		$findings = $this->findingsFor('violation_exec.php');
+		$this->assertNotEmpty($findings, 'an unfiltered exec sink in an in-scope function must be flagged');
+	}
 
-    public function testFlagsManifestSinkWithoutValidator(): void
-    {
-        $findings = $this->findingsFor('violation_json.php');
-        $this->assertNotEmpty($findings, 'an unfiltered json_encode manifest sink must be flagged');
-    }
+	public function testFlagsManifestSinkWithoutValidator(): void
+	{
+		$findings = $this->findingsFor('violation_json.php');
+		$this->assertNotEmpty($findings, 'an unfiltered json_encode manifest sink must be flagged');
+	}
 
-    public function testFlagsPathBuildWithoutValidator(): void
-    {
-        $findings = $this->findingsFor('violation_path.php');
-        $this->assertNotEmpty($findings, 'an unfiltered interpolated path build must be flagged');
-    }
+	public function testFlagsNamespaceQualifiedExecSink(): void
+	{
+		// Regression: a fully-qualified \exec() (one T_NAME_FULLY_QUALIFIED token)
+		// bypassed the T_STRING-only match. The bare name must be resolved so a
+		// namespace-qualified sink is still flagged.
+		$findings = $this->findingsFor('violation_namespaced.php');
+		$this->assertNotEmpty($findings, 'a namespace-qualified exec sink must still be flagged');
+	}
 
-    public function testValidatorBeforeSinkPasses(): void
-    {
-        // Before/after partner of testFlagsExecSinkWithoutValidator: identical exec
-        // sink, the only added code is the leading pfb_filter() — so zero findings
-        // proves the validator presence (not some unrelated detail) clears it.
-        $findings = $this->findingsFor('compliant_filtered.php');
-        $this->assertSame([], $findings, 'a validator preceding the sink must clear the finding');
-    }
+	public function testFlagsPathBuildWithoutValidator(): void
+	{
+		$findings = $this->findingsFor('violation_path.php');
+		$this->assertNotEmpty($findings, 'an unfiltered interpolated path build must be flagged');
+	}
 
-    public function testOutOfScopeFunctionIsNotFlagged(): void
-    {
-        // A raw exec in a non-allow-listed function must NOT be flagged — encodes the
-        // ADR's "legacy code paths are out of scope" carve-out.
-        $findings = $this->findingsFor('out_of_scope.php');
-        $this->assertSame([], $findings, 'a function outside the in-scope allow-list must never be flagged');
-    }
+	public function testValidatorBeforeSinkPasses(): void
+	{
+		// Before/after partner of testFlagsExecSinkWithoutValidator: identical exec
+		// sink, the only added code is the leading pfb_filter() — so zero findings
+		// proves the validator presence (not some unrelated detail) clears it.
+		$findings = $this->findingsFor('compliant_filtered.php');
+		$this->assertSame([], $findings, 'a validator preceding the sink must clear the finding');
+	}
+
+	public function testOutOfScopeFunctionIsNotFlagged(): void
+	{
+		// A raw exec in a non-allow-listed function must NOT be flagged — encodes the
+		// ADR's "legacy code paths are out of scope" carve-out.
+		$findings = $this->findingsFor('out_of_scope.php');
+		$this->assertSame([], $findings, 'a function outside the in-scope allow-list must never be flagged');
+	}
 }

--- a/tests/php/RequirePfbFilterSniffTest.php
+++ b/tests/php/RequirePfbFilterSniffTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * PFBL-01 Requirement 4 — the custom PHP_CodeSniffer rule (PfBlockerNG.Validation.
+ * RequirePfbFilter) that mechanically enforces the input-validation contract.
+ *
+ * A linter that never fires is worthless, so this suite pins BOTH sides of every
+ * decision the sniff makes, driving the real `phpcs` binary over fixture files
+ * under tests/phpcs/fixtures/:
+ *
+ *   - it FLAGS an unfiltered exec / json_encode / path sink inside an in-scope
+ *     (allow-listed) function — one test per sink class;
+ *   - it STAYS SILENT when a semantic-validation call precedes the sink (the
+ *     before/after partner of the exec case — same sink, the lone difference is the
+ *     leading pfb_filter(), so green proves the validator is what suppresses it);
+ *   - it STAYS SILENT for a function NOT on the allow-list (the ADR's legacy
+ *     carve-out: scope is an explicit list, never a blanket scan).
+ *
+ * The sniff is dev-only tooling; if phpcs is not installed the suite SKIPs (CI's
+ * php-codesniffer job is the hard gate), it never falsely fails.
+ */
+final class RequirePfbFilterSniffTest extends TestCase
+{
+    private const SOURCE = 'PfBlockerNG.Validation.RequirePfbFilter.MissingFilter';
+
+    private static function repoRoot(): string
+    {
+        return dirname(__DIR__, 2);
+    }
+
+    private static function phpcsBin(): string
+    {
+        return self::repoRoot() . '/vendor/bin/phpcs';
+    }
+
+    protected function setUp(): void
+    {
+        if (!is_file(self::phpcsBin())) {
+            $this->markTestSkipped('phpcs not installed (composer install) — CI php-codesniffer job is the gate.');
+        }
+    }
+
+    /**
+     * Run the custom standard over one fixture and return the MissingFilter findings.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function findingsFor(string $fixture): array
+    {
+        $root    = self::repoRoot();
+        $path    = $root . '/tests/phpcs/fixtures/' . $fixture;
+        $this->assertFileExists($path, "fixture {$fixture} must exist");
+
+        $cmd = escapeshellarg(self::phpcsBin())
+            . ' --standard=' . escapeshellarg($root . '/tests/phpcs/PfBlockerNG/ruleset.xml')
+            . ' --report=json'
+            . ' ' . escapeshellarg($path)
+            . ' 2>/dev/null';
+
+        $json = shell_exec($cmd);
+        $this->assertIsString($json, 'phpcs must produce JSON output');
+
+        $report = json_decode((string) $json, true);
+        $this->assertIsArray($report, 'phpcs JSON report must decode');
+
+        $messages = $report['files'][$path]['messages'] ?? [];
+        return array_values(array_filter(
+            $messages,
+            static fn (array $m): bool => ($m['source'] ?? '') === self::SOURCE
+        ));
+    }
+
+    public function testFlagsExecSinkWithoutValidator(): void
+    {
+        // When: an in-scope function reaches exec() with no preceding validator.
+        // Then: the sniff reports at least one MissingFilter error.
+        $findings = $this->findingsFor('violation_exec.php');
+        $this->assertNotEmpty($findings, 'an unfiltered exec sink in an in-scope function must be flagged');
+    }
+
+    public function testFlagsManifestSinkWithoutValidator(): void
+    {
+        $findings = $this->findingsFor('violation_json.php');
+        $this->assertNotEmpty($findings, 'an unfiltered json_encode manifest sink must be flagged');
+    }
+
+    public function testFlagsPathBuildWithoutValidator(): void
+    {
+        $findings = $this->findingsFor('violation_path.php');
+        $this->assertNotEmpty($findings, 'an unfiltered interpolated path build must be flagged');
+    }
+
+    public function testValidatorBeforeSinkPasses(): void
+    {
+        // Before/after partner of testFlagsExecSinkWithoutValidator: identical exec
+        // sink, the only added code is the leading pfb_filter() — so zero findings
+        // proves the validator presence (not some unrelated detail) clears it.
+        $findings = $this->findingsFor('compliant_filtered.php');
+        $this->assertSame([], $findings, 'a validator preceding the sink must clear the finding');
+    }
+
+    public function testOutOfScopeFunctionIsNotFlagged(): void
+    {
+        // A raw exec in a non-allow-listed function must NOT be flagged — encodes the
+        // ADR's "legacy code paths are out of scope" carve-out.
+        $findings = $this->findingsFor('out_of_scope.php');
+        $this->assertSame([], $findings, 'a function outside the in-scope allow-list must never be flagged');
+    }
+}

--- a/tests/php/SafeSearchCnameTest.php
+++ b/tests/php/SafeSearchCnameTest.php
@@ -35,12 +35,52 @@ use PHPUnit\Framework\TestCase;
  *                  non-CNAME / malformed rows preserved verbatim;
  *                  each distinct target resolved exactly once (memo).
  *   resolve_target: empty target -> ['',''] without calling the resolver.
+ *
+ * PFBL-01 boundary (both sides): a target failing pfb_filter(PFB_FILTER_DOMAIN) is
+ * rejected BEFORE any command is composed — logged + the same ['',''] shape as the
+ * empty-target guard (so the refresh keeps prior baked IPs); a domain-valid target
+ * passes the boundary with no rejection logged and proceeds to resolution.
  */
 #[CoversFunction('pfb_ss_csv_rows')]
 #[CoversFunction('pfb_ss_refresh_lines')]
 #[CoversFunction('pfb_ss_resolve_target')]
 final class SafeSearchCnameTest extends TestCase
 {
+	private string $tmp;
+	private array $savedPfbKeys = [];
+
+	protected function setUp(): void
+	{
+		// Per-test log + extdns sandbox for the resolve_target boundary assertions.
+		$this->tmp = sys_get_temp_dir() . '/pfb_ss_' . uniqid('', true);
+		mkdir($this->tmp, 0777, true);
+		foreach (['log', 'errlog', 'extdns'] as $key) {
+			$this->savedPfbKeys[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? [])
+				? $GLOBALS['pfb'][$key] : null;
+		}
+		$GLOBALS['pfb']['log']    = "{$this->tmp}/log";
+		$GLOBALS['pfb']['errlog'] = "{$this->tmp}/errlog";
+		// Loopback resolver: never generates external traffic off-appliance.
+		$GLOBALS['pfb']['extdns'] = '127.0.0.1';
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedPfbKeys as $key => $value) {
+			if ($value === null) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $value;
+			}
+		}
+		rmdir_recursive($this->tmp);
+	}
+
+	private function logContents(): string
+	{
+		$path = $GLOBALS['pfb']['log'];
+		return file_exists($path) ? (string) file_get_contents($path) : '';
+	}
 	// --- pfb_ss_csv_rows -------------------------------------------------------
 
 	public function test_csv_rows_nxdomain_is_single_three_col_row(): void
@@ -187,5 +227,37 @@ final class SafeSearchCnameTest extends TestCase
 	{
 		// The empty-target guard returns ['',''] without attempting resolution.
 		$this->assertSame(['', ''], pfb_ss_resolve_target(''));
+	}
+
+	public function test_resolve_target_rejects_non_domain_value_with_log(): void
+	{
+		// Given a target that is not a valid domain, and an empty log
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		// When resolution is requested
+		$result = pfb_ss_resolve_target('safe.example.com;ls');
+
+		// Then it returns the same empty-pair shape as the empty-target guard
+		// (so pfb_ss_refresh_lines keeps prior baked IPs) and logs the rejection.
+		$this->assertSame(['', ''], $result);
+		$log = $this->logContents();
+		$this->assertStringContainsString('pfb_ss_resolve_target', $log);
+		$this->assertStringContainsString('failed validation', $log);
+		$this->assertStringContainsString(htmlspecialchars('safe.example.com;ls'), $log);
+	}
+
+	public function test_resolve_target_valid_domain_passes_boundary_unlogged(): void
+	{
+		// The accept side of the same branch: a domain-valid target proceeds past
+		// the validation boundary to the resolution stage with no rejection logged.
+		// Off-appliance the resolver tool is absent / answers nothing on loopback,
+		// so resolution yields the empty pair — same contract as a failed lookup;
+		// the live resolution leg stays smoke territory.
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		$result = pfb_ss_resolve_target('safe.duckduckgo.com');
+
+		$this->assertSame(['', ''], $result);
+		$this->assertStringNotContainsString('failed validation', $this->logContents());
 	}
 }

--- a/tests/php/SafeSearchCnameTest.php
+++ b/tests/php/SafeSearchCnameTest.php
@@ -48,6 +48,7 @@ final class SafeSearchCnameTest extends TestCase
 {
 	private string $tmp;
 	private array $savedPfbKeys = [];
+	private array $hadPfbKeys = [];
 
 	protected function setUp(): void
 	{
@@ -55,8 +56,8 @@ final class SafeSearchCnameTest extends TestCase
 		$this->tmp = sys_get_temp_dir() . '/pfb_ss_' . uniqid('', true);
 		mkdir($this->tmp, 0777, true);
 		foreach (['log', 'errlog', 'extdns'] as $key) {
-			$this->savedPfbKeys[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? [])
-				? $GLOBALS['pfb'][$key] : null;
+			$this->hadPfbKeys[$key]   = array_key_exists($key, $GLOBALS['pfb'] ?? []);
+			$this->savedPfbKeys[$key] = $GLOBALS['pfb'][$key] ?? null;
 		}
 		$GLOBALS['pfb']['log']    = "{$this->tmp}/log";
 		$GLOBALS['pfb']['errlog'] = "{$this->tmp}/errlog";
@@ -67,10 +68,10 @@ final class SafeSearchCnameTest extends TestCase
 	protected function tearDown(): void
 	{
 		foreach ($this->savedPfbKeys as $key => $value) {
-			if ($value === null) {
-				unset($GLOBALS['pfb'][$key]);
-			} else {
+			if ($this->hadPfbKeys[$key]) {
 				$GLOBALS['pfb'][$key] = $value;
+			} else {
+				unset($GLOBALS['pfb'][$key]);
 			}
 		}
 		rmdir_recursive($this->tmp);

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -15,10 +15,20 @@ use PHPUnit\Framework\TestCase;
  * Also covers the #51 temporary-unlock plumbing: the full build clears
  * config.user_unlock (Force/Cron re-lock), and pfb_unbound_python_sources_unlock()
  * recomputes it in place from the live pfb_unlock store (pfb_dnsbl_unlock_lines()).
+ *
+ * PFBL-01 boundary coverage (both sides of each new validation branch):
+ *   - feed headers re-validated at the manifest choke point: a valid header builds
+ *     its raw + manifest row exactly as before; a non-\w header is skipped + logged
+ *     before any file is touched.
+ *   - suppression (whitelist) lines and unlock-store domains must be
+ *     PFB_FILTER_DOMAIN-valid to enter the manifest: valid lines (incl. the
+ *     leading-dot wildcard form) pass unchanged with nothing logged; a failing
+ *     line is skipped + logged, never silently dropped.
  */
 #[CoversFunction('pfb_unbound_python_sources')]
 #[CoversFunction('pfb_unbound_python_sources_unlock')]
 #[CoversFunction('pfb_dnsbl_unlock_lines')]
+#[CoversFunction('pfb_dnsbl_whitelist_lines')]
 final class UnboundPythonSourcesTest extends TestCase
 {
 	private string $tmp;
@@ -37,6 +47,8 @@ final class UnboundPythonSourcesTest extends TestCase
 		mkdir("{$this->tmp}/db", 0777, true);
 
 		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'log'                => "{$this->tmp}/pfblockerng.log",
+			'errlog'             => "{$this->tmp}/error.log",
 			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
 			'dnsdir'             => "{$this->tmp}/dnsbl",
 			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
@@ -205,5 +217,94 @@ final class UnboundPythonSourcesTest extends TestCase
 		// No full build ran -> no manifest to patch.
 		$this->assertFileDoesNotExist("{$this->tmp}/pfb_py_sources.json");
 		$this->assertFalse(pfb_unbound_python_sources_unlock());
+	}
+
+	// --- PFBL-01: header re-validation at the manifest choke point ----------------
+
+	private function logContents(): string
+	{
+		$path = $GLOBALS['pfb']['log'];
+		return file_exists($path) ? (string) file_get_contents($path) : '';
+	}
+
+	public function testInvalidHeaderRowIsSkippedAndLoggedValidRowsKept(): void
+	{
+		// Given a build whose feed list carries one non-\w header among valid rows
+		// (its source file even exists, so only the validation can be the skip cause)
+		file_put_contents("{$this->tmp}/dnsbl/bad.header.txt", "1,example.com,a,b,c,d\n");
+		$feeds = $this->feeds();
+		$feeds[] = ['header' => 'bad.header', 'group' => 'g', 'log' => '1', 'format' => 'plain'];
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		// When the manifest is built
+		$m = pfb_unbound_python_sources($feeds);
+
+		// Then the invalid row is absent, logged, and produced no raw file ...
+		$this->assertSame(['feed1', 'abpfeed'], array_column($m['feeds'], 'feed'));
+		$log = $this->logContents();
+		$this->assertStringContainsString('pfb_unbound_python_sources', $log);
+		$this->assertStringContainsString('Feed header failed validation', $log);
+		$this->assertFileDoesNotExist("{$this->tmp}/pfb_py_raw/bad.header.raw");
+
+		// ... and the valid rows built exactly as in an all-valid run.
+		$this->assertSame("example.com\nfoo.com\n",
+			file_get_contents("{$this->tmp}/pfb_py_raw/feed1.raw"));
+	}
+
+	public function testAllValidHeadersBuildWithoutValidationLogging(): void
+	{
+		// The accept side of the same branch: an all-valid build logs no rejection.
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+		$m = pfb_unbound_python_sources($this->feeds());
+		$this->assertCount(2, $m['feeds']);
+		$this->assertStringNotContainsString('failed validation', $this->logContents());
+	}
+
+	// --- PFBL-01: suppression (whitelist) lines must be domain-valid --------------
+
+	public function testWhitelistKeepsValidDomainAndWildcardLinesUnchanged(): void
+	{
+		// Plain domain + leading-dot wildcard both pass through unchanged, no log.
+		$GLOBALS['pfb']['dnsblconfig']['suppression'] =
+			base64_encode("good.example.com\r\n.wild.example.com");
+
+		$this->assertSame(['good.example.com', '.wild.example.com'], pfb_dnsbl_whitelist_lines());
+		$this->assertSame('', $this->logContents(), 'valid lines must not be logged');
+	}
+
+	public function testWhitelistSkipsAndLogsNonDomainLine(): void
+	{
+		// Given one failing line among valid ones, and an empty log
+		$GLOBALS['pfb']['dnsblconfig']['suppression'] =
+			base64_encode("good.example.com\r\nbad domain;ls\r\n.wild.example.com");
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		// When the manifest whitelist is collected
+		$lines = pfb_dnsbl_whitelist_lines();
+
+		// Then only the valid lines remain and the rejection is logged
+		$this->assertSame(['good.example.com', '.wild.example.com'], $lines);
+		$log = $this->logContents();
+		$this->assertStringContainsString('pfb_dnsbl_whitelist_lines', $log);
+		$this->assertStringContainsString('failed validation', $log);
+	}
+
+	// --- PFBL-01: unlock-store domains re-validated at read -----------------------
+
+	public function testUnlockLinesSkipAndLogNonDomainStoreRow(): void
+	{
+		// Given a store carrying one non-domain row among valid ones, and an empty log
+		file_put_contents("{$this->tmp}/dnsbl_unlock",
+			"evil.com,python\nbad;row.com,python\nfoo.org,python\n");
+		$this->assertSame('', $this->logContents(), 'log must start empty');
+
+		// When the store is read back for the manifest
+		$lines = pfb_dnsbl_unlock_lines();
+
+		// Then the failing row is skipped and logged; the valid rows survive
+		$this->assertSame(['evil.com', 'foo.org'], $lines);
+		$log = $this->logContents();
+		$this->assertStringContainsString('pfb_dnsbl_unlock_lines', $log);
+		$this->assertStringContainsString('failed validation', $log);
 	}
 }

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -132,6 +132,101 @@ if (!function_exists('is_ipaddr_configured')) {
 	}
 }
 
+// --- config.lib.inc doubles (faithful path walkers over $GLOBALS['config']) ---
+//
+// pfb_manage_dnsbl_vip() (ADR-13 / PFBL-01) reads and writes config via the pfSense
+// config path API. These mirror config.lib.inc's array_get_path/array_set_path
+// semantics over a plain $GLOBALS['config'] array the tests seed, so the lifecycle
+// code runs unmodified off-appliance. write_config() records each invocation in
+// $GLOBALS['pfb_test_write_config_calls'] so tests can assert a path persisted
+// config -- or, just as load-bearing, that an abort path did NOT.
+
+if (!function_exists('config_get_path')) {
+	// pfSense config.lib.inc: walk a '/'-separated path, $default when absent.
+	function config_get_path(string $path, $default = null) {
+		$node = $GLOBALS['config'] ?? [];
+		foreach (explode('/', rtrim($path, '/')) as $key) {
+			if (!is_array($node) || !array_key_exists($key, $node)) {
+				return $default;
+			}
+			$node = $node[$key];
+		}
+		return $node;
+	}
+}
+
+if (!function_exists('config_set_path')) {
+	// pfSense config.lib.inc: set the value at a '/'-separated path (creating
+	// intermediate arrays), returning the value set.
+	function config_set_path(string $path, $value, $default = null) {
+		$node = &$GLOBALS['config'];
+		if (!is_array($node)) {
+			$node = [];
+		}
+		foreach (explode('/', rtrim($path, '/')) as $key) {
+			if (!is_array($node)) {
+				return $default;
+			}
+			if (!array_key_exists($key, $node) || !is_array($node[$key])) {
+				$node[$key] = [];
+			}
+			$node = &$node[$key];
+		}
+		$node = $value;
+		return $value;
+	}
+}
+
+if (!function_exists('config_path_enabled')) {
+	// pfSense config.lib.inc: node exists, is an array and carries the enable key.
+	function config_path_enabled(string $path, $enable_key = 'enable') {
+		$node = config_get_path($path);
+		return (is_array($node) && array_key_exists($enable_key, $node));
+	}
+}
+
+if (!function_exists('write_config')) {
+	// Persisting is out of scope off-appliance; record the call (so tests can
+	// assert whether a code path wrote config) and report success like pfSense.
+	function write_config($desc = 'Unknown', $backup = true, $write_config_only = false) {
+		$GLOBALS['pfb_test_write_config_calls'][] = $desc;
+		return true;
+	}
+}
+
+if (!function_exists('get_configured_vip_ipv4')) {
+	// pfSense util.inc (faithful-lite): resolve a '_vip<uniqid>' id against
+	// virtualip/vip and return the entry's v4 address, null when unresolved.
+	function get_configured_vip_ipv4($vipinterface = '') {
+		if (!is_string($vipinterface) || !str_starts_with($vipinterface, '_vip')) {
+			return null;
+		}
+		$uniqid = substr($vipinterface, strlen('_vip'));
+		foreach (config_get_path('virtualip/vip', []) as $vip) {
+			if (($vip['uniqid'] ?? '') === $uniqid && is_ipaddrv4($vip['subnet'] ?? '')) {
+				return $vip['subnet'];
+			}
+		}
+		return null;
+	}
+}
+
+if (!function_exists('get_configured_vip_ipv6')) {
+	// pfSense util.inc (faithful-lite): v6 counterpart of the above.
+	function get_configured_vip_ipv6($vipinterface = '') {
+		if (!is_string($vipinterface) || !str_starts_with($vipinterface, '_vip')) {
+			return null;
+		}
+		$uniqid = substr($vipinterface, strlen('_vip'));
+		foreach (config_get_path('virtualip/vip', []) as $vip) {
+			if (($vip['uniqid'] ?? '') === $uniqid && is_ipaddrv6($vip['subnet'] ?? '')) {
+				return $vip['subnet'];
+			}
+		}
+		return null;
+	}
+}
+
 // --- VIP doubles for pfb_validate_vips() (ADR-13) ---
 //
 // The v6-recommendation tests (DnsblV6RequiredTest) drive pfb_validate_vips() and the

--- a/tests/phpcs/PfBlockerNG/Sniffs/Validation/RequirePfbFilterSniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Validation/RequirePfbFilterSniff.php
@@ -1,0 +1,255 @@
+<?php
+
+/*
+ * PFBL-01: enforce the input-validation contract mechanically.
+ *
+ * Flags any SINK -- an exec-family call, a json_encode() (the Python manifest
+ * writer), or a dynamic filesystem-path build -- that appears inside a PFBL-01
+ * in-scope function WITHOUT a preceding semantic-validation call (pfb_filter() /
+ * pfb_sanitise_feed_header() / sanitize_ipaddr()) in the same function scope.
+ * This is the "ADR-06/07/10/13 surfaces" gate from PFBL-01 Requirement 4: it does
+ * not replace escapeshellarg() -- it enforces that the SEMANTIC layer is also
+ * present, the dual-layer rule pfb_unbound_py_ccache_flush_cmds() already follows.
+ *
+ * Scope is an explicit, auditable allow-list of function names (the Phase 1 audit
+ * table), settable from the ruleset so the in-scope set stays visible and grows
+ * deliberately -- the ADR's "legacy code is out of scope" carve-out is encoded by
+ * NOT listing legacy functions, never by a blanket file scan.
+ */
+
+namespace PfBlockerNG\Sniffs\Validation;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class RequirePfbFilterSniff implements Sniff
+{
+    /**
+     * The PFBL-01 in-scope surface: the functions the Phase 1 audit identified as
+     * accepting caller-supplied input that reaches a path / exec / manifest sink.
+     * Override from the ruleset via <property name="scopeFunctions" type="array">
+     * when a new in-scope function is added.
+     *
+     * @var string[]
+     */
+    public $scopeFunctions = [
+        'pfb_manage_dnsbl_vip',
+        'pfb_ss_resolve_target',
+        'pfb_dnsbl_whitelist_lines',
+        'pfb_dnsbl_unlock_lines',
+        'pfb_sanitise_feed_header',
+        'pfb_unbound_python_sources',
+        'pfb_unbound_py_ccache_flush_cmds',
+    ];
+
+    /**
+     * Calls that satisfy the semantic-validation contract. escapeshellarg() is NOT
+     * here on purpose: it is shell quoting, not semantic validation -- PFBL-01
+     * requires both layers and this sniff enforces the one escapeshellarg() cannot.
+     *
+     * @var string[]
+     */
+    public $validatorFunctions = [
+        'pfb_filter',
+        'pfb_sanitise_feed_header',
+        'sanitize_ipaddr',
+    ];
+
+    /**
+     * Exec-family sinks: a value reaching any of these must have passed a
+     * semantic-validation call first; the sniff flags one that has not.
+     *
+     * @var string[]
+     */
+    public $execFunctions = [
+        'exec',
+        'shell_exec',
+        'system',
+        'passthru',
+        'proc_open',
+        'popen',
+        'mwexec',
+        'mwexec_bg',
+    ];
+
+    /**
+     * Manifest / serialisation sinks: json_encode() writes the Python build manifest
+     * (pfb_unbound_py_sources.json) consumed by pfb_unbound.py; a value stored here
+     * propagates to query time, so it must be validated first.
+     *
+     * @var string[]
+     */
+    public $encodeFunctions = [
+        'json_encode',
+    ];
+
+    /**
+     * @return array<int, int|string>
+     */
+    public function register()
+    {
+        return [T_FUNCTION];
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $name = $phpcsFile->getDeclarationName($stackPtr);
+        if ($name === null || !in_array($name, $this->scopeFunctions, true)) {
+            return;
+        }
+
+        // No body (abstract / interface) -> nothing to guard.
+        if (!isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer'])) {
+            return;
+        }
+
+        $open  = $tokens[$stackPtr]['scope_opener'];
+        $close = $tokens[$stackPtr]['scope_closer'];
+
+        // Earliest semantic-validation call inside the body; null when there is none.
+        $firstValidator = $this->firstValidatorCall($phpcsFile, $tokens, $open, $close);
+
+        for ($i = $open + 1; $i < $close; $i++) {
+            $sink = $this->matchSink($phpcsFile, $tokens, $i);
+            if ($sink === null) {
+                continue;
+            }
+
+            // Satisfied iff some validator call precedes this sink in the same scope.
+            if ($firstValidator !== null && $firstValidator < $i) {
+                continue;
+            }
+
+            $phpcsFile->addError(
+                sprintf(
+                    'PFBL-01: %s in %s() is not preceded by a semantic-validation call '
+                    . '(%s) in the same function scope. Validate the input before '
+                    . 'it reaches a path/exec/manifest sink; escapeshellarg() alone is not enough.',
+                    $sink,
+                    $name,
+                    implode('() / ', $this->validatorFunctions) . '()'
+                ),
+                $i,
+                'MissingFilter'
+            );
+        }
+    }
+
+    /**
+     * Index of the first validator call within ($open, $close), or null.
+     *
+     * @param array<int, array<string, mixed>> $tokens
+     * @return int|null
+     */
+    private function firstValidatorCall(File $phpcsFile, array $tokens, int $open, int $close)
+    {
+        for ($i = $open + 1; $i < $close; $i++) {
+            if ($tokens[$i]['code'] !== T_STRING) {
+                continue;
+            }
+            if (!in_array(strtolower((string) $tokens[$i]['content']), $this->validatorFunctions, true)) {
+                continue;
+            }
+            if ($this->isFunctionCall($phpcsFile, $tokens, $i)) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Classify the token at $i as a PFBL-01 sink, or null when it is not one.
+     *
+     * @param array<int, array<string, mixed>> $tokens
+     * @return string|null  Human-readable sink description for the error message.
+     */
+    private function matchSink(File $phpcsFile, array $tokens, int $i)
+    {
+        $code = $tokens[$i]['code'];
+
+        // Function-call sinks: exec-family + json_encode.
+        if ($code === T_STRING && $this->isFunctionCall($phpcsFile, $tokens, $i)) {
+            $fn = strtolower((string) $tokens[$i]['content']);
+            if (in_array($fn, $this->execFunctions, true)) {
+                return "an exec-family call ({$fn}())";
+            }
+            if (in_array($fn, $this->encodeFunctions, true)) {
+                return "a serialisation sink ({$fn}())";
+            }
+        }
+
+        // Interpolated path: a "..." / heredoc carrying both '/' and an interpolated
+        // variable, e.g. "{$pfb['dnsdir']}/{$header}.txt".
+        if ($code === T_DOUBLE_QUOTED_STRING || $code === T_HEREDOC) {
+            $content = (string) $tokens[$i]['content'];
+            if (strpos($content, '/') !== false && strpos($content, '$') !== false) {
+                return 'a dynamic filesystem-path build (interpolated string)';
+            }
+        }
+
+        // Concatenated path: a string literal containing '/' joined by '.' to another
+        // term, e.g. $dir . '/' . $name.
+        if ($code === T_CONSTANT_ENCAPSED_STRING) {
+            $literal = trim((string) $tokens[$i]['content'], "'\"");
+            if (strpos($literal, '/') !== false && $this->isConcatenated($phpcsFile, $tokens, $i)) {
+                return 'a dynamic filesystem-path build (string concatenation)';
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * True when the T_STRING at $i is a direct function call (next non-empty token is
+     * '(') and not a method/property access, declaration, namespace segment or
+     * object instantiation.
+     *
+     * @param array<int, array<string, mixed>> $tokens
+     */
+    private function isFunctionCall(File $phpcsFile, array $tokens, int $i): bool
+    {
+        $next = $phpcsFile->findNext(T_WHITESPACE, $i + 1, null, true);
+        if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
+            return false;
+        }
+
+        $prev = $phpcsFile->findPrevious(T_WHITESPACE, $i - 1, null, true);
+        if ($prev === false) {
+            return true;
+        }
+
+        $disqualifiers = [
+            T_OBJECT_OPERATOR,
+            T_NULLSAFE_OBJECT_OPERATOR,
+            T_DOUBLE_COLON,
+            T_FUNCTION,
+            T_NEW,
+            T_STRING,        // namespace segment: Foo\bar(
+            T_NS_SEPARATOR,
+        ];
+
+        return !in_array($tokens[$prev]['code'], $disqualifiers, true);
+    }
+
+    /**
+     * True when the literal at $i is part of a '.' concatenation (either side).
+     *
+     * @param array<int, array<string, mixed>> $tokens
+     */
+    private function isConcatenated(File $phpcsFile, array $tokens, int $i): bool
+    {
+        $prev = $phpcsFile->findPrevious(T_WHITESPACE, $i - 1, null, true);
+        $next = $phpcsFile->findNext(T_WHITESPACE, $i + 1, null, true);
+
+        $prevIsConcat = $prev !== false && $tokens[$prev]['code'] === T_STRING_CONCAT;
+        $nextIsConcat = $next !== false && $tokens[$next]['code'] === T_STRING_CONCAT;
+
+        return $prevIsConcat || $nextIsConcat;
+    }
+}

--- a/tests/phpcs/PfBlockerNG/Sniffs/Validation/RequirePfbFilterSniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Validation/RequirePfbFilterSniff.php
@@ -24,232 +24,266 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class RequirePfbFilterSniff implements Sniff
 {
-    /**
-     * The PFBL-01 in-scope surface: the functions the Phase 1 audit identified as
-     * accepting caller-supplied input that reaches a path / exec / manifest sink.
-     * Override from the ruleset via <property name="scopeFunctions" type="array">
-     * when a new in-scope function is added.
-     *
-     * @var string[]
-     */
-    public $scopeFunctions = [
-        'pfb_manage_dnsbl_vip',
-        'pfb_ss_resolve_target',
-        'pfb_dnsbl_whitelist_lines',
-        'pfb_dnsbl_unlock_lines',
-        'pfb_sanitise_feed_header',
-        'pfb_unbound_python_sources',
-        'pfb_unbound_py_ccache_flush_cmds',
-    ];
+	/**
+	 * The PFBL-01 in-scope surface: the functions the Phase 1 audit identified as
+	 * accepting caller-supplied input that reaches a path / exec / manifest sink.
+	 * Override from the ruleset via <property name="scopeFunctions" type="array">
+	 * when a new in-scope function is added.
+	 *
+	 * @var string[]
+	 */
+	public $scopeFunctions = [
+		'pfb_manage_dnsbl_vip',
+		'pfb_ss_resolve_target',
+		'pfb_dnsbl_whitelist_lines',
+		'pfb_dnsbl_unlock_lines',
+		'pfb_sanitise_feed_header',
+		'pfb_unbound_python_sources',
+		'pfb_unbound_py_ccache_flush_cmds',
+	];
 
-    /**
-     * Calls that satisfy the semantic-validation contract. escapeshellarg() is NOT
-     * here on purpose: it is shell quoting, not semantic validation -- PFBL-01
-     * requires both layers and this sniff enforces the one escapeshellarg() cannot.
-     *
-     * @var string[]
-     */
-    public $validatorFunctions = [
-        'pfb_filter',
-        'pfb_sanitise_feed_header',
-        'sanitize_ipaddr',
-    ];
+	/**
+	 * Calls that satisfy the semantic-validation contract. escapeshellarg() is NOT
+	 * here on purpose: it is shell quoting, not semantic validation -- PFBL-01
+	 * requires both layers and this sniff enforces the one escapeshellarg() cannot.
+	 *
+	 * @var string[]
+	 */
+	public $validatorFunctions = [
+		'pfb_filter',
+		'pfb_sanitise_feed_header',
+		'sanitize_ipaddr',
+	];
 
-    /**
-     * Exec-family sinks: a value reaching any of these must have passed a
-     * semantic-validation call first; the sniff flags one that has not.
-     *
-     * @var string[]
-     */
-    public $execFunctions = [
-        'exec',
-        'shell_exec',
-        'system',
-        'passthru',
-        'proc_open',
-        'popen',
-        'mwexec',
-        'mwexec_bg',
-    ];
+	/**
+	 * Exec-family sinks: a value reaching any of these must have passed a
+	 * semantic-validation call first; the sniff flags one that has not.
+	 *
+	 * @var string[]
+	 */
+	public $execFunctions = [
+		'exec',
+		'shell_exec',
+		'system',
+		'passthru',
+		'proc_open',
+		'popen',
+		'mwexec',
+		'mwexec_bg',
+	];
 
-    /**
-     * Manifest / serialisation sinks: json_encode() writes the Python build manifest
-     * (pfb_unbound_py_sources.json) consumed by pfb_unbound.py; a value stored here
-     * propagates to query time, so it must be validated first.
-     *
-     * @var string[]
-     */
-    public $encodeFunctions = [
-        'json_encode',
-    ];
+	/**
+	 * Manifest / serialisation sinks: json_encode() writes the Python build manifest
+	 * (pfb_unbound_py_sources.json) consumed by pfb_unbound.py; a value stored here
+	 * propagates to query time, so it must be validated first.
+	 *
+	 * @var string[]
+	 */
+	public $encodeFunctions = [
+		'json_encode',
+	];
 
-    /**
-     * @return array<int, int|string>
-     */
-    public function register()
-    {
-        return [T_FUNCTION];
-    }
+	/**
+	 * @return array<int, int|string>
+	 */
+	public function register()
+	{
+		return [T_FUNCTION];
+	}
 
-    /**
-     * @param int $stackPtr
-     */
-    public function process(File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
+	/**
+	 * @param int $stackPtr
+	 */
+	public function process(File $phpcsFile, $stackPtr)
+	{
+		$tokens = $phpcsFile->getTokens();
 
-        $name = $phpcsFile->getDeclarationName($stackPtr);
-        if ($name === null || !in_array($name, $this->scopeFunctions, true)) {
-            return;
-        }
+		$name = $phpcsFile->getDeclarationName($stackPtr);
+		if ($name === null || !in_array($name, $this->scopeFunctions, true)) {
+			return;
+		}
 
-        // No body (abstract / interface) -> nothing to guard.
-        if (!isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer'])) {
-            return;
-        }
+		// No body (abstract / interface) -> nothing to guard.
+		if (!isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer'])) {
+			return;
+		}
 
-        $open  = $tokens[$stackPtr]['scope_opener'];
-        $close = $tokens[$stackPtr]['scope_closer'];
+		$open  = $tokens[$stackPtr]['scope_opener'];
+		$close = $tokens[$stackPtr]['scope_closer'];
 
-        // Earliest semantic-validation call inside the body; null when there is none.
-        $firstValidator = $this->firstValidatorCall($phpcsFile, $tokens, $open, $close);
+		// Earliest semantic-validation call inside the body; null when there is none.
+		$firstValidator = $this->firstValidatorCall($phpcsFile, $tokens, $open, $close);
 
-        for ($i = $open + 1; $i < $close; $i++) {
-            $sink = $this->matchSink($phpcsFile, $tokens, $i);
-            if ($sink === null) {
-                continue;
-            }
+		for ($i = $open + 1; $i < $close; $i++) {
+			$sink = $this->matchSink($phpcsFile, $tokens, $i);
+			if ($sink === null) {
+				continue;
+			}
 
-            // Satisfied iff some validator call precedes this sink in the same scope.
-            if ($firstValidator !== null && $firstValidator < $i) {
-                continue;
-            }
+			// Satisfied iff some validator call precedes this sink in the same scope.
+			if ($firstValidator !== null && $firstValidator < $i) {
+				continue;
+			}
 
-            $phpcsFile->addError(
-                sprintf(
-                    'PFBL-01: %s in %s() is not preceded by a semantic-validation call '
-                    . '(%s) in the same function scope. Validate the input before '
-                    . 'it reaches a path/exec/manifest sink; escapeshellarg() alone is not enough.',
-                    $sink,
-                    $name,
-                    implode('() / ', $this->validatorFunctions) . '()'
-                ),
-                $i,
-                'MissingFilter'
-            );
-        }
-    }
+			$phpcsFile->addError(
+				sprintf(
+					'PFBL-01: %s in %s() is not preceded by a semantic-validation call '
+					. '(%s) in the same function scope. Validate the input before '
+					. 'it reaches a path/exec/manifest sink; escapeshellarg() alone is not enough.',
+					$sink,
+					$name,
+					implode('() / ', $this->validatorFunctions) . '()'
+				),
+				$i,
+				'MissingFilter'
+			);
+		}
+	}
 
-    /**
-     * Index of the first validator call within ($open, $close), or null.
-     *
-     * @param array<int, array<string, mixed>> $tokens
-     * @return int|null
-     */
-    private function firstValidatorCall(File $phpcsFile, array $tokens, int $open, int $close)
-    {
-        for ($i = $open + 1; $i < $close; $i++) {
-            if ($tokens[$i]['code'] !== T_STRING) {
-                continue;
-            }
-            if (!in_array(strtolower((string) $tokens[$i]['content']), $this->validatorFunctions, true)) {
-                continue;
-            }
-            if ($this->isFunctionCall($phpcsFile, $tokens, $i)) {
-                return $i;
-            }
-        }
+	/**
+	 * Index of the first validator call within ($open, $close), or null.
+	 *
+	 * @param array<int, array<string, mixed>> $tokens
+	 * @return int|null
+	 */
+	private function firstValidatorCall(File $phpcsFile, array $tokens, int $open, int $close)
+	{
+		for ($i = $open + 1; $i < $close; $i++) {
+			if (!$this->isNameToken($tokens[$i]['code'])) {
+				continue;
+			}
+			if (!in_array($this->callName($tokens, $i), $this->validatorFunctions, true)) {
+				continue;
+			}
+			if ($this->isFunctionCall($phpcsFile, $tokens, $i)) {
+				return $i;
+			}
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    /**
-     * Classify the token at $i as a PFBL-01 sink, or null when it is not one.
-     *
-     * @param array<int, array<string, mixed>> $tokens
-     * @return string|null  Human-readable sink description for the error message.
-     */
-    private function matchSink(File $phpcsFile, array $tokens, int $i)
-    {
-        $code = $tokens[$i]['code'];
+	/**
+	 * Classify the token at $i as a PFBL-01 sink, or null when it is not one.
+	 *
+	 * @param array<int, array<string, mixed>> $tokens
+	 * @return string|null  Human-readable sink description for the error message.
+	 */
+	private function matchSink(File $phpcsFile, array $tokens, int $i)
+	{
+		$code = $tokens[$i]['code'];
 
-        // Function-call sinks: exec-family + json_encode.
-        if ($code === T_STRING && $this->isFunctionCall($phpcsFile, $tokens, $i)) {
-            $fn = strtolower((string) $tokens[$i]['content']);
-            if (in_array($fn, $this->execFunctions, true)) {
-                return "an exec-family call ({$fn}())";
-            }
-            if (in_array($fn, $this->encodeFunctions, true)) {
-                return "a serialisation sink ({$fn}())";
-            }
-        }
+		// Function-call sinks: exec-family + json_encode.
+		if ($this->isNameToken($code) && $this->isFunctionCall($phpcsFile, $tokens, $i)) {
+			$fn = $this->callName($tokens, $i);
+			if (in_array($fn, $this->execFunctions, true)) {
+				return "an exec-family call ({$fn}())";
+			}
+			if (in_array($fn, $this->encodeFunctions, true)) {
+				return "a serialisation sink ({$fn}())";
+			}
+		}
 
-        // Interpolated path: a "..." / heredoc carrying both '/' and an interpolated
-        // variable, e.g. "{$pfb['dnsdir']}/{$header}.txt".
-        if ($code === T_DOUBLE_QUOTED_STRING || $code === T_HEREDOC) {
-            $content = (string) $tokens[$i]['content'];
-            if (strpos($content, '/') !== false && strpos($content, '$') !== false) {
-                return 'a dynamic filesystem-path build (interpolated string)';
-            }
-        }
+		// Interpolated path: a "..." / heredoc carrying both '/' and an interpolated
+		// variable, e.g. "{$pfb['dnsdir']}/{$header}.txt".
+		if ($code === T_DOUBLE_QUOTED_STRING || $code === T_HEREDOC) {
+			$content = (string) $tokens[$i]['content'];
+			if (strpos($content, '/') !== false && strpos($content, '$') !== false) {
+				return 'a dynamic filesystem-path build (interpolated string)';
+			}
+		}
 
-        // Concatenated path: a string literal containing '/' joined by '.' to another
-        // term, e.g. $dir . '/' . $name.
-        if ($code === T_CONSTANT_ENCAPSED_STRING) {
-            $literal = trim((string) $tokens[$i]['content'], "'\"");
-            if (strpos($literal, '/') !== false && $this->isConcatenated($phpcsFile, $tokens, $i)) {
-                return 'a dynamic filesystem-path build (string concatenation)';
-            }
-        }
+		// Concatenated path: a string literal containing '/' joined by '.' to another
+		// term, e.g. $dir . '/' . $name.
+		if ($code === T_CONSTANT_ENCAPSED_STRING) {
+			$literal = trim((string) $tokens[$i]['content'], "'\"");
+			if (strpos($literal, '/') !== false && $this->isConcatenated($phpcsFile, $tokens, $i)) {
+				return 'a dynamic filesystem-path build (string concatenation)';
+			}
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    /**
-     * True when the T_STRING at $i is a direct function call (next non-empty token is
-     * '(') and not a method/property access, declaration, namespace segment or
-     * object instantiation.
-     *
-     * @param array<int, array<string, mixed>> $tokens
-     */
-    private function isFunctionCall(File $phpcsFile, array $tokens, int $i): bool
-    {
-        $next = $phpcsFile->findNext(T_WHITESPACE, $i + 1, null, true);
-        if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
-            return false;
-        }
+	/**
+	 * True when $code is a callable-name token: a plain T_STRING or a namespace-
+	 * qualified name (T_NAME_QUALIFIED / T_NAME_FULLY_QUALIFIED), so a qualified
+	 * call like \exec() or Foo\exec() is considered alongside a bare exec().
+	 *
+	 * @param int|string $code
+	 */
+	private function isNameToken($code): bool
+	{
+		return $code === T_STRING
+			|| $code === T_NAME_QUALIFIED
+			|| $code === T_NAME_FULLY_QUALIFIED;
+	}
 
-        $prev = $phpcsFile->findPrevious(T_WHITESPACE, $i - 1, null, true);
-        if ($prev === false) {
-            return true;
-        }
+	/**
+	 * Bare, lowercased function name at $i: strips any namespace prefix and a leading
+	 * '\', so \exec and Foo\exec both resolve to exec. Without this a namespace-
+	 * qualified sink would slip past the allow-list checks (a PFBL-01 gate bypass).
+	 *
+	 * @param array<int, array<string, mixed>> $tokens
+	 */
+	private function callName(array $tokens, int $i): string
+	{
+		$content = (string) $tokens[$i]['content'];
+		$tail = strrchr($content, '\\');
+		return strtolower($tail === false ? $content : substr($tail, 1));
+	}
 
-        $disqualifiers = [
-            T_OBJECT_OPERATOR,
-            T_NULLSAFE_OBJECT_OPERATOR,
-            T_DOUBLE_COLON,
-            T_FUNCTION,
-            T_NEW,
-            T_STRING,        // namespace segment: Foo\bar(
-            T_NS_SEPARATOR,
-        ];
+	/**
+	 * True when the name token at $i is a direct function call (next non-empty token is
+	 * '(') and not a method/property access, declaration, namespace segment or
+	 * object instantiation.
+	 *
+	 * @param array<int, array<string, mixed>> $tokens
+	 */
+	private function isFunctionCall(File $phpcsFile, array $tokens, int $i): bool
+	{
+		$next = $phpcsFile->findNext(T_WHITESPACE, $i + 1, null, true);
+		if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
+			return false;
+		}
 
-        return !in_array($tokens[$prev]['code'], $disqualifiers, true);
-    }
+		// PHPCS tokenizes a qualified call (\exec, Foo\exec) as a T_NS_SEPARATOR /
+		// T_STRING chain. Walk back over that whole prefix so the call is judged by
+		// what precedes the qualified NAME, not by its own namespace separators —
+		// otherwise a leading '\' would mask the call (a PFBL-01 gate bypass).
+		$prev = $phpcsFile->findPrevious(T_WHITESPACE, $i - 1, null, true);
+		while ($prev !== false
+			&& ($tokens[$prev]['code'] === T_NS_SEPARATOR || $tokens[$prev]['code'] === T_STRING)) {
+			$prev = $phpcsFile->findPrevious(T_WHITESPACE, $prev - 1, null, true);
+		}
+		if ($prev === false) {
+			return true;
+		}
 
-    /**
-     * True when the literal at $i is part of a '.' concatenation (either side).
-     *
-     * @param array<int, array<string, mixed>> $tokens
-     */
-    private function isConcatenated(File $phpcsFile, array $tokens, int $i): bool
-    {
-        $prev = $phpcsFile->findPrevious(T_WHITESPACE, $i - 1, null, true);
-        $next = $phpcsFile->findNext(T_WHITESPACE, $i + 1, null, true);
+		$disqualifiers = [
+			T_OBJECT_OPERATOR,
+			T_NULLSAFE_OBJECT_OPERATOR,
+			T_DOUBLE_COLON,
+			T_FUNCTION,
+			T_NEW,
+		];
 
-        $prevIsConcat = $prev !== false && $tokens[$prev]['code'] === T_STRING_CONCAT;
-        $nextIsConcat = $next !== false && $tokens[$next]['code'] === T_STRING_CONCAT;
+		return !in_array($tokens[$prev]['code'], $disqualifiers, true);
+	}
 
-        return $prevIsConcat || $nextIsConcat;
-    }
+	/**
+	 * True when the literal at $i is part of a '.' concatenation (either side).
+	 *
+	 * @param array<int, array<string, mixed>> $tokens
+	 */
+	private function isConcatenated(File $phpcsFile, array $tokens, int $i): bool
+	{
+		$prev = $phpcsFile->findPrevious(T_WHITESPACE, $i - 1, null, true);
+		$next = $phpcsFile->findNext(T_WHITESPACE, $i + 1, null, true);
+
+		$prevIsConcat = $prev !== false && $tokens[$prev]['code'] === T_STRING_CONCAT;
+		$nextIsConcat = $next !== false && $tokens[$next]['code'] === T_STRING_CONCAT;
+
+		return $prevIsConcat || $nextIsConcat;
+	}
 }

--- a/tests/phpcs/PfBlockerNG/ruleset.xml
+++ b/tests/phpcs/PfBlockerNG/ruleset.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="PfBlockerNG">
+    <description>
+        PfBlockerNG custom PHP_CodeSniffer standard. Carries the PFBL-01
+        RequirePfbFilter sniff: no exec / manifest / path sink inside an in-scope
+        function without a preceding semantic-validation call. Not a general style
+        standard -- it ships only this one project-specific rule.
+    </description>
+
+    <!-- Reference the sniff by its path so PHPCS loads it without an installed_paths
+         config entry. The directory layout PfBlockerNG/Sniffs/Validation/ encodes the
+         sniff code PfBlockerNG.Validation.RequirePfbFilter. -->
+    <rule ref="./Sniffs/Validation/RequirePfbFilterSniff.php"/>
+</ruleset>

--- a/tests/phpcs/fixtures/compliant_filtered.php
+++ b/tests/phpcs/fixtures/compliant_filtered.php
@@ -11,11 +11,11 @@
 
 function pfb_ss_resolve_target($target)
 {
-    $filtered = pfb_filter($target, PFB_FILTER_DOMAIN, 'pfb_ss_resolve_target');
-    if (empty($filtered)) {
-        return array('', '');
-    }
-    $out = array();
-    exec('/usr/bin/drill ' . escapeshellarg($filtered), $out);
-    return $out;
+	$filtered = pfb_filter($target, PFB_FILTER_DOMAIN, 'pfb_ss_resolve_target');
+	if (empty($filtered)) {
+		return array('', '');
+	}
+	$out = array();
+	exec('/usr/bin/drill ' . escapeshellarg($filtered), $out);
+	return $out;
 }

--- a/tests/phpcs/fixtures/compliant_filtered.php
+++ b/tests/phpcs/fixtures/compliant_filtered.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * PFBL-01 sniff fixture (NOT production code). In-scope function name whose exec +
+ * path sinks are all PRECEDED by a semantic-validation call -> the sniff MUST stay
+ * silent. This is the before/after partner of violation_exec.php: same sink, the
+ * only difference is the leading pfb_filter(), so a green result proves the
+ * validator presence is what suppresses the finding. Pinned by
+ * RequirePfbFilterSniffTest::testValidatorBeforeSinkPasses.
+ */
+
+function pfb_ss_resolve_target($target)
+{
+    $filtered = pfb_filter($target, PFB_FILTER_DOMAIN, 'pfb_ss_resolve_target');
+    if (empty($filtered)) {
+        return array('', '');
+    }
+    $out = array();
+    exec('/usr/bin/drill ' . escapeshellarg($filtered), $out);
+    return $out;
+}

--- a/tests/phpcs/fixtures/out_of_scope.php
+++ b/tests/phpcs/fixtures/out_of_scope.php
@@ -10,5 +10,5 @@
 
 function some_legacy_helper($value)
 {
-    exec('/bin/echo ' . $value);
+	exec('/bin/echo ' . $value);
 }

--- a/tests/phpcs/fixtures/out_of_scope.php
+++ b/tests/phpcs/fixtures/out_of_scope.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * PFBL-01 sniff fixture (NOT production code). A function whose name is NOT on the
+ * in-scope allow-list: even with a raw, unfiltered exec sink the sniff MUST
+ * stay silent, encoding the ADR's "legacy code paths are out of scope" carve-out
+ * (scope is an explicit allow-list, never a blanket file scan). Pinned by
+ * RequirePfbFilterSniffTest::testOutOfScopeFunctionIsNotFlagged.
+ */
+
+function some_legacy_helper($value)
+{
+    exec('/bin/echo ' . $value);
+}

--- a/tests/phpcs/fixtures/violation_exec.php
+++ b/tests/phpcs/fixtures/violation_exec.php
@@ -8,7 +8,7 @@
 
 function pfb_ss_resolve_target($target)
 {
-    $out = array();
-    exec('/usr/bin/drill ' . escapeshellarg($target), $out);
-    return $out;
+	$out = array();
+	exec('/usr/bin/drill ' . escapeshellarg($target), $out);
+	return $out;
 }

--- a/tests/phpcs/fixtures/violation_exec.php
+++ b/tests/phpcs/fixtures/violation_exec.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * PFBL-01 sniff fixture (NOT production code). In-scope function name + an
+ * exec-family sink with NO preceding semantic-validation call -> the sniff MUST
+ * flag it. Pinned by RequirePfbFilterSniffTest::testFlagsExecSinkWithoutValidator.
+ */
+
+function pfb_ss_resolve_target($target)
+{
+    $out = array();
+    exec('/usr/bin/drill ' . escapeshellarg($target), $out);
+    return $out;
+}

--- a/tests/phpcs/fixtures/violation_json.php
+++ b/tests/phpcs/fixtures/violation_json.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * PFBL-01 sniff fixture (NOT production code). In-scope function name + a
+ * json_encode() manifest sink with NO preceding validation -> the sniff MUST flag
+ * it. Pinned by RequirePfbFilterSniffTest::testFlagsManifestSinkWithoutValidator.
+ */
+
+function pfb_unbound_python_sources($feeds)
+{
+    $header = $feeds[0]['header'];
+    return json_encode(array('feed' => $header));
+}

--- a/tests/phpcs/fixtures/violation_json.php
+++ b/tests/phpcs/fixtures/violation_json.php
@@ -8,6 +8,6 @@
 
 function pfb_unbound_python_sources($feeds)
 {
-    $header = $feeds[0]['header'];
-    return json_encode(array('feed' => $header));
+	$header = $feeds[0]['header'];
+	return json_encode(array('feed' => $header));
 }

--- a/tests/phpcs/fixtures/violation_namespaced.php
+++ b/tests/phpcs/fixtures/violation_namespaced.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * PFBL-01 sniff fixture (NOT production code). A namespace-qualified exec sink
+ * (root-namespaced \exec) inside an in-scope function with no preceding validator
+ * MUST still be flagged: PHP tokenizes \exec as a single T_NAME_FULLY_QUALIFIED
+ * token, so a T_STRING-only match would let it slip past (a gate bypass). No '/'
+ * appears in any literal here, so only the exec-family branch can fire. Pinned by
+ * RequirePfbFilterSniffTest::testFlagsNamespaceQualifiedExecSink.
+ */
+
+function pfb_ss_resolve_target($target)
+{
+	\exec('echo ' . $target);
+}

--- a/tests/phpcs/fixtures/violation_path.php
+++ b/tests/phpcs/fixtures/violation_path.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * PFBL-01 sniff fixture (NOT production code). In-scope function name + a dynamic
+ * filesystem-path build (interpolated string) with NO preceding validation -> the
+ * sniff MUST flag it. Pinned by
+ * RequirePfbFilterSniffTest::testFlagsPathBuildWithoutValidator.
+ */
+
+function pfb_manage_dnsbl_vip($mode)
+{
+    $iface = $_POST['if'];
+    $path  = "/var/db/pfblockerng/{$iface}.txt";
+    return $path;
+}

--- a/tests/phpcs/fixtures/violation_path.php
+++ b/tests/phpcs/fixtures/violation_path.php
@@ -9,7 +9,7 @@
 
 function pfb_manage_dnsbl_vip($mode)
 {
-    $iface = $_POST['if'];
-    $path  = "/var/db/pfblockerng/{$iface}.txt";
-    return $path;
+	$iface = $_POST['if'];
+	$path  = "/var/db/pfblockerng/{$iface}.txt";
+	return $path;
 }


### PR DESCRIPTION
Implements PFBL-01 (private ADR). Applies the `pfb_filter()` input-validation contract at the ADR-06/07/10/13 input boundaries, and adds a custom PHPCS sniff that mechanically enforces it going forward.

## Phases 1–2 — apply the contract

Validation applied at all five audited boundaries, each with a WARNING-logged skip/abort (never a silent drop):

| Function | Filter | On rejection |
| --- | --- | --- |
| `pfb_manage_dnsbl_vip()` (`$interface`) | `PFB_FILTER_WORD` | abort — no config read/write, no VIP op |
| `pfb_ss_resolve_target()` (`$target`) | `PFB_FILTER_DOMAIN` | skip — return `('','')`, no `exec()` |
| `pfb_dnsbl_whitelist_lines()` (suppression) | `PFB_FILTER_DOMAIN` | skip row |
| `pfb_dnsbl_unlock_lines()` (alert unlock) | `PFB_FILTER_DOMAIN` | skip row |
| `pfb_unbound_python_sources()` (`$header`) | `pfb_sanitise_feed_header()` (`PFB_FILTER_WORD`) | skip row, before any path/manifest key |

New helper `pfb_sanitise_feed_header()`; tests pin each constant both ways + the per-site skip/abort + rejection-logging.

## Phase 3 — mechanical enforcement (Requirement 4)

Custom PHP_CodeSniffer rule `PfBlockerNG.Validation.RequirePfbFilter`: flags an `exec`-family call, `json_encode` manifest write, or dynamic filesystem-path build inside an **in-scope (allow-listed) function** not preceded by a semantic-validation call (`pfb_filter` / `pfb_sanitise_feed_header` / `sanitize_ipaddr`) in the same scope. It also resolves namespace-qualified calls (`\exec()`, `Foo\exec()`) so a qualified sink can't slip past. `escapeshellarg()` is the shell layer, not a validator — both are required. Scope is an explicit allow-list, so the ADR's "legacy is out of scope" carve-out is encoded by omission, never a blanket scan.

- `tests/phpcs/PfBlockerNG/` — the sniff + ruleset; `phpcs.xml.dist` runs it over the package include.
- `composer.json` — `squizlabs/php_codesniffer` dev-dep + `phpcs` script.
- `tests/php/RequirePfbFilterSniffTest.php` + `tests/phpcs/fixtures/` — pin the sniff **both ways**: fires on each sink class (incl. namespace-qualified), silent when a validator precedes the sink or the function is out of scope.
- `.githooks/pre-commit` + `.github/workflows/test.yml` — wire the gate (folded into the `all-tests-passed` required check).
- `CLAUDE.md` — documents the sniff.

No runtime/functional change for valid data. The ADR text + results live in the private repo.

## Verification

PHPUnit 295 green · PHPStan clean · PHPCS clean on the in-scope surface and fires on every violation fixture (incl. namespace-qualified) · mypy/markdownlint clean.

https://claude.ai/code/session_01ERcdqBSNVgTHfAsbnjAnqj