### PR TITLE
dev: fold each edition's older nightlies under its own table (CE/Plus)

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -358,6 +358,16 @@ def _join_matrix(rows: list[dict], matrix: list[dict] | None) -> list[tuple[str,
     return out
 
 
+def _order_edition_keys(sections: dict[str, list[dict]]) -> list[str]:
+    """Edition display order: CE, then Plus, then any other variant alphabetically,
+    with "Other" (unmatched ABIs) always last."""
+    keys = [k for k in EDITION_ORDER if k in sections]
+    keys += [k for k in sorted(sections) if k not in EDITION_ORDER and k != "Other"]
+    if "Other" in sections:
+        keys.append("Other")
+    return keys
+
+
 def build_edition_sections(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str, list[dict]]]:
     """Group the current installables into per-edition row lists, display-ordered.
 
@@ -369,12 +379,8 @@ def build_edition_sections(pkgs: list[dict], matrix: list[dict] | None) -> list[
     sections: dict[str, list[dict]] = {}
     for ekey, row in _join_matrix(build_table(pkgs), matrix):
         sections.setdefault(ekey, []).append(row)
-    keys = [k for k in EDITION_ORDER if k in sections]
-    keys += [k for k in sorted(sections) if k not in EDITION_ORDER and k != "Other"]
-    if "Other" in sections:
-        keys.append("Other")
     out: list[tuple[str, list[dict]]] = []
-    for k in keys:
+    for k in _order_edition_keys(sections):
         rows = sections[k]
         rows.sort(key=lambda p: (ver_key(p.get("pfsense_version", "")), CH_ORDER.index(p["channel"]), p["abi"]))
         out.append((k, rows))
@@ -404,11 +410,17 @@ def _edition_table_html(rows: list[dict]) -> str:
 
 
 def _packages_html(pkgs: list[dict], matrix: list[dict] | None) -> str:
-    """The Published-packages block: one titled table per pfSense edition."""
+    """The Published-packages block: one titled table per pfSense edition, each followed by
+    that edition's retained older nightlies folded into a collapsed disclosure."""
     sections = [(k, rows) for k, rows in build_edition_sections(pkgs, matrix) if rows]
     if not sections:
         return '<p class="empty">No packages published yet.</p>'
-    return "".join(f"<h3>{_esc(EDITION_LABELS.get(k, k))}</h3>{_edition_table_html(rows)}" for k, rows in sections)
+    older_by_edition = _older_nightlies_by_edition(pkgs, matrix)
+    return "".join(
+        f"<h3>{_esc(EDITION_LABELS.get(k, k))}</h3>"
+        f"{_edition_table_html(rows)}{_older_nightlies_details(older_by_edition.get(k, []))}"
+        for k, rows in sections
+    )
 
 
 def older_nightlies(pkgs: list[dict]) -> list[dict]:
@@ -425,16 +437,10 @@ def older_nightlies(pkgs: list[dict]) -> list[dict]:
     return rows
 
 
-def _older_nightlies_html(pkgs: list[dict], matrix: list[dict] | None = None) -> str:
-    """A collapsed disclosure listing the retained older nightlies; "" when there are none.
-
-    Carries the same columns as the per-edition tables (matrix-joined pfSense version +
-    PHP/Python), minus Channel — every row here is, by construction, a nightly.
-    """
-    older = older_nightlies(pkgs)
-    if not older:
-        return ""
-    rows = [row for _ekey, row in _join_matrix(older, matrix)]
+def _older_nightlies_table_html(rows: list[dict]) -> str:
+    """One older-nightlies table for a single edition: the same columns as the per-edition
+    tables (matrix-joined pfSense version + PHP/Python), minus Channel — every row here is,
+    by construction, a nightly."""
     body = "".join(
         f"<tr><td>{_or_dash(r.get('pfsense_version', ''))}</td>"
         f'<td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
@@ -447,12 +453,28 @@ def _older_nightlies_html(pkgs: list[dict], matrix: list[dict] | None = None) ->
         for r in rows
     )
     return (
-        f"<details><summary>Older nightlies ({len(older)})</summary>"
         '<div class="tablewrap"><table><thead><tr>'
         "<th>pfSense</th><th>Version</th><th>ABI</th>"
         "<th>PHP</th><th>Python</th><th>Published</th><th>Commit</th><th>Size</th>"
-        f"</tr></thead><tbody>{body}</tbody></table></div></details>"
+        f"</tr></thead><tbody>{body}</tbody></table></div>"
     )
+
+
+def _older_nightlies_by_edition(pkgs: list[dict], matrix: list[dict] | None) -> dict[str, list[dict]]:
+    """The retained older nightlies grouped by edition key (matrix-joined by ABI), so each
+    edition's disclosure folds in directly under that edition's table. Empty when none."""
+    by_edition: dict[str, list[dict]] = {}
+    for ekey, row in _join_matrix(older_nightlies(pkgs), matrix):
+        by_edition.setdefault(ekey, []).append(row)
+    return by_edition
+
+
+def _older_nightlies_details(rows: list[dict]) -> str:
+    """One edition's retained older nightlies, folded into a collapsed disclosure; "" when
+    that edition has none. Same columns as the edition table, minus Channel (all nightlies)."""
+    if not rows:
+        return ""
+    return f"<details><summary>Older nightlies ({len(rows)})</summary>{_older_nightlies_table_html(rows)}</details>"
 
 
 def render_page(
@@ -478,7 +500,7 @@ def render_page(
         "<strong>devel</strong> share one repo &mdash; pick the package; <strong>nightly</strong> is a "
         "separate, opt-in repo.</p>"
         f'<h2>Channels</h2><div class="cards">{cards}</div>'
-        f"<h2>Published packages</h2>{_packages_html(pkgs, matrix)}{_older_nightlies_html(pkgs, matrix)}"
+        f"<h2>Published packages</h2>{_packages_html(pkgs, matrix)}"
         "<h2>Catalog trees</h2>"
         '<p class="blurb">The raw pkg(8) catalogs (what your firewall fetches). <code>${ABI}</code> is filled '
         "in by pkg automatically, e.g. <code>FreeBSD:16:aarch64</code> on a Netgate ARM box.</p>"

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -288,26 +288,61 @@ def test_older_nightlies_lists_retained_excludes_latest() -> None:
     versions = [r["version"] for r in rows]
     assert versions == ["3.2.16.20260613.4", "3.2.16.20260601.1"]  # newest excluded, rest newest-first
     assert all(r["channel"] == "nightly" for r in rows)  # devel never listed
-    # The page renders the two retained nightlies in a collapsed disclosure, never the latest.
+    # The packages block folds the two retained nightlies into a disclosure UNDER the edition
+    # table, never the latest (which lives in the edition table itself).
     matrix = [_mx("FreeBSD:16:amd64", "26.03", "Plus", "8.5", "py311")]
-    html = gl._older_nightlies_html([new, mid, old, dev], matrix)
+    html = gl._packages_html([new, mid, old, dev], matrix)
+    assert "<h3>pfSense Plus</h3>" in html
     assert "<details><summary>Older nightlies (2)</summary>" in html
-    assert "3.2.16.20260613.4" in html and "3.2.16.20260601.1" in html
-    assert "3.2.16.20260614.9" not in html  # the current nightly stays out of the 'older' list
-    # Same columns as the per-edition tables, minus Channel (every row here is a nightly).
-    for header in ("<th>pfSense</th>", "<th>Version</th>", "<th>ABI</th>", "<th>PHP</th>", "<th>Python</th>"):
-        assert header in html
-    assert "<th>Channel</th>" not in html  # the one column deliberately dropped
-    # …and the matrix-joined pfSense version / PHP / Python land in the cells.
-    assert ">26.03<" in html and ">8.5<" in html and ">3.11<" in html
+    # The disclosure sits AFTER the edition's main table (folded under it).
+    assert html.index("<h3>pfSense Plus</h3>") < html.index("Older nightlies (2)")
+    details = html[html.index("Older nightlies (2)") :]
+    assert "3.2.16.20260613.4" in details and "3.2.16.20260601.1" in details
+    assert "3.2.16.20260614.9" not in details  # the current nightly stays out of the 'older' disclosure
+    # The disclosure's table carries the same columns as the edition table, minus Channel.
+    assert "<th>Channel</th>" not in details and "<th>pfSense</th>" in details
+    assert ">26.03<" in details and ">8.5<" in details and ">3.11<" in details
 
 
 def test_older_nightlies_empty_when_only_latest() -> None:
     """With a single nightly version present there is nothing 'older' to disclose."""
     only = _pkg("nightly", "n", "3.2.16.20260614.9", "FreeBSD:16:amd64", "n.pkg")
     assert gl.older_nightlies([only, _pkg("devel", "d", "3.2.16", "FreeBSD:16:amd64", "d.pkg")]) == []
-    # …and the page omits the disclosure entirely (no empty 'Older nightlies' affordance).
-    assert "Older nightlies" not in gl._older_nightlies_html([only])
+    # …and the packages block omits the disclosure entirely (no empty 'Older nightlies' affordance).
+    assert "Older nightlies" not in gl._packages_html([only], None)
+
+
+def test_older_nightlies_fold_under_each_edition() -> None:
+    """Scenario: each edition's older nightlies fold UNDER that edition's own table.
+
+    Given retained older nightlies for BOTH a CE ABI and a Plus ABI,
+    When the packages block is rendered with a matrix covering both ABIs,
+    Then the CE older-nightlies disclosure sits inside the CE section (after the CE table,
+      before the Plus heading) carrying only CE rows, and the Plus one sits in the Plus
+      section carrying only Plus rows — CE section first.
+    """
+    ce_new = _pkg("nightly", "n", "3.2.16.20260614.9", "FreeBSD:15:amd64", "ce9.pkg")
+    ce_old = _pkg("nightly", "n", "3.2.16.20260601.1", "FreeBSD:15:amd64", "ce1.pkg")
+    plus_new = _pkg("nightly", "n", "3.2.16.20260614.9", "FreeBSD:16:aarch64", "p9.pkg")
+    plus_old = _pkg("nightly", "n", "3.2.16.20260601.1", "FreeBSD:16:aarch64", "p1.pkg")
+    matrix = [
+        _mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311"),
+        _mx("FreeBSD:16:aarch64", "26.03", "Plus", "8.5", "py311"),
+    ]
+
+    html = gl._packages_html([ce_new, ce_old, plus_new, plus_old], matrix)
+
+    # CE section before Plus section; each has its own folded older-nightlies disclosure.
+    assert html.index("<h3>pfSense CE</h3>") < html.index("<h3>pfSense Plus</h3>")
+    assert html.count("<summary>Older nightlies (1)</summary>") == 2  # one per edition (each ABI: 1 older)
+    # The CE section spans from its heading to the Plus heading; the Plus section follows.
+    ce_section = html[html.index("<h3>pfSense CE</h3>") : html.index("<h3>pfSense Plus</h3>")]
+    plus_section = html[html.index("<h3>pfSense Plus</h3>") :]
+    # Each edition's disclosure folds in its OWN ABI's older nightly, never the other's.
+    assert "Older nightlies (1)" in ce_section and "FreeBSD:15:amd64" in ce_section
+    assert "FreeBSD:16:aarch64" not in ce_section and ">2.8<" in ce_section and ">8.3<" in ce_section
+    assert "Older nightlies (1)" in plus_section and "FreeBSD:16:aarch64" in plus_section
+    assert "FreeBSD:15:amd64" not in plus_section and ">26.03<" in plus_section and ">8.5<" in plus_section
 
 
 def test_build_edition_sections_unmatched_abi_falls_to_other() -> None:


### PR DESCRIPTION
## What

Reorganize the landing page's retained **older nightlies** so each edition's old nightlies fold **directly under that edition's own table** — CE old nightlies under the **pfSense CE** table, Plus old nightlies under the **pfSense Plus** table — instead of one flat block at the bottom of "Published packages".

## How

- `_packages_html` now renders, per edition: `<h3>edition</h3>` → the edition table → a collapsed `<details>Older nightlies (n)</details>` carrying **only that edition's** retained nightlies (matrix-joined by ABI; same 8 columns minus Channel).
- New helpers `_older_nightlies_by_edition()` (group older nightlies by edition key) + `_older_nightlies_details()` (one edition's folded disclosure, "" when none).
- `render_page` no longer emits a separate bottom disclosure; edition-ordering stays factored in `_order_edition_keys()`.

## Tests

- `test_older_nightlies_lists_retained_excludes_latest` — now asserts via `_packages_html` that the disclosure folds **after** the edition table and excludes the current nightly.
- `test_older_nightlies_fold_under_each_edition` — mixed CE+Plus: each edition section carries its **own** folded disclosure with only its ABI's older nightly (CE section first).
- empty case unchanged in intent (no disclosure when nothing older).

`test_gen_landing.py` green (21). After merge I'll re-dispatch the `pkg` publish so the live page reflects it.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reworked the “Older nightlies” UI to show a collapsed “Older nightlies (N)” disclosure under each pfSense edition (CE, Plus, then others), rather than a single global section.
  * Edition sections now render in a deterministic order, with the disclosure placed directly beneath each edition’s main table.
* **Tests**
  * Updated existing tests to validate per-edition disclosure behavior (retained-only rows, no inclusion of the current nightly).
  * Added coverage to confirm older-nightlies content correctly folds under CE and Plus independently, preventing cross-edition leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->