### PR TITLE
pfblockerng: curb filterlog daemon CPU by caching unresolved tracker IDs (#326)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8467,55 +8467,54 @@ function pfb_collect_localhosts() {
 
 // Resolve a filter.log Tracker ID to a pfBlockerNG rule.
 //
-// Returns TRUE when $tracker is a known pfB rule whose type matches $type (caller
-// should process the log line). Returns FALSE when the tracker is a known non-pfB
-// ('other') tracker or could not be resolved after retries (caller should skip).
+// Returns TRUE when $tracker is a pfB rule whose type matches $type (caller processes
+// the line); FALSE for a known non-pfB ('other') or an unresolvable tracker (caller skips).
 //
-// $rule_list is updated in-place when a reparse is triggered.
-// $reparse   : callable() => array  — returns a fresh rule list (production: pfb_filterrules).
-// $sleeper   : callable(int) => void — sleep shim (injectable for tests; null => builtin sleep).
-// $on_reparse: callable() => void   — called after each reparse so the daemon can refresh
-//             its $pfb_local / $pfb_localsub / $local_hosts variables; null => no callback.
+// $rule_list  : positive cache from pfb_filterrules(); rebuilt in place on a reparse.
+// $miss_cache : PERSISTENT negative cache of trackers not present in the ruleset; survives
+//               reparses (a reparse rebuilds $rule_list but not this), so each unresolvable
+//               tracker triggers at most ONE reparse for the daemon's life.
+// $reparse    : callable() => array — fresh rule list (production: 'pfb_filterrules').
+// $on_reparse : callable() => void  — refresh daemon-local IP/host collections after a reparse.
 function pfb_resolve_tracker(
 	array &$rule_list,
+	array &$miss_cache,
 	string $tracker,
 	string $type,
-	int &$max_retries,
 	callable $reparse,
-	?callable $sleeper = null,
-	?callable $on_reparse = null
+	?callable $on_reparse = NULL
 ): bool {
-	if ($sleeper === null) {
-		$sleeper = 'sleep';
+	// Negative cache: a tracker the ruleset doesn't list (anchor/trackerless) — never reparse again.
+	if (isset($miss_cache[$tracker])) {
+		return FALSE;
 	}
 
-	for ($retries = 1; $retries <= 5; $retries++) {
-
-		// Skip known non-pfBlockerNG Tracker IDs
-		if (isset($rule_list['other'][$tracker])) {
-			return FALSE;
-		}
-
-		// Resolved: pfB rule whose type matches
-		if (isset($rule_list[$tracker]) && $rule_list[$tracker]['type'] == $type) {
-			return TRUE;
-		}
-
-		// Tracker not yet known — collect updated pfctl rule data and refresh daemon locals
-		$rule_list = ($reparse)();
-		if ($on_reparse !== null) {
-			($on_reparse)();
-		}
-
-		if ($retries < 5 && $max_retries < 30) {
-			$max_retries++;
-			($sleeper)(5);
-		} else {
-			return FALSE;
-		}
+	// Known non-pfB tracker.
+	if (isset($rule_list['other'][$tracker])) {
+		return FALSE;
 	}
 
-	// Unreachable: loop exits via return inside, but satisfy static analysis
+	// Known pfB tracker of the matching type.
+	if (isset($rule_list[$tracker]) && $rule_list[$tracker]['type'] == $type) {
+		return TRUE;
+	}
+
+	// Unknown — reparse ONCE to pick up a freshly added/changed rule.
+	$rule_list = ($reparse)();
+	if ($on_reparse !== NULL) {
+		($on_reparse)();
+	}
+
+	if (isset($rule_list[$tracker]) && $rule_list[$tracker]['type'] == $type) {
+		return TRUE;
+	}
+
+	if (isset($rule_list['other'][$tracker])) {
+		return FALSE;
+	}
+
+	// Still absent after a fresh parse — record in the persistent negative cache.
+	$miss_cache[$tracker] = TRUE;
 	return FALSE;
 }
 
@@ -8638,9 +8637,9 @@ function pfb_daemon_filterlog() {
 		[18]	= Client Hostname
 		[19]	= Duplicate ID indicator		*/
 
-	// Disable pfctl Tracker ID lookup on too many lookup failures
-	$max_retries = 0;
-	
+	// Persistent negative cache: trackers absent from the ruleset are never reparsed again.
+	$tracker_misses = array();
+
 	if (($s_handle = @fopen('php://stdin', 'r')) !== FALSE) {
 		logger(LOG_NOTICE, localize_text('filterlog daemon started'), LOG_PREFIX_PKG_PFBLOCKERNG);
 		while (!feof($s_handle)) {
@@ -8670,7 +8669,8 @@ function pfb_daemon_filterlog() {
 			}
 			$d = explode(',', $f[$f_pos]);
 
-			// Attempt to find the Tracker ID, if not found wait 5secs for filter_reload
+			// Resolve the Tracker ID: reparse at most once per unknown tracker; persistent
+			// negative cache prevents repeated reparses for anchor/trackerless rules.
 			if (!empty($d[3])) {
 				// On reparse: refresh the daemon-local IP/host collections from the box.
 				$pfb_reparse_cb = function () use (&$pfb_local, &$pfb_localsub, &$local_hosts) {
@@ -8681,7 +8681,7 @@ function pfb_daemon_filterlog() {
 				};
 
 				// Resolve the Tracker ID — returns TRUE when a matching pfB rule is found.
-				if (!pfb_resolve_tracker($rule_list, $d[3], $d[6], $max_retries, 'pfb_filterrules', null, $pfb_reparse_cb)) {
+				if (!pfb_resolve_tracker($rule_list, $tracker_misses, $d[3], $d[6], 'pfb_filterrules', $pfb_reparse_cb)) {
 					continue;
 				}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8471,9 +8471,11 @@ function pfb_collect_localhosts() {
 // the line); FALSE for a known non-pfB ('other') or an unresolvable tracker (caller skips).
 //
 // $rule_list  : positive cache from pfb_filterrules(); rebuilt in place on a reparse.
-// $miss_cache : PERSISTENT negative cache of trackers not present in the ruleset; survives
-//               reparses (a reparse rebuilds $rule_list but not this), so each unresolvable
-//               tracker triggers at most ONE reparse for the daemon's life.
+// $miss_cache : PERSISTENT negative cache keyed by "tracker\0type"; survives reparses (a
+//               reparse rebuilds $rule_list but not this), so each unresolvable tracker/type
+//               triggers at most ONE reparse for the daemon's life. Keying by type (and
+//               checking the positive pfB cache first) ensures a transient type mismatch
+//               never suppresses a later log event whose type DOES match the pfB rule.
 // $reparse    : callable() => array — fresh rule list (production: 'pfb_filterrules').
 // $on_reparse : callable() => void  — refresh daemon-local IP/host collections after a reparse.
 function pfb_resolve_tracker(
@@ -8484,19 +8486,22 @@ function pfb_resolve_tracker(
 	callable $reparse,
 	?callable $on_reparse = NULL
 ): bool {
-	// Negative cache: a tracker the ruleset doesn't list (anchor/trackerless) — never reparse again.
-	if (isset($miss_cache[$tracker])) {
+	// Known pfB tracker of the matching type. Checked before the miss cache so a tracker
+	// that becomes valid (e.g. after a reparse for another tracker) always resolves.
+	if (isset($rule_list[$tracker]) && $rule_list[$tracker]['type'] == $type) {
+		return TRUE;
+	}
+
+	$miss_key = "{$tracker}\0{$type}";
+
+	// Negative cache: a tracker/type the ruleset doesn't list (anchor/trackerless) — never reparse again.
+	if (isset($miss_cache[$miss_key])) {
 		return FALSE;
 	}
 
 	// Known non-pfB tracker.
 	if (isset($rule_list['other'][$tracker])) {
 		return FALSE;
-	}
-
-	// Known pfB tracker of the matching type.
-	if (isset($rule_list[$tracker]) && $rule_list[$tracker]['type'] == $type) {
-		return TRUE;
 	}
 
 	// Unknown — reparse ONCE to pick up a freshly added/changed rule.
@@ -8513,8 +8518,8 @@ function pfb_resolve_tracker(
 		return FALSE;
 	}
 
-	// Still absent after a fresh parse — record in the persistent negative cache.
-	$miss_cache[$tracker] = TRUE;
+	// Still unresolved for this tracker/type after a fresh parse — record in the negative cache.
+	$miss_cache[$miss_key] = TRUE;
 	return FALSE;
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8465,6 +8465,61 @@ function pfb_collect_localhosts() {
 }
 
 
+// Resolve a filter.log Tracker ID to a pfBlockerNG rule.
+//
+// Returns TRUE when $tracker is a known pfB rule whose type matches $type (caller
+// should process the log line). Returns FALSE when the tracker is a known non-pfB
+// ('other') tracker or could not be resolved after retries (caller should skip).
+//
+// $rule_list is updated in-place when a reparse is triggered.
+// $reparse   : callable() => array  — returns a fresh rule list (production: pfb_filterrules).
+// $sleeper   : callable(int) => void — sleep shim (injectable for tests; null => builtin sleep).
+// $on_reparse: callable() => void   — called after each reparse so the daemon can refresh
+//             its $pfb_local / $pfb_localsub / $local_hosts variables; null => no callback.
+function pfb_resolve_tracker(
+	array &$rule_list,
+	string $tracker,
+	string $type,
+	int &$max_retries,
+	callable $reparse,
+	?callable $sleeper = null,
+	?callable $on_reparse = null
+): bool {
+	if ($sleeper === null) {
+		$sleeper = 'sleep';
+	}
+
+	for ($retries = 1; $retries <= 5; $retries++) {
+
+		// Skip known non-pfBlockerNG Tracker IDs
+		if (isset($rule_list['other'][$tracker])) {
+			return FALSE;
+		}
+
+		// Resolved: pfB rule whose type matches
+		if (isset($rule_list[$tracker]) && $rule_list[$tracker]['type'] == $type) {
+			return TRUE;
+		}
+
+		// Tracker not yet known — collect updated pfctl rule data and refresh daemon locals
+		$rule_list = ($reparse)();
+		if ($on_reparse !== null) {
+			($on_reparse)();
+		}
+
+		if ($retries < 5 && $max_retries < 30) {
+			$max_retries++;
+			($sleeper)(5);
+		} else {
+			return FALSE;
+		}
+	}
+
+	// Unreachable: loop exits via return inside, but satisfy static analysis
+	return FALSE;
+}
+
+
 // Firewall filter.log parser daemon
 function pfb_daemon_filterlog() {
 	global $pfb;
@@ -8616,42 +8671,17 @@ function pfb_daemon_filterlog() {
 			$d = explode(',', $f[$f_pos]);
 
 			// Attempt to find the Tracker ID, if not found wait 5secs for filter_reload
-			$other = FALSE;
 			if (!empty($d[3])) {
-				for ($retries = 1; $retries <= 5; $retries++) {
+				// On reparse: refresh the daemon-local IP/host collections from the box.
+				$pfb_reparse_cb = function () use (&$pfb_local, &$pfb_localsub, &$local_hosts) {
+					$data		= pfb_collect_localip();
+					$pfb_local	= $data[0] ?: array();
+					$pfb_localsub	= $data[1] ?: array();
+					$local_hosts	= pfb_collect_localhosts();
+				};
 
-					// Skip known non-pfBlockerNG Tracker IDs
-					if (isset($rule_list['other'][$d[3]])) {
-						$other = TRUE;
-						break;
-					}
-
-					// Break on pfBlockerNG rule Tracker ID and Rule type (block|permit|match)
-					// If the user switched a manual rule from one type to another, the Tracker ID will stay the same
-					// So this comparison will refresh the data on changes
-					if (isset($rule_list[$d[3]]) && $rule_list[$d[3]]['type'] == $d[6]) {
-						break;
-					}
-
-					// Collect updated pfctl Rule data, Host and local IP data
-					else {
-						$rule_list	= pfb_filterrules();
-						$data		= pfb_collect_localip();
-						$pfb_local	= $data[0] ?: array();
-						$pfb_localsub	= $data[1] ?: array();
-
-						$local_hosts	= pfb_collect_localhosts();
-					}
-
-					if ($retries < 5 && $max_retries < 30) {
-						$max_retries++;
-						sleep(5);
-					} else {
-						$other = TRUE;
-					}
-				}
-
-				if ($other) {
+				// Resolve the Tracker ID — returns TRUE when a matching pfB rule is found.
+				if (!pfb_resolve_tracker($rule_list, $d[3], $d[6], $max_retries, 'pfb_filterrules', null, $pfb_reparse_cb)) {
 					continue;
 				}
 

--- a/tests/php/FilterlogTrackerResolveTest.php
+++ b/tests/php/FilterlogTrackerResolveTest.php
@@ -138,7 +138,7 @@ final class FilterlogTrackerResolveTest extends TestCase
 		};
 
 		$ruleList  = $this->emptyRuleList();
-		$missCache = ['7777' => TRUE];  // pre-loaded into the negative cache
+		$missCache = ["7777\0block" => TRUE];  // pre-loaded into the negative cache (tracker\0type key)
 
 		// When: tracker is in miss_cache
 		$result = pfb_resolve_tracker($ruleList, $missCache, '7777', 'block', $reparse);
@@ -176,14 +176,14 @@ final class FilterlogTrackerResolveTest extends TestCase
 
 		// Before: no reparses yet, tracker absent from both caches
 		$this->assertSame(0, $reparseCount, 'Precondition: zero reparses before call');
-		$this->assertArrayNotHasKey('4242', $missCache, 'Precondition: tracker not in miss_cache');
+		$this->assertArrayNotHasKey("4242\0block", $missCache, 'Precondition: tracker not in miss_cache');
 
 		$result = pfb_resolve_tracker($ruleList, $missCache, '4242', 'block', $reparse);
 
 		// Then: FALSE with exactly one reparse, tracker now in miss_cache
 		$this->assertFalse($result, 'Unresolved tracker must return FALSE');
 		$this->assertSame(1, $reparseCount, '#326 fix: an unresolved tracker must trigger at most ONE reparse per first encounter, not 5');
-		$this->assertArrayHasKey('4242', $missCache, 'Unresolved tracker must be added to miss_cache after one reparse');
+		$this->assertArrayHasKey("4242\0block", $missCache, 'Unresolved tracker must be added to miss_cache after one reparse');
 	}
 
 	// ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@ final class FilterlogTrackerResolveTest extends TestCase
 
 		$this->assertFalse($first, 'First call for unresolved tracker must return FALSE');
 		$this->assertSame(1, $afterFirst, 'First call must trigger exactly one reparse');
-		$this->assertArrayHasKey('5555', $missCache, 'First call must add tracker to miss_cache');
+		$this->assertArrayHasKey("5555\0block", $missCache, 'First call must add tracker to miss_cache');
 
 		// When: second call for the SAME tracker — miss_cache already has the entry
 		$second = pfb_resolve_tracker($ruleList, $missCache, '5555', 'block', $reparse);
@@ -236,8 +236,8 @@ final class FilterlogTrackerResolveTest extends TestCase
 		$afterOtherTracker = $reparseCount;
 
 		$this->assertSame($afterFirst + 1, $afterOtherTracker, 'A different unresolved tracker triggers one more reparse');
-		$this->assertArrayHasKey('5555', $missCache, 'miss_cache entry for 5555 must survive a reparse triggered by a different tracker');
-		$this->assertArrayHasKey('6666', $missCache, 'New unresolved tracker 6666 must also be added to miss_cache');
+		$this->assertArrayHasKey("5555\0block", $missCache, 'miss_cache entry for 5555 must survive a reparse triggered by a different tracker');
+		$this->assertArrayHasKey("6666\0block", $missCache, 'New unresolved tracker 6666 must also be added to miss_cache');
 
 		// And now '5555' is still negative-cached even though $rule_list was just rebuilt
 		$third = pfb_resolve_tracker($ruleList, $missCache, '5555', 'block', $reparse);
@@ -341,6 +341,48 @@ final class FilterlogTrackerResolveTest extends TestCase
 		$this->assertSame(1, $reparseCount, 'Type mismatch must trigger exactly one reparse');
 		$this->assertSame('block', $ruleList['2222']['type'], 'rule_list must reflect the fresh parse result');
 		$this->assertArrayNotHasKey('2222', $missCache, 'A positively-resolved tracker must NOT be in miss_cache');
+	}
+
+	// ---------------------------------------------------------------------------
+	// Regression: a type mismatch must NOT poison the cache for the matching type
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Scenario: a transient type mismatch must never suppress a later matching event.
+	 *
+	 * Given  a pfB tracker present in rule_list as type 'block'
+	 * When   a log line arrives with a mismatched type 'match' (and the reparse does NOT
+	 *        resolve that type), then a later line arrives with the correct type 'block'
+	 * Then   the mismatched call is FALSE and caches only the (tracker,'match') key;
+	 *        the matching call returns TRUE via the positive cache with ZERO reparses —
+	 *        the negative cache did not poison the tracker.
+	 *
+	 * Guards the keyed-by-(tracker,type) + positive-first design: keying the miss cache
+	 * by tracker alone would have suppressed the matching event for the daemon's life.
+	 */
+	public function testTypeMismatchDoesNotPoisonCacheForMatchingType(): void
+	{
+		$reparseCount = 0;
+		// Reparse returns the tracker still only as type 'block' — the 'match' type stays unresolved.
+		$reparse = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->ruleListWithPfb('1212', 'block');
+		};
+
+		$ruleList  = $this->ruleListWithPfb('1212', 'block');
+		$missCache = [];
+
+		// When: a mismatched-type ('match') line is resolved — unresolved, one reparse, cached by (tracker,type)
+		$mismatch = pfb_resolve_tracker($ruleList, $missCache, '1212', 'match', $reparse);
+		$this->assertFalse($mismatch, 'A type mismatch that the reparse cannot resolve must return FALSE');
+		$this->assertSame(1, $reparseCount, 'The mismatched type triggers exactly one reparse');
+		$this->assertArrayHasKey("1212\0match", $missCache, 'Only the mismatched (tracker,type) pair is negative-cached');
+		$this->assertArrayNotHasKey("1212\0block", $missCache, 'The matching type must NOT be negative-cached');
+
+		// Then: a later correctly-typed ('block') line resolves TRUE via the positive cache, no reparse
+		$match = pfb_resolve_tracker($ruleList, $missCache, '1212', 'block', $reparse);
+		$this->assertTrue($match, 'The matching type must still resolve TRUE — the cache was not poisoned');
+		$this->assertSame(1, $reparseCount, 'The matching-type lookup must not trigger any further reparse (positive cache first)');
 	}
 
 	// ---------------------------------------------------------------------------

--- a/tests/php/FilterlogTrackerResolveTest.php
+++ b/tests/php/FilterlogTrackerResolveTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_resolve_tracker() — testable seam for the filter.log tracker-resolution logic.
+ *
+ * The two "unresolved tracker" cases are the REGRESSION ANCHORS for #326: they pin
+ * the DESIRED post-fix behaviour and intentionally FAIL (RED) against the current
+ * code, which calls the reparse callable up to 5× per unresolved tracker and has no
+ * negative cache. Step 2 adds the negative cache + single-parse-per-line fix to turn
+ * them GREEN.
+ *
+ * The "sanity" cases (already-cached pfB rule, already-cached 'other' tracker) are
+ * GREEN today and must remain GREEN after the fix.
+ */
+#[CoversFunction('pfb_resolve_tracker')]
+final class FilterlogTrackerResolveTest extends TestCase
+{
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Build a rule_list containing a known pfB rule.
+	 * @return array<string, mixed>
+	 */
+	private function ruleListWithPfb(string $tracker, string $type): array
+	{
+		return [
+			'id'    => [$tracker],
+			'other' => [],
+			'int'   => [],
+			$tracker => ['name' => 'pfB_TestAlias', 'type' => $type],
+		];
+	}
+
+	/**
+	 * Build a rule_list that has $tracker in the 'other' bucket (known non-pfB).
+	 * @return array<string, mixed>
+	 */
+	private function ruleListWithOther(string $tracker): array
+	{
+		return [
+			'id'    => [],
+			'other' => [$tracker => ''],
+			'int'   => [],
+		];
+	}
+
+	/**
+	 * Build an empty rule_list (tracker unknown to pfB).
+	 * @return array<string, mixed>
+	 */
+	private function emptyRuleList(): array
+	{
+		return ['id' => [], 'other' => [], 'int' => []];
+	}
+
+	// ---------------------------------------------------------------------------
+	// Sanity cases — GREEN today, must stay GREEN after the fix
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * A pfB tracker already present in rule_list with the correct type resolves TRUE
+	 * with zero reparse calls. Behaviour pinned: cache hit on the fast path.
+	 */
+	public function testKnownPfbTrackerResolvesWithoutReparse(): void
+	{
+		$reparseCount = 0;
+		$reparse      = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->emptyRuleList();
+		};
+		$noSleep = static function (int $s): void { /* no-op */ };
+
+		$ruleList    = $this->ruleListWithPfb('1001', 'block');
+		$maxRetries  = 0;
+
+		// When: tracker is in rule_list and types match
+		$result = pfb_resolve_tracker($ruleList, '1001', 'block', $maxRetries, $reparse, $noSleep);
+
+		// Then: resolves TRUE, no reparse needed
+		$this->assertTrue($result, 'Known pfB tracker with matching type must resolve TRUE');
+		$this->assertSame(0, $reparseCount, 'No reparse should occur when tracker is already in rule_list');
+	}
+
+	/**
+	 * A known 'other' (non-pfB) tracker cached in rule_list resolves FALSE immediately
+	 * with zero reparse calls. Behaviour pinned: 'other' cache hit.
+	 */
+	public function testKnownOtherTrackerResolvesWithoutReparse(): void
+	{
+		$reparseCount = 0;
+		$reparse      = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->emptyRuleList();
+		};
+		$noSleep = static function (int $s): void { /* no-op */ };
+
+		$ruleList   = $this->ruleListWithOther('9999');
+		$maxRetries = 0;
+
+		// When: tracker is in rule_list['other']
+		$result = pfb_resolve_tracker($ruleList, '9999', 'block', $maxRetries, $reparse, $noSleep);
+
+		// Then: resolves FALSE, no reparse needed
+		$this->assertFalse($result, 'Known other tracker must resolve FALSE');
+		$this->assertSame(0, $reparseCount, 'No reparse should occur for a cached other tracker');
+	}
+
+	// ---------------------------------------------------------------------------
+	// Regression anchors — RED today, must be GREEN after Step 2 fixes #326
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Scenario: unresolved tracker triggers at most ONE reparse per first encounter.
+	 *
+	 * Given  a rule_list with no entry for the tracker
+	 * When   pfb_resolve_tracker() is called for that tracker
+	 * Then   the reparse callable is invoked AT MOST ONCE (not 5×)
+	 *
+	 * RED today: the current code calls the reparse callable once per retry loop
+	 * iteration (up to 5 times) before giving up. The fix should attempt a single
+	 * reparse, cache the miss in rule_list['other'], and return FALSE immediately.
+	 */
+	public function testUnresolvedTrackerTriggersAtMostOneReparse(): void
+	{
+		$reparseCount = 0;
+		// The reparse double always returns an empty rule_list (tracker stays unknown).
+		$reparse = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->emptyRuleList();
+		};
+		$noSleep = static function (int $s): void { /* no-op */ };
+
+		$ruleList   = $this->emptyRuleList();
+		$maxRetries = 0;
+
+		$result = pfb_resolve_tracker($ruleList, '4242', 'block', $maxRetries, $reparse, $noSleep);
+
+		$this->assertFalse($result, 'Unresolved tracker must return FALSE');
+
+		// DESIRED post-fix behaviour: exactly 1 reparse (try once, then give up + cache miss).
+		// RED today: the current implementation calls reparse 5 times before returning FALSE.
+		$this->assertSame(1, $reparseCount, '#326 fix: an unresolved tracker must trigger at most ONE reparse per first encounter, not 5');
+	}
+
+	/**
+	 * Scenario: repeated calls for the same unresolved tracker use the negative cache.
+	 *
+	 * Given  a rule_list that has already been returned from a previous resolve call
+	 *        (so the tracker's miss was negative-cached in rule_list['other'])
+	 * When   pfb_resolve_tracker() is called again for the same tracker
+	 * Then   the reparse callable is NOT called (counter stays at the prior value)
+	 *
+	 * RED today: the current code has no negative cache, so the second call also
+	 * triggers up to 5 reparses. The fix must write the unresolved tracker into
+	 * rule_list['other'] on miss so subsequent calls short-circuit immediately.
+	 */
+	public function testRepeatedUnresolvedTrackerUsesNegativeCache(): void
+	{
+		$reparseCount = 0;
+		$reparse      = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->emptyRuleList();
+		};
+		$noSleep = static function (int $s): void { /* no-op */ };
+
+		$ruleList   = $this->emptyRuleList();
+		$maxRetries = 0;
+
+		// First call: populates the negative cache (1 reparse expected post-fix)
+		pfb_resolve_tracker($ruleList, '5555', 'block', $maxRetries, $reparse, $noSleep);
+		$afterFirst = $reparseCount;
+
+		// Second call with the SAME $ruleList (which now carries the negative-cache entry)
+		$result = pfb_resolve_tracker($ruleList, '5555', 'block', $maxRetries, $reparse, $noSleep);
+
+		$this->assertFalse($result, 'Negatively-cached tracker must still resolve FALSE');
+
+		// DESIRED post-fix behaviour: zero additional reparses on the second call.
+		// RED today: the current code has no negative cache, so a second call also
+		// hits the reparse loop.
+		$this->assertSame($afterFirst, $reparseCount, '#326 fix: a negatively-cached tracker must not trigger any further reparse');
+	}
+}

--- a/tests/php/FilterlogTrackerResolveTest.php
+++ b/tests/php/FilterlogTrackerResolveTest.php
@@ -8,14 +8,21 @@ use PHPUnit\Framework\TestCase;
 /**
  * pfb_resolve_tracker() — testable seam for the filter.log tracker-resolution logic.
  *
- * The two "unresolved tracker" cases are the REGRESSION ANCHORS for #326: they pin
- * the DESIRED post-fix behaviour and intentionally FAIL (RED) against the current
- * code, which calls the reparse callable up to 5× per unresolved tracker and has no
- * negative cache. Step 2 adds the negative cache + single-parse-per-line fix to turn
- * them GREEN.
+ * Covers every branch of the helper:
+ *   - Negative-cache hit ($miss_cache)        → FALSE, zero reparses
+ *   - 'other' cache hit ($rule_list['other'])  → FALSE, zero reparses
+ *   - Positive cache hit ($rule_list[$tracker])→ TRUE,  zero reparses
+ *   - Unknown → reparse resolves as pfB        → TRUE,  exactly one reparse
+ *   - Unknown → reparse resolves as 'other'    → FALSE, one reparse, NOT in miss_cache
+ *   - Unknown → reparse still absent           → FALSE, one reparse, added to miss_cache
+ *   - Type mismatch → reparse, resolved on fresh list → TRUE, one reparse
  *
- * The "sanity" cases (already-cached pfB rule, already-cached 'other' tracker) are
- * GREEN today and must remain GREEN after the fix.
+ * The two regression anchors (#326 fix) prove the negative-cache behaviour:
+ *   testUnresolvedTrackerTriggersAtMostOneReparse   (was RED, now GREEN)
+ *   testRepeatedUnresolvedTrackerUsesNegativeCache  (was RED, now GREEN)
+ *
+ * All tests use a call-counting $reparse closure and assert the count before and
+ * after so green proves the cache—not coincidence—caused the drop.
  */
 #[CoversFunction('pfb_resolve_tracker')]
 final class FilterlogTrackerResolveTest extends TestCase
@@ -31,9 +38,9 @@ final class FilterlogTrackerResolveTest extends TestCase
 	private function ruleListWithPfb(string $tracker, string $type): array
 	{
 		return [
-			'id'    => [$tracker],
-			'other' => [],
-			'int'   => [],
+			'id'     => [$tracker],
+			'other'  => [],
+			'int'    => [],
 			$tracker => ['name' => 'pfB_TestAlias', 'type' => $type],
 		];
 	}
@@ -61,12 +68,12 @@ final class FilterlogTrackerResolveTest extends TestCase
 	}
 
 	// ---------------------------------------------------------------------------
-	// Sanity cases — GREEN today, must stay GREEN after the fix
+	// Positive-cache hit: known pfB tracker, matching type
 	// ---------------------------------------------------------------------------
 
 	/**
 	 * A pfB tracker already present in rule_list with the correct type resolves TRUE
-	 * with zero reparse calls. Behaviour pinned: cache hit on the fast path.
+	 * with zero reparse calls. Behaviour pinned: positive cache hit on the fast path.
 	 */
 	public function testKnownPfbTrackerResolvesWithoutReparse(): void
 	{
@@ -75,18 +82,21 @@ final class FilterlogTrackerResolveTest extends TestCase
 			$reparseCount++;
 			return $this->emptyRuleList();
 		};
-		$noSleep = static function (int $s): void { /* no-op */ };
 
-		$ruleList    = $this->ruleListWithPfb('1001', 'block');
-		$maxRetries  = 0;
+		$ruleList   = $this->ruleListWithPfb('1001', 'block');
+		$missCache  = [];
 
 		// When: tracker is in rule_list and types match
-		$result = pfb_resolve_tracker($ruleList, '1001', 'block', $maxRetries, $reparse, $noSleep);
+		$result = pfb_resolve_tracker($ruleList, $missCache, '1001', 'block', $reparse);
 
 		// Then: resolves TRUE, no reparse needed
 		$this->assertTrue($result, 'Known pfB tracker with matching type must resolve TRUE');
 		$this->assertSame(0, $reparseCount, 'No reparse should occur when tracker is already in rule_list');
 	}
+
+	// ---------------------------------------------------------------------------
+	// 'other' cache hit: known non-pfB tracker in rule_list
+	// ---------------------------------------------------------------------------
 
 	/**
 	 * A known 'other' (non-pfB) tracker cached in rule_list resolves FALSE immediately
@@ -99,13 +109,12 @@ final class FilterlogTrackerResolveTest extends TestCase
 			$reparseCount++;
 			return $this->emptyRuleList();
 		};
-		$noSleep = static function (int $s): void { /* no-op */ };
 
-		$ruleList   = $this->ruleListWithOther('9999');
-		$maxRetries = 0;
+		$ruleList  = $this->ruleListWithOther('9999');
+		$missCache = [];
 
 		// When: tracker is in rule_list['other']
-		$result = pfb_resolve_tracker($ruleList, '9999', 'block', $maxRetries, $reparse, $noSleep);
+		$result = pfb_resolve_tracker($ruleList, $missCache, '9999', 'block', $reparse);
 
 		// Then: resolves FALSE, no reparse needed
 		$this->assertFalse($result, 'Known other tracker must resolve FALSE');
@@ -113,53 +122,87 @@ final class FilterlogTrackerResolveTest extends TestCase
 	}
 
 	// ---------------------------------------------------------------------------
-	// Regression anchors — RED today, must be GREEN after Step 2 fixes #326
+	// Negative-cache hit: tracker already in miss_cache
 	// ---------------------------------------------------------------------------
 
 	/**
-	 * Scenario: unresolved tracker triggers at most ONE reparse per first encounter.
+	 * A tracker already in the persistent miss_cache resolves FALSE immediately with
+	 * zero reparse calls. Behaviour pinned: negative cache hit on the fast path.
+	 */
+	public function testNegativeCacheHitResolvesWithoutReparse(): void
+	{
+		$reparseCount = 0;
+		$reparse      = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->emptyRuleList();
+		};
+
+		$ruleList  = $this->emptyRuleList();
+		$missCache = ['7777' => TRUE];  // pre-loaded into the negative cache
+
+		// When: tracker is in miss_cache
+		$result = pfb_resolve_tracker($ruleList, $missCache, '7777', 'block', $reparse);
+
+		// Then: resolves FALSE without touching reparse
+		$this->assertFalse($result, 'Negatively-cached tracker must resolve FALSE');
+		$this->assertSame(0, $reparseCount, 'No reparse should occur for a miss_cache hit');
+	}
+
+	// ---------------------------------------------------------------------------
+	// Regression anchor #1 — #326 fix: at most ONE reparse per first encounter
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Scenario: unresolved tracker triggers at most ONE reparse on its first encounter.
 	 *
-	 * Given  a rule_list with no entry for the tracker
+	 * Given  a rule_list and miss_cache with no entry for the tracker
 	 * When   pfb_resolve_tracker() is called for that tracker
-	 * Then   the reparse callable is invoked AT MOST ONCE (not 5×)
+	 * Then   the reparse callable is invoked EXACTLY ONCE (not 5×)
+	 *        and the tracker is added to miss_cache
 	 *
-	 * RED today: the current code calls the reparse callable once per retry loop
-	 * iteration (up to 5 times) before giving up. The fix should attempt a single
-	 * reparse, cache the miss in rule_list['other'], and return FALSE immediately.
+	 * This was RED against the old code (which reparsed up to 5×). GREEN proves the fix.
 	 */
 	public function testUnresolvedTrackerTriggersAtMostOneReparse(): void
 	{
 		$reparseCount = 0;
-		// The reparse double always returns an empty rule_list (tracker stays unknown).
+		// Reparse double always returns an empty rule_list (tracker stays unknown).
 		$reparse = function () use (&$reparseCount): array {
 			$reparseCount++;
 			return $this->emptyRuleList();
 		};
-		$noSleep = static function (int $s): void { /* no-op */ };
 
-		$ruleList   = $this->emptyRuleList();
-		$maxRetries = 0;
+		$ruleList  = $this->emptyRuleList();
+		$missCache = [];
 
-		$result = pfb_resolve_tracker($ruleList, '4242', 'block', $maxRetries, $reparse, $noSleep);
+		// Before: no reparses yet, tracker absent from both caches
+		$this->assertSame(0, $reparseCount, 'Precondition: zero reparses before call');
+		$this->assertArrayNotHasKey('4242', $missCache, 'Precondition: tracker not in miss_cache');
 
+		$result = pfb_resolve_tracker($ruleList, $missCache, '4242', 'block', $reparse);
+
+		// Then: FALSE with exactly one reparse, tracker now in miss_cache
 		$this->assertFalse($result, 'Unresolved tracker must return FALSE');
-
-		// DESIRED post-fix behaviour: exactly 1 reparse (try once, then give up + cache miss).
-		// RED today: the current implementation calls reparse 5 times before returning FALSE.
 		$this->assertSame(1, $reparseCount, '#326 fix: an unresolved tracker must trigger at most ONE reparse per first encounter, not 5');
+		$this->assertArrayHasKey('4242', $missCache, 'Unresolved tracker must be added to miss_cache after one reparse');
 	}
 
+	// ---------------------------------------------------------------------------
+	// Regression anchor #2 — #326 fix: negative cache prevents further reparses
+	// ---------------------------------------------------------------------------
+
 	/**
-	 * Scenario: repeated calls for the same unresolved tracker use the negative cache.
+	 * Scenario: repeated calls for the same unresolved tracker use the persistent negative cache.
 	 *
-	 * Given  a rule_list that has already been returned from a previous resolve call
-	 *        (so the tracker's miss was negative-cached in rule_list['other'])
+	 * Given  a first call has already negative-cached the tracker in miss_cache
 	 * When   pfb_resolve_tracker() is called again for the same tracker
-	 * Then   the reparse callable is NOT called (counter stays at the prior value)
+	 * Then   the reparse callable is NOT called (count stays at 1)
 	 *
-	 * RED today: the current code has no negative cache, so the second call also
-	 * triggers up to 5 reparses. The fix must write the unresolved tracker into
-	 * rule_list['other'] on miss so subsequent calls short-circuit immediately.
+	 * Also proves the cache survives a reparse for a DIFFERENT tracker: even after
+	 * $rule_list is rebuilt for tracker '6666', the miss_cache entry for '5555' remains,
+	 * so a third call for '5555' still triggers zero reparses. This is the critical
+	 * correctness property: the negative cache must be separate from $rule_list.
+	 *
+	 * This was RED against the old code (no negative cache, every call reparsed). GREEN proves the fix.
 	 */
 	public function testRepeatedUnresolvedTrackerUsesNegativeCache(): void
 	{
@@ -168,23 +211,198 @@ final class FilterlogTrackerResolveTest extends TestCase
 			$reparseCount++;
 			return $this->emptyRuleList();
 		};
-		$noSleep = static function (int $s): void { /* no-op */ };
 
-		$ruleList   = $this->emptyRuleList();
-		$maxRetries = 0;
+		$ruleList  = $this->emptyRuleList();
+		$missCache = [];
 
-		// First call: populates the negative cache (1 reparse expected post-fix)
-		pfb_resolve_tracker($ruleList, '5555', 'block', $maxRetries, $reparse, $noSleep);
+		// Given: first call for '5555' — populates the negative cache (1 reparse expected)
+		$first = pfb_resolve_tracker($ruleList, $missCache, '5555', 'block', $reparse);
 		$afterFirst = $reparseCount;
 
-		// Second call with the SAME $ruleList (which now carries the negative-cache entry)
-		$result = pfb_resolve_tracker($ruleList, '5555', 'block', $maxRetries, $reparse, $noSleep);
+		$this->assertFalse($first, 'First call for unresolved tracker must return FALSE');
+		$this->assertSame(1, $afterFirst, 'First call must trigger exactly one reparse');
+		$this->assertArrayHasKey('5555', $missCache, 'First call must add tracker to miss_cache');
 
-		$this->assertFalse($result, 'Negatively-cached tracker must still resolve FALSE');
+		// When: second call for the SAME tracker — miss_cache already has the entry
+		$second = pfb_resolve_tracker($ruleList, $missCache, '5555', 'block', $reparse);
 
-		// DESIRED post-fix behaviour: zero additional reparses on the second call.
-		// RED today: the current code has no negative cache, so a second call also
-		// hits the reparse loop.
+		// Then: FALSE, zero additional reparses
+		$this->assertFalse($second, 'Negatively-cached tracker must still resolve FALSE');
 		$this->assertSame($afterFirst, $reparseCount, '#326 fix: a negatively-cached tracker must not trigger any further reparse');
+
+		// Prove the cache survives a reparse for a DIFFERENT tracker ('6666'):
+		// $rule_list is rebuilt by this call, but miss_cache['5555'] must survive.
+		pfb_resolve_tracker($ruleList, $missCache, '6666', 'block', $reparse);
+		$afterOtherTracker = $reparseCount;
+
+		$this->assertSame($afterFirst + 1, $afterOtherTracker, 'A different unresolved tracker triggers one more reparse');
+		$this->assertArrayHasKey('5555', $missCache, 'miss_cache entry for 5555 must survive a reparse triggered by a different tracker');
+		$this->assertArrayHasKey('6666', $missCache, 'New unresolved tracker 6666 must also be added to miss_cache');
+
+		// And now '5555' is still negative-cached even though $rule_list was just rebuilt
+		$third = pfb_resolve_tracker($ruleList, $missCache, '5555', 'block', $reparse);
+		$this->assertFalse($third, '5555 must still resolve FALSE after rule_list rebuild for 6666');
+		$this->assertSame($afterOtherTracker, $reparseCount, '5555 must not trigger a reparse after rule_list rebuild — cache is separate from rule_list');
+	}
+
+	// ---------------------------------------------------------------------------
+	// Unknown → reparse resolves as pfB (newly added rule)
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * An unknown tracker that the reparse resolves as a pfB rule of the matching type
+	 * returns TRUE after exactly one reparse and is NOT added to miss_cache.
+	 * Behaviour pinned: newly added/changed pfB rule discovered on first reparse.
+	 */
+	public function testUnknownTrackerResolvedByReparseAsPfb(): void
+	{
+		$reparseCount = 0;
+		// Reparse returns a rule_list that now includes the tracker.
+		$reparse = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->ruleListWithPfb('3333', 'block');
+		};
+
+		$ruleList  = $this->emptyRuleList();
+		$missCache = [];
+
+		// Before: tracker absent from both lists
+		$this->assertSame(0, $reparseCount, 'Precondition: zero reparses before call');
+
+		$result = pfb_resolve_tracker($ruleList, $missCache, '3333', 'block', $reparse);
+
+		// Then: TRUE after exactly one reparse; NOT negative-cached (it resolved positively)
+		$this->assertTrue($result, 'Tracker resolved by reparse as pfB must return TRUE');
+		$this->assertSame(1, $reparseCount, 'Exactly one reparse must occur when the tracker is found on the fresh rule_list');
+		$this->assertArrayNotHasKey('3333', $missCache, 'A positively-resolved tracker must NOT be added to miss_cache');
+	}
+
+	// ---------------------------------------------------------------------------
+	// Unknown → reparse resolves as 'other'
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * An unknown tracker that the reparse places in rule_list['other'] returns FALSE
+	 * after one reparse and is NOT added to miss_cache (it is in rule_list['other']).
+	 * Behaviour pinned: the 'other' path after a reparse.
+	 */
+	public function testUnknownTrackerResolvedByReparseAsOther(): void
+	{
+		$reparseCount = 0;
+		$reparse      = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->ruleListWithOther('8888');
+		};
+
+		$ruleList  = $this->emptyRuleList();
+		$missCache = [];
+
+		$this->assertSame(0, $reparseCount, 'Precondition: zero reparses before call');
+
+		$result = pfb_resolve_tracker($ruleList, $missCache, '8888', 'block', $reparse);
+
+		// Then: FALSE after one reparse; in rule_list['other'], NOT in miss_cache
+		$this->assertFalse($result, 'Tracker resolved as other by reparse must return FALSE');
+		$this->assertSame(1, $reparseCount, 'Exactly one reparse must occur');
+		$this->assertArrayNotHasKey('8888', $missCache, 'Tracker in rule_list["other"] must NOT be added to miss_cache');
+		$this->assertArrayHasKey('8888', $ruleList['other'], 'Tracker must be in rule_list["other"] after reparse');
+	}
+
+	// ---------------------------------------------------------------------------
+	// Type mismatch → reparse resolves with fresh correct type
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * A tracker present in rule_list but with a different type triggers exactly one
+	 * reparse. If the fresh rule_list has the tracker with the correct type, returns TRUE.
+	 * Behaviour pinned: changed rule type discovered on reparse.
+	 */
+	public function testTypeMismatchTriggersOneReparseAndResolvesOnFreshList(): void
+	{
+		$reparseCount = 0;
+		// Reparse returns the tracker with the correct type ('block').
+		$reparse = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->ruleListWithPfb('2222', 'block');
+		};
+
+		// Initial rule_list has the tracker but with the WRONG type ('permit').
+		$ruleList  = $this->ruleListWithPfb('2222', 'permit');
+		$missCache = [];
+
+		// Before: type mismatch exists; no reparses yet
+		$this->assertSame('permit', $ruleList['2222']['type'], 'Precondition: type in rule_list is permit, not block');
+		$this->assertSame(0, $reparseCount, 'Precondition: zero reparses before call');
+
+		$result = pfb_resolve_tracker($ruleList, $missCache, '2222', 'block', $reparse);
+
+		// Then: TRUE after exactly one reparse (type now matches on fresh list)
+		$this->assertTrue($result, 'Type-matched tracker on fresh rule_list must return TRUE');
+		$this->assertSame(1, $reparseCount, 'Type mismatch must trigger exactly one reparse');
+		$this->assertSame('block', $ruleList['2222']['type'], 'rule_list must reflect the fresh parse result');
+		$this->assertArrayNotHasKey('2222', $missCache, 'A positively-resolved tracker must NOT be in miss_cache');
+	}
+
+	// ---------------------------------------------------------------------------
+	// $on_reparse callback is invoked on a reparse
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * When $on_reparse is provided and a reparse occurs, the callback is invoked once.
+	 * Behaviour pinned: daemon-local refresh runs alongside rule_list rebuild.
+	 */
+	public function testOnReparseCallbackInvokedOnReparse(): void
+	{
+		$reparseCount   = 0;
+		$callbackCount  = 0;
+		$reparse        = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->emptyRuleList();
+		};
+		$onReparse = function () use (&$callbackCount): void {
+			$callbackCount++;
+		};
+
+		$ruleList  = $this->emptyRuleList();
+		$missCache = [];
+
+		// Before: no reparses, no callbacks
+		$this->assertSame(0, $reparseCount, 'Precondition: zero reparses');
+		$this->assertSame(0, $callbackCount, 'Precondition: zero callbacks');
+
+		pfb_resolve_tracker($ruleList, $missCache, '1234', 'block', $reparse, $onReparse);
+
+		// Then: reparse and callback each invoked exactly once
+		$this->assertSame(1, $reparseCount, 'Reparse must be called once for an unknown tracker');
+		$this->assertSame(1, $callbackCount, 'on_reparse callback must be called once alongside the reparse');
+	}
+
+	// ---------------------------------------------------------------------------
+	// $on_reparse callback is NOT invoked when tracker is already known
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * When the tracker hits the positive cache, $on_reparse is never invoked.
+	 * Behaviour pinned: callback is reparse-only; no spurious side-effects on cache hits.
+	 */
+	public function testOnReparseCallbackNotInvokedOnCacheHit(): void
+	{
+		$reparseCount  = 0;
+		$callbackCount = 0;
+		$reparse       = function () use (&$reparseCount): array {
+			$reparseCount++;
+			return $this->emptyRuleList();
+		};
+		$onReparse = function () use (&$callbackCount): void {
+			$callbackCount++;
+		};
+
+		$ruleList  = $this->ruleListWithPfb('5050', 'block');
+		$missCache = [];
+
+		pfb_resolve_tracker($ruleList, $missCache, '5050', 'block', $reparse, $onReparse);
+
+		$this->assertSame(0, $reparseCount, 'No reparse on positive cache hit');
+		$this->assertSame(0, $callbackCount, 'on_reparse callback must NOT fire on a positive cache hit');
 	}
 }


### PR DESCRIPTION
## Problem

The `filterlog` reporting daemon (`php_pfb … filterlog`) can sustain very high CPU (#326 reports ~91%, on both 2.7.2 and 24.11 — version-independent, consistent with a structural defect).

Root cause in `pfb_daemon_filterlog()`: each log line's Tracker ID is resolved against a cache built by `pfb_filterrules()` (which parses `pfctl -vvsr`). A **non-zero** tracker that `pfctl -vvsr` does not list — anchor-nested rules (OpenVPN/IPsec/UPnP/IDS/captive-portal) or a rule without a numeric `ridentifier` — is never cached. For such a tracker the resolution `for`-loop ran **all 5 iterations, each calling `pfb_filterrules()`** (a full ruleset parse) — up to 5 parses per log line — and **never negative-cached** it, so the next line repeated the whole thing. Sustained logging from such trackers pegs the CPU. (`$d[3] == '0'` is exempt — `!empty('0')` is FALSE in PHP — so default-deny/tracker-0 lines never triggered it.)

## Fix

Resolve each tracker with **at most one** reparse per line, backed by a **persistent negative cache**:

- Extract the resolution into a testable helper `pfb_resolve_tracker(&$rule_list, &$miss_cache, $tracker, $type, $reparse, $on_reparse)`.
- On an unknown tracker: reparse **once** (picks up a freshly added/changed rule, which is present in `pfctl -vvsr` by the time its packets are logged); if still absent, record it in `$miss_cache` and skip.
- **`$miss_cache` is separate from `$rule_list`** — a reparse rebuilds `$rule_list` but not the miss cache, so two interleaved uncacheable trackers can't defeat it. Each unresolvable tracker therefore triggers at most one reparse for the daemon's life.

This removes the `sleep(5)` settle-retry loop (a newly added rule resolves on the single reparse; the rare sub-second mid-reload race may mislabel one tracker as non-pfB until the daemon restarts on the next pfB reload — a documented, low-risk tradeoff). Behaviour for known pfB / 'other' trackers is unchanged.

## Tests

`tests/php/FilterlogTrackerResolveTest.php` (10 cases, every branch) — the two regression anchors prove (a) an unknown tracker triggers exactly **one** reparse, and (b) it is negative-cached so repeats trigger **zero** further reparses, **including across a reparse for a different tracker** (proving the cache survives a `$rule_list` rebuild — the key correctness property). The fix is split into two commits: a behaviour-preserving extraction (RED test) + the fix (GREEN).

Full PHP suite green (889), `php -l` / PHPCS (incl. PFBL-01) / PHPStan clean.

Fixes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEtct4G4nCXfjLYq51AJ5k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter log daemon reliability and responsiveness when resolving Tracker IDs by resolving mappings in a single step and continuing parsing once resolution succeeds.
  * Added negative-result caching so unknown or unresolvable Tracker IDs don’t repeatedly trigger expensive resolution attempts.
* **Tests**
  * Added PHPUnit coverage for Tracker ID resolution, including fast-path cache hits, negative cache behavior, type-mismatch handling, one-time reparse/regeneration behavior, and callback invocation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->