### PR TITLE
tests: live-VM + UI coverage for IPv6 alert external-host attribution

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3457,3 +3457,254 @@ class CaseContext:
                 print(f"[smoke] reset() failed during teardown (suppressed; original error stands): {reset_exc!r}")
             else:
                 raise
+
+
+# --------------------------------------------------------------------------- #
+# IPv6 locality helpers — issue #361 live-VM coverage
+# --------------------------------------------------------------------------- #
+
+# RFC 3849 documentation-range constants used by the locality smoke tests.
+# These are inert (documentation range only; no internet routing).
+IPV6_LOCAL_IFACE = "lan"  # LAN — never touches the WAN/SSH path
+IPV6_LOCAL_ADDR = "2001:db8:51:1::1"  # static address on the LAN interface
+IPV6_LOCAL_BITS = 64  # prefix length → /64
+IPV6_LOCAL_SUBNET = "2001:db8:51:1::"  # network address of the /64
+IPV6_LOCAL_HOST = "2001:db8:51:1::1234"  # a host INSIDE the /64
+IPV6_FOREIGN = "2001:db8:dead:beef::1"  # OUTSIDE the /64 → must be foreign
+
+# ip_block.log lives here on a pfSense guest (pfblockerng.inc:81).
+IP_BLOCK_LOG = "/var/log/pfblockerng/ip_block.log"
+
+
+def set_interface_ipv6(
+    vm: SmokeVM,
+    iface: str,
+    addr: str,
+    bits: int,
+    *,
+    timeout: float = 120.0,
+) -> dict[str, str]:
+    """Set a static IPv6 address on ``iface`` and return the prior IPv6 config.
+
+    Writes ``ipaddrv6 = addr`` and ``subnetv6 = str(bits)`` to the
+    ``interfaces/<iface>`` config section, calls ``interface_configure()`` to
+    apply the address to the OS, then polls ``get_configured_ipv6_addresses()``
+    until the address is live (up to 20 s).
+
+    Only the LAN interface (``IPV6_LOCAL_IFACE``) should be used here: the WAN
+    interface carries the SLIRP-NAT SSH path; changing its IPv6 config risks
+    disconnecting the guest.
+
+    Returns the *prior* IPv6 keys so the caller can restore them in ``finally``:
+    ``{"ipaddrv6": <old_ipaddrv6>, "subnetv6": <old_subnetv6>}`` (empty strings
+    when the keys were absent).
+    """
+    # Read the prior IPv6 config first so the caller can restore on teardown.
+    prior_snippet = (
+        f"$iface = config_get_path({_php_str('interfaces/' + iface)}, array());\n"
+        f"echo {_php_str(_CFG_VAL_OPEN)}"
+        " . ($iface['ipaddrv6'] ?? '')"
+        f" . {_php_str('|||')}"
+        " . ($iface['subnetv6'] ?? '')"
+        f" . {_php_str(_CFG_VAL_CLOSE)};"
+    )
+    prior_result = php_eval(vm, prior_snippet, timeout=timeout)
+    out = prior_result.stdout
+    start = out.find(_CFG_VAL_OPEN)
+    end = out.find(_CFG_VAL_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"set_interface_ipv6: could not read prior config: rc={prior_result.returncode} out={out!r}")
+    inner = out[start + len(_CFG_VAL_OPEN) : end]
+    parts = inner.split("|||", 1)
+    prior = {"ipaddrv6": parts[0], "subnetv6": parts[1] if len(parts) > 1 else ""}
+
+    # Apply the new static IPv6 via pfSsh.php → the pfSense config API.
+    # interface_configure() brings the address up on the OS level.
+    snippet = (
+        "require_once('interfaces.inc');\n"
+        f"$iface = config_get_path({_php_str('interfaces/' + iface)}, array());\n"
+        f"$iface['ipaddrv6'] = {_php_str(addr)};\n"
+        f"$iface['subnetv6'] = {_php_str(str(bits))};\n"
+        f"config_set_path({_php_str('interfaces/' + iface)}, $iface);\n"
+        "write_config('pfBlockerNG smoke: set static IPv6 for locality test');\n"
+        f"if (function_exists('interface_configure')) {{ interface_configure({_php_str(iface)}); }}\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_interface_ipv6({iface}, {addr}/{bits}) failed: "
+            f"rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+    # Poll until get_configured_ipv6_addresses() returns the address (≤20 s).
+    deadline = time.monotonic() + 20.0
+    while time.monotonic() < deadline:
+        live_snippet = (
+            "$addrs = get_configured_ipv6_addresses();\n"
+            f"echo {_php_str(_CFG_VAL_OPEN)}"
+            " . (isset($addrs[" + _php_str(iface) + "]) ? $addrs[" + _php_str(iface) + "] : '')"
+            f" . {_php_str(_CFG_VAL_CLOSE)};"
+        )
+        live_result = php_eval(vm, live_snippet, timeout=30.0)
+        lout = live_result.stdout
+        ls = lout.find(_CFG_VAL_OPEN)
+        le = lout.find(_CFG_VAL_CLOSE)
+        if ls != -1 and le != -1:
+            live_addr = lout[ls + len(_CFG_VAL_OPEN) : le].strip()
+            if live_addr == addr:
+                return prior
+        time.sleep(1.0)
+    raise RuntimeError(
+        f"set_interface_ipv6({iface}, {addr}/{bits}): address never appeared in "
+        f"get_configured_ipv6_addresses() within 20 s"
+    )
+
+
+def restore_interface_ipv6(
+    vm: SmokeVM,
+    iface: str,
+    prior: dict[str, str],
+    *,
+    timeout: float = 120.0,
+) -> None:
+    """Restore the IPv6 config on ``iface`` to the state saved by :func:`set_interface_ipv6`.
+
+    When ``prior["ipaddrv6"]`` is empty the keys are removed (the interface had no
+    static IPv6 before the test). Calls ``interface_configure()`` to make the
+    removal/change effective on the OS.
+    """
+    if prior.get("ipaddrv6"):
+        snippet = (
+            "require_once('interfaces.inc');\n"
+            f"$iface = config_get_path({_php_str('interfaces/' + iface)}, array());\n"
+            f"$iface['ipaddrv6'] = {_php_str(prior['ipaddrv6'])};\n"
+            f"$iface['subnetv6'] = {_php_str(prior.get('subnetv6', ''))};\n"
+            f"config_set_path({_php_str('interfaces/' + iface)}, $iface);\n"
+            "write_config('pfBlockerNG smoke: restore IPv6 after locality test');\n"
+            f"if (function_exists('interface_configure')) {{ interface_configure({_php_str(iface)}); }}\n"
+            "echo 'OK';"
+        )
+    else:
+        snippet = (
+            "require_once('interfaces.inc');\n"
+            f"$iface = config_get_path({_php_str('interfaces/' + iface)}, array());\n"
+            "unset($iface['ipaddrv6'], $iface['subnetv6']);\n"
+            f"config_set_path({_php_str('interfaces/' + iface)}, $iface);\n"
+            "write_config('pfBlockerNG smoke: restore IPv6 after locality test');\n"
+            f"if (function_exists('interface_configure')) {{ interface_configure({_php_str(iface)}); }}\n"
+            "echo 'OK';"
+        )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"restore_interface_ipv6({iface}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def collect_localip(
+    vm: SmokeVM,
+    *,
+    timeout: float = 60.0,
+) -> tuple[set[str], list[str]]:
+    """Call the REAL ``pfb_collect_localip()`` on the box and return its two structures.
+
+    Returns ``(pfb_local, pfb_localsub)`` where:
+
+    * ``pfb_local``   — a :class:`set` of exact local IP strings (the keys of the
+      PHP hash; ``$pfb_local`` after the ``array_flip`` in the function).
+    * ``pfb_localsub`` — a :class:`list` of local CIDR subnet strings
+      (``$pfb_localsub``).
+
+    Both are serialized from PHP as JSON so the boundary is explicit and survives
+    any value that might contain the sentinel delimiters.  The function is called
+    via ``pfSsh.php`` so it runs in the FULLY bootstrapped pfSense + pfBlockerNG
+    environment (config loaded, all includes available).
+    """
+    snippet = (
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "list($pfb_local, $pfb_localsub) = pfb_collect_localip();\n"
+        # pfb_local is an array_flip'd hash: keys are the IPs, values are indices.
+        # json_encode a plain array of its keys so Python gets clean strings.
+        "$out_local  = array_keys($pfb_local);\n"
+        "$out_sub    = array_values($pfb_localsub);\n"
+        f"echo {_php_str(_CFG_VAL_OPEN)}"
+        " . json_encode(array('local' => $out_local, 'localsub' => $out_sub))"
+        f" . {_php_str(_CFG_VAL_CLOSE)};"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    out = result.stdout
+    start = out.find(_CFG_VAL_OPEN)
+    end = out.find(_CFG_VAL_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(
+            f"collect_localip: no delimited JSON in pfSsh.php output: "
+            f"rc={result.returncode} out={out!r} err={result.stderr!r}"
+        )
+    import json
+
+    payload = json.loads(out[start + len(_CFG_VAL_OPEN) : end])
+    pfb_local: set[str] = set(payload["local"])
+    pfb_localsub: list[str] = list(payload["localsub"])
+    return pfb_local, pfb_localsub
+
+
+def ip_in_localsub(addr: str, pfb_localsub: list[str]) -> bool:
+    """Return True iff ``addr`` falls inside any subnet in ``pfb_localsub``.
+
+    Pure Python mirror of ``pfb_local_ip()`` (``ip_in_subnet()`` in PHP).
+    Uses :mod:`ipaddress` so IPv6 normalisation (``::`` == ``::0``) is handled
+    correctly.  Only the CIDR-subnet side (``pfb_localsub``) is checked; the
+    exact-match side (``pfb_local``) is tested by simple set membership.
+    """
+    import ipaddress
+
+    try:
+        target = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    for cidr in pfb_localsub:
+        try:
+            net = ipaddress.ip_network(cidr, strict=False)
+            if target in net:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def get_lan_ipv4(vm: SmokeVM, *, timeout: float = 30.0) -> str:
+    """Return the configured IPv4 address of the LAN interface (or '' if absent).
+
+    Used by the locality smoke test to assert the IPv4 path is unaffected.
+    Reads ``interfaces/lan/ipaddr`` from config.xml — the stored address (valid
+    for static interfaces; DHCP stores 'dhcp', which is also a usable string for
+    the test's assertion that it appears in ``pfb_local``).
+    """
+    snippet = (
+        f"$iface = config_get_path({_php_str('interfaces/lan')}, array());\n"
+        f"echo {_php_str(_CFG_VAL_OPEN)}"
+        " . ($iface['ipaddr'] ?? '')"
+        f" . {_php_str(_CFG_VAL_CLOSE)};"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    out = result.stdout
+    start = out.find(_CFG_VAL_OPEN)
+    end = out.find(_CFG_VAL_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"get_lan_ipv4: no delimited value: rc={result.returncode} out={out!r}")
+    return out[start + len(_CFG_VAL_OPEN) : end].strip()
+
+
+def get_live_ipv4(vm: SmokeVM, iface: str = "lan", *, timeout: float = 30.0) -> str:
+    """Return the RUNTIME IPv4 of ``iface`` via ``get_interface_ip()`` (or '').
+
+    ``get_interface_ip()`` resolves DHCP/static/alias so it is the authoritative
+    live address even when config.xml stores 'dhcp'.
+    """
+    return _php_read_scalar(
+        vm,
+        "",
+        f"get_interface_ip({_php_str(iface)}) ?: ''",
+        timeout=timeout,
+    )

--- a/tests/smoke/test_smoke_ipv6_alerts.py
+++ b/tests/smoke/test_smoke_ipv6_alerts.py
@@ -1,0 +1,223 @@
+"""Issue #361 — live-VM smoke for pfb_collect_localip() IPv6 locality recognition.
+
+Before the fix, ``pfb_collect_localip()`` did not enumerate runtime IPv6 addresses
+for interfaces whose ``ipaddrv6`` config key stores a dynamic-mode keyword
+(``track6``, ``dhcp6``, ``slaac``, etc.) rather than a static address.  As a
+result, a local destination's IPv6 was not recognised as local and
+``pfb_daemon_filterlog()`` misidentified it as the external ``$host``, running
+GeoIP/ASN lookups on the local machine's own address.
+
+The fix adds a ``get_configured_ipv6_addresses()`` enumeration pass to
+``pfb_collect_localip()`` so the *runtime* IPv6 address is collected regardless
+of how the config keyword is stored.
+
+These tests call the REAL ``pfb_collect_localip()`` on a booted pfSense VM:
+
+* Configure a static RFC 3849 IPv6 address (``2001:db8:51:1::1/64``) on the
+  LAN interface so the address is unconditionally present at probe time.
+* Call ``collect_localip(vm)`` to obtain the ``(pfb_local, pfb_localsub)``
+  structures from the live box.
+* Assert every locality invariant — before and after — so a regression would
+  produce a red test, not a vacuous green.
+
+Test domains and IPs are RFC 3849 / RFC 5737: inert, non-routable, never
+HSTS-preloaded.
+
+These tests are DESELECTED from the default ``python -m pytest`` run.  Run via::
+
+    python -m pytest tests/smoke -m smoke --override-ini="addopts="
+
+A live VM (``smoke_vm``) and a built package (``SMOKE_PKG``) are required; both
+fixtures skip cleanly when absent.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+
+pytestmark = pytest.mark.smoke
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped deploy fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ipv6_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg once; yield the VM for the locality tests.
+
+    No DNSBL config is required — ``pfb_collect_localip()`` runs before any
+    reload and has no dependency on the DNSBL pipeline being active.  The
+    package is installed (so pfblockerng.inc is present on disk) and the VM is
+    otherwise in its default state.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.collect_host_diagnostics(smoke_vm)
+
+
+# ---------------------------------------------------------------------------
+# Local helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_ipv6_config(vm: SmokeVM, iface: str) -> dict[str, str]:
+    """Read the stored IPv6 config keys for ``iface`` from config.xml.
+
+    Returns ``{"ipaddrv6": <value-or-empty>, "subnetv6": <value-or-empty>}``
+    without writing anything to config.xml.  Used to capture the pre-test
+    state so it can be restored in the test's ``finally`` block.
+    """
+    snippet = (
+        f"$iface = config_get_path({h._php_str('interfaces/' + iface)}, array());\n"
+        f"echo {h._php_str(h._CFG_VAL_OPEN)}"
+        " . ($iface['ipaddrv6'] ?? '')"
+        f" . {h._php_str('|||')}"
+        " . ($iface['subnetv6'] ?? '')"
+        f" . {h._php_str(h._CFG_VAL_CLOSE)};"
+    )
+    result = h.php_eval(vm, snippet, timeout=30.0)
+    out = result.stdout
+    start = out.find(h._CFG_VAL_OPEN)
+    end = out.find(h._CFG_VAL_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(
+            f"_read_ipv6_config({iface}): no delimited value in output: rc={result.returncode} out={out!r}"
+        )
+    inner = out[start + len(h._CFG_VAL_OPEN) : end]
+    parts = inner.split("|||", 1)
+    return {"ipaddrv6": parts[0], "subnetv6": parts[1] if len(parts) > 1 else ""}
+
+
+# ---------------------------------------------------------------------------
+# Locality smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_collect_localip_recognises_ipv6_address_and_subnet(
+    ipv6_vm: SmokeVM,
+) -> None:
+    """Scenario: pfb_collect_localip() recognises a static IPv6 on the LAN interface.
+
+    Background:
+        The LAN interface (never the WAN — that carries the SLIRP-NAT SSH path)
+        is configured with the RFC 3849 address ``2001:db8:51:1::1/64``.
+        ``pfb_collect_localip()`` is called on the live box.
+
+    Given the LAN interface has NO static IPv6 configured (before state):
+        ``pfb_local`` does NOT contain ``2001:db8:51:1::1``.
+        ``pfb_localsub`` does NOT contain ``2001:db8:51:1::/64``.
+        ``ip_in_localsub(IPV6_LOCAL_HOST, pfb_localsub)`` returns False.
+
+    When the static IPv6 ``2001:db8:51:1::1/64`` is applied to the LAN interface:
+
+    Then (after state):
+        ``pfb_local`` CONTAINS ``2001:db8:51:1::1`` (exact-match recognised).
+        ``pfb_localsub`` CONTAINS a subnet covering ``2001:db8:51:1::/64``
+            (subnet recognised).
+        ``ip_in_localsub(IPV6_LOCAL_HOST, pfb_localsub)`` returns True — a
+            host inside the /64 is classified as local.
+        ``ip_in_localsub(IPV6_FOREIGN, pfb_localsub)`` returns False — a host
+            in a different /32 block is NOT classified as local.
+
+    And the IPv4 path is unaffected:
+        The LAN IPv4 runtime address is NOT empty AND IS present in ``pfb_local``
+            (proves the IPv6 pass did not break IPv4 enumeration).
+    """
+    vm = ipv6_vm
+    iface = h.IPV6_LOCAL_IFACE
+    addr = h.IPV6_LOCAL_ADDR
+    bits = h.IPV6_LOCAL_BITS
+    local_host = h.IPV6_LOCAL_HOST
+    foreign = h.IPV6_FOREIGN
+
+    # ------------------------------------------------------------------
+    # Save the original IPv6 config for restore in finally (read-only —
+    # no config.xml mutation at this point).
+    # ------------------------------------------------------------------
+    original_ipv6_config = _read_ipv6_config(vm, iface)
+
+    try:
+        # ------------------------------------------------------------------
+        # GIVEN: Clear any static IPv6 from the LAN interface so the
+        # before-state is clean, then read collect_localip().
+        # restore_interface_ipv6 with empty ipaddrv6 removes the keys and
+        # calls interface_configure() to remove the OS-level address.
+        # ------------------------------------------------------------------
+        h.restore_interface_ipv6(vm, iface, {"ipaddrv6": "", "subnetv6": ""}, timeout=120.0)
+
+        before_local, before_localsub = h.collect_localip(vm)
+
+        # GIVEN assertions: the target address is absent before we add it.
+        assert addr not in before_local, (
+            f"GIVEN violated: {addr!r} already in pfb_local before set_interface_ipv6 — "
+            f"cannot assert causal before/after.  pfb_local={before_local!r}"
+        )
+        assert not h.ip_in_localsub(addr, before_localsub), (
+            f"GIVEN violated: {addr!r} already in a pfb_localsub subnet — pfb_localsub={before_localsub!r}"
+        )
+        assert not h.ip_in_localsub(local_host, before_localsub), (
+            f"GIVEN violated: in-subnet host {local_host!r} already matched pfb_localsub — "
+            f"pfb_localsub={before_localsub!r}"
+        )
+
+        # ------------------------------------------------------------------
+        # WHEN: Apply the static IPv6 address on the LAN interface.
+        # set_interface_ipv6 polls until get_configured_ipv6_addresses() confirms
+        # the address is live on the OS, so probes after this call are authoritative.
+        # ------------------------------------------------------------------
+        h.set_interface_ipv6(vm, iface, addr, bits, timeout=120.0)
+
+        # WHEN: Call pfb_collect_localip() on the live box.
+        after_local, after_localsub = h.collect_localip(vm)
+
+        # ------------------------------------------------------------------
+        # THEN: Local IPv6 is recognised.
+        # ------------------------------------------------------------------
+        assert addr in after_local, (
+            f"THEN violated: {addr!r} NOT in pfb_local after set_interface_ipv6 — "
+            f"fix for issue #361 not effective.  pfb_local={after_local!r}"
+        )
+
+        # THEN: The /64 subnet is recognised.
+        assert h.ip_in_localsub(addr, after_localsub), (
+            f"THEN violated: configured address {addr!r} not matched by any "
+            f"pfb_localsub subnet.  pfb_localsub={after_localsub!r}"
+        )
+
+        # THEN: A host INSIDE the /64 is recognised as local.
+        assert h.ip_in_localsub(local_host, after_localsub), (
+            f"THEN violated: in-subnet host {local_host!r} NOT matched by pfb_localsub — "
+            f"fix for issue #361 not effective.  pfb_localsub={after_localsub!r}"
+        )
+
+        # THEN: A FOREIGN address (outside the /64) is NOT recognised as local.
+        assert not h.ip_in_localsub(foreign, after_localsub), (
+            f"THEN violated: foreign address {foreign!r} IS matched by pfb_localsub — "
+            f"over-broad subnet or wrong prefix.  pfb_localsub={after_localsub!r}"
+        )
+
+        # AND: The IPv4 path is unaffected.
+        lan_ipv4 = h.get_live_ipv4(vm, iface)
+        assert lan_ipv4, (
+            "AND violated: get_live_ipv4(lan) returned empty — the IPv6 pass may have broken IPv4 enumeration."
+        )
+        assert lan_ipv4 in after_local, (
+            f"AND violated: LAN IPv4 {lan_ipv4!r} NOT in pfb_local — "
+            f"IPv4 enumeration broken after IPv6 change.  pfb_local={after_local!r}"
+        )
+
+    finally:
+        # Always restore the original IPv6 config regardless of assertion outcome.
+        h.restore_interface_ipv6(vm, iface, original_ipv6_config, timeout=120.0)

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -562,45 +562,55 @@ def test_upstream_block_renders_cloud_icon_and_correct_group(
 # --------------------------------------------------------------------------- #
 
 
+@pytest.mark.parametrize(
+    ("direction", "src_ip", "dst_ip"),
+    [
+        # Inbound: foreign is the SRC, local is the DST. convert_ip_log() picks
+        # $fields[7] (SRC) as the external host for dir == 'in'.
+        ("in", helpers.IPV6_FOREIGN, helpers.IPV6_LOCAL_HOST),
+        # Outbound: roles swap — local is the SRC, foreign is the DST. The else
+        # branch picks $fields[8] (DST) as the external host for dir != 'in'.
+        ("out", helpers.IPV6_LOCAL_HOST, helpers.IPV6_FOREIGN),
+    ],
+)
 def test_ipv6_alert_external_host_attribution(
     webui: "WebUI",
     smoke_vm: helpers.SmokeVM,
+    direction: str,
+    src_ip: str,
+    dst_ip: str,
 ) -> None:
-    """Foreign IPv6 in SRC renders as blocked host; local IPv6 in DST does not.
+    """The foreign IPv6 renders as the blocked host; the local IPv6 never does.
 
-    Scenario: ip_block.log rendering correctly attributes external vs local IPv6.
+    Scenario: ip_block.log rendering attributes the external host by direction.
 
     Background:
-        ``pfblockerng_alerts.php`` ``convert_ip_log()`` reads ip_block.log and
-        uses the stored SRC IP (``$fields[7]``) as the external/blocked host for
-        inbound events.  The fix for issue #361 ensures pfb_daemon_filterlog()
-        correctly identifies local IPv6 before writing the log row so that:
-        - a foreign IPv6 appears as SRC (the blocked host)
-        - a local IPv6 appears as DST (the local client)
+        ``pfblockerng_alerts.php`` ``convert_ip_log()`` chooses the external host
+        by direction: for ``dir == 'in'`` the host is the SRC IP (``$fields[7]``),
+        for ``dir == 'out'`` it is the DST IP (``$fields[8]``).  The fix for issue
+        #361 makes ``pfb_daemon_filterlog()`` classify local IPv6 correctly so the
+        FOREIGN endpoint is always the host and the LOCAL endpoint is the client.
 
-        This test seeds a synthetic inbound-IPv6 row where:
-        - SRC = ``2001:db8:dead:beef::1`` (foreign — outside the LAN /64)
-        - DST = ``2001:db8:51:1::1234`` (local — inside the LAN /64)
-        - GeoIP = "US" (present in the stored row; rendered from $fields[12])
-        - direction = "in"
+        This test seeds a synthetic IPv6 row for BOTH directions (parametrized),
+        keeping the foreign address (``2001:db8:dead:beef::1``) as the external
+        endpoint in each case — SRC for inbound, DST for outbound — and the local
+        address (``2001:db8:51:1::1234``) as the internal endpoint, GeoIP "US".
+        Covering both ``dir`` branches proves the page keys on direction rather
+        than always rendering one column.
 
-        and asserts the rendered HTML reflects the correct attribution.
+    Given: the foreign threat-lookup link is ABSENT from the Alerts page before
+        the synthetic row is appended (before-state — no false pass).
 
-    Given: a synthetic inbound-IPv6 ip_block.log line with a foreign SRC and a
-        local DST is appended to ``/var/log/pfblockerng/ip_block.log``.
-
-    When: the Reports/Alerts page is GET-ted (IP Firewall tab renders ip_block.log).
+    When: the row is appended to ip_block.log and the Alerts page is GET-ted.
 
     Then (rendering-layer attribution — complements, does not duplicate, the live
-    ``pfb_collect_localip`` smoke test; ``dir`` is seeded ``in`` here, so this
-    guards ``convert_ip_log()``'s host selection + IPv6 rendering, not the
-    collect_localip fix itself):
-        (a) The foreign SRC IPv6 is rendered as the attributed external/blocked
-            host — it appears verbatim in the threat-lookup href
-            ``pfblockerng_threats.php?host=<src>`` (``$host`` = SRC for an inbound
-            event), with its GeoIP code "US" rendered in the same row.
-        (b) The local DST IPv6 is NEVER rendered as the attributed host: its
-            address must not appear as a threat-lookup ``host=`` — that exact
+    ``pfb_collect_localip`` smoke test; ``dir`` is seeded here, so this guards
+    ``convert_ip_log()``'s host selection + IPv6 rendering, not collect_localip):
+        (a) The foreign IPv6 is rendered as the attributed external/blocked host —
+            it appears verbatim in the threat-lookup href
+            ``pfblockerng_threats.php?host=<foreign>``, with GeoIP "US" in the row.
+        (b) The local IPv6 is NEVER rendered as the attributed host: its address
+            must not appear as a threat-lookup ``host=`` — that exact
             misattribution (local shown as the blocked host) is the issue #361
             regression. NB: the SRC/DST table cells wrap IPv6 in ``[...]`` and
             insert a zero-width space after every colon, so the cells must not be
@@ -611,22 +621,33 @@ def test_ipv6_alert_external_host_attribution(
     vm = smoke_vm
     ts = time.strftime("%b %e %H:%M:%S")  # e.g. "Jun  8 12:00:00"
 
-    # RFC 3849 addresses — inert, non-routable, never HSTS-preloaded.
-    foreign_src = helpers.IPV6_FOREIGN  # 2001:db8:dead:beef::1 — outside /64
-    local_dst = helpers.IPV6_LOCAL_HOST  # 2001:db8:51:1::1234   — inside /64
+    # RFC 3849 addresses — inert, non-routable, never HSTS-preloaded. The foreign
+    # address is the external host in BOTH directions; only its column moves.
+    foreign = helpers.IPV6_FOREIGN  # 2001:db8:dead:beef::1 — outside the /64
+    local = helpers.IPV6_LOCAL_HOST  # 2001:db8:51:1::1234   — inside the /64
 
     # ip_block.log IPv6 CSV format (21 fields):
     # ts,rule,real_iface,friendly_iface,action,ipv,proto_id,proto,
     # src_ip,dst_ip,src_port,dst_port,
     # dir,geoip,alias,ip_eval,feed,rhost,chost,asn,dup
+    # ip_eval is the evaluated (blocked) host = the foreign address in both cases.
     csv_line = (
         f"{ts},100,em0,WAN,block,6,58,ICMPV6,"
-        f"{foreign_src},{local_dst},,"
-        f",in,US,pfB_Deny_v6,"
-        f"{foreign_src},pfB_TestFeed_v6,Unknown,Unknown,Unknown,+\n"
+        f"{src_ip},{dst_ip},,"
+        f",{direction},US,pfB_Deny_v6,"
+        f"{foreign},pfB_TestFeed_v6,Unknown,Unknown,Unknown,+\n"
     )
 
     ip_block_log = helpers.IP_BLOCK_LOG
+
+    # convert_ip_log() renders the attributed external host's IP verbatim in the
+    # threat-lookup icon href ($alert_ip): /pfblockerng/pfblockerng_threats.php?host=<host>
+    # ($host = SRC for inbound, DST for outbound). This href carries the RAW
+    # address (colons intact) — unlike the SRC/DST cells, which wrap IPv6 in [...]
+    # and insert a zero-width space (&#8203;) after every colon. Match the href,
+    # never the mangled cell text.
+    threat_foreign = f"/pfblockerng/pfblockerng_threats.php?host={foreign}"
+    threat_local = f"/pfblockerng/pfblockerng_threats.php?host={local}"
 
     # Capture the original byte size — fail fast so cleanup cannot wipe the log.
     size_result = vm.ssh("stat", "-f", "%z", ip_block_log, timeout=15)
@@ -635,8 +656,17 @@ def test_ipv6_alert_external_host_attribution(
     )
     original_size = size_result.stdout.strip()
 
+    # GIVEN (before-state): the foreign threat link is absent before the seed, so a
+    # later 'present' assertion proves THIS row caused it (no false pass).
+    pre = webui.get(ALERTS_PAGE)
+    assert not looks_like_login_page(pre.text), "alerts page GET returned login form before mutation (session lost)"
+    assert threat_foreign not in pre.text, (
+        f"Precondition failed: foreign threat link {threat_foreign!r} already "
+        f"present before the synthetic row was seeded — cannot prove causation."
+    )
+
     try:
-        # GIVEN: append the synthetic IPv6 block line via SSH tee -a.
+        # WHEN: append the synthetic IPv6 block line via SSH tee -a.
         append_result = subprocess.run(
             vm.ssh_argv("tee", "-a", ip_block_log),
             input=csv_line,
@@ -650,45 +680,35 @@ def test_ipv6_alert_external_host_attribution(
             f"rc={append_result.returncode}, stderr={append_result.stderr!r}"
         )
 
-        # WHEN: GET the Alerts page (IP Firewall tab renders ip_block.log).
+        # WHEN: GET the Alerts page (default view renders the ip_block.log table).
         resp = webui.get(ALERTS_PAGE)
         assert not looks_like_login_page(resp.text), (
             "alerts page GET returned login form (session lost before IPv6 attribution render test)"
         )
         html_body = resp.text
 
-        # convert_ip_log() renders the attributed external host's IP verbatim in
-        # the threat-lookup icon href ($alert_ip):
-        #     /pfblockerng/pfblockerng_threats.php?host=<host>
-        # For an inbound event $host is the SRC IP. This href carries the RAW
-        # address (colons intact) — unlike the SRC/DST table cells, which wrap
-        # IPv6 in [...] and insert a zero-width space (&#8203;) after every colon.
-        # So we match on the href, never on the mangled cell text.
-        threat_foreign = f"/pfblockerng/pfblockerng_threats.php?host={foreign_src}"
-        threat_local = f"/pfblockerng/pfblockerng_threats.php?host={local_dst}"
-
-        # THEN (a): the foreign SRC is the attributed external/blocked host.
+        # THEN (a): the foreign IPv6 is the attributed external/blocked host.
         idx = html_body.find(threat_foreign)
         assert idx != -1, (
-            f"Foreign SRC IPv6 {foreign_src!r} is not rendered as the threat-lookup "
-            f"host ({threat_foreign!r} absent) — the inbound IPv6 row did not render, "
-            f"or the foreign address was not attributed as the external host."
+            f"Foreign IPv6 {foreign!r} is not rendered as the threat-lookup host "
+            f"({threat_foreign!r} absent) for dir={direction!r} — the IPv6 row did "
+            f"not render, or the foreign address was not attributed as the host."
         )
         # Its GeoIP code renders in the same row (the GeoIP cell follows the host
         # icons), proving geo attribution went to the foreign host.
         window = html_body[idx : idx + 2048]
         assert "US" in window, (
-            f"GeoIP code 'US' not found in the rendered row for {foreign_src!r} — "
+            f"GeoIP code 'US' not found in the rendered row for {foreign!r} — "
             f"the row may have rendered without GeoIP attribution."
         )
 
-        # THEN (b): the LOCAL DST is NEVER the attributed external host — the local
+        # THEN (b): the LOCAL IPv6 is NEVER the attributed external host — its
         # address must not appear as a threat-lookup host. That misattribution
         # (local rendered as the blocked host) is exactly the issue #361 regression.
         assert threat_local not in html_body, (
-            f"Local DST IPv6 {local_dst!r} is rendered as a threat-lookup host "
-            f"({threat_local!r} present) — the page attributed the LOCAL address as "
-            f"the external blocked host (issue #361 regression)."
+            f"Local IPv6 {local!r} is rendered as a threat-lookup host "
+            f"({threat_local!r} present) for dir={direction!r} — the page attributed "
+            f"the LOCAL address as the external blocked host (issue #361 regression)."
         )
 
     finally:

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -544,3 +544,163 @@ def test_upstream_block_renders_cloud_icon_and_correct_group(
             f"Failed to restore {dnsbl_log!r} to size={original_size!r}: "
             f"rc={truncate_result.returncode}, stderr={truncate_result.stderr!r}"
         )
+
+
+# --------------------------------------------------------------------------- #
+# IPv6 alert external-host attribution (issue #361): a synthetic ip_block.log
+# row with a FOREIGN IPv6 as SRC and a LOCAL IPv6 as DST must render the
+# foreign address as the blocked host (with GeoIP) and must NOT render the
+# local address as an external/blocked host.
+#
+# The display logic in convert_ip_log() is:
+#   inbound ($fields[11] == 'in') → $host = $fields[7] (SRC = external/blocked)
+#                                   $client = $fields[8] (DST = local)
+# The fix for issue #361 ensures pfb_daemon_filterlog() correctly identifies
+# local IPv6 before writing the log row, so the stored SRC/DST are authoritative.
+# We verify the RENDERING layer honours the stored values — a complementary check
+# to the smoke test that drives the PHP logic directly.
+# --------------------------------------------------------------------------- #
+
+
+def test_ipv6_alert_external_host_attribution(
+    webui: "WebUI",
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Foreign IPv6 in SRC renders as blocked host; local IPv6 in DST does not.
+
+    Scenario: ip_block.log rendering correctly attributes external vs local IPv6.
+
+    Background:
+        ``pfblockerng_alerts.php`` ``convert_ip_log()`` reads ip_block.log and
+        uses the stored SRC IP (``$fields[7]``) as the external/blocked host for
+        inbound events.  The fix for issue #361 ensures pfb_daemon_filterlog()
+        correctly identifies local IPv6 before writing the log row so that:
+        - a foreign IPv6 appears as SRC (the blocked host)
+        - a local IPv6 appears as DST (the local client)
+
+        This test seeds a synthetic inbound-IPv6 row where:
+        - SRC = ``2001:db8:dead:beef::1`` (foreign — outside the LAN /64)
+        - DST = ``2001:db8:51:1::1234`` (local — inside the LAN /64)
+        - GeoIP = "US" (present in the stored row; rendered from $fields[12])
+        - direction = "in"
+
+        and asserts the rendered HTML reflects the correct attribution.
+
+    Given: a synthetic inbound-IPv6 ip_block.log line with a foreign SRC and a
+        local DST is appended to ``/var/log/pfblockerng/ip_block.log``.
+
+    When: the Reports/Alerts page is GET-ted (IP Firewall tab renders ip_block.log).
+
+    Then (rendering-layer attribution — complements, does not duplicate, the live
+    ``pfb_collect_localip`` smoke test; ``dir`` is seeded ``in`` here, so this
+    guards ``convert_ip_log()``'s host selection + IPv6 rendering, not the
+    collect_localip fix itself):
+        (a) The foreign SRC IPv6 is rendered as the attributed external/blocked
+            host — it appears verbatim in the threat-lookup href
+            ``pfblockerng_threats.php?host=<src>`` (``$host`` = SRC for an inbound
+            event), with its GeoIP code "US" rendered in the same row.
+        (b) The local DST IPv6 is NEVER rendered as the attributed host: its
+            address must not appear as a threat-lookup ``host=`` — that exact
+            misattribution (local shown as the blocked host) is the issue #361
+            regression. NB: the SRC/DST table cells wrap IPv6 in ``[...]`` and
+            insert a zero-width space after every colon, so the cells must not be
+            substring-matched; the threat href carries the raw address and can be.
+
+    Cleanup: ip_block.log is truncated back to its pre-seed size in finally.
+    """
+    vm = smoke_vm
+    ts = time.strftime("%b %e %H:%M:%S")  # e.g. "Jun  8 12:00:00"
+
+    # RFC 3849 addresses — inert, non-routable, never HSTS-preloaded.
+    foreign_src = helpers.IPV6_FOREIGN  # 2001:db8:dead:beef::1 — outside /64
+    local_dst = helpers.IPV6_LOCAL_HOST  # 2001:db8:51:1::1234   — inside /64
+
+    # ip_block.log IPv6 CSV format (21 fields):
+    # ts,rule,real_iface,friendly_iface,action,ipv,proto_id,proto,
+    # src_ip,dst_ip,src_port,dst_port,
+    # dir,geoip,alias,ip_eval,feed,rhost,chost,asn,dup
+    csv_line = (
+        f"{ts},100,em0,WAN,block,6,58,ICMPV6,"
+        f"{foreign_src},{local_dst},,"
+        f",in,US,pfB_Deny_v6,"
+        f"{foreign_src},pfB_TestFeed_v6,Unknown,Unknown,Unknown,+\n"
+    )
+
+    ip_block_log = helpers.IP_BLOCK_LOG
+
+    # Capture the original byte size — fail fast so cleanup cannot wipe the log.
+    size_result = vm.ssh("stat", "-f", "%z", ip_block_log, timeout=15)
+    assert size_result.returncode == 0, (
+        f"Failed to stat {ip_block_log!r} before mutation: rc={size_result.returncode}, stderr={size_result.stderr!r}"
+    )
+    original_size = size_result.stdout.strip()
+
+    try:
+        # GIVEN: append the synthetic IPv6 block line via SSH tee -a.
+        append_result = subprocess.run(
+            vm.ssh_argv("tee", "-a", ip_block_log),
+            input=csv_line,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        assert append_result.returncode == 0, (
+            f"Failed to append synthetic line to {ip_block_log!r}: "
+            f"rc={append_result.returncode}, stderr={append_result.stderr!r}"
+        )
+
+        # WHEN: GET the Alerts page (IP Firewall tab renders ip_block.log).
+        resp = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(resp.text), (
+            "alerts page GET returned login form (session lost before IPv6 attribution render test)"
+        )
+        html_body = resp.text
+
+        # convert_ip_log() renders the attributed external host's IP verbatim in
+        # the threat-lookup icon href ($alert_ip):
+        #     /pfblockerng/pfblockerng_threats.php?host=<host>
+        # For an inbound event $host is the SRC IP. This href carries the RAW
+        # address (colons intact) — unlike the SRC/DST table cells, which wrap
+        # IPv6 in [...] and insert a zero-width space (&#8203;) after every colon.
+        # So we match on the href, never on the mangled cell text.
+        threat_foreign = f"/pfblockerng/pfblockerng_threats.php?host={foreign_src}"
+        threat_local = f"/pfblockerng/pfblockerng_threats.php?host={local_dst}"
+
+        # THEN (a): the foreign SRC is the attributed external/blocked host.
+        idx = html_body.find(threat_foreign)
+        assert idx != -1, (
+            f"Foreign SRC IPv6 {foreign_src!r} is not rendered as the threat-lookup "
+            f"host ({threat_foreign!r} absent) — the inbound IPv6 row did not render, "
+            f"or the foreign address was not attributed as the external host."
+        )
+        # Its GeoIP code renders in the same row (the GeoIP cell follows the host
+        # icons), proving geo attribution went to the foreign host.
+        window = html_body[idx : idx + 2048]
+        assert "US" in window, (
+            f"GeoIP code 'US' not found in the rendered row for {foreign_src!r} — "
+            f"the row may have rendered without GeoIP attribution."
+        )
+
+        # THEN (b): the LOCAL DST is NEVER the attributed external host — the local
+        # address must not appear as a threat-lookup host. That misattribution
+        # (local rendered as the blocked host) is exactly the issue #361 regression.
+        assert threat_local not in html_body, (
+            f"Local DST IPv6 {local_dst!r} is rendered as a threat-lookup host "
+            f"({threat_local!r} present) — the page attributed the LOCAL address as "
+            f"the external blocked host (issue #361 regression)."
+        )
+
+    finally:
+        # Truncate ip_block.log back to its pre-test size to remove the appended line.
+        truncate_result = subprocess.run(
+            vm.ssh_argv("/usr/bin/truncate", "-s", original_size, ip_block_log),
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        assert truncate_result.returncode == 0, (
+            f"Failed to restore {ip_block_log!r} to size={original_size!r}: "
+            f"rc={truncate_result.returncode}, stderr={truncate_result.stderr!r}"
+        )


### PR DESCRIPTION
Follow-up to #361 — adds live-VM (ADR-04) and Web-UI (ADR-14) coverage for the IPv6 Alerts/Reports external-host attribution that the off-appliance PHPUnit test (which used doubles) could not exercise.

## Context

#361 fixed `pfb_collect_localip()` so it collects the box's **runtime** IPv6 (track6/dhcp6/SLAAC), letting `pfb_daemon_filterlog()` attribute an inbound IPv6 block to the foreign source instead of the user's own IP. The unit test stubbed `get_configured_ipv6_addresses()`, so the real pfSense path was never validated. These tests close that gap on a live box.

## What's added

**1. Harness (`tests/smoke/helpers.py`)**
- `set_interface_ipv6()` / `restore_interface_ipv6()` — assign and roll back a static IPv6 on a non-WAN interface (LAN — the WAN carries the SLIRP SSH path), polling `get_configured_ipv6_addresses()` until the address is live.
- `collect_localip()` — run the real `pfb_collect_localip()` on the box via `pfSsh.php` and return `($pfb_local, $pfb_localsub)` to Python.
- `ip_in_localsub()` — pure-Python mirror of `pfb_local_ip()`; plus small IPv4 read helpers. RFC 3849 (`2001:db8::/32`) constants only.

**2. Smoke test (`tests/smoke/test_smoke_ipv6_alerts.py`, marker `smoke`)**
Runs the real `pfb_collect_localip()` on the live VM with genuine before/after:
- **Before** (no static IPv6): the address/subnet/in-/64 host are absent.
- **After** (static `2001:db8:51:1::1/64` on LAN): the address is in `$pfb_local`, the `/64` is in `$pfb_localsub`, a host inside it is local, a **foreign** IPv6 is **not** local, and the LAN IPv4 is still in `$pfb_local` (IPv4 path unaffected). Config restored in `finally`.

**3. Web-UI test (`tests/smoke/ui/test_alerts.py`, marker `ui_e2e`)**
Seeds a faithful inbound-IPv6 `ip_block.log` row (foreign src → local dst) and GETs the Alerts page. Asserts on the threat-lookup href (`pfblockerng_threats.php?host=<raw $host>`) — the un-mangled attributed external host: the **foreign** IP is the rendered host (with its GeoIP), and the **local** IP is **never** rendered as the host (the #361 misattribution). The SRC/DST table cells wrap IPv6 in `[...]` + zero-width spaces, so the href is matched rather than the cell text. This guards the rendering layer; the smoke test proves the attribution itself.

## Validation

Off-box gates green: ruff, mypy, full unit suite (1904 passed). The live-VM legs require a smoke/UI dispatch (`smoke.yml` / `ui-tests.yml`) and skip cleanly when no VM / `SMOKE_ADMIN_PASSWORD` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Tests**
  - Added an IPv6 locality smoke-test suite that validates correct recognition of local IPv6 addresses/subnets and ensures IPv4 locality enumeration remains unaffected.
  - Added a UI smoke test for IPv6 alert rendering, verifying threat-lookup link attribution for external/blocked hosts while confirming local IPv6 addresses are never misattributed.
  - Expanded UI coverage to run the attribution checks for both inbound and outbound alert directions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->