### PR TITLE
pfblockerng: preserve user settings across pkg upgrade (#281)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ ignore = [
 # ``test_repo_install`` so their cases can request it (pytest resolves fixtures per-module).
 # Each case param then "redefines" the imported name from ruff's view — the standard
 # re-export idiom, not real shadowing. F811 is suppressed only for these files.
-"tests/smoke/test_software_update.py"          = ["F811"]
+"tests/smoke/test_software_update.py"              = ["F811"]
+"tests/smoke/test_upgrade_config_stability.py"  = ["F811"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["pfb_unbound"]

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1306,7 +1306,7 @@ function pfb_global() {
 	$pfb['config_global']	= config_get_path('installedpackages/pfblockerngglobal', []);
 
 	$pfb['enable']		= $pfb['config']['enable_cb'];			// Enable/Disable of pfBlockerNG
-	$pfb['keep']		= $pfb['config']['pfb_keep'];			// Keep blocklists on pfBlockerNG Disable
+	$pfb['keep']		= $pfb['config']['pfb_keep'] ?? 'on';		// Keep blocklists on pfBlockerNG Disable (default ON; matches GUI, preserves settings on upgrade)
 	$pfb['interval']	= $pfb['config']['pfb_interval']	?: '1';	// Hour cycle for scheduler
 
 	// ADR-11: opt-in per-type aggregate ("Uber") aliases. CSV scalar of the action types
@@ -6365,6 +6365,27 @@ function pfb_dnsbl_lenient_migrate($dconfig) {
 	}
 	$dconfig['pfb_dnsbl_lenient'] = 'on';
 	return $dconfig;
+}
+
+
+// Issue #281: one-time upgrade seed for the 'pfb_keep' General-settings flag. The
+// pre-deinstall hook wipes ALL pfBlockerNG config sections unless pfb_keep == 'on';
+// the GUI default is 'on' but it only persists to config.xml once General settings are
+// saved. On an EXISTING install (a populated General config section) that predates the
+// key, seed it to 'on' so a later pkg upgrade's pre-deinstall preserves user settings.
+// A fresh install has no prior section -> NULL (no write); the runtime default in
+// pfb_global() covers it. An existing value (including an explicit '' = off) is never
+// overwritten. Returns the updated config array to persist, or NULL when nothing changes.
+function pfb_keep_migrate($gconfig) {
+
+	if (!is_array($gconfig) || empty($gconfig)) {
+		return NULL;
+	}
+	if (isset($gconfig['pfb_keep'])) {
+		return NULL;
+	}
+	$gconfig['pfb_keep'] = 'on';
+	return $gconfig;
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -142,6 +142,18 @@ if ($cfg_lenient !== NULL) {
 }
 unset($cfg, $cfg_lenient);
 
+// Issue #281: preserve user settings across pkg upgrade. pfb_keep_migrate() seeds the
+// missing 'pfb_keep' General-settings flag to 'on' only on an already-populated config
+// section (an existing install); a fresh install returns NULL and the pfb_global()
+// runtime default stands. An existing value is never overwritten.
+$cfg = config_get_path('installedpackages/pfblockerng/config/0', []);
+$cfg_keep = pfb_keep_migrate($cfg);
+if ($cfg_keep !== NULL) {
+	config_set_path('installedpackages/pfblockerng/config/0', $cfg_keep);
+	write_config('pfBlockerNG: preserve settings across upgrade (seed Keep flag, issue #281)');
+}
+unset($cfg, $cfg_keep);
+
 // MaxMind Database is no longer pre-installed during package installation
 if (empty($pfb['maxmind_key'])) {
 	update_status("\nMaxMind GeoIP databases are not pre-installed during installation.\nTo utilize the MaxMind GeoIP functionalities, you will be required to register for a free MaxMind user account and access key. Review the IP tab: MaxMind Settings for more details.\n\n");

--- a/tests/php/PfbKeepMigrateTest.php
+++ b/tests/php/PfbKeepMigrateTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_keep_migrate() -- the one-time upgrade seed for the 'pfb_keep'
+ * General-settings flag (issue #281).
+ *
+ * Scenario: preserve user settings across pkg upgrade.
+ *   Background: $gconfig is the existing General 'config/0' node.
+ *     - The pre-deinstall hook wipes ALL pfBlockerNG config sections unless
+ *       pfb_keep == 'on'. The GUI default is 'on' but it only persists to
+ *       config.xml once General settings are saved.
+ *     - On an EXISTING install (a populated section) that predates the key,
+ *       seed it to 'on' so a later pkg upgrade's pre-deinstall is safe.
+ *     - A fresh install has no prior section -> NULL (no write); pfb_global()
+ *       covers it with ?? 'on'.
+ *     - An existing value (including an explicit '' = off) is NEVER overwritten.
+ *
+ * Contract:
+ *   - empty/non-array config (fresh install) => NULL (no migration; runtime default stands).
+ *   - populated config lacking the key (existing install) => key seeded to 'on'.
+ *   - populated config with explicit '' (user chose off) => NULL (never overwritten).
+ *   - populated config already carrying 'on' => NULL (idempotent, never re-seeds).
+ */
+#[CoversFunction('pfb_keep_migrate')]
+final class PfbKeepMigrateTest extends TestCase
+{
+	public function testMigrationSkipsFreshInstall(): void
+	{
+		// Given a first-ever install: no prior General config section.
+		// Before: nothing to migrate.
+		$this->assertNull(pfb_keep_migrate([]));
+		$this->assertNull(pfb_keep_migrate(null));
+		// After: still nothing written -- the pfb_global() runtime default ('on') stands.
+		// (A NULL return means the install.inc block does not config_set_path/write_config,
+		// so the key is never created; pfb_global() fills it with ?? 'on' at runtime.)
+	}
+
+	public function testMigrationSeedsOnForExistingInstallMissingKey(): void
+	{
+		// Given an existing, already-configured install (a populated section) that predates
+		// the key.
+		$gconfig = ['enable_cb' => 'on', 'pfb_interval' => '1'];
+		// Before: the key is absent.
+		$this->assertArrayNotHasKey('pfb_keep', $gconfig);
+
+		// When the one-time migration runs.
+		$out = pfb_keep_migrate($gconfig);
+
+		// Then it is seeded to 'on' -- the safe upgrade default is preserved.
+		$this->assertIsArray($out);
+		$this->assertSame('on', $out['pfb_keep']);
+		// And the rest of the section is carried through untouched.
+		$this->assertSame('on', $out['enable_cb']);
+		$this->assertSame('1', $out['pfb_interval']);
+	}
+
+	public function testMigrationDoesNotOverwriteExplicitOffValue(): void
+	{
+		// Given an existing install where the operator explicitly chose off ('').
+		// This is the critical branch: '' means the user WANTS to lose settings on
+		// disable/upgrade -- their deliberate choice must never be overwritten.
+		$gconfig = ['enable_cb' => 'on', 'pfb_keep' => ''];
+		// Before: value is '' (explicit off).
+		$this->assertSame('', $gconfig['pfb_keep']);
+
+		// When the migration runs.
+		$out = pfb_keep_migrate($gconfig);
+
+		// Then nothing changes (NULL = no write) -- the chosen value is never overwritten.
+		$this->assertNull($out);
+	}
+
+	public function testMigrationDoesNotOverwriteExistingOnValue(): void
+	{
+		// A box already carrying 'on' is likewise left alone (run-once, idempotent).
+		$gconfig = ['enable_cb' => 'on', 'pfb_keep' => 'on'];
+		// Before: value is already 'on'.
+		$this->assertSame('on', $gconfig['pfb_keep']);
+
+		// When the migration runs.
+		$out = pfb_keep_migrate($gconfig);
+
+		// Then nothing changes -- no redundant re-seed.
+		$this->assertNull($out);
+	}
+}

--- a/tests/smoke/test_upgrade_config_stability.py
+++ b/tests/smoke/test_upgrade_config_stability.py
@@ -1,0 +1,325 @@
+"""Issue #281 — UPGRADE CONFIG-PRESERVATION CONTRACT: config.xml user settings
+survive a ``pkg upgrade`` from a prior-release build to the branch build.
+
+NOT A SMOKE TEST. Like ``test_repo_install.py`` this validates a *distribution*
+mechanic — specifically the config-preservation guarantee across package upgrade —
+and carries the ``repo`` marker (NOT ``smoke``), so ``pytest -m smoke`` never
+selects it. It reuses ``test_repo_install.py``'s hermetic ``file://`` catalog and
+``repo_vm`` fixture machinery.
+
+ROOT CAUSE (issue #281): on ``pkg upgrade``, pfSense fires the old pkg's
+``custom_php_pre_deinstall_command`` -> ``pfblockerng_php_pre_deinstall_command()``.
+It reads ``$pfb['keep']`` = ``$pfb['config']['pfb_keep']`` with no default. The key
+only persists to config.xml when the user explicitly saves the General tab; the GUI
+default is 'on' but that default never persists automatically. When the key is absent,
+the ``!= 'on'`` check is TRUE -> ``pfb_remove_config_settings()`` deletes ALL ~22
+pfBlockerNG config sections -> wholesale config loss on upgrade.
+
+The fix (pfb_keep_migrate + the ?? 'on' runtime default) ensures that:
+
+  1. The install-time seed (``pfb_keep_migrate``) writes 'on' into config.xml on
+     an existing, already-populated General config section so the pre-deinstall hook
+     finds the key on the NEXT upgrade.
+  2. The runtime default (``?? 'on'`` in ``pfb_global()``) covers the gap between
+     installation and the first General-tab save.
+
+WHAT THE CASE PROVES (issue #281 contract):
+
+  ``test_pkg_upgrade_preserves_config_values`` — config.xml stored values are
+  byte-identical after a ``pkg upgrade`` from the prior-release build (``<V>_1``)
+  to the branch build (``<V>_9``). The test asserts:
+
+    (1) BEFORE state: representative config written and read back correctly on the
+        LOWER build. pfb_keep is NOT set by the test (its absence is the bug
+        condition the fix handles). After the lower build installs, the
+        install-time seed migration writes pfb_keep='on' into config.xml
+        automatically — the test asserts this seeded value is present.
+        Representative config fields verified before upgrade:
+          - ``dnsbl_lenient='on'``    (PfbLenient-adapted field)
+          - ``dnsbl_vip_auto='on'``   (PfbToggle-adapted field)
+          - ``pfb_dnsbl='on'``        (CONTROL field — not ADR-28-adapted here)
+          - ``pfb_idn='all'``         (excluded field — kept as raw string; proves
+                                       'all' is preserved, not "both empty")
+          - ``pfb_keep='on'``         (seeded by install migration — the fix output)
+        BEFORE runtime behaviour: a DNSBL-blocked ``unique_domain()`` name returns
+        the VIP block shape on-box (proves DNSBL is live before the upgrade).
+
+    (2) WHEN: branch build (``<V>_9``) is installed over the lower build via
+        ``pkg upgrade``.
+
+    (3) THEN every snapshotted config.xml value is byte-identical (same raw stored
+        string, no loss or mutation), AND the DNSBL probe still returns the same VIP
+        block shape on the same domain (runtime contract unchanged).
+
+DESELECTED from the default ``python -m pytest``
+(``--ignore=tests/smoke`` in pyproject.toml).
+Run only via its own dispatch::
+
+    python -m pytest tests/smoke -m repo --override-ini="addopts="
+
+Needs the booted ``smoke_vm`` / ``repo_vm`` fixture, the branch ``.pkg``
+(``SMOKE_PKG``) and the ``zstd`` runner host-tool (for the re-versioned builds);
+without them it skips cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import tests.smoke.helpers as h
+
+# ``repo_vm`` is re-exported (not just imported): pytest resolves fixtures
+# PER-MODULE, so importing the helper functions does NOT register the fixture in
+# this module's namespace — the name must be present here for the cases below to
+# request it. noqa keeps the (module-level "unused") fixture import; the matching
+# F811 ("redefinition" by each case param) is suppressed for this file in pyproject.
+from .conftest import SmokeVM
+from .test_repo_install import (  # noqa: F401
+    NETGATE_REPO_NAME,
+    UPGRADE_REPO_DIR,
+    build_guest_repo,
+    pkg_delete,
+    pkg_install_from_repo,
+    pkg_installed_version,
+    pkg_update,
+    pkg_upgrade,
+    read_compact_version,
+    repo_priority,
+    repo_vm,
+    reversion_pkg,
+    write_repo_conf,
+)
+
+pytestmark = pytest.mark.repo
+
+# Config paths (mirrors helpers.py CFG_* constants — avoid importing private names)
+_CFG_GLOBAL = "installedpackages/pfblockerng/config/0"
+_CFG_DNSBL = "installedpackages/pfblockerngdnsblsettings/config/0"
+
+# The fields snapshotted for the upgrade-contract assertion.
+# pfb_keep is NOT included here — it is instead asserted explicitly as the
+# seeded value after lower-build install (the fix output), then included in the
+# before snapshot so we verify it survives the upgrade unchanged.
+_SNAPSHOT_FIELDS: list[tuple[str, str]] = [
+    (_CFG_DNSBL + "/dnsbl_lenient", "on"),  # PfbLenient::On
+    (_CFG_DNSBL + "/dnsbl_vip_auto", "on"),  # PfbToggle::On (dnsbl-settings side)
+    (_CFG_DNSBL + "/pfb_dnsbl", "on"),  # control field
+    (_CFG_DNSBL + "/pfb_idn", "all"),  # excluded field — canonical stored value
+    (_CFG_GLOBAL + "/pfb_keep", "on"),  # seeded by pfb_keep_migrate (the fix)
+]
+
+# Local feed fixture content used for the DNSBL probe.
+_FEED_CONTENT = "uuid-9f3c1e8a2b47.com\n"
+_BLOCKED_DOMAIN = "uuid-9f3c1e8a2b47.com"
+
+
+def _write_representative_config(vm: SmokeVM) -> None:
+    """Write representative config into config.xml on the lower build.
+
+    Sets the minimum DNSBL enable chain and the four representative fields so
+    the before-state DNS probe works. pfb_keep is intentionally NOT set here —
+    its absence on a real user's box is the bug condition the fix handles.
+    The install-time migration (pfb_keep_migrate) is responsible for seeding it.
+    """
+    snippet = (
+        # Global block: master switch on (pfb_keep intentionally omitted here)
+        f"$g = config_get_path({h._php_str(_CFG_GLOBAL)}, array());\n"
+        "$g['enable_cb'] = 'on';\n"
+        f"config_set_path({h._php_str(_CFG_GLOBAL)}, $g);\n"
+        # DNSBL-settings block: the representative fields
+        f"$s = config_get_path({h._php_str(_CFG_DNSBL)}, array());\n"
+        "$s['pfb_dnsbl']      = 'on';\n"
+        "$s['dnsbl_vip_auto'] = 'on';\n"
+        "$s['dnsbl_lenient']  = 'on';\n"
+        "$s['pfb_idn']        = 'all';\n"
+        f"config_set_path({h._php_str(_CFG_DNSBL)}, $s);\n"
+        "write_config('pfBlockerNG upgrade-config-stability smoke: set representative config');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=60.0)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_write_representative_config failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def _snapshot_config(vm: SmokeVM) -> dict[str, str]:
+    """Read each snapshotted field from config.xml and return {path: stored_value}."""
+    return {path: h.config_get(vm, path) for path, _ in _SNAPSHOT_FIELDS}
+
+
+def _assert_snapshot_identical(before: dict[str, str], after: dict[str, str]) -> None:
+    """Assert every snapshotted field is byte-identical before and after upgrade.
+
+    Raises AssertionError listing ALL drifted fields (not just the first).
+    """
+    drifts: list[str] = []
+    for path, before_val in before.items():
+        after_val = after.get(path, "<ABSENT>")
+        if before_val != after_val:
+            drifts.append(f"  {path!r}:  before={before_val!r}  after={after_val!r}")
+    if drifts:
+        raise AssertionError(
+            "Upgrade config-preservation VIOLATED: config.xml stored values drifted "
+            f"after pkg upgrade ({len(drifts)} field(s)):\n" + "\n".join(drifts)
+        )
+
+
+def _setup_dnsbl_feed(vm: SmokeVM) -> str:
+    """Write the local DNSBL feed and wire it as the active DNSBL list; return the feed path."""
+    feed_path = h.write_local_feed(vm, "upgrade_config_stability.txt", _FEED_CONTENT)
+    spec = h.DnsblCase(
+        aliasname="UpgradeConfigStability",
+        feed_url=feed_path,
+        mode=h.DnsblMode.VIP,
+        header="upgrade-config-stability",
+        hsts=False,
+    )
+    h.inject(vm, spec)
+    return feed_path
+
+
+# --------------------------------------------------------------------------- #
+# The upgrade config-preservation test
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(900)  # two pkg installs + two reloads + DNS probes; budget ~12 min
+def test_pkg_upgrade_preserves_config_values(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """UPGRADE CONFIG-PRESERVATION CONTRACT: config.xml user settings are byte-identical
+    before and after ``pkg upgrade`` from the prior-release build to the branch build.
+
+    Issue #281: the pre-deinstall hook wipes ALL pfBlockerNG config sections when
+    pfb_keep is absent from config.xml. The fix seeds pfb_keep='on' via
+    pfb_keep_migrate() at install time so the hook is safe on the next upgrade.
+    This test proves the fix works end-to-end on the live VM.
+
+    NOTE: pfb_keep is intentionally NOT set in _write_representative_config() — its
+    absence is the exact bug condition the fix must handle. The test asserts that after
+    the lower build installs, pfb_keep='on' appears in config.xml (seeded by the
+    install migration), and that it and all other representative fields survive upgrade
+    byte-identical.
+
+    Scenario: issue #281 fix preserves user settings across pkg upgrade.
+      Background: our NONE-signed file:// repo above the Netgate ``pfSense`` repo.
+
+    Given the prior-release build (``<V>_1``) installed and representative config
+      written (dnsbl_lenient='on', dnsbl_vip_auto='on', pfb_dnsbl='on',
+      pfb_idn='all'; pfb_keep NOT set by the test), and the install migration having
+      seeded pfb_keep='on' into config.xml, and a DNSBL-blocked unique_domain() name
+      returning the VIP block shape on-box,
+
+    When the branch build (``<V>_9``) is installed over the lower build via
+      ``pkg upgrade``,
+
+    Then every snapshotted config.xml value is byte-identical (same raw stored string,
+      no config loss), AND the DNSBL probe still returns NOERROR + VIP on the SAME
+      domain (runtime contract unchanged).
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file — repo_vm already gated this"
+
+    base_version = read_compact_version(Path(pkg))
+    low_version = f"{base_version}_1"
+    high_version = f"{base_version}_9"
+    assert low_version != high_version, "forged builds must differ for a real version transition"
+
+    # Forge two builds on the runner — only the version string changes.
+    low_pkg = reversion_pkg(Path(pkg), low_version, tmp_path / "low")
+    high_pkg = reversion_pkg(Path(pkg), high_version, tmp_path / "high")
+
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+
+    try:
+        # ------------------------------------------------------------------ #
+        # GIVEN: prior-release build installed; representative config written #
+        # ------------------------------------------------------------------ #
+
+        # Install the LOWER (prior-release) build from our file:// repo.
+        pkg_delete(repo_vm)
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [low_pkg])
+        write_repo_conf(repo_vm, UPGRADE_REPO_DIR, ours_priority=pfsense_prio + 100)
+        pkg_update(repo_vm)
+        assert pkg_installed_version(repo_vm) is None, (
+            "package unexpectedly present before upgrade-contract test install"
+        )
+        pkg_install_from_repo(repo_vm)
+        assert pkg_installed_version(repo_vm) == low_version, (
+            f"expected lower build {low_version!r} installed, got {pkg_installed_version(repo_vm)!r}"
+        )
+
+        # Write representative config fields into config.xml (pfb_keep intentionally omitted).
+        _write_representative_config(repo_vm)
+
+        # Assert the install-time migration seeded pfb_keep='on' into config.xml.
+        # This proves pfb_keep_migrate() ran during install and the fix is in effect.
+        # pfb_keep was NOT written by _write_representative_config; only the migration seeds it.
+        seeded_keep = h.config_get(repo_vm, _CFG_GLOBAL + "/pfb_keep")
+        assert seeded_keep == "on", (
+            f"install-time migration did not seed pfb_keep: got {seeded_keep!r}, expected 'on'. "
+            f"The issue #281 fix (pfb_keep_migrate) did not run or did not write the key."
+        )
+
+        # Snapshot the stored values (BEFORE values — the exact raw strings from config.xml).
+        before_snapshot = _snapshot_config(repo_vm)
+
+        # Verify every expected value is present in the before snapshot.
+        for path, expected in _SNAPSHOT_FIELDS:
+            actual = before_snapshot[path]
+            assert actual == expected, f"BEFORE: config.xml {path!r} = {actual!r}, expected {expected!r}"
+
+        # Set up the DNSBL feed and ensure_dnsbl_vip so the DNS probe can run.
+        h.ensure_dnsbl_vip(repo_vm)
+        _setup_dnsbl_feed(repo_vm)
+
+        # Reload (the full DNSBL pass) to make the DNSBL live.
+        h.reload(repo_vm, "updatednsbl")
+
+        # BEFORE state DNS probe: the blocked domain must return NOERROR + VIP.
+        before_answer = h.dns_probe(repo_vm, _BLOCKED_DOMAIN, "A")
+        assert h.is_vip(before_answer), (
+            f"BEFORE upgrade: expected VIP block for {_BLOCKED_DOMAIN!r}; "
+            f"got rcode={before_answer.rcode!r} records={before_answer.records!r}. "
+            f"DNSBL was not live on the lower build."
+        )
+
+        # ------------------------------------------------------------------ #
+        # WHEN: branch build installed over the lower build via pkg upgrade   #
+        # ------------------------------------------------------------------ #
+
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [high_pkg])
+        pkg_update(repo_vm)
+        proc = pkg_upgrade(repo_vm)
+
+        # Basic sanity: the upgrade actually moved the version.
+        combined = proc.stdout + proc.stderr
+        assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve on pkg upgrade:\n{combined}"
+        installed_after = pkg_installed_version(repo_vm)
+        assert installed_after == high_version, (
+            f"pkg upgrade did not move {low_version!r} -> {high_version!r}; now at {installed_after!r}"
+        )
+
+        # ------------------------------------------------------------------ #
+        # THEN: config.xml values byte-identical; DNSBL behaviour unchanged  #
+        # ------------------------------------------------------------------ #
+
+        # Read config.xml AFTER upgrade and assert every field is byte-identical.
+        after_snapshot = _snapshot_config(repo_vm)
+        _assert_snapshot_identical(before_snapshot, after_snapshot)
+
+        # DNS contract: re-reload so the upgraded build's DNSBL is live, then
+        # probe the SAME blocked domain. Must still return NOERROR + VIP.
+        h.reload(repo_vm, "updatednsbl")
+        after_answer = h.dns_probe(repo_vm, _BLOCKED_DOMAIN, "A")
+        assert h.is_vip(after_answer), (
+            f"AFTER upgrade: expected VIP block for {_BLOCKED_DOMAIN!r}; "
+            f"got rcode={after_answer.rcode!r} records={after_answer.records!r}. "
+            f"Runtime contract broken by upgrade."
+        )
+
+    finally:
+        pkg_delete(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)


### PR DESCRIPTION
## Summary

On `pkg upgrade`, pfSense fires the old package's `custom_php_pre_deinstall_command` → `pfblockerng_php_pre_deinstall_command()`. That reads `$pfb['keep']` = `$pfb['config']['pfb_keep']` with no fallback. `pfb_keep` only persists to `config.xml` once the user saves the General tab (the GUI default is `'on'`, but that default never persists). When the key is absent, `$pfb['keep'] != 'on'` is true and `pfb_remove_config_settings()` deletes **all ~22 pfBlockerNG config sections** — wholesale loss of user settings on upgrade for any box where General settings were never explicitly saved.

This matches the symptom reported in #281 (all DNSBL-settings fields, including `pfb_dnsbl` which ADR-28 never touched, reset together after a forged `_1 → _9` upgrade) — a genuine config-loss-on-upgrade, not an ADR-28 regression or a pure harness artifact.

## Fix

1. **Runtime default** — `pfb_global()` reads `$pfb['config']['pfb_keep'] ?? 'on'`, so an absent key never evaluates as off (and the PHP 8 undefined-key warning is silenced). `??` (not `?:`) preserves an explicit `''` (user-chosen off).
2. **Install-time seed** — `pfb_keep_migrate()` seeds the key to `'on'` only on an existing, already-populated General config section, wired in `pfblockerng_install.inc` alongside the other upgrade migrations. A fresh install returns `NULL` (the runtime default stands); an existing explicit `''` is never overwritten.

## Tests

- `PfbKeepMigrateTest` — all four branches (fresh install, existing-missing, explicit off, already-on idempotent), before-and-after.
- Re-adds the upgrade config-stability smoke test (`test_upgrade_config_stability.py`, `repo` marker), reframed from the removed ADR-28 case to the #281 preservation contract: it never sets `pfb_keep`, and asserts config.xml values are byte-identical before and after `pkg upgrade` plus a live DNSBL VIP probe for the runtime contract. Live before/after runs in the CI repo fan-out.

Note: the pre-deinstall hook cannot currently distinguish upgrade from true removal; broadening that (and a centralized config reader/writer with migration/adapters for smooth rollback) is tracked as a separate follow-up per the issue discussion.

Fixes #281

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA2jJJPJzJaVraEVDp8NVp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration settings now preserved during package upgrades
  * Migration mechanism ensures seamless upgrades from prior versions with existing installations

* **Tests**
  * Added comprehensive upgrade configuration stability tests to validate settings retention across package versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->