### PR TITLE
pfblockerng: make MaxMind credential notice name the missing field (#335)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1306,6 +1306,26 @@ function pfb_validate_domain_labels($input) {
 }
 
 
+// Field-aware MaxMind credential notice. MaxMind GeoLite2 requires BOTH an
+// Account ID and a License Key. Returns the notice naming the missing field(s),
+// or '' when both are present.
+function pfb_maxmind_credential_notice(string $maxmind_key, string $maxmind_account): string {
+	$key_missing     = ($maxmind_key === '');
+	$account_missing = ($maxmind_account === '');
+	if (!$key_missing && !$account_missing) {
+		return '';
+	}
+	if ($key_missing && $account_missing) {
+		$need = 'an Account ID and License Key';
+	} elseif ($account_missing) {
+		$need = 'an Account ID';
+	} else {
+		$need = 'a License Key';
+	}
+	return "MaxMind now requires {$need}! Review the IP tab: MaxMind settings for more information.";
+}
+
+
 // [ $pfb ] pfBlockerNG global array. This needs to be called to get the updated settings.
 function pfb_global() {
 	global $g, $pfb;
@@ -12116,11 +12136,13 @@ function sync_package_pfblockerng($cron='') {
 			$cc_name = 'pfblockerng' . strtolower(str_replace(' ', '', $continent));
 			if (isset($continent_config['action']) && $continent_config['action'] != 'Disabled' && $pfb['enable'] == 'on') {
 
-				// Maxmind License Key verification and user notification
+				// Maxmind credential verification and user notification
 				if ($maxmind_run_once && !$maxmind_verify) {
-					$mmsg = 'MaxMind now requires a License Key! Review the IP tab: MaxMind settings for more information.';
-					pfb_logger("\n\nURGENT:\n    {$mmsg}\n", 1);
-					file_notice('pfBlockerNG MaxMind', $mmsg, 'pfBlockerNG', '/pfblockerng/pfblockerng_ip.php', 2);
+					$mmsg = pfb_maxmind_credential_notice($pfb['maxmind_key'], $pfb['maxmind_account']);
+					if ($mmsg !== '') {
+						pfb_logger("\n\nURGENT:\n    {$mmsg}\n", 1);
+						file_notice('pfBlockerNG MaxMind', $mmsg, 'pfBlockerNG', '/pfblockerng/pfblockerng_ip.php', 2);
+					}
 					$maxmind_run_once = FALSE;
 				}
 
@@ -12399,11 +12421,11 @@ function sync_package_pfblockerng($cron='') {
 							$custom	= FALSE;
 						}
 
-						// Maxmind License Key verification
+						// Maxmind credential verification
 						if ($maxmind_run_once && $row['format'] == 'geoip') {
-							$mmsg = 'MaxMind now requires an Account ID and License Key! Review the IP tab: MaxMind settings for more information.';
-							if (empty($pfb['maxmind_key']) || empty($pfb['maxmind_account'])) {
-								pfb_logger("\n\nURGENT:\n    {$mmsg}.\n", 1);
+							$mmsg = pfb_maxmind_credential_notice($pfb['maxmind_key'], $pfb['maxmind_account']);
+							if ($mmsg !== '') {
+								pfb_logger("\n\nURGENT:\n    {$mmsg}\n", 1);
 								file_notice('pfBlockerNG MaxMind', $mmsg, 'pfBlockerNG', '/pfblockerng/pfblockerng_ip.php', 2);
 							}
 							$maxmind_run_once = FALSE;

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1880,11 +1880,10 @@ $section->addInput(new Form_StaticText(
 	. '&emsp;Use &emsp;<strong>CTRL+CLICK</strong>&emsp;to&emsp;<strong>select/unselect</strong>&emsp; the IPv4/6 Countries below as required.'
 ));
 
-// Maxmind License Key verification
-if (empty($pfb['maxmind_key'])) {
-	print_callout('<br /><br /><p><strong>'
-			. 'MaxMind now requires a License Key! Review the IP tab: MaxMind settings for more information.'
-			. '</strong></p><br />', 'danger', '');
+// Maxmind credential verification
+$mmsg = pfb_maxmind_credential_notice($pfb['maxmind_key'], $pfb['maxmind_account']);
+if ($mmsg !== '') {
+	print_callout('<br /><br /><p><strong>' . $mmsg . '</strong></p><br />', 'danger', '');
 }
 
 $group = new Form_Group('');

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -387,14 +387,13 @@ if (isset($savemsg)) {
 	<div id="<?=$pageid;?>" class="panel-body">
 
 		<?php
-			// Maxmind License Key verification
+			// Maxmind credential verification
 			if ($gtype == 'geoip') {
 				$maxmind_verify = TRUE;
-				if (empty($pfb['maxmind_key'])) {
+				$mmsg = pfb_maxmind_credential_notice($pfb['maxmind_key'], $pfb['maxmind_account']);
+				if ($mmsg !== '') {
 					$maxmind_verify = FALSE;
-					print_callout('<br /><p><strong>'
-							. 'MaxMind now requires a License Key! Review the IP tab: MaxMind settings for more information.'
-							. '</strong></p><br />', 'warning', '');
+					print_callout('<br /><p><strong>' . $mmsg . '</strong></p><br />', 'warning', '');
 				}
 			}
 		?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -583,10 +583,12 @@ if ($_POST && isset($_POST['save'])) {
 			$line++;
 		}
 
-		// Validate MaxMind License Key
-		if ($value == 'geoip' && strpos($key, 'format-') !== FALSE && empty($pfb['maxmind_key'])) {
-			$input_errors[] = "{$type} Source Definitions, Line {$line}: "
-				. 'MaxMind now requires a License Key! Review the IP tab: MaxMind settings for more information.';
+		// Validate MaxMind credentials
+		if ($value == 'geoip' && strpos($key, 'format-') !== FALSE) {
+			$mmsg = pfb_maxmind_credential_notice($pfb['maxmind_key'], $pfb['maxmind_account']);
+			if ($mmsg !== '') {
+				$input_errors[] = "{$type} Source Definitions, Line {$line}: " . $mmsg;
+			}
 		}
 	}
 

--- a/tests/php/MaxMindCredentialNoticeTest.php
+++ b/tests/php/MaxMindCredentialNoticeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_maxmind_credential_notice() — returns a field-aware notice when one or
+ * both MaxMind credentials are absent, or '' when both are present.
+ *
+ * Regression anchor: the old code hardcoded "requires a License Key" even when
+ * the Key was present and only the Account ID was missing — the exact case
+ * reported in issue #335.
+ */
+#[CoversFunction('pfb_maxmind_credential_notice')]
+final class MaxMindCredentialNoticeTest extends TestCase
+{
+	// Both credentials present — no notice expected.
+	public function testBothPresentReturnsEmpty(): void
+	{
+		$this->assertSame('', pfb_maxmind_credential_notice('mykey', 'myaccount'));
+	}
+
+	// Account ID missing, Key present — notice must name Account ID and must NOT
+	// say "License Key" (regression anchor for issue #335: old code wrongly said
+	// "requires a License Key" in this case).
+	public function testAccountMissingKeyPresentNamesAccountId(): void
+	{
+		$notice = pfb_maxmind_credential_notice('mykey', '');
+		$this->assertStringContainsString('requires an Account ID!', $notice);
+		$this->assertStringNotContainsString('License Key', $notice);
+	}
+
+	// License Key missing, Account ID present — notice must name License Key.
+	public function testKeyMissingAccountPresentNamesLicenseKey(): void
+	{
+		$notice = pfb_maxmind_credential_notice('', 'myaccount');
+		$this->assertStringContainsString('requires a License Key!', $notice);
+		$this->assertStringNotContainsString('Account ID', $notice);
+	}
+
+	// Both missing — notice must name both fields.
+	public function testBothMissingNamesBothFields(): void
+	{
+		$notice = pfb_maxmind_credential_notice('', '');
+		$this->assertStringContainsString('requires an Account ID and License Key!', $notice);
+	}
+
+	// Full expected strings — ensures the suffix is intact for all non-empty branches.
+	public function testAccountMissingFullMessage(): void
+	{
+		$this->assertSame(
+			'MaxMind now requires an Account ID! Review the IP tab: MaxMind settings for more information.',
+			pfb_maxmind_credential_notice('mykey', '')
+		);
+	}
+
+	public function testKeyMissingFullMessage(): void
+	{
+		$this->assertSame(
+			'MaxMind now requires a License Key! Review the IP tab: MaxMind settings for more information.',
+			pfb_maxmind_credential_notice('', 'myaccount')
+		);
+	}
+
+	public function testBothMissingFullMessage(): void
+	{
+		$this->assertSame(
+			'MaxMind now requires an Account ID and License Key! Review the IP tab: MaxMind settings for more information.',
+			pfb_maxmind_credential_notice('', '')
+		);
+	}
+}


### PR DESCRIPTION
## Problem

MaxMind GeoLite2 downloads require **both** a MaxMind Account ID and a License Key. The credential gate checks both (`pfblockerng.inc:12071`), but the user-facing notices were wrong/inconsistent:

- `pfblockerng.inc:12104` fired when *either* field was missing yet hardcoded **"MaxMind now requires a License Key!"** — so entering the Key but not the Account ID showed the wrong message (the exact case in #335; the follow-up confirms the message was identical whether only the Account ID, only the Key, or neither was set).
- Three more sites hardcoded the same "License Key" wording **and only tested `maxmind_key`**, ignoring the Account ID entirely: `pfblockerng.php:1885`, `pfblockerng_category.php:393`, `pfblockerng_category_edit.php:587`.

## Fix

Add one pure, field-aware helper and route all five notice sites through it:

```php
function pfb_maxmind_credential_notice(string $maxmind_key, string $maxmind_account): string
```

It returns the message naming the actually-missing field — "an Account ID", "a License Key", or "an Account ID and License Key" — or `''` when both are present. All five sites now use it (and the three key-only checks now consider both fields). The existing message suffix and callout markup/severities are unchanged. A stray double-period in one logger line was also dropped.

## Tests

New `tests/php/MaxMindCredentialNoticeTest.php` pins all four branches; the "Account ID missing, Key present" case is the regression anchor (asserts the message names the Account ID and does **not** say "License Key" — fails on the old hardcoded string).

Gates: `php -l` (all 4 files), `vendor/bin/phpcs` (custom sniffs), full `vendor/bin/phpunit` (858 tests), PHPStan — all green.

Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEtct4G4nCXfjLYq51AJ5k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MaxMind credential validation now provides specific error messages identifying exactly which credential is missing—License Key or Account ID—instead of generic notifications, enabling faster configuration troubleshooting across GeoIP features.

* **Tests**
  * Added comprehensive test coverage for MaxMind credential validation logic to ensure accurate error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->