### PR TITLE
ci-metadata: enable pfSense Plus 26.03 in CI (ADR-24 Phase 4)

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -4,7 +4,7 @@
   "lifecycle_policy": {
     "add": "Add an entry when a new pfSense beta or GA lands (curated — a human edits this file). Set status='beta' until the release is GA.",
     "drop_ce": "Drop the oldest CE entry only when the newest CE goes GA. The supported window is always (previous GA CE + current GA CE), transiently +1 during an active beta.",
-    "plus": "Plus entries are always ci=false (build-only: we track the version and build .pkg artifacts, but never run Plus in CI — licensing).",
+    "plus": "Plus runs in CI from a PRIVATE, licensed GHCR image (ghcr.io/pfblockerng/pfsense-plus). To enable: set ci=true + image_name=pfsense-plus. The VM identity (NIC MAC + SMBIOS uuid, which the Netgate Device ID is keyed to) comes from the SMOKE_PLUS_MAC + SMOKE_PLUS_SMBIOS_UUID repo secrets, NEVER this matrix; the smoke harness redacts that identity from the uploaded diagnostics. Image refresh is MANUAL (image-refresh.yml is CE-only) — republish via scripts/image-publish.sh (ADR-24).",
     "ci_metadata_pr": "Changes to this file should be made via a PR against ci-metadata (branch-protected) so there is a git audit trail (diff/blame/rollback) without touching main/devel.",
     "future_migration": "If CI infrastructure grows, this file can move to a dedicated public pfBlockerNG-ci-infra repo (read via raw URL, no token) — a mechanical swap."
   },
@@ -29,7 +29,8 @@
       "py_flavor": "py311",
       "variant": "Plus",
       "status": "active",
-      "ci": false
+      "ci": true,
+      "image_name": "pfsense-plus"
     }
   ]
 }

--- a/supported-versions.schema.json
+++ b/supported-versions.schema.json
@@ -27,7 +27,7 @@
           "channel": {
             "type": "string",
             "enum": ["CE", "Plus"],
-            "description": "CE = Community Edition; Plus = pfSense Plus (build-only, ci must be false)."
+            "description": "CE = Community Edition; Plus = pfSense Plus (runs in CI from a private licensed image when ci=true + image_name=pfsense-plus)."
           },
           "freebsd_version": {
             "type": "string",
@@ -57,7 +57,11 @@
           },
           "ci": {
             "type": "boolean",
-            "description": "true = include in the CI smoke matrix (CE only). false = build-only (false for Plus for now — no licensed/redistributable CI image; use for beta CE if no image is available yet)."
+            "description": "true = include in the CI smoke matrix (CE, or Plus from its private licensed image). false = build-only (use for a beta with no CI image yet)."
+          },
+          "image_name": {
+            "type": "string",
+            "description": "GHCR image name for the smoke leg, e.g. 'pfsense-ce' (default if omitted) or 'pfsense-plus'. For a Plus leg the VM identity (MAC + SMBIOS uuid) is NOT carried here — it comes from the SMOKE_PLUS_MAC + SMOKE_PLUS_SMBIOS_UUID repo secrets (ADR-24)."
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
## ADR-24 Phase 4 — enable pfSense Plus 26.03 in CI

Flips the **Plus 26.03** matrix entry to `ci: true` + `image_name: pfsense-plus`, making it a first-class smoke fan-out leg (the nightly `smoke-fanout.yml` will include it too). The supporting harness already landed on `devel`:

- The smoke pipeline is channel-capable (#193); diagnostics use the Actuator tag-scrub (#194); and the Plus VM **identity (MAC + SMBIOS uuid) is resolved from the `SMOKE_PLUS_MAC` + `SMOKE_PLUS_SMBIOS_UUID` secrets, never this matrix**, and is redacted from the uploaded diagnostics (#195).

### Changes
- `supported-versions.json`: Plus `26.03` → `ci: true`, `image_name: "pfsense-plus"`. **No MAC/uuid** (license/NDI-keyed → secrets).
- `supported-versions.schema.json`: adds the optional `image_name` field (was `additionalProperties: false`); de-stales the `channel`/`ci` descriptions that claimed Plus must be `ci:false`.
- `lifecycle_policy.plus`: rewritten to the new reality (private licensed image; identity from secrets; manual image refresh).

### Verified
- Both JSON valid; the matrix validates against the schema (`jsonschema`).
- `read-version-matrix.sh` (current `devel`) against this branch now emits **both** legs: `[(2.8, CE, pfsense-ce), (26.03, Plus, pfsense-plus)]`; the live `ci-metadata` still emits CE-only. The matrix `mac` for the Plus entry is the CE-pin default and is **ignored** by `smoke.yml` (it resolves Plus identity from the secrets).

### After this merges
Dispatch `smoke-fanout.yml` and confirm: CE + Plus legs both green, and the Plus-leg `smoke-diagnostics` artifact carries no MAC/uuid/NDI (redaction working end-to-end). This is the first live boot of the licensed Plus image in CI.

https://claude.ai/code/session_013jLsppCcoQzRW9hEpb3qJC

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLsppCcoQzRW9hEpb3qJC)_