### PR TITLE
test: guard the no-variant case against an accidental python* dep too

### DIFF
--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -719,9 +719,15 @@ def test_no_php_no_guard_injected(tmp_path: Path) -> None:
     assert rc == 0
     full, _compact, _tf = _read_pkg(out / "testpkg-1.0_2.pkg")
     dep_names = set(full.get("deps", {}).keys())
-    # foo comes from RUN_DEPENDS; no php* / py* variant guard added (no --php)
+    # foo comes from RUN_DEPENDS; no variant guard is injected without --php. Exclude
+    # both shapes a guard could take: the real Python guard dep is the interpreter
+    # package pythonNNN (e.g. python311 — which does NOT start with "py3"), and the bare
+    # flavor token py311 must never become a dep name either (the --php companion test
+    # asserts that directly). Checking both means an accidental guard of either form
+    # fails this test rather than slipping through.
     assert "foo" in dep_names
     assert not any(n.startswith("php8") for n in dep_names)
+    assert not any(n.startswith("python3") for n in dep_names)
     assert not any(n.startswith("py3") for n in dep_names)
 
 


### PR DESCRIPTION
## Problem

`test_no_php_no_guard_injected` (build without `--php`) asserts that no variant guard dep is injected, but the Python side only excluded `py3*`:

```python
assert not any(n.startswith("py3") for n in dep_names)
```

The Python guard dep is the **real interpreter package** (`pythonNNN`, e.g. `python311`), and `"python311"` does **not** start with `"py3"`. So an accidental Python guard would slip past this assertion — the off-branch test could go green even if the guard regressed.

## Fix

Add a `python3*` exclusion alongside the existing `py3*`/`php8*` ones and align the comment. The companion `--php` test already asserts the guard IS `python311` on the on-branch, so this closes the off-branch gap.

Test-only change; the affected test passes against current `devel`. Addresses a CodeRabbit **outside-diff-range** finding originally raised on #249 that was not handled at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuvzvY8VjJ5sR9dqwPLesp)_