### PR TITLE
test(smoke): convert aggregate post-hook to the script model (#220 follow-up)

### DIFF
--- a/tests/smoke/test_smoke_aggregate.py
+++ b/tests/smoke/test_smoke_aggregate.py
@@ -411,9 +411,13 @@ def test_aggregate_post_hook_sees_fresh_table_and_changed_alias(deployed_vm: Smo
     h.inject(deployed_vm, spec)
     h.set_aggregate_types(deployed_vm, ["Deny"])
 
-    # The post hook: record the LIVE aggregate table, then the env (one /bin/sh -c command).
+    # The post hook records the LIVE aggregate table, then the env. Under the ADR-12
+    # security model a hook runs a VETTED script file (not a typed command), so install
+    # the script via the transient ``_body`` key that set_update_hooks() writes into the
+    # on-box hook-script dir before persisting the entry.
     post_hook = {
-        "command": f"/sbin/pfctl -t {agg} -T show > {table_marker}; /usr/bin/env > {env_marker}",
+        "script": f"hook_post_{token}.sh",
+        "_body": f"#!/bin/sh\n/sbin/pfctl -t {agg} -T show > {table_marker}\n/usr/bin/env > {env_marker}\n",
         "when": "post",
         "enabled": "on",
         "description": f"smoke {token} aggregate post",


### PR DESCRIPTION
Follow-up to #223 (issue #220). When I ran the live-VM smoke after merging the hooks hardening, `test_smoke_aggregate.py::test_aggregate_post_hook_sees_fresh_table_and_changed_alias` failed: its inline post hook still used the **old `{ command: … }`** shape that I'd converted everywhere else. Under the new model that hook has no `script`, so the runner skips it, the marker is never written, and the test fails.

Fix: install the hook's script via the transient `_body` key (same mechanism as the other smoke hooks).

**Context on that smoke run (devel head `d6a1954`):** the hook tests passed (`test_smoke_hooks.py` + the UI hooks tests are green). Besides this one (mine), the run also had **6 unrelated `test_smoke_feeds.py` failures** ("Download FAIL … pfctl: Table does not exist" / "Timeout") in the **HTTP feed-download** path — nothing to do with hooks, and present on the devel head itself. Those look like either a flake or a regression around the recent `d6a1954` "commonpath manifest base-dir containment" commit; worth a **separate** look. I'm re-running smoke on this branch to confirm the aggregate test now passes (and to characterize the feed failures).

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for post-hook execution scenarios, improving validation of hook configuration and environment variable tracking during aggregate table operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->