### PR TITLE
ci: fix variant guard dep origin + name (ADR-20 smoke regression)

### DIFF
--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -732,26 +732,32 @@ def _glob_origin(ports_root: Path, pkgdir: str) -> str:
     return ""
 
 
-def _resolve_variant_deps(php_version: str, py_flavor: str) -> list[str]:
-    """Return the RUN_DEPENDS package names for a specific pfSense variant.
+def _resolve_variant_deps(php_version: str, py_flavor: str) -> list[tuple[str, str]]:
+    """Return the variant guard RUN_DEPENDS as ``(name, origin)`` pairs.
 
-    Derives the PHP dep name by stripping the dot from ``php_version``
-    (e.g. ``"8.3"`` → ``"php83"``); uses ``py_flavor`` directly as the
-    Python dep name (e.g. ``"py311"``).  Both are needed because the exact
-    versions differ between CE and Plus — this is the variant guard that
-    prevents a wrong-variant package from silently installing.
+    Derives the PHP dep from ``php_version`` (``"8.3"`` → ``php83`` / ``lang/php83``)
+    and the Python dep from ``py_flavor`` (``"py311"`` → ``python311`` /
+    ``lang/python311``) — the SAME names + origins ``make package`` records for a
+    ``USES=php``/``USES=python`` port, so when the port already synthesises them the
+    guard de-dups cleanly (it never introduces a second, conflicting dep). Both are
+    needed because the exact PHP version differs between CE and Plus — this is the
+    variant guard that prevents a wrong-variant package from silently installing.
 
-    Each side is emitted only when its source value is non-empty, so a build
-    that supplies only one of ``--php`` / ``--py-flavor`` still yields a
-    well-formed dep list (no bare ``"py"`` / ``"php"``).
+    A non-empty ``origin`` is REQUIRED: libpkg's ``pkg repo`` asserts every dep has
+    one (``pkg_adddep_chain``), so an empty origin aborts a real FreeBSD catalog build.
+
+    Each side is emitted only when its source value is non-empty, so a build that
+    supplies only one of ``--php`` / ``--py-flavor`` still yields a well-formed list.
 
     Pure function: no I/O, no side effects.  Testable without a ports tree.
     """
-    deps: list[str] = []
+    deps: list[tuple[str, str]] = []
     if php_version:
-        deps.append("php" + php_version.replace(".", ""))
+        phpv = php_version.replace(".", "")
+        deps.append((f"php{phpv}", f"lang/php{phpv}"))
     if py_flavor:
-        deps.append(py_flavor if py_flavor.startswith("py") else f"py{py_flavor}")
+        pyv = py_flavor[2:] if py_flavor.startswith("py") else py_flavor
+        deps.append((f"python{pyv}", f"lang/python{pyv}"))
     return deps
 
 
@@ -1352,9 +1358,10 @@ def run_build(args: argparse.Namespace) -> Build:
     # args, NOT the USES-derived php_ver: the guard is independent of whether the port
     # itself USES=php (php_ver is "" for a non-php port, but the guard must still land).
     if args.php:
-        for dep_name in _resolve_variant_deps(args.php, args.py_flavor):
-            # Variant guard deps augment (never override) USES-synthesised deps.
-            deps.setdefault(dep_name, Dep(name=dep_name, origin="", version="0"))
+        for dep_name, dep_origin in _resolve_variant_deps(args.php, args.py_flavor):
+            # Variant guard deps augment (never override) USES-synthesised deps. A real
+            # origin is mandatory — libpkg's `pkg repo` aborts on an empty dep origin.
+            deps.setdefault(dep_name, Dep(name=dep_name, origin=dep_origin, version="0"))
     b.deps = list(deps.values())
     # Best-effort dep versions come from the ports tree; the version make package
     # actually records is the INSTALLED binary package's. Pin those exactly from

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1358,7 +1358,9 @@ def run_build(args: argparse.Namespace) -> Build:
     # args, NOT the USES-derived php_ver: the guard is independent of whether the port
     # itself USES=php (php_ver is "" for a non-php port, but the guard must still land).
     if args.php:
-        for dep_name, dep_origin in _resolve_variant_deps(args.php, args.py_flavor):
+        # Use the RESOLVED py_flavor (prompt-filled when --py-flavor is omitted), not the
+        # raw arg — otherwise an interactive build would silently drop the Python guard.
+        for dep_name, dep_origin in _resolve_variant_deps(args.php, py_flavor):
             # Variant guard deps augment (never override) USES-synthesised deps. A real
             # origin is mandatory — libpkg's `pkg repo` aborts on an empty dep origin.
             deps.setdefault(dep_name, Dep(name=dep_name, origin=dep_origin, version="0"))

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -639,38 +639,54 @@ def test_parse_annotations_rejects_malformed(bad: str) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Variant-aware manifest deps (ADR-20 Phase 2) — _resolve_variant_deps
+# Variant-aware manifest deps (ADR-20) — _resolve_variant_deps
 #
-# Dep-name derivation rule: php_version "X.Y" → strip dot → "phpXY"
-# py_flavor is used verbatim (e.g. "py311").
+# This is a pure DERIVATION, not a record of today's matrix: php "X.Y" → phpXY /
+# lang/phpXY; py "pyNNN" → pythonNNN / lang/pythonNNN. The tests therefore pin the
+# RULE (expected computed from the input), not the specific CE=php83 / Plus=php85
+# values — those are matrix-driven and will drift. 8.3/8.5 are just two of several
+# inputs; 8.4/8.10 prove it is the transform, not a hardcode.
 # --------------------------------------------------------------------------- #
 
 
-def test_ce_manifest_has_php83_dep() -> None:
-    """CE entry (php 8.3, py311) → guard contains php83/lang/php83, NOT php85."""
-    # Given the CE matrix values from supported-versions.json
-    deps = dict(bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311"))
-    # Then php83 is present (CE dep guard) with a REAL origin (libpkg requires one)
-    assert deps.get("php83") == "lang/php83"
-    # And the Plus PHP dep is absent (mutual exclusion)
-    assert "php85" not in deps
-    # The Python guard uses the real package name (python311), not the flavor "py311"
-    assert deps.get("python311") == "lang/python311"
-    assert "py311" not in deps
+@pytest.mark.parametrize("php_version", ["8.3", "8.5", "8.4", "8.10"])
+def test_php_guard_is_derived_from_php_version(php_version: str) -> None:
+    """The PHP guard is DERIVED from --php (strip the dot → phpXY / lang/phpXY).
+
+    Whatever the matrix carries, exactly ONE php* dep appears and it is the derived
+    one — so no other edition's php token can leak in (the CE-vs-Plus discrimination).
+    """
+    expected = "php" + php_version.replace(".", "")
+    deps = dict(bpp._resolve_variant_deps(php_version=php_version, py_flavor="py311"))
+    # The derived php dep is present with its real origin (libpkg requires a non-empty one).
+    assert deps.get(expected) == f"lang/{expected}"
+    # Exactly one php* dep, and it IS the derived one (no other edition's php leaks in).
+    assert [n for n in deps if n.startswith("php")] == [expected]
 
 
-def test_plus_manifest_has_php85_dep() -> None:
-    """Plus entry (php 8.5, py311) → guard contains php85/lang/php85, NOT php83."""
-    # Given the Plus matrix values from supported-versions.json
-    deps = dict(bpp._resolve_variant_deps(php_version="8.5", py_flavor="py311"))
-    # Then php85 is present (Plus dep guard) with a real origin
-    assert deps.get("php85") == "lang/php85"
-    # And the CE PHP dep is absent (mutual exclusion)
-    assert "php83" not in deps
+@pytest.mark.parametrize(
+    "py_flavor,expected",
+    [("py311", "python311"), ("py39", "python39"), ("py312", "python312")],
+)
+def test_python_guard_is_derived_from_py_flavor(py_flavor: str, expected: str) -> None:
+    """The Python guard is DERIVED from --py-flavor (pyNNN → pythonNNN / lang/pythonNNN).
+
+    Symmetric with the PHP guard, and asserted for BOTH editions: Python does not differ
+    by edition today, but the guard is still emitted + derived, and uses the real package
+    name (pythonNNN), never the bare flavor token (pyNNN — which is not installable).
+    """
+    # Asserted with a CE php (8.3) and a Plus php (8.5) so the Python guard is covered
+    # on both editions, not just one.
+    for php_version in ("8.3", "8.5"):
+        deps = dict(bpp._resolve_variant_deps(php_version=php_version, py_flavor=py_flavor))
+        assert deps.get(expected) == f"lang/{expected}"
+        # Exactly one python* dep, and the bare flavor token is never a dep name.
+        assert [n for n in deps if n.startswith("python")] == [expected]
+        assert py_flavor not in deps
 
 
 def test_variant_dep_origin_is_non_empty() -> None:
-    """Every guard dep carries a non-empty origin — libpkg's `pkg repo` aborts without one.
+    """Every guard dep carries a non-empty <category>/<port> origin.
 
     Regression guard: an empty origin reached real FreeBSD `pkg repo` and tripped
     `Assertion failed: origin != NULL && origin[0] != '\\0'` (pkg_adddep_chain).
@@ -678,25 +694,6 @@ def test_variant_dep_origin_is_non_empty() -> None:
     for name, origin in bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311"):
         assert origin, f"guard dep {name!r} has an empty origin"
         assert "/" in origin, f"guard dep {name!r} origin {origin!r} is not a <category>/<port>"
-
-
-def test_wrong_variant_dep_absent() -> None:
-    """Each variant carries only its own PHP dep — the other side's is absent.
-
-    After-state CE: php83 present, php85 absent.
-    After-state Plus: php85 present, php83 absent.
-    """
-    # The pure helper is enough: assert the CE result lacks php85 and Plus lacks php83.
-    ce_deps = dict(bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311"))
-    plus_deps = dict(bpp._resolve_variant_deps(php_version="8.5", py_flavor="py311"))
-
-    # CE lacks the Plus PHP dep
-    assert "php85" not in ce_deps
-    # Plus lacks the CE PHP dep
-    assert "php83" not in plus_deps
-    # Neither set is empty
-    assert len(ce_deps) > 0
-    assert len(plus_deps) > 0
 
 
 def test_no_php_no_guard_injected(tmp_path: Path) -> None:
@@ -760,34 +757,3 @@ def test_php_injects_variant_guard_via_cli(tmp_path: Path) -> None:
     assert deps.get("python311", {}).get("origin") == "lang/python311"  # Python guard, real origin
     assert "php85" not in deps  # the Plus discriminator stays absent
     assert "py311" not in deps  # the flavor token is NOT a dep name (would be unsatisfiable)
-
-
-def test_two_simultaneous_ce_entries() -> None:
-    """Transition window: two CE entries with different PHP versions.
-
-    Scenario: matrix carries CE 2.8.x (FreeBSD 15, php83) AND CE 2.9.x
-    (FreeBSD 16, php84) simultaneously. _resolve_variant_deps called for each
-    returns the correct php dep for that entry; they are distinct.
-
-    Given two CE matrix entries (php 8.3 and php 8.4),
-    When _resolve_variant_deps is called for each,
-    Then each returns its own correct php dep and the results are distinct.
-    """
-    # Given: two CE entries with different PHP versions
-    ce_15_deps = dict(bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311"))
-    ce_16_deps = dict(bpp._resolve_variant_deps(php_version="8.4", py_flavor="py311"))
-
-    # Then: each has the correct versioned PHP dep
-    assert "php83" in ce_15_deps, "FreeBSD 15 CE entry must have php83"
-    assert "php84" in ce_16_deps, "FreeBSD 16 CE entry must have php84"
-
-    # And: each lacks the other's PHP dep
-    assert "php84" not in ce_15_deps
-    assert "php83" not in ce_16_deps
-
-    # And: both carry the python311 guard
-    assert "python311" in ce_15_deps
-    assert "python311" in ce_16_deps
-
-    # And: the two dep maps are distinct (not identical)
-    assert ce_15_deps != ce_16_deps

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -647,41 +647,48 @@ def test_parse_annotations_rejects_malformed(bad: str) -> None:
 
 
 def test_ce_manifest_has_php83_dep() -> None:
-    """CE entry (php 8.3, py311) → dep list contains 'php83', NOT 'php85'."""
+    """CE entry (php 8.3, py311) → guard contains php83/lang/php83, NOT php85."""
     # Given the CE matrix values from supported-versions.json
-    deps = bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311")
-    # Then php83 is present (CE dep guard)
-    assert "php83" in deps
+    deps = dict(bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311"))
+    # Then php83 is present (CE dep guard) with a REAL origin (libpkg requires one)
+    assert deps.get("php83") == "lang/php83"
     # And the Plus PHP dep is absent (mutual exclusion)
     assert "php85" not in deps
+    # The Python guard uses the real package name (python311), not the flavor "py311"
+    assert deps.get("python311") == "lang/python311"
+    assert "py311" not in deps
 
 
 def test_plus_manifest_has_php85_dep() -> None:
-    """Plus entry (php 8.5, py311) → dep list contains 'php85', NOT 'php83'."""
+    """Plus entry (php 8.5, py311) → guard contains php85/lang/php85, NOT php83."""
     # Given the Plus matrix values from supported-versions.json
-    deps = bpp._resolve_variant_deps(php_version="8.5", py_flavor="py311")
-    # Then php85 is present (Plus dep guard)
-    assert "php85" in deps
+    deps = dict(bpp._resolve_variant_deps(php_version="8.5", py_flavor="py311"))
+    # Then php85 is present (Plus dep guard) with a real origin
+    assert deps.get("php85") == "lang/php85"
     # And the CE PHP dep is absent (mutual exclusion)
     assert "php83" not in deps
+
+
+def test_variant_dep_origin_is_non_empty() -> None:
+    """Every guard dep carries a non-empty origin — libpkg's `pkg repo` aborts without one.
+
+    Regression guard: an empty origin reached real FreeBSD `pkg repo` and tripped
+    `Assertion failed: origin != NULL && origin[0] != '\\0'` (pkg_adddep_chain).
+    """
+    for name, origin in bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311"):
+        assert origin, f"guard dep {name!r} has an empty origin"
+        assert "/" in origin, f"guard dep {name!r} origin {origin!r} is not a <category>/<port>"
 
 
 def test_wrong_variant_dep_absent() -> None:
     """Each variant carries only its own PHP dep — the other side's is absent.
 
-    Before-state (no variant): neither versioned name appears.
     After-state CE: php83 present, php85 absent.
     After-state Plus: php85 present, php83 absent.
     """
-    # Given: before any variant call, a plain dep-list has no versioned php names.
-    # (Simulate: call with a hypothetical neutral php_version "8.x" not matching
-    # either real entry — confirms the derivation is purely from php_version, not
-    # hardcoded for "8.3" or "8.5".)
-    # The real before-state check: verify an unversioned invocation produces neither.
-    # We cannot call synthesize_uses_deps without a ports tree, but the pure helper
-    # is enough: assert the CE result lacks php85 and Plus lacks php83.
-    ce_deps = bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311")
-    plus_deps = bpp._resolve_variant_deps(php_version="8.5", py_flavor="py311")
+    # The pure helper is enough: assert the CE result lacks php85 and Plus lacks php83.
+    ce_deps = dict(bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311"))
+    plus_deps = dict(bpp._resolve_variant_deps(php_version="8.5", py_flavor="py311"))
 
     # CE lacks the Plus PHP dep
     assert "php85" not in ce_deps
@@ -729,8 +736,8 @@ def test_php_injects_variant_guard_via_cli(tmp_path: Path) -> None:
 
     Given the synthetic classic port,
     When built with --php 8.3 + --py-flavor py311 (CE values),
-    Then deps gain php83 + py311 (alongside the Makefile RUN_DEPENDS), and the
-    Plus discriminator php85 is absent.
+    Then deps gain php83 + python311 (alongside the Makefile RUN_DEPENDS), each with a
+    real origin, and the Plus discriminator php85 is absent.
     """
     ports, portdir = _make_classic_port(tmp_path)
     out = tmp_path / "out"
@@ -747,11 +754,12 @@ def test_php_injects_variant_guard_via_cli(tmp_path: Path) -> None:
     )  # fmt: skip
     assert rc == 0
     full, _compact, _tf = _read_pkg(out / "testpkg-1.0_2.pkg")
-    dep_names = set(full.get("deps", {}).keys())
-    assert "foo" in dep_names  # Makefile RUN_DEPENDS still present
-    assert "php83" in dep_names  # CE PHP guard injected
-    assert "py311" in dep_names  # Python guard injected
-    assert "php85" not in dep_names  # the Plus discriminator stays absent
+    deps = full.get("deps", {})
+    assert "foo" in deps  # Makefile RUN_DEPENDS still present
+    assert deps.get("php83", {}).get("origin") == "lang/php83"  # CE PHP guard, real origin
+    assert deps.get("python311", {}).get("origin") == "lang/python311"  # Python guard, real origin
+    assert "php85" not in deps  # the Plus discriminator stays absent
+    assert "py311" not in deps  # the flavor token is NOT a dep name (would be unsatisfiable)
 
 
 def test_two_simultaneous_ce_entries() -> None:
@@ -766,8 +774,8 @@ def test_two_simultaneous_ce_entries() -> None:
     Then each returns its own correct php dep and the results are distinct.
     """
     # Given: two CE entries with different PHP versions
-    ce_15_deps = bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311")
-    ce_16_deps = bpp._resolve_variant_deps(php_version="8.4", py_flavor="py311")
+    ce_15_deps = dict(bpp._resolve_variant_deps(php_version="8.3", py_flavor="py311"))
+    ce_16_deps = dict(bpp._resolve_variant_deps(php_version="8.4", py_flavor="py311"))
 
     # Then: each has the correct versioned PHP dep
     assert "php83" in ce_15_deps, "FreeBSD 15 CE entry must have php83"
@@ -777,9 +785,9 @@ def test_two_simultaneous_ce_entries() -> None:
     assert "php84" not in ce_15_deps
     assert "php83" not in ce_16_deps
 
-    # And: both carry py311
-    assert "py311" in ce_15_deps
-    assert "py311" in ce_16_deps
+    # And: both carry the python311 guard
+    assert "python311" in ce_15_deps
+    assert "python311" in ce_16_deps
 
-    # And: the two dep lists are distinct (not identical)
-    assert sorted(ce_15_deps) != sorted(ce_16_deps)
+    # And: the two dep maps are distinct (not identical)
+    assert ce_15_deps != ce_16_deps


### PR DESCRIPTION
Fixes a regression from #245's variant guard. The repo-install smoke (`pytest -m repo`) failed: the on-guest `pkg repo` (real libpkg) aborts —

```
Assertion failed: (origin != NULL && origin[0] != '\0'), function pkg_adddep_chain, file pkg.c, line 483
```

**Cause:** the guard injected deps with `origin=""` and used the flavor token `py311` as a dep name. libpkg requires a non-empty origin (the portable generator tolerated it; real `pkg repo` doesn't), and `py311` is not an installable package (the interpreter is `python311`) so the dep was unsatisfiable.

**Fix:** `_resolve_variant_deps` now returns `(name, origin)` pairs matching what the `USES=php`/`USES=python` synthesis already records — `php<XY>`/`lang/php<XY>` and `python<NNN>`/`lang/python<NNN>` — so the guard de-dups cleanly against the port's own deps and never introduces a broken one. The injection sets that real origin.

Tests updated; added `test_variant_dep_origin_is_non_empty` as a regression guard. 64 pass.

After this lands I'll re-dispatch `smoke.yml -m repo` to confirm green on CE + Plus.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated variant-guard dependency derivation so guard entries use standardized dependency identifiers and consistently include non-empty origin metadata for both PHP and Python variants.

* **Tests**
  * Enhanced coverage to validate the computed guard dependency names (including ensuring only the expected PHP/Python guard deps are present), require that origins are populated, and adjust expectations for CLI-injected Python guard deps to use the real package naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->