### PR TITLE
dev: align the older-nightlies table columns with the edition tables

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -332,6 +332,32 @@ def _edition_key(variant: str) -> str:
     return variant.strip() or "Other"
 
 
+def _join_matrix(rows: list[dict], matrix: list[dict] | None) -> list[tuple[str, dict]]:
+    """Enrich each row with the pfSense version + PHP/Python from the matrix join.
+
+    Returns ``(edition_key, row)`` pairs. An ABI shared by two pfSense versions yields
+    one row per match (the same .pkg installs on each); an ABI with no matrix entry
+    yields a single ("Other") row with a blank pfSense version + manifest-derived
+    php/py, so nothing published is ever hidden. Input order is preserved.
+    """
+    idx = matrix_index(matrix)
+    out: list[tuple[str, dict]] = []
+    for r in rows:
+        entries = idx.get(r["abi"], [])
+        if entries:
+            for e in entries:
+                row = dict(r)
+                row["pfsense_version"] = e.get("pfsense_version", "")
+                row["php"] = e.get("php_version") or e.get("php") or r.get("php", "")
+                row["py"] = _dotted_ver(e.get("py_flavor", "")) or r.get("py", "")
+                out.append((_edition_key(e.get("variant", "")), row))
+        else:
+            row = dict(r)
+            row["pfsense_version"] = ""
+            out.append(("Other", row))
+    return out
+
+
 def build_edition_sections(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str, list[dict]]]:
     """Group the current installables into per-edition row lists, display-ordered.
 
@@ -340,21 +366,9 @@ def build_edition_sections(pkgs: list[dict], matrix: list[dict] | None) -> list[
     entry falls into a trailing "Other" section using its manifest-derived php/py, so
     nothing published is ever hidden. Editions sort CE, then Plus, then the rest.
     """
-    idx = matrix_index(matrix)
     sections: dict[str, list[dict]] = {}
-    for r in build_table(pkgs):
-        entries = idx.get(r["abi"], [])
-        if entries:
-            for e in entries:
-                row = dict(r)
-                row["pfsense_version"] = e.get("pfsense_version", "")
-                row["php"] = e.get("php_version") or e.get("php") or r.get("php", "")
-                row["py"] = _dotted_ver(e.get("py_flavor", "")) or r.get("py", "")
-                sections.setdefault(_edition_key(e.get("variant", "")), []).append(row)
-        else:
-            row = dict(r)
-            row["pfsense_version"] = ""
-            sections.setdefault("Other", []).append(row)
+    for ekey, row in _join_matrix(build_table(pkgs), matrix):
+        sections.setdefault(ekey, []).append(row)
     keys = [k for k in EDITION_ORDER if k in sections]
     keys += [k for k in sorted(sections) if k not in EDITION_ORDER and k != "Other"]
     if "Other" in sections:
@@ -411,23 +425,32 @@ def older_nightlies(pkgs: list[dict]) -> list[dict]:
     return rows
 
 
-def _older_nightlies_html(pkgs: list[dict]) -> str:
-    """A collapsed disclosure listing the retained older nightlies; "" when there are none."""
-    rows = older_nightlies(pkgs)
-    if not rows:
+def _older_nightlies_html(pkgs: list[dict], matrix: list[dict] | None = None) -> str:
+    """A collapsed disclosure listing the retained older nightlies; "" when there are none.
+
+    Carries the same columns as the per-edition tables (matrix-joined pfSense version +
+    PHP/Python), minus Channel — every row here is, by construction, a nightly.
+    """
+    older = older_nightlies(pkgs)
+    if not older:
         return ""
+    rows = [row for _ekey, row in _join_matrix(older, matrix)]
     body = "".join(
-        f'<tr><td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
+        f"<tr><td>{_or_dash(r.get('pfsense_version', ''))}</td>"
+        f'<td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
         f"<td><code>{_esc(r['abi'])}</code></td>"
+        f'<td class="num">{_or_dash(r.get("php", ""))}</td>'
+        f'<td class="num">{_or_dash(r.get("py", ""))}</td>'
         f'<td class="num">{_esc(r.get("published", ""))}</td>'
         f"<td>{commit_cell(r.get('commit', ''))}</td>"
         f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
         for r in rows
     )
     return (
-        f"<details><summary>Older nightlies ({len(rows)})</summary>"
+        f"<details><summary>Older nightlies ({len(older)})</summary>"
         '<div class="tablewrap"><table><thead><tr>'
-        "<th>Version</th><th>ABI</th><th>Published</th><th>Commit</th><th>Size</th>"
+        "<th>pfSense</th><th>Version</th><th>ABI</th>"
+        "<th>PHP</th><th>Python</th><th>Published</th><th>Commit</th><th>Size</th>"
         f"</tr></thead><tbody>{body}</tbody></table></div></details>"
     )
 
@@ -455,7 +478,7 @@ def render_page(
         "<strong>devel</strong> share one repo &mdash; pick the package; <strong>nightly</strong> is a "
         "separate, opt-in repo.</p>"
         f'<h2>Channels</h2><div class="cards">{cards}</div>'
-        f"<h2>Published packages</h2>{_packages_html(pkgs, matrix)}{_older_nightlies_html(pkgs)}"
+        f"<h2>Published packages</h2>{_packages_html(pkgs, matrix)}{_older_nightlies_html(pkgs, matrix)}"
         "<h2>Catalog trees</h2>"
         '<p class="blurb">The raw pkg(8) catalogs (what your firewall fetches). <code>${ABI}</code> is filled '
         "in by pkg automatically, e.g. <code>FreeBSD:16:aarch64</code> on a Netgate ARM box.</p>"

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -289,10 +289,17 @@ def test_older_nightlies_lists_retained_excludes_latest() -> None:
     assert versions == ["3.2.16.20260613.4", "3.2.16.20260601.1"]  # newest excluded, rest newest-first
     assert all(r["channel"] == "nightly" for r in rows)  # devel never listed
     # The page renders the two retained nightlies in a collapsed disclosure, never the latest.
-    html = gl._older_nightlies_html([new, mid, old, dev])
+    matrix = [_mx("FreeBSD:16:amd64", "26.03", "Plus", "8.5", "py311")]
+    html = gl._older_nightlies_html([new, mid, old, dev], matrix)
     assert "<details><summary>Older nightlies (2)</summary>" in html
     assert "3.2.16.20260613.4" in html and "3.2.16.20260601.1" in html
     assert "3.2.16.20260614.9" not in html  # the current nightly stays out of the 'older' list
+    # Same columns as the per-edition tables, minus Channel (every row here is a nightly).
+    for header in ("<th>pfSense</th>", "<th>Version</th>", "<th>ABI</th>", "<th>PHP</th>", "<th>Python</th>"):
+        assert header in html
+    assert "<th>Channel</th>" not in html  # the one column deliberately dropped
+    # …and the matrix-joined pfSense version / PHP / Python land in the cells.
+    assert ">26.03<" in html and ">8.5<" in html and ">3.11<" in html
 
 
 def test_older_nightlies_empty_when_only_latest() -> None:


### PR DESCRIPTION
## What

The **Older nightlies** disclosure on the pkg-repo landing page listed only `Version / ABI / Published / Commit / Size`, while the per-edition "Published packages" tables also carry **pfSense version + PHP + Python** (matrix-joined by ABI). This gives the older-nightlies table the **same column set** — `pfSense / Version / ABI / PHP / Python / Published / Commit / Size` — **minus Channel** (every row in that table is, by construction, a nightly).

## How

- Factored the per-row matrix join out of `build_edition_sections` into a shared `_join_matrix()` helper so both tables enrich rows identically (pfSense version from the matrix, PHP/Python from the matrix with a manifest fallback, unmatched ABI → blank pfSense + "Other").
- `_older_nightlies_html(pkgs, matrix)` now renders the full column set; `render_page` passes the matrix through.
- The `(N)` summary count stays the number of older nightly **packages** (pre-join), so a multi-edition ABI doesn't inflate it.

## Tests

`test_older_nightlies_lists_retained_excludes_latest` now passes a matrix and asserts the new headers are present, `Channel` is absent, and the matrix-joined pfSense/PHP/Python values land in the cells. Full unit suite green (1635).

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how pfSense edition/version and PHP/Python flavor information is enriched for published packages, with consistent application across all package display sections.

* **Tests**
  * Updated test coverage to verify proper display of edition and flavor information in the older nightly packages section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->