### PR TITLE
ci: build pfBlockerNG .pkg for aarch64, not just amd64 (#199)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,16 +115,19 @@ jobs:
         id: matrices
         uses: ./.github/actions/read-version-matrix
 
-      - name: Dedupe build matrix by freebsd_major
+      - name: Dedupe build matrix by freebsd_major + arch
         id: dedupe
-        # For each distinct freebsd_major, select the first CE entry (preferred);
-        # if no CE entry exists for that major, fall back to the first Plus entry.
-        # Result: one build entry per distinct FreeBSD major, fed to the portable
-        # builder's inline per-major loop (build-pkgs-portable).
+        # For each distinct (freebsd_major, arch), select the first CE entry
+        # (preferred); if no CE entry exists for that pair, fall back to the first
+        # Plus entry. Result: one build entry per distinct FreeBSD major × arch — so
+        # an aarch64 entry (Plus-only, issue #199) produces its own .pkg alongside
+        # the amd64 build — fed to the portable builder's inline loop
+        # (build-pkgs-portable). The reader resolves `arch` (default amd64) on every
+        # entry, so a matrix with no aarch64 entry dedupes exactly as before.
         run: |
           DEDUPED=$(printf '%s' '${{ steps.matrices.outputs.build_matrix }}' \
             | jq -c '
-                group_by(.freebsd_major)
+                group_by([.freebsd_major, .arch])
                 | map(
                     (map(select(.channel == "CE")) | first)
                     // first
@@ -306,16 +309,17 @@ jobs:
                 FREEBSD_VERSION=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_version')
                 PHP=$(printf '%s\n' "$ENTRY" | jq -r '.php_version')
                 PY=$(printf '%s\n' "$ENTRY" | jq -r '.py_flavor')
-                ABI="FreeBSD:${MAJOR}:amd64"
+                ARCH=$(printf '%s\n' "$ENTRY" | jq -r '.arch')
+                ABI="FreeBSD:${MAJOR}:${ARCH}"
 
-                echo "--- Building .pkg for FreeBSD ${MAJOR} (${FREEBSD_VERSION}), PHP ${PHP}, ${PY} ---"
+                echo "--- Building .pkg for FreeBSD ${MAJOR}/${ARCH} (${FREEBSD_VERSION}), PHP ${PHP}, ${PY} ---"
 
-                PORTS_DIR="${RUNNER_TEMP}/ports-${MAJOR}"
+                PORTS_DIR="${RUNNER_TEMP}/ports-${MAJOR}-${ARCH}"
                 git clone --depth 1 -b pfblockerng/use-github \
                   "https://github.com/pfBlockerNG/FreeBSD-ports" \
                   "$PORTS_DIR"
 
-                PKG_OUT="out/major-${MAJOR}"
+                PKG_OUT="out/major-${MAJOR}-${ARCH}"
                 mkdir -p "$PKG_OUT"
                 python3 scripts/build-pkg-portable.py \
                   --ports "$PORTS_DIR" \
@@ -326,15 +330,16 @@ jobs:
                   --php "$PHP" \
                   --out "$PKG_OUT"
 
-                echo "Built for FreeBSD ${MAJOR}:"
+                echo "Built for FreeBSD ${MAJOR}/${ARCH}:"
                 ls -l "${PKG_OUT}"/*.pkg
 
-                # Rename to embed FreeBSD major before upload
+                # Rename to embed FreeBSD major + arch before upload (two arches of
+                # one major must not collide on a shared -FreeBSD-<major>.pkg name).
                 for f in "${PKG_OUT}"/*.pkg; do
                   [ -f "$f" ] || continue
                   BASE=$(basename "$f" .pkg)
-                  mv "$f" "${PKG_OUT}/${BASE}-FreeBSD-${MAJOR}.pkg"
-                  echo "Renamed: $(basename "$f") -> ${BASE}-FreeBSD-${MAJOR}.pkg"
+                  mv "$f" "${PKG_OUT}/${BASE}-FreeBSD-${MAJOR}-${ARCH}.pkg"
+                  echo "Renamed: $(basename "$f") -> ${BASE}-FreeBSD-${MAJOR}-${ARCH}.pkg"
                 done
               done
 

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -150,6 +150,7 @@ jobs:
             MAJOR=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_major')
             PHP=$(printf '%s\n' "$ENTRY" | jq -r '.php_version')
             PY=$(printf '%s\n' "$ENTRY" | jq -r '.py_flavor')
+            ARCH=$(printf '%s\n' "$ENTRY" | jq -r '.arch')
 
             # Filter to target version if specified
             if [ -n "$TARGET_VERSION" ] && [ "$PFSENSE" != "$TARGET_VERSION" ]; then
@@ -157,7 +158,10 @@ jobs:
               continue
             fi
 
-            ABI="FreeBSD:${MAJOR}:amd64"
+            # The reader resolves arch (default amd64) on every build entry, so an
+            # aarch64 entry (Plus-only, issue #199) dispatches a FreeBSD:N:aarch64
+            # build; every existing amd64 entry is unchanged.
+            ABI="FreeBSD:${MAJOR}:${ARCH}"
             # Channel maps to pkg channel: CE on devel branch -> devel, main -> stable
             # For standalone tracker runs we use 'devel' as the pkg channel by default.
             # A real release tag push always uses release.yml; this is a build smoke-check.
@@ -165,10 +169,10 @@ jobs:
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "  [DRY-RUN] WOULD dispatch build-pkg-linux.yml:"
-              echo "    pfsense_version=${PFSENSE} (${CHANNEL})  freebsd_major=${MAJOR}"
+              echo "    pfsense_version=${PFSENSE} (${CHANNEL})  freebsd_major=${MAJOR}  arch=${ARCH}"
               echo "    abi=${ABI}  php=${PHP}  py_flavor=${PY}  pkg_channel=${PKG_CHANNEL}"
             else
-              echo "  [TRIGGER] build-pkg-linux.yml for ${PFSENSE} (${CHANNEL}) FreeBSD ${MAJOR}"
+              echo "  [TRIGGER] build-pkg-linux.yml for ${PFSENSE} (${CHANNEL}) FreeBSD ${MAJOR}/${ARCH}"
               # Dispatch the portable Linux builder for this matrix entry.
               # build-pkg-linux.yml expects: channel, abi, php_version, py_flavor.
               # INVARIANT: we dispatch a build-only workflow — no commits, no pushes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,10 +40,17 @@ prints both to stdout (mirroring `--print-build` / `--print-ci`).
   "freebsd_major":   "15",           # FreeBSD major (ABI dedup key; artifact suffix)
   "php_version":     "8.3",          # PHP version (pinned so USES=php dep names match)
   "py_flavor":       "py311",        # Python flavor for build-pkg-linux.yml
+  "arch":            "amd64",        # OPTIONAL; ABI arch (amd64 | aarch64). Omit => amd64. aarch64 = Netgate ARM appliances, Plus-only (issue #199)
   "status":          "GA",           # beta | GA
   "ci":              true            # include in the smoke CI fan-out (CE + Plus; Plus from a private licensed image, ADR-24)
 }
 ```
+
+The reader resolves `arch` to `amd64` when omitted (or empty), so a pre-#199 matrix
+builds exactly as before. The build path keys on `(freebsd_major, arch)`, so an
+`aarch64` entry produces its own `FreeBSD:N:aarch64` `.pkg` alongside the amd64 one.
+ARM is **Plus-only** (pfSense CE is amd64-only). Live-VM smoke stays amd64 — no ARM
+image yet, so an `aarch64` entry should set `ci: false` (build + distribute only).
 
 ### Lifecycle policy
 
@@ -78,8 +85,8 @@ pfBlockerNG is a `NO_BUILD` port (nothing compiles) and `pkg add` checks a depen
 
 A tag push (`vX.Y.Z[-devel]`) triggers `release.yml`, which reads `build_matrix` and
 builds one `.pkg` per entry against its `(freebsd_version, php_version)` pair. Artifacts
-are attached to the **GitHub Release**, deduplicated by FreeBSD major — one `.pkg` per
-distinct major covers every pfSense version on that major. A build failure surfaces in CI
+are attached to the **GitHub Release**, deduplicated by FreeBSD major × arch — one `.pkg`
+per distinct `(major, arch)` covers every pfSense version on that major. A build failure surfaces in CI
 but must **not** block the `ports-pr` step (the ports PR is the real distribution path).
 
 The daily **version-tracker** (`version-tracker.yml`, `0 6 * * *`) also triggers

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -29,12 +29,17 @@
 # Outputs:
 #   BUILD matrix     — all entries from supported-versions.json, each carrying:
 #     pfsense_version, channel, freebsd_version, freebsd_major,
-#     php_version, py_flavor, variant, status, ci
+#     php_version, py_flavor, variant, status, ci, arch. `arch` is resolved
+#     (default "amd64"), so the build fans out version × arch — an entry that
+#     omits arch (every entry today) stays amd64, while an aarch64 entry
+#     (Plus-only, Netgate ARM appliances) builds a FreeBSD:N:aarch64 .pkg
+#     (issue #199).
 #   CI matrix        — the ci:true entries (ANY channel), subset of BUILD matrix.
-#     Each emitted entry additionally carries a resolved image_name (default
-#     "pfsense-ce") and mac (default the CE pin "BC:24:11:37:9C:AC"), so an entry
-#     that omits them — every CE entry today — keeps the CE image + MAC, while a
-#     ci:true Plus entry can carry its own image_name/mac (ADR-24).
+#     Inherits the resolved `arch` from the BUILD matrix, and additionally carries
+#     a resolved image_name (default "pfsense-ce") and mac (default the CE pin
+#     "BC:24:11:37:9C:AC"), so an entry that omits them — every CE entry today —
+#     keeps the CE image + MAC, while a ci:true Plus entry can carry its own
+#     image_name/mac (ADR-24).
 #   python_versions  — DISTINCT python versions derived from each BUILD-matrix
 #     entry's py_flavor (`pyN` + `MM` => `N.MM`, e.g. py311 => 3.11; py39 => 3.9),
 #     sorted + deduped. test.yml's pytest matrix (supported-only — only the
@@ -122,6 +127,16 @@ if [ -n "$VARIANT_FILTER" ]; then
 else
   BUILD_MATRIX="$(printf '%s' "$RAW_JSON" | jq -c '.versions')"
 fi
+
+# ── Normalise: each BUILD-matrix entry carries a resolved `arch` (default amd64) ──
+# So the build fans out version × arch (issue #199 — aarch64 Netgate appliances).
+# An entry that omits arch — or sets it to "" — stays amd64; an aarch64 entry
+# (Plus-only) builds a FreeBSD:N:aarch64 .pkg. The empty-string coercion mirrors
+# the image_name/mac handling below: `//` alone treats only null/missing as absent,
+# so a literal "" would flow through and a downstream ABI build would emit
+# `FreeBSD:N:` (no arch). The CI matrix inherits this resolved arch verbatim.
+BUILD_MATRIX="$(printf '%s' "$BUILD_MATRIX" | jq -c '
+  [ .[] | . + { arch: (if ((.arch // "") == "") then "amd64" else .arch end) } ]')"
 
 # ── CI matrix: the ci:true entries (ANY channel) within the variant-filtered set ──
 # The channel no longer filters (ADR-24): a ci:true Plus entry is a first-class CI

--- a/tests/test_read_version_matrix.py
+++ b/tests/test_read_version_matrix.py
@@ -267,3 +267,55 @@ def test_build_and_test_matrices_unchanged_by_new_fields(tmp_path: Path) -> None
     py, php = _test_matrices(repo)
     assert py == ["3.11"]  # both entries are py311
     assert php == ["8.3", "8.5"]  # distinct, sorted
+
+
+# --------------------------------------------------------------------------- #
+# Scenario f — arch defaults to amd64 when omitted (issue #199).
+# A pre-#199 matrix has no `arch` field; every entry must resolve to amd64 so the
+# build path emits the unchanged FreeBSD:N:amd64 ABI. RED before the reader injects
+# arch (the field would simply be absent).
+# --------------------------------------------------------------------------- #
+def test_build_matrix_defaults_arch_to_amd64_when_omitted(tmp_path: Path) -> None:
+    """An entry without an `arch` field resolves to amd64 in the BUILD matrix (and CI inherits it)."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry()])  # omits arch
+    build = _build_matrix(repo)
+    assert len(build) == 1
+    assert build[0]["arch"] == "amd64", f"omitted arch must default to amd64; got {build[0].get('arch')!r}"
+    # CI matrix inherits the resolved arch (no separate injection).
+    ci = _ci_matrix(repo)
+    assert len(ci) == 1 and ci[0]["arch"] == "amd64"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario g — explicit aarch64 passes through verbatim (issue #199 — the point).
+# An aarch64 Plus entry (Netgate ARM appliances) must carry arch=aarch64 into both
+# the BUILD and CI matrices so release.yml/version-tracker build a FreeBSD:N:aarch64
+# .pkg. RED before #199 (no arch field is propagated at all).
+# --------------------------------------------------------------------------- #
+def test_build_matrix_passes_through_explicit_aarch64(tmp_path: Path) -> None:
+    """An explicit arch=aarch64 is emitted verbatim in the BUILD matrix and inherited by CI."""
+    repo = _make_matrix_ref(
+        tmp_path,
+        [_ce_entry(), _plus_entry(ci=True, arch="aarch64", image_name="pfsense-plus", mac=FAKE_DOC_MAC)],
+    )
+    build = _build_matrix(repo)
+    arches = {e["pfsense_version"]: e["arch"] for e in build}
+    assert arches == {"2.8": "amd64", "26.03": "aarch64"}, f"explicit aarch64 must pass through; got {arches!r}"
+    # The ci:true aarch64 Plus entry carries aarch64 into the CI matrix too.
+    ci = _ci_matrix(repo)
+    plus = [e for e in ci if e["channel"] == "Plus"]
+    assert len(plus) == 1 and plus[0]["arch"] == "aarch64"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario h — empty-string arch normalizes to amd64 (the other invalid input).
+# `//` alone treats only null/missing as absent, so a literal "" would otherwise
+# flow through and a downstream ABI build would emit `FreeBSD:N:` (no arch) — the
+# same trap guarded for image_name/mac. The reader must coerce "" to amd64.
+# --------------------------------------------------------------------------- #
+def test_build_matrix_empty_string_arch_normalizes_to_amd64(tmp_path: Path) -> None:
+    """An empty-string arch is treated as absent → amd64 (never a bare `FreeBSD:N:` ABI)."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry(arch="")])
+    build = _build_matrix(repo)
+    assert len(build) == 1
+    assert build[0]["arch"] == "amd64", f"empty arch must default to amd64; got {build[0]['arch']!r}"


### PR DESCRIPTION
Closes #199.

## Why

Netgate ARM (aarch64) appliances run pfSense Plus, but our `.pkg` is ABI-tagged `FreeBSD:N:arch` and we only ever built **amd64** — so `pkg add` refuses the package on every ARM box. pfBlockerNG is a `NO_BUILD` port (nothing compiles; staged PHP/Python/shell are byte-identical across arches), so producing an aarch64 `.pkg` needs only the right ABI tag — `scripts/build-pkg-portable.py` already maps `aarch64 → aarch64:64`.

## What

Thread an `arch` field (default `amd64`) through the build matrix:

- **`scripts/read-version-matrix.sh`** — resolves `arch` on every BUILD entry (omitted or `""` ⇒ `amd64`, mirroring the `image_name`/`mac` coercion); the CI matrix inherits it. A pre-#199 matrix resolves to all-amd64 and builds exactly as before.
- **`.github/workflows/release.yml`** — dedupes by `(freebsd_major, arch)`, builds `FreeBSD:N:<arch>`, and embeds the arch in the artifact name so two arches of one major don't collide on a shared `-FreeBSD-<major>.pkg`.
- **`.github/workflows/version-tracker.yml`** — dispatches `build-pkg-linux.yml` per `(major, arch)`.

## Scope held

ARM is **Plus-only** (pfSense CE is amd64-only). Live-VM smoke/UI legs stay amd64 — there is no ARM Plus image yet — so an aarch64 entry is **build + distribute only** (`ci: false`); ARM smoke is deferred behind image availability. The self-hosted pkg repo (ADR-17) already buckets each `.pkg` by the ABI read from its manifest, so an aarch64 build folds into the catalog with **no further change**.

## Activation (follow-up, separate)

This is the plumbing only — it's inert until a one-line `aarch64` Plus entry (`ci: false`) is added to `supported-versions.json` on the `ci-metadata` orphan branch (its own self-test gates it there).

## Tests

`tests/test_read_version_matrix.py` +3: arch defaults to `amd64` when omitted, explicit `aarch64` passes through to BUILD + CI, empty-string arch normalizes to `amd64`. Full suite (1531) + ruff/mypy/markdownlint green.

https://claude.ai/code/session_01GvPJgQx2yyFhhCxN5QdSY8

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvPJgQx2yyFhhCxN5QdSY8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-architecture build support enabling separate builds for amd64 and aarch64 platforms with updated package naming to reflect target architecture.

* **Documentation**
  * Updated version matrix documentation with architecture configuration guidance and output deduplication rules.

* **Tests**
  * Added architecture detection and normalization validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->