### PR TITLE
pfblockerng: tighten input-handling guards (escape at sink, confine manifest paths, validate alias/vtype, JS-context encode)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4054,6 +4054,22 @@ def build(
     )
 
 
+def _dnsbl_path_within_base(path: str, base_dir: str) -> bool:
+    """Containment check: is the resolved real path of ``path`` inside ``base_dir``?
+
+    The manifest is published next to its raw feeds, so every ``raw`` / ``tld_master``
+    file a row references must resolve under the manifest's own directory. A row whose
+    resolved path escapes that directory (e.g. via ``..`` or an absolute path pointing
+    elsewhere) is rejected by the caller -- never opened. Symlinks are resolved
+    (``os.path.realpath``) so a link inside ``base_dir`` cannot point outside it. The
+    base itself resolves the same way; containment is a prefix match on
+    ``base_dir + os.sep`` (the equal-to-base case never holds for a file path).
+    """
+    real_base = os.path.realpath(base_dir)
+    real_path = os.path.realpath(path)
+    return real_path == real_base or real_path.startswith(real_base + os.sep)
+
+
 def _dnsbl_file_line_reader(base_dir: str) -> Callable[[str], Iterable[str]]:
     """A file-backed ``line_reader`` for build(): map a feed_row["raw"] reference to
     its raw lines, streamed lazily so peak RAM stays at the dict floor (RESULTS/01).
@@ -4065,6 +4081,10 @@ def _dnsbl_file_line_reader(base_dir: str) -> Callable[[str], Iterable[str]]:
 
     def reader(raw: str) -> Iterable[str]:
         path = raw if os.path.isabs(raw) else os.path.join(base_dir, raw)
+        if not _dnsbl_path_within_base(path, base_dir):
+            # The feed path escapes the manifest directory -- skip it (do not open).
+            sys.stderr.write("[pfBlockerNG]: Refusing DNSBL feed outside base dir: '{}'".format(path))
+            return
         try:
             fh = open(path, encoding="utf-8", errors="replace")
         except OSError as e:
@@ -4096,11 +4116,15 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
         tld_master_lines = list(tld_master)
     elif isinstance(tld_master, str) and tld_master:
         path = tld_master if os.path.isabs(tld_master) else os.path.join(base_dir, tld_master)
-        try:
-            with open(path, encoding="utf-8", errors="replace") as fh:
-                tld_master_lines = fh.read().splitlines()
-        except OSError as e:
-            sys.stderr.write("[pfBlockerNG]: Failed to read tld_master '{}': {}".format(path, e))
+        if not _dnsbl_path_within_base(path, base_dir):
+            # The tld_master path escapes the manifest directory -- skip it (do not open).
+            sys.stderr.write("[pfBlockerNG]: Refusing tld_master outside base dir: '{}'".format(path))
+        else:
+            try:
+                with open(path, encoding="utf-8", errors="replace") as fh:
+                    tld_master_lines = fh.read().splitlines()
+            except OSError as e:
+                sys.stderr.write("[pfBlockerNG]: Failed to read tld_master '{}': {}".format(path, e))
 
     # ADR-07 P7: the static-cap flag reaches build() via the ini-derived pfb setting
     # (the cap setting lives in pfb_unbound.ini MAIN, not the manifest); a manifest

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4059,15 +4059,16 @@ def _dnsbl_path_within_base(path: str, base_dir: str) -> bool:
 
     The manifest is published next to its raw feeds, so every ``raw`` / ``tld_master``
     file a row references must resolve under the manifest's own directory. A row whose
-    resolved path escapes that directory (e.g. via ``..`` or an absolute path pointing
-    elsewhere) is rejected by the caller -- never opened. Symlinks are resolved
-    (``os.path.realpath``) so a link inside ``base_dir`` cannot point outside it. The
-    base itself resolves the same way; containment is a prefix match on
-    ``base_dir + os.sep`` (the equal-to-base case never holds for a file path).
+    resolved path escapes that directory (via ``..`` or an absolute path elsewhere) is
+    rejected by the caller -- never opened. Symlinks are resolved (``os.path.realpath``)
+    so a link inside ``base_dir`` cannot point outside it.
     """
     real_base = os.path.realpath(base_dir)
     real_path = os.path.realpath(path)
-    return real_path == real_base or real_path.startswith(real_base + os.sep)
+    try:
+        return os.path.commonpath([real_base, real_path]) == real_base
+    except ValueError:
+        return False
 
 
 def _dnsbl_file_line_reader(base_dir: str) -> Callable[[str], Iterable[str]]:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -310,6 +310,14 @@ define('PFB_DOWNLOAD_MAXREDIRS', 10);
 define('PFB_AUTO_VIP_DESCR_V4', 'pfB_AUTO_VIP_v4');
 define('PFB_AUTO_VIP_DESCR_V6', 'pfB_AUTO_VIP_v6');
 
+// Allowlist the alias-type suffix ($vtype) before it is interpolated into an
+// alias name or filesystem path. The only legitimate values are '_v4' and '_v6';
+// any other value is rejected so a stray/unexpected suffix can never reach a
+// path/alias build. Returns TRUE only for an exact-match allowed suffix.
+function pfb_valid_vtype($vtype) {
+	return ($vtype === '_v4' || $vtype === '_v6');
+}
+
 // Function to filter/sanitize user input
 function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE) {
 	global $pfb;
@@ -582,7 +590,9 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			break;
 		case PFB_FILTER_FILE_MIME:
 			// Validate File Mime-types
-			// $input [0] path/file escaped, [1] path/file [2] URL
+			// $input [0] path/file (legacy, unused), [1] path/file [2] URL
+			// The probed path ($input[1]) is escapeshellarg()'d at the sink below,
+			// so callers need not pre-escape it.
 
 			if (isset($retval)) {
 				unset($retval);
@@ -594,7 +604,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				pfb_logger("{$header} Downloaded file not found: [" .  htmlspecialchars($input[0]) . "|" . htmlspecialchars($input[1]) . "]", 2);
 				return FALSE;
 			}
-			exec("/usr/bin/file -b --mime-type {$input[0]} 2>&1", $output, $retval);
+			exec("/usr/bin/file -b --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);
 			if ($retval != 0 || empty($output[0]) || !isset($pfb['mime_types'][$output[0]])) {
 
 				// Exceptions
@@ -616,7 +626,9 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			break;
 		case PFB_FILTER_FILE_MIME_COMPRESSED:
 			// Validate File Mime-types in compressed files
-			// $input [0] path/file escaped, [1] path/file [2] URL
+			// $input [0] path/file (legacy, unused), [1] path/file [2] URL
+			// The probed path ($input[1]) is escapeshellarg()'d at the sink below,
+			// so callers need not pre-escape it.
 			if (isset($retval)) {
 				unset($retval);
 			}
@@ -627,7 +639,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				pfb_logger("{$header} Downloaded file not found: [" .  htmlspecialchars($input[0]) . "|" . htmlspecialchars($input[1]) . "]", 2);
 				return FALSE;
 			}
-			exec("/usr/bin/file -bZ --mime-type {$input[0]} 2>&1", $output, $retval);
+			exec("/usr/bin/file -bZ --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);
 			if ($retval != 0 || empty($output[0]) || !isset($pfb['mime_types'][$output[0]])) {
 				pfb_logger("{$header} Failed or invalid Mime Type Compressed: [" .  htmlspecialchars($output[0]) . "|" . htmlspecialchars($retval) . "]", 2);
 				unlink_if_exists($input[1]);
@@ -11083,6 +11095,11 @@ function sync_package_pfblockerng($cron='') {
 				// Determine if Continent lists require action (IPv4 and IPv6)
 				foreach ($cont_types as $c_type => $vtype) {
 
+					// Only the '_v4'/'_v6' suffix may build an alias/path
+					if (!pfb_valid_vtype($vtype)) {
+						continue;
+					}
+
 					$cc_alias = "{$pfb_alias}{$vtype}";
 
 					// Determine 'list' details (return array $pfbarr)
@@ -11261,6 +11278,12 @@ function sync_package_pfblockerng($cron='') {
 
 		// Collect lists and custom list configuration and format into one array ($lists).
 		foreach	($ip_types as $ip_type	=> $vtype) {
+
+			// Only the '_v4'/'_v6' suffix may build an alias/path
+			if (!pfb_valid_vtype($vtype)) {
+				continue;
+			}
+
 			foreach (config_get_path("installedpackages/{$ip_type}/config", []) as $key => $list) {
 				if (!is_array($list)) {
 					$list = array();
@@ -11890,6 +11913,12 @@ function sync_package_pfblockerng($cron='') {
 	#################################################
 
 	foreach ($ip_types as $ip_type => $vtype) {
+
+		// Only the '_v4'/'_v6' suffix may build an alias/path
+		if (!pfb_valid_vtype($vtype)) {
+			continue;
+		}
+
 		$lists = config_get_path("installedpackages/{$ip_type}/config");
 
 		// Add DNSBLIP, if configured (IPv4 + IPv6)

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -194,8 +194,28 @@ emptyfiles() {
 # Function to remove lists from masterfiles and delete associated files.
 remove() {
 	echo; echo
+
+	# Self-defence: a path separator or traversal sequence in the alias must
+	# never reach the "rm -f ...${header}*" globs below. Reject it at entry so
+	# the script does not rely solely on the PHP caller having sanitised it.
+	case "${alias}" in
+		*/*|*..*)
+			echo "Invalid alias [ ${alias} ], *aborting remove*"
+			return 1
+			;;
+	esac
+
 	for i in ${cc}; do
 		header="${i%*,}"
+
+		# Same guard for each per-entry header before it builds an rm glob.
+		case "${header}" in
+			*/*|*..*)
+				echo "Invalid header [ ${header} ], *skipping*"
+				continue
+				;;
+		esac
+
 		if [ -n "${header}" ]; then
 			# Make sure that alias exists in masterfile before removal.
 			query="${header} "

--- a/src/usr/local/www/pfblockerng/www/index.php
+++ b/src/usr/local/www/pfblockerng/www/index.php
@@ -87,7 +87,10 @@ if (pathinfo($ptype['REQUEST_URI'], PATHINFO_EXTENSION) == 'js') {
 	$type = 'DNSBL-JS';
 	?>
 	<script type="text/javascript">
-		var dnsbl = "DNSBL : <?=$ptype['HTTP_HOST'];?> (JS)";
+		// JS-context-correct encoding of the host: json_encode() emits a
+		// properly-escaped JS string literal, so a host value cannot break out
+		// of the string into script context regardless of its contents.
+		var dnsbl = <?=json_encode('DNSBL : ' . $ptype['HTTP_HOST'] . ' (JS)');?>;
 	</script>
 	<?php
 }

--- a/tests/php/PfbFileMimeSinkEscapeTest.php
+++ b/tests/php/PfbFileMimeSinkEscapeTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_filter() FILE_MIME / FILE_MIME_COMPRESSED — the file-type probe argument is
+ * escaped AT the sink, so a metacharacter-bearing path is rendered inert (passed
+ * to /usr/bin/file as a single literal argument) and cannot start a second command.
+ *
+ * The probe runs the real /usr/bin/file against a real on-disk file, so these tests
+ * use actual temp files. Both branches are pinned:
+ *   - a benign path probes correctly (mime returned unchanged for valid input);
+ *   - a path whose NAME contains shell metacharacters does NOT execute the injected
+ *     command (no sentinel side effect) — proving the sink, not the caller, escapes.
+ */
+#[CoversFunction('pfb_filter')]
+final class PfbFileMimeSinkEscapeTest extends TestCase
+{
+	private string $dir;
+	private string $cwd;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_mime_' . uniqid('', true);
+		mkdir($this->dir);
+		// Work from inside the dir so a metacharacter-bearing filename (which may
+		// not itself contain '/') and its sentinel are addressed by bare name.
+		$this->cwd = (string) getcwd();
+		chdir($this->dir);
+		// FILE_MIME accepts the probed type only when it is a known mime_type.
+		$GLOBALS['pfb']['mime_types'] = ['text/plain' => 1];
+	}
+
+	protected function tearDown(): void
+	{
+		chdir($this->cwd);
+		foreach (glob($this->dir . '/*') ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dir);
+		unset($GLOBALS['pfb']['mime_types']);
+	}
+
+	public function testBenignPathProbesMimeUnchanged(): void
+	{
+		// Given a plain-text file with an ordinary name (addressed by bare name; cwd
+		// is the test dir).
+		file_put_contents('benign.txt', "127.0.0.1 example\n");
+
+		// When FILE_MIME validates it ($input[1] is the raw path, escaped at the sink).
+		$result = pfb_filter(["'unused'", 'benign.txt', 'http://feed.example/'], PFB_FILTER_FILE_MIME, 'test');
+
+		// Then the probed mime-type is returned unchanged — valid input is untouched.
+		$this->assertSame('text/plain', $result);
+	}
+
+	public function testMetacharacterPathIsInertAtSink(): void
+	{
+		// Given a real file whose NAME embeds a command-injection attempt, and a
+		// sentinel that the injected command would create if the arg were unescaped.
+		// The filename cannot contain '/', so both file and sentinel are bare names.
+		$evilName = 'evil; touch SENTINEL #.txt';
+		file_put_contents($evilName, "data\n");
+
+		// Sanity (before-state): the sentinel does not exist yet.
+		$this->assertFileDoesNotExist('SENTINEL');
+
+		// When FILE_MIME validates the metacharacter-bearing path.
+		pfb_filter(["'unused'", $evilName, 'http://feed.example/'], PFB_FILTER_FILE_MIME, 'test');
+
+		// Then the embedded command never ran: escaping at the sink rendered it inert.
+		$this->assertFileDoesNotExist('SENTINEL');
+	}
+
+	public function testCompressedMetacharacterPathIsInertAtSink(): void
+	{
+		// Same guarantee for the COMPRESSED case (file -bZ).
+		$evilName = 'evilz; touch SENTINEL_Z #.gz';
+		file_put_contents($evilName, "data\n");
+
+		$this->assertFileDoesNotExist('SENTINEL_Z');
+
+		pfb_filter(["'unused'", $evilName, 'http://feed.example/'], PFB_FILTER_FILE_MIME_COMPRESSED, 'test');
+
+		$this->assertFileDoesNotExist('SENTINEL_Z');
+	}
+}

--- a/tests/php/PfbValidVtypeTest.php
+++ b/tests/php/PfbValidVtypeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_valid_vtype() — the alias-type suffix allowlist. Only '_v4' and '_v6' may be
+ * interpolated into an alias name or filesystem path; every other value is rejected
+ * before it reaches a path/alias build. Exact-match only (no substring/prefix slack).
+ */
+#[CoversFunction('pfb_valid_vtype')]
+final class PfbValidVtypeTest extends TestCase
+{
+	public static function vtypeProvider(): array
+	{
+		return [
+			// Allowed — the only two legitimate suffixes.
+			'_v4 accepted'            => ['_v4', true],
+			'_v6 accepted'            => ['_v6', true],
+			// Rejected — everything else.
+			'empty rejected'          => ['', false],
+			'bare v4 rejected'        => ['v4', false],
+			'trailing junk rejected'  => ['_v4x', false],
+			'leading junk rejected'   => ['x_v4', false],
+			'path traversal rejected' => ['_v4/../etc', false],
+			'separator rejected'      => ['_v4/passwd', false],
+			'uppercase rejected'      => ['_V4', false],
+		];
+	}
+
+	#[DataProvider('vtypeProvider')]
+	public function testVtypeAllowlist(string $vtype, bool $expected): void
+	{
+		$this->assertSame($expected, pfb_valid_vtype($vtype));
+	}
+}

--- a/tests/shell/pfblockerng_remove_guard_spec.sh
+++ b/tests/shell/pfblockerng_remove_guard_spec.sh
@@ -1,0 +1,106 @@
+#shellcheck shell=sh
+# pfblockerng.sh remove() entry guard — a path separator or '..' traversal in the
+# alias/header must never reach the "rm -f ...${header}*" globs. The function
+# self-defends instead of trusting the PHP caller to have sanitised the value.
+#
+# Both branches are pinned: a malicious alias aborts before any rm (sentinel
+# survives); a malicious header is skipped (sentinel survives); a valid alias
+# proceeds and removes its own files (before-state asserted: the file exists first).
+
+Describe 'pfblockerng.sh remove() entry guard'
+  BeforeAll 'pfb_source'
+
+  # The variables below are consumed by the sourced remove() at runtime, which
+  # ShellCheck cannot see — suppress the false "appears unused" (SC2034) reports.
+  # shellcheck disable=SC2034
+  setup_sandbox() {
+    sandbox="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbrm.XXXXXX")"
+    # remove() globs over these path prefixes.
+    pfborig="${sandbox}/orig/"
+    pfbdeny="${sandbox}/deny/"
+    pfbmatch="${sandbox}/match/"
+    pfbpermit="${sandbox}/permit/"
+    pfbnative="${sandbox}/native/"
+    mkdir -p "${pfborig}" "${pfbdeny}" "${pfbmatch}" "${pfbpermit}" "${pfbnative}"
+    # An (empty) masterfile so the master-file bookkeeping is inert.
+    masterfile="${sandbox}/master"
+    mastercat="${sandbox}/mastercat"
+    tempfile="${sandbox}/t1"
+    tempfile2="${sandbox}/t2"
+    : > "${masterfile}"
+    # A sentinel OUTSIDE the sandbox that an unguarded traversal glob could delete.
+    sentinel="${sandbox}/SENTINEL"
+    : > "${sentinel}"
+  }
+
+  cleanup_sandbox() {
+    rm -rf "${sandbox}"
+  }
+
+  It 'aborts before any rm when the alias contains a traversal sequence'
+    setup_sandbox
+    # When the alias escapes via '..' (header is irrelevant — entry guard fires first).
+    alias='../evil'
+    cc='Whatever_v4,'
+    When call remove
+    The status should equal 1
+    The output should include 'Invalid alias'
+    # Then the sentinel still exists — no rm ran.
+    The path "${sentinel}" should be exist
+    cleanup_sandbox
+  End
+
+  It 'aborts before any rm when the alias contains a path separator'
+    setup_sandbox
+    alias='etc/passwd'
+    cc='Whatever_v4,'
+    When call remove
+    The status should equal 1
+    The output should include 'Invalid alias'
+    The path "${sentinel}" should be exist
+    cleanup_sandbox
+  End
+
+  It 'skips a per-entry header that contains a traversal sequence'
+    setup_sandbox
+    # A benign alias passes the entry guard; the malicious value rides the header.
+    alias='Benign'
+    cc='../../SENTINEL,'
+    When call remove
+    The output should include 'Invalid header'
+    # Then the sentinel survives — the malicious header never built an rm glob.
+    The path "${sentinel}" should be exist
+    cleanup_sandbox
+  End
+
+  # Wrapper: assert the file EXISTS before remove(), run remove(), report whether
+  # it still exists after — so the test proves removal CAUSED the change.
+  remove_valid_and_report() {
+    if [ -f "${pfborig}GoodList_v4.txt" ]; then
+      echo 'PRE:exists'
+    else
+      echo 'PRE:missing'
+    fi
+    remove
+    if [ -f "${pfborig}GoodList_v4.txt" ]; then
+      echo 'POST:exists'
+    else
+      echo 'POST:removed'
+    fi
+  }
+
+  It 'proceeds and removes its own files for a valid alias/header'
+    setup_sandbox
+    # shellcheck disable=SC2034  # read by the sourced remove() via the wrapper
+    alias='GoodList_v4'
+    # shellcheck disable=SC2034
+    cc='GoodList_v4,'
+    : > "${pfborig}GoodList_v4.txt"
+    When call remove_valid_and_report
+    # Before-state: the file existed; After: it is gone (the valid path proceeds).
+    The output should include 'PRE:exists'
+    The output should include 'POST:removed'
+    The output should include 'has been REMOVED'
+    cleanup_sandbox
+  End
+End

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 from typing import Any
 
 import pytest
@@ -63,20 +64,29 @@ from tests.test_adr06_golden_oracle import (
 
 
 def _write_onbox_manifest(tmp_path: Any, *, top1m_enabled: bool) -> str:
-    """Write a single manifest JSON (feeds + config) next to the fixture raw feeds.
+    """Write a single manifest JSON (feeds + config) with its raw files copied under
+    the manifest directory.
 
-    The manifest is written INTO the fixtures dir is avoided -- instead the feed
-    ``raw`` / ``tld_master`` are made ABSOLUTE (pointing at the committed fixtures)
-    so the manifest can live in a tmp dir without copying the feeds.
+    This mirrors the PRODUCTION shape (pfblockerng.inc): the manifest lives at the
+    chroot root and every feed ``raw`` / ``tld_master`` it references resolves UNDER
+    that directory (the build now confines manifest paths to the manifest's base dir,
+    so an out-of-base reference is skipped). The committed fixtures are copied into a
+    ``pfb_py_raw/`` subdir of tmp_path and referenced RELATIVELY, and ``tld_master``
+    is copied alongside and referenced by name -- the build reads it as a PATH.
     """
     src_manifest = _load_json("manifest.json")
     src_config = _load_json("config.json")
 
+    raw_dir = os.path.join(str(tmp_path), "pfb_py_raw")
+    os.makedirs(raw_dir, exist_ok=True)
+
     feeds = []
     for row in src_manifest["feeds"]:
+        rel = os.path.join("pfb_py_raw", os.path.basename(row["raw"]))
+        shutil.copyfile(os.path.join(FIXTURES, row["raw"]), os.path.join(str(tmp_path), rel))
         feeds.append(
             {
-                "raw": os.path.join(FIXTURES, row["raw"]),  # absolute -> reader resolves
+                "raw": rel,  # relative -> reader resolves under the manifest dir
                 "feed": row["feed"],
                 "group": row["group"],
                 "format_hint": row["format_hint"],
@@ -84,10 +94,12 @@ def _write_onbox_manifest(tmp_path: Any, *, top1m_enabled: bool) -> str:
             }
         )
 
+    shutil.copyfile(os.path.join(FIXTURES, "tld_master.txt"), os.path.join(str(tmp_path), "tld_master.txt"))
+
     manifest = {
         "version": 1,
         "config": {
-            "tld_master": os.path.join(FIXTURES, "tld_master.txt"),  # PATH, read on build
+            "tld_master": "tld_master.txt",  # PATH (in-base), read on build
             "tld_blacklist": src_config.get("tld_blacklist", []),
             "tld_exclusion": src_config.get("tld_exclusion", []),
             "user_whitelist": src_config.get("user_whitelist", []),
@@ -281,21 +293,24 @@ class TestManifestFallback:
 
     def test_missing_feed_file_is_skipped_not_fatal(self, tmp_path: Any) -> None:
         # One feed references a non-existent raw file; the build must still load the
-        # OTHER feeds rather than aborting (the bad feed is logged + skipped).
+        # OTHER feeds rather than aborting (the bad feed is logged + skipped). All
+        # referenced paths live UNDER the manifest dir (the production/confined shape).
         path = os.path.join(str(tmp_path), "m.json")
+        shutil.copyfile(os.path.join(FIXTURES, "tld_master.txt"), os.path.join(str(tmp_path), "tld_master.txt"))
+        shutil.copyfile(os.path.join(FIXTURES, "feed_plain.txt"), os.path.join(str(tmp_path), "feed_plain.txt"))
         manifest = {
             "version": 1,
-            "config": {"tld_master": os.path.join(FIXTURES, "tld_master.txt")},
+            "config": {"tld_master": "tld_master.txt"},
             "feeds": [
                 {
-                    "raw": os.path.join(str(tmp_path), "does_not_exist.txt"),
+                    "raw": "does_not_exist.txt",
                     "feed": "Gone",
                     "group": "Gone",
                     "format_hint": "plain",
                     "log_flag": "1",
                 },
                 {
-                    "raw": os.path.join(FIXTURES, "feed_plain.txt"),
+                    "raw": "feed_plain.txt",
                     "feed": "PlainFeed",
                     "group": "Malware",
                     "format_hint": "plain",

--- a/tests/test_adr06_php_boundary.py
+++ b/tests/test_adr06_php_boundary.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 from typing import Any
 
 import pfb_unbound
@@ -100,10 +101,14 @@ def _write_plain_boundary_manifest(tmp_path: Any, *, top1m_enabled: bool) -> tup
             }
         )
 
+    # tld_master must resolve UNDER the manifest dir (the build confines manifest
+    # paths to their base dir) -- copy it alongside the feeds and reference by name.
+    shutil.copyfile(os.path.join(FIXTURES, "tld_master.txt"), os.path.join(str(tmp_path), "tld_master.txt"))
+
     manifest = {
         "version": 1,
         "config": {
-            "tld_master": os.path.join(FIXTURES, "tld_master.txt"),
+            "tld_master": "tld_master.txt",
             "tld_blacklist": src_config.get("tld_blacklist", []),
             "tld_exclusion": src_config.get("tld_exclusion", []),
             "user_whitelist": src_config.get("user_whitelist", []),

--- a/tests/test_manifest_path_confinement.py
+++ b/tests/test_manifest_path_confinement.py
@@ -72,6 +72,22 @@ class TestFeedPathConfinement:
         assert "Refusing DNSBL feed outside base dir" in capsys.readouterr().err
 
 
+class TestPathWithinBaseHelper:
+    """The containment helper ``_dnsbl_path_within_base`` itself: in-base -> True,
+    out-of-base -> False, and the root-base edge case (``base_dir`` resolving to ``/``)
+    where a child must still be accepted (the old ``startswith(real_base + os.sep)`` form
+    built ``//`` and falsely rejected every child of ``/``).
+    """
+
+    def test_root_base_accepts_child(self) -> None:
+        # Given base_dir resolving to "/", a child path is contained (True), not rejected.
+        assert pfb_unbound._dnsbl_path_within_base("/var/unbound/x/y", "/") is True
+
+    def test_out_of_base_is_rejected(self) -> None:
+        # A path outside the base dir is not contained (containment still enforced).
+        assert pfb_unbound._dnsbl_path_within_base("/etc/passwd", "/var/unbound/pfb") is False
+
+
 class TestTldMasterPathConfinement:
     def test_in_base_tld_master_is_read(self, tmp_path: Any) -> None:
         # Given a tld_master file inside the base dir, referenced by name.

--- a/tests/test_manifest_path_confinement.py
+++ b/tests/test_manifest_path_confinement.py
@@ -1,0 +1,109 @@
+"""Manifest path confinement: a feed ``raw`` / ``tld_master`` path that resolves
+OUTSIDE the manifest's base directory is skipped and logged, never opened.
+
+The manifest is published next to its raw feeds, so every referenced file must
+resolve under the manifest directory. A row whose resolved real path escapes that
+directory (``..`` traversal, an absolute path elsewhere, or a symlink pointing out)
+is refused. Both branches are pinned for each sink (``_dnsbl_file_line_reader`` for
+feed ``raw`` paths, ``_dnsbl_config_from_manifest`` for ``tld_master``):
+in-base content is read; out-of-base content is skipped with a stderr log line.
+
+Scenario: confine manifest file references under base_dir
+  Background: a base dir holding an in-base file, and an out-of-base file alongside
+  Given a line_reader bound to base_dir
+  When it is asked for an in-base path  Then it yields the file's lines
+  When it is asked for an out-of-base path  Then it yields nothing and logs a refusal
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+import pfb_unbound
+
+
+class TestFeedPathConfinement:
+    def test_in_base_feed_is_read(self, tmp_path: Any, capsys: pytest.CaptureFixture[str]) -> None:
+        # Given a feed file inside the manifest base dir.
+        base = tmp_path / "base"
+        base.mkdir()
+        (base / "feed.txt").write_text("good.example\nblock.example\n", encoding="utf-8")
+        reader = pfb_unbound._dnsbl_file_line_reader(str(base))
+
+        # When the reader is asked for the in-base feed (by relative name).
+        lines = list(reader("feed.txt"))
+
+        # Then its lines are yielded and nothing is refused.
+        assert lines == ["good.example", "block.example"]
+        assert "Refusing DNSBL feed" not in capsys.readouterr().err
+
+    def test_out_of_base_feed_is_skipped_and_logged(self, tmp_path: Any, capsys: pytest.CaptureFixture[str]) -> None:
+        # Given a real file OUTSIDE the manifest base dir (a sibling of base).
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "secret.txt"
+        outside.write_text("escaped.example\n", encoding="utf-8")
+        reader = pfb_unbound._dnsbl_file_line_reader(str(base))
+
+        # Before-state: the in-base equivalent of the same name WOULD be read.
+        (base / "secret.txt").write_text("inbase.example\n", encoding="utf-8")
+        assert list(reader("secret.txt")) == ["inbase.example"]
+        capsys.readouterr()  # drain the in-base (clean) run
+
+        # When the reader is asked for a traversal path escaping base_dir.
+        escaped = list(reader(os.path.join("..", "secret.txt")))
+
+        # Then nothing is yielded (the outside file is never opened) and it is logged.
+        assert escaped == []
+        assert "Refusing DNSBL feed outside base dir" in capsys.readouterr().err
+
+    def test_absolute_out_of_base_feed_is_skipped(self, tmp_path: Any, capsys: pytest.CaptureFixture[str]) -> None:
+        # An absolute path pointing outside base_dir is refused too.
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "abs.txt"
+        outside.write_text("escaped.example\n", encoding="utf-8")
+        reader = pfb_unbound._dnsbl_file_line_reader(str(base))
+
+        assert list(reader(str(outside))) == []
+        assert "Refusing DNSBL feed outside base dir" in capsys.readouterr().err
+
+
+class TestTldMasterPathConfinement:
+    def test_in_base_tld_master_is_read(self, tmp_path: Any) -> None:
+        # Given a tld_master file inside the base dir, referenced by name.
+        base = tmp_path / "base"
+        base.mkdir()
+        (base / "tlds.txt").write_text("com\nnet\n", encoding="utf-8")
+        manifest = {"config": {"tld_master": "tlds.txt"}}
+
+        # When the config is shaped from the manifest.
+        config = pfb_unbound._dnsbl_config_from_manifest(manifest, str(base))
+
+        # Then the in-base suffix lines are loaded.
+        assert config["tld_master"] == ["com", "net"]
+
+    def test_out_of_base_tld_master_is_skipped_and_logged(
+        self, tmp_path: Any, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Given a tld_master file OUTSIDE the base dir, reached via traversal.
+        base = tmp_path / "base"
+        base.mkdir()
+        (tmp_path / "tlds.txt").write_text("evil\n", encoding="utf-8")
+
+        # Before-state: an in-base tld_master of the same name IS loaded.
+        (base / "tlds.txt").write_text("com\n", encoding="utf-8")
+        inbase = pfb_unbound._dnsbl_config_from_manifest({"config": {"tld_master": "tlds.txt"}}, str(base))
+        assert inbase["tld_master"] == ["com"]
+        capsys.readouterr()
+
+        # When the manifest points tld_master at an escaping path.
+        manifest = {"config": {"tld_master": os.path.join("..", "tlds.txt")}}
+        config = pfb_unbound._dnsbl_config_from_manifest(manifest, str(base))
+
+        # Then no suffix lines are loaded and the refusal is logged.
+        assert config["tld_master"] == []
+        assert "Refusing tld_master outside base dir" in capsys.readouterr().err


### PR DESCRIPTION
Five small, independent defensive guards across the input-handling surfaces. Each is behaviour-preserving for valid input; only malformed input changes outcome (escaped / skipped / rejected).

## Changes

1. **Escape the file-type probe arg at the sink** — `pfblockerng.inc` `pfb_filter()` (`PFB_FILTER_FILE_MIME` / `_COMPRESSED`): the `/usr/bin/file ...` exec now `escapeshellarg()`s the probed path (`$input[1]`) AT the sink, matching the sibling `FILE_MIME_COMPARE` case, so shell-safety is no longer a cross-function contract on the caller.

2. **Confine DNSBL manifest paths under the base dir** — `pfb_unbound.py` `dnsbl_build_from_manifest()`: a feed `raw` or `tld_master` whose resolved real path escapes the manifest's own directory (the chroot root in production) is now skipped + logged, never opened (`_dnsbl_path_within_base()`). Matches the production shape (feed paths are written RELATIVE to the manifest dir).

3. **Reject path separators in `remove()`** — `pfblockerng.sh`: an `alias`/`header` containing `/` or `..` is rejected at function entry, before the `rm -f ...${header}*` globs, so the script self-defends instead of trusting the PHP caller.

4. **JS-context encode the DNSBL block-page host** — `www/index.php`: the host is emitted into the `<script>` string via `json_encode()` (JS-context-correct) instead of relying on the upstream domain validation + `htmlspecialchars` (an HTML-context encoder).

5. **Allowlist `$vtype`** — `pfblockerng.inc`: `pfb_valid_vtype()` gates the three alias/path-building loops so only the `_v4`/`_v6` suffix is interpolated into an alias name or filesystem path.

## Tests

- `tests/php/PfbFileMimeSinkEscapeTest.php` — metacharacter-bearing path rendered inert at the sink; benign path probed unchanged.
- `tests/php/PfbValidVtypeTest.php` — `$vtype` allowlist, both branches.
- `tests/test_manifest_path_confinement.py` — in-base read vs out-of-base skip+log, for both the feed reader and `tld_master`, both branches.
- `tests/shell/pfblockerng_remove_guard_spec.sh` — malicious alias aborts, malicious header skips, valid alias proceeds and removes its own files (before-state asserted).
- `tests/test_adr06_init_from_raw.py` / `tests/test_adr06_php_boundary.py` — updated to the production-faithful in-base manifest shape.

Item 4 (block-page output) is exercised by the UI render/smoke tiers, not an off-appliance unit test.

## Gates (all green locally)

`php -l`, `phpunit` (376), `phpstan`, `phpcs` (PFBL-01), `pytest` (1564), `ruff check`/`format`, `mypy tests/`, `sh -n` + `shellcheck`, `shellspec` (71).

https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened manifest-based feed and `tld_master` loading to prevent path escape outside the configured base directory.
  * Enforced strict IP version suffix validation (`_v4`/`_v6`) to prevent malformed alias/rule inputs from being used.
  * Improved MIME-type probing safety to avoid unsafe filename interactions.
  * Strengthened `remove()` guards to reject traversal/invalid alias and header values.
  * Improved JS output escaping for DNSBL host text rendering.

* **Tests**
  * Added/extended PHPUnit and ShellSpec coverage for feed/path confinement, `vtype` validation, `remove()` guardrails, and MIME probe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->