### PR TITLE
pfblockerng: clarify XMLRPC Sync page help text

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -193,8 +193,12 @@ $section->addInput(new Form_Select(
 	'Enable Sync',
 	$pconfig['varsynconchanges'],
 	$options_varsynconchanges
-))->setHelp('When enabled, this will sync all configuration settings to the Replication Targets.<br /><br />'
-		. '<b>Important:</b> While using "Sync to hosts defined below", only sync from host A to B, A to C'
+))->setHelp('Push this firewall\'s pfBlockerNG configuration to other firewalls. '
+		. '<b>Sync to configured system backup server</b> includes pfBlockerNG in the firewall\'s '
+		. 'normal config sync to the peer set under System &gt; High Availability Sync '
+		. '(the Replication Targets below are ignored). <b>Sync to host(s) defined below</b> pushes '
+		. 'to the Replication Targets configured here.<br /><br />'
+		. '<b>Important:</b> While using "Sync to host(s) defined below", only sync from host A to B, A to C'
 		. '<br /> but <b>do not</b> enable XMLRPC sync <b>to</b> A. This will result in a loop!');
 
 $section->addInput(new Form_Input(
@@ -215,6 +219,15 @@ $section->addInput(new Form_Checkbox(
 $form->add($section);
 
 $section = new Form_Section('XMLRPC Replication Targets');
+$section->addInput(new Form_StaticText(
+	'Notes',
+	'<small>'
+	. 'For each target, match the protocol, IP/hostname and port of the remote firewall\'s '
+	. 'webConfigurator &mdash; the protocol (http or https) must match the remote, or the sync will fail.<br />'
+	. 'Using a dedicated user in the <i>admins</i> group on the target (rather than the primary admin '
+	. 'account) is recommended, so the primary account is not exposed for syncing.'
+	. '</small>'
+));
 $rowdata = $pfb['sconfig']['row'];
 
 // Add empty row placeholder if no rows defined


### PR DESCRIPTION
## Summary

Documentation/UX pass on the **XMLRPC Sync** page (`www/pfblockerng/pfblockerng_sync.php`) per issue #345. Help text only — no behaviour, label, or schema change.

## Changes

- **Enable Sync** help — now states it *pushes* this firewall's pfBlockerNG configuration to other firewalls, and explains the two active modes:
  - *Sync to configured system backup server* — includes pfBlockerNG in the firewall's normal config sync to the peer set under **System → High Availability Sync** (the Replication Targets are ignored). Matches the `'auto'` path (`pfblockerng_plugin_xmlrpc_send/recv`).
  - *Sync to host(s) defined below* — pushes to the Replication Targets on this page (the `'manual'` path).
- **XMLRPC Replication Targets** — added a note: match the remote webConfigurator's protocol/IP/port (the protocol must match the remote, or the sync fails), and prefer a dedicated *admins*-group user over the primary admin account.

## Scope notes (triage)

- The "Disable General/IP/DNSBL tab settings sync" help already clarifies it affects exactly those three tabs — left as-is.
- The http/https note is framed as "must match the remote" rather than "http is insecure", per the earlier Redmine comment.
- The original report's "Allow Sync Pushes" inbound toggle and per-area sync checkboxes are **new features** (new config fields/behaviour), out of scope for this help-text pass.

## Verification

- `php -l`: no syntax errors (the two pre-existing `continue`/switch warnings are outside the change).
- Adds no boolean literals or `config_*_path` calls, so the ADR-28/ADR-29 PHPCS sniffs are unaffected.
- Web-UI tier-A render gate (ADR-14) covers page render in CI.

Fixes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017uTPDHrRKbKnzWseMBrHK7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sync mode help text with clearer descriptions of replication requirements and directional guidelines.
  * Added instructional notes for XMLRPC replication configuration, including protocol/IP/port matching guidance and best practices for target firewall authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->