### PR TITLE
pfblockerng: store XMLRPC sync password verbatim, not HTML-escaped

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -391,6 +391,17 @@ function pfb_filter_whitelist_atype(string $raw): string {
 	return "Whitelist|{$ip}|{$descr}";
 }
 
+// Normalise an XMLRPC sync password for storage. The password is a secret
+// credential sent to the replication peer for authentication; it is never
+// rendered as raw HTML (the Sync form's Form_Input escapes the value attribute
+// for display via Form_Element). It is therefore stored VERBATIM — HTML-encoding
+// it on save corrupted any password containing & " ' < > (the escaped form was
+// sent to the peer, so authentication failed and repeated attempts tripped
+// sshguard). Storage is frozen as the literal secret; escaping is an output concern.
+function pfb_sync_filter_password(string $value): string {
+	return $value;
+}
+
 // Function to filter/sanitize user input
 function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE) {
 	global $pfb;

--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -89,7 +89,12 @@ if ($_POST) {
 						}
 						break;
 					case 'varsyncpassword':
-						$value = htmlspecialchars($value);
+						// Store verbatim: the password is a secret credential used for
+						// XMLRPC authentication, not rendered as raw HTML. HTML-escaping
+						// it here corrupted any password containing & " ' < > (the
+						// escaped form was sent to the peer, breaking auth). Form_Input
+						// escapes it for safe display on re-render.
+						$value = pfb_sync_filter_password($value);
 						break;
 					case 'varsyncipaddress':
 						// Validate IP Address/Hostname
@@ -300,7 +305,7 @@ foreach ($rowdata as $r_id => $row) {
 		'varsyncpassword-' . $r_id,
 		NULL,
 		'password',
-		htmlspecialchars($row['varsyncpassword']),
+		$row['varsyncpassword'],
 		[ 'placeholder' => 'Target password' ]
 	))->setHelp(($numrows == $rowcounter) ? 'Target Password' : NULL)
 	  ->setWidth(2);

--- a/tests/php/PfbSyncPasswordTest.php
+++ b/tests/php/PfbSyncPasswordTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_sync_filter_password() — stores an XMLRPC sync password verbatim.
+ *
+ * Bug pinned (issue #339): pfblockerng_sync.php ran varsyncpassword through
+ * htmlspecialchars() on save, so a password containing & " ' < > was stored
+ * HTML-escaped. pfblockerng.inc later read it back verbatim and handed the
+ * escaped form to the XMLRPC client, so authentication to the peer failed and
+ * repeated attempts tripped sshguard.
+ *
+ * Fix: the helper is the named, unit-tested storage contract — return the value
+ * unchanged. The Sync form's Form_Input escapes the value attribute for display
+ * via Form_Element::__toString(), so escaping at the storage boundary is wrong.
+ *
+ * Contracts pinned:
+ *   1. A password containing & is stored verbatim (no &amp; corruption).
+ *   2. A password containing " ' < > is stored verbatim.
+ *   3. A plain alphanumeric password round-trips unchanged.
+ *   4. An empty password returns empty.
+ *   5. Before/after contrast: htmlspecialchars() corrupts; the helper does not.
+ */
+#[CoversFunction('pfb_sync_filter_password')]
+final class PfbSyncPasswordTest extends TestCase
+{
+	/**
+	 * A password containing & is stored verbatim — no &amp; introduced.
+	 */
+	public function testPasswordWithAmpersandStoredVerbatim(): void
+	{
+		$result = pfb_sync_filter_password('p@ss&word');
+
+		$this->assertSame('p@ss&word', $result,
+			'ampersand must be stored verbatim, not HTML-encoded');
+		$this->assertStringNotContainsString('&amp;', $result,
+			'no &amp; entity may appear in the stored password');
+	}
+
+	/**
+	 * A password containing " ' < > is stored verbatim — no HTML entities introduced.
+	 */
+	public function testPasswordWithQuotesAndAnglesStoredVerbatim(): void
+	{
+		$result = pfb_sync_filter_password('a"b\'c<d>e');
+
+		$this->assertSame('a"b\'c<d>e', $result,
+			'quotes and angle brackets must be stored verbatim');
+		$this->assertStringContainsString('"', $result, 'raw double-quote must be present');
+		$this->assertStringContainsString('<', $result, 'raw less-than must be present');
+		$this->assertStringContainsString('>', $result, 'raw greater-than must be present');
+		$this->assertStringNotContainsString('&quot;', $result, 'no &quot; entity may appear');
+		$this->assertStringNotContainsString('&lt;', $result, 'no &lt; entity may appear');
+		$this->assertStringNotContainsString('&gt;', $result, 'no &gt; entity may appear');
+		$this->assertStringNotContainsString('&#039;', $result, 'no &#039; entity may appear');
+	}
+
+	/**
+	 * A plain alphanumeric password is stored unchanged.
+	 */
+	public function testPlainPasswordUnchanged(): void
+	{
+		$this->assertSame('S3cr3tPass', pfb_sync_filter_password('S3cr3tPass'));
+	}
+
+	/**
+	 * An empty password returns empty — no error, no substitution.
+	 */
+	public function testEmptyPasswordReturnsEmpty(): void
+	{
+		$this->assertSame('', pfb_sync_filter_password(''));
+	}
+
+	/**
+	 * Regression contrast: documents the corruption the fix removes.
+	 *
+	 * Before: htmlspecialchars() encodes & in the password, so 'p@ss&word' becomes
+	 * 'p@ss&amp;word' in config.xml and that escaped form is sent to the XMLRPC peer.
+	 *
+	 * After: pfb_sync_filter_password() stores the literal secret unchanged, so the
+	 * peer receives the real password and authentication succeeds.
+	 */
+	public function testRegressionContrastsOldHtmlspecialcharsCorruption(): void
+	{
+		$password = 'p@ss&word';
+
+		// Before state: the old htmlspecialchars() call corrupts the password.
+		$this->assertNotSame($password, htmlspecialchars($password),
+			'htmlspecialchars() must encode & — proving the old code corrupted the password');
+
+		// After state: the helper preserves the literal secret.
+		$this->assertSame($password, pfb_sync_filter_password($password),
+			'pfb_sync_filter_password() must return the password unchanged');
+	}
+}

--- a/tests/smoke/ui/test_sync.py
+++ b/tests/smoke/ui/test_sync.py
@@ -286,7 +286,10 @@ def test_sync_target_row_add_persists(webui: WebUI, smoke_vm: helpers.SmokeVM) -
         "varsyncipaddress-0": host,
         "varsyncport-0": "8443",
         "varsyncusername-0": "syncuser",
-        "varsyncpassword-0": "syncsecret",
+        # Special characters (& " ' < >) pin issue #339: the password must persist
+        # verbatim, NOT HTML-escaped. The pre-fix code stored htmlspecialchars() of
+        # this (P@ss&amp;w&quot;o&#039;rd&lt;x&gt;), which broke XMLRPC auth.
+        "varsyncpassword-0": "P@ss&w\"o'rd<x>",
         "varsyncdestinenable-0": "on",
     }
     try:
@@ -298,7 +301,9 @@ def test_sync_target_row_add_persists(webui: WebUI, smoke_vm: helpers.SmokeVM) -
         assert helpers.config_get(vm, _row_path(0, "varsyncipaddress")) == host, "row hostname not persisted"
         assert helpers.config_get(vm, _row_path(0, "varsyncport")) == "8443", "row port not persisted"
         assert helpers.config_get(vm, _row_path(0, "varsyncusername")) == "syncuser", "row username not persisted"
-        assert helpers.config_get(vm, _row_path(0, "varsyncpassword")) == "syncsecret", "row password not persisted"
+        assert helpers.config_get(vm, _row_path(0, "varsyncpassword")) == "P@ss&w\"o'rd<x>", (
+            "row password not persisted verbatim (issue #339: must not be HTML-escaped)"
+        )
         assert helpers.config_get(vm, _row_path(0, "varsyncdestinenable")) == "on", "row enable flag not persisted"
 
         # Reverse: omit the row keys -> the undefined-row prune deletes row/0.


### PR DESCRIPTION
Fixes #339.

## Problem

XMLRPC sync fails — and trips sshguard on the target — when the sync user's password contains an HTML-special character (`&`, `"`, `'`, `<`, `>`). Reproduced on the original report (23.05.1 / 3.2.0_6) and reconfirmed on 23.09-RC.

Root cause, verified against `devel`:

- **Save** (`pfblockerng_sync.php`): `varsyncpassword` was run through `htmlspecialchars()` before being written to config, so the stored value was the *escaped* string.
- **Use** (`pfblockerng.inc`): the stored value is read verbatim and handed to the XMLRPC client with no decode, so the peer receives `&amp;`/`&quot;`/… instead of the real password → auth fails → repeated retries trip sshguard.
- **Render** (`pfblockerng_sync.php`): the form wrapped `htmlspecialchars()` around the value passed to `Form_Input`, but pfSense's `Form_Element::__toString()` already `htmlspecialchars()`-escapes every attribute — so this was a redundant second escape that re-corrupted the stored value on every save-without-retype.

## Fix

- Store the password **verbatim** via a small named helper `pfb_sync_filter_password()` (the password is a secret credential for XMLRPC auth, never rendered as raw HTML).
- Drop the redundant `htmlspecialchars()` at the form-render site — `Form_Input` escapes the value attribute itself, so display stays safe and the round-trip is now lossless.

Escaping is purely an output concern; storage holds the literal secret. No migration of existing stored values is possible (a literal `&` can't be distinguished from an escaped one), so affected users re-enter the password once — their sync was already broken.

## Tests

- `tests/php/PfbSyncPasswordTest.php` — pins the verbatim-storage contract (special chars `& " ' < >` preserved, no entities introduced) and contrasts the old `htmlspecialchars()` corruption, so green proves the helper — not escaping — governs storage.
- The live form save/render round-trip and the actual XMLRPC auth are an ADR-04 §7 two-box limitation (no sync target in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GighgrxzgA8pzAPtS66iCK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed XMLRPC sync password handling to keep submitted credentials verbatim, including special characters, avoiding authentication issues caused by unintended escaping.
  * Updated the replication target password field to display/re-render the stored password without applying extra HTML escaping.

* **Tests**
  * Added unit tests for password preservation across special-character and edge-case inputs (ampersands, quotes, angle brackets, empty values) and included a regression check against the previous escaping behavior.
  * Updated the sync UI smoke test to use a special-character password and verify verbatim persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->