### PR TITLE
pfblockerng: move DoH/DoT/DoQ blocking from SafeSearch to DNSBL page

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -122,6 +122,10 @@ $pconfig['alexa_inclusion']	= explode(',', $pfb['dconfig']['alexa_inclusion'])	?
 $pconfig['tldexclusion']	= base64_decode($pfb['dconfig']['tldexclusion'])	?: '';
 $pconfig['tldblacklist']	= base64_decode($pfb['dconfig']['tldblacklist'])	?: '';
 
+// DoH/DoT/DoQ blocking — stored in pfblockerngsafesearch; read via gateway (registered keys)
+$pconfig['safesearch_doh']		= PfbConfig::read('safesearch_doh');
+$pconfig['safesearch_doh_list']		= explode(',', PfbConfig::read('safesearch_doh_list'));
+
 // Select field options
 
 $options_dnsbl_interface	= pfb_build_if_list(FALSE, FALSE);
@@ -328,6 +332,151 @@ $options_action			= [ 'Disabled' => 'Disabled', 'Deny_Inbound' => 'Deny Inbound'
 
 $options_aliaslog		= [ 'enabled' => 'Enable', 'disabled' => 'Disable' ];
 
+// DoH/DoT/DoQ blocking options — stored in pfblockerngsafesearch (foreign section; see ADR-29 foreign-key exclusion list)
+$options_safesearch_doh		= ['Disable' => 'Disable', 'Enable' => 'Enable'];
+$options_safesearch_doh_list	= [
+					'use-application-dns.net' => 'Firefox [use-application-dns.net]',
+					'cloudflare-dns.com' => 'CloudFlare DoH/DoT [cloudflare-dns.com]',
+					'security.cloudflare-dns.com' => 'CloudFlare Security DoH/DoT [security.cloudflare-dns.com]',
+					'family.cloudflare-dns.com' => 'CloudFlare Family DoH/DoT [family.cloudflare-dns.com]',
+					'one.one.one.one' => 'CloudFlare One [one.one.one.one]',
+					'1dot1dot1dot1.cloudflare-dns.com' => 'CloudFlare 1dot DoT [1dot1dot1dot1.cloudflare-dns.com]',
+					'dns.google' => 'Google DoH/DoT [dns.google]',
+					'doh.dns.apple.com' => 'Apple [doh.dns.apple.com]',
+					'mask.icloud.com' => 'Apple iCloud Private Relay [mask.icloud.com]',
+					'mask-h2.icloud.com' => 'Apple iCloud Private Relay [mask-h2.icloud.com]',
+					'mask-api.icloud.com' => 'Apple iCloud Private Relay [mask-api.icloud.com]',
+					'mask-t.apple-dns.net' => 'Apple iCloud Private Relay [mask-t.apple-dns.net]',
+					'mask.apple-dns.net' => 'Apple iCloud Private Relay [mask.apple-dns.net]',
+					'mask-api.fe.apple-dns.net' => 'Apple iCloud Private Relay [mask-api.fe.apple-dns.net]',
+					'doh.opendns.com' => 'OpenDNS DoH [doh.opendns.com]',
+					'doh.familyshield.opendns.com' => 'OpenDNS Family DoH [doh.familyshield.opendns.com]',
+					'dns.quad9.net' => 'Quad9 DoH/DoT [dns.quad9.net]',
+					'dns10.quad9.net' => 'Quad9 Unsecured DoH/DoT [dns10.quad9.net]',
+					'dns11.quad9.net' => 'Quad9 ECS DoH/DoT [dns11.quad9.net]',
+					'dns.adguard-dns.com' => 'AdGuard DoH/DoT/DoQ [dns.adguard-dns.com]',
+					'unfiltered.adguard-dns.com' => 'AdGuard Unfiltered DoH/DoT/DoQ [unfiltered.adguard-dns.com]',
+					'family.adguard-dns.com' => 'AdGuard Family DoH/DoT/DoQ [family.adguard-dns.com]',
+					'doh.cleanbrowsing.org' => 'CleanBrowsing [doh.cleanbrowsing.org]',
+					'security-filter-dns.cleanbrowsing.org' => 'CleanBrowsing Security [security-filter-dns.cleanbrowsing.org]',
+					'family-filter-dns.cleanbrowsing.org' => 'CleanBrowsing Family [family-filter-dns.cleanbrowsing.org]',
+					'adult-filter-dns.cleanbrowsing.org' => 'CleanBrowsing Adult [adult-filter-dns.cleanbrowsing.org]',
+					'dns.nextdns.io' => 'NextDNS DoH/DoT/DoQ [dns.nextdns.io]',
+					'dns.switch.ch' => 'SWITCH DoH/DoT [dns.switch.ch]',
+					'dns.futuredns.me' => 'FutureDNS DoH/DoT/DoQ [dns.futuredns.me]',
+					'dns.comss.one' => 'Comss.ru West DoH/DoT [dns.comss.one]',
+					'dns.east.comss.one' => 'Comss.ru East [dns.east.comss.one]',
+					'private.canadianshield.cira.ca' => 'CIRA Private [private.canadianshield.cira.ca]',
+					'protected.canadianshield.cira.ca' => 'CIRA Protected [protected.canadianshield.cira.ca]',
+					'family.canadianshield.cira.ca' => 'CIRA Family [family.canadianshield.cira.ca]',
+					'doh-fi.blahdns.com' => 'BlahDNS DoH Finland [doh-fi.blahdns.com]',
+					'doh-jp.blahdns.com' => 'BlahDNS DoH Japan [doh-jp.blahdns.com]',
+					'doh-de.blahdns.com' => 'BlahDNS DoH Germany [doh-de.blahdns.com]',
+					'dot-fi.blahdns.com' => 'BlahDNS DoT Finland [dot-fi.blahdns.com]',
+					'dot-jp.blahdns.com' => 'BlahDNS DoT Japan [dot-fi.blahdns.com]',
+					'dot-de.blahdns.com' => 'BlahDNS DoT Germany [dot-de.blahdns.com]',
+					'fi.doh.dns.snopyta.org' => 'Snopyta [fi.doh.dns.snopyta.org]',
+					'dns-doh.dnsforfamily.com' => 'DNS for Family DoH [dns-doh.dnsforfamily.com]',
+					'dns-dot.dnsforfamily.com' => 'DNS for Family DoT [dns-dot.dnsforfamily.com]',
+					'odvr.nic.cz' => 'CZ.NIC ODVR [odvr.nic.cz]',
+					'dns.alidns.com' => 'Ali [dns.alidns.com]',
+					'dns.cfiec.net' => 'CFIEC [dns.cfiec.net]',
+					'asia.dnscepat.id' => 'DNSCEPAT Asia [asia.dnscepat.id]',
+					'eropa.dnscepat.id' => 'DNSCEPAT Eropa [eropa.dnscepat.id]',
+					'doh.360.cn' => '360 Secure [doh.360.cn]',
+					'public.dns.iij.jp' => 'IIJ.JP [public.dns.iij.jp]',
+					'dns.pub' => 'DNSPod [dns.pub]',
+					'doh.pub' => 'DNSPod DoH [doh.pub]',
+					'dot.pub' => 'DNSPod DoT [dot.pub]',
+					'dns.twnic.tw' => 'Quad101 [dns.twnic.tw]',
+					'doh.tiarap.org' => 'Privacy-First Singapore [doh.tiarap.org]',
+					'doh.tiar.app' => 'Privacy-First Singapore DoH/DoQ [doh.tiar.app]',
+					'dot.tiar.app' => 'Privacy-First Singapore DoT [dot.tiar.app]',
+					'jp.tiarap.org' => 'Privacy-First Japan DoH [jp.tiarap.org]',
+					'jp.tiar.app' => 'Privacy-First Japan DoT [jp.tiar.app]',
+					'dns.oszx.co' => 'OSZX [dns.oszx.co]',
+					'dns.pumplex.com' => 'Pumplex [dns.pumplex.com]',
+					'doh.applied-privacy.net' => 'Applied Privacy DoH [doh.applied-privacy.net]',
+					'dot1.applied-privacy.net' => 'Applied Privacy DoT [dot1.applied-privacy.net]',
+					'dns.decloudus.com' => 'DeCloudUs [dns.decloudus.com]',
+					'resolver-eu.lelux.fi' => 'Lelux [resolver-eu.lelux.fi]',
+					'doh.dns.sb' => 'DNS.SB [doh.dns.sb]',
+					'dnsforge.de' => 'DNS Forge [dnsforge.de]',
+					'kaitain.restena.lu' => 'Fondation Restena [kaitain.restena.lu]',
+					'doh.ffmuc.net' => 'FFMUC DoH [doh.ffmuc.net]',
+					'dot.ffmuc.net' => 'FFMUC DoT [dot.ffmuc.net]',
+					'dns.digitale-gesellschaft.ch' => 'Digitale Gesellschaft [dns.digitale-gesellschaft.ch]',
+					'doh.libredns.gr' => 'LibreDNS DoH [doh.libredns.gr]',
+					'dot.libredns.gr' => 'LibreDNS DoT [dot.libredns.gr]',
+					'ibksturm.synology.me' => 'ibksturm [ibksturm.synology.me]',
+					'getdnsapi.net' => 'DNS Privacy [getdnsapi.net]',
+					'dnsovertls.sinodun.com' => 'DNS Privacy TLS [dnsovertls.sinodun.com]',
+					'dnsovertls1.sinodun.com' => 'DNS Privacy TLS2 [dnsovertls1.sinodun.com]',
+					'unicast.censurfridns.dk' => 'DNS Privacy Unicast [unicast.censurfridns.dk]',
+					'anycast.censurfridns.dk' => 'DNS Privacy Anycast [anycast.censurfridns.dk]',
+					'dns.cmrg.net' => 'DNS Privacy dkg [dns.cmrg.net]',
+					'dns.larsdebruin.net' => 'DNS Privacy larsdebruin [dns.larsdebruin.net]',
+					'dns-tls.bitwiseshift.net' => 'DNS Privacy bitwiseshift [dns-tls.bitwiseshift.net]',
+					'ns1.dnsprivacy.at' => 'DNS Privacy dnsprivacy [ns1.dnsprivacy.at]',
+					'ns2.dnsprivacy.at' => 'DNS Privacy dnsprivacy2 [ns2.dnsprivacy.at]',
+					'dns.bitgeek.in' => 'DNS Privacy bitgeek [dns.bitgeek.in]',
+					'dns.neutopia.org' => 'DNS Privacy neutopia [dns.neutopia.org]',
+					'privacydns.go6lab.si' => 'DNS Privacy Go6Lab [privacydns.go6lab.si]',
+					'dot.securedns.eu' => 'DNS Privacy securedns [dot.securedns.eu]',
+					'dnsotls.lab.nic.cl' => 'DNS Privacy NIC Chile [dnsotls.lab.nic.cl]',
+					'tls-dns-u.odvr.dns-oarc.net' => 'DNS Privacy OARC [tls-dns-u.odvr.dns-oarc.net]',
+					'doh.centraleu.pi-dns.com' => 'PI-DNS Central EU DoH [doh.centraleu.pi-dns.com]',
+					'dot.centraleu.pi-dns.com' => 'PI-DNS Central EU DoT [dot.centraleu.pi-dns.com]',
+					'doh.northeu.pi-dns.com' => 'PI-DNS North EU DoH [doh.northeu.pi-dns.com]',
+					'dot.northeu.pi-dns.com' => 'PI-DNS North EU DoT [dot.northeu.pi-dns.com]',
+					'doh.westus.pi-dns.com' => 'PI-DNS West USA DoH [doh.westus.pi-dns.com]',
+					'dot.westus.pi-dns.com' => 'PI-DNS West USA DoT [dot.westus.pi-dns.com]',
+					'doh.eastus.pi-dns.com' => 'PI-DNS East USA DoH [doh.eastus.pi-dns.com]',
+					'dot.eastus.pi-dns.com' => 'PI-DNS East USA DoT [dot.eastus.pi-dns.com]',
+					'doh.eastau.pi-dns.com' => 'PI-DNS East AU DoH [doh.eastau.pi-dns.com]',
+					'dot.eastau.pi-dns.com' => 'PI-DNS East AU DoT [dot.eastau.pi-dns.com]',
+					'doh.eastas.pi-dns.com' => 'PI-DNS East AS DoH [doh.eastas.pi-dns.com]',
+					'dot.eastas.pi-dns.com' => 'PI-DNS East AS DoT [dot.eastas.pi-dns.com]',
+					'doh.pi-dns.com' => 'PI-DNS [doh.pi-dns.com]',
+					'dot.seby.io' => 'Seby [dot.seby.io]',
+					'doh-2.seby.io' => 'Seby 2 [doh-2.seby.io]',
+					'doh.dnslify.com' => 'DNSlify [doh.dnslify.com]',
+					'yandex.dns' => 'Yandex [yandex.dns]',
+					'blitz.ahadns.com' => 'AhaDNS Blitz DoH [blitz.ahadns.com]',
+					'doh.nl.ahadns.net' => 'AhaDNS Blitz Netherlands DoH [doh.nl.ahadns.net]',
+					'dot.nl.ahadns.net' => 'AhaDNS Blitz Netherlands DoT [dot.nl.ahadns.net]',
+					'doh.in.ahadns.net' => 'AhaDNS Blitz India DoH [doh.in.ahadns.net]',
+					'dot.in.ahadns.net' => 'AhaDNS Blitz India DoT [dot.in.ahadns.net]',
+					'doh.la.ahadns.net' => 'AhaDNS Blitz Las Angeles DoH [doh.la.ahadns.net]',
+					'dot.la.ahadns.net' => 'AhaDNS Blitz Las Angeles DoT [dot.la.ahadns.net]',
+					'doh.ny.ahadns.net' => 'AhaDNS Blitz New York DoH [doh.ny.ahadns.net]',
+					'dot.ny.ahadns.net' => 'AhaDNS Blitz New York DoT [dot.ny.ahadns.net]',
+					'doh.pl.ahadns.net' => 'AhaDNS Blitz Poland DoH [doh.pl.ahadns.net]',
+					'dot.pl.ahadns.net' => 'AhaDNS Blitz Poland DoT [dot.pl.ahadns.net]',
+					'doh.it.ahadns.net' => 'AhaDNS Blitz Italy DoH [doh.it.ahadns.net]',
+					'dot.it.ahadns.net' => 'AhaDNS Blitz Italy DoT [dot.it.ahadns.net]',
+					'doh.es.ahadns.net' => 'AhaDNS Blitz Spain DoH [doh.es.ahadns.net]',
+					'dot.es.ahadns.net' => 'AhaDNS Blitz Spain DoT [dot.es.ahadns.net]',
+					'doh.no.ahadns.net' => 'AhaDNS Blitz Norway DoH [doh.no.ahadns.net]',
+					'dot.no.ahadns.net' => 'AhaDNS Blitz Norway DoT [dot.no.ahadns.net]',
+					'doh.chi.ahadns.net' => 'AhaDNS Blitz Chicago DoH [doh.chi.ahadns.net]',
+					'dot.chi.ahadns.net' => 'AhaDNS Blitz Chicago DoT [dot.chi.ahadns.net]',
+					'doh.au.ahadns.net' => 'AhaDNS Blitz Australia DoH [doh.au.ahadns.net]',
+					'dot.au.ahadns.net' => 'AhaDNS Blitz Australia DoT [dot.au.ahadns.net]',
+					'basic.rethinkdns.com' => 'RethinkDNS DoH [basic.rethinkdns.com]',
+					'max.rethinkdns.com' => 'RethinkDNS DoT [max.rethinkdns.com]',
+					'freedns.controld.com' => 'ControlD DoH [freedns.controld.com]',
+					'p0.freedns.controld.com' => 'ControlD DoT [p0.freedns.controld.com]',
+					'p1.freedns.controld.com' => 'ControlD DoT [p1.freedns.controld.com]',
+					'p2.freedns.controld.com' => 'ControlD DoT [p2.freedns.controld.com]',
+					'p3.freedns.controld.com' => 'ControlD DoT [p3.freedns.controld.com]',
+					'doh.mullvad.net' => 'Mullvad [doh.mullvad.net]',
+					'adblock.doh.mullvad.net' => 'Mullvad [adblock.doh.mullvad.net]',
+					'dns.arapurayil.com' => 'Arapurayil [dns.arapurayil.com]',
+					'dandelionsprout.asuscomm.com' => 'Dandelion Sprout DoH/DoT/DoQ [dandelionsprout.asuscomm.com]',
+					'zero.dns0.eu' => 'European public DNS DoH/DoT/DoQ [zero.dns0.eu]'
+					];
+
 // Collect all pfSense 'Port' Aliases
 // foreign key — out of ADR-29 gateway scope (aliases/alias is not a pfblockerng* path)
 $ports_list = $networks_list = '';
@@ -529,6 +678,27 @@ if ($_POST) {
 			}
 		}
 
+		// Validate DoH/DoT/DoQ blocking fields (stored in pfblockerngsafesearch — foreign section)
+		if (($_POST['safesearch_doh'] ?? '') == 'Enable' && empty($_POST['safesearch_doh_list'])) {
+			$input_errors[] = 'Warning: With DoH/DoT/DoQ Blocking enabled, you must select at least one List';
+		}
+
+		if (!array_key_exists($_POST['safesearch_doh'] ?? '', $options_safesearch_doh)) {
+			$_POST['safesearch_doh'] = 'Disable';
+		}
+
+		if (is_array($_POST['safesearch_doh_list'] ?? '')) {
+			foreach ($_POST['safesearch_doh_list'] as $validate) {
+				if (!array_key_exists($validate, $options_safesearch_doh_list)) {
+					$_POST['safesearch_doh_list'] = '';
+					break;
+				}
+			}
+		}
+		elseif (!array_key_exists($_POST['safesearch_doh_list'] ?? '', $options_safesearch_doh_list)) {
+			$_POST['safesearch_doh_list'] = '';
+		}
+
 		if (!$input_errors) {
 
 			$pfb['dconfig']['pfb_dnsbl']		= pfb_filter($_POST['pfb_dnsbl'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
@@ -643,6 +813,10 @@ if ($_POST) {
 			if ($dnsbl_webpage || !file_exists('/usr/local/www/pfblockerng/www/dnsbl_active.php')) {
 				@copy("/usr/local/www/pfblockerng/www/{$pfb['dconfig']['dnsbl_webpage']}", '/usr/local/www/pfblockerng/www/dnsbl_active.php');
 			}
+
+			// Save DoH/DoT/DoQ blocking fields via gateway (registered keys in pfblockerngsafesearch)
+			PfbConfig::write('safesearch_doh', $_POST['safesearch_doh'] ?: 'Disable');
+			PfbConfig::write('safesearch_doh_list', implode(',', (array)$_POST['safesearch_doh_list']) ?: '');
 
 			PfbConfig::writeSection('installedpackages/pfblockerngdnsblsettings/config/0', $pfb['dconfig']);
 			write_config('[pfBlockerNG] save DNSBL settings');
@@ -2547,6 +2721,28 @@ $section->addInput(new Form_Checkbox(
 	pfb_cfg_toggle_read($pconfig['pfb_gp']) === PfbToggle::On,
 	'on'
 ))->setHelp('Enable the Group Policy functionality to allow certain Local LAN IPs to bypass DNSBL');
+
+$form->add($section);
+
+$section = new Form_Section('DNS over HTTPS/TLS/QUIC Blocking');
+$section->addInput(new Form_Select(
+	'safesearch_doh',
+	gettext('DoH/DoT/DoQ Blocking'),
+	$pconfig['safesearch_doh'],
+	$options_safesearch_doh
+))->setHelp('Block well-known DNS over HTTPS/TLS/QUIC (DoH/DoT/DoQ) providers. Modern browsers and devices often use encrypted DNS that bypasses DNSBL; blocking these providers keeps clients on the local resolver so DNSBL stays effective.<br />'
+		. 'DNS requests to these domains will return NXDOMAIN.')
+  ->setAttribute('style', 'width: auto');
+
+$section->addInput(new Form_Select(
+	'safesearch_doh_list',
+	gettext('DoH/DoT/DoQ Blocking List'),
+	$pconfig['safesearch_doh_list'],
+	$options_safesearch_doh_list,
+	TRUE
+))->setHelp('Select the DoH/DoT/DoQ providers to block.')
+  ->setAttribute('style', 'width: auto')
+  ->setAttribute('size', 140);
 
 $form->add($section);
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
@@ -32,155 +32,10 @@ $pfb['bconfig']	= PfbConfig::readSection('installedpackages/pfblockerngsafesearc
 $pconfig = array();
 $pconfig['safesearch_enable']		= $pfb['bconfig']['safesearch_enable']			?: 'Disable';
 $pconfig['safesearch_youtube']		= $pfb['bconfig']['safesearch_youtube']			?: 'Disable';
-$pconfig['safesearch_doh']		= $pfb['bconfig']['safesearch_doh']			?: 'Disable';
-$pconfig['safesearch_doh_list']		= explode(',', $pfb['bconfig']['safesearch_doh_list'])	?: array();
 
 // Select field options
 $options_safesearch_enable	= ['Disable' => 'Disable', 'Enable' => 'Enable'];
 $options_safesearch_youtube	= ['Disable' => 'Disable', 'Strict' => 'Strict', 'Moderate' => 'Moderate'];
-$options_safesearch_doh		= ['Disable' => 'Disable', 'Enable' => 'Enable'];
-$options_safesearch_doh_list	= [
-					'use-application-dns.net' => 'Firefox [use-application-dns.net]',
-					'cloudflare-dns.com' => 'CloudFlare DoH/DoT [cloudflare-dns.com]',
-					'security.cloudflare-dns.com' => 'CloudFlare Security DoH/DoT [security.cloudflare-dns.com]',
-					'family.cloudflare-dns.com' => 'CloudFlare Family DoH/DoT [family.cloudflare-dns.com]',
-					'one.one.one.one' => 'CloudFlare One [one.one.one.one]',
-					'1dot1dot1dot1.cloudflare-dns.com' => 'CloudFlare 1dot DoT [1dot1dot1dot1.cloudflare-dns.com]',
-					'dns.google' => 'Google DoH/DoT [dns.google]',
-					'doh.dns.apple.com' => 'Apple [doh.dns.apple.com]',
-					'mask.icloud.com' => 'Apple iCloud Private Relay [mask.icloud.com]',
-					'mask-h2.icloud.com' => 'Apple iCloud Private Relay [mask-h2.icloud.com]',
-					'mask-api.icloud.com' => 'Apple iCloud Private Relay [mask-api.icloud.com]',
-					'mask-t.apple-dns.net' => 'Apple iCloud Private Relay [mask-t.apple-dns.net]',
-					'mask.apple-dns.net' => 'Apple iCloud Private Relay [mask.apple-dns.net]',
-					'mask-api.fe.apple-dns.net' => 'Apple iCloud Private Relay [mask-api.fe.apple-dns.net]',
-					'doh.opendns.com' => 'OpenDNS DoH [doh.opendns.com]',
-					'doh.familyshield.opendns.com' => 'OpenDNS Family DoH [doh.familyshield.opendns.com]',
-					'dns.quad9.net' => 'Quad9 DoH/DoT [dns.quad9.net]',
-					'dns10.quad9.net' => 'Quad9 Unsecured DoH/DoT [dns10.quad9.net]',
-					'dns11.quad9.net' => 'Quad9 ECS DoH/DoT [dns11.quad9.net]',
-					'dns.adguard-dns.com' => 'AdGuard DoH/DoT/DoQ [dns.adguard-dns.com]',
-					'unfiltered.adguard-dns.com' => 'AdGuard Unfiltered DoH/DoT/DoQ [unfiltered.adguard-dns.com]',
-					'family.adguard-dns.com' => 'AdGuard Family DoH/DoT/DoQ [family.adguard-dns.com]',
-					'doh.cleanbrowsing.org' => 'CleanBrowsing [doh.cleanbrowsing.org]',
-					'security-filter-dns.cleanbrowsing.org' => 'CleanBrowsing Security [security-filter-dns.cleanbrowsing.org]',
-					'family-filter-dns.cleanbrowsing.org' => 'CleanBrowsing Family [family-filter-dns.cleanbrowsing.org]',
-					'adult-filter-dns.cleanbrowsing.org' => 'CleanBrowsing Adult [adult-filter-dns.cleanbrowsing.org]',
-					'dns.nextdns.io' => 'NextDNS DoH/DoT/DoQ [dns.nextdns.io]',
-					'dns.switch.ch' => 'SWITCH DoH/DoT [dns.switch.ch]',
-					'dns.futuredns.me' => 'FutureDNS DoH/DoT/DoQ [dns.futuredns.me]',
-					'dns.comss.one' => 'Comss.ru West DoH/DoT [dns.comss.one]',
-					'dns.east.comss.one' => 'Comss.ru East [dns.east.comss.one]',
-					'private.canadianshield.cira.ca' => 'CIRA Private [private.canadianshield.cira.ca]',
-					'protected.canadianshield.cira.ca' => 'CIRA Protected [protected.canadianshield.cira.ca]',
-					'family.canadianshield.cira.ca' => 'CIRA Family [family.canadianshield.cira.ca]',
-					'doh-fi.blahdns.com' => 'BlahDNS DoH Finland [doh-fi.blahdns.com]',
-					'doh-jp.blahdns.com' => 'BlahDNS DoH Japan [doh-jp.blahdns.com]',
-					'doh-de.blahdns.com' => 'BlahDNS DoH Germany [doh-de.blahdns.com]',
-					'dot-fi.blahdns.com' => 'BlahDNS DoT Finland [dot-fi.blahdns.com]',
-					'dot-jp.blahdns.com' => 'BlahDNS DoT Japan [dot-fi.blahdns.com]',
-					'dot-de.blahdns.com' => 'BlahDNS DoT Germany [dot-de.blahdns.com]',
-					'fi.doh.dns.snopyta.org' => 'Snopyta [fi.doh.dns.snopyta.org]',
-					'dns-doh.dnsforfamily.com' => 'DNS for Family DoH [dns-doh.dnsforfamily.com]',
-					'dns-dot.dnsforfamily.com' => 'DNS for Family DoT [dns-dot.dnsforfamily.com]',
-					'odvr.nic.cz' => 'CZ.NIC ODVR [odvr.nic.cz]',
-					'dns.alidns.com' => 'Ali [dns.alidns.com]',
-					'dns.cfiec.net' => 'CFIEC [dns.cfiec.net]',
-					'asia.dnscepat.id' => 'DNSCEPAT Asia [asia.dnscepat.id]',
-					'eropa.dnscepat.id' => 'DNSCEPAT Eropa [eropa.dnscepat.id]',
-					'doh.360.cn' => '360 Secure [doh.360.cn]',
-					'public.dns.iij.jp' => 'IIJ.JP [public.dns.iij.jp]',
-					'dns.pub' => 'DNSPod [dns.pub]',
-					'doh.pub' => 'DNSPod DoH [doh.pub]',
-					'dot.pub' => 'DNSPod DoT [dot.pub]',
-					'dns.twnic.tw' => 'Quad101 [dns.twnic.tw]',
-					'doh.tiarap.org' => 'Privacy-First Singapore [doh.tiarap.org]',
-					'doh.tiar.app' => 'Privacy-First Singapore DoH/DoQ [doh.tiar.app]',
-					'dot.tiar.app' => 'Privacy-First Singapore DoT [dot.tiar.app]',
-					'jp.tiarap.org' => 'Privacy-First Japan DoH [jp.tiarap.org]',
-					'jp.tiar.app' => 'Privacy-First Japan DoT [jp.tiar.app]',
-					'dns.oszx.co' => 'OSZX [dns.oszx.co]',
-					'dns.pumplex.com' => 'Pumplex [dns.pumplex.com]',
-					'doh.applied-privacy.net' => 'Applied Privacy DoH [doh.applied-privacy.net]',
-					'dot1.applied-privacy.net' => 'Applied Privacy DoT [dot1.applied-privacy.net]',
-					'dns.decloudus.com' => 'DeCloudUs [dns.decloudus.com]',
-					'resolver-eu.lelux.fi' => 'Lelux [resolver-eu.lelux.fi]',
-					'doh.dns.sb' => 'DNS.SB [doh.dns.sb]',
-					'dnsforge.de' => 'DNS Forge [dnsforge.de]',
-					'kaitain.restena.lu' => 'Fondation Restena [kaitain.restena.lu]',
-					'doh.ffmuc.net' => 'FFMUC DoH [doh.ffmuc.net]',
-					'dot.ffmuc.net' => 'FFMUC DoT [dot.ffmuc.net]',
-					'dns.digitale-gesellschaft.ch' => 'Digitale Gesellschaft [dns.digitale-gesellschaft.ch]',
-					'doh.libredns.gr' => 'LibreDNS DoH [doh.libredns.gr]',
-					'dot.libredns.gr' => 'LibreDNS DoT [dot.libredns.gr]',
-					'ibksturm.synology.me' => 'ibksturm [ibksturm.synology.me]',
-					'getdnsapi.net' => 'DNS Privacy [getdnsapi.net]',
-					'dnsovertls.sinodun.com' => 'DNS Privacy TLS [dnsovertls.sinodun.com]',
-					'dnsovertls1.sinodun.com' => 'DNS Privacy TLS2 [dnsovertls1.sinodun.com]',
-					'unicast.censurfridns.dk' => 'DNS Privacy Unicast [unicast.censurfridns.dk]',
-					'anycast.censurfridns.dk' => 'DNS Privacy Anycast [anycast.censurfridns.dk]',
-					'dns.cmrg.net' => 'DNS Privacy dkg [dns.cmrg.net]',
-					'dns.larsdebruin.net' => 'DNS Privacy larsdebruin [dns.larsdebruin.net]',
-					'dns-tls.bitwiseshift.net' => 'DNS Privacy bitwiseshift [dns-tls.bitwiseshift.net]',
-					'ns1.dnsprivacy.at' => 'DNS Privacy dnsprivacy [ns1.dnsprivacy.at]',
-					'ns2.dnsprivacy.at' => 'DNS Privacy dnsprivacy2 [ns2.dnsprivacy.at]',
-					'dns.bitgeek.in' => 'DNS Privacy bitgeek [dns.bitgeek.in]',
-					'dns.neutopia.org' => 'DNS Privacy neutopia [dns.neutopia.org]',
-					'privacydns.go6lab.si' => 'DNS Privacy Go6Lab [privacydns.go6lab.si]',
-					'dot.securedns.eu' => 'DNS Privacy securedns [dot.securedns.eu]',
-					'dnsotls.lab.nic.cl' => 'DNS Privacy NIC Chile [dnsotls.lab.nic.cl]',
-					'tls-dns-u.odvr.dns-oarc.net' => 'DNS Privacy OARC [tls-dns-u.odvr.dns-oarc.net]',
-					'doh.centraleu.pi-dns.com' => 'PI-DNS Central EU DoH [doh.centraleu.pi-dns.com]',
-					'dot.centraleu.pi-dns.com' => 'PI-DNS Central EU DoT [dot.centraleu.pi-dns.com]',
-					'doh.northeu.pi-dns.com' => 'PI-DNS North EU DoH [doh.northeu.pi-dns.com]',
-					'dot.northeu.pi-dns.com' => 'PI-DNS North EU DoT [dot.northeu.pi-dns.com]',
-					'doh.westus.pi-dns.com' => 'PI-DNS West USA DoH [doh.westus.pi-dns.com]',
-					'dot.westus.pi-dns.com' => 'PI-DNS West USA DoT [dot.westus.pi-dns.com]',
-					'doh.eastus.pi-dns.com' => 'PI-DNS East USA DoH [doh.eastus.pi-dns.com]',
-					'dot.eastus.pi-dns.com' => 'PI-DNS East USA DoT [dot.eastus.pi-dns.com]',
-					'doh.eastau.pi-dns.com' => 'PI-DNS East AU DoH [doh.eastau.pi-dns.com]',
-					'dot.eastau.pi-dns.com' => 'PI-DNS East AU DoT [dot.eastau.pi-dns.com]',
-					'doh.eastas.pi-dns.com' => 'PI-DNS East AS DoH [doh.eastas.pi-dns.com]',
-					'dot.eastas.pi-dns.com' => 'PI-DNS East AS DoT [dot.eastas.pi-dns.com]',
-					'doh.pi-dns.com' => 'PI-DNS [doh.pi-dns.com]',
-					'dot.seby.io' => 'Seby [dot.seby.io]',
-					'doh-2.seby.io' => 'Seby 2 [doh-2.seby.io]',
-					'doh.dnslify.com' => 'DNSlify [doh.dnslify.com]',
-					'yandex.dns' => 'Yandex [yandex.dns]',
-					'blitz.ahadns.com' => 'AhaDNS Blitz DoH [blitz.ahadns.com]',
-					'doh.nl.ahadns.net' => 'AhaDNS Blitz Netherlands DoH [doh.nl.ahadns.net]',
-					'dot.nl.ahadns.net' => 'AhaDNS Blitz Netherlands DoT [dot.nl.ahadns.net]',
-					'doh.in.ahadns.net' => 'AhaDNS Blitz India DoH [doh.in.ahadns.net]',
-					'dot.in.ahadns.net' => 'AhaDNS Blitz India DoT [dot.in.ahadns.net]',
-					'doh.la.ahadns.net' => 'AhaDNS Blitz Las Angeles DoH [doh.la.ahadns.net]',
-					'dot.la.ahadns.net' => 'AhaDNS Blitz Las Angeles DoT [dot.la.ahadns.net]',
-					'doh.ny.ahadns.net' => 'AhaDNS Blitz New York DoH [doh.ny.ahadns.net]',
-					'dot.ny.ahadns.net' => 'AhaDNS Blitz New York DoT [dot.ny.ahadns.net]',
-					'doh.pl.ahadns.net' => 'AhaDNS Blitz Poland DoH [doh.pl.ahadns.net]',
-					'dot.pl.ahadns.net' => 'AhaDNS Blitz Poland DoT [dot.pl.ahadns.net]',
-					'doh.it.ahadns.net' => 'AhaDNS Blitz Italy DoH [doh.it.ahadns.net]',
-					'dot.it.ahadns.net' => 'AhaDNS Blitz Italy DoT [dot.it.ahadns.net]',
-					'doh.es.ahadns.net' => 'AhaDNS Blitz Spain DoH [doh.es.ahadns.net]',
-					'dot.es.ahadns.net' => 'AhaDNS Blitz Spain DoT [dot.es.ahadns.net]',
-					'doh.no.ahadns.net' => 'AhaDNS Blitz Norway DoH [doh.no.ahadns.net]',
-					'dot.no.ahadns.net' => 'AhaDNS Blitz Norway DoT [dot.no.ahadns.net]',
-					'doh.chi.ahadns.net' => 'AhaDNS Blitz Chicago DoH [doh.chi.ahadns.net]',
-					'dot.chi.ahadns.net' => 'AhaDNS Blitz Chicago DoT [dot.chi.ahadns.net]',
-					'doh.au.ahadns.net' => 'AhaDNS Blitz Australia DoH [doh.au.ahadns.net]',
-					'dot.au.ahadns.net' => 'AhaDNS Blitz Australia DoT [dot.au.ahadns.net]',
-					'basic.rethinkdns.com' => 'RethinkDNS DoH [basic.rethinkdns.com]',
-					'max.rethinkdns.com' => 'RethinkDNS DoT [max.rethinkdns.com]',
-					'freedns.controld.com' => 'ControlD DoH [freedns.controld.com]',
-					'p0.freedns.controld.com' => 'ControlD DoT [p0.freedns.controld.com]',
-					'p1.freedns.controld.com' => 'ControlD DoT [p1.freedns.controld.com]',
-					'p2.freedns.controld.com' => 'ControlD DoT [p2.freedns.controld.com]',
-					'p3.freedns.controld.com' => 'ControlD DoT [p3.freedns.controld.com]',
-					'doh.mullvad.net' => 'Mullvad [doh.mullvad.net]',
-					'adblock.doh.mullvad.net' => 'Mullvad [adblock.doh.mullvad.net]',
-					'dns.arapurayil.com' => 'Arapurayil [dns.arapurayil.com]',
-					'dandelionsprout.asuscomm.com' => 'Dandelion Sprout DoH/DoT/DoQ [dandelionsprout.asuscomm.com]',
-					'zero.dns0.eu' => 'European public DNS DoH/DoT/DoQ [zero.dns0.eu]'
-					];
 
 // $input_errors is read unconditionally in the render section below, so it must be
 // defined on every request path. Initialise it once.
@@ -188,14 +43,9 @@ $input_errors = array();
 
 if (isset($_POST['save'])) {
 
-	if (($_POST['safesearch_doh'] == 'Enable') && empty($_POST['safesearch_doh_list'])) {
-		$input_errors[] = 'Warning: With DoH/DoT Blocking enabled, you must select at least one List';
-	}
-
 	// Validate Select field (array) options
 	$select_options = array(	'safesearch_enable'	=> '',
-					'safesearch_youtube'	=> '',
-					'safesearch_doh'	=> ''
+					'safesearch_youtube'	=> ''
 					);
 
 	foreach ($select_options as $s_option => $s_default) {
@@ -212,24 +62,9 @@ if (isset($_POST['save'])) {
 		}
 	}
 
-	// Validate SafeSearch selections
-	if (is_array($_POST['safesearch_doh_list'])) {
-		foreach ($_POST['safesearch_doh_list'] as $validate) {
-			if (!array_key_exists($validate, $options_safesearch_doh_list)) {
-				$_POST['safesearch_doh_list'] = '';
-				break;
-			}
-		}
-	}
-	elseif (!array_key_exists($_POST['safesearch_doh_list'], $options_safesearch_doh_list)) {
-		$_POST['safesearch_doh_list'] = '';
-	}
-
 	if (!$input_errors) {
 		$pfb['bconfig']['safesearch_enable']	= $_POST['safesearch_enable']				?: 'Disable';
 		$pfb['bconfig']['safesearch_youtube']	= $_POST['safesearch_youtube']				?: 'Disable';
-		$pfb['bconfig']['safesearch_doh']	= $_POST['safesearch_doh']				?: 'Disable';
-		$pfb['bconfig']['safesearch_doh_list']	= implode(',', (array)$_POST['safesearch_doh_list'])	?: '';
 
 		PfbConfig::writeSection('installedpackages/pfblockerngsafesearch', $pfb['bconfig']);
 		$msg = 'Saved SafeSearch configuration';
@@ -308,28 +143,6 @@ $section->addInput(new Form_Select(
 ))->setHelp('Select YouTube Restrictions. You can check it by visiting: '
 		. '<a target="_blank" href="https://www.youtube.com/check_content_restrictions">Check Youtube Content Restrictions</a>.')
   ->setAttribute('style', 'width: auto');
-$form->add($section);
-
-$section = new Form_Section('DNS over HTTPS/TLS/QUIC Blocking');
-$section->addInput(new Form_Select(
-	'safesearch_doh',
-	gettext('DoH/DoT/DoQ Blocking'),
-	$pconfig['safesearch_doh'],
-	$options_safesearch_doh
-))->setHelp('Block the feature to use DNS over HTTPS/TLS/QUIC to resolve DNS queries directly in the browser rather than using the native OS resolver.<br />'
-		. 'DNS requests to these domains will return NXDOMAIN')
-  ->setAttribute('style', 'width: auto');
-
-$section->addInput(new Form_Select(
-	'safesearch_doh_list',
-	gettext('DoH/DoT/DoQ Blocking List'),
-	$pconfig['safesearch_doh_list'],
-	$options_safesearch_doh_list,
-	TRUE
-))->setHelp('Select the DoH/DoT/DoQ blocking DNS Servers')
-  ->setAttribute('style', 'width: auto')
-  ->setAttribute('size', 140);
-
 $form->add($section);
 print($form);
 print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');


### PR DESCRIPTION
## Summary

Moves the **DNS over HTTPS/TLS/QUIC (DoH/DoT/DoQ) Blocking** option from the *DNSBL SafeSearch* page to the *DNSBL* page, where it logically belongs, and clarifies its help text. Resolves #374.

The issue originally proposed removing the static SafeSearch DoH option in favour of feeds, but the maintainers noted that the curated list is useful and removing it would break existing setups. This change keeps the option (and its data) but relocates the UI to a more sensible home and explains *why* it exists.

## What changed

- **DNSBL page** (`pfblockerng_dnsbl.php`): adds the `DNS over HTTPS/TLS/QUIC Blocking` section (the `safesearch_doh` enable toggle + the `safesearch_doh_list` provider multiselect, all 140 providers), with reworded help.
- **SafeSearch page** (`pfblockerng_safesearch.php`): removes that section and all its POST handling. No DoH/DoT/DoQ references remain on the SafeSearch page.
- **Help text** (DNSBL):
  > Block well-known DNS over HTTPS/TLS/QUIC (DoH/DoT/DoQ) providers. Modern browsers and devices often use encrypted DNS that bypasses DNSBL; blocking these providers keeps clients on the local resolver so DNSBL stays effective.
  > DNS requests to these domains will return NXDOMAIN.

## Storage unchanged (backward/forward compatible)

The config keys `safesearch_doh` / `safesearch_doh_list` stay exactly where they are — `installedpackages/pfblockerngsafesearch` (registered fields, accessed via the ADR-29 `PfbConfig` gateway). No migration; existing setups keep working and the option's enabled/disabled state and provider selection are preserved. The backend (`pfblockerng.inc`) is untouched — it still reads the same keys. The DNSBL page writes the two keys per-key so the sibling SafeSearch settings are never disturbed.

## Scope

UI relocation + help rewording only. The separate idea (from the issue thread) of turning the static list into a subscribable feed / auto-subscribe is intentionally **out of scope** here.

## Validation

`php -l`, `phpcs` (0 errors — incl. the ADR-29 config-gateway sniff), `phpstan`, `phpunit`, `pytest` all green; provider list verified intact (140 → 140). Live page render is covered by the ADR-14 `ui_render` smoke tier (dispatch-only).

Resolves #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWUuidswrN5TNyfBHwHqgt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNS over HTTPS/TLS/QUIC blocking configuration with selectable provider options
* **Changes**
  * SafeSearch configuration page streamlined to focus on redirection and YouTube restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->