### PR TITLE
ci-metadata: activate aarch64 (ARM) Plus build leg (#199)

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -5,6 +5,7 @@
     "add": "Add an entry when a new pfSense beta or GA lands (curated — a human edits this file). Set status='beta' until the release is GA.",
     "drop_ce": "Drop the oldest CE entry only when the newest CE goes GA. The supported window is always (previous GA CE + current GA CE), transiently +1 during an active beta.",
     "plus": "Plus runs in CI from a PRIVATE, licensed GHCR image (ghcr.io/pfblockerng/pfsense-plus). To enable: set ci=true + image_name=pfsense-plus. The VM identity (NIC MAC + SMBIOS uuid, which the Netgate Device ID is keyed to) comes from the SMOKE_PLUS_MAC + SMOKE_PLUS_SMBIOS_UUID repo secrets, NEVER this matrix; the smoke harness redacts that identity from the uploaded diagnostics. Image refresh is MANUAL (image-refresh.yml is CE-only) — republish via scripts/image-publish.sh (ADR-24).",
+    "arm": "ARM (aarch64) is Plus-only (Netgate ARM appliances; pfSense CE is amd64-only). Add an entry with arch='aarch64' to produce a FreeBSD:<major>:aarch64 .pkg alongside the amd64 build (the build keys on (freebsd_major, arch)). There is no aarch64 CI image yet, so an aarch64 entry MUST be build-only (ci=false); promote to ci=true only once a licensed aarch64 Plus smoke image is baked (issue #199).",
     "ci_metadata_pr": "Changes to this file should be made via a PR against ci-metadata (branch-protected) so there is a git audit trail (diff/blame/rollback) without touching main/devel.",
     "future_migration": "If CI infrastructure grows, this file can move to a dedicated public pfBlockerNG-ci-infra repo (read via raw URL, no token) — a mechanical swap."
   },
@@ -31,6 +32,18 @@
       "status": "active",
       "ci": true,
       "image_name": "pfsense-plus"
+    },
+    {
+      "pfsense_version": "26.03",
+      "channel": "Plus",
+      "freebsd_version": "16.0-RELEASE",
+      "freebsd_major": "16",
+      "php_version": "8.5",
+      "py_flavor": "py311",
+      "variant": "Plus",
+      "status": "active",
+      "ci": false,
+      "arch": "aarch64"
     }
   ]
 }

--- a/supported-versions.schema.json
+++ b/supported-versions.schema.json
@@ -62,6 +62,11 @@
           "image_name": {
             "type": "string",
             "description": "GHCR image name for the smoke leg, e.g. 'pfsense-ce' (default if omitted) or 'pfsense-plus'. For a Plus leg the VM identity (MAC + SMBIOS uuid) is NOT carried here — it comes from the SMOKE_PLUS_MAC + SMOKE_PLUS_SMBIOS_UUID repo secrets (ADR-24)."
+          },
+          "arch": {
+            "type": "string",
+            "enum": ["amd64", "aarch64"],
+            "description": "Target ABI architecture. Omit (or 'amd64') for the standard amd64 build; the reader resolves missing/empty to 'amd64'. 'aarch64' = Netgate ARM appliances (Plus-only); the build keys on (freebsd_major, arch) so an aarch64 entry yields a FreeBSD:<major>:aarch64 .pkg. No ARM CI image exists yet, so an aarch64 entry must be build-only (ci=false)."
           }
         },
         "additionalProperties": false

--- a/supported-versions.schema.json
+++ b/supported-versions.schema.json
@@ -35,7 +35,7 @@
           },
           "freebsd_major": {
             "type": "string",
-            "description": "FreeBSD major version digit only, e.g. '15'. Used to construct the ABI tag FreeBSD:<major>:amd64 for build-pkg-linux.yml and for artifact dedup (one .pkg per distinct major)."
+            "description": "FreeBSD major version digit only, e.g. '15'. Used to construct the ABI tag FreeBSD:<major>:<arch> for build-pkg-linux.yml and for artifact dedup (one .pkg per distinct (major, arch) pair)."
           },
           "php_version": {
             "type": "string",
@@ -57,7 +57,7 @@
           },
           "ci": {
             "type": "boolean",
-            "description": "true = include in the CI smoke matrix (CE, or Plus from its private licensed image). false = build-only (use for a beta with no CI image yet)."
+            "description": "true = include in the CI smoke matrix (CE, or Plus from its private licensed image). false = build-only (use for a beta, or an arch/platform with no CI image yet, e.g. aarch64)."
           },
           "image_name": {
             "type": "string",
@@ -66,6 +66,7 @@
           "arch": {
             "type": "string",
             "enum": ["amd64", "aarch64"],
+            "default": "amd64",
             "description": "Target ABI architecture. Omit (or 'amd64') for the standard amd64 build; the reader resolves missing/empty to 'amd64'. 'aarch64' = Netgate ARM appliances (Plus-only); the build keys on (freebsd_major, arch) so an aarch64 entry yields a FreeBSD:<major>:aarch64 .pkg. No ARM CI image exists yet, so an aarch64 entry must be build-only (ci=false)."
           }
         },


### PR DESCRIPTION
Activation follow-up to #202 (merged) — turns on the aarch64 build now that the pipeline carries `arch`.

## Change

- **`supported-versions.json`** — add a second Plus 26.03 entry with `arch: "aarch64"`, `ci: false`. The build now keys on `(freebsd_major, arch)`, so this yields a third leg — `FreeBSD:16:aarch64` — alongside CE 2.8 amd64 and Plus 26.03 amd64. Plus an `arm` lifecycle note.
- **`supported-versions.schema.json`** — add the optional `arch` property (`amd64` | `aarch64`); required because the schema is `additionalProperties: false`.

## Why `ci: false`

ARM is **Plus-only** (pfSense CE is amd64-only) and there is **no aarch64 CI smoke image** yet — booting one needs a native arm64 KVM host. So this entry is **build + distribute only**: `version-tracker.yml` / `release.yml` build the aarch64 `.pkg`, the ADR-17 self-hosted repo buckets it by manifest ABI, and ARM devices can install it — but no live-VM smoke runs for it. Promote to `ci: true` only once a licensed aarch64 Plus image is baked.

## Verified locally (reader output)

- BUILD matrix → 3 legs: `2.8/amd64`, `26.03/amd64`, `26.03/aarch64`.
- CI matrix → 2 legs: `2.8` (pfsense-ce), `26.03/amd64` (pfsense-plus) — the aarch64 leg is correctly **excluded** (`ci: false`).
- JSON well-formed; validates against the updated schema; `variant == channel` and "no `aarch64` with `ci: true`" invariants hold.

https://claude.ai/code/session_01GvPJgQx2yyFhhCxN5QdSY8

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvPJgQx2yyFhhCxN5QdSY8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added documentation for ARM/aarch64 architecture support
  * Extended pfSense 26.03 to support aarch64 builds (build-only phase pending full CI support)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->