### PR TITLE
pfblockerng: exclude reserved IPv6 addresses from loaded block lists

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11583,6 +11583,7 @@ function sync_package_pfblockerng($cron='') {
 							}
 
 							$ip_data = '';		// IPs collected from feed
+							$ip_suppressed = FALSE;	// TRUE when suppression dropped otherwise-valid IPv6 entries
 							$parse_fail = 0;	// Failed parsed lines from feed
 							pfb_logger('.', 1);
 
@@ -11749,6 +11750,9 @@ function sync_package_pfblockerng($cron='') {
 													if (!empty($parsed)) {
 														$ip_data .= $parsed . "\n";
 													}
+													else {
+														$ip_suppressed = TRUE;
+													}
 													continue;
 												}
 											}
@@ -11766,6 +11770,9 @@ function sync_package_pfblockerng($cron='') {
 																$parsed = sanitize_ipaddr_v6($cidr, $custom);
 																if (!empty($parsed)) {
 																	$ip_data .= $parsed . "\n";
+																}
+																else {
+																	$ip_suppressed = TRUE;
 																}
 															}
 															else {
@@ -11799,6 +11806,9 @@ function sync_package_pfblockerng($cron='') {
 														$parsed = sanitize_ipaddr_v6($match, $custom);
 														if (!empty($parsed)) {
 															$ip_data .= $parsed . "\n";
+														}
+														else {
+															$ip_suppressed = TRUE;
 														}
 													}
 												}
@@ -11846,6 +11856,14 @@ function sync_package_pfblockerng($cron='') {
 									$log		= "  Empty file, Adding '{$p_ip}' to avoid download failure.\n";
 									pfb_logger("{$log}", 1);
 								}
+							}
+
+							// All parsed IPv6 entries were suppressed; replace the list with the IPv6
+							// placeholder so stale (previously-loaded) entries are not left in the alias.
+							if (empty($ip_data) && $ip_suppressed && $list['vtype'] == '_v6') {
+								$p_ip     = "::{$pfb['ip_ph']}";
+								$ip_data  = "{$p_ip}\n";
+								pfb_logger("  All IPv6 entries suppressed, adding '{$p_ip}' to avoid stale alias contents.\n", 1);
 							}
 
 							if (!empty($ip_data)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5189,6 +5189,30 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 }
 
 
+// IPv6 sibling of sanitize_ipaddr(): exclude private/reserved/loopback IPv6
+// addresses from loaded block lists when Suppression is enabled. Returns the
+// entry unchanged when kept; returns nothing (drops it) when excluded.
+function sanitize_ipaddr_v6($ipaddr, $custom) {
+	global $pfb;
+
+	// Exclude private/reserved IPs (bypass exclusion for custom lists)
+	if ($pfb['supp'] == 'on' && !$custom) {
+
+		// Extract the address part (before '/' for a CIDR like 'fc00::/7')
+		$s_ip = explode('/', $ipaddr)[0];
+
+		// Drop ULA (fc00::/7), link-local (fe80::/10), loopback (::1),
+		// IPv4-mapped and the reserved set (mirrors inc:7118-7119).
+		if (!filter_var($s_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) ||
+		    !filter_var($s_ip, FILTER_CALLBACK, array('options' => 'FILTER_FLAG_NO_LOOPBACK_RANGE'))) {
+			return;
+		}
+	}
+
+	return $ipaddr;
+}
+
+
 // Validate IPv4 IP addresses
 function validate_ipv4($ipaddr) {
 	if (strpos($ipaddr, '/') !== FALSE) {
@@ -11721,7 +11745,10 @@ function sync_package_pfblockerng($cron='') {
 												}
 
 												if (validate_ipv6($line)) {
-													$ip_data .= $line . "\n";
+													$parsed = sanitize_ipaddr_v6($line, $custom);
+													if (!empty($parsed)) {
+														$ip_data .= $parsed . "\n";
+													}
 													continue;
 												}
 											}
@@ -11736,7 +11763,10 @@ function sync_package_pfblockerng($cron='') {
 													foreach ($a_cidr as $cidr) {
 														if (!empty($cidr)) {
 															if (validate_ipv6($cidr)) {
-																$ip_data .= $cidr . "\n";
+																$parsed = sanitize_ipaddr_v6($cidr, $custom);
+																if (!empty($parsed)) {
+																	$ip_data .= $parsed . "\n";
+																}
 															}
 															else {
 																$parse_error = TRUE;
@@ -11766,7 +11796,10 @@ function sync_package_pfblockerng($cron='') {
 												// Workaround to skip cloudflare error pages
 												if (strpos($oline, 'cf-footer-item') === FALSE) {
 													if (validate_ipv6($match)) {
-														$ip_data .= $match . "\n";
+														$parsed = sanitize_ipaddr_v6($match, $custom);
+														if (!empty($parsed)) {
+															$ip_data .= $parsed . "\n";
+														}
 													}
 												}
 											}

--- a/tests/php/SanitizeIpaddrV6Test.php
+++ b/tests/php/SanitizeIpaddrV6Test.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * sanitize_ipaddr_v6() — IPv6 sibling of sanitize_ipaddr(): when
+ * $pfb['supp']=='on' and not a custom list, drop private (ULA fc00::/7),
+ * link-local (fe80::/10), loopback (::1) and the reserved set (::/128) from
+ * loaded block lists; keep a genuinely public address. Suppression off, or a
+ * custom list, keeps the entry unchanged.
+ */
+#[CoversFunction('sanitize_ipaddr_v6')]
+final class SanitizeIpaddrV6Test extends TestCase
+{
+	protected function setUp(): void
+	{
+		// Default: suppression OFF (no reserved/private filtering).
+		$GLOBALS['pfb']['supp'] = 'off';
+	}
+
+	// --- Suppression on: reserved/private/loopback dropped -------------------
+
+	public function testSuppressionDropsUla(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// ULA fc00::/7
+		$this->assertNull(sanitize_ipaddr_v6('fc00::1', false));
+	}
+
+	public function testSuppressionDropsLinkLocal(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// Link-local fe80::/10
+		$this->assertNull(sanitize_ipaddr_v6('fe80::1', false));
+	}
+
+	public function testSuppressionDropsLoopback(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// Loopback ::1
+		$this->assertNull(sanitize_ipaddr_v6('::1', false));
+	}
+
+	public function testSuppressionDropsReserved(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// Reserved ::/128 (unspecified) — part of the NO_RES_RANGE set.
+		$this->assertNull(sanitize_ipaddr_v6('::', false));
+	}
+
+	// --- Suppression on: a genuinely public address is kept ------------------
+
+	public function testSuppressionKeepsPublicIp(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// Routable address (Cloudflare resolver) — NOT 2001:db8::/32 (reserved).
+		$this->assertSame('2606:4700:4700::1111', sanitize_ipaddr_v6('2606:4700:4700::1111', false));
+	}
+
+	// --- Suppression toggle is the cause (assert before-state, then flip) ----
+
+	public function testSuppressionTogglesReservedDrop(): void
+	{
+		// Given suppression OFF, a reserved v6 entry is KEPT (before-state).
+		$GLOBALS['pfb']['supp'] = 'off';
+		$this->assertSame('fc00::1', sanitize_ipaddr_v6('fc00::1', false));
+
+		// When suppression is flipped ON, the same entry is now DROPPED —
+		// so green proves suppression caused the change.
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr_v6('fc00::1', false));
+	}
+
+	// --- Custom list bypasses suppression ------------------------------------
+
+	public function testCustomListBypassesSuppression(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// $custom = true -> reserved v6 retained.
+		$this->assertSame('fc00::1', sanitize_ipaddr_v6('fc00::1', true));
+	}
+
+	// --- CIDR form: address part extracted before the filter -----------------
+
+	public function testSuppressionDropsReservedCidr(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// 'fc00::/7' — address part 'fc00::' is ULA -> dropped.
+		$this->assertNull(sanitize_ipaddr_v6('fc00::/7', false));
+	}
+
+	public function testSuppressionKeepsPublicCidr(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// A routable v6 CIDR survives unchanged (returned as-is, mask intact).
+		$this->assertSame('2606:4700:4700::/48', sanitize_ipaddr_v6('2606:4700:4700::/48', false));
+	}
+}


### PR DESCRIPTION
## What

Adds IPv6 parity to the Suppression-gated reserved-address exclusion when loading IP block lists.

Previously the `_v4` feed-load path routed every entry through `sanitize_ipaddr()`, which (when **Suppression** is on and the list is not custom) drops loopback / private / reserved IPv4. The `_v6` path accepted entries through `validate_ipv6()` only, with no equivalent exclusion — so private/reserved IPv6 (ULA `fc00::/7`, link-local `fe80::/10`, loopback `::1`, the reserved set) could enter a loaded block list.

## Change

- New helper `sanitize_ipaddr_v6($ipaddr, $custom)` — the IPv6 sibling of `sanitize_ipaddr()`. When `$pfb['supp'] == 'on'` and the list is not custom, it extracts the address part (before `/` for a CIDR) and drops private/reserved/loopback IPv6 via the same `filter_var(FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)` + loopback-callback combo already used elsewhere in the file. Suppression off, or a custom list, returns the entry unchanged.
- Wired into the three `_v6` acceptance points (auto / range / regex parsers): `validate_ipv6()` stays the syntactic gate, then the entry passes through `sanitize_ipaddr_v6()` and is appended only if it survives — mirroring the `_v4` path.

Scope is private/reserved parity only. The IPv4-only Advanced CIDR block-size floor stays IPv4-only. Behaviour-preserving: Suppression off ⇒ IPv6 entries pass exactly as before; custom lists bypass; public IPv6 always kept.

## Tests

`tests/php/SanitizeIpaddrV6Test.php` — branch coverage with before-state:
- Suppression ON drops ULA / link-local / loopback / reserved (`::`) and keeps a routable public address (`2606:4700:4700::1111`).
- Suppression toggle test asserts the reserved entry is **kept** with Suppression OFF, then **dropped** after flipping it ON — proving Suppression caused the change.
- Custom-list bypass keeps a reserved entry with Suppression ON.
- CIDR form (`fc00::/7`) — address part extracted and dropped; a public CIDR kept unchanged.

All PHP gates green: `php -l`, PHPUnit (393 tests), PHPStan, PHPCS.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced IPv6 suppression to automatically exclude non-routable addresses (ULA, link-local, loopback, and reserved ranges) from blocklists when enabled.
  * IPv6 feed parsing now applies the same suppression rules across “auto”, range expansion, and regex-based inputs.
  * Custom lists bypass suppression so entries are retained unchanged.
  * When all IPv6 entries are suppressed, the list is replaced with an IPv6 placeholder to prevent stale content.

* **Tests**
  * Added PHPUnit coverage validating suppression on/off behavior, custom bypass, and CIDR handling for IPv6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->