### PR TITLE
test(php): cover symlink cases in local-file feed-path validation (PFBL-02)

### DIFF
--- a/tests/php/FeedUrlLocalFileTest.php
+++ b/tests/php/FeedUrlLocalFileTest.php
@@ -125,6 +125,17 @@ final class FeedUrlLocalFileTest extends TestCase
 			$this->markTestSkipped('cannot create an out-of-bounds target file');
 		}
 
+		// Make the "outside" precondition explicit and deterministic: if this
+		// environment's temp dir happens to resolve INSIDE the allowed dir, the
+		// rejection below would not be exercised, so skip rather than assert.
+		$real_dir     = realpath($dir);
+		$real_outside = realpath($outside);
+		if ($real_dir === false || $real_outside === false ||
+		    str_starts_with($real_outside, rtrim($real_dir, '/') . '/')) {
+			@unlink($outside);
+			$this->markTestSkipped('temp target is not outside the allowed dir in this environment');
+		}
+
 		$link = $dir . '/pfb_symlink_escape_' . getmypid() . '.txt';
 		@unlink($link);
 		if (!@symlink($outside, $link)) {

--- a/tests/php/FeedUrlLocalFileTest.php
+++ b/tests/php/FeedUrlLocalFileTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
  *   - a path with '..' that realpath-escapes an allowed dir   -> REJECTED
  *   - a redundant-separator variant of an escaping path       -> REJECTED
  *   - a non-existent path (realpath() returns FALSE)          -> REJECTED
+ *   - a symlink in an allowed dir pointing OUTSIDE it         -> REJECTED
+ *   - a symlink in an allowed dir whose target is in-bounds   -> ALLOWED
  *   - a real regular file DIRECTLY under an allowed dir       -> ALLOWED
  *
  * The ALLOWED case needs a real file under a real allowed directory (the allow-list
@@ -99,6 +101,83 @@ final class FeedUrlLocalFileTest extends TestCase
 			$this->assertTrue($this->validate($file), 'a real file directly in an allowed dir must be allowed');
 		} finally {
 			@unlink($file);
+		}
+	}
+
+	/**
+	 * A symlink placed INSIDE an allowed directory but pointing OUTSIDE it must be
+	 * rejected: realpath() resolves the link to its target, whose canonical directory
+	 * is not in the allow-list. Paired with the in-bounds symlink test below, this proves
+	 * the verdict follows the canonical TARGET location, not the link's own path — the
+	 * core reason canonicalization is required. Skips (does not fail) when the environment
+	 * cannot create the allowed dir, the out-of-bounds target, or the symlink.
+	 */
+	public function testSymlinkEscapingAllowedDirRejected(): void
+	{
+		$dir = '/var/db/pfblockerng/deny';
+		if (!@is_dir($dir) && !@mkdir($dir, 0o755, true) && !@is_dir($dir)) {
+			$this->markTestSkipped("cannot create allowed dir {$dir} in this environment");
+		}
+
+		// Target OUTSIDE every allowed dir.
+		$outside = tempnam(sys_get_temp_dir(), 'pfb_outside_');
+		if ($outside === false) {
+			$this->markTestSkipped('cannot create an out-of-bounds target file');
+		}
+
+		$link = $dir . '/pfb_symlink_escape_' . getmypid() . '.txt';
+		@unlink($link);
+		if (!@symlink($outside, $link)) {
+			@unlink($outside);
+			$this->markTestSkipped('cannot create a symlink in this environment');
+		}
+
+		try {
+			$this->assertFalse(
+				$this->validate($link),
+				'a symlink inside an allowed dir pointing outside it must be rejected'
+			);
+		} finally {
+			@unlink($link);
+			@unlink($outside);
+		}
+	}
+
+	/**
+	 * The companion in-bounds case: a symlink inside an allowed dir whose target is a
+	 * regular file ALSO directly under an allowed dir is accepted. Establishes that the
+	 * rejection above is caused by the target ESCAPING the allow-list, not by the input
+	 * merely being a symlink — without it, an "always reject symlinks" implementation
+	 * would pass the escape test for the wrong reason. Skips when the environment cannot
+	 * create the files/link.
+	 */
+	public function testSymlinkWithinAllowedDirAccepted(): void
+	{
+		$dir = '/var/db/pfblockerng/deny';
+		if (!@is_dir($dir) && !@mkdir($dir, 0o755, true) && !@is_dir($dir)) {
+			$this->markTestSkipped("cannot create allowed dir {$dir} in this environment");
+		}
+
+		$target = $dir . '/pfb_symlink_target_' . getmypid() . '.txt';
+		if (@file_put_contents($target, "test\n") === false) {
+			$this->markTestSkipped("cannot write {$target} in this environment");
+		}
+
+		$link = $dir . '/pfb_symlink_inbounds_' . getmypid() . '.txt';
+		@unlink($link);
+		if (!@symlink($target, $link)) {
+			@unlink($target);
+			$this->markTestSkipped('cannot create a symlink in this environment');
+		}
+
+		try {
+			$this->assertTrue(
+				$this->validate($link),
+				'a symlink whose target is a regular file directly in an allowed dir must be allowed'
+			);
+		} finally {
+			@unlink($link);
+			@unlink($target);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds regression coverage to the `PFB_FILTER_URL` **local-file branch** suite
(`tests/php/FeedUrlLocalFileTest.php`). The branch already canonicalizes the
operator-supplied feed path with `realpath()` before requiring it to sit directly
in a hardcoded allowed directory (PFBL-02 Phase 2); these tests pin that the
verdict follows the canonical, symlink-resolved **target** location rather than
the link's own path.

Two new cases:

- **Escaping symlink → REJECTED** — a symlink placed inside an allowed dir but
  pointing outside it. `realpath()` resolves to the out-of-bounds target, whose
  directory is not in the allow-list. This would wrongly pass if the literal link
  path were matched, so it is a genuine guard for the canonicalization step.
- **In-bounds symlink → ALLOWED** — the companion case: a symlink whose target is
  a regular file also directly under an allowed dir. Establishes the rejection
  above is caused by the target escaping the allow-list, not by the input merely
  being a symlink (rules out an "always reject symlinks" false pass).

Both skip (do not fail) when the environment cannot create the allowed dir,
target, or symlink — consistent with the existing filesystem-dependent case.

## Verification

- `vendor/bin/phpunit` — 604 passed (`FeedUrlLocalFileTest`: 6 tests / 7
  assertions, the two new cases exercised, not skipped)
- `vendor/bin/phpstan analyse` — no errors
- Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4G8PSiJyE6v6Y5yed8ywE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for local file validation by adding symlink-specific cases: symlinks that resolve outside allowed directories are now explicitly verified as rejected, while symlinks that resolve within allowed directories are verified as accepted. This strengthens confidence in security hardening for path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->