### PR TITLE
pfblockerng: make Reports stats pie responsive and printable

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -3251,7 +3251,61 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Alerts'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '@self');
 include_once('head.inc');
+?>
 
+<style>
+/* Stats panel: flex columns that shrink and wrap on narrow viewports */
+.pfb-stats-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+}
+.pfb-stats-col {
+	flex: 1 1 480px;
+	min-width: 0;
+}
+/* Let the d3pie SVG scale fluidly within its column */
+.pfb-stats-col svg {
+	max-width: 100%;
+	height: auto;
+}
+
+@media print {
+	.pfb-stats-row { display: block; }
+	.pfb-stats-col {
+		width: 100% !important;
+		float: none !important;
+		height: auto !important;
+		overflow: visible !important;
+		page-break-inside: avoid;
+	}
+	.panel-body { overflow: visible !important; }
+	* { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+}
+</style>
+
+<script type="text/javascript">
+//<![CDATA[
+/* Set a viewBox on the fixed-size d3pie SVG so CSS max-width scales it
+   without distorting the annotated labels. */
+function pfbPieFluid(id) {
+	var el = document.getElementById(id);
+	if (!el) { return; }
+	var svg = el.querySelector('svg');
+	if (!svg) { return; }
+	var w = svg.getAttribute('width');
+	var h = svg.getAttribute('height');
+	if (w && h && !svg.getAttribute('viewBox')) {
+		svg.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+	}
+	svg.removeAttribute('width');
+	svg.removeAttribute('height');
+	svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+}
+//]]>
+</script>
+
+<?php
 // Define default Alerts Tab href link (Top row)
 $get_req = pfb_alerts_default_page();
 
@@ -4636,7 +4690,8 @@ foreach ($stats as $stat_type => $stype):
 
 			<?php else: ?>
 
-			<div style="height: <?=$height;?>px; width: 50%; float: left; overflow-y: scroll;">
+			<div class="pfb-stats-row">
+			<div class="pfb-stats-col" style="height: <?=$height;?>px; overflow-y: scroll;">
 			<table class="table table-responsive table-bordered table-striped table-hover table-compact sortable-theme-bootstrap" data-sortable>
 
 				<thead>
@@ -4806,7 +4861,7 @@ foreach ($stats as $stat_type => $stype):
 			</table>
 			</div>
 
-			<div style="height: <?=$height;?>px; width: 50%; float: right;">
+			<div class="pfb-stats-col" style="height: <?=$height;?>px;">
 				<div id="pieChart_<?=$stat_type?>">
 				<?php
 					if ($topcount > 9) {
@@ -4819,6 +4874,7 @@ foreach ($stats as $stat_type => $stype):
 				?>
 				</div>
 			</div>
+			</div><!-- /.pfb-stats-row -->
 
 			<!-- Display max table extry limit, if found -->
 			<?php if ($max_table_entries): ?>
@@ -5027,6 +5083,7 @@ var pieChart_<?=$stat_type?> = new d3pie("pieChart_<?=$stat_type?>", {
 		}
 	}
 });
+pfbPieFluid("pieChart_<?=$stat_type?>");
 //]]>
 </script>
 <?php
@@ -5445,6 +5502,7 @@ events.push(function() {
 		} else if (pieChart == 'replydate') {
 			pieChart_replydate.redraw();
 		}
+		pfbPieFluid('pieChart_' + pieChart);
 	})
 
 	$('[id^=DNSBLWT]').click(function(event) {

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -91,6 +91,15 @@ PAGE_TABLE: tuple[Page, ...] = (
         ("Pre-defined Alias/Group/Feeds", "DNSBL Alias name(s):"),
     ),
     Page("alerts", "/pfblockerng/pfblockerng_alerts.php", ("Alert Settings",)),
+    # The Reports sub-tabs are the same page under ?view=; the stats views (IP Block
+    # Stats + DNSBL Block Stats, issue #387) traverse the view switch + the per-stat-type
+    # two-column render path. The sub-tab nav label is rendered on every view
+    # (data-independent), so it is the marker. The pie panels themselves are alert-data
+    # gated, and the responsive-layout + print-stylesheet *visual* correctness added for
+    # #387 is an ADR-14 out-of-CI item (ui_browser tier + maintainer), not asserted here;
+    # these entries guard the stats view-handler paths against a PHP render regression.
+    Page("alerts_ip_block_stat", "/pfblockerng/pfblockerng_alerts.php?view=ip_block_stat", ("IP Block Stats",)),
+    Page("alerts_dnsbl_stat", "/pfblockerng/pfblockerng_alerts.php?view=dnsbl_stat", ("DNSBL Block Stats",)),
     Page("log", "/pfblockerng/pfblockerng_log.php", ("Log/File Browser selections",)),
     Page("sync", "/pfblockerng/pfblockerng_sync.php", ("XMLRPC Sync Settings",)),
     Page("safesearch", "/pfblockerng/pfblockerng_safesearch.php", ("SafeSearch settings", "DNSBL SafeSearch")),


### PR DESCRIPTION
## Summary

Fixes #387 (Redmine #10278). On the Reports **IP Block Stats / DNSBL Stats** pages the source list and pie chart were a fixed two-column split (each `width:50%` float) and the d3pie chart was rendered at a hardcoded `canvasWidth:560`/`canvasHeight:390`. On viewports narrower than ~1120px the 560px canvas overflowed its 50% column and the annotated pie clipped on the right; printing/PDF cropped it further (no print stylesheet).

## Fix (`src/usr/local/www/pfblockerng/pfblockerng_alerts.php`)

- **Fluid chart:** a small `pfbPieFluid()` helper stamps a `viewBox` (from d3pie's intrinsic 560×390) onto the generated `<svg>` and drops its fixed `width`/`height`, so CSS `.pfb-stats-col svg { max-width:100%; height:auto; }` scales the pie within its column — labels stay positioned (`preserveAspectRatio`). Called after each chart is built **and** after the collapse-redraw (which re-stamps the fixed size).
- **Responsive columns:** the two columns are wrapped in a `.pfb-stats-row` flex container with `flex-wrap`; each `.pfb-stats-col` is `flex:1 1 480px; min-width:0` so they shrink and wrap instead of overflowing.
- **Print:** an `@media print` block stacks the columns (source list above the full pie), removes overflow clipping, and enables `print-color-adjust` so the annotated pie prints/PDFs uncropped.

No d3pie data/colours/sizes changed; the alerts data logic is untouched. Diff is one file + a test.

## Tests

- `tests/smoke/ui/test_render_smoke.py`: added the `ip_block_stat` + `dnsbl_stat` views to the ADR-14 `ui_render` sweep (PHP-error coverage of the stats view-handler paths). The responsive/print **visual** correctness is an ADR-14 out-of-CI item (verified via the `ui_browser` tier + maintainer screenshot), noted inline.
- `php -l` clean; full pre-commit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Responsive design improvements for Alerts statistics view with enhanced scaling and layout of statistics panels and pie charts, providing better visualization across all device sizes

* **Tests**
  * Extended test coverage for Alerts statistics view rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->