### PR TITLE
ci: normalize version-tracker families to Major.Minor (fix #185)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,7 +22,7 @@ entries → the smoke-fan-out set, never Plus).
 
 ```text
 {
-  "pfsense_version": "2.8.x",       # pfSense version (CE: X.Y.x; Plus: release label)
+  "pfsense_version": "2.8",          # pfSense Major.Minor family (CE: Y.Z; Plus: YY.MM)
   "channel":         "CE",           # CE | Plus
   "freebsd_version": "15.0-RELEASE", # full FreeBSD version string (build env)
   "freebsd_major":   "15",           # FreeBSD major (ABI dedup key; artifact suffix)

--- a/scripts/check-pfsense-versions.py
+++ b/scripts/check-pfsense-versions.py
@@ -51,7 +51,7 @@ class _Row(NamedTuple):
     freebsd_version: str
     freebsd_major: str
     channel: str  # "CE" | "Plus"
-    normalized: str  # family key: "2.8.x" (CE) or "26.03" (Plus)
+    normalized: str  # family key: "2.8" (CE) or "26.03" (Plus)
 
 
 class _Family(NamedTuple):
@@ -151,16 +151,20 @@ def _channel_from_branch(branch: str) -> str | None:
     return None
 
 
-def _normalize(raw: str, channel: str) -> str:
-    """Normalize a raw version string to its family key.
+def _normalize(raw: str) -> str:
+    """Normalize a raw version string to its Major.Minor family key.
 
-    CE  '2.8.1'    → '2.8.x'
-    Plus '26.03.1' → '26.03'
+    CE   '2.8.1'   → '2.8'    (Y.Z)
+    Plus '26.03.1' → '26.03'  (YY.MM)
+
+    The rule is channel-agnostic: both schemes collapse to their leading two
+    dot-separated components, so every patch level of the same family maps to a
+    single key — matching the floating Major.Minor matrix on ci-metadata, which
+    carries no '.x' suffix (the pre-#184 CE form '2.8.x' would never match '2.8'
+    and produced a false 'still-supported, missing from matrix' nudge).
     """
     parts = raw.strip().split(".")
-    if channel == "CE" and len(parts) >= 2:
-        return f"{parts[0]}.{parts[1]}.x"
-    if channel == "Plus" and len(parts) >= 2:
+    if len(parts) >= 2:
         return f"{parts[0]}.{parts[1]}"
     return raw
 
@@ -216,7 +220,7 @@ def parse_tables(tables: list[list[list[str]]]) -> list[_Row]:
                     freebsd_version=fbsd_raw,
                     freebsd_major=_freebsd_major(fbsd_raw),
                     channel=channel,
-                    normalized=_normalize(ver_raw, channel),
+                    normalized=_normalize(ver_raw),
                 )
             )
     return rows

--- a/tests/test_version_probe.py
+++ b/tests/test_version_probe.py
@@ -174,6 +174,11 @@ class TestNormalize:
         # Given Plus version already at Year.Month level
         assert cvs._normalize("26.07") == "26.07"
 
+    def test_single_component_version_uses_fallback_branch(self) -> None:
+        # Given a raw version with no dot (len(parts) < 2): the false side of the
+        # Major.Minor split returns the input unchanged.
+        assert cvs._normalize("2") == "2"
+
 
 # ── FreeBSD major extraction ──────────────────────────────────────────────────
 

--- a/tests/test_version_probe.py
+++ b/tests/test_version_probe.py
@@ -7,7 +7,7 @@ Branch coverage rules (CLAUDE.md):
 Scenario: Version probe against the Netgate docs page fixture
   Background:
     Given the fixture HTML contains Plus 26.x (supported + future),
-          Plus 25.x (all EOL), CE 2.9.x (future), CE 2.8.x (supported)
+          Plus 25.x (all EOL), CE 2.9 (future), CE 2.8 (supported)
     And the BUILD matrix represents the current ci-metadata state
 """
 
@@ -143,28 +143,36 @@ class TestChannelFromBranch:
 
 
 class TestNormalize:
-    """Scenario: Raw version string → family key.
+    """Scenario: Raw version string → Major.Minor family key.
 
-    Given a raw version and channel
+    Given a raw version string
     When _normalize() is called
-    Then CE is reduced to Major.Minor.x and Plus to Year.Month
+    Then both channels collapse to their leading two dot components (CE Y.Z,
+         Plus YY.MM) — every patch level of a family maps to one key, the
+         floating Major.Minor form the matrix uses (no '.x' suffix).
     """
 
     def test_ce_patch_normalizes_to_family(self) -> None:
-        # Given CE version with patch component
-        assert cvs._normalize("2.8.1", "CE") == "2.8.x"
+        # Given a CE version with a patch component → Major.Minor (no '.x')
+        assert cvs._normalize("2.8.1") == "2.8"
 
     def test_ce_zero_patch_normalizes_to_family(self) -> None:
         # Given CE version 2.9.0 (zero patch — same rule)
-        assert cvs._normalize("2.9.0", "CE") == "2.9.x"
+        assert cvs._normalize("2.9.0") == "2.9"
+
+    def test_ce_already_major_minor_is_idempotent(self) -> None:
+        # Given a CE version already at Major.Minor: it stays '2.8' so it matches
+        # the matrix key. Regression guard: the old rule emitted '2.8.x', which
+        # never matched '2.8' and triggered a false 'missing from matrix' nudge.
+        assert cvs._normalize("2.8") == "2.8"
 
     def test_plus_patch_normalizes_to_year_month(self) -> None:
-        # Given Plus version with patch component
-        assert cvs._normalize("26.03.1", "Plus") == "26.03"
+        # Given a Plus version with a patch component
+        assert cvs._normalize("26.03.1") == "26.03"
 
     def test_plus_without_patch_is_idempotent(self) -> None:
         # Given Plus version already at Year.Month level
-        assert cvs._normalize("26.07", "Plus") == "26.07"
+        assert cvs._normalize("26.07") == "26.07"
 
 
 # ── FreeBSD major extraction ──────────────────────────────────────────────────
@@ -211,21 +219,21 @@ class TestParseFixture:
         rows = cvs.parse_tables(p.tables)
         self.families = {(f.version, f.channel): f for f in cvs.group_families(rows)}
 
-    def test_ce_2_8_x_is_supported(self) -> None:
-        fam = self.families[("2.8.x", "CE")]
+    def test_ce_2_8_is_supported(self) -> None:
+        fam = self.families[("2.8", "CE")]
         assert fam.status == "supported"
 
-    def test_ce_2_8_x_has_freebsd_15(self) -> None:
-        fam = self.families[("2.8.x", "CE")]
+    def test_ce_2_8_has_freebsd_15(self) -> None:
+        fam = self.families[("2.8", "CE")]
         assert fam.freebsd_major == "15"
 
-    def test_ce_2_9_x_is_future(self) -> None:
-        # Before-state: 2.9.x has no released row → future (not supported/EOL)
-        fam = self.families[("2.9.x", "CE")]
+    def test_ce_2_9_is_future(self) -> None:
+        # Before-state: 2.9 has no released row → future (not supported/EOL)
+        fam = self.families[("2.9", "CE")]
         assert fam.status == "future"
 
-    def test_ce_2_9_x_released_is_tbd(self) -> None:
-        fam = self.families[("2.9.x", "CE")]
+    def test_ce_2_9_released_is_tbd(self) -> None:
+        fam = self.families[("2.9", "CE")]
         assert fam.released == "TBD"
 
     def test_plus_26_03_is_supported(self) -> None:
@@ -234,7 +242,7 @@ class TestParseFixture:
         assert fam.status == "supported"
 
     def test_plus_26_03_has_freebsd_16(self) -> None:
-        # FreeBSD major for Plus 26.03 is 16, distinct from CE 2.8.x (FreeBSD 15)
+        # FreeBSD major for Plus 26.03 is 16, distinct from CE 2.8 (FreeBSD 15)
         fam = self.families[("26.03", "Plus")]
         assert fam.freebsd_major == "16"
 
@@ -256,7 +264,7 @@ class TestDiffSupportedMissing:
     """Scenario: Supported families absent from the matrix are reported.
 
     Background:
-      Given the fixture has CE 2.8.x (supported) and Plus 26.03 (supported)
+      Given the fixture has CE 2.8 (supported) and Plus 26.03 (supported)
 
     Tests prove both the positive case (missing → reported) and the negative
     case (present → not reported), so a regression in either direction fails.
@@ -269,18 +277,19 @@ class TestDiffSupportedMissing:
         rows = cvs.parse_tables(p.tables)
         self.families = cvs.group_families(rows)
 
-    def test_ce_2_8_x_present_in_matrix_not_reported(self) -> None:
-        # Given 2.8.x IS in the matrix
-        # Then it does NOT appear in supported_missing
-        matrix = [{"pfsense_version": "2.8.x", "channel": "CE"}]
+    def test_ce_2_8_present_in_matrix_not_reported(self) -> None:
+        # Given 2.8 IS in the matrix (the floating Major.Minor key)
+        # Then it does NOT appear in supported_missing. Regression guard: the old
+        # '2.8.x' normalization never matched '2.8' and falsely reported it missing.
+        matrix = [{"pfsense_version": "2.8", "channel": "CE"}]
         result = cvs.diff(self.families, matrix)
         versions = [e["version"] for e in result["supported_missing"]]
-        assert "2.8.x" not in versions
+        assert "2.8" not in versions
 
     def test_plus_26_03_absent_from_matrix_is_reported(self) -> None:
-        # Given 26.03 is NOT in the matrix (matrix only has 2.8.x)
+        # Given 26.03 is NOT in the matrix (matrix only has 2.8)
         # Then 26.03 DOES appear in supported_missing
-        matrix = [{"pfsense_version": "2.8.x", "channel": "CE"}]
+        matrix = [{"pfsense_version": "2.8", "channel": "CE"}]
         result = cvs.diff(self.families, matrix)
         versions = [e["version"] for e in result["supported_missing"]]
         assert "26.03" in versions
@@ -288,7 +297,7 @@ class TestDiffSupportedMissing:
     def test_channel_and_freebsd_major_in_missing_entry(self) -> None:
         # Given Plus 26.03 is absent
         # Then the entry carries channel=Plus and freebsd_major=16
-        matrix = [{"pfsense_version": "2.8.x", "channel": "CE"}]
+        matrix = [{"pfsense_version": "2.8", "channel": "CE"}]
         result = cvs.diff(self.families, matrix)
         entry = next(e for e in result["supported_missing"] if e["version"] == "26.03")
         assert entry["channel"] == "Plus"
@@ -319,12 +328,12 @@ class TestDiffFuture:
         rows = cvs.parse_tables(p.tables)
         self.families = cvs.group_families(rows)
 
-    def test_ce_2_9_x_in_future_not_missing(self) -> None:
+    def test_ce_2_9_in_future_not_missing(self) -> None:
         result = cvs.diff(self.families, [])
         future_versions = [e["version"] for e in result["future"]]
         missing_versions = [e["version"] for e in result["supported_missing"]]
-        assert "2.9.x" in future_versions
-        assert "2.9.x" not in missing_versions
+        assert "2.9" in future_versions
+        assert "2.9" not in missing_versions
 
     def test_plus_26_07_in_future_not_missing(self) -> None:
         result = cvs.diff(self.families, [])
@@ -335,12 +344,12 @@ class TestDiffFuture:
 
     def test_future_entry_has_tbd_released(self) -> None:
         result = cvs.diff(self.families, [])
-        entry_29 = next(e for e in result["future"] if e["version"] == "2.9.x")
+        entry_29 = next(e for e in result["future"] if e["version"] == "2.9")
         assert entry_29["released"] == "TBD"
 
     def test_future_entry_includes_freebsd_major(self) -> None:
         result = cvs.diff(self.families, [])
-        entry_29 = next(e for e in result["future"] if e["version"] == "2.9.x")
+        entry_29 = next(e for e in result["future"] if e["version"] == "2.9")
         assert entry_29["freebsd_major"] == "16"
 
 
@@ -380,9 +389,9 @@ class TestGracefulDegradation:
         result = self._run_capture(_fixture(), "[]")
         assert isinstance(result["supported_missing"], list)
         assert isinstance(result["future"], list)
-        # At least CE 2.8.x and Plus 26.03 should be missing
+        # At least CE 2.8 and Plus 26.03 should be missing
         missing = [e["version"] for e in result["supported_missing"]]
-        assert "2.8.x" in missing
+        assert "2.8" in missing
         assert "26.03" in missing
 
 


### PR DESCRIPTION
Closes #185.

## Problem

The version-tracker probe (`scripts/check-pfsense-versions.py`) normalized CE versions to the **pre-#184 form** `2.8.x`, but PR #184 moved the matrix on `ci-metadata` to **floating Major.Minor** keys (`"pfsense_version": "2.8"`, no `.x`). So a scraped CE family normalized to `2.8.x` never matched the matrix key `2.8` → every supported CE family was reported as `supported_missing` → a spurious "still-supported, missing from matrix" issue (#185). Plus (`26.03`) already matched and was unaffected.

## Fix (per the maintainer's direction on the issue)

`_normalize()` now collapses **both** channels to their leading two dot-separated components:

- CE `2.8.1` → `2.8` (Y.Z)
- Plus `26.03.1` → `26.03` (YY.MM)

The rule is channel-agnostic, so the `channel` argument is dropped. Any patch level of the same `Y.Z` / `YY.MM` maps to a single family key, matching the floating-tag matrix.

## Changes

- `scripts/check-pfsense-versions.py` — `_normalize()` rewritten (drop `.x`, drop `channel` param); call site + `_Row.normalized` doc updated.
- `scripts/README.md` — schema example was also stale (`"2.8.x"`); corrected to `"2.8"` with `(CE: Y.Z; Plus: YY.MM)`.
- `tests/test_version_probe.py` — family keys `2.8.x`→`2.8` / `2.9.x`→`2.9`, `_normalize` calls drop the channel arg, and a **regression-guard** case pins `_normalize("2.8") == "2.8"` (the exact mismatch that fired #185).

No workflow YAML change needed — `version-tracker.yml` consumes only `.version`/`.channel`/`.freebsd_major`, so emitting `2.8` flows through (and future nudge titles read `2.8`, not `2.8.x`).

## Verification

`python -m pytest tests/test_version_probe.py` → 38 passed · ruff lint+format clean.

https://claude.ai/code/session_01ERcdqBSNVgTHfAsbnjAnqj

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERcdqBSNVgTHfAsbnjAnqj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified version-family examples to use major.minor format instead of wildcard patch style.

* **Refactor**
  * Normalized version-family handling to consistently use major.minor keys across channels and processing.

* **Tests**
  * Updated test fixtures and assertions to match the new major.minor normalization and related expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->