### PR TITLE
ci: use vX.Y.Z.alpha.N pre-release tag format

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,8 +3,8 @@
 # Single source of truth for the scheme: scripts/release-version.sh.
 #
 # Rules:
-#   - vX.Y.Z              -> commit must be reachable from origin/main   (stable)
-#   - vX.Y.Z.aW|.bW|.rcW  -> commit on origin/devel but NOT origin/main  (prerelease)
+#   - vX.Y.Z                       -> commit must be reachable from origin/main   (stable)
+#   - vX.Y.Z.alpha.N|.beta.N|.rc.N -> commit on origin/devel but NOT origin/main  (prerelease)
 #   - neither branch, or a malformed version tag -> rejected
 #
 # Enable: git config core.hooksPath .githooks

--- a/.github/release-notes/v4.0.0.alpha.1.md
+++ b/.github/release-notes/v4.0.0.alpha.1.md
@@ -54,5 +54,6 @@ welcome.
 ### Versioning
 
 Starting with this release the development channel uses semantic pre-release
-tags: `vX.Y.Z.aN` (alpha), `vX.Y.Z.bN` (beta), and `vX.Y.Z.rcN` (release
-candidate), cut from `devel`; stable releases are plain `vX.Y.Z`, cut from `main`.
+tags: `vX.Y.Z.alpha.N` (alpha), `vX.Y.Z.beta.N` (beta), and `vX.Y.Z.rc.N`
+(release candidate), cut from `devel`; stable releases are plain `vX.Y.Z`, cut
+from `main`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 # Triggered when a versioned tag is pushed.  Tag scheme (single source of truth:
 # scripts/release-version.sh):
-#   * vX.Y.Z              -> STABLE release    (from 'main')  -> full release
-#   * vX.Y.Z.aW|.bW|.rcW  -> ALPHA/BETA/RC      (from 'devel') -> pre-release
+#   * vX.Y.Z                       -> STABLE release (from 'main')  -> full release
+#   * vX.Y.Z.alpha.N|.beta.N|.rc.N -> ALPHA/BETA/RC   (from 'devel') -> pre-release
 # After publishing the GitHub Release, the matching port's PORTVERSION +
 # GH_TAGNAME are bumped directly on our own FreeBSD-ports fork
 # (pfBlockerNG/FreeBSD-ports @ pfblockerng/use-github) — the build-input branch.
@@ -17,11 +17,11 @@ on:
   push:
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'      # stable: vX.Y.Z (from main)
-      - 'v[0-9]*.[0-9]*.[0-9]*.*'    # prerelease: vX.Y.Z.aW|.bW|.rcW (from devel)
+      - 'v[0-9]*.[0-9]*.[0-9]*.*'    # prerelease: vX.Y.Z.alpha.N|.beta.N|.rc.N (from devel)
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to simulate, e.g. v4.0.0.a1 (REQUIRED for a dispatch run)."
+        description: "Tag to simulate, e.g. v4.0.0.alpha.1 (REQUIRED for a dispatch run)."
         required: true
       dry_run:
         description: "true (default) = validate + build but publish NOTHING."
@@ -122,7 +122,7 @@ jobs:
       - name: Detect pkg channel from tag
         id: channel
         # The channel drives which port we build (devel vs stable). Classified by
-        # scripts/release-version.sh: vX.Y.Z.aW|.bW|.rcW -> devel, vX.Y.Z -> stable.
+        # scripts/release-version.sh: vX.Y.Z.alpha.N|.beta.N|.rc.N -> devel, vX.Y.Z -> stable.
         env:
           EVENT: ${{ github.event_name }}
           INPUT_TAG: ${{ github.event.inputs.tag }}
@@ -206,7 +206,7 @@ jobs:
               exit 1
             fi
             TAG="$INPUT_TAG"
-            [ -n "$TAG" ] || { echo "::error::workflow_dispatch requires the 'tag' input (e.g. v4.0.0.a1)"; exit 1; }
+            [ -n "$TAG" ] || { echo "::error::workflow_dispatch requires the 'tag' input (e.g. v4.0.0.alpha.1)"; exit 1; }
             BRANCH=""   # simulation: skip branch<->channel enforcement
           else
             DRY_RUN="false"
@@ -640,15 +640,15 @@ jobs:
         # template-inject into this shell.
         env:
           BRANCH: ${{ needs.release.outputs.branch }}
-          TAG: ${{ needs.release.outputs.tag }}              # e.g. v4.0.0.a1 | v4.0.0
-          PORTVERSION: ${{ needs.release.outputs.portversion }}  # e.g. 4.0.0.a1 | 4.0.0 (pkg-safe)
+          TAG: ${{ needs.release.outputs.tag }}              # e.g. v4.0.0.alpha.1 | v4.0.0
+          PORTVERSION: ${{ needs.release.outputs.portversion }}  # e.g. 4.0.0.alpha.1 | 4.0.0 (pkg-safe)
         run: |
           set -eu
           # PORTVERSION is already classified + pkg-safe (no '-') by release-version.sh
           # in the `release` job; re-assert the shape here as belt-and-braces so a
           # malformed value can never reach the Makefile.
           if [ "$BRANCH" = "devel" ]; then
-            printf '%s' "$PORTVERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.(a|b|rc)[0-9]+$' || {
+            printf '%s' "$PORTVERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta|rc)\.[0-9]+$' || {
               echo "::error::invalid devel PORTVERSION/tag: ${TAG}"; exit 1; }
           else
             printf '%s' "$PORTVERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -608,7 +608,7 @@ automated commits hit the same checks (subject to the runner's installed tools).
   `pre-commit`/`commit-msg`).
 - **`.githooks/pre-push`** enforces the release tag scheme before pushes reach the remote — it
   delegates to `scripts/release-version.sh` (the single source of truth), so a `vX.Y.Z` tag must
-  sit on `main` and a `vX.Y.Z.aW`/`.bW`/`.rcW` tag on `devel` (not yet on `main`).
+  sit on `main` and a `vX.Y.Z.alpha.N`/`.beta.N`/`.rc.N` tag on `devel` (not yet on `main`).
 
 ---
 
@@ -859,13 +859,14 @@ build-input branch) — self-hosted distribution, **no upstream `pfsense/FreeBSD
 **Tag scheme (single source of truth: `scripts/release-version.sh`).** Semver core `X.Y.Z`, no
 odd/even conventions:
 
-- **Pre-releases — `vX.Y.Z.aW` / `.bW` / `.rcW`** (alpha / beta / rc; `W` ≥ 1): cut from
-  **`devel` only** → GitHub **pre-release**. FreeBSD pkg orders them natively
-  (`4.0.0.a1 < 4.0.0.b1 < 4.0.0.rc1 < 4.0.0`), and the tag maps to a pkg-safe `PORTVERSION`
+- **Pre-releases — `vX.Y.Z.alpha.N` / `.beta.N` / `.rc.N`** (alpha / beta / rc; `N` ≥ 1): cut
+  from **`devel` only** → GitHub **pre-release**. FreeBSD pkg orders them natively
+  (`4.0.0.alpha.1 < 4.0.0.beta.1 < 4.0.0.rc.1 < 4.0.0` — pkg special-cases the `alpha`/`beta`/`rc`
+  stage keywords as sorting below the bare release), and the tag maps to a pkg-safe `PORTVERSION`
   verbatim (carries no `-`).
 - **Stable — `vX.Y.Z`**: cut from **`main` only** → full release. The stable tag is typically
-  the same commit as the final `rcW`, so `devel` stays in sync; `devel` then opens the next
-  series (`X.(Y+1).0.a1`).
+  the same commit as the final `rc.N`, so `devel` stays in sync; `devel` then opens the next
+  series (`X.(Y+1).0.alpha.1`).
 - `release-version.sh` validates the shape + branch↔channel pairing; both `release.yml` and
   `.githooks/pre-push` consume it, so the rule never drifts. Behaviour pinned by
   `tests/test_release_version.py`.
@@ -877,7 +878,7 @@ absent that, an optional Haiku draft if an `ANTHROPIC_API_KEY` secret is set; el
 **Nightly builds get no GitHub Release.**
 
 **Dry-run.** `release.yml`'s `workflow_dispatch` is a no-publish harness: pass the `tag` to
-simulate (e.g. `v4.0.0.a1`) with `dry_run=true` (default) to validate the scheme, build the
+simulate (e.g. `v4.0.0.alpha.1`) with `dry_run=true` (default) to validate the scheme, build the
 `.pkg` artifacts, and render the body — **publishing nothing** (no Release, port bump, pkg-repo
 poke, or Worker deploy). Dispatchable only from the default branch once merged.
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ The three packages are mutually exclusive — install **one**. Choose **stable**
 you specifically want to track development builds.
 
 Releases follow semantic versioning. Development releases are pre-release tags cut
-from `devel` — `vX.Y.Z.aN` (alpha), `vX.Y.Z.bN` (beta), `vX.Y.Z.rcN` (release
-candidate) — and stable releases are plain `vX.Y.Z`, cut from `main`. The
-corresponding package versions order naturally for `pkg` (`4.0.0.a1` < `4.0.0.b1`
-< `4.0.0.rc1` < `4.0.0`). Nightly builds are not published as GitHub releases.
+from `devel` — `vX.Y.Z.alpha.N` (alpha), `vX.Y.Z.beta.N` (beta), `vX.Y.Z.rc.N`
+(release candidate) — and stable releases are plain `vX.Y.Z`, cut from `main`. The
+corresponding package versions order naturally for `pkg` (`4.0.0.alpha.1` <
+`4.0.0.beta.1` < `4.0.0.rc.1` < `4.0.0`). Nightly builds are not published as GitHub
+releases.
 
 In the self-hosted repository the **stable** and **development** packages are served
 from a single repo (`pfblockerng`) — exactly as Netgate ships `pfSense-pkg-pfBlockerNG`

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -2,20 +2,22 @@
 # Single source of truth for the release tag / version scheme.
 #
 # Tag formats (semver core X.Y.Z, no odd/even conventions):
-#   * vX.Y.Z              -> STABLE release   (cut from `main` only)
-#   * vX.Y.Z.aW           -> ALPHA  prerelease (cut from `devel` only)
-#   * vX.Y.Z.bW           -> BETA   prerelease (cut from `devel` only)
-#   * vX.Y.Z.rcW          -> RC     prerelease (cut from `devel` only)
-# (W is a 1+ digit sequence number: a1, a2, ..., b1, ..., rc1, ...)
+#   * vX.Y.Z              -> STABLE release    (cut from `main` only)
+#   * vX.Y.Z.alpha.N      -> ALPHA  prerelease (cut from `devel` only)
+#   * vX.Y.Z.beta.N       -> BETA   prerelease (cut from `devel` only)
+#   * vX.Y.Z.rc.N         -> RC     prerelease (cut from `devel` only)
+# (N is a 1+ digit sequence number: alpha.1, alpha.2, ..., beta.1, ..., rc.1, ...)
 #
 # FreeBSD pkg orders these correctly out of the box:
-#   4.0.0.a1 < 4.0.0.a2 < 4.0.0.b1 < 4.0.0.rc1 < 4.0.0
-# (a non-stage single letter gets value c-'a'+2: a=2, b=3; the stage word
-#  "rc" gets 'r'-'a'+2=19; a missing leading number sorts below none, so the
-#  suffixed prereleases sort below the bare stable.) The tag therefore maps to
-#  a pkg-safe PORTVERSION verbatim (it carries no '-', the pkg name/version
-#  separator) — devel keeps its .aW/.bW/.rcW suffix, distinguishing it from the
-#  stable X.Y.Z within its own (-devel) package name.
+#   4.0.0.alpha.1 < 4.0.0.alpha.2 < 4.0.0.beta.1 < 4.0.0.rc.1 < 4.0.0
+# pkg's version comparison special-cases the stage keywords alpha/beta/pre/rc
+# (libpkg/pkg_version.c): a component that starts with a letter gets an implicit
+# leading number of -1, so any `.alpha`/`.beta`/`.rc` component sorts below the
+# bare release (whose missing component is 0); the keyword weight (alpha < beta <
+# rc) breaks ties between two prereleases. The tag therefore maps to a pkg-safe
+# PORTVERSION verbatim (it carries no '-', the pkg name/version separator) — devel
+# keeps its .alpha.N/.beta.N/.rc.N suffix, distinguishing it from the stable X.Y.Z
+# within its own (-devel) package name.
 #
 # Usage:
 #   release-version.sh <tag> [branch]
@@ -24,7 +26,7 @@
 #   version=<tag without leading v>
 #   channel=devel|stable
 #   prerelease=true|false
-#   prekind=a|b|rc|            (empty for stable)
+#   prekind=alpha|beta|rc|     (empty for stable)
 #   portversion=<version>      (pkg-safe; == version)
 #
 # Exit 0 + KEY=VALUE on a valid tag. Exit 1 + error on stderr on a malformed
@@ -45,22 +47,22 @@ fi
 
 version="${tag#v}"
 
-# Classify by shape. Stage prereleases carry a .(a|b|rc)<N> suffix; stable is
-# the bare semver core. grep -E with anchors gives a full-string match. Numeric
+# Classify by shape. Stage prereleases carry a .(alpha|beta|rc).<N> suffix; stable
+# is the bare semver core. grep -E with anchors gives a full-string match. Numeric
 # parts are strict semver — no leading zeros (`0` or `[1-9][0-9]*`); the stage
-# sequence number is >= 1 (`[1-9][0-9]*`), per the documented `W >= 1`.
+# sequence number is >= 1 (`[1-9][0-9]*`), per the documented `N >= 1`.
 if printf '%s' "$tag" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
 	channel="stable"
 	prerelease="false"
 	prekind=""
-elif printf '%s' "$tag" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(a|b|rc)[1-9][0-9]*$'; then
+elif printf '%s' "$tag" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(alpha|beta|rc)\.[1-9][0-9]*$'; then
 	channel="devel"
 	prerelease="true"
-	# Extract the stage kind (a|b|rc) from the trailing .<kind><N> component.
-	prekind="$(printf '%s' "$version" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+\.(a|b|rc)[0-9]+$/\1/')"
+	# Extract the stage kind (alpha|beta|rc) from the trailing .<kind>.<N> component.
+	prekind="$(printf '%s' "$version" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta|rc)\.[0-9]+$/\1/')"
 else
 	echo "error: '${tag}' is not a valid release tag" >&2
-	echo "       stable: vX.Y.Z   prerelease (devel): vX.Y.Z.aW | .bW | .rcW" >&2
+	echo "       stable: vX.Y.Z   prerelease (devel): vX.Y.Z.alpha.N | .beta.N | .rc.N" >&2
 	exit 1
 fi
 
@@ -78,7 +80,7 @@ case "$branch" in
 		;;
 	devel)
 		if [ "$channel" != "devel" ]; then
-			echo "error: '${tag}' is a stable tag but points at 'devel'; prerelease tags from devel are vX.Y.Z.aW | .bW | .rcW" >&2
+			echo "error: '${tag}' is a stable tag but points at 'devel'; prerelease tags from devel are vX.Y.Z.alpha.N | .beta.N | .rc.N" >&2
 			exit 1
 		fi
 		;;

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -5,8 +5,8 @@ bump) and `.githooks/pre-push` (client-side tag enforcement) both consume, so it
 is pinned here directly rather than re-deriving the regex in each consumer.
 
 Scheme:
-  * vX.Y.Z              -> STABLE release, cut from `main` only
-  * vX.Y.Z.aW/.bW/.rcW  -> ALPHA/BETA/RC prerelease, cut from `devel` only
+  * vX.Y.Z                          -> STABLE release, cut from `main` only
+  * vX.Y.Z.alpha.N/.beta.N/.rc.N    -> ALPHA/BETA/RC prerelease, cut from `devel` only
 
 The script classifies a tag into version/channel/prerelease/prekind/portversion,
 rejects malformed tags, and (when a branch is supplied) enforces branch<->channel.
@@ -39,15 +39,15 @@ def _fields(stdout: str) -> dict[str, str]:
 
 # (tag, branch, expected channel/prerelease/prekind/portversion)
 _VALID = [
-    ("v4.0.0.a1", "devel", "devel", "true", "a", "4.0.0.a1"),
-    ("v4.0.0.a2", "devel", "devel", "true", "a", "4.0.0.a2"),
-    ("v4.0.0.b1", "devel", "devel", "true", "b", "4.0.0.b1"),
-    ("v4.0.0.rc1", "devel", "devel", "true", "rc", "4.0.0.rc1"),
-    ("v4.0.0.rc12", "devel", "devel", "true", "rc", "4.0.0.rc12"),
+    ("v4.0.0.alpha.1", "devel", "devel", "true", "alpha", "4.0.0.alpha.1"),
+    ("v4.0.0.alpha.2", "devel", "devel", "true", "alpha", "4.0.0.alpha.2"),
+    ("v4.0.0.beta.1", "devel", "devel", "true", "beta", "4.0.0.beta.1"),
+    ("v4.0.0.rc.1", "devel", "devel", "true", "rc", "4.0.0.rc.1"),
+    ("v4.0.0.rc.12", "devel", "devel", "true", "rc", "4.0.0.rc.12"),
     ("v4.0.0", "main", "stable", "false", "", "4.0.0"),
     ("v10.20.30", "main", "stable", "false", "", "10.20.30"),
     # No branch context (dry-run): channel inferred from the tag shape, no branch check.
-    ("v4.1.0.a3", "", "devel", "true", "a", "4.1.0.a3"),
+    ("v4.1.0.alpha.3", "", "devel", "true", "alpha", "4.1.0.alpha.3"),
     ("v4.1.0", "", "stable", "false", "", "4.1.0"),
 ]
 
@@ -72,18 +72,22 @@ def test_valid_tag_classification(
 
 _MALFORMED = [
     "v4.0.0-devel",  # legacy suffix scheme — no longer valid
-    "v4.0.0-rc1",  # dash, not the dotted .rcW form
-    "v4.0.0.x1",  # unknown stage letter
-    "v4.0.0.a",  # stage letter without a sequence number
-    "v4.0.a1",  # only two numeric components
-    "v4.0.0.alpha1",  # spelled-out stage word, not a|b|rc
-    "4.0.0.a1",  # missing leading v
-    "v4.0.0.a1.1",  # trailing junk after the stage
+    "v4.0.0.a1",  # legacy short stage form — no longer valid
+    "v4.0.0.b1",  # legacy short stage form — no longer valid
+    "v4.0.0.rc1",  # legacy short stage form (rc without the dot+seq) — no longer valid
+    "v4.0.0-rc.1",  # dash, not the dotted .rc.N form
+    "v4.0.0.alpha1",  # stage word not dot-separated from the sequence
+    "v4.0.0.alpha",  # stage word without a sequence number
+    "v4.0.a.1",  # only two numeric components
+    "v4.0.0.gamma.1",  # unknown stage word (not alpha|beta|rc)
+    "v4.0.0.pre.1",  # 'pre' is pkg-recognized but not part of our scheme
+    "4.0.0.alpha.1",  # missing leading v
+    "v4.0.0.alpha.1.1",  # trailing junk after the sequence
     "v01.2.3",  # leading zero in a version component (not strict semver)
     "v1.02.3",  # leading zero in the minor component
     "v1.2.03",  # leading zero in the patch component
-    "v4.0.0.a0",  # prerelease sequence must be >= 1
-    "v4.0.0.a01",  # leading zero in the prerelease sequence
+    "v4.0.0.alpha.0",  # prerelease sequence must be >= 1
+    "v4.0.0.alpha.01",  # leading zero in the prerelease sequence
 ]
 
 
@@ -107,7 +111,7 @@ def test_empty_tag_rejected() -> None:
 @pytest.mark.parametrize(
     "tag,good_branch,bad_branch",
     [
-        ("v4.0.0.a1", "devel", "main"),  # prerelease belongs on devel, not main
+        ("v4.0.0.alpha.1", "devel", "main"),  # prerelease belongs on devel, not main
         ("v4.0.0", "main", "devel"),  # stable belongs on main, not devel
     ],
 )
@@ -122,11 +126,15 @@ def test_branch_channel_enforcement(tag: str, good_branch: str, bad_branch: str)
 
 
 def test_ordering_documented_matches_pkg_semantics() -> None:
-    """Sanity: the four stage forms classify so their PORTVERSIONs order a<b<rc<stable.
+    """Sanity: the stage forms classify so their PORTVERSIONs order alpha<beta<rc<stable.
 
-    FreeBSD pkg orders 4.0.0.a1 < 4.0.0.b1 < 4.0.0.rc1 < 4.0.0 natively; this only
-    asserts the script emits those exact PORTVERSION strings (the ordering itself is
-    a pkg property, validated live by the repo-install smoke).
+    FreeBSD pkg orders 4.0.0.alpha.1 < 4.0.0.beta.1 < 4.0.0.rc.1 < 4.0.0 natively
+    (a component starting with a letter gets an implicit leading -1, so any
+    .alpha/.beta/.rc sorts below the bare release; the keyword weight alpha<beta<rc
+    breaks ties). This only asserts the script emits those exact PORTVERSION strings;
+    the ordering itself is a pkg property, validated live by the repo-install smoke.
     """
-    versions = [_fields(_run(t).stdout)["portversion"] for t in ("v4.0.0.a1", "v4.0.0.b1", "v4.0.0.rc1", "v4.0.0")]
-    assert versions == ["4.0.0.a1", "4.0.0.b1", "4.0.0.rc1", "4.0.0"]
+    versions = [
+        _fields(_run(t).stdout)["portversion"] for t in ("v4.0.0.alpha.1", "v4.0.0.beta.1", "v4.0.0.rc.1", "v4.0.0")
+    ]
+    assert versions == ["4.0.0.alpha.1", "4.0.0.beta.1", "4.0.0.rc.1", "4.0.0"]


### PR DESCRIPTION
## Summary

Changes the pre-release tag format from the short `vX.Y.Z.aW` / `.bW` / `.rcW` to the spelled-out, dot-separated form:

- `vX.Y.Z.alpha.N` (alpha)
- `vX.Y.Z.beta.N` (beta)
- `vX.Y.Z.rc.N` (release candidate)

Stable tags are unchanged (`vX.Y.Z`).

## Why it's still pkg-safe

The whole scheme exists so the self-hosted `pkg` repo orders versions correctly (newest-wins). Verified against FreeBSD `pkg` (`libpkg/pkg_version.c`): the version comparison **special-cases the `alpha`/`beta`/`rc` stage keywords** — a component starting with a letter gets an implicit leading `-1`, so any `.alpha`/`.beta`/`.rc` component sorts **below** the bare release (whose missing component is `0`), and the keyword weight (`alpha < beta < rc`) breaks ties. Result:

```
4.0.0.alpha.1 < 4.0.0.alpha.2 < 4.0.0.beta.1 < 4.0.0.rc.1 < 4.0.0
```

The tag still maps to a pkg-safe `PORTVERSION` verbatim (no `-`).

## Changes

- `scripts/release-version.sh` — classifier regex + `prekind` extraction now `alpha|beta|rc` with a dotted sequence; strict semver (no leading zeros, sequence ≥ 1) preserved.
- `release.yml` — `sync-ports-fork` `PORTVERSION` shape check updated to `(alpha|beta|rc)\.N`; comments/examples updated. (Tag trigger glob already matches.)
- `.githooks/pre-push` — comment updated (delegates to the classifier, unchanged logic).
- `tests/test_release_version.py` — valid/ordering/branch cases switched to the new form; legacy short forms (`v4.0.0.a1` etc.) and `pre`/`gamma`/no-dot/leading-zero now asserted **rejected**. 30 cases.
- Docs — `CLAUDE.md`, `README.md`, and the first-alpha notes renamed `v4.0.0.a1.md` → `v4.0.0.alpha.1.md`.

## Validation

- `tests/test_release_version.py` green (30 passed); ruff/mypy/markdownlint clean; `release.yml` parses; `sh -n` clean.
- Dry-run logic emulated for `v4.0.0.alpha.1` → `channel=devel`, `PORTVERSION=4.0.0.alpha.1`, highlights file resolved, compare base `v3.2.16`.

No tag is created by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-release tag format from short notation (e.g., `v4.0.0.a1`) to explicit labels (e.g., `v4.0.0.alpha.1`). Pre-releases now use `alpha.N`, `beta.N`, and `rc.N` suffixes for enhanced clarity and consistency across all release channels and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->