### PR TITLE
test(smoke): fix nightly-install import of removed GUEST_ABI

### DIFF
--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -42,9 +42,9 @@ from pathlib import Path
 import pytest
 
 from . import helpers as h
+from ._matrix import matrix_abi
 from .conftest import SmokeVM
 from .test_repo_install import (
-    GUEST_ABI,
     _ensure_egress_open,
     _ssh_check,
     build_guest_repo,
@@ -372,7 +372,7 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
 
     # BACKSTOP: prove the deploy actually serves the nightly catalog from the runner
     # first (independent of the guest) — polls through first-deploy / DNS / cert lag.
-    poll_catalog_served(base_url, GUEST_ABI)
+    poll_catalog_served(base_url, matrix_abi())
 
     _ensure_egress_open()
 


### PR DESCRIPTION
## What

`tests/smoke/test_nightly_install.py` imported `GUEST_ABI` from `test_repo_install.py`, but `b7ccf0e` ("derive the repo-smoke variant topology from the version matrix") removed that constant in favour of the matrix-derived `matrix_abi()` (from `tests/smoke/_matrix.py`). The sibling `test_repo_install.py` was migrated; the nightly module was not.

## Impact

pytest imports **every** module at collection time, so the `repo`-marked nightly module's `ImportError` aborted the entire `pytest -m smoke` collection with exit 2 — failing **every** smoke fan-out leg (CE + Plus) in ~1 second, with no VM diagnostics. This blocked all smoke-based ADR acceptance fan-outs since `b7ccf0e` landed (after the last green fan-out at `34761904`).

```
ERROR collecting tests/smoke/test_nightly_install.py
tests/smoke/test_nightly_install.py:46: from .test_repo_install import (
E   ImportError: cannot import name 'GUEST_ABI' from 'tests.smoke.test_repo_install'
!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!
```

## Fix

Mirror the sibling refactor exactly: import `matrix_abi` from `._matrix` and call it at the `poll_catalog_served()` site. No behaviour change — `matrix_abi()` returns the same `FreeBSD:15:amd64` for the CE leg (and the correct ABI per leg in the fan-out).

Verified locally: `pytest -m "smoke or repo" --collect-only` now collects with 0 errors; full unit suite (1647) + ruff + mypy + markdownlint green.

https://claude.ai/code/session_014qKGQtz556UbUyATPMKg5s

---
_Generated by [Claude Code](https://claude.ai/code/session_014qKGQtz556UbUyATPMKg5s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite reliability by aligning catalog polling logic with test parameters for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->