### PR TITLE
ci: variant-qualify the UI diagnostics artifact name (ce-2.8)

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -249,18 +249,19 @@ jobs:
           printf 'build_matrix={"include":%s}\n' "$BUILD_INCLUDE" >> "$GITHUB_OUTPUT"
 
           # Cross the tier set with the legs: one matrix item per (tier × leg),
-          # each carrying tier + version (= pfsense_version) + image_name + channel.
-          # jq builds the include array directly from $LEGS and the tier list.
+          # each carrying tier + version (= pfsense_version) + a lowercased `variant`
+          # (ce / plus, from image_name) for a variant-qualified artifact name + image_name + channel.
           INCLUDE="$(printf '%s\n' "$LEGS" | jq -c \
             --arg tiers "${TIERS}" \
             '($tiers | split(" ")) as $ts
              | [ $ts[] as $t | .[]
-                 | {tier: $t, version: .pfsense_version, image_name: .image_name, channel: .channel} ]')"
+                 | {tier: $t, version: .pfsense_version, variant: (.image_name | ltrimstr("pfsense-")),
+                    image_name: .image_name, channel: .channel} ]')"
           printf 'matrix={"include":%s}\n' "$INCLUDE" >> "$GITHUB_OUTPUT"
           echo "tiers=[${TIERS}] legs=${LEGS} run=${RUN}"
 
   ui:
-    name: ${{ matrix.tier }} / ${{ matrix.version }} (live pfSense VM)
+    name: ${{ matrix.tier }} / ${{ matrix.variant }}-${{ matrix.version }} (live pfSense VM)
     needs: [build-pkg, prepare]
     # Skip the whole leg set when the nightly guard says there's nothing to run.
     if: needs.prepare.outputs.run == 'true'
@@ -592,8 +593,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          # One artifact per leg so a re-run of a single leg overwrites only its own.
-          name: ui-diagnostics-${{ matrix.tier }}-${{ matrix.version }}
+          # One artifact per leg so a re-run of a single leg overwrites only its own. The
+          # variant (ce/plus) qualifies the name so CE+Plus of the same pfSense major.minor
+          # never collide and the edition is obvious — e.g. ui-diagnostics-browser-ce-2.8.
+          name: ui-diagnostics-${{ matrix.tier }}-${{ matrix.variant }}-${{ matrix.version }}
           path: |
             test-results/ui-screenshots/**
             **/vm*.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -982,7 +982,8 @@ on **image-ref/version** and tier-selectable, building the branch `.pkg` via
 (tier × version)** with `fail-fast: false`, so GitHub's "Re-run failed jobs"
 re-runs only the flaky leg (no auto-retry on assertions; bounded readiness retry
 only on boot/login). Diagnostics (screenshots + VM/boot logs + the smoke state
-snapshot) upload `if: always()` as `ui-diagnostics-<tier>-<version>`. Wiring:
+snapshot) upload `if: always()` as `ui-diagnostics-<tier>-<variant>-<version>`
+(variant = ce/plus, e.g. `ui-diagnostics-browser-ce-2.8`). Wiring:
 
 - **Tier A** runs per-PR (`test.yml`) on PRs touching `src/**/*.php`, `**/*.inc`,
   `src/**/*.js`, folded into the **"All tests passed"** aggregate (blocking).

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -152,7 +152,8 @@ matrix-parametric on image-ref/version and tier-selectable, **one GH job per (ti
 leg re-runnable in isolation. The version axis is parametric but runs the **single CE image**
 today (B1) — adding one is a one-line `DEFAULT_VERSIONS` append + image-ref wire (IMAGE_RUNBOOK).
 Diagnostics (screenshots + VM logs + smoke snapshot) upload `if: always()` as
-`ui-diagnostics-<tier>-<version>`. The §7 browser reliability numbers are **CI-pending**; the
+`ui-diagnostics-<tier>-<variant>-<version>` (variant = ce/plus, e.g. `ui-diagnostics-browser-ce-2.8`).
+The §7 browser reliability numbers are **CI-pending**; the
 browser leg has a one-line demote/drop switch (drop `browser` from `DEFAULT_SCHEDULE_TIERS` +
 run release `ui-suite` as `tier: functional`). Full design: `.ADRs/ADR_14_UI_UX_Testing/`.
 


### PR DESCRIPTION
## What

Make the UI-test diagnostics artifacts **variant-qualified** — `ui-diagnostics-browser-ce-2.8` instead of `ui-diagnostics-browser-2.8` — so the CE and Plus legs of the same pfSense `major.minor` are distinct and the edition is obvious at a glance.

## How

- In the `ui-tests.yml` matrix jq, derive a lowercased **`variant`** (`ce`/`plus`) from `matrix.image_name` (`pfsense-ce`/`pfsense-plus`, via `ltrimstr("pfsense-")`).
- Use it in the **artifact name** (`ui-diagnostics-<tier>-<variant>-<version>`) and the **job display name** (`browser / ce-2.8 (live pfSense VM)`).
- Doc reference (`architecture-notes.md`) updated.

Derived from `image_name` (not hardcoded), so it stays correct as the version matrix grows. jq dry-run confirms `ui-diagnostics-browser-ce-2.8` / `…-plus-26.03`; YAML + markdownlint clean.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced UI test matrix configuration to include edition variants (CE/Plus) alongside existing tier and version dimensions.
  * Updated artifact naming to prevent naming collisions between concurrent test runs of different pfSense editions.

* **Documentation**
  * Updated CI diagnostics artifact naming documentation to reflect the new naming convention that includes edition variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->