### PR TITLE
pfblockerng: mark the Alienvault feed discontinued (#319)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -143,6 +143,7 @@
 			"cron":		"01hour",
 			"feeds": [
 				{
+					"status":	"discontinued",
 					"feed":		"Alienvault",
 					"website":	"https://www.alienvault.com/",
 					"contact":	"https://www.alienvault.com/support",

--- a/tests/php/FeedsDiscontinuedTest.php
+++ b/tests/php/FeedsDiscontinuedTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the shipped feeds catalogue (www/pfblockerng/pfblockerng_feeds.json):
+ *   - the file is valid JSON (a syntax slip would break the feeds UI page), and
+ *   - the Alienvault feed carries status 'discontinued' (#319) so the
+ *     discontinued-feed filter in pfblockerng.inc drops it from the picker.
+ *
+ * The source has been dead/stale since 2021; per the maintainer the feed is
+ * flagged rather than deleted (same treatment as the other discontinued feeds).
+ */
+final class FeedsDiscontinuedTest extends TestCase
+{
+	/** @return array<string, mixed> */
+	private function loadFeeds(): array
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_feeds.json';
+		$this->assertFileExists($path, 'feeds catalogue must exist');
+
+		$decoded = json_decode((string) file_get_contents($path), TRUE);
+		$this->assertIsArray($decoded, 'feeds catalogue must be valid JSON: ' . json_last_error_msg());
+
+		return $decoded;
+	}
+
+	// The catalogue parses as JSON — a syntax error would blank the feeds page.
+	public function testFeedsCatalogueIsValidJson(): void
+	{
+		$this->assertNotEmpty($this->loadFeeds());
+	}
+
+	// The Alienvault feed is flagged discontinued so the pfblockerng.inc filter drops it.
+	public function testAlienvaultFeedIsDiscontinued(): void
+	{
+		$feeds = $this->loadFeeds();
+
+		$alienvault = NULL;
+		foreach ($feeds['ipv4']['PRI2']['feeds'] as $feed) {
+			if (($feed['feed'] ?? '') === 'Alienvault') {
+				$alienvault = $feed;
+				break;
+			}
+		}
+
+		$this->assertNotNull($alienvault, 'Alienvault feed must still be present in ipv4/PRI2 (flagged, not deleted)');
+		$this->assertSame('discontinued', $alienvault['status'] ?? NULL, 'Alienvault feed must be marked discontinued (#319)');
+	}
+}


### PR DESCRIPTION
## Problem

The `Alienvault` reputation feed (`ipv4/PRI2` in `pfblockerng_feeds.json`) has been dead/stale since 2021 — the download is zero-length/2021-dated and the project homepage now redirects to AT&T (#319, confirmed by two reporters).

## Change

Per the maintainer's call on the issue (flag, don't delete), mark the feed `"status": "discontinued"` — the same treatment as the other discontinued feeds. The existing filter in `pfblockerng.inc` (`$feed['status'] == 'discontinued'`) then drops it from the feeds picker, while the entry is preserved in case the source is ever revived.

This is distinct from the unrelated "OTX Alienvault" reputation-lookup link on the Alerts/Reports page, which is untouched.

## Tests

`tests/php/FeedsDiscontinuedTest.php` — guards that the catalogue is valid JSON (a syntax slip would blank the feeds page) and that the Alienvault feed is present and flagged `discontinued`.

Full PHP suite green (1016); `php -l` clean; JSON validated.

Fixes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEtct4G4nCXfjLYq51AJ5k)_