### PR TITLE
pfblockerng: serialize concurrent DNSBL control-channel writers

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4323,6 +4323,38 @@ function pfb_unbound_py_wait_applied($gen, $timeout_s = 30) {
 }
 
 
+// Poll until the control-channel watcher has applied sequence $seq (or beyond), confirming
+// the published command was consumed. Mirrors pfb_unbound_py_wait_applied() in structure:
+// reads the applied marker (/var/unbound/pfb_py_control.applied), parses the first line as
+// an integer, and returns TRUE when the stored value >= $seq. Returns FALSE on timeout.
+// A $timeout_s <= 0 is never passed here (the caller guards); 200 ms poll interval.
+function pfb_unbound_py_wait_control_applied($seq, $timeout_s = 5) {
+	global $pfb;
+
+	$seq     = (int) $seq;
+	$applied  = "{$pfb['dnsbldir']}/pfb_py_control.applied";
+	$deadline = microtime(TRUE) + (float) $timeout_s;
+
+	do {
+		if (file_exists($applied)) {
+			$raw = @file_get_contents($applied);
+			if ($raw !== FALSE) {
+				$first = strtok($raw, "\n");
+				if ($first !== FALSE) {
+					$first = trim($first);
+					if ($first !== '' && ctype_digit($first) && (int) $first >= $seq) {
+						return TRUE;
+					}
+				}
+			}
+		}
+		usleep(200000);	// 200 ms between polls
+	} while (microtime(TRUE) < $deadline);
+
+	return FALSE;
+}
+
+
 // PFBL-03: atomically publish the DNSBL-control command channel to the chroot
 // (/var/unbound/pfb_py_control). Mirrors pfb_unbound_py_atomic_write (stage -> fwrite ->
 // fflush -> fsync -> rename) but uses a COMMAND-CHANNEL permission model rather than the
@@ -4398,10 +4430,13 @@ function pfb_unbound_py_atomic_write_root($path, $content) {
 //   $duration optional seconds (1-3600) for disable/addbypass; ignored otherwise
 //
 // Returns the published sequence (>= 1) on success, or FALSE on an invalid command /
-// invalid argument / write failure. No die()/exit().
-function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '') {
+// invalid argument / lock failure / write failure. No die()/exit().
+// $wait_timeout: seconds to wait for the watcher to apply the command (default 5).
+//   <= 0 = fire-and-forget (skip the wait entirely, return the seq immediately).
+function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '', $wait_timeout = 5) {
 	global $pfb;
 
+	// Validate the command allow-list before touching the lock -- cheap guard first.
 	$valid_cmds = array('disable', 'enable', 'addbypass', 'removebypass');
 	if (!in_array($cmd, $valid_cmds, TRUE)) {
 		pfb_logger("\nPFBL-03: control command not authorized [ " . htmlspecialchars((string) $cmd) . " ]", 2);
@@ -4430,8 +4465,23 @@ function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '') {
 		$record['duration'] = (int) $clean_dur;
 	}
 
-	// Read the current sequence from the channel (first line is no longer used; the seq
-	// rides INSIDE the JSON record) and advance it. A missing/unparseable record -> 1.
+	// Serialize concurrent writers: acquire an exclusive lock before read->increment->publish
+	// so two writers cannot read the same seq and issue duplicate records, and a second
+	// writer cannot overwrite a still-unapplied command.
+	$lockpath = "{$pfb['dnsbldir']}/pfb_py_control.lock";
+	$lock = @fopen($lockpath, 'c');	// 'c': create if absent, no truncate
+	if ($lock === FALSE) {
+		pfb_logger("\nPFBL-03: control channel lock open failed [ {$lockpath} ]", 2);
+		return FALSE;
+	}
+	if (!@flock($lock, LOCK_EX)) {
+		@fclose($lock);
+		pfb_logger("\nPFBL-03: control channel lock acquire failed [ {$lockpath} ]", 2);
+		return FALSE;
+	}
+
+	// Read the current sequence from the channel and advance it. A missing/unparseable
+	// record -> seq 0 -> next publish is 1.
 	$channel = "{$pfb['dnsbldir']}/pfb_py_control";
 	$cur = 0;
 	if (file_exists($channel)) {
@@ -4448,14 +4498,30 @@ function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '') {
 
 	$payload = json_encode($record);
 	if ($payload === FALSE) {
+		@flock($lock, LOCK_UN);
+		@fclose($lock);
 		pfb_logger("\nPFBL-03: control command [ {$cmd} ] rejected: encode failure", 2);
 		return FALSE;
 	}
 
 	if (!pfb_unbound_py_atomic_write_root($channel, $payload . "\n")) {
+		@flock($lock, LOCK_UN);
+		@fclose($lock);
 		return FALSE;
 	}
 
+	// While still holding the lock, optionally wait for the watcher to apply the command
+	// before returning. The command IS on disk regardless; the wait only confirms consumption.
+	if ($wait_timeout > 0) {
+		$applied = pfb_unbound_py_wait_control_applied($record['seq'], $wait_timeout);
+		if (!$applied) {
+			pfb_logger("\nPFBL-03: control command [ {$cmd} ] seq {$record['seq']} published"
+				. " but not confirmed applied within {$wait_timeout}s; the watcher will still apply it", 2);
+		}
+	}
+
+	@flock($lock, LOCK_UN);
+	@fclose($lock);
 	return $record['seq'];
 }
 

--- a/tests/php/UnboundPyControlWriteTest.php
+++ b/tests/php/UnboundPyControlWriteTest.php
@@ -373,8 +373,8 @@ final class UnboundPyControlWriteTest extends TestCase
 		// Given: no lock file yet.
 		$this->assertFileDoesNotExist("{$this->tmp}/pfb_py_control.lock");
 
-		// When: a write succeeds.
-		pfb_unbound_py_write_control('enable');
+		// When: a write succeeds (assert the seq so a FALSE return can't pass this test).
+		$this->assertSame(1, pfb_unbound_py_write_control('enable'));
 
 		// Then: the lock file was created.
 		$this->assertFileExists("{$this->tmp}/pfb_py_control.lock");

--- a/tests/php/UnboundPyControlWriteTest.php
+++ b/tests/php/UnboundPyControlWriteTest.php
@@ -6,25 +6,36 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * PFBL-03 privileged DNSBL-control writer: pfb_unbound_py_write_control() and its
- * permission-specific publisher pfb_unbound_py_atomic_write_root().
+ * Control-channel writer: pfb_unbound_py_write_control(),
+ * pfb_unbound_py_wait_control_applied(), and pfb_unbound_py_atomic_write_root().
  *
  * Scenario: the writer is the ROOT-only producer of the local privileged command
  * channel (/var/unbound/pfb_py_control, here redirected to a temp dnsbldir). It
- * validates the command + argument (the semantic layer), assembles a JSON record with
- * a monotonically-advancing sequence, and atomically publishes it. These tests pin:
+ * validates the command + argument (the semantic layer), acquires an exclusive lock,
+ * assembles a JSON record with a monotonically-advancing sequence, atomically publishes
+ * it, and waits for the watcher to advance the applied marker before returning.
+ * These tests pin:
  *   - the command allow-list (disable/enable/addbypass/removebypass) and rejection of
  *     anything else (no file written);
  *   - argument validation at the WRITER (invalid IP / out-of-range duration rejected,
  *     no side effect) -- the reader re-validates independently (Python suite);
  *   - the record shape (cmd/ip/duration/seq/ts) and the seq advance (replay safety);
+ *   - the lock file is created on a successful write;
+ *   - the applied-wait semantics: returns TRUE when the marker >= seq, FALSE on timeout;
+ *   - the writer still returns the seq when the wait times out (command IS on disk);
  *   - the publisher's command-channel permission model (owner root, group unbound,
  *     mode 0640) and its atomic, no-temp-left-behind behaviour.
  *
  * Run against a temp $pfb sandbox (no live box, no chroot). chown('root') is a no-op
  * for a non-root test runner; mode 0640 is asserted because it does not need privilege.
+ *
+ * The applied marker is pre-seeded to PHP_INT_MAX in setUp() so the default-timeout
+ * wait path returns immediately for all existing tests (simulates the watcher having
+ * already applied any seq). New tests that exercise the wait directly use an explicit
+ * $wait_timeout argument.
  */
 #[CoversFunction('pfb_unbound_py_write_control')]
+#[CoversFunction('pfb_unbound_py_wait_control_applied')]
 #[CoversFunction('pfb_unbound_py_atomic_write_root')]
 final class UnboundPyControlWriteTest extends TestCase
 {
@@ -44,6 +55,11 @@ final class UnboundPyControlWriteTest extends TestCase
 			'dnsbldir' => $this->tmp,
 			'supp'     => 'off',	// pfb_filter()'s private/reserved IP exclusion off for the test
 		]);
+
+		// Pre-seed the applied marker to PHP_INT_MAX so the default-timeout wait in
+		// write_control returns immediately -- simulates the watcher having already applied
+		// any seq. Tests that probe the wait directly overwrite this before calling.
+		file_put_contents("{$this->tmp}/pfb_py_control.applied", (string) PHP_INT_MAX . "\n");
 	}
 
 	protected function tearDown(): void
@@ -83,6 +99,11 @@ final class UnboundPyControlWriteTest extends TestCase
 		$rec = json_decode(trim($raw), true);
 		$this->assertIsArray($rec);
 		return $rec;
+	}
+
+	private function channelApplied(): string
+	{
+		return "{$this->tmp}/pfb_py_control.applied";
 	}
 
 	// --- the four valid commands (record shape) -----------------------------
@@ -255,5 +276,129 @@ final class UnboundPyControlWriteTest extends TestCase
 		$this->assertFalse(
 			pfb_unbound_py_atomic_write_root("{$this->tmp}/nope/deep/cmd", 'x')
 		);
+	}
+
+	// --- wait_control_applied: poll semantics -------------------------------
+
+	public function testWaitControlAppliedReturnsTrueWhenMarkerAlreadySatisfied(): void
+	{
+		// Given: applied marker already >= the seq we wait for.
+		file_put_contents($this->channelApplied(), "10\n");
+
+		// When/Then: returns TRUE immediately for seq <= 10.
+		$this->assertTrue(pfb_unbound_py_wait_control_applied(10));
+		$this->assertTrue(pfb_unbound_py_wait_control_applied(5));
+		$this->assertTrue(pfb_unbound_py_wait_control_applied(1));
+	}
+
+	public function testWaitControlAppliedReturnsTrueWhenMarkerExceedsSeq(): void
+	{
+		// Marker strictly greater than requested seq is also satisfied.
+		file_put_contents($this->channelApplied(), "99\n");
+		$this->assertTrue(pfb_unbound_py_wait_control_applied(50));
+	}
+
+	public function testWaitControlAppliedReturnsFalseOnTimeoutWhenMarkerBelow(): void
+	{
+		// Given: marker is below the seq we wait for.
+		file_put_contents($this->channelApplied(), "0\n");
+
+		// When: wait with a very short timeout (0.4 s keeps the test fast).
+		// Then: returns FALSE -- the marker never advanced.
+		$result = pfb_unbound_py_wait_control_applied(5, 0.4);
+		$this->assertFalse($result);
+	}
+
+	public function testWaitControlAppliedReturnsFalseWhenMarkerAbsent(): void
+	{
+		// Given: no applied marker file at all.
+		@unlink($this->channelApplied());
+
+		// When: wait with a short timeout.
+		// Then: returns FALSE (file never appears).
+		$this->assertFalse(pfb_unbound_py_wait_control_applied(1, 0.4));
+	}
+
+	// --- write_control with wait satisfied (marker high via setUp) ----------
+
+	public function testWriteControlReturnsSeqWhenWaitSatisfied(): void
+	{
+		// Given: applied marker is at PHP_INT_MAX (setUp), so the wait returns instantly.
+		// When/Then: write returns the published seq.
+		$seq = pfb_unbound_py_write_control('enable');
+		$this->assertSame(1, $seq);
+		$this->assertSame(1, $this->readRecord()['seq']);
+	}
+
+	// --- write_control with wait NOT satisfied (marker low) -----------------
+
+	public function testWriteControlReturnsSeqEvenWhenWaitTimesOut(): void
+	{
+		// Given: applied marker is below any seq the writer will publish.
+		file_put_contents($this->channelApplied(), "0\n");
+
+		// When: write with a small timeout so the wait times out quickly.
+		// Then: STILL returns the published seq (the command IS on disk).
+		$seq = pfb_unbound_py_write_control('enable', '', '', 0.4);
+		$this->assertSame(1, $seq);
+
+		// And: the channel record was written with the correct seq.
+		$rec = $this->readRecord();
+		$this->assertSame('enable', $rec['cmd']);
+		$this->assertSame(1, $rec['seq']);
+	}
+
+	// --- write_control with wait_timeout = 0 (fire-and-forget) -------------
+
+	public function testWriteControlSkipsWaitWhenTimeoutIsZero(): void
+	{
+		// Given: applied marker is NOT advanced (below any seq).
+		file_put_contents($this->channelApplied(), "0\n");
+
+		// When: write with $wait_timeout = 0 -- skip-wait path.
+		// Then: returns the seq immediately without blocking.
+		$seq = pfb_unbound_py_write_control('disable', '', '', 0);
+		$this->assertSame(1, $seq);
+
+		// And: the record is on disk.
+		$rec = $this->readRecord();
+		$this->assertSame('disable', $rec['cmd']);
+		$this->assertSame(1, $rec['seq']);
+	}
+
+	// --- lock file ---------------------------------------------------------
+
+	public function testLockFileExistsAfterSuccessfulWrite(): void
+	{
+		// Given: no lock file yet.
+		$this->assertFileDoesNotExist("{$this->tmp}/pfb_py_control.lock");
+
+		// When: a write succeeds.
+		pfb_unbound_py_write_control('enable');
+
+		// Then: the lock file was created.
+		$this->assertFileExists("{$this->tmp}/pfb_py_control.lock");
+	}
+
+	// --- sequential writers advance the seq under the lock -----------------
+
+	public function testTwoSequentialWritersAdvanceSeqCorrectly(): void
+	{
+		// Given: applied marker is high (setUp) so waits return immediately.
+		// Note: true multi-process concurrency cannot be exercised in the unit sandbox;
+		// this test proves the sequential case (lock does not break the normal advance).
+
+		// When: first write.
+		$seq1 = pfb_unbound_py_write_control('disable');
+
+		// Then: seq is 1.
+		$this->assertSame(1, $seq1);
+
+		// When: second write.
+		$seq2 = pfb_unbound_py_write_control('enable');
+
+		// Then: seq strictly advances to 2, and the on-disk record reflects it.
+		$this->assertSame(2, $seq2);
+		$this->assertSame(2, $this->readRecord()['seq']);
 	}
 }


### PR DESCRIPTION
## Summary

The DNSBL control-channel writer `pfb_unbound_py_write_control()` read the current sequence from the single channel file and republished it with `seq + 1`, with no serialization of the read→increment→publish cycle. Two consequences:

1. Two concurrent writers could read the same sequence and publish a duplicate.
2. A second command issued before the watcher consumed the first overwrote (silently lost) the first — only the last record survived on disk.

## Fix

- **Serialize writers** with an exclusive `flock(LOCK_EX)` on a dedicated lock file `{dnsbldir}/pfb_py_control.lock`, held across the entire read→increment→publish.
- **Wait for the watcher to apply the published sequence** before returning: new `pfb_unbound_py_wait_control_applied($seq, $timeout_s = 5)` mirrors the existing reload-side `pfb_unbound_py_wait_applied()` (polls the `.applied` marker, 200 ms interval). The lock is held through the wait, so a second writer cannot overwrite a still-unapplied command.
- New `$wait_timeout` parameter (default 5s). On timeout the command is already on disk and the watcher will still apply it, so the writer logs a warning and **still returns the published sequence** (existing success contract preserved). `$wait_timeout <= 0` skips the wait entirely (fire-and-forget).
- Validation runs before the lock is acquired (cheap-guard-first); the lock handle is released on every exit path after it is opened.

The Python watcher is unchanged — it already adopts a baseline without replay, ignores `seq <= last_applied` (duplicate/stale), advances the applied marker per consumed record, and never regresses it (pinned by the existing control-channel test suite).

## Tests

`tests/php/UnboundPyControlWriteTest.php`: existing tests pre-seed the applied marker in `setUp()` so the default-timeout wait returns instantly (no stalls); 9 new tests cover the wait function (TRUE when satisfied / equal / greater; FALSE on timeout and on absent marker), the writer returning the seq when the wait is satisfied, returning the seq even when the wait times out (in-flight contract), `$wait_timeout = 0` skipping the wait, the lock file being created, and two sequential writers advancing the sequence under the lock.

php -l, PHPUnit (29 control / 647 full), PHPStan, and PHPCS all green. Full suite runs in ~5s (no wait stalls).

Note: a true multi-process writer race is not reproducible off-box (no forked processes in the unit suite); the lock is an OS-level `flock`, and the consumer-side monotonic/duplicate-ignore invariants are already covered by the Python watcher suite — a documented out-of-CI limitation.

Fixes #234

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEtct4G4nCXfjLYq51AJ5k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved DNS control command handling with synchronized publishing to avoid conflicts.
  * Added an optional “wait for applied confirmation” behavior (configurable timeout) so the command writer can verify consumption before returning.

* **Tests**
  * Expanded automated coverage for the applied-confirmation wait logic, including satisfied markers, timeouts, and missing marker scenarios.
  * Added checks for correct sequence return values and that the synchronization behavior works as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->