### PR TITLE
ci(smoke): write SMOKE_MATRIX_JSON via heredoc (unbreak the smoke fan-out)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -222,7 +222,10 @@ jobs:
         run: |
           set -u
           if matrix="$(sh scripts/read-version-matrix.sh --print-build 2>/dev/null)" && [ -n "$matrix" ]; then
-            printf 'SMOKE_MATRIX_JSON=%s\n' "$matrix" >> "$GITHUB_ENV"
+            # --print-build emits pretty (multi-line) JSON, so write it via the heredoc
+            # delimiter form (as RESOLVED_REDACT below does): a single-line KEY=value write
+            # of a multi-line value errors the step ("Invalid format") and drops the matrix.
+            { printf 'SMOKE_MATRIX_JSON<<__EOF__\n%s\n__EOF__\n' "$matrix"; } >> "$GITHUB_ENV"
             echo "Resolved $(printf '%s' "$matrix" | jq 'length') build-matrix entries for the smoke topology."
           else
             echo "::warning::could not resolve the version matrix — ADR-20 variant-topology cases will SKIP"


### PR DESCRIPTION
## Problem

The smoke fan-out is **red on every leg** (CE + Plus), failing *before* the VM/pytest step. The "Resolve the version matrix" step (added in `b7ccf0e`) does:

```sh
printf 'SMOKE_MATRIX_JSON=%s\n' "$matrix" >> "$GITHUB_ENV"
```

but `read-version-matrix.sh --print-build` emits **pretty (multi-line) JSON**. A single-line `KEY=value` write of a multi-line value is illegal for `$GITHUB_ENV`, so the step errors:

```
Resolved 3 build-matrix entries for the smoke topology.
##[error]Unable to process file command 'env' successfully.
##[error]Invalid format '  {'
```

`SMOKE_MATRIX_JSON` then becomes just `[`, the "Run the live-VM matrix (pytest -m smoke)" step is **skipped**, and the `All smoke legs passed` AND-gate fails. (The step's intended best-effort SKIP-on-failure never triggers because the malformed env write itself errors the step.)

Confirmed on fan-out run `27611529611` (both legs failed identically at this step).

## Fix

Write it with the **heredoc delimiter** form — exactly as the `RESOLVED_REDACT` export in the *same job* already does for its multi-line value:

```sh
{ printf 'SMOKE_MATRIX_JSON<<__EOF__\n%s\n__EOF__\n' "$matrix"; } >> "$GITHUB_ENV"
```

Multi-line-safe; `SMOKE_MATRIX_JSON` is exported intact (JSON parsers downstream handle multi-line fine). One-line change, no behaviour change beyond a valid env write. Restores the CE + Plus smoke fan-out.

`yaml.safe_load` clean.

https://claude.ai/code/session_014qKGQtz556UbUyATPMKg5s

---
_Generated by [Claude Code](https://claude.ai/code/session_014qKGQtz556UbUyATPMKg5s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved stability of internal build and test workflows to prevent processing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->