### PR TITLE
tests: drive the scheduled log-reset smoke via the cron verb (#414)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1883,7 +1883,11 @@ def reload(vm: SmokeVM, scope: str = "update", *, data_path: bool = False, timeo
     """Run a pfBlockerNG reload via the PHP CLI cron verb.
 
     ``scope`` is the verb: ``updatednsbl`` / ``updateip`` (targeted, faster per
-    case) or ``update`` (full force, IP+DNSBL).
+    case), ``update`` (full force, IP+DNSBL), or ``cron`` (the scheduled cron
+    tick, ``pfblockerng_sync_cron()``). NOTE: ``cron`` is the ONLY verb that runs
+    the ADR-30 per-log scheduled reset (``pfb_log_reset()``); ``update`` calls
+    ``sync_package_pfblockerng('cron')`` directly and bypasses it, so a test that
+    needs a scheduled log reset to fire MUST use ``cron``, not ``update``.
 
     READINESS depends on whether a restart is expected (ADR-10):
 
@@ -1902,8 +1906,8 @@ def reload(vm: SmokeVM, scope: str = "update", *, data_path: bool = False, timeo
       the no-restart invariant (pid unchanged), so use this only when a config-clean
       python-mode DNSBL data update is expected; it RAISES if the swap line never appears.
     """
-    if scope not in ("update", "updateip", "updatednsbl"):
-        raise ValueError(f"reload scope must be update/updateip/updatednsbl, got {scope!r}")
+    if scope not in ("update", "updateip", "updatednsbl", "cron"):
+        raise ValueError(f"reload scope must be update/updateip/updatednsbl/cron, got {scope!r}")
     swap_before = count_log_marker(vm, PFB_LOG, SWAP_LOG_MARKER) if data_path else 0
     deadline = time.monotonic() + timeout
     result = vm.ssh(PHP_BIN, PFB_CLI, scope, timeout=timeout)

--- a/tests/smoke/test_log_rotate.py
+++ b/tests/smoke/test_log_rotate.py
@@ -258,7 +258,7 @@ def test_boundary_reset_inode_preserved_and_per_log_independence(
       - Both logs seeded with inert content.
       - Inode of ``ip_blocklog`` captured before the cron runs.
 
-    When: the cron entry runs (``pfblockerng.php update``).
+    When: the cron entry runs (``pfblockerng.php cron`` -> ``pfblockerng_sync_cron()``).
 
     Then:
       - ``ip_blocklog`` is EMPTY (reset occurred).
@@ -292,7 +292,7 @@ def test_boundary_reset_inode_preserved_and_per_log_independence(
     assert "ip_permitlog" not in marker_before, "BEFORE: marker should have no ip_permitlog entry (schedule is off)"
 
     # --- When ---
-    # Trigger the cron entry point; pfb_log_reset() runs inside pfblockerng.php update.
+    # Trigger the cron entry point; pfb_log_reset() runs inside pfblockerng_sync_cron().
     h.reload(vm, "cron")
 
     # --- Then ---

--- a/tests/smoke/test_log_rotate.py
+++ b/tests/smoke/test_log_rotate.py
@@ -66,9 +66,12 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     """Deploy the branch .pkg once for this module and set up the base state.
 
     Log rotation does not require DNSBL to be active — it runs purely from the
-    cron tick (``pfblockerng.php update``), which is reached via
-    ``helpers.reload(vm, 'update')``.  We still need pfBlockerNG installed and
-    ``enable_cb=on`` so the cron function body executes (inc:793 gates on it).
+    cron tick (``pfblockerng.php cron`` → ``pfblockerng_sync_cron()``), driven
+    via ``helpers.reload(vm, 'cron')``.  The scheduled reset (``pfb_log_reset()``)
+    lives in ``pfblockerng_sync_cron()`` and runs ONLY on the ``cron`` verb; the
+    ``update`` (Force-Update) verb calls ``sync_package_pfblockerng('cron')``
+    directly and bypasses it, so these cases must drive ``cron``.  We still need
+    pfBlockerNG installed and ``enable_cb=on`` so the cron function body executes.
     The DNSBL VIP and feed infrastructure are NOT needed for these cases.
     """
     if not os.environ.get("SMOKE_PKG"):
@@ -290,7 +293,7 @@ def test_boundary_reset_inode_preserved_and_per_log_independence(
 
     # --- When ---
     # Trigger the cron entry point; pfb_log_reset() runs inside pfblockerng.php update.
-    h.reload(vm, "update")
+    h.reload(vm, "cron")
 
     # --- Then ---
     content_after_block = _read_file(vm, LOG_IP_BLOCKLOG)
@@ -359,7 +362,7 @@ def test_same_period_is_idempotent(deployed_vm: SmokeVM) -> None:
     )
 
     # --- When ---
-    h.reload(vm, "update")
+    h.reload(vm, "cron")
 
     # --- Then ---
     content_after = _read_file(vm, LOG_IP_BLOCKLOG)
@@ -456,7 +459,7 @@ def test_chrooted_python_log_reset_preserves_inode_and_ownership(
     )
 
     # --- When ---
-    h.reload(vm, "update")
+    h.reload(vm, "cron")
 
     # --- Then ---
     content_after = _read_file(vm, dnslog_path)
@@ -538,7 +541,7 @@ def test_all_off_no_log_emptied(deployed_vm: SmokeVM) -> None:
     assert marker_before.get("ip_permitlog") == stale_key, f"BEFORE: marker ip_permitlog should be {stale_key!r}"
 
     # --- When ---
-    h.reload(vm, "update")
+    h.reload(vm, "cron")
 
     # --- Then ---
     content_after_block = _read_file(vm, LOG_IP_BLOCKLOG)


### PR DESCRIPTION
## Summary

Fixes the two ADR-30 scheduled-log-reset live-VM smoke failures (issue #414).

## Root cause

`pfb_log_reset()` (the ADR-30 per-log scheduled reset) lives in `pfblockerng_sync_cron()`, which is reached only by the **`cron`** verb. The log-rotate smoke triggered it via `helpers.reload(vm, "update")`, but the `update` (Force-Update) verb calls `sync_package_pfblockerng('cron')` directly and **bypasses** `pfblockerng_sync_cron()` — so the reset never ran. The two truncation cases failed, and the two no-op cases passed only **vacuously** (nothing executed).

## Fix (test-only)

- Add a `cron` scope to `helpers.reload()` (`php pfblockerng.php cron` → `pfblockerng_sync_cron()` → `pfb_log_reset()`), with a docstring note on why `update` can't be used here.
- Point all four `tests/smoke/test_log_rotate.py` cases at `reload(vm, "cron")`, so they genuinely exercise `pfb_log_reset()`: the truncation cases now reset, and the no-op cases now exercise the real no-op branches (current-period marker ⇒ idempotent; all-off ⇒ untouched) instead of passing vacuously.
- Correct the fixture docstring's premise (it claimed `update` reaches the cron tick).

## Design note

Scheduled reset stays **cron-only by design**: Force-Update fires at arbitrary times (config saves, manual reloads), so coupling a log truncation to it would make the reset moment unpredictable and could clear entries before their scheduled boundary. No production change.

## Validation

No production code changed; these tests run only on the live VM (skipped off-box), so verification is via a dispatched CE smoke run on this branch — expecting the four `test_log_rotate.py` cases to pass and the run to be green.

Fixes #414

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWUuidswrN5TNyfBHwHqgt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the smoke test suite to validate the pfBlockerNG log-reset behavior via the cron reload entrypoint, ensuring scheduled execution occurs only for the cron path and that scenarios still cover boundary handling, idempotency, chrooted dnslog reset, and no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->