### PR TITLE
docs(adr): amend ADR-17/19/20 for the shared pfblockerng repo collapse

### DIFF
--- a/.ADRs/ADR_17_Pkg_Repository/ADR.md
+++ b/.ADRs/ADR_17_Pkg_Repository/ADR.md
@@ -1,5 +1,14 @@
 # ADR-17: Self-hosted pfSense `pkg` repository on GitHub Pages
 
+> **Amendment (2026-06-14, PR #216):** The client bootstrap no longer writes a separate
+> `pfblockerng-devel.conf` / `pfblockerng-devel` repo. `scripts/add-repo.sh` now writes a
+> single shared `/usr/local/etc/pkg/repos/pfblockerng.conf` (repo `pfblockerng`) for **both**
+> the stable and devel packages — Netgate-style, one catalog carrying both (they conflict;
+> install one) — superseding the `pfblockerng-devel.conf` references throughout this record.
+> Only `nightly` keeps its own conf (`pfblockerng-nightly.conf`, ADR-18). `build-repo.sh` and
+> `build-repo-portable.py` `--print-conf` emit the same `pfblockerng` stanza. The historical
+> `RESULTS/*.txt` logs predate this and still name `pfblockerng-devel` as observed at the time.
+
 - **Status:** **Accepted** (2026-06-06; implemented 2026-06-05). The §7 affected-flow smoke
   (install / cross-repo precedence / `pkg upgrade`) is **GREEN on the live VM**, and the
   public Pages deploy is **live + verified**: `repo-publish.yml` (dispatched on `devel`)

--- a/.ADRs/ADR_19_Update_Channel_Panel/ADR.md
+++ b/.ADRs/ADR_19_Update_Channel_Panel/ADR.md
@@ -1,5 +1,13 @@
 # ADR-19: A pfBlockerNG-owned "Software" update/channel panel + new-version notice
 
+> **Amendment (2026-06-14, PR #216):** This (Proposed) design below assumes the per-channel
+> conf section name is unchanged — `pfblockerng-devel` for devel, `pfblockerng` for stable.
+> That no longer holds: `scripts/add-repo.sh` now writes ONE shared `pfblockerng` repo
+> (`pfblockerng.conf`) for **both** stable and devel; only `nightly` is separate
+> (`pfblockerng-nightly`). When this ADR is implemented, `pfb_pkg_repo_name_for_channel()`
+> must map **both** stable and devel to `pfblockerng` (the channel selects the *package* —
+> `pfSense-pkg-pfBlockerNG` vs `-devel` — not a per-channel repo name).
+
 - **Status:** **Proposed** (2026-06-06)
 - **Date:** 2026-06-06
 - **Branch:** `adr/19-update-channel-panel` (off **`devel`**; `{slug}` = sanitised

--- a/.ADRs/ADR_20_CE_Plus_Variant_Distribution/ADR.md
+++ b/.ADRs/ADR_20_CE_Plus_Variant_Distribution/ADR.md
@@ -1,5 +1,11 @@
 # ADR-20: CE/Plus variant-aware pkg distribution
 
+> **Amendment (2026-06-14, PR #216):** `add-repo.sh devel` and `add-repo.sh stable` now both
+> write the shared `/usr/local/etc/pkg/repos/pfblockerng.conf` (repo `pfblockerng`) — one
+> catalog carrying both packages, Netgate-style — superseding the `pfblockerng-devel.conf`
+> references below; only `nightly` keeps its own conf. The single-Worker-URL decision (one
+> conf, written once, User-Agent routing) is unchanged — only the repo/conf **name** collapsed.
+
 - **Status:** **Accepted** (2026-06-10)
 - **Date:** 2026-06-09
 - **Branch:** `adr/20-ce-plus-variant-distribution` (off **`devel`**; `{slug}` =


### PR DESCRIPTION
Docs-only (ADR text, CI-skipped). Amends the living decision records to reflect the shared-`pfblockerng`-repo collapse landed in #216:

- **ADR-17** — the client bootstrap writes one shared `pfblockerng.conf` (repo `pfblockerng`) for both stable and devel; `pfblockerng-devel.conf` no longer exists.
- **ADR-19** (Proposed) — its "conf section name unchanged" assumption no longer holds; `pfb_pkg_repo_name_for_channel()` must map both stable and devel to `pfblockerng` when implemented.
- **ADR-20** — `add-repo.sh devel`/`stable` both write the shared conf; the single-Worker-URL decision is unchanged, only the name collapsed.

Each amendment is a dated blockquote after the title. Historical `RESULTS/*.txt` and phase `.txt` logs are left intact — they were accurate when recorded; rewriting them would falsify the execution log.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture decision records to clarify repository configuration simplification. Repository setup now uses a single shared configuration for both stable and development packages, with nightly remaining separate. Documentation reflects updates to repository management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->