### PR TITLE
pkg-repo: add a Commit column linking each artifact to its source commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,9 @@ jobs:
           # Baked into each .pkg as the `created` annotation so the landing page shows
           # when the code was created, not when the catalog was last republished.
           CREATED="$(git show -s --format=%ct HEAD)"
+          # The source commit the artifact was built from — surfaced as a linked
+          # short SHA in the landing page's Commit column.
+          COMMIT="$(git rev-parse HEAD)"
 
           printf '%s\n' "$BUILD_MATRIX" \
             | jq -c '.[]' \
@@ -336,6 +339,7 @@ jobs:
                   --py-flavor "$PY" \
                   --php "$PHP" \
                   --annotate "created=${CREATED}" \
+                  --annotate "commit=${COMMIT}" \
                   --out "$PKG_OUT"
 
                 echo "Built for FreeBSD ${MAJOR}/${ARCH}:"

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -36,6 +36,8 @@ CHANNELS: dict[str, tuple[str, str]] = {
 }
 CH_ORDER: list[str] = ["stable", "devel", "nightly"]
 RAW_ADDREPO = "https://raw.githubusercontent.com/pfBlockerNG/pfBlockerNG/devel/scripts/add-repo.sh"
+# The source repo a .pkg is built from — base for the per-artifact commit link.
+SOURCE_REPO_URL = "https://github.com/pfBlockerNG/pfBlockerNG"
 
 # pkg(8) catalog files that live in a catalog dir but are NOT packages — excluded
 # from the human listing and the package table.
@@ -93,6 +95,20 @@ def published_datetime(manifest: dict, mtime_epoch: float) -> str:
     return artifact_datetime(mtime_epoch)
 
 
+def commit_cell(sha: str) -> str:
+    """Render the source-commit cell: a short SHA linking to the commit on GitHub.
+
+    The full SHA rides the .pkg's `commit` build annotation (stamped per channel at
+    build time). A missing annotation — e.g. an older release asset built before
+    commit stamping — or a non-hex value renders an em dash, never a broken/unsafe
+    link (the hex guard also keeps untrusted annotation text out of the URL/markup).
+    """
+    sha = (sha or "").strip()
+    if not re.fullmatch(r"[0-9a-fA-F]{7,40}", sha):
+        return '<span class="empty">&mdash;</span>'
+    return f'<a href="{SOURCE_REPO_URL}/commit/{_esc(sha)}"><code>{_esc(sha[:7])}</code></a>'
+
+
 def read_manifest_zstd(path: str) -> dict:
     """Read a .pkg's +COMPACT_MANIFEST (a libpkg .pkg is a zstd-compressed tar)."""
     if shutil.which("zstd") is None:
@@ -125,6 +141,7 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
                     "abi": abi,
                     "size": os.path.getsize(path),
                     "published": published_datetime(man, os.path.getmtime(path)),
+                    "commit": (man.get("annotations") or {}).get("commit", ""),
                     "rel": os.path.relpath(path, site),
                 }
             )
@@ -217,13 +234,14 @@ def _table_html(rows: list[dict]) -> str:
         f"<tr><td>{_esc(r['channel'])}</td><td>{_esc(r['name'])}</td>"
         f'<td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
         f'<td class="num">{_esc(r.get("published", ""))}</td>'
+        f"<td>{commit_cell(r.get('commit', ''))}</td>"
         f"<td><code>{_esc(r['abi'])}</code></td>"
         f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
         for r in rows
     )
     return (
         "<table><thead><tr><th>Channel</th><th>Package</th><th>Version</th>"
-        f"<th>Published</th><th>ABI</th><th>Size</th></tr></thead><tbody>{body}</tbody></table>"
+        f"<th>Published</th><th>Commit</th><th>ABI</th><th>Size</th></tr></thead><tbody>{body}</tbody></table>"
     )
 
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -94,6 +94,25 @@ def test_published_datetime_prefers_created_annotation() -> None:
     )
 
 
+def test_commit_cell_links_valid_sha_and_dashes_missing() -> None:
+    """The Commit column links a short SHA to GitHub, and degrades safely.
+
+    Every input class is covered: a real SHA renders a 7-char link to the commit on
+    the source repo; an absent annotation (older asset) and a non-hex value both
+    render an em dash, never a broken or unsafe link.
+    """
+    full = "9d4b0b4556edca49b856c093838ccd0e2e91736b"
+    cell = gl.commit_cell(full)
+    assert f'href="{gl.SOURCE_REPO_URL}/commit/{full}"' in cell  # full SHA in the URL
+    assert ">9d4b0b4<" in cell  # 7-char short SHA shown
+    # Missing / blank annotation -> em dash, no link.
+    for missing in ("", "   ", None):
+        assert gl.commit_cell(missing) == '<span class="empty">&mdash;</span>'  # type: ignore[arg-type]
+    # Non-hex / junk -> em dash (the hex guard keeps untrusted text out of the URL).
+    assert "href" not in gl.commit_cell("not-a-sha")
+    assert "href" not in gl.commit_cell("../../evil")
+
+
 def test_read_manifest_requires_zstd(monkeypatch: Any) -> None:
     """A clear error (not a generic FileNotFoundError) when the zstd binary is absent."""
     monkeypatch.setattr(gl.shutil, "which", lambda _name: None)
@@ -131,9 +150,9 @@ def test_collect_packages_walks_and_excludes_metadata(tmp_path: Path) -> None:
         _touch(site / rel / "data.pkg")
         (site / rel / "meta.conf").write_text("version = 2;\n")
 
-    def fake_read(path: str) -> dict[str, str]:
+    def fake_read(path: str) -> dict[str, Any]:
         name, ver = layout[os.path.relpath(path, site)]
-        return {"name": name, "version": ver, "abi": Path(path).parent.name}
+        return {"name": name, "version": ver, "abi": Path(path).parent.name, "annotations": {"commit": "cafe1234"}}
 
     # When
     pkgs = gl.collect_packages(str(site), read_manifest=fake_read)
@@ -143,6 +162,8 @@ def test_collect_packages_walks_and_excludes_metadata(tmp_path: Path) -> None:
     assert {p["channel"] for p in pkgs} == {"devel", "nightly"}
     assert all(p["rel"].endswith(".pkg") for p in pkgs)
     assert not any("packagesite" in p["rel"] or "data.pkg" in p["rel"] for p in pkgs)
+    # The source-commit annotation is carried onto each row (drives the Commit column).
+    assert {p["commit"] for p in pkgs} == {"cafe1234"}
 
 
 # ── build_table: newest version per (channel, ABI) ────────────────────────────
@@ -157,6 +178,7 @@ def _pkg(channel: str, name: str, version: str, abi: str, rel: str, size: int = 
         "rel": rel,
         "size": size,
         "published": "2026-06-14 09:38 UTC",
+        "commit": "9d4b0b4556edca49b856c093838ccd0e2e91736b",
     }
 
 
@@ -215,6 +237,10 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
     # The package table carries a Published datetime column (UTC, minute precision).
     assert "<th>Published</th>" in page
     assert "2026-06-14 09:38 UTC" in page
+    # …and a Commit column linking the short SHA to the source commit on GitHub.
+    assert "<th>Commit</th>" in page
+    assert f'href="{gl.SOURCE_REPO_URL}/commit/9d4b0b4556edca49b856c093838ccd0e2e91736b"' in page
+    assert ">9d4b0b4<" in page
     # Stable has no package -> empty state, NOT a bogus version.
     assert "not yet published" in page
     # Install one-liner pins this repo's base URL (the working Pages mirror).


### PR DESCRIPTION
## What

Adds a **Commit** column to the self-hosted pkg-repo landing page: for each published `.pkg`, a short SHA linking to the exact source commit it was built from on GitHub — so you can see at a glance what code is in each artifact.

- **`gen_landing.py`** — reads the `commit` build annotation onto each row and renders `commit_cell()`: a 7-char SHA linking to `…/pfBlockerNG/commit/<full-sha>`. A missing annotation (e.g. an older release asset built before commit stamping) or a non-hex value renders an em dash — never a broken or unsafe link (the hex guard keeps untrusted annotation text out of the URL/markup).
- **`release.yml`** — stamps `--annotate commit=$(git rev-parse HEAD)` on release builds (nightly already stamped `commit`; this brings release/devel into line).

The **devel + nightly** builds run in `pfBlockerNG/pkg`'s `publish.yml`; nightly already carries `commit`, and a companion PR there adds it to the devel build. Until that lands, the devel row simply shows an em dash (graceful) — this PR is independently safe.

## Tests

`test_commit_cell_links_valid_sha_and_dashes_missing` — every input class: a real SHA → 7-char link to the commit; absent/blank/None and non-hex/junk → em dash, no link. Plus: `collect_packages` carries the `commit` annotation, and `render_page` emits the `<th>Commit</th>` header and a linked short SHA. Full `gen_landing` suite green; ruff + format + mypy clean; `release.yml` YAML valid.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package table now includes a Commit column with direct links to source commits on GitHub, providing build traceability.
  * Build process now captures source commit information for each artifact.

* **Tests**
  * Added test coverage for commit cell rendering and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->