### PR TITLE
pfblockerng: add timed DNSBL bypass IP to bypass set (#233)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2961,6 +2961,7 @@ def pfb_apply_control_command(control_command: list[str]) -> tuple[bool, str]:
                                     control_rcd = False
                                     control_msg = "Python_control: Add bypass for IP: [ {} ] thread failed".format(b_ip)
                                 else:
+                                    gpListDB[b_ip] = 0
                                     control_msg = "{} for {} second(s)".format(control_msg, duration)
                             else:
                                 control_rcd = False

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -139,6 +139,29 @@ class TestSharedHandlerBypass:
         # Cleanup: await the spawned timer thread so its async state does not leak.
         _await_control_thread_stopped("addbypass192.0.2.10")
 
+    def test_addbypass_with_duration_adds_ip_then_expires(self) -> None:
+        # Scenario: a timed addbypass must insert the IP into the bypass set immediately
+        # (so DNSBL is bypassed for the duration), then the expiry thread removes it.
+        # Background: the no-duration path inserts synchronously; the timed path must too.
+
+        # Given: the IP is NOT in the bypass DB before the command (BEFORE state).
+        assert P.gpListDB.get("198.51.100.20") is None
+
+        # When: addbypass with a 1-second duration is applied.
+        P.pfb["mod_threading"] = True
+        applied, msg = P.pfb_apply_control_command(["python_control", "addbypass", "198.51.100.20", "1"])
+
+        # Then (insert): the command succeeds and the IP is in the bypass set immediately --
+        # before the expiry thread's sleep elapses. This assertion fails on pre-fix code.
+        assert applied is True
+        assert "second" in msg
+        assert P.gpListDB.get("198.51.100.20") == 0
+        assert P.pfb["gpListDB"] is True
+
+        # Then (expiry): once the timer thread finishes, the IP is removed.
+        _await_control_thread_stopped("addbypass198.51.100.20")
+        assert P.gpListDB.get("198.51.100.20") is None
+
     def test_addbypass_dash_encoded_ipv4_is_unmapped(self) -> None:
         # The DNS-TXT transport encodes the dotted IPv4 with '-'; the shared handler
         # un-maps it. Proves the legacy encoding still resolves to the real IP.


### PR DESCRIPTION
## Summary

In the DNSBL control handler `pfb_apply_control_command()` (`src/usr/local/pkg/pfblockerng/pfb_unbound.py`), a **timed** `addbypass <ip> <dur>` validated the duration and started the expiry thread but never inserted the IP into `gpListDB`. Only the no-duration path inserted (`gpListDB[b_ip] = 0`). The expiry thread `python_control_addbypass()` merely sleeps then pops the key *if present* — so a timed bypass reported success while the IP was never in the bypass set: the bypass silently no-opped (DNSBL kept applying).

Fails closed (no over-permit) — but a timed bypass simply had no effect.

## Fix

Insert `gpListDB[b_ip] = 0` in the timed-bypass **thread-started success branch only**, mirroring the no-duration path. No failure branch (thread-start-failed / previous-in-progress / duration-out-of-range) is touched.

## Test

Adds `test_addbypass_with_duration_adds_ip_then_expires` to `TestSharedHandlerBypass`, pinning the full lifecycle: IP absent **before**, present in `gpListDB` immediately **after** the command (the assertion that fails on pre-fix code), and absent **after** the expiry thread finishes. The pre-existing duration test only asserted the thread starts, never `gpListDB` membership — which is why the bug hid.

Verified fail-before / pass-after: pre-fix the new test fails at `assert gpListDB.get(...) == 0` (`None == 0`); post-fix the full control-channel module (33) and full suite (1731) pass.

Fixes #233

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA2jJJPJzJaVraEVDp8NVp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Bypass IP addresses with a specified duration are now immediately active while the expiration timer runs, instead of remaining unavailable until activated elsewhere.

* **Tests**
  * Added test coverage for timed bypass functionality to verify immediate activation and expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->