### PR TITLE
dev: replace catalog-trees list with a folder-navigable browse page

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -198,8 +198,8 @@ def latest_versions(pkgs: Iterable[dict]) -> dict[str, str]:
 def build_table(pkgs: list[dict]) -> list[dict]:
     """The table rows: the newest version's package per (channel, ABI), display-sorted.
 
-    Older nightly builds stay reachable via the catalog-tree links — the table
-    surfaces only what a human would install right now.
+    Older builds stay reachable via the directory-browse page — the table surfaces
+    only what a human would install right now.
     """
     latest = latest_versions(pkgs)
     rows = [p for p in pkgs if p["version"] == latest.get(p["channel"])]

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -207,11 +207,6 @@ def build_table(pkgs: list[dict]) -> list[dict]:
     return rows
 
 
-def catalog_dirs(site: str) -> list[str]:
-    """Relative paths of dirs holding a real package (a catalog tree)."""
-    return sorted(os.path.relpath(d, site) for d, _x, files in os.walk(site) if any(is_package_file(f) for f in files))
-
-
 def _esc(s: object) -> str:
     return html.escape(str(s))
 
@@ -244,9 +239,9 @@ td.num{font-variant-numeric:tabular-nums;color:var(--mut)}
 .badge{display:inline-block;font-size:.72rem;padding:.05rem .45rem;border-radius:20px;
   border:1px solid var(--bd);color:var(--mut)}
 details summary{cursor:pointer;color:var(--mut);font-size:.85rem;margin-top:.5rem}
-ul.trees{display:grid;grid-template-columns:repeat(auto-fill,minmax(15rem,1fr));
-  gap:.15rem 1rem;list-style:none;padding:0;margin:0}
-ul.trees li{margin:.15rem 0;overflow-wrap:anywhere}
+a.browse{display:inline-block;padding:.5rem .9rem;border:1px solid var(--acc);border-radius:8px;font-weight:600}
+table.autoindex td:first-child{white-space:normal;overflow-wrap:anywhere}
+table.autoindex td.num{white-space:nowrap}
 footer{margin-top:3rem;color:var(--mut);font-size:.85rem;border-top:1px solid var(--bd);padding-top:1rem}
 .empty{color:var(--mut);font-style:italic}
 .card ul.pkgs{margin:.3rem 0 .7rem;padding-left:0;list-style:none}
@@ -480,14 +475,12 @@ def _older_nightlies_details(rows: list[dict]) -> str:
 def render_page(
     base: str,
     pkgs: list[dict],
-    trees: list[str],
     conf_fn: Callable[[str], str],
     matrix: list[dict] | None = None,
 ) -> str:
     """Render the root landing page."""
     latest = latest_versions(pkgs)
     cards = _release_card(base, latest, conf_fn) + _nightly_card(base, latest, conf_fn)
-    tree_items = "".join(f'<li><a href="./{_esc(d)}/">{_esc(d)}</a></li>' for d in trees)
     return (
         '<!doctype html><html lang="en"><head><meta charset="utf-8">'
         '<meta name="viewport" content="width=device-width, initial-scale=1">'
@@ -501,10 +494,10 @@ def render_page(
         "separate, opt-in repo.</p>"
         f'<h2>Channels</h2><div class="cards">{cards}</div>'
         f"<h2>Published packages</h2>{_packages_html(pkgs, matrix)}"
-        "<h2>Catalog trees</h2>"
-        '<p class="blurb">The raw pkg(8) catalogs (what your firewall fetches). <code>${ABI}</code> is filled '
-        "in by pkg automatically, e.g. <code>FreeBSD:16:aarch64</code> on a Netgate ARM box.</p>"
-        f'<ul class="trees">{tree_items}</ul>'
+        "<h2>Repository files</h2>"
+        '<p class="blurb">Browse every channel, version and ABI &mdash; and the raw pkg(8) catalogs your '
+        "firewall fetches &mdash; in a directory-style listing.</p>"
+        '<p><a class="browse" href="./browse.html">&#128193; Browse the repository &rarr;</a></p>'
         '<footer><a href="https://github.com/pfBlockerNG/pfBlockerNG">Source</a> &middot; '
         '<a href="https://github.com/pfBlockerNG/pfBlockerNG/releases">Releases</a> &middot; '
         '<a href="https://github.com/pfBlockerNG/pkg">This repository</a></footer>'
@@ -512,20 +505,74 @@ def render_page(
     )
 
 
-def render_dir_index(rel: str, files: Iterable[str]) -> str:
-    """Render a per-catalog-dir index listing only the real package file(s)."""
-    items = sorted(f for f in files if is_package_file(f))
-    li = "".join(f'<li><a href="{_esc(f)}">{_esc(f)}</a></li>' for f in items)
-    back = "../" * (rel.count("/") + 1)
+def all_dirs(site: str) -> list[str]:
+    """Every directory under ``site`` (relative path, "/"-separated), excluding the site root,
+    sorted. Used to emit a browsable autoindex at EVERY level (GitHub Pages has no autoindex)."""
+    out = [os.path.relpath(d, site) for d, _x, _f in os.walk(site) if os.path.relpath(d, site) != "."]
+    return sorted(out)
+
+
+# Generated HTML + Pages plumbing that an autoindex listing hides (it is not repository content).
+_INDEX_HIDDEN = frozenset({"index.html", "browse.html", ".nojekyll"})
+
+
+def _dir_entries(site: str, rel: str) -> tuple[list[str], list[tuple[str, int, float]]]:
+    """The immediate children of ``site/rel``: (subdir names, file (name, size, mtime) tuples),
+    each sorted, with the generated index pages + Pages plumbing hidden."""
+    d = os.path.join(site, rel) if rel else site
+    subdirs: list[str] = []
+    files: list[tuple[str, int, float]] = []
+    for name in sorted(os.listdir(d)):
+        if name in _INDEX_HIDDEN:
+            continue
+        p = os.path.join(d, name)
+        if os.path.isdir(p):
+            subdirs.append(name)
+        else:
+            st = os.stat(p)
+            files.append((name, st.st_size, st.st_mtime))
+    return subdirs, files
+
+
+def render_autoindex(
+    rel: str, subdirs: list[str], files: list[tuple[str, int, float]], *, is_root: bool = False
+) -> str:
+    """A FreeBSD/Debian-style directory listing for ``rel`` (the browse root when ``is_root``).
+
+    Subdirs link to ``./<name>/`` and files to ``./<name>`` (the ``./`` prefix keeps a colon-bearing
+    ABI segment like ``FreeBSD:15:amd64`` a relative path, not a URI scheme — RFC 3986 §4.2). A
+    "Parent Directory" row (``../``) is shown except at the browse root."""
+    title = f"/{rel}" if rel else "/"
+    rows = []
+    if not is_root:
+        rows.append(
+            '<tr><td><a href="../">../</a></td><td class="num">&mdash;</td><td class="num">Parent Directory</td></tr>'
+        )
+    for name in subdirs:
+        rows.append(
+            f'<tr><td><a href="./{_esc(name)}/">{_esc(name)}/</a></td>'
+            '<td class="num">&mdash;</td><td class="num">&mdash;</td></tr>'
+        )
+    for name, size, mtime in files:
+        rows.append(
+            f'<tr><td><a href="./{_esc(name)}">{_esc(name)}</a></td>'
+            f'<td class="num">{_esc(artifact_datetime(mtime))}</td>'
+            f'<td class="num">{_esc(human_size(size))}</td></tr>'
+        )
+    # "repository home" climbs to the site root (which serves the human landing page).
+    home = "./" if is_root else "../" * (rel.count("/") + 1)
     return (
         '<!doctype html><html lang="en"><head><meta charset="utf-8">'
         '<meta name="viewport" content="width=device-width, initial-scale=1">'
-        f"<title>pfBlockerNG pkg — {_esc(rel)}</title><style>{_CSS}</style></head>"
-        f'<body><div class="wrap"><header><h1>{_esc(rel)}</h1>'
-        f'<p><a href="{_esc(back)}">&larr; back to the repository</a></p></header>'
-        f"<ul>{li}</ul>"
-        "<footer>pkg(8) catalog metadata (<code>meta.conf</code>, <code>packagesite.pkg</code>, …) "
-        "is served from this directory too.</footer></div></body></html>\n"
+        f"<title>pfBlockerNG pkg — Index of {_esc(title)}</title><style>{_CSS}</style></head>"
+        f'<body><div class="wrap"><header><h1>Index of {_esc(title)}</h1>'
+        f'<p><a href="{_esc(home)}">&larr; pfBlockerNG repository home</a></p></header>'
+        '<div class="tablewrap"><table class="autoindex"><thead><tr>'
+        "<th>Name</th><th>Last modified</th><th>Size</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
+        "<footer>Directory listing of the self-hosted pfBlockerNG pkg repository. "
+        "pkg(8) fetches the catalog files (<code>meta.conf</code>, <code>packagesite.pkg</code>, …) directly.</footer>"
+        "</div></body></html>\n"
     )
 
 
@@ -543,20 +590,27 @@ def _conf_via_addrepo(addrepo: str, base: str, channel: str) -> str:
 
 
 def write_site(site: str, base: str, addrepo: str, matrix: list[dict] | None = None) -> int:
-    """Generate index.html at the root and in every catalog dir. Returns package count."""
+    """Generate the human landing page (root index.html), a browsable autoindex at EVERY
+    directory level (so the whole tree is folder-navigable on GitHub Pages, which has no
+    autoindex), and a root ``browse.html`` entry point the landing page links to. Returns the
+    package count."""
     base = base.rstrip("/")
     pkgs = collect_packages(site)
-    trees = catalog_dirs(site)
 
     def conf_fn(channel: str) -> str:
         return _conf_via_addrepo(addrepo, base, channel)
 
+    # The human landing page stays the site root; browse.html is the directory-style entry.
     with open(os.path.join(site, "index.html"), "w") as fh:
-        fh.write(render_page(base, pkgs, trees, conf_fn, matrix))
-    for rel in trees:
-        d = os.path.join(site, rel)
-        with open(os.path.join(d, "index.html"), "w") as fh:
-            fh.write(render_dir_index(rel, os.listdir(d)))
+        fh.write(render_page(base, pkgs, conf_fn, matrix))
+    root_subdirs, root_files = _dir_entries(site, "")
+    with open(os.path.join(site, "browse.html"), "w") as fh:
+        fh.write(render_autoindex("", root_subdirs, root_files, is_root=True))
+    # An autoindex index.html in every directory (intermediate + leaf), so each level is browsable.
+    for rel in all_dirs(site):
+        subdirs, files = _dir_entries(site, rel)
+        with open(os.path.join(site, rel, "index.html"), "w") as fh:
+            fh.write(render_autoindex(rel, subdirs, files))
     return len(pkgs)
 
 
@@ -577,7 +631,7 @@ def main(argv: list[str] | None = None) -> int:
         with open(args.matrix) as fh:
             matrix = json.load(fh)
     n = write_site(args.site, args.base_url, args.add_repo, matrix)
-    print(f"landing page + {len(catalog_dirs(args.site))} dir index(es) written; {n} package(s) indexed")
+    print(f"landing page + browse.html + {len(all_dirs(args.site))} dir index(es) written; {n} package(s) indexed")
     return 0
 
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -382,7 +382,7 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
         _mx("FreeBSD:16:aarch64", "26.03", "Plus", "8.5", "py311"),
     ]
     base = "https://pfblockerng.github.io/pkg"
-    page = gl.render_page(base, pkgs, ["FreeBSD:16:aarch64", "nightly/FreeBSD:16:aarch64"], _stub_conf, matrix)
+    page = gl.render_page(base, pkgs, _stub_conf, matrix)
 
     # Latest versions surfaced for the present channels.
     assert "3.2.16.20260614.9" in page
@@ -428,46 +428,74 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
     assert "--warn:#d29922" in page
     assert ".card.release{border-color:var(--acc)}" in page
     assert ".card.nightly{border-color:var(--warn)}" in page
-    # Catalog-tree link to the colon-ABI dir is './'-prefixed (browser scheme guard).
-    assert 'href="./FreeBSD:16:aarch64/"' in page
-    # The catalog-tree list is a responsive auto-fill grid (column count follows the
-    # viewport — one column on a phone), not a fixed 2-column layout that hugs the edge.
-    assert "ul.trees{display:grid;grid-template-columns:repeat(auto-fill" in page
+    # The catalog-trees list is replaced by a SINGLE link to the folder-navigable browse page.
+    assert '<a class="browse" href="./browse.html">' in page
+    assert "Browse the repository" in page
+    # The old flat tree list is gone (no per-leaf-dir <ul> on the landing page).
+    assert "ul.trees" not in page
+    assert 'href="./FreeBSD:16:aarch64/"' not in page
 
 
 def test_render_page_table_empty_when_no_packages() -> None:
-    page = gl.render_page("https://x/pkg", [], [], _stub_conf)
+    page = gl.render_page("https://x/pkg", [], _stub_conf)
     assert "No packages published yet." in page
+    assert '<a class="browse" href="./browse.html">' in page  # browse link present even when empty
 
 
-def test_render_dir_index_lists_package_hides_plumbing() -> None:
-    """A per-dir index links the package(s) but not meta.conf/packagesite.pkg/data.pkg."""
-    files = ["pfSense-pkg-pfBlockerNG-nightly-3.2.16.20260614.9.pkg", "packagesite.pkg", "data.pkg", "meta.conf"]
-    out = gl.render_dir_index("nightly/FreeBSD:16:aarch64", files)
-    assert 'href="pfSense-pkg-pfBlockerNG-nightly-3.2.16.20260614.9.pkg"' in out
-    assert "packagesite.pkg</a>" not in out
-    assert 'href="data.pkg"' not in out
-    assert 'href="meta.conf"' not in out
-    # Two path segments deep -> back link climbs two levels.
-    assert 'href="../../"' in out
+def test_render_autoindex_lists_dirs_files_and_parent() -> None:
+    """A non-root autoindex shows a Parent Directory row, subdirs (name/), and files (name+size),
+    with './'-prefixed hrefs so a colon-bearing ABI segment stays a relative path."""
+    out = gl.render_autoindex(
+        "release/ce-2.8",
+        ["amd64"],
+        [("notes.txt", 12, 1_700_000_000.0)],
+    )
+    assert "Index of /release/ce-2.8" in out
+    assert '<a href="../">../</a>' in out  # Parent Directory row
+    assert '<a href="./amd64/">amd64/</a>' in out  # subdir, trailing slash
+    assert '<a href="./notes.txt">notes.txt</a>' in out  # file
+    assert "12 B" in out  # size column rendered
 
 
-def test_write_site_end_to_end(tmp_path: Path, monkeypatch: Any) -> None:
-    """write_site emits a root index + one per catalog dir, package count returned."""
+def test_render_autoindex_root_has_no_parent_and_is_colon_safe() -> None:
+    """The browse root omits Parent Directory; an ABI dir with ':' links via './' (RFC 3986 §4.2)."""
+    out = gl.render_autoindex("", ["release", "nightly"], [("routing.json", 99, 1_700_000_000.0)], is_root=True)
+    assert "Index of /" in out
+    assert "Parent Directory" not in out and 'href="../"' not in out
+    assert '<a href="./release/">release/</a>' in out and '<a href="./nightly/">nightly/</a>' in out
+    # A colon-ABI subdir would link with the scheme-safe './' prefix.
+    deep = gl.render_autoindex("release", ["FreeBSD:16:aarch64"], [])
+    assert 'href="./FreeBSD:16:aarch64/"' in deep
+
+
+def test_write_site_emits_browse_and_autoindex_at_every_level(tmp_path: Path, monkeypatch: Any) -> None:
+    """write_site emits the landing page, browse.html, and an autoindex index.html at EVERY
+    directory level (intermediate dirs too) so the whole tree is folder-navigable."""
     site = tmp_path / "site"
-    _touch(site / "FreeBSD:16:amd64" / "pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg")
-    _touch(site / "FreeBSD:16:amd64" / "packagesite.pkg")
+    _touch(site / "release" / "ce-2.8" / "FreeBSD:15:amd64" / "pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg")
+    _touch(site / "release" / "ce-2.8" / "FreeBSD:15:amd64" / "packagesite.pkg")
+    _touch(site / "routing.json")
 
-    manifest = {"name": "pfSense-pkg-pfBlockerNG-devel", "version": "3.2.16", "abi": "FreeBSD:16:amd64"}
+    manifest = {"name": "pfSense-pkg-pfBlockerNG-devel", "version": "3.2.16", "abi": "FreeBSD:15:amd64"}
     monkeypatch.setattr(gl, "read_manifest_zstd", lambda p: manifest)
     monkeypatch.setattr(gl, "_conf_via_addrepo", lambda addrepo, base, ch: f"{ch}-conf")
 
     n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", "add-repo.sh")
 
     assert n == 1
+    # Landing page (root) links to the browse entry; browse.html exists and lists the top dirs.
     assert (site / "index.html").is_file()
-    assert (site / "FreeBSD:16:amd64" / "index.html").is_file()
-    # The dir index links the package, not the catalog plumbing.
-    dir_index = (site / "FreeBSD:16:amd64" / "index.html").read_text()
-    assert "pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg" in dir_index
-    assert 'href="packagesite.pkg"' not in dir_index
+    assert '<a class="browse" href="./browse.html">' in (site / "index.html").read_text()
+    browse = (site / "browse.html").read_text()
+    assert '<a href="./release/">release/</a>' in browse
+    # An autoindex index.html exists at EVERY level — intermediate dirs too, not just the leaf.
+    for rel in ("release", "release/ce-2.8", "release/ce-2.8/FreeBSD:15:amd64"):
+        assert (site / rel / "index.html").is_file(), f"missing autoindex at {rel}"
+    # Intermediate dir lists its subdir; leaf lists the package + the catalog plumbing (a real
+    # directory listing, unlike the old package-only view).
+    assert '<a href="./ce-2.8/">ce-2.8/</a>' in (site / "release" / "index.html").read_text()
+    leaf = (site / "release" / "ce-2.8" / "FreeBSD:15:amd64" / "index.html").read_text()
+    assert "pfSense-pkg-pfBlockerNG-devel-3.2.16.pkg" in leaf
+    assert "packagesite.pkg" in leaf  # the catalog files ARE shown in a directory listing
+    # The generated index pages themselves are hidden from listings (not repository content).
+    assert "browse.html" not in browse.split("<tbody>")[1]

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -499,3 +499,59 @@ def test_write_site_emits_browse_and_autoindex_at_every_level(tmp_path: Path, mo
     assert "packagesite.pkg" in leaf  # the catalog files ARE shown in a directory listing
     # The generated index pages themselves are hidden from listings (not repository content).
     assert "browse.html" not in browse.split("<tbody>")[1]
+
+
+def test_browse_adapts_to_any_future_tree_shape(tmp_path: Path, monkeypatch: Any) -> None:
+    """Scenario: the browse view is derived purely by walking the tree — no hardcoded layout.
+
+    Given a deliberately NOVEL tree (a brand-new top-level channel, an `_archive/` subtree, deeper
+    nesting than today, and an exotic ABI no current matrix entry covers),
+    When write_site runs,
+    Then an autoindex index.html appears at EVERY level (whatever the names/depth), browse.html lists
+    the new top-level entries, packages are discovered wherever they live, and the deepest dir's
+    autoindex still climbs correctly — proving a future folder restructure needs NO code change.
+    """
+    site = tmp_path / "site"
+    # A structure we do NOT use today: a future channel, an archive subtree, +1 nesting level, an
+    # ABI/varver the matrix doesn't know, and a stray top-level file.
+    novel = [
+        "experimental/ce-2.9/FreeBSD:16:riscv64/extra/pfSense-pkg-pfBlockerNG-devel-9.9.9.pkg",
+        "release/_archive/plus-99.03/FreeBSD:99:powerpc64/pfSense-pkg-pfBlockerNG-9.9.9.pkg",
+    ]
+    for rel in novel:
+        _touch(site / rel)
+    _touch(site / "CHECKSUMS.txt")
+
+    # The manifest is read from each .pkg wherever it sits (path-agnostic); derive it from the path.
+    def fake_manifest(path: str) -> dict:
+        name = "pfSense-pkg-pfBlockerNG-devel" if "experimental" in path else "pfSense-pkg-pfBlockerNG"
+        abi = "FreeBSD:16:riscv64" if "experimental" in path else "FreeBSD:99:powerpc64"
+        return {"name": name, "version": "9.9.9", "abi": abi}
+
+    monkeypatch.setattr(gl, "read_manifest_zstd", fake_manifest)
+    monkeypatch.setattr(gl, "_conf_via_addrepo", lambda addrepo, base, ch: f"{ch}-conf")
+
+    n = gl.write_site(str(site), "https://x/pkg/", "add-repo.sh")
+
+    # Packages found wherever they live (both novel locations), not by an assumed path.
+    assert n == 2
+    # browse.html lists the NEW top-level entries (a channel we've never used + a stray file).
+    browse = (site / "browse.html").read_text()
+    assert '<a href="./experimental/">experimental/</a>' in browse
+    assert '<a href="./release/">release/</a>' in browse
+    assert '<a href="./CHECKSUMS.txt">CHECKSUMS.txt</a>' in browse
+    # An autoindex exists at EVERY directory of the novel tree — arbitrary names + extra depth.
+    for rel in (
+        "experimental",
+        "experimental/ce-2.9",
+        "experimental/ce-2.9/FreeBSD:16:riscv64",
+        "experimental/ce-2.9/FreeBSD:16:riscv64/extra",
+        "release/_archive",
+        "release/_archive/plus-99.03",
+        "release/_archive/plus-99.03/FreeBSD:99:powerpc64",
+    ):
+        assert (site / rel / "index.html").is_file(), f"no autoindex generated at {rel}"
+    # The deepest dir lists its package and climbs to the repository root (depth-correct home link).
+    deep = (site / "experimental/ce-2.9/FreeBSD:16:riscv64/extra" / "index.html").read_text()
+    assert "pfSense-pkg-pfBlockerNG-devel-9.9.9.pkg" in deep
+    assert 'href="../../../../"' in deep  # 4 levels deep -> 4 hops to the site root


### PR DESCRIPTION
## What

Replace the landing page's flat **"Catalog trees"** list (one link per leaf catalog dir) with a single **"Browse the repository"** link to a **folder-navigable, FreeBSD/Debian-style directory listing** of the whole repo.

Motivation: today `gen_landing.py` only emits a browsable `index.html` in **leaf** catalog dirs, so intermediate dirs (`release/`, `release/ce-2.8/`) 404 on GitHub Pages (no autoindex). There was no real folder navigation.

## How

- **`render_autoindex()`** — a `Name / Last modified / Size` listing per directory, with a `../` Parent Directory row and `./`-prefixed hrefs so a colon-bearing ABI segment (`FreeBSD:15:amd64`) stays a relative path, not a URI scheme (RFC 3986 §4.2).
- **`write_site()`** — emits an autoindex `index.html` at **every** directory level (intermediate + leaf) plus a root **`browse.html`** entry point; the human landing page stays the site root (`index.html`).
- **`render_page()`** — drops the per-leaf `<ul class="trees">`; the section becomes one `📁 Browse the repository →` link to `browse.html`. Removed the now-unused `catalog_dirs()` + `ul.trees` CSS; added a small autoindex/browse style.
- The directory listings now show the catalog files too (`meta.conf`/`packagesite.pkg`/…), like a real autoindex. **pkg(8) is unaffected** — it builds catalog URLs itself and never reads these pages.

## Tests

`tests/test_gen_landing.py`: replaced the trees-list assertions with the single browse link; new `render_autoindex` cases (parent row, subdir/file rows, colon-safe hrefs, root has no parent); `write_site` now asserts `browse.html` + an autoindex `index.html` at **every** level (intermediate dirs included) and that generated index pages are hidden from listings. Full suite green (1646); mypy clean.

After merge I'll re-dispatch the `pkg` publish so the live page shows the new Browse link + directory listings.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic directory index pages at every level of the generated site
  * Introduced a new `browse.html` entry point for exploring repository contents
  * Updated the landing page to include a “Browse” button linking to `browse.html`
  * Improved directory browsing layout and link correctness (including safe handling of special characters)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->