### PR TITLE
ci: matrix-driven pkg repository builder + UA-routing Worker (ADR-20)

### DIFF
--- a/.ADRs/ADR_20_CE_Plus_Variant_Distribution/ADR.md
+++ b/.ADRs/ADR_20_CE_Plus_Variant_Distribution/ADR.md
@@ -16,9 +16,12 @@
 > variant into manifests (#242) → generator variant bucketing → `publish.yml` routing.json +
 > variant catalogs → Worker nightly-prefix fix + `wrangler deploy`, then un-`xfail` Case 4.
 
-- **Status:** **Accepted (code) — routing NOT yet live** (code accepted 2026-06-10; corrected
-  2026-06-15, see the amendment above). §4/§7's *"routing.json live with active CE+Plus
-  routes"* is unmet until the routing-completion PRs land.
+- **Status:** **Accepted (code) — routing rework landed, awaiting live deploy** (code accepted
+  2026-06-10; routing rework B1–B3 landed 2026-06-15, see the amendment + the routing-completion
+  handoff). The matrix-driven builder/tree/`routing.json` (B1), the matrix-driven `publish.yml`
+  (B2), and the Worker rewrite (B3) are implemented + unit-tested. §4/§7's *"routing.json live with
+  active CE+Plus routes"* is unmet until the maintainer runs `publish.yml` (publishes the variant
+  tree + `routing.json` to Pages) and `wrangler deploy`s the Worker, then un-`xfail`s Case 4.
 - **Date:** 2026-06-09
 - **Branch:** `adr/20-ce-plus-variant-distribution` (off **`devel`**; `{slug}` =
   sanitised ADR-title slug per CLAUDE.md "Branch naming") / **Component(s):**

--- a/.ADRs/ADR_20_CE_Plus_Variant_Distribution/RESULTS/09_Routing_Rework_Landed.txt
+++ b/.ADRs/ADR_20_CE_Plus_Variant_Distribution/RESULTS/09_Routing_Rework_Landed.txt
@@ -1,0 +1,117 @@
+ADR-20 — ROUTING REWORK LANDED (B1–B3 implemented)  (2026-06-15)
+================================================================
+
+Follows 08_Routing_Completion_Handoff.txt. The B1→B2→B3 plan is implemented and
+pushed. What remains is the maintainer-only live deploy (CF creds) + un-xfail.
+
+Work branch (all repos): claude/adr-20-ql247e
+
+
+1. B1 — pfBlockerNG repo (branch claude/adr-20-ql247e)
+------------------------------------------------------
+scripts/build-pkg-portable.py — DUMB builder (ADR-20 D1):
+  - Dropped --variant. The versioned php/py guard deps are now injected directly
+    from --php / --py-flavor, keyed on --php (independent of whether the port
+    USES=php; php_ver was "" for a non-php port but the guard must still land).
+  - _resolve_variant_deps() emits each side only when its source is non-empty.
+  - .github/workflows/build-pkg-linux.yml: dropped the now-unused `variant`
+    input + VARIANT_ARG plumbing (the guard rides --php).
+  - Tests: test_no_php_no_guard_injected (off) + test_php_injects_variant_guard_via_cli
+    (on) — the real branch, before/after.
+
+scripts/build-repo-portable.py — the BRAIN (ADR-20 D2):
+  - build_repo_matrix(matrix, out, *, builder=_subprocess_pkg_builder, ports,
+    local_src, stable_src, stable_tag, nightly_keep=14, nightly_pkgversion,
+    build_nightly=True, **builder_kwargs). Per entry:
+      * release/<varver>/<arch>/  = devel + (stable from tag, if any), one catalog.
+      * nightly/<varver>/<arch>/  = fresh nightly folded with retained priors, pruned to N.
+      * a routing.json route {pattern: UA, catalog: <varver>, status}, deduped, most
+        specific first.
+  - LEAF = bare ARCH (amd64/aarch64), NOT the full ABI (ADR-20 D5). The varver
+    segment implies the FreeBSD major; each .pkg's manifest carries its real ABI.
+    NOTE: this is the reconciliation flagged in handoff 08 §5. The LEGACY build_repo
+    + its --catalog-name (full-ABI leaf under varver) is UNCHANGED and still tested —
+    it is the per-subtree primitive; the brain uses the arch leaf via _write_catalog_dir.
+  - Helpers: _ua_pattern (CE "pfSense/<mm>" / Plus "Netgate pfSense Plus/<mm>"),
+    _pkg_version_key (numeric component sort — .10 > .2), _dedup_routes,
+    _emit_catalog_from_paths, _retain_newest, _write_catalog_dir (refactored out of
+    build_repo; reads all source bytes BEFORE the wipe so a source .pkg inside dest —
+    nightly retention — survives).
+  - CLI: --build-matrix --matrix-json <file|-> --out ... [--ports --local-src
+    --stable-tag --stable-src --nightly-keep --nightly-pkgversion --no-nightly
+    --annotate K=V (repeatable, all builds)]. Accepts a bare array or {versions:[...]}.
+  - _CATALOG_PKG_FILES = {packagesite.pkg, data.pkg} — excluded when re-scanning a
+    built subtree for retention (they are *.pkg but not libpkg archives — a real bug
+    the tests caught).
+  - Tests (tests/test_build_repo_portable.py): tree layout (arch leaf, NOT full ABI),
+    routing.json contents + status passthrough + dedup/order, release devel-only→devel+stable
+    (before/after), full-matrix no-dedup, aarch64 distinct leaf, --no-nightly, nightly
+    retention across 3 runs (keep 2), _retain_newest, _ua_pattern, _pkg_version_key,
+    annotate passthrough, CLI validation + {versions:[...]} unwrap.
+
+Source-repo commits: df8e3ac (matrix builder + drop --variant), cbead2b (--annotate).
+
+
+2. B3 — pfBlockerNG repo, the Worker (same branch)
+--------------------------------------------------
+scripts/worker/src/index.js — rewritten to redirect to the matrix tree:
+    https://pfblockerng.github.io/pkg/<channel>/<varver>/<arch>/<rest>
+  channel = "nightly" if the request path starts with /nightly/, else "release"
+            (the tree HAS a release/ dir — resolves the 08-§3-vs-B3 ambiguity in
+             favour of §3's explicit examples; both channels carry a prefix).
+  varver  = matched from the UA via routing.json (first match wins).
+  arch    = parsed from the request's FreeBSD:<major>:<arch> ABI segment.
+  rest    = the path after the ABI segment.
+  Pure helpers parseArch() + resolveTarget() exported; failure modes 502/404 kept.
+  scripts/worker/test/router.test.js (node:test, `npm test`) — every branch incl.
+  the no-ABI 404 path. package.json: "type":"module" + "test":"node --test".
+
+Commit: 71d29b3.
+
+
+3. B2 — pfBlockerNG/pkg repo (branch claude/adr-20-ql247e)
+----------------------------------------------------------
+.github/workflows/publish.yml — rewritten to call the brain. Replaced the hand-rolled
+per-ABI devel loop, the manual nightly build/fingerprint/prune, the per-ABI catalog
+gen, and the release-asset fold-in with ONE `build-repo-portable.py --build-matrix`
+call. Reads the SOURCE BUILD matrix → matrix.json; resolves the latest non-prerelease
+release tag (→ stable_src; none today → stable skipped); restores the nightly Actions
+cache into site/nightly; builds; saves the cache; gen_landing (unchanged — it is
+manifest-driven, walks the tree, reads ABI/channel from each .pkg); deploy-pages.
+  - Nightly VER = <(-nightly PORTVERSION)>.YYYYMMDD.<run_number>.
+  - commit/created annotations stamped via --annotate for the landing page.
+
+Commit (pkg repo): 2dddc42.
+
+
+4. WHAT REMAINS (maintainer-only — needs creds I do not have)
+-------------------------------------------------------------
+a) Land the three branches (claude/adr-20-ql247e in pfBlockerNG, pfBlockerNG/pkg).
+   These are CI/scripts changes — normally /pr-merge-flow; here pushed to the
+   session branch per the task instructions (no PR opened).
+b) Run pfBlockerNG/pkg publish.yml (workflow_dispatch) → publishes the variant tree
+   + routing.json to Pages. Verify pfblockerng.github.io/pkg/routing.json is 200 and
+   release/ce-2.8/amd64/meta.conf etc. exist.
+c) `wrangler deploy` the Worker (scripts/worker) with the CF account creds.
+d) Verify: curl with the CE UA ("pfSense/2.8.0-RELEASE:<uid>") and Plus UA
+   ("Netgate pfSense Plus/26.03-RELEASE:<uid>") through the Worker → 302 to the
+   correct release/<varver>/<arch>/ target (and /nightly/ → nightly/).
+e) Un-xfail Case 4 (tests/smoke/test_repo_install.py ::
+   test_routing_url_delivers_variant_catalog): remove @pytest.mark.xfail and turn the
+   else-branch pytest.xfail into a hard assert. Dispatch the repo-install fan-out /
+   live-URL smoke to prove green. THEN ADR-20 flips to fully Accepted.
+
+
+5. KNOWN DEVIATIONS / FOLLOW-UPS
+--------------------------------
+- The old publish.yml's nightly FINGERPRINT skip (don't rebuild on a no-change day)
+  is GONE — the brain rebuilds the nightly every run, so a daily schedule yields a
+  new nightly per day even with unchanged source, consuming the 14-slot window with
+  identical-code builds. Acceptable for a nightly channel; re-add a skip in the brain
+  if churn matters.
+- The --annotate values (devel HEAD commit/created) are applied to ALL builds incl.
+  stable; for a real stable build from a tag the commit annotation would be devel's,
+  not the tag's. Harmless while production is empty; revisit when the first stable tag
+  is cut (pass the tag's commit for the stable leg).
+- gen_landing may list a .pkg twice if two varvers share the SAME ABI (full-matrix,
+  no-dedup). No such collision in today's matrix (CE FreeBSD:15, Plus FreeBSD:16).

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -42,10 +42,6 @@ on:
         description: "PHP version for dep names (CE 2.8 = 8.3)"
         required: false
         default: "8.3"
-      variant:
-        description: "pfSense variant (CE or Plus). Injects variant-specific RUN_DEPENDS. Omit for legacy behaviour."
-        required: false
-        default: ""
       ports_repo:
         description: "FreeBSD-ports repo carrying the port + Mk framework"
         required: false
@@ -76,10 +72,6 @@ on:
         required: false
         type: string
         default: "8.3"
-      variant:
-        required: false
-        type: string
-        default: ""
       ports_repo:
         required: false
         type: string
@@ -129,16 +121,11 @@ jobs:
             "https://github.com/${{ inputs.ports_repo }}" "${{ runner.temp }}/ports"
 
       - name: Build the .pkg (portable, from the local tree)
-        env:
-          BUILD_VARIANT: ${{ inputs.variant }}
         run: |
           set -eu
           mkdir -p out
-          VARIANT_ARG=""
-          if [ -n "$BUILD_VARIANT" ]; then
-            VARIANT_ARG="--variant $BUILD_VARIANT"
-          fi
-          # shellcheck disable=SC2086
+          # The variant guard deps (versioned php*/py*) are injected automatically
+          # from --php / --py-flavor (ADR-20); the builder stamps no variant itself.
           python3 scripts/build-pkg-portable.py \
             --ports "${{ runner.temp }}/ports" \
             --channel '${{ inputs.channel }}' \
@@ -146,7 +133,6 @@ jobs:
             --abi '${{ inputs.abi }}' \
             --py-flavor '${{ inputs.py_flavor }}' \
             --php '${{ inputs.php_version }}' \
-            $VARIANT_ARG \
             --out out
           ls -l out
 

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -741,11 +741,18 @@ def _resolve_variant_deps(php_version: str, py_flavor: str) -> list[str]:
     versions differ between CE and Plus — this is the variant guard that
     prevents a wrong-variant package from silently installing.
 
+    Each side is emitted only when its source value is non-empty, so a build
+    that supplies only one of ``--php`` / ``--py-flavor`` still yields a
+    well-formed dep list (no bare ``"py"`` / ``"php"``).
+
     Pure function: no I/O, no side effects.  Testable without a ports tree.
     """
-    php_dep = "php" + php_version.replace(".", "")
-    py_dep = py_flavor if py_flavor.startswith("py") else f"py{py_flavor}"
-    return [php_dep, py_dep]
+    deps: list[str] = []
+    if php_version:
+        deps.append("php" + php_version.replace(".", ""))
+    if py_flavor:
+        deps.append(py_flavor if py_flavor.startswith("py") else f"py{py_flavor}")
+    return deps
 
 
 def apply_repo_catalogue(deps: list[Dep], source: str, abi: str) -> None:
@@ -1336,14 +1343,17 @@ def run_build(args: argparse.Namespace) -> Build:
     deps: dict[str, Dep] = {}
     for d in resolve_deps(mk, ports_root, seed) + synthesize_uses_deps(mk, ports_root, php_ver, py_flavor, seed):
         deps.setdefault(d.name, d)
-    # When --variant is given, inject variant-specific RUN_DEPENDS entries derived
-    # from --php and --py-flavor. These are the variant guard: they ensure `pkg add`
-    # rejects a wrong-variant .pkg (CE php83 won't satisfy a Plus php85 dep).
-    # The dep names are derived — not hardcoded — so updating ci-metadata is the
-    # only change needed when CE/Plus bumps their PHP or Python version.
-    if args.variant:
-        for dep_name in _resolve_variant_deps(php_ver, py_flavor):
-            # Variant deps augment (never override) USES-synthesised deps.
+    # Inject the variant guard RUN_DEPENDS derived from --php and --py-flavor
+    # whenever --php is supplied. These ensure `pkg add` rejects a wrong-variant
+    # .pkg (CE php83 won't satisfy a Plus php85 dep). The dep names are derived —
+    # not hardcoded — so a CE/Plus PHP or Python bump is just a ci-metadata edit.
+    # (ADR-20: the builder is dumb — it stamps no variant; the guard is purely the
+    # versioned php/py deps the requested --php/--py-flavor imply.) Keyed on the CLI
+    # args, NOT the USES-derived php_ver: the guard is independent of whether the port
+    # itself USES=php (php_ver is "" for a non-php port, but the guard must still land).
+    if args.php:
+        for dep_name in _resolve_variant_deps(args.php, args.py_flavor):
+            # Variant guard deps augment (never override) USES-synthesised deps.
             deps.setdefault(dep_name, Dep(name=dep_name, origin="", version="0"))
     b.deps = list(deps.values())
     # Best-effort dep versions come from the ports tree; the version make package
@@ -1404,17 +1414,6 @@ def main(argv: list[str]) -> int:
     )
     g_target.add_argument(
         "--freebsd-version", default="", help="build host __FreeBSD_version for annotations, e.g. 1500068 (optional)"
-    )
-    g_target.add_argument(
-        "--variant",
-        default="",
-        metavar="CE|Plus",
-        help=(
-            "pfSense variant (CE or Plus). When set, injects variant-specific RUN_DEPENDS "
-            "entries derived from --php and --py-flavor (e.g. php83 + py311 for CE 2.8). "
-            "Prevents wrong-variant packages from silently installing. "
-            "Without this flag behaviour is unchanged (backward-compatible)."
-        ),
     )
 
     g_snap = ap.add_argument_group("nightly overrides (ADR-18; default off — release build byte-identical)")

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -860,6 +860,13 @@ def main(argv: list[str]) -> int:
         help="full pkg-safe nightly version <target>.YYYYMMDD.N applied to every entry's nightly build",
     )
     g_matrix.add_argument("--no-nightly", action="store_true", help="skip the nightly subtree (release + routing only)")
+    g_matrix.add_argument(
+        "--annotate",
+        action="append",
+        default=[],
+        metavar="K=V",
+        help="manifest annotation K=V applied to EVERY build (repeatable; e.g. commit=<sha> created=<epoch>)",
+    )
     args = ap.parse_args(argv)
 
     if args.print_conf:
@@ -895,6 +902,12 @@ def main(argv: list[str]) -> int:
             sys.stderr.write("build-repo-portable: matrix must be a JSON array (or {versions:[...]})\n")
             return 1
         pkgver = args.nightly_pkgversion
+        annotate: dict[str, str] = {}
+        for item in args.annotate:
+            if "=" not in item:
+                ap.error(f"--annotate must be K=V (got {item!r})")
+            k, v = item.split("=", 1)
+            annotate[k] = v
         try:
             build_repo_matrix(
                 matrix,
@@ -906,6 +919,7 @@ def main(argv: list[str]) -> int:
                 nightly_keep=args.nightly_keep,
                 nightly_pkgversion=(lambda _e: pkgver) if pkgver else None,
                 build_nightly=not args.no_nightly,
+                annotate=annotate or None,
             )
         except (BuildRepoError, subprocess.CalledProcessError) as e:
             sys.stderr.write(f"build-repo-portable: {e}\n")

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -68,6 +68,16 @@
 #   catalog. Entries have {pattern, catalog, status}; output is {"routes": [...]}.
 #   Also callable from Python as generate_routing_json(entries, output_path).
 #
+# MATRIX-DRIVEN BUILD (ADR-20 routing rework) — the BRAIN
+#   Pass --build-matrix --matrix-json <file|-> --out <dir> to drive the DUMB
+#   build-pkg-portable.py per (matrix entry × channel) and project the version matrix
+#   1:1 onto the tree:
+#       release/<variant>-<major.minor>/<arch>/<catalog files>   (devel + stable)
+#       nightly/<variant>-<major.minor>/<arch>/<catalog files>   (retained to N)
+#   plus routing.json at the pkg root. The LEAF is the bare arch (amd64/aarch64) —
+#   the version segment already implies the FreeBSD major, and each .pkg's manifest
+#   carries its real ABI. Also callable from Python as build_repo_matrix(...).
+#
 # Requires: python3 (stdlib only) + a zstd encoder (the `zstd` binary, or the
 # python `zstandard` module) — the same compressor contract as build-pkg-portable.py.
 #
@@ -93,6 +103,8 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 # --------------------------------------------------------------------------- #
@@ -445,41 +457,294 @@ def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) 
     catalog_root.mkdir(parents=True, exist_ok=True)
     for abi in sorted(by_abi):
         bucket = catalog_root / abi
-        # Wipe + rebuild for determinism (a removed .pkg never lingers).
-        if bucket.exists():
-            shutil.rmtree(bucket)
-        bucket.mkdir(parents=True)
-
-        catalog_objs: list[dict] = []
-        # Deterministic order: by (name, version).
-        for (name, version), (path, manifest) in sorted(by_abi[abi].items()):
-            canonical = f"{name}-{version}.pkg"
-            pkg_bytes = path.read_bytes()
-            dest = bucket / canonical
-            dest.write_bytes(pkg_bytes)
-            # Preserve the source .pkg's mtime so the published artifact reflects its
-            # real build time — a cache-restored nightly keeps its original datetime
-            # instead of jumping to this catalog-regeneration run. The landing page
-            # reads this mtime as the artifact's publish date.
-            src_mtime = path.stat().st_mtime
-            os.utime(dest, (src_mtime, src_mtime))
-            obj = catalog_object(
-                manifest,
-                pkg_name=canonical,
-                sum_=pkg_checksum(pkg_bytes),
-                pkgsize=len(pkg_bytes),
-            )
-            catalog_objs.append(obj)
-
-        # meta.conf + its identical `meta` copy (real `pkg repo` writes both).
-        (bucket / "meta.conf").write_text(META_CONF)
-        (bucket / "meta").write_text(META_CONF)
-        # packagesite.pkg (packagesite.yaml = NDJSON) + data.pkg (data = one JSON object).
-        write_zstd_tar("packagesite.yaml", _ndjson(catalog_objs), bucket / "packagesite.pkg")
-        write_zstd_tar("data", _data_blob(catalog_objs), bucket / "data.pkg")
-        sys.stderr.write(f"==> built catalog {bucket} ({len(catalog_objs)} package(s))\n")
+        n = _write_catalog_dir(bucket, by_abi[abi])
+        sys.stderr.write(f"==> built catalog {bucket} ({n} package(s))\n")
 
     return sorted(by_abi)
+
+
+def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict]]) -> int:
+    """Write one pkg catalog at ``dest`` from a ``{(name, version): (path, manifest)}`` map.
+
+    Wipes + rebuilds ``dest`` for determinism (a removed .pkg never lingers), copies each
+    package CANONICALLY (``<name>-<version>.pkg``, source mtime preserved), and emits the
+    catalog descriptor (``meta.conf`` + its identical ``meta``) plus ``packagesite.pkg``
+    (NDJSON) and ``data.pkg`` (one JSON object). Returns the package count.
+
+    All source bytes are read BEFORE the wipe so a source .pkg living inside ``dest``
+    (e.g. nightly-retention inputs already in the bucket) survives the rebuild.
+    """
+    # Read every source up front (sources may live inside dest — see nightly retention).
+    staged: list[tuple[str, bytes, float, dict]] = []
+    for (name, version), (path, manifest) in sorted(items.items()):
+        canonical = f"{name}-{version}.pkg"
+        staged.append((canonical, path.read_bytes(), path.stat().st_mtime, manifest))
+
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True)
+
+    catalog_objs: list[dict] = []
+    for canonical, pkg_bytes, src_mtime, manifest in staged:
+        target = dest / canonical
+        target.write_bytes(pkg_bytes)
+        # Preserve the source .pkg's mtime so the published artifact reflects its real
+        # build time — a cache-restored nightly keeps its original datetime instead of
+        # jumping to this catalog-regeneration run. The landing page reads this mtime
+        # as the artifact's publish date.
+        os.utime(target, (src_mtime, src_mtime))
+        catalog_objs.append(
+            catalog_object(manifest, pkg_name=canonical, sum_=pkg_checksum(pkg_bytes), pkgsize=len(pkg_bytes))
+        )
+
+    # meta.conf + its identical `meta` copy (real `pkg repo` writes both).
+    (dest / "meta.conf").write_text(META_CONF)
+    (dest / "meta").write_text(META_CONF)
+    # packagesite.pkg (packagesite.yaml = NDJSON) + data.pkg (data = one JSON object).
+    write_zstd_tar("packagesite.yaml", _ndjson(catalog_objs), dest / "packagesite.pkg")
+    write_zstd_tar("data", _data_blob(catalog_objs), dest / "data.pkg")
+    return len(catalog_objs)
+
+
+# --------------------------------------------------------------------------- #
+# ADR-20 routing rework: the matrix-driven BRAIN
+#
+# build_repo_matrix() is the single orchestrator. It reads the ci-metadata version
+# matrix and, per (entry × channel), drives the DUMB build-pkg-portable.py builder,
+# places each .pkg into a literal 1:1 projection of the matrix —
+#     release/<variant>-<major.minor>/<arch>/<catalog files>
+#     nightly/<variant>-<major.minor>/<arch>/<catalog files>
+# — generates each subtree's catalog, and writes routing.json at the pkg root.
+#
+# Layout decisions (maintainer-confirmed):
+#   * channel-group "release" = the production (stable-tag) + devel packages in ONE
+#     catalog (Netgate-style; both coexist). "nightly" = nightly only, retained to N.
+#   * the version segment = catalog_name_from_version() ("ce-2.8" / "plus-26.03").
+#   * the LEAF is the bare ARCH (amd64 / aarch64), NOT the full ABI: the version
+#     segment already implies the FreeBSD major, and each .pkg's real ABI lives in
+#     its own manifest (pkg validates the ABI from the package), so the directory is
+#     purely the routing path.
+#   * FULL MATRIX, NO DEDUP — each entry populates its own (version, arch) subtree
+#     independently, even if two pfSense versions share ABI+PHP+PY.
+# --------------------------------------------------------------------------- #
+
+
+# A builder produces ONE .pkg for a given channel/target into out_dir and returns its
+# path. The default subprocess builder drives build-pkg-portable.py; tests inject a
+# stub. Keyword-only target args keep call sites self-documenting.
+PkgBuilder = Callable[..., Path]
+
+_THIS_DIR = Path(__file__).resolve().parent
+_BUILD_PKG = _THIS_DIR / "build-pkg-portable.py"
+
+# Catalog files that are *.pkg but NOT libpkg packages — skip them when re-scanning a
+# built subtree (e.g. for nightly retention).
+_CATALOG_PKG_FILES = {"packagesite.pkg", "data.pkg"}
+
+
+def _ua_pattern(variant: str, pfsense_version: str) -> str:
+    """The pfSense User-Agent prefix the Worker matches a request against.
+
+    CE   -> "pfSense/<major.minor>"               (e.g. "pfSense/2.8")
+    Plus -> "Netgate pfSense Plus/<major.minor>"  (e.g. "Netgate pfSense Plus/26.03")
+    """
+    major_minor = ".".join(pfsense_version.split(".")[:2])
+    if variant.lower() == "plus":
+        return f"Netgate pfSense Plus/{major_minor}"
+    return f"pfSense/{major_minor}"
+
+
+def _pkg_version_key(version: str) -> list[int]:
+    """A monotone sort key for a pkg version, component-wise on ``.`` / ``_`` / ``,``.
+
+    Nightly versions are ``<target>.YYYYMMDD.N`` (all-numeric components), so a plain
+    numeric component compare orders them chronologically — a later build sorts higher.
+    Non-numeric components degrade to 0 (good enough for the nightly retention sort,
+    the only caller).
+    """
+    return [int(c) if c.isdigit() else 0 for c in re.split(r"[._,]", version)]
+
+
+def _dedup_routes(routes: list[dict]) -> list[dict]:
+    """Dedup routing entries and order most-specific (longest pattern) first.
+
+    Two matrix entries that share a UA pattern + catalog + status (e.g. a Plus
+    version's amd64 and aarch64 entries) collapse to ONE route. Ordering longest
+    pattern first lets the Worker's first-match win for overlapping prefixes
+    ("Netgate pfSense Plus/26.03" before "pfSense/2.8").
+    """
+    seen: set[tuple[str, str, str]] = set()
+    unique: list[dict] = []
+    for r in routes:
+        key = (r["pattern"], r["catalog"], r["status"])
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(r)
+    return sorted(unique, key=lambda r: (-len(r["pattern"]), r["pattern"]))
+
+
+def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path]) -> int:
+    """Read each .pkg's manifest, dedup by (name, version), collision-check, emit at dest."""
+    entries: list[tuple[Path, dict]] = [(p, read_compact_manifest(p)) for p in sorted(set(pkg_paths))]
+    _check_collisions(entries)
+    items: dict[tuple[str, str], tuple[Path, dict]] = {}
+    for path, manifest in entries:
+        nv = (manifest["name"], manifest["version"])
+        if nv in items:
+            sys.stderr.write(f"==> dedup: {path.name} duplicates {items[nv][0].name} ({nv[0]}-{nv[1]})\n")
+            continue
+        items[nv] = (path, manifest)
+    return _write_catalog_dir(dest, items)
+
+
+def _retain_newest(pkg_paths: list[Path], keep: int) -> list[Path]:
+    """Keep the ``keep`` newest .pkg by version (a later nightly supersedes an older one).
+
+    Dedup by (name, version) first; tie-break the version sort by mtime then name so the
+    result is deterministic. Returns the kept paths (≤ keep).
+    """
+    by_nv: dict[tuple[str, str], tuple[Path, float]] = {}
+    for p in pkg_paths:
+        m = read_compact_manifest(p)
+        nv = (m["name"], m["version"])
+        mt = p.stat().st_mtime
+        # On a (name, version) dup, keep the newer-on-disk file.
+        if nv not in by_nv or mt > by_nv[nv][1]:
+            by_nv[nv] = (p, mt)
+    ordered = sorted(
+        by_nv.items(),
+        key=lambda kv: (_pkg_version_key(kv[0][1]), kv[1][1], kv[0][0]),
+        reverse=True,
+    )
+    return [path for _nv, (path, _mt) in ordered[:keep]]
+
+
+def _subprocess_pkg_builder(
+    channel: str,
+    *,
+    abi: str,
+    php: str,
+    py_flavor: str,
+    out_dir: Path,
+    ports: Path | None = None,
+    local_src: Path | None = None,
+    pkgversion: str | None = None,
+    annotate: dict[str, str] | None = None,
+    **_ignored: object,
+) -> Path:
+    """Default builder: drive build-pkg-portable.py to produce ONE .pkg, return its path."""
+    cmd = [
+        sys.executable, str(_BUILD_PKG),
+        "--channel", channel,
+        "--abi", abi,
+        "--php", php,
+        "--py-flavor", py_flavor,
+        "--out", str(out_dir),
+    ]  # fmt: skip
+    if ports is not None:
+        cmd += ["--ports", str(ports)]
+    if local_src is not None:
+        cmd += ["--local-src", str(local_src)]
+    if pkgversion is not None:
+        cmd += ["--pkgversion", pkgversion]
+    for k, v in (annotate or {}).items():
+        cmd += ["--annotate", f"{k}={v}"]
+    before = set(out_dir.glob("*.pkg"))
+    subprocess.run(cmd, check=True)
+    produced = sorted(set(out_dir.glob("*.pkg")) - before)
+    if not produced:
+        raise BuildRepoError(f"builder produced no .pkg (channel={channel}, abi={abi})")
+    return produced[-1]
+
+
+def build_repo_matrix(
+    matrix: list[dict],
+    out_dir: Path,
+    *,
+    builder: PkgBuilder = _subprocess_pkg_builder,
+    ports: Path | None = None,
+    local_src: Path | None = None,
+    stable_src: Path | None = None,
+    stable_tag: str | None = None,
+    nightly_keep: int = 14,
+    nightly_pkgversion: Callable[[dict], str] | None = None,
+    build_nightly: bool = True,
+    **builder_kwargs: object,
+) -> dict:
+    """Build the full variant/arch repository tree + routing.json from the version matrix.
+
+    For each matrix entry (each carrying pfsense_version, variant, freebsd_major, arch,
+    php_version, py_flavor, status):
+
+      * RELEASE subtree ``release/<varver>/<arch>/`` — the devel .pkg, plus the stable
+        .pkg built from ``stable_tag`` (skipped when no stable tag exists), in one catalog.
+      * NIGHTLY subtree ``nightly/<varver>/<arch>/`` — the freshly built nightly folded in
+        with any pre-existing nightlies in that subtree (cache-restored by the caller),
+        pruned to the ``nightly_keep`` newest. Skipped when ``build_nightly`` is False.
+      * a routing.json route ``{pattern, catalog: <varver>, status}`` (deduped, most
+        specific first).
+
+    ``builder`` is injectable (tests pass a stub); the default drives build-pkg-portable.py.
+    Extra ``builder_kwargs`` pass through to every builder call. Returns a summary dict.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    routes: list[dict] = []
+    built: list[str] = []
+
+    for entry in matrix:
+        version = entry["pfsense_version"]
+        variant = entry["variant"]
+        arch = entry.get("arch") or "amd64"
+        major = entry["freebsd_major"]
+        abi = f"FreeBSD:{major}:{arch}"
+        php = entry["php_version"]
+        py_flavor = entry["py_flavor"]
+        status = entry.get("status", "active")
+        varver = catalog_name_from_version(version, variant)  # e.g. "ce-2.8"
+        common = dict(abi=abi, php=php, py_flavor=py_flavor, varver=varver, arch=arch, **builder_kwargs)
+
+        # --- release subtree: devel + (optional) stable, one channel-group catalog ---
+        release_dir = out_dir / "release" / varver / arch
+        with tempfile.TemporaryDirectory() as td:
+            staging = Path(td)
+            release_pkgs: list[Path] = [builder("devel", out_dir=staging, ports=ports, local_src=local_src, **common)]
+            if stable_tag:
+                release_pkgs.append(
+                    builder("stable", out_dir=staging, ports=ports, local_src=stable_src or local_src, **common)
+                )
+            _emit_catalog_from_paths(release_dir, release_pkgs)
+        built.append(str(release_dir))
+        sys.stderr.write(f"==> release catalog {release_dir} ({len(release_pkgs)} package(s))\n")
+
+        # --- nightly subtree: fold the new build in with retained prior nightlies ---
+        if build_nightly:
+            nightly_dir = out_dir / "nightly" / varver / arch
+            # Glob the retained package files, EXCLUDING the catalog files (which are also
+            # named *.pkg: packagesite.pkg / data.pkg) — they are not libpkg archives.
+            existing = (
+                sorted(p for p in nightly_dir.glob("*.pkg") if p.name not in _CATALOG_PKG_FILES)
+                if nightly_dir.is_dir()
+                else []
+            )
+            with tempfile.TemporaryDirectory() as td:
+                staging = Path(td)
+                pkgver = nightly_pkgversion(entry) if nightly_pkgversion else None
+                new_nightly = builder(
+                    "nightly", out_dir=staging, ports=ports, local_src=local_src, pkgversion=pkgver, **common
+                )
+                kept = _retain_newest([*existing, new_nightly], nightly_keep)
+                n = _emit_catalog_from_paths(nightly_dir, kept)
+            built.append(str(nightly_dir))
+            sys.stderr.write(f"==> nightly catalog {nightly_dir} ({n} package(s), kept ≤{nightly_keep})\n")
+
+        routes.append({"pattern": _ua_pattern(variant, version), "catalog": varver, "status": status})
+
+    routes = _dedup_routes(routes)
+    generate_routing_json(routes, str(out_dir / "routing.json"))
+    sys.stderr.write(f"==> wrote routing.json ({len(routes)} route(s))\n")
+    return {"routes": routes, "built": built}
 
 
 def print_conf(base_url: str) -> None:
@@ -516,7 +781,11 @@ def main(argv: list[str]) -> int:
             "  # write a routing manifest (ADR-20)\n"
             "  build-repo-portable.py --generate-routing-json \\\n"
             '    --routing-entries \'[{"pattern":"pfSense/2.8","catalog":"ce-2.8","status":"active"}]\' \\\n'
-            "    --routing-json-path routing.json\n"
+            "    --routing-json-path routing.json\n\n"
+            "  # matrix-driven: build the full variant/arch tree + routing.json (ADR-20)\n"
+            "  read-version-matrix.sh --print-build | build-repo-portable.py --build-matrix \\\n"
+            "    --matrix-json - --out ./site --ports ./ports --local-src . \\\n"
+            "    --nightly-pkgversion 3.2.16.20260615.1\n"
         ),
     )
     ap.add_argument("--in", dest="in_dir", help="directory holding the input .pkg files (searched, non-recursive)")
@@ -555,6 +824,42 @@ def main(argv: list[str]) -> int:
         default=None,
         help="output file path for --generate-routing-json",
     )
+    g_matrix = ap.add_argument_group("matrix-driven build (ADR-20 routing rework)")
+    g_matrix.add_argument(
+        "--build-matrix",
+        action="store_true",
+        help=(
+            "drive build-pkg-portable.py per (matrix entry × channel), lay out the "
+            "release/<varver>/<arch>/ + nightly/<varver>/<arch>/ tree under --out, and "
+            "write routing.json. Requires --matrix-json + --out."
+        ),
+    )
+    g_matrix.add_argument(
+        "--matrix-json",
+        default=None,
+        help="path to the BUILD matrix JSON (a JSON array, or {versions:[...]}); '-' reads stdin",
+    )
+    g_matrix.add_argument("--ports", default=None, help="FreeBSD-ports tree passed to build-pkg-portable.py --ports")
+    g_matrix.add_argument(
+        "--local-src", default=None, help="local pfBlockerNG source passed to build-pkg-portable.py --local-src"
+    )
+    g_matrix.add_argument(
+        "--stable-tag",
+        default=None,
+        help="latest stable release tag; when set, a stable .pkg joins each release catalog",
+    )
+    g_matrix.add_argument(
+        "--stable-src", default=None, help="source tree checked out at --stable-tag (defaults to --local-src)"
+    )
+    g_matrix.add_argument(
+        "--nightly-keep", type=int, default=14, help="nightlies retained per (version, arch) (default 14)"
+    )
+    g_matrix.add_argument(
+        "--nightly-pkgversion",
+        default=None,
+        help="full pkg-safe nightly version <target>.YYYYMMDD.N applied to every entry's nightly build",
+    )
+    g_matrix.add_argument("--no-nightly", action="store_true", help="skip the nightly subtree (release + routing only)")
     args = ap.parse_args(argv)
 
     if args.print_conf:
@@ -574,6 +879,37 @@ def main(argv: list[str]) -> int:
             return 1
         generate_routing_json(entries, args.routing_json_path)
         sys.stderr.write(f"==> wrote routing manifest: {args.routing_json_path} ({len(entries)} route(s))\n")
+        return 0
+
+    if args.build_matrix:
+        if not args.matrix_json or not args.out_dir:
+            ap.error("--build-matrix requires --matrix-json and --out")
+        raw = sys.stdin.read() if args.matrix_json == "-" else Path(args.matrix_json).read_text()
+        try:
+            parsed = json.loads(raw)
+        except ValueError as e:
+            sys.stderr.write(f"build-repo-portable: --matrix-json is not valid JSON: {e}\n")
+            return 1
+        matrix = parsed.get("versions") if isinstance(parsed, dict) else parsed
+        if not isinstance(matrix, list):
+            sys.stderr.write("build-repo-portable: matrix must be a JSON array (or {versions:[...]})\n")
+            return 1
+        pkgver = args.nightly_pkgversion
+        try:
+            build_repo_matrix(
+                matrix,
+                Path(args.out_dir),
+                ports=Path(args.ports) if args.ports else None,
+                local_src=Path(args.local_src) if args.local_src else None,
+                stable_tag=args.stable_tag,
+                stable_src=Path(args.stable_src) if args.stable_src else None,
+                nightly_keep=args.nightly_keep,
+                nightly_pkgversion=(lambda _e: pkgver) if pkgver else None,
+                build_nightly=not args.no_nightly,
+            )
+        except (BuildRepoError, subprocess.CalledProcessError) as e:
+            sys.stderr.write(f"build-repo-portable: {e}\n")
+            return 1
         return 0
 
     if not args.in_dir or not args.out_dir:

--- a/scripts/worker/package.json
+++ b/scripts/worker/package.json
@@ -1,9 +1,11 @@
 {
   "name": "pfblockerng-pkg-router",
   "private": true,
+  "type": "module",
   "scripts": {
     "deploy": "wrangler deploy",
-    "dev": "wrangler dev"
+    "dev": "wrangler dev",
+    "test": "node --test"
   },
   "devDependencies": {
     "wrangler": "^3"

--- a/scripts/worker/src/index.js
+++ b/scripts/worker/src/index.js
@@ -39,6 +39,13 @@ export function parseArch(abiSegment) {
   return m ? m[1] : null;
 }
 
+// Normalize the parsed routing.json to a routes array, or null when the manifest
+// has an unexpected shape — so a malformed manifest fails closed (502) instead of
+// throwing past the explicit error handling on routes.find().
+export function normalizeRoutes(data) {
+  return Array.isArray(data?.routes) ? data.routes : null;
+}
+
 // Resolve the Pages target URL for a request path + matched route.
 // Returns the absolute Pages URL, or null when the path has no valid ABI segment.
 export function resolveTarget(pathname, route) {
@@ -101,5 +108,5 @@ async function getRoutes(ctx) {
     resp = ttlResp;
   }
   const data = await resp.clone().json();
-  return data.routes ?? null;
+  return normalizeRoutes(data);
 }

--- a/scripts/worker/src/index.js
+++ b/scripts/worker/src/index.js
@@ -1,15 +1,65 @@
-// Cloudflare Worker — pfBlockerNG pkg routing (ADR-20 Phase 5).
+// Cloudflare Worker — pfBlockerNG pkg routing (ADR-20).
 //
-// Reads User-Agent, fetches routing.json from Pages (edge-cached 5 min),
-// matches the UA against route patterns (first match wins), and 302-redirects
-// to the version-keyed catalog dir on Pages.
+// A pfSense box's pkg(8) hits this Worker (its repo-conf url is the Worker, not
+// Pages directly). The Worker reads the request's User-Agent, matches it against
+// routing.json (fetched from Pages, edge-cached 5 min), and 302-redirects to the
+// matrix-projected catalog dir on Pages:
+//
+//   <channel>/<varver>/<arch>/<rest>
+//
+// where
+//   channel = "nightly" when the request path starts with /nightly/, else "release"
+//             (the nightly repo-conf url carries a /nightly/ prefix; the release
+//             repo-conf url does not — see scripts/add-repo.sh);
+//   varver  = the catalog matched from the UA via routing.json (first match wins),
+//             e.g. "ce-2.8" / "plus-26.03";
+//   arch    = the architecture parsed from the request's FreeBSD:<major>:<arch>
+//             ABI segment (amd64 / aarch64) — the catalog leaf is the bare arch,
+//             since the varver segment already implies the FreeBSD major;
+//   rest    = the path AFTER the ABI segment (meta.conf, packagesite.pkg,
+//             <name>-<version>.pkg, ...).
+//
+// This mirrors the tree scripts/build-repo-portable.py --build-matrix lays out.
 //
 // Failure modes are explicit, never a silent wrong install:
-//   - routing.json unavailable  → 502
-//   - no matching route (unsupported pfSense version) → 404
+//   - routing.json unavailable                         → 502
+//   - no route matches the UA (unsupported version)    → 404
+//   - the request path carries no valid ABI segment    → 404
 
-const ROUTING_MANIFEST_URL = "https://pfblockerng.github.io/pkg/routing.json";
+const PAGES_BASE = "https://pfblockerng.github.io/pkg";
+const ROUTING_MANIFEST_URL = `${PAGES_BASE}/routing.json`;
 const CACHE_TTL = 300; // seconds — edge cache for routing.json
+
+// Parse the architecture out of a FreeBSD ABI segment.
+//   "FreeBSD:15:amd64"   -> "amd64"
+//   "FreeBSD:16:aarch64" -> "aarch64"
+// Anything that is not a well-formed ABI segment -> null (caller 404s).
+export function parseArch(abiSegment) {
+  const m = /^FreeBSD:\d+:([A-Za-z0-9_]+)$/.exec(abiSegment ?? "");
+  return m ? m[1] : null;
+}
+
+// Resolve the Pages target URL for a request path + matched route.
+// Returns the absolute Pages URL, or null when the path has no valid ABI segment.
+export function resolveTarget(pathname, route) {
+  const segments = pathname.split("/").filter((s) => s.length > 0);
+
+  // A leading /nightly/ selects the nightly channel tree; otherwise release.
+  let channel = "release";
+  if (segments[0] === "nightly") {
+    channel = "nightly";
+    segments.shift();
+  }
+
+  // The next segment must be the FreeBSD ABI (the repo-conf url is "<worker>/${ABI}").
+  const arch = parseArch(segments.shift());
+  if (!arch) {
+    return null;
+  }
+
+  const rest = segments.join("/");
+  return `${PAGES_BASE}/${channel}/${route.catalog}/${arch}/${rest}`;
+}
 
 export default {
   async fetch(request, env, ctx) {
@@ -21,19 +71,19 @@ export default {
       return new Response("Routing manifest unavailable", { status: 502 });
     }
 
-    // First match wins; list more-specific patterns before less-specific ones
-    // in routing.json (e.g. "pfSense/2.9" before a "pfSense/2" catch-all).
+    // First match wins; routing.json lists more-specific patterns first
+    // (e.g. "Netgate pfSense Plus/26.03" before "pfSense/2.8").
     const route = routes.find((r) => ua.includes(r.pattern));
     if (!route) {
-      return new Response(`Unsupported pfSense version (UA: ${ua})`, {
+      return new Response(`Unsupported pfSense version (UA: ${ua})`, { status: 404 });
+    }
+
+    const target = resolveTarget(url.pathname, route);
+    if (!target) {
+      return new Response(`Malformed request path (expected an ABI segment): ${url.pathname}`, {
         status: 404,
       });
     }
-
-    // 302 redirect to the version-keyed catalog dir on Pages.
-    // Input path:  /FreeBSD:15:amd64/packagesite.yaml.pkg
-    // Output path: https://pfblockerng.github.io/pkg/ce-2.8/FreeBSD:15:amd64/...
-    const target = `https://pfblockerng.github.io/pkg/${route.catalog}${url.pathname}`;
     return Response.redirect(target, 302);
   },
 };

--- a/scripts/worker/test/router.test.js
+++ b/scripts/worker/test/router.test.js
@@ -1,0 +1,58 @@
+// Unit coverage for the pkg-routing Worker's pure path-mapping helpers (ADR-20).
+// Run: node --test  (from scripts/worker/)  — no wrangler / network needed.
+//
+// These pin the request -> Pages target mapping against the tree
+// build-repo-portable.py --build-matrix lays out: <channel>/<varver>/<arch>/<rest>.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseArch, resolveTarget } from "../src/index.js";
+
+const PAGES = "https://pfblockerng.github.io/pkg";
+const CE = { pattern: "pfSense/2.8", catalog: "ce-2.8", status: "active" };
+const PLUS = { pattern: "Netgate pfSense Plus/26.03", catalog: "plus-26.03", status: "active" };
+
+test("parseArch extracts the arch from a FreeBSD ABI segment", () => {
+  assert.equal(parseArch("FreeBSD:15:amd64"), "amd64");
+  assert.equal(parseArch("FreeBSD:16:aarch64"), "aarch64");
+});
+
+test("parseArch rejects non-ABI segments", () => {
+  // The off branch: anything that is not FreeBSD:<digits>:<arch> -> null (caller 404s).
+  assert.equal(parseArch("nightly"), null);
+  assert.equal(parseArch("amd64"), null);
+  assert.equal(parseArch(""), null);
+  assert.equal(parseArch(undefined), null);
+});
+
+test("release request maps to the release/<varver>/<arch>/ tree", () => {
+  // Given a CE release request (no channel prefix), the catalog file lands under release/.
+  const target = resolveTarget("/FreeBSD:15:amd64/meta.conf", CE);
+  assert.equal(target, `${PAGES}/release/ce-2.8/amd64/meta.conf`);
+});
+
+test("nightly request maps to the nightly/<varver>/<arch>/ tree", () => {
+  // The /nightly/ prefix flips the channel dir; everything else is identical.
+  // Before: the same path WITHOUT the prefix would be release/ (proven above);
+  // here the prefix is the only change, so green proves the prefix drives the channel.
+  const target = resolveTarget("/nightly/FreeBSD:15:amd64/meta.conf", CE);
+  assert.equal(target, `${PAGES}/nightly/ce-2.8/amd64/meta.conf`);
+});
+
+test("Plus aarch64 request maps to its own arch leaf", () => {
+  const target = resolveTarget("/FreeBSD:16:aarch64/packagesite.pkg", PLUS);
+  assert.equal(target, `${PAGES}/release/plus-26.03/aarch64/packagesite.pkg`);
+});
+
+test("a package download path (after the ABI segment) is preserved verbatim", () => {
+  const target = resolveTarget("/FreeBSD:15:amd64/pfBlockerNG-devel-3.2.16.pkg", CE);
+  assert.equal(target, `${PAGES}/release/ce-2.8/amd64/pfBlockerNG-devel-3.2.16.pkg`);
+});
+
+test("a request with no ABI segment resolves to null (the 404 branch)", () => {
+  assert.equal(resolveTarget("/", CE), null);
+  assert.equal(resolveTarget("/notanabi/meta.conf", CE), null);
+  // A /nightly/ prefix followed by no ABI is still malformed.
+  assert.equal(resolveTarget("/nightly/", CE), null);
+});

--- a/scripts/worker/test/router.test.js
+++ b/scripts/worker/test/router.test.js
@@ -7,7 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { parseArch, resolveTarget } from "../src/index.js";
+import { normalizeRoutes, parseArch, resolveTarget } from "../src/index.js";
 
 const PAGES = "https://pfblockerng.github.io/pkg";
 const CE = { pattern: "pfSense/2.8", catalog: "ce-2.8", status: "active" };
@@ -48,6 +48,19 @@ test("Plus aarch64 request maps to its own arch leaf", () => {
 test("a package download path (after the ABI segment) is preserved verbatim", () => {
   const target = resolveTarget("/FreeBSD:15:amd64/pfBlockerNG-devel-3.2.16.pkg", CE);
   assert.equal(target, `${PAGES}/release/ce-2.8/amd64/pfBlockerNG-devel-3.2.16.pkg`);
+});
+
+test("normalizeRoutes returns the array for a well-formed manifest", () => {
+  assert.deepEqual(normalizeRoutes({ routes: [CE] }), [CE]);
+});
+
+test("normalizeRoutes returns null for a malformed manifest (fail-closed 502 branch)", () => {
+  // A non-array routes (or missing / non-object data) must NOT reach routes.find()
+  // — returning null makes the Worker answer 502, never throw an unhandled 500.
+  assert.equal(normalizeRoutes({ routes: { pattern: "x" } }), null);
+  assert.equal(normalizeRoutes({}), null);
+  assert.equal(normalizeRoutes(null), null);
+  assert.equal(normalizeRoutes("nope"), null);
 });
 
 test("a request with no ABI segment resolves to null (the 404 branch)", () => {

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -692,11 +692,11 @@ def test_wrong_variant_dep_absent() -> None:
     assert len(plus_deps) > 0
 
 
-def test_no_variant_flag_unchanged(tmp_path: Path) -> None:
-    """Without --variant, the dep list is identical to the current baseline.
+def test_no_php_no_guard_injected(tmp_path: Path) -> None:
+    """Without --php, no variant guard dep is injected (ADR-20: guard is gated on --php).
 
     Given the synthetic classic port (no USES=php / USES=python),
-    When built without --variant,
+    When built with --py-flavor but NO --php,
     Then the deps dict contains only the RUN_DEPENDS from the Makefile
     and none of the versioned php*/py* variant guards.
     """
@@ -715,10 +715,43 @@ def test_no_variant_flag_unchanged(tmp_path: Path) -> None:
     assert rc == 0
     full, _compact, _tf = _read_pkg(out / "testpkg-1.0_2.pkg")
     dep_names = set(full.get("deps", {}).keys())
-    # foo comes from RUN_DEPENDS; no php* / py* variant guard added (no --variant)
+    # foo comes from RUN_DEPENDS; no php* / py* variant guard added (no --php)
     assert "foo" in dep_names
     assert not any(n.startswith("php8") for n in dep_names)
     assert not any(n.startswith("py3") for n in dep_names)
+
+
+def test_php_injects_variant_guard_via_cli(tmp_path: Path) -> None:
+    """With --php, the versioned php*/py* guard deps ARE injected (the on branch).
+
+    Paired with test_no_php_no_guard_injected (the off branch) this proves the guard
+    is a real branch keyed on --php, not an always-present or always-absent dep.
+
+    Given the synthetic classic port,
+    When built with --php 8.3 + --py-flavor py311 (CE values),
+    Then deps gain php83 + py311 (alongside the Makefile RUN_DEPENDS), and the
+    Plus discriminator php85 is absent.
+    """
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--py-flavor", "py311",
+            "--php", "8.3",
+            "--compression", "xz",
+            "--out", str(out),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    full, _compact, _tf = _read_pkg(out / "testpkg-1.0_2.pkg")
+    dep_names = set(full.get("deps", {}).keys())
+    assert "foo" in dep_names  # Makefile RUN_DEPENDS still present
+    assert "php83" in dep_names  # CE PHP guard injected
+    assert "py311" in dep_names  # Python guard injected
+    assert "php85" not in dep_names  # the Plus discriminator stays absent
 
 
 def test_two_simultaneous_ce_entries() -> None:

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -844,3 +844,285 @@ def test_nightly_plus_catalog_under_versioned_subdir(tmp_path: Path) -> None:
     plus_names = {json.loads(ln)["name"] for ln in plus_raw.splitlines() if ln}
     assert "pfBlockerNG-nightly-plus" in plus_names
     assert "pfBlockerNG-nightly-ce" not in plus_names
+
+
+# --------------------------------------------------------------------------- #
+# ADR-20 routing rework: the matrix-driven brain (build_repo_matrix + helpers)
+#
+# These pin the LITERAL 1:1 projection of the version matrix onto the tree
+# (release/<varver>/<arch>/ + nightly/<varver>/<arch>/, arch leaf — NOT full ABI),
+# the routing.json contents, the release channel-group (devel + stable in one
+# catalog), full-matrix/no-dedup placement, and nightly retention. The DUMB pkg
+# builder is stubbed so the tests exercise the BRAIN (arrangement) without a ports
+# tree — build-pkg-portable.py's own behaviour is covered by its own suite.
+# --------------------------------------------------------------------------- #
+
+# The live matrix shape (subset of fields build_repo_matrix consumes).
+_CE = {
+    "pfsense_version": "2.8",
+    "variant": "CE",
+    "freebsd_major": "15",
+    "php_version": "8.3",
+    "py_flavor": "py311",
+    "status": "active",
+    "arch": "amd64",
+}
+_PLUS = {
+    "pfsense_version": "26.03",
+    "variant": "Plus",
+    "freebsd_major": "16",
+    "php_version": "8.5",
+    "py_flavor": "py311",
+    "status": "active",
+    "arch": "amd64",
+}
+_PLUS_ARM = {**_PLUS, "arch": "aarch64", "status": "active"}
+
+_CHANNEL_NAME = {"devel": "pfBlockerNG-devel", "stable": "pfBlockerNG", "nightly": "pfBlockerNG-nightly"}
+
+
+def _stub_builder(
+    channel: str,
+    *,
+    abi: str,
+    php: str,
+    py_flavor: str,
+    out_dir: Path,
+    varver: str,
+    arch: str,
+    pkgversion: str | None = None,
+    **_kw: Any,
+) -> Path:
+    """Stand-in for build-pkg-portable.py: drop a libpkg-shaped .pkg, return its path.
+
+    The package NAME encodes the channel (so a subtree's catalog reveals which channels
+    landed there); the manifest carries the requested ABI + a versioned php guard dep
+    (so a wrong-flavor mix would trip the collision guard, as in a real build).
+    """
+    name = _CHANNEL_NAME[channel]
+    version = pkgversion or "1.0_1"
+    php_dep = "php" + php.replace(".", "")
+    deps = {
+        php_dep: {"origin": f"lang/{php_dep}", "version": "0"},
+        py_flavor: {"origin": f"lang/{py_flavor}", "version": "0"},
+    }
+    # Distinct on-disk filename per (channel, varver, arch) so concurrent staging never clashes;
+    # the catalog copies it CANONICALLY as <name>-<version>.pkg regardless.
+    out = out_dir / f"{name}-{version}-{varver}-{arch}-{channel}.pkg"
+    make_pkg(out, name=name, version=version, abi=abi, deps=deps)
+    return out
+
+
+def _names_in(catalog_pkg: Path) -> set[str]:
+    raw = _read_member(catalog_pkg, "packagesite.yaml").decode()
+    return {json.loads(ln)["name"] for ln in raw.splitlines() if ln}
+
+
+def test_ua_pattern_ce_vs_plus() -> None:
+    """_ua_pattern: CE -> 'pfSense/<mm>'; Plus -> 'Netgate pfSense Plus/<mm>'."""
+    assert brp._ua_pattern("CE", "2.8") == "pfSense/2.8"
+    assert brp._ua_pattern("CE", "2.8.1") == "pfSense/2.8"
+    assert brp._ua_pattern("Plus", "26.03") == "Netgate pfSense Plus/26.03"
+    assert brp._ua_pattern("Plus", "26.03.1") == "Netgate pfSense Plus/26.03"
+
+
+def test_pkg_version_key_orders_nightlies_chronologically() -> None:
+    """_pkg_version_key sorts nightly <target>.YYYYMMDD.N so a later build ranks higher."""
+    older = brp._pkg_version_key("3.2.16.20260606.2")
+    newer_day = brp._pkg_version_key("3.2.16.20260607.1")
+    newer_counter = brp._pkg_version_key("3.2.16.20260606.3")
+    # A later date outranks an earlier date even with a lower counter.
+    assert newer_day > older
+    # Same date, higher counter outranks (the bug a naive lexicographic compare hits at .10 vs .2).
+    assert newer_counter > older
+    assert brp._pkg_version_key("3.2.16.20260606.10") > brp._pkg_version_key("3.2.16.20260606.2")
+
+
+def test_dedup_routes_collapses_and_orders_most_specific_first() -> None:
+    """_dedup_routes collapses identical (pattern,catalog,status) and longest-pattern-first.
+
+    Two Plus entries (amd64 + aarch64) share the same UA pattern/catalog/status -> ONE route.
+    The longer Plus pattern precedes the shorter CE pattern (Worker first-match-wins).
+    """
+    routes = [
+        {"pattern": "pfSense/2.8", "catalog": "ce-2.8", "status": "active"},
+        {"pattern": "Netgate pfSense Plus/26.03", "catalog": "plus-26.03", "status": "active"},
+        {"pattern": "Netgate pfSense Plus/26.03", "catalog": "plus-26.03", "status": "active"},
+    ]
+    out = brp._dedup_routes(routes)
+    assert len(out) == 2  # the duplicate Plus route collapsed
+    assert out[0]["pattern"] == "Netgate pfSense Plus/26.03"  # most specific first
+    assert out[1]["pattern"] == "pfSense/2.8"
+
+
+def test_build_matrix_tree_layout_arch_leaf(tmp_path: Path) -> None:
+    """build_repo_matrix projects the matrix 1:1 with the bare ARCH as the leaf.
+
+    Scenario: a CE + a Plus entry
+      Given an empty output root
+      When build_repo_matrix runs over [CE, Plus]
+      Then release/ce-2.8/amd64/ and release/plus-26.03/amd64/ catalogs exist
+       And the leaf is the bare arch — NOT the full ABI (no FreeBSD:NN:amd64 dir)
+       And the matching nightly subtrees exist
+    """
+    out = tmp_path / "site"
+    # Before-state: nothing built.
+    assert not out.exists()
+
+    brp.build_repo_matrix([_CE, _PLUS], out, builder=_stub_builder)
+
+    # Arch leaf, version segment implies the FreeBSD major.
+    assert (out / "release" / "ce-2.8" / "amd64" / "meta.conf").is_file()
+    assert (out / "release" / "plus-26.03" / "amd64" / "meta.conf").is_file()
+    assert (out / "nightly" / "ce-2.8" / "amd64" / "meta.conf").is_file()
+    assert (out / "nightly" / "plus-26.03" / "amd64" / "meta.conf").is_file()
+    # The full ABI must NOT appear as a path segment (this is the arch-leaf reconciliation).
+    assert not (out / "release" / "ce-2.8" / "FreeBSD:15:amd64").exists()
+    assert not (out / "release" / "plus-26.03" / "FreeBSD:16:amd64").exists()
+
+
+def test_build_matrix_routing_json(tmp_path: Path) -> None:
+    """routing.json carries one deduped route per variant, catalog=varver, with status.
+
+    Scenario: CE + Plus(amd64) + Plus(aarch64)
+      When build_repo_matrix runs
+      Then routing.json has TWO routes (the two Plus arches collapse to one),
+           each {pattern: UA, catalog: varver, status}, most specific first.
+    """
+    out = tmp_path / "site"
+    brp.build_repo_matrix([_CE, _PLUS, _PLUS_ARM], out, builder=_stub_builder)
+
+    routing = json.loads((out / "routing.json").read_text())
+    routes = routing["routes"]
+    assert len(routes) == 2  # Plus amd64 + aarch64 collapsed to one route
+    # Most-specific (Plus) first.
+    assert routes[0] == {"pattern": "Netgate pfSense Plus/26.03", "catalog": "plus-26.03", "status": "active"}
+    assert routes[1] == {"pattern": "pfSense/2.8", "catalog": "ce-2.8", "status": "active"}
+
+
+def test_build_matrix_routing_status_passthrough(tmp_path: Path) -> None:
+    """A legacy entry's status flows into its route verbatim (not dropped, not rewritten)."""
+    legacy_ce = {**_CE, "status": "legacy"}
+    out = tmp_path / "site"
+    brp.build_repo_matrix([legacy_ce], out, builder=_stub_builder)
+    routes = json.loads((out / "routing.json").read_text())["routes"]
+    assert routes == [{"pattern": "pfSense/2.8", "catalog": "ce-2.8", "status": "legacy"}]
+
+
+def test_build_matrix_release_holds_devel_and_stable(tmp_path: Path) -> None:
+    """The release channel-group is devel-only without a stable tag, devel+stable with one.
+
+    Scenario: stable tag absent -> present (the branch + the before/after)
+      Given build_repo_matrix([CE]) with NO stable_tag
+      Then release/ce-2.8/amd64 holds ONLY the devel package
+      When re-run WITH stable_tag set
+      Then the release catalog holds BOTH the devel and the stable package
+    """
+    out = tmp_path / "site"
+
+    # Off branch: no stable tag -> devel only.
+    brp.build_repo_matrix([_CE], out, builder=_stub_builder)
+    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    assert _names_in(rel) == {"pfBlockerNG-devel"}
+
+    # On branch: a stable tag -> devel + stable coexist in ONE catalog.
+    brp.build_repo_matrix([_CE], out, builder=_stub_builder, stable_tag="v3.2.15")
+    assert _names_in(rel) == {"pfBlockerNG-devel", "pfBlockerNG"}
+
+
+def test_build_matrix_full_matrix_no_dedup(tmp_path: Path) -> None:
+    """Two versions sharing ABI+php+py still get their OWN subtree (full matrix, no dedup)."""
+    ce_28 = _CE
+    ce_29 = {**_CE, "pfsense_version": "2.9"}  # same FreeBSD major/php/py as 2.8
+    out = tmp_path / "site"
+    brp.build_repo_matrix([ce_28, ce_29], out, builder=_stub_builder)
+    # Distinct version segments, each populated independently.
+    assert (out / "release" / "ce-2.8" / "amd64" / "meta.conf").is_file()
+    assert (out / "release" / "ce-2.9" / "amd64" / "meta.conf").is_file()
+
+
+def test_build_matrix_aarch64_distinct_leaf(tmp_path: Path) -> None:
+    """An aarch64 Plus entry lands under its own arch leaf, separate from amd64."""
+    out = tmp_path / "site"
+    brp.build_repo_matrix([_PLUS, _PLUS_ARM], out, builder=_stub_builder)
+    assert (out / "release" / "plus-26.03" / "amd64" / "meta.conf").is_file()
+    assert (out / "release" / "plus-26.03" / "aarch64" / "meta.conf").is_file()
+
+
+def test_build_matrix_no_nightly(tmp_path: Path) -> None:
+    """build_nightly=False builds the release subtree + routing but NO nightly/ tree."""
+    out = tmp_path / "site"
+    brp.build_repo_matrix([_CE], out, builder=_stub_builder, build_nightly=False)
+    assert (out / "release" / "ce-2.8" / "amd64" / "meta.conf").is_file()
+    assert (out / "routing.json").is_file()
+    assert not (out / "nightly").exists()
+
+
+def test_build_matrix_nightly_retention(tmp_path: Path) -> None:
+    """Nightly subtree retains only the N newest builds across runs (a later build supersedes).
+
+    Scenario: nightly_keep=2, three successive nightly versions
+      Given build #1 (.1) -> the subtree holds 1 nightly
+       When build #2 (.2) lands -> it holds 2
+       When build #3 (.3) lands -> it is pruned back to 2, keeping the 2 NEWEST (.2, .3)
+    """
+    out = tmp_path / "site"
+    nl = out / "nightly" / "ce-2.8" / "amd64" / "packagesite.pkg"
+
+    def run(counter: int) -> None:
+        brp.build_repo_matrix(
+            [_CE],
+            out,
+            builder=_stub_builder,
+            nightly_keep=2,
+            nightly_pkgversion=lambda _e: f"3.2.16.2026060{counter}.{counter}",
+        )
+
+    run(1)
+    assert _versions_in_nightly(nl) == {"3.2.16.20260601.1"}
+    run(2)
+    assert _versions_in_nightly(nl) == {"3.2.16.20260601.1", "3.2.16.20260602.2"}
+    run(3)
+    # Pruned to the 2 NEWEST; the oldest (.1) dropped.
+    assert _versions_in_nightly(nl) == {"3.2.16.20260602.2", "3.2.16.20260603.3"}
+
+
+def _versions_in_nightly(catalog_pkg: Path) -> set[str]:
+    raw = _read_member(catalog_pkg, "packagesite.yaml").decode()
+    return {json.loads(ln)["version"] for ln in raw.splitlines() if ln}
+
+
+def test_retain_newest_dedups_and_truncates(tmp_path: Path) -> None:
+    """_retain_newest keeps the N highest versions, deduping (name,version)."""
+    paths = []
+    for i in (1, 2, 3, 4):
+        p = tmp_path / f"n{i}.pkg"
+        make_pkg(p, name="pfBlockerNG-nightly", version=f"3.2.16.2026060{i}.{i}", abi="FreeBSD:15:amd64")
+        paths.append(p)
+    kept = brp._retain_newest(paths, 2)
+    kept_versions = {brp.read_compact_manifest(p)["version"] for p in kept}
+    assert kept_versions == {"3.2.16.20260603.3", "3.2.16.20260604.4"}
+
+
+def test_cli_build_matrix_requires_matrix_and_out(capsys: pytest.CaptureFixture[str]) -> None:
+    """--build-matrix without --matrix-json/--out is a usage error."""
+    with pytest.raises(SystemExit):
+        brp.main(["--build-matrix", "--out", "/tmp/x"])  # missing --matrix-json
+
+
+def test_cli_build_matrix_unwraps_versions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI accepts a {versions:[...]} matrix file and forwards the array to the brain."""
+    captured: dict[str, Any] = {}
+
+    def fake_brain(matrix: list[dict], out_dir: Path, **kw: Any) -> dict:
+        captured["matrix"] = matrix
+        captured["kw"] = kw
+        return {"routes": [], "built": []}
+
+    monkeypatch.setattr(brp, "build_repo_matrix", fake_brain)
+    mfile = tmp_path / "m.json"
+    mfile.write_text(json.dumps({"versions": [_CE, _PLUS]}))
+    rc = brp.main(["--build-matrix", "--matrix-json", str(mfile), "--out", str(tmp_path / "site"), "--no-nightly"])
+    assert rc == 0
+    assert captured["matrix"] == [_CE, _PLUS]  # unwrapped from {versions:[...]}
+    assert captured["kw"]["build_nightly"] is False

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -1126,3 +1126,25 @@ def test_cli_build_matrix_unwraps_versions(tmp_path: Path, monkeypatch: pytest.M
     assert rc == 0
     assert captured["matrix"] == [_CE, _PLUS]  # unwrapped from {versions:[...]}
     assert captured["kw"]["build_nightly"] is False
+
+
+def test_build_matrix_annotate_passthrough(tmp_path: Path) -> None:
+    """annotate kwargs reach every builder call (so publish.yml's commit/created stamp lands).
+
+    Given a recording builder,
+      When build_repo_matrix runs with annotate={commit, created},
+      Then every build (devel + nightly) receives that exact annotate dict.
+    """
+    seen: list[dict] = []
+
+    def recording_builder(channel: str, *, annotate: dict | None = None, **kw: Any) -> Path:
+        seen.append({"channel": channel, "annotate": annotate})
+        return _stub_builder(channel, **kw)
+
+    brp.build_repo_matrix(
+        [_CE], tmp_path / "site", builder=recording_builder, annotate={"commit": "deadbeef", "created": "123"}
+    )
+    assert seen, "builder was never called"
+    for call in seen:
+        assert call["annotate"] == {"commit": "deadbeef", "created": "123"}
+    assert {c["channel"] for c in seen} == {"devel", "nightly"}


### PR DESCRIPTION
Implements the ADR-20 routing rework (B1 + B3) — the self-hosted pkg repository now projects the version matrix 1:1 onto a variant/arch tree the Cloudflare Worker routes against.

## B1 — builder + repository generator

**`scripts/build-pkg-portable.py` (dumb builder)**
- Drops `--variant`. The versioned php/py guard deps are now injected directly from `--php`/`--py-flavor` (keyed on `--php`, independent of whether the port `USES=php`). The builder stamps no variant of its own.
- `.github/workflows/build-pkg-linux.yml`: removes the now-unused `variant` input + plumbing (the guard rides `--php`).

**`scripts/build-repo-portable.py` (the brain)**
- New `build_repo_matrix()` + `--build-matrix` CLI: drives the dumb builder per (entry × channel) and lays out
  - `release/<variant>-<major.minor>/<arch>/` — devel + (stable from tag), one catalog
  - `nightly/<variant>-<major.minor>/<arch>/` — nightly only, retained to 14
  - `routing.json` — `{pattern: UA, catalog: <varver>, status}`, deduped, most-specific first
- Leaf is the bare **arch** (the version segment implies the FreeBSD major; each `.pkg` manifest carries its real ABI). The legacy `build_repo`/`--catalog-name` (full-ABI leaf) is unchanged and still tested.
- `--annotate K=V` passthrough so the publish pipeline can stamp the `commit`/`created` annotations the landing page reads.

## B3 — Cloudflare Worker

**`scripts/worker/src/index.js`** redirects to `<channel>/<varver>/<arch>/<rest>` — channel from a `/nightly/` path prefix, varver matched from the UA via `routing.json`, arch parsed from the request's `FreeBSD:<major>:<arch>` segment. Path mapping factored into pure `parseArch()`/`resolveTarget()` with `node:test` coverage of every branch (`npm test`).

## Tests
- `tests/test_build_pkg_portable.py` — guard injected on `--php` / absent without it (before/after).
- `tests/test_build_repo_portable.py` — tree layout (arch leaf, not full ABI), routing.json contents/order/dedup, release devel-only→devel+stable, full-matrix no-dedup, aarch64 distinct leaf, nightly retention, helpers, annotate passthrough, CLI.
- `scripts/worker/test/router.test.js` — release/nightly mapping, arch leaf, no-ABI 404.
- Full suite green: 1631 pytest + 7 worker tests; ruff clean.

## Remaining (maintainer, needs Cloudflare creds)
After this + the `pfBlockerNG/pkg` PR land: dispatch `pkg` `publish.yml` (publishes the tree + `routing.json` to Pages), `wrangler deploy` the Worker, then un-`xfail` smoke Case 4 (`test_routing_url_delivers_variant_catalog`). ADR-20 flips to fully Accepted then.

ADR doc status + `RESULTS/09_Routing_Rework_Landed.txt` updated in this branch.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added matrix-driven repository building across release and nightly channels, producing routing-aware catalogs.
  * Updated request routing so redirects are determined by User-Agent patterns plus FreeBSD ABI-derived architecture, with fail-closed behavior for malformed requests.
  * Simplified the portable build process to use PHP and Python flavor inputs (instead of a separate variant flag).

* **Documentation**
  * Updated the routing-rework acceptance record and added landing results for the completed rework.

* **Tests**
  * Expanded coverage for routing helpers, matrix build layout/routing.json generation, nightly retention, and PHP guard dependency injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->