### PR TITLE
pfblockerng: skip _v6 aliases in the firewall-rule _v4 suffix migration (#360)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -343,6 +343,17 @@ function pfb_alias_entry_count(array $grep_lines): int {
 	return is_numeric($grep_lines[0] ?? NULL) ? (int) $grep_lines[0] : 0;
 }
 
+// Returns TRUE only for a legacy bare pfB_ alias on an IPv4-family rule that
+// still needs the '_v4' suffix appended. Addresses already ending in '_v4' or
+// '_v6' are left alone (the '_v6' skip mirrors the NAT-rule upgrade path and
+// fixes issue #360: a 'pfB_*_v6' alias must never become 'pfB_*_v6_v4').
+function pfb_rule_alias_needs_v4_suffix($address, $ipprotocol) {
+	return str_starts_with((string) $address, 'pfB_') &&
+	       substr((string) $address, -3) !== '_v4' &&
+	       substr((string) $address, -3) !== '_v6' &&
+	       $ipprotocol === 'inet';
+}
+
 
 // Function to filter/sanitize user input
 function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE) {
@@ -10148,9 +10159,7 @@ function sync_package_pfblockerng($cron='') {
 
 		// Query for previous IPv4 pfBlockerNG 'alias type' aliasnames which are not in the new '_v4' suffix format
 		foreach (array('source', 'destination') as $rtype) {
-			if (substr($rule[$rtype]['address'], 0, 4) == 'pfB_' &&
-				substr($rule[$rtype]['address'], -3) != '_v4' &&
-				$rule['ipprotocol'] == 'inet') {
+			if (pfb_rule_alias_needs_v4_suffix($rule[$rtype]['address'] ?? '', $rule['ipprotocol'] ?? '')) {
 				$pfb['autorules'] = TRUE;	// Set flag to re-configure Firewall rules and add missing '_v4' suffix
 			}
 		}
@@ -13248,10 +13257,7 @@ function sync_package_pfblockerng($cron='') {
 
 						// Upgrade previous IPv4 pfBlockerNG 'alias type' aliasnames to new '_v4' suffix format
 						foreach (array('source', 'destination') as $rtype) {
-							if (substr($rule[$rtype]['address'], 0, 4) == 'pfB_' &&
-							    substr($rule[$rtype]['address'], -3) != '_v4' &&
-							    $rule['ipprotocol'] == 'inet') {
-
+							if (pfb_rule_alias_needs_v4_suffix($rule[$rtype]['address'] ?? '', $rule['ipprotocol'] ?? '')) {
 								// Add '_v4' suffix
 								$rule[$rtype]['address'] = "{$rule[$rtype]['address']}_v4";
 							}

--- a/tests/php/AliasSuffixUpgradeTest.php
+++ b/tests/php/AliasSuffixUpgradeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_rule_alias_needs_v4_suffix() — pins the predicate that guards the
+ * firewall-rule '_v4' suffix migration (scan phase and upgrade phase in
+ * pfblockerng.inc).
+ *
+ * The predicate returns TRUE only for a bare pfB_ alias on an inet-family rule
+ * that still needs the '_v4' suffix. Addresses already ending in '_v4' or '_v6'
+ * are excluded:
+ *   - '_v4' already suffixed — no double-suffix.
+ *   - '_v6' guard — fixes issue #360: without this guard a rule referencing
+ *     'pfB_Bogons_v6' on an inet-family rule would be rewritten to the
+ *     nonexistent 'pfB_Bogons_v6_v4', breaking the pf filter reload. The NAT
+ *     upgrade path already carried this guard; the filter-rule paths did not.
+ *
+ * Branch coverage: every exit path of the predicate has its own assertion.
+ * The '_v6'+inet→FALSE case is paired with a bare-pfB_+inet→TRUE case in the
+ * same test so green proves the '_v6' guard is a real branch, not an
+ * always-FALSE path.
+ */
+#[CoversFunction('pfb_rule_alias_needs_v4_suffix')]
+final class AliasSuffixUpgradeTest extends TestCase
+{
+	// -------------------------------------------------------------------------
+	// Core: bare pfB_ alias on inet — the only case that should return TRUE.
+	// Paired in one test with the _v6 case to prove both branches are real.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A bare pfB_ alias on an inet-family rule needs the '_v4' suffix (TRUE),
+	 * but a pfB_*_v6 alias on the same inet-family rule must NOT be eligible
+	 * (FALSE) — appending '_v4' would produce the nonexistent 'pfB_Foo_v6_v4'
+	 * (issue #360).
+	 */
+	public function testBarePfbInetNeedsSuffixButV6InetDoesNot(): void
+	{
+		// Given: a bare pfB_ alias on an inet rule → should be suffixed.
+		$this->assertTrue(
+			pfb_rule_alias_needs_v4_suffix('pfB_Bogons', 'inet'),
+			'bare pfB_ alias + inet must return TRUE (needs _v4 suffix)'
+		);
+
+		// Given: a _v6 alias on an inet rule → must NOT be suffixed (issue #360).
+		$this->assertFalse(
+			pfb_rule_alias_needs_v4_suffix('pfB_Bogons_v6', 'inet'),
+			'pfB_*_v6 alias + inet must return FALSE (would become pfB_*_v6_v4)'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Already suffixed with '_v4' — no double-suffix.
+	// -------------------------------------------------------------------------
+
+	public function testAlreadyV4SuffixedReturnsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_rule_alias_needs_v4_suffix('pfB_Bogons_v4', 'inet'),
+			'pfB_*_v4 alias already has the suffix — must return FALSE'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// IPv6-family rule — suffix migration only applies to inet.
+	// -------------------------------------------------------------------------
+
+	public function testBarePfbInet6ReturnsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_rule_alias_needs_v4_suffix('pfB_Bogons', 'inet6'),
+			'bare pfB_ alias on an inet6 rule must return FALSE (not an IPv4 rule)'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Non-pfB_ address — never eligible.
+	// -------------------------------------------------------------------------
+
+	public function testNonPfbAddressReturnsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_rule_alias_needs_v4_suffix('RFC1918', 'inet'),
+			'non-pfB_ address must return FALSE'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Empty string — the 'any' source/destination case; must not crash.
+	// -------------------------------------------------------------------------
+
+	public function testEmptyAddressReturnsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_rule_alias_needs_v4_suffix('', 'inet'),
+			'empty address (any rule) must return FALSE without error'
+		);
+	}
+}


### PR DESCRIPTION
Fixes #360 (Redmine #14054).

## Bug

The firewall-rule `_v4`-suffix migration in `pfblockerng.inc` appends `_v4` to any rule address that starts with `pfB_`, does **not** end in `_v4`, and has `ipprotocol == 'inet'` — but it has **no guard for addresses already ending in `_v6`**. So a rule referencing `pfB_Bogons_v6` on an `inet`-family rule was rewritten to the nonexistent `pfB_Bogons_v6_v4`, producing:

```text
Unresolvable source alias 'pfB_Bogons_v6_v4' for rule 'Bogons (outside) IPv6'
```

and a **failed filter reload**. It fires during the cron "Saving configuration" step. The NAT-rule upgrade path already guards this correctly (`if ($pfb_suffix == '_v6') { continue; }`); the two filter-rule paths did not.

## Fix

Extract a pure predicate `pfb_rule_alias_needs_v4_suffix($address, $ipprotocol)` that returns TRUE only for a bare `pfB_` alias on an IPv4-family rule still needing the suffix — i.e. starts with `pfB_`, does **not** end in `_v4`, does **not** end in `_v6`, and `ipprotocol === 'inet'`. Both filter-rule sites (the scan phase that sets `autorules`, and the upgrade phase that mutates the address) now go through it, adding the missing `_v6` skip and de-duplicating the previously-identical inline conditions. Behaviour for bare `pfB_Foo` and `pfB_Foo_v4` is unchanged; the NAT path is untouched (reference only). The `?? ''` on the array accesses also removes a latent undefined-key warning for `any`-address rules without changing the result.

## Testing

New `tests/php/AliasSuffixUpgradeTest.php` (`#[CoversFunction]`) covers every branch:

- bare `pfB_Bogons` + `inet` → eligible (TRUE) — **paired in one test** with
- `pfB_Bogons_v6` + `inet` → NOT eligible (FALSE) — the bug scenario; green proves the `_v6` skip is a real branch, not an always-FALSE path
- `pfB_Bogons_v4` + `inet` → FALSE (already suffixed)
- `pfB_Bogons` + `inet6` → FALSE (IPv6-family rule)
- `RFC1918` + `inet` → FALSE (non-`pfB_`)
- `''` + `inet` → FALSE (the `any`-rule case, no crash)

Verified the test **fails without** the `_v6` guard and **passes with** it. Gates green: PHPUnit, PHPStan (0), PHPCS (0), `php -l`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA2jJJPJzJaVraEVDp8NVp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of legacy IPv4 firewall alias configuration by centralizing suffix determination logic across multiple code paths, reducing duplication and preventing unintended alias name modifications.

* **Tests**
  * Added comprehensive unit tests for alias suffix validation, covering various address formats and protocol versions to ensure correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->