### PR TITLE
pfblockerng: guard get_tld against invalid UTF-8 qname bytes

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2071,8 +2071,14 @@ def get_rep_ttl(rep: reply_info | None) -> str:
 
 def get_tld(qstate: module_qstate) -> str:
     tld = ""
-    if qstate and qstate.qinfo and len(qstate.qinfo.qname_list) > 1:
-        tld = qstate.qinfo.qname_list[-2]
+    try:
+        if qstate and qstate.qinfo and len(qstate.qinfo.qname_list) > 1:
+            tld = qstate.qinfo.qname_list[-2]
+    except Exception as e:
+        # A qname carrying invalid UTF-8 bytes makes Unbound's qname_list access raise
+        # while decoding the labels; swallow it and fall back to an empty TLD rather than
+        # crashing the Python module on that query (mirrors get_q_name_qstate).
+        sys.stderr.write("[pfBlockerNG]: Failed get_tld: {}".format(e))
     return tld
 
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2078,7 +2078,7 @@ def get_tld(qstate: module_qstate) -> str:
         # A qname carrying invalid UTF-8 bytes makes Unbound's qname_list access raise
         # while decoding the labels; swallow it and fall back to an empty TLD rather than
         # crashing the Python module on that query (mirrors get_q_name_qstate).
-        sys.stderr.write("[pfBlockerNG]: Failed get_tld: {}".format(e))
+        sys.stderr.write("[pfBlockerNG]: Failed get_tld: {}\n".format(e))
     return tld
 
 

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -877,6 +877,18 @@ class TestGetTld:
     def test_none_qstate_returns_empty(self) -> None:
         assert pfb_unbound.get_tld(None) == ""
 
+    def test_invalid_utf8_qname_returns_empty_not_raise(self) -> None:
+        # Regression (issue #328): a qname carrying an invalid UTF-8 byte (0xdc) makes
+        # Unbound's qname_list access raise while decoding the labels. get_tld must
+        # swallow it and return an empty TLD, not propagate and crash the Python module.
+        class _RaisingQinfo:
+            @property
+            def qname_list(self) -> list[str]:
+                raise UnicodeDecodeError("utf-8", b"\xdc", 0, 1, "invalid continuation byte")
+
+        qstate = types.SimpleNamespace(qinfo=_RaisingQinfo())
+        assert pfb_unbound.get_tld(qstate) == ""
+
 
 class TestGetTldFromName:
     def test_multilabel(self) -> None:


### PR DESCRIPTION
## Summary

A DNS query whose qname carries an invalid UTF-8 byte (the reported `0xdc`) made Unbound's `qname_list` access raise `UnicodeDecodeError` while decoding the labels. `get_tld()` in `pfb_unbound.py` read `qstate.qinfo.qname_list` with no exception guard, and `operate()` calls it outside any try/except, so the exception propagated and crashed the Python module on that query — repeating for every such query.

The sibling helper `get_q_name_qstate()` already wraps the analogous access in `try/except Exception`. This change does the same in `get_tld()`: the qname access is wrapped, and on failure it falls back to an empty TLD rather than propagating.

## Changes

- `src/usr/local/pkg/pfblockerng/pfb_unbound.py` — wrap the `get_tld()` qname access in `try/except`, returning an empty TLD on decode failure.
- `tests/test_pfb_unbound.py` — regression test feeding a qname whose `qname_list` access raises `UnicodeDecodeError`; asserts `get_tld()` returns `""` instead of raising (fails on the pre-fix code, passes after).

## Verification

- `ruff check` / `ruff format --check`: clean
- `mypy tests/`: clean
- `pytest tests/test_pfb_unbound.py`: 237 passed; the new test fails without the fix and passes with it

Fixes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017uTPDHrRKbKnzWseMBrHK7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of domain name TLD extraction by safely handling invalid decoded input, logging the error and returning a safe fallback instead of crashing.

* **Tests**
  * Added a regression test to confirm TLD extraction returns an empty result when the input contains invalid UTF-8 and does not raise an exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->