### PR TITLE
pfblockerng: rework the ADR-19 Software page UX + new-version check setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,15 +251,12 @@ offers three buttons:
 A daily background check (riding the existing pfBlockerNG cron) compares installed vs our
 latest and raises a **de-duped notification** when a newer build exists — the pfSense bell
 plus whatever remote channels you have configured (SMTP / Telegram / Pushover / Slack). It
-fires **once per new version**, not once per day. Whether it notifies is governed by one
-knob on the Software tab, **`pfb_software_notify`** (Default / On / Off):
+fires **once per new version**, not once per day. It is governed by a single checkbox on the
+Software tab, **Check for new versions** (`pfb_software_check`), **enabled by default** and
+applied equally on every channel: when enabled, pfBlockerNG checks our repository and notifies
+you of a newer build; untick it to stop the background checks and notifications. The page's
+**Check now** button always runs a one-off check regardless of the setting.
 
-| Channel | Default (knob unset) |
-| --- | --- |
-| stable / devel | **Off** — quiet; check the tab when you choose |
-| nightly | **On** — you opted into the tip, so you are told when it moves |
-
-Set the knob to **On** or **Off** to override the per-channel default either way.
 Cross-channel **switching** from the GUI is not offered (the selector is read-only); switch
 channels with `add-repo.sh` + `pkg install` as in Option 2 above.
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2016,34 +2016,26 @@ function pfb_update_available(?string $installed, ?string $latest): bool {
 }
 
 /*
- * The channel-aware default for the notify knob when it is unset/'default': nightly
- * defaults ON (trackers opted into the tip), stable/devel (and any other) default OFF
- * (quiet for release users). Overridden by an explicit 'on'/'off' in pfb_should_notify().
+ * Whether the "Check for new versions" setting (pfb_software_check) is enabled. Default
+ * ENABLED: an our-repo install checks for and notifies of new versions out of the box. Only
+ * an explicit 'off' (the user un-ticking the box, persisted by the Software page) disables it;
+ * an unset value (never saved) or 'on' reads as enabled.
  */
-function pfb_notify_default_for_channel(?string $channel): bool {
-	return $channel === 'nightly';
+function pfb_software_check_enabled(?string $raw): bool {
+	return $raw !== 'off';
 }
 
 /*
  * The notify state machine: TRUE iff a `file_notice` should fire THIS tick.
  *
- * Resolve effective-notify from the knob — 'on' => true, 'off' => false, anything else
- * ('default'/unset) => pfb_notify_default_for_channel($channel) — then notify ONLY when
- * effective-notify AND an update is available (latest > installed) AND we have not
- * already notified for this exact latest ($latest !== $last_notified). The last clause
- * is the per-version de-dupe (ADR-19 §2 "persist last-notified"): a daily cron at the
- * same latest does NOT renotify; a newer latest does.
+ * The single "Check for new versions" boolean ($enabled) gates notifications equally on every
+ * channel: a notice fires ONLY when checking is enabled AND an update is available (latest >
+ * installed) AND we have not already notified for this exact latest ($latest !== $last_notified).
+ * The last clause is the per-version de-dupe (ADR-19 §2 "persist last-notified"): a daily cron at
+ * the same latest does NOT renotify; a newer latest does.
  */
-function pfb_should_notify(?string $installed, ?string $latest, ?string $last_notified, ?string $knob, ?string $channel): bool {
-	if ($knob === 'on') {
-		$effective = true;
-	} elseif ($knob === 'off') {
-		$effective = false;
-	} else {
-		$effective = pfb_notify_default_for_channel($channel);
-	}
-
-	if (!$effective) {
+function pfb_should_notify(?string $installed, ?string $latest, ?string $last_notified, bool $enabled): bool {
+	if (!$enabled) {
 		return false;
 	}
 	if (!pfb_update_available($installed, $latest)) {
@@ -2217,8 +2209,9 @@ function pfb_software_write_cache(array $cache): void {
  *      last_notified = latest (so repeated ticks at the same latest do not renotify).
  *
  * Best-effort throughout: it returns the cache array and never throws, so wiring it into
- * the cron pass can never break a feed update. $force is accepted for the Phase-4 "Check
- * now" button (there is no freshness short-circuit yet, so it is presently a no-op flag).
+ * the cron pass can never break a feed update. $force (the page's "Check now" button) bypasses
+ * the "Check for new versions" enable-gate so a manual check always runs; it never bypasses the
+ * provenance gate, and notifications still require the setting enabled.
  */
 function pfb_software_update_check(bool $force = false, ?array $io = null): array {
 	$io = is_array($io) ? $io : array();
@@ -2235,6 +2228,15 @@ function pfb_software_update_check(bool $force = false, ?array $io = null): arra
 
 	// 2. Provenance gate FIRST — a Netgate-installed build does nothing at all.
 	if (!pfb_software_is_our_build($installed_repo)) {
+		return pfb_software_read_cache();
+	}
+
+	// The single "Check for new versions" setting (default ENABLED) gates the BACKGROUND
+	// (cron) check + notifications. A manual "Check now" ($force) always runs, so a user can
+	// do a one-off check without leaving background checking enabled.
+	$check_raw = config_get_path('installedpackages/pfblockerng/config/0/pfb_software_check', null);
+	$enabled = pfb_software_check_enabled(is_string($check_raw) ? $check_raw : null);
+	if (!$enabled && !$force) {
 		return pfb_software_read_cache();
 	}
 
@@ -2258,7 +2260,6 @@ function pfb_software_update_check(bool $force = false, ?array $io = null): arra
 	}
 
 	$last_notified = $cache_matches_pkg ? (string) ($cache['last_notified'] ?? '') : '';
-	$knob = (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_software_notify', 'default');
 
 	// 4. Refresh the cache. last_notified is written from the scoped value so a cache left
 	// by a different package (channel switch) is reset rather than carried forward.
@@ -2269,7 +2270,7 @@ function pfb_software_update_check(bool $force = false, ?array $io = null): arra
 	$cache['last_notified'] = $last_notified;
 	$cache['last_checked']  = time();
 
-	if (pfb_should_notify($installed, $latest, $last_notified, $knob, $channel)) {
+	if (pfb_should_notify($installed, $latest, $last_notified, $enabled)) {
 		file_notice('pfBlockerNG', "pfBlockerNG {$latest} available ({$channel})", 'pfBlockerNG', '/pfblockerng/pfblockerng_software.php', 1);
 		$cache['last_notified'] = $latest;
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -20,10 +20,10 @@
  * limitations under the License.
  */
 
-// ADR-19: the "Software" page — show the installed pfBlockerNG channel/version vs
-// our-repo latest (from the cron-maintained cache), toggle the new-version notice,
-// and run same-channel Check / Update / Bootstrap actions. Disable NGINX output
-// buffering so the Update/Bootstrap live terminal streams (mirrors _update.php).
+// ADR-19: the "Software" page — show the installed pfBlockerNG channel/version vs our-repo
+// latest (from the cron-maintained cache), toggle the "Check for new versions" setting, and
+// run same-channel Check / Update actions. Disable NGINX output buffering so the Update live
+// terminal streams (mirrors _update.php).
 header("X-Accel-Buffering: no");
 
 require_once('guiconfig.inc');
@@ -48,14 +48,10 @@ if (!pfb_software_provenance_ok()) {
 $pfb_sw_pkgname	= pfb_pkg_installed_name();
 $pfb_sw_channel	= pfb_channel_from_pkgname($pfb_sw_pkgname);
 
-// The notify knob (default|on|off) — persisted to config like the other general knobs.
-$pfb_sw_notify	= (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_software_notify', 'default');
-
-$options_pfb_software_notify = array(
-	'default'	=> 'Default (per channel)',
-	'on'		=> 'On',
-	'off'		=> 'Off'
-);
+// The "Check for new versions" setting (default ENABLED). Persisted as 'on'/'off'; an unset
+// value (never saved) reads as enabled via pfb_software_check_enabled().
+$pfb_sw_check_raw = config_get_path('installedpackages/pfblockerng/config/0/pfb_software_check', null);
+$pfb_sw_check	= pfb_software_check_enabled(is_string($pfb_sw_check_raw) ? $pfb_sw_check_raw : null);
 
 
 // Stream one line to the live terminal window (reuses the _update.php mechanic).
@@ -105,27 +101,26 @@ function pfb_software_run_stream($cmd) {
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Software'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '@self');
 
-// Determine which (POST-guarded) action was requested. Destructive actions
-// (Update/Bootstrap) and the cache-refreshing Check run on POST only — never on a
-// GET (so the ui_render gate's GET cannot trigger pkg).
+// Determine which (POST-guarded) action was requested. The destructive Update and the
+// cache-refreshing Check run on POST only — never on a GET (so the ui_render gate's GET
+// cannot trigger pkg).
 $pfb_sw_action = '';
 if ($_POST && !empty($_POST['pfb_sw_action'])) {
 	$pfb_sw_action = (string) $_POST['pfb_sw_action'];
 }
 
-// "Save" the notify knob (standard pfSense CSRF POST).
+// "Save" the settings (standard pfSense CSRF POST). A checkbox is absent from the POST when
+// unticked, so persist an explicit 'on'/'off' — an unset value defaults to enabled, an
+// explicit 'off' is the user opting out.
 if ($_POST && isset($_POST['save'])) {
-	$notify_post = (string) ($_POST['pfb_software_notify'] ?? 'default');
-	if (!array_key_exists($notify_post, $options_pfb_software_notify)) {
-		$notify_post = 'default';
-	}
-	config_set_path('installedpackages/pfblockerng/config/0/pfb_software_notify', $notify_post);
-	write_config('[pfBlockerNG] save Software notify setting');
+	config_set_path('installedpackages/pfblockerng/config/0/pfb_software_check', isset($_POST['pfb_software_check']) ? 'on' : 'off');
+	write_config('[pfBlockerNG] save Software settings');
 	header('Location: /pfblockerng/pfblockerng_software.php');
 	exit;
 }
 
-// "Check now" — force a cache refresh from our repo, then redisplay.
+// "Check now" — a manual, explicit cache refresh from our repo, then redisplay. $force=true
+// bypasses the "Check for new versions" enable-gate so a one-off check always works.
 if ($pfb_sw_action === 'check') {
 	pfb_software_update_check(true);
 	header('Location: /pfblockerng/pfblockerng_software.php');
@@ -149,18 +144,20 @@ $tab_array[]	= array(gettext('Sync'),	false,	'/pfblockerng/pfblockerng_sync.php'
 pfb_software_add_tab($tab_array, true);
 display_top_tabs($tab_array, true);
 
-// Read the cron-maintained cache for the display state. Empty/unknown renders a
-// clean "not checked yet" — never a warning (the page must pass ui_render on the
-// first GET, before any check has run).
+// Channel + installed version are read LIVE (local `pkg query`, no network) so they are
+// always known on an installed box. Only the our-repo "latest" + status + last-checked come
+// from the cron-maintained cache (empty/unknown renders a clean "Not checked yet" — never a
+// warning — so the page passes ui_render on the first GET, before any check has run).
 $cache		= pfb_software_read_cache();
-$disp_channel	= !empty($cache['channel']) ? $cache['channel'] : ($pfb_sw_channel ?: gettext('unknown'));
-$disp_installed	= !empty($cache['installed']) ? $cache['installed'] : gettext('unknown');
-$disp_latest	= !empty($cache['latest']) ? $cache['latest'] : gettext('not checked yet');
+$installed_ver	= pfb_pkg_installed_version($pfb_sw_pkgname);
+$disp_channel	= $pfb_sw_channel ?: gettext('unknown');
+$disp_installed	= ($installed_ver !== '') ? $installed_ver : gettext('unknown');
+$disp_latest	= !empty($cache['latest']) ? (string) $cache['latest'] : gettext('Not checked yet');
 $disp_checked	= !empty($cache['last_checked'])
 			? date('Y-m-d H:i:s', (int) $cache['last_checked'])
 			: gettext('never');
 
-$update_available = pfb_update_available((string) ($cache['installed'] ?? ''), (string) ($cache['latest'] ?? ''));
+$update_available = pfb_update_available($installed_ver, (string) ($cache['latest'] ?? ''));
 if ($update_available) {
 	$disp_status = '<span class="text-warning">' . gettext('Update available') . '</span>';
 } elseif (!empty($cache['latest'])) {
@@ -170,7 +167,7 @@ if ($update_available) {
 }
 
 // pfb-software-panel — the page-specific render marker (ADR-14 ui_render oracle).
-$form = new Form(false);
+$form = new Form('Save');
 
 $section = new Form_Section('Software Status');
 $section->addInput(new Form_StaticText(
@@ -178,11 +175,11 @@ $section->addInput(new Form_StaticText(
 	'<span id="pfb-software-panel">' . htmlspecialchars((string) $disp_channel) . '</span>'
 ));
 $section->addInput(new Form_StaticText(
-	'Installed Version',
+	'Installed version',
 	htmlspecialchars((string) $disp_installed)
 ));
 $section->addInput(new Form_StaticText(
-	'Latest (our repo)',
+	'Latest version',
 	htmlspecialchars((string) $disp_latest)
 ));
 $section->addInput(new Form_StaticText(
@@ -190,41 +187,22 @@ $section->addInput(new Form_StaticText(
 	$disp_status
 ));
 $section->addInput(new Form_StaticText(
-	'Last Checked',
+	'Last checked',
 	htmlspecialchars((string) $disp_checked)
 ));
 $form->add($section);
 
-$section = new Form_Section('Notification');
-$section->addInput(new Form_Select(
-	'pfb_software_notify',
-	'New-version Notice',
-	$pfb_sw_notify,
-	$options_pfb_software_notify
-))->setHelp('Default: <strong>per channel</strong> &mdash; nightly notifies, stable/devel stay quiet. '
-		. 'Raise a notification when a newer pfBlockerNG build is available on your channel.')
-  ->setAttribute('style', 'width: auto');
-
-$btn_save = new Form_Button(
-	'save',
-	'Save',
-	null,
-	'fa-solid fa-save'
-);
-$btn_save->setAttribute('value', 'save');
-$section->addInput(new Form_StaticText(
-	null,
-	$btn_save
-));
+$section = new Form_Section('Updates');
+$section->addInput(new Form_Checkbox(
+	'pfb_software_check',
+	'Check for new versions',
+	'Periodically check our repository for a newer pfBlockerNG build',
+	$pfb_sw_check
+))->setHelp('When enabled, pfBlockerNG checks our repository for a newer build on your channel and raises a '
+		. 'notification when one is available. Disable to stop the background checks and notifications.');
 $form->add($section);
 
 $section = new Form_Section('Actions');
-$section->addInput(new Form_StaticText(
-	null,
-	gettext('Check refreshes the version cache from your channel. Update installs the latest build on '
-		. 'your CURRENT channel (no cross-channel switch). Bootstrap repo (re)writes the pfBlockerNG '
-		. 'pkg repository so future installs/updates resolve to our build.')
-));
 
 $btn_check = new Form_Button(
 	'pfb_sw_check',
@@ -233,6 +211,10 @@ $btn_check = new Form_Button(
 	'fa-solid fa-arrows-rotate'
 );
 $btn_check->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setWidth(2);
+// A button is a Form_Element, not a Form_Input — wrap each in a Form_StaticText (the
+// established pattern) so it gets its own labelled row + per-line help.
+$section->addInput(new Form_StaticText(null, $btn_check))
+	->setHelp('Refresh the latest-version information from our repository for your channel now.');
 
 $btn_update = new Form_Button(
 	'pfb_sw_update',
@@ -240,24 +222,17 @@ $btn_update = new Form_Button(
 	null,
 	'fa-solid fa-download'
 );
-$btn_update->removeClass('btn-primary')->addClass('btn-warning btn-xs')->setWidth(2)
-	   ->setAttribute('title', gettext('Same-channel upgrade only'));
-
-$btn_bootstrap = new Form_Button(
-	'pfb_sw_bootstrap',
-	'Bootstrap repo',
-	null,
-	'fa-solid fa-screwdriver-wrench'
-);
-$btn_bootstrap->removeClass('btn-primary')->addClass('btn-default btn-xs')->setWidth(2);
-
-$section->addInput(new Form_StaticText(
-	null,
-	$btn_check . $btn_update . $btn_bootstrap
-));
+$btn_update->removeClass('btn-primary')->addClass('btn-warning btn-xs')->setWidth(2);
+// Enabled ONLY when an update is available (a same-channel upgrade has something to do).
+if (!$update_available) {
+	$btn_update->setAttribute('disabled', 'disabled');
+}
+$section->addInput(new Form_StaticText(null, $btn_update))
+	->setHelp('Install the latest build on your current channel (same-channel upgrade only). '
+		. 'Enabled only when an update is available.');
 $form->add($section);
 
-// Live terminal window (shown when an Update/Bootstrap is streaming).
+// Live terminal window (shown when an Update is streaming).
 $section = new Form_Section('Output');
 $section->addInput(new Form_Textarea(
 	'pfb_status',
@@ -275,7 +250,7 @@ $form->add($section);
 
 print($form);
 
-// Destructive actions stream into the terminal AFTER the form has rendered (so the
+// The destructive Update streams into the terminal AFTER the form has rendered (so the
 // textareas exist for the JS to write into). POST-guarded only.
 if ($pfb_sw_action === 'update') {
 	if ($pfb_sw_pkgname === '') {
@@ -287,40 +262,6 @@ if ($pfb_sw_action === 'update') {
 		pfb_software_run_stream("{$bin} upgrade -y {$pkg}");
 		pfb_software_status(gettext('Update task finished.'));
 	}
-} elseif ($pfb_sw_action === 'bootstrap') {
-	pfb_software_status(gettext('Bootstrapping the pfBlockerNG pkg repository...'));
-	// Reproduce add-repo.sh's effect for the current channel (the dev-only script
-	// is not shipped). nightly -> the separate nightly repo; stable/devel share the
-	// release repo (the package, not the repo, is the channel — ADR-19 amendment 2).
-	if ($pfb_sw_channel === 'nightly') {
-		$repo_name = 'pfblockerng-nightly';
-		$conf_name = 'pfblockerng-nightly.conf';
-		$url_subpath = 'nightly/';
-	} else {
-		$repo_name = 'pfblockerng';
-		$conf_name = 'pfblockerng.conf';
-		$url_subpath = '';
-	}
-	$base_url = 'https://pkg.pfblockerng.workers.dev';
-	$conf =	"# pfBlockerNG self-hosted pkg repository (ADR-17). Managed by pfBlockerNG.\n"
-		. "{$repo_name}: {\n"
-		. "  url: \"{$base_url}/{$url_subpath}\${ABI}\",\n"
-		. "  mirror_type: none,\n"
-		. "  signature_type: none,\n"
-		. "  priority: 100,\n"
-		. "  enabled: yes\n"
-		. "}\n";
-	$conf_dir = '/usr/local/etc/pkg/repos';
-	safe_mkdir($conf_dir);
-	if (@file_put_contents("{$conf_dir}/{$conf_name}", $conf, LOCK_EX) === false) {
-		pfb_software_output(gettext('Failed to write the repository conf.'));
-	} else {
-		pfb_software_output(sprintf(gettext('Wrote %s'), "{$conf_dir}/{$conf_name}"));
-		$bin = escapeshellarg(PFB_PKG_BIN);
-		$repo = escapeshellarg($repo_name);
-		pfb_software_run_stream("{$bin} update -r {$repo}");
-	}
-	pfb_software_status(gettext('Bootstrap task finished.'));
 }
 ?>
 
@@ -328,9 +269,8 @@ if ($pfb_sw_action === 'update') {
 //<![CDATA[
 events.push(function() {
 
-	// Wire each action button to a confirm + POST. Update/Bootstrap are
-	// destructive (they run pkg / write a repo conf) so they confirm first;
-	// Check is a cache refresh and posts straight through.
+	// Wire each action button to a POST. Update is destructive (it runs pkg) so it
+	// confirms first; Check is a cache refresh and posts straight through.
 	function pfb_sw_submit(action) {
 		var f = document.forms[0];
 		var i = document.createElement('input');
@@ -349,12 +289,6 @@ events.push(function() {
 		e.preventDefault();
 		if (confirm('Run a same-channel pfBlockerNG update now?')) {
 			pfb_sw_submit('update');
-		}
-	});
-	$('#pfb_sw_bootstrap').click(function(e) {
-		e.preventDefault();
-		if (confirm('(Re)write the pfBlockerNG pkg repository configuration?')) {
-			pfb_sw_submit('bootstrap');
 		}
 	});
 });

--- a/tests/php/SoftwareUpdateCheckTest.php
+++ b/tests/php/SoftwareUpdateCheckTest.php
@@ -30,6 +30,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_software_read_cache')]
 #[CoversFunction('pfb_software_write_cache')]
 #[CoversFunction('pfb_pkg_latest')]
+#[CoversFunction('pfb_software_check_enabled')]
 final class SoftwareUpdateCheckTest extends TestCase
 {
 	private string $dbdir = '';
@@ -47,8 +48,8 @@ final class SoftwareUpdateCheckTest extends TestCase
 		$GLOBALS['pfb_test_pkg_locked']   = false;
 		$GLOBALS['pfb_test_dns_available'] = true;
 
-		// Quiet default knob unless a test overrides it — exercise the channel-aware
-		// default rather than a forced on/off.
+		// No saved setting unless a test overrides it — exercises the DEFAULT (enabled)
+		// state of "Check for new versions" (pfb_software_check unset => enabled).
 		$GLOBALS['config'] = [];
 	}
 
@@ -85,10 +86,10 @@ final class SoftwareUpdateCheckTest extends TestCase
 		return is_array($data) ? $data : null;
 	}
 
-	private function setKnob(string $value): void
+	private function setCheck(string $value): void
 	{
 		$GLOBALS['config'] = [
-			'installedpackages' => ['pfblockerng' => ['config' => [0 => ['pfb_software_notify' => $value]]]],
+			'installedpackages' => ['pfblockerng' => ['config' => [0 => ['pfb_software_check' => $value]]]],
 		];
 	}
 
@@ -115,7 +116,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 	public function testOurBuildRunsCheckWritesCacheAndCanNotify(): void
 	{
 		// Given: no cache yet, no notice yet (before-state).
-		$this->setKnob('on');
+		$this->setCheck('on');
 		$this->assertNull($this->readCache(), 'before: no cache file should exist');
 		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice raised');
 
@@ -147,7 +148,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 	public function testNetgateBuildIsCompleteNoOp(string $repo): void
 	{
 		// Given: ON knob (would notify if the gate let it through), clean before-state.
-		$this->setKnob('on');
+		$this->setCheck('on');
 		$this->assertNull($this->readCache(), 'before: no cache file');
 		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice');
 
@@ -190,7 +191,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 	{
 		// Given: seed a cache as if a prior tick already notified for 3.2.0_9 (a real prior
 		// tick records the pkgname it was for, so the same-package reuse path is taken).
-		$this->setKnob('on');
+		$this->setCheck('on');
 		pfb_software_write_cache([
 			'pkgname'       => 'pfSense-pkg-pfBlockerNG-devel',
 			'channel'       => 'devel',
@@ -226,7 +227,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 	 */
 	public function testNoDnsServesCacheNoNetworkNoNotice(): void
 	{
-		$this->setKnob('on');
+		$this->setCheck('on');
 		pfb_software_write_cache([
 			'pkgname'       => 'pfSense-pkg-pfBlockerNG-devel',
 			'channel'       => 'devel',
@@ -260,7 +261,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 	public function testChannelSwitchDoesNotReuseStaleCache(): void
 	{
 		// Given: a cache from a nightly build that had announced a nightly version.
-		$this->setKnob('on');
+		$this->setCheck('on');
 		pfb_software_write_cache([
 			'pkgname'       => 'pfSense-pkg-pfBlockerNG-nightly',
 			'channel'       => 'nightly',
@@ -288,35 +289,80 @@ final class SoftwareUpdateCheckTest extends TestCase
 	}
 
 	/*
-	 * ---- Knob gating — notice fires exactly when pfb_should_notify says so ----
+	 * ---- "Check for new versions" gating: enabled vs disabled, background vs manual ----
 	 */
 
 	/**
-	 * Given an our-repo build with an update available but the notify knob OFF,
-	 * When the check runs,
-	 * Then the cache is still refreshed (the page always shows latest) but NO notice fires.
-	 * Paired with testOurBuildRunsCheckWritesCacheAndCanNotify (knob on) so the branch is real.
+	 * Given an our-repo build with an update available but the setting DISABLED ('off'),
+	 * When the BACKGROUND check runs (force=false, the cron path),
+	 * Then it is a COMPLETE no-op: no cache is written and no notice fires — the disabled
+	 * setting stops background checking entirely. Paired with the default-enabled and the
+	 * manual-force tests so the gate is proven a real branch, not an always-run path.
 	 */
-	public function testKnobOffRefreshesCacheButSuppressesNotice(): void
+	public function testDisabledBackgroundCheckIsNoOp(): void
 	{
-		$this->setKnob('off');
+		// Given: disabled, clean before-state (no cache, no notice).
+		$this->setCheck('off');
+		$this->assertNull($this->readCache(), 'before: no cache file');
 		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice');
 
-		$cache = pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_9'));
+		// When: a background (non-forced) check with an update nominally available.
+		pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_9'));
 
-		$this->assertSame('3.2.0_9', $cache['latest'], 'after: cache refreshed to latest');
-		$this->assertSame('', (string) ($cache['last_notified'] ?? ''), 'after: last_notified NOT advanced');
-		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: knob off suppresses the notice');
+		// Then: nothing happened — no cache write, no notice.
+		$this->assertNull($this->readCache(), 'after: disabled background check writes NO cache');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: disabled background check raises NO notice');
 	}
 
 	/**
-	 * Given an our-repo build already at the latest (no update),
-	 * When the check runs with the knob ON,
+	 * Given the same disabled setting but a MANUAL "Check now" (force=true),
+	 * When the check runs,
+	 * Then the cache IS refreshed (the explicit one-off check always runs) but NO notice fires
+	 * (notifications still require the setting enabled). Pairs with the background no-op above
+	 * to prove force bypasses ONLY the enable-gate, not the notify gate.
+	 */
+	public function testDisabledManualForceRefreshesCacheButSuppressesNotice(): void
+	{
+		$this->setCheck('off');
+		$this->assertNull($this->readCache(), 'before: no cache file');
+
+		$cache = pfb_software_update_check(true, $this->ourBuildIo('3.2.0_1', '3.2.0_9'));
+
+		$this->assertNotNull($this->readCache(), 'after: a forced manual check writes the cache');
+		$this->assertSame('3.2.0_9', $cache['latest'], 'after: cache refreshed to latest');
+		$this->assertSame('', (string) ($cache['last_notified'] ?? ''), 'after: last_notified NOT advanced');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: disabled setting suppresses the notice');
+	}
+
+	/**
+	 * Given an our-repo build with the setting UNSET (never saved) and an update available,
+	 * When the background check runs,
+	 * Then it behaves as ENABLED by default: the cache is refreshed AND a notice fires. Proves
+	 * the default-enabled path (no explicit 'on' needed) is the real out-of-the-box behaviour.
+	 */
+	public function testDefaultUnsetIsEnabledAndNotifies(): void
+	{
+		// Given: no setting at all (setUp left config empty), clean before-state.
+		$this->assertNull($this->readCache(), 'before: no cache');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice');
+
+		// When.
+		$cache = pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_9'));
+
+		// Then: default-enabled => cache written and a notice raised.
+		$this->assertSame('3.2.0_9', $cache['latest'], 'after: default-enabled refreshes the cache');
+		$this->assertSame('3.2.0_9', $cache['last_notified'], 'after: default-enabled advances last_notified');
+		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'after: default-enabled raises the notice');
+	}
+
+	/**
+	 * Given an our-repo build already at the latest (no update) with checking enabled,
+	 * When the check runs,
 	 * Then the cache is refreshed but no notice fires (nothing newer to announce).
 	 */
 	public function testNoUpdateAvailableRefreshesCacheNoNotice(): void
 	{
-		$this->setKnob('on');
+		$this->setCheck('on');
 
 		$cache = pfb_software_update_check(false, $this->ourBuildIo('3.2.0_9', '3.2.0_9'));
 
@@ -339,7 +385,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 	 */
 	public function testNoticeDeDupesPerVersionAcrossTicks(): void
 	{
-		$this->setKnob('on');
+		$this->setCheck('on');
 
 		// Tick 1: first sight of 3.2.0_9 -> one notice, last_notified advanced.
 		$this->assertNull($this->readCache(), 'before tick 1: no cache');

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_pkg_repo_name_for_channel')]
 #[CoversFunction('pfb_software_is_our_build')]
 #[CoversFunction('pfb_update_available')]
-#[CoversFunction('pfb_notify_default_for_channel')]
+#[CoversFunction('pfb_software_check_enabled')]
 #[CoversFunction('pfb_should_notify')]
 final class SoftwareUpdateDecisionTest extends TestCase
 {
@@ -133,60 +133,50 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	}
 
 	/*
-	 * ---- pfb_notify_default_for_channel() — channel-aware notify default ----
-	 * nightly defaults ON (trackers opted into the tip); stable/devel (and any other)
-	 * default OFF (quiet for release users). Each side asserted so green proves it is a
-	 * real per-channel branch, not an always-value path.
+	 * ---- pfb_software_check_enabled() — the single "Check for new versions" boolean ----
+	 * Default ENABLED: only an explicit 'off' (the user un-ticking the box, persisted by the
+	 * page) disables it. An unset value (null, never saved), 'on', or any other string reads
+	 * as enabled. Both sides asserted so green proves 'off' is a real disabling branch, not an
+	 * always-enabled path.
 	 */
-	public static function notifyDefaultProvider(): array
+	public static function checkEnabledProvider(): array
 	{
 		return [
-			'nightly -> ON'      => ['nightly', true],
-			'stable -> OFF'      => ['stable', false],
-			'devel -> OFF'       => ['devel', false],
-			'unknown -> OFF'     => ['beta', false],
-			'null -> OFF'        => [null, false],
+			'unset (never saved) -> enabled' => [null, true],
+			'on -> enabled'                  => ['on', true],
+			'off -> disabled'                => ['off', false],
+			'empty string -> enabled'        => ['', true],
+			'legacy/other -> enabled'        => ['default', true],
 		];
 	}
 
-	#[DataProvider('notifyDefaultProvider')]
-	public function testNotifyDefaultForChannel(?string $channel, bool $expected): void
+	#[DataProvider('checkEnabledProvider')]
+	public function testCheckEnabled(?string $raw, bool $expected): void
 	{
-		$this->assertSame($expected, pfb_notify_default_for_channel($channel));
+		$this->assertSame($expected, pfb_software_check_enabled($raw));
 	}
 
 	/*
-	 * ---- pfb_should_notify() — the knob x channel-default x available matrix ----
-	 * Effective-notify resolves from the knob ('on' => true, 'off' => false, else the
-	 * channel default), then a notice fires ONLY when effective AND available AND not
-	 * already notified for this latest. This matrix pins the knob override on BOTH sides
-	 * AND the channel default on both sides:
-	 *   - knob 'on' notifies even on stable (default OFF) when available;
-	 *   - knob 'off' suppresses even on nightly (default ON) when available;
-	 *   - knob 'default' yields OFF on stable/devel but ON on nightly (the paired branch
-	 *     proving the default is real), and never notifies when no update is available.
-	 * Every row uses last_notified='' so the de-dupe clause is satisfied — the de-dupe
-	 * lifecycle itself is the dedicated BDD test below.
+	 * ---- pfb_should_notify() — the enabled x available x de-dupe matrix ----
+	 * A notice fires ONLY when checking is enabled AND an update is available AND it has not
+	 * already been notified for this exact latest. The matrix pins each clause on BOTH sides:
+	 *   - enabled true + available + new -> notify;
+	 *   - enabled false suppresses even when available + new (the gate);
+	 *   - enabled true but not available -> silent;
+	 *   - enabled true + available but already notified -> silent (de-dupe).
+	 * Notifications are channel-agnostic now (the single boolean gates every channel equally),
+	 * so there is no per-channel default to assert here.
 	 */
 	public static function shouldNotifyMatrixProvider(): array
 	{
-		// [installed, latest, last_notified, knob, channel, expected]
+		// [installed, latest, last_notified, enabled, expected]
 		return [
-			// knob 'on' overrides the OFF default -> notifies on stable when available.
-			'on + stable + available -> notify'        => ['1.0', '1.1', '', 'on', 'stable', true],
-			'on + stable + not available -> silent'    => ['1.0', '1.0', '', 'on', 'stable', false],
-			// knob 'off' overrides the ON default -> silent on nightly even when available.
-			'off + nightly + available -> silent'      => ['1.0', '1.1', '', 'off', 'nightly', false],
-			// default: OFF on stable/devel (paired) ...
-			'default + stable + available -> silent'   => ['1.0', '1.1', '', 'default', 'stable', false],
-			'default + devel + available -> silent'    => ['1.0', '1.1', '', 'default', 'devel', false],
-			// ... ON on nightly (proves the default is a real branch, not always-OFF) ...
-			'default + nightly + available -> notify'  => ['1.0', '1.1', '', 'default', 'nightly', true],
-			// ... and never when there is no update, regardless of the channel default.
-			'default + nightly + not available -> silent' => ['1.0', '1.0', '', 'default', 'nightly', false],
-			// an unset/foreign knob string resolves to the channel default too.
-			'unset knob + nightly + available -> notify'  => ['1.0', '1.1', '', '', 'nightly', true],
-			'unset knob + stable + available -> silent'   => ['1.0', '1.1', '', '', 'stable', false],
+			'enabled + available + new -> notify'        => ['1.0', '1.1', '', true, true],
+			'disabled + available + new -> silent'       => ['1.0', '1.1', '', false, false],
+			'enabled + not available -> silent'          => ['1.0', '1.0', '', true, false],
+			'disabled + not available -> silent'         => ['1.0', '1.0', '', false, false],
+			'enabled + available + already notified -> silent' => ['1.0', '1.1', '1.1', true, false],
+			'enabled + older latest -> silent'           => ['1.1', '1.0', '', true, false],
 		];
 	}
 
@@ -195,13 +185,12 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		?string $installed,
 		?string $latest,
 		?string $lastNotified,
-		?string $knob,
-		?string $channel,
+		bool $enabled,
 		bool $expected
 	): void {
 		$this->assertSame(
 			$expected,
-			pfb_should_notify($installed, $latest, $lastNotified, $knob, $channel)
+			pfb_should_notify($installed, $latest, $lastNotified, $enabled)
 		);
 	}
 
@@ -209,8 +198,8 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	 * ---- pfb_should_notify() — the per-version de-dupe lifecycle (BDD) ----
 	 *
 	 * Scenario: a daily cron must notify ONCE per new version, not once per tick.
-	 *   Background: knob 'on' (effective-notify true) so only the de-dupe clause varies.
-	 *               installed stays '1.0'; the catalog's latest advances over time.
+	 *   Background: checking ENABLED so only the de-dupe clause varies. installed stays '1.0';
+	 *               the catalog's latest advances over time.
 	 *
 	 *   GIVEN nothing has been notified yet (last_notified empty) and a newer latest 1.1
 	 *    THEN the first tick notifies (the before-state: no prior notice).
@@ -224,20 +213,19 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	public function testShouldNotifyDeDupeLifecycle(): void
 	{
 		$installed = '1.0';
-		$knob = 'on';
-		$channel = 'devel';
+		$enabled = true;
 
 		// GIVEN never-notified + a newer latest 1.1 -> first tick notifies.
 		$lastNotified = '';
 		$this->assertTrue(
-			pfb_should_notify($installed, '1.1', $lastNotified, $knob, $channel),
+			pfb_should_notify($installed, '1.1', $lastNotified, $enabled),
 			'first sighting of 1.1 must notify'
 		);
 
 		// WHEN 1.1 recorded as last_notified -> the SAME tick must not renotify.
 		$lastNotified = '1.1';
 		$this->assertFalse(
-			pfb_should_notify($installed, '1.1', $lastNotified, $knob, $channel),
+			pfb_should_notify($installed, '1.1', $lastNotified, $enabled),
 			'a repeat tick at the already-notified 1.1 must NOT renotify (de-dupe)'
 		);
 
@@ -245,18 +233,18 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		// Before-state: re-assert the 1.1 tick is still suppressed so the flip is caused
 		// by the newer version, not by time.
 		$this->assertFalse(
-			pfb_should_notify($installed, '1.1', $lastNotified, $knob, $channel),
+			pfb_should_notify($installed, '1.1', $lastNotified, $enabled),
 			'before the newer version, 1.1 is still de-duped'
 		);
 		$this->assertTrue(
-			pfb_should_notify($installed, '1.2', $lastNotified, $knob, $channel),
+			pfb_should_notify($installed, '1.2', $lastNotified, $enabled),
 			'a newer 1.2 (not yet notified) must notify again'
 		);
 
 		// WHEN 1.2 recorded -> its repeat tick is de-duped again.
 		$lastNotified = '1.2';
 		$this->assertFalse(
-			pfb_should_notify($installed, '1.2', $lastNotified, $knob, $channel),
+			pfb_should_notify($installed, '1.2', $lastNotified, $enabled),
 			'a repeat tick at the already-notified 1.2 must NOT renotify'
 		);
 	}

--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -134,12 +134,11 @@ SOFTWARE_PAGE_FILE = "/usr/local/www/pfblockerng/pfblockerng_software.php"
 # build ran with ports_ref=adr/19-update-channel-panel).
 SOFTWARE_PANEL_MARKER = "pfb-software-panel"
 
-# The notify config knob the page writes + the orchestrator reads (Phase 3). Driving it
-# off the installed channel (devel) proves the channel-default OFF branch; injecting a
-# nightly channel proves the channel-default ON branch (the nightly repo/package is not
-# in this hermetic CE image, so the nightly CHANNEL is simulated via the orchestrator's
-# documented $io seam — noted in the handoff).
-NOTIFY_KNOB_PATH = "installedpackages/pfblockerng/config/0/pfb_software_notify"
+# The single "Check for new versions" boolean the page writes + the orchestrator reads. It
+# gates the BACKGROUND (cron) check + notifications equally on every channel (default ENABLED);
+# a manual "Check now" (force) always runs. Persisted as 'on'/'off' ('off' = the user opting
+# out; unset reads as enabled).
+SOFTWARE_CHECK_PATH = "installedpackages/pfblockerng/config/0/pfb_software_check"
 
 # Delimiters for reading a single scalar back out of pfSsh.php (its startup banner
 # otherwise pollutes stdout — same pattern as count_matching_notices above).
@@ -711,24 +710,24 @@ def clear_software_state(vm: SmokeVM, *, timeout: float = 30.0) -> None:
     close_all_notices(vm, timeout=120.0)
 
 
-def set_notify_knob(vm: SmokeVM, value: str, *, timeout: float = 120.0) -> None:
-    """Persist ``pfb_software_notify`` (default|on|off) via the real config API.
+def set_software_check(vm: SmokeVM, value: str, *, timeout: float = 120.0) -> None:
+    """Persist ``pfb_software_check`` ('on'|'off') via the real config API.
 
     Mirrors what the page's save POST does — config_set_path + write_config in the
     config-locked pfSsh.php env — so the orchestrator reads the same value the GUI would.
     """
     snippet = (
-        f"config_set_path({_php_str(NOTIFY_KNOB_PATH)}, {_php_str(value)});\n"
-        "write_config('ADR-19 phase-5 smoke: set pfb_software_notify');\necho 'OK';"
+        f"config_set_path({_php_str(SOFTWARE_CHECK_PATH)}, {_php_str(value)});\n"
+        "write_config('ADR-19 phase-5 smoke: set pfb_software_check');\necho 'OK';"
     )
     out = _pfssh(vm, snippet, timeout=timeout)
     if "OK" not in out:
-        raise RuntimeError(f"set_notify_knob did not confirm: {out!r}")
+        raise RuntimeError(f"set_software_check did not confirm: {out!r}")
 
 
-def clear_notify_knob(vm: SmokeVM, *, timeout: float = 120.0) -> None:
-    """Reset the notify knob to its unset/'default' value (the channel-default branch)."""
-    set_notify_knob(vm, "default", timeout=timeout)
+def clear_software_check(vm: SmokeVM, *, timeout: float = 120.0) -> None:
+    """Reset the setting to its unset value (which reads as the default ENABLED state)."""
+    set_software_check(vm, "", timeout=timeout)
 
 
 def php_lint_ok(vm: SmokeVM, path: str, *, timeout: float = 60.0) -> bool:
@@ -764,16 +763,16 @@ def test_software_positive_journey_on_our_repo_install(repo_vm: SmokeVM, tmp_pat
 
     Proves every gate Phase 4 showed HIDDEN is now OPEN, and the publish-newer ->
     de-duped notice + cache + same-channel Update chain works live. Channel here is
-    ``devel`` (the installed ``-devel`` package), whose notify default is OFF — so the
-    knob is forced ``on`` for the notice legs (the channel-default OFF/ON branches are
-    pinned separately in ``test_software_notify_default_is_channel_correct``).
+    ``devel`` (the installed ``-devel`` package); checking is ENABLED for the notice legs
+    (the enable/disable gate is pinned separately in
+    ``test_software_check_setting_gates_background_check``).
 
     Scenario: an our-repo box sees the Software page, gets one notice for a newer build,
     and Update-now pulls it.
       Background: our NONE-signed file:// repo above the Netgate repo; egress open.
 
     Given build ``<V>_1`` installed FROM our repo (the asserted BEFORE: provenance OPEN,
-      page parses + carries its marker, knob=on, NO cache, NO notice),
+      page parses + carries its marker, checking enabled, NO cache, NO notice),
     When the first check runs at installed==latest==``<V>_1``,
     Then the cache records installed==latest==``<V>_1`` and NO notice is raised (up to date).
     When ``<V>_9`` is published to the SAME repo and the check runs,
@@ -839,9 +838,9 @@ def test_software_positive_journey_on_our_repo_install(repo_vm: SmokeVM, tmp_pat
             f"the .pkg did not carry Phase-4's page"
         )
 
-        # GIVEN: a clean state + knob ON; assert the BEFORE (no cache, no notice for high).
+        # GIVEN: a clean state + checking ENABLED; assert the BEFORE (no cache, no notice for high).
         clear_software_state(repo_vm)
-        set_notify_knob(repo_vm, "on")
+        set_software_check(repo_vm, "on")
         assert read_software_cache(repo_vm) == {}, "software cache unexpectedly present before the first check"
         assert count_matching_notices(repo_vm, high) == 0, f"a notice for {high} existed before any check"
 
@@ -889,39 +888,35 @@ def test_software_positive_journey_on_our_repo_install(repo_vm: SmokeVM, tmp_pat
         )
     finally:
         clear_software_state(repo_vm)
-        clear_notify_knob(repo_vm)
+        clear_software_check(repo_vm)
         pkg_delete(repo_vm)
         repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)
 
 
 # --------------------------------------------------------------------------- #
-# (f) Channel-correct notify DEFAULT — the OFF (devel) vs ON (nightly) branch, live
+# (f) "Check for new versions" gating — disabled vs enabled, background vs manual, live
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.timeout(600)  # install + 2 forged builds + several live checks > the 30s cap.
-def test_software_notify_default_is_channel_correct(repo_vm: SmokeVM, tmp_path: Path) -> None:
-    """The notify DEFAULT is driven by the CHANNEL, not an always-path (knob unset/'default').
+@pytest.mark.timeout(600)  # install + 1 forged build + several live checks > the 30s cap.
+def test_software_check_setting_gates_background_check(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """The single "Check for new versions" boolean gates the BACKGROUND (cron) check + notify.
 
-    Pairs the two channel branches so green proves the channel drives the default:
-    ``devel`` (the installed channel) defaults OFF -> a newer build raises NO notice;
-    ``nightly`` defaults ON -> the same newer-build condition raises ONE notice. The
-    nightly *channel* is simulated via the orchestrator's documented ``$io`` seam (a
-    nightly ``installed_name`` + an our-repo ``installed_repo`` so the gate still OPENS):
-    the nightly repo/package is not built into this hermetic CE image (ADR-18), so the
-    CHANNEL-default decision is what is proven end to end (real orchestrator -> real
-    file_notice), not a nightly pkg install. Noted as a simulation in the handoff.
+    Three paired legs, each asserting the before-state, prove every branch is real:
+    disabled vs enabled (the gate), and manual force vs background (force bypasses ONLY the
+    enable-gate, never the notify gate). It is channel-agnostic now — the same boolean gates
+    every channel — so there is no per-channel default to simulate.
 
-    Scenario: a newer build notifies by default ONLY on the nightly channel.
-      Background: our build installed from our repo; the notify knob UNSET ('default').
+    Scenario: an our-repo box controls its own update checks with one switch.
+      Background: ``<V>_1`` installed from our repo, a newer ``<V>_9`` published to it.
 
-    Given build ``<V>_1`` installed from our repo, knob='default', a clean notice state,
-      and a published newer ``<V>_9`` (the asserted BEFORE: no notice for ``<V>_9``),
-    When a check runs as the DEVEL channel (the real installed one),
-    Then NO notice is raised (devel default is OFF).
-    When a check runs as the NIGHTLY channel (same newer-build condition, $io-simulated),
-    Then EXACTLY ONE notice is raised (nightly default is ON) — the same condition, the
-      opposite outcome, so the difference is the channel default and nothing else.
+    Given a clean state and the setting DISABLED ('off'),
+    When a BACKGROUND check (force=false, the cron path) runs,
+    Then it is a complete no-op: no cache is written and no notice fires.
+    When the setting is ENABLED ('on') and a BACKGROUND check runs,
+    Then the cache advances to ``<V>_9`` and EXACTLY ONE notice fires (the enable branch).
+    When the setting is DISABLED again and a MANUAL check (force=true) runs,
+    Then the cache still refreshes but NO additional notice fires (force bypasses only the gate).
     """
     pkg = os.environ.get("SMOKE_PKG")
     assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"
@@ -929,45 +924,45 @@ def test_software_notify_default_is_channel_correct(repo_vm: SmokeVM, tmp_path: 
     base_version = read_compact_version(src)
     low = f"{base_version}_1"
     high = f"{base_version}_9"
-    devel_msg = "available (devel)"
-    nightly_msg = "available (nightly)"
+    msg = "available (devel)"
 
     try:
-        # GIVEN: our-repo install, knob 'default', clean notices, a newer build published.
+        # GIVEN: our-repo install + a newer build published into the same repo.
         install_our_build_at(repo_vm, low, src, tmp_path, "low")
         assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, "build did not come from our repo (gate would be closed)"
         high_pkg = reversion_pkg(src, high, tmp_path / "high")
         build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [high_pkg])
+
+        # DISABLED + BACKGROUND (force=false) -> complete no-op (before: clean).
         clear_software_state(repo_vm)
-        clear_notify_knob(repo_vm)
-        assert count_matching_notices(repo_vm, devel_msg) == 0, "a devel notice existed before the devel check"
-        assert count_matching_notices(repo_vm, nightly_msg) == 0, "a nightly notice existed before the nightly check"
+        set_software_check(repo_vm, "off")
+        assert read_software_cache(repo_vm) == {}, "cache present before the disabled background check"
+        assert count_matching_notices(repo_vm, msg) == 0, "a notice existed before the disabled background check"
+        run_update_check_on_box(repo_vm, force=False)
+        assert read_software_cache(repo_vm) == {}, "disabled background check wrote a cache (must be a no-op)"
+        assert count_matching_notices(repo_vm, msg) == 0, "disabled background check raised a notice"
 
-        # WHEN/THEN (devel, default OFF): a newer build raises NO notice.
-        run_update_check_on_box(repo_vm)
-        assert count_matching_notices(repo_vm, devel_msg) == 0, (
-            "the devel channel notified by default (its default must be OFF)"
+        # ENABLED + BACKGROUND -> cache advances + EXACTLY ONE notice (the paired branch).
+        set_software_check(repo_vm, "on")
+        run_update_check_on_box(repo_vm, force=False)
+        cache = read_software_cache(repo_vm)
+        assert cache.get("latest") == high, (
+            f"enabled background check did not advance latest to {high!r}: {cache.get('latest')!r}"
         )
+        assert count_matching_notices(repo_vm, msg) == 1, "enabled background check did not raise exactly one notice"
 
-        # WHEN/THEN (nightly, default ON): the SAME newer-build condition raises ONE notice.
-        # $io supplies a nightly installed_name (-> channel nightly) + an our-repo
-        # installed_repo (gate OPENS) + the installed/latest version gap; the channel
-        # default (ON) is the only thing that differs from the devel leg above.
-        run_update_check_on_box(
-            repo_vm,
-            io_overrides={
-                "installed_name": "pfSense-pkg-pfBlockerNG-NIGHTLY",
-                "installed_repo": OURS_REPO_NAME,
-                "installed": low,
-                "latest": high,
-            },
-        )
-        assert count_matching_notices(repo_vm, nightly_msg) == 1, (
-            "the nightly channel did NOT notify by default (its default must be ON) — "
-            "the channel does not drive the default"
-        )
+        # DISABLED again + MANUAL force -> cache refreshes, NO additional notice (force bypasses
+        # only the enable-gate). Reset the cache + notices first so each side is asserted clean.
+        clear_software_state(repo_vm)
+        close_all_notices(repo_vm)
+        set_software_check(repo_vm, "off")
+        assert count_matching_notices(repo_vm, msg) == 0, "a notice survived the reset before the forced check"
+        run_update_check_on_box(repo_vm, force=True)
+        cache = read_software_cache(repo_vm)
+        assert cache.get("latest") == high, "forced manual check did not refresh the cache while disabled"
+        assert count_matching_notices(repo_vm, msg) == 0, "forced check notified while the setting was disabled"
     finally:
         clear_software_state(repo_vm)
-        clear_notify_knob(repo_vm)
+        clear_software_check(repo_vm)
         pkg_delete(repo_vm)
         repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)

--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -956,6 +956,7 @@ def test_software_check_setting_gates_background_check(repo_vm: SmokeVM, tmp_pat
         clear_software_state(repo_vm)
         close_all_notices(repo_vm)
         set_software_check(repo_vm, "off")
+        assert read_software_cache(repo_vm) == {}, "cache survived reset before the forced check"
         assert count_matching_notices(repo_vm, msg) == 0, "a notice survived the reset before the forced check"
         run_update_check_on_box(repo_vm, force=True)
         cache = read_software_cache(repo_vm)


### PR DESCRIPTION
## What

Reworks the ADR-19 **Software** page in response to GUI/behaviour feedback (screenshot review). Ten items:

1. **Installed version no longer "unknown"** — channel + installed version are now read **live** (`pkg query`, local/no-network) instead of from the cron cache, so an installed box always shows them. Only `latest`/`status`/`last checked` come from the cache.
2. Consistent casing — the unknown text is unified to **"Not checked yet"** for both Latest and Status.
3. Dropped the **"(our repo)"** qualifier.
4. Sentence-case labels: **"Installed version"**, **"Latest version"** (lower `v`), **"Last checked"**.
5/10. Replaced the per-channel **"New-version Notice"** select with a single boolean **"Check for new versions"** (`pfb_software_check`, **default enabled**), applied **equally on every channel**: enabled ⇒ the background cron check runs and notifies of a newer build; disabled ⇒ neither. (The old per-channel default is gone.)
6. **Standard Save button** (the form's canonical `Save`), not a hand-built one.
7. **Bootstrap repo removed entirely** (button, JS handler, action handler).
8. **Per-line help** for *Check now* / *Update now* (matching the uber-aliases help style).
9. **Update now is disabled** unless an update is available.

Plus (per the decision in chat): the **manual "Check now" always runs** — `force` bypasses only the enable-gate, never the provenance gate or the notify gate.

## Backing logic (`pfblockerng.inc`)

- Removed `pfb_notify_default_for_channel`; added `pfb_software_check_enabled` (only an explicit `'off'` disables — unset/`'on'` ⇒ enabled).
- `pfb_should_notify` now takes a single `bool $enabled` (channel-agnostic).
- `pfb_software_update_check` gates the **background** pass on the setting (`!$enabled && !$force` ⇒ no-op); notifications require `$enabled`; `$force` (manual Check now) bypasses only that gate.

## Tests

- `SoftwareUpdateDecisionTest`: drop the channel-default cases; add `pfb_software_check_enabled` (both sides); rewrite the `pfb_should_notify` matrix + de-dupe lifecycle for the boolean.
- `SoftwareUpdateCheckTest`: disabled-background = complete no-op; disabled + manual `force` = cache refresh, no notice; default-unset = enabled + notifies.
- `tests/smoke/test_software_update.py`: rename the knob helper/key; replace the channel-default journey with an enable/disable + background/force gate test.
- README updated.

## Validation

PHPUnit 552, PHPStan + PHPCS clean, `php -l` clean, pytest 1646, mypy clean, markdownlint clean. The live render/screenshot of the reworked page comes from the `ui_render`/`ui_browser` tiers (dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified software update notifications to a single “Check for new versions” checkbox on the Software tab (enabled by default).
  * Updated actions: “Check now” performs an immediate check; “Update now” applies updates (disabled when none are available).
* **Refactor**
  * Notification behavior is now consistently governed by the checkbox across all channels, including background checks.
  * Background notice behavior differs from manual force refresh: manual refresh can update cached data without triggering a new notice when the checkbox is off.
* **Documentation**
  * Updated the self-hosted update notice wording and behavior notes.
* **Tests**
  * Updated software update decision and smoke coverage to match the new checkbox-based gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->