### PR TITLE
ci: build a per-leg ABI-matched .pkg for the smoke fan-out (ADR-24)

### DIFF
--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -54,6 +54,10 @@ on:
         description: "FreeBSD-ports branch"
         required: false
         default: "pfblockerng/use-github"
+      artifact_name:
+        description: "Name of the uploaded .pkg artifact. Override to keep per-leg builds distinct in one run (the smoke fan-out builds a CE + a Plus .pkg in the same workflow run)."
+        required: false
+        default: "pfBlockerNG-pkg"
   workflow_call:
     inputs:
       channel:
@@ -84,10 +88,14 @@ on:
         required: false
         type: string
         default: "pfblockerng/use-github"
+      artifact_name:
+        required: false
+        type: string
+        default: "pfBlockerNG-pkg"
     outputs:
       artifact:
         description: "Name of the uploaded package artifact"
-        value: "pfBlockerNG-pkg"
+        value: ${{ inputs.artifact_name }}
 
 permissions:
   contents: read
@@ -146,7 +154,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: pfBlockerNG-pkg
+          name: ${{ inputs.artifact_name }}
           path: out/*.pkg
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/smoke-fanout.yml
+++ b/.github/workflows/smoke-fanout.yml
@@ -110,12 +110,16 @@ jobs:
   # `fail-fast: false` ensures EVERY leg runs to completion regardless of
   # whether another leg has already failed.
   #
-  # IMAGE REF RESOLUTION:
+  # IMAGE REF RESOLUTION + PER-LEG .pkg ABI:
   # Each CI matrix entry carries pfsense_version (the GHCR floating tag, e.g. "2.8"
-  # / "26.03"), image_name (e.g. "pfsense-ce" / "pfsense-plus"), and mac. We pass
-  # all three to smoke.yml: it composes the GHCR ref from the SMOKE_IMAGE_REPO repo
-  # variable + the image_name input + the pfsense_version tag (each input overriding
-  # its repo-variable default), and exports mac as SMOKE_VM_MAC for the boot.
+  # / "26.03"), image_name (e.g. "pfsense-ce" / "pfsense-plus"), mac, and the build
+  # target (freebsd_major, php_version, py_flavor). We pass them all to smoke.yml: it
+  # composes the GHCR ref from the SMOKE_IMAGE_REPO repo variable + the image_name
+  # input + the pfsense_version tag (each input overriding its repo-variable default),
+  # exports mac as SMOKE_VM_MAC for the boot, AND builds the leg's .pkg for the
+  # matching ABI (FreeBSD:<major>:amd64) + dep flavors. The ABI step is essential:
+  # pkg add refuses a cross-major .pkg, so a CE FreeBSD:15 .pkg cannot install on the
+  # Plus FreeBSD:16 base — each leg must build its own ABI-matched package.
   smoke:
     name: Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }})
     needs: prepare
@@ -133,6 +137,12 @@ jobs:
       pfsense_version: ${{ matrix.pfsense_version }}
       image_name: ${{ matrix.image_name }}
       mac: ${{ matrix.mac }}
+      # Per-leg .pkg target so the built package matches the image's pfSense base:
+      # the ABI tag is keyed on the matrix freebsd_major (CE=15, Plus=16) — pkg add
+      # refuses a cross-major-ABI .pkg — and the dep names track php_version/py_flavor.
+      abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
+      php_version: ${{ matrix.php_version }}
+      py_flavor: ${{ matrix.py_flavor }}
     secrets: inherit
 
   # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -56,6 +56,18 @@ on:
         description: "QEMU NIC MAC for the VM boot (default the CE pin BC:24:11:37:9C:AC). Used for CE only; a non-CE (Plus) image takes its license/NDI-keyed MAC from the SMOKE_PLUS_MAC secret, never this input."
         required: false
         default: "BC:24:11:37:9C:AC"
+      abi:
+        description: "Target ABI for the .pkg the smoke leg installs — MUST match the image's pfSense base (CE 2.8 = FreeBSD:15:amd64; Plus 26.03 = FreeBSD:16:amd64). pkg add refuses a cross-major-ABI .pkg. The fan-out passes FreeBSD:<matrix.freebsd_major>:amd64."
+        required: false
+        default: "FreeBSD:15:amd64"
+      php_version:
+        description: "PHP version for the .pkg's dep names (CE 2.8 = 8.3; Plus 26.03 = 8.5). The fan-out passes matrix.php_version."
+        required: false
+        default: "8.3"
+      py_flavor:
+        description: "Python flavor for the .pkg's dep names (CE/Plus = py311). The fan-out passes matrix.py_flavor."
+        required: false
+        default: "py311"
       pytest_marker:
         description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
         required: false
@@ -86,6 +98,21 @@ on:
         required: false
         type: string
         default: "BC:24:11:37:9C:AC"
+      abi:
+        description: "Target ABI for the .pkg the smoke leg installs — MUST match the image's pfSense base (CE 2.8 = FreeBSD:15:amd64; Plus 26.03 = FreeBSD:16:amd64). pkg add refuses a cross-major-ABI .pkg. The fan-out passes FreeBSD:<matrix.freebsd_major>:amd64."
+        required: false
+        type: string
+        default: "FreeBSD:15:amd64"
+      php_version:
+        description: "PHP version for the .pkg's dep names (CE 2.8 = 8.3; Plus 26.03 = 8.5). The fan-out passes matrix.php_version."
+        required: false
+        type: string
+        default: "8.3"
+      py_flavor:
+        description: "Python flavor for the .pkg's dep names (CE/Plus = py311). The fan-out passes matrix.py_flavor."
+        required: false
+        type: string
+        default: "py311"
       pytest_marker:
         description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
         required: false
@@ -117,7 +144,17 @@ jobs:
     uses: ./.github/workflows/build-pkg-linux.yml
     with:
       channel: devel
-    # abi/py_flavor/php_version default to CE 2.8 (FreeBSD:15:amd64 / py311 / 8.3).
+      # Build a .pkg whose ABI + dep names match THIS leg's image. A bare dispatch
+      # keeps the CE 2.8 defaults (FreeBSD:15:amd64 / 8.3 / py311) — byte-identical
+      # to before; the fan-out passes per-leg values so the Plus leg gets a
+      # FreeBSD:16 / php85 .pkg (a FreeBSD:15 .pkg is refused on the Plus base).
+      abi: ${{ inputs.abi }}
+      php_version: ${{ inputs.php_version }}
+      py_flavor: ${{ inputs.py_flavor }}
+      # Per-leg artifact name: the fan-out builds a CE and a Plus .pkg in ONE run,
+      # so a shared name would collide / cross-feed. Keying on image_name keeps each
+      # leg's artifact distinct (and the download below follows build-pkg.outputs.artifact).
+      artifact_name: pfBlockerNG-pkg-${{ inputs.image_name }}
 
   smoke:
     name: pytest -m smoke (live pfSense VM)

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -341,7 +341,7 @@ jobs:
           mkdir -p out-nightly
           python3 scripts/build-pkg-portable.py \
             --ports "${{ runner.temp }}/ports-nightly" --channel nightly \
-            --local-src . --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 \
+            --local-src . --abi ${{ inputs.abi }} --py-flavor ${{ inputs.py_flavor }} --php ${{ inputs.php_version }} \
             --pkgversion 3.2.16.20260606.2 --annotate commit=${{ github.sha }} \
             --out out-nightly
           echo "SMOKE_NIGHTLY_PKG=$(find "$PWD/out-nightly" -name '*.pkg' | head -1)" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Why

The first live two-channel smoke fan-out (ADR-24) failed on the Plus leg at package install:

```
pkg: wrong architecture: FreeBSD:15:amd64 instead of FreeBSD:16:amd64
```

The fan-out built a **single** `.pkg` with the CE default ABI (`FreeBSD:15:amd64`) and fed it to every leg. `pkg add` refuses a cross-major-ABI package, so the Plus image (FreeBSD:16 base) could never install the CE-ABI build. The CE leg passed; the Plus leg errored before any assertion ran.

## What

Thread the per-leg build target through to the portable builder, which already accepts `--abi`/`--php`/`--py-flavor`:

- **`smoke.yml`** gains `abi` / `php_version` / `py_flavor` inputs (defaulting to the CE 2.8 values — `FreeBSD:15:amd64` / `8.3` / `py311`), passed into the `build-pkg` job. A bare dispatch is byte-identical to before.
- **`smoke-fanout.yml`** passes `abi: FreeBSD:${{ matrix.freebsd_major }}:amd64` plus `matrix.php_version` / `matrix.py_flavor` per leg, so each leg builds a package for its own base (CE → FreeBSD:15/php83, Plus → FreeBSD:16/php85).
- **`build-pkg-linux.yml`** gains an `artifact_name` input (default `pfBlockerNG-pkg`). The fan-out builds a CE *and* a Plus `.pkg` in one workflow run, so the previously-shared artifact name would collide / cross-feed; `smoke.yml` keys it on `image_name`, and the download step already follows `build-pkg.outputs.artifact`.

## Notes

- `--variant` is deliberately **not** threaded: its guard injects a bare `py311` dep (no real FreeBSD package by that name; `python311` is) that would break `pkg add` on both legs, and it's never been exercised against a live image. The ABI tag + `--php`-derived dep names already differentiate the two builds correctly.
- The portable builder tolerates a missing `php85` port dir (best-effort version; `pkg add` checks dep *presence*, not version), and its multi-ABI/multi-PHP dep synthesis is unit-pinned in `tests/test_build_pkg_portable.py`.
- Workload-only change; full local gate run green (1523 passed, ruff/mypy/markdownlint clean).

https://claude.ai/code/session_013jLsppCcoQzRW9hEpb3qJC

---
_Generated by [Claude Code](https://claude.ai/code/session_013jLsppCcoQzRW9hEpb3qJC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflows now produce ABI- and dependency-specific package builds per platform to ensure artifacts match target images.
  * Artifact naming is configurable and set per build leg, preventing collisions and improving artifact organization and retrieval.
  * Nightly builds and smoke tests now use per-leg parameters so packages align with the selected platform dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->