### PR TITLE
test: fix software_panel_forced SSH write over tcsh (ADR-19)

### DIFF
--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -463,20 +463,24 @@ _SOFTWARE_PAGE = "/pfblockerng/pfblockerng_software.php"
 _SOFTWARE_PANEL_MARKER = "pfb-software-panel"
 _SOFTWARE_TAB_HREF = "/pfblockerng/pfblockerng_software.php"
 # Mirrors PFB_SOFTWARE_PANEL_OVERRIDE in pfblockerng.inc (the hidden test/support sentinel).
-_SOFTWARE_OVERRIDE_FILE = "/var/db/pfblockerng/.pfb_software_panel"
+_SOFTWARE_OVERRIDE_NAME = ".pfb_software_panel"
+_SOFTWARE_OVERRIDE_FILE = f"{helpers.PFB_DBDIR}/{_SOFTWARE_OVERRIDE_NAME}"
 
 
 @contextmanager
 def software_panel_forced(vm: SmokeVM, state: str) -> Iterator[None]:
     """Force the Software-page gate ``on``/``off`` for the block via the hidden sentinel, then
     remove it so subsequent tests see the default auto-detect. ``state`` is a fixed 'on'/'off'
-    literal (never user input). Both the write and the cleanup are checked so a silently failed
-    write can't let the forced-off case pass on the default-hidden path, and a failed cleanup
-    can't leak override state into a later test."""
-    write = vm.ssh(
-        "/bin/sh", "-c", f"mkdir -p /var/db/pfblockerng && printf '%s' '{state}' > '{_SOFTWARE_OVERRIDE_FILE}'"
-    )
-    assert write.returncode == 0, f"failed to set software override to {state!r}: {write.stderr.strip()}"
+    literal (never user input).
+
+    The write goes through ``helpers.write_local_feed`` (bare ``mkdir -p`` argv + ``tee`` over
+    stdin), NOT ``ssh "/bin/sh -c 'mkdir … && printf … > file'"``: ssh space-joins the remote
+    argv and the pfSense root LOGIN shell (tcsh) re-parses it, so the compound ``sh -c`` form
+    silently mis-runs (``mkdir`` gets no operand). ``write_local_feed`` already raises on a
+    failed write, so a silent failure can't let the forced-off case pass on the default-hidden
+    path; the cleanup ``rm`` is checked too so a failure can't leak override state into a later
+    test."""
+    helpers.write_local_feed(vm, _SOFTWARE_OVERRIDE_NAME, state)
     try:
         yield
     finally:


### PR DESCRIPTION
## What

Fix the live `ui_browser` / `ui_render` failure introduced with the Software‑page override helper (#268): `software_panel_forced()` couldn't write the sentinel on the VM.

## Root cause

The helper wrote the sentinel with:

```python
vm.ssh("/bin/sh", "-c", "mkdir -p /var/db/pfblockerng && printf '%s' 'on' > '<file>'")
```

`ssh` **space‑joins** the remote argv and the pfSense root **login shell is tcsh**, which re‑parses the joined string — so the compound `sh -c` mis‑runs: `mkdir` gets no operand (`usage: mkdir …`, `returncode=64`). The `returncode == 0` assert (added in #268 review) correctly turned this into a hard failure rather than a silent mis‑configuration. `helpers.py` already documents this exact gotcha.

## Fix

Write through the canonical `helpers.write_local_feed()` — a bare `mkdir -p` argv + `tee` over stdin (shell‑agnostic, no `&&`/redirect/nested quotes) — which also raises on a failed write, preserving the "validate the write" intent. The cleanup `rm -f` (a simple argv) keeps its checked return.

No behaviour change to the override itself; this only fixes how the test harness drops the sentinel.

## Validation

`ruff` clean, `tests/smoke/ui` collects (149). The live browser tier (which failed) will be re‑dispatched after merge to confirm `software_panel_enabled.png` is produced.

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for software panel validation by refactoring the sentinel configuration method to use internal helpers instead of hard-coded system paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->