### PR TITLE
smoke: cover DNSBL control channel + CLI (PFBL-03)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2206,6 +2206,144 @@ def resolve_control(vm: SmokeVM, name: str) -> list[str]:
 
 
 # --------------------------------------------------------------------------- #
+# DNSBL Control channel (PFBL-03) — CLI driver + applied-marker observation
+# --------------------------------------------------------------------------- #
+# PFBL-03 moved DNSBL runtime control (disable/enable/addbypass/removebypass) off
+# in-band DNS-TXT queries onto a local privileged command channel + a CLI. The
+# operator CLI is the ``dnsbl-control`` action of the package shell script
+# (``pfblockerng.sh dnsbl-control …``), which forwards to ``pfblockerng.php
+# dnsbl-control …`` — the PHP writer validates the command and atomically publishes
+# a JSON record to the chroot channel ``/var/unbound/pfb_py_control``; the in-module
+# reader thread (``pfb_control_watcher``) applies it and writes the applied sequence
+# to ``/var/unbound/pfb_py_control.applied``. The reader thread starts only when the
+# DNSBL Control toggle (``pfb_control`` -> ini ``python_control``) is on.
+
+PFB_SH = "/usr/local/pkg/pfblockerng/pfblockerng.sh"
+# Host paths of the in-chroot channel + applied-sequence marker (Unbound's CWD is
+# /var/unbound, so the module's relative names live here on the host).
+UNBOUND_CONTROL_FILE = "/var/unbound/pfb_py_control"
+UNBOUND_CONTROL_APPLIED_FILE = "/var/unbound/pfb_py_control.applied"
+
+
+def set_dnsbl_control(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Toggle the DNSBL Control feature (``pfb_control`` -> ini ``python_control``).
+
+    On: the next reload writes ``python_control = on`` to pfb_unbound.ini and the
+    reader thread (``pfb_control_watcher``) starts, so CLI commands take effect.
+    Off: the thread never starts and the channel is ignored.
+    """
+    val = "on" if on else ""
+    snippet = (
+        f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
+        f"$d['pfb_control'] = {_php_str(val)};\n"
+        f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $d);\n"
+        "write_config('pfBlockerNG smoke: toggle pfb_control');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_dnsbl_control({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def set_dnsbl_control_legacy(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Toggle the deprecated DNS-TXT control sub-path (``pfb_control_legacy`` -> ini
+    ``python_control_legacy``).
+
+    The ini key is written ``on`` only when BOTH ``pfb_control`` and
+    ``pfb_control_legacy`` are on (inc:4744); with it off (default) the in-band
+    ``python_control.*`` DNS-TXT branch in ``operate()`` is inert.
+    """
+    val = "on" if on else ""
+    snippet = (
+        f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
+        f"$d['pfb_control_legacy'] = {_php_str(val)};\n"
+        f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $d);\n"
+        "write_config('pfBlockerNG smoke: toggle pfb_control_legacy');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_dnsbl_control_legacy({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def assert_control_ini(vm: SmokeVM, *, control: bool, legacy: bool, timeout: float = 30.0) -> None:
+    """Precondition guard: the generated ini matches the expected control flags.
+
+    Confirms ``python_control`` / ``python_control_legacy`` are ``on``/``off`` in
+    ``pfb_unbound.ini`` so a control assertion can be attributed to the feature gate
+    (not a config-write miss). The reader thread keys on ``python_control``; the
+    DNS-TXT branch keys on ``python_control_legacy``.
+    """
+    ini = vm.ssh("cat", UNBOUND_PFB_INI, timeout=timeout)
+    want_control = "on" if control else "off"
+    want_legacy = "on" if legacy else "off"
+    if not re.search(rf"(?im)^\s*python_control\s*=\s*{want_control}\b", ini.stdout):
+        raise AssertionError(f"python_control != {want_control} in {UNBOUND_PFB_INI}:\n{ini.stdout}")
+    if not re.search(rf"(?im)^\s*python_control_legacy\s*=\s*{want_legacy}\b", ini.stdout):
+        raise AssertionError(f"python_control_legacy != {want_legacy} in {UNBOUND_PFB_INI}:\n{ini.stdout}")
+
+
+def dnsbl_control_cli(vm: SmokeVM, *args: str, timeout: float = 30.0) -> int:
+    """Run the operator CLI ``pfblockerng.sh dnsbl-control <args…>`` ON the guest as root.
+
+    This is the REAL operator entry point: the shell action forwards the positional
+    args to ``pfblockerng.php dnsbl-control``, whose writer validates and publishes the
+    command record to the control channel. Returns the published sequence number parsed
+    from the CLI's ``queued (seq N)`` line. Raises on a non-zero exit or unparsable output
+    so an invalid/rejected command is a hard failure, never a silent pass.
+    """
+    result = vm.ssh("/bin/sh", PFB_SH, "dnsbl-control", *args, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"dnsbl-control {args} failed: rc={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+    m = re.search(r"\(seq\s+(\d+)\)", result.stdout)
+    if not m:
+        raise RuntimeError(f"dnsbl-control {args}: no '(seq N)' in CLI output: {result.stdout!r}")
+    return int(m.group(1))
+
+
+def read_control_applied(vm: SmokeVM, *, timeout: float = 30.0) -> int | None:
+    """The applied-sequence marker the reader publishes, or ``None`` if absent/empty."""
+    return read_py_int(vm, UNBOUND_CONTROL_APPLIED_FILE, timeout=timeout)
+
+
+def wait_control_applied(vm: SmokeVM, seq: int, *, timeout: float = 30.0, interval: float = 1.0) -> int:
+    """Poll the applied marker until it has advanced to (at least) ``seq``; raise on timeout.
+
+    The reader applies the command then republishes the consumed sequence — so the
+    marker reaching ``seq`` proves the command was CONSUMED. A bounded poll (no fixed
+    sleep) mirrors the other async-settle primitives; raising on timeout surfaces "the
+    command was never applied" rather than masking it.
+    """
+    deadline = time.monotonic() + timeout
+    last: int | None = None
+    while time.monotonic() < deadline:
+        last = read_control_applied(vm, timeout=timeout)
+        if last is not None and last >= seq:
+            return last
+        time.sleep(interval)
+    raise RuntimeError(
+        f"wait_control_applied: applied marker never reached seq {seq} within {timeout}s "
+        f"(last seen {last}) — the control reader did not consume the command"
+    )
+
+
+def drill_txt(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> subprocess.CompletedProcess[str]:
+    """Issue a TXT query for ``name`` against the on-box resolver (``drill <name> TXT @127.0.0.1``).
+
+    Used to drive the deprecated in-band ``python_control.<cmd>`` DNS-TXT path: the side
+    effect (whether DNSBL blocking changes) is what the test asserts via a follow-up
+    A-record probe, NOT the TXT answer — so this returns the raw process for diagnostics.
+    """
+    return vm.ssh(f"{DRILL_BIN} {shlex.quote(name)} TXT @127.0.0.1", timeout=timeout)
+
+
+# --------------------------------------------------------------------------- #
 # Python-emitted counts (ADR-06/07) — the values the DNSBL UI aliases read.
 # pfb_unbound.py writes these as BARE relative names ("pfb_py_count",
 # "pfb_py_regex_count"), which resolve against Unbound's chroot CWD (/var/unbound),

--- a/tests/smoke/test_smoke_dnsbl_control.py
+++ b/tests/smoke/test_smoke_dnsbl_control.py
@@ -1,0 +1,221 @@
+"""Live-VM smoke for DNSBL runtime control via the local command channel (PFBL-03).
+
+DNSBL runtime control (disable / enable / addbypass / removebypass) is driven by a
+root-only CLI — ``pfblockerng dnsbl-control …`` (the ``dnsbl-control`` action of the
+package shell script, forwarding to ``pfblockerng.php``). The PHP writer validates the
+command and atomically publishes a JSON record to the chroot channel
+``/var/unbound/pfb_py_control``; the in-module reader thread (``pfb_control_watcher``)
+applies it and republishes the applied sequence to ``/var/unbound/pfb_py_control.applied``.
+The reader thread runs only when the DNSBL Control toggle (``pfb_control`` -> ini
+``python_control``) is on.
+
+A deprecated in-band DNS-TXT control path remains, gated by a separate, default-OFF
+sub-toggle (``pfb_control_legacy`` -> ini ``python_control_legacy``). With it off (the
+default) a ``python_control.*`` DNS-TXT query does nothing; with it on the in-band path
+is honoured again.
+
+These tests drive the REAL paths on a live VM:
+
+* The CLI disables then re-enables DNSBL blocking (asserting the blocked-name shape
+  before and after each command), and the applied-sequence marker advances across them.
+* The CLI adds then removes a per-client bypass for the on-box client (127.0.0.1), so a
+  blocked name resolves clean for that client while the bypass stands.
+* The deprecated DNS-TXT control path is inert by default (a TXT ``python_control.disable``
+  leaves blocking unchanged), and turning its sub-toggle on re-enables that path — proving
+  it is a real gate, not an always-off branch.
+
+Probed ON-BOX (``drill @127.0.0.1``): python-mode DNSBL has no localhost exemption, so a
+blocked name returns its block shape even from 127.0.0.1; the per-client bypass keys on the
+client IP, which an on-box drill presents as 127.0.0.1.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.fixture(scope="module")
+def control_vm(smoke_vm: SmokeVM) -> Iterator[tuple[SmokeVM, str]]:
+    """Deploy once with DNSBL + DNSBL Control on and a single feed-listed blocked domain.
+
+    DNSBL Control is enabled (``pfb_control`` -> ini ``python_control`` on) so the reader
+    thread runs; the legacy DNS-TXT sub-toggle is left OFF (its default). One local feed
+    pins a unique domain to a VIP block; that injection is done ONCE and NOT reloaded
+    between control commands, so the domain stays on the blocklist while the CLI flips
+    runtime state on the live resolver. Yields ``(vm, blocked_domain)``.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+
+    blocked = h.unique_domain("ctlblocked")
+    feed = h.write_local_feed(smoke_vm, "smoke_ctl_feed.txt", f"{blocked}\n")
+    spec = h.DnsblCase(aliasname="smokectl", feed_url=feed, header="smokectl", mode=h.DnsblMode.VIP)
+
+    # DNSBL Control on (reader thread runs), legacy DNS-TXT off (default) — set BEFORE
+    # the reload so the ini is generated with the right flags.
+    h.set_dnsbl_control(smoke_vm, True)
+    h.set_dnsbl_control_legacy(smoke_vm, False)
+    h.inject(smoke_vm, spec)
+    h.reload(smoke_vm, "update")
+
+    # Guard the gate: the reader thread is enabled and the DNS-TXT path is inert by default.
+    h.assert_control_ini(smoke_vm, control=True, legacy=False)
+    try:
+        yield smoke_vm, blocked
+    finally:
+        h.unblock_egress()
+        try:
+            h.clear_dnsbl_settings(smoke_vm)
+        except Exception as cleanup_exc:  # noqa: BLE001
+            print(f"[smoke] clear_dnsbl_settings failed on control teardown (suppressed): {cleanup_exc!r}")
+        h.collect_host_diagnostics(smoke_vm)
+
+
+def test_cli_disable_then_enable_drives_dnsbl(control_vm: tuple[SmokeVM, str]) -> None:
+    """Scenario: the CLI disable/enable toggles DNSBL blocking at runtime.
+
+    Background: DNSBL Control is on (reader thread running) and ``blocked`` is feed-listed.
+    Given the domain is VIP-blocked,
+    When ``dnsbl-control disable`` is applied (reader consumes it),
+    Then the SAME domain resolves clean (not the block shape);
+    When ``dnsbl-control enable`` is applied,
+    Then it is VIP-blocked again.
+    And the applied-sequence marker strictly advances across the two commands — proof the
+    reader consumed each one (not a left-over state).
+    """
+    vm, blocked = control_vm
+
+    # GIVEN: blocked first (the before-state, so the disable's effect is causal).
+    before = h.dns_probe(vm, blocked, "A")
+    assert h.is_vip(before), f"{blocked} expected VIP block before disable, got {before}"
+    applied0 = h.read_control_applied(vm)
+
+    # WHEN: disable. THEN: resolves clean (no VIP).
+    seq_disable = h.dnsbl_control_cli(vm, "disable")
+    h.wait_control_applied(vm, seq_disable)
+    h.flush_unbound_cache(vm)
+    disabled = h.dns_probe(vm, blocked, "A")
+    assert not h.is_vip(disabled), f"{blocked} should resolve clean after disable, still VIP-blocked: {disabled}"
+
+    # WHEN: enable. THEN: VIP-blocked again.
+    seq_enable = h.dnsbl_control_cli(vm, "enable")
+    h.wait_control_applied(vm, seq_enable)
+    h.flush_unbound_cache(vm)
+    reenabled = h.dns_probe(vm, blocked, "A")
+    assert h.is_vip(reenabled), f"{blocked} should be VIP-blocked again after enable, got {reenabled}"
+
+    # AND: the applied marker advanced across both commands.
+    assert seq_enable > seq_disable, f"enable seq {seq_enable} did not advance past disable seq {seq_disable}"
+    final_applied = h.read_control_applied(vm)
+    assert final_applied is not None and final_applied >= seq_enable, (
+        f"applied marker {final_applied} did not advance to the enable seq {seq_enable} "
+        f"(baseline before commands: {applied0})"
+    )
+
+
+def test_cli_addbypass_then_removebypass_exempts_client(control_vm: tuple[SmokeVM, str]) -> None:
+    """Scenario: the CLI add/remove a per-client DNSBL bypass for the on-box client.
+
+    Background: DNSBL Control is on and ``blocked`` is feed-listed; an on-box drill
+    presents as client 127.0.0.1, and the bypass keys on the client IP.
+    Given the domain is VIP-blocked for that client,
+    When ``dnsbl-control addbypass 127.0.0.1`` is applied,
+    Then the domain resolves clean for that client (the bypass stands);
+    When ``dnsbl-control removebypass 127.0.0.1`` is applied,
+    Then it is VIP-blocked again.
+    """
+    vm, blocked = control_vm
+    client = "127.0.0.1"
+
+    # GIVEN: blocked first for the on-box client (the before-state).
+    before = h.dns_probe(vm, blocked, "A")
+    assert h.is_vip(before), f"{blocked} expected VIP block before addbypass, got {before}"
+
+    # WHEN: addbypass the on-box client. THEN: resolves clean for it.
+    seq_add = h.dnsbl_control_cli(vm, "addbypass", client)
+    h.wait_control_applied(vm, seq_add)
+    h.flush_unbound_cache(vm)
+    bypassed = h.dns_probe(vm, blocked, "A")
+    assert not h.is_vip(bypassed), (
+        f"{blocked} should resolve clean for bypassed client {client}, still VIP-blocked: {bypassed}"
+    )
+
+    # WHEN: removebypass. THEN: VIP-blocked again.
+    seq_remove = h.dnsbl_control_cli(vm, "removebypass", client)
+    h.wait_control_applied(vm, seq_remove)
+    h.flush_unbound_cache(vm)
+    restored = h.dns_probe(vm, blocked, "A")
+    assert h.is_vip(restored), f"{blocked} should be VIP-blocked again after removebypass, got {restored}"
+    assert seq_remove > seq_add, f"removebypass seq {seq_remove} did not advance past addbypass seq {seq_add}"
+
+
+def test_legacy_dns_txt_control_inert_by_default(control_vm: tuple[SmokeVM, str]) -> None:
+    """Scenario: the deprecated DNS-TXT control path is inert by default.
+
+    Background: DNSBL Control is on but the legacy DNS-TXT sub-toggle is OFF (its default),
+    so the ini has ``python_control_legacy = off``.
+    Given the domain is VIP-blocked,
+    When an in-band ``python_control.disable`` TXT query is issued on-box,
+    Then DNSBL blocking is UNCHANGED — the domain STAYS VIP-blocked (the DNS-TXT path does
+    nothing). The before/after pair proves it is the disabled gate, not a missed query.
+    """
+    vm, blocked = control_vm
+
+    # GIVEN: the gate is off and the domain is blocked.
+    h.assert_control_ini(vm, control=True, legacy=False)
+    before = h.dns_probe(vm, blocked, "A")
+    assert h.is_vip(before), f"{blocked} expected VIP block before the TXT query, got {before}"
+
+    # WHEN: issue the in-band TXT control query. THEN: still VIP-blocked (path inert).
+    h.drill_txt(vm, "python_control.disable")
+    h.flush_unbound_cache(vm)
+    after = h.dns_probe(vm, blocked, "A")
+    assert h.is_vip(after), (
+        f"{blocked} should STAY VIP-blocked — the legacy DNS-TXT control path must be inert by default, got {after}"
+    )
+
+
+def test_legacy_dns_txt_control_active_when_enabled(control_vm: tuple[SmokeVM, str]) -> None:
+    """Scenario (branch coverage): turning the legacy sub-toggle on re-activates DNS-TXT control.
+
+    Background: the same VM, but the legacy DNS-TXT sub-toggle is flipped ON (ini
+    ``python_control_legacy = on``) and reloaded — proving the default-off behaviour above
+    is a real gate, not an always-off path.
+    Given (after the reload re-initialises blocking) the domain is VIP-blocked,
+    When an in-band ``python_control.disable`` TXT query is issued on-box,
+    Then DNSBL blocking IS disabled — the domain now resolves clean.
+
+    Run LAST: it mutates the module config + reloads; the fixture finalizer restores the
+    baseline DNSBL settings node.
+    """
+    vm, blocked = control_vm
+
+    # Flip the legacy sub-toggle on and reload so the ini regenerates with it on. The reload
+    # restarts Unbound, re-initialising python_blacklist (blocking back on) — so the BEFORE
+    # state below is a fresh block, and the TXT disable's effect is causal.
+    h.set_dnsbl_control_legacy(vm, True)
+    h.reload(vm, "update")
+    h.assert_control_ini(vm, control=True, legacy=True)
+
+    # GIVEN: blocked first (the reload re-enabled blocking).
+    before = h.dns_probe(vm, blocked, "A")
+    assert h.is_vip(before), f"{blocked} expected VIP block after legacy-on reload, got {before}"
+
+    # WHEN: the in-band TXT control query. THEN: blocking is disabled — resolves clean.
+    h.drill_txt(vm, "python_control.disable")
+    h.flush_unbound_cache(vm)
+    after = h.dns_probe(vm, blocked, "A")
+    assert not h.is_vip(after), (
+        f"{blocked} should resolve clean — with the legacy sub-toggle ON the DNS-TXT control path "
+        f"must disable DNSBL, still blocked: {after}"
+    )

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -275,6 +275,28 @@ def test_dnsbl_idn_blocking_fields_render(webui: WebUI, php_error_log_guard: Php
         assert needle in body, f"DNSBL page is missing the IDN-mode marker {needle!r}"
 
 
+def test_dnsbl_control_fields_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The DNSBL Control toggle + its deprecated legacy DNS-TXT sub-toggle (PFBL-03) render
+    cleanly on the DNSBL page — so a regression that drops or breaks either field is caught
+    at the render tier.
+
+    Asserts the page passes the clean-render oracle AND that both POST field names
+    (``pfb_control`` + ``pfb_control_legacy``) and their labels are present in the body.
+    """
+    path = "/pfblockerng/pfblockerng_dnsbl.php"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
+    assert result.ok, f"DNSBL render oracle failed: {result.detail}"
+    body = resp.text
+    for needle in (
+        'name="pfb_control"',
+        'name="pfb_control_legacy"',
+        "DNSBL Control",
+        "DNSBL Control (legacy DNS TXT)",
+    ):
+        assert needle in body, f"DNSBL page is missing the control marker {needle!r}"
+
+
 # ADR-23: the setup wizard's DNSBL step now surfaces ADR-13's pfb_dnsvip_auto auto-VIP
 # toggle. Core wizard.php renders ONE step per GET, indexed by a 0-based `stepid` (verified
 # against pfSense upstream wizard.php: `$stepid` defaults to "0" and indexes $pkg['step']


### PR DESCRIPTION
## Summary

Adds the live-VM (ADR-04) smoke coverage for the merged **PFBL-03** DNSBL control channel + CLI, plus a render assertion for the new DNSBL-page fields.

- `tests/smoke/test_smoke_dnsbl_control.py` (4 tests, `smoke` marker):
  - CLI `disable` → a feed-listed domain resolves clean; `enable` → blocked again; the applied-sequence marker advances (before/after each).
  - CLI `addbypass <client> [sec]` → that client is exempted; `removebypass` → blocked again.
  - The deprecated DNS-TXT control path is **inert by default** (regression proof), and re-activates only when its sub-toggle is enabled (branch coverage).
- New helpers in `tests/smoke/helpers.py` (`dnsbl_control_cli`, `set_dnsbl_control[_legacy]`, `read/wait_control_applied`, `drill_txt`, …); existing harness reused, no logic forked.
- `tests/smoke/ui/test_render_smoke.py`: a focused `ui_render` assertion that the new `pfb_control` / `pfb_control_legacy` fields render on the DNSBL page.

## Validation (live VMs, this branch)

- **Smoke fan-out — CE 2.8 ✅ and Plus 26.03 ✅** (AND-gate green).
- **UI render ✅** for the DNSBL page.
- Off-appliance: `ruff` clean, the 4 smoke tests collect + SKIP cleanly without the VM env, full unit suite green.

Dev-only (`tests/smoke/`) — not shipped in the package. Ref: PFBL-03.

https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added smoke coverage for DNSBL Control runtime management, validating enable/disable behavior, bypass add/remove, and progression of the applied control sequence.
  * Added checks for the deprecated in-band DNS-TXT control path, confirming it is inert by default and becomes active when the legacy sub-toggle is enabled.
  * Added UI rendering validation for DNSBL Control and legacy DNS-TXT configuration toggle fields, including guarding against new PHP error log output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->