### PR TITLE
ci: explicit /release/ in client conf URL (ADR-20 symmetric paths)

### DIFF
--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -112,15 +112,16 @@ done
 # release (default) -> repo `pfblockerng`,        conf pfblockerng.conf,        Pages root
 #                      carries BOTH pfSense-pkg-pfBlockerNG (stable) and ...-devel
 # nightly           -> repo `pfblockerng-nightly`, conf pfblockerng-nightly.conf, `nightly/` subtree
-# URL_SUBPATH: nightly is served from the `nightly/` catalog subtree; the release repo
-# from the Pages root. The literal ${ABI} pkg(8) variable follows it.
+# URL_SUBPATH: each channel carries an explicit, symmetric prefix — `release/` and
+# `nightly/` — that the Cloudflare Worker (ADR-20) maps to the variant catalog tree.
+# The literal ${ABI} pkg(8) variable follows it.
 # PKG_NAMES: the package(s) the verify step checks + the install hints printed (the
 # release repo carries two; nightly one).
 case "$CHANNEL" in
     release)
         REPO_NAME="pfblockerng"
         CONF_NAME="pfblockerng.conf"
-        URL_SUBPATH=""
+        URL_SUBPATH="release/"
         PKG_NAMES="pfSense-pkg-pfBlockerNG pfSense-pkg-pfBlockerNG-devel"
         ;;
     nightly)

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -756,7 +756,7 @@ def print_conf(base_url: str) -> None:
         f"# priority {CONF_PRIORITY} sits above the base Netgate `pfSense` repo so cross-repo\n"
         "# resolution (pkg install/upgrade, GUI Install) selects our build.\n"
         "pfblockerng: {\n"
-        f'  url: "{base}/${{ABI}}",\n'
+        f'  url: "{base}/release/${{ABI}}",\n'
         "  mirror_type: none,\n"
         "  signature_type: none,\n"
         f"  priority: {CONF_PRIORITY},\n"

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -101,7 +101,7 @@ print_conf() {
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
 # resolution (pkg install/upgrade, GUI Install) selects our build.
 pfblockerng: {
-  url: "${base}/\${ABI}",
+  url: "${base}/release/\${ABI}",
   mirror_type: none,
   signature_type: none,
   priority: ${CONF_PRIORITY},

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -119,8 +119,9 @@ def test_release_conf_byte_identical_across_all_three_generators() -> None:
 @pytest.mark.parametrize(
     ("args", "repo_name", "url"),
     [
-        # Default (no argument) -> the shared `pfblockerng` release repo.
-        ((), "pfblockerng", f'url: "{_WORKER_URL}/${{ABI}}"'),
+        # Default (no argument) -> the shared `pfblockerng` release repo on the explicit
+        # `release/` catalog subtree (symmetric with nightly; ADR-20).
+        ((), "pfblockerng", f'url: "{_WORKER_URL}/release/${{ABI}}"'),
         # --nightly -> a DISTINCT `pfblockerng-nightly` repo on a `nightly/` catalog
         # subtree (so it never collides with the release tree on Pages).
         (("--nightly",), "pfblockerng-nightly", f'url: "{_WORKER_URL}/nightly/${{ABI}}"'),

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -507,7 +507,7 @@ def test_print_conf_matches_template(capsys: pytest.CaptureFixture[str]) -> None
     assert rc == 0
     out = capsys.readouterr().out
     assert "pfblockerng: {" in out  # the shared release repo (stable + devel)
-    assert 'url: "https://pkg.pfblockerng.workers.dev/${ABI}"' in out  # canonical Worker URL (ADR-20)
+    assert 'url: "https://pkg.pfblockerng.workers.dev/release/${ABI}"' in out  # Worker URL + release prefix (ADR-20)
     assert "signature_type: none," in out
     assert "priority: 100," in out
     assert "enabled: yes" in out
@@ -518,7 +518,7 @@ def test_print_conf_base_url_override(capsys: pytest.CaptureFixture[str]) -> Non
     rc = brp.main(["--print-conf", "--base-url", "https://fork.example.io/p/"])
     assert rc == 0
     out = capsys.readouterr().out
-    assert 'url: "https://fork.example.io/p/${ABI}"' in out  # trailing slash trimmed
+    assert 'url: "https://fork.example.io/p/release/${ABI}"' in out  # trailing slash trimmed + release prefix
 
 
 def test_cli_requires_in_and_out(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
Step 2 of the symmetric-channel-path change (step 1 = Worker PR #250). Makes the client conf URL carry an **explicit `/release/`** prefix, symmetric with `/nightly/`.

- `scripts/add-repo.sh`: release `URL_SUBPATH` `""` → `"release/"` → conf url `"<worker>/release/${ABI}"`.
- `scripts/build-repo.sh` + `scripts/build-repo-portable.py` `--print-conf`: same `/release/${ABI}`.
- Drift tests (`test_add_repo_conf.py`, `test_build_repo_portable.py`) updated; the three generators stay **byte-identical** (verified).

The Worker (PR #250) maps `/release/` to the release tree and keeps bare `/<ABI>/` working (back-compat), so **#250 must merge + deploy before this lands** — otherwise a freshly-bootstrapped client would send `/release/` to a Worker that doesn't yet consume it. Full suite green (1635).

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release repository URLs to include `/release/` path segment across repository configuration and build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->