### PR TITLE
ADR-22: DNSBL parser — lenient/strict scheme parsing toggle

### DIFF
--- a/.ADRs/ADR_22_DNSBL_Parser_Scheme_Anchored_Host/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_22_DNSBL_Parser_Scheme_Anchored_Host/RESULTS/01_Results.txt
@@ -1,0 +1,139 @@
+================================================================================
+ADR-22 Phase 1 — RESULTS
+Extract pfb_dnsbl_strip_scheme() helper + oracle tests (behaviour-preserving)
+================================================================================
+
+PREREQUISITE (ADR-21 Phase 2 merged to devel) — CONFIRMED
+    git log --oneline origin/devel | grep -i ADR-21 shows the full ADR-21 sequence
+    merged and Accepted, including:
+        b2f33b5  pfblockerng: PHP companion for per-line ABP detection (ADR-21 P2)
+        27973e9  pfb_unbound: per-line ABP detection in build() (ADR-21 P1)
+        118c530  adr: ADR-21 -> Accepted (validated by live CE+Plus smoke)
+    => safe to land ADR-22 Phase 1.
+
+--------------------------------------------------------------------------------
+1. HELPER FUNCTION (exact definition, 4 functional lines)
+--------------------------------------------------------------------------------
+File: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+Definition at line 4012 (preceded by an ADR-22 explanatory comment block):
+
+    function pfb_dnsbl_strip_scheme(string $line): string {
+        if (strpos($line, '://') !== FALSE) {
+            return substr($line, strpos($line, '://') + 3);
+        }
+        return $line;
+    }
+
+(Tabs in source per CLAUDE.md; rendered with spaces here.)
+
+Phase-1 signature is `string` return ONLY — no string|false, no preg_match.
+This is a byte-identical extraction of the former inline logic: strpos() finds
+the FIRST '://' anywhere in the token and substr() strips up to and including
+'//' (the +3 covers ':' + '/' + '/'). Zero behaviour change.
+
+--------------------------------------------------------------------------------
+2. LOCATION IN FILE (near which function)
+--------------------------------------------------------------------------------
+Placed IMMEDIATELY AFTER pfb_strip_trailing_port() (that helper's def is at
+line 3997, closes at 4002). pfb_dnsbl_strip_scheme() def begins at line 4012,
+following the established named-helper pattern in that region.
+
+--------------------------------------------------------------------------------
+3. CALL SITE (exact line number)
+--------------------------------------------------------------------------------
+File: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+Inside sync_package_pfblockerng(), the non-lite block (`if (!$lite) {`):
+
+    line 11237:   $line = pfb_dnsbl_strip_scheme($line);
+
+This replaces the former two inline lines:
+    // If 'http|https|telnet|ftp://' found, remove
+    if (strpos($line, '://') !== FALSE) {
+        $line = substr($line, strpos($line, '://') + 3);
+    }
+
+The surrounding `if (!$lite) { ... }` block and the downstream path/query/
+fragment/port strips (now lines 11239-11266; the prompt's 9679-9706) are
+UNCHANGED. The ADR-21 ||/@@|| guard is untouched.
+
+NOTE on line numbers: the ADR/prompt cited ~9675-9676 (call) and ~9706
+(pfb_strip_trailing_port). Those were approximate against an earlier devel tip;
+PFBL-03 and ADR-21 changes already merged shifted the file. The CODE REGION is
+exactly the one the ADR describes — verified by reading the non-lite block.
+
+--------------------------------------------------------------------------------
+4. PHPUNIT ORACLE TESTS
+--------------------------------------------------------------------------------
+New test class: tests/php/PfbDnsblStripSchemeTest.php
+Class name:     PfbDnsblStripSchemeTest  (final, declare(strict_types=1),
+                #[CoversFunction('pfb_dnsbl_strip_scheme')])
+
+Test methods (all `: void`, typed, intent-named, assert exact return value):
+    a. testHttpSchemeStripped               'http://evil.com/path' -> 'evil.com/path'
+    b. testHttpsSchemeStripped              'https://evil.com'     -> 'evil.com'
+    c. testFtpSchemeStripped                'ftp://evil.com'       -> 'evil.com'
+    d. testTelnetSchemeStripped             'telnet://evil.com'    -> 'evil.com'
+    e. testCustomValidSchemeStripped        'evil://evil.com'      -> 'evil.com'
+    f. testCompoundSchemeStripped           'pkg+https://fakepkg.com' -> 'fakepkg.com'
+    g. testNoSchemeUnchanged                'evil.com'             -> 'evil.com'
+    h. testDigitStartSchemeCurrentBehavior  '123://evil.com'       -> 'evil.com'  [BEFORE-STATE ORACLE]
+    i. testEmptySchemeCurrentBehavior       '://evil.com'          -> 'evil.com'  [BEFORE-STATE ORACLE]
+    j. testMidTokenValidSchemeCurrentBehavior 'evil.com://junk'    -> 'junk'
+
+BEFORE-STATE ORACLES for Phase 2 (their result CHANGES to false under strict):
+    - testDigitStartSchemeCurrentBehavior (h): digit-start scheme is NOT RFC 3986
+      valid; Phase 2 strict mode -> false (skip + log).
+    - testEmptySchemeCurrentBehavior (i): empty scheme prefix; Phase 2 strict
+      mode -> false (skip + log).
+Each carries an inline comment documenting the Phase-2 delta.
+
+UNCHANGED in Phase 2 (valid scheme / documented edge), pinned here as anchors:
+    - a/b/c/d/e/f (valid RFC 3986 schemes, no path) stay accepted.
+    - j (mid-token 'evil.com' is a valid scheme; 'junk' extracted, then rejected
+      downstream by pfb_filter for lacking a '.').
+    - http://evil.com/path (a): helper keeps the path; downstream strips it when
+      lenient ON. (Phase 2 strict mode rejects the path at the helper level.)
+
+--------------------------------------------------------------------------------
+5. VERIFICATION GATE OUTCOMES
+--------------------------------------------------------------------------------
+php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc
+    => No syntax errors detected.
+php -l tests/php/PfbDnsblStripSchemeTest.php
+    => No syntax errors detected.
+vendor/bin/phpunit
+    => OK (525 tests, 1041 assertions). Includes the 10 new oracle tests.
+       (An incidental "/usr/bin/drill: not found" line is emitted by an unrelated
+        pre-existing test exercising a shell path; the suite passes.)
+python -m pytest
+    => 1611 passed. Unchanged — no Python touched this phase.
+ruff check .   => All checks passed!
+ruff format .  => 101 files left unchanged.
+
+Diff scope (git status / git diff origin/devel...HEAD): ONLY
+    M  src/usr/local/pkg/pfblockerng/pfblockerng.inc  (helper + call site)
+    A  tests/php/PfbDnsblStripSchemeTest.php           (oracle test class)
+No other file modified. Matches the Phase-1 constraint exactly.
+
+--------------------------------------------------------------------------------
+6. SELF-REVIEW VERDICT
+--------------------------------------------------------------------------------
+PASS. The helper is a pure, behaviour-preserving extraction (output byte-identical
+for every feed line); the call site replaces exactly the two former inline lines;
+all downstream strips and the ADR-21 guard are untouched; the oracle tests cover
+every input class including the three pathological before-state cases and assert
+exact return values (no coverage theater); the diff is limited to pfblockerng.inc
+and tests/php/. All gates green.
+
+--------------------------------------------------------------------------------
+7. GO-AHEAD FOR PHASE 2
+--------------------------------------------------------------------------------
+GO. The pure, testable seam pfb_dnsbl_strip_scheme() exists with its current
+behaviour pinned. Phase 2 may now: change the return type to string|false, add a
+$strict parameter (default false) doing RFC 3986 scheme validation + path
+rejection, wire the call site with `strict = (pfb_dnsbl_lenient !== 'on')`, add
+the pfb_dnsbl_lenient config key + DNSBL-tab checkbox, the upgrade migration in
+pfblockerng_install.inc (existing install lacking the key -> 'on'), and the
+per-line + per-feed skip logging. Oracle tests h and i are the before-state that
+Phase 2 will flip to false under strict mode.
+================================================================================

--- a/.ADRs/ADR_22_DNSBL_Parser_Scheme_Anchored_Host/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_22_DNSBL_Parser_Scheme_Anchored_Host/RESULTS/02_Results.txt
@@ -1,0 +1,264 @@
+================================================================================
+ADR-22 Phase 2 — RESULTS
+Lenient DNSBL parsing toggle + RFC 3986 validation + migration + skip logging
+================================================================================
+
+PREREQUISITE — Phase 1 handoff (01_Results.txt) confirmed: pfb_dnsbl_strip_scheme()
+extracted, 10 oracle tests green, helper + call-site located. GO recorded for Phase 2.
+
+--------------------------------------------------------------------------------
+1. HELPER pfb_dnsbl_strip_scheme() — final signature + body
+--------------------------------------------------------------------------------
+File: src/usr/local/pkg/pfblockerng/pfblockerng.inc (def follows pfb_strip_trailing_port).
+
+    function pfb_dnsbl_strip_scheme(string $line, bool $strict = FALSE): string|false {
+        $pos = strpos($line, '://');
+        if ($pos === FALSE) {
+            return $line;
+        }
+        if ($strict) {
+            $scheme = substr($line, 0, $pos);
+            if (!preg_match('/^[a-zA-Z][a-zA-Z0-9+\-.]*$/', $scheme)) {
+                return FALSE;
+            }
+        }
+        $remainder = substr($line, $pos + 3);
+        if ($strict) {
+            // A single trailing '/' is the root path -- normalise it away.
+            if (str_ends_with($remainder, '/')) {
+                $remainder = substr($remainder, 0, -1);
+            }
+            // Any remaining '/' means an actual path is present -- reject.
+            if (strpos($remainder, '/') !== FALSE) {
+                return FALSE;
+            }
+        }
+        return $remainder;
+    }
+
+$strict DEFAULTS to FALSE -> Phase-1 oracle tests (no 2nd arg) still pass unmodified.
+return type widened string -> string|false (FALSE = skip+log). Matches ADR §2.4 exactly.
+
+Two NEW sibling helpers (same region) provide the testable call-site seam:
+
+    // per-line: strip + on-reject record parse-error + bump per-feed counter; returns
+    //           kept host string OR FALSE.
+    function pfb_dnsbl_scheme_line(string $line, bool $strict, $header, $oline,
+                                   $logfile, &$skipped): string|false {
+        $stripped = pfb_dnsbl_strip_scheme($line, $strict);
+        if ($stripped === FALSE) {
+            pfb_parsed_fail($header, $line, $oline, $logfile);
+            $skipped++;
+            return FALSE;
+        }
+        return $stripped;
+    }
+
+    // per-feed: one WARNING when something was skipped (silent otherwise).
+    function pfb_dnsbl_scheme_skip_warn($skipped, $header) {
+        if ($skipped > 0) {
+            pfb_logger("\n[ DNSBL ] {$header}: {$skipped} line(s) skipped - strict "
+                . "parsing rejected an invalid scheme or URL path (see DNSBL "
+                . "parse-error log)\n", 2);
+        }
+    }
+(single-line in source; wrapped here for readability.)
+
+--------------------------------------------------------------------------------
+2. CONFIG KEY + exact read path
+--------------------------------------------------------------------------------
+Config key:  pfb_dnsbl_lenient
+Stored in:   installedpackages/pfblockerngdnsblsettings/config/0  (the DNSBL-settings
+             section, read into $pfb['dnsblconfig'] at pfblockerng.inc:1287 and into
+             $pfb['dconfig'] in the UI page).
+
+Read (in pfb_global(), pfblockerng.inc, right after $pfb['dnsbl_global_log']):
+
+    $pfb['dnsbl_lenient'] =
+        (($pfb['dnsblconfig']['pfb_dnsbl_lenient'] ?? '') === 'on') ? 'on' : 'off';
+
+Null-coalesced source (a config predating the key reads '' -> 'off' = strict; no
+undefined-key warning), matching the pfb_idn idiom nearby. Anything but 'on' => 'off'.
+
+--------------------------------------------------------------------------------
+3. UI FIELD — name + help text
+--------------------------------------------------------------------------------
+File: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php   (the actual DNSBL-tab page;
+      the prompt/ADR named pfblockerng_general.php, but the DNSBL config section + all
+      sibling DNSBL toggles — pfb_cname, pfb_hsts, pfb_idn, … — live HERE, keyed to
+      pfblockerngdnsblsettings. Followed CLAUDE.md "read the file, don't guess paths":
+      a checkbox in pfblockerng_general.php would not persist to the DNSBL section the
+      parser reads. Placed in the "DNSBL Python Configuration" section after pfb_cname.)
+
+Field id:   pfb_dnsbl_lenient   (Form_Checkbox, value 'on'; checked iff pconfig === 'on')
+Label:      "Lenient feed parsing"
+Help:       'Parse DNSBL feed lines permissively: any <scheme://> is stripped and URL
+             paths are removed.
+             When disabled (strict), lines with an invalid scheme (e.g. 123://) or a
+             URL path are skipped and logged.
+             New installs default to disabled (strict); upgraded installs keep the
+             permissive behaviour.'
+            (<strong>-marked tokens in source; brief, matches neighbour help length.)
+
+$pconfig read:  $pconfig['pfb_dnsbl_lenient'] = $pfb['dconfig']['pfb_dnsbl_lenient'] ?: '';
+                (absent => '' => unchecked = strict for NEW installs.)
+Save:           $pfb['dconfig']['pfb_dnsbl_lenient'] =
+                    pfb_filter($_POST['pfb_dnsbl_lenient'], PFB_FILTER_ON_OFF, 'dnsbl') ?: '';
+                (identical idiom to every sibling on/off DNSBL toggle.)
+
+--------------------------------------------------------------------------------
+4. CALL-SITE wiring (resolution + skip + counter)
+--------------------------------------------------------------------------------
+sync_package_pfblockerng(), the non-lite block (`if (!$lite) {`):
+
+    $strict = ($pfb['dnsbl_lenient'] !== 'on');
+    $line = pfb_dnsbl_scheme_line($line, $strict, $header, $oline,
+        $pfb['dnsbl_parse_err'], $pfb_scheme_skipped);
+    if ($line === FALSE) {
+        continue;
+    }
+
+Counter init:  $pfb_scheme_skipped = 0;  placed with the other per-feed resets
+               ($ipcount = $ip_cnt = $ip_cnt6 = 0;) BEFORE the per-line while loop,
+               so it resets once per feed.
+
+Per-feed WARNING: emitted AFTER the per-line loop closes (right after the $fhandle
+               fclose), still inside the per-feed `foreach ($list['row'] ...)` iteration:
+
+    pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);
+
+=> ONE summary line per feed, never per skipped line. Lenient mode never increments
+   $pfb_scheme_skipped, so the warning stays silent => byte-identical to today.
+
+The old `// If 'http|https|telnet|ftp://' found, remove (ADR-22)` comment is replaced by a
+comment stating the ADR-22 behaviour. Downstream path/query/fragment/port strips
+(unchanged) still run when lenient (only valid, path-free hosts reach them under strict).
+
+--------------------------------------------------------------------------------
+5. MAIN-LOG function / level for the WARNING
+--------------------------------------------------------------------------------
+pfb_logger($log, 2)  — logtype 2 = "Print to pfBlockerNG log AND Error log" (same level
+the sibling "Header Field cannot be empty. *Skipping*" feed warning uses). Per-line sink
+is the existing pfb_parsed_fail(..., $pfb['dnsbl_parse_err']) CSV parse-error log.
+
+--------------------------------------------------------------------------------
+6. MIGRATION — location + existing-vs-fresh detection
+--------------------------------------------------------------------------------
+Pure decision fn (pfblockerng.inc, after pfb_control_legacy_seed):
+
+    function pfb_dnsbl_lenient_migrate($dconfig) {
+        if (!is_array($dconfig) || empty($dconfig)) { return NULL; }   // fresh install
+        if (isset($dconfig['pfb_dnsbl_lenient']))   { return NULL; }   // never overwrite
+        $dconfig['pfb_dnsbl_lenient'] = 'on';
+        return $dconfig;
+    }
+
+Existing-vs-fresh detection: a NON-EMPTY $dconfig (a populated DNSBL config/0 section) =
+an UPGRADE; an empty/absent section = a first-ever install => NULL => no write => the
+new-install strict default (unchecked, 'off') stands. This is the SAME predicate the
+adjacent ADR-02 migration block uses (`!empty($cfg)`), so it is consistent in-file.
+
+Call site (pfblockerng_install.inc, after the PFBL-03 seed block):
+
+    $cfg = config_get_path('installedpackages/pfblockerngdnsblsettings/config/0', []);
+    $cfg_lenient = pfb_dnsbl_lenient_migrate($cfg);
+    if ($cfg_lenient !== NULL) {
+        config_set_path('installedpackages/pfblockerngdnsblsettings/config/0', $cfg_lenient);
+        write_config('pfBlockerNG: preserve permissive DNSBL parsing for existing install (ADR-22 migration)');
+    }
+    unset($cfg, $cfg_lenient);
+
+Extracted as a pure fn (mirrors pfb_control_legacy_seed) precisely so it is unit-testable
+off-appliance; the top-level install.inc code is procedural and not directly testable.
+
+--------------------------------------------------------------------------------
+7. PHPUNIT — test classes + method names
+--------------------------------------------------------------------------------
+tests/php/PfbDnsblStripSchemeTest.php  (Phase-1 oracles UNMODIFIED + Phase-2 toggle cases):
+  Phase-1 (unchanged): testHttpSchemeStripped, testHttpsSchemeStripped,
+    testFtpSchemeStripped, testTelnetSchemeStripped, testCustomValidSchemeStripped,
+    testCompoundSchemeStripped, testNoSchemeUnchanged, testDigitStartSchemeCurrentBehavior,
+    testEmptySchemeCurrentBehavior, testMidTokenValidSchemeCurrentBehavior
+  Phase-2 lenient (strict=false passthrough):
+    testInvalidSchemePassthroughWhenLenient, testEmptySchemePassthroughWhenLenient,
+    testPathPassthroughWhenLenient
+  Phase-2 strict (strict=true, before-state lenient asserted first on each transition):
+    testInvalidSchemeRejectedWhenStrict, testEmptySchemeRejectedWhenStrict,
+    testSpecialCharsSchemeRejectedWhenStrict, testPathRejectedWhenStrict,
+    testTrailingSlashNormalisedWhenStrict, testPathAfterRootSlashRejectedWhenStrict
+  Regression guards (valid scheme accepted in BOTH states):
+    testValidSchemeAcceptedWhenLenient, testValidSchemeAcceptedWhenStrict,
+    testCompoundSchemeWhenStrict, testNoSchemeWhenStrict
+
+tests/php/PfbDnsblLenientMigrateTest.php  (#[CoversFunction pfb_dnsbl_lenient_migrate]):
+    testMigrationSkipsFreshInstall (empty + null -> NULL),
+    testMigrationSetsLenientOnForExistingInstallMissingKey (before: no key; after: 'on';
+      siblings preserved),
+    testMigrationDoesNotOverwriteExistingValue ('off' stays -> NULL),
+    testMigrationDoesNotOverwriteExistingOnValue ('on' stays -> NULL)
+
+tests/php/PfbDnsblSchemeSkipLogTest.php  (#[CoversFunction pfb_dnsbl_scheme_line,
+    pfb_dnsbl_scheme_skip_warn]):
+    testStrictResolvesTrueWhenLenientOff, testStrictResolvesFalseWhenLenientOn
+      (the `strict = lenient !== 'on'` predicate, both branches),
+    testStrictSkipIsLogged (FALSE returned, counter=1, parse-error CSV written w/ header+line),
+    testLenientEmitsNoNewLog (same input lenient -> kept 'evil.com', counter=0, log empty),
+    testValidSchemeLineKeptInStrictWithoutLogging (strict must not skip a valid line),
+    testPerFeedWarningEmittedOnceWhenSkipped (one WARNING, names feed + count;
+      substr_count('line(s) skipped')==1),
+    testPerFeedWarningSilentWhenNothingSkipped (count 0 -> log empty)
+
+Skip-log tests exercise the REAL pfb_parsed_fail()/pfb_logger() (shipped code), pointed at
+tempnam() files (parse-error log via the $logfile param; main log via $GLOBALS['pfb']['log']),
+then read the file back and assert the contents — not coverage theater.
+
+--------------------------------------------------------------------------------
+8. VERIFICATION GATE OUTCOMES
+--------------------------------------------------------------------------------
+php -l pfblockerng.inc            => No syntax errors detected.
+php -l pfblockerng_install.inc    => No syntax errors detected.
+php -l pfblockerng_dnsbl.php      => No syntax errors detected.
+vendor/bin/phpunit               => OK (549 tests, 1088 assertions). +24 over Phase 1's 525.
+                                    (incidental "/usr/bin/drill: not found" line is the
+                                     pre-existing unrelated test noise noted in Phase 1.)
+vendor/bin/phpstan analyse       => [OK] No errors.
+vendor/bin/phpcs                 => clean (PFBL-01 RequirePfbFilter sniff passes; the new
+                                    helpers are not in-scope sinks).
+python -m pytest                 => 1611 passed. Unchanged (no Python touched).
+ruff check . && ruff format .    => All checks passed! / 101 files left unchanged.
+
+Diff scope (git diff origin/devel...HEAD, Phase-2 working set) — ONLY:
+    M src/usr/local/pkg/pfblockerng/pfblockerng.inc
+    M src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+    M src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+    M tests/php/PfbDnsblStripSchemeTest.php
+    A tests/php/PfbDnsblLenientMigrateTest.php
+    A tests/php/PfbDnsblSchemeSkipLogTest.php
+Matches the Phase-2 CONSTRAINTS exactly. No log double needed in pfsense_doubles.php —
+the real pfb_parsed_fail/pfb_logger write to test-controlled temp paths.
+
+--------------------------------------------------------------------------------
+9. EDGE CASES / NOTES
+--------------------------------------------------------------------------------
+- 'http://evil.com/path/' (trailing slash AFTER a path): strict normalises the single
+  trailing '/', but a '/' remains -> FALSE. Guards a "strip the last slash" bypass
+  (testPathAfterRootSlashRejectedWhenStrict).
+- 'ftp://ftp.evil.com/' (root-slash only): strict returns 'ftp.evil.com' (ADR §2.6.5).
+- pfb_filter() remains the unconditional domain gate downstream (untouched).
+- ADR-21 ||/@@|| guard, lite path, ABP path: untouched.
+- UI file is pfblockerng_dnsbl.php, NOT pfblockerng_general.php (the ADR/prompt named the
+  latter; the DNSBL config section actually lives in the former — see §3). This is the
+  single intentional deviation, forced by reading the source; it makes the checkbox
+  persist to the section pfb_global() reads.
+
+--------------------------------------------------------------------------------
+10. GO-AHEAD FOR PHASE 3 (DoD smoke)
+--------------------------------------------------------------------------------
+GO. The toggle, RFC 3986 validation, migration, and per-line + per-feed skip logging are
+implemented and unit-proven (both states, before+after, migration 3 ways, log fires/silent,
+warning once-per-feed). Phase 3 may now stand up the live-VM smoke: lenient OFF (strict) ->
+123:// + http://host/path skipped (parse-error log + per-feed WARNING), evil://host +
+http://host blocked; lenient ON -> 123:// + http://host/path blocked; migration: an existing
+install upgraded -> pfb_dnsbl_lenient = 'on'. The UI checkbox is on the DNSBL tab
+(pfblockerng_dnsbl.php), field id 'pfb_dnsbl_lenient'.
+================================================================================

--- a/.ADRs/ADR_22_DNSBL_Parser_Scheme_Anchored_Host/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_22_DNSBL_Parser_Scheme_Anchored_Host/RESULTS/03_Results.txt
@@ -1,0 +1,168 @@
+================================================================================
+ADR-22 Phase 3 — RESULTS  (FINAL — ADR-22 complete)
+Live-VM smoke for both toggle states + the migration; DoD evidence
+================================================================================
+
+PREREQUISITE — Phase 2 handoff (02_Results.txt) confirmed complete: the
+pfb_dnsbl_lenient toggle, RFC 3986 scheme validation + path rejection, the upgrade
+migration, and the per-line + per-feed skip logging are all wired and PHPUnit-proven
+(549 tests OK). Exact names trusted from 02_Results.txt:
+  - config key       : pfb_dnsbl_lenient (installedpackages/pfblockerngdnsblsettings/config/0)
+  - UI field         : checkbox 'pfb_dnsbl_lenient' on the DNSBL tab (pfblockerng_dnsbl.php)
+  - parse-error log  : $pfb['dnsbl_parse_err'] = /var/log/pfblockerng/dnsbl_parsed_error.log
+  - main-log WARNING : pfb_logger(..., 2)  (logtype 2 = pfBlockerNG log + Error log)
+                       text (inc:4073): "\n[ DNSBL ] {header}: {N} line(s) skipped -
+                       strict parsing rejected an invalid scheme or URL path (see DNSBL
+                       parse-error log)\n"
+  - migration fn     : pfb_dnsbl_lenient_migrate($dconfig)  (pfblockerng.inc:6278),
+                       called from the upgrade hook (pfblockerng_install.inc:138-142).
+
+--------------------------------------------------------------------------------
+1. WHAT PHASE 3 ADDED  (diff scope: tests/smoke/ ONLY)
+--------------------------------------------------------------------------------
+tests/smoke/helpers.py:
+  + set_dnsbl_lenient(vm, on)  — set pfb_dnsbl_lenient 'on'/'off' via the config API
+                                 (array_merge into CFG_DNSBL_SETTINGS + write_config),
+                                 mirroring set_dnsbl_enabled. Set BEFORE the reload.
+  + read_log_file(vm, path)    — cat a guest log file (-> '' if absent) for asserting
+                                 the parse-error-log skip records.
+  + DNSBL_PARSE_ERR_LOG        — "/var/log/pfblockerng/dnsbl_parsed_error.log"
+                                 (mirrors $pfb['dnsbl_parse_err']).
+
+tests/smoke/test_smoke_feeds.py — three @pytest.mark.smoke + @pytest.mark.timeout(300)
+cases, every domain via helpers.unique_domain(), full config + feed cleanup in finally.
+Delivery: a header-less LOCAL feed (write_local_feed) carrying runtime uuids — the same
+mechanism test_abp_perline_detection_in_plain_feed uses; the scheme lines flow through
+the SAME non-lite download loop the GUI Custom_List feeds via its synthetic row, so the
+gated behaviour (the loop) is faithfully exercised. Tests A/B drive
+inject -> set_dnsbl_lenient -> reload('update') manually (NOT CaseContext, which
+injects+reloads atomically before the toggle could be set).
+
+  A) test_strict_skips_invalid_scheme_and_path_and_logs  (lenient OFF / strict)
+     Feed: http://<http>, evil://<evil>, 123://<bad>, http://<path>/path
+     Asserts BEFORE: all four resolve via the stub (STUB_DNS_A), none blocked.
+     Asserts AFTER (lenient OFF):
+       <http>  -> blocked  (VIP or NULL; valid scheme, no path)
+       <evil>  -> blocked  (valid custom RFC 3986 scheme, no path)
+       <bad>   -> still RESOLVES via stub (123:// rejected -> skipped)
+       <path>  -> still RESOLVES via stub (URL path rejected -> skipped)
+     Asserts LOGGING (ADR §2.3):
+       - <bad> AND <path> labels present in DNSBL_PARSE_ERR_LOG (per-line sink);
+       - per-feed WARNING "<header>: 2 line(s) skipped" count in PFB_LOG strictly
+         greater than the pre-update baseline (proves THIS update emitted it).
+
+  B) test_lenient_blocks_invalid_scheme_and_path  (lenient ON)
+     Feed: 123://<bad>, http://<path>/path
+     Asserts BEFORE: both resolve via the stub, none blocked.
+     Asserts AFTER (lenient ON):
+       <bad>  -> blocked  (123:// stripped -> today's behaviour)
+       <path> -> blocked  (path stripped downstream -> today's behaviour)
+     Asserts LOGGING: NO new "line(s) skipped - strict parsing" WARNING (count
+       unchanged) AND no per-feed WARNING naming this feed (lenient is silent).
+     Pairing B (ON) with A (OFF) on the SAME malformed inputs proves the toggle is a
+     real branch — A skips+logs them, B blocks them silently — not an always-X path.
+
+  C) test_migration_sets_lenient_on_for_existing_install
+     Drives the SHIPPED migration decision (pfb_dnsbl_lenient_migrate) against the REAL
+     on-box config store — the exact two-line install-hook body:
+       BEFORE: populate the DNSBL section (existing install) + remove pfb_dnsbl_lenient;
+               assert it is ABSENT (config_get -> '').
+       WHEN  : require pfblockerng.inc; run pfb_dnsbl_lenient_migrate($cfg); if non-NULL,
+               config_set_path + write_config; assert the fn returned SET (not NULL).
+       AFTER : assert the live config now reads pfb_dnsbl_lenient == 'on'.
+     Restores lenient=ON in finally.
+
+--------------------------------------------------------------------------------
+2. SMOKE RUN — DISPATCH IS THE ORCHESTRATOR'S STEP (run ID PENDING)
+--------------------------------------------------------------------------------
+This phase was executed in a clean-context environment with NO `gh` and NO live VM, so
+the live-VM smoke was NOT dispatched here. The tests are AUTHORED, parse, and collect
+cleanly (collection verified off-box; see §3). The live dispatch + run-ID capture is the
+orchestrator's step:
+
+    gh workflow run smoke.yml -f pytest_marker=smoke           # single-leg
+    gh workflow run smoke-fanout.yml                           # CE + Plus fan-out
+                                                               #   (acceptance validation)
+
+Capture the run ID(s) and the per-case PASS (A, B, C) + exact `drill` outputs + the
+observed parse-error-log lines and main-log WARNING text, and the migration before/after,
+into this section before flipping ADR-22 to Accepted. Expected per the test assertions:
+  - A: drill <http>/<evil> -> NOERROR + VIP (10.10.10.1) or NULL (0.0.0.0/::);
+       drill <bad>/<path>  -> NOERROR + STUB_DNS_A (resolves, skipped);
+       dnsbl_parsed_error.log contains the <bad> + <path> labels;
+       pfblockerng.log contains "[ DNSBL ] smokeadr22strict: 2 line(s) skipped - strict
+       parsing rejected an invalid scheme or URL path (see DNSBL parse-error log)".
+  - B: drill <bad>/<path> -> NOERROR + VIP/NULL (blocked); no strict-skip WARNING.
+  - C: config pfb_dnsbl_lenient '' (before) -> 'on' (after).
+
+--------------------------------------------------------------------------------
+3. OFF-BOX VERIFICATION GATES — ALL GREEN
+--------------------------------------------------------------------------------
+python -m pytest                  => 1611 passed (UNCHANGED from Phase 1/2; smoke is
+                                     deselected via --ignore=tests/smoke).
+ruff check .                      => All checks passed!
+ruff format --check .             => 102 files already formatted.
+mypy tests/                       => Success: no issues found in 42 source files.
+                                     (tests/smoke is excluded from mypy by config; the
+                                      non-smoke suite still type-checks clean.)
+php -l pfblockerng.inc            => No syntax errors detected. (No PHP change this phase;
+                                     the call-site comment was already ADR-22-correct from
+                                     Phase 2.)
+vendor/bin/phpunit               => OK (549 tests, 1088 assertions) — Phases 1-2 all still
+                                     pass. (Incidental "/usr/bin/drill: not found" line is
+                                     pre-existing unrelated test noise.)
+Smoke collect-only               => `python -m pytest tests/smoke/test_smoke_feeds.py
+                                     --collect-only -q` collects 13 tests incl. the 3 new
+                                     ADR-22 cases — no import/syntax error, markers correct
+                                     (@pytest.mark.smoke via module pytestmark; the
+                                     PytestUnknownMark(timeout) warning is pre-existing —
+                                     pytest-timeout is a CI-only dep, same as the ADR-21
+                                     cases).
+
+git diff origin/devel...HEAD (Phase-3 working set) — ONLY:
+    M tests/smoke/helpers.py
+    M tests/smoke/test_smoke_feeds.py
+(plus the Phases 1-2 committed files + RESULTS/01,02). Matches the Phase-3 constraint
+(diff limited to tests/smoke/; no PHP touched).
+
+--------------------------------------------------------------------------------
+4. ACCEPTANCE DETERMINATION
+--------------------------------------------------------------------------------
+Per CLAUDE.md "ADR acceptance — automated tests, not a manual maintainer sign-off":
+ADR-22 flips to Accepted on GREEN automated coverage that PROVES the behaviour + GUARDS
+regression, across the live-VM fan-out (CE + Plus). The coverage is in place:
+
+  - PHPUnit (Phases 1-2, 549 tests): the helper both states + the pathological inputs,
+    the migration 3 ways (set / no-overwrite-off / no-overwrite-on / fresh-skip), and the
+    per-line + per-feed skip-log emission (fires on skip, silent on lenient, once-per-feed)
+    — all asserting real values against temp-file reads, before-and-after, not theater.
+  - Smoke (this phase): both toggle states on the live box (A strict skips+logs, B lenient
+    blocks silently — the SAME malformed inputs, proving the branch) + the migration
+    (C: absent -> 'on'), each asserting DNS block-shapes AND the skip logging, with the
+    before-state asserted first.
+
+=> The automated coverage SUFFICES to flip ADR-22 to Accepted ONCE the live smoke
+   fan-out is GREEN. The flip is gated on the orchestrator dispatching smoke.yml /
+   smoke-fanout.yml and recording the green run ID(s) in §2 — it is NOT yet green here
+   (no dispatch was possible in this environment).
+
+DOCUMENTED OUT-OF-CI LIMITATION (per CLAUDE.md):
+  - Migration live leg (Test C) drives the SHIPPED migration FUNCTION
+    (pfb_dnsbl_lenient_migrate) against the REAL on-box config store — the exact body the
+    upgrade hook runs — but does NOT `require` the full pfblockerng_install.inc end to end
+    (that would re-run every unrelated install migration — VIP, python-mode, PFBL-03 — and
+    all their side effects on the live box). The load-bearing ADR-22 behaviour (an existing
+    install lacking the key -> 'on', never overwriting a present value) IS exercised live
+    here and is additionally pinned in PHPUnit (PfbDnsblLenientMigrateTest). The full
+    install-include require-flow is the documented out-of-CI limitation, not an acceptance
+    blocker.
+
+--------------------------------------------------------------------------------
+5. FINAL — ADR-22 COMPLETE
+--------------------------------------------------------------------------------
+All three phases implemented and verified off-box. Single Phase-3 commit (tests/smoke/ +
+this handoff) pushed to adr/22-dnsbl-parser-scheme-anchored-host (rebased onto the latest
+origin/devel first). The orchestrator lands the ADR (PR + merge) and dispatches the live
+smoke fan-out; record the green run ID(s) + per-case evidence in §2 and flip the ADR
+Status to Accepted.
+================================================================================

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1353,6 +1353,10 @@ function pfb_global() {
 	$pfb['dnsbl_alexatype'] = isset($pfb['dnsblconfig']['alexa_type'])	? $pfb['dnsblconfig']['alexa_type'] 	 : 'tranco';	// TOP1M type (Tranco, Alexa or Cisco)
 	$pfb['dnsbl_res_cache']	= $pfb['dnsblconfig']['pfb_cache'];									// DNSBL Option to backup/restore Resolver cache
 	$pfb['dnsbl_global_log']= isset($pfb['dnsblconfig']['global_log']) 	? $pfb['dnsblconfig']['global_log']	 : '';		// Global Logging/Blocking mode
+	// ADR-22: lenient feed parsing. 'on' = permissive scheme strip (today); anything else =
+	// strict RFC 3986 scheme validation + URL-path rejection. New installs default OFF
+	// (strict); existing installs are migrated to 'on' on upgrade (pfb_dnsbl_lenient_migrate).
+	$pfb['dnsbl_lenient']	= (($pfb['dnsblconfig']['pfb_dnsbl_lenient'] ?? '') === 'on') ? 'on' : 'off';			// DNSBL scheme-parsing leniency
 
 	$pfb['dnsbl_py_reply']	= $pfb['dnsblconfig']['pfb_py_reply'];			// DNSBL Resolver python DNS Reply logging
 	$pfb['dnsbl_hsts']	= $pfb['dnsblconfig']['pfb_hsts'];			// DNSBL Resolver python block HSTS via Null Blocking mode
@@ -4002,18 +4006,72 @@ function pfb_strip_trailing_port($line) {
 }
 
 
-// ADR-22 Phase 1: extract the non-lite scheme strip into a named, testable helper.
-// If a '<scheme>://' is present, strip everything up to and including the first '://'
-// and return the remainder; otherwise return the line unchanged. Behaviour-preserving
-// extraction of the former inline logic -- strpos() finds the FIRST '://' anywhere in the
-// token, so today's permissive cases ('123://evil.com', '://evil.com', mid-token schemes)
-// are kept byte-identical. Phase 2 adds a $strict toggle (RFC 3986 scheme validation +
-// path rejection) returning string|false; Phase 1 returns string only.
-function pfb_dnsbl_strip_scheme(string $line): string {
-	if (strpos($line, '://') !== FALSE) {
-		return substr($line, strpos($line, '://') + 3);
+// ADR-22: the non-lite scheme strip, gated on the 'pfb_dnsbl_lenient' toggle.
+//
+// No '://' present  -> return the line unchanged (no scheme to strip).
+//
+// $strict === FALSE (lenient -- today's behaviour, byte-identical): strip everything up to
+// and including the FIRST '://' and return the remainder (paths/query/port handled
+// downstream). strpos() finds the first '://' anywhere, so the permissive cases
+// ('123://evil.com', '://evil.com', mid-token schemes) are accepted exactly as before. The
+// $strict parameter DEFAULTS to FALSE so callers (and the Phase-1 oracle tests) that pass no
+// second argument observe this unchanged behaviour.
+//
+// $strict === TRUE (lenient OFF): validate the text before '://' against the RFC 3986 scheme
+// grammar (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )); an invalid scheme returns FALSE.
+// A single trailing '/' (root path) is normalised away; any remaining '/' is an actual path
+// and returns FALSE. A FALSE return tells the caller to skip + log the line (ADR §2.3/§2.4).
+function pfb_dnsbl_strip_scheme(string $line, bool $strict = FALSE): string|false {
+	$pos = strpos($line, '://');
+	if ($pos === FALSE) {
+		return $line;
 	}
-	return $line;
+	if ($strict) {
+		$scheme = substr($line, 0, $pos);
+		if (!preg_match('/^[a-zA-Z][a-zA-Z0-9+\-.]*$/', $scheme)) {
+			return FALSE;
+		}
+	}
+	$remainder = substr($line, $pos + 3);
+	if ($strict) {
+		// A single trailing '/' is the root path -- normalise it away.
+		if (str_ends_with($remainder, '/')) {
+			$remainder = substr($remainder, 0, -1);
+		}
+		// Any remaining '/' means an actual path is present -- reject.
+		if (strpos($remainder, '/') !== FALSE) {
+			return FALSE;
+		}
+	}
+	return $remainder;
+}
+
+
+// ADR-22: per-line scheme parse for the non-lite download path. Returns the parsed host
+// string to keep, or FALSE when strict parsing rejected the line (invalid scheme or a URL
+// path). On rejection it records the line in the DNSBL parse-error log (the established
+// per-line sink) and increments the per-feed skip counter so the caller can emit one summary
+// WARNING (pfb_dnsbl_scheme_skip_warn) after the feed. In lenient mode it never rejects, so
+// the counter is untouched and no parse-error line is written -- byte-identical to today.
+function pfb_dnsbl_scheme_line(string $line, bool $strict, $header, $oline, $logfile, &$skipped): string|false {
+	$stripped = pfb_dnsbl_strip_scheme($line, $strict);
+	if ($stripped === FALSE) {
+		pfb_parsed_fail($header, $line, $oline, $logfile);
+		$skipped++;
+		return FALSE;
+	}
+	return $stripped;
+}
+
+
+// ADR-22: the once-per-feed strict-parsing skip summary. A WARNING to the main pfBlockerNG
+// log (and error log -- logtype 2) naming the feed + the count, so a feed with many
+// malformed lines summarises in one line (per-line detail stays in the parse-error log).
+// Silent when nothing was skipped (lenient mode never increments the counter).
+function pfb_dnsbl_scheme_skip_warn($skipped, $header) {
+	if ($skipped > 0) {
+		pfb_logger("\n[ DNSBL ] {$header}: {$skipped} line(s) skipped - strict parsing rejected an invalid scheme or URL path (see DNSBL parse-error log)\n", 2);
+	}
 }
 
 
@@ -6203,6 +6261,29 @@ function pfb_control_legacy_seed($dconfig) {
 		$dconfig['pfb_control_legacy'] = 'on';
 	}
 	$dconfig['pfb_control_legacy_seeded'] = 'on';
+	return $dconfig;
+}
+
+
+// ADR-22: one-time upgrade migration for the 'pfb_dnsbl_lenient' DNSBL scheme-parsing
+// toggle. $dconfig is the existing DNSBL-settings 'config/0' node. New installs default to
+// OFF (strict RFC 3986 parsing); an EXISTING install (a non-empty config section) that
+// predates this key is migrated to 'on' (lenient) to preserve the permissive behaviour it
+// already relies on -- malformed-scheme lines were silently accepted/blocked before. Keying
+// on a non-empty $dconfig distinguishes an upgrade from a first-ever install (which has no
+// prior config section, so the new-install strict default stands). Migration ONLY sets a
+// missing key -- an existing 'on'/'off' value is never overwritten. Returns the updated
+// config array to persist, or NULL when nothing should change (fresh install, or the key
+// already present).
+function pfb_dnsbl_lenient_migrate($dconfig) {
+
+	if (!is_array($dconfig) || empty($dconfig)) {
+		return NULL;
+	}
+	if (isset($dconfig['pfb_dnsbl_lenient'])) {
+		return NULL;
+	}
+	$dconfig['pfb_dnsbl_lenient'] = 'on';
 	return $dconfig;
 }
 
@@ -10910,6 +10991,7 @@ function sync_package_pfblockerng($cron='') {
 								$run_once = $csv_parser = FALSE;
 								$csv_type = '';
 								$ipcount = $ip_cnt = $ip_cnt6 = 0;
+								$pfb_scheme_skipped = 0;	// ADR-22: per-feed strict scheme/path skips
 
 								// Parse downloaded file for Domain names
 								if (($fhandle = @fopen("{$file_dwn}.orig", 'r')) !== FALSE) {
@@ -11233,8 +11315,18 @@ function sync_package_pfblockerng($cron='') {
 
 											if (!$lite) {
 
-												// If 'http|https|telnet|ftp://' found, remove (ADR-22)
-												$line = pfb_dnsbl_strip_scheme($line);
+												// ADR-22: strip the '<scheme>://' prefix. Lenient (toggle ON,
+												// the migrated/legacy default) keeps today's permissive strip;
+												// strict (toggle OFF, the new-install default) validates the
+												// scheme against RFC 3986 and rejects URL paths -- a rejected
+												// line is skipped, recorded per-line in the parse-error log, and
+												// counted for the once-per-feed summary WARNING below.
+												$strict = ($pfb['dnsbl_lenient'] !== 'on');
+												$line = pfb_dnsbl_scheme_line($line, $strict, $header, $oline,
+													$pfb['dnsbl_parse_err'], $pfb_scheme_skipped);
+												if ($line === FALSE) {
+													continue;
+												}
 
 												// If '/' character found, remove characters after '/'
 												if (strpos($line, '/') !== FALSE) {
@@ -11344,6 +11436,11 @@ function sync_package_pfblockerng($cron='') {
 								if ($fhandle) {
 									@fclose($fhandle);
 								}
+
+								// ADR-22: one WARNING per feed summarising strict-mode skips (silent
+								// when none -- lenient never increments the counter).
+								pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);
+
 								if (isset($csvline)) {
 									unset($csvline);
 								}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4002,6 +4002,21 @@ function pfb_strip_trailing_port($line) {
 }
 
 
+// ADR-22 Phase 1: extract the non-lite scheme strip into a named, testable helper.
+// If a '<scheme>://' is present, strip everything up to and including the first '://'
+// and return the remainder; otherwise return the line unchanged. Behaviour-preserving
+// extraction of the former inline logic -- strpos() finds the FIRST '://' anywhere in the
+// token, so today's permissive cases ('123://evil.com', '://evil.com', mid-token schemes)
+// are kept byte-identical. Phase 2 adds a $strict toggle (RFC 3986 scheme validation +
+// path rejection) returning string|false; Phase 1 returns string only.
+function pfb_dnsbl_strip_scheme(string $line): string {
+	if (strpos($line, '://') !== FALSE) {
+		return substr($line, strpos($line, '://') + 3);
+	}
+	return $line;
+}
+
+
 // ADR-21: whole-feed ABP header sniff. A line in a feed's leading '!'-comment block
 // that starts (leading whitespace tolerated) with '[Adblock', '[uBlock', or '! Title:'
 // flags the feed as whole-feed ABP ($easylist = TRUE). The three generic prefixes are a
@@ -11218,10 +11233,8 @@ function sync_package_pfblockerng($cron='') {
 
 											if (!$lite) {
 
-												// If 'http|https|telnet|ftp://' found, remove
-												if (strpos($line, '://') !== FALSE) {
-													$line = substr($line, strpos($line, '://') + 3);
-												}
+												// If 'http|https|telnet|ftp://' found, remove (ADR-22)
+												$line = pfb_dnsbl_strip_scheme($line);
 
 												// If '/' character found, remove characters after '/'
 												if (strpos($line, '/') !== FALSE) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4065,12 +4065,12 @@ function pfb_dnsbl_scheme_line(string $line, bool $strict, $header, $oline, $log
 
 
 // ADR-22: the once-per-feed strict-parsing skip summary. A WARNING to the main pfBlockerNG
-// log (and error log -- logtype 2) naming the feed + the count, so a feed with many
-// malformed lines summarises in one line (per-line detail stays in the parse-error log).
-// Silent when nothing was skipped (lenient mode never increments the counter).
+// log only (logtype 1) naming the feed + the count, so a feed with many malformed lines
+// summarises in one line (per-line detail stays in the DNSBL parse-error log; the summary
+// is not error-log noise). Silent when nothing was skipped (lenient never bumps the counter).
 function pfb_dnsbl_scheme_skip_warn($skipped, $header) {
 	if ($skipped > 0) {
-		pfb_logger("\n[ DNSBL ] {$header}: {$skipped} line(s) skipped - strict parsing rejected an invalid scheme or URL path (see DNSBL parse-error log)\n", 2);
+		pfb_logger("\n[ DNSBL ] {$header}: {$skipped} line(s) skipped - strict parsing rejected an invalid scheme or URL path (see DNSBL parse-error log)\n", 1);
 	}
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -129,6 +129,19 @@ if ($cfg_seeded !== NULL) {
 }
 unset($cfg, $cfg_seeded);
 
+// ADR-22: preserve permissive DNSBL scheme parsing for EXISTING installs on upgrade.
+// pfb_dnsbl_lenient_migrate() sets the missing key to 'on' (lenient) only on an
+// already-populated DNSBL config section; a fresh install has no prior section, so it
+// returns NULL and the new-install strict default (OFF) stands. An existing value is
+// never overwritten.
+$cfg = config_get_path('installedpackages/pfblockerngdnsblsettings/config/0', []);
+$cfg_lenient = pfb_dnsbl_lenient_migrate($cfg);
+if ($cfg_lenient !== NULL) {
+	config_set_path('installedpackages/pfblockerngdnsblsettings/config/0', $cfg_lenient);
+	write_config('pfBlockerNG: preserve permissive DNSBL parsing for existing install (ADR-22 migration)');
+}
+unset($cfg, $cfg_lenient);
+
 // MaxMind Database is no longer pre-installed during package installation
 if (empty($pfb['maxmind_key'])) {
 	update_status("\nMaxMind GeoIP databases are not pre-installed during installation.\nTo utilize the MaxMind GeoIP functionalities, you will be required to register for a free MaxMind user account and access key. Review the IP tab: MaxMind Settings for more details.\n\n");

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -72,6 +72,9 @@ $pconfig['pfb_idn_escalate_suspicious']	= $pfb['dconfig']['pfb_idn_escalate_susp
 $pconfig['pfb_regex']		= $pfb['dconfig']['pfb_regex']				?: '';
 $pconfig['pfb_regex_cap']	= $pfb['dconfig']['pfb_regex_cap']			?: '';
 $pconfig['pfb_cname']		= $pfb['dconfig']['pfb_cname']				?: '';
+// ADR-22: lenient scheme parsing. Absent = unchecked (strict) for new installs; existing
+// installs are migrated to 'on' on upgrade (pfb_dnsbl_lenient_migrate).
+$pconfig['pfb_dnsbl_lenient']	= $pfb['dconfig']['pfb_dnsbl_lenient']			?: '';
 $pconfig['pfb_noaaaa']		= $pfb['dconfig']['pfb_noaaaa']				?: '';
 $pconfig['pfb_gp']		= $pfb['dconfig']['pfb_gp']				?: '';
 $pconfig['pfb_pytld']		= $pfb['dconfig']['pfb_pytld']				?: '';
@@ -560,6 +563,7 @@ if ($_POST) {
 			$pfb['dconfig']['pfb_regex']		= pfb_filter($_POST['pfb_regex'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_regex_cap']	= pfb_filter($_POST['pfb_regex_cap'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_cname']		= pfb_filter($_POST['pfb_cname'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
+			$pfb['dconfig']['pfb_dnsbl_lenient']	= pfb_filter($_POST['pfb_dnsbl_lenient'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_noaaaa']		= pfb_filter($_POST['pfb_noaaaa'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_gp']		= pfb_filter($_POST['pfb_gp'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 
@@ -2514,6 +2518,16 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ))->setHelp('Enable the CNAME Validation feature. All CNAMES will be evaluated against DNSBL database and blocked.<br />'
 		. 'Events are logged with a "_CNAME" suffix in the DNSBL Log.');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_dnsbl_lenient',
+	gettext('Lenient feed parsing'),
+	'Enable',
+	$pconfig['pfb_dnsbl_lenient'] === 'on' ? true:false,
+	'on'
+))->setHelp('Parse DNSBL feed lines permissively: any <strong>scheme://</strong> is stripped and URL paths are removed.<br />'
+		. 'When disabled (strict), lines with an invalid scheme (e.g. <strong>123://</strong>) or a URL path are skipped and logged.<br />'
+		. 'New installs default to disabled (strict); upgraded installs keep the permissive behaviour.');
 
 $section->addInput(new Form_Checkbox(
 	'pfb_noaaaa',

--- a/tests/php/PfbDnsblLenientMigrateTest.php
+++ b/tests/php/PfbDnsblLenientMigrateTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_lenient_migrate() -- the one-time upgrade migration for the ADR-22
+ * 'pfb_dnsbl_lenient' DNSBL scheme-parsing toggle.
+ *
+ * Scenario: preserve permissive parsing for existing installs on upgrade.
+ *   Background: $dconfig is the existing DNSBL-settings 'config/0' node.
+ *     - New installs default OFF (strict): a fresh box has no prior config section.
+ *     - Existing installs are migrated to 'on' (lenient): a populated section that
+ *       predates the key keeps the permissive behaviour it relied on.
+ *     - Migration ONLY sets a missing key; it never overwrites an existing value.
+ *
+ * Contract (ADR §2.2 / §2.6.6):
+ *   - empty/non-array config (fresh install) => NULL (no migration; strict default stands).
+ *   - populated config lacking the key (existing install) => key set to 'on'.
+ *   - populated config already carrying the key => NULL (never overwritten), for both
+ *     'on' and 'off'.
+ */
+#[CoversFunction('pfb_dnsbl_lenient_migrate')]
+final class PfbDnsblLenientMigrateTest extends TestCase
+{
+	public function testMigrationSkipsFreshInstall(): void
+	{
+		// Given a first-ever install: no prior DNSBL config section.
+		// Before: nothing to migrate.
+		$this->assertNull(pfb_dnsbl_lenient_migrate([]));
+		$this->assertNull(pfb_dnsbl_lenient_migrate(null));
+		// After: still nothing written -- the new-install strict default (OFF) stands.
+		// (A NULL return means the install.inc block does not config_set_path/write_config,
+		// so the key is never created and the unchecked checkbox = strict is preserved.)
+	}
+
+	public function testMigrationSetsLenientOnForExistingInstallMissingKey(): void
+	{
+		// Given an existing, already-configured install (a populated section) that predates
+		// the key.
+		$dconfig = ['pfb_dnsbl' => 'on', 'pfb_hsts' => 'on'];
+		// Before: the key is absent.
+		$this->assertArrayNotHasKey('pfb_dnsbl_lenient', $dconfig);
+
+		// When the one-time migration runs.
+		$out = pfb_dnsbl_lenient_migrate($dconfig);
+
+		// Then it is set to 'on' (lenient) -- the permissive behaviour is preserved.
+		$this->assertIsArray($out);
+		$this->assertSame('on', $out['pfb_dnsbl_lenient']);
+		// And the rest of the section is carried through untouched.
+		$this->assertSame('on', $out['pfb_dnsbl']);
+		$this->assertSame('on', $out['pfb_hsts']);
+	}
+
+	public function testMigrationDoesNotOverwriteExistingValue(): void
+	{
+		// Given an existing install where the operator already chose strict ('off').
+		$dconfig = ['pfb_dnsbl' => 'on', 'pfb_dnsbl_lenient' => 'off'];
+		// Before: value is 'off'.
+		$this->assertSame('off', $dconfig['pfb_dnsbl_lenient']);
+
+		// When the migration runs.
+		$out = pfb_dnsbl_lenient_migrate($dconfig);
+
+		// Then nothing changes (NULL = no write) -- the chosen value is never overwritten.
+		$this->assertNull($out);
+	}
+
+	public function testMigrationDoesNotOverwriteExistingOnValue(): void
+	{
+		// A box already carrying 'on' is likewise left alone (run-once, idempotent).
+		$out = pfb_dnsbl_lenient_migrate(['pfb_dnsbl' => 'on', 'pfb_dnsbl_lenient' => 'on']);
+		$this->assertNull($out);
+	}
+}

--- a/tests/php/PfbDnsblSchemeSkipLogTest.php
+++ b/tests/php/PfbDnsblSchemeSkipLogTest.php
@@ -18,12 +18,59 @@ use PHPUnit\Framework\TestCase;
  *     - pfb_dnsbl_scheme_skip_warn($skipped, $header): one main-log WARNING when $skipped>0.
  *
  * Real pfb_parsed_fail()/pfb_logger() are exercised (the shipped code), pointed at temp
- * files so the side-effects are asserted -- not coverage theater.
+ * files so the side-effects are asserted -- not coverage theater. File I/O results are
+ * asserted (no '@' suppression) so a setup/teardown failure cannot mask a false green, and
+ * $GLOBALS['pfb']['log'] is saved/restored per test so the suite stays order-independent.
  */
 #[CoversFunction('pfb_dnsbl_scheme_line')]
 #[CoversFunction('pfb_dnsbl_scheme_skip_warn')]
 final class PfbDnsblSchemeSkipLogTest extends TestCase
 {
+	/** @var string[] temp files to remove in tearDown */
+	private array $tmpfiles = [];
+
+	/** original $GLOBALS['pfb']['log'] (sentinel FALSE = was unset) */
+	private mixed $prevLog = false;
+
+	protected function setUp(): void
+	{
+		$this->prevLog = array_key_exists('log', $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb']['log'] : false;
+	}
+
+	protected function tearDown(): void
+	{
+		// Restore the shared global so a test that points pfb_logger() at a temp file does
+		// not leak that path into later tests.
+		if ($this->prevLog === false) {
+			unset($GLOBALS['pfb']['log']);
+		} else {
+			$GLOBALS['pfb']['log'] = $this->prevLog;
+		}
+		foreach ($this->tmpfiles as $f) {
+			if (is_file($f)) {
+				$this->assertTrue(unlink($f), "failed to remove temp file {$f}");
+			}
+		}
+		$this->tmpfiles = [];
+	}
+
+	/** Create an empty temp file, registered for teardown removal, with its result asserted. */
+	private function mktemp(string $prefix): string
+	{
+		$path = tempnam(sys_get_temp_dir(), $prefix);
+		$this->assertNotFalse($path, "tempnam({$prefix}) failed");
+		$this->tmpfiles[] = $path;
+		$this->assertNotFalse(file_put_contents($path, ''), "could not truncate {$path}");
+		return $path;
+	}
+
+	private function readFile(string $path): string
+	{
+		$raw = file_get_contents($path);
+		$this->assertNotFalse($raw, "could not read {$path}");
+		return (string) $raw;
+	}
+
 	// --- Toggle resolution: strict = lenient !== 'on' (ADR §2.1). Both branches. ---
 
 	public function testStrictResolvesTrueWhenLenientOff(): void
@@ -44,9 +91,7 @@ final class PfbDnsblSchemeSkipLogTest extends TestCase
 
 	public function testStrictSkipIsLogged(): void
 	{
-		$logfile = tempnam(sys_get_temp_dir(), 'pfb_parse_err_');
-		$this->assertNotFalse($logfile);
-		@file_put_contents($logfile, '');	// Given: an empty parse-error log.
+		$logfile = $this->mktemp('pfb_parse_err_');	// Given: an empty parse-error log.
 		$skipped = 0;
 
 		// When: a malformed line ('123://evil.com') is parsed in STRICT mode.
@@ -55,18 +100,14 @@ final class PfbDnsblSchemeSkipLogTest extends TestCase
 		// Then: the line is rejected, the counter bumped, and a CSV parse-error row written.
 		$this->assertFalse($result);
 		$this->assertSame(1, $skipped);
-		$logged = (string)@file_get_contents($logfile);
+		$logged = $this->readFile($logfile);
 		$this->assertStringContainsString('TestFeed', $logged);
 		$this->assertStringContainsString('123://evil.com', $logged);
-
-		@unlink($logfile);
 	}
 
 	public function testLenientEmitsNoNewLog(): void
 	{
-		$logfile = tempnam(sys_get_temp_dir(), 'pfb_parse_err_');
-		$this->assertNotFalse($logfile);
-		@file_put_contents($logfile, '');	// Given: an empty parse-error log.
+		$logfile = $this->mktemp('pfb_parse_err_');	// Given: an empty parse-error log.
 		$skipped = 0;
 
 		// When: the SAME malformed line is parsed in LENIENT mode.
@@ -76,61 +117,49 @@ final class PfbDnsblSchemeSkipLogTest extends TestCase
 		// -- byte-identical to today.
 		$this->assertSame('evil.com', $result);
 		$this->assertSame(0, $skipped);
-		$this->assertSame('', (string)@file_get_contents($logfile));
-
-		@unlink($logfile);
+		$this->assertSame('', $this->readFile($logfile));
 	}
 
 	public function testValidSchemeLineKeptInStrictWithoutLogging(): void
 	{
 		// A valid scheme, no path: kept in strict too, nothing logged/counted (regression
 		// guard -- strict must not skip legitimate lines).
-		$logfile = tempnam(sys_get_temp_dir(), 'pfb_parse_err_');
-		@file_put_contents($logfile, '');
+		$logfile = $this->mktemp('pfb_parse_err_');
 		$skipped = 0;
 
 		$result = pfb_dnsbl_scheme_line('evil://evil.com', true, 'TestFeed', 'evil://evil.com', $logfile, $skipped);
 
 		$this->assertSame('evil.com', $result);
 		$this->assertSame(0, $skipped);
-		$this->assertSame('', (string)@file_get_contents($logfile));
-
-		@unlink($logfile);
+		$this->assertSame('', $this->readFile($logfile));
 	}
 
 	// --- Per-feed summary WARNING: once per feed, only when something was skipped. ---
 
 	public function testPerFeedWarningEmittedOnceWhenSkipped(): void
 	{
-		$mainlog = tempnam(sys_get_temp_dir(), 'pfb_main_log_');
-		$this->assertNotFalse($mainlog);
-		@file_put_contents($mainlog, '');
-		$GLOBALS['pfb']['log'] = $mainlog;	// pfb_logger() writes here (logtype 2).
+		$mainlog = $this->mktemp('pfb_main_log_');
+		$GLOBALS['pfb']['log'] = $mainlog;	// pfb_logger() writes here (logtype 1; restored in tearDown).
 
 		// When: the per-feed summary fires for a feed that skipped 3 lines.
 		pfb_dnsbl_scheme_skip_warn(3, 'TestFeed');
 
 		// Then: exactly ONE WARNING line, naming the feed + the count (not one per line).
-		$logged = (string)@file_get_contents($mainlog);
+		$logged = $this->readFile($mainlog);
 		$this->assertStringContainsString('TestFeed', $logged);
 		$this->assertStringContainsString('3 line(s) skipped', $logged);
 		$this->assertSame(1, substr_count($logged, 'line(s) skipped'));
-
-		@unlink($mainlog);
 	}
 
 	public function testPerFeedWarningSilentWhenNothingSkipped(): void
 	{
 		// Before: empty log. Lenient mode never increments the counter, so the summary must
 		// stay silent (byte-identical to today).
-		$mainlog = tempnam(sys_get_temp_dir(), 'pfb_main_log_');
-		@file_put_contents($mainlog, '');
+		$mainlog = $this->mktemp('pfb_main_log_');
 		$GLOBALS['pfb']['log'] = $mainlog;
 
 		pfb_dnsbl_scheme_skip_warn(0, 'TestFeed');
 
-		$this->assertSame('', (string)@file_get_contents($mainlog));
-
-		@unlink($mainlog);
+		$this->assertSame('', $this->readFile($mainlog));
 	}
 }

--- a/tests/php/PfbDnsblSchemeSkipLogTest.php
+++ b/tests/php/PfbDnsblSchemeSkipLogTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-22 Phase 2 -- the call-site toggle resolution + the strict-mode skip logging.
+ *
+ * Scenario: a strict skip is recorded per-line AND summarised once per feed; lenient is
+ * byte-identical to today (nothing skipped, no new log output).
+ *   Background:
+ *     - strict = (pfb_dnsbl_lenient !== 'on') -- the trivial single-toggle resolution.
+ *     - pfb_dnsbl_scheme_line($line, $strict, $header, $oline, $logfile, &$skipped):
+ *       returns the kept host, or FALSE after recording a parse-error line + bumping the
+ *       per-feed counter.
+ *     - pfb_dnsbl_scheme_skip_warn($skipped, $header): one main-log WARNING when $skipped>0.
+ *
+ * Real pfb_parsed_fail()/pfb_logger() are exercised (the shipped code), pointed at temp
+ * files so the side-effects are asserted -- not coverage theater.
+ */
+#[CoversFunction('pfb_dnsbl_scheme_line')]
+#[CoversFunction('pfb_dnsbl_scheme_skip_warn')]
+final class PfbDnsblSchemeSkipLogTest extends TestCase
+{
+	// --- Toggle resolution: strict = lenient !== 'on' (ADR §2.1). Both branches. ---
+
+	public function testStrictResolvesTrueWhenLenientOff(): void
+	{
+		// lenient OFF (the new-install default) => strict parsing.
+		$lenient = 'off';
+		$this->assertTrue($lenient !== 'on');
+	}
+
+	public function testStrictResolvesFalseWhenLenientOn(): void
+	{
+		// lenient ON (the migrated/legacy default) => permissive parsing.
+		$lenient = 'on';
+		$this->assertFalse($lenient !== 'on');
+	}
+
+	// --- Per-line skip + parse-error log (strict) vs silent passthrough (lenient). ---
+
+	public function testStrictSkipIsLogged(): void
+	{
+		$logfile = tempnam(sys_get_temp_dir(), 'pfb_parse_err_');
+		$this->assertNotFalse($logfile);
+		@file_put_contents($logfile, '');	// Given: an empty parse-error log.
+		$skipped = 0;
+
+		// When: a malformed line ('123://evil.com') is parsed in STRICT mode.
+		$result = pfb_dnsbl_scheme_line('123://evil.com', true, 'TestFeed', '123://evil.com', $logfile, $skipped);
+
+		// Then: the line is rejected, the counter bumped, and a CSV parse-error row written.
+		$this->assertFalse($result);
+		$this->assertSame(1, $skipped);
+		$logged = (string)@file_get_contents($logfile);
+		$this->assertStringContainsString('TestFeed', $logged);
+		$this->assertStringContainsString('123://evil.com', $logged);
+
+		@unlink($logfile);
+	}
+
+	public function testLenientEmitsNoNewLog(): void
+	{
+		$logfile = tempnam(sys_get_temp_dir(), 'pfb_parse_err_');
+		$this->assertNotFalse($logfile);
+		@file_put_contents($logfile, '');	// Given: an empty parse-error log.
+		$skipped = 0;
+
+		// When: the SAME malformed line is parsed in LENIENT mode.
+		$result = pfb_dnsbl_scheme_line('123://evil.com', false, 'TestFeed', '123://evil.com', $logfile, $skipped);
+
+		// Then: it is kept (today's behaviour), nothing is counted, and the log stays empty
+		// -- byte-identical to today.
+		$this->assertSame('evil.com', $result);
+		$this->assertSame(0, $skipped);
+		$this->assertSame('', (string)@file_get_contents($logfile));
+
+		@unlink($logfile);
+	}
+
+	public function testValidSchemeLineKeptInStrictWithoutLogging(): void
+	{
+		// A valid scheme, no path: kept in strict too, nothing logged/counted (regression
+		// guard -- strict must not skip legitimate lines).
+		$logfile = tempnam(sys_get_temp_dir(), 'pfb_parse_err_');
+		@file_put_contents($logfile, '');
+		$skipped = 0;
+
+		$result = pfb_dnsbl_scheme_line('evil://evil.com', true, 'TestFeed', 'evil://evil.com', $logfile, $skipped);
+
+		$this->assertSame('evil.com', $result);
+		$this->assertSame(0, $skipped);
+		$this->assertSame('', (string)@file_get_contents($logfile));
+
+		@unlink($logfile);
+	}
+
+	// --- Per-feed summary WARNING: once per feed, only when something was skipped. ---
+
+	public function testPerFeedWarningEmittedOnceWhenSkipped(): void
+	{
+		$mainlog = tempnam(sys_get_temp_dir(), 'pfb_main_log_');
+		$this->assertNotFalse($mainlog);
+		@file_put_contents($mainlog, '');
+		$GLOBALS['pfb']['log'] = $mainlog;	// pfb_logger() writes here (logtype 2).
+
+		// When: the per-feed summary fires for a feed that skipped 3 lines.
+		pfb_dnsbl_scheme_skip_warn(3, 'TestFeed');
+
+		// Then: exactly ONE WARNING line, naming the feed + the count (not one per line).
+		$logged = (string)@file_get_contents($mainlog);
+		$this->assertStringContainsString('TestFeed', $logged);
+		$this->assertStringContainsString('3 line(s) skipped', $logged);
+		$this->assertSame(1, substr_count($logged, 'line(s) skipped'));
+
+		@unlink($mainlog);
+	}
+
+	public function testPerFeedWarningSilentWhenNothingSkipped(): void
+	{
+		// Before: empty log. Lenient mode never increments the counter, so the summary must
+		// stay silent (byte-identical to today).
+		$mainlog = tempnam(sys_get_temp_dir(), 'pfb_main_log_');
+		@file_put_contents($mainlog, '');
+		$GLOBALS['pfb']['log'] = $mainlog;
+
+		pfb_dnsbl_scheme_skip_warn(0, 'TestFeed');
+
+		$this->assertSame('', (string)@file_get_contents($mainlog));
+
+		@unlink($mainlog);
+	}
+}

--- a/tests/php/PfbDnsblStripSchemeTest.php
+++ b/tests/php/PfbDnsblStripSchemeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_strip_scheme() — ADR-22 Phase 1 oracle tests.
+ *
+ * Phase 1 is a behaviour-preserving extraction of the former inline non-lite scheme
+ * strip: if '<scheme>://' is present, strip up to and including the FIRST '://' and
+ * return the remainder; otherwise return the line unchanged. These tests PIN the
+ * CURRENT (permissive) behaviour for every input class so the Phase-2 tightening (a
+ * $strict toggle that validates the RFC 3986 scheme + rejects paths, returning
+ * string|false) has explicit before-state anchors.
+ *
+ * Path/query/fragment/port stripping happens downstream (lines 9679-9706); this helper
+ * intentionally returns the remainder WITH any path intact.
+ */
+#[CoversFunction('pfb_dnsbl_strip_scheme')]
+final class PfbDnsblStripSchemeTest extends TestCase
+{
+	public function testHttpSchemeStripped(): void
+	{
+		// Path stripping is downstream; helper returns the remainder WITH '/path' intact.
+		$this->assertSame('evil.com/path', pfb_dnsbl_strip_scheme('http://evil.com/path'));
+	}
+
+	public function testHttpsSchemeStripped(): void
+	{
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('https://evil.com'));
+	}
+
+	public function testFtpSchemeStripped(): void
+	{
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('ftp://evil.com'));
+	}
+
+	public function testTelnetSchemeStripped(): void
+	{
+		// telnet is a valid RFC 3986 scheme; this behaviour is UNCHANGED in Phase 2.
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('telnet://evil.com'));
+	}
+
+	public function testCustomValidSchemeStripped(): void
+	{
+		// Any valid RFC 3986 scheme is accepted; UNCHANGED in Phase 2.
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('evil://evil.com'));
+	}
+
+	public function testCompoundSchemeStripped(): void
+	{
+		// '+' is valid inside an RFC 3986 scheme; UNCHANGED in Phase 2.
+		$this->assertSame('fakepkg.com', pfb_dnsbl_strip_scheme('pkg+https://fakepkg.com'));
+	}
+
+	public function testNoSchemeUnchanged(): void
+	{
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('evil.com'));
+	}
+
+	public function testDigitStartSchemeCurrentBehavior(): void
+	{
+		// BEFORE-STATE ORACLE for Phase 2: a digit-start scheme is NOT a valid RFC 3986
+		// scheme, yet the permissive strpos()-based strip extracts 'evil.com'. Phase 2's
+		// strict mode changes this to false (skip + log). This pins today's behaviour.
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('123://evil.com'));
+	}
+
+	public function testEmptySchemeCurrentBehavior(): void
+	{
+		// BEFORE-STATE ORACLE for Phase 2: an empty scheme prefix -- strpos() finds '://'
+		// at position 0, so the strip yields 'evil.com'. Phase 2's strict mode changes
+		// this to false (skip + log). This pins today's behaviour.
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('://evil.com'));
+	}
+
+	public function testMidTokenValidSchemeCurrentBehavior(): void
+	{
+		// 'evil.com' is an RFC 3986-valid scheme ('.' is allowed), so the first '://'
+		// match extracts 'junk'. This behaviour does NOT change in Phase 2 (the scheme is
+		// valid); pfb_filter() downstream rejects 'junk' (no '.'). Documents the edge case.
+		$this->assertSame('junk', pfb_dnsbl_strip_scheme('evil.com://junk'));
+	}
+}

--- a/tests/php/PfbDnsblStripSchemeTest.php
+++ b/tests/php/PfbDnsblStripSchemeTest.php
@@ -84,4 +84,111 @@ final class PfbDnsblStripSchemeTest extends TestCase
 		// valid); pfb_filter() downstream rejects 'junk' (no '.'). Documents the edge case.
 		$this->assertSame('junk', pfb_dnsbl_strip_scheme('evil.com://junk'));
 	}
+
+	// ------------------------------------------------------------------
+	// ADR-22 Phase 2 -- the $strict toggle (ADR §2.4 / §2.5 decision table).
+	//
+	// Scenario: scheme validation behind a single global lenient/strict toggle.
+	//   Background: pfb_dnsbl_strip_scheme($line, $strict) -- $strict resolved at the
+	//   call site from `lenient !== 'on'`. Lenient (false) is today's permissive strip;
+	//   strict (true) validates the RFC 3986 scheme + rejects URL paths, returning FALSE.
+	// ------------------------------------------------------------------
+
+	// --- Lenient (strict=false): current behaviour preserved (the malformed cases that
+	//     strict flips to FALSE; each pinned at strict=false BEFORE the strict assertion
+	//     in the paired strict test, so green proves the toggle CAUSED the change). ---
+
+	public function testInvalidSchemePassthroughWhenLenient(): void
+	{
+		// Given a digit-start (invalid RFC 3986) scheme, When lenient, Then the
+		// permissive strip still yields the host (today's behaviour).
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('123://evil.com', false));
+	}
+
+	public function testEmptySchemePassthroughWhenLenient(): void
+	{
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('://evil.com', false));
+	}
+
+	public function testPathPassthroughWhenLenient(): void
+	{
+		// Lenient keeps the path on the remainder (stripped downstream); not rejected.
+		$this->assertSame('evil.com/path', pfb_dnsbl_strip_scheme('http://evil.com/path', false));
+	}
+
+	// --- Strict (strict=true): new behaviour. Each transition test first asserts the
+	//     lenient (before) result, then the strict (after) result, so the change is
+	//     attributable to the toggle, not an always-FALSE path. ---
+
+	public function testInvalidSchemeRejectedWhenStrict(): void
+	{
+		// BEFORE (lenient): '123://evil.com' -> 'evil.com'.
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('123://evil.com', false));
+		// AFTER (strict): digit-start scheme is not RFC 3986 valid -> FALSE (skip + log).
+		$this->assertFalse(pfb_dnsbl_strip_scheme('123://evil.com', true));
+	}
+
+	public function testEmptySchemeRejectedWhenStrict(): void
+	{
+		// BEFORE (lenient): '://evil.com' -> 'evil.com'.
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('://evil.com', false));
+		// AFTER (strict): empty scheme prefix -> FALSE.
+		$this->assertFalse(pfb_dnsbl_strip_scheme('://evil.com', true));
+	}
+
+	public function testSpecialCharsSchemeRejectedWhenStrict(): void
+	{
+		// BEFORE (lenient): a non-alpha-start scheme still strips to the host.
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('!!bad://evil.com', false));
+		// AFTER (strict): '!!bad' is not a valid scheme (non-alpha start) -> FALSE.
+		$this->assertFalse(pfb_dnsbl_strip_scheme('!!bad://evil.com', true));
+	}
+
+	public function testPathRejectedWhenStrict(): void
+	{
+		// BEFORE (lenient): the path rides through on the remainder.
+		$this->assertSame('evil.com/path', pfb_dnsbl_strip_scheme('http://evil.com/path', false));
+		// AFTER (strict): a real URL path is present -> FALSE (skip + log).
+		$this->assertFalse(pfb_dnsbl_strip_scheme('http://evil.com/path', true));
+	}
+
+	public function testTrailingSlashNormalisedWhenStrict(): void
+	{
+		// A single trailing '/' is the root path -- normalised away, NOT a rejection.
+		$this->assertSame('ftp.evil.com', pfb_dnsbl_strip_scheme('ftp://ftp.evil.com/', true));
+	}
+
+	public function testPathAfterRootSlashRejectedWhenStrict(): void
+	{
+		// BEFORE (lenient): remainder keeps 'evil.com/path/'.
+		$this->assertSame('evil.com/path/', pfb_dnsbl_strip_scheme('http://evil.com/path/', false));
+		// AFTER (strict): one trailing '/' is normalised, but a '/' remains (the real
+		// path) -> FALSE. Guards against a naive "strip the last slash" bypass.
+		$this->assertFalse(pfb_dnsbl_strip_scheme('http://evil.com/path/', true));
+	}
+
+	// --- Regression guards: a valid RFC 3986 scheme (no path) is accepted in BOTH
+	//     toggle states (ADR §2.6.1). ---
+
+	public function testValidSchemeAcceptedWhenLenient(): void
+	{
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('evil://evil.com', false));
+	}
+
+	public function testValidSchemeAcceptedWhenStrict(): void
+	{
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('evil://evil.com', true));
+	}
+
+	public function testCompoundSchemeWhenStrict(): void
+	{
+		// '+' is valid inside a scheme; accepted under strict too.
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('pkg+https://evil.com', true));
+	}
+
+	public function testNoSchemeWhenStrict(): void
+	{
+		// No '://' -> returned unchanged regardless of toggle state.
+		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('evil.com', true));
+	}
 }

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -757,6 +757,40 @@ def set_dnsbl_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
         )
 
 
+def set_dnsbl_lenient(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Set the ADR-22 ``pfb_dnsbl_lenient`` toggle in the DNSBL-settings section.
+
+    ``on`` -> lenient (today's permissive scheme strip; nothing skipped, no new log).
+    ``off`` -> strict: ``pfb_dnsbl_strip_scheme`` validates the scheme against RFC 3986
+    and rejects URL paths, recording each rejected line in the DNSBL parse-error log and
+    emitting one per-feed WARNING. Written via ``array_merge`` so it never clobbers the
+    rest of the DNSBL settings ``inject()`` already wrote. Set BEFORE the reload that
+    rebuilds the feed (``pfb_global`` reads it once per run)."""
+    val = "on" if on else "off"
+    snippet = (
+        f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
+        f"$d['pfb_dnsbl_lenient'] = {_php_str(val)};\n"
+        f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $d);\n"
+        "write_config('pfBlockerNG smoke: set pfb_dnsbl_lenient');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_dnsbl_lenient({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def read_log_file(vm: SmokeVM, path: str, *, timeout: float = 30.0) -> str:
+    """Return the full text of a guest log file (empty string if absent).
+
+    Used to assert ADR-22 strict-mode skips landed in the DNSBL parse-error log:
+    a rejected line's original text (its ``uuid-*`` label) appears in the CSV record
+    pfb_parsed_fail() appended. ``cat`` a missing file -> '' (never raises)."""
+    result = vm.ssh("cat", path, timeout=timeout)
+    return result.stdout if result.returncode == 0 else ""
+
+
 CFG_SAFESEARCH_ENABLE = "installedpackages/pfblockerngsafesearch/safesearch_enable"
 
 
@@ -1829,6 +1863,11 @@ PY_ERROR_LOG = f"{PFB_LOGDIR}/py_error.log"
 # bare phrase "the zero-downtime swap", so matching the unbracketed substring would
 # false-positive on a fallback (restart) as if the swap had been taken.
 SWAP_LOG_MARKER = "[ zero-downtime swap ]"
+# The DNSBL per-line parse-error log: pfb_parsed_fail() appends one CSV record
+# ({date},{header},{line},{oline}) here for every rejected line — including an ADR-22
+# strict-mode scheme/path skip. Mirrors $pfb['dnsbl_parse_err'] (inc:88,
+# "{$pfb['logdir']}/dnsbl_parsed_error.log"), the established per-line failure sink.
+DNSBL_PARSE_ERR_LOG = f"{PFB_LOGDIR}/dnsbl_parsed_error.log"
 
 
 def unbound_pid(vm: SmokeVM, *, timeout: float = 30.0) -> int:

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -741,6 +741,10 @@ def test_lenient_blocks_invalid_scheme_and_path(deployed_vm: SmokeVM) -> None:
         # Any per-feed strict-skip WARNING for THIS feed (1 or 2 lines) must NOT appear.
         warn_marker_any = f"{header}: "
         warn_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "line(s) skipped - strict parsing")
+        # Baseline the feed-specific count too: the log persists across cases, so assert it is
+        # UNCHANGED by this reload rather than absolutely zero (transition, not absolute state).
+        feed_warn_before = h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker_any + "1 line(s) skipped")
+        feed_warn_before += h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker_any + "2 line(s) skipped")
         h.reload(deployed_vm, "update")
 
         # THEN (DNS shapes): both malformed lines are now BLOCKED (today's behaviour).
@@ -762,9 +766,12 @@ def test_lenient_blocks_invalid_scheme_and_path(deployed_vm: SmokeVM) -> None:
             f"lenient mode must emit NO strict-skip WARNING, but the count rose "
             f"(before={warn_before}, after={warn_after})"
         )
-        feed_warn = h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker_any + "1 line(s) skipped")
-        feed_warn += h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker_any + "2 line(s) skipped")
-        assert feed_warn == 0, f"lenient mode wrongly emitted a per-feed strict-skip WARNING for {header}"
+        feed_warn_after = h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker_any + "1 line(s) skipped")
+        feed_warn_after += h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker_any + "2 line(s) skipped")
+        assert feed_warn_after == feed_warn_before, (
+            f"lenient mode wrongly emitted a per-feed strict-skip WARNING for {header} "
+            f"(before={feed_warn_before}, after={feed_warn_after})"
+        )
     finally:
         h.reset(deployed_vm)
         h.set_dnsbl_lenient(deployed_vm, True)

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -566,3 +566,278 @@ def test_abp_perline_path_anchor_not_overblocked(deployed_vm: SmokeVM, mock_feed
         assert not h.is_vip(ans_path), (
             f"{path_dom} wrongly VIP-blocked (path anchor truncated into a block): {ans_path}"
         )
+
+
+# --------------------------------------------------------------------------- #
+# ADR-22 — the "Lenient feed parsing" toggle (pfb_dnsbl_lenient) over the live box.
+#
+# The non-lite DNSBL download path strips a ``<scheme>://`` prefix from each feed
+# line (pfblockerng.inc:11316-11329). Lenient (toggle ON — the migrated/legacy
+# default) keeps today's permissive strip: ANY ``://`` is removed at its first
+# occurrence and a URL path is stripped downstream, so a malformed-scheme line
+# (digit-start) and a path line are still extracted + blocked. Strict (toggle OFF —
+# the new-install default) validates the scheme against RFC 3986 and rejects a URL
+# path: a rejected line is SKIPPED, recorded per-line in the DNSBL parse-error log
+# (pfb_parsed_fail -> $pfb['dnsbl_parse_err']), and counted into ONE per-feed WARNING
+# in the main pfBlockerNG log (pfb_dnsbl_scheme_skip_warn).
+#
+# DELIVERY: the scheme lines ride a normal LOCAL feed row (write_local_feed), the
+# same mechanism test_abp_perline_detection_in_plain_feed uses — the body carries
+# runtime unique_domain() uuids so it must be a local file, and a feed row is exactly
+# what flows through the non-lite download loop the toggle gates (the GUI Custom_List
+# feeds the SAME loop via a synthetic row; the loop, not the entry point, is the
+# behaviour under test). Tests A/B drive inject -> set toggle -> Force Update manually
+# (NOT CaseContext, which injects+reloads atomically before the toggle could be set)
+# and restore config + custom feed in finally.
+# --------------------------------------------------------------------------- #
+
+
+def _scheme_feed_path(vm: SmokeVM, name: str, lines: list[str]) -> str:
+    """Write a header-less plain feed of raw scheme lines; return its on-box path."""
+    body = "\n".join(lines) + "\n"
+    return h.write_local_feed(vm, name, body)
+
+
+@pytest.mark.timeout(300)
+def test_strict_skips_invalid_scheme_and_path_and_logs(deployed_vm: SmokeVM) -> None:
+    """ADR-22 strict (lenient OFF): invalid-scheme + path lines are skipped AND logged.
+
+    Scenario: a DNSBL feed mixes two well-formed scheme lines (a valid RFC 3986 scheme,
+    no path) with two malformed ones (a digit-start scheme; a valid scheme bearing a URL
+    path). With ``pfb_dnsbl_lenient='off'`` the parser must BLOCK the two well-formed
+    hosts and SKIP+LOG the two malformed lines — both in the DNSBL parse-error log
+    (per-line) and as one per-feed WARNING in the main log (ADR §2.3).
+
+    Given (before any feed loads) all four hosts RESOLVE via the controlled stub upstream
+      (``STUB_DNS_A``) — the real, observable before-state (none is blocked yet).
+    When  the feed is written, ``pfb_dnsbl_lenient`` is set OFF (strict), and a Force
+      Update runs (Unbound reloads),
+    Then:
+      * ``http://<http>``      -> VIP/NULL block (valid scheme, no path);
+      * ``evil://<evil>``      -> VIP/NULL block (valid custom RFC 3986 scheme, no path);
+      * ``123://<badscheme>``  -> still RESOLVES (digit-start scheme rejected -> skipped);
+      * ``http://<haspath>/path`` -> still RESOLVES (URL path rejected -> skipped);
+    And the two skipped originals' labels appear in the DNSBL parse-error log, AND a
+      per-feed "N line(s) skipped - strict parsing ..." WARNING for this feed is present
+      in the main pfBlockerNG log (count strictly greater than the pre-update baseline,
+      proving THIS update wrote it).
+    """
+    http_dom = h.unique_domain("adr22http")  # http://     -> valid scheme, no path -> BLOCK
+    evil_dom = h.unique_domain("adr22evil")  # evil://     -> valid custom scheme   -> BLOCK
+    bad_dom = h.unique_domain("adr22bad")  # 123://       -> digit-start invalid    -> SKIP+LOG
+    path_dom = h.unique_domain("adr22path")  # http://.../path -> URL path present  -> SKIP+LOG
+    header = "smokeadr22strict"
+    feed_url = _scheme_feed_path(
+        deployed_vm,
+        "smoke_adr22_strict.txt",
+        [f"http://{http_dom}", f"evil://{evil_dom}", f"123://{bad_dom}", f"http://{path_dom}/path"],
+    )
+    spec = h.DnsblCase(aliasname="smokeadr22s", feed_url=feed_url, header=header, mode=h.DnsblMode.VIP)
+
+    def _blocked(ans: h.DnsAnswer) -> bool:
+        return h.is_vip(ans) or h.is_null_ip(ans)
+
+    try:
+        # BEFORE: none of the four is on a feed yet -> each resolves via the stub.
+        h.unblock_egress()
+        for name in (http_dom, evil_dom, bad_dom, path_dom):
+            before = h.dns_probe(deployed_vm, name, "A")
+            assert h.resolves_to(before, STUB_DNS_A), f"{name} should resolve via stub BEFORE listing, got {before}"
+            assert not _blocked(before), f"{name} unexpectedly blocked before any feed: {before}"
+
+        # WHEN: load the feed STRICTLY (lenient OFF). Capture the per-feed-WARNING + the
+        # parse-error-log baselines before the update so a strictly-greater count proves
+        # THIS update emitted them.
+        h.inject(deployed_vm, spec)
+        h.set_dnsbl_lenient(deployed_vm, False)
+        warn_marker = f"{header}: 2 line(s) skipped"
+        warn_before = h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker)
+        h.reload(deployed_vm, "update")
+
+        # THEN (DNS shapes): the two valid-scheme hosts BLOCK; the two skipped lines
+        # still RESOLVE. A feed load swaps via the ADR-10 async path -> flush + poll the
+        # blocked names; the skipped names were never listed so they keep resolving.
+        h.flush_unbound_name(deployed_vm, http_dom)
+        h.flush_unbound_name(deployed_vm, evil_dom)
+        ans_http = h.dns_probe_until(deployed_vm, http_dom, _blocked)
+        assert not h.resolves_to(ans_http, STUB_DNS_A), (
+            f"http://{http_dom} still resolving after strict load: {ans_http}"
+        )
+        ans_evil = h.dns_probe_until(deployed_vm, evil_dom, _blocked)
+        assert not h.resolves_to(ans_evil, STUB_DNS_A), (
+            f"evil://{evil_dom} still resolving after strict load: {ans_evil}"
+        )
+        ans_bad = h.dns_probe(deployed_vm, bad_dom, "A")
+        assert h.resolves_to(ans_bad, STUB_DNS_A), (
+            f"123://{bad_dom} must be SKIPPED under strict (digit-start scheme) -> still resolves, got {ans_bad}"
+        )
+        assert not _blocked(ans_bad), f"123://{bad_dom} wrongly blocked under strict (should be skipped): {ans_bad}"
+        ans_path = h.dns_probe(deployed_vm, path_dom, "A")
+        assert h.resolves_to(ans_path, STUB_DNS_A), (
+            f"http://{path_dom}/path must be SKIPPED under strict (URL path) -> still resolves, got {ans_path}"
+        )
+        assert not _blocked(ans_path), (
+            f"http://{path_dom}/path wrongly blocked under strict (should be skipped): {ans_path}"
+        )
+
+        # THEN (logging, ADR §2.3): both skipped originals appear in the parse-error log...
+        parse_err = h.read_log_file(deployed_vm, h.DNSBL_PARSE_ERR_LOG)
+        assert bad_dom in parse_err, f"{bad_dom} (123:// skip) not in DNSBL parse-error log:\n{parse_err[-2000:]}"
+        assert path_dom in parse_err, f"{path_dom} (path skip) not in DNSBL parse-error log:\n{parse_err[-2000:]}"
+        # ...and exactly the per-feed summary WARNING (2 lines skipped) appears in the main log.
+        warn_after = h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker)
+        assert warn_after > warn_before, (
+            f"per-feed strict-skip WARNING ('{warn_marker}') not appended to {h.PFB_LOG} "
+            f"(before={warn_before}, after={warn_after})"
+        )
+    finally:
+        h.reset(deployed_vm)
+        h.set_dnsbl_lenient(deployed_vm, True)
+        deployed_vm.ssh("/bin/rm", "-f", feed_url)
+
+
+@pytest.mark.timeout(300)
+def test_lenient_blocks_invalid_scheme_and_path(deployed_vm: SmokeVM) -> None:
+    """ADR-22 lenient (ON): invalid-scheme + path lines are BLOCKED, no WARNING (today's behaviour).
+
+    The lenient counterpart of the strict test: with ``pfb_dnsbl_lenient='on'`` the SAME
+    two malformed lines that strict skips are instead extracted and blocked (byte-identical
+    to today's permissive strip), and NO per-feed strict-skip WARNING is emitted. Pairing
+    this ON case with the OFF case above proves the toggle is a real branch, not an
+    always-skip or always-block path.
+
+    Given (before any feed loads) both hosts RESOLVE via the controlled stub upstream.
+    When  the feed is written, ``pfb_dnsbl_lenient`` is set ON (lenient), and a Force
+      Update runs,
+    Then  ``123://<badscheme>`` and ``http://<haspath>/path`` BOTH return the block shape
+      and no longer resolve (the digit-start scheme is stripped; the path is stripped
+      downstream) — AND no per-feed strict-skip WARNING for this feed appears in the main
+      log (lenient is silent, ADR §2.3).
+    """
+    bad_dom = h.unique_domain("adr22lbad")  # 123://     -> stripped -> BLOCK under lenient
+    path_dom = h.unique_domain("adr22lpath")  # http://.../path -> path stripped -> BLOCK under lenient
+    header = "smokeadr22lenient"
+    feed_url = _scheme_feed_path(
+        deployed_vm,
+        "smoke_adr22_lenient.txt",
+        [f"123://{bad_dom}", f"http://{path_dom}/path"],
+    )
+    spec = h.DnsblCase(aliasname="smokeadr22l", feed_url=feed_url, header=header, mode=h.DnsblMode.VIP)
+
+    def _blocked(ans: h.DnsAnswer) -> bool:
+        return h.is_vip(ans) or h.is_null_ip(ans)
+
+    try:
+        # BEFORE: neither host is on a feed yet -> each resolves via the stub.
+        h.unblock_egress()
+        for name in (bad_dom, path_dom):
+            before = h.dns_probe(deployed_vm, name, "A")
+            assert h.resolves_to(before, STUB_DNS_A), f"{name} should resolve via stub BEFORE listing, got {before}"
+            assert not _blocked(before), f"{name} unexpectedly blocked before any feed: {before}"
+
+        # WHEN: load the feed LENIENTLY (toggle ON).
+        h.inject(deployed_vm, spec)
+        h.set_dnsbl_lenient(deployed_vm, True)
+        # Any per-feed strict-skip WARNING for THIS feed (1 or 2 lines) must NOT appear.
+        warn_marker_any = f"{header}: "
+        warn_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "line(s) skipped - strict parsing")
+        h.reload(deployed_vm, "update")
+
+        # THEN (DNS shapes): both malformed lines are now BLOCKED (today's behaviour).
+        for name in (bad_dom, path_dom):
+            h.flush_unbound_name(deployed_vm, name)
+        ans_bad = h.dns_probe_until(deployed_vm, bad_dom, _blocked)
+        assert not h.resolves_to(ans_bad, STUB_DNS_A), (
+            f"123://{bad_dom} must be BLOCKED under lenient (today's strip), still resolving: {ans_bad}"
+        )
+        ans_path = h.dns_probe_until(deployed_vm, path_dom, _blocked)
+        assert not h.resolves_to(ans_path, STUB_DNS_A), (
+            f"http://{path_dom}/path must be BLOCKED under lenient (path stripped downstream), got {ans_path}"
+        )
+
+        # THEN (logging): lenient is SILENT -> no new strict-skip WARNING line at all, and
+        # none naming this feed.
+        warn_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "line(s) skipped - strict parsing")
+        assert warn_after == warn_before, (
+            f"lenient mode must emit NO strict-skip WARNING, but the count rose "
+            f"(before={warn_before}, after={warn_after})"
+        )
+        feed_warn = h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker_any + "1 line(s) skipped")
+        feed_warn += h.count_log_marker(deployed_vm, h.PFB_LOG, warn_marker_any + "2 line(s) skipped")
+        assert feed_warn == 0, f"lenient mode wrongly emitted a per-feed strict-skip WARNING for {header}"
+    finally:
+        h.reset(deployed_vm)
+        h.set_dnsbl_lenient(deployed_vm, True)
+        deployed_vm.ssh("/bin/rm", "-f", feed_url)
+
+
+@pytest.mark.timeout(300)
+def test_migration_sets_lenient_on_for_existing_install(deployed_vm: SmokeVM) -> None:
+    """ADR-22 §2.2 migration on the live box: an existing install lacking the key -> 'on'.
+
+    Proves the SHIPPED migration decision (``pfb_dnsbl_lenient_migrate``, pfblockerng.inc)
+    against the REAL on-box config store — exactly the two-line body the upgrade hook in
+    pfblockerng_install.inc runs: read the DNSBL-settings section, run the migration, and
+    if it returns a (changed) array, persist it. An EXISTING install is one with a
+    populated DNSBL config section that merely lacks ``pfb_dnsbl_lenient``; the migration
+    must set it to 'on' (preserving the legacy permissive behaviour), never overwriting a
+    present value.
+
+    Given the live DNSBL-settings section is populated (it always is on the deployed box —
+      pfb_dnsbl etc. are set) and ``pfb_dnsbl_lenient`` is REMOVED (the upgrade-from-an-
+      older-version state) — asserted absent as the before-state,
+    When  the shipped ``pfb_dnsbl_lenient_migrate`` runs against that section and the
+      result is persisted (the install-hook body),
+    Then  the live config now reads ``pfb_dnsbl_lenient == 'on'``.
+
+    NOTE (out-of-CI limitation): the FULL ``pfblockerng_install.inc`` require-flow (which
+    also runs the unrelated VIP / python-mode / PFBL-03 migrations) is not driven end to
+    end here — that would re-run every install side effect on the live box. This case
+    drives the migration FUNCTION the hook calls, against the live config store, which is
+    the load-bearing ADR-22 behaviour; the surrounding hook plumbing is identical to the
+    in-tree PHPUnit migration coverage (PfbDnsblLenientMigrateTest).
+    """
+    sentinel_open = "<<<LENIENT>>>"
+    sentinel_close = "<<<END>>>"
+
+    # BEFORE: populate the section (it is on the deployed box) then REMOVE the key, and
+    # assert it is absent — the genuine "upgraded-from-older-version" before-state.
+    remove = (
+        f"$d = config_get_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, array());\n"
+        "$d['pfb_dnsbl'] = 'on';\n"  # ensure the section is populated (an existing install)
+        "unset($d['pfb_dnsbl_lenient']);\n"
+        f"config_set_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, $d);\n"
+        "write_config('pfBlockerNG smoke: ADR-22 migration before-state');\n"
+        "echo 'OK';"
+    )
+    res = h.php_eval(deployed_vm, remove)
+    assert "OK" in res.stdout, f"could not stage the migration before-state: {res.stdout!r} {res.stderr!r}"
+    assert h.config_get(deployed_vm, h.CFG_DNSBL_SETTINGS + "/pfb_dnsbl_lenient") == "", (
+        "pfb_dnsbl_lenient should be ABSENT (empty) before the migration runs"
+    )
+
+    try:
+        # WHEN: run the SHIPPED migration function (the install-hook body) against the live
+        # config and persist the (changed) result.
+        migrate = (
+            "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+            f"$cfg = config_get_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, array());\n"
+            "$out = pfb_dnsbl_lenient_migrate($cfg);\n"
+            "if ($out !== NULL) {\n"
+            f"  config_set_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, $out);\n"
+            "  write_config('pfBlockerNG: ADR-22 migration (smoke)');\n"
+            "}\n"
+            f"echo {h._php_str(sentinel_open)} . ($out === NULL ? 'NULL' : 'SET') . {h._php_str(sentinel_close)};"
+        )
+        res = h.php_eval(deployed_vm, migrate)
+        assert sentinel_open in res.stdout, f"migration eval produced no sentinel: {res.stdout!r} {res.stderr!r}"
+        verdict = res.stdout[res.stdout.find(sentinel_open) + len(sentinel_open) : res.stdout.find(sentinel_close)]
+        assert verdict == "SET", f"migration should SET the missing key (returned {verdict})"
+
+        # THEN: the live config now carries pfb_dnsbl_lenient == 'on'.
+        after = h.config_get(deployed_vm, h.CFG_DNSBL_SETTINGS + "/pfb_dnsbl_lenient")
+        assert after == "on", f"migration must set pfb_dnsbl_lenient='on' for an existing install, got {after!r}"
+    finally:
+        # Restore the harness default (lenient ON) — same value the migration set, but make
+        # the cleanup explicit + independent of the assertion above.
+        h.set_dnsbl_lenient(deployed_vm, True)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -297,6 +297,27 @@ def test_dnsbl_control_fields_render(webui: WebUI, php_error_log_guard: PhpError
         assert needle in body, f"DNSBL page is missing the control marker {needle!r}"
 
 
+def test_dnsbl_lenient_parsing_field_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The ADR-22 'Lenient feed parsing' toggle renders cleanly on the DNSBL page — so a
+    regression that drops or breaks the field is caught at the render tier (not only by the
+    feed-parsing smoke).
+
+    Asserts the page passes the clean-render oracle AND that the POST field name
+    (``pfb_dnsbl_lenient``) and its 'Lenient feed parsing' label are present in the body.
+    ``php_error_log_guard`` enrolls this GET in the module-level no-growth sweep.
+    """
+    path = "/pfblockerng/pfblockerng_dnsbl.php"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
+    assert result.ok, f"DNSBL render oracle failed: {result.detail}"
+    body = resp.text
+    for needle in (
+        'name="pfb_dnsbl_lenient"',
+        "Lenient feed parsing",
+    ):
+        assert needle in body, f"DNSBL page is missing the lenient-parsing marker {needle!r}"
+
+
 # ADR-23: the setup wizard's DNSBL step now surfaces ADR-13's pfb_dnsvip_auto auto-VIP
 # toggle. Core wizard.php renders ONE step per GET, indexed by a 0-based `stepid` (verified
 # against pfSense upstream wizard.php: `$stepid` defaults to "0" and indexes $pkg['step']


### PR DESCRIPTION
Implements **ADR-22** — RFC 3986 scheme validation for the DNSBL non-lite feed parser, behind a single global **`pfb_dnsbl_lenient`** toggle (the 2026-06-15 design revision: one toggle, no per-feed selector, no known-affected list).

## Behaviour
- **`pfb_dnsbl_lenient` = ON (lenient)** — today's permissive strip, **byte-identical**: any `scheme://` stripped, URL paths removed downstream, malformed schemes silently accepted. No skips, no new log output.
- **`pfb_dnsbl_lenient` = OFF (strict)** — `pfb_dnsbl_strip_scheme()` validates the scheme against RFC 3986 (`^[a-zA-Z][a-zA-Z0-9+\-.]*$`) and rejects URL paths; a rejected line is **skipped + logged**.
- Resolution is one predicate: `strict = (pfb_dnsbl_lenient !== 'on')`.

## Defaults & migration
- **New installs default OFF (strict)** — correct parsing from day one.
- **Existing installs migrate to ON (lenient)** on upgrade (`pfblockerng_install.inc`), preserving prior behaviour; a first-ever install is not migrated; an existing value is never overwritten.

## Skip logging (strict only)
- Per line → the existing DNSBL parse-error log (`pfb_parsed_fail`).
- Per feed → one human-readable WARNING in the main pfBlockerNG log (`[ DNSBL ] <feed>: N line(s) skipped — strict parsing rejected an invalid scheme or URL path`). Summary-per-feed so a messy feed can't flood the main log.

## Phases (all on this branch)
- **P1** (`a6d54de`/replayed): behaviour-preserving extraction of `pfb_dnsbl_strip_scheme()` + 10 oracle tests pinning today's output (incl. the `123://`/`://` before-states).
- **P2** (`2794f0f`): the `pfb_dnsbl_lenient` checkbox (DNSBL tab) + RFC 3986 validation (`$strict` param) + call-site wiring + per-line/per-feed skip logging + upgrade migration. +24 PHPUnit (strict/lenient both ways, migration ×3, logging fires/silent).
- **P3** (`061b291`): three live-VM smoke cases (strict skips+logs / lenient blocks / migration) + helpers.

## Off-box gates
ruff, 1611 pytest, mypy, `php -l`, PHPUnit (549), PHPStan, PHPCS — all green.

## Live-VM smoke
Dispatched separately (`-m smoke`); run id will be posted here. The UI/checkbox is on the existing DNSBL settings page (`pfblockerng_dnsbl.php`, where the DNSBL config section lives — not `pfblockerng_general.php` as the ADR draft named).

https://claude.ai/code/session_01FQw7c1A4jkFrdxJ9Xm3CtW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQw7c1A4jkFrdxJ9Xm3CtW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added a **“Lenient feed parsing”** DNSBL setting (strict by default for new installs) to control how `scheme://` and URL paths are handled.
- In strict mode, invalid scheme/path entries are skipped, recorded in the DNSBL parse-error log, and summarized with a single per-feed WARNING.

**Bug Fixes**
- Enforces consistent strict-vs-lenient behavior for malformed DNSBL feed lines.

**Tests**
- Added unit and live smoke coverage for strict/lenient outcomes, per-feed warning/log behavior, and upgrade migration of the setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->