### PR TITLE
pfblockerng: gate the background version check on the Software page's provenance predicate

### DIFF
--- a/.ADRs/ADR_19_Update_Channel_Panel/ADR.md
+++ b/.ADRs/ADR_19_Update_Channel_Panel/ADR.md
@@ -29,6 +29,8 @@
 >    channelled build. "Read latest" maps channel -> repo: stable/devel -> `-r pfblockerng`,
 >    nightly -> `-r pfblockerng-nightly`.
 
+**Amendment (2026-06-19):** The background cron check now gates on `pfb_software_provenance_ok()` — the same predicate that gates the Software page's visibility — so the page and the background check share one displayability condition. A build that is not page-displayable (not installed from our repo, or overridden off) performs no background check and raises no update notice, even if "Check for new versions" remains enabled from a prior our-repo install.
+
 - **Status:** **Accepted** (2026-06-15) — landed on `devel` (PR #232, rebase-merged);
   validated by the off-box gates + the live-VM `repo` positive journey and the `ui_render`
   negative gate. No separate manual maintainer sign-off is required per the CLAUDE.md

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2229,13 +2229,15 @@ function pfb_software_write_cache(array $cache): void {
  * The cron-driven software-update check (ADR-19 §2 "Background check").
  *
  * Order is deliberate:
- *   1. Resolve installed name + version + the repo it came FROM. The repo can be
- *      injected for unit tests via $io ['installed_name','installed','installed_repo',
- *      'latest']; absent keys fall through to the live pfb_pkg_*() shellout.
- *   2. PROVENANCE GATE FIRST (2026-06-15 amendment): pfb_software_is_our_build() on the
- *      installed repo. A Netgate-installed build (repo 'pfSense'/unknown/empty) is a
- *      complete no-op — NO catalog read, NO cache write, NO file_notice — Netgate's own
- *      badge serves those users.
+ *   1. Resolve installed name + version. These can be injected for unit tests via
+ *      $io ['installed_name','installed','latest']; absent keys fall through to the
+ *      live pfb_pkg_*() shellout.
+ *   2. PROVENANCE GATE FIRST: gate on pfb_software_provenance_ok() — the SAME predicate
+ *      that decides whether the Software PAGE is displayable (our-repo install, honouring
+ *      the hidden CI/support override) — so a build that cannot show the page never runs
+ *      the background check or raises an update notice, even if "Check for new versions"
+ *      remains enabled from a prior our-repo install. Injectable via $io['provenance_ok']
+ *      for off-box tests.
  *   3. Read our-repo latest for the channel's repo (guarded inside pfb_pkg_latest()).
  *      An empty latest (pkg locked / no DNS / repo absent) preserves the cached latest so
  *      the page keeps showing the last-known value rather than regressing to ''.
@@ -2257,12 +2259,16 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 	$installed = array_key_exists('installed', $io)
 		? (string) $io['installed']
 		: pfb_pkg_installed_version($pkgname);
-	$installed_repo = array_key_exists('installed_repo', $io)
-		? (string) $io['installed_repo']
-		: pfb_pkg_installed_repo($pkgname);
 
-	// 2. Provenance gate FIRST — a Netgate-installed build does nothing at all.
-	if (!pfb_software_is_our_build($installed_repo)) {
+	// 2. Provenance gate FIRST — gate on the SAME predicate that decides whether the Software
+	// PAGE is displayable (pfb_software_provenance_ok(): our-repo install, honouring the
+	// hidden CI/support override), so a build that cannot show the page never runs the
+	// background check or notifies — even if "Check for new versions" is still enabled from a
+	// prior our-repo install. Injectable via $io['provenance_ok'] for off-box tests.
+	$provenance_ok = array_key_exists('provenance_ok', $io)
+		? (bool) $io['provenance_ok']
+		: pfb_software_provenance_ok();
+	if (!$provenance_ok) {
 		return pfb_software_read_cache();
 	}
 

--- a/tests/php/SoftwareUpdateCheckTest.php
+++ b/tests/php/SoftwareUpdateCheckTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\Attributes\CoversFunction;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -11,17 +10,20 @@ use PHPUnit\Framework\TestCase;
  * + the cache helpers, with the pkg IO INJECTED (no real `pkg` off-appliance).
  *
  * Scenario: a cron tick reads installed-vs-our-repo-latest, writes a cache, and raises a
- * de-duped file_notice — but ONLY on a build installed from one of OUR repos.
+ * de-duped file_notice — but ONLY on a build that is page-displayable (provenance_ok).
  *
  * Background: the pure decision core (Phase 2) is already pinned; here we pin the
- * SIDE-EFFECTS — the provenance gate (no-op on a Netgate build), the pkg-lock / no-DNS
- * short-circuits (serve cache, no network, no error), the cache contents, and the
+ * SIDE-EFFECTS — the provenance gate (no-op on a non-displayable build), the pkg-lock /
+ * no-DNS short-circuits (serve cache, no network, no error), the cache contents, and the
  * per-version de-dupe across ticks. Every branch asserts the BEFORE-state (cache present?
  * notice fired?) and the AFTER-state so green proves the side-effect was CAUSED by the
  * input, not pre-existing.
  *
- * The IO is doubled by passing $io = ['installed_name','installed','installed_repo',
- * 'latest'] to the orchestrator (its documented unit-test seam). file_notice /
+ * The IO is doubled by passing $io = ['installed_name','installed','provenance_ok','latest']
+ * to the orchestrator (its documented unit-test seam). 'provenance_ok' (bool) replaces the
+ * old 'installed_repo' key: the orchestrator now delegates repo-string discrimination to
+ * pfb_software_provenance_ok() (the page-displayability predicate); per-repo branch coverage
+ * for pfb_software_is_our_build() lives in SoftwareUpdateDecisionTest. file_notice /
  * is_subsystem_dirty / get_dnsavailable are doubled in pfsense_doubles.php, driven via
  * $GLOBALS (pfb_test_file_notices / pfb_test_pkg_locked / pfb_test_dns_available).
  */
@@ -93,22 +95,29 @@ final class SoftwareUpdateCheckTest extends TestCase
 		];
 	}
 
-	private function ourBuildIo(string $installed, string $latest, string $repo = 'pfblockerng', string $name = 'pfSense-pkg-pfBlockerNG-devel'): array
+	private function ourBuildIo(string $installed, string $latest, string $name = 'pfSense-pkg-pfBlockerNG-devel'): array
 	{
 		return [
 			'installed_name' => $name,
 			'installed'      => $installed,
-			'installed_repo' => $repo,
+			'provenance_ok'  => TRUE,
 			'latest'         => $latest,
 		];
 	}
 
 	/*
-	 * ---- Provenance gate (the 2026-06-15 amendment) — BOTH sides ----
+	 * ---- Provenance gate — BOTH sides ----
+	 *
+	 * The gate is now pfb_software_provenance_ok() — the same predicate that controls
+	 * whether the Software PAGE is displayable — injected as $io['provenance_ok'] (bool).
+	 * Per-repo branch coverage for pfb_software_is_our_build() lives in
+	 * SoftwareUpdateDecisionTest; here we pin the ORCHESTRATOR's behaviour on each side
+	 * of the boolean, including the real-world case (enabled flag left over from a prior
+	 * our-repo install, user has since switched back to Netgate).
 	 */
 
 	/**
-	 * Given a build installed from OUR repo with a newer version available,
+	 * Given a page-displayable build (provenance_ok=true) with a newer version available,
 	 * When the check runs,
 	 * Then it writes the cache AND reaches a notify decision (a notice fires under an
 	 * ON knob). This is the "feature present" side of the gate.
@@ -137,38 +146,104 @@ final class SoftwareUpdateCheckTest extends TestCase
 	}
 
 	/**
-	 * Given a build installed from the Netgate ports repo ('pfSense') — or any non-our
-	 * origin — with a newer version nominally available,
+	 * Given a non-displayable build (provenance_ok=false) with a newer version nominally
+	 * available and "Check for new versions" ON,
 	 * When the check runs,
-	 * Then it is a COMPLETE no-op: no cache is written and no notice is raised. This is
-	 * the "feature absent on a stock build" side of the gate; it must be the FIRST thing
-	 * the check does.
+	 * Then it is a COMPLETE no-op: no cache is written and no notice is raised. This is the
+	 * "feature absent" side of the gate. Per-repo discrimination (which repo strings yield
+	 * false) is pinned in SoftwareUpdateDecisionTest::testSoftwareIsOurBuild.
 	 */
-	#[DataProvider('foreignRepoProvider')]
-	public function testNetgateBuildIsCompleteNoOp(string $repo): void
+	public function testNonDisplayableBuildIsCompleteNoOp(): void
 	{
 		// Given: ON knob (would notify if the gate let it through), clean before-state.
 		$this->setCheck('on');
 		$this->assertNull($this->readCache(), 'before: no cache file');
 		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice');
 
-		// When: an update IS nominally available, but the build is not ours.
-		$io = $this->ourBuildIo('3.2.0_1', '3.2.0_9', $repo);
+		// When: an update IS nominally available, but the build is not page-displayable.
+		$io = [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
+			'installed'      => '3.2.0_1',
+			'provenance_ok'  => FALSE,
+			'latest'         => '3.2.0_9',
+		];
 		pfb_software_update_check(false, $io);
 
 		// Then: nothing happened — no cache write, no notice.
-		$this->assertNull($this->readCache(), 'after: Netgate build must NOT write a cache');
-		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: Netgate build raises NO notice');
+		$this->assertNull($this->readCache(), 'after: non-displayable build must NOT write a cache');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: non-displayable build raises NO notice');
 	}
 
-	public static function foreignRepoProvider(): array
+	/**
+	 * Regression test: a user who was on our build (so "Check for new versions" is
+	 * still 'on') switches back to the Netgate-installed build. The enabled flag persists
+	 * in config but provenance_ok is now false — the background check must be a complete
+	 * no-op regardless of the enabled setting.
+	 *
+	 * Given: "Check for new versions" ON (persisted from the prior our-repo install),
+	 *        a newer version nominally available,
+	 *        but provenance_ok=false (the build is no longer ours).
+	 * When the background check runs,
+	 * Then it is a complete no-op (no cache written, no notice raised) — the enabled flag
+	 * is irrelevant once the provenance gate closes.
+	 */
+	public function testEnabledButNotDisplayableDoesNotCheckOrNotify(): void
 	{
-		return [
-			'Netgate ports repo' => ['pfSense'],
-			'empty/unknown'      => [''],
-			'literal unknown'    => ['unknown'],
-			'a decoy repo'       => ['netgate-decoy'],
+		// Given: setting is still ON from the prior our-repo install; clean before-state.
+		$this->setCheck('on');
+		$this->assertNull($this->readCache(), 'before: no cache file');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice');
+
+		// When: provenance gate is closed (user moved back to Netgate's build).
+		$io = [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
+			'installed'      => '3.2.0_1',
+			'provenance_ok'  => FALSE,
+			'latest'         => '3.2.0_9',
 		];
+		pfb_software_update_check(false, $io);
+
+		// Then: complete no-op — neither the cache nor any notice was written.
+		$this->assertNull($this->readCache(), 'after: no cache despite enabled flag (gate is closed)');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: no notice despite enabled flag');
+	}
+
+	/**
+	 * Transition test — proves the provenance gate is a real branch, not an always-on path.
+	 *
+	 * BEFORE (provenance_ok=false): same enabled + update-available inputs → complete no-op.
+	 * AFTER  (provenance_ok=true):  same inputs → cache written + notice raised.
+	 *
+	 * Green proves the gate flip (not pre-existing state) caused the behaviour change.
+	 */
+	public function testProvenanceGateTransition(): void
+	{
+		$this->setCheck('on');
+
+		// BEFORE: gate closed → complete no-op.
+		$this->assertNull($this->readCache(), 'before gate flip: no cache');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before gate flip: no notice');
+
+		$closedIo = [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
+			'installed'      => '3.2.0_1',
+			'provenance_ok'  => FALSE,
+			'latest'         => '3.2.0_9',
+		];
+		pfb_software_update_check(false, $closedIo);
+		$this->assertNull($this->readCache(), 'gate closed: no cache written');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'gate closed: no notice raised');
+
+		// AFTER: gate open → cache written + notice raised.
+		$openIo = [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
+			'installed'      => '3.2.0_1',
+			'provenance_ok'  => TRUE,
+			'latest'         => '3.2.0_9',
+		];
+		pfb_software_update_check(false, $openIo);
+		$this->assertNotNull($this->readCache(), 'gate open: cache must be written');
+		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'gate open: notice must fire');
 	}
 
 	/*
@@ -209,7 +284,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 		$cache = pfb_software_update_check(false, [
 			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
 			'installed'      => '3.2.0_1',
-			'installed_repo' => 'pfblockerng',
+			'provenance_ok'  => TRUE,
 			// note: NO 'latest' key -> forces the guarded live read.
 		]);
 
@@ -242,7 +317,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 		$cache = pfb_software_update_check(false, [
 			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
 			'installed'      => '3.2.0_1',
-			'installed_repo' => 'pfblockerng',
+			'provenance_ok'  => TRUE,
 		]);
 
 		$this->assertSame('3.2.0_9', $cache['latest'], 'after: cached latest preserved when no DNS');
@@ -277,7 +352,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 		$cache = pfb_software_update_check(false, [
 			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
 			'installed'      => '3.2.0_1',
-			'installed_repo' => 'pfblockerng',
+			'provenance_ok'  => TRUE,
 			// no 'latest' -> guarded live read returns '' (pkg locked).
 		]);
 


### PR DESCRIPTION
## Summary

Ties the ADR-19 background (cron) software-update check to the **same predicate that gates the Software page's visibility**, so "the page is displayable" and "the background check runs" are one condition by construction.

Previously `pfb_software_update_check()` had its own provenance gate (`pfb_software_is_our_build()` on the raw `pkg query '%R'` repo), separate from the page's `pfb_software_provenance_ok()`. The two could drift (the page additionally honors the hidden CI/support override). This unifies them: the cron now gates on `pfb_software_provenance_ok()`.

## Behaviour

- **Installed from our repo (page displayable):** the check + notifications may run, gated by the user's "Check for new versions" setting (unchanged).
- **Not our build (page not displayable):** no background check, no `pkg` read, no update notice — **even if `Check for new versions` is still `on`** from a prior our-repo install. This is the real-world case: a user moves from our build back to Netgate's; the enabled flag persists in config but must no longer notify.

On a production box with no override sentinel this is **behaviour-identical** to before — it unifies the two gates and pins the requirement with tests; the only added effect is that the hidden `.pfb_software_panel` override now suppresses the cron too, consistent with the page.

## Changes

- `src/usr/local/pkg/pfblockerng/pfblockerng.inc` — `pfb_software_update_check()`: the provenance gate now resolves `pfb_software_provenance_ok()` (injectable via `$io['provenance_ok']` for off-box tests), replacing the inline `pfb_software_is_our_build($installed_repo)`. Docblock updated. `pfb_software_is_our_build()` is unchanged (still used inside `pfb_software_provenance_ok()`).
- `tests/php/SoftwareUpdateCheckTest.php` — migrated to the `provenance_ok` seam; added `testEnabledButNotDisplayableDoesNotCheckOrNotify` (the switch-back regression) and `testProvenanceGateTransition` (before/after, proving the gate is a real branch). Per-repo discrimination of `pfb_software_is_our_build()` remains covered in `SoftwareUpdateDecisionTest`.
- `.ADRs/ADR_19_Update_Channel_Panel/ADR.md` — amendment note recording the unification.

## Verification

`php -l` clean · `vendor/bin/phpunit` 646 tests / 1411 assertions green · PHPStan no errors · PHPCS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9eEPiZPP6wQUBh762dkTk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Background software update checks are now gated by the same condition that determines whether the Software page is shown. Non-displayable builds will not run background checks or raise update notices, even if automatic version checking was previously enabled.
* **Tests**
  * Updated and expanded software update-check test coverage to validate the new provenance gating and state transitions.
* **Documentation**
  * Updated the relevant update-notice behavior notes to reflect the new gating logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->