### PR TITLE
pfblockerng: validate feed tokens and match as fixed strings during list processing

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -145,12 +145,19 @@ pfb_is_octet_prefix() {
 	esac
 }
 
-# A CIDR-ish token: digits, dots and slashes only (e.g. '10.0.0.1/32').
+# A CIDR token: digits/dots, then EXACTLY one '/', then a non-empty numeric mask
+# (e.g. '10.0.0.1/32'). The suppress() caller splits on '/' and compares the mask
+# with -eq, so a bare IP, an empty mask ('10.0.0.1/'), or a double slash
+# ('10.0.0.1//32') is rejected here and skipped rather than reaching that compare.
 pfb_is_cidr_token() {
 	case "${1}" in
-		''|*[!0-9./]*) return 1 ;;
-		*) return 0 ;;
+		''|*[!0-9./]*|*/*/*|/*|*/) return 1 ;;
 	esac
+	[ "${1#*/}" = "${1}" ] && return 1   # must contain a slash
+	case "${1##*/}" in
+		''|*[!0-9]*) return 1 ;;          # mask must be non-empty digits
+	esac
+	return 0
 }
 
 # Escape every '.' in $1 for use as a literal in a grep BRE, and emit the result

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -120,6 +120,48 @@ exitnow() {
 }
 
 
+# Token-shape guards for feed-derived list data. The list-processing functions
+# iterate values that ultimately originate from downloaded feeds and splice them
+# into `grep` patterns (anchored octet-prefix matches such as `^10\.0\.0\.`).
+# Previously only the literal dot was escaped, so any other regex metacharacter
+# in a token stayed live and `grep` interpreted it as a pattern -- yielding an
+# over-broad / incorrect match set, or an expensive pattern.
+#
+# Each guard returns success only when the token is built solely from the
+# characters that shape allows (digits, dots, and -- for CIDR -- a slash). A
+# token that fails is dropped by its caller (`continue`), never matched. Because
+# the surviving tokens contain only digits/dots/slashes, the existing dot-escape
+# + `^` anchor that follows is then exact and safe.
+#
+# Reject the empty string explicitly: `case ''` would match the `*[!set]*`
+# negation as "no disallowed char present" and pass.
+
+# An octet prefix: one or more dot-separated decimal octets, digits and dots
+# only (e.g. '10' or '10.0.0'). No anchors, no slash.
+pfb_is_octet_prefix() {
+	case "${1}" in
+		''|*[!0-9.]*) return 1 ;;
+		*) return 0 ;;
+	esac
+}
+
+# A CIDR-ish token: digits, dots and slashes only (e.g. '10.0.0.1/32').
+pfb_is_cidr_token() {
+	case "${1}" in
+		''|*[!0-9./]*) return 1 ;;
+		*) return 0 ;;
+	esac
+}
+
+# Escape every '.' in $1 for use as a literal in a grep BRE, and emit the result
+# anchored at line start ('^'). The caller MUST validate the token shape first
+# (pfb_is_octet_prefix) so only digits/dots reach here; this then yields an exact
+# '^10\.0\.0\.'-style prefix pattern with no live regex metacharacter.
+pfb_anchor_octet_pattern() {
+	printf '^%s' "${1}" | sed 's/\./\\./g'
+}
+
+
 # Function to restore IP aliastables and DNSBL database from archive on reboot. ( Ramdisk installations only )
 aliastables() {
 	if [ "${USE_MFS_TMPVAR}" -gt 0 ] || [ "${DISK_TYPE}" = 'md' ]; then
@@ -180,13 +222,24 @@ process255() {
 	if [ -n "${data255}" ]; then
 		cp "${pfbdeny}${alias}.txt" "${tempfile}"
 
-		for ip in ${data255}; do
-			ii="$(echo "^${ip}." | sed 's/\./\\\./g')"
+		# Iterate the octet prefixes safely (no IFS re-splitting) and validate each
+		# to digits/dots before building the anchored '^10\.0\.0\.' grep pattern, so
+		# a malformed token cannot reach grep as a live regex.
+		while IFS= read -r ip; do
+			pfb_is_octet_prefix "${ip}" || continue
+			ii="$(pfb_anchor_octet_pattern "${ip}.")"
 			grep "${ii}" "${tempfile}" >> "${dedupfile}"
-		done
+		done <<EOF
+${data255}
+EOF
 
 		awk 'FNR==NR{a[$0];next}!($0 in a)' "${dedupfile}" "${tempfile}" > "${pfbdeny}${alias}.txt"
-		for ip in ${data255}; do echo "${ip}.0/24" >> "${pfbdeny}${alias}.txt"; done
+		while IFS= read -r ip; do
+			pfb_is_octet_prefix "${ip}" || continue
+			echo "${ip}.0/24" >> "${pfbdeny}${alias}.txt"
+		done <<EOF
+${data255}
+EOF
 	fi
 }
 
@@ -216,18 +269,28 @@ suppress() {
 				countg="$(grep -c ^ "${pfbfolder}${alias}.txt")"
 				cp "${pfbfolder}${alias}.txt" "${tempfile}"
 
-				for ip in ${data}; do
+				# Iterate the suppression entries safely (no IFS re-splitting) via a
+				# here-doc so the loop body stays in THIS shell -- it accumulates
+				# ${counter} and appends to ${dupfile}/${tempfile}, which a `while|read`
+				# subshell would discard. Validate each token to a CIDR shape
+				# (digits/dots/slashes) and skip a malformed one, so only literal
+				# octet text reaches the fixed-string greps below.
+				while IFS= read -r ip; do
+					pfb_is_cidr_token "${ip}" || continue
 					found=''; dcheck='';
 					mask="${ip##*/}"
 					iptrim="${ip%.*}"
 					ip="${ip%%/*}"
-					found="$(grep -m1 "${iptrim}.0/24" "${tempfile}")"
+					# Fixed-string match: '${iptrim}.0/24' is a literal whole token,
+					# no anchor needed, so grep -F matches it exactly (the '.' is a
+					# literal dot, not a regex 'any char').
+					found="$(grep -F -m1 "${iptrim}.0/24" "${tempfile}")"
 
 					# If a suppression is '/32' and a blocklist has a full '/24' block, execute the following.
 					if [ -n "${found}" ] && [ "${mask}" -eq 32 ]; then
 						echo " Suppression ${alias}: ${iptrim}.0/24 (Excluding: ${ip}/32)"
 						octet4="${ip##*.}"
-						dcheck="$(grep "${iptrim}.0/24" "${dupfile}")"
+						dcheck="$(grep -F "${iptrim}.0/24" "${dupfile}")"
 
 						if [ -z "${dcheck}" ]; then
 							echo "${iptrim}.0/24" >> "${dupfile}"
@@ -242,7 +305,9 @@ suppress() {
 							done
 						fi
 					fi
-				done
+				done <<EOF
+${data}
+EOF
 
 				if [ -s "${dupfile}" ]; then
 					# Remove '/24' suppressed ranges
@@ -493,7 +558,10 @@ duplicate() {
 whoisconvert() {
 
 	vtype="${max}"
-	custom_list="$(echo "${dedup}" | tr ',' ' ')"
+	# One entry per line so the loop below can iterate via a here-doc + `read`
+	# instead of an unquoted `for` over the value (which would re-split each
+	# entry on IFS).
+	custom_list="$(echo "${dedup}" | tr ',' '\n')"
 
 	if [ "${vtype}" = '_v4' ]; then
 		_type=A
@@ -509,7 +577,10 @@ whoisconvert() {
 	echo
 	found=false
 
-	for host in ${custom_list}; do
+	# Iterate via a here-doc so the loop body stays in THIS shell (it sets the
+	# ${found} flag the restore logic below reads); skip blank entries.
+	while IFS= read -r host; do
+		[ -z "${host}" ] && continue
 		# Determine if host is a Domain or an AS
 		host_check="$(echo "${host}" | grep '\.')"
 		if [ -n "${host_check}" ]; then
@@ -533,7 +604,17 @@ whoisconvert() {
 			else
 				asn="$(echo "${host}" | tr -d 'AaSs')"
 				printf '  Collecting ASN: AS%s' "${asn}"
-				grep ",AS${asn}," "${pathasncsv}" | cut -d ',' -f1-2 | tr ',' '-' > "${pfborig}${alias}.wk"
+				# An AS number is digits only; drop anything else so the value
+				# spliced into the grep below is a literal, not a live pattern.
+				case "${asn}" in
+					''|*[!0-9]*)
+						printf "... Invalid ASN [ %s ]" "${host}"
+						touch "${pfborig}${alias}.fail"
+						found=false
+						continue
+						;;
+				esac
+				grep -F ",AS${asn}," "${pathasncsv}" | cut -d ',' -f1-2 | tr ',' '-' > "${pfborig}${alias}.wk"
 
 				# Collect only IPv4 or IPv6
 				if [ "${vtype}" = '_v4' ]; then
@@ -552,7 +633,9 @@ whoisconvert() {
 			fi
 			rm -f "${pfborig}${alias}.wk"
 		fi
-	done
+	done <<EOF
+${custom_list}
+EOF
 
 	# Restore previous orig file
 	if [ "${found}" = false ]; then
@@ -651,7 +734,12 @@ reputation_max() {
 
 	# Classify repeat offenders by Country code
 	if [ -n "${data}" ]; then
-		for ip in ${data}; do
+		# Iterate the octet prefixes via a here-doc (no IFS re-splitting) so the
+		# loop body stays in THIS shell -- it accumulates ${count}/${countr} and
+		# appends to ${dupfile}/${matchfile}. Validate each to digits/dots and
+		# skip a malformed token.
+		while IFS= read -r ip; do
+			pfb_is_octet_prefix "${ip}" || continue
 			ccheck="$(${pathgeoip} -f "${pathgeoipdat}" -i "${ip}.1" country iso_code 2>&1 | grep -v 'Could\|Got\|^$' | cut -d '"' -f2)"
 			# A failed GeoIP lookup yields an empty ${ccheck}; an unquoted *${ccheck}*
 			# case pattern would collapse to '**' and match every ${cc}, wrongly
@@ -674,17 +762,23 @@ reputation_max() {
 					echo "${ip}." >> "${dupfile}"
 					;;
 			esac
-		done
+		done <<EOF
+${data}
+EOF
 	else
 		countr=0; count=0
 	fi
 
 	# Collect match file details
 	if [ -s "${matchfile}" ] && [ "${dedup}" != 'on' ] && [ "${ccwhite}" = 'match' ]; then
-		mon="$(sed -e 's/^/^/' -e 's/\./\\\./g' "${matchfile}")"
-		for ip in ${mon}; do
-			grep "${ip}" "${tempfile}" >> "${tempfile2}"
-		done
+		# Each matchfile line is a '10.0.0.'-style octet prefix. Read them
+		# directly (no sed pre-escape, no IFS re-split), validate to digits/dots,
+		# and build the anchored '^10\.0\.0\.' pattern via the shared helper so
+		# only a literal prefix reaches grep.
+		while IFS= read -r ip; do
+			pfb_is_octet_prefix "${ip}" || continue
+			grep "$(pfb_anchor_octet_pattern "${ip}")" "${tempfile}" >> "${tempfile2}"
+		done < "${matchfile}"
 		counts="$(grep -c ^ "${tempfile2}")"
 		if [ "${ccwhite}" = 'match' ]; then
 			sed 's/$/0\/24/' "${matchfile}" >> "${tempmatchfile}"
@@ -705,10 +799,14 @@ reputation_max() {
 	# Find repeat offenders in each individual blocklist outfile
 	if [ -s "${dupfile}" ]; then
 		: > "${tempfile2}"
-		dup="$(sed -e 's/^/^/' -e 's/\./\\\./g' "${dupfile}")"
-		for ip in ${dup}; do
-			grep "${ip}" "${tempfile}" >> "${tempfile2}"
-		done
+		# Each dupfile line is a '10.0.0.'-style octet prefix. Read them directly
+		# (no sed pre-escape, no IFS re-split), validate to digits/dots, and build
+		# the anchored '^10\.0\.0\.' pattern via the shared helper so only a
+		# literal prefix reaches grep.
+		while IFS= read -r ip; do
+			pfb_is_octet_prefix "${ip}" || continue
+			grep "$(pfb_anchor_octet_pattern "${ip}")" "${tempfile}" >> "${tempfile2}"
+		done < "${dupfile}"
 		countb="$(grep -c ^ "${tempfile2}")"
 
 		if [ "${ccblack}" = 'block' ]; then
@@ -750,7 +848,12 @@ reputation_dmax() {
 	# Classify repeat offenders by Country code
 	if [ -n "${data}" ]; then
 		echo '  Classifying repeat offenders by GeoIP'
-		for ip in ${data}; do
+		# Iterate the octet prefixes via a here-doc (no IFS re-splitting) so the
+		# loop body stays in THIS shell -- it accumulates ${count}/${countr} and
+		# appends to ${dupfile}/${matchfile}. Validate each to digits/dots and
+		# skip a malformed token.
+		while IFS= read -r ip; do
+			pfb_is_octet_prefix "${ip}" || continue
 			ccheck="$(${pathgeoip} -f "${pathgeoipdat}" -i "${ip}.1" country iso_code 2>&1 | grep -v 'Could\|Got\|^$' | cut -d '"' -f2)"
 			# A failed GeoIP lookup yields an empty ${ccheck}; an unquoted *${ccheck}*
 			# case pattern would collapse to '**' and match every ${cc}, wrongly
@@ -773,18 +876,23 @@ reputation_dmax() {
 					echo "${ip}." >> "${dupfile}"
 					;;
 			esac
-		done
+		done <<EOF
+${data}
+EOF
 	else
 		countr=0; count=0
 	fi
 
 	if [ "${ccwhite}" = 'match' ] && [ -s "${matchfile}" ]; then
 		echo '  Processing [ Match ] IPs'
-		match="$(sed -e 's/^/^/' -e 's/\./\\\./g' "${matchfile}")"
-
-		for mfile in ${match}; do
-			grep "${mfile}" "${pfbdeny}"*.txt >> "${tempfile}"
-		done
+		# Each matchfile line is a '10.0.0.'-style octet prefix. Read them
+		# directly (no sed pre-escape, no IFS re-split), validate to digits/dots,
+		# and build the anchored '^10\.0\.0\.' pattern via the shared helper so
+		# only a literal prefix reaches grep.
+		while IFS= read -r ip; do
+			pfb_is_octet_prefix "${ip}" || continue
+			grep "$(pfb_anchor_octet_pattern "${ip}")" "${pfbdeny}"*.txt >> "${tempfile}"
+		done < "${matchfile}"
 
 		sed 's/$/0\/24/' "${matchfile}" >> "${tempmatchfile}"
 		sed -e 's/.*://' -e 's/^/\!/' "${tempfile}" >> "${tempmatchfile}"
@@ -796,13 +904,21 @@ reputation_dmax() {
 	# Find repeat offenders in each individual blocklist outfile
 	if [ "${count}" -gt 0 ]; then
 		echo '  Processing [ Block ] IPs'
-		dup="$(cat "${dupfile}")"
 
-		for ip in ${dup}; do
-			runonce=0; ii="$(echo "^${ip}" | sed 's/\./\\\./g')"
+		# Each dupfile line is a '10.0.0.'-style octet prefix. Read them directly
+		# from the file (no IFS re-split) so the body stays in THIS shell -- it
+		# sets ${runonce} and appends to ${dedupfile}/${addfile}. Validate each to
+		# digits/dots, then build the anchored '^10\.0\.0\.' pattern via the shared
+		# helper so only a literal prefix reaches grep.
+		while IFS= read -r ip; do
+			pfb_is_octet_prefix "${ip}" || continue
+			runonce=0; ii="$(pfb_anchor_octet_pattern "${ip}")"
 			list="$(find "${pfbdeny}"*.txt ! -name 'pfB*.txt' ! -name '*_v6.txt' -type f | xargs grep -al "${ii}")"
 
-			for blfile in ${list}; do
+			# Iterate the matched blocklist files via a here-doc (no IFS re-split)
+			# so the inner body's ${runonce}/file accumulation stays in THIS shell.
+			while IFS= read -r blfile; do
+				[ -z "${blfile}" ] && continue
 				header="$(echo "${blfile##*/}" | cut -d '.' -f1)"
 				grep "${ii}" "${blfile}" > "${tempfile}"
 
@@ -826,14 +942,20 @@ reputation_dmax() {
 						runonce=1
 					fi
 				fi
-			done
-		done
+			done <<EOF
+${list}
+EOF
+		done < "${dupfile}"
 
 		# Remove repeat offenders in masterfiles
 		echo '  Removing   [ Block ] IPs'
-		: > "${tempfile}"; : > "${tempfile2}"
-		sed 's/\./\\\./g' "${dedupfile}" > "${tempfile2}"
-		while IFS=' ' read -r ips; do grep "${ips}" "${masterfile}" >> "${tempfile}"; done < "${tempfile2}"
+		: > "${tempfile}"
+		# Each dedupfile line is 'header 10.0.0.[0/24]' -- a literal whole token,
+		# no anchor needed, so match it with grep -F (the '.' is a literal dot).
+		while IFS= read -r ips; do
+			[ -z "${ips}" ] && continue
+			grep -F "${ips}" "${masterfile}" >> "${tempfile}"
+		done < "${dedupfile}"
 		countb="$(grep -c ^ "${tempfile}")"
 		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${masterfile}"
 		cat "${addfile}" >> "${masterfile}"
@@ -870,12 +992,21 @@ reputation_pmax(){
 		echo '  Processing [ Block ] IPs'
 		count=0
 
-		for ip in ${data}; do
+		# Iterate the octet prefixes via a here-doc (no IFS re-splitting) so the
+		# loop body stays in THIS shell -- it accumulates ${count} and appends to
+		# ${dedupfile}/${addfile}. Validate each to digits/dots, then build the
+		# anchored '^10\.0\.0\.' pattern via the shared helper so only a literal
+		# prefix reaches grep.
+		while IFS= read -r ip; do
+			pfb_is_octet_prefix "${ip}" || continue
 			count="$((count + 1))"
-			runonce=0; ii="$(echo "^${ip}." | sed 's/\./\\\./g')"
+			runonce=0; ii="$(pfb_anchor_octet_pattern "${ip}.")"
 			list="$(find "${pfbdeny}"*.txt ! -name 'pfB*.txt' ! -name '*_v6.txt' -type f | xargs grep -al "${ii}")"
 
-			for blfile in ${list}; do
+			# Iterate the matched blocklist files via a here-doc (no IFS re-split)
+			# so the inner body's ${runonce}/file accumulation stays in THIS shell.
+			while IFS= read -r blfile; do
+				[ -z "${blfile}" ] && continue
 				header="$(echo "${blfile##*/}" | cut -d '.' -f1)"
 				grep "${ii}" "${blfile}" > "${tempfile}"
 				awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${blfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${blfile}"
@@ -888,14 +1019,22 @@ reputation_pmax(){
 				else
 					echo "${header}" "${ip}." >> "${dedupfile}"
 				fi
-			done
-		done
+			done <<EOF
+${list}
+EOF
+		done <<EOF
+${data}
+EOF
 
 		# Remove repeat offenders in masterfile
 		echo '  Removing   [ Block ] IPs'
-		: > "${tempfile}"; : > "${tempfile2}"
-		sed 's/\./\\\./g' "${dedupfile}" > "${tempfile2}"
-		while IFS=' ' read -r ips; do grep "${ips}" "${masterfile}" >> "${tempfile}"; done < "${tempfile2}"
+		: > "${tempfile}"
+		# Each dedupfile line is 'header 10.0.0.' -- a literal whole token, no
+		# anchor needed, so match it with grep -F (the '.' is a literal dot).
+		while IFS= read -r ips; do
+			[ -z "${ips}" ] && continue
+			grep -F "${ips}" "${masterfile}" >> "${tempfile}"
+		done < "${dedupfile}"
 		countb="$(grep -c ^ "${tempfile}")"
 		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${masterfile}"
 		cat "${addfile}" >> "${masterfile}"

--- a/tests/shell/pfblockerng_feed_token_match_spec.sh
+++ b/tests/shell/pfblockerng_feed_token_match_spec.sh
@@ -45,12 +45,31 @@ Describe 'feed-token shape guards'
       When call pfb_is_cidr_token '10.0.0.1/32'
       The status should be success
     End
+    It 'accepts a network/prefix CIDR token'
+      When call pfb_is_cidr_token '10.0.0.0/24'
+      The status should be success
+    End
     It 'rejects a token carrying a regex metacharacter'
       When call pfb_is_cidr_token '10.0.0.*'
       The status should be failure
     End
     It 'rejects the empty string'
       When call pfb_is_cidr_token ''
+      The status should be failure
+    End
+    # The mask is required: suppress() splits on '/' and compares it with -eq, so a
+    # token with no slash, an empty mask, or a double slash must be dropped here
+    # rather than reaching that numeric compare.
+    It 'rejects a bare IP with no slash (no mask to compare)'
+      When call pfb_is_cidr_token '10.0.0.1'
+      The status should be failure
+    End
+    It 'rejects an empty mask (trailing slash)'
+      When call pfb_is_cidr_token '10.0.0.1/'
+      The status should be failure
+    End
+    It 'rejects a double slash'
+      When call pfb_is_cidr_token '10.0.0.1//32'
       The status should be failure
     End
   End

--- a/tests/shell/pfblockerng_feed_token_match_spec.sh
+++ b/tests/shell/pfblockerng_feed_token_match_spec.sh
@@ -1,0 +1,156 @@
+#shellcheck shell=sh
+# Feed-token matching during IP-list processing. The reputation/suppress/process
+# loops derive octet-prefix tokens from list data and splice them into `grep`.
+# Previously only the literal dot was escaped, so any other regex metacharacter
+# in a token stayed live and grep treated it as a pattern -- an over-broad /
+# incorrect match. The fix validates each token to a digits/dots (CIDR: + slash)
+# shape and drops a non-conforming one, then matches the survivor as an exact
+# anchored literal. This suite pins BOTH branches: a well-formed token still
+# matches its intended lines, and a metachar-bearing token is dropped (matches
+# nothing).
+
+Describe 'feed-token shape guards'
+  BeforeAll 'pfb_source'
+
+  # Trivial mapping: assert each side of the digits/dots membership rule.
+  Describe 'pfb_is_octet_prefix'
+    It 'accepts a digits-and-dots octet prefix'
+      When call pfb_is_octet_prefix '10.0.0'
+      The status should be success
+    End
+    It 'accepts a prefix with a trailing dot (the form written to the dup/match files)'
+      When call pfb_is_octet_prefix '10.0.0.'
+      The status should be success
+    End
+    It 'rejects a token carrying a regex metacharacter'
+      When call pfb_is_octet_prefix '10.0.*'
+      The status should be failure
+    End
+    It 'rejects a token with an alternation/anchor metacharacter'
+      When call pfb_is_octet_prefix '10|^9'
+      The status should be failure
+    End
+    It 'rejects a slash (an octet prefix carries no mask)'
+      When call pfb_is_octet_prefix '10.0.0/24'
+      The status should be failure
+    End
+    It 'rejects the empty string'
+      When call pfb_is_octet_prefix ''
+      The status should be failure
+    End
+  End
+
+  Describe 'pfb_is_cidr_token'
+    It 'accepts a digits/dots/slash CIDR token'
+      When call pfb_is_cidr_token '10.0.0.1/32'
+      The status should be success
+    End
+    It 'rejects a token carrying a regex metacharacter'
+      When call pfb_is_cidr_token '10.0.0.*'
+      The status should be failure
+    End
+    It 'rejects the empty string'
+      When call pfb_is_cidr_token ''
+      The status should be failure
+    End
+  End
+
+  # The escaper turns a validated prefix into an anchored, dot-escaped BRE. Once
+  # the caller has validated the token to digits/dots, this is the ONLY pattern
+  # text that reaches grep -- so it must escape every dot and anchor at '^'.
+  Describe 'pfb_anchor_octet_pattern'
+    It 'anchors at line start and escapes every dot'
+      When call pfb_anchor_octet_pattern '10.0.0.'
+      The output should equal '^10\.0\.0\.'
+    End
+  End
+End
+
+# End-to-end through a real list-processing function (reputation_max), driven the
+# same way the in-tree reputation specs drive it (sourced library + GeoIP stub).
+# This proves the guard+escaper are wired into the production path, not just unit
+# correct in isolation.
+Describe 'reputation_max() feed-token matching'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/feedtok.XXXXXX")"
+    pfbdeny="${work}/deny/"
+    pfbmatch="${work}/match/"
+    mkdir -p "$pfbdeny" "$pfbmatch"
+    tempfile="${work}/t1"; tempfile2="${work}/t2"
+    dupfile="${work}/t3"; matchfile="${work}/t7"; tempmatchfile="${work}/t8"
+    pathgeoip="${work}/mmdblookup"
+    pathgeoipdat="${work}/geo.mmdb"; touch "$pathgeoipdat"
+    now="now"
+    count=0; countb=0; counts=0; countr=0
+    # ccblack=block routes a repeat offender to the block path: the function
+    # removes its /24 members from the list and appends a single 'p.q.r.0/24'.
+    dedup="off"; ccwhite="off"; ccblack="block"; cc="ZZ"
+    alias="MYLIST"
+    max=1
+    # A GeoIP miss keeps every offender on the block path (country never equals
+    # cc=ZZ), so classification cannot divert the test IPs into a match file.
+    make_geoip_stub "$pathgeoip" 'Could not find an entry for this IP address'
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  # Scenario: a well-formed octet prefix matches ONLY its own /24, anchored.
+  #   Given a list whose '1.2.3.*' members repeat past Max, plus a decoy
+  #         '91.2.3.7' that a non-anchored / substring match would wrongly catch,
+  #   When  reputation_max runs (the offender token is '1.2.3'),
+  #   Then  the three '1.2.3.*' members are replaced by '1.2.3.0/24'
+  #   And   the decoy '91.2.3.7' survives untouched (the '^1\.2\.3\.' anchor does
+  #         not match it) -- proving the match is anchored and literal.
+  Describe 'a well-formed octet prefix (anchored, literal)'
+    fixture() { printf '1.2.3.4\n1.2.3.5\n1.2.3.6\n91.2.3.7\n' > "${pfbdeny}${alias}.txt"; }
+    Before 'fixture'
+
+    # Before-state: the offender member and the look-alike decoy are both present
+    # in the unprocessed list (so the after-state below proves the run caused the
+    # change, not a pre-existing absence).
+    It 'starts with the offender member and the look-alike decoy present'
+      When call cat "${pfbdeny}${alias}.txt"
+      The output should include '1.2.3.4'
+      The output should include '91.2.3.7'
+    End
+
+    It 'collapses only the anchored /24 and leaves the decoy intact'
+      When call reputation_max
+      The status should be success
+      The stdout should include 'Reputation -Max Stats'
+      The contents of file "${pfbdeny}${alias}.txt" should include '1.2.3.0/24'
+      The contents of file "${pfbdeny}${alias}.txt" should not include '1.2.3.4'
+      The contents of file "${pfbdeny}${alias}.txt" should include '91.2.3.7'
+    End
+  End
+
+  # Scenario: a token carrying a regex metacharacter is DROPPED, never matched.
+  #   Given list members whose first three dot-fields contain a '*' ('1.2.*.N'),
+  #         so the repeat-offender token is the metachar-bearing '1.2.*', plus a
+  #         decoy '1.2.9.9' that a live '^1.2.*' regex would match,
+  #   When  reputation_max runs,
+  #   Then  the validation drops '1.2.*' (not digits/dots) -> no /24 is produced,
+  #         nothing is removed, and the decoy survives -- proving the token is no
+  #         longer interpreted as a regex.
+  Describe 'a metacharacter-bearing token (dropped)'
+    fixture() { printf '1.2.*.4\n1.2.*.5\n1.2.9.9\n' > "${pfbdeny}${alias}.txt"; }
+    Before 'fixture'
+
+    # Before-state: the metachar members and the decoy are present unprocessed.
+    It 'starts with the metachar members and the decoy present'
+      When call cat "${pfbdeny}${alias}.txt"
+      The output should include '1.2.*.4'
+      The output should include '1.2.9.9'
+    End
+
+    It 'drops the token instead of matching as a regex (list unchanged)'
+      When call reputation_max
+      The status should be success
+      The contents of file "${pfbdeny}${alias}.txt" should not include '0/24'
+      The contents of file "${pfbdeny}${alias}.txt" should include '1.2.9.9'
+      The contents of file "${pfbdeny}${alias}.txt" should include '1.2.*.4'
+    End
+  End
+End


### PR DESCRIPTION
## What

Harden how `pfblockerng.sh` iterates and matches the IP-list tokens its list-processing functions derive from list data.

Two fragile patterns are replaced:

1. **Token interpolated into `grep` with only dots escaped.** A token spliced into a `grep` pattern previously had only its literal dots escaped (`sed 's/\./\\./g'`); any other regex metacharacter stayed live, so `grep` interpreted the token as a pattern -- an over-broad or incorrect membership result. Tokens are now validated to their expected shape and matched either as an anchored literal or as a fixed string.

2. **Unquoted `for x in ${data}` over command-substituted data.** Iterating an unquoted command-substitution re-splits each entry on `IFS`. The loops now iterate with `read` (here-doc or file redirection), so a value cannot be re-tokenised.

## How

- New helpers: `pfb_is_octet_prefix` / `pfb_is_cidr_token` (token-shape guards: digits + dots, optionally a slash) and `pfb_anchor_octet_pattern` (builds the `^10\.0\.0\.`-style anchored, dot-escaped pattern from an already-validated token).
- Each in-scope loop in `process255`, `suppress`, `whoisconvert`, and `reputation_max` / `reputation_dmax` / `reputation_pmax` now reads its tokens safely, validates each to its expected shape and **skips** a non-conforming one, then matches it:
  - as an **anchored literal** where the `^…\.` octet-prefix semantics are required (built via the shared helper), or
  - with **`grep -F`** where a literal whole token suffices (e.g. the `…0/24` suppression lookup, the masterfile-removal lookups, the ASN lookup).
- Loops that accumulate counters or flags use a here-doc / file-redirected `read` (not a `while | read` pipeline) so the body stays in the current shell and the accumulation is preserved.

Behaviour is unchanged for well-formed IP data -- only malformed tokens (which never represented valid list entries) change outcome: they are now dropped instead of being interpreted as a pattern.

## Tests

New `tests/shell/pfblockerng_feed_token_match_spec.sh` (shellspec):

- Unit-pins both branches of each shape guard (accepts a digits/dots[/slash] token, rejects a metacharacter-bearing token, the empty string, and a slash where none is allowed) and the anchored-pattern builder.
- End-to-end through `reputation_max` (sourced library + GeoIP stub, mirroring the existing reputation specs):
  - a well-formed octet prefix collapses **only** its anchored `/24` and leaves a look-alike decoy (`91.2.3.7`) untouched -- proving the match is anchored and literal;
  - a metacharacter-bearing token (`1.2.*`) is **dropped** rather than matched as a regex -- the list is left unchanged and a decoy a live regex would have caught survives.
  - Each scenario asserts the before-state (offender + decoy present, unprocessed) and then the after-state, so green proves the run caused the change.

Verified the metacharacter end-to-end case fails against the pre-change code.

`sh -n`, `shellcheck`, and the full `shellspec` suite (63 examples) are green; `pytest` (no Python touched) and the other linters pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added feed-token shape validation and anchored pattern generation so only well-formed octet-prefix and CIDR tokens are used.
  * Updated token processing (including 255 handling and suppression entries) to iterate safely line-by-line and use literal matching, preventing metacharacter or malformed tokens from altering results.
  * Improved dedup parsing in whois conversion and tightened ASN handling to digits-only with safer CSV matching.
* **Tests**
  * Added ShellSpec tests covering token-shape guards and verifying `reputation_max` drops metacharacter tokens while leaving valid entries correctly anchored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->