### PR TITLE
pfblockerng: note DoH/DoT/DoQ feed alternative in DNSBL help

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2731,7 +2731,8 @@ $section->addInput(new Form_Select(
 	$pconfig['safesearch_doh'],
 	$options_safesearch_doh
 ))->setHelp('Block well-known DNS over HTTPS/TLS/QUIC (DoH/DoT/DoQ) providers. Modern browsers and devices often use encrypted DNS that bypasses DNSBL; blocking these providers keeps clients on the local resolver so DNSBL stays effective.<br />'
-		. 'DNS requests to these domains will return NXDOMAIN.')
+		. 'DNS requests to these domains will return NXDOMAIN.<br />'
+		. 'A DoH/DoT/DoQ <a href="/pfblockerng/pfblockerng_feeds.php">Feed</a> may cover more providers and update more often than this built-in list.')
   ->setAttribute('style', 'width: auto');
 
 $section->addInput(new Form_Select(

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2732,7 +2732,7 @@ $section->addInput(new Form_Select(
 	$options_safesearch_doh
 ))->setHelp('Block well-known DNS over HTTPS/TLS/QUIC (DoH/DoT/DoQ) providers. Modern browsers and devices often use encrypted DNS that bypasses DNSBL; blocking these providers keeps clients on the local resolver so DNSBL stays effective.<br />'
 		. 'DNS requests to these domains will return NXDOMAIN.<br />'
-		. 'A DoH/DoT/DoQ <a href="/pfblockerng/pfblockerng_feeds.php">Feed</a> may cover more providers and update more often than this built-in list.')
+		. 'A DoH/DoT/DoQ <a href="/pfblockerng/pfblockerng_feeds.php" target="_blank">Feed</a> may cover more providers and update more often than this built-in list.')
   ->setAttribute('style', 'width: auto');
 
 $section->addInput(new Form_Select(


### PR DESCRIPTION
## Summary

Small follow-up to #429 (issue #374). Extends the help text of the **DoH/DoT/DoQ Blocking** toggle on the DNSBL page to point users at the **Feeds** page as a complementary option, since a feed can cover more providers and update more frequently than the built-in static list.

## Change

Help text of `safesearch_doh` (DNSBL page) now reads:

> Block well-known DNS over HTTPS/TLS/QUIC (DoH/DoT/DoQ) providers. Modern browsers and devices often use encrypted DNS that bypasses DNSBL; blocking these providers keeps clients on the local resolver so DNSBL stays effective.
> DNS requests to these domains will return NXDOMAIN.
> A DoH/DoT/DoQ [Feed](/pfblockerng/pfblockerng_feeds.php) may cover more providers and update more often than this built-in list.

The link targets the default **Feeds** page (`/pfblockerng/pfblockerng_feeds.php`), not a sub-tab.

Help-text only — no behaviour, config, or backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWUuidswrN5TNyfBHwHqgt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the DoH/DoT/DoQ Blocking provider selection help text to clarify that DNS queries to the selected providers’ domains return NXDOMAIN.
  * Noted that feed-based providers may provide broader coverage and more frequent updates than the built-in list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->