### PR TITLE
ADR-23: DNSBL Wizard VIP Auto-Toggle

### DIFF
--- a/.ADRs/ADR_23_Wizard_DNSBL_VIP/ADR.md
+++ b/.ADRs/ADR_23_Wizard_DNSBL_VIP/ADR.md
@@ -202,7 +202,9 @@ No migration logic needed: `pfb_dnsvip_auto` defaults to absent/off in existing 
 - [ ] PHPStan clean (no new un-stubbed calls)
 - [ ] `vendor/bin/phpunit` — all tests pass including new `WizardVipAutoTest`
 - [ ] ADR-14 Tier A (`ui_render`): GET wizard page → 200, no PHP errors, `pfb_dnsvip_auto`
-      checkbox present in response body, no new `php_error.log` line
+      checkbox present in response body, no new `php_error.log` line — test added
+      (`tests/smoke/ui/test_render_smoke.py::test_wizard_dnsbl_step_renders_auto_vip`, GETs
+      `wizard.php?xml=pfblockerng_wizard.xml&stepid=3`); runs in the live-VM `ui_render` CI leg
 
 ### Manual smoke (maintainer, on-box)
 

--- a/.ADRs/ADR_23_Wizard_DNSBL_VIP/ADR.md
+++ b/.ADRs/ADR_23_Wizard_DNSBL_VIP/ADR.md
@@ -1,6 +1,6 @@
 # ADR-23: DNSBL Wizard VIP Auto-Toggle
 
-**Status:** Proposed
+**Status:** Implemented (pending smoke test)
 **Issue:** [#178](https://github.com/pfBlockerNG/pfBlockerNG/issues/178)
 **Slack:** [thread](https://pfblockerng.slack.com/archives/C0B9QBZBEQG/p1781160111017199?thread_ts=1781008355.595609&cid=C0B9QBZBEQG)
 
@@ -214,3 +214,27 @@ No migration logic needed: `pfb_dnsvip_auto` defaults to absent/off in existing 
       accepts valid lo0 VIP; `pfb_dnsvip4` stored correctly
 - [ ] Back navigation from step 4: checkbox state restored correctly
 - [ ] HA/CARP disclaimer visible in rendered wizard step 4
+
+---
+
+## 8  Notes
+
+Two implementation choices deviated from the §4.3 sketch enough to record:
+
+- **Test approach — indirect over a helper.** §4.3 offered "extract a
+  `pfb_wizard_vip_auto_enabled()` helper OR test `step3_submitphpaction()` indirectly". Phase 1
+  inlined the boolean (no helper extracted), so Phase 2 took the indirect route:
+  `WizardVipAutoTest` drives the real shipped `step3_submitphpaction()` and observes whether
+  `pfb_validate_vips()` runs (the gate's observable effect) — avoiding a coverage-theater
+  re-implementation of the predicate. To load the wizard controller off-appliance,
+  `tests/php/bootstrap.php` reads the wizard `.inc`, strips its top-of-file `require_once()`s
+  (one is a host-absolute path unsatisfiable via `include_path`), and evals from the first
+  `function` keyword onward (skipping top-level `pfb_global()`/interface-list wiring); a
+  faithful `is_port()` double was added to `pfsense_doubles.php`. No production code changed.
+- **Part B (step4 persistence shape) deferred.** Writing `pfb_dnsvip_auto` + guarding the
+  manual VIP-id writes is NOT unit-invoked: `step4_submitphpaction()` ends in `header()+exit`,
+  requires a live feeds-DB JSON fixture, and calls undoubled pfSense services. Covering it
+  cleanly needs the config-mutation block extracted into a pure helper (a `src/`-touching
+  change) — tracked as a follow-up, out of scope for ADR-23's tests phase. The step3 coverage
+  pins the same inlined gate predicate on shipped code; `DnsblMarkedVipTest` pins the ADR-13
+  engine the flag drives.

--- a/.ADRs/ADR_23_Wizard_DNSBL_VIP/ADR.md
+++ b/.ADRs/ADR_23_Wizard_DNSBL_VIP/ADR.md
@@ -233,10 +233,15 @@ Two implementation choices deviated from the §4.3 sketch enough to record:
   (one is a host-absolute path unsatisfiable via `include_path`), and evals from the first
   `function` keyword onward (skipping top-level `pfb_global()`/interface-list wiring); a
   faithful `is_port()` double was added to `pfsense_doubles.php`. No production code changed.
-- **Part B (step4 persistence shape) deferred.** Writing `pfb_dnsvip_auto` + guarding the
-  manual VIP-id writes is NOT unit-invoked: `step4_submitphpaction()` ends in `header()+exit`,
-  requires a live feeds-DB JSON fixture, and calls undoubled pfSense services. Covering it
-  cleanly needs the config-mutation block extracted into a pure helper (a `src/`-touching
-  change) — tracked as a follow-up, out of scope for ADR-23's tests phase. The step3 coverage
-  pins the same inlined gate predicate on shipped code; `DnsblMarkedVipTest` pins the ADR-13
-  engine the flag drives.
+- **Part B (step4 persistence shape) — covered via an extracted pure helper.**
+  `step4_submitphpaction()` itself can't be unit-invoked (it ends in `header()+exit`), so the
+  DNSBL-VIP settings decision was extracted into the pure `pfb_wizard_dnsvip_settings(bool $auto,
+  $vip4, $vip6): array` (in `pfblockerng.inc`, beside the other `pfb_wizard_*` deciders); the
+  controller now merges the returned slice into the DNSBL config. `WizardVipAutoTest`
+  (`testAutoVipToggleDecidesPersistedDnsvipSettings`) asserts the shape both ways — auto OFF →
+  `pfb_dnsvip_auto=''` + both manual ids written; auto ON → `'on'` + neither id pinned (ADR-13
+  owns the VIP) — passing the same ids to prove the flag drove the change. (The earlier
+  feeds-DB/services framing was a non-issue: the feeds catalog ships with the package and the
+  `pfb_dnsvip_auto` write does not depend on it; the only genuine obstacle was the terminal
+  `exit`, which the extraction removes from the test path.) `DnsblMarkedVipTest` still pins the
+  ADR-13 engine the flag drives.

--- a/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/01_Results.txt
@@ -1,0 +1,67 @@
+# ADR-23 Phase 1 Results — Wizard XML + .inc (handoff to Phase 2)
+
+## Scope delivered
+Wired ADR-13 `pfb_dnsvip_auto` auto-VIP toggle into the setup wizard (step 4 / step3-temp
+config). Two files changed; ADR-13 engine in pfblockerng.inc untouched.
+
+## Final changed hunks (post-rebase line numbers — re-verify if devel moved)
+
+### src/usr/local/www/wizards/pfblockerng_wizard.inc
+- step3_submitphpaction(): lines ~114–126
+  VIP-validation block now gated on `$pfb_auto = isset($_POST['pfb_dnsvip_auto']) && == 'on'`;
+  pfb_validate_vips() + the 'none'->'' normalisation run ONLY when auto is OFF.
+- step4_submitphpaction(): lines ~168–173
+  Persists `pfb_dnsvip_auto` (=> 'on' | '') always; writes pfb_dnsvip4/pfb_dnsvip6 from
+  step3 config ONLY when auto is OFF. Var named $pfb_auto_wiz (no shadow).
+
+### src/usr/local/www/wizards/pfblockerng_wizard.xml  (step id=4)
+- line 252: <description> rewritten to choice framing (Create VIPs automatically vs manual VIP).
+- lines 258–265: NEW pfb_dnsvip_auto checkbox field (displayname "Auto VIP", bound to
+  pfblockerng_wizard->step3->pfb_dnsvip_auto, HA/CARP disclaimer + 10.10.X.53 / fd00:X::53
+  help), inserted after the "DNSBL Webserver Configuration" listtopic, before pfb_dnsvip4.
+- line 272: pfb_dnsvip4 <description> + " (manual mode only — ignored when Auto VIP is enabled)".
+- line 282: pfb_dnsvip6 <description> + same suffix.
+
+## step4_submitphpaction() testability verdict: NOT-WITHOUT-REFACTOR
+
+bootstrap.php loads the REAL pfblockerng.inc only — it does NOT include
+pfblockerng_wizard.inc, so the wizard fns are absent from the PHPUnit suite as-is. Even after
+manually including the wizard .inc, step4_submitphpaction() is NOT directly exercisable under
+the current tests/php/ doubles. Blockers found by reading it end-to-end:
+
+1. HARD EXIT at the tail: `header("Location: .../pfblockerng_update.php?wizard=reload"); exit;`
+   — `exit` terminates the PHPUnit process. (pfb_wizard_skip_check() at the top is SAFE — with
+   no `skip` in $_POST, pfb_wizard_skip_action() returns null and it just returns; it would
+   only header()+exit if $_POST['skip'] were set.)
+2. Early hard return needs a feeds DB: `json_decode(@file_get_contents($pfb['feeds']))`; absent
+   a valid feeds JSON fixture at $pfb['feeds'] it returns early with an input_error before any
+   persistence runs — must seed a feeds fixture + point $pfb['feeds'] at it.
+3. Undoubled pfSense calls reached before the exit: services_unbound_configure(),
+   system_resolvconf_generate(), system_dhcpleases_configure() — NONE in pfsense_doubles.php
+   (only config_get_path + write_config are doubled there). is_port() (step3) also undoubled.
+   pfb_remove_config_settings / pfb_clear_contents / pfb_global / pfb_unbound_dnsbl are real
+   (in pfblockerng.inc) and would run with live side effects.
+
+### Phase 2 recommendation (Part B vs fallback)
+Take the FALLBACK, not Part B's direct step4 invocation. Two clean options:
+
+- PREFERRED: test the decision PREDICATE in isolation. The auto gate is the pure expression
+  `config_get_path('pfblockerng_wizard/step3/pfb_dnsvip_auto') == 'on'` (step4) and
+  `isset($_POST['pfb_dnsvip_auto']) && $_POST['pfb_dnsvip_auto'] == 'on'` (step3). Pin branch
+  coverage via a tiny extracted helper OR by asserting config_get_path/$_POST inputs map to the
+  on/off branch — values: 'on'->true ; absent/''/'0'->false. Mirrors ADR.md §4.3 "Decision
+  predicate" bullet, which itself flags step4 as "if testable under bootstrap doubles".
+- IF full step4 persistence-shape coverage is required: it needs a refactor — extract the
+  config-mutation block (the `$new_config[...]['pfblockerngdnsblsettings'][0][...]` writes +
+  the auto gate) into a pure helper returning the array, callable without header()/exit/feeds/
+  unbound. That is a src/ change (engine-adjacent) -> its own ADR phase/PR, out of Phase-1 scope.
+
+## Gate results
+- php -l pfblockerng_wizard.inc : No syntax errors detected.
+- xmllint --noout pfblockerng_wizard.xml : OK (well-formed).
+- vendor/bin/phpunit : OK (295 tests, 580 assertions) — unchanged count, no regression.
+- python -m pytest -q : 1480 passed — no regression.
+- ruff check . : All checks passed.
+
+(PHPStan/PHPCS not run locally — vendor lacks them in this env; CI is the gate. The wizard
+.inc adds no new un-stubbed pfSense call: only isset/config_get_path, both already known.)

--- a/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/01_Results.txt
@@ -8,7 +8,7 @@ config). Two files changed; ADR-13 engine in pfblockerng.inc untouched.
 
 ### src/usr/local/www/wizards/pfblockerng_wizard.inc
 - step3_submitphpaction(): lines ~114–126
-  VIP-validation block now gated on `$pfb_auto = isset($_POST['pfb_dnsvip_auto']) && == 'on'`;
+  VIP-validation block now gated on `$pfb_auto = isset($_POST['pfb_dnsvip_auto']) && $_POST['pfb_dnsvip_auto'] == 'on'`;
   pfb_validate_vips() + the 'none'->'' normalisation run ONLY when auto is OFF.
 - step4_submitphpaction(): lines ~168–173
   Persists `pfb_dnsvip_auto` (=> 'on' | '') always; writes pfb_dnsvip4/pfb_dnsvip6 from

--- a/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/02_Results.txt
@@ -8,7 +8,7 @@ INVOKING the real shipped step3_submitphpaction() (no re-implemented predicate b
 - Part A (step3 gate): IMPLEMENTED against shipped code. Drives step3_submitphpaction()
   and observes whether pfb_validate_vips() runs (the gate's observable consequence).
   Orchestrator directive followed: NO standalone predicate test (would re-implement the
-  inlined `isset($_POST['pfb_dnsvip_auto']) && == 'on'` boolean = coverage theater).
+  inlined `isset($_POST['pfb_dnsvip_auto']) && $_POST['pfb_dnsvip_auto'] == 'on'` boolean = coverage theater).
 - Part B (step4 persistence shape): FELL BACK (documented @todo + markTestSkipped).
   Confirmed the Phase-1 NOT-WITHOUT-REFACTOR verdict by reading step4_submitphpaction()
   end-to-end. Three hard blockers, all before any assertable persistence:

--- a/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/02_Results.txt
@@ -1,0 +1,63 @@
+# ADR-23 Phase 2 Results — PHPUnit tests (handoff to Phase 3)
+
+## Delivered
+Added tests/php/WizardVipAutoTest.php covering the Phase-1 pfb_dnsvip_auto gate by
+INVOKING the real shipped step3_submitphpaction() (no re-implemented predicate boolean).
+
+## Part A vs Part B
+- Part A (step3 gate): IMPLEMENTED against shipped code. Drives step3_submitphpaction()
+  and observes whether pfb_validate_vips() runs (the gate's observable consequence).
+  Orchestrator directive followed: NO standalone predicate test (would re-implement the
+  inlined `isset($_POST['pfb_dnsvip_auto']) && == 'on'` boolean = coverage theater).
+- Part B (step4 persistence shape): FELL BACK (documented @todo + markTestSkipped).
+  Confirmed the Phase-1 NOT-WITHOUT-REFACTOR verdict by reading step4_submitphpaction()
+  end-to-end. Three hard blockers, all before any assertable persistence:
+    1. tail `header(".../pfblockerng_update.php?wizard=reload"); exit;` — exit kills the
+       PHPUnit process.
+    2. early input_error return unless json_decode(@file_get_contents($pfb['feeds']))
+       yields a feeds array — needs a live feeds-DB fixture first.
+    3. undoubled pfSense services reached before exit: services_unbound_configure(),
+       system_resolvconf_generate(), system_dhcpleases_configure() — live side effects.
+  Clean coverage needs the config-mutation block extracted into a pure helper — a
+  src/-touching change, hence its own ADR-23 phase/PR, out of this tests-only phase.
+  Step3 already pins the SAME inlined auto-gate predicate on shipped code; DnsblMarkedVipTest
+  pins the ADR-13 engine the step4 flag drives.
+
+## Coverage (CLAUDE.md mandatory rules)
+- Both sides: auto OFF and auto ON, same invalid (empty) VIP selection.
+- Before-state first: OFF asserts the DNSBL error is PRESENT, THEN flips ON and asserts
+  ABSENT -> green proves the auto flip CAUSED the skip (not an always-skip path).
+- Falsey strings '' and '0' pinned as OFF (validation still runs), mirroring
+  WizardDecisionTest::testSuppressCheckboxFalseyValuesStaySkip.
+- Anti-coverage-theater check: temporarily reverted the Phase-1 $pfb_auto guard ->
+  testAutoOnSkipsVipValidationThatAutoOffEnforces FAILS ("Failed asserting that true is
+  false"). Reverted the temp change; src/ is untouched.
+
+## bootstrap/doubles changes (tests/php/ only — NO src/ modified)
+- tests/php/bootstrap.php: added a guarded wizard-loader (step 5). The wizard .inc can't
+  be require()d as-is (3 relative require_once + 1 HOST-ABSOLUTE require of
+  /usr/local/pkg/pfblockerng/pfblockerng.inc not resolvable via include_path, plus
+  top-level wiring needing unprovisioned runtime). Loader: reads the source, strips the
+  require_once() lines, evals ONLY from the first `function ` keyword onward -> the
+  function bodies (shipped code under test) are defined verbatim, top-level wiring skipped.
+  function_exists()-guarded so an on-appliance include never double-defines.
+- tests/php/pfsense_doubles.php: added a faithful is_port() double (pure-digit 1..65535,
+  no ranges/aliases — pfSense util.inc semantics). step3 validates pfb_dnsport/
+  pfb_dnsport_ssl through it; tests supply valid ports so the port branch never masks the
+  VIP branch. Guarded by function_exists().
+
+## Gate results
+- php -l tests/php/WizardVipAutoTest.php : No syntax errors detected.
+- vendor/bin/phpunit : OK (299 tests, 584 assertions, 1 skipped). Grew from 295 -> 299
+  (1 transition case + 2 falsey testWith cases + 1 documented Part-B skip).
+  New cases (--testdox):
+    Wizard Vip Auto
+     [pass] Auto on skips vip validation that auto off enforces
+     [pass] Auto falsey values still enforce vip validation with data set #0   ('')
+     [pass] Auto falsey values still enforce vip validation with data set #1   ('0')
+     [skip] Step 4 persistence shape is not unit invokable
+- python -m pytest -q : 1480 passed (unchanged — no regression).
+- ruff check . : All checks passed.
+
+(The single suite-wide skip count == this file's Part-B fallback. The "drill not found"
+stderr lines are a pre-existing unrelated smoke-helper probe, not a failure.)

--- a/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_23_Wizard_DNSBL_VIP/RESULTS/03_Results.txt
@@ -1,0 +1,58 @@
+# ADR-23 Phase 3 Results — Docs + Definition of Done (final phase)
+
+## Delivered (three doc edits, doc-only — no src/ or tests/ change)
+
+1. CLAUDE.md — smoke "ADR-04" bullet list, the `pfb_dnsvip_auto`/`ensure_dnsbl_vip`
+   sentence (line ~308). Appended ONE sentence: the setup wizard (ADR-23) also exposes
+   the `pfb_dnsvip_auto` toggle, but `ensure_dnsbl_vip` remains the harness fixture since
+   the smoke harness does not run the wizard flow. Terse, matches surrounding style; no
+   other churn in that paragraph.
+
+2. ADR.md — Status flipped `Proposed` -> `Implemented (pending smoke test)`.
+   Deliberately NOT "PR #NNN, merged": no PR exists yet (created after this phase) and the
+   §7 manual on-box smoke checks need a live box (not in CI), so status stays
+   "pending smoke test" until the maintainer runs them. Issue #178 link in header is the
+   cross-reference.
+
+3. ADR.md — added `## 8  Notes` recording the two decision-relevant deviations from the
+   §4.3 sketch: (a) test approach went indirect-over-helper (Phase 1 inlined the boolean;
+   Phase 2 drove real step3_submitphpaction() observing pfb_validate_vips(); bootstrap
+   wizard-loader strips require_once + evals from first `function`; is_port() double added);
+   (b) Part B step4 persistence deferred (header()+exit, feeds-DB fixture, undoubled
+   services -> needs pure-helper extraction = src/ follow-up, out of scope).
+
+## Gate results (this phase, local)
+
+- npx markdownlint-cli2 (CLAUDE.md + ADR.md, plus full repo sweep) : 0 error(s). GREEN
+- vendor/bin/phpunit : OK, 299 tests, 584 assertions, 1 skipped. Unchanged from Phase 2 —
+  no regression. (The skip is WizardVipAutoTest's documented Part-B fallback.)
+- python -m pytest -q : 1480 passed. Unchanged — no regression. GREEN
+- php -l src/usr/local/www/wizards/pfblockerng_wizard.inc : No syntax errors detected.
+- php -l ...pfblockerng_wizard.xml : No syntax errors (non-PHP file, trivially clean).
+- vendor/bin/phpstan analyse --no-progress : [OK] No errors. GREEN
+- git diff : minimal — 2 files, +28/-2; CLAUDE.md exactly one added sentence; ADR.md
+  status line + §8. No unrelated churn.
+
+## Definition of Done checklist (ADR §7 + phase prompt) — per-item status
+
+Automated (CI):
+- [x] php -l both wizard files — no parse errors. AUTOMATED-GREEN (local + CI)
+- [x] PHPStan clean (no new un-stubbed calls). AUTOMATED-GREEN (local + CI)
+- [x] vendor/bin/phpunit all pass incl. WizardVipAutoTest (present, green; 1 documented
+      Part-B skip). AUTOMATED-GREEN (local + CI)
+- [ ] ADR-14 Tier A (ui_render): GET wizard page 200, pfb_dnsvip_auto checkbox present, no
+      new php_error.log line. CI-PENDING — requires live pfSense VM (SMOKE_ADMIN_PASSWORD);
+      not runnable in this environment. Maintainer/CI follow-up.
+
+Manual smoke (maintainer, on-box):
+- [ ] Wizard auto=ON: Finish -> config.xml pfb_dnsvip_auto='on'; after reload
+      pfB_AUTO_VIP_v4 at 10.10.X.53; pfb_dnsvip4 repointed. MAINTAINER-SMOKE-PENDING
+- [ ] Wizard auto=OFF + manual lo0 VIP: validation rejects missing/wrong-interface VIP;
+      accepts valid; pfb_dnsvip4 stored. MAINTAINER-SMOKE-PENDING
+- [ ] Back navigation from step 4 preserves checkbox state. MAINTAINER-SMOKE-PENDING
+- [ ] HA/CARP disclaimer visible in rendered wizard step 4. MAINTAINER-SMOKE-PENDING
+
+## Notes for next step
+ADR-23 implementation complete across Phases 1-3 (doc-only this phase). A PR is created
+AFTER this phase per the orchestrator flow. Status remains "pending smoke test" until the
+maintainer runs the §7 on-box checks on a live box.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,7 +306,9 @@ cost real debugging — internalise them first:
 - **The image bakes only the deps + qemu-guest-agent** — the harness injects the DNSBL VIP
   (`ensure_dnsbl_vip`) and all per-case config; `pkg add` runs offline. The package can now
   auto-create the sinkhole VIP (`pfb_dnsvip_auto`, ADR-13) but defaults **OFF**, so
-  `ensure_dnsbl_vip` stays accurate. The smoke qcow2 cache is content-keyed by GHCR digest
+  `ensure_dnsbl_vip` stays accurate. The setup wizard (ADR-23) also exposes the
+  `pfb_dnsvip_auto` toggle, but `ensure_dnsbl_vip` remains the harness fixture since the smoke
+  harness does not run the wizard flow. The smoke qcow2 cache is content-keyed by GHCR digest
   (a same-tag re-push invalidates automatically).
 - **The branch `.pkg` is built on a plain Linux runner** (`build-pkg-linux.yml` →
   `scripts/build-pkg-portable.py`), NOT a FreeBSD VM: pfBlockerNG is a `NO_BUILD` port, so

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1791,6 +1791,22 @@ function pfb_wizard_suppress_autolaunch(?string $get_action, $wizard_skip_flag, 
 }
 
 /*
+ * ADR-23: the DNSBL sinkhole-VIP settings the setup wizard persists to the DNSBL config,
+ * given the Auto VIP choice. Auto on -> pfb_dnsvip_auto='on' and the manual selector ids
+ * are NOT written (ADR-13 provisions and owns the VIP at enable time); auto off -> the flag
+ * is '' and the operator's step3 lo0 VIP selections are persisted. step4_submitphpaction()
+ * merges the returned slice into the dnsbl settings config.
+ */
+function pfb_wizard_dnsvip_settings(bool $auto, $vip4, $vip6): array {
+	$settings = array('pfb_dnsvip_auto' => $auto ? 'on' : '');
+	if (!$auto) {
+		$settings['pfb_dnsvip4'] = $vip4;
+		$settings['pfb_dnsvip6'] = $vip6;
+	}
+	return $settings;
+}
+
+/*
  * Return the enabled hook entries matching $when ('pre'|'post'), in list order.
  *
  * Pure helper: takes the pfBlockerNG config array (config/0) so it can be unit

--- a/src/usr/local/www/wizards/pfblockerng_wizard.inc
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.inc
@@ -111,16 +111,19 @@ function step3_submitphpaction() {
 		}
 	}
 
-	// Validate DNSBL VIP address
-	if ($_POST['pfb_dnsvip4'] == 'none') {
-		$_POST['pfb_dnsvip4'] = '';
-	}
-	if ($_POST['pfb_dnsvip6'] == 'none') {
-		$_POST['pfb_dnsvip6'] = '';
-	}
-	list($vips_valid, $error) = pfb_validate_vips('lo0', $_POST['pfb_dnsvip4'], $_POST['pfb_dnsvip6']);
-	if (!$vips_valid) {
-		$input_errors[] = "DNSBL: {$error}";
+	// Validate DNSBL VIP address (manual mode only — skip when Auto VIP is enabled)
+	$pfb_auto = (isset($_POST['pfb_dnsvip_auto']) && $_POST['pfb_dnsvip_auto'] == 'on');
+	if (!$pfb_auto) {
+		if ($_POST['pfb_dnsvip4'] == 'none') {
+			$_POST['pfb_dnsvip4'] = '';
+		}
+		if ($_POST['pfb_dnsvip6'] == 'none') {
+			$_POST['pfb_dnsvip6'] = '';
+		}
+		list($vips_valid, $error) = pfb_validate_vips('lo0', $_POST['pfb_dnsvip4'], $_POST['pfb_dnsvip6']);
+		if (!$vips_valid) {
+			$input_errors[] = "DNSBL: {$error}";
+		}
 	}
 
 	// Validate DNSBL Port selections
@@ -162,8 +165,12 @@ function step4_submitphpaction() {
 	$new_config['pfblockerngipsettings']['config'][0]['outbound_deny_action']	= 'reject';	
 	$new_config['pfblockerngipsettings']['config'][0]['pass_order']			= 'order_0';
 
-	$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsvip4'] = config_get_path('pfblockerng_wizard/step3/pfb_dnsvip4');
-	$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsvip6'] = config_get_path('pfblockerng_wizard/step3/pfb_dnsvip6');
+	$pfb_auto_wiz = (config_get_path('pfblockerng_wizard/step3/pfb_dnsvip_auto') == 'on');
+	$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsvip_auto'] = $pfb_auto_wiz ? 'on' : '';
+	if (!$pfb_auto_wiz) {
+		$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsvip4'] = config_get_path('pfblockerng_wizard/step3/pfb_dnsvip4');
+		$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsvip6'] = config_get_path('pfblockerng_wizard/step3/pfb_dnsvip6');
+	}
 	$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsport']		= config_get_path('pfblockerng_wizard/step3/pfb_dnsport');
 	$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsport_ssl']		= config_get_path('pfblockerng_wizard/step3/pfb_dnsport_ssl');
 

--- a/src/usr/local/www/wizards/pfblockerng_wizard.inc
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.inc
@@ -166,10 +166,13 @@ function step4_submitphpaction() {
 	$new_config['pfblockerngipsettings']['config'][0]['pass_order']			= 'order_0';
 
 	$pfb_auto_wiz = (config_get_path('pfblockerng_wizard/step3/pfb_dnsvip_auto') == 'on');
-	$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsvip_auto'] = $pfb_auto_wiz ? 'on' : '';
-	if (!$pfb_auto_wiz) {
-		$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsvip4'] = config_get_path('pfblockerng_wizard/step3/pfb_dnsvip4');
-		$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsvip6'] = config_get_path('pfblockerng_wizard/step3/pfb_dnsvip6');
+	$dnsvip_settings = pfb_wizard_dnsvip_settings(
+		$pfb_auto_wiz,
+		config_get_path('pfblockerng_wizard/step3/pfb_dnsvip4'),
+		config_get_path('pfblockerng_wizard/step3/pfb_dnsvip6')
+	);
+	foreach ($dnsvip_settings as $pfb_dnsvip_key => $pfb_dnsvip_val) {
+		$new_config['pfblockerngdnsblsettings']['config'][0][$pfb_dnsvip_key] = $pfb_dnsvip_val;
 	}
 	$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsport']		= config_get_path('pfblockerng_wizard/step3/pfb_dnsport');
 	$new_config['pfblockerngdnsblsettings']['config'][0]['pfb_dnsport_ssl']		= config_get_path('pfblockerng_wizard/step3/pfb_dnsport_ssl');

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -158,7 +158,7 @@
 				<dd>Utilizing the DNS Resolver, ADverts and the worst known malicious domains will be blocked.</dd>
 			</dl>
 			<ul>
-				<li>A VIP on the Localhost interface <strong>must be configured first</strong> at <a target="_blank" href="/firewall_virtual_ip.php">Firewall > Virtual IPs</a>.</li>
+				<li>A VIP on the Localhost interface can be configured manually at <a target="_blank" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>, or pfBlockerNG can create one automatically in the DNSBL step.</li>
 			</ul>
 		</div>
 		]]>

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -249,11 +249,19 @@
 <step>
 	<id>4</id>
 	<title>pfBlockerNG DNSBL Component Configuration</title>
-	<description><![CDATA[On this screen the pfBlockerNG DNSBL Category parameters will be set.<br />A VIP on the Localhost interface <strong>must be configured first</strong> at <a target="_blank" href="/firewall_virtual_ip.php">Firewall > Virtual IPs</a>.]]></description>
+	<description><![CDATA[On this screen the pfBlockerNG DNSBL Category parameters will be set.<br />Enable <strong>Create VIPs automatically</strong> below to have pfBlockerNG manage the DNSBL sinkhole Virtual IP, or configure a VIP on the Localhost interface manually first at <a target="_blank" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>.]]></description>
 	<fields>
 		<field>
 			<name>DNSBL Webserver Configuration</name>
 			<type>listtopic</type>
+		</field>
+		<field>
+			<name>pfb_dnsvip_auto</name>
+			<displayname>Auto VIP</displayname>
+			<bindstofield>pfblockerng_wizard-&gt;step3-&gt;pfb_dnsvip_auto</bindstofield>
+			<description><![CDATA[Create VIPs automatically. When enabled, pfBlockerNG creates and manages the DNSBL sinkhole Virtual IP in the <strong>10.10.X.53</strong> range (IPv6: <strong>fd00:X::53</strong>) &#8212; the manual selections below are ignored.<br /><span class="text-danger">Note:</span> auto-created VIPs are <strong>not HA/CARP aware</strong>. On a CARP/HA cluster, configure the DNSBL Virtual IP manually instead.]]></description>
+			<type>checkbox</type>
+			<value>on</value>
 		</field>
 		<field>
 			<name>pfb_dnsvip4</name>
@@ -261,7 +269,7 @@
 			<source><![CDATA[pfb_get_vip_options(AF_INET, true)]]></source>
 			<source_name>descr</source_name>
 			<source_value>id</source_value>
-			<description>Select the IPv4 DNSBL Virtual IP</description>
+			<description>Select the IPv4 DNSBL Virtual IP (manual mode only — ignored when Auto VIP is enabled)</description>
 			<displayname>IPv4 DNSBL Virtual IP</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;step3-&gt;pfb_dnsvip4</bindstofield>
 		</field>
@@ -271,7 +279,7 @@
 			<source><![CDATA[pfb_get_vip_options(AF_INET6, true)]]></source>
 			<source_name>descr</source_name>
 			<source_value>id</source_value>
-			<description>Select the IPv6 DNSBL Virtual IP</description>
+			<description>Select the IPv6 DNSBL Virtual IP (manual mode only — ignored when Auto VIP is enabled)</description>
 			<displayname>IPv6 DNSBL Virtual IP</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;step3-&gt;pfb_dnsvip6</bindstofield>
 		</field>

--- a/tests/php/WizardVipAutoTest.php
+++ b/tests/php/WizardVipAutoTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-23 — the setup wizard's Auto VIP gate (Phase 1). The wizard offers a
+ * pfb_dnsvip_auto checkbox so a fresh install can let ADR-13 auto-provision the
+ * DNSBL sinkhole VIP instead of forcing the operator to pick a manual VIP on the
+ * wizard step. Phase 1 added the same boolean gate
+ *   $pfb_auto = isset($_POST['pfb_dnsvip_auto']) && $_POST['pfb_dnsvip_auto'] == 'on'
+ * to TWO controllers:
+ *   1. step3_submitphpaction() — SKIPS pfb_validate_vips()/the 'none'->'' normalise
+ *      when auto is ON (the operator supplies no VIP in auto mode, so requiring a
+ *      valid one would block the wizard).
+ *   2. step4_submitphpaction() — persists the flag and guards the VIP-id writes.
+ *
+ * This pins the REAL shipped branch in step3_submitphpaction() (loaded verbatim by
+ * tests/php/bootstrap.php) rather than re-implementing the predicate in the test:
+ * the gate is inlined in the controller (no extracted helper to call), so asserting
+ * the inlined boolean would be coverage theater. Instead we drive the controller and
+ * observe whether VIP validation runs — the OBSERVABLE consequence of the gate.
+ *
+ * Branch coverage per CLAUDE.md: auto OFF and auto ON are both exercised with the
+ * SAME invalid (empty) VIP selection, and the OFF before-state is asserted first so
+ * green proves the auto flip CAUSED validation to be skipped — not an always-skip
+ * path. The falsey strings '' and '0' are pinned as OFF too (mirrors
+ * WizardDecisionTest::testSuppressCheckboxFalseyValuesStaySkip).
+ *
+ * Part B (step4_submitphpaction persistence shape) is NOT unit-invoked here — see
+ * the @todo on testStep4PersistenceShapeIsNotUnitInvokable for the concrete blocker.
+ */
+#[CoversFunction('step3_submitphpaction')]
+final class WizardVipAutoTest extends TestCase
+{
+	/**
+	 * Reset the shared globals step3_submitphpaction() reads/writes via
+	 * `global $stepid, $input_errors;` so each case starts clean (input_errors is
+	 * accumulated, not replaced, by the controller — a leaked entry would give a
+	 * false pass/fail).
+	 */
+	protected function setUp(): void
+	{
+		$GLOBALS['input_errors'] = [];
+		$GLOBALS['stepid'] = 2;
+		$_POST = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$_POST = [];
+		$GLOBALS['input_errors'] = [];
+	}
+
+	/** Did the controller surface a DNSBL VIP-validation error this run? */
+	private function hasDnsblError(): bool
+	{
+		foreach ($GLOBALS['input_errors'] as $err) {
+			if (is_string($err) && str_starts_with($err, 'DNSBL:')) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * A wizard step3 POST with an empty (invalid) VIP selection and valid ports — the
+	 * common knobs both auto OFF and auto ON cases share. Ports are deliberately valid
+	 * so the separate port-validation branch never adds an unrelated error that could
+	 * mask the VIP branch under test.
+	 *
+	 * @return array<string,string>
+	 */
+	private function postWithInvalidVip(): array
+	{
+		return [
+			'back'           => '',   // present so the controller's $_POST['back'] read is defined
+			'pfb_dnsvip4'    => '',   // no VIP -> pfb_validate_vips() returns "no VIP configured"
+			'pfb_dnsvip6'    => '',
+			'pfb_dnsport'    => '8081',
+			'pfb_dnsport_ssl' => '8443',
+		];
+	}
+
+	/**
+	 * Scenario: the Auto VIP checkbox decides whether the wizard validates the VIP.
+	 *
+	 *   Background:
+	 *     Given a wizard step3 POST whose VIP selection is empty (invalid)
+	 *       and whose DNSBL ports are valid
+	 *
+	 *   When pfb_dnsvip_auto is absent (auto OFF)
+	 *   Then step3 runs pfb_validate_vips() and surfaces a "DNSBL: ..." input error
+	 *
+	 *   --- the OFF before-state above is asserted FIRST ---
+	 *
+	 *   When pfb_dnsvip_auto = 'on' (auto ON), same invalid VIP
+	 *   Then step3 SKIPS validation and surfaces NO "DNSBL: ..." error
+	 *
+	 * The two halves sharing one invalid VIP is what proves the auto flip — not the
+	 * VIP value — caused the change.
+	 */
+	public function testAutoOnSkipsVipValidationThatAutoOffEnforces(): void
+	{
+		// Given/When: auto OFF (checkbox absent), invalid VIP.
+		$GLOBALS['input_errors'] = [];
+		$_POST = $this->postWithInvalidVip();
+		step3_submitphpaction();
+
+		// Then (before-state): validation ran -> a DNSBL error is present.
+		$this->assertTrue(
+			$this->hasDnsblError(),
+			'auto OFF must run pfb_validate_vips() and reject the empty VIP'
+		);
+
+		// When: flip auto ON, SAME invalid VIP.
+		$GLOBALS['input_errors'] = [];
+		$_POST = $this->postWithInvalidVip();
+		$_POST['pfb_dnsvip_auto'] = 'on';
+		step3_submitphpaction();
+
+		// Then (after-state): validation skipped -> no DNSBL error. Green here only
+		// because the auto flag flipped, proving the gate is a real branch.
+		$this->assertFalse(
+			$this->hasDnsblError(),
+			'auto ON must SKIP VIP validation (ADR-13 auto-provisions the VIP)'
+		);
+	}
+
+	/**
+	 * The gate is strict equality to the checkbox-checked value 'on'. Every other
+	 * value — the falsey strings '' and '0' a stale/empty submit can carry — must be
+	 * treated as OFF so validation still runs (mirrors the suppress-checkbox falsey
+	 * handling in WizardDecisionTest). Without this, an empty 'pfb_dnsvip_auto' POST
+	 * field would silently disable VIP validation.
+	 *
+	 * @testWith [""]
+	 *           ["0"]
+	 */
+	public function testAutoFalseyValuesStillEnforceVipValidation(string $falsey): void
+	{
+		$GLOBALS['input_errors'] = [];
+		$_POST = $this->postWithInvalidVip();
+		$_POST['pfb_dnsvip_auto'] = $falsey;
+		step3_submitphpaction();
+
+		$this->assertTrue(
+			$this->hasDnsblError(),
+			"pfb_dnsvip_auto='{$falsey}' is falsey -> auto OFF -> VIP validation must run"
+		);
+	}
+
+	/**
+	 * Part B (step4_submitphpaction persistence shape) — FALLBACK, documented.
+	 *
+	 * @todo step4_submitphpaction() cannot be unit-invoked under the tests/php/
+	 *   doubles without a src/ refactor, so its persistence shape (writing
+	 *   pfb_dnsvip_auto and guarding the pfb_dnsvip4/6 id writes) is NOT covered here.
+	 *   Reading the shipped function end-to-end, three hard blockers stand before any
+	 *   assertable persistence:
+	 *     1. It ends in `header("Location: .../pfblockerng_update.php?wizard=reload"); exit;`
+	 *        — `exit` would terminate the PHPUnit process.
+	 *     2. It early-returns with an input_error unless `json_decode(@file_get_contents(
+	 *        $pfb['feeds']))` yields a feeds array — i.e. it requires a live feeds DB
+	 *        fixture before reaching the config-mutation block.
+	 *     3. Before the exit it calls undoubled pfSense services —
+	 *        services_unbound_configure(), system_resolvconf_generate(),
+	 *        system_dhcpleases_configure() — with live side effects.
+	 *   Exercising it cleanly needs the config-mutation block (the auto gate + the
+	 *   $new_config[...]['pfblockerngdnsblsettings'][0][...] writes) extracted into a
+	 *   pure helper returning the array — a src/-touching change, hence its own
+	 *   ADR-23 phase/PR, out of scope for this tests-only phase. The step3 direct
+	 *   invocation above already pins the SAME inlined auto-gate predicate on shipped
+	 *   code, and DnsblMarkedVipTest pins the ADR-13 engine that step4's flag drives.
+	 */
+	public function testStep4PersistenceShapeIsNotUnitInvokable(): void
+	{
+		$this->markTestSkipped(
+			'step4_submitphpaction() ends in header()+exit, requires a feeds-DB fixture, '
+			. 'and calls undoubled pfSense services — its persistence shape needs a src/ '
+			. 'refactor to a pure helper (own ADR-23 phase). See the @todo above.'
+		);
+	}
+}

--- a/tests/php/WizardVipAutoTest.php
+++ b/tests/php/WizardVipAutoTest.php
@@ -29,10 +29,13 @@ use PHPUnit\Framework\TestCase;
  * path. The falsey strings '' and '0' are pinned as OFF too (mirrors
  * WizardDecisionTest::testSuppressCheckboxFalseyValuesStaySkip).
  *
- * Part B (step4_submitphpaction persistence shape) is NOT unit-invoked here — see
- * the @todo on testStep4PersistenceShapeIsNotUnitInvokable for the concrete blocker.
+ * Part B (the persisted DNSBL-VIP settings shape) is covered directly via the pure
+ * helper pfb_wizard_dnsvip_settings() (ADR-23), which step4_submitphpaction() now
+ * calls to build the slice it merges into the DNSBL config — see
+ * testAutoVipToggleDecidesPersistedDnsvipSettings.
  */
 #[CoversFunction('step3_submitphpaction')]
+#[CoversFunction('pfb_wizard_dnsvip_settings')]
 final class WizardVipAutoTest extends TestCase
 {
 	/**
@@ -153,34 +156,46 @@ final class WizardVipAutoTest extends TestCase
 	}
 
 	/**
-	 * Part B (step4_submitphpaction persistence shape) — FALLBACK, documented.
+	 * Part B — the persisted DNSBL-VIP settings shape, on the pure helper
+	 * step4_submitphpaction() now calls (pfb_wizard_dnsvip_settings). The controller
+	 * itself can't be unit-invoked (it ends in header()+exit), so ADR-23 extracts the
+	 * VIP-settings decision into this helper and the controller merges the returned
+	 * slice into the DNSBL config — so testing the helper pins exactly what is written.
 	 *
-	 * @todo step4_submitphpaction() cannot be unit-invoked under the tests/php/
-	 *   doubles without a src/ refactor, so its persistence shape (writing
-	 *   pfb_dnsvip_auto and guarding the pfb_dnsvip4/6 id writes) is NOT covered here.
-	 *   Reading the shipped function end-to-end, three hard blockers stand before any
-	 *   assertable persistence:
-	 *     1. It ends in `header("Location: .../pfblockerng_update.php?wizard=reload"); exit;`
-	 *        — `exit` would terminate the PHPUnit process.
-	 *     2. It early-returns with an input_error unless `json_decode(@file_get_contents(
-	 *        $pfb['feeds']))` yields a feeds array — i.e. it requires a live feeds DB
-	 *        fixture before reaching the config-mutation block.
-	 *     3. Before the exit it calls undoubled pfSense services —
-	 *        services_unbound_configure(), system_resolvconf_generate(),
-	 *        system_dhcpleases_configure() — with live side effects.
-	 *   Exercising it cleanly needs the config-mutation block (the auto gate + the
-	 *   $new_config[...]['pfblockerngdnsblsettings'][0][...] writes) extracted into a
-	 *   pure helper returning the array — a src/-touching change, hence its own
-	 *   ADR-23 phase/PR, out of scope for this tests-only phase. The step3 direct
-	 *   invocation above already pins the SAME inlined auto-gate predicate on shipped
-	 *   code, and DnsblMarkedVipTest pins the ADR-13 engine that step4's flag drives.
+	 * Scenario: the Auto VIP choice decides which DNSBL-VIP keys are persisted.
+	 *
+	 *   Background:
+	 *     Given step3 selected the manual lo0 VIP ids pfb_dnsvip4='_vip1', pfb_dnsvip6='_vip2'
+	 *
+	 *   When auto is OFF
+	 *   Then pfb_dnsvip_auto persists as '' AND both manual ids are written through
+	 *
+	 *   --- the OFF before-state above is asserted FIRST ---
+	 *
+	 *   When auto is ON (same step3 ids passed)
+	 *   Then pfb_dnsvip_auto persists as 'on' AND neither manual id is written
+	 *        (ADR-13 owns/provisions the VIP, so the wizard must not pin a manual id)
+	 *
+	 * Passing the SAME ids to both calls proves the auto flag — not the id values —
+	 * decides whether the manual ids are persisted.
 	 */
-	public function testStep4PersistenceShapeIsNotUnitInvokable(): void
+	public function testAutoVipToggleDecidesPersistedDnsvipSettings(): void
 	{
-		$this->markTestSkipped(
-			'step4_submitphpaction() ends in header()+exit, requires a feeds-DB fixture, '
-			. 'and calls undoubled pfSense services — its persistence shape needs a src/ '
-			. 'refactor to a pure helper (own ADR-23 phase). See the @todo above.'
-		);
+		// Given: step3's manual VIP selections.
+		$vip4 = '_vip1';
+		$vip6 = '_vip2';
+
+		// When/Then (before-state): auto OFF persists the flag '' and BOTH manual ids.
+		$off = pfb_wizard_dnsvip_settings(false, $vip4, $vip6);
+		$this->assertSame('', $off['pfb_dnsvip_auto'], 'auto OFF must persist pfb_dnsvip_auto as empty');
+		$this->assertSame('_vip1', $off['pfb_dnsvip4'], 'auto OFF must persist the manual IPv4 VIP id');
+		$this->assertSame('_vip2', $off['pfb_dnsvip6'], 'auto OFF must persist the manual IPv6 VIP id');
+
+		// When/Then (after-state): auto ON persists the flag 'on' and OMITS the manual
+		// ids — the same ids are passed, so green here proves the flag drove the change.
+		$on = pfb_wizard_dnsvip_settings(true, $vip4, $vip6);
+		$this->assertSame('on', $on['pfb_dnsvip_auto'], 'auto ON must persist pfb_dnsvip_auto as on');
+		$this->assertArrayNotHasKey('pfb_dnsvip4', $on, 'auto ON must NOT pin a manual IPv4 VIP id (ADR-13 owns it)');
+		$this->assertArrayNotHasKey('pfb_dnsvip6', $on, 'auto ON must NOT pin a manual IPv6 VIP id (ADR-13 owns it)');
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -55,3 +55,31 @@ $pfb_prev_er = error_reporting();
 error_reporting($pfb_prev_er & ~E_DEPRECATED & ~E_WARNING);
 require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc';
 error_reporting($pfb_prev_er);
+
+// 5. Load the setup-wizard controller's FUNCTIONS so the unit suite can invoke
+//    them on shipped code (WizardVipAutoTest -> step3_submitphpaction). The wizard
+//    .inc cannot be require()d as-is here: it opens with four require_once()s —
+//    three relative (config.inc/util.inc/services.inc, satisfiable by the shims)
+//    plus one HOST-ABSOLUTE require of /usr/local/pkg/pfblockerng/pfblockerng.inc
+//    (NOT resolvable via include_path, and a duplicate of the real include already
+//    loaded above) — and then runs top-level wiring (pfb_global(), interface-list
+//    build) that needs runtime pfSense state we deliberately do not stand up.
+//    So we read the source, strip its require_once() lines, and eval only from the
+//    first function definition onward: the function bodies are the shipped code
+//    under test, defined verbatim; no production file is modified. Guarded so a
+//    real include path (on-appliance) never double-defines.
+if (!function_exists('step3_submitphpaction')) {
+	$pfb_wizard_src = file_get_contents(
+		dirname(__DIR__, 2) . '/src/usr/local/www/wizards/pfblockerng_wizard.inc'
+	);
+	// Drop the top-of-file require_once() statements (shims/real include already
+	// satisfy them); keep everything else byte-for-byte.
+	$pfb_wizard_src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $pfb_wizard_src);
+	// Eval only the function definitions (from the first `function ` keyword),
+	// skipping the top-level wiring that would call into unprovisioned runtime.
+	$pfb_fn_pos = strpos($pfb_wizard_src, 'function ');
+	if ($pfb_fn_pos !== false) {
+		eval("\n" . substr($pfb_wizard_src, $pfb_fn_pos));
+	}
+	unset($pfb_wizard_src, $pfb_fn_pos);
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -72,6 +72,9 @@ if (!function_exists('step3_submitphpaction')) {
 	$pfb_wizard_src = file_get_contents(
 		dirname(__DIR__, 2) . '/src/usr/local/www/wizards/pfblockerng_wizard.inc'
 	);
+	if ($pfb_wizard_src === false) {
+		throw new RuntimeException('test bootstrap: failed to read pfblockerng_wizard.inc for the wizard-function load');
+	}
 	// Drop the top-of-file require_once() statements (shims/real include already
 	// satisfy them); keep everything else byte-for-byte.
 	$pfb_wizard_src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $pfb_wizard_src);

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -65,6 +65,20 @@ if (!function_exists('is_hostname')) {
 	}
 }
 
+if (!function_exists('is_port')) {
+	// pfSense util.inc: a single TCP/UDP port — a pure-digit string in 1..65535
+	// (no ranges, no aliases). step3_submitphpaction() validates pfb_dnsport /
+	// pfb_dnsport_ssl through this; WizardVipAutoTest supplies valid ports so the
+	// port branch never masks the VIP-validation branch under test.
+	function is_port($port) {
+		if (!ctype_digit((string) $port)) {
+			return false;
+		}
+		$port = (int) $port;
+		return ($port >= 1 && $port <= 65535);
+	}
+}
+
 if (!function_exists('system_get_uniqueid')) {
 	// Called at pfblockerng.inc load time (cURL user-agent). Any stable string.
 	function system_get_uniqueid() {

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -275,6 +275,46 @@ def test_dnsbl_idn_blocking_fields_render(webui: WebUI, php_error_log_guard: Php
         assert needle in body, f"DNSBL page is missing the IDN-mode marker {needle!r}"
 
 
+# ADR-23: the setup wizard's DNSBL step now surfaces ADR-13's pfb_dnsvip_auto auto-VIP
+# toggle. Core wizard.php renders ONE step per GET, indexed by a 0-based `stepid` (verified
+# against pfSense upstream wizard.php: `$stepid` defaults to "0" and indexes $pkg['step']
+# directly). The DNSBL step is the 4th <step> (<id>4</id>, "DNSBL Component Configuration")
+# in pfblockerng_wizard.xml -> stepid=3. The wizard is NOT in PAGE_TABLE (a core-rendered
+# www/wizards/ page, not a www/pfblockerng/ one), so it gets its own render assertion.
+_WIZARD_DNSBL_STEP = "/wizard.php?xml=pfblockerng_wizard.xml&stepid=3"
+
+
+def test_wizard_dnsbl_step_renders_auto_vip(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """ADR-23: the wizard DNSBL step renders the Auto VIP (pfb_dnsvip_auto) checkbox cleanly.
+
+    The setup wizard exposes ADR-13's auto-create toggle on its DNSBL step so a first-run
+    user need not pre-create a sinkhole VIP — a render regression that drops/breaks the field
+    (or the wizard step itself) must fail here, not only in the maintainer on-box check. A
+    direct authenticated GET renders the step regardless of the first-run dismissal the
+    `webui` fixture performs (dismissal only suppresses general.php's auto-launch redirect,
+    not wizard.php itself).
+
+    Asserts the step passes the clean-render oracle (200, no PHP diagnostic, the step-title
+    Form_Section marker present, not the login form) AND — from three independent wizard.php
+    render paths — that the field's POST name (`pfb_dnsvip_auto`), its 'Auto VIP' displayname
+    label, and the 'Create VIPs automatically' setHelp() wording are present. The IPv4/IPv6
+    manual selectors carry the new "manual mode only" note, asserted too so the mode framing
+    that pairs with the checkbox is pinned. `php_error_log_guard` enrolls this GET in the
+    module-level no-growth sweep.
+    """
+    resp = webui.get(_WIZARD_DNSBL_STEP)
+    result = evaluate_render(_WIZARD_DNSBL_STEP, resp.status_code, resp.text, ("DNSBL Component Configuration",))
+    assert result.ok, f"wizard DNSBL-step render oracle failed: {result.detail}"
+    body = resp.text
+    for needle in (
+        "pfb_dnsvip_auto",  # the checkbox field's POST name (input name/id)
+        "Auto VIP",  # the <displayname> label
+        "Create VIPs automatically",  # the <description> setHelp() wording
+        "manual mode only",  # the pfb_dnsvip4/6 selectors' new mode-dependency note
+    ):
+        assert needle in body, f"wizard DNSBL step is missing the Auto VIP marker {needle!r}"
+
+
 # threats.php's NEGATIVE branches: each malformed/absent param print_info_box()es
 # a specific message and exit()s BEFORE the "$pgtitle" lookup-page chrome. These
 # pair with the positive threats_{domain,host,port} entries above (CLAUDE.md


### PR DESCRIPTION
Implements ADR-23 (issue #178): surfaces ADR-13's `pfb_dnsvip_auto` auto-create toggle in the setup wizard's DNSBL step, so a fresh install can let pfBlockerNG manage the DNSBL sinkhole VIP instead of having to pre-create one at Firewall > Virtual IPs.

## Changes

- **`pfblockerng_wizard.xml`** — step 4 reframed from "a VIP must be configured first" to a choice; new **Auto VIP** (`pfb_dnsvip_auto`) checkbox bound to step3 temp config with a HA/CARP disclaimer; manual `pfb_dnsvip4`/`pfb_dnsvip6` selectors annotated "manual mode only — ignored when Auto VIP is enabled".
- **`pfblockerng_wizard.inc`** — `step3_submitphpaction()` skips `pfb_validate_vips()` when auto is ON; `step4_submitphpaction()` persists the flag and guards the manual VIP-id writes when auto is ON. The existing reload redirect triggers ADR-13's `pfb_manage_dnsbl_vip('enabled')` to provision the VIP — no engine changes.
- **`tests/php/WizardVipAutoTest.php`** (new) — drives the real `step3_submitphpaction()` and asserts the auto-OFF before-state (validation runs) before flipping to auto-ON (validation skipped), plus falsey-value handling. Bootstrap loads the wizard controller off-appliance; an `is_port()` double was added. step4 persistence shape is deferred (see ADR §8 — needs a `src/` refactor to a pure helper).
- **Docs** — CLAUDE.md smoke note; ADR-23 marked Implemented (pending smoke test) with a §8 Notes recording the test approach.

## Validation

`php -l`, PHPStan, PHPUnit (299 tests, 1 documented skip), pytest (1480), ruff, markdownlint — all green.

The ADR-14 Tier A `ui_render` check and the §7 on-box manual smoke checks (config persistence, VIP provisioning at `10.10.X.53`, back-nav, disclaimer rendering) require a live pfSense VM and are pending the maintainer — status stays "Implemented (pending smoke test)" until they pass.

Implements ADR-23. Closes #178.

https://claude.ai/code/session_01VUXzg5SHmXuFSkaXdWKGFo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUXzg5SHmXuFSkaXdWKGFo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "Auto VIP" mode in the setup wizard: when enabled, manual VIP selections are ignored and manual VIP validation is skipped.

* **Documentation**
  * ADR status set to "Implemented (pending smoke test)"; wizard text and smoke-test guidance updated, including HA/cluster guidance for auto-created VIPs.

* **Tests**
  * Unit tests validate Auto VIP gating and strict falsey handling; persistence-shape behavior covered via an extracted helper and test-harness enhancements.

* **Smoke**
  * UI render smoke test added to verify the Auto VIP checkbox, label, help text, and contextual "manual mode only" messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->