### PR TITLE
pfblockerng: hidden override to render the Software page both ways (ADR-19)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2291,7 +2291,40 @@ function pfb_software_update_check(bool $force = false, ?array $io = null): arra
  * the priv match line all gate on this single predicate so a Netgate-installed
  * add-on shows no Software page anywhere.
  */
+// Hidden test/support override for the Software-page provenance gate (ADR-19). A file
+// containing 'on' or 'off' FORCES the gate (case-insensitive, trimmed); absent or any other
+// content => fall through to the auto-detect below. NOT a GUI knob: the webConfigurator never
+// writes it. It lets CI render BOTH the enabled and disabled states deterministically (the
+// Tier-A UI deploy is a sideloaded `pkg add`, whose %R is empty, so auto-detect alone could
+// only ever show the hidden state), and gives support a force-on/off escape-hatch on a real box.
+define('PFB_SOFTWARE_PANEL_OVERRIDE', '/var/db/pfblockerng/.pfb_software_panel');
+
+/*
+ * The forced Software-gate state, or NULL when not forced. Reads the hidden override sentinel
+ * (PFB_SOFTWARE_PANEL_OVERRIDE; $path is injectable for off-box tests): 'on' => true,
+ * 'off' => false, absent / any other content => NULL (the auto-detect applies).
+ */
+function pfb_software_panel_override(?string $path = null): ?bool {
+	$path = $path ?? PFB_SOFTWARE_PANEL_OVERRIDE;
+	if (!is_file($path)) {
+		return null;
+	}
+	$v = strtolower(trim((string) @file_get_contents($path)));
+	if ($v === 'on') {
+		return true;
+	}
+	if ($v === 'off') {
+		return false;
+	}
+	return null;
+}
+
 function pfb_software_provenance_ok(): bool {
+	// A hidden override (CI / support) wins; otherwise auto-detect from the install's repo (%R).
+	$forced = pfb_software_panel_override();
+	if ($forced !== null) {
+		return $forced;
+	}
 	return pfb_software_is_our_build(pfb_pkg_installed_repo(pfb_pkg_installed_name()));
 }
 

--- a/tests/php/SoftwarePanelOverrideTest.php
+++ b/tests/php/SoftwarePanelOverrideTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-19 — the hidden Software-page override sentinel (pfb_software_panel_override). A pure,
+ * pfSense-decoupled helper: the file's content forces the provenance gate on/off so CI can
+ * render BOTH the enabled and disabled Software-page states deterministically (the Tier-A UI
+ * deploy is a sideload whose %R is empty, so the auto-detect alone could only show "hidden").
+ *
+ * Per CLAUDE.md test-coverage rules every branch + input class is asserted: forced-on,
+ * forced-off, case/whitespace normalisation, the absent file, and the "any other content =>
+ * NULL (auto-detect applies)" fall-through (empty / garbage / a non-on-off word).
+ */
+#[CoversFunction('pfb_software_panel_override')]
+final class SoftwarePanelOverrideTest extends TestCase
+{
+	private string $tmp = '';
+
+	protected function setUp(): void
+	{
+		$this->tmp = (string) tempnam(sys_get_temp_dir(), 'pfb_sw_panel_');
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->tmp !== '' && is_file($this->tmp)) {
+			unlink($this->tmp);
+		}
+	}
+
+	private function override(string $content): ?bool
+	{
+		file_put_contents($this->tmp, $content);
+		return pfb_software_panel_override($this->tmp);
+	}
+
+	public function testOnForcesEnabled(): void
+	{
+		// 'on' (and case/whitespace variants) => force the gate OPEN (true).
+		$this->assertTrue($this->override('on'));
+		$this->assertTrue($this->override("  ON\n"));
+		$this->assertTrue($this->override("On\r\n"));
+	}
+
+	public function testOffForcesDisabled(): void
+	{
+		// 'off' (and case/whitespace variants) => force the gate CLOSED (false) — distinct from
+		// NULL: a forced-off must NOT fall through to the auto-detect.
+		$this->assertFalse($this->override('off'));
+		$this->assertFalse($this->override("\tOFF "));
+	}
+
+	public function testAnyOtherContentFallsThroughToAutoDetect(): void
+	{
+		// Empty / unrelated content => NULL: the caller then runs the %R auto-detect. This is the
+		// third branch, NOT a silent on/off — a typo'd sentinel must never force a state.
+		$this->assertNull($this->override(''));
+		$this->assertNull($this->override('   '));
+		$this->assertNull($this->override('enabled'));
+		$this->assertNull($this->override('1'));
+		$this->assertNull($this->override('on off'));
+	}
+
+	public function testAbsentFileIsNotForced(): void
+	{
+		// No sentinel => NULL (auto-detect): the default state on every normal install.
+		unlink($this->tmp);
+		$this->assertNull(pfb_software_panel_override($this->tmp));
+	}
+}

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -52,6 +52,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from .conftest import mask_page_identity
+from .test_render_smoke import software_panel_forced
 
 sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
 expect = sync_api.expect
@@ -59,7 +60,12 @@ expect = sync_api.expect
 if TYPE_CHECKING:
     from playwright.sync_api import Page
 
+    from ..conftest import SmokeVM
     from .webui import WebUI
+
+# The provenance-gated Software (version/upgrades) page + its panel marker (ADR-19).
+SOFTWARE_PAGE = "/pfblockerng/pfblockerng_software.php"
+SOFTWARE_PANEL_MARKER = "pfb-software-panel"
 
 pytestmark = pytest.mark.ui_browser
 
@@ -320,3 +326,22 @@ def test_feeds_alt_radio_submit_wiring(
     assert page.evaluate("window.__pfb_alt_submitted") is True, (
         "clicking an Alternate-URL radio did not trigger the #save submit handler"
     )
+
+
+def test_software_panel_screenshot_when_enabled(
+    smoke_vm: SmokeVM,
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """Capture the Software (version/upgrades) panel in its ENABLED state.
+
+    The default Tier-A/B sideload deploy hides the page (provenance gate, %R empty), so it never
+    appears in a normal browser run. Forcing the hidden override 'on' (software_panel_forced)
+    renders the panel deterministically; assert its marker is in the DOM and write a full-page
+    screenshot artifact for human review. Captures the state the always-on tiers otherwise can't.
+    """
+    with software_panel_forced(smoke_vm, "on"):
+        _open(browser_page, webui, SOFTWARE_PAGE)
+        assert SOFTWARE_PANEL_MARKER in browser_page.content(), "Software panel marker absent when forced on"
+        _shot(browser_page, screenshot_dir, "software_panel_enabled")

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -470,12 +470,18 @@ _SOFTWARE_OVERRIDE_FILE = "/var/db/pfblockerng/.pfb_software_panel"
 def software_panel_forced(vm: SmokeVM, state: str) -> Iterator[None]:
     """Force the Software-page gate ``on``/``off`` for the block via the hidden sentinel, then
     remove it so subsequent tests see the default auto-detect. ``state`` is a fixed 'on'/'off'
-    literal (never user input)."""
-    vm.ssh("/bin/sh", "-c", f"mkdir -p /var/db/pfblockerng && printf '%s' {state} > {_SOFTWARE_OVERRIDE_FILE}")
+    literal (never user input). Both the write and the cleanup are checked so a silently failed
+    write can't let the forced-off case pass on the default-hidden path, and a failed cleanup
+    can't leak override state into a later test."""
+    write = vm.ssh(
+        "/bin/sh", "-c", f"mkdir -p /var/db/pfblockerng && printf '%s' '{state}' > '{_SOFTWARE_OVERRIDE_FILE}'"
+    )
+    assert write.returncode == 0, f"failed to set software override to {state!r}: {write.stderr.strip()}"
     try:
         yield
     finally:
-        vm.ssh("/bin/rm", "-f", _SOFTWARE_OVERRIDE_FILE)
+        clear = vm.ssh("/bin/rm", "-f", _SOFTWARE_OVERRIDE_FILE)
+        assert clear.returncode == 0, f"failed to clear software override sentinel: {clear.stderr.strip()}"
 
 
 def test_software_page_provenance_gate_hides_on_nonour_build(

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -23,6 +23,7 @@ with the reason and the access note for Phase 5, NOT silently dropped.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -449,18 +450,32 @@ def test_threats_rejects_malformed_lookup(name: str, query: str, message: str, w
     assert not present, f"{name}: reject path unexpectedly rendered lookup chrome {present}"
 
 
-# ADR-19: the "Software" page + tab are PROVENANCE-GATED — present ONLY on a build
-# installed from one of OUR repos (pkg %R == pfblockerng / pfblockerng-nightly). The
-# ADR-04 UI harness installs the branch .pkg with `pkg add -f` (offline), so its %R is
-# NOT one of our repos -> the provenance gate HIDES the page and the tab. This is the
-# NEGATIVE side of the gate, and it is the one this Tier-A deploy can prove live: the
-# page's top-of-file guard `header('Location: /index.php'); exit;` fires, and
-# pfb_software_add_tab() appends nothing. The POSITIVE render (200 + the
-# 'pfb-software-panel' marker + the action buttons) belongs to Phase 5's `repo`-install
-# journey, where the package IS installed from our repo so %R == pfblockerng.
+# ADR-19: the "Software" page + tab are PROVENANCE-GATED — present ONLY on a build installed
+# from one of OUR repos (pkg %R == pfblockerng / pfblockerng-nightly). The ADR-04 UI harness
+# sideloads the branch .pkg with `pkg add -f` (offline), so its %R is empty -> the auto-detect
+# HIDES the page and tab (the DEFAULT negative state, proven below). To exercise BOTH states
+# deterministically on this same sideload deploy, pfblockerng.inc honours a HIDDEN override
+# sentinel (PFB_SOFTWARE_PANEL_OVERRIDE, a file containing 'on'|'off'); software_panel_forced()
+# drops/clears it over SSH so we can render the page ENABLED (positive: 200 + the
+# 'pfb-software-panel' marker) and DISABLED (negative) without needing an our-repo install. The
+# REAL %R-driven behaviour is separately validated by the `repo` flow (test_software_update.py).
 _SOFTWARE_PAGE = "/pfblockerng/pfblockerng_software.php"
 _SOFTWARE_PANEL_MARKER = "pfb-software-panel"
 _SOFTWARE_TAB_HREF = "/pfblockerng/pfblockerng_software.php"
+# Mirrors PFB_SOFTWARE_PANEL_OVERRIDE in pfblockerng.inc (the hidden test/support sentinel).
+_SOFTWARE_OVERRIDE_FILE = "/var/db/pfblockerng/.pfb_software_panel"
+
+
+@contextmanager
+def software_panel_forced(vm: SmokeVM, state: str) -> Iterator[None]:
+    """Force the Software-page gate ``on``/``off`` for the block via the hidden sentinel, then
+    remove it so subsequent tests see the default auto-detect. ``state`` is a fixed 'on'/'off'
+    literal (never user input)."""
+    vm.ssh("/bin/sh", "-c", f"mkdir -p /var/db/pfblockerng && printf '%s' {state} > {_SOFTWARE_OVERRIDE_FILE}")
+    try:
+        yield
+    finally:
+        vm.ssh("/bin/rm", "-f", _SOFTWARE_OVERRIDE_FILE)
 
 
 def test_software_page_provenance_gate_hides_on_nonour_build(
@@ -507,6 +522,47 @@ def test_software_tab_absent_on_nonour_build(webui: WebUI, php_error_log_guard: 
     assert _SOFTWARE_TAB_HREF not in resp.text, (
         "the Software tab must be ABSENT on a non-our-build (provenance gate hides it everywhere)"
     )
+
+
+def test_software_page_renders_when_override_forces_on(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """Forcing the hidden override 'on' renders the Software page POSITIVELY on this sideload deploy.
+
+    Scenario: the Tier-A deploy is a sideload (%R empty) — the page is hidden by default (the
+    provenance tests above). Forcing the override 'on' is the ONLY change.
+      Given the override sentinel set to 'on',
+      When the Software page is GET,
+      Then it renders clean (200, no Fatal/Warning/Notice/Uncaught, the 'pfb-software-panel'
+           marker present) AND the Software tab now appears on a normal page — proving the gate's
+           POSITIVE branch on the same deploy that otherwise hides it (before/after the flip).
+      And no new php_error.log line (php_error_log_guard sweeps).
+    """
+    with software_panel_forced(smoke_vm, "on"):
+        resp = webui.get(_SOFTWARE_PAGE)
+        result = evaluate_render(_SOFTWARE_PAGE, resp.status_code, resp.text, (_SOFTWARE_PANEL_MARKER,))
+        assert result.ok, f"forced-on Software page render failed: {result.detail}"
+        # The tab is injected everywhere on an enabled build — the positive of the tab-absent test.
+        general = webui.get(_GENERAL_PAGE)
+        assert _SOFTWARE_TAB_HREF in general.text, "the Software tab must be PRESENT when the gate is forced on"
+
+
+def test_software_page_hidden_when_override_forces_off(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """Forcing the override 'off' hides the page DETERMINISTICALLY — independent of install %R.
+
+    The 'off' branch must win even on a box that WOULD auto-detect as our-build, so support can
+    force the page away. GET (redirects not followed) -> the guard's 3xx to /index.php, marker
+    absent — the explicit negative branch paired with the forced-on positive above.
+    """
+    with software_panel_forced(smoke_vm, "off"):
+        resp = webui.get(_SOFTWARE_PAGE, allow_redirects=False)
+        assert resp.status_code in (301, 302, 303, 307, 308), (
+            f"forced-off Software page expected a redirect, got HTTP {resp.status_code}"
+        )
+        assert resp.headers.get("Location", "").endswith("/index.php")
+        assert _SOFTWARE_PANEL_MARKER not in resp.text, "forced-off must NOT render the Software panel"
 
 
 def test_page_table_covers_every_pfblockerng_page() -> None:


### PR DESCRIPTION
## Why

The ADR‑19 **Software** (version/upgrades) page is provenance‑gated on `pkg query %R` (installed‑from‑our‑repo). The always‑on UI tiers **sideload** the branch `.pkg` (`pkg add`, empty `%R`), so they could only ever render the **hidden** state — the **enabled** panel had no UI/screenshot coverage outside the dispatch‑only `repo` flow. We need to capture + validate **both** states.

Per the discussion, this keeps the `%R` auto‑detect and layers a **hidden override** over it (decision: override‑on‑top‑of‑`%R`, via a hidden test/support sentinel — not a GUI knob).

## How

- **`src/.../pfblockerng.inc`** — `pfb_software_panel_override()` reads `PFB_SOFTWARE_PANEL_OVERRIDE` (`/var/db/pfblockerng/.pfb_software_panel`): `on`/`off` (case‑insensitive, trimmed) forces the gate; absent/any‑other content falls through to today's `%R` auto‑detect. Wired into `pfb_software_provenance_ok()` (auto‑detect unchanged when unset). Not written by the GUI; doubles as a support force‑on/off escape‑hatch.
- **`tests/php/SoftwarePanelOverrideTest.php`** — every branch (on / off / case+whitespace / absent / empty / garbage), path‑injected (off‑box, pure).
- **`tests/smoke/ui/test_render_smoke.py`** — `software_panel_forced()` (SSH‑drops/clears the sentinel) + **forced‑on** (200 + `pfb-software-panel` marker + Software tab present) and **forced‑off** (redirect to `/index.php` + marker absent) render cases, both on the standard sideload deploy. Existing default‑hidden provenance tests kept.
- **`tests/smoke/ui/test_browser_misc.py`** — a **forced‑on browser screenshot** (`software_panel_enabled.png`) so the enabled panel is captured.

The real `%R`‑driven behaviour stays validated by the `repo` flow (`test_software_update.py`).

## Validation

PHPUnit 553 (4 new), pytest 1647, mypy clean, PHPStan/PHPCS clean, `php -l` clean. The live render/browser cases run in the `ui_render`/`ui_browser` tiers (dispatch).

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hidden override mechanism to let administrators force whether the Software page/panel is shown (enabled/disabled), while allowing automatic behavior when no override is provided.
* **Bug Fixes**
  * Ensures the Software page behavior follows the forced state deterministically, including correct redirect handling when disabled.
* **Tests**
  * Added unit tests covering all override input scenarios.
  * Added smoke/UI tests (including screenshot capture) to validate the Software page rendering in both forced states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->