### PR TITLE
ADR-19: pfBlockerNG-owned Software update/channel panel + notice (provenance-gated)

### DIFF
--- a/.ADRs/ADR_19_Update_Channel_Panel/ADR.md
+++ b/.ADRs/ADR_19_Update_Channel_Panel/ADR.md
@@ -381,6 +381,49 @@ logic is pinned by oracle tests first.
 - The `repo`-marked live-VM journey is **GREEN** (capture the run id): newer build →
   de-duped notice (channel-correct) + cache update + same-channel Update.
 
+### DoD status / evidence (filled Phase 5, 2026-06-15)
+
+- **Phase 1 kill-gate — GO.** `tests/smoke/test_software_update.py` (marker `repo`) proves
+  all three §1 premises + the provenance amendment on the live VM: read-our-latest without
+  touching the `pfSense` repo, per-version-idempotent `file_notice`, same-channel
+  `pkg upgrade` from our repo, and `%R` discriminating our build from a decoy. (`RESULTS/01`.)
+- **Phase 2 pure core — DONE.** `tests/php/SoftwareUpdateCheckTest.php` + the pure-helper
+  tests pin every branch (each channel, available/not, default/on/off, de-dupe lifecycle)
+  with before-state asserts. PHPUnit green (487 tests). (`RESULTS/02`, `RESULTS/03`.)
+- **Phase 4 page — DONE; NEGATIVE side GREEN live.** The ADR-14 Tier-A `ui_render` PR gate
+  asserts the provenance gate **hides** the page + tab on the harness's `pkg add -f` install
+  (non-our `%R`):
+  `tests/smoke/ui/test_render_smoke.py::test_software_page_provenance_gate_hides_on_nonour_build`
+  and `::test_software_tab_absent_on_nonour_build`. (`RESULTS/04`.)
+- **Phase 5 POSITIVE journey — DONE (the `repo`-marked live journey above).** Two new
+  `repo`-marked cases in `tests/smoke/test_software_update.py`, run on an **our-repo**
+  install (`%R == pfblockerng`) so the provenance gate **opens**:
+  - `test_software_positive_journey_on_our_repo_install` — `pfb_software_provenance_ok()`
+    reads **true** on-box (live inverse of the Phase-4 negative), the shipped page parses
+    (`php -l`) and carries its `pfb-software-panel` marker (so the `.pkg` carried Phase-4's
+    page, built with `ports_ref=adr/19-update-channel-panel`), the orchestrator writes the
+    cache up-to-date with **no** notice, a published newer build advances the cache `latest`
+    and raises **exactly one** notice (a second check at the same latest raises none —
+    de-dupe), and `pkg upgrade` advances the box from our repo with **no** re-notice — every
+    before/after by value.
+  - `test_software_notify_default_is_channel_correct` — paired channel-default branches:
+    **devel → no notice by default**, **nightly → one notice by default** under the identical
+    newer-build condition (nightly *channel* simulated via the orchestrator's `$io` seam, as
+    the nightly repo/package is not in the hermetic CE image — noted in `RESULTS/05`).
+- **Dispatch:** `gh workflow run smoke.yml -f pytest_marker=repo -f ports_ref=adr/19-update-channel-panel`
+  (the `ports_ref` makes the built `.pkg` carry `www/pfblockerng/pfblockerng_software.php`
+  via the FreeBSD-ports plist entry). The captured run id is recorded in `RESULTS/05`.
+- **Docs — DONE.** `README.md` "Usage → Software tab" documents the tab, the three buttons,
+  the provenance gate (present only on an our-repo build, absent on Netgate), and the
+  `pfb_software_notify` knob with its channel-correct defaults; the Option-2 transition note
+  now points at the Software tab instead of "no update badge".
+- **Acceptance:** under the CLAUDE.md "ADR acceptance — automated tests, not a manual
+  maintainer sign-off" rule, the green automated coverage above (PHPUnit branch coverage +
+  the `ui_render` negative gate + the `repo` positive journey on the CE/Plus fan-out) is the
+  acceptance basis. The manual checklist below is retained as **out-of-CI** confirmation
+  (real remote-channel delivery, a real channel switch, a live nightly repo), **not** an
+  acceptance blocker.
+
 ### Manual smoke checklist (owner: maintainer — what CI cannot fully cover)
 
 1. On a live box on the **devel** channel with ADR-17's repo configured: confirm the

--- a/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/01_Results.txt
@@ -1,0 +1,162 @@
+================================================================================
+ADR-19 — PHASE 1 RESULTS (KILL-GATE): read-our-repo-latest + idempotent
+file_notice + same-channel upgrade + provenance probe
+Branch: adr/19-update-channel-panel   Phase: 1   Status: OFF-BOX GREEN; live run PENDING
+================================================================================
+
+VERDICT (pending the live `repo`-marked CI run)
+-----------------------------------------------
+Off-box gates are GREEN and the four kill-gate cases COLLECT under `-m repo`. The
+GO / REJECT / DEGRADE verdict per ADR §1 premise is decided by the LIVE run on the
+ADR-04 VM (the orchestrator dispatches it — this agent cannot boot the VM). The
+cases are written so each premise's pass is unambiguous (see the GO/REJECT map
+below). No `src/` code was written this phase, per the ADR-01 guard.
+
+
+WHAT WAS ADDED
+--------------
+ONE new test file, NOTHING else changed (no src/, no CI, no other tests):
+
+  tests/smoke/test_software_update.py   (marker `repo`, deselected from `-m smoke`)
+
+It REUSES `tests/smoke/test_repo_install.py` wholesale — the `repo_vm` fixture, the
+hermetic `file://` catalog builder (`build_guest_repo`), the `.pkg` re-versioner
+(`reversion_pkg` / `read_compact_version`), the `netgate-decoy` repo, and the
+`pkg_*` / `write_repo_conf` / `repo_priority` helpers — so there is NO second VM
+boot path and NO duplicated catalog machinery (the prompt's constraint). It adds
+only the ADR-19-specific mechanics on top:
+
+  * pkg-read via `-r <ourrepo>` ONLY:
+      pkg_update_our_repo()  -> `pkg update -f -r pfblockerng`
+      pkg_rquery_latest()    -> `pkg rquery -r pfblockerng %v pfSense-pkg-pfBlockerNG-devel`
+      file_sha256()          -> digest of /usr/local/etc/pkg/repos/pfSense.conf
+                                (the "pfSense repo untouched" oracle)
+  * notices via pfSsh.php (the fully-bootstrapped, cron-equivalent env):
+      raise_notice()         -> file_notice('pfBlockerNG', "<msg>", 'pfBlockerNG',
+                                '/pfblockerng/pfblockerng_software.php', 1)
+      count_matching_notices()-> counts get_notices() rows whose `notice` text
+                                carries a per-version substring (the oracle)
+      close_notice('pfBlockerNG') for teardown (VM left clean)
+  * the caller-side de-dupe pattern proven (ADR §2 "persist last-notified"):
+      LAST_NOTIFIED_FILE = /var/db/pfblockerng/pfb_software_last_notified
+      cron_tick(latest, msg): raise+record ONLY when latest != last-notified;
+                              returns True iff a notice fired this tick.
+
+Every case asserts EFFECTIVE state by value (pkg query / pkg rquery / get_notices),
+befores AND afters, never an exit code alone, and cleans up in `finally`.
+
+
+THE FOUR CASES — EXACT LIVE TEST IDS TO DISPATCH + GO/REJECT MAPPING
+--------------------------------------------------------------------
+Dispatch (orchestrator):  gh workflow run smoke.yml -f pytest_marker=repo
+(runs the whole `repo` marker — this file + test_repo_install.py). Capture the run
+id and paste it under "LIVE RUN" below.
+
+The four ADR-19 ids that MUST be green for this kill-gate:
+
+(a) tests/smoke/test_software_update.py::test_read_our_repo_latest_without_pfsense_repo
+    Premise: ADR §1 premise 1 (read our latest WITHOUT `-r pfSense`).
+    Proves: with `<V>_1` installed from ours and `<V>_9` published to ours,
+      `pkg rquery -r pfblockerng %v` == `<V>_9` (our latest) while
+      `pkg query %v` == `<V>_1` (installed) — latest != installed by value — AND
+      the `pfSense.conf` sha256 is byte-identical before vs after the read
+      (pfSense-repo-setup did NOT run).
+    GO  : assertions hold (rquery answers from ours alone; pfSense conf unchanged).
+    REJECT/REDESIGN: rquery cannot answer without `-r pfSense`, OR the pfSense conf
+      digest changes across the read (the §7 premise-1 reject criterion).
+
+(b) tests/smoke/test_software_update.py::test_file_notice_is_idempotent_per_version
+    Premise: ADR §1 premise 2 (file_notice fires from cron + de-dupes per version).
+    Proves: tick1 at version A -> exactly ONE notice for A (before: 0); tick2 at the
+      SAME A -> still exactly ONE (no re-notify); tick3 at higher B -> a notice for B
+      appears. last-notified advances A then B. Before-state asserted at each step.
+    GO  : one-per-new-version, none-per-repeat-version holds.
+    REJECT/REDESIGN: file_notice does not appear in get_notices from the cron-context
+      env, OR the notice cannot be made idempotent per version (the §7 premise-2
+      reject criterion).
+
+(c) tests/smoke/test_software_update.py::test_same_channel_upgrade_advances_from_our_repo
+    Premise: ADR §1 premise 3 (same-channel `pkg upgrade` pulls our build).
+    Proves: `<V>_1` installed from ours (before), then `pkg upgrade -y` after
+      publishing `<V>_9` -> `%v` == `<V>_9`, `%R` == pfblockerng, deps resolved.
+    GO  : the version moves N->N+1 from our repo.
+    DEGRADE (NOT reject): if the in-repo upgrade is unreliable, "Update now" degrades
+      to a documented CLI `pkg upgrade` step (ADR §7) — display + notice still ship.
+
+(d) tests/smoke/test_software_update.py::test_provenance_repo_origin_distinguishes_our_build_from_decoy
+    Premise: the 2026-06-15 provenance amendment (the gate keys on `pkg query %R`).
+    Proves: install with ours higher-priority -> `%R` == `pfblockerng` (gate would
+      SHOW the feature); reinstall with the decoy higher-priority -> `%R` ==
+      `netgate-decoy` (gate would HIDE it). Both directions, `%R` provably changes —
+      so `pfb_software_is_our_build()` can tell our build from a stock/Netgate build.
+    GO  : `%R` discriminates (ours -> show; non-ours -> hide).
+    REJECT/REDESIGN of the provenance approach: `%R` cannot distinguish the install
+      source (e.g. both read identically) — the gate would have no signal to key on.
+
+
+OFF-BOX GATE RESULTS (this agent, in the worktree)
+--------------------------------------------------
+  ruff check .                        -> All checks passed!
+  ruff format --check .               -> 99 files already formatted (incl. the new file)
+  python -m pytest -q  (default)      -> 1575 passed (UNCHANGED; smoke tree --ignore'd)
+  setup-plan (new file):              -> all 4 cases resolve, one shared `SETUP M repo_vm`,
+                                         NO "fixture not found"
+    python -m pytest tests/smoke/test_software_update.py --setup-plan \
+      --override-ini="addopts="
+  mypy: tests/smoke is excluded from the type gate (pyproject `exclude =
+    ['^tests/smoke/']`), as is the whole sibling smoke suite — out of scope here.
+
+  Fixture re-export (post-CI fix): pytest resolves fixtures PER-MODULE, so importing the
+    helper functions from test_repo_install.py did NOT register its `repo_vm` fixture in
+    this module — the first live `repo` run errored at SETUP with `fixture 'repo_vm' not
+    found` (4 errors). Fix: re-export `repo_vm` into this module's namespace (the standard
+    pytest idiom) — `from .test_repo_install import (..., repo_vm, ...)  # noqa: F401`,
+    with `F811` suppressed for this file in pyproject (each case param "redefines" the
+    imported name from ruff's view). `--collect-only` does NOT resolve the fixture graph
+    and so MISSED this — `--setup-plan` is the gate that catches it (used above).
+
+  Note: the `PytestUnknownMarkWarning: ... timeout` lines are pre-existing and shared
+  with test_repo_install.py — `pytest-timeout` is installed in the smoke CI env (the
+  smoke requirements), not in the lint env; harmless, not introduced by this phase.
+
+
+DEPENDENCIES / RUNTIME NEEDS FOR THE LIVE RUN
+---------------------------------------------
+  * SMOKE_PKG  = the branch `.pkg` (the harness already provides it for `-m repo`).
+  * `zstd` on the runner — the re-versioner (reversion_pkg, reused from
+    test_repo_install.py) needs it to forge `<V>_1` / `<V>_9`. Already a dependency
+    of the existing `repo` upgrade test, so the CI runner already has it.
+  * Egress OPEN — inherited from the `repo_vm` fixture (`_ensure_egress_open`); these
+    cases never enter a CaseContext, so they do not block egress.
+  * pfSsh.php on the guest (base pfSense) — used for file_notice/get_notices.
+
+
+DEVIATIONS / NOTES
+------------------
+  * The prompt offered "test_repo_install.py OR a sibling test_software_update.py" —
+    chose the sibling so the ADR-19 mechanics stay separable from the ADR-17 flow,
+    while importing (not copying) all catalog machinery from test_repo_install.py.
+  * count_matching_notices keys on the per-version message SUBSTRING, not the notice
+    id: file_notice is id-keyed (a repeat id REPLACES its row), so counting by id
+    could not distinguish "raised once" from "raised again at a new version". The
+    de-dupe being proven is the CALLER not re-raising (the ADR §2 last-notified
+    pattern), which a version-string count measures correctly.
+  * The nightly channel mapping (stable/devel -> `pfblockerng`, nightly ->
+    `pfblockerng-nightly`) is pure-helper logic; Phase 1 exercises only the shared
+    `pfblockerng` repo (the one the `repo_vm` fixture builds). The nightly repo is
+    pure-helper / Phase-2 territory (ADR §6) and ADR-18-coupled — not part of this
+    kill-gate. OURS_REPO_NAME_DEVEL is an alias of the fixture's `pfblockerng`.
+
+
+LIVE RUN (fill in after dispatch)
+---------------------------------
+  run id: __________   result: __________
+  (a) ____  (b) ____  (c) ____  (d) ____
+
+
+GO-AHEAD FOR PHASE 2
+--------------------
+Phase 2 (pure decision core + PHPUnit oracle) is unblocked once the live run shows
+(a) + (b) GREEN (the hard GO gates) and (c) GREEN-or-noted-DEGRADE. If (a) or (b)
+REJECTs, STOP and reshape the read/notice design per ADR §7 before Phase 2.
+================================================================================

--- a/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/02_Results.txt
@@ -1,0 +1,135 @@
+================================================================================
+ADR-19 — PHASE 2 RESULTS: pure channel/provenance/version/notify decision core
+Branch: adr/19-update-channel-panel   Phase: 2   Status: GREEN (off-box gates)
+================================================================================
+
+SCOPE
+-----
+Phase 2 is the PURE decision core ONLY — strings in, decisions out. NO GUI, NO
+cron, NO `pkg` shellout/IO, NO `file_notice`, NO config wiring (those are Phases
+3-4). All six helpers are pure and side-effect-free.
+
+Predicate: Phase 1 kill-gate verdict was GO (per the orchestrator's live run on
+the ADR-04 VM; 01_Results.txt §GO-AHEAD). Phase 2 proceeded on that GO.
+
+
+HELPERS ADDED (src/usr/local/pkg/pfblockerng/pfblockerng.inc, lines ~1924-2044)
+------------------------------------------------------------------------------
+All under one docblock "ADR-19 software-update decision core (pure)".
+
+1. pfb_channel_from_pkgname(?string $name): ?string
+   Installed package NAME -> channel. Case-insensitive suffix match on the
+   'pfsense-pkg-pfblockerng' prefix:
+     ''        -> 'stable'
+     '-devel'  -> 'devel'
+     '-nightly'-> 'nightly'  (ADR-18 NIGHTLY build)
+   Non-pfBlockerNG name / foreign suffix / empty / null -> null (unknown).
+
+2. pfb_pkg_repo_name_for_channel(?string $channel): ?string
+   channel -> the OUR-repo to read latest from (2026-06-14 + 2026-06-15
+   amendments): stable AND devel both -> 'pfblockerng' (one shared repo; the
+   channel selects the PACKAGE, not the repo); 'nightly' -> 'pfblockerng-nightly'
+   (the sole separately-channelled build); unknown/null -> null.
+
+3. pfb_software_is_our_build(?string $installed_repo): bool
+   THE PROVENANCE GATE (2026-06-15 amendment). The repo is read from
+   `pkg query '%R' <pkgname>`. TRUE only for 'pfblockerng' or
+   'pfblockerng-nightly'; 'pfSense' (Netgate), '', 'unknown', null, or any other
+   -> FALSE. Later phases gate the tab append, the page top-of-file guard, the
+   priv match[] line, AND the cron notice on this single predicate.
+
+4. pfb_update_available(?string $installed, ?string $latest): bool
+   TRUE iff $latest is strictly newer than $installed, via pfSense
+   pkg_version_compare() === '<' (never a string compare). Empty/null installed
+   OR latest -> FALSE (a missing version is never "an update is available").
+   Nightly's dated YYYYMMDD versions compare nightly-to-nightly.
+
+5. pfb_notify_default_for_channel(?string $channel): bool
+   Channel-aware default for the notify knob when unset/'default':
+   nightly -> TRUE (trackers opted into the tip); stable/devel/other/null ->
+   FALSE (quiet for release users). (Implemented as $channel === 'nightly'.)
+
+6. pfb_should_notify(?string $installed, ?string $latest, ?string $last_notified,
+                     ?string $knob, ?string $channel): bool
+   The notify state machine. effective-notify = ($knob==='on') ? true :
+   ($knob==='off') ? false : pfb_notify_default_for_channel($channel). Returns
+   TRUE only when effective AND pfb_update_available($installed,$latest) AND
+   $latest !== $last_notified (the per-version de-dupe: a daily cron at the same
+   latest does NOT renotify; a newer latest does).
+
+   NOTE the signature follows the PHASE-2 PROMPT order
+   ($installed,$latest,$last_notified,$knob,$channel), NOT the ADR §2 "Helper
+   seam" sketch ($cur,$last_notified,$available,$knob,$channel) which predates
+   the prompt. The prompt's explicit-version form is implemented (it computes
+   availability internally via pfb_update_available rather than taking a
+   pre-computed $available bool). Phase 3 callers must use the prompt order.
+
+
+STUB / DOUBLE ADDED
+-------------------
+- Stubs: NONE needed — pkg_version_compare (stubs/pfsense/services.php:181) and
+  file_notice (stubs/pfsense/logging.php:34) already exist. PHPStan clean with no
+  baseline suppression.
+- Double: ADDED a FAITHFUL pkg_version_compare() to tests/php/pfsense_doubles.php
+  (function_exists-guarded). It maps PHP version_compare() to the FreeBSD pkg(8)
+  symbol '<' | '=' | '>' — the real function shells to `pkg version -t`, which is
+  unavailable off-appliance. version_compare orders every version class the
+  decision core sees (semver, the '_N' port-revision upgrade legs the catalog
+  uses, and nightly's dated YYYYMMDD), verified against the test matrix.
+
+
+TESTS (tests/php/SoftwareUpdateDecisionTest.php) — 47 cases, all green
+---------------------------------------------------------------------
+Every branch, both sides, before-state asserted on transitions; the de-dupe
+machine gets a BDD Given/When/Then lifecycle.
+
+- testChannelFromPkgname (DataProvider): stable / devel / nightly (+ case-
+  insensitive devel & nightly) / other-pkg / foreign-suffix / empty / null.
+- testRepoNameForChannel (DataProvider, the channel->repo mapping):
+    stable -> 'pfblockerng', devel -> 'pfblockerng',
+    nightly -> 'pfblockerng-nightly', unknown -> null, null -> null.
+- testSoftwareIsOurBuild (DataProvider, the provenance gate, BOTH sides pinned):
+    'pfblockerng' -> true, 'pfblockerng-nightly' -> true,
+    'pfSense' -> false, '' -> false, 'unknown' -> false, null -> false,
+    'netgate-decoy' -> false.
+- testUpdateAvailable (DataProvider): newer/newer-minor -> true; equal/older ->
+  false; nightly newer/same/older date; empty/null installed; empty/null latest.
+- testNotifyDefaultForChannel (DataProvider): nightly -> true (ON);
+  stable/devel/unknown/null -> false (OFF) — paired so the branch is real.
+- testShouldNotifyMatrix (DataProvider): knob on overrides OFF default (stable);
+  knob off overrides ON default (nightly); default OFF on stable AND devel
+  PAIRED WITH default ON on nightly; never-notify when not available; unset knob
+  resolves to the channel default both ways.
+- testShouldNotifyDeDupeLifecycle (BDD): GIVEN never-notified + newer 1.1 ->
+  notify; WHEN 1.1 recorded, same tick -> NO renotify; WHEN newer 1.2 (1.1 still
+  recorded) -> notify again (re-asserts the 1.1 tick still suppressed first, so
+  the flip is caused by the newer version); WHEN 1.2 recorded, repeat -> NO
+  renotify. Before-state asserted at every step.
+
+The provenance test ids:    SoftwareUpdateDecisionTest::testSoftwareIsOurBuild
+The channel-mapping test ids: SoftwareUpdateDecisionTest::testRepoNameForChannel
+
+
+OFF-BOX GATE RESULTS (this agent, in the worktree)
+--------------------------------------------------
+  php -l (pfblockerng.inc, pfsense_doubles.php) -> No syntax errors
+  vendor/bin/phpunit (filter)  -> OK (47 tests, 51 assertions)
+  vendor/bin/phpunit (full)    -> OK (477 tests, 878 assertions)
+  vendor/bin/phpstan analyse --no-progress -> [OK] No errors
+  ruff check .                 -> All checks passed!
+  python -m pytest -q          -> 1575 passed (UNCHANGED; no Python touched)
+
+
+GO-AHEAD FOR PHASE 3
+--------------------
+The pure core is pinned. Phase 3 wires it to real IO:
+  - Add the thin pfb_pkg_*() shellout wrapper (pkg update -r <repo> /
+    pkg rquery -r <repo> %v / pkg query %v %R), pkg-lock- and DNS-guarded.
+  - pfb_software_update_check(): read installed + our-repo latest, write the
+    cache under /var/db/pfblockerng/, gate on pfb_software_is_our_build(), call
+    pfb_should_notify() -> file_notice (de-duped), persist last-notified.
+  - Wire into the pfblockerng.php cron path; register the pfb_software_notify
+    config field default.
+  Phase-3 callers MUST use the prompt-order pfb_should_notify signature
+  ($installed,$latest,$last_notified,$knob,$channel).
+================================================================================

--- a/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/03_Results.txt
@@ -1,0 +1,206 @@
+================================================================================
+ADR-19 — PHASE 3 RESULTS: cron-driven update check + de-duped, provenance-gated notice
+Branch: adr/19-update-channel-panel   Phase: 3   Status: GREEN (off-box gates)
+================================================================================
+
+SCOPE
+-----
+Phase 3 wires the Phase-2 pure decision core to real IO: a thin pkg-IO wrapper, a
+cron-driven orchestrator that caches installed-vs-our-repo-latest and raises a
+de-duped file_notice, and the cron wiring. NO GUI page / tab (Phase 4). The live
+pkg/file_notice legs are Phase-4/5 smoke (not run here).
+
+Predicate: Phase 2 GO (six pure helpers landed, 47 cases green). Phase-3 callers use
+the prompt-order pfb_should_notify($installed,$latest,$last_notified,$knob,$channel).
+
+
+FUNCTIONS ADDED (src/usr/local/pkg/pfblockerng/pfblockerng.inc, after the Phase-2 core)
+--------------------------------------------------------------------------------------
+Under one docblock "ADR-19 Phase 3 — pkg IO wrapper + cron-driven update check".
+
+Constant:
+  PFB_PKG_BIN = '/usr/sbin/pkg'   (base pkg binary on every supported target)
+
+Thin pkg-IO wrapper (the ONLY new code that shells to pkg; escapeshellarg'd; all the
+exec args are fixed flags + pkg-derived names — NOT attacker-controlled feed input, so
+the PFBL-01 sniff scope does not apply and they are not added to its allow-list):
+
+  pfb_pkg_installed_name(): string
+    -> `pkg query '%n' 'pfSense-pkg-pfBlockerNG*'`, returns the first line that
+       pfb_channel_from_pkgname() recognises; '' if not installed / query fails.
+
+  pfb_pkg_installed_version(string $pkgname): string
+    -> `pkg query '%v' <pkgname>`; '' when absent/failed.
+
+  pfb_pkg_installed_repo(string $pkgname): string
+    -> `pkg query '%R' <pkgname>` (the provenance signal); '' when absent/failed.
+
+  pfb_pkg_latest(string $pkgname, string $reponame): string
+    -> GUARDS FIRST: '' if pkgname/reponame empty, OR is_subsystem_dirty('pkg'),
+       OR (function_exists('get_dnsavailable') && !get_dnsavailable()).
+       Else best-effort `pkg update -r <repo>` then
+       `pkg rquery -r <repo> '%v' <pkgname>`. Reads ONLY our repo — never -r pfSense /
+       get_pkg_info. '' when the repo/conf is absent.
+
+Cache helpers:
+  pfb_software_cache_file(): string   -> "{$pfb['dbdir']}/software_update.json"
+                                         (dbdir falls back to /var/db/pfblockerng).
+  pfb_software_read_cache(): array    -> json_decode the file; [] when absent/corrupt.
+  pfb_software_write_cache(array): void -> atomic-ish @file_put_contents(LOCK_EX),
+                                         best-effort (swallowed on failure; never throws).
+
+Orchestrator:
+  pfb_software_update_check(bool $force = false, ?array $io = null): array
+    Order (deliberate):
+      1. Resolve installed_name / installed / installed_repo. $io overrides each key
+         ('installed_name','installed','installed_repo','latest') for unit tests; absent
+         keys fall through to the live pfb_pkg_*() shellout. (This is the documented
+         unit-test seam — the IO is "doubled" by injection, not by redefining functions.)
+      2. PROVENANCE GATE FIRST: if !pfb_software_is_our_build($installed_repo) -> return
+         the existing cache and DO NOTHING ELSE (no catalog read, no cache write, no
+         file_notice). A Netgate-installed build (repo 'pfSense'/unknown/'') is a true
+         no-op.
+      3. Read our-repo latest (channel -> repo via pfb_pkg_repo_name_for_channel()).
+         An empty latest (pkg locked / no DNS / repo absent) PRESERVES the cached latest
+         (page keeps showing last-known, never regresses to '').
+      4. Refresh cache (channel/installed/latest/last_checked). If
+         pfb_should_notify($installed,$latest,$last_notified,$knob,$channel) ->
+         file_notice(...) AND persist last_notified = latest (per-version de-dupe).
+    Best-effort; returns the cache array; never throws.
+    $force is accepted for the Phase-4 "Check now" button — currently a no-op flag
+    (there is no freshness short-circuit yet).
+
+
+CACHE FILE
+----------
+  Path:   /var/db/pfblockerng/software_update.json   (pfb_software_cache_file())
+  Format: JSON object (JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES), keys:
+    {
+      "channel":       "stable" | "devel" | "nightly" | null,
+      "installed":     "<pkg %v>"   (e.g. "3.2.0_1"),
+      "latest":        "<our-repo %v>" (e.g. "3.2.0_9"; preserved when read unavailable),
+      "last_checked":  <unix epoch int>,
+      "last_notified": "<version last announced>"  (the de-dupe key; '' until first notice)
+    }
+  Cleared on deinstall like sibling /var/db/pfblockerng state.
+
+NOTICE
+------
+  file_notice('pfBlockerNG',
+              "pfBlockerNG <latest> available (<channel>)",
+              'pfBlockerNG',
+              '/pfblockerng/pfblockerng_software.php',   <- the Phase-4 page (not yet shipped)
+              1)
+  Fires ONCE per new latest (de-dupe via last_notified); local bell + the admin's
+  configured remote channels (SMTP/Telegram/Pushover/Slack), per pfSense notices.inc.
+
+
+CONFIG FIELD
+------------
+  Name:    pfb_software_notify   (pfb_* neighbour pattern, e.g. pfb_hsts/pfb_dnsvip_auto)
+  Path:    installedpackages/pfblockerng/config/0/pfb_software_notify
+  Values:  'default' | 'on' | 'off'
+  Default: read with config_get_path(..., 'default'); 'default' resolves PER CHANNEL via
+           the Phase-2 pfb_notify_default_for_channel() inside pfb_should_notify()
+           (nightly -> ON, stable/devel -> OFF). There is no central <default_value> xml
+           registration for pfBlockerNG general-settings knobs — the codebase resolves
+           defaults read-side with ?:/config_get_path defaults (same as pfb_hsts /
+           pfb_dnsvip_auto). The Phase-4 page writes the field; the orchestrator reads it.
+
+
+CRON WIRING
+-----------
+  src/usr/local/www/pfblockerng/pfblockerng.php :: pfblockerng_sync_cron()
+  Added `pfb_software_update_check();` at the TAIL (after the feed-update sync decision,
+  before pfb_log_mgmt()). Runs ONCE per cron tick (not per feed/sync). Best-effort +
+  fully guarded -> cannot throw into / slow the feed cron. `pfblockerng.php cron`
+  (-> pfblockerng_sync_cron) is the entry; `pfblockerng.php update`/'updateip'/'updatednsbl'
+  go through sync_package_pfblockerng directly and are NOT on this path (intentional —
+  the version check is a daily-tick concern, not a force-reload concern).
+
+
+STUBS / DOUBLES
+---------------
+  Stub ADDED (stubs/pfsense/system.php): get_dnsavailable($ipproto = "inet"): bool
+    (it IS in 2.7.2 system.inc so a stub regen would reproduce it; added to system.php,
+     the canonical home). No phpstan-baseline suppression — PHPStan clean.
+    Existing stubs reused: file_notice (logging.php), is_subsystem_dirty (util.php),
+    config_get_path (config.php), pkg_version_compare (services.php).
+
+  Doubles ADDED (tests/php/pfsense_doubles.php), function_exists-guarded, $GLOBALS-driven:
+    file_notice()        -> appends to $GLOBALS['pfb_test_file_notices'] (capture/count).
+    is_subsystem_dirty() -> 'pkg' returns $GLOBALS['pfb_test_pkg_locked'] (default false).
+    get_dnsavailable()   -> $GLOBALS['pfb_test_dns_available'] (default true).
+  The pkg IO itself is NOT doubled (it is real code under test) — the orchestrator's $io
+  injection seam supplies installed/latest/installed_repo so no real `pkg` shells off-box.
+
+
+TESTS (tests/php/SoftwareUpdateCheckTest.php) — 10 cases, 55 assertions, all green
+---------------------------------------------------------------------------------
+Every branch, both sides, before-state asserted; the de-dupe machine is BDD.
+
+  Provenance gate (the amendment, BOTH sides):
+    testOurBuildRunsCheckWritesCacheAndCanNotify
+        our repo -> cache written (channel/installed/latest/last_checked/last_notified)
+        + exactly one notice. Before: no cache, no notice.
+    testNetgateBuildIsCompleteNoOp  (DataProvider foreignRepoProvider:
+        'pfSense' / '' / 'unknown' / 'netgate-decoy')
+        update nominally available + knob ON, yet NO cache write + NO notice. Before/after
+        both asserted -> the gate is the first thing the check does.
+
+  pkg-lock / no-DNS short-circuit (LIVE pfb_pkg_latest path, no injected latest):
+    testPkgLockedServesCacheNoNetworkNoNotice  (is_subsystem_dirty('pkg') true)
+    testNoDnsServesCacheNoNetworkNoNotice       (get_dnsavailable() false)
+        Both: a seeded prior cache (latest=3.2.0_9, last_notified=3.2.0_9) is PRESERVED,
+        no NEW notice, no error. Before: cache holds prior latest.
+
+  Knob gating (cache always refreshed; notice gated):
+    testKnobOffRefreshesCacheButSuppressesNotice   (off vs the on case above = real branch)
+    testNoUpdateAvailableRefreshesCacheNoNotice     (installed==latest -> no notify)
+
+  De-dupe lifecycle across ticks (the persist-last-notified contract), BDD:
+    testNoticeDeDupesPerVersionAcrossTicks
+        tick1 3.2.0_9 -> notify once + persist; tick2 same -> NO renotify;
+        tick3 newer 3.2.0_10 -> notify again + persist (re-asserts tick2 suppression
+        first); tick4 same -> NO renotify. last_notified asserted BEFORE each tick.
+
+  KEY TEST IDS:
+    Provenance gate:  SoftwareUpdateCheckTest::testNetgateBuildIsCompleteNoOp
+                      SoftwareUpdateCheckTest::testOurBuildRunsCheckWritesCacheAndCanNotify
+    De-dupe:          SoftwareUpdateCheckTest::testNoticeDeDupesPerVersionAcrossTicks
+    pkg-lock:         SoftwareUpdateCheckTest::testPkgLockedServesCacheNoNetworkNoNotice
+    no-DNS:           SoftwareUpdateCheckTest::testNoDnsServesCacheNoNetworkNoNotice
+
+
+OFF-BOX GATE RESULTS (this agent, in the worktree)
+--------------------------------------------------
+  php -l (inc, pfblockerng.php, doubles, test, system.php) -> No syntax errors
+  vendor/bin/phpunit --filter SoftwareUpdateCheckTest      -> OK (10 tests, 55 assertions)
+  vendor/bin/phpunit (full)                                -> OK (487 tests, 933 assertions)
+  vendor/bin/phpstan analyse --no-progress                 -> [OK] No errors
+  vendor/bin/phpcs (PFBL-01 sniff)                         -> clean (no violations)
+  ruff check .                                             -> All checks passed!
+  python -m pytest -q                                      -> 1575 passed (UNCHANGED)
+
+
+GO-AHEAD FOR PHASE 4 — the "Software" page (display + actions) + UI render gate
+------------------------------------------------------------------------------
+Phase 4 builds src/usr/local/www/pfblockerng/pfblockerng_software.php. It must:
+  * GUARD top-of-file on pfb_software_is_our_build(pfb_pkg_installed_repo(
+    pfb_pkg_installed_name())) -> header(Location: /index.php) on a Netgate build.
+  * READ the cache via pfb_software_read_cache() (path pfb_software_cache_file(),
+    /var/db/pfblockerng/software_update.json) -> show channel, installed, latest,
+    last_checked. Compute "update available" with pfb_update_available(installed, latest).
+  * Render the pfb_software_notify knob (default|on|off) and persist it to
+    installedpackages/pfblockerng/config/0/pfb_software_notify.
+  * "Check now" -> call pfb_software_update_check(true) (force flag wired but presently a
+    no-op; add a freshness short-circuit here if desired) to refresh the cache.
+  * "Update now" -> same-channel `pkg upgrade -y <currentpkg>` (reuse pfblockerng_update.php
+    streaming). "Bootstrap repo" -> scripts/add-repo.sh <current-channel>.
+  * Add the "Software" tab to every page's $tab_array[] (gate the append on
+    pfb_software_is_our_build) + a match[] line in pfblockerng.priv.inc (also gated).
+  * Add the www/ page to the FreeBSD-ports pkg-plist (new shipped file).
+LIVE legs deferred to Phase 4 (ui_render) / Phase 5 (repo smoke): the real pkg shellout
+(pfb_pkg_*), the actual file_notice on the VM, and the publish-newer-build -> notice +
+cache + Update-now journey.
+================================================================================

--- a/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/04_Results.txt
@@ -1,0 +1,180 @@
+================================================================================
+ADR-19 — PHASE 4 RESULTS: provenance-gated Software page + tab + ui_render negative
+                          gate + ports_ref CI plumbing
+Branch: adr/19-update-channel-panel   Phase: 4   Status: GREEN (off-box gates)
+================================================================================
+
+SCOPE
+-----
+First shipped src/ GUI for ADR-19: a new pfblockerng_software.php page (display +
+POST-guarded Check/Update/Bootstrap actions + the notify knob), the "Software" tab
+appended to EVERY pfBlockerNG page (provenance-gated), the priv match[] line, the
+ui_render NEGATIVE gate (the hide-path is the one this Tier-A deploy can prove live),
+and the optional ports_ref/ports_repo CI plumbing for Option-A validation.
+
+Predicate: Phase 3 GO (cache + orchestrator + cron + de-duped notice landed; HEAD
+322da60). Phase-4 consumes the Phase-2/3 helpers verbatim.
+
+
+A. THE PAGE — src/usr/local/www/pfblockerng/pfblockerng_software.php
+-------------------------------------------------------------------
+PROVENANCE GUARD is the FIRST executable thing (after require_once + pfb_global(),
+which must run to define $pfb):
+    if (!pfb_software_provenance_ok()) { header('Location: /index.php'); exit; }
+pfb_software_provenance_ok() = pfb_software_is_our_build(pfb_pkg_installed_repo(
+pfb_pkg_installed_name())) — a Netgate/sideloaded install (repo pfSense/unknown/'')
+is redirected away before any render or action handler runs.
+
+DISPLAY (from pfb_software_read_cache(), /var/db/pfblockerng/software_update.json):
+  channel, installed version, latest (our repo), status (Update available / Up to
+  date / Not checked yet via pfb_update_available()), last_checked. An empty/unknown
+  cache renders a clean "not checked yet" / "never" state — NO warning (so the first
+  GET passes ui_render before any check has run).
+
+NOTIFY KNOB: Form_Select pfb_software_notify (default|on|off), saved via the standard
+pfSense CSRF POST (isset($_POST['save'])) to
+installedpackages/pfblockerng/config/0/pfb_software_notify, then redirect-back.
+
+ACTIONS (POST-only, never on GET — so the ui_render GET cannot fire pkg; the three
+action buttons preventDefault + JS-submit a hidden pfb_sw_action; Update/Bootstrap
+confirm() first):
+  * Check now  -> pfb_software_update_check(true) then redirect-back (cache refresh).
+  * Update now -> SAME-CHANNEL `pkg upgrade -y <currentpkg>` (escapeshellarg'd
+    pkg-derived name; NO cross-channel install), streamed via the _update.php live-
+    terminal mechanic (pfb_software_output/_status, X-Accel-Buffering: no).
+  * Bootstrap repo -> reproduces add-repo.sh's effect for the CURRENT channel inline
+    (the dev-only script is NOT shipped in src/): writes the repo conf
+    (/usr/local/etc/pkg/repos/pfblockerng.conf for stable/devel; ...-nightly.conf +
+    `nightly/` subpath for nightly; url pkg.pfblockerng.workers.dev/${ABI}, priority
+    100, NONE-signed — byte-matching add-repo.sh) then `pkg update -r <repo>`,
+    streamed. stable+devel share repo `pfblockerng`; nightly -> `pfblockerng-nightly`
+    (ADR-19 amendment 2).
+
+CONTENT MARKER (ui_render oracle): element id="pfb-software-panel" (on the Channel
+StaticText in the "Software Status" Form_Section). Page title crumb: Firewall >
+pfBlockerNG > Software.
+
+
+B. TAB + PRIV (both provenance-gated)
+-------------------------------------
+TAB-GATE HELPER (src/usr/local/pkg/pfblockerng/pfblockerng.inc, after the Phase-3
+orchestrator):
+  pfb_software_provenance_ok(): bool   — live wrapper over the pure
+        pfb_software_is_our_build() (reads pkg %R via the Phase-3 IO).
+  pfb_software_add_tab(array &$tab_array, bool $active=false): void
+        — appends array(gettext('Software'), $active, '/pfblockerng/
+          pfblockerng_software.php') ONLY when pfb_software_provenance_ok(). Called
+          immediately before display_top_tabs() on EVERY page, so the tab is present
+          (our build) or absent (Netgate build) consistently across the GUI.
+
+Wired into all 14 pages' MAIN tab row (the row ending in the Sync tab — NOT the
+secondary IPv4/IPv6/GeoIP sub-row): pfblockerng.php (2 main rows), _general.php
+(before the Wizard tab), _ip, _dnsbl, _update, _hooks, _alerts, _feeds, _log, _sync,
+_safesearch, _blacklist, _category, _category_edit. The new page sets $active=true
+for its own tab.
+
+PRIV LINE (src/etc/inc/priv/pfblockerng.priv.inc, after the _update.php match, in
+$priv_list['page-firewall-pfblockerng']['match']):
+  $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_software.php";
+(Operator-gated like the sibling pages. The RUNTIME hide is the page's own top-of-
+file guard + the gated tab append; the priv match makes the page reachable for an
+operator on an our-build box.)
+
+
+C. CI PLUMBING — ports_ref / ports_repo (Option-A validation)
+-------------------------------------------------------------
+Added an OPTIONAL ports_repo + ports_ref input to BOTH .github/workflows/smoke.yml
+and .github/workflows/ui-tests.yml (workflow_dispatch AND workflow_call), forwarded
+to the build-pkg-linux.yml job's with::
+    ports_repo: ${{ inputs.ports_repo || 'pfBlockerNG/FreeBSD-ports' }}
+    ports_ref:  ${{ inputs.ports_ref  || 'pfblockerng/use-github' }}
+Blank input -> build-pkg-linux's own defaults, so a NORMAL run is byte-identical.
+A maintainer can now point a pre-merge smoke/ui run at a FreeBSD-ports branch
+carrying the new plist entry (build-pkg-linux already accepts ports_ref/ports_repo
+and clones that tree for the portable .pkg build). YAML parse: confirmed for both +
+build-pkg-linux.yml.
+
+
+D. ui_render TEST — the NEGATIVE side (tests/smoke/ui/test_render_smoke.py)
+--------------------------------------------------------------------------
+The ADR-04 UI harness installs the branch .pkg with `pkg add -f` (offline) -> the
+installed package's repo (pkg %R) is NOT one of our repos -> the provenance gate
+HIDES the page AND the tab. That hide-path is what THIS deploy can prove live (the
+POSITIVE render is Phase 5). Two new tests (both enrolled in the module-level
+php_error_log_guard no-growth sweep):
+
+  test_software_page_provenance_gate_hides_on_nonour_build
+      GET /pfblockerng/pfblockerng_software.php with allow_redirects=False ->
+      asserts a 3xx whose Location ends in /index.php AND the 'pfb-software-panel'
+      marker is ABSENT from the body (a broken guard that 200-renders the panel
+      can't pass by following the redirect). No new php_error.log line (the guard is
+      a clean redirect+exit, not a fatal).
+
+  test_software_tab_absent_on_nonour_build
+      GET the General page -> passes the clean-render oracle AND the Software tab
+      href '/pfblockerng/pfblockerng_software.php' is ABSENT from the tab bar
+      (pfb_software_add_tab() appended nothing). Pairs with the page-gate test so
+      BOTH gated surfaces are proven hidden.
+
+Test ids:
+  tests/smoke/ui/test_render_smoke.py::test_software_page_provenance_gate_hides_on_nonour_build
+  tests/smoke/ui/test_render_smoke.py::test_software_tab_absent_on_nonour_build
+Collection + fixture resolution confirmed (--collect-only + --setup-plan: fixtures
+webui, php_error_log_guard, deployed_vm, smoke_vm all resolve).
+
+
+PLIST — the EXACT install path the orchestrator must add to FreeBSD-ports
+------------------------------------------------------------------------
+pkg-plist entries are PREFIX-relative (PREFIX=/usr/local), matching the sibling www
+pages (e.g. `www/pfblockerng/pfblockerng_update.php`). Add this line to the
+pfBlockerNG[-devel/-nightly] port's pkg-plist (alongside the other
+www/pfblockerng/*.php entries):
+
+    www/pfblockerng/pfblockerng_software.php
+
+It installs to /usr/local/www/pfblockerng/pfblockerng_software.php. www/ pages are
+NOT chroot-copied (only the Unbound module is) — plist ONLY, no chroot/deploy wiring.
+The FreeBSD-ports repo is SEPARATE (pfBlockerNG/FreeBSD-ports, branch
+pfblockerng/use-github) — the orchestrator adds the plist line there; the ports_ref
+input (C above) lets a pre-merge run validate the .pkg built from that branch. PR CI
+does not build the .pkg, so this stays green locally.
+
+NO src/ stub additions were needed beyond Phase 3: the page calls already-stubbed
+pfSense fns (safe_mkdir, display_top_tabs, config_set_path, write_config,
+pfb_alerts_default_page, the Form_* classes in stubs/pfsense/forms.php). PHPStan
+clean at level 1 (the page is in `src`, which PHPStan scans).
+
+
+OFF-BOX GATE RESULTS (this agent, in the worktree)
+--------------------------------------------------
+  php -l (the new page + the inc + the priv + all 14 edited www pages) -> clean
+      (sync.php's pre-existing "continue targeting switch" warnings are unrelated)
+  vendor/bin/phpstan analyse --no-progress  -> [OK] No errors
+  vendor/bin/phpcs                          -> clean (no PFBL-01 violations)
+  vendor/bin/phpunit                        -> OK (487 tests, 933 assertions)
+  ruff check .                              -> All checks passed!
+  python -m pytest -q                       -> 1575 passed (UNCHANGED)
+  ui_render collect (--collect-only)        -> both new tests collected
+  ui_render --setup-plan                    -> fixtures resolve for both new tests
+  YAML parse smoke.yml + ui-tests.yml (+ build-pkg-linux.yml) -> OK
+
+
+GO-AHEAD FOR PHASE 5 — the repo-install POSITIVE journey
+--------------------------------------------------------
+Phase 5 is the ADR-17 `repo`-marker live journey on a VM where the package is
+installed FROM our repo (pkg %R == pfblockerng / pfblockerng-nightly). It must
+assert the POSITIVE side of every gate Phase 4 proved hidden:
+  * GET /pfblockerng/pfblockerng_software.php -> HTTP 200 (no redirect), the
+    'pfb-software-panel' marker PRESENT, the Check/Update/Bootstrap buttons + the
+    pfb_software_notify select rendered, body free of PHP diagnostics, no new
+    php_error.log line.
+  * The "Software" tab PRESENT (href /pfblockerng/pfblockerng_software.php) on a
+    normal pfBlockerNG page (e.g. general).
+  * The end-to-end notice journey: publish a newer our-repo build -> cron
+    pfb_software_update_check() raises ONE de-duped file_notice -> the page shows
+    "Update available" -> "Update now" (same-channel pkg upgrade) clears it.
+  * A Netgate-decoy-installed box (the existing repo-smoke cross-repo decoy) shows
+    NO Software tab + raises NO notice (the negative, on the live box).
+Use the ports_ref input (C) to point the pre-merge build at the FreeBSD-ports branch
+carrying the new plist line, so the .pkg actually ships pfblockerng_software.php.
+================================================================================

--- a/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/05_Results.txt
@@ -1,0 +1,160 @@
+================================================================================
+ADR-19 — PHASE 5 RESULTS: POSITIVE end-to-end repo-install journey (Software page +
+                          de-duped channel-correct notice + same-channel Update) + docs
+Branch: adr/19-update-channel-panel   Phase: 5 (final)   Status: GREEN (off-box gates)
+================================================================================
+
+SCOPE
+-----
+The POSITIVE side of every gate Phase 4 proved hidden, on a VM where pfBlockerNG is
+installed FROM our repo (pkg %R == pfblockerng) — the only place the provenance gate
+OPENS. Two new `repo`-marked cases extend tests/smoke/test_software_update.py (reusing
+Phase-1's repo_vm + hermetic-catalog machinery + the notice helpers), plus user docs
+(README) and ADR §7 DoD. NO src/ change this phase.
+
+Predicate: Phase 4 GO (HEAD 9f9619f — provenance-gated page + tab + ui_render NEGATIVE
+gate + ports_ref CI plumbing). Phase 5 consumes the shipped Phase-3/4 surfaces verbatim.
+
+
+WHY pfSsh.php (not a webui GET) IS THE LIVE PAGE ORACLE HERE
+-----------------------------------------------------------
+The ADR-14 `webui` fixture (tests/smoke/ui/conftest.py) depends on `deployed_vm` — a
+`pkg add -f` (offline) install whose %R is NOT our repo, so on that box the provenance
+gate HIDES the page (that is exactly Phase 4's negative ui_render proof). The `repo`
+harness has no authenticated webui client, and an our-repo install only exists in this
+`repo` flow. So the POSITIVE page assertion is driven via pfSsh.php (the bootstrapped,
+config-locked pfSense env the cron uses):
+  * pfb_software_provenance_ok() evaluated on-box reads TRUE (the live inverse of Phase
+    4's negative gate) — the exact predicate the page top-of-file guard + the tab append
+    key on;
+  * `php -l` of the SHIPPED page /usr/local/www/pfblockerng/pfblockerng_software.php
+    parses clean (no Fatal/Parse);
+  * the page FILE contains the `pfb-software-panel` marker — proving the built .pkg
+    actually carried Phase-4's page (the FreeBSD-ports plist entry took effect because
+    the build ran with ports_ref=adr/19-update-channel-panel).
+This is the most robust live assertion the `repo` harness supports; no false-greens (a
+broken/absent page fails php -l or the marker grep; a broken gate fails provenance_ok).
+
+
+NEW `repo`-MARKED TEST IDS + WHAT EACH PROVES LIVE
+--------------------------------------------------
+File: tests/smoke/test_software_update.py  (marker `repo`, fixture repo_vm)
+
+1. test_software_positive_journey_on_our_repo_install   (@timeout 900)
+   GIVEN build <V>_1 installed FROM our repo (%v==<V>_1, %R==pfblockerng):
+     - pfb_software_provenance_ok() == TRUE on-box (page/tab WOULD be shown);
+     - the shipped page parses (php -l) AND carries the `pfb-software-panel` marker;
+     - BEFORE: empty cache, no notice for <V>_9.
+   WHEN the first check runs at installed==latest==<V>_1:
+     THEN cache {installed,latest}==<V>_1, channel=='devel', NO notice (up to date).
+   WHEN <V>_9 is published to the SAME repo and the check runs:
+     THEN cache.latest advances to <V>_9 AND exactly ONE notice mentioning <V>_9;
+     a SECOND check at the same latest -> still ONE notice (per-version de-dupe).
+   WHEN `pkg upgrade` (Update now) runs and the check runs again:
+     THEN %v moved <V>_1 -> <V>_9, %R still pfblockerng, deps resolved, cache
+     installed==latest==<V>_9, and NO new notice (no newer version).
+   Every before/after asserted BY VALUE. Channel here is devel (default OFF) so the
+   knob is forced `on` for the notice legs (the channel-default branches are case 2).
+
+2. test_software_notify_default_is_channel_correct      (@timeout 600)
+   The notify DEFAULT is driven by the CHANNEL, not an always-path (knob unset/'default'):
+   GIVEN our-repo install (gate OPEN), knob='default', clean notices, a newer <V>_9
+     published (BEFORE: 0 devel notices, 0 nightly notices):
+   WHEN a live check runs as the DEVEL channel  -> NO notice (devel default OFF).
+   WHEN a check runs as the NIGHTLY channel under the IDENTICAL newer-build condition
+     -> exactly ONE notice (nightly default ON).
+   Same condition, opposite outcome => the channel default is the only difference.
+
+   NIGHTLY SIMULATION (noted as required): the nightly repo/package
+   (pfSense-pkg-pfBlockerNG-NIGHTLY / pfblockerng-nightly) is NOT built into the
+   hermetic CE image (ADR-18 not live here). The nightly CHANNEL is simulated via the
+   orchestrator's documented $io seam — injecting installed_name
+   'pfSense-pkg-pfBlockerNG-NIGHTLY' (-> channel nightly), installed_repo
+   'pfblockerng' (so the provenance gate still OPENS), and the installed/latest gap.
+   Because latest is injected, pfb_pkg_latest() never shells to the (absent) nightly
+   repo. What is proven end to end is the CHANNEL-DEFAULT decision through the REAL
+   orchestrator -> REAL file_notice -> get_notices, not a nightly pkg install. When
+   ADR-18's nightly repo lands, this can be upgraded to a real nightly install.
+
+Both cases CLOSE every notice raised, clear the cache + knob, delete the package, and
+remove UPGRADE_REPO_DIR in `finally` — the VM is left clean.
+
+Reused verbatim from Phase 1 / test_repo_install: repo_vm, build_guest_repo,
+reversion_pkg, write_repo_conf, pkg_install_from_repo, pkg_upgrade, pkg_update,
+pkg_installed_version, pkg_repo_origin, read_compact_version, repo_priority,
+NETGATE_REPO_NAME/OURS_REPO_NAME/UPGRADE_REPO_DIR/PKG_NAME, _pfssh,
+count_matching_notices, close_all_notices, _php_str.
+New on-box helpers (this file): provenance_ok_on_box, run_update_check_on_box,
+read_software_cache, clear_software_state, set_notify_knob/clear_notify_knob,
+php_lint_ok, install_our_build_at, _pfssh_scalar.
+
+
+DISPATCH (the orchestrator MUST use ports_ref so the .pkg carries the page)
+--------------------------------------------------------------------------
+    gh workflow run smoke.yml \
+        -f pytest_marker=repo \
+        -f ports_ref=adr/19-update-channel-panel
+
+ports_ref=adr/19-update-channel-panel points build-pkg-linux at the FreeBSD-ports
+branch carrying the new pkg-plist line `www/pfblockerng/pfblockerng_software.php`, so
+the built .pkg actually ships pfblockerng_software.php (installed at
+/usr/local/www/pfblockerng/pfblockerng_software.php — the marker/lint asserts depend on
+it). ports_repo defaults to pfBlockerNG/FreeBSD-ports; a blank ports_ref falls back to
+pfblockerng/use-github (which does NOT yet carry the plist line) -> the page-file legs
+would fail, so ports_ref is REQUIRED for this `repo` run until the plist line lands on
+use-github. (smoke.yml/ui-tests.yml ports_ref plumbing was added in Phase 4 — RESULTS/04 C.)
+
+CAPTURED RUN ID: <fill on first green dispatch — not run by this off-box agent>
+
+
+DOCS UPDATED
+------------
+README.md:
+  * New "Usage -> Software tab — version + update notice for self-hosted builds":
+    documents the tab (channel + installed-vs-latest + last-checked), the three buttons
+    (Check now / Update now same-channel / Bootstrap repo), the PROVENANCE GATE (present
+    only on an our-repo build; entirely absent on a Netgate-ports install), the daily
+    de-duped notice (bell + configured remote channels, once per new version), and the
+    pfb_software_notify knob with the channel-correct default table (stable/devel OFF,
+    nightly ON) + override.
+  * Option-2 transition note: the stale "GUI won't show an update badge" line now points
+    at the Software tab (the stock badge stays Netgate-bound; ours tracks our builds).
+docs/misc/architecture-notes.md: left unchanged — it scopes DNSBL/ABP + UI-tier
+  internals, not the ADR-17/18/19 distribution/awareness surface (which lives in README
+  for users + each ADR for design); adding an unrelated section there was off-topic.
+ADR.md §7: DoD status/evidence filled (Phase-1 GO, Phase-2 pure core, Phase-4 negative
+  ui_render GREEN, Phase-5 positive `repo` journey), the dispatch command, docs, and the
+  CLAUDE.md "automated acceptance" framing (manual checklist retained as out-of-CI, not a
+  blocker).
+
+
+OFF-BOX GATE RESULTS (this agent, in the worktree)
+--------------------------------------------------
+  ruff check .                                            -> All checks passed!
+  ruff format --check .                                   -> 99 files already formatted
+  python -m pytest -q                                     -> 1575 passed (UNCHANGED)
+  pytest tests/smoke -m repo --collect-only (addopts="")  -> both new cases collected
+  pytest tests/smoke -m repo --setup-plan   (addopts="")  -> repo_vm resolves for both
+  vendor/bin/phpunit                                      -> OK (487 tests, 933 assertions)
+  npx markdownlint-cli2 README.md ADR.md                  -> 0 error(s)
+  scripts/check_url_encoding.py                           -> exit 0 (no violations)
+
+
+DoD STATE / GO
+--------------
+Automated coverage is complete and validating (not coverage theater): PHPUnit branch
+coverage of the pure core + the de-dupe machine; the ui_render NEGATIVE gate (page/tab
+hidden on a non-our build); and this `repo` POSITIVE journey (provenance OPEN + cache +
+de-duped channel-correct notice + same-channel Update, all before/after by value). Under
+the CLAUDE.md "ADR acceptance — automated tests, not a manual maintainer sign-off" rule,
+ADR-19 is READY to move Proposed -> Accepted once the `repo` fan-out leg is GREEN on CI
+(dispatch above; capture the run id here). The §7 manual checklist (real remote-channel
+delivery, a live channel switch, a live nightly repo) is recorded as out-of-CI
+confirmation, NOT an acceptance blocker.
+
+REMAINING (out of CI / follow-on, all pre-decided/deferred in the ADR):
+  * Real nightly install once ADR-18's nightly repo is live (upgrade case 2's $io
+    simulation to a true install).
+  * Cross-channel SWITCHING (explicitly deferred, §2; the selector is read-only).
+  * Capture the green `repo`-fanout run id into this file after the first dispatch.
+================================================================================

--- a/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_19_Update_Channel_Panel/RESULTS/05_Results.txt
@@ -107,6 +107,53 @@ use-github. (smoke.yml/ui-tests.yml ports_ref plumbing was added in Phase 4 — 
 CAPTURED RUN ID: <fill on first green dispatch — not run by this off-box agent>
 
 
+FIRST LIVE `repo` RUN — FAILURE + FIX (root cause B: production defect)
+----------------------------------------------------------------------
+First live dispatch: 1 failed / 20 passed. FAILED
+test_software_positive_journey_on_our_repo_install:
+  "pfb_software_provenance_ok() is FALSE on an our-repo install — the page/tab would
+   be wrongly HIDDEN"  (assert False is True)
+The sibling test_software_notify_default_is_channel_correct PASSED (it injects
+installed_repo via the $io seam, so it never shells to pkg for %R).
+
+ROOT CAUSE = B (real ADR-19 production bug in src/, not a test-setup bug):
+  pfblockerng.inc hardcoded  define('PFB_PKG_BIN', '/usr/sbin/pkg')  — the FreeBSD
+  base pkg(7) BOOTSTRAP STUB. The package is installed by the pfSense port libpkg at
+  /usr/local/sbin/pkg, which records the repository-origin annotation read back as
+  '%R'. The /usr/sbin/pkg stub does NOT report '%R' the same way (it returned empty /
+  not 'pfblockerng'), so on a genuine our-repo install:
+    pfb_pkg_installed_repo(PKG_NAME) -> ''  (via the stub)
+    pfb_software_is_our_build('')    -> FALSE
+    pfb_software_provenance_ok()     -> FALSE  => the Software page + tab + priv +
+                                                  cron notice are ALL wrongly hidden
+                                                  on real self-hosted-repo installs.
+  Why the test's own preconditions passed while the gate failed: the precondition read
+  %R via BARE `pkg` (pfSense PATH -> /usr/local/sbin/pkg, the port libpkg) = correct
+  'pfblockerng'; and %n/%v are INTRINSIC pkg fields the stub resolves fine. Only %R
+  (the repo-origin annotation) diverges between the two binaries — exactly the field
+  the provenance chain keys on. Our own scripts/add-repo.sh + build-repo.sh already use
+  /usr/local/sbin/pkg as the canonical binary; pfblockerng.inc was the outlier.
+
+FIX:
+  src/usr/local/pkg/pfblockerng/pfblockerng.inc:
+    PFB_PKG_BIN '/usr/sbin/pkg' -> '/usr/local/sbin/pkg' (the port libpkg pfSense and
+    our repo scripts shell to), + corrected the define's comment.
+  tests/smoke/test_software_update.py: added installed_repo_on_box() (evaluates the
+    SHIPPED pfb_pkg_installed_repo() live) and a THIRD precondition asserting the
+    helper's own %R equals the ground-truth bare-pkg %R — so a future binary-path
+    regression fails at the precondition with the raw values echoed (self-diagnosing),
+    not at the opaque final gate. The positive-journey assertion now echoes both the
+    shipped %R and the ground-truth %R.
+  No PHPUnit case added: the pfb_pkg_*() helpers shell to real pkg against a real pkg
+  DB (no off-appliance %R to read) — the live `repo` precondition IS their correct
+  guard; a mocked-exec unit test would be coverage theater.
+
+RE-RUN OFF-BOX GATES (this fix): ruff check / ruff format --check clean;
+  python -m pytest -q -> 1575 passed (unchanged); pytest tests/smoke -m repo
+  --collect-only / --setup-plan -> both cases collected, repo_vm resolves; php -l clean;
+  vendor/bin/phpunit -> OK (487 tests, 933 assertions); phpstan -> No errors; phpcs clean.
+
+
 DOCS UPDATED
 ------------
 README.md:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -76,6 +76,14 @@ on:
         description: "Live nightly Pages base URL for test_install_from_live_nightly_url (e.g. https://pfblockerng.github.io/pkg/nightly). Blank -> SKIP."
         required: false
         default: ""
+      ports_repo:
+        description: "FreeBSD-ports repo carrying the port + Mk framework (blank = build-pkg-linux default pfBlockerNG/FreeBSD-ports). Point a pre-merge run at a ports branch carrying a new plist entry."
+        required: false
+        default: ""
+      ports_ref:
+        description: "FreeBSD-ports branch (blank = build-pkg-linux default pfblockerng/use-github)."
+        required: false
+        default: ""
   workflow_call:
     inputs:
       image_ref:
@@ -123,6 +131,16 @@ on:
         required: false
         type: string
         default: ""
+      ports_repo:
+        description: "FreeBSD-ports repo carrying the port + Mk framework (blank = build-pkg-linux default)."
+        required: false
+        type: string
+        default: ""
+      ports_ref:
+        description: "FreeBSD-ports branch (blank = build-pkg-linux default)."
+        required: false
+        type: string
+        default: ""
   # Nightly gated run — enable once the wall-time is confirmed within budget.
   # schedule:
   #   - cron: "0 5 * * *"
@@ -155,6 +173,11 @@ jobs:
       # so a shared name would collide / cross-feed. Keying on image_name keeps each
       # leg's artifact distinct (and the download below follows build-pkg.outputs.artifact).
       artifact_name: pfBlockerNG-pkg-${{ inputs.image_name }}
+      # Optional Option-A validation: point the .pkg build at a FreeBSD-ports branch
+      # carrying a new plist entry. Blank -> build-pkg-linux's own defaults
+      # (pfBlockerNG/FreeBSD-ports @ pfblockerng/use-github), so a normal run is unchanged.
+      ports_repo: ${{ inputs.ports_repo || 'pfBlockerNG/FreeBSD-ports' }}
+      ports_ref: ${{ inputs.ports_ref || 'pfblockerng/use-github' }}
 
   smoke:
     name: pytest -m smoke (live pfSense VM)

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -78,6 +78,16 @@ on:
         required: false
         type: string
         default: "all"
+      ports_repo:
+        description: "FreeBSD-ports repo carrying the port + Mk framework (blank = build-pkg-linux default)."
+        required: false
+        type: string
+        default: ""
+      ports_ref:
+        description: "FreeBSD-ports branch (blank = build-pkg-linux default)."
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       image_ref:
@@ -98,6 +108,14 @@ on:
           - functional
           - browser
           - all
+      ports_repo:
+        description: "FreeBSD-ports repo carrying the port + Mk framework (blank = build-pkg-linux default). Point a pre-merge run at a ports branch carrying a new plist entry."
+        required: false
+        default: ""
+      ports_ref:
+        description: "FreeBSD-ports branch (blank = build-pkg-linux default pfblockerng/use-github)."
+        required: false
+        default: ""
   # Daily Tier-B run (functional + browser). Non-PR-blocking by construction.
   # The `prepare` job guards it to SKIP when there were no commits in the last
   # day (mirrors a smoke-style nightly guard) so an idle repo does not boot a VM.
@@ -138,6 +156,11 @@ jobs:
       # Per-version artifact name so the CE + Plus builds in one run don't collide;
       # the ui leg downloads pfBlockerNG-pkg-<its version>.
       artifact_name: pfBlockerNG-pkg-${{ matrix.version }}
+      # Optional Option-A validation: point the .pkg build at a FreeBSD-ports branch
+      # carrying a new plist entry. Blank -> build-pkg-linux's own defaults, so a
+      # normal run is byte-identical.
+      ports_repo: ${{ inputs.ports_repo || 'pfBlockerNG/FreeBSD-ports' }}
+      ports_ref: ${{ inputs.ports_ref || 'pfblockerng/use-github' }}
 
   # Compute the (tier × version) matrix and the nightly no-commit guard. Emits a
   # JSON `include` list so each leg is a distinct, independently-re-runnable job.

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ pfblockerng: {
 > refresh the conf to the Worker URL.
 > The legacy `pfblockerng.github.io/pkg/${ABI}/` path continues to serve CE packages
 > during the transition window.
-> Installs and updates work via the **Install** button or `pkg upgrade`,
-> but pfSense's GUI won't show an "update available" badge for our builds.
+> Installs and updates work via the **Install** button or `pkg upgrade`. pfSense's stock
+> "update available" badge stays Netgate-bound and won't track our builds, but
+> pfBlockerNG's own **Software** tab does (see [Usage](#software-tab--version--update-notice-for-self-hosted-builds)).
 
 #### Nightly channel (bleeding edge)
 
@@ -224,6 +225,43 @@ it as a `post` hook:
 The full trust model, the complete HAProxy frontend ACL setup, and the URL-encoding
 rules are in [ADR-12](.ADRs/ADR_12_Update_Hooks/ADR.md) and
 [CONTRIBUTING.md](CONTRIBUTING.md#update-hooks-prepost-update-scripts-adr-12).
+
+### Software tab — version + update notice for self-hosted builds
+
+When pfBlockerNG was installed from **this fork's self-hosted repository** (Option 2
+above), a **Software** tab appears on every pfBlockerNG page
+([ADR-19](.ADRs/ADR_19_Update_Channel_Panel/ADR.md)). It is the substitute for the stock
+GUI's "update available" badge, which only ever tracks the Netgate catalog and cannot see
+our builds. The tab shows your current **channel** (stable / devel / nightly) and
+**installed version** against **our repository's latest**, plus the last-checked time, and
+offers three buttons:
+
+- **Check now** — refresh the comparison from our repo (reads `pkg … -r <ourrepo>`, never
+  the Netgate repo).
+- **Update now** — a **same-channel** `pkg upgrade` of the installed package, streamed live
+  (it never switches channels).
+- **Bootstrap repo** — (re)write the repo conf for your current channel, the in-GUI
+  equivalent of `add-repo.sh`.
+
+> The Software tab, the page, and the update notice are present **only on a build installed
+> from one of our repos** (`pfblockerng` / `pfblockerng-nightly`). On a stock
+> **Netgate-ports** install they are **entirely absent** — Netgate's own repo-bound badge
+> already serves those users, so ours would be redundant.
+
+A daily background check (riding the existing pfBlockerNG cron) compares installed vs our
+latest and raises a **de-duped notification** when a newer build exists — the pfSense bell
+plus whatever remote channels you have configured (SMTP / Telegram / Pushover / Slack). It
+fires **once per new version**, not once per day. Whether it notifies is governed by one
+knob on the Software tab, **`pfb_software_notify`** (Default / On / Off):
+
+| Channel | Default (knob unset) |
+| --- | --- |
+| stable / devel | **Off** — quiet; check the tab when you choose |
+| nightly | **On** — you opted into the tip, so you are told when it moves |
+
+Set the knob to **On** or **Off** to override the per-channel default either way.
+Cross-channel **switching** from the GUI is not offered (the selector is read-only); switch
+channels with `add-repo.sh` + `pkg install` as in Option 2 above.
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,13 @@ ignore = [
     "E402",  # module-level import not at top of file (intentional try/except guards)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# Cross-module pytest fixture re-export: ``test_software_update.py`` imports the ``repo_vm``
+# fixture from ``test_repo_install`` so its cases can request it (pytest resolves fixtures
+# per-module). Each case param then "redefines" the imported name from ruff's view — the
+# standard re-export idiom, not real shadowing. F811 is suppressed only for this file.
+"tests/smoke/test_software_update.py" = ["F811"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["pfb_unbound"]
 

--- a/src/etc/inc/priv/pfblockerng.priv.inc
+++ b/src/etc/inc/priv/pfblockerng.priv.inc
@@ -30,6 +30,7 @@ $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_ge
 $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_ip.php*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_dnsbl.php*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_update.php";
+$priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_software.php";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_hooks.php";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_alerts.php*";
 $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/pfblockerng_feeds.php";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2130,11 +2130,14 @@ function pfb_pkg_latest(string $pkgname, string $reponame): string {
 	}
 	$bin = escapeshellarg(PFB_PKG_BIN);
 	$repo = escapeshellarg($reponame);
+	// Bound both networked pkg calls with timeout(1) (same idiom as the hook runner) so a
+	// hung mirror can never stall the cron pass or the page's forced "Check now".
+	$tmo = '/usr/bin/timeout -s TERM -k 5 60 ';
 	// Best-effort catalog refresh of our repo only; ignore failures (stale DB still reads).
-	exec("{$bin} update -r {$repo} 2>/dev/null");
+	exec("{$tmo}{$bin} update -r {$repo} 2>/dev/null");
 	$out = array();
 	$ret = -1;
-	exec("{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
+	exec("{$tmo}{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
 	return ($ret === 0 && isset($out[0])) ? trim($out[0]) : '';
 }
 
@@ -2170,8 +2173,19 @@ function pfb_software_read_cache(): array {
  */
 function pfb_software_write_cache(array $cache): void {
 	$json = json_encode($cache, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-	if ($json !== FALSE) {
-		@file_put_contents(pfb_software_cache_file(), $json . "\n", LOCK_EX);
+	if ($json === FALSE) {
+		return;
+	}
+	// Stage to a temp file then rename() into place: a concurrent reader (which takes no
+	// shared lock) then sees either the old or the new complete file, never a truncated one
+	// that would decode to [] and drop last_notified (re-emitting a notice).
+	$file = pfb_software_cache_file();
+	$tmp = @tempnam(dirname($file), '.pfbsw_');
+	if ($tmp === FALSE) {
+		return;
+	}
+	if (@file_put_contents($tmp, $json . "\n", LOCK_EX) === FALSE || !@rename($tmp, $file)) {
+		@unlink($tmp);
 	}
 }
 
@@ -2226,18 +2240,25 @@ function pfb_software_update_check(bool $force = false, ?array $io = null): arra
 	} else {
 		$latest = pfb_pkg_latest($pkgname, (string) $repo);
 	}
-	if ($latest === '') {
+	// Only reuse cached latest/last_notified when the cache belongs to the SAME installed
+	// package — after a channel switch (stable<->devel<->nightly) a stale value must not
+	// drive a wrong notice or suppress the first valid one for the new package.
+	$cache_matches_pkg = (($cache['pkgname'] ?? '') === $pkgname);
+	if ($latest === '' && $cache_matches_pkg) {
 		$latest = (string) ($cache['latest'] ?? '');
 	}
 
-	$last_notified = (string) ($cache['last_notified'] ?? '');
+	$last_notified = $cache_matches_pkg ? (string) ($cache['last_notified'] ?? '') : '';
 	$knob = (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_software_notify', 'default');
 
-	// 4. Refresh the cache.
-	$cache['channel']      = $channel;
-	$cache['installed']    = $installed;
-	$cache['latest']       = $latest;
-	$cache['last_checked'] = time();
+	// 4. Refresh the cache. last_notified is written from the scoped value so a cache left
+	// by a different package (channel switch) is reset rather than carried forward.
+	$cache['pkgname']       = $pkgname;
+	$cache['channel']       = $channel;
+	$cache['installed']     = $installed;
+	$cache['latest']        = $latest;
+	$cache['last_notified'] = $last_notified;
+	$cache['last_checked']  = time();
 
 	if (pfb_should_notify($installed, $latest, $last_notified, $knob, $channel)) {
 		file_notice('pfBlockerNG', "pfBlockerNG {$latest} available ({$channel})", 'pfBlockerNG', '/pfblockerng/pfblockerng_software.php', 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1922,6 +1922,128 @@ function pfb_wizard_dnsvip_settings(bool $auto, $vip4, $vip6): array {
 }
 
 /*
+ * ADR-19 software-update decision core (pure; pinned by tests/php/SoftwareUpdateDecisionTest.php).
+ *
+ * These are the branchy "do we have a newer build, and should we notify about it"
+ * deciders behind the Software tab + the cron new-version notice. They take strings
+ * (installed/latest version, the installed package name + the repo it came from, the
+ * notify knob) and return decisions ONLY — no GUI, no cron, no `pkg` IO/file_notice
+ * (the thin pfb_pkg_*() shellout wrapper + the cache/notice wiring live in later
+ * phases). Keeping the risky logic pure lets the fast PHPUnit tier prove every branch
+ * off-appliance.
+ */
+
+/*
+ * Channel a build is on, from its installed package NAME:
+ *   pfSense-pkg-pfBlockerNG         -> 'stable'
+ *   pfSense-pkg-pfBlockerNG-devel   -> 'devel'
+ *   pfSense-pkg-pfBlockerNG-NIGHTLY -> 'nightly' (ADR-18)
+ * Anything unrecognised/empty -> NULL. The installed name is authoritative for "what
+ * channel am I on" (ADR-19 §2 channel detection). Suffix match is case-insensitive so
+ * the NIGHTLY/devel spellings are tolerant.
+ */
+function pfb_channel_from_pkgname(?string $name): ?string {
+	if (!is_string($name) || $name === '') {
+		return null;
+	}
+	$lname = strtolower($name);
+	if (!str_starts_with($lname, 'pfsense-pkg-pfblockerng')) {
+		return null;
+	}
+	$suffix = substr($lname, strlen('pfsense-pkg-pfblockerng'));
+	switch ($suffix) {
+		case '':
+			return 'stable';
+		case '-devel':
+			return 'devel';
+		case '-nightly':
+			return 'nightly';
+		default:
+			return null;
+	}
+}
+
+/*
+ * The pkg repo "read latest" maps to, for a given channel (2026-06-14 + 2026-06-15
+ * amendments): stable AND devel share ONE repo 'pfblockerng' (the channel selects the
+ * package, not a per-channel repo); 'nightly' is the sole separately-channelled build,
+ * repo 'pfblockerng-nightly'. An unrecognised channel -> NULL (no repo to read from).
+ */
+function pfb_pkg_repo_name_for_channel(?string $channel): ?string {
+	switch ($channel) {
+		case 'stable':
+		case 'devel':
+			return 'pfblockerng';
+		case 'nightly':
+			return 'pfblockerng-nightly';
+		default:
+			return null;
+	}
+}
+
+/*
+ * Provenance gate (2026-06-15 amendment): TRUE only when the build was installed FROM
+ * one of OUR repos — 'pfblockerng' (stable+devel) or 'pfblockerng-nightly'. The repo is
+ * read from `pkg query '%R' <pkgname>`. A Netgate-installed add-on (repo 'pfSense'),
+ * an empty/'unknown' origin, or anything else -> FALSE: the Software tab, the page, the
+ * priv match[] line, AND the cron notice all gate on this so a stock build shows none of
+ * them.
+ */
+function pfb_software_is_our_build(?string $installed_repo): bool {
+	return in_array($installed_repo, array('pfblockerng', 'pfblockerng-nightly'), true);
+}
+
+/*
+ * TRUE when $latest is strictly newer than $installed, via pfSense pkg_version_compare()
+ * (never a string compare — it returns '<' | '=' | '>'). Empty/invalid inputs -> FALSE
+ * (no update): a missing installed or latest version is never "an update is available".
+ * Nightly's dated versions are only ever compared nightly-to-nightly (ADR-18 §1.5).
+ */
+function pfb_update_available(?string $installed, ?string $latest): bool {
+	if (!is_string($installed) || $installed === '' || !is_string($latest) || $latest === '') {
+		return false;
+	}
+	return pkg_version_compare($installed, $latest) === '<';
+}
+
+/*
+ * The channel-aware default for the notify knob when it is unset/'default': nightly
+ * defaults ON (trackers opted into the tip), stable/devel (and any other) default OFF
+ * (quiet for release users). Overridden by an explicit 'on'/'off' in pfb_should_notify().
+ */
+function pfb_notify_default_for_channel(?string $channel): bool {
+	return $channel === 'nightly';
+}
+
+/*
+ * The notify state machine: TRUE iff a `file_notice` should fire THIS tick.
+ *
+ * Resolve effective-notify from the knob — 'on' => true, 'off' => false, anything else
+ * ('default'/unset) => pfb_notify_default_for_channel($channel) — then notify ONLY when
+ * effective-notify AND an update is available (latest > installed) AND we have not
+ * already notified for this exact latest ($latest !== $last_notified). The last clause
+ * is the per-version de-dupe (ADR-19 §2 "persist last-notified"): a daily cron at the
+ * same latest does NOT renotify; a newer latest does.
+ */
+function pfb_should_notify(?string $installed, ?string $latest, ?string $last_notified, ?string $knob, ?string $channel): bool {
+	if ($knob === 'on') {
+		$effective = true;
+	} elseif ($knob === 'off') {
+		$effective = false;
+	} else {
+		$effective = pfb_notify_default_for_channel($channel);
+	}
+
+	if (!$effective) {
+		return false;
+	}
+	if (!pfb_update_available($installed, $latest)) {
+		return false;
+	}
+	return $latest !== $last_notified;
+}
+
+/*
  * Return the enabled hook entries matching $when ('pre'|'post'), in list order.
  *
  * Pure helper: takes the pfBlockerNG config array (config/0) so it can be unit

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2242,6 +2242,35 @@ function pfb_software_update_check(bool $force = false, ?array $io = null): arra
 }
 
 /*
+ * ADR-19 Phase 4 — provenance gate for the shipped GUI surfaces.
+ *
+ * Live wrapper over the pure pfb_software_is_our_build() (ADR-19 2026-06-15
+ * amendment): reads the installed package's provenance from `pkg query '%R'`
+ * and returns true ONLY when pfBlockerNG was installed from one of OUR repos
+ * (`pfblockerng` / `pfblockerng-nightly`). A Netgate-ports install (repo
+ * 'pfSense'/unknown/'') returns false.
+ *
+ * The Software tab append, the pfblockerng_software.php top-of-file guard, and
+ * the priv match line all gate on this single predicate so a Netgate-installed
+ * add-on shows no Software page anywhere.
+ */
+function pfb_software_provenance_ok(): bool {
+	return pfb_software_is_our_build(pfb_pkg_installed_repo(pfb_pkg_installed_name()));
+}
+
+/*
+ * Append the "Software" tab to a page's $tab_array — ONLY on an our-repo build
+ * (pfb_software_provenance_ok()). Shared by every pfBlockerNG page so the tab is
+ * consistently present (our build) or absent (Netgate build) across the GUI.
+ * Call immediately before display_top_tabs(); $active marks it the current tab.
+ */
+function pfb_software_add_tab(array &$tab_array, bool $active = false): void {
+	if (pfb_software_provenance_ok()) {
+		$tab_array[] = array(gettext('Software'), $active, '/pfblockerng/pfblockerng_software.php');
+	}
+}
+
+/*
  * Return the enabled hook entries matching $when ('pre'|'post'), in list order.
  *
  * Pure helper: takes the pfBlockerNG config array (config/0) so it can be unit

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2049,9 +2049,13 @@ function pfb_should_notify(?string $installed, ?string $latest, ?string $last_no
  * The pfb_pkg_*() functions below are the ONLY new code that shells to `pkg`; isolating
  * the shellout in thin wrappers keeps pfb_software_update_check() unit-testable (the
  * tests inject the installed/latest/installed-repo via its $io override rather than run
- * `pkg`). The base `pkg` binary lives at /usr/sbin/pkg on every supported target.
+ * `pkg`). The pkg(8) port binary (libpkg) lives at /usr/local/sbin/pkg on every supported
+ * target — this is the binary pfSense itself and our add-repo.sh/build-repo.sh shell to.
+ * The base /usr/sbin/pkg bootstrap stub does NOT report the repository origin ('%R') the
+ * same way, so the provenance gate read FALSE on a genuine our-repo install when it was
+ * used; the port binary returns the recorded repo name ('pfblockerng').
  */
-define('PFB_PKG_BIN', '/usr/sbin/pkg');
+define('PFB_PKG_BIN', '/usr/local/sbin/pkg');
 
 /*
  * The installed pfBlockerNG package NAME (e.g. 'pfSense-pkg-pfBlockerNG-devel'), read
@@ -2061,7 +2065,10 @@ define('PFB_PKG_BIN', '/usr/sbin/pkg');
 function pfb_pkg_installed_name(): string {
 	$out = array();
 	$ret = -1;
-	exec(escapeshellarg(PFB_PKG_BIN) . " query '%n' " . escapeshellarg('pfSense-pkg-pfBlockerNG*') . ' 2>/dev/null', $out, $ret);
+	// -g: match the trailing '*' as a glob. pkg query treats the pattern as an EXACT
+	// pkg-name without it, so 'pfSense-pkg-pfBlockerNG*' would match nothing and the
+	// provenance gate would wrongly read the package as not-our-build on every install.
+	exec(escapeshellarg(PFB_PKG_BIN) . " query -g '%n' " . escapeshellarg('pfSense-pkg-pfBlockerNG*') . ' 2>/dev/null', $out, $ret);
 	if ($ret !== 0) {
 		return '';
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2044,6 +2044,204 @@ function pfb_should_notify(?string $installed, ?string $latest, ?string $last_no
 }
 
 /*
+ * ADR-19 Phase 3 — pkg IO wrapper + cron-driven update check (consumes the pure core).
+ *
+ * The pfb_pkg_*() functions below are the ONLY new code that shells to `pkg`; isolating
+ * the shellout in thin wrappers keeps pfb_software_update_check() unit-testable (the
+ * tests inject the installed/latest/installed-repo via its $io override rather than run
+ * `pkg`). The base `pkg` binary lives at /usr/sbin/pkg on every supported target.
+ */
+define('PFB_PKG_BIN', '/usr/sbin/pkg');
+
+/*
+ * The installed pfBlockerNG package NAME (e.g. 'pfSense-pkg-pfBlockerNG-devel'), read
+ * from `pkg query '%n'` filtered to our prefix; '' when not installed via pkg or the
+ * query fails. Feeds pfb_channel_from_pkgname().
+ */
+function pfb_pkg_installed_name(): string {
+	$out = array();
+	$ret = -1;
+	exec(escapeshellarg(PFB_PKG_BIN) . " query '%n' " . escapeshellarg('pfSense-pkg-pfBlockerNG*') . ' 2>/dev/null', $out, $ret);
+	if ($ret !== 0) {
+		return '';
+	}
+	foreach ($out as $line) {
+		$line = trim($line);
+		if (pfb_channel_from_pkgname($line) !== null) {
+			return $line;
+		}
+	}
+	return '';
+}
+
+/*
+ * The installed version of $pkgname via `pkg query '%v'`; '' when absent/failed.
+ */
+function pfb_pkg_installed_version(string $pkgname): string {
+	if ($pkgname === '') {
+		return '';
+	}
+	$out = array();
+	$ret = -1;
+	exec(escapeshellarg(PFB_PKG_BIN) . " query '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
+	return ($ret === 0 && isset($out[0])) ? trim($out[0]) : '';
+}
+
+/*
+ * The repo $pkgname was installed FROM via `pkg query '%R'` (the provenance signal the
+ * 2026-06-15 gate keys on); '' when absent/failed. Fed to pfb_software_is_our_build().
+ */
+function pfb_pkg_installed_repo(string $pkgname): string {
+	if ($pkgname === '') {
+		return '';
+	}
+	$out = array();
+	$ret = -1;
+	exec(escapeshellarg(PFB_PKG_BIN) . " query '%R' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
+	return ($ret === 0 && isset($out[0])) ? trim($out[0]) : '';
+}
+
+/*
+ * OUR repo's latest version of $pkgname: `pkg update -r <repo>` (best-effort refresh of
+ * just our catalog DB) then `pkg rquery -r <repo> '%v' <pkgname>`. Reads ONLY our repo
+ * ($reponame) — never -r pfSense / get_pkg_info (ADR-19 §2 "Read latest"). Returns ''
+ * (the caller then serves cache) when:
+ *   - $pkgname/$reponame is empty;
+ *   - the pkg subsystem is locked (is_subsystem_dirty('pkg')) — never fight a base update;
+ *   - DNS is unavailable (get_dnsavailable()) — never stall on a network read;
+ *   - the rquery yields nothing (repo/conf absent).
+ */
+function pfb_pkg_latest(string $pkgname, string $reponame): string {
+	if ($pkgname === '' || $reponame === '') {
+		return '';
+	}
+	if (is_subsystem_dirty('pkg')) {
+		return '';
+	}
+	if (function_exists('get_dnsavailable') && !get_dnsavailable()) {
+		return '';
+	}
+	$bin = escapeshellarg(PFB_PKG_BIN);
+	$repo = escapeshellarg($reponame);
+	// Best-effort catalog refresh of our repo only; ignore failures (stale DB still reads).
+	exec("{$bin} update -r {$repo} 2>/dev/null");
+	$out = array();
+	$ret = -1;
+	exec("{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
+	return ($ret === 0 && isset($out[0])) ? trim($out[0]) : '';
+}
+
+/*
+ * Absolute path of the software-update cache (the page reads it; the cron writes it).
+ */
+function pfb_software_cache_file(): string {
+	global $pfb;
+	$dbdir = $pfb['dbdir'] ?? '/var/db/pfblockerng';
+	return "{$dbdir}/software_update.json";
+}
+
+/*
+ * Read the cache file as an assoc array (channel, installed, latest, last_checked,
+ * last_notified); [] when absent/unreadable/corrupt.
+ */
+function pfb_software_read_cache(): array {
+	$file = pfb_software_cache_file();
+	if (!is_file($file)) {
+		return array();
+	}
+	$raw = @file_get_contents($file);
+	if ($raw === FALSE || $raw === '') {
+		return array();
+	}
+	$data = json_decode($raw, true);
+	return is_array($data) ? $data : array();
+}
+
+/*
+ * Persist the cache atomically (encode -> write). Best-effort; a write failure is
+ * swallowed (the next tick retries) so it can never throw into the cron pass.
+ */
+function pfb_software_write_cache(array $cache): void {
+	$json = json_encode($cache, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+	if ($json !== FALSE) {
+		@file_put_contents(pfb_software_cache_file(), $json . "\n", LOCK_EX);
+	}
+}
+
+/*
+ * The cron-driven software-update check (ADR-19 §2 "Background check").
+ *
+ * Order is deliberate:
+ *   1. Resolve installed name + version + the repo it came FROM. The repo can be
+ *      injected for unit tests via $io ['installed_name','installed','installed_repo',
+ *      'latest']; absent keys fall through to the live pfb_pkg_*() shellout.
+ *   2. PROVENANCE GATE FIRST (2026-06-15 amendment): pfb_software_is_our_build() on the
+ *      installed repo. A Netgate-installed build (repo 'pfSense'/unknown/empty) is a
+ *      complete no-op — NO catalog read, NO cache write, NO file_notice — Netgate's own
+ *      badge serves those users.
+ *   3. Read our-repo latest for the channel's repo (guarded inside pfb_pkg_latest()).
+ *      An empty latest (pkg locked / no DNS / repo absent) preserves the cached latest so
+ *      the page keeps showing the last-known value rather than regressing to ''.
+ *   4. Refresh the cache (channel/installed/latest/last_checked) and, when
+ *      pfb_should_notify() says so, raise a DE-DUPED file_notice and persist
+ *      last_notified = latest (so repeated ticks at the same latest do not renotify).
+ *
+ * Best-effort throughout: it returns the cache array and never throws, so wiring it into
+ * the cron pass can never break a feed update. $force is accepted for the Phase-4 "Check
+ * now" button (there is no freshness short-circuit yet, so it is presently a no-op flag).
+ */
+function pfb_software_update_check(bool $force = false, ?array $io = null): array {
+	$io = is_array($io) ? $io : array();
+
+	$pkgname = array_key_exists('installed_name', $io)
+		? (string) $io['installed_name']
+		: pfb_pkg_installed_name();
+	$installed = array_key_exists('installed', $io)
+		? (string) $io['installed']
+		: pfb_pkg_installed_version($pkgname);
+	$installed_repo = array_key_exists('installed_repo', $io)
+		? (string) $io['installed_repo']
+		: pfb_pkg_installed_repo($pkgname);
+
+	// 2. Provenance gate FIRST — a Netgate-installed build does nothing at all.
+	if (!pfb_software_is_our_build($installed_repo)) {
+		return pfb_software_read_cache();
+	}
+
+	$channel = pfb_channel_from_pkgname($pkgname);
+	$repo    = pfb_pkg_repo_name_for_channel($channel);
+
+	$cache = pfb_software_read_cache();
+
+	// 3. Read our-repo latest; keep the cached value when the live read is unavailable.
+	if (array_key_exists('latest', $io)) {
+		$latest = (string) $io['latest'];
+	} else {
+		$latest = pfb_pkg_latest($pkgname, (string) $repo);
+	}
+	if ($latest === '') {
+		$latest = (string) ($cache['latest'] ?? '');
+	}
+
+	$last_notified = (string) ($cache['last_notified'] ?? '');
+	$knob = (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_software_notify', 'default');
+
+	// 4. Refresh the cache.
+	$cache['channel']      = $channel;
+	$cache['installed']    = $installed;
+	$cache['latest']       = $latest;
+	$cache['last_checked'] = time();
+
+	if (pfb_should_notify($installed, $latest, $last_notified, $knob, $channel)) {
+		file_notice('pfBlockerNG', "pfBlockerNG {$latest} available ({$channel})", 'pfBlockerNG', '/pfblockerng/pfblockerng_software.php', 1);
+		$cache['last_notified'] = $latest;
+	}
+
+	pfb_software_write_cache($cache);
+	return $cache;
+}
+
+/*
  * Return the enabled hook entries matching $when ('pre'|'post'), in list order.
  *
  * Pure helper: takes the pfBlockerNG config array (config/0) so it can be unit

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -735,6 +735,12 @@ function pfblockerng_sync_cron() {
 		pfb_logger("{$log}", 1);
 	}
 
+	// ADR-19: once-per-cron-tick software-update check. Best-effort + fully guarded
+	// (provenance gate, pkg-lock + DNS guards inside) — it can never throw, so it does
+	// not affect the feed cron timing/outcome. Provenance-gated: a no-op on a
+	// Netgate-installed build.
+	pfb_software_update_check();
+
 	// Call log mgmt function
 	// If Update GUI 'Manual view' is selected. Last output will be missed. So sleep for 5 secs.
 	sleep(5);

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1807,6 +1807,7 @@ $tab_array[]	= array(gettext('Reports'),		false,	"/pfblockerng/pfblockerng_alert
 $tab_array[]	= array(gettext('Feeds'),		false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),		false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),		false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $tab_array	= array();
@@ -2349,6 +2350,7 @@ $tab_array[]	= array(gettext('Reports'),	false,	"/pfblockerng/pfblockerng_alerts
 $tab_array[]	= array(gettext('Feeds'),	false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $tab_array	= array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -3234,6 +3234,7 @@ $tab_array[] = array(gettext('Reports'),	true,	"/pfblockerng/pfblockerng_alerts.
 $tab_array[] = array(gettext('Feeds'),		false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[] = array(gettext('Logs'),		false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[] = array(gettext('Sync'),		false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $tab_array   = array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -317,6 +317,7 @@ $tab_array[]	= array(gettext('Reports'),		false,	"/pfblockerng/pfblockerng_alert
 $tab_array[]	= array(gettext('Feeds'),		false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),		false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),		false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $tab_array	= array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -344,6 +344,7 @@ $tab_array[]	= array(gettext('Reports'),	false,			"/pfblockerng/pfblockerng_aler
 $tab_array[]	= array(gettext('Feeds'),	false,			'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	false,			'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	false,			'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $tab_array = array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -948,6 +948,7 @@ $tab_array[]	= array(gettext('Reports'),	false,			"/pfblockerng/pfblockerng_aler
 $tab_array[]	= array(gettext('Feeds'),	false,			'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	false,			'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	false,			'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $tab_array 	= array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -670,6 +670,7 @@ $tab_array[]	= array(gettext('Reports'),	false,	"/pfblockerng/pfblockerng_alerts
 $tab_array[]	= array(gettext('Feeds'),	false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $tab_array	= array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -617,6 +617,7 @@ $tab_array[]	= array(gettext('Reports'),	false,	"/pfblockerng/pfblockerng_alerts
 $tab_array[]	= array(gettext('Feeds'),	true,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 // Second sub-tab row: [IPv4 | IPv6 | DNSBL] -> pfblockerng_feeds.php?type=...

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -237,6 +237,7 @@ else {
 	$tab_array[]	= array(gettext('Feeds'),	false,	'/pfblockerng/pfblockerng_feeds.php');
 	$tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php');
 	$tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
+	pfb_software_add_tab($tab_array);
 	$tab_array[]	= array(gettext('Wizard'),	false,	'/wizard.php?xml=pfblockerng_wizard.xml');
 	display_top_tabs($tab_array, true);
 }

--- a/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
@@ -190,6 +190,7 @@ $tab_array[]	= array(gettext('Reports'),	false,	"/pfblockerng/pfblockerng_alerts
 $tab_array[]	= array(gettext('Feeds'),	false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $form = new Form('Save');

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -239,6 +239,7 @@ $tab_array[]	= array(gettext('Reports'),	false,	"/pfblockerng/pfblockerng_alerts
 $tab_array[]	= array(gettext('Feeds'),	false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $tab_array	= array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -365,6 +365,7 @@ $tab_array[]	= array(gettext('Reports'),	false,	"/pfblockerng/pfblockerng_alerts
 $tab_array[]	= array(gettext('Feeds'),	false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	true,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 // Create Form

--- a/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
@@ -260,6 +260,7 @@ $tab_array[]	= array(gettext('Reports'),		false,	"/pfblockerng/pfblockerng_alert
 $tab_array[]	= array(gettext('Feeds'),		false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),		false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),		false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $tab_array	= array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -1,0 +1,365 @@
+<?php
+/*
+ * pfblockerng_software.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2016-2026 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2024 BBcan177@gmail.com
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ADR-19: the "Software" page — show the installed pfBlockerNG channel/version vs
+// our-repo latest (from the cron-maintained cache), toggle the new-version notice,
+// and run same-channel Check / Update / Bootstrap actions. Disable NGINX output
+// buffering so the Update/Bootstrap live terminal streams (mirrors _update.php).
+header("X-Accel-Buffering: no");
+
+require_once('guiconfig.inc');
+require_once('globals.inc');
+require_once('pfsense-utils.inc');
+require_once('util.inc');
+require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
+
+global $pfb;
+pfb_global();
+
+// PROVENANCE GUARD — FIRST executable thing. The Software page exists ONLY on a
+// build installed from one of OUR repos (ADR-19 2026-06-15 amendment). A
+// Netgate-ports / sideloaded install (repo 'pfSense'/unknown/'') must never see
+// this page; redirect it away before any rendering or action handler runs.
+if (!pfb_software_provenance_ok()) {
+	header('Location: /index.php');
+	exit;
+}
+
+// Resolve the installed package + channel ONCE (used by display + the actions).
+$pfb_sw_pkgname	= pfb_pkg_installed_name();
+$pfb_sw_channel	= pfb_channel_from_pkgname($pfb_sw_pkgname);
+
+// The notify knob (default|on|off) — persisted to config like the other general knobs.
+$pfb_sw_notify	= (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_software_notify', 'default');
+
+$options_pfb_software_notify = array(
+	'default'	=> 'Default (per channel)',
+	'on'		=> 'On',
+	'off'		=> 'Off'
+);
+
+
+// Stream one line to the live terminal window (reuses the _update.php mechanic).
+function pfb_software_output($text) {
+	$text = htmlspecialchars(str_replace("\n", "\\n", $text), ENT_COMPAT);
+	print("\n<script type=\"text/javascript\">");
+	print("\n//<![CDATA[");
+	print("\nthis.document.forms[0].pfb_output.value += \"" . $text . "\\n\";");
+	print("\nthis.document.forms[0].pfb_output.scrollTop = this.document.forms[0].pfb_output.scrollHeight;");
+	print("\n//]]>");
+	print("\n</script>");
+	ob_flush();
+	flush();
+}
+
+
+// Post a one-line status to the terminal status window.
+function pfb_software_status($status) {
+	$status = htmlspecialchars(str_replace("\n", "\\n", $status), ENT_COMPAT);
+	print("\n<script type=\"text/javascript\">");
+	print("\n//<![CDATA[");
+	print("\nthis.document.forms[0].pfb_status.value=\"" . $status . "\";");
+	print("\n//]]>");
+	print("\n</script>");
+	ob_flush();
+	flush();
+}
+
+
+// Run a fixed command and stream its output to the terminal, line by line. The
+// command is a FIXED string (no request input is interpolated), so there is no
+// shell-injection surface — the only variable parts are pkg-derived names already
+// escapeshellarg'd by the caller.
+function pfb_software_run_stream($cmd) {
+	$fh = popen("{$cmd} 2>&1", 'r');
+	if (!is_resource($fh)) {
+		pfb_software_output(gettext('Failed to start the task.'));
+		return;
+	}
+	while (($line = fgets($fh)) !== false) {
+		pfb_software_output(rtrim($line, "\r\n"));
+	}
+	pclose($fh);
+}
+
+
+$pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Software'));
+$pglinks = array('', '/pfblockerng/pfblockerng_general.php', '@self');
+
+// Determine which (POST-guarded) action was requested. Destructive actions
+// (Update/Bootstrap) and the cache-refreshing Check run on POST only — never on a
+// GET (so the ui_render gate's GET cannot trigger pkg).
+$pfb_sw_action = '';
+if ($_POST && !empty($_POST['pfb_sw_action'])) {
+	$pfb_sw_action = (string) $_POST['pfb_sw_action'];
+}
+
+// "Save" the notify knob (standard pfSense CSRF POST).
+if ($_POST && isset($_POST['save'])) {
+	$notify_post = (string) ($_POST['pfb_software_notify'] ?? 'default');
+	if (!array_key_exists($notify_post, $options_pfb_software_notify)) {
+		$notify_post = 'default';
+	}
+	config_set_path('installedpackages/pfblockerng/config/0/pfb_software_notify', $notify_post);
+	write_config('[pfBlockerNG] save Software notify setting');
+	header('Location: /pfblockerng/pfblockerng_software.php');
+	exit;
+}
+
+// "Check now" — force a cache refresh from our repo, then redisplay.
+if ($pfb_sw_action === 'check') {
+	pfb_software_update_check(true);
+	header('Location: /pfblockerng/pfblockerng_software.php');
+	exit;
+}
+
+include_once('head.inc');
+
+// Tab bar (the Software tab is the active one here; gated like every page).
+$get_req = pfb_alerts_default_page();
+
+$tab_array	= array();
+$tab_array[]	= array(gettext('General'),	false,	'/pfblockerng/pfblockerng_general.php');
+$tab_array[]	= array(gettext('IP'),		false,	'/pfblockerng/pfblockerng_ip.php');
+$tab_array[]	= array(gettext('DNSBL'),	false,	'/pfblockerng/pfblockerng_dnsbl.php');
+$tab_array[]	= array(gettext('Update'),	false,	'/pfblockerng/pfblockerng_update.php');
+$tab_array[]	= array(gettext('Update Hooks'),	false,	'/pfblockerng/pfblockerng_hooks.php');
+$tab_array[]	= array(gettext('Reports'),	false,	"/pfblockerng/pfblockerng_alerts.php{$get_req}");
+$tab_array[]	= array(gettext('Feeds'),	false,	'/pfblockerng/pfblockerng_feeds.php');
+$tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php');
+$tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array, true);
+display_top_tabs($tab_array, true);
+
+// Read the cron-maintained cache for the display state. Empty/unknown renders a
+// clean "not checked yet" — never a warning (the page must pass ui_render on the
+// first GET, before any check has run).
+$cache		= pfb_software_read_cache();
+$disp_channel	= !empty($cache['channel']) ? $cache['channel'] : ($pfb_sw_channel ?: gettext('unknown'));
+$disp_installed	= !empty($cache['installed']) ? $cache['installed'] : gettext('unknown');
+$disp_latest	= !empty($cache['latest']) ? $cache['latest'] : gettext('not checked yet');
+$disp_checked	= !empty($cache['last_checked'])
+			? date('Y-m-d H:i:s', (int) $cache['last_checked'])
+			: gettext('never');
+
+$update_available = pfb_update_available((string) ($cache['installed'] ?? ''), (string) ($cache['latest'] ?? ''));
+if ($update_available) {
+	$disp_status = '<span class="text-warning">' . gettext('Update available') . '</span>';
+} elseif (!empty($cache['latest'])) {
+	$disp_status = '<span class="text-success">' . gettext('Up to date') . '</span>';
+} else {
+	$disp_status = gettext('Not checked yet');
+}
+
+// pfb-software-panel — the page-specific render marker (ADR-14 ui_render oracle).
+$form = new Form(false);
+
+$section = new Form_Section('Software Status');
+$section->addInput(new Form_StaticText(
+	'Channel',
+	'<span id="pfb-software-panel">' . htmlspecialchars((string) $disp_channel) . '</span>'
+));
+$section->addInput(new Form_StaticText(
+	'Installed Version',
+	htmlspecialchars((string) $disp_installed)
+));
+$section->addInput(new Form_StaticText(
+	'Latest (our repo)',
+	htmlspecialchars((string) $disp_latest)
+));
+$section->addInput(new Form_StaticText(
+	'Status',
+	$disp_status
+));
+$section->addInput(new Form_StaticText(
+	'Last Checked',
+	htmlspecialchars((string) $disp_checked)
+));
+$form->add($section);
+
+$section = new Form_Section('Notification');
+$section->addInput(new Form_Select(
+	'pfb_software_notify',
+	'New-version Notice',
+	$pfb_sw_notify,
+	$options_pfb_software_notify
+))->setHelp('Default: <strong>per channel</strong> &mdash; nightly notifies, stable/devel stay quiet. '
+		. 'Raise a notification when a newer pfBlockerNG build is available on your channel.')
+  ->setAttribute('style', 'width: auto');
+
+$btn_save = new Form_Button(
+	'save',
+	'Save',
+	null,
+	'fa-solid fa-save'
+);
+$btn_save->setAttribute('value', 'save');
+$section->addInput(new Form_StaticText(
+	null,
+	$btn_save
+));
+$form->add($section);
+
+$section = new Form_Section('Actions');
+$section->addInput(new Form_StaticText(
+	null,
+	gettext('Check refreshes the version cache from your channel. Update installs the latest build on '
+		. 'your CURRENT channel (no cross-channel switch). Bootstrap repo (re)writes the pfBlockerNG '
+		. 'pkg repository so future installs/updates resolve to our build.')
+));
+
+$btn_check = new Form_Button(
+	'pfb_sw_check',
+	'Check now',
+	null,
+	'fa-solid fa-arrows-rotate'
+);
+$btn_check->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setWidth(2);
+
+$btn_update = new Form_Button(
+	'pfb_sw_update',
+	'Update now',
+	null,
+	'fa-solid fa-download'
+);
+$btn_update->removeClass('btn-primary')->addClass('btn-warning btn-xs')->setWidth(2)
+	   ->setAttribute('title', gettext('Same-channel upgrade only'));
+
+$btn_bootstrap = new Form_Button(
+	'pfb_sw_bootstrap',
+	'Bootstrap repo',
+	null,
+	'fa-solid fa-screwdriver-wrench'
+);
+$btn_bootstrap->removeClass('btn-primary')->addClass('btn-default btn-xs')->setWidth(2);
+
+$section->addInput(new Form_StaticText(
+	null,
+	$btn_check . $btn_update . $btn_bootstrap
+));
+$form->add($section);
+
+// Live terminal window (shown when an Update/Bootstrap is streaming).
+$section = new Form_Section('Output');
+$section->addInput(new Form_Textarea(
+	'pfb_status',
+	null,
+	'Standby'
+))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '1')->setAttribute('wrap', 'off')
+  ->setAttribute('style', 'background:#fafafa; width: 100%');
+$section->addInput(new Form_Textarea(
+	'pfb_output',
+	null,
+	null
+))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '20')->setAttribute('wrap', 'off')
+  ->setAttribute('style', 'background:#fafafa; width: 100%');
+$form->add($section);
+
+print($form);
+
+// Destructive actions stream into the terminal AFTER the form has rendered (so the
+// textareas exist for the JS to write into). POST-guarded only.
+if ($pfb_sw_action === 'update') {
+	if ($pfb_sw_pkgname === '') {
+		pfb_software_status(gettext('No pfBlockerNG package detected — cannot update.'));
+	} else {
+		pfb_software_status(gettext('Running same-channel update...'));
+		$bin = escapeshellarg(PFB_PKG_BIN);
+		$pkg = escapeshellarg($pfb_sw_pkgname);
+		pfb_software_run_stream("{$bin} upgrade -y {$pkg}");
+		pfb_software_status(gettext('Update task finished.'));
+	}
+} elseif ($pfb_sw_action === 'bootstrap') {
+	pfb_software_status(gettext('Bootstrapping the pfBlockerNG pkg repository...'));
+	// Reproduce add-repo.sh's effect for the current channel (the dev-only script
+	// is not shipped). nightly -> the separate nightly repo; stable/devel share the
+	// release repo (the package, not the repo, is the channel — ADR-19 amendment 2).
+	if ($pfb_sw_channel === 'nightly') {
+		$repo_name = 'pfblockerng-nightly';
+		$conf_name = 'pfblockerng-nightly.conf';
+		$url_subpath = 'nightly/';
+	} else {
+		$repo_name = 'pfblockerng';
+		$conf_name = 'pfblockerng.conf';
+		$url_subpath = '';
+	}
+	$base_url = 'https://pkg.pfblockerng.workers.dev';
+	$conf =	"# pfBlockerNG self-hosted pkg repository (ADR-17). Managed by pfBlockerNG.\n"
+		. "{$repo_name}: {\n"
+		. "  url: \"{$base_url}/{$url_subpath}\${ABI}\",\n"
+		. "  mirror_type: none,\n"
+		. "  signature_type: none,\n"
+		. "  priority: 100,\n"
+		. "  enabled: yes\n"
+		. "}\n";
+	$conf_dir = '/usr/local/etc/pkg/repos';
+	safe_mkdir($conf_dir);
+	if (@file_put_contents("{$conf_dir}/{$conf_name}", $conf, LOCK_EX) === false) {
+		pfb_software_output(gettext('Failed to write the repository conf.'));
+	} else {
+		pfb_software_output(sprintf(gettext('Wrote %s'), "{$conf_dir}/{$conf_name}"));
+		$bin = escapeshellarg(PFB_PKG_BIN);
+		$repo = escapeshellarg($repo_name);
+		pfb_software_run_stream("{$bin} update -r {$repo}");
+	}
+	pfb_software_status(gettext('Bootstrap task finished.'));
+}
+?>
+
+<script type="text/javascript">
+//<![CDATA[
+events.push(function() {
+
+	// Wire each action button to a confirm + POST. Update/Bootstrap are
+	// destructive (they run pkg / write a repo conf) so they confirm first;
+	// Check is a cache refresh and posts straight through.
+	function pfb_sw_submit(action) {
+		var f = document.forms[0];
+		var i = document.createElement('input');
+		i.type = 'hidden';
+		i.name = 'pfb_sw_action';
+		i.value = action;
+		f.appendChild(i);
+		f.submit();
+	}
+
+	$('#pfb_sw_check').click(function(e) {
+		e.preventDefault();
+		pfb_sw_submit('check');
+	});
+	$('#pfb_sw_update').click(function(e) {
+		e.preventDefault();
+		if (confirm('Run a same-channel pfBlockerNG update now?')) {
+			pfb_sw_submit('update');
+		}
+	});
+	$('#pfb_sw_bootstrap').click(function(e) {
+		e.preventDefault();
+		if (confirm('(Re)write the pfBlockerNG pkg repository configuration?')) {
+			pfb_sw_submit('bootstrap');
+		}
+	});
+});
+//]]>
+</script>
+
+<?php include('foot.inc'); ?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -172,6 +172,7 @@ $tab_array[]	= array(gettext('Reports'),	false,	"/pfblockerng/pfblockerng_alerts
 $tab_array[]	= array(gettext('Feeds'),	false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	true,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 $form = new Form('Save XMLRPC sync settings');

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -153,6 +153,7 @@ $tab_array[]	= array(gettext('Reports'),	false,	"/pfblockerng/pfblockerng_alerts
 $tab_array[]	= array(gettext('Feeds'),	false,	'/pfblockerng/pfblockerng_feeds.php');
 $tab_array[]	= array(gettext('Logs'),	false,	'/pfblockerng/pfblockerng_log.php');
 $tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
 display_top_tabs($tab_array, true);
 
 if ($pfb['enable'] == 'on') {

--- a/stubs/pfsense/system.php
+++ b/stubs/pfsense/system.php
@@ -16,6 +16,9 @@
 
 // @codingStandardsIgnoreFile
 
+/** @return bool */
+function get_dnsavailable($ipproto = "inet") {}
+
 /** @return mixed */
 function filter_antilockout_tracker() {}
 

--- a/tests/php/SoftwareUpdateCheckTest.php
+++ b/tests/php/SoftwareUpdateCheckTest.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-19 Phase 3 — the cron-driven software-update orchestrator pfb_software_update_check()
+ * + the cache helpers, with the pkg IO INJECTED (no real `pkg` off-appliance).
+ *
+ * Scenario: a cron tick reads installed-vs-our-repo-latest, writes a cache, and raises a
+ * de-duped file_notice — but ONLY on a build installed from one of OUR repos.
+ *
+ * Background: the pure decision core (Phase 2) is already pinned; here we pin the
+ * SIDE-EFFECTS — the provenance gate (no-op on a Netgate build), the pkg-lock / no-DNS
+ * short-circuits (serve cache, no network, no error), the cache contents, and the
+ * per-version de-dupe across ticks. Every branch asserts the BEFORE-state (cache present?
+ * notice fired?) and the AFTER-state so green proves the side-effect was CAUSED by the
+ * input, not pre-existing.
+ *
+ * The IO is doubled by passing $io = ['installed_name','installed','installed_repo',
+ * 'latest'] to the orchestrator (its documented unit-test seam). file_notice /
+ * is_subsystem_dirty / get_dnsavailable are doubled in pfsense_doubles.php, driven via
+ * $GLOBALS (pfb_test_file_notices / pfb_test_pkg_locked / pfb_test_dns_available).
+ */
+#[CoversFunction('pfb_software_update_check')]
+#[CoversFunction('pfb_software_cache_file')]
+#[CoversFunction('pfb_software_read_cache')]
+#[CoversFunction('pfb_software_write_cache')]
+#[CoversFunction('pfb_pkg_latest')]
+final class SoftwareUpdateCheckTest extends TestCase
+{
+	private string $dbdir = '';
+
+	protected function setUp(): void
+	{
+		// Each test gets a private temp dbdir so the cache file is isolated and the
+		// orchestrator's $pfb['dbdir'] lookup resolves there.
+		$this->dbdir = sys_get_temp_dir() . '/pfb_adr19_' . uniqid('', true);
+		mkdir($this->dbdir, 0755, true);
+		$GLOBALS['pfb']['dbdir'] = $this->dbdir;
+
+		// Reset the test-driveable doubles to their permissive defaults.
+		$GLOBALS['pfb_test_file_notices'] = [];
+		$GLOBALS['pfb_test_pkg_locked']   = false;
+		$GLOBALS['pfb_test_dns_available'] = true;
+
+		// Quiet default knob unless a test overrides it — exercise the channel-aware
+		// default rather than a forced on/off.
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$file = $this->dbdir . '/software_update.json';
+		if (is_file($file)) {
+			unlink($file);
+		}
+		if (is_dir($this->dbdir)) {
+			rmdir($this->dbdir);
+		}
+		unset(
+			$GLOBALS['pfb']['dbdir'],
+			$GLOBALS['pfb_test_file_notices'],
+			$GLOBALS['pfb_test_pkg_locked'],
+			$GLOBALS['pfb_test_dns_available'],
+			$GLOBALS['config']
+		);
+	}
+
+	private function cacheFile(): string
+	{
+		return $this->dbdir . '/software_update.json';
+	}
+
+	private function readCache(): ?array
+	{
+		$file = $this->cacheFile();
+		if (!is_file($file)) {
+			return null;
+		}
+		$data = json_decode((string) file_get_contents($file), true);
+		return is_array($data) ? $data : null;
+	}
+
+	private function setKnob(string $value): void
+	{
+		$GLOBALS['config'] = [
+			'installedpackages' => ['pfblockerng' => ['config' => [0 => ['pfb_software_notify' => $value]]]],
+		];
+	}
+
+	private function ourBuildIo(string $installed, string $latest, string $repo = 'pfblockerng', string $name = 'pfSense-pkg-pfBlockerNG-devel'): array
+	{
+		return [
+			'installed_name' => $name,
+			'installed'      => $installed,
+			'installed_repo' => $repo,
+			'latest'         => $latest,
+		];
+	}
+
+	/*
+	 * ---- Provenance gate (the 2026-06-15 amendment) — BOTH sides ----
+	 */
+
+	/**
+	 * Given a build installed from OUR repo with a newer version available,
+	 * When the check runs,
+	 * Then it writes the cache AND reaches a notify decision (a notice fires under an
+	 * ON knob). This is the "feature present" side of the gate.
+	 */
+	public function testOurBuildRunsCheckWritesCacheAndCanNotify(): void
+	{
+		// Given: no cache yet, no notice yet (before-state).
+		$this->setKnob('on');
+		$this->assertNull($this->readCache(), 'before: no cache file should exist');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice raised');
+
+		// When.
+		$cache = pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_9'));
+
+		// Then: cache written with the read values, and a notice fired (update available).
+		$onDisk = $this->readCache();
+		$this->assertNotNull($onDisk, 'after: cache file must be written for our build');
+		$this->assertSame('devel', $onDisk['channel']);
+		$this->assertSame('3.2.0_1', $onDisk['installed']);
+		$this->assertSame('3.2.0_9', $onDisk['latest']);
+		$this->assertSame('3.2.0_9', $onDisk['last_notified']);
+		$this->assertArrayHasKey('last_checked', $onDisk);
+		$this->assertSame($onDisk, $cache, 'returns the freshly written cache');
+		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'after: exactly one notice fired');
+		$this->assertStringContainsString('3.2.0_9 available (devel)', $GLOBALS['pfb_test_file_notices'][0]['notice']);
+	}
+
+	/**
+	 * Given a build installed from the Netgate ports repo ('pfSense') — or any non-our
+	 * origin — with a newer version nominally available,
+	 * When the check runs,
+	 * Then it is a COMPLETE no-op: no cache is written and no notice is raised. This is
+	 * the "feature absent on a stock build" side of the gate; it must be the FIRST thing
+	 * the check does.
+	 */
+	#[DataProvider('foreignRepoProvider')]
+	public function testNetgateBuildIsCompleteNoOp(string $repo): void
+	{
+		// Given: ON knob (would notify if the gate let it through), clean before-state.
+		$this->setKnob('on');
+		$this->assertNull($this->readCache(), 'before: no cache file');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice');
+
+		// When: an update IS nominally available, but the build is not ours.
+		$io = $this->ourBuildIo('3.2.0_1', '3.2.0_9', $repo);
+		pfb_software_update_check(false, $io);
+
+		// Then: nothing happened — no cache write, no notice.
+		$this->assertNull($this->readCache(), 'after: Netgate build must NOT write a cache');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: Netgate build raises NO notice');
+	}
+
+	public static function foreignRepoProvider(): array
+	{
+		return [
+			'Netgate ports repo' => ['pfSense'],
+			'empty/unknown'      => [''],
+			'literal unknown'    => ['unknown'],
+			'a decoy repo'       => ['netgate-decoy'],
+		];
+	}
+
+	/*
+	 * ---- pkg-lock / no-DNS short-circuit — serve cache, no network, no error ----
+	 *
+	 * These exercise the LIVE pfb_pkg_latest() path (no injected 'latest'), so the
+	 * is_subsystem_dirty('pkg') / get_dnsavailable() guards inside it are hit. Because
+	 * the guard returns '' (no live read) and there is no injected latest, the
+	 * orchestrator preserves the cached latest.
+	 */
+
+	/**
+	 * Given a pre-existing cache (an earlier tick found 3.2.0_9) and the pkg subsystem
+	 * locked,
+	 * When the check runs without an injected latest,
+	 * Then the cached latest is preserved, no notice fires (it already de-duped), and no
+	 * error is thrown.
+	 */
+	public function testPkgLockedServesCacheNoNetworkNoNotice(): void
+	{
+		// Given: seed a cache as if a prior tick already notified for 3.2.0_9.
+		$this->setKnob('on');
+		pfb_software_write_cache([
+			'channel'       => 'devel',
+			'installed'     => '3.2.0_1',
+			'latest'        => '3.2.0_9',
+			'last_checked'  => 100,
+			'last_notified' => '3.2.0_9',
+		]);
+		$before = $this->readCache();
+		$this->assertSame('3.2.0_9', $before['latest'], 'before: cache holds the prior latest');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice this run yet');
+
+		// When: pkg locked; no injected latest -> pfb_pkg_latest() short-circuits to ''.
+		$GLOBALS['pfb_test_pkg_locked'] = true;
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
+			'installed'      => '3.2.0_1',
+			'installed_repo' => 'pfblockerng',
+			// note: NO 'latest' key -> forces the guarded live read.
+		]);
+
+		// Then: cached latest preserved, last_notified intact, no NEW notice.
+		$this->assertSame('3.2.0_9', $cache['latest'], 'after: cached latest preserved when pkg locked');
+		$this->assertSame('3.2.0_9', $cache['last_notified'], 'after: de-dupe state intact');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: no notice while locked');
+	}
+
+	/**
+	 * Given the same pre-existing cache but DNS unavailable,
+	 * When the check runs without an injected latest,
+	 * Then identical behaviour to the locked case — the cache is served, no network read,
+	 * no notice.
+	 */
+	public function testNoDnsServesCacheNoNetworkNoNotice(): void
+	{
+		$this->setKnob('on');
+		pfb_software_write_cache([
+			'channel'       => 'devel',
+			'installed'     => '3.2.0_1',
+			'latest'        => '3.2.0_9',
+			'last_checked'  => 100,
+			'last_notified' => '3.2.0_9',
+		]);
+		$this->assertSame('3.2.0_9', $this->readCache()['latest'], 'before: cache holds prior latest');
+
+		$GLOBALS['pfb_test_dns_available'] = false;
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
+			'installed'      => '3.2.0_1',
+			'installed_repo' => 'pfblockerng',
+		]);
+
+		$this->assertSame('3.2.0_9', $cache['latest'], 'after: cached latest preserved when no DNS');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: no notice without DNS');
+	}
+
+	/*
+	 * ---- Knob gating — notice fires exactly when pfb_should_notify says so ----
+	 */
+
+	/**
+	 * Given an our-repo build with an update available but the notify knob OFF,
+	 * When the check runs,
+	 * Then the cache is still refreshed (the page always shows latest) but NO notice fires.
+	 * Paired with testOurBuildRunsCheckWritesCacheAndCanNotify (knob on) so the branch is real.
+	 */
+	public function testKnobOffRefreshesCacheButSuppressesNotice(): void
+	{
+		$this->setKnob('off');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice');
+
+		$cache = pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_9'));
+
+		$this->assertSame('3.2.0_9', $cache['latest'], 'after: cache refreshed to latest');
+		$this->assertSame('', (string) ($cache['last_notified'] ?? ''), 'after: last_notified NOT advanced');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: knob off suppresses the notice');
+	}
+
+	/**
+	 * Given an our-repo build already at the latest (no update),
+	 * When the check runs with the knob ON,
+	 * Then the cache is refreshed but no notice fires (nothing newer to announce).
+	 */
+	public function testNoUpdateAvailableRefreshesCacheNoNotice(): void
+	{
+		$this->setKnob('on');
+
+		$cache = pfb_software_update_check(false, $this->ourBuildIo('3.2.0_9', '3.2.0_9'));
+
+		$this->assertSame('3.2.0_9', $cache['installed']);
+		$this->assertSame('3.2.0_9', $cache['latest']);
+		$this->assertSame('', (string) ($cache['last_notified'] ?? ''), 'after: no notify when not newer');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: no notice when up to date');
+	}
+
+	/*
+	 * ---- De-dupe lifecycle across ticks (the §2 "persist last-notified" contract) ----
+	 *
+	 * GIVEN a fresh our-repo build at 3.2.0_1, knob ON, no cache;
+	 * WHEN tick 1 sees latest 3.2.0_9       -> notify ONCE, persist last_notified=3.2.0_9;
+	 * WHEN tick 2 sees the SAME 3.2.0_9     -> NO renotify (de-duped);
+	 * WHEN tick 3 sees a newer 3.2.0_10     -> notify AGAIN, persist last_notified=3.2.0_10;
+	 * WHEN tick 4 sees the SAME 3.2.0_10    -> NO renotify.
+	 * The persisted last_notified is asserted BEFORE each tick so each (no-)notify is
+	 * proven CAUSED by the version change, not coincidence.
+	 */
+	public function testNoticeDeDupesPerVersionAcrossTicks(): void
+	{
+		$this->setKnob('on');
+
+		// Tick 1: first sight of 3.2.0_9 -> one notice, last_notified advanced.
+		$this->assertNull($this->readCache(), 'before tick 1: no cache');
+		$c1 = pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_9'));
+		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'tick 1: exactly one notice');
+		$this->assertSame('3.2.0_9', $c1['last_notified']);
+
+		// Tick 2: same latest, already notified -> NO new notice.
+		$this->assertSame('3.2.0_9', $this->readCache()['last_notified'], 'before tick 2: 3.2.0_9 recorded');
+		$c2 = pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_9'));
+		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'tick 2: still one notice (de-duped)');
+		$this->assertSame('3.2.0_9', $c2['last_notified']);
+
+		// Tick 3: a newer latest -> notify AGAIN (re-assert tick-2 suppression first).
+		$this->assertSame('3.2.0_9', $this->readCache()['last_notified'], 'before tick 3: still at 3.2.0_9');
+		$c3 = pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_10'));
+		$this->assertCount(2, $GLOBALS['pfb_test_file_notices'], 'tick 3: a second notice for the newer version');
+		$this->assertSame('3.2.0_10', $c3['last_notified']);
+		$this->assertStringContainsString('3.2.0_10 available', $GLOBALS['pfb_test_file_notices'][1]['notice']);
+
+		// Tick 4: same newer latest -> NO renotify.
+		$this->assertSame('3.2.0_10', $this->readCache()['last_notified'], 'before tick 4: 3.2.0_10 recorded');
+		pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_10'));
+		$this->assertCount(2, $GLOBALS['pfb_test_file_notices'], 'tick 4: still two notices total (de-duped)');
+	}
+}

--- a/tests/php/SoftwareUpdateCheckTest.php
+++ b/tests/php/SoftwareUpdateCheckTest.php
@@ -188,9 +188,11 @@ final class SoftwareUpdateCheckTest extends TestCase
 	 */
 	public function testPkgLockedServesCacheNoNetworkNoNotice(): void
 	{
-		// Given: seed a cache as if a prior tick already notified for 3.2.0_9.
+		// Given: seed a cache as if a prior tick already notified for 3.2.0_9 (a real prior
+		// tick records the pkgname it was for, so the same-package reuse path is taken).
 		$this->setKnob('on');
 		pfb_software_write_cache([
+			'pkgname'       => 'pfSense-pkg-pfBlockerNG-devel',
 			'channel'       => 'devel',
 			'installed'     => '3.2.0_1',
 			'latest'        => '3.2.0_9',
@@ -226,6 +228,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 	{
 		$this->setKnob('on');
 		pfb_software_write_cache([
+			'pkgname'       => 'pfSense-pkg-pfBlockerNG-devel',
 			'channel'       => 'devel',
 			'installed'     => '3.2.0_1',
 			'latest'        => '3.2.0_9',
@@ -243,6 +246,45 @@ final class SoftwareUpdateCheckTest extends TestCase
 
 		$this->assertSame('3.2.0_9', $cache['latest'], 'after: cached latest preserved when no DNS');
 		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: no notice without DNS');
+	}
+
+	/**
+	 * Given a cache left by a DIFFERENT installed package (a prior nightly build) and a
+	 * live read that comes back empty (pkg locked) for the now-installed devel build,
+	 * When the check runs,
+	 * Then the stale nightly latest/last_notified are NOT reused — latest regresses to ''
+	 * and last_notified resets — so a channel switch can neither show a wrong version nor
+	 * suppress the first valid notice for the new package. Paired with the pkg-locked test
+	 * above (same-package reuse) so the pkgname-match branch is proven both ways.
+	 */
+	public function testChannelSwitchDoesNotReuseStaleCache(): void
+	{
+		// Given: a cache from a nightly build that had announced a nightly version.
+		$this->setKnob('on');
+		pfb_software_write_cache([
+			'pkgname'       => 'pfSense-pkg-pfBlockerNG-nightly',
+			'channel'       => 'nightly',
+			'installed'     => '3.2.0_1',
+			'latest'        => '3.2.0_99',
+			'last_checked'  => 100,
+			'last_notified' => '3.2.0_99',
+		]);
+		$this->assertSame('3.2.0_99', $this->readCache()['latest'], 'before: stale nightly latest present');
+
+		// When: now a DEVEL build is installed and the live read is unavailable (pkg locked).
+		$GLOBALS['pfb_test_pkg_locked'] = true;
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
+			'installed'      => '3.2.0_1',
+			'installed_repo' => 'pfblockerng',
+			// no 'latest' -> guarded live read returns '' (pkg locked).
+		]);
+
+		// Then: the stale nightly values are discarded, not carried into the devel cache.
+		$this->assertSame('devel', $cache['channel'], 'after: cache rekeyed to the devel build');
+		$this->assertSame('', (string) ($cache['latest'] ?? ''), 'after: stale nightly latest NOT reused');
+		$this->assertSame('', (string) ($cache['last_notified'] ?? ''), 'after: stale last_notified reset');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: no notice (no known latest yet)');
 	}
 
 	/*

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-19 Phase 2 — the PURE software-update decision core in pfblockerng.inc.
+ *
+ * Pins every branch of the channel/provenance/version/notify deciders behind the
+ * Software tab + the cron new-version notice: strings in, decisions out (no GUI,
+ * no cron, no pkg IO). Each toggle/mode/input-class is asserted on BOTH sides, and
+ * the de-dupe state machine carries a BDD Given/When/Then lifecycle with the
+ * before-state asserted at each tick so green proves the transition CAUSED the flip.
+ */
+#[CoversFunction('pfb_channel_from_pkgname')]
+#[CoversFunction('pfb_pkg_repo_name_for_channel')]
+#[CoversFunction('pfb_software_is_our_build')]
+#[CoversFunction('pfb_update_available')]
+#[CoversFunction('pfb_notify_default_for_channel')]
+#[CoversFunction('pfb_should_notify')]
+final class SoftwareUpdateDecisionTest extends TestCase
+{
+	/*
+	 * ---- pfb_channel_from_pkgname() — package name -> channel ----
+	 * The installed package name is authoritative for "what channel am I on". Each of
+	 * the three shipped names maps to its channel; anything else (incl. empty/null) is
+	 * an UNKNOWN channel -> null, the safe default (no feature without a known channel).
+	 */
+	public static function channelProvider(): array
+	{
+		return [
+			'stable: bare release name'   => ['pfSense-pkg-pfBlockerNG', 'stable'],
+			'devel: -devel suffix'        => ['pfSense-pkg-pfBlockerNG-devel', 'devel'],
+			'nightly: -NIGHTLY suffix'    => ['pfSense-pkg-pfBlockerNG-NIGHTLY', 'nightly'],
+			'nightly: case-insensitive'   => ['pfSense-pkg-pfBlockerNG-nightly', 'nightly'],
+			'devel: case-insensitive'     => ['PFSENSE-PKG-PFBLOCKERNG-DEVEL', 'devel'],
+			'unknown: other package'      => ['pfSense-pkg-suricata', null],
+			'unknown: foreign suffix'     => ['pfSense-pkg-pfBlockerNG-beta', null],
+			'unknown: empty string'       => ['', null],
+			'unknown: null'               => [null, null],
+		];
+	}
+
+	#[DataProvider('channelProvider')]
+	public function testChannelFromPkgname(?string $name, ?string $expected): void
+	{
+		$this->assertSame($expected, pfb_channel_from_pkgname($name));
+	}
+
+	/*
+	 * ---- pfb_pkg_repo_name_for_channel() — channel -> our repo to read latest from ----
+	 * 2026-06-14 + 2026-06-15 amendments: stable AND devel share ONE repo 'pfblockerng'
+	 * (the channel selects the package, not a per-channel repo); 'nightly' is the sole
+	 * separately-channelled build, repo 'pfblockerng-nightly'. Unknown channel -> null.
+	 */
+	public static function repoForChannelProvider(): array
+	{
+		return [
+			'stable -> shared pfblockerng'  => ['stable', 'pfblockerng'],
+			'devel -> shared pfblockerng'   => ['devel', 'pfblockerng'],
+			'nightly -> pfblockerng-nightly' => ['nightly', 'pfblockerng-nightly'],
+			'unknown channel -> null'        => ['beta', null],
+			'null channel -> null'           => [null, null],
+		];
+	}
+
+	#[DataProvider('repoForChannelProvider')]
+	public function testRepoNameForChannel(?string $channel, ?string $expected): void
+	{
+		$this->assertSame($expected, pfb_pkg_repo_name_for_channel($channel));
+	}
+
+	/*
+	 * ---- pfb_software_is_our_build() — the provenance gate (2026-06-15) ----
+	 * TRUE only for a build installed FROM one of OUR repos ('pfblockerng' /
+	 * 'pfblockerng-nightly', the `pkg query %R` origin). A Netgate-installed add-on
+	 * (repo 'pfSense'), an empty/'unknown' origin, or anything else -> FALSE. Both sides
+	 * pinned: this single predicate gates the tab, the page guard, the priv match[] line,
+	 * AND the cron notice, so a false positive would leak the whole feature onto a stock
+	 * build and a false negative would hide it from our users.
+	 */
+	public static function provenanceProvider(): array
+	{
+		return [
+			// Ours -> present.
+			'ours: pfblockerng (stable+devel)'   => ['pfblockerng', true],
+			'ours: pfblockerng-nightly'          => ['pfblockerng-nightly', true],
+			// Not ours -> absent.
+			'netgate: pfSense repo'              => ['pfSense', false],
+			'empty origin'                       => ['', false],
+			'literal unknown'                    => ['unknown', false],
+			'null origin'                        => [null, false],
+			'foreign repo'                       => ['netgate-decoy', false],
+		];
+	}
+
+	#[DataProvider('provenanceProvider')]
+	public function testSoftwareIsOurBuild(?string $installedRepo, bool $expected): void
+	{
+		$this->assertSame($expected, pfb_software_is_our_build($installedRepo));
+	}
+
+	/*
+	 * ---- pfb_update_available() — latest strictly newer than installed? ----
+	 * Via pkg_version_compare (never a string compare). Newer -> true; equal/older ->
+	 * false; an empty/missing installed or latest -> false (never "an update is
+	 * available"). Nightly's dated versions compare nightly-to-nightly.
+	 */
+	public static function availableProvider(): array
+	{
+		return [
+			'newer latest -> available'        => ['3.2.0_5', '3.2.0_6', true],
+			'newer minor -> available'         => ['3.2.0', '3.2.1', true],
+			'equal -> not available'           => ['3.2.0', '3.2.0', false],
+			'older latest -> not available'    => ['3.2.0_6', '3.2.0_5', false],
+			'nightly newer date -> available'  => ['20260101', '20260615', true],
+			'nightly same date -> not avail'   => ['20260615', '20260615', false],
+			'nightly older date -> not avail'  => ['20260615', '20260101', false],
+			'empty installed -> not available' => ['', '3.2.1', false],
+			'empty latest -> not available'    => ['3.2.0', '', false],
+			'null installed -> not available'  => [null, '3.2.1', false],
+			'null latest -> not available'     => ['3.2.0', null, false],
+		];
+	}
+
+	#[DataProvider('availableProvider')]
+	public function testUpdateAvailable(?string $installed, ?string $latest, bool $expected): void
+	{
+		$this->assertSame($expected, pfb_update_available($installed, $latest));
+	}
+
+	/*
+	 * ---- pfb_notify_default_for_channel() — channel-aware notify default ----
+	 * nightly defaults ON (trackers opted into the tip); stable/devel (and any other)
+	 * default OFF (quiet for release users). Each side asserted so green proves it is a
+	 * real per-channel branch, not an always-value path.
+	 */
+	public static function notifyDefaultProvider(): array
+	{
+		return [
+			'nightly -> ON'      => ['nightly', true],
+			'stable -> OFF'      => ['stable', false],
+			'devel -> OFF'       => ['devel', false],
+			'unknown -> OFF'     => ['beta', false],
+			'null -> OFF'        => [null, false],
+		];
+	}
+
+	#[DataProvider('notifyDefaultProvider')]
+	public function testNotifyDefaultForChannel(?string $channel, bool $expected): void
+	{
+		$this->assertSame($expected, pfb_notify_default_for_channel($channel));
+	}
+
+	/*
+	 * ---- pfb_should_notify() — the knob x channel-default x available matrix ----
+	 * Effective-notify resolves from the knob ('on' => true, 'off' => false, else the
+	 * channel default), then a notice fires ONLY when effective AND available AND not
+	 * already notified for this latest. This matrix pins the knob override on BOTH sides
+	 * AND the channel default on both sides:
+	 *   - knob 'on' notifies even on stable (default OFF) when available;
+	 *   - knob 'off' suppresses even on nightly (default ON) when available;
+	 *   - knob 'default' yields OFF on stable/devel but ON on nightly (the paired branch
+	 *     proving the default is real), and never notifies when no update is available.
+	 * Every row uses last_notified='' so the de-dupe clause is satisfied — the de-dupe
+	 * lifecycle itself is the dedicated BDD test below.
+	 */
+	public static function shouldNotifyMatrixProvider(): array
+	{
+		// [installed, latest, last_notified, knob, channel, expected]
+		return [
+			// knob 'on' overrides the OFF default -> notifies on stable when available.
+			'on + stable + available -> notify'        => ['1.0', '1.1', '', 'on', 'stable', true],
+			'on + stable + not available -> silent'    => ['1.0', '1.0', '', 'on', 'stable', false],
+			// knob 'off' overrides the ON default -> silent on nightly even when available.
+			'off + nightly + available -> silent'      => ['1.0', '1.1', '', 'off', 'nightly', false],
+			// default: OFF on stable/devel (paired) ...
+			'default + stable + available -> silent'   => ['1.0', '1.1', '', 'default', 'stable', false],
+			'default + devel + available -> silent'    => ['1.0', '1.1', '', 'default', 'devel', false],
+			// ... ON on nightly (proves the default is a real branch, not always-OFF) ...
+			'default + nightly + available -> notify'  => ['1.0', '1.1', '', 'default', 'nightly', true],
+			// ... and never when there is no update, regardless of the channel default.
+			'default + nightly + not available -> silent' => ['1.0', '1.0', '', 'default', 'nightly', false],
+			// an unset/foreign knob string resolves to the channel default too.
+			'unset knob + nightly + available -> notify'  => ['1.0', '1.1', '', '', 'nightly', true],
+			'unset knob + stable + available -> silent'   => ['1.0', '1.1', '', '', 'stable', false],
+		];
+	}
+
+	#[DataProvider('shouldNotifyMatrixProvider')]
+	public function testShouldNotifyMatrix(
+		?string $installed,
+		?string $latest,
+		?string $lastNotified,
+		?string $knob,
+		?string $channel,
+		bool $expected
+	): void {
+		$this->assertSame(
+			$expected,
+			pfb_should_notify($installed, $latest, $lastNotified, $knob, $channel)
+		);
+	}
+
+	/*
+	 * ---- pfb_should_notify() — the per-version de-dupe lifecycle (BDD) ----
+	 *
+	 * Scenario: a daily cron must notify ONCE per new version, not once per tick.
+	 *   Background: knob 'on' (effective-notify true) so only the de-dupe clause varies.
+	 *               installed stays '1.0'; the catalog's latest advances over time.
+	 *
+	 *   GIVEN nothing has been notified yet (last_notified empty) and a newer latest 1.1
+	 *    THEN the first tick notifies (the before-state: no prior notice).
+	 *   WHEN that 1.1 has been recorded as last_notified and the same tick repeats
+	 *    THEN it does NOT renotify (the before-state: already notified for 1.1).
+	 *   WHEN a yet-newer latest 1.2 arrives (last_notified still 1.1)
+	 *    THEN it notifies again (the before-state: 1.2 not yet notified).
+	 *   WHEN 1.2 is then recorded and its tick repeats
+	 *    THEN it does NOT renotify.
+	 */
+	public function testShouldNotifyDeDupeLifecycle(): void
+	{
+		$installed = '1.0';
+		$knob = 'on';
+		$channel = 'devel';
+
+		// GIVEN never-notified + a newer latest 1.1 -> first tick notifies.
+		$lastNotified = '';
+		$this->assertTrue(
+			pfb_should_notify($installed, '1.1', $lastNotified, $knob, $channel),
+			'first sighting of 1.1 must notify'
+		);
+
+		// WHEN 1.1 recorded as last_notified -> the SAME tick must not renotify.
+		$lastNotified = '1.1';
+		$this->assertFalse(
+			pfb_should_notify($installed, '1.1', $lastNotified, $knob, $channel),
+			'a repeat tick at the already-notified 1.1 must NOT renotify (de-dupe)'
+		);
+
+		// WHEN a newer latest 1.2 arrives (last_notified still 1.1) -> notify again.
+		// Before-state: re-assert the 1.1 tick is still suppressed so the flip is caused
+		// by the newer version, not by time.
+		$this->assertFalse(
+			pfb_should_notify($installed, '1.1', $lastNotified, $knob, $channel),
+			'before the newer version, 1.1 is still de-duped'
+		);
+		$this->assertTrue(
+			pfb_should_notify($installed, '1.2', $lastNotified, $knob, $channel),
+			'a newer 1.2 (not yet notified) must notify again'
+		);
+
+		// WHEN 1.2 recorded -> its repeat tick is de-duped again.
+		$lastNotified = '1.2';
+		$this->assertFalse(
+			pfb_should_notify($installed, '1.2', $lastNotified, $knob, $channel),
+			'a repeat tick at the already-notified 1.2 must NOT renotify'
+		);
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -331,3 +331,41 @@ if (!function_exists('pkg_version_compare')) {
 		return '=';
 	}
 }
+
+// --- ADR-19 Phase 3 doubles (cron software-update check) ---
+//
+// The orchestrator pfb_software_update_check() is unit-tested with the pkg IO injected
+// via its $io override (so no real `pkg` shells off-appliance). These three pfSense
+// functions it still reaches are doubled here, test-driveable via $GLOBALS:
+//   * file_notice()        -> appended to $GLOBALS['pfb_test_file_notices'] so a test can
+//                             assert a notice fired exactly when (and as often as) expected.
+//   * is_subsystem_dirty() -> reads $GLOBALS['pfb_test_pkg_locked'] for the 'pkg' subsystem
+//                             (default false) so the pkg-lock short-circuit can be exercised.
+//   * get_dnsavailable()   -> reads $GLOBALS['pfb_test_dns_available'] (default true).
+
+if (!function_exists('file_notice')) {
+	function file_notice($id, $notice, $category = 'General', $url = '', $local_only = 0) {
+		$GLOBALS['pfb_test_file_notices'][] = array(
+			'id'         => $id,
+			'notice'     => $notice,
+			'category'   => $category,
+			'url'        => $url,
+			'local_only' => $local_only,
+		);
+	}
+}
+
+if (!function_exists('is_subsystem_dirty')) {
+	function is_subsystem_dirty($subsystem = '') {
+		if ($subsystem === 'pkg') {
+			return (bool) ($GLOBALS['pfb_test_pkg_locked'] ?? false);
+		}
+		return false;
+	}
+}
+
+if (!function_exists('get_dnsavailable')) {
+	function get_dnsavailable($ipproto = 'inet') {
+		return (bool) ($GLOBALS['pfb_test_dns_available'] ?? true);
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -312,3 +312,22 @@ if (!function_exists('convert_friendly_interface_to_friendly_descr')) {
 		return $interface;
 	}
 }
+
+if (!function_exists('pkg_version_compare')) {
+	// pfSense pkg.inc / pkg-utils.inc: compare two package versions, returning the
+	// FreeBSD pkg(8) symbol '<' | '=' | '>' for ($v1 <=> $v2). The real function shells
+	// to `pkg version -t <v1> <v2>`; off-appliance we reproduce that ordering with PHP's
+	// version_compare (which orders the pkg-style versions the decision core sees —
+	// semver, the `_N` port revision the catalog uses for upgrade legs, and nightly's
+	// dated `YYYYMMDD` versions). pfb_update_available() keys on the '<' result.
+	function pkg_version_compare($v1, $v2) {
+		$cmp = version_compare((string) $v1, (string) $v2);
+		if ($cmp < 0) {
+			return '<';
+		}
+		if ($cmp > 0) {
+			return '>';
+		}
+		return '=';
+	}
+}

--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -1,0 +1,548 @@
+"""ADR-19 Phase 1 — KILL-GATE: read-our-repo-latest + idempotent file_notice + provenance.
+
+This is the ADR-01-style cheap falsification of ADR-19's THREE load-bearing pkg/API-mechanic
+premises (ADR §1 "Premise to falsify cheaply", §6 Phase 1, §7 reject/degrade criteria), proven
+on the SAME live ADR-04 pfSense CE VM the ADR-17 repo flow uses — BEFORE any ``src/`` page or
+cron code is written. If a real box cannot read OUR repo's latest version without falling back
+to ``-r pfSense`` (re-locking discovery to Netgate), or ``file_notice`` cannot be made
+idempotent per version from a cron-like context, the design is wrong and must be reshaped now.
+
+NOT A SMOKE TEST. Like ``test_repo_install.py`` this validates *distribution/awareness*
+mechanics, not pfBlockerNG runtime behaviour, and carries the SAME marker ``repo`` (NOT
+``smoke``), so ``pytest -m smoke`` never selects it. It REUSES that file's hermetic catalog +
+``repo_vm`` machinery wholesale (no new VM boot path, no duplicated catalog code) and only adds
+the new ADR-19 mechanics on top.
+
+WHAT EACH CASE PROVES (mapped to ADR §1 premises + the 2026-06-15 provenance amendment):
+
+  (a) ``test_read_our_repo_latest_without_pfsense_repo`` — §1 premise 1. ``pkg update
+      -r <ourrepo>`` + ``pkg rquery -r <ourrepo> '%v' <pkgname>`` reads our catalog's HIGHER
+      version while ``pkg query '%v'`` still reports the installed (lower) one, and the read
+      does NOT touch the ``pfSense`` repo (no ``pfSense-repo-setup`` invocation; the pfSense
+      conf is byte-unchanged across the read). GO/REJECT gate for premise 1.
+
+  (b) ``test_file_notice_is_idempotent_per_version`` — §1 premise 2. ``file_notice(...)`` from
+      a php-cli (cron-like) context puts EXACTLY ONE matching row in ``get_notices()`` (before:
+      absent; after: present once); a SECOND tick at the SAME latest version raises NO new
+      notice when gated by a caller-side last-notified file; a HIGHER latest version raises a
+      SECOND notice. GO/REJECT gate for premise 2.
+
+  (c) ``test_same_channel_upgrade_advances_from_our_repo`` — §1 premise 3. A same-channel
+      ``pkg upgrade <ourpkg>`` advances the installed version from OUR repo (``%v`` N -> N+1,
+      ``%R`` == ours). GO-or-DEGRADE gate for premise 3. (This re-confirms ADR-17 Phase-5 for
+      THIS package name + the ADR-19 read/upgrade combination on one image.)
+
+  (d) ``test_provenance_repo_origin_distinguishes_our_build_from_decoy`` — the 2026-06-15
+      amendment. ``pkg query '%R' <pkgname>`` returns OUR repo name for an our-repo install and
+      the DECOY/Netgate repo name for a decoy install — the exact signal the later
+      ``pfb_software_is_our_build()`` provenance gate keys on. Both directions asserted so the
+      signal is provably discriminating, not an always-ours artefact.
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke`` in pyproject.toml).
+Run only via its own dispatch::
+
+    python -m pytest tests/smoke -m repo --override-ini="addopts="
+
+Needs the booted ``smoke_vm`` / ``repo_vm`` fixture, the branch ``.pkg`` (``SMOKE_PKG``) and
+the ``zstd`` runner host-tool (for the re-versioned builds); without them it skips cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ``repo_vm`` is re-exported (not just imported): pytest resolves fixtures PER-MODULE, so
+# importing the helper functions does NOT register the fixture in this module's namespace —
+# the name must be present here for the cases below to request it. The noqa keeps the
+# (module-level "unused") fixture import; the matching F811 ("redefinition" by each case param)
+# is suppressed for this file in pyproject. Both are the standard pytest re-export idiom.
+from .conftest import SmokeVM
+from .test_repo_install import (  # noqa: F401
+    DECOY_REPO_DIR,
+    DECOY_REPO_NAME,
+    NETGATE_REPO_NAME,
+    OURS_REPO_DIR,
+    OURS_REPO_NAME,
+    PKG_NAME,
+    UPGRADE_REPO_DIR,
+    _ssh_check,
+    build_guest_repo,
+    pkg_delete,
+    pkg_install_from_repo,
+    pkg_installed_version,
+    pkg_repo_origin,
+    pkg_update,
+    pkg_upgrade,
+    read_compact_version,
+    repo_priority,
+    repo_vm,
+    reversion_pkg,
+    write_repo_conf,
+)
+
+pytestmark = pytest.mark.repo
+
+# The per-channel repo a "Read latest" maps to (ADR §2 + 2026-06-15 amendment): stable/devel
+# share ``pfblockerng``; nightly is the only separate repo. Phase 1 exercises the shared repo
+# (the ADR-17 ``repo_vm`` fixture builds ``pfblockerng`` from the branch .pkg); the nightly
+# mapping is pure-helper logic settled off-box in Phase 2. ``OURS_REPO_NAME`` IS ``pfblockerng``.
+OURS_REPO_NAME_DEVEL = OURS_REPO_NAME
+
+# The pfSense repo conf the read must NOT disturb (premise 1). Reading our latest with
+# ``-r <ourrepo>`` must never run ``pfSense-repo-setup`` (which would rewrite this) nor read it.
+PFSENSE_REPO_CONF = "/usr/local/etc/pkg/repos/pfSense.conf"
+
+# A throwaway caller-side last-notified state file under the package's own state dir — the
+# de-dupe pattern the Phase-3 cron will use (ADR §2 "De-duped by persisting the last-notified
+# version"). Phase 1 only PROVES the pattern works; the real path/field land in Phase 3.
+LAST_NOTIFIED_FILE = "/var/db/pfblockerng/pfb_software_last_notified"
+
+# The notice identity the cron will raise (ADR §2 "Notice" row). Phase 1 uses the same id +
+# category so the get_notices row shape is what Phase 3 will produce.
+NOTICE_ID = "pfBlockerNG"
+NOTICE_CATEGORY = "pfBlockerNG"
+NOTICE_URL = "/pfblockerng/pfblockerng_software.php"
+
+
+# --------------------------------------------------------------------------- #
+# pkg-read helpers — read our repo's latest via -r <ourrepo>, never -r pfSense
+# --------------------------------------------------------------------------- #
+
+
+def pkg_update_our_repo(vm: SmokeVM, repo: str = OURS_REPO_NAME_DEVEL, *, timeout: float = 240.0) -> None:
+    """``pkg update -r <repo>`` — refresh ONLY our catalog DB (premise-1 read path).
+
+    The ``-r <repo>`` form re-reads exactly the named repo's catalog and no other; crucially it
+    does NOT invoke ``get_pkg_info`` / ``pfSense-repo-setup`` (the base-system path that re-locks
+    discovery to the Netgate ``pfSense`` repo, ADR §1 Context 2). ``-f`` forces a re-fetch so a
+    just-rebuilt ``file://`` catalog is honoured even when its mtime/etag looks unchanged.
+    """
+    _ssh_check(vm, "env", "ASSUME_ALWAYS_YES=yes", "pkg", "update", "-f", "-r", repo, timeout=timeout)
+
+
+def pkg_rquery_latest(vm: SmokeVM, repo: str = OURS_REPO_NAME_DEVEL, *, timeout: float = 60.0) -> str:
+    """The latest ``%v`` our repo advertises for the package, read via ``-r <repo>`` alone.
+
+    This is the ADR §2 "Read latest" invocation: ``pkg rquery -r <ourrepo> '%v' <pkgname>``.
+    The ``-r`` confines the lookup to OUR catalog — no fall-through to the Netgate ``pfSense``
+    repo. Raises (with output) on a non-zero exit so a repo that fails to answer is a hard fail,
+    not a silent empty string.
+    """
+    return _ssh_check(vm, "pkg", "rquery", "-r", repo, "%v", PKG_NAME, timeout=timeout).stdout.strip()
+
+
+def file_sha256(vm: SmokeVM, path: str, *, timeout: float = 60.0) -> str | None:
+    """The sha256 of a guest file, or ``None`` if it is absent (the byte-unchanged oracle).
+
+    Used to prove the read left the ``pfSense`` repo conf BYTE-IDENTICAL (premise 1). ``None``
+    on either side (file absent before AND after) is itself acceptable — the read created
+    nothing — so the caller asserts before == after, not non-None.
+    """
+    result = vm.ssh("/sbin/sha256", "-q", path, timeout=timeout)
+    if result.returncode != 0:
+        return None
+    digest = result.stdout.strip()
+    return digest or None
+
+
+# --------------------------------------------------------------------------- #
+# Notice helpers — drive file_notice / get_notices / close_notice via pfSsh.php
+# --------------------------------------------------------------------------- #
+# pfSense's notices API (upstream src/etc/inc/notices.inc):
+#   file_notice($id, $notice, $category="General", $url="", $priority=1, $local_only=false)
+#   get_notices()  -> array of {id, notice, category, url, priority, time} rows
+#   close_notice($id) -> removes every row whose id matches
+# pfSsh.php runs them in the fully-bootstrapped pfSense env (notices.inc is auto-loaded), the
+# same env the real cron uses, so this proves the cron-context delivery path end-to-end.
+
+_NOTICE_OPEN = "<<<NOTICECOUNT>>>"
+_NOTICE_CLOSE = "<<<NOTICEEND>>>"
+
+
+def _pfssh(vm: SmokeVM, snippet: str, *, timeout: float = 120.0) -> str:
+    """Run a PHP snippet through pfSsh.php (bootstrapped + config-locked) and return stdout.
+
+    Mirrors ``helpers.php_eval`` but kept local so this file imports only catalog machinery
+    from ``test_repo_install`` and does not couple to the DNSBL matrix helpers. Raises on a
+    non-zero pfSsh.php exit with the captured output.
+    """
+    program = snippet + "\nexec\nexit\n"
+    result = subprocess.run(
+        vm.ssh_argv("/usr/local/sbin/pfSsh.php"),
+        input=program,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"pfSsh.php snippet failed: rc={result.returncode}\n{result.stderr}\n{result.stdout}")
+    return result.stdout
+
+
+def raise_notice(vm: SmokeVM, message: str, *, timeout: float = 120.0) -> None:
+    """Raise ONE ``file_notice`` with the ADR-19 id/category/url (the cron's delivery call).
+
+    The ``$local_only`` flag is left at its default (false) — the real cron wants remote
+    fan-out too — but in CI there are no configured remote channels, so only the local bell row
+    is created, which is exactly what ``get_notices`` reports and what this gate measures.
+    """
+    snippet = (
+        f"file_notice({_php_str(NOTICE_ID)}, {_php_str(message)}, "
+        f"{_php_str(NOTICE_CATEGORY)}, {_php_str(NOTICE_URL)}, 1);\necho 'OK';"
+    )
+    out = _pfssh(vm, snippet, timeout=timeout)
+    if "OK" not in out:
+        raise RuntimeError(f"raise_notice did not confirm: {out!r}")
+
+
+def count_matching_notices(vm: SmokeVM, needle: str, *, timeout: float = 120.0) -> int:
+    """How many ``get_notices()`` rows carry ``needle`` in their ``notice`` text (the oracle).
+
+    Counts by the message SUBSTRING (a per-version string), not the id: file_notice with a
+    repeated id REPLACES the prior row of that id (notices are id-keyed by their md5), so the
+    de-dupe being proven is the CALLER not re-raising — a count keyed on the version string is
+    what distinguishes "raised once" from "raised again at a new version". Delimited so
+    pfSsh.php's startup banner never pollutes the integer.
+    """
+    snippet = (
+        "$n = 0;\n"
+        "foreach (get_notices() as $row) {\n"
+        f"  if (strpos((string)($row['notice'] ?? ''), {_php_str(needle)}) !== FALSE) {{ $n++; }}\n"
+        "}\n"
+        f"echo {_php_str(_NOTICE_OPEN)} . $n . {_php_str(_NOTICE_CLOSE)};"
+    )
+    out = _pfssh(vm, snippet, timeout=timeout)
+    start = out.find(_NOTICE_OPEN)
+    end = out.find(_NOTICE_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"count_matching_notices: no delimited count in pfSsh.php output: {out!r}")
+    return int(out[start + len(_NOTICE_OPEN) : end])
+
+
+def close_all_notices(vm: SmokeVM, *, timeout: float = 120.0) -> None:
+    """Close every notice carrying our id — leave the VM CLEAN (teardown counterpart)."""
+    snippet = f"close_notice({_php_str(NOTICE_ID)});\necho 'OK';"
+    _pfssh(vm, snippet, timeout=timeout)
+
+
+def _php_str(value: str) -> str:
+    """Render a Python str as a single-quoted PHP string literal (mirrors helpers._php_str)."""
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+# --------------------------------------------------------------------------- #
+# De-dupe pattern — the caller-side last-notified state file (ADR §2)
+# --------------------------------------------------------------------------- #
+
+
+def read_last_notified(vm: SmokeVM, *, timeout: float = 30.0) -> str | None:
+    """The version recorded in the last-notified state file, or ``None`` if never written."""
+    result = vm.ssh("cat", LAST_NOTIFIED_FILE, timeout=timeout)
+    if result.returncode != 0:
+        return None
+    val = result.stdout.strip()
+    return val or None
+
+
+def write_last_notified(vm: SmokeVM, version: str, *, timeout: float = 30.0) -> None:
+    """Persist ``version`` as the last-notified state (mkdir the state dir first)."""
+    _ssh_check(vm, "/bin/mkdir", "-p", os.path.dirname(LAST_NOTIFIED_FILE), timeout=timeout)
+    result = subprocess.run(
+        vm.ssh_argv("tee", LAST_NOTIFIED_FILE),
+        input=f"{version}\n",
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"write_last_notified failed: rc={result.returncode} {result.stderr!r}")
+
+
+def cron_tick(vm: SmokeVM, latest: str, message: str) -> bool:
+    """One de-duped cron-like tick: raise the notice ONLY when ``latest`` is newly notifiable.
+
+    This is the exact caller-side de-dupe the Phase-3 cron will implement (ADR §2 "De-duped by
+    persisting the last-notified version"): compare ``latest`` to the last-notified file; raise
+    + record only when they differ. Returns ``True`` iff a notice was raised this tick — the
+    branch the test asserts (raised at a new version, suppressed at the same one).
+    """
+    if read_last_notified(vm) == latest:
+        return False
+    raise_notice(vm, message)
+    write_last_notified(vm, latest)
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# (a) §1 premise 1 — read our repo's latest WITHOUT touching the pfSense repo
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(600)  # forge a higher build + install lower + 2 pkg updates + rquery > the 30s cap.
+def test_read_our_repo_latest_without_pfsense_repo(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """KILL-GATE §1 premise 1: ``pkg rquery -r <ourrepo>`` reads our HIGHER latest while the
+    installed stays LOWER, and the read leaves the Netgate ``pfSense`` repo conf BYTE-UNCHANGED.
+
+    The ADR §2 "Read latest" path is ``pkg update -r <ourrepo>`` then
+    ``pkg rquery -r <ourrepo> '%v' <pkgname>`` — it must answer from OUR catalog ALONE, never
+    falling back to ``get_pkg_info`` / ``-r pfSense`` (which would re-lock discovery to Netgate
+    and show Netgate's version, ADR §1 Context 2/3). REJECT/redesign if reading our latest
+    requires the pfSense path or ``pfSense-repo-setup`` rewrites our/its conf on every read.
+
+    Scenario: read our repo's newer build without disturbing the Netgate repo.
+      Background: our NONE-signed file:// repo carries a build HIGHER than the installed one.
+
+    Given the LOWER build ``<V>_1`` installed from OUR repo and the ``pfSense.conf`` digest
+      captured (the BEFORE state),
+    When the repo is rebuilt to the HIGHER build ``<V>_9``, ``pkg update -r <ourrepo>`` refreshes
+      ONLY our catalog, and ``pkg rquery -r <ourrepo> '%v'`` is read,
+    Then rquery returns ``<V>_9`` (our latest) while ``pkg query '%v'`` still returns ``<V>_1``
+      (the installed) — latest != installed, read by value — AND the ``pfSense.conf`` digest is
+      byte-identical to before (the read never ran ``pfSense-repo-setup``).
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
+    base_version = read_compact_version(Path(pkg))
+    low_version = f"{base_version}_1"
+    high_version = f"{base_version}_9"
+    assert low_version != high_version  # the installed-vs-latest gap must be real
+
+    low_pkg = reversion_pkg(Path(pkg), low_version, tmp_path / "low")
+    high_pkg = reversion_pkg(Path(pkg), high_version, tmp_path / "high")
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+    try:
+        # GIVEN: install the LOWER build from our repo; capture the pfSense conf digest BEFORE.
+        pkg_delete(repo_vm)
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [low_pkg])
+        write_repo_conf(repo_vm, UPGRADE_REPO_DIR, ours_priority=pfsense_prio + 100)
+        pkg_update(repo_vm)
+        pkg_install_from_repo(repo_vm)
+        assert pkg_installed_version(repo_vm) == low_version, (
+            f"expected {low_version!r} installed, got {pkg_installed_version(repo_vm)!r}"
+        )
+        pfsense_conf_before = file_sha256(repo_vm, PFSENSE_REPO_CONF)
+
+        # WHEN: publish the HIGHER build, read OUR latest via -r <ourrepo> ALONE.
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [high_pkg])
+        pkg_update_our_repo(repo_vm)
+        latest = pkg_rquery_latest(repo_vm)
+        installed = pkg_installed_version(repo_vm)
+
+        # THEN: our latest is the HIGHER build; the installed is still the LOWER one (read by
+        # value, latest != installed), and the Netgate conf is byte-unchanged (no -r pfSense).
+        assert latest == high_version, (
+            f"pkg rquery -r {OURS_REPO_NAME_DEVEL} returned {latest!r}, expected {high_version!r}"
+        )
+        assert installed == low_version, f"installed moved unexpectedly to {installed!r}, expected {low_version!r}"
+        assert latest != installed, "latest must differ from installed for the read to be meaningful"
+        pfsense_conf_after = file_sha256(repo_vm, PFSENSE_REPO_CONF)
+        assert pfsense_conf_after == pfsense_conf_before, (
+            f"the -r {OURS_REPO_NAME_DEVEL} read disturbed {PFSENSE_REPO_CONF} "
+            f"(before={pfsense_conf_before!r} after={pfsense_conf_after!r}) — pfSense-repo-setup ran"
+        )
+    finally:
+        pkg_delete(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)
+
+
+# --------------------------------------------------------------------------- #
+# (b) §1 premise 2 — file_notice fires from cron context + is idempotent per version
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(300)  # several pfSsh.php round-trips (raise/count/close) > the 30s cap.
+def test_file_notice_is_idempotent_per_version(repo_vm: SmokeVM) -> None:
+    """KILL-GATE §1 premise 2: ``file_notice`` fires from a cron-like (php-cli) context and is
+    DE-DUPED per version by a caller-side last-notified file — one notice per new version, not
+    one per tick. REJECT/redesign the notice path if it cannot be made idempotent per version.
+
+    Drives the real pfSense notices API (``file_notice`` -> ``get_notices``) in the
+    fully-bootstrapped env the cron uses; de-dupe is proven a CALLER concern (the ADR §2
+    pattern: persist last-notified, only call when latest != last).
+
+    Scenario: a daily cron tick must notify once per NEW version, never re-notify the same one.
+      Background: a clean notice state (our id closed, no last-notified file).
+
+    Given NO matching notice for version ``A`` (count == 0) and no last-notified state — the
+      asserted BEFORE state,
+    When a first cron tick runs at latest ``A``,
+    Then exactly ONE notice mentioning ``A`` exists (it fired) and last-notified == ``A``.
+    When a SECOND tick runs at the SAME latest ``A``,
+    Then still exactly ONE notice mentioning ``A`` (no re-notify — the de-dupe held).
+    When a third tick runs at a HIGHER latest ``B``,
+    Then a notice mentioning ``B`` now exists (a new version DOES re-notify) while the ``A`` and
+      ``B`` notifications are distinct messages — proving the gate keys on the version, not a
+      blanket once-ever suppression.
+    """
+    version_a = "9.9.9_1"
+    version_b = "9.9.9_2"
+    msg_a = f"pfBlockerNG {version_a} available (devel)"
+    msg_b = f"pfBlockerNG {version_b} available (devel)"
+    try:
+        # GIVEN: a clean before-state — no last-notified, no matching notice for A.
+        close_all_notices(repo_vm)
+        repo_vm.ssh("/bin/rm", "-f", LAST_NOTIFIED_FILE, timeout=30.0)
+        assert read_last_notified(repo_vm) is None, "last-notified file unexpectedly present before the test"
+        assert count_matching_notices(repo_vm, version_a) == 0, (
+            f"a notice for {version_a} already present before tick 1"
+        )
+
+        # WHEN/THEN (tick 1, new version A): fires exactly once; state records A.
+        assert cron_tick(repo_vm, version_a, msg_a) is True, "tick 1 should have raised a notice (new version)"
+        assert count_matching_notices(repo_vm, version_a) == 1, "tick 1 did not produce exactly one notice for A"
+        assert read_last_notified(repo_vm) == version_a, "tick 1 did not record A as last-notified"
+
+        # WHEN/THEN (tick 2, SAME version A): suppressed; still exactly one A notice.
+        assert cron_tick(repo_vm, version_a, msg_a) is False, "tick 2 re-notified the SAME version (de-dupe failed)"
+        assert count_matching_notices(repo_vm, version_a) == 1, "tick 2 created a duplicate notice for the same version"
+
+        # WHEN/THEN (tick 3, HIGHER version B): a new version DOES re-notify.
+        assert count_matching_notices(repo_vm, version_b) == 0, f"a notice for {version_b} present before tick 3"
+        assert cron_tick(repo_vm, version_b, msg_b) is True, "tick 3 should have raised a notice (newer version)"
+        assert count_matching_notices(repo_vm, version_b) == 1, "tick 3 did not produce exactly one notice for B"
+        assert read_last_notified(repo_vm) == version_b, "tick 3 did not advance last-notified to B"
+    finally:
+        close_all_notices(repo_vm)
+        repo_vm.ssh("/bin/rm", "-f", LAST_NOTIFIED_FILE, timeout=30.0)
+
+
+# --------------------------------------------------------------------------- #
+# (c) §1 premise 3 — same-channel pkg upgrade advances from our repo
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(600)  # forge 2 builds + install lower + a real pkg upgrade transition > the 30s cap.
+def test_same_channel_upgrade_advances_from_our_repo(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """KILL-GATE §1 premise 3 (GO-or-DEGRADE): a same-channel ``pkg upgrade <ourpkg>`` advances
+    the installed version from OUR repo — the "Update now" path the Software page will wrap.
+
+    This re-confirms ADR-17 Phase-5's in-repo upgrade precedence for THIS package name combined
+    with the ADR-19 read step, on one image. DEGRADE (not REJECT) to a documented CLI step if an
+    in-GUI same-channel upgrade proves unreliable (ADR §7) — display + notice still ship.
+
+    Scenario: a newer same-channel build in our repo upgrades an installed box.
+      Background: our NONE-signed file:// repo above the Netgate ``pfSense`` repo.
+
+    Given the LOWER build ``<V>_1`` installed from OUR repo (``%v`` == ``<V>_1``, ``%R`` == ours)
+      — the asserted BEFORE state,
+    When the SAME repo is rebuilt to the HIGHER build ``<V>_9`` and ``pkg upgrade -y`` runs,
+    Then the box MOVES to ``<V>_9`` still from OUR repo (``%v`` == ``<V>_9``, ``%R`` == ours) —
+      a real before != after transition, deps resolved.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
+    base_version = read_compact_version(Path(pkg))
+    low_version = f"{base_version}_1"
+    high_version = f"{base_version}_9"
+    assert low_version != high_version
+
+    low_pkg = reversion_pkg(Path(pkg), low_version, tmp_path / "low")
+    high_pkg = reversion_pkg(Path(pkg), high_version, tmp_path / "high")
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+    try:
+        # GIVEN: the LOWER build installed from our repo (the BEFORE state).
+        pkg_delete(repo_vm)
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [low_pkg])
+        write_repo_conf(repo_vm, UPGRADE_REPO_DIR, ours_priority=pfsense_prio + 100)
+        pkg_update(repo_vm)
+        pkg_install_from_repo(repo_vm)
+        assert pkg_installed_version(repo_vm) == low_version, (
+            f"expected {low_version!r} before upgrade, got {pkg_installed_version(repo_vm)!r}"
+        )
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, "lower build did not come from our repo"
+
+        # WHEN: publish the HIGHER build into the SAME repo, re-read it, upgrade.
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [high_pkg])
+        pkg_update(repo_vm)
+        proc = pkg_upgrade(repo_vm)
+
+        # THEN: moved to the HIGHER build, still from our repo, deps resolved.
+        combined = proc.stdout + proc.stderr
+        assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve on upgrade:\n{combined}"
+        assert pkg_installed_version(repo_vm) == high_version, (
+            f"pkg upgrade did not move {low_version!r} -> {high_version!r}; now at {pkg_installed_version(repo_vm)!r}"
+        )
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, "upgraded build did not come from our repo"
+    finally:
+        pkg_delete(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)
+
+
+# --------------------------------------------------------------------------- #
+# (d) 2026-06-15 amendment — the provenance probe (%R distinguishes our build)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(600)  # two installs (ours, then decoy) + queries > the 30s cap.
+def test_provenance_repo_origin_distinguishes_our_build_from_decoy(repo_vm: SmokeVM) -> None:
+    """KILL-GATE (2026-06-15 provenance amendment): ``pkg query '%R' <pkgname>`` returns OUR repo
+    name for an our-repo install and the COMPETING repo name for a decoy install — the exact
+    signal the later ``pfb_software_is_our_build()`` provenance gate keys on (the whole Software
+    feature is present ONLY when ``%R`` is one of OUR repos).
+
+    Both directions are asserted so the signal is provably DISCRIMINATING — a Netgate-installed
+    add-on (a decoy/non-``pfblockerng`` ``%R``) must read DIFFERENTLY from our build, else the
+    gate could never hide the feature on a stock install. The controlled ``netgate-decoy``
+    file:// repo stands in for the Netgate repo (which does not serve ``-devel`` in this hermetic
+    CE image), exactly as the ADR-17 precedence cases use it.
+
+    Scenario: provenance is read from the repo a package was installed FROM.
+      Background: ours + a decoy file:// repo both serving the identical package.
+
+    Given the package ABSENT (before state) and OUR repo at the higher priority,
+    When ``pkg install -y`` resolves across all repos,
+    Then ``pkg query '%R'`` == ``pfblockerng`` (our build -> the gate would SHOW the feature).
+    When the package is removed and reinstalled with the DECOY at the higher priority,
+    Then ``pkg query '%R'`` == ``netgate-decoy`` (a non-our build -> the gate would HIDE it) —
+      a real before != after on the provenance signal, not an always-ours artefact.
+    """
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+    try:
+        # GIVEN: package absent; ours ABOVE the decoy (both above pfSense).
+        pkg_delete(repo_vm)
+        write_repo_conf(
+            repo_vm,
+            OURS_REPO_DIR,
+            ours_priority=pfsense_prio + 200,
+            decoy_dir=DECOY_REPO_DIR,
+            decoy_priority=pfsense_prio + 100,
+        )
+        pkg_update(repo_vm)
+        assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the provenance install"
+
+        # WHEN/THEN (our build): %R reads OUR repo -> the gate would SHOW the feature.
+        pkg_install_from_repo(repo_vm)
+        our_origin = pkg_repo_origin(repo_vm)
+        assert our_origin == OURS_REPO_NAME, (
+            f"provenance %R for our-repo install was {our_origin!r}, expected {OURS_REPO_NAME!r} "
+            f"(the gate would wrongly HIDE the feature on our own build)"
+        )
+
+        # WHEN: reinstall with the DECOY now at the higher priority (a non-our build).
+        pkg_delete(repo_vm)
+        write_repo_conf(
+            repo_vm,
+            OURS_REPO_DIR,
+            ours_priority=pfsense_prio + 100,
+            decoy_dir=DECOY_REPO_DIR,
+            decoy_priority=pfsense_prio + 200,
+        )
+        pkg_update(repo_vm)
+        assert pkg_installed_version(repo_vm) is None, "package not cleanly removed before the decoy install"
+        pkg_install_from_repo(repo_vm)
+
+        # THEN (decoy build): %R reads the DECOY repo -> the gate would HIDE the feature.
+        decoy_origin = pkg_repo_origin(repo_vm)
+        assert decoy_origin == DECOY_REPO_NAME, (
+            f"provenance %R for decoy install was {decoy_origin!r}, expected {DECOY_REPO_NAME!r} "
+            f"(the gate could not tell a stock/non-our build apart)"
+        )
+        assert decoy_origin != our_origin, "provenance %R did not change between our-repo and decoy installs"
+    finally:
+        pkg_delete(repo_vm)

--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -628,6 +628,41 @@ def provenance_ok_on_box(vm: SmokeVM, *, timeout: float = 120.0) -> bool:
     return _pfssh_scalar(vm, snippet, timeout=timeout) == "1"
 
 
+def installed_name_on_box(vm: SmokeVM, *, timeout: float = 120.0) -> str:
+    """The SHIPPED ``pfb_pkg_installed_name()`` evaluated on the live box.
+
+    This is the FIRST link of the provenance chain (``pfb_software_provenance_ok()`` =
+    ``is_our_build(installed_repo(installed_name()))``): the glob query that resolves the
+    installed pfBlockerNG package name. An empty string here means the name glob matched
+    nothing -> ``installed_repo('')`` -> ``''`` -> the gate reads FALSE on an our-repo
+    install. Surfaced so the precondition can prove the chain's input is non-empty and the
+    failure message can echo the raw value that broke it.
+    """
+    snippet = (
+        f"require_once({_php_str(PFB_INC_PATH)});\n"
+        f"echo {_php_str(_VAL_OPEN)} . pfb_pkg_installed_name() . {_php_str(_VAL_CLOSE)};"
+    )
+    return _pfssh_scalar(vm, snippet, timeout=timeout)
+
+
+def installed_repo_on_box(vm: SmokeVM, pkgname: str, *, timeout: float = 120.0) -> str:
+    """The SHIPPED ``pfb_pkg_installed_repo($pkgname)`` evaluated on the live box.
+
+    The SECOND link of the provenance chain (``pfb_software_provenance_ok()`` =
+    ``is_our_build(installed_repo(installed_name()))``): the ``pkg query '%R'`` read
+    of the repo a package was installed FROM. It must match a direct ``pkg query
+    '%R'`` (``pkg_repo_origin``) — a mismatch means the helper shells to a pkg binary
+    that resolves ``%R`` differently (the /usr/sbin bootstrap-stub vs the
+    /usr/local/sbin port libpkg). Surfaced so the precondition proves the gate's own
+    input is ``pfblockerng`` and a re-failure echoes the raw value the gate saw.
+    """
+    snippet = (
+        f"require_once({_php_str(PFB_INC_PATH)});\n"
+        f"echo {_php_str(_VAL_OPEN)} . pfb_pkg_installed_repo({_php_str(pkgname)}) . {_php_str(_VAL_CLOSE)};"
+    )
+    return _pfssh_scalar(vm, snippet, timeout=timeout)
+
+
 def run_update_check_on_box(
     vm: SmokeVM,
     *,
@@ -761,12 +796,39 @@ def test_software_positive_journey_on_our_repo_install(repo_vm: SmokeVM, tmp_pat
         install_our_build_at(repo_vm, low, src, tmp_path, "low")
         got = pkg_installed_version(repo_vm)
         assert got == low, f"expected {low!r} installed, got {got!r}"
-        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, "lower build did not come from our repo"
+
+        # PRECONDITION: the provenance chain's three live inputs are correct, asserted
+        # SEPARATELY so a gate failure is self-diagnosing. pfb_software_provenance_ok()
+        # is is_our_build(installed_repo(installed_name())); prove (1) the package's %R is
+        # 'pfblockerng' read DIRECTLY (the ground-truth repo signal), (2) the shipped
+        # pfb_pkg_installed_name() actually resolves the package (its glob query must match
+        # the installed name) — an empty name silently collapses the chain to FALSE even
+        # when %R is correct — AND (3) the shipped pfb_pkg_installed_repo() reads the SAME
+        # %R the ground truth does. A (1)-vs-(3) mismatch means the helper shells to a pkg
+        # binary that resolves %R differently from the port libpkg the install used (the
+        # /usr/sbin bootstrap-stub vs /usr/local/sbin) — the exact bug the gate trips on.
+        repo_origin = pkg_repo_origin(repo_vm)
+        assert repo_origin == OURS_REPO_NAME, (
+            f"%R for the install is {repo_origin!r}, expected {OURS_REPO_NAME!r} (build is not from our repo)"
+        )
+        resolved_name = installed_name_on_box(repo_vm)
+        assert resolved_name == PKG_NAME, (
+            f"pfb_pkg_installed_name() resolved {resolved_name!r}, expected {PKG_NAME!r} — "
+            f"the name glob matched nothing, so installed_repo('') -> '' -> the gate reads FALSE"
+        )
+        shipped_repo = installed_repo_on_box(repo_vm, resolved_name)
+        assert shipped_repo == repo_origin, (
+            f"pfb_pkg_installed_repo({resolved_name!r}) read {shipped_repo!r} but `pkg query %R` reads "
+            f"{repo_origin!r} — the helper's pkg binary resolves %R differently from the install's "
+            f"(PFB_PKG_BIN must be the port libpkg /usr/local/sbin/pkg, not the /usr/sbin bootstrap stub)"
+        )
 
         # GIVEN (the Phase-4 NEGATIVE inverse, now POSITIVE): the gate reads TRUE, the
         # SHIPPED page parses, and the .pkg actually carried it (marker in the file).
         assert provenance_ok_on_box(repo_vm) is True, (
-            "pfb_software_provenance_ok() is FALSE on an our-repo install — the page/tab would be wrongly HIDDEN"
+            f"pfb_software_provenance_ok() is FALSE on an our-repo install — the page/tab would be "
+            f"wrongly HIDDEN (installed_name={resolved_name!r}, shipped %R={shipped_repo!r}, "
+            f"ground-truth %R={repo_origin!r})"
         )
         assert php_lint_ok(repo_vm, SOFTWARE_PAGE_FILE), (
             f"{SOFTWARE_PAGE_FILE} failed php -l (or is absent — was the .pkg built with the ports plist entry?)"

--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -49,6 +49,7 @@ the ``zstd`` runner host-tool (for the re-versioned builds); without them it ski
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -106,6 +107,44 @@ LAST_NOTIFIED_FILE = "/var/db/pfblockerng/pfb_software_last_notified"
 NOTICE_ID = "pfBlockerNG"
 NOTICE_CATEGORY = "pfBlockerNG"
 NOTICE_URL = "/pfblockerng/pfblockerng_software.php"
+
+# --------------------------------------------------------------------------- #
+# Phase-5 POSITIVE journey constants — the SHIPPED Phase-4 src/ surfaces, now on a
+# box installed FROM our repo (``%R`` == ``pfblockerng``), so the provenance gate is
+# SATISFIED. (Phase 4 proved the NEGATIVE side live: the ADR-04 ``ui_render`` harness
+# installs with ``pkg add -f``, ``%R`` is NOT our repo, so the page + tab are HIDDEN.
+# An our-repo install — only reachable in this ``repo`` flow — is the only place the
+# POSITIVE side can be proven.)
+# --------------------------------------------------------------------------- #
+
+# The Phase-3 orchestrator's cache file (ADR §2 "Background check"). The page reads it;
+# the cron (pfb_software_update_check) writes it. Cleared between cases for clean befores.
+SOFTWARE_CACHE_FILE = "/var/db/pfblockerng/software_update.json"
+
+# The installed pfBlockerNG include + the Phase-4 page, at their on-box install paths.
+# The page is shipped under www/ (NOT chroot-copied); the inc holds the orchestrator +
+# the provenance helper the page guards on. ``pfb_software_provenance_ok()`` and
+# ``pfb_software_update_check()`` are driven live by loading this inc in pfSsh.php.
+PFB_INC_PATH = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+SOFTWARE_PAGE_FILE = "/usr/local/www/pfblockerng/pfblockerng_software.php"
+
+# The page's ui_render content marker (Phase 4): the element id on the Channel
+# StaticText. Asserting it inside the SHIPPED page file proves the .pkg actually
+# carried pfblockerng_software.php (the FreeBSD-ports plist entry took effect when the
+# build ran with ports_ref=adr/19-update-channel-panel).
+SOFTWARE_PANEL_MARKER = "pfb-software-panel"
+
+# The notify config knob the page writes + the orchestrator reads (Phase 3). Driving it
+# off the installed channel (devel) proves the channel-default OFF branch; injecting a
+# nightly channel proves the channel-default ON branch (the nightly repo/package is not
+# in this hermetic CE image, so the nightly CHANNEL is simulated via the orchestrator's
+# documented $io seam — noted in the handoff).
+NOTIFY_KNOB_PATH = "installedpackages/pfblockerng/config/0/pfb_software_notify"
+
+# Delimiters for reading a single scalar back out of pfSsh.php (its startup banner
+# otherwise pollutes stdout — same pattern as count_matching_notices above).
+_VAL_OPEN = "<<<PFBVAL>>>"
+_VAL_CLOSE = "<<<PFBEND>>>"
 
 
 # --------------------------------------------------------------------------- #
@@ -546,3 +585,327 @@ def test_provenance_repo_origin_distinguishes_our_build_from_decoy(repo_vm: Smok
         assert decoy_origin != our_origin, "provenance %R did not change between our-repo and decoy installs"
     finally:
         pkg_delete(repo_vm)
+
+
+# =========================================================================== #
+# PHASE 5 — the POSITIVE end-to-end journey on an OUR-REPO install
+# =========================================================================== #
+# Phases 1-3 proved the pkg/notice/upgrade MECHANICS and the pure decision core; Phase 4
+# proved the page's NEGATIVE (hidden-on-Netgate) side live. This phase proves the
+# POSITIVE side that only an our-repo install (``%R`` == ``pfblockerng``) can exercise:
+# the provenance gate OPENS, the SHIPPED orchestrator (pfb_software_update_check) writes
+# the cache + raises the de-duped channel-correct file_notice, and same-channel
+# ``pkg upgrade`` advances the box from OUR repo. The page itself is asserted live via
+# pfSsh.php (provenance_ok TRUE + ``php -l`` of the shipped page + its content marker
+# present in the installed file) — the ``repo`` harness has no authenticated webui client
+# (the ADR-14 ``webui`` fixture depends on ``deployed_vm``, a ``pkg add -f`` install whose
+# ``%R`` is NOT our repo), so pfSsh.php is the robust live oracle here.
+
+
+def _pfssh_scalar(vm: SmokeVM, snippet: str, *, timeout: float = 120.0) -> str:
+    """Run a PHP snippet through pfSsh.php and return the value it prints between the
+    ``_VAL_OPEN``/``_VAL_CLOSE`` delimiters (pfSsh.php's startup banner is stripped)."""
+    out = _pfssh(vm, snippet, timeout=timeout)
+    start = out.find(_VAL_OPEN)
+    end = out.find(_VAL_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"_pfssh_scalar: no delimited value in pfSsh.php output: {out!r}")
+    return out[start + len(_VAL_OPEN) : end]
+
+
+def provenance_ok_on_box(vm: SmokeVM, *, timeout: float = 120.0) -> bool:
+    """The SHIPPED ``pfb_software_provenance_ok()`` evaluated on the live box.
+
+    Loads the installed ``pfblockerng.inc`` in the bootstrapped pfSsh.php env and calls the
+    real gate — the exact predicate the page's top-of-file guard + the tab append key on.
+    On an our-repo install it must read TRUE (``%R`` == ``pfblockerng``); on a Netgate /
+    decoy install FALSE. This is the live inverse of Phase 4's negative ``ui_render`` gate.
+    """
+    snippet = (
+        f"require_once({_php_str(PFB_INC_PATH)});\n"
+        f"echo {_php_str(_VAL_OPEN)} . (pfb_software_provenance_ok() ? '1' : '0') . {_php_str(_VAL_CLOSE)};"
+    )
+    return _pfssh_scalar(vm, snippet, timeout=timeout) == "1"
+
+
+def run_update_check_on_box(
+    vm: SmokeVM,
+    *,
+    force: bool = True,
+    io_overrides: dict[str, str] | None = None,
+    timeout: float = 240.0,
+) -> None:
+    """Drive the SHIPPED ``pfb_software_update_check()`` once, the way the cron tick does.
+
+    With no ``io_overrides`` it runs fully live (reads ``pkg`` for installed/latest/repo) —
+    the real journey. ``io_overrides`` exercises the documented ``$io`` seam to inject a
+    channel/version (used ONLY to simulate the *nightly* channel, which has no repo/package
+    in this hermetic CE image — noted in the handoff). Raises on a non-zero pfSsh.php exit.
+    """
+    if io_overrides:
+        pairs = ", ".join(f"{_php_str(k)} => {_php_str(v)}" for k, v in io_overrides.items())
+        io_arg = f"array({pairs})"
+    else:
+        io_arg = "null"
+    snippet = (
+        f"require_once({_php_str(PFB_INC_PATH)});\n"
+        f"global $pfb; pfb_global();\n"
+        f"pfb_software_update_check({'true' if force else 'false'}, {io_arg});\n"
+        "echo 'OK';"
+    )
+    out = _pfssh(vm, snippet, timeout=timeout)
+    if "OK" not in out:
+        raise RuntimeError(f"pfb_software_update_check did not confirm: {out!r}")
+
+
+def read_software_cache(vm: SmokeVM, *, timeout: float = 30.0) -> dict[str, object]:
+    """The orchestrator's cache file decoded, or ``{}`` when absent (the before/after oracle)."""
+    result = vm.ssh("cat", SOFTWARE_CACHE_FILE, timeout=timeout)
+    if result.returncode != 0:
+        return {}
+    raw = result.stdout.strip()
+    if not raw:
+        return {}
+    data = json.loads(raw)
+    return data if isinstance(data, dict) else {}
+
+
+def clear_software_state(vm: SmokeVM, *, timeout: float = 30.0) -> None:
+    """Remove the cache + close our notices — a clean BEFORE state for each case."""
+    vm.ssh("/bin/rm", "-f", SOFTWARE_CACHE_FILE, timeout=timeout)
+    close_all_notices(vm, timeout=120.0)
+
+
+def set_notify_knob(vm: SmokeVM, value: str, *, timeout: float = 120.0) -> None:
+    """Persist ``pfb_software_notify`` (default|on|off) via the real config API.
+
+    Mirrors what the page's save POST does — config_set_path + write_config in the
+    config-locked pfSsh.php env — so the orchestrator reads the same value the GUI would.
+    """
+    snippet = (
+        f"config_set_path({_php_str(NOTIFY_KNOB_PATH)}, {_php_str(value)});\n"
+        "write_config('ADR-19 phase-5 smoke: set pfb_software_notify');\necho 'OK';"
+    )
+    out = _pfssh(vm, snippet, timeout=timeout)
+    if "OK" not in out:
+        raise RuntimeError(f"set_notify_knob did not confirm: {out!r}")
+
+
+def clear_notify_knob(vm: SmokeVM, *, timeout: float = 120.0) -> None:
+    """Reset the notify knob to its unset/'default' value (the channel-default branch)."""
+    set_notify_knob(vm, "default", timeout=timeout)
+
+
+def php_lint_ok(vm: SmokeVM, path: str, *, timeout: float = 60.0) -> bool:
+    """``php -l <path>`` on the box — the shipped page parses cleanly (no Fatal/Parse)."""
+    result = vm.ssh("php", "-l", path, timeout=timeout)
+    return result.returncode == 0 and "No syntax errors detected" in result.stdout
+
+
+def install_our_build_at(vm: SmokeVM, version: str, src: Path, tmp_path: Path, tag: str) -> None:
+    """Install ``version`` of our package FROM our (re-versioned) repo (``%R`` == ours).
+
+    Builds a single-build catalog in ``UPGRADE_REPO_DIR`` at ``version`` and installs it
+    above the Netgate repo by priority, so the install provenance is OUR repo — the
+    precondition for the provenance gate to OPEN.
+    """
+    forged = reversion_pkg(src, version, tmp_path / tag)
+    pfsense_prio = repo_priority(vm, NETGATE_REPO_NAME)
+    pkg_delete(vm)
+    build_guest_repo(vm, UPGRADE_REPO_DIR, [forged])
+    write_repo_conf(vm, UPGRADE_REPO_DIR, ours_priority=pfsense_prio + 100)
+    pkg_update(vm)
+    pkg_install_from_repo(vm)
+
+
+# --------------------------------------------------------------------------- #
+# (e) The POSITIVE page-gate + cache + de-duped-notice + Update-now journey
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(900)  # 2 forged builds + install + 2 checks + a real pkg upgrade > the 30s cap.
+def test_software_positive_journey_on_our_repo_install(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """The POSITIVE end-to-end Software journey on an OUR-REPO install (``%R`` == ours).
+
+    Proves every gate Phase 4 showed HIDDEN is now OPEN, and the publish-newer ->
+    de-duped notice + cache + same-channel Update chain works live. Channel here is
+    ``devel`` (the installed ``-devel`` package), whose notify default is OFF — so the
+    knob is forced ``on`` for the notice legs (the channel-default OFF/ON branches are
+    pinned separately in ``test_software_notify_default_is_channel_correct``).
+
+    Scenario: an our-repo box sees the Software page, gets one notice for a newer build,
+    and Update-now pulls it.
+      Background: our NONE-signed file:// repo above the Netgate repo; egress open.
+
+    Given build ``<V>_1`` installed FROM our repo (the asserted BEFORE: provenance OPEN,
+      page parses + carries its marker, knob=on, NO cache, NO notice),
+    When the first check runs at installed==latest==``<V>_1``,
+    Then the cache records installed==latest==``<V>_1`` and NO notice is raised (up to date).
+    When ``<V>_9`` is published to the SAME repo and the check runs,
+    Then the cache ``latest`` advances to ``<V>_9`` and EXACTLY ONE notice mentioning
+      ``<V>_9`` appears; a SECOND check at the same latest raises NO second notice (de-dupe).
+    When ``pkg upgrade`` runs and the check runs again,
+    Then the box moved to ``<V>_9`` still from OUR repo, the cache shows installed==latest,
+      and NO new notice is raised — each before/after asserted by value.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
+    src = Path(pkg)
+    base_version = read_compact_version(src)
+    low = f"{base_version}_1"
+    high = f"{base_version}_9"
+    assert low != high
+
+    try:
+        # GIVEN: the LOWER build installed FROM our repo -> provenance gate OPENS.
+        install_our_build_at(repo_vm, low, src, tmp_path, "low")
+        got = pkg_installed_version(repo_vm)
+        assert got == low, f"expected {low!r} installed, got {got!r}"
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, "lower build did not come from our repo"
+
+        # GIVEN (the Phase-4 NEGATIVE inverse, now POSITIVE): the gate reads TRUE, the
+        # SHIPPED page parses, and the .pkg actually carried it (marker in the file).
+        assert provenance_ok_on_box(repo_vm) is True, (
+            "pfb_software_provenance_ok() is FALSE on an our-repo install — the page/tab would be wrongly HIDDEN"
+        )
+        assert php_lint_ok(repo_vm, SOFTWARE_PAGE_FILE), (
+            f"{SOFTWARE_PAGE_FILE} failed php -l (or is absent — was the .pkg built with the ports plist entry?)"
+        )
+        marker_grep = repo_vm.ssh("grep", "-q", SOFTWARE_PANEL_MARKER, SOFTWARE_PAGE_FILE, timeout=30.0)
+        assert marker_grep.returncode == 0, (
+            f"the {SOFTWARE_PANEL_MARKER!r} marker is absent from the shipped page — "
+            f"the .pkg did not carry Phase-4's page"
+        )
+
+        # GIVEN: a clean state + knob ON; assert the BEFORE (no cache, no notice for high).
+        clear_software_state(repo_vm)
+        set_notify_knob(repo_vm, "on")
+        assert read_software_cache(repo_vm) == {}, "software cache unexpectedly present before the first check"
+        assert count_matching_notices(repo_vm, high) == 0, f"a notice for {high} existed before any check"
+
+        # WHEN/THEN (first check, installed==latest): cache says up to date; NO notice.
+        run_update_check_on_box(repo_vm)
+        cache = read_software_cache(repo_vm)
+        assert cache.get("installed") == low, f"cache installed {cache.get('installed')!r} != {low!r}"
+        assert cache.get("latest") == low, f"cache latest {cache.get('latest')!r} != {low!r} (should equal installed)"
+        assert cache.get("channel") == "devel", f"cache channel {cache.get('channel')!r} != 'devel'"
+        assert count_matching_notices(repo_vm, high) == 0, "a notice fired while installed == latest (no update)"
+
+        # WHEN: publish the HIGHER build into the SAME repo; the check sees a newer latest.
+        high_pkg = reversion_pkg(src, high, tmp_path / "high")
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [high_pkg])
+        run_update_check_on_box(repo_vm)
+
+        # THEN: cache latest advances; EXACTLY ONE notice for the new version.
+        cache = read_software_cache(repo_vm)
+        assert cache.get("installed") == low, f"installed moved unexpectedly to {cache.get('installed')!r}"
+        assert cache.get("latest") == high, f"cache latest did not advance to {high!r}: {cache.get('latest')!r}"
+        assert count_matching_notices(repo_vm, high) == 1, "the newer build did not raise exactly one notice"
+
+        # WHEN/THEN (de-dupe): a second check at the SAME latest raises NO second notice.
+        run_update_check_on_box(repo_vm)
+        assert count_matching_notices(repo_vm, high) == 1, (
+            "a second check at the same latest re-notified (de-dupe failed)"
+        )
+
+        # WHEN: Update now -> same-channel pkg upgrade pulls the newer build from OUR repo.
+        proc = pkg_upgrade(repo_vm)
+        combined = proc.stdout + proc.stderr
+        assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve on upgrade:\n{combined}"
+
+        # THEN: moved to HIGH, still from our repo; re-check shows up-to-date + NO new notice.
+        assert pkg_installed_version(repo_vm) == high, (
+            f"pkg upgrade did not move {low!r} -> {high!r}; now {pkg_installed_version(repo_vm)!r}"
+        )
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, "upgraded build did not come from our repo"
+        run_update_check_on_box(repo_vm)
+        cache = read_software_cache(repo_vm)
+        assert cache.get("installed") == high, f"post-upgrade cache installed {cache.get('installed')!r} != {high!r}"
+        assert cache.get("latest") == high, f"post-upgrade cache latest {cache.get('latest')!r} != {high!r}"
+        assert count_matching_notices(repo_vm, high) == 1, (
+            "a notice re-fired after upgrading to the latest (no new version)"
+        )
+    finally:
+        clear_software_state(repo_vm)
+        clear_notify_knob(repo_vm)
+        pkg_delete(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)
+
+
+# --------------------------------------------------------------------------- #
+# (f) Channel-correct notify DEFAULT — the OFF (devel) vs ON (nightly) branch, live
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(600)  # install + 2 forged builds + several live checks > the 30s cap.
+def test_software_notify_default_is_channel_correct(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """The notify DEFAULT is driven by the CHANNEL, not an always-path (knob unset/'default').
+
+    Pairs the two channel branches so green proves the channel drives the default:
+    ``devel`` (the installed channel) defaults OFF -> a newer build raises NO notice;
+    ``nightly`` defaults ON -> the same newer-build condition raises ONE notice. The
+    nightly *channel* is simulated via the orchestrator's documented ``$io`` seam (a
+    nightly ``installed_name`` + an our-repo ``installed_repo`` so the gate still OPENS):
+    the nightly repo/package is not built into this hermetic CE image (ADR-18), so the
+    CHANNEL-default decision is what is proven end to end (real orchestrator -> real
+    file_notice), not a nightly pkg install. Noted as a simulation in the handoff.
+
+    Scenario: a newer build notifies by default ONLY on the nightly channel.
+      Background: our build installed from our repo; the notify knob UNSET ('default').
+
+    Given build ``<V>_1`` installed from our repo, knob='default', a clean notice state,
+      and a published newer ``<V>_9`` (the asserted BEFORE: no notice for ``<V>_9``),
+    When a check runs as the DEVEL channel (the real installed one),
+    Then NO notice is raised (devel default is OFF).
+    When a check runs as the NIGHTLY channel (same newer-build condition, $io-simulated),
+    Then EXACTLY ONE notice is raised (nightly default is ON) — the same condition, the
+      opposite outcome, so the difference is the channel default and nothing else.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"
+    src = Path(pkg)
+    base_version = read_compact_version(src)
+    low = f"{base_version}_1"
+    high = f"{base_version}_9"
+    devel_msg = "available (devel)"
+    nightly_msg = "available (nightly)"
+
+    try:
+        # GIVEN: our-repo install, knob 'default', clean notices, a newer build published.
+        install_our_build_at(repo_vm, low, src, tmp_path, "low")
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, "build did not come from our repo (gate would be closed)"
+        high_pkg = reversion_pkg(src, high, tmp_path / "high")
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [high_pkg])
+        clear_software_state(repo_vm)
+        clear_notify_knob(repo_vm)
+        assert count_matching_notices(repo_vm, devel_msg) == 0, "a devel notice existed before the devel check"
+        assert count_matching_notices(repo_vm, nightly_msg) == 0, "a nightly notice existed before the nightly check"
+
+        # WHEN/THEN (devel, default OFF): a newer build raises NO notice.
+        run_update_check_on_box(repo_vm)
+        assert count_matching_notices(repo_vm, devel_msg) == 0, (
+            "the devel channel notified by default (its default must be OFF)"
+        )
+
+        # WHEN/THEN (nightly, default ON): the SAME newer-build condition raises ONE notice.
+        # $io supplies a nightly installed_name (-> channel nightly) + an our-repo
+        # installed_repo (gate OPENS) + the installed/latest version gap; the channel
+        # default (ON) is the only thing that differs from the devel leg above.
+        run_update_check_on_box(
+            repo_vm,
+            io_overrides={
+                "installed_name": "pfSense-pkg-pfBlockerNG-NIGHTLY",
+                "installed_repo": OURS_REPO_NAME,
+                "installed": low,
+                "latest": high,
+            },
+        )
+        assert count_matching_notices(repo_vm, nightly_msg) == 1, (
+            "the nightly channel did NOT notify by default (its default must be ON) — "
+            "the channel does not drive the default"
+        )
+    finally:
+        clear_software_state(repo_vm)
+        clear_notify_knob(repo_vm)
+        pkg_delete(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -351,6 +351,66 @@ def test_threats_rejects_malformed_lookup(name: str, query: str, message: str, w
     assert not present, f"{name}: reject path unexpectedly rendered lookup chrome {present}"
 
 
+# ADR-19: the "Software" page + tab are PROVENANCE-GATED — present ONLY on a build
+# installed from one of OUR repos (pkg %R == pfblockerng / pfblockerng-nightly). The
+# ADR-04 UI harness installs the branch .pkg with `pkg add -f` (offline), so its %R is
+# NOT one of our repos -> the provenance gate HIDES the page and the tab. This is the
+# NEGATIVE side of the gate, and it is the one this Tier-A deploy can prove live: the
+# page's top-of-file guard `header('Location: /index.php'); exit;` fires, and
+# pfb_software_add_tab() appends nothing. The POSITIVE render (200 + the
+# 'pfb-software-panel' marker + the action buttons) belongs to Phase 5's `repo`-install
+# journey, where the package IS installed from our repo so %R == pfblockerng.
+_SOFTWARE_PAGE = "/pfblockerng/pfblockerng_software.php"
+_SOFTWARE_PANEL_MARKER = "pfb-software-panel"
+_SOFTWARE_TAB_HREF = "/pfblockerng/pfblockerng_software.php"
+
+
+def test_software_page_provenance_gate_hides_on_nonour_build(
+    webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """The Software page's provenance guard hides it on a non-our-repo install.
+
+    Scenario: pfBlockerNG installed via `pkg add -f` (the UI harness), so the
+    installed package's repo (`pkg query %R`) is NOT one of our repos.
+      Given the standard Tier-A deploy (offline `pkg add -f`),
+      When the Software page is GET (redirects NOT followed),
+      Then the top-of-file provenance guard redirects to /index.php (a 3xx, not a
+           200 panel body), the page-specific 'pfb-software-panel' marker is absent
+           from the body, AND no new php_error.log line is produced (the guard is a
+           clean redirect+exit, NOT a fatal). The enrolled php_error_log_guard pins
+           the no-new-error-line condition over the sweep.
+    """
+    # Do NOT follow the redirect: assert the guard's 3xx -> /index.php directly, so a
+    # broken guard that 200-renders the panel can't pass by following to a clean page.
+    resp = webui.get(_SOFTWARE_PAGE, allow_redirects=False)
+    assert resp.status_code in (301, 302, 303, 307, 308), (
+        f"Software page expected a provenance-guard redirect, got HTTP {resp.status_code}"
+    )
+    location = resp.headers.get("Location", "")
+    assert location.endswith("/index.php"), f"provenance guard should redirect to /index.php, got Location={location!r}"
+    assert _SOFTWARE_PANEL_MARKER not in resp.text, (
+        "provenance guard must NOT render the Software panel on a non-our-build"
+    )
+
+
+def test_software_tab_absent_on_nonour_build(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The 'Software' tab is absent from a normal pfBlockerNG page on a non-our-build.
+
+    Given the same offline `pkg add -f` deploy (non-our-repo provenance),
+    When the General page is GET,
+    Then pfb_software_add_tab() appended nothing: the Software tab href is NOT in the
+         tab bar. Pairs with the page-gate test above to prove BOTH gated surfaces
+         (page + tab) are hidden. The positive (tab PRESENT) state is Phase 5's
+         repo-install journey. php_error_log_guard enrolls this GET in the sweep.
+    """
+    resp = webui.get(_GENERAL_PAGE)
+    result = evaluate_render(_GENERAL_PAGE, resp.status_code, resp.text, ("General Settings",))
+    assert result.ok, f"General page render oracle failed: {result.detail}"
+    assert _SOFTWARE_TAB_HREF not in resp.text, (
+        "the Software tab must be ABSENT on a non-our-build (provenance gate hides it everywhere)"
+    )
+
+
 def test_page_table_covers_every_pfblockerng_page() -> None:
     """Guard: the table (plus the recorded exclusions) covers the on-disk page set.
 


### PR DESCRIPTION
Implements **ADR-19** — a pfBlockerNG-owned **Software** update/channel panel + de-duped new-version notice, **present only on a self-hosted-repo install** (absent on a Netgate-installed add-on), per the maintainer directive.

## Phases (all on this branch)
- **P1 kill-gate (live VM, GO):** `pkg`-read of our repo's latest without touching the `pfSense` repo; `file_notice` idempotency; same-channel `pkg upgrade`; **provenance probe** (`pkg query %R`). `tests/smoke/test_software_update.py` (`repo` marker).
- **P2 pure decision core (PHPUnit):** `pfb_channel_from_pkgname`, `pfb_pkg_repo_name_for_channel` (stable+devel→`pfblockerng`, nightly→`pfblockerng-nightly`), `pfb_software_is_our_build` (**provenance gate**), `pfb_update_available`, `pfb_notify_default_for_channel` (nightly ON / else OFF), `pfb_should_notify` (de-dupe state machine). Every branch + before-state.
- **P3 cron check + notice:** thin `pkg` IO wrapper (pkg-lock + DNS guarded), `pfb_software_update_check`, cache `/var/db/pfblockerng/software_update.json`, `pfb_software_notify` knob, wired to the existing cron. **Provenance-gated first** (Netgate build = full no-op).
- **P4 the page + gate:** `pfblockerng_software.php` (top-of-file provenance guard; Check/Update/Bootstrap actions), the **Software** tab + priv `match[]` appended **only** on an our-repo build, `ports_ref` plumbing in smoke/ui-tests. Negative `ui_render` proves the page/tab are hidden on a sideloaded install.
- **P5 positive journey + docs:** `repo`-install journey (provenance true → page served, newer build → one de-duped notice, `pkg upgrade` advances from our repo) + README/§7.

## Real bug caught by the positive smoke
`PFB_PKG_BIN` was the base `/usr/sbin/pkg` bootstrap stub, which returns empty `%R` → the panel would be **wrongly hidden on every real self-hosted-repo install**. Fixed to the port libpkg `/usr/local/sbin/pkg` (`446a507`).

## Acceptance evidence (live)
- Kill-gate `repo` smoke GREEN — run 27556866855.
- Negative `ui_render` (CE) GREEN — run 27561878398 (page packaged, hidden by provenance on a `pkg add` install).
- Positive `repo` journey GREEN — run 27563499127.
- Off-box: `ruff`/`pytest` (1575), PHPUnit (487), PHPStan, PHPCS, `php -l`, markdownlint all green.

## ⚠️ Lockstep dependency (FreeBSD-ports)
This ships pfBlockerNG's **first new `www/` file**. The portable builder packages from the static `pkg-plist` on `pfBlockerNG/FreeBSD-ports@pfblockerng/use-github`. A matching plist + `do-install` entry is staged on **`pfBlockerNG/FreeBSD-ports@adr/19-update-channel-panel`** and must fast-forward onto `use-github` **in lockstep** with this merge (devel + nightly ports). The **stable** port entry must wait until ADR-19 promotes to a release (its `src` has no page yet, or the stable release build breaks). Until the `use-github` bump, devel/nightly builds simply don't package the page (tolerated, no break).

https://claude.ai/code/session_01FQw7c1A4jkFrdxJ9Xm3CtW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQw7c1A4jkFrdxJ9Xm3CtW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a provenance-gated pfBlockerNG “Software” tab (shown only for self-hosted/approved builds; non-approved boxes redirect and hide the tab).
  * Included a background check on cron ticks to detect updates and raise de-duplicated, per-version notifications.
  * Added manual Software actions: **Check**, **Update**, and **Bootstrap Repository**.
  * Extended UI navigation so the Software tab is available from multiple pfBlockerNG pages.
* **Documentation**
  * Updated README to clarify Software tab availability and notification behavior/knob behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->