### PR TITLE
widget: assemble dashboard AJAX rows as complete &lt;tr&gt; elements

### DIFF
--- a/src/usr/local/www/widgets/javascript/pfblockerng.js
+++ b/src/usr/local/www/widgets/javascript/pfblockerng.js
@@ -44,11 +44,11 @@ function pfBlockerNG_escapeHtml(s) {
  * verbatim. Mirrors the per-column escaping contract in pfblockerng.widget.php.
  *
  * @param {string[]} cols - [alias, count, packets, updated, img].
- * @returns {string} the row's <td> cells terminated by a closing </tr>; the
- *   caller prepends the opening <tr> (preserving the original row assembly).
+ * @returns {string} a complete <tr>...</tr> table row; the caller concatenates
+ *   the rows with join('') (no separator), so the markup stays well-formed.
  */
 function pfBlockerNG_buildWidgetRow(cols) {
-	var line = '<td><small>' + cols[0] + '</small></td>';
+	var line = '<tr><td><small>' + cols[0] + '</small></td>';
 	line += '<td><small>' + pfBlockerNG_escapeHtml(cols[1]) + '</small></td>';
 	line += '<td><small>' + cols[2] + '</small></td>';
 	line += '<td><small>' + pfBlockerNG_escapeHtml(cols[3]) + '</small></td>';
@@ -97,7 +97,7 @@ function pfBlockerNG_fetch_new_widget_callback(callback_data) {
 
 		if (new_data_to_add.length > 0) {
 			var tbody = $('#pfBNG-table');
-			tbody.html('<tr>' + new_data_to_add + '</tr>');
+			tbody.html(new_data_to_add.join(''));
 			$('body').popover({ selector: '[data-popover]', trigger: 'click hover', placement: 'right', delay: {show: 50, hide: 400}});
 			$('#pfB_col1, #pfB_col2, #pfB_col3, #pfB_col4').attr("data-sorted", false);
 		}

--- a/tests/js/widget_render.test.js
+++ b/tests/js/widget_render.test.js
@@ -127,10 +127,51 @@ test('pfBlockerNG_buildWidgetRow: plain row (no metacharacters) renders correctl
 	// When
 	var row = pfBlockerNG_buildWidgetRow(cols);
 
-	// Then: all five columns appear in the expected td structure.
+	// Then: all five columns appear in the expected td structure, wrapped in a
+	// complete <tr>...</tr> (the row owns both its opening and closing tags).
+	assert.ok(row.startsWith('<tr>'), 'row starts with opening <tr>');
+	assert.ok(row.endsWith('</td></tr>'), 'row ends with closing </td></tr>');
 	assert.ok(row.includes('<td><small>pfB_Deny_v4</small></td>'), 'col0 present');
 	assert.ok(row.includes('<td><small>1,234</small></td>'), 'col1 present');
 	assert.ok(row.includes('<td><small>0</small></td>'), 'col2 present');
 	assert.ok(row.includes('<td><small>Jun 01 12:00</small></td>'), 'col3 present');
 	assert.ok(row.includes('<td><i class="fa-solid fa-turn-down"></i></td></tr>'), 'col4 present');
+});
+
+// Scenario: the row is self-contained — exactly one <tr>/</tr> pair, no nesting.
+//
+// Given any row built by the helper,
+// When its tag occurrences are counted,
+// Then there is exactly one opening <tr> and one closing </tr> (so the caller
+//   must NOT add its own wrapping tags — issue #288).
+
+test('pfBlockerNG_buildWidgetRow: emits exactly one <tr>/</tr> pair', () => {
+	var cols = ['pfB_Deny_v4', '1,234', '0', 'Jun 01 12:00', '<i class="fa"></i>'];
+
+	var row = pfBlockerNG_buildWidgetRow(cols);
+
+	assert.equal(row.split('<tr>').length - 1, 1, 'exactly one opening <tr>');
+	assert.equal(row.split('</tr>').length - 1, 1, 'exactly one closing </tr>');
+});
+
+// Scenario: multi-row assembly matches the caller's join('') (issue #288).
+//
+// Given several rows accumulated in an array (as the AJAX callback does),
+// When they are concatenated the way the caller now does — join('') —
+// Then the markup carries no stray comma (the old '<tr>' + array coercion
+//   inserted commas via Array.prototype.toString()) and contains exactly one
+//   <tr>/</tr> pair per row, with no leftover trailing tag.
+
+test('pfBlockerNG_buildWidgetRow: rows join into well-formed markup with no stray commas', () => {
+	// Given: two distinct rows.
+	var rowA = pfBlockerNG_buildWidgetRow(['AliasA', '1', '0', 'Jun 01 12:00', '<i></i>']);
+	var rowB = pfBlockerNG_buildWidgetRow(['AliasB', '2', '0', 'Jun 02 12:00', '<i></i>']);
+
+	// When: assembled the way the AJAX callback inserts them.
+	var assembled = [rowA, rowB].join('');
+
+	// Then: no comma artifact, and exactly one <tr>/</tr> per row (no extra trailing tag).
+	assert.ok(!assembled.includes(','), 'no stray comma between rows');
+	assert.equal(assembled.split('<tr>').length - 1, 2, 'one opening <tr> per row');
+	assert.equal(assembled.split('</tr>').length - 1, 2, 'one closing </tr> per row');
 });


### PR DESCRIPTION
## Summary

In the Dashboard widget refresh path (`src/usr/local/www/widgets/javascript/pfblockerng.js`), `pfBlockerNG_buildWidgetRow()` returned only the `<td>` cells terminated by `</tr>` (no opening `<tr>`), and the AJAX callback inserted the accumulated rows with:

```js
tbody.html('<tr>' + new_data_to_add + '</tr>');
```

Coercing the row array to a string runs `Array.prototype.toString()` (comma-separated), so for N rows the markup carried stray commas between rows and an extra trailing `</tr>` — malformed but tolerated by browsers, which is why it went unnoticed. Pre-existing; predates the #287 escaping refactor.

## Fix

- `pfBlockerNG_buildWidgetRow()` now emits a complete `<tr>…</tr>` row (prepended `<tr>`; `@returns` docblock updated).
- The caller uses `new_data_to_add.join('')` — no separator, no redundant outer wrapping.

Rendered output stays equivalent and the per-column escaping contract from #287 is unchanged (col1/col3 escaped, col0/col2/col4 verbatim).

## Tests

`tests/js/widget_render.test.js`:

- The "plain row" test now asserts the row starts with `<tr>` and ends with `</td></tr>`.
- New test: the helper emits exactly one `<tr>`/`</tr>` pair (no nesting/duplication).
- New test: two rows assembled via `join('')` carry **no stray comma** and exactly one `<tr>`/`</tr>` pair per row (pins the corrected contract against the old coercion artifact).

Verified the 3 contract assertions fail on pre-fix source and pass with the fix; the 12 escaping tests stay green (15/15 with the fix).

Fixes #288

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEtct4G4nCXfjLYq51AJ5k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed widget table rendering so each generated data row is well-formed as a complete `<tr>...</tr>`, ensuring consistent formatting across the interface.

* **Tests**
  * Expanded widget row generation tests to verify exact `<tr>...</tr>` output, correct `<td>`/`<small>` structure for all columns, and proper well-formed markup when multiple rows are concatenated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->