### PR TITLE
ci: sync the port on our FreeBSD-ports fork, not an upstream PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,10 @@ name: Release
 
 # Triggered when a versioned tag (v*) is pushed to any branch.
 # Tags pushed from 'devel' become pre-releases; tags from 'main' become
-# full releases.  After publishing the GitHub Release, a PR is opened
-# on pfsense/FreeBSD-ports to update the corresponding port's GH_TAGNAME.
+# full releases.  After publishing the GitHub Release, the matching port's
+# PORTVERSION + GH_TAGNAME are bumped directly on our own FreeBSD-ports fork
+# (pfBlockerNG/FreeBSD-ports @ pfblockerng/use-github) — the build-input branch.
+# Self-hosted distribution (ADR-17): no upstream pfsense/FreeBSD-ports PR.
 #
 # workflow_dispatch allows a dry-run (point at an existing tag via
 # workflow_dispatch + the tag ref).
@@ -16,8 +18,8 @@ on:
 # Least-privilege default; jobs that need more elevate explicitly below
 # (release: contents:write to publish; verify-checks: checks:read to read the
 # tagged commit's check runs; ui-suite: packages:read to pull the pfSense image
-# from private GHCR). ports-pr operates on the FreeBSD-ports fork via PORTS_TOKEN,
-# not GITHUB_TOKEN.
+# from private GHCR). sync-ports-fork operates on the FreeBSD-ports fork via
+# PORTS_TOKEN, not GITHUB_TOKEN.
 permissions:
   contents: read
   packages: read
@@ -54,7 +56,7 @@ jobs:
   # (tier × version) leg — render / functional / browser × each image — and
   # `fail-fast: false` keeps every leg independent. Because each leg is its own
   # job, GitHub's "Re-run failed jobs" re-runs ONLY a flaky leg; `release` and
-  # `ports-pr` do NOT re-run until all legs are green again (they only run once
+  # `sync-ports-fork` do NOT re-run until all legs are green again (they only run once
   # their `needs:` are all `success`), so a not-our-fault browser flake costs a
   # single-leg re-run, never a republish.
   #
@@ -274,7 +276,7 @@ jobs:
   # uploading one artifact per entry with a unique name (pfBlockerNG-pkg-<major>).
   #
   # A build failure surfaces clearly (the job goes red) but MUST NOT break
-  # ports-pr: ports-pr needs only `release`, never build-pkgs-*.
+  # sync-ports-fork: it needs only `release`, never build-pkgs-*.
   # attach-pkgs absorbs the failure with `if: always() && ...` (below).
   build-pkgs-portable:
     name: build .pkg artifacts (portable Linux)
@@ -360,12 +362,12 @@ jobs:
   # skip missing downloads), renames each to embed the FreeBSD major for
   # unambiguity, and appends them to the already-published GitHub Release.
   #
-  # DEPENDENCY EDGES — WHY ports-pr IS INTACT:
-  #   ports-pr  needs: [release]              ← never needs build-pkgs
+  # DEPENDENCY EDGES — WHY sync-ports-fork IS INTACT:
+  #   sync-ports-fork needs: [release]         ← never needs build-pkgs
   #   attach-pkgs needs: [release, build-pkgs] ← waits for both, if: always()
   #
   # A build-pkgs failure makes attach-pkgs skip that leg's artifact but
-  # attach the rest (or skip entirely if release also failed). ports-pr is
+  # attach the rest (or skip entirely if release also failed). sync-ports-fork is
   # completely unblocked by any build outcome — it runs as soon as `release`
   # succeeds, in parallel with attach-pkgs.
   attach-pkgs:
@@ -425,9 +427,9 @@ jobs:
   # same-repo OIDC — no cross-repo deploy key. On a release we just trigger it so
   # the new Release appears at pfblockerng.github.io/pkg within seconds (its daily
   # schedule is the backstop).
-  # ADDITIVE + ISOLATED — wired like attach-pkgs: ports-pr / attach-pkgs do NOT
-  # `needs:` this, and this only `needs: [release]`, so a failure here can NEVER
-  # gate or break release / ports-pr / attach-pkgs.
+  # ADDITIVE + ISOLATED — wired like attach-pkgs: sync-ports-fork / attach-pkgs do
+  # NOT `needs:` this, and this only `needs: [release]`, so a failure here can NEVER
+  # gate or break release / sync-ports-fork / attach-pkgs.
   repo-publish:
     name: Trigger pkg repository publish
     runs-on: ubuntu-latest
@@ -458,7 +460,7 @@ jobs:
   # The Worker reads routing.json from Pages and 302-redirects pkg to the
   # correct variant catalog.  Redeployed on every release so the live Worker
   # always matches the current wrangler.toml / source.  ADDITIVE + ISOLATED —
-  # same pattern as repo-publish: only needs: [release], never blocks ports-pr.
+  # same pattern as repo-publish: only needs: [release], never blocks sync-ports-fork.
   deploy-worker:
     name: Deploy Cloudflare routing Worker
     needs: [release]
@@ -468,86 +470,77 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-  # ── 3. Open PR on pfsense/FreeBSD-ports ──────────────────────────────────
-  ports-pr:
-    name: Open FreeBSD ports PR
+  # ── 3. Sync the port on our FreeBSD-ports fork (pfblockerng/use-github) ─────
+  # Self-hosted distribution (ADR-17): we do NOT PR the upstream pfsense ports
+  # tree. Bump the matching port's PORTVERSION + GH_TAGNAME directly on our own
+  # fork's build-input branch (pfblockerng/use-github) — the SAME branch every
+  # build reads (release.yml build-pkgs-portable, pfBlockerNG/pkg publish.yml) —
+  # so the fork's port stays in lockstep with each release. Direct push: it's our
+  # branch, no PR. A no-op bump (version unchanged) just exits.
+  sync-ports-fork:
+    name: Sync port on FreeBSD-ports fork
     runs-on: ubuntu-latest
     needs: release
     permissions:
       contents: read
 
     steps:
-      - name: Checkout FreeBSD-ports fork
+      - name: Checkout the FreeBSD-ports fork (use-github branch)
         uses: actions/checkout@v6
         with:
           repository: pfBlockerNG/FreeBSD-ports
+          ref: pfblockerng/use-github
           token: ${{ secrets.PORTS_TOKEN }}
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Configure git
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Determine port path and branch
-        id: port
+      - name: Bump PORTVERSION + GH_TAGNAME and push to use-github
         run: |
+          set -eu
           BRANCH="${{ needs.release.outputs.branch }}"
-          VERSION="${{ needs.release.outputs.version }}"
+          VERSION="${{ needs.release.outputs.version }}"   # e.g. 3.2.16-devel | 3.2.16
           TAG="v${VERSION}"
+          # PORTVERSION must be pkg-safe (no '-'): the channel lives in the port's
+          # PKGNAMESUFFIX, not the version. Strip a trailing -devel.
+          PORTVERSION="${VERSION%-devel}"
 
           if [ "$BRANCH" = "devel" ]; then
             PORT_PATH="net/pfSense-pkg-pfBlockerNG-devel"
           else
             PORT_PATH="net/pfSense-pkg-pfBlockerNG"
           fi
+          MAKEFILE="${PORT_PATH}/Makefile"
 
-          PR_BRANCH="pfblockerng/bump-${TAG}-$(date +%Y%m%d%H%M%S)"
-
-          echo "port_path=${PORT_PATH}" >> "$GITHUB_OUTPUT"
-          echo "pr_branch=${PR_BRANCH}"  >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}"              >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}"      >> "$GITHUB_OUTPUT"
-
-      - name: Update GH_TAGNAME and PORTVERSION in Makefile
-        run: |
-          MAKEFILE="${{ steps.port.outputs.port_path }}/Makefile"
-          VERSION="${{ steps.port.outputs.version }}"
-          TAG="${{ steps.port.outputs.tag }}"
-
-          # Update PORTVERSION and GH_TAGNAME; reset PORTREVISION to 0
+          # PORTVERSION = the numeric version; GH_TAGNAME = the actual release tag
+          # (so a real `make package` fetch resolves it); drop PORTREVISION.
           sed -i \
-            -e "s/^PORTVERSION=.*/PORTVERSION=\t${VERSION}/" \
-            -e "s/^GH_TAGNAME=.*/GH_TAGNAME=\tv${VERSION}/" \
+            -e "s/^PORTVERSION=.*/PORTVERSION=\t${PORTVERSION}/" \
+            -e "s|^GH_TAGNAME=.*|GH_TAGNAME=\t${TAG}|" \
             -e "/^PORTREVISION=/d" \
             "$MAKEFILE"
 
-          git checkout -b "${{ steps.port.outputs.pr_branch }}"
-          git add "$MAKEFILE"
-          git commit -m "$(printf '%s: update to %s\n\nPoints GH_TAGNAME to %s in pfBlockerNG/pfBlockerNG.' \
-            "${{ steps.port.outputs.port_path }}" "$VERSION" "$TAG")"
-          git push origin "${{ steps.port.outputs.pr_branch }}"
-
-      - name: Create pull request on pfsense/FreeBSD-ports
-        env:
-          GH_TOKEN: ${{ secrets.PORTS_TOKEN }}
-        run: |
-          PRERELEASE="${{ needs.release.outputs.prerelease }}"
-          VERSION="${{ steps.port.outputs.version }}"
-          PORT="${{ steps.port.outputs.port_path }}"
-          TAG="${{ steps.port.outputs.tag }}"
-
-          if [ "$PRERELEASE" = "true" ]; then
-            CHANNEL_NOTE=" (devel / pre-release)"
-          else
-            CHANNEL_NOTE=""
+          if git diff --quiet -- "$MAKEFILE"; then
+            echo "${PORT_PATH} already at ${PORTVERSION} (${TAG}) — nothing to push."
+            exit 0
           fi
+          git add "$MAKEFILE"
+          git commit -m "$(printf '%s: update to %s\n\nGH_TAGNAME=%s — pfBlockerNG/pfBlockerNG release.' \
+            "$PORT_PATH" "$PORTVERSION" "$TAG")"
 
-          gh pr create \
-            --repo pfsense/FreeBSD-ports \
-            --base devel \
-            --head "pfBlockerNG:${{ steps.port.outputs.pr_branch }}" \
-            --title "${PORT}: update to ${VERSION}${CHANNEL_NOTE}" \
-            --body "$(printf \
-              'Bump \`GH_TAGNAME\` to \`%s\` in \`%s\`.\n\nSource: https://github.com/pfBlockerNG/pfBlockerNG/releases/tag/%s' \
-              "$TAG" "$PORT" "$TAG")"
+          # use-github only advances via releases; push directly, rebasing once on a
+          # racing update.
+          n=0
+          until git push origin HEAD:pfblockerng/use-github; do
+            n=$((n + 1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::could not push the port bump to use-github after ${n} attempts"
+              exit 1
+            fi
+            echo "push rejected — rebasing on the latest use-github (attempt ${n})"
+            git pull --rebase origin pfblockerng/use-github
+          done
+          echo "Pushed ${PORT_PATH} ${PORTVERSION} (${TAG}) to pfblockerng/use-github"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,11 +499,25 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump PORTVERSION + GH_TAGNAME and push to use-github
+        # branch/version ride in via env (NOT inline ${{ }}) so a crafted tag can't
+        # template-inject into this shell.
+        env:
+          BRANCH: ${{ needs.release.outputs.branch }}
+          VERSION: ${{ needs.release.outputs.version }}   # e.g. 3.2.16-devel | 3.2.16
         run: |
           set -eu
-          BRANCH="${{ needs.release.outputs.branch }}"
-          VERSION="${{ needs.release.outputs.version }}"   # e.g. 3.2.16-devel | 3.2.16
           TAG="v${VERSION}"
+          # Strict branch-aware version shape: devel = X.Y.Z-devel, stable = X.Y.Z.
+          # Fail fast on any other shape (e.g. -rc1/-alpha) so PORTVERSION below can
+          # never keep a '-' (an invalid pkg version). Belt-and-braces with release's
+          # meta gate, which only checks the -devel suffix, not the rest of the string.
+          if [ "$BRANCH" = "devel" ]; then
+            printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-devel$' || {
+              echo "::error::invalid devel version/tag: ${TAG}"; exit 1; }
+          else
+            printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || {
+              echo "::error::invalid stable version/tag: ${TAG}"; exit 1; }
+          fi
           # PORTVERSION must be pkg-safe (no '-'): the channel lives in the port's
           # PKGNAMESUFFIX, not the version. Strip a trailing -devel.
           PORTVERSION="${VERSION%-devel}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -585,8 +585,10 @@ When the min CE version changes, also:
 | `main` | Stable  | `net/pfSense-pkg-pfBlockerNG` |
 | `devel` | Development | `net/pfSense-pkg-pfBlockerNG-devel` |
 
-New features land in `devel`. Pushing a `vX.Y.Z` tag triggers CI: tests → GitHub Release → PR
-on `pfsense/FreeBSD-ports`. Tags from `devel` become pre-releases; from `main`, stable releases.
+New features land in `devel`. Pushing a `vX.Y.Z` tag triggers CI: tests → GitHub Release →
+bump the matching port on **our own `pfBlockerNG/FreeBSD-ports` fork** (`pfblockerng/use-github`,
+the build-input branch) — self-hosted distribution, **no upstream `pfsense/FreeBSD-ports` PR**.
+Tags from `devel` become pre-releases; from `main`, stable releases.
 
 ### Self-hosted `pkg` repository (ADR-17)
 
@@ -614,7 +616,7 @@ update badge stay Netgate-bound; a GUI "Updates/Channel" panel is deferred (woul
   `actions/create-github-app-token@v3`, secrets **`PKG_GITHUB_APP_ID`** +
   **`PKG_GITHUB_APP_PRIVATE_KEY`** — `Actions:write` on `pfBlockerNG/pkg` only) so a release publishes
   within seconds; additive + isolated (only `needs: [release]`), so its failure never
-  breaks `release`/`ports-pr`/`attach-pkgs`. The FreeBSD `pkg repo` fidelity path
+  breaks `release`/`sync-ports-fork`/`attach-pkgs`. The FreeBSD `pkg repo` fidelity path
   (`scripts/build-repo.sh`) is retained as a script only.
 - **Generators + bootstrap:** `scripts/build-repo-portable.py` (primary catalog gen),
   `scripts/build-repo.sh` (fallback + the single `--print-conf` conf template),


### PR DESCRIPTION
## What

Self-hosted distribution (ADR-17): a release no longer opens a PR against the
**upstream** `pfsense/FreeBSD-ports` tree. Instead it bumps the matching port's
`PORTVERSION` + `GH_TAGNAME` **directly on our own fork's build-input branch**,
`pfBlockerNG/FreeBSD-ports` @ `pfblockerng/use-github` — the same branch every
build already reads (`release.yml` `build-pkgs-portable`, `pfBlockerNG/pkg`'s
`publish.yml`). The fork's port now stays in lockstep with each release.

Per the decision: **direct push to `use-github`** (no PR), and **drop the
upstream pfsense PR entirely**.

## Changes (`.github/workflows/release.yml`)

- Rename job `ports-pr` → **`sync-ports-fork`** (+ all prose references).
- Checkout `pfblockerng/use-github` directly; bump `PORTVERSION` + `GH_TAGNAME`
  on the matching port (`-devel` vs stable), commit, and **push straight to
  `use-github`** with a rebase-retry on a racing update.
- **No-op guard:** if the bump leaves the Makefile unchanged, the job exits 0
  without pushing.
- Remove the `gh pr create --repo pfsense/FreeBSD-ports` step.

### Bug fixed along the way

The old step wrote `PORTVERSION=<tab>${VERSION}` where `VERSION` still carried
the `-devel` suffix → `PORTVERSION=3.2.16-devel`, an **invalid** port version
(`-` is the pkg name/version separator). The channel belongs in
`PKGNAMESUFFIX`, not the version, so `PORTVERSION` is now stripped to the
pkg-safe numeric (`3.2.16`) while `GH_TAGNAME` keeps the **actual** release tag
(`v3.2.16-devel`) so a real `make package` fetch still resolves.

## Verified locally

- Ran the strip + `sed` against the **real** fork Makefiles for
  `devel 3.2.16-devel`, `main 3.2.16`, `devel 3.3.0-devel`:
  `PORTVERSION` always pkg-safe (no `-`); `GH_TAGNAME` = the real tag.
- `release.yml` YAML parses; the new job is `sh -n` + ShellCheck clean (the
  remaining ShellCheck notes are pre-existing, in untouched jobs).
- Full Python suite green (`1531 passed`); pre-commit hooks pass.

## Note

`use-github` must accept a push from `PORTS_TOKEN` (it already pushed feature
branches to this fork). If that branch is protected against the token, the
direct push will fail the rebase-retry loop — flag if so.

The builds themselves already use our fork @ `use-github`; this only repoints
the post-release version bump. Docs (`CLAUDE.md` release-flow lines) updated to
match.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release automation to sync FreeBSD port version changes directly to the project’s ports fork branch instead of opening upstream pull requests.
  * Improved the sync step to validate release tag/version formats, update the port’s version automatically, and only publish changes when a diff exists (with retry handling).
  * Updated release/tag workflow documentation to match the new fork-based sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->