### PR TITLE
ci: offline Worker UA-dispatch tests + gate the live Case-4 leg (ADR-20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -386,6 +386,28 @@ jobs:
         # Reads .markdownlint.jsonc (rules) + .markdownlint-cli2.jsonc (globs/ignores).
         run: npx --yes markdownlint-cli2
 
+  worker-tests:
+    name: Worker unit tests (node --test)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      - name: Run the pkg-routing Worker tests
+        # Offline unit coverage for scripts/worker/ (the Cloudflare routing Worker):
+        # the path math (parseArch/resolveTarget) AND the UA->catalog dispatch through
+        # worker.fetch, with the edge (caches + routing.json fetch) stubbed — no network,
+        # no wrangler. This is the deterministic gate for the routing logic that the
+        # live-VM ADR-20 Case-4 leg can only exercise against the real (CDN-fronted) edge.
+        run: node --test
+        working-directory: scripts/worker
+
   benchmarks:
     name: Benchmark kill-gates (ReDoS + build RAM)
     # MANUAL-ONLY (issue #76). The spikes carry their GO/NO-GO verdict in their EXIT
@@ -460,7 +482,7 @@ jobs:
     # The ADR-14 UI suite (`ui-suite`) IS folded in: it is skipped (== pass) on an
     # unlabeled PR / push, and only a `ui-tests`-labeled PR whose UI suite FAILS
     # blocks here — that is how the opt-in label gates a merge.
-    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, ui-suite]
+    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, worker-tests, ui-suite]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
@@ -507,6 +529,10 @@ jobs:
           fi
           if [ "${{ needs.markdownlint.result }}" != "success" ]; then
             echo "markdownlint failed or was cancelled."
+            exit 1
+          fi
+          if [ "${{ needs.worker-tests.result }}" != "success" ]; then
+            echo "Worker unit tests (node --test) failed or were cancelled."
             exit 1
           fi
           # ADR-14 UI suite (label-gated): 'skipped' (unlabeled PR / push) is a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -666,7 +666,17 @@ update badge stay Netgate-bound; a GUI "Updates/Channel" panel is deferred (woul
   `gh workflow run smoke.yml -f pytest_marker=repo` (or `repo-install.yml` once it lands on
   `devel`). The gated `test_install_from_live_pages_url` (`SMOKE_REPO_LIVE_URL`) hits the
   real `pfblockerng.github.io` URL — post-merge (a new `workflow_dispatch` workflow is only
-  dispatchable from the default branch).
+  dispatchable from the default branch). The Case-4 live-Worker leg
+  (`test_routing_url_delivers_variant_catalog`) is likewise gated (`SMOKE_WORKER_LIVE`,
+  unset → SKIP): it depends on a deployed + CDN-propagated Cloudflare Worker that a
+  PR/dispatch can't guarantee, so it is opt-in post-deploy verification, **not** a hard gate.
+- **Cloudflare routing Worker (ADR-20):** lives in `scripts/worker/` (`src/index.js` reads the
+  pfSense pkg User-Agent, matches `routing.json` from Pages, 302s to
+  `<channel>/<varver>/<arch>/`). Its routing logic — UA→catalog dispatch + path mapping — is
+  proven **offline + always-on** by `scripts/worker/test/router.test.js` (`node --test`, edge
+  stubbed, no network/wrangler), run in CI by the `worker-tests` job in `test.yml`. This is the
+  deterministic routing gate; the live Case-4 leg only adds end-to-end edge confidence.
+  `deploy-worker.yml` deploys the Worker (push to `scripts/worker/**`, dispatch, or post-release).
 
 **Merge PRs by rebase only** — `gh pr merge <N> --rebase` (or GitHub's "Rebase and merge");
 never a merge commit, never squash. History across `main` ← `devel` stays strictly linear

--- a/scripts/worker/test/router.test.js
+++ b/scripts/worker/test/router.test.js
@@ -88,3 +88,101 @@ test("bare base URL redirects a browser to the human landing page (not a 404)", 
   assert.equal(res.status, 302);
   assert.equal(res.headers.get("location"), `${PAGES}/`);
 });
+
+// --- worker.fetch UA dispatch (the route MATCH) ------------------------------
+// The helpers above pin the path math (resolveTarget). These drive worker.fetch
+// end-to-end to pin the OTHER half — matching the request's User-Agent against
+// routing.json — which is the exact decision the live Worker makes and the one the
+// ADR-20 Case-4 live-VM gate exercises. getRoutes() reads caches.default + global
+// fetch, so we stub the edge to serve a known manifest WITHOUT any network.
+const ROUTING_URL = `${PAGES}/routing.json`;
+const CTX = { waitUntil() {} };
+
+// Stub the edge so getRoutes() resolves `manifest` (a cache HIT serves it directly),
+// or, when `manifest === null`, a cache MISS + a 5xx fetch (the fail-closed path).
+function stubEdge(manifest) {
+  globalThis.caches = {
+    default: {
+      async match() {
+        return manifest === null ? undefined : new Response(JSON.stringify(manifest), { status: 200 });
+      },
+      async put() {},
+    },
+  };
+  // Only reached on a cache miss (the manifest === null / 502 path).
+  globalThis.fetch = async (url) => {
+    assert.equal(String(url), ROUTING_URL, "getRoutes must fetch the Pages routing.json");
+    return new Response("unavailable", { status: 500 });
+  };
+}
+
+function route(ua, path) {
+  const headers = ua === null ? {} : { "User-Agent": ua };
+  return worker.fetch(new Request(`https://pkg.pfblockerng.workers.dev${path}`, { headers }), {}, CTX);
+}
+
+// routing.json lists the more-specific pattern (Plus) first, exactly as published.
+const MANIFEST = { routes: [PLUS, CE] };
+
+test("fetch: a CE pfSense UA is routed to the ce-2.8 release catalog", async () => {
+  stubEdge(MANIFEST);
+  const res = await route("pkg/1.21 (FreeBSD:15:amd64; pfSense/2.8)", "/FreeBSD:15:amd64/meta.conf");
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get("location"), `${PAGES}/release/ce-2.8/amd64/meta.conf`);
+});
+
+test("fetch: a Plus pfSense UA is routed to the plus-26.03 release catalog", async () => {
+  // Same request shape, different UA -> different catalog: proves the UA (not the path)
+  // drives the variant. aarch64 also confirms the arch leaf rides through.
+  stubEdge(MANIFEST);
+  const res = await route("pkg/1.21 (FreeBSD:16:aarch64; Netgate pfSense Plus/26.03)", "/FreeBSD:16:aarch64/packagesite.pkg");
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get("location"), `${PAGES}/release/plus-26.03/aarch64/packagesite.pkg`);
+});
+
+test("fetch: a /nightly/ path with a CE UA hits the nightly ce-2.8 tree", async () => {
+  // The UA picks the variant; the /nightly/ prefix picks the channel — both compose.
+  stubEdge(MANIFEST);
+  const res = await route("pkg/1.21 (FreeBSD:15:amd64; pfSense/2.8)", "/nightly/FreeBSD:15:amd64/meta.conf");
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get("location"), `${PAGES}/nightly/ce-2.8/amd64/meta.conf`);
+});
+
+test("fetch: a non-pfSense UA matches no route -> 404 (never a wrong-variant install)", async () => {
+  // The whole point of UA routing: a client whose UA matches no pattern is refused,
+  // not silently served some default catalog.
+  stubEdge(MANIFEST);
+  for (const ua of ["curl/8.7.1", "pkg/1.21.3", null]) {
+    const res = await route(ua, "/FreeBSD:15:amd64/meta.conf");
+    assert.equal(res.status, 404, `UA ${JSON.stringify(ua)} should 404`);
+  }
+});
+
+test("fetch: first matching route wins (routing.json order is honored)", async () => {
+  // Two patterns both substrings of the UA -> find() returns the FIRST. Pins that the
+  // published "more-specific first" ordering is what selects the catalog.
+  stubEdge({
+    routes: [
+      { pattern: "pfSense/2.8", catalog: "ce-2.8", status: "active" },
+      { pattern: "pfSense", catalog: "generic", status: "active" },
+    ],
+  });
+  const res = await route("pkg/1.21 (FreeBSD:15:amd64; pfSense/2.8)", "/FreeBSD:15:amd64/meta.conf");
+  assert.equal(res.headers.get("location"), `${PAGES}/release/ce-2.8/amd64/meta.conf`);
+});
+
+test("fetch: a matched UA with no ABI segment in the path -> 404", async () => {
+  // The UA resolves, but the path carries no FreeBSD:<major>:<arch> segment -> the
+  // resolveTarget null branch surfaces as a 404 (not a 302 to a malformed target).
+  stubEdge(MANIFEST);
+  const res = await route("pkg/1.21 (FreeBSD:15:amd64; pfSense/2.8)", "/notanabi/meta.conf");
+  assert.equal(res.status, 404);
+});
+
+test("fetch: routing.json unavailable -> 502 (fail closed, never a guess)", async () => {
+  // Cache miss + a 5xx manifest fetch: getRoutes returns null and the Worker answers
+  // 502 rather than throwing or defaulting to some catalog.
+  stubEdge(null);
+  const res = await route("pkg/1.21 (FreeBSD:15:amd64; pfSense/2.8)", "/FreeBSD:15:amd64/meta.conf");
+  assert.equal(res.status, 502);
+});

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -151,6 +151,13 @@ GUEST_ADD_REPO_SH = f"{GUEST_SPIKE_DIR}/add-repo.sh"
 # always-on proof; the live URL only exists once the deploy has run).
 LIVE_BASE_URL_ENV = "SMOKE_REPO_LIVE_URL"
 DEFAULT_LIVE_BASE_URL = "https://pfblockerng.github.io/pkg"
+# Case 4 (the live Cloudflare Worker leg) is GATED on SMOKE_WORKER_LIVE: unset -> SKIP.
+# The Worker's routing (UA -> catalog + path mapping) is proven deterministically and
+# always-on by the offline unit tests in scripts/worker/test/router.test.js; the live
+# leg additionally depends on the Worker + Pages routing.json being deployed AND
+# CDN-propagated, which a PR/dispatch can't guarantee — so it is opt-in post-deploy
+# verification, not a hard CI gate (it would red the suite on a deploy/propagation race).
+WORKER_LIVE_ENV = "SMOKE_WORKER_LIVE"
 GUEST_ABI = "FreeBSD:15:amd64"  # the single supported ABI (CE 2.8 + Plus 25.03)
 # GitHub Pages' anycast IPs. The smoke harness sandboxes guest DNS to a mock that
 # only answers `uuid-*.com`, so `pfblockerng.github.io` does not resolve on the guest. Pinning
@@ -1771,10 +1778,19 @@ def test_routing_url_delivers_variant_catalog(repo_vm: SmokeVM) -> None:
       confirmed by ``pkg rquery -r pfblockerng '%dn %dv' <pkgname>`` showing the box's own
       php dep (php83 on CE / php85 on Plus, from the matrix).
 
-    The Cloudflare Worker is live and routing.json is deployed to Pages (the matrix-
-    driven publish), so this is a HARD gate: a failed ``pkg update`` (e.g. a 502 from a
-    missing routing.json, or the wrong-variant catalog) fails the test.
+    GATED on ``SMOKE_WORKER_LIVE`` (unset -> SKIP). The routing LOGIC is proven
+    always-on + deterministically by the offline Worker unit tests
+    (``scripts/worker/test/router.test.js`` — UA->catalog dispatch + path mapping with
+    the edge stubbed). THIS leg additionally exercises the LIVE Worker + Pages
+    routing.json end-to-end, which depends on a deployed + CDN-propagated edge a
+    PR/dispatch can't guarantee; run it as opt-in post-deploy verification.
     """
+    val = os.environ.get(WORKER_LIVE_ENV, "").strip().lower()
+    if val not in {"1", "true", "yes", "on"}:
+        pytest.skip(
+            f"{WORKER_LIVE_ENV} not set — the live Cloudflare Worker leg is CDN-dependent "
+            f"(deterministic routing proof is the offline scripts/worker/test/ unit suite)"
+        )
     _ensure_egress_open()
 
     # Write a NONE-signed repo conf pointing at the Worker URL.

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -158,7 +158,10 @@ DEFAULT_LIVE_BASE_URL = "https://pfblockerng.github.io/pkg"
 # CDN-propagated, which a PR/dispatch can't guarantee — so it is opt-in post-deploy
 # verification, not a hard CI gate (it would red the suite on a deploy/propagation race).
 WORKER_LIVE_ENV = "SMOKE_WORKER_LIVE"
-GUEST_ABI = "FreeBSD:15:amd64"  # the single supported ABI (CE 2.8 + Plus 25.03)
+# The ABI of the repo-smoke guest (the live Pages-URL check, poll_catalog_served, runs on
+# the CE 2.8 box). NOT the only supported ABI — the build matrix now spans CE FreeBSD:15:amd64
+# plus Plus FreeBSD:16:amd64 / FreeBSD:16:aarch64 (see the routing.json catalogs).
+GUEST_ABI = "FreeBSD:15:amd64"
 # GitHub Pages' anycast IPs. The smoke harness sandboxes guest DNS to a mock that
 # only answers `uuid-*.com`, so `pfblockerng.github.io` does not resolve on the guest. Pinning
 # the Pages IPs in the guest /etc/hosts lets `pkg`'s HTTPS fetch reach Pages by name


### PR DESCRIPTION
## Why

The pkg‑routing **Cloudflare Worker** (`scripts/worker/`) had unit coverage only for its pure path helpers, and that suite **ran nowhere in CI**. The one place its UA→catalog routing was exercised was the live ADR‑20 **Case 4** smoke leg (`test_routing_url_delivers_variant_catalog`), which hits the real Worker + Pages `routing.json` — inherently CDN/propagation‑dependent, so a flaky hard gate (it red the repo‑smoke suite on a post‑deploy propagation race even though the code was fine).

This moves the routing confidence **offline + deterministic**, and demotes the live leg to opt‑in.

## Changes

- **`scripts/worker/test/router.test.js`** — add `worker.fetch`‑level cases driving the UA→catalog **dispatch** with the edge (`caches` + `routing.json` fetch) **stubbed** (no network, no wrangler): CE UA→`ce-2.8`, Plus UA→`plus-26.03`, `/nightly/` channel compose, **non‑pfSense UA → 404**, **first‑match‑wins** ordering, matched UA + no ABI → 404, manifest unavailable → **502**. (The pre‑existing helper tests already cover the path math.)
- **`.github/workflows/test.yml`** — new `worker-tests` job (`node --test` in `scripts/worker`) folded into the `all-tests-passed` aggregate → the deterministic routing gate now runs on **every PR**.
- **`tests/smoke/test_repo_install.py`** — gate Case 4 on **`SMOKE_WORKER_LIVE`** (unset → SKIP), mirroring `test_install_from_live_pages_url`'s `SMOKE_REPO_LIVE_URL`. The live Worker leg is now opt‑in post‑deploy verification, not a hard gate.
- **`CLAUDE.md`** — document the Worker test/CI gate + the Case‑4 `SMOKE_WORKER_LIVE` gate.

## Validation

`node --test` → 19/19 (12 existing + 7 new). Full Python unit suite green (1635). `test.yml` YAML valid; smoke file lints/parses.

Context: when I probed the live Worker manually, it routed correctly for `pfSense/2.8` / `Netgate pfSense Plus/26.03` UAs (200 → `release/<varver>/amd64/...`); only non‑pfSense UAs 404 — consistent with the Case‑4 failure being a deploy/CDN‑propagation race, not a routing bug.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added offline Worker routing integration coverage that verifies redirect and error behavior across User-Agent matching and path-based ABI segment handling.
  * Made the live Worker routing verification opt-in via an environment variable.

* **Documentation**
  * Expanded self-hosted `pkg` smoke-flow guidance and clarified Cloudflare routing Worker behavior and where offline CI routing tests apply.

* **Chores**
  * Updated the CI workflow to run dedicated Worker unit tests and require them as part of the overall test pass gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->