### PR TITLE
pfblockerng: validate Force Reload option against allowed values

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -323,6 +323,18 @@ function pfb_valid_vtype($vtype) {
 	return ($vtype === '_v4' || $vtype === '_v6');
 }
 
+// Normalise the user-supplied 'Force Reload' option to one of its only
+// legitimate values — 'All', 'IP', 'DNSBL' — returning 'All' for any absent,
+// non-string, or unexpected input. Used to validate $_POST['pfb_reload_option']
+// at the pfblockerng_update.php input boundary before it reaches the status
+// display, the reload-type switch, or the log line. Exact-match only.
+function pfb_reload_option_value($value) {
+	if (is_string($value) && in_array($value, array('All', 'IP', 'DNSBL'), TRUE)) {
+		return $value;
+	}
+	return 'All';
+}
+
 // Function to filter/sanitize user input
 function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE) {
 	global $pfb;

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -131,6 +131,12 @@ if ($_POST) {
 	$pconfig = $_POST;
 }
 
+// Validate the user-supplied 'Force Reload' option against its allowed values,
+// defaulting to 'All' for any unexpected input.
+if (isset($pconfig['pfb_reload_option'])) {
+	$pconfig['pfb_reload_option'] = pfb_reload_option_value($pconfig['pfb_reload_option']);
+}
+
 // Load Wizard settings and reload pfBlockerNG
 $pfb_wizard = FALSE;
 if (isset($_GET) && isset($_GET['wizard']) && $_GET['wizard'] == 'reload') {

--- a/tests/php/PfbReloadOptionValueTest.php
+++ b/tests/php/PfbReloadOptionValueTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_reload_option_value() — normalises $_POST['pfb_reload_option'] to one
+ * of the only three legitimate values ('All', 'IP', 'DNSBL'), defaulting to
+ * 'All' for any absent, non-string, or unexpected input. Exact-match only.
+ */
+#[CoversFunction('pfb_reload_option_value')]
+final class PfbReloadOptionValueTest extends TestCase
+{
+	public static function reloadOptionProvider(): array
+	{
+		return [
+			// Allowed — each of the three legitimate values passes through unchanged.
+			"'All' passes through"  => ['All',   'All'],
+			"'IP' passes through"   => ['IP',    'IP'],
+			"'DNSBL' passes through" => ['DNSBL', 'DNSBL'],
+			// Rejected — every non-allowlisted input class normalises to 'All'.
+			'empty string normalises to All'       => ['',                         'All'],
+			'lowercase all normalises to All'      => ['all',                      'All'],
+			'unknown token normalises to All'      => ['Bogus',                    'All'],
+			'XSS payload normalises to All'        => ['<script>alert(1)</script>', 'All'],
+			'value with whitespace normalises to All' => [' All ',                 'All'],
+		];
+	}
+
+	#[DataProvider('reloadOptionProvider')]
+	public function testReloadOptionAllowlist(mixed $input, string $expected): void
+	{
+		$this->assertSame($expected, pfb_reload_option_value($input));
+	}
+}


### PR DESCRIPTION
## Summary

The `pfb_reload_option` value POSTed to `pfblockerng_update.php` was passed to the status display, the reload-type `switch`, and the log line without any input validation. This constrains it at the input boundary to its only legitimate values — `All`, `IP`, `DNSBL` — defaulting to `All` for any absent, non-string, or unexpected input.

## Changes

- `pfblockerng.inc`: add `pfb_reload_option_value()` — a small allowlist normaliser mirroring the existing `pfb_valid_vtype()`.
- `pfblockerng_update.php`: normalise `$pconfig['pfb_reload_option']` right after the `$_POST` copy, before any consumer reads it.
- `tests/php/PfbReloadOptionValueTest.php`: PHPUnit coverage — each allowed value passes through unchanged (proving it is not an always-`All` path), and each rejected class (empty, lowercase `all`, unknown token, markup payload, whitespace-padded) normalises to `All`.

The existing output-side `htmlspecialchars()` in `pfbupdate_status()` is unchanged; with the value now a fixed three-literal set it is belt-and-suspenders.

## Tests

`php -l`, PHPCS (incl. the ADR-28 uppercase-boolean sniff), PHPStan, and the full PHPUnit suite (612 tests) are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4G8PSiJyE6v6Y5yed8ywE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for the "Force Reload" option to ensure only valid values (`All`, `IP`, or `DNSBL`) are accepted, with proper handling of invalid or malformed input.

* **Tests**
  * Added comprehensive test coverage for Force Reload option validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->