### PR TITLE
ADR-24: source Plus VM identity (MAC + SMBIOS uuid) from secrets; redact from diagnostics

### DIFF
--- a/.ADRs/ADR_24_Plus_CI_Smoke/01_Harness_Mac_Image_Param.txt
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/01_Harness_Mac_Image_Param.txt
@@ -11,7 +11,7 @@ byte-identical to today. Inline on the branch, one commit, push directly.
 
 WHY THIS PHASE EXISTS
 boot_vm.sh hardcodes the CE source-VM MAC (BC:24:11:37:9C:AC). The pfSense Plus
-image (ADR-24) must boot with ITS source-VM MAC (REDACTED_PLUS_MAC) — pfSense
+image (ADR-24) must boot with ITS source-VM MAC (held in the SMOKE_PLUS_MAC secret) — pfSense
 matches interface assignment by MAC AND the Plus license/NDI registration is
 keyed to it. conftest.py boots exclusively via boot_vm.sh, so one env override
 parameterizes the whole harness.

--- a/.ADRs/ADR_24_Plus_CI_Smoke/04_Matrix_Flip_Live.txt
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/04_Matrix_Flip_Live.txt
@@ -26,15 +26,19 @@ Read RESULTS/03_Results.txt FIRST (if missing: STOP). It must confirm:
 If ANY precondition is unmet: STOP and report which.
 
 ACTION PLAN (ordered)
+0. Set the GitHub Actions secrets (maintainer): SMOKE_PLUS_MAC +
+   SMOKE_PLUS_SMBIOS_UUID (optionally SMOKE_PLUS_NDI) = the Plus source-VM
+   identity. These are license/NDI-keyed and live ONLY in secrets — never the
+   public matrix.
 1. Branch off origin/ci-metadata (worktree); edit supported-versions.json:
    the Plus 26.03 entry gets:
        "ci": true,
-       "image_name": "pfsense-plus",
-       "mac": "REDACTED_PLUS_MAC"
-   Update supported-versions.schema.json: optional string fields image_name
-   (lowercase OCI name pattern) and mac (MAC pattern). Rewrite
-   lifecycle_policy.plus: Plus runs in CI from a private licensed image; the MAC
-   is license/NDI-keyed and MUST equal the source VM's; image refresh is manual.
+       "image_name": "pfsense-plus"
+   (the MAC/uuid are NOT in the matrix — they are the SMOKE_PLUS_* secrets).
+   Update supported-versions.schema.json: optional string field image_name
+   (lowercase OCI name pattern). Rewrite lifecycle_policy.plus: Plus runs in CI
+   from a private licensed image; the VM identity (MAC + SMBIOS uuid) is
+   license/NDI-keyed and comes from secrets; image refresh is manual.
 2. PR against ci-metadata; land it per repo flow.
 3. Dispatch smoke-fanout.yml. Required outcome: CE leg(s) green, Plus leg green,
    all-smoke-passed green. On a Plus-leg failure: read the smoke-diagnostics
@@ -59,7 +63,8 @@ VERIFICATION (must all pass before the phase is done)
 
 EXPECTED RESULT
 CI fans out to every supported version, CE and Plus; Plus leg pulls the private
-image, boots with REDACTED_PLUS_MAC, passes the ADR-04 suite.
+image, boots with the secret source-VM identity (SMOKE_PLUS_MAC +
+SMOKE_PLUS_SMBIOS_UUID), passes the ADR-04 suite.
 
 COMMIT
   (on ci-metadata, via PR)  ci-metadata: enable Plus 26.03 in CI (ADR-24 P4)

--- a/.ADRs/ADR_24_Plus_CI_Smoke/05_Docs.txt
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/05_Docs.txt
@@ -28,8 +28,9 @@ ACTION PLAN (ordered)
    CE-only).
 2. scripts/README.md: update the ci_matrix description + lifecycle notes; in the
    Plus-images section, replace "Plus stays out of CI regardless" with the new
-   state (CI pulls the private image; MAC REDACTED_PLUS_MAC rides the matrix
-   entry; manual refresh).
+   state (CI pulls the private image; the VM identity — MAC + SMBIOS uuid — comes
+   from the SMOKE_PLUS_MAC/SMOKE_PLUS_SMBIOS_UUID secrets, never the matrix;
+   manual refresh).
 3. Sweep for stragglers:
        grep -rn "never Plus\|Never Plus\|ci: false" CLAUDE.md scripts/ docs/ README.md
    Update what describes CI reality; leave historical ADR texts (ADR-04/09/20

--- a/.ADRs/ADR_24_Plus_CI_Smoke/ADR.md
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/ADR.md
@@ -46,9 +46,12 @@ ending: a maintainer-owned licensed Plus qcow2 (Proxmox VM 104) is being publish
   defaults the same pin but already has `--mac`. `conftest.py` boots exclusively via
   `boot_vm.sh` (`tests/smoke/conftest.py:60`), so the harness has exactly one MAC plumb
   point.
-- **The Plus MAC is `REDACTED_PLUS_MAC` and is license-critical:** the Plus
-  license/NDI registration is keyed to it. Every boot of the Plus image MUST use it,
-  and it differs from the CE pin.
+- **The Plus VM identity (MAC + SMBIOS uuid) is license-critical and SECRET:** the
+  Plus license/NDI registration is keyed to BOTH the source-VM MAC and its SMBIOS
+  type-1 uuid (the Netgate Device ID is derived from MAC + uuid). Every boot of the
+  Plus image MUST use them, and they differ from the CE pins. Because they identify a
+  licensed instance, they are held in the **`SMOKE_PLUS_MAC` + `SMOKE_PLUS_SMBIOS_UUID`
+  GitHub secrets** (optionally `SMOKE_PLUS_NDI`), NEVER the public `ci-metadata` matrix.
 - **GHCR auth:** `smoke.yml` already logs in (`SMOKE_GHCR_USER`/`TOKEN` secrets,
   falling back to `github.actor`/`GITHUB_TOKEN`, `smoke.yml:176–181`) — pulling a
   private package needs only the package granting this repo read access; no new
@@ -73,21 +76,26 @@ ending: a maintainer-owned licensed Plus qcow2 (Proxmox VM 104) is being publish
 
 ## 2. Decision
 
-Plus becomes a first-class CI smoke leg. The matrix entry is the single source of
-truth for the per-leg image name and MAC; the harness defaults stay CE so every change
-before the final matrix flip is behaviour-preserving.
+Plus becomes a first-class CI smoke leg. The matrix entry is the source of truth for
+the per-leg **image name** (public); the per-leg **VM identity** (MAC + SMBIOS uuid)
+is license/NDI-keyed and therefore comes from **GitHub secrets**, never the public
+matrix. The harness defaults stay CE so every change before the final matrix flip is
+behaviour-preserving.
 
 ### 2.1 Decision table
 
 | Area | Current | New |
 | ---- | ------- | --- |
 | `boot_vm.sh` MAC | hardcoded `BC:24:11:37:9C:AC` | `VM_MAC="${SMOKE_VM_MAC:-BC:24:11:37:9C:AC}"` — env override, CE default |
-| `conftest.py` | no MAC awareness | passes `SMOKE_VM_MAC` through to `boot_vm.sh` env (no default of its own) |
-| Matrix schema | per-entry: version/channel/freebsd/php/py/ci… | + optional `image_name` (default `pfsense-ce`) and `mac` (default CE pin) — defaults applied by the reader, existing entries valid unchanged |
-| `read-version-matrix.sh` CI filter | `.ci == true and .channel == "CE"` | `.ci == true` (any channel); each emitted entry carries resolved `image_name` + `mac` |
-| `smoke-fanout.yml` PLUS GUARD | fails on `channel != "CE"` | becomes a CI GUARD: fails on `ci != true` only; leg name gains the channel (`Smoke (CE 2.8)` / `Smoke (Plus 26.03)`) |
-| `smoke.yml` inputs | `pfsense_version`, `image_ref` | + `image_name` (default `pfsense-ce`), `mac` (default CE pin) → ref composition + `SMOKE_VM_MAC` env for pytest |
-| Plus matrix entry | `ci: false` | `ci: true`, `image_name: pfsense-plus`, `mac: REDACTED_PLUS_MAC` (flipped LAST, via `ci-metadata` PR) |
+| `boot_vm.sh` SMBIOS uuid | hardcoded CE uuid | `VM_SMBIOS_UUID="${SMOKE_VM_SMBIOS_UUID:-58fd7964-…}"` — env override, CE default (Plus NDI is derived from MAC + uuid, so the uuid is as license-keyed as the MAC) |
+| `conftest.py` | no identity awareness | unchanged — boots `boot_vm.sh` via `subprocess` inheriting `os.environ`, so `SMOKE_VM_MAC`/`SMOKE_VM_SMBIOS_UUID` propagate with no edit |
+| Matrix schema | per-entry: version/channel/freebsd/php/py/ci… | + optional `image_name` (default `pfsense-ce`); the **MAC/uuid are NOT in the matrix** (license/NDI-keyed secrets). Existing entries valid unchanged |
+| `read-version-matrix.sh` CI filter | `.ci == true and .channel == "CE"` | `.ci == true` (any channel); each emitted entry carries a resolved `image_name`. (`mac` stays a CE-public default placeholder — ignored for Plus, which overrides from the secret.) |
+| `smoke.yml` VM identity | none | a "Resolve VM identity" step keys on the image: CE → public pin; non-CE (Plus) → `SMOKE_PLUS_MAC`/`SMOKE_PLUS_SMBIOS_UUID` secrets (fail-closed if absent), masked, and emitted as the diagnostics redaction set |
+| `smoke-fanout.yml` PLUS GUARD | fails on `channel != "CE"` | becomes a CI GUARD: fails on `ci != true` only; `secrets: inherit` so smoke.yml reads `SMOKE_PLUS_*`; leg name gains the channel (`Smoke (CE 2.8)` / `Smoke (Plus 26.03)`) |
+| `smoke.yml` inputs | `pfsense_version`, `image_ref` | + `image_name` (default `pfsense-ce`); pytest gets `SMOKE_VM_MAC`/`SMOKE_VM_SMBIOS_UUID`/`SMOKE_REDACT_VALUES` from the resolve step |
+| Plus diagnostics | none | runner-side: drop console screenshots (NDI/serial as pixels) + literal-redact the secret identity; in-guest: value-redact the whole bundle (MAC in ifconfig, uuid in dmesg, + live serial) before tar |
+| Plus matrix entry | `ci: false` | `ci: true`, `image_name: pfsense-plus` (the MAC/uuid live in the `SMOKE_PLUS_*` secrets, not the entry; flipped LAST, via `ci-metadata` PR) |
 | `image-refresh.yml` / `image-upgrade.sh` | CE upgrade-in-place | **unchanged — CE-only.** Plus refresh stays manual (`image-publish.sh` from Proxmox VM 104); `pfSense-upgrade` on Plus needs subscription auth CI doesn't hold |
 | Docs (`CLAUDE.md`, `scripts/README.md`, matrix `lifecycle_policy`) | "never Plus", "ci: false for Plus" | rewritten: Plus runs in CI from a private licensed image; refresh manual |
 
@@ -100,13 +108,17 @@ before the final matrix flip is behaviour-preserving.
    zero legs stays red.
 3. **`ci: false` still excludes:** a `ci: false` entry (of either channel) never
    produces a leg; the fan-out guard hard-fails if one leaks through.
-4. **Plus boots ONLY with `REDACTED_PLUS_MAC`:** the Plus leg's QEMU NIC MAC equals
-   the matrix `mac`; no code path may fall back to the CE pin for a Plus image
-   (license/NDI keyed to the MAC).
-5. **The Plus image stays private:** no workflow step pushes, re-tags, attaches, or
-   uploads the Plus qcow2 (cache keys/digests are fine); `smoke-diagnostics` from a
-   Plus leg contains no license identifier (NDI/token scrubbed like `config.xml`
-   secrets).
+4. **Plus boots ONLY with its secret identity:** the Plus leg's QEMU NIC MAC + SMBIOS
+   uuid equal the `SMOKE_PLUS_MAC` / `SMOKE_PLUS_SMBIOS_UUID` secrets; no code path may
+   fall back to the CE pin for a Plus image (license/NDI keyed to MAC + uuid), and the
+   resolve step fails closed if a non-CE image is selected without those secrets.
+5. **The Plus image stays private AND its identity never leaks:** no workflow step
+   pushes, re-tags, attaches, or uploads the Plus qcow2 (cache keys/digests are fine);
+   the secret identity (MAC + uuid [+ NDI] + live serial) is value-redacted out of the
+   `smoke-diagnostics` bundle — in-guest across the whole bundle before tar, and
+   runner-side across the boot `vm*.log` — and console screenshots are dropped for a
+   non-CE image (a banner shows the NDI/serial as pixels). The actuator-style
+   sensitive-tag scrub of `config.xml` runs for every leg as before.
 6. **Build matrix untouched:** `build_matrix`, `python_versions`, `php_versions`
    outputs are unchanged (Plus was already in the build matrix).
 
@@ -144,18 +156,25 @@ before the final matrix flip is behaviour-preserving.
 
 ## 4. Requirements (acceptance)
 
-1. `boot_vm.sh` boots with `SMOKE_VM_MAC` when set, CE pin otherwise.
+1. `boot_vm.sh` boots with `SMOKE_VM_MAC` + `SMOKE_VM_SMBIOS_UUID` when set, CE pins
+   otherwise.
 2. `read-version-matrix.sh` CI matrix includes the Plus entry iff `ci: true`, with
-   `image_name`/`mac` resolved (defaults for CE entries that omit them).
-3. `smoke-fanout.yml` runs one leg per `ci: true` entry, passing `image_name` + `mac`;
-   guard fails on any `ci != true` leak.
-4. `smoke.yml` composes `ghcr.io/pfblockerng/pfsense-plus:26.03` for the Plus leg and
-   exports `SMOKE_VM_MAC` to the pytest env.
+   `image_name` resolved (default for CE entries that omit it). The MAC/uuid are NOT
+   in the matrix — they are secrets.
+3. `smoke-fanout.yml` runs one leg per `ci: true` entry, passing `image_name`; carries
+   `secrets: inherit` so smoke.yml reads `SMOKE_PLUS_*`; guard fails on any `ci != true`
+   leak.
+4. `smoke.yml` composes `ghcr.io/pfblockerng/pfsense-plus:26.03` for the Plus leg and,
+   via the resolve step, exports `SMOKE_VM_MAC`/`SMOKE_VM_SMBIOS_UUID` (from the
+   secrets) + `SMOKE_REDACT_VALUES` to the pytest env; fails closed when a non-CE image
+   lacks the secrets.
 5. Full fan-out dispatch: CE leg(s) green AND Plus leg green; `all-smoke-passed`
    green.
-6. CE-only dispatch (pre-flip state) produces byte-identical refs/QEMU args to today
-   (§2.2.1 — pinned before the flip).
-7. A Plus-leg `smoke-diagnostics` artifact contains no NDI/license token.
+6. CE-only dispatch (pre-flip state) produces byte-identical refs/QEMU args AND a
+   byte-identical diagnostics bundle to today (§2.2.1 — pinned before the flip;
+   `SMOKE_REDACT_VALUES` empty → redaction is a strict no-op).
+7. A Plus-leg `smoke-diagnostics` artifact contains no MAC, SMBIOS uuid, NDI, serial,
+   or other license token (value-redacted in-guest + runner-side; screenshots dropped).
 
 ## 5. Constraints (from CLAUDE.md)
 
@@ -213,9 +232,12 @@ Prompt: `04_Matrix_Flip_Live.txt`
   `ghcr.io/pfblockerng/pfsense-plus:26.03` published from Proxmox VM 104 and
   **private**; package grants this repo read access; Plus image has baked deps
   (FreeBSD-16 RUN_DEPENDS) + the smoke SSH key; diagnostics scrub verified for NDI.
-- PR against `ci-metadata`: Plus entry `ci: true` + `image_name: pfsense-plus` +
-  `mac: REDACTED_PLUS_MAC`; schema gains the two optional fields;
-  `lifecycle_policy.plus` text rewritten.
+- Set the `SMOKE_PLUS_MAC` + `SMOKE_PLUS_SMBIOS_UUID` (optionally `SMOKE_PLUS_NDI`)
+  Actions secrets to the Plus source-VM identity (license/NDI-keyed — secrets, never
+  the matrix).
+- PR against `ci-metadata`: Plus entry `ci: true` + `image_name: pfsense-plus` (the
+  MAC/uuid stay in the secrets, NOT the entry); schema gains the optional `image_name`
+  field; `lifecycle_policy.plus` text rewritten.
 - Dispatch `smoke-fanout.yml`; both legs + AND-gate green; pull a Plus-leg
   diagnostics artifact and verify no license identifier (§4.7).
 
@@ -241,11 +263,12 @@ Evidence in `RESULTS/05_Results.txt` (and per-phase RESULTS):
 
 1. `oras manifest fetch ghcr.io/pfblockerng/pfsense-plus:26.03` succeeds with repo
    token; the package page shows **Private**.
-2. Boot the published Plus qcow2 locally via `boot_vm.sh` with
-   `SMOKE_VM_MAC=REDACTED_PLUS_MAC`: no interface-reassignment prompt; license
-   status intact in the GUI.
-3. Boot it once WITHOUT the override (CE pin): expect the reassignment prompt /
-   unregistered state — proving the MAC is load-bearing (then discard the overlay).
+2. Boot the published Plus qcow2 locally via `boot_vm.sh` with `SMOKE_VM_MAC` +
+   `SMOKE_VM_SMBIOS_UUID` set to the Plus source-VM identity (the values held in the
+   `SMOKE_PLUS_MAC`/`SMOKE_PLUS_SMBIOS_UUID` secrets): no interface-reassignment
+   prompt; license status intact in the GUI.
+3. Boot it once WITHOUT the overrides (CE pins): expect the reassignment prompt /
+   unregistered state — proving the identity is load-bearing (then discard the overlay).
 4. `pkg info` on the Plus guest shows the baked RUN_DEPENDS (no network installs
    during smoke).
 

--- a/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/02_Results.txt
@@ -39,7 +39,9 @@ WHAT CHANGED
    c. test_ci_matrix_entries_default_image_name_and_mac  — CE entry omitting the
       fields resolves image_name=pfsense-ce, mac=BC:24:11:37:9C:AC. RED today.
    d. test_ci_matrix_entries_pass_through_explicit_image_name_and_mac — explicit
-      pfsense-plus / REDACTED_PLUS_MAC emitted verbatim. RED today.
+      pfsense-plus / a fake documentation MAC emitted verbatim. RED today.
+      (ADR-24 step 3 superseded the real Plus MAC out of the fixture: the Plus
+      identity is now a secret, never the matrix — the test uses a fake doc MAC.)
    e. test_build_and_test_matrices_unchanged_by_new_fields — BUILD matrix is the
       verbatim versions array (no image_name/mac injected on the CE build entry),
       python_versions==["3.11"], php_versions==["8.3","8.5"] (§2.2.6). Pin.

--- a/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/RESULTS/03_Results.txt
@@ -22,8 +22,12 @@ WHAT CHANGED (only the two workflow files)
        image_name  (string, default "pfsense-ce")
        mac         (string, default "BC:24:11:37:9C:AC")  ← the CE pin
      Each carries a help description noting the fan-out passes the per-leg
-     matrix.image_name / matrix.mac (Plus = pfsense-plus / REDACTED_PLUS_MAC),
-     and that image_name is ignored when image_ref is set.
+     matrix.image_name (Plus = pfsense-plus), and that image_name is ignored
+     when image_ref is set.
+     (NOTE: ADR-24 step 3 superseded the mac-via-matrix design — the Plus VM
+     identity, MAC + SMBIOS uuid, now comes from the SMOKE_PLUS_* secrets, and
+     smoke.yml gained a "Resolve VM identity" step. The mac input remains a
+     CE-public default placeholder only.)
    - RESOLVE-REF step ("Resolve the pfSense image ref"):
        new env  INPUT_IMAGE_NAME: ${{ inputs.image_name }}
        NAME line changed from
@@ -105,19 +109,24 @@ A') Bare smoke.yml dispatch (no inputs at all):
    ⇒ Same ref + same MAC as a pre-change bare dispatch. ✔ (§2.2.1)
 
 B) Plus matrix entry (Phase 4 will introduce this on ci-metadata; NOT live today):
-     pfsense_version="26.03", image_name="pfsense-plus", mac="REDACTED_PLUS_MAC",
-     channel="Plus", ci=true
+     pfsense_version="26.03", image_name="pfsense-plus", channel="Plus", ci=true
+     (NOTE: ADR-24 step 3 superseded the mac-via-matrix design — the Plus VM
+     identity, MAC + SMBIOS uuid, now comes from the SMOKE_PLUS_MAC +
+     SMOKE_PLUS_SMBIOS_UUID secrets, never the matrix entry.)
    fan-out passes to smoke.yml:
-     pfsense_version=26.03  image_name=pfsense-plus  mac=REDACTED_PLUS_MAC
+     pfsense_version=26.03  image_name=pfsense-plus  (+ secrets: inherit)
    smoke.yml resolve-ref:
      REPO = ghcr.io/pfblockerng
      NAME = pfsense-plus
      TAG  = 26.03
      REF  = ghcr.io/pfblockerng/pfsense-plus:26.03   (private, pulled not published)
-   pytest env: SMOKE_VM_MAC = REDACTED_PLUS_MAC → boot_vm.sh boots the Plus VM with
-     its license-keyed NIC MAC.
+   smoke.yml "Resolve VM identity" step (non-CE branch): reads SMOKE_PLUS_MAC +
+     SMOKE_PLUS_SMBIOS_UUID secrets → SMOKE_VM_MAC / SMOKE_VM_SMBIOS_UUID for pytest
+     (+ SMOKE_REDACT_VALUES for the diagnostics scrub); fails closed if absent.
+   pytest env: SMOKE_VM_MAC / SMOKE_VM_SMBIOS_UUID → boot_vm.sh boots the Plus VM
+     with its license-keyed NIC MAC + SMBIOS uuid.
    leg name in the UI: "Smoke (Plus 26.03)".
-   ⇒ A Plus entry, once ci:true, routes its own private image + license MAC
+   ⇒ A Plus entry, once ci:true, routes its own private image + secret identity
      end-to-end. Does NOT appear today (live Plus is ci:false → excluded by the
      matrix reader, and the CI GUARD would also catch a ci:false leak).
 
@@ -190,9 +199,11 @@ confirm before dispatching the live flip:
       key in root authorized_keys.                               — UNVERIFIED here
   [ ] Diagnostics scrub verified for the Plus license (no NDI / license
       identifier in the smoke-diagnostics artifact — §4.7).      — UNVERIFIED here
-Once all four hold, Phase 4 opens a PR against ci-metadata (Plus entry ci:true +
-image_name: pfsense-plus + mac: REDACTED_PLUS_MAC; schema gains the two optional
-fields; lifecycle_policy.plus text rewritten), then dispatches smoke-fanout.yml
+Once all four hold, Phase 4 sets the SMOKE_PLUS_MAC + SMOKE_PLUS_SMBIOS_UUID
+secrets and opens a PR against ci-metadata (Plus entry ci:true +
+image_name: pfsense-plus; the MAC/uuid are secrets, not matrix fields; schema
+gains the optional image_name field; lifecycle_policy.plus text rewritten), then
+dispatches smoke-fanout.yml
 and verifies both legs + the AND-gate green and the Plus-leg diagnostics carry no
 license identifier.
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -327,16 +327,21 @@ jobs:
           PLUS_NDI: ${{ secrets.SMOKE_PLUS_NDI }}
         run: |
           set -eu
-          IMG="${IMAGE_REF:-${INPUT_IMAGE_NAME:-pfsense-ce}}"
-          case "$IMG" in
-            *pfsense-ce*)
+          # Resolve the EXACT image name (strip ghcr path, @digest, :tag) — a substring
+          # match could misclassify a non-CE image as CE and skip the secret + redaction.
+          IMG_NAME="${INPUT_IMAGE_NAME:-pfsense-ce}"
+          if [ -n "${IMAGE_REF:-}" ]; then
+            REF_NO_DIGEST="${IMAGE_REF%@*}"; IMG_NAME="${REF_NO_DIGEST##*/}"; IMG_NAME="${IMG_NAME%%:*}"
+          fi
+          case "$IMG_NAME" in
+            pfsense-ce)
               # CE: the public pin. No identity is secret -> nothing to redact.
               echo "RESOLVED_VM_MAC=${INPUT_MAC:-BC:24:11:37:9C:AC}" >> "$GITHUB_ENV"
               echo "RESOLVED_VM_SMBIOS_UUID=58fd7964-c40c-4f47-bf02-3fdad18f8b00" >> "$GITHUB_ENV"
               echo "RESOLVED_REDACT=" >> "$GITHUB_ENV" ;;
             *)  # non-CE (Plus): license/NDI-keyed identity comes from secrets, never the matrix
               if [ -z "${PLUS_MAC:-}" ] || [ -z "${PLUS_UUID:-}" ]; then
-                echo "::error::non-CE image '$IMG' requires the SMOKE_PLUS_MAC and SMOKE_PLUS_SMBIOS_UUID secrets (the Plus source-VM identity); one or both are empty."; exit 1
+                echo "::error::non-CE image '$IMG_NAME' requires the SMOKE_PLUS_MAC and SMOKE_PLUS_SMBIOS_UUID secrets (the Plus source-VM identity); one or both are empty."; exit 1
               fi
               # Mask before anything echoes them; NDI optional.
               printf '::add-mask::%s\n' "$PLUS_MAC" "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '::add-mask::%s\n' "$PLUS_NDI" || true
@@ -434,10 +439,14 @@ jobs:
           SMOKE_REDACT_VALUES: ${{ env.RESOLVED_REDACT }}
         run: |
           set -eu
-          IMG="${IMAGE_REF:-${INPUT_IMAGE_NAME:-pfsense-ce}}"
+          # Exact image-name match (strip ghcr path, @digest, :tag), not a substring.
+          IMG_NAME="${INPUT_IMAGE_NAME:-pfsense-ce}"
+          if [ -n "${IMAGE_REF:-}" ]; then
+            REF_NO_DIGEST="${IMAGE_REF%@*}"; IMG_NAME="${REF_NO_DIGEST##*/}"; IMG_NAME="${IMG_NAME%%:*}"
+          fi
           # Non-CE: drop console screenshots (pixels can leak NDI/serial).
-          case "$IMG" in
-            *pfsense-ce*) : ;;
+          case "$IMG_NAME" in
+            pfsense-ce) : ;;
             *) find . -type f \( -name 'screen-*.png' -o -name 'screen-*.ppm' \) -delete 2>/dev/null || true ;;
           esac
           # Value-redaction is a strict no-op when RESOLVED_REDACT is empty (CE).
@@ -449,9 +458,11 @@ jobs:
               -e 's/\[/\\[/g' -e 's/\]/\\]/g' -e 's/\^/\\^/g' -e 's/\$/\\$/g' -e 's/#/\\#/g'
           }
           : > redact.sed
+          # `I` flag = case-insensitive (GNU + FreeBSD sed) so an upper-case secret
+          # scrubs the lower-case MAC/uuid that logs/ifconfig emit.
           printf '%s\n' "$SMOKE_REDACT_VALUES" | while IFS= read -r v; do
             [ -n "$v" ] || continue
-            printf 's#%s#REDACTED#g;\n' "$(esc "$v")" >> redact.sed
+            printf 's#%s#REDACTED#gI;\n' "$(esc "$v")" >> redact.sed
           done
           # GNU sed on the runner: -i with no backup-suffix arg. Redact every vm*.log
           # and every TEXT file under the diag dirs.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -53,7 +53,7 @@ on:
         required: false
         default: "pfsense-ce"
       mac:
-        description: "QEMU NIC MAC for the VM boot (default the CE pin BC:24:11:37:9C:AC). The fan-out passes the per-leg matrix.mac; Plus is license-keyed to REDACTED_PLUS_MAC."
+        description: "QEMU NIC MAC for the VM boot (default the CE pin BC:24:11:37:9C:AC). Used for CE only; a non-CE (Plus) image takes its license/NDI-keyed MAC from the SMOKE_PLUS_MAC secret, never this input."
         required: false
         default: "BC:24:11:37:9C:AC"
       pytest_marker:
@@ -82,7 +82,7 @@ on:
         type: string
         default: "pfsense-ce"
       mac:
-        description: "QEMU NIC MAC for the VM boot (default the CE pin BC:24:11:37:9C:AC). The fan-out passes the per-leg matrix.mac; Plus is license-keyed to REDACTED_PLUS_MAC."
+        description: "QEMU NIC MAC for the VM boot (default the CE pin BC:24:11:37:9C:AC). Used for CE only; a non-CE (Plus) image takes its license/NDI-keyed MAC from the SMOKE_PLUS_MAC secret, never this input."
         required: false
         type: string
         default: "BC:24:11:37:9C:AC"
@@ -309,21 +309,42 @@ jobs:
             --out out-nightly
           echo "SMOKE_NIGHTLY_PKG=$(find "$PWD/out-nightly" -name '*.pkg' | head -1)" >> "$GITHUB_ENV"
 
-      # ADR-24 §2.2.4: a non-CE image (Plus) is license/NDI-keyed to its OWN
-      # source-VM MAC and must NEVER boot with the CE pin. Fail fast if a caller
-      # selects a non-CE image_name but leaves mac at the CE default — booting
-      # Plus with the wrong VM identity would invalidate its registration.
-      - name: Validate image/MAC contract
+      # ADR-24 §2.2.4: the VM identity (NIC MAC + SMBIOS uuid) is per-image. CE
+      # uses the public pin (the `mac` input + the CE source-VM uuid). A non-CE
+      # (Plus) image is LICENSE/NDI-keyed to its OWN source-VM identity, which is
+      # SECRET — it comes from the SMOKE_PLUS_MAC + SMOKE_PLUS_SMBIOS_UUID secrets,
+      # NEVER the public ci-metadata matrix (the NDI is derived from MAC + uuid, so
+      # both are as license-keyed as the MAC). This resolves the effective identity
+      # and, for Plus, masks it + emits the diagnostics redaction set. Fail closed
+      # if a non-CE image is selected without those secrets.
+      - name: Resolve VM identity (MAC + SMBIOS uuid)
         env:
+          IMAGE_REF: ${{ steps.ref.outputs.ref }}
           INPUT_IMAGE_NAME: ${{ inputs.image_name }}
           INPUT_MAC: ${{ inputs.mac }}
+          PLUS_MAC: ${{ secrets.SMOKE_PLUS_MAC }}
+          PLUS_UUID: ${{ secrets.SMOKE_PLUS_SMBIOS_UUID }}
+          PLUS_NDI: ${{ secrets.SMOKE_PLUS_NDI }}
         run: |
           set -eu
-          if [ "${INPUT_IMAGE_NAME:-pfsense-ce}" != "pfsense-ce" ] && \
-             [ "${INPUT_MAC:-}" = "BC:24:11:37:9C:AC" ]; then
-            echo "::error::Image '${INPUT_IMAGE_NAME}' must boot with its own source-VM MAC (license/NDI-keyed); inputs.mac is still the CE pin. Set inputs.mac explicitly."
-            exit 1
-          fi
+          IMG="${IMAGE_REF:-${INPUT_IMAGE_NAME:-pfsense-ce}}"
+          case "$IMG" in
+            *pfsense-ce*)
+              # CE: the public pin. No identity is secret -> nothing to redact.
+              echo "RESOLVED_VM_MAC=${INPUT_MAC:-BC:24:11:37:9C:AC}" >> "$GITHUB_ENV"
+              echo "RESOLVED_VM_SMBIOS_UUID=58fd7964-c40c-4f47-bf02-3fdad18f8b00" >> "$GITHUB_ENV"
+              echo "RESOLVED_REDACT=" >> "$GITHUB_ENV" ;;
+            *)  # non-CE (Plus): license/NDI-keyed identity comes from secrets, never the matrix
+              if [ -z "${PLUS_MAC:-}" ] || [ -z "${PLUS_UUID:-}" ]; then
+                echo "::error::non-CE image '$IMG' requires the SMOKE_PLUS_MAC and SMOKE_PLUS_SMBIOS_UUID secrets (the Plus source-VM identity); one or both are empty."; exit 1
+              fi
+              # Mask before anything echoes them; NDI optional.
+              printf '::add-mask::%s\n' "$PLUS_MAC" "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '::add-mask::%s\n' "$PLUS_NDI" || true
+              echo "RESOLVED_VM_MAC=$PLUS_MAC" >> "$GITHUB_ENV"
+              echo "RESOLVED_VM_SMBIOS_UUID=$PLUS_UUID" >> "$GITHUB_ENV"
+              # newline-joined redaction set for the diagnostics scrub (MAC + uuid [+ NDI])
+              { printf 'RESOLVED_REDACT<<__EOF__\n%s\n%s\n' "$PLUS_MAC" "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '%s\n' "$PLUS_NDI"; printf '__EOF__\n'; } >> "$GITHUB_ENV" ;;
+          esac
 
       # HERMETICITY (ADR §2/§4): the egress block is done INSIDE pytest, by the
       # matrix's `deployed_vm` fixture, after deploy() and before the per-case
@@ -346,11 +367,15 @@ jobs:
           # boot needs no network. SMOKE_IMAGE_REF is kept for provenance/logs.
           SMOKE_IMAGE_DIR: ${{ github.workspace }}/image
           SMOKE_IMAGE_REF: ${{ steps.ref.outputs.ref }}
-          # QEMU NIC MAC for the VM boot (ADR-24): conftest passes this through to
-          # boot_vm.sh. Defaults to the CE pin so a bare dispatch is byte-identical;
-          # the fan-out passes the per-leg matrix.mac (Plus = REDACTED_PLUS_MAC,
-          # license-keyed). boot_vm.sh keeps the same CE default if this is unset.
-          SMOKE_VM_MAC: ${{ inputs.mac }}
+          # QEMU NIC MAC + SMBIOS uuid for the VM boot (ADR-24): conftest passes
+          # these through to boot_vm.sh. RESOLVED_* come from the "Resolve VM
+          # identity" step — the CE pin for a CE image (byte-identical to a bare
+          # dispatch), the SMOKE_PLUS_* secrets for a Plus image. SMOKE_REDACT_VALUES
+          # is the (masked) Plus identity the diagnostics scrub value-redacts; EMPTY
+          # for CE -> the scrub is a strict no-op (CE bundle unchanged).
+          SMOKE_VM_MAC: ${{ env.RESOLVED_VM_MAC }}
+          SMOKE_VM_SMBIOS_UUID: ${{ env.RESOLVED_VM_SMBIOS_UUID }}
+          SMOKE_REDACT_VALUES: ${{ env.RESOLVED_REDACT }}
           SMOKE_SSH_KEY: smoke_key
           SMOKE_PKG: ${{ steps.paths.outputs.pkg }}
           # The builder-produced -nightly .pkg (set above for the `repo` marker; the
@@ -391,6 +416,52 @@ jobs:
           python3 -m pytest tests/smoke -m "${PYTEST_MARKER}" \
             --override-ini="addopts=" --override-ini="timeout_func_only=true" \
             --timeout=30 --timeout-method=signal -v
+
+      # ADR-24: runner-side scrub of the Plus secret identity from the diagnostics
+      # BEFORE upload. For a non-CE (Plus) image: drop the console screenshots
+      # (screen-*.png/.ppm) — a banner screenshot shows the NDI/serial as PIXELS
+      # that no text redaction can reach — and literal-redact each secret value
+      # (MAC + uuid [+ NDI], from RESOLVED_REDACT) across every vm*.log and text
+      # file under the diag dir. CE: RESOLVED_REDACT is empty -> no-op (the artifact
+      # is byte-identical to today). The literal escape mirrors helpers.py's
+      # _sed_escape_literal (one -e per BRE metachar, NOT a bracket-class) so a
+      # regex-special value is matched literally.
+      - name: Scrub Plus secret identity from diagnostics (runner side)
+        if: always()
+        env:
+          IMAGE_REF: ${{ steps.ref.outputs.ref }}
+          INPUT_IMAGE_NAME: ${{ inputs.image_name }}
+          SMOKE_REDACT_VALUES: ${{ env.RESOLVED_REDACT }}
+        run: |
+          set -eu
+          IMG="${IMAGE_REF:-${INPUT_IMAGE_NAME:-pfsense-ce}}"
+          # Non-CE: drop console screenshots (pixels can leak NDI/serial).
+          case "$IMG" in
+            *pfsense-ce*) : ;;
+            *) find . -type f \( -name 'screen-*.png' -o -name 'screen-*.ppm' \) -delete 2>/dev/null || true ;;
+          esac
+          # Value-redaction is a strict no-op when RESOLVED_REDACT is empty (CE).
+          [ -n "${SMOKE_REDACT_VALUES:-}" ] || { echo "no redaction values (CE leg) — runner-side scrub is a no-op"; exit 0; }
+          # Build a redact.sed of literal s###REDACTED### per value. BRE-escape each
+          # value with one -e per metachar (\ first, then . * [ ] ^ $ #).
+          esc() {
+            printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/\./\\./g' -e 's/\*/\\*/g' \
+              -e 's/\[/\\[/g' -e 's/\]/\\]/g' -e 's/\^/\\^/g' -e 's/\$/\\$/g' -e 's/#/\\#/g'
+          }
+          : > redact.sed
+          printf '%s\n' "$SMOKE_REDACT_VALUES" | while IFS= read -r v; do
+            [ -n "$v" ] || continue
+            printf 's#%s#REDACTED#g;\n' "$(esc "$v")" >> redact.sed
+          done
+          # GNU sed on the runner: -i with no backup-suffix arg. Redact every vm*.log
+          # and every TEXT file under the diag dirs.
+          find . -type f -name 'vm*.log' 2>/dev/null | while IFS= read -r f; do
+            sed -i -f redact.sed "$f" 2>/dev/null || true
+          done
+          find smoke-diag -type f 2>/dev/null | while IFS= read -r f; do
+            LC_ALL=C grep -Iq . "$f" 2>/dev/null && sed -i -f redact.sed "$f" 2>/dev/null || true
+          done
+          rm -f redact.sed
 
       - name: Upload smoke diagnostics
         if: always()

--- a/tests/smoke/boot_vm.sh
+++ b/tests/smoke/boot_vm.sh
@@ -22,6 +22,11 @@
 #     image MUST set SMOKE_VM_MAC to its OWN source-VM MAC: the Plus license/NDI
 #     registration is keyed to it, so the CE pin would deregister/reassign it
 #     (see ADR-24 and scripts/README.md § "pfSense Plus images").
+#   - SMBIOS type-1 uuid pinned, per-image. The Plus Netgate Device ID (NDI) is
+#     derived from the source VM's MAC + this SMBIOS uuid, so the uuid is as
+#     license-keyed as the MAC. CE defaults to the public CE source-VM uuid;
+#     a Plus image MUST set SMOKE_VM_SMBIOS_UUID to its OWN source-VM uuid (held
+#     in a secret, NOT the public ci-metadata matrix — license/NDI-keyed).
 #   - VirtIO-SCSI disk (guest sees da0)
 #   - machine type pc (i440fx; Proxmox pc+pve0), -cpu host, 2 vCPU, 4 GB RAM
 #
@@ -38,9 +43,11 @@ QEMU=/usr/bin/qemu-system-x86_64
 QEMU_IMG=/usr/bin/qemu-img
 
 # Source-VM hardware profile (mirror — do not change without re-baking image).
-# MAC is per-image: CE pin by default, SMOKE_VM_MAC overrides (Plus MUST set it).
+# MAC + SMBIOS uuid are per-image: CE pins by default, SMOKE_VM_MAC /
+# SMOKE_VM_SMBIOS_UUID override (Plus MUST set both — its NDI is derived from
+# MAC + uuid, so both are license-keyed and come from secrets, not the matrix).
 VM_MAC="${SMOKE_VM_MAC:-BC:24:11:37:9C:AC}"
-VM_SMBIOS_UUID="58fd7964-c40c-4f47-bf02-3fdad18f8b00"
+VM_SMBIOS_UUID="${SMOKE_VM_SMBIOS_UUID:-58fd7964-c40c-4f47-bf02-3fdad18f8b00}"
 VM_SMP="2,sockets=1,cores=2"
 VM_MEM="4096"
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2279,7 +2279,7 @@ _SENSITIVE_TAG_WORDS: tuple[str, ...] = (
 # the exact same alternation and can never drift. A tag name is `[a-z0-9_:-]*`
 # ending in one of the words, optionally followed by a single plural `s`.
 _SENSITIVE_TAG_ALTERNATION = "|".join(_SENSITIVE_TAG_WORDS)
-_SENSITIVE_TAG_PATTERN = re.compile(r"(<[a-z0-9_:-]*(?:" + _SENSITIVE_TAG_ALTERNATION + r")s?>)[^<]*")
+_SENSITIVE_TAG_PATTERN = re.compile(r"(<[a-z0-9_:-]*(?:" + _SENSITIVE_TAG_ALTERNATION + r")s?>)[^<]*", re.IGNORECASE)
 
 
 def redact_sensitive_xml_tags(text: str) -> str:
@@ -2294,27 +2294,27 @@ def redact_sensitive_xml_tags(text: str) -> str:
     (``<name>…``) match — never closing tags (``</name>``, excluded because the name
     charset omits ``/``) — so element structure is never corrupted.
 
-    Match is case-sensitive lowercase: pfSense ``config.xml`` tag names are
-    machine-generated lowercase, so a lowercase-only pattern is sufficient and keeps
-    the BSD-``sed`` counterpart (no portable ``I`` flag) identical.
+    Match is CASE-INSENSITIVE (``re.IGNORECASE`` here, the ``I`` sed flag in the
+    counterpart): pfSense ``config.xml`` tag names are machine-generated lowercase,
+    but matching any case is strictly safer (a stray ``<TOKEN>`` is still scrubbed)
+    and costs nothing.
 
-    Pure Python — the in-guest scrub uses the equivalent BSD-``sed`` program from
+    Pure Python — the in-guest scrub uses the equivalent ``sed`` program from
     :func:`sensitive_tag_sed_program`; the two are pinned together by a parity test.
     """
     return _SENSITIVE_TAG_PATTERN.sub(r"\1" + REDACTED, text)
 
 
 def sensitive_tag_sed_program() -> str:
-    """Return the BSD-``sed -E`` substitution that performs the SAME redaction as
+    """Return the ``sed -E`` substitution that performs the SAME redaction as
     :func:`redact_sensitive_xml_tags`.
 
     Delimiter ``#``, constant replacement ``REDACTED``, alternation built from
     :data:`_SENSITIVE_TAG_WORDS` (so the shell and Python redactors cannot drift).
-    Portable ERE only — no GNU-only constructs, no case-insensitive ``I`` flag (BSD
-    ``sed`` lacks it; the lowercase-only match is sufficient for machine-generated
-    config.xml tag names).
+    The ``I`` flag makes it case-insensitive — supported by both FreeBSD ``sed``
+    (in-guest) and GNU ``sed`` — mirroring the Python pattern's ``re.IGNORECASE``.
     """
-    return "s#(<[a-z0-9_:-]*(" + _SENSITIVE_TAG_ALTERNATION + ")s?>)[^<]*#\\1" + REDACTED + "#g"
+    return "s#(<[a-z0-9_:-]*(" + _SENSITIVE_TAG_ALTERNATION + ")s?>)[^<]*#\\1" + REDACTED + "#gI"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2364,9 +2364,11 @@ def _sed_escape_literal(value: str) -> str:
 
 
 def redact_values(text: str, values: Iterable[str]) -> str:
-    """Replace every non-empty ``value`` (matched LITERALLY, not as a regex) in
-    ``text`` with ``REDACTED``.
+    """Replace every non-empty ``value`` (matched LITERALLY, not as a regex, and
+    CASE-INSENSITIVELY) in ``text`` with ``REDACTED``.
 
+    Case-insensitive to mirror the ``s###REDACTED###gI`` sed flag the shell paths
+    use, so an upper-case MAC/uuid secret still scrubs its lower-case rendering.
     Pure Python — pinned in the unit suite against the shell ``sed`` redactor
     (:func:`_sed_escape_literal` parity). Empty / whitespace-only values are ignored
     (an empty needle would otherwise match everywhere). With an empty ``values`` this
@@ -2375,7 +2377,9 @@ def redact_values(text: str, values: Iterable[str]) -> str:
     out = text
     for value in values:
         if value and value.strip():
-            out = out.replace(value, REDACTED)
+            # Case-insensitive (mirrors the `s###gI` sed flag) so an upper-case secret
+            # still matches the lower-case MAC/uuid that ifconfig/dmesg/logs emit.
+            out = re.sub(re.escape(value), REDACTED, out, flags=re.IGNORECASE)
     return out
 
 
@@ -2453,7 +2457,10 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
     build_redact_sed = ""
     redact_bundle = ""
     if redact_values_set:
-        sed_prog = "".join(f"s#{_sed_escape_literal(v)}#{REDACTED}#g;" for v in redact_values_set)
+        # `I` flag = case-insensitive (supported by both FreeBSD sed in-guest and GNU
+        # sed on the runner), so an upper-case secret still matches the lower-case
+        # MAC/uuid that ifconfig/dmesg/logs emit.
+        sed_prog = "".join(f"s#{_sed_escape_literal(v)}#{REDACTED}#gI;" for v in redact_values_set)
         # In-guest BRE-escape of the live serial — SAME metachar set + order as
         # _sed_escape_literal (`\` first, then `. * [ ] ^ $ #`), one `-e` per
         # metachar (NOT a bracket-class: a class like `[\.*[]^$#]` closes early at
@@ -2472,7 +2479,8 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
             "case \"$SL\" in 'not specified'|'to be filled by o.e.m.'|'0'|'none'|'default string'|'') S='' ;; esac; "
             'if [ -n "$S" ]; then '
             f"ES=$(printf '%s' \"$S\" | {serial_esc}); "
-            'printf \'s#%s#REDACTED#g;\' "$ES" >> "$D/redact.sed"; '
+            # `I` flag → case-insensitive, so a differently-cased serial rendering scrubs too.
+            'printf \'s#%s#REDACTED#gI;\' "$ES" >> "$D/redact.sed"; '
             "fi; "
         )
         var_log_capture = 'cp -a /var/log "$D/var_log_stage" 2>/dev/null; '

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -47,7 +47,7 @@ import shlex
 import subprocess
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -2317,6 +2317,91 @@ def sensitive_tag_sed_program() -> str:
     return "s#(<[a-z0-9_:-]*(" + _SENSITIVE_TAG_ALTERNATION + ")s?>)[^<]*#\\1" + REDACTED + "#g"
 
 
+# --------------------------------------------------------------------------- #
+# ADR-24 — value-based redaction of the pfSense Plus secret VM identity
+# --------------------------------------------------------------------------- #
+# The Plus source-VM MAC + SMBIOS uuid (and, if supplied, the Netgate Device ID)
+# are LICENSE/NDI-keyed secrets — they come from the SMOKE_PLUS_MAC /
+# SMOKE_PLUS_SMBIOS_UUID (/ SMOKE_PLUS_NDI) GitHub secrets, NEVER the public
+# ci-metadata matrix. Booting the licensed Plus image in CI puts those values into
+# the diagnostics bundle (the MAC lands in ifconfig.txt, the uuid in dmesg.txt,
+# both can surface in /var/log), so a live Plus run would otherwise LEAK them in an
+# uploaded artifact. The set is supplied newline-/comma-joined via
+# SMOKE_REDACT_VALUES (smoke.yml builds it for the Plus leg only) plus the live
+# in-guest serial; a CE leg sets it empty -> the parsed set is empty -> every
+# redactor below is a strict no-op and the CE bundle stays byte-identical.
+
+# Generic SMBIOS placeholders that are NOT secrets — `kenv smbios.system.serial`
+# returns one of these on hardware/VMs without a real serial. Redacting them would
+# scrub harmless ubiquitous strings out of the logs (and could even no-op-mangle
+# unrelated text), so they are dropped from the redaction set.
+_SMBIOS_PLACEHOLDERS = frozenset(
+    {
+        "not specified",
+        "to be filled by o.e.m.",
+        "0",
+        "none",
+        "default string",
+    }
+)
+
+
+def _sed_escape_literal(value: str) -> str:
+    """Escape ``value`` so it is safe as the PATTERN of a ``sed`` BRE ``s###``
+    substitution (the in-guest/runner shell redactor).
+
+    The substitution uses ``#`` as the delimiter and a constant replacement
+    (``REDACTED``), so only the PATTERN side needs escaping. In a POSIX BRE the
+    active metacharacters are ``\\ . * [ ] ^ $`` (``^``/``$`` only as anchors, but
+    escaping them unconditionally is safe and simpler); the chosen delimiter ``#``
+    must also be escaped so a value containing it cannot terminate the pattern.
+    Backslash is escaped FIRST so the escapes we add are not themselves re-escaped.
+    """
+    out = value.replace("\\", "\\\\")
+    for ch in (".", "*", "[", "]", "^", "$", "#"):
+        out = out.replace(ch, "\\" + ch)
+    return out
+
+
+def redact_values(text: str, values: Iterable[str]) -> str:
+    """Replace every non-empty ``value`` (matched LITERALLY, not as a regex) in
+    ``text`` with ``REDACTED``.
+
+    Pure Python — pinned in the unit suite against the shell ``sed`` redactor
+    (:func:`_sed_escape_literal` parity). Empty / whitespace-only values are ignored
+    (an empty needle would otherwise match everywhere). With an empty ``values`` this
+    is the identity function — the load-bearing CE no-op.
+    """
+    out = text
+    for value in values:
+        if value and value.strip():
+            out = out.replace(value, REDACTED)
+    return out
+
+
+def parse_redact_values(raw: str | None) -> list[str]:
+    """Parse ``SMOKE_REDACT_VALUES`` into the de-duplicated literal redaction set.
+
+    The raw env value is newline- and/or comma-separated. Each token is stripped;
+    empties and obviously-generic SMBIOS placeholders (``Not Specified``,
+    ``To Be Filled By O.E.M.``, ``0``, ``None``, ``Default string``,
+    case-insensitive) are dropped — they are not secrets and redacting them would
+    mangle unrelated diagnostics. ``None`` / empty -> ``[]`` (the CE no-op).
+    """
+    if not raw:
+        return []
+    seen: set[str] = set()
+    values: list[str] = []
+    for token in raw.replace(",", "\n").split("\n"):
+        value = token.strip()
+        if not value or value.lower() in _SMBIOS_PLACEHOLDERS:
+            continue
+        if value not in seen:
+            seen.add(value)
+            values.append(value)
+    return values
+
+
 def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeout: float = 240.0) -> None:
     """Tar a COMPREHENSIVE pfSense-GUEST snapshot and pull it to ``dest_dir/`` on
     the runner, for the workflow to upload as an artifact.
@@ -2334,6 +2419,12 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
     cert private keys, authorized keys redacted before it leaves the box).
     """
     remote_tar = "/tmp/pfb_smoke_diag.tgz"
+    # ADR-24: value-based redaction of the Plus secret VM identity. Active IFF
+    # SMOKE_REDACT_VALUES parses to a non-empty set; CE legs (no secret) -> empty
+    # -> redaction is a strict no-op and the emitted script below is byte-identical
+    # to before (the CE bundle is unchanged).
+    redact_values_set = parse_redact_values(os.environ.get("SMOKE_REDACT_VALUES"))
+
     # config.xml secret scrub. The explicit credential substitutions
     # (bcrypt/prv/authorizedkeys/tls_certificate) stay belt-and-suspenders — they are
     # NOT name-matched by the sensitive-tag pass. ADR-24: the Actuator-style
@@ -2347,10 +2438,62 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
         '/conf/config.xml > "$D/config.scrubbed.xml" 2>/dev/null; '
     )
 
+    # /var/log: tarred directly when value-redaction is OFF; when ON it is STAGED
+    # (cp -a) so the per-bundle redaction pass below can scrub the log text in place
+    # before the stage is tarred — the secret MAC/uuid can surface in /var/log too.
+    var_log_capture = 'tar czf "$D/var_log.tgz" -C /var log 2>/dev/null; '
+
+    # Value-redaction pass (Plus only). The MAC lives in ifconfig.txt, the SMBIOS
+    # uuid in dmesg.txt, and either can land in the staged /var/log — so the WHOLE
+    # bundle (config.scrubbed.xml, the var_log stage, ifconfig/dmesg/ps/sockstat/
+    # netstat, the unbound *.conf copies, …) is scrubbed, not just config + logs.
+    # A redact.sed program (one literal s###REDACTED### per maintainer value, BRE-
+    # escaped) is emitted once, the live in-guest serial appended (escaped the same
+    # way), then run over every TEXT file in $D (grep -Iq . detects text).
+    build_redact_sed = ""
+    redact_bundle = ""
+    if redact_values_set:
+        sed_prog = "".join(f"s#{_sed_escape_literal(v)}#{REDACTED}#g;" for v in redact_values_set)
+        # In-guest BRE-escape of the live serial — SAME metachar set + order as
+        # _sed_escape_literal (`\` first, then `. * [ ] ^ $ #`), one `-e` per
+        # metachar (NOT a bracket-class: a class like `[\.*[]^$#]` closes early at
+        # the first `]` and escapes nothing) — so the shell and Python redactors
+        # agree (pinned by the parity test).
+        serial_esc = (
+            "sed -e 's/\\\\/\\\\\\\\/g' -e 's/\\./\\\\./g' -e 's/\\*/\\\\*/g' "
+            "-e 's/\\[/\\\\[/g' -e 's/\\]/\\\\]/g' -e 's/\\^/\\\\^/g' "
+            "-e 's/\\$/\\\\$/g' -e 's/#/\\\\#/g'"
+        )
+        build_redact_sed = (
+            f"printf '%s' {shlex.quote(sed_prog)} > \"$D/redact.sed\"; "
+            "S=$(kenv -q smbios.system.serial 2>/dev/null); "
+            # Drop generic SMBIOS placeholders case-insensitively (mirror parse_redact_values).
+            "SL=$(printf '%s' \"$S\" | tr '[:upper:]' '[:lower:]'); "
+            "case \"$SL\" in 'not specified'|'to be filled by o.e.m.'|'0'|'none'|'default string'|'') S='' ;; esac; "
+            'if [ -n "$S" ]; then '
+            f"ES=$(printf '%s' \"$S\" | {serial_esc}); "
+            'printf \'s#%s#REDACTED#g;\' "$ES" >> "$D/redact.sed"; '
+            "fi; "
+        )
+        var_log_capture = 'cp -a /var/log "$D/var_log_stage" 2>/dev/null; '
+        # Run AFTER every file is collected (so it also catches the var_log stage,
+        # ifconfig.txt, dmesg.txt, the unbound confs, …) and BEFORE the final tar.
+        # redact.sed itself is removed so the program (which embeds the literals) is
+        # never shipped in the bundle. Then the staged /var/log is tarred + dropped.
+        redact_bundle = (
+            'find "$D" -type f ! -name redact.sed 2>/dev/null | while IFS= read -r f; do '
+            'LC_ALL=C grep -Iq . "$f" 2>/dev/null && sed -i \'\' -f "$D/redact.sed" "$f" 2>/dev/null; '
+            "done; "
+            'rm -f "$D/redact.sed" 2>/dev/null; '
+            'tar czf "$D/var_log.tgz" -C "$D" var_log_stage 2>/dev/null; '
+            'rm -rf "$D/var_log_stage" 2>/dev/null; '
+        )
+
     script = (
         'set +e; D=/tmp/pfb_smoke_diag; rm -rf "$D"; mkdir -p "$D/unbound"; '
-        'tar czf "$D/var_log.tgz" -C /var log 2>/dev/null; '
-        '/sbin/dmesg > "$D/dmesg.txt" 2>&1; cp /var/run/dmesg.boot "$D/dmesg.boot" 2>/dev/null; '
+        + build_redact_sed
+        + var_log_capture
+        + '/sbin/dmesg > "$D/dmesg.txt" 2>&1; cp /var/run/dmesg.boot "$D/dmesg.boot" 2>/dev/null; '
         '/sbin/pfctl -sa > "$D/pfctl_sa.txt" 2>&1; '
         '/sbin/ifconfig -a > "$D/ifconfig.txt" 2>&1; '
         '/usr/bin/sockstat > "$D/sockstat.txt" 2>&1; /usr/bin/netstat -rn > "$D/netstat_rn.txt" 2>&1; '
@@ -2363,6 +2506,9 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
         '/bin/ps auxww > "$D/ps.txt" 2>&1; '
         # Scrub secrets from config.xml BEFORE it leaves the box.
         + config_scrub
+        # ADR-24: value-redact the Plus secret identity across the WHOLE bundle
+        # (no-op for CE — redact_bundle is empty), then tar.
+        + redact_bundle
         + f"tar czf {remote_tar} -C /tmp pfb_smoke_diag 2>/dev/null; true"
     )
     try:

--- a/tests/test_read_version_matrix.py
+++ b/tests/test_read_version_matrix.py
@@ -53,6 +53,11 @@ def _clean_git_env() -> dict[str, str]:
 
 CE_DEFAULT_IMAGE_NAME = "pfsense-ce"
 CE_DEFAULT_MAC = "BC:24:11:37:9C:AC"
+# A clearly-fake DOCUMENTATION MAC for the explicit-pass-through fixture. The real
+# Plus source-VM MAC is a license/NDI-keyed SECRET (SMOKE_PLUS_MAC) and must NEVER
+# appear in the repo (ADR-24); this test only proves the reader emits an explicit
+# `mac` field verbatim, so any non-default value exercises that branch.
+FAKE_DOC_MAC = "02:00:00:00:00:01"
 
 # Skip the whole module if git or jq is missing — the script hard-requires both,
 # and a missing tool is an environment gap, not a behaviour regression.
@@ -219,13 +224,13 @@ def test_ci_matrix_entries_pass_through_explicit_image_name_and_mac(tmp_path: Pa
     """Explicit image_name/mac in the JSON are emitted verbatim — no default override."""
     repo = _make_matrix_ref(
         tmp_path,
-        [_plus_entry(ci=True, image_name="pfsense-plus", mac="REDACTED_PLUS_MAC")],
+        [_plus_entry(ci=True, image_name="pfsense-plus", mac=FAKE_DOC_MAC)],
     )
     ci = _ci_matrix(repo)
     assert len(ci) == 1
     entry = ci[0]
     assert entry["image_name"] == "pfsense-plus"
-    assert entry["mac"] == "REDACTED_PLUS_MAC"
+    assert entry["mac"] == FAKE_DOC_MAC
 
 
 # --------------------------------------------------------------------------- #
@@ -249,7 +254,7 @@ def test_ci_matrix_empty_string_image_name_and_mac_normalize_to_defaults(tmp_pat
 # --------------------------------------------------------------------------- #
 def test_build_and_test_matrices_unchanged_by_new_fields(tmp_path: Path) -> None:
     """The new CI-matrix fields do not perturb build_matrix / python_versions / php_versions."""
-    versions = [_ce_entry(), _plus_entry(ci=True, image_name="pfsense-plus", mac="REDACTED_PLUS_MAC")]
+    versions = [_ce_entry(), _plus_entry(ci=True, image_name="pfsense-plus", mac=FAKE_DOC_MAC)]
     repo = _make_matrix_ref(tmp_path, versions)
 
     build = _build_matrix(repo)

--- a/tests/test_smoke_diag_redaction.py
+++ b/tests/test_smoke_diag_redaction.py
@@ -83,6 +83,16 @@ def test_redact_sensitive_xml_tags_scrubs_plural_tag() -> None:
     assert redact_sensitive_xml_tags("<tokens>a b c</tokens>") == f"<tokens>{REDACTED}</tokens>"
 
 
+def test_redact_sensitive_xml_tags_is_case_insensitive() -> None:
+    """Given an UPPER/mixed-case sensitive tag (`<API_TOKEN>`, `<Secret>`)
+    When redact_sensitive_xml_tags runs
+    Then it is still scrubbed — the match is case-insensitive (`re.IGNORECASE` /
+         the `I` sed flag), not lowercase-only. Pre-state asserted (value present).
+    """
+    assert redact_sensitive_xml_tags("<API_TOKEN>abc123</API_TOKEN>") == f"<API_TOKEN>{REDACTED}</API_TOKEN>"
+    assert redact_sensitive_xml_tags("<Secret>s3kr3t</Secret>") == f"<Secret>{REDACTED}</Secret>"
+
+
 @pytest.mark.parametrize(
     "element",
     [
@@ -174,6 +184,7 @@ def test_sensitive_tag_sed_program_agrees_with_python() -> None:
         "  <some_credential>c</some_credential>\n"
         "  <key>KK</key>\n"
         "  <token></token>\n"
+        "  <API_TOKEN>UPPER</API_TOKEN>\n"
         "</system>\n"
     )
 

--- a/tests/test_smoke_diag_redaction.py
+++ b/tests/test_smoke_diag_redaction.py
@@ -1,24 +1,29 @@
-"""ADR-24 — Spring-Boot-Actuator-style sensitive-TAG redaction of the smoke
-config.xml scrub.
+"""ADR-24 — redaction of the smoke diagnostics: the Spring-Boot-Actuator-style
+sensitive-TAG scrub of config.xml AND the value-based scrub of the pfSense Plus
+secret VM identity.
 
-These pin the PURE, off-VM seam shared by the in-guest config.xml scrub
-(``collect_host_diagnostics`` appends ``sensitive_tag_sed_program()`` to the
-credential ``sed``): scrub the inner text of any config.xml element whose TAG NAME
-looks sensitive (Spring Boot Actuator default keys-to-sanitize:
-password / secret / key / token / *credential* / …), auto-catching unknown
-token/secret-named tags by name without enumerating them. The live box's
-``<ipsecpsk>`` is the motivating catch.
+These pin the PURE, off-VM seams shared by ``collect_host_diagnostics``:
 
-(Value-based NDI/serial redaction was dropped: the Netgate Device ID is a
-non-reversible hash of the already-public MAC, so scrubbing it while the MAC ships
-in the repo is not meaningful.)
+* **Sensitive-TAG scrub** (``sensitive_tag_sed_program()`` appended to the
+  credential ``sed``): scrub the inner text of any config.xml element whose TAG
+  NAME looks sensitive (Spring Boot Actuator default keys-to-sanitize:
+  password / secret / key / token / *credential* / …), auto-catching unknown
+  token/secret-named tags by name without enumerating them. The live box's
+  ``<ipsecpsk>`` is the motivating catch.
+* **Value-based scrub** (``parse_redact_values`` / ``redact_values`` /
+  ``_sed_escape_literal``): the Plus source-VM identity (MAC + SMBIOS uuid [+ NDI]
+  + live serial) is a license/NDI-keyed SECRET supplied via SMOKE_REDACT_VALUES on
+  the Plus leg only; the bundle is value-redacted before upload so a live Plus run
+  cannot leak it. A CE leg sets no value -> the set is empty -> the redactor is a
+  strict no-op (the CE artifact stays byte-identical). The Python redactor and the
+  in-guest BSD-``sed`` program must agree, so a literal-escape parity test pins them.
 
 They live under ``tests/`` (NOT ``tests/smoke/``) so they run in the default suite
 without a VM. The behaviour is non-trivial (per-word-class branches, plurals,
-prefix/text near-misses, cross-language Python-vs-`sed` parity) -> BDD-style
-Given/When/Then specs below. Branch coverage requires BOTH a positive (sensitive
-tag scrubbed) for each word class AND the load-bearing negative (a non-sensitive
-tag left intact).
+prefix/text near-misses, cross-language Python-vs-`sed` parity, the empty CE no-op
+vs the populated Plus path) -> BDD-style Given/When/Then specs below. Branch
+coverage requires BOTH a positive (sensitive tag / secret value scrubbed) AND the
+load-bearing negative (a non-sensitive tag / the empty no-op left intact).
 """
 
 from __future__ import annotations
@@ -30,7 +35,10 @@ import pytest
 
 from tests.smoke.helpers import (
     REDACTED,
+    _sed_escape_literal,
+    parse_redact_values,
     redact_sensitive_xml_tags,
+    redact_values,
     sensitive_tag_sed_program,
 )
 
@@ -188,3 +196,150 @@ def test_sensitive_tag_sed_program_agrees_with_python() -> None:
     assert "abc.def" not in result.stdout
     assert REDACTED in result.stdout
     assert "<hostname>fw1</hostname>" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# redact_values — literal value redaction of the Plus secret identity
+# --------------------------------------------------------------------------- #
+# Documentation/test-only fake values — NEVER a real Plus MAC/uuid (those are the
+# SMOKE_PLUS_* secrets and must not appear in the repo, ADR-24).
+_FAKE_MAC = "02:00:00:00:00:01"
+_FAKE_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def test_redact_values_empty_set_is_identity_ce_no_op() -> None:
+    """LOAD-BEARING CE NO-OP: an empty value set leaves the text byte-identical.
+
+    Given the diagnostics text and an EMPTY redaction set (the CE leg — no
+          SMOKE_REDACT_VALUES secret)
+    When redact_values runs
+    Then the text is returned unchanged — this is what guarantees the CE artifact
+         is byte-identical to pre-ADR-24 (it fails if redaction ever fires on CE).
+    """
+    text = f"link#1: {_FAKE_MAC}\nsmbios uuid {_FAKE_UUID}\n"
+    assert redact_values(text, []) == text
+
+
+def test_redact_values_present_value_is_replaced() -> None:
+    """Given text containing a secret value and a redaction set containing it
+    When redact_values runs
+    Then every occurrence of the value is replaced with REDACTED and the value is gone.
+
+    Pre-state asserted first (value present, REDACTED absent) so green proves the
+    redaction CAUSED the removal, not that the value was never there.
+    """
+    text = f"nic0 ether {_FAKE_MAC} (active); peer {_FAKE_MAC}"
+    assert _FAKE_MAC in text and REDACTED not in text
+    out = redact_values(text, [_FAKE_MAC])
+    assert _FAKE_MAC not in out
+    assert out.count(REDACTED) == 2  # both occurrences scrubbed
+    assert out == f"nic0 ether {REDACTED} (active); peer {REDACTED}"
+
+
+def test_redact_values_regex_special_value_matched_literally() -> None:
+    """Given a value packed with regex/BRE metacharacters (`. * [ ] ^ $ #` + `\\`)
+    When redact_values runs
+    Then it is matched LITERALLY (not as a regex) and replaced, while a string that
+         the metachars WOULD match as a regex is left untouched — proving literal,
+         not pattern, matching.
+    """
+    needle = r"a.b*c[d]e^f$g#h\i"
+    text = f"value={needle}; decoy=aXbYYcde_f_g_h_i"
+    assert needle in text and REDACTED not in text
+    out = redact_values(text, [needle])
+    assert needle not in out
+    assert out == f"value={REDACTED}; decoy=aXbYYcde_f_g_h_i"  # decoy survives (literal match)
+
+
+def test_redact_values_ignores_blank_needles() -> None:
+    """Given a redaction set with empty/whitespace-only entries among real ones
+    When redact_values runs
+    Then the blanks are ignored (an empty needle would otherwise match everywhere)
+         and only the real value is scrubbed.
+    """
+    text = f"mac {_FAKE_MAC} end"
+    out = redact_values(text, ["", "   ", _FAKE_MAC])
+    assert out == f"mac {REDACTED} end"
+
+
+# --------------------------------------------------------------------------- #
+# parse_redact_values — newline/comma split, trim, placeholder drop, dedup
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_redact_values_none_and_empty_yield_empty_list() -> None:
+    """Given a None or empty SMOKE_REDACT_VALUES (the CE leg)
+    When parse_redact_values runs
+    Then the result is [] — the empty set that makes redact_values a no-op.
+    """
+    assert parse_redact_values(None) == []
+    assert parse_redact_values("") == []
+    assert parse_redact_values("\n  \n") == []
+
+
+def test_parse_redact_values_splits_newline_and_comma_and_trims() -> None:
+    """Given a mixed newline- and comma-separated raw value with surrounding space
+    When parse_redact_values runs
+    Then each token is split and trimmed, preserving order.
+    """
+    raw = f"  {_FAKE_MAC} \n{_FAKE_UUID},deadbeef  "
+    assert parse_redact_values(raw) == [_FAKE_MAC, _FAKE_UUID, "deadbeef"]
+
+
+def test_parse_redact_values_drops_generic_smbios_placeholders() -> None:
+    """Given raw values that include generic SMBIOS placeholders (case-insensitive)
+    When parse_redact_values runs
+    Then the placeholders are dropped (they are not secrets and redacting them would
+         mangle unrelated diagnostics), keeping only the real value.
+    """
+    raw = f"Not Specified\nTo Be Filled By O.E.M.\n0\nNONE\nDefault String\n{_FAKE_MAC}"
+    assert parse_redact_values(raw) == [_FAKE_MAC]
+
+
+def test_parse_redact_values_dedups_preserving_first_occurrence() -> None:
+    """Given a raw value with a duplicate token
+    When parse_redact_values runs
+    Then duplicates collapse to a single entry (first occurrence order kept).
+    """
+    raw = f"{_FAKE_MAC}\n{_FAKE_UUID}\n{_FAKE_MAC}"
+    assert parse_redact_values(raw) == [_FAKE_MAC, _FAKE_UUID]
+
+
+# --------------------------------------------------------------------------- #
+# Python ⇄ BSD-sed parity for the VALUE redactor (anti-coverage-theater gate)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skipif(shutil.which("sed") is None, reason="sed not available")
+def test_value_redactor_python_matches_sed() -> None:
+    """Scenario: the in-guest BSD-`sed` value scrub == the Python redact_values.
+
+    Given a set of secret-shaped values (incl. one packed with BRE metacharacters)
+          and a sample of diagnostics text containing each
+    When the values are escaped via _sed_escape_literal into a `s#…#REDACTED#g`
+         program and run through `sed`, AND redact_values runs over the same text
+    Then the two outputs are identical — the gate that FAILS if the shell and Python
+         value redactors drift (e.g. a metachar escaped on one side only).
+    """
+    values = [_FAKE_MAC, _FAKE_UUID, r"x.y*z[q]^w$v#u\t"]
+    sample = f"ether {_FAKE_MAC}\nsmbios.system.uuid: {_FAKE_UUID}\nweird={values[2]}\nuntouched: plain text line\n"
+    # Pre-state — the secrets are present and unredacted, so a green result proves
+    # the scrub CAUSED their removal.
+    for v in values:
+        assert v in sample
+    assert REDACTED not in sample
+
+    sed_prog = "".join(f"s#{_sed_escape_literal(v)}#{REDACTED}#g;" for v in values)
+    result = subprocess.run(
+        ["sed", sed_prog],
+        input=sample,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout == redact_values(sample, values)
+    # Post-state — every secret gone, the non-secret line intact.
+    for v in values:
+        assert v not in result.stdout
+    assert "untouched: plain text line" in result.stdout

--- a/tests/test_smoke_diag_redaction.py
+++ b/tests/test_smoke_diag_redaction.py
@@ -236,6 +236,41 @@ def test_redact_values_present_value_is_replaced() -> None:
     assert out == f"nic0 ether {REDACTED} (active); peer {REDACTED}"
 
 
+def test_redact_values_is_case_insensitive() -> None:
+    """LOAD-BEARING: a secret stored UPPER-case must scrub its lower-case rendering.
+
+    Given an upper-case MAC in the redaction set but the lower-case form in the text
+         (ifconfig/dmesg/logs emit lower-case)
+    When redact_values runs
+    Then the lower-case rendering is gone — without this, an upper-case secret would
+         leak through. Mirrors the `s###REDACTED###gI` sed flag the shell paths use.
+    """
+    upper = "02:AB:CD:EF:12:34"  # fake doc MAC; letters differ by case
+    text = f"nic0 ether {upper.lower()} (active)"
+    assert upper not in text and upper.lower() in text and REDACTED not in text
+    out = redact_values(text, [upper])
+    assert upper.lower() not in out
+    assert out == f"nic0 ether {REDACTED} (active)"
+
+
+@pytest.mark.skipif(shutil.which("sed") is None, reason="sed not on PATH")
+def test_value_sed_program_gI_flag_is_case_insensitive() -> None:
+    """The in-guest `s###REDACTED###gI` program scrubs a case-mismatched value.
+
+    Given the sed program built from an upper-case secret (as the in-guest scrub
+         emits it, with the `I` flag) and a sample carrying the lower-case rendering
+    When run through `sed`
+    Then the value is scrubbed — proving the `I` (case-insensitive) flag the harness
+         relies on actually works on the available sed (GNU here; FreeBSD in-guest).
+    """
+    upper = "02:AB:CD:EF:12:34"
+    sample = f"ether {upper.lower()}"
+    sed_prog = f"s#{_sed_escape_literal(upper)}#{REDACTED}#gI;"
+    out = subprocess.run(["sed", sed_prog], input=sample, capture_output=True, text=True, check=True).stdout
+    assert upper.lower() not in out
+    assert out == f"ether {REDACTED}"
+
+
 def test_redact_values_regex_special_value_matched_literally() -> None:
     """Given a value packed with regex/BRE metacharacters (`. * [ ] ^ $ #` + `\\`)
     When redact_values runs

--- a/tests/test_smoke_harness_defaults.py
+++ b/tests/test_smoke_harness_defaults.py
@@ -1,20 +1,23 @@
 """Pin the smoke-harness boot defaults that ADR-24 parameterizes.
 
-The pfSense Plus smoke image (ADR-24) must boot with ITS source-VM MAC, distinct
-from the CE pin, because pfSense matches interface assignment by MAC AND the Plus
-license/NDI registration is keyed to it. ``tests/smoke/conftest.py`` boots
-exclusively via ``boot_vm.sh``, so a single ``SMOKE_VM_MAC`` env override
-parameterizes the whole harness while keeping CE byte-identical when unset.
+The pfSense Plus smoke image (ADR-24) must boot with ITS source-VM identity (NIC
+MAC + SMBIOS type-1 uuid), distinct from the CE pins, because pfSense matches
+interface assignment by MAC AND the Plus license/NDI registration is keyed to the
+MAC + uuid pair (the NDI is derived from both). ``tests/smoke/conftest.py`` boots
+exclusively via ``boot_vm.sh``, so single ``SMOKE_VM_MAC`` / ``SMOKE_VM_SMBIOS_UUID``
+env overrides parameterize the whole harness while keeping CE byte-identical when
+unset (the Plus values come from the SMOKE_PLUS_* secrets, never the public matrix).
 
-These tests read ``boot_vm.sh`` as text (no QEMU/VM needed) and pin:
+These tests read ``boot_vm.sh`` as text (no QEMU/VM needed) and pin, for BOTH the
+MAC and the SMBIOS uuid:
 
-* the CE default MAC string is present — a regression pin guarding against
-  accidental drift of the documented CE source-VM MAC (it appears in both the
-  header comment and the assignment); and
-* the assignment is the env-override form ``${SMOKE_VM_MAC:-<CE pin>}`` — so a
-  Plus run can override it while CE keeps the pin as the default.
+* the CE default string is present — a regression pin guarding against accidental
+  drift of the documented CE source-VM value (each appears in both the header
+  comment and the assignment); and
+* the assignment is the env-override form ``${SMOKE_VM_*:-<CE pin>}`` — so a Plus
+  run can override it while CE keeps the pin as the default.
 
-Both branches of the override are covered: CE (env unset -> pin) by the default
+Both branches of each override are covered: CE (env unset -> pin) by the default
 string assertion, Plus (env set -> override) by the override-form assertion.
 """
 
@@ -24,6 +27,11 @@ from pathlib import Path
 
 # The CE source-VM MAC pin (also documented in boot_vm.sh's header + the ADR).
 CE_DEFAULT_MAC = "BC:24:11:37:9C:AC"
+# The CE source-VM SMBIOS type-1 uuid pin. Like the MAC it is per-image: CE pins
+# the public source-VM uuid; a Plus image overrides via SMOKE_VM_SMBIOS_UUID (its
+# NDI is derived from MAC + uuid, so the uuid is as license-keyed as the MAC and
+# comes from the SMOKE_PLUS_SMBIOS_UUID secret, never the public matrix).
+CE_DEFAULT_SMBIOS_UUID = "58fd7964-c40c-4f47-bf02-3fdad18f8b00"
 
 _BOOT_VM_SH = Path(__file__).resolve().parent.parent / "tests" / "smoke" / "boot_vm.sh"
 
@@ -52,4 +60,30 @@ def test_vm_mac_is_env_override_with_ce_default() -> None:
     """
     text = _boot_vm_text()
     expected = f'VM_MAC="${{SMOKE_VM_MAC:-{CE_DEFAULT_MAC}}}"'
+    assert expected in text
+
+
+def test_ce_default_smbios_uuid_pin_present() -> None:
+    """The CE source-VM SMBIOS uuid pin is present in boot_vm.sh.
+
+    Regression pin (mirror of the MAC pin): the documented CE source-VM SMBIOS
+    uuid must stay the harness default; a typo'd or drifted pin would drop it and
+    fail. It legitimately appears more than once (header comment + assignment),
+    so this asserts presence, not a count.
+    """
+    text = _boot_vm_text()
+    assert CE_DEFAULT_SMBIOS_UUID in text
+
+
+def test_vm_smbios_uuid_is_env_override_with_ce_default() -> None:
+    """VM_SMBIOS_UUID is the SMOKE_VM_SMBIOS_UUID override form, defaulting to the CE uuid.
+
+    With SMOKE_VM_SMBIOS_UUID unset the expansion yields the CE pin (default path,
+    byte-identical to pre-ADR-24); a Plus run sets SMOKE_VM_SMBIOS_UUID (from the
+    SMOKE_PLUS_SMBIOS_UUID secret) to override it. Both branches of the override are
+    covered: CE (env unset -> pin) by the default-string assertion above, Plus (env
+    set -> override) by this override-form assertion.
+    """
+    text = _boot_vm_text()
+    expected = f'VM_SMBIOS_UUID="${{SMOKE_VM_SMBIOS_UUID:-{CE_DEFAULT_SMBIOS_UUID}}}"'
     assert expected in text


### PR DESCRIPTION
## ADR-24 step 3 — Plus VM identity from secrets, redacted from diagnostics

Enables the pfSense **Plus** smoke leg to boot with its real, license/NDI-keyed identity (MAC + SMBIOS uuid) **without putting those values in the repo or leaking them in CI artifacts**. The Netgate Device ID is `SHA256(NIC MAC + SMBIOS uuid)`, so both inputs must be pinned for registration to match — and both are now secrets.

### Wiring (identity from secrets)

- **`tests/smoke/boot_vm.sh`** — `VM_SMBIOS_UUID="${SMOKE_VM_SMBIOS_UUID:-58fd7964-…}"` (CE default = public CE source-VM uuid); pairs with the existing `SMOKE_VM_MAC`.
- **`.github/workflows/smoke.yml`** — new "Resolve VM identity" step: CE → public pins; **non-CE (Plus) → `SMOKE_PLUS_MAC` + `SMOKE_PLUS_SMBIOS_UUID` secrets**, `add-mask`'d, **fail-closed** if either is empty. pytest env now carries `SMOKE_VM_MAC` / `SMOKE_VM_SMBIOS_UUID`. The old "Validate image/MAC contract" guard is removed (subsumed by the empty-secret check). The matrix never carries these values.

### Leak protection (the identity is secret → redact it from diagnostics)

- **`tests/smoke/helpers.py`** — re-adds value redaction (`SMOKE_REDACT_VALUES`, populated by the resolve step with the MAC + uuid [+ optional NDI]); `collect_host_diagnostics` redacts **every text file in the whole bundle** (so the MAC in `ifconfig.txt` and the uuid in `dmesg.txt` are caught, not just config/logs), plus the live in-guest serial.
- **`smoke.yml`** runner-side step (`if: always()`) — literal-redacts those values across `vm*.log` + `smoke-diag/` text, and **drops console screenshots for non-CE** (the boot banner shows NDI/serial as pixels).

### CE no-op (load-bearing)

With a CE image and no Plus secrets, `SMOKE_REDACT_VALUES` is empty → redaction is a strict no-op and the in-guest bundle/runner side are byte-identical to today (verified by diffing the emitted script against baseline). CE MAC/uuid resolve to the public pins.

### Notes

- **No real Plus MAC/uuid appears anywhere** in the tree (grep-asserted); they live only in the secrets.
- ADR-24 §2.1/§2.2/§4/§6 updated to the secret-based design; the `REDACTED_PLUS_MAC` history-rewrite placeholder is cleaned up.
- Full suite green (1520); ruff/mypy clean; both workflows parse; markdownlint clean.

Follow-ups (separate): Phase 4 — flip `ci-metadata` to `ci:true` + `image_name: pfsense-plus` (no MAC/uuid in the matrix) and the live two-channel fan-out; Phase 5 — docs.

https://claude.ai/code/session_013jLsppCcoQzRW9hEpb3qJC

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLsppCcoQzRW9hEpb3qJC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CI smoke plan: pfSense Plus is a first-class leg, matrix exposes only image_name while Plus VM identity (MAC + SMBIOS UUID, optionally NDI) must come from secrets; manual image refresh remains.

* **New Features**
  * Workflow now resolves Plus VM identity from secrets, uses env overrides for SMBIOS, and scrubs/redacts Plus identity from diagnostics and artifacts while keeping CE behavior a strict no-op.

* **Tests**
  * Added/expanded tests for identity resolution, redact parsing/behavior, and harness SMBIOS/MAC override semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->