### PR TITLE
ci: fix repo-install nightly gate — gh can't resolve repo without a checkout

### DIFF
--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -53,6 +53,11 @@ jobs:
       - id: check
         env:
           GH_TOKEN: ${{ github.token }}
+          # This gate has no checkout, so gh can't infer the repo from a git remote.
+          # A runner-image gh bump (~2026-06) dropped the GITHUB_REPOSITORY fallback,
+          # so `gh run list` started failing ("failed to determine base repo"). Pin the
+          # repo explicitly to keep the gate checkout-free.
+          GH_REPO: ${{ github.repository }}
         run: |
           set -eu
           if [ "${{ github.event_name }}" != "schedule" ]; then


### PR DESCRIPTION
## Symptom

The **Repo install (ADR-17, live pfSense VM)** nightly (`repo-install.yml`) has failed every day **since 2026-06-06** (last green 06-05). Every failure is the same first job, `Gate (skip nightly if devel unchanged)`:

```text
failed to determine base repo: failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

## Root cause — runner-image `gh` regression, not our code

The gate job intentionally has **no `actions/checkout`** (it only needs to query the API), and runs:

```sh
since="$(gh run list --workflow=repo-install.yml --branch=... --status=success ...)"
```

`gh run list` resolves its target repo from the git remote of a checkout. With no checkout it historically fell back to `$GITHUB_REPOSITORY`, but a runner-image `gh` bump around 2026-06 (the image went to `ubuntu-24.04 20260607.184`) **dropped that fallback**, so `gh run list` now errors with "failed to determine base repo". The neighbouring `gh api "repos/${{ github.repository }}/commits..."` call uses an explicit path and was unaffected — which is why only the `gh run list` line failed.

## Fix

Pin the repo explicitly via the `GH_REPO` env var on the gate step (one line), keeping the job checkout-free:

```yaml
env:
  GH_TOKEN: ${{ github.token }}
  GH_REPO: ${{ github.repository }}
```

`gh run list` now resolves the repo from `GH_REPO`; the `gh api` call is unchanged.

## Scope / validation

- `repo-install.yml` is the **only** workflow using `gh run list`, and the only checkout-free `gh` gate — verified by grep — so this is the complete fix, not a one-off patch.
- YAML validates; the change is 5 lines (the env line + a comment explaining the regression).
- This is a `schedule`-gated nightly, so the real proof is the next scheduled run (or a `workflow_dispatch`) going green; `workflow_dispatch`/`push` events bypass the gate's `gh` path entirely (the `if event != schedule` early-return), so they were never affected.

https://claude.ai/code/session_01VUXzg5SHmXuFSkaXdWKGFo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUXzg5SHmXuFSkaXdWKGFo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with the scheduled workflow that was causing failures due to runner environment changes, ensuring continuous integration checks run reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->