### PR TITLE
pkg-repo: make the packages table scroll horizontally on mobile

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -199,7 +199,8 @@ pre{background:var(--code);border:1px solid var(--bd);border-radius:8px;padding:
 code{font:13px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
   background:#1f2630;padding:.1em .35em;border-radius:5px}
 table{width:100%;border-collapse:collapse;font-size:.92rem}
-th,td{text-align:left;padding:.5rem .6rem;border-bottom:1px solid var(--bd)}
+.tablewrap{overflow-x:auto;-webkit-overflow-scrolling:touch}
+th,td{text-align:left;padding:.5rem .6rem;border-bottom:1px solid var(--bd);white-space:nowrap}
 th{color:var(--mut);font-weight:600}
 td.num{font-variant-numeric:tabular-nums;color:var(--mut)}
 .badge{display:inline-block;font-size:.72rem;padding:.05rem .45rem;border-radius:20px;
@@ -239,9 +240,11 @@ def _table_html(rows: list[dict]) -> str:
         f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
         for r in rows
     )
+    # Wrapped in an overflow-x container so a narrow (mobile) viewport scrolls the
+    # table horizontally instead of widening the whole page past the screen.
     return (
-        "<table><thead><tr><th>Channel</th><th>Package</th><th>Version</th>"
-        f"<th>Published</th><th>Commit</th><th>ABI</th><th>Size</th></tr></thead><tbody>{body}</tbody></table>"
+        '<div class="tablewrap"><table><thead><tr><th>Channel</th><th>Package</th><th>Version</th>'
+        f"<th>Published</th><th>Commit</th><th>ABI</th><th>Size</th></tr></thead><tbody>{body}</tbody></table></div>"
     )
 
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -241,6 +241,10 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
     assert "<th>Commit</th>" in page
     assert f'href="{gl.SOURCE_REPO_URL}/commit/9d4b0b4556edca49b856c093838ccd0e2e91736b"' in page
     assert ">9d4b0b4<" in page
+    # The table sits in an overflow-x wrapper so a mobile viewport scrolls the table,
+    # not the whole page (the .tablewrap rule is what makes that scroll possible).
+    assert '<div class="tablewrap"><table>' in page
+    assert ".tablewrap{overflow-x:auto" in page
     # Stable has no package -> empty state, NOT a bogus version.
     assert "not yet published" in page
     # Install one-liner pins this repo's base URL (the working Pages mirror).


### PR DESCRIPTION
## What

On a narrow (mobile) viewport the 7-column **Published packages** table could be wider than the screen, widening the whole page (horizontal scroll on the body).

Fix: wrap the table in a `.tablewrap` `overflow-x:auto` container and set `white-space:nowrap` on cells. Now the **table** scrolls horizontally within the page, the page itself stays at viewport width, and cell values (datetime, version, SHA) no longer wrap mid-value. The empty-state (`No packages published yet.`) is unchanged — only the real table is wrapped.

## Tests

`test_render_page_shows_latest_and_empty_stable` now asserts the table is emitted inside `<div class="tablewrap">` and that the `.tablewrap{overflow-x:auto…}` rule is present. Full `gen_landing` suite green; ruff + format + mypy clean.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced table rendering for mobile viewports. Tables now properly scroll horizontally on narrow screens rather than expanding the page width, ensuring proper layout behavior and preventing layout shifts. This provides better readability for users viewing tabular content and data on mobile devices without disrupting the overall page structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->