### PR TITLE
pfblockerng: give the DNSBL TLD_Allow block its feed band

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5138,6 +5138,12 @@ def evaluate_domain(
             is_found = True
             feed = "TLD_Allow"
             group = "DNSBL_TLD_Allow"
+            # Feed-stratum block band (mirrors the IDN arms below): without it
+            # block_band stays 0, and the numeric important_rules resolution
+            # (_resolve_numeric_allow: blocked iff block_band > allow_band) would treat
+            # band 0 as already overridden by any allow (allow_band >= 0 is always true),
+            # so a disallowed-TLD query would resolve instead of being blocked.
+            block_band = PRIO_FEED_BLOCK
 
         # ADR-08: the IDN feed. ``idn_mode`` is the three-valued selector (off/all/
         # confusable); derive it from the legacy cfg["python_idn"] when a cfg predates

--- a/tests/test_adr07_matcher_strata.py
+++ b/tests/test_adr07_matcher_strata.py
@@ -274,6 +274,59 @@ class TestNumericBandResolution:
         assert self._decide(False, {}, {"r": r"benign"}) is False
 
 
+# --------------------------------------------------------------------------- #
+# TLD_Allow under the numeric (important_rules True) path.
+#
+# A disallowed-TLD hit is a feed-stratum BLOCK, so it must carry the feed band.
+# Regression guard: the TLD_Allow arm used to leave block_band at 0, and the
+# numeric resolution (blocked iff block_band > allow_band) then treated band 0 as
+# already overridden by any allow (allow_band >= 0 is always true) -- so a
+# disallowed-TLD query RESOLVED instead of being blocked once important_rules
+# engaged. With the band set, a no-allow case stays blocked.
+# --------------------------------------------------------------------------- #
+class TestTldAllowNumericBand:
+    """Scenario: a query whose TLD is not on the TLD-allow list stays blocked even
+    when the numeric ``important_rules`` resolution is engaged.
+
+    Background: ``python_tld`` on with allow-list ``{"com"}``; ``important_rules`` True
+    (an ABP ``@@`` / feed-regex / ``$important`` rule is loaded); no data/zone/regex hit.
+    """
+
+    def _decide(self, tld: str, allow_regex_db: dict) -> Any:
+        import re
+
+        cfg = _cfg(
+            python_tld=True,
+            python_tlds=["com"],
+            allowRegexDB=bool(allow_regex_db),
+            important_rules=True,
+        )
+        compiled = {k: (re.compile(v) if isinstance(v, str) else v) for k, v in allow_regex_db.items()}
+        containers = _containers(allowRegexDB=compiled)
+        return evaluate_domain(f"host.{tld}", f"host.{tld}", tld, False, cfg, containers)
+
+    def test_disallowed_tld_block_stands_with_no_allow(self) -> None:
+        # When: TLD "xyz" is not on the allow-list and NO allow rule matches.
+        dec = self._decide("xyz", {})
+        # Then: a real TLD_Allow block the numeric resolution lets STAND (in_whitelist
+        # False). This is the regression discriminator -- with block_band left at 0 the
+        # zero-allow case (allow_band 0 >= block_band 0) would mark it overridden -> resolve.
+        assert dec.is_found is True
+        assert dec.feed == "TLD_Allow"
+        assert dec.in_whitelist is False
+
+    def test_allowed_tld_is_not_a_block(self) -> None:
+        # Off side of the branch: a TLD on the allow-list is NOT a TLD_Allow hit.
+        dec = self._decide("com", {})
+        assert dec.is_found is False
+
+    def test_feed_allow_still_overrides_the_tld_block(self) -> None:
+        # Band ceiling: the TLD_Allow block is exactly the feed-block band (1), so a
+        # band-2 feed allow still wins -- the band is set, not over-promoted.
+        dec = self._decide("xyz", {"r": r"host"})
+        assert dec.in_whitelist is True
+
+
 class TestUserRegexSovereign:
     """A USER regex is band 5 (user block): it beats ANY feed allow (@@ band 2 /
     @@$important band 4) but still loses to the user whitelist (band 6).


### PR DESCRIPTION
## Problem

In `evaluate_domain`, the **TLD_Allow** arm marks a query whose TLD is not on the allow-list as a block (`is_found = True`, `feed = "TLD_Allow"`) but left `block_band` at its `0` default.

Once `important_rules` is engaged (an ABP `@@` / feed-regex / `$important` rule is loaded), resolution takes the numeric 6-band path: `_resolve_numeric_allow` returns blocked iff `block_band > allow_band`. With `block_band == 0` and `allow_band >= 0` always true, the TLD_Allow block is treated as **already overridden** — so a disallowed-TLD query **resolves instead of being blocked**. The IDN arms just below already set `block_band = PRIO_FEED_BLOCK` for exactly this reason.

## Fix

Set the feed-stratum band (`block_band = PRIO_FEED_BLOCK`) in the TLD_Allow arm, mirroring the IDN arms.

## Test (before/after)

`TestTldAllowNumericBand` in `tests/test_adr07_matcher_strata.py`:
- **no-allow case stays blocked** (`in_whitelist` False) — the regression discriminator: on the band-0 code this asserts `True` and **fails** (verified — `DnsblDecision(..., in_whitelist=True ...)`), and passes with the band set;
- **allowed-TLD case is not a block** (off side of the branch);
- **a band-2 feed allow still overrides** the TLD_Allow block — proving the band is set to the feed-block band, not over-promoted.

Full suite green (1650 passed), ruff + mypy clean. Addresses a CodeRabbit **outside-diff-range** finding originally raised on #136 that was not handled at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuvzvY8VjJ5sR9dqwPLesp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected TLD-Allow resolution so disallowed TLD matches no longer start from an ineffective “band 0” state, preventing allow logic from incorrectly overriding them.

* **Tests**
  * Added new test coverage for numeric (6-band) TLD-Allow behavior with `important_rules=True`, including cases for allowed vs. disallowed TLDs and interactions with feed allow rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->