### PR TITLE
tests(smoke): make the SafeSearch CNAME-chase test hermetic via the mock DNS zone

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -47,10 +47,11 @@ import shlex
 import subprocess
 import time
 import uuid
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+from typing import NamedTuple
 
 from .conftest import GUEST_TO_HOST_ALIAS, SMOKE_DIR, STUB_DNS_A, SmokeVM, resolve_a
 
@@ -315,6 +316,23 @@ class IpCase:
         return f"pfB_{self.aliasname}_{self.family}"
 
 
+class SafeSearchEntry(NamedTuple):
+    """One SafeSearch CNAME-redirect row for :func:`inject_safesearch_cname_entries`.
+
+    Stored as a 5-column CSV row in ``pfb_py_ss.txt``:
+    ``domain,cname,target,baked_v4,baked_v6`` — where column 2 is the LITERAL
+    token ``cname`` (the routing marker ``isSafeSearch["A"] == "cname"``), column 3
+    is the CNAME target fqdn that Unbound chases (#1 redirect), and columns 4/5 are
+    the #2 baked-fallback IPs used when the chase yields only a bare CNAME (no address).
+    Leave ``baked_v4`` / ``baked_v6`` empty when the test does not exercise the fallback.
+    """
+
+    domain: str
+    target: str
+    baked_v4: str = ""
+    baked_v6: str = ""
+
+
 # --------------------------------------------------------------------------- #
 # Deploy — install the branch-under-test .pkg (evolved; NOT deploy.sh rsync)
 # --------------------------------------------------------------------------- #
@@ -414,6 +432,17 @@ def write_local_feed(vm: SmokeVM, name: str, contents: str, *, timeout: float = 
 
 UNBOUND_HSTS_FILE = "/var/unbound/pfb_py_hsts.txt"
 UNBOUND_PFB_INI = "/var/unbound/pfb_unbound.ini"
+# pfb_unbound.py loads SafeSearch redirect entries from this chroot-relative CSV
+# (5-col format: domain,cname,target,baked_v4,baked_v6; see inject_safesearch_cname_entries).
+UNBOUND_PY_SS_FILE = "/var/unbound/pfb_py_ss.txt"
+
+# SafeSearch test IPs — each is DISTINCT from the stub sentinel (STUB_DNS_A /
+# STUB_DNS_AAAA) so a test can tell "chase reached the target" from "sentinel default",
+# and from each other so a test can tell "#1 chase result" from "#2 baked fallback".
+SS_TARGET_A = "198.51.100.10"  # RFC 5737 TEST-NET-2: the CNAME chase target address (#1)
+SS_TARGET_AAAA = "2001:db8:5350::10"  # RFC 3849: the CNAME chase target address (#1)
+SS_BAKED_A = "203.0.113.20"  # RFC 5737 TEST-NET-3 (≠ STUB_DNS_A .99): baked fallback (#2)
+SS_BAKED_AAAA = "2001:db8:5350::20"  # RFC 3849 (≠ STUB_DNS_AAAA ::99): baked fallback (#2)
 
 
 def add_hsts_name(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> None:
@@ -988,6 +1017,156 @@ def set_unbound_forwarding(vm: SmokeVM, on: bool, *, upstream: str = "1.1.1.1", 
             f"set_unbound_forwarding({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
         )
     # services_unbound_configure restarts Unbound — wait for it before any probe.
+    wait_unbound_ready(vm)
+
+
+def use_stub_for_safesearch(vm: SmokeVM, forwarding_on: bool, *, timeout: float = 120.0) -> None:
+    """Wire Unbound to the stub DNS so SafeSearch CNAME redirects resolve hermetically.
+
+    Supports BOTH resolver modes so a test can vary forwarding without touching
+    the stub wiring:
+
+    ``forwarding_on=True`` (FORWARDING mode): delegates to the same config as
+    :func:`use_system_dns_upstream` — sets ``system/dnsserver = [10.0.2.2]``,
+    ``unbound/forwarding = on``, clears ``dnssec`` and ``custom_options``.
+    Queries forward to ``10.0.2.2`` (the SLIRP host alias), which NATs
+    ``guest->10.0.2.2:53`` to the stub on the runner's loopback.
+
+    ``forwarding_on=False`` (RECURSIVE mode): keeps ``unbound/forwarding`` UNSET
+    (Unbound recurses normally) but injects a catch-all ``forward-zone`` in
+    ``unbound/custom_options`` pointing every query at ``10.0.2.2``, so the stub
+    still answers all queries while Unbound operates in recursive mode.
+    ``custom_options`` is stored base64-encoded in ``config.xml`` (the pfBlockerNG
+    textarea convention: the GUI base64-encodes on save, the renderer decodes on
+    read); the encoded value is written here.  ``dnssec`` is cleared in both
+    modes — the stub's answers are unsigned and a validator would mark them bogus.
+
+    In BOTH modes: runs ``services_unbound_configure()`` + :func:`wait_unbound_ready`,
+    then probes a throwaway name to confirm the stub relay is live before returning.
+    A failed self-check raises immediately with the mode and the answer received.
+
+    NOTE: ``services_unbound_configure`` regenerates ``unbound.conf`` WITHOUT
+    pfBlockerNG's python module.  The caller MUST run a pfBlockerNG reload AFTER
+    this call to re-add the module and reload ``safeSearchDB`` before any
+    SafeSearch probe.
+    """
+    if forwarding_on:
+        # Forwarding mode: identical to use_system_dns_upstream — delegate so
+        # the self-check and config shape stay in sync with that helper.
+        use_system_dns_upstream(vm, timeout=timeout)
+        return
+
+    # Recursive mode: no unbound/forwarding, but route every query to the stub
+    # via a catch-all forward-zone in custom_options.  pfSense stores
+    # custom_options base64-encoded (pfbng_text_area_decode / base64_encode on
+    # save), so encode before writing.
+    forward_zone = 'forward-zone:\n    name: "."\n    forward-addr: 10.0.2.2\n'
+    encoded = base64.b64encode(forward_zone.encode()).decode()
+    snippet = (
+        "$s = config_get_path('system', array());\n"
+        f"$s['dnsserver'] = array({_php_str(GUEST_TO_HOST_ALIAS)});\n"
+        "unset($s['dnsallowoverride']);\n"
+        "config_set_path('system', $s);\n"
+        "$u = config_get_path('unbound', array());\n"
+        "unset($u['forwarding']);\n"
+        "unset($u['dnssec']);\n"
+        f"$u['custom_options'] = {_php_str(encoded)};\n"
+        "config_set_path('unbound', $u);\n"
+        "write_config('pfBlockerNG smoke: stub-DNS SafeSearch recursive mode');\n"
+        "services_unbound_configure();\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"use_stub_for_safesearch(forwarding_on=False) failed: "
+            f"rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+    # services_unbound_configure restarts Unbound — wait for it before any probe.
+    wait_unbound_ready(vm)
+    # RELAY SELF-CHECK: resolve a throwaway name; in recursive mode every query
+    # routes to the stub via the catch-all forward-zone and MUST return the sentinel.
+    probe = unique_domain("ssstubselfcheck")
+    ans = dns_probe(vm, probe, "A", timeout=10.0, attempts=3, delay=3.0)
+    if not resolves_to(ans, STUB_DNS_A):
+        raise RuntimeError(
+            f"SafeSearch stub relay self-check FAILED (recursive mode): "
+            f"{probe} -> {ans} (expected sentinel {STUB_DNS_A}). "
+            f"The catch-all forward-zone -> 10.0.2.2 -> runner 127.0.0.1:53 path is not working."
+        )
+
+
+def inject_safesearch_cname_entries(
+    vm: SmokeVM,
+    entries: Sequence[SafeSearchEntry],
+    *,
+    timeout: float = 60.0,
+) -> None:
+    """Append fabricated SafeSearch CNAME-redirect rows to ``pfb_py_ss.txt`` and reload.
+
+    Each entry is written as a 5-column CSV row:
+    ``domain,cname,target,baked_v4,baked_v6`` where column 2 is the LITERAL token
+    ``cname`` (the routing marker ``isSafeSearch["A"] == "cname"`` in
+    ``pfb_unbound.py``), column 3 is the CNAME target fqdn that Unbound chases
+    (#1 redirect), and columns 4/5 are the #2 baked-fallback IPs used when the chase
+    yields only a bare CNAME with no address.  Empty strings for ``baked_v4``/
+    ``baked_v6`` are valid when the test does not exercise the fallback path.
+
+    Rows are APPENDED (``tee -a``) so any package-written rows survive; the file is
+    created if absent.  Appending is idempotent-friendly within a session as long as
+    each test uses unique domain names (:func:`unique_domain`).
+
+    After writing, the Unbound daemon is bounced RAW (TERM the pid, wait, restart)
+    to reload ``safeSearchDB`` from the updated file — identical to
+    ``pfb_stop_start_unbound`` (``pfblockerng.inc:5444``).  This is NOT a pfBlockerNG
+    update (which would overwrite the file with package-generated content); the raw
+    bounce re-runs the python module's ``init()`` which re-reads ``pfb_py_ss.txt`` as
+    written.  For ``safeSearchDB`` to take effect the DNSBL python module must already
+    be loaded in ``unbound.conf`` — DNSBL must be enabled and a pfBlockerNG reload run
+    before this call.
+    """
+    csv_lines = "\n".join(f"{e.domain},cname,{e.target},{e.baked_v4},{e.baked_v6}" for e in entries)
+    contents = csv_lines + "\n"
+    # Append to the SafeSearch CSV (chroot-relative; Unbound is chrooted at /var/unbound).
+    result = subprocess.run(
+        vm.ssh_argv("tee", "-a", UNBOUND_PY_SS_FILE),
+        input=contents,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"inject_safesearch_cname_entries: tee to {UNBOUND_PY_SS_FILE} failed: "
+            f"rc={result.returncode} {result.stderr!r}"
+        )
+    # Raw Unbound bounce to reload safeSearchDB from the updated file.
+    # Mirrors pfb_stop_start_unbound (pfblockerng.inc:5444): TERM the pid, wait
+    # up to 30 s for exit, then restart the daemon (which re-daemonizes and returns).
+    # Fed on stdin to a remote /bin/sh (the php_eval idiom) so the multi-token POSIX
+    # script — $(...), `;`, the for-loop — is parsed by sh itself, never the SSH
+    # login shell (pfSense root defaults to tcsh, which would mangle it).
+    bounce_cmd = (
+        "kill -TERM $(cat /var/run/unbound.pid)\n"
+        "for i in $(seq 1 30); do\n"
+        "  pgrep -x unbound >/dev/null || break\n"
+        "  sleep 1\n"
+        "done\n"
+        "/usr/local/sbin/unbound -c /var/unbound/unbound.conf\n"
+    )
+    bounce = subprocess.run(
+        vm.ssh_argv("/bin/sh"),
+        input=bounce_cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if bounce.returncode != 0:
+        raise RuntimeError(
+            f"inject_safesearch_cname_entries: Unbound bounce failed: rc={bounce.returncode} {bounce.stderr!r}"
+        )
     wait_unbound_ready(vm)
 
 

--- a/tests/smoke/test_smoke_safesearch.py
+++ b/tests/smoke/test_smoke_safesearch.py
@@ -1,48 +1,54 @@
-"""Live-VM smoke for the SafeSearch CNAME redirect (issue #149).
+"""Live-VM smoke for the SafeSearch CNAME redirect — fully hermetic (issue #238).
 
-SafeSearch ships two CNAME redirects — ``duckduckgo.com -> safe.duckduckgo.com``
-and ``pixabay.com -> safesearch.pixabay.com`` — every other SafeSearch entry is a
-plain A/AAAA rewrite. Before #149 those two rode a residual native-Unbound
-``local-zone`` include (the last sliver ADR-02 left behind); now pfb_unbound.py does
-the redirect itself: it plants the synthetic CNAME in Unbound's cache and restarts
-the iterator so the iterator chases the target (working around NLnetLabs/unbound
-#976 — a module-handed CNAME is not chased), re-stamping DNSSEC so the synthesized
-hop is not bogus. A #2 baked-IP fallback (resolved at list-build, kept fresh by the
-15-min cron) answers if the chase ever yields no address.
+The test is driven entirely against the in-process stub DNS server with egress
+BLOCKED.  No live third-party DNS is contacted; all source and target names are
+fabricated with :func:`~helpers.unique_domain` (``uuid-*.com``) and served by
+the stub with distinct RFC 5737 / RFC 3849 fixture IPs.
 
-Run in BOTH resolver modes (the fixture is parametrized on ``unbound/forwarding``):
-RECURSIVE and FORWARDING to a real upstream. The redirect works in both — the
-iterator checks the message cache (where the module plants the CNAME) before it
-forwards/recurses, then chases the TARGET. Forwarding uses a REAL upstream so the
-SafeSearch target resolves to its own distinct address (the mock stub answers every
-name identically and would mask the result; that — NOT a broken chase — is why the
-smoke must not run against the stub). Targets are unsigned in DNS, so no DNSSEC angle.
+Mechanism under test: pfBlockerNG plants a synthetic ``src -> CNAME -> target``
+redirect in Unbound's message cache (via ``safesearch_cname_redirect`` in
+``pfb_unbound.py``) and restarts the iterator so the iterator chases the target
+name.  The stub serves the target's address, so ``src`` resolves to that address
+(#1 chase outcome).  When the target resolves with NO address (NODATA), the module
+falls back to the baked IP embedded in the CSV row (#2 baked-fallback outcome).
 
-The slow per-mode setup (Unbound reconfigure + pfBlockerNG reloads) lives in the
-FIXTURE, so the 30s per-test-body cap (smoke.yml: ``timeout_func_only``) does not bite
-and no per-test timeout override is needed.
+Both resolver modes are covered (the fixture is parametrized):
 
-Probed ON-BOX (``drill @127.0.0.1``); SafeSearch redirects have no localhost
-exemption, so the redirect shows there.
+* **recursive** — Unbound recurses; a catch-all ``forward-zone`` in
+  ``custom_options`` redirects all queries to the stub.
+* **forwarding** — Unbound forwards to ``10.0.2.2`` (SLIRP host alias → stub).
+
+All heavy setup (Unbound reconfigure + pfBlockerNG reloads) lives in the fixture
+so the 30 s per-test-body cap (``smoke.yml: timeout_func_only``) does not bite.
+
+This replaces the former live-DNS dependency on real ``duckduckgo.com`` /
+``pixabay.com`` redirects, which drifted and made the test flaky (issue #238).
 """
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from collections.abc import Iterator
+from typing import NamedTuple
 
 import pytest
 
 from . import helpers as h
-from .conftest import SmokeVM
+from .conftest import STUB_DNS_A, SmokeVM, _StubDnsServer
 
 pytestmark = [pytest.mark.smoke, pytest.mark.safesearch]
 
-# The two shipped CNAME-SafeSearch names and their redirect targets.
-DDG = "duckduckgo.com"
-DDG_TARGET = "safe.duckduckgo.com"
-PIX = "pixabay.com"
-PIX_TARGET = "safesearch.pixabay.com"
+
+class _SSFixture(NamedTuple):
+    """Everything the SafeSearch tests need, yielded by :func:`safesearch_vm`."""
+
+    vm: SmokeVM
+    forwarding_on: bool
+    src_chase: str  # the CNAME-redirect source name for the #1 chase test
+    target_chase: str  # the CNAME target name served with SS_TARGET_A/AAAA by the stub
+    src_fallback: str  # the CNAME-redirect source name for the #2 baked-fallback test
+    before: h.DnsAnswer  # sentinel answer for src_chase BEFORE the redirect is active
 
 
 @pytest.fixture(scope="module")
@@ -57,107 +63,222 @@ def _ss_deployed(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
 
 @pytest.fixture(scope="module", params=[False, True], ids=["recursive", "forwarding"])
 def safesearch_vm(
-    _ss_deployed: SmokeVM, request: pytest.FixtureRequest
-) -> Iterator[tuple[SmokeVM, bool, h.DnsAnswer, h.DnsAnswer]]:
-    """Enable DNSBL + SafeSearch in one resolver mode; capture the pre-redirect answers.
+    _ss_deployed: SmokeVM,
+    stub_dns: _StubDnsServer,
+    request: pytest.FixtureRequest,
+) -> Iterator[_SSFixture]:
+    """Wire Unbound to the stub, inject fabricated SafeSearch CNAME rows, yield fixture.
 
-    Parametrized on ``forwarding`` — the ONLY difference between the two runs is
-    ``unbound/forwarding`` off (recursive) vs on (forward to a real upstream). Egress
-    stays open so both recursion and the real-upstream forward resolve. All reloads are
-    here in the fixture (not the test body), so no per-test timeout override is needed.
+    Parametrized on ``forwarding_on``.  Egress is BLOCKED for the duration so the
+    test is hermetic; the stub is reachable via the SLIRP ``10.0.2.2`` loopback path
+    regardless.
 
-    Yields ``(vm, forwarding_on, ddg_before, pix_before)`` — the SafeSearch-off answers,
-    so each test proves the redirect CHANGED them.
+    Sequence:
+
+    1. Block egress (hermeticity gate).
+    2. Fabricate source + target names via :func:`~helpers.unique_domain`.
+    3. Wire Unbound to the stub (:func:`~helpers.use_stub_for_safesearch`) — this
+       strips the pfb python module from ``unbound.conf``.
+    4. Enable DNSBL with a dummy local feed so the pfb python module is reloaded
+       into ``unbound.conf``.  SafeSearch is NOT enabled via config — rows are
+       injected directly so the package's real ddg/pixabay rows are irrelevant.
+    5. Register stub records: ``target_chase`` → SS_TARGET_A/AAAA; ``target_fallback``
+       → NODATA (no families registered → the chase yields no address → baked fallback).
+    6. Capture the BEFORE answer for ``src_chase`` (stub sentinel — distinct from the
+       post-redirect SS_TARGET_A so the before/after mandate is provable).
+    7. Inject the fabricated CSV rows and bounce Unbound to reload ``safeSearchDB``.
+    8. Flush the Unbound cache (the BEFORE probe cached the sentinel; clear it so the
+       AFTER probe is evaluated fresh through the module).
+    9. Yield the :class:`_SSFixture`.
+    10. Teardown: drop stub records, restore egress, collect diagnostics.
     """
-    vm = _ss_deployed
+    vm: SmokeVM = _ss_deployed
     forwarding_on: bool = request.param
-    h.unblock_egress()
 
-    # The single toggled variable. services_unbound_configure here regenerates the base
-    # unbound.conf WITHOUT pfBlockerNG's python module; the reloads below re-add it.
-    h.set_unbound_forwarding(vm, on=forwarding_on)
+    # Step 1: block egress — all DNS must route through the stub.
+    h.block_egress()
 
-    # Enable DNSBL (python module loaded) with a dummy local feed; SafeSearch still OFF,
-    # so the CNAME names resolve to their real sites for the BEFORE capture.
-    feed = h.write_local_feed(vm, "smoke_ss_dummy.txt", f"{h.unique_domain('ssdummy')}\n")
-    spec = h.DnsblCase(aliasname="smokess", feed_url=feed, header="smokess")
-    h.set_safesearch_enabled(vm, False)
-    h.inject(vm, spec)
-    h.reload(vm, "update")
-
-    ddg_before = h.dns_probe(vm, DDG, "A")
-    pix_before = h.dns_probe(vm, PIX, "A")
-
-    # WHEN: enable SafeSearch and rebuild -> the redirect rows enter pfb_py_ss.txt and
-    # pfb_unbound.py reloads safeSearchDB on the unbound restart (issue #149 forces the
-    # restart, since the data swap alone does not reload safeSearchDB).
-    h.set_safesearch_enabled(vm, True)
-    h.reload(vm, "update")
-    # The BEFORE probe cached the real site answer; clear it so the AFTER probe is
-    # evaluated fresh through the module (belt-and-braces; the reload already restarted).
-    h.flush_unbound_cache(vm)
+    # Step 2: fabricate source + target names (must be unique_domain — never RFC-6761
+    # TLDs or HSTS-preload names; SafeSearch redirects have no localhost exemption).
+    src_chase = h.unique_domain("ss-src")
+    target_chase = h.unique_domain("ss-tgt")
+    src_fallback = h.unique_domain("ss-fb-src")
+    target_fallback = h.unique_domain("ss-fb-tgt")
 
     try:
-        yield vm, forwarding_on, ddg_before, pix_before
+        # Step 3: wire Unbound to the stub (strips pfb python module from unbound.conf).
+        h.use_stub_for_safesearch(vm, forwarding_on)
+
+        # Step 4: enable DNSBL with a dummy local feed — reloads pfb python module into
+        # unbound.conf so safeSearchDB and the CNAME redirect logic are active.
+        # SafeSearch is left DISABLED in config; we inject rows directly below.
+        feed = h.write_local_feed(vm, "smoke_ss_dummy.txt", f"{h.unique_domain('ssdummy')}\n")
+        spec = h.DnsblCase(aliasname="smokess", feed_url=feed, header="smokess")
+        h.inject(vm, spec)
+        h.reload(vm, "update")
+
+        # Step 5: register stub records.
+        # Chase target: stub serves SS_TARGET_A/AAAA — DISTINCT from the sentinel so
+        # the test can tell "chase reached the target" from "sentinel default".
+        stub_dns.set_records(target_chase, a=(h.SS_TARGET_A,), aaaa=(h.SS_TARGET_AAAA,))
+        # Fallback target: NODATA (no families) — chase yields only a bare CNAME with no
+        # address, so the module answers src_fallback with the baked IP from the CSV row.
+        stub_dns.set_records(target_fallback)
+
+        # Step 6: capture the BEFORE answer (redirect not active yet).
+        # src_chase is an unregistered name -> stub sentinel STUB_DNS_A.
+        # This is DISTINCT from SS_TARGET_A so the before≠after transition is provable.
+        before = h.dns_probe(vm, src_chase, "A")
+
+        # Step 7: inject the fabricated SafeSearch CNAME rows and bounce Unbound.
+        h.inject_safesearch_cname_entries(
+            vm,
+            [
+                h.SafeSearchEntry(src_chase, target_chase),
+                h.SafeSearchEntry(src_fallback, target_fallback, h.SS_BAKED_A, h.SS_BAKED_AAAA),
+            ],
+        )
+
+        # Step 8: flush the cache — the BEFORE probe cached the sentinel; clearing it
+        # ensures the AFTER probe is evaluated fresh through the pfb python module.
+        h.flush_unbound_cache(vm)
+
+        yield _SSFixture(
+            vm=vm,
+            forwarding_on=forwarding_on,
+            src_chase=src_chase,
+            target_chase=target_chase,
+            src_fallback=src_fallback,
+            before=before,
+        )
+
     finally:
+        # Drop all fabricated stub records so they do not leak to later test modules.
+        stub_dns.clear_cname()
         h.unblock_egress()
         h.collect_host_diagnostics(vm)
 
 
-def test_safesearch_cname_redirect_takes_effect(
-    safesearch_vm: tuple[SmokeVM, bool, h.DnsAnswer, h.DnsAnswer],
-) -> None:
-    """The gate: enabling SafeSearch REDIRECTS duckduckgo.com away from its real site.
+def test_safesearch_cname_redirect_takes_effect(safesearch_vm: _SSFixture) -> None:
+    """The gate: enabling SafeSearch REDIRECTS src_chase away from its sentinel default.
 
-    When SafeSearch is enabled, Then the on-box answer becomes a clean NOERROR with
-    records, is NOT a SERVFAIL (which would mean the synthesized hop went
-    DNSSEC-bogus), and DIFFERS from the SafeSearch-off baseline — the redirect took
-    effect. Asserted in BOTH recursive and forwarding mode (the fixture parametrization).
+    Scenario: SafeSearch CNAME redirect changes the on-box answer.
+
+    Background:
+        Given a fabricated source name with no SafeSearch entry active.
+
+    Given the BEFORE answer is the stub sentinel (SafeSearch-off baseline):
+        The source name resolves to STUB_DNS_A — confirming no redirect is active yet.
+    When the SafeSearch CNAME row is injected and Unbound is bounced.
+    Then the on-box answer is a clean NOERROR with records, is NOT SERVFAIL (which
+        would mean the synthesized CNAME hop went DNSSEC-bogus), and DIFFERS from the
+        BEFORE sentinel — proving the redirect CAUSED the change.
     """
-    vm, forwarding_on, ddg_before, _ = safesearch_vm
+    vm, forwarding_on, src_chase, _target_chase, _src_fallback, before = safesearch_vm
 
-    after = h.dns_probe(vm, DDG, "A")
-    assert after.rcode != "SERVFAIL", f"[forwarding={forwarding_on}] {DDG} SERVFAIL after redirect — {after}"
+    # Given: assert the before-state (sentinel) so green proves the redirect CAUSED the change.
+    assert h.resolves_to(before, STUB_DNS_A), (
+        f"[forwarding={forwarding_on}] BEFORE: {src_chase} should resolve to sentinel "
+        f"{STUB_DNS_A} (no redirect yet); got {before}"
+    )
+
+    # When: redirect is active (injected in the fixture).
+    after = h.dns_probe(vm, src_chase, "A")
+
+    # Then: NOERROR with records, not SERVFAIL, and different from the sentinel before-state.
+    assert after.rcode != "SERVFAIL", (
+        f"[forwarding={forwarding_on}] {src_chase} SERVFAIL after redirect — "
+        f"synthesized CNAME hop may be DNSSEC-bogus: {after}"
+    )
     assert after.rcode == "NOERROR" and after.records, (
-        f"[forwarding={forwarding_on}] {DDG} should still resolve after redirect, got {after}"
+        f"[forwarding={forwarding_on}] {src_chase} should still resolve after redirect; got {after}"
     )
-    assert set(after.records) != set(ddg_before.records), (
-        f"[forwarding={forwarding_on}] {DDG} answer unchanged by SafeSearch — redirect did not take "
-        f"effect (before={ddg_before.records}, after={after.records})"
+    assert set(after.records) != set(before.records), (
+        f"[forwarding={forwarding_on}] {src_chase} answer unchanged after SafeSearch injection — "
+        f"redirect did not take effect (before={before.records}, after={after.records})"
     )
 
 
-def test_safesearch_cname_chase_reaches_target(
-    safesearch_vm: tuple[SmokeVM, bool, h.DnsAnswer, h.DnsAnswer],
-) -> None:
-    """#1 live chase: duckduckgo.com resolves to safe.duckduckgo.com's own address.
+def test_safesearch_cname_chase_reaches_target(safesearch_vm: _SSFixture) -> None:
+    """#1 chase: src_chase resolves to the stub-served fixture address of target_chase.
 
-    The redirect plants ``duckduckgo.com -> CNAME -> safe.duckduckgo.com`` and the
-    iterator chases it, so the queried name ends up at the TARGET's address. Proven by
-    comparing duckduckgo.com's answer to a direct lookup of safe.duckduckgo.com: the
-    chase populated the target's cache entry, so the direct lookup is a cache hit and
-    the two share an address (rotation-proof). A second CNAME name (pixabay) shows the
-    redirect is general, not duckduckgo-special. Asserted in BOTH recursive and
-    forwarding mode (the fixture parametrization).
+    Scenario: CNAME iterator chase reaches the stub target address.
 
-    This asserts the OUTCOME — the queried name resolves to the safe target's address —
-    which the #1 live chase satisfies and (were it ever to fail) the #2 baked fallback
-    would too; the assertion does not distinguish them. That the #1 chase specifically
-    fires in BOTH modes was confirmed during bring-up via the module's phase log trace
-    (issue #149), not re-derived here.
+    Background:
+        Given the stub serves SS_TARGET_A / SS_TARGET_AAAA for target_chase.
+        Given pfBlockerNG plants src_chase -> CNAME -> target_chase in the message cache.
+
+    When the iterator chases src_chase.
+    Then src_chase A resolves to SS_TARGET_A and src_chase AAAA resolves to SS_TARGET_AAAA
+        (the stub-served fixture address — DISTINCT from the sentinel so the assertion
+        proves the chase, not a stub default).
+    And a direct lookup of target_chase returns the same fixture address (cache-population
+        / chase-consistency check: the iterator populated target_chase's cache entry).
     """
-    vm, forwarding_on, _, _ = safesearch_vm
+    vm, forwarding_on, src_chase, target_chase, _src_fallback, _before = safesearch_vm
 
-    for name, target in ((DDG, DDG_TARGET), (PIX, PIX_TARGET)):
-        redirected = h.dns_probe(vm, name, "A")
+    for rtype, expected in (("A", h.SS_TARGET_A), ("AAAA", h.SS_TARGET_AAAA)):
+        redirected = h.dns_probe(vm, src_chase, rtype)
         assert redirected.rcode == "NOERROR" and redirected.records, (
-            f"[forwarding={forwarding_on}] {name} did not resolve after redirect: {redirected}"
+            f"[forwarding={forwarding_on}] {src_chase} {rtype} did not resolve after redirect: {redirected}"
         )
-        target_ans = h.dns_probe(vm, target, "A")  # cache hit from the chase above
-        assert target_ans.records, (
-            f"[forwarding={forwarding_on}] {target} did not resolve (expected the chase cache hit): {target_ans}"
+        # Compare IPv6 by value (:: == ::0) via ipaddress.ip_address normalisation.
+        normalised_records = {str(ipaddress.ip_address(r)) for r in redirected.records}
+        assert str(ipaddress.ip_address(expected)) in normalised_records, (
+            f"[forwarding={forwarding_on}] {src_chase} {rtype}: expected {expected} "
+            f"(chase target address); got {redirected.records}"
         )
-        assert set(redirected.records) & set(target_ans.records), (
-            f"[forwarding={forwarding_on}] {name} should resolve to {target}'s address (CNAME chase); "
-            f"{name}={redirected.records} vs {target}={target_ans.records}"
+
+        # Cache-population check: target_chase itself resolves to the same fixture address.
+        target_ans = h.dns_probe(vm, target_chase, rtype)
+        assert target_ans.rcode == "NOERROR" and target_ans.records, (
+            f"[forwarding={forwarding_on}] {target_chase} {rtype} did not resolve "
+            f"(expected cache hit from the chase): {target_ans}"
         )
+        normalised_target = {str(ipaddress.ip_address(r)) for r in target_ans.records}
+        assert normalised_records & normalised_target, (
+            f"[forwarding={forwarding_on}] {src_chase} {rtype} address does not overlap "
+            f"{target_chase} {rtype} — CNAME chase did not reach the target: "
+            f"{src_chase}={redirected.records} vs {target_chase}={target_ans.records}"
+        )
+
+
+def test_safesearch_cname_fallback_to_baked_ip(safesearch_vm: _SSFixture) -> None:
+    """#2 baked fallback: src_fallback (NODATA target) resolves to the baked CSV IP.
+
+    Scenario: baked-fallback fires when the CNAME chase yields no address.
+
+    Background:
+        Given the stub serves NODATA for target_fallback (no A or AAAA registered).
+        Given pfBlockerNG plants src_fallback -> CNAME -> target_fallback; the baked
+        IPs SS_BAKED_A / SS_BAKED_AAAA are embedded in the CSV row.
+
+    When the iterator chases src_fallback and finds only a bare CNAME with no address.
+    Then the module answers src_fallback with the baked IPs (SS_BAKED_A / SS_BAKED_AAAA).
+    And the answer does NOT contain SS_TARGET_A or the stub sentinel — proving the baked
+        fallback fired, not the chase (#1) and not the stub default.
+
+    This test pairs with test_safesearch_cname_chase_reaches_target to prove #1 (chase)
+    and #2 (baked fallback) are DISTINCT real branches — not the same code path.
+    """
+    vm, forwarding_on, _src_chase, _target_chase, src_fallback, _before = safesearch_vm
+
+    for rtype, expected, not_expected_label, not_expected in (
+        ("A", h.SS_BAKED_A, "chase/sentinel", {h.SS_TARGET_A, STUB_DNS_A}),
+        ("AAAA", h.SS_BAKED_AAAA, "chase/sentinel", {h.SS_TARGET_AAAA}),
+    ):
+        ans = h.dns_probe(vm, src_fallback, rtype)
+        assert ans.rcode == "NOERROR" and ans.records, (
+            f"[forwarding={forwarding_on}] {src_fallback} {rtype} should resolve via baked "
+            f"fallback (NODATA target); got {ans}"
+        )
+        normalised = {str(ipaddress.ip_address(r)) for r in ans.records}
+        assert str(ipaddress.ip_address(expected)) in normalised, (
+            f"[forwarding={forwarding_on}] {src_fallback} {rtype}: expected baked fallback "
+            f"address {expected}; got {ans.records}"
+        )
+        for bad in not_expected:
+            assert str(ipaddress.ip_address(bad)) not in normalised, (
+                f"[forwarding={forwarding_on}] {src_fallback} {rtype}: found {not_expected_label} "
+                f"address {bad} — baked fallback did not fire (got {ans.records})"
+            )


### PR DESCRIPTION
Fixes #238

## Problem

`tests/smoke/test_smoke_safesearch.py::test_safesearch_cname_chase_reaches_target` depended on **live third-party DNS** — it resolved the real `duckduckgo.com → safe.duckduckgo.com` and `pixabay.com → safesearch.pixabay.com` redirects and asserted the source name reached the target's **real** address. It was the one non-hermetic smoke test, and it flaked whenever the third party shifted infrastructure (PFBL-03 fan-out run `27570934834`: the `[recursive]` CE 2.8 leg failed when `pixabay.com` and `safesearch.pixabay.com` momentarily resolved to non-overlapping addresses, and passed on re-run — classic external-DNS drift).

## What changed

The test now runs **fully hermetic and deterministic with egress blocked**, driven entirely by the in-process stub DNS server — no live domains, no real IPs.

**`tests/smoke/helpers.py`** — new infrastructure:
- `use_stub_for_safesearch(vm, forwarding_on)` — wires Unbound to the stub in **both** resolver modes: forwarding (System-DNS → `10.0.2.2` SLIRP host alias) and recursive (a catch-all `forward-zone` in `custom_options`), each with a relay self-check.
- `inject_safesearch_cname_entries(vm, entries)` — appends fabricated 5-column SafeSearch CNAME rows (`domain,cname,target,baked_v4,baked_v6`) to `pfb_py_ss.txt` and reloads `safeSearchDB` via a raw Unbound daemon bounce (not a pfBlockerNG update, which would overwrite the file).
- `SafeSearchEntry` row type + distinct RFC 5737 / RFC 3849 fixture-IP constants (chase-target vs baked-fallback vs stub sentinel — all distinct so a test can tell the paths apart).

**`tests/smoke/test_smoke_safesearch.py`** — hermetic rewrite:
- Fabricated `unique_domain()` source/target names; the stub serves the target's distinct fixture address.
- Egress **blocked**; both resolver modes parametrized.
- `test_safesearch_cname_redirect_takes_effect` — asserts the SafeSearch-off baseline (stub sentinel) **before** the redirect, then that the answer changed (before ≠ after, NOERROR, not SERVFAIL).
- `test_safesearch_cname_chase_reaches_target` — `src` resolves (A **and** AAAA) to the target's distinct fixture address; a direct target lookup shares it (cache-population/chase-consistency).
- `test_safesearch_cname_fallback_to_baked_ip` (new) — with a NODATA target, `src` resolves to the **baked** CSV IP and **not** the chase address or sentinel, proving the `#2` baked-fallback path is a distinct branch from the `#1` chase.
- Removes the build-time real-DNS baking dependency for this test path.

## Acceptance (issue #238)

- ✅ Passes deterministically with egress blocked, no live third-party domains/IPs.
- ✅ Both CNAME-redirect analogues (chase + baked fallback) and both resolver modes covered, asserting the source resolves to the target's distinct fixture address.
- ✅ Removes the real-DNS dependency for the test path.

Validation is the live-VM smoke fan-out (CE + Plus); `tests/smoke` is not collected by the default suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9eEPiZPP6wQUBh762dkTk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved SafeSearch CNAME redirect testing with isolated stub DNS to eliminate external dependencies.
  * Added test coverage for fallback IP resolution when CNAME chase encounters no data.
  * Expanded testing to verify both recursive and forwarding resolver modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->