### PR TITLE
pfblockerng: fix dashboard widget alias IP count (#322)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -335,6 +335,15 @@ function pfb_reload_option_value($value) {
 	return 'All';
 }
 
+// Entry count for a pfBlockerNG alias file, excluding the '1.1.1.1' placeholder
+// (used for an empty alias). $grep_lines is the output array of
+// `grep -cv '^1.1.1.1$' <file>` — a single line holding the count in element 0.
+// Returns 0 when the output is missing or non-numeric.
+function pfb_alias_entry_count(array $grep_lines): int {
+	return is_numeric($grep_lines[0] ?? NULL) ? (int) $grep_lines[0] : 0;
+}
+
+
 // Function to filter/sanitize user input
 function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE) {
 	global $pfb;

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -279,10 +279,7 @@ function pfBlockerNG_update_table() {
 
 				$pfb_aliasdir_esc = escapeshellarg("{$pfb['aliasdir']}/{$pfb_alias}.txt");
 				exec("{$pfb['grep']} -cv '^1\.1\.1\.1\$' {$pfb_aliasdir_esc}", $match);
-				if (!is_numeric($match[1])) {
-					$match[1] = 0;
-				}
-				$pfb_table[$pfb_alias] = array('count' => $match[1], 'img' => $pfb['down']);
+				$pfb_table[$pfb_alias] = array('count' => pfb_alias_entry_count($match), 'img' => $pfb['down']);
 				exec("{$pfb['ls']} -l -D'%b %d %T' {$pfb_aliasdir_esc} | {$pfb['awk']} '{ print \$6,\$7,\$8 }'", $update);
 
 				$pfb_table[$pfb_alias]['update']	= $update[0];

--- a/tests/php/WidgetAliasCountTest.php
+++ b/tests/php/WidgetAliasCountTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_alias_entry_count() — read the grep -cv count from element [0] of the
+ * exec() output array and return it as an int, returning 0 for absent, empty,
+ * or non-numeric output.
+ *
+ * The dashboard widget runs `grep -cv '^1.1.1.1$' <alias-file>` (excluding
+ * the placeholder entry pfBlockerNG writes for an otherwise-empty alias) and
+ * passes the resulting array to this helper. grep -cv emits a single line —
+ * the count — into element [0]; element [1] does not exist. The pre-fix widget
+ * read $match[1] (always undefined → reset to 0), so every alias showed 0
+ * until the authoritative pfctl branch overwrote it. This test suite pins the
+ * correct [0] behaviour so that regression is detectable off-box.
+ */
+#[CoversFunction('pfb_alias_entry_count')]
+final class WidgetAliasCountTest extends TestCase
+{
+	// Populated alias: grep -cv found 16 788 non-placeholder lines.
+	// The old code read element [1] (absent → 0); the fix reads element [0].
+	public function testPopulatedAliasReturnsCountFromElementZero(): void
+	{
+		$this->assertSame(16788, pfb_alias_entry_count(['16788']));
+	}
+
+	// Empty/placeholder-only alias: the sole entry is '1.1.1.1', which grep -cv
+	// excludes, so the count is 0 — returned as int 0, not the string '0'.
+	public function testPlaceholderOnlyAliasReturnsZero(): void
+	{
+		$this->assertSame(0, pfb_alias_entry_count(['0']));
+	}
+
+	// grep produced no output at all (file absent, exec failed).
+	// Empty array → element [0] absent → 0.
+	public function testMissingOutputReturnsZero(): void
+	{
+		$this->assertSame(0, pfb_alias_entry_count([]));
+	}
+
+	// grep output is an empty string — non-numeric → 0.
+	public function testEmptyStringOutputReturnsZero(): void
+	{
+		$this->assertSame(0, pfb_alias_entry_count(['']));
+	}
+
+	// grep output is unexpected non-numeric text — non-numeric → 0.
+	public function testNonNumericOutputReturnsZero(): void
+	{
+		$this->assertSame(0, pfb_alias_entry_count(['abc']));
+	}
+}


### PR DESCRIPTION
## Problem

The Dashboard widget's alias **Count** column can show a wrong value. The preliminary count is read from the wrong array index in `pfblockerng.widget.php`:

```php
exec("{$pfb['grep']} -cv '^1\.1\.1\.1\$' {$pfb_aliasdir_esc}", $match);
if (!is_numeric($match[1])) { $match[1] = 0; }   // <-- $match[1]
$pfb_table[$pfb_alias] = array('count' => $match[1], ...);
```

`grep -cv` emits a **single** line (the count) into `$match[0]`; the code reads `$match[1]`, which is always absent and resets to `0`. (`1.1.1.1` is pfBlockerNG's placeholder for an empty alias, hence `-cv`.) This preliminary value is normally overwritten by the authoritative pfctl branch (`Addresses` → `pfctl -t <alias> -Tshow | wc -l`), which masks the bug in the common path — but the fallback was always wrong, so whenever that overwrite is skipped the widget shows a bogus count.

## Fix

Extract a pure, testable helper and read the correct element:

```php
function pfb_alias_entry_count(array $grep_lines): int {
	return is_numeric($grep_lines[0] ?? NULL) ? (int) $grep_lines[0] : 0;
}
```

The widget calls `pfb_alias_entry_count($match)` instead of the buggy `$match[1]` block. This makes the `.txt` fallback count correct and hardens the path independently of the pfctl overwrite. No other widget logic changes.

## Tests

New `tests/php/WidgetAliasCountTest.php` (5 cases) pins every branch: populated alias → real count (the regression anchor — fails on the old `[1]` logic), placeholder-only/empty → 0, missing output → 0, non-numeric → 0.

Full PHP suite green (838 tests); `php -l`, PHPCS (custom sniffs), and the Python suite clean.

Fixes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEtct4G4nCXfjLYq51AJ5k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alias entry counting in the pfBlockerNG widget to ensure accurate display of alias counts.

* **Tests**
  * Added comprehensive test coverage for alias entry counting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->