### PR TITLE
pkg-repo: make the Catalog trees list responsive

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -206,8 +206,9 @@ td.num{font-variant-numeric:tabular-nums;color:var(--mut)}
 .badge{display:inline-block;font-size:.72rem;padding:.05rem .45rem;border-radius:20px;
   border:1px solid var(--bd);color:var(--mut)}
 details summary{cursor:pointer;color:var(--mut);font-size:.85rem;margin-top:.5rem}
-ul.trees{columns:2;list-style:none;padding:0;margin:0}
-ul.trees li{margin:.15rem 0}
+ul.trees{display:grid;grid-template-columns:repeat(auto-fill,minmax(15rem,1fr));
+  gap:.15rem 1rem;list-style:none;padding:0;margin:0}
+ul.trees li{margin:.15rem 0;overflow-wrap:anywhere}
 footer{margin-top:3rem;color:var(--mut);font-size:.85rem;border-top:1px solid var(--bd);padding-top:1rem}
 .empty{color:var(--mut);font-style:italic}
 """

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -254,6 +254,9 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
     assert "devel-conf-snippet" in page
     # Catalog-tree link to the colon-ABI dir is './'-prefixed (browser scheme guard).
     assert 'href="./FreeBSD:16:aarch64/"' in page
+    # The catalog-tree list is a responsive auto-fill grid (column count follows the
+    # viewport — one column on a phone), not a fixed 2-column layout that hugs the edge.
+    assert "ul.trees{display:grid;grid-template-columns:repeat(auto-fill" in page
 
 
 def test_render_page_table_empty_when_no_packages() -> None:


### PR DESCRIPTION
## What

Follow-up to the mobile-layout work (#209). The **Catalog trees** list used a fixed `columns:2`, so on a narrow viewport a long entry like `nightly/FreeBSD:16:aarch64` filled its half-width column right to the screen edge.

Switch it to the same responsive `grid` `repeat(auto-fill, minmax(15rem, 1fr))` pattern the channel **cards** already use, so the browser picks the column count from the available width — **one** column on a phone (full-width entries with proper margin), several on desktop. Long tokens get `overflow-wrap:anywhere` as a defensive break.

## Tests

`test_render_page_shows_latest_and_empty_stable` now asserts the trees list is the responsive auto-fill grid (not the fixed 2-column layout). Full `gen_landing` suite green; ruff + format + mypy clean.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the catalog trees directory layout to use a responsive CSS grid system for improved display and organization across different screen sizes and viewport widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->