### PR TITLE
tests/smoke: reboot regression for IP/GeoIP alias + rule survival (#334)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ markers = [
     "repo: live-VM release->repository install flow (ADR-17); distinct from -m smoke; deselected from the default run",
     "safesearch: live-VM SafeSearch CNAME redirect (issue #149); ALSO marked smoke (runs under -m smoke); focused dispatch via -m safesearch",
     "upstream: live-VM upstream/external-block detection (issue #267); ALSO marked smoke (runs under -m smoke); focused dispatch via -m upstream",
+    "reboot: live-VM guest-reboot regression (issue #334); REBOOTS the shared session VM, so distinct from -m smoke; deselected from the default run",
 ]
 
 # coverage.py (issue #38). BRANCH coverage is the point of the sweep -- line

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2016,6 +2016,43 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT, poll: float
     wait_unbound_ready(vm)
 
 
+# pfBlockerNG archives its IP aliastables + DNSBL DB here for RAMDISK installs; the
+# earlyshellcmd `pfblockerng.sh aliastables` restores it on boot (pfblockerng.inc:7791,
+# pfblockerng.sh:208). Present only after an `update` runs with use_mfs_tmpvar enabled.
+ALIASARCHIVE = "/usr/local/etc/aliastables.tar.bz2"
+
+
+def set_ramdisk(vm: SmokeVM, on: bool, *, var_size: int = 512, tmp_size: int = 128, timeout: float = 60.0) -> None:
+    """Enable/disable pfSense RAM disks for /tmp and /var (takes effect on next boot).
+
+    pfSense mounts /tmp and /var as memory filesystems when ``<system><use_mfs_tmpvar>``
+    is present (``system_advanced_misc.php``); sizes are MiB (GUI minimums: /tmp 40,
+    /var 60). The element's mere PRESENCE is "enabled" — both pfSense's
+    ``config_path_enabled('system', 'use_mfs_tmpvar')`` (pfblockerng.inc:7777) and the
+    shell's ``grep -c use_mfs_tmpvar`` (pfblockerng.sh:101) key on it.
+
+    On the conversion reboot pfSense WIPES /var, so pfBlockerNG's earlyshellcmd restores
+    its aliastables from :data:`ALIASARCHIVE` — the exact path issue #334 exercises on a
+    RAMDISK install. ``var_size`` is generous (the default 60 MiB is tight for the
+    unbound chroot + pfBlockerNG DB on a 4 GB box).
+    """
+    if on:
+        snippet = (
+            f"config_set_path('system/use_mfs_tmpvar', '');\n"
+            f"config_set_path('system/use_mfs_var_size', {_php_str(str(var_size))});\n"
+            f"config_set_path('system/use_mfs_tmp_size', {_php_str(str(tmp_size))});\n"
+            "write_config('pfBlockerNG smoke: enable RAM disks');\necho 'OK';"
+        )
+    else:
+        snippet = (
+            "config_del_path('system/use_mfs_tmpvar');\n"
+            "write_config('pfBlockerNG smoke: disable RAM disks');\necho 'OK';"
+        )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"set_ramdisk({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
 UNBOUND_CONF = "/var/unbound/unbound.conf"
 UNBOUND_BEFORE = "/tmp/pfb_unbound_before.conf"
 # Snapshot of the EFFECTIVE unbound config (unbound.conf + every file it pulls in

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -53,7 +53,15 @@ from enum import Enum
 from pathlib import Path
 from typing import NamedTuple
 
-from .conftest import GUEST_TO_HOST_ALIAS, SMOKE_DIR, STUB_DNS_A, SmokeVM, resolve_a
+from .conftest import (
+    DEFAULT_BOOT_TIMEOUT,
+    GUEST_TO_HOST_ALIAS,
+    SMOKE_DIR,
+    STUB_DNS_A,
+    WAIT_READY_SH,
+    SmokeVM,
+    resolve_a,
+)
 
 # --------------------------------------------------------------------------- #
 # Paths / constants
@@ -1933,6 +1941,79 @@ def reset(vm: SmokeVM, *, timeout: float = 600.0) -> None:
         if result.returncode != 0:
             raise RuntimeError(f"reset {verb} failed: rc={result.returncode} stderr={result.stderr!r}")
     reload(vm, "update", timeout=timeout)
+
+
+# --------------------------------------------------------------------------- #
+# Reboot — restart the guest OS, then wait until it is fully usable again
+# --------------------------------------------------------------------------- #
+# conftest.smoke_vm is ONE long-lived boot whose copy-on-write overlay IS the guest
+# disk, so a guest ``/sbin/reboot`` restarts the OS while QEMU, the overlay,
+# /conf/config.xml and /var/db all survive -- exactly the boot path issue #334 is
+# about (``is_platform_booting()`` true). A test that reboots carries the ``reboot``
+# marker (deselected from ``-m smoke``): the reboot mutates the SHARED session VM, so
+# it must run in its own dispatch, not interleaved with the per-case smoke matrix.
+
+
+def kern_boottime(vm: SmokeVM, *, timeout: float = 15.0) -> str:
+    """The guest's ``kern.boottime`` sysctl -- a token unique to each boot.
+
+    It changes on every real reboot, so comparing it before/after PROVES the box
+    actually went down and came back, rather than the harness reconnecting to a
+    still-alive pre-reboot sshd. Returns '' when unreadable (SSH down mid-reboot)."""
+    result = vm.ssh("/sbin/sysctl", "-n", "kern.boottime", timeout=timeout)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT, poll: float = 5.0) -> None:
+    """Reboot the guest OS and block until it is usable again (SSH + web + Unbound).
+
+    Each step guards against a FALSE "ready":
+
+      1. Capture ``kern.boottime`` BEFORE the reboot.
+      2. Issue ``/sbin/reboot`` -- best-effort: the command tears down our SSH
+         session, so a non-zero / dropped result is EXPECTED, not an error.
+      3. Poll ``kern.boottime`` until it is readable AND differs from the captured
+         value. This proves the OS rebooted and cleanly steps over the brief window
+         where the OLD sshd still answers (same boottime) before it dies.
+      4. Run ``wait_ready.sh`` (watching the QEMU pid + the web port) so the
+         webConfigurator (nginx + PHP) is up, then ``wait_unbound_ready`` -- the
+         same full-readiness gate the initial boot uses.
+    """
+    before = kern_boottime(vm)
+    # The reboot drops the SSH connection; ignore the result (best-effort).
+    vm.ssh("/sbin/reboot", timeout=30.0)
+
+    deadline = time.monotonic() + timeout
+    rebooted = False
+    while time.monotonic() < deadline:
+        now = kern_boottime(vm)
+        if now and now != before:
+            rebooted = True
+            break
+        time.sleep(poll)
+    if not rebooted:
+        raise RuntimeError(f"reboot_vm: guest did not reboot within {timeout}s (kern.boottime stayed {before!r})")
+
+    # Full readiness via the same shell gate the initial boot uses. wait_ready.sh's
+    # positional args are <ssh-key> [host] [port] [timeout] [vm-pid] [web-port]; pass
+    # the vm-pid + web-port pair only when the pid is known (so a dead boot fails fast
+    # AND web readiness requires nginx+PHP, not just sshd).
+    argv = [
+        "sh",
+        str(WAIT_READY_SH),
+        vm.ssh_key_path,
+        vm.host,
+        str(vm.ssh_port),
+        str(int(max(1.0, deadline - time.monotonic()))),
+    ]
+    if vm.vm_pid is not None:
+        argv += [str(vm.vm_pid), str(vm.web_port)]
+    result = subprocess.run(argv, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"reboot_vm: VM not ready after reboot (wait_ready exit {result.returncode}); stderr={result.stderr!r}"
+        )
+    wait_unbound_ready(vm)
 
 
 UNBOUND_CONF = "/var/unbound/unbound.conf"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1979,7 +1979,19 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT, poll: float
          webConfigurator (nginx + PHP) is up, then ``wait_unbound_ready`` -- the
          same full-readiness gate the initial boot uses.
     """
-    before = kern_boottime(vm)
+    # Capture a NON-EMPTY boottime baseline first: an empty '' baseline (SSH transiently
+    # unreadable) would let the first readable post-reboot boottime compare unequal and
+    # falsely report a reboot that never happened. The box is known-ready here, so a short
+    # retry is enough.
+    before = ""
+    baseline_deadline = time.monotonic() + 30.0
+    while time.monotonic() < baseline_deadline:
+        before = kern_boottime(vm)
+        if before:
+            break
+        time.sleep(poll)
+    if not before:
+        raise RuntimeError("reboot_vm: could not read a kern.boottime baseline before rebooting")
     # The reboot drops the SSH connection; ignore the result (best-effort).
     vm.ssh("/sbin/reboot", timeout=30.0)
 
@@ -1998,17 +2010,23 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT, poll: float
     # positional args are <ssh-key> [host] [port] [timeout] [vm-pid] [web-port]; pass
     # the vm-pid + web-port pair only when the pid is known (so a dead boot fails fast
     # AND web readiness requires nginx+PHP, not just sshd).
+    wait_budget = int(max(1.0, deadline - time.monotonic()))
     argv = [
         "sh",
         str(WAIT_READY_SH),
         vm.ssh_key_path,
         vm.host,
         str(vm.ssh_port),
-        str(int(max(1.0, deadline - time.monotonic()))),
+        str(wait_budget),
     ]
     if vm.vm_pid is not None:
         argv += [str(vm.vm_pid), str(vm.web_port)]
-    result = subprocess.run(argv, capture_output=True, text=True, check=False)
+    # Cap the subprocess itself a little past the script's own budget, so a stalled
+    # wait_ready.sh can never hang the (timeout-exempt) module fixture indefinitely.
+    try:
+        result = subprocess.run(argv, capture_output=True, text=True, check=False, timeout=wait_budget + 30)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"reboot_vm: wait_ready.sh did not return within {wait_budget + 30}s") from exc
     if result.returncode != 0:
         raise RuntimeError(
             f"reboot_vm: VM not ready after reboot (wait_ready exit {result.returncode}); stderr={result.stderr!r}"

--- a/tests/smoke/test_smoke_boot_reload.py
+++ b/tests/smoke/test_smoke_boot_reload.py
@@ -1,0 +1,118 @@
+"""Issue #334 — continent/IP ``pfB_*`` aliases lost across a reboot.
+
+REPRODUCE-FIRST regression guard. A pfBlockerNG IP/GeoIP feed builds a
+``pfB_<name>_v4`` urltable alias plus an auto firewall rule that references it.
+The Redmine report (#15567) is that after a reboot those aliases are gone and the
+firewall is not reloaded, so rules referencing ``pfB_<Continent>_v4`` stay
+unresolvable until a manual filter reload.
+
+Root cause (code, current ``devel``): ``sync_package_pfblockerng()`` short-circuits
+on the boot path (``is_platform_booting()``, ``pfblockerng.inc:9952``) — it recreates
+only the DNSBL VIP/NAT/webserver and returns, so it does NOT rebuild the IP/GeoIP
+alias tables and does NOT call ``filter_configure()``. The only boot-time alias
+handling is the ``earlyshellcmd`` running ``pfblockerng.sh aliastables``, which
+restores from the archive for RAMDISK/``md`` installs only (``pfblockerng.sh:202``).
+
+This test pins the END STATE the fix must guarantee: after a reboot, the IP alias
+table is still populated AND a pf rule still references it. It runs on the smoke
+VM's standard (non-ramdisk) install — the lowest-risk reboot scenario — and is the
+empirical probe for which half of the contract is actually lost there.
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke``) AND from
+``-m smoke`` (it carries its own ``reboot`` marker, because rebooting the shared
+session VM is destructive). Run only by an explicit dispatch::
+
+    python -m pytest tests/smoke -m reboot --override-ini="addopts="
+
+Needs the booted ``smoke_vm`` fixture, the branch ``.pkg`` (``SMOKE_PKG``), and the
+smoke deps; without them it skips cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM, _StubDnsServer
+
+pytestmark = pytest.mark.reboot
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+    """Deploy the branch .pkg once for the reboot module.
+
+    Egress stays OPEN across reloads: the ``update`` path also builds DNSBL
+    (``pfb_create_dnsbl``) and a dark egress deadlocks the guest. ``ensure_dnsbl_vip``
+    + ``use_system_dns_upstream`` give DNSBL a sinkhole VIP and a reachable upstream so
+    a full ``update`` completes cleanly. The session VM is torn down at end of run, so
+    a full guest snapshot is collected on teardown.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.snapshot_unbound_conf(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        # Rebuild the aliases the reboot may have dropped, so the box is left in a
+        # known-good state for any later dispatch on the same image. Best-effort —
+        # never mask the test result.
+        try:
+            h.reload(smoke_vm, "update")
+        except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the test result
+            print(f"[smoke] reboot teardown reload failed (non-fatal): {exc}")
+        h.unblock_egress()
+        h.collect_host_diagnostics(smoke_vm)
+
+
+def test_ip_alias_and_rule_survive_reboot(deployed_vm: SmokeVM) -> None:
+    """Scenario: a ``pfB_<name>_v4`` Deny alias + its auto rule survive a reboot.
+
+    Background:
+        A Deny IP feed builds the ``pfB_<name>_v4`` urltable alias and an auto
+        firewall rule that references it.
+
+    Given the feed is injected and reloaded
+        the alias table contains the fed IP AND a pf rule references the alias.
+    When the guest is rebooted (the boot-time sync path runs)
+        ``sync_package_pfblockerng()`` takes the ``is_platform_booting()`` branch.
+    Then the alias table is STILL populated AND a rule STILL references it.
+
+    The before-state is asserted first (proving the alias/rule WERE present), so a
+    post-reboot failure proves the reboot CAUSED the loss — the #334 reproduction.
+    On current ``devel`` this is expected to fail; the fix makes it pass.
+    """
+    vm = deployed_vm
+    fed_ip = "198.51.100.77"  # RFC 5737 TEST-NET-2 (inert documentation IP)
+    spec = h.IpCase(aliasname="Cont334", feed_url="", action="Deny_Both", family="v4")
+    spec.feed_url = h.write_local_feed(vm, "issue334_deny.txt", f"{fed_ip}\n")
+
+    # --- Given: inject + reload build the alias table and the referencing rule ---
+    h.inject(vm, spec)
+    h.reload(vm, "update")
+
+    before_members = h.wait_pfctl_table(vm, spec.alias)
+    assert h.member_present(before_members, fed_ip), (
+        f"precondition: {spec.alias} must contain {fed_ip} after reload, got {before_members!r}"
+    )
+    assert h.rule_references(vm, spec.alias), f"precondition: a pf rule must reference {spec.alias} after reload"
+
+    # --- When: reboot the guest, exercising the boot-time sync short-circuit ---
+    h.reboot_vm(vm)
+
+    # --- Then: the alias table + its rule reference must STILL be present ---
+    after_members = h.wait_pfctl_table(vm, spec.alias)
+    assert h.member_present(after_members, fed_ip), (
+        f"issue #334: {spec.alias} lost member {fed_ip} after reboot — the boot path "
+        f"did not rebuild the IP alias table; got {after_members!r}"
+    )
+    assert h.rule_references(vm, spec.alias), (
+        f"issue #334: no pf rule references {spec.alias} after reboot — the boot path "
+        "did not reload the firewall filter"
+    )

--- a/tests/smoke/test_smoke_boot_reload.py
+++ b/tests/smoke/test_smoke_boot_reload.py
@@ -53,6 +53,14 @@ from .conftest import SmokeVM, _StubDnsServer
 
 pytestmark = pytest.mark.reboot
 
+# A throwaway marker dropped in /var right before the ramdisk reboot. pfSense's MFS
+# wipes /var on every boot (it only restores a known set: RRD, DHCP leases, logs,
+# captive portal — NOT a top-level /var file), so the sentinel VANISHING after the
+# reboot is direct, implementation-agnostic proof that /var really came up as a memory
+# filesystem. If it SURVIVES, the config flag did not engage MFS and the ramdisk leg
+# would be a false negative — so the leg asserts on this.
+VAR_WIPE_SENTINEL = "/var/PFB_SMOKE_WIPE_SENTINEL"
+
 
 @dataclass
 class RebootObservation:
@@ -66,6 +74,9 @@ class RebootObservation:
     archive_present: bool
     after_members: list[str]
     after_rule: bool
+    # ramdisk leg only: did /var actually get wiped on the reboot (MFS engaged)?
+    var_wiped: bool | None = None
+    var_mount: str = ""
 
 
 @pytest.fixture(scope="module")
@@ -124,6 +135,11 @@ def reboot_observation(request: pytest.FixtureRequest, deployed_vm: SmokeVM) -> 
     before_rule = h.rule_references(vm, spec.alias)
     archive_present = ramdisk and vm.ssh("test", "-f", h.ALIASARCHIVE).returncode == 0
 
+    # ramdisk leg: drop a /var sentinel so the post-reboot check can PROVE /var came up
+    # as a memory filesystem (the sentinel is wiped) rather than persisting on disk.
+    if ramdisk:
+        vm.ssh("/usr/bin/touch", VAR_WIPE_SENTINEL)
+
     # When: reboot the guest, exercising the boot-time sync short-circuit (and, on the
     # ramdisk leg, the /var wipe + earlyshellcmd archive restore).
     h.reboot_vm(vm)
@@ -131,6 +147,13 @@ def reboot_observation(request: pytest.FixtureRequest, deployed_vm: SmokeVM) -> 
     # Then (captured): the alias table + its rule reference, post-reboot.
     after_members = h.wait_pfctl_table(vm, spec.alias)
     after_rule = h.rule_references(vm, spec.alias)
+
+    var_wiped: bool | None = None
+    var_mount = ""
+    if ramdisk:
+        var_wiped = vm.ssh("test", "-e", VAR_WIPE_SENTINEL).returncode != 0
+        mounts = vm.ssh("/sbin/mount")
+        var_mount = next((ln for ln in mounts.stdout.splitlines() if " on /var " in ln), "")
 
     return RebootObservation(
         ramdisk=ramdisk,
@@ -141,6 +164,8 @@ def reboot_observation(request: pytest.FixtureRequest, deployed_vm: SmokeVM) -> 
         archive_present=archive_present,
         after_members=after_members,
         after_rule=after_rule,
+        var_wiped=var_wiped,
+        var_mount=var_mount,
     )
 
 
@@ -169,6 +194,13 @@ def test_ip_alias_and_rule_survive_reboot(reboot_observation: RebootObservation)
         assert obs.archive_present, (
             f"precondition [ramdisk]: {h.ALIASARCHIVE} must exist pre-reboot (the earlyshellcmd "
             "restore source) — else the ramdisk path is not actually exercised"
+        )
+        # Prove MFS actually engaged: the /var sentinel must be GONE after the reboot,
+        # which means /var came up fresh (memory FS) and the alias survived via the
+        # archive restore — not because /var merely persisted on disk.
+        assert obs.var_wiped, (
+            "precondition [ramdisk]: /var was NOT wiped on reboot — use_mfs_tmpvar did not "
+            f"engage a memory filesystem, so this leg is a false negative (mount: {obs.var_mount!r})"
         )
 
     # --- Then (after reboot): the alias table + its rule must STILL be present ---

--- a/tests/smoke/test_smoke_boot_reload.py
+++ b/tests/smoke/test_smoke_boot_reload.py
@@ -74,7 +74,9 @@ class RebootObservation:
     archive_present: bool
     after_members: list[str]
     after_rule: bool
-    # ramdisk leg only: did /var actually get wiped on the reboot (MFS engaged)?
+    # ramdisk leg only: was the /var sentinel created pre-reboot, and did /var actually
+    # get wiped on the reboot (MFS engaged)?
+    sentinel_created: bool | None = None
     var_wiped: bool | None = None
     var_mount: str = ""
 
@@ -137,8 +139,12 @@ def reboot_observation(request: pytest.FixtureRequest, deployed_vm: SmokeVM) -> 
 
     # ramdisk leg: drop a /var sentinel so the post-reboot check can PROVE /var came up
     # as a memory filesystem (the sentinel is wiped) rather than persisting on disk.
+    # Confirm it actually landed — a sentinel that was never created would read as
+    # "wiped" after the reboot and make the MFS proof a false green.
+    sentinel_created: bool | None = None
     if ramdisk:
         vm.ssh("/usr/bin/touch", VAR_WIPE_SENTINEL)
+        sentinel_created = vm.ssh("test", "-e", VAR_WIPE_SENTINEL).returncode == 0
 
     # When: reboot the guest, exercising the boot-time sync short-circuit (and, on the
     # ramdisk leg, the /var wipe + earlyshellcmd archive restore).
@@ -164,6 +170,7 @@ def reboot_observation(request: pytest.FixtureRequest, deployed_vm: SmokeVM) -> 
         archive_present=archive_present,
         after_members=after_members,
         after_rule=after_rule,
+        sentinel_created=sentinel_created,
         var_wiped=var_wiped,
         var_mount=var_mount,
     )
@@ -194,6 +201,12 @@ def test_ip_alias_and_rule_survive_reboot(reboot_observation: RebootObservation)
         assert obs.archive_present, (
             f"precondition [ramdisk]: {h.ALIASARCHIVE} must exist pre-reboot (the earlyshellcmd "
             "restore source) — else the ramdisk path is not actually exercised"
+        )
+        # The sentinel must have been created pre-reboot, else the wipe check below is a
+        # false green (a sentinel that never existed also reads as "gone" after reboot).
+        assert obs.sentinel_created, (
+            f"precondition [ramdisk]: {VAR_WIPE_SENTINEL} must exist pre-reboot — could not "
+            "create it, so the post-reboot wipe assertion cannot be trusted"
         )
         # Prove MFS actually engaged: the /var sentinel must be GONE after the reboot,
         # which means /var came up fresh (memory FS) and the alias survived via the

--- a/tests/smoke/test_smoke_boot_reload.py
+++ b/tests/smoke/test_smoke_boot_reload.py
@@ -13,10 +13,22 @@ alias tables and does NOT call ``filter_configure()``. The only boot-time alias
 handling is the ``earlyshellcmd`` running ``pfblockerng.sh aliastables``, which
 restores from the archive for RAMDISK/``md`` installs only (``pfblockerng.sh:202``).
 
-This test pins the END STATE the fix must guarantee: after a reboot, the IP alias
-table is still populated AND a pf rule still references it. It runs on the smoke
-VM's standard (non-ramdisk) install — the lowest-risk reboot scenario — and is the
-empirical probe for which half of the contract is actually lost there.
+Two legs, because the install kind changes what survives a reboot:
+
+* **standard** — a normal disk install. The ``pfB_*`` alias DEFINITION lives in
+  ``config.xml`` and the urltable backing file persists on disk, so pfSense core's
+  boot ``filter_configure`` may repopulate the table independently of pfBlockerNG.
+* **ramdisk** — ``<system><use_mfs_tmpvar>`` enabled, so /var is wiped on boot. This
+  is the reporter's scenario: the earlyshellcmd restores the aliastables archive,
+  then the pfBlockerNG boot short-circuit neither rebuilds nor reloads the filter.
+
+Both legs pin the SAME end state the fix must guarantee: after a reboot, the IP
+alias table is still populated AND a pf rule still references it.
+
+The slow work (inject → reload → reboot) runs in the module fixture, NOT the test
+body: the smoke workflow caps the test BODY at 30s (``--timeout=30``,
+``timeout_func_only=true``), but fixtures are exempt — same reason the ~2 min
+``deploy`` fixture is. The test body is pure assertions on the captured observation.
 
 DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke``) AND from
 ``-m smoke`` (it carries its own ``reboot`` marker, because rebooting the shared
@@ -32,6 +44,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterator
+from dataclasses import dataclass
 
 import pytest
 
@@ -39,6 +52,20 @@ from . import helpers as h
 from .conftest import SmokeVM, _StubDnsServer
 
 pytestmark = pytest.mark.reboot
+
+
+@dataclass
+class RebootObservation:
+    """The alias/rule state captured before and after one reboot, for one leg."""
+
+    ramdisk: bool
+    fed_ip: str
+    alias: str
+    before_members: list[str]
+    before_rule: bool
+    archive_present: bool
+    after_members: list[str]
+    after_rule: bool
 
 
 @pytest.fixture(scope="module")
@@ -60,10 +87,10 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     try:
         yield smoke_vm
     finally:
-        # Rebuild the aliases the reboot may have dropped, so the box is left in a
-        # known-good state for any later dispatch on the same image. Best-effort —
-        # never mask the test result.
+        # Leave RAM disks OFF and rebuild the aliases the reboot may have dropped, so
+        # the box is left in a known-good state. Best-effort — never mask the result.
         try:
+            h.set_ramdisk(smoke_vm, False)
             h.reload(smoke_vm, "update")
         except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the test result
             print(f"[smoke] reboot teardown reload failed (non-fatal): {exc}")
@@ -71,48 +98,85 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
         h.collect_host_diagnostics(smoke_vm)
 
 
-def test_ip_alias_and_rule_survive_reboot(deployed_vm: SmokeVM) -> None:
-    """Scenario: a ``pfB_<name>_v4`` Deny alias + its auto rule survive a reboot.
+@pytest.fixture(scope="module", params=[False, True], ids=["standard", "ramdisk"])
+def reboot_observation(request: pytest.FixtureRequest, deployed_vm: SmokeVM) -> RebootObservation:
+    """Build a Deny IP alias, capture its state, reboot, recapture — once per leg.
 
-    Background:
-        A Deny IP feed builds the ``pfB_<name>_v4`` urltable alias and an auto
-        firewall rule that references it.
-
-    Given the feed is injected and reloaded
-        the alias table contains the fed IP AND a pf rule references the alias.
-    When the guest is rebooted (the boot-time sync path runs)
-        ``sync_package_pfblockerng()`` takes the ``is_platform_booting()`` branch.
-    Then the alias table is STILL populated AND a rule STILL references it.
-
-    The before-state is asserted first (proving the alias/rule WERE present), so a
-    post-reboot failure proves the reboot CAUSED the loss — the #334 reproduction.
-    On current ``devel`` this is expected to fail; the fix makes it pass.
+    All VM I/O (inject → reload → reboot → recapture) lives HERE so the 30s test-body
+    timeout never covers the ~1 min reboot. ``params`` runs ``standard`` first (pristine
+    install) then ``ramdisk`` (enables ``use_mfs_tmpvar``, which the next reboot honours).
     """
     vm = deployed_vm
+    ramdisk: bool = request.param
     fed_ip = "198.51.100.77"  # RFC 5737 TEST-NET-2 (inert documentation IP)
-    spec = h.IpCase(aliasname="Cont334", feed_url="", action="Deny_Both", family="v4")
-    spec.feed_url = h.write_local_feed(vm, "issue334_deny.txt", f"{fed_ip}\n")
+    spec = h.IpCase(aliasname=f"Cont334{'ram' if ramdisk else 'std'}", feed_url="", action="Deny_Both", family="v4")
 
-    # --- Given: inject + reload build the alias table and the referencing rule ---
+    # Given: (ramdisk leg) enable RAM disks BEFORE the reload so the reload registers
+    # the earlyshellcmd and archives the aliastables under use_mfs_tmpvar.
+    if ramdisk:
+        h.set_ramdisk(vm, True)
+
+    spec.feed_url = h.write_local_feed(vm, f"issue334_{'ram' if ramdisk else 'std'}.txt", f"{fed_ip}\n")
     h.inject(vm, spec)
     h.reload(vm, "update")
 
     before_members = h.wait_pfctl_table(vm, spec.alias)
-    assert h.member_present(before_members, fed_ip), (
-        f"precondition: {spec.alias} must contain {fed_ip} after reload, got {before_members!r}"
-    )
-    assert h.rule_references(vm, spec.alias), f"precondition: a pf rule must reference {spec.alias} after reload"
+    before_rule = h.rule_references(vm, spec.alias)
+    archive_present = ramdisk and vm.ssh("test", "-f", h.ALIASARCHIVE).returncode == 0
 
-    # --- When: reboot the guest, exercising the boot-time sync short-circuit ---
+    # When: reboot the guest, exercising the boot-time sync short-circuit (and, on the
+    # ramdisk leg, the /var wipe + earlyshellcmd archive restore).
     h.reboot_vm(vm)
 
-    # --- Then: the alias table + its rule reference must STILL be present ---
+    # Then (captured): the alias table + its rule reference, post-reboot.
     after_members = h.wait_pfctl_table(vm, spec.alias)
-    assert h.member_present(after_members, fed_ip), (
-        f"issue #334: {spec.alias} lost member {fed_ip} after reboot — the boot path "
-        f"did not rebuild the IP alias table; got {after_members!r}"
+    after_rule = h.rule_references(vm, spec.alias)
+
+    return RebootObservation(
+        ramdisk=ramdisk,
+        fed_ip=fed_ip,
+        alias=spec.alias,
+        before_members=before_members,
+        before_rule=before_rule,
+        archive_present=archive_present,
+        after_members=after_members,
+        after_rule=after_rule,
     )
-    assert h.rule_references(vm, spec.alias), (
-        f"issue #334: no pf rule references {spec.alias} after reboot — the boot path "
-        "did not reload the firewall filter"
+
+
+def test_ip_alias_and_rule_survive_reboot(reboot_observation: RebootObservation) -> None:
+    """Scenario: a ``pfB_<name>_v4`` Deny alias + its auto rule survive a reboot.
+
+    Given a Deny IP feed is injected and reloaded
+        the alias table contains the fed IP AND a pf rule references the alias.
+    When the guest is rebooted (the boot-time sync path runs)
+    Then the alias table is STILL populated AND a rule STILL references it.
+
+    The before-state is asserted first (proving the alias/rule WERE present), so a
+    post-reboot failure proves the reboot CAUSED the loss — the #334 reproduction.
+    On current ``devel`` at least the ramdisk leg is expected to fail; the fix makes
+    both legs pass.
+    """
+    obs = reboot_observation
+    leg = "ramdisk" if obs.ramdisk else "standard"
+
+    # --- Given (before reboot): the alias table + rule were built ---
+    assert h.member_present(obs.before_members, obs.fed_ip), (
+        f"precondition [{leg}]: {obs.alias} must contain {obs.fed_ip} after reload, got {obs.before_members!r}"
+    )
+    assert obs.before_rule, f"precondition [{leg}]: a pf rule must reference {obs.alias} after reload"
+    if obs.ramdisk:
+        assert obs.archive_present, (
+            f"precondition [ramdisk]: {h.ALIASARCHIVE} must exist pre-reboot (the earlyshellcmd "
+            "restore source) — else the ramdisk path is not actually exercised"
+        )
+
+    # --- Then (after reboot): the alias table + its rule must STILL be present ---
+    assert h.member_present(obs.after_members, obs.fed_ip), (
+        f"issue #334 [{leg}]: {obs.alias} lost member {obs.fed_ip} after reboot — "
+        f"the boot path did not rebuild the IP alias table; got {obs.after_members!r}"
+    )
+    assert obs.after_rule, (
+        f"issue #334 [{leg}]: no pf rule references {obs.alias} after reboot — "
+        "the boot path did not reload the firewall filter"
     )


### PR DESCRIPTION
## What

Adds a dispatch-only live-VM reboot regression test (`tests/smoke/test_smoke_boot_reload.py`, new `reboot` marker, deselected from `-m smoke`) that pins the issue #334 / Redmine #15567 end state: a `pfB_<name>_v4` Deny URL-Table alias **and** its auto firewall rule must still be present after a guest reboot.

## Why

Issue #334 reports continent aliases (`pfB_Europe_v4`, …) going missing after a reboot, leaving rules referencing them unresolvable until a manual filter reload. This test reproduces that scenario on a real pfSense VM to (a) check whether it reproduces on current `devel` and (b) guard against a future regression.

## Coverage

Two parametrized legs, because the install kind changes what survives a reboot:

- **standard** — normal disk install; the urltable backing file persists on disk, so pfSense core's boot `filter_configure` repopulates the table.
- **ramdisk** — `<system><use_mfs_tmpvar>` enabled, so `/var` is wiped on boot (the reporter's scenario). The `earlyshellcmd` restores the aliastables archive, then pfSense core repopulates from the restored backing file.

The ramdisk leg additionally **proves MFS actually engaged** — it drops a sentinel file in `/var` before the reboot and asserts it is gone afterward (MFS wipes `/var` on every boot), so the leg can't be a false negative where `/var` merely persisted on disk.

Each leg asserts the before-state (alias populated + rule present) first, so a post-reboot failure proves the reboot caused the loss.

## Result

Both legs **pass** on `devel` (pkg `3.2.16`, pfSense CE 2.8 / FreeBSD 15): the alias table and its rule survive a reboot on both a standard and a RAM-disk install. The full investigation and verdict are recorded on issue #334.

## Scope

Test-only — no production code changes. Runs only by explicit dispatch (`pytest_marker=reboot`), never in the PR `-m smoke` gate, because rebooting the shared session VM is destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new reboot-focused smoke test to verify pf IP/GeoIP alias table contents and pf firewall rule references persist across reboots.
  * Extended smoke test infrastructure with VM reboot helpers and pfSense RAM-disk toggle support for additional boot scenarios.

* **Chores**
  * Updated pytest configuration to add a dedicated `reboot` marker and exclude these scenarios from default test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->