### PR TITLE
pfblockerng: make DNSBL control CLI-driven via a local privileged channel (PFBL-03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,27 @@ Set the knob to **On** or **Off** to override the per-channel default either way
 Cross-channel **switching** from the GUI is not offered (the selector is read-only); switch
 channels with `add-repo.sh` + `pkg install` as in Option 2 above.
 
+### DNSBL Control (CLI)
+
+When **DNSBL Control** is enabled (DNSBL settings), DNSBL can be driven at runtime
+through the local root CLI:
+
+```sh
+pfblockerng dnsbl-control disable [seconds]   # seconds: 1-3600
+pfblockerng dnsbl-control enable
+pfblockerng dnsbl-control addbypass <ip> [seconds]
+pfblockerng dnsbl-control removebypass <ip>
+```
+
+These commands can be incorporated in CRON/Scheduler tasks or run manually; all events
+are logged to the Reports tab.
+
+> **Migration:** the older `drill TXT python_control.*` DNS-TXT transport is
+> **deprecated** and **off by default**. Switch any CRON/Scheduler task to the
+> `pfblockerng dnsbl-control` CLI above. A one-release **DNSBL Control (legacy DNS TXT)**
+> sub-toggle re-enables the old path for migration only — it will be **removed next
+> release**.
+
 ## Documentation
 
 - **Using pfBlockerNG:**

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -133,6 +133,13 @@ pfb_loggers: dict[str, Any] = {}
 pfb_reload_watcher_thread: Any
 pfb_reload_stop: Any
 
+# PFBL-03: the DNSBL-control command-channel reader daemon + its stop handle. The
+# watcher waits on the control file's DIRECTORY (mirroring the reload watcher) and routes
+# a fresh command through pfb_apply_control_command() OFF the query threads. Declared
+# here; created in init_standard (gated on pfb["mod_threading"]) and joined in deinit.
+pfb_control_watcher_thread: Any
+pfb_control_stop: Any
+
 if TYPE_CHECKING:
     # Modules imported defensively in the try/except guards below. Declared here
     # unconditionally so static checkers treat them as always bound (the runtime
@@ -607,6 +614,166 @@ class _ReloadKqueueWaiter:
             self._fd = -1
 
 
+# --------------------------------------------------------------------------- #
+# PFBL-03 -- the local privileged DNSBL-control command channel (reader daemon).
+#
+# A daemon thread mirrors the ADR-10 reload watcher: it waits on the control file's
+# DIRECTORY (kqueue EVFILT_VNODE where available, mtime-poll fallback) and, on a change,
+# reads the JSON record. The record carries a monotonically-advancing SEQUENCE; the
+# watcher tracks the last-applied seq and IGNORES any record with seq <= last_applied
+# (exactly-once + replay safety, exactly as the reload watcher compares generations).
+# A FRESH record is re-validated and routed through the SHARED pfb_apply_control_command()
+# handler -- the same implementation the legacy DNS-TXT branch uses -- then the applied
+# seq is published so the writer can confirm execution. Correctness rides on the atomic
+# publish + the seq COMPARE, NOT on notify latency: a missed event only delays.
+#
+# The reader runs OFF the query threads (its own daemon, blocking only on the kqueue/poll
+# wait), so it never blocks DNS response processing.
+# --------------------------------------------------------------------------- #
+
+
+def _control_read_record(path: str) -> dict[str, Any] | None:
+    """Read + parse the control channel's JSON record, or ``None`` if absent/unreadable/
+    malformed. Best-effort: any read or JSON error yields ``None`` (treated as "no
+    command")."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = fh.read()
+    except OSError:
+        return None
+    if not raw.strip():
+        return None
+    try:
+        record = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(record, dict):
+        return None
+    return record
+
+
+def _control_write_applied(seq: int) -> None:
+    """Publish ``seq`` as the APPLIED-sequence marker (atomic temp + ``os.replace``).
+
+    Written by the watcher after it consumes a record so the writer can confirm the
+    command ran. Best-effort: a write failure is logged and the command still stands."""
+    path = pfb.get("pfb_py_control_applied")
+    if not path:
+        return
+    tmp = "{}.tmp".format(path)
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write("{}\n".format(int(seq)))
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except OSError as e:
+        sys.stderr.write("[pfBlockerNG]: failed to write control applied marker [ {} ]: {}\n".format(path, e))
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def _control_record_to_command(record: dict[str, Any]) -> list[str] | None:
+    """Translate a control JSON record into the dot-split token list the shared handler
+    consumes (mirroring the DNS-TXT q_name split), or ``None`` when the command is
+    unknown / the required fields are absent. The shared handler re-validates the IP and
+    duration; this only assembles the tokens.
+
+    Record shape: ``{"seq": int, "cmd": "disable|enable|addbypass|removebypass",
+    "ip": "<v4/v6>", "duration": <int>, "ts": <epoch>}`` -- ``ip``/``duration`` present
+    only for the commands that take them."""
+    cmd = record.get("cmd")
+    if cmd not in ("disable", "enable", "addbypass", "removebypass"):
+        return None
+
+    command = ["python_control", cmd]
+    if cmd in ("addbypass", "removebypass"):
+        ip = record.get("ip")
+        if not isinstance(ip, str) or ip == "":
+            return None
+        # The shared handler un-maps '-' to '.' (the DNS-TXT transport encoding); the
+        # channel carries the IP verbatim, so a dotted IPv4 passes through unchanged.
+        command.append(ip)
+    elif cmd == "disable":
+        # disable carries an optional duration as the 3rd token (validated downstream).
+        if "duration" in record:
+            command.append("{}".format(record.get("duration")))
+        return command
+
+    # addbypass takes an optional duration as the 4th token.
+    if cmd == "addbypass" and "duration" in record:
+        command.append("{}".format(record.get("duration")))
+
+    return command
+
+
+def pfb_control_watcher() -> None:
+    """Daemon body: wait on the control channel and apply each FRESH command (seq advance)
+    until the stop Event is set.
+
+    Adopts the current seq at startup WITHOUT applying (a record already on disk from a
+    prior run is not replayed), publishes it as the applied baseline, then on every change
+    reads the record, applies it iff its seq strictly advances, and republishes the
+    applied seq. Single-flight by construction (one record at a time, latest seq wins)."""
+    channel = pfb["pfb_py_control"]
+    watch_dir = os.path.dirname(os.path.abspath(channel)) or "."
+
+    # Baseline: adopt the seq of any record already present WITHOUT applying it -- the
+    # watcher only acts on a FUTURE advance (mirrors the reload watcher's baseline).
+    last_seq = 0
+    record = _control_read_record(channel)
+    if record is not None:
+        seq = record.get("seq")
+        if isinstance(seq, int):
+            last_seq = seq
+    _control_write_applied(last_seq)
+
+    def drain_and_apply() -> None:
+        nonlocal last_seq
+        while not pfb_control_stop.is_set():
+            rec = _control_read_record(channel)
+            if rec is None:
+                return
+            seq = rec.get("seq")
+            if not isinstance(seq, int) or seq <= last_seq:
+                return
+            last_seq = seq
+            command = _control_record_to_command(rec)
+            if command is not None:
+                applied, msg = pfb_apply_control_command(command)
+                if msg:
+                    log_info("[pfBlockerNG]: {}".format(msg))
+            # Advance the applied marker on every consumed record (advance or rejection),
+            # so the writer's wait never blocks on a record the reader already saw.
+            _control_write_applied(seq)
+
+    waiter = _ReloadKqueueWaiter(watch_dir) if hasattr(select, "kqueue") else None
+    if waiter is not None and not waiter.is_active():
+        waiter.close()
+        waiter = None
+    try:
+        while not pfb_control_stop.is_set():
+            drain_and_apply()
+            if pfb_control_stop.is_set():
+                break
+            if waiter is not None:
+                waiter.wait(RELOAD_POLL_INTERVAL)
+            else:
+                pfb_control_stop.wait(RELOAD_POLL_INTERVAL)
+    except Exception as e:
+        err = sys.__stderr__
+        if err is not None:
+            try:
+                err.write("[pfBlockerNG]: control watcher error: {}\n".format(e))
+            except Exception:
+                pass
+    finally:
+        if waiter is not None:
+            waiter.close()
+
+
 def init_standard(id: int, env: module_env) -> bool:
     global \
         pfb, \
@@ -629,7 +796,9 @@ def init_standard(id: int, env: module_env) -> bool:
         pfb_db_queue, \
         pfb_db_worker_thread, \
         pfb_reload_watcher_thread, \
-        pfb_reload_stop
+        pfb_reload_stop, \
+        pfb_control_watcher_thread, \
+        pfb_control_stop
 
     if not register_inplace_cb_reply(inplace_cb_reply, env, id):
         log_info("[pfBlockerNG]: Failed register_inplace_cb_reply")
@@ -759,6 +928,7 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["sqlite3_resolver_con"] = False
     pfb["async_worker"] = False
     pfb["reload_watcher"] = False
+    pfb["control_watcher"] = False
 
     # DNSBL Python files
     pfb["pfb_unbound.ini"] = "pfb_unbound.ini"
@@ -790,6 +960,19 @@ def init_standard(id: int, env: module_env) -> bool:
     # hook + the #51 alert page + the smoke suite then observe the new state, not a
     # pending swap). Host path /var/unbound/pfb_py_reload.applied; chroot-relative here.
     pfb["pfb_py_reload_applied"] = "pfb_py_reload.applied"
+    # PFBL-03: the local privileged DNSBL-control command channel. PHP/shell (root only)
+    # atomically publishes a small JSON record carrying a monotonically-advancing
+    # sequence + the command; the control-watcher thread wakes on the directory change,
+    # ignores any record whose seq <= the last applied (exactly-once + replay safety),
+    # and routes a fresh one through pfb_apply_control_command(). Chroot-relative
+    # (Unbound's CWD is /var/unbound) -> host path /var/unbound/pfb_py_control. The
+    # writer keeps owner root, group unbound, mode 0640: root WRITES, unbound READS via
+    # group -- authorization is "only root may write" (no group/other write).
+    pfb["pfb_py_control"] = "pfb_py_control"
+    # PFBL-03: the APPLIED-sequence marker (mirrors pfb_py_reload.applied). After the
+    # control-watcher applies a record with seq N it writes N here (atomic temp+rename),
+    # so the writer can confirm execution. Host path /var/unbound/pfb_py_control.applied.
+    pfb["pfb_py_control_applied"] = "pfb_py_control.applied"
     pfb["pfb_py_count"] = "pfb_py_count"
     # ADR-07 P8: the ADMITTED (cap-filtered) feed+user regex total -- the count the
     # DNSBL_Regex UI alias reads (inc:8329). It is the live size of regexDB +
@@ -1369,6 +1552,22 @@ def init_standard(id: int, env: module_env) -> bool:
         except Exception as e:
             pfb["reload_watcher"] = False
             sys.stderr.write("[pfBlockerNG]: Failed to start reload watcher: {}".format(e))
+
+    # PFBL-03: start the DNSBL-control command-channel reader (daemon) when the feature is
+    # enabled. It waits on the control channel and routes a fresh command through the
+    # shared handler off the query threads -- the local privileged transport that replaces
+    # the DNS-TXT path.
+    if pfb["mod_threading"] and pfb["python_control"] and not pfb.get("control_watcher"):
+        try:
+            pfb_control_stop = threading.Event()
+            pfb_control_watcher_thread = threading.Thread(
+                name="pfb_control_watcher", target=pfb_control_watcher, daemon=True
+            )
+            pfb_control_watcher_thread.start()
+            pfb["control_watcher"] = True
+        except Exception as e:
+            pfb["control_watcher"] = False
+            sys.stderr.write("[pfBlockerNG]: Failed to start control watcher: {}".format(e))
 
     pfb_setup_logging()
 
@@ -2488,6 +2687,113 @@ def python_control_addbypass(duration: int, b_ip: str) -> bool:
     return False
 
 
+# PFBL-03: the SINGLE DNSBL-control command handler. Both transports route here -- the
+# legacy DNS-TXT branch (operate(), retired in a later phase) and the local privileged
+# command channel consumed by pfb_control_watcher() -- so the command grammar and its
+# side effects have exactly one implementation.
+#
+# ``control_command`` is the dot-split token list exactly as the DNS-TXT path builds it
+# (q_name "python_control.disable.60" -> ["python_control", "disable", "60"]); the file
+# reader builds the identical list from its JSON record. Validation contract (re-checked
+# here, never trusting the transport): a bypass IP must parse via ipaddress.ip_address()
+# and a duration must pass python_control_duration() (1-3600) before any side effect.
+#
+# Returns ``(applied, message)`` -- ``applied`` is the DNS-TXT branch's control_rcd
+# (True only when the command took effect), ``message`` its human-readable status. The
+# behaviour is BYTE-FOR-BYTE the prior DNS-TXT branch (disable/enable toggle
+# python_blacklist; addbypass/removebypass mutate gpListDB; durations spawn the same
+# timed re-enable/remove threads).
+def pfb_apply_control_command(control_command: list[str]) -> tuple[bool, str]:
+    global pfb, gpListDB
+
+    control_rcd = False
+    control_msg = ""
+
+    if len(control_command) >= 2:
+        if control_command[1] == "disable":
+            control_rcd = True
+            control_msg = "Python_control: DNSBL disabled"
+            pfb["python_blacklist"] = False
+
+            # If duration specified, disable DNSBL Blocking for specified time in seconds
+            if pfb["mod_threading"] and len(control_command) == 3 and control_command[2] != "":
+                # Validate Duration argument
+                duration = python_control_duration(control_command[2])
+                if duration:
+                    # Ensure thread is not active
+                    if not python_control_thread("sleep"):
+                        # Start Thread
+                        if not python_control_start_thread("sleep", python_control_sleep, duration, None):
+                            control_rcd = False
+                            control_msg = "Python_control: DNSBL disabled: Thread failed"
+                        else:
+                            control_msg = "{} for {} second(s)".format(control_msg, duration)
+                    else:
+                        control_rcd = False
+                        control_msg = "Python_control: DNSBL disabled: Previous call still in progress"
+                else:
+                    control_rcd = False
+                    control_msg = "Python_control: DNSBL disabled: duration [ {} ] out of range (1-3600sec)".format(
+                        control_command[2]
+                    )
+
+        elif control_command[1] == "enable":
+            control_rcd = True
+            control_msg = "Python_control: DNSBL enabled"
+            pfb["python_blacklist"] = True
+
+        elif control_command[1] == "addbypass" or control_command[1] == "removebypass":
+            b_ip = (control_command[2]).replace("-", ".")
+            isIPValid = ipaddress.ip_address(b_ip)
+
+            if isIPValid:
+                if not pfb["gpListDB"]:
+                    pfb["gpListDB"] = True
+
+                control_rcd = True
+                if control_command[1] == "addbypass":
+                    control_msg = "Python_control: Add bypass for IP: [ {} ]".format(b_ip)
+
+                    # If duration specified, disable DNSBL Blocking for specified time in seconds
+                    if pfb["mod_threading"] and len(control_command) == 4 and control_command[3] != "":
+                        # Validate Duration argument
+                        duration = python_control_duration(control_command[3])
+                        if duration:
+                            # Ensure thread is not active
+                            if not python_control_thread("addbypass" + b_ip):
+                                # Start Thread
+                                if not python_control_start_thread(
+                                    "addbypass" + b_ip, python_control_addbypass, duration, b_ip
+                                ):
+                                    control_rcd = False
+                                    control_msg = "Python_control: Add bypass for IP: [ {} ] thread failed".format(b_ip)
+                                else:
+                                    control_msg = "{} for {} second(s)".format(control_msg, duration)
+                            else:
+                                control_rcd = False
+                                control_msg = (
+                                    "Python_control: Add bypass for IP: [ {} ]: Previous call still in progress"
+                                ).format(b_ip)
+                        else:
+                            control_rcd = False
+                            control_msg = (
+                                "Python_control: Add bypass for IP: [ {} ]: duration [ {} ] out of range (1-3600sec)"
+                            ).format(b_ip, control_command[3])
+                    else:
+                        # Add bypass called without duration
+                        if control_rcd:
+                            gpListDB[b_ip] = 0
+
+                elif control_command[1] == "removebypass":
+                    if gpListDB.get(b_ip) is not None:
+                        control_msg = "Python_control: Remove bypass for IP: [ {} ]".format(b_ip)
+                        gpListDB.pop(b_ip)
+                    else:
+                        control_msg = "Python_control: IP not in Group Policy: [ {} ]".format(b_ip)
+
+    return control_rcd, control_msg
+
+
 def inplace_cb_reply(
     qinfo: query_info,
     qstate: module_qstate,
@@ -2553,7 +2859,9 @@ def deinit(id: int) -> bool:
         pfb_db_queue, \
         pfb_db_worker_thread, \
         pfb_reload_watcher_thread, \
-        pfb_reload_stop
+        pfb_reload_stop, \
+        pfb_control_watcher_thread, \
+        pfb_control_stop
 
     if pfb["python_maxmind"]:
         maxmindReader.close()
@@ -2569,6 +2877,16 @@ def deinit(id: int) -> bool:
         except Exception:
             pass
         pfb["reload_watcher"] = False
+
+    # PFBL-03: stop the control-channel reader cleanly (same pattern as the reload
+    # watcher -- set the stop Event to wake the kqueue/poll wait, then a bounded join).
+    if pfb.get("control_watcher"):
+        try:
+            pfb_control_stop.set()
+            pfb_control_watcher_thread.join(timeout=5)
+        except Exception:
+            pass
+        pfb["control_watcher"] = False
 
     # Drain and stop the background DB-write worker, then close connections
     if pfb.get("db_worker"):
@@ -5200,95 +5518,9 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
             control_msg = ""
             if pfb["python_control"] and q_ip == "127.0.0.1":
                 control_command = q_name_original.split(".")
-                if len(control_command) >= 2:
-                    if control_command[1] == "disable":
-                        control_rcd = True
-                        control_msg = "Python_control: DNSBL disabled"
-                        pfb["python_blacklist"] = False
-
-                        # If duration specified, disable DNSBL Blocking for specified time in seconds
-                        if pfb["mod_threading"] and len(control_command) == 3 and control_command[2] != "":
-                            # Validate Duration argument
-                            duration = python_control_duration(control_command[2])
-                            if duration:
-                                # Ensure thread is not active
-                                if not python_control_thread("sleep"):
-                                    # Start Thread
-                                    if not python_control_start_thread("sleep", python_control_sleep, duration, None):
-                                        control_rcd = False
-                                        control_msg = "Python_control: DNSBL disabled: Thread failed"
-                                    else:
-                                        control_msg = "{} for {} second(s)".format(control_msg, duration)
-                                else:
-                                    control_rcd = False
-                                    control_msg = "Python_control: DNSBL disabled: Previous call still in progress"
-                            else:
-                                control_rcd = False
-                                control_msg = (
-                                    "Python_control: DNSBL disabled: duration [ {} ] out of range (1-3600sec)".format(
-                                        control_command[2]
-                                    )
-                                )
-
-                    elif control_command[1] == "enable":
-                        control_rcd = True
-                        control_msg = "Python_control: DNSBL enabled"
-                        pfb["python_blacklist"] = True
-
-                    elif control_command[1] == "addbypass" or control_command[1] == "removebypass":
-                        b_ip = (control_command[2]).replace("-", ".")
-                        isIPValid = ipaddress.ip_address(b_ip)
-
-                        if isIPValid:
-                            if not pfb["gpListDB"]:
-                                pfb["gpListDB"] = True
-
-                            control_rcd = True
-                            if control_command[1] == "addbypass":
-                                control_msg = "Python_control: Add bypass for IP: [ {} ]".format(b_ip)
-
-                                # If duration specified, disable DNSBL Blocking for specified time in seconds
-                                if pfb["mod_threading"] and len(control_command) == 4 and control_command[3] != "":
-                                    # Validate Duration argument
-                                    duration = python_control_duration(control_command[3])
-                                    if duration:
-                                        # Ensure thread is not active
-                                        if not python_control_thread("addbypass" + b_ip):
-                                            # Start Thread
-                                            if not python_control_start_thread(
-                                                "addbypass" + b_ip, python_control_addbypass, duration, b_ip
-                                            ):
-                                                control_rcd = False
-                                                control_msg = (
-                                                    "Python_control: Add bypass for IP: [ {} ] thread failed".format(
-                                                        b_ip
-                                                    )
-                                                )
-                                            else:
-                                                control_msg = "{} for {} second(s)".format(control_msg, duration)
-                                        else:
-                                            control_rcd = False
-                                            control_msg = (
-                                                "Python_control: Add bypass for IP:"
-                                                " [ {} ]: Previous call still in progress"
-                                            ).format(b_ip)
-                                    else:
-                                        control_rcd = False
-                                        control_msg = (
-                                            "Python_control: Add bypass for IP:"
-                                            " [ {} ]: duration [ {} ] out of range (1-3600sec)"
-                                        ).format(b_ip, control_command[3])
-                                else:
-                                    # Add bypass called without duration
-                                    if control_rcd:
-                                        gpListDB[b_ip] = 0
-
-                            elif control_command[1] == "removebypass":
-                                if gpListDB.get(b_ip) is not None:
-                                    control_msg = "Python_control: Remove bypass for IP: [ {} ]".format(b_ip)
-                                    gpListDB.pop(b_ip)
-                                else:
-                                    control_msg = "Python_control: IP not in Group Policy: [ {} ]".format(b_ip)
+                # PFBL-03: route to the SINGLE shared handler (also used by the local
+                # privileged command channel) -- one implementation of the grammar.
+                control_rcd, control_msg = pfb_apply_control_command(control_command)
 
                 if control_rcd:
                     q_reply = "python_control"

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -921,6 +921,12 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["python_enable"] = False
     pfb["python_nolog"] = False
     pfb["python_control"] = False
+    # PFBL-03: the legacy DNS-TXT control transport is OFF by default and gated behind
+    # this separate opt-in. DNSBL control is CLI-driven (pfblockerng dnsbl-control ...) via
+    # the local privileged command file; the DNS-TXT path is deprecated and slated for
+    # removal next release. NEXT RELEASE (PFBL-03): drop python_control_legacy + the
+    # DNS-TXT branch in operate() + the IPv4-only ``::1`` quirk entirely.
+    pfb["python_control_legacy"] = False
     pfb["python_maxmind"] = False
     pfb["python_blocking"] = False
     pfb["python_blacklist"] = False
@@ -1106,6 +1112,8 @@ def init_standard(id: int, env: module_env) -> bool:
                 pfb["python_cname"] = config.getboolean("MAIN", "python_cname")
             if config.has_option("MAIN", "python_control"):
                 pfb["python_control"] = config.getboolean("MAIN", "python_control")
+            if config.has_option("MAIN", "python_control_legacy"):
+                pfb["python_control_legacy"] = config.getboolean("MAIN", "python_control_legacy")
 
             # ADR-07 P7: regex-safety knobs. ``regex_cap`` is the opt-in "Limit
             # long/complex regex" static pre-filter (drops over-long/nested-quantifier
@@ -5513,7 +5521,17 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                     return True
 
         # Python_control - Receive TXT commands from pfSense local IP
-        if qstate_valid and q_type == RR_TYPE_TXT and q_name_original.startswith("python_control."):
+        # PFBL-03: DEPRECATED legacy DNS-TXT control transport. Inert unless the operator
+        # explicitly opts back in via ``python_control_legacy``; OFF by default, no DNSBL
+        # control command is honoured over DNS-TXT. DNSBL control is CLI-driven
+        # (pfblockerng dnsbl-control ...) over the local privileged command file. This whole
+        # branch is slated for removal next release.
+        if (
+            pfb["python_control_legacy"]
+            and qstate_valid
+            and q_type == RR_TYPE_TXT
+            and q_name_original.startswith("python_control.")
+        ):
             control_rcd = False
             control_msg = ""
             if pfb["python_control"] and q_ip == "127.0.0.1":

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2751,8 +2751,14 @@ def pfb_apply_control_command(control_command: list[str]) -> tuple[bool, str]:
             pfb["python_blacklist"] = True
 
         elif control_command[1] == "addbypass" or control_command[1] == "removebypass":
+            # PFBL-03: reject a malformed bypass command instead of raising
+            if len(control_command) < 3 or control_command[2] == "":
+                return False, "Python_control: Missing bypass IP"
             b_ip = (control_command[2]).replace("-", ".")
-            isIPValid = ipaddress.ip_address(b_ip)
+            try:
+                isIPValid = ipaddress.ip_address(b_ip)
+            except ValueError:
+                return False, "Python_control: Invalid IP: [ {} ]".format(b_ip)
 
             if isIPValid:
                 if not pfb["gpListDB"]:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4177,12 +4177,15 @@ function pfb_unbound_py_atomic_write_root($path, $content) {
 		return FALSE;
 	}
 
-	$ok = (@fwrite($fh, $content) !== FALSE);
+	// Require the FULL content to land (fwrite returns the byte count, not just
+	// TRUE/FALSE) and that the durability barrier itself succeeds, so a truncated or
+	// unflushed command record is never published as success.
+	$written = @fwrite($fh, $content);
+	$ok = ($written === strlen($content));
 	if ($ok) {
-		@fflush($fh);
 		// Durably persist the staged bytes before the rename so a crash cannot
 		// expose a half-written command record.
-		@fsync($fh);
+		$ok = (@fflush($fh) && @fsync($fh));
 	}
 	@fclose($fh);
 
@@ -9746,7 +9749,7 @@ function sync_package_pfblockerng($cron='') {
 	$pfb['dnsbl_alexa_inc']	= $pfb['dnsblconfig']['alexa_inclusion']?: '';			// TOP1M TLDs inclusions for whitelisting
 	$pfb['dnsbl_tld']	= $pfb['dnsblconfig']['pfb_tld'];				// Enable TLD Function
 	$pfb['dnsbl_control']	= $pfb['dnsblconfig']['pfb_control']	?: '';			// Python Control integration
-	$pfb['dnsbl_control_legacy']	= $pfb['dnsblconfig']['pfb_control_legacy']	?: '';	// PFBL-03: deprecated legacy DNS-TXT control transport
+	$pfb['dnsbl_control_legacy']	= $pfb['dnsblconfig']['pfb_control_legacy']	?? '';	// PFBL-03: deprecated legacy DNS-TXT control transport
 
 	// Validate pfB Script variable
 	$pfb['dnsbl_alexa_inc'] = pfb_filter($pfb['dnsbl_alexa_inc'], PFB_FILTER_CSV, 'Validate pfB Script variable');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4153,6 +4153,140 @@ function pfb_unbound_py_wait_applied($gen, $timeout_s = 30) {
 }
 
 
+// PFBL-03: atomically publish the DNSBL-control command channel to the chroot
+// (/var/unbound/pfb_py_control). Mirrors pfb_unbound_py_atomic_write (stage -> fwrite ->
+// fflush -> fsync -> rename) but uses a COMMAND-CHANNEL permission model rather than the
+// data model: the published file keeps owner ROOT, group unbound, mode 0640 -- root
+// WRITES, unbound READS via its group, no write for group/other, no access for other.
+// The authorization is therefore purely "only root may write": the channel is unwritable
+// by the unbound user that consumes it (and by everyone else). This is why the data
+// publisher (which chowns to owner unbound) is NOT reused here. Returns TRUE on success;
+// no die()/exit() -- a failure is logged + returned FALSE.
+function pfb_unbound_py_atomic_write_root($path, $content) {
+	$dir = dirname($path);
+	$tmp = @tempnam($dir, '.pfbctl_');
+	if ($tmp === FALSE) {
+		pfb_logger("\nPFBL-03: failed to stage control write for [ {$path} ]", 2);
+		return FALSE;
+	}
+
+	$fh = @fopen($tmp, 'wb');
+	if ($fh === FALSE) {
+		@unlink($tmp);
+		pfb_logger("\nPFBL-03: failed to open control staging file [ {$tmp} ]", 2);
+		return FALSE;
+	}
+
+	$ok = (@fwrite($fh, $content) !== FALSE);
+	if ($ok) {
+		@fflush($fh);
+		// Durably persist the staged bytes before the rename so a crash cannot
+		// expose a half-written command record.
+		@fsync($fh);
+	}
+	@fclose($fh);
+
+	if (!$ok) {
+		@unlink($tmp);
+		pfb_logger("\nPFBL-03: failed to write control staging file [ {$tmp} ]", 2);
+		return FALSE;
+	}
+
+	// Command-channel permission model: owner root, group unbound, mode 0640. Set it on
+	// the staging inode so the rename publishes the correctly-owned/permissioned file
+	// atomically. root is the staging file's owner already (the package runs as root);
+	// set the group explicitly so the consuming (chrooted) unbound user can READ it, and
+	// the mode so only the owner may write.
+	@chown($tmp, 'root');
+	@chgrp($tmp, 'unbound');
+	@chmod($tmp, 0640);
+
+	if (!@rename($tmp, $path)) {
+		@unlink($tmp);
+		pfb_logger("\nPFBL-03: failed to publish control channel [ {$path} ]", 2);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+
+// PFBL-03: root-only DNSBL-control writer. Validates the command + its argument (the
+// SEMANTIC layer -- a bypass IP through pfb_filter(PFB_FILTER_IP), a duration through
+// pfb_filter(PFB_FILTER_NUM) clamped to 1-3600), assembles a small JSON record carrying a
+// monotonically-advancing SEQUENCE, and atomically publishes it to the local privileged
+// command channel with the root:unbound 0640 permission model (pfb_unbound_py_atomic_write_root).
+// The control-watcher in pfb_unbound.py consumes a record only when its seq advances
+// (exactly-once + replay safety) and re-validates every argument again before any side
+// effect, so this writer and the reader form a dual-validation boundary.
+//
+//   $cmd      one of disable|enable|addbypass|removebypass
+//   $ip       required for addbypass/removebypass (a v4/v6 literal); ignored otherwise
+//   $duration optional seconds (1-3600) for disable/addbypass; ignored otherwise
+//
+// Returns the published sequence (>= 1) on success, or FALSE on an invalid command /
+// invalid argument / write failure. No die()/exit().
+function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '') {
+	global $pfb;
+
+	$valid_cmds = array('disable', 'enable', 'addbypass', 'removebypass');
+	if (!in_array($cmd, $valid_cmds, TRUE)) {
+		pfb_logger("\nPFBL-03: control command not authorized [ " . htmlspecialchars((string) $cmd) . " ]", 2);
+		return FALSE;
+	}
+
+	$record = array('cmd' => $cmd);
+
+	// Validate the bypass IP for the commands that take one (the semantic layer).
+	if ($cmd == 'addbypass' || $cmd == 'removebypass') {
+		$clean_ip = pfb_filter($ip, PFB_FILTER_IP, 'pfb_unbound_py_write_control');
+		if (empty($clean_ip)) {
+			pfb_logger("\nPFBL-03: control command [ {$cmd} ] rejected: invalid IP", 2);
+			return FALSE;
+		}
+		$record['ip'] = $clean_ip;
+	}
+
+	// Validate the optional duration for the commands that take one (1-3600 seconds).
+	if (($cmd == 'disable' || $cmd == 'addbypass') && $duration !== '' && $duration !== NULL) {
+		$clean_dur = pfb_filter($duration, PFB_FILTER_NUM, 'pfb_unbound_py_write_control');
+		if (empty($clean_dur) || (int) $clean_dur < 1 || (int) $clean_dur > 3600) {
+			pfb_logger("\nPFBL-03: control command [ {$cmd} ] rejected: duration out of range (1-3600)", 2);
+			return FALSE;
+		}
+		$record['duration'] = (int) $clean_dur;
+	}
+
+	// Read the current sequence from the channel (first line is no longer used; the seq
+	// rides INSIDE the JSON record) and advance it. A missing/unparseable record -> 1.
+	$channel = "{$pfb['dnsbldir']}/pfb_py_control";
+	$cur = 0;
+	if (file_exists($channel)) {
+		$raw = @file_get_contents($channel);
+		if ($raw !== FALSE && $raw !== '') {
+			$prev = @json_decode($raw, TRUE);
+			if (is_array($prev) && isset($prev['seq']) && is_int($prev['seq'])) {
+				$cur = $prev['seq'];
+			}
+		}
+	}
+	$record['seq'] = $cur + 1;
+	$record['ts']  = time();
+
+	$payload = json_encode($record);
+	if ($payload === FALSE) {
+		pfb_logger("\nPFBL-03: control command [ {$cmd} ] rejected: encode failure", 2);
+		return FALSE;
+	}
+
+	if (!pfb_unbound_py_atomic_write_root($channel, $payload . "\n")) {
+		return FALSE;
+	}
+
+	return $record['seq'];
+}
+
+
 // ADR-10 P5: PRIMARY RAM gate for the zero-downtime swap (the Python watcher re-checks
 // it as a safety net -- RESULTS/04 SS3). The background rebuild holds the OLD and NEW
 // matcher structures resident at once (~2x transient); on a constrained box that bust

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4734,6 +4734,14 @@ function pfb_unbound_python($mode) {
 			$python_control = 'on';
 		}
 
+		// PFBL-03: deprecated legacy DNS-TXT control transport. OFF unless the operator
+		// explicitly opted back in (and the parent DNSBL Control toggle is enabled).
+		// DNSBL control is CLI-driven; this path is slated for removal next release.
+		$python_control_legacy = 'off';
+		if ($pfb['dnsbl_control'] == 'on' && $pfb['dnsbl_control_legacy'] == 'on') {
+			$python_control_legacy = 'on';
+		}
+
 		$python_noaaaa = 'off';
 		if ($pfb['dnsbl_noaaaa'] == 'on') {
 			$python_noaaaa = 'on';
@@ -4802,6 +4810,7 @@ python_tlds	= {$python_tlds}
 python_nolog	= {$python_nolog}
 python_cname	= {$python_cname}
 python_control	= {$python_control}
+python_control_legacy	= {$python_control_legacy}
 regex_cap	= {$regex_cap}
 
 EOF;
@@ -6151,6 +6160,32 @@ function pfb_feed_filter_install_default($gconfig) {
 		return 'off';
 	}
 	return NULL;
+}
+
+
+// PFBL-03: one-time upgrade seed for the deprecated legacy DNS-TXT control sub-toggle.
+// $dconfig is the existing DNSBL-settings 'config/0' node. DNSBL control is CLI-driven and
+// the DNS-TXT transport is OFF by default; to avoid breaking an operator already driving
+// control over DNS TXT, the legacy sub-toggle is seeded ON IFF the pre-existing config
+// already had DNSBL Control enabled ('pfb_control' == 'on') at this upgrade. A one-shot
+// marker ('pfb_control_legacy_seeded') makes this run EXACTLY ONCE: once set, the function
+// returns NULL (no change), so a later save never re-seeds and never re-enables a toggle
+// the operator deliberately turned back off. Returns the updated config array to persist,
+// or NULL when nothing should change (empty config, or the seed already ran). Slated for
+// removal next release with the rest of the legacy DNS-TXT path.
+function pfb_control_legacy_seed($dconfig) {
+
+	if (!is_array($dconfig) || empty($dconfig)) {
+		return NULL;
+	}
+	if (($dconfig['pfb_control_legacy_seeded'] ?? '') === 'on') {
+		return NULL;
+	}
+	if (($dconfig['pfb_control'] ?? '') == 'on') {
+		$dconfig['pfb_control_legacy'] = 'on';
+	}
+	$dconfig['pfb_control_legacy_seeded'] = 'on';
+	return $dconfig;
 }
 
 
@@ -9711,6 +9746,7 @@ function sync_package_pfblockerng($cron='') {
 	$pfb['dnsbl_alexa_inc']	= $pfb['dnsblconfig']['alexa_inclusion']?: '';			// TOP1M TLDs inclusions for whitelisting
 	$pfb['dnsbl_tld']	= $pfb['dnsblconfig']['pfb_tld'];				// Enable TLD Function
 	$pfb['dnsbl_control']	= $pfb['dnsblconfig']['pfb_control']	?: '';			// Python Control integration
+	$pfb['dnsbl_control_legacy']	= $pfb['dnsblconfig']['pfb_control_legacy']	?: '';	// PFBL-03: deprecated legacy DNS-TXT control transport
 
 	// Validate pfB Script variable
 	$pfb['dnsbl_alexa_inc'] = pfb_filter($pfb['dnsbl_alexa_inc'], PFB_FILTER_CSV, 'Validate pfB Script variable');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -115,8 +115,9 @@ fi
 
 # Remove the private per-run temp directory before exiting (issue #30).
 exitnow() {
+	rc="${1:-0}"
 	rm -rf "${tmpdir}"
-	exit
+	exit "${rc}"
 }
 
 
@@ -1326,6 +1327,7 @@ case "${1}" in
 		#        addbypass <ip> [sec] | removebypass <ip>
 		shift
 		/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dnsbl-control "$@"
+		exitnow "$?"
 		;;
 	closing)
 		emptyfiles

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1317,6 +1317,16 @@ case "${1}" in
 	aliastables)
 		aliastables
 		;;
+	dnsbl-control)
+		# PFBL-03: root-only DNSBL-control CLI. Forwards the operator's command to the
+		# PHP writer, which validates it and writes it to the local privileged command
+		# channel consumed by pfb_unbound.py. The arguments ride as their own positional
+		# parameters (no URL/shell interpolation); the writer re-validates each.
+		# Usage: pfblockerng dnsbl-control disable [sec] | enable |
+		#        addbypass <ip> [sec] | removebypass <ip>
+		shift
+		/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dnsbl-control "$@"
+		;;
 	closing)
 		emptyfiles
 		closingprocess

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -116,6 +116,19 @@ if (!empty($cfg) && (($cfg['dnsbl_mode'] ?? '') !== 'dnsbl_python' || ($cfg['pfb
 }
 unset($cfg);
 
+// PFBL-03: one-time seed of the deprecated legacy DNS-TXT control sub-toggle. DNSBL
+// control is now CLI-driven; the DNS-TXT transport is OFF by default. The run-once,
+// iff-grandfather decision is pfb_control_legacy_seed() (NULL => leave unchanged); it seeds
+// 'pfb_control_legacy' ON only when the pre-existing config already had DNSBL Control
+// enabled, and a one-shot marker keeps it from re-seeding on later saves.
+$cfg = config_get_path('installedpackages/pfblockerngdnsblsettings/config/0', []);
+$cfg_seeded = pfb_control_legacy_seed($cfg);
+if ($cfg_seeded !== NULL) {
+	config_set_path('installedpackages/pfblockerngdnsblsettings/config/0', $cfg_seeded);
+	write_config('pfBlockerNG: seeded legacy DNSBL control toggle (PFBL-03)');
+}
+unset($cfg, $cfg_seeded);
+
 // MaxMind Database is no longer pre-installed during package installation
 if (empty($pfb['maxmind_key'])) {
 	update_status("\nMaxMind GeoIP databases are not pre-installed during installation.\nTo utilize the MaxMind GeoIP functionalities, you will be required to register for a free MaxMind user account and access key. Review the IP tab: MaxMind Settings for more details.\n\n");

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -107,6 +107,30 @@ if (isset($argv[1])) {
 		pfblockerng_ss_refresh();
 		exit;
 	}
+	// PFBL-03: root-only DNSBL-control entrypoint. Writes a validated command to the
+	// local privileged command channel consumed by pfb_unbound.py.
+	// Usage: pfblockerng.php dnsbl-control <disable [sec] | enable |
+	//        addbypass <ip> [sec] | removebypass <ip>>
+	// The writer (pfb_unbound_py_write_control) re-validates the command + argument and
+	// the reader re-validates again, so an invalid command prints an error and exits 1.
+	elseif ($argv[1] == 'dnsbl-control') {
+		$cmd = $argv[2] ?? '';
+		$ip  = '';
+		$dur = '';
+		if ($cmd == 'addbypass' || $cmd == 'removebypass') {
+			$ip  = $argv[3] ?? '';
+			$dur = $argv[4] ?? '';	// only addbypass honours it; writer ignores it for removebypass
+		} else {
+			$dur = $argv[3] ?? '';	// disable [sec]; enable ignores it
+		}
+		$seq = pfb_unbound_py_write_control($cmd, $ip, $dur);
+		if ($seq === FALSE) {
+			echo "DNSBL control command failed (invalid command/argument or write error)\n";
+			exit(1);
+		}
+		echo "DNSBL control command [ {$cmd} ] queued (seq {$seq})\n";
+		exit;
+	}
 }
 
 // Extras - MaxMind/TOP1M Download URLs/filenames/settings

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -42,6 +42,7 @@ $pconfig = array();
 $pconfig['pfb_dnsbl']		= $pfb['dconfig']['pfb_dnsbl']				?: '';
 $pconfig['pfb_tld']		= $pfb['dconfig']['pfb_tld']				?: '';
 $pconfig['pfb_control']		= $pfb['dconfig']['pfb_control']			?: '';
+$pconfig['pfb_control_legacy']	= $pfb['dconfig']['pfb_control_legacy']			?: '';
 $pconfig['pfb_dnsvip4'] = $pfb['dconfig']['pfb_dnsvip4'] ?: 'none';
 $pconfig['pfb_dnsvip6'] = $pfb['dconfig']['pfb_dnsvip6'] ?: 'none';
 $pconfig['pfb_dnsvip_auto']	= $pfb['dconfig']['pfb_dnsvip_auto']			?: '';
@@ -526,6 +527,7 @@ if ($_POST) {
 			$pfb['dconfig']['pfb_dnsbl']		= pfb_filter($_POST['pfb_dnsbl'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_tld']		= pfb_filter($_POST['pfb_tld'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_control']		= pfb_filter($_POST['pfb_control'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
+			$pfb['dconfig']['pfb_control_legacy']	= pfb_filter($_POST['pfb_control_legacy'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 
 			// [ ADR-13 ] Persist the auto-create decision. When ON, leave the stored
 			// pfb_dnsvip4/6 ids untouched here (the manual dropdowns are disabled): the
@@ -767,10 +769,10 @@ $section->addInput(new Form_Checkbox(
 	'Enable',
 	$pconfig['pfb_control'] === 'on' ? true:false,
 	'on'
-))->setHelp('Enabling this option will allow sending python_control commands (via DNS TXT) to DNSBL.'
+))->setHelp('Enabling this option will allow sending DNSBL control commands via the local CLI.'
 	. '<div class="infoblock" style="width: 90%;">'
-	. 'The python_control feature is limited to DNS TXT records sent from pfSense localhost (127.0.0.1) only!<br />'
-	. 'This is a temporary intervention, and will be reset on a restart of the Resolver<br />'
+	. 'Commands are run on pfSense as root via the <strong>pfblockerng dnsbl-control</strong> CLI<br />'
+	. 'A disable is a temporary intervention, and will be reset on a restart of the Resolver<br />'
 	. 'These commands can be incorporated in CRON/Scheduler tasks or run manually as required<br />'
 	. 'All events are logged to the Reports Tab (Gear icon)<br /><br />'
 	. '<strong>Command Syntax:</strong><br />'
@@ -783,14 +785,27 @@ $section->addInput(new Form_Checkbox(
 	. '		</tr>'
 	. '	</thead>'
 	. '	<tbody>'
-	. '		<tr><td>Enable DNSBL</td><td>drill TXT python_control.enable</td><td></td></tr>'
-	. '		<tr><td>Disable DNSBL</td><td>drill TXT python_control.disable</td><td></td></tr>'
-	. '		<tr><td>Disable DNSBL for duration</td><td>drill TXT python_control.disable.seconds</td><td>Seconds: 1-3600</td></tr>'
-	. '		<tr><td>Add a Global bypass IP</td><td>drill TXT python_control.addbypass.1-2-3-4</td><td>Use "-" in place of "."</td></tr>'
-	. '		<tr><td>Add a Global bypass IP for duration</td><td>drill TXT python_control.addbypass.1-2-3-4.seconds</td><td>Seconds: 1-3600</td></tr>'
-	. '		<tr><td>Remove a Global bypass IP</td><td>;drill TXT python_control.removebypass.1-2-3-4</td><td>Use "-" in place of "."</td></tr>'
+	. '		<tr><td>Enable DNSBL</td><td>pfblockerng dnsbl-control enable</td><td></td></tr>'
+	. '		<tr><td>Disable DNSBL</td><td>pfblockerng dnsbl-control disable</td><td></td></tr>'
+	. '		<tr><td>Disable DNSBL for duration</td><td>pfblockerng dnsbl-control disable seconds</td><td>Seconds: 1-3600</td></tr>'
+	. '		<tr><td>Add a Global bypass IP</td><td>pfblockerng dnsbl-control addbypass 1.2.3.4</td><td></td></tr>'
+	. '		<tr><td>Add a Global bypass IP for duration</td><td>pfblockerng dnsbl-control addbypass 1.2.3.4 seconds</td><td>Seconds: 1-3600</td></tr>'
+	. '		<tr><td>Remove a Global bypass IP</td><td>pfblockerng dnsbl-control removebypass 1.2.3.4</td><td></td></tr>'
 	. '	</tbody>'
 	. '</table>'
+	. '</div>');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_control_legacy',
+	gettext('DNSBL Control (legacy DNS TXT)'),
+	'Enable',
+	$pconfig['pfb_control_legacy'] === 'on' ? true:false,
+	'on'
+))->setHelp('<span class="text-danger">Deprecated</span> - re-enable the legacy DNS TXT control transport (drill TXT python_control.*).'
+	. '<div class="infoblock" style="width: 90%;">'
+	. 'This option is <strong>deprecated</strong>, <strong>less secure</strong>, and will be <strong>removed next release</strong>.<br />'
+	. 'It only takes effect when <strong>DNSBL Control</strong> above is enabled. Leave it off and use the CLI instead.<br />'
+	. 'Migrate any CRON/Scheduler tasks from drill TXT python_control.* to the pfblockerng dnsbl-control CLI shown above.'
 	. '</div>');
 
 $section->addInput(new Form_Checkbox(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,12 @@ def reset_pfb_globals() -> None:
         "pfb_py_dnsbl": ":memory:",
         "pfb_py_resolver": ":memory:",
         "pfb_py_cache": ":memory:",
+        # PFBL-03: the local privileged control channel + its applied-seq marker
+        # (chroot-relative, exactly as init_standard sets them). Tests that drive the
+        # reader thread override these to a temp path; the keys exist here so a unit
+        # test can read the stable names without spinning up the watcher.
+        "pfb_py_control": "pfb_py_control",
+        "pfb_py_control_applied": "pfb_py_control.applied",
     }
     pfb_unbound.dataDB = defaultdict(list)
     pfb_unbound.zoneDB = defaultdict(list)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ def reset_pfb_globals() -> None:
         "python_nolog": False,
         "python_cname": False,
         "python_control": False,
+        "python_control_legacy": False,
         "python_hsts": False,
         "python_idn": False,
         "python_tld": False,

--- a/tests/php/ControlLegacySeedTest.php
+++ b/tests/php/ControlLegacySeedTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_control_legacy_seed() -- the one-time upgrade seed for the deprecated legacy
+ * DNS-TXT control sub-toggle (PFBL-03). DNSBL control is CLI-driven; the DNS-TXT
+ * transport is OFF by default. To keep an operator already driving control over DNS TXT
+ * working through the one-release migration window, the legacy sub-toggle is seeded ON
+ * IFF the pre-existing config already had DNSBL Control enabled at this upgrade. A
+ * one-shot marker makes the seed run EXACTLY ONCE.
+ *
+ * Contract:
+ *   - empty/non-array config => NULL (nothing to seed).
+ *   - pfb_control == 'on' and not yet seeded => legacy ON + marker set.
+ *   - pfb_control absent/off and not yet seeded => legacy left OFF, marker set.
+ *   - already seeded (marker present) => NULL, regardless of pfb_control -- run-once,
+ *     and an operator who cleared the legacy toggle is never re-enabled.
+ */
+#[CoversFunction('pfb_control_legacy_seed')]
+final class ControlLegacySeedTest extends TestCase
+{
+	public function testEmptyConfigIsNoSeed(): void
+	{
+		// A fresh, never-configured install has nothing to grandfather.
+		$this->assertNull(pfb_control_legacy_seed([]));
+		$this->assertNull(pfb_control_legacy_seed(null));
+	}
+
+	public function testControlOnSeedsLegacyOnAndMarks(): void
+	{
+		// BEFORE: DNSBL Control was enabled over DNS TXT; legacy toggle unset.
+		$dconfig = ['pfb_control' => 'on', 'pfb_dnsbl' => 'on'];
+		$this->assertArrayNotHasKey('pfb_control_legacy', $dconfig);
+
+		// WHEN: the one-time seed runs.
+		$out = pfb_control_legacy_seed($dconfig);
+
+		// THEN: the deprecated path is kept working (seeded ON) and the run-once marker set.
+		$this->assertIsArray($out);
+		$this->assertSame('on', $out['pfb_control_legacy']);
+		$this->assertSame('on', $out['pfb_control_legacy_seeded']);
+	}
+
+	public function testControlOffLeavesLegacyOffButMarks(): void
+	{
+		// A box that never enabled DNSBL Control: no DNS-TXT path active by default.
+		$out = pfb_control_legacy_seed(['pfb_control' => '', 'pfb_dnsbl' => 'on']);
+		$this->assertIsArray($out);
+		$this->assertArrayNotHasKey('pfb_control_legacy', $out);  // left OFF.
+		$this->assertSame('on', $out['pfb_control_legacy_seeded']);  // but the seed ran.
+	}
+
+	public function testControlAbsentLeavesLegacyOffButMarks(): void
+	{
+		// pfb_control key absent entirely (older/minimal config) is also treated as OFF.
+		$out = pfb_control_legacy_seed(['pfb_dnsbl' => 'on']);
+		$this->assertIsArray($out);
+		$this->assertArrayNotHasKey('pfb_control_legacy', $out);
+		$this->assertSame('on', $out['pfb_control_legacy_seeded']);
+	}
+
+	public function testAlreadySeededIsNoOpEvenWithControlOn(): void
+	{
+		// Run-once: a second pass does nothing even though pfb_control is on.
+		$dconfig = ['pfb_control' => 'on', 'pfb_control_legacy_seeded' => 'on'];
+		$this->assertNull(pfb_control_legacy_seed($dconfig));
+	}
+
+	public function testAlreadySeededDoesNotReEnableUserClearedToggle(): void
+	{
+		// The operator deliberately turned the legacy toggle back OFF after the seed.
+		// A later upgrade pass MUST NOT re-enable it (NULL => no change written).
+		$dconfig = [
+			'pfb_control' => 'on',
+			'pfb_control_legacy' => '',
+			'pfb_control_legacy_seeded' => 'on',
+		];
+		$this->assertNull(pfb_control_legacy_seed($dconfig));
+	}
+
+	public function testSeedIsExactlyOnceAcrossTwoPasses(): void
+	{
+		// First pass seeds (control on -> legacy on + marker). Feeding the RESULT back in
+		// (a simulated second upgrade) yields NULL -> the seed never runs twice.
+		$first = pfb_control_legacy_seed(['pfb_control' => 'on']);
+		$this->assertSame('on', $first['pfb_control_legacy']);
+		$this->assertNull(pfb_control_legacy_seed($first));
+	}
+}

--- a/tests/php/UnboundPyControlWriteTest.php
+++ b/tests/php/UnboundPyControlWriteTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * PFBL-03 privileged DNSBL-control writer: pfb_unbound_py_write_control() and its
+ * permission-specific publisher pfb_unbound_py_atomic_write_root().
+ *
+ * Scenario: the writer is the ROOT-only producer of the local privileged command
+ * channel (/var/unbound/pfb_py_control, here redirected to a temp dnsbldir). It
+ * validates the command + argument (the semantic layer), assembles a JSON record with
+ * a monotonically-advancing sequence, and atomically publishes it. These tests pin:
+ *   - the command allow-list (disable/enable/addbypass/removebypass) and rejection of
+ *     anything else (no file written);
+ *   - argument validation at the WRITER (invalid IP / out-of-range duration rejected,
+ *     no side effect) -- the reader re-validates independently (Python suite);
+ *   - the record shape (cmd/ip/duration/seq/ts) and the seq advance (replay safety);
+ *   - the publisher's command-channel permission model (owner root, group unbound,
+ *     mode 0640) and its atomic, no-temp-left-behind behaviour.
+ *
+ * Run against a temp $pfb sandbox (no live box, no chroot). chown('root') is a no-op
+ * for a non-root test runner; mode 0640 is asserted because it does not need privilege.
+ */
+#[CoversFunction('pfb_unbound_py_write_control')]
+#[CoversFunction('pfb_unbound_py_atomic_write_root')]
+final class UnboundPyControlWriteTest extends TestCase
+{
+	private string $tmp;
+	private array $originalPfb = [];
+	private bool $hadPfb = false;
+
+	protected function setUp(): void
+	{
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+
+		$this->tmp = sys_get_temp_dir() . '/pfb_control_' . uniqid('', true);
+		mkdir($this->tmp, 0777, true);
+
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dnsbldir' => $this->tmp,
+			'supp'     => 'off',	// pfb_filter()'s private/reserved IP exclusion off for the test
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		$this->rrmdir($this->tmp);
+	}
+
+	private function rrmdir(string $dir): void
+	{
+		if (!is_dir($dir)) {
+			return;
+		}
+		foreach (scandir($dir) as $f) {
+			if ($f === '.' || $f === '..') {
+				continue;
+			}
+			$p = "{$dir}/{$f}";
+			is_dir($p) ? $this->rrmdir($p) : @unlink($p);
+		}
+		@rmdir($dir);
+	}
+
+	private function channel(): string
+	{
+		return "{$this->tmp}/pfb_py_control";
+	}
+
+	private function readRecord(): array
+	{
+		$raw = file_get_contents($this->channel());
+		$this->assertNotFalse($raw);
+		$rec = json_decode(trim($raw), true);
+		$this->assertIsArray($rec);
+		return $rec;
+	}
+
+	// --- the four valid commands (record shape) -----------------------------
+
+	public function testDisableWritesRecordSeqOne(): void
+	{
+		// Given: no channel yet (BEFORE).
+		$this->assertFileDoesNotExist($this->channel());
+
+		// When: a root-issued disable is written.
+		$this->assertSame(1, pfb_unbound_py_write_control('disable'));
+
+		// Then: a fresh record, seq 1, no ip/duration.
+		$rec = $this->readRecord();
+		$this->assertSame('disable', $rec['cmd']);
+		$this->assertSame(1, $rec['seq']);
+		$this->assertArrayNotHasKey('ip', $rec);
+		$this->assertArrayNotHasKey('duration', $rec);
+		$this->assertArrayHasKey('ts', $rec);
+	}
+
+	public function testDisableWithValidDurationCarriesIt(): void
+	{
+		$this->assertSame(1, pfb_unbound_py_write_control('disable', '', '60'));
+		$rec = $this->readRecord();
+		$this->assertSame('disable', $rec['cmd']);
+		$this->assertSame(60, $rec['duration']);
+	}
+
+	public function testEnableWritesRecord(): void
+	{
+		$this->assertSame(1, pfb_unbound_py_write_control('enable'));
+		$rec = $this->readRecord();
+		$this->assertSame('enable', $rec['cmd']);
+		$this->assertArrayNotHasKey('ip', $rec);
+	}
+
+	public function testAddbypassCarriesIpAndDuration(): void
+	{
+		$this->assertSame(1, pfb_unbound_py_write_control('addbypass', '192.0.2.10', '120'));
+		$rec = $this->readRecord();
+		$this->assertSame('addbypass', $rec['cmd']);
+		$this->assertSame('192.0.2.10', $rec['ip']);
+		$this->assertSame(120, $rec['duration']);
+	}
+
+	public function testAddbypassWithoutDurationOmitsIt(): void
+	{
+		$this->assertSame(1, pfb_unbound_py_write_control('addbypass', '2001:db8::1'));
+		$rec = $this->readRecord();
+		$this->assertSame('addbypass', $rec['cmd']);
+		$this->assertSame('2001:db8::1', $rec['ip']);
+		$this->assertArrayNotHasKey('duration', $rec);
+	}
+
+	public function testRemovebypassCarriesIpIgnoresDuration(): void
+	{
+		// removebypass takes no duration; a 4th arg must be ignored (no 'duration' key).
+		$this->assertSame(1, pfb_unbound_py_write_control('removebypass', '192.0.2.10', '60'));
+		$rec = $this->readRecord();
+		$this->assertSame('removebypass', $rec['cmd']);
+		$this->assertSame('192.0.2.10', $rec['ip']);
+		$this->assertArrayNotHasKey('duration', $rec);
+	}
+
+	// --- the sequence advance (replay safety) -------------------------------
+
+	public function testSequenceAdvancesAcrossCalls(): void
+	{
+		// BEFORE: first write -> seq 1.
+		$this->assertSame(1, pfb_unbound_py_write_control('disable'));
+		// AFTER each subsequent write the seq strictly advances, read from the prior record.
+		$this->assertSame(2, pfb_unbound_py_write_control('enable'));
+		$this->assertSame(3, pfb_unbound_py_write_control('disable'));
+		$this->assertSame(3, $this->readRecord()['seq']);
+	}
+
+	public function testSequenceFromCorruptChannelRestartsAtOne(): void
+	{
+		// A non-JSON / seq-less channel is treated as seq 0 -> next write is 1 (fail-safe).
+		file_put_contents($this->channel(), "garbage not json\n");
+		$this->assertSame(1, pfb_unbound_py_write_control('enable'));
+		$this->assertSame(1, $this->readRecord()['seq']);
+	}
+
+	// --- argument validation at the writer (no side effect on reject) -------
+
+	public function testInvalidCommandRejectedNoFileWritten(): void
+	{
+		$this->assertFileDoesNotExist($this->channel());
+		$this->assertFalse(pfb_unbound_py_write_control('nuke-everything'));
+		$this->assertFileDoesNotExist($this->channel());
+	}
+
+	public function testEmptyCommandRejected(): void
+	{
+		$this->assertFalse(pfb_unbound_py_write_control(''));
+		$this->assertFileDoesNotExist($this->channel());
+	}
+
+	public function testAddbypassWithInvalidIpRejectedNoFileWritten(): void
+	{
+		$this->assertFalse(pfb_unbound_py_write_control('addbypass', '999.1.1.1'));
+		$this->assertFileDoesNotExist($this->channel());
+	}
+
+	public function testAddbypassWithEmptyIpRejected(): void
+	{
+		$this->assertFalse(pfb_unbound_py_write_control('addbypass', ''));
+		$this->assertFileDoesNotExist($this->channel());
+	}
+
+	public function testRemovebypassWithInvalidIpRejected(): void
+	{
+		$this->assertFalse(pfb_unbound_py_write_control('removebypass', 'not-an-ip'));
+		$this->assertFileDoesNotExist($this->channel());
+	}
+
+	public function testDurationZeroRejected(): void
+	{
+		$this->assertFalse(pfb_unbound_py_write_control('disable', '', '0'));
+		$this->assertFileDoesNotExist($this->channel());
+	}
+
+	public function testDurationAboveMaxRejected(): void
+	{
+		$this->assertFalse(pfb_unbound_py_write_control('disable', '', '3601'));
+		$this->assertFileDoesNotExist($this->channel());
+	}
+
+	public function testDurationBoundariesAccepted(): void
+	{
+		// 1 and 3600 are the inclusive valid bounds.
+		$this->assertSame(1, pfb_unbound_py_write_control('disable', '', '1'));
+		$this->assertSame(1, $this->readRecord()['duration']);
+
+		$this->assertSame(2, pfb_unbound_py_write_control('disable', '', '3600'));
+		$this->assertSame(3600, $this->readRecord()['duration']);
+	}
+
+	public function testNonNumericDurationRejected(): void
+	{
+		$this->assertFalse(pfb_unbound_py_write_control('addbypass', '192.0.2.10', 'abc'));
+		$this->assertFileDoesNotExist($this->channel());
+	}
+
+	// --- the publisher's command-channel permission model -------------------
+
+	public function testPublishedChannelIsMode0640(): void
+	{
+		$this->assertSame(1, pfb_unbound_py_write_control('disable'));
+		clearstatcache();
+		// Owner read/write, group read, no other access (the command-channel model).
+		$this->assertSame('0640', substr(sprintf('%o', fileperms($this->channel())), -4));
+	}
+
+	public function testAtomicWriteRootLeavesNoStagingTempBehind(): void
+	{
+		$path = "{$this->tmp}/cmd";
+		$this->assertTrue(pfb_unbound_py_atomic_write_root($path, "x\n"));
+		$leftover = array_filter(scandir($this->tmp), static function ($f) {
+			return strpos($f, '.pfbctl_') === 0;
+		});
+		$this->assertSame([], array_values($leftover));
+	}
+
+	public function testAtomicWriteRootFailsWhenDirMissing(): void
+	{
+		// Staging dir absent -> tempnam fails -> FALSE, fail-safe (no crash).
+		$this->assertFalse(
+			pfb_unbound_py_atomic_write_root("{$this->tmp}/nope/deep/cmd", 'x')
+		);
+	}
+}

--- a/tests/phpcs/PfBlockerNG/Sniffs/Validation/RequirePfbFilterSniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Validation/RequirePfbFilterSniff.php
@@ -41,6 +41,7 @@ class RequirePfbFilterSniff implements Sniff
 		'pfb_unbound_python_sources',
 		'pfb_unbound_py_ccache_flush_cmds',
 		'pfb_run_hooks',
+		'pfb_unbound_py_write_control',
 	];
 
 	/**

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -1,0 +1,417 @@
+"""PFBL-03 -- the local privileged DNSBL-control command channel (reader + shared handler).
+
+WHY THIS FILE EXISTS
+--------------------
+PFBL-03 moves DNSBL control off the DNS-TXT transport onto a local privileged command
+FILE consumed by a daemon reader (``pfb_control_watcher``), mirroring the ADR-10 reload
+watcher. The command SEMANTICS are preserved byte-for-byte; only the transport +
+authentication change. These tests pin:
+
+  * the SHARED handler ``pfb_apply_control_command`` -- the SINGLE implementation both the
+    legacy DNS-TXT branch and the new reader call -- exercised independent of transport,
+    every command + every validation branch (BEFORE/AFTER state asserted);
+  * the reader's JSON record -> token translation + re-validation;
+  * the reader thread: a FRESH seq is applied, a replayed/stale seq (<= last applied) is
+    IGNORED, the pre-existing record at startup is adopted as the baseline (not replayed);
+  * the applied-seq marker handshake the writer confirms execution with.
+
+Per the repo coverage rules every transition test asserts the BEFORE state first, so a
+green proves the command CAUSED the change. The reader runs on its own daemon thread; it
+is gated on ``pfb["mod_threading"]`` and only a test that explicitly starts it runs it.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pfb_unbound as P
+
+# --------------------------------------------------------------------------- #
+# The shared handler -- exercised INDEPENDENT of transport (a plain token list).
+# Both the DNS-TXT branch and the file reader build the SAME ["python_control", ...]
+# list and call this; here we call it directly, proving it is transport-agnostic.
+# --------------------------------------------------------------------------- #
+
+
+class TestSharedHandlerDisableEnable:
+    def test_disable_then_enable_toggles_blacklist(self) -> None:
+        # Scenario: disable turns DNSBL blocking off; enable restores it.
+        # Given: DNSBL blocking is ON (BEFORE).
+        P.pfb["python_blacklist"] = True
+
+        # When: a disable command (no duration) is applied.
+        applied, msg = P.pfb_apply_control_command(["python_control", "disable"])
+
+        # Then: it took effect and blocking is OFF.
+        assert applied is True
+        assert "disabled" in msg.lower()
+        assert P.pfb["python_blacklist"] is False
+
+        # When: an enable command is applied. Then: blocking is restored ON.
+        applied, msg = P.pfb_apply_control_command(["python_control", "enable"])
+        assert applied is True
+        assert P.pfb["python_blacklist"] is True
+
+    def test_disable_with_valid_duration_starts_sleep_thread(self) -> None:
+        # Given: blocking ON, no live "sleep" thread.
+        P.pfb["python_blacklist"] = True
+        P.pfb["mod_threading"] = True
+
+        # When: disable.<sec> with a valid duration.
+        applied, msg = P.pfb_apply_control_command(["python_control", "disable", "1"])
+
+        # Then: applied, blocking off, and a timed re-enable thread is running.
+        assert applied is True
+        assert P.pfb["python_blacklist"] is False
+        assert "second" in msg
+        assert P.python_control_thread("sleep") is True
+
+    def test_disable_with_out_of_range_duration_rejected(self) -> None:
+        # The toggle still flips (semantics preserved) but the command is NOT marked
+        # applied and no timer is started -- the duration is out of range (1-3600).
+        P.pfb["python_blacklist"] = True
+        applied, msg = P.pfb_apply_control_command(["python_control", "disable", "3601"])
+        assert applied is False
+        assert "out of range" in msg
+        # The toggle still flipped (the legacy semantics: disable takes effect, only the
+        # TIMED re-enable is refused for the bad duration).
+        assert P.pfb["python_blacklist"] is False
+
+
+class TestSharedHandlerBypass:
+    def test_addbypass_adds_ip_to_gplistdb(self) -> None:
+        # Given: the IP is NOT in the bypass DB (BEFORE).
+        assert P.gpListDB.get("192.0.2.10") is None
+
+        # When: addbypass without a duration.
+        applied, msg = P.pfb_apply_control_command(["python_control", "addbypass", "192.0.2.10"])
+
+        # Then: applied and the IP is now a bypass entry.
+        assert applied is True
+        assert P.gpListDB.get("192.0.2.10") == 0
+        assert P.pfb["gpListDB"] is True
+
+    def test_removebypass_removes_ip(self) -> None:
+        # Given: the IP IS a bypass entry (BEFORE).
+        P.gpListDB["192.0.2.10"] = 0
+        P.pfb["gpListDB"] = True
+        assert P.gpListDB.get("192.0.2.10") == 0
+
+        # When: removebypass. Then: the IP is gone.
+        applied, msg = P.pfb_apply_control_command(["python_control", "removebypass", "192.0.2.10"])
+        assert applied is True
+        assert P.gpListDB.get("192.0.2.10") is None
+
+    def test_removebypass_absent_ip_reports_not_in_policy(self) -> None:
+        # An IP not in the DB still validates (applied True) but the message says so.
+        assert P.gpListDB.get("198.51.100.7") is None
+        applied, msg = P.pfb_apply_control_command(["python_control", "removebypass", "198.51.100.7"])
+        assert applied is True
+        assert "not in Group Policy" in msg
+
+    def test_addbypass_with_duration_starts_remove_thread(self) -> None:
+        P.pfb["mod_threading"] = True
+        applied, msg = P.pfb_apply_control_command(["python_control", "addbypass", "192.0.2.10", "1"])
+        assert applied is True
+        assert "second" in msg
+        assert P.python_control_thread("addbypass192.0.2.10") is True
+
+    def test_addbypass_dash_encoded_ipv4_is_unmapped(self) -> None:
+        # The DNS-TXT transport encodes the dotted IPv4 with '-'; the shared handler
+        # un-maps it. Proves the legacy encoding still resolves to the real IP.
+        applied, _ = P.pfb_apply_control_command(["python_control", "addbypass", "192-0-2-10"])
+        assert applied is True
+        assert P.gpListDB.get("192.0.2.10") == 0
+
+    def test_addbypass_invalid_ip_raises(self) -> None:
+        # ipaddress.ip_address() rejects a non-IP -- the shared handler re-validates the
+        # bypass IP (the reader also screens it, but the handler is the last gate).
+        import pytest
+
+        with pytest.raises(ValueError):
+            P.pfb_apply_control_command(["python_control", "addbypass", "not-an-ip"])
+
+    def test_unknown_command_is_noop(self) -> None:
+        applied, msg = P.pfb_apply_control_command(["python_control", "frobnicate"])
+        assert applied is False
+        assert msg == ""
+
+    def test_too_short_token_list_is_noop(self) -> None:
+        applied, msg = P.pfb_apply_control_command(["python_control"])
+        assert applied is False
+        assert msg == ""
+
+
+# --------------------------------------------------------------------------- #
+# Record reader + record->token translation (the reader's plumbing).
+# --------------------------------------------------------------------------- #
+
+
+class TestControlReadRecord:
+    def test_absent_file_is_none(self, tmp_path: Any) -> None:
+        assert P._control_read_record(str(tmp_path / "nope")) is None
+
+    def test_empty_file_is_none(self, tmp_path: Any) -> None:
+        p = tmp_path / "ctl"
+        p.write_text("")
+        assert P._control_read_record(str(p)) is None
+
+    def test_malformed_json_is_none(self, tmp_path: Any) -> None:
+        p = tmp_path / "ctl"
+        p.write_text("not json {")
+        assert P._control_read_record(str(p)) is None
+
+    def test_non_object_json_is_none(self, tmp_path: Any) -> None:
+        p = tmp_path / "ctl"
+        p.write_text("[1, 2, 3]")
+        assert P._control_read_record(str(p)) is None
+
+    def test_valid_record_parsed(self, tmp_path: Any) -> None:
+        p = tmp_path / "ctl"
+        p.write_text('{"seq": 3, "cmd": "enable"}\n')
+        rec = P._control_read_record(str(p))
+        assert rec == {"seq": 3, "cmd": "enable"}
+
+
+class TestRecordToCommand:
+    def test_enable(self) -> None:
+        assert P._control_record_to_command({"cmd": "enable"}) == ["python_control", "enable"]
+
+    def test_disable_without_duration(self) -> None:
+        assert P._control_record_to_command({"cmd": "disable"}) == ["python_control", "disable"]
+
+    def test_disable_with_duration(self) -> None:
+        assert P._control_record_to_command({"cmd": "disable", "duration": 60}) == [
+            "python_control",
+            "disable",
+            "60",
+        ]
+
+    def test_addbypass_with_ip_and_duration(self) -> None:
+        assert P._control_record_to_command({"cmd": "addbypass", "ip": "192.0.2.10", "duration": 30}) == [
+            "python_control",
+            "addbypass",
+            "192.0.2.10",
+            "30",
+        ]
+
+    def test_removebypass_with_ip(self) -> None:
+        assert P._control_record_to_command({"cmd": "removebypass", "ip": "192.0.2.10"}) == [
+            "python_control",
+            "removebypass",
+            "192.0.2.10",
+        ]
+
+    def test_unknown_cmd_is_none(self) -> None:
+        assert P._control_record_to_command({"cmd": "wipe"}) is None
+
+    def test_missing_cmd_is_none(self) -> None:
+        assert P._control_record_to_command({"seq": 1}) is None
+
+    def test_bypass_without_ip_is_none(self) -> None:
+        assert P._control_record_to_command({"cmd": "addbypass"}) is None
+        assert P._control_record_to_command({"cmd": "addbypass", "ip": ""}) is None
+
+
+class TestControlWriteApplied:
+    def test_writes_seq_first_line(self, tmp_path: Any) -> None:
+        applied = str(tmp_path / "pfb_py_control.applied")
+        P.pfb["pfb_py_control_applied"] = applied
+        P._control_write_applied(7)
+        with open(applied, encoding="utf-8") as fh:
+            assert fh.readline().strip() == "7"
+
+
+# --------------------------------------------------------------------------- #
+# The reader thread -- drive a real daemon with a temp channel; assert the FRESH
+# command applies, a replayed/stale seq is ignored, the baseline is not replayed.
+# --------------------------------------------------------------------------- #
+
+
+class _ControlHarness:
+    """Run pfb_control_watcher on a real daemon thread against a temp channel file.
+    Mirrors init's start + deinit's stop/join."""
+
+    def __init__(self, tmp_path: Any, monkeypatch: Any) -> None:
+        self.channel = str(tmp_path / "pfb_py_control")
+        self.applied = str(tmp_path / "pfb_py_control.applied")
+        P.pfb["pfb_py_control"] = self.channel
+        P.pfb["pfb_py_control_applied"] = self.applied
+        # Short cadence so the poll/kqueue timeout (hence stop + apply) is prompt.
+        monkeypatch.setattr(P, "RELOAD_POLL_INTERVAL", 0.05)
+        P.pfb_control_stop = threading.Event()
+        self.thread: Any = None
+
+    def publish(self, record: dict[str, Any]) -> None:
+        import json
+        import os
+
+        tmp = self.channel + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+        os.replace(tmp, self.channel)
+
+    def read_applied(self) -> int | None:
+        try:
+            with open(self.applied, encoding="utf-8") as fh:
+                return int(fh.readline().strip())
+        except (OSError, ValueError):
+            return None
+
+    def start(self) -> None:
+        self.thread = threading.Thread(name="pfb_control_watcher_test", target=P.pfb_control_watcher, daemon=True)
+        self.thread.start()
+
+    def wait_applied(self, seq: int, timeout: float = 3.0) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if (self.read_applied() or -1) >= seq:
+                return True
+            time.sleep(0.01)
+        return False
+
+    def stop_join(self, timeout: float = 5.0) -> None:
+        P.pfb_control_stop.set()
+        if self.thread is not None:
+            self.thread.join(timeout=timeout)
+
+
+class TestControlWatcherLoop:
+    def test_fresh_command_is_applied(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # Scenario: a root-issued command arriving on the channel performs the action.
+        h = _ControlHarness(tmp_path, monkeypatch)
+        # Given: DNSBL blocking is ON (BEFORE).
+        P.pfb["python_blacklist"] = True
+        h.start()
+        try:
+            assert P.pfb["python_blacklist"] is True  # BEFORE: still on, nothing applied.
+
+            # When: a disable command (seq 1) is published.
+            h.publish({"seq": 1, "cmd": "disable"})
+
+            # Then: the reader applies it -- blocking goes OFF and the applied marker reaches 1.
+            assert h.wait_applied(1)
+            assert P.pfb["python_blacklist"] is False
+        finally:
+            h.stop_join()
+        assert not h.thread.is_alive()
+
+    def test_addbypass_then_removebypass_via_channel(self, tmp_path: Any, monkeypatch: Any) -> None:
+        h = _ControlHarness(tmp_path, monkeypatch)
+        # Given: the IP is NOT bypassed (BEFORE).
+        assert P.gpListDB.get("192.0.2.10") is None
+        h.start()
+        try:
+            h.publish({"seq": 1, "cmd": "addbypass", "ip": "192.0.2.10"})
+            assert h.wait_applied(1)
+            assert P.gpListDB.get("192.0.2.10") == 0  # AFTER add: bypassed.
+
+            h.publish({"seq": 2, "cmd": "removebypass", "ip": "192.0.2.10"})
+            assert h.wait_applied(2)
+            assert P.gpListDB.get("192.0.2.10") is None  # AFTER remove: gone again.
+        finally:
+            h.stop_join()
+        assert not h.thread.is_alive()
+
+    def test_stale_seq_is_ignored_fresh_is_applied(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # Scenario: replay safety -- a record whose seq <= last applied is IGNORED; only
+        # a strictly-advancing seq takes effect.
+        h = _ControlHarness(tmp_path, monkeypatch)
+        P.pfb["python_blacklist"] = True
+        h.start()
+        try:
+            # Apply seq 5 (disable): blocking OFF.
+            h.publish({"seq": 5, "cmd": "disable"})
+            assert h.wait_applied(5)
+            assert P.pfb["python_blacklist"] is False
+
+            # Re-arm blocking out-of-band, then replay an OLD seq (3, enable). The reader
+            # must NOT apply it (3 <= 5), so blocking stays as we set it.
+            P.pfb["python_blacklist"] = True
+            h.publish({"seq": 3, "cmd": "enable"})
+            time.sleep(0.3)  # give the watcher a few poll cycles
+            assert P.pfb["python_blacklist"] is True  # unchanged: stale seq ignored.
+            assert (h.read_applied() or 0) == 5  # applied marker did NOT regress.
+
+            # A genuinely fresh seq (6, disable) IS applied -> blocking OFF again.
+            h.publish({"seq": 6, "cmd": "disable"})
+            assert h.wait_applied(6)
+            assert P.pfb["python_blacklist"] is False
+        finally:
+            h.stop_join()
+        assert not h.thread.is_alive()
+
+    def test_preexisting_record_adopted_as_baseline_not_replayed(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # A record already on disk at startup (e.g. from a prior run) is the baseline --
+        # the reader adopts its seq WITHOUT applying it; only a future advance acts.
+        h = _ControlHarness(tmp_path, monkeypatch)
+        # Pre-existing disable at seq 9, but blocking is ON: if it were replayed, blocking
+        # would be flipped OFF. It must NOT be.
+        h.publish({"seq": 9, "cmd": "disable"})
+        P.pfb["python_blacklist"] = True
+        h.start()
+        try:
+            assert h.wait_applied(9)  # baseline adopted + published.
+            time.sleep(0.2)
+            assert P.pfb["python_blacklist"] is True  # NOT replayed.
+
+            # A future advance (seq 10) DOES apply.
+            h.publish({"seq": 10, "cmd": "disable"})
+            assert h.wait_applied(10)
+            assert P.pfb["python_blacklist"] is False
+        finally:
+            h.stop_join()
+        assert not h.thread.is_alive()
+
+    def test_unknown_command_record_consumed_without_side_effect(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # A record with an unknown cmd advances the seq (consumed) but performs no action.
+        h = _ControlHarness(tmp_path, monkeypatch)
+        P.pfb["python_blacklist"] = True
+        h.start()
+        try:
+            h.publish({"seq": 1, "cmd": "wipe-everything"})
+            assert h.wait_applied(1)  # consumed (marker advances) ...
+            assert P.pfb["python_blacklist"] is True  # ... but no side effect.
+        finally:
+            h.stop_join()
+        assert not h.thread.is_alive()
+
+
+# --------------------------------------------------------------------------- #
+# Permission boundary modelled at unit level: authorization is "only root may
+# write" -- the reader NEVER writes the channel, it only writes the applied
+# marker. This pins the read/write split the on-box 0640 root:unbound perms enforce.
+# --------------------------------------------------------------------------- #
+
+
+class TestPermissionBoundaryModel:
+    def test_reader_does_not_write_the_channel(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # Given: a channel published by the (root) writer with a known record.
+        h = _ControlHarness(tmp_path, monkeypatch)
+        h.publish({"seq": 1, "cmd": "enable"})
+        import os
+
+        before = os.stat(h.channel)
+        before_bytes = open(h.channel, "rb").read()
+        h.start()
+        try:
+            assert h.wait_applied(1)
+            time.sleep(0.2)
+            # Then: the reader consumed the command and wrote ONLY the applied marker --
+            # the command channel itself is byte-for-byte unchanged (the reader is a
+            # read-only consumer of it; only root writes the channel).
+            after = os.stat(h.channel)
+            assert open(h.channel, "rb").read() == before_bytes
+            assert after.st_mtime == before.st_mtime
+            # The applied marker (which the reader DOES own) was written.
+            assert os.path.exists(h.applied)
+        finally:
+            h.stop_join()
+
+    def test_applied_marker_is_separate_file_from_channel(self) -> None:
+        # The reader's only write target is the .applied marker, a DIFFERENT path from the
+        # command channel -- so the reader needs no write access to the channel at all.
+        assert P.pfb["pfb_py_control"] != P.pfb["pfb_py_control_applied"]
+        assert P.pfb["pfb_py_control_applied"].endswith(".applied")

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -28,6 +28,21 @@ from typing import Any
 
 import pfb_unbound as P
 
+
+def _await_control_thread_stopped(name: str, timeout: float = 2.0) -> None:
+    """Wait (bounded) for a spawned control timer thread to stop.
+
+    The duration commands start a real background timer thread; without awaiting it the
+    async state leaks into later tests. Poll the module's own predicate until the thread
+    is no longer active or the timeout elapses.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not P.python_control_thread(name):
+            return
+        time.sleep(0.01)
+
+
 # --------------------------------------------------------------------------- #
 # The shared handler -- exercised INDEPENDENT of transport (a plain token list).
 # Both the DNS-TXT branch and the file reader build the SAME ["python_control", ...]
@@ -67,6 +82,9 @@ class TestSharedHandlerDisableEnable:
         assert P.pfb["python_blacklist"] is False
         assert "second" in msg
         assert P.python_control_thread("sleep") is True
+
+        # Cleanup: await the spawned timer thread so its async state does not leak.
+        _await_control_thread_stopped("sleep")
 
     def test_disable_with_out_of_range_duration_rejected(self) -> None:
         # The toggle still flips (semantics preserved) but the command is NOT marked
@@ -118,6 +136,9 @@ class TestSharedHandlerBypass:
         assert "second" in msg
         assert P.python_control_thread("addbypass192.0.2.10") is True
 
+        # Cleanup: await the spawned timer thread so its async state does not leak.
+        _await_control_thread_stopped("addbypass192.0.2.10")
+
     def test_addbypass_dash_encoded_ipv4_is_unmapped(self) -> None:
         # The DNS-TXT transport encodes the dotted IPv4 with '-'; the shared handler
         # un-maps it. Proves the legacy encoding still resolves to the real IP.
@@ -125,13 +146,26 @@ class TestSharedHandlerBypass:
         assert applied is True
         assert P.gpListDB.get("192.0.2.10") == 0
 
-    def test_addbypass_invalid_ip_raises(self) -> None:
-        # ipaddress.ip_address() rejects a non-IP -- the shared handler re-validates the
-        # bypass IP (the reader also screens it, but the handler is the last gate).
-        import pytest
+    def test_malformed_bypass_rejected_without_raising(self) -> None:
+        # PFBL-03: a malformed bypass command must be REJECTED (returned), never RAISED --
+        # a missing IP (IndexError) or a non-IP (ValueError) would otherwise crash the
+        # control watcher thread. Both classes return (False, <message>) and leave the
+        # bypass DB untouched.
+        # Given: the would-be IP is NOT in the bypass DB (BEFORE).
+        assert P.gpListDB.get("not-an-ip") is None
 
-        with pytest.raises(ValueError):
-            P.pfb_apply_control_command(["python_control", "addbypass", "not-an-ip"])
+        # When: a 2-token command (missing IP) is applied. Then: rejected, no raise.
+        applied, msg = P.pfb_apply_control_command(["python_control", "addbypass"])
+        assert applied is False
+        assert "Missing bypass IP" in msg
+
+        # When: a command with a non-IP token is applied. Then: rejected, no raise.
+        applied, msg = P.pfb_apply_control_command(["python_control", "addbypass", "not-an-ip"])
+        assert applied is False
+        assert "Invalid IP" in msg
+
+        # Then: neither malformed command mutated the bypass DB.
+        assert P.gpListDB.get("not-an-ip") is None
 
     def test_unknown_command_is_noop(self) -> None:
         applied, msg = P.pfb_apply_control_command(["python_control", "frobnicate"])

--- a/tests/test_pfbl03_txt_legacy_gate.py
+++ b/tests/test_pfbl03_txt_legacy_gate.py
@@ -1,0 +1,124 @@
+"""PFBL-03 Phase 3 -- the deprecated DNS-TXT control transport is OFF by default.
+
+WHY THIS FILE EXISTS
+--------------------
+DNSBL control moved onto the local privileged command file + CLI (pinned in
+``test_pfbl03_control_channel.py``). The old DNS-TXT transport (``drill TXT
+python_control.*``) is retained for ONE release behind a new, separate, opt-in
+sub-toggle ``python_control_legacy`` -- OFF by default. These tests pin that gate:
+
+  * legacy OFF (the DEFAULT): a ``python_control.`` DNS TXT query is NOT honoured --
+    the DNS-TXT path performs no DNSBL control action;
+  * legacy ON: the same query IS honoured -- proving the gate is a REAL branch, not an
+    always-off path.
+
+Per the repo coverage rules each transition test asserts the BEFORE state first, so a
+green proves the gate value CAUSED the outcome. The shared handler
+``pfb_apply_control_command`` is exercised transport-agnostically in the sibling file;
+here we drive it through the real ``operate()`` DNS-TXT branch.
+"""
+
+from __future__ import annotations
+
+import types
+
+from unboundmodule import DNSMessage
+
+import pfb_unbound as P
+
+RR_TXT = 16
+MODULE_EVENT_NEW = 0
+
+
+def _txt_control_qstate(qname: str, q_ip: str = "127.0.0.1") -> types.SimpleNamespace:
+    """A localhost DNS TXT query carrying a python_control command (the legacy transport).
+
+    Mirrors the operate() inputs: a numeric TXT qtype, a localhost reply IP, and a
+    ``python_control.<cmd>`` qname (trailing dot, as Unbound presents it)."""
+    reply_list = types.SimpleNamespace(query_reply=types.SimpleNamespace(addr=q_ip), next=None)
+    qinfo = types.SimpleNamespace(
+        qname_str=qname,
+        qtype=RR_TXT,
+        qtype_str="",
+        qname_list=qname.rstrip(".").split("."),
+    )
+    return types.SimpleNamespace(
+        qinfo=qinfo,
+        mesh_info=types.SimpleNamespace(reply_list=reply_list),
+        return_msg=None,
+        return_rcode=0,
+        ext_state={},
+        no_cache_store=0,
+    )
+
+
+class TestLegacyTxtControlGate:
+    """Scenario: the DNS-TXT control transport is honoured ONLY when the deprecated
+    legacy sub-toggle is explicitly enabled.
+
+    Background:
+      * DNSBL Control is enabled (``python_control`` True) -- the parent toggle.
+      * A localhost ``python_control.disable`` DNS TXT query is the command under test.
+    """
+
+    def test_txt_control_not_honoured_when_legacy_off_default(self) -> None:
+        # Given: the legacy DNS-TXT transport is OFF (the DEFAULT) and DNSBL blocking is ON.
+        P.pfb["python_control"] = True
+        P.pfb["python_control_legacy"] = False
+        P.pfb["python_blacklist"] = True
+        assert P.pfb["python_blacklist"] is True  # BEFORE: blocking on.
+
+        # When: a localhost python_control.disable DNS TXT query is processed.
+        qstate = _txt_control_qstate("python_control.disable.")
+        P.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        # Then: the DNS-TXT path did NOT honour it -- blocking is UNCHANGED (still on), and
+        # the control branch produced no TXT reply (it never ran).
+        assert P.pfb["python_blacklist"] is True
+        assert not any(
+            "python_control" in (getattr(ans, "answer", [""]) or [""])[0]
+            for ans in DNSMessage.instances
+            if getattr(ans, "answer", None)
+        )
+
+    def test_txt_control_honoured_when_legacy_on(self) -> None:
+        # Given: the legacy DNS-TXT transport is explicitly ON and DNSBL blocking is ON.
+        P.pfb["python_control"] = True
+        P.pfb["python_control_legacy"] = True
+        P.pfb["python_blacklist"] = True
+        assert P.pfb["python_blacklist"] is True  # BEFORE: blocking on.
+
+        # When: the SAME localhost python_control.disable DNS TXT query is processed.
+        qstate = _txt_control_qstate("python_control.disable.")
+        rcd = P.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        # Then: the DNS-TXT path honoured it -- blocking is now OFF (the disable applied),
+        # proving the gate is a real branch rather than an always-off path.
+        assert rcd is True
+        assert P.pfb["python_blacklist"] is False
+
+    def test_txt_control_inert_when_legacy_on_but_parent_disabled(self) -> None:
+        # The deprecated branch still requires the parent DNSBL Control toggle + localhost:
+        # with python_control OFF the existing in-branch guard refuses the command even
+        # when the legacy transport gate is open.
+        P.pfb["python_control"] = False
+        P.pfb["python_control_legacy"] = True
+        P.pfb["python_blacklist"] = True
+
+        qstate = _txt_control_qstate("python_control.disable.")
+        P.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        # The command was not authorized -> blocking unchanged.
+        assert P.pfb["python_blacklist"] is True
+
+    def test_txt_control_inert_when_legacy_on_but_not_localhost(self) -> None:
+        # The legacy branch's 127.0.0.1 guard still applies: a non-localhost source is
+        # refused even with the legacy gate open and the parent toggle on.
+        P.pfb["python_control"] = True
+        P.pfb["python_control_legacy"] = True
+        P.pfb["python_blacklist"] = True
+
+        qstate = _txt_control_qstate("python_control.disable.", q_ip="192.0.2.50")
+        P.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        assert P.pfb["python_blacklist"] is True


### PR DESCRIPTION
## Summary

Reworks the DNSBL runtime control feature (the **DNSBL Control** toggle) so commands are issued through a local, root-only privileged channel and a CLI instead of in-band DNS TXT queries. The command set and semantics are unchanged.

- **Out-of-band command channel + reader.** `pfb_unbound.py` gains a daemon reader (`pfb_control_watcher`, mirroring the ADR-10 reload watcher) that consumes commands from a root-written command file under the Unbound chroot (`/var/unbound/pfb_py_control`, owner `root`, group `unbound`, mode `0640`). A monotonic sequence makes it replay-safe. The `disable`/`enable`/`addbypass`/`removebypass` logic is refactored into one shared handler, `pfb_apply_control_command()`, that both the reader and the (now-deprecated) DNS-TXT path call.
- **Root-only writer + CLI.** `pfb_unbound_py_write_control()` validates the command and its arguments (PFBL-01) and atomically publishes the sequenced record (owner `root`, group `unbound`, `0640`). A new CLI invokes it:
  `pfblockerng dnsbl-control disable [sec] | enable | addbypass <ip> [sec] | removebypass <ip>`
- **DNS-TXT path deprecated and off by default.** The in-band `python_control.*` DNS-TXT transport is hard-gated behind a new **DNSBL Control (legacy DNS TXT)** sub-toggle, default **off**, marked deprecated and slated for removal next release. A one-time upgrade migration enables the legacy sub-toggle **only** for installs that already had DNSBL Control enabled, so existing CRON/Scheduler `drill TXT` workflows keep working for one release; fresh installs use the CLI.
- **UI + docs migrated.** The DNSBL Control help no longer documents the DNS-TXT/localhost model; the command table and `README.md` now show the `pfblockerng dnsbl-control` CLI plus a migration note.

Authorization for the channel is local filesystem permission (only root can write it). Ref: **PFBL-03**.

## Tests
- **Python** — `tests/test_pfbl03_control_channel.py` (shared handler, reader fresh/stale/baseline sequence, writer validation, permission boundary; before/after) and `tests/test_pfbl03_txt_legacy_gate.py` (DNS-TXT dead-by-default vs legacy-on — a real gate, not an always-off path).
- **PHP** — `tests/php/UnboundPyControlWriteTest.php` (writer validation + record shape + `0640` permission model) and `tests/php/ControlLegacySeedTest.php` (the exactly-once upgrade seed).
- Off-appliance gates green: `pytest` 1611, `ruff`, `mypy tests/`, `php -l`, PHPStan, PHPUnit 457, PHPCS (PFBL-01 sniff). ADR-14 `ui_render` for the DNSBL page and the live-VM DNSBL-control smoke are the CI / maintainer fan-out leg (no live Unbound off-box).

https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **DNSBL Control (CLI)** for runtime management: enable/disable blocking, timed disable, and add/remove bypass IPs.
  * Control actions are queued and recorded so you can review them in the **Reports** tab.
* **Documentation**
  * Updated DNSBL control help to document the new CLI workflow.
  * Deprecated the legacy DNS-TXT control transport (now **off by default**) and added a one-release opt-in migration option in settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->