### PR TITLE
ci: Worker UX — landing redirect + explicit /release path (ADR-20)

### DIFF
--- a/scripts/worker/src/index.js
+++ b/scripts/worker/src/index.js
@@ -73,6 +73,14 @@ export default {
     const ua = request.headers.get("User-Agent") ?? "";
     const url = new URL(request.url);
 
+    // A human opening the bare base URL in a browser has no pfSense UA and no ABI path —
+    // send them to the human landing page instead of a bare "unsupported version" 404.
+    // pkg(8) never requests "/": it always fetches /<ABI>/<file>, so this only catches
+    // people, not clients.
+    if (url.pathname === "/" || url.pathname === "") {
+      return Response.redirect(`${PAGES_BASE}/`, 302);
+    }
+
     const routes = await getRoutes(ctx);
     if (!routes) {
       return new Response("Routing manifest unavailable", { status: 502 });

--- a/scripts/worker/src/index.js
+++ b/scripts/worker/src/index.js
@@ -51,10 +51,13 @@ export function normalizeRoutes(data) {
 export function resolveTarget(pathname, route) {
   const segments = pathname.split("/").filter((s) => s.length > 0);
 
-  // A leading /nightly/ selects the nightly channel tree; otherwise release.
+  // A leading /nightly/ or /release/ selects the channel tree; a bare /<ABI>/ (no
+  // channel prefix) defaults to release for back-compat with older client confs.
   let channel = "release";
   if (segments[0] === "nightly") {
     channel = "nightly";
+    segments.shift();
+  } else if (segments[0] === "release") {
     segments.shift();
   }
 

--- a/scripts/worker/test/router.test.js
+++ b/scripts/worker/test/router.test.js
@@ -32,6 +32,18 @@ test("release request maps to the release/<varver>/<arch>/ tree", () => {
   assert.equal(target, `${PAGES}/release/ce-2.8/amd64/meta.conf`);
 });
 
+test("explicit /release/ prefix maps to the release tree (symmetric with /nightly/)", () => {
+  // The client conf may carry an explicit /release/ prefix; it maps to the same release tree
+  // as the bare path — the prefix segment is consumed, not treated as the ABI.
+  const target = resolveTarget("/release/FreeBSD:15:amd64/meta.conf", CE);
+  assert.equal(target, `${PAGES}/release/ce-2.8/amd64/meta.conf`);
+});
+
+test("explicit /release/ for Plus aarch64 maps correctly", () => {
+  const target = resolveTarget("/release/FreeBSD:16:aarch64/packagesite.pkg", PLUS);
+  assert.equal(target, `${PAGES}/release/plus-26.03/aarch64/packagesite.pkg`);
+});
+
 test("nightly request maps to the nightly/<varver>/<arch>/ tree", () => {
   // The /nightly/ prefix flips the channel dir; everything else is identical.
   // Before: the same path WITHOUT the prefix would be release/ (proven above);

--- a/scripts/worker/test/router.test.js
+++ b/scripts/worker/test/router.test.js
@@ -7,7 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { normalizeRoutes, parseArch, resolveTarget } from "../src/index.js";
+import worker, { normalizeRoutes, parseArch, resolveTarget } from "../src/index.js";
 
 const PAGES = "https://pfblockerng.github.io/pkg";
 const CE = { pattern: "pfSense/2.8", catalog: "ce-2.8", status: "active" };
@@ -68,4 +68,11 @@ test("a request with no ABI segment resolves to null (the 404 branch)", () => {
   assert.equal(resolveTarget("/notanabi/meta.conf", CE), null);
   // A /nightly/ prefix followed by no ABI is still malformed.
   assert.equal(resolveTarget("/nightly/", CE), null);
+});
+
+test("bare base URL redirects a browser to the human landing page (not a 404)", async () => {
+  // A browser hitting "/" has no pfSense UA — it must land on the Pages page, not 404.
+  const res = await worker.fetch(new Request("https://pkg.pfblockerng.workers.dev/"), {}, { waitUntil() {} });
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get("location"), `${PAGES}/`);
 });


### PR DESCRIPTION
Two Worker routing/UX improvements (one file, one deploy).

**1. Bare base URL → landing page.** Opening the Worker URL in a browser returned a bare 404 (`Unsupported pfSense version (UA: Mozilla/...)`) — the router matches pfSense pkg(8) UAs, so a human had no match. Now `/` (empty path) 302-redirects to the human landing page `https://pfblockerng.github.io/pkg/`. pkg(8) never requests `/`.

**2. Explicit `/release/` prefix.** The Worker now maps `/release/<ABI>/...` to the release tree, **symmetric** with `/nightly/`. A bare `/<ABI>/` still defaults to release (back-compat with older confs). This lets the client confs carry explicit, symmetric `/release` + `/nightly` prefixes (the conf-generator side lands in a follow-up PR, after this deploys so the Worker accepts `/release/` before any client emits it).

Covered by `node:test` (root redirect; `/release/` for CE + Plus aarch64; existing bare + `/nightly/` cases unchanged). Merging triggers `deploy-worker.yml`.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Root path requests to the package base URL now redirect to the pfBlockerNG Pages landing page.
  * Release URLs with an explicit `/release/` prefix now resolve consistently with existing release path behavior.

* **Tests**
  * Added integration coverage for the root-path redirect (HTTP 302 with the correct `location` header).
  * Added routing tests ensuring `/release/FreeBSD:<ver>:<arch>/...` paths map to the expected Pages-backed release targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->