### PR TITLE
pkg-repo: serve stable + devel from one shared pfblockerng repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -620,8 +620,10 @@ update badge stay Netgate-bound; a GUI "Updates/Channel" panel is deferred (woul
   (`scripts/build-repo.sh`) is retained as a script only.
 - **Generators + bootstrap:** `scripts/build-repo-portable.py` (primary catalog gen),
   `scripts/build-repo.sh` (fallback + the single `--print-conf` conf template),
-  `scripts/add-repo.sh` (client bootstrap — `devel|stable` channel arg, `priority: 100`,
-  writes `/usr/local/etc/pkg/repos/pfblockerng-<channel>.conf`, `pkg update` + verify). The
+  `scripts/add-repo.sh` (client bootstrap — `devel|stable|nightly` channel arg, `priority: 100`,
+  `pkg update` + verify). `devel`/`stable` write the SAME shared release conf
+  `/usr/local/etc/pkg/repos/pfblockerng.conf` (repo `pfblockerng` carries BOTH packages,
+  Netgate-style); only `nightly` gets its own `pfblockerng-nightly.conf`. The
   emitted conf is byte-identical across all three (drift-pinned in
   `tests/test_add_repo_conf.py` + `tests/test_build_repo_portable.py`).
 - **Repo smoke flow:** `tests/smoke/test_repo_install.py` carries its **own marker `repo`**

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ opt-in package available **only** from this fork's self-hosted repository (Optio
 The three packages are mutually exclusive — install **one**. Choose **stable** unless
 you specifically want to track development builds.
 
+In the self-hosted repository the **stable** and **development** packages are served
+from a single repo (`pfblockerng`) — exactly as Netgate ships `pfSense-pkg-pfBlockerNG`
+and `-devel` from its one `pfSense` repo — so one bootstrap exposes both; you pick which
+to `pkg install`. **Nightly** sits on its own catalog path and so has its own repo conf.
+
 ## Installation
 
 ### Option 1 — pfSense Package Manager
@@ -81,16 +86,18 @@ catalog — add our self-hosted FreeBSD `pkg` repository
 normally (no `pkg add -f`). Run the bootstrap **on the firewall** over SSH, then install:
 
 ```sh
-./scripts/add-repo.sh devel        # or: stable
+./scripts/add-repo.sh devel        # or: stable — both set up the same `pfblockerng` repo
 pkg install pfSense-pkg-pfBlockerNG-devel
 ```
 
-`add-repo.sh` writes `/usr/local/etc/pkg/repos/pfblockerng-<channel>.conf`, runs
-`pkg update`, and verifies the package is visible. No variant argument is needed — the
-script auto-detects CE vs Plus via the routing layer. The configuration it writes is:
+`add-repo.sh devel` and `add-repo.sh stable` both write the shared
+`/usr/local/etc/pkg/repos/pfblockerng.conf` (only **nightly** gets its own
+`pfblockerng-nightly.conf`), run `pkg update`, and verify the package is visible. No
+variant argument is needed — the script auto-detects CE vs Plus via the routing layer.
+The configuration it writes is:
 
 ```sh
-pfblockerng-devel: {
+pfblockerng: {
   url: "https://pkg.pfblockerng.workers.dev/${ABI}",
   mirror_type: none,
   signature_type: none,

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -8,9 +8,15 @@
 # pulls it too via cross-repo resolution (ADR §2; install is not repo-locked).
 #
 # CHANNELS
-#   devel  (default) -> conf /usr/local/etc/pkg/repos/pfblockerng-devel.conf
-#                       repo name `pfblockerng-devel`, pkg pfSense-pkg-pfBlockerNG-devel
-#   stable           -> conf /usr/local/etc/pkg/repos/pfblockerng.conf
+#   The stable and devel packages share ONE repo/catalog — the `pfblockerng` repo,
+#   exactly like Netgate ships `pfSense-pkg-pfBlockerNG` and `-devel` from its single
+#   `pfSense` repo (the two packages CONFLICT — install one). So `stable` and `devel`
+#   write the SAME conf (byte-identical); they differ only in which package the verify
+#   step checks + the install hint printed. Nightly lives on its own catalog path and
+#   so needs its own conf.
+#   devel  (default) -> conf /usr/local/etc/pkg/repos/pfblockerng.conf
+#                       repo name `pfblockerng`,       pkg pfSense-pkg-pfBlockerNG-devel
+#   stable           -> conf /usr/local/etc/pkg/repos/pfblockerng.conf  (SAME file)
 #                       repo name `pfblockerng`,       pkg pfSense-pkg-pfBlockerNG
 #   nightly          -> conf /usr/local/etc/pkg/repos/pfblockerng-nightly.conf
 #                       repo name `pfblockerng-nightly`, pkg ...-nightly (bleeding edge)
@@ -81,15 +87,21 @@ while [ $# -gt 0 ]; do
 done
 
 # ── Per-channel identity ───────────────────────────────────────────────────────
-# devel  -> repo `pfblockerng-devel`,   conf pfblockerng-devel.conf,   pkg ...-devel
+# devel  -> repo `pfblockerng`,         conf pfblockerng.conf,         pkg ...-devel
 # stable -> repo `pfblockerng`,         conf pfblockerng.conf,         pkg pfSense-pkg-pfBlockerNG
 # nightly-> repo `pfblockerng-nightly`, conf pfblockerng-nightly.conf, pkg ...-nightly
+# stable + devel deliberately resolve to the SAME repo/conf (one shared `pfblockerng`
+# catalog carries both packages); only PKG_NAME (verify target + install hint) differs.
 # URL_SUBPATH: nightly is served from the `nightly/` catalog subtree; the release
 # channels from the Pages root. The literal ${ABI} pkg(8) variable follows it.
+# CONF_LABEL names the REPO (not the channel) in the conf comment, so the stable and
+# devel confs stay byte-identical (both "release"); CHANNEL_LABEL stays per-channel for
+# the user-facing progress/verify messages only.
 case "$CHANNEL" in
     devel)
-        REPO_NAME="pfblockerng-devel"
-        CONF_NAME="pfblockerng-devel.conf"
+        REPO_NAME="pfblockerng"
+        CONF_NAME="pfblockerng.conf"
+        CONF_LABEL="release"
         PKG_NAME="pfSense-pkg-pfBlockerNG-devel"
         CHANNEL_LABEL="devel"
         URL_SUBPATH=""
@@ -97,6 +109,7 @@ case "$CHANNEL" in
     stable)
         REPO_NAME="pfblockerng"
         CONF_NAME="pfblockerng.conf"
+        CONF_LABEL="release"
         PKG_NAME="pfSense-pkg-pfBlockerNG"
         CHANNEL_LABEL="stable"
         URL_SUBPATH=""
@@ -104,6 +117,7 @@ case "$CHANNEL" in
     nightly)
         REPO_NAME="pfblockerng-nightly"
         CONF_NAME="pfblockerng-nightly.conf"
+        CONF_LABEL="nightly"
         PKG_NAME="pfSense-pkg-pfBlockerNG-nightly"
         CHANNEL_LABEL="nightly"
         URL_SUBPATH="nightly/"
@@ -118,7 +132,7 @@ CONF_PATH="${REPOS_DIR}/${CONF_NAME}"
 print_conf() {
     base="${1%/}"
     cat <<EOF
-# pfBlockerNG (${CHANNEL_LABEL} channel) — self-hosted pkg repository (ADR-17).
+# pfBlockerNG (${CONF_LABEL} channel) — self-hosted pkg repository (ADR-17).
 # NONE-signed: trust anchor is HTTPS to the host (no signing key). The \${ABI}
 # variable is expanded by pkg(8) and follows the box across a pfSense OS upgrade.
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -79,7 +79,7 @@ while [ $# -gt 0 ]; do
         --base-url)     BASE_URL="$2"; shift 2 ;;
         devel|stable|nightly)   CHANNEL="$1"; shift ;;
         -h|--help)
-            sed -n '34,39p' "$0"   # the Usage block from the header
+            sed -n '41,44p' "$0"   # the Usage block from the header
             exit 0 ;;
         -*) echo "add-repo: unknown option: $1" >&2; exit 2 ;;
         *)  echo "add-repo: unknown channel '$1' (expected devel|stable|nightly)" >&2; exit 2 ;;

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -484,12 +484,12 @@ def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) 
 def print_conf(base_url: str) -> None:
     base = base_url.rstrip("/")
     sys.stdout.write(
-        "# pfBlockerNG (devel channel) — self-hosted pkg repository (ADR-17).\n"
+        "# pfBlockerNG (release channel) — self-hosted pkg repository (ADR-17).\n"
         "# NONE-signed: trust anchor is HTTPS to the host (no signing key). The ${ABI}\n"
         "# variable is expanded by pkg(8) and follows the box across a pfSense OS upgrade.\n"
         f"# priority {CONF_PRIORITY} sits above the base Netgate `pfSense` repo so cross-repo\n"
         "# resolution (pkg install/upgrade, GUI Install) selects our build.\n"
-        "pfblockerng-devel: {\n"
+        "pfblockerng: {\n"
         f'  url: "{base}/${{ABI}}",\n'
         "  mirror_type: none,\n"
         "  signature_type: none,\n"

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -116,10 +116,11 @@ META_CONF = (
 # upgrade; priority 100 sits above the base Netgate `pfSense` repo (priority 0) —
 # Phase 1 proved priority dominates version, so this is the precedence lever.
 # The published GitHub Pages base — the repo's standard project Pages URL
-# (gh api repos/.../pages -> html_url https://pfblockerng.github.io/pkg/);
-# we serve over HTTPS, so the base is https://pfblockerng.github.io/pkg. Kept identical
-# to scripts/build-repo.sh DEFAULT_BASE_URL so the two generators stay byte-equal.
-DEFAULT_BASE_URL = "https://pfblockerng.github.io/pkg"
+# The canonical client conf URL is the Cloudflare Worker (ADR-20 Phase 4), which routes
+# by pfSense User-Agent — written once, never needs updating on an OS upgrade. Kept
+# identical to scripts/build-repo.sh / add-repo.sh DEFAULT_BASE_URL so all three
+# generators emit a byte-equal --print-conf.
+DEFAULT_BASE_URL = "https://pkg.pfblockerng.workers.dev"
 CONF_PRIORITY = 100
 
 # A safe single path segment: an ABI is used UNVALIDATED from manifest data as a

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -69,8 +69,9 @@ set -eu
 #                     positive value (add-repo.sh may recompute it live, +100 over the
 #                     effective pfSense priority, the way the Phase-1 smoke does).
 #   * enabled: yes.
-# `pfblockerng-devel` matches the channel-named conf Phase 4 writes
-# (/usr/local/etc/pkg/repos/pfblockerng-devel.conf).
+# `pfblockerng` matches the shared release conf Phase 4 writes
+# (/usr/local/etc/pkg/repos/pfblockerng.conf) — the one repo that carries BOTH the
+# stable and devel packages (Netgate-style); only nightly gets its own conf.
 # The published GitHub Pages base — the repo's standard project Pages URL
 # (gh api repos/.../pages -> html_url https://pfblockerng.github.io/pkg/);
 # we serve over HTTPS, so the base is https://pfblockerng.github.io/pkg and the conf
@@ -82,8 +83,9 @@ set -eu
 # requests to the correct versioned dir based on the pfSense User-Agent.
 # add-repo.sh (Phase 4) writes the Worker URL as the canonical conf URL — written
 # once, never needs updating on a pfSense OS upgrade (Worker re-routes automatically).
-# This --print-conf template is kept in sync with add-repo.sh (byte-identical devel
-# stanza). Override with --base-url for forks/staging.
+# This --print-conf template is kept in sync with add-repo.sh (byte-identical release
+# stanza — what `add-repo.sh stable` and `add-repo.sh devel` both write). Override with
+# --base-url for forks/staging.
 DEFAULT_BASE_URL="https://pkg.pfblockerng.workers.dev"
 CONF_PRIORITY=100
 
@@ -93,12 +95,12 @@ print_conf() {
     # so neither this shell nor the URL-encoding gate sees a live expansion.
     base="$1"
     cat <<EOF
-# pfBlockerNG (devel channel) — self-hosted pkg repository (ADR-17).
+# pfBlockerNG (release channel) — self-hosted pkg repository (ADR-17).
 # NONE-signed: trust anchor is HTTPS to the host (no signing key). The \${ABI}
 # variable is expanded by pkg(8) and follows the box across a pfSense OS upgrade.
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
 # resolution (pkg install/upgrade, GUI Install) selects our build.
-pfblockerng-devel: {
+pfblockerng: {
   url: "${base}/\${ABI}",
   mirror_type: none,
   signature_type: none,

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -30,9 +30,12 @@ from datetime import datetime, timezone
 # Channel identity (mirrors add-repo.sh): package name + one-line blurb, in
 # display order. The channel of a package is read from its name suffix.
 CHANNELS: dict[str, tuple[str, str]] = {
-    "stable": ("pfSense-pkg-pfBlockerNG", "Tagged stable releases."),
-    "devel": ("pfSense-pkg-pfBlockerNG-devel", "The development channel — current devel tree."),
-    "nightly": ("pfSense-pkg-pfBlockerNG-nightly", "Bleeding edge — the devel tip, rebuilt daily."),
+    "stable": ("pfSense-pkg-pfBlockerNG", "Tagged stable releases — from the shared pfblockerng repo."),
+    "devel": (
+        "pfSense-pkg-pfBlockerNG-devel",
+        "The development tree — the same pfblockerng repo as stable; pick the package.",
+    ),
+    "nightly": ("pfSense-pkg-pfBlockerNG-nightly", "Bleeding edge — the devel tip, rebuilt daily (its own repo)."),
 }
 CH_ORDER: list[str] = ["stable", "devel", "nightly"]
 RAW_ADDREPO = "https://raw.githubusercontent.com/pfBlockerNG/pfBlockerNG/devel/scripts/add-repo.sh"
@@ -419,6 +422,10 @@ def render_page(
         "so it sits above the Netgate repo and the stock webConfigurator <strong>Install</strong> button pulls "
         "this build too. Catalogs are NONE-signed (trust anchor = HTTPS to this host) and ABI-keyed, so a box "
         "keeps resolving the right package across a pfSense OS upgrade.</p>"
+        "<p><strong>stable</strong> and <strong>devel</strong> are served from one shared <code>pfblockerng</code> "
+        "repo (one bootstrap exposes both &mdash; just <code>pkg install</code> the package you want, exactly as "
+        "Netgate ships both from its single <code>pfSense</code> repo); <strong>nightly</strong> sits on its own "
+        "catalog path with its own conf.</p>"
         f'<h2>Channels</h2><div class="cards">{cards}</div>'
         f"<h2>Published packages</h2>{_packages_html(pkgs, matrix)}{_older_nightlies_html(pkgs)}"
         "<h2>Catalog trees</h2>"

--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -60,7 +60,7 @@ pytestmark = pytest.mark.repo
 NIGHTLY_NAME = "pfSense-pkg-pfBlockerNG-nightly"
 DEVEL_NAME = "pfSense-pkg-pfBlockerNG-devel"
 NIGHTLY_REPO = "pfblockerng-nightly"  # the %R origin a nightly install reports
-DEVEL_REPO = "pfblockerng-devel"  # the %R origin the controlled -devel install reports
+DEVEL_REPO = "pfblockerng"  # %R origin of the controlled -devel install (the shared release repo)
 
 SPIKE = "/tmp/pfb_nightly_spike"
 NIGHTLY_DIR = f"{SPIKE}/nightly"  # the file:// nightly catalog

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -45,9 +45,10 @@ NOT built here):
     Pages-style HTTP catalog is accepted is Phase 2/3's concern; the premise (does
     pfSense honor a NONE-signed third-party repo for install + precedence) is
     orthogonal to the transport.
-  * A repo conf at `/usr/local/etc/pkg/repos/pfblockerng-devel.conf`
-    (`signature_type: none`, `enabled: yes`, `priority:` above/below the pfSense
-    repo per case), then `pkg update` + `pkg install -y` with NO `-f`.
+  * A repo conf at `/usr/local/etc/pkg/repos/pfblockerng.conf` (the shared release
+    repo `pfblockerng` — stable + devel; `signature_type: none`, `enabled: yes`,
+    `priority:` above/below the pfSense repo per case), then `pkg update` +
+    `pkg install -y` with NO `-f`.
 
 WHAT IS ASSERTED (transition + branch coverage, via EFFECTIVE state — never an
 exit code alone): the package is ABSENT before; AFTER a from-our-repo install it is
@@ -95,16 +96,16 @@ PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"
 
 # Our repo conf on the guest + the served catalog root. The conf name follows the
 # CLAUDE.md "match the surrounding pattern" rule: pfSense's own conf is
-# `pfSense.conf` under the SAME dir; ours is the channel-named sibling Phase 4 will
-# write for real (`add-repo.sh`).
-REPO_CONF = "/usr/local/etc/pkg/repos/pfblockerng-devel.conf"
+# `pfSense.conf` under the SAME dir; ours is the shared release sibling Phase 4 will
+# write for real (`add-repo.sh` — `pfblockerng.conf`, carrying stable + devel).
+REPO_CONF = "/usr/local/etc/pkg/repos/pfblockerng.conf"
 GUEST_SPIKE_DIR = "/tmp/pfb_repo_spike"
 OURS_REPO_DIR = f"{GUEST_SPIKE_DIR}/ours"
 DECOY_REPO_DIR = f"{GUEST_SPIKE_DIR}/decoy"
 # The upgrade test rebuilds ONE repo dir in place (lower build -> higher build) so a
 # `pkg upgrade` moves the box across versions WITHIN our repo (not across repos).
 UPGRADE_REPO_DIR = f"{GUEST_SPIKE_DIR}/upgrade"
-OURS_REPO_NAME = "pfblockerng-devel"  # the %R origin a from-our-repo install reports
+OURS_REPO_NAME = "pfblockerng"  # the %R origin a from-our-repo install reports (shared release repo)
 DECOY_REPO_NAME = "netgate-decoy"  # a controlled file:// stand-in for a competing repo
 NETGATE_REPO_NAME = "pfSense"  # the real base-system Netgate repo (left enabled; loses on priority)
 GUEST_FILE_LIST = f"{GUEST_SPIKE_DIR}/installed_files.txt"
@@ -330,7 +331,7 @@ def run_add_repo_sh(vm: SmokeVM, base_url: str, *, timeout: float = 300.0) -> su
     """Stage the SHIPPED ``scripts/add-repo.sh`` and run it (devel) against ``base_url``.
 
     Drives the real client bootstrap on the box: it writes the production conf to
-    ``/usr/local/etc/pkg/repos/pfblockerng-devel.conf`` (here pointed at a local
+    ``/usr/local/etc/pkg/repos/pfblockerng.conf`` (here pointed at a local
     ``file://`` catalog via the script's own ``--base-url`` override — the github.io
     default and a live HTTPS add-repo.sh run are a post-deploy note), runs ``pkg
     update``, and VERIFIES the package is visible from OUR repo. A non-zero exit (its
@@ -462,7 +463,7 @@ def write_repo_conf(
 ) -> None:
     """Write our NONE-signed repo conf on the guest (ours, plus an optional decoy).
 
-    Declares OUR repo (`pfblockerng-devel`) and — for the precedence cases — a
+    Declares OUR repo (`pfblockerng`) and — for the precedence cases — a
     controlled `file://` `netgate-decoy` repo serving the SAME package, so the
     priority outcome between two genuine providers is deterministic. The base-system
     Netgate repos (`pfSense` / `pfSense-core`) are LEFT ENABLED and untouched (this
@@ -674,7 +675,7 @@ def test_install_from_our_repo_lands_all_files(repo_vm: SmokeVM) -> None:
 
     Given the package ABSENT (``pkg query %v`` fails),
     When ``pkg install -y pfSense-pkg-pfBlockerNG-devel`` runs (NO ``-r``, NO ``-f``),
-    Then it installs from OUR repo (``pkg query %R`` == ``pfblockerng-devel``), with
+    Then it installs from OUR repo (``pkg query %R`` == ``pfblockerng``), with
       no "Missing dependency" (RUN_DEPENDS resolved), AND every file the package
       registers (``pkg info -l``) is present on-box (> 50) — the install really wrote
       the payload. Runtime behaviour is the smoke suite's job, not re-probed here.
@@ -718,11 +719,11 @@ def test_pkg_upgrade_moves_to_our_newer_build(repo_vm: SmokeVM, tmp_path: Path) 
     Given the package ABSENT, and our repo carries ONLY the LOWER build ``<V>_1``,
       When ``pkg install -y`` runs (NO -r, NO -f),
       Then the box is at ``<V>_1`` from OUR repo (``%v`` == ``<V>_1``, ``%R`` ==
-        ``pfblockerng-devel``) — the asserted BEFORE state.
+        ``pfblockerng``) — the asserted BEFORE state.
     When our repo is REBUILT in place with the HIGHER build ``<V>_9``, ``pkg update
       -f`` re-reads the catalog, and ``pkg upgrade -y`` runs,
       Then the box MOVES to ``<V>_9`` from OUR repo (``%v`` == ``<V>_9``, ``%R`` ==
-        ``pfblockerng-devel``) — a real before != after transition, not a final-state
+        ``pfblockerng``) — a real before != after transition, not a final-state
         snapshot. (Runtime behaviour is the smoke suite's job, not re-probed here.)
     """
     pkg = os.environ.get("SMOKE_PKG")
@@ -789,7 +790,7 @@ def test_precedence_ours_higher_priority_wins(repo_vm: SmokeVM) -> None:
 
     Given the package ABSENT and BOTH file:// repos enabled, ours at the HIGHER priority,
     When ``pkg install -y`` resolves across all enabled repos,
-    Then ours wins (``pkg query %R`` == ``pfblockerng-devel``).
+    Then ours wins (``pkg query %R`` == ``pfblockerng``).
     """
     pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
 
@@ -868,7 +869,7 @@ def test_build_repo_script_catalog_is_accepted(repo_vm: SmokeVM) -> None:
       enabled via a NONE-signed ``file://`` repo above the pfSense repo,
     When ``pkg update`` reads it and ``pkg install -y`` runs (NO ``-r``, NO ``-f``),
     Then ``pkg update`` accepts the script-generated catalog AND the install comes
-      from OUR repo (``pkg query %R`` == ``pfblockerng-devel``) with deps resolved —
+      from OUR repo (``pkg query %R`` == ``pfblockerng``) with deps resolved —
       the build tool's output is real and VM-consumable.
     """
     pkg = os.environ.get("SMOKE_PKG")
@@ -911,8 +912,8 @@ def test_shipped_add_repo_sh_bootstrap_installs(repo_vm: SmokeVM) -> None:
     When ``add-repo.sh --base-url file://<root> devel`` runs (writes the conf, ``pkg
       update``, verifies) and then ``pkg install -y`` runs (NO -r, NO -f),
     Then add-repo.sh exits 0 (its own verify found the package in our repo), it wrote
-      the production conf to ``pfblockerng-devel.conf``, and the install comes from
-      OUR repo (``pkg query %R`` == ``pfblockerng-devel``) with deps resolved.
+      the production conf to ``pfblockerng.conf``, and the install comes from
+      OUR repo (``pkg query %R`` == ``pfblockerng``) with deps resolved.
     """
     pkg = os.environ.get("SMOKE_PKG")
     assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
@@ -928,7 +929,7 @@ def test_shipped_add_repo_sh_bootstrap_installs(repo_vm: SmokeVM) -> None:
     proc = run_add_repo_sh(repo_vm, f"file://{SCRIPT_REPO_ROOT}")
 
     # THEN: add-repo.sh wrote the production conf and its verify confirmed our package.
-    assert "available from 'pfblockerng-devel'" in proc.stdout, (
+    assert "available from 'pfblockerng'" in proc.stdout, (
         f"add-repo.sh did not report the package from our repo:\n{proc.stdout}"
     )
     conf_present = repo_vm.ssh("/bin/test", "-f", REPO_CONF)
@@ -962,7 +963,7 @@ def test_portable_catalog_is_accepted(repo_vm: SmokeVM, tmp_path: Path) -> None:
     When ``pkg update`` reads the pure-Python catalog and ``pkg install -y`` runs
       (NO ``-r``, NO ``-f``),
     Then ``pkg update`` accepts it AND the install comes from OUR repo
-      (``pkg query %R`` == ``pfblockerng-devel``) with deps resolved and the ``.pkg``
+      (``pkg query %R`` == ``pfblockerng``) with deps resolved and the ``.pkg``
       checksum validated — the pure-Python generator's output is real + VM-consumable.
     """
     pkg = os.environ.get("SMOKE_PKG")
@@ -1164,7 +1165,7 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     When ``pkg update`` reads the live catalog and ``pkg install -y`` runs (NO ``-r``,
       NO ``-f``),
     Then ``pkg update`` accepts the deployed catalog AND the install comes from OUR
-      repo (``pkg query %R`` == ``pfblockerng-devel``) with deps resolved and the .pkg
+      repo (``pkg query %R`` == ``pfblockerng``) with deps resolved and the .pkg
       checksum validated — the deployed Pages repo is real + installable over HTTPS.
     """
     base_url = _live_base_url()
@@ -1644,9 +1645,9 @@ def test_routing_url_delivers_ce_catalog(repo_vm: SmokeVM) -> None:
       Background: conf with url: https://pkg.pfblockerng.workers.dev.
 
     Given a CE VM with the conf pointing at the Worker URL (``${ABI}`` suffix added
-      by pkg), ``pkg update -r pfblockerng-devel`` fetches from the Worker.
+      by pkg), ``pkg update -r pfblockerng`` fetches from the Worker.
     Then the fetched catalog contains the CE package (not Plus) — confirmed by
-      ``pkg rquery -r pfblockerng-devel '%dn %dv' <pkgname>`` showing ``php83`` dep.
+      ``pkg rquery -r pfblockerng '%dn %dv' <pkgname>`` showing ``php83`` dep.
 
     XFAIL: the Cloudflare Worker is live but routing.json has not yet been deployed
     to Pages (Phase 5 RESULTS: Worker returns 502 when routing.json absent).  Once

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -86,21 +86,24 @@ def _field(conf: str, key: str) -> str:
 # --------------------------------------------------------------------------- #
 
 
-def test_add_repo_devel_conf_is_byte_identical_to_build_repo() -> None:
-    """The devel conf from add-repo.sh == build-repo.sh --print-conf, byte-for-byte.
+def test_release_conf_byte_identical_across_stable_devel_and_build_repo() -> None:
+    """stable and devel emit the SAME release conf, == build-repo.sh --print-conf.
 
-    build-repo.sh --print-conf is the published single source (Phase 2/3). If
-    add-repo.sh's devel stanza diverges by even a byte (url, priority, comment),
-    the client would write a conf that disagrees with what CI publishes — this
-    pins them together.
+    The stable and devel packages share ONE repo/catalog (`pfblockerng`, Netgate-style),
+    so `add-repo.sh stable` and `add-repo.sh devel` must write byte-identical confs — and
+    both must match build-repo.sh --print-conf, the published single source (Phase 2/3).
+    A one-byte divergence (url, priority, repo name, comment) would split what is meant to
+    be one repo, so this pins all three generators together.
     """
-    add = _print_conf(_ADD_REPO, "devel")
+    stable = _print_conf(_ADD_REPO, "stable")
+    devel = _print_conf(_ADD_REPO, "devel")
     build = _print_conf(_BUILD_REPO)
-    assert add == build
+    assert stable == devel  # collapsed: stable + devel are one shared `pfblockerng` repo
+    assert stable == build  # == the published single-source template
 
 
-def test_add_repo_devel_conf_default_channel_matches_explicit() -> None:
-    """No channel arg defaults to devel (the documented default)."""
+def test_add_repo_default_channel_matches_devel() -> None:
+    """No channel arg defaults to devel (the documented default; the release conf)."""
     assert _print_conf(_ADD_REPO) == _print_conf(_ADD_REPO, "devel")
 
 
@@ -112,7 +115,8 @@ def test_add_repo_devel_conf_default_channel_matches_explicit() -> None:
 @pytest.mark.parametrize(
     ("channel", "repo_name", "url"),
     [
-        ("devel", "pfblockerng-devel", f'url: "{_WORKER_URL}/${{ABI}}"'),
+        # stable + devel collapse onto the ONE shared `pfblockerng` release repo.
+        ("devel", "pfblockerng", f'url: "{_WORKER_URL}/${{ABI}}"'),
         ("stable", "pfblockerng", f'url: "{_WORKER_URL}/${{ABI}}"'),
         # nightly is served from a DISTINCT `nightly/` catalog subtree (so it never
         # collides with the release tree on Pages) — its url carries the extra path.
@@ -120,21 +124,20 @@ def test_add_repo_devel_conf_default_channel_matches_explicit() -> None:
     ],
 )
 def test_add_repo_conf_fields_per_channel(channel: str, repo_name: str, url: str) -> None:
-    """Each channel names its repo distinctly but shares the precedence-bearing fields.
+    """stable/devel name the shared release repo; nightly its own — all share the rest.
 
-    devel -> `pfblockerng-devel`; stable -> `pfblockerng`; nightly ->
-    `pfblockerng-nightly` (and a `nightly/${ABI}` url subtree). All carry priority 100
-    (above Netgate's 0) and none/none (NONE-signed). The repo NAME (and, for nightly,
-    the url subpath) is the only channel-varying field — a conf that reused another
-    channel's repo name would collide on a box.
+    stable + devel -> `pfblockerng` (one shared repo); nightly -> `pfblockerng-nightly`
+    (and a `nightly/${ABI}` url subtree). All carry priority 100 (above Netgate's 0) and
+    none/none (NONE-signed). The repo NAME (and, for nightly, the url subpath) is the only
+    varying field — and nightly's name must never collide with the release repo on a box.
     """
     conf = _print_conf(_ADD_REPO, channel)
 
-    # The stanza is keyed by the channel-specific repo name (and ONLY that name).
+    # The stanza is keyed by the expected repo name (and ONLY that name).
     assert re.search(rf"^{re.escape(repo_name)}:\s*\{{", conf, re.MULTILINE), conf
-    # No OTHER channel's repo name appears as a stanza key (each conf names exactly one;
-    # the anchored `:` keeps `pfblockerng:` from matching `pfblockerng-devel:` etc.).
-    for other in {"pfblockerng", "pfblockerng-devel", "pfblockerng-nightly"} - {repo_name}:
+    # The OTHER repo name does not appear as a stanza key (the anchored `:` keeps
+    # `pfblockerng:` from matching `pfblockerng-nightly:`).
+    for other in {"pfblockerng", "pfblockerng-nightly"} - {repo_name}:
         assert not re.search(rf"^{re.escape(other)}:\s*\{{", conf, re.MULTILINE), conf
 
     # The literal ${ABI} survives (single-quoted on emission — pkg expands it, not the shell).
@@ -180,12 +183,12 @@ def test_primary_url_is_worker_url() -> None:
     (confirmed absent here — fresh tmpdir).
     """
     with tempfile.TemporaryDirectory() as root:
-        conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng-devel.conf"
+        conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng.conf"
 
         # Given: conf does not exist yet (before-state)
         assert not conf_path.exists(), "conf should not exist before first run"
 
-        # When: run add-repo.sh devel
+        # When: run add-repo.sh devel (writes the shared release conf)
         _run_add_repo("devel", root)
 
         # Then: conf written with Worker URL
@@ -234,7 +237,7 @@ def test_conf_written_once_invariant() -> None:
     Then  the URL is unchanged — the conf is rewritten with the same Worker URL.
     """
     with tempfile.TemporaryDirectory() as root:
-        conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng-devel.conf"
+        conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng.conf"
 
         # Given: first run writes the conf
         _run_add_repo("devel", root)
@@ -250,3 +253,33 @@ def test_conf_written_once_invariant() -> None:
         assert content_first == content_second, (
             f"Second run must produce identical conf (idempotent):\nFirst:\n{content_first}\nSecond:\n{content_second}"
         )
+
+
+def test_stable_and_devel_collapse_onto_one_shared_conf_file() -> None:
+    """stable and devel write the SAME on-box file — no separate per-channel conf.
+
+    Scenario: the stable + devel packages share one repo, so both channels target
+              /usr/local/etc/pkg/repos/pfblockerng.conf (never a `pfblockerng-devel.conf`).
+    Given stable is bootstrapped first (writes the shared release conf),
+    When  devel is bootstrapped into the same root,
+    Then  it rewrites the SAME file with identical bytes, and no `pfblockerng-devel.conf`
+          is ever created — proving the collapse (a regression that re-split the channels
+          would leave two distinct files here).
+    """
+    with tempfile.TemporaryDirectory() as root:
+        repos = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos"
+        shared = repos / "pfblockerng.conf"
+        legacy_split = repos / "pfblockerng-devel.conf"
+
+        # Given: stable writes the shared release conf (before-state)
+        _run_add_repo("stable", root)
+        assert shared.exists(), "stable must write the shared pfblockerng.conf"
+        stable_bytes = shared.read_text()
+        assert not legacy_split.exists(), "stable must not write a split pfblockerng-devel.conf"
+
+        # When: devel is bootstrapped into the same root
+        _run_add_repo("devel", root)
+
+        # Then: same file, identical bytes, and still no split conf
+        assert shared.read_text() == stable_bytes, "devel must rewrite the SAME shared conf, byte-identical"
+        assert not legacy_split.exists(), "devel must NOT create a separate pfblockerng-devel.conf"

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -30,9 +31,21 @@ import pytest
 _SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
 _ADD_REPO = _SCRIPTS / "add-repo.sh"
 _BUILD_REPO = _SCRIPTS / "build-repo.sh"
+_BUILD_REPO_PORTABLE = _SCRIPTS / "build-repo-portable.py"
 
 _WORKER_URL = "https://pkg.pfblockerng.workers.dev"
 _OLD_PAGES_URL = "https://pfblockerng.github.io/pkg"
+
+
+def _print_conf_portable() -> str:
+    """Run `build-repo-portable.py --print-conf` (the Python generator) and return stdout."""
+    proc = subprocess.run(
+        [sys.executable, str(_BUILD_REPO_PORTABLE), "--print-conf"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
 
 
 def _print_conf(script: Path, *args: str) -> str:
@@ -98,8 +111,10 @@ def test_release_conf_byte_identical_across_stable_devel_and_build_repo() -> Non
     stable = _print_conf(_ADD_REPO, "stable")
     devel = _print_conf(_ADD_REPO, "devel")
     build = _print_conf(_BUILD_REPO)
+    portable = _print_conf_portable()
     assert stable == devel  # collapsed: stable + devel are one shared `pfblockerng` repo
-    assert stable == build  # == the published single-source template
+    assert stable == build  # == the published single-source template (build-repo.sh)
+    assert stable == portable  # == the portable Python generator — all THREE byte-equal
 
 
 def test_add_repo_default_channel_matches_devel() -> None:

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -507,7 +507,7 @@ def test_print_conf_matches_template(capsys: pytest.CaptureFixture[str]) -> None
     assert rc == 0
     out = capsys.readouterr().out
     assert "pfblockerng: {" in out  # the shared release repo (stable + devel)
-    assert 'url: "https://pfblockerng.github.io/pkg/${ABI}"' in out
+    assert 'url: "https://pkg.pfblockerng.workers.dev/${ABI}"' in out  # canonical Worker URL (ADR-20)
     assert "signature_type: none," in out
     assert "priority: 100," in out
     assert "enabled: yes" in out

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -506,7 +506,7 @@ def test_print_conf_matches_template(capsys: pytest.CaptureFixture[str]) -> None
     rc = brp.main(["--print-conf"])
     assert rc == 0
     out = capsys.readouterr().out
-    assert "pfblockerng-devel: {" in out
+    assert "pfblockerng: {" in out  # the shared release repo (stable + devel)
     assert 'url: "https://pfblockerng.github.io/pkg/${ABI}"' in out
     assert "signature_type: none," in out
     assert "priority: 100," in out


### PR DESCRIPTION
## What

The **stable** and **devel** packages live in one catalog (Netgate-style: pfSense ships `pfSense-pkg-pfBlockerNG` and `-devel` from its single `pfSense` repo; the two conflict — install one). Our client bootstrap, though, wrote **two** confs — `pfblockerng-devel.conf` and `pfblockerng.conf` — naming two repos at the **identical** url. That split one repo in two, and (run for both channels) made `pkg` fetch the same catalog twice under two names.

This collapses them:

- `add-repo.sh devel` and `add-repo.sh stable` now both write the shared `/usr/local/etc/pkg/repos/pfblockerng.conf` (repo `pfblockerng`); only the verify target + install hint differ by channel.
- **nightly** keeps its own conf — it's a distinct `nightly/` catalog path.
- The release conf is **byte-identical** for stable/devel across all three generators (`add-repo.sh`, `build-repo.sh`, `build-repo-portable.py`), pinned by the drift test.

## Why

`devel` and `stable` already pointed at the same URL (`URL_SUBPATH=""` for both) — the only difference was the repo stanza name. Two repo names at one URL is redundant at best and double-fetches at worst. The catalog generator already buckets by ABI/version, never by stable-vs-devel, so one repo is the faithful model.

## Tests

- `test_release_conf_byte_identical_across_stable_devel_and_build_repo` — stable == devel == `build-repo.sh --print-conf`.
- `test_stable_and_devel_collapse_onto_one_shared_conf_file` — both channels write the same `pfblockerng.conf`; no `pfblockerng-devel.conf` is ever created (before/after asserted).
- Updated per-channel field + portable-gen drift tests; updated the repo-install / nightly-install smoke repo-origin constants to the new `pfblockerng` name.

Full suite green (1553 passed); shellcheck / ruff / markdownlint / url-encoding gate clean.

## Docs + page

README, CLAUDE.md, the `gen_landing.py` landing page (intro + channel blurbs), and the `pfBlockerNG/pkg` README all updated to describe the single shared repo. Paired pkg-repo README PR: pfBlockerNG/pkg.

ADR text (ADR-17/18/20) left as historical record; this supersedes their per-channel-conf detail.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosted pkg repository docs and README to clarify stable and development now share a single `pfblockerng` repo/config, while nightly uses a separate nightly config/catalog path.
  * Refreshed landing page wording to match the revised channel-to-repo organization.

* **Tests**
  * Updated smoke and repo-install tests to expect the shared `pfblockerng` repo identity and config file for stable/devel.
  * Enhanced add-repo configuration tests to ensure stable and devel generate identical shared conf output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->