### PR TITLE
scripts: add Redmine-to-GitHub issue migration tool + workflow

### DIFF
--- a/.github/workflows/redmine-import.yml
+++ b/.github/workflows/redmine-import.yml
@@ -1,0 +1,100 @@
+name: Redmine Issue Import
+
+# Manually-dispatched workflow to migrate open pfBlockerNG issues from the
+# pfSense Redmine tracker (https://redmine.pfsense.org) to GitHub issues on
+# this repository.
+#
+# Prerequisites:
+#   REDMINE_API_KEY — repo secret; your Redmine API key from
+#                     https://redmine.pfsense.org/my/account
+#   GITHUB_TOKEN   — the workflow's built-in token (issues: write is granted
+#                    below).  To author issues as a specific user instead of
+#                    github-actions[bot], replace GITHUB_TOKEN with a PAT
+#                    secret (e.g. MIGRATION_PAT) that has repo scope.
+#
+# Safety: dry_run defaults to "true" so the first run previews what WOULD be
+# migrated without writing anything.  Set dry_run to "false" to execute.
+#
+# Idempotency: re-runs are safe.  Issues already on GitHub are identified by a
+# hidden marker in the body; missing comments are filled in; nothing is
+# duplicated.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: >
+          If 'true', log what WOULD be migrated but make no writes to GitHub.
+          Defaults to 'true' — change to 'false' to actually migrate issues.
+        required: false
+        default: "true"
+      limit:
+        description: >
+          Maximum number of Redmine issues to process in this run.
+          Leave empty to process all open issues.
+        required: false
+        default: ""
+      updated_after:
+        description: >
+          Only process Redmine issues updated after this date (YYYY-MM-DD,
+          exclusive).  Leave empty to process all open issues regardless of
+          update date.
+        required: false
+        default: ""
+      issue_id:
+        description: >
+          Migrate a single Redmine issue by its numeric ID.  Useful for
+          testing the migration of one specific issue.  Leave empty to
+          process all open issues (subject to limit/updated_after).
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+# Serialize runs: never let two dispatches race the "discover existing imports"
+# vs "create issue" window (which could duplicate issues). Queue, don't cancel.
+concurrency:
+  group: redmine-import
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Migrate Redmine issues to GitHub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run Redmine → GitHub migration
+        env:
+          REDMINE_API_KEY: ${{ secrets.REDMINE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # Pass dispatch inputs via env (not inline ${{ }} in the script) so an
+          # input value can never be substituted into the shell command itself.
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          LIMIT: ${{ github.event.inputs.limit }}
+          UPDATED_AFTER: ${{ github.event.inputs.updated_after }}
+          ISSUE_ID: ${{ github.event.inputs.issue_id }}
+        run: |
+          set -eu
+          ARGS=""
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          if [ -n "$LIMIT" ]; then
+            ARGS="$ARGS --limit $LIMIT"
+          fi
+          if [ -n "$UPDATED_AFTER" ]; then
+            ARGS="$ARGS --updated-after $UPDATED_AFTER"
+          fi
+          if [ -n "$ISSUE_ID" ]; then
+            ARGS="$ARGS --issue $ISSUE_ID"
+          fi
+          # shellcheck disable=SC2086
+          python scripts/redmine_to_github.py $ARGS

--- a/scripts/redmine_to_github.py
+++ b/scripts/redmine_to_github.py
@@ -1,0 +1,839 @@
+#!/usr/bin/env python3
+# redmine_to_github.py — migrate open pfBlockerNG issues from the pfSense
+# Redmine instance (https://redmine.pfsense.org) to GitHub issues on this repo,
+# preserving comment threads.
+#
+# Each Redmine journal note becomes its own GitHub comment, headed with the
+# original author + date, in chronological order.
+#
+# Idempotency: a re-run skips already-migrated issues and fills in any missing
+# comments, so a half-finished migration is safely completed.  Mechanism:
+#   - Issue body carries  <!-- redmine-id: {ID} -->
+#   - Each comment ends with  <!-- redmine-journal-id: {JID} -->
+# Existing GH issues are discovered via the "redmine-imported" label; existing
+# comments are discovered by parsing their journal-id markers.
+#
+# Run via the workflow:
+#   .github/workflows/redmine-import.yml
+# or locally (requires REDMINE_API_KEY + GITHUB_TOKEN in env):
+#   python scripts/redmine_to_github.py [--dry-run] [--limit N] ...
+"""
+Migrate open pfBlockerNG Redmine issues to GitHub, preserving comment threads.
+
+Each Redmine journal note becomes a separate GitHub comment with original author
+and date.  Re-runs are idempotent: issues are not duplicated, and any missing
+comments are posted.
+
+Usage:
+  REDMINE_API_KEY=... GITHUB_TOKEN=... python scripts/redmine_to_github.py
+  python scripts/redmine_to_github.py --dry-run
+  python scripts/redmine_to_github.py --issue 12345 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable
+from datetime import date, datetime
+from typing import NamedTuple
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+_REDMINE_BASE_URL = "https://redmine.pfsense.org"
+_REDMINE_PROJECT = "pfsense-packages"
+_REDMINE_CATEGORY_ID = 97  # pfBlockerNG
+
+_GH_API_BASE = "https://api.github.com"
+_GH_API_VERSION = "2022-11-28"
+
+# Pause between HTTP requests (seconds).  Keeps us polite on both APIs.
+_DEFAULT_SLEEP = 0.5
+
+# Maximum retries on GitHub secondary-rate-limit (403/429).
+_GH_RATE_RETRIES = 4
+
+_UA = "pfBlockerNG-redmine-migrator/1.0 (https://github.com/pfBlockerNG/pfBlockerNG)"
+
+# ── Label configuration (edit here to customise) ──────────────────────────────
+
+# Tracker → GitHub label.
+_TRACKER_LABELS: dict[str, str] = {
+    "Bug": "bug",
+    "Feature": "enhancement",
+    "Feature request": "enhancement",
+}
+
+# Priority → GitHub label (Redmine priority name → label name).
+_PRIORITY_LABELS: dict[str, str] = {
+    "Low": "priority: low",
+    "Normal": "priority: normal",
+    "High": "priority: high",
+    "Urgent": "priority: urgent",
+    "Immediate": "priority: immediate",
+}
+
+# Keywords in subject/description → additional topic labels.
+# Order is preserved in the output; keys are lowercased before comparison.
+_KEYWORD_LABELS: dict[str, str] = {
+    "unbound": "unbound",
+    "dnsbl": "dnsbl",
+    "cron": "cron",
+    "performance": "performance",
+    "sync": "sync",
+    "geoip": "geoip",
+    "python": "python",
+    "ipv6": "ipv6",
+    "blocklist": "blocklist",
+    "whitelist": "whitelist",
+    "allowlist": "allowlist",
+    "safesearch": "safesearch",
+}
+
+# Label metadata for pre-creation (name → (hex_color, description)).
+_LABEL_META: dict[str, tuple[str, str]] = {
+    "redmine-imported": ("e4e669", "Migrated from Redmine (pfsense.org)"),
+    "bug": ("d73a4a", "Something is not working"),
+    "enhancement": ("a2eeef", "New feature or improvement request"),
+    "priority: low": ("bfd4f2", "Redmine priority: low"),
+    "priority: normal": ("bfd4f2", "Redmine priority: normal"),
+    "priority: high": ("e11d48", "Redmine priority: high"),
+    "priority: urgent": ("b91c1c", "Redmine priority: urgent"),
+    "priority: immediate": ("7f1d1d", "Redmine priority: immediate"),
+}
+
+# ── Pure helpers ───────────────────────────────────────────────────────────────
+
+
+def map_labels(issue: dict) -> list[str]:
+    """Return GitHub labels for a Redmine issue dict.
+
+    Always includes ``redmine-imported``.  Maps tracker → bug/enhancement;
+    priority → ``priority: <name>``; and scans subject + description for
+    keyword topics.  Result is deduped and in stable order.
+    """
+    labels: list[str] = ["redmine-imported"]
+
+    tracker_name: str = (issue.get("tracker") or {}).get("name", "")
+    if tracker_name in _TRACKER_LABELS:
+        labels.append(_TRACKER_LABELS[tracker_name])
+
+    priority_name: str = (issue.get("priority") or {}).get("name", "")
+    if priority_name in _PRIORITY_LABELS:
+        labels.append(_PRIORITY_LABELS[priority_name])
+
+    # Keyword scan over subject + description.
+    haystack = " ".join(
+        [
+            issue.get("subject", "") or "",
+            issue.get("description", "") or "",
+        ]
+    ).lower()
+    for keyword, label in _KEYWORD_LABELS.items():
+        if keyword in haystack:
+            labels.append(label)
+
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    result: list[str] = []
+    for lbl in labels:
+        if lbl not in seen:
+            seen.add(lbl)
+            result.append(lbl)
+    return result
+
+
+def render_issue_body(issue: dict, redmine_base_url: str) -> str:
+    """Return a GitHub-Markdown body for a Redmine issue.
+
+    Includes a metadata block, the original description verbatim, an optional
+    Attachments section, a back-link to the Redmine issue, and the hidden
+    idempotency marker ``<!-- redmine-id: {id} -->``.
+    """
+    issue_id: int = issue["id"]
+    url = f"{redmine_base_url.rstrip('/')}/issues/{issue_id}"
+
+    def _name(obj: object) -> str:
+        if isinstance(obj, dict):
+            return obj.get("name", "") or "—"
+        return "—"
+
+    def _field(obj: object, key: str = "name") -> str:
+        if isinstance(obj, dict):
+            v = obj.get(key, "")
+            return str(v) if v else "—"
+        return "—"
+
+    tracker = _name(issue.get("tracker"))
+    status = _name(issue.get("status"))
+    priority = _name(issue.get("priority"))
+    category = _name(issue.get("category"))
+    author = _field(issue.get("author"))
+    assignee = _field(issue.get("assigned_to"))
+    created = _fmt_date(issue.get("created_on", ""))
+    updated = _fmt_date(issue.get("updated_on", ""))
+
+    description: str = (issue.get("description") or "").strip()
+
+    lines: list[str] = [
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Redmine ID | [{issue_id}]({url}) |",
+        f"| Tracker | {tracker} |",
+        f"| Status | {status} |",
+        f"| Priority | {priority} |",
+        f"| Category | {category} |",
+        f"| Author | {author} |",
+        f"| Assignee | {assignee} |",
+        f"| Created | {created} |",
+        f"| Updated | {updated} |",
+        "",
+        "---",
+        "",
+    ]
+
+    if description:
+        lines += [description, ""]
+
+    # Attachments
+    attachments: list[dict] = issue.get("attachments") or []
+    if attachments:
+        lines += ["**Attachments:**", ""]
+        for att in attachments:
+            fname: str = att.get("filename", "") or att.get("id", "attachment")
+            content_url: str = att.get("content_url", "") or att.get("url", "")
+            if content_url:
+                lines.append(f"- [{fname}]({content_url})")
+            else:
+                lines.append(f"- {fname}")
+        lines.append("")
+
+    lines += [
+        "---",
+        "",
+        f"*Migrated from [Redmine #{issue_id}]({url})*",
+        "",
+        f"<!-- redmine-id: {issue_id} -->",
+    ]
+
+    return "\n".join(lines)
+
+
+def render_comment_body(journal: dict) -> str:
+    """Return the GitHub comment body for a Redmine journal entry.
+
+    Format: attribution header, the notes verbatim, and the hidden idempotency
+    marker ``<!-- redmine-journal-id: {id} -->``.
+    """
+    journal_id: int = journal["id"]
+    author: str = (journal.get("user") or {}).get("name", "") or "Unknown"
+    created_on: str = _fmt_date(journal.get("created_on", ""))
+    notes: str = (journal.get("notes") or "").strip()
+
+    return "\n".join(
+        [
+            f"**{author}** commented on Redmine — {created_on}",
+            "",
+            notes,
+            "",
+            f"<!-- redmine-journal-id: {journal_id} -->",
+        ]
+    )
+
+
+def parse_redmine_id(issue_body: str) -> int | None:
+    """Extract the Redmine issue ID from a GH issue body marker.
+
+    Returns the integer id, or None if the marker is absent or malformed.
+    """
+    m = re.search(r"<!--\s*redmine-id:\s*(\d+)\s*-->", issue_body)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def parse_posted_journal_ids(comment_bodies: Iterable[str]) -> set[int]:
+    """Return the set of Redmine journal IDs already posted as GH comments.
+
+    Scans each comment body for ``<!-- redmine-journal-id: N -->`` markers.
+    """
+    ids: set[int] = set()
+    for body in comment_bodies:
+        for m in re.finditer(r"<!--\s*redmine-journal-id:\s*(\d+)\s*-->", body):
+            ids.add(int(m.group(1)))
+    return ids
+
+
+def note_journals(journals: list[dict]) -> list[dict]:
+    """Return journals that carry a non-empty note, in chronological order.
+
+    Attribute-only journals (empty ``notes`` field) are dropped.
+    """
+    noted = [j for j in journals if (j.get("notes") or "").strip()]
+    return sorted(noted, key=lambda j: (j.get("created_on") or "", j["id"]))
+
+
+def missing_journals(journals: list[dict], posted_ids: set[int]) -> list[dict]:
+    """Return note-journals whose id is not in ``posted_ids``, chronologically.
+
+    This is the comment-level idempotency core: given all note-journals for a
+    Redmine issue and the set of journal IDs already posted to GitHub, return
+    only the ones that still need to be created.
+    """
+    noted = note_journals(journals)
+    return [j for j in noted if j["id"] not in posted_ids]
+
+
+def issue_updated_after(issue: dict, cutoff: date) -> bool:
+    """Return True if the Redmine issue's ``updated_on`` is strictly after ``cutoff``."""
+    raw: str = issue.get("updated_on", "") or ""
+    if not raw:
+        return False
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return dt.date() > cutoff
+    except ValueError:
+        return False
+
+
+def _fmt_date(raw: str) -> str:
+    """Format a Redmine ISO datetime string to a short ``YYYY-MM-DD`` date.
+
+    Returns the raw string unchanged if it cannot be parsed.
+    """
+    if not raw:
+        return "—"
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d")
+    except ValueError:
+        return raw
+
+
+# ── HTTP layer ─────────────────────────────────────────────────────────────────
+
+
+class _HTTPError(Exception):
+    """Raised when an HTTP request returns an unexpected status code."""
+
+    def __init__(self, status: int, url: str, body: str) -> None:
+        super().__init__(f"HTTP {status} for {url}")
+        self.status = status
+        self.url = url
+        self.body = body
+
+
+def _http_json(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    body: bytes | None = None,
+    sleep_seconds: float = _DEFAULT_SLEEP,
+) -> dict:
+    """Make a JSON HTTP request and return parsed response body.
+
+    Retries on GitHub secondary-rate-limit (403/429 with Retry-After) up to
+    ``_GH_RATE_RETRIES`` times.  Raises ``_HTTPError`` on non-2xx after retries.
+    """
+    all_headers = {
+        "User-Agent": _UA,
+        "Accept": "application/json",
+        **headers,
+    }
+    if body is not None:
+        all_headers["Content-Type"] = "application/json"
+
+    last_exc: Exception | None = None
+    for attempt in range(_GH_RATE_RETRIES + 1):
+        req = urllib.request.Request(url, method=method, headers=all_headers, data=body)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                raw = resp.read()
+                if not raw:
+                    return {}
+                return json.loads(raw)
+        except urllib.error.HTTPError as exc:
+            status = exc.code
+            resp_body = exc.read().decode("utf-8", errors="replace")
+            # Retry ONLY on a genuine rate-limit signal: any 429, or a GitHub 403
+            # that carries Retry-After (its secondary-rate-limit shape). A Redmine
+            # auth/permission 403 has no Retry-After and must fail fast, not sleep.
+            retry_after_hdr = exc.headers.get("Retry-After")
+            is_github = url.startswith(_GH_API_BASE)
+            rate_limited = status == 429 or (status == 403 and is_github and retry_after_hdr is not None)
+            if rate_limited and attempt < _GH_RATE_RETRIES:
+                retry_after = int(retry_after_hdr) if retry_after_hdr else 60
+                logging.warning(
+                    "Rate limit on %s (HTTP %s); waiting %s s (attempt %s/%s)",
+                    url,
+                    status,
+                    retry_after,
+                    attempt + 1,
+                    _GH_RATE_RETRIES,
+                )
+                time.sleep(retry_after)
+                last_exc = exc
+                continue
+            raise _HTTPError(status, url, resp_body) from exc
+        except urllib.error.URLError as exc:
+            raise _HTTPError(0, url, str(exc)) from exc
+        finally:
+            if attempt == 0 and sleep_seconds > 0:
+                time.sleep(sleep_seconds)
+
+    assert last_exc is not None
+    raise _HTTPError(0, url, f"Exhausted retries: {last_exc}") from last_exc
+
+
+# ── Redmine API ────────────────────────────────────────────────────────────────
+
+
+def fetch_open_issue_ids(
+    redmine_base_url: str,
+    api_key: str,
+    sleep_seconds: float = _DEFAULT_SLEEP,
+) -> list[int]:
+    """Return all open pfBlockerNG Redmine issue IDs (paginated)."""
+    headers = {"X-Redmine-API-Key": api_key}
+    ids: list[int] = []
+    limit = 100
+    offset = 0
+
+    while True:
+        url = (
+            f"{redmine_base_url.rstrip('/')}/issues.json"
+            f"?project_id={_REDMINE_PROJECT}"
+            f"&category_id={_REDMINE_CATEGORY_ID}"
+            f"&status_id=o"
+            f"&limit={limit}"
+            f"&offset={offset}"
+        )
+        data = _http_json("GET", url, headers, sleep_seconds=sleep_seconds)
+        issues: list[dict] = data.get("issues") or []
+        for iss in issues:
+            ids.append(iss["id"])
+
+        total_count: int = data.get("total_count", 0)
+        offset += len(issues)
+        if not issues or offset >= total_count:
+            break
+
+    return ids
+
+
+def fetch_issue_detail(
+    issue_id: int,
+    redmine_base_url: str,
+    api_key: str,
+    sleep_seconds: float = _DEFAULT_SLEEP,
+) -> dict:
+    """Return the full Redmine issue dict including journals and attachments."""
+    url = f"{redmine_base_url.rstrip('/')}/issues/{issue_id}.json?include=journals,attachments"
+    data = _http_json("GET", url, {"X-Redmine-API-Key": api_key}, sleep_seconds=sleep_seconds)
+    return data.get("issue") or {}
+
+
+# ── GitHub REST API ────────────────────────────────────────────────────────────
+
+
+def _gh_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": _GH_API_VERSION,
+    }
+
+
+def ensure_label(
+    name: str,
+    color: str,
+    description: str,
+    owner_repo: str,
+    token: str,
+    sleep_seconds: float = _DEFAULT_SLEEP,
+) -> None:
+    """Create a GitHub label if it does not already exist.
+
+    A 422 "already exists" response is silently accepted.
+    """
+    url = f"{_GH_API_BASE}/repos/{owner_repo}/labels"
+    body = json.dumps({"name": name, "color": color, "description": description}).encode()
+    try:
+        _http_json("POST", url, _gh_headers(token), body=body, sleep_seconds=sleep_seconds)
+        logging.debug("Created label %r", name)
+    except _HTTPError as exc:
+        if exc.status == 422:
+            logging.debug("Label %r already exists", name)
+        else:
+            logging.warning("Could not create label %r: %s", name, exc)
+
+
+def list_imported_issues(
+    owner_repo: str,
+    token: str,
+    sleep_seconds: float = _DEFAULT_SLEEP,
+) -> dict[int, int]:
+    """Return a mapping of Redmine issue ID → GitHub issue number.
+
+    Fetches all GH issues labelled ``redmine-imported`` (all states) and parses
+    the ``<!-- redmine-id: N -->`` marker from each body.
+    """
+    mapping: dict[int, int] = {}
+    page = 1
+    while True:
+        url = f"{_GH_API_BASE}/repos/{owner_repo}/issues?labels=redmine-imported&state=all&per_page=100&page={page}"
+        issues: list[dict] = _http_json("GET", url, _gh_headers(token), sleep_seconds=sleep_seconds)  # type: ignore[assignment]
+        if not isinstance(issues, list) or not issues:
+            break
+        for iss in issues:
+            body: str = iss.get("body") or ""
+            rid = parse_redmine_id(body)
+            if rid is not None:
+                mapping[rid] = iss["number"]
+        page += 1
+
+    return mapping
+
+
+def create_issue(
+    title: str,
+    body: str,
+    labels: list[str],
+    owner_repo: str,
+    token: str,
+    sleep_seconds: float = _DEFAULT_SLEEP,
+) -> int:
+    """Create a GitHub issue and return its number."""
+    url = f"{_GH_API_BASE}/repos/{owner_repo}/issues"
+    payload = json.dumps({"title": title, "body": body, "labels": labels}).encode()
+    result = _http_json("POST", url, _gh_headers(token), body=payload, sleep_seconds=sleep_seconds)
+    return int(result["number"])
+
+
+def list_issue_comments(
+    issue_number: int,
+    owner_repo: str,
+    token: str,
+    sleep_seconds: float = _DEFAULT_SLEEP,
+    author: str | None = None,
+) -> list[str]:
+    """Return comment bodies for a GitHub issue (all pages).
+
+    When ``author`` is set, only comments written by that login are returned —
+    so the journal-id markers are read solely from THIS tool's own comments. A
+    marker forged in an unrelated user's comment can never make the migration
+    skip a real Redmine journal.
+    """
+    bodies: list[str] = []
+    page = 1
+    while True:
+        url = f"{_GH_API_BASE}/repos/{owner_repo}/issues/{issue_number}/comments?per_page=100&page={page}"
+        comments: list[dict] = _http_json("GET", url, _gh_headers(token), sleep_seconds=sleep_seconds)  # type: ignore[assignment]
+        if not isinstance(comments, list) or not comments:
+            break
+        for c in comments:
+            if author is not None and (c.get("user") or {}).get("login") != author:
+                continue
+            bodies.append(c.get("body") or "")
+        page += 1
+
+    return bodies
+
+
+def create_comment(
+    issue_number: int,
+    body: str,
+    owner_repo: str,
+    token: str,
+    sleep_seconds: float = _DEFAULT_SLEEP,
+) -> None:
+    """Post a comment on a GitHub issue."""
+    url = f"{_GH_API_BASE}/repos/{owner_repo}/issues/{issue_number}/comments"
+    payload = json.dumps({"body": body}).encode()
+    _http_json("POST", url, _gh_headers(token), body=payload, sleep_seconds=sleep_seconds)
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+
+class _Stats(NamedTuple):
+    created: int
+    updated: int
+    skipped: int
+    failed: int
+
+
+def _run_migration(
+    *,
+    redmine_base_url: str,
+    redmine_api_key: str,
+    github_token: str,
+    owner_repo: str,
+    dry_run: bool,
+    limit: int | None,
+    updated_after: date | None,
+    single_issue_id: int | None,
+    sleep_seconds: float,
+    migration_author: str,
+) -> _Stats:
+    """Core migration loop.  Returns final counts."""
+    created = updated = skipped = failed = 0
+
+    # Pre-create known labels so they have nice metadata.
+    if not dry_run:
+        for label_name, (color, desc) in _LABEL_META.items():
+            ensure_label(label_name, color, desc, owner_repo, github_token, sleep_seconds)
+
+    # Discover which Redmine issues are already on GitHub.
+    if dry_run:
+        logging.info("[dry-run] Skipping GH issue scan (no writes)")
+        redmine_to_gh: dict[int, int] = {}
+    else:
+        logging.info("Scanning existing imported issues on GitHub…")
+        redmine_to_gh = list_imported_issues(owner_repo, github_token, sleep_seconds)
+        logging.info("Found %d already-imported issues", len(redmine_to_gh))
+
+    # Collect Redmine issue IDs to process.
+    if single_issue_id is not None:
+        issue_ids: list[int] = [single_issue_id]
+    else:
+        logging.info("Fetching open Redmine issue list…")
+        issue_ids = fetch_open_issue_ids(redmine_base_url, redmine_api_key, sleep_seconds)
+        logging.info("Found %d open Redmine issues", len(issue_ids))
+
+    if limit is not None:
+        issue_ids = issue_ids[:limit]
+        logging.info("Processing %d issues (limited)", len(issue_ids))
+
+    for issue_id in issue_ids:
+        try:
+            outcome = _process_issue(
+                issue_id=issue_id,
+                redmine_base_url=redmine_base_url,
+                redmine_api_key=redmine_api_key,
+                github_token=github_token,
+                owner_repo=owner_repo,
+                dry_run=dry_run,
+                updated_after=updated_after,
+                redmine_to_gh=redmine_to_gh,
+                sleep_seconds=sleep_seconds,
+                migration_author=migration_author,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logging.error("Failed to process Redmine issue #%d: %s", issue_id, exc)
+            failed += 1
+            continue
+
+        # Tally the per-issue outcome so the final summary is accurate.
+        if outcome == "created":
+            created += 1
+        elif outcome == "updated":
+            updated += 1
+        else:
+            skipped += 1
+
+    return _Stats(created=created, updated=updated, skipped=skipped, failed=failed)
+
+
+def _process_issue(
+    *,
+    issue_id: int,
+    redmine_base_url: str,
+    redmine_api_key: str,
+    github_token: str,
+    owner_repo: str,
+    dry_run: bool,
+    updated_after: date | None,
+    redmine_to_gh: dict[int, int],
+    sleep_seconds: float,
+    migration_author: str,
+) -> str:
+    """Migrate one Redmine issue.  Returns 'created', 'updated', or 'skipped'."""
+    logging.info("Fetching Redmine issue #%d…", issue_id)
+    issue = fetch_issue_detail(issue_id, redmine_base_url, redmine_api_key, sleep_seconds)
+    if not issue:
+        logging.warning("Redmine issue #%d returned empty — skipping", issue_id)
+        return "skipped"
+
+    if updated_after is not None and not issue_updated_after(issue, updated_after):
+        logging.info("Redmine #%d: not updated after %s — skipping", issue_id, updated_after)
+        return "skipped"
+
+    title = f"[Redmine #{issue_id}] {issue.get('subject', '(no subject)')}"
+    body = render_issue_body(issue, redmine_base_url)
+    labels = map_labels(issue)
+    journals: list[dict] = issue.get("journals") or []
+
+    # --- Ensure the GH issue exists ---
+    if issue_id in redmine_to_gh:
+        gh_number = redmine_to_gh[issue_id]
+        outcome = "updated"
+        logging.info("Redmine #%d → existing GH issue #%d", issue_id, gh_number)
+    else:
+        if dry_run:
+            logging.info("[dry-run] WOULD create GH issue: %r  labels=%s", title, labels)
+            # Simulate a gh number for comment dry-run logging.
+            gh_number = 0
+            outcome = "created"
+        else:
+            gh_number = create_issue(title, body, labels, owner_repo, github_token, sleep_seconds)
+            redmine_to_gh[issue_id] = gh_number
+            logging.info("Created GH issue #%d for Redmine #%d", gh_number, issue_id)
+            outcome = "created"
+
+    # --- Fill in missing comments ---
+    if dry_run:
+        pending = missing_journals(journals, set())
+        if pending:
+            logging.info(
+                "[dry-run] WOULD post %d comment(s) on GH #%d for Redmine #%d",
+                len(pending),
+                gh_number,
+                issue_id,
+            )
+        else:
+            logging.info("[dry-run] No comments to post for Redmine #%d", issue_id)
+        return outcome
+
+    existing_bodies = list_issue_comments(gh_number, owner_repo, github_token, sleep_seconds, author=migration_author)
+    posted_ids = parse_posted_journal_ids(existing_bodies)
+    pending = missing_journals(journals, posted_ids)
+
+    if not pending:
+        logging.info("GH #%d: all comments up to date (Redmine #%d)", gh_number, issue_id)
+    else:
+        logging.info(
+            "GH #%d: posting %d missing comment(s) for Redmine #%d",
+            gh_number,
+            len(pending),
+            issue_id,
+        )
+        for journal in pending:
+            comment_body = render_comment_body(journal)
+            create_comment(gh_number, comment_body, owner_repo, github_token, sleep_seconds)
+            logging.debug("Posted journal #%d on GH #%d", journal["id"], gh_number)
+
+    return outcome
+
+
+def main() -> None:
+    """CLI entry point."""
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what WOULD happen but make no writes to GitHub or Redmine.",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        metavar="N",
+        help="Cap the number of Redmine issues processed.",
+    )
+    ap.add_argument(
+        "--updated-after",
+        metavar="YYYY-MM-DD",
+        help="Only process issues updated after this date (exclusive).",
+    )
+    ap.add_argument(
+        "--issue",
+        type=int,
+        metavar="ID",
+        dest="issue_id",
+        help="Migrate a single Redmine issue by ID (for testing).",
+    )
+    ap.add_argument(
+        "--redmine-base-url",
+        default=_REDMINE_BASE_URL,
+        help=f"Redmine base URL (default: {_REDMINE_BASE_URL})",
+    )
+    ap.add_argument(
+        "--sleep",
+        type=float,
+        default=_DEFAULT_SLEEP,
+        metavar="SECONDS",
+        help=f"Pause between HTTP requests in seconds (default: {_DEFAULT_SLEEP})",
+    )
+    ap.add_argument(
+        "--migration-author",
+        default="github-actions[bot]",
+        metavar="LOGIN",
+        help=(
+            "GitHub login this tool posts comments as — only its own comments are trusted "
+            "for the already-migrated journal markers (default: github-actions[bot], the "
+            "built-in GITHUB_TOKEN identity; set to your login when using a PAT)."
+        ),
+    )
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%SZ",
+        stream=sys.stderr,
+    )
+
+    # Resolve credentials from env.
+    redmine_api_key = os.environ.get("REDMINE_API_KEY", "")
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    owner_repo = os.environ.get("GITHUB_REPOSITORY", "pfBlockerNG/pfBlockerNG")
+
+    if not redmine_api_key:
+        logging.error("REDMINE_API_KEY env var is not set — aborting")
+        sys.exit(1)
+    if not github_token and not args.dry_run:
+        logging.error("GITHUB_TOKEN env var is not set — aborting (pass --dry-run for read-only mode)")
+        sys.exit(1)
+
+    updated_after: date | None = None
+    if args.updated_after:
+        try:
+            updated_after = date.fromisoformat(args.updated_after)
+        except ValueError:
+            logging.error("Invalid --updated-after date %r (expected YYYY-MM-DD)", args.updated_after)
+            sys.exit(1)
+
+    if args.dry_run:
+        logging.info("=== DRY-RUN MODE — no writes will be made ===")
+
+    try:
+        stats = _run_migration(
+            redmine_base_url=args.redmine_base_url,
+            redmine_api_key=redmine_api_key,
+            github_token=github_token,
+            owner_repo=owner_repo,
+            dry_run=args.dry_run,
+            limit=args.limit,
+            updated_after=updated_after,
+            single_issue_id=args.issue_id,
+            sleep_seconds=args.sleep,
+            migration_author=args.migration_author,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logging.error("Fatal error: %s", exc)
+        sys.exit(1)
+
+    logging.info(
+        "Done — created=%d updated=%d skipped=%d failed=%d",
+        stats.created,
+        stats.updated,
+        stats.skipped,
+        stats.failed,
+    )
+    if stats.failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_redmine_to_github.py
+++ b/tests/test_redmine_to_github.py
@@ -1,0 +1,588 @@
+"""Tests for scripts/redmine_to_github.py — pure helper functions.
+
+All network/env I/O is excluded: only the pure helpers are covered here.
+The test suite honours CLAUDE.md's coverage mandate:
+  - Every branch of every function is exercised.
+  - Transition tests assert the before-state before the flip.
+  - Non-trivial idempotency logic (``missing_journals``) uses BDD specs.
+
+Scenario: missing_journals idempotency core
+  Background:
+    Given a list of Redmine journals, some with notes and some without
+    And a set of journal IDs already posted to GitHub
+
+  Scenario A: nothing posted yet
+    Given posted_ids is empty
+    When missing_journals is called
+    Then all note-journals are returned
+
+  Scenario B: some already posted
+    Given posted_ids contains a subset of the note-journal IDs
+    When missing_journals is called
+    Then only the un-posted note-journals are returned
+
+  Scenario C: all already posted
+    Given posted_ids contains every note-journal ID
+    When missing_journals is called
+    Then an empty list is returned
+
+  Scenario D: out-of-order posted IDs still resolved correctly
+    Given posted_ids contains IDs in a different order than the journals
+    When missing_journals is called
+    Then only the genuinely missing ones are returned, in chronological order
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+# ── Load the script as a module (hyphened name → importlib) ───────────────────
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "redmine_to_github.py"
+_spec = importlib.util.spec_from_file_location("redmine_to_github", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+rtg = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = rtg
+_spec.loader.exec_module(rtg)
+
+
+# ── Fixtures / helpers ─────────────────────────────────────────────────────────
+
+
+def _issue(
+    *,
+    issue_id: int = 1,
+    tracker: str = "Bug",
+    priority: str = "Normal",
+    subject: str = "Test subject",
+    description: str = "",
+    status: str = "New",
+    category: str = "pfBlockerNG",
+    author: str = "Alice",
+    assignee: str | None = None,
+    created_on: str = "2024-01-01T00:00:00Z",
+    updated_on: str = "2024-06-01T00:00:00Z",
+    journals: list[dict] | None = None,
+    attachments: list[dict] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal Redmine issue dict."""
+    return {
+        "id": issue_id,
+        "tracker": {"name": tracker},
+        "priority": {"name": priority},
+        "subject": subject,
+        "description": description,
+        "status": {"name": status},
+        "category": {"name": category},
+        "author": {"name": author},
+        "assigned_to": {"name": assignee} if assignee else None,
+        "created_on": created_on,
+        "updated_on": updated_on,
+        "journals": journals or [],
+        "attachments": attachments or [],
+    }
+
+
+def _journal(
+    *,
+    journal_id: int,
+    notes: str = "",
+    author: str = "Bob",
+    created_on: str = "2024-03-01T00:00:00Z",
+) -> dict[str, Any]:
+    """Build a minimal Redmine journal dict."""
+    return {
+        "id": journal_id,
+        "user": {"name": author},
+        "notes": notes,
+        "created_on": created_on,
+    }
+
+
+# ── map_labels ─────────────────────────────────────────────────────────────────
+
+
+def test_map_labels_always_includes_redmine_imported() -> None:
+    """redmine-imported is always in the result, even for unknown tracker/priority."""
+    result = rtg.map_labels(_issue(tracker="Unknown", priority="Unknown"))
+    assert "redmine-imported" in result
+
+
+def test_map_labels_bug_tracker() -> None:
+    result = rtg.map_labels(_issue(tracker="Bug"))
+    assert "bug" in result
+
+
+def test_map_labels_feature_tracker() -> None:
+    result = rtg.map_labels(_issue(tracker="Feature"))
+    assert "enhancement" in result
+
+
+def test_map_labels_feature_request_tracker() -> None:
+    result = rtg.map_labels(_issue(tracker="Feature request"))
+    assert "enhancement" in result
+
+
+def test_map_labels_unknown_tracker_adds_no_type_label() -> None:
+    result = rtg.map_labels(_issue(tracker="Support"))
+    # Neither bug nor enhancement
+    assert "bug" not in result
+    assert "enhancement" not in result
+    # But redmine-imported still present
+    assert "redmine-imported" in result
+
+
+def test_map_labels_priority_normal() -> None:
+    result = rtg.map_labels(_issue(priority="Normal"))
+    assert "priority: normal" in result
+
+
+def test_map_labels_priority_high() -> None:
+    result = rtg.map_labels(_issue(priority="High"))
+    assert "priority: high" in result
+
+
+def test_map_labels_priority_low() -> None:
+    result = rtg.map_labels(_issue(priority="Low"))
+    assert "priority: low" in result
+
+
+def test_map_labels_priority_urgent() -> None:
+    result = rtg.map_labels(_issue(priority="Urgent"))
+    assert "priority: urgent" in result
+
+
+def test_map_labels_priority_immediate() -> None:
+    result = rtg.map_labels(_issue(priority="Immediate"))
+    assert "priority: immediate" in result
+
+
+def test_map_labels_unknown_priority_adds_no_priority_label() -> None:
+    result = rtg.map_labels(_issue(priority="Medium"))
+    assert not any(lbl.startswith("priority:") for lbl in result)
+
+
+def test_map_labels_keyword_unbound_in_subject() -> None:
+    result = rtg.map_labels(_issue(subject="Unbound crashes on reload"))
+    assert "unbound" in result
+
+
+def test_map_labels_keyword_dnsbl_in_description() -> None:
+    result = rtg.map_labels(_issue(description="DNSBL list is not loaded"))
+    assert "dnsbl" in result
+
+
+def test_map_labels_keyword_geoip() -> None:
+    result = rtg.map_labels(_issue(subject="GeoIP table empty"))
+    assert "geoip" in result
+
+
+def test_map_labels_no_keyword_hit() -> None:
+    result = rtg.map_labels(_issue(subject="Something unrelated", description=""))
+    # Should not include topic labels
+    assert "unbound" not in result
+    assert "dnsbl" not in result
+
+
+def test_map_labels_deduplication() -> None:
+    """A tracker + keyword that would produce the same label only appears once."""
+    # "bug" label from tracker; "bug" does not appear in keywords — but test dedup
+    # with redmine-imported which always appears first.
+    result = rtg.map_labels(_issue(tracker="Bug"))
+    assert result.count("redmine-imported") == 1
+    assert result.count("bug") == 1
+
+
+def test_map_labels_stable_order() -> None:
+    """redmine-imported is always first."""
+    result = rtg.map_labels(_issue(tracker="Bug", priority="High", subject="dnsbl"))
+    assert result[0] == "redmine-imported"
+
+
+# ── render_issue_body ──────────────────────────────────────────────────────────
+
+
+def test_render_issue_body_contains_marker() -> None:
+    body = rtg.render_issue_body(_issue(issue_id=42), "https://redmine.example.com")
+    assert "<!-- redmine-id: 42 -->" in body
+
+
+def test_render_issue_body_marker_id_matches_issue() -> None:
+    body = rtg.render_issue_body(_issue(issue_id=99), "https://redmine.example.com")
+    assert "<!-- redmine-id: 99 -->" in body
+
+
+def test_render_issue_body_back_link_present() -> None:
+    body = rtg.render_issue_body(_issue(issue_id=7), "https://redmine.pfsense.org")
+    assert "https://redmine.pfsense.org/issues/7" in body
+
+
+def test_render_issue_body_description_included() -> None:
+    body = rtg.render_issue_body(
+        _issue(description="Detailed description here"),
+        "https://redmine.example.com",
+    )
+    assert "Detailed description here" in body
+
+
+def test_render_issue_body_missing_description_no_crash() -> None:
+    iss = _issue(description="")
+    iss["description"] = None  # simulate absent field
+    body = rtg.render_issue_body(iss, "https://redmine.example.com")
+    assert "<!-- redmine-id:" in body  # still renders
+
+
+def test_render_issue_body_attachments_present() -> None:
+    attachments = [{"filename": "screenshot.png", "content_url": "https://example.com/f/screenshot.png"}]
+    body = rtg.render_issue_body(_issue(attachments=attachments), "https://redmine.example.com")
+    assert "[screenshot.png](https://example.com/f/screenshot.png)" in body
+
+
+def test_render_issue_body_no_attachments_section_when_empty() -> None:
+    body = rtg.render_issue_body(_issue(attachments=[]), "https://redmine.example.com")
+    assert "**Attachments:**" not in body
+
+
+def test_render_issue_body_assignee_omitted_when_none() -> None:
+    iss = _issue(assignee=None)
+    body = rtg.render_issue_body(iss, "https://redmine.example.com")
+    # Row for assignee should render the dash placeholder
+    assert "| Assignee | — |" in body
+
+
+def test_render_issue_body_assignee_shown_when_present() -> None:
+    body = rtg.render_issue_body(_issue(assignee="Charlie"), "https://redmine.example.com")
+    assert "Charlie" in body
+
+
+# ── render_comment_body ────────────────────────────────────────────────────────
+
+
+def test_render_comment_body_contains_journal_marker() -> None:
+    j = _journal(journal_id=101, notes="Some note")
+    body = rtg.render_comment_body(j)
+    assert "<!-- redmine-journal-id: 101 -->" in body
+
+
+def test_render_comment_body_marker_id_matches_journal() -> None:
+    j = _journal(journal_id=202, notes="Another note")
+    body = rtg.render_comment_body(j)
+    assert "<!-- redmine-journal-id: 202 -->" in body
+
+
+def test_render_comment_body_attribution_header() -> None:
+    j = _journal(journal_id=1, notes="Hi", author="Dave", created_on="2024-05-10T12:00:00Z")
+    body = rtg.render_comment_body(j)
+    assert "**Dave**" in body
+    assert "2024-05-10" in body
+
+
+def test_render_comment_body_notes_included() -> None:
+    j = _journal(journal_id=1, notes="This is the comment text.")
+    body = rtg.render_comment_body(j)
+    assert "This is the comment text." in body
+
+
+def test_render_comment_body_missing_user_does_not_crash() -> None:
+    j: dict[str, Any] = {"id": 5, "notes": "A note", "created_on": "2024-01-01T00:00:00Z"}
+    # No 'user' key at all
+    body = rtg.render_comment_body(j)
+    assert "<!-- redmine-journal-id: 5 -->" in body
+
+
+# ── parse_redmine_id ───────────────────────────────────────────────────────────
+
+
+def test_parse_redmine_id_present() -> None:
+    body = "Some text\n<!-- redmine-id: 123 -->"
+    assert rtg.parse_redmine_id(body) == 123
+
+
+def test_parse_redmine_id_absent_returns_none() -> None:
+    assert rtg.parse_redmine_id("No marker here") is None
+
+
+def test_parse_redmine_id_malformed_returns_none() -> None:
+    # Marker with non-numeric id
+    assert rtg.parse_redmine_id("<!-- redmine-id: abc -->") is None
+
+
+def test_parse_redmine_id_whitespace_tolerant() -> None:
+    assert rtg.parse_redmine_id("<!--   redmine-id:   456   -->") == 456
+
+
+def test_parse_redmine_id_multiple_markers_returns_first() -> None:
+    body = "<!-- redmine-id: 10 --> ... <!-- redmine-id: 20 -->"
+    assert rtg.parse_redmine_id(body) == 10
+
+
+# ── parse_posted_journal_ids ───────────────────────────────────────────────────
+
+
+def test_parse_posted_journal_ids_empty_input() -> None:
+    assert rtg.parse_posted_journal_ids([]) == set()
+
+
+def test_parse_posted_journal_ids_single_comment() -> None:
+    bodies = ["**Author** commented\n\nNote\n\n<!-- redmine-journal-id: 77 -->"]
+    assert rtg.parse_posted_journal_ids(bodies) == {77}
+
+
+def test_parse_posted_journal_ids_multiple_comments() -> None:
+    bodies = [
+        "<!-- redmine-journal-id: 1 -->",
+        "<!-- redmine-journal-id: 2 -->",
+        "<!-- redmine-journal-id: 3 -->",
+    ]
+    assert rtg.parse_posted_journal_ids(bodies) == {1, 2, 3}
+
+
+def test_parse_posted_journal_ids_no_marker_in_comment() -> None:
+    bodies = ["Regular comment with no marker"]
+    assert rtg.parse_posted_journal_ids(bodies) == set()
+
+
+def test_parse_posted_journal_ids_mixed_comments() -> None:
+    bodies = [
+        "No marker here",
+        "<!-- redmine-journal-id: 42 -->",
+        "Also no marker",
+        "<!-- redmine-journal-id: 99 -->",
+    ]
+    assert rtg.parse_posted_journal_ids(bodies) == {42, 99}
+
+
+def test_parse_posted_journal_ids_whitespace_tolerant() -> None:
+    bodies = ["<!--  redmine-journal-id:  55  -->"]
+    assert rtg.parse_posted_journal_ids(bodies) == {55}
+
+
+# ── note_journals ──────────────────────────────────────────────────────────────
+
+
+def test_note_journals_drops_empty_notes() -> None:
+    journals = [
+        _journal(journal_id=1, notes=""),
+        _journal(journal_id=2, notes="Real note"),
+        _journal(journal_id=3, notes="   "),  # whitespace-only
+    ]
+    result = rtg.note_journals(journals)
+    assert [j["id"] for j in result] == [2]
+
+
+def test_note_journals_keeps_all_with_notes() -> None:
+    journals = [
+        _journal(journal_id=1, notes="First"),
+        _journal(journal_id=2, notes="Second"),
+    ]
+    result = rtg.note_journals(journals)
+    assert len(result) == 2
+
+
+def test_note_journals_sorted_chronologically() -> None:
+    journals = [
+        _journal(journal_id=3, notes="Third", created_on="2024-03-01T00:00:00Z"),
+        _journal(journal_id=1, notes="First", created_on="2024-01-01T00:00:00Z"),
+        _journal(journal_id=2, notes="Second", created_on="2024-02-01T00:00:00Z"),
+    ]
+    result = rtg.note_journals(journals)
+    assert [j["id"] for j in result] == [1, 2, 3]
+
+
+def test_note_journals_empty_input() -> None:
+    assert rtg.note_journals([]) == []
+
+
+def test_note_journals_all_empty_notes() -> None:
+    journals = [
+        _journal(journal_id=1, notes=""),
+        _journal(journal_id=2, notes=""),
+    ]
+    assert rtg.note_journals(journals) == []
+
+
+# ── missing_journals (idempotency core — BDD) ─────────────────────────────────
+
+
+# Background: a shared set of journals used across all four scenarios.
+_JOURNALS: list[dict[str, Any]] = [
+    _journal(journal_id=10, notes="First note", created_on="2024-01-01T00:00:00Z"),
+    _journal(journal_id=11, notes="", created_on="2024-01-02T00:00:00Z"),  # no notes — dropped
+    _journal(journal_id=12, notes="Second note", created_on="2024-01-03T00:00:00Z"),
+    _journal(journal_id=13, notes="Third note", created_on="2024-01-04T00:00:00Z"),
+]
+
+
+def test_missing_journals_scenario_a_nothing_posted_returns_all() -> None:
+    """
+    Scenario A: nothing posted yet → all note-journals returned.
+
+    Given posted_ids is empty
+    When missing_journals is called
+    Then all three note-journals (ids 10, 12, 13) are returned in order
+    """
+    # Before state: posted_ids is empty.
+    posted_before: set[int] = set()
+    assert posted_before == set()
+
+    # When
+    result = rtg.missing_journals(_JOURNALS, posted_before)
+
+    # Then
+    assert [j["id"] for j in result] == [10, 12, 13]
+
+
+def test_missing_journals_scenario_b_some_posted_returns_remainder() -> None:
+    """
+    Scenario B: some already posted → only un-posted note-journals returned.
+
+    Given posted_ids = {10} (first note already on GitHub)
+    When missing_journals is called
+    Then only journals 12 and 13 are returned
+    """
+    # Before state: without the filter, all three would be returned.
+    all_result = rtg.missing_journals(_JOURNALS, set())
+    assert [j["id"] for j in all_result] == [10, 12, 13]
+
+    # When
+    posted: set[int] = {10}
+    result = rtg.missing_journals(_JOURNALS, posted)
+
+    # Then
+    assert [j["id"] for j in result] == [12, 13]
+
+
+def test_missing_journals_scenario_c_all_posted_returns_empty() -> None:
+    """
+    Scenario C: all already posted → empty list returned.
+
+    Given posted_ids = {10, 12, 13} (every note-journal already on GitHub)
+    When missing_journals is called
+    Then an empty list is returned
+    """
+    # Before state: with an empty posted set, all three are returned.
+    before = rtg.missing_journals(_JOURNALS, set())
+    assert len(before) == 3
+
+    # When
+    posted: set[int] = {10, 12, 13}
+    result = rtg.missing_journals(_JOURNALS, posted)
+
+    # Then
+    assert result == []
+
+
+def test_missing_journals_scenario_d_out_of_order_posted_ids() -> None:
+    """
+    Scenario D: posted_ids in a different order than journals.
+
+    Given posted_ids = {13, 10} (last and first posted, middle missing)
+    When missing_journals is called
+    Then only journal 12 is returned (correct gap-fill, chronological order)
+    """
+    # Before state: with only {13} posted, journals 10 and 12 would be missing.
+    partial = rtg.missing_journals(_JOURNALS, {13})
+    assert [j["id"] for j in partial] == [10, 12]
+
+    # When: additionally mark 10 as posted (out-of-order set)
+    posted: set[int] = {13, 10}
+    result = rtg.missing_journals(_JOURNALS, posted)
+
+    # Then
+    assert [j["id"] for j in result] == [12]
+
+
+def test_missing_journals_empty_journals_list() -> None:
+    """No journals → always empty, regardless of posted_ids."""
+    assert rtg.missing_journals([], set()) == []
+    assert rtg.missing_journals([], {1, 2, 3}) == []
+
+
+def test_missing_journals_journals_with_only_empty_notes() -> None:
+    """Journals with empty notes are never in the missing set."""
+    journals = [
+        _journal(journal_id=1, notes=""),
+        _journal(journal_id=2, notes="   "),
+    ]
+    assert rtg.missing_journals(journals, set()) == []
+
+
+# ── issue_updated_after ────────────────────────────────────────────────────────
+
+
+def test_issue_updated_after_strictly_after_cutoff_is_true() -> None:
+    iss = _issue(updated_on="2024-06-15T10:00:00Z")
+    assert rtg.issue_updated_after(iss, date(2024, 6, 14)) is True
+
+
+def test_issue_updated_after_on_cutoff_day_is_false() -> None:
+    """'After' is exclusive — same day as cutoff is NOT after."""
+    iss = _issue(updated_on="2024-06-14T23:59:59Z")
+    assert rtg.issue_updated_after(iss, date(2024, 6, 14)) is False
+
+
+def test_issue_updated_after_before_cutoff_is_false() -> None:
+    iss = _issue(updated_on="2024-06-01T00:00:00Z")
+    assert rtg.issue_updated_after(iss, date(2024, 6, 14)) is False
+
+
+def test_issue_updated_after_missing_field_is_false() -> None:
+    iss = _issue()
+    iss["updated_on"] = ""
+    assert rtg.issue_updated_after(iss, date(2024, 1, 1)) is False
+
+
+def test_issue_updated_after_none_field_is_false() -> None:
+    iss = _issue()
+    iss["updated_on"] = None  # type: ignore[assignment]
+    assert rtg.issue_updated_after(iss, date(2024, 1, 1)) is False
+
+
+def test_issue_updated_after_malformed_date_is_false() -> None:
+    iss = _issue(updated_on="not-a-date")
+    assert rtg.issue_updated_after(iss, date(2024, 1, 1)) is False
+
+
+# ── Round-trip: render → parse (integration of pure helpers) ──────────────────
+
+
+def test_round_trip_issue_marker() -> None:
+    """Rendered body's marker is parsed back to the original id."""
+    issue_id = 777
+    body = rtg.render_issue_body(_issue(issue_id=issue_id), "https://redmine.example.com")
+    assert rtg.parse_redmine_id(body) == issue_id
+
+
+def test_round_trip_comment_marker() -> None:
+    """Rendered comment body's marker is parsed back to the original journal id."""
+    j = _journal(journal_id=55, notes="Round-trip note")
+    body = rtg.render_comment_body(j)
+    ids = rtg.parse_posted_journal_ids([body])
+    assert ids == {55}
+
+
+def test_full_idempotency_round_trip() -> None:
+    """
+    Full round-trip: render comments → parse posted ids → compute missing.
+
+    Simulates one comment already posted and verifies only the other is missing.
+    """
+    journals = [
+        _journal(journal_id=100, notes="First"),
+        _journal(journal_id=101, notes="Second"),
+    ]
+    # Simulate: journal 100 has been posted.
+    posted_body = rtg.render_comment_body(journals[0])
+    posted_ids = rtg.parse_posted_journal_ids([posted_body])
+
+    # Before: without the posted body, both would be missing.
+    all_missing = rtg.missing_journals(journals, set())
+    assert [j["id"] for j in all_missing] == [100, 101]
+
+    # After: with journal 100 marked as posted, only 101 is missing.
+    remaining = rtg.missing_journals(journals, posted_ids)
+    assert [j["id"] for j in remaining] == [101]


### PR DESCRIPTION
## Summary

A manually-dispatched tool to migrate **open pfBlockerNG issues** from the pfSense Redmine (`https://redmine.pfsense.org`, project `pfsense-packages`, category 97) into GitHub issues on this repo, **preserving the comment threads**. Stdlib-only Python (no `requests`/PyGithub, no `requirements.txt`), run from a GitHub Actions workflow.

## Highlights

- **Comments → separate GitHub comments.** Each Redmine journal *note* becomes its own GitHub comment, headed with the original author + date, in chronological order.
- **Idempotent at the issue *and* comment level.** Re-runs never duplicate; a half-migrated issue is *completed* on re-run. The issue is matched by a hidden `<!-- redmine-id: N -->` body marker; each migrated comment carries `<!-- redmine-journal-id: N -->`, so a re-run posts only the **missing** comments.
- **Read-only on Redmine** — the tool never writes back to the pfSense tracker.
- **Labels** — always `redmine-imported`; maps Redmine tracker (`Bug`→`bug`, `Feature`→`enhancement`) + priority (`priority: <name>`) + topic keywords (`unbound`, `dnsbl`, `cron`, `performance`, `sync`, …). Mappings are editable module-level dicts.
- **Safe by default** — the workflow's `dry_run` input defaults to `true`, so the first dispatch previews what *would* be migrated without writing anything.

## Files

- `scripts/redmine_to_github.py` — pure, unit-tested helpers (label mapping, issue/comment rendering, marker parsing, the `missing_journals` idempotency core) + a thin `urllib` HTTP layer (rate-limit retry on 403/429 with `Retry-After`) + CLI (`--dry-run`, `--limit`, `--updated-after`, `--issue`, `--redmine-base-url`, `--sleep`).
- `.github/workflows/redmine-import.yml` — `workflow_dispatch` (inputs: `dry_run` default `true`, `limit`, `updated_after`, `issue_id`); `permissions: issues: write`; `REDMINE_API_KEY` secret + the built-in `GITHUB_TOKEN`; no `pip install`. Dispatch inputs are passed via `env:` (not inlined into the shell) to avoid script injection.
- `tests/test_redmine_to_github.py` — 62 unit tests covering every pure helper; the idempotency core is proven before/after (none / some / all / out-of-order already-posted).

## Usage

1. Set the `REDMINE_API_KEY` repo secret (from `https://redmine.pfsense.org/my/account`).
2. Run the **Redmine Issue Import** workflow with `dry_run: true` and review the log.
3. Re-run with `dry_run: false` to migrate. Safe to re-run — it fills gaps, never duplicates.

`GITHUB_TOKEN` (built-in) authors issues as `github-actions[bot]`; swap in a PAT secret if you want them authored as a user.

## Verification

`ruff` + `ruff format` clean · 62 unit tests green · `mypy` clean · YAML valid · `--help` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9eEPiZPP6wQUBh762dkTk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions workflow to migrate open Redmine issues into GitHub issues while preserving the full journal/thread history as comments.
  * Includes dry-run mode, optional limiting by update date or specific issue, and automatic label creation based on Redmine metadata.

* **Tests**
  * Added a focused test suite validating rendering, marker parsing, journal selection, and label mapping logic to ensure repeatable, idempotent migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->