### PR TITLE
ci: stop version-tracker opening duplicate version issues

### DIFF
--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -355,7 +355,12 @@ jobs:
             TITLE="[version-tracker] pfSense ${CHANNEL} ${VERSION} still-supported — evaluate for matrix"
 
             # Skip if an open issue with this exact title already exists.
-            EXISTING=$(gh issue list --repo "$REPO" --state open --json title 2>/dev/null \
+            # Scope to the version-tracker label and lift the default 30-item cap:
+            # without an explicit --limit, gh issue list returns only the 30 newest
+            # open issues, so an older tracker issue beyond that window is invisible
+            # to the dedup and a duplicate is opened every run.
+            EXISTING=$(gh issue list --repo "$REPO" --state open \
+              --label "version-tracker" --limit 500 --json title 2>/dev/null \
               | jq --arg t "$TITLE" '[.[] | select(.title == $t)] | length')
             if [ "${EXISTING:-0}" -gt 0 ]; then
               echo "  [skip] open issue already exists for ${CHANNEL} ${VERSION}"
@@ -363,8 +368,9 @@ jobs:
             fi
 
             # Skip if a closed issue with tracker-wontfix mentions this version.
+            # --limit 500 lifts the default 30-item cap (see the dedup note above).
             WONTFIX=$(gh issue list --repo "$REPO" --state closed --label "tracker-wontfix" \
-              --json title 2>/dev/null \
+              --limit 500 --json title 2>/dev/null \
               | jq --arg v "$VERSION" '[.[] | select(.title | contains($v))] | length')
             if [ "${WONTFIX:-0}" -gt 0 ]; then
               echo "  [wontfix] suppressed for ${CHANNEL} ${VERSION}"
@@ -439,10 +445,13 @@ jobs:
             } > "$BODY_FILE"
 
             # Update an existing open tracking issue; create one if none exists.
-            EXISTING_NUM=$(gh issue list --repo "$REPO" --state open --json number,title \
-              2>/dev/null \
+            # Scope to the version-tracker label and lift the default 30-item cap so
+            # an older tracking issue past the first page is still found and updated
+            # in place rather than re-created (the duplicate-issue bug).
+            EXISTING_NUM=$(gh issue list --repo "$REPO" --state open \
+              --label "version-tracker" --limit 500 --json number,title 2>/dev/null \
               | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
-              | head -1)
+              | sort -n | head -1)
 
             if [ -n "$EXISTING_NUM" ]; then
               echo "  [update] Updating tracking issue #${EXISTING_NUM} for ${CHANNEL} ${VERSION}"


### PR DESCRIPTION
## Problem

The version-tracker probe opens a fresh duplicate issue for the **same** version on every scheduled run once the repo has more than ~30 open issues. Live examples: CE 2.9 (#418 duplicates #190) and Plus 26.07 (#419 duplicates #174).

## Root cause

The probe deduplicates by listing open issues and matching titles, e.g.:

```sh
gh issue list --repo "$REPO" --state open --json title | jq 'select(.title == $t)'
```

`gh issue list` **defaults to a 30-item page**. With 66 open issues in the repo, the older version-tracker tracking issues (#190, #174) sit outside the 30 newest returned, so the dedup never sees them — and the "future" path that is supposed to *update an existing tracking issue in place* instead falls through to *create*, every single day.

## Fix

Bound all three dedup `gh issue list` queries (nudge / wontfix / future-tracking):

- Scope to the `version-tracker` label (every tracker issue carries it) and pass `--limit 500`, so the full set of tracker issues is always considered regardless of total open-issue count.
- The future-tracking lookup additionally `sort -n | head -1`s, so it deterministically targets the **lowest (original)** issue number and updates it in place rather than re-creating.

## Cleanup

The two existing duplicate pairs are consolidated separately: the newer duplicates (#418, #419) are closed, keeping the original tracking issues (#190, #174) that the fixed workflow now updates in place.

## Testing note

The dedup logic is embedded shell inside the workflow YAML (not an extractable script), so there is no unit-test seam for it without a larger refactor. The change is a bounded-query fix to the `gh issue list` calls; validated by YAML parse + manual trace against the live duplicate state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version tracking workflow to enhance deduplication of tracked issues and optimize issue lookup and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->