### PR TITLE
pfblockerng: clarify DNSBL IPs Alias action and add Alias Native option

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -324,7 +324,7 @@ $options_alexa_inclusion	= [	'ae' => 'AE',
 					'za' => 'ZA'
 				];
 
-$options_action			= [ 'Disabled' => 'Disabled', 'Deny_Inbound' => 'Deny Inbound', 'Deny_Outbound' => 'Deny Outbound', 'Deny_Both' => 'Deny Both', 'Alias_Deny' => 'Alias Deny' ];
+$options_action			= [ 'Disabled' => 'Disabled', 'Deny_Inbound' => 'Deny Inbound', 'Deny_Outbound' => 'Deny Outbound', 'Deny_Both' => 'Deny Both', 'Alias_Deny' => 'Alias Deny', 'Alias_Native' => 'Alias Native' ];
 
 $options_aliaslog		= [ 'enabled' => 'Enable', 'disabled' => 'Disable' ];
 
@@ -2959,9 +2959,16 @@ $list_action_text = 'Default: <strong>Disabled</strong>
 				still allowing <u>deliberate</u> outgoing sessions to be created in the other direction.</li>
 				</ul>
 
-				<strong><u>\'Alias Deny\' Rule:</u></strong><br />
-				<strong>\'Alias Deny\'</strong> rules create an <a href="/firewall_aliases.php">alias</a> for the list (and do nothing else).
-				This enables a pfBlockerNG list to be used by name, in any firewall rule or pfSense function, as desired.
+				<strong><u>\'Alias\' Rules:</u></strong><br />
+				\'Alias\' rules create an <a href="/firewall_aliases.php">alias</a> for the list without adding any firewall rules.
+				 This enables a pfBlockerNG list to be used by name, in any firewall rule or pfSense function, as desired.<br />
+
+				<ul>
+				<li><strong>Alias Deny</strong> - the IPs are added to the alias and can use the De-Duplication and Reputation
+				processes (if configured).</li>
+				<li><strong>Alias Native</strong> - the IPs are kept in their Native format without any modifications
+				(De-Duplication and Reputation are bypassed).</li>
+				</ul>
 			</div>';
 
 $section->addInput(new Form_Select(

--- a/tests/php/DnsblIpAliasActionTest.php
+++ b/tests/php/DnsblIpAliasActionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #340 — pin the action -> folder routing that distinguishes the DNSBL-IPs
+ * "Alias Deny" and "Alias Native" List Actions, the distinction the report conflated.
+ *
+ * pfb_determine_list_detail() is the single decision point that maps a list action to
+ * its working folder. The folder is what the downstream pass treats the list as:
+ *   * denydir  -> the DENY set, which the De-Duplication + Reputation passes process
+ *                 (pfblockerng.sh dedup/reputation operate over the deny folder);
+ *   * nativedir -> the NATIVE set, kept verbatim, De-Duplication + Reputation BYPASSED.
+ * The ' Auto ' vs '' descr is the second axis: a non-'Alias' action also gets auto
+ * firewall rules; every 'Alias' action is alias-only (no auto rules).
+ *
+ * This is exactly the contract the DNSBL-IPs help text now states and the issue
+ * questioned ("does Alias Deny dedup / add rules?"). The DNSBLIP synthetic list is
+ * processed through this same function with $list['action'] = $pfb['dnsbl_ip']
+ * (pfblockerng.inc, "Add DNSBLIP" block), so exposing 'Alias_Native' in the DNSBL
+ * dropdown routes DNSBLIP to nativedir with no further change.
+ *
+ * Feature: DNSBL-IPs List Action routing
+ *   Background:
+ *     Given the per-action-class working dirs (deny/native) and a settings section
+ *           with no Advanced Invert (so the force-Native override does not fire)
+ *   Branch coverage (each action class, both axes):
+ *     * Alias Native -> native folder, alias-only  (dedup/reputation bypassed)
+ *     * Alias Deny   -> deny  folder, alias-only   (dedup/reputation eligible)
+ *     * Deny Both    -> deny  folder, auto rules   (proves the descr axis is real)
+ */
+#[CoversFunction('pfb_determine_list_detail')]
+final class DnsblIpAliasActionTest extends TestCase
+{
+	/** @var array<string,array{bool,mixed}> Saved globals to restore (key => [existed, value]). */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		// Snapshot the shared globals this test mutates, so tearDown restores the
+		// bootstrap-seeded state other tests depend on (a wholesale unset would
+		// break later suites that read $pfb/$config seeded once at bootstrap).
+		foreach (['pfb', 'pfbarr', 'config'] as $g) {
+			$this->saved[$g] = [array_key_exists($g, $GLOBALS), $GLOBALS[$g] ?? null];
+		}
+
+		// The action -> folder targets the function routes to.
+		$GLOBALS['pfb']['denydir']   = '/tmp/pfb_deny';
+		$GLOBALS['pfb']['nativedir'] = '/tmp/pfb_native';
+		$GLOBALS['pfb']['origdir']   = '/tmp/pfb_orig';
+		$GLOBALS['pfb']['reuse']     = '';
+
+		// A settings section with every advanced key present but OFF, so the
+		// autoports/autoaddr block is a no-op AND the "Invert -> force Native"
+		// override (which would mask the routing under test) does not fire.
+		$off = [];
+		foreach (['autoproto', 'autonot', 'autoaddrnot', 'agateway', 'autoports', 'autoaddr'] as $k) {
+			$off["{$k}_in"]  = '';
+			$off["{$k}_out"] = '';
+		}
+		$GLOBALS['config'] = ['installedpackages' => ['pfblockerngdnsblsettings' => ['config' => [0 => $off]]]];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $g => [$existed, $value]) {
+			if ($existed) {
+				$GLOBALS[$g] = $value;
+			} else {
+				unset($GLOBALS[$g]);
+			}
+		}
+	}
+
+	/** @return array<string,mixed> */
+	private function routeFor(string $action): array
+	{
+		return pfb_determine_list_detail($action, 'DNSBLIP_v4', 'pfblockerngdnsblsettings', '0');
+	}
+
+	public function testAliasNativeRoutesToNativeFolderBypassingDedup(): void
+	{
+		// When: the DNSBL-IPs action is 'Alias Native'
+		$r = $this->routeFor('Alias_Native');
+
+		// Then: the list lands in the NATIVE folder (kept verbatim; dedup/reputation
+		// bypassed) and carries no auto firewall rules ('Alias' => '' descr).
+		$this->assertSame($GLOBALS['pfb']['nativedir'], $r['folder']);
+		$this->assertSame('', $r['descr']);
+	}
+
+	public function testAliasDenyRoutesToDenyFolderForDedup(): void
+	{
+		// When: the DNSBL-IPs action is 'Alias Deny'
+		$r = $this->routeFor('Alias_Deny');
+
+		// Then: the list lands in the DENY folder (the set De-Duplication + Reputation
+		// process) yet still carries no auto firewall rules ('Alias' => '' descr) --
+		// i.e. it DOES dedup, contrary to the issue's premise, and is NOT == Native.
+		$this->assertSame($GLOBALS['pfb']['denydir'], $r['folder']);
+		$this->assertSame('', $r['descr']);
+		$this->assertNotSame($GLOBALS['pfb']['nativedir'], $r['folder']);
+	}
+
+	public function testDenyBothRoutesToDenyFolderWithAutoRules(): void
+	{
+		// When: the action is a non-'Alias' Deny
+		$r = $this->routeFor('Deny_Both');
+
+		// Then: deny folder AND ' Auto ' descr -> auto firewall rules are created,
+		// proving the alias-only ('' descr) result above is a real branch, not constant.
+		$this->assertSame($GLOBALS['pfb']['denydir'], $r['folder']);
+		$this->assertSame(' Auto ', $r['descr']);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #340 (Redmine #14718).

The report flagged the DNSBL IPs **List Action** "Alias Deny" as misnamed, suggesting it be renamed "Alias Native" per the help text ("create an alias … and do nothing else"). Investigation shows the premise is inverted — the two actions are genuinely different, and the **help text is the inaccurate part**:

- **`Alias_Deny`** routes the list to the **deny set** (`denydir`), which the **De-Duplication and Reputation** passes process. It only skips the *auto firewall rules* (the `'Alias'` action class is alias-only). So it does **not** "do nothing else".
- **`Alias_Native`** routes to `nativedir` — kept verbatim, **dedup/reputation bypassed**.

(The DNSBLIP synthetic list is processed through the same `pfb_determine_list_detail()` path with `action = $pfb['dnsbl_ip']`, so the routing matches the IP tabs.)

Renaming "Alias Deny" → "Alias Native" would therefore be wrong (the option still deduplicates). Instead this PR:

1. **Corrects the DNSBL IPs help text** to match the IP-tab wording — `Alias` rules add no firewall rules; `Alias Deny` is eligible for De-Duplication/Reputation, `Alias Native` is kept in native format with those bypassed.
2. **Adds the genuinely native `Alias_Native` option** to the DNSBL IPs List Action dropdown, so both choices are available (matching the IP tabs). It flows through the existing generic action handling — no processing changes — and the stored config token is unchanged (backward compatible).

## Tests

- New `tests/php/DnsblIpAliasActionTest.php` pins the action→folder routing: `Alias Native`→`nativedir` (alias-only, dedup bypassed), `Alias Deny`→`denydir` (alias-only, dedup-eligible), `Deny Both`→`denydir` + auto-rules — the exact distinction the issue conflated.
- Full PHPUnit suite green (1116 tests); PHPCS / PHPStan / php -l clean; Python suite + ruff unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEtct4G4nCXfjLYq51AJ5k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded DNSBL List Action options to include `Alias_Native` mode alongside the existing `Alias_Deny` option. Help text updated to clarify the differences and behavioral impact of each action mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->