### PR TITLE
pkg: stamp pfSense variant + version into the manifest (ADR-20)

### DIFF
--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1356,6 +1356,15 @@ def run_build(args: argparse.Namespace) -> Build:
         b.annotations = {"FreeBSD_version": args.freebsd_version}
     # `--annotate K=V` merges on top (e.g. commit=<sha>); release build adds nothing.
     b.annotations.update(extra_annotations)
+    # Stamp the pfSense variant (+ version) so build-repo-portable.py can bucket each
+    # .pkg into its variant-keyed catalog dir (ce-2.8 / plus-26.03) from the manifest
+    # alone — independent of ABI, which stops being a variant discriminator once CE and
+    # Plus converge on the same FreeBSD ABI (ADR-20 §1.2). Only when --variant is given;
+    # a plain (no-variant) release build is byte-identical to before.
+    if args.variant:
+        b.annotations["pfb_variant"] = args.variant
+        if args.pfsense_version:
+            b.annotations["pfb_pfsense_version"] = args.pfsense_version
     return b
 
 
@@ -1414,6 +1423,17 @@ def main(argv: list[str]) -> int:
             "entries derived from --php and --py-flavor (e.g. php83 + py311 for CE 2.8). "
             "Prevents wrong-variant packages from silently installing. "
             "Without this flag behaviour is unchanged (backward-compatible)."
+        ),
+    )
+    g_target.add_argument(
+        "--pfsense-version",
+        default="",
+        metavar="X.Y",
+        help=(
+            "pfSense target version (e.g. 2.8 / 26.03). When set with --variant, records "
+            "pfb_variant + pfb_pfsense_version manifest annotations so build-repo-portable.py "
+            "can bucket the .pkg into its variant-keyed catalog dir (ce-2.8 / plus-26.03) "
+            "from the manifest alone, independent of ABI (ADR-20)."
         ),
     )
 

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1417,6 +1417,7 @@ def main(argv: list[str]) -> int:
     g_target.add_argument(
         "--variant",
         default="",
+        choices=("CE", "Plus", ""),
         metavar="CE|Plus",
         help=(
             "pfSense variant (CE or Plus). When set, injects variant-specific RUN_DEPENDS "
@@ -1481,6 +1482,11 @@ def main(argv: list[str]) -> int:
     g_out.add_argument("--dry-run", action="store_true", help="print the build plan; do not write a .pkg")
 
     args = ap.parse_args(argv)
+    # Guard the manifest stamp contract: a malformed version would stamp a non-canonical
+    # pfb_pfsense_version and drift catalog bucketing downstream (ADR-20). --variant is
+    # already restricted to CE|Plus by `choices`.
+    if args.pfsense_version and not re.fullmatch(r"[0-9]+(?:\.[0-9]+)+", args.pfsense_version):
+        ap.error("--pfsense-version must be a dotted numeric version like 2.8 or 26.03")
 
     try:
         b = run_build(args)

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -721,6 +721,75 @@ def test_no_variant_flag_unchanged(tmp_path: Path) -> None:
     assert not any(n.startswith("py3") for n in dep_names)
 
 
+def test_variant_stamp_in_manifest_annotations(tmp_path: Path) -> None:
+    """`--variant` + `--pfsense-version` stamp pfb_variant / pfb_pfsense_version into
+    BOTH manifests, so build-repo-portable.py can bucket the .pkg into its variant-keyed
+    catalog dir (ce-2.8 / plus-26.03) from the manifest alone — needed once CE and Plus
+    converge on the same FreeBSD ABI, where ABI stops discriminating them (ADR-20 §1.2).
+
+    Before-state: a no-variant build carries no pfb_* annotation.
+    After-state CE: pfb_variant=CE, pfb_pfsense_version=2.8.
+    After-state Plus: pfb_variant=Plus, pfb_pfsense_version=26.03 (the opposite branch).
+    """
+    ports, portdir = _make_classic_port(tmp_path)
+
+    def _annotations(extra_args: list[str], out_name: str) -> dict:
+        out = tmp_path / out_name
+        rc = bpp.main(
+            [
+                "--ports", str(ports),
+                "--port-dir", str(portdir),
+                "--abi", "FreeBSD:15:amd64",
+                "--py-flavor", "py311",
+                "--compression", "xz",
+                "--out", str(out),
+                *extra_args,
+            ]
+        )  # fmt: skip
+        assert rc == 0
+        full, compact, _tf = _read_pkg(out / "testpkg-1.0_2.pkg")
+        # The stamp must ride BOTH manifests (the catalog reads compact, install reads full).
+        assert full.get("annotations", {}) == compact.get("annotations", {})
+        return full.get("annotations", {})
+
+    # Before: no --variant -> no stamp (proves the stamp is what adds the keys).
+    before = _annotations([], "plain")
+    assert "pfb_variant" not in before
+    assert "pfb_pfsense_version" not in before
+
+    # After CE.
+    ce = _annotations(["--variant", "CE", "--pfsense-version", "2.8", "--php", "8.3"], "ce")
+    assert ce["pfb_variant"] == "CE"
+    assert ce["pfb_pfsense_version"] == "2.8"
+
+    # After Plus (the opposite branch).
+    plus = _annotations(["--variant", "Plus", "--pfsense-version", "26.03", "--php", "8.5"], "plus")
+    assert plus["pfb_variant"] == "Plus"
+    assert plus["pfb_pfsense_version"] == "26.03"
+
+
+def test_variant_stamp_requires_variant_flag(tmp_path: Path) -> None:
+    """`--pfsense-version` alone (no --variant) does NOT stamp — the stamp is gated on
+    --variant, so a plain release build stays byte-identical."""
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--py-flavor", "py311",
+            "--compression", "xz",
+            "--pfsense-version", "2.8",
+            "--out", str(out),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    full, _compact, _tf = _read_pkg(out / "testpkg-1.0_2.pkg")
+    assert "pfb_variant" not in full.get("annotations", {})
+    assert "pfb_pfsense_version" not in full.get("annotations", {})
+
+
 def test_two_simultaneous_ce_entries() -> None:
     """Transition window: two CE entries with different PHP versions.
 

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -762,6 +762,12 @@ def test_variant_stamp_in_manifest_annotations(tmp_path: Path) -> None:
     assert ce["pfb_variant"] == "CE"
     assert ce["pfb_pfsense_version"] == "2.8"
 
+    # After variant-only (no --pfsense-version): variant is stamped, version is NOT
+    # (the `if args.pfsense_version` branch inside the stamp).
+    variant_only = _annotations(["--variant", "CE", "--php", "8.3"], "variant_only")
+    assert variant_only["pfb_variant"] == "CE"
+    assert "pfb_pfsense_version" not in variant_only
+
     # After Plus (the opposite branch).
     plus = _annotations(["--variant", "Plus", "--pfsense-version", "26.03", "--php", "8.5"], "plus")
     assert plus["pfb_variant"] == "Plus"
@@ -785,9 +791,37 @@ def test_variant_stamp_requires_variant_flag(tmp_path: Path) -> None:
         ]
     )  # fmt: skip
     assert rc == 0
-    full, _compact, _tf = _read_pkg(out / "testpkg-1.0_2.pkg")
-    assert "pfb_variant" not in full.get("annotations", {})
-    assert "pfb_pfsense_version" not in full.get("annotations", {})
+    full, compact, _tf = _read_pkg(out / "testpkg-1.0_2.pkg")
+    # Neither manifest carries the stamp (the catalog reads compact, install reads full).
+    for manifest in (full, compact):
+        assert "pfb_variant" not in manifest.get("annotations", {})
+        assert "pfb_pfsense_version" not in manifest.get("annotations", {})
+
+
+@pytest.mark.parametrize(
+    "bad_args",
+    [
+        ["--variant", "CE", "--pfsense-version", "bad"],  # non-numeric version
+        ["--variant", "CE", "--pfsense-version", "2"],  # no dotted component
+        ["--variant", "ce"],  # off-canon variant casing — rejected by choices
+    ],
+)
+def test_variant_inputs_rejected_at_parse(tmp_path: Path, bad_args: list[str]) -> None:
+    """Malformed --variant / --pfsense-version are rejected at parse time, so a typo can't
+    stamp a non-canonical annotation and drift catalog bucketing (ADR-20)."""
+    ports, portdir = _make_classic_port(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        bpp.main(
+            [
+                "--ports", str(ports),
+                "--port-dir", str(portdir),
+                "--abi", "FreeBSD:15:amd64",
+                "--py-flavor", "py311",
+                "--out", str(tmp_path / "o"),
+                *bad_args,
+            ]
+        )  # fmt: skip
+    assert exc.value.code == 2
 
 
 def test_two_simultaneous_ce_entries() -> None:


### PR DESCRIPTION
## What

Stamp the pfSense **variant + version** into each `.pkg` manifest so the catalog generator can bucket packages into variant-keyed catalogs (`ce-2.8/`, `plus-26.03/`) **from the manifest alone**.

- `build-pkg-portable.py`: new `--pfsense-version`; when `--variant` is set, records `pfb_variant` + `pfb_pfsense_version` annotations in both manifests.
- Gated on `--variant` — a plain (no-variant) build is byte-identical to before.
- Tests: before-state (no stamp without `--variant`), both variant branches (CE/Plus), stamp rides both manifests, and `--pfsense-version` alone is inert.

## Why — this is step 1 of fixing a real ADR-20 gap

ADR-20's self-hosted variant routing was marked **Accepted (2026-06-10)** but the live path was never wired: `routing.json` is **not deployed** (`pfblockerng.github.io/pkg/routing.json` → 404), so the Worker returns `502 "Routing manifest unavailable"` and **self-hosted repo installs via the Worker URL are currently non-functional** (the Netgate ports channel is unaffected). It looked done because the unit tests/code merged and the proving smoke (Case 4) was parked as a non-failing `xfail`.

`build-repo-portable.py` currently buckets by **ABI**, but ADR-20 §1.2 is explicit that `${ABI}` is a *FreeBSD-version* discriminator, not a CE/Plus one — CE and Plus converge on `FreeBSD:16:amd64` once CE moves to FreeBSD 16, at which point ABI can't separate the variant catalogs. Stamping the variant into the package makes bucketing robust through that convergence (the maintainer-chosen approach).

## Remaining sequence (separate PRs)

2. `build-repo-portable.py` — bucket by the stamp into variant-keyed catalogs (+ tests).
3. `pfBlockerNG/pkg publish.yml` — pass `--variant`/`--pfsense-version` on every build, generate + deploy `site/routing.json`, build the variant subtrees → **unblocks the live Worker**.
4. Worker — nightly `/nightly/` path-stripping + a real `wrangler deploy` (needs Cloudflare creds) — tracked follow-up. Then un-xfail Case 4.

**Routing is not live until #3 lands.**

## Validation

Local pre-commit green (ruff, 1613 pytest, mypy, markdownlint, shellcheck, `php -l`).

https://claude.ai/code/session_01GxxkRyv2k7JQu3fbdVTaJw

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxxkRyv2k7JQu3fbdVTaJw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portable package manifests now stamp pfSense variant metadata when built with the variant option (CE or Plus).
  * Added `--pfsense-version` to optionally include the pfSense version in manifest annotations (recorded only when a valid variant is specified).

* **Tests**
  * Added end-to-end coverage to confirm annotations are included/omitted correctly based on provided flags.
  * Added checks that invalid variant/version inputs are rejected at parse time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->