### PR TITLE
scripts: add --issue-ids to migrate a curated list of Redmine issues

### DIFF
--- a/.github/workflows/redmine-import.yml
+++ b/.github/workflows/redmine-import.yml
@@ -48,6 +48,13 @@ on:
           process all open issues (subject to limit/updated_after).
         required: false
         default: ""
+      issue_ids:
+        description: >
+          Process ONLY this explicit comma/space-separated list of Redmine
+          issue IDs (skips fetching the open-issue list).  Use after triage
+          to import a curated set.  Leave empty to process all open issues.
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -81,20 +88,25 @@ jobs:
           LIMIT: ${{ github.event.inputs.limit }}
           UPDATED_AFTER: ${{ github.event.inputs.updated_after }}
           ISSUE_ID: ${{ github.event.inputs.issue_id }}
+          ISSUE_IDS: ${{ github.event.inputs.issue_ids }}
         run: |
           set -eu
-          ARGS=""
+          # Build argv as a bash array so each value stays one argument (handles the
+          # comma/space list in ISSUE_IDS) and never re-tokenizes the command.
+          ARGS=()
           if [ "$DRY_RUN" = "true" ]; then
-            ARGS="$ARGS --dry-run"
+            ARGS+=(--dry-run)
           fi
           if [ -n "$LIMIT" ]; then
-            ARGS="$ARGS --limit $LIMIT"
+            ARGS+=(--limit "$LIMIT")
           fi
           if [ -n "$UPDATED_AFTER" ]; then
-            ARGS="$ARGS --updated-after $UPDATED_AFTER"
+            ARGS+=(--updated-after "$UPDATED_AFTER")
           fi
           if [ -n "$ISSUE_ID" ]; then
-            ARGS="$ARGS --issue $ISSUE_ID"
+            ARGS+=(--issue "$ISSUE_ID")
           fi
-          # shellcheck disable=SC2086
-          python scripts/redmine_to_github.py $ARGS
+          if [ -n "$ISSUE_IDS" ]; then
+            ARGS+=(--issue-ids "$ISSUE_IDS")
+          fi
+          python scripts/redmine_to_github.py "${ARGS[@]}"

--- a/scripts/redmine_to_github.py
+++ b/scripts/redmine_to_github.py
@@ -272,6 +272,25 @@ def parse_posted_journal_ids(comment_bodies: Iterable[str]) -> set[int]:
     return ids
 
 
+def parse_issue_ids(raw: str) -> list[int]:
+    """Parse a comma/space-separated list of Redmine issue IDs into ints.
+
+    Tolerates commas, spaces, and newlines as separators; ignores blank tokens;
+    drops non-numeric tokens. Duplicates are removed while preserving first-seen
+    order (so the migration processes them in the order given).
+    """
+    ids: list[int] = []
+    seen: set[int] = set()
+    for tok in re.split(r"[,\s]+", raw.strip()):
+        if not tok or not tok.isdigit():
+            continue
+        n = int(tok)
+        if n not in seen:
+            seen.add(n)
+            ids.append(n)
+    return ids
+
+
 def note_journals(journals: list[dict]) -> list[dict]:
     """Return journals that carry a non-empty note, in chronological order.
 
@@ -581,6 +600,7 @@ def _run_migration(
     limit: int | None,
     updated_after: date | None,
     single_issue_id: int | None,
+    explicit_ids: list[int] | None,
     sleep_seconds: float,
     migration_author: str,
 ) -> _Stats:
@@ -601,9 +621,14 @@ def _run_migration(
         redmine_to_gh = list_imported_issues(owner_repo, github_token, sleep_seconds)
         logging.info("Found %d already-imported issues", len(redmine_to_gh))
 
-    # Collect Redmine issue IDs to process.
-    if single_issue_id is not None:
-        issue_ids: list[int] = [single_issue_id]
+    # Collect Redmine issue IDs to process. An explicit ID list (--issue-ids) takes
+    # precedence and skips the open-issue fetch entirely; then a single --issue; else
+    # the full open-issue list.
+    if explicit_ids is not None:
+        issue_ids: list[int] = list(explicit_ids)
+        logging.info("Processing %d explicitly-listed Redmine issue(s)", len(issue_ids))
+    elif single_issue_id is not None:
+        issue_ids = [single_issue_id]
     else:
         logging.info("Fetching open Redmine issue list…")
         issue_ids = fetch_open_issue_ids(redmine_base_url, redmine_api_key, sleep_seconds)
@@ -754,6 +779,15 @@ def main() -> None:
         help="Migrate a single Redmine issue by ID (for testing).",
     )
     ap.add_argument(
+        "--issue-ids",
+        default="",
+        metavar="IDS",
+        help=(
+            "Process ONLY this explicit, comma/space-separated list of Redmine issue IDs "
+            "(skips fetching the open-issue list). Useful after triage to import a curated set."
+        ),
+    )
+    ap.add_argument(
         "--redmine-base-url",
         default=_REDMINE_BASE_URL,
         help=f"Redmine base URL (default: {_REDMINE_BASE_URL})",
@@ -807,6 +841,15 @@ def main() -> None:
     if args.dry_run:
         logging.info("=== DRY-RUN MODE — no writes will be made ===")
 
+    # An explicit --issue-ids that parses to nothing (only junk/separators) must NOT
+    # silently fall through to migrating every open issue — fail loudly instead.
+    explicit_ids: list[int] | None = None
+    if args.issue_ids.strip():
+        explicit_ids = parse_issue_ids(args.issue_ids)
+        if not explicit_ids:
+            logging.error("Invalid --issue-ids %r (expected at least one numeric ID)", args.issue_ids)
+            sys.exit(1)
+
     try:
         stats = _run_migration(
             redmine_base_url=args.redmine_base_url,
@@ -817,6 +860,7 @@ def main() -> None:
             limit=args.limit,
             updated_after=updated_after,
             single_issue_id=args.issue_id,
+            explicit_ids=explicit_ids,
             sleep_seconds=args.sleep,
             migration_author=args.migration_author,
         )

--- a/tests/test_redmine_to_github.py
+++ b/tests/test_redmine_to_github.py
@@ -586,3 +586,38 @@ def test_full_idempotency_round_trip() -> None:
     # After: with journal 100 marked as posted, only 101 is missing.
     remaining = rtg.missing_journals(journals, posted_ids)
     assert [j["id"] for j in remaining] == [101]
+
+
+# --- parse_issue_ids (the explicit --issue-ids list parser) --------------------
+
+
+def test_parse_issue_ids_comma_separated() -> None:
+    assert rtg.parse_issue_ids("16893,16830,16814") == [16893, 16830, 16814]
+
+
+def test_parse_issue_ids_space_and_newline_separated() -> None:
+    assert rtg.parse_issue_ids("16893 16830\n16814") == [16893, 16830, 16814]
+
+
+def test_parse_issue_ids_mixed_separators_and_padding() -> None:
+    assert rtg.parse_issue_ids("  16893, 16830 ,16814 ") == [16893, 16830, 16814]
+
+
+def test_parse_issue_ids_dedupes_preserving_first_seen_order() -> None:
+    # 16830 repeats; the result keeps first-seen order and drops the dup.
+    assert rtg.parse_issue_ids("16893,16830,16893,16814,16830") == [16893, 16830, 16814]
+
+
+def test_parse_issue_ids_drops_non_numeric_tokens() -> None:
+    assert rtg.parse_issue_ids("16893, foo, 16830, 12.5, -4") == [16893, 16830]
+
+
+def test_parse_issue_ids_empty_returns_empty_list() -> None:
+    assert rtg.parse_issue_ids("") == []
+    assert rtg.parse_issue_ids("   ,  \n ") == []
+
+
+def test_parse_issue_ids_all_non_numeric_returns_empty() -> None:
+    # All-junk input must parse to [] so the CLI can reject it instead of
+    # silently falling back to migrating every open issue.
+    assert rtg.parse_issue_ids("foo, bar, baz") == []


### PR DESCRIPTION
## Summary

Adds an explicit **`--issue-ids`** parameter (and matching `issue_ids` workflow input) to the Redmine→GitHub migration tool, so a **curated list** of Redmine issue IDs can be migrated instead of the whole open-issue set. This is the mechanism for importing only the post-triage keep-list (issues not already fixed/implemented in the 4.0.0 work).

## Changes

- `scripts/redmine_to_github.py`:
  - New pure helper `parse_issue_ids(raw)` — parses a comma/space/newline-separated list into ints; ignores blanks, drops non-numeric tokens, dedupes preserving first-seen order.
  - New `--issue-ids IDS` CLI flag. When provided, the migration processes **exactly** those IDs in order and **skips** the open-issue fetch. Precedence: `--issue-ids` > `--issue` > open-issue list. Fully compatible with `--dry-run` / `--limit` / `--updated-after`.
- `.github/workflows/redmine-import.yml`:
  - New `issue_ids` dispatch input (comma/space-separated; empty = all open issues).
  - The run step now builds argv as a **bash array** (`"${ARGS[@]}"`) so the comma/space list is passed as one argument and the command can never re-tokenize — replacing the prior string-concat + `# shellcheck disable=SC2086`.
- `tests/test_redmine_to_github.py`: 6 new unit tests for `parse_issue_ids` (comma, space/newline, mixed+padding, dedupe-order, non-numeric drop, empty).

## Verification

`ruff` + `ruff format` clean · 68 unit tests green (62 → 68) · `mypy` clean · `--help` shows `--issue-ids` · YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9eEPiZPP6wQUBh762dkTk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Redmine import workflow now supports selective imports during manual dispatch by accepting an optional `issue_ids` list (comma/space-separated) to migrate only the specified Redmine issues.
* **Tests**
  * Added test coverage for parsing and validating the provided issue IDs, including handling of mixed separators, whitespace, deduplication, and invalid/non-numeric tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->