### PR TITLE
pfblockerng: seed the Upstream counter row at DB init in Python

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2179,6 +2179,17 @@ def _db_create(db: int, cursor: Any) -> None:
         cursor.execute(
             "CREATE TABLE IF NOT EXISTS dnsbl ( groupname TEXT, timestamp TEXT, entries INTEGER, counter INTEGER )"
         )
+        # Seed the synthetic 'Upstream' group row (issue #285) so the per-block counter
+        # UPDATE in _db_flush_dnsbl has a row to increment -- the upstream block is not a
+        # feed, so dnsbl_save_stats() never creates it. Idempotent + preserves any
+        # accumulated counter (only inserts when absent), mirroring the resolver row-0
+        # seed above.
+        cursor.execute("SELECT COUNT(*) FROM dnsbl WHERE groupname = 'Upstream'")
+        if cursor.fetchone()[0] == 0:
+            cursor.execute(
+                "INSERT INTO dnsbl ( groupname, timestamp, entries, counter ) VALUES ( 'Upstream', ?, 0, 0 )",
+                (make_timestamp(),),
+            )
     elif db == DB_CACHE:
         cursor.execute(
             "CREATE TABLE IF NOT EXISTS dnsblcache ( type TEXT, domain TEXT, groupname TEXT, final TEXT, feed TEXT );"

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2181,15 +2181,16 @@ def _db_create(db: int, cursor: Any) -> None:
         )
         # Seed the synthetic 'Upstream' group row (issue #285) so the per-block counter
         # UPDATE in _db_flush_dnsbl has a row to increment -- the upstream block is not a
-        # feed, so dnsbl_save_stats() never creates it. Idempotent + preserves any
-        # accumulated counter (only inserts when absent), mirroring the resolver row-0
-        # seed above.
-        cursor.execute("SELECT COUNT(*) FROM dnsbl WHERE groupname = 'Upstream'")
-        if cursor.fetchone()[0] == 0:
-            cursor.execute(
-                "INSERT INTO dnsbl ( groupname, timestamp, entries, counter ) VALUES ( 'Upstream', ?, 0, 0 )",
-                (make_timestamp(),),
-            )
+        # feed, so dnsbl_save_stats() never creates it. The single INSERT ... WHERE NOT
+        # EXISTS is atomic (vs a check-then-insert): it stays a no-op once the row is
+        # present, so it is idempotent and preserves any accumulated counter across a
+        # re-init/reconnect, and cannot duplicate the row if another opener races it.
+        cursor.execute(
+            "INSERT INTO dnsbl ( groupname, timestamp, entries, counter ) "
+            "SELECT 'Upstream', ?, 0, 0 "
+            "WHERE NOT EXISTS (SELECT 1 FROM dnsbl WHERE groupname = 'Upstream')",
+            (make_timestamp(),),
+        )
     elif db == DB_CACHE:
         cursor.execute(
             "CREATE TABLE IF NOT EXISTS dnsblcache ( type TEXT, domain TEXT, groupname TEXT, final TEXT, feed TEXT );"

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2172,9 +2172,13 @@ def _db_file(db: int) -> str:
 def _db_create(db: int, cursor: Any) -> None:
     if db == DB_RESOLVER:
         cursor.execute("CREATE TABLE IF NOT EXISTS resolver (row integer, totalqueries integer, queries integer)")
-        cursor.execute("SELECT COUNT(*) FROM resolver")
-        if cursor.fetchone()[0] == 0:
-            cursor.execute("INSERT INTO resolver ( row, totalqueries, queries ) VALUES ( 0, 0, 0 )")
+        # Seed row 0 atomically (no-op once present) -- same singleton-seed shape as the
+        # dnsbl 'Upstream' row below: INSERT ... WHERE NOT EXISTS avoids a check-then-insert
+        # race and is idempotent (preserves accumulated totals across a re-init/reconnect).
+        cursor.execute(
+            "INSERT INTO resolver ( row, totalqueries, queries ) "
+            "SELECT 0, 0, 0 WHERE NOT EXISTS (SELECT 1 FROM resolver)"
+        )
     elif db == DB_DNSBL:
         cursor.execute(
             "CREATE TABLE IF NOT EXISTS dnsbl ( groupname TEXT, timestamp TEXT, entries INTEGER, counter INTEGER )"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3240,26 +3240,6 @@ function dnsbl_save_stats() {
 					}
 				}
 			}
-
-			// Seed the aggregate Upstream group row if it does not yet exist.
-			// Python increments its counter via pfb_db_enqueue on each upstream block;
-			// the UPDATE in _db_flush_dnsbl only fires on an existing row, so we must
-			// ensure the row is present whenever DNSBL feeds are active.
-			if (!isset($sql_groupnames['Upstream'])) {
-				// INSERT ... WHERE NOT EXISTS keeps the seed atomic: dnsbl.groupname has
-				// no UNIQUE constraint, so a bare INSERT could create a duplicate row if
-				// two reloads race past the pre-loop snapshot check above (which would
-				// then over-count, as the counter UPDATE hits every matching row).
-				$stmt = $db_handle->prepare(
-					"INSERT INTO dnsbl (groupname, timestamp, entries, counter)"
-					. " SELECT 'Upstream', :timestamp, 0, 0"
-					. " WHERE NOT EXISTS (SELECT 1 FROM dnsbl WHERE groupname = 'Upstream');"
-				);
-				if ($stmt) {
-					$stmt->bindValue(':timestamp', date('M j H:i:s', time()), SQLITE3_TEXT);
-					$stmt->execute();
-				}
-			}
 		}
 		pfb_close_sqlite($db_handle);
 	}

--- a/tests/smoke/test_smoke_upstream_block.py
+++ b/tests/smoke/test_smoke_upstream_block.py
@@ -325,31 +325,42 @@ class TestUpstreamBlockNormalControl:
 # ---------------------------------------------------------------------------
 
 _DNSBL_DB = "/var/unbound/pfb_py_dnsbl.sqlite"
+_CTR_OPEN = "<<<UPCTR>>>"
+_CTR_CLOSE = "<<<UPEND>>>"
 
 
 def _read_upstream_counter(vm: SmokeVM) -> int:
-    """Read the ``counter`` column of the ``Upstream`` row from the on-box dnsbl SQLite DB.
+    """Read the ``counter`` of the ``Upstream`` row from the on-box dnsbl SQLite DB.
 
-    Uses ``python3 -c`` over SSH — py-sqlite3 is a baked dep on the smoke image.
-    Returns -1 when the row does not yet exist (DB absent or row missing).
+    Uses pfSsh.php (PHP + the SQLite3 class the package itself runs on), NOT a python
+    one-liner: the appliance ships ``python3.11`` with no ``python3`` symlink, so a
+    ``python3 -c`` read is not portable. Reads the same ``/var/unbound/pfb_py_dnsbl.sqlite``
+    the chrooted Python module writes. The value is delimited so pfSsh.php's startup
+    banner does not pollute it. Returns the integer counter, or -1 when the row is
+    absent or the DB/table cannot be read.
     """
-    script = (
-        "import sqlite3, sys\n"
-        f"try:\n"
-        f"    con = sqlite3.connect({_DNSBL_DB!r})\n"
-        f"    row = con.execute(\"SELECT counter FROM dnsbl WHERE groupname='Upstream'\").fetchone()\n"
-        f"    print(row[0] if row else -1)\n"
-        f"except Exception as e:\n"
-        f"    print(-1)\n"
+    snippet = (
+        "$__c = -1;\n"
+        "try {\n"
+        f"    $__db = new SQLite3('{_DNSBL_DB}');\n"
+        "    $__r = $__db->querySingle(\"SELECT counter FROM dnsbl WHERE groupname = 'Upstream'\");\n"
+        "    $__c = ($__r === null || $__r === FALSE) ? -1 : (int) $__r;\n"
+        "    $__db->close();\n"
+        "} catch (Throwable $__e) { $__c = -1; }\n"
+        f"echo '{_CTR_OPEN}' . $__c . '{_CTR_CLOSE}';\n"
     )
-    result = vm.ssh("python3", "-c", script)
+    out = h.php_eval(vm, snippet).stdout or ""
+    start = out.find(_CTR_OPEN)
+    end = out.find(_CTR_CLOSE)
+    if start == -1 or end == -1:
+        return -1
     try:
-        return int(result.stdout.strip())
-    except (ValueError, AttributeError):
+        return int(out[start + len(_CTR_OPEN) : end])
+    except ValueError:
         return -1
 
 
-def _wait_for_counter_above(vm: SmokeVM, baseline: int, *, timeout_s: float = 15.0, poll_s: float = 0.5) -> int:
+def _wait_for_counter_above(vm: SmokeVM, baseline: int, *, timeout_s: float = 30.0, poll_s: float = 2.0) -> int:
     """Poll the on-box Upstream dnsbl counter until it exceeds ``baseline`` or the deadline expires.
 
     The counter is flushed by the async db_worker thread, so a freshly-logged block
@@ -393,7 +404,7 @@ class TestUpstreamCounterIncrement:
         baseline = _read_upstream_counter(deployed_vm)
         assert baseline >= 0, (
             "Upstream row not found in dnsbl table before probe — "
-            "dnsbl_save_stats() did not seed it. "
+            "the Python DB-init seed (_db_create) did not create it. "
             f"DB: {_DNSBL_DB!r}"
         )
 

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -349,6 +349,27 @@ class TestDbSubsystem:
         finally:
             con.close()
 
+    def test_seed_is_idempotent_and_preserves_resolver_counter(self, tmp_path: Any) -> None:
+        # The atomic row-0 seed (INSERT ... WHERE NOT EXISTS) must not reset or
+        # duplicate the row on a later init/reconnect. Accumulate, re-create, assert.
+        import sqlite3
+
+        con = sqlite3.connect(str(tmp_path / "resolver.sqlite"))
+        try:
+            pfb_unbound._db_create(pfb_unbound.DB_RESOLVER, con.cursor())
+            con.commit()
+            assert con.execute("SELECT totalqueries FROM resolver").fetchall() == [(0,)]  # before: single seed at 0
+            con.execute("UPDATE resolver SET totalqueries = totalqueries + 7 WHERE row = 0")
+            con.commit()
+
+            pfb_unbound._db_create(pfb_unbound.DB_RESOLVER, con.cursor())  # re-init
+            con.commit()
+
+            # Single row, counter preserved (not reset to 0, not duplicated).
+            assert con.execute("SELECT totalqueries FROM resolver").fetchall() == [(7,)]
+        finally:
+            con.close()
+
     def test_resolver_counter_accumulates(self, tmp_path: Any) -> None:
         self._resolver(tmp_path)
         for _ in range(5):

--- a/tests/test_upstream_block.py
+++ b/tests/test_upstream_block.py
@@ -11,15 +11,19 @@ All tests are pure off-box — no Unbound API calls, no fixtures, no I/O.
 
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 from unboundmodule import RCODE_NOERROR, RCODE_NXDOMAIN
 
 import pfb_unbound
 from pfb_unbound import (
+    DB_DNSBL,
     EDE_BLOCKED,
     EDE_FILTERED,
     EDNS_OPT_CODE_EDE,
     UpstreamBlock,
+    _db_create,
     _log_upstream_block,
     _parse_ede_options,
     classify_upstream_block,
@@ -435,3 +439,52 @@ class TestLogUpstreamBlockCounterEnqueue:
 
         dnsbl_tasks = [t for t in calls if len(t) == 2 and t[0] == "dnsbl"]
         assert dnsbl_tasks == [], f"Expected no dnsbl enqueue with sqlite3_dnsbl_con=False; got: {calls}"
+
+
+# ---------------------------------------------------------------------------
+# _db_create — the dnsbl table seeds the synthetic 'Upstream' row at zero
+# ---------------------------------------------------------------------------
+
+
+class TestDnsblDbSeedsUpstreamRow:
+    """Scenario: creating the dnsbl DB seeds an 'Upstream' counter row at zero.
+
+    Background:
+        The per-block counter is applied as a bare ``UPDATE dnsbl SET counter =
+        counter + ? WHERE groupname = ?`` (_db_flush_dnsbl), which no-ops on a
+        missing row. 'Upstream' is synthetic (never a feed), so _db_create seeds it
+        on DB creation -- mirroring the resolver row-0 seed -- so the increment has
+        a row to hit. The seed must be idempotent and must never reset an already
+        accumulated counter on a later init/reconnect.
+    """
+
+    @staticmethod
+    def _counter_rows(con: sqlite3.Connection) -> list[tuple[int]]:
+        return con.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchall()
+
+    def test_create_seeds_upstream_row_at_zero(self) -> None:
+        # Given/When: a fresh dnsbl DB is created.
+        con = sqlite3.connect(":memory:")
+        _db_create(DB_DNSBL, con.cursor())
+        con.commit()
+        # Then: exactly one 'Upstream' row exists, entries and counter both 0.
+        row = con.execute("SELECT entries, counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone()
+        assert row == (0, 0), f"Upstream row not seeded at zero: {row!r}"
+        assert len(self._counter_rows(con)) == 1, "expected exactly one Upstream row"
+
+    def test_create_is_idempotent_and_preserves_counter(self) -> None:
+        # Given: a created DB whose Upstream counter has since accumulated.
+        con = sqlite3.connect(":memory:")
+        _db_create(DB_DNSBL, con.cursor())
+        con.commit()
+        assert self._counter_rows(con) == [(0,)]  # before: seeded at 0
+        con.execute("UPDATE dnsbl SET counter = counter + 5 WHERE groupname = 'Upstream'")
+        con.commit()
+        assert self._counter_rows(con) == [(5,)]  # accumulated
+
+        # When: the DB is (re-)created again (a later module init / fault reconnect).
+        _db_create(DB_DNSBL, con.cursor())
+        con.commit()
+
+        # Then: still a single row, counter PRESERVED (not reset, not duplicated).
+        assert self._counter_rows(con) == [(5,)], "re-create must not reset or duplicate the Upstream row"


### PR DESCRIPTION
Follow-up to #285 / #300, addressing review of the Upstream counter seed.

## Why
The per-block counter is applied as a bare `UPDATE dnsbl SET counter = counter + ? WHERE groupname = ?`, which no-ops on a missing row. The `Upstream` group is synthetic (never a feed), so nothing in the feed-stats path creates its row — it must be seeded. The original seed lived in `dnsbl_save_stats()` (PHP, whose job is *feed* row lifecycle), coupling an unrelated function across the language boundary and leaving the behaviour testable only by the slow live-VM smoke.

## Change
- **Move the seed into Python `_db_create()`** (the DB-init path), co-located with `_log_upstream_block`'s increment — the only writer of that row. Mirrors the existing resolver row-0 seed exactly: idempotent, and preserves an accumulated counter across re-init/reconnect. **Removes the PHP seed** from `dnsbl_save_stats()`.
- **Lower-level tests** (per review): Python unit tests that the dnsbl DB-init seeds `Upstream` at zero, is idempotent, and does not reset an accumulated counter on re-create. (The increment guard was already unit-tested.)
- **Smoke read fix**: read the on-box counter via `pfSsh.php` (PHP + the SQLite3 class the package runs on) instead of `python3` — the appliance ships `python3.11` with no `python3` symlink, which is why the first dispatched smoke run failed at the baseline read.

## Validation
- Local: `pytest` 1735 (incl. the 2 new seed tests), `phpunit` 638, `phpcs`/`phpstan`/`php -l`/`ruff` clean.
- The UI tiers (render + functional) already passed on the live VM for #300, validating the rendering side (incl. the new cloud-icon test and the undefined-key fix). I'll re-dispatch the smoke tier after this lands to confirm the counter end-to-end.

Refs #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GighgrxzgA8pzAPtS66iCK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured fresh database initialization always provides the required DNSBL “Upstream” counter row so upstream-block statistics can be tracked from the first update.
  * Made DNS resolver counter seeding idempotent so re-initialization preserves existing counts without creating duplicates or resetting values.

* **Tests**
  * Added unit tests to verify “Upstream” DNSBL row seeding at zero and idempotency.
  * Added unit tests to verify resolver row seeding is idempotent and preserves `totalqueries`.
  * Improved upstream smoke test counter reading and increased polling timeouts for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->