### PR TITLE
pfblockerng: guard Update action server-side + drop stale README button

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ offers two buttons:
 - **Check now** — refresh the comparison from our repo (reads `pkg … -r <ourrepo>`, never
   the Netgate repo).
 - **Update now** — a **same-channel** `pkg upgrade` of the installed package, streamed live
-  (it never switches channels). Enabled only when an update is available.
+  (it never switches channels). The button is enabled only when an update is available.
 
 > The Software tab, the page, and the update notice are present **only on a build installed
 > from one of our repos** (`pfblockerng` / `pfblockerng-nightly`). On a stock

--- a/README.md
+++ b/README.md
@@ -234,14 +234,12 @@ above), a **Software** tab appears on every pfBlockerNG page
 GUI's "update available" badge, which only ever tracks the Netgate catalog and cannot see
 our builds. The tab shows your current **channel** (stable / devel / nightly) and
 **installed version** against **our repository's latest**, plus the last-checked time, and
-offers three buttons:
+offers two buttons:
 
 - **Check now** — refresh the comparison from our repo (reads `pkg … -r <ourrepo>`, never
   the Netgate repo).
 - **Update now** — a **same-channel** `pkg upgrade` of the installed package, streamed live
-  (it never switches channels).
-- **Bootstrap repo** — (re)write the repo conf for your current channel, the in-GUI
-  equivalent of `add-repo.sh`.
+  (it never switches channels). Enabled only when an update is available.
 
 > The Software tab, the page, and the update notice are present **only on a build installed
 > from one of our repos** (`pfblockerng` / `pfblockerng-nightly`). On a stock

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -251,8 +251,9 @@ print($form);
 // The destructive Update streams into the terminal AFTER the form has rendered (so the
 // textareas exist for the JS to write into). POST-guarded only.
 if ($pfb_sw_action === 'update') {
-	// Re-check availability server-side: the disabled button is client-side only, so a
-	// crafted/stale POST must not run pkg when there is nothing to install.
+	// Defense-in-depth: the "Update now" button is only disabled client-side, so also
+	// refuse the action server-side when there is nothing to install — never run pkg on a
+	// stale/no-op POST. (Request authenticity is enforced by pfSense's CSRF token.)
 	if (!$update_available) {
 		pfb_software_status(gettext('No update is currently available.'));
 	} elseif ($pfb_sw_pkgname === '') {

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -251,7 +251,11 @@ print($form);
 // The destructive Update streams into the terminal AFTER the form has rendered (so the
 // textareas exist for the JS to write into). POST-guarded only.
 if ($pfb_sw_action === 'update') {
-	if ($pfb_sw_pkgname === '') {
+	// Re-check availability server-side: the disabled button is client-side only, so a
+	// crafted/stale POST must not run pkg when there is nothing to install.
+	if (!$update_available) {
+		pfb_software_status(gettext('No update is currently available.'));
+	} elseif ($pfb_sw_pkgname === '') {
 		pfb_software_status(gettext('No pfBlockerNG package detected — cannot update.'));
 	} else {
 		pfb_software_status(gettext('Updating pfBlockerNG...'));


### PR DESCRIPTION
Addresses the **"⚠️ Outside diff range"** CodeRabbit findings that were missed on the now-merged #270 and #271 (both validated against current code — real and in scope):

- **#271** — `pfblockerng_software.php`: the Update action executed `pkg upgrade` on any POST with `pfb_sw_action=update`. The disabled "Update now" button is client-side only, so a crafted or stale POST could trigger a package operation with no update available. Now re-checks `$update_available` **server-side** before running pkg (mirrors the button's enable logic).
- **#270** — `README.md`: the Software-tab docs still listed a removed **"Bootstrap repo"** button. Dropped it ("three buttons" → "two") and noted Update now is enabled only when an update is available.

`php -l` + markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjy4EmVDREkdpeEHHqSgNP)_