### PR TITLE
pfblockerng: default reverse DNS lookup off for new installs

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1414,7 +1414,7 @@ function pfb_global() {
 	$pfb['maxmind_locale']	= $pfb['ipconfig']['maxmind_locale']	?: 'en';	// MaxMind Localized Language setting
 	$pfb['asn_reporting']	= $pfb['ipconfig']['asn_reporting']	?: 'disabled';	// ASN Reporting
 	$pfb['asn_token']	= $pfb['ipconfig']['asn_token']		?: '';		// ASN Token (IPinfo)
-	$pfb['resolve']		= pfb_resolve_enabled($pfb['ipconfig']);			// Reverse-DNS lookup for block-log entries (issue #336; default ON)
+	$pfb['rdns']		= pfb_resolve_enabled($pfb['ipconfig']);			// Reverse-DNS lookup for block-log entries (issue #336)
 
 	$pfb['maxmind_account']	= pfb_filter($pfb['ipconfig']['maxmind_account'], PFB_FILTER_WORD, 'pfb_global')	?: '';		// Maxmind Account ID
 	$pfb['maxmind_key']	= pfb_filter($pfb['ipconfig']['maxmind_key'], PFB_FILTER_WORD, 'pfb_global')		?: '';		// Maxmind License Key
@@ -8797,14 +8797,29 @@ function pfb_resolve_tracker(
 }
 
 
-// Reverse-DNS (PTR) lookup for block-log entries (issue #336). Default ON:
-// an absent key (fresh install / upgrade) keeps the legacy behaviour of
-// resolving; FALSE only when the user explicitly unchecks "Resolve IP Addresses".
+// Reverse-DNS (PTR) lookup for block-log entries (issue #336). Defaults OFF for
+// new installs; existing installs are seeded 'on' at upgrade (see
+// pfb_rdns_seed_value() + pfblockerng_install.inc) to preserve prior behaviour.
+// Returns FALSE when the key is absent (new install) or explicitly unchecked.
 function pfb_resolve_enabled(array $ipconfig): bool {
-	if (!array_key_exists('enable_resolve', $ipconfig)) {
-		return TRUE;
+	if (!array_key_exists('enable_rdns', $ipconfig)) {
+		return FALSE;
 	}
-	return pfb_cfg_toggle_read($ipconfig['enable_resolve']) === PfbToggle::On;
+	return pfb_cfg_toggle_read($ipconfig['enable_rdns']) === PfbToggle::On;
+}
+
+// Decide the one-time upgrade seed for enable_rdns (issue #336). An EXISTING
+// install (non-empty general config) that has no enable_rdns key yet predates
+// the option and historically always resolved, so seed 'on' to preserve that.
+// A fresh install (empty general config) is left unseeded -> defaults OFF.
+// A box that already has the key (incl. an explicit '' opt-out) is never reseeded.
+// $gconfig  = installedpackages/pfblockerng/config/0
+// $ipconfig = installedpackages/pfblockerngipsettings/config/0
+function pfb_rdns_seed_value(array $gconfig, array $ipconfig): ?string {
+	if (!empty($gconfig) && !array_key_exists('enable_rdns', $ipconfig)) {
+		return 'on';
+	}
+	return null;
 }
 
 
@@ -9098,7 +9113,7 @@ function pfb_daemon_filterlog() {
 							$geoip = 'Unk';
 						}
 
-						if ($pfb['resolve']) {
+						if ($pfb['rdns']) {
 							$resolved_host = gethostbyaddr($host) ?: 'Unknown';
 							if ($host == $resolved_host || $resolved_host == 'Unknown') {
 								$resolved_host = 'Unknown';

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -457,6 +457,20 @@ else {
 	update_status(" no changes required ... done.\n");
 }
 
+// Reverse DNS lookups (enable_rdns) default OFF for new installs; preserve the
+// historical always-on behaviour for existing installs with a one-time seed.
+update_status(" Reverse DNS lookup default...");
+$pfb_rdns_seed = pfb_rdns_seed_value(
+	config_get_path('installedpackages/pfblockerng/config/0', []),
+	config_get_path('installedpackages/pfblockerngipsettings/config/0', [])
+);
+if ($pfb_rdns_seed !== null) {
+	config_set_path('installedpackages/pfblockerngipsettings/config/0/enable_rdns', $pfb_rdns_seed);
+	update_status(" saving new changes ... done.\n");
+} else {
+	update_status(" no changes required ... done.\n");
+}
+
 // Upgrade pfBlockerNGSuppress alias to IPv4 Suppression custom list
 update_status(" pfBlockerNGSuppress Alias -> IPv4 Suppression Customlist...");
 $ufound = FALSE;

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -37,7 +37,7 @@ $pconfig['enable_agg']		= $pfb['iconfig']['enable_agg']				?: '';
 $pconfig['suppression']		= isset($pfb['iconfig']['suppression'])			? $pfb['iconfig']['suppression'] : 'on';
 
 $pconfig['enable_log']		= $pfb['iconfig']['enable_log']				?: '';
-$pconfig['enable_resolve']	= isset($pfb['iconfig']['enable_resolve'])		? $pfb['iconfig']['enable_resolve'] : 'on';
+$pconfig['enable_rdns']		= $pfb['iconfig']['enable_rdns']				?: '';
 $pconfig['ip_placeholder']	= $pfb['iconfig']['ip_placeholder']			?: '127.1.7.7';
 $pconfig['maxmind_locale']	= $pfb['iconfig']['maxmind_locale']			?: 'en';
 $pconfig['asn_reporting']	= $pfb['iconfig']['asn_reporting']			?: 'disabled';
@@ -187,7 +187,7 @@ if ($_POST) {
 			$pfb['iconfig']['enable_agg']		= pfb_filter($_POST['enable_agg'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['suppression']		= pfb_filter($_POST['suppression'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['enable_log']		= pfb_filter($_POST['enable_log'], PFB_FILTER_ON_OFF, 'ip')	?: '';
-			$pfb['iconfig']['enable_resolve']	= pfb_filter($_POST['enable_resolve'], PFB_FILTER_ON_OFF, 'ip')	?: '';
+			$pfb['iconfig']['enable_rdns']		= pfb_filter($_POST['enable_rdns'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['ip_placeholder']	= $_POST['ip_placeholder']					?: '127.1.7.7';
 			$pfb['iconfig']['maxmind_locale']	= $_POST['maxmind_locale']					?: 'en';
 			$pfb['iconfig']['database_cc']		= pfb_filter($_POST['database_cc'], PFB_FILTER_ON_OFF, 'ip')	?: '';
@@ -308,13 +308,13 @@ $section->addInput(new Form_Checkbox(
 );
 
 $section->addInput(new Form_Checkbox(
-	'enable_resolve',
-	'Resolve IP Addresses',
+	'enable_rdns',
+	'Reverse DNS Lookups',
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['enable_resolve']) === PfbToggle::On,
+	pfb_cfg_toggle_read($pconfig['enable_rdns']) === PfbToggle::On,
 	'on'
-))->setHelp('Perform a reverse DNS (PTR) lookup to resolve the hostname for each blocked IP address in the Alerts and logs.<br />'
-		. 'Disable to avoid the extra DNS traffic and load from these lookups.');
+))->setHelp('Perform a reverse DNS (PTR) lookup to resolve the hostname of each blocked IP address shown in the Alerts and logs.<br />'
+		. 'Enabling this increases the number of DNS queries performed, though the impact is usually negligible.');
 
 $section->addInput(new Form_Input(
 	'ip_placeholder',

--- a/tests/php/ResolveEnabledTest.php
+++ b/tests/php/ResolveEnabledTest.php
@@ -6,42 +6,109 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_resolve_enabled() — predicate for the reverse-DNS PTR lookup gate in the
- * block-log daemon (issue #336).
+ * pfb_resolve_enabled() and pfb_rdns_seed_value() — reverse-DNS toggle gate
+ * and upgrade-seed decision for the block-log daemon (issue #336).
  *
- * Default-ON contract: an absent 'enable_resolve' key (fresh install / upgrade
- * from a version that did not have this option) returns TRUE, preserving the
- * legacy behaviour of always resolving. The user must explicitly uncheck
- * "Resolve IP Addresses" (stored as '') to disable lookups.
+ * Default-OFF contract (pfb_resolve_enabled): an absent 'enable_rdns' key
+ * (new install) returns FALSE — reverse-DNS is off by default. Existing
+ * installs receive a one-time 'on' seed at upgrade via pfb_rdns_seed_value()
+ * (see pfblockerng_install.inc) to preserve the historical always-resolving
+ * behaviour.
  *
- * Three branches:
- *   - key absent     → TRUE  (default-on / legacy behaviour)
- *   - key = 'on'     → TRUE  (user has the checkbox checked)
- *   - key = ''       → FALSE (user unchecked the checkbox)
+ * pfb_resolve_enabled() branches:
+ *   - key absent     → FALSE  (new-install default OFF)
+ *   - key = 'on'     → TRUE   (user has the checkbox checked)
+ *   - key = ''       → FALSE  (user unchecked the checkbox)
+ *
+ * Scenario: pfb_rdns_seed_value() grandfather logic
+ *   Background: the key 'enable_rdns' did not exist before issue #336.
+ *               Existing installs historically always resolved (default ON).
+ *               New installs must default OFF.
+ *
+ *   Given an existing install (non-empty general config) with no enable_rdns key
+ *   When  pfb_rdns_seed_value() is called
+ *   Then  it returns 'on' — so the install hook seeds the key to ON (preserve behaviour)
+ *
+ *   Given a fresh install (empty general config)
+ *   When  pfb_rdns_seed_value() is called
+ *   Then  it returns null — key stays absent, pfb_resolve_enabled() defaults OFF
+ *
+ *   Given an existing install where enable_rdns is already 'on'
+ *   When  pfb_rdns_seed_value() is called
+ *   Then  it returns null — key already set, never reseed
+ *
+ *   Given an existing install where the user explicitly unchecked the box (key = '')
+ *   When  pfb_rdns_seed_value() is called
+ *   Then  it returns null — user's explicit OFF must never be overwritten
  */
 #[CoversFunction('pfb_resolve_enabled')]
+#[CoversFunction('pfb_rdns_seed_value')]
 final class ResolveEnabledTest extends TestCase
 {
-	public function testDefaultsOnWhenKeyAbsent(): void
+	// -------------------------------------------------------------------------
+	// pfb_resolve_enabled()
+	// -------------------------------------------------------------------------
+
+	public function testDefaultsOffWhenKeyAbsent(): void
 	{
-		// Fresh install or upgrade: the key does not exist in the config row yet.
-		// Must return TRUE so existing boxes keep resolving without any config change.
-		$this->assertTrue(pfb_resolve_enabled([]));
+		// New install: enable_rdns key does not exist yet.
+		// Must return FALSE — reverse-DNS is off by default for new installs.
+		$this->assertFalse(pfb_resolve_enabled([]));
 	}
 
 	public function testExplicitOnReturnsTrue(): void
 	{
-		// Before: absent → TRUE.
-		$this->assertTrue(pfb_resolve_enabled([]));
+		// Before: absent key → FALSE (new-install default).
+		$this->assertFalse(pfb_resolve_enabled([]));
 		// After: stored 'on' (checkbox checked) → TRUE.
-		$this->assertTrue(pfb_resolve_enabled(['enable_resolve' => 'on']));
+		$this->assertTrue(pfb_resolve_enabled(['enable_rdns' => 'on']));
 	}
 
 	public function testExplicitOffReturnsFalse(): void
 	{
-		// Before: stored 'on' (default) → TRUE; proves the flip is real.
-		$this->assertTrue(pfb_resolve_enabled(['enable_resolve' => 'on']));
+		// Before: stored 'on' (checkbox checked) → TRUE; proves the flip is real.
+		$this->assertTrue(pfb_resolve_enabled(['enable_rdns' => 'on']));
 		// After: stored '' (unchecked save) → FALSE — reverse-DNS disabled.
-		$this->assertFalse(pfb_resolve_enabled(['enable_resolve' => '']));
+		$this->assertFalse(pfb_resolve_enabled(['enable_rdns' => '']));
+	}
+
+	// -------------------------------------------------------------------------
+	// pfb_rdns_seed_value()
+	// -------------------------------------------------------------------------
+
+	public function testExistingInstallWithNoKeySeededOn(): void
+	{
+		// Given: existing install (non-empty general config), enable_rdns absent.
+		// When:  pfb_rdns_seed_value() called.
+		// Then:  returns 'on' — install hook seeds existing installs to preserve
+		//        historical always-resolving behaviour.
+		$this->assertSame('on', pfb_rdns_seed_value(['enable' => 'on'], []));
+	}
+
+	public function testFreshInstallNoKeyReturnsNull(): void
+	{
+		// Given: fresh install (empty general config), enable_rdns absent.
+		// When:  pfb_rdns_seed_value() called.
+		// Then:  returns null — key stays absent; pfb_resolve_enabled() defaults OFF.
+		$this->assertNull(pfb_rdns_seed_value([], []));
+	}
+
+	public function testExistingInstallKeyAlreadyOnReturnsNull(): void
+	{
+		// Given: existing install with enable_rdns already 'on' (already seeded).
+		// When:  pfb_rdns_seed_value() called.
+		// Then:  returns null — never reseed an already-set key.
+		$this->assertNull(pfb_rdns_seed_value(['enable' => 'on'], ['enable_rdns' => 'on']));
+	}
+
+	public function testUserOptedOutExplicitlyNeverReseeded(): void
+	{
+		// Given: existing install where the user EXPLICITLY unchecked the box
+		//        (stored as '' — the 'off' value for this toggle).
+		// When:  pfb_rdns_seed_value() called.
+		// Then:  returns null — the key IS present (value ''), so no reseed.
+		//        This is the critical safety branch: a user's deliberate opt-out
+		//        must NEVER be overwritten by the upgrade seed.
+		$this->assertNull(pfb_rdns_seed_value(['enable' => 'on'], ['enable_rdns' => '']));
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #336, refining the reverse-DNS toggle that #336 introduced (it is unreleased — devel only — so this is free to change with no migration):

1. **Renames** the config key `enable_resolve` → **`enable_rdns`** and the UI label "Resolve IP Addresses" → **"Reverse DNS Lookups"** (the old label was ambiguous; the new one names the mechanism).
2. **Defaults it OFF for new installs** — a fresh install no longer performs reverse-DNS (PTR) lookups for blocked IPs unless the user opts in.
3. **Grandfathers existing installs to ON** at upgrade, preserving the historical always-resolving behaviour so current users see no change.

## How the split default works

The runtime gate (`pfb_resolve_enabled`) now treats an **absent key as OFF**. To keep existing boxes resolving, `pfblockerng_install.inc` seeds `enable_rdns = 'on'` **once** at upgrade for any already-configured install. The decision is a pure, unit-tested predicate:

```php
pfb_rdns_seed_value($gconfig, $ipconfig)
  // existing install (non-empty general config) + key absent → 'on'  (grandfather)
  // fresh install (empty general config)                     → null  (stays OFF)
  // key already present (incl. explicit '' opt-out)          → null  (never reseed)
```

`installedpackages/pfblockerng/config/0` is a reliable "existing install" signal because the package sets `<donotsave>true</donotsave>` — pfSense does not auto-create that section on a fresh install (it's the same signal the existing maxmind seed relies on). A user's explicit opt-out (`''`) is never overwritten.

## Help text

> Perform a reverse DNS (PTR) lookup to resolve the hostname of each blocked IP address shown in the Alerts and logs.
> Enabling this increases the number of DNS queries performed, though the impact is usually negligible.

## Tests

`tests/php/ResolveEnabledTest.php` covers both predicates (7 cases): the gate's flipped default (absent → FALSE) with before/after transitions, and all four seed-decision branches including the "user opted out → never reseed" safety branch. Green: `php -l`, `phpcs` (0 errors), `phpstan`, full `phpunit`, `pytest`.

Follow-up to #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWUuidswrN5TNyfBHwHqgt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reverse DNS Lookups setting now defaults to OFF for new installations
  * Setting label updated from "Resolve IP Addresses" to "Reverse DNS Lookups"
  * Help text improved to clarify reverse DNS (PTR) lookup functionality
  * Existing configurations automatically preserved during upgrades

* **Tests**
  * Expanded test coverage for reverse DNS behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->