### PR TITLE
pfblockerng: add toggle to disable reverse DNS lookup for log entries

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1414,6 +1414,7 @@ function pfb_global() {
 	$pfb['maxmind_locale']	= $pfb['ipconfig']['maxmind_locale']	?: 'en';	// MaxMind Localized Language setting
 	$pfb['asn_reporting']	= $pfb['ipconfig']['asn_reporting']	?: 'disabled';	// ASN Reporting
 	$pfb['asn_token']	= $pfb['ipconfig']['asn_token']		?: '';		// ASN Token (IPinfo)
+	$pfb['resolve']		= pfb_resolve_enabled($pfb['ipconfig']);			// Reverse-DNS lookup for block-log entries (issue #336; default ON)
 
 	$pfb['maxmind_account']	= pfb_filter($pfb['ipconfig']['maxmind_account'], PFB_FILTER_WORD, 'pfb_global')	?: '';		// Maxmind Account ID
 	$pfb['maxmind_key']	= pfb_filter($pfb['ipconfig']['maxmind_key'], PFB_FILTER_WORD, 'pfb_global')		?: '';		// Maxmind License Key
@@ -8796,6 +8797,17 @@ function pfb_resolve_tracker(
 }
 
 
+// Reverse-DNS (PTR) lookup for block-log entries (issue #336). Default ON:
+// an absent key (fresh install / upgrade) keeps the legacy behaviour of
+// resolving; FALSE only when the user explicitly unchecks "Resolve IP Addresses".
+function pfb_resolve_enabled(array $ipconfig): bool {
+	if (!array_key_exists('enable_resolve', $ipconfig)) {
+		return TRUE;
+	}
+	return pfb_cfg_toggle_read($ipconfig['enable_resolve']) === PfbToggle::On;
+}
+
+
 // Firewall filter.log parser daemon
 function pfb_daemon_filterlog() {
 	global $pfb;
@@ -9086,8 +9098,12 @@ function pfb_daemon_filterlog() {
 							$geoip = 'Unk';
 						}
 
-						$resolved_host = gethostbyaddr($host) ?: 'Unknown';
-						if ($host == $resolved_host || $resolved_host == 'Unknown') {
+						if ($pfb['resolve']) {
+							$resolved_host = gethostbyaddr($host) ?: 'Unknown';
+							if ($host == $resolved_host || $resolved_host == 'Unknown') {
+								$resolved_host = 'Unknown';
+							}
+						} else {
 							$resolved_host = 'Unknown';
 						}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -37,6 +37,7 @@ $pconfig['enable_agg']		= $pfb['iconfig']['enable_agg']				?: '';
 $pconfig['suppression']		= isset($pfb['iconfig']['suppression'])			? $pfb['iconfig']['suppression'] : 'on';
 
 $pconfig['enable_log']		= $pfb['iconfig']['enable_log']				?: '';
+$pconfig['enable_resolve']	= isset($pfb['iconfig']['enable_resolve'])		? $pfb['iconfig']['enable_resolve'] : 'on';
 $pconfig['ip_placeholder']	= $pfb['iconfig']['ip_placeholder']			?: '127.1.7.7';
 $pconfig['maxmind_locale']	= $pfb['iconfig']['maxmind_locale']			?: 'en';
 $pconfig['asn_reporting']	= $pfb['iconfig']['asn_reporting']			?: 'disabled';
@@ -186,6 +187,7 @@ if ($_POST) {
 			$pfb['iconfig']['enable_agg']		= pfb_filter($_POST['enable_agg'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['suppression']		= pfb_filter($_POST['suppression'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['enable_log']		= pfb_filter($_POST['enable_log'], PFB_FILTER_ON_OFF, 'ip')	?: '';
+			$pfb['iconfig']['enable_resolve']	= pfb_filter($_POST['enable_resolve'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['ip_placeholder']	= $_POST['ip_placeholder']					?: '127.1.7.7';
 			$pfb['iconfig']['maxmind_locale']	= $_POST['maxmind_locale']					?: 'en';
 			$pfb['iconfig']['database_cc']		= pfb_filter($_POST['database_cc'], PFB_FILTER_ON_OFF, 'ip')	?: '';
@@ -304,6 +306,15 @@ $section->addInput(new Form_Checkbox(
 ))->setHelp('The global logging option is only used to force logging for all IP Aliases, and not to disable the logging of all IP Aliases.<br />'
 		. 'This overrides any logging settings in the GeoIP/IPv4/v6 tabs.'
 );
+
+$section->addInput(new Form_Checkbox(
+	'enable_resolve',
+	'Resolve IP Addresses',
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['enable_resolve']) === PfbToggle::On,
+	'on'
+))->setHelp('Perform a reverse DNS (PTR) lookup to resolve the hostname for each blocked IP address in the Alerts and logs.<br />'
+		. 'Disable to avoid the extra DNS traffic and load from these lookups.');
 
 $section->addInput(new Form_Input(
 	'ip_placeholder',

--- a/tests/php/ResolveEnabledTest.php
+++ b/tests/php/ResolveEnabledTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_resolve_enabled() — predicate for the reverse-DNS PTR lookup gate in the
+ * block-log daemon (issue #336).
+ *
+ * Default-ON contract: an absent 'enable_resolve' key (fresh install / upgrade
+ * from a version that did not have this option) returns TRUE, preserving the
+ * legacy behaviour of always resolving. The user must explicitly uncheck
+ * "Resolve IP Addresses" (stored as '') to disable lookups.
+ *
+ * Three branches:
+ *   - key absent     → TRUE  (default-on / legacy behaviour)
+ *   - key = 'on'     → TRUE  (user has the checkbox checked)
+ *   - key = ''       → FALSE (user unchecked the checkbox)
+ */
+#[CoversFunction('pfb_resolve_enabled')]
+final class ResolveEnabledTest extends TestCase
+{
+	public function testDefaultsOnWhenKeyAbsent(): void
+	{
+		// Fresh install or upgrade: the key does not exist in the config row yet.
+		// Must return TRUE so existing boxes keep resolving without any config change.
+		$this->assertTrue(pfb_resolve_enabled([]));
+	}
+
+	public function testExplicitOnReturnsTrue(): void
+	{
+		// Before: absent → TRUE.
+		$this->assertTrue(pfb_resolve_enabled([]));
+		// After: stored 'on' (checkbox checked) → TRUE.
+		$this->assertTrue(pfb_resolve_enabled(['enable_resolve' => 'on']));
+	}
+
+	public function testExplicitOffReturnsFalse(): void
+	{
+		// Before: stored 'on' (default) → TRUE; proves the flip is real.
+		$this->assertTrue(pfb_resolve_enabled(['enable_resolve' => 'on']));
+		// After: stored '' (unchecked save) → FALSE — reverse-DNS disabled.
+		$this->assertFalse(pfb_resolve_enabled(['enable_resolve' => '']));
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **Resolve IP Addresses** option (IP settings) that gates the reverse-DNS (PTR) lookup performed when writing block-log entries. Resolves the RFE in #336: the `gethostbyaddr()` call ran unconditionally for every blocked IP, generating extra DNS traffic/load that some deployments do not want.

## Behaviour

- New config key `enable_resolve` on the IP settings page (`pfblockerngipsettings`), **default ON** — existing installs and fresh installs keep resolving hostnames exactly as before; no config migration, zero behaviour change on upgrade.
- Unchecked → the block-log daemon skips `gethostbyaddr()` and records the hostname as `Unknown` (the same sentinel a failed lookup already produces). ASN and GeoIP lookups are unaffected.

## Implementation

- `pfb_resolve_enabled(array $ipconfig): bool` predicate encapsulates the default-ON semantics (absent key → resolve; explicit `''` → off). Wired into `pfb_global()` as `$pfb['resolve']`; the daemon gates the PTR lookup on it.
- UI follows the existing IP-settings toggle pattern (`suppression`/`enable_log`): section read/write + `pfb_cfg_toggle_read(...) === PfbToggle::On` render. `pfblockerngipsettings` is foreign to the ADR-29 config registry, so no registry/sniff changes.

## Tests

- `tests/php/ResolveEnabledTest.php` pins all three branches (absent → TRUE, `'on'` → TRUE, `''` → FALSE) with before/after assertions on the transition. Fails without the predicate, passes with it.
- Gates green locally: `php -l`, `phpcs` (0 errors), `phpstan`, full `phpunit`, `pytest`.

Fixes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWUuidswrN5TNyfBHwHqgt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an opt-in reverse DNS (PTR) resolution toggle for blocked IP addresses in logs and alerts. When enabled, hostnames are displayed; when disabled, addresses show as "Unknown" to reduce DNS overhead.

* **Tests**
  * Added test coverage for the new resolution feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->