### PR TITLE
pkg-repo: show artifacts' real creation time, not the republish date

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,11 @@ jobs:
           set -eu
           mkdir -p out
 
+          # The artifact's creation time = the tagged commit's committer date (epoch).
+          # Baked into each .pkg as the `created` annotation so the landing page shows
+          # when the code was created, not when the catalog was last republished.
+          CREATED="$(git show -s --format=%ct HEAD)"
+
           printf '%s\n' "$BUILD_MATRIX" \
             | jq -c '.[]' \
             | while IFS= read -r ENTRY; do
@@ -330,6 +335,7 @@ jobs:
                   --abi "$ABI" \
                   --py-flavor "$PY" \
                   --php "$PHP" \
+                  --annotate "created=${CREATED}" \
                   --out "$PKG_OUT"
 
                 echo "Built for FreeBSD ${MAJOR}/${ARCH}:"

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -70,14 +70,27 @@ def ver_key(v: str) -> list[int]:
     return [int(x) for x in re.findall(r"\d+", v)]
 
 
-def artifact_datetime(mtime_epoch: float) -> str:
-    """The artifact's actual publish datetime (UTC, minute precision) from its mtime.
+def artifact_datetime(epoch: float) -> str:
+    """Format a Unix epoch as a UTC, minute-precision datetime string."""
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
-    The .pkg keeps its real build time end-to-end: build-pkg-portable writes it then,
-    the nightly retention cache preserves it, and build-repo-portable copies it onto
-    the published file (os.utime). So this distinguishes several nightlies built on
-    the same day (they differ by build time, not just the version's date)."""
-    return datetime.fromtimestamp(mtime_epoch, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+def published_datetime(manifest: dict, mtime_epoch: float) -> str:
+    """The artifact's creation datetime (UTC, minute precision).
+
+    Prefer the ``created`` build annotation — the source commit's committer epoch,
+    baked into the .pkg at build time, so it reflects when the artifact's CODE was
+    created and survives every daily republish/re-download (devel is rebuilt and a
+    release asset re-downloaded each run, which would otherwise reset the mtime to
+    'today'). Fall back to the .pkg's mtime only when the annotation is absent.
+    """
+    created = (manifest.get("annotations") or {}).get("created")
+    if created is not None:
+        try:
+            return artifact_datetime(float(created))
+        except (TypeError, ValueError):
+            pass  # malformed annotation — fall back to mtime
+    return artifact_datetime(mtime_epoch)
 
 
 def read_manifest_zstd(path: str) -> dict:
@@ -111,7 +124,7 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
                     "version": ver,
                     "abi": abi,
                     "size": os.path.getsize(path),
-                    "published": artifact_datetime(os.path.getmtime(path)),
+                    "published": published_datetime(man, os.path.getmtime(path)),
                     "rel": os.path.relpath(path, site),
                 }
             )

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -88,8 +88,8 @@ def published_datetime(manifest: dict, mtime_epoch: float) -> str:
     if created is not None:
         try:
             return artifact_datetime(float(created))
-        except (TypeError, ValueError):
-            pass  # malformed annotation — fall back to mtime
+        except (TypeError, ValueError, OverflowError, OSError):
+            pass  # malformed or out-of-range annotation — fall back to mtime
     return artifact_datetime(mtime_epoch)
 
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -55,16 +55,36 @@ def test_ver_key_orders_nightly_after_release() -> None:
 
 
 def test_artifact_datetime_is_utc_minute_precision() -> None:
-    """The publish datetime is the artifact's real mtime in UTC, to the minute.
+    """A Unix epoch formats to a UTC, minute-precision datetime.
 
-    Two nightlies built on the same day differ by build time, so the column must
-    carry the time-of-day — not just the date.
+    Two artifacts created on the same day differ by time, so the column must carry
+    the time-of-day — not just the date.
     """
     morning = datetime(2026, 6, 14, 3, 5, 40, tzinfo=timezone.utc).timestamp()
     evening = datetime(2026, 6, 14, 21, 47, 0, tzinfo=timezone.utc).timestamp()
     assert gl.artifact_datetime(morning) == "2026-06-14 03:05 UTC"
     assert gl.artifact_datetime(evening) == "2026-06-14 21:47 UTC"
     assert gl.artifact_datetime(morning) != gl.artifact_datetime(evening)  # same day, distinct
+
+
+def test_published_datetime_prefers_created_annotation() -> None:
+    """Scenario: a daily republish must NOT reset an artifact's shown creation time.
+
+    Given a .pkg whose manifest carries a `created` build annotation (the source
+    commit epoch) AND a much-later mtime (a re-download/rebuild 'today'),
+    When the published datetime is computed,
+    Then the annotation wins — so devel/release stop showing the republish date.
+    And with no annotation, it falls back to the mtime.
+    """
+    commit_epoch = datetime(2026, 6, 10, 5, 52, tzinfo=timezone.utc).timestamp()
+    republish_mtime = datetime(2026, 6, 14, 9, 38, tzinfo=timezone.utc).timestamp()
+    manifest_with = {"annotations": {"commit": "deadbeef", "created": str(int(commit_epoch))}}
+    assert gl.published_datetime(manifest_with, republish_mtime) == "2026-06-10 05:52 UTC"
+    # No annotation -> mtime fallback.
+    assert gl.published_datetime({"annotations": {}}, republish_mtime) == "2026-06-14 09:38 UTC"
+    assert gl.published_datetime({}, republish_mtime) == "2026-06-14 09:38 UTC"
+    # Malformed annotation -> mtime fallback, not a crash.
+    assert gl.published_datetime({"annotations": {"created": "nope"}}, republish_mtime) == "2026-06-14 09:38 UTC"
 
 
 def test_read_manifest_requires_zstd(monkeypatch: Any) -> None:

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -85,6 +85,13 @@ def test_published_datetime_prefers_created_annotation() -> None:
     assert gl.published_datetime({}, republish_mtime) == "2026-06-14 09:38 UTC"
     # Malformed annotation -> mtime fallback, not a crash.
     assert gl.published_datetime({"annotations": {"created": "nope"}}, republish_mtime) == "2026-06-14 09:38 UTC"
+    # Numeric-but-out-of-range epoch (inf / huge) -> mtime fallback, not a crash on the
+    # whole page (datetime.fromtimestamp raises OverflowError/OSError, not ValueError).
+    assert gl.published_datetime({"annotations": {"created": "1e309"}}, republish_mtime) == "2026-06-14 09:38 UTC"
+    assert (
+        gl.published_datetime({"annotations": {"created": "999999999999999999"}}, republish_mtime)
+        == "2026-06-14 09:38 UTC"
+    )
 
 
 def test_read_manifest_requires_zstd(monkeypatch: Any) -> None:


### PR DESCRIPTION
## What

The landing page's **Published** column was reading the `.pkg` mtime — but **devel is rebuilt and release assets are re-downloaded every publish run**, so their mtime is just "today" (the website-publish date), not when the artifact was actually created. (nightly was fine — it carries a real build time.)

Fix: bake the artifact's **real creation time** into the `.pkg` at build time and read **that**, not the file mtime.

- The creation time = the **source commit's committer epoch** (devel/nightly = the devel HEAD commit; stable = the tagged commit). Stamped as a `created` manifest annotation (`build-pkg-portable --annotate`), so it rides in the package bytes and survives every re-download / recopy / daily republish.
- `gen_landing.py` — `published_datetime()` prefers `annotations.created` over the mtime (mtime stays only as a fallback for an un-stamped artifact).
- `release.yml` — stamps `--annotate created=<tagged commit epoch>` on release builds.

The **`pfBlockerNG/pkg` `publish.yml`** devel + nightly build steps get the same `--annotate created=…` in a **follow-up PR** (it checks out `devel`, so it needs this merged first). Until then, devel/nightly fall back to mtime (unchanged behaviour).

## Tests

`test_published_datetime_prefers_created_annotation` — a `created` annotation **wins over a much-later mtime** (the core fix: a republish can't reset the shown time); an absent or malformed annotation falls back to mtime without crashing.

## Verified end-to-end (real build)

Built a devel `.pkg` with `created=2026-06-10 05:52 UTC`, then forced its file mtime to **today** (simulating a republish), regenerated the catalog, and rendered the page — the table shows **`2026-06-10 05:52 UTC`** (the real creation time), not today. Full suite green; ruff + format + mypy clean; `release.yml` YAML + ShellCheck clean.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Landing page now shows more accurate “Published” timestamps based on the tagged commit creation time when available, with safe fallback to artifact filesystem modification time.
  * Updated package metadata so generated FreeBSD packages carry creation annotations for correct display.
* **Tests**
  * Added coverage to ensure created annotations are preferred (and malformed/missing values fall back properly) and clarified datetime formatting expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->