### PR TITLE
pfblockerng: follow alias renames into Advanced In/Out refs + enforce per-field alias types (#357, #356)

### DIFF
--- a/src/usr/local/pkg/firewall_aliases_edit/pre_write_config/pfblockerng.php
+++ b/src/usr/local/pkg/firewall_aliases_edit/pre_write_config/pfblockerng.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * pfblockerng.php — pre_write_config hook for firewall_aliases_edit
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2015-2026 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2024 BBcan177@gmail.com
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * pfBlockerNG — follow a firewall-alias rename into our stored Advanced
+ * Inbound/Outbound references (issue #357). Included by
+ * pfSense_handle_custom_code() in saveAlias(); $origname (old) and
+ * $post['name'] (new) are in scope, and saveAlias persists via its own
+ * write_config() right after this runs. Keep this file MINIMAL — it is the
+ * only piece coupled to pfSense's internal save scope; the actual work lives
+ * in pfb_alias_rename_followup() (pfblockerng_extra.inc), gateway-routed and
+ * unit-tested.
+ */
+
+require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');
+if (isset($origname, $post['name']) && function_exists('pfb_alias_rename_followup')) {
+	pfb_alias_rename_followup((string) $origname, (string) $post['name']);
+}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1205,6 +1205,102 @@ function pfb_cfg_field_adapter_type(array $entry): string
 	return 'toggle';
 }
 
+// ---------------------------------------------------------------------------
+// Issue #357 — alias-rename follow-up helper.
+//
+// pfSense's alias-rename path (saveAlias() in alias-utils.inc) calls
+// update_alias_name() to rewrite core config sections (aliases, filter,
+// nat, …) but does NOT touch installedpackages/*.  The four per-row
+// Advanced Inbound/Outbound alias keys (aliasports_in / aliasports_out /
+// aliasaddr_in / aliasaddr_out) stored in our list sections go stale after
+// a rename.  pfb_alias_rename_followup() rewrites them in-memory via the
+// PfbConfig section gateway; the caller (the pre_write_config shim or any
+// other save path) is responsible for persisting via write_config().
+// ---------------------------------------------------------------------------
+
+/**
+ * pfb_alias_rename_followup — follow a firewall-alias rename into
+ * pfBlockerNG's stored Advanced Inbound/Outbound references.
+ *
+ * pfSense's alias rename does not update installedpackages/*, so rewrite
+ * the four per-row alias keys across the IP/DNSBL list sections, through
+ * the PfbConfig section gateway. Does NOT persist (write_config is the
+ * caller's job). Returns TRUE if anything changed.
+ *
+ * @param  string $old_name  The alias name before the rename.
+ * @param  string $new_name  The alias name after the rename.
+ * @return bool              TRUE when at least one key was rewritten.
+ */
+function pfb_alias_rename_followup(string $old_name, string $new_name): bool
+{
+	if ($old_name === '' || $new_name === '' || $old_name === $new_name) {
+		return FALSE;
+	}
+
+	$changed  = FALSE;
+	$sections = ['pfblockernglistsv4', 'pfblockernglistsv6', 'pfblockerngdnsbl'];
+	$keys     = ['aliasports_in', 'aliasports_out', 'aliasaddr_in', 'aliasaddr_out'];
+
+	foreach ($sections as $section) {
+		$path = "installedpackages/{$section}/config";
+		$rows = PfbConfig::readSection($path);
+		if (empty($rows)) {
+			continue;
+		}
+
+		$section_dirty = FALSE;
+		foreach ($rows as $i => $row) {
+			foreach ($keys as $key) {
+				if (($rows[$i][$key] ?? '') === $old_name) {
+					$rows[$i][$key] = $new_name;
+					$section_dirty  = TRUE;
+					$changed        = TRUE;
+				}
+			}
+		}
+
+		if ($section_dirty) {
+			PfbConfig::writeSection($path, $rows);
+		}
+	}
+
+	return $changed;
+}
+
+// ---------------------------------------------------------------------------
+// Issue #356 — per-field alias-type validation helper.
+//
+// The four Advanced Inbound/Outbound alias fields accept different alias
+// types: port fields (aliasports_*) require a pfSense 'port' alias; address
+// fields (aliasaddr_*) require a 'network' or 'host' alias.  This helper
+// encodes that rule in one testable place so the category-edit validation
+// loop and any future caller stay in sync.
+// ---------------------------------------------------------------------------
+
+/**
+ * pfb_alias_field_type_ok — check whether an alias type is valid for a
+ * given Advanced Inbound/Outbound field.
+ *
+ * Port fields (aliasports_*) require a 'port' alias; address fields
+ * (aliasaddr_*) require a 'network' or 'host' alias.
+ * Unknown field names return FALSE (fail closed).
+ *
+ * @param  string $field       One of aliasports_in, aliasports_out,
+ *                             aliasaddr_in, aliasaddr_out.
+ * @param  string $alias_type  The type string returned by alias_get_type().
+ * @return bool                TRUE when the alias type is allowed for this field.
+ */
+function pfb_alias_field_type_ok(string $field, string $alias_type): bool
+{
+	if ($field === 'aliasports_in' || $field === 'aliasports_out') {
+		return $alias_type === 'port';
+	}
+	if ($field === 'aliasaddr_in' || $field === 'aliasaddr_out') {
+		return $alias_type === 'network' || $alias_type === 'host';
+	}
+	return FALSE;
+}
+
 // logger() and localize_text() are pfSense-core helpers (src/etc/inc/util.inc)
 // on pfSense Plus / master, but absent from released pfSense CE <= 2.8.1. Define
 // fallbacks ONLY when core does not provide them, so this package runs on both:

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -597,7 +597,7 @@ if ($_POST && isset($_POST['save'])) {
 		'aliasports_in'  => ['dir' => 'Port In',         'type_label' => 'Port-type'],
 		'aliasports_out' => ['dir' => 'Port Out',        'type_label' => 'Port-type'],
 		'aliasaddr_in'   => ['dir' => 'Destination In',  'type_label' => 'Network or Host-type'],
-		'aliasaddr_out'  => ['dir' => 'Destination Out', 'type_label' => 'Network or Host-type'],
+		'aliasaddr_out'  => ['dir' => 'Source Out',      'type_label' => 'Network or Host-type'],
 	];
 	foreach ($adv_alias_fields as $field => $meta) {
 		if (!empty($_POST[$field])) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -591,14 +591,20 @@ if ($_POST && isset($_POST['save'])) {
 	}
 
 
-	// Validate Adv. firewall rule settings
-	foreach (array(	'aliasports_in' => 'Port In', 'aliasaddr_in' => 'Destination In',
-			'aliasports_out' => 'Port Out', 'aliasaddr_out' => 'Destination Out') as $value => $auto_dir) {
-		if (!empty($_POST[$value])) {
-			if (!is_alias($_POST[$value])) {
-				$input_errors[] = "Settings: Advanced {$auto_dir}bound Alias error - Must use an existing Alias";
-			} elseif (!in_array(alias_get_type($_POST[$value]), ['network', 'port'])) {
-				$input_errors[] = "Settings: Advanced {$auto_dir}bound Alias error - Must use an alias type of Network or Port";
+	// Validate Adv. firewall rule settings (issue #356: per-field alias-type check).
+	// Port fields require a port-type alias; address fields require a network or host alias.
+	$adv_alias_fields = [
+		'aliasports_in'  => ['dir' => 'Port In',         'type_label' => 'Port-type'],
+		'aliasports_out' => ['dir' => 'Port Out',        'type_label' => 'Port-type'],
+		'aliasaddr_in'   => ['dir' => 'Destination In',  'type_label' => 'Network or Host-type'],
+		'aliasaddr_out'  => ['dir' => 'Destination Out', 'type_label' => 'Network or Host-type'],
+	];
+	foreach ($adv_alias_fields as $field => $meta) {
+		if (!empty($_POST[$field])) {
+			if (!is_alias($_POST[$field])) {
+				$input_errors[] = "Settings: Advanced {$meta['dir']}bound Alias error - Must use an existing Alias";
+			} elseif (!pfb_alias_field_type_ok($field, alias_get_type($_POST[$field]))) {
+				$input_errors[] = "Settings: Advanced {$meta['dir']}bound Alias error - Must use a {$meta['type_label']} alias";
 			}
 		}
 	}
@@ -1449,7 +1455,7 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			'text',
 			$pconfig["aliasports_{$advmode}"]
 		))->setHelp('<a target="_blank" href="/firewall_aliases.php?tab=port">Click Here to add/edit Aliases</a>
-				Do not manually enter port numbers.<br />Do not use \'pfB_\' in the Port Alias name.')
+				Do not manually enter port numbers.<br />Do not use \'pfB_\' in the Port Alias name.<br />Must be a Port-type alias.')
 		  ->setWidth(8);
 		$section->add($group);
 
@@ -1483,7 +1489,7 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			$pconfig['aliasaddr_' . $advmode]
 		))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
 			. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the \'IP Network Type\' Alias name.<br />'
-			. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)")
+			. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)<br />Must be a Network or Host-type alias.")
 		  ->setWidth(8);
 		$section->add($group);
 

--- a/tests/php/AliasRenameFollowupTest.php
+++ b/tests/php/AliasRenameFollowupTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_alias_rename_followup() (issue #357) and
+ * pfb_alias_field_type_ok() (issue #356).
+ *
+ * pfb_alias_rename_followup():
+ *   Rewrites the four per-row Advanced Inbound/Outbound alias keys
+ *   (aliasports_in / aliasports_out / aliasaddr_in / aliasaddr_out) across
+ *   the three pfBlockerNG list sections when a firewall alias is renamed.
+ *   Operates via the PfbConfig section gateway; does NOT call write_config().
+ *   Returns TRUE when at least one key changed, FALSE otherwise.
+ *
+ * pfb_alias_field_type_ok():
+ *   Port fields (aliasports_*) require a 'port' alias.
+ *   Address fields (aliasaddr_*) require a 'network' or 'host' alias.
+ *   Unknown fields return FALSE (fail closed).
+ */
+#[CoversFunction('pfb_alias_rename_followup')]
+#[CoversFunction('pfb_alias_field_type_ok')]
+final class AliasRenameFollowupTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Seed a single row into one of the three list sections.
+	 *
+	 * @param string $section  'pfblockernglistsv4', 'pfblockernglistsv6', or 'pfblockerngdnsbl'.
+	 * @param int    $idx      Row index.
+	 * @param array  $row      Row data (partial; only the keys you provide are set).
+	 */
+	private function seedRow(string $section, int $idx, array $row): void
+	{
+		$path = "installedpackages/{$section}/config/{$idx}";
+		foreach ($row as $key => $value) {
+			config_set_path("{$path}/{$key}", $value);
+		}
+	}
+
+	/**
+	 * Read a single key from a stored row.
+	 */
+	private function readRowKey(string $section, int $idx, string $key): mixed
+	{
+		return config_get_path("installedpackages/{$section}/config/{$idx}/{$key}");
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_alias_rename_followup() — rename-follow tests
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A row in pfblockernglistsv4 with aliasaddr_in = 'OldAlias' is rewritten
+	 * to 'NewAlias' after the rename, and the function returns TRUE.
+	 *
+	 * Before-and-after asserted so a regression (rename not applied) would
+	 * fail on the post-call assertion, not silently pass.
+	 */
+	public function testSingleKeyInV4SectionIsRewrittenAndReturnsTrue(): void
+	{
+		// Given: one row in pfblockernglistsv4 with aliasaddr_in = 'OldAlias'.
+		$this->seedRow('pfblockernglistsv4', 0, [
+			'aliasname'    => 'MyFeed',
+			'aliasaddr_in' => 'OldAlias',
+		]);
+
+		// Before: confirm the original value is present.
+		$this->assertSame('OldAlias', $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'),
+			'Before rename: aliasaddr_in must be OldAlias');
+
+		// When.
+		$result = pfb_alias_rename_followup('OldAlias', 'NewAlias');
+
+		// Then: value was rewritten and return is TRUE.
+		$this->assertTrue($result, 'Should return TRUE when at least one key changed');
+		$this->assertSame('NewAlias', $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'),
+			'After rename: aliasaddr_in must be NewAlias');
+	}
+
+	/**
+	 * All four alias keys are rewritten across two sections when they all
+	 * reference the old alias name.
+	 *
+	 * Covers every key path in the function and verifies cross-section handling.
+	 */
+	public function testAllFourKeysAcrossTwoSectionsAreRewritten(): void
+	{
+		// Given: a row in pfblockernglistsv4 with all four alias keys set.
+		$this->seedRow('pfblockernglistsv4', 0, [
+			'aliasports_in'  => 'OldPorts',
+			'aliasports_out' => 'OldPorts',
+			'aliasaddr_in'   => 'OldAlias',
+			'aliasaddr_out'  => 'OldAlias',
+		]);
+		// And a row in pfblockerngdnsbl with two of the four keys.
+		$this->seedRow('pfblockerngdnsbl', 0, [
+			'aliasports_in' => 'OldPorts',
+			'aliasaddr_in'  => 'OldAlias',
+		]);
+
+		// Before: confirm original values in both sections.
+		$this->assertSame('OldPorts', $this->readRowKey('pfblockernglistsv4', 0, 'aliasports_in'),
+			'Before: aliasports_in in v4 must be OldPorts');
+		$this->assertSame('OldAlias', $this->readRowKey('pfblockerngdnsbl', 0, 'aliasaddr_in'),
+			'Before: aliasaddr_in in dnsbl must be OldAlias');
+
+		// When: rename OldPorts.
+		$result_ports = pfb_alias_rename_followup('OldPorts', 'NewPorts');
+
+		// Then: all OldPorts keys updated.
+		$this->assertTrue($result_ports, 'Should return TRUE for OldPorts rename');
+		$this->assertSame('NewPorts', $this->readRowKey('pfblockernglistsv4', 0, 'aliasports_in'),
+			'After OldPorts rename: aliasports_in in v4 must be NewPorts');
+		$this->assertSame('NewPorts', $this->readRowKey('pfblockernglistsv4', 0, 'aliasports_out'),
+			'After OldPorts rename: aliasports_out in v4 must be NewPorts');
+		$this->assertSame('NewPorts', $this->readRowKey('pfblockerngdnsbl', 0, 'aliasports_in'),
+			'After OldPorts rename: aliasports_in in dnsbl must be NewPorts');
+
+		// When: rename OldAlias.
+		$result_addr = pfb_alias_rename_followup('OldAlias', 'NewAddr');
+
+		// Then: all OldAlias keys updated.
+		$this->assertTrue($result_addr, 'Should return TRUE for OldAlias rename');
+		$this->assertSame('NewAddr', $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'),
+			'After OldAlias rename: aliasaddr_in in v4 must be NewAddr');
+		$this->assertSame('NewAddr', $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_out'),
+			'After OldAlias rename: aliasaddr_out in v4 must be NewAddr');
+		$this->assertSame('NewAddr', $this->readRowKey('pfblockerngdnsbl', 0, 'aliasaddr_in'),
+			'After OldAlias rename: aliasaddr_in in dnsbl must be NewAddr');
+	}
+
+	/**
+	 * A row referencing a DIFFERENT alias is left unchanged (targeted rewrite,
+	 * not blanket replacement).
+	 *
+	 * Proves the function rewrites only the exact matching key value.
+	 */
+	public function testRowReferencingDifferentAliasIsNotTouched(): void
+	{
+		// Given: two rows — one references OldAlias, one references OtherAlias.
+		$this->seedRow('pfblockernglistsv4', 0, ['aliasaddr_in' => 'OldAlias']);
+		$this->seedRow('pfblockernglistsv4', 1, ['aliasaddr_in' => 'OtherAlias']);
+
+		// Before: both values confirmed.
+		$this->assertSame('OldAlias',   $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'));
+		$this->assertSame('OtherAlias', $this->readRowKey('pfblockernglistsv4', 1, 'aliasaddr_in'));
+
+		// When: rename OldAlias only.
+		pfb_alias_rename_followup('OldAlias', 'NewAlias');
+
+		// Then: row 0 updated, row 1 unchanged.
+		$this->assertSame('NewAlias',   $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'),
+			'Row referencing OldAlias must be updated');
+		$this->assertSame('OtherAlias', $this->readRowKey('pfblockernglistsv4', 1, 'aliasaddr_in'),
+			'Row referencing OtherAlias must be unchanged');
+	}
+
+	/**
+	 * No-op: old_name === new_name — returns FALSE and changes nothing.
+	 */
+	public function testSameNameReturnsFalseAndChangesNothing(): void
+	{
+		$this->seedRow('pfblockernglistsv4', 0, ['aliasaddr_in' => 'SameAlias']);
+
+		$result = pfb_alias_rename_followup('SameAlias', 'SameAlias');
+
+		$this->assertFalse($result, 'old === new must return FALSE');
+		$this->assertSame('SameAlias', $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'),
+			'Value must be unchanged when old === new');
+	}
+
+	/**
+	 * No-op: empty old_name — returns FALSE immediately without touching config.
+	 */
+	public function testEmptyOldNameReturnsFalse(): void
+	{
+		$this->seedRow('pfblockernglistsv4', 0, ['aliasaddr_in' => 'SomeAlias']);
+
+		$result = pfb_alias_rename_followup('', 'NewAlias');
+
+		$this->assertFalse($result, 'Empty old_name must return FALSE');
+		$this->assertSame('SomeAlias', $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'),
+			'Value must be unchanged when old_name is empty');
+	}
+
+	/**
+	 * No-op: empty new_name — returns FALSE immediately without touching config.
+	 */
+	public function testEmptyNewNameReturnsFalse(): void
+	{
+		$this->seedRow('pfblockernglistsv4', 0, ['aliasaddr_in' => 'SomeAlias']);
+
+		$result = pfb_alias_rename_followup('SomeAlias', '');
+
+		$this->assertFalse($result, 'Empty new_name must return FALSE');
+		$this->assertSame('SomeAlias', $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'),
+			'Value must be unchanged when new_name is empty');
+	}
+
+	/**
+	 * No-op: old_name not present in any section — returns FALSE.
+	 *
+	 * Proves the function does not corrupt unrelated data when the alias name
+	 * does not appear anywhere in the config.
+	 */
+	public function testAbsentOldNameReturnsFalse(): void
+	{
+		$this->seedRow('pfblockernglistsv4', 0, ['aliasaddr_in' => 'CompletelyDifferent']);
+
+		// Before: confirm value.
+		$this->assertSame('CompletelyDifferent', $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'));
+
+		$result = pfb_alias_rename_followup('NotPresentAnywhere', 'NewAlias');
+
+		$this->assertFalse($result, 'Absent old_name must return FALSE');
+		$this->assertSame('CompletelyDifferent', $this->readRowKey('pfblockernglistsv4', 0, 'aliasaddr_in'),
+			'Unrelated value must be unchanged');
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_alias_field_type_ok() — per-field alias-type validation tests
+	// -----------------------------------------------------------------------
+
+	/**
+	 * aliasports_in + 'port' → TRUE (port field accepts port alias).
+	 */
+	public function testPortsInFieldAcceptsPortType(): void
+	{
+		$this->assertTrue(pfb_alias_field_type_ok('aliasports_in', 'port'),
+			'aliasports_in + port must be TRUE');
+	}
+
+	/**
+	 * aliasports_out + 'port' → TRUE (port field accepts port alias).
+	 */
+	public function testPortsOutFieldAcceptsPortType(): void
+	{
+		$this->assertTrue(pfb_alias_field_type_ok('aliasports_out', 'port'),
+			'aliasports_out + port must be TRUE');
+	}
+
+	/**
+	 * aliasports_in + 'network' → FALSE (port field rejects network alias).
+	 * aliasports_in + 'host' → FALSE (port field rejects host alias).
+	 *
+	 * Paired in one test so both sides of the type check are proven non-trivial.
+	 */
+	public function testPortsInFieldRejectsNetworkAndHostTypes(): void
+	{
+		$this->assertFalse(pfb_alias_field_type_ok('aliasports_in', 'network'),
+			'aliasports_in + network must be FALSE');
+		$this->assertFalse(pfb_alias_field_type_ok('aliasports_in', 'host'),
+			'aliasports_in + host must be FALSE');
+	}
+
+	/**
+	 * aliasports_out + 'network' → FALSE (port field rejects network alias).
+	 * aliasports_out + 'host' → FALSE (port field rejects host alias).
+	 */
+	public function testPortsOutFieldRejectsNetworkAndHostTypes(): void
+	{
+		$this->assertFalse(pfb_alias_field_type_ok('aliasports_out', 'network'),
+			'aliasports_out + network must be FALSE');
+		$this->assertFalse(pfb_alias_field_type_ok('aliasports_out', 'host'),
+			'aliasports_out + host must be FALSE');
+	}
+
+	/**
+	 * aliasaddr_in + 'network' → TRUE (address field accepts network alias).
+	 * aliasaddr_in + 'host' → TRUE (address field accepts host alias).
+	 */
+	public function testAddrInFieldAcceptsNetworkAndHostTypes(): void
+	{
+		$this->assertTrue(pfb_alias_field_type_ok('aliasaddr_in', 'network'),
+			'aliasaddr_in + network must be TRUE');
+		$this->assertTrue(pfb_alias_field_type_ok('aliasaddr_in', 'host'),
+			'aliasaddr_in + host must be TRUE');
+	}
+
+	/**
+	 * aliasaddr_out + 'network' → TRUE (address field accepts network alias).
+	 * aliasaddr_out + 'host' → TRUE (address field accepts host alias).
+	 */
+	public function testAddrOutFieldAcceptsNetworkAndHostTypes(): void
+	{
+		$this->assertTrue(pfb_alias_field_type_ok('aliasaddr_out', 'network'),
+			'aliasaddr_out + network must be TRUE');
+		$this->assertTrue(pfb_alias_field_type_ok('aliasaddr_out', 'host'),
+			'aliasaddr_out + host must be TRUE');
+	}
+
+	/**
+	 * aliasaddr_in + 'port' → FALSE (address field rejects port alias).
+	 * aliasaddr_out + 'port' → FALSE (address field rejects port alias).
+	 *
+	 * Paired so both address fields are shown to reject port aliases.
+	 */
+	public function testAddrFieldsRejectPortType(): void
+	{
+		$this->assertFalse(pfb_alias_field_type_ok('aliasaddr_in', 'port'),
+			'aliasaddr_in + port must be FALSE');
+		$this->assertFalse(pfb_alias_field_type_ok('aliasaddr_out', 'port'),
+			'aliasaddr_out + port must be FALSE');
+	}
+
+	/**
+	 * Unknown field name → FALSE (fail closed — no permissive default).
+	 */
+	public function testUnknownFieldReturnsFalse(): void
+	{
+		$this->assertFalse(pfb_alias_field_type_ok('unknown_field', 'port'),
+			'Unknown field + port must be FALSE (fail closed)');
+		$this->assertFalse(pfb_alias_field_type_ok('unknown_field', 'network'),
+			'Unknown field + network must be FALSE (fail closed)');
+		$this->assertFalse(pfb_alias_field_type_ok('', 'port'),
+			'Empty field name must be FALSE (fail closed)');
+	}
+}

--- a/tests/smoke/test_smoke_alias_rename.py
+++ b/tests/smoke/test_smoke_alias_rename.py
@@ -1,0 +1,322 @@
+"""Live-VM smoke for pfb_alias_rename_followup() end-to-end (#357).
+
+pfBlockerNG ships a ``pre_write_config`` hook shim that pfSense calls (via
+``pfSense_handle_custom_code``) whenever a firewall alias is saved. The shim
+invokes ``pfb_alias_rename_followup($origname, $post['name'])`` which rewrites
+every occurrence of the old alias name in the four alias-reference fields
+(``aliasports_in``, ``aliasports_out``, ``aliasaddr_in``, ``aliasaddr_out``)
+across all three list sections (v4, v6, DNSBL).
+
+This test exercises the FULL path on a live pfSense VM:
+
+1. Assert the hook shim file exists (skip if the build does not ship it yet —
+   this decouples a ports pkg-plist update that may land separately).
+2. Seed a test IPv4 list row with a known alias name in two fields.
+3. Trigger the rename via ``php_eval`` (simulate the shim invocation from
+   ``saveAlias()``) and assert the rewrite landed in config.xml.
+4. Assert an unrelated alias name in the same row is UNCHANGED (no fan-out).
+5. Restore the VM to a clean state in ``finally``.
+
+These tests are DESELECTED from the default ``python -m pytest`` run.  Run via::
+
+    python -m pytest tests/smoke -m smoke --override-ini="addopts="
+
+They need the booted ``smoke_vm`` fixture, the branch ``.pkg`` (``SMOKE_PKG``),
+and the smoke deps.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+
+pytestmark = [pytest.mark.smoke]
+
+# The hook shim ``pfSense_handle_custom_code`` includes when ``saveAlias()`` runs.
+HOOK_SHIM = "/usr/local/pkg/firewall_aliases_edit/pre_write_config/pfblockerng.php"
+
+# Config section for IPv4 lists — the section ``pfb_alias_rename_followup`` iterates.
+CFG_IPV4 = "installedpackages/pfblockernglistsv4/config"
+
+# Timeout passed to ``php_eval`` / ``config_get`` calls (seconds).
+_TIMEOUT = 120.0
+
+
+# --------------------------------------------------------------------------- #
+# Module-scoped deploy fixture
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg once for all alias-rename tests in this module."""
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.collect_host_diagnostics(smoke_vm)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _free_rowid(vm: SmokeVM, cfg_root: str) -> int:
+    """Return the next free numeric index under ``cfg_root``."""
+    pre = (
+        f"$c = config_get_path({h._php_str(cfg_root)}, array());\n"
+        "$max = -1;\n"
+        "foreach (array_keys($c) as $k) { if (is_numeric($k) && (int)$k > $max) { $max = (int)$k; } }\n"
+        "$free = $max + 1;"
+    )
+    return int(h._php_read_scalar(vm, pre, "$free", timeout=_TIMEOUT))
+
+
+def _write_row(vm: SmokeVM, cfg_root: str, rowid: int, row: dict[str, str]) -> None:
+    """Write ``row`` dict to ``cfg_root/{rowid}`` via the pfSense config API."""
+    php_row = h._php_kv_array(row)
+    snippet = (
+        f"config_set_path({h._php_str(f'{cfg_root}/{rowid}')}, {php_row});\n"
+        "write_config('pfBlockerNG smoke: seed alias-rename test row');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_write_row failed: rc={result.returncode} {result.stdout!r}")
+
+
+def _del_row(vm: SmokeVM, cfg_root: str, rowid: int) -> None:
+    """Delete ``cfg_root/{rowid}`` from config.xml."""
+    snippet = (
+        f"config_del_path({h._php_str(f'{cfg_root}/{rowid}')});\n"
+        "write_config('pfBlockerNG smoke: drop alias-rename test row');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_del_row({cfg_root}/{rowid}) failed: rc={result.returncode} {result.stdout!r}")
+
+
+def _invoke_rename_shim(vm: SmokeVM, old_name: str, new_name: str) -> None:
+    """Invoke the hook shim exactly as ``pfSense_handle_custom_code()`` does.
+
+    ``saveAlias()`` sets ``$origname`` (old alias name) and ``$post['name']``
+    (new alias name) in scope, then ``include``s the shim — which calls
+    ``pfb_alias_rename_followup($origname, $post['name'])``.  We replicate
+    that calling convention here (variables in scope + include), which is
+    precisely what the pre_write_config hook tests.
+    """
+    snippet = (
+        f"$origname = {h._php_str(old_name)};\n"
+        f"$post = array('name' => {h._php_str(new_name)});\n"
+        f"@include({h._php_str(HOOK_SHIM)});\n"
+        "write_config('pfBlockerNG smoke: alias-rename followup');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_invoke_rename_shim failed: rc={result.returncode} {result.stdout!r} {result.stderr!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def test_hook_shim_file_exists_on_deployed_build(deployed_vm: SmokeVM) -> None:
+    """The pre_write_config hook shim is present on the deployed build.
+
+    This is the prerequisite for all alias-rename tests: if the shim is not
+    shipped in this build's pkg-plist, skip the remaining tests rather than
+    failing on a known-absent file.  The skip is recorded in the first test so
+    the module-level ``deployed_vm`` fixture only runs once.
+    """
+    vm = deployed_vm
+    result = vm.ssh("test", "-f", HOOK_SHIM, timeout=30)
+    if result.returncode != 0:
+        pytest.skip(
+            f"alias-rename hook shim not present on this build ({HOOK_SHIM}); "
+            "pkg-plist update pending — skipping alias-rename smoke"
+        )
+
+
+def test_alias_rename_followup_rewrites_addr_and_port_keys(deployed_vm: SmokeVM) -> None:
+    """``pfb_alias_rename_followup`` rewrites aliasaddr_in and aliasports_in on rename.
+
+    Scenario: rename-followup replaces both alias-reference fields in a seeded row.
+
+    Background:
+        The shim invokes ``pfb_alias_rename_followup($old, $new)`` which iterates
+        all three list sections (v4/v6/dnsbl) and rewrites four per-row keys
+        (aliasports_in, aliasports_out, aliasaddr_in, aliasaddr_out) wherever the
+        old name appears. This case targets the v4 section (the simplest; the
+        cross-section fan-out is covered in the next test).
+
+    Given:
+        An IPv4 list row with:
+        - aliasaddr_in = 'PfbRenameSrc'
+        - aliasports_in = 'PfbRenameSrc'
+        (both fields reference the same source alias name)
+    When:
+        The rename shim is invoked with old='PfbRenameSrc', new='PfbRenameDst'.
+    Then:
+        - aliasaddr_in is rewritten to 'PfbRenameDst'.
+        - aliasports_in is rewritten to 'PfbRenameDst'.
+    """
+    vm = deployed_vm
+    # Skip here too in case test ordering bypasses the shim-exists test.
+    shim_check = vm.ssh("test", "-f", HOOK_SHIM, timeout=30)
+    if shim_check.returncode != 0:
+        pytest.skip(f"alias-rename hook shim absent ({HOOK_SHIM}) — skip")
+
+    old_name = "PfbRenameSrc"
+    new_name = "PfbRenameDst"
+    rowid = _free_rowid(vm, CFG_IPV4)
+    base = f"{CFG_IPV4}/{rowid}"
+
+    seed_row: dict[str, str] = {
+        "aliasname": "SmkRenameRow",
+        "action": "Deny_Both",
+        "aliasaddr_in": old_name,
+        "aliasports_in": old_name,
+    }
+
+    try:
+        # BEFORE: seed the row and confirm both fields carry the old name.
+        _write_row(vm, CFG_IPV4, rowid, seed_row)
+        assert h.config_get(vm, f"{base}/aliasaddr_in") == old_name, (
+            f"precondition: aliasaddr_in should be {old_name!r} before rename"
+        )
+        assert h.config_get(vm, f"{base}/aliasports_in") == old_name, (
+            f"precondition: aliasports_in should be {old_name!r} before rename"
+        )
+
+        # ACT: invoke the hook shim (the same code path ``saveAlias()`` triggers).
+        _invoke_rename_shim(vm, old_name, new_name)
+
+        # AFTER: both fields must reflect the new name.
+        assert h.config_get(vm, f"{base}/aliasaddr_in") == new_name, (
+            f"aliasaddr_in was not rewritten from {old_name!r} to {new_name!r} by the rename shim"
+        )
+        assert h.config_get(vm, f"{base}/aliasports_in") == new_name, (
+            f"aliasports_in was not rewritten from {old_name!r} to {new_name!r} by the rename shim"
+        )
+    finally:
+        _del_row(vm, CFG_IPV4, rowid)
+
+
+def test_alias_rename_followup_leaves_unrelated_alias_unchanged(deployed_vm: SmokeVM) -> None:
+    """A rename does not rewrite fields that reference a DIFFERENT alias name.
+
+    Scenario: only the fields whose value matches the old name are touched; a
+    field referencing an unrelated alias stays intact.
+
+    Background:
+        ``pfb_alias_rename_followup`` checks each field value individually
+        against the old name.  A field referencing ``PfbUnrelated`` must not be
+        rewritten even though a co-located field referencing ``PfbRenameSrc2``
+        is — proving the match is per-field-value, not per-row.
+
+    Given:
+        An IPv4 list row with:
+        - aliasaddr_in = 'PfbRenameSrc2'   (will be renamed)
+        - aliasaddr_out = 'PfbUnrelated'   (must stay unchanged)
+    When:
+        The rename shim is invoked with old='PfbRenameSrc2', new='PfbRenameDst2'.
+    Then:
+        - aliasaddr_in is rewritten to 'PfbRenameDst2'.
+        - aliasaddr_out stays 'PfbUnrelated' (unrelated — no touch).
+    """
+    vm = deployed_vm
+    shim_check = vm.ssh("test", "-f", HOOK_SHIM, timeout=30)
+    if shim_check.returncode != 0:
+        pytest.skip(f"alias-rename hook shim absent ({HOOK_SHIM}) — skip")
+
+    old_name = "PfbRenameSrc2"
+    new_name = "PfbRenameDst2"
+    unrelated = "PfbUnrelated"
+    rowid = _free_rowid(vm, CFG_IPV4)
+    base = f"{CFG_IPV4}/{rowid}"
+
+    seed_row: dict[str, str] = {
+        "aliasname": "SmkRenameRow2",
+        "action": "Deny_Both",
+        "aliasaddr_in": old_name,
+        "aliasaddr_out": unrelated,
+    }
+
+    try:
+        # BEFORE: seed and confirm both fields.
+        _write_row(vm, CFG_IPV4, rowid, seed_row)
+        assert h.config_get(vm, f"{base}/aliasaddr_in") == old_name, (
+            f"precondition: aliasaddr_in should be {old_name!r}"
+        )
+        assert h.config_get(vm, f"{base}/aliasaddr_out") == unrelated, (
+            f"precondition: aliasaddr_out should be {unrelated!r}"
+        )
+
+        # ACT: rename old_name → new_name.
+        _invoke_rename_shim(vm, old_name, new_name)
+
+        # AFTER: only the matching field is updated; the unrelated field is intact.
+        assert h.config_get(vm, f"{base}/aliasaddr_in") == new_name, (
+            f"aliasaddr_in was not rewritten from {old_name!r} to {new_name!r}"
+        )
+        assert h.config_get(vm, f"{base}/aliasaddr_out") == unrelated, (
+            f"aliasaddr_out must NOT be rewritten (references {unrelated!r}, not {old_name!r})"
+        )
+    finally:
+        _del_row(vm, CFG_IPV4, rowid)
+
+
+def test_alias_rename_same_name_is_noop(deployed_vm: SmokeVM) -> None:
+    """Renaming an alias to itself leaves every field unchanged.
+
+    ``pfb_alias_rename_followup`` guards ``$old_name === $new_name`` and returns
+    FALSE immediately (no config write). This branch is important: a pfSense
+    alias re-save with an unchanged name MUST not dirty config.xml.
+
+    Given:
+        An IPv4 list row with aliasaddr_in = 'PfbRenameNoop'.
+    When:
+        The rename shim is invoked with old='PfbRenameNoop', new='PfbRenameNoop'
+        (same name — the identity rename).
+    Then:
+        aliasaddr_in remains 'PfbRenameNoop' (no write occurred).
+    """
+    vm = deployed_vm
+    shim_check = vm.ssh("test", "-f", HOOK_SHIM, timeout=30)
+    if shim_check.returncode != 0:
+        pytest.skip(f"alias-rename hook shim absent ({HOOK_SHIM}) — skip")
+
+    name = "PfbRenameNoop"
+    rowid = _free_rowid(vm, CFG_IPV4)
+    base = f"{CFG_IPV4}/{rowid}"
+
+    seed_row: dict[str, str] = {
+        "aliasname": "SmkRenameNoop",
+        "action": "Deny_Both",
+        "aliasaddr_in": name,
+    }
+
+    try:
+        _write_row(vm, CFG_IPV4, rowid, seed_row)
+        assert h.config_get(vm, f"{base}/aliasaddr_in") == name, f"precondition: aliasaddr_in should be {name!r}"
+
+        # ACT: identity rename — shim should be a no-op.
+        _invoke_rename_shim(vm, name, name)
+
+        # AFTER: unchanged.
+        assert h.config_get(vm, f"{base}/aliasaddr_in") == name, (
+            f"aliasaddr_in must be unchanged after identity rename (same name {name!r})"
+        )
+    finally:
+        _del_row(vm, CFG_IPV4, rowid)

--- a/tests/smoke/ui/test_browser_category_edit.py
+++ b/tests/smoke/ui/test_browser_category_edit.py
@@ -58,7 +58,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from .. import helpers
 from .conftest import mask_page_identity
+from .webui import extract_csrf_token, looks_like_login_page
 
 sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
 expect = sync_api.expect
@@ -310,3 +312,230 @@ def test_addrow_clones_a_source_row_and_renumbers(
     expect(page.locator("select[id^='state-']")).to_have_count(before + 1, timeout=JS_TIMEOUT_MS)
     expect(page.locator("#state-1")).to_be_attached(timeout=JS_TIMEOUT_MS)
     _shot(page, screenshot_dir, "addrow_after")
+
+
+# --------------------------------------------------------------------------- #
+# Alias-type validation (#356): wrong alias type in a port/address field is
+# rejected by the server with the expected error string.
+#
+# Implementation note: the alias-type check (``pfb_alias_field_type_ok``) fires
+# on the SAVE round-trip (a PHP server validation), not purely in JS.  Driving
+# it through a Playwright browser would require navigating away from the page on
+# submit (the error page replaces the form page) and then back — a brittle,
+# slow flow that is harder to reason about than a direct HTTP POST.  The HTTP
+# approach (webui.session.post) is the same mechanism ``test_category_edit.py``
+# uses for every save flow and is the accepted pattern in this suite.  We use
+# ``webui`` here (its session is already authenticated, shared, and correct) with
+# a fresh CSRF token harvested from a real GET — the same pattern as
+# ``_post_form`` in ``test_category_edit.py``.
+# --------------------------------------------------------------------------- #
+
+_CATEGORY_PAGE = "/pfblockerng/pfblockerng_category_edit.php"
+_SAVE_TIMEOUT = 120.0
+_CFG_IPV4 = "installedpackages/pfblockernglistsv4/config"
+
+
+def _post_ipv4_form(webui: WebUI, payload: dict[str, str]) -> str:
+    """POST a fully-enumerated IPv4 category-edit payload and return the response body.
+
+    GETs the page first to harvest a fresh ``__csrf_magic`` token, then POSTs
+    directly via the raw session (same pattern as ``_post_form`` in
+    ``test_category_edit.py`` — avoids the rowhelper scrape limitation).
+    """
+    get = webui.get(_CATEGORY_PAGE, params={"type": "ipv4"})
+    assert not looks_like_login_page(get.text), "category GET returned the login form (session lost)"
+    token = extract_csrf_token(get.text)
+    data = dict(payload)
+    data["__csrf_magic"] = token
+    data["save"] = "save"
+    resp = webui.session.post(webui.url(_CATEGORY_PAGE), data=data, verify=webui._verify, timeout=_SAVE_TIMEOUT)
+    assert not looks_like_login_page(resp.text), "category POST returned the login form (session lost)"
+    return resp.text
+
+
+def _free_rowid_ipv4(vm: helpers.SmokeVM) -> int:
+    """Next free IPv4 list rowid (gaps in existing rows are avoided)."""
+    pre = (
+        f"$c = config_get_path({helpers._php_str(_CFG_IPV4)}, array());\n"
+        "$max = -1;\n"
+        "foreach (array_keys($c) as $k) { if (is_numeric($k) && (int)$k > $max) { $max = (int)$k; } }\n"
+        "$free = $max + 1;"
+    )
+    return int(helpers._php_read_scalar(vm, pre, "$free", timeout=_SAVE_TIMEOUT))
+
+
+def _del_rowid_ipv4(vm: helpers.SmokeVM, rowid: int) -> None:
+    snippet = (
+        f"config_del_path({helpers._php_str(f'{_CFG_IPV4}/{rowid}')});\n"
+        "write_config('pfBlockerNG smoke: drop alias-type test row');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=_SAVE_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_del_rowid_ipv4({rowid}) failed: rc={result.returncode} {result.stdout!r}")
+
+
+def _mk_alias(vm: helpers.SmokeVM, name: str, alias_type: str, address: str) -> None:
+    """Append a pfSense firewall alias via the config API."""
+    row = {
+        "name": name,
+        "type": alias_type,
+        "address": address,
+        "descr": "pfBlockerNG smoke alias",
+        "detail": "",
+    }
+    snippet = (
+        "$aliases = config_get_path('aliases/alias', array());\n"
+        f"$aliases[] = {helpers._php_kv_array(row)};\n"
+        "config_set_path('aliases/alias', $aliases);\n"
+        "write_config('pfBlockerNG smoke: create test alias');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=_SAVE_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_mk_alias({name!r}) failed: rc={result.returncode} {result.stdout!r}")
+
+
+def _rm_alias(vm: helpers.SmokeVM, name: str) -> None:
+    """Remove the first firewall alias whose name matches ``name``."""
+    snippet = (
+        "$aliases = config_get_path('aliases/alias', array());\n"
+        "$out = array();\n"
+        "foreach ($aliases as $a) {\n"
+        f"  if (($a['name'] ?? '') !== {helpers._php_str(name)}) {{ $out[] = $a; }}\n"
+        "}\n"
+        "config_set_path('aliases/alias', $out);\n"
+        "write_config('pfBlockerNG smoke: delete test alias');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=_SAVE_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_rm_alias({name!r}) failed: rc={result.returncode} {result.stdout!r}")
+
+
+def _ipv4_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, str]:
+    """A complete IPv4 alias save payload (one Disabled placeholder row)."""
+    payload = {
+        "type": "ipv4",
+        "rowid": str(rowid),
+        "aliasname": aliasname,
+        "description": "smoke alias-type test",
+        "action": "Deny_Both",
+        "cron": "Never",
+        "dow": "",
+        "sort": "sort",
+        "aliaslog": "enabled",
+        "stateremoval": "enabled",
+        "autoproto_in": "tcp",
+        "agateway_in": "default",
+        "autoproto_out": "any",
+        "agateway_out": "default",
+        "suppression_cidr": "Disabled",
+        "srcint": "",
+        "script_pre": "",
+        "script_post": "",
+        "custom": "",
+        "format-0": "auto",
+        "state-0": "Disabled",
+        "url-0": "",
+        "header-0": "",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_alias_type_port_field_rejects_network_alias(
+    webui: "WebUI",
+    smoke_vm: helpers.SmokeVM,
+    browser_page: "Page",  # noqa: ARG001
+    screenshot_dir: Path,  # noqa: ARG001
+) -> None:
+    """Saving a network alias in ``aliasports_in`` (a port field) is rejected.
+
+    Scenario: ``pfb_alias_field_type_ok()`` validates that port alias fields
+    only accept port-type aliases. Supplying a network alias produces the error
+    ``Must use a Port-type alias`` in the response; a valid port alias in the
+    same field is accepted.
+
+    Background:
+        Issue #356 added ``pfb_alias_field_type_ok()`` which returns FALSE when
+        an address-type alias (``alias_get_type() === 'network'``) is passed to
+        a port field (``aliasports_*``). The save handler converts that to an
+        ``$input_errors`` entry whose text matches ``'Must use a Port-type alias'``.
+        A browser form-submit round-trip would navigate away from the page, making
+        it fragile to drive with Playwright; the server-side validation is
+        equivalently exercised through the authenticated HTTP session (the same
+        mechanism ``test_category_edit.py`` uses for all save flows).
+
+    Given:
+        - A network alias ``smkbwtypenet`` exists in the firewall config.
+        - A port alias ``smkbwtypeport`` exists in the firewall config.
+        - The target IPv4 rowid is free.
+    When (reject):
+        POST the IPv4 save with ``aliasports_in=smkbwtypenet`` (network alias
+        in a port field) and ``autoports_in=on``, ``autoproto_in=tcp``.
+    Then (reject):
+        - The response body contains ``Must use a Port-type alias``
+          (server validation error — the config is NOT written).
+    When (accept):
+        POST the same payload with ``aliasports_in=smkbwtypeport`` (correct
+        port alias in the port field).
+    Then (accept):
+        - The response body does NOT contain ``Must use a Port-type alias``.
+        - config.xml stores ``aliasports_in='smkbwtypeport'``.
+    """
+    vm = smoke_vm
+    net_alias = "smkbwtypenet"
+    port_alias = "smkbwtypeport"
+    rowid = _free_rowid_ipv4(vm)
+    base = f"{_CFG_IPV4}/{rowid}"
+
+    _mk_alias(vm, net_alias, "network", "192.0.2.0/24")
+    _mk_alias(vm, port_alias, "port", "8080")
+    try:
+        # BEFORE: rowid is free (no aliasports_in set yet).
+        assert helpers.config_get(vm, f"{base}/aliasports_in") == "", (
+            f"precondition: rowid {rowid} not free (aliasports_in already set)"
+        )
+
+        # REJECT: network alias supplied to a port field -> server validation error.
+        reject_body = _post_ipv4_form(
+            webui,
+            _ipv4_payload(
+                rowid,
+                "smkbwtype",
+                autoports_in="on",
+                autoproto_in="tcp",
+                aliasports_in=net_alias,
+            ),
+        )
+        assert "Must use a Port-type alias" in reject_body, (
+            f"expected 'Must use a Port-type alias' error in response when a network alias "
+            f"is used in a port field, but it was absent (first 500 chars: {reject_body[:500]!r})"
+        )
+        # Config must NOT have been written (the error aborted the save).
+        assert helpers.config_get(vm, f"{base}/aliasports_in") == "", (
+            "aliasports_in must not be written when the save is rejected by alias-type validation"
+        )
+
+        # ACCEPT: correct port alias in the port field -> no error, config written.
+        accept_body = _post_ipv4_form(
+            webui,
+            _ipv4_payload(
+                rowid,
+                "smkbwtype",
+                autoports_in="on",
+                autoproto_in="tcp",
+                aliasports_in=port_alias,
+            ),
+        )
+        assert "Must use a Port-type alias" not in accept_body, (
+            "expected no alias-type error when a port alias is used in a port field"
+        )
+        assert helpers.config_get(vm, f"{base}/aliasports_in") == port_alias, (
+            f"aliasports_in was not written after a valid save with port alias {port_alias!r}"
+        )
+    finally:
+        _del_rowid_ipv4(vm, rowid)
+        _rm_alias(vm, net_alias)
+        _rm_alias(vm, port_alias)

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -710,3 +710,87 @@ def test_ipv4_invert_toggles_persist_with_alias_native(
 
     finally:
         _del_rowid(vm, CFG_IPV4, rowid)
+
+
+# --------------------------------------------------------------------------- #
+# ui_render tier (PR gate): GET the IPv4 category-edit page and assert the
+# alias-type help-text and <select> fields added by issue #356.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.ui_render
+def test_ipv4_category_edit_renders_alias_type_help_text(
+    webui: "WebUI",
+    smoke_vm: helpers.SmokeVM,  # noqa: ARG001
+) -> None:
+    """The IPv4 category-edit page renders the alias-type help-text strings.
+
+    Scenario: a GET of ``pfblockerng_category_edit.php?type=ipv4`` returns a
+    200 response with the ``Must be a Port-type alias.`` and
+    ``Must be a Network or Host-type alias.`` help strings that were added by
+    issue #356 to guide the user when filling the Advanced In/Out alias fields.
+
+    Background:
+        ``pfb_alias_field_type_ok()`` validates alias type on save; the matching
+        help text was added to the page alongside each alias <select> (one for
+        port fields, one for address fields). This render test confirms the text
+        is present in the response body and the page is error-free.
+
+    Given:
+        The webConfigurator is accessible and the admin session is valid.
+    When:
+        GET ``pfblockerng_category_edit.php?type=ipv4``.
+    Then:
+        - HTTP 200.
+        - Body contains ``Must be a Port-type alias.``
+        - Body contains ``Must be a Network or Host-type alias.``
+        - Body free of ``Fatal error``, ``Parse error``, ``Warning``, ``Notice``,
+          ``Uncaught`` (standard ui_render guarantee).
+    """
+    resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4"})
+    assert resp.status_code == 200, f"IPv4 category-edit GET returned HTTP {resp.status_code} (expected 200)"
+    body = resp.text
+    assert not looks_like_login_page(body), "IPv4 category-edit GET returned the login form (session lost)"
+    for bad in ("Fatal error", "Parse error", "Warning", "Notice", "Uncaught"):
+        assert bad not in body, f"IPv4 category-edit page contains PHP error: {bad!r}"
+    assert "Must be a Port-type alias." in body, (
+        "IPv4 category-edit page is missing help text 'Must be a Port-type alias.'"
+    )
+    assert "Must be a Network or Host-type alias." in body, (
+        "IPv4 category-edit page is missing help text 'Must be a Network or Host-type alias.'"
+    )
+
+
+@pytest.mark.ui_render
+def test_ipv4_category_edit_renders_four_alias_select_fields(
+    webui: "WebUI",
+    smoke_vm: helpers.SmokeVM,  # noqa: ARG001
+) -> None:
+    """The IPv4 category-edit page renders all four alias <select> fields.
+
+    Scenario: the four Advanced In/Out alias-reference <select> fields —
+    ``aliasports_in``, ``aliasports_out``, ``aliasaddr_in``, ``aliasaddr_out`` —
+    are present in the rendered page body.
+
+    Background:
+        Issue #356 wires alias-type validation to these four fields. A render
+        test confirms the page actually emits <select> tags with those names so
+        the validation path is reachable from the UI (not a dead branch).
+
+    Given:
+        The webConfigurator is accessible and the admin session is valid.
+    When:
+        GET ``pfblockerng_category_edit.php?type=ipv4``.
+    Then:
+        - HTTP 200, no PHP errors.
+        - Each of ``aliasports_in``, ``aliasports_out``, ``aliasaddr_in``,
+          ``aliasaddr_out`` appears as a ``<select name="...">`` in the body.
+    """
+    resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4"})
+    assert resp.status_code == 200, f"IPv4 category-edit GET returned HTTP {resp.status_code} (expected 200)"
+    body = resp.text
+    assert not looks_like_login_page(body), "IPv4 category-edit GET returned the login form (session lost)"
+    for bad in ("Fatal error", "Parse error", "Warning", "Notice", "Uncaught"):
+        assert bad not in body, f"IPv4 category-edit page contains PHP error: {bad!r}"
+    for field in ("aliasports_in", "aliasports_out", "aliasaddr_in", "aliasaddr_out"):
+        assert f'name="{field}"' in body, f'IPv4 category-edit page is missing <select name="{field}"> field'


### PR DESCRIPTION
Fixes #357 (Redmine #14147). Fixes #356 (Redmine #14148).

Both touch the same Advanced Inbound/Outbound alias surface, so they're landed together.

## #357 — follow alias renames into pfBlockerNG's stored references

When a firewall alias is renamed, pfSense's `update_alias_name()` rewrites only core sections (filter/NAT/nested aliases) — it does **not** touch `installedpackages/*`. pfBlockerNG stores user-alias references for the Advanced In/Out rule settings as plain name strings (`aliasports_in/out`, `aliasaddr_in/out`) in its IP/DNSBL list rows, so those went stale on rename ("the old reference was left in place").

**Fix — decoupled + gateway-routed:**
- **`pfb_alias_rename_followup($old, $new)`** (`pfblockerng_extra.inc`): rewrites the four per-row alias keys across `pfblockernglistsv4/v6` + `pfblockerngdnsbl` **through the `PfbConfig` section gateway** (ADR-29). Pure, unit-tested, does not persist (the caller's `write_config()` does).
- **Thin hook shim** `pkg/firewall_aliases_edit/pre_write_config/pfblockerng.php`: pfSense's `pfSense_handle_custom_code()` includes it from `saveAlias()` (after `update_alias_name()`, before `write_config()`), with `$origname`/`$post['name']` in scope. This file is the **only** piece coupled to pfSense's save internals — it just delegates to the gateway-routed function. Multiple packages can share that hook directory (it's a directory include), so no collision.

The #356 `is_alias()` save-validation stays as the safety net for non-GUI rename paths.

> **Ships via a companion `pfBlockerNG/FreeBSD-ports` (`pfblockerng/use-github`) change** that adds the new file to the port `Makefile` `do-install` + `pkg-plist`. That PR lands right after this one (build-order: the file must be in `src/` on `devel` before the plist references it). Until it ships, the new hook file is inert and the `-m smoke` test below skips with a clear precondition message.

## #356 — per-field alias-type enforcement + help text

Save-time validation already existed (rejects a non-existent / wrong-type alias instead of a blank failure). This finishes the two remaining items:
- **Per-field type**: `aliasports_*` (Custom DST Port) now require a **port**-type alias; `aliasaddr_*` (Custom Source) require a **network or host** alias — previously both accepted either. Extracted into a pure, fail-closed `pfb_alias_field_type_ok()` and unit-tested; the error message names the required type.
- **Help text**: the four fields now state the required alias type ("Must be a Port-type alias." / "Must be a Network or Host-type alias.").

## Tests

- **Unit (`tests/php/AliasRenameFollowupTest.php`)** — 15 tests pinning every branch of both helpers (before/after assertions; verified to fail without the fix).
- **Smoke (`-m smoke`, `tests/smoke/test_smoke_alias_rename.py`)** — seeds a list row, invokes the **shipped shim** end-to-end via pfSsh.php (`$origname`/`$post` + `@include`), asserts the stored ref followed the rename and an unrelated ref is untouched. Skips cleanly when the hook file isn't shipped yet (ports plist pending) or off-VM.
- **UI** — `ui_render`: the new help text + the four alias `<select>` fields render on the IPv4 category-edit page (no PHP errors). `ui_browser`: a network alias placed in a port field is rejected with "Must use a Port-type alias" (a correctly-typed alias saves).

Gates green: PHPUnit (866), PHPStan (0), PHPCS (0), `php -l`, ruff/mypy/markdownlint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA2jJJPJzJaVraEVDp8NVp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * When firewall aliases are renamed, pfBlockerNG advanced inbound/outbound configuration references are automatically updated via a pre-save hook.
  * Category editor now enforces per-field alias-type compatibility (Port-type vs Network/Host-type) with clearer, field-specific help text.

* **Tests**
  * Added unit and end-to-end smoke coverage for alias rename follow-up behavior.
  * Added UI-level smoke tests to verify alias-type validation and rendered help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->