### PR TITLE
pfblockerng: check rsync exit status, not exec() output, on feed download

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6679,11 +6679,15 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		}
 		$rsync_src_esc = escapeshellarg("{$rsync_src}");
 
-		$result	= exec("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}");
-		if ($result == 0) {
+		// exec() returns the command's LAST output line, not its exit status; the
+		// real return code rides in the third argument. Test that, so a normal
+		// rsync transfer (which prints progress/stats) is not mistaken for a failure.
+		exec("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}", $rsync_output, $rsync_rc);
+		if ($rsync_rc === 0) {
 			$http_status = '200';
 		} else {
-			$log = "\n  RSYNC Failed...\n";
+			$rsync_msg = trim(implode(' ', $rsync_output));
+			$log = "\n  RSYNC Failed (exit {$rsync_rc})" . ($rsync_msg !== '' ? ": {$rsync_msg}" : '') . "...\n";
 			pfb_logger("{$log}", "{$logtype}");
 			return FALSE;
 		}


### PR DESCRIPTION
## Problem

In the rsync feed-download path (`pfb_download`), the result of `exec("/usr/local/bin/rsync …")` was compared to `0`:

```php
$result = exec("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}");
if ($result == 0) { … }
```

`exec()` returns the command's **last output line** (a string), not its exit status. A successful rsync that prints any progress/stats line yields a non-empty string, so `($result == 0)` is false and the transfer is wrongly reported as `RSYNC Failed`. On PHP 8 an empty-string return no longer loosely equals `0` either, so even a silent success misfires.

## Fix

Capture the real exit code via `exec()`'s third argument and test that:

```php
exec("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}", $rsync_output, $rsync_rc);
if ($rsync_rc === 0) { … }
```

No change to the escaping at the sink. Addresses a CodeRabbit **outside-diff-range** finding originally raised on #215 that was not handled at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuvzvY8VjJ5sR9dqwPLesp)_