### PR TITLE
ADR-24: pfSense Plus in the CI smoke fan-out (Phases 1–3, plumbing)

### DIFF
--- a/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/01_Results.txt
@@ -1,0 +1,88 @@
+ADR-24 — Phase 1 Results
+========================
+Harness parameterization: SMOKE_VM_MAC override (CE default), behaviour-preserving.
+
+Branch: adr/24-pfsense-plus-in-the-ci-smoke
+
+WHAT CHANGED
+------------
+1. tests/smoke/boot_vm.sh
+   - VM_MAC assignment is now the env-override form (exact new line):
+
+         VM_MAC="${SMOKE_VM_MAC:-BC:24:11:37:9C:AC}"
+
+     With SMOKE_VM_MAC unset the expansion yields the CE pin BC:24:11:37:9C:AC,
+     so the default path is byte-identical to pre-ADR-24 (contract §2.2.1).
+   - Header hardware-profile comment block extended: MAC is per-image, CE pin by
+     default, SMOKE_VM_MAC overrides; a pfSense Plus image MUST set SMOKE_VM_MAC
+     to its OWN source-VM MAC because the Plus license/NDI registration is keyed
+     to it (the CE pin would deregister/reassign). Cross-ref ADR-24 +
+     scripts/README.md § "pfSense Plus images".
+   - No other QEMU argument changed; the MAC still feeds the single plumb point
+     -device virtio-net-pci,mac=${VM_MAC},...
+
+2. tests/test_smoke_harness_defaults.py  (NEW — harness-side, NOT under tests/smoke/)
+   - test_ce_default_mac_pin_present: regression pin — the CE source-VM MAC
+     string is present in boot_vm.sh (guards against drift; it legitimately
+     appears twice — header comment + assignment default — so asserts presence,
+     not a count).
+   - test_vm_mac_is_env_override_with_ce_default: asserts the assignment is the
+     override form VM_MAC="${SMOKE_VM_MAC:-BC:24:11:37:9C:AC}" exactly.
+   - Both override branches are covered: CE (env unset -> pin) by the default
+     string assertion; Plus (env set -> override) by the override-form assertion.
+   - Fully typed (-> None), mypy clean under disallow_untyped_defs.
+
+conftest.py — NO CHANGE NEEDED (and why)
+----------------------------------------
+boot_vm.sh is invoked at tests/smoke/conftest.py:226 via
+    subprocess.Popen(["sh", str(BOOT_VM_SH), str(base_image)], stdout=..., stderr=...)
+with NO env= keyword. subprocess.Popen with env=None inherits the parent's full
+os.environ, so SMOKE_VM_MAC already propagates from the pytest process into the
+boot_vm.sh subprocess unchanged. No filtered/constructed env is built for that
+call. Per the Phase-1 plan step 3, changed nothing in conftest.py and recorded it
+here.
+
+RED -> GREEN EVIDENCE
+---------------------
+Method: temporarily reverted the boot_vm.sh assignment line to the pre-change
+hardcoded form (VM_MAC="BC:24:11:37:9C:AC"), ran the new tests, then restored.
+
+RED (pre-change assignment, header comment already updated):
+    test_vm_mac_is_env_override_with_ce_default  FAILED  (assertion b — override form absent)
+    test_ce_default_mac_pin_present              PASSED  (assertion a — pin still present)
+    => 1 failed, 1 passed
+
+GREEN (assignment restored to the override form):
+    test_ce_default_mac_pin_present              PASSED
+    test_vm_mac_is_env_override_with_ce_default  PASSED
+    => 2 passed
+
+So green proves the override-form change caused the flip; the regression-pin
+assertion (a) passed in both states, confirming the CE pin is never dropped.
+
+VERIFICATION GATES (all green/clean)
+------------------------------------
+- python -m pytest          -> 1482 passed
+- ruff check .              -> All checks passed!
+- ruff format --check .     -> 89 files already formatted
+- mypy tests/               -> Success: no issues found in 32 source files
+- sh -n tests/smoke/boot_vm.sh   -> OK
+- shellcheck                -> NOT installed in this environment (reported-and-
+                               skipped; CI is the hard gate). sh -n passed.
+- git diff origin/devel...HEAD scope: ONLY the two files above
+  (tests/smoke/boot_vm.sh, tests/test_smoke_harness_defaults.py) — conftest.py
+  untouched, image-upgrade.sh untouched.
+
+CONTRACT CHECK (§2.2)
+---------------------
+- §2.2.1 CE bit-identical with SMOKE_VM_MAC unset: YES — expansion default is the
+  CE pin; no other QEMU arg touched.
+- §4.1 acceptance (boot_vm.sh boots with SMOKE_VM_MAC when set, CE pin otherwise):
+  satisfied by the override form + verified env propagation.
+- image-upgrade.sh --mac default unchanged (out of scope this phase): untouched.
+
+GO-AHEAD FOR PHASE 2
+--------------------
+Cleared. Phase 2 = read-version-matrix.sh CI filter -> select(.ci == true),
+emit image_name (default pfsense-ce) + mac (default BC:24:11:37:9C:AC) per
+CI-matrix entry, with red-first fixture tests. No blockers from Phase 1.

--- a/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/02_Results.txt
@@ -1,0 +1,152 @@
+ADR-24 — Phase 2 Results
+========================
+Matrix reader: CI filter -> ci-only (any channel) + per-entry image_name/mac.
+Behaviour-preserving for the live matrix (Plus is still ci:false -> excluded).
+
+Branch: adr/24-pfsense-plus-in-the-ci-smoke
+
+WHAT CHANGED
+------------
+1. scripts/read-version-matrix.sh
+   - CI-matrix jq filter: channel no longer filters; each ci:true entry gains
+     resolved image_name + mac. New jq (the operative change):
+
+         CI_MATRIX="$(printf '%s' "$BUILD_MATRIX" | jq -c '
+           [ .[]
+             | select(.ci == true)
+             | . + { image_name: (.image_name // "pfsense-ce"), mac: (.mac // "BC:24:11:37:9C:AC") }
+           ]')"
+
+     Old filter was: [.[] | select(.ci == true and .channel == "CE")]
+   - Header "Outputs" comment for the CI matrix rewritten: "the ci:true entries
+     (ANY channel)", documenting the image_name (default pfsense-ce) + mac
+     (default the CE pin BC:24:11:37:9C:AC) resolution and that an entry omitting
+     them keeps the CE image+MAC while a Plus entry carries its own.
+   - The empty-CI guard's skip-on-plus comment reworded for the new reality (the
+     skip still fires only for --variant plus; logic unchanged — a Plus-only
+     filtered set may legitimately be empty while live Plus is ci:false).
+   - jq is `. + {…}` MERGE: an explicit image_name/mac in the JSON wins (the //
+     default only fills a null/absent field), so explicit values pass through
+     verbatim. BUILD-matrix jq + python_versions/php_versions jq UNTOUCHED.
+
+2. tests/test_read_version_matrix.py (NEW — script-driving, subprocess, temp git
+   repo fixture; module-skips if git/jq absent)
+   Scenarios:
+   a. test_ci_matrix_excludes_plus_entry_with_ci_false   — ci:false Plus EXCLUDED
+      (§2.2.3). Passes today (regression pin).
+   b. test_ci_matrix_includes_plus_entry_with_ci_true    — ci:true Plus INCLUDED
+      (channel no longer filters). RED today.
+   c. test_ci_matrix_entries_default_image_name_and_mac  — CE entry omitting the
+      fields resolves image_name=pfsense-ce, mac=BC:24:11:37:9C:AC. RED today.
+   d. test_ci_matrix_entries_pass_through_explicit_image_name_and_mac — explicit
+      pfsense-plus / BC:24:11:9C:FE:85 emitted verbatim. RED today.
+   e. test_build_and_test_matrices_unchanged_by_new_fields — BUILD matrix is the
+      verbatim versions array (no image_name/mac injected on the CE build entry),
+      python_versions==["3.11"], php_versions==["8.3","8.5"] (§2.2.6). Pin.
+
+COMPOSITE ACTION — NO CHANGE NEEDED (and why)
+---------------------------------------------
+.github/actions/read-version-matrix/action.yml invokes the script with
+--github-output and passes ci_matrix THROUGH OPAQUELY as a heredoc-delimited JSON
+string ($GITHUB_OUTPUT). It does not enumerate or name per-entry fields — the new
+image_name/mac ride inside the same JSON blob untouched. Its `outputs.ci_matrix`
+description still says "ci:true CE entries only"; that wording reconciliation is
+Phase 5 (docs), out of scope here. No functional change required -> left untouched.
+
+RED -> GREEN EVIDENCE
+---------------------
+RED (unmodified script, new test file):
+    test_ci_matrix_excludes_plus_entry_with_ci_false              PASSED
+    test_ci_matrix_includes_plus_entry_with_ci_true               FAILED
+    test_ci_matrix_entries_default_image_name_and_mac             FAILED
+    test_ci_matrix_entries_pass_through_explicit_image_name_and_mac FAILED
+    test_build_and_test_matrices_unchanged_by_new_fields          PASSED
+    => 3 failed, 2 passed
+  Failure shapes:
+    - b: ci_matrix had channels=={"CE"} only (old `.channel=="CE"` dropped Plus).
+    - c: KeyError/assert — entry had no image_name/mac key.
+    - d: script EXITED rc=1 "CI matrix is empty — no ci:true CE entries" (the
+      Plus-only fixture's sole entry was dropped by the CE filter -> empty CI
+      matrix -> the non-empty guard fired). Proves the channel filter was the gate.
+
+GREEN (modified script):
+    all 5 PASSED.
+
+So green proves the filter/merge change caused each flip; the two pins (a, e) held
+in both states -> the ci:false exclusion and the build/test matrices are untouched.
+
+LIVE-MATRIX BEFORE/AFTER (real origin/ci-metadata, default ref)
+---------------------------------------------------------------
+`git fetch origin ci-metadata` then `sh scripts/read-version-matrix.sh --print-ci`.
+Live Plus entry is still ci:false -> excluded both before and after. The CI-matrix
+LEG SET is unchanged (the single CE 2.8 entry); AFTER additionally carries the
+resolved image_name/mac, which for CE are exactly today's CE values (§2.2.1).
+
+BEFORE (unmodified script — script stashed, real matrix):
+    [
+      {
+        "pfsense_version": "2.8",
+        "channel": "CE",
+        "freebsd_version": "15.0-RELEASE",
+        "freebsd_major": "15",
+        "php_version": "8.3",
+        "py_flavor": "py311",
+        "variant": "CE",
+        "status": "active",
+        "ci": true
+      }
+    ]
+
+AFTER (modified script, real matrix):
+    [
+      {
+        "pfsense_version": "2.8",
+        "channel": "CE",
+        "freebsd_version": "15.0-RELEASE",
+        "freebsd_major": "15",
+        "php_version": "8.3",
+        "py_flavor": "py311",
+        "variant": "CE",
+        "status": "active",
+        "ci": true,
+        "image_name": "pfsense-ce",
+        "mac": "BC:24:11:37:9C:AC"
+      }
+    ]
+
+Same single CE leg; the only delta is the two resolved fields holding the CE
+defaults (image pfsense-ce, CE MAC pin). No Plus leg appears because live Plus is
+ci:false — the §2.2.3 exclusion still holds. When Phase 4 flips Plus to ci:true on
+ci-metadata, this same script will then emit a second (Plus) leg with its own
+image_name/mac; today it does not.
+
+VERIFICATION GATES (all green/clean)
+------------------------------------
+- python -m pytest          -> 1487 passed
+- ruff check .              -> All checks passed!
+- ruff format --check .     -> 90 files already formatted (test file formatted)
+- mypy tests/               -> Success: no issues found in 33 source files
+- sh -n scripts/read-version-matrix.sh -> OK
+- shellcheck                -> NOT installed in this environment (reported-and-
+                               skipped; CI is the hard gate). sh -n passed.
+- git diff scope: ONLY scripts/read-version-matrix.sh + the new test file.
+  Composite action untouched. README untouched (Phase 5).
+
+CONTRACT CHECK (§2.2)
+---------------------
+- §2.2.1 CE bit-identical: the CE leg SET is unchanged; the added image_name/mac
+  resolve to the CE defaults — no composed-ref/QEMU input changes for a CE entry
+  that omits the fields. (Workflow consumption of the fields is Phase 3.)
+- §2.2.3 ci:false still excludes: scenario a + the live before/after both confirm
+  the ci:false Plus entry never enters the CI matrix.
+- §2.2.6 build matrix untouched: scenario e + the BUILD-matrix jq is byte-for-byte
+  unchanged; python_versions/php_versions jq unchanged.
+
+GO-AHEAD FOR PHASE 3
+--------------------
+Cleared. CI matrix now = all ci:true entries, each with resolved image_name/mac;
+live output's leg set unchanged. Phase 3 = smoke.yml gains image_name/mac inputs
+(ref composition + SMOKE_VM_MAC export) and smoke-fanout.yml's PLUS GUARD becomes a
+CI GUARD (ci != true only), passing matrix.image_name/matrix.mac + channel-named
+legs. No blockers from Phase 2. The composite action's ci_matrix output description
+("CE entries only") is a Phase 5 doc reconciliation, not a code gap.

--- a/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/03_Results.txt
@@ -1,0 +1,199 @@
+ADR-24 — Phase 3 Results
+========================
+Workflows: route per-leg image_name + MAC through smoke.yml / smoke-fanout.yml.
+Behaviour-preserving pre-flip: with the live matrix (Plus ci:false → excluded)
+and default inputs, every resolved GHCR ref and QEMU MAC is byte-identical to
+today.
+
+Branch: adr/24-pfsense-plus-in-the-ci-smoke
+
+NOTE ON WORKING STATE
+---------------------
+On pick-up the two workflow files already carried the Phase-3 edits in the
+worktree (uncommitted — a prior session applied them but did not commit). They
+were verified line-by-line against the ACTION PLAN (all correct, no deviation),
+the gates were re-run, and this phase committed them together with this handoff.
+No further edits to the YAML were required.
+
+WHAT CHANGED (only the two workflow files)
+------------------------------------------
+1. .github/workflows/smoke.yml
+   - INPUTS (added to BOTH workflow_dispatch AND workflow_call):
+       image_name  (string, default "pfsense-ce")
+       mac         (string, default "BC:24:11:37:9C:AC")  ← the CE pin
+     Each carries a help description noting the fan-out passes the per-leg
+     matrix.image_name / matrix.mac (Plus = pfsense-plus / BC:24:11:9C:FE:85),
+     and that image_name is ignored when image_ref is set.
+   - RESOLVE-REF step ("Resolve the pfSense image ref"):
+       new env  INPUT_IMAGE_NAME: ${{ inputs.image_name }}
+       NAME line changed from
+           NAME="${SMOKE_IMAGE_NAME:-pfsense-ce}"
+       to
+           NAME="${INPUT_IMAGE_NAME:-${SMOKE_IMAGE_NAME:-pfsense-ce}}"
+       → the per-leg input wins over the repo variable; both default to
+         pfsense-ce, so a bare dispatch is unchanged. image_ref override path
+         untouched; TAG line untouched.
+   - PYTEST step env: added
+           SMOKE_VM_MAC: ${{ inputs.mac }}
+     This is the point where the MAC joins the harness (conftest → boot_vm.sh,
+     Phase 1). Default = the CE pin, so a bare dispatch is byte-identical;
+     boot_vm.sh keeps the same CE default if SMOKE_VM_MAC is unset.
+
+2. .github/workflows/smoke-fanout.yml
+   - HEADER + INVARIANT box rewritten: now "runs every ci:true entry, CE and
+     Plus; the Plus image is private (Netgate-licensed) — pulled, never
+     published"; the "NEVER runs Plus" / "channel != CE" language removed.
+     Workflow `name:` updated to "Smoke Fan-out (all ci:true legs, ADR-09 P6 /
+     ADR-24)". The NEVER-commits-to-a-branch invariant is preserved verbatim.
+   - prepare job, "Count legs" step: PLUS GUARD → CI GUARD.
+       Old: select(.channel != "CE" or .ci != true)   → PLUS_COUNT, abort if !=0
+       New: select(.ci != true)                        → BAD_COUNT,  abort if !=0
+     The CHANNEL ASSERTION IS REMOVED; only ci != true now aborts. Still a hard
+     fail-safe (matrix reader already filters to ci:true; this catches a schema
+     change leaking a ci:false entry). Log/echo strings reworded accordingly.
+   - smoke job:
+       name: "Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }})"
+       with: + image_name: ${{ matrix.image_name }}
+             + mac:        ${{ matrix.mac }}
+       (pfsense_version pass-through + secrets: inherit unchanged.)
+   - AND-gate (all-smoke-passed) untouched.
+
+CONSTRAINTS HONOURED
+--------------------
+- Touched ONLY smoke.yml + smoke-fanout.yml (git diff scope confirmed below).
+- image-refresh.yml / build-image.yml / repo-install.yml NOT touched (CE-only by
+  design, ADR §2.3).
+- secrets: inherit retained; no new secret introduced (GHCR auth still falls back
+  to GITHUB_TOKEN via the existing SMOKE_GHCR_* expression).
+- Default-path behaviour byte-identical (§2.2.1) — see the CE trace below.
+
+YAML VALIDATION
+---------------
+actionlint: NOT installed in this environment.
+yamllint:   NOT installed.
+Fallback (per orchestrator note): python3 -c "import yaml; yaml.safe_load(open(f))"
+on each changed workflow.
+  OK: .github/workflows/smoke.yml
+  OK: .github/workflows/smoke-fanout.yml
+Both parse cleanly. (actionlint remains the CI-side gate; static structural parse
+is the strongest check available locally.)
+
+REF + MAC RESOLUTION TRACE (on paper — §4.6 evidence in lieu of a live dispatch)
+--------------------------------------------------------------------------------
+Live-dispatch deferred (see DEFERRED below); the composition is traced by hand.
+Assume the repo variable SMOKE_IMAGE_REPO = ghcr.io/pfblockerng (its current
+value), SMOKE_IMAGE_NAME unset, SMOKE_IMAGE_TAG unset (defaults), image_ref blank.
+
+A) CE matrix entry (today's live entry — Phase 2 AFTER output):
+     pfsense_version="2.8", image_name="pfsense-ce", mac="BC:24:11:37:9C:AC"
+   fan-out passes to smoke.yml:
+     pfsense_version=2.8  image_name=pfsense-ce  mac=BC:24:11:37:9C:AC
+   smoke.yml resolve-ref:
+     image_ref blank → compose branch
+     REPO = ghcr.io/pfblockerng
+     NAME = INPUT_IMAGE_NAME("pfsense-ce") wins → "pfsense-ce"
+     TAG  = INPUT_VERSION("2.8")                → "2.8"
+     REF  = ghcr.io/pfblockerng/pfsense-ce:2.8
+   pytest env: SMOKE_VM_MAC = BC:24:11:37:9C:AC  → boot_vm.sh -netdev … mac=BC:24:11:37:9C:AC
+   ⇒ IDENTICAL to today (pre-change: NAME defaulted to pfsense-ce, SMOKE_VM_MAC
+     was unset → boot_vm.sh fell back to the same CE pin). Byte-identical. ✔
+
+A') Bare smoke.yml dispatch (no inputs at all):
+     image_name input default = "pfsense-ce", mac input default = "BC:24:11:37:9C:AC"
+     NAME = pfsense-ce, TAG = 2.8 → REF = ghcr.io/pfblockerng/pfsense-ce:2.8
+     SMOKE_VM_MAC = BC:24:11:37:9C:AC
+   ⇒ Same ref + same MAC as a pre-change bare dispatch. ✔ (§2.2.1)
+
+B) Plus matrix entry (Phase 4 will introduce this on ci-metadata; NOT live today):
+     pfsense_version="26.03", image_name="pfsense-plus", mac="BC:24:11:9C:FE:85",
+     channel="Plus", ci=true
+   fan-out passes to smoke.yml:
+     pfsense_version=26.03  image_name=pfsense-plus  mac=BC:24:11:9C:FE:85
+   smoke.yml resolve-ref:
+     REPO = ghcr.io/pfblockerng
+     NAME = pfsense-plus
+     TAG  = 26.03
+     REF  = ghcr.io/pfblockerng/pfsense-plus:26.03   (private, pulled not published)
+   pytest env: SMOKE_VM_MAC = BC:24:11:9C:FE:85 → boot_vm.sh boots the Plus VM with
+     its license-keyed NIC MAC.
+   leg name in the UI: "Smoke (Plus 26.03)".
+   ⇒ A Plus entry, once ci:true, routes its own private image + license MAC
+     end-to-end. Does NOT appear today (live Plus is ci:false → excluded by the
+     matrix reader, and the CI GUARD would also catch a ci:false leak).
+
+GUARD DIFF (PLUS GUARD → CI GUARD)
+----------------------------------
+- jq select  : `.channel != "CE" or .ci != true`   →   `.ci != true`
+- var name    : PLUS_COUNT → BAD_COUNT
+- error msg   : "PLUS GUARD: … non-CE or ci:false …" → "CI GUARD: … ci:false …"
+- pass msg    : "all … CE ci:true." → "all … ci:true."
+Net: the channel half of the predicate is gone; the ci:true requirement is the
+sole gate. A Plus entry (channel="Plus", ci=true) now PASSES the guard (it would
+have aborted under the old PLUS GUARD); a ci:false entry of any channel still
+aborts. This is the behavioural flip that lets Plus into the fan-out once Phase 4
+sets its ci:true on ci-metadata.
+
+VERIFICATION GATES (all green)
+------------------------------
+- python -m pytest      → 1487 passed in ~9.5s
+- ruff check .          → All checks passed!
+- ruff format --check . → 90 files already formatted
+- mypy tests/           → Success: no issues found in 33 source files
+- YAML safe_load        → both workflows OK
+- git diff origin/devel...HEAD scope: ONLY the two workflow files beyond the
+  prior-phase artifacts (read-version-matrix.sh, boot_vm.sh, conftest passthrough,
+  the new tests, and the RESULTS files). No src/ touched. No other workflow touched.
+  (The Python gates are unaffected by this YAML-only phase — they run as a sanity
+  pin, exactly as the prompt requires.)
+
+DEFERRED — live CE-only fan-out dispatch (§4.6 acceptance pin)
+--------------------------------------------------------------
+The §4.6 "live CE-only fan-out run, refs identical to a pre-change run (record
+both run ids)" and the bare smoke.yml dispatch CANNOT run in this environment: no
+gh / workflow-dispatch credentials, and the YAML changes live on the feature
+branch (workflow_dispatch is only dispatchable from the default branch / once the
+branch is on devel). Per the orchestrator note this is a known constraint, not a
+phase failure. It is replaced here by static YAML validation + the on-paper ref/
+MAC trace above (CE byte-identical; Plus routes its own image+MAC).
+
+  DEFERRED MAINTAINER STEP (do once the branch reaches devel, BEFORE the Phase-4
+  flip lands Plus ci:true):
+    1. Dispatch smoke-fanout.yml (matrix still CE-only — Plus still ci:false).
+       Expect: one leg "Smoke (CE 2.8)", resolved ref
+       ghcr.io/pfblockerng/pfsense-ce:2.8, AND-gate green. Record the run id.
+    2. Dispatch a bare smoke.yml (no inputs). Expect the identical ref. Record id.
+    3. Compare the resolved-ref log lines to a pre-ADR-24 fan-out run — they MUST
+       be identical (this is the live regression pin the trace stands in for).
+
+COMMIT
+------
+Single commit (the two workflow files + this handoff):
+    ci: route per-leg image_name + MAC through smoke fan-out (ADR-24 P3)
+Pushed directly to adr/24-pfsense-plus-in-the-ci-smoke.
+
+GO-AHEAD FOR PHASE 4
+--------------------
+Cleared. The harness (P1) + matrix reader (P2) + workflows (P3) now carry
+image_name/mac end-to-end; the guard is keyed purely on ci:true. Flipping the
+live Plus entry to ci:true on ci-metadata is now sufficient to add the Plus leg —
+no further workflow YAML edits needed.
+
+Phase-4 PRECONDITION CHECKLIST (maintainer/manual — ADR §6 Phase 4). State as
+observable from THIS environment: NONE can be verified here (no GHCR/registry
+access, no Proxmox access, no gh). These are for the orchestrator/maintainer to
+confirm before dispatching the live flip:
+  [ ] ghcr.io/pfblockerng/pfsense-plus:26.03 published (from Proxmox VM 104) and
+      marked PRIVATE.                                            — UNVERIFIED here
+  [ ] The package grants THIS repo read access (so the fan-out's GITHUB_TOKEN /
+      SMOKE_GHCR_* can pull it).                                 — UNVERIFIED here
+  [ ] Plus image has baked deps (FreeBSD-16 RUN_DEPENDS) + the smoke SSH public
+      key in root authorized_keys.                               — UNVERIFIED here
+  [ ] Diagnostics scrub verified for the Plus license (no NDI / license
+      identifier in the smoke-diagnostics artifact — §4.7).      — UNVERIFIED here
+Once all four hold, Phase 4 opens a PR against ci-metadata (Plus entry ci:true +
+image_name: pfsense-plus + mac: BC:24:11:9C:FE:85; schema gains the two optional
+fields; lifecycle_policy.plus text rewritten), then dispatches smoke-fanout.yml
+and verifies both legs + the AND-gate green and the Plus-leg diagnostics carry no
+license identifier.
+
+NO DEVIATIONS. NO STOP CONDITIONS HIT.

--- a/.github/workflows/smoke-fanout.yml
+++ b/.github/workflows/smoke-fanout.yml
@@ -68,9 +68,11 @@ jobs:
         uses: ./.github/actions/read-version-matrix
 
       - name: Log CI matrix
+        env:
+          CI_MATRIX: ${{ steps.read.outputs.ci_matrix }}
         run: |
           echo "=== CI matrix (ci:true entries, CE + Plus — fed to smoke strategy.matrix) ==="
-          printf '%s\n' '${{ steps.read.outputs.ci_matrix }}' | jq .
+          printf '%s\n' "$CI_MATRIX" | jq .
 
       - name: Count legs + assert every leg is ci:true
         id: count

--- a/.github/workflows/smoke-fanout.yml
+++ b/.github/workflows/smoke-fanout.yml
@@ -1,8 +1,10 @@
-name: Smoke Fan-out (all CE, ADR-09 P6)
+name: Smoke Fan-out (all ci:true legs, ADR-09 P6 / ADR-24)
 
-# Fan the ADR-04 smoke suite across every ci:true CE image in parallel.
-# NEVER runs Plus images (ci:false entries are excluded by the CI matrix filter;
-# an additional guard below aborts any leg that carries channel != CE or ci != true).
+# Fan the ADR-04 smoke suite across every ci:true image in parallel — CE and
+# Plus alike (ADR-24). Each leg carries its own image_name + mac from the matrix;
+# the Plus image is private (Netgate-licensed) — CI pulls it, never publishes it.
+# ci:false entries are excluded by the CI matrix filter; a CI GUARD below aborts
+# any leg that carries ci != true (a schema-change fail-safe).
 #
 # Workflow name + no-version-input dispatch contract (Phase 4 / RESULTS/04):
 #   Workflow file name:  .github/workflows/smoke-fanout.yml
@@ -22,8 +24,10 @@ name: Smoke Fan-out (all CE, ADR-09 P6)
 #
 # ┌─────────────────────────────────────────────────────────────────────┐
 # │ INVARIANT: this workflow NEVER commits to or writes any branch.     │
-# │ Plus is NEVER run (ci:false entries are excluded at the matrix     │
-# │ read step and double-guarded in the smoke job itself).             │
+# │ Runs every ci:true entry, CE and Plus; the Plus image is private — │
+# │ pulled, never published (no push/re-tag/attach of the qcow2).      │
+# │ ci:false entries are excluded at the matrix read step and the CI   │
+# │ GUARD below hard-fails any ci != true leak.                        │
 # └─────────────────────────────────────────────────────────────────────┘
 
 on:
@@ -43,11 +47,11 @@ permissions:
   packages: read
 
 jobs:
-  # ── 1. Read CI matrix (ci:true CE entries only) ──────────────────────────────
+  # ── 1. Read CI matrix (every ci:true entry, CE and Plus) ─────────────────────
   #
   # Emits `ci_matrix` (JSON array) as the `include` list for the smoke job's
-  # strategy.matrix.  The reader already filters to ci:true CE entries; Plus
-  # entries (ci:false) are NEVER present in ci_matrix.
+  # strategy.matrix.  The reader filters to ci:true entries of ANY channel, each
+  # carrying its resolved image_name + mac; ci:false entries are NEVER present.
   prepare:
     name: Read CI matrix
     runs-on: ubuntu-latest
@@ -65,10 +69,10 @@ jobs:
 
       - name: Log CI matrix
         run: |
-          echo "=== CI matrix (ci:true CE entries — fed to smoke strategy.matrix) ==="
+          echo "=== CI matrix (ci:true entries, CE + Plus — fed to smoke strategy.matrix) ==="
           printf '%s\n' '${{ steps.read.outputs.ci_matrix }}' | jq .
 
-      - name: Count legs + assert no Plus entries
+      - name: Count legs + assert every leg is ci:true
         id: count
         env:
           CI_MATRIX: ${{ steps.read.outputs.ci_matrix }}
@@ -78,21 +82,23 @@ jobs:
           echo "leg_count=${COUNT}" >> "$GITHUB_OUTPUT"
           echo "Legs in CI matrix: ${COUNT}"
 
-          # PLUS GUARD: assert that every entry in the CI matrix is a CE entry
-          # with ci=true.  The matrix reader already filters to these; this step
-          # is a hard fail-safe so a schema change can never silently let Plus in.
-          PLUS_COUNT=$(printf '%s\n' "$CI_MATRIX" \
-            | jq '[.[] | select(.channel != "CE" or .ci != true)] | length')
-          if [ "$PLUS_COUNT" -ne 0 ]; then
-            echo "::error::PLUS GUARD: CI matrix contains ${PLUS_COUNT} non-CE or ci:false entries — aborting."
+          # CI GUARD: assert that every entry in the CI matrix has ci=true (ADR-24).
+          # The channel is no longer asserted — Plus runs in CI from its private
+          # licensed image. The matrix reader already filters to ci:true; this step
+          # is a hard fail-safe so a schema change can never silently admit a
+          # ci:false (e.g. retired/unlicensed) entry.
+          BAD_COUNT=$(printf '%s\n' "$CI_MATRIX" \
+            | jq '[.[] | select(.ci != true)] | length')
+          if [ "$BAD_COUNT" -ne 0 ]; then
+            echo "::error::CI GUARD: CI matrix contains ${BAD_COUNT} ci:false entries — aborting."
             printf '%s\n' "$CI_MATRIX" \
-              | jq '.[] | select(.channel != "CE" or .ci != true)'
+              | jq '.[] | select(.ci != true)'
             exit 1
           fi
-          echo "Plus guard: OK — all ${COUNT} leg(s) are CE ci:true."
+          echo "CI guard: OK — all ${COUNT} leg(s) are ci:true."
 
           if [ "$COUNT" -eq 0 ]; then
-            echo "::warning::CI matrix is empty — no CE images to smoke-test."
+            echo "::warning::CI matrix is empty — no images to smoke-test."
           fi
 
   # ── 2. Per-CE smoke run (parallel, fail-fast: false) ─────────────────────────
@@ -103,12 +109,13 @@ jobs:
   # whether another leg has already failed.
   #
   # IMAGE REF RESOLUTION:
-  # The CI matrix entry carries pfsense_version (e.g. "2.8"). We pass it to
-  # smoke.yml as `pfsense_version`; smoke.yml composes the GHCR ref from the
-  # SMOKE_IMAGE_REPO / SMOKE_IMAGE_NAME / SMOKE_IMAGE_TAG repo variables, with
-  # pfsense_version overriding the tag.
+  # Each CI matrix entry carries pfsense_version (the GHCR floating tag, e.g. "2.8"
+  # / "26.03"), image_name (e.g. "pfsense-ce" / "pfsense-plus"), and mac. We pass
+  # all three to smoke.yml: it composes the GHCR ref from the SMOKE_IMAGE_REPO repo
+  # variable + the image_name input + the pfsense_version tag (each input overriding
+  # its repo-variable default), and exports mac as SMOKE_VM_MAC for the boot.
   smoke:
-    name: Smoke (${{ matrix.pfsense_version }})
+    name: Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }})
     needs: prepare
     # Run even if prepare had warnings; skip only if prepare hard-failed.
     if: needs.prepare.outputs.leg_count != '0'
@@ -118,10 +125,12 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.ci_matrix) }}
     uses: ./.github/workflows/smoke.yml
     with:
-      # Pass the per-leg version directly — pfsense_version IS the GHCR floating tag
-      # (e.g. "2.8"), so no transformation needed. smoke.yml uses it to override the
-      # SMOKE_IMAGE_TAG repo variable.
+      # Pass the per-leg version/name/mac directly — pfsense_version IS the GHCR
+      # floating tag (e.g. "2.8"), so no transformation needed. image_name selects
+      # the image (Plus = pfsense-plus); mac is the license-keyed boot MAC.
       pfsense_version: ${{ matrix.pfsense_version }}
+      image_name: ${{ matrix.image_name }}
+      mac: ${{ matrix.mac }}
     secrets: inherit
 
   # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -309,6 +309,22 @@ jobs:
             --out out-nightly
           echo "SMOKE_NIGHTLY_PKG=$(find "$PWD/out-nightly" -name '*.pkg' | head -1)" >> "$GITHUB_ENV"
 
+      # ADR-24 §2.2.4: a non-CE image (Plus) is license/NDI-keyed to its OWN
+      # source-VM MAC and must NEVER boot with the CE pin. Fail fast if a caller
+      # selects a non-CE image_name but leaves mac at the CE default — booting
+      # Plus with the wrong VM identity would invalidate its registration.
+      - name: Validate image/MAC contract
+        env:
+          INPUT_IMAGE_NAME: ${{ inputs.image_name }}
+          INPUT_MAC: ${{ inputs.mac }}
+        run: |
+          set -eu
+          if [ "${INPUT_IMAGE_NAME:-pfsense-ce}" != "pfsense-ce" ] && \
+             [ "${INPUT_MAC:-}" = "BC:24:11:37:9C:AC" ]; then
+            echo "::error::Image '${INPUT_IMAGE_NAME}' must boot with its own source-VM MAC (license/NDI-keyed); inputs.mac is still the CE pin. Set inputs.mac explicitly."
+            exit 1
+          fi
+
       # HERMETICITY (ADR §2/§4): the egress block is done INSIDE pytest, by the
       # matrix's `deployed_vm` fixture, after deploy() and before the per-case
       # assertions (helpers.block_egress, gated by SMOKE_BLOCK_EGRESS=1 below;

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -48,6 +48,14 @@ on:
         description: "Image tag to pull (blank = SMOKE_IMAGE_TAG var, else 2.8). Ignored when image_ref is set."
         required: false
         default: ""
+      image_name:
+        description: "Image name in the GHCR ref (default pfsense-ce). The fan-out passes the per-leg matrix.image_name (Plus = pfsense-plus). Ignored when image_ref is set."
+        required: false
+        default: "pfsense-ce"
+      mac:
+        description: "QEMU NIC MAC for the VM boot (default the CE pin BC:24:11:37:9C:AC). The fan-out passes the per-leg matrix.mac; Plus is license-keyed to BC:24:11:9C:FE:85."
+        required: false
+        default: "BC:24:11:37:9C:AC"
       pytest_marker:
         description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
         required: false
@@ -68,6 +76,16 @@ on:
         required: false
         type: string
         default: ""
+      image_name:
+        description: "Image name in the GHCR ref (default pfsense-ce). The fan-out passes the per-leg matrix.image_name (Plus = pfsense-plus). Ignored when image_ref is set."
+        required: false
+        type: string
+        default: "pfsense-ce"
+      mac:
+        description: "QEMU NIC MAC for the VM boot (default the CE pin BC:24:11:37:9C:AC). The fan-out passes the per-leg matrix.mac; Plus is license-keyed to BC:24:11:9C:FE:85."
+        required: false
+        type: string
+        default: "BC:24:11:37:9C:AC"
       pytest_marker:
         description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
         required: false
@@ -139,10 +157,13 @@ jobs:
         env:
           # image_ref input (full ref) wins. Otherwise compose from the
           # SMOKE_IMAGE_{REPO,NAME,TAG} repo vars; the pfsense_version input (the
-          # per-version caller, e.g. smoke-fanout) overrides the TAG. None are
-          # sensitive, so they are variables, not secrets.
+          # per-version caller, e.g. smoke-fanout) overrides the TAG, and the
+          # image_name input (the per-leg matrix.image_name) overrides the NAME var
+          # (Plus = pfsense-plus). None are sensitive, so they are variables, not
+          # secrets.
           INPUT_REF: ${{ inputs.image_ref }}
           INPUT_VERSION: ${{ inputs.pfsense_version }}
+          INPUT_IMAGE_NAME: ${{ inputs.image_name }}
           SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
           SMOKE_IMAGE_NAME: ${{ vars.SMOKE_IMAGE_NAME }}
           SMOKE_IMAGE_TAG: ${{ vars.SMOKE_IMAGE_TAG }}
@@ -153,7 +174,9 @@ jobs:
           else
             # Fallback for REPO: lowercased owner (GHCR refs MUST be lowercase).
             REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
-            NAME="${SMOKE_IMAGE_NAME:-pfsense-ce}"
+            # NAME: the per-leg image_name input wins over the repo variable; both
+            # default to pfsense-ce, so a bare dispatch is unchanged.
+            NAME="${INPUT_IMAGE_NAME:-${SMOKE_IMAGE_NAME:-pfsense-ce}}"
             TAG="${INPUT_VERSION:-${SMOKE_IMAGE_TAG:-2.8}}"
             REF="${REPO%/}/${NAME}:${TAG}"
           fi
@@ -307,6 +330,11 @@ jobs:
           # boot needs no network. SMOKE_IMAGE_REF is kept for provenance/logs.
           SMOKE_IMAGE_DIR: ${{ github.workspace }}/image
           SMOKE_IMAGE_REF: ${{ steps.ref.outputs.ref }}
+          # QEMU NIC MAC for the VM boot (ADR-24): conftest passes this through to
+          # boot_vm.sh. Defaults to the CE pin so a bare dispatch is byte-identical;
+          # the fan-out passes the per-leg matrix.mac (Plus = BC:24:11:9C:FE:85,
+          # license-keyed). boot_vm.sh keeps the same CE default if this is unset.
+          SMOKE_VM_MAC: ${{ inputs.mac }}
           SMOKE_SSH_KEY: smoke_key
           SMOKE_PKG: ${{ steps.paths.outputs.pkg }}
           # The builder-produced -nightly .pkg (set above for the `repo` marker; the

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -30,7 +30,11 @@
 #   BUILD matrix     — all entries from supported-versions.json, each carrying:
 #     pfsense_version, channel, freebsd_version, freebsd_major,
 #     php_version, py_flavor, variant, status, ci
-#   CI matrix        — the ci:true CE entries only (subset of BUILD matrix).
+#   CI matrix        — the ci:true entries (ANY channel), subset of BUILD matrix.
+#     Each emitted entry additionally carries a resolved image_name (default
+#     "pfsense-ce") and mac (default the CE pin "BC:24:11:37:9C:AC"), so an entry
+#     that omits them — every CE entry today — keeps the CE image + MAC, while a
+#     ci:true Plus entry can carry its own image_name/mac (ADR-24).
 #   python_versions  — DISTINCT python versions derived from each BUILD-matrix
 #     entry's py_flavor (`pyN` + `MM` => `N.MM`, e.g. py311 => 3.11; py39 => 3.9),
 #     sorted + deduped. test.yml's pytest matrix (supported-only — only the
@@ -119,11 +123,20 @@ else
   BUILD_MATRIX="$(printf '%s' "$RAW_JSON" | jq -c '.versions')"
 fi
 
-# ── CI matrix: ci:true CE entries only (within the variant-filtered set) ──────
-CI_MATRIX="$(printf '%s' "$BUILD_MATRIX" | jq -c '[.[] | select(.ci == true and .channel == "CE")]')"
+# ── CI matrix: the ci:true entries (ANY channel) within the variant-filtered set ──
+# The channel no longer filters (ADR-24): a ci:true Plus entry is a first-class CI
+# leg. Each entry gains a resolved image_name (default "pfsense-ce") and mac (default
+# the CE pin) — an entry that omits them keeps the CE image + MAC, while a Plus entry
+# carries its own. The MAC is load-bearing for a Plus image (license/NDI keyed to it).
+CI_MATRIX="$(printf '%s' "$BUILD_MATRIX" | jq -c '
+  [ .[]
+    | select(.ci == true)
+    | . + { image_name: (.image_name // "pfsense-ce"), mac: (.mac // "BC:24:11:37:9C:AC") }
+  ]')"
 
 # ── Sanity: CI matrix must not be empty ───────────────────────────────────────
-# Skip when --variant filters to a non-CE variant (Plus has ci=false by policy).
+# Skip when --variant filters to a non-CE variant (a Plus-only filtered set may have
+# no ci:true entry while Plus is still ci=false on the live matrix).
 if [ "${_VF_LOWER:-}" != "plus" ]; then
   CI_COUNT="$(printf '%s' "$CI_MATRIX" | jq 'length')"
   if [ "$CI_COUNT" -eq 0 ]; then

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -131,7 +131,10 @@ fi
 CI_MATRIX="$(printf '%s' "$BUILD_MATRIX" | jq -c '
   [ .[]
     | select(.ci == true)
-    | . + { image_name: (.image_name // "pfsense-ce"), mac: (.mac // "BC:24:11:37:9C:AC") }
+    | . + {
+        image_name: (if ((.image_name // "") == "") then "pfsense-ce" else .image_name end),
+        mac: (if ((.mac // "") == "") then "BC:24:11:37:9C:AC" else .mac end)
+      }
   ]')"
 
 # ── Sanity: CI matrix must not be empty ───────────────────────────────────────

--- a/tests/smoke/boot_vm.sh
+++ b/tests/smoke/boot_vm.sh
@@ -17,7 +17,11 @@
 # published qcow2 boots without pfSense re-detecting hardware and dropping
 # to the interface-reassignment console prompt:
 #   - single virtio-net-pci NIC, MAC pinned to BC:24:11:37:9C:AC
-#     (the source VM's MAC; a MAC is not sensitive, so it is hardcoded)
+#     (the CE source VM's MAC; a MAC is not sensitive). The MAC is per-image
+#     and defaults to the CE pin; override it with SMOKE_VM_MAC. A pfSense Plus
+#     image MUST set SMOKE_VM_MAC to its OWN source-VM MAC: the Plus license/NDI
+#     registration is keyed to it, so the CE pin would deregister/reassign it
+#     (see ADR-24 and scripts/README.md § "pfSense Plus images").
 #   - VirtIO-SCSI disk (guest sees da0)
 #   - machine type pc (i440fx; Proxmox pc+pve0), -cpu host, 2 vCPU, 4 GB RAM
 #
@@ -34,7 +38,8 @@ QEMU=/usr/bin/qemu-system-x86_64
 QEMU_IMG=/usr/bin/qemu-img
 
 # Source-VM hardware profile (mirror — do not change without re-baking image).
-VM_MAC="BC:24:11:37:9C:AC"
+# MAC is per-image: CE pin by default, SMOKE_VM_MAC overrides (Plus MUST set it).
+VM_MAC="${SMOKE_VM_MAC:-BC:24:11:37:9C:AC}"
 VM_SMBIOS_UUID="58fd7964-c40c-4f47-bf02-3fdad18f8b00"
 VM_SMP="2,sockets=1,cores=2"
 VM_MEM="4096"

--- a/tests/test_read_version_matrix.py
+++ b/tests/test_read_version_matrix.py
@@ -229,6 +229,22 @@ def test_ci_matrix_entries_pass_through_explicit_image_name_and_mac(tmp_path: Pa
 
 
 # --------------------------------------------------------------------------- #
+# Scenario d2 — EMPTY-STRING image_name/mac normalize to the defaults.
+# `//` alone treats only null/missing as absent, so a literal "" would flow
+# through and later be read as a CE fallback by downstream workflows — silently
+# mis-routing a Plus leg. The reader must coerce "" to the default too.
+# --------------------------------------------------------------------------- #
+def test_ci_matrix_empty_string_image_name_and_mac_normalize_to_defaults(tmp_path: Path) -> None:
+    """An empty-string image_name/mac is treated as absent → CE image + pin (not "")."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry(image_name="", mac="")])
+    ci = _ci_matrix(repo)
+    assert len(ci) == 1
+    entry = ci[0]
+    assert entry["image_name"] == CE_DEFAULT_IMAGE_NAME, f"empty image_name must default; got {entry['image_name']!r}"
+    assert entry["mac"] == CE_DEFAULT_MAC, f"empty mac must default; got {entry['mac']!r}"
+
+
+# --------------------------------------------------------------------------- #
 # Scenario e — BUILD matrix + derived test matrices unaffected (§2.2.6 regression).
 # --------------------------------------------------------------------------- #
 def test_build_and_test_matrices_unchanged_by_new_fields(tmp_path: Path) -> None:

--- a/tests/test_read_version_matrix.py
+++ b/tests/test_read_version_matrix.py
@@ -1,0 +1,248 @@
+"""Tests for scripts/read-version-matrix.sh — the BUILD/CI matrix reader (ADR-24 Phase 2).
+
+The reader cats supported-versions.json from a git ref and emits, as JSON, the BUILD
+matrix (all entries) and the CI matrix. ADR-24 changes the CI filter from
+`.ci == true and .channel == "CE"` to `.ci == true` (any channel), and has each
+CI-matrix entry carry a resolved `image_name` (default `pfsense-ce`) + `mac`
+(default the CE pin `BC:24:11:37:9C:AC`) so existing CE entries that omit those
+fields need no edit while a `ci: true` Plus entry can enter CI with its own image/MAC.
+
+These tests do not merely run the script — they pin the behaviour that matters:
+
+  * a `ci: false` Plus entry is EXCLUDED from the CI matrix (the §2.2.3 contract);
+  * a `ci: true` Plus entry is INCLUDED (the channel no longer filters) — the RED
+    scenario pre-change, since today's filter pins `.channel == "CE"`;
+  * every CI-matrix entry carries `image_name` + `mac`, defaulted when the JSON
+    omits them, and passed through verbatim when present;
+  * the BUILD matrix and the derived `python_versions` / `php_versions` outputs are
+    unaffected by the new fields (§2.2.6 — build matrix untouched).
+
+Each test builds a SYNTHETIC supported-versions.json, commits it to a throwaway git
+repo on a ref, and runs the script with `--ref`/`--file` pointed at it (subprocess,
+cwd = the temp repo) — the same shape as the other script-driving tests in tests/.
+No network; needs git + jq (both present on the CI runner and locally).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "read-version-matrix.sh"
+
+
+def _clean_git_env() -> dict[str, str]:
+    """Env with every GIT_* var stripped.
+
+    The test drives git in a throwaway repo (cwd=tmp_path) and the script itself
+    shells out to git. When the suite runs under the pre-commit hook, git exports
+    GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / GIT_PREFIX into the hook's
+    environment; those would override `cwd` and point every git invocation at the
+    REAL repo (where a `ci-metadata` ref already exists — `git branch ci-metadata`
+    then fails rc 128, and `git show` reads the wrong matrix). Scrub them so the
+    temp repo is the sole git context, matching a clean standalone `pytest` run.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+CE_DEFAULT_IMAGE_NAME = "pfsense-ce"
+CE_DEFAULT_MAC = "BC:24:11:37:9C:AC"
+
+# Skip the whole module if git or jq is missing — the script hard-requires both,
+# and a missing tool is an environment gap, not a behaviour regression.
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("jq") is None,
+    reason="read-version-matrix.sh requires git + jq",
+)
+
+
+def _ce_entry(**overrides: Any) -> dict[str, Any]:
+    """A minimal valid CE matrix entry (ci:true); override any field."""
+    entry: dict[str, Any] = {
+        "pfsense_version": "2.8",
+        "channel": "CE",
+        "freebsd_version": "15.0-RELEASE",
+        "freebsd_major": "15",
+        "php_version": "8.3",
+        "py_flavor": "py311",
+        "variant": "CE",
+        "status": "active",
+        "ci": True,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _plus_entry(**overrides: Any) -> dict[str, Any]:
+    """A minimal valid Plus matrix entry; override any field (e.g. ci)."""
+    entry: dict[str, Any] = {
+        "pfsense_version": "26.03",
+        "channel": "Plus",
+        "freebsd_version": "16.0-RELEASE",
+        "freebsd_major": "16",
+        "php_version": "8.5",
+        "py_flavor": "py311",
+        "variant": "Plus",
+        "status": "active",
+        "ci": False,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _make_matrix_ref(tmp_path: Path, versions: list[dict[str, Any]], *, ref: str = "ci-metadata") -> Path:
+    """Create a git repo in tmp_path with supported-versions.json committed on `ref`.
+
+    Returns the repo path. The script reads via `git show <ref>:<file>` relative to
+    cwd, so callers run the script with cwd = this path.
+    """
+    repo = tmp_path / "matrix-repo"
+    repo.mkdir()
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_clean_git_env(),
+        )
+
+    _git("init", "-q", "-b", "main")
+    _git("config", "user.email", "test@example.com")
+    _git("config", "user.name", "test")
+    # Throwaway repo — never sign (a signing-enabled global config would otherwise
+    # break the commit and is irrelevant to what this test pins).
+    _git("config", "commit.gpgsign", "false")
+    _git("config", "tag.gpgsign", "false")
+
+    matrix = {
+        "description": "synthetic test matrix",
+        "versions": versions,
+    }
+    (repo / "supported-versions.json").write_text(json.dumps(matrix, indent=2) + "\n")
+    _git("add", "supported-versions.json")
+    _git("commit", "-q", "-m", "matrix")
+    # Put it on the requested ref name (a local branch is a valid git ref the script
+    # can `git show` — its internal `git fetch origin ci-metadata` failure is ignored).
+    if ref != "main":
+        _git("branch", ref)
+    return repo
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run the script in `repo` with the given args; assert it succeeded."""
+    proc = subprocess.run(
+        ["sh", str(_SCRIPT), *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=_clean_git_env(),
+    )
+    assert proc.returncode == 0, f"script failed (rc={proc.returncode})\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    return proc
+
+
+def _ci_matrix(repo: Path, ref: str = "ci-metadata") -> list[dict[str, Any]]:
+    proc = _run(repo, "--ref", ref, "--file", "supported-versions.json", "--print-ci")
+    return json.loads(proc.stdout)  # type: ignore[no-any-return]
+
+
+def _build_matrix(repo: Path, ref: str = "ci-metadata") -> list[dict[str, Any]]:
+    proc = _run(repo, "--ref", ref, "--file", "supported-versions.json", "--print-build")
+    return json.loads(proc.stdout)  # type: ignore[no-any-return]
+
+
+def _test_matrices(repo: Path, ref: str = "ci-metadata") -> tuple[list[str], list[str]]:
+    """Return (python_versions, php_versions) parsed from --print-test output."""
+    proc = _run(repo, "--ref", ref, "--file", "supported-versions.json", "--print-test")
+    # Output is two labelled JSON blocks: "python_versions:\n[...]\n\nphp_versions:\n[...]"
+    out = proc.stdout
+    py_label = "python_versions:"
+    php_label = "php_versions:"
+    py_start = out.index(py_label) + len(py_label)
+    php_idx = out.index(php_label)
+    py_json = out[py_start:php_idx].strip()
+    php_json = out[php_idx + len(php_label) :].strip()
+    return json.loads(py_json), json.loads(php_json)
+
+
+# --------------------------------------------------------------------------- #
+# Scenario a — ci:false Plus entry is EXCLUDED (passes today; regression pin).
+# --------------------------------------------------------------------------- #
+def test_ci_matrix_excludes_plus_entry_with_ci_false(tmp_path: Path) -> None:
+    """A Plus entry with ci:false never enters the CI matrix (§2.2.3)."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry(), _plus_entry(ci=False)])
+    ci = _ci_matrix(repo)
+    channels = {e["channel"] for e in ci}
+    assert channels == {"CE"}, f"ci:false Plus must be excluded; got {ci!r}"
+    assert all(e["ci"] is True for e in ci)
+
+
+# --------------------------------------------------------------------------- #
+# Scenario b — ci:true Plus entry is INCLUDED (RED today: channel filter drops it).
+# --------------------------------------------------------------------------- #
+def test_ci_matrix_includes_plus_entry_with_ci_true(tmp_path: Path) -> None:
+    """A Plus entry with ci:true enters the CI matrix — the channel no longer filters."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry(), _plus_entry(ci=True)])
+    ci = _ci_matrix(repo)
+    channels = {e["channel"] for e in ci}
+    assert channels == {"CE", "Plus"}, f"ci:true Plus must be included; got {ci!r}"
+    plus = [e for e in ci if e["channel"] == "Plus"]
+    assert len(plus) == 1 and plus[0]["pfsense_version"] == "26.03"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario c — defaults applied when image_name/mac omitted (RED today: no fields).
+# --------------------------------------------------------------------------- #
+def test_ci_matrix_entries_default_image_name_and_mac(tmp_path: Path) -> None:
+    """Each CI-matrix entry carries image_name/mac, defaulting to the CE image + pin."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry()])  # omits image_name + mac
+    ci = _ci_matrix(repo)
+    assert len(ci) == 1
+    entry = ci[0]
+    assert entry["image_name"] == CE_DEFAULT_IMAGE_NAME
+    assert entry["mac"] == CE_DEFAULT_MAC
+
+
+# --------------------------------------------------------------------------- #
+# Scenario d — explicit image_name/mac pass through verbatim (RED today: no fields).
+# --------------------------------------------------------------------------- #
+def test_ci_matrix_entries_pass_through_explicit_image_name_and_mac(tmp_path: Path) -> None:
+    """Explicit image_name/mac in the JSON are emitted verbatim — no default override."""
+    repo = _make_matrix_ref(
+        tmp_path,
+        [_plus_entry(ci=True, image_name="pfsense-plus", mac="BC:24:11:9C:FE:85")],
+    )
+    ci = _ci_matrix(repo)
+    assert len(ci) == 1
+    entry = ci[0]
+    assert entry["image_name"] == "pfsense-plus"
+    assert entry["mac"] == "BC:24:11:9C:FE:85"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario e — BUILD matrix + derived test matrices unaffected (§2.2.6 regression).
+# --------------------------------------------------------------------------- #
+def test_build_and_test_matrices_unchanged_by_new_fields(tmp_path: Path) -> None:
+    """The new CI-matrix fields do not perturb build_matrix / python_versions / php_versions."""
+    versions = [_ce_entry(), _plus_entry(ci=True, image_name="pfsense-plus", mac="BC:24:11:9C:FE:85")]
+    repo = _make_matrix_ref(tmp_path, versions)
+
+    build = _build_matrix(repo)
+    # BUILD matrix is the verbatim versions array — both entries, no injected fields
+    # on the CE entry (image_name/mac resolution is a CI-matrix concern only).
+    assert [e["pfsense_version"] for e in build] == ["2.8", "26.03"]
+    ce_build = next(e for e in build if e["channel"] == "CE")
+    assert "image_name" not in ce_build and "mac" not in ce_build
+
+    py, php = _test_matrices(repo)
+    assert py == ["3.11"]  # both entries are py311
+    assert php == ["8.3", "8.5"]  # distinct, sorted

--- a/tests/test_smoke_harness_defaults.py
+++ b/tests/test_smoke_harness_defaults.py
@@ -1,0 +1,55 @@
+"""Pin the smoke-harness boot defaults that ADR-24 parameterizes.
+
+The pfSense Plus smoke image (ADR-24) must boot with ITS source-VM MAC, distinct
+from the CE pin, because pfSense matches interface assignment by MAC AND the Plus
+license/NDI registration is keyed to it. ``tests/smoke/conftest.py`` boots
+exclusively via ``boot_vm.sh``, so a single ``SMOKE_VM_MAC`` env override
+parameterizes the whole harness while keeping CE byte-identical when unset.
+
+These tests read ``boot_vm.sh`` as text (no QEMU/VM needed) and pin:
+
+* the CE default MAC string is present — a regression pin guarding against
+  accidental drift of the documented CE source-VM MAC (it appears in both the
+  header comment and the assignment); and
+* the assignment is the env-override form ``${SMOKE_VM_MAC:-<CE pin>}`` — so a
+  Plus run can override it while CE keeps the pin as the default.
+
+Both branches of the override are covered: CE (env unset -> pin) by the default
+string assertion, Plus (env set -> override) by the override-form assertion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# The CE source-VM MAC pin (also documented in boot_vm.sh's header + the ADR).
+CE_DEFAULT_MAC = "BC:24:11:37:9C:AC"
+
+_BOOT_VM_SH = Path(__file__).resolve().parent.parent / "tests" / "smoke" / "boot_vm.sh"
+
+
+def _boot_vm_text() -> str:
+    return _BOOT_VM_SH.read_text(encoding="utf-8")
+
+
+def test_ce_default_mac_pin_present() -> None:
+    """The CE source-VM MAC pin is present in boot_vm.sh.
+
+    Regression pin: the documented CE source-VM MAC must stay the harness
+    default; a typo'd or drifted pin would drop it and fail. (It legitimately
+    appears more than once — the header comment plus the assignment default —
+    so this asserts presence, not a count.)
+    """
+    text = _boot_vm_text()
+    assert CE_DEFAULT_MAC in text
+
+
+def test_vm_mac_is_env_override_with_ce_default() -> None:
+    """VM_MAC is the SMOKE_VM_MAC override form, defaulting to the CE pin.
+
+    With SMOKE_VM_MAC unset the expansion yields the CE pin (default path,
+    byte-identical to pre-ADR-24); a Plus run sets SMOKE_VM_MAC to override it.
+    """
+    text = _boot_vm_text()
+    expected = f'VM_MAC="${{SMOKE_VM_MAC:-{CE_DEFAULT_MAC}}}"'
+    assert expected in text


### PR DESCRIPTION
## ADR-24 — Phases 1–3 (behaviour-preserving plumbing)

Makes the CI smoke pipeline **channel-capable** so pfSense Plus can join the fan-out, without changing any live CI behaviour yet. The live activation (flipping the `ci-metadata` matrix entry + a two-channel fan-out) is **ADR-24 Phase 4**, done separately after this lands; docs reconciliation is Phase 5.

Full design: `.ADRs/ADR_24_Plus_CI_Smoke/ADR.md`.

### What's in this PR

| Phase | Commit | Change |
| ----- | ------ | ------ |
| 1 | `8489e7c` | `tests/smoke/boot_vm.sh`: VM MAC via `${SMOKE_VM_MAC:-BC:24:11:37:9C:AC}` — env override, CE pin default. `conftest.py` already inherits the env (no change). |
| 2 | `52e981e` | `scripts/read-version-matrix.sh`: CI filter relaxed from `ci==true && channel=="CE"` to **`ci==true`** (any channel); each CI entry gains resolved `image_name` (default `pfsense-ce`) + `mac` (default CE pin). |
| 3 | `6cee0c7` | `smoke.yml` gains `image_name`/`mac` inputs (defaults = today) and exports `SMOKE_VM_MAC`; `smoke-fanout.yml` PLUS GUARD → **CI GUARD** (`ci != true` only), per-leg `image_name`/`mac` passthrough, leg name `Smoke (<channel> <version>)`. |

### Behaviour-preserving (the contract, §2.2)

With the **live matrix unchanged** (Plus still `ci:false`), every composed image ref, QEMU arg, and workflow path is **byte-identical to today**:
- CE leg still resolves `ghcr.io/pfblockerng/pfsense-ce:2.8` with the CE MAC pin.
- `select(.ci == true)` still yields only the single CE 2.8 leg (Plus excluded).
- AND-gate semantics untouched; build matrix / python-php version outputs untouched (§2.2.6).

### Tests / red→green

- New `tests/test_smoke_harness_defaults.py` — pins the CE default + the override form (red→green verified).
- New `tests/test_read_version_matrix.py` — Plus excluded at `ci:false`, included at `ci:true`, default + explicit `image_name`/`mac` resolution, build-matrix invariant.
- Full suite green; ruff/mypy clean; both workflow YAMLs parse.

### Deferred to Phase 4 (post-merge)

The §4.6 live CE-only fan-out dispatch can only run once this is on `devel`. Phase 4 then: grant the private `pfsense-plus` package read access to this repo, PR the `ci-metadata` flip (`ci:true` + `image_name: pfsense-plus` + the Plus source-VM MAC supplied via the `SMOKE_PLUS_MAC` secret), and dispatch the two-channel fan-out.

https://claude.ai/code/session_013jLsppCcoQzRW9hEpb3qJC