### PR TITLE
ci: semver pre-release tag scheme, dry-run release, and authored notes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,15 +1,17 @@
 #!/bin/sh
-# Enforces tag naming convention before any push.
+# Enforces the release tag scheme before any push reaches the remote.
+# Single source of truth for the scheme: scripts/release-version.sh.
 #
 # Rules:
-#   - vX.X.X        -> commit must be reachable from origin/main
-#   - vX.X.X-devel  -> commit must be reachable from origin/devel
-#                      but NOT yet merged into origin/main
-#   - Neither branch -> rejected
+#   - vX.Y.Z              -> commit must be reachable from origin/main   (stable)
+#   - vX.Y.Z.aW|.bW|.rcW  -> commit on origin/devel but NOT origin/main  (prerelease)
+#   - neither branch, or a malformed version tag -> rejected
 #
 # Enable: git config core.hooksPath .githooks
 
 z40="0000000000000000000000000000000000000000"
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || ROOT="."
+CLASSIFY="${ROOT}/scripts/release-version.sh"
 
 while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
     # Only inspect tag pushes
@@ -20,7 +22,7 @@ while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
 
     tag="${remote_ref#refs/tags/}"
 
-    # Only enforce versioned tags (vX.X.X or vX.X.X-*)
+    # Only enforce versioned tags (vX.Y.Z and vX.Y.Z.<suffix>)
     case "$tag" in v[0-9]*.[0-9]*.[0-9]*) ;; *) continue ;; esac
 
     # Dereference annotated tags to the underlying commit
@@ -38,23 +40,20 @@ while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
         exit 1
     fi
 
-    # A commit merged into main must use the plain vX.X.X form
-    if [ "$on_main" = 1 ]; then
-        case "$tag" in
-            *-devel)
-                echo "error: '$tag' points to a commit on 'main'; use vX.X.X (drop the -devel suffix)" >&2
-                exit 1
-                ;;
-        esac
-    # A commit only on devel must use the vX.X.X-devel form
-    elif [ "$on_devel" = 1 ]; then
-        case "$tag" in
-            *-devel) ;;
-            *)
-                echo "error: '$tag' points to a commit only on 'devel'; use vX.X.X-devel" >&2
-                exit 1
-                ;;
-        esac
+    # A commit merged into main must be a STABLE tag; a commit only on devel must
+    # be a PRERELEASE tag. Delegate the shape + branch<->channel check to the
+    # single source of truth so the hook and the workflow never drift.
+    if [ "$on_main" = 1 ]; then branch="main"; else branch="devel"; fi
+
+    if [ ! -f "$CLASSIFY" ]; then
+        echo "error: ${CLASSIFY} not found — cannot validate the tag scheme" >&2
+        exit 1
+    fi
+
+    if ! err=$(sh "$CLASSIFY" "$tag" "$branch" 2>&1 >/dev/null); then
+        echo "error: tag '$tag' is not valid for branch '$branch':" >&2
+        printf '%s\n' "$err" | sed 's/^/       /' >&2
+        exit 1
     fi
 done
 

--- a/.github/release-notes/v4.0.0.a1.md
+++ b/.github/release-notes/v4.0.0.a1.md
@@ -1,0 +1,58 @@
+**This is the first alpha of the 4.0.0 series — a large rework of pfBlockerNG.**
+It is intended for testing only: expect rough edges, and do not run it on a
+production firewall without a config backup. Feedback and bug reports are very
+welcome.
+
+### DNS blocking & security
+
+- **Python-only DNSBL engine.** The domain-blocklist path now runs entirely
+  through a single in-resolver Python matcher — faster, simpler, and the only
+  mode going forward (the legacy Unbound mode has been removed).
+- **ABP / EasyList feed support.** Feeds written in Adblock Plus / EasyList
+  syntax are parsed natively, including reliable host extraction regardless of
+  feed header style.
+- **Homoglyph (confusable) blocking.** Optional protection against look-alike
+  internationalized domains (e.g. a Cyrillic `аpple`), using Unicode confusable
+  analysis.
+- **Zero-downtime blocklist updates.** DNSBL list swaps no longer drop in-flight
+  queries during a reload.
+- **Unified decision cache** for consistent, lower-latency block decisions.
+- **Group-policy DNSBL** — apply different DNSBL behaviour per client source.
+- **Automatic sinkhole VIP** (opt-in) and a **setup wizard** that can create the
+  DNSBL VIP for you instead of configuring it by hand.
+
+### Feeds & aliases
+
+- **Aggregated ("Uber") aliases** — opt-in, per-action unioned urltable aliases
+  for downstream consumers such as HAProxy. Native reference sets, no extra
+  firewall rules.
+- **Reworked Feeds UI** with a clearer tabbed layout.
+
+### Distribution & updates
+
+- **Self-hosted package repository.** Install and upgrade pfBlockerNG directly
+  from the project's own repository, alongside the Netgate channel.
+- **Nightly channel** — a separate package rebuilt from the development tip each
+  night for early testers.
+- **CE and Plus aware distribution** — the correct package variant is delivered
+  automatically for your pfSense edition and version.
+- **Release rollback & retention.** Older releases are retained in the catalog so
+  you can pin to a previous version; end-of-life pfSense versions keep receiving
+  their last compatible build.
+
+### Reliability & quality
+
+- **Safer configuration handling** — a single config access layer with a
+  downgrade-safe storage contract, so rolling back a release will not corrupt
+  stored settings.
+- **Correct locale handling** across blocklist processing to avoid silently
+  dropping entries.
+- **pfSense Plus support**, validated in CI.
+- **Extensive automated testing** — live-VM smoke tests, Web-UI render checks,
+  and a portable package builder now back every change.
+
+### Versioning
+
+Starting with this release the development channel uses semantic pre-release
+tags: `X.Y.Z.aN` (alpha), `X.Y.Z.bN` (beta), and `X.Y.Z.rcN` (release
+candidate), cut from `devel`; stable releases are plain `X.Y.Z`, cut from `main`.

--- a/.github/release-notes/v4.0.0.a1.md
+++ b/.github/release-notes/v4.0.0.a1.md
@@ -54,5 +54,5 @@ welcome.
 ### Versioning
 
 Starting with this release the development channel uses semantic pre-release
-tags: `X.Y.Z.aN` (alpha), `X.Y.Z.bN` (beta), and `X.Y.Z.rcN` (release
-candidate), cut from `devel`; stable releases are plain `X.Y.Z`, cut from `main`.
+tags: `vX.Y.Z.aN` (alpha), `vX.Y.Z.bN` (beta), and `vX.Y.Z.rcN` (release
+candidate), cut from `devel`; stable releases are plain `vX.Y.Z`, cut from `main`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,22 +196,43 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "$EVENT" = "workflow_dispatch" ]; then
+            # Dispatch is the DRY-RUN harness only: the commit-check gate and the
+            # branch<->channel enforcement are both skipped here, so a real publish
+            # must never run from a dispatch. Reject dry_run=false explicitly — cut a
+            # real release by pushing a tag, which runs the full gates.
             DRY_RUN="${INPUT_DRY:-true}"
+            if [ "$DRY_RUN" != "true" ]; then
+              echo "::error::workflow_dispatch is dry-run only (it skips the commit + branch gates); to publish, push a release tag instead"
+              exit 1
+            fi
             TAG="$INPUT_TAG"
             [ -n "$TAG" ] || { echo "::error::workflow_dispatch requires the 'tag' input (e.g. v4.0.0.a1)"; exit 1; }
             BRANCH=""   # simulation: skip branch<->channel enforcement
           else
             DRY_RUN="false"
             TAG="$REF_NAME"
-            BRANCH=$(git branch -r --contains "$TAG" \
-              | grep -v HEAD | sed 's|origin/||' | grep -E '^(main|devel)$' | head -1)
+            # Branch detection must be deterministic AND mandatory: a stable tag sits
+            # on BOTH main and devel (main is an ancestor of devel), so prefer main;
+            # a tag reachable from neither release branch is rejected (never published).
+            ON_MAIN=0
+            ON_DEVEL=0
+            git merge-base --is-ancestor "$TAG" "origin/main"  2>/dev/null && ON_MAIN=1
+            git merge-base --is-ancestor "$TAG" "origin/devel" 2>/dev/null && ON_DEVEL=1
+            if [ "$ON_MAIN" = 1 ]; then
+              BRANCH="main"
+            elif [ "$ON_DEVEL" = 1 ]; then
+              BRANCH="devel"
+            else
+              echo "::error::${TAG} is not reachable from origin/main or origin/devel"
+              exit 1
+            fi
           fi
 
           OUT=$(sh scripts/release-version.sh "$TAG" "$BRANCH") || { echo "$OUT"; exit 1; }
           eval "$OUT"   # sets version / channel / prerelease / prekind / portversion
 
-          # Map an empty branch (dispatch) to the channel's canonical branch so the
-          # downstream port-bump picks the right port path even in a dry-run.
+          # Dispatch (dry-run) has no branch context; map the classified channel to its
+          # canonical branch so the downstream port path is still correct in the summary.
           if [ -z "$BRANCH" ]; then
             [ "$channel" = "devel" ] && BRANCH="devel" || BRANCH="main"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,32 @@
 name: Release
 
-# Triggered when a versioned tag (v*) is pushed to any branch.
-# Tags pushed from 'devel' become pre-releases; tags from 'main' become
-# full releases.  After publishing the GitHub Release, the matching port's
-# PORTVERSION + GH_TAGNAME are bumped directly on our own FreeBSD-ports fork
+# Triggered when a versioned tag is pushed.  Tag scheme (single source of truth:
+# scripts/release-version.sh):
+#   * vX.Y.Z              -> STABLE release    (from 'main')  -> full release
+#   * vX.Y.Z.aW|.bW|.rcW  -> ALPHA/BETA/RC      (from 'devel') -> pre-release
+# After publishing the GitHub Release, the matching port's PORTVERSION +
+# GH_TAGNAME are bumped directly on our own FreeBSD-ports fork
 # (pfBlockerNG/FreeBSD-ports @ pfblockerng/use-github) — the build-input branch.
 # Self-hosted distribution (ADR-17): no upstream pfsense/FreeBSD-ports PR.
 #
-# workflow_dispatch allows a dry-run (point at an existing tag via
-# workflow_dispatch + the tag ref).
+# workflow_dispatch is a DRY-RUN harness: pass the tag to simulate; with
+# dry_run=true (default) it validates the scheme, builds the .pkg artifacts and
+# renders the release body, but publishes NOTHING (no Release, no port bump, no
+# pkg-repo poke, no Worker deploy) — for end-to-end validation before a real tag.
 on:
   push:
     tags:
-      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'      # stable: vX.Y.Z (from main)
+      - 'v[0-9]*.[0-9]*.[0-9]*.*'    # prerelease: vX.Y.Z.aW|.bW|.rcW (from devel)
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to simulate, e.g. v4.0.0.a1 (REQUIRED for a dispatch run)."
+        required: true
+      dry_run:
+        description: "true (default) = validate + build but publish NOTHING."
+        required: false
+        default: "true"
 
 # Least-privilege default; jobs that need more elevate explicitly below
 # (release: contents:write to publish; verify-checks: checks:read to read the
@@ -36,6 +49,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # A workflow_dispatch run is the dry-run harness (no real tag / commit
+          # gate to assert) — skip the commit-check requirement for it.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Dry-run dispatch: skipping the 'All tests passed' commit gate."
+            exit 0
+          fi
           SHA="${{ github.sha }}"
           REPO="${{ github.repository }}"
 
@@ -102,16 +121,18 @@ jobs:
 
       - name: Detect pkg channel from tag
         id: channel
-        # Tags from devel are *-devel; tags from main have no -devel suffix.
-        # The channel drives which port we build: devel or stable.
+        # The channel drives which port we build (devel vs stable). Classified by
+        # scripts/release-version.sh: vX.Y.Z.aW|.bW|.rcW -> devel, vX.Y.Z -> stable.
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          case "$TAG" in
-            *-devel) PKG_CHANNEL="devel" ;;
-            *)       PKG_CHANNEL="stable" ;;
-          esac
-          echo "pkg_channel=${PKG_CHANNEL}" >> "$GITHUB_OUTPUT"
-          echo "Tag: ${TAG}  →  pkg channel: ${PKG_CHANNEL}"
+          if [ "$EVENT" = "workflow_dispatch" ]; then TAG="$INPUT_TAG"; else TAG="$REF_NAME"; fi
+          OUT=$(sh scripts/release-version.sh "$TAG") || { echo "$OUT"; exit 1; }
+          eval "$OUT"
+          echo "pkg_channel=${channel}" >> "$GITHUB_OUTPUT"
+          echo "Tag: ${TAG}  →  pkg channel: ${channel}"
 
       - name: Read matrix from ci-metadata
         id: matrices
@@ -150,9 +171,12 @@ jobs:
       contents: write
 
     outputs:
+      tag: ${{ steps.meta.outputs.tag }}
       version: ${{ steps.meta.outputs.version }}
       prerelease: ${{ steps.meta.outputs.prerelease }}
       branch: ${{ steps.meta.outputs.branch }}
+      portversion: ${{ steps.meta.outputs.portversion }}
+      dry_run: ${{ steps.meta.outputs.dry_run }}
 
     steps:
       - uses: actions/checkout@v6
@@ -161,90 +185,147 @@ jobs:
 
       - name: Gather release metadata
         id: meta
+        # Validate + classify the tag via the single source of truth
+        # (scripts/release-version.sh). A push is a real release (dry_run=false,
+        # branch enforced); a workflow_dispatch is the dry-run harness (dry_run
+        # defaults true, branch check skipped since the tag may not exist yet).
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          INPUT_DRY: ${{ github.event.inputs.dry_run }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-          # Determine which branch this tag was created from
-          BRANCH=$(git branch -r --contains "$TAG" \
-            | grep -v HEAD \
-            | sed 's|origin/||' \
-            | grep -E '^(main|devel)$' \
-            | head -1)
-          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
-
-          # Enforce tag naming convention per branch
-          case "$BRANCH" in
-            devel)
-              case "$TAG" in
-                *-devel) ;;
-                *) echo "Error: tags from 'devel' must match vX.X.X-devel (got '${TAG}')"; exit 1 ;;
-              esac
-              ;;
-            main)
-              case "$TAG" in
-                *-devel) echo "Error: tags from 'main' must not have -devel suffix (got '${TAG}')"; exit 1 ;;
-              esac
-              ;;
-          esac
-
-          # Tags from 'devel' are pre-releases
-          if [ "$BRANCH" = "devel" ]; then
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            DRY_RUN="${INPUT_DRY:-true}"
+            TAG="$INPUT_TAG"
+            [ -n "$TAG" ] || { echo "::error::workflow_dispatch requires the 'tag' input (e.g. v4.0.0.a1)"; exit 1; }
+            BRANCH=""   # simulation: skip branch<->channel enforcement
           else
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            DRY_RUN="false"
+            TAG="$REF_NAME"
+            BRANCH=$(git branch -r --contains "$TAG" \
+              | grep -v HEAD | sed 's|origin/||' | grep -E '^(main|devel)$' | head -1)
           fi
 
-      - name: Find previous tag on the same branch
-        id: prev_tag
-        run: |
-          BRANCH="${{ steps.meta.outputs.branch }}"
-          CURRENT="${GITHUB_REF_NAME}"
+          OUT=$(sh scripts/release-version.sh "$TAG" "$BRANCH") || { echo "$OUT"; exit 1; }
+          eval "$OUT"   # sets version / channel / prerelease / prekind / portversion
 
-          # All tags reachable from this branch, sorted by version descending,
-          # excluding the current tag
-          PREV=$(git tag --sort=-version:refname \
-            | grep -v "^${CURRENT}$" \
-            | while read t; do
-                git merge-base --is-ancestor "$t" "origin/${BRANCH}" 2>/dev/null \
-                  && echo "$t" && break
-              done)
-
-          echo "tag=${PREV}" >> "$GITHUB_OUTPUT"
-
-      - name: Generate changelog
-        id: changelog
-        run: |
-          CURRENT="${GITHUB_REF_NAME}"
-          PREV="${{ steps.prev_tag.outputs.tag }}"
-
-          if [ -n "$PREV" ]; then
-            RANGE="${PREV}..${CURRENT}"
-            HEADER="Changes since ${PREV}"
-          else
-            RANGE="${CURRENT}"
-            HEADER="Initial release"
+          # Map an empty branch (dispatch) to the channel's canonical branch so the
+          # downstream port-bump picks the right port path even in a dry-run.
+          if [ -z "$BRANCH" ]; then
+            [ "$channel" = "devel" ] && BRANCH="devel" || BRANCH="main"
           fi
-
-          BODY=$(git log "$RANGE" \
-            --pretty=format:"- %s" \
-            --no-merges \
-            -- \
-            src/ scripts/ \
-            | head -50)
 
           {
-            echo "body<<EOF"
-            echo "## ${HEADER}"
-            echo ""
-            echo "${BODY}"
-            echo "EOF"
+            echo "tag=${TAG}"
+            echo "version=${version}"
+            echo "channel=${channel}"
+            echo "prerelease=${prerelease}"
+            echo "portversion=${portversion}"
+            echo "branch=${BRANCH}"
+            echo "dry_run=${DRY_RUN}"
           } >> "$GITHUB_OUTPUT"
+          echo "Tag ${TAG}: channel=${channel} prerelease=${prerelease} portversion=${portversion} dry_run=${DRY_RUN}"
+
+      - name: Find the previous release tag (compare base)
+        id: prev_tag
+        # The previous release = the highest-version tag that is an ANCESTOR of the
+        # current release's commit (a real compare base, robust to channel renames
+        # and rebased history). For a dispatch dry-run the "commit" is the checked-out
+        # ref HEAD; for a push it is the tag.
+        env:
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then COMMIT="HEAD"; else COMMIT="$TAG"; fi
+          # Prefer the highest-version tag that is an ANCESTOR of this commit (a true
+          # predecessor in history). `|| true` guards each stage so an empty tag list /
+          # all-excluded grep does not trip the default `pipefail`.
+          PREV=$(git tag --sort=-version:refname \
+            | { grep -v "^${TAG}$" || true; } \
+            | while read -r t; do
+                git merge-base --is-ancestor "$t" "$COMMIT" 2>/dev/null && { echo "$t"; break; }
+              done) || true
+          # Fallback (e.g. the first tag of a rebased series, whose predecessor is no
+          # longer an ancestor): the next-lower version tag overall. A GitHub compare
+          # link is still meaningful across diverged history.
+          if [ -z "$PREV" ]; then
+            PREV=$( { git tag; echo "$TAG"; } | sort -V -r | uniq \
+              | awk -v cur="$TAG" 'found{print; exit} $0==cur{found=1}' ) || true
+          fi
+          echo "tag=${PREV}" >> "$GITHUB_OUTPUT"
+          echo "Previous release tag: ${PREV:-<none>}"
+
+      - name: Render release body
+        id: changelog
+        # Body = Claude-authored highlights + a link to the FULL commit list +
+        # a collapsed commit summary. Highlights come from a hand-written
+        # .github/release-notes/<tag>.md when present (the default, $0, Claude-
+        # authored per release); else, if an ANTHROPIC_API_KEY secret is set, a
+        # best-effort Haiku draft from the commit range; else a placeholder.
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          PREV: ${{ steps.prev_tag.outputs.tag }}
+          EVENT: ${{ github.event_name }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -u
+          if [ "$EVENT" = "workflow_dispatch" ]; then HEAD_REF="HEAD"; else HEAD_REF="$TAG"; fi
+
+          # Range for the commit list + the full-changelog link.
+          if [ -n "$PREV" ]; then
+            RANGE="${PREV}..${HEAD_REF}"
+            FULL_LINK="**Full changelog:** [\`${PREV}\` → \`${TAG}\`](https://github.com/${REPO}/compare/${PREV}...${TAG})"
+          else
+            RANGE="$HEAD_REF"
+            FULL_LINK="**Full changelog:** [commits in \`${TAG}\`](https://github.com/${REPO}/commits/${TAG})"
+          fi
+
+          COMMITS=$(git log "$RANGE" --no-merges --pretty=format:"- %s" -- src/ scripts/)
+          COUNT=$(printf '%s\n' "$COMMITS" | grep -c '^- ' || true)
+
+          # Resolve the highlights section.
+          NOTES_FILE=".github/release-notes/${TAG}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            HIGHLIGHTS=$(cat "$NOTES_FILE")
+            echo "Using hand-written highlights: ${NOTES_FILE}"
+          elif [ -n "${ANTHROPIC_API_KEY}" ]; then
+            echo "No ${NOTES_FILE}; drafting highlights with Haiku from ${RANGE}."
+            PROMPT=$(printf 'Write concise GitHub release-note highlights (markdown, grouped by theme, no preamble) for pfBlockerNG %s, summarizing the most important features and fixes from these commit subjects:\n\n%s' "$TAG" "$COMMITS")
+            REQ=$(jq -n --arg m "claude-haiku-4-5" --arg p "$PROMPT" \
+              '{model:$m,max_tokens:1024,messages:[{role:"user",content:$p}]}')
+            HIGHLIGHTS=$(curl -sS https://api.anthropic.com/v1/messages \
+              -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+              -H "anthropic-version: 2023-06-01" \
+              -H "content-type: application/json" \
+              -d "$REQ" | jq -r '.content[0].text // empty') || HIGHLIGHTS=""
+            [ -n "$HIGHLIGHTS" ] || HIGHLIGHTS="_Highlights unavailable; see the full changelog below._"
+          else
+            HIGHLIGHTS="_Highlights not yet written. See the full changelog below._"
+          fi
+
+          # Assemble the body once in-shell, then emit it to BOTH the step output
+          # (consumed by the publish step) and the run summary (so a dry-run shows
+          # exactly what would be published). Built from shell vars only — never by
+          # templating the body back into a script.
+          BODY=$(printf '## Highlights\n\n%s\n\n%s\n\n<details><summary>All commits (%s)</summary>\n\n%s\n\n</details>\n' \
+            "$HIGHLIGHTS" "$FULL_LINK" "$COUNT" "$COMMITS")
+
+          {
+            echo "body<<__RELEASE_BODY__"
+            printf '%s\n' "$BODY"
+            echo "__RELEASE_BODY__"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Rendered release body — ${TAG}"
+            echo ""
+            printf '%s\n' "$BODY"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build source archive
         run: |
-          TAG="${GITHUB_REF_NAME}"
           VERSION="${{ steps.meta.outputs.version }}"
           ARCHIVE="pfBlockerNG-${VERSION}.tar.gz"
 
@@ -255,9 +336,33 @@ jobs:
             src/
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
+      - name: Dry-run validation summary (no publish)
+        if: ${{ steps.meta.outputs.dry_run == 'true' }}
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          CHANNEL: ${{ steps.meta.outputs.channel }}
+          PRERELEASE: ${{ steps.meta.outputs.prerelease }}
+          PORTVERSION: ${{ steps.meta.outputs.portversion }}
+          PREV: ${{ steps.prev_tag.outputs.tag }}
+        run: |
+          {
+            echo "## Dry-run release validation — ${TAG}"
+            echo ""
+            echo "Publishing is SKIPPED (dry_run=true). The rendered body is shown above."
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| channel | ${CHANNEL} |"
+            echo "| prerelease | ${PRERELEASE} |"
+            echo "| PORTVERSION | ${PORTVERSION} |"
+            echo "| previous tag | ${PREV:-<none>} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Publish GitHub Release
+        if: ${{ steps.meta.outputs.dry_run != 'true' }}
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ steps.meta.outputs.tag }}
           name: pfBlockerNG ${{ steps.meta.outputs.version }}
           body: ${{ steps.changelog.outputs.body }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
@@ -384,10 +489,10 @@ jobs:
     name: Attach .pkg artifacts to Release
     runs-on: ubuntu-latest
     needs: [release, build-pkgs-portable, read-matrix]
-    # Run whenever release succeeded, regardless of the build outcome. A
-    # build-pkgs-portable failure surfaces as a red leg but does not prevent
-    # attach-pkgs from completing with a warning if nothing built.
-    if: always() && needs.release.result == 'success'
+    # Run whenever release succeeded AND it was a real publish (not a dry-run);
+    # regardless of the build outcome. A build-pkgs-portable failure surfaces as a
+    # red leg but does not prevent attach-pkgs from completing with a warning.
+    if: always() && needs.release.result == 'success' && needs.release.outputs.dry_run != 'true'
     permissions:
       contents: write
 
@@ -444,7 +549,7 @@ jobs:
     name: Trigger pkg repository publish
     runs-on: ubuntu-latest
     needs: [release]
-    if: always() && needs.release.result == 'success'
+    if: always() && needs.release.result == 'success' && needs.release.outputs.dry_run != 'true'
     permissions:
       contents: read
     steps:
@@ -474,7 +579,7 @@ jobs:
   deploy-worker:
     name: Deploy Cloudflare routing Worker
     needs: [release]
-    if: always() && needs.release.result == 'success'
+    if: always() && needs.release.result == 'success' && needs.release.outputs.dry_run != 'true'
     uses: ./.github/workflows/deploy-worker.yml
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -491,6 +596,7 @@ jobs:
     name: Sync port on FreeBSD-ports fork
     runs-on: ubuntu-latest
     needs: release
+    if: needs.release.outputs.dry_run != 'true'
     permissions:
       contents: read
 
@@ -513,24 +619,20 @@ jobs:
         # template-inject into this shell.
         env:
           BRANCH: ${{ needs.release.outputs.branch }}
-          VERSION: ${{ needs.release.outputs.version }}   # e.g. 3.2.16-devel | 3.2.16
+          TAG: ${{ needs.release.outputs.tag }}              # e.g. v4.0.0.a1 | v4.0.0
+          PORTVERSION: ${{ needs.release.outputs.portversion }}  # e.g. 4.0.0.a1 | 4.0.0 (pkg-safe)
         run: |
           set -eu
-          TAG="v${VERSION}"
-          # Strict branch-aware version shape: devel = X.Y.Z-devel, stable = X.Y.Z.
-          # Fail fast on any other shape (e.g. -rc1/-alpha) so PORTVERSION below can
-          # never keep a '-' (an invalid pkg version). Belt-and-braces with release's
-          # meta gate, which only checks the -devel suffix, not the rest of the string.
+          # PORTVERSION is already classified + pkg-safe (no '-') by release-version.sh
+          # in the `release` job; re-assert the shape here as belt-and-braces so a
+          # malformed value can never reach the Makefile.
           if [ "$BRANCH" = "devel" ]; then
-            printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-devel$' || {
-              echo "::error::invalid devel version/tag: ${TAG}"; exit 1; }
+            printf '%s' "$PORTVERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.(a|b|rc)[0-9]+$' || {
+              echo "::error::invalid devel PORTVERSION/tag: ${TAG}"; exit 1; }
           else
-            printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || {
-              echo "::error::invalid stable version/tag: ${TAG}"; exit 1; }
+            printf '%s' "$PORTVERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || {
+              echo "::error::invalid stable PORTVERSION/tag: ${TAG}"; exit 1; }
           fi
-          # PORTVERSION must be pkg-safe (no '-'): the channel lives in the port's
-          # PKGNAMESUFFIX, not the version. Strip a trailing -devel.
-          PORTVERSION="${VERSION%-devel}"
 
           if [ "$BRANCH" = "devel" ]; then
             PORT_PATH="net/pfSense-pkg-pfBlockerNG-devel"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -606,7 +606,9 @@ automated commits hit the same checks (subject to the runner's installed tools).
   else `$CLAUDE_CODE_USER_EMAIL`, else the commit author — and is a no-op when the human is already
   the committer or already credited. Runs even under `--no-verify` (that flag skips only
   `pre-commit`/`commit-msg`).
-- **`.githooks/pre-push`** enforces tag naming before pushes reach the remote.
+- **`.githooks/pre-push`** enforces the release tag scheme before pushes reach the remote — it
+  delegates to `scripts/release-version.sh` (the single source of truth), so a `vX.Y.Z` tag must
+  sit on `main` and a `vX.Y.Z.aW`/`.bW`/`.rcW` tag on `devel` (not yet on `main`).
 
 ---
 
@@ -850,10 +852,34 @@ When the min CE version changes, also:
 | `main` | Stable  | `net/pfSense-pkg-pfBlockerNG` |
 | `devel` | Development | `net/pfSense-pkg-pfBlockerNG-devel` |
 
-New features land in `devel`. Pushing a `vX.Y.Z` tag triggers CI: tests → GitHub Release → bump
+New features land in `devel`. Pushing a versioned tag triggers CI: tests → GitHub Release → bump
 the matching port on **our own `pfBlockerNG/FreeBSD-ports` fork** (`pfblockerng/use-github`, the
-build-input branch) — self-hosted distribution, **no upstream `pfsense/FreeBSD-ports` PR**. Tags
-from `devel` → pre-releases; from `main` → stable releases.
+build-input branch) — self-hosted distribution, **no upstream `pfsense/FreeBSD-ports` PR**.
+
+**Tag scheme (single source of truth: `scripts/release-version.sh`).** Semver core `X.Y.Z`, no
+odd/even conventions:
+
+- **Pre-releases — `vX.Y.Z.aW` / `.bW` / `.rcW`** (alpha / beta / rc; `W` ≥ 1): cut from
+  **`devel` only** → GitHub **pre-release**. FreeBSD pkg orders them natively
+  (`4.0.0.a1 < 4.0.0.b1 < 4.0.0.rc1 < 4.0.0`), and the tag maps to a pkg-safe `PORTVERSION`
+  verbatim (carries no `-`).
+- **Stable — `vX.Y.Z`**: cut from **`main` only** → full release. The stable tag is typically
+  the same commit as the final `rcW`, so `devel` stays in sync; `devel` then opens the next
+  series (`X.(Y+1).0.a1`).
+- `release-version.sh` validates the shape + branch↔channel pairing; both `release.yml` and
+  `.githooks/pre-push` consume it, so the rule never drifts. Behaviour pinned by
+  `tests/test_release_version.py`.
+
+**Release notes.** `release.yml` renders the body as Claude-authored **highlights** +
+a full-commit **compare link** + a collapsed commit list. Highlights come from a hand-written
+`.github/release-notes/<tag>.md` when present (the default — $0, Claude-authored per release);
+absent that, an optional Haiku draft if an `ANTHROPIC_API_KEY` secret is set; else a placeholder.
+**Nightly builds get no GitHub Release.**
+
+**Dry-run.** `release.yml`'s `workflow_dispatch` is a no-publish harness: pass the `tag` to
+simulate (e.g. `v4.0.0.a1`) with `dry_run=true` (default) to validate the scheme, build the
+`.pkg` artifacts, and render the body — **publishing nothing** (no Release, port bump, pkg-repo
+poke, or Worker deploy). Dispatchable only from the default branch once merged.
 
 ### Self-hosted `pkg` repository (ADR-17)
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ opt-in package available **only** from this fork's self-hosted repository (Optio
 The three packages are mutually exclusive — install **one**. Choose **stable** unless
 you specifically want to track development builds.
 
+Releases follow semantic versioning. Development releases are pre-release tags cut
+from `devel` — `X.Y.Z.aN` (alpha), `X.Y.Z.bN` (beta), `X.Y.Z.rcN` (release
+candidate) — and stable releases are plain `X.Y.Z`, cut from `main`. They order
+naturally for `pkg` (`4.0.0.a1` < `4.0.0.b1` < `4.0.0.rc1` < `4.0.0`). Nightly builds
+are not published as GitHub releases.
+
 In the self-hosted repository the **stable** and **development** packages are served
 from a single repo (`pfblockerng`) — exactly as Netgate ships `pfSense-pkg-pfBlockerNG`
 and `-devel` from its one `pfSense` repo — so one bootstrap exposes both; you pick which

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ The three packages are mutually exclusive — install **one**. Choose **stable**
 you specifically want to track development builds.
 
 Releases follow semantic versioning. Development releases are pre-release tags cut
-from `devel` — `X.Y.Z.aN` (alpha), `X.Y.Z.bN` (beta), `X.Y.Z.rcN` (release
-candidate) — and stable releases are plain `X.Y.Z`, cut from `main`. They order
-naturally for `pkg` (`4.0.0.a1` < `4.0.0.b1` < `4.0.0.rc1` < `4.0.0`). Nightly builds
-are not published as GitHub releases.
+from `devel` — `vX.Y.Z.aN` (alpha), `vX.Y.Z.bN` (beta), `vX.Y.Z.rcN` (release
+candidate) — and stable releases are plain `vX.Y.Z`, cut from `main`. The
+corresponding package versions order naturally for `pkg` (`4.0.0.a1` < `4.0.0.b1`
+< `4.0.0.rc1` < `4.0.0`). Nightly builds are not published as GitHub releases.
 
 In the self-hosted repository the **stable** and **development** packages are served
 from a single repo (`pfblockerng`) — exactly as Netgate ships `pfSense-pkg-pfBlockerNG`

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -46,12 +46,14 @@ fi
 version="${tag#v}"
 
 # Classify by shape. Stage prereleases carry a .(a|b|rc)<N> suffix; stable is
-# the bare semver core. grep -E with anchors gives a full-string match.
-if printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+# the bare semver core. grep -E with anchors gives a full-string match. Numeric
+# parts are strict semver — no leading zeros (`0` or `[1-9][0-9]*`); the stage
+# sequence number is >= 1 (`[1-9][0-9]*`), per the documented `W >= 1`.
+if printf '%s' "$tag" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
 	channel="stable"
 	prerelease="false"
 	prekind=""
-elif printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+\.(a|b|rc)[0-9]+$'; then
+elif printf '%s' "$tag" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(a|b|rc)[1-9][0-9]*$'; then
 	channel="devel"
 	prerelease="true"
 	# Extract the stage kind (a|b|rc) from the trailing .<kind><N> component.

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Single source of truth for the release tag / version scheme.
+#
+# Tag formats (semver core X.Y.Z, no odd/even conventions):
+#   * vX.Y.Z              -> STABLE release   (cut from `main` only)
+#   * vX.Y.Z.aW           -> ALPHA  prerelease (cut from `devel` only)
+#   * vX.Y.Z.bW           -> BETA   prerelease (cut from `devel` only)
+#   * vX.Y.Z.rcW          -> RC     prerelease (cut from `devel` only)
+# (W is a 1+ digit sequence number: a1, a2, ..., b1, ..., rc1, ...)
+#
+# FreeBSD pkg orders these correctly out of the box:
+#   4.0.0.a1 < 4.0.0.a2 < 4.0.0.b1 < 4.0.0.rc1 < 4.0.0
+# (a non-stage single letter gets value c-'a'+2: a=2, b=3; the stage word
+#  "rc" gets 'r'-'a'+2=19; a missing leading number sorts below none, so the
+#  suffixed prereleases sort below the bare stable.) The tag therefore maps to
+#  a pkg-safe PORTVERSION verbatim (it carries no '-', the pkg name/version
+#  separator) — devel keeps its .aW/.bW/.rcW suffix, distinguishing it from the
+#  stable X.Y.Z within its own (-devel) package name.
+#
+# Usage:
+#   release-version.sh <tag> [branch]
+#
+# Validates <tag>'s shape and prints, one KEY=VALUE per line:
+#   version=<tag without leading v>
+#   channel=devel|stable
+#   prerelease=true|false
+#   prekind=a|b|rc|            (empty for stable)
+#   portversion=<version>      (pkg-safe; == version)
+#
+# Exit 0 + KEY=VALUE on a valid tag. Exit 1 + error on stderr on a malformed
+# tag. If [branch] is given (main|devel), also enforces branch<->channel:
+# `main` may cut ONLY stable; `devel` may cut ONLY a prerelease — mismatch is
+# an error. Other/absent branch values skip the branch check (e.g. dry-run).
+
+set -eu
+
+tag="${1:-}"
+branch="${2:-}"
+
+if [ -z "$tag" ]; then
+	echo "error: no tag given" >&2
+	echo "usage: release-version.sh <tag> [branch]" >&2
+	exit 1
+fi
+
+version="${tag#v}"
+
+# Classify by shape. Stage prereleases carry a .(a|b|rc)<N> suffix; stable is
+# the bare semver core. grep -E with anchors gives a full-string match.
+if printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+	channel="stable"
+	prerelease="false"
+	prekind=""
+elif printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+\.(a|b|rc)[0-9]+$'; then
+	channel="devel"
+	prerelease="true"
+	# Extract the stage kind (a|b|rc) from the trailing .<kind><N> component.
+	prekind="$(printf '%s' "$version" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+\.(a|b|rc)[0-9]+$/\1/')"
+else
+	echo "error: '${tag}' is not a valid release tag" >&2
+	echo "       stable: vX.Y.Z   prerelease (devel): vX.Y.Z.aW | .bW | .rcW" >&2
+	exit 1
+fi
+
+# PORTVERSION is the version verbatim — pkg-safe (no '-'); the channel lives in
+# the port's PKGNAMESUFFIX, not the version string.
+portversion="$version"
+
+# Branch<->channel consistency (only when a known branch is supplied).
+case "$branch" in
+	main)
+		if [ "$channel" != "stable" ]; then
+			echo "error: '${tag}' is a ${channel} prerelease but points at 'main'; stable tags from main are vX.Y.Z" >&2
+			exit 1
+		fi
+		;;
+	devel)
+		if [ "$channel" != "devel" ]; then
+			echo "error: '${tag}' is a stable tag but points at 'devel'; prerelease tags from devel are vX.Y.Z.aW | .bW | .rcW" >&2
+			exit 1
+		fi
+		;;
+	"") ;;  # no branch context (e.g. dry-run): skip the branch check
+	*)  ;;  # unknown branch: skip (caller validates reachability separately)
+esac
+
+echo "version=${version}"
+echo "channel=${channel}"
+echo "prerelease=${prerelease}"
+echo "prekind=${prekind}"
+echo "portversion=${portversion}"

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,125 @@
+"""Behaviour guard for the release tag/version scheme (scripts/release-version.sh).
+
+This is the single source of truth that `release.yml` (publish gating, PORTVERSION
+bump) and `.githooks/pre-push` (client-side tag enforcement) both consume, so it
+is pinned here directly rather than re-deriving the regex in each consumer.
+
+Scheme:
+  * vX.Y.Z              -> STABLE release, cut from `main` only
+  * vX.Y.Z.aW/.bW/.rcW  -> ALPHA/BETA/RC prerelease, cut from `devel` only
+
+The script classifies a tag into version/channel/prerelease/prekind/portversion,
+rejects malformed tags, and (when a branch is supplied) enforces branch<->channel.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "release-version.sh"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["sh", str(_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _fields(stdout: str) -> dict[str, str]:
+    return dict(line.split("=", 1) for line in stdout.splitlines() if "=" in line)
+
+
+# (tag, branch, expected channel/prerelease/prekind/portversion)
+_VALID = [
+    ("v4.0.0.a1", "devel", "devel", "true", "a", "4.0.0.a1"),
+    ("v4.0.0.a2", "devel", "devel", "true", "a", "4.0.0.a2"),
+    ("v4.0.0.b1", "devel", "devel", "true", "b", "4.0.0.b1"),
+    ("v4.0.0.rc1", "devel", "devel", "true", "rc", "4.0.0.rc1"),
+    ("v4.0.0.rc12", "devel", "devel", "true", "rc", "4.0.0.rc12"),
+    ("v4.0.0", "main", "stable", "false", "", "4.0.0"),
+    ("v10.20.30", "main", "stable", "false", "", "10.20.30"),
+    # No branch context (dry-run): channel inferred from the tag shape, no branch check.
+    ("v4.1.0.a3", "", "devel", "true", "a", "4.1.0.a3"),
+    ("v4.1.0", "", "stable", "false", "", "4.1.0"),
+]
+
+
+@pytest.mark.parametrize("tag,branch,channel,prerelease,prekind,portversion", _VALID)
+def test_valid_tag_classification(
+    tag: str, branch: str, channel: str, prerelease: str, prekind: str, portversion: str
+) -> None:
+    """A well-formed tag classifies into the expected channel/prerelease/PORTVERSION."""
+    args = [tag, branch] if branch else [tag]
+    res = _run(*args)
+    assert res.returncode == 0, res.stderr
+    f = _fields(res.stdout)
+    assert f["version"] == tag[1:]
+    assert f["channel"] == channel
+    assert f["prerelease"] == prerelease
+    assert f["prekind"] == prekind
+    # PORTVERSION must be pkg-safe (no '-', the pkg name/version separator) and == version.
+    assert f["portversion"] == portversion
+    assert "-" not in f["portversion"]
+
+
+_MALFORMED = [
+    "v4.0.0-devel",  # legacy suffix scheme — no longer valid
+    "v4.0.0-rc1",  # dash, not the dotted .rcW form
+    "v4.0.0.x1",  # unknown stage letter
+    "v4.0.0.a",  # stage letter without a sequence number
+    "v4.0.a1",  # only two numeric components
+    "v4.0.0.alpha1",  # spelled-out stage word, not a|b|rc
+    "4.0.0.a1",  # missing leading v
+    "v4.0.0.a1.1",  # trailing junk after the stage
+]
+
+
+@pytest.mark.parametrize("tag", _MALFORMED)
+def test_malformed_tag_rejected(tag: str) -> None:
+    """A tag that does not match either form is rejected with a non-zero exit."""
+    res = _run(tag)
+    assert res.returncode != 0
+    assert "not a valid release tag" in res.stderr
+
+
+def test_empty_tag_rejected() -> None:
+    """No tag argument is a usage error."""
+    res = _run()
+    assert res.returncode != 0
+    assert "no tag given" in res.stderr
+
+
+# Branch<->channel mismatches: a prerelease may only come from devel, a stable
+# only from main. The opposite pairing must fail (the before/after of the gate).
+@pytest.mark.parametrize(
+    "tag,good_branch,bad_branch",
+    [
+        ("v4.0.0.a1", "devel", "main"),  # prerelease belongs on devel, not main
+        ("v4.0.0", "main", "devel"),  # stable belongs on main, not devel
+    ],
+)
+def test_branch_channel_enforcement(tag: str, good_branch: str, bad_branch: str) -> None:
+    """The SAME tag passes on its correct branch and is rejected on the wrong one."""
+    ok = _run(tag, good_branch)
+    assert ok.returncode == 0, ok.stderr
+
+    bad = _run(tag, bad_branch)
+    assert bad.returncode != 0
+    assert "points at" in bad.stderr or "points to" in bad.stderr
+
+
+def test_ordering_documented_matches_pkg_semantics() -> None:
+    """Sanity: the four stage forms classify so their PORTVERSIONs order a<b<rc<stable.
+
+    FreeBSD pkg orders 4.0.0.a1 < 4.0.0.b1 < 4.0.0.rc1 < 4.0.0 natively; this only
+    asserts the script emits those exact PORTVERSION strings (the ordering itself is
+    a pkg property, validated live by the repo-install smoke).
+    """
+    versions = [_fields(_run(t).stdout)["portversion"] for t in ("v4.0.0.a1", "v4.0.0.b1", "v4.0.0.rc1", "v4.0.0")]
+    assert versions == ["4.0.0.a1", "4.0.0.b1", "4.0.0.rc1", "4.0.0"]

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -23,6 +23,7 @@ _SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "release-version.
 
 
 def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke the classifier script with the given args, capturing stdout/stderr/exit."""
     return subprocess.run(
         ["sh", str(_SCRIPT), *args],
         capture_output=True,
@@ -32,6 +33,7 @@ def _run(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 def _fields(stdout: str) -> dict[str, str]:
+    """Parse the script's ``KEY=VALUE`` stdout lines into a dict."""
     return dict(line.split("=", 1) for line in stdout.splitlines() if "=" in line)
 
 
@@ -77,6 +79,11 @@ _MALFORMED = [
     "v4.0.0.alpha1",  # spelled-out stage word, not a|b|rc
     "4.0.0.a1",  # missing leading v
     "v4.0.0.a1.1",  # trailing junk after the stage
+    "v01.2.3",  # leading zero in a version component (not strict semver)
+    "v1.02.3",  # leading zero in the minor component
+    "v1.2.03",  # leading zero in the patch component
+    "v4.0.0.a0",  # prerelease sequence must be >= 1
+    "v4.0.0.a01",  # leading zero in the prerelease sequence
 ]
 
 


### PR DESCRIPTION
## Summary

Prepares the release pipeline for the `4.0.0` series and the first alpha (`v4.0.0.a1`).

### Tag scheme — single source of truth

New `scripts/release-version.sh` classifies a tag and validates its shape + branch↔channel pairing:

- **Pre-release** `vX.Y.Z.aW` / `.bW` / `.rcW` (alpha/beta/rc) — cut from `devel` only → GitHub pre-release.
- **Stable** `vX.Y.Z` — cut from `main` only → full release.

The suffix maps to a pkg-safe `PORTVERSION` verbatim and orders natively in FreeBSD pkg (`4.0.0.a1 < 4.0.0.b1 < 4.0.0.rc1 < 4.0.0`). Both `release.yml` and `.githooks/pre-push` consume the script, so the rule never drifts. The legacy `-devel`-suffix scheme is removed.

### `release.yml`

- Validates + classifies the tag via the script; bumps the port `PORTVERSION`/`GH_TAGNAME` from the classified value.
- **No-publish dry-run**: `workflow_dispatch` with a `tag` input and `dry_run` (default `true`) validates the scheme, builds the `.pkg` artifacts, and renders the release body — but publishes nothing (no Release, port bump, pkg-repo poke, or Worker deploy; all gated off).
- Release body = authored highlights + a full-commit **compare link** (`<prev>...<tag>`, with a version-sort fallback when the predecessor is no longer an ancestor) + a collapsed commit list. Highlights come from a hand-written `.github/release-notes/<tag>.md` when present; absent that, an optional Haiku draft if an `ANTHROPIC_API_KEY` secret is set; else a placeholder.

### Tests & docs

- `tests/test_release_version.py` pins the scheme (valid/malformed/branch-enforcement/ordering) — 21 cases.
- `.github/release-notes/v4.0.0.a1.md` — the authored highlights for the first alpha.
- `CLAUDE.md` + `README.md` updated to the new scheme and the dry-run/notes flow.

## Validation

- Full suite green (`1862 passed`); ruff/mypy/markdownlint clean; `release.yml` parses.
- Dry-run logic emulated locally for `v4.0.0.a1` → `channel=devel`, `PORTVERSION=4.0.0.a1`, compare base `v3.2.16`, body renders.

## Notes

No tag is created by this PR. After merge, the real GitHub dry-run can be dispatched from `release.yml` (workflow_dispatch only runs from the default branch), then `v4.0.0.a1` can be tagged when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * v4.0.0.a1 released: Python DNS engine, ABP/EasyList parsing, confusable blocking, zero-downtime updates, group-policy control, optional DNS VIP wizard, and enhanced feeds UI with aggregated aliases.
  * Improved reliability with safer config handling, locale fixes, and expanded testing support.

* **Documentation**
  * Clarified release channel versioning scheme (alpha, beta, RC, and stable releases).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->