### PR TITLE
pfblockerng: hoist static cURL opts into curl_defaults

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -183,6 +183,11 @@ $pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'pfSense/pfBlockerNG cURL d
 				CURLOPT_FORBID_REUSE	=> true,
 				CURLOPT_SSL_ENABLE_ALPN	=> true,
 				CURLOPT_SSL_ENABLE_NPN	=> true,
+				CURLOPT_ENCODING	=> 'gzip',	// Request 'gzip' response encoding when the server offers it
+				// Constrain libcurl to the schemes pfBlockerNG fetches feeds over (http/https/ftp;
+				// rsync uses exec separately) — an independent backstop to the PFB_FILTER_URL scheme
+				// allowlist, since PHP parse_url and libcurl can disagree on crafted input.
+				CURLOPT_PROTOCOLS	=> CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP,
 				);
 
 // RFC7231 HTTP response codes
@@ -6707,17 +6712,12 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					return FALSE;
 				}
 
-				curl_setopt_array($ch, $pfb['curl_defaults']);	// Load curl default settings
-
-				// Constrain libcurl to the schemes pfBlockerNG fetches feeds over (http/https/ftp;
-				// rsync uses exec separately). An independent backstop to the PFB_FILTER_URL scheme
-				// allowlist — the two parsers (PHP parse_url vs libcurl) can disagree on crafted
-				// input, so enforce the allowlist at libcurl's own layer too.
-				curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP);
+				// Load curl default settings — incl. the CURLOPT_PROTOCOLS scheme allow-list
+				// (an independent libcurl-layer backstop to PFB_FILTER_URL) and gzip encoding.
+				curl_setopt_array($ch, $pfb['curl_defaults']);
 
 				curl_setopt($ch, CURLOPT_FILE, $fhandle);	// Add $fhandle setting to cURL
 				curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);	// Set cURL download timeout
-				curl_setopt($ch, CURLOPT_ENCODING, 'gzip');	// Request 'gzip' encoding from server if available
 
 				// With the filter ON, do NOT let cURL auto-follow redirects: a 3xx
 				// is followed manually below so every hop's host is re-vetted by the


### PR DESCRIPTION
## What

Moves the two **static, constant** cURL options that were set inline in `pfb_download()` into the `$pfb['curl_defaults']` block at the top of `pfblockerng.inc`:

- `CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP` — the scheme allow-list (a libcurl-layer backstop to `PFB_FILTER_URL`), added by the PFBL-02 feed-validation series.
- `CURLOPT_ENCODING => 'gzip'`.

## Why

Per maintainer feedback (BBcan177, on commit `71da6c9`): these cURL defaults belong in the defaults section at the start of `pfblockerng.inc`, not scattered inline. They're identical for every download, so the defaults block is the right home; the SSRF rationale comment moves with `CURLOPT_PROTOCOLS`.

## Behaviour-preserving

Both options are applied via the existing `curl_setopt_array($ch, $pfb['curl_defaults'])` at the same point the inline calls ran, **before** any per-download `curl_setopt()`, and **nothing later overrides** them (they persist across the reused redirect handle exactly as before). Everything left inline in `pfb_download()` is genuinely per-download/dynamic and stays put: the file handle, timeout, the `$feed_filter`-gated `FOLLOWLOCATION`/`MAXREDIRS`, the `CURLOPT_RESOLVE` pin, auth, and the insecure-retry SSL overrides.

## Validation

- `php -l` clean.
- No test references cURL options (this is a pure relocation, no observable behaviour change); the feed-download path stays covered by the ADR-04 live-VM smoke and the ADR-16 mock-feed load smoke.

https://claude.ai/code/session_014qKGQtz556UbUyATPMKg5s

---
_Generated by [Claude Code](https://claude.ai/code/session_014qKGQtz556UbUyATPMKg5s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated cURL configuration settings into a centralized defaults array for improved consistency and maintainability.
  * Enhanced security by constraining allowed URL schemes and enforcing gzip encoding across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->