### PR TITLE
adr-35/36/37: managed firewall objects framework + DNS-redirect + DoT/DoQ block ADRs

### DIFF
--- a/.ADRs/ADR_35_Managed_Firewall_Objects/01_Pin_Current_Behaviour.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/01_Pin_Current_Behaviour.txt
@@ -1,0 +1,124 @@
+================================================================================
+PHASE 1 PROMPT — Prep: pin current VIP/NAT ownership + teardown behaviour (oracle)
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md   (read §1, §2, §2.2, §6 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/35-managed-firewall-objects (off devel; create off
+the latest devel if absent). Phase 1 is ORACLE-ONLY: add PHPUnit golden tests that pin today's
+behaviour; change NO production code. One commit, push directly (open a PR only if the direct
+push is rejected).
+
+WHY THIS PHASE EXISTS
+Phases 2 and 3 refactor the VIP + DNSBL-NAT call sites. If a behaviour changes during the
+refactor, the tests written here catch it. Writing the oracle FIRST — before any production
+change — is the only way to know the refactor is safe. These tests are the contract; the refactor
+must not break them.
+
+REQUIRED READING
+- .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md — full document; §1 (context + markers), §2.2
+  (the contract to pin), §6 Phase 1 scope.
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc:
+    - Constants PFB_AUTO_VIP_DESCR_V4 = 'pfB_AUTO_VIP_v4' and
+      PFB_AUTO_VIP_DESCR_V6 = 'pfB_AUTO_VIP_v6'  (line ~315)
+    - pfb_find_marked_vip()  (line ~1121) — marker-only find; returns the vip array or FALSE
+    - pfb_manage_dnsbl_vip()  (line ~1178) — create idempotency + disable removal; the
+      double-guard: marker AND IP stored in pfb_dnsvip4/pfb_dnsvip6 must both match for removal
+    - pfb_create_dnsbl()  (line ~3775) — NAT add/strip; descr written as
+      'pfB DNSBL - DO NOT EDIT' (line ~3822); detection via
+      strpos($descr, 'pfB DNSBL') !== FALSE  (line ~3798)
+    - pfblockerng_php_pre_deinstall_command()  (line ~14423) — calls sync_package_pfblockerng()
+      then pfb_remove_config_settings() (line ~14512); no independent marker sweep today
+- src/usr/local/pkg/pfblockerng/pfblockerng_install.inc:48 — legacy 'pfB DNSBL' VIP descr
+  migration to the marker on upgrade
+- tests/php/ — existing PHPUnit tests for style + bootstrap pattern
+- tests/php/bootstrap.php and tests/php/pfsense_doubles.php — how pfSense functions are doubled
+- CLAUDE.md — PHP standards (tabs, PHP 8.3, uppercase TRUE/FALSE), test-coverage mandate (branch
+  coverage, before/after, BDD style for complex flows)
+
+ACTION PLAN (ordered — tests ONLY, no production change)
+1. Read pfb_find_marked_vip() and pfb_manage_dnsbl_vip() carefully. Understand what config.xml
+   shape they consume: virtualip/vip[] each has {descr, subnet, mode, ...}. The find checks
+   descr against PFB_AUTO_VIP_DESCR_V4/V6. The disable branch also checks subnet against the IP
+   in pfb_dnsvip4/pfb_dnsvip6 (the double-guard).
+2. Read pfb_create_dnsbl()'s NAT block. Understand: it reads nat/rule[], removes any with
+   strpos($descr, 'pfB DNSBL') !== FALSE on disable, and adds a new entry with
+   'pfB DNSBL - DO NOT EDIT' on enable.
+3. Add tests/php/FwobjCurrentBehaviourTest.php (new file; class FwobjCurrentBehaviourTest).
+   Cover all branches — each test asserts the before-state, then the after-state:
+
+   VIP tests (drive pfb_find_marked_vip + pfb_manage_dnsbl_vip via config fixtures):
+   a. testVipFindByMarkerV4 — fixture has one VIP with descr=PFB_AUTO_VIP_DESCR_V4 and one
+      unmarked user VIP; find returns the marked row and only that row.
+   b. testVipFindByMarkerV6 — same for PFB_AUTO_VIP_DESCR_V6.
+   c. testVipFindReturnsNullWhenAbsent — no marked VIP present → find returns FALSE.
+   d. testVipCreateIsIdempotent — call manage('enabled') twice with a marked VIP already present;
+      assert exactly one VIP entry after (no duplicate created). Assert before: one VIP. Assert
+      after: still one VIP.
+   e. testVipDisableRemovesMarkedVipWithMatchingIp — fixture has marked VIP + matching pfb_dnsvip4
+      IP; call manage('disabled'); assert the marked VIP is gone. Assert before: present.
+   f. testVipDisableDoesNotRemoveVipWithNonMatchingIp — the DOUBLE-GUARD: fixture has a marked
+      VIP but pfb_dnsvip4 holds a DIFFERENT IP; call manage('disabled'); assert the VIP remains
+      (double-guard prevents removal). Assert before: present.
+   g. testVipDisableNeverTouchesUserVip — fixture has a marked VIP (matching IP) plus a sibling
+      user VIP (no pfBlockerNG marker); call manage('disabled'); assert user VIP survives.
+      Assert before: both present.
+
+   NAT tests (drive pfb_create_dnsbl() NAT section via config fixtures):
+   h. testNatAddWritesPfbDnslDescr — call create_dnsbl(mode=enabled/create); assert new nat/rule
+      has descr='pfB DNSBL - DO NOT EDIT'.
+   i. testNatStripsOnDisable — fixture has nat/rule with descr='pfB DNSBL - DO NOT EDIT'; call
+      with mode=disabled; assert that rule is gone. Assert before: present.
+   j. testNatStripsLegacyPfbDnsblPrefix — fixture has nat/rule with descr='pfB DNSBL' (legacy,
+      no ' - DO NOT EDIT' suffix); strpos detects it; call with mode=disabled; assert removed.
+      Assert before: present.
+   k. testNatNeverTouchesUserRule — fixture has pfB DNSBL NAT rule plus a sibling user nat/rule
+      (descr='My custom rule'); call with mode=disabled; assert user rule survives.
+
+4. If pfb_manage_dnsbl_vip() or pfb_create_dnsbl() call pfSense functions not yet doubled
+   (e.g. config_get_path, config_set_path, write_config, return_gateways_array, get_interface_ip),
+   add faithful no-op doubles to tests/php/pfsense_doubles.php (+ empty shim if needed).
+   Do NOT stub complex pfSense runtime behaviour — keep doubles minimal and correct for the paths
+   under test.
+5. Run vendor/bin/phpunit — all new tests green.
+
+CONSTRAINTS
+- NO production code changes — tests only.
+- PHP tabs; PHP 8.3; uppercase TRUE/FALSE (ADR-28); no die()/exit().
+- These are pfSense-core sections (foreign key exclusion list, ADR-29) — direct config_*_path
+  use in production code is correct and must NOT be flagged; the test fixtures simulate the
+  config array directly, not via PfbConfig.
+- The RequireConfigGateway sniff is scoped to src/; tests/ is out of scope — no sniff concern
+  for the test file.
+- Each test must assert the BEFORE state before acting; no false passes.
+- Branch coverage: every conditional branch in the functions under test must be exercised by at
+  least one test case.
+
+VERIFICATION (must all pass before the phase is done)
+- vendor/bin/phpunit -> green (all new FwobjCurrentBehaviourTest cases pass)
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc (no syntax error — file untouched)
+- PHPStan (vendor/bin/phpstan analyse) -> no new errors
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> green (no src/ change, so trivially green)
+- python -m pytest -> green (Python suite unaffected)
+- Diff-read: only tests/php/FwobjCurrentBehaviourTest.php (and any doubles additions) — zero
+  production code changed
+
+EXPECTED RESULT
+A comprehensive oracle test suite pinning VIP find/create/disable (including the double-guard
+and user-row survival) and DNSBL-NAT add/strip (including legacy prefix and user-row survival).
+All green against the unmodified pfblockerng.inc. No behaviour change.
+
+COMMIT (single)
+    pfblockerng: pin VIP/NAT ownership + teardown golden tests (ADR-35 P1)
+Push directly to adr/35-managed-firewall-objects; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/01_Results.txt (plain .txt)
+Record:
+- The test file path and class name.
+- The exact test method names and what each pins (one line each).
+- Which pfSense doubles were added to pfsense_doubles.php and why.
+- The config.xml fixture shapes the tests use (virtualip/vip[] fields, nat/rule[] fields).
+- Verification output: phpunit pass count, phpstan clean, phpcs clean, pytest count.
+- Any surprises in the current production behaviour observed while writing the tests.
+- Go-ahead for Phase 2.

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/02_Fwobj_Layer.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/02_Fwobj_Layer.txt
@@ -1,0 +1,183 @@
+================================================================================
+PHASE 2 PROMPT — Extract the ownership/marker layer (pfblockerng_fwobj.inc)
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md   (read §1, §2, §2.1, §2.2, §4, §6 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/35-managed-firewall-objects (off devel). Phase 2
+creates the new ownership/marker layer as a pure include; it does NOT yet retrofit the existing
+call sites (that is Phase 3). One commit, push directly (open a PR only if the direct push is
+rejected).
+
+WHY THIS PHASE EXISTS
+The layer must exist and be independently unit-tested before the Phase 3 retrofit touches any
+live call site. Extracting and pinning the pure helpers first means Phase 3 can wire them in
+and immediately verify correctness by re-running both this phase's tests and the Phase 1 golden
+suite.
+
+REQUIRED READING
+FIRST, read the prior phase's handoff:
+.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/01_Results.txt — it must confirm: the oracle
+test suite is green, the fixture shapes for virtualip/vip[] and nat/rule[], the pfSense doubles
+added, and the go-ahead for Phase 2. If it is missing, the previous phase is not complete;
+STOP and report.
+
+Then read:
+- .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md — §2.1 (per-area decision table), §2.2
+  (semantics contract), §4 (requirements: the exact function signatures required).
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc:
+    - PFB_AUTO_VIP_DESCR_V4 = 'pfB_AUTO_VIP_v4'  (line ~315)
+    - PFB_AUTO_VIP_DESCR_V6 = 'pfB_AUTO_VIP_v6'  (line ~315)
+    - pfb_find_marked_vip()  (line ~1121) — to understand the find pattern being generalised
+    - pfb_create_dnsbl() NAT detection strpos($descr, 'pfB DNSBL') !== FALSE  (line ~3798)
+    - pfb_firewall_rule() pfB_ prefix separation  (line ~13709)
+- tests/php/FwobjCurrentBehaviourTest.php (written in Phase 1) — the fixture shapes
+- tests/php/ existing tests — style reference
+- CLAUDE.md — PHP standards (tabs, PHP 8.3, uppercase TRUE/FALSE, no die()/exit()), ADR-28
+  (enums/bools, storage freeze), ADR-29 (foreign sections use direct config_*_path — do NOT
+  use PfbConfig for virtualip/vip, nat/rule, filter/rule; do NOT register new fields)
+
+ACTION PLAN
+1. Create src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc (new file).
+   The file contains ONLY pure functions and the recognised-marker constants (no shell, no
+   write_config, no require_once of pfSense runtime files — the caller flushes):
+
+   a. Recognised-marker constants (in addition to the existing PFB_AUTO_VIP_DESCR_* already in
+      pfblockerng.inc — do NOT redefine those; reference them or define complementary ones):
+        PFB_FWOBJ_NAT_DESCR      = 'pfB DNSBL - DO NOT EDIT'
+        PFB_FWOBJ_NAT_LEGACY_PFX = 'pfB DNSBL'   // the strpos prefix for legacy detection
+        PFB_FWOBJ_FILTER_PFX     = 'pfB_'         // the filter-rule prefix already in use
+
+   b. pfb_fwobj_is_owned(string $descr): bool
+      Returns TRUE iff $descr indicates pfBlockerNG ownership. Recognises the UNION of:
+        - New prefix: str_starts_with($descr, 'pfB_')
+        - Legacy VIP markers: $descr === 'pfB_AUTO_VIP_v4' OR $descr === 'pfB_AUTO_VIP_v6'
+        - Legacy NAT markers: str_contains($descr, 'pfB DNSBL')  (covers both the ' - DO NOT
+          EDIT' form and the bare 'pfB DNSBL' legacy form in one strpos-equivalent call)
+      NOTE: 'pfB_AUTO_VIP_v4' already starts with 'pfB_', so the new prefix subsumes the VIP
+      markers — but list them explicitly in a comment for clarity. A descr that is empty or
+      belongs to a user object ('My rule', 'WAN', etc.) returns FALSE.
+
+   c. pfb_fwobj_find(string $section, string $marker, ?callable $guard = NULL): array|false
+      Reads config_get_path($section, []) — an array of rows — and returns the FIRST row whose
+      $row['descr'] satisfies pfb_fwobj_is_owned() AND whose descr matches $marker specifically
+      (exact string equality for legacy markers; or str_starts_with for a pfB_ prefix marker).
+      If $guard is provided, also calls $guard($row) — returns TRUE to accept, FALSE to skip.
+      Returns the matching row array, or FALSE if not found.
+      $section is the config path string, e.g. 'virtualip/vip', 'nat/rule', 'filter/rule'.
+
+   d. pfb_fwobj_remove(string $section, string $marker, ?callable $guard = NULL): bool
+      Reads config_get_path($section, []), filters OUT every row where descr matches $marker
+      (via pfb_fwobj_is_owned() + marker match) AND the optional $guard passes, then writes the
+      filtered array back via config_set_path($section, $filtered). Returns TRUE if at least one
+      row was removed, FALSE if nothing matched (no write, no spurious write_config call —
+      caller decides when to flush).
+      IMPORTANT: a row that pfb_fwobj_is_owned() returns FALSE for is NEVER removed regardless
+      of $marker — this is the user-safety invariant.
+
+   e. pfb_fwobj_sweep(array $sections): bool
+      Iterates each section in $sections (array of config path strings). For each, reads all
+      rows; removes any row where pfb_fwobj_is_owned($row['descr']) is TRUE. Returns TRUE if
+      anything was removed. Idempotent: if no owned rows remain, no write_config is called and
+      FALSE is returned. This is the deinstall/disable primitive that closes the orphan gap.
+
+   f. pfb_fwobj_register(array $spec): void
+      Registers a firewall-object spec into the internal $registry (a static variable).
+      $spec shape: ['type' => 'vip'|'nat'|'filter', 'section' => string, 'marker' => string,
+      'builder' => callable, 'guard' => callable|NULL].
+      Stores in $registry keyed by $spec['marker']. Does NOT immediately create anything.
+
+   g. pfb_fwobj_reconcile(string $marker): void
+      Finds the registration for $marker, calls pfb_fwobj_find() with it; if not found, calls
+      $spec['builder']() to create the object and config_set_path to insert it. Idempotent.
+
+2. Wire the include: add require_once for pfblockerng_fwobj.inc in pfblockerng.inc near the
+   top where other sibling includes are already required (check the existing pattern — likely
+   near pfblockerng_extra.inc). Do NOT add it in a way that changes test bootstrap ordering.
+
+3. Add tests/php/FwobjLayerTest.php (new file; class FwobjLayerTest). Tests ONLY the new
+   pfblockerng_fwobj.inc pure functions — do NOT call pfb_manage_dnsbl_vip or pfb_create_dnsbl
+   here (those are in Phase 1's oracle). Cover all branches:
+
+   is_owned truth table (one assertion per input class):
+   a. testIsOwnedNewPfbPrefix — 'pfB_MyRule' -> TRUE
+   b. testIsOwnedVipV4Marker — 'pfB_AUTO_VIP_v4' -> TRUE (already pfB_ prefix; also VIP marker)
+   c. testIsOwnedVipV6Marker — 'pfB_AUTO_VIP_v6' -> TRUE
+   d. testIsOwnedNatFullDescr — 'pfB DNSBL - DO NOT EDIT' -> TRUE
+   e. testIsOwnedNatLegacyPrefix — 'pfB DNSBL' -> TRUE
+   f. testIsOwnedNatLegacyVariant — 'pfB DNSBL Redirect' -> TRUE (contains 'pfB DNSBL')
+   g. testIsOwnedReturnsFalseForUserDescr — 'My custom rule' -> FALSE
+   h. testIsOwnedReturnsFalseForEmpty — '' -> FALSE
+   i. testIsOwnedReturnsFalseForPartialMatch — 'pfB' -> FALSE (not 'pfB_' or 'pfB DNSBL')
+
+   find/remove with and without guard:
+   j. testFindReturnsMatchedRow — fixture: two rows, one with marker descr, one user row;
+      find returns the marked row. Assert before: two rows present.
+   k. testFindReturnsFalseWhenAbsent — no owned row; find returns FALSE.
+   l. testFindWithGuardSkipsNonMatchingGuard — two rows with same marker but different subnet;
+      guard accepts only one subnet; find returns correct row.
+   m. testRemoveDeletesOwnedRow — fixture: one owned row + one user row; remove deletes owned,
+      user survives. Assert before: both present. Assert after: only user row remains.
+   n. testRemoveReturnsFalseWhenNothingMatches — no owned row; remove returns FALSE, no
+      write_config called.
+   o. testRemoveNeverTouchesUserRow — fixture: user row only (no pfBlockerNG marker); remove
+      returns FALSE, user row untouched.
+   p. testRemoveWithGuard — two owned rows with same marker, different subnet guard; remove with
+      guard removes only the matching subnet row.
+
+   sweep:
+   q. testSweepRemovesAllOwnedRows — fixture: two different sections each with owned rows +
+      user rows; sweep removes all owned across both sections, user rows survive.
+   r. testSweepIsNoopOnCleanConfig — empty config; sweep returns FALSE, no write called.
+   s. testSweepIsIdempotent — sweep twice; second call returns FALSE.
+
+   register/reconcile:
+   t. testRegisterAndReconcileCreatesWhenAbsent — register a spec with a builder; reconcile
+      calls the builder since the object is absent; assert object created in config.
+   u. testReconcileIsIdempotentWhenPresent — object already in config; reconcile does NOT call
+      builder again.
+
+4. Run vendor/bin/phpunit — Phase 1 suite AND new FwobjLayerTest both green.
+
+CONSTRAINTS
+- PHP tabs; PHP 8.3; uppercase TRUE/FALSE (ADR-28).
+- pfblockerng_fwobj.inc: NO die()/exit(), NO shell/exec, NO write_config inside helpers —
+  write_config is always the caller's responsibility (mirrors PfbConfig contract).
+- The sections handled (virtualip/vip, nat/rule, filter/rule) are pfSense-core foreign sections
+  (ADR-29 exclusion list) — direct config_get_path/config_set_path is correct here; the
+  RequireConfigGateway sniff does NOT flag pfSense-core sections.
+- Do NOT add pfblockerng_fwobj.inc to pfblockerng.xml's pkg-plist yet — Phase 4 handles wiring.
+  DO add it to src/usr/local/pkg/pfblockerng/ so it ships with the package.
+- Do NOT retrofit pfb_manage_dnsbl_vip or pfb_create_dnsbl yet — Phase 3.
+- Phase 1 oracle tests must still pass green (behaviour untouched).
+
+VERIFICATION (must all pass before the phase is done)
+- vendor/bin/phpunit -> green (Phase 1 FwobjCurrentBehaviourTest AND new FwobjLayerTest)
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc -> no syntax errors
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc -> no syntax errors (require_once added)
+- PHPStan (vendor/bin/phpstan analyse) -> no new errors
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> green (PFBL-01 + ADR-28 + ADR-29 sniffs)
+- python -m pytest -> green
+- Diff-read: new pfblockerng_fwobj.inc; one require_once line added to pfblockerng.inc;
+  new tests/php/FwobjLayerTest.php; no other production file changed
+
+EXPECTED RESULT
+A standalone, pure pfblockerng_fwobj.inc with all five functions fully tested (is_owned truth
+table, find/remove/sweep with and without guard, register/reconcile). Phase 1 oracle still
+green. No behaviour change to existing code paths.
+
+COMMIT (single)
+    pfblockerng: add pfblockerng_fwobj.inc ownership/marker layer (ADR-35 P2)
+Push directly to adr/35-managed-firewall-objects; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/02_Results.txt (plain .txt)
+Record:
+- The exact function signatures in pfblockerng_fwobj.inc (name, params, return types).
+- The constant definitions (PFB_FWOBJ_NAT_DESCR, PFB_FWOBJ_NAT_LEGACY_PFX, PFB_FWOBJ_FILTER_PFX).
+- The require_once line added to pfblockerng.inc (file + surrounding context).
+- Test method names in FwobjLayerTest and what each covers.
+- Verification output: phpunit pass counts (Phase1 + Phase2), phpstan clean, phpcs clean.
+- Any design decisions made during implementation (e.g. how $marker matching works for
+  prefix vs exact strings, how $registry is stored).
+- Go-ahead for Phase 3.

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/03_Retrofit_Vip_Nat.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/03_Retrofit_Vip_Nat.txt
@@ -1,0 +1,127 @@
+================================================================================
+PHASE 3 PROMPT — Retrofit VIP + NAT onto the shared layer (behaviour-preserving)
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md   (read §1, §2.1, §2.2, §6 Phase 3 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/35-managed-firewall-objects (off devel). Phase 3
+rewires the existing VIP + DNSBL-NAT call sites to use the shared pfb_fwobj_find/remove helpers.
+Observable behaviour must be IDENTICAL — the Phase 1 golden suite is the gate. One commit, push
+directly (open a PR only if the direct push is rejected).
+
+WHY THIS PHASE EXISTS
+The shared layer exists (Phase 2) and is proven correct in isolation. Now the existing ad-hoc
+VIP and NAT code must call it — so the per-section marker logic is in one place and the Phase 4
+sweep is meaningful. The constraint is absolute: the Phase 1 oracle must stay green. If it
+doesn't, the retrofit changed behaviour and must be corrected before proceeding.
+
+REQUIRED READING
+FIRST, read the prior phase's handoff:
+.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/02_Results.txt — it must confirm: the exact
+function signatures in pfblockerng_fwobj.inc, the constant names, how $marker matching works
+for prefix vs exact string, and the go-ahead for Phase 3. If it is missing, Phase 2 is not
+complete; STOP and report.
+
+Then read:
+- .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md — §2.1 (per-area decision), §2.2 (no persisted
+  marker change; identical idempotency; double-guard preserved; user objects inviolable).
+- .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/01_Results.txt — the Phase 1 oracle fixture
+  shapes; what the tests drive and assert.
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc:
+    - pfb_find_marked_vip()  (line ~1121) — the function to retrofit; it currently reads
+      config_get_path('virtualip/vip', []) and loops looking for descr matching
+      PFB_AUTO_VIP_DESCR_V4/V6. Replace the loop body with a call to pfb_fwobj_find().
+    - pfb_manage_dnsbl_vip()  (line ~1178) — the create + disable logic. On disable it calls
+      pfb_find_marked_vip() then checks the IP double-guard before removing. The double-guard
+      MUST be preserved exactly — pass it as the $guard callable to pfb_fwobj_remove().
+    - pfb_create_dnsbl()  (line ~3775) — the NAT block. Retrofit the remove-on-disable path
+      (the strpos loop) to call pfb_fwobj_remove() with the 'pfB DNSBL' marker. The add-on-
+      enable path writes the entry with 'pfB DNSBL - DO NOT EDIT' — no change to what is
+      written; only the removal detection uses the shared helper.
+- src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc (from Phase 2) — the helpers to call.
+- tests/php/FwobjCurrentBehaviourTest.php (Phase 1 oracle) — must stay green after this phase.
+- CLAUDE.md — ADR-28 (storage freeze: no persisted string changes), PHP standards.
+
+ACTION PLAN
+1. Retrofit pfb_find_marked_vip():
+   - Replace the manual loop over config_get_path('virtualip/vip', []) with a call to
+     pfb_fwobj_find('virtualip/vip', PFB_AUTO_VIP_DESCR_V4) (for v4) or PFB_AUTO_VIP_DESCR_V6
+     (for v6), depending on the address family context the caller passes.
+   - The function's return contract is unchanged: returns the matching row array, or FALSE.
+   - Verify: testVipFindByMarkerV4, testVipFindByMarkerV6, testVipFindReturnsNullWhenAbsent
+     all still pass.
+
+2. Retrofit pfb_manage_dnsbl_vip() disable branch:
+   - The current code calls pfb_find_marked_vip() then manually checks if the row's subnet
+     matches pfb_dnsvip4/pfb_dnsvip6 (the double-guard). Preserve this logic exactly but
+     express it as the $guard callable passed to pfb_fwobj_remove():
+       $guard = function($row) use ($stored_ip) {
+           return isset($row['subnet']) && $row['subnet'] === $stored_ip;
+       };
+       pfb_fwobj_remove('virtualip/vip', PFB_AUTO_VIP_DESCR_V4, $guard);
+   - CRITICAL: the double-guard must behave identically to today — a marked VIP with a
+     non-matching IP must NOT be removed (testVipDisableDoesNotRemoveVipWithNonMatchingIp).
+   - The create (enabled) branch of pfb_manage_dnsbl_vip() calls pfb_find_marked_vip() and
+     creates the VIP if absent. After step 1, this already benefits from the shared find. No
+     further change needed to the create branch.
+
+3. Retrofit pfb_create_dnsbl() NAT removal:
+   - The current code iterates nat/rule[], removing rows where
+     strpos($descr, 'pfB DNSBL') !== FALSE. Replace this loop with:
+       pfb_fwobj_remove('nat/rule', PFB_FWOBJ_NAT_LEGACY_PFX);
+     (The Phase 2 handoff confirms how pfb_fwobj_remove handles the 'pfB DNSBL' prefix marker.)
+   - The add-on-enable path is NOT changed — it still writes descr='pfB DNSBL - DO NOT EDIT'.
+   - Verify: testNatStripsOnDisable, testNatStripsLegacyPfbDnsblPrefix,
+     testNatNeverTouchesUserRule all still pass.
+
+4. Run vendor/bin/phpunit. The COMPLETE test suite (Phase 1 + Phase 2) must be green. If any
+   Phase 1 test fails, the retrofit changed behaviour — fix until all pass, do NOT relax the
+   tests.
+
+5. Diff-read the changes before committing:
+   - Only pfb_find_marked_vip(), pfb_manage_dnsbl_vip() disable branch, and the NAT removal
+     loop in pfb_create_dnsbl() should change.
+   - No new constants written to config.xml; no persisted descr string changed.
+   - No new helpers added (those are in pfblockerng_fwobj.inc, already committed in Phase 2).
+
+CONSTRAINTS
+- PHP tabs; PHP 8.3; uppercase TRUE/FALSE (ADR-28).
+- NO persisted marker/string changes. The descr values written to config.xml are identical
+  before and after. (Storage freeze — ADR-28 §2.2.)
+- The double-guard for VIP removal MUST be preserved exactly.
+- The filter-rule side (pfb_firewall_rule, pfb_ prefix rebuild) is left AS-IS — §2.3 out of
+  scope. Do not touch it.
+- No new test methods added to FwobjCurrentBehaviourTest — it is a golden oracle and must not
+  be modified (only read to confirm it stays green).
+- PFBL-01 sniff: pfb_fwobj_find/remove are pure helpers in pfblockerng_fwobj.inc, not in
+  pfblockerng.inc's scoped functions — no new exec-family calls introduced; sniff stays green.
+
+VERIFICATION (must all pass before the phase is done)
+- vendor/bin/phpunit -> green — ALL tests: Phase 1 FwobjCurrentBehaviourTest (unchanged oracle)
+  AND Phase 2 FwobjLayerTest
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc -> no syntax errors
+- PHPStan (vendor/bin/phpstan analyse) -> no new errors
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> green (PFBL-01 + ADR-28 + ADR-29 sniffs)
+- python -m pytest -> green
+- Diff-read: changes in pfblockerng.inc confined to pfb_find_marked_vip(),
+  pfb_manage_dnsbl_vip() disable branch, pfb_create_dnsbl() NAT removal loop only
+
+EXPECTED RESULT
+pfb_find_marked_vip(), pfb_manage_dnsbl_vip(), and pfb_create_dnsbl() NAT removal all route
+through pfb_fwobj_find/remove. The Phase 1 golden suite passes unchanged — behaviour provably
+identical. No persisted marker string changed.
+
+COMMIT (single)
+    pfblockerng: retrofit VIP + NAT teardown onto fwobj layer (ADR-35 P3)
+Push directly to adr/35-managed-firewall-objects; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/03_Results.txt (plain .txt)
+Record:
+- The exact lines changed in pfblockerng.inc for each of the three functions (line number
+  ranges before and after, and what was replaced with what).
+- The $guard closure used for the VIP double-guard (exact code or equivalent).
+- The marker string passed to pfb_fwobj_remove for the NAT removal.
+- Confirmation that Phase 1 oracle tests pass unchanged.
+- Verification output: phpunit total pass count (Phase 1 + Phase 2), phpstan clean, phpcs clean.
+- Go-ahead for Phase 4.

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/04_Sweep_And_Seam.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/04_Sweep_And_Seam.txt
@@ -1,0 +1,162 @@
+================================================================================
+PHASE 4 PROMPT — Deinstall + disable marker sweep + registration seam
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md   (read §1, §2.1, §2.2, §4, §6 Phase 4 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/35-managed-firewall-objects (off devel). Phase 4
+wires pfb_fwobj_sweep() into the deinstall and disable paths, and demonstrates the registration
+seam by expressing the VIP + DNSBL NAT as the first two registrations. One commit, push directly
+(open a PR only if the direct push is rejected).
+
+WHY THIS PHASE EXISTS
+The marker sweep in pfblockerng_fwobj.inc (Phase 2) is the primitive that closes the orphan gap
+identified in ADR-35 §1. Without this wiring, the sweep exists as dead code. This phase threads
+it into the two teardown paths (deinstall + disable) and proves the orphan scenario with a test —
+so the gap is demonstrably closed, not merely hoped-closed. The registration seam is demonstrated
+here so ADR-36/37 have a working pattern to follow.
+
+REQUIRED READING
+FIRST, read the prior phase's handoff:
+.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/03_Results.txt — it must confirm: the VIP +
+NAT retrofit is green, the Phase 1 oracle is still passing, and the go-ahead for Phase 4. If
+it is missing, Phase 3 is not complete; STOP and report.
+
+Then read:
+- .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md — §2.1 (deinstall sweep + registration seam
+  decisions), §2.2 (orphan teardown + idempotent + no-op-on-empty contract), §4 (DoD
+  requirements for sweep and seam).
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc:
+    - pfblockerng_php_pre_deinstall_command()  (line ~14423) — the deinstall entry point wired
+      via pfblockerng.xml. It currently calls sync_package_pfblockerng() then
+      pfb_remove_config_settings(). The sweep must be inserted BETWEEN these two calls.
+    - pfb_remove_config_settings()  (line ~14512) — bulk-deletes installedpackages/pfblockerng*.
+      Do NOT change this function. The sweep runs before it so owned firewall objects are cleaned
+      before the config reference data that identifies them is gone.
+    - The disable path inside sync_package_pfblockerng() or pfb_manage_dnsbl_vip('disabled') —
+      identify where the sweep should also run on disable (so a half-written state converges).
+- src/usr/local/pkg/pfblockerng/pfblockerng_install.inc — check whether the deinstall hook is
+  also wired here or only via pfblockerng.xml.
+- src/usr/local/pkg/pfblockerng/pfblockerng.xml — locate <custom_php_pre_deinstall_command>
+  to confirm pfblockerng_php_pre_deinstall_command() is the sole deinstall hook.
+- src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc (Phases 2–3) — pfb_fwobj_sweep(),
+  pfb_fwobj_register(), pfb_fwobj_reconcile().
+- CLAUDE.md — PHP standards, ADR-28 (storage freeze), ADR-29 (foreign sections = direct
+  config_*_path; do NOT use PfbConfig; do NOT register new fields in pfb_cfg_registry).
+
+ACTION PLAN
+1. Wire pfb_fwobj_sweep() into the deinstall path:
+   In pfblockerng_php_pre_deinstall_command(), after sync_package_pfblockerng() and BEFORE
+   pfb_remove_config_settings(), add:
+       pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule']);
+   If sweep returns TRUE (something was swept), call write_config() to persist the removal.
+   If sweep returns FALSE (nothing to sweep), do NOT call write_config() — idempotent, no
+   spurious write.
+
+2. Wire pfb_fwobj_sweep() into the disable path:
+   Identify the call site where disable teardown removes VIP + NAT (inside pfb_manage_dnsbl_vip
+   or sync_package_pfblockerng with mode='disabled'). After the existing removal calls, add a
+   defensive sweep on the same sections as step 1. This ensures a half-written state (e.g. VIP
+   reference cleared but VIP entry not yet removed) still converges on disable.
+
+3. Express VIP + DNSBL NAT as the first two registrations:
+   Near the top of the deinstall + disable path (or in a dedicated init function called from
+   pfblockerng_php_pre_deinstall_command and the disable path), call pfb_fwobj_register() for:
+     a. VIP registration:
+          pfb_fwobj_register([
+              'type'    => 'vip',
+              'section' => 'virtualip/vip',
+              'marker'  => PFB_AUTO_VIP_DESCR_V4,
+              'builder' => 'pfb_manage_dnsbl_vip',  // or a closure that calls it
+              'guard'   => NULL,  // guard is applied at reconcile time via the stored IP
+          ]);
+        Register V6 similarly with PFB_AUTO_VIP_DESCR_V6.
+     b. NAT registration:
+          pfb_fwobj_register([
+              'type'    => 'nat',
+              'section' => 'nat/rule',
+              'marker'  => PFB_FWOBJ_NAT_LEGACY_PFX,
+              'builder' => NULL,  // NAT is managed by pfb_create_dnsbl; registration proves seam
+              'guard'   => NULL,
+          ]);
+   The registration seam is demonstrated — these specs are what ADR-36/37 will mirror.
+
+4. Update pfblockerng.xml and/or pfblockerng_install.inc pkg-plist to include
+   pfblockerng_fwobj.inc in the installed file list, so it ships with the package. Check how
+   other sibling includes (pfblockerng_extra.inc, pfb_unbound_include.inc) are listed; follow
+   the same pattern.
+
+5. Add tests/php/FwobjSweepSeamTest.php (new file; class FwobjSweepSeamTest). Cover:
+
+   Orphan teardown:
+   a. testSweepRemovesOrphanVip — Scenario: a VIP with descr='pfB_AUTO_VIP_v4' exists in
+      virtualip/vip, but pfb_dnsvip4 reference is cleared (empty). The normal double-guard
+      would skip it. pfb_fwobj_sweep(['virtualip/vip']) MUST still remove it (sweep uses
+      marker only, not the double-guard). Assert before: orphan VIP present. Assert after: gone.
+   b. testSweepRemovesOrphanNat — same pattern: nat/rule with 'pfB DNSBL - DO NOT EDIT' descr
+      survives after pfb_create_dnsbl teardown (simulate by not calling it); pfb_fwobj_sweep
+      removes it. Assert before/after.
+   c. testUserVipSurvivesSweep — fixture: orphan owned VIP + sibling user VIP (no marker);
+      sweep removes owned, user survives. Assert before: both. Assert after: only user.
+   d. testUserNatSurvivesSweep — same for nat/rule.
+   e. testSweepIsNoopOnCleanConfig — no owned rows anywhere; sweep returns FALSE, write_config
+      NOT called (spy or flag check).
+   f. testSweepIsIdempotent — run sweep, then run it again; second call returns FALSE.
+
+   Registration seam:
+   g. testRegisterVipAndReconcileCreatesWhenAbsent — register the VIP spec; call
+      pfb_fwobj_reconcile(PFB_AUTO_VIP_DESCR_V4); assert the VIP entry is created by the
+      builder. Assert before: absent.
+   h. testRegisterVipAndReconcileIsIdempotent — register, reconcile twice; builder called only
+      once. Assert before: absent; after first reconcile: present; after second: still one entry.
+
+CONSTRAINTS
+- PHP tabs; PHP 8.3; uppercase TRUE/FALSE (ADR-28).
+- The sweep runs BEFORE pfb_remove_config_settings() in the deinstall path — ORDER IS CRITICAL.
+  pfb_remove_config_settings() deletes installedpackages/pfblockerng* so the IP references (e.g.
+  pfb_dnsvip4) are gone after it runs; the sweep must see them while they still exist if it
+  needs them (though the sweep itself is marker-only, the before/after ordering matters for
+  correctness of the overall deinstall).
+- No persisted string/marker changes (ADR-28 storage freeze).
+- No new PfbConfig registered fields; no changes to pfb_cfg_registry() (ADR-29).
+- pfblockerng_fwobj.inc helper functions still do NO write_config inside — caller (the wired
+  path added here) owns the flush.
+- PFBL-01 sniff: pfb_fwobj_sweep is called from pfblockerng_php_pre_deinstall_command —
+  verify that PFBL-01's scopeFunctions allow-list does not need updating (sweep is not an
+  exec/json_encode/path-build call, so no sniff concern).
+- Phase 1 and Phase 2 test suites must still pass green.
+
+VERIFICATION (must all pass before the phase is done)
+- vendor/bin/phpunit -> green — ALL tests: Phase 1 (FwobjCurrentBehaviourTest), Phase 2
+  (FwobjLayerTest), Phase 4 (FwobjSweepSeamTest)
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc -> no syntax errors
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc -> no syntax errors
+- PHPStan (vendor/bin/phpstan analyse) -> no new errors
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> green (PFBL-01 + ADR-28 + ADR-29 sniffs)
+- python -m pytest -> green
+- Diff-read: changes in pfblockerng.inc confined to pfblockerng_php_pre_deinstall_command()
+  and the disable teardown path; pfblockerng.xml or pfblockerng_install.inc pkg-plist updated;
+  new tests/php/FwobjSweepSeamTest.php
+
+EXPECTED RESULT
+pfb_fwobj_sweep() is wired before pfb_remove_config_settings() on deinstall and after the
+disable teardown; orphan VIPs/NAT rules are removed even when the double-guard reference is
+gone; user objects survive; clean-config sweep is a no-op (verified). VIP + DNSBL NAT are
+expressed as the first two registrations, demonstrating the seam for ADR-36/37.
+
+COMMIT (single)
+    pfblockerng: wire fwobj sweep + registration seam for deinstall/disable (ADR-35 P4)
+Push directly to adr/35-managed-firewall-objects; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/04_Results.txt (plain .txt)
+Record:
+- The exact insertion point in pfblockerng_php_pre_deinstall_command() (line number, surrounding
+  context) where pfb_fwobj_sweep() was added.
+- The disable-path insertion point.
+- The two pfb_fwobj_register() call specs (VIP V4, VIP V6, NAT) as written.
+- How pkg-plist was updated for pfblockerng_fwobj.inc (file + line).
+- Test method names in FwobjSweepSeamTest and what each pins.
+- Verification output: phpunit total pass count (all three phases), phpstan clean, phpcs clean.
+- Any edge cases discovered (e.g. write_config call site decisions).
+- Go-ahead for Phase 5.

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/05_Smoke_DoD_Docs.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/05_Smoke_DoD_Docs.txt
@@ -1,0 +1,155 @@
+================================================================================
+PHASE 5 PROMPT — Live-VM smoke + DoD + docs
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md   (read §4, §5, §6 Phase 5, §7 DoD first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/35-managed-firewall-objects (off devel). Phase 5
+adds the ADR-04 live-VM smoke tests that prove the end-to-end add→remove→uninstall + orphan
+sweep contract on a real pfSense CE VM, updates architecture-notes.md with an ADR-35 blurb,
+and satisfies the §7 Definition of Done. One commit, push directly (open a PR only if the
+direct push is rejected).
+
+WHY THIS PHASE EXISTS
+The unit suite (Phases 1–4) proves correctness against config.xml fixtures off-appliance. Only
+a live-VM smoke can prove that enable/disable actually creates/removes objects in a running
+pfSense config, that an orphan is swept during real uninstall, and that user-created objects
+survive. This phase is the final automated gate that flips ADR-35 to Accepted.
+
+REQUIRED READING
+FIRST, read the prior phase's handoff:
+.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/04_Results.txt — it must confirm: the sweep is
+wired before pfb_remove_config_settings(), the registration seam is demonstrated, all PHPUnit
+phases are green, and the go-ahead for Phase 5. If it is missing, Phase 4 is not complete;
+STOP and report.
+
+Then read:
+- .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md — §7 DoD (every checkbox), §5 (constraints),
+  §2.2 (the semantics the smoke must prove).
+- CLAUDE.md — full "Smoke tests (ADR-04 — live pfSense VM)" section: probe ON-BOX via SSH;
+  test domains must be helpers.unique_domain(); block shapes; enable chain; the image bakes
+  only deps + qemu-guest-agent; diagnostics upload on failure.
+- tests/smoke/ — existing smoke tests for style + fixture patterns (test_smoke_dnsbl.py,
+  helpers.py, conftest.py); understand the smoke_vm fixture, how SSH commands are run, and how
+  config.xml is read back via SSH.
+- tests/smoke/test_smoke_dnsbl.py — how DNSBL enable/disable is toggled; how config.xml is
+  asserted via SSH (e.g. reading /conf/config.xml on-box and parsing it).
+- docs/misc/architecture-notes.md — existing structure; where to insert the ADR-35 blurb.
+- .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/01_Results.txt through 04_Results.txt — the
+  complete picture of what was built and tested, to write accurate notes.
+
+ACTION PLAN
+1. Add tests/smoke/test_smoke_fwobj.py (new file; marker: smoke).
+   Three scenarios, each using the smoke_vm fixture:
+
+   Scenario A — enable → VIP + NAT present:
+   Given: pfBlockerNG installed + DNSBL enabled (use ensure_dnsbl_vip + existing enable helpers).
+   When: sync is triggered (or package load completes).
+   Then: SSH into the VM, read /conf/config.xml, assert:
+     - virtualip/vip[] contains at least one entry with descr='pfB_AUTO_VIP_v4' or
+       'pfB_AUTO_VIP_v6'.
+     - nat/rule[] contains at least one entry with descr='pfB DNSBL - DO NOT EDIT'.
+   Assert the BEFORE state too: before enabling, confirm neither is present (or confirm the
+   enable is what creates them, not a pre-existing state).
+
+   Scenario B — disable → VIP + NAT removed:
+   Given: DNSBL enabled (Scenario A state, or re-enable here).
+   When: DNSBL is disabled.
+   Then: assert virtualip/vip[] has NO entry with a pfBlockerNG marker; nat/rule[] has NO
+   entry with descr containing 'pfB DNSBL'. Assert before: both present. Assert after: both gone.
+
+   Scenario C — orphan + user objects survive/are-swept on uninstall:
+   Given:
+     - Seed an ORPHAN VIP directly into config.xml via SSH (write an entry with
+       descr='pfB_AUTO_VIP_v4' to virtualip/vip[] but clear the pfb_dnsvip4 reference so the
+       normal double-guard would skip it).
+     - Seed a USER VIP (descr='my-test-user-vip-do-not-delete') in virtualip/vip[].
+     - Seed a USER NAT rule (descr='my-test-user-nat-do-not-delete') in nat/rule[].
+     Assert before: all three present in config.xml.
+   When: pfBlockerNG is uninstalled (pkg delete pfSense-pkg-pfBlockerNG-devel or equivalent).
+   Then:
+     - The orphan VIP (pfB_AUTO_VIP_v4) is GONE from virtualip/vip[].
+     - The user VIP (my-test-user-vip-do-not-delete) STILL PRESENT.
+     - The user NAT rule (my-test-user-nat-do-not-delete) STILL PRESENT.
+     - installedpackages/pfblockerng* sections are GONE from config.xml
+       (pfb_remove_config_settings ran correctly).
+
+   Each scenario is a separate test function with a @pytest.mark.smoke decorator. Use
+   helpers.unique_domain() only where DNS probes are needed (Scenario A/B may probe DNSBL to
+   confirm enable state, but VIP/NAT assertions are config.xml reads, not DNS queries). Follow
+   the existing smoke_vm fixture pattern for SSH commands and config.xml reads.
+
+2. Update docs/misc/architecture-notes.md — add a concise "ADR-35: Managed firewall objects"
+   subsection (after the ADR-13 VIP section if one exists, or in the ownership/teardown area):
+   - One paragraph: the layer pfblockerng_fwobj.inc provides; the marker-recognition union
+     (pfB_ prefix + legacy strings); the sweep primitive and when it runs (disable + deinstall);
+     the registration seam (how ADR-36/37 plug in).
+   - Keep it professional and terse — match the style and length of neighbouring notes.
+   - Do NOT include security framing, vulnerability descriptions, or ADR numbers from private
+     ADRs.
+
+3. Mark ADR-35 as Accepted:
+   In .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md, change the Status line from Proposed to
+   Accepted:
+     - **Status:** **Accepted** (2026-06-20)
+   Tick all DoD checkboxes (§7) that the automated test suite now covers. Leave the manual smoke
+   checklist items (§7 "Manual smoke" block) as unchecked — they are documented out-of-CI
+   limitations, not acceptance blockers (per CLAUDE.md "ADR acceptance" policy).
+
+4. Diff-read the full branch diff (git diff origin/devel...HEAD) before committing. Confirm:
+   - No debug logging (log_info/print/DBG*) left in any src/ file.
+   - No temporary comments left in test files.
+   - The diff is the minimal intentional change: Phases 1–4 production + test changes + this
+     phase's smoke + docs + ADR status update.
+
+CONSTRAINTS
+- Smoke tests must use smoke_vm fixture; never hardcode the VM IP or credentials.
+- Config.xml reads must go via SSH cat /conf/config.xml + XML parse — follow the existing
+  smoke pattern; do not assume a REST API.
+- The orphan seeding in Scenario C must be done via SSH config.xml write + pfSense config
+  reload — follow how other smoke tests manipulate config.xml directly.
+- docs/misc/architecture-notes.md: professional grammar (documentation exception per CLAUDE.md
+  communication rules); no caveman register.
+- PHP + Python linting must still pass (no src/ change in this phase; but php -l and ruff
+  must be clean on the full tree).
+- The smoke tests carry @pytest.mark.smoke and are excluded from the default pytest run
+  (-m "not smoke") — they are workflow_dispatch/smoke.yml only. Confirm the existing
+  conftest.py marker registration covers 'smoke'; if not, add it.
+
+VERIFICATION (must all pass before the phase is done)
+- vendor/bin/phpunit -> green (all phases: P1 FwobjCurrentBehaviourTest, P2 FwobjLayerTest,
+  P4 FwobjSweepSeamTest)
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc and pfblockerng_fwobj.inc -> clean
+- PHPStan (vendor/bin/phpstan analyse) -> no new errors
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> green (PFBL-01 + ADR-28 + ADR-29 sniffs)
+- python -m pytest (default, smoke excluded) -> green
+- python -m pytest tests/smoke/test_smoke_fwobj.py --collect-only -> collects 3 test functions
+  (no import errors)
+- npx markdownlint-cli2 docs/misc/architecture-notes.md -> 0 errors
+- npx markdownlint-cli2 .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md -> 0 errors
+- ADR status line reads "Accepted"
+- Dispatch smoke.yml (workflow_dispatch) on the branch; all three fwobj scenarios pass on
+  the live CE VM — this is the authoritative gate. If the live smoke fails, diagnose via the
+  smoke-diagnostics artifact (/var/log, pfctl -sa, config.xml) before concluding.
+
+EXPECTED RESULT
+Three live-VM smoke scenarios green: enable→VIP+NAT present; disable→removed; orphan swept on
+uninstall + user VIP/NAT survive. Architecture-notes updated. ADR-35 status Accepted. All §7
+DoD automated checkboxes ticked.
+
+COMMIT (single)
+    pfblockerng: add fwobj live-VM smoke, update docs, mark ADR-35 Accepted (ADR-35 P5)
+Push directly to adr/35-managed-firewall-objects; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/05_Results.txt (plain .txt)
+Record:
+- The three smoke test function names and what each scenario proves.
+- The orphan seeding method used in Scenario C (SSH command sequence).
+- The config.xml assertion method (SSH + XML parse; key paths checked).
+- The architecture-notes.md section title and location where the blurb was inserted.
+- Confirmation that ADR.md status is now Accepted and which §7 DoD checkboxes are ticked.
+- Live-VM smoke run outcome (job URL or pass/fail summary per scenario).
+- Verification output: phpunit count, phpstan clean, phpcs clean, pytest count, markdownlint.
+- Final branch diff summary: files changed, lines added/removed.
+- ADR-RESUME: branch=adr/35-managed-firewall-objects next-phase=COMPLETE

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/ADR.md
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/ADR.md
@@ -1,0 +1,232 @@
+# ADR-35: Unify ownership + teardown of pfBlockerNG-managed firewall objects
+
+- **Status:** **Proposed** (2026-06-20)
+- **Date:** 2026-06-20
+- **Branch:** `adr/35-managed-firewall-objects` (off `devel`; `{slug}` per CLAUDE.md "Branch naming")
+- **Component(s):** new `src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc` (ownership +
+  marker helpers), `src/usr/local/pkg/pfblockerng/pfblockerng.inc` (VIP/NAT/filter create +
+  remove call sites), `src/usr/local/pkg/pfblockerng/pfblockerng_install.inc` /
+  `pfblockerng.xml` (deinstall sweep wiring)
+- **Target runtime:** PHP 8.3 (pfSense CE 2.8)
+- **Test suite:** `tests/php/` (PHPUnit, off-appliance), `tests/smoke/` (live-VM, ADR-04)
+- **Enables:** ADR-36 (DNS Redirection NAT), ADR-37 (DoT/DoQ port block) — both register their
+  rules through the seam this ADR establishes.
+
+## 1. Context
+
+pfBlockerNG writes objects into three pfSense-core `config.xml` sections — **`virtualip/vip`**,
+**`nat/rule`**, **`filter/rule`** — and is responsible for removing them on disable and on
+package uninstall. Today each is managed by its own ad-hoc code with **inconsistent ownership
+markers and inconsistent teardown**:
+
+- **VIP** (ADR-13). Markers `PFB_AUTO_VIP_DESCR_V4 = 'pfB_AUTO_VIP_v4'` /
+  `PFB_AUTO_VIP_DESCR_V6 = 'pfB_AUTO_VIP_v6'` (`pfblockerng.inc:315`). Created idempotently by
+  `pfb_manage_dnsbl_vip()` (`:1178`) via `pfb_find_marked_vip()` (`:1121`, matches `descr`
+  marker only). Disable removes only entries matching the marker **AND** the IP stored in
+  `pfb_dnsvip4`/`pfb_dnsvip6` (a double-guard so a manually created VIP is never touched). A
+  legacy `'pfB DNSBL'` descr is migrated to the marker on upgrade (`pfblockerng_install.inc:48`).
+- **NAT** (DNSBL anti-lockout / web redirect). `pfb_create_dnsbl()` (`:3775`) writes `nat/rule`
+  entries with `descr = 'pfB DNSBL - DO NOT EDIT'` (`:3822`), detected by
+  `strpos($descr, 'pfB DNSBL') !== FALSE` (`:3798`), stripped on `$mode == 'disabled'`.
+- **Filter** (DNSBL pass rules + IP-feed deny/permit/match). `pfb_firewall_rule()` (`:7835`) +
+  `sync_package_pfblockerng()` manage `filter/rule` keyed on a **`pfB_` descr prefix** (`:13709`
+  separates pfBlockerNG rules from user rules); **all** `pfB_`-prefixed rules are stripped and
+  rebuilt from scratch each sync.
+
+Load-bearing facts:
+
+- **Uninstall relies on lifecycle ORDER, not on a marker sweep.**
+  `pfblockerng_php_pre_deinstall_command()` (`pfblockerng.inc:14423`, wired via
+  `pfblockerng.xml` `<custom_php_pre_deinstall_command>`) calls `sync_package_pfblockerng()`
+  (which runs `pfb_manage_dnsbl_vip('disabled')` and the filter/NAT teardown) **before**
+  `pfb_remove_config_settings()` (`:14512`) bulk-deletes `installedpackages/pfblockerng*`. The
+  deinstall never independently scans `virtualip/vip` / `nat/rule` for the marker. **If a prior
+  run half-failed and left an orphan** (e.g. a VIP whose `pfb_dnsvip4` reference was already
+  cleared, so the double-guard no longer matches it), that orphan is **never removed** — it
+  survives uninstall. This is the concrete fragility this ADR closes.
+- **`config.xml` storage is hard-frozen (ADR-28).** Existing markers are persisted strings:
+  renaming `'pfB_AUTO_VIP_v4'` or `'pfB DNSBL - DO NOT EDIT'` would orphan every object created
+  by a prior release across upgrade. Marker strings already on disk are therefore **immutable**;
+  this ADR may add recognition + a new convention for *new* objects, never rewrite the old ones.
+- **These are pfSense-core sections** (`virtualip`, `nat`, `filter`) — on the ADR-29
+  foreign-key exclusion list, accessed via direct `config_*_path` (not `PfbConfig`). Unchanged.
+- **No live pf/Unbound in CI** — the pure ownership/marker logic is unit-tested off-appliance
+  against `config.xml`-shaped fixtures; the real add/remove/uninstall against a running box is a
+  live-VM smoke (ADR-04).
+- **Two new features are queued** (ADR-36 DNS-redirect NAT, ADR-37 DoT/DoQ filter block) that
+  each need exactly this: create an owned rule, reconcile it idempotently, remove it on disable,
+  and have it swept on uninstall. Without a shared seam they would each re-invent the marker +
+  teardown code a fourth and fifth time.
+
+## 2. Decision
+
+Introduce a **small, shared ownership-and-teardown layer** for pfBlockerNG-managed firewall
+objects (VIP / NAT / filter), and **retrofit** the existing VIP + DNSBL-NAT management onto it
+**without changing any persisted marker string or observable behaviour**. The layer adds the one
+genuinely missing guarantee — a **marker-based defensive sweep on disable and on uninstall** —
+and exposes a **registration seam** that ADR-36/37 plug into.
+
+This is a **refactor + hardening**, not a rewrite. It is deliberately a set of **functions +
+constants in one new include**, not a class/registry hierarchy (see Alternatives).
+
+### 2.1 Per-area decision
+
+| Area | Decision |
+| --- | --- |
+| Ownership model | A pfBlockerNG object is **owned iff its `descr` carries a recognised pfBlockerNG marker**. Marker is the sole ownership signal. New objects use a single convention: `descr` begins `pfB_` (the prefix the filter side already uses). |
+| Marker recognition | `pfb_fwobj_is_owned($descr)` recognises the **union of all known markers** — the new `pfB_` prefix **plus** the exact legacy strings (`pfB_AUTO_VIP_v4/v6`, `pfB DNSBL`, `pfB DNSBL - DO NOT EDIT`, the legacy `'pfB DNSBL'` VIP descr). Legacy strings are matched verbatim; never rewritten (storage freeze). |
+| Helper layer | new `pfblockerng_fwobj.inc`: pure predicates (`pfb_fwobj_is_owned`, marker builders) + section operators `pfb_fwobj_find()` / `pfb_fwobj_remove()` over a given section (`virtualip/vip`, `nat/rule`, `filter/rule`) with an optional **secondary-guard** predicate (e.g. VIP's `subnet == stored IP`). |
+| Retrofit (VIP) | `pfb_manage_dnsbl_vip()` / `pfb_find_marked_vip()` call the shared find/remove with the **same** marker + the **same** IP double-guard. Behaviour identical; pinned before/after. |
+| Retrofit (NAT) | `pfb_create_dnsbl()` NAT add/strip calls the shared find/remove with the existing `'pfB DNSBL'` marker. Behaviour identical. |
+| Filter side | **Left as-is** (already strips all `pfB_` rules each sync — effectively a sweep). The shared `pfb_fwobj_is_owned()` reuses the same `pfB_` predicate so recognition is consistent, but the rebuild-each-sync model is **not** changed. |
+| Deinstall sweep | **NEW.** After the normal lifecycle teardown and **before** `pfb_remove_config_settings()`, run `pfb_fwobj_sweep()` over `virtualip/vip` + `nat/rule` (+ a `filter/rule` `pfB_` safety pass) removing **every** owned object by marker — even orphans the lifecycle missed. Idempotent; a no-op when nothing is owned. |
+| Disable sweep | The same marker sweep is the teardown primitive `pfb_manage_dnsbl_vip('disabled')` etc. call, so a disable that races a half-written state still converges. |
+| Registration seam | `pfb_fwobj_register($spec)` — a feature declares `{ type: vip/nat/filter, marker, builder, guard? }`. The reconcile/remove/sweep machinery then covers it for free. ADR-36/37 consume this; ADR-13's VIP and the DNSBL NAT are expressed as the first two registrations. |
+| Safety invariant | A removal/sweep **only ever** deletes an object whose `descr` matches a pfBlockerNG marker. A user object (no marker) is **never** touched — asserted by tests that seed sibling user VIP/NAT/filter rows and prove they survive. |
+
+### 2.2 Semantics that MUST be preserved / hold (the contract — pin with tests before refactor)
+
+- **No persisted marker string changes.** Every `descr` written today is written byte-identical
+  after the refactor; recognition is additive. (Upgrade safety: objects from a prior release
+  stay owned.)
+- **Behaviour-preserving retrofit.** For the existing VIP and DNSBL-NAT paths, the exact same
+  objects are created, found, and removed as before — same idempotency, same VIP IP double-guard.
+  Pinned by before/after tests over `config.xml` fixtures.
+- **User objects are inviolable.** No marker → never created, modified, or deleted. A removal or
+  sweep that would touch a non-marked row is a bug; tests seed user rows and assert survival.
+- **Orphan teardown.** An owned object whose secondary guard no longer matches (e.g. a VIP whose
+  stored IP reference was cleared) is still removed by the marker sweep on disable/uninstall.
+- **Idempotent + safe-on-empty.** Reconcile finds-or-creates exactly one object per spec; sweep
+  on a clean config is a no-op (no spurious `write_config`).
+- **No new `config.xml` schema / no `PfbConfig` change.** The managed sections stay
+  pfSense-core, accessed by direct `config_*_path`; no registered field is added by this ADR.
+
+### 2.3 Explicitly kept / out of scope
+
+- **The actual new rules** (DNS-redirect NAT, DoT/DoQ block) — those are **ADR-36 / ADR-37**;
+  this ADR only builds the seam and proves it on the existing VIP + NAT.
+- **Renaming/normalising legacy markers** — out (storage freeze; would orphan prior-release
+  objects). Recognition handles the heterogeneity instead.
+- **Reworking the filter-rule rebuild-each-sync model** — out; it already self-sweeps. Only
+  recognition is unified.
+- **A generic OO "managed resource registry" / class hierarchy** — out (over-engineering for
+  ~3 object types; see Alternatives). Functions + constants only.
+- **Changing `pfb_remove_config_settings()` bulk-delete of `installedpackages/pfblockerng*`** —
+  unchanged; the sweep is additive and runs before it.
+
+## 3. Consequences
+
+**Positive**
+
+- One ownership convention + one teardown primitive across VIP/NAT/filter — less duplicated,
+  drift-prone marker logic.
+- Closes the real uninstall gap: orphaned VIP/NAT objects from a half-failed run are now removed
+  on uninstall instead of surviving forever.
+- Gives ADR-36/37 (and any future managed rule) create/reconcile/remove/sweep for free, so those
+  ADRs stay thin and consistent.
+- Behaviour-preserving + storage-frozen, so it ships with no upgrade risk and is fully unit-pinnable.
+
+**Negative / risks**
+
+- A sweep that mis-identifies ownership could delete a user object — mitigated by "marker is the
+  sole signal", the immutable legacy-marker allow-list, and tests that prove user rows survive.
+- Retrofitting two live call sites (VIP, NAT) risks a subtle behaviour change — mitigated by
+  before/after golden tests over `config.xml` fixtures **written first** (Phase 1).
+- Real config mutation (VIP bring-up/down, pf reload) can only be fully validated on a live box —
+  covered by the ADR-04 smoke (add/remove/uninstall + orphan sweep), a documented non-CI gate.
+
+## 4. Requirements (acceptance)
+
+- `pfblockerng_fwobj.inc` with `pfb_fwobj_is_owned`, `pfb_fwobj_find`, `pfb_fwobj_remove`,
+  `pfb_fwobj_sweep`, `pfb_fwobj_register`; pure where possible, unit-tested.
+- VIP + DNSBL-NAT retrofitted onto it with **identical** persisted markers and behaviour
+  (before/after tests green).
+- Deinstall (and disable) marker sweep wired in before `pfb_remove_config_settings()`; orphans
+  removed; user objects untouched (asserted).
+- The registration seam demonstrated by expressing the VIP + DNSBL NAT as registrations.
+- All gates green (§5); live-VM smoke proves add→remove→uninstall leaves `config.xml` clean and
+  a seeded orphan is swept, while a user-created VIP/NAT/filter survives.
+
+## 5. Constraints (from CLAUDE.md)
+
+- PHP tabs, PHP 8.3; no `die()`/`exit()` in library code; new pfSense fns stubbed
+  (`stubs/pfsense/`) + doubled (`tests/php/pfsense_doubles.php`).
+- ADR-28: uppercase `TRUE`/`FALSE`; storage freeze (no persisted marker/string change).
+- ADR-29: managed sections are pfSense-core (foreign) → direct `config_*_path`, **not**
+  `PfbConfig`; do not register a new field; the `RequireConfigGateway` sniff must stay green.
+- PFBL-01: any new dynamic path / `exec` in scope validated; if `pfb_fwobj_*` lands in
+  `pfblockerng.inc` scope, keep the sniff green (the helpers do no shell/exec — pure config).
+- ADR-04 smoke for the end-to-end add/remove/uninstall + orphan sweep (no pf in CI).
+
+## 6. Action plan
+
+### Phase 1 — Prep: pin current VIP/NAT ownership + teardown behaviour (behaviour-preserving)
+
+- Prompt: `01_Pin_Current_Behaviour.txt`
+- Add PHPUnit golden tests over `config.xml`-shaped fixtures pinning **today's** behaviour:
+  VIP find-by-marker + create idempotency + disable removal (marker **AND** IP double-guard);
+  DNSBL-NAT add + `strpos('pfB DNSBL')` strip; and that a sibling **user** VIP/NAT row is never
+  touched. No production change — this is the oracle the refactor must not break.
+- Tests: the above, all green against current `pfblockerng.inc` (via the existing doubles).
+
+### Phase 2 — Extract the ownership/marker layer (`pfblockerng_fwobj.inc`)
+
+- Prompt: `02_Fwobj_Layer.txt`
+- New include with pure `pfb_fwobj_is_owned($descr)` (union of new `pfB_` prefix + the exact
+  legacy markers), `pfb_fwobj_find($section, $marker, $guard=NULL)`, `pfb_fwobj_remove(...)` —
+  no shell, no `write_config` inside the helpers (caller flushes, mirroring `PfbConfig`).
+- Tests: `is_owned` truth table (each legacy marker + new prefix = owned; unmarked/user = not);
+  find/remove over fixtures with and without the secondary guard; user rows survive.
+
+### Phase 3 — Retrofit VIP + NAT onto the layer (behaviour-preserving)
+
+- Prompt: `03_Retrofit_Vip_Nat.txt`
+- Rewire `pfb_find_marked_vip()` / `pfb_manage_dnsbl_vip()` and `pfb_create_dnsbl()`'s NAT
+  add/strip to call the shared find/remove with the **same** markers + the VIP IP guard. No
+  persisted string changes.
+- Tests: the Phase-1 golden suite still green (proves identical behaviour); plus the retrofit
+  paths now exercise the shared helpers.
+
+### Phase 4 — Deinstall + disable marker sweep + registration seam
+
+- Prompt: `04_Sweep_And_Seam.txt`
+- Add `pfb_fwobj_sweep()` (marker sweep over `virtualip/vip` + `nat/rule` + `filter/rule` `pfB_`
+  safety pass) and wire it into `pfblockerng_php_pre_deinstall_command()` **before**
+  `pfb_remove_config_settings()`; have the disable teardown use the same primitive. Add
+  `pfb_fwobj_register($spec)` and express the VIP + DNSBL NAT as the first registrations.
+- Tests: a seeded **orphan** (owned marker, guard no longer matching) is swept on deinstall;
+  a sibling user object survives; sweep on a clean config is a no-op (no `write_config`).
+
+### Phase 5 — Live-VM smoke + DoD + docs
+
+- Prompt: `05_Smoke_DoD_Docs.txt`
+- ADR-04 smoke: enable → assert pfBlockerNG VIP + DNSBL NAT exist in `config.xml`; disable →
+  assert removed; seed an orphan VIP + a **user** VIP/NAT, uninstall → orphan gone, user objects
+  survive, `installedpackages/pfblockerng*` gone. Architecture-notes blurb + manual checklist.
+
+## 7. Definition of done
+
+- [ ] `pfblockerng_fwobj.inc` layer (is_owned/find/remove/sweep/register), pure parts unit-tested
+      (branch coverage: each legacy marker + new prefix; guard on/off; user-row survival).
+- [ ] VIP + DNSBL NAT retrofitted with **no** persisted marker/string change; Phase-1 golden
+      suite green (behaviour identical, before/after).
+- [ ] Deinstall + disable marker sweep wired before bulk config delete; orphan removed; user
+      objects untouched; clean-config sweep is a no-op (asserted).
+- [ ] Registration seam in place and demonstrated (VIP + NAT registered through it); ready for
+      ADR-36/37.
+- [ ] All gates green: `vendor/bin/phpunit`, PHPStan, PHPCS (PFBL-01 + ADR-28 + ADR-29 sniffs),
+      `php -l`, `python -m pytest`; live-VM smoke proves add→remove→uninstall + orphan sweep.
+
+**Manual smoke (owner: maintainer):**
+
+- [ ] Install → enable DNSBL VIP + DNSBL → confirm VIP + NAT present (Firewall ▸ Virtual IPs /
+      NAT) with the pfBlockerNG markers.
+- [ ] Create an unrelated user VIP + a user NAT/filter rule → uninstall pfBlockerNG → confirm the
+      user objects survive and **no** `pfB_*` object remains.
+- [ ] Force an orphan (e.g. clear the `pfb_dnsvip4` reference but leave the marked VIP) →
+      uninstall → confirm the orphan is swept.
+
+**Reject criteria:** if the unified ownership signal cannot distinguish pfBlockerNG objects from
+user objects reliably across the heterogeneous legacy markers (risk of deleting user data), or
+the retrofit cannot be made provably behaviour-preserving, **reduce** to "deinstall sweep only"
+(keep the per-object code, add just the defensive sweep) or **reject**, recording the evidence.

--- a/.ADRs/ADR_36_DNS_Redirection/01_Config_Fields_And_Builder_Tests.txt
+++ b/.ADRs/ADR_36_DNS_Redirection/01_Config_Fields_And_Builder_Tests.txt
@@ -1,0 +1,152 @@
+================================================================================
+PHASE 1 PROMPT — Config fields + golden rule-builder tests (oracle)
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_36_DNS_Redirection/ADR.md   (read §2.1, §2.2, §5 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/36-dns-redirection (off devel; create off the
+latest devel if absent). Phase 1 is ORACLE-FIRST: register new config fields and write golden
+tests that pin the exact rule shape before any rule-building logic is wired to a live sync.
+One commit, push directly to the branch.
+
+WHY THIS PHASE EXISTS
+The §2.2 rule shape is the ground truth (maintainer's working config.xml). Encode it as
+machine-checked tests BEFORE writing the builder, so the builder is validated against the
+oracle, not the other way around.
+
+REQUIRED READING
+- .ADRs/ADR_36_DNS_Redirection/ADR.md — especially §2.2 (rule shape, invariants), §2.1
+  (decision table), §5 (constraints).
+- src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc — pfb_cfg_registry(), PfbConfig class,
+  existing toggle/plain adapter pattern, and the RequireConfigGateway sniff exclusion comment
+  convention.
+- tests/php/CfgGatewayTest.php — the round-trip + default-absent test pattern to follow.
+- tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php — the $registeredPaths
+  property; add all three new full paths here.
+- tests/php/RollbackContractTest.php — the $inventory array; add all three new keys here.
+- CLAUDE.md — ADR-29 "Adding a new registered field" (5-step process), ADR-28 storage freeze +
+  uppercase TRUE/FALSE, PHP standards, Test coverage mandate (branch + BDD).
+
+ACTION PLAN (ordered — registry + tests FIRST)
+
+1. Register three new fields in pfb_cfg_registry() (pfblockerng_extra.inc):
+
+   Key: dns_redirect_enable
+   Section path: installedpackages/pfblockerngdnsblsettings/config/0
+   Config.xml key: dns_redirect_enable
+   Adapter: toggle (pfb_cfg_toggle_read / pfb_cfg_toggle_write)
+   Stored vocabulary: {'on', ''}
+   Default stored string: ''  (feature off by default)
+   since: '4.0.0'
+
+   Key: dns_redirect_iface
+   Section path: installedpackages/pfblockerngdnsblsettings/config/0
+   Config.xml key: dns_redirect_iface
+   Adapter: NULL/NULL (plain identity — comma-joined interface string)
+   Stored vocabulary: any string (comma-separated interface names)
+   Default stored string: ''
+   since: '4.0.0'
+
+   Key: dns_redirect_exception
+   Section path: installedpackages/pfblockerngdnsblsettings/config/0
+   Config.xml key: dns_redirect_exception
+   Adapter: NULL/NULL (plain identity — alias name string)
+   Stored vocabulary: any string
+   Default stored string: ''
+   since: '4.0.0'
+
+2. Add all three full config.xml paths to $registeredPaths in
+   tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php so the sniff enforces
+   gateway access for these keys in all non-gateway PHP source files.
+
+3. Add all three keys to the $inventory in RollbackContractTest.php
+   (testInventoryCompletenessAllKnownKeysAccountedFor).
+
+4. Add CfgGatewayTest.php tests for each of the three fields:
+   - round-trip: write(read(v)) == v for every stored vocabulary value
+   - default-absent: PfbConfig::read($key) on an empty config returns the correct default
+   These are the ADR-29 step-4 tests.
+
+5. Write a pure skeleton function pfb_build_dns_redirect_rules($iface, $ipprotocol, $exception)
+   in pfblockerng.inc (or a new pfblockerng_dns_redirect.inc if the implementer judges it
+   cleaner — check the file sizes and existing structure first). The function signature and
+   return structure must be defined now; the full implementation comes in Phase 2.
+   Return type: array with two entries:
+     [0] => array (the NAT rdr rule fields)
+     [1] => array (the associated filter PASS rule fields)
+   Stub may return an empty/placeholder array at this stage.
+
+6. Write PHPUnit golden tests for pfb_build_dns_redirect_rules() (tests/php/). Required test
+   cases (branch coverage — all mandatory):
+
+   a. inet family, no exception alias:
+      - ipprotocol is 'inet'
+      - target is '127.0.0.1'
+      - source is <any> (no address/not elements in source)
+      - destination has network '(self)', not present, port '53'
+      - natreflection is 'disable'
+      - protocol is 'tcp/udp'
+      - local-port is '53'
+      - descr contains the pfB_DNS_Redirect marker
+
+   b. inet6 family, no exception alias:
+      - ipprotocol is 'inet6'
+      - target is '::1'
+      - source is <any>
+      - destination: same negated (self) + port 53 invariant
+      - natreflection, protocol, local-port: same as (a)
+
+   c. inet family, exception alias set (non-empty string):
+      - source has address equal to the alias name AND not present (negated)
+      - destination: same negated (self) + port 53 invariant
+
+   d. inet6 family, exception alias set:
+      - same negated-alias source, ::1 target, inet6 ipprotocol
+
+   e. Multiple interfaces (call builder for two interfaces):
+      - each call returns independent rule sets
+      - markers differ by interface name
+
+   f. Marker in both NAT rule descr AND associated filter rule descr (for each family):
+      - assert descr field present and starts with 'pfB_' in both entries [0] and [1]
+
+   Tests MUST assert each individual field, not just array shape. A missing 'natreflection'
+   key, a wrong target, or a non-negated destination must each independently fail a test.
+   Write tests BEFORE completing the builder implementation (the tests will initially fail
+   against the stub — that is expected and correct).
+
+CONSTRAINTS
+- PHP tabs; PHP 8.3; no die()/exit().
+- ADR-28: uppercase TRUE/FALSE in all new PHP.
+- ADR-29: follow the 5-step registry process exactly. The stored vocabulary is defined once
+  here and NEVER changes.
+- Storage freeze: the chosen stored key names (dns_redirect_enable, dns_redirect_iface,
+  dns_redirect_exception) are permanent. Confirm they do not collide with any existing key
+  before registering.
+- Do NOT wire the builder to sync_package_pfblockerng() yet (Phase 2). Do NOT add UI yet
+  (Phase 3).
+
+VERIFICATION (must all pass before phase is done)
+- vendor/bin/phpunit -> green (CfgGateway round-trip + default-absent; golden rule tests will
+  FAIL against the stub — document this in the handoff; the phase is done when the registry
+  tests are green and the golden tests are written and passing against the stub where they can).
+- php -l on all touched files.
+- PHPStan + phpcs clean (PFBL-01 + ADR-28 + ADR-29 sniffs) on all touched files.
+- python -m pytest -> green (no Python changes; verify no regressions).
+- Confirm: no existing key collision (grep pfblockerngdnsblsettings for dns_redirect_* before
+  registering).
+
+EXPECTED RESULT
+Three PfbConfig-registered fields with round-trip tests green; a pfb_build_dns_redirect_rules()
+skeleton with golden tests that pin the §2.2 rule shape and will be driven green in Phase 2.
+
+COMMIT (single)
+    pfblockerng: add DNS redirect config fields + rule-shape oracle tests (ADR-36 P1)
+Push directly to adr/36-dns-redirection; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_36_DNS_Redirection/RESULTS/01_Results.txt (plain .txt)
+Record: the three registry entries (key names, section paths, adapter types, defaults, since);
+the $registeredPaths additions (exact path strings); pfb_build_dns_redirect_rules() signature
+and return structure; which golden tests are green vs still failing against the stub (expected);
+verification numbers; any key collision check result; go-ahead for Phase 2.

--- a/.ADRs/ADR_36_DNS_Redirection/02_Builder_And_Sync.txt
+++ b/.ADRs/ADR_36_DNS_Redirection/02_Builder_And_Sync.txt
@@ -1,0 +1,127 @@
+================================================================================
+PHASE 2 PROMPT — Rule builder + ADR-35 registration + sync wiring
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_36_DNS_Redirection/ADR.md   (read §2.1, §2.2, §5 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/36-dns-redirection. Phase 2 completes the rule
+builder, registers it via ADR-35, and wires create/reconcile/remove into the sync flow.
+One commit, push directly.
+
+WHY THIS PHASE EXISTS
+The oracle (Phase 1 golden tests) is in place. Now fill in the builder so the tests go green,
+then connect it to the lifecycle (sync + disable + sweep) via the ADR-35 seam so the feature
+has full managed-object ownership from day one.
+
+REQUIRED READING
+- FIRST, read .ADRs/ADR_36_DNS_Redirection/RESULTS/01_Results.txt. If missing, STOP and
+  report.
+- .ADRs/ADR_36_DNS_Redirection/ADR.md — §2.2 (exact rule shape), §2.1 (lifecycle decision
+  row), §5 (ADR-35 constraint).
+- .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md — §2.1 (pfb_fwobj_register spec), §2.2
+  (ownership contract: marker is the sole signal, user objects inviolable), §2.3 (what is
+  out of scope for this ADR). Understand the registration seam BEFORE touching it.
+- src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc — pfb_fwobj_register(), pfb_fwobj_find(),
+  pfb_fwobj_remove(), pfb_fwobj_sweep() signatures and semantics. Read the actual code; do not
+  guess the API.
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc — sync_package_pfblockerng() call site; how
+  the existing DNSBL NAT create/strip is wired; pfb_global() read pattern for config keys;
+  pfb_build_if_list() for interface validation.
+- CLAUDE.md — ADR-35 constraint, PFBL-01, PHP standards, test mandate.
+
+ACTION PLAN (ordered)
+
+1. Complete pfb_build_dns_redirect_rules($iface, $ipprotocol, $exception) so it passes all
+   Phase-1 golden tests. The function must:
+   - Build the NAT rdr rule array with all §2.2 fields present:
+     ipprotocol, protocol, target (127.0.0.1 or ::1 per family), local-port 53,
+     destination (network '(self)' + not + port 53), source (negated alias when $exception
+     is non-empty, else <any>), interface $iface, descr marker, natreflection 'disable'.
+   - Build the associated filter PASS rule array with a corresponding descr marker.
+   - Return both as a two-element array [nat_rule, filter_rule].
+   - Be pure (no config reads, no shell calls, no write_config inside the function).
+   Confirm ALL Phase-1 golden tests pass after implementation.
+
+2. Register the DNS redirect builder via pfb_fwobj_register(). Read pfblockerng_fwobj.inc
+   for the exact $spec structure accepted by pfb_fwobj_register() before writing the call.
+   The registration must:
+   - Cover the NAT rule entries (type 'nat').
+   - Also cover the associated filter rule entries (type 'filter') — either as a second
+     registration or as part of the same spec if the ADR-35 API supports compound entries.
+     Check the API; do not assume.
+   - Use the pfB_DNS_Redirect_ marker prefix so pfb_fwobj_is_owned() recognises both.
+   Call pfb_fwobj_register() at include-load time (same pattern as the existing VIP + DNSBL
+   NAT registrations, if any — check the file).
+
+3. Wire into sync_package_pfblockerng():
+   - Read dns_redirect_enable via PfbConfig::read().
+   - If enabled: read dns_redirect_iface (comma-split to an array of interface names) and
+     dns_redirect_exception.
+   - For each selected interface, call pfb_build_dns_redirect_rules() for both 'inet' and
+     'inet6' and write the resulting rules into nat/rule and filter/rule via config_*_path.
+   - Stale-interface prune: after writing the rules for the current interface set, scan all
+     existing nat/rule and filter/rule entries for pfB_DNS_Redirect_ markers belonging to
+     interfaces NOT in the current selected set and remove them via pfb_fwobj_remove().
+   - If disabled or no interfaces selected: remove all pfB_DNS_Redirect_* entries via the
+     ADR-35 marker sweep (pfb_fwobj_sweep() or pfb_fwobj_remove() — use whichever the ADR-35
+     API provides for a full-marker removal, reading the code to confirm).
+   - Do NOT call write_config() inside the builder or the registration logic; the sync flow
+     decides when to flush.
+
+4. Tests (PHPUnit). Required branches — all mandatory:
+
+   a. Reconcile is idempotent: call the sync logic twice with identical settings; assert the
+      config.xml nat/rule + filter/rule sections contain the same entries (no duplicates).
+      Assert before-state (no redirect rules) then after-first-sync, then after-second-sync.
+
+   b. Disable removes all marked rules; user NAT rule survives:
+      Seed a user nat/rule entry (no pfBlockerNG marker) in the fixture config. Enable the
+      redirect, sync (rules appear). Disable, sync again. Assert all pfB_DNS_Redirect_* rules
+      are gone. Assert the user nat/rule entry is still present and unchanged.
+
+   c. Stale-interface prune: enable on two interfaces (e.g. 'lan' and 'opt1'), sync (4 NAT +
+      4 filter entries — 2 families × 2 interfaces). Reduce selection to 'lan' only, sync
+      again. Assert the 'opt1' rules (all 4) are gone. Assert the 'lan' rules (all 4) remain.
+
+   d. Exception alias branch: enable with a non-empty exception alias, sync. Assert the
+      nat/rule entries have the negated-alias source structure. Change to empty alias, sync.
+      Assert source is <any>. (Before/after both asserted.)
+
+CONSTRAINTS
+- PHP tabs; PHP 8.3; no die()/exit().
+- ADR-28: uppercase TRUE/FALSE in all new PHP.
+- ADR-35 contract: ownership = marker only; user objects inviolable; do NOT re-invent sweep or
+  teardown logic outside pfb_fwobj_*; no new marker string beyond pfB_DNS_Redirect_<iface>_v4
+  and pfB_DNS_Redirect_<iface>_v6. Storage freeze: markers are immutable once written.
+- ADR-29: read registered fields only via PfbConfig::read(); write only via PfbConfig::write().
+  nat/rule and filter/rule are pfSense-core (foreign) — direct config_*_path only.
+- PFBL-01: pfb_build_dns_redirect_rules() is called from an in-scope sync function — confirm
+  it is in (or called from) a function on the PHPCS scopeFunctions allow-list. Interface names
+  read from config must be validated before use; they come from PfbConfig::read(), which
+  returns the stored comma-joined string. Validate each interface name against the result of
+  pfb_build_if_list() before composing a rule. Add any new in-scope function to scopeFunctions.
+- Do NOT add UI yet (Phase 3).
+
+VERIFICATION (must all pass before phase is done)
+- vendor/bin/phpunit -> green (all Phase-1 golden tests + all Phase-2 lifecycle tests).
+- php -l on all touched files.
+- PHPStan + phpcs clean (PFBL-01 + ADR-28 + ADR-29 sniffs).
+- python -m pytest -> green.
+- diff-read: no spurious changes to unrelated code; nat/rule and filter/rule are accessed by
+  direct config_*_path (not PfbConfig) — sniff must be satisfied.
+
+EXPECTED RESULT
+pfb_build_dns_redirect_rules() passes all golden tests; ADR-35 registration in place; full
+lifecycle (create/reconcile/stale-prune/disable/sweep) wired and unit-tested with branch
+coverage.
+
+COMMIT (single)
+    pfblockerng: implement DNS redirect rule builder + ADR-35 lifecycle wiring (ADR-36 P2)
+Push directly to adr/36-dns-redirection; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_36_DNS_Redirection/RESULTS/02_Results.txt (plain .txt)
+Record: pfb_build_dns_redirect_rules() final signature; the ADR-35 registration spec used
+(type, marker strings, API shape chosen); how stale-interface prune is implemented (scan
+method + remove API); any deviation from the plan with rationale; scopeFunctions additions;
+verification numbers; go-ahead for Phase 3.

--- a/.ADRs/ADR_36_DNS_Redirection/03_UI.txt
+++ b/.ADRs/ADR_36_DNS_Redirection/03_UI.txt
@@ -1,0 +1,134 @@
+================================================================================
+PHASE 3 PROMPT — UI on the DNSBL settings page + server-side validation
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_36_DNS_Redirection/ADR.md   (read §2.1, §5 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/36-dns-redirection. Phase 3 adds the UI control
+block on the DNSBL settings page and the server-side validator. One commit, push directly.
+
+WHY THIS PHASE EXISTS
+The feature is non-functional without a UI; the UI's server-side validation is a PFBL-01
+surface (user-controlled interface names and alias names flow into config before they reach
+the builder). Build the UI and its validator together so they are tested as a unit.
+
+REQUIRED READING
+- FIRST, read .ADRs/ADR_36_DNS_Redirection/RESULTS/02_Results.txt. If missing, STOP and
+  report.
+- .ADRs/ADR_36_DNS_Redirection/ADR.md — §2.1 (UI row, exception alias row), §5 (PFBL-01,
+  ADR-29, ADR-14 constraints).
+- src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php — find the DoH/DoT/DoQ blocking control
+  section; study the surrounding enable checkbox + multi-select pattern, the quick-fill
+  mechanism if one exists, and the POST handler that saves via PfbConfig::write(). The new
+  control block must match the visual and structural style of that section.
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc — pfb_build_if_list() signature and return
+  shape; the inbound_interface + outbound_interface config keys (read how the quick-fill
+  interface union is derived for similar features); pfb_filter() / is_validaliasname()
+  validation functions.
+- tests/php/ for test style; CLAUDE.md — PFBL-01, ADR-14 ui_render, PHP/UI standards.
+
+ACTION PLAN (ordered)
+
+1. Study pfblockerng_dnsbl.php carefully before writing any code:
+   - Locate the DoH/DoT/DoQ section (or nearest analogous control block with an enable checkbox
+     + multi-select). Note the HTML structure (table rows, input names, the form action).
+   - Identify where PfbConfig::read() is called to populate existing form fields.
+   - Identify the POST handler block and how it saves via PfbConfig::write().
+   - Note the help text style, length, and proximity to the field.
+   Do not guess; the existing pattern is the source of truth.
+
+2. Add the DNS redirect control block immediately after (or adjacent to) the DoH/DoT/DoQ
+   section. The block contains:
+
+   a. Enable checkbox:
+      - Label: "DNS Redirect" (or match the naming style of adjacent checkboxes).
+      - Bound to dns_redirect_enable via PfbConfig::read/write().
+      - Help text (one or two sentences, style matching neighbours): explain that this redirects
+        all outbound port-53 DNS traffic on selected interfaces to the firewall's own resolver;
+        note that DoH/DoT bypass is NOT covered; note that the firewall itself is always exempt.
+
+   b. Interface multi-select:
+      - Built from pfb_build_if_list() (WAN-excluded by default — check the existing calls for
+        the correct exclusion parameter).
+      - Pre-selected items read from dns_redirect_iface (PfbConfig::read(), comma-split to an
+        array for the selected attribute).
+      - A quick-fill mechanism (button or link — match the style of any existing quick-fill on
+        the page): when triggered, populates the multi-select with the union of the values from
+        inbound_interface and outbound_interface (the pfBlockerNG fw-rule interface set). This
+        may be a JavaScript helper; match the existing quick-fill pattern if one exists.
+
+   c. Exception alias field:
+      - A free-text input bound to dns_redirect_exception.
+      - Help text (brief): "Optional. Name of an existing Firewall Alias. Hosts/subnets in this
+        alias bypass the DNS redirect. The alias must be created separately in Firewall → Aliases."
+
+3. Server-side POST handler — add to the existing save/validation block:
+
+   a. Validate selected interfaces: split the POSTed multi-select value by comma; for each
+      name, verify it appears in the pfb_build_if_list() result. Reject (error message,
+      no write) if any name is invalid.
+
+   b. Validate exception alias name (when non-empty): run pfb_filter() (PFB_FILTER_ALIAS or
+      equivalent) and/or is_validaliasname() on the POSTed value. Reject if invalid.
+
+   c. Save all three fields via PfbConfig::write() on valid input.
+
+   d. Add the POST handler function (or the relevant code block, if inline) to the PHPCS
+      scopeFunctions allow-list in phpcs.xml.dist (PFBL-01 surface). Read the current
+      scopeFunctions list to confirm the right function name or scope.
+
+4. Tests (PHPUnit). Required cases:
+
+   a. Server-side validator (valid cases):
+      - Valid interface name in pfb_build_if_list() output → accepted.
+      - Empty exception alias → accepted.
+      - Valid alias name (only alphanumeric + underscore, pfSense alias name rules) → accepted.
+
+   b. Server-side validator (invalid cases — each rejected without a write):
+      - Interface name not in pfb_build_if_list() output → rejected.
+      - Invalid alias name (e.g. contains spaces, or shell-special chars) → rejected.
+      Assert that PfbConfig::write() is NOT called when validation fails. (Use a spy/mock
+      pattern consistent with the existing test doubles.)
+
+5. ADR-14 ui_render test for pfblockerng_dnsbl.php:
+   - Ensure the page is already in the ui_render test suite (tests/smoke/ui/). If not, add it.
+   - Confirm the test checks: HTTP 200; body free of Fatal error / Parse error / Warning /
+     Notice / Uncaught; a page-specific marker present; no new php_error.log line.
+   - The test must pass green (the new control block must not introduce any PHP error or warning).
+
+CONSTRAINTS
+- PHP tabs; PHP 8.3; no die()/exit() in library code.
+- ADR-28: uppercase TRUE/FALSE in all new PHP.
+- ADR-29: read dns_redirect_* fields via PfbConfig::read(); write via PfbConfig::write() only.
+  Never call config_get_path / config_set_path directly for these registered keys.
+- PFBL-01: the POST handler is an in-scope surface. Validate interface names and alias names
+  BEFORE any call to pfb_build_dns_redirect_rules() or any config write. Add to scopeFunctions.
+- UI style: match the EXACT visual and structural conventions of the DoH/DoT/DoQ adjacent
+  section. Do not introduce a different table structure, naming convention, or help-text style.
+- Web UI help text: brief yet clear. Match the wording length and style of neighbours. Do not
+  over-explain.
+- Do not modify pfb_build_dns_redirect_rules() or sync wiring (Phase 2 is locked).
+
+VERIFICATION (must all pass before phase is done)
+- vendor/bin/phpunit -> green (all prior tests + new validator tests).
+- php -l on all touched files.
+- PHPStan + phpcs clean (PFBL-01 + ADR-28 + ADR-29 sniffs; scopeFunctions updated).
+- python -m pytest -> green.
+- ADR-14 ui_render: pfblockerng_dnsbl.php renders 200 with no PHP errors (requires SMOKE_ADMIN_
+  PASSWORD; if CI is unavailable, document the pending gate in the handoff).
+- diff-read: only pfblockerng_dnsbl.php + test files changed; no changes to builder or sync.
+
+EXPECTED RESULT
+A fully functional UI control block on the DNSBL page that correctly reads, validates, and
+saves the three new config fields, with PFBL-01 server-side validation and a passing ui_render
+gate.
+
+COMMIT (single)
+    pfblockerng: add DNS redirect UI + server-side validation on DNSBL page (ADR-36 P3)
+Push directly to adr/36-dns-redirection; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_36_DNS_Redirection/RESULTS/03_Results.txt (plain .txt)
+Record: the HTML input names used (for the smoke harness); the quick-fill mechanism implemented
+(JS or server-side); the scopeFunctions addition(s); ui_render result (green or pending — with
+reason if pending); any deviation from the plan; verification numbers; go-ahead for Phase 4.

--- a/.ADRs/ADR_36_DNS_Redirection/04_Smoke_DoD_Docs.txt
+++ b/.ADRs/ADR_36_DNS_Redirection/04_Smoke_DoD_Docs.txt
@@ -1,0 +1,147 @@
+================================================================================
+PHASE 4 PROMPT — Smoke tests + DoD + docs
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_36_DNS_Redirection/ADR.md   (read §6 Phase 4, §7 DoD first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/36-dns-redirection. Phase 4 writes the live-VM
+smoke tests, verifies all gates are green, adds an architecture-notes blurb, and closes the
+ADR. One commit, push directly.
+
+WHY THIS PHASE EXISTS
+The builder and sync logic are unit-tested against config.xml fixtures; the real pf interaction
+(natd loading the rdr rule, pfctl -sn confirmation) and the full install/disable/uninstall
+lifecycle can only be verified on a real pfSense VM. This phase provides the authoritative
+end-to-end gate that no off-appliance test can substitute.
+
+REQUIRED READING
+- FIRST, read .ADRs/ADR_36_DNS_Redirection/RESULTS/03_Results.txt. If missing, STOP and
+  report.
+- .ADRs/ADR_36_DNS_Redirection/ADR.md — §6 Phase 4 (required smoke cases), §7 (DoD checklist
+  + manual smoke + reject criteria).
+- .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md — §6 Phase 5 (smoke pattern for the sweep test);
+  reuse the uninstall + orphan-sweep test structure.
+- tests/smoke/ — the existing smoke test file layout, conftest.py, helpers.py; how config.xml
+  is written via SSH helpers; how pfctl is queried; the smoke_vm fixture and skip conventions.
+- CLAUDE.md — ADR-04 smoke (read before touching tests/smoke/), ADR-14 ui_render gate,
+  test coverage mandate (before/after, branch coverage, BDD-style for multi-step flows).
+
+ACTION PLAN (ordered)
+
+1. Write tests/smoke/test_dns_redirect.py (new file, or append to an appropriate existing
+   smoke file if one covers NAT lifecycle — check before creating). Each test case is a
+   distinct test function with explicit Given/When/Then structure.
+
+   Required test cases (all mandatory — read §6 Phase 4 for the full list):
+
+   Case 1 — Enable path (basic lifecycle, both families):
+   Given: redirect disabled, no pfB_DNS_Redirect_* rules in config.xml.
+   When: enable redirect on LAN interface via PfbConfig (or SSH config write) + sync.
+   Then:
+     - config.xml nat/rule contains exactly 2 pfB_DNS_Redirect_lan_* entries (v4 + v6).
+     - config.xml filter/rule contains exactly 2 corresponding associated filter entries.
+     - Each nat/rule entry: verify ipprotocol, target, destination (negated (self) + port 53),
+       natreflection disable, protocol tcp/udp, local-port 53 — field-by-field.
+     - pfctl -sn output (via SSH) contains rdr rules on the LAN interface for port 53.
+   Note: assert before-state (no rdr rules) before enabling.
+
+   Case 2 — Disable path:
+   Given: redirect enabled on LAN (from Case 1 or re-setup).
+   When: disable redirect + sync.
+   Then:
+     - No pfB_DNS_Redirect_* entries in config.xml nat/rule or filter/rule.
+     - pfctl -sn shows no pfBlockerNG rdr rules for port 53.
+   Note: assert the before-state (rules present) before disabling.
+
+   Case 3 — User-rule survival:
+   Given: a user nat/rule entry present in config.xml (no pfBlockerNG marker), redirect
+          disabled initially.
+   When: enable redirect (rules appear) → disable (rules removed).
+   Then: the user nat/rule entry is still present, byte-identical to the original.
+
+   Case 4 — Stale-interface prune:
+   Given: redirect enabled on LAN + OPT1 (or two available interfaces — pick from the VM's
+          interface list; use helpers to discover available interfaces).
+   When: reduce selection to LAN only + sync.
+   Then:
+     - OPT1 pfB_DNS_Redirect_opt1_* rules are gone (both nat/rule and filter/rule).
+     - LAN pfB_DNS_Redirect_lan_* rules remain (both families, all 4 entries).
+   Note: assert both sets present before the reduction.
+
+   Case 5 — Exception alias branch (config.xml assertion):
+   Given: redirect disabled.
+   When: enable with dns_redirect_exception set to a valid alias name (e.g. 'DNS_Exceptions').
+   Then: each nat/rule entry has source with address 'DNS_Exceptions' and not present.
+   When: clear the exception alias (empty string) + sync.
+   Then: each nat/rule entry has source as <any>.
+   Note: assert both branches (alias set and alias empty) in both IP families.
+
+   Case 6 — Uninstall sweep:
+   Given: redirect enabled on LAN; a user nat/rule present (no marker).
+   When: uninstall pfBlockerNG (pkg delete / the standard uninstall path).
+   Then:
+     - All pfB_DNS_Redirect_* entries gone from config.xml.
+     - No pfBlockerNG nat/rule or filter/rule entries remain.
+     - installedpackages/pfblockerng* gone.
+     - User nat/rule entry is still present and unchanged.
+   Reuse the ADR-35 sweep test fixture pattern; see ADR-35 §6 Phase 5 smoke for the uninstall
+   invocation pattern.
+
+2. Mark the smoke tests with the appropriate pytest marker (check the existing smoke file
+   markers — likely @pytest.mark.smoke or similar). If any test requires a specific env var
+   gate (e.g. a second host for the full client-redirect behaviour), add a skip decorator with
+   a clear message and document the gate in the handoff.
+
+3. Verify all gates are green (see VERIFICATION below).
+
+4. Add a blurb to docs/misc/architecture-notes.md under an appropriate heading (e.g. "DNS
+   enforcement" or adjacent to the DoH/DoT section if one exists). The blurb covers:
+   - What the DNS redirect feature does (port-53 rdr to loopback).
+   - The structural self-exempt (negated (self) destination).
+   - Complementary relationship with DoH/DoT domain NXDOMAIN (DNSBL) and ADR-37 port-853 block.
+   - ADR-35 ownership model (pfB_DNS_Redirect_* marker, registered via pfb_fwobj_register).
+   Keep it brief (3–5 sentences); no security framing; no PFBL references.
+
+5. Check off the §7 DoD items against the evidence collected across all four phases. Document
+   any item that cannot be checked automatically (full client-redirect behaviour) as a
+   maintainer manual-smoke item with a clear test description. Update the ADR.md §7 checklist
+   if the implementer has the ADR doc in scope (or leave it for the maintainer to tick — the
+   handoff documents the evidence either way).
+
+CONSTRAINTS
+- CLAUDE.md smoke rules: probe on-box (SSH), never runner-side SLIRP; assert before-state
+  before any change; use helpers.unique_domain() if any domain lookup is needed (unlikely here —
+  this is a NAT smoke, not a DNSBL domain smoke); never hardcode interface names (discover from
+  the VM or the version matrix).
+- ADR-04: every run uploads smoke-diagnostics; on failure, read that artifact first.
+- ADR-14 ui_render: if the pfblockerng_dnsbl.php ui_render gate was pending in Phase 3,
+  confirm it is green now. If it requires a live VM, run it here.
+- Docs: Markdown lint clean (markdownlint-cli2); blank line around headings/lists/fences;
+  language on every fence; professional prose (documentation exception to caveman mode).
+- Full client-redirect behaviour (a client bypassing the redirect is answered by the pfSense
+  resolver) requires a second host. This is a documented maintainer manual-smoke item, NOT a
+  CI gate. The CI-feasible gate is config.xml rule presence + pfctl -sn rdr confirmation.
+
+VERIFICATION (must all pass before phase is done)
+- vendor/bin/phpunit -> green (all phases).
+- php -l on all touched files.
+- PHPStan + phpcs clean.
+- python -m pytest -> green (unit suite; smoke tests skipped off-VM as expected).
+- ADR-14 ui_render -> green (pfblockerng_dnsbl.php, or document pending gate).
+- markdownlint-cli2 -> 0 errors on all touched .md files.
+- Smoke test file: python -m pytest tests/smoke/test_dns_redirect.py --collect-only -> all
+  cases collected without import error.
+
+EXPECTED RESULT
+A complete live-VM smoke suite covering the full lifecycle; all prior gates green; a brief
+architecture-notes blurb; a fully checked §7 DoD with documented manual-smoke items.
+
+COMMIT (single)
+    pfblockerng: add DNS redirect smoke tests + docs (ADR-36 P4)
+Push directly to adr/36-dns-redirection; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_36_DNS_Redirection/RESULTS/04_Results.txt (plain .txt)
+Record: smoke test file path and case count; any env-var-gated cases and their skip
+conditions; ui_render status (green / pending with reason); docs path updated;
+full verification matrix; open items for the maintainer manual smoke; ADR-36 DONE.

--- a/.ADRs/ADR_36_DNS_Redirection/ADR.md
+++ b/.ADRs/ADR_36_DNS_Redirection/ADR.md
@@ -1,0 +1,361 @@
+# ADR-36: Optional NAT DNS-redirection rule set (DNS hijack)
+
+- **Status:** **Proposed** (2026-06-20)
+- **Date:** 2026-06-20
+- **Branch:** `adr/36-dns-redirection` (off `devel`)
+- **Folds in maintainer's working config** (config.xml NAT "Redirect DNS IPv4/IPv6" — ground
+  truth for the exact rule shape; see §2.2)
+- **Component(s):** `src/usr/local/pkg/pfblockerng/pfblockerng.inc` (rule builder + sync wiring),
+  `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` (PfbConfig registry — 3 new fields),
+  `src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc` (ADR-35 registration),
+  `src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php` (UI control block)
+- **Target runtime:** PHP 8.3 (pfSense CE 2.8)
+- **Test suite:** `tests/php/` (PHPUnit, off-appliance), `tests/smoke/` (ADR-04 live-VM),
+  `tests/smoke/ui/` (ADR-14 `ui_render`)
+- **Depends on:** ADR-35 (Managed Firewall Objects) — the ADR-35 seam
+  (`pfb_fwobj_register` / `pfb_fwobj_find` / `pfb_fwobj_remove` / `pfb_fwobj_sweep`,
+  ownership-by-descr-marker) must be in place before Phase 2 of this ADR.
+
+## 1. Context
+
+pfBlockerNG's DNSBL blocks DNS resolution of known-bad domains at the resolver level. However,
+clients that are configured with a hardcoded external DNS server (e.g. `8.8.8.8`) bypass Unbound
+entirely and are never subject to DNSBL matching. The result is a security gap: a device on a
+LAN interface can evade pfBlockerNG DNSBL by simply ignoring the DHCP-advertised DNS server.
+
+The conventional pfSense mitigation is a NAT port-forward (redirect) rule: intercept any
+outbound DNS query on port 53 (TCP + UDP) and redirect it to the firewall's own resolver
+(`127.0.0.1:53` for IPv4, `::1:53` for IPv6). Clients see no difference in normal operation
+(the firewall answers), but a client that would have bypassed pfBlockerNG is now answered by it.
+
+Today there is no pfBlockerNG-managed mechanism for this. Admins who want it must add the NAT
+rule(s) manually, maintain them by hand, and remember to remove them when uninstalling the
+package. The rules have no pfBlockerNG ownership marker, so they will not be swept on uninstall.
+
+Two critical scoping decisions are settled by the maintainer:
+
+1. **Only port-53 (plaintext DNS) is covered here.** Clients using DoH (DNS-over-HTTPS) or
+   DoT/DoQ (DNS-over-TLS/QUIC) bypass port-53 interception entirely. That gap is
+   **complementary** to this ADR — DoH is addressed at the domain level via the DNSBL feed, and
+   port-853/443 blocking is **ADR-37**. This ADR does not try to intercept encrypted DNS; it
+   closes only the plaintext :53 path.
+
+2. **The firewall itself must be exempted.** A redirect that catches the firewall's own outbound
+   DNS queries would break upstream resolution and prevent the firewall from resolving anything.
+   The exemption is structural (negated destination `(self)` — see §2.2) and is always on.
+
+Load-bearing facts:
+
+- **pfSense port-forwards auto-create an associated filter PASS rule.** When a `nat/rule` entry
+  carries an `<associated-rule-id>`, pfSense writes a companion `filter/rule` that passes the
+  redirected traffic. Each NAT rdr rule therefore corresponds to exactly one filter pass rule;
+  both must be created and removed atomically (same pfBlockerNG descr marker so the ADR-35 sweep
+  covers both).
+- **These are pfSense-core sections** (`nat/rule`, `filter/rule`) — on the ADR-29 foreign-key
+  exclusion list; accessed via direct `config_*_path`. Unchanged by this ADR.
+- **The three new config fields** (`dns_redirect_enable`, `dns_redirect_iface`,
+  `dns_redirect_exception`) live in `installedpackages/pfblockerngdnsblsettings/config/0` and are
+  registered in `PfbConfig` per ADR-29. They are the only `config.xml` additions this ADR makes.
+- **Interface selection tracks pfBlockerNG's own firewall-rule interface set.** The quick-fill
+  option populates the multi-select with the union of the IP-feature `inbound_interface` +
+  `outbound_interface` fields (plus floating) — the same set pfBlockerNG already builds filter
+  rules for — because these NAT redirect rules are firewall rules and should follow the same
+  scope as the rest of pfBlockerNG's enforcement.
+- **No live pf in CI.** Rule-builder logic is unit-tested off-appliance against config-shaped
+  fixtures; the real NAT + pf interaction is a live-VM smoke (ADR-04).
+
+## 2. Decision
+
+Add an **optional, default-off** NAT DNS-redirection feature. When enabled, pfBlockerNG creates
+and maintains a set of NAT port-forward (rdr) rules — one pair per selected interface (IPv4 +
+IPv6) — that redirect all outbound port-53 DNS traffic on those interfaces to the firewall's own
+resolver. The rules are registered as ADR-35 managed objects (pfBlockerNG-marker ownership)
+and are created, reconciled, and removed through the ADR-35 seam. No ADR-35 marker/teardown
+logic is re-invented here.
+
+### 2.1 Per-area decision
+
+| Area | Decision |
+| --- | --- |
+| Feature scope | Port-53 TCP+UDP redirection only. DoH/DoT/DoQ bypass is out of scope (see §2.3). Plaintext :53 only. |
+| Redirect target | `127.0.0.1:53` for inet (IPv4) rules; `::1:53` for inet6 (IPv6) rules. `local-port 53`. `natreflection disable`. Protocol `tcp/udp`. |
+| Firewall-self exemption | **Always on.** Destination negated `<network>(self)</network><not/>` ensures the firewall's own outbound DNS is never intercepted. Cannot be disabled. |
+| User exception list | An optional **free-text exceptions field** holding zero or more entries — each an **IP / CIDR / host or an existing alias name** (whatever the maintainer needs for "these hosts get direct DNS"). Not restricted to a pre-existing alias. When non-empty it builds a negated source (`<source><not/>…</source>` — an alias when a single alias name is given, else the inline address set) so listed hosts bypass the redirect; when empty (default) source is `<any>`. Each entry is PFBL-01-validated before use. Both branches (empty / non-empty) tested. |
+| Interface selection | Multi-select using `pfb_build_if_list()` (WAN-excluded by default), stored comma-joined (plain string) — **reuse the existing "Permit Firewall Rules" pattern** (`dnsbl_allow_int`, `pfblockerng_dnsbl.php:2921`: `Form_Group('Permit Firewall Rules')` → multi `Form_Select` from `pfb_build_if_list(FALSE, FALSE)`, `size` = interface count), not an ad-hoc control. A **quick-fill** option tracks the union of pfBlockerNG's IP-feature `inbound_interface` + `outbound_interface` (plus floating) — the same scope as the existing firewall rules. Per selected interface: one inet + one inet6 rdr rule, each with its associated filter PASS rule. |
+| Rule count per interface | 2 NAT rdr rules (inet + inet6) + 2 associated filter PASS rules. Total: 4 config.xml entries per interface. |
+| Ownership + lifecycle | All 4 entries per interface carry a pfBlockerNG descr marker (`pfB_DNS_Redirect_<iface>_v4` / `pfB_DNS_Redirect_<iface>_v6` — exact naming confirmed in implementing phase against the codebase `pfB_` conventions). Registered via `pfb_fwobj_register()` per ADR-35. Created/reconciled idempotently on `sync_package_pfblockerng()`; removed on disable; swept on uninstall via `pfb_fwobj_sweep()`. |
+| Reconcile (stale-interface pruning) | On each sync, rules for interfaces **no longer in the selected set** are removed. A removed-from-config interface is treated as absent from the set; its rules are pruned by the marker sweep. |
+| Config fields | 3 new registered `PfbConfig` fields in `pfblockerngdnsblsettings/config/0` (see §2.2). ADR-29 5-step adding process. |
+| UI location | DNSBL settings page (`pfblockerng_dnsbl.php`) — new control block adjacent to the existing DoH/DoT/DoQ blocking section, **folding into / mirroring the existing `Form_Group('Permit Firewall Rules')` structure** (`:2921`) the interface multi-select already uses. Enable checkbox + interface multi-select + quick-fill button + exception-alias field + brief help text matching neighbouring style. Server-side validation (PFBL-01) before any rule build or path composition. |
+| Naming (config keys + marker) | Follow the established sibling convention rather than ad-hoc names: keys live beside `dnsbl_allow_int` / `dnsbl_interface` in `pfblockerngdnsblsettings`, so the `dns_redirect_*` names below are **provisional** — final names align to the `dnsbl_*` / `*_int` pattern (e.g. `dnsbl_redir` / `dnsbl_redir_int` / `dnsbl_redir_exclude`), confirmed with the maintainer before the keys are frozen (CLAUDE.md "Naming — follow the established pattern"; storage freeze applies once chosen). |
+| Complementary features | Port-53 redirect is complementary to the DoH/DoT/DoQ domain NXDOMAIN approach. ADR-37 adds port-853/443 blocking. This ADR does not replace either; it closes only the plaintext :53 bypass path. |
+
+### 2.2 Semantics that MUST be preserved / hold (the contract — pin with tests)
+
+**Ground-truth rule shape** (from the maintainer's working config.xml; every field below is
+mandatory and exactly matched):
+
+```xml
+<rule>                                    <!-- nat/rule -->
+  <!-- source: negated exception alias; <any> when alias is empty -->
+  <source><address>EXCEPTION_ALIAS</address><not></not></source>
+  <!-- destination: negated (self) = firewall-self-exempt; port 53 -->
+  <destination><network>(self)</network><not></not><port>53</port></destination>
+  <ipprotocol>inet</ipprotocol>           <!-- inet for v4 rule; inet6 for v6 rule -->
+  <protocol>tcp/udp</protocol>
+  <target>127.0.0.1</target>              <!-- v4: 127.0.0.1  v6: ::1 -->
+  <local-port>53</local-port>
+  <interface>lan</interface>              <!-- one rule set per selected interface -->
+  <descr><![CDATA[pfB_DNS_Redirect_lan_v4]]></descr>   <!-- pfBlockerNG marker -->
+  <associated-rule-id>nat_...</associated-rule-id>
+  <natreflection>disable</natreflection>
+</rule>
+```
+
+Invariants (each asserted by PHPUnit tests with full branch coverage):
+
+- **Destination is always negated `(self)` with port 53** — the firewall-self-exempt is
+  structurally present in every generated rule, for both inet and inet6 families. No code path
+  produces a rule without it.
+- **Source is negated-alias when exception alias is set; `<any>` when alias is empty.** Both
+  branches produce structurally valid rules. The transition (empty → set → empty) is
+  round-trip stable.
+- **Target is family-specific**: inet rule → `127.0.0.1`; inet6 rule → `::1`. Never crossed.
+- **`natreflection` is `disable`** on every generated rule.
+- **Protocol is `tcp/udp`** on every generated rule.
+- **`local-port` is `53`** on every generated rule.
+- **`descr` carries the pfBlockerNG marker** and is the sole ownership signal (ADR-35 contract).
+  The associated filter PASS rule carries a corresponding marker so the ADR-35 sweep removes
+  both atomically.
+- **Multiple interfaces → one rule set (inet + inet6 rdr + 2 filter) per interface.** Each
+  set is independent and carries the interface name in its marker.
+- **Disable removes all owned rules** (marker sweep via ADR-35). A user NAT rule (no marker)
+  is never touched.
+- **Reconcile is idempotent** — calling the builder twice with identical settings produces the
+  same config.xml state; no duplicate rules accumulate.
+- **Stale-interface rules are pruned on reconcile** — if an interface is removed from the
+  selection, its rules (identified by marker) are removed on the next sync.
+- **New config fields round-trip** through `PfbConfig` (ADR-29 backward-compat contract):
+  `write(read(v)) == v` for every stored vocabulary value.
+
+### 2.3 Explicitly kept / out of scope
+
+- **DoH (DNS-over-HTTPS) interception** — out. Clients using DoH on port 443 bypass port-53
+  redirect entirely; domain-level DNSBL blocking is the existing countermeasure.
+- **DoT/DoQ port-853 blocking** — out; that is ADR-37. The two features are complementary but
+  independent.
+- **Per-client or per-subnet policies beyond the single exception alias** — out. A single
+  alias covers the use case; per-row policies are a future extension.
+- **Redirecting non-53 DNS** (e.g. non-standard ports, DNS-over-TLS on 853) — out.
+- **NAT reflection** — explicitly disabled (`natreflection disable`). The redirect targets
+  the firewall loopback; reflection is meaningless here.
+- **Creating/managing an alias object** — out. The exceptions field is a plain reference: it
+  accepts inline IP/CIDR/host entries and/or the name of an alias the user maintains through the
+  normal pfSense Firewall → Aliases UI. pfBlockerNG does not create or own that alias.
+- **Renaming or modifying existing pfBlockerNG NAT markers** — out (storage freeze, ADR-28).
+  This ADR introduces new markers only.
+- **Changing `pfb_remove_config_settings()` or the ADR-35 sweep logic** — out. The sweep is
+  already provided by ADR-35; this ADR registers through it.
+
+## 3. Consequences
+
+**Positive**
+
+- Closes the plaintext :53 DNS-bypass gap: a client with a hardcoded external DNS server is
+  redirected to the firewall's resolver and is subject to pfBlockerNG DNSBL matching.
+- Firewall-self exemption is structural (negated destination `(self)`) — cannot be accidentally
+  removed; upstream resolution is never disrupted.
+- Lifecycle managed via ADR-35 (register/reconcile/remove/sweep) — no bespoke teardown code;
+  the feature stays thin and consistent with ADR-36/37 siblings.
+- Default off — zero impact on existing installations that do not opt in.
+- Config fields are registered in `PfbConfig` with the ADR-29 backward-compat invariants;
+  an older release ignores the keys (inert), a rollback preserves them for roll-forward.
+
+**Negative / risks**
+
+- **Risk: breaking the firewall's own DNS.** The negated `(self)` destination exempts the
+  firewall structurally. Tested: a rule without negation would redirect the firewall's own
+  queries to itself (loopback), causing a resolution loop. The structural exemption prevents
+  this; every generated rule is asserted to carry it.
+- **Risk: redirect with no active DNS resolver on loopback.** If Unbound is not listening on
+  `127.0.0.1:53` / `::1:53` (unusual pfSense configuration), the redirect sends DNS queries to
+  a dead port, effectively breaking DNS for affected clients. Documented in the UI help text;
+  out of scope to gate on the resolver state.
+- **Risk: DoH/DoT bypass.** Port-53 redirect does not catch DNS-over-HTTPS or DNS-over-TLS
+  clients. Documented limitation; ADR-37 addresses the DoT/DoQ side. Users must understand
+  the feature does not provide complete bypass protection.
+- **Risk: NAT + associated filter rule atomicity.** If the NAT rule is created but the filter
+  PASS rule is absent (or vice versa), traffic is either redirected without a pass rule
+  (dropped) or a dangling filter rule exists. Both are registered via ADR-35 with the same
+  marker so the sweep removes both; idempotent create ensures both are written in the same
+  `write_config()` flush.
+- **Risk: interface churn leaving stale rules.** Mitigated by the reconcile-time stale-prune
+  (marker scan for rules belonging to interfaces no longer in the selected set).
+- **Risk: user exception alias mismatch** (alias name changed or deleted outside pfBlockerNG).
+  Out of scope to validate alias existence at runtime; the rule will reference a non-existent
+  alias, which pfSense treats as matching nothing — the rule becomes effectively a catch-all
+  redirect. Documented in help text.
+
+## 4. Requirements (acceptance)
+
+- A pure `pfb_build_dns_redirect_rules($settings)` builder function returning the exact
+  rule-set array (NAT + associated filter) matching the §2.2 ground-truth shape, for any
+  combination of interface / IP family / exception alias state.
+- The builder registered via `pfb_fwobj_register()` (ADR-35); create/reconcile/remove/sweep
+  wired into `sync_package_pfblockerng()` and the disable/uninstall paths.
+- Three new `PfbConfig`-registered fields: `dns_redirect_enable` (toggle), `dns_redirect_iface`
+  (plain string), `dns_redirect_exception` (plain string) — ADR-29 5-step process, including
+  `CfgGatewayTest.php` round-trip tests + inventory update + `$registeredPaths` in the sniff.
+- UI control block on `pfblockerng_dnsbl.php`: enable checkbox + interface multi-select +
+  quick-fill (tracks pfBlockerNG fw-rule interface set) + exception-alias field + help text;
+  server-side PFBL-01 validation of interface names and alias name before rule build.
+- All gates green (§5); live-VM smoke proves the full lifecycle.
+
+## 5. Constraints (from CLAUDE.md)
+
+- PHP tabs, PHP 8.3; no `die()`/`exit()` in library code.
+- **ADR-28**: uppercase `TRUE`/`FALSE`; storage freeze (new stored vocabulary defined once and
+  never changed; existing markers are immutable).
+- **ADR-29**: three new fields registered in `PfbConfig` via the 5-step process. The managed
+  sections (`nat/rule`, `filter/rule`) stay pfSense-core foreign → direct `config_*_path`, NOT
+  `PfbConfig`. The sniff's `$registeredPaths` must be updated for all three new keys.
+  `pfblockerng_extra.inc` is excluded from the sniff (the gateway itself).
+- **ADR-35**: use `pfb_fwobj_register` / `pfb_fwobj_find` / `pfb_fwobj_remove` / `pfb_fwobj_sweep`
+  exclusively. Do NOT re-invent marker detection, teardown logic, or orphan sweep.
+- **PFBL-01**: the rule builder and any UI form handler that accepts interface names or alias
+  names is an in-scope input-handling surface. Add the new functions to the PHPCS
+  `scopeFunctions` allow-list; validate interface names against `pfb_build_if_list()` output
+  and alias names via `pfb_filter()` / `is_validaliasname()` before any rule construction or
+  path composition.
+- **ADR-04 smoke** for the end-to-end create/disable/uninstall lifecycle and the pf table
+  verification.
+- **ADR-14 `ui_render`** for the modified DNSBL settings page.
+
+## 6. Action plan
+
+### Phase 1 — Config fields + golden rule-builder tests
+
+- Prompt: `01_Config_Fields_And_Builder_Tests.txt`
+- Register the three new `PfbConfig` fields in `pfb_cfg_registry()` (`pfblockerng_extra.inc`):
+  `dns_redirect_enable` (toggle adapter, stored `'on'`/`''`, default `''`),
+  `dns_redirect_iface` (plain adapter, stored comma-joined string, default `''`),
+  `dns_redirect_exception` (plain adapter, stored string, default `''`).
+  Follow the ADR-29 5-step process: registry entry + `since: '4.0.0'` + round-trip verify +
+  `CfgGatewayTest.php` (round-trip + default-absent) + inventory update +
+  `$registeredPaths` in `RequireConfigGatewaySniff.php`.
+- Write a pure `pfb_build_dns_redirect_rules($settings)` skeleton function in
+  `pfblockerng.inc` (or a new helper include — implementer's call based on code size). The
+  function takes: interface name, IP family (`inet`/`inet6`), exception alias string (may be
+  empty). It returns an array with exactly two entries: the NAT rdr rule array + the associated
+  filter rule array, matching the §2.2 ground-truth field-for-field.
+- **Tests (oracle first):** PHPUnit golden tests pinning the exact rule structure. Required
+  branches: (a) inet family → target `127.0.0.1`, source `<any>`; (b) inet6 family → target
+  `::1`, source `<any>`; (c) exception alias set → source negated-alias; (d) exception alias
+  empty → source `<any>`; (e) multiple interfaces → independent rule sets; (f) descr marker
+  present in both NAT and filter entries. Assert destination is always negated `(self)` + port
+  53. Assert `natreflection` is `disable`. Assert `protocol` is `tcp/udp`. Assert `local-port`
+  is `53`. All branches before the builder implementation is wired to any live sync.
+- Tests: `CfgGatewayTest.php` round-trip for all three new fields.
+
+### Phase 2 — Rule builder + ADR-35 registration + sync wiring
+
+- Prompt: `02_Builder_And_Sync.txt`
+- Complete the `pfb_build_dns_redirect_rules()` implementation so it passes all Phase-1 golden
+  tests.
+- Register the builder via `pfb_fwobj_register()` (ADR-35): spec includes type `nat`, the
+  `pfB_DNS_Redirect_*` marker prefix, the builder callable, and the associated filter rule
+  builder so both are tracked under the same registration (or register as two entries sharing
+  the marker prefix — implementer decides based on ADR-35 spec shape, reading
+  `pfblockerng_fwobj.inc` first).
+- Wire create/reconcile into `sync_package_pfblockerng()`: when `dns_redirect_enable == 'on'`,
+  build and write the rule set for each selected interface; when off or no interfaces selected,
+  remove all owned rules (marker sweep). On each sync, prune rules for any interface no longer
+  in the selected set (stale-interface reconcile).
+- Tests: reconcile-is-idempotent (two syncs → same config); disable removes all marked rules
+  while a seeded user NAT rule (no marker) survives; stale-interface rules are pruned on the
+  next sync (rule for removed interface is gone; rule for retained interface stays).
+
+### Phase 3 — UI on the DNSBL settings page
+
+- Prompt: `03_UI.txt`
+- Add a new control block in `pfblockerng_dnsbl.php` adjacent to the DoH/DoT/DoQ section.
+  Block contains: (a) enable checkbox bound to `dns_redirect_enable`; (b) interface
+  multi-select (`pfb_build_if_list()`, WAN-excluded by default, pre-selected from
+  `dns_redirect_iface`); (c) a quick-fill button/link that populates the multi-select with
+  the union of the current `inbound_interface` + `outbound_interface` values (the pfBlockerNG
+  fw-rule interface set); (d) exception-alias free-text field bound to
+  `dns_redirect_exception`; (e) brief help text (style matches neighbouring DoH/DoT/DoQ help
+  text) warning that (i) port-53 only, (ii) DoH/DoT bypass is not covered, (iii) the alias must
+  exist in Firewall → Aliases.
+- Server-side POST handler: validate selected interface names against `pfb_build_if_list()`
+  output before accepting; validate alias name via `pfb_filter()` / `is_validaliasname()` if
+  non-empty (PFBL-01 surface — add the handler function to PHPCS `scopeFunctions`).
+- Save via `PfbConfig::write()` for all three registered fields.
+- Tests: PHPUnit for the server-side validator (valid/invalid interface name, valid/empty/invalid
+  alias); ADR-14 `ui_render` for `pfblockerng_dnsbl.php` (200, no PHP errors, page marker
+  present, no new `php_error.log` line).
+
+### Phase 4 — Smoke + DoD + docs
+
+- Prompt: `04_Smoke_DoD_Docs.txt`
+- ADR-04 live-VM smoke (`tests/smoke/test_dns_redirect.py` or appended to an existing smoke
+  file). Required cases:
+  - **Enable path:** enable redirect on the LAN interface → assert both NAT rdr rules (inet +
+    inet6) appear in `config.xml` with the pfBlockerNG marker; assert the associated filter PASS
+    rules are present; assert `pfctl -sn` shows the rdr rules active.
+  - **Disable path:** disable → assert all pfB_DNS_Redirect_* entries removed from
+    `config.xml`; assert `pfctl -sn` shows no pfBlockerNG rdr rules.
+  - **User-rule survival:** seed a user NAT rule (no marker) before enable; after disable +
+    uninstall, assert the user rule survives untouched.
+  - **Stale-interface prune:** enable on two interfaces, then reduce to one → assert the rule
+    set for the removed interface is gone; the retained interface rules remain.
+  - **Exception alias branch (config.xml assertion):** enable with a non-empty alias → assert
+    the source is `<address>ALIAS</address><not/>` in config.xml; enable with empty alias →
+    assert source is `<any>` (both branches, both IP families).
+  - **Uninstall sweep:** use ADR-35's sweep test pattern — install + enable → uninstall →
+    assert all pfB_DNS_Redirect_* gone, no pfBlockerNG `nat/rule` or `filter/rule` entries
+    remain, and `installedpackages/pfblockerng*` gone.
+  - **Full client-redirect behaviour** (on-box `pfctl -sn` assertion of the rdr rule is the
+    CI-feasible gate; actual client DNS interception requires a second host and is a documented
+    maintainer manual-smoke item — see §7).
+- `docs/misc/architecture-notes.md` blurb covering the redirect feature, the self-exempt
+  mechanism, and the DoH/DoT complementary relationship.
+- ADR-14 `ui_render` for `pfblockerng_dnsbl.php` (if not already green from Phase 3 CI).
+
+## 7. Definition of done
+
+- [ ] `pfb_build_dns_redirect_rules()` passes all golden tests — exact §2.2 rule shape, all
+      branches (inet/inet6, alias set/empty, multiple interfaces, marker present in NAT +
+      filter entries).
+- [ ] Three `PfbConfig`-registered fields (`dns_redirect_enable`, `dns_redirect_iface`,
+      `dns_redirect_exception`) with ADR-29 round-trip + forward/backward invariants green
+      (`CfgGatewayTest.php`, `RollbackContractTest.php`).
+- [ ] ADR-35 registration in place; create/reconcile/remove/sweep exercised for the redirect
+      rule set (idempotent, stale-prune, user-rule survival — all asserted).
+- [ ] UI control block on `pfblockerng_dnsbl.php`: enable + multi-select + quick-fill +
+      exception alias + help text; server-side PFBL-01 validation.
+- [ ] All gates green: `vendor/bin/phpunit`, PHPStan, PHPCS (PFBL-01 + ADR-28 + ADR-29 sniffs),
+      `php -l`, `python -m pytest`, ADR-14 `ui_render`.
+- [ ] Live-VM smoke proves: NAT + filter rules appear on enable, are removed on disable, survive
+      uninstall correctly (pfB_DNS_Redirect_* gone; user rule survives); stale-interface prune
+      works; `pfctl -sn` confirms the rdr rules are active.
+
+**Manual smoke (owner: maintainer):**
+
+- [ ] Enable DNS redirect on LAN with an empty exception alias → confirm a client with `8.8.8.8`
+      as DNS server has its port-53 queries answered by the pfSense resolver (verified by a DNS
+      query to an external server that should return DNSBL-blocked result — block is applied).
+- [ ] Populate the exception alias with the client's IP → confirm that client now bypasses the
+      redirect (external DNS server answers again).
+- [ ] Enable redirect on LAN + OPT1 → disable on OPT1 only → confirm OPT1 rules gone, LAN rules
+      remain.
+- [ ] Uninstall pfBlockerNG with redirect enabled → confirm no pfB_DNS_Redirect_* rules remain
+      in Firewall → NAT and no dangling filter rules.
+
+**Reject criteria:** if the pfSense port-forward + associated-filter-rule creation cannot be
+driven deterministically from config.xml writes alone (e.g. if pfSense requires a PHP function
+call that cannot be replicated off-appliance to wire the `associated-rule-id`), **reduce** to
+a documented limitation (the associated filter rule is created manually or via a pfSense-internal
+hook on package apply). If the ADR-35 registration seam cannot cover both the NAT and associated
+filter rule atomically, **reduce** to a single-marker sweep with a documented atomicity caveat
+and a verify-both-exist assertion on every reconcile.

--- a/.ADRs/ADR_37_DoT_DoQ_Block/01_Config_Fields_And_Builder_Tests.txt
+++ b/.ADRs/ADR_37_DoT_DoQ_Block/01_Config_Fields_And_Builder_Tests.txt
@@ -1,0 +1,133 @@
+================================================================================
+PHASE 1 PROMPT — Config fields (PfbConfig registry) + golden rule-builder tests
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_37_DoT_DoQ_Block/ADR.md   (read §1, §2.1, §2.2, §5 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/37-dot-doq-block (off devel; create off the latest
+devel if absent). Phase 1 is ORACLE-FIRST: register config fields and write golden PHPUnit
+tests pinning the exact rule shape BEFORE any builder implementation. One commit, push directly.
+
+WHY THIS PHASE EXISTS
+The golden tests are the specification. The builder (Phase 2) must pass them all; if it cannot,
+that is a Phase 2 bug — not a reason to relax the tests. Writing the tests before the
+implementation removes any unconscious bias toward the implementation rather than the ground
+truth.
+
+REQUIRED READING
+- .ADRs/ADR_37_DoT_DoQ_Block/ADR.md — full document; focus on §2.1, §2.2 (ground-truth XML),
+  §4 (requirements), §5 (constraints).
+- src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc — pfb_cfg_registry() (the PfbConfig
+  field registry); the existing toggle/plain adapter entries for style reference; PfbConfig
+  class definition.
+- tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php — the $registeredPaths
+  property; add all three new keys here.
+- tests/php/CfgGatewayTest.php — round-trip + default-absent test pattern; add three new test
+  cases following the existing style.
+- tests/php/RollbackContractTest.php — $inventory; add the three new field names.
+- tests/php/ — general PHPUnit style; CLAUDE.md §"Test coverage" for branch + BDD mandate.
+- .ADRs/ADR_36_DNS_Redirection/ADR.md §2.1 + §2.2 — sibling feature for naming consistency.
+
+ACTION PLAN (ordered — tests FIRST)
+
+1. REGISTER the three new PfbConfig fields in pfb_cfg_registry() in pfblockerng_extra.inc:
+   - dnsbl_dot_block         toggle adapter  stored 'on'/'', default ''
+   - dnsbl_dot_block_int     plain adapter   stored comma-joined string, default ''
+   - dnsbl_dot_block_exclude plain adapter   stored string, default ''
+   Section path for all three: installedpackages/pfblockerngdnsblsettings/config/0/<key>
+   since: '4.0.0' for all three (new in this ADR).
+   Verify the adapter pairs: toggle uses pfb_cfg_toggle_read/write; plain uses NULL/NULL.
+
+2. ADD the three new full paths to $registeredPaths in RequireConfigGatewaySniff.php.
+   Exact format: 'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block' etc.
+
+3. ADD three new test cases to CfgGatewayTest.php following the existing pattern:
+   - dnsbl_dot_block: round-trip 'on' -> PfbToggle::On -> 'on'; round-trip '' -> PfbToggle::Off
+     -> ''; default-absent returns PfbToggle::Off.
+   - dnsbl_dot_block_int: round-trip 'lan,opt1' -> 'lan,opt1'; default-absent returns ''.
+   - dnsbl_dot_block_exclude: round-trip 'DoT_Exceptions' -> 'DoT_Exceptions'; default-absent ''.
+
+4. UPDATE $inventory in RollbackContractTest.php to include the three new field names.
+
+5. WRITE a skeleton pfb_build_dot_block_rule($iface, $exclude_alias) function in pfblockerng.inc
+   (or a new helper include if the implementer judges that cleaner given the file size — read the
+   file first). The skeleton may return an empty array or throw; it exists only so the tests can
+   call it. The implementation is Phase 2.
+   Place it near the ADR-36 DNS redirect builder when that exists, or near pfb_firewall_rule()
+   otherwise — grep pfblockerng.inc for the nearest sibling.
+
+6. WRITE PHPUnit golden tests for pfb_build_dot_block_rule() in a new test file
+   tests/php/DotDoQBlockRuleTest.php. Tests are ORACLE-FIRST — they MUST FAIL against the
+   skeleton and PASS only against a correct implementation. Required branches (all must be
+   independent test methods with descriptive names):
+
+   a. test_source_is_any_when_no_exception_alias
+      Call pfb_build_dot_block_rule('lan', '') — assert source element is <any/>.
+
+   b. test_source_is_negated_alias_when_exception_alias_set
+      Call pfb_build_dot_block_rule('lan', 'DoT_Exceptions') — assert source has <address>
+      containing 'DoT_Exceptions' AND <not/> present in source.
+
+   c. test_type_is_block
+      Assert rule['type'] === 'block'.
+
+   d. test_ipprotocol_is_inet46
+      Assert rule['ipprotocol'] === 'inet46'.
+
+   e. test_protocol_is_tcp_udp
+      Assert rule['protocol'] === 'tcp/udp'.
+
+   f. test_destination_has_self_not_and_port_853
+      Assert destination['network'] === '(self)'; destination has <not/> present; destination
+      port === '853'. Both with alias set and alias empty (call both; assert destination is
+      identical regardless of alias).
+
+   g. test_statetype_is_keep_state
+      Assert rule['statetype'] === 'keep state'.
+
+   h. test_descr_marker_contains_iface
+      Call pfb_build_dot_block_rule('opt2', '') — assert descr starts with 'pfB_DoT_Block_'
+      and contains 'opt2'.
+
+   i. test_multiple_interfaces_produce_independent_rules
+      Call the builder for 'lan' and 'opt1' separately — assert each rule has the correct
+      interface value and its own distinct marker; they do not share state.
+
+   All assertions must be on the exact field values from §2.2 — not substring contains unless
+   the field is a CDATA string. Assert the before-state where applicable (e.g. assert the
+   skeleton returns empty-or-throws before describing what a correct implementation must return
+   — use @depends or the test ordering to make the oracle nature clear in comments).
+
+CONSTRAINTS
+- PHP tabs; PHP 8.3; no die()/exit().
+- Do NOT implement pfb_build_dot_block_rule() — skeleton only. Phase 2 implements.
+- Do NOT wire the builder into sync_package_pfblockerng() — that is Phase 2.
+- Do NOT add UI code — that is Phase 3.
+- Do NOT change any existing config field, marker string, or adapter.
+- Tests MUST fail against the skeleton and be designed to pass only against a correct
+  implementation (oracle-first discipline).
+
+VERIFICATION (must all pass before the phase is done)
+- vendor/bin/phpunit -> CfgGatewayTest + RollbackContractTest green; DotDoQBlockRuleTest
+  MAY be red (the builder is a skeleton) — but all other tests must be green.
+- php -l src/ tests/php/DotDoQBlockRuleTest.php -> no syntax errors.
+- PHPStan -> no new errors (the skeleton function is typed; tests load via bootstrap).
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> green (RequireConfigGateway sniff sees
+  the new registered paths; UppercaseBooleanLiteral sniff clean).
+- python -m pytest -> green (no Python changes; existing suite must pass).
+
+EXPECTED RESULT
+Three PfbConfig fields registered + round-trip tested; the RequireConfigGateway sniff updated;
+a skeleton builder function; PHPUnit golden tests that specify the exact rule shape and fail
+against the skeleton.
+
+COMMIT (single)
+    pfblockerng: add DoT/DoQ block config fields and golden rule tests (ADR-37 P1)
+Push directly to adr/37-dot-doq-block; open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_37_DoT_DoQ_Block/RESULTS/01_Results.txt (plain .txt)
+Record: the three field names + adapter types + stored vocabulary + since values confirmed in
+registry; the $registeredPaths entries added to the sniff; the builder function signature +
+file location; the list of golden test method names; which tests are red (expected — skeleton)
+vs green; PHPUnit/PHPStan/PHPCS/pytest pass counts; go-ahead for Phase 2.

--- a/.ADRs/ADR_37_DoT_DoQ_Block/02_Builder_And_Sync.txt
+++ b/.ADRs/ADR_37_DoT_DoQ_Block/02_Builder_And_Sync.txt
@@ -1,0 +1,119 @@
+================================================================================
+PHASE 2 PROMPT — Builder implementation + ADR-35 registration + sync wiring
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_37_DoT_DoQ_Block/ADR.md   (read §2.1, §2.2, §4, §5 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/37-dot-doq-block. Phase 2 implements the rule
+builder (passes the Phase-1 golden tests), registers it via ADR-35, and wires it into
+sync_package_pfblockerng(). One commit, push directly.
+
+REQUIRED READING (FIRST — read before writing a single line of code)
+FIRST, read the prior phase's handoff:
+    .ADRs/ADR_37_DoT_DoQ_Block/RESULTS/01_Results.txt
+If that file is missing, STOP and report — do not proceed.
+
+Then read:
+- .ADRs/ADR_37_DoT_DoQ_Block/ADR.md — §2.1, §2.2 (ground-truth rule shape), §4, §5.
+- src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc — the ADR-35 implementation. Read it
+  fully: pfb_fwobj_register(), pfb_fwobj_find(), pfb_fwobj_remove(), pfb_fwobj_sweep(), the
+  $spec shape, the marker contract. Do NOT guess the API — read the actual file.
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc — the builder skeleton location (confirmed in
+  Phase-1 handoff); sync_package_pfblockerng() (grep for it; read the section that wires the
+  ADR-36 redirect, if present, for the pattern to mirror). The filter-rule rebuild at ~13709
+  (the pfB_ prefix strip-and-rebuild model).
+- tests/php/DotDoQBlockRuleTest.php — the Phase-1 golden tests; the implementation must pass
+  all of them without modifying the tests.
+- .ADRs/ADR_36_DNS_Redirection/ADR.md §6 Phase 2 — sibling sync-wiring pattern for reference.
+
+ACTION PLAN
+
+1. IMPLEMENT pfb_build_dot_block_rule($iface, $exclude_alias) — the full production
+   implementation. The function must:
+   - Return a single PHP array representing the filter/rule with all fields from §2.2:
+     type='block', interface=$iface, ipprotocol='inet46', protocol='tcp/udp',
+     source=<any> when $exclude_alias is empty / negated alias array when set,
+     destination=['network'=>'(self)', 'not'=>'', 'port'=>'853'],
+     statetype='keep state',
+     descr='pfB_DoT_Block_' . $iface (CDATA is a pfSense serialisation detail; the array
+     value is the plain string — pfSense writes it as CDATA when serialising config.xml).
+   - Pass ALL nine test methods in DotDoQBlockRuleTest.php without any modification to the
+     tests.
+   - Uppercase TRUE/FALSE where boolean literals are needed (ADR-28). PHP tabs, PHP 8.3.
+   - No die()/exit(); return the array or throw on invalid input.
+
+2. REGISTER via ADR-35. Read pfblockerng_fwobj.inc first to confirm the exact pfb_fwobj_register()
+   $spec shape, then register:
+   - type: 'filter'
+   - marker prefix: 'pfB_DoT_Block_' (matches the descr prefix the builder emits)
+   - builder: the pfb_build_dot_block_rule callable (or equivalent spec field)
+   Register this call at the same site as the ADR-35 VIP and NAT registrations, or adjacent
+   to the ADR-36 redirect registration if that exists. Read the file; do not guess the location.
+
+3. WIRE into sync_package_pfblockerng():
+   - Read dnsbl_dot_block via PfbConfig::read('dnsbl_dot_block').
+   - Read dnsbl_dot_block_int via PfbConfig::read('dnsbl_dot_block_int').
+   - Read dnsbl_dot_block_exclude via PfbConfig::read('dnsbl_dot_block_exclude').
+   - When enabled and at least one interface selected: for each comma-split interface, call
+     pfb_build_dot_block_rule($iface, $exclude_alias) and write the resulting rule into
+     filter/rule via config_set_path (pfSense-core section — direct config_*_path, NOT
+     PfbConfig — see the foreign-key exclusion list in CLAUDE.md).
+   - Reconcile: on each sync, prune rules for interfaces no longer in the selected set using
+     pfb_fwobj_find() / pfb_fwobj_remove() with the 'pfB_DoT_Block_' marker prefix.
+     A rule for 'opt1' when 'opt1' is no longer in dnsbl_dot_block_int must be removed.
+   - When disabled or no interfaces selected: remove all pfB_DoT_Block_* rules via the
+     ADR-35 marker sweep.
+   Wire at the same position as the ADR-36 wiring (or near pfb_firewall_rule() / the IP
+   filter rule build section) — mirror the sibling pattern exactly.
+
+4. WRITE additional PHPUnit tests in a new or extended test file:
+   a. test_reconcile_is_idempotent: call the sync helper twice with the same settings;
+      assert config.xml filter/rule contains exactly one pfB_DoT_Block_lan entry (no
+      duplicates). Assert before-state (zero rules) first.
+   b. test_disable_removes_all_dot_block_rules: seed a pfB_DoT_Block_lan rule in the fixture;
+      assert it is present (before-state); call the sync helper with enabled=false; assert no
+      pfB_DoT_Block_* rules remain.
+   c. test_user_rule_survives_disable: seed a user filter rule (no pfB_ marker); disable the
+      DoT block; assert the user rule is still present.
+   d. test_stale_interface_pruned_on_reconcile: seed rules for 'lan' and 'opt1'; call sync
+      with only 'lan' selected; assert the 'opt1' rule is gone and the 'lan' rule remains.
+      Assert both present before the reconcile call (before-state).
+
+   BDD-style for the stale-interface test (Given/When/Then comments in the test body).
+
+CONSTRAINTS
+- PHP tabs; PHP 8.3; uppercase TRUE/FALSE (ADR-28); no die()/exit().
+- Do NOT modify the Phase-1 golden tests — the implementation must pass them as written.
+- Do NOT re-implement marker detection or sweep logic — use ADR-35 functions exclusively.
+- Use PfbConfig::read() for the three registered fields; use direct config_*_path for
+  filter/rule (pfSense-core foreign section).
+- Do NOT add UI code — that is Phase 3.
+- The RequireConfigGateway sniff must stay green: filter/rule writes use config_*_path
+  directly (correct — it is a foreign pfSense-core section), not PfbConfig.
+- PFBL-01: the sync wiring is not in an in-scope function per the allow-list, but if the
+  builder or any helper is added to pfblockerng.inc in an allow-listed scope, ensure no
+  unguarded exec/path-build appears.
+
+VERIFICATION (must all pass before the phase is done)
+- vendor/bin/phpunit -> ALL tests green including Phase-1 DotDoQBlockRuleTest + new
+  reconcile/disable/survival/stale-prune tests.
+- php -l src/ -> no syntax errors.
+- PHPStan -> no new errors.
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> green.
+- python -m pytest -> green.
+
+EXPECTED RESULT
+pfb_build_dot_block_rule() fully implemented and passing all golden tests; ADR-35 registration
+in place; sync_package_pfblockerng() creates, reconciles, and removes DoT/DoQ block rules
+correctly; idempotency, disable, user-rule survival, and stale-interface pruning all tested.
+
+COMMIT (single)
+    pfblockerng: implement DoT/DoQ block rule builder and sync wiring (ADR-37 P2)
+Push directly to adr/37-dot-doq-block.
+
+HANDOFF — write .ADRs/ADR_37_DoT_DoQ_Block/RESULTS/02_Results.txt (plain .txt)
+Record: builder function signature + file:line; ADR-35 registration call location + $spec
+fields used; sync_package_pfblockerng() wiring location (file:line range); list of new test
+methods + pass/fail counts; any deviation from the plan (e.g. if the ADR-35 spec shape
+differed from what was expected — note it so Phase 3 can account for it); go-ahead for Phase 3.

--- a/.ADRs/ADR_37_DoT_DoQ_Block/03_UI.txt
+++ b/.ADRs/ADR_37_DoT_DoQ_Block/03_UI.txt
@@ -1,0 +1,128 @@
+================================================================================
+PHASE 3 PROMPT — UI control on DNSBL settings page + PFBL-01 validation
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_37_DoT_DoQ_Block/ADR.md   (read §2.1, §4, §5 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/37-dot-doq-block. Phase 3 adds the UI control block
+to pfblockerng_dnsbl.php, the server-side PFBL-01 validation, and the ADR-14 ui_render test.
+One commit, push directly.
+
+REQUIRED READING (FIRST — read before writing a single line of code)
+FIRST, read the prior phase's handoff:
+    .ADRs/ADR_37_DoT_DoQ_Block/RESULTS/02_Results.txt
+and the ADR-36 UI implementation in src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php around
+line 2921 — the Form_Group('Permit Firewall Rules') block + pfb_build_if_list(FALSE, FALSE)
+multi-select pattern that this ADR mirrors exactly. If either is missing, STOP and report.
+
+Then read:
+- .ADRs/ADR_37_DoT_DoQ_Block/ADR.md — §2.1 (UI location, naming), §4, §5 (PFBL-01 constraint).
+- src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php — the existing DoH/DoT/DoQ blocking
+  section (grep for 'DoT' or 'DoH' to find it); the ADR-36 redirect UI block if present;
+  the Form_Group('Permit Firewall Rules') pattern at ~2921. Read the surrounding ~100 lines
+  for style, field naming, help-text wording length, and PfbConfig::read/write call sites.
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc — pfb_build_if_list() signature (grep ~3374).
+- tests/php/ — existing UI/validator test style; CLAUDE.md §"Test coverage" BDD mandate.
+- tests/smoke/ui/ — ADR-14 ui_render test pattern (existing tests for pfblockerng_dnsbl.php).
+
+ACTION PLAN
+
+1. ADD the DoT/DoQ block UI control block to pfblockerng_dnsbl.php. Place it adjacent to:
+   - The ADR-36 redirect control block (if present — check), AND
+   - The existing DoH/DoT/DoQ blocking section (grep for 'DoT'/'DoH' to locate).
+   Mirror the exact Form_Group structure from the ADR-36 redirect block and the existing
+   dnsbl_allow_int Form_Group('Permit Firewall Rules') at ~2921. The new block contains:
+
+   a. Enable checkbox — field: dnsbl_dot_block; read via PfbConfig::read('dnsbl_dot_block');
+      save via PfbConfig::write('dnsbl_dot_block', ...) on POST. Label: e.g. "Block
+      DNS-over-TLS / DNS-over-QUIC (port 853)" — match the wording style of neighbouring
+      controls.
+
+   b. Interface multi-select — field: dnsbl_dot_block_int; built from pfb_build_if_list(FALSE,
+      FALSE) (WAN-excluded); pre-selected from PfbConfig::read('dnsbl_dot_block_int') (split
+      on comma); size = count of available interfaces (match the dnsbl_allow_int pattern
+      exactly). Save the selected values as a comma-joined string via PfbConfig::write().
+
+   c. Quick-fill — a button or link that, when clicked (JS), populates the interface
+      multi-select with the union of the current inbound_interface + outbound_interface values
+      (the pfBlockerNG fw-rule interface set). Mirror the ADR-36 quick-fill implementation
+      exactly — read how it works in that block first.
+
+   d. Exception alias field — text input; field: dnsbl_dot_block_exclude; read/save via
+      PfbConfig. Default empty. Label: e.g. "DoT/DoQ Exception Alias".
+
+   e. Help text — one short paragraph, style matching the neighbouring DoH/DoT/DoQ help text.
+      Must include all four of these notes (terse; do not out-prose neighbours):
+      - Blocks standard-port DoT (TCP 853) and DoQ (UDP 853) only.
+      - DoH (port 443) is NOT blocked here — blocking 443 would break all HTTPS; DoH is
+        addressed by the DoH-IP feed (IP-alias layer) and DNSBL domain blocking.
+      - The exception alias must exist in Firewall > Aliases before use.
+      - The firewall itself is always exempt and will never have its own port-853 traffic
+        blocked.
+
+2. ADD server-side POST validation (PFBL-01 surface):
+   - Write a new validation function (or inline in the POST handler) that:
+     - Validates each selected interface name against pfb_build_if_list(FALSE, FALSE) output
+       (only known, non-WAN interfaces are accepted).
+     - Validates the exception alias name via pfb_filter() / is_validaliasname() when non-empty.
+       Empty string is always valid (means no exception alias).
+     - Returns the validated values; rejects and re-displays the form on invalid input.
+   - Add this function (or the enclosing POST handler function) to the PHPCS RequirePfbFilter
+     scopeFunctions allow-list in phpcs.xml.dist (PFBL-01 scope — it handles user-controlled
+     input that feeds into config writes adjacent to rule builds).
+   - Save validated values via PfbConfig::write() for all three fields.
+
+3. WRITE PHPUnit tests for the server-side validator in tests/php/DotDoQBlockUiValidatorTest.php:
+   a. test_valid_interface_name_accepted: a name returned by pfb_build_if_list() is accepted.
+   b. test_invalid_interface_name_rejected: a name not in the list is rejected; return indicates
+      failure; no PfbConfig::write() is called.
+   c. test_empty_alias_accepted: empty string passes alias validation.
+   d. test_valid_alias_name_accepted: a name passing is_validaliasname() is accepted.
+   e. test_invalid_alias_name_rejected: a name failing is_validaliasname() is rejected.
+   Before-state assertions: for the rejection tests, assert that nothing is written (the
+   write is not called) — mock or spy PfbConfig::write as needed using the test double pattern
+   in tests/php/pfsense_doubles.php.
+
+4. ADD or extend the ADR-14 ui_render test for pfblockerng_dnsbl.php in tests/smoke/ui/:
+   - GET the DNSBL settings page -> assert HTTP 200.
+   - Assert body is free of 'Fatal error', 'Parse error', 'Warning:', 'Notice:', 'Uncaught'.
+   - Assert a page-specific marker is present (grep the page for its existing marker string;
+     or add one if absent — but prefer an existing one).
+   - Assert no new php_error.log line was added during the GET.
+   If a ui_render test for this page already exists (check tests/smoke/ui/), extend it rather
+   than creating a duplicate.
+
+CONSTRAINTS
+- PHP tabs; PHP 8.3; uppercase TRUE/FALSE (ADR-28); no die()/exit() in library code.
+- PfbConfig::read/write for all three registered fields; direct config_*_path is NOT used here
+  (the UI only reads/writes the pfblockerngdnsblsettings config keys — registered fields).
+- PFBL-01: the POST handler / validator is in scope — add to scopeFunctions; validate before
+  any write or rule build reference.
+- Do NOT modify the Phase-1 or Phase-2 tests — they must remain green.
+- Do NOT implement smoke test infrastructure (no test_dot_doq_block.py) — that is Phase 4.
+- Markdown lint: no unescaped pipes in any Markdown file you touch. Language tag on all fences.
+
+VERIFICATION (must all pass before the phase is done)
+- vendor/bin/phpunit -> ALL tests green (Phase 1 + 2 + new UI validator tests).
+- php -l src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php -> no syntax errors.
+- PHPStan -> no new errors.
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> green (PFBL-01 scopeFunctions updated;
+  ADR-28 UppercaseBooleanLiteral clean; ADR-29 RequireConfigGateway clean).
+- python -m pytest -> green.
+- ADR-14 ui_render test for pfblockerng_dnsbl.php -> green (requires SMOKE_ADMIN_PASSWORD in
+  env; if not set, the test SKIPs cleanly — document the skip in the handoff).
+
+EXPECTED RESULT
+DoT/DoQ block control block on the DNSBL settings page; server-side PFBL-01 validation; all
+unit tests green; ui_render green or documented skip.
+
+COMMIT (single)
+    pfblockerng: add DoT/DoQ block UI control and validation (ADR-37 P3)
+Push directly to adr/37-dot-doq-block.
+
+HANDOFF — write .ADRs/ADR_37_DoT_DoQ_Block/RESULTS/03_Results.txt (plain .txt)
+Record: exact location in pfblockerng_dnsbl.php where the block was inserted (file:line range);
+the scopeFunctions entry added to phpcs.xml.dist; ui_render result (green or skip reason);
+list of new validator test methods; PHPUnit/PHPStan/PHPCS/pytest pass counts; any deviation
+from the plan; go-ahead for Phase 4.

--- a/.ADRs/ADR_37_DoT_DoQ_Block/04_Smoke_DoD_Docs.txt
+++ b/.ADRs/ADR_37_DoT_DoQ_Block/04_Smoke_DoD_Docs.txt
@@ -1,0 +1,154 @@
+================================================================================
+PHASE 4 PROMPT — Live-VM smoke + DoD verification + architecture-notes docs
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_37_DoT_DoQ_Block/ADR.md   (read §6 Phase 4, §7 DoD, full §2 first)
+================================================================================
+
+ROLE
+Work in the per-ADR worktree on branch adr/37-dot-doq-block. Phase 4 writes the ADR-04 live-VM
+smoke test, adds the architecture-notes blurb, and performs a final DoD verification pass.
+One commit, push directly.
+
+REQUIRED READING (FIRST — read before writing a single line of code)
+FIRST, read the prior phase's handoff:
+    .ADRs/ADR_37_DoT_DoQ_Block/RESULTS/03_Results.txt
+If that file is missing, STOP and report.
+
+Then read:
+- .ADRs/ADR_37_DoT_DoQ_Block/ADR.md — §6 Phase 4 (required cases), §7 (DoD checklist).
+- CLAUDE.md §"Smoke tests (ADR-04)" — all bullet points; non-obvious truths that apply here:
+  probe ON-BOX, test domains must be helpers.unique_domain() (N/A for a firewall rule test,
+  but the general harness discipline applies), every run uploads diagnostics on failure.
+- tests/smoke/ — existing smoke test files for style and fixture pattern; the helpers module;
+  the conftest + smoke_vm fixture. Read tests/smoke/test_dns_redirect.py if it exists (ADR-36
+  sibling) — mirror its structure for the DoT/DoQ block test.
+- docs/misc/architecture-notes.md — the existing document; find the right section to append
+  the DoT/DoQ blurb (likely near the ADR-36 redirect blurb if present, or in the firewall
+  rules section).
+
+ACTION PLAN
+
+1. WRITE tests/smoke/test_dot_doq_block.py with marker `smoke` (or append to an existing
+   smoke test file — check if one already covers the DNSBL firewall rules; mirror the ADR-36
+   test file structure if it exists). Required test cases (each as an independent test
+   function with a descriptive name and BDD-style Given/When/Then comments):
+
+   a. test_dot_doq_block_rule_appears_on_enable
+      Given: DoT/DoQ block disabled (baseline).
+      When: enable dnsbl_dot_block on the LAN interface and trigger sync.
+      Then: config.xml filter/rule contains an entry with descr='pfB_DoT_Block_lan',
+            type='block', ipprotocol='inet46', protocol='tcp/udp',
+            destination port='853' with (self) not-negated present,
+            statetype='keep state'.
+            pfctl -sr output contains a block rule for port 853 (parse pfctl output; assert
+            the rule is present).
+      Assert the before-state: config.xml has no pfB_DoT_Block_* entry before enable.
+
+   b. test_dot_doq_block_rule_removed_on_disable
+      Given: DoT/DoQ block enabled on LAN (use the enable helper or the result of case (a)).
+      When: disable dnsbl_dot_block and trigger sync.
+      Then: config.xml has no pfB_DoT_Block_* entries; pfctl -sr shows no pfBlockerNG
+            port-853 block rules.
+      Assert the before-state (rule present before disable).
+
+   c. test_user_filter_rule_survives_disable_and_uninstall
+      Given: a user filter rule with no pfB_ marker seeded in config.xml before enable.
+      When: enable DoT/DoQ block, then disable, then uninstall pfBlockerNG.
+      Then: the user filter rule is still present in config.xml; no pfB_DoT_Block_* remains;
+            installedpackages/pfblockerng* is gone.
+      Assert at each stage: user rule present after enable; user rule present after disable;
+      user rule present after uninstall.
+
+   d. test_stale_interface_rule_pruned_on_reconcile
+      Given: DoT/DoQ block enabled on LAN and OPT1.
+      When: reduce the interface selection to LAN only and trigger sync.
+      Then: config.xml has pfB_DoT_Block_lan present and pfB_DoT_Block_opt1 absent.
+      Assert before-state: both rules present before the reduction.
+
+   e. test_exception_alias_source_in_config_xml_when_set
+      Given: DoT/DoQ block enabled with dnsbl_dot_block_exclude = 'DoT_Exceptions'.
+      Then: config.xml source element has address containing 'DoT_Exceptions' and <not/>
+            present. (Config.xml assertion — not a live-client test.)
+      When: change to empty alias and re-sync.
+      Then: source element is <any>. (Both branches — before/after.)
+
+   f. test_uninstall_sweep_removes_all_dot_block_rules
+      Given: DoT/DoQ block enabled on LAN (rule present with marker).
+      When: uninstall pfBlockerNG (use the ADR-35 sweep test pattern from the sibling ADR).
+      Then: no pfB_DoT_Block_* filter/rule entries remain; no pfBlockerNG-owned filter rules
+            remain; installedpackages/pfblockerng* gone.
+      Assert before-state: rule present before uninstall.
+
+   g. test_self_exempt_guard_in_pfctl_output
+      Given: DoT/DoQ block enabled on LAN.
+      Then: pfctl -sr output contains the block rule for port 853; parse the output to confirm
+            the rule includes the self-exclusion guard (pfSense renders the `!<self>` guard or
+            equivalent in pfctl -sr — read the actual pfctl output on the live VM and assert
+            the relevant token). This is the CI-feasible gate.
+      NOTE: full client-to-:853 block behaviour (a second host attempting a TCP connection to
+      an external :853 server and being dropped) requires a second host and is a documented
+      maintainer manual-smoke item (§7) — not a CI assertion.
+
+   Use the smoke_vm fixture + SSH helpers from the existing smoke harness. Use
+   helpers.unique_domain() only for DNS-level tests (N/A here, but keep the import clean).
+   Mark all tests with @pytest.mark.smoke.
+
+2. UPDATE docs/misc/architecture-notes.md with a short blurb in the appropriate section
+   (near the ADR-36 redirect blurb if present, otherwise in the Firewall Rules or DNSBL
+   section). The blurb covers:
+   - DoT/DoQ block feature: one inet46 BLOCK rule per selected interface on port 853 (TCP +
+     UDP), managed via ADR-35.
+   - The inet46 single-rule design (simpler than per-family split; valid for a block rule
+     with no family-specific target).
+   - Firewall self-exempt via negated (self) destination — always on.
+   - Complementary relationship: ADR-36 closes port-53 plaintext bypass; ADR-37 closes
+     port-853 DoT/DoQ bypass; the DoH-IP feed + DNSBL domain blocking address port-443 DoH.
+   - Limitation: non-standard port DoT/DoQ and DoH over 443 are not covered by this rule.
+   Markdown lint: blank lines around headings/lists/fences; language on all fences; no
+   unescaped pipes in table cells; single trailing newline.
+
+3. PERFORM DoD verification pass — for each item in ADR.md §7:
+   - Run vendor/bin/phpunit; assert all tests green.
+   - Run PHPStan; assert no new errors.
+   - Run vendor/bin/phpcs --standard=phpcs.xml.dist src/; assert green.
+   - Run php -l src/; assert no syntax errors.
+   - Run python -m pytest; assert green.
+   - Confirm the ui_render test is green (or skip if SMOKE_ADMIN_PASSWORD absent — document).
+   - Confirm the smoke tests pass (requires smoke_vm; document any skip conditions).
+   Record all counts in the handoff.
+
+CONSTRAINTS
+- PHP tabs in PHP files; Python 4-space indent in smoke tests.
+- Smoke tests must use the existing smoke_vm fixture and SSH helpers — do not re-implement the
+  connection layer.
+- Before-state assertions are mandatory on every transition test (CLAUDE.md test-coverage
+  mandate).
+- Do NOT modify Phase 1, 2, or 3 tests.
+- Do NOT change any source file beyond the smoke test and the docs blurb. If you discover a
+  bug in the builder or sync code, document it in the handoff and the ADR §7 notes — do not
+  silently fix it in this phase (a Phase 5 / follow-up PR is the right path).
+- Markdown lint: npx markdownlint-cli2 must pass on docs/misc/architecture-notes.md after
+  the blurb is added.
+
+VERIFICATION (must all pass before the phase is done)
+- vendor/bin/phpunit -> ALL tests green.
+- PHPStan -> no new errors.
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> green.
+- php -l src/ -> no syntax errors.
+- python -m pytest -> green (unit suite; smoke tests SKIP cleanly when smoke_vm absent).
+- npx markdownlint-cli2 docs/misc/architecture-notes.md -> 0 error(s).
+
+EXPECTED RESULT
+Six smoke test cases covering the full DoT/DoQ block lifecycle; architecture-notes blurb
+committed; full DoD gate green; ADR ready to flip to Accepted on passing CI + live-VM fan-out.
+
+COMMIT (single)
+    pfblockerng: add DoT/DoQ block smoke tests and architecture notes (ADR-37 P4)
+Push directly to adr/37-dot-doq-block.
+
+HANDOFF — write .ADRs/ADR_37_DoT_DoQ_Block/RESULTS/04_Results.txt (plain .txt)
+Record: smoke test file path + list of test function names; architecture-notes section updated
+(file:line range of the blurb); DoD checklist — tick each §7 item as DONE or note the
+blocking condition; gate counts (PHPUnit pass/fail, PHPStan errors, PHPCS errors, pytest
+pass/fail, markdownlint errors); any open issues discovered in this phase; recommended next
+step (PR open, manual smoke, or a follow-up).

--- a/.ADRs/ADR_37_DoT_DoQ_Block/ADR.md
+++ b/.ADRs/ADR_37_DoT_DoQ_Block/ADR.md
@@ -1,0 +1,388 @@
+# ADR-37: Optional firewall BLOCK of DNS-over-TLS and DNS-over-QUIC (port 853)
+
+- **Status:** **Proposed** (2026-06-20)
+- **Date:** 2026-06-20
+- **Branch:** `adr/37-dot-doq-block` (off `devel`)
+- **Folds in maintainer's working config** (config.xml filter "Block DNS-over-TLS (DoT)" —
+  ground truth for the exact rule shape; see §2.2)
+- **Component(s):** `src/usr/local/pkg/pfblockerng/pfblockerng.inc` (rule builder + sync
+  wiring), `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` (PfbConfig registry — 3 new
+  fields), `src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc` (ADR-35 registration),
+  `src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php` (UI control block)
+- **Target runtime:** PHP 8.3 (pfSense CE 2.8)
+- **Test suite:** `tests/php/` (PHPUnit, off-appliance), `tests/smoke/` (ADR-04 live-VM),
+  `tests/smoke/ui/` (ADR-14 `ui_render`)
+- **Depends on:** ADR-35 (Managed Firewall Objects) — the ADR-35 seam
+  (`pfb_fwobj_register` / `pfb_fwobj_find` / `pfb_fwobj_remove` / `pfb_fwobj_sweep`,
+  ownership-by-descr-marker) must be in place before Phase 2 of this ADR.
+- **Sibling of:** ADR-36 (DNS Redirection) — same UI page, same interface-selector pattern,
+  same PfbConfig approach; keep consistent.
+
+## 1. Context
+
+pfBlockerNG's DNSBL blocks known-bad domains at the resolver level. Clients that bypass the
+pfSense resolver via encrypted DNS channels — specifically **DNS-over-TLS (DoT, RFC 7858)** or
+**DNS-over-QUIC (DoQ, RFC 9250)** — are never subject to DNSBL matching. Both protocols use
+**port 853** as their well-known port, making them distinguishable at the firewall layer.
+
+The conventional mitigation is a `filter/rule` BLOCK on destination port 853. The maintainer
+runs exactly this rule manually today (the ground-truth config.xml entry this ADR formalises).
+Without pfBlockerNG management, the rule has no ownership marker and is never swept on
+uninstall.
+
+**DNS-over-HTTPS (DoH, port 443)** is explicitly **not** addressed here. Blocking port 443
+would break all HTTPS traffic. The correct countermeasure for DoH is the DNSBL feed approach:
+known DoH resolver IPs are already present in the **Dibdot DoH-IP** and similar IP feeds that
+pfBlockerNG can block at the IP-alias layer, and known DoH hostnames are blockable at the DNSBL
+domain layer. This ADR covers only port 853 (DoT + DoQ).
+
+ADR-36 (DNS Redirection) closes the plaintext port-53 bypass. ADR-37 closes the encrypted
+port-853 bypass. Together they form the standard port-based encrypted-DNS containment, alongside
+the DoH-IP feed approach for port 443. Neither ADR alone provides a complete encrypted-DNS seal:
+a client using DoH over 443, DoT/DoQ on a non-standard port, or DoH over Tor would still
+bypass. That limitation is documented explicitly.
+
+Load-bearing facts:
+
+- **A single `inet46` BLOCK rule covers both IPv4 and IPv6.** The maintainer's working rule uses
+  `ipprotocol inet46` — a single filter rule matching both address families. This is simpler
+  than ADR-36's per-family split (which was required because NAT redirect targets are
+  family-specific; a BLOCK rule has no such constraint).
+- **Protocol `tcp/udp`** in one rule covers both DoT (TCP 853) and DoQ (UDP 853) without
+  requiring two separate rules.
+- **Self-exempt is mandatory and always on.** The firewall must never block its own outbound
+  connections to port 853 — the firewall may itself act as a DoT/DoH/DoQ server in a future
+  pfSense release, and must not block its own traffic. Implemented via destination
+  `<network>(self)</network><not/>` — negated, so the firewall's own traffic to port 853 is
+  excluded from the block.
+- **The existing filter-rule rebuild** already strips and rebuilds all `pfB_`-prefixed rules
+  on each `sync_package_pfblockerng()` call (see `pfblockerng.inc:13709`). The managed DoT/DoQ
+  block rules carry the `pfB_` marker prefix and are naturally covered by this rebuild. The
+  ADR-35 registration additionally provides the explicit sweep for disable and uninstall paths.
+- **No live pf in CI** — the rule builder is unit-tested off-appliance against config-shaped
+  fixtures; the real pf interaction is a live-VM smoke (ADR-04).
+- **Marker collision with ADR-36 is not possible** — distinct marker prefixes:
+  `pfB_DoT_Block_<iface>` (this ADR) vs `pfB_DNS_Redirect_<iface>_v4/v6` (ADR-36).
+
+## 2. Decision
+
+Add an **optional, default-off** firewall block feature. When enabled, pfBlockerNG creates and
+maintains one `filter/rule` BLOCK entry per selected interface — blocking all traffic from any
+source to any non-self destination on port 853 (TCP + UDP) on that interface. The rules are
+registered as ADR-35 managed objects (pfBlockerNG-marker ownership) and are created, reconciled,
+and removed through the ADR-35 seam. No ADR-35 marker/teardown logic is re-invented here.
+
+### 2.1 Per-area decision
+
+| Area | Decision |
+| --- | --- |
+| Feature scope | Port-853 TCP+UDP BLOCK only. DoH (443) is out of scope (see §2.3); blocking 443 would break HTTPS. |
+| Protocol | `tcp/udp` in a single rule — covers DoT (TCP 853) and DoQ (UDP 853) simultaneously. |
+| IP protocol | `inet46` — one rule covers both IPv4 and IPv6 clients. No per-family split needed (block has no family-specific target, unlike NAT redirect). |
+| Source | `<any>` by default. An optional **free-text exceptions field** (zero or more entries — each an IP / CIDR / host or an existing alias name; "these hosts get direct encrypted DNS") — when non-empty, applied as a negated source (an alias when a single alias name is given, else the inline address set) so listed hosts bypass the block. Each entry PFBL-01-validated. |
+| Destination | Always: negated `(self)` (`<network>(self)</network><not/>`) + port 853. Firewall-self exemption is structural and cannot be disabled. |
+| State type | `keep state` — matches the maintainer's ground-truth rule. |
+| Firewall-self exemption | **Always on and non-disableable.** The firewall may itself serve DoT/DoH/DoQ in future; blocking its own port-853 traffic would be self-defeating. Structural via negated `(self)`. |
+| Interface selection | Multi-select using `pfb_build_if_list(FALSE, FALSE)` (WAN-excluded), stored comma-joined (plain string) — **reuse the "Permit Firewall Rules" pattern** (`dnsbl_allow_int`, `pfblockerng_dnsbl.php:2921`), mirroring ADR-36 exactly. Quick-fill option tracks the pfBlockerNG fw-rule interface set. |
+| Rule count per interface | 1 filter BLOCK rule per selected interface (not 4 like ADR-36 — no NAT, no associated filter; just the single block rule). |
+| Ownership + lifecycle | Each rule carries a pfBlockerNG descr marker (`pfB_DoT_Block_<iface>` — exact naming confirmed at implementation time against the `pfB_` codebase convention). Registered via `pfb_fwobj_register()` per ADR-35. Created/reconciled idempotently on `sync_package_pfblockerng()`; removed on disable; swept on uninstall via `pfb_fwobj_sweep()`. |
+| Reconcile (stale-interface pruning) | On each sync, rules for interfaces no longer in the selected set are pruned by the marker sweep. An interface removed from config is treated as absent. |
+| Config fields | 3 new registered `PfbConfig` fields in `pfblockerngdnsblsettings/config/0` (see §2.2). ADR-29 5-step adding process. |
+| UI location | DNSBL settings page (`pfblockerng_dnsbl.php`) — new control block adjacent to ADR-36's redirect control and the existing DoH/DoT/DoQ blocking section. Enable checkbox + interface multi-select + quick-fill + optional exception-alias field + brief help text. Server-side PFBL-01 validation before any rule build. |
+| Naming (config keys + marker) | **Provisional** — follow the `dnsbl_*` / `*_int` sibling convention beside `dnsbl_allow_int` and the ADR-36 keys: `dnsbl_dot_block` (enable toggle), `dnsbl_dot_block_int` (interface list), `dnsbl_dot_block_exclude` (exception alias). Final names aligned with the maintainer before keys are frozen (CLAUDE.md "Naming — follow the established pattern"; storage freeze applies once chosen). |
+| Complementary features | Port-853 block + ADR-36 port-53 redirect together close the standard-port bypass paths. Port 443 DoH is handled by the DoH-IP feed (IP-alias layer) and DNSBL domain blocking — not by this ADR. |
+
+### 2.2 Semantics that MUST be preserved / hold (the contract — pin with tests)
+
+**Ground-truth rule shape** (from the maintainer's working config.xml; every field below is
+mandatory and exactly matched):
+
+```xml
+<rule>                                          <!-- filter/rule -->
+  <type>block</type>
+  <interface>lan</interface>                    <!-- one rule per selected interface -->
+  <ipprotocol>inet46</ipprotocol>              <!-- single rule covers IPv4 + IPv6 -->
+  <protocol>tcp/udp</protocol>                 <!-- DoT (TCP 853) + DoQ (UDP 853) -->
+  <source><any></any></source>                 <!-- <any> when no exception alias -->
+  <!-- when exception alias is set: -->
+  <!-- <source><address>ALIAS</address><not></not></source> -->
+  <destination>
+    <network>(self)</network><not></not>        <!-- firewall self-exempt, always on -->
+    <port>853</port>
+  </destination>
+  <statetype><![CDATA[keep state]]></statetype>
+  <descr><![CDATA[pfB_DoT_Block_lan]]></descr> <!-- pfBlockerNG ownership marker -->
+</rule>
+```
+
+Invariants (each asserted by PHPUnit tests with full branch coverage):
+
+- **Type is always `block`.** No generated rule has any other type.
+- **`ipprotocol` is always `inet46`.** One rule covers both families; no per-family split.
+- **`protocol` is always `tcp/udp`.** Covers both DoT (TCP) and DoQ (UDP) in one rule.
+- **Destination is always negated `(self)` with port 853** — the firewall-self-exempt is
+  structurally present in every generated rule. No code path produces a rule without it.
+- **Source is negated-alias when exception alias is set; `<any>` when alias is empty.**
+  Both branches produce structurally valid rules. The transition (empty → set → empty)
+  round-trips stably.
+- **`statetype` is `keep state`** on every generated rule.
+- **`descr` carries the pfBlockerNG marker** (`pfB_DoT_Block_<iface>`) and is the sole
+  ownership signal (ADR-35 contract).
+- **Multiple interfaces → one rule per interface.** Each carries the interface name in its
+  marker; they are independent and independently prunable.
+- **Disable removes all owned rules** (marker sweep via ADR-35). A user filter rule (no marker)
+  is never touched.
+- **Reconcile is idempotent** — calling the builder twice with identical settings produces the
+  same config.xml state; no duplicate rules accumulate.
+- **Stale-interface rules are pruned on reconcile** — an interface removed from the selection
+  has its rule removed on the next sync.
+- **New config fields round-trip** through `PfbConfig` (ADR-29 backward-compat contract):
+  `write(read(v)) == v` for every stored vocabulary value.
+
+### 2.3 Explicitly kept / out of scope
+
+- **DoH (DNS-over-HTTPS) port blocking** — explicitly out. Blocking port 443 would break all
+  HTTPS traffic. DoH is addressed at the domain level via DNSBL feeds (known DoH hostnames) and
+  at the IP level via the Dibdot DoH-IP and similar IP feeds. This ADR does not attempt to
+  intercept or block DoH.
+- **Non-standard port DoT/DoQ** — out. This rule blocks only the well-known port 853. A client
+  using DoT/DoQ on a non-standard port bypasses this rule; that gap is inherent and documented.
+- **Per-client or per-subnet policies beyond the single exception alias** — out. One alias covers
+  the use case; per-row policies are a future extension.
+- **Creating/managing an alias object** — out. The exceptions field is a plain reference: it
+  accepts inline IP/CIDR/host entries and/or the name of an alias the user maintains through the
+  normal pfSense Firewall → Aliases UI. pfBlockerNG does not create or own that alias.
+- **Changing the filter-rule rebuild model** — out. The existing `pfB_`-prefix rebuild-each-sync
+  already handles the block rules. ADR-35 registration is additive.
+- **Renaming or modifying existing pfBlockerNG filter markers** — out (storage freeze, ADR-28).
+  This ADR introduces the `pfB_DoT_Block_<iface>` marker only.
+- **Changing `pfb_remove_config_settings()` or the ADR-35 sweep logic** — out. The sweep is
+  provided by ADR-35; this ADR registers through it.
+
+## 3. Consequences
+
+**Positive**
+
+- Stops LAN clients from bypassing pfBlockerNG DNSBL via encrypted DNS on the standard port —
+  DoT (TCP 853) and DoQ (UDP 853) are blocked at the firewall before the connection completes.
+- Firewall-self exemption is structural (negated `(self)`) — cannot be accidentally removed;
+  the firewall's own outbound to port 853 is never disrupted.
+- One `inet46` rule per interface is simpler than per-family rules — less config churn, clearer
+  intent.
+- Lifecycle managed via ADR-35 (register/reconcile/remove/sweep) — no bespoke teardown code;
+  consistent with the ADR-36 sibling.
+- Default off — zero impact on existing installations that do not opt in.
+- Config fields are registered in `PfbConfig` with ADR-29 backward-compat invariants; an older
+  release ignores the keys (inert), a rollback preserves them for roll-forward.
+
+**Negative / risks**
+
+- **Risk: blocking legitimate port-853 traffic.** Port 853 is exclusively assigned to DoT/DoQ
+  (IANA). Blocking it should not affect normal LAN traffic; however, any self-hosted DoT
+  resolver on the LAN that clients should be able to reach is blocked too. Documented in help
+  text; out of scope to gate on resolver topology.
+- **Risk: incomplete encrypted-DNS coverage.** Port-853 block stops standard-port DoT/DoQ. A
+  client using DoH over port 443, DoT/DoQ on a non-standard port, or DoH over Tor still
+  bypasses. Documented limitation; complementary to ADR-36 and the DoH-IP feed.
+- **Risk: user exception alias mismatch** (alias name changed or deleted outside pfBlockerNG).
+  If the alias no longer exists, pfSense treats it as matching nothing — the source `<not/>`
+  negation means the block applies to everyone; effectively the exception is lost. Documented in
+  help text.
+- **Risk: interface churn leaving stale rules.** Mitigated by reconcile-time stale-prune (marker
+  scan for rules belonging to interfaces no longer in the selected set).
+
+**Alternative considered — floating block rule instead of per-interface**
+
+A floating block rule with direction `in` on all selected interfaces would achieve similar effect
+with fewer config.xml entries. The maintainer notes floating rules are probably the right choice
+for most users. However, the `in`/`out`/`any` direction selector on floating rules has caused
+real bugs in pfSense integrations in the past: a floating rule without an explicit direction (or
+with the wrong direction) can have surprising or silently-wrong behaviour.
+
+Per-interface block rules avoid the direction footgun entirely — they apply at the interface
+level without a direction selector, matching client egress on the LAN side with no ambiguity.
+This is the safer default for an automated, managed rule.
+
+If a future maintainer decision moves to floating, the direction MUST be set explicitly to `in`
+and the smoke test MUST verify the pf rule is active and effective. The block-rule builder is
+designed to be upgraded to floating cleanly (a single field change in the rule array).
+
+## 4. Requirements (acceptance)
+
+- A pure `pfb_build_dot_block_rule($settings)` builder function returning the exact rule array
+  matching the §2.2 ground-truth shape, for any combination of interface, exception alias state
+  (set/empty), and number of interfaces.
+- The builder registered via `pfb_fwobj_register()` (ADR-35); create/reconcile/remove/sweep
+  wired into `sync_package_pfblockerng()` and the disable/uninstall paths.
+- Three new `PfbConfig`-registered fields: `dnsbl_dot_block` (toggle), `dnsbl_dot_block_int`
+  (plain string), `dnsbl_dot_block_exclude` (plain string) — ADR-29 5-step process, including
+  `CfgGatewayTest.php` round-trip tests + inventory update + `$registeredPaths` in the sniff.
+- UI control block on `pfblockerng_dnsbl.php`: enable checkbox + interface multi-select +
+  quick-fill + exception-alias field + help text (noting DoH/443 is handled by the DoH-IP feed,
+  not this control); server-side PFBL-01 validation.
+- All gates green (§5); live-VM smoke proves the full lifecycle.
+
+## 5. Constraints (from CLAUDE.md)
+
+- PHP tabs, PHP 8.3; no `die()`/`exit()` in library code.
+- **ADR-28**: uppercase `TRUE`/`FALSE`; storage freeze (new stored vocabulary defined once and
+  never changed; existing markers are immutable).
+- **ADR-29**: three new fields registered in `PfbConfig` via the 5-step process. The managed
+  section (`filter/rule`) stays pfSense-core foreign → direct `config_*_path`, NOT `PfbConfig`.
+  The sniff's `$registeredPaths` must be updated for all three new keys.
+  `pfblockerng_extra.inc` is excluded from the sniff (the gateway itself).
+- **ADR-35**: use `pfb_fwobj_register` / `pfb_fwobj_find` / `pfb_fwobj_remove` /
+  `pfb_fwobj_sweep` exclusively. Do NOT re-invent marker detection, teardown logic, or orphan
+  sweep.
+- **PFBL-01**: the rule builder and any UI form handler that accepts interface names or alias
+  names is an in-scope input-handling surface. Add the new functions to the PHPCS
+  `scopeFunctions` allow-list; validate interface names against `pfb_build_if_list()` output and
+  alias names via `pfb_filter()` / `is_validaliasname()` before any rule construction or path
+  composition.
+- **ADR-04 smoke** for the end-to-end create/disable/uninstall lifecycle and pf table
+  verification.
+- **ADR-14 `ui_render`** for the modified DNSBL settings page.
+
+## 6. Action plan
+
+### Phase 1 — Config fields + golden rule-builder tests
+
+- Prompt: `01_Config_Fields_And_Builder_Tests.txt`
+- Register the three new `PfbConfig` fields in `pfb_cfg_registry()` (`pfblockerng_extra.inc`):
+  `dnsbl_dot_block` (toggle adapter, stored `'on'`/`''`, default `''`),
+  `dnsbl_dot_block_int` (plain adapter, stored comma-joined string, default `''`),
+  `dnsbl_dot_block_exclude` (plain adapter, stored string, default `''`).
+  Follow the ADR-29 5-step process: registry entry + `since: '4.0.0'` + round-trip verify +
+  `CfgGatewayTest.php` (round-trip + default-absent) + inventory update +
+  `$registeredPaths` in `RequireConfigGatewaySniff.php`.
+- Write a pure `pfb_build_dot_block_rule($iface, $exclude_alias)` skeleton function in
+  `pfblockerng.inc` (or a new helper include — implementer's call based on code size). The
+  function takes: interface name (string), exception alias string (may be empty). It returns a
+  single filter rule array matching the §2.2 ground-truth field-for-field.
+- **Tests (oracle first):** PHPUnit golden tests pinning the exact rule structure. Required
+  branches:
+  - (a) exception alias empty → source is `<any>`;
+  - (b) exception alias set → source is negated-alias;
+  - (c) multiple interfaces → one independent rule per interface, each with the correct marker;
+  - (d) descr marker is `pfB_DoT_Block_<iface>` (exact interface name in marker);
+  - (e) type is `block`, ipprotocol `inet46`, protocol `tcp/udp`, destination negated `(self)`
+    - port 853, statetype `keep state` — all asserted in every branch.
+  All branches before the builder implementation is wired to any live sync.
+- Tests: `CfgGatewayTest.php` round-trip for all three new fields.
+
+### Phase 2 — Builder implementation + ADR-35 registration + sync wiring
+
+- Prompt: `02_Builder_And_Sync.txt`
+- FIRST, read the prior phase's handoff:
+  `.ADRs/ADR_37_DoT_DoQ_Block/RESULTS/01_Results.txt`
+  and the ADR-35 implementation in `pfblockerng_fwobj.inc`. If either is missing, STOP and
+  report.
+- Complete the `pfb_build_dot_block_rule()` implementation so it passes all Phase-1 golden
+  tests.
+- Register the builder via `pfb_fwobj_register()` (ADR-35): spec includes type `filter`, the
+  `pfB_DoT_Block_` marker prefix, and the builder callable. Read `pfblockerng_fwobj.inc` first
+  to confirm the exact spec shape before implementing.
+- Wire create/reconcile into `sync_package_pfblockerng()`: when `dnsbl_dot_block == 'on'`, build
+  and write one rule per selected interface; when off or no interfaces selected, remove all owned
+  rules (marker sweep). On each sync, prune rules for any interface no longer in the selected set
+  (stale-interface reconcile).
+- Tests: reconcile is idempotent (two syncs → same config); disable removes all
+  `pfB_DoT_Block_*` rules while a seeded user filter rule (no marker) survives; stale-interface
+  rules are pruned on the next sync (rule for removed interface is gone; rule for retained
+  interface stays).
+
+### Phase 3 — UI on the DNSBL settings page + PFBL-01 validation
+
+- Prompt: `03_UI.txt`
+- FIRST, read the prior phase's handoff:
+  `.ADRs/ADR_37_DoT_DoQ_Block/RESULTS/02_Results.txt`
+  and the ADR-36 UI implementation at `pfblockerng_dnsbl.php` ~2921 for the exact
+  `Form_Group('Permit Firewall Rules')` + `pfb_build_if_list()` pattern. If either is missing,
+  STOP and report.
+- Add a new control block in `pfblockerng_dnsbl.php` adjacent to ADR-36's redirect control and
+  the existing DoH/DoT/DoQ section. Block contains:
+  - (a) enable checkbox bound to `dnsbl_dot_block`;
+  - (b) interface multi-select (`pfb_build_if_list(FALSE, FALSE)`, WAN-excluded, pre-selected
+    from `dnsbl_dot_block_int`) — same `Form_Group` pattern as ADR-36 and `dnsbl_allow_int`;
+  - (c) a quick-fill button/link that populates the multi-select with the union of the current
+    `inbound_interface` + `outbound_interface` values (the pfBlockerNG fw-rule interface set);
+  - (d) exception-alias free-text field bound to `dnsbl_dot_block_exclude`;
+  - (e) brief help text (style matches neighbouring text) noting: (i) blocks standard-port
+    DoT (TCP 853) and DoQ (UDP 853) only; (ii) DoH (port 443) is handled by the DoH-IP feed,
+    not this control — blocking 443 would break all HTTPS; (iii) the exception alias must exist
+    in Firewall → Aliases; (iv) the firewall itself is always exempt.
+- Server-side POST handler: validate selected interface names against `pfb_build_if_list()`
+  output before accepting; validate alias name via `pfb_filter()` / `is_validaliasname()` if
+  non-empty (PFBL-01 surface — add the handler function to PHPCS `scopeFunctions`).
+- Save via `PfbConfig::write()` for all three registered fields.
+- Tests: PHPUnit for the server-side validator (valid/invalid interface name; valid/empty/invalid
+  alias); ADR-14 `ui_render` for `pfblockerng_dnsbl.php` (200, no PHP errors, page marker
+  present, no new `php_error.log` line).
+
+### Phase 4 — Smoke + DoD + docs
+
+- Prompt: `04_Smoke_DoD_Docs.txt`
+- FIRST, read the prior phase's handoff:
+  `.ADRs/ADR_37_DoT_DoQ_Block/RESULTS/03_Results.txt`. If missing, STOP and report.
+- ADR-04 live-VM smoke (`tests/smoke/test_dot_doq_block.py` or appended to an existing smoke
+  file). Required cases:
+  - **Enable path:** enable on the LAN interface → assert the block rule appears in
+    `config.xml` with the `pfB_DoT_Block_lan` marker, type `block`, ipprotocol `inet46`,
+    protocol `tcp/udp`, destination negated `(self)` + port 853; assert `pfctl -sr` shows the
+    rule active.
+  - **Disable path:** disable → assert all `pfB_DoT_Block_*` entries removed from `config.xml`;
+    assert `pfctl -sr` shows no pfBlockerNG port-853 block rules.
+  - **User-rule survival:** seed a user filter rule (no marker) before enable; after disable +
+    uninstall, assert the user rule survives untouched.
+  - **Stale-interface prune:** enable on two interfaces, then reduce to one → assert the rule
+    for the removed interface is gone; the retained interface rule remains.
+  - **Exception alias branch (config.xml assertion):** enable with a non-empty alias → assert
+    source is `<address>ALIAS</address><not/>` in config.xml; enable with empty alias → assert
+    source is `<any>` (both branches).
+  - **Uninstall sweep:** install + enable → uninstall → assert all `pfB_DoT_Block_*` gone, no
+    pfBlockerNG-owned filter/rule entries remain, and `installedpackages/pfblockerng*` gone.
+  - **Self-exempt assertion (CI-feasible gate):** `pfctl -sr` shows the block rule present;
+    verify the rule carries the `!<self>` guard (or equivalent pfSense pf output confirming the
+    self-exempt is active). Full client-to-:853 block behaviour requires a second host and is a
+    documented maintainer manual-smoke item (see §7).
+- `docs/misc/architecture-notes.md` blurb covering the DoT/DoQ block feature, the inet46
+  single-rule design, the self-exempt mechanism, and the complementary relationship with ADR-36
+  (port-53 redirect) and the DoH-IP feed.
+- ADR-14 `ui_render` for `pfblockerng_dnsbl.php` (if not already green from Phase 3 CI).
+
+## 7. Definition of done
+
+- [ ] `pfb_build_dot_block_rule()` passes all golden tests — exact §2.2 rule shape, all
+      branches (alias set/empty, multiple interfaces, type/ipprotocol/protocol/destination/
+      statetype/marker all asserted).
+- [ ] Three `PfbConfig`-registered fields (`dnsbl_dot_block`, `dnsbl_dot_block_int`,
+      `dnsbl_dot_block_exclude`) with ADR-29 round-trip + forward/backward invariants green
+      (`CfgGatewayTest.php`, `RollbackContractTest.php`).
+- [ ] ADR-35 registration in place; create/reconcile/remove/sweep exercised for the DoT/DoQ
+      block rule set (idempotent, stale-prune, user-rule survival — all asserted).
+- [ ] UI control block on `pfblockerng_dnsbl.php`: enable + multi-select + quick-fill +
+      exception alias + help text (DoH/443 note included); server-side PFBL-01 validation.
+- [ ] All gates green: `vendor/bin/phpunit`, PHPStan, PHPCS (PFBL-01 + ADR-28 + ADR-29 sniffs),
+      `php -l`, `python -m pytest`, ADR-14 `ui_render`.
+- [ ] Live-VM smoke proves: block rule appears on enable with correct shape + `pfctl -sr`
+      confirms active; rule removed on disable; user rule survives uninstall; stale-interface
+      prune works; self-exempt guard confirmed in `pfctl -sr` output.
+
+**Manual smoke (owner: maintainer):**
+
+- [ ] Enable DoT/DoQ block on LAN → attempt a TCP connection from a LAN client to an external
+      host on port 853 → confirm the connection is blocked (firewall drops it).
+- [ ] Confirm the firewall's own outbound port-853 connections are NOT blocked (self-exempt
+      working).
+- [ ] Populate the exception alias with a client IP → confirm that client can reach port 853
+      (exception bypass working).
+- [ ] Enable on LAN + OPT1 → disable on OPT1 only → confirm OPT1 rule gone, LAN rule remains.
+- [ ] Uninstall pfBlockerNG with DoT/DoQ block enabled → confirm no `pfB_DoT_Block_*` rules
+      remain in Firewall → Rules and no dangling entries.
+
+**Reject criteria:** if the `inet46` ipprotocol is not supported for a BLOCK rule in the pfSense
+version targeted (CE 2.8 / FreeBSD 15), **reduce** to two per-family rules (inet + inet6,
+mirroring ADR-36's split) with updated tests and docs. If the ADR-35 registration seam cannot
+cover a pure filter-block rule (vs NAT + filter atomicity required by ADR-36), **reduce** to a
+direct `pfB_`-prefix filter rebuild (the existing rebuild-each-sync model) with a documented
+seam limitation.


### PR DESCRIPTION
Three coupled **Proposed** ADRs (design + phased implementation plans; no `src/` change yet). 36 and 37 build on 35.

## ADR-35 — Unify ownership + teardown of pfBlockerNG-managed firewall objects
A small shared layer (`pfblockerng_fwobj.inc`) for the firewall-layer objects pfBlockerNG owns (VIP / NAT / filter): one ownership-marker convention, idempotent find/reconcile, and a uniform removal contract. Adds the one genuinely missing guarantee — a **marker-based defensive sweep on disable AND uninstall**, so objects orphaned by a half-failed run are still removed (today's deinstall relies on lifecycle order and can leave orphans). Retrofits the existing auto-VIP (ADR-13) + DNSBL NAT onto it, **behaviour-preserving** and within the ADR-28 storage freeze (no persisted marker string changes). Exposes the registration seam ADR-36/37 plug into. 5 phases, prep-first (golden tests pin current behaviour before any refactor).

## ADR-36 — Optional NAT DNS-redirection (port-53 hijack)
Force client plaintext DNS (`tcp/udp` dest 53) to the local resolver so clients can't bypass DNSBL. Grounded in the maintainer's working rule: target `127.0.0.1`/`::1`, `local-port 53`, `natreflection disable`, **firewall self-exempt** (negated `(self)` destination, always on), optional **free-text exceptions** (IP/CIDR/host or alias → negated source), per selected interface (+ associated filter rule). Interface multiselect + UI reuse the existing "Permit Firewall Rules" (`dnsbl_allow_int`) structure. Managed via ADR-35. 4 phases.

## ADR-37 — Optional DoT/DoQ block (port 853)
Block encrypted DNS on the standard port: a per-interface `block` rule, `ipprotocol inet46` (one rule, both families), `tcp/udp` (DoT over TCP + DoQ over UDP), dest `!(self):853`, `keep state`. Grounded in the maintainer's working rule. **DoH (443) is explicitly out of scope** — port-blocking 443 would break all HTTPS; DoH stays on the existing DoH-IP feed + domain blocking. Floating rules documented as the alternative (best for many, but the in/out/any direction selector has bitten before, so per-interface is the default). Managed via ADR-35. 4 phases.

### Open items (deferred to implementation, not blockers)
- Final config-key + `pfB_` marker names — provisional in the ADRs (`dnsbl_redir*` / `dnsbl_dot_block*`), to align with the `dnsbl_allow_int` convention before the keys are frozen.
- ADR-37 `inet46`-on-block — confirmed by the maintainer's live config; §7 keeps a per-family fallback as a safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V78xkNULQajVs3QZycMT3N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architectural planning documentation for upcoming product enhancements: centralized firewall-object management with unified device ownership tracking across firewall components, optional DNS traffic redirection to the local resolver with configurable exception support, and DNS-over-TLS/QUIC blocking on well-known standard ports to prevent users from bypassing DNSBL filtering rules through encrypted DNS protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->