### PR TITLE
pfblockerng: drop unused mod_auth from DNSBL lighttpd conf (#266)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3255,15 +3255,15 @@ EOF;
 
 	if (file_exists('/usr/local/lib/lighttpd/mod_openssl.so')) {
 		if ($pfb['dnsbl_py_nolog'] == 'on') {
-			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_auth", "mod_accesslog", "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
+			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_accesslog", "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
 		} else {
-			$pfb_conf .= 'server.modules			= ( "mod_auth", "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
+			$pfb_conf .= 'server.modules			= ( "mod_fastcgi", "mod_rewrite", "mod_openssl" )';
 		}
 	} else {
 		if ($pfb['dnsbl_py_nolog'] == 'on') {
-			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_auth", "mod_accesslog", "mod_fastcgi", "mod_rewrite" )';
+			$pfb_conf .= 'server.modules			= ( "mod_access", "mod_accesslog", "mod_fastcgi", "mod_rewrite" )';
 		} else {
-			$pfb_conf .= 'server.modules			= ( "mod_auth", "mod_fastcgi", "mod_rewrite" )';
+			$pfb_conf .= 'server.modules			= ( "mod_fastcgi", "mod_rewrite" )';
 		}
 	}
 

--- a/tests/php/CreateLighttpdModulesTest.php
+++ b/tests/php/CreateLighttpdModulesTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_create_lighttpd() — pins the server.modules list emitted for the DNSBL
+ * lighttpd configuration.
+ *
+ * Two facts this test enforces:
+ *   (1) mod_auth is ABSENT from every server.modules line — it was loaded in all
+ *       four variants but never referenced by any auth.* directive; removing it is
+ *       the fix for issue #266.
+ *   (2) The py_nolog flag drives a real branch: 'off' produces no access-log modules
+ *       (mod_access / mod_accesslog absent); 'on' adds them (mod_access +
+ *       mod_accesslog present). Both sides are asserted before/after the flip so the
+ *       test fails on a regression, not just on coverage.
+ *
+ * On the CI runner (no lighttpd binary, no /usr/local/lib/lighttpd/mod_openssl.so)
+ * the function deterministically exercises the non-openssl branches. Those are the
+ * two branches asserted here; the openssl variants are structurally identical — the
+ * module-list logic is the same conditional, so the non-openssl gate is sufficient.
+ */
+#[CoversFunction('pfb_create_lighttpd')]
+final class CreateLighttpdModulesTest extends TestCase
+{
+	private array $originalPfb = [];
+	private bool $hadPfb       = false;
+
+	protected function setUp(): void
+	{
+		$this->hadPfb     = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+
+		// Minimal keys pfb_create_lighttpd() reads from $pfb.
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dnsbl_iface'    => 'lo0',
+			'dnsbl_vip4'     => '10.10.10.1',
+			'dnsbl_port'     => '8081',
+			'dnsbl_port_ssl' => '8443',
+			'dnsbl_vip6'     => '',
+			'dnsbl_py_nolog' => 'off',
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+	}
+
+	/**
+	 * Extract the server.modules line from a generated lighttpd conf string.
+	 * Returns the raw line (trimmed) so assertions are on the exact emitted text.
+	 */
+	private function modulesLine(string $conf): string
+	{
+		foreach (explode("\n", $conf) as $line) {
+			if (strpos($line, 'server.modules') !== false) {
+				return trim($line);
+			}
+		}
+		return '';
+	}
+
+	// -------------------------------------------------------------------------
+	// py_nolog OFF — logging modules absent; mod_auth absent (regression guard).
+	// -------------------------------------------------------------------------
+
+	public function testNologOffOmitsAccessLogModulesAndModAuth(): void
+	{
+		// Given: py_nolog is off (the before-state).
+		$GLOBALS['pfb']['dnsbl_py_nolog'] = 'off';
+
+		// When: conf is generated.
+		$conf    = pfb_create_lighttpd();
+		$modules = $this->modulesLine($conf);
+
+		// Then: core modules are present.
+		$this->assertStringContainsString('"mod_fastcgi"', $modules,
+			'mod_fastcgi must be present when py_nolog=off');
+		$this->assertStringContainsString('"mod_rewrite"', $modules,
+			'mod_rewrite must be present when py_nolog=off');
+
+		// Access-log modules must NOT appear (logging is disabled).
+		$this->assertStringNotContainsString('"mod_access"', $modules,
+			'mod_access must be absent when py_nolog=off');
+		$this->assertStringNotContainsString('"mod_accesslog"', $modules,
+			'mod_accesslog must be absent when py_nolog=off');
+
+		// Regression guard — mod_auth must be absent (dead config removed in #266).
+		$this->assertStringNotContainsString('"mod_auth"', $modules,
+			'mod_auth must not appear in server.modules (issue #266: no auth.* directive uses it)');
+	}
+
+	// -------------------------------------------------------------------------
+	// py_nolog ON — before/after: proves the flag is a live branch, not dead code.
+	// -------------------------------------------------------------------------
+
+	public function testNologOnAddsAccessLogModulesAndStillOmitsModAuth(): void
+	{
+		// Given: start with py_nolog off (before-state asserted explicitly).
+		$GLOBALS['pfb']['dnsbl_py_nolog'] = 'off';
+		$confBefore    = pfb_create_lighttpd();
+		$modulesBefore = $this->modulesLine($confBefore);
+
+		// Before: access-log modules absent (same as the dedicated off-test above,
+		// but re-asserted here so the flip has an observable before-state).
+		$this->assertStringNotContainsString('"mod_access"', $modulesBefore,
+			'before: mod_access absent with py_nolog=off');
+		$this->assertStringNotContainsString('"mod_accesslog"', $modulesBefore,
+			'before: mod_accesslog absent with py_nolog=off');
+
+		// When: py_nolog is flipped to on.
+		$GLOBALS['pfb']['dnsbl_py_nolog'] = 'on';
+		$confAfter    = pfb_create_lighttpd();
+		$modulesAfter = $this->modulesLine($confAfter);
+
+		// Then: access-log modules now appear (the flip caused the change).
+		$this->assertStringContainsString('"mod_access"', $modulesAfter,
+			'after: mod_access must be present when py_nolog=on');
+		$this->assertStringContainsString('"mod_accesslog"', $modulesAfter,
+			'after: mod_accesslog must be present when py_nolog=on');
+
+		// Core modules still present.
+		$this->assertStringContainsString('"mod_fastcgi"', $modulesAfter,
+			'mod_fastcgi must be present when py_nolog=on');
+		$this->assertStringContainsString('"mod_rewrite"', $modulesAfter,
+			'mod_rewrite must be present when py_nolog=on');
+
+		// Regression guard — mod_auth absent in the on-branch too.
+		$this->assertStringNotContainsString('"mod_auth"', $modulesAfter,
+			'mod_auth must not appear in server.modules with py_nolog=on (issue #266)');
+	}
+}


### PR DESCRIPTION
Fixes #266.

## What

`pfb_create_lighttpd()` loaded `mod_auth` in every `server.modules` list, but no `auth.*` directive (`auth.require`/`auth.backend`/…) exists anywhere in the generated DNSBL lighttpd conf — the module is loaded and never used. It is a leftover from the pre-Python DNSBL webserver. This drops `mod_auth` from all four variants (openssl-present/absent × `py_nolog` on/off).

## Scope note

The issue (permalink anchoring `pfb_create_lighttpd()`) asked to remove "remnants of the old unbound mode." The substantive old-mode gate — `dnsbl_py_blacklist` — is **already gone on `devel`** (it still gates the webserver-logging blocks on `main`). `mod_auth` is the one genuinely-dead directive that survived. The `dnsbl_py_nolog` logging path, the `$SERVER["socket"]` blocks (each opens a real listening socket), and the `url.rewrite-once` blocks are functional and left untouched.

## Test

New `tests/php/CreateLighttpdModulesTest.php` pins the `server.modules` list against the real `pfb_create_lighttpd()`:

- asserts `mod_auth` is absent in both `py_nolog` states (the regression guard for this fix), and
- covers the `py_nolog` branch both ways with the before-state asserted — off omits `mod_access`/`mod_accesslog`, on adds them — so green proves the flip caused the change.

Verified the test fails on the pre-fix code (with `mod_auth` re-added) and passes after. Full PHPUnit suite green (554 tests); PHPStan + PHPCS clean.

The openssl-present variants are not exercised on the Linux CI runner (no `mod_openssl.so`); they are the same conditional and structurally identical — documented in the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014DaX5qd8aRsawyRhxzDSRh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated web server module configuration to conditionally load access and logging modules based on DNS blacklist logging settings.
  * Removed authentication module from web server default configuration.

* **Tests**
  * Added test coverage for web server module selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->