### PR TITLE
pfblockerng: truncate logs in place to preserve inode (#264)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1751,16 +1751,39 @@ function pfb_log_mgmt() {
 				}
 
 				if (file_exists($final_log_file)) {
-					exec("/usr/bin/tail -n " . escapeshellarg($logmax) . " " . escapeshellarg($final_log_file) . " > " . escapeshellarg($temp));
-					@chown($temp, 'unbound');
-					@chgrp($temp, 'unbound');
-					exec("/bin/mv -f " . escapeshellarg($temp) . " " . escapeshellarg($final_log_file));
+					// Truncate in place to preserve the inode (#264): mv replaces the
+					// inode, so a remote syslog shipper keyed on (inode, offset) treats
+					// it as a rotation and re-sends the whole log. cat over '>' keeps the
+					// same inode - the file just shrinks - and so keeps its ownership.
+					// Gate on each exit code: unlike the atomic mv, '>' truncates first,
+					// so a failed tail/cat must not be allowed to leave an empty/partial log.
+					exec("/usr/bin/tail -n " . escapeshellarg($logmax) . " " . escapeshellarg($final_log_file) . " > " . escapeshellarg($temp), $out, $ret);
+					if ($ret === 0) {
+						exec("/bin/cat " . escapeshellarg($temp) . " > " . escapeshellarg($final_log_file), $out, $ret);
+						if ($ret === 0) {
+							@chown($final_log_file, 'unbound');
+							@chgrp($final_log_file, 'unbound');
+						} else {
+							pfb_logger("\npfb_log_mgmt: failed to overwrite {$final_log_file} during truncation", 2);
+						}
+					} else {
+						pfb_logger("\npfb_log_mgmt: failed to tail {$final_log_file} for truncation", 2);
+					}
 				}
 			}
 			else {
 				$temp = tempnam("{$g['tmp_path']}/", 'pfb_log_');
-				exec("/usr/bin/tail -n " . escapeshellarg($logmax) . " {$pfb[$logtype]} > " . escapeshellarg($temp));
-				exec("/bin/mv -f " . escapeshellarg($temp) . " {$pfb[$logtype]}");
+				// Truncate in place to preserve the inode (#264) - see above. Gate on
+				// each exit code so a failed tail/cat cannot truncate the live log.
+				exec("/usr/bin/tail -n " . escapeshellarg($logmax) . " {$pfb[$logtype]} > " . escapeshellarg($temp), $out, $ret);
+				if ($ret === 0) {
+					exec("/bin/cat " . escapeshellarg($temp) . " > {$pfb[$logtype]}", $out, $ret);
+					if ($ret !== 0) {
+						pfb_logger("\npfb_log_mgmt: failed to overwrite {$pfb[$logtype]} during truncation", 2);
+					}
+				} else {
+					pfb_logger("\npfb_log_mgmt: failed to tail {$pfb[$logtype]} for truncation", 2);
+				}
 			}
 			unlink_if_exists($temp);
 		}


### PR DESCRIPTION
Fixes #264

## Problem

`pfb_log_mgmt()` capped each log file by writing its last N lines to a temp file and `mv`'ing that over the original. `mv` is `rename(2)`: it swaps in a new inode and unlinks the old one. A remote syslog shipper that keys its state on `(inode, offset)` — syslog-ng `file()` + `follow()`, rsyslog `imfile`, Vector, Fluent Bit, pfelk, Wazuh, etc. — sees the inode change as a log rotation and re-reads from offset 0, re-sending the entire (now truncated-to-last-N) log to the remote destination on every trim.

## Fix

Overwrite the file in place instead of replacing it: `cat temp > file`. The shell `>` redirection truncates the **existing** inode and rewrites it, so the file simply shrinks — well-behaved shippers see "same file, smaller" rather than a rotation. Applied to both branches of `pfb_log_mgmt()` (the chroot DNS-log branch and the generic log branch).

Because the inode (and therefore its ownership) is now preserved, the chroot DNS-log branch `chown`s the **final file** rather than the throwaway temp, which `mv` previously turned into the final file. The trailing `unlink_if_exists($temp)` now cleans up the temp (which `cat` reads but does not consume).

## Notes

- Shell-only, minimal change — no behavioural change to the truncation result; only the inode is preserved.
- No `exec` surface added/removed in a PFBL-01-scoped function (`pfb_log_mgmt` is not allow-listed), so the RequirePfbFilter sniff is unaffected.
- The runtime filesystem behaviour (inode preservation across a trim) is exercised by the live-VM smoke path, not the off-appliance unit suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqzVpusF6f4zSPWAiMY5K6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log truncation and rotation handling to preserve existing log files by overwriting content instead of replacing them, reducing the risk of inconsistencies during routine maintenance.
  * Enhanced DNSBL-related log updates to ensure correct ownership/permissions are applied after truncation.
  * Added more robust success/failure handling for log read/write operations to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->