### PR TITLE
ci: force catalogue refresh in ADR-20 repo Case 4 (pkg update -f)

### DIFF
--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1777,8 +1777,13 @@ def test_routing_url_delivers_variant_catalog(repo_vm: SmokeVM) -> None:
     if written.returncode != 0:
         raise RuntimeError(f"write Worker conf failed: rc={written.returncode} {written.stderr!r}")
 
-    # pkg update via the Worker must succeed (routing.json is live on Pages).
-    update_result = repo_vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "update", "-r", OURS_REPO_NAME, timeout=120.0)
+    # pkg update via the Worker must succeed (routing.json is live on Pages). Force a full
+    # catalogue refresh (-f): earlier cases in this VM built the `pfblockerng` repo DB from a
+    # different (Pages/add-repo) URL, so swapping the conf to the Worker URL otherwise trips
+    # pkg's "wrong packagesite, need to re-create database" staleness guard.
+    update_result = repo_vm.ssh(
+        "env", "ASSUME_ALWAYS_YES=yes", "pkg", "update", "-f", "-r", OURS_REPO_NAME, timeout=120.0
+    )
     if update_result.returncode != 0:
         update_out = update_result.stdout + update_result.stderr
         pytest.fail(


### PR DESCRIPTION
The repo-install smoke proof (`smoke.yml -m repo`) came back **21 passed, 1 failed** — the guard-dep fix (#249) cleared the `pkg repo` abort, and every install/variant/cross-repo/software-update case is green. The lone failure is the un-xfailed Case 4:

```
pkg: Repository pfblockerng has a wrong packagesite, need to re-create database
```

Not a routing fault (curl + `test_install_from_variant_catalog` confirm the Worker routes correctly) — a test artifact: Case 4 reuses the `pfblockerng` repo name after earlier cases built its local pkg DB from a different (Pages/add-repo) URL, so re-pointing the conf at the Worker URL trips pkg's stale-catalogue guard. Fix: `pkg update -f` forces a clean re-create.

After this lands I'll re-dispatch `smoke.yml -m repo` to confirm fully green.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved package repository test to ensure proper catalog refresh behavior across different URL routing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->