### PR TITLE
pfblockerng: accept IPv6 loopback for legacy DNSBL control + warn on its use (PFBL-03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,9 @@ are logged to the Reports tab.
 
 > **Migration:** the older `drill TXT python_control.*` DNS-TXT transport is
 > **deprecated** and **off by default**. Switch any CRON/Scheduler task to the
-> `pfblockerng dnsbl-control` CLI above. A one-release **DNSBL Control (legacy DNS TXT)**
-> sub-toggle re-enables the old path for migration only — it will be **removed next
-> release**.
+> `pfblockerng dnsbl-control` CLI above. The **DNSBL Control (legacy DNS TXT)** sub-toggle
+> re-enables the old path for migration; it is **deprecated**, **less secure**, and will be
+> **removed in a future release**.
 
 ## Documentation
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
         invalidateQueryInCache,
         log_err,
         log_info,
+        log_warn,
         module_env,
         module_qstate,
         query_info,
@@ -774,6 +775,18 @@ def pfb_control_watcher() -> None:
             waiter.close()
 
 
+def warn_if_legacy_control_enabled(enabled: bool) -> None:
+    """PFBL-03: log a one-time deprecation warning at module load when the legacy
+    DNS-TXT control transport is enabled. Neutral wording -- the path is deprecated
+    and less secure than the CLI, and will be removed in a future release."""
+    if enabled:
+        log_warn(
+            "[pfBlockerNG]: DNSBL Control legacy DNS-TXT transport is enabled. It is "
+            "deprecated and less secure than the CLI and will be removed in a future "
+            "release; migrate CRON/Scheduler tasks to the 'pfblockerng dnsbl-control' CLI."
+        )
+
+
 def init_standard(id: int, env: module_env) -> bool:
     global \
         pfb, \
@@ -923,9 +936,9 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["python_control"] = False
     # PFBL-03: the legacy DNS-TXT control transport is OFF by default and gated behind
     # this separate opt-in. DNSBL control is CLI-driven (pfblockerng dnsbl-control ...) via
-    # the local privileged command file; the DNS-TXT path is deprecated and slated for
-    # removal next release. NEXT RELEASE (PFBL-03): drop python_control_legacy + the
-    # DNS-TXT branch in operate() + the IPv4-only ``::1`` quirk entirely.
+    # the local privileged command file; the DNS-TXT path is deprecated and less secure,
+    # and will be removed in a future release (no fixed version). A startup warning is
+    # logged when it is enabled (see the config ingest in init_standard).
     pfb["python_control_legacy"] = False
     pfb["python_maxmind"] = False
     pfb["python_blocking"] = False
@@ -1114,6 +1127,7 @@ def init_standard(id: int, env: module_env) -> bool:
                 pfb["python_control"] = config.getboolean("MAIN", "python_control")
             if config.has_option("MAIN", "python_control_legacy"):
                 pfb["python_control_legacy"] = config.getboolean("MAIN", "python_control_legacy")
+            warn_if_legacy_control_enabled(pfb["python_control_legacy"])
 
             # ADR-07 P7: regex-safety knobs. ``regex_cap`` is the opt-in "Limit
             # long/complex regex" static pre-filter (drops over-long/nested-quantifier
@@ -5531,7 +5545,7 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
         # explicitly opts back in via ``python_control_legacy``; OFF by default, no DNSBL
         # control command is honoured over DNS-TXT. DNSBL control is CLI-driven
         # (pfblockerng dnsbl-control ...) over the local privileged command file. This whole
-        # branch is slated for removal next release.
+        # branch is deprecated and will be removed in a future release.
         if (
             pfb["python_control_legacy"]
             and qstate_valid
@@ -5540,7 +5554,8 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
         ):
             control_rcd = False
             control_msg = ""
-            if pfb["python_control"] and q_ip == "127.0.0.1":
+            # PFBL-03: accept the loopback address over either family (the old check was IPv4-only).
+            if pfb["python_control"] and q_ip in ("127.0.0.1", "::1", "::ffff:127.0.0.1"):
                 control_command = q_name_original.split(".")
                 # PFBL-03: route to the SINGLE shared handler (also used by the local
                 # privileged command channel) -- one implementation of the grammar.

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -807,7 +807,7 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ))->setHelp('<span class="text-danger">Deprecated</span> - re-enable the legacy DNS TXT control transport (drill TXT python_control.*).'
 	. '<div class="infoblock" style="width: 90%;">'
-	. 'This option is <strong>deprecated</strong>, <strong>less secure</strong>, and will be <strong>removed next release</strong>.<br />'
+	. 'This option is <strong>deprecated</strong>, <strong>less secure</strong>, and will be <strong>removed in a future release</strong>.<br />'
 	. 'It only takes effect when <strong>DNSBL Control</strong> above is enabled. Leave it off and use the CLI instead.<br />'
 	. 'Migrate any CRON/Scheduler tasks from drill TXT python_control.* to the pfblockerng dnsbl-control CLI shown above.'
 	. '</div>');

--- a/tests/test_pfbl03_txt_legacy_gate.py
+++ b/tests/test_pfbl03_txt_legacy_gate.py
@@ -4,8 +4,8 @@ WHY THIS FILE EXISTS
 --------------------
 DNSBL control moved onto the local privileged command file + CLI (pinned in
 ``test_pfbl03_control_channel.py``). The old DNS-TXT transport (``drill TXT
-python_control.*``) is retained for ONE release behind a new, separate, opt-in
-sub-toggle ``python_control_legacy`` -- OFF by default. These tests pin that gate:
+python_control.*``) is retained behind a new, separate, opt-in sub-toggle
+``python_control_legacy`` -- OFF by default. These tests pin that gate:
 
   * legacy OFF (the DEFAULT): a ``python_control.`` DNS TXT query is NOT honoured --
     the DNS-TXT path performs no DNSBL control action;
@@ -20,7 +20,9 @@ here we drive it through the real ``operate()`` DNS-TXT branch.
 
 from __future__ import annotations
 
+import builtins
 import types
+from typing import Any
 
 from unboundmodule import DNSMessage
 
@@ -97,6 +99,40 @@ class TestLegacyTxtControlGate:
         assert rcd is True
         assert P.pfb["python_blacklist"] is False
 
+    def test_legacy_dns_txt_control_honoured_over_ipv6_loopback(self) -> None:
+        # PFBL-03: the loopback gate accepts the IPv6 loopback ``::1``, not only the IPv4
+        # ``127.0.0.1`` -- so a legacy DNS-TXT command from an IPv6-loopback caller produces
+        # the SAME outcome as the IPv4 case (the old check was IPv4-only and dropped it).
+        # Given: the legacy transport is ON, the parent toggle is ON, and blocking is ON.
+        P.pfb["python_control"] = True
+        P.pfb["python_control_legacy"] = True
+        P.pfb["python_blacklist"] = True
+        assert P.pfb["python_blacklist"] is True  # BEFORE: blocking on.
+
+        # When: the python_control.disable DNS TXT query arrives over the IPv6 loopback.
+        qstate = _txt_control_qstate("python_control.disable.", q_ip="::1")
+        rcd = P.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        # Then: it is honoured -- blocking flips OFF, exactly as for 127.0.0.1.
+        assert rcd is True
+        assert P.pfb["python_blacklist"] is False
+
+    def test_legacy_dns_txt_control_honoured_over_mapped_ipv4_loopback(self) -> None:
+        # PFBL-03: the IPv4-mapped IPv6 loopback ``::ffff:127.0.0.1`` is also accepted.
+        # Given: the legacy transport is ON, the parent toggle is ON, and blocking is ON.
+        P.pfb["python_control"] = True
+        P.pfb["python_control_legacy"] = True
+        P.pfb["python_blacklist"] = True
+        assert P.pfb["python_blacklist"] is True  # BEFORE: blocking on.
+
+        # When: the command arrives over the IPv4-mapped IPv6 loopback.
+        qstate = _txt_control_qstate("python_control.disable.", q_ip="::ffff:127.0.0.1")
+        rcd = P.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        # Then: it is honoured -- blocking flips OFF.
+        assert rcd is True
+        assert P.pfb["python_blacklist"] is False
+
     def test_txt_control_inert_when_legacy_on_but_parent_disabled(self) -> None:
         # The deprecated branch still requires the parent DNSBL Control toggle + localhost:
         # with python_control OFF the existing in-branch guard refuses the command even
@@ -122,3 +158,51 @@ class TestLegacyTxtControlGate:
         P.operate(0, MODULE_EVENT_NEW, qstate, None)
 
         assert P.pfb["python_blacklist"] is True
+
+
+class TestLegacyControlStartupWarning:
+    """Scenario: at module load the config-ingest path logs a one-time deprecation
+    warning IFF the legacy DNS-TXT transport is enabled.
+
+    Background:
+      * ``warn_if_legacy_control_enabled`` is the exact unit init_standard calls right
+        after ingesting ``python_control_legacy`` from the ini -- driving it directly
+        exercises the SHIPPED warn, not a copy (init_standard needs the live env).
+      * The injected ``log_warn`` is captured to assert the call (and its absence).
+    """
+
+    @staticmethod
+    def _capture_warn(monkeypatch: Any) -> list[str]:
+        calls: list[str] = []
+        monkeypatch.setattr(builtins, "log_warn", lambda msg: calls.append(str(msg)))
+        return calls
+
+    def test_warns_once_when_legacy_enabled(self, monkeypatch: Any) -> None:
+        # Given: the deprecation warning logger is captured.
+        calls = self._capture_warn(monkeypatch)
+        assert calls == []  # BEFORE: nothing logged.
+
+        # When: the ingest path runs with the legacy transport enabled.
+        P.warn_if_legacy_control_enabled(True)
+
+        # Then: exactly ONE deprecation warning is logged.
+        assert len(calls) == 1
+        msg = calls[0].lower()
+        # The message is NEUTRAL: it names the deprecation + the migration, never a
+        # threat class.
+        assert "deprecated" in msg
+        assert "future release" in msg
+        assert "dnsbl-control" in msg
+        for banned in ("attacker", "spoof", "forged", "inject", "vulnerab", "bypass"):
+            assert banned not in msg
+
+    def test_does_not_warn_when_legacy_disabled(self, monkeypatch: Any) -> None:
+        # Given: the deprecation warning logger is captured.
+        calls = self._capture_warn(monkeypatch)
+        assert calls == []  # BEFORE: nothing logged.
+
+        # When: the ingest path runs with the legacy transport OFF (the default).
+        P.warn_if_legacy_control_enabled(False)
+
+        # Then: NO warning is logged -- proving the warn is gated, not unconditional.
+        assert calls == []


### PR DESCRIPTION
## Summary

Follow-up hardening + messaging for the PFBL-03 deprecated **DNSBL Control (legacy DNS TXT)** path. The secure CLI / command-channel path is unchanged.

- **Accept IPv6 loopback.** The legacy DNS-TXT gate matched only the IPv4 loopback (`q_ip == "127.0.0.1"`), so it was silently a no-op over `::1`. It now accepts the loopback address over either family: `q_ip in ("127.0.0.1", "::1", "::ffff:127.0.0.1")`.
- **Startup deprecation warning.** A new `warn_if_legacy_control_enabled()` helper (called from the config ingest in `init_standard`) logs a one-time warning at module load when the legacy path is enabled: it's deprecated, less secure than the CLI, and will be removed in a future release — with the `pfblockerng dnsbl-control` migration pointer.
- **Drop the fixed removal timeline.** Removed the "next release" / "one-release" claims from the UI help, `README.md`, and code comments in favor of "a future release" (the legacy path stays available for an open-ended deprecation window).

## Tests
- `tests/test_pfbl03_txt_legacy_gate.py`: new `::1` and `::ffff:127.0.0.1` cases (the control command flips blocking off, same as `127.0.0.1`; before-state asserted), the existing `127.0.0.1` case and the non-loopback negative branch retained.
- `TestLegacyControlStartupWarning`: warns exactly once when enabled (asserting the message is neutral — contains "deprecated"/"future release"/"dnsbl-control" and none of a threat-word denylist) and does not warn when disabled.
- Gates green: `pytest` 1615, `ruff`, `mypy tests/`, `php -l`, `markdownlint`.

Ref: PFBL-03.

https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6MSW6vcPUECmRacuGgdMf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated deprecation wording for the legacy DNS-TXT control transport to indicate it will be removed in a future release.

* **New Features**
  * Added a startup deprecation warning when legacy DNS-TXT control is enabled (warning shown once, only when enabled).

* **Updates**
  * Expanded legacy DNS-TXT loopback handling to support IPv6 loopback and IPv4-mapped IPv6 loopback.

* **Tests**
  * Added coverage for IPv6 loopback transition behavior and for the one-time startup deprecation warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->