### PR TITLE
pkg-repo: split packages table by pfSense edition + show older nightlies

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -109,6 +109,42 @@ def commit_cell(sha: str) -> str:
     return f'<a href="{SOURCE_REPO_URL}/commit/{_esc(sha)}"><code>{_esc(sha[:7])}</code></a>'
 
 
+# pfSense edition display order + labels (the matrix `variant` field: CE / Plus).
+# A build whose ABI the matrix doesn't cover lands in a trailing "Other" section.
+EDITION_ORDER: list[str] = ["CE", "Plus"]
+EDITION_LABELS: dict[str, str] = {"CE": "pfSense CE", "Plus": "pfSense Plus", "Other": "Other builds"}
+
+
+def _dotted_ver(token: str) -> str:
+    """A php/python flavor token -> dotted version: php85->8.5, py311/python311->3.11.
+
+    Returns "" when the token carries no trailing digit run.
+    """
+    m = re.search(r"(\d+)$", token or "")
+    if not m:
+        return ""
+    d = m.group(1)
+    return f"{d[0]}.{d[1:]}" if len(d) > 1 else d
+
+
+def _dep_flavor(deps: Iterable[str], names: tuple[str, ...]) -> str:
+    """Dotted version of the first dep named exactly <name><digits> (e.g. php85, py311).
+
+    Matches the runtime flavor package, not its sub-packages (php85-intl, py311-sqlite3),
+    so the manifest yields the PHP/Python a build targets when no matrix row is joined.
+    """
+    for dep in deps:
+        for nm in names:
+            if re.fullmatch(rf"{nm}\d+", dep):
+                return _dotted_ver(dep)
+    return ""
+
+
+def _or_dash(value: str) -> str:
+    """An escaped cell value, or an em dash when it's empty (keeps columns aligned)."""
+    return _esc(value) if value else '<span class="empty">&mdash;</span>'
+
+
 def read_manifest_zstd(path: str) -> dict:
     """Read a .pkg's +COMPACT_MANIFEST (a libpkg .pkg is a zstd-compressed tar)."""
     if shutil.which("zstd") is None:
@@ -133,6 +169,7 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
             path = os.path.join(dirpath, fname)
             man = read_manifest(path)
             name, ver, abi = man.get("name", ""), man.get("version", ""), man.get("abi", "")
+            deps = man.get("deps") or {}
             pkgs.append(
                 {
                     "channel": channel_of(name),
@@ -142,6 +179,10 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
                     "size": os.path.getsize(path),
                     "published": published_datetime(man, os.path.getmtime(path)),
                     "commit": (man.get("annotations") or {}).get("commit", ""),
+                    # PHP/Python the build targets, read from its RUN_DEPENDS — the fallback
+                    # for an ABI the matrix doesn't cover (the matrix value wins when joined).
+                    "php": _dep_flavor(deps, ("php",)),
+                    "py": _dep_flavor(deps, ("py", "python")),
                     "rel": os.path.relpath(path, site),
                 }
             )
@@ -189,6 +230,7 @@ a{color:var(--acc);text-decoration:none}a:hover{text-decoration:underline}
 header h1{margin:0 0 .25rem;font-size:2rem}
 header p{margin:0;color:var(--mut)}
 h2{margin:2.5rem 0 1rem;font-size:1.3rem;border-bottom:1px solid var(--bd);padding-bottom:.4rem}
+h3{margin:1.6rem 0 .5rem;font-size:1.05rem}
 .cards{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
 .card{background:var(--card);border:1px solid var(--bd);border-radius:10px;padding:1rem 1.1rem}
 .card h3{margin:0 0 .15rem;font-size:1.1rem;text-transform:capitalize}
@@ -229,27 +271,138 @@ def _channel_card(channel: str, base: str, latest: dict[str, str], conf_fn: Call
     )
 
 
-def _table_html(rows: list[dict]) -> str:
-    if not rows:
-        return '<p class="empty">No packages published yet.</p>'
+def matrix_index(matrix: list[dict] | None) -> dict[str, list[dict]]:
+    """Map each ABI to its matrix entries (edition / pfSense version / php / py).
+
+    An ABI shared by two pfSense versions maps to BOTH — the same .pkg installs on
+    each (pkg resolves on ABI alone), so it is shown under each. The join is needed
+    because the manifest itself names no pfSense edition/version, only its ABI.
+    """
+    idx: dict[str, list[dict]] = {}
+    for e in matrix or []:
+        abi = e.get("abi", "")
+        if abi:
+            idx.setdefault(abi, []).append(e)
+    return idx
+
+
+def _edition_key(variant: str) -> str:
+    """Normalise the matrix `variant` to an edition key (CE / Plus / passthrough)."""
+    low = (variant or "").strip().lower()
+    if low == "ce":
+        return "CE"
+    if low == "plus":
+        return "Plus"
+    return variant.strip() or "Other"
+
+
+def build_edition_sections(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str, list[dict]]]:
+    """Group the current installables into per-edition row lists, display-ordered.
+
+    Each row is the newest version per (channel, ABI) (build_table), enriched with the
+    pfSense version + PHP/Python from the matrix join. A build whose ABI has no matrix
+    entry falls into a trailing "Other" section using its manifest-derived php/py, so
+    nothing published is ever hidden. Editions sort CE, then Plus, then the rest.
+    """
+    idx = matrix_index(matrix)
+    sections: dict[str, list[dict]] = {}
+    for r in build_table(pkgs):
+        entries = idx.get(r["abi"], [])
+        if entries:
+            for e in entries:
+                row = dict(r)
+                row["pfsense_version"] = e.get("pfsense_version", "")
+                row["php"] = e.get("php_version") or e.get("php") or r.get("php", "")
+                row["py"] = _dotted_ver(e.get("py_flavor", "")) or r.get("py", "")
+                sections.setdefault(_edition_key(e.get("variant", "")), []).append(row)
+        else:
+            row = dict(r)
+            row["pfsense_version"] = ""
+            sections.setdefault("Other", []).append(row)
+    keys = [k for k in EDITION_ORDER if k in sections]
+    keys += [k for k in sorted(sections) if k not in EDITION_ORDER and k != "Other"]
+    if "Other" in sections:
+        keys.append("Other")
+    out: list[tuple[str, list[dict]]] = []
+    for k in keys:
+        rows = sections[k]
+        rows.sort(key=lambda p: (ver_key(p.get("pfsense_version", "")), CH_ORDER.index(p["channel"]), p["abi"]))
+        out.append((k, rows))
+    return out
+
+
+def _edition_table_html(rows: list[dict]) -> str:
     body = "".join(
-        f"<tr><td>{_esc(r['channel'])}</td><td>{_esc(r['name'])}</td>"
+        f"<tr><td>{_or_dash(r.get('pfsense_version', ''))}</td>"
+        f"<td>{_esc(r['channel'])}</td>"
         f'<td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
+        f"<td><code>{_esc(r['abi'])}</code></td>"
+        f'<td class="num">{_or_dash(r.get("php", ""))}</td>'
+        f'<td class="num">{_or_dash(r.get("py", ""))}</td>'
         f'<td class="num">{_esc(r.get("published", ""))}</td>'
         f"<td>{commit_cell(r.get('commit', ''))}</td>"
-        f"<td><code>{_esc(r['abi'])}</code></td>"
         f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
         for r in rows
     )
-    # Wrapped in an overflow-x container so a narrow (mobile) viewport scrolls the
-    # table horizontally instead of widening the whole page past the screen.
+    # overflow-x wrapper: a narrow (mobile) viewport scrolls the table, not the page.
     return (
-        '<div class="tablewrap"><table><thead><tr><th>Channel</th><th>Package</th><th>Version</th>'
-        f"<th>Published</th><th>Commit</th><th>ABI</th><th>Size</th></tr></thead><tbody>{body}</tbody></table></div>"
+        '<div class="tablewrap"><table><thead><tr>'
+        "<th>pfSense</th><th>Channel</th><th>Version</th><th>ABI</th>"
+        "<th>PHP</th><th>Python</th><th>Published</th><th>Commit</th><th>Size</th>"
+        f"</tr></thead><tbody>{body}</tbody></table></div>"
     )
 
 
-def render_page(base: str, pkgs: list[dict], trees: list[str], conf_fn: Callable[[str], str]) -> str:
+def _packages_html(pkgs: list[dict], matrix: list[dict] | None) -> str:
+    """The Published-packages block: one titled table per pfSense edition."""
+    sections = [(k, rows) for k, rows in build_edition_sections(pkgs, matrix) if rows]
+    if not sections:
+        return '<p class="empty">No packages published yet.</p>'
+    return "".join(f"<h3>{_esc(EDITION_LABELS.get(k, k))}</h3>{_edition_table_html(rows)}" for k, rows in sections)
+
+
+def older_nightlies(pkgs: list[dict]) -> list[dict]:
+    """The retained nightly builds OTHER than the newest (newest-first, ABI-grouped).
+
+    The per-edition tables surface only the latest nightly (the "install now" view);
+    retention (ADR-18) keeps several older nightlies in the catalog, reachable here
+    rather than only via the raw catalog-tree links. Empty when none are retained.
+    """
+    latest = latest_versions(pkgs).get("nightly")
+    rows = [p for p in pkgs if p["channel"] == "nightly" and p["version"] != latest]
+    rows.sort(key=lambda p: p["abi"])
+    rows.sort(key=lambda p: ver_key(p["version"]), reverse=True)
+    return rows
+
+
+def _older_nightlies_html(pkgs: list[dict]) -> str:
+    """A collapsed disclosure listing the retained older nightlies; "" when there are none."""
+    rows = older_nightlies(pkgs)
+    if not rows:
+        return ""
+    body = "".join(
+        f'<tr><td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
+        f"<td><code>{_esc(r['abi'])}</code></td>"
+        f'<td class="num">{_esc(r.get("published", ""))}</td>'
+        f"<td>{commit_cell(r.get('commit', ''))}</td>"
+        f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
+        for r in rows
+    )
+    return (
+        f"<details><summary>Older nightlies ({len(rows)})</summary>"
+        '<div class="tablewrap"><table><thead><tr>'
+        "<th>Version</th><th>ABI</th><th>Published</th><th>Commit</th><th>Size</th>"
+        f"</tr></thead><tbody>{body}</tbody></table></div></details>"
+    )
+
+
+def render_page(
+    base: str,
+    pkgs: list[dict],
+    trees: list[str],
+    conf_fn: Callable[[str], str],
+    matrix: list[dict] | None = None,
+) -> str:
     """Render the root landing page."""
     latest = latest_versions(pkgs)
     cards = "".join(_channel_card(c, base, latest, conf_fn) for c in CH_ORDER)
@@ -267,7 +420,7 @@ def render_page(base: str, pkgs: list[dict], trees: list[str], conf_fn: Callable
         "this build too. Catalogs are NONE-signed (trust anchor = HTTPS to this host) and ABI-keyed, so a box "
         "keeps resolving the right package across a pfSense OS upgrade.</p>"
         f'<h2>Channels</h2><div class="cards">{cards}</div>'
-        f"<h2>Published packages</h2>{_table_html(build_table(pkgs))}"
+        f"<h2>Published packages</h2>{_packages_html(pkgs, matrix)}{_older_nightlies_html(pkgs)}"
         "<h2>Catalog trees</h2>"
         '<p class="blurb">The raw pkg(8) catalogs (what your firewall fetches). <code>${ABI}</code> is filled '
         "in by pkg automatically, e.g. <code>FreeBSD:16:aarch64</code> on a Netgate ARM box.</p>"
@@ -306,7 +459,7 @@ def _conf_via_addrepo(addrepo: str, base: str, channel: str) -> str:
     return out.stdout.rstrip("\n")
 
 
-def write_site(site: str, base: str, addrepo: str) -> int:
+def write_site(site: str, base: str, addrepo: str, matrix: list[dict] | None = None) -> int:
     """Generate index.html at the root and in every catalog dir. Returns package count."""
     base = base.rstrip("/")
     pkgs = collect_packages(site)
@@ -316,7 +469,7 @@ def write_site(site: str, base: str, addrepo: str) -> int:
         return _conf_via_addrepo(addrepo, base, channel)
 
     with open(os.path.join(site, "index.html"), "w") as fh:
-        fh.write(render_page(base, pkgs, trees, conf_fn))
+        fh.write(render_page(base, pkgs, trees, conf_fn, matrix))
     for rel in trees:
         d = os.path.join(site, rel)
         with open(os.path.join(d, "index.html"), "w") as fh:
@@ -329,8 +482,18 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("site", help="the built catalog tree (output of build-repo-portable.py)")
     ap.add_argument("base_url", help="the Pages base URL, e.g. https://pfblockerng.github.io/pkg")
     ap.add_argument("add_repo", help="path to add-repo.sh (for the per-channel conf snippets)")
+    ap.add_argument(
+        "--matrix",
+        help="supported-versions build matrix JSON (list of {abi, pfsense_version, variant, "
+        "php_version, py_flavor}) — splits the packages table by pfSense edition. Omitted -> "
+        "a single 'Other builds' table from manifest data.",
+    )
     args = ap.parse_args(argv)
-    n = write_site(args.site, args.base_url, args.add_repo)
+    matrix = None
+    if args.matrix:
+        with open(args.matrix) as fh:
+            matrix = json.load(fh)
+    n = write_site(args.site, args.base_url, args.add_repo, matrix)
     print(f"landing page + {len(catalog_dirs(args.site))} dir index(es) written; {n} package(s) indexed")
     return 0
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -152,7 +152,13 @@ def test_collect_packages_walks_and_excludes_metadata(tmp_path: Path) -> None:
 
     def fake_read(path: str) -> dict[str, Any]:
         name, ver = layout[os.path.relpath(path, site)]
-        return {"name": name, "version": ver, "abi": Path(path).parent.name, "annotations": {"commit": "cafe1234"}}
+        return {
+            "name": name,
+            "version": ver,
+            "abi": Path(path).parent.name,
+            "annotations": {"commit": "cafe1234"},
+            "deps": {"php85": {}, "php85-intl": {}, "py311": {}, "py311-sqlite3": {}, "python311": {}},
+        }
 
     # When
     pkgs = gl.collect_packages(str(site), read_manifest=fake_read)
@@ -164,6 +170,9 @@ def test_collect_packages_walks_and_excludes_metadata(tmp_path: Path) -> None:
     assert not any("packagesite" in p["rel"] or "data.pkg" in p["rel"] for p in pkgs)
     # The source-commit annotation is carried onto each row (drives the Commit column).
     assert {p["commit"] for p in pkgs} == {"cafe1234"}
+    # PHP/Python come from the manifest deps — the runtime flavor pkg, not its sub-packages.
+    assert {p["php"] for p in pkgs} == {"8.5"}
+    assert {p["py"] for p in pkgs} == {"3.11"}
 
 
 # ── build_table: newest version per (channel, ABI) ────────────────────────────
@@ -210,6 +219,102 @@ def test_latest_versions_per_channel() -> None:
     assert gl.latest_versions(pkgs) == {"nightly": "3.2.16.20260614.9", "devel": "3.2.16"}
 
 
+# ── Edition split: matrix join → per-edition sections ─────────────────────────
+
+
+def _mx(abi: str, ver: str, variant: str, php: str, py: str) -> dict[str, str]:
+    """A supported-versions matrix entry, as read-version-matrix.sh --print-build emits."""
+    return {"abi": abi, "pfsense_version": ver, "variant": variant, "php_version": php, "py_flavor": py}
+
+
+def test_dotted_and_dep_flavor_formatting() -> None:
+    """A flavor token / dep name formats to a dotted version; sub-packages don't match."""
+    assert gl._dotted_ver("py311") == "3.11"
+    assert gl._dotted_ver("php85") == "8.5"
+    assert gl._dotted_ver("python314") == "3.14"
+    assert gl._dotted_ver("nodigits") == ""
+    # The runtime flavor pkg matches; its sub-packages (php85-intl, py311-sqlite3) do not.
+    assert gl._dep_flavor(["php85-intl", "php85"], ("php",)) == "8.5"
+    assert gl._dep_flavor(["py311-sqlite3", "python311"], ("py", "python")) == "3.11"
+    assert gl._dep_flavor(["lighttpd", "jq"], ("php",)) == ""
+
+
+def test_build_edition_sections_splits_and_shares_abi_across_versions() -> None:
+    """Scenario: organize installables by pfSense edition, sharing a build across versions.
+
+    Given devel builds for two ABIs, and a matrix where one ABI serves TWO pfSense
+      versions (a CE and a Plus),
+    When the edition sections are built,
+    Then CE sorts before Plus; each row carries the matrix pfSense version + PHP/Python;
+      and the shared-ABI build appears under BOTH editions (it installs on each, since
+      pkg resolves on ABI alone).
+    """
+    p_ce = _pkg("devel", "d", "3.2.16", "FreeBSD:15:amd64", "a.pkg")
+    p_shared = _pkg("devel", "d", "3.2.16", "FreeBSD:16:amd64", "b.pkg")
+    matrix = [
+        _mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311"),
+        _mx("FreeBSD:16:amd64", "2.9", "CE", "8.4", "py311"),
+        _mx("FreeBSD:16:amd64", "26.03", "Plus", "8.5", "py312"),
+    ]
+
+    sections = dict(gl.build_edition_sections([p_ce, p_shared], matrix))
+
+    assert [k for k, _ in gl.build_edition_sections([p_ce, p_shared], matrix)] == ["CE", "Plus"]
+    # The shared ABI build appears under BOTH editions.
+    assert any(r["abi"] == "FreeBSD:16:amd64" for r in sections["CE"])
+    assert any(r["abi"] == "FreeBSD:16:amd64" for r in sections["Plus"])
+    # Matrix php/py/version win per edition — proving the join, not a fixed value.
+    plus = next(r for r in sections["Plus"] if r["abi"] == "FreeBSD:16:amd64")
+    assert (plus["pfsense_version"], plus["php"], plus["py"]) == ("26.03", "8.5", "3.12")
+    ce_29 = next(r for r in sections["CE"] if r["abi"] == "FreeBSD:16:amd64")
+    assert (ce_29["pfsense_version"], ce_29["php"], ce_29["py"]) == ("2.9", "8.4", "3.11")
+
+
+def test_older_nightlies_lists_retained_excludes_latest() -> None:
+    """Scenario: surface the retained older nightlies, never the current one.
+
+    Given three nightly builds for one ABI (two old + the newest) plus a devel build,
+    When the older-nightlies list is built,
+    Then the NEWEST nightly is excluded (it's already in the edition table) and the two
+      older ones remain, newest-first; devel/stable are never included.
+    """
+    new = _pkg("nightly", "n", "3.2.16.20260614.9", "FreeBSD:16:amd64", "n9.pkg")
+    mid = _pkg("nightly", "n", "3.2.16.20260613.4", "FreeBSD:16:amd64", "n4.pkg")
+    old = _pkg("nightly", "n", "3.2.16.20260601.1", "FreeBSD:16:amd64", "n1.pkg")
+    dev = _pkg("devel", "d", "3.2.16", "FreeBSD:16:amd64", "d.pkg")
+
+    rows = gl.older_nightlies([new, mid, old, dev])
+
+    versions = [r["version"] for r in rows]
+    assert versions == ["3.2.16.20260613.4", "3.2.16.20260601.1"]  # newest excluded, rest newest-first
+    assert all(r["channel"] == "nightly" for r in rows)  # devel never listed
+    # The page renders the two retained nightlies in a collapsed disclosure, never the latest.
+    html = gl._older_nightlies_html([new, mid, old, dev])
+    assert "<details><summary>Older nightlies (2)</summary>" in html
+    assert "3.2.16.20260613.4" in html and "3.2.16.20260601.1" in html
+    assert "3.2.16.20260614.9" not in html  # the current nightly stays out of the 'older' list
+
+
+def test_older_nightlies_empty_when_only_latest() -> None:
+    """With a single nightly version present there is nothing 'older' to disclose."""
+    only = _pkg("nightly", "n", "3.2.16.20260614.9", "FreeBSD:16:amd64", "n.pkg")
+    assert gl.older_nightlies([only, _pkg("devel", "d", "3.2.16", "FreeBSD:16:amd64", "d.pkg")]) == []
+    # …and the page omits the disclosure entirely (no empty 'Older nightlies' affordance).
+    assert "Older nightlies" not in gl._older_nightlies_html([only])
+
+
+def test_build_edition_sections_unmatched_abi_falls_to_other() -> None:
+    """A build whose ABI the matrix doesn't cover lands in 'Other' (manifest php/py), not hidden."""
+    p = _pkg("devel", "d", "3.2.16", "FreeBSD:14:amd64", "x.pkg")
+    p["php"], p["py"] = "8.2", "3.9"  # manifest-derived fallback (no matrix row)
+
+    sections = dict(gl.build_edition_sections([p], matrix=[]))
+
+    assert list(sections) == ["Other"]
+    row = sections["Other"][0]
+    assert row["pfsense_version"] == "" and (row["php"], row["py"]) == ("8.2", "3.9")
+
+
 # ── Rendering ─────────────────────────────────────────────────────────────────
 
 
@@ -218,8 +323,9 @@ def _stub_conf(channel: str) -> str:
 
 
 def test_render_page_shows_latest_and_empty_stable() -> None:
-    """The page shows devel+nightly latest and the install URL; stable (absent) is empty-stated."""
+    """The page splits packages into per-edition tables; stable (absent) is empty-stated."""
     pkgs = [
+        _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.16", "FreeBSD:15:amd64", "FreeBSD:15:amd64/d.pkg"),
         _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.16", "FreeBSD:16:aarch64", "FreeBSD:16:aarch64/d.pkg"),
         _pkg(
             "nightly",
@@ -229,19 +335,31 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
             "nightly/FreeBSD:16:aarch64/n.pkg",
         ),
     ]
+    matrix = [
+        _mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311"),
+        _mx("FreeBSD:16:aarch64", "26.03", "Plus", "8.5", "py311"),
+    ]
     base = "https://pfblockerng.github.io/pkg"
-    page = gl.render_page(base, pkgs, ["FreeBSD:16:aarch64", "nightly/FreeBSD:16:aarch64"], _stub_conf)
+    page = gl.render_page(base, pkgs, ["FreeBSD:16:aarch64", "nightly/FreeBSD:16:aarch64"], _stub_conf, matrix)
 
     # Latest versions surfaced for the present channels.
     assert "3.2.16.20260614.9" in page
-    # The package table carries a Published datetime column (UTC, minute precision).
-    assert "<th>Published</th>" in page
+    # One table per pfSense edition, CE before Plus.
+    assert "<h3>pfSense CE</h3>" in page
+    assert "<h3>pfSense Plus</h3>" in page
+    assert page.index("pfSense CE") < page.index("pfSense Plus")
+    # Each table carries the informative pfSense version + PHP + Python columns (joined
+    # from the matrix), plus Published and Commit.
+    for header in ("<th>pfSense</th>", "<th>PHP</th>", "<th>Python</th>", "<th>Published</th>", "<th>Commit</th>"):
+        assert header in page
+    assert ">2.8<" in page and ">26.03<" in page  # pfSense versions, per edition
+    assert ">8.3<" in page and ">8.5<" in page  # PHP, per edition
+    assert ">3.11<" in page  # Python
     assert "2026-06-14 09:38 UTC" in page
-    # …and a Commit column linking the short SHA to the source commit on GitHub.
-    assert "<th>Commit</th>" in page
+    # The Commit column links the short SHA to the source commit on GitHub.
     assert f'href="{gl.SOURCE_REPO_URL}/commit/9d4b0b4556edca49b856c093838ccd0e2e91736b"' in page
     assert ">9d4b0b4<" in page
-    # The table sits in an overflow-x wrapper so a mobile viewport scrolls the table,
+    # Each table sits in an overflow-x wrapper so a mobile viewport scrolls the table,
     # not the whole page (the .tablewrap rule is what makes that scroll possible).
     assert '<div class="tablewrap"><table>' in page
     assert ".tablewrap{overflow-x:auto" in page


### PR DESCRIPTION
## What

Reorganizes the landing page's **Published packages** section around what a user actually knows — their **pfSense edition/version** — instead of only the ABI that `pkg` resolves on.

### Per-edition tables
`gen_landing.py` now reads the version matrix (new `--matrix` arg) and joins each `.pkg`'s ABI → `(edition, pfSense version, php, py)`, rendering **one table per edition** (`pfSense CE`, `pfSense Plus`) with columns `pfSense | Channel | Version | ABI | PHP | Python | Published | Commit | Size`.

- A build whose ABI serves **two** pfSense versions appears under **each** (it installs on both — `pkg` keys on ABI alone), so there are no ambiguous duplicate-ABI rows.
- An ABI **not** in the matrix (e.g. a stale release for a dropped version) falls into a trailing **"Other builds"** table using **manifest-derived** PHP/Python (read from `RUN_DEPENDS`), so nothing published is hidden. (These are usually cleaned up, so it's normally empty.)
- PHP/Python come from the matrix when joined, else from the manifest deps.

### Older nightlies
Adds a **collapsed "Older nightlies"** disclosure listing the retained older nightly builds (ADR-18 keeps several per ABI). The per-edition tables show only the latest-per-channel "install now" view; the older retained nightlies were previously reachable only via the raw catalog-tree links.

The matrix is wired from `pfBlockerNG/pkg`'s `publish.yml` (which already loads it) in a companion PR; with no `--matrix` this falls back to a single "Other builds" table, so it's safe independent of order.

## Rendered (sample)

```text
pfSense CE
pfSense | Channel | Version             | ABI              | PHP | Python | …
2.8     | devel   | 3.2.16              | FreeBSD:15:amd64 | 8.3 | 3.11   | …
2.8     | nightly | 3.2.16.20260614.25  | FreeBSD:15:amd64 | 8.3 | 3.11   | …

pfSense Plus
26.03   | devel   | 3.2.16              | FreeBSD:16:amd64 | 8.5 | 3.11   | …
26.03   | nightly | 3.2.16.20260614.25  | FreeBSD:16:amd64 | 8.5 | 3.11   | …

▸ Older nightlies (2)   ← collapsed <details>
```

## Tests

`gen_landing` suite extended (20 tests): the matrix join + edition split (CE before Plus; a shared ABI listed under both editions with each edition's php/py winning); the unmatched-ABI → "Other" fallback; PHP/Python parsed from manifest deps (flavor pkg, not sub-packages); `older_nightlies` excludes the latest and lists the rest newest-first (and the disclosure is omitted when there are none). ruff + format + mypy clean.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Landing page now organizes published packages by edition (CE/Plus/Other) when a build matrix is provided.
  * Added support for displaying PHP and Python flavor versions extracted from package metadata.
  * New matrix argument allows flexible organization of build information; falls back to unified display when omitted.

* **Tests**
  * Expanded test coverage for edition-based table rendering and manifest metadata extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->