### PR TITLE
pfblockerng: distinct upstream-block presentation + DNSBL Upstream counter

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2530,6 +2530,9 @@ def _log_upstream_block(q_name: str, q_ip: str, result: UpstreamBlock, q_type: s
     )
     pfb_log("/var/log/pfblockerng/dnsbl.log", csv_line)
     pfb_log("/var/log/pfblockerng/unified.log", csv_line)
+    # Increment the aggregate Upstream group counter (parity with per-feed DNSBL blocks).
+    if pfb["sqlite3_dnsbl_con"]:
+        pfb_db_enqueue(("dnsbl", "Upstream"))
 
 
 def make_timestamp() -> str:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3240,6 +3240,21 @@ function dnsbl_save_stats() {
 					}
 				}
 			}
+
+			// Seed the aggregate Upstream group row if it does not yet exist.
+			// Python increments its counter via pfb_db_enqueue on each upstream block;
+			// the UPDATE in _db_flush_dnsbl only fires on an existing row, so we must
+			// ensure the row is present whenever DNSBL feeds are active.
+			if (!isset($sql_groupnames['Upstream'])) {
+				$stmt = $db_handle->prepare(
+					"INSERT INTO dnsbl (groupname, timestamp, entries, counter)"
+					. " VALUES ('Upstream', :timestamp, 0, 0);"
+				);
+				if ($stmt) {
+					$stmt->bindValue(':timestamp', date('M j H:i:s', time()), SQLITE3_TEXT);
+					$stmt->execute();
+				}
+			}
 		}
 		pfb_close_sqlite($db_handle);
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3246,9 +3246,14 @@ function dnsbl_save_stats() {
 			// the UPDATE in _db_flush_dnsbl only fires on an existing row, so we must
 			// ensure the row is present whenever DNSBL feeds are active.
 			if (!isset($sql_groupnames['Upstream'])) {
+				// INSERT ... WHERE NOT EXISTS keeps the seed atomic: dnsbl.groupname has
+				// no UNIQUE constraint, so a bare INSERT could create a duplicate row if
+				// two reloads race past the pre-loop snapshot check above (which would
+				// then over-count, as the counter UPDATE hits every matching row).
 				$stmt = $db_handle->prepare(
 					"INSERT INTO dnsbl (groupname, timestamp, entries, counter)"
-					. " VALUES ('Upstream', :timestamp, 0, 0);"
+					. " SELECT 'Upstream', :timestamp, 0, 0"
+					. " WHERE NOT EXISTS (SELECT 1 FROM dnsbl WHERE groupname = 'Upstream');"
 				);
 				if ($stmt) {
 					$stmt->bindValue(':timestamp', date('M j H:i:s', time()), SQLITE3_TEXT);

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -49,7 +49,7 @@ $pfb['uniblock']	= $pfb['aglobal']['uniblock']		?: '#FFF9C4';
 $pfb['unipermit']	= $pfb['aglobal']['unipermit']		?: '#80CBC4';
 $pfb['unimatch']	= $pfb['aglobal']['unimatch']		?: '#B3E5FC';
 $pfb['unidnsbl']	= $pfb['aglobal']['unidnsbl']		?: '#EF9A9A';
-$pfb['uniupstream']	= $pfb['aglobal']['uniupstream']	?: '#CE93D8';
+$pfb['uniupstream']	= ($pfb['aglobal']['uniupstream'] ?? '')	?: '#CE93D8';
 $pfb['unireply']	= $pfb['aglobal']['unireply']		?: '#E8E8E8';
 
 // Unified Log - Dark Theme
@@ -57,7 +57,7 @@ $pfb['uniblock2']	= $pfb['aglobal']['uniblock2']		?: '#83791D';
 $pfb['unipermit2']	= $pfb['aglobal']['unipermit2']		?: '#3B8780';	
 $pfb['unimatch2']	= $pfb['aglobal']['unimatch2']		?: '#42809D';
 $pfb['unidnsbl2']	= $pfb['aglobal']['unidnsbl2']		?: '#E84E4E';
-$pfb['uniupstream2']	= $pfb['aglobal']['uniupstream2']	?: '#9C27B0';
+$pfb['uniupstream2']	= ($pfb['aglobal']['uniupstream2'] ?? '')	?: '#9C27B0';
 $pfb['unireply2']	= $pfb['aglobal']['unireply2']		?: '#54585E';
 
 $pfbchartcnt	= $pfb['aglobal']['pfbchartcnt']		?: '24';

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -49,6 +49,7 @@ $pfb['uniblock']	= $pfb['aglobal']['uniblock']		?: '#FFF9C4';
 $pfb['unipermit']	= $pfb['aglobal']['unipermit']		?: '#80CBC4';
 $pfb['unimatch']	= $pfb['aglobal']['unimatch']		?: '#B3E5FC';
 $pfb['unidnsbl']	= $pfb['aglobal']['unidnsbl']		?: '#EF9A9A';
+$pfb['uniupstream']	= $pfb['aglobal']['uniupstream']	?: '#CE93D8';
 $pfb['unireply']	= $pfb['aglobal']['unireply']		?: '#E8E8E8';
 
 // Unified Log - Dark Theme
@@ -56,6 +57,7 @@ $pfb['uniblock2']	= $pfb['aglobal']['uniblock2']		?: '#83791D';
 $pfb['unipermit2']	= $pfb['aglobal']['unipermit2']		?: '#3B8780';	
 $pfb['unimatch2']	= $pfb['aglobal']['unimatch2']		?: '#42809D';
 $pfb['unidnsbl2']	= $pfb['aglobal']['unidnsbl2']		?: '#E84E4E';
+$pfb['uniupstream2']	= $pfb['aglobal']['uniupstream2']	?: '#9C27B0';
 $pfb['unireply2']	= $pfb['aglobal']['unireply2']		?: '#54585E';
 
 $pfbchartcnt	= $pfb['aglobal']['pfbchartcnt']		?: '24';
@@ -524,7 +526,7 @@ if (isset($_POST) && !empty($_POST)) {
 		}
 
 		// Unified Log - Light Theme Hex settings
-		foreach (array('uniblock' => '#FFF9C4', 'unipermit' => '#80CBC4', 'unimatch' => '#B3E5FC', 'unidnsbl' => '#EF9A9A', 'unireply' => '#E8E8E8') as $h_type => $h_default) {
+		foreach (array('uniblock' => '#FFF9C4', 'unipermit' => '#80CBC4', 'unimatch' => '#B3E5FC', 'unidnsbl' => '#EF9A9A', 'uniupstream' => '#CE93D8', 'unireply' => '#E8E8E8') as $h_type => $h_default) {
 			if (isset($_POST[$h_type]) && !empty($_POST[$h_type])) {
 				$pfb['aglobal'][$h_type] = pfb_filter($_POST[$h_type], PFB_FILTER_HEX_COLOR, 'alerts hex', $h_default);
 			} else {
@@ -533,7 +535,7 @@ if (isset($_POST) && !empty($_POST)) {
 		}
 
 		// Unified Log - Dark Theme Hex settings
-		foreach (array('uniblock2' => '#83791D', 'unipermit2' => '#3B8780', 'unimatch2' => '#42809D', 'unidnsbl2' => '#E84E4E', 'unireply2' => '#54585E') as $h_type => $h_default) {
+		foreach (array('uniblock2' => '#83791D', 'unipermit2' => '#3B8780', 'unimatch2' => '#42809D', 'unidnsbl2' => '#E84E4E', 'uniupstream2' => '#9C27B0', 'unireply2' => '#54585E') as $h_type => $h_default) {
 			if (isset($_POST[$h_type]) && !empty($_POST[$h_type])) {
 				$pfb['aglobal'][$h_type] = pfb_filter($_POST[$h_type], PFB_FILTER_HEX_COLOR, 'alerts hex', $h_default);
 			} else {
@@ -2183,6 +2185,9 @@ function convert_dnsbl_log($mode, $fields) {
 		$fields[4] = '';
 	}
 
+	// Upstream DNS block (logged by _log_upstream_block; not a local feed entry).
+	$isUpstream = ($fields[5] === 'Upstream_Block');
+
 	// Determine event parameters
 	list ( $isTLD, $isCNAME, $isPython, $isExclusion, $pfb_python, $qdomain, $wt_line ) = dnsbl_log_details($fields);
 
@@ -2193,7 +2198,9 @@ function convert_dnsbl_log($mode, $fields) {
 	$p_group = $p_domain = $p_feed = $p_mode = '';
 
 	// Collect current details about domain
-	if (!$isPython && !$isWhitelist_found) {
+	// Skip for upstream blocks: the domain is not in a local feed, so pfb_dnsbl_parse()
+	// would rewrite group/feed/mode to 'Unknown', corrupting the row.
+	if (!$isPython && !$isUpstream && !$isWhitelist_found) {
 		$domain_details = pfb_dnsbl_parse('alerts', $qdomain, '', '');
 		$pfb_mode	= $domain_details['pfb_mode']	?: 'Unknown';
 		$pfb_group	= $domain_details['pfb_group']	?: 'Unknown';
@@ -2241,6 +2248,11 @@ function convert_dnsbl_log($mode, $fields) {
 	if (!$isMatch) {
 		list ( $isTLD, $isCNAME, $isPython, $isExclusion, $pfb_python, $qdomain, $wt_line ) = dnsbl_log_details($fields);
 		list ( $supp_dom, $ex_dom, $isWhitelist_found ) = dnsbl_whitelist_type($fields, $clists, $isExclusion, $isTLD, $qdomain);
+	}
+
+	// Upstream block: override icon to cloud (uses raw fields[7]/[8] before truncation below).
+	if ($isUpstream) {
+		$pfb_python = "&nbsp;<i class=\"fa-solid fa-cloud\" title=\"Upstream Block: " . pfb_hsc($fields[7]) . " [ " . pfb_hsc($fields[8]) . " ]\"></i>";
 	}
 
 	// Filter Field array
@@ -2482,6 +2494,15 @@ function convert_dnsbl_log($mode, $fields) {
 		$dup['DNSBL'] = 0;
 	}
 
+	// Upstream blocks have no local feed entry: suppress the lock/whitelist/exclusion
+	// action icons (they all target a local-feed domain; they are no-op or confusing
+	// for an upstream block). The threat-lookup $alert_dom icon is kept as-is.
+	if ($isUpstream) {
+		$unlock_dom = '&nbsp;&nbsp;&nbsp;';
+		$supp_dom   = '';
+		$ex_dom     = '';
+	}
+
 	if ($mode != 'Unified') {
 		print ("<tr>
 			<td>{$pfbalertdnsbl[99]}{$dup_cnt}</td>
@@ -2494,12 +2515,17 @@ function convert_dnsbl_log($mode, $fields) {
 			</tr>");
 	}
 	else {
-		$bg = strpos(config_get_path('system/webgui/webguicss'), 'dark') ? $pfb['unidnsbl2'] : $pfb['unidnsbl'];
+		if ($isUpstream) {
+			$bg = strpos(config_get_path('system/webgui/webguicss'), 'dark') ? $pfb['uniupstream2'] : $pfb['uniupstream'];
+		} else {
+			$bg = strpos(config_get_path('system/webgui/webguicss'), 'dark') ? $pfb['unidnsbl2'] : $pfb['unidnsbl'];
+		}
 		if ($bg == 'none') {
 			$bg = '';
 		}
+		$tr_title = $isUpstream ? 'Upstream Block Event' : 'DNSBL Event';
 
-		print ("<tr title=\"DNSBL Event\" style=\"background-color:{$bg}\">
+		print ("<tr title=\"{$tr_title}\" style=\"background-color:{$bg}\">
 			<td style=\"white-space: nowrap;\">{$pfbalertdnsbl[99]}{$dup_cnt}</td>
 			<td></td>
 			<td>{$pfbalertdnsbl[7]}<br /><small>{$pfbalertdnsbl[17]}</small></td>
@@ -3443,6 +3469,16 @@ if (pfb_cfg_toggle_read($pfb['dnsbl']) === PfbToggle::On) {
 	  ->setWidth(2);
 
 	$group->add(new Form_Input(
+		'uniupstream',
+		'',
+		'text',
+		$pfb['uniupstream'],
+		['placeholder' => '#CE93D8']
+	))->setHelp('Upstream Block Event color')
+	  ->setAttribute('style', "background: {$pfb['uniupstream']}")
+	  ->setWidth(2);
+
+	$group->add(new Form_Input(
 		'unireply',
 		'',
 		'text',
@@ -3494,6 +3530,16 @@ if (pfb_cfg_toggle_read($pfb['dnsbl']) === PfbToggle::On) {
 		['placeholder' => '#E84E4E']
 	))->setHelp('DNSBL Block Event color')
 	  ->setAttribute('style', "background: {$pfb['unidnsbl2']}; color: white;")
+	  ->setWidth(2);
+
+	$group->add(new Form_Input(
+		'uniupstream2',
+		'',
+		'text',
+		$pfb['uniupstream2'],
+		['placeholder' => '#9C27B0']
+	))->setHelp('Upstream Block Event color')
+	  ->setAttribute('style', "background: {$pfb['uniupstream2']}; color: white;")
 	  ->setWidth(2);
 
 	$group->add(new Form_Input(

--- a/tests/smoke/test_smoke_upstream_block.py
+++ b/tests/smoke/test_smoke_upstream_block.py
@@ -21,6 +21,10 @@ When triggered, a ``DNSBL-python``-source CSV line is written to
 ``Upstream_Block``, ``group`` ``Upstream``, and ``b_eval`` equal to the
 classifier label (``"NXRA"``, ``"EDE15 (Blocked)"``, etc.).
 
+The ``Upstream`` groupname row in the SQLite ``dnsbl`` table is seeded by
+``dnsbl_save_stats()`` in PHP and its ``counter`` column is incremented by
+Python on each upstream block — the same pattern as per-feed DNSBL counters.
+
 These tests are DESELECTED from the default ``python -m pytest`` run. Run via::
 
     python -m pytest tests/smoke -m smoke --override-ini="addopts="
@@ -313,4 +317,103 @@ class TestUpstreamBlockNormalControl:
         assert not lines, (
             f"Normal resolution produced Upstream_Block lines — over-triggering.\n"
             f"Lines: {lines}\nLog excerpt:\n{log[-2000:]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Upstream SQLite counter — dnsbl table row increments end-to-end
+# ---------------------------------------------------------------------------
+
+_DNSBL_DB = "/var/unbound/pfb_py_dnsbl.sqlite"
+
+
+def _read_upstream_counter(vm: SmokeVM) -> int:
+    """Read the ``counter`` column of the ``Upstream`` row from the on-box dnsbl SQLite DB.
+
+    Uses ``python3 -c`` over SSH — py-sqlite3 is a baked dep on the smoke image.
+    Returns -1 when the row does not yet exist (DB absent or row missing).
+    """
+    script = (
+        "import sqlite3, sys\n"
+        f"try:\n"
+        f"    con = sqlite3.connect({_DNSBL_DB!r})\n"
+        f"    row = con.execute(\"SELECT counter FROM dnsbl WHERE groupname='Upstream'\").fetchone()\n"
+        f"    print(row[0] if row else -1)\n"
+        f"except Exception as e:\n"
+        f"    print(-1)\n"
+    )
+    result = vm.ssh("python3", "-c", script)
+    try:
+        return int(result.stdout.strip())
+    except (ValueError, AttributeError):
+        return -1
+
+
+def _wait_for_counter_above(vm: SmokeVM, baseline: int, *, timeout_s: float = 15.0, poll_s: float = 0.5) -> int:
+    """Poll the on-box Upstream dnsbl counter until it exceeds ``baseline`` or the deadline expires.
+
+    The counter is flushed by the async db_worker thread, so a freshly-logged block
+    does not appear instantly.  Bounded polling matches the log-line polling pattern
+    used by ``_wait_for_upstream_block_lines``.
+
+    Returns the final observed counter value (may equal ``baseline`` on timeout).
+    """
+    deadline = time.monotonic() + timeout_s
+    current = baseline
+    while time.monotonic() < deadline:
+        current = _read_upstream_counter(vm)
+        if current > baseline:
+            return current
+        time.sleep(poll_s)
+    return current
+
+
+class TestUpstreamCounterIncrement:
+    """The dnsbl SQLite Upstream counter increments end-to-end on an upstream block.
+
+    Scenario: an NXRA block is logged by _log_upstream_block; the async
+    db_worker flushes the enqueued ("dnsbl", "Upstream") task; the on-box
+    ``counter`` column for the Upstream row increases.
+
+    Before/after: counter is read BEFORE the probe and AFTER, asserting a
+    strict increase so that the test fails if the counter is stuck.
+    """
+
+    def test_upstream_counter_increments_on_nxra_block(self, deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+        """
+        Given: DNSBL active, forwarding to stub, dnsbl table seeded with Upstream row.
+        When: stub answers NXDOMAIN (RA=0, AA=0) — an NXRA upstream block is logged.
+        Then: the on-box dnsbl counter for groupname='Upstream' strictly increases.
+        """
+        name = h.unique_domain("pfbsmoke-upstream-ctr")
+        stub_dns.register_nxdomain(name)  # RA=0, AA=0 -> NXRA block
+
+        # Before: record the baseline counter (row may already have a count from
+        # earlier tests in this session).
+        baseline = _read_upstream_counter(deployed_vm)
+        assert baseline >= 0, (
+            "Upstream row not found in dnsbl table before probe — "
+            "dnsbl_save_stats() did not seed it. "
+            f"DB: {_DNSBL_DB!r}"
+        )
+
+        # When: trigger a block (first response is authoritative — assert it arrived).
+        ans = h.dns_probe(deployed_vm, name, "A")
+        assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
+
+        # Confirm the block line was logged (proves the detection fired, not just a
+        # natural NXDOMAIN — the counter increment is meaningless without this).
+        lines = _wait_for_upstream_block_lines(deployed_vm, name)
+        assert lines, (
+            f"No Upstream_Block log line for {name} — detection did not fire; "
+            f"counter increment cannot be attributed to an upstream block.\n"
+            f"Log excerpt:\n{_read_dnsbl_log(deployed_vm)[-2000:]}"
+        )
+
+        # Then: wait for the async flush and assert strict increase.
+        final = _wait_for_counter_above(deployed_vm, baseline)
+        assert final > baseline, (
+            f"Upstream counter did not increase after NXRA block: "
+            f"baseline={baseline}, final={final}. "
+            f"Detection fired (log line present), so the enqueue or flush may be broken."
         )

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -477,21 +477,30 @@ def test_upstream_block_renders_cloud_icon_and_correct_group(
 
     dnsbl_log = "/var/log/pfblockerng/dnsbl.log"
 
-    # Capture the original byte size so we can truncate back to it on cleanup.
+    # Capture the original byte size so we can truncate back to it on cleanup. Fail
+    # fast if stat fails: falling back to "0" would make the cleanup truncate wipe
+    # the whole log.
     size_result = vm.ssh("stat", "-f", "%z", dnsbl_log, timeout=15)
-    original_size = size_result.stdout.strip() if size_result.returncode == 0 else "0"
+    assert size_result.returncode == 0, (
+        f"Failed to stat {dnsbl_log!r} before mutation: rc={size_result.returncode}, stderr={size_result.stderr!r}"
+    )
+    original_size = size_result.stdout.strip()
 
     helpers.set_dnsbl_enabled(vm, True)
 
     try:
         # GIVEN: append the synthetic upstream-block line via SSH tee -a.
-        subprocess.run(
+        append_result = subprocess.run(
             vm.ssh_argv("tee", "-a", dnsbl_log),
             input=csv_line,
             capture_output=True,
             text=True,
             timeout=15,
             check=False,
+        )
+        assert append_result.returncode == 0, (
+            f"Failed to append synthetic line to {dnsbl_log!r}: "
+            f"rc={append_result.returncode}, stderr={append_result.stderr!r}"
         )
 
         # WHEN: GET the Alerts page (default alert view → DNSBL Python tab).
@@ -524,10 +533,14 @@ def test_upstream_block_renders_cloud_icon_and_correct_group(
         )
     finally:
         # Truncate dnsbl.log back to its pre-test size to remove the appended line.
-        subprocess.run(
+        truncate_result = subprocess.run(
             vm.ssh_argv("/usr/bin/truncate", "-s", original_size, dnsbl_log),
             capture_output=True,
             text=True,
             timeout=15,
             check=False,
+        )
+        assert truncate_result.returncode == 0, (
+            f"Failed to restore {dnsbl_log!r} to size={original_size!r}: "
+            f"rc={truncate_result.returncode}, stderr={truncate_result.stderr!r}"
         )

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -30,6 +30,8 @@ session-scoped VM for the sibling flows -- exercises the reverse branch too.
 from __future__ import annotations
 
 import base64
+import subprocess
+import time
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -414,4 +416,118 @@ def test_addsuppress_cidr24_writes_and_invalid_ip_rejected(
             f"config_set_path('{CFG_V4SUPPRESSION}', '{original}');\n"
             "write_config('pfBlockerNG smoke: restore v4suppression');\n"
             "echo 'OK';",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Upstream block rendering (issue #285): a synthetic Upstream_Block CSV line
+# appended to dnsbl.log must render with the cloud icon ($pfb_python override)
+# and the Group column must show "Upstream", NOT "Unknown".
+#
+# "Unknown" is what the stale-entry correction block (pfb_dnsbl_parse) would
+# produce for a domain that is not in any local feed.  The $isUpstream guard
+# skips that correction; these two assertions discriminate the branches:
+#
+#   fa-cloud   present  → Edit D step 9 (icon override) ran
+#   Upstream   present  → Edit D step 8 (skip stale-correction) kept the group
+#   Unknown    absent   → the old code path is NOT taken
+# --------------------------------------------------------------------------- #
+
+
+def test_upstream_block_renders_cloud_icon_and_correct_group(
+    webui: "WebUI",
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Upstream_Block CSV line renders the cloud icon and preserves group 'Upstream'.
+
+    Scenario: stale-correction skip + icon override for upstream DNS blocks.
+
+    Background:
+        pfblockerng_alerts.php ``convert_dnsbl_log`` has two paths for upstream
+        blocks: (a) skip the ``pfb_dnsbl_parse`` stale-entry correction that would
+        rewrite group/feed to 'Unknown', and (b) replace the bolt icon with a cloud.
+        Both are tested by injecting a synthetic ``Upstream_Block`` CSV line directly
+        into ``dnsbl.log`` and asserting the rendered HTML.
+
+    Given: DNSBL is enabled (required for the DNSBL Python tab to appear); a
+        synthetic ``Upstream_Block`` line for a unique domain is appended to
+        ``/var/log/pfblockerng/dnsbl.log``.
+
+    When: the Reports/Alerts page is GET-ted (default ``alert`` view, which renders
+        the ``DNSBL Python`` tab from ``dnsbl.log``).
+
+    Then:
+        (a) ``fa-cloud`` is present in the rendered HTML for that domain's row —
+            proving the bolt-icon override fired (Edit D step 9).
+        (b) the text ``Upstream`` appears near the domain and the text ``Unknown``
+            does NOT appear near it — proving the stale-entry correction was skipped
+            (Edit D step 8); without the skip, pfb_dnsbl_parse would rewrite the
+            group to 'Unknown'.
+
+    Cleanup: the appended log line is removed in ``finally`` (truncate the file back
+        to its original size) so the session VM is clean for sibling tests.
+    """
+    vm = smoke_vm
+    domain = helpers.unique_domain("upstrmui")
+
+    # The synthetic log line exactly mirrors _log_upstream_block's CSV output.
+    # 11 fields (indices 0-10), comma-separated, with '+' as the dup-entry token.
+    ts = time.strftime("%b %d %H:%M:%S")  # e.g. "Jun 18 12:00:00"
+    csv_line = f"DNSBL-python,{ts},{domain},127.0.0.1,Python,Upstream_Block,Upstream,NXRA,Quad9,+,A\n"
+
+    dnsbl_log = "/var/log/pfblockerng/dnsbl.log"
+
+    # Capture the original byte size so we can truncate back to it on cleanup.
+    size_result = vm.ssh("stat", "-f", "%z", dnsbl_log, timeout=15)
+    original_size = size_result.stdout.strip() if size_result.returncode == 0 else "0"
+
+    helpers.set_dnsbl_enabled(vm, True)
+
+    try:
+        # GIVEN: append the synthetic upstream-block line via SSH tee -a.
+        subprocess.run(
+            vm.ssh_argv("tee", "-a", dnsbl_log),
+            input=csv_line,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+
+        # WHEN: GET the Alerts page (default alert view → DNSBL Python tab).
+        resp = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(resp.text), (
+            "alerts page GET returned login form (session lost before upstream-block render test)"
+        )
+        html_body = resp.text
+
+        # THEN (a): the cloud icon class is present in the page (Edit D step 9).
+        assert "fa-cloud" in html_body, (
+            f"fa-cloud icon class absent from the rendered Alerts page — "
+            f"the upstream-block icon override (Edit D step 9) did not fire for {domain!r}"
+        )
+
+        # THEN (b): the domain appears and its row shows group 'Upstream', not 'Unknown'.
+        # We find the domain in the rendered HTML and inspect a window around it.
+        dom_idx = html_body.find(domain)
+        assert dom_idx != -1, f"synthetic upstream-block domain {domain!r} not found in the rendered Alerts page HTML"
+        # Look in a 2 kB window around the domain occurrence for the Group value.
+        window = html_body[max(0, dom_idx - 1024) : dom_idx + 1024]
+        assert "Upstream" in window, (
+            f"Group 'Upstream' not found near domain {domain!r} in rendered HTML — "
+            f"stale-entry correction may have overwritten it (Edit D step 8 check failed)"
+        )
+        assert "Unknown" not in window, (
+            f"Group 'Unknown' found near domain {domain!r} in rendered HTML — "
+            f"pfb_dnsbl_parse rewrote the group, meaning $isUpstream guard did not fire "
+            f"(Edit D step 8 regression)"
+        )
+    finally:
+        # Truncate dnsbl.log back to its pre-test size to remove the appended line.
+        subprocess.run(
+            vm.ssh_argv("/usr/bin/truncate", "-s", original_size, dnsbl_log),
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
         )

--- a/tests/test_upstream_block.py
+++ b/tests/test_upstream_block.py
@@ -4,19 +4,23 @@ Covers:
 - ``_parse_ede_options`` (pure EDE wire parser)
 - ``classify_upstream_block`` (NXRA / EDE15 / EDE17 classifier)
 - ``UpstreamBlock`` result type
+- ``_log_upstream_block`` counter enqueue branch (sqlite3_dnsbl_con guard)
 
 All tests are pure off-box — no Unbound API calls, no fixtures, no I/O.
 """
 
 from __future__ import annotations
 
+import pytest
 from unboundmodule import RCODE_NOERROR, RCODE_NXDOMAIN
 
+import pfb_unbound
 from pfb_unbound import (
     EDE_BLOCKED,
     EDE_FILTERED,
     EDNS_OPT_CODE_EDE,
     UpstreamBlock,
+    _log_upstream_block,
     _parse_ede_options,
     classify_upstream_block,
 )
@@ -366,3 +370,68 @@ class TestClassifyUpstreamBlockAAGuard:
         assert result is not None
         assert result.signal == "EDE15"
         assert result.provider == "Quad9"
+
+
+# ---------------------------------------------------------------------------
+# _log_upstream_block — sqlite3_dnsbl_con guard (counter enqueue)
+# ---------------------------------------------------------------------------
+
+
+class TestLogUpstreamBlockCounterEnqueue:
+    """Scenario: _log_upstream_block enqueues a dnsbl counter task iff sqlite3_dnsbl_con is truthy.
+
+    Background:
+        The function writes CSV to dnsbl.log + unified.log, then — when the SQLite
+        DNSBL connection is active — calls pfb_db_enqueue(("dnsbl", "Upstream")) to
+        increment the aggregate Upstream row counter.  The guard ``if pfb["sqlite3_dnsbl_con"]``
+        must be the discriminator: the enqueue fires when truthy and is suppressed when falsy.
+
+    Given:
+        A valid UpstreamBlock result (NXRA signal, no provider) and a monkeypatched
+        pfb_db_enqueue that records calls.  pfb_log is patched to a no-op so no real
+        file I/O occurs.
+    """
+
+    _RESULT = UpstreamBlock(signal="NXRA", label="NXRA", provider="")
+
+    def test_enqueues_upstream_counter_when_connection_active(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """
+        When sqlite3_dnsbl_con is truthy, _log_upstream_block enqueues ("dnsbl", "Upstream").
+
+        Before-state (con=False): no enqueue occurs (proven in the companion test).
+        After-state (con=True): exactly one ("dnsbl", "Upstream") task is enqueued.
+        """
+        calls: list[tuple[str, ...]] = []
+        monkeypatch.setattr(pfb_unbound, "pfb_db_enqueue", lambda task: calls.append(task))
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda _log, _line: None)
+
+        # Before: connection inactive -> no enqueue (verified in companion test; establish
+        # that the initial fixture state is falsy so the flip is meaningful).
+        assert not pfb_unbound.pfb["sqlite3_dnsbl_con"]
+
+        # Flip to active.
+        pfb_unbound.pfb["sqlite3_dnsbl_con"] = True
+
+        _log_upstream_block("example.com", "192.0.2.1", self._RESULT, "A")
+
+        dnsbl_tasks = [t for t in calls if len(t) == 2 and t[0] == "dnsbl"]
+        assert dnsbl_tasks == [("dnsbl", "Upstream")], f"Expected exactly one ('dnsbl', 'Upstream') task; got: {calls}"
+
+    def test_no_enqueue_when_connection_inactive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """
+        When sqlite3_dnsbl_con is falsy, _log_upstream_block does NOT enqueue any dnsbl task.
+
+        This is the discriminating before-state: same function call, con=False -> no task.
+        Proves the guard is real and the counter is not always incremented.
+        """
+        calls: list[tuple[str, ...]] = []
+        monkeypatch.setattr(pfb_unbound, "pfb_db_enqueue", lambda task: calls.append(task))
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda _log, _line: None)
+
+        # Fixture default: sqlite3_dnsbl_con is False (see conftest reset_pfb_globals).
+        assert not pfb_unbound.pfb["sqlite3_dnsbl_con"]
+
+        _log_upstream_block("example.com", "192.0.2.1", self._RESULT, "A")
+
+        dnsbl_tasks = [t for t in calls if len(t) == 2 and t[0] == "dnsbl"]
+        assert dnsbl_tasks == [], f"Expected no dnsbl enqueue with sqlite3_dnsbl_con=False; got: {calls}"


### PR DESCRIPTION
Follow-up to #267/#284 (issue #285): the cosmetic presentation polish deferred from that work.

## Alerts/Reports rendering
- Upstream/external DNS blocks (`b_type=Upstream_Block`, `group=Upstream`) now render with a distinct purple row background (light `#CE93D8` / dark `#9C27B0`, user-configurable colour fields) and a `fa-cloud` icon tooltipping the signal (NXRA / EDE15 / EDE17) and provider.
- Fixes a latent defect: the stale-entry correction (`pfb_dnsbl_parse`) was rewriting an upstream row's group/feed/mode to `Unknown` because the domain is not in a local feed. Upstream rows now skip that correction so the `Upstream` group/feed are preserved.
- Suppresses the lock / whitelist / TLD-exclusion action icons on upstream rows (they target local-feed entries and are no-ops for an upstream block); the threat-lookup icon is kept.
- No dedicated filter toggle: upstream events already filter via the existing Blocking-Mode/Group column search and the "Top DNSBL Modes" stat (one-click), since they share the `DNSBL-python` log prefix.

## SQLite Upstream counter
- Seeds an `Upstream` group row in the `dnsbl` SQLite table from `dnsbl_save_stats()` (insert-if-missing; any accumulated counter is preserved across reloads).
- Increments that row's counter from Python on each upstream block, mirroring the per-feed DNSBL counter path. Both sides operate on the same `/var/unbound/pfb_py_dnsbl.sqlite` (the Python module runs in Unbound's chroot). The dashboard widget and Reports surface the row with no further change.

## Tests
- Python unit test for the counter-enqueue guard (both branches).
- Live-VM smoke test asserting the counter increments end-to-end on an NXRA block.
- Tier-B UI render test pinning the cloud icon and the preserved `Upstream` group (the discriminating assertion for the stale-correction skip).

Local gates green: `pytest` 1733, `phpunit` 638, `phpcs`/`phpstan`/`php -l`/`ruff` clean.

Fixes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GighgrxzgA8pzAPtS66iCK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upstream DNS Block events are now reflected in statistics and reports via a dedicated **“Upstream”** counter.
  * Unified Logs now highlights Upstream Block events with a cloud icon and adds configurable light/dark theme colors.
* **Bug Fixes**
  * Improves Upstream Block handling to avoid unintended changes to other rendered row details.
* **Tests**
  * Added smoke and UI end-to-end coverage to verify the Upstream counter increment and correct icon/labels rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->