### PR TITLE
test+ci: derive the repo-smoke variant topology from the version matrix

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -212,6 +212,22 @@ jobs:
           # Harmless for the default `smoke` marker (the helper just isn't called).
           sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils openssh-client python3 python3-pip python3-venv zstd
 
+      - name: Resolve the version matrix (SMOKE_MATRIX_JSON for the ADR-20 variant topology)
+        # The repo-smoke variant cases derive every ABI / PHP / Python / catalog from the
+        # ci-metadata version matrix (no hardcoded CE/Plus). Resolve it HERE — at job start,
+        # while egress is open — and export it. The test reads SMOKE_MATRIX_JSON; without it
+        # the test falls back to running this script itself, which needs network the pytest
+        # phase may not have. Best-effort: on failure the topology cases SKIP, never fail the
+        # whole smoke job. (read-version-matrix.sh self-fetches the ci-metadata orphan ref.)
+        run: |
+          set -u
+          if matrix="$(sh scripts/read-version-matrix.sh --print-build 2>/dev/null)" && [ -n "$matrix" ]; then
+            printf 'SMOKE_MATRIX_JSON=%s\n' "$matrix" >> "$GITHUB_ENV"
+            echo "Resolved $(printf '%s' "$matrix" | jq 'length') build-matrix entries for the smoke topology."
+          else
+            echo "::warning::could not resolve the version matrix — ADR-20 variant-topology cases will SKIP"
+          fi
+
       - name: Resolve the pfSense image ref (image_ref input overrides the SMOKE_IMAGE_* vars)
         id: ref
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -662,7 +662,15 @@ update badge stay Netgate-bound; a GUI "Updates/Channel" panel is deferred (woul
 - **Repo smoke flow:** `tests/smoke/test_repo_install.py` carries its **own marker `repo`**
   (a distribution flow, **deselected from `-m smoke`**) — install-from-our-repo (no `-f`),
   cross-repo precedence (both directions vs a `netgate-decoy`), `pkg upgrade` `_1`→`_9`, and
-  the catalog accepted from both generators. Dispatch:
+  the catalog accepted from both generators. The ADR-20 **variant topology** (each leg's ABI /
+  PHP / Python / catalog, and the opposite-edition guard) is **derived entirely from the version
+  matrix** — never hardcoded CE/Plus: `tests/smoke/_matrix.py` (unit-tested off-box by
+  `tests/test_smoke_matrix.py`) reads `SMOKE_MATRIX_JSON` (smoke.yml injects
+  `read-version-matrix.sh --print-build` at job start, while egress is open), falling back to
+  running that script, and SKIPs the topology cases when neither is available. Per-leg
+  `SMOKE_ABI`/`SMOKE_PHP_VERSION`/`SMOKE_PY_FLAVOR` still select within it; adding a pfSense
+  version needs no edit here. (`scripts/install-from-repo.sh` likewise derives its `py3xx-*`
+  deps from the matrix via the box's ABI.) Dispatch:
   `gh workflow run smoke.yml -f pytest_marker=repo` (or `repo-install.yml` once it lands on
   `devel`). The gated `test_install_from_live_pages_url` (`SMOKE_REPO_LIVE_URL`) hits the
   real `pfblockerng.github.io` URL — post-merge (a new `workflow_dispatch` workflow is only

--- a/scripts/install-from-repo.sh
+++ b/scripts/install-from-repo.sh
@@ -78,6 +78,25 @@ if ! ssh_t 'command -v rsync >/dev/null 2>&1'; then
         || { echo "Error: failed to install rsync on $SSH_TARGET" >&2; exit 1; }
 fi
 
+# The Python flavor for the py3xx-* RUN_DEPENDS is DERIVED FROM THE VERSION MATRIX (no
+# hardcoded py311): match the box's ABI (FreeBSD:major:arch) to its matrix entry's py_flavor.
+# Fallbacks keep the installer working when the matrix/jq is unavailable: the box's OWN
+# installed py3xx flavor, then py311. (read-version-matrix.sh self-fetches the ci-metadata ref.)
+PY_FLAVOR=""
+BOX_ABI="$(ssh_t 'pkg config ABI 2>/dev/null' | tr -d '\r')"
+if [ -n "$BOX_ABI" ] && command -v jq >/dev/null 2>&1; then
+    PY_FLAVOR="$(sh "${REPO_ROOT}/scripts/read-version-matrix.sh" --print-build 2>/dev/null \
+        | jq -r --arg abi "$BOX_ABI" \
+            '[ .[] | select("FreeBSD:\(.freebsd_major):\(.arch // "amd64")" == $abi) ][0].py_flavor // empty' \
+        2>/dev/null || true)"
+fi
+if [ -z "$PY_FLAVOR" ]; then
+    # The box knows its own python: the py3xx that owns its py-sqlite3, if already present.
+    PY_FLAVOR="$(ssh_t "pkg query %n 2>/dev/null | grep -E '^py3[0-9]+-sqlite3\$' | sed 's/-sqlite3//' | head -1" | tr -d '\r' || true)"
+fi
+[ -n "$PY_FLAVOR" ] || PY_FLAVOR="py311"
+echo "==> Python dep flavor for ${BOX_ABI:-unknown ABI}: ${PY_FLAVOR}"
+
 # 0b) Install the package's other RUN_DEPENDS — what `pkg install
 #     pfSense-pkg-pfBlockerNG[-devel]` pulls per the port Makefile — so the
 #     installed package is actually functional (jq/grepcidr/iprange for the IP
@@ -85,7 +104,7 @@ fi
 #     lighttpd for the sinkhole webserver; rsync is handled in 0a). Best-effort:
 #     a renamed/absent dep shouldn't block the smoke install, so warn not abort.
 echo "==> Installing pfBlockerNG runtime dependencies (mirrors port RUN_DEPENDS)"
-ssh_t 'env ASSUME_ALWAYS_YES=yes pkg install -y libmaxminddb gnugrep grepcidr iprange jq lighttpd py311-sqlite3 py311-maxminddb' \
+ssh_t "env ASSUME_ALWAYS_YES=yes pkg install -y libmaxminddb gnugrep grepcidr iprange jq lighttpd ${PY_FLAVOR}-sqlite3 ${PY_FLAVOR}-maxminddb" \
     || echo "WARN: some pfBlockerNG runtime deps failed to install (continuing)" >&2
 
 # 1) Sync the package files. src/ mirrors the filesystem root, so src/usr/local/

--- a/tests/smoke/_matrix.py
+++ b/tests/smoke/_matrix.py
@@ -1,0 +1,159 @@
+"""Per-leg variant topology for the ADR-20 repo smoke — DERIVED FROM THE VERSION MATRIX.
+
+Every ABI / PHP / Python / catalog fact comes from the ci-metadata version matrix, never a
+literal. The whole BUILD matrix is read from ``SMOKE_MATRIX_JSON`` (injected by smoke.yml from
+``read-version-matrix.sh --print-build``); a local run falls back to running that script itself;
+when neither is available the variant-topology cases SKIP. Per-leg selection still honours
+``SMOKE_ABI`` / ``SMOKE_PHP_VERSION`` / ``SMOKE_PY_FLAVOR`` (the fan-out exports them per matrix
+entry); a bare dispatch defaults to the matrix's CE entry. So adding a pfSense version to the
+matrix needs no edit here.
+
+Kept in its own stdlib-only module (no intra-package smoke imports) so the derivation is
+unit-testable off-box — see ``tests/test_smoke_matrix.py``.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+# tests/smoke/_matrix.py -> repo root, for the read-version-matrix.sh fallback.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class Variant:
+    """A distributed pfSense variant, derived from a matrix entry: its pkg ``php`` dependency,
+    ABI, catalog dir, ``py`` flavor, and edition (``variant``)."""
+
+    php: str
+    abi: str
+    catalog: str
+    py: str
+    variant: str
+
+
+def catalog_name(pfsense_version: str, variant: str) -> str:
+    """``("2.8.1", "CE") -> "ce-2.8"`` / ``("26.03.1", "Plus") -> "plus-26.03"`` — the
+    variant-keyed catalog dir (variant + the pfSense major.minor; mirrors
+    build-repo-portable.py:catalog_name_from_version)."""
+    parts = [p for p in str(pfsense_version).split(".") if p != ""]
+    return f"{variant.lower()}-{'.'.join(parts[:2])}"
+
+
+@functools.lru_cache(maxsize=1)
+def build_matrix() -> tuple[dict, ...] | None:
+    """The whole BUILD matrix (every CE+Plus entry), or None when unavailable.
+
+    Prefers ``SMOKE_MATRIX_JSON`` (smoke.yml injects ``read-version-matrix.sh --print-build``);
+    falls back to running that script on the runner; None when neither yields a non-empty JSON
+    array (the caller then SKIPs the topology cases)."""
+    raw = os.environ.get("SMOKE_MATRIX_JSON", "").strip()
+    if not raw:
+        script = _REPO_ROOT / "scripts" / "read-version-matrix.sh"
+        if script.is_file():
+            try:
+                proc = subprocess.run(
+                    ["sh", str(script), "--print-build"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30.0,
+                    check=False,
+                )
+                if proc.returncode == 0:
+                    raw = proc.stdout.strip()
+            except (OSError, subprocess.SubprocessError):
+                raw = ""
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return tuple(data) if isinstance(data, list) and data else None
+
+
+def matrix_variants() -> list[Variant]:
+    """One Variant per distinct (ABI, edition) build target in the matrix. SKIPs when the matrix
+    is unavailable, so the topology cases never silently pass on hardcoded values."""
+    entries = build_matrix()
+    if entries is None:
+        pytest.skip(
+            "version matrix unavailable (set SMOKE_MATRIX_JSON, or make the ci-metadata ref "
+            "readable by scripts/read-version-matrix.sh) — cannot derive the variant topology"
+        )
+    out: dict[tuple[str, str], Variant] = {}
+    for e in entries:
+        major = str(e.get("freebsd_major", "")).strip()
+        arch = str(e.get("arch", "")).strip() or "amd64"
+        abi = f"FreeBSD:{major}:{arch}"
+        variant = str(e.get("variant", "")).strip()
+        out.setdefault(
+            (abi, variant),
+            Variant(
+                php="php" + str(e.get("php_version", "")).replace(".", ""),
+                abi=abi,
+                catalog=catalog_name(str(e.get("pfsense_version", "")), variant),
+                py=str(e.get("py_flavor", "")).strip(),
+                variant=variant,
+            ),
+        )
+    return list(out.values())
+
+
+def _own_entry() -> Variant:
+    """This leg's variant: matched by SMOKE_ABI, else the matrix CE entry (bare dispatch)."""
+    variants = matrix_variants()
+    abi = os.environ.get("SMOKE_ABI")
+    if not abi:
+        ce = [v for v in variants if v.variant.lower() == "ce"]
+        abi = (ce[0] if ce else variants[0]).abi
+    matches = [v for v in variants if v.abi == abi]
+    if not matches:
+        raise RuntimeError(f"no matrix variant for ABI {abi!r} (known: {sorted(v.abi for v in variants)})")
+    return matches[0]
+
+
+def matrix_php_dep() -> str:
+    """This leg's pkg PHP dep name (``php83``/``php85``) — SMOKE_PHP_VERSION when set, else the
+    matrix entry's php_version."""
+    ver = os.environ.get("SMOKE_PHP_VERSION")
+    return "php" + ver.replace(".", "") if ver else _own_entry().php
+
+
+def matrix_abi() -> str:
+    """This leg's target ABI — SMOKE_ABI when set, else the matrix entry's ABI."""
+    return os.environ.get("SMOKE_ABI") or _own_entry().abi
+
+
+def matrix_py_flavor() -> str:
+    """This leg's Python flavor (``py311``) — SMOKE_PY_FLAVOR when set, else the matrix entry's."""
+    return os.environ.get("SMOKE_PY_FLAVOR") or _own_entry().py
+
+
+def own_variant() -> Variant:
+    """The variant THIS leg runs (matrix-derived). When SMOKE_PHP_VERSION is also set it must
+    agree with the matrix entry's php dep — a mismatch is a CI-wiring bug, not a silent pass."""
+    own = _own_entry()
+    env_php = os.environ.get("SMOKE_PHP_VERSION")
+    if env_php:
+        assert own.php == "php" + env_php.replace(".", ""), (
+            f"matrix inconsistency: ABI {own.abi} maps to {own.php} but SMOKE_PHP_VERSION={env_php}"
+        )
+    return own
+
+
+def opposite_variant() -> Variant:
+    """The OTHER edition — the 'wrong' variant for this box (the forged package the wrong-variant
+    guard must reject): the first matrix variant of a different edition."""
+    own = own_variant()
+    others = [v for v in matrix_variants() if v.variant.lower() != own.variant.lower()]
+    if not others:
+        pytest.skip(f"matrix has no opposite-edition variant to {own.variant!r} — skipping the wrong-variant guard")
+    return others[0]

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -83,12 +83,17 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Iterator
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
 from . import helpers as h
+from ._matrix import (
+    matrix_abi,
+    matrix_py_flavor,
+    opposite_variant,
+    own_variant,
+)
 from .conftest import SmokeVM
 
 pytestmark = pytest.mark.repo
@@ -158,10 +163,6 @@ DEFAULT_LIVE_BASE_URL = "https://pfblockerng.github.io/pkg"
 # CDN-propagated, which a PR/dispatch can't guarantee — so it is opt-in post-deploy
 # verification, not a hard CI gate (it would red the suite on a deploy/propagation race).
 WORKER_LIVE_ENV = "SMOKE_WORKER_LIVE"
-# The ABI of the repo-smoke guest (the live Pages-URL check, poll_catalog_served, runs on
-# the CE 2.8 box). NOT the only supported ABI — the build matrix now spans CE FreeBSD:15:amd64
-# plus Plus FreeBSD:16:amd64 / FreeBSD:16:aarch64 (see the routing.json catalogs).
-GUEST_ABI = "FreeBSD:15:amd64"
 # GitHub Pages' anycast IPs. The smoke harness sandboxes guest DNS to a mock that
 # only answers `uuid-*.com`, so `pfblockerng.github.io` does not resolve on the guest. Pinning
 # the Pages IPs in the guest /etc/hosts lets `pkg`'s HTTPS fetch reach Pages by name
@@ -1209,8 +1210,9 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     assert host, f"could not parse a host from {base_url!r}"
 
     # BACKSTOP: prove the deploy actually serves the catalog from the RUNNER first
-    # (independent of the guest) — polls through first-deploy / DNS / cert lag.
-    poll_catalog_served(base_url, GUEST_ABI)
+    # (independent of the guest) — polls through first-deploy / DNS / cert lag. The ABI to
+    # poll is this leg's own, derived from the matrix (the CE box for the live-pages check).
+    poll_catalog_served(base_url, matrix_abi())
 
     # GIVEN: Pages IPs pinned (guest DNS is sandboxed), package absent, our conf at
     # the LIVE url above pfSense.
@@ -1241,96 +1243,12 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
 #     gh workflow run smoke.yml -f pytest_marker=repo                          #
 # =========================================================================== #
 
-# CE smoke image uses FreeBSD 15; Plus uses FreeBSD 16.
-CE_ABI = "FreeBSD:15:amd64"
-PLUS_ABI = "FreeBSD:16:amd64"
-
-# Catalog names for the variant-keyed subtrees (ADR-20 §2 decision).
-CE_CATALOG_NAME = "ce-2.8"
-PLUS_CATALOG_NAME = "plus-26.03"
-
 # Base dir for ADR-20 variant catalogs on the guest (isolated from the ADR-17 spike dir).
 VARIANT_REPO_ROOT = "/tmp/pfb_variant_repo"
-CE_REPO_DIR = f"{VARIANT_REPO_ROOT}/{CE_CATALOG_NAME}"
-PLUS_REPO_DIR = f"{VARIANT_REPO_ROOT}/{PLUS_CATALOG_NAME}"
-LEGACY_REPO_DIR = f"{VARIANT_REPO_ROOT}/legacy"
 
 
-# --------------------------------------------------------------------------- #
-# Per-leg variant — derived from the ci-metadata matrix (surfaced by smoke.yml) #
-# --------------------------------------------------------------------------- #
-#
-# The fan-out (smoke-fanout.yml / repo-install.yml) passes each leg's build target
-# — ABI / PHP / Python flavor — straight from the ci-metadata matrix into smoke.yml,
-# which exports them as SMOKE_ABI / SMOKE_PHP_VERSION / SMOKE_PY_FLAVOR. The ADR-20
-# variant cases assert the box's OWN php dep / ABI against THESE (matrix = single
-# source of truth) instead of hardcoding php83 / FreeBSD:15 — so the CE leg asserts
-# php83 / FreeBSD:15 and the Plus leg asserts php85 / FreeBSD:16, automatically. A
-# bare smoke.yml dispatch (no inputs) defaults to the CE values, keeping the
-# single-CE run byte-identical.
-
-
-@dataclass(frozen=True)
-class Variant:
-    """A distributed pfSense variant: its pkg ``php`` dependency, ABI, and catalog dir."""
-
-    php: str
-    abi: str
-    catalog: str
-
-
-# The two variants ADR-20 distributes, keyed by ABI (the binary CE<->Plus topology
-# the wrong-variant guard flips between): own_variant() picks THIS leg's entry from
-# the matrix; opposite_variant() returns the other for the guard's forged package.
-_VARIANTS = (
-    Variant(php="php83", abi=CE_ABI, catalog=CE_CATALOG_NAME),
-    Variant(php="php85", abi=PLUS_ABI, catalog=PLUS_CATALOG_NAME),
-)
-
-
-def matrix_php_dep() -> str:
-    """The pkg PHP dependency name for THIS leg from the matrix ``php_version``
-    (``SMOKE_PHP_VERSION``, e.g. ``8.3`` -> ``php83`` / ``8.5`` -> ``php85``).
-    Defaults to the CE flavor when unset (a bare smoke.yml dispatch)."""
-    ver = os.environ.get("SMOKE_PHP_VERSION") or "8.3"
-    return "php" + ver.replace(".", "")
-
-
-def matrix_abi() -> str:
-    """This leg's target ABI from the matrix (``SMOKE_ABI``); CE default when unset."""
-    return os.environ.get("SMOKE_ABI") or CE_ABI
-
-
-def matrix_py_flavor() -> str:
-    """This leg's Python flavor from the matrix (``SMOKE_PY_FLAVOR``, e.g. ``py311``);
-    CE default when unset."""
-    return os.environ.get("SMOKE_PY_FLAVOR") or "py311"
-
-
-def own_variant() -> Variant:
-    """The variant THIS leg runs, matched from the matrix ABI. Asserts the matrix
-    ``php_version`` agrees with the variant's php dep — the two matrix fields must be
-    consistent; a mismatch is a CI-wiring bug, not a silent pass."""
-    abi = matrix_abi()
-    for v in _VARIANTS:
-        if v.abi == abi:
-            assert v.php == matrix_php_dep(), (
-                f"matrix inconsistency: ABI {abi} maps to {v.php} but SMOKE_PHP_VERSION says {matrix_php_dep()}"
-            )
-            return v
-    raise RuntimeError(f"no known ADR-20 variant for matrix ABI {abi!r} (known: {[v.abi for v in _VARIANTS]})")
-
-
-def opposite_variant() -> Variant:
-    """The OTHER variant — the 'wrong' one for this box (the forged package the
-    wrong-variant guard must reject)."""
-    own = own_variant()
-    others = [v for v in _VARIANTS if v.abi != own.abi]
-    assert len(others) == 1, f"expected exactly one opposite variant, got {others}"
-    return others[0]
-
-
-# Routing Worker URL (Phase 5). routing.json is live on Pages, so Case 4 is a hard gate.
+# Routing Worker URL (Phase 5). The live Case 4 leg is gated on SMOKE_WORKER_LIVE (the
+# deterministic routing proof is the offline scripts/worker/test/ suite).
 WORKER_BASE_URL = "https://pkg.pfblockerng.workers.dev"
 
 

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -1,0 +1,130 @@
+"""Unit tests for tests/smoke/_matrix.py — the matrix-derived variant topology used by the
+ADR-20 repo smoke. Loaded by path (like test_gen_landing) so no live-VM / conftest baggage.
+
+These pin that ALL ABI/PHP/Python/catalog facts come from the version matrix (never a literal):
+the JSON source of truth, the per-(ABI, edition) variant derivation, own/opposite selection,
+and the env overrides — so adding a pfSense version to the matrix needs no edit in the smoke test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Load tests/smoke/_matrix.py by path, REGISTERING it in sys.modules so its @dataclass resolves.
+_PATH = Path(__file__).resolve().parent / "smoke" / "_matrix.py"
+_SPEC = importlib.util.spec_from_file_location("smoke_matrix_under_test", _PATH)
+assert _SPEC and _SPEC.loader
+mx = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = mx
+_SPEC.loader.exec_module(mx)
+
+
+# A representative multi-edition, multi-arch matrix (CE amd64 + Plus amd64 + Plus aarch64).
+_MATRIX = (
+    '[{"pfsense_version":"2.8.0","freebsd_major":"15","arch":"amd64","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
+    '{"pfsense_version":"26.03.1","freebsd_major":"16","arch":"amd64","php_version":"8.5","py_flavor":"py311","variant":"Plus"},'
+    '{"pfsense_version":"26.03.1","freebsd_major":"16","arch":"aarch64","php_version":"8.5","py_flavor":"py311","variant":"Plus"}]'
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_matrix_cache() -> Any:
+    """build_matrix() is lru_cached; clear it around each case so env changes take effect."""
+    mx.build_matrix.cache_clear()
+    yield
+    mx.build_matrix.cache_clear()
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, **kv: str | None) -> None:
+    for k in ("SMOKE_MATRIX_JSON", "SMOKE_ABI", "SMOKE_PHP_VERSION", "SMOKE_PY_FLAVOR"):
+        monkeypatch.delenv(k, raising=False)
+    for k, v in kv.items():
+        if v is not None:
+            monkeypatch.setenv(k, v)
+
+
+def test_catalog_name_maps_version_and_variant() -> None:
+    """catalog_name = <edition>-<major.minor>, regardless of patch component."""
+    assert mx.catalog_name("2.8.0", "CE") == "ce-2.8"
+    assert mx.catalog_name("26.03.1", "Plus") == "plus-26.03"
+    assert mx.catalog_name("2.8", "CE") == "ce-2.8"  # two-component version
+
+
+def test_build_matrix_parses_env_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A well-formed SMOKE_MATRIX_JSON array is returned as a tuple of entries."""
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX)
+    m = mx.build_matrix()
+    assert m is not None and len(m) == 3 and m[0]["variant"] == "CE"
+
+
+def test_build_matrix_none_on_malformed_or_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed JSON / a non-array / an empty array -> None (caller SKIPs, never a bogus pass)."""
+    for bad in ("not json", '{"not":"an array"}', "[]"):
+        mx.build_matrix.cache_clear()
+        _set_env(monkeypatch, SMOKE_MATRIX_JSON=bad)
+        assert mx.build_matrix() is None
+
+
+def test_variants_derived_per_abi_edition(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One Variant per (ABI, edition), php/catalog/py derived from the matrix entry."""
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX)
+    by_abi = {v.abi: v for v in mx.matrix_variants()}
+    assert set(by_abi) == {"FreeBSD:15:amd64", "FreeBSD:16:amd64", "FreeBSD:16:aarch64"}
+    assert by_abi["FreeBSD:15:amd64"] == mx.Variant("php83", "FreeBSD:15:amd64", "ce-2.8", "py311", "CE")
+    assert by_abi["FreeBSD:16:aarch64"].php == "php85" and by_abi["FreeBSD:16:aarch64"].catalog == "plus-26.03"
+
+
+def test_own_and_opposite_follow_smoke_abi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """own = the SMOKE_ABI entry; opposite = the first entry of a DIFFERENT edition.
+
+    Before/after: the CE leg's own is CE / opposite is Plus; flipping SMOKE_ABI to the Plus
+    box swaps both — proving the selection tracks the matrix, not a hardcoded side.
+    """
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX, SMOKE_ABI="FreeBSD:15:amd64", SMOKE_PHP_VERSION="8.3")
+    assert mx.own_variant().variant == "CE" and mx.own_variant().abi == "FreeBSD:15:amd64"
+    assert mx.opposite_variant().variant == "Plus"  # a different edition
+
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX, SMOKE_ABI="FreeBSD:16:amd64", SMOKE_PHP_VERSION="8.5")
+    assert mx.own_variant().variant == "Plus" and mx.own_variant().abi == "FreeBSD:16:amd64"
+    assert mx.opposite_variant().variant == "CE"
+
+
+def test_bare_dispatch_defaults_to_ce_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no SMOKE_ABI, own defaults to the matrix's CE entry (the bare-dispatch default)."""
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX)
+    assert mx.own_variant().variant == "CE" and mx.matrix_abi() == "FreeBSD:15:amd64"
+    assert mx.matrix_py_flavor() == "py311"
+
+
+def test_env_overrides_win_over_matrix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SMOKE_* env values override the derived matrix defaults (the per-leg injection)."""
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX, SMOKE_ABI="FreeBSD:16:aarch64", SMOKE_PY_FLAVOR="py312")
+    assert mx.matrix_abi() == "FreeBSD:16:aarch64"
+    assert mx.matrix_py_flavor() == "py312"  # env wins
+    assert mx.matrix_php_dep() == "php85"  # derived from the matched entry (no SMOKE_PHP_VERSION)
+
+
+def test_php_version_mismatch_is_a_wiring_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If SMOKE_PHP_VERSION disagrees with the matched entry's php, own_variant() FAILS loudly
+    (a CI-wiring bug), never silently passes."""
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX, SMOKE_ABI="FreeBSD:15:amd64", SMOKE_PHP_VERSION="8.5")
+    with pytest.raises(AssertionError, match="matrix inconsistency"):
+        mx.own_variant()
+
+
+def test_topology_skips_when_matrix_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No SMOKE_MATRIX_JSON and no readable matrix -> matrix_variants() SKIPs (not a bogus pass).
+
+    Point the fallback script lookup at a missing path so build_matrix() yields None.
+    """
+    _set_env(monkeypatch)  # clears SMOKE_MATRIX_JSON
+    monkeypatch.setattr(mx, "_REPO_ROOT", Path("/nonexistent-repo-root"))
+    mx.build_matrix.cache_clear()
+    assert mx.build_matrix() is None
+    with pytest.raises(pytest.skip.Exception):
+        mx.matrix_variants()


### PR DESCRIPTION
## Why

The ADR-20 repo smoke hardcoded the CE/Plus **topology** — `CE_ABI`/`PLUS_ABI`, the `ce-2.8`/`plus-26.03` catalog names, the `_VARIANTS` map, `GUEST_ABI`, and the CE fallback literals — so every new pfSense version meant editing test constants. This derives **all ABI / PHP / Python / catalog facts from the ci-metadata version matrix** (the single source of truth), per the request that nothing be hardcoded.

## Changes

- **`tests/smoke/_matrix.py`** (new, stdlib-only): reads the whole BUILD matrix from `SMOKE_MATRIX_JSON`, falls back to running `read-version-matrix.sh --print-build`, and **SKIPs** the topology cases when neither is available (never a bogus pass). Derives one `Variant` per `(ABI, edition)`; `own`/`opposite` selection honours `SMOKE_ABI`/`SMOKE_PHP_VERSION`/`SMOKE_PY_FLAVOR` (a bare dispatch defaults to the matrix's CE entry). Kept separate so it's unit-testable off-box.
- **`tests/smoke/test_repo_install.py`**: import the helpers from `_matrix`; remove the hardcoded constants + dead `CE_REPO_DIR`/`PLUS_REPO_DIR`/`LEGACY_REPO_DIR`; poll the live catalog by the matrix-derived ABI (was `GUEST_ABI`). ~95 fewer lines.
- **`tests/test_smoke_matrix.py`** (new): off-box unit coverage — catalog naming, JSON parse + fail-closed (malformed/empty → None), per-`(ABI, edition)` derivation, `own`/`opposite` tracking `SMOKE_ABI` (before/after flip), bare-dispatch CE default, env overrides, the php-version **mismatch → wiring error**, and the **matrix-absent → SKIP** branch.
- **`smoke.yml`**: resolve + inject `SMOKE_MATRIX_JSON` at job start (while egress is open; the pytest phase may have restricted network), best-effort.
- **`scripts/install-from-repo.sh`**: derive the `py3xx-*` RUN_DEPENDS flavor from the matrix via the box's ABI (fallbacks: the box's own installed flavor, then `py311`).
- `install_deps_CE_2.8.sh` is intentionally **left as-is** — a per-version image-bake helper, version-pinned by its filename.

## Tests

`tests/test_smoke_matrix.py` 9/9; full unit suite green (1645); mypy clean; shellcheck/sh -n/url-encoding/markdownlint pass. The live variant cases run on the smoke fan-out (CE + Plus), now matrix-keyed.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added matrix-based configuration resolution for smoke tests with graceful fallback behavior.
  * Implemented dynamic Python dependency selection based on system ABI instead of hardcoded defaults.

* **Documentation**
  * Clarified how variant topology is derived from the version matrix.

* **Tests**
  * Added comprehensive smoke test matrix infrastructure and validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->