### PR TITLE
pfblockerng: treat a bare IPv4 as a single host, not a /24 (#320)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6009,12 +6009,11 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 		}
 
 		if ($key == 3) {
-			// If mask is not defined and 4th octet is '0', set mask to '24'
-			if ($octet == 0 && empty($mask)) {
-				$mask = 24;
-			}
-
-			// If mask is '24', force 4th octet to '0'
+			// If mask is '24', force 4th octet to '0' (normalise to the
+			// network address). A bare IPv4 with no mask is treated as a
+			// single host (/32) - the trailing '.0' is a valid host, so it
+			// is NOT widened to a /24 (that silently over-blocks 255 extra
+			// addresses; a feed that means the network writes '.0/24').
 			if ($mask == 24 && $octet != 0) {
 				$ip[$key] = 0;
 			}

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -7,9 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * sanitize_ipaddr() — normalise an IPv4(/mask): strip leading zeros, drop a /32,
- * auto-/24 a trailing-zero host, force the 4th octet to 0 on /24, and (when
- * $pfb['supp']=='on' and not a custom list) drop loopback/reserved/private and
- * apply the Advanced CIDR floor.
+ * keep a bare address as a single host (/32) even when it ends in '.0', force
+ * the 4th octet to 0 on an explicit /24, and (when $pfb['supp']=='on' and not a
+ * custom list) drop loopback/reserved/private and apply the Advanced CIDR floor.
  */
 #[CoversFunction('sanitize_ipaddr')]
 final class SanitizeIpaddrTest extends TestCase
@@ -32,11 +32,16 @@ final class SanitizeIpaddrTest extends TestCase
 		$this->assertSame('10.0.0.0/24', sanitize_ipaddr('10.0.0.0/24', false, 'Disabled'));
 	}
 
-	public function testAutoSlash24WhenTrailingOctetZeroAndNoMask(): void
+	// A bare IPv4 ending in '.0' is a single host (/32), not a /24 network.
+	// '.0' is a valid host address; inferring /24 would silently over-block the
+	// surrounding 255 addresses (issue #320). A feed that means the network
+	// writes the mask explicitly ('192.0.2.0/24'), covered by the next test.
+	public function testBareTrailingZeroAddressKeptAsSingleHostNotWidenedToSlash24(): void
 	{
-		$this->assertSame('192.0.2.0/24', sanitize_ipaddr('192.0.2.0', false, 'Disabled'));
+		$this->assertSame('192.0.2.0', sanitize_ipaddr('192.0.2.0', false, 'Disabled'));
 	}
 
+	// The paired branch: an EXPLICIT /24 is normalised to its network address.
 	public function testSlash24ForcesFourthOctetToZero(): void
 	{
 		$this->assertSame('192.0.2.0/24', sanitize_ipaddr('192.0.2.7/24', false, 'Disabled'));


### PR DESCRIPTION
## Problem

`sanitize_ipaddr()` inferred a `/24` for any bare IPv4 ending in `.0`, silently widening a single entry into 256 addresses:

```php
// before
if ($octet == 0 && empty($mask)) {
    $mask = 24;
}
```

`.0` is a valid host address in classless routing (it is the network address only when the prefix is `/24`), so a feed — or a hand-typed Custom_List entry — listing `203.0.113.0` as one address was over-blocking the surrounding `/24` (255 collateral addresses). The inference also fired unconditionally: the `$custom` flag only gates the private/reserved suppression below it, so even a manually entered Custom_List address was widened. This is issue #320.

## Fix

Treat a bare IPv4 as a single host (`/32`) — drop the `.0`→`/24` inference. A network must carry an explicit mask (`203.0.113.0/24`). This matches the universal convention (pf, `grepcidr`, CIDR notation) that a bare IP literal is `/32`.

The separate, correct normalisation — an **explicit** `/24` has its 4th octet forced to the network address (`203.0.113.7/24` → `203.0.113.0/24`) — is unchanged.

## Tests

The two `SanitizeIpaddrTest` characterization tests were updated to assert the corrected behaviour (they previously pinned the buggy `/24`):

- `testBareTrailingZeroAddressKeptAsSingleHostNotWidenedToSlash24` — `192.0.2.0` → `192.0.2.0` (host).
- `testSlash24ForcesFourthOctetToZero` (paired branch, retained) — explicit `192.0.2.7/24` → `192.0.2.0/24`.

Full PHPUnit suite green (833 tests); `php -l`, the custom PHPCS standard, and `ruff` clean.

Fixes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEtct4G4nCXfjLYq51AJ5k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined IPv4 address normalization to correctly preserve single-host addresses with trailing zeros instead of automatically expanding them to larger network ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->