### PR TITLE
alerts: group IP alert feed/match cell by record (#366)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2722,6 +2722,35 @@ function convert_dns_reply_log($mode, $fields) {
 }
 
 
+/**
+ * Build the inner HTML for the IP alert Feed/Match cell.
+ *
+ * When both the feed name and matched IP/CIDR were re-evaluated (both $feed_new
+ * and $match_new are non-empty), groups the output by record: the struck
+ * previous pair first, then the current pair. When only one field changed the
+ * per-field layout is preserved, matching today's existing behaviour.
+ *
+ * All four parameters must already be HTML-escaped by the caller; $feed_new and
+ * $match_new must be empty strings when the corresponding field did not change.
+ */
+function pfb_ip_feed_match_cell(string $feed, string $feed_new, string $match, string $match_new): string {
+	if ($feed_new !== '' && $match_new !== '') {
+		// Both changed — group by record: struck previous pair, then current pair.
+		return "<s>{$feed}</s><br /><small><s>{$match}</s></small><br />{$feed_new}<br /><small>{$match_new}</small>";
+	}
+	elseif ($feed_new !== '') {
+		// Only feed changed — per-field layout.
+		return "<s>{$feed}</s><br />{$feed_new}<br /><small>{$match}</small>";
+	}
+	elseif ($match_new !== '') {
+		// Only match changed — per-field layout.
+		return "{$feed}<br /><small><s>{$match}</s><br />{$match_new}</small>";
+	}
+	// Neither changed.
+	return "{$feed}<br /><small>{$match}</small>";
+}
+
+
 // Function to convert IP Logs (ip_block, ip_permit and ip_match).log -> Reports Tab
 function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	global $pfb, $continents, $filterfieldsarray, $clists, $ip_unlock, $counter, $pfbentries, $skipcount, $dup, $ipfilterlimit, $ipfilterlimitentries;
@@ -3160,14 +3189,8 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		$feed_new	= pfb_hsc($feed_new);
 	}
 
-	if (!empty($feed_new)) {
-		$fields[15]	= "<s>{$fields[15]}</s><br />{$feed_new}";
-	}
-
-	$fields[14]	= pfb_hsc($fields[14]);
-	if (!empty($eval_new)) {
-		$fields[14]	= "<s>{$fields[14]}</s><br />" . pfb_hsc($eval_new);
-	}
+	$fields[14]		= pfb_hsc($fields[14]);
+	$feed_match_cell	= pfb_ip_feed_match_cell($fields[15], $feed_new, $fields[14], pfb_hsc($eval_new));
 
 	if (empty($fields[16])) {
 		$fields[16] = 'Unknown';
@@ -3207,7 +3230,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			<td>{$dst_icons}</td>
 			<td>{$fields[98]}{$dstport}&emsp;{$query_port}<br /><small>{$hostname['dst']}</small></td>
 			<td>{$fields[12]}<br />{$fields[18]}</td>
-			<td title=\"{$pfb_matchtitle}\">{$fields[15]}<br /><small>{$fields[14]}</small></td>
+			<td title=\"{$pfb_matchtitle}\">{$feed_match_cell}</td>
 			</tr>");
 	}
 	else {
@@ -3236,7 +3259,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			<td><small>{$fields[2]}</small></td>
 			<td style=\"white-space: nowrap; text-align: center;\">{$dst_icons}</td>
 			<td>{$fields[98]}{$dstport}&emsp;{$query_port}<br /><small>{$hostname['dst']}</small></td>
-			<td title=\"{$pfb_matchtitle}\">{$fields[15]}<br /><small>{$fields[14]}</small></td>
+			<td title=\"{$pfb_matchtitle}\">{$feed_match_cell}</td>
 			<td>{$fields[12]}<br />{$fields[18]}</td>
 			</tr>");
 	}

--- a/tests/php/AlertsFeedMatchCellGroupingTest.php
+++ b/tests/php/AlertsFeedMatchCellGroupingTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the grouping behaviour of pfb_ip_feed_match_cell(): when both the feed
+ * name and matched IP/CIDR were re-evaluated the cell groups output by record
+ * (previous struck pair first, then current pair); when only one field changed
+ * the per-field layout is preserved.
+ *
+ * The function under test is loaded off-appliance via the same eval-extract
+ * technique as AlertsRowOutputEncodingTest: the alerts page source is read,
+ * require_once() lines stripped, and only the function block eval'd.
+ */
+#[CoversFunction('pfb_ip_feed_match_cell')]
+final class AlertsFeedMatchCellGroupingTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (function_exists('pfb_ip_feed_match_cell')) {
+            return;
+        }
+        $src = file_get_contents(
+            dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
+        );
+        if ($src === false) {
+            throw new RuntimeException('failed to read pfblockerng_alerts.php');
+        }
+        $src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $src);
+        $start = strpos($src, "\nfunction ");
+        $end   = strpos($src, "\n\$pgtitle = ");
+        if ($start === false || $end === false || $end <= $start) {
+            throw new RuntimeException('could not locate the function block in pfblockerng_alerts.php');
+        }
+        eval("\n" . substr($src, $start + 1, $end - $start - 1));
+    }
+
+    /**
+     * Neither field changed — both values render at their normal sizes with no
+     * struck markup.
+     */
+    public function test_neither_changed_renders_feed_then_match_in_small(): void
+    {
+        $result = pfb_ip_feed_match_cell('CINS_army_v4', '', '45.154.96.76', '');
+
+        $this->assertSame('CINS_army_v4<br /><small>45.154.96.76</small>', $result);
+    }
+
+    /**
+     * Only the feed changed — per-field layout: struck old feed, current feed,
+     * then the (unchanged) match wrapped in <small>.
+     */
+    public function test_only_feed_changed_shows_struck_old_feed_then_new_feed_then_match(): void
+    {
+        $result = pfb_ip_feed_match_cell('CINS_army_v4', 'ET_Block_v4', '45.154.96.76', '');
+
+        $this->assertSame(
+            '<s>CINS_army_v4</s><br />ET_Block_v4<br /><small>45.154.96.76</small>',
+            $result
+        );
+    }
+
+    /**
+     * Only the match changed — per-field layout: feed at normal size, then
+     * struck old match followed by new match, both inside <small>.
+     */
+    public function test_only_match_changed_shows_feed_then_struck_old_match_and_new_match(): void
+    {
+        $result = pfb_ip_feed_match_cell('CINS_army_v4', '', '45.154.96.76', '45.154.96.0/24');
+
+        $this->assertSame(
+            'CINS_army_v4<br /><small><s>45.154.96.76</s><br />45.154.96.0/24</small>',
+            $result
+        );
+    }
+
+    /**
+     * Both feed and match changed — groups by RECORD, not by field.
+     *
+     * Scenario: IP alert re-evaluated to a different feed and a broader CIDR.
+     *   Background:
+     *     Given a logged event for 45.154.96.76 matched by CINS_army_v4
+     *     And a re-evaluation that matches ET_Block_v4 / 45.154.96.0/24 instead
+     *
+     *   When pfb_ip_feed_match_cell is called with both new values non-empty
+     *
+     *   Then the output groups by record: struck previous pair first, current pair second.
+     *     The struck previous match (<s>45.154.96.76</s>) must appear BEFORE the
+     *     current feed token (ET_Block_v4) — proving the by-record grouping and
+     *     distinguishing it from the old per-field layout (which placed
+     *     ET_Block_v4 before <s>45.154.96.76</s>).
+     */
+    public function test_both_changed_groups_by_record_struck_previous_pair_before_current_pair(): void
+    {
+        // Given
+        $feed     = 'CINS_army_v4';
+        $feedNew  = 'ET_Block_v4';
+        $match    = '45.154.96.76';
+        $matchNew = '45.154.96.0/24';
+
+        // When
+        $result = pfb_ip_feed_match_cell($feed, $feedNew, $match, $matchNew);
+
+        // Then — full expected string (by-record grouping)
+        $expected = '<s>CINS_army_v4</s><br /><small><s>45.154.96.76</s></small><br />ET_Block_v4<br /><small>45.154.96.0/24</small>';
+        $this->assertSame($expected, $result);
+
+        // Structural proof: the struck previous match must come BEFORE the current feed,
+        // so this assertion would FAIL on the old per-field layout where ET_Block_v4
+        // appeared before <s>45.154.96.76</s>.
+        $posStruckMatch  = strpos($result, '<s>45.154.96.76</s>');
+        $posCurrentFeed  = strpos($result, 'ET_Block_v4');
+        $this->assertNotFalse($posStruckMatch, 'struck previous match must be present');
+        $this->assertNotFalse($posCurrentFeed, 'current feed must be present');
+        $this->assertLessThan(
+            $posCurrentFeed,
+            $posStruckMatch,
+            'struck previous match must appear before current feed (by-record grouping)'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #366

## Problem

On the IP/firewall Alerts page, when pfBlockerNG re-evaluates a logged event and both the feed name and the matched IP/CIDR differ from what was logged, the Feed column stacked the values grouped **by field** — distinguished only by strikethrough and a hover tooltip:

```
~CINS_army_v4~      (struck previous feed)
ET_Block_v4         (current feed)
~45.154.96.76~      (struck previous match)
45.154.96.0/24      (current match)
```

It is not obvious that two records are shown, nor which feed/match belong together.

## Change

Group the cell **by record** instead — the struck previous pair first, then the current pair:

```
~CINS_army_v4~      (struck previous feed)
~45.154.96.76~      (struck previous match)
ET_Block_v4         (current feed)
45.154.96.0/24      (current match)
```

- New pure helper `pfb_ip_feed_match_cell()` assembles the cell inner HTML; both print sites (standard and Unified IP-alert views) use it.
- Regrouping applies **only when both** the feed and the matched IP changed (the confusing case). When only one — or neither — changed, today's exact layout is preserved.
- Presentation-only: no change to parsing, the hover tooltip, truncation, or any data model.

## Tests

`tests/php/AlertsFeedMatchCellGroupingTest.php` pins all four change-branches with exact-HTML assertions, plus a structural ordering assertion (struck previous match precedes the current feed) that fails on the old per-field layout.

Gates: `php -l`, full `phpunit` (842 tests), `phpcs`, `phpstan` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9eEPiZPP6wQUBh762dkTk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the feed and match cell rendering logic in IP alert logs for improved code organization and maintainability.

* **Style**
  * Enhanced the visual presentation of feed and match information in alert logs to clearly distinguish current values from previous values.

* **Tests**
  * Added comprehensive test coverage for various feed and match display scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->