### PR TITLE
ci: make repo-install gate fail-open on gh errors

### DIFF
--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -70,15 +70,22 @@ jobs:
           # out unvalidated, since the anchor only advances when a run actually
           # succeeded. (A skip-run also "succeeds", but harmlessly — it only happens
           # when nothing changed.) No prior success (first run) -> run unconditionally.
+          # Fail-open: any gh hiccup (a transient API error, a future CLI change like the
+          # 2026-06 base-repo regression) yields an empty value, which the next check
+          # treats as "run" — a skip-optimisation gate must never be the thing that reds
+          # the nightly.
           since="$(gh run list --workflow=repo-install.yml --branch="${{ github.ref_name }}" \
-                     --status=success --limit 1 --json createdAt --jq '.[0].createdAt // ""')"
+                     --status=success --limit 1 --json createdAt --jq '.[0].createdAt // ""' 2>/dev/null || true)"
           if [ -z "$since" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "No prior successful run — running (bootstrap)."
+            echo "No prior successful run (or gh unavailable) — running."
             exit 0
           fi
-          n="$(gh api "repos/${{ github.repository }}/commits?sha=${{ github.ref_name }}&since=${since}" --jq 'length')"
-          if [ "${n:-0}" -gt 0 ]; then
+          n="$(gh api "repos/${{ github.repository }}/commits?sha=${{ github.ref_name }}&since=${since}" --jq 'length' 2>/dev/null || true)"
+          if [ -z "$n" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not count commits since ${since} (gh api failed) — running to be safe."
+          elif [ "$n" -gt 0 ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             echo "${n} commit(s) to ${{ github.ref_name }} since the last successful run (${since}) — running."
           else


### PR DESCRIPTION
## Why

Follow-up to #191. That PR fixed the immediate cause (a runner-image `gh` bump that broke `gh run list` repo resolution). This hardens the **`gate` job** so the *class* of failure can't recur: the gate is a **skip-optimisation**, not a correctness check, so a transient `gh` hiccup should make the nightly **run**, never **fail** (or silently skip).

The gate runs under `bash -e`, so any non-zero `gh` exit aborts the job — which is exactly how #191's bug surfaced as a red nightly for ~6 days.

## Change

Both `gh` calls in the gate now **fail-open**:

- `gh run list … 2>/dev/null || true` → on failure, `since` is empty → the existing *"no prior run → run"* branch fires.
- `gh api …/commits 2>/dev/null || true` → on failure, `n` is empty → a new branch runs (with a `::warning::`) instead of the old `${n:-0}` → `0` → **skip** (which was fail-*closed* — a gh error would have silently skipped the nightly).

Net behaviour (verified by simulating all four branches under `bash -e`):

| Situation | Before | After |
|---|---|---|
| `gh run list` errors | **job fails** (red nightly) | RUN (fail-open) |
| `gh api` (commit count) errors | SKIP (silent) | RUN + warning |
| commits since last success > 0 | RUN | RUN |
| no commits since last success | SKIP | SKIP |

The #191 `GH_REPO` fix stays — that makes the gate *resolve correctly* when gh is healthy; this makes it *degrade safely* when gh isn't. Worst case of the fail-open is one ~5-min VM run when nothing changed, which is the correct trade for a skip gate.

## Validation

- YAML validates; `shellcheck` clean (pre-commit).
- All four gate branches simulated under `bash -e` (gh-list fail → RUN, gh-api fail → RUN, N>0 → RUN, N=0 → SKIP).
- As with #191, the gate's `gh` path only runs on `schedule`, so the live proof is the next nightly; `workflow_dispatch` bypasses it.

https://claude.ai/code/session_01VUXzg5SHmXuFSkaXdWKGFo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUXzg5SHmXuFSkaXdWKGFo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the scheduled workflow's reliability by implementing fail-open logic for temporary API failures, ensuring nightly repository-install tests proceed without interruption even when transient issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->