### PR TITLE
ci: match sync-ports-fork PORTVERSION guard to the canonical validator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -648,10 +648,10 @@ jobs:
           # in the `release` job; re-assert the shape here as belt-and-braces so a
           # malformed value can never reach the Makefile.
           if [ "$BRANCH" = "devel" ]; then
-            printf '%s' "$PORTVERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta|rc)\.[0-9]+$' || {
+            printf '%s' "$PORTVERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(alpha|beta|rc)\.[1-9][0-9]*$' || {
               echo "::error::invalid devel PORTVERSION/tag: ${TAG}"; exit 1; }
           else
-            printf '%s' "$PORTVERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || {
+            printf '%s' "$PORTVERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' || {
               echo "::error::invalid stable PORTVERSION/tag: ${TAG}"; exit 1; }
           fi
 


### PR DESCRIPTION
## Summary

Follow-up to #390. CodeRabbit flagged (outside-diff, post-merge) that the `sync-ports-fork` `PORTVERSION` guard regex was looser than the canonical classifier (`scripts/release-version.sh`): it used `[0-9]+` segments, so it would accept values the classifier rejects — leading zeros (`01.2.3`), `4.0.0.alpha.0`, `4.0.0.alpha.01`.

This is a defense-in-depth gate (a malformed version can't actually reach `sync-ports-fork` today — the `meta` step's classifier already fails the release job first), but the secondary guard should mirror the source of truth so the two never diverge.

## Change

Both guards now use the strict form, identical to the classifier:

- devel: `^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(alpha|beta|rc)\.[1-9][0-9]*$`
- stable: `^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`

## Validation

YAML parses; verified the regexes accept `4.0.0.alpha.1` / `4.0.0.rc.12` / `4.0.0` and reject `4.0.0.alpha.0`, `4.0.0.alpha.01`, `01.2.3`, `4.0.0.a1`, `4.0.0.gamma.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version format validation in release workflows to enforce stricter semantic versioning patterns for pre-release and stable versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->