### PR TITLE
ci: derive test.yml pytest+PHP matrices from supported-versions

### DIFF
--- a/.github/actions/read-version-matrix/action.yml
+++ b/.github/actions/read-version-matrix/action.yml
@@ -1,9 +1,11 @@
 name: Read version matrix
 description: >
   Read supported-versions.json from the ci-metadata orphan ref and emit
-  two workflow output matrices: the BUILD matrix (all entries with their
-  (freebsd_version, php_version) pair) and the CI matrix (ci:true CE
-  entries only). Pure read — no writes anywhere.
+  the workflow output matrices: the BUILD matrix (all entries with their
+  (freebsd_version, php_version) pair), the CI matrix (ci:true CE entries
+  only), and the derived test matrices python_versions / php_versions
+  (the distinct, supported-only python + php versions test.yml fans out
+  over). Pure read — no writes anywhere.
 
 inputs:
   ref:
@@ -47,6 +49,17 @@ outputs:
       output (e.g. ["CE"] or ["CE","Plus"]). Useful for downstream jobs
       that need to know which variants are present.
     value: ${{ steps.read.outputs.variant }}
+  python_versions:
+    description: >
+      JSON array of the distinct python versions derived from each entry's
+      py_flavor (py311 => "3.11"), sorted + deduped. test.yml's pytest
+      matrix — supported-only (only the pythons the matrix ships).
+    value: ${{ steps.read.outputs.python_versions }}
+  php_versions:
+    description: >
+      JSON array of the distinct php_version values, sorted + deduped.
+      test.yml's PHP-jobs matrix — supported-only.
+    value: ${{ steps.read.outputs.php_versions }}
 
 runs:
   using: composite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,16 +55,43 @@ permissions:
   packages: read
 
 jobs:
+  # Derive the pytest + PHP test matrices from the single-source-of-truth
+  # supported-versions matrix (ci-metadata orphan branch). The pytest matrix is
+  # the distinct python versions (from each entry's py_flavor) and the PHP matrix
+  # the distinct php_version values, across ALL entries (CE + Plus) — supported-only
+  # (only versions the matrix actually ships; nothing hardcoded). Adding/dropping a
+  # version on ci-metadata changes these legs automatically — no YAML edit here.
+  read-matrix:
+    name: Read supported-version matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      python_versions: ${{ steps.matrix.outputs.python_versions }}
+      php_versions: ${{ steps.matrix.outputs.php_versions }}
+    steps:
+      - name: Checkout (for scripts/read-version-matrix.sh + the action)
+        uses: actions/checkout@v6
+
+      - name: Fetch the ci-metadata orphan ref
+        # The reader reads origin/ci-metadata; checkout doesn't bring orphan refs.
+        run: git fetch --no-tags --depth=1 origin ci-metadata:refs/remotes/origin/ci-metadata
+
+      - name: Read derived test matrices
+        id: matrix
+        uses: ./.github/actions/read-version-matrix
+
   test:
     name: pytest / Python ${{ matrix.python-version }}
+    needs: read-matrix
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        # 3.11 is the minimum (pfSense CE 2.8 / FreeBSD 15 baseline).
-        # Also test against the current stable and latest releases.
-        python-version: ['3.11', '3.12', '3.13']
+        # Matrix-derived (supported-only) from supported-versions.json — the
+        # distinct pythons across all entries' py_flavor. Today: ["3.11"]. This
+        # intentionally tracks only shipped pythons (no speculative 3.12/3.13 leg).
+        python-version: ${{ fromJSON(needs.read-matrix.outputs.python_versions) }}
 
     steps:
       - name: Checkout
@@ -222,34 +249,49 @@ jobs:
           if-no-files-found: ignore
 
   php-syntax:
-    name: PHP syntax check (php -l)
+    name: PHP syntax check (php -l) / PHP ${{ matrix.php-version }}
+    needs: read-matrix
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Matrix-derived (supported-only) — the distinct php_version values across
+        # all supported-versions.json entries (CE + Plus). Today: ["8.3","8.5"].
+        php-version: ${{ fromJSON(needs.read-matrix.outputs.php_versions) }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up PHP 8.3
+      - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: ${{ matrix.php-version }}
           tools: none
 
       - name: Syntax-check all PHP and .inc files
         run: find src -name '*.php' -o -name '*.inc' | sort | xargs -n1 php -l
 
   php-static-analysis:
-    name: PHPStan static analysis
+    name: PHPStan static analysis / PHP ${{ matrix.php-version }}
+    needs: read-matrix
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Matrix-derived (supported-only) — see php-syntax. Today: ["8.3","8.5"].
+        php-version: ${{ fromJSON(needs.read-matrix.outputs.php_versions) }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up PHP 8.3
+      - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: ${{ matrix.php-version }}
           tools: composer
 
       - name: Install PHPStan
@@ -262,17 +304,24 @@ jobs:
         run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
 
   php-codesniffer:
-    name: PHPCS PFBL-01 RequirePfbFilter sniff
+    name: PHPCS PFBL-01 RequirePfbFilter sniff / PHP ${{ matrix.php-version }}
+    needs: read-matrix
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Matrix-derived (supported-only) — see php-syntax. Today: ["8.3","8.5"].
+        php-version: ${{ fromJSON(needs.read-matrix.outputs.php_versions) }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up PHP 8.3
+      - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: ${{ matrix.php-version }}
           tools: composer
 
       - name: Install dependencies
@@ -285,18 +334,26 @@ jobs:
         run: vendor/bin/phpcs
 
   php-unit:
-    name: PHPUnit unit tests
+    name: PHPUnit unit tests / PHP ${{ matrix.php-version }}
+    needs: read-matrix
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Matrix-derived (supported-only) — the distinct php_version values across
+        # all supported-versions.json entries (CE + Plus). Today: ["8.3","8.5"].
+        php-version: ${{ fromJSON(needs.read-matrix.outputs.php_versions) }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up PHP 8.3
+      - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
-          # Target CE 2.8 (PHP 8.3). pcov drives informational coverage.
-          php-version: '8.3'
+          # pcov drives informational coverage.
+          php-version: ${{ matrix.php-version }}
           extensions: curl, intl, mbstring, ctype, filter
           coverage: pcov
           tools: composer
@@ -403,11 +460,15 @@ jobs:
     # The ADR-14 UI suite (`ui-suite`) IS folded in: it is skipped (== pass) on an
     # unlabeled PR / push, and only a `ui-tests`-labeled PR whose UI suite FAILS
     # blocks here — that is how the opt-in label gates a merge.
-    needs: [test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, ui-suite]
+    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, ui-suite]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
         run: |
+          if [ "${{ needs.read-matrix.result }}" != "success" ]; then
+            echo "Reading the supported-version matrix failed or was cancelled."
+            exit 1
+          fi
           if [ "${{ needs.test.result }}" != "success" ]; then
             echo "One or more Python test jobs failed or were cancelled."
             exit 1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,9 +14,20 @@ the **`ci-metadata` orphan branch** (its own history, off `main`/`devel`) as
 | [`read-version-matrix.sh`](read-version-matrix.sh) | Read the matrix from `ci-metadata` and print/emit the BUILD matrix and CI matrix. |
 
 The `read-version-matrix.sh` reader is also exposed as a composite GH Actions action
-(`.github/actions/read-version-matrix/`) that emits two outputs: `build_matrix` (all
-entries → one `.pkg` per distinct FreeBSD major) and `ci_matrix` (`ci: true` CE
-entries → the smoke-fan-out set, never Plus).
+(`.github/actions/read-version-matrix/`) that emits these outputs:
+
+- `build_matrix` — all entries → one `.pkg` per distinct FreeBSD major.
+- `ci_matrix` — `ci: true` CE entries → the smoke-fan-out set, never Plus.
+- `python_versions` — the DISTINCT python versions derived from each entry's `py_flavor`
+  (`pyN` + `MM` → `N.MM`; e.g. `py311` → `3.11`, `py39` → `3.9`), sorted + deduped.
+- `php_versions` — the DISTINCT `php_version` values across the entries, sorted + deduped.
+
+`python_versions` / `php_versions` are the **supported-only** test matrices (only the
+versions the matrix actually ships): `test.yml`'s `read-matrix` job feeds them into the
+pytest job (`strategy.matrix.python-version`) and the four PHP jobs
+(`strategy.matrix.php-version`) via `fromJSON`, so the test gates fan out over exactly the
+supported set — no hardcoded version list. The reader also has a `--print-test` mode that
+prints both to stdout (mirroring `--print-build` / `--print-ci`).
 
 ### Schema
 

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   read-version-matrix.sh [--ref <git-ref>] [--file <path>] [--github-output]
-#                          [--print-build | --print-ci | --print-all]
+#                          [--print-build | --print-ci | --print-test | --print-all]
 #                          [--variant CE|Plus]
 #
 # Options:
@@ -12,10 +12,13 @@
 #                        Must be reachable in the current git repo.
 #   --file <path>        Matrix file path on the ref
 #                        (default: supported-versions.json).
-#   --github-output      Write build_matrix and ci_matrix to $GITHUB_OUTPUT
-#                        (GitHub Actions step outputs format).
+#   --github-output      Write build_matrix, ci_matrix, variant, python_versions,
+#                        and php_versions to $GITHUB_OUTPUT (GitHub Actions step
+#                        outputs format).
 #   --print-build        Print BUILD matrix JSON to stdout.
 #   --print-ci           Print CI matrix JSON to stdout.
+#   --print-test         Print the derived test matrices (python_versions +
+#                        php_versions) to stdout (labelled).
 #   --print-all          Print both matrices to stdout (labelled).
 #   --variant CE|Plus    Filter both matrices to entries whose `variant` field
 #                        matches the given value (case-insensitive). Returns ALL
@@ -24,10 +27,16 @@
 #                        this flag all entries are returned (backward-compatible).
 #
 # Outputs:
-#   BUILD matrix — all entries from supported-versions.json, each carrying:
+#   BUILD matrix     — all entries from supported-versions.json, each carrying:
 #     pfsense_version, channel, freebsd_version, freebsd_major,
 #     php_version, py_flavor, variant, status, ci
-#   CI matrix    — the ci:true CE entries only (subset of BUILD matrix).
+#   CI matrix        — the ci:true CE entries only (subset of BUILD matrix).
+#   python_versions  — DISTINCT python versions derived from each BUILD-matrix
+#     entry's py_flavor (`pyN` + `MM` => `N.MM`, e.g. py311 => 3.11; py39 => 3.9),
+#     sorted + deduped. test.yml's pytest matrix (supported-only — only the
+#     pythons the matrix actually ships).
+#   php_versions     — DISTINCT php_version across the BUILD-matrix entries,
+#     sorted + deduped. test.yml's PHP-jobs matrix (supported-only).
 #
 # Requirements: git, jq (both available on ubuntu-latest GH runners).
 # Pure read — no writes anywhere; exits non-zero on any error.
@@ -44,6 +53,7 @@ MATRIX_FILE="${MATRIX_FILE:-supported-versions.json}"
 DO_GITHUB_OUTPUT=0
 DO_PRINT_BUILD=0
 DO_PRINT_CI=0
+DO_PRINT_TEST=0
 VARIANT_FILTER=""
 
 # ── Argument parsing ───────────────────────────────────────────────────────────
@@ -55,13 +65,15 @@ while [ $# -gt 0 ]; do
     --github-output) DO_GITHUB_OUTPUT=1; shift ;;
     --print-build)   DO_PRINT_BUILD=1;   shift ;;
     --print-ci)      DO_PRINT_CI=1;      shift ;;
+    --print-test)    DO_PRINT_TEST=1;    shift ;;
     --print-all)     DO_PRINT_BUILD=1; DO_PRINT_CI=1; shift ;;
     *) printf 'unknown option: %s\n' "$1" >&2; exit 1 ;;
   esac
 done
 
-# Default: print both when running standalone with no print flags and no GH output.
-if [ "$DO_GITHUB_OUTPUT" -eq 0 ] && [ "$DO_PRINT_BUILD" -eq 0 ] && [ "$DO_PRINT_CI" -eq 0 ]; then
+# Default: print both matrices when running standalone with no print flags and no
+# GH output. (--print-test alone is an explicit request — don't add build/ci to it.)
+if [ "$DO_GITHUB_OUTPUT" -eq 0 ] && [ "$DO_PRINT_BUILD" -eq 0 ] && [ "$DO_PRINT_CI" -eq 0 ] && [ "$DO_PRINT_TEST" -eq 0 ]; then
   DO_PRINT_BUILD=1
   DO_PRINT_CI=1
 fi
@@ -124,6 +136,33 @@ fi
 # Variant JSON array: distinct variant values present in the BUILD matrix.
 VARIANT_ARRAY="$(printf '%s' "$BUILD_MATRIX" | jq -c '[.[].variant // empty] | unique')"
 
+# ── Derived test matrices (test.yml — supported-only) ─────────────────────────
+# python_versions: map each entry's py_flavor ("pyN" + "MM") to "N.MM"
+#   (py311 => 3.11, py39 => 3.9), then dedup + sort. The regex captures the
+#   single major digit and the remaining minor digits, joined with a dot.
+# php_versions: distinct php_version values, deduped + sorted.
+# Both feed test.yml's strategy.matrix unfiltered (CE + Plus) so the pytest /
+# PHP gates only ever run a version the matrix actually ships.
+PYTHON_VERSIONS="$(printf '%s' "$BUILD_MATRIX" | jq -c '
+  [ .[].py_flavor
+    | capture("^py(?<maj>[0-9])(?<min>[0-9]+)$")
+    | "\(.maj).\(.min)"
+  ] | unique')"
+PHP_VERSIONS="$(printf '%s' "$BUILD_MATRIX" | jq -c '[.[].php_version] | unique')"
+
+# Fail-closed: a non-empty BUILD matrix must derive at least one python + php
+# version. An empty derive means a malformed py_flavor / missing php_version.
+if [ "$(printf '%s' "$BUILD_MATRIX" | jq 'length')" -gt 0 ]; then
+  if [ "$(printf '%s' "$PYTHON_VERSIONS" | jq 'length')" -eq 0 ]; then
+    printf '::error::no python versions derived from py_flavor in %s (malformed py_flavor?)\n' "$MATRIX_FILE" >&2
+    exit 1
+  fi
+  if [ "$(printf '%s' "$PHP_VERSIONS" | jq 'length')" -eq 0 ]; then
+    printf '::error::no php versions found (missing php_version?) in %s\n' "$MATRIX_FILE" >&2
+    exit 1
+  fi
+fi
+
 if [ "$DO_GITHUB_OUTPUT" -eq 1 ]; then
   if [ -z "${GITHUB_OUTPUT:-}" ]; then
     printf '::error::GITHUB_OUTPUT is not set — cannot write step outputs\n' >&2
@@ -134,6 +173,8 @@ if [ "$DO_GITHUB_OUTPUT" -eq 1 ]; then
     printf 'build_matrix<<__EOF_BUILD_MATRIX__\n%s\n__EOF_BUILD_MATRIX__\n' "$BUILD_MATRIX"
     printf 'ci_matrix<<__EOF_CI_MATRIX__\n%s\n__EOF_CI_MATRIX__\n' "$CI_MATRIX"
     printf 'variant<<__EOF_VARIANT__\n%s\n__EOF_VARIANT__\n' "$VARIANT_ARRAY"
+    printf 'python_versions<<__EOF_PYTHON_VERSIONS__\n%s\n__EOF_PYTHON_VERSIONS__\n' "$PYTHON_VERSIONS"
+    printf 'php_versions<<__EOF_PHP_VERSIONS__\n%s\n__EOF_PHP_VERSIONS__\n' "$PHP_VERSIONS"
   } >> "$GITHUB_OUTPUT"
 fi
 
@@ -149,4 +190,11 @@ if [ "$DO_PRINT_CI" -eq 1 ]; then
     printf '\nCI matrix:\n'
   fi
   printf '%s' "$CI_MATRIX" | jq .
+fi
+
+if [ "$DO_PRINT_TEST" -eq 1 ]; then
+  printf 'python_versions:\n'
+  printf '%s' "$PYTHON_VERSIONS" | jq .
+  printf '\nphp_versions:\n'
+  printf '%s' "$PHP_VERSIONS" | jq .
 fi

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -150,15 +150,18 @@ PYTHON_VERSIONS="$(printf '%s' "$BUILD_MATRIX" | jq -c '
   ] | unique')"
 PHP_VERSIONS="$(printf '%s' "$BUILD_MATRIX" | jq -c '[.[].php_version] | unique')"
 
-# Fail-closed: a non-empty BUILD matrix must derive at least one python + php
-# version. An empty derive means a malformed py_flavor / missing php_version.
+# Fail-closed: every entry in a non-empty BUILD matrix must yield a python AND a php
+# version. The py_flavor map above already aborts on a malformed flavor (jq capture()
+# errors under set -e); guard the php side SYMMETRICALLY — a null/empty php_version on
+# any entry must fail HERE, not slip through as a [null] matrix leg (a bare length check
+# would pass [null], whose length is 1, straight into test.yml's strategy.matrix).
 if [ "$(printf '%s' "$BUILD_MATRIX" | jq 'length')" -gt 0 ]; then
   if [ "$(printf '%s' "$PYTHON_VERSIONS" | jq 'length')" -eq 0 ]; then
     printf '::error::no python versions derived from py_flavor in %s (malformed py_flavor?)\n' "$MATRIX_FILE" >&2
     exit 1
   fi
-  if [ "$(printf '%s' "$PHP_VERSIONS" | jq 'length')" -eq 0 ]; then
-    printf '::error::no php versions found (missing php_version?) in %s\n' "$MATRIX_FILE" >&2
+  if [ "$(printf '%s' "$BUILD_MATRIX" | jq '[.[].php_version | select(. == null or . == "")] | length')" -gt 0 ]; then
+    printf '::error::an entry has a missing/empty php_version in %s\n' "$MATRIX_FILE" >&2
     exit 1
   fi
 fi

--- a/tests/shell/read_version_matrix_test_spec.sh
+++ b/tests/shell/read_version_matrix_test_spec.sh
@@ -99,4 +99,26 @@ Describe 'read-version-matrix.sh derived test matrices'
       The stderr should include 'no python versions derived'
     End
   End
+
+  Describe 'fail-closed on a missing/empty php_version'
+    It 'exits non-zero when an entry omits php_version (no [null] matrix leg)'
+      # Given a non-empty matrix whose only entry has NO php_version key
+      # Then the derive fails closed rather than emitting a [null] php matrix leg
+      #      — symmetric with the malformed-py_flavor guard above; a bare length
+      #      check would pass [null] (length 1) straight into test.yml's matrix.
+      json='{"versions":[{"channel":"CE","ci":true,"py_flavor":"py311"}]}'
+      When call run_print_test "$json"
+      The status should be failure
+      The stderr should include 'missing/empty php_version'
+    End
+
+    It 'exits non-zero when an entry has an empty php_version string'
+      # Given an entry whose php_version is the empty string "" (the other invalid
+      # input class) — Then the same fail-closed guard fires.
+      json='{"versions":[{"channel":"CE","ci":true,"php_version":"","py_flavor":"py311"}]}'
+      When call run_print_test "$json"
+      The status should be failure
+      The stderr should include 'missing/empty php_version'
+    End
+  End
 End

--- a/tests/shell/read_version_matrix_test_spec.sh
+++ b/tests/shell/read_version_matrix_test_spec.sh
@@ -1,0 +1,102 @@
+#shellcheck shell=sh
+# read-version-matrix.sh derived test matrices (python_versions / php_versions) —
+# locks the test.yml matrix-derivation: pytest fans out over the DISTINCT pythons
+# mapped from each entry's py_flavor, the PHP jobs over the DISTINCT php_version,
+# both deduped + sorted. Strict supported-only derive (no hardcoded version list).
+#
+# The reader reads its JSON via `git show <ref>:<file>`, so the fixture matrix is
+# committed to a throwaway git repo and addressed with --ref HEAD --file. Each
+# fixture includes a ci:true CE entry so the reader's CI-empty guard is satisfied
+# and the UNFILTERED (CE + Plus) derive path — the one test.yml uses — is exercised.
+
+Describe 'read-version-matrix.sh derived test matrices'
+  READER="${PFB_ROOT}/scripts/read-version-matrix.sh"
+
+  # Build a self-contained git repo holding $1 as supported-versions.json on HEAD,
+  # and echo the repo path. The reader's `git fetch origin ...` is a harmless no-op
+  # there (no remote); `git show HEAD:file` reads the commit. Commit signing is
+  # disabled (-c commit.gpgsign=false) so the spec runs in any environment.
+  make_matrix_repo() {
+    _mm_json="$1"
+    _mm_repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/vermx.XXXXXX")"
+    (
+      cd "$_mm_repo" || exit 1
+      git init -q
+      git config user.email ci@example.invalid
+      git config user.name CI
+      printf '%s\n' "$_mm_json" > supported-versions.json
+      git add supported-versions.json
+      git -c commit.gpgsign=false commit -qm fixture
+    )
+    printf '%s' "$_mm_repo"
+  }
+
+  # Run the reader's --print-test against a fixture-matrix repo, from inside it.
+  # Preserve the reader's exit status across the cleanup so a fail-closed exit is
+  # observable to the caller.
+  run_print_test() {
+    _rt_repo="$(make_matrix_repo "$1")"
+    ( cd "$_rt_repo" && sh "$READER" --ref HEAD --file supported-versions.json --print-test )
+    _rt_status=$?
+    rm -rf "$_rt_repo"
+    return "$_rt_status"
+  }
+
+  Describe 'python_versions derivation (py_flavor -> N.MM)'
+    It 'derives, dedups, and sorts py311,py312,py311 into ["3.11","3.12"]'
+      # Given three entries whose py_flavor is py311, py312, py311 (a duplicate)
+      # When the reader derives python_versions
+      # Then the result is the deduped, sorted distinct set ["3.11","3.12"]
+      #      (3.11 once, despite appearing twice in the input).
+      json='{"versions":[
+        {"channel":"CE","ci":true,"php_version":"8.3","py_flavor":"py311"},
+        {"channel":"CE","ci":true,"php_version":"8.3","py_flavor":"py312"},
+        {"channel":"Plus","ci":false,"php_version":"8.5","py_flavor":"py311"}
+      ]}'
+      When call run_print_test "$json"
+      The status should be success
+      # --print-test prints python_versions first (jq-pretty, one element/line):
+      #   1 python_versions:  2 [  3   "3.11",  4   "3.12"  5 ]
+      The line 3 of output should equal '  "3.11",'
+      The line 4 of output should equal '  "3.12"'
+    End
+
+    It 'maps a single-digit minor flavor py39 to 3.9'
+      # Given an entry whose py_flavor is py39 (single major, single minor digit)
+      # Then it maps to "3.9" (not "3.39" nor "39") — the documented N.MM transform.
+      json='{"versions":[{"channel":"CE","ci":true,"php_version":"8.3","py_flavor":"py39"}]}'
+      When call run_print_test "$json"
+      The status should be success
+      The line 3 of output should equal '  "3.9"'
+    End
+  End
+
+  Describe 'php_versions derivation'
+    It 'dedups and sorts 8.3,8.5,8.3 into ["8.3","8.5"]'
+      # Given entries with php_version 8.3, 8.5, 8.3 (a duplicate)
+      # Then php_versions is the deduped, sorted set ["8.3","8.5"] (8.3 once).
+      json='{"versions":[
+        {"channel":"CE","ci":true,"php_version":"8.3","py_flavor":"py311"},
+        {"channel":"Plus","ci":false,"php_version":"8.5","py_flavor":"py311"},
+        {"channel":"CE","ci":true,"php_version":"8.3","py_flavor":"py312"}
+      ]}'
+      When call run_print_test "$json"
+      The status should be success
+      # python_versions block is lines 1-5 (two distinct pythons), then a blank
+      # line 6, 'php_versions:' line 7, '[' line 8, then the php elements:
+      The line 9 of output should equal '  "8.3",'
+      The line 10 of output should equal '  "8.5"'
+    End
+  End
+
+  Describe 'fail-closed on a malformed py_flavor'
+    It 'exits non-zero when no python version can be derived'
+      # Given a non-empty matrix whose only entry has an unparseable py_flavor
+      # Then the derive fails closed (non-zero) rather than emitting [] silently.
+      json='{"versions":[{"channel":"CE","ci":true,"php_version":"8.3","py_flavor":"python3"}]}'
+      When call run_print_test "$json"
+      The status should be failure
+      The stderr should include 'no python versions derived'
+    End
+  End
+End


### PR DESCRIPTION
## What

Make `test.yml` derive its **pytest** and **PHP** test matrices from the single-source-of-truth
supported-versions matrix (`ci-metadata` orphan branch) instead of hardcoding them.

## Decision — supported-only / strict derive

- **pytest matrix** = the DISTINCT python versions derived from each entry's `py_flavor`
  (`pyN`+`MM` -> `N.MM`) across ALL entries (CE + Plus). Today: **`["3.11"]`**.
- **PHP matrix** = the DISTINCT `php_version` across all entries. Today: **`["8.3","8.5"]`**.

This intentionally:

- **DROPS `3.12` / `3.13` from pytest** — they aren't shipped (pfSense CE 2.8 / FreeBSD 15 is
  `py311`; Plus 26.03 is also `py311`). Only versions the matrix actually ships are tested.
- **ADDS PHP `8.5`** — the Plus 26.03 entry's `php_version`. The four PHP jobs (`php-syntax`,
  `php-static-analysis`, `php-codesniffer`, `php-unit`) now run on **both** 8.3 and 8.5.

No "ahead"/speculative leg is added. Scanner auto-fill of a `python_version` field is **out of
scope** — python is derived from the existing `py_flavor` (no ci-metadata schema edit, no
scanner change, no ADR).

## Changes

- `scripts/read-version-matrix.sh` — two new outputs `python_versions` / `php_versions`
  (derived, deduped, sorted), wired into `--github-output` and a new `--print-test` mode. All
  existing outputs/flags unchanged (backward-compatible).
- `.github/actions/read-version-matrix/action.yml` — exposes the two new outputs.
- `.github/workflows/test.yml` — new `read-matrix` job (checkout + fetch `ci-metadata` +
  action); pytest + the four PHP jobs gain `needs: read-matrix` and a `fromJSON`-fed matrix;
  `all-tests-passed` folds in `read-matrix` (fail-closed).
- `tests/shell/read_version_matrix_test_spec.sh` — shellspec coverage for the derive (dedup +
  sort, `py39`->`3.9` edge, fail-closed on malformed `py_flavor`).
- `scripts/README.md` — documents the two new outputs + that `test.yml` now derives from them.

## Branch protection — design is config-free on version bumps

The point of this change is that **adding/dropping a pfSense version on `ci-metadata` requires
no edit anywhere** — the matrix derives the legs, and the stable `All tests passed` aggregate
job folds every leg's result (a matrix job's aggregate `.result` is success only if all legs
pass), so the **single required check name never changes**.

That only holds if branch protection requires **only** `All tests passed`. The four PHP jobs
are now matrixed, so their per-leg check names include the version (e.g.
`PHPUnit unit tests / PHP 8.3`) and the old fixed names (`PHPUnit unit tests`,
`PHPStan static analysis`, `PHPCS PFBL-01 RequirePfbFilter sniff`, `PHP syntax check (php -l)`)
stop reporting. **One-time cleanup for the maintainer:** confirm `All tests passed` is the sole
required status check and drop any individually-pinned `php-*` / `pytest` checks. After that,
no per-version edits to branch protection are ever needed. (pytest's job name is unchanged,
`pytest / Python 3.11`; a new `Read supported-version matrix` check also appears.)

## 8.5 — intended signal, not suppressed

`composer.json` has **no `php` platform constraint / `config.platform.php` pin**, so
`composer install` won't hard-block on 8.5. The 8.5 legs may newly surface a transitive
composer/tooling gap (PHP 8.5 is bleeding-edge; `shivammathur/setup-php` provides it as a
nightly). That exposure is the intended outcome — **not** hacked around here. The PR's own CI
is the real validation of the workflow wiring (workflows can't run locally).

## Validation (local)

- `sh -n` + `shellcheck --severity=info` on the reader + spec: clean.
- New shellspec spec + full shellspec suite: 47 examples, 0 failures.
- `python -m pytest`: 1480 passed (unaffected).
- `markdownlint-cli2 scripts/README.md`: 0 errors.
- `actionlint .github/workflows/test.yml`: clean.

https://claude.ai/code/session_01VUXzg5SHmXuFSkaXdWKGFo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Test workflows now dynamically derive supported Python and PHP versions for automated testing instead of using hardcoded values.

* **Documentation**
  * Updated version matrix configuration documentation.

* **Tests**
  * Added comprehensive test coverage for version matrix derivation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->