### PR TITLE
pkg-repo: base64 the feed-internal-allowlist + smoke coverage for the SSRF filter

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5462,6 +5462,11 @@ function pfb_feed_internal_allowlist($ignored = NULL) {
 		return array();
 	}
 
+	// The allowlist is stored base64-encoded, like every other pfBlockerNG textarea
+	// (suppression / whitelist / custom; see pfbng_text_area_decode). Decode before
+	// parsing; an undecodable value yields no entries, so the filter stays fail-closed.
+	$raw = (string) base64_decode($raw);
+
 	$entries = array();
 	foreach (preg_split('/[\s,]+/', $raw) as $entry) {
 		$entry = trim($entry);

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -63,7 +63,7 @@ $pconfig['pfb_feed_internal_filter']	= isset($pfb['gconfig']['pfb_feed_internal_
 
 // Exemptions from the internal-address feed-host check: IP addresses / CIDR ranges
 // (one per line) whose feeds are allowed even when they resolve internally.
-$pconfig['pfb_feed_internal_allowlist']	= $pfb['gconfig']['pfb_feed_internal_allowlist']	?: '';
+$pconfig['pfb_feed_internal_allowlist']	= (string) base64_decode($pfb['gconfig']['pfb_feed_internal_allowlist'] ?? '');
 
 $pconfig['pfb_interval']		= $pfb['gconfig']['pfb_interval']			?: 1;
 
@@ -168,7 +168,7 @@ if ($_POST) {
 			// browser does not submit it. Preserve the previously stored value in that
 			// case rather than overwriting it with the absent POST field.
 			if ($pfb['gconfig']['pfb_feed_internal_filter'] === 'on') {
-				$pfb['gconfig']['pfb_feed_internal_allowlist']	= str_replace("\r\n", "\n", trim($_POST['pfb_feed_internal_allowlist'] ?? ''));
+				$pfb['gconfig']['pfb_feed_internal_allowlist']	= base64_encode(str_replace("\r\n", "\n", trim($_POST['pfb_feed_internal_allowlist'] ?? '')));
 			}
 			$pfb['gconfig']['pfb_interval']			= $_POST['pfb_interval']			?: 1;
 			$pfb['gconfig']['pfb_min']			= $_POST['pfb_min']				?: 0;

--- a/tests/php/FeedHostAllowedTest.php
+++ b/tests/php/FeedHostAllowedTest.php
@@ -35,10 +35,14 @@ final class FeedHostAllowedTest extends TestCase
 		$GLOBALS['pfb_test_configured_ips'] = [];
 	}
 
-	/** Set the internal-address allowlist config value the guard reads. */
+	/** Set the internal-address allowlist config value the guard reads.
+	 *
+	 * Stored base64-encoded (the pfBlockerNG textarea convention; pfb_feed_internal_allowlist()
+	 * base64_decodes it), so encode the plain IP/CIDR list the caller passes.
+	 */
 	private function setAllowlist(string $value): void
 	{
-		config_set_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_allowlist', $value);
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_allowlist', base64_encode($value));
 	}
 
 	protected function tearDown(): void

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -809,6 +809,32 @@ def vip_alias_live(vm: SmokeVM, ip: str, iface: str = "lo0", *, timeout: float =
     return False
 
 
+def set_feed_internal_allowlist(vm: SmokeVM, value: str, *, timeout: float = 60.0) -> None:
+    """Set the General-settings feed-host internal-address ALLOWLIST (``pfb_feed_internal_allowlist``).
+
+    The feed-host filter (``pfb_feed_internal_filter``, default-ON SSRF guard) rejects a feed
+    whose host resolves to an internal/private address — but EXEMPTS any IP covered by this
+    allowlist (IPs/CIDRs, whitespace/comma-separated, stored base64-encoded; ``pfb_feed_internal_allowlist()``
+    parses it, ``pfb_ip_in_allowlist()`` matches by CIDR). The smoke mock feed server is the SLIRP
+    host alias ``10.0.2.2`` (RFC1918, and NOT the box's own IP, so the self-exemption does not
+    apply), so the HTTP-feed smoke allowlists the SLIRP test network ``10.0.2.0/24`` — keeping the
+    filter ON while letting the mock fetch through.
+
+    The field is stored base64-encoded (the pfBlockerNG textarea convention; the reader
+    base64_decodes it), so ``value`` is encoded here before it is written.
+    """
+    encoded = base64.b64encode(value.encode()).decode()
+    snippet = (
+        f"config_set_path({_php_str(CFG_GLOBAL + '/pfb_feed_internal_allowlist')}, {_php_str(encoded)});\n"
+        "write_config('pfBlockerNG smoke: set feed internal allowlist');\necho 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_feed_internal_allowlist failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
 def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     """Point pfSense at the runner-side mock via its REAL System-DNS path (no custom zone).
 

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -73,6 +73,12 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
+    # The mock feed server is the SLIRP host alias 10.0.2.2 (RFC1918) — the default-ON
+    # feed-host internal-address filter (SSRF guard, pfb_feed_internal_filter) would reject
+    # every HTTP mock fetch as an internal-resolving host. Allowlist the SLIRP test network
+    # so the filter stays ON yet the mock is reachable (the fix for the regression these
+    # HTTP-feed tests hit after the filter landed default-on).
+    h.set_feed_internal_allowlist(smoke_vm, "10.0.2.0/24")
     h.ensure_dnsbl_vip(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
     try:
@@ -178,6 +184,58 @@ def test_dnsbl_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
         passed = h.dns_probe(deployed_vm, non_member, "A")
         assert h.resolves_to(passed, STUB_DNS_A), f"non-member {non_member} should resolve via stub, got {passed}"
         assert not h.is_vip(passed), f"non-member {non_member} wrongly VIP-blocked: {passed}"
+
+
+# --------------------------------------------------------------------------- #
+# Feed-host internal-address filter (SSRF guard) — BOTH branches over the live box.
+# --------------------------------------------------------------------------- #
+
+
+def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """The default-ON feed-host filter BLOCKS an internal-resolving feed; the allowlist EXEMPTS it.
+
+    The mock feed server is the SLIRP host alias 10.0.2.2 (RFC1918) — exactly the
+    internal-pivot the filter (``pfb_feed_internal_filter``, default ON) guards against.
+    This pins BOTH branches end to end over the live box (the module fixture allowlists
+    10.0.2.0/24 so the other HTTP-feed cases load at all; this test brackets it).
+
+    Scenario:
+      Given the filter ON and the allowlist EMPTY (so 10.0.2.2 is not exempt),
+      When  the mock IP feed is Force-Updated,
+      Then  the download is REFUSED and the pf table is never built (the block branch).
+      When  the SLIRP net 10.0.2.0/24 is then allowlisted and re-updated,
+      Then  the SAME feed downloads and its pf table IS built (the exempt branch).
+    """
+    feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
+    spec = h.IpCase(aliasname="smokefiltergate", feed_url=feed_url, header="smokefiltergate", family="v4")
+    # The mock fetch must be reachable across both updates (the SSRF filter, not egress,
+    # is what we are exercising).
+    h.unblock_egress()
+    try:
+        h.inject(deployed_vm, spec)
+        # BLOCK branch: empty allowlist => the internal mock host is not exempt.
+        # An IpCase settles its pf table + rule only after the full Force Update
+        # FOLLOWED BY the targeted updateip (see CaseContext) — mirror that here so
+        # the "table not built" assertion reflects a fully settled reload, not a race.
+        h.set_feed_internal_allowlist(deployed_vm, "")
+        assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before any load"
+        h.reload(deployed_vm, "update")
+        h.reload(deployed_vm, "updateip")
+        assert spec.alias not in h.pfctl_tables(deployed_vm), (
+            "filter ON + empty allowlist must BLOCK the internal mock feed (pf table not built)"
+        )
+
+        # EXEMPT branch: allowlist the SLIRP net => the SAME feed now downloads + loads.
+        h.set_feed_internal_allowlist(deployed_vm, "10.0.2.0/24")
+        h.reload(deployed_vm, "update")
+        h.reload(deployed_vm, "updateip")
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
+        assert members, "allowlisting the SLIRP CIDR must EXEMPT the feed (pf table built)"
+        assert h.member_present(members, "203.0.113.5"), f"listed host missing after exemption: {members}"
+    finally:
+        # Restore the module-default allowlist (siblings rely on it) and baseline the box.
+        h.set_feed_internal_allowlist(deployed_vm, "10.0.2.0/24")
+        h.reset(deployed_vm)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Root cause

The 6 `tests/smoke/test_smoke_feeds.py` failures (surfaced when running the live smoke for #220) are a regression from the recent SSRF-hardening commits **`3bb2e0e`** ("guard feed downloads against internal-resolving hosts") + **`9c3dd79`** ("feed-host filter toggle, default-on"). That filter (`pfb_feed_internal_filter`, default **ON**) rejects any feed whose host resolves to an internal/private address.

The smoke HTTP **mock feed server is the SLIRP host alias `10.0.2.2`** — RFC1918, and *not* the box's own IP — so with the filter ON **every HTTP mock fetch is refused** (IP "Download FAIL → `pfctl: Table does not exist`", DNSBL "Timeout"). Only `test_smoke_feeds.py` uses the HTTP mock server; every other smoke test injects **local-file** feeds, which is why those were unaffected.

## Changes

**Smoke (the regression fix + new coverage):**
- The HTTP-feed fixture allowlists the SLIRP net **`10.0.2.0/24`** via `pfb_feed_internal_allowlist` (new `helpers.set_feed_internal_allowlist()`) — filter stays **ON**, mock reachable.
- New **`test_feed_internal_filter_blocks_then_allowlist_exempts`** pins *both* branches live: empty allowlist ⇒ the internal feed is **blocked** (no pf table); allowlist the SLIRP CIDR ⇒ the same feed **loads**.

**Consistency (per review):** store `pfb_feed_internal_allowlist` **base64-encoded** like every other pfBlockerNG textarea (suppression/whitelist/custom) instead of plain — the reader `base64_decode`s (fail-closed on garbage), the General-settings GUI encodes on save / decodes on display, and `FeedHostAllowedTest` + the smoke helper encode to match. Clean break (the field is `devel`-only / unreleased).

## Validation
- The allowlist fix **passed the full live smoke** (the plain-allowlist intermediate run was green — all 6 feed tests + the rest). A fresh smoke is running on this branch to confirm the base64 storage + the new filter-transition test.
- Off-box gates green: PHPUnit 393 (incl. `FeedHostAllowedTest` with the base64 setter), PHPStan, PHPCS, ruff, mypy, markdownlint, url-encoding.

https://claude.ai/code/session_01ABAdCMHZBXCLBpBcMVPuSo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed internal allowlist storage and retrieval mechanism with proper encoding support.
  * Enhanced internal address filter to correctly process allowlist exemptions, preventing legitimate feed sources on exempted networks from being blocked.

* **Tests**
  * Added comprehensive test coverage for feed internal filter allowlist functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->