### PR TITLE
pfblockerng: guard feed downloads against internal-resolving hosts

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5768,6 +5768,13 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				}
 
 				curl_setopt_array($ch, $pfb['curl_defaults']);	// Load curl default settings
+
+				// Constrain libcurl to the schemes pfBlockerNG fetches feeds over (http/https/ftp;
+				// rsync uses exec separately). An independent backstop to the PFB_FILTER_URL scheme
+				// allowlist — the two parsers (PHP parse_url vs libcurl) can disagree on crafted
+				// input, so enforce the allowlist at libcurl's own layer too.
+				curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP);
+
 				curl_setopt($ch, CURLOPT_FILE, $fhandle);	// Add $fhandle setting to cURL
 				curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);	// Set cURL download timeout
 				curl_setopt($ch, CURLOPT_ENCODING, 'gzip');	// Request 'gzip' encoding from server if available

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5225,6 +5225,245 @@ function find_reported_header($ip, $pfbfolder, $geoip=FALSE) {
 }
 
 
+// Test whether a single IP literal is contained within a CIDR range. Both the IP
+// and the network of the CIDR are compared in their packed (inet_pton) binary form,
+// byte-for-byte over the whole bytes of the prefix plus a masked compare of the
+// remainder bit. Returns TRUE when $ip lies inside $cidr, FALSE otherwise (including
+// a parse failure or a family mismatch between $ip and $cidr). Single source of the
+// binary-containment math, shared by pfb_ip_is_internal() and the feed-host
+// allowlist check.
+function pfb_ip_in_cidr($ip, $cidr) {
+
+	if (!is_string($ip) || $ip === '' || !is_string($cidr) || strpos($cidr, '/') === FALSE) {
+		return FALSE;
+	}
+
+	$bin = @inet_pton($ip);
+	if ($bin === FALSE) {
+		return FALSE;
+	}
+
+	list($net, $bits) = explode('/', $cidr, 2);
+	$net_bin = @inet_pton($net);
+	if ($net_bin === FALSE || strlen($net_bin) !== strlen($bin)) {
+		// A parse failure or a family mismatch (v4 ip vs v6 cidr or vice versa).
+		return FALSE;
+	}
+
+	$bits = (int) $bits;
+	$full = intdiv($bits, 8);		// whole bytes that must match exactly
+	$rem  = $bits % 8;			// remaining bits in the next byte
+
+	if ($full > 0 && substr($bin, 0, $full) !== substr($net_bin, 0, $full)) {
+		return FALSE;
+	}
+	if ($rem !== 0) {
+		$mask = (~0 << (8 - $rem)) & 0xFF;
+		if ((ord($bin[$full]) & $mask) !== (ord($net_bin[$full]) & $mask)) {
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+
+// Test whether a single IP literal falls inside one of the non-public/reserved
+// ranges feeds may not be fetched from. Returns the matched CIDR (string) when
+// the address is non-permitted, or FALSE when it is a routable public address.
+// IPv4-mapped IPv6 (::ffff:0:0/96) is unwrapped and re-checked as IPv4 so a
+// mapped form can't slip a private v4 address past the v6 ranges.
+function pfb_ip_is_internal($ip) {
+
+	// Non-permitted v4 / v6 ranges (CIDR). The exact set is explicit (rather than
+	// the pfSense range helpers) so it is identical across releases.
+	static $ranges_v4 = array(
+		'0.0.0.0/8',		// 'this' network (RFC 1122)
+		'10.0.0.0/8',		// private (RFC 1918)
+		'100.64.0.0/10',	// CGNAT shared address space (RFC 6598)
+		'127.0.0.0/8',		// loopback
+		'169.254.0.0/16',	// link-local (RFC 3927)
+		'172.16.0.0/12',	// private (RFC 1918)
+		'192.168.0.0/16',	// private (RFC 1918)
+	);
+	static $ranges_v6 = array(
+		'::1/128',		// loopback
+		'fc00::/7',		// unique-local (RFC 4193)
+		'fe80::/10',		// link-local (RFC 4291)
+	);
+
+	if (!is_string($ip) || $ip === '') {
+		return FALSE;
+	}
+
+	$bin = @inet_pton($ip);
+	if ($bin === FALSE) {
+		return FALSE;
+	}
+
+	// Unwrap an IPv4-mapped IPv6 address (::ffff:0:0/96) to its IPv4 form so it is
+	// vetted against the IPv4 ranges, not skipped by the v6 set.
+	if (strlen($bin) === 16 && substr($bin, 0, 12) === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff") {
+		$ip = inet_ntop(substr($bin, 12));
+		$bin = substr($bin, 12);
+	}
+
+	if (strlen($bin) === 4) {
+		$ranges = $ranges_v4;
+	} elseif (strlen($bin) === 16) {
+		$ranges = $ranges_v6;
+	} else {
+		return FALSE;
+	}
+
+	foreach ($ranges as $cidr) {
+		if (pfb_ip_in_cidr($ip, $cidr)) {
+			return $cidr;
+		}
+	}
+
+	return FALSE;
+}
+
+
+// Parse the General-settings 'internal-address exemption' allowlist into a list of
+// valid IP/CIDR entries. The stored value is one entry per line (also accepting
+// comma/space separators); blank and invalid entries are silently dropped (only a
+// valid is_ipaddr() literal or an is_subnet() CIDR survives). $ignored receives the
+// count of non-blank entries that were rejected as invalid (for a neutral log line).
+function pfb_feed_internal_allowlist($ignored = NULL) {
+
+	$ignored = 0;
+	$raw = config_get_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_allowlist');
+	if (!is_string($raw) || $raw === '') {
+		return array();
+	}
+
+	$entries = array();
+	foreach (preg_split('/[\s,]+/', $raw) as $entry) {
+		$entry = trim($entry);
+		if ($entry === '') {
+			continue;
+		}
+		if (is_ipaddr($entry) || is_subnet($entry)) {
+			$entries[] = $entry;
+		} else {
+			$ignored++;
+		}
+	}
+
+	return $entries;
+}
+
+
+// Test whether a single IP literal is exempted by the allowlist: covered when it
+// equals an allowlisted IP literal (by value) or is contained within an allowlisted
+// CIDR. Returns TRUE when exempt, FALSE otherwise.
+function pfb_ip_in_allowlist($ip, array $allowlist) {
+
+	if (!is_string($ip) || $ip === '') {
+		return FALSE;
+	}
+
+	$bin = @inet_pton($ip);
+
+	foreach ($allowlist as $entry) {
+		if (strpos($entry, '/') !== FALSE) {
+			if (pfb_ip_in_cidr($ip, $entry)) {
+				return TRUE;
+			}
+		} elseif ($bin !== FALSE && @inet_pton($entry) === $bin) {
+			// IP-literal equality by packed value (so '::1' == '::0:1' etc.).
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
+
+// Verify a feed host does not resolve to a non-public/reserved address before any
+// connection is made. Fail-closed: an unresolvable host, or any resolved address
+// that is non-public AND not covered by the operator's internal-address allowlist,
+// is rejected. On success $pinned receives the vetted IP the caller pins the
+// connection to (so the fetch cannot rebind to another address); $reason carries a
+// neutral skip reason on rejection.
+//
+// A resolved address that is internal is permitted ONLY when it is covered by an
+// allowlist entry (exact IP, or containment in an allowlisted CIDR — General
+// settings: 'internal-address exemptions'). An empty allowlist (the default) blocks
+// every feed that resolves to an internal/private address.
+function pfb_feed_host_allowed($host, &$reason, &$pinned) {
+
+	$reason = '';
+	$pinned = '';
+
+	if (!is_string($host) || $host === '') {
+		$reason = 'feed host is empty';
+		return FALSE;
+	}
+
+	// Build the candidate IP list. A host that is already an IP literal is checked
+	// directly; otherwise it is resolved (A/AAAA, following CNAMEs as the URL
+	// validator does) into its address set.
+	$candidates = array();
+	if (is_ipaddr($host)) {
+		$candidates[] = $host;
+	} else {
+		$records = resolve_host_addresses("{$host}.");
+		if (empty($records) || !is_array($records)) {
+			$reason = 'feed host did not resolve';
+			return FALSE;
+		}
+		foreach ($records as $record) {
+			if (empty($record['data'])) {
+				continue;
+			}
+			if ($record['type'] == 'CNAME') {
+				$cname = is_ipaddr($record['data'])
+				    ? array(array('type' => 'A', 'data' => $record['data']))
+				    : resolve_host_addresses("{$record['data']}.");
+				if (!empty($cname) && is_array($cname)) {
+					foreach ($cname as $centry) {
+						if (!empty($centry['data']) && is_ipaddr($centry['data'])) {
+							$candidates[] = $centry['data'];
+						}
+					}
+				}
+				continue;
+			}
+			if (is_ipaddr($record['data'])) {
+				$candidates[] = $record['data'];
+			}
+		}
+	}
+
+	if (empty($candidates)) {
+		$reason = 'feed host did not resolve to a valid address';
+		return FALSE;
+	}
+
+	$allowlist = pfb_feed_internal_allowlist();
+
+	// Reject if ANY resolved address is internal and not allowlisted (fail-closed).
+	// Pin the first vetted address for the connection — by the time the loop
+	// completes every candidate is public or allowlisted, so pinning the first is
+	// safe (and lets an allowlisted internal mirror's IP become the pinned target).
+	foreach ($candidates as $candidate) {
+		if (pfb_ip_is_internal($candidate) !== FALSE &&
+		    !pfb_ip_in_allowlist($candidate, $allowlist)) {
+			$reason = 'feed host resolves to a non-permitted address';
+			return FALSE;
+		}
+		if ($pinned === '') {
+			$pinned = $candidate;
+		}
+	}
+
+	return TRUE;
+}
+
+
 // Function to download feeds
 function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $logtype, $vtype='', $timeout=300, $type='', $username='', $password='', $srcint=FALSE) {
 	global $pfb;
@@ -5277,6 +5516,25 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 	// Download RSYNC format
 	if ($format == 'rsync') {
+
+		// Apply the same resolve+reject guard before rsync (fail-closed; opt-out
+		// in General settings). rsync runs via exec, not cURL, so the vetted IP
+		// cannot be pinned for the connection here — the guard rejects an
+		// internal-resolving host, but a sub-second re-resolution between check
+		// and connect is not closed off for this scheme as it is for cURL.
+		if (strpos($list_url, '::') !== FALSE) {
+			$rsync_host = explode('::', $list_url, 2)[0];	// host::module form
+		} else {
+			$rsync_host = parse_url($list_url, PHP_URL_HOST) ?: '';	// rsync://host/path form
+		}
+		$rsync_reason	= '';
+		$rsync_pinned	= '';
+		if (!pfb_feed_host_allowed($rsync_host, $rsync_reason, $rsync_pinned)) {
+			$log = "\n[ {$header} ] {$rsync_reason} \xe2\x80\x94 skipped\n";
+			pfb_logger("{$log}", "{$logtype}");
+			return FALSE;
+		}
+
 		$result	= exec("/usr/local/bin/rsync --timeout=5 {$list_url_esc} {$file_dwn_esc}");
 		if ($result == 0) {
 			$http_status = '200';
@@ -5316,6 +5574,22 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		// Download using cURL
 		else {
 			$remote_stamp = -1;
+
+			// Verify the feed host does not resolve to a non-public/reserved
+			// address before opening any connection (fail-closed; opt-out in
+			// General settings). Pin the connection to the vetted IP so it cannot
+			// rebind to a different address between this check and the fetch.
+			$url_parts	= parse_url($list_download);
+			$feed_host	= $url_parts['host'] ?? '';
+			$feed_scheme	= strtolower($url_parts['scheme'] ?? '');
+			$feed_reason	= '';
+			$feed_pinned	= '';
+			if (!pfb_feed_host_allowed($feed_host, $feed_reason, $feed_pinned)) {
+				$log = "\n[ {$header} ] {$feed_reason} \xe2\x80\x94 skipped\n";
+				pfb_logger("{$log}", "{$logtype}");
+				return FALSE;
+			}
+
 			if (($fhandle = @fopen("{$file_download}", 'w')) !== FALSE) {
 				if (!($ch = curl_init("{$list_download}"))) {
 					$log = "\nFailed to create cURL resource... Exiting...\n";
@@ -5330,6 +5604,22 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				if ($srcint) {
 					curl_setopt($ch, CURLOPT_INTERFACE, $srcint);	// Use a specific interface when downloading lists
 					pfb_logger("\nList: {$header} will be downloaded via interface: {$srcint}\n", 1);
+				}
+
+				// Pin the resolved IP for this connection (DNS-rebind close). The
+				// host header/SNI stay the original host; only the address cURL
+				// dials is forced to the one vetted above. Coexists with
+				// CURLOPT_INTERFACE (the source interface is independent of the
+				// destination address) and follow-redirect settings (CURLOPT_RESOLVE
+				// only pins this host:port, so a redirect to another host is still
+				// resolved normally). The destination port is derived from the URL
+				// or its scheme when implicit.
+				if ($feed_pinned !== '' && $feed_host !== '' && !empty($feed_scheme)) {
+					$scheme_ports	= array('http' => 80, 'https' => 443, 'ftp' => 21, 'rsync' => 873);
+					$feed_port	= $url_parts['port'] ?? ($scheme_ports[$feed_scheme] ?? 0);
+					if ($feed_port > 0) {
+						curl_setopt($ch, CURLOPT_RESOLVE, array("{$feed_host}:{$feed_port}:{$feed_pinned}"));
+					}
 				}
 
 				if (!empty($username) && !empty($password)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -298,6 +298,11 @@ define('PFB_FILTER_ATYPE', 19);
 define('PFB_FILTER_HEX_COLOR', 20);
 define('PFB_FILTER_ON_OFF', 21);
 
+// Maximum number of HTTP redirects pfb_download() follows manually (each hop's
+// host is re-vetted by the feed-host guard before it is dialled). Matches the
+// previous cURL CURLOPT_MAXREDIRS auto-follow cap.
+define('PFB_DOWNLOAD_MAXREDIRS', 10);
+
 // Machine-detectable markers (the VIP 'descr') stamped on DNSBL sinkhole VIPs that
 // pfBlockerNG auto-creates and therefore owns (ADR-13). ONLY VIPs carrying one of
 // these markers are ever managed/deleted by the package; a manually-created VIP is
@@ -5464,6 +5469,157 @@ function pfb_feed_host_allowed($host, &$reason, &$pinned) {
 }
 
 
+// Resolve a (possibly relative) HTTP redirect Location against the URL it was
+// returned from, then re-run the feed-host guard on the redirect target so a
+// redirect cannot send the fetch to a non-permitted address. Returns FALSE when
+// the target host is not permitted (or the Location cannot be resolved to an
+// absolute http(s) URL); $reason carries a neutral skip reason. On success it
+// returns array('url' => <absolute target URL>, 'host' => <host>, 'scheme' =>
+// <scheme>, 'port' => <int port>) and $pinned receives the vetted IP the caller
+// re-pins the connection to. The curl mechanics stay in pfb_download(); this
+// holds only the per-hop decision so it is unit-testable off-appliance.
+function pfb_feed_redirect_target($location, $current_url, &$reason, &$pinned) {
+
+	$reason = '';
+	$pinned = '';
+
+	if (!is_string($location) || trim($location) === '') {
+		$reason = 'feed redirect has no target';
+		return FALSE;
+	}
+	$location = trim($location);
+
+	// Resolve a possibly-relative Location against the current absolute URL.
+	$target = pfb_resolve_relative_url($location, (string) $current_url);
+	if ($target === '') {
+		$reason = 'feed redirect target could not be resolved';
+		return FALSE;
+	}
+
+	$parts	= parse_url($target);
+	$host	= $parts['host'] ?? '';
+	$scheme	= strtolower($parts['scheme'] ?? '');
+	if ($host === '' || ($scheme !== 'http' && $scheme !== 'https')) {
+		$reason = 'feed redirect target is not an http(s) URL';
+		return FALSE;
+	}
+
+	if (!pfb_feed_host_allowed($host, $reason, $pinned)) {
+		// $reason already carries the neutral guard reason.
+		return FALSE;
+	}
+
+	$scheme_ports	= array('http' => 80, 'https' => 443);
+	$port		= (int) ($parts['port'] ?? ($scheme_ports[$scheme] ?? 0));
+
+	return array(
+		'url'    => $target,
+		'host'   => $host,
+		'scheme' => $scheme,
+		'port'   => $port,
+	);
+}
+
+
+// Resolve a possibly-relative URL reference ($ref) against an absolute base URL
+// ($base), returning an absolute URL string (or '' on failure). Handles an
+// already-absolute reference, a scheme-relative '//host/path', an absolute-path
+// '/path', and a relative-path reference (resolved against the base directory).
+// A minimal RFC 3986-style resolver, sufficient for following HTTP redirects.
+function pfb_resolve_relative_url($ref, $base) {
+
+	if (!is_string($ref) || $ref === '') {
+		return '';
+	}
+
+	// Already absolute (has a scheme).
+	if (preg_match('#^[a-zA-Z][a-zA-Z0-9+.-]*://#', $ref)) {
+		return $ref;
+	}
+
+	$bparts = parse_url((string) $base);
+	$bscheme = strtolower($bparts['scheme'] ?? '');
+	$bhost   = $bparts['host'] ?? '';
+	if ($bscheme === '' || $bhost === '') {
+		return '';
+	}
+	$bauth = $bhost . (isset($bparts['port']) ? ':' . $bparts['port'] : '');
+
+	// Scheme-relative reference: //host/path
+	if (strncmp($ref, '//', 2) === 0) {
+		return "{$bscheme}:{$ref}";
+	}
+
+	// Absolute-path reference: /path
+	if ($ref[0] === '/') {
+		return "{$bscheme}://{$bauth}{$ref}";
+	}
+
+	// Relative-path reference: resolve against the base path's directory.
+	$bpath = $bparts['path'] ?? '/';
+	$dir   = (strpos($bpath, '/') !== FALSE) ? substr($bpath, 0, strrpos($bpath, '/') + 1) : '/';
+	if ($dir === '' || $dir[0] !== '/') {
+		$dir = '/' . $dir;
+	}
+	return "{$bscheme}://{$bauth}{$dir}{$ref}";
+}
+
+
+// Rebuild an rsync feed source so it connects to the vetted IP instead of the
+// hostname (the guard's pinned address), keeping the module/path intact. Accepts
+// both rsync forms: 'host::module/path' -> 'IP::module/path', and
+// 'rsync://host/path' -> 'rsync://IP/path' (preserving an explicit port and any
+// user@ prefix). Returns '' when the form cannot be parsed to substitute the host
+// (caller fails closed). $ip must be a vetted IP literal.
+function pfb_rsync_pin_url($list_url, $ip) {
+
+	if (!is_string($list_url) || $list_url === '' || !is_string($ip) || $ip === '') {
+		return '';
+	}
+
+	// Bracket an IPv6 literal for the rsync:// (URL) form.
+	$ip_url = (strpos($ip, ':') !== FALSE) ? "[{$ip}]" : $ip;
+
+	// rsync://[user@]host[:port]/path
+	if (stripos($list_url, 'rsync://') === 0) {
+		$rest = substr($list_url, strlen('rsync://'));
+		// Split off the path (everything from the first '/').
+		$slash = strpos($rest, '/');
+		$authority = ($slash === FALSE) ? $rest : substr($rest, 0, $slash);
+		$path = ($slash === FALSE) ? '' : substr($rest, $slash);
+		if ($authority === '') {
+			return '';
+		}
+		// Preserve a 'user@' prefix; drop the host[:port], substitute the IP.
+		$at = strrpos($authority, '@');
+		$userpart = ($at === FALSE) ? '' : substr($authority, 0, $at + 1);
+		$hostport = ($at === FALSE) ? $authority : substr($authority, $at + 1);
+		// Carry over an explicit ':port' (last colon, but not inside an IPv6 [..]).
+		$port = '';
+		if ($hostport !== '' && $hostport[0] !== '[') {
+			$colon = strrpos($hostport, ':');
+			if ($colon !== FALSE) {
+				$port = substr($hostport, $colon);
+			}
+		}
+		return "rsync://{$userpart}{$ip_url}{$port}{$path}";
+	}
+
+	// [user@]host::module/path
+	if (strpos($list_url, '::') !== FALSE) {
+		list($hostpart, $module) = explode('::', $list_url, 2);
+		if ($hostpart === '') {
+			return '';
+		}
+		$at = strrpos($hostpart, '@');
+		$userpart = ($at === FALSE) ? '' : substr($hostpart, 0, $at + 1);
+		return "{$userpart}{$ip}::{$module}";
+	}
+
+	return '';
+}
+
+
 // Function to download feeds
 function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $logtype, $vtype='', $timeout=300, $type='', $username='', $password='', $srcint=FALSE) {
 	global $pfb;
@@ -5518,12 +5674,16 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 	if ($format == 'rsync') {
 
 		// Apply the same resolve+reject guard before rsync (fail-closed; opt-out
-		// in General settings). rsync runs via exec, not cURL, so the vetted IP
-		// cannot be pinned for the connection here — the guard rejects an
-		// internal-resolving host, but a sub-second re-resolution between check
-		// and connect is not closed off for this scheme as it is for cURL.
+		// in General settings), then connect to the vetted IP rather than the
+		// hostname so the exec cannot re-resolve to a different address between
+		// the check and the connect.
 		if (strpos($list_url, '::') !== FALSE) {
 			$rsync_host = explode('::', $list_url, 2)[0];	// host::module form
+			// Strip an optional 'user@' prefix from the host component.
+			$at = strrpos($rsync_host, '@');
+			if ($at !== FALSE) {
+				$rsync_host = substr($rsync_host, $at + 1);
+			}
 		} else {
 			$rsync_host = parse_url($list_url, PHP_URL_HOST) ?: '';	// rsync://host/path form
 		}
@@ -5535,7 +5695,17 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			return FALSE;
 		}
 
-		$result	= exec("/usr/local/bin/rsync --timeout=5 {$list_url_esc} {$file_dwn_esc}");
+		// Pin the connection to the vetted IP (substitute it for the host in the
+		// rsync source). Fail closed if the source form can't be parsed to do so.
+		$rsync_src = pfb_rsync_pin_url($list_url, $rsync_pinned);
+		if ($rsync_src === '') {
+			$log = "\n[ {$header} ] feed host could not be pinned \xe2\x80\x94 skipped\n";
+			pfb_logger("{$log}", "{$logtype}");
+			return FALSE;
+		}
+		$rsync_src_esc = escapeshellarg("{$rsync_src}");
+
+		$result	= exec("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}");
 		if ($result == 0) {
 			$http_status = '200';
 		} else {
@@ -5601,6 +5771,29 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				curl_setopt($ch, CURLOPT_FILE, $fhandle);	// Add $fhandle setting to cURL
 				curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);	// Set cURL download timeout
 				curl_setopt($ch, CURLOPT_ENCODING, 'gzip');	// Request 'gzip' encoding from server if available
+
+				// Do NOT let cURL auto-follow redirects: a 3xx is followed manually
+				// below so every hop's host is re-vetted by the feed-host guard and
+				// re-pinned before it is dialled (an auto-followed redirect would be
+				// re-resolved by cURL, bypassing the guard + the IP pin).
+				curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+				curl_setopt($ch, CURLOPT_MAXREDIRS, 0);
+
+				// Capture the response 'Location' header for the manual redirect
+				// follow. Reset per hop ($redirect_location is cleared before each
+				// curl_exec). Bodies are written to $fhandle; a redirect hop's body
+				// is truncated away before the next hop so only the final 2xx body
+				// survives.
+				$redirect_location = '';
+				curl_setopt($ch, CURLOPT_HEADERFUNCTION,
+					function ($curl_handle, $hdr_line) use (&$redirect_location) {
+						$trimmed = trim($hdr_line);
+						if (stripos($trimmed, 'Location:') === 0) {
+							$redirect_location = trim(substr($trimmed, strlen('Location:')));
+						}
+						return strlen($hdr_line);
+					}
+				);
 				if ($srcint) {
 					curl_setopt($ch, CURLOPT_INTERFACE, $srcint);	// Use a specific interface when downloading lists
 					pfb_logger("\nList: {$header} will be downloaded via interface: {$srcint}\n", 1);
@@ -5610,12 +5803,10 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				// host header/SNI stay the original host; only the address cURL
 				// dials is forced to the one vetted above. Coexists with
 				// CURLOPT_INTERFACE (the source interface is independent of the
-				// destination address) and follow-redirect settings (CURLOPT_RESOLVE
-				// only pins this host:port, so a redirect to another host is still
-				// resolved normally). The destination port is derived from the URL
+				// destination address). The destination port is derived from the URL
 				// or its scheme when implicit.
+				$scheme_ports	= array('http' => 80, 'https' => 443, 'ftp' => 21, 'rsync' => 873);
 				if ($feed_pinned !== '' && $feed_host !== '' && !empty($feed_scheme)) {
-					$scheme_ports	= array('http' => 80, 'https' => 443, 'ftp' => 21, 'rsync' => 873);
 					$feed_port	= $url_parts['port'] ?? ($scheme_ports[$feed_scheme] ?? 0);
 					if ($feed_port > 0) {
 						curl_setopt($ch, CURLOPT_RESOLVE, array("{$feed_host}:{$feed_port}:{$feed_pinned}"));
@@ -5627,52 +5818,118 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
 				}
 
-				// Attempt 3 Downloads before failing.
-				for ($retries = 1; $retries <= 3; $retries++) {
-					if (curl_exec($ch)) {
-						// Collect remote timestamp.
-						$raw_filetime = curl_getinfo($ch, CURLINFO_FILETIME);
-						if ($raw_filetime == -1) {
-							$remote_stamp = -1;
-						} elseif (!empty(pfb_filter($raw_filetime, PFB_FILTER_NUM, 'pfb_download - remote timestamp'))) {
-							$remote_stamp = $raw_filetime;
+				// Manually follow validated redirects. Each hop's body is written to
+				// $fhandle, truncated before the next hop so only the final response
+				// body survives. The hop cap (PFB_DOWNLOAD_MAXREDIRS, 10) matches the
+				// previous CURLOPT_MAXREDIRS. The common (non-redirecting) feed exits
+				// on the first iteration with the body intact, behaving exactly as
+				// before.
+				$current_url	= $list_download;
+				$http_status	= '';
+				for ($hop = 0; $hop <= PFB_DOWNLOAD_MAXREDIRS; $hop++) {
+					$redirect_location = '';
+
+					// Attempt 3 Downloads before failing.
+					$hop_ok = FALSE;
+					for ($retries = 1; $retries <= 3; $retries++) {
+						if (curl_exec($ch)) {
+							// Collect remote timestamp.
+							$raw_filetime = curl_getinfo($ch, CURLINFO_FILETIME);
+							if ($raw_filetime == -1) {
+								$remote_stamp = -1;
+							} elseif (!empty(pfb_filter($raw_filetime, PFB_FILTER_NUM, 'pfb_download - remote timestamp'))) {
+								$remote_stamp = $raw_filetime;
+							}
+							$hop_ok = TRUE;
+							break;	// Break on success
 						}
-						break;	// Break on success
-					}
 
-					$curl_error = curl_errno($ch);
-					if ($logtype != 3) {
-						pfb_logger(" cURL Error: {$curl_error} [ NOW ]\n", 1);
-					} else {
-						pfb_logger(" {$header}\t\tcURL Error: {$curl_error} [ NOW ]\n\n", 3);
-					}
-
-					/* 'Flex' Downgrade cURL errors -	[ 35 - GET_SERVER_HELLO:sslv3		]
-										[ 51 - NO alternative certificate	]
-										[ 60 - Local Issuer Certificate Subject	]	*/
-
-					// Allow downgrade of cURL settings 'Flex' after 1st failure, if user configured.
-					if ($retries == 1 && $pflex && in_array($curl_error, array( '35', '51', '60'))) {
-						curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-						curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-						curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'TLSv1.3, TLSv1.2, TLSv1.1, TLSv1, SSLv3');
-						$log = "\n  Downgrading SSL settings (Flex)";
-						pfb_logger("{$log}", "{$logtype}");
-					}
-					else {
-						if ($retries == 3) {
-							$log = curl_error($ch) . " |{$head_download}|{$list_download}| Retry [{$retries}] in 5 seconds...\n";
+						$curl_error = curl_errno($ch);
+						if ($logtype != 3) {
+							pfb_logger(" cURL Error: {$curl_error} [ NOW ]\n", 1);
 						} else {
-							$log = curl_error($ch) . " Retry [{$retries}] in 5 seconds...\n";
+							pfb_logger(" {$header}\t\tcURL Error: {$curl_error} [ NOW ]\n\n", 3);
 						}
+
+						/* 'Flex' Downgrade cURL errors -	[ 35 - GET_SERVER_HELLO:sslv3		]
+											[ 51 - NO alternative certificate	]
+											[ 60 - Local Issuer Certificate Subject	]	*/
+
+						// Allow downgrade of cURL settings 'Flex' after 1st failure, if user configured.
+						if ($retries == 1 && $pflex && in_array($curl_error, array( '35', '51', '60'))) {
+							curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+							curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+							curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'TLSv1.3, TLSv1.2, TLSv1.1, TLSv1, SSLv3');
+							$log = "\n  Downgrading SSL settings (Flex)";
+							pfb_logger("{$log}", "{$logtype}");
+						}
+						else {
+							if ($retries == 3) {
+								$log = curl_error($ch) . " |{$head_download}|{$list_download}| Retry [{$retries}] in 5 seconds...\n";
+							} else {
+								$log = curl_error($ch) . " Retry [{$retries}] in 5 seconds...\n";
+							}
+							pfb_logger("{$log}", "{$logtype}");
+							sleep(5);
+							pfb_logger('.', "{$logtype}");
+						}
+					}
+
+					// Collect RFC7231 http status code for this hop
+					$http_status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+
+					// Not a redirect (or the request failed) -> this is the final
+					// response; stop and treat what was written as the download.
+					if (!$hop_ok || $http_status < 300 || $http_status >= 400 || $redirect_location === '') {
+						break;
+					}
+
+					// A redirect: validate the target host before following it.
+					if ($hop >= PFB_DOWNLOAD_MAXREDIRS) {
+						$log = "\n[ {$header} ] too many redirects \xe2\x80\x94 skipped\n";
 						pfb_logger("{$log}", "{$logtype}");
-						sleep(5);
-						pfb_logger('.', "{$logtype}");
+						if ($ch) {
+							curl_close($ch);
+						}
+						if ($fhandle) {
+							@fclose($fhandle);
+						}
+						return FALSE;
+					}
+
+					$rdr_reason	= '';
+					$rdr_pinned	= '';
+					$next = pfb_feed_redirect_target($redirect_location, $current_url, $rdr_reason, $rdr_pinned);
+					if ($next === FALSE) {
+						$log = "\n[ {$header} ] {$rdr_reason} \xe2\x80\x94 skipped\n";
+						pfb_logger("{$log}", "{$logtype}");
+						if ($ch) {
+							curl_close($ch);
+						}
+						if ($fhandle) {
+							@fclose($fhandle);
+						}
+						return FALSE;
+					}
+
+					// Discard the redirect-page body so only the final hop's body
+					// remains in the feed file.
+					ftruncate($fhandle, 0);
+					rewind($fhandle);
+
+					// Re-point cURL at the vetted target and re-pin its address. The
+					// '-host:port' entry removes any prior pin for the same host:port
+					// (e.g. a same-host relative redirect) so the add is not a
+					// duplicate.
+					$current_url = $next['url'];
+					curl_setopt($ch, CURLOPT_URL, $next['url']);
+					if ($rdr_pinned !== '' && $next['port'] > 0) {
+						curl_setopt($ch, CURLOPT_RESOLVE, array(
+							"-{$next['host']}:{$next['port']}",
+							"{$next['host']}:{$next['port']}:{$rdr_pinned}",
+						));
 					}
 				}
-
-				// Collect RFC7231 http status code
-				$http_status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
 
 				if (isset($pfb['rfc7231'][$http_status])) {
 					if ($logtype < 3) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5387,6 +5387,48 @@ function pfb_ip_in_allowlist($ip, array $allowlist) {
 }
 
 
+// Grandfather decision for the feed-host filter at install/upgrade. $gconfig is the
+// existing General-settings 'config/0' node (null on a fresh, never-configured install).
+// Returns 'off' only for an already-configured install that has not yet seen the toggle
+// (so its existing feeds are never silently dropped); otherwise NULL — meaning leave the
+// key unset, which the runtime reader (pfb_feed_filter_enabled) interprets as the ON
+// default. Run-once + idempotent: once the key is set (either value) it returns NULL,
+// never re-disabling an operator who opted back in.
+function pfb_feed_filter_install_default($gconfig) {
+
+	if (is_array($gconfig) && !isset($gconfig['pfb_feed_internal_filter'])) {
+		return 'off';
+	}
+	return NULL;
+}
+
+
+// Whether the feed-host internal-address filter is enabled. Reads the General-settings
+// 'pfb_feed_internal_filter' on/off flag, defaulting to ON when the key is absent (a
+// fresh install ships the filter active; the install-time migration pins it OFF on an
+// already-configured box so existing feeds are never silently dropped). Any value other
+// than the literal 'off' is treated as ON.
+function pfb_feed_filter_enabled() {
+
+	$value = config_get_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_filter');
+	return ($value !== 'off');
+}
+
+
+// Whether a resolved candidate IP is the firewall itself — its own configured address,
+// or the IPv4/IPv6 loopback. A self-hosted feed (served by the box) is a long-supported
+// pfBlockerNG case (see PFB_FILTER_URL), so a self IP is treated as allowed even though
+// it is non-public; it is never the internal-pivot case the filter guards against.
+function pfb_ip_is_self($ip) {
+
+	if (!is_string($ip) || $ip === '') {
+		return FALSE;
+	}
+
+	return ($ip === '127.0.0.1' || $ip === '::1' || is_ipaddr_configured($ip));
+}
+
+
 // Verify a feed host does not resolve to a non-public/reserved address before any
 // connection is made. Fail-closed: an unresolvable host, or any resolved address
 // that is non-public AND not covered by the operator's internal-address allowlist,
@@ -5394,10 +5436,11 @@ function pfb_ip_in_allowlist($ip, array $allowlist) {
 // connection to (so the fetch cannot rebind to another address); $reason carries a
 // neutral skip reason on rejection.
 //
-// A resolved address that is internal is permitted ONLY when it is covered by an
-// allowlist entry (exact IP, or containment in an allowlisted CIDR — General
+// A resolved address is permitted when it is public, when it is the firewall itself
+// (its own configured address / loopback — a self-hosted feed), or when it is covered
+// by an allowlist entry (exact IP, or containment in an allowlisted CIDR — General
 // settings: 'internal-address exemptions'). An empty allowlist (the default) blocks
-// every feed that resolves to an internal/private address.
+// every other feed that resolves to an internal/private address.
 function pfb_feed_host_allowed($host, &$reason, &$pinned) {
 
 	$reason = '';
@@ -5450,12 +5493,15 @@ function pfb_feed_host_allowed($host, &$reason, &$pinned) {
 
 	$allowlist = pfb_feed_internal_allowlist();
 
-	// Reject if ANY resolved address is internal and not allowlisted (fail-closed).
-	// Pin the first vetted address for the connection — by the time the loop
-	// completes every candidate is public or allowlisted, so pinning the first is
-	// safe (and lets an allowlisted internal mirror's IP become the pinned target).
+	// Reject if ANY resolved address is internal and neither the firewall itself nor
+	// allowlisted (fail-closed). The self-exemption is per-candidate: a host resolving
+	// to [box-self, foreign-internal] still rejects on the foreign-internal address.
+	// Pin the first vetted address for the connection — by the time the loop completes
+	// every candidate is public, self, or allowlisted, so pinning the first is safe
+	// (and lets a self / allowlisted internal mirror's IP become the pinned target).
 	foreach ($candidates as $candidate) {
 		if (pfb_ip_is_internal($candidate) !== FALSE &&
+		    !pfb_ip_is_self($candidate) &&
 		    !pfb_ip_in_allowlist($candidate, $allowlist)) {
 			$reason = 'feed host resolves to a non-permitted address';
 			return FALSE;
@@ -5674,34 +5720,38 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 	if ($format == 'rsync') {
 
 		// Apply the same resolve+reject guard before rsync (fail-closed; opt-out
-		// in General settings), then connect to the vetted IP rather than the
-		// hostname so the exec cannot re-resolve to a different address between
-		// the check and the connect.
-		if (strpos($list_url, '::') !== FALSE) {
-			$rsync_host = explode('::', $list_url, 2)[0];	// host::module form
-			// Strip an optional 'user@' prefix from the host component.
-			$at = strrpos($rsync_host, '@');
-			if ($at !== FALSE) {
-				$rsync_host = substr($rsync_host, $at + 1);
+		// in General settings via 'pfb_feed_internal_filter'), then connect to the
+		// vetted IP rather than the hostname so the exec cannot re-resolve to a
+		// different address between the check and the connect. When the filter is
+		// disabled, skip the guard and pin entirely (pre-filter fetch behaviour).
+		$rsync_src = $list_url;
+		if (pfb_feed_filter_enabled()) {
+			if (strpos($list_url, '::') !== FALSE) {
+				$rsync_host = explode('::', $list_url, 2)[0];	// host::module form
+				// Strip an optional 'user@' prefix from the host component.
+				$at = strrpos($rsync_host, '@');
+				if ($at !== FALSE) {
+					$rsync_host = substr($rsync_host, $at + 1);
+				}
+			} else {
+				$rsync_host = parse_url($list_url, PHP_URL_HOST) ?: '';	// rsync://host/path form
 			}
-		} else {
-			$rsync_host = parse_url($list_url, PHP_URL_HOST) ?: '';	// rsync://host/path form
-		}
-		$rsync_reason	= '';
-		$rsync_pinned	= '';
-		if (!pfb_feed_host_allowed($rsync_host, $rsync_reason, $rsync_pinned)) {
-			$log = "\n[ {$header} ] {$rsync_reason} \xe2\x80\x94 skipped\n";
-			pfb_logger("{$log}", "{$logtype}");
-			return FALSE;
-		}
+			$rsync_reason	= '';
+			$rsync_pinned	= '';
+			if (!pfb_feed_host_allowed($rsync_host, $rsync_reason, $rsync_pinned)) {
+				$log = "\n[ {$header} ] {$rsync_reason} \xe2\x80\x94 skipped\n";
+				pfb_logger("{$log}", "{$logtype}");
+				return FALSE;
+			}
 
-		// Pin the connection to the vetted IP (substitute it for the host in the
-		// rsync source). Fail closed if the source form can't be parsed to do so.
-		$rsync_src = pfb_rsync_pin_url($list_url, $rsync_pinned);
-		if ($rsync_src === '') {
-			$log = "\n[ {$header} ] feed host could not be pinned \xe2\x80\x94 skipped\n";
-			pfb_logger("{$log}", "{$logtype}");
-			return FALSE;
+			// Pin the connection to the vetted IP (substitute it for the host in the
+			// rsync source). Fail closed if the source form can't be parsed to do so.
+			$rsync_src = pfb_rsync_pin_url($list_url, $rsync_pinned);
+			if ($rsync_src === '') {
+				$log = "\n[ {$header} ] feed host could not be pinned \xe2\x80\x94 skipped\n";
+				pfb_logger("{$log}", "{$logtype}");
+				return FALSE;
+			}
 		}
 		$rsync_src_esc = escapeshellarg("{$rsync_src}");
 
@@ -5747,14 +5797,19 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 			// Verify the feed host does not resolve to a non-public/reserved
 			// address before opening any connection (fail-closed; opt-out in
-			// General settings). Pin the connection to the vetted IP so it cannot
-			// rebind to a different address between this check and the fetch.
+			// General settings via 'pfb_feed_internal_filter'). Pin the connection
+			// to the vetted IP so it cannot rebind to a different address between
+			// this check and the fetch. When the filter is disabled, skip the guard
+			// and the IP pin entirely (pre-filter fetch behaviour); $feed_filter
+			// also selects manual (re-vetted) vs cURL-native redirect following.
+			$feed_filter	= pfb_feed_filter_enabled();
 			$url_parts	= parse_url($list_download);
 			$feed_host	= $url_parts['host'] ?? '';
 			$feed_scheme	= strtolower($url_parts['scheme'] ?? '');
 			$feed_reason	= '';
 			$feed_pinned	= '';
-			if (!pfb_feed_host_allowed($feed_host, $feed_reason, $feed_pinned)) {
+			if ($feed_filter &&
+			    !pfb_feed_host_allowed($feed_host, $feed_reason, $feed_pinned)) {
 				$log = "\n[ {$header} ] {$feed_reason} \xe2\x80\x94 skipped\n";
 				pfb_logger("{$log}", "{$logtype}");
 				return FALSE;
@@ -5779,12 +5834,14 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);	// Set cURL download timeout
 				curl_setopt($ch, CURLOPT_ENCODING, 'gzip');	// Request 'gzip' encoding from server if available
 
-				// Do NOT let cURL auto-follow redirects: a 3xx is followed manually
-				// below so every hop's host is re-vetted by the feed-host guard and
-				// re-pinned before it is dialled (an auto-followed redirect would be
-				// re-resolved by cURL, bypassing the guard + the IP pin).
-				curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
-				curl_setopt($ch, CURLOPT_MAXREDIRS, 0);
+				// With the filter ON, do NOT let cURL auto-follow redirects: a 3xx
+				// is followed manually below so every hop's host is re-vetted by the
+				// feed-host guard and re-pinned before it is dialled (an auto-followed
+				// redirect would be re-resolved by cURL, bypassing the guard + the IP
+				// pin). With the filter OFF, restore cURL-native following (the
+				// pre-filter behaviour) so the manual revalidation loop is bypassed.
+				curl_setopt($ch, CURLOPT_FOLLOWLOCATION, !$feed_filter);
+				curl_setopt($ch, CURLOPT_MAXREDIRS, $feed_filter ? 0 : PFB_DOWNLOAD_MAXREDIRS);
 
 				// Capture the response 'Location' header for the manual redirect
 				// follow. Reset per hop ($redirect_location is cleared before each

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -484,6 +484,16 @@ if ($ufound) {
 	update_status(" no changes required ... done.\n");
 }
 
+// Feed-host filter defaults ON for new installs; pin OFF once on an already-configured
+// install so existing feeds are never silently dropped (operator can re-enable). The
+// run-once decision is pfb_feed_filter_install_default() (NULL => leave unset => default
+// ON); the !isset guard there makes this idempotent across repeated installs/upgrades.
+$pfb_gcfg = config_get_path('installedpackages/pfblockerng/config/0');
+$pfb_feed_default = pfb_feed_filter_install_default($pfb_gcfg);
+if ($pfb_feed_default !== null) {
+	config_set_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_filter', $pfb_feed_default);
+}
+
 // Convert dnsbl_info CSV file to SQLite3 database format
 if (file_exists('/var/db/pfblockerng/dnsbl_info') &&
     !file_exists('/var/db/pfblockerng/dnsbl.sqlite') &&

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -56,6 +56,10 @@ $pconfig['enable_cb']			= $pfb['gconfig']['enable_cb']				?: '';
 // Default to 'on' for new installation only
 $pconfig['pfb_keep']			= isset($pfb['gconfig']['pfb_keep'])			? $pfb['gconfig']['pfb_keep'] : 'on';
 
+// Exemptions from the internal-address feed-host check: IP addresses / CIDR ranges
+// (one per line) whose feeds are allowed even when they resolve internally.
+$pconfig['pfb_feed_internal_allowlist']	= $pfb['gconfig']['pfb_feed_internal_allowlist']	?: '';
+
 $pconfig['pfb_interval']		= $pfb['gconfig']['pfb_interval']			?: 1;
 
 // ADR-11: opt-in per-type aggregate ("Uber") Native aliases. CSV scalar (like
@@ -148,6 +152,7 @@ if ($_POST) {
 
 			$pfb['gconfig']['enable_cb']			= pfb_filter($_POST['enable_cb'], PFB_FILTER_ON_OFF, 'general', '');
 			$pfb['gconfig']['pfb_keep']			= pfb_filter($_POST['pfb_keep'], PFB_FILTER_ON_OFF, 'general', '');
+			$pfb['gconfig']['pfb_feed_internal_allowlist']	= str_replace("\r\n", "\n", trim($_POST['pfb_feed_internal_allowlist'] ?? ''));
 			$pfb['gconfig']['pfb_interval']			= $_POST['pfb_interval']			?: 1;
 			$pfb['gconfig']['pfb_min']			= $_POST['pfb_min']				?: 0;
 			$pfb['gconfig']['pfb_hour']			= $_POST['pfb_hour']				?: 0;
@@ -252,6 +257,15 @@ $section->addInput(new Form_Checkbox(
 		. ' If \'Keep Settings\' is not \'enabled\' on pkg Install/De-Install, all settings will be Wiped!<br /><br />'
 		. '<span class="text-danger">Note: </span>'
 		. ' To clear all downloaded lists, uncheck these two checkboxes and \'Save\'. Re-check both boxes and run a \'Force Update|Reload\''
+);
+
+$section->addInput(new Form_Textarea(
+	'pfb_feed_internal_allowlist',
+	'Internal Feed Host Exemptions',
+	$pconfig['pfb_feed_internal_allowlist']
+))->setHelp('IP addresses or CIDR ranges (one per line) that are exempt from the '
+		. 'internal-address check &mdash; e.g. an internal mirror. '
+		. 'Leave empty to block all feeds that resolve to an internal/private address.'
 );
 
 $group = new Form_Group('CRON Settings');

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -56,6 +56,11 @@ $pconfig['enable_cb']			= $pfb['gconfig']['enable_cb']				?: '';
 // Default to 'on' for new installation only
 $pconfig['pfb_keep']			= isset($pfb['gconfig']['pfb_keep'])			? $pfb['gconfig']['pfb_keep'] : 'on';
 
+// Master toggle for the internal-address feed-host filter. Default 'on' for a new,
+// unconfigured install (key absent); pinned 'off' once on an existing install by the
+// upgrade migration in pfblockerng_install.inc so configured feeds are never dropped.
+$pconfig['pfb_feed_internal_filter']	= isset($pfb['gconfig']['pfb_feed_internal_filter'])	? $pfb['gconfig']['pfb_feed_internal_filter'] : 'on';
+
 // Exemptions from the internal-address feed-host check: IP addresses / CIDR ranges
 // (one per line) whose feeds are allowed even when they resolve internally.
 $pconfig['pfb_feed_internal_allowlist']	= $pfb['gconfig']['pfb_feed_internal_allowlist']	?: '';
@@ -152,7 +157,19 @@ if ($_POST) {
 
 			$pfb['gconfig']['enable_cb']			= pfb_filter($_POST['enable_cb'], PFB_FILTER_ON_OFF, 'general', '');
 			$pfb['gconfig']['pfb_keep']			= pfb_filter($_POST['pfb_keep'], PFB_FILTER_ON_OFF, 'general', '');
-			$pfb['gconfig']['pfb_feed_internal_allowlist']	= str_replace("\r\n", "\n", trim($_POST['pfb_feed_internal_allowlist'] ?? ''));
+
+			// Store the master feed-host filter toggle as an explicit 'on'/'off' (a
+			// checkbox submits 'on' when checked, nothing when unchecked) so the
+			// runtime reader can tell an unchecked save (off) from a never-configured
+			// install (key absent => default on).
+			$pfb['gconfig']['pfb_feed_internal_filter']	= (($_POST['pfb_feed_internal_filter'] ?? '') === 'on') ? 'on' : 'off';
+
+			// The allowlist textarea is greyed (disabled) when the filter is off, so the
+			// browser does not submit it. Preserve the previously stored value in that
+			// case rather than overwriting it with the absent POST field.
+			if ($pfb['gconfig']['pfb_feed_internal_filter'] === 'on') {
+				$pfb['gconfig']['pfb_feed_internal_allowlist']	= str_replace("\r\n", "\n", trim($_POST['pfb_feed_internal_allowlist'] ?? ''));
+			}
 			$pfb['gconfig']['pfb_interval']			= $_POST['pfb_interval']			?: 1;
 			$pfb['gconfig']['pfb_min']			= $_POST['pfb_min']				?: 0;
 			$pfb['gconfig']['pfb_hour']			= $_POST['pfb_hour']				?: 0;
@@ -257,6 +274,16 @@ $section->addInput(new Form_Checkbox(
 		. ' If \'Keep Settings\' is not \'enabled\' on pkg Install/De-Install, all settings will be Wiped!<br /><br />'
 		. '<span class="text-danger">Note: </span>'
 		. ' To clear all downloaded lists, uncheck these two checkboxes and \'Save\'. Re-check both boxes and run a \'Force Update|Reload\''
+);
+
+$section->addInput(new Form_Checkbox(
+	'pfb_feed_internal_filter',
+	'Internal Feed Host Filter',
+	gettext('Enable'),
+	$pconfig['pfb_feed_internal_filter'] === 'on' ? true:false,
+	'on'
+))->setHelp('Restrict feeds from being fetched from non-public/internal addresses. '
+		. 'The exemptions list below allows specific IP/CIDRs through.'
 );
 
 $section->addInput(new Form_Textarea(
@@ -440,4 +467,22 @@ $form->add($section);
 print($form);
 print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');
 ?>
+
+<script type="text/javascript">
+//<![CDATA[
+events.push(function() {
+
+	// Grey out the internal-feed-host exemption list when the master filter is off.
+	// The value is left intact (disabled, not cleared); the POST handler preserves the
+	// stored exemptions across an off-toggle save, since a disabled field is not sent.
+	function pfb_sync_internal_filter() {
+		disableInput('pfb_feed_internal_allowlist', !$('#pfb_feed_internal_filter').prop('checked'));
+	}
+
+	$('#pfb_feed_internal_filter').click(pfb_sync_internal_filter);
+	pfb_sync_internal_filter();
+});
+//]]>
+</script>
+
 <?php include('foot.inc');?>

--- a/tests/php/FeedFilterEnabledTest.php
+++ b/tests/php/FeedFilterEnabledTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_feed_filter_enabled() — the runtime reader for the master feed-host filter
+ * toggle ('pfb_feed_internal_filter'). It gates whether pfb_download() invokes the
+ * feed-host guard at all.
+ *
+ * Default-ON contract: a fresh, never-configured install (key absent) reads as ON, so
+ * the filter ships active. An explicit stored 'off' (written by an unchecked save, or
+ * pinned by the install-time grandfather migration on an existing box) reads as OFF.
+ * Any other stored value reads as ON (the value the UI writes when checked is 'on').
+ */
+#[CoversFunction('pfb_feed_filter_enabled')]
+final class FeedFilterEnabledTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['config']);
+	}
+
+	private function setToggle(string $value): void
+	{
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_filter', $value);
+	}
+
+	public function testDefaultsOnWhenKeyAbsent(): void
+	{
+		// Fresh install: the key is unset -> the filter is enabled (secure default).
+		$this->assertTrue(pfb_feed_filter_enabled());
+	}
+
+	public function testExplicitOffDisablesTheFilter(): void
+	{
+		// Before: absent -> enabled.
+		$this->assertTrue(pfb_feed_filter_enabled());
+		// After: a stored 'off' (unchecked save / grandfather pin) -> disabled.
+		$this->setToggle('off');
+		$this->assertFalse(pfb_feed_filter_enabled());
+	}
+
+	public function testExplicitOnEnablesTheFilter(): void
+	{
+		// First pin it off, then on, so green proves the 'on' value flips it back.
+		$this->setToggle('off');
+		$this->assertFalse(pfb_feed_filter_enabled());
+		$this->setToggle('on');
+		$this->assertTrue(pfb_feed_filter_enabled());
+	}
+
+	public function testAnyNonOffValueReadsAsEnabled(): void
+	{
+		// Only the literal 'off' disables; an empty string or stray value reads ON
+		// (fail-safe toward keeping the filter active).
+		$this->setToggle('');
+		$this->assertTrue(pfb_feed_filter_enabled());
+	}
+}

--- a/tests/php/FeedFilterInstallDefaultTest.php
+++ b/tests/php/FeedFilterInstallDefaultTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_feed_filter_install_default() — the grandfather decision the install/upgrade
+ * hook applies for the feed-host filter toggle. (The procedural application in
+ * pfblockerng_install.inc — config_get_path/config_set_path — is smoke/manual-verified;
+ * this pins the pure decision the hook delegates to.)
+ *
+ * Contract:
+ *   - config/0 == null (fresh, never-configured install) => NULL: leave the key unset,
+ *     so the runtime reader's ON default applies (filter active for new installs).
+ *   - config/0 present, key absent (an already-configured upgrade) => 'off': pin it off
+ *     once so existing feeds are never silently dropped.
+ *   - key already set (either value) => NULL: run-once + idempotent, never re-disables
+ *     an operator who re-enabled it.
+ */
+#[CoversFunction('pfb_feed_filter_install_default')]
+final class FeedFilterInstallDefaultTest extends TestCase
+{
+	public function testFreshInstallLeavesKeyUnset(): void
+	{
+		// config/0 == null => fresh => NULL (=> runtime default ON).
+		$this->assertNull(pfb_feed_filter_install_default(null));
+	}
+
+	public function testExistingInstallWithoutKeyIsPinnedOff(): void
+	{
+		// An already-configured install (other settings present, toggle absent) is the
+		// grandfather case -> pin 'off'.
+		$gconfig = ['enable_cb' => 'on', 'pfb_keep' => 'on'];
+		$this->assertSame('off', pfb_feed_filter_install_default($gconfig));
+	}
+
+	public function testKeyAlreadyOffIsLeftUnchanged(): void
+	{
+		// Idempotent: a stored 'off' is not re-applied (NULL => no write).
+		$this->assertNull(pfb_feed_filter_install_default(['pfb_feed_internal_filter' => 'off']));
+	}
+
+	public function testKeyAlreadyOnIsNotReDisabled(): void
+	{
+		// An operator who opted back in ('on') must never be re-disabled by a later
+		// upgrade -> NULL (no write).
+		$this->assertNull(pfb_feed_filter_install_default(['pfb_feed_internal_filter' => 'on']));
+	}
+}

--- a/tests/php/FeedHostAllowedTest.php
+++ b/tests/php/FeedHostAllowedTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_feed_host_allowed() / pfb_ip_is_internal() / pfb_ip_in_cidr() — the pre-fetch
+ * guard that rejects a feed whose host resolves to a non-public/reserved address
+ * before any connection is made (loopback / link-local / RFC1918 / ULA / CGNAT /
+ * metadata), fail-closed on a host that does not resolve. A resolved internal
+ * address is permitted only when covered by the operator's IP/CIDR allowlist; an
+ * empty allowlist (the default) blocks every internal-resolving feed.
+ *
+ * Scenario: a feed download must only ever dial a routable public address, unless
+ * the operator has explicitly allowlisted the internal address it resolves to.
+ *   Background:
+ *     Given the allowlist 'pfb_feed_internal_allowlist' is empty (secure default)
+ *     And the resolver is driven by $GLOBALS['pfb_test_resolve_map']
+ */
+#[CoversFunction('pfb_feed_host_allowed')]
+#[CoversFunction('pfb_ip_is_internal')]
+#[CoversFunction('pfb_ip_in_cidr')]
+final class FeedHostAllowedTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		// Secure default: allowlist empty (no internal exemptions).
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_resolve_map'] = [];
+	}
+
+	/** Set the internal-address allowlist config value the guard reads. */
+	private function setAllowlist(string $value): void
+	{
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_allowlist', $value);
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map']);
+	}
+
+	/** Drive the guard for a host, returning [allowed, reason, pinned]. */
+	private function guard(string $host): array
+	{
+		$reason = '';
+		$pinned = '';
+		$allowed = pfb_feed_host_allowed($host, $reason, $pinned);
+		return [$allowed, $reason, $pinned];
+	}
+
+	// --- pfb_ip_is_internal(): every reserved range, each family ----------------
+
+	public static function internalIpProvider(): array
+	{
+		return [
+			'loopback v4'        => ['127.0.0.1', '127.0.0.0/8'],
+			'rfc1918 10/8'       => ['10.1.2.3', '10.0.0.0/8'],
+			'rfc1918 172.16/12'  => ['172.16.5.5', '172.16.0.0/12'],
+			'rfc1918 192.168/16' => ['192.168.1.1', '192.168.0.0/16'],
+			'link-local v4'      => ['169.254.169.254', '169.254.0.0/16'],	// metadata IP
+			'cgnat 100.64/10'    => ['100.64.0.1', '100.64.0.0/10'],
+			'this-network 0/8'   => ['0.0.0.0', '0.0.0.0/8'],
+			'loopback v6'        => ['::1', '::1/128'],
+			'link-local v6'      => ['fe80::1', 'fe80::/10'],
+			'ula v6'             => ['fd00::1', 'fc00::/7'],
+			'v4-mapped private'  => ['::ffff:10.0.0.1', '10.0.0.0/8'],	// unwrap then v4 check
+		];
+	}
+
+	#[DataProvider('internalIpProvider')]
+	public function testInternalIpIsRejected(string $ip, string $expectedCidr): void
+	{
+		// Then the address is flagged internal, reporting the matched CIDR.
+		$this->assertSame($expectedCidr, pfb_ip_is_internal($ip));
+	}
+
+	public static function publicIpProvider(): array
+	{
+		return [
+			'public v4'          => ['203.0.113.10'],	// TEST-NET-3, routable shape
+			'public v6'          => ['2001:db8::1'],
+			'just outside 100.64'=> ['100.128.0.1'],	// 100.64/10 upper bound check
+			'just outside 172.16'=> ['172.32.0.1'],		// 172.16/12 upper bound check
+		];
+	}
+
+	#[DataProvider('publicIpProvider')]
+	public function testPublicIpIsAllowed(string $ip): void
+	{
+		// Then a routable public address is not flagged.
+		$this->assertFalse(pfb_ip_is_internal($ip));
+	}
+
+	public function testNonIpInputIsNotFlagged(): void
+	{
+		// pfb_ip_is_internal answers "is this a known-internal IP"; a non-IP is not
+		// (the host-level guard is what fails such input closed — see below).
+		$this->assertFalse(pfb_ip_is_internal('not-an-ip'));
+		$this->assertFalse(pfb_ip_is_internal(''));
+	}
+
+	// --- pfb_feed_host_allowed(): host resolution + verdict ---------------------
+
+	public function testPublicHostIsAllowedAndPinsResolvedIp(): void
+	{
+		// Given a host resolving to a public address
+		$GLOBALS['pfb_test_resolve_map']['feed.example.'] = [
+			['type' => 'A', 'data' => '203.0.113.5'],
+		];
+		// When the guard runs
+		[$allowed, $reason, $pinned] = $this->guard('feed.example');
+		// Then it is allowed and the connection is pinned to that vetted IP.
+		$this->assertTrue($allowed);
+		$this->assertSame('', $reason);
+		$this->assertSame('203.0.113.5', $pinned);
+	}
+
+	public function testIpLiteralPublicHostIsAllowedAndPinned(): void
+	{
+		// A host that is already an IP literal is vetted directly (no resolution).
+		[$allowed, , $pinned] = $this->guard('198.51.100.7');
+		$this->assertTrue($allowed);
+		$this->assertSame('198.51.100.7', $pinned);
+	}
+
+	public function testInternalHostIsRejected(): void
+	{
+		// Given a host resolving to an RFC1918 address
+		$GLOBALS['pfb_test_resolve_map']['internal.example.'] = [
+			['type' => 'A', 'data' => '10.10.10.10'],
+		];
+		// When the guard runs / Then it is rejected with a neutral reason and no pin.
+		[$allowed, $reason, $pinned] = $this->guard('internal.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+		$this->assertSame('', $pinned);
+	}
+
+	public function testMetadataIpLiteralHostIsRejected(): void
+	{
+		// The cloud metadata address as a bare host literal is rejected.
+		[$allowed, $reason] = $this->guard('169.254.169.254');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+	}
+
+	public function testAnyInternalAddressInTheSetRejectsTheWholeHost(): void
+	{
+		// A host with one public AND one internal address is rejected (fail-closed:
+		// the internal record must not be reachable via round-robin).
+		$GLOBALS['pfb_test_resolve_map']['mixed.example.'] = [
+			['type' => 'A', 'data' => '203.0.113.9'],
+			['type' => 'A', 'data' => '192.168.50.1'],
+		];
+		[$allowed, $reason] = $this->guard('mixed.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+	}
+
+	public function testCnameChainResolvingInternalIsRejected(): void
+	{
+		// A CNAME whose target resolves to an internal address is followed and rejected.
+		$GLOBALS['pfb_test_resolve_map']['alias.example.'] = [
+			['type' => 'CNAME', 'data' => 'backend.example'],
+		];
+		$GLOBALS['pfb_test_resolve_map']['backend.example.'] = [
+			['type' => 'A', 'data' => '172.16.0.5'],
+		];
+		[$allowed, $reason] = $this->guard('alias.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+	}
+
+	// --- Fail-closed --------------------------------------------------------------
+
+	public function testUnresolvableHostIsRejected(): void
+	{
+		// Given a host that does not resolve ([] from the resolver)
+		$GLOBALS['pfb_test_resolve_map']['nxdomain.example.'] = false;
+		// When the guard runs / Then it fails closed.
+		[$allowed, $reason] = $this->guard('nxdomain.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host did not resolve', $reason);
+	}
+
+	public function testHostResolvingToNoValidAddressIsRejected(): void
+	{
+		// Records exist but carry no usable IP -> fail closed.
+		$GLOBALS['pfb_test_resolve_map']['empty.example.'] = [
+			['type' => 'A', 'data' => ''],
+		];
+		[$allowed, $reason] = $this->guard('empty.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host did not resolve to a valid address', $reason);
+	}
+
+	public function testEmptyHostIsRejected(): void
+	{
+		[$allowed, $reason] = $this->guard('');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host is empty', $reason);
+	}
+
+	// --- Allowlist is a real branch (absent -> rejected, present -> allowed) -----
+
+	public function testAllowlistingTheResolvedIpFlipsInternalHostFromRejectedToAllowed(): void
+	{
+		// Given a host resolving to an internal address
+		$GLOBALS['pfb_test_resolve_map']['internal.example.'] = [
+			['type' => 'A', 'data' => '10.0.0.9'],
+		];
+
+		// When the allowlist is empty (default) -> rejected (before-state).
+		[$allowedOff, $reasonOff, $pinnedOff] = $this->guard('internal.example');
+		$this->assertFalse($allowedOff);
+		$this->assertSame('feed host resolves to a non-permitted address', $reasonOff);
+		$this->assertSame('', $pinnedOff);
+
+		// When that exact IP is allowlisted -> the same host is now allowed, and the
+		// vetted internal IP becomes the pinned connection target.
+		$this->setAllowlist('10.0.0.9');
+		[$allowedOn, $reasonOn, $pinnedOn] = $this->guard('internal.example');
+		$this->assertTrue($allowedOn);
+		$this->assertSame('', $reasonOn);
+		$this->assertSame('10.0.0.9', $pinnedOn);
+	}
+
+	public function testInternalIpCoveredByAllowlistedCidrIsAllowed(): void
+	{
+		// Given a host resolving to an internal address inside an allowlisted CIDR
+		$GLOBALS['pfb_test_resolve_map']['mirror.example.'] = [
+			['type' => 'A', 'data' => '10.1.2.3'],
+		];
+		$this->setAllowlist('10.0.0.0/8');
+		// When the guard runs / Then it is allowed and pins the vetted IP.
+		[$allowed, $reason, $pinned] = $this->guard('mirror.example');
+		$this->assertTrue($allowed);
+		$this->assertSame('', $reason);
+		$this->assertSame('10.1.2.3', $pinned);
+	}
+
+	public function testHostWithOnlyOneOfTwoInternalIpsAllowlistedIsRejected(): void
+	{
+		// A host with two internal addresses where only one is allowlisted is
+		// rejected: EVERY internal address must be covered (fail-closed).
+		$GLOBALS['pfb_test_resolve_map']['twohomed.example.'] = [
+			['type' => 'A', 'data' => '10.0.0.1'],
+			['type' => 'A', 'data' => '192.168.1.1'],
+		];
+		$this->setAllowlist('10.0.0.1');	// covers only the first
+		[$allowed, $reason] = $this->guard('twohomed.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+	}
+
+	public function testInvalidAllowlistEntriesAreIgnored(): void
+	{
+		// Given a host resolving to an internal address
+		$GLOBALS['pfb_test_resolve_map']['internal.example.'] = [
+			['type' => 'A', 'data' => '10.0.0.9'],
+		];
+		// And an allowlist made only of invalid entries (no valid IP/CIDR exemption)
+		$this->setAllowlist("not-an-ip\n999.0.0.0/8");
+		// When the guard runs / Then nothing is exempted -> still rejected.
+		[$allowed, $reason] = $this->guard('internal.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+	}
+
+	public function testPublicHostIsAllowedRegardlessOfAllowlistContents(): void
+	{
+		// The allowlist exempts internal addresses only; a public host is allowed
+		// whether or not the allowlist is populated (here it lists an unrelated range).
+		$GLOBALS['pfb_test_resolve_map']['public.example.'] = [
+			['type' => 'A', 'data' => '203.0.113.20'],
+		];
+		$this->setAllowlist('10.0.0.0/8');
+		[$allowed, $reason, $pinned] = $this->guard('public.example');
+		$this->assertTrue($allowed);
+		$this->assertSame('', $reason);
+		$this->assertSame('203.0.113.20', $pinned);
+	}
+
+	// --- pfb_ip_in_cidr(): the shared binary-containment helper -----------------
+
+	public function testIpInCidrMatchesInsideRange(): void
+	{
+		$this->assertTrue(pfb_ip_in_cidr('10.1.2.3', '10.0.0.0/8'));
+		$this->assertTrue(pfb_ip_in_cidr('2001:db8::5', '2001:db8::/32'));
+	}
+
+	public function testIpJustOutsideCidrDoesNotMatch(): void
+	{
+		// 100.128.0.1 is one block above the 100.64.0.0/10 (CGNAT) upper bound.
+		$this->assertFalse(pfb_ip_in_cidr('100.128.0.1', '100.64.0.0/10'));
+		$this->assertFalse(pfb_ip_in_cidr('172.32.0.1', '172.16.0.0/12'));
+	}
+
+	public function testIpInCidrFamilyMismatchDoesNotMatch(): void
+	{
+		// A v4 address can never be contained in a v6 CIDR, nor a bare (non-CIDR) arg.
+		$this->assertFalse(pfb_ip_in_cidr('10.0.0.1', 'fc00::/7'));
+		$this->assertFalse(pfb_ip_in_cidr('::1', '10.0.0.0/8'));
+		$this->assertFalse(pfb_ip_in_cidr('10.0.0.1', '10.0.0.0'));
+	}
+}

--- a/tests/php/FeedHostAllowedTest.php
+++ b/tests/php/FeedHostAllowedTest.php
@@ -23,13 +23,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_feed_host_allowed')]
 #[CoversFunction('pfb_ip_is_internal')]
 #[CoversFunction('pfb_ip_in_cidr')]
+#[CoversFunction('pfb_ip_is_self')]
 final class FeedHostAllowedTest extends TestCase
 {
 	protected function setUp(): void
 	{
-		// Secure default: allowlist empty (no internal exemptions).
+		// Secure default: allowlist empty (no internal exemptions), and no IP
+		// configured on the box (the self-exemption never fires unless seeded).
 		$GLOBALS['config'] = [];
 		$GLOBALS['pfb_test_resolve_map'] = [];
+		$GLOBALS['pfb_test_configured_ips'] = [];
 	}
 
 	/** Set the internal-address allowlist config value the guard reads. */
@@ -40,7 +43,7 @@ final class FeedHostAllowedTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map']);
+		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map'], $GLOBALS['pfb_test_configured_ips']);
 	}
 
 	/** Drive the guard for a host, returning [allowed, reason, pinned]. */
@@ -297,6 +300,107 @@ final class FeedHostAllowedTest extends TestCase
 		$this->assertTrue($allowed);
 		$this->assertSame('', $reason);
 		$this->assertSame('203.0.113.20', $pinned);
+	}
+
+	// --- Self-host exemption: a feed served by the box itself -------------------
+	//
+	// The firewall's own LAN address is RFC1918, but a self-hosted feed
+	// (http://127.0.0.1/…, http://[::1]/…, http://<box-IP>/…) is a long-supported
+	// pfBlockerNG case. A resolved candidate that is the box itself is allowed even
+	// with an empty allowlist; the same RFC1918 IP NOT configured on the box is
+	// rejected — proving self-ownership, not the address shape, is the cause.
+
+	public function testSelfConfiguredInternalIpFlipsRejectedHostToAllowed(): void
+	{
+		// Given a host resolving to an RFC1918 address
+		$GLOBALS['pfb_test_resolve_map']['selfhost.example.'] = [
+			['type' => 'A', 'data' => '192.168.1.1'],
+		];
+
+		// When that IP is NOT configured on the box -> rejected (before-state).
+		[$allowedOff, $reasonOff, $pinnedOff] = $this->guard('selfhost.example');
+		$this->assertFalse($allowedOff);
+		$this->assertSame('feed host resolves to a non-permitted address', $reasonOff);
+		$this->assertSame('', $pinnedOff);
+
+		// When the SAME IP is the box's own configured address -> allowed, pinning it.
+		$GLOBALS['pfb_test_configured_ips'] = ['192.168.1.1'];
+		[$allowedOn, $reasonOn, $pinnedOn] = $this->guard('selfhost.example');
+		$this->assertTrue($allowedOn);
+		$this->assertSame('', $reasonOn);
+		$this->assertSame('192.168.1.1', $pinnedOn);
+	}
+
+	public function testLoopbackLiteralHostsAreAllowed(): void
+	{
+		// 127.0.0.1 / ::1 as bare host literals are self (loopback) -> allowed, with
+		// no box-configured IPs seeded (loopback is recognised unconditionally).
+		[$allowed4, , $pinned4] = $this->guard('127.0.0.1');
+		$this->assertTrue($allowed4);
+		$this->assertSame('127.0.0.1', $pinned4);
+
+		[$allowed6, , $pinned6] = $this->guard('::1');
+		$this->assertTrue($allowed6);
+		$this->assertSame('::1', $pinned6);
+	}
+
+	public function testSelfExemptionDoesNotBlanketAllowAMixedSet(): void
+	{
+		// A host resolving to [box-self, foreign-internal-not-self-not-allowlisted]
+		// still REJECTS on the foreign-internal address: the self-exemption is
+		// per-candidate, never a blanket allow once one candidate is self.
+		$GLOBALS['pfb_test_resolve_map']['mixedself.example.'] = [
+			['type' => 'A', 'data' => '192.168.1.1'],	// the box itself
+			['type' => 'A', 'data' => '10.0.0.5'],		// foreign internal
+		];
+		$GLOBALS['pfb_test_configured_ips'] = ['192.168.1.1'];
+
+		[$allowed, $reason] = $this->guard('mixedself.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+	}
+
+	public function testHostResolvingOnlyToBoxSelfIsAllowed(): void
+	{
+		// The complement of the mixed-set case: a host resolving ONLY to the box's own
+		// (RFC1918) address is allowed and pins that address.
+		$GLOBALS['pfb_test_resolve_map']['onlyself.example.'] = [
+			['type' => 'A', 'data' => '192.168.1.1'],
+		];
+		$GLOBALS['pfb_test_configured_ips'] = ['192.168.1.1'];
+
+		[$allowed, $reason, $pinned] = $this->guard('onlyself.example');
+		$this->assertTrue($allowed);
+		$this->assertSame('', $reason);
+		$this->assertSame('192.168.1.1', $pinned);
+	}
+
+	public function testPublicForeignHostRejectedWhenAllCandidatesNonSelfInternal(): void
+	{
+		// A host resolving to [public, foreign-internal] (neither self nor allowlisted)
+		// is rejected on the foreign-internal record (fail-closed preserved).
+		$GLOBALS['pfb_test_resolve_map']['pubint.example.'] = [
+			['type' => 'A', 'data' => '203.0.113.50'],
+			['type' => 'A', 'data' => '10.0.0.5'],
+		];
+		[$allowed, $reason] = $this->guard('pubint.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+	}
+
+	// --- pfb_ip_is_self(): the self-ownership predicate -------------------------
+
+	public function testIpIsSelfPredicate(): void
+	{
+		// Loopback is self unconditionally; a configured box IP is self; anything else
+		// (incl. a non-configured RFC1918 address and a public address) is not.
+		$GLOBALS['pfb_test_configured_ips'] = ['192.168.1.1'];
+		$this->assertTrue(pfb_ip_is_self('127.0.0.1'));
+		$this->assertTrue(pfb_ip_is_self('::1'));
+		$this->assertTrue(pfb_ip_is_self('192.168.1.1'));
+		$this->assertFalse(pfb_ip_is_self('10.0.0.5'));		// RFC1918 but not configured
+		$this->assertFalse(pfb_ip_is_self('203.0.113.7'));	// public, not configured
+		$this->assertFalse(pfb_ip_is_self(''));
 	}
 
 	// --- pfb_ip_in_cidr(): the shared binary-containment helper -----------------

--- a/tests/php/FeedHostAllowedTest.php
+++ b/tests/php/FeedHostAllowedTest.php
@@ -175,6 +175,20 @@ final class FeedHostAllowedTest extends TestCase
 		$this->assertSame('feed host resolves to a non-permitted address', $reason);
 	}
 
+	public function testCnameWithInternalIpLiteralIsRejected(): void
+	{
+		// A CNAME record whose 'data' is itself an IP literal (the IP-literal branch
+		// of the CNAME handling) is taken directly as an address: when that literal
+		// is internal it must be rejected without a further resolution step.
+		$GLOBALS['pfb_test_resolve_map']['alias.example.'] = [
+			['type' => 'CNAME', 'data' => '10.0.0.7'],
+		];
+		[$allowed, $reason, $pinned] = $this->guard('alias.example');
+		$this->assertFalse($allowed);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+		$this->assertSame('', $pinned);
+	}
+
 	// --- Fail-closed --------------------------------------------------------------
 
 	public function testUnresolvableHostIsRejected(): void

--- a/tests/php/FeedRedirectTargetTest.php
+++ b/tests/php/FeedRedirectTargetTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_feed_redirect_target() / pfb_resolve_relative_url() — the per-hop decision a
+ * feed download makes when a server returns an HTTP 3xx redirect. The redirect
+ * target host is re-vetted by the feed-host guard before being followed, so a
+ * redirect cannot send the fetch to a non-permitted address. A relative Location is
+ * resolved against the URL it was returned from.
+ *
+ * Scenario: a redirect must be followed only to a routable public address, and the
+ * caller re-pins the connection to the freshly vetted IP.
+ *   Background:
+ *     Given the internal-address allowlist is empty (secure default)
+ *     And the resolver is driven by $GLOBALS['pfb_test_resolve_map']
+ */
+#[CoversFunction('pfb_feed_redirect_target')]
+#[CoversFunction('pfb_resolve_relative_url')]
+final class FeedRedirectTargetTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_resolve_map'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map']);
+	}
+
+	/** Drive the helper, returning [result, reason, pinned]. */
+	private function redirect(string $location, string $current): array
+	{
+		$reason = '';
+		$pinned = '';
+		$result = pfb_feed_redirect_target($location, $current, $reason, $pinned);
+		return [$result, $reason, $pinned];
+	}
+
+	public function testAbsoluteRedirectToPublicHostIsFollowedAndPinned(): void
+	{
+		// Given the redirect target resolves to a public address
+		$GLOBALS['pfb_test_resolve_map']['mirror.example.'] = [
+			['type' => 'A', 'data' => '203.0.113.40'],
+		];
+		// When an absolute Location to that host is evaluated
+		[$result, $reason, $pinned] = $this->redirect(
+			'https://mirror.example/feed/list.txt',
+			'https://feed.example/list.txt'
+		);
+		// Then the next URL is returned and the vetted public IP is pinned.
+		$this->assertIsArray($result);
+		$this->assertSame('https://mirror.example/feed/list.txt', $result['url']);
+		$this->assertSame('mirror.example', $result['host']);
+		$this->assertSame('https', $result['scheme']);
+		$this->assertSame(443, $result['port']);
+		$this->assertSame('203.0.113.40', $pinned);
+		$this->assertSame('', $reason);
+	}
+
+	public function testRedirectToInternalHostIsRejected(): void
+	{
+		// Given the redirect target resolves to an internal address
+		$GLOBALS['pfb_test_resolve_map']['internal.example.'] = [
+			['type' => 'A', 'data' => '10.0.0.50'],
+		];
+		// When the redirect is evaluated / Then it is refused (fail-closed) with the
+		// neutral guard reason and no pin.
+		[$result, $reason, $pinned] = $this->redirect(
+			'https://internal.example/secret',
+			'https://feed.example/list.txt'
+		);
+		$this->assertFalse($result);
+		$this->assertSame('feed host resolves to a non-permitted address', $reason);
+		$this->assertSame('', $pinned);
+	}
+
+	public function testRelativeLocationIsResolvedAgainstCurrentUrl(): void
+	{
+		// Given a public host serving the current URL and an absolute-path Location
+		$GLOBALS['pfb_test_resolve_map']['feed.example.'] = [
+			['type' => 'A', 'data' => '203.0.113.7'],
+		];
+		// When a relative ('/v2/list.txt') Location is evaluated against the current URL
+		[$result, , $pinned] = $this->redirect('/v2/list.txt', 'https://feed.example/v1/list.txt');
+		// Then it resolves to the same host's absolute URL and re-vets that host.
+		$this->assertIsArray($result);
+		$this->assertSame('https://feed.example/v2/list.txt', $result['url']);
+		$this->assertSame('203.0.113.7', $pinned);
+	}
+
+	public function testRelativePathLocationIsResolvedAgainstBaseDirectory(): void
+	{
+		// A bare relative-path Location ('list2.txt') resolves against the directory
+		// of the current URL's path.
+		$GLOBALS['pfb_test_resolve_map']['feed.example.'] = [
+			['type' => 'A', 'data' => '203.0.113.7'],
+		];
+		[$result, , ] = $this->redirect('list2.txt', 'https://feed.example/dir/list.txt');
+		$this->assertIsArray($result);
+		$this->assertSame('https://feed.example/dir/list2.txt', $result['url']);
+	}
+
+	public function testNonHttpRedirectTargetIsRejected(): void
+	{
+		// A redirect to a non-http(s) scheme (e.g. file://) is refused.
+		[$result, $reason] = $this->redirect('file:///etc/passwd', 'https://feed.example/list.txt');
+		$this->assertFalse($result);
+		$this->assertSame('feed redirect target is not an http(s) URL', $reason);
+	}
+
+	public function testEmptyLocationIsRejected(): void
+	{
+		[$result, $reason] = $this->redirect('', 'https://feed.example/list.txt');
+		$this->assertFalse($result);
+		$this->assertSame('feed redirect has no target', $reason);
+	}
+}

--- a/tests/php/RsyncPinUrlTest.php
+++ b/tests/php/RsyncPinUrlTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_rsync_pin_url() — rebuild an rsync feed source so it connects to the vetted
+ * IP (the guard's pinned address) instead of the hostname, keeping the module/path
+ * intact, for both rsync source forms. An unparseable form returns '' so the caller
+ * fails closed (does not connect).
+ */
+#[CoversFunction('pfb_rsync_pin_url')]
+final class RsyncPinUrlTest extends TestCase
+{
+	public static function pinProvider(): array
+	{
+		return [
+			// host::module form -> IP substituted for the host, module intact.
+			'module form'            => ['rsync.example::feed/list.txt', '203.0.113.5', '203.0.113.5::feed/list.txt'],
+			'module form bare'       => ['rsync.example::feed', '198.51.100.9', '198.51.100.9::feed'],
+			'module form user@'      => ['user@rsync.example::feed/x', '203.0.113.5', 'user@203.0.113.5::feed/x'],
+			// rsync://host/path form -> IP substituted for the host, path intact.
+			'url form'               => ['rsync://rsync.example/feed/list.txt', '203.0.113.5', 'rsync://203.0.113.5/feed/list.txt'],
+			'url form with port'     => ['rsync://rsync.example:8730/feed', '203.0.113.5', 'rsync://203.0.113.5:8730/feed'],
+			'url form user@'         => ['rsync://user@rsync.example/feed', '203.0.113.5', 'rsync://user@203.0.113.5/feed'],
+			// IPv6 vetted IP is bracketed in the URL form.
+			'url form ipv6'          => ['rsync://rsync.example/feed', '2001:db8::1', 'rsync://[2001:db8::1]/feed'],
+		];
+	}
+
+	#[DataProvider('pinProvider')]
+	public function testHostIsReplacedByVettedIp(string $url, string $ip, string $expected): void
+	{
+		$this->assertSame($expected, pfb_rsync_pin_url($url, $ip));
+	}
+
+	public function testUnparseableFormFailsClosed(): void
+	{
+		// A source that is neither a 'host::module' nor an 'rsync://' URL cannot be
+		// host-substituted -> '' so the caller fails closed.
+		$this->assertSame('', pfb_rsync_pin_url('https://rsync.example/feed', '203.0.113.5'));
+		$this->assertSame('', pfb_rsync_pin_url('rsync.example/feed', '203.0.113.5'));
+		$this->assertSame('', pfb_rsync_pin_url('', '203.0.113.5'));
+		$this->assertSame('', pfb_rsync_pin_url('rsync.example::feed', ''));
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -55,6 +55,35 @@ if (!function_exists('is_ipaddr')) {
 	}
 }
 
+if (!function_exists('is_subnetv4')) {
+	// pfSense util.inc: 'ipv4/bits' with a 0-32 prefix and a valid v4 network part.
+	function is_subnetv4($subnet) {
+		if (!is_string($subnet) || strpos($subnet, '/') === false) {
+			return false;
+		}
+		list($ip, $bits) = explode('/', $subnet, 2);
+		return (is_ipaddrv4($ip) && ctype_digit($bits) && (int) $bits >= 0 && (int) $bits <= 32);
+	}
+}
+
+if (!function_exists('is_subnetv6')) {
+	// pfSense util.inc: 'ipv6/bits' with a 0-128 prefix and a valid v6 network part.
+	function is_subnetv6($subnet) {
+		if (!is_string($subnet) || strpos($subnet, '/') === false) {
+			return false;
+		}
+		list($ip, $bits) = explode('/', $subnet, 2);
+		return (is_ipaddrv6($ip) && ctype_digit($bits) && (int) $bits >= 0 && (int) $bits <= 128);
+	}
+}
+
+if (!function_exists('is_subnet')) {
+	// pfSense util.inc: v4 OR v6 subnet.
+	function is_subnet($subnet) {
+		return (is_subnetv4($subnet) || is_subnetv6($subnet));
+	}
+}
+
 if (!function_exists('is_hostname')) {
 	// Reached only by PFB_FILTER_HOSTNAME, which the seed suite does not exercise.
 	// Fail fast rather than guess pfSense's semantics (a guessed double could let a
@@ -131,10 +160,18 @@ if (!function_exists('unlink_if_exists')) {
 }
 
 if (!function_exists('resolve_host_addresses')) {
-	// Only reached by PFB_FILTER_URL, which the seed suite does not exercise. Fail
-	// fast rather than return a guessed [] that could hide a missing real double.
+	// pfSense util.inc returns a list of ['type'=>'A'|'AAAA'|'CNAME','data'=>...]
+	// records (or [] when a host does not resolve). FeedHostAllowedTest drives the
+	// guard by seeding $GLOBALS['pfb_test_resolve_map'] (host => records | false).
+	// A host absent from the map keeps the original fail-fast, so an unrelated path
+	// reaching this double still surfaces as a missing double, not a silent [].
 	function resolve_host_addresses($host, $records = [], $dnscache = false) {
-		throw new LogicException(__FUNCTION__ . '() double not implemented — add a real one before testing this path');
+		$map = $GLOBALS['pfb_test_resolve_map'] ?? null;
+		if (is_array($map) && array_key_exists($host, $map)) {
+			$result = $map[$host];
+			return $result === false ? [] : $result;
+		}
+		throw new LogicException(__FUNCTION__ . '() double not implemented — add a real one before testing this path (host: ' . (string) $host . ')');
 	}
 }
 

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -176,10 +176,13 @@ if (!function_exists('resolve_host_addresses')) {
 }
 
 if (!function_exists('is_ipaddr_configured')) {
-	// Only reached by PFB_FILTER_URL, which the seed suite does not exercise. Fail
-	// fast rather than return a guessed false that could hide a missing real double.
+	// pfSense interfaces.inc: TRUE when $ipaddr is an address configured on the box.
+	// The feed-host self-exemption (pfb_ip_is_self) drives this — a test declares the
+	// firewall's own addresses by seeding $GLOBALS['pfb_test_configured_ips'] (a list
+	// of IP literals it returns TRUE for; absent/empty => no configured IPs).
 	function is_ipaddr_configured($ipaddr, $ignore_if = '', $check_localip = false, $check_subnets = false, $cidrprefix = '') {
-		throw new LogicException(__FUNCTION__ . '() double not implemented — add a real one before testing this path');
+		$configured = $GLOBALS['pfb_test_configured_ips'] ?? [];
+		return is_array($configured) && in_array($ipaddr, $configured, true);
 	}
 }
 


### PR DESCRIPTION
Verify a feed host resolves only to routable public addresses before any connection is made.

## What

- New guard `pfb_feed_host_allowed($host, &amp;$reason, &amp;$pinned)` in `pfblockerng.inc`. It resolves the feed host (or uses an IP literal directly, following CNAMEs as the URL validator does) and rejects — fail-closed — when any resolved address falls in a non-public/reserved range and is not covered by the allowlist (below):
  - v4: `0.0.0.0/8`, `10.0.0.0/8`, `100.64.0.0/10` (CGNAT), `127.0.0.0/8`, `169.254.0.0/16`, `172.16.0.0/12`, `192.168.0.0/16`
  - v6: `::1/128`, `fc00::/7` (ULA), `fe80::/10`; IPv4-mapped (`::ffff:0:0/96`) is unwrapped and re-checked as v4
  - An unresolvable host / no-valid-address / empty host also fails closed.
- Helpers: `pfb_ip_is_internal($ip)` (returns the matched reserved CIDR or `FALSE`) and `pfb_ip_in_cidr($ip, $cidr)` — the shared binary (`inet_pton`) containment math, reused by `pfb_ip_is_internal()` **and** the allowlist check (single source of truth).
- Applied to the cURL feed-download branch (and the rsync branch) in `pfb_download()`. On the cURL path the vetted IP is pinned via `CURLOPT_RESOLVE` so the connection cannot rebind between check and fetch; it coexists with `CURLOPT_INTERFACE`. Port is derived from the URL or its scheme (80/443/873/21).
- The cURL feed handle is also constrained to the schemes pfBlockerNG fetches over (`CURLOPT_PROTOCOLS` = http/https/ftp; rsync uses exec separately) — an independent libcurl-layer backstop to the URL scheme allowlist.

## Redirect handling (cURL) and rsync pinning

- **Redirects are followed manually and re-validated per hop.** cURL auto-follow is disabled on the feed handle (`CURLOPT_FOLLOWLOCATION` off, `CURLOPT_MAXREDIRS` 0); `pfb_download()` follows any `3xx` `Location` itself in a bounded loop (cap `PFB_DOWNLOAD_MAXREDIRS`, 10 — matching the previous auto-follow cap). For each hop the redirect target host is re-vetted by `pfb_feed_host_allowed()` and the connection is re-pinned (`CURLOPT_RESOLVE`) to the freshly vetted IP before it is dialled; a redirect to a non-permitted host is skipped (fail-closed). Only the **final** response body becomes the feed file — redirect-hop bodies are truncated away. The common, non-redirecting feed download behaves exactly as before (same file output, status, retry and timestamp logic).
  - New pure helper `pfb_feed_redirect_target($location, $current_url, &amp;$reason, &amp;$pinned)` (with `pfb_resolve_relative_url()`) holds the per-hop decision — resolves a possibly-relative `Location` to an absolute http(s) URL, extracts the host, runs the guard, returns the next URL + pinned IP or `FALSE`. The curl mechanics stay in `pfb_download()`.
- **rsync now connects to the vetted IP.** The rsync source is rebuilt to substitute the pinned IP for the host component (both `host::module` and `rsync://host/path` forms, preserving the module/path, an explicit port, and a `user@` prefix), `escapeshellarg`&#39;d before the `exec`; an unparseable form fails closed. New pure helper `pfb_rsync_pin_url($list_url, $ip)`.

## Internal Feed Host Exemptions (allowlist)

A General-settings textarea, **Internal Feed Host Exemptions** (`pfb_feed_internal_allowlist`), holds IP addresses and/or CIDR ranges — one per line (comma/space separators also accepted, normalised on read). Each entry is validated (`is_ipaddr` / `is_subnet`); blank and invalid entries are silently ignored.

- A resolved address that is internal is permitted **only** when it equals an allowlisted IP literal (by value) or is contained in an allowlisted CIDR.
- **Every** internal address a host resolves to must be covered, else the whole host is rejected (fail-closed).
- The default (empty) allowlist blocks every feed that resolves to an internal/private address. There is no blanket &#34;allow all&#34; — list an explicit CIDR to wave through a whole internal range. Public addresses are always allowed.
- For a permitted allowlisted-internal host the vetted internal IP becomes the pinned `CURLOPT_RESOLVE` target.

## Master toggle, self-host exemption, and grandfathering

- **Master enable toggle** — a General-settings on/off checkbox, **Internal Feed Host Filter** (`pfb_feed_internal_filter`), gates the whole feed-host filter. New runtime reader `pfb_feed_filter_enabled()` reads it, **defaulting to ON when the key is absent** (a fresh install ships the filter active). When the toggle is off, `pfb_download()` skips the guard and the IP pin entirely on both the cURL and rsync paths (pre-filter fetch behaviour, including cURL-native redirect following).
- **Self-host exemption** — a self-hosted feed served by the box itself (`http://127.0.0.1/…`, `http://[::1]/…`, `http://&lt;box-IP&gt;/…`) is a long-supported case (cf. the existing `PFB_FILTER_URL` handling). A resolved candidate that is the firewall itself is now treated as allowed even though its address is non-public. New predicate `pfb_ip_is_self($ip)`: true for `127.0.0.1`, `::1`, or any `is_ipaddr_configured($ip)`. The exemption is **per-candidate** — a host resolving to `[box-self, foreign-internal]` still rejects on the foreign-internal address; it never blanket-allows a mixed set.
- **Grandfather migration** — `pfblockerng_install.inc` pins the toggle **off once** on an already-configured install (so existing feeds are never silently dropped); a fresh, never-configured install leaves the key unset and reads as ON. The decision is the pure helper `pfb_feed_filter_install_default($gconfig)` (config/0 null ⇒ leave unset ⇒ default ON; config/0 present &amp; key unset ⇒ `off`; key already set ⇒ unchanged), making the migration run-once + idempotent — an operator who re-enabled the filter is never re-disabled by a later upgrade.
- **Greyed-but-preserved exemptions** — when the toggle is off, the **Internal Feed Host Exemptions** textarea renders disabled/greyed via the page&#39;s `disableInput()` dependency idiom. A disabled field is not submitted by the browser, so the POST handler **preserves the previously stored exemptions** on an off-toggle save rather than overwriting them with the absent field.

## Tests

`tests/php/FeedHostAllowedTest.php`: every reserved range per family rejected, public addresses allowed, IP-literal + CNAME-chain paths (incl. a CNAME whose data is itself an internal IP literal), fail-closed on unresolvable / no-valid-address / empty host, mixed public+internal set rejected; allowlist cases — exact-IP exemption proven a real branch (rejected with it absent, then allowed once the IP is listed, with the vetted internal IP pinned), CIDR-covered internal allowed, a two-internal host with only one entry rejected, invalid entries ignored, public host allowed regardless of allowlist; and focused `pfb_ip_in_cidr()` unit cases (in-range, just-outside, family-mismatch). **New:** self-host exemption — a box-configured RFC1918 IP flips a host from rejected (not configured) to allowed (configured) and pins it, loopback literals allowed, a `[box-self, foreign-internal]` mixed set still rejected (per-candidate, not blanket), a `[public, foreign-internal]` set still rejected (fail-closed preserved), plus a focused `pfb_ip_is_self()` predicate test.

`tests/php/FeedFilterEnabledTest.php` (**new**): the `pfb_feed_filter_enabled()` reader — default-ON when the key is absent, OFF on an explicit `off`, ON again on `on` (asserting the before-state), and any non-`off` value reads ON.

`tests/php/FeedFilterInstallDefaultTest.php` (**new**): the `pfb_feed_filter_install_default()` grandfather decision — fresh (null) leaves the key unset, an already-configured install without the key is pinned `off`, and a key already set (either value) is left unchanged (run-once/idempotent). The procedural application in `pfblockerng_install.inc` is smoke/manual-verified; the greyed-but-preserved POST round-trip is manual/UI-verified.

`tests/php/FeedRedirectTargetTest.php`: the per-hop redirect decision — an absolute redirect to a public host returns the next URL + pinned public IP; a redirect to an internal host is refused (fail-closed); a relative / bare-relative `Location` resolves against the current URL; a non-http(s) target and an empty `Location` are refused.

`tests/php/RsyncPinUrlTest.php`: host→vetted-IP substitution for both `host::module` and `rsync://host/path` forms (with `user@`, explicit port, IPv6 bracketing), and the unparseable→fail-closed case.

Resolver + `is_subnet` + `is_ipaddr_configured` driven by seedable doubles in `tests/php/pfsense_doubles.php`; no network access. The full cURL redirect/rsync wiring is integration/smoke territory; the unit tests pin the pure decision helpers.

`php -l`, PHPUnit (361 pass), PHPStan, PHPCS all green.




## Summary by CodeRabbit

* **New Features**
  * Added **Internal Feed Host Exemptions** setting in General Settings (`pfb_feed_internal_allowlist`) to permit specific IPs/CIDRs.
  * Added an **Internal Feed Host Filter** master toggle (`pfb_feed_internal_filter`) in General Settings (default on for new installs) that greys out the exemptions list when disabled.

* **Security / Improvements**
  * Hardened feed downloads by rejecting internal/private-resolving feed hosts, validating redirect targets, capping manual redirect hops (`PFB_DOWNLOAD_MAXREDIRS`), and pinning connections to vetted destination IPs for both cURL and rsync.
  * Exempted self-hosted feeds (the firewall's own address / loopback) from the internal-address check.

* **Tests**
  * Added PHPUnit coverage for internal address detection, CIDR matching, allowlist behavior, the self-host exemption, the filter toggle reader, the install-time default, redirect target handling, and rsync URL pinning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an **“Internal Feed Host Filter”** checkbox in General Settings to control feed host vetting
  * Added **“Internal Feed Host Exemptions”** to allowlist permitted internal destinations
  * Improved feed downloads with stricter host verification and safer redirect handling (rejecting unsafe/internal redirect targets)

* **Tests**
  * Added comprehensive automated tests covering feed host validation, allowlist behavior, and redirect processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->