### PR TITLE
pfblockerng: show widget dates in ISO 8601 format

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -343,6 +343,22 @@ function pfb_alias_entry_count(array $grep_lines): int {
 	return is_numeric($grep_lines[0] ?? NULL) ? (int) $grep_lines[0] : 0;
 }
 
+// Reformat a stored timestamp string to ISO 8601 'YYYY-MM-DD HH:MM:SS' for display.
+// Accepts any date string parseable by strtotime() (e.g. the DNSBL SQLite timestamp
+// written as 'M j H:i:s' — 'Nov 31 14:30:45'). An already-ISO value round-trips
+// unchanged. An unparseable or empty value is returned as-is so callers never see
+// a garbled '1970-01-01 00:00:00' placeholder.
+function pfb_iso_timestamp(string $raw): string {
+	if ($raw === '') {
+		return $raw;
+	}
+	$epoch = strtotime($raw);
+	if ($epoch === FALSE) {
+		return $raw;
+	}
+	return date('Y-m-d H:i:s', $epoch);
+}
+
 // Returns TRUE only for a legacy bare pfB_ alias on an IPv4-family rule that
 // still needs the '_v4' suffix appended. Addresses already ending in '_v4' or
 // '_v6' are left alone (the '_v6' skip mirrors the NAT-rule upgrade path and

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -280,7 +280,7 @@ function pfBlockerNG_update_table() {
 				$pfb_aliasdir_esc = escapeshellarg("{$pfb['aliasdir']}/{$pfb_alias}.txt");
 				exec("{$pfb['grep']} -cv '^1\.1\.1\.1\$' {$pfb_aliasdir_esc}", $match);
 				$pfb_table[$pfb_alias] = array('count' => pfb_alias_entry_count($match), 'img' => $pfb['down']);
-				exec("{$pfb['ls']} -l -D'%b %d %T' {$pfb_aliasdir_esc} | {$pfb['awk']} '{ print \$6,\$7,\$8 }'", $update);
+				exec("{$pfb['ls']} -l -D'%Y-%m-%d %T' {$pfb_aliasdir_esc} | {$pfb['awk']} '{ print \$6,\$7 }'", $update);
 
 				$pfb_table[$pfb_alias]['update']	= $update[0];
 				$pfb_table[$pfb_alias]['rule']		= 0;
@@ -405,7 +405,7 @@ function pfBlockerNG_update_table() {
 							$pfb_dtable[$res['groupname']] = array ('count' => $res['entries'], 'img' => $pfb['up']);
 						}
 					}
-					$pfb_dtable[$res['groupname']]['update'] = "{$res['timestamp']}";
+					$pfb_dtable[$res['groupname']]['update'] = pfb_iso_timestamp((string) $res['timestamp']);
 
 					if (!is_numeric($res['counter'])) {
 						$res['counter'] = 0;

--- a/tests/php/PfbIsoTimestampTest.php
+++ b/tests/php/PfbIsoTimestampTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_iso_timestamp() — reformats a stored timestamp string to ISO 8601
+ * 'YYYY-MM-DD HH:MM:SS' for display (issue #333: widget date localisation).
+ *
+ * Two branches:
+ *   1. Parseable input (strtotime() succeeds) → ISO-formatted output.
+ *   2. Unparseable or empty input (strtotime() returns FALSE / empty string) →
+ *      raw value returned unchanged (no '1970-01-01 00:00:00' placeholder).
+ *
+ * Both branches are asserted so a regression in either guard would cause a failure.
+ */
+#[CoversFunction('pfb_iso_timestamp')]
+final class PfbIsoTimestampTest extends TestCase
+{
+	/**
+	 * A US-style date string with an explicit year is converted to ISO 8601.
+	 * Proves the parseable branch reformats the value.
+	 */
+	public function testUsStyleWithYearConvertsToIso(): void
+	{
+		// Given: a US-format datetime string that includes a full year.
+		$input = '07/04/2024 13:30:45';
+
+		// When.
+		$result = pfb_iso_timestamp($input);
+
+		// Then: the output is the ISO equivalent.
+		$this->assertSame('2024-07-04 13:30:45', $result);
+	}
+
+	/**
+	 * An already-ISO value round-trips unchanged.
+	 * Proves strtotime() parses ISO correctly and date('Y-m-d H:i:s') round-trips it.
+	 */
+	public function testAlreadyIsoRoundTrips(): void
+	{
+		$input = '2024-11-05 14:30:45';
+
+		$result = pfb_iso_timestamp($input);
+
+		$this->assertSame('2024-11-05 14:30:45', $result);
+	}
+
+	/**
+	 * A DNSBL-style 'M j H:i:s' stored timestamp (e.g. written by date('M j H:i:s'))
+	 * with a full year produces the correct ISO output. Uses a deterministic full-date
+	 * string so the test is not year-dependent.
+	 *
+	 * date('M j H:i:s') writes e.g. 'Jul  4 13:30:45' (no year). To avoid relying on
+	 * the current year, we use a format that includes a year.
+	 */
+	public function testFullDatetimeStringConvertsToIso(): void
+	{
+		// strtotime() handles 'Month D, YYYY HH:MM:SS' reliably.
+		$input    = 'November 5, 2024 14:30:45';
+		$expected = '2024-11-05 14:30:45';
+
+		$this->assertSame($expected, pfb_iso_timestamp($input));
+	}
+
+	/**
+	 * An unparseable/garbage value passes through unchanged — the FALSE guard.
+	 * Proves the function never returns '1970-01-01 00:00:00' for junk input.
+	 */
+	public function testUnparseableValuePassesThroughUnchanged(): void
+	{
+		$garbage = 'not a date at all';
+
+		$result = pfb_iso_timestamp($garbage);
+
+		// Result must be the original garbage, not a formatted epoch.
+		$this->assertSame($garbage, $result);
+		$this->assertStringNotContainsString('1970', $result, 'must not format to epoch');
+	}
+
+	/**
+	 * An empty string passes through unchanged — the early-return guard.
+	 * Proves the empty-check fires before strtotime() so '' stays ''.
+	 */
+	public function testEmptyStringPassesThroughUnchanged(): void
+	{
+		$this->assertSame('', pfb_iso_timestamp(''));
+	}
+
+	/**
+	 * Transition test: proves the two branches are real and independent.
+	 *
+	 * BEFORE (parseable): a datetime string → ISO output (not the original string).
+	 * AFTER  (garbage):   a garbage string  → original string (not an ISO value).
+	 *
+	 * Green proves both paths execute, not that one constant path was taken.
+	 */
+	public function testParseableAndUnparseableBranchesAreDistinct(): void
+	{
+		$parseable = '2024-07-04 13:30:45';
+		$garbage   = 'xyzzy-no-date';
+
+		// Parseable branch: returns ISO (which round-trips here).
+		$isoResult = pfb_iso_timestamp($parseable);
+		$this->assertSame('2024-07-04 13:30:45', $isoResult, 'parseable: must return ISO');
+
+		// Unparseable branch: returns the raw garbage, NOT an ISO string.
+		$rawResult = pfb_iso_timestamp($garbage);
+		$this->assertSame($garbage, $rawResult, 'unparseable: must return raw input');
+
+		// Cross-assert: the two outputs are different (rules out an always-return-input path).
+		$this->assertNotSame($isoResult, $rawResult, 'the two branches must produce different outputs');
+	}
+}


### PR DESCRIPTION
## Summary

Issue #333: the dashboard widget shows dates in US/abbreviated form (`Nov 31 14:30:45`), hard to read outside the USA. This switches the widget's **displayed** dates to ISO 8601 `YYYY-MM-DD HH:MM:SS`.

Direction confirmed as **hardcoded ISO**: pfSense has no user-locale date mechanism, and pfBlockerNG already uses ISO elsewhere (`pfblockerng_software.php`), so ISO is the consistent choice.

## Changes (display-side only)

The widget renders one merged table (IP aliases + DNSBL), printed via a single `update` column. Both date sources are reformatted at the **display** boundary; storage/writers are untouched:

- **IP "Updated" column** (`pfblockerng.widget.php` ~283): `ls -D '%b %d %T'` → `'%Y-%m-%d %T'`, with the matching awk field-count fix (`$6,$7,$8` → `$6,$7`, since the ISO date+time is two tokens, not three).
- **DNSBL "update" column** (`pfblockerng.widget.php` ~408): the stored timestamp is reformatted via a new pure helper `pfb_iso_timestamp()` in `pfblockerng.inc`, which converts any `strtotime()`-parseable value to ISO and passes an unparseable/empty value through unchanged (no `1970-01-01` placeholder).

Deliberately **not** touched (their format is load-bearing for log-grep matching, and would broaden blast radius into Alerts/Reports and the sinkhole block page): `make_timestamp()` (Python), the `dnsbl_alias_update()` writers, the SQLite storage, `www/index.php`, and the hidden failed-downloads errlog filter.

## Tests

`tests/php/PfbIsoTimestampTest.php` pins `pfb_iso_timestamp()`: US→ISO conversion, ISO round-trip, and the unparseable/empty passthrough branch (both branches covered). The `ls`/awk change is shell-exec and can't be unit-tested off-box — a documented out-of-CI limitation, covered by the ADR-14 `ui_render` tier and manual smoke.

Fixes #333.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GighgrxzgA8pzAPtS66iCK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized timestamp display format in pfBlockerNG widget for alias file and DNSBL statistics updates to YYYY-MM-DD HH:MM:SS format for improved readability and consistency.

* **Tests**
  * Added comprehensive test coverage for timestamp formatting functionality, including various input formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->