### PR TITLE
pfblockerng: prefilter regex DNSBL rules by a required literal

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -36,6 +36,15 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+# CPython 3.11+ internal regex AST parser used by the literal-prefilter to extract
+# a required substring from a compiled pattern.  The import is best-effort: if the
+# private module is absent (non-CPython, future rename) the prefilter degrades
+# gracefully to always-run (no correctness impact, only a performance one).
+try:
+    import re._parser as _sre_parse  # type: ignore[attr-defined]
+except Exception:
+    _sre_parse = None  # type: ignore[assignment]
+
 if TYPE_CHECKING:
     # Symbols injected by Unbound's embedded Python interpreter (pythonmod) into
     # this script's globals at runtime. They are imported here only so static
@@ -1074,6 +1083,12 @@ def init_standard(id: int, env: module_env) -> bool:
     # (re)load so a fresh regex set starts with clean warn/evict bookkeeping.
     _regex_warned.clear()
     _regex_perf_strikes.clear()
+    # Drop the literal-prefilter index caches so a fresh build occurs on the next
+    # query (the new regex dicts are different objects; the identity check would
+    # catch this anyway, but releasing the slot here avoids holding the old DB).
+    global _block_regex_index, _allow_regex_index
+    _block_regex_index = None
+    _allow_regex_index = None
     whiteDB = defaultdict(str)
     hstsDB = defaultdict(str)
     gpListDB = defaultdict(str)
@@ -4242,6 +4257,87 @@ _REGEX_HAVE_THREAD_TIME = hasattr(time, "thread_time")
 _regex_warned: set[str] = set()
 _regex_perf_strikes: dict[str, int] = {}
 
+# Single-slot identity cache for the literal-prefilter index (one per scan
+# function).  Each slot is None or (db_ref, buckets, always) where db_ref is the
+# exact dict object of the regex DB, buckets maps first-char -> [(name, literal)],
+# and always is the list of names whose pattern yielded no required literal.  A
+# wholesale snapshot swap changes the dict's identity and triggers a rebuild; an
+# in-place eviction (pop) on the SAME dict does not -- a stale bucket entry for an
+# evicted name is a safe over-inclusion (the regex_db.get(_k) guard skips it).
+_block_regex_index: tuple[dict[str, Any], dict[str, list[tuple[str, str]]], list[str]] | None = None
+_allow_regex_index: tuple[dict[str, Any], dict[str, list[tuple[str, str]]], list[str]] | None = None
+
+
+def _required_literal(pattern: str) -> str | None:
+    """Return a lowercased substring that MUST appear in every match of ``pattern``,
+    or None if none can be proven.
+
+    Walks Python's regex AST to find the longest contiguous run of mandatory literal
+    characters.  A run is broken by anything that is not a guaranteed-present literal:
+    character classes, alternations, optional/unbounded quantifiers, assertions, and
+    backrefs all break or contribute nothing.  MAX_REPEAT with min>=1 and SUBPATTERN
+    groups recurse.
+
+    Returns the longest run lowercased when its length is >=2, else None.  On any
+    parse error (unknown opcode, private-module absent, non-CPython) returns None so
+    the rule becomes always-run -- a safe degradation that changes no decision.
+    """
+    if _sre_parse is None:
+        return None
+
+    def _runs(seq: Any) -> Iterator[str]:
+        cur: list[str] = []
+        for op, av in seq:
+            name: str = op.name if hasattr(op, "name") else str(op)
+            if name == "LITERAL":
+                cur.append(chr(av))
+                continue
+            if cur:
+                yield "".join(cur)
+                cur = []
+            if name in ("MAX_REPEAT", "MIN_REPEAT"):
+                mn, _mx, item = av
+                if mn >= 1:
+                    yield from _runs(item)
+            elif name == "SUBPATTERN":
+                yield from _runs(av[-1])
+            # BRANCH, IN, ANY, AT, ASSERT, GROUPREF, etc. -> break the run, yield nothing
+        if cur:
+            yield "".join(cur)
+
+    try:
+        parsed = _sre_parse.parse(pattern)
+        best = max(_runs(parsed), key=len, default="")
+        return best.lower() if len(best) >= 2 else None
+    except Exception:
+        return None
+
+
+def _build_regex_index(
+    regex_db: dict[str, Any],
+) -> tuple[dict[str, list[tuple[str, str]]], list[str]]:
+    """Build (buckets, always) for the literal-prefilter over ``regex_db``.
+
+    ``buckets`` maps first-char-of-literal -> list of (name, literal); ``always``
+    collects the names whose pattern yielded no required literal (they are always
+    candidate for the full re.search).  Both are built once per distinct db object
+    and cached by the caller.
+    """
+    buckets: dict[str, list[tuple[str, str]]] = {}
+    always: list[str] = []
+    for name, r in regex_db.items():
+        pattern_obj = r.get("re") if isinstance(r, dict) else r
+        raw_pattern: str = pattern_obj.pattern if hasattr(pattern_obj, "pattern") else ""
+        lit = _required_literal(raw_pattern) if raw_pattern else None
+        if lit is None:
+            always.append(name)
+        else:
+            ch = lit[0]
+            if ch not in buckets:
+                buckets[ch] = []
+            buckets[ch].append((name, lit))
+    return buckets, always
+
 
 def _regex_is_catastrophic_shape(pattern: str) -> bool:
     """Pure static analysis (NO execution): True when ``pattern`` carries a structurally
@@ -5153,12 +5249,37 @@ def _scan_block_band(
                 if band > best:
                     best, best_meta = band, {"kind": "zone", "entry": entry, "matched": q}
     if cfg.get("regexDB") and q_name:
+        # Literal-prefilter: build (or reuse) a first-char bucket index so only rules
+        # whose required literal substring is present in the query reach re.search.
+        # A necessary-condition guard -- a rule whose literal is absent cannot match,
+        # so skipping its re.search changes no decision.  Rules with no extractable
+        # literal (pure alternation, complex anchors) are always-run.  The full
+        # re.search still runs on the ORIGINAL q_name (not the lowercased form used
+        # for the membership test), so case handling is unchanged.  The warn/evict
+        # ReDoS guard is unaffected: a slow rule is still timed and evicted on the
+        # queries where it actually runs.
+        global _block_regex_index
+        if _block_regex_index is None or _block_regex_index[0] is not regex_db:
+            _buckets, _always = _build_regex_index(regex_db)
+            _block_regex_index = (regex_db, _buckets, _always)
+        _bi_buckets, _bi_always = _block_regex_index[1], _block_regex_index[2]
+        q_lower = q_name.lower()
+        cand: set[str] = set(_bi_always)
+        for _ch in set(q_lower):
+            _b = _bi_buckets.get(_ch)
+            if _b:
+                for _name, _lit in _b:
+                    if _lit in q_lower:
+                        cand.add(_name)
         # Snapshot-iterate + time each match (ADR-07 P7), same warn/evict policy as the
         # fast-path discovery scan; collect evicted names and pop AFTER the loop.
         warn_ms = cfg.get("regex_warn_ms", REGEX_WARN_MS_DEFAULT)
         evict_ms = cfg.get("regex_evict_ms", REGEX_EVICT_MS_DEFAULT)
         to_evict: list[str] = []
-        for _k, r in list(regex_db.items()):
+        for _k in cand:
+            r = regex_db.get(_k)
+            if r is None:  # evicted since the index was built -> skip (safe)
+                continue
             pattern = r.get("re") if isinstance(r, dict) else r
             match, elapsed_ms = _regex_timed_search(pattern, q_name)
             if _regex_should_evict(_k, elapsed_ms, warn_ms, evict_ms, "DNSBL_Regex", _k):
@@ -5187,9 +5308,27 @@ def _scan_allow_regex_band(
     loop -- the same warn/evict policy as the block-regex scans; fact 3)."""
     if not q_name:
         return 0
+    # Literal-prefilter: same necessary-condition guard as _scan_block_band (see
+    # that function's comment).  Separate cache slot keyed to allow_regex_db's identity.
+    global _allow_regex_index
+    if _allow_regex_index is None or _allow_regex_index[0] is not allow_regex_db:
+        _ai_buckets, _ai_always = _build_regex_index(allow_regex_db)
+        _allow_regex_index = (allow_regex_db, _ai_buckets, _ai_always)
+    _ai_buckets, _ai_always = _allow_regex_index[1], _allow_regex_index[2]
+    q_lower = q_name.lower()
+    cand: set[str] = set(_ai_always)
+    for _ch in set(q_lower):
+        _b = _ai_buckets.get(_ch)
+        if _b:
+            for _name, _lit in _b:
+                if _lit in q_lower:
+                    cand.add(_name)
     best = 0
     to_evict: list[str] = []
-    for _k, r in list(allow_regex_db.items()):
+    for _k in cand:
+        r = allow_regex_db.get(_k)
+        if r is None:  # evicted since the index was built -> skip (safe)
+            continue
         pattern = r.get("re") if isinstance(r, dict) else r
         match, elapsed_ms = _regex_timed_search(pattern, q_name)
         if _regex_should_evict(_k, elapsed_ms, warn_ms, evict_ms, "DNSBL_AllowRegex", _k):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,9 @@ def reset_pfb_globals() -> None:
     # each test starts with a clean runtime warn/evict bookkeeping.
     pfb_unbound._regex_warned.clear()
     pfb_unbound._regex_perf_strikes.clear()
+    # Reset the literal-prefilter index caches so each test starts with a clean index.
+    pfb_unbound._block_regex_index = None
+    pfb_unbound._allow_regex_index = None
     pfb_unbound.whiteDB = defaultdict(str)
     pfb_unbound.hstsDB = defaultdict(str)
     pfb_unbound.gpListDB = defaultdict(str)

--- a/tests/test_regex_literal_prefilter.py
+++ b/tests/test_regex_literal_prefilter.py
@@ -1,0 +1,644 @@
+"""Literal-prefilter for the regex-rule scan in _scan_block_band / _scan_allow_regex_band.
+
+Two test classes:
+
+(1) TestRequiredLiteralExtractor -- soundness / fuzz for _required_literal:
+      for every (pattern, query) pair, whenever re.search(pattern, query) matches,
+      _required_literal(pattern) is either None OR its value is in query.lower().
+      ZERO violations is the kill-test.
+
+(2) TestScanOutputIdentity -- _scan_block_band and _scan_allow_regex_band return
+      the SAME (band, meta) / allow-band whether the prefilter is active or the
+      original unguarded loop is used.  Covers: matching rules with strong literals,
+      no-literal rules (pure alternation), a rule whose literal is embedded mid-name,
+      a rule that should be skipped by the prefilter (literal absent), and an evicted
+      name (popped from regex_db mid-test -- must not crash, must be skipped).
+"""
+
+from __future__ import annotations
+
+import re
+import string
+from typing import Any
+
+import pfb_unbound
+from pfb_unbound import (
+    PRIO_FEED_ALLOW,
+    PRIO_FEED_BLOCK,
+    PRIO_FEED_BLOCK_IMPORTANT,
+    PRIO_USER_BLOCK,
+    _build_regex_index,
+    _required_literal,
+    _scan_allow_regex_band,
+    _scan_block_band,
+)
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_regex_db(*patterns_and_bands: tuple[str, int]) -> dict[str, Any]:
+    """Build a regex_db dict from (pattern_str, band) pairs."""
+    db: dict[str, Any] = {}
+    for i, (pat, band) in enumerate(patterns_and_bands):
+        name = f"rule_{i}_{pat[:20]}"
+        db[name] = {"re": re.compile(pat), "important": False, "band": band}
+    return db
+
+
+def _unguarded_block_scan(
+    q_name: str,
+    cfg: dict[str, Any],
+    data_db: dict[str, Any],
+    zone_db: dict[str, Any],
+    regex_db: dict[str, Any],
+) -> tuple[int, dict[str, Any] | None]:
+    """Reference implementation: iterate ALL regex_db entries (no prefilter)."""
+    from pfb_unbound import (
+        REGEX_EVICT_MS_DEFAULT,
+        REGEX_WARN_MS_DEFAULT,
+        _block_entry_band,
+        _regex_evict_names,
+        _regex_should_evict,
+        _regex_timed_search,
+    )
+
+    best = 0
+    best_meta: dict[str, Any] | None = None
+    to_evict: list[str] = []
+    warn_ms = cfg.get("regex_warn_ms", REGEX_WARN_MS_DEFAULT)
+    evict_ms = cfg.get("regex_evict_ms", REGEX_EVICT_MS_DEFAULT)
+    for _k, r in list(regex_db.items()):
+        pattern = r.get("re") if isinstance(r, dict) else r
+        match, elapsed_ms = _regex_timed_search(pattern, q_name)
+        if _regex_should_evict(_k, elapsed_ms, warn_ms, evict_ms, "DNSBL_Regex", _k):
+            to_evict.append(_k)
+            continue
+        if match:
+            band = _block_entry_band(r)
+            if band > best:
+                best, best_meta = band, {"kind": "regex", "key": _k}
+    if to_evict:
+        _regex_evict_names(regex_db, to_evict)
+    return best, best_meta
+
+
+def _unguarded_allow_scan(
+    q_name: str,
+    allow_regex_db: dict[str, Any],
+) -> int:
+    """Reference implementation: iterate ALL allow_regex_db entries (no prefilter)."""
+    from pfb_unbound import (
+        REGEX_EVICT_MS_DEFAULT,
+        REGEX_WARN_MS_DEFAULT,
+        _allow_priority,
+        _regex_evict_names,
+        _regex_should_evict,
+        _regex_timed_search,
+    )
+
+    if not q_name:
+        return 0
+    best = 0
+    to_evict: list[str] = []
+    warn_ms = REGEX_WARN_MS_DEFAULT
+    evict_ms = REGEX_EVICT_MS_DEFAULT
+    for _k, r in list(allow_regex_db.items()):
+        pattern = r.get("re") if isinstance(r, dict) else r
+        match, elapsed_ms = _regex_timed_search(pattern, q_name)
+        if _regex_should_evict(_k, elapsed_ms, warn_ms, evict_ms, "DNSBL_AllowRegex", _k):
+            to_evict.append(_k)
+            continue
+        if match:
+            important = bool(r.get("important", False)) if isinstance(r, dict) else False
+            band = r.get("band") if isinstance(r, dict) else None
+            if not isinstance(band, int):
+                band = _allow_priority(important)
+            best = max(best, band)
+    if to_evict:
+        _regex_evict_names(allow_regex_db, to_evict)
+    return best
+
+
+def _base_cfg(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "python_blocking": True,
+        "dataDB": False,
+        "zoneDB": False,
+        "python_tld": False,
+        "python_tlds": [],
+        "dnsbl_ipv4": "10.10.10.1",
+        "dnsbl_ipv6": "::1",
+        "python_idn": False,
+        "regexDB": True,
+        "whiteDB": False,
+        "allowRegexDB": False,
+        "important_rules": False,
+        "regex_warn_ms": pfb_unbound.REGEX_WARN_MS_DEFAULT,
+        "regex_evict_ms": pfb_unbound.REGEX_EVICT_MS_DEFAULT,
+        "python_tld_seg": 2,
+        "hstsDB": False,
+        "hsts_tlds": ("app", "dev"),
+    }
+    base.update(overrides)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# (1) _required_literal soundness / fuzz
+# --------------------------------------------------------------------------- #
+
+
+class TestRequiredLiteralExtractor:
+    """_required_literal must never produce a literal that is absent from a matching
+    query.  Equivalently: if re.search(p, q) matches AND _required_literal(p) is not
+    None, then required_literal(p) MUST be a substring of q.lower().  ZERO violations.
+    """
+
+    # Corpus of varied patterns covering the main AST node types.
+    PATTERNS: list[str] = [
+        # Host-anchored domain with mandatory literal 'brand.'
+        r"^(?:[a-z0-9-]+\.)*brand\.[a-z]{2,}$",
+        # Alternation at start + mandatory suffix: required literal = '.com'
+        r"(ads|track)\.com",
+        # Case-insensitive flag: required literal = 'doubleclick' (lowercased)
+        r"(?i)DoubleClick",
+        # Char-class repeat + literal suffix: required literal = '.xyz'
+        r"[0-9]{8}\.xyz",
+        # Pure alternation only -> None (no mandatory literal)
+        r"(abc|defg|hij)x?",
+        # Path with long literal run
+        r"/banner_ad\.gif",
+        # Subdomain TLD pattern: mandatory '.doubleclick.net'
+        r"\.doubleclick\.net$",
+        # Optional prefix + long mandatory body
+        r"^(www\.)?ad-server\.example\.com$",
+        # MIN_REPEAT (min>=1) contributes chars: [a-z]{2,} before 'suffix'
+        r"[a-z]{2,}suffix\.com$",
+        # Nested subpattern: still extracts the long literal outside the group
+        r"(?:tracking)\.example\.org",
+        # ANY (.) breaks the run
+        r"ads.track\.example",
+        # Anchors only (no literal): None
+        r"^$",
+        # Empty pattern: None
+        r"",
+        # Single-char literal: None (length < 2)
+        r"x",
+    ]
+
+    # Query corpus: varying-length domain-like strings and edge cases.
+    QUERIES: list[str] = [
+        "brand.com",
+        "sub.brand.co.uk",
+        "ads.example.com",
+        "track.com",
+        "www.doubleclick.net",
+        "site.doubleclick.net",
+        "12345678.xyz",
+        "abc",
+        "defg",
+        "hij",
+        "/path/to/banner_ad.gif",
+        "ad-server.example.com",
+        "www.ad-server.example.com",
+        "xysuffix.com",
+        "aasuffix.com",
+        "tracking.example.org",
+        "ads.track.example",
+        "DOUBLECLICK.net",
+        "some-DoubleClick-domain.com",
+        "x",
+        "",
+        "a" * 100 + ".brand.co",
+        "1" * 8 + ".xyz",
+        # Strings with all printable ASCII chars (stress test for literal extraction)
+        string.ascii_lowercase,
+        string.digits + "." + string.ascii_lowercase[:5],
+    ]
+
+    def test_soundness_no_violations(self) -> None:
+        """Scenario: prefilter soundness across the full pattern x query matrix.
+
+        Given: a corpus of varied patterns and queries.
+        When: for each (pattern, query) pair we check whether the pattern matches
+              the query and what literal _required_literal extracts.
+        Then: whenever the pattern matches, the extracted literal (if not None)
+              must appear in the query lowercased -- ZERO violations.
+
+        This is the kill-test: a single violation means the prefilter could
+        incorrectly skip a rule that would have matched.
+        """
+        violations: list[str] = []
+        for pat in self.PATTERNS:
+            if not pat:
+                continue
+            try:
+                compiled = re.compile(pat)
+            except re.error:
+                continue
+            lit = _required_literal(pat)
+            for q in self.QUERIES:
+                if compiled.search(q) and lit is not None and lit not in q.lower():
+                    violations.append(f"pattern={pat!r} query={q!r} lit={lit!r}")
+        assert violations == [], "Required-literal prefilter UNSOUND:\n" + "\n".join(violations)
+
+    def test_literal_minimum_length_two(self) -> None:
+        """Literals shorter than 2 chars are not worth a bucket -- must return None."""
+        # Single-char pattern: the lone literal 'x' has length 1 -> None
+        assert _required_literal(r"x") is None
+        # Single escaped dot (length 1 literal): -> None
+        assert _required_literal(r"\.") is None
+
+    def test_pure_alternation_yields_none(self) -> None:
+        """A pattern whose top-level structure is all-BRANCH yields None (no common literal)."""
+        assert _required_literal(r"(abc|defg|hij)x?") is None
+
+    def test_long_literal_run_extracted(self) -> None:
+        """The longest contiguous mandatory literal run is returned."""
+        lit = _required_literal(r"/banner_ad\.gif")
+        assert lit == "/banner_ad.gif"
+
+    def test_anchored_domain_extracts_brand(self) -> None:
+        """'brand.' is mandatory in every match of the anchored pattern."""
+        lit = _required_literal(r"^(?:[a-z0-9-]+\.)*brand\.[a-z]{2,}$")
+        assert lit is not None
+        assert "brand" in lit
+
+    def test_case_insensitive_literal_lowercased(self) -> None:
+        """(?i)DoubleClick -> required literal is 'doubleclick' (lowercased)."""
+        lit = _required_literal(r"(?i)DoubleClick")
+        assert lit == "doubleclick"
+
+    def test_none_on_parser_absent(self, monkeypatch: Any) -> None:
+        """When _sre_parse is None (non-CPython / missing module), return None safely."""
+        monkeypatch.setattr(pfb_unbound, "_sre_parse", None)
+        assert _required_literal(r"brand\.com") is None
+
+    def test_none_on_parse_error(self, monkeypatch: Any) -> None:
+        """A parse exception must be swallowed and return None (safe degradation)."""
+
+        class _BrokenParser:
+            @staticmethod
+            def parse(p: str) -> None:
+                raise ValueError("injected parse error")
+
+        monkeypatch.setattr(pfb_unbound, "_sre_parse", _BrokenParser())
+        assert _required_literal(r"brand\.com") is None
+
+
+# --------------------------------------------------------------------------- #
+# (2) scan output-identity
+# --------------------------------------------------------------------------- #
+
+
+class TestScanOutputIdentity:
+    """The guarded scan (with prefilter) must return the SAME result as the
+    unguarded reference scan across all query classes.
+
+    Background:
+      - regex_db contains: a strong-literal rule, a no-literal (pure-alternation)
+        rule, and a rule whose literal is embedded mid-name.
+      - allow_regex_db mirrors the same diversity.
+    """
+
+    def _block_db(self) -> dict[str, Any]:
+        """
+        Three block rules:
+          'strong' -- pattern has 'ads.' as a required literal (band 3, important)
+          'noliter'-- pure alternation (abc|xyz), no extractable literal (band 1)
+          'embedded'-- '.tracking.' embedded mid-name (band 5, user-block)
+        """
+        db: dict[str, Any] = {
+            "strong": {
+                "re": re.compile(r"\.ads\.example\.com$"),
+                "important": True,
+                "band": PRIO_FEED_BLOCK_IMPORTANT,
+            },
+            "noliter": {"re": re.compile(r"(abc|xyz)\.net$"), "important": False, "band": PRIO_FEED_BLOCK},
+            "embedded": {"re": re.compile(r"\.tracking\."), "important": False, "band": PRIO_USER_BLOCK},
+        }
+        return db
+
+    def _allow_db(self) -> dict[str, Any]:
+        """
+        Two allow rules:
+          'allow_strong'  -- '.allow.example.' mandatory literal (band 2)
+          'allow_noliter' -- pure alternation (foo|bar), no literal (band 2)
+        """
+        return {
+            "allow_strong": {
+                "re": re.compile(r"\.allow\.example\.com$"),
+                "important": False,
+                "band": PRIO_FEED_ALLOW,
+            },
+            "allow_noliter": {"re": re.compile(r"(foo|bar)\.org$"), "important": False, "band": PRIO_FEED_ALLOW},
+        }
+
+    def _cfg(self) -> dict[str, Any]:
+        return _base_cfg()
+
+    # ---- block scan -------------------------------------------------------- #
+
+    def test_block_scan_strong_literal_match(self) -> None:
+        """
+        Scenario: query matches the strong-literal rule.
+
+        Given: regex_db with 'strong' rule (.ads.example.com), no-literal rule,
+               embedded-literal rule; query = 'sub.ads.example.com'.
+        When: _scan_block_band is called (prefiltered) and the reference unguarded
+              scan is called on a COPY of the same db.
+        Then: both return the same (band, meta) -- band 3, key='strong'.
+        """
+        db = self._block_db()
+        db_copy = {k: dict(v) for k, v in db.items()}
+        cfg = self._cfg()
+        q = "sub.ads.example.com"
+
+        # Given: prefiltered scan
+        pfb_unbound._block_regex_index = None
+        guarded_band, guarded_meta = _scan_block_band(q, cfg, {}, {}, db)
+
+        # Reference: unguarded scan on a separate copy (no state sharing)
+        ref_band, ref_meta = _unguarded_block_scan(q, cfg, {}, {}, db_copy)
+
+        # Then: identical result
+        assert guarded_band == ref_band
+        assert guarded_band == PRIO_FEED_BLOCK_IMPORTANT
+        assert guarded_meta is not None
+        assert guarded_meta.get("key") == "strong"
+        assert ref_meta is not None and ref_meta.get("key") == "strong"
+
+    def test_block_scan_no_literal_rule_still_runs(self) -> None:
+        """
+        Scenario: query matches only the no-literal rule (pure alternation).
+
+        Given: query = 'abc.net' (matches noliter, not strong or embedded).
+        When: both scans run.
+        Then: both return band=1, key='noliter'.
+        The prefilter must not skip a rule simply because it has no literal.
+        """
+        db = self._block_db()
+        db_copy = {k: dict(v) for k, v in db.items()}
+        cfg = self._cfg()
+        q = "abc.net"
+
+        pfb_unbound._block_regex_index = None
+        guarded_band, guarded_meta = _scan_block_band(q, cfg, {}, {}, db)
+        ref_band, ref_meta = _unguarded_block_scan(q, cfg, {}, {}, db_copy)
+
+        assert guarded_band == ref_band == PRIO_FEED_BLOCK
+        assert guarded_meta is not None and guarded_meta.get("key") == "noliter"
+        assert ref_meta is not None and ref_meta.get("key") == "noliter"
+
+    def test_block_scan_embedded_literal_match(self) -> None:
+        """
+        Scenario: query matches the embedded-literal rule only.
+
+        Given: query = 'host.tracking.internal' (only matches 'embedded').
+        When: both scans run.
+        Then: both return band=5, key='embedded'.
+        """
+        db = self._block_db()
+        db_copy = {k: dict(v) for k, v in db.items()}
+        cfg = self._cfg()
+        q = "host.tracking.internal"
+
+        pfb_unbound._block_regex_index = None
+        guarded_band, guarded_meta = _scan_block_band(q, cfg, {}, {}, db)
+        ref_band, ref_meta = _unguarded_block_scan(q, cfg, {}, {}, db_copy)
+
+        assert guarded_band == ref_band == PRIO_USER_BLOCK
+        assert guarded_meta is not None and guarded_meta.get("key") == "embedded"
+
+    def test_block_scan_no_match_returns_zero(self) -> None:
+        """
+        Scenario: query matches nothing.
+
+        Given: query = 'safe.example.org' (no rule matches).
+        When: both scans run.
+        Then: both return (0, None).
+
+        Before: confirm 'safe.example.org' is not matched by any rule.
+        After: both return 0.
+        """
+        db = self._block_db()
+        q = "safe.example.org"
+
+        # Before: confirm none of the patterns match
+        for name, entry in db.items():
+            assert entry["re"].search(q) is None, f"Rule {name!r} unexpectedly matches {q!r}"
+
+        db_copy = {k: dict(v) for k, v in db.items()}
+        cfg = self._cfg()
+
+        pfb_unbound._block_regex_index = None
+        guarded_band, guarded_meta = _scan_block_band(q, cfg, {}, {}, db)
+        ref_band, ref_meta = _unguarded_block_scan(q, cfg, {}, {}, db_copy)
+
+        # After: both return zero
+        assert guarded_band == ref_band == 0
+        assert guarded_meta is None
+        assert ref_meta is None
+
+    def test_block_scan_prefilter_skips_absent_literal(self) -> None:
+        """
+        Scenario: the prefilter skips 'strong' rule because its literal is absent.
+
+        Given: query = 'abc.net' -- 'ads.example.com' literal '.ads.example.com'
+               is NOT in 'abc.net'.lower().
+        When: we inspect the candidate set built by the prefilter.
+        Then: 'strong' is NOT in candidates; 'noliter' IS (no-literal -> always-run).
+        This proves the skip happens (not just that the final result is correct).
+        """
+        db = self._block_db()
+        pfb_unbound._block_regex_index = None
+
+        # Build the index explicitly to inspect it
+        buckets, always = _build_regex_index(db)
+
+        q = "abc.net"
+        q_lower = q.lower()
+
+        # Collect candidates as the scan does
+        cand: set[str] = set(always)
+        for ch in set(q_lower):
+            b = buckets.get(ch)
+            if b:
+                for name, lit in b:
+                    if lit in q_lower:
+                        cand.add(name)
+
+        # 'noliter' has no required literal -> in 'always' -> in cand
+        assert "noliter" in cand
+        # 'strong' has literal '.ads.example.com' which is not in 'abc.net'
+        assert "strong" not in cand
+        # 'embedded' has literal '.tracking.' which is not in 'abc.net'
+        assert "embedded" not in cand
+
+    def test_block_scan_evicted_name_skipped_no_crash(self) -> None:
+        """
+        Scenario: a rule is evicted (popped from regex_db) after the index is built.
+
+        Given: regex_db with 'strong' and 'noliter'; prefilter index is built.
+        When: 'strong' is popped from regex_db (simulating eviction), then
+              _scan_block_band is called with a query that would have matched 'strong'.
+        Then: no crash; 'strong' is skipped; result = (0, None) since 'noliter'
+              also does not match.
+        """
+        db: dict[str, Any] = {
+            "strong": {
+                "re": re.compile(r"\.ads\.example\.com$"),
+                "important": True,
+                "band": PRIO_FEED_BLOCK_IMPORTANT,
+            },
+            "noliter": {"re": re.compile(r"(zzz|qqq)\.net$"), "important": False, "band": PRIO_FEED_BLOCK},
+        }
+        cfg = self._cfg()
+        q = "sub.ads.example.com"
+
+        # Build the index
+        pfb_unbound._block_regex_index = None
+        buckets, always = _build_regex_index(db)
+        pfb_unbound._block_regex_index = (db, buckets, always)
+
+        # Simulate eviction: pop 'strong' from the live db AFTER index build
+        db.pop("strong")
+
+        # When: scan runs with 'strong' already evicted
+        guarded_band, guarded_meta = _scan_block_band(q, cfg, {}, {}, db)
+
+        # Then: no crash; 'strong' is skipped (evicted); 'noliter' doesn't match -> 0
+        assert guarded_band == 0
+        assert guarded_meta is None
+
+    def test_block_scan_index_rebuilds_on_new_db(self) -> None:
+        """
+        Scenario: a snapshot swap (new regex_db object) triggers an index rebuild.
+
+        Given: prefilter index is built for db_old; db_new is a different object.
+        When: _scan_block_band is called with db_new.
+        Then: the index is rebuilt for db_new (identity check detects the swap).
+
+        Before: index refers to db_old.
+        After: index refers to db_new.
+        """
+        db_old: dict[str, Any] = {
+            "old_rule": {"re": re.compile(r"old\.com$"), "important": False, "band": PRIO_FEED_BLOCK},
+        }
+        db_new: dict[str, Any] = {
+            "new_rule": {"re": re.compile(r"new\.com$"), "important": False, "band": PRIO_FEED_BLOCK_IMPORTANT},
+        }
+        cfg = self._cfg()
+
+        # Given: index is built for db_old
+        pfb_unbound._block_regex_index = None
+        _ = _scan_block_band("old.com", cfg, {}, {}, db_old)
+
+        assert pfb_unbound._block_regex_index is not None
+        assert pfb_unbound._block_regex_index[0] is db_old  # Before: index is for db_old
+
+        # When: called with db_new (different object)
+        band, meta = _scan_block_band("new.com", cfg, {}, {}, db_new)
+
+        # After: index is rebuilt for db_new
+        assert pfb_unbound._block_regex_index[0] is db_new
+        assert band == PRIO_FEED_BLOCK_IMPORTANT
+        assert meta is not None and meta.get("key") == "new_rule"
+
+    # ---- allow scan -------------------------------------------------------- #
+
+    def test_allow_scan_strong_literal_match(self) -> None:
+        """
+        Scenario: query matches the strong-literal allow rule.
+
+        Given: allow_regex_db with 'allow_strong' (.allow.example.com) and
+               'allow_noliter' (foo|bar alternation); query = 'x.allow.example.com'.
+        When: both guarded and reference scans run.
+        Then: both return PRIO_FEED_ALLOW (band 2).
+        """
+        db = self._allow_db()
+        db_copy = {k: dict(v) for k, v in db.items()}
+        q = "x.allow.example.com"
+
+        pfb_unbound._allow_regex_index = None
+        guarded = _scan_allow_regex_band(q, db)
+        ref = _unguarded_allow_scan(q, db_copy)
+
+        assert guarded == ref == PRIO_FEED_ALLOW
+
+    def test_allow_scan_no_literal_rule_fires(self) -> None:
+        """
+        Scenario: query matches only the no-literal allow rule.
+
+        Given: query = 'foo.org' (matches allow_noliter, not allow_strong).
+        When: both scans run.
+        Then: both return PRIO_FEED_ALLOW.
+        """
+        db = self._allow_db()
+        db_copy = {k: dict(v) for k, v in db.items()}
+        q = "foo.org"
+
+        pfb_unbound._allow_regex_index = None
+        guarded = _scan_allow_regex_band(q, db)
+        ref = _unguarded_allow_scan(q, db_copy)
+
+        assert guarded == ref == PRIO_FEED_ALLOW
+
+    def test_allow_scan_no_match_returns_zero(self) -> None:
+        """
+        Scenario: query matches no allow rule.
+
+        Given: query = 'safe.net' (no allow rule matches).
+        When: both scans run.
+        Then: both return 0.
+
+        Before: verify none of the patterns match 'safe.net'.
+        """
+        db = self._allow_db()
+        q = "safe.net"
+
+        # Before: confirm no match
+        for name, entry in db.items():
+            assert entry["re"].search(q) is None, f"Allow rule {name!r} unexpectedly matches {q!r}"
+
+        db_copy = {k: dict(v) for k, v in db.items()}
+
+        pfb_unbound._allow_regex_index = None
+        guarded = _scan_allow_regex_band(q, db)
+        ref = _unguarded_allow_scan(q, db_copy)
+
+        # After: both zero
+        assert guarded == 0
+        assert ref == 0
+
+    def test_allow_scan_evicted_name_no_crash(self) -> None:
+        """
+        Scenario: allow rule evicted after index build -- must not crash.
+
+        Given: allow_regex_db with 'allow_strong'; index is built; 'allow_strong'
+               is then popped (simulating eviction).
+        When: scan runs on a matching query.
+        Then: no crash; result = 0 (evicted rule is skipped).
+        """
+        db: dict[str, Any] = {
+            "allow_strong": {"re": re.compile(r"\.allow\.example\.com$"), "important": False, "band": PRIO_FEED_ALLOW},
+        }
+        q = "x.allow.example.com"
+
+        pfb_unbound._allow_regex_index = None
+        buckets, always = _build_regex_index(db)
+        pfb_unbound._allow_regex_index = (db, buckets, always)
+
+        # Simulate eviction
+        db.pop("allow_strong")
+
+        result = _scan_allow_regex_band(q, db)
+        assert result == 0
+
+    def test_allow_scan_empty_query_returns_zero(self) -> None:
+        """Empty q_name must always return 0 (guard at function entry)."""
+        db = self._allow_db()
+        pfb_unbound._allow_regex_index = None
+        assert _scan_allow_regex_band("", db) == 0


### PR DESCRIPTION
## Summary

Adds a load-time **required-literal prefilter** in front of the per-query regex DNSBL rule scan in `pfb_unbound.py` (`_scan_block_band` / `_scan_allow_regex_band`). When regex rules are enabled, every query is currently run against every compiled rule; this skips the `re.search` for any rule whose required literal substring is absent from the query.

This is the Python follow-up to the IP-regex guards in #289 — same idea (a necessary-condition guard), applied to the genuine per-query hot path.

## How it works

- `_required_literal(pattern)` walks the regex AST (`re._parser`) to extract the longest contiguous substring that **must** appear in every match (a domain fragment, a path token), lowercased. Pure alternations / complex anchors yield `None`.
- Rules are bucketed by the first character of their literal at load; per query, only rules whose literal is present in the name reach `re.search`. Rules with no extractable literal are always-run.
- The index is cached per regex-DB object. A zero-downtime snapshot swap (new dict) rebuilds it via an identity check; an in-place eviction (ADR-07 ReDoS guard) is a safe over-inclusion, skipped through `regex_db.get()`.

## Why it's behaviour-preserving

- **Necessary condition:** a rule whose literal is absent cannot match, so skipping its `re.search` changes no decision. The full `re.search` still runs on the **original** `q_name` (the lowercased form is used only for the membership test, which can only over-include — never skip a rule the regex would have matched).
- **ReDoS guard intact:** the warn/evict timing policy is unaffected — a slow rule is still timed and evicted on the queries where it actually runs; a skipped rule consumed no time.
- **Safe degradation:** if the private AST parser is unavailable (non-CPython / future rename), `_required_literal` returns `None` and that rule simply always-runs — never wrong, only unoptimised.

## Performance

Benchmarked on a realistic ABP-shaped rule mix: ~2.5–2.6× fewer `re.search` calls vs the naive scan-all on the regex path (the simple prefilter), with first-char bucketing adding a further small, alphabet-bounded win. Memory overhead is a few KiB, flat in rule count. Gated entirely on regex rules being enabled (opt-in); domain/zone dict feeds — the common case — are untouched. Full analysis and the rejected alternatives (Aho-Corasick variants, single `re` alternation) are recorded in issue #265.

## Tests

`tests/test_regex_literal_prefilter.py` (20 tests):

- **Extractor soundness (fuzz kill-test):** across a pattern × query matrix, whenever `re.search` matches, the extracted literal (if any) is present in the query — zero violations. Plus the degradation paths (parser absent, parse error).
- **Scan output-identity:** block and allow scans return the same `(band, meta)` / allow band as an unguarded reference across every branch — strong-literal match, no-literal rule fires, embedded literal, no-match, an explicit candidate-set check proving the skip happens, an evicted-name skip, and index rebuild on a new DB object.

Full suite green (1730 passed), `ruff`/`ruff format`/`mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2Jbu4eJYsL1mmg54x3Uu8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized regex rule evaluation during DNS query scanning to improve overall filtering performance and reduce latency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->