### PR TITLE
pkg-repo: show each artifact's actual publish datetime on the landing page

### DIFF
--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -87,6 +87,7 @@ import argparse
 import hashlib
 import io
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -455,6 +456,12 @@ def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) 
             pkg_bytes = path.read_bytes()
             dest = bucket / canonical
             dest.write_bytes(pkg_bytes)
+            # Preserve the source .pkg's mtime so the published artifact reflects its
+            # real build time — a cache-restored nightly keeps its original datetime
+            # instead of jumping to this catalog-regeneration run. The landing page
+            # reads this mtime as the artifact's publish date.
+            src_mtime = path.stat().st_mtime
+            os.utime(dest, (src_mtime, src_mtime))
             obj = catalog_object(
                 manifest,
                 pkg_name=canonical,

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -25,6 +25,7 @@ import shutil
 import subprocess
 import tarfile
 from collections.abc import Callable, Iterable
+from datetime import datetime, timezone
 
 # Channel identity (mirrors add-repo.sh): package name + one-line blurb, in
 # display order. The channel of a package is read from its name suffix.
@@ -69,6 +70,16 @@ def ver_key(v: str) -> list[int]:
     return [int(x) for x in re.findall(r"\d+", v)]
 
 
+def artifact_datetime(mtime_epoch: float) -> str:
+    """The artifact's actual publish datetime (UTC, minute precision) from its mtime.
+
+    The .pkg keeps its real build time end-to-end: build-pkg-portable writes it then,
+    the nightly retention cache preserves it, and build-repo-portable copies it onto
+    the published file (os.utime). So this distinguishes several nightlies built on
+    the same day (they differ by build time, not just the version's date)."""
+    return datetime.fromtimestamp(mtime_epoch, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
 def read_manifest_zstd(path: str) -> dict:
     """Read a .pkg's +COMPACT_MANIFEST (a libpkg .pkg is a zstd-compressed tar)."""
     if shutil.which("zstd") is None:
@@ -100,6 +111,7 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
                     "version": ver,
                     "abi": abi,
                     "size": os.path.getsize(path),
+                    "published": artifact_datetime(os.path.getmtime(path)),
                     "rel": os.path.relpath(path, site),
                 }
             )
@@ -191,13 +203,14 @@ def _table_html(rows: list[dict]) -> str:
     body = "".join(
         f"<tr><td>{_esc(r['channel'])}</td><td>{_esc(r['name'])}</td>"
         f'<td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
+        f'<td class="num">{_esc(r.get("published", ""))}</td>'
         f"<td><code>{_esc(r['abi'])}</code></td>"
         f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
         for r in rows
     )
     return (
         "<table><thead><tr><th>Channel</th><th>Package</th><th>Version</th>"
-        f"<th>ABI</th><th>Size</th></tr></thead><tbody>{body}</tbody></table>"
+        f"<th>Published</th><th>ABI</th><th>Size</th></tr></thead><tbody>{body}</tbody></table>"
     )
 
 

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -33,6 +33,7 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
 import sys
 import tarfile
 from pathlib import Path
@@ -198,6 +199,29 @@ def test_meta_conf_is_byte_exact(tmp_path: Path) -> None:
     )
     assert (bucket / "meta.conf").read_text() == expected
     assert (bucket / "meta").read_text() == expected
+
+
+def test_published_pkg_preserves_source_mtime(tmp_path: Path) -> None:
+    """The published .pkg keeps the SOURCE artifact's mtime (its real build time).
+
+    The landing page reads this mtime as the publish datetime, so it must survive
+    catalog generation — otherwise a cache-restored nightly would wrongly show the
+    regeneration run's time. Set a fixed past mtime on the input and assert it rides
+    through to the published copy.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    src = in_dir / "demo-1.0_1.pkg"
+    make_pkg(src)
+    build_mtime = 1700000000  # 2023-11-14, clearly before "now"
+    os.utime(src, (build_mtime, build_mtime))
+
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out)
+
+    dest = out / "FreeBSD:15:amd64" / "demo-1.0_1.pkg"
+    assert dest.is_file()
+    assert int(dest.stat().st_mtime) == build_mtime
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -51,6 +52,19 @@ def test_ver_key_orders_nightly_after_release() -> None:
     """The dated nightly version sorts above the bare PORTVERSION."""
     assert gl.ver_key("3.2.16.20260614.20") > gl.ver_key("3.2.16")
     assert gl.ver_key("3.2.16.20260614.20") > gl.ver_key("3.2.16.20260614.7")
+
+
+def test_artifact_datetime_is_utc_minute_precision() -> None:
+    """The publish datetime is the artifact's real mtime in UTC, to the minute.
+
+    Two nightlies built on the same day differ by build time, so the column must
+    carry the time-of-day — not just the date.
+    """
+    morning = datetime(2026, 6, 14, 3, 5, 40, tzinfo=timezone.utc).timestamp()
+    evening = datetime(2026, 6, 14, 21, 47, 0, tzinfo=timezone.utc).timestamp()
+    assert gl.artifact_datetime(morning) == "2026-06-14 03:05 UTC"
+    assert gl.artifact_datetime(evening) == "2026-06-14 21:47 UTC"
+    assert gl.artifact_datetime(morning) != gl.artifact_datetime(evening)  # same day, distinct
 
 
 def test_read_manifest_requires_zstd(monkeypatch: Any) -> None:
@@ -108,7 +122,15 @@ def test_collect_packages_walks_and_excludes_metadata(tmp_path: Path) -> None:
 
 
 def _pkg(channel: str, name: str, version: str, abi: str, rel: str, size: int = 10) -> dict[str, Any]:
-    return {"channel": channel, "name": name, "version": version, "abi": abi, "rel": rel, "size": size}
+    return {
+        "channel": channel,
+        "name": name,
+        "version": version,
+        "abi": abi,
+        "rel": rel,
+        "size": size,
+        "published": "2026-06-14 09:38 UTC",
+    }
 
 
 def test_build_table_keeps_only_latest_nightly_per_abi() -> None:
@@ -163,6 +185,9 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
 
     # Latest versions surfaced for the present channels.
     assert "3.2.16.20260614.9" in page
+    # The package table carries a Published datetime column (UTC, minute precision).
+    assert "<th>Published</th>" in page
+    assert "2026-06-14 09:38 UTC" in page
     # Stable has no package -> empty state, NOT a bogus version.
     assert "not yet published" in page
     # Install one-liner pins this repo's base URL (the working Pages mirror).


### PR DESCRIPTION
## What

Adds a **Published** column to the landing-page package table showing each
artifact's **actual publish datetime** (UTC, minute precision) — e.g.
`2026-06-14 09:38 UTC`.

Per the requirement: multiple nightlies can be built on the same day, so a
version-derived *date* is too coarse. This uses the artifact's real build
time, to the minute, so same-day builds are distinct.

## How (the datetime survives end-to-end)

The `.pkg` already carries its real build mtime (`build-pkg-portable` writes it
then; the nightly retention cache preserves it). The one gap was the catalog
copy, now closed:

- **`build-repo-portable.py`** — after writing the published `.pkg`, preserve
  the **source mtime** (`os.utime`). So a cache-restored nightly keeps its
  original build time instead of jumping to the catalog-regeneration run.
- **`gen_landing.py`** — the `Published` column formats that mtime as
  `YYYY-MM-DD HH:MM UTC` (was a version-parsed date).

(Devel/stable use the same mtime; for a future release asset that's its
download time — accurate release dates can be added later by stamping the
fold-in step. No releases exist yet.)

## Tests

- `test_build_repo_portable.py::test_published_pkg_preserves_source_mtime` —
  a fixed past mtime on the input rides through to the published copy.
- `test_gen_landing.py::test_artifact_datetime_is_utc_minute_precision` — two
  same-day mtimes render as **distinct** minute-precision datetimes.
- Updated the render test to assert the `Published` header + a datetime cell.

Verified end-to-end locally: stamped a source `.pkg` `2026-06-10 03:05 UTC`,
regenerated the catalog, and the rendered table shows `2026-06-10 03:05 UTC`
(not the run time). Full suite green; ruff + format + mypy clean.

## Deploy

After merge, the next pkg publish run (which checks out `devel`) picks it up —
no `pfBlockerNG/pkg` change needed.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package artifacts now preserve their original build timestamps during publication
  * Landing page now displays a "Published" column showing each package's build time in UTC format with minute-level precision

<!-- end of auto-generated comment: release notes by coderabbit.ai -->