### PR TITLE
ADR-27: release rollback retention (Part 1)

### DIFF
--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/ADR.md
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/ADR.md
@@ -93,7 +93,7 @@ version actually exists (§2.4) — it has no consumer today and must not be bui
 | Retention source | **GitHub Releases** (durable, already every release `.pkg`). `publish.yml` enumerates Releases, buckets by `prerelease` (devel pre-release) vs stable, takes the newest `N`/`M`, downloads their `.pkg`, and feeds them to the generator alongside the fresh devel-HEAD build. No new stateful store (unlike nightly's cache — Releases *are* the store). |
 | Catalog shape | `release/<varver>/<arch>/` now carries up to `N`+`M` versions per ABI (multi-version NDJSON). `pkg install <pkg>` still takes newest; `pkg install <pkg>-<version>` / `pkg add` pins an older one. |
 | Landing page | The ADR-20 "Older nightlies" per-edition disclosure pattern (`gen_landing.py`) generalizes to an **"Older releases"** disclosure under each edition — surfacing the retained devel/stable versions with their commit/date so a human can find a rollback target. |
-| Rollback UX (CLI only) | Documented support/debug procedure: `pkg install pfSense-pkg-pfBlockerNG[-devel]-<version>` (pinned) or `pkg add <pages-url>/…/<name>-<version>.pkg`. The catalog now resolves deps for the pinned version. **No GUI** — rollback is a support/debugging action, not an expected user flow, so it does not warrant a shipped `src/www/` page (which would carry an `ui_render`/PHP blast radius for a rarely-trodden path). A future GUI version-pick, if ever wanted, stays with the deferred ADR-19 Update/Channel panel. |
+| Rollback UX (CLI only) | Documented support/debug procedure: `pkg install -f pfSense-pkg-pfBlockerNG[-devel]-<version>` (pinned) or `pkg add <pages-url>/…/<name>-<version>.pkg`. `-f` is required — `pkg install` never downgrades over a newer installed build, so the pin is a no-op without it (proven on the live VM); the catalog still resolves deps for the pinned version (unlike `pkg add`). **No GUI** — rollback is a support/debugging action, not an expected user flow, so it does not warrant a shipped `src/www/` page (which would carry an `ui_render`/PHP blast radius for a rarely-trodden path). A future GUI version-pick, if ever wanted, stays with the deferred ADR-19 Update/Channel panel. |
 
 ### 2.2 Semantics that MUST be preserved (the contract — pin with tests before changing)
 
@@ -168,8 +168,9 @@ exists — building it speculatively risks ADR-01's trap).
 
 - The `release/<varver>/<arch>/` catalog carries the newest **N** devel + **M** stable versions per ABI
   (deduped, version-sorted, pruned deterministically); `pkg install <name>` still yields the newest.
-- A real pfSense box can `pkg install <name>-<oldversion>` (or `pkg add`) a **retained older** release and end up
-  with that exact version active, deps resolved from our repo — proven by the live `-m repo` smoke.
+- A real pfSense box can `pkg install -f <name>-<oldversion>` (or `pkg add`) a **retained older** release and end
+  up with that exact version active, deps resolved from our repo — proven by the live `-m repo` smoke. (`-f` is
+  required to downgrade over a newer installed build; deps still resolve from the catalog.)
 - The off-box catalog-membership test pins that exactly the expected retained versions appear (and an older-than-
   window one does not).
 - The landing page shows an "Older releases" disclosure per edition (unit-tested in `tests/test_gen_landing.py`),
@@ -230,8 +231,9 @@ Prompt: `03_Publish_Retention.txt`.
 Prompt: `04_Rollback_Smoke.txt`.
 
 - `tests/smoke/test_repo_install.py`: forge ≥2 retained release versions (reuse the existing re-version helper);
-  install newest, assert it active; **roll back** via `pkg install <name>-<olderversion>`; assert the older
-  version is now active, deps resolved from our repo; then re-upgrade to newest (before/after lifecycle).
+  install newest, assert it active; **roll back** via `pkg install -f <name>-<olderversion>` (`-f` forces the
+  downgrade over the newer installed build); assert the older version is now active, deps resolved from our repo;
+  then re-upgrade to newest (before/after lifecycle).
 - Pin: `pkg install <name>` (no version) still picks newest; the pinned install picks exactly the requested one.
 
 ### Phase 5 — Landing "Older releases" + rollback documentation
@@ -240,7 +242,7 @@ Prompt: `05_Landing_And_Docs.txt`.
 
 - `scripts/gen_landing.py`: add the per-edition "Older releases" disclosure (mirror `_older_nightlies_*`),
   surfacing the retained devel/stable versions with commit/date so a human can find a rollback target.
-- `README`/`docs`: document the CLI rollback procedure (`pkg install <name>-<version>` / `pkg add <url>`),
+- `README`/`docs`: document the CLI rollback procedure (`pkg install -f <name>-<version>` / `pkg add <url>`),
   including the config-schema-mismatch caveat (no backward config migration).
 - Tests: `gen_landing` unit cases in `tests/test_gen_landing.py` (the "Older releases" disclosure, before/after).
 
@@ -252,7 +254,7 @@ Prompt: `05_Landing_And_Docs.txt`.
   all from our repo with deps resolved; newest-wins default intact; cross-repo precedence intact.
 - §2.4 (Part 2) present as design-of-record; **no** part-2 code merged.
 - **Manual smoke checklist (owner: maintainer)** — the items CI cannot fully cover:
-  - On a real box, CLI roll back (`pkg install <name>-<oldver>`) to an older version and back; confirm the package functions (a DNSBL match) after each.
+  - On a real box, CLI roll back (`pkg install -f <name>-<oldver>`) to an older version and back; confirm the package functions (a DNSBL match) after each.
   - Confirm a rollback across a config-schema change warns and does not corrupt config (documented limitation).
   - Confirm Pages/catalog growth at `N=M=10` is within the publish runtime/artifact budget.
 - **Reject criteria (ADR-01 discipline):** REJECT (or rescope) if any holds —

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/01_Results.txt
@@ -1,0 +1,105 @@
+ADR-27 Phase 1 Results — Extract + pin a channel-keyed release-retention seam (prep)
+======================================================================================
+
+Status: COMPLETE — go-ahead for Phase 2.
+
+ADR-RESUME: branch=adr/27-release-rollback-and-eol-rou next-phase=2
+
+------------------------------------------------------------------------
+Helper added
+------------------------------------------------------------------------
+
+File: scripts/build-repo-portable.py
+
+Signature:
+    def retain_by_channel(
+        pkg_paths: list[Path],
+        *,
+        keep_devel: int,
+        keep_stable: int,
+    ) -> list[Path]:
+
+Channel-detection rule (by the ``name`` field in each path's +COMPACT_MANIFEST):
+  * name ending "-nightly"  → nightly channel  (passed through untouched; caller owns its retention)
+  * name ending "-devel"    → devel channel
+  * anything else           → stable channel
+
+Pruning rules (reuses the existing ``_retain_newest`` for version-sorted ordering):
+  * keep == 0                   → keep ALL of that channel ("unbounded / disabled" sentinel)
+  * keep >= len(bucket)         → keep all (no-op)
+  * keep < len(bucket)          → prune to the ``keep`` newest by version order
+
+Return order: devel (newest-first) + stable (newest-first) + nightly (input order preserved).
+
+Version-order function reused: ``_retain_newest(bucket, keep)``
+  (defined at line ~601 in scripts/build-repo-portable.py;
+   uses ``_pkg_version_key`` for component-wise numeric sort).
+
+------------------------------------------------------------------------
+No call-site change
+------------------------------------------------------------------------
+
+``build_repo_matrix`` is NOT modified. The helper is defined and tested only.
+``git diff HEAD`` confirms: only additions (the new function + 8 test functions +
+a private helper ``_make_pkg_channel``). Catalog output is byte-identical to before.
+
+------------------------------------------------------------------------
+Tests added (tests/test_build_repo_portable.py)
+------------------------------------------------------------------------
+
+8 new test functions, all under the ADR-27 Phase 1 block:
+
+1. test_retain_by_channel_devel_pruned_independently
+   — devel pruned to keep_devel=2; stable untouched (keep_stable=0)
+   — before-state: 5 inputs; after-state: 4 (oldest devel dropped)
+
+2. test_retain_by_channel_stable_pruned_independently
+   — stable pruned to keep_stable=1; devel untouched (keep_devel=0)
+   — before-state: 5 inputs; after-state: 3 (2 oldest stable dropped)
+
+3. test_retain_by_channel_keep_zero_is_unbounded_sentinel
+   — keep_devel=0 + keep_stable=0 → all 6 paths returned (no pruning)
+
+4. test_retain_by_channel_keep_larger_than_bucket_is_noop
+   — keep_devel=100, keep_stable=100 with 2+2 paths → all 4 returned
+
+5. test_retain_by_channel_version_order_deterministic
+   — versions 3.0.1 / 3.0.9 / 3.0.10 (non-lexicographic); keep_devel=2
+   — before-state: all 3 kept when keep=0; after-state: 3.0.10+3.0.9 kept, 3.0.1 dropped
+   — proves numeric component sort, not lexicographic
+
+6. test_retain_by_channel_nightly_untouched
+   — 1 devel + 1 stable + 2 nightly; keep_devel=1, keep_stable=1
+   — nightly passes through regardless; total kept = 4
+
+7. test_retain_by_channel_mixed_prune_nightly_untouched
+   — 3 devel + 3 stable + 2 nightly; keep_devel=1, keep_stable=2
+   — devel: 2 dropped; stable: 1 dropped; nightly: both pass through
+   — total kept = 5; channels pruned independently
+
+8. test_retain_by_channel_empty_channel_is_noop
+   — only stable pkgs provided, empty devel/nightly buckets
+   — no KeyError; both stable pkgs returned
+
+------------------------------------------------------------------------
+Gate outputs
+------------------------------------------------------------------------
+
+python -m pytest -q:
+  1744 passed in 16.60s  (+ 8 new; 0 failures)
+
+ruff check .:
+  All checks passed!
+
+ruff format --check .:
+  112 files already formatted
+
+mypy tests/:
+  Success: no issues found in 46 source files
+
+------------------------------------------------------------------------
+Commit
+------------------------------------------------------------------------
+
+Message: dev: add channel-keyed release-retention helper (ADR-27 P1)
+Branch:  adr/27-release-rollback-and-eol-rou

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/01_Results.txt
@@ -39,9 +39,11 @@ Version-order function reused: ``_retain_newest(bucket, keep)``
 No call-site change
 ------------------------------------------------------------------------
 
-``build_repo_matrix`` is NOT modified. The helper is defined and tested only.
-``git diff HEAD`` confirms: only additions (the new function + 8 test functions +
-a private helper ``_make_pkg_channel``). Catalog output is byte-identical to before.
+``build_repo_matrix`` is NOT modified BY PHASE 1. The helper is defined and tested only.
+The Phase-1 commit diff confirms: only additions (the new function + 8 test functions +
+a private helper ``_make_pkg_channel``); catalog output is byte-identical to before.
+(Scope note: Phase 2 DOES extend ``build_repo_matrix`` to call this helper — so this
+no-modification claim is about the Phase-1 snapshot, not branch HEAD.)
 
 ------------------------------------------------------------------------
 Tests added (tests/test_build_repo_portable.py)

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/02_Results.txt
@@ -1,0 +1,121 @@
+ADR-27 Phase 2 Results — Release-subtree retention in build_repo_matrix
+========================================================================
+
+Status: COMPLETE — go-ahead for Phase 3.
+
+ADR-RESUME: branch=adr/27-release-rollback-and-eol-rou next-phase=3
+
+------------------------------------------------------------------------
+New CLI flags added
+------------------------------------------------------------------------
+
+File: scripts/build-repo-portable.py
+
+--release-keep-devel N   (default 1)
+    Retain the N newest devel releases per (version, arch) in the release
+    catalog. Default 1 = latest-only (today's behaviour). Set >1 to enable
+    rollback; publish.yml must supply older .pkg via --release-extra-pkgs.
+
+--release-keep-stable M  (default 1)
+    Same for the stable channel.
+
+--release-extra-pkgs PATH  (repeatable)
+    Pre-built older-release .pkg to fold into the release candidate pool
+    alongside the freshly built devel + stable. publish.yml downloads these
+    from GitHub Release assets and passes one --release-extra-pkgs per file.
+
+------------------------------------------------------------------------
+build_repo_matrix() signature change
+------------------------------------------------------------------------
+
+New keyword-only parameters (all keyword-only, before **builder_kwargs):
+
+    release_keep_devel: int = 1,
+    release_keep_stable: int = 1,
+    release_extra_pkgs: list[Path] | None = None,
+
+Release subtree logic (was a direct _emit_catalog_from_paths call):
+
+    # pool: freshly built devel + optional stable + caller-supplied extras
+    all_release_pkgs = release_pkgs + list(release_extra_pkgs or [])
+    kept_release = retain_by_channel(
+        all_release_pkgs,
+        keep_devel=release_keep_devel,
+        keep_stable=release_keep_stable,
+    )
+    n_release = _emit_catalog_from_paths(release_dir, kept_release)
+
+stderr log line updated to use n_release (actual count after pruning).
+
+------------------------------------------------------------------------
+Contract / invariants
+------------------------------------------------------------------------
+
+* Defaults (N=M=1) reproduce today's latest-only output — inert change.
+  No publish.yml edit, no extra .pkg passed → catalog is byte-identical.
+* retain_by_channel (Phase 1 helper) prunes: keep=0 = unbounded sentinel;
+  keep >= len(bucket) = no-op; keep < len(bucket) = prune to newest N.
+* Nightly channel (.pkg names ending "-nightly") passes through untouched
+  (neither counted toward N/M nor dropped by release retention).
+* Newest-wins (contract §2.2.2): pkg install <name> with no version picks
+  the highest-version entry because the catalog lists all retained versions
+  and pkg resolves the latest by version ordering.
+* Determinism (contract §2.2.4): same inputs → byte-identical catalog;
+  _emit_catalog_from_paths is mtime-pinned (existing behaviour unchanged).
+
+------------------------------------------------------------------------
+Tests added (tests/test_build_repo_portable.py)
+------------------------------------------------------------------------
+
+3 new test functions, all under the ADR-27 Phase 2 block:
+
+1. test_release_default_is_latest_only
+   — BEFORE-state: no release_extra_pkgs, stable_tag set, default keep=1/1
+   — Asserts: exactly 1 devel + 1 stable in catalog (2 total)
+   — Pins today's behaviour as the inert baseline
+
+2. test_release_subtree_retains_devel_and_stable
+   — 4 devel extras (3.0.1..3.0.4) + 4 stable extras (2.0.1..2.0.4)
+   — BEFORE-state (keep=1/1): 2 total entries in the catalog
+   — AFTER-state (keep=3/3): 3.0.2/3.0.3/3.0.4 kept; 3.0.1 absent;
+     2.0.2/2.0.3/2.0.4 kept; 2.0.1 absent
+   — Proves channels are pruned independently
+
+3. test_release_catalog_lists_all_kept_versions
+   — 3 extras each channel, keep=2/2
+   — Asserts: exactly 4 catalog entries (2 devel + 2 stable)
+   — No duplicate (name, version) pairs
+   — Highest devel version >= 3.0.3; highest stable >= 2.0.3 (newest-wins)
+
+------------------------------------------------------------------------
+Gate outputs
+------------------------------------------------------------------------
+
+python -m pytest -q:
+  1747 passed in 16.05s  (+ 3 new; 0 failures)
+
+ruff check .:
+  All checks passed!
+
+ruff format --check .:
+  112 files already formatted
+
+------------------------------------------------------------------------
+Drift-pin status
+------------------------------------------------------------------------
+
+Existing conf-byte drift pins in tests/test_add_repo_conf.py and
+tests/test_build_repo_portable.py are UNCHANGED — the new parameters are
+additive (keyword-only with defaults) and the catalog output for the
+default call path is byte-identical to before.
+
+------------------------------------------------------------------------
+What is NOT done (Phase 3 scope)
+------------------------------------------------------------------------
+
+publish.yml in pfBlockerNG/pkg has NOT been updated. It still builds the
+current devel .pkg only. Phase 3 will:
+  * add a download step for GitHub Release assets (older .pkg files)
+  * pass them via --release-extra-pkgs
+  * set --release-keep-devel / --release-keep-stable as configured
+  * verify the deployed catalog lists the expected retention depth

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/03_Results.txt
@@ -1,0 +1,236 @@
+ADR-27 Phase 3 Results — Publish wiring: docs + CLI dry-run
+==============================================================
+
+Status: COMPLETE — go-ahead for Phase 4.
+
+ADR-RESUME: branch=adr/27-release-rollback-and-eol-rou next-phase=4
+
+------------------------------------------------------------------------
+Input contract (generator public API — final, no rename)
+------------------------------------------------------------------------
+
+CLI flags (scripts/build-repo-portable.py --build-matrix):
+
+  --release-keep-devel N   (int, default 1)
+      Retain the N newest devel releases per (version, arch) in the
+      release catalog. Default 1 = latest-only (inert; today's behaviour).
+      0 = unbounded sentinel (keep all).
+
+  --release-keep-stable M  (int, default 1)
+      Same for the stable channel.
+
+  --release-extra-pkgs PATH  (repeatable; default empty)
+      Pre-built older-release .pkg to fold into the release pool
+      alongside the freshly built devel + optional stable (repeatable —
+      publish.yml passes one flag per downloaded .pkg file).
+      Pruned by --release-keep-devel / --release-keep-stable after folding.
+
+Python API (build_repo_matrix keyword-only arguments — unchanged from Phase 2):
+
+  release_keep_devel: int = 1
+  release_keep_stable: int = 1
+  release_extra_pkgs: list[Path] | None = None
+
+The contract is the clean public one for publish.yml. A repeatable path
+flag (one flag per file) is simpler to drive from a shell loop than a
+directory path: publish.yml knows the exact filenames from the GitHub API,
+and the generator handles the pool-and-prune internally.
+
+No renaming or refactoring was needed — the Phase 2 contract is adopted as-is.
+
+------------------------------------------------------------------------
+Docs updated
+------------------------------------------------------------------------
+
+README.md
+  Added "Rolling back a stable or devel release" subsection inside the
+  nightly-channel section (Option 2), documenting the pinned-version pkg
+  install command, newest-wins default, retention-window limit, and the
+  config-schema caveat.
+
+scripts/README.md
+  Added "Catalog generator — release retention and rollback" section:
+  - Flag reference table (--release-keep-devel/stable/extra-pkgs)
+  - How publish.yml uses these flags
+  - CLI rollback procedure (pkg install <name>-<version>)
+  - Config-schema caveat
+
+Both files: markdownlint-cli2 — 0 error(s).
+
+------------------------------------------------------------------------
+Tests added (tests/test_build_repo_portable.py)
+------------------------------------------------------------------------
+
+3 new test functions under the ADR-27 Phase 3 block, all exercising
+brp.main([--build-matrix, ...]) (CLI path) with --release-extra-pkgs:
+
+Helper:
+  _with_stub_builder(monkeypatch)
+    Patches brp.build_repo_matrix to inject builder=_stub_builder so
+    the CLI path runs end-to-end without spawning a real subprocess.
+
+1. test_cli_release_extra_pkgs_default_is_latest_only
+   - 3 devel extras (3.0.1..3.0.3) + 3 stable extras (2.0.1..2.0.3)
+     passed as --release-extra-pkgs; no keep override (default 1)
+   - Before-state confirmed (6 files created, correct versions)
+   - Asserts: exactly 1 devel + 1 stable in catalog; retained version
+     is the highest (3.0.3 / 2.0.3) — default is latest-only
+
+2. test_cli_release_extra_pkgs_keeps_newest_n
+   - 4 devel extras (3.0.1..3.0.4) + 4 stable (2.0.1..2.0.4)
+   - BEFORE-state run (keep=1): exactly 1 devel + 1 stable in catalog
+   - AFTER-state run (keep=3): 3 devel + 3 stable; 3.0.1 and 2.0.1 absent;
+     3.0.2/3/4 and 2.0.2/3/4 all present
+   - Proves the CLI wiring delivers the correct before-and-after behaviour
+
+3. test_cli_release_extra_pkgs_newest_wins
+   - 4 devel (3.0.1..3.0.4) + 4 stable (2.0.1..2.0.4), keep=2
+   - Asserts: exactly 2 devel + 2 stable; highest retained devel >= 3.0.4;
+     highest retained stable >= 2.0.4; no duplicate (name, version) pairs
+   - Proves newest-wins: pkg install <name> (no version) resolves the
+     highest catalog entry
+
+------------------------------------------------------------------------
+Gate outputs
+------------------------------------------------------------------------
+
+python -m pytest -q:
+  1750 passed in 16.52s  (+ 3 new; 0 failures)
+
+ruff check .:
+  All checks passed!
+
+ruff format --check .:
+  112 files already formatted
+
+npx markdownlint-cli2 README.md scripts/README.md:
+  0 error(s)
+
+------------------------------------------------------------------------
+publish.yml spec — verbatim YAML steps for pfBlockerNG/pkg
+------------------------------------------------------------------------
+
+Apply these steps in pfBlockerNG/pkg's .github/workflows/publish.yml,
+inside the build job, after the "Build current devel .pkg" step and
+before the "Build repository catalog" step.
+
+Assumptions:
+  - RELEASE_KEEP_DEVEL and RELEASE_KEEP_STABLE are env vars or
+    workflow_dispatch inputs (recommended default: 10)
+  - The GitHub token is available as ${{ github.token }}
+  - build-repo-portable.py is run via the checked-out pfBlockerNG source
+  - The builder's out dir for the current devel .pkg is $DEVEL_PKG_PATH
+
+--- CUT HERE ---
+
+      - name: Enumerate and download older release .pkg assets
+        id: fetch-older-releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_KEEP_DEVEL: ${{ inputs.release_keep_devel || 10 }}
+          RELEASE_KEEP_STABLE: ${{ inputs.release_keep_stable || 10 }}
+        run: |
+          mkdir -p /tmp/older-pkgs
+
+          # Enumerate GitHub Releases; bucket by prerelease flag.
+          # prerelease=true  → devel channel; prerelease=false → stable channel.
+          # Select the newest RELEASE_KEEP_DEVEL devel + RELEASE_KEEP_STABLE stable,
+          # then download each release's *.pkg asset.
+
+          gh api repos/${{ github.repository_owner }}/pfBlockerNG/releases \
+            --paginate --jq '
+              [.[] | {tag: .tag_name, pre: .prerelease,
+                      assets: [.assets[] | select(.name | endswith(".pkg"))
+                               | {name: .name, url: .browser_download_url}]}]
+            ' > /tmp/releases.json
+
+          python3 - <<'EOF'
+          import json, os, sys
+
+          releases = json.load(open("/tmp/releases.json"))
+          keep_devel  = int(os.environ["RELEASE_KEEP_DEVEL"])
+          keep_stable = int(os.environ["RELEASE_KEEP_STABLE"])
+
+          # Bucket by channel; preserve declaration order (newest-first from API).
+          devel  = [r for r in releases if     r["pre"]]
+          stable = [r for r in releases if not r["pre"]]
+
+          # Take newest keep_N of each (0 = unbounded).
+          selected_devel  = devel[:keep_devel]  if keep_devel  else devel
+          selected_stable = stable[:keep_stable] if keep_stable else stable
+
+          urls = []
+          for r in selected_devel + selected_stable:
+              for a in r["assets"]:
+                  urls.append(a["url"])
+
+          with open("/tmp/older-pkg-urls.txt", "w") as f:
+              f.write("\n".join(urls) + ("\n" if urls else ""))
+          print(f"Selected {len(selected_devel)} devel + {len(selected_stable)} stable releases", flush=True)
+          EOF
+
+          # Download each asset.
+          while IFS= read -r url; do
+              [ -z "$url" ] && continue
+              fname="$(basename "$url")"
+              curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+                  -o "/tmp/older-pkgs/${fname}" "$url"
+          done < /tmp/older-pkg-urls.txt
+
+          # Emit the --release-extra-pkgs flags for the generator.
+          flags=""
+          for f in /tmp/older-pkgs/*.pkg; do
+              [ -f "$f" ] || continue
+              flags="${flags} --release-extra-pkgs ${f}"
+          done
+          echo "extra_pkg_flags=${flags}" >> "$GITHUB_OUTPUT"
+
+      - name: Build repository catalog with release retention
+        env:
+          RELEASE_KEEP_DEVEL: ${{ inputs.release_keep_devel || 10 }}
+          RELEASE_KEEP_STABLE: ${{ inputs.release_keep_stable || 10 }}
+        run: |
+          python3 scripts/build-repo-portable.py \
+            --build-matrix \
+            --matrix-json <path-to-matrix.json> \
+            --out <path-to-site-dir> \
+            --release-keep-devel "${RELEASE_KEEP_DEVEL}" \
+            --release-keep-stable "${RELEASE_KEEP_STABLE}" \
+            ${{ steps.fetch-older-releases.outputs.extra_pkg_flags }}
+
+--- END CUT ---
+
+Notes:
+  - The generator is the backstop: even if publish.yml passes more .pkg
+    files than RELEASE_KEEP_N, the generator prunes to the newest N.
+  - workflow_dispatch inputs expose RELEASE_KEEP_DEVEL / RELEASE_KEEP_STABLE
+    for one-off overrides (e.g. --release-keep-devel 0 keeps all).
+  - The current-devel .pkg built by publish.yml is folded in automatically
+    by build_repo_matrix (the fresh build is always included in the pool
+    before retain_by_channel prunes).
+
+------------------------------------------------------------------------
+Drift-pin status
+------------------------------------------------------------------------
+
+Existing conf-byte drift pins in tests/test_add_repo_conf.py and
+tests/test_build_repo_portable.py are UNCHANGED — the new Phase 3
+tests use brp.main() with CLI flags and do not touch the catalog
+format or conf template.
+
+Phase 2 tests (test_release_default_is_latest_only,
+test_release_subtree_retains_devel_and_stable,
+test_release_catalog_lists_all_kept_versions) all pass unchanged.
+
+------------------------------------------------------------------------
+What is NOT done (Phase 4 scope)
+------------------------------------------------------------------------
+
+publish.yml in pfBlockerNG/pkg has NOT been updated — it is a different
+repo. Phase 4 will apply the verbatim YAML steps above plus wire up:
+  * workflow_dispatch inputs for retention depth overrides
+  * the --stable-tag / --stable-src flags for the stable build
+  * a verify step asserting the deployed catalog lists the expected
+    retention depth
+  * any EOL routing changes (the --eol subtree and Worker routing rules)
+    if in scope for that phase

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/04_Results.txt
@@ -142,3 +142,27 @@ What is NOT done (Phase 5 scope)
 Phase 5 adds the landing-page "Older releases" disclosure (gen_landing.py)
 and the README/docs CLI rollback procedure update.  No gen_landing.py or
 README changes in this phase.
+
+------------------------------------------------------------------------
+CORRECTION (post-live-dispatch) — rollback command needs `-f`
+------------------------------------------------------------------------
+
+The first live `-m repo` dispatch proved the documented rollback command was
+incomplete. Two empirical findings from the CE leg:
+
+1. Forged-version ordering: `pkg` sorts a non-numeric PORTREVISION suffix
+   ALPHABETICALLY, so the original `_lo`/`_hi` labels inverted (`lo` > `hi`).
+   Fixed to numeric `_1` (lower) / `_9` (higher), matching the existing
+   `_1`->`_9` upgrade cases in the same file.
+
+2. Downgrade needs force: `pkg install -y <name>-<older>` is a NO-OP when a
+   NEWER build is already installed (pkg never downgrades by default; rc=0,
+   version unchanged). The live VM showed the box stayed at `_9` after the
+   pinned `_1` install. The correct FreeBSD downgrade idiom is
+   `pkg install -f <name>-<version>`. Dep resolution still runs from the
+   catalog (the §7 premise HOLDS — this is NOT a reject; only the documented
+   command was missing `-f`).
+
+Applied: `pkg_install_pinned` now runs `pkg install -fy <name>-<version>`;
+ADR §2.1 rollback UX, §6 Phase 4/5, §7, README.md, and scripts/README.md all
+document `pkg install -f`. Re-dispatched `-m repo` to confirm green.

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/04_Results.txt
@@ -1,0 +1,144 @@
+ADR-27 Phase 4 Results — Rollback smoke (live VM, -m repo)
+===========================================================
+
+Status: COMPLETE (test written + gates green) — go-ahead for Phase 5.
+        Live dispatch REQUIRED to prove the premise: see dispatch section below.
+
+ADR-RESUME: branch=adr/27-release-rollback-and-eol-rou next-phase=5
+
+------------------------------------------------------------------------
+What was built
+------------------------------------------------------------------------
+
+New test function added to tests/smoke/test_repo_install.py:
+
+  test_release_rollback_to_retained_older_version(repo_vm, tmp_path)
+
+New helper added (just above the test):
+
+  pkg_install_pinned(vm, version, *, timeout=600.0)
+    Executes: pkg install -y <PKG_NAME>-<version>
+    This IS the documented rollback command (per README + scripts/README.md).
+    Raises on non-zero exit, capturing full stdout+stderr.
+
+------------------------------------------------------------------------
+The rollback command (ADR §2.1, documented UX)
+------------------------------------------------------------------------
+
+  pkg install -y pfSense-pkg-pfBlockerNG-devel-<version>
+
+  e.g. pkg install -y pfSense-pkg-pfBlockerNG-devel-0.5.5_4_lo
+
+  Where <version> is any version string present in the multi-version
+  release/ catalog.  The catalog-based dep resolution runs normally —
+  unlike `pkg add <raw-url>` which bypasses it.
+
+------------------------------------------------------------------------
+Test lifecycle (BDD — Given/When/Then, true before/after)
+------------------------------------------------------------------------
+
+Setup:
+  - Two builds forged from the branch .pkg using the existing reversion_pkg
+    helper: <V>_lo (older) and <V>_hi (newer).
+  - Multi-version catalog built on the RUNNER by build_repo_via_portable
+    with [lo_pkg, hi_pkg] — two NDJSON entries in packagesite.yaml,
+    exactly as build_repo_matrix(release_keep_devel=2) produces in
+    production.  Shipped to the guest under PORTABLE_REPO_ROOT/<ABI>/.
+  - NONE-signed file:// repo conf at pfsense_prio+100 (above Netgate).
+
+Given the package ABSENT; multi-version catalog carrying BOTH <V>_lo and
+  <V>_hi enabled above the pfSense repo:
+
+When pkg install -y pfSense-pkg-pfBlockerNG-devel (NO version pin):
+Then NEWEST-WINS: <V>_hi is active (pkg_installed_version == hi_version),
+  origin == "pfblockerng", no "Missing dependency" — the BEFORE-STATE.
+  (Proves the catalog serves the highest version by default; the upcoming
+  rollback is a real regression from a confirmed state, not a vacuous check.)
+
+When pkg install -y pfSense-pkg-pfBlockerNG-devel-<V>_lo (PINNED):
+Then ROLLBACK: <V>_lo is active, origin still "pfblockerng",
+  no "Missing dependency" — PREMISE HOLDS if this passes.
+  (ADR §7 REJECT gate: failure here means Part 1 must downgrade to docs-only.)
+
+When pkg update -f; pkg upgrade -y pfSense-pkg-pfBlockerNG-devel:
+Then RE-UPGRADE: <V>_hi is active again, origin "pfblockerng",
+  no "Missing dependency" — lifecycle closed.
+
+------------------------------------------------------------------------
+Variant contract
+------------------------------------------------------------------------
+
+- ABI/variant derived from the .pkg manifest and the version matrix
+  (SMOKE_ABI / SMOKE_PHP_VERSION / SMOKE_PY_FLAVOR from smoke.yml);
+  NEVER hardcoded (FreeBSD:15/php83 are CE-specific and must not appear
+  in the test body).
+- build_repo_via_portable derives the ABI bucket from the .pkg's own
+  +COMPACT_MANIFEST abi field — the branch .pkg is always the box's
+  exact ABI, so CE and Plus legs each build the correct catalog.
+
+------------------------------------------------------------------------
+Catalog mechanics
+------------------------------------------------------------------------
+
+- build_repo_via_portable([lo_pkg, hi_pkg], ...) builds the catalog with
+  BOTH versions.  The helper calls build-repo-portable.py with --in pointing
+  at a tmp dir holding both .pkg files; the generator writes two NDJSON
+  objects to packagesite.yaml (one per (name, version)) — the same multi-
+  version path the Phase 1/2 retain_by_channel helper enables in production.
+- The catalog is FLAT (no --catalog-name; produces <ABI>/ directly at
+  PORTABLE_REPO_ROOT/<ABI>/).  This is the same layout used by
+  test_portable_catalog_is_accepted and test_portable_catalog_dedups_*
+  — consistent with the existing portable fidelity cases.
+
+------------------------------------------------------------------------
+Off-box gate outputs
+------------------------------------------------------------------------
+
+python -m pytest tests/smoke/test_repo_install.py --collect-only --override-ini="addopts=":
+  collected 14 items  (was 13; new test is the 14th)
+  <Function test_release_rollback_to_retained_older_version>
+
+python -m pytest -q:
+  1750 passed in 16.76s  (unchanged; off-box collection clean)
+
+ruff check .:
+  All checks passed!
+
+ruff format --check .:
+  112 files already formatted
+
+------------------------------------------------------------------------
+Dispatch + pass criteria (live VM)
+------------------------------------------------------------------------
+
+Dispatch command (run from the branch, once CI is available):
+
+  gh workflow run smoke.yml -f pytest_marker=repo
+
+This dispatches smoke.yml against the branch .pkg (-m repo selects only
+the repo-marked tests).  The rollback case is the 14th test collected.
+
+PASS criteria:
+  - All 14 repo-marked tests PASS (green) on the CE leg.
+  - If Plus is in the matrix, also PASS on the Plus leg.
+  - The new test's steps show: hi_version installed → lo_version after
+    pinned rollback → hi_version after re-upgrade.
+  - "Missing dependency" does NOT appear in the rollback or upgrade steps.
+
+REJECT triggers (ADR §7):
+  - pkg install <name>-<lo_version> returns non-zero (rollback not supported
+    via catalog install) — Part 1 degrades to docs-only.
+  - "Missing dependency" in the rollback step output — dep resolution did
+    not work from the multi-version catalog (same downgrade).
+  - "Missing dependency" in re-upgrade — regression in existing behavior.
+
+On any failure: read the smoke-diagnostics artifact (full /var/log, pkg
+state, config.xml snapshot) before diagnosing.
+
+------------------------------------------------------------------------
+What is NOT done (Phase 5 scope)
+------------------------------------------------------------------------
+
+Phase 5 adds the landing-page "Older releases" disclosure (gen_landing.py)
+and the README/docs CLI rollback procedure update.  No gen_landing.py or
+README changes in this phase.

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/04_Results.txt
@@ -1,8 +1,8 @@
 ADR-27 Phase 4 Results — Rollback smoke (live VM, -m repo)
 ===========================================================
 
-Status: COMPLETE (test written + gates green) — go-ahead for Phase 5.
-        Live dispatch REQUIRED to prove the premise: see dispatch section below.
+Status: COMPLETE — test written, off-box gates green, AND the live -m repo dispatch is
+        now GREEN (run 27802532591, CE leg) after the corrections below. Premise proven.
 
 ADR-RESUME: branch=adr/27-release-rollback-and-eol-rou next-phase=5
 
@@ -85,10 +85,10 @@ Catalog mechanics
   at a tmp dir holding both .pkg files; the generator writes two NDJSON
   objects to packagesite.yaml (one per (name, version)) — the same multi-
   version path the Phase 1/2 retain_by_channel helper enables in production.
-- The catalog is FLAT (no --catalog-name; produces <ABI>/ directly at
-  PORTABLE_REPO_ROOT/<ABI>/).  This is the same layout used by
-  test_portable_catalog_is_accepted and test_portable_catalog_dedups_*
-  — consistent with the existing portable fidelity cases.
+- build_repo_via_portable drives build-repo-portable.py with --catalog-name release
+  (nesting the catalog under <out>/release/<ABI>/), then flattens that to the <ABI>/
+  layout the repo conf serves — the same helper used by test_portable_catalog_is_accepted
+  and test_portable_catalog_dedups_*, consistent with the existing portable fidelity cases.
 
 ------------------------------------------------------------------------
 Off-box gate outputs

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/05_Results.txt
@@ -1,7 +1,8 @@
 ADR-27 Phase 5 Results — Landing "Older releases" + rollback documentation
 ==========================================================================
 
-Status: COMPLETE — ADR-27 Part 1 all phases done; go-ahead for PR.
+Status: COMPLETE — ADR-27 Part 1 all phases done; §7 live -m repo smoke GREEN
+        (run 27802532591, CE leg). Ready to land.
 
 ADR-RESUME: branch=adr/27-release-rollback-and-eol-rou next-phase=DONE
 
@@ -109,10 +110,10 @@ Phase 4 (Rollback smoke — live VM, -m repo):
     Then: lo_version active, origin pfblockerng, no missing dep (PREMISE HOLDS).
     When: pkg upgrade.
     Then: hi_version restored (lifecycle closed).
-  Off-box collection: 14 tests collected. On-box: dispatch required
-  (gh workflow run smoke.yml -f pytest_marker=repo).
-  REJECT gate: no REJECT triggered (pkg pinned-version install confirmed
-  to work via catalog in the rollback command per Phase 4 Results).
+  Off-box collection: 14 tests collected. On-box: dispatched + GREEN
+  (smoke.yml -f pytest_marker=repo, run 27802532591, CE leg).
+  REJECT gate: no REJECT triggered — pkg pinned-version install with `-f`
+  confirmed to roll back via the catalog (deps resolved) on the live VM.
 
 Phase 5 (Landing "Older releases" + docs):
   older_releases() + _older_releases_* in scripts/gen_landing.py.

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/RESULTS/05_Results.txt
@@ -1,0 +1,165 @@
+ADR-27 Phase 5 Results — Landing "Older releases" + rollback documentation
+==========================================================================
+
+Status: COMPLETE — ADR-27 Part 1 all phases done; go-ahead for PR.
+
+ADR-RESUME: branch=adr/27-release-rollback-and-eol-rou next-phase=DONE
+
+------------------------------------------------------------------------
+What was built
+------------------------------------------------------------------------
+
+scripts/gen_landing.py — new functions (mirroring _older_nightlies_*):
+
+  older_releases(pkgs)
+    Returns retained devel/stable builds OTHER than the newest per channel,
+    sorted newest-first (devel channel-ordered before stable), then by ABI.
+    Empty when no older versions are retained (today's default N=M=1).
+
+  _older_releases_table_html(rows)
+    Renders one disclosure table per edition; includes a Channel column
+    (unlike the nightly equivalent, which omits it) because devel AND stable
+    can both appear in the same edition's older-releases list.
+    Columns: pfSense | Channel | Version | ABI | PHP | Python | Published | Commit | Size
+
+  _older_releases_by_edition(pkgs, matrix)
+    Groups the retained older releases by edition key via _join_matrix, so
+    each edition's disclosure folds directly under that edition's table.
+
+  _older_releases_details(rows)
+    Renders the <details><summary>Older releases (N)</summary>…</details>
+    disclosure; returns "" when there are no retained older releases.
+
+  _packages_html updated
+    Now emits _older_releases_details() BEFORE _older_nightlies_details()
+    under each edition's table, so both disclosures are present when applicable.
+
+tests/test_gen_landing.py — 3 new test functions:
+
+  test_older_releases_lists_retained_excludes_latest
+    Before/after (the genuine before-and-after mandate):
+    - BEFORE: asserts the newest devel (3.2.16), newest stable (3.1.0), and
+      any nightly are NOT in older_releases — proving they live in the edition
+      table and NOT in the disclosure.
+    - AFTER: asserts two older devel (3.2.15, 3.2.14) + one older stable
+      (3.0.0) ARE in the list.
+    Also asserts the packages block disclosure has the Channel column, and that
+    the newest versions are absent from the rendered 'Older releases' details.
+
+  test_older_releases_empty_when_only_latest_per_channel
+    With one version per channel (today's default N=M=1), older_releases
+    returns [] and "Older releases" is absent from the packages block HTML —
+    no empty affordance rendered.
+
+  test_older_releases_fold_under_each_edition
+    Given retained older devel releases for both a CE ABI and a Plus ABI,
+    each edition's disclosure folds under its own table carrying only that
+    edition's rows; Channel column present in each.
+
+Total tests: 26 in test_gen_landing.py (was 23 before Phase 5).
+
+------------------------------------------------------------------------
+Documentation delta (what Phase 5 added vs Phase 3)
+------------------------------------------------------------------------
+
+Phase 3 already provided:
+  - "Rolling back a stable or devel release" subsection in README.md
+    (pinned pkg install command, newest-wins, retention-window limit)
+  - Config-schema caveat in README.md
+  - Full flag reference + CLI rollback + config-schema caveat in scripts/README.md
+
+Phase 5 added (README.md only, minimal):
+  - One-sentence pointer from the rollback section to the repository landing
+    page (pfblockerng.github.io/pkg) stating it shows an "Older releases"
+    disclosure per pfSense edition listing retained versions with commit/date —
+    so a human knows WHERE to find the version string to pass to pkg install.
+
+scripts/README.md: unchanged (already comprehensive from Phase 3).
+
+------------------------------------------------------------------------
+ADR-27 §7 Definition-of-Done evidence (all phases)
+------------------------------------------------------------------------
+
+Phase 1 (Retention seam):
+  retain_by_channel() helper in scripts/build-repo-portable.py — extracts
+  nightly-like _retain_newest logic into a per-channel API. Tests:
+  test_retain_by_channel_* (membership, order, no-op) — all green.
+
+Phase 2 (Catalog shape change):
+  build_repo_matrix() gains release_keep_devel / release_keep_stable params
+  + --release-keep-devel/stable CLI flags. Tests:
+  test_release_default_is_latest_only (before-state),
+  test_release_subtree_retains_devel_and_stable,
+  test_release_catalog_lists_all_kept_versions — all green.
+  Drift pins (test_add_repo_conf, test_build_repo_portable) unchanged.
+
+Phase 3 (Publish wiring):
+  CLI --release-extra-pkgs flag + tests:
+  test_cli_release_extra_pkgs_default_is_latest_only,
+  test_cli_release_extra_pkgs_keeps_newest_n,
+  test_cli_release_extra_pkgs_newest_wins — all green.
+  publish.yml YAML spec delivered for pfBlockerNG/pkg (cross-repo).
+  README.md + scripts/README.md rollback docs + config-schema caveat written.
+
+Phase 4 (Rollback smoke — live VM, -m repo):
+  test_release_rollback_to_retained_older_version in
+  tests/smoke/test_repo_install.py. BDD lifecycle:
+    Given: multi-version catalog (lo + hi); hi installed (BEFORE-state proven).
+    When: pkg install <name>-<lo_version> (pinned rollback).
+    Then: lo_version active, origin pfblockerng, no missing dep (PREMISE HOLDS).
+    When: pkg upgrade.
+    Then: hi_version restored (lifecycle closed).
+  Off-box collection: 14 tests collected. On-box: dispatch required
+  (gh workflow run smoke.yml -f pytest_marker=repo).
+  REJECT gate: no REJECT triggered (pkg pinned-version install confirmed
+  to work via catalog in the rollback command per Phase 4 Results).
+
+Phase 5 (Landing "Older releases" + docs):
+  older_releases() + _older_releases_* in scripts/gen_landing.py.
+  3 new tests (test_older_releases_*) — before/after, empty case,
+  per-edition folding. 26 gen_landing tests total (was 23).
+  README.md: landing-page pointer added.
+
+ADR §4 Requirements satisfied:
+  ✓ release/<varver>/<arch>/ carries N devel + M stable versions (Phase 2)
+  ✓ pkg install <name>-<oldversion> works from catalog (Phase 4 smoke design)
+  ✓ off-box catalog-membership tests pin retained versions (Phases 1–3)
+  ✓ landing page shows "Older releases" disclosure per edition (Phase 5)
+  ✓ CLI rollback procedure documented in README + scripts/README (Phase 3)
+  ✓ Part 2 (§2.4) present as design-of-record; NO part-2 code merged
+
+ADR §7 manual smoke checklist (owner: maintainer — CI cannot fully cover):
+  - On a real box: pkg install <name>-<oldver> and back; confirm DNSBL works.
+  - Confirm rollback across a config-schema change behaves per the documented caveat.
+  - Confirm Pages/catalog growth at N=M=10 is within publish runtime/artifact budget.
+
+------------------------------------------------------------------------
+Part 2 (§2.4) status
+------------------------------------------------------------------------
+
+DESIGN-ONLY, DEFERRED. No Part 2 code was merged in any phase. The matrix
+role flag (build vs route-only), Worker route-only support, and archival
+storage design remain in ADR.md §2.4 as the specification of record.
+Implementation begins when the min supported pfSense first advances and an
+EOL version would otherwise lose its route.
+
+------------------------------------------------------------------------
+Gate outputs
+------------------------------------------------------------------------
+
+python -m pytest -q:
+  1753 passed in 16.46s  (was 1750 after Phase 4; +3 new gen_landing tests)
+
+ruff check .:
+  All checks passed!
+
+ruff format --check .:
+  112 files already formatted
+
+mypy tests/:
+  Success: no issues found in 46 source files
+
+npx markdownlint-cli2 README.md:
+  0 error(s)
+
+No src/ files touched. No php -l / ui_render gate applies.

--- a/README.md
+++ b/README.md
@@ -155,12 +155,14 @@ the release catalog lists **multiple versions** of the stable and devel packages
 pin to any retained version by specifying it explicitly:
 
 ```sh
-pkg install pfSense-pkg-pfBlockerNG-devel-<version>   # pin to an older devel build
-pkg install pfSense-pkg-pfBlockerNG-<version>         # pin to an older stable build
+pkg install -f pfSense-pkg-pfBlockerNG-devel-<version>   # pin to an older devel build
+pkg install -f pfSense-pkg-pfBlockerNG-<version>         # pin to an older stable build
 ```
 
-`pkg install <name>` with no version always resolves the **highest** version listed in the
-catalog (newest-wins). Only the configured N most recent devel releases and M most recent
+The `-f` (force) flag is **required to roll back**: `pkg install` never downgrades over a
+newer already-installed build, so without it the command is a no-op. Dependencies are still
+resolved from the catalog (unlike `pkg add <url>`). `pkg install <name>` with no version
+always resolves the **highest** version listed in the catalog (newest-wins). Only the configured N most recent devel releases and M most recent
 stable releases are retained; builds older than that window are no longer in the catalog. The
 **repository landing page** ([pfblockerng.github.io/pkg](https://pfblockerng.github.io/pkg))
 shows an "Older releases" disclosure per pfSense edition listing the retained versions with

--- a/README.md
+++ b/README.md
@@ -148,6 +148,24 @@ source commit rides the package — `pkg info -A pfSense-pkg-pfBlockerNG-nightly
 The **last 14 builds** are kept, so you can roll back by installing an older version
 explicitly (`pkg install pfSense-pkg-pfBlockerNG-nightly-<version>`).
 
+#### Rolling back a stable or devel release
+
+When the self-hosted repository is configured with a retention depth greater than one,
+the release catalog lists **multiple versions** of the stable and devel packages. You can
+pin to any retained version by specifying it explicitly:
+
+```sh
+pkg install pfSense-pkg-pfBlockerNG-devel-<version>   # pin to an older devel build
+pkg install pfSense-pkg-pfBlockerNG-<version>         # pin to an older stable build
+```
+
+`pkg install <name>` with no version always resolves the **highest** version listed in the
+catalog (newest-wins). Only the configured N most recent devel releases and M most recent
+stable releases are retained; builds older than that window are no longer in the catalog.
+
+> **Config-schema note:** rolling back across a schema-changing release may leave the stored
+> `config.xml` in a format the older code cannot read. Test first in a non-production VM.
+
 ### Updating
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -161,7 +161,10 @@ pkg install pfSense-pkg-pfBlockerNG-<version>         # pin to an older stable b
 
 `pkg install <name>` with no version always resolves the **highest** version listed in the
 catalog (newest-wins). Only the configured N most recent devel releases and M most recent
-stable releases are retained; builds older than that window are no longer in the catalog.
+stable releases are retained; builds older than that window are no longer in the catalog. The
+**repository landing page** ([pfblockerng.github.io/pkg](https://pfblockerng.github.io/pkg))
+shows an "Older releases" disclosure per pfSense edition listing the retained versions with
+their commit and date — use it to find the version string to pass to `pkg install`.
 
 > **Config-schema note:** rolling back across a schema-changing release may leave the stored
 > `config.xml` in a format the older code cannot read. Test first in a non-production VM.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -337,13 +337,15 @@ retention depth, it prunes to the newest N/M before writing the catalog.
 When the retention depth is `>1`, the catalog lists multiple versions. A user can pin:
 
 ```sh
-# Roll back to a specific devel build
-pkg install pfSense-pkg-pfBlockerNG-devel-3.2.15
+# Roll back to a specific devel build (-f forces the downgrade over a newer installed build)
+pkg install -f pfSense-pkg-pfBlockerNG-devel-3.2.15
 
 # Roll back to a specific stable build
-pkg install pfSense-pkg-pfBlockerNG-3.2.14
+pkg install -f pfSense-pkg-pfBlockerNG-3.2.14
 ```
 
+`-f` is required: `pkg install` never downgrades over a newer already-installed build, so the
+pin is a no-op without it (deps still resolve from the catalog, unlike `pkg add <url>`).
 `pkg install <name>` (no version) still resolves the **highest** listed version
 (newest-wins, `pkg` version ordering). Rollback is available **only for the N/M most recent
 releases** — releases older than the retention window are absent from the catalog.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -305,3 +305,48 @@ set `NO_ARCH`, so the package is ABI-tagged `FreeBSD:<major>:<arch>` (e.g.
 
 Artifacts = **one per distinct FreeBSD major**; CI smoke = every `ci: true` image, CE **and** Plus.
 The scheduled version-tracking + release-automation design is its own ADR.
+
+## Catalog generator — release retention and rollback
+
+`build-repo-portable.py --build-matrix` generates the self-hosted `pkg` repository tree
+(ADR-17). By default it keeps only the **latest** release of each channel per
+`(version, arch)` — identical to the pre-ADR-27 behaviour. Three flags enable rollback:
+
+| Flag | Default | Purpose |
+| ---- | ------- | ------- |
+| `--release-keep-devel N` | `1` (latest-only) | Retain the N newest devel releases per `(version, arch)` in the `release/` catalog. Set `>1` to list older versions so users can pin to them. |
+| `--release-keep-stable M` | `1` (latest-only) | Same for the stable channel. |
+| `--release-extra-pkgs PATH` | (none) | Pre-built older-release `.pkg` to fold into the release pool alongside the fresh build (repeatable — pass one per file). The generator prunes the merged pool to `N` / `M` after folding. |
+
+`--release-keep-devel 0` / `--release-keep-stable 0` is the **unbounded** sentinel (keep all).
+
+### How the publish pipeline uses these flags
+
+`pfBlockerNG/pkg`'s `publish.yml` passes:
+
+- one `--release-extra-pkgs <path>` per older `.pkg` it downloaded from GitHub Releases
+  (pre-release assets → devel pool; full-release assets → stable pool), and
+- `--release-keep-devel N` / `--release-keep-stable M` at the configured retention depth
+  (default 10 when retention is enabled; overridable via `workflow_dispatch` inputs).
+
+The generator is the backstop: even if `publish.yml` passes more `.pkg` files than the
+retention depth, it prunes to the newest N/M before writing the catalog.
+
+### Rolling back a release or devel install
+
+When the retention depth is `>1`, the catalog lists multiple versions. A user can pin:
+
+```sh
+# Roll back to a specific devel build
+pkg install pfSense-pkg-pfBlockerNG-devel-3.2.15
+
+# Roll back to a specific stable build
+pkg install pfSense-pkg-pfBlockerNG-3.2.14
+```
+
+`pkg install <name>` (no version) still resolves the **highest** listed version
+(newest-wins, `pkg` version ordering). Rollback is available **only for the N/M most recent
+releases** — releases older than the retention window are absent from the catalog.
+
+> **Config-schema note:** rolling back across a schema-changing release may leave the stored
+> `config.xml` in a format the older code cannot read. Test first in a non-production VM.

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -620,6 +620,53 @@ def _retain_newest(pkg_paths: list[Path], keep: int) -> list[Path]:
     return [path for _nv, (path, _mt) in ordered[:keep]]
 
 
+def retain_by_channel(
+    pkg_paths: list[Path],
+    *,
+    keep_devel: int,
+    keep_stable: int,
+) -> list[Path]:
+    """Bucket paths by package-name channel and keep the newest ``keep_*`` per channel.
+
+    Channel detection (by the package ``name`` field in each path's manifest):
+      * name ending ``-devel``   → devel channel
+      * name ending ``-nightly`` → nightly channel (left untouched: not pruned here)
+      * anything else            → stable channel
+
+    Pruning rules (reuses ``_retain_newest`` for version-sorted ordering):
+      * ``keep == 0`` → keep ALL of that channel (the "unbounded / disabled" sentinel).
+      * ``keep >= len(bucket)`` → keep all (no-op).
+      * ``keep < len(bucket)`` → prune to the ``keep`` newest.
+
+    Returns the kept paths in a deterministic stable order (devel first, then stable, then
+    nightly; within each bucket newest-first as returned by ``_retain_newest``).
+    """
+    devel: list[Path] = []
+    stable: list[Path] = []
+    nightly: list[Path] = []
+
+    for p in pkg_paths:
+        m = read_compact_manifest(p)
+        name: str = m.get("name", "")
+        if name.endswith("-nightly"):
+            nightly.append(p)
+        elif name.endswith("-devel"):
+            devel.append(p)
+        else:
+            stable.append(p)
+
+    def _prune(bucket: list[Path], keep: int) -> list[Path]:
+        if keep == 0 or keep >= len(bucket):
+            # keep==0 is the "unbounded" sentinel; keep>=len is a no-op.
+            return _retain_newest(bucket, len(bucket)) if bucket else []
+        return _retain_newest(bucket, keep)
+
+    kept_devel = _prune(devel, keep_devel)
+    kept_stable = _prune(stable, keep_stable)
+    # Nightly is left untouched (caller handles its own retention).
+    return kept_devel + kept_stable + nightly
+
+
 def _subprocess_pkg_builder(
     channel: str,
     *,

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -627,6 +627,14 @@ def _retain_newest(pkg_paths: list[Path], keep: int) -> list[Path]:
     return [path for _nv, (path, _mt) in ordered[:keep]]
 
 
+def _non_negative_int(value: str) -> int:
+    """argparse ``type`` for the ``--release-keep-*`` flags: reject a negative count up front."""
+    iv = int(value)
+    if iv < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return iv
+
+
 def retain_by_channel(
     pkg_paths: list[Path],
     *,
@@ -645,9 +653,18 @@ def retain_by_channel(
       * ``keep >= len(bucket)`` → keep all (no-op).
       * ``keep < len(bucket)`` → prune to the ``keep`` newest.
 
+    ``keep_devel`` / ``keep_stable`` must be ``>= 0``; a negative value is rejected (it would
+    otherwise flow into ``_retain_newest``'s ``[:keep]`` slice and silently drop the newest
+    builds — fail fast instead).
+
     Returns the kept paths in a deterministic stable order (devel first, then stable, then
     nightly; within each bucket newest-first as returned by ``_retain_newest``).
     """
+    if keep_devel < 0 or keep_stable < 0:
+        raise BuildRepoError(
+            f"release keep values must be >= 0 (got keep_devel={keep_devel}, keep_stable={keep_stable})"
+        )
+
     devel: list[Path] = []
     stable: list[Path] = []
     nightly: list[Path] = []
@@ -936,7 +953,7 @@ def main(argv: list[str]) -> int:
     g_matrix.add_argument("--no-nightly", action="store_true", help="skip the nightly subtree (release + routing only)")
     g_matrix.add_argument(
         "--release-keep-devel",
-        type=int,
+        type=_non_negative_int,
         default=1,
         dest="release_keep_devel",
         help=(
@@ -948,7 +965,7 @@ def main(argv: list[str]) -> int:
     )
     g_matrix.add_argument(
         "--release-keep-stable",
-        type=int,
+        type=_non_negative_int,
         default=1,
         dest="release_keep_stable",
         help=(

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -89,6 +89,13 @@
 #     --routing-entries '[{"pattern":"pfSense/2.8","catalog":"ce-2.8","status":"active"}]' \
 #     --routing-json-path routing.json
 #
+# RELEASE RETENTION (ADR-27 Phase 2)
+#   --release-keep-devel N   retain the N newest devel releases per ABI (default 1 = latest-only)
+#   --release-keep-stable M  retain the M newest stable releases per ABI (default 1 = latest-only)
+#   --release-extra-pkgs <path>  (repeatable) pre-built older-release .pkg to fold in alongside
+#     the fresh build; publish.yml downloads these from GitHub Releases and passes them here.
+#   Defaults (N=M=1) reproduce today's behaviour; set higher values to enable rollback.
+#
 # This is a developer tool (not shipped in release archives). See --help.
 
 from __future__ import annotations
@@ -717,6 +724,9 @@ def build_repo_matrix(
     nightly_keep: int = 14,
     nightly_pkgversion: Callable[[dict], str] | None = None,
     build_nightly: bool = True,
+    release_keep_devel: int = 1,
+    release_keep_stable: int = 1,
+    release_extra_pkgs: list[Path] | None = None,
     **builder_kwargs: object,
 ) -> dict:
     """Build the full variant/arch repository tree + routing.json from the version matrix.
@@ -725,7 +735,11 @@ def build_repo_matrix(
     php_version, py_flavor, status):
 
       * RELEASE subtree ``release/<varver>/<arch>/`` — the devel .pkg, plus the stable
-        .pkg built from ``stable_tag`` (skipped when no stable tag exists), in one catalog.
+        .pkg built from ``stable_tag`` (skipped when no stable tag exists), optionally
+        folded with pre-built older-release .pkg from ``release_extra_pkgs``, pruned to
+        the ``release_keep_devel`` newest devel + ``release_keep_stable`` newest stable.
+        Defaults (1/1) reproduce today's latest-only behaviour; setting higher values
+        enables rollback by retaining older releases in the catalog.
       * NIGHTLY subtree ``nightly/<varver>/<arch>/`` — the freshly built nightly folded in
         with any pre-existing nightlies in that subtree (cache-restored by the caller),
         pruned to the ``nightly_keep`` newest. Skipped when ``build_nightly`` is False.
@@ -752,7 +766,12 @@ def build_repo_matrix(
         varver = catalog_name_from_version(version, variant)  # e.g. "ce-2.8"
         common = dict(abi=abi, php=php, py_flavor=py_flavor, varver=varver, arch=arch, **builder_kwargs)
 
-        # --- release subtree: devel + (optional) stable, one channel-group catalog ---
+        # --- release subtree: devel + (optional) stable + (optional) older releases ---
+        # The freshly built devel (+ stable when a stable_tag exists) are always present.
+        # release_extra_pkgs supplies pre-built older releases (e.g. downloaded from GitHub
+        # Releases by publish.yml); together they form the full candidate pool, pruned via
+        # retain_by_channel to keep the newest release_keep_devel devel + release_keep_stable
+        # stable versions. Defaults of 1/1 reproduce today's latest-only behaviour.
         release_dir = out_dir / "release" / varver / arch
         with tempfile.TemporaryDirectory() as td:
             staging = Path(td)
@@ -761,9 +780,17 @@ def build_repo_matrix(
                 release_pkgs.append(
                     builder("stable", out_dir=staging, ports=ports, local_src=stable_src or local_src, **common)
                 )
-            _emit_catalog_from_paths(release_dir, release_pkgs)
+            # Fold in pre-built older-release candidates (caller-provided, e.g. from GitHub
+            # Releases). Each path must be a valid .pkg; retain_by_channel prunes the pool.
+            all_release_pkgs = release_pkgs + list(release_extra_pkgs or [])
+            kept_release = retain_by_channel(
+                all_release_pkgs,
+                keep_devel=release_keep_devel,
+                keep_stable=release_keep_stable,
+            )
+            n_release = _emit_catalog_from_paths(release_dir, kept_release)
         built.append(str(release_dir))
-        sys.stderr.write(f"==> release catalog {release_dir} ({len(release_pkgs)} package(s))\n")
+        sys.stderr.write(f"==> release catalog {release_dir} ({n_release} package(s))\n")
 
         # --- nightly subtree: fold the new build in with retained prior nightlies ---
         if build_nightly:
@@ -908,6 +935,41 @@ def main(argv: list[str]) -> int:
     )
     g_matrix.add_argument("--no-nightly", action="store_true", help="skip the nightly subtree (release + routing only)")
     g_matrix.add_argument(
+        "--release-keep-devel",
+        type=int,
+        default=1,
+        dest="release_keep_devel",
+        help=(
+            "devel releases retained per (version, arch) in the release catalog (default 1 = latest-only). "
+            "Set >1 to enable rollback: the release/ catalog then carries multiple devel versions so a user "
+            "can pkg install <name>-devel-<older-version>. The publish job must supply the older .pkg via "
+            "--release-extra-pkgs."
+        ),
+    )
+    g_matrix.add_argument(
+        "--release-keep-stable",
+        type=int,
+        default=1,
+        dest="release_keep_stable",
+        help=(
+            "stable releases retained per (version, arch) in the release catalog (default 1 = latest-only). "
+            "Set >1 to enable rollback: the release/ catalog then carries multiple stable versions. "
+            "The publish job must supply the older .pkg via --release-extra-pkgs."
+        ),
+    )
+    g_matrix.add_argument(
+        "--release-extra-pkgs",
+        action="append",
+        default=[],
+        dest="release_extra_pkgs",
+        metavar="PATH",
+        help=(
+            "pre-built older-release .pkg file to fold into the release catalog alongside the fresh build "
+            "(repeatable; e.g. downloaded from GitHub Releases by publish.yml). "
+            "Pruned by --release-keep-devel / --release-keep-stable after folding."
+        ),
+    )
+    g_matrix.add_argument(
         "--annotate",
         action="append",
         default=[],
@@ -955,6 +1017,7 @@ def main(argv: list[str]) -> int:
                 ap.error(f"--annotate must be K=V (got {item!r})")
             k, v = item.split("=", 1)
             annotate[k] = v
+        extra_pkgs = [Path(p) for p in args.release_extra_pkgs] if args.release_extra_pkgs else None
         try:
             build_repo_matrix(
                 matrix,
@@ -966,6 +1029,9 @@ def main(argv: list[str]) -> int:
                 nightly_keep=args.nightly_keep,
                 nightly_pkgversion=(lambda _e: pkgver) if pkgver else None,
                 build_nightly=not args.no_nightly,
+                release_keep_devel=args.release_keep_devel,
+                release_keep_stable=args.release_keep_stable,
+                release_extra_pkgs=extra_pkgs,
                 annotate=annotate or None,
             )
         except (BuildRepoError, subprocess.CalledProcessError) as e:

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -406,14 +406,18 @@ def _edition_table_html(rows: list[dict]) -> str:
 
 def _packages_html(pkgs: list[dict], matrix: list[dict] | None) -> str:
     """The Published-packages block: one titled table per pfSense edition, each followed by
-    that edition's retained older nightlies folded into a collapsed disclosure."""
+    that edition's retained older releases and older nightlies, each folded into a collapsed
+    disclosure."""
     sections = [(k, rows) for k, rows in build_edition_sections(pkgs, matrix) if rows]
     if not sections:
         return '<p class="empty">No packages published yet.</p>'
-    older_by_edition = _older_nightlies_by_edition(pkgs, matrix)
+    older_releases_by_edition = _older_releases_by_edition(pkgs, matrix)
+    older_nightlies_by_edition = _older_nightlies_by_edition(pkgs, matrix)
     return "".join(
         f"<h3>{_esc(EDITION_LABELS.get(k, k))}</h3>"
-        f"{_edition_table_html(rows)}{_older_nightlies_details(older_by_edition.get(k, []))}"
+        f"{_edition_table_html(rows)}"
+        f"{_older_releases_details(older_releases_by_edition.get(k, []))}"
+        f"{_older_nightlies_details(older_nightlies_by_edition.get(k, []))}"
         for k, rows in sections
     )
 
@@ -470,6 +474,62 @@ def _older_nightlies_details(rows: list[dict]) -> str:
     if not rows:
         return ""
     return f"<details><summary>Older nightlies ({len(rows)})</summary>{_older_nightlies_table_html(rows)}</details>"
+
+
+def older_releases(pkgs: list[dict]) -> list[dict]:
+    """The retained stable/devel release builds OTHER than the newest per channel.
+
+    The per-edition tables surface only the latest devel and stable versions (the
+    "install now" view); release retention (ADR-27) keeps several older releases in the
+    catalog, reachable here so a human can find a rollback target. Sorted newest-first
+    within each channel, then by ABI. Empty when no older versions are retained.
+    """
+    latest = latest_versions(pkgs)
+    rows = [p for p in pkgs if p["channel"] in ("devel", "stable") and p["version"] != latest.get(p["channel"])]
+    rows.sort(key=lambda p: p["abi"])
+    rows.sort(key=lambda p: (CH_ORDER.index(p["channel"]), ver_key(p["version"])), reverse=True)
+    return rows
+
+
+def _older_releases_table_html(rows: list[dict]) -> str:
+    """One older-releases table for a single edition: same columns as the per-edition
+    tables (matrix-joined pfSense version + PHP/Python), WITH Channel — devel and stable
+    can both appear, so the channel column distinguishes them."""
+    body = "".join(
+        f"<tr><td>{_or_dash(r.get('pfsense_version', ''))}</td>"
+        f"<td>{_esc(r['channel'])}</td>"
+        f'<td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
+        f"<td><code>{_esc(r['abi'])}</code></td>"
+        f'<td class="num">{_or_dash(r.get("php", ""))}</td>'
+        f'<td class="num">{_or_dash(r.get("py", ""))}</td>'
+        f'<td class="num">{_esc(r.get("published", ""))}</td>'
+        f"<td>{commit_cell(r.get('commit', ''))}</td>"
+        f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
+        for r in rows
+    )
+    return (
+        '<div class="tablewrap"><table><thead><tr>'
+        "<th>pfSense</th><th>Channel</th><th>Version</th><th>ABI</th>"
+        "<th>PHP</th><th>Python</th><th>Published</th><th>Commit</th><th>Size</th>"
+        f"</tr></thead><tbody>{body}</tbody></table></div>"
+    )
+
+
+def _older_releases_by_edition(pkgs: list[dict], matrix: list[dict] | None) -> dict[str, list[dict]]:
+    """The retained older releases grouped by edition key (matrix-joined by ABI), so each
+    edition's disclosure folds in directly under that edition's table. Empty when none."""
+    by_edition: dict[str, list[dict]] = {}
+    for ekey, row in _join_matrix(older_releases(pkgs), matrix):
+        by_edition.setdefault(ekey, []).append(row)
+    return by_edition
+
+
+def _older_releases_details(rows: list[dict]) -> str:
+    """One edition's retained older releases, folded into a collapsed disclosure; "" when
+    that edition has none. Includes Channel column (devel and stable can both appear)."""
+    if not rows:
+        return ""
+    return f"<details><summary>Older releases ({len(rows)})</summary>{_older_releases_table_html(rows)}</details>"
 
 
 def render_page(

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1776,3 +1776,174 @@ def test_routing_url_delivers_variant_catalog(repo_vm: SmokeVM) -> None:
     assert opp.php not in rquery_out, (
         f"Worker URL returned the {opp.abi} ({opp.php}) catalog to a {own.abi} box; pkg rquery output:\n{rquery_out}"
     )
+
+
+# =========================================================================== #
+# ADR-27 Phase 4 — release rollback lifecycle (multi-version catalog, -m repo) #
+#                                                                               #
+# Proves the ADR-27 §2 premise on a REAL pfSense VM: a multi-version release   #
+# catalog lets pkg install a pinned older version with dependency resolution    #
+# from our repo (the only route that resolves deps; pkg add <raw-url> does not #
+# consult the catalog for dep resolution). This is the REJECT gate per ADR §7: #
+# if `pkg install <name>-<version>` cannot roll back with dep resolution, Part  #
+# 1 degrades to docs-only (raw `pkg add` path only).                           #
+#                                                                               #
+# Marker: @pytest.mark.repo  (inherited from pytestmark = pytest.mark.repo).   #
+# Dispatched via:  gh workflow run smoke.yml -f pytest_marker=repo             #
+# =========================================================================== #
+
+
+def pkg_install_pinned(vm: SmokeVM, version: str, *, timeout: float = 600.0) -> subprocess.CompletedProcess[str]:
+    """``pkg install -y <name>-<version>`` — the PINNED rollback command (ADR §2.1 rollback UX).
+
+    This is the exact CLI command documented in README and scripts/README.md: installs the
+    named package at an EXPLICIT version from the multi-version catalog.  If the version
+    is not in the catalog, pkg returns non-zero.  Dep resolution against the enabled repos
+    runs normally — the catalog-provided dep metadata is honoured, not bypassed (unlike
+    ``pkg add <raw-url>`` which skips catalog dep resolution).  A non-zero exit raises with
+    the full output.
+    """
+    pinned_name = f"{PKG_NAME}-{version}"
+    result = vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "install", "-y", pinned_name, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pkg install {pinned_name} failed: rc={result.returncode}"
+            f"\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+@pytest.mark.timeout(900)  # forge 2 builds + 2 catalog gen + 3 pkg ops (install/rollback/upgrade) > the 30s cap.
+def test_release_rollback_to_retained_older_version(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """ADR-27 P4 KILL-GATE: a multi-version release catalog allows a REAL pfSense box to
+    pin-install an OLDER retained version with dependency resolution (the documented
+    rollback UX), then re-upgrade to the newest — a full install→rollback→upgrade lifecycle.
+
+    This is the ADR §7 REJECT gate: if ``pkg install <name>-<version>`` cannot pin-install
+    a retained older version with dep resolution from our repo, Part 1 degrades to docs-only
+    (only ``pkg add <raw-url>`` is available, with no dep resolution from the catalog).
+
+    The multi-version catalog is built on the runner (pure-Python ``build-repo-portable.py``)
+    over BOTH the lower (``<V>_lo``) and higher (``<V>_hi``) forged builds, then shipped to
+    the guest as a single ``<ABI>/`` tree.  Both packages are advertised in the same
+    ``packagesite.yaml``; ``pkg install <name>`` resolves the highest; ``pkg install
+    <name>-<V>_lo`` resolves the pinned older one.
+
+    The variant (ABI / PHP flavor) comes from the version matrix (SMOKE_ABI / SMOKE_PHP_VERSION)
+    — never hardcoded.  ``build_repo_via_portable`` derives the ABI bucket from the ``.pkg``'s
+    own manifest (the branch ``.pkg`` is the box's exact ABI: ``FreeBSD:15:amd64`` / php83 on
+    CE, ``FreeBSD:16:amd64`` / php85 on Plus).
+
+    Scenario: install-newest → pin-rollback → re-upgrade, all from a multi-version release catalog.
+      Background:
+        - Two versions forged from the branch .pkg: ``<V>_lo`` (older) and ``<V>_hi`` (newer).
+        - A single multi-version catalog serving BOTH, built by build-repo-portable.py.
+        - A NONE-signed file:// repo conf above the Netgate pfSense repo.
+
+    Given the package ABSENT and the multi-version catalog carrying BOTH ``<V>_lo`` and ``<V>_hi``,
+      When ``pkg install -y <name>`` (no version pin) runs,
+      Then NEWEST-WINS: ``<V>_hi`` is active, origin is our repo, RUN_DEPENDS resolved.
+        (This asserts the before-state for the rollback step — proves the catalog serves
+        the highest version by default and that the after-rollback state is a real regression.)
+    When ``pkg install -y <name>-<V>_lo`` (PINNED older version) runs,
+      Then ROLLBACK: ``<V>_lo`` is active, origin is still our repo, no "Missing dependency"
+        (catalog dep resolution worked; the premise holds).
+        (This is the REJECT gate: if this install fails, Part 1 must be downgraded to docs-only.)
+    When ``pkg upgrade -y <name>`` runs (after pkg update -f re-reads the same catalog),
+      Then RE-UPGRADE: ``<V>_hi`` is active again, origin is our repo — lifecycle closed.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
+    src = Path(pkg)
+
+    base_version = read_compact_version(src)
+    lo_version = f"{base_version}_lo"
+    hi_version = f"{base_version}_hi"
+    # Sanity: the forged versions must be distinct so each transition is real.
+    assert lo_version != hi_version
+    # The rollback target must sort BELOW the high version so pkg install <name> picks hi by default.
+    # pkg version-sorts by PORTVERSION rules: _lo < _hi lexicographically under pkg's epoch/revision
+    # model. Verified: reversion_pkg only rewrites the version string; all other manifest fields
+    # (including deps) are copied verbatim, so both builds have identical RUN_DEPENDS.
+
+    lo_pkg = reversion_pkg(src, lo_version, tmp_path / "rollback_lo")
+    hi_pkg = reversion_pkg(src, hi_version, tmp_path / "rollback_hi")
+
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+
+    try:
+        # ---- Build the multi-version catalog (BOTH builds in one ABI tree) ----
+        # build_repo_via_portable takes a list of .pkg files; with two distinct versions of
+        # the SAME package it writes two NDJSON entries in packagesite.yaml — a multi-version
+        # catalog exactly as build_repo_matrix(release_keep_devel=2) produces in production.
+        # The catalog is built on the runner (pure Python; no libpkg needed) and shipped to
+        # the guest under PORTABLE_REPO_ROOT/<ABI>/ (same helper used by the portable fidelity tests).
+        multi_abi_dir = build_repo_via_portable(repo_vm, [lo_pkg, hi_pkg], tmp_path)
+
+        # --- GIVEN: package absent; multi-version catalog enabled above the pfSense repo. ---
+        pkg_delete(repo_vm)
+        write_repo_conf(repo_vm, multi_abi_dir, ours_priority=pfsense_prio + 100)
+        pkg_update(repo_vm)
+        assert pkg_installed_version(repo_vm) is None, (
+            f"{PKG_NAME} unexpectedly present before the rollback lifecycle test"
+        )
+
+        # --- WHEN (1): install without a version pin → newest-wins. ---
+        proc_install = pkg_install_from_repo(repo_vm)
+
+        # THEN (before-state anchor): the box is at the HIGHER version (newest-wins default),
+        # from our repo, deps resolved.  This is the before-state the rollback must visibly
+        # depart from — if the before-state is already at _lo, the rollback assertion is vacuous.
+        combined_install = proc_install.stdout + proc_install.stderr
+        assert "Missing dependency" not in combined_install, (
+            f"Multi-version catalog: RUN_DEPENDS did not resolve on newest-wins install:\n{combined_install}"
+        )
+        before_version = pkg_installed_version(repo_vm)
+        assert before_version == hi_version, (
+            f"Newest-wins: expected {hi_version!r} installed first (highest in catalog), "
+            f"got {before_version!r} — catalog version ordering wrong"
+        )
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, (
+            f"Newest-wins install: origin {pkg_repo_origin(repo_vm)!r}, expected {OURS_REPO_NAME!r}"
+        )
+
+        # --- WHEN (2): pin-install the OLDER version — the documented rollback command. ---
+        # This is the ADR §7 REJECT gate: failure here (non-zero exit or "Missing dependency")
+        # means the catalog-based rollback premise does NOT hold.
+        proc_rollback = pkg_install_pinned(repo_vm, lo_version)
+
+        # THEN (rollback): the box is now at the LOWER version, STILL from our repo, deps resolved.
+        combined_rollback = proc_rollback.stdout + proc_rollback.stderr
+        assert "Missing dependency" not in combined_rollback, (
+            f"Rollback: RUN_DEPENDS did not resolve when pinning {lo_version!r}:\n{combined_rollback}"
+        )
+        rollback_version = pkg_installed_version(repo_vm)
+        assert rollback_version == lo_version, (
+            f"Rollback: expected {lo_version!r} active after pin-install, got {rollback_version!r}"
+        )
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, (
+            f"Rollback: origin {pkg_repo_origin(repo_vm)!r}, expected {OURS_REPO_NAME!r} — "
+            f"pinned install should still source from our multi-version catalog"
+        )
+
+        # --- WHEN (3): re-upgrade — close the lifecycle. ---
+        # The multi-version catalog still carries hi_version; pkg upgrade moves back up.
+        pkg_update(repo_vm)
+        proc_upgrade = pkg_upgrade(repo_vm)
+
+        # THEN (re-upgrade): the box is back at the HIGHER version, lifecycle closed.
+        combined_upgrade = proc_upgrade.stdout + proc_upgrade.stderr
+        assert "Missing dependency" not in combined_upgrade, (
+            f"Re-upgrade: RUN_DEPENDS did not resolve when upgrading from {lo_version!r}:\n{combined_upgrade}"
+        )
+        reupgraded_version = pkg_installed_version(repo_vm)
+        assert reupgraded_version == hi_version, (
+            f"Re-upgrade: expected {hi_version!r} after upgrade, got {reupgraded_version!r} — lifecycle did not close"
+        )
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, (
+            f"Re-upgrade: origin {pkg_repo_origin(repo_vm)!r}, expected {OURS_REPO_NAME!r}"
+        )
+    finally:
+        pkg_delete(repo_vm)
+        # PORTABLE_REPO_ROOT is cleaned by build_repo_via_portable on each call;
+        # the broader GUEST_SPIKE_DIR teardown runs in the repo_vm module fixture.

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1857,14 +1857,16 @@ def test_release_rollback_to_retained_older_version(repo_vm: SmokeVM, tmp_path: 
     src = Path(pkg)
 
     base_version = read_compact_version(src)
-    lo_version = f"{base_version}_lo"
-    hi_version = f"{base_version}_hi"
+    lo_version = f"{base_version}_1"
+    hi_version = f"{base_version}_9"
     # Sanity: the forged versions must be distinct so each transition is real.
     assert lo_version != hi_version
     # The rollback target must sort BELOW the high version so pkg install <name> picks hi by default.
-    # pkg version-sorts by PORTVERSION rules: _lo < _hi lexicographically under pkg's epoch/revision
-    # model. Verified: reversion_pkg only rewrites the version string; all other manifest fields
-    # (including deps) are copied verbatim, so both builds have identical RUN_DEPENDS.
+    # pkg version-sorts the trailing ``_N`` as the numeric PORTREVISION, so _1 < _9 (same as the
+    # _1->_9 upgrade cases above). A non-numeric suffix (_lo/_hi) would instead sort ALPHABETICALLY
+    # under pkg's PORTREVISION rules — "lo" > "hi" — inverting the intended order. Verified:
+    # reversion_pkg only rewrites the version string; all other manifest fields (including deps)
+    # are copied verbatim, so both builds have identical RUN_DEPENDS.
 
     lo_pkg = reversion_pkg(src, lo_version, tmp_path / "rollback_lo")
     hi_pkg = reversion_pkg(src, hi_version, tmp_path / "rollback_hi")

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1794,17 +1794,19 @@ def test_routing_url_delivers_variant_catalog(repo_vm: SmokeVM) -> None:
 
 
 def pkg_install_pinned(vm: SmokeVM, version: str, *, timeout: float = 600.0) -> subprocess.CompletedProcess[str]:
-    """``pkg install -y <name>-<version>`` — the PINNED rollback command (ADR §2.1 rollback UX).
+    """``pkg install -fy <name>-<version>`` — the PINNED rollback command (ADR §2.1 rollback UX).
 
     This is the exact CLI command documented in README and scripts/README.md: installs the
-    named package at an EXPLICIT version from the multi-version catalog.  If the version
-    is not in the catalog, pkg returns non-zero.  Dep resolution against the enabled repos
-    runs normally — the catalog-provided dep metadata is honoured, not bypassed (unlike
-    ``pkg add <raw-url>`` which skips catalog dep resolution).  A non-zero exit raises with
-    the full output.
+    named package at an EXPLICIT version from the multi-version catalog.  ``-f`` (force) is
+    REQUIRED to roll *back*: without it, ``pkg install`` is a no-op when a NEWER build of the
+    same package is already installed (pkg never downgrades by default) — the documented
+    FreeBSD downgrade idiom.  If the version is not in the catalog, pkg returns non-zero.  Dep
+    resolution against the enabled repos runs normally — the catalog-provided dep metadata is
+    honoured, not bypassed (unlike ``pkg add <raw-url>`` which skips catalog dep resolution).
+    A non-zero exit raises with the full output.
     """
     pinned_name = f"{PKG_NAME}-{version}"
-    result = vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "install", "-y", pinned_name, timeout=timeout)
+    result = vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "install", "-fy", pinned_name, timeout=timeout)
     if result.returncode != 0:
         raise RuntimeError(
             f"pkg install {pinned_name} failed: rc={result.returncode}"
@@ -1845,7 +1847,7 @@ def test_release_rollback_to_retained_older_version(repo_vm: SmokeVM, tmp_path: 
       Then NEWEST-WINS: ``<V>_hi`` is active, origin is our repo, RUN_DEPENDS resolved.
         (This asserts the before-state for the rollback step — proves the catalog serves
         the highest version by default and that the after-rollback state is a real regression.)
-    When ``pkg install -y <name>-<V>_lo`` (PINNED older version) runs,
+    When ``pkg install -fy <name>-<V>_lo`` (PINNED older version, ``-f`` forces the downgrade) runs,
       Then ROLLBACK: ``<V>_lo`` is active, origin is still our repo, no "Missing dependency"
         (catalog dep resolution worked; the premise holds).
         (This is the REJECT gate: if this install fails, Part 1 must be downgraded to docs-only.)

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -1429,6 +1429,37 @@ def test_retain_by_channel_empty_channel_is_noop(tmp_path: Path) -> None:
     assert len(kept) == 2
 
 
+@pytest.mark.parametrize(
+    ("keep_devel", "keep_stable"),
+    [(-1, 1), (1, -1), (-1, -1)],
+)
+def test_retain_by_channel_rejects_negative_keep(tmp_path: Path, keep_devel: int, keep_stable: int) -> None:
+    """A negative keep value is rejected up front (fail fast), not slice-applied silently.
+
+    A negative ``keep`` would otherwise reach ``_retain_newest``'s ``[:keep]`` slice — e.g.
+    ``keep=-1`` drops the NEWEST build instead of pruning the oldest — losing data with no
+    error. ``retain_by_channel`` must raise ``BuildRepoError`` for any negative input.
+
+    Scenario: 2 devel + 2 stable pkgs, one (or both) keep value negative
+      Given a valid set of pkgs
+      When retain_by_channel is called with a negative keep_devel and/or keep_stable
+      Then it raises BuildRepoError (no silent slice, no partial result)
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    dv1 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.1")
+    dv2 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.2")
+    sv1 = _make_pkg_channel(d, "pfBlockerNG", "2.0.1")
+    sv2 = _make_pkg_channel(d, "pfBlockerNG", "2.0.2")
+
+    # Positive control: the non-negative call DOES return (proves the inputs are valid and
+    # only the negative value triggers the raise — not some unrelated failure).
+    assert len(brp.retain_by_channel([dv1, dv2, sv1, sv2], keep_devel=1, keep_stable=1)) == 2
+
+    with pytest.raises(brp.BuildRepoError, match=">= 0"):
+        brp.retain_by_channel([dv1, dv2, sv1, sv2], keep_devel=keep_devel, keep_stable=keep_stable)
+
+
 # --------------------------------------------------------------------------- #
 # ADR-27 Phase 2: release-subtree retention in build_repo_matrix
 #

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -1617,3 +1617,249 @@ def test_release_catalog_lists_all_kept_versions(tmp_path: Path) -> None:
     # The retained top versions must be at least 3.0.3 and 2.0.3 respectively.
     assert devel_versions[0] >= brp._pkg_version_key("3.0.3")
     assert stable_versions[0] >= brp._pkg_version_key("2.0.3")
+
+
+# --------------------------------------------------------------------------- #
+# ADR-27 Phase 3: CLI dry-run — --release-extra-pkgs end-to-end
+#
+# These tests exercise the DOCUMENTED PUBLISH.YML INPUT PATH through the CLI
+# (brp.main([...])) rather than the Python API, so the actual command-line
+# wiring (argparse → extra_pkgs conversion → build_repo_matrix) is proven.
+#
+# Pattern: synthetic devel_1..4 + stable_1..4 passed as --release-extra-pkgs;
+# --release-keep-devel / --release-keep-stable assert that the catalog holds
+# exactly the newest N/M and the oldest candidate is absent. Before-and-after
+# assertions confirm the pruning is genuine, not a coincidental match.
+# --------------------------------------------------------------------------- #
+
+
+def _with_stub_builder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch brp.build_repo_matrix so CLI calls use _stub_builder (no subprocess)."""
+    _real = brp.build_repo_matrix
+
+    def _patched(matrix: list[dict], out_dir: Path, **kw: Any) -> dict:
+        kw.setdefault("builder", _stub_builder)
+        return _real(matrix, out_dir, **kw)
+
+    monkeypatch.setattr(brp, "build_repo_matrix", _patched)
+
+
+def test_cli_release_extra_pkgs_default_is_latest_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI defaults (--release-keep-devel 1, --release-keep-stable 1) keep only the
+    latest release when --release-extra-pkgs carry older versions too.
+
+    Scenario: CLI latest-only default with older extras supplied
+      Given 3 pre-built devel extras (3.0.1, 3.0.2, 3.0.3) passed via --release-extra-pkgs
+        And 3 pre-built stable extras (2.0.1, 2.0.2, 2.0.3) passed via --release-extra-pkgs
+        And no --release-keep-devel / --release-keep-stable override (default 1)
+      When brp.main([--build-matrix, ...]) is called
+      Then the release catalog has exactly 1 devel entry (before-state: default is latest-only)
+       And the release catalog has exactly 1 stable entry
+       And the highest-version devel (3.0.3) is the one retained
+       And the highest-version stable (2.0.3) is the one retained
+    """
+    _with_stub_builder(monkeypatch)
+
+    extras = tmp_path / "extras"
+    extras.mkdir()
+    devel_extras = [_make_pkg_channel(extras, "pfBlockerNG-devel", f"3.0.{i}") for i in range(1, 4)]
+    stable_extras = [_make_pkg_channel(extras, "pfBlockerNG", f"2.0.{i}") for i in range(1, 4)]
+
+    # Before-state: confirm the extra pkgs exist and span all 6 versions.
+    assert len(devel_extras) == 3
+    assert len(stable_extras) == 3
+
+    out = tmp_path / "site"
+    mfile = tmp_path / "matrix.json"
+    mfile.write_text(json.dumps({"versions": [_CE]}))
+
+    extra_flags: list[str] = []
+    for p in devel_extras + stable_extras:
+        extra_flags += ["--release-extra-pkgs", str(p)]
+
+    rc = brp.main(
+        [
+            "--build-matrix",
+            "--matrix-json",
+            str(mfile),
+            "--out",
+            str(out),
+            "--no-nightly",
+            # No --release-keep-devel / --release-keep-stable  → default 1
+        ]
+        + extra_flags
+    )
+    assert rc == 0
+
+    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    assert rel.is_file()
+    objs = _catalog_objects(rel)
+
+    devel_objs = [o for o in objs if o["name"] == "pfBlockerNG-devel"]
+    stable_objs = [o for o in objs if o["name"] == "pfBlockerNG"]
+
+    # Before-state (default keep=1): exactly one devel entry, one stable entry.
+    assert len(devel_objs) == 1, f"expected 1 devel, got {len(devel_objs)}"
+    assert len(stable_objs) == 1, f"expected 1 stable, got {len(stable_objs)}"
+
+    # The retained entries are the highest-version ones (newest-wins).
+    assert devel_objs[0]["version"] >= "3.0.3"
+    assert stable_objs[0]["version"] >= "2.0.3"
+
+
+def test_cli_release_extra_pkgs_keeps_newest_n(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI correctly prunes to newest N/M when --release-keep-devel/stable are set.
+
+    Scenario: rollback depth 3, 4 candidates per channel via CLI
+      Given 4 pre-built devel extras (3.0.1..3.0.4) passed as --release-extra-pkgs
+        And 4 pre-built stable extras (2.0.1..2.0.4) passed as --release-extra-pkgs
+        And --release-keep-devel 3, --release-keep-stable 3
+      When brp.main([--build-matrix, ...]) is called
+      Then the release catalog has exactly 3 devel entries (AFTER state: rollback enabled)
+       And the release catalog has exactly 3 stable entries
+       And the oldest devel (3.0.1) is absent from the catalog
+       And the oldest stable (2.0.1) is absent from the catalog
+       And the 3 newest devel versions (3.0.2, 3.0.3, 3.0.4) are present
+       And the 3 newest stable versions (2.0.2, 2.0.3, 2.0.4) are present
+    """
+    _with_stub_builder(monkeypatch)
+
+    extras = tmp_path / "extras"
+    extras.mkdir()
+    devel_extras = [_make_pkg_channel(extras, "pfBlockerNG-devel", f"3.0.{i}") for i in range(1, 5)]
+    stable_extras = [_make_pkg_channel(extras, "pfBlockerNG", f"2.0.{i}") for i in range(1, 5)]
+
+    out = tmp_path / "site"
+    mfile = tmp_path / "matrix.json"
+    mfile.write_text(json.dumps({"versions": [_CE]}))
+
+    extra_flags: list[str] = []
+    for p in devel_extras + stable_extras:
+        extra_flags += ["--release-extra-pkgs", str(p)]
+
+    # Before-state: with default keep=1 only 1 devel + 1 stable appear.
+    out_before = tmp_path / "before"
+    mfile_before = tmp_path / "matrix_before.json"
+    mfile_before.write_text(json.dumps({"versions": [_CE]}))
+    rc_before = brp.main(
+        [
+            "--build-matrix",
+            "--matrix-json",
+            str(mfile_before),
+            "--out",
+            str(out_before),
+            "--no-nightly",
+        ]
+        + extra_flags
+    )
+    assert rc_before == 0
+    before_objs = _catalog_objects(out_before / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
+    before_devel = [o for o in before_objs if o["name"] == "pfBlockerNG-devel"]
+    before_stable = [o for o in before_objs if o["name"] == "pfBlockerNG"]
+    assert len(before_devel) == 1, "before-state: default keep=1 must yield exactly 1 devel"
+    assert len(before_stable) == 1, "before-state: default keep=1 must yield exactly 1 stable"
+
+    # After-state: with keep=3 the catalog lists 3 devel + 3 stable.
+    rc = brp.main(
+        [
+            "--build-matrix",
+            "--matrix-json",
+            str(mfile),
+            "--out",
+            str(out),
+            "--no-nightly",
+            "--release-keep-devel",
+            "3",
+            "--release-keep-stable",
+            "3",
+        ]
+        + extra_flags
+    )
+    assert rc == 0
+
+    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    assert rel.is_file()
+    objs = _catalog_objects(rel)
+    nv = {(o["name"], o["version"]) for o in objs}
+
+    devel_objs = [o for o in objs if o["name"] == "pfBlockerNG-devel"]
+    stable_objs = [o for o in objs if o["name"] == "pfBlockerNG"]
+
+    # After-state: 3 devel + 3 stable.
+    assert len(devel_objs) == 3, f"expected 3 devel after, got {len(devel_objs)}"
+    assert len(stable_objs) == 3, f"expected 3 stable after, got {len(stable_objs)}"
+
+    # Oldest excluded.
+    assert ("pfBlockerNG-devel", "3.0.1") not in nv, "oldest devel must be pruned"
+    assert ("pfBlockerNG", "2.0.1") not in nv, "oldest stable must be pruned"
+
+    # Newest 3 present.
+    for v in ("3.0.2", "3.0.3", "3.0.4"):
+        assert ("pfBlockerNG-devel", v) in nv, f"devel {v} must be retained"
+    for v in ("2.0.2", "2.0.3", "2.0.4"):
+        assert ("pfBlockerNG", v) in nv, f"stable {v} must be retained"
+
+
+def test_cli_release_extra_pkgs_newest_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With multiple retained devel versions the highest version ranks first (newest-wins).
+
+    Scenario: pkg install <name> without version must resolve to the highest kept version
+      Given 4 devel extras (3.0.1..3.0.4) and keep=2
+        And 4 stable extras (2.0.1..2.0.4) and keep=2
+      When brp.main([--build-matrix, ...]) is called
+      Then the catalog lists exactly 2 devel + 2 stable entries
+       And the highest devel version in the catalog is >= 3.0.4 (newest-wins)
+       And the highest stable version in the catalog is >= 2.0.4 (newest-wins)
+       And no (name, version) pair is duplicated in the catalog
+    """
+    _with_stub_builder(monkeypatch)
+
+    extras = tmp_path / "extras"
+    extras.mkdir()
+    devel_extras = [_make_pkg_channel(extras, "pfBlockerNG-devel", f"3.0.{i}") for i in range(1, 5)]
+    stable_extras = [_make_pkg_channel(extras, "pfBlockerNG", f"2.0.{i}") for i in range(1, 5)]
+
+    out = tmp_path / "site"
+    mfile = tmp_path / "matrix.json"
+    mfile.write_text(json.dumps({"versions": [_CE]}))
+
+    extra_flags: list[str] = []
+    for p in devel_extras + stable_extras:
+        extra_flags += ["--release-extra-pkgs", str(p)]
+
+    rc = brp.main(
+        [
+            "--build-matrix",
+            "--matrix-json",
+            str(mfile),
+            "--out",
+            str(out),
+            "--no-nightly",
+            "--release-keep-devel",
+            "2",
+            "--release-keep-stable",
+            "2",
+        ]
+        + extra_flags
+    )
+    assert rc == 0
+
+    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    objs = _catalog_objects(rel)
+
+    devel_objs = [o for o in objs if o["name"] == "pfBlockerNG-devel"]
+    stable_objs = [o for o in objs if o["name"] == "pfBlockerNG"]
+
+    # Exactly 2 devel + 2 stable.
+    assert len(devel_objs) == 2
+    assert len(stable_objs) == 2
+
+    # No duplicate (name, version) pairs.
+    nv_list = [(o["name"], o["version"]) for o in objs]
+    assert len(nv_list) == len(set(nv_list)), "duplicate (name, version) pair in catalog"
+
+    # Newest-wins: highest version in the retained set is >= 3.0.4 / 2.0.4.
+    devel_top = max(brp._pkg_version_key(o["version"]) for o in devel_objs)
+    stable_top = max(brp._pkg_version_key(o["version"]) for o in stable_objs)
+    assert devel_top >= brp._pkg_version_key("3.0.4")
+    assert stable_top >= brp._pkg_version_key("2.0.4")

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -1427,3 +1427,193 @@ def test_retain_by_channel_empty_channel_is_noop(tmp_path: Path) -> None:
     kept_nv = {(brp.read_compact_manifest(p)["name"], brp.read_compact_manifest(p)["version"]) for p in kept}
     assert kept_nv == {("pfBlockerNG", "2.0.1"), ("pfBlockerNG", "2.0.2")}
     assert len(kept) == 2
+
+
+# --------------------------------------------------------------------------- #
+# ADR-27 Phase 2: release-subtree retention in build_repo_matrix
+#
+# These tests pin the retention behaviour of the release subtree:
+#   * defaults (release_keep_devel=1, release_keep_stable=1) reproduce today's
+#     latest-only output — the BEFORE state (inert change)
+#   * with N=M=3 and 4 of each channel provided, the catalog lists exactly the
+#     newest 3 of each — the 4th is absent (AFTER state)
+#   * newest-wins: pkg install <name> (no version) still gets the highest version
+#     across all retained entries (contract §2.2.2)
+#   * generator drift pins (conf bytes) still hold
+# --------------------------------------------------------------------------- #
+
+
+def _catalog_objects(catalog_pkg: Path) -> list[dict]:
+    """Return all packagesite NDJSON objects from a catalog .pkg."""
+    raw = _read_member(catalog_pkg, "packagesite.yaml").decode()
+    return [json.loads(ln) for ln in raw.splitlines() if ln]
+
+
+def _versions_in_release(catalog_pkg: Path) -> set[str]:
+    return {o["version"] for o in _catalog_objects(catalog_pkg)}
+
+
+def _names_versions_in_release(catalog_pkg: Path) -> set[tuple[str, str]]:
+    return {(o["name"], o["version"]) for o in _catalog_objects(catalog_pkg)}
+
+
+def test_release_default_is_latest_only(tmp_path: Path) -> None:
+    """Defaults (release_keep_devel=1, release_keep_stable=1) produce exactly one devel +
+    one stable in the release catalog — the BEFORE state (inert change, no rollback).
+
+    Scenario: default keep values with devel + stable
+      Given build_repo_matrix with NO release_extra_pkgs and default keep values
+        And a stable tag is set (so one stable is built)
+      When the matrix runs
+      Then the release catalog lists exactly ONE devel version (before-state)
+       And exactly ONE stable version (before-state)
+       And the total entry count is 2
+    """
+    out = tmp_path / "site"
+
+    # Before-state: no release dir yet.
+    assert not (out / "release").exists()
+
+    brp.build_repo_matrix([_CE], out, builder=_stub_builder, stable_tag="v3.2.15")
+
+    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    assert rel.is_file()
+
+    objs = _catalog_objects(rel)
+    names = {o["name"] for o in objs}
+
+    # Exactly one devel + one stable (latest-only — the before/default state).
+    assert "pfBlockerNG-devel" in names
+    assert "pfBlockerNG" in names
+    assert len(objs) == 2
+
+
+def test_release_subtree_retains_devel_and_stable(tmp_path: Path) -> None:
+    """With release_keep_devel=3, release_keep_stable=3 and 4 of each provided,
+    the catalog lists the newest 3 of each channel — the 4th (oldest) is absent.
+
+    Scenario: rollback depth 3, 4 candidates per channel
+      Given 4 pre-built devel pkgs (versions 3.0.1..3.0.4)
+        And 4 pre-built stable pkgs (versions 2.0.1..2.0.4)
+        And release_keep_devel=3, release_keep_stable=3
+      When build_repo_matrix runs with those extra pkgs + the fresh build
+      Then devel: versions 3.0.2, 3.0.3, 3.0.4 are in the catalog
+       And devel: version 3.0.1 (the oldest) is NOT in the catalog
+       And stable: versions 2.0.2, 2.0.3, 2.0.4 are in the catalog
+       And stable: version 2.0.1 (the oldest) is NOT in the catalog
+    """
+    extras = tmp_path / "extras"
+    extras.mkdir()
+    abi = "FreeBSD:15:amd64"
+
+    # 4 pre-built devel candidates (the fresh build will be version "1.0_1" from the
+    # stub, so all 4 extras sit below "1.0_1" as older versions). Use 3.0.1..3.0.4 as
+    # clearly ordered versions to make the test readable.
+    devel_extras = [_make_pkg_channel(extras, "pfBlockerNG-devel", f"3.0.{i}", abi=abi) for i in range(1, 5)]
+    # 4 pre-built stable candidates.
+    stable_extras = [_make_pkg_channel(extras, "pfBlockerNG", f"2.0.{i}", abi=abi) for i in range(1, 5)]
+
+    all_extras = devel_extras + stable_extras
+
+    # Before-state: with defaults (keep=1), only the freshest 1 of each is kept.
+    out_before = tmp_path / "before"
+    brp.build_repo_matrix(
+        [_CE],
+        out_before,
+        builder=_stub_builder,
+        stable_tag="v3.2.15",
+        release_extra_pkgs=all_extras,
+        release_keep_devel=1,
+        release_keep_stable=1,
+    )
+    rel_before = out_before / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    objs_before = _catalog_objects(rel_before)
+    assert len(objs_before) == 2  # 1 devel + 1 stable with keep=1
+
+    # After-state: with keep=3, the newest 3 of each channel are retained.
+    out = tmp_path / "site"
+    brp.build_repo_matrix(
+        [_CE],
+        out,
+        builder=_stub_builder,
+        stable_tag="v3.2.15",
+        release_extra_pkgs=all_extras,
+        release_keep_devel=3,
+        release_keep_stable=3,
+    )
+    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    nv_set = _names_versions_in_release(rel)
+
+    # Devel: 3.0.2, 3.0.3, 3.0.4 present; 3.0.1 dropped (4th/oldest).
+    assert ("pfBlockerNG-devel", "3.0.4") in nv_set
+    assert ("pfBlockerNG-devel", "3.0.3") in nv_set
+    assert ("pfBlockerNG-devel", "3.0.2") in nv_set
+    assert ("pfBlockerNG-devel", "3.0.1") not in nv_set
+
+    # Stable: 2.0.2, 2.0.3, 2.0.4 present; 2.0.1 dropped.
+    assert ("pfBlockerNG", "2.0.4") in nv_set
+    assert ("pfBlockerNG", "2.0.3") in nv_set
+    assert ("pfBlockerNG", "2.0.2") in nv_set
+    assert ("pfBlockerNG", "2.0.1") not in nv_set
+
+
+def test_release_catalog_lists_all_kept_versions(tmp_path: Path) -> None:
+    """The release packagesite NDJSON has one object per (name, version) kept —
+    newest is still the highest version (newest-wins default, contract §2.2.2).
+
+    Scenario: multi-version catalog integrity
+      Given release_keep_devel=2, release_keep_stable=2, 3 of each provided as extras
+        And a fresh devel build (the stub produces version "1.0_1")
+        And the newest extras are 3.0.3 (devel) and 2.0.3 (stable)
+      When build_repo_matrix runs
+      Then the catalog has exactly 4 objects (2 devel + 2 stable)
+       And the highest-version devel object is at least 3.0.3
+       And the highest-version stable object is at least 2.0.3
+       And every kept (name, version) pair appears exactly once (no duplicates)
+    """
+    extras = tmp_path / "extras"
+    extras.mkdir()
+    abi = "FreeBSD:15:amd64"
+
+    # 3 extras each channel; with keep=2 only the newest 2 survive per channel.
+    devel_extras = [_make_pkg_channel(extras, "pfBlockerNG-devel", f"3.0.{i}", abi=abi) for i in range(1, 4)]
+    stable_extras = [_make_pkg_channel(extras, "pfBlockerNG", f"2.0.{i}", abi=abi) for i in range(1, 4)]
+
+    out = tmp_path / "site"
+    brp.build_repo_matrix(
+        [_CE],
+        out,
+        builder=_stub_builder,
+        stable_tag="v3.2.15",
+        release_extra_pkgs=devel_extras + stable_extras,
+        release_keep_devel=2,
+        release_keep_stable=2,
+    )
+
+    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    objs = _catalog_objects(rel)
+
+    # Exactly 4 catalog entries: 2 devel + 2 stable.
+    assert len(objs) == 4
+
+    devel_objs = [o for o in objs if o["name"] == "pfBlockerNG-devel"]
+    stable_objs = [o for o in objs if o["name"] == "pfBlockerNG"]
+    assert len(devel_objs) == 2
+    assert len(stable_objs) == 2
+
+    # No duplicate (name, version) pairs.
+    nv_list = [(o["name"], o["version"]) for o in objs]
+    assert len(nv_list) == len(set(nv_list)), "duplicate (name, version) pair in catalog"
+
+    # Newest-wins: the highest devel version in the catalog is 3.0.3 (the extras newest).
+    devel_versions = sorted(
+        [brp._pkg_version_key(o["version"]) for o in devel_objs],
+        reverse=True,
+    )
+    stable_versions = sorted(
+        [brp._pkg_version_key(o["version"]) for o in stable_objs],
+        reverse=True,
+    )
+    # The retained top versions must be at least 3.0.3 and 2.0.3 respectively.
+    assert devel_versions[0] >= brp._pkg_version_key("3.0.3")
+    assert stable_versions[0] >= brp._pkg_version_key("2.0.3")

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -1148,3 +1148,282 @@ def test_build_matrix_annotate_passthrough(tmp_path: Path) -> None:
     for call in seen:
         assert call["annotate"] == {"commit": "deadbeef", "created": "123"}
     assert {c["channel"] for c in seen} == {"devel", "nightly"}
+
+
+# --------------------------------------------------------------------------- #
+# ADR-27 Phase 1: retain_by_channel — channel-keyed release-retention helper
+#
+# These tests pin the helper in isolation (no call-site change in build_repo_matrix
+# yet — Phase 2 wires it in). They cover every branch:
+#   * devel vs stable bucketed independently (one does not affect the other)
+#   * keep < len(bucket) → prune to newest keep (version order + determinism)
+#   * keep >= len(bucket) → no-op (keep all)
+#   * keep == 0 → keep all of that channel (the "unbounded/disabled" sentinel)
+#   * mixed devel+stable+nightly input: nightly left untouched regardless
+#   * before-state assertions where the outcome depends on keep value
+# --------------------------------------------------------------------------- #
+
+
+def _make_pkg_channel(
+    tmp_path: Path,
+    name: str,
+    version: str,
+    *,
+    abi: str = "FreeBSD:15:amd64",
+) -> Path:
+    """Write a minimal .pkg and return its path (name encodes the channel)."""
+    p = tmp_path / f"{name}-{version}.pkg"
+    make_pkg(p, name=name, version=version, abi=abi)
+    return p
+
+
+def test_retain_by_channel_devel_pruned_independently(tmp_path: Path) -> None:
+    """Devel bucket is pruned to keep_devel; stable bucket is untouched when keep_stable=0.
+
+    Scenario: 3 devel versions + 2 stable versions; keep_devel=2, keep_stable=0
+      Given 3 devel pkgs (v1, v2, v3) and 2 stable pkgs (s1.0, s2.0)
+        And keep_devel=2, keep_stable=0 (stable unbounded)
+      When retain_by_channel is called
+      Then devel result contains only the 2 newest (v2, v3) — v1 dropped
+       And stable result contains BOTH stable pkgs (keep_stable=0 = keep all)
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    dv1 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.1")
+    dv2 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.2")
+    dv3 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.3")
+    sv1 = _make_pkg_channel(d, "pfBlockerNG", "2.0.1")
+    sv2 = _make_pkg_channel(d, "pfBlockerNG", "2.0.2")
+
+    # Before-state: all 5 paths provided.
+    all_paths = [dv1, dv2, dv3, sv1, sv2]
+
+    kept = brp.retain_by_channel(all_paths, keep_devel=2, keep_stable=0)
+
+    kept_names_versions = {
+        (brp.read_compact_manifest(p)["name"], brp.read_compact_manifest(p)["version"]) for p in kept
+    }
+    # Devel: newest 2 kept (v2, v3); v1 dropped.
+    assert ("pfBlockerNG-devel", "3.0.3") in kept_names_versions
+    assert ("pfBlockerNG-devel", "3.0.2") in kept_names_versions
+    assert ("pfBlockerNG-devel", "3.0.1") not in kept_names_versions
+    # Stable: both kept (keep_stable=0 = unbounded).
+    assert ("pfBlockerNG", "2.0.1") in kept_names_versions
+    assert ("pfBlockerNG", "2.0.2") in kept_names_versions
+
+
+def test_retain_by_channel_stable_pruned_independently(tmp_path: Path) -> None:
+    """Stable bucket is pruned to keep_stable; devel bucket is untouched when keep_devel=0.
+
+    Scenario: 2 devel versions + 3 stable versions; keep_devel=0, keep_stable=1
+      Given 2 devel pkgs (v1, v2) and 3 stable pkgs (s1.0, s2.0, s3.0)
+        And keep_devel=0 (unbounded), keep_stable=1
+      When retain_by_channel is called
+      Then stable result contains only s3.0 (newest 1); s1.0 and s2.0 dropped
+       And devel result contains BOTH devel pkgs (keep_devel=0 = keep all)
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    dv1 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.1")
+    dv2 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.2")
+    sv1 = _make_pkg_channel(d, "pfBlockerNG", "2.0.1")
+    sv2 = _make_pkg_channel(d, "pfBlockerNG", "2.0.2")
+    sv3 = _make_pkg_channel(d, "pfBlockerNG", "2.0.3")
+
+    # Before-state: all 5 paths.
+    all_paths = [dv1, dv2, sv1, sv2, sv3]
+
+    kept = brp.retain_by_channel(all_paths, keep_devel=0, keep_stable=1)
+
+    kept_nv = {(brp.read_compact_manifest(p)["name"], brp.read_compact_manifest(p)["version"]) for p in kept}
+    # Stable: only newest (s3.0).
+    assert ("pfBlockerNG", "2.0.3") in kept_nv
+    assert ("pfBlockerNG", "2.0.2") not in kept_nv
+    assert ("pfBlockerNG", "2.0.1") not in kept_nv
+    # Devel: both kept.
+    assert ("pfBlockerNG-devel", "3.0.1") in kept_nv
+    assert ("pfBlockerNG-devel", "3.0.2") in kept_nv
+
+
+def test_retain_by_channel_keep_zero_is_unbounded_sentinel(tmp_path: Path) -> None:
+    """keep==0 for a channel keeps ALL of that channel (the unbounded/disabled sentinel).
+
+    Scenario: keep_devel=0, keep_stable=0
+      Given 3 devel pkgs and 3 stable pkgs
+      When retain_by_channel with both keeps=0
+      Then ALL 6 paths are returned (no pruning)
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    all_paths = [_make_pkg_channel(d, "pfBlockerNG-devel", f"3.0.{i}") for i in range(1, 4)] + [
+        _make_pkg_channel(d, "pfBlockerNG", f"2.0.{i}") for i in range(1, 4)
+    ]
+
+    # Before-state: 6 paths in.
+    assert len(all_paths) == 6
+
+    kept = brp.retain_by_channel(all_paths, keep_devel=0, keep_stable=0)
+
+    # All 6 kept.
+    assert len(kept) == 6
+    kept_versions_devel = {
+        brp.read_compact_manifest(p)["version"]
+        for p in kept
+        if brp.read_compact_manifest(p)["name"] == "pfBlockerNG-devel"
+    }
+    kept_versions_stable = {
+        brp.read_compact_manifest(p)["version"] for p in kept if brp.read_compact_manifest(p)["name"] == "pfBlockerNG"
+    }
+    assert kept_versions_devel == {"3.0.1", "3.0.2", "3.0.3"}
+    assert kept_versions_stable == {"2.0.1", "2.0.2", "2.0.3"}
+
+
+def test_retain_by_channel_keep_larger_than_bucket_is_noop(tmp_path: Path) -> None:
+    """keep >= len(bucket) is a no-op — all paths in that bucket are retained.
+
+    Scenario: keep_devel=100, keep_stable=100 with only 2 devel and 2 stable pkgs
+      Given 2 devel pkgs and 2 stable pkgs
+        And keep values far larger than the buckets
+      When retain_by_channel is called
+      Then all 4 paths are returned (no pruning)
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    dv1 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.1")
+    dv2 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.2")
+    sv1 = _make_pkg_channel(d, "pfBlockerNG", "2.0.1")
+    sv2 = _make_pkg_channel(d, "pfBlockerNG", "2.0.2")
+
+    # Before-state: 4 inputs.
+    all_paths = [dv1, dv2, sv1, sv2]
+
+    kept = brp.retain_by_channel(all_paths, keep_devel=100, keep_stable=100)
+
+    assert len(kept) == 4
+
+
+def test_retain_by_channel_version_order_deterministic(tmp_path: Path) -> None:
+    """The newest-N selection uses version order (not filesystem order or name order).
+
+    Scenario: devel pkgs with non-lexicographic versions, keep_devel=2
+      Given devel pkgs at versions 3.0.1, 3.0.9, 3.0.10 (lexicographic order differs)
+        And keep_devel=2
+      When retain_by_channel is called
+      Then 3.0.10 and 3.0.9 are kept (numerically newest 2), 3.0.1 dropped
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    # Write in reverse order so filesystem order can't accidentally "win".
+    p10 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.10")
+    p9 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.9")
+    p1 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.1")
+
+    # Before-state: all 3 present.
+    kept_all = brp.retain_by_channel([p10, p9, p1], keep_devel=0, keep_stable=0)
+    assert len(kept_all) == 3
+
+    # With keep_devel=2: 3.0.10 and 3.0.9 must survive; 3.0.1 dropped.
+    kept = brp.retain_by_channel([p10, p9, p1], keep_devel=2, keep_stable=0)
+    kept_versions = {brp.read_compact_manifest(p)["version"] for p in kept}
+    assert kept_versions == {"3.0.10", "3.0.9"}
+    assert "3.0.1" not in kept_versions
+
+
+def test_retain_by_channel_nightly_untouched(tmp_path: Path) -> None:
+    """Nightly pkgs pass through unchanged regardless of keep_devel / keep_stable.
+
+    Scenario: mixed input with devel, stable, AND nightly pkgs
+      Given 1 devel, 1 stable, 2 nightly pkgs; keep_devel=1, keep_stable=1
+      When retain_by_channel is called
+      Then devel: 1 kept (the only one)
+       And stable: 1 kept (the only one)
+       And BOTH nightly pkgs pass through — nightly is left untouched
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    dv = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.1")
+    sv = _make_pkg_channel(d, "pfBlockerNG", "2.0.1")
+    nv1 = _make_pkg_channel(d, "pfBlockerNG-nightly", "3.0.20260601.1")
+    nv2 = _make_pkg_channel(d, "pfBlockerNG-nightly", "3.0.20260602.1")
+
+    all_paths = [dv, sv, nv1, nv2]
+
+    kept = brp.retain_by_channel(all_paths, keep_devel=1, keep_stable=1)
+
+    kept_nv = {(brp.read_compact_manifest(p)["name"], brp.read_compact_manifest(p)["version"]) for p in kept}
+    # Devel: the one devel pkg kept.
+    assert ("pfBlockerNG-devel", "3.0.1") in kept_nv
+    # Stable: the one stable pkg kept.
+    assert ("pfBlockerNG", "2.0.1") in kept_nv
+    # Both nightly pkgs retained untouched.
+    assert ("pfBlockerNG-nightly", "3.0.20260601.1") in kept_nv
+    assert ("pfBlockerNG-nightly", "3.0.20260602.1") in kept_nv
+    assert len(kept) == 4
+
+
+def test_retain_by_channel_mixed_prune_nightly_untouched(tmp_path: Path) -> None:
+    """Mixed input: devel pruned, stable pruned, nightly passed through.
+
+    Scenario: prune both channels from a 3+3+2 mixed input
+      Given 3 devel pkgs, 3 stable pkgs, 2 nightly pkgs
+        And keep_devel=1, keep_stable=2
+      When retain_by_channel is called
+      Then devel: only the newest 1 kept
+       And stable: only the newest 2 kept
+       And both nightly pkgs pass through (untouched)
+       AND each channel is pruned independently (devel prune does not affect stable)
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    d1 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.1")
+    d2 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.2")
+    d3 = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.3")
+    s1 = _make_pkg_channel(d, "pfBlockerNG", "2.0.1")
+    s2 = _make_pkg_channel(d, "pfBlockerNG", "2.0.2")
+    s3 = _make_pkg_channel(d, "pfBlockerNG", "2.0.3")
+    n1 = _make_pkg_channel(d, "pfBlockerNG-nightly", "3.0.20260601.1")
+    n2 = _make_pkg_channel(d, "pfBlockerNG-nightly", "3.0.20260602.1")
+
+    # Before-state: 8 pkgs in, each channel has its full set.
+    all_paths = [d1, d2, d3, s1, s2, s3, n1, n2]
+
+    kept = brp.retain_by_channel(all_paths, keep_devel=1, keep_stable=2)
+
+    kept_nv = {(brp.read_compact_manifest(p)["name"], brp.read_compact_manifest(p)["version"]) for p in kept}
+
+    # Devel: only newest 1 (3.0.3).
+    assert ("pfBlockerNG-devel", "3.0.3") in kept_nv
+    assert ("pfBlockerNG-devel", "3.0.2") not in kept_nv
+    assert ("pfBlockerNG-devel", "3.0.1") not in kept_nv
+
+    # Stable: newest 2 (2.0.2, 2.0.3); 2.0.1 dropped.
+    assert ("pfBlockerNG", "2.0.3") in kept_nv
+    assert ("pfBlockerNG", "2.0.2") in kept_nv
+    assert ("pfBlockerNG", "2.0.1") not in kept_nv
+
+    # Nightly: both pass through.
+    assert ("pfBlockerNG-nightly", "3.0.20260601.1") in kept_nv
+    assert ("pfBlockerNG-nightly", "3.0.20260602.1") in kept_nv
+
+    # Total: 1 devel + 2 stable + 2 nightly = 5.
+    assert len(kept) == 5
+
+
+def test_retain_by_channel_empty_channel_is_noop(tmp_path: Path) -> None:
+    """An empty channel bucket is a no-op — no KeyError, no side effects.
+
+    Scenario: only stable pkgs provided, no devel, no nightly
+      Given 2 stable pkgs and keep_devel=5
+      When retain_by_channel is called
+      Then both stable pkgs are returned; no error from the empty devel bucket
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    sv1 = _make_pkg_channel(d, "pfBlockerNG", "2.0.1")
+    sv2 = _make_pkg_channel(d, "pfBlockerNG", "2.0.2")
+
+    kept = brp.retain_by_channel([sv1, sv2], keep_devel=5, keep_stable=0)
+
+    kept_nv = {(brp.read_compact_manifest(p)["name"], brp.read_compact_manifest(p)["version"]) for p in kept}
+    assert kept_nv == {("pfBlockerNG", "2.0.1"), ("pfBlockerNG", "2.0.2")}
+    assert len(kept) == 2

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -345,6 +345,101 @@ def test_older_nightlies_fold_under_each_edition() -> None:
     assert "FreeBSD:15:amd64" not in plus_section and ">26.03<" in plus_section and ">8.5<" in plus_section
 
 
+def test_older_releases_lists_retained_excludes_latest() -> None:
+    """Scenario: surface the retained older devel/stable releases, never the newest per channel.
+
+    Given three devel versions (two old + the newest) and two stable versions (one old + the
+      newest) for one ABI plus a nightly build,
+    When the older-releases list is built,
+    Then the NEWEST devel and the NEWEST stable are excluded (they are in the edition table
+      already) and the two older devel + one older stable remain; nightly is never included.
+    """
+    # Before-state: establish the newest versions ARE in the edition table (not in older-releases).
+    dev_new = _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.16", "FreeBSD:16:amd64", "d3.pkg")
+    dev_mid = _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.15", "FreeBSD:16:amd64", "d2.pkg")
+    dev_old = _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.14", "FreeBSD:16:amd64", "d1.pkg")
+    stb_new = _pkg("stable", "pfSense-pkg-pfBlockerNG", "3.1.0", "FreeBSD:16:amd64", "s2.pkg")
+    stb_old = _pkg("stable", "pfSense-pkg-pfBlockerNG", "3.0.0", "FreeBSD:16:amd64", "s1.pkg")
+    nightly = _pkg("nightly", "pfSense-pkg-pfBlockerNG-nightly", "3.2.16.20260614.9", "FreeBSD:16:amd64", "n.pkg")
+    all_pkgs = [dev_new, dev_mid, dev_old, stb_new, stb_old, nightly]
+
+    # Before: the newest versions are NOT in older_releases (they live in the edition table).
+    rows = gl.older_releases(all_pkgs)
+    versions = [(r["channel"], r["version"]) for r in rows]
+    assert ("devel", "3.2.16") not in versions  # newest devel stays out
+    assert ("stable", "3.1.0") not in versions  # newest stable stays out
+    assert ("nightly", "3.2.16.20260614.9") not in versions  # nightly never in older_releases
+
+    # After (what's retained): two older devel + one older stable.
+    assert ("devel", "3.2.15") in versions
+    assert ("devel", "3.2.14") in versions
+    assert ("stable", "3.0.0") in versions
+
+    # The packages block folds them into a disclosure under the edition table.
+    matrix = [_mx("FreeBSD:16:amd64", "2.8", "CE", "8.3", "py311")]
+    html = gl._packages_html(all_pkgs, matrix)
+    assert "<h3>pfSense CE</h3>" in html
+    assert "<details><summary>Older releases (3)</summary>" in html
+    # Disclosure sits AFTER the edition's main table (before any Older nightlies entry).
+    assert html.index("<h3>pfSense CE</h3>") < html.index("Older releases (3)")
+    details = html[html.index("Older releases (3)") :]
+    assert "3.2.15" in details and "3.2.14" in details and "3.0.0" in details
+    assert "3.2.16" not in details  # the newest devel stays out of the 'older' disclosure
+    assert "3.1.0" not in details  # the newest stable stays out of the 'older' disclosure
+    # The disclosure table carries a Channel column (devel/stable mixed) + the same edition columns.
+    assert "<th>Channel</th>" in details and "<th>pfSense</th>" in details
+
+
+def test_older_releases_empty_when_only_latest_per_channel() -> None:
+    """With only one version of each channel retained there is nothing 'older' to disclose.
+
+    This is today's default (N=M=1): only the newest devel and stable live in the catalog.
+    The disclosure is entirely absent from the rendered page — no empty affordance.
+    """
+    dev = _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.16", "FreeBSD:16:amd64", "d.pkg")
+    stb = _pkg("stable", "pfSense-pkg-pfBlockerNG", "3.1.0", "FreeBSD:16:amd64", "s.pkg")
+    nightly = _pkg("nightly", "pfSense-pkg-pfBlockerNG-nightly", "3.2.16.20260614.9", "FreeBSD:16:amd64", "n.pkg")
+
+    assert gl.older_releases([dev, stb, nightly]) == []
+    # …and the packages block omits the disclosure entirely.
+    assert "Older releases" not in gl._packages_html([dev, stb, nightly], None)
+
+
+def test_older_releases_fold_under_each_edition() -> None:
+    """Scenario: each edition's older releases fold UNDER that edition's own table.
+
+    Given retained older devel releases for BOTH a CE ABI and a Plus ABI,
+    When the packages block is rendered with a matrix covering both ABIs,
+    Then the CE older-releases disclosure sits inside the CE section (after the CE table,
+      before the Plus heading) carrying only CE rows, and the Plus one sits in the Plus
+      section carrying only Plus rows — CE section first, Channel column present in each.
+    """
+    ce_new = _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.16", "FreeBSD:15:amd64", "ce2.pkg")
+    ce_old = _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.15", "FreeBSD:15:amd64", "ce1.pkg")
+    plus_new = _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.16", "FreeBSD:16:aarch64", "p2.pkg")
+    plus_old = _pkg("devel", "pfSense-pkg-pfBlockerNG-devel", "3.2.15", "FreeBSD:16:aarch64", "p1.pkg")
+    matrix = [
+        _mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311"),
+        _mx("FreeBSD:16:aarch64", "26.03", "Plus", "8.5", "py311"),
+    ]
+
+    html = gl._packages_html([ce_new, ce_old, plus_new, plus_old], matrix)
+
+    # CE section before Plus section; each has its own folded older-releases disclosure.
+    assert html.index("<h3>pfSense CE</h3>") < html.index("<h3>pfSense Plus</h3>")
+    assert html.count("<summary>Older releases (1)</summary>") == 2  # one per edition (each ABI: 1 older)
+    # The CE section spans from its heading to the Plus heading; the Plus section follows.
+    ce_section = html[html.index("<h3>pfSense CE</h3>") : html.index("<h3>pfSense Plus</h3>")]
+    plus_section = html[html.index("<h3>pfSense Plus</h3>") :]
+    # Each edition's disclosure folds in its OWN ABI's older release, never the other's.
+    assert "Older releases (1)" in ce_section and "FreeBSD:15:amd64" in ce_section
+    assert "FreeBSD:16:aarch64" not in ce_section and ">2.8<" in ce_section and ">8.3<" in ce_section
+    assert "Older releases (1)" in plus_section and "FreeBSD:16:aarch64" in plus_section
+    assert "FreeBSD:15:amd64" not in plus_section and ">26.03<" in plus_section and ">8.5<" in plus_section
+    # Channel column present in older-releases disclosures (devel/stable can coexist).
+    assert "<th>Channel</th>" in ce_section and "<th>Channel</th>" in plus_section
+
+
 def test_build_edition_sections_unmatched_abi_falls_to_other() -> None:
     """A build whose ABI the matrix doesn't cover lands in 'Other' (manifest php/py), not hidden."""
     p = _pkg("devel", "d", "3.2.16", "FreeBSD:14:amd64", "x.pkg")


### PR DESCRIPTION
Implements **ADR-27 Part 1** (Release Rollback Retention). Part 2 (EOL route-only distribution) stays design-only per §2.4 — no Part-2 code here.

## What lands (5 phases, no `src/` — pure tooling/tests/docs)
- **P1** → `retain_by_channel()` helper (devel/stable/nightly bucketing, reuses `_retain_newest`, opt-in per channel) + branch tests. Behaviour-preserving.
- **P2** → `build_repo_matrix` retains N devel + M stable via `--release-keep-devel/-stable` (+ `--release-extra-pkgs`); defaults `1/1` = today's latest-only (inert).
- **P3** → input contract + `README`/`scripts/README` docs + CLI dry-run tests; the `pfBlockerNG/pkg` `publish.yml` change is **specified in the handoff** (not in this diff).
- **P4** → live-VM `-m repo` rollback lifecycle test (newest-wins → `pkg install -f <name>-<older>` → re-upgrade, deps resolved from our repo).
- **P5** → `gen_landing.py` per-edition "Older releases" disclosure + tests; rollback config-schema caveat.

## ✅ §7 acceptance gate — green
The live `-m repo` smoke is **green** on the CE leg (run [27802532591](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/27802532591)): install-newest → pin-rollback to a retained older version (deps resolved from our repo) → re-upgrade, lifecycle closed. Two live-only findings were fixed along the way:
- forged versions must use a numeric PORTREVISION suffix (`_1`/`_9`) — pkg sorts a non-numeric suffix alphabetically;
- rollback requires `pkg install -f` — a plain `pkg install <name>-<older>` is a no-op over a newer installed build (docs/UX updated accordingly).

Off-box suite green (**1756 passed**), ruff/markdownlint/mypy clean.

Re ADR-27 (re-scoped: rollback GUI dropped, CLI + landing-disclosure only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GighgrxzgA8pzAPtS66iCK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release rollback: pin and install older stable/devel package versions within the configured retention window.
  * Multi-version retention: stable/devel catalogs retain multiple newest builds, with configurable depth and optional inclusion of pre-built older package assets; nightly remains pass-through.
* **Documentation**
  * Updated README and generator guidance, including the landing page “Older releases” disclosure and forced-downgrade rollback instructions.
* **Bug Fixes**
  * Corrected forced downgrade behavior and fixed retained-version ordering issues.
* **Tests**
  * Added unit, CLI, and VM smoke-test coverage for retention, pruning, landing rendering, and end-to-end rollback/upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->