### PR TITLE
alerts: group DNSBL feed/group cell by record (#366)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2208,6 +2208,7 @@ function convert_dnsbl_log($mode, $fields) {
 
 	$isMatch = TRUE;
 	$p_group = $p_domain = $p_feed = $p_mode = '';
+	$p_feed_disp = $p_group_disp = '';
 
 	// Collect current details about domain
 	// Skip for upstream blocks: the domain is not in a local feed, so pfb_dnsbl_parse()
@@ -2363,6 +2364,7 @@ function convert_dnsbl_log($mode, $fields) {
 		} else {
 			$p_feed	= pfb_hsc($p_feed);
 		}
+		$p_feed_disp = $p_feed;
 		$p_feed	= "<s>{$p_feed}</s><br />";
 	}
 	if (!empty($fields[8])) {
@@ -2375,6 +2377,7 @@ function convert_dnsbl_log($mode, $fields) {
 		} else {
 			$p_group = pfb_hsc($p_group);
 		}
+		$p_group_disp = $p_group;
 		$p_group = "<s>{$p_group}</s><br />";
 	}
 	if (!empty($fields[6])) {
@@ -2383,6 +2386,9 @@ function convert_dnsbl_log($mode, $fields) {
 
 	$pfbalertdnsbl[13]	= "{$p_group}" . pfb_hsc($fields[6]);
 	$pfbalertdnsbl[15]	= "{$p_feed}" . pfb_hsc($fields[8]);
+
+	// Group the Feed/Group cell by record when both changed, mirroring the IP cell.
+	$feed_group_cell = pfb_dnsbl_feed_group_cell($p_feed_disp, pfb_hsc($fields[8]), $p_group_disp, pfb_hsc($fields[6]));
 
 	// Query type suffix (Python mode logs the record type as field [10]; older
 	// Unbound-mode lines carry it in the b_type suffix [5] and lack field [10]).
@@ -2523,7 +2529,7 @@ function convert_dnsbl_log($mode, $fields) {
 			<td style=\"white-space: nowrap;\">{$unlock_dom}&nbsp;{$alert_dom}&nbsp;{$supp_dom}{$ex_dom}</td>
 			<td>{$pfbalertdnsbl[8]}<small>&emsp;[ {$pfbalertdnsbl[20]} ]</small> {$pfb_https}{$pfb_python}
 				<br /><small>{$pfbalertdnsbl[19]}</small></td>
-			<td title=\"{$f_g_title}\">{$pfbalertdnsbl[15]}<br /><small>{$pfbalertdnsbl[13]}</small></td>
+			<td title=\"{$f_g_title}\">{$feed_group_cell}</td>
 			</tr>");
 	}
 	else {
@@ -2547,7 +2553,7 @@ function convert_dnsbl_log($mode, $fields) {
 			<td>{$pfbalertdnsbl[2]}</td>
 			<td style=\"white-space: nowrap;\">{$unlock_dom}&nbsp;{$alert_dom}&nbsp;{$supp_dom}{$ex_dom}</td>
 			<td>{$pfbalertdnsbl[8]}</td>
-			<td title=\"{$f_g_title}\">{$pfbalertdnsbl[15]}<br /><small>{$pfbalertdnsbl[13]}</small></td>
+			<td title=\"{$f_g_title}\">{$feed_group_cell}</td>
 			<td></td>
 			</tr>");
 	}
@@ -2748,6 +2754,36 @@ function pfb_ip_feed_match_cell(string $feed, string $feed_new, string $match, s
 	}
 	// Neither changed.
 	return "{$feed}<br /><small>{$match}</small>";
+}
+
+
+/**
+ * Build the inner HTML for the DNSBL alert Feed/Group cell.
+ *
+ * Sibling of pfb_ip_feed_match_cell() for the DNSBL views. When a domain was
+ * previously blocked by a different feed AND a different group (both $prev_feed
+ * and $prev_group are non-empty), groups the output by record: the struck
+ * previous pair first, then the current pair. When only one of the two has a
+ * previous value the per-field layout is preserved, matching today's behaviour.
+ *
+ * All four parameters must already be HTML-escaped by the caller; $prev_feed and
+ * $prev_group are empty strings when there is no previous value for that field.
+ */
+function pfb_dnsbl_feed_group_cell(string $prev_feed, string $cur_feed, string $prev_group, string $cur_group): string {
+	if ($prev_feed !== '' && $prev_group !== '') {
+		// Both changed — group by record: struck previous pair, then current pair.
+		return "<s>{$prev_feed}</s><br /><small><s>{$prev_group}</s></small><br />{$cur_feed}<br /><small>{$cur_group}</small>";
+	}
+	elseif ($prev_feed !== '') {
+		// Only the feed changed — per-field layout.
+		return "<s>{$prev_feed}</s><br />{$cur_feed}<br /><small>{$cur_group}</small>";
+	}
+	elseif ($prev_group !== '') {
+		// Only the group changed — per-field layout.
+		return "{$cur_feed}<br /><small><s>{$prev_group}</s><br />{$cur_group}</small>";
+	}
+	// No previous value.
+	return "{$cur_feed}<br /><small>{$cur_group}</small>";
 }
 
 

--- a/tests/php/AlertsDnsblFeedGroupCellGroupingTest.php
+++ b/tests/php/AlertsDnsblFeedGroupCellGroupingTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the grouping behaviour of pfb_dnsbl_feed_group_cell() — the DNSBL/Unified
+ * analogue of pfb_ip_feed_match_cell(): when a domain was previously blocked by a
+ * different feed AND a different group the cell groups output by record (struck
+ * previous pair first, then current pair); when only one has a previous value the
+ * per-field layout is preserved.
+ *
+ * The function under test is loaded off-appliance via the same eval-extract
+ * technique as AlertsFeedMatchCellGroupingTest: the alerts page source is read,
+ * require_once() lines stripped, and only the function block eval'd.
+ */
+#[CoversFunction('pfb_dnsbl_feed_group_cell')]
+final class AlertsDnsblFeedGroupCellGroupingTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (function_exists('pfb_dnsbl_feed_group_cell')) {
+            return;
+        }
+        $src = file_get_contents(
+            dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
+        );
+        if ($src === false) {
+            throw new RuntimeException('failed to read pfblockerng_alerts.php');
+        }
+        $src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $src);
+        $start = strpos($src, "\nfunction ");
+        $end   = strpos($src, "\n\$pgtitle = ");
+        if ($start === false || $end === false || $end <= $start) {
+            throw new RuntimeException('could not locate the function block in pfblockerng_alerts.php');
+        }
+        eval("\n" . substr($src, $start + 1, $end - $start - 1));
+    }
+
+    /**
+     * No previous detection — both current values render at their normal sizes
+     * (feed, then group in <small>) with no struck markup.
+     */
+    public function test_no_previous_renders_feed_then_group_in_small(): void
+    {
+        $result = pfb_dnsbl_feed_group_cell('', 'StevenBlack', '', 'Malicious');
+
+        $this->assertSame('StevenBlack<br /><small>Malicious</small>', $result);
+    }
+
+    /**
+     * Only the feed had a previous value — per-field layout: struck previous
+     * feed, current feed, then the (unchanged) group wrapped in <small>.
+     */
+    public function test_only_feed_previous_shows_struck_prev_feed_then_cur_feed_then_group(): void
+    {
+        $result = pfb_dnsbl_feed_group_cell('OISD_Big', 'StevenBlack', '', 'Malicious');
+
+        $this->assertSame(
+            '<s>OISD_Big</s><br />StevenBlack<br /><small>Malicious</small>',
+            $result
+        );
+    }
+
+    /**
+     * Only the group had a previous value — per-field layout: current feed at
+     * normal size, then struck previous group followed by current group, both
+     * inside <small>.
+     */
+    public function test_only_group_previous_shows_feed_then_struck_prev_group_and_cur_group(): void
+    {
+        $result = pfb_dnsbl_feed_group_cell('', 'StevenBlack', 'Ads', 'Malicious');
+
+        $this->assertSame(
+            'StevenBlack<br /><small><s>Ads</s><br />Malicious</small>',
+            $result
+        );
+    }
+
+    /**
+     * Both feed and group had a previous value — groups by RECORD, not by field.
+     *
+     * Scenario: a domain re-detected under a different feed in a different group.
+     *   Background:
+     *     Given a domain previously blocked by OISD_Big in group Ads
+     *     And now blocked by StevenBlack in group Malicious
+     *
+     *   When pfb_dnsbl_feed_group_cell is called with both previous values non-empty
+     *
+     *   Then the output groups by record: struck previous pair first, current pair
+     *     second. The struck previous group (<s>Ads</s>) must appear BEFORE the
+     *     current feed (StevenBlack) — proving the by-record grouping and
+     *     distinguishing it from the old per-field layout (which placed StevenBlack
+     *     before <s>Ads</s>).
+     */
+    public function test_both_previous_groups_by_record_struck_previous_pair_before_current_pair(): void
+    {
+        // Given / When
+        $result = pfb_dnsbl_feed_group_cell('OISD_Big', 'StevenBlack', 'Ads', 'Malicious');
+
+        // Then — full expected string (by-record grouping)
+        $expected = '<s>OISD_Big</s><br /><small><s>Ads</s></small><br />StevenBlack<br /><small>Malicious</small>';
+        $this->assertSame($expected, $result);
+
+        // Structural proof: the struck previous group must come BEFORE the current
+        // feed, so this assertion would FAIL on the old per-field layout where
+        // StevenBlack appeared before <s>Ads</s>.
+        $posStruckGroup = strpos($result, '<s>Ads</s>');
+        $posCurrentFeed = strpos($result, 'StevenBlack');
+        $this->assertNotFalse($posStruckGroup, 'struck previous group must be present');
+        $this->assertNotFalse($posCurrentFeed, 'current feed must be present');
+        $this->assertLessThan(
+            $posCurrentFeed,
+            $posStruckGroup,
+            'struck previous group must appear before current feed (by-record grouping)'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #366

Follow-on to the IP-alert fix (PR #399): the **DNSBL** alert views — both the standard DNSBL view and the **Unified** view — share the same combined Feed/Group cell, and had the same "grouped by field, not by record" confusion.

## Problem

When a domain is re-detected under a **different feed *and* a different group**, `convert_dnsbl_log()` stacked the cell field-first:

```
~OISD_Big~       (struck previous feed)
StevenBlack      (current feed)
~Ads~            (struck previous group, in <small>)
Malicious        (current group)
```

It is not obvious that two records are shown, nor which feed/group belong together. (Same root cause as #366 on the IP side, where the cell combined feed + matched IP/CIDR.)

## Change

Group the cell **by record** — the struck previous pair first, then the current pair:

```
~OISD_Big~  ~Ads~
StevenBlack  Malicious
```

- New helper `pfb_dnsbl_feed_group_cell()` — sibling of `pfb_ip_feed_match_cell()`, in the DNSBL data model's natural convention (previous-optional, current always present).
- Both DNSBL print sites (standard ~line 2529 and Unified ~line 2553) use it.
- Regrouping applies **only when both** the feed and group had a previous value (the confusing case). When only one — or neither — changed, today's exact layout is preserved.
- The `[13]`/`[15]` fields are retained unchanged (the alert filter matches against them); only the rendered cell is regrouped. Presentation-only — no change to parsing, the hover tooltip, or truncation.

## Tests

`tests/php/AlertsDnsblFeedGroupCellGroupingTest.php` pins all four branches with exact-HTML assertions, plus a structural ordering assertion (struck previous group precedes the current feed) that fails on the old per-field layout.

Gates: `php -l`, full `phpunit` (846 tests), `phpcs`, `phpstan` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9eEPiZPP6wQUBh762dkTk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNSBL alert table display to better group feed and group information when both values change, now consistent with IP log formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->