### PR TITLE
pfblockerng: reject pathological feed regex before compile

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -397,10 +397,17 @@ def _build_swap_snapshot() -> Snapshot | None:
             if config.has_section("REGEX"):
                 r_count = 1
                 for name, pattern in config.items("REGEX"):
-                    if pfb["regex_cap"] and _regex_exceeds_static_cap(pattern):
+                    if _regex_is_catastrophic_shape(pattern):
                         sys.stderr.write(
-                            "[pfBlockerNG]: dropping long/complex user regex [ {} ] pattern [ {} ] "
-                            "on line #{} (static cap)".format(name, pattern, r_count)
+                            "[pfBlockerNG]: dropping pathological user regex [ {} ] pattern [ {} ] "
+                            "on line #{} (catastrophic shape)".format(name, pattern, r_count)
+                        )
+                        r_count += 1
+                        continue
+                    if pfb["regex_cap"] and len(pattern) > REGEX_STATIC_LEN_CAP:
+                        sys.stderr.write(
+                            "[pfBlockerNG]: dropping over-length user regex [ {} ] pattern [ {} ] "
+                            "on line #{} (static length cap)".format(name, pattern, r_count)
                         )
                         r_count += 1
                         continue
@@ -979,14 +986,22 @@ def init_standard(id: int, env: module_env) -> bool:
                 if regex_config:
                     r_count = 1
                     for name, pattern in regex_config:
-                        # ADR-07 P7: the opt-in static cap also covers the un-vetted
-                        # USER regex list -- an over-long / nested-quantifier user
-                        # pattern is dropped at load (logged, not compiled) when the
-                        # "Limit long/complex regex" setting is enabled.
-                        if pfb["regex_cap"] and _regex_exceeds_static_cap(pattern):
+                        # ADR-07 P7: a catastrophic SHAPE in the un-vetted USER regex
+                        # list is dropped at load UNCONDITIONALLY (logged, not compiled)
+                        # -- the always-on safety gate. The opt-in length ceiling (the
+                        # "Limit long/complex regex" setting) is the separate tunable
+                        # half: it drops over-length-but-safe user patterns only when on.
+                        if _regex_is_catastrophic_shape(pattern):
                             sys.stderr.write(
-                                "[pfBlockerNG]: dropping long/complex user regex [ {} ] pattern [ {} ] "
-                                "on line #{} (static cap)".format(name, pattern, r_count)
+                                "[pfBlockerNG]: dropping pathological user regex [ {} ] pattern [ {} ] "
+                                "on line #{} (catastrophic shape)".format(name, pattern, r_count)
+                            )
+                            r_count += 1
+                            continue
+                        if pfb["regex_cap"] and len(pattern) > REGEX_STATIC_LEN_CAP:
+                            sys.stderr.write(
+                                "[pfBlockerNG]: dropping over-length user regex [ {} ] pattern [ {} ] "
+                                "on line #{} (static length cap)".format(name, pattern, r_count)
                             )
                             r_count += 1
                             continue
@@ -3609,9 +3624,10 @@ def _dnsbl_normalise_whitelist(
 #       pattern from the live regexDB/allowRegexDB (snapshot-iterate, evict-after-
 #       loop -- never mutate mid-iteration; dict.pop is atomic under the GIL).
 
-# Static-cap defaults (Phase-1 RESULTS/01 SS3c heuristic): a pattern over this
-# many characters, OR carrying a nested/overlapping unbounded quantifier, is the
-# genuinely catastrophic shape and is dropped at load when the cap is enabled.
+# Length ceiling (Phase-1 RESULTS/01 SS3c heuristic): a pattern over this many
+# characters is dropped at load ONLY when the opt-in "Limit long/complex regex"
+# setting is enabled. Length alone is a tunable convenience cap, NOT a safety gate --
+# a long pattern is not inherently pathological -- so it stays behind the flag.
 REGEX_STATIC_LEN_CAP = 200
 
 # A quantified group that itself sits inside a quantifier: (a+)+, (a*)*, (\w+\.)+,
@@ -3625,6 +3641,32 @@ _REGEX_NESTED_QUANTIFIER = re.compile(r"\([^()]*[+*][^()]*\)\s*[+*{]")
 # nested-quantifier shape above does not catch them (no inner quantifier). Kept
 # conservative: a single `(...)` (no inner parens) with a `|`, then a quantifier.
 _REGEX_ALTERNATION_OVERLAP = re.compile(r"\([^()]*\|[^()]*\)\s*[+*{]")
+
+# Multi-group adjacent quantified groups: (a+)(a+)+, (a+)(b+)*, (...)(...)+ -- two
+# back-to-back groups where the SECOND carries a trailing quantifier. The first
+# group's unbounded body and the quantified second group share input, so the engine
+# explores an exponential partition of the matched span. The single-group
+# _REGEX_NESTED_QUANTIFIER above misses this (the outer quantifier sits on a sibling
+# group, not the enclosing one). Each group body is paren-free (kept conservative).
+_REGEX_ADJACENT_GROUP_QUANTIFIER = re.compile(r"\([^()]*[+*][^()]*\)\([^()]*\)\s*[+*]")
+
+# Stacked bounded repeats: a{1000}{1000}, (x){500}{500}, [a-z]{50}{50} -- a `{m}`/`{m,n}`
+# repeat immediately followed by another `{...}`. Python's re multiplies the bounds, so a
+# pair of large counts is a polynomial/exponential blow-up with a tiny source string. A
+# group/atom (optionally already quantified) then two consecutive brace quantifiers.
+_REGEX_STACKED_BOUNDED_REPEAT = re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?:,\d*)?\}")
+
+# Complexity-budget backstop: cap the combined count of unbounded quantifiers (`+`/`*`,
+# unescaped) and alternations (`|`, unescaped) in one pattern. The structural regexes
+# above catch KNOWN bad shapes; this catches novel compositions of many quantifiers /
+# alternatives that together create a large backtracking surface even when no single
+# pair matches a structural template. The threshold (12) is generous: realistic ABP/DNS
+# feed regex carries a handful of anchors + one or two trailing quantifiers (a domain
+# pattern like `^(.+\.)?ads?[0-9]*\.example\.(com|net|org)$` counts ~5), so 12 clears
+# every benign pattern in the Phase-1 corpus while still bounding adversarial stacking.
+_REGEX_BUDGET_MAX = 12
+_REGEX_UNBOUNDED_QUANTIFIER = re.compile(r"(?<!\\)[+*]")
+_REGEX_ALTERNATION = re.compile(r"(?<!\\)\|")
 
 # Runtime warn/evict ceilings (milliseconds of per-match thread CPU; Phase-1
 # defaults, ADR.md SS2). Overridable via the pfb_unbound.ini MAIN section
@@ -3648,17 +3690,39 @@ _regex_warned: set[str] = set()
 _regex_perf_strikes: dict[str, int] = {}
 
 
-def _regex_exceeds_static_cap(pattern: str) -> bool:
-    """Pure static-cap check (NO execution): True if ``pattern`` is over the length
-    ceiling OR matches the nested-quantifier heuristic OR the alternation-overlap
-    heuristic. Used at LOAD time, gated by the opt-in "Limit long/complex regex"
-    setting -- when the setting is OFF nothing is dropped. Catches the catastrophic
-    shapes cheaply without running the regex."""
-    if len(pattern) > REGEX_STATIC_LEN_CAP:
-        return True
+def _regex_is_catastrophic_shape(pattern: str) -> bool:
+    """Pure static analysis (NO execution): True when ``pattern`` carries a structurally
+    catastrophic shape -- a nested / adjacent / overlapping unbounded quantifier, a
+    stacked bounded repeat, or so many unbounded quantifiers + alternations combined that
+    its backtracking surface is unsafe. This is the SAFETY gate: it is applied to FEED and
+    user regex UNCONDITIONALLY at load (independent of the opt-in length cap) because these
+    shapes drive catastrophic backtracking in the `re` engine. It only inspects the pattern
+    STRING -- it never runs the candidate against any input -- so it is itself cheap and
+    safe. Length is deliberately NOT part of this gate (a long pattern is not inherently
+    catastrophic; the length ceiling is the separate opt-in convenience cap)."""
     if _REGEX_NESTED_QUANTIFIER.search(pattern) is not None:
         return True
-    return _REGEX_ALTERNATION_OVERLAP.search(pattern) is not None
+    if _REGEX_ALTERNATION_OVERLAP.search(pattern) is not None:
+        return True
+    if _REGEX_ADJACENT_GROUP_QUANTIFIER.search(pattern) is not None:
+        return True
+    if _REGEX_STACKED_BOUNDED_REPEAT.search(pattern) is not None:
+        return True
+    # Budget backstop: total unbounded quantifiers + alternations over the threshold.
+    budget = len(_REGEX_UNBOUNDED_QUANTIFIER.findall(pattern)) + len(_REGEX_ALTERNATION.findall(pattern))
+    return budget > _REGEX_BUDGET_MAX
+
+
+def _regex_exceeds_static_cap(pattern: str) -> bool:
+    """Pure static-cap check (NO execution): True if ``pattern`` is over the length
+    ceiling OR carries a catastrophic shape. Used at LOAD time for the opt-in "Limit
+    long/complex regex" setting -- when the setting is OFF the length ceiling is NOT
+    enforced (long-but-safe patterns load). The catastrophic-shape half is also enforced
+    UNCONDITIONALLY via ``_regex_is_catastrophic_shape`` regardless of this setting; this
+    wrapper folds in the additional length ceiling for the gated path."""
+    if len(pattern) > REGEX_STATIC_LEN_CAP:
+        return True
+    return _regex_is_catastrophic_shape(pattern)
 
 
 def _regex_timed_search(pattern: Any, q_name: str) -> tuple[Any, float]:
@@ -3743,18 +3807,29 @@ def _dnsbl_compile_regex_rules(
     load) -- it never aborts the build. Names are unique per pattern occurrence so two
     feeds carrying the same pattern both load.
 
-    ADR-07 P7: when ``static_cap`` is True (the opt-in "Limit long/complex regex"
-    setting) an over-length / nested-quantifier pattern is DROPPED at load (logged,
-    not compiled, not counted) -- the cheap no-execution pre-filter. The always-on
-    runtime warn/evict guard lives in the matcher (it is what bounds the residual).
+    ADR-07 P7: a pattern carrying a catastrophic SHAPE (nested / adjacent / overlapping
+    unbounded quantifier, stacked bounded repeat, or over the complexity budget) is
+    DROPPED at load UNCONDITIONALLY -- independent of ``static_cap`` -- because such a
+    shape drives catastrophic backtracking in the `re` engine. The opt-in length ceiling
+    (the "Limit long/complex regex" setting, ``static_cap``) is the SEPARATE tunable half:
+    when True it ALSO drops over-length-but-safe patterns. All checks are pure static
+    string analysis (no execution); the always-on runtime warn/evict guard lives in the
+    matcher (it is what bounds the residual of anything that slips through).
     """
     db: dict[str, dict[str, Any]] = {}
     admitted = 0
     seq = 0
     for rule in regex_rules:
-        if static_cap and _regex_exceeds_static_cap(rule.pattern):
+        if _regex_is_catastrophic_shape(rule.pattern):
             sys.stderr.write(
-                "[pfBlockerNG]: dropping long/complex {} regex feed [ {} ] pattern [ {} ] (static cap)".format(
+                "[pfBlockerNG]: dropping pathological {} regex feed [ {} ] pattern [ {} ] (catastrophic shape)".format(
+                    rule.kind, rule.feed, rule.pattern
+                )
+            )
+            continue
+        if static_cap and len(rule.pattern) > REGEX_STATIC_LEN_CAP:
+            sys.stderr.write(
+                "[pfBlockerNG]: dropping over-length {} regex feed [ {} ] pattern [ {} ] (static length cap)".format(
                     rule.kind, rule.feed, rule.pattern
                 )
             )

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1355,8 +1355,9 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         settings["pfb_regex"] = "on"
         settings["pfb_regex_list"] = _b64_textarea(spec.user_regex)
     if spec.regex_cap:
-        # Opt-in static cap (inc:2685 -> ini regex_cap=on). Drops over-cap feed AND
-        # user regex at load (pfb_unbound.py:_regex_exceeds_static_cap).
+        # Opt-in length cap (inc:2685 -> ini regex_cap=on). Drops over-LENGTH feed AND
+        # user regex at load. The catastrophic-SHAPE gate is separate and ALWAYS on
+        # (pfb_unbound.py:_regex_is_catastrophic_shape), independent of this flag.
         settings["pfb_regex_cap"] = "on"
     if spec.cname_validation:
         # "CNAME Validation" (inc:852 -> ini python_cname). Walk a resolved answer's

--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -250,24 +250,33 @@ def test_abp_regex_block_and_allow(deployed_vm: SmokeVM, mock_feeds: _MockFeedSe
 
 
 def test_abp_regex_admitted_count(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
-    """The DNSBL_Regex count reflects ADMITTED regex, and the static cap shrinks it.
+    """The DNSBL_Regex count reflects ADMITTED regex; the length cap (opt-in) shrinks it.
 
-    Two USER regex patterns — one benign (``ads[0-9]+``), one nested-quantifier
-    (``(a+)+evil``, which ``_regex_exceeds_static_cap`` flags). With the cap OFF both
-    are admitted (count 2); with the cap ON the over-cap pattern is dropped at load
-    (count 1). A minimal plain feed is present so the DNSBL build runs and emits the
-    count file. (allowRegexDB is empty here, so the count is purely regexDB.)
+    Two USER regex patterns — one short benign (``ads[0-9]+``), one long-but-benign
+    (a >200-char literal alternation, structurally safe). With the opt-in length cap
+    OFF both are admitted (count 2); with it ON the over-length pattern is dropped at
+    load (count 1). A catastrophic SHAPE would be dropped regardless of the cap — that
+    UNCONDITIONAL gate is asserted separately in ``test_abp_catastrophic_regex_dropped``;
+    here the long-but-benign pattern proves the LENGTH ceiling stays gated. A minimal
+    plain feed is present so the DNSBL build runs and emits the count file. (allowRegexDB
+    is empty here, so the count is purely regexDB.)
     """
     domain = h.unique_domain("abpcnt")
     feed_url = h.write_local_feed(deployed_vm, "smoke_abp_cnt.txt", f"{domain}\n")
-    patterns = [r"ads[0-9]+", r"(a+)+evil"]
+    # A long-but-structurally-safe pattern: a long concatenation of literal labels with a
+    # single optional group, over the 200-char length ceiling but with no catastrophic
+    # shape (no nested/overlapping quantifier, no stacked repeat, budget well under
+    # threshold) -- so only the opt-in LENGTH cap can drop it.
+    long_benign = r"^(sub)?" + "verylongsubdomainlabel" * 10 + r"\.example\.com$"
+    assert len(long_benign) > 200
+    patterns = [r"ads[0-9]+", long_benign]
 
     spec_off = h.DnsblCase(
         aliasname="smokeabpcnt", feed_url=feed_url, header="smokeabpcnt", mode=h.DnsblMode.VIP, user_regex=patterns
     )
     with h.CaseContext(deployed_vm, spec_off):
         n_off = h.regex_admitted_count(deployed_vm)
-    assert n_off == 2, f"cap OFF: both user regex admitted, expected 2, got {n_off!r}"
+    assert n_off == 2, f"cap OFF: both user regex admitted (length cap not enforced), expected 2, got {n_off!r}"
 
     spec_on = h.DnsblCase(
         aliasname="smokeabpcnt",
@@ -279,8 +288,29 @@ def test_abp_regex_admitted_count(deployed_vm: SmokeVM, mock_feeds: _MockFeedSer
     )
     with h.CaseContext(deployed_vm, spec_on):
         n_on = h.regex_admitted_count(deployed_vm)
-    assert n_on == 1, f"cap ON: nested-quantifier dropped at load, expected admitted 1, got {n_on!r}"
+    assert n_on == 1, f"cap ON: over-length pattern dropped at load, expected admitted 1, got {n_on!r}"
     assert n_on < n_off, f"cap must shrink the admitted count: off={n_off} on={n_on}"
+
+
+def test_abp_catastrophic_regex_dropped(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """A catastrophic-SHAPE user regex is dropped at load with the length cap OFF.
+
+    The always-on shape gate is independent of the opt-in "Limit long/complex regex"
+    setting: a nested-quantifier pattern (``(a+)+evil``) is never compiled into the
+    regexDB even when ``regex_cap`` is OFF, while a benign sibling (``ads[0-9]+``) is
+    admitted. Proves the SHAPE half of the decoupled gate is unconditional (the key
+    behaviour change) on the live box, not just in the unit suite.
+    """
+    domain = h.unique_domain("abpcat")
+    feed_url = h.write_local_feed(deployed_vm, "smoke_abp_cat.txt", f"{domain}\n")
+    patterns = [r"ads[0-9]+", r"(a+)+evil"]
+
+    spec = h.DnsblCase(
+        aliasname="smokeabpcat", feed_url=feed_url, header="smokeabpcat", mode=h.DnsblMode.VIP, user_regex=patterns
+    )
+    with h.CaseContext(deployed_vm, spec):
+        n = h.regex_admitted_count(deployed_vm)
+    assert n == 1, f"cap OFF: catastrophic shape dropped unconditionally, only benign admitted, expected 1, got {n!r}"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -153,6 +153,20 @@ class TestCatastrophicShapeHeuristic:
         over_budget = "".join(f"a{i}*|" for i in range(pfb_unbound._REGEX_BUDGET_MAX + 2))
         assert _regex_is_catastrophic_shape(over_budget) is True
 
+    def test_complexity_budget_at_threshold_not_flagged(self) -> None:
+        # The budget comparison is strictly `>` _REGEX_BUDGET_MAX, so a pattern whose budget
+        # equals MAX exactly is the last admissible value (off-by-one guard: a `>=` regression
+        # would flag this). Build a pattern whose budget is EXACTLY MAX -- `_REGEX_BUDGET_MAX`
+        # unbounded `*` quantifiers, zero alternations, and no other catastrophic shape (no
+        # nested/adjacent quantified group, no stacked bounded repeat).
+        at_budget = "a*" * pfb_unbound._REGEX_BUDGET_MAX
+        # Compute the budget the SAME way the code does and pin it to MAX before asserting.
+        budget = len(pfb_unbound._REGEX_UNBOUNDED_QUANTIFIER.findall(at_budget)) + len(
+            pfb_unbound._REGEX_ALTERNATION.findall(at_budget)
+        )
+        assert budget == pfb_unbound._REGEX_BUDGET_MAX
+        assert _regex_is_catastrophic_shape(at_budget) is False
+
     # --- false-positive guard: realistic benign feed regex must NOT be flagged ----- #
     def test_benign_feed_patterns_not_flagged(self) -> None:
         for pat in (

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -1,13 +1,20 @@
-"""ADR-07 Phase 7 -- regex safety: opt-in static cap + always-on runtime warn/evict.
+"""ADR-07 Phase 7 -- regex safety: always-on catastrophic-shape gate + opt-in length
+cap + always-on runtime warn/evict.
 
 `re` does not release the GIL during a match and a Python thread cannot be killed
 (ADR.md fact 2), so a query-time timeout CANNOT interrupt a catastrophic match. The
 accepted design is a bounded residual: a pathological pattern's FIRST match may block
-one query, but it is then EVICTED so it cannot hang again. Two layers, both stdlib +
-in-process, applied to FEED *and* user regex:
+one query, but it is then EVICTED so it cannot hang again. The LOAD-time gate is split
+into two DECOUPLED concerns, both stdlib + in-process, applied to FEED *and* user regex:
 
-  (1) opt-in STATIC CAP -- drop over-long / nested-quantifier patterns at LOAD (no
-      execution) when "Limit long/complex regex" is enabled;
+  (1a) always-on catastrophic-SHAPE gate -- a structurally pathological pattern (nested /
+       adjacent / overlapping unbounded quantifier, stacked bounded repeat, or over the
+       complexity budget) is dropped at LOAD UNCONDITIONALLY -- independent of any
+       setting -- because such a shape drives catastrophic backtracking in `re`. Pure
+       static string analysis, NO execution of the candidate;
+  (1b) opt-in LENGTH ceiling -- a long-but-safe pattern is dropped at LOAD only when the
+       "Limit long/complex regex" setting is enabled; length alone is a tunable
+       convenience cap, NOT a safety gate, so it stays behind the flag;
   (2) always-on RUNTIME timing -- over a warn ceiling log, over a higher evict ceiling
       log + remove the pattern from the live regexDB/allowRegexDB (snapshot-iterate,
       evict-after-loop -- never mutate mid-iteration; dict.pop is atomic under the GIL).
@@ -32,6 +39,7 @@ from pfb_unbound import (
     RegexRule,
     _dnsbl_compile_regex_rules,
     _regex_exceeds_static_cap,
+    _regex_is_catastrophic_shape,
     _scan_allow_regex_band,
     evaluate_domain,
 )
@@ -90,6 +98,16 @@ class _FakeClock:
         return self._ticks.pop(0)
 
 
+def _long_benign_pattern() -> str:
+    """A pattern over the length ceiling but STRUCTURALLY safe: a long concatenation of
+    literal labels with a single optional group -- no nested/overlapping quantifier, no
+    stacked repeat, and a complexity budget well under the threshold. Used to prove the
+    LENGTH ceiling is decoupled from (and gated independently of) the shape gate."""
+    pat = r"^(sub)?" + "verylongsubdomainlabel" * 10 + r"\.example\.com$"
+    assert len(pat) > pfb_unbound.REGEX_STATIC_LEN_CAP
+    return pat
+
+
 def _install_clock(monkeypatch: Any, elapsed_ms_per_match: list[float]) -> None:
     """Make every match report a fixed elapsed time (ms). Forces the thread_time path
     so the warn/evict policy is deterministic (no perf-fallback 2-strike interplay)."""
@@ -101,7 +119,64 @@ def _install_clock(monkeypatch: Any, elapsed_ms_per_match: list[float]) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# (1) STATIC CAP -- pure heuristic
+# (1a) CATASTROPHIC-SHAPE gate -- pure, ALWAYS-ON (length-independent)
+# --------------------------------------------------------------------------- #
+class TestCatastrophicShapeHeuristic:
+    """``_regex_is_catastrophic_shape`` is the always-on SAFETY half: it flags the
+    structurally dangerous shapes and is independent of pattern LENGTH."""
+
+    def test_single_group_nested_quantifier_flagged(self) -> None:
+        for pat in (r"(a+)+$", r"(a*)*", r"(\w+\.)+\w+$", r"([a-z]+)*\.example$", r"(.*a){20}$"):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_single_group_alternation_overlap_flagged(self) -> None:
+        # A quantified group whose body contains `|` backtracks catastrophically yet
+        # has no INNER quantifier, so the nested-quantifier heuristic alone misses it.
+        for pat in (r"^(a|a)+$", r"(a|ab)*", r"(foo|foobar)+", r"(x|y|x){10}"):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_multi_group_adjacent_quantifier_flagged(self) -> None:
+        # The dangerous shape the single-group heuristics MISS: two back-to-back groups
+        # where the second is quantified -- the first group's unbounded body and the
+        # quantified sibling share input, an exponential partition of the matched span.
+        for pat in (r"(a+)(a+)+", r"(a+)(b+)*", r"(\w+)(\d+)+$", r"^(x+)(y+)*\.example$"):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_stacked_bounded_repeat_flagged(self) -> None:
+        # Two consecutive {m}/{m,n} repeats multiply -> a tiny source string explodes.
+        for pat in (r"a{500}{500}", r"(x){500}{500}", r"[a-z]{50}{50}", r"\w{20}{20}$"):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_complexity_budget_backstop_flagged(self) -> None:
+        # A pattern with no single matching structural template but a large combined
+        # count of unbounded quantifiers + alternations is caught by the budget backstop.
+        over_budget = "".join(f"a{i}*|" for i in range(pfb_unbound._REGEX_BUDGET_MAX + 2))
+        assert _regex_is_catastrophic_shape(over_budget) is True
+
+    # --- false-positive guard: realistic benign feed regex must NOT be flagged ----- #
+    def test_benign_feed_patterns_not_flagged(self) -> None:
+        for pat in (
+            r"ads\.",
+            r"ad[0-9]\.example\.com$",
+            r"^x[0-9]+\.example\.com$",
+            r"\.doubleclick\.net$",
+            r"^(.+\.)?doubleclick\.net$",
+            r"^(www\.)?ad-?serv(er|ice)\.example$",
+            r"^(foo|bar)\.example$",
+            r"^(.+\.)?ads?[0-9]*\.example\.(com|net|org)$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is False, pat
+
+    def test_shape_gate_independent_of_length(self) -> None:
+        # A long-but-structurally-safe pattern is NOT a catastrophic shape: the shape
+        # gate must ignore length entirely (length is the separate opt-in ceiling).
+        assert _regex_is_catastrophic_shape(_long_benign_pattern()) is False
+        # And a SHORT catastrophic shape IS flagged regardless of being well under length.
+        assert _regex_is_catastrophic_shape(r"(a+)+") is True
+
+
+# --------------------------------------------------------------------------- #
+# (1b) STATIC LENGTH CAP -- combined length-OR-shape helper (gated path)
 # --------------------------------------------------------------------------- #
 class TestStaticCapHeuristic:
     def test_normal_pattern_passes(self) -> None:
@@ -114,22 +189,10 @@ class TestStaticCapHeuristic:
         # Exactly at the cap is allowed (strictly greater is the cap).
         assert _regex_exceeds_static_cap("a" * pfb_unbound.REGEX_STATIC_LEN_CAP) is False
 
-    def test_nested_quantifier_flagged(self) -> None:
-        for pat in (r"(a+)+$", r"(a*)*", r"(\w+\.)+\w+$", r"([a-z]+)*\.example$", r"(.*a){20}$"):
+    def test_catastrophic_shape_also_flagged(self) -> None:
+        # The combined helper folds in the shape gate too (used only on the gated path).
+        for pat in (r"(a+)+$", r"^(a|a)+$", r"(a+)(a+)+", r"a{500}{500}"):
             assert _regex_exceeds_static_cap(pat) is True, pat
-
-    def test_alternation_overlap_flagged(self) -> None:
-        # A quantified group whose body contains `|` backtracks catastrophically yet
-        # has no INNER quantifier, so the nested-quantifier heuristic misses it. These
-        # PASSED the old static cap (the gap the corrected ReDoS probe exposed).
-        for pat in (r"^(a|a)+$", r"(a|ab)*", r"(foo|foobar)+", r"(x|y|x){10}"):
-            assert _regex_exceeds_static_cap(pat) is True, pat
-
-    def test_benign_alternation_not_flagged(self) -> None:
-        # An UNquantified alternation group is fine -- it is the quantifier on an
-        # overlapping alternation that is dangerous, not `|` alone.
-        assert _regex_exceeds_static_cap(r"^(www\.)?ad-?serv(er|ice)\.example$") is False
-        assert _regex_exceeds_static_cap(r"^(foo|bar)\.example$") is False
 
 
 # --------------------------------------------------------------------------- #
@@ -149,41 +212,62 @@ def _block_rule(pattern: str, feed: str = "F") -> RegexRule:
 
 
 class TestStaticCapAtLoad:
-    def test_cap_off_keeps_nested_quantifier(self) -> None:
+    def test_shape_gate_drops_catastrophic_even_with_cap_off(self) -> None:
+        # DECOUPLING (the key change): a catastrophic SHAPE is dropped at load even when
+        # the opt-in length cap is OFF -- the safety gate is unconditional. The benign
+        # sibling is admitted, proving it is the SHAPE, not a blanket drop.
         rules = [_block_rule(r"(a+)+$"), _block_rule(r"^safe\.example$")]
+        db, admitted = _dnsbl_compile_regex_rules(rules, static_cap=False)
+        assert admitted == 1
+        assert len(db) == 1
+        compiled = next(iter(db.values()))["re"]
+        assert compiled.search("safe.example")
+
+    def test_shape_gate_drops_multi_group_and_stacked_repeat_cap_off(self) -> None:
+        # The newly-broadened shapes (missed by the old single-group heuristics) are also
+        # dropped with the cap OFF: multi-group adjacent quantifier + stacked repeat.
+        rules = [
+            _block_rule(r"(a+)(a+)+"),
+            _block_rule(r"a{500}{500}"),
+            _block_rule(r"^keep\.example$"),
+        ]
+        db, admitted = _dnsbl_compile_regex_rules(rules, static_cap=False)
+        assert admitted == 1
+        assert next(iter(db.values()))["re"].search("keep.example")
+
+    def test_cap_off_keeps_long_but_benign(self) -> None:
+        # BEFORE-state for the length-cap gating test: a long-but-structurally-safe
+        # pattern is ADMITTED when the cap is OFF (length is not enforced by default).
+        rules = [_block_rule(_long_benign_pattern()), _block_rule(r"^safe\.example$")]
         db, admitted = _dnsbl_compile_regex_rules(rules, static_cap=False)
         assert admitted == 2
         assert len(db) == 2
 
-    def test_cap_on_drops_nested_quantifier(self) -> None:
-        rules = [_block_rule(r"(a+)+$"), _block_rule(r"safe\.example$")]
-        db, admitted = _dnsbl_compile_regex_rules(rules, static_cap=True)
-        # Only the safe pattern survives.
-        assert admitted == 1
-        assert len(db) == 1
-        compiled = next(iter(db.values()))["re"]
-        assert compiled.search("x.safe.example")
-
-    def test_cap_on_drops_over_length(self) -> None:
-        long_pat = "a" * (pfb_unbound.REGEX_STATIC_LEN_CAP + 5)
-        rules = [_block_rule(long_pat), _block_rule(r"keep\.example$")]
+    def test_cap_on_drops_long_but_benign(self) -> None:
+        # AFTER-state: the SAME long-but-benign pattern is dropped once the cap is ON,
+        # proving the length ceiling stays GATED (only the length cap differs between
+        # this and the previous test -- the pattern is structurally safe in both).
+        rules = [_block_rule(_long_benign_pattern()), _block_rule(r"^safe\.example$")]
         db, admitted = _dnsbl_compile_regex_rules(rules, static_cap=True)
         assert admitted == 1
+        assert next(iter(db.values()))["re"].search("safe.example")
 
     def test_build_threads_regex_cap_from_config(self) -> None:
-        # build() reads config["regex_cap"] and forwards it to the compile helper.
+        # build() reads config["regex_cap"] and forwards it to the compile helper. The
+        # length cap (not the shape gate) is what the flag toggles, so use a long-but-
+        # benign irreducible pattern to prove the flag is threaded.
         manifest = {
             "feeds": [{"feed": "F", "group": "G", "format_hint": "abp", "log_flag": "1", "raw": "F"}],
             "config": {},
         }
-        lines = ["/(a+)+x/", "/^irreducible-[0-9]+\\.example$/"]
+        lines = ["/" + _long_benign_pattern() + "/", "/^irreducible-[0-9]+\\.example$/"]
 
         def reader(_ref: str) -> list[str]:
             return lines
 
         cap_on = pfb_unbound.build(manifest, {"regex_cap": True}, line_reader=reader)
         cap_off = pfb_unbound.build(manifest, {"regex_cap": False}, line_reader=reader)
-        # The nested-quantifier irreducible regex is dropped only when the cap is on.
+        # The long-but-benign irreducible regex is dropped only when the length cap is on.
         assert cap_on.regex_count < cap_off.regex_count
 
 
@@ -324,24 +408,23 @@ class TestFastPathUnchanged:
 
 
 # --------------------------------------------------------------------------- #
-# Real catastrophic pattern + static cap (end-to-end, BOUNDED so it can't hang)
+# Real catastrophic pattern dropped UNCONDITIONALLY (end-to-end, BOUNDED so it
+# can't hang -- the pattern is never executed against any input)
 # --------------------------------------------------------------------------- #
 class TestRealCatastrophicCapped:
-    def test_static_cap_drops_real_redos_pattern(self) -> None:
-        # The static cap catches the genuinely catastrophic shape WITHOUT executing it.
+    def test_shape_gate_drops_real_redos_pattern_cap_off(self) -> None:
+        # The shape gate catches the genuinely catastrophic shape WITHOUT executing it,
+        # and does so with the length cap OFF (the always-on safety gate).
         rule = _block_rule(r"([a-z]+)*\.example$")
-        db, admitted = _dnsbl_compile_regex_rules([rule], static_cap=True)
+        db, admitted = _dnsbl_compile_regex_rules([rule], static_cap=False)
         assert admitted == 0
         assert db == {}
 
-    def test_static_cap_drops_alternation_overlap_pattern(self) -> None:
-        # ^(a|a)+$ PASSES the old cap but backtracks catastrophically; the broadened
-        # cap drops it at load WITHOUT executing it (cap ON).
+    def test_shape_gate_drops_alternation_overlap_cap_off(self) -> None:
+        # ^(a|a)+$ PASSES a naive length cap but backtracks catastrophically; the shape
+        # gate drops it at load WITHOUT executing it -- regardless of the length cap.
         rule = _block_rule(r"^(a|a)+$")
-        db, admitted = _dnsbl_compile_regex_rules([rule], static_cap=True)
-        assert admitted == 0
-        assert db == {}
-        # With the cap OFF the un-vetted pattern is still admitted (opt-in only).
-        db_off, admitted_off = _dnsbl_compile_regex_rules([rule], static_cap=False)
-        assert admitted_off == 1
-        assert len(db_off) == 1
+        for cap in (False, True):
+            db, admitted = _dnsbl_compile_regex_rules([rule], static_cap=cap)
+            assert admitted == 0, cap
+            assert db == {}, cap


### PR DESCRIPTION
Decouple the load-time ABP/feed regex gate into two independent concerns so the genuinely dangerous shapes are always rejected while the length ceiling stays an opt-in convenience.

## What changed

**1. Always-on catastrophic-shape gate (`_regex_is_catastrophic_shape`).**
Feed *and* user regex are now checked at load **unconditionally** — independent of the opt-in "Limit long/complex regex" setting (`regex_cap`, off by default). A pattern carrying a structurally pathological shape is dropped at load (logged, never compiled into `regexDB`/`allowRegexDB`). This is pure static analysis of the pattern *string* — the candidate is never executed against any input. Catastrophic backtracking is a well-known property of the `re` engine for these shapes.

Broadened well beyond the prior single-group heuristics. Now caught:
- single-group nested quantifier — `(a+)+`, `(a*)*`, `(\w+\.)+`, `([a-z]+)*` (kept)
- single-group alternation overlap — `(a|a)+`, `(a|ab)*`, `(foo|foobar)+` (kept)
- **multi-group adjacent quantified groups** — `(a+)(a+)+`, `(a+)(b+)*`, `(...)(...)+`
- **stacked bounded repeats** — `a{500}{500}`, `(x){500}{500}`, `[a-z]{50}{50}`
- **complexity-budget backstop** — caps the combined count of unbounded quantifiers (`+`/`*`) and alternations (`|`) at 12, catching novel compositions no structural template matches

**2. The 200-char length ceiling stays a user tunable** behind the existing `regex_cap` flag (off by default). Length alone is not inherently pathological, so a long-but-safe pattern is **not** rejected by default — only when the operator opts in.

Applied at all three load sites: the feed compiler (`_dnsbl_compile_regex_rules`) and both user-`REGEX`-ini loaders (swap-snapshot rebuild + `init_standard`). The always-on runtime warn/evict guard is unchanged.

## False-positive guard

Verified the broadened gate still **accepts** realistic feed regex: `ads\.`, `ad[0-9]\.example\.com$`, `^x[0-9]+\.example\.com$`, `\.doubleclick\.net$`, `^(.+\.)?doubleclick\.net$`, `^(www\.)?ad-?serv(er|ice)\.example$`, `^(foo|bar)\.example$`, `^(.+\.)?ads?[0-9]*\.example\.(com|net|org)$`. The full ADR-07 parser/oracle corpus continues to pass.

## Tests

Extended `tests/test_adr07_regex_safety.py`:
- new `TestCatastrophicShapeHeuristic` — every broadened shape class flagged; the benign corpus and a long-but-safe pattern **not** flagged; shape gate proven length-independent
- at-load: catastrophic shape dropped with `regex_cap` **off** (the key decoupling), benign sibling admitted; length cap proven gated (long-but-safe pattern **admitted off**, **dropped on** — before/after the flag flip)
- `TestRealCatastrophicCapped` updated to assert the unconditional drop

Smoke (`tests/smoke/test_smoke_abp.py`): split into a length-cap-gating case (long-but-benign) and a new `test_abp_catastrophic_regex_dropped` proving the shape gate fires with the cap off on the live box.

`ruff check`/`ruff format --check`/`mypy tests/` clean; full `pytest` 1558 passed.

https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened regex safety with an always-on catastrophic-shape detector that rejects risky user/feed regex patterns at load time, independent of settings.
  * Extended the detector with additional structural heuristics and updated filtering so the optional regex length cap only drops patterns that exceed the configured length (safe patterns are no longer discarded when the cap is off).

* **Tests**
  * Added/updated smoke and unit tests to confirm decoupled behavior: catastrophic shapes are dropped even when caps are disabled, while the length cap only affects long-but-safe patterns.

* **Documentation**
  * Clarified the intended meaning of the regex length-cap option and its separation from the always-on catastrophic-shape gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->