### PR TITLE
pkg-repo: flag-based add-repo channel + unified landing cards + casing fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -620,10 +620,11 @@ update badge stay Netgate-bound; a GUI "Updates/Channel" panel is deferred (woul
   (`scripts/build-repo.sh`) is retained as a script only.
 - **Generators + bootstrap:** `scripts/build-repo-portable.py` (primary catalog gen),
   `scripts/build-repo.sh` (fallback + the single `--print-conf` conf template),
-  `scripts/add-repo.sh` (client bootstrap — `devel|stable|nightly` channel arg, `priority: 100`,
-  `pkg update` + verify). `devel`/`stable` write the SAME shared release conf
-  `/usr/local/etc/pkg/repos/pfblockerng.conf` (repo `pfblockerng` carries BOTH packages,
-  Netgate-style); only `nightly` gets its own `pfblockerng-nightly.conf`. The
+  `scripts/add-repo.sh` (client bootstrap — channel is a FLAG: no-arg = release repo,
+  `--nightly` = nightly repo; `priority: 100`, `pkg update` + verify). The default writes the
+  shared release conf `/usr/local/etc/pkg/repos/pfblockerng.conf` (repo `pfblockerng` carries
+  BOTH the stable and devel packages, Netgate-style — pick the package at install time); only
+  `--nightly` writes its own `pfblockerng-nightly.conf`. The
   emitted conf is byte-identical across all three (drift-pinned in
   `tests/test_add_repo_conf.py` + `tests/test_build_repo_portable.py`).
 - **Repo smoke flow:** `tests/smoke/test_repo_install.py` carries its **own marker `repo`**

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ pfblockerng: {
   resolution (and the webConfigurator's **Install** button) picks our build.
 
 > **Transition note (ADR-20):** If you configured the repo before 2026-06-10, re-run
-> `sh scripts/add-repo.sh devel` (or `stable`) to refresh the conf to the Worker URL.
+> `sh scripts/add-repo.sh` (or `sh scripts/add-repo.sh --nightly` for the nightly repo) to
+> refresh the conf to the Worker URL.
 > The legacy `pfblockerng.github.io/pkg/${ABI}/` path continues to serve CE packages
 > during the transition window.
 > Installs and updates work via the **Install** button or `pkg upgrade`,
@@ -133,13 +134,14 @@ channel — a distinct package `pfSense-pkg-pfBlockerNG-nightly` served from a
 `nightly/` catalog subtree:
 
 ```sh
-./scripts/add-repo.sh nightly
+./scripts/add-repo.sh --nightly
 pkg install pfSense-pkg-pfBlockerNG-nightly
 ```
 
 It **conflicts with the stable and `-devel` packages** (they install the same files),
-so it replaces whichever you had; switch back any time with `./scripts/add-repo.sh devel`
-(or `stable`) and `pkg install` the release package. Nightly versions order as
+so it replaces whichever you had; switch back any time with `./scripts/add-repo.sh`
+and `pkg install` the release package you want (`pfSense-pkg-pfBlockerNG` or `-devel`).
+Nightly versions order as
 `<target>.YYYYMMDD.N`, so `pkg upgrade` always moves to the newest build, and the
 source commit rides the package — `pkg info -A pfSense-pkg-pfBlockerNG-nightly` shows it.
 The **last 14 builds** are kept, so you can roll back by installing an older version

--- a/README.md
+++ b/README.md
@@ -86,15 +86,17 @@ catalog — add our self-hosted FreeBSD `pkg` repository
 normally (no `pkg add -f`). Run the bootstrap **on the firewall** over SSH, then install:
 
 ```sh
-./scripts/add-repo.sh devel        # or: stable — both set up the same `pfblockerng` repo
-pkg install pfSense-pkg-pfBlockerNG-devel
+./scripts/add-repo.sh                       # adds the shared `pfblockerng` repo (stable + devel)
+pkg install pfSense-pkg-pfBlockerNG-devel    # or: pfSense-pkg-pfBlockerNG (stable)
 ```
 
-`add-repo.sh devel` and `add-repo.sh stable` both write the shared
-`/usr/local/etc/pkg/repos/pfblockerng.conf` (only **nightly** gets its own
-`pfblockerng-nightly.conf`), run `pkg update`, and verify the package is visible. No
-variant argument is needed — the script auto-detects CE vs Plus via the routing layer.
-The configuration it writes is:
+`add-repo.sh` with no argument writes the shared
+`/usr/local/etc/pkg/repos/pfblockerng.conf` (which carries **both** the stable and devel
+packages — pick one at `pkg install`), runs `pkg update`, and verifies a package is
+visible. The **nightly** repo is opt-in — `./scripts/add-repo.sh --nightly` writes its
+own `pfblockerng-nightly.conf` (bleeding edge, not for daily use). No variant argument is
+needed — the script auto-detects CE vs Plus via the routing layer. The configuration the
+default run writes is:
 
 ```sh
 pfblockerng: {

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -8,18 +8,20 @@
 # pulls it too via cross-repo resolution (ADR §2; install is not repo-locked).
 #
 # CHANNELS
-#   The stable and devel packages share ONE repo/catalog — the `pfblockerng` repo,
-#   exactly like Netgate ships `pfSense-pkg-pfBlockerNG` and `-devel` from its single
-#   `pfSense` repo (the two packages CONFLICT — install one). So `stable` and `devel`
-#   write the SAME conf (byte-identical); they differ only in which package the verify
-#   step checks + the install hint printed. Nightly lives on its own catalog path and
-#   so needs its own conf.
-#   devel  (default) -> conf /usr/local/etc/pkg/repos/pfblockerng.conf
-#                       repo name `pfblockerng`,       pkg pfSense-pkg-pfBlockerNG-devel
-#   stable           -> conf /usr/local/etc/pkg/repos/pfblockerng.conf  (SAME file)
-#                       repo name `pfblockerng`,       pkg pfSense-pkg-pfBlockerNG
-#   nightly          -> conf /usr/local/etc/pkg/repos/pfblockerng-nightly.conf
-#                       repo name `pfblockerng-nightly`, pkg ...-nightly (bleeding edge)
+#   Default (NO argument) sets up the RELEASE repo `pfblockerng` — one shared catalog
+#   carrying BOTH the stable and devel packages, exactly like Netgate ships
+#   `pfSense-pkg-pfBlockerNG` and `-devel` from its single `pfSense` repo (the two
+#   packages CONFLICT — install one). After the bootstrap, pick the package:
+#       pkg install pfSense-pkg-pfBlockerNG          # stable
+#       pkg install pfSense-pkg-pfBlockerNG-devel    # development tree
+#
+#   --nightly sets up the SEPARATE `pfblockerng-nightly` repo instead (its own
+#   `nightly/` catalog path). Bleeding edge — NOT for daily use: the only guarantee is
+#   that CI passed (devel still carries a stability target; nightly does not):
+#       pkg install pfSense-pkg-pfBlockerNG-nightly
+#
+#   default     -> conf /usr/local/etc/pkg/repos/pfblockerng.conf,         repo `pfblockerng`
+#   --nightly   -> conf /usr/local/etc/pkg/repos/pfblockerng-nightly.conf, repo `pfblockerng-nightly`
 #
 # THE CONF (single source of truth — matches `build-repo.sh --print-conf`):
 #   url:            Cloudflare Worker URL (ADR-20). The Worker routes requests to
@@ -39,9 +41,10 @@
 # IDEMPOTENT: re-running rewrites the conf (safe to run again at any time).
 #
 # Usage:
-#   add-repo.sh [devel|stable|nightly]      # write the conf, pkg update, verify (default: devel)
-#   add-repo.sh --print-conf [devel|stable|nightly]   # print the conf to stdout and exit (no writes)
-#   add-repo.sh --base-url <url> [devel|stable|nightly]   # override the base (forks/staging)
+#   add-repo.sh                       # set up the release repo (stable + devel), pkg update, verify
+#   add-repo.sh --nightly             # set up the nightly repo instead (bleeding edge)
+#   add-repo.sh --print-conf [--nightly]       # print the conf to stdout and exit (no writes)
+#   add-repo.sh --base-url <url> [--nightly]   # override the catalog base (forks/staging)
 #
 # POSIX sh; quoted expansions; absolute path for the privileged `pkg` binary.
 # Env:
@@ -68,59 +71,61 @@ REPOS_DIR="${PFBLOCKERNG_ROOT%/}/usr/local/etc/pkg/repos"
 DEFAULT_BASE_URL="https://pkg.pfblockerng.workers.dev"
 CONF_PRIORITY=100
 
-CHANNEL="devel"
+CHANNEL="release"
 PRINT_CONF=0
 BASE_URL="$DEFAULT_BASE_URL"
 
+usage() {
+    cat <<'USAGE'
+add-repo.sh — bootstrap pfBlockerNG's self-hosted pkg repository (run ON the pfSense box).
+
+Usage:
+  add-repo.sh                                set up the release repo (stable + devel), pkg update, verify
+  add-repo.sh --nightly                      set up the nightly repo instead (bleeding edge; not for daily use)
+  add-repo.sh --print-conf [--nightly]       print the repo conf to stdout and exit (no writes)
+  add-repo.sh --base-url <url> [--nightly]   override the catalog base (forks/staging)
+
+After the release bootstrap, install ONE of (the packages conflict):
+  pkg install pfSense-pkg-pfBlockerNG          # stable
+  pkg install pfSense-pkg-pfBlockerNG-devel    # development tree
+USAGE
+}
+
 # ── Arg parsing ────────────────────────────────────────────────────────────────
+# The channel is a FLAG, not a positional: default is the release repo; --nightly
+# selects the separate nightly repo. (There is no stable/devel switch — both live in
+# the one release repo; you pick the package at `pkg install` time.)
 while [ $# -gt 0 ]; do
     case "$1" in
+        --nightly)      CHANNEL="nightly"; shift ;;
         --print-conf)   PRINT_CONF=1; shift ;;
         --base-url)     BASE_URL="$2"; shift 2 ;;
-        devel|stable|nightly)   CHANNEL="$1"; shift ;;
-        -h|--help)
-            sed -n '41,44p' "$0"   # the Usage block from the header
-            exit 0 ;;
-        -*) echo "add-repo: unknown option: $1" >&2; exit 2 ;;
-        *)  echo "add-repo: unknown channel '$1' (expected devel|stable|nightly)" >&2; exit 2 ;;
+        -h|--help)      usage; exit 0 ;;
+        -*) echo "add-repo: unknown option: $1 (see --help)" >&2; exit 2 ;;
+        *)  echo "add-repo: unexpected argument '$1' — the channel is a flag (--nightly); the release repo is the default. See --help." >&2; exit 2 ;;
     esac
 done
 
 # ── Per-channel identity ───────────────────────────────────────────────────────
-# devel  -> repo `pfblockerng`,         conf pfblockerng.conf,         pkg ...-devel
-# stable -> repo `pfblockerng`,         conf pfblockerng.conf,         pkg pfSense-pkg-pfBlockerNG
-# nightly-> repo `pfblockerng-nightly`, conf pfblockerng-nightly.conf, pkg ...-nightly
-# stable + devel deliberately resolve to the SAME repo/conf (one shared `pfblockerng`
-# catalog carries both packages); only PKG_NAME (verify target + install hint) differs.
-# URL_SUBPATH: nightly is served from the `nightly/` catalog subtree; the release
-# channels from the Pages root. The literal ${ABI} pkg(8) variable follows it.
-# CONF_LABEL names the REPO (not the channel) in the conf comment, so the stable and
-# devel confs stay byte-identical (both "release"); CHANNEL_LABEL stays per-channel for
-# the user-facing progress/verify messages only.
+# release (default) -> repo `pfblockerng`,        conf pfblockerng.conf,        Pages root
+#                      carries BOTH pfSense-pkg-pfBlockerNG (stable) and ...-devel
+# nightly           -> repo `pfblockerng-nightly`, conf pfblockerng-nightly.conf, `nightly/` subtree
+# URL_SUBPATH: nightly is served from the `nightly/` catalog subtree; the release repo
+# from the Pages root. The literal ${ABI} pkg(8) variable follows it.
+# PKG_NAMES: the package(s) the verify step checks + the install hints printed (the
+# release repo carries two; nightly one).
 case "$CHANNEL" in
-    devel)
+    release)
         REPO_NAME="pfblockerng"
         CONF_NAME="pfblockerng.conf"
-        CONF_LABEL="release"
-        PKG_NAME="pfSense-pkg-pfBlockerNG-devel"
-        CHANNEL_LABEL="devel"
         URL_SUBPATH=""
-        ;;
-    stable)
-        REPO_NAME="pfblockerng"
-        CONF_NAME="pfblockerng.conf"
-        CONF_LABEL="release"
-        PKG_NAME="pfSense-pkg-pfBlockerNG"
-        CHANNEL_LABEL="stable"
-        URL_SUBPATH=""
+        PKG_NAMES="pfSense-pkg-pfBlockerNG pfSense-pkg-pfBlockerNG-devel"
         ;;
     nightly)
         REPO_NAME="pfblockerng-nightly"
         CONF_NAME="pfblockerng-nightly.conf"
-        CONF_LABEL="nightly"
-        PKG_NAME="pfSense-pkg-pfBlockerNG-nightly"
-        CHANNEL_LABEL="nightly"
         URL_SUBPATH="nightly/"
+        PKG_NAMES="pfSense-pkg-pfBlockerNG-nightly"
         ;;
 esac
 CONF_PATH="${REPOS_DIR}/${CONF_NAME}"
@@ -132,7 +137,7 @@ CONF_PATH="${REPOS_DIR}/${CONF_NAME}"
 print_conf() {
     base="${1%/}"
     cat <<EOF
-# pfBlockerNG (${CONF_LABEL} channel) — self-hosted pkg repository (ADR-17).
+# pfBlockerNG (${CHANNEL} channel) — self-hosted pkg repository (ADR-17).
 # NONE-signed: trust anchor is HTTPS to the host (no signing key). The \${ABI}
 # variable is expanded by pkg(8) and follows the box across a pfSense OS upgrade.
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
@@ -159,7 +164,7 @@ command -v "$PKG_BIN" >/dev/null 2>&1 || {
     exit 1
 }
 
-echo "==> Writing ${CHANNEL_LABEL} repo conf to ${CONF_PATH}"
+echo "==> Writing ${CHANNEL} repo conf to ${CONF_PATH}"
 mkdir -p "$REPOS_DIR"
 # Rewrite unconditionally => idempotent (a re-run refreshes the conf in place).
 print_conf "$BASE_URL" > "$CONF_PATH"
@@ -167,19 +172,28 @@ print_conf "$BASE_URL" > "$CONF_PATH"
 echo "==> pkg update (refreshing catalogs, including our repo)"
 env ASSUME_ALWAYS_YES=yes "$PKG_BIN" update -f >/dev/null
 
-# VERIFY our package is visible FROM OUR repo (not merely that pkg update ran).
-# `pkg rquery -r <repo>` queries that ONE repo's catalog; a hit means our catalog
-# loaded and carries the package. Exit non-zero (fail loud) if it is absent.
-echo "==> Verifying ${PKG_NAME} is visible from repo '${REPO_NAME}'"
-if "$PKG_BIN" rquery -r "$REPO_NAME" '%n %v' "$PKG_NAME" 2>/dev/null | grep -q .; then
-    found="$("$PKG_BIN" rquery -r "$REPO_NAME" '%n-%v' "$PKG_NAME" 2>/dev/null | head -n1)"
-    echo "==> OK: ${found} available from '${REPO_NAME}' (${CONF_PATH})"
-    echo "    Install:  ${PKG_BIN} install ${PKG_NAME}"
-    echo "    Upgrade:  ${PKG_BIN} upgrade ${PKG_NAME}"
-else
-    echo "add-repo: ${PKG_NAME} is NOT visible from repo '${REPO_NAME}' after pkg update." >&2
+# VERIFY a pfBlockerNG package is visible FROM OUR repo (not merely that pkg update
+# ran). `pkg rquery -r <repo>` queries that ONE repo's catalog; a hit means our catalog
+# loaded and carries the package. The release repo carries two packages (stable may not
+# be published yet) — finding EITHER proves the repo loaded; nightly carries one. Exit
+# non-zero (fail loud) only if NONE is present.
+echo "==> Verifying pfBlockerNG package(s) are visible from repo '${REPO_NAME}'"
+found_any=0
+# Word-splitting the space-separated package list is intentional.
+# shellcheck disable=SC2086
+for pkg_name in $PKG_NAMES; do
+    if "$PKG_BIN" rquery -r "$REPO_NAME" '%n %v' "$pkg_name" 2>/dev/null | grep -q .; then
+        found="$("$PKG_BIN" rquery -r "$REPO_NAME" '%n-%v' "$pkg_name" 2>/dev/null | head -n1)"
+        echo "==> OK: ${found} available from '${REPO_NAME}'"
+        echo "    Install:  ${PKG_BIN} install ${pkg_name}"
+        found_any=1
+    fi
+done
+if [ "$found_any" -eq 0 ]; then
+    echo "add-repo: no pfBlockerNG package visible from repo '${REPO_NAME}' after pkg update." >&2
     echo "  Checked conf: ${CONF_PATH}" >&2
     echo "  The catalog may not be published yet for this box's ABI, or the URL is unreachable." >&2
     echo "  Inspect with: ${PKG_BIN} -d update   (traces the catalog fetch)" >&2
     exit 1
 fi
+echo "==> Done — conf at ${CONF_PATH}"

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -99,7 +99,9 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --nightly)      CHANNEL="nightly"; shift ;;
         --print-conf)   PRINT_CONF=1; shift ;;
-        --base-url)     BASE_URL="$2"; shift 2 ;;
+        --base-url)
+            [ $# -ge 2 ] || { echo "add-repo: --base-url requires a value" >&2; exit 2; }
+            BASE_URL="$2"; shift 2 ;;
         -h|--help)      usage; exit 0 ;;
         -*) echo "add-repo: unknown option: $1 (see --help)" >&2; exit 2 ;;
         *)  echo "add-repo: unexpected argument '$1' — the channel is a flag (--nightly); the release repo is the default. See --help." >&2; exit 2 ;;

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -27,16 +27,9 @@ import tarfile
 from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 
-# Channel identity (mirrors add-repo.sh): package name + one-line blurb, in
-# display order. The channel of a package is read from its name suffix.
-CHANNELS: dict[str, tuple[str, str]] = {
-    "stable": ("pfSense-pkg-pfBlockerNG", "Tagged stable releases — from the shared pfblockerng repo."),
-    "devel": (
-        "pfSense-pkg-pfBlockerNG-devel",
-        "The development tree — the same pfblockerng repo as stable; pick the package.",
-    ),
-    "nightly": ("pfSense-pkg-pfBlockerNG-nightly", "Bleeding edge — the devel tip, rebuilt daily (its own repo)."),
-}
+# Display order for the published-packages table (newest per channel). The channel of a
+# package is read from its name suffix (channel_of); the install CARDS are rendered
+# separately (release vs nightly) since stable + devel share one repo.
 CH_ORDER: list[str] = ["stable", "devel", "nightly"]
 RAW_ADDREPO = "https://raw.githubusercontent.com/pfBlockerNG/pfBlockerNG/devel/scripts/add-repo.sh"
 # The source repo a .pkg is built from — base for the per-artifact commit link.
@@ -236,7 +229,7 @@ h2{margin:2.5rem 0 1rem;font-size:1.3rem;border-bottom:1px solid var(--bd);paddi
 h3{margin:1.6rem 0 .5rem;font-size:1.05rem}
 .cards{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
 .card{background:var(--card);border:1px solid var(--bd);border-radius:10px;padding:1rem 1.1rem}
-.card h3{margin:0 0 .15rem;font-size:1.1rem;text-transform:capitalize}
+.card h3{margin:0 0 .15rem;font-size:1.1rem}
 .card .ver{color:var(--mut);font-size:.9rem;margin:0 0 .6rem}
 .card .blurb{color:var(--mut);font-size:.92rem;margin:.15rem 0 .8rem}
 pre{background:var(--code);border:1px solid var(--bd);border-radius:8px;padding:.7rem .8rem;overflow:auto;
@@ -256,21 +249,59 @@ ul.trees{display:grid;grid-template-columns:repeat(auto-fill,minmax(15rem,1fr));
 ul.trees li{margin:.15rem 0;overflow-wrap:anywhere}
 footer{margin-top:3rem;color:var(--mut);font-size:.85rem;border-top:1px solid var(--bd);padding-top:1rem}
 .empty{color:var(--mut);font-style:italic}
+.card ul.pkgs{margin:.3rem 0 .7rem;padding-left:0;list-style:none}
+.card ul.pkgs li{margin:.45rem 0}
+.card ul.pkgs .lbl{font-weight:600}
+.card.nightly{border-color:var(--acc)}
+.warn{color:var(--acc)}
 """
 
+# The release repo carries both packages (the channel picks the package, not the repo).
+_PKG_STABLE = "pfSense-pkg-pfBlockerNG"
+_PKG_DEVEL = "pfSense-pkg-pfBlockerNG-devel"
+_PKG_NIGHTLY = "pfSense-pkg-pfBlockerNG-nightly"
 
-def _channel_card(channel: str, base: str, latest: dict[str, str], conf_fn: Callable[[str], str]) -> str:
-    pkg, blurb = CHANNELS[channel]
+
+def _ver_or_empty(latest: dict[str, str], channel: str) -> str:
+    """The `Latest: <ver>` fragment for a channel, or an italic 'not yet published'."""
     lv = latest.get(channel)
-    ver_line = f"Latest: <code>{_esc(lv)}</code>" if lv else '<span class="empty">not yet published</span>'
-    one_liner = f"fetch -qo - {RAW_ADDREPO} \\\n  | sh -s -- --base-url {base} {channel}\npkg install {pkg}"
+    return f"Latest <code>{_esc(lv)}</code>" if lv else '<span class="empty">not yet published</span>'
+
+
+def _release_card(base: str, latest: dict[str, str], conf_fn: Callable[[str], str]) -> str:
+    """The unified stable+devel card: ONE bootstrap (the shared `pfblockerng` repo), then
+    install whichever package you want — the channels differ only in the package name."""
+    setup = f"fetch -qo - {RAW_ADDREPO} \\\n  | sh -s -- --base-url {base}"
+    items = (
+        f'<li><span class="lbl">Stable</span> — {_ver_or_empty(latest, "stable")}'
+        f"<pre>pkg install {_esc(_PKG_STABLE)}</pre></li>"
+        f'<li><span class="lbl">Development</span> — {_ver_or_empty(latest, "devel")}'
+        f"<pre>pkg install {_esc(_PKG_DEVEL)}</pre></li>"
+    )
     return (
-        f'<div class="card"><h3>{_esc(channel)} <span class="badge">{_esc(pkg)}</span></h3>'
-        f'<p class="ver">{ver_line}</p>'
-        f'<p class="blurb">{_esc(blurb)}</p>'
+        '<div class="card"><h3>Stable &amp; development</h3>'
+        '<p class="blurb">One bootstrap adds the shared <code>pfblockerng</code> repo, which carries '
+        "both packages (they conflict &mdash; install one):</p>"
+        f"<pre>{_esc(setup)}</pre>"
+        f'<ul class="pkgs">{items}</ul>'
+        "<details><summary>Manual conf (drop in /usr/local/etc/pkg/repos/)</summary>"
+        f"<pre>{_esc(conf_fn('release'))}</pre></details></div>"
+    )
+
+
+def _nightly_card(base: str, latest: dict[str, str], conf_fn: Callable[[str], str]) -> str:
+    """The nightly card — deliberately set apart: its own repo + a stability caveat."""
+    one_liner = f"fetch -qo - {RAW_ADDREPO} \\\n  | sh -s -- --base-url {base} --nightly\npkg install {_PKG_NIGHTLY}"
+    return (
+        '<div class="card nightly"><h3>Nightly <span class="badge">not for daily use</span></h3>'
+        f'<p class="ver">{_ver_or_empty(latest, "nightly")}</p>'
+        '<p class="blurb">The <code>devel</code> tip rebuilt every night on its own separate '
+        '<code>pfblockerng-nightly</code> repo. <span class="warn">Bleeding edge</span> &mdash; the only '
+        "guarantee is that CI passed; unlike <code>devel</code> it carries no stability target. Use it to "
+        "track the very latest, not on a production firewall.</p>"
         f"<pre>{_esc(one_liner)}</pre>"
-        f"<details><summary>Manual conf (drop in /usr/local/etc/pkg/repos/)</summary>"
-        f"<pre>{_esc(conf_fn(channel))}</pre></details></div>"
+        "<details><summary>Manual conf (drop in /usr/local/etc/pkg/repos/)</summary>"
+        f"<pre>{_esc(conf_fn('nightly'))}</pre></details></div>"
     )
 
 
@@ -408,7 +439,7 @@ def render_page(
 ) -> str:
     """Render the root landing page."""
     latest = latest_versions(pkgs)
-    cards = "".join(_channel_card(c, base, latest, conf_fn) for c in CH_ORDER)
+    cards = _release_card(base, latest, conf_fn) + _nightly_card(base, latest, conf_fn)
     tree_items = "".join(f'<li><a href="./{_esc(d)}/">{_esc(d)}</a></li>' for d in trees)
     return (
         '<!doctype html><html lang="en"><head><meta charset="utf-8">'
@@ -457,8 +488,11 @@ def render_dir_index(rel: str, files: Iterable[str]) -> str:
 
 
 def _conf_via_addrepo(addrepo: str, base: str, channel: str) -> str:
+    # add-repo.sh selects the channel by FLAG: the release repo is the default (no arg),
+    # --nightly picks the nightly repo. Anything other than "nightly" => the release conf.
+    extra = ["--nightly"] if channel == "nightly" else []
     out = subprocess.run(
-        ["sh", addrepo, "--print-conf", "--base-url", base, channel],
+        ["sh", addrepo, "--print-conf", "--base-url", base, *extra],
         capture_output=True,
         text=True,
         check=True,

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -328,7 +328,7 @@ def build_repo_via_portable(vm: SmokeVM, pkg_files: list[Path], tmp_path: Path) 
 
 
 def run_add_repo_sh(vm: SmokeVM, base_url: str, *, timeout: float = 300.0) -> subprocess.CompletedProcess[str]:
-    """Stage the SHIPPED ``scripts/add-repo.sh`` and run it (devel) against ``base_url``.
+    """Stage the SHIPPED ``scripts/add-repo.sh`` and run it (default release repo) against ``base_url``.
 
     Drives the real client bootstrap on the box: it writes the production conf to
     ``/usr/local/etc/pkg/repos/pfblockerng.conf`` (here pointed at a local
@@ -341,7 +341,7 @@ def run_add_repo_sh(vm: SmokeVM, base_url: str, *, timeout: float = 300.0) -> su
     """
     _ssh_check(vm, "/bin/mkdir", "-p", GUEST_SPIKE_DIR)
     _scp_to_guest(vm, ADD_REPO_SH, GUEST_ADD_REPO_SH)
-    result = vm.ssh("/bin/sh", GUEST_ADD_REPO_SH, "--base-url", base_url, "devel", timeout=timeout)
+    result = vm.ssh("/bin/sh", GUEST_ADD_REPO_SH, "--base-url", base_url, timeout=timeout)
     if result.returncode != 0:
         raise RuntimeError(
             f"add-repo.sh --base-url {base_url} failed: rc={result.returncode}\n"
@@ -909,8 +909,8 @@ def test_shipped_add_repo_sh_bootstrap_installs(repo_vm: SmokeVM) -> None:
     install picks ours — exactly the production mechanism.
 
     Given the package ABSENT and a ``build-repo.sh`` catalog under ``<root>/<ABI>/``,
-    When ``add-repo.sh --base-url file://<root> devel`` runs (writes the conf, ``pkg
-      update``, verifies) and then ``pkg install -y`` runs (NO -r, NO -f),
+    When ``add-repo.sh --base-url file://<root>`` runs (default release repo: writes the
+      conf, ``pkg update``, verifies) and then ``pkg install -y`` runs (NO -r, NO -f),
     Then add-repo.sh exits 0 (its own verify found the package in our repo), it wrote
       the production conf to ``pfblockerng.conf``, and the install comes from
       OUR repo (``pkg query %R`` == ``pfblockerng``) with deps resolved.

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -59,8 +59,8 @@ def _print_conf(script: Path, *args: str) -> str:
     return proc.stdout
 
 
-def _run_add_repo(channel: str, root: str) -> None:
-    """Run add-repo.sh <channel> with PFBLOCKERNG_ROOT=root.
+def _run_add_repo(root: str, *, nightly: bool = False) -> None:
+    """Run add-repo.sh with PFBLOCKERNG_ROOT=root (default = release repo; --nightly opt-in).
 
     PKG_BIN is overridden to a stub that satisfies `command -v` (it exists and
     is executable) and exits 0 for every subcommand — enough for the script to
@@ -78,13 +78,8 @@ def _run_add_repo(channel: str, root: str) -> None:
     os.chmod(fake_pkg, 0o755)
 
     env = {**os.environ, "PFBLOCKERNG_ROOT": root, "PKG_BIN": fake_pkg}
-    subprocess.run(
-        ["sh", str(_ADD_REPO), channel],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    argv = ["sh", str(_ADD_REPO), *(["--nightly"] if nightly else [])]
+    subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
 
 
 def _field(conf: str, key: str) -> str:
@@ -95,58 +90,51 @@ def _field(conf: str, key: str) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# Devel: add-repo.sh must emit the EXACT bytes build-repo.sh publishes.
+# The default (release) conf must be the EXACT bytes build-repo.sh publishes.
 # --------------------------------------------------------------------------- #
 
 
-def test_release_conf_byte_identical_across_stable_devel_and_build_repo() -> None:
-    """stable and devel emit the SAME release conf, == build-repo.sh --print-conf.
+def test_release_conf_byte_identical_across_all_three_generators() -> None:
+    """The default (release) conf == build-repo.sh == build-repo-portable.py, byte-for-byte.
 
-    The stable and devel packages share ONE repo/catalog (`pfblockerng`, Netgate-style),
-    so `add-repo.sh stable` and `add-repo.sh devel` must write byte-identical confs — and
-    both must match build-repo.sh --print-conf, the published single source (Phase 2/3).
-    A one-byte divergence (url, priority, repo name, comment) would split what is meant to
+    The release repo (`pfblockerng`) is what `add-repo.sh` writes by default (no argument);
+    it carries both the stable and devel packages (Netgate-style). It must match the two
+    catalog generators' `--print-conf` (the published single source, Phase 2/3) to the byte
+    — a one-byte divergence (url, priority, repo name, comment) would split what is meant to
     be one repo, so this pins all three generators together.
     """
-    stable = _print_conf(_ADD_REPO, "stable")
-    devel = _print_conf(_ADD_REPO, "devel")
+    add = _print_conf(_ADD_REPO)  # default = release (no channel argument)
     build = _print_conf(_BUILD_REPO)
     portable = _print_conf_portable()
-    assert stable == devel  # collapsed: stable + devel are one shared `pfblockerng` repo
-    assert stable == build  # == the published single-source template (build-repo.sh)
-    assert stable == portable  # == the portable Python generator — all THREE byte-equal
-
-
-def test_add_repo_default_channel_matches_devel() -> None:
-    """No channel arg defaults to devel (the documented default; the release conf)."""
-    assert _print_conf(_ADD_REPO) == _print_conf(_ADD_REPO, "devel")
+    assert add == build  # == the published single-source template (build-repo.sh)
+    assert add == portable  # == the portable Python generator — all THREE byte-equal
 
 
 # --------------------------------------------------------------------------- #
-# The load-bearing fields hold for BOTH channels (branch coverage).
+# The load-bearing fields hold for BOTH channels (branch coverage): the default
+# release repo and the --nightly flag.
 # --------------------------------------------------------------------------- #
 
 
 @pytest.mark.parametrize(
-    ("channel", "repo_name", "url"),
+    ("args", "repo_name", "url"),
     [
-        # stable + devel collapse onto the ONE shared `pfblockerng` release repo.
-        ("devel", "pfblockerng", f'url: "{_WORKER_URL}/${{ABI}}"'),
-        ("stable", "pfblockerng", f'url: "{_WORKER_URL}/${{ABI}}"'),
-        # nightly is served from a DISTINCT `nightly/` catalog subtree (so it never
-        # collides with the release tree on Pages) — its url carries the extra path.
-        ("nightly", "pfblockerng-nightly", f'url: "{_WORKER_URL}/nightly/${{ABI}}"'),
+        # Default (no argument) -> the shared `pfblockerng` release repo.
+        ((), "pfblockerng", f'url: "{_WORKER_URL}/${{ABI}}"'),
+        # --nightly -> a DISTINCT `pfblockerng-nightly` repo on a `nightly/` catalog
+        # subtree (so it never collides with the release tree on Pages).
+        (("--nightly",), "pfblockerng-nightly", f'url: "{_WORKER_URL}/nightly/${{ABI}}"'),
     ],
 )
-def test_add_repo_conf_fields_per_channel(channel: str, repo_name: str, url: str) -> None:
-    """stable/devel name the shared release repo; nightly its own — all share the rest.
+def test_add_repo_conf_fields_per_channel(args: tuple[str, ...], repo_name: str, url: str) -> None:
+    """The default names the shared release repo; --nightly its own — all share the rest.
 
-    stable + devel -> `pfblockerng` (one shared repo); nightly -> `pfblockerng-nightly`
-    (and a `nightly/${ABI}` url subtree). All carry priority 100 (above Netgate's 0) and
-    none/none (NONE-signed). The repo NAME (and, for nightly, the url subpath) is the only
-    varying field — and nightly's name must never collide with the release repo on a box.
+    Default (no arg) -> `pfblockerng` (the shared repo carrying stable + devel); --nightly ->
+    `pfblockerng-nightly` (and a `nightly/${ABI}` url subtree). Both carry priority 100 (above
+    Netgate's 0) and none/none (NONE-signed). The repo NAME (and, for nightly, the url subpath)
+    is the only varying field — and nightly's name must never collide with the release repo.
     """
-    conf = _print_conf(_ADD_REPO, channel)
+    conf = _print_conf(_ADD_REPO, *args)
 
     # The stanza is keyed by the expected repo name (and ONLY that name).
     assert re.search(rf"^{re.escape(repo_name)}:\s*\{{", conf, re.MULTILINE), conf
@@ -166,19 +154,22 @@ def test_add_repo_conf_fields_per_channel(channel: str, repo_name: str, url: str
     assert _field(conf, "enabled") == "yes"
 
 
-def test_add_repo_rejects_unknown_channel() -> None:
-    """An unknown channel arg fails loud (exit != 0), never silently writing a conf.
+def test_add_repo_rejects_positional_argument() -> None:
+    """A positional argument fails loud (exit != 0) — the channel is a flag, not a word.
 
-    (devel/stable/nightly are the three valid channels; anything else is rejected.)
+    The old `devel`/`stable`/`nightly` positionals are gone: the release repo is the default
+    and `--nightly` selects the nightly repo. A leftover `add-repo.sh devel` (or any word)
+    must error rather than silently do the wrong thing.
     """
-    proc = subprocess.run(
-        ["sh", str(_ADD_REPO), "--print-conf", "bogus"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert proc.returncode != 0
-    assert "channel" in proc.stderr.lower()
+    for bad in ("devel", "stable", "nightly", "bogus"):
+        proc = subprocess.run(
+            ["sh", str(_ADD_REPO), "--print-conf", bad],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode != 0, f"{bad!r} should be rejected"
+        assert "unexpected argument" in proc.stderr.lower(), proc.stderr
 
 
 # --------------------------------------------------------------------------- #
@@ -190,7 +181,7 @@ def test_primary_url_is_worker_url() -> None:
     """add-repo.sh writes the Cloudflare Worker URL, not the old GitHub Pages URL.
 
     Scenario: Given the conf does not exist (or exists with the old GitHub Pages URL),
-    When  add-repo.sh devel is run,
+    When  add-repo.sh is run (default = release repo),
     Then  the written conf URL contains pkg.pfblockerng.workers.dev and does NOT
           contain pfblockerng.github.io.
 
@@ -203,8 +194,8 @@ def test_primary_url_is_worker_url() -> None:
         # Given: conf does not exist yet (before-state)
         assert not conf_path.exists(), "conf should not exist before first run"
 
-        # When: run add-repo.sh devel (writes the shared release conf)
-        _run_add_repo("devel", root)
+        # When: run add-repo.sh with no argument (writes the shared release conf)
+        _run_add_repo(root)
 
         # Then: conf written with Worker URL
         assert conf_path.exists(), "conf should be written by add-repo.sh"
@@ -221,7 +212,7 @@ def test_worker_url_has_no_abi_placeholder() -> None:
     The ${ABI} placeholder appears only in the full url: line (appended after
     the base), not embedded in the Worker hostname or path prefix.
     """
-    conf = _print_conf(_ADD_REPO, "devel")
+    conf = _print_conf(_ADD_REPO)
     url_line = _field(conf, "url").strip('"')
     # The Worker base itself must not contain ${ABI}
     base = url_line.split("${ABI}")[0]
@@ -231,37 +222,37 @@ def test_worker_url_has_no_abi_placeholder() -> None:
 
 
 def test_worker_url_unchanged_regardless_of_channel() -> None:
-    """All three channels write the same Worker base URL; only repo section name differs.
+    """Both channels write the same Worker base URL; only the repo name / subpath differs.
 
     The Worker handles routing for all channels uniformly — the variant/version
     routing is User-Agent-based, not channel-based. The nightly channel adds the
-    `nightly/` subpath prefix, but the Worker hostname is identical across all three.
+    `nightly/` subpath prefix, but the Worker hostname is identical for both.
     """
-    for channel in ("devel", "stable", "nightly"):
-        conf = _print_conf(_ADD_REPO, channel)
+    for args in ((), ("--nightly",)):
+        conf = _print_conf(_ADD_REPO, *args)
         url_line = _field(conf, "url")
-        assert _WORKER_URL in url_line, f"Channel {channel!r}: Worker URL not in url field: {url_line!r}"
-        assert _OLD_PAGES_URL not in url_line, f"Channel {channel!r}: old Pages URL must not appear: {url_line!r}"
+        assert _WORKER_URL in url_line, f"args {args!r}: Worker URL not in url field: {url_line!r}"
+        assert _OLD_PAGES_URL not in url_line, f"args {args!r}: old Pages URL must not appear: {url_line!r}"
 
 
 def test_conf_written_once_invariant() -> None:
-    """Running add-repo.sh devel twice produces the same URL (idempotent).
+    """Running add-repo.sh twice produces the same URL (idempotent).
 
     Scenario: Given the conf is written by a first run (Worker URL present),
-    When  add-repo.sh devel is run again,
+    When  add-repo.sh is run again,
     Then  the URL is unchanged — the conf is rewritten with the same Worker URL.
     """
     with tempfile.TemporaryDirectory() as root:
         conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng.conf"
 
         # Given: first run writes the conf
-        _run_add_repo("devel", root)
+        _run_add_repo(root)
         assert conf_path.exists()
         content_first = conf_path.read_text()
         assert _WORKER_URL in content_first  # before-state: Worker URL present
 
         # When: run again
-        _run_add_repo("devel", root)
+        _run_add_repo(root)
 
         # Then: URL unchanged
         content_second = conf_path.read_text()
@@ -270,31 +261,34 @@ def test_conf_written_once_invariant() -> None:
         )
 
 
-def test_stable_and_devel_collapse_onto_one_shared_conf_file() -> None:
-    """stable and devel write the SAME on-box file — no separate per-channel conf.
+def test_default_writes_release_conf_and_nightly_writes_its_own() -> None:
+    """The default writes ONLY the shared release conf; --nightly writes ONLY the nightly one.
 
-    Scenario: the stable + devel packages share one repo, so both channels target
-              /usr/local/etc/pkg/repos/pfblockerng.conf (never a `pfblockerng-devel.conf`).
-    Given stable is bootstrapped first (writes the shared release conf),
-    When  devel is bootstrapped into the same root,
-    Then  it rewrites the SAME file with identical bytes, and no `pfblockerng-devel.conf`
-          is ever created — proving the collapse (a regression that re-split the channels
-          would leave two distinct files here).
+    Scenario: stable + devel share one repo (`pfblockerng.conf`); nightly is separate
+              (`pfblockerng-nightly.conf`). The default bootstrap must never create a
+              per-channel `pfblockerng-devel.conf`, and the two channels must not clobber
+              each other's file.
+    Given a fresh root,
+    When  add-repo.sh runs with no argument,
+    Then  only `pfblockerng.conf` exists (no `pfblockerng-devel.conf`, no nightly conf);
+    When  add-repo.sh --nightly then runs into the same root,
+    Then  `pfblockerng-nightly.conf` is added alongside, and the release conf is untouched.
     """
     with tempfile.TemporaryDirectory() as root:
         repos = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos"
-        shared = repos / "pfblockerng.conf"
+        release = repos / "pfblockerng.conf"
+        nightly = repos / "pfblockerng-nightly.conf"
         legacy_split = repos / "pfblockerng-devel.conf"
 
-        # Given: stable writes the shared release conf (before-state)
-        _run_add_repo("stable", root)
-        assert shared.exists(), "stable must write the shared pfblockerng.conf"
-        stable_bytes = shared.read_text()
-        assert not legacy_split.exists(), "stable must not write a split pfblockerng-devel.conf"
+        # When: default (no arg) → only the shared release conf
+        _run_add_repo(root)
+        assert release.exists(), "default must write the shared pfblockerng.conf"
+        assert not legacy_split.exists(), "default must NOT write a split pfblockerng-devel.conf"
+        assert not nightly.exists(), "default must NOT write the nightly conf"
+        release_bytes = release.read_text()
 
-        # When: devel is bootstrapped into the same root
-        _run_add_repo("devel", root)
-
-        # Then: same file, identical bytes, and still no split conf
-        assert shared.read_text() == stable_bytes, "devel must rewrite the SAME shared conf, byte-identical"
-        assert not legacy_split.exists(), "devel must NOT create a separate pfblockerng-devel.conf"
+        # When: --nightly → adds its own conf, leaves the release conf untouched
+        _run_add_repo(root, nightly=True)
+        assert nightly.exists(), "--nightly must write pfblockerng-nightly.conf"
+        assert release.read_text() == release_bytes, "--nightly must not touch the release conf"
+        assert not legacy_split.exists(), "no pfblockerng-devel.conf is ever created"

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -172,6 +172,18 @@ def test_add_repo_rejects_positional_argument() -> None:
         assert "unexpected argument" in proc.stderr.lower(), proc.stderr
 
 
+def test_add_repo_base_url_requires_a_value() -> None:
+    """`--base-url` with no following value errors cleanly (not a cryptic `set -u` crash)."""
+    proc = subprocess.run(
+        ["sh", str(_ADD_REPO), "--print-conf", "--base-url"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    assert "--base-url requires a value" in proc.stderr, proc.stderr
+
+
 # --------------------------------------------------------------------------- #
 # ADR-20 Phase 4: Worker URL tests
 # --------------------------------------------------------------------------- #

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -363,13 +363,22 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
     # not the whole page (the .tablewrap rule is what makes that scroll possible).
     assert '<div class="tablewrap"><table>' in page
     assert ".tablewrap{overflow-x:auto" in page
-    # Stable has no package -> empty state, NOT a bogus version.
+    # Stable has no package -> empty state, NOT a bogus version (its line in the unified
+    # release card).
     assert "not yet published" in page
-    # Install one-liner pins this repo's base URL (the working Pages mirror).
-    assert f"--base-url {base} devel" in page
+    # The unified release card: ONE bootstrap (no channel arg), then both install targets.
+    assert f"sh -s -- --base-url {base}" in page
+    assert "pkg install pfSense-pkg-pfBlockerNG<" in page  # stable (exact, not -devel)
+    assert "pkg install pfSense-pkg-pfBlockerNG-devel" in page  # development
+    # Nightly is its own card with the --nightly flag and its own package.
+    assert f"--base-url {base} --nightly" in page
     assert "pkg install pfSense-pkg-pfBlockerNG-nightly" in page
-    # The manual conf came from the injected conf function.
-    assert "devel-conf-snippet" in page
+    # The manual conf came from the injected conf function — release + nightly, keyed by
+    # the logical channel the cards pass.
+    assert "release-conf-snippet" in page
+    assert "nightly-conf-snippet" in page
+    # The badge/title casing fix: no CSS capitalize that would mangle `pfSense-pkg-...`.
+    assert "text-transform:capitalize" not in page
     # Catalog-tree link to the colon-ABI dir is './'-prefixed (browser scheme guard).
     assert 'href="./FreeBSD:16:aarch64/"' in page
     # The catalog-tree list is a responsive auto-fill grid (column count follows the


### PR DESCRIPTION
Follow-up to #216, addressing three points of feedback.

## 1. `add-repo.sh` — channel is a flag, not a positional

- **No argument** → the release repo (the shared `pfblockerng` catalog carrying stable + devel).
- **`--nightly`** → the separate nightly repo.
- The old `devel`/`stable`/`nightly` positionals are **removed** — a leftover positional now errors with a clear message. (Stable vs devel was never a repo distinction; you pick the *package* at `pkg install`.)
- Verify now checks **any** pfBlockerNG package in the repo (release carries two; stable may be unpublished) and prints per-package install hints.
- `--help` is a self-contained heredoc — no more brittle `sed` line-range (the source of a #216 fix).

## 2. Landing page — unified instructions

- **Stable + devel** collapse into one **"Stable & development"** card: a single bootstrap (`add-repo.sh`, no arg), then two install targets differing only by package name + their latest versions.
- **Nightly** is its own card, deliberately set apart (accent border, "not for daily use" badge) with the stability caveat: the only guarantee is CI passing; unlike devel it carries no stability target.

## 3. Casing fix

The package names next to each title rendered as `PfSense-Pkg-PfBlockerNG-Devel` — `.card h3 { text-transform: capitalize }` was capitalizing the badge too. Dropped it; titles are now written correctly in the HTML, so the package names render verbatim (`pfSense-pkg-pfBlockerNG-devel`).

## Tests / docs

All three conf generators still byte-equal (drift test pins the default release conf == build-repo == portable). Updated the per-channel field test (default vs `--nightly`), the positional-rejection test, the render test (unified card + `--nightly` + casing assertion), and the repo-install smoke caller. README / CLAUDE.md / pkg README updated. Full suite green (1551); shellcheck / ruff / markdownlint / url-encoding clean.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Simplified repository bootstrap selection: use the default command for the shared release repository (stable + devel), and `--nightly` to enable the nightly repository.

* **Documentation**
  * Updated installation and transition guidance to remove positional channel arguments and to rerun the bootstrap script to refresh the Worker URL.

* **UI Improvements**
  * Updated the landing page to present separate stable/devel and nightly installation cards.

* **Tests**
  * Expanded automated checks to validate default vs nightly configuration output and argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->