### PR TITLE
pkg-repo: human-navigable landing-page generator (gen_landing.py)

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -21,6 +21,7 @@ import io
 import json
 import os
 import re
+import shutil
 import subprocess
 import tarfile
 from collections.abc import Callable, Iterable
@@ -70,6 +71,8 @@ def ver_key(v: str) -> list[int]:
 
 def read_manifest_zstd(path: str) -> dict:
     """Read a .pkg's +COMPACT_MANIFEST (a libpkg .pkg is a zstd-compressed tar)."""
+    if shutil.which("zstd") is None:
+        raise RuntimeError("gen_landing.py needs the zstd binary to read .pkg manifests (e.g. pkg/apt install zstd)")
     raw = subprocess.run(["zstd", "-dc", path], capture_output=True, check=True).stdout
     with tarfile.open(fileobj=io.BytesIO(raw), mode="r:") as tar:
         member = tar.extractfile("+COMPACT_MANIFEST")

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# gen_landing.py — generate the human-navigable landing page + per-directory
+# indexes for the self-hosted pkg repository (ADR-17). Run by pfBlockerNG/pkg's
+# publish.yml AFTER the per-ABI catalog trees are built under <site>/.
+#
+# It is the human-facing sibling of build-repo-portable.py: that tool emits the
+# machine catalog pkg(8) fetches; this one renders a styled index over it —
+# channel install cards (stable / devel / nightly), a Version x ABI table read
+# from each .pkg's own manifest, and a clean per-directory listing that shows the
+# package(s) but not the pkg(8) catalog plumbing (meta.conf/packagesite.pkg/...).
+#
+# Stdlib only + the `zstd` binary (to read a .pkg's +COMPACT_MANIFEST). Dev-only
+# tooling — not shipped in release archives (those contain only src/).
+#
+# Usage: gen_landing.py <site-dir> <pages-base-url> <add-repo.sh path>
+from __future__ import annotations
+
+import argparse
+import html
+import io
+import json
+import os
+import re
+import subprocess
+import tarfile
+from collections.abc import Callable, Iterable
+
+# Channel identity (mirrors add-repo.sh): package name + one-line blurb, in
+# display order. The channel of a package is read from its name suffix.
+CHANNELS: dict[str, tuple[str, str]] = {
+    "stable": ("pfSense-pkg-pfBlockerNG", "Tagged stable releases."),
+    "devel": ("pfSense-pkg-pfBlockerNG-devel", "The development channel — current devel tree."),
+    "nightly": ("pfSense-pkg-pfBlockerNG-nightly", "Bleeding edge — the devel tip, rebuilt daily."),
+}
+CH_ORDER: list[str] = ["stable", "devel", "nightly"]
+RAW_ADDREPO = "https://raw.githubusercontent.com/pfBlockerNG/pfBlockerNG/devel/scripts/add-repo.sh"
+
+# pkg(8) catalog files that live in a catalog dir but are NOT packages — excluded
+# from the human listing and the package table.
+CATALOG_META = ("packagesite.pkg", "data.pkg")
+
+
+def channel_of(name: str) -> str:
+    """Map a package NAME to its channel by suffix (-nightly / -devel / stable)."""
+    if name.endswith("-nightly"):
+        return "nightly"
+    if name.endswith("-devel"):
+        return "devel"
+    return "stable"
+
+
+def is_package_file(fname: str) -> bool:
+    """True for a real package .pkg, False for catalog plumbing / non-.pkg."""
+    return fname.endswith(".pkg") and fname not in CATALOG_META
+
+
+def human_size(n: int) -> str:
+    f = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if f < 1024 or unit == "GiB":
+            return f"{f:.0f} {unit}" if unit == "B" else f"{f:.1f} {unit}"
+        f /= 1024
+    return f"{f:.1f} GiB"
+
+
+def ver_key(v: str) -> list[int]:
+    """A coarse version sort key (numeric runs) — enough to pick the newest build."""
+    return [int(x) for x in re.findall(r"\d+", v)]
+
+
+def read_manifest_zstd(path: str) -> dict:
+    """Read a .pkg's +COMPACT_MANIFEST (a libpkg .pkg is a zstd-compressed tar)."""
+    raw = subprocess.run(["zstd", "-dc", path], capture_output=True, check=True).stdout
+    with tarfile.open(fileobj=io.BytesIO(raw), mode="r:") as tar:
+        member = tar.extractfile("+COMPACT_MANIFEST")
+        if member is None:
+            raise ValueError(f"{path}: no +COMPACT_MANIFEST member")
+        return json.loads(member.read())
+
+
+def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = None) -> list[dict]:
+    """Walk <site>/, returning one row per published package (channel/name/version/abi/size/rel)."""
+    if read_manifest is None:
+        read_manifest = read_manifest_zstd
+    pkgs: list[dict] = []
+    for dirpath, _dirs, files in os.walk(site):
+        for fname in sorted(files):
+            if not is_package_file(fname):
+                continue
+            path = os.path.join(dirpath, fname)
+            man = read_manifest(path)
+            name, ver, abi = man.get("name", ""), man.get("version", ""), man.get("abi", "")
+            pkgs.append(
+                {
+                    "channel": channel_of(name),
+                    "name": name,
+                    "version": ver,
+                    "abi": abi,
+                    "size": os.path.getsize(path),
+                    "rel": os.path.relpath(path, site),
+                }
+            )
+    return pkgs
+
+
+def latest_versions(pkgs: Iterable[dict]) -> dict[str, str]:
+    """Newest version present per channel (by numeric key)."""
+    latest: dict[str, str] = {}
+    for p in pkgs:
+        ch = p["channel"]
+        if ch not in latest or ver_key(p["version"]) > ver_key(latest[ch]):
+            latest[ch] = p["version"]
+    return latest
+
+
+def build_table(pkgs: list[dict]) -> list[dict]:
+    """The table rows: the newest version's package per (channel, ABI), display-sorted.
+
+    Older nightly builds stay reachable via the catalog-tree links — the table
+    surfaces only what a human would install right now.
+    """
+    latest = latest_versions(pkgs)
+    rows = [p for p in pkgs if p["version"] == latest.get(p["channel"])]
+    rows.sort(key=lambda p: (CH_ORDER.index(p["channel"]), p["abi"], p["name"]))
+    return rows
+
+
+def catalog_dirs(site: str) -> list[str]:
+    """Relative paths of dirs holding a real package (a catalog tree)."""
+    return sorted(os.path.relpath(d, site) for d, _x, files in os.walk(site) if any(is_package_file(f) for f in files))
+
+
+def _esc(s: object) -> str:
+    return html.escape(str(s))
+
+
+_CSS = """
+:root{--bg:#0d1117;--card:#161b22;--bd:#30363d;--fg:#e6edf3;--mut:#8b949e;--acc:#2f81f7;--code:#0b0f14}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);
+  font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+a{color:var(--acc);text-decoration:none}a:hover{text-decoration:underline}
+.wrap{max-width:980px;margin:0 auto;padding:2rem 1.25rem 4rem}
+header h1{margin:0 0 .25rem;font-size:2rem}
+header p{margin:0;color:var(--mut)}
+h2{margin:2.5rem 0 1rem;font-size:1.3rem;border-bottom:1px solid var(--bd);padding-bottom:.4rem}
+.cards{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+.card{background:var(--card);border:1px solid var(--bd);border-radius:10px;padding:1rem 1.1rem}
+.card h3{margin:0 0 .15rem;font-size:1.1rem;text-transform:capitalize}
+.card .ver{color:var(--mut);font-size:.9rem;margin:0 0 .6rem}
+.card .blurb{color:var(--mut);font-size:.92rem;margin:.15rem 0 .8rem}
+pre{background:var(--code);border:1px solid var(--bd);border-radius:8px;padding:.7rem .8rem;overflow:auto;
+  font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:var(--fg)}
+code{font:13px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  background:#1f2630;padding:.1em .35em;border-radius:5px}
+table{width:100%;border-collapse:collapse;font-size:.92rem}
+th,td{text-align:left;padding:.5rem .6rem;border-bottom:1px solid var(--bd)}
+th{color:var(--mut);font-weight:600}
+td.num{font-variant-numeric:tabular-nums;color:var(--mut)}
+.badge{display:inline-block;font-size:.72rem;padding:.05rem .45rem;border-radius:20px;
+  border:1px solid var(--bd);color:var(--mut)}
+details summary{cursor:pointer;color:var(--mut);font-size:.85rem;margin-top:.5rem}
+ul.trees{columns:2;list-style:none;padding:0;margin:0}
+ul.trees li{margin:.15rem 0}
+footer{margin-top:3rem;color:var(--mut);font-size:.85rem;border-top:1px solid var(--bd);padding-top:1rem}
+.empty{color:var(--mut);font-style:italic}
+"""
+
+
+def _channel_card(channel: str, base: str, latest: dict[str, str], conf_fn: Callable[[str], str]) -> str:
+    pkg, blurb = CHANNELS[channel]
+    lv = latest.get(channel)
+    ver_line = f"Latest: <code>{_esc(lv)}</code>" if lv else '<span class="empty">not yet published</span>'
+    one_liner = f"fetch -qo - {RAW_ADDREPO} \\\n  | sh -s -- --base-url {base} {channel}\npkg install {pkg}"
+    return (
+        f'<div class="card"><h3>{_esc(channel)} <span class="badge">{_esc(pkg)}</span></h3>'
+        f'<p class="ver">{ver_line}</p>'
+        f'<p class="blurb">{_esc(blurb)}</p>'
+        f"<pre>{_esc(one_liner)}</pre>"
+        f"<details><summary>Manual conf (drop in /usr/local/etc/pkg/repos/)</summary>"
+        f"<pre>{_esc(conf_fn(channel))}</pre></details></div>"
+    )
+
+
+def _table_html(rows: list[dict]) -> str:
+    if not rows:
+        return '<p class="empty">No packages published yet.</p>'
+    body = "".join(
+        f"<tr><td>{_esc(r['channel'])}</td><td>{_esc(r['name'])}</td>"
+        f'<td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
+        f"<td><code>{_esc(r['abi'])}</code></td>"
+        f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
+        for r in rows
+    )
+    return (
+        "<table><thead><tr><th>Channel</th><th>Package</th><th>Version</th>"
+        f"<th>ABI</th><th>Size</th></tr></thead><tbody>{body}</tbody></table>"
+    )
+
+
+def render_page(base: str, pkgs: list[dict], trees: list[str], conf_fn: Callable[[str], str]) -> str:
+    """Render the root landing page."""
+    latest = latest_versions(pkgs)
+    cards = "".join(_channel_card(c, base, latest, conf_fn) for c in CH_ORDER)
+    tree_items = "".join(f'<li><a href="./{_esc(d)}/">{_esc(d)}</a></li>' for d in trees)
+    return (
+        '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        "<title>pfBlockerNG — self-hosted pkg repository</title>"
+        f'<style>{_CSS}</style></head><body><div class="wrap">'
+        "<header><h1>pfBlockerNG</h1>"
+        "<p>Self-hosted FreeBSD <code>pkg</code> repository for pfSense&nbsp;CE &amp; pfSense&nbsp;Plus.</p></header>"
+        "<p>Install pfBlockerNG straight from this repository. Pick a channel, run the bootstrap on your "
+        "firewall (as <code>root</code>), then <code>pkg install</code>. The conf pins <code>priority: 100</code> "
+        "so it sits above the Netgate repo and the stock webConfigurator <strong>Install</strong> button pulls "
+        "this build too. Catalogs are NONE-signed (trust anchor = HTTPS to this host) and ABI-keyed, so a box "
+        "keeps resolving the right package across a pfSense OS upgrade.</p>"
+        f'<h2>Channels</h2><div class="cards">{cards}</div>'
+        f"<h2>Published packages</h2>{_table_html(build_table(pkgs))}"
+        "<h2>Catalog trees</h2>"
+        '<p class="blurb">The raw pkg(8) catalogs (what your firewall fetches). <code>${ABI}</code> is filled '
+        "in by pkg automatically, e.g. <code>FreeBSD:16:aarch64</code> on a Netgate ARM box.</p>"
+        f'<ul class="trees">{tree_items}</ul>'
+        '<footer><a href="https://github.com/pfBlockerNG/pfBlockerNG">Source</a> &middot; '
+        '<a href="https://github.com/pfBlockerNG/pfBlockerNG/releases">Releases</a> &middot; '
+        '<a href="https://github.com/pfBlockerNG/pkg">This repository</a></footer>'
+        "</div></body></html>\n"
+    )
+
+
+def render_dir_index(rel: str, files: Iterable[str]) -> str:
+    """Render a per-catalog-dir index listing only the real package file(s)."""
+    items = sorted(f for f in files if is_package_file(f))
+    li = "".join(f'<li><a href="{_esc(f)}">{_esc(f)}</a></li>' for f in items)
+    back = "../" * (rel.count("/") + 1)
+    return (
+        '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        f"<title>pfBlockerNG pkg — {_esc(rel)}</title><style>{_CSS}</style></head>"
+        f'<body><div class="wrap"><header><h1>{_esc(rel)}</h1>'
+        f'<p><a href="{_esc(back)}">&larr; back to the repository</a></p></header>'
+        f"<ul>{li}</ul>"
+        "<footer>pkg(8) catalog metadata (<code>meta.conf</code>, <code>packagesite.pkg</code>, …) "
+        "is served from this directory too.</footer></div></body></html>\n"
+    )
+
+
+def _conf_via_addrepo(addrepo: str, base: str, channel: str) -> str:
+    out = subprocess.run(
+        ["sh", addrepo, "--print-conf", "--base-url", base, channel],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.rstrip("\n")
+
+
+def write_site(site: str, base: str, addrepo: str) -> int:
+    """Generate index.html at the root and in every catalog dir. Returns package count."""
+    base = base.rstrip("/")
+    pkgs = collect_packages(site)
+    trees = catalog_dirs(site)
+
+    def conf_fn(channel: str) -> str:
+        return _conf_via_addrepo(addrepo, base, channel)
+
+    with open(os.path.join(site, "index.html"), "w") as fh:
+        fh.write(render_page(base, pkgs, trees, conf_fn))
+    for rel in trees:
+        d = os.path.join(site, rel)
+        with open(os.path.join(d, "index.html"), "w") as fh:
+            fh.write(render_dir_index(rel, os.listdir(d)))
+    return len(pkgs)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Generate the pkg-repo landing page + per-dir indexes.")
+    ap.add_argument("site", help="the built catalog tree (output of build-repo-portable.py)")
+    ap.add_argument("base_url", help="the Pages base URL, e.g. https://pfblockerng.github.io/pkg")
+    ap.add_argument("add_repo", help="path to add-repo.sh (for the per-channel conf snippets)")
+    args = ap.parse_args(argv)
+    n = write_site(args.site, args.base_url, args.add_repo)
+    print(f"landing page + {len(catalog_dirs(args.site))} dir index(es) written; {n} package(s) indexed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -1,0 +1,201 @@
+"""Tests for scripts/gen_landing.py — the human-navigable pkg-repo landing page.
+
+The generator turns a built per-ABI catalog tree into a styled index: channel
+install cards, a Version x ABI table read from each .pkg manifest, and per-dir
+listings that show packages but hide pkg(8) catalog plumbing. These tests pin
+that behaviour without needing real .pkg archives (the manifest reader is
+injected / the render helpers are pure).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+# Load scripts/gen_landing.py (a script path, not an installed module).
+_SPEC = importlib.util.spec_from_file_location(
+    "gen_landing", Path(__file__).resolve().parent.parent / "scripts" / "gen_landing.py"
+)
+assert _SPEC and _SPEC.loader
+gl = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(gl)
+
+
+# ── Pure helpers ──────────────────────────────────────────────────────────────
+
+
+def test_channel_of_maps_each_suffix() -> None:
+    """Every package-name suffix routes to its channel (each branch covered)."""
+    assert gl.channel_of("pfSense-pkg-pfBlockerNG-nightly") == "nightly"
+    assert gl.channel_of("pfSense-pkg-pfBlockerNG-devel") == "devel"
+    assert gl.channel_of("pfSense-pkg-pfBlockerNG") == "stable"
+
+
+def test_is_package_file_excludes_catalog_plumbing() -> None:
+    """A real package is a .pkg; packagesite.pkg / data.pkg / non-.pkg are not."""
+    assert gl.is_package_file("pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg")
+    assert not gl.is_package_file("packagesite.pkg")
+    assert not gl.is_package_file("data.pkg")
+    assert not gl.is_package_file("meta.conf")
+
+
+def test_human_size_units() -> None:
+    assert gl.human_size(512) == "512 B"
+    assert gl.human_size(1024) == "1.0 KiB"
+    assert gl.human_size(1024 * 1024 * 3) == "3.0 MiB"
+
+
+def test_ver_key_orders_nightly_after_release() -> None:
+    """The dated nightly version sorts above the bare PORTVERSION."""
+    assert gl.ver_key("3.2.16.20260614.20") > gl.ver_key("3.2.16")
+    assert gl.ver_key("3.2.16.20260614.20") > gl.ver_key("3.2.16.20260614.7")
+
+
+# ── collect_packages: walk + classify + exclude plumbing ──────────────────────
+
+
+def _touch(path: Path, size: int = 10) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+
+
+def test_collect_packages_walks_and_excludes_metadata(tmp_path: Path) -> None:
+    """Given a catalog tree with packages + pkg(8) metadata, collect only packages."""
+    # Given: a devel + nightly bucket per ABI, each also holding catalog plumbing.
+    site = tmp_path / "site"
+    layout = {
+        "FreeBSD:16:amd64/pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg": ("pfSense-pkg-pfBlockerNG-devel", "3.2.16"),
+        "nightly/FreeBSD:16:amd64/pfSense-pkg-pfBlockerNG-nightly-3.2.16.20260614.7.pkg": (
+            "pfSense-pkg-pfBlockerNG-nightly",
+            "3.2.16.20260614.7",
+        ),
+    }
+    for rel in layout:
+        _touch(site / rel)
+    for rel in ("FreeBSD:16:amd64", "nightly/FreeBSD:16:amd64"):
+        _touch(site / rel / "packagesite.pkg")
+        _touch(site / rel / "data.pkg")
+        (site / rel / "meta.conf").write_text("version = 2;\n")
+
+    def fake_read(path: str) -> dict[str, str]:
+        name, ver = layout[os.path.relpath(path, site)]
+        return {"name": name, "version": ver, "abi": Path(path).parent.name}
+
+    # When
+    pkgs = gl.collect_packages(str(site), read_manifest=fake_read)
+
+    # Then: only the two real packages, correctly classified; no packagesite/data.
+    assert {p["name"] for p in pkgs} == {"pfSense-pkg-pfBlockerNG-devel", "pfSense-pkg-pfBlockerNG-nightly"}
+    assert {p["channel"] for p in pkgs} == {"devel", "nightly"}
+    assert all(p["rel"].endswith(".pkg") for p in pkgs)
+    assert not any("packagesite" in p["rel"] or "data.pkg" in p["rel"] for p in pkgs)
+
+
+# ── build_table: newest version per (channel, ABI) ────────────────────────────
+
+
+def _pkg(channel: str, name: str, version: str, abi: str, rel: str, size: int = 10) -> dict[str, Any]:
+    return {"channel": channel, "name": name, "version": version, "abi": abi, "rel": rel, "size": size}
+
+
+def test_build_table_keeps_only_latest_nightly_per_abi() -> None:
+    """Scenario: retention keeps several nightlies; the table shows only the newest.
+
+    Given two nightly builds (old + new) for one ABI plus a devel build,
+    When the table is built,
+    Then the OLD nightly is dropped (proving newest-wins, not just 'all rows')
+    and the devel + newest-nightly rows remain, channel-then-ABI sorted.
+    """
+    old = _pkg("nightly", "pfSense-pkg-pfBlockerNG-nightly", "3.2.16.20260601.1", "FreeBSD:16:amd64", "old.pkg")
+    new = _pkg("nightly", "pfSense-pkg-pfBlockerNG-nightly", "3.2.16.20260614.9", "FreeBSD:16:amd64", "new.pkg")
+    dev = _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.16", "FreeBSD:16:amd64", "dev.pkg")
+
+    rows = gl.build_table([new, old, dev])
+
+    versions = [(r["channel"], r["version"]) for r in rows]
+    assert ("nightly", "3.2.16.20260601.1") not in versions  # old build dropped
+    assert versions == [("devel", "3.2.16"), ("nightly", "3.2.16.20260614.9")]  # sorted, latest only
+
+
+def test_latest_versions_per_channel() -> None:
+    pkgs = [
+        _pkg("nightly", "n", "3.2.16.20260601.1", "a", "1"),
+        _pkg("nightly", "n", "3.2.16.20260614.9", "a", "2"),
+        _pkg("devel", "d", "3.2.16", "a", "3"),
+    ]
+    assert gl.latest_versions(pkgs) == {"nightly": "3.2.16.20260614.9", "devel": "3.2.16"}
+
+
+# ── Rendering ─────────────────────────────────────────────────────────────────
+
+
+def _stub_conf(channel: str) -> str:
+    return f"{channel}-conf-snippet"
+
+
+def test_render_page_shows_latest_and_empty_stable() -> None:
+    """The page shows devel+nightly latest and the install URL; stable (absent) is empty-stated."""
+    pkgs = [
+        _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.16", "FreeBSD:16:aarch64", "FreeBSD:16:aarch64/d.pkg"),
+        _pkg(
+            "nightly",
+            "pfSense-pkg-pfBlockerNG-nightly",
+            "3.2.16.20260614.9",
+            "FreeBSD:16:aarch64",
+            "nightly/FreeBSD:16:aarch64/n.pkg",
+        ),
+    ]
+    base = "https://pfblockerng.github.io/pkg"
+    page = gl.render_page(base, pkgs, ["FreeBSD:16:aarch64", "nightly/FreeBSD:16:aarch64"], _stub_conf)
+
+    # Latest versions surfaced for the present channels.
+    assert "3.2.16.20260614.9" in page
+    # Stable has no package -> empty state, NOT a bogus version.
+    assert "not yet published" in page
+    # Install one-liner pins this repo's base URL (the working Pages mirror).
+    assert f"--base-url {base} devel" in page
+    assert "pkg install pfSense-pkg-pfBlockerNG-nightly" in page
+    # The manual conf came from the injected conf function.
+    assert "devel-conf-snippet" in page
+    # Catalog-tree link to the colon-ABI dir is './'-prefixed (browser scheme guard).
+    assert 'href="./FreeBSD:16:aarch64/"' in page
+
+
+def test_render_page_table_empty_when_no_packages() -> None:
+    page = gl.render_page("https://x/pkg", [], [], _stub_conf)
+    assert "No packages published yet." in page
+
+
+def test_render_dir_index_lists_package_hides_plumbing() -> None:
+    """A per-dir index links the package(s) but not meta.conf/packagesite.pkg/data.pkg."""
+    files = ["pfSense-pkg-pfBlockerNG-nightly-3.2.16.20260614.9.pkg", "packagesite.pkg", "data.pkg", "meta.conf"]
+    out = gl.render_dir_index("nightly/FreeBSD:16:aarch64", files)
+    assert 'href="pfSense-pkg-pfBlockerNG-nightly-3.2.16.20260614.9.pkg"' in out
+    assert "packagesite.pkg</a>" not in out
+    assert 'href="data.pkg"' not in out
+    assert 'href="meta.conf"' not in out
+    # Two path segments deep -> back link climbs two levels.
+    assert 'href="../../"' in out
+
+
+def test_write_site_end_to_end(tmp_path: Path, monkeypatch: Any) -> None:
+    """write_site emits a root index + one per catalog dir, package count returned."""
+    site = tmp_path / "site"
+    _touch(site / "FreeBSD:16:amd64" / "pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg")
+    _touch(site / "FreeBSD:16:amd64" / "packagesite.pkg")
+
+    manifest = {"name": "pfSense-pkg-pfBlockerNG-devel", "version": "3.2.16", "abi": "FreeBSD:16:amd64"}
+    monkeypatch.setattr(gl, "read_manifest_zstd", lambda p: manifest)
+    monkeypatch.setattr(gl, "_conf_via_addrepo", lambda addrepo, base, ch: f"{ch}-conf")
+
+    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", "add-repo.sh")
+
+    assert n == 1
+    assert (site / "index.html").is_file()
+    assert (site / "FreeBSD:16:amd64" / "index.html").is_file()
+    # The dir index links the package, not the catalog plumbing.
+    dir_index = (site / "FreeBSD:16:amd64" / "index.html").read_text()
+    assert "pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg" in dir_index
+    assert 'href="packagesite.pkg"' not in dir_index

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -53,6 +53,17 @@ def test_ver_key_orders_nightly_after_release() -> None:
     assert gl.ver_key("3.2.16.20260614.20") > gl.ver_key("3.2.16.20260614.7")
 
 
+def test_read_manifest_requires_zstd(monkeypatch: Any) -> None:
+    """A clear error (not a generic FileNotFoundError) when the zstd binary is absent."""
+    monkeypatch.setattr(gl.shutil, "which", lambda _name: None)
+    try:
+        gl.read_manifest_zstd("whatever.pkg")
+    except RuntimeError as exc:
+        assert "zstd" in str(exc)
+    else:  # pragma: no cover - the guard must fire
+        raise AssertionError("expected RuntimeError when zstd is missing")
+
+
 # ── collect_packages: walk + classify + exclude plumbing ──────────────────────
 
 


### PR DESCRIPTION
## What

A human-navigable landing page for the self-hosted pkg repository (ADR-17),
layered over the machine catalog. This PR adds the **generator + tests** to the
source repo (alongside `build-repo-portable.py`, the way `publish.yml` already
runs this repo's scripts). A follow-up PR repoints `pfBlockerNG/pkg`'s
`publish.yml` to call it.

`scripts/gen_landing.py` renders, from a built catalog tree:

- **Channel install cards** (stable / devel / nightly) — each with a copy-paste
  bootstrap (`add-repo.sh --base-url … <channel>` + `pkg install <pkg>`) and the
  raw conf in a `<details>`. The install URL pins **this repo's Pages base**
  (`https://pfblockerng.github.io/pkg`), which is the layout actually served
  today — not the `add-repo.sh` default Worker URL (ADR-20 routing isn't live).
- **A Version × ABI table** read from each `.pkg`'s own manifest — the newest
  build per (channel, ABI); older nightlies stay reachable via the trees.
- **Per-directory indexes** that list the package(s) but hide the pkg(8) catalog
  plumbing (`meta.conf` / `packagesite.pkg` / `data.pkg`), which is still served
  by URL for pkg(8).

Self-contained styled HTML (inline CSS, no framework/build). Stdlib + the `zstd`
binary — the human-facing sibling of `build-repo-portable.py`. Dev-only (not in
release archives).

## Why a real page

The current `publish.yml` already emits a bare landing page (unstyled `<ul>`,
raw catalog internals listed). This replaces that generation with a proper page.
Keeping the generator here (not inline in `publish.yml`) makes it lintable +
unit-tested + co-located with the other portable scripts.

## Tests (`tests/test_gen_landing.py`)

Pins, without needing real `.pkg` archives (manifest reader injected / render
helpers pure): channel classification (each suffix), catalog-plumbing exclusion,
`human_size`, version ordering (dated nightly > PORTVERSION), **newest-per-
channel table dedup** (an old nightly is dropped — proving newest-wins, not
"all rows"), the stable **empty-state**, the `./`-prefixed colon-ABI links
(browser scheme guard), and the per-dir plumbing exclusion. Full suite green;
ruff + ruff format + mypy clean.

A rendered preview (from the live catalog fixture) was shared in the session.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic generation of a styled HTML landing page for self-hosted FreeBSD package repositories, including channel-based views (stable, devel, nightly) with latest-version highlights, install command snippets, and collapsible channel configuration details.
  * Generates per-catalog directory index pages that link only to actual package artifacts present in each directory.

* **Tests**
  * Added a comprehensive test suite covering channel detection, package discovery/exclusions, version selection, page rendering states, directory index output, and an end-to-end site generation run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->