### PR TITLE
pkg-repo: accent release card blue (primary), nightly amber (caution)

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -217,7 +217,7 @@ def _esc(s: object) -> str:
 
 
 _CSS = """
-:root{--bg:#0d1117;--card:#161b22;--bd:#30363d;--fg:#e6edf3;--mut:#8b949e;--acc:#2f81f7;--code:#0b0f14}
+:root{--bg:#0d1117;--card:#161b22;--bd:#30363d;--fg:#e6edf3;--mut:#8b949e;--acc:#2f81f7;--warn:#d29922;--code:#0b0f14}
 *{box-sizing:border-box}
 body{margin:0;background:var(--bg);color:var(--fg);
   font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
@@ -252,8 +252,10 @@ footer{margin-top:3rem;color:var(--mut);font-size:.85rem;border-top:1px solid va
 .card ul.pkgs{margin:.3rem 0 .7rem;padding-left:0;list-style:none}
 .card ul.pkgs li{margin:.45rem 0}
 .card ul.pkgs .lbl{font-weight:600}
-.card.nightly{border-color:var(--acc)}
-.warn{color:var(--acc)}
+.card.release{border-color:var(--acc)}
+.card.nightly{border-color:var(--warn)}
+.card.nightly .badge{border-color:var(--warn);color:var(--warn)}
+.warn{color:var(--warn)}
 """
 
 # The release repo carries both packages (the channel picks the package, not the repo).
@@ -279,7 +281,7 @@ def _release_card(base: str, latest: dict[str, str], conf_fn: Callable[[str], st
         f"<pre>pkg install {_esc(_PKG_DEVEL)}</pre></li>"
     )
     return (
-        '<div class="card"><h3>Stable &amp; development</h3>'
+        '<div class="card release"><h3>Stable &amp; development</h3>'
         '<p class="blurb">One bootstrap adds the shared <code>pfblockerng</code> repo, which carries '
         "both packages (they conflict &mdash; install one):</p>"
         f"<pre>{_esc(setup)}</pre>"

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -379,6 +379,13 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
     assert "nightly-conf-snippet" in page
     # The badge/title casing fix: no CSS capitalize that would mangle `pfSense-pkg-...`.
     assert "text-transform:capitalize" not in page
+    # Accent grammar: the release card is the primary (blue --acc); nightly is cautioned
+    # (amber --warn), never the other way round (blue would read as "recommended").
+    assert '<div class="card release">' in page
+    assert '<div class="card nightly">' in page
+    assert "--warn:#d29922" in page
+    assert ".card.release{border-color:var(--acc)}" in page
+    assert ".card.nightly{border-color:var(--warn)}" in page
     # Catalog-tree link to the colon-ABI dir is './'-prefixed (browser scheme guard).
     assert 'href="./FreeBSD:16:aarch64/"' in page
     # The catalog-tree list is a responsive auto-fill grid (column count follows the


### PR DESCRIPTION
Follow-up to #218 — fix the accent grammar on the landing cards.

The nightly card borrowed the blue `--acc` (the link/primary color), which reads as *"recommended"* — backwards for a not-for-daily-use channel, and it left the actual primary (release) card unstyled.

- New `--warn` amber token (`#d29922`, GitHub's attention color) → nightly's border + badge + "Bleeding edge" text. Amber = handle with care.
- The **release** card now gets the blue `--acc` accent → it's the one most users want.

So: blue = primary/recommended, amber = caution. Render test pins both (`.card.release` blue, `.card.nightly` amber, the `--warn` token present).

CSS-only change to `gen_landing.py` + the test. Full suite green; ruff/shellcheck/markdownlint clean.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced landing page styling to improve visual distinction between release/stable and nightly build installation options. The cards now feature distinct visual treatments, making it easier to differentiate between installation choices.

* **Tests**
  * Added test validation to ensure correct styling is properly applied to both release and nightly installation cards on the landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->