### PR TITLE
release: curated v4.0.0.alpha.1 notes + committed-file precedence

### DIFF
--- a/.claude/skills/release-with-changelog/SKILL.md
+++ b/.claude/skills/release-with-changelog/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: release-with-changelog
+description: >
+  Cut a pfBlockerNG release WITH hand-authored release notes: play the role of the
+  GitHub Models step — write docs/release-notes/<tag>.md from the commit range using the
+  same prompt the workflow feeds the model — commit it on the channel branch, then hand
+  off to the /release skill to validate + push the tag. Because the file is committed, the
+  workflow's GitHub Models step is skipped and the release body comes from your file. Use
+  this when Models is unavailable (e.g. the org hasn't enabled it), when you want curated
+  notes, or when the user says "write the changelog and release", "release with notes",
+  "play the model and cut the release", or invokes /release-with-changelog.
+  Args: <tag> (e.g. v4.0.0.alpha.1).
+---
+
+You author the release notes yourself, commit them, then cut the release. The release
+workflow uses a committed `docs/release-notes/<tag>.md` **in preference to** GitHub Models
+(it skips the Models step when the file exists), so providing the file IS "playing the
+model". The actual tag validation + push is delegated to **`/release`** — do not
+re-implement it.
+
+`scripts/release-notes-prompt.txt` is the **same system prompt** the workflow feeds the
+model; you apply it by hand here. `scripts/release-version.sh` classifies the tag/channel.
+
+## Arguments
+
+- `<tag>` — required, e.g. `v4.0.0.alpha.1` (must start with `v`).
+
+## Steps
+
+1. **Classify the tag + pick the channel branch.** `sh scripts/release-version.sh <tag>` →
+   `channel`/`prerelease`. `devel` for a prerelease, `main` for stable. A malformed tag stops
+   here (show its error). Don't push anything yet.
+
+2. **Resolve the compare base (previous same-channel release).** Mirror `release.yml`'s
+   `prev_tag`: `git fetch origin --tags`; the highest-version tag of the **same channel** that
+   is an ancestor of the channel-branch tip (classify each candidate with
+   `release-version.sh`), falling back to the highest ancestor tag of any channel, then the
+   next-lower version tag. Call it `PREV`. The compare link is
+   `https://github.com/<owner>/<repo>/compare/<PREV>...<tag>` (or `…/commits/<tag>` when there
+   is no `PREV`).
+
+3. **Gather the commits the "model" sees.**
+   `git log <PREV>..origin/<branch> --no-merges --pretty='%h %s' -- src/ scripts/`.
+   For a **genesis release of a new series** (the first `X.0.0.alpha.1`, whose `PREV` is an
+   old-scheme tag), also describe the headline features of the whole series — the narrow
+   `PREV..HEAD` range alone undersells it; read prior notes / ADR titles for the arc.
+
+4. **Author the notes by applying `scripts/release-notes-prompt.txt`.** Produce exactly what
+   the model would: keep only user-relevant changes (drop CI / tests / tooling / lint /
+   internal refactors / dev-docs); group under `## Features`, `## Improvements`, `## Bug Fixes`
+   (omit an empty group); link each item's PR/issue as `([#N](…/issues/N))` when the subject
+   references `#N` (the `/issues/` path resolves for PRs too); **never name internal ADRs** —
+   describe the user-facing change. Professional, engineer-like tone; precision over flash.
+   End the body with the exact compare link from step 2.
+
+5. **Write `docs/release-notes/<tag>.md`.** First line is the title marker
+   `<!-- SUMMARY: <three-word summary> -->` (the workflow turns it into the Release title
+   suffix `pfBlockerNG <version> — <summary>` and strips it from the rendered body); then the
+   grouped body. Lint it: `npx markdownlint-cli2 docs/release-notes/<tag>.md` → 0 errors.
+
+6. **Confirm the rendered notes with the user.** Show the title + body. This is the public
+   release body — get a nod before committing (cheap to revise now, immutable after release).
+
+7. **Commit the notes file on the channel branch.** It must be on the channel branch **before**
+   the tag, so the tagged checkout contains it. Commit `docs: add release notes for <tag>`
+   (docs-only ⇒ CI-skipped) and land it on the channel branch via the repo's normal flow
+   (managed-remote: a docs PR to `devel`/`main`; off-appliance: the worktree flow). Wait until
+   it is merged so the channel-branch tip carries the file.
+
+8. **Cut the release — delegate to `/release`.** Invoke **`/release <tag>`**. It re-validates
+   the channel↔branch scheme, checks CI is green on the release commit (now including the notes
+   commit), and pushes the tag. The release workflow then sees the committed file, **skips the
+   Models step**, and publishes the Release with your notes as the body and the `SUMMARY` as the
+   title suffix.
+
+## Guardrails
+
+- **The notes file must land on the channel branch before the tag** — a tag whose commit
+  predates the file means the workflow won't see it (it would fall through to Models, or a
+  placeholder). Order matters: notes commit first, tag second.
+- **Inherit every `/release` guardrail** — channel↔branch enforcement, immutable tags (cut the
+  next `.N` instead of moving one), tag-only pushes (never a direct `main`/`devel` push). This
+  skill only adds the notes-authoring + commit in front.
+- **Don't fabricate PR/issue numbers.** Link a `#N` only when a commit subject references it;
+  otherwise describe the change without a link.
+- **Keep ADRs out of the public notes** — neutral, user-facing wording only.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -71,11 +71,13 @@ devel" guard, applied before the tag exists.
    - Git hooks are active (`git config core.hooksPath` = `.githooks`); if not, run
      `sh scripts/setup-hooks.sh` so the pre-push backstop is armed.
 
-5. **Optional — curated notes.** The release body is auto-drafted by GitHub Models
-   (`openai/gpt-4.1`) from the commit range and persisted to `docs/release-notes/<tag>.md`.
-   If the user wants hand-written notes instead, they commit `docs/release-notes/<tag>.md`
-   on the channel branch first — the workflow falls back to it when present and inference
-   is unavailable. Do not author it unless asked.
+5. **Notes source.** The release body comes from `docs/release-notes/<tag>.md` when that file
+   is committed on the channel branch — it is **authoritative**, and the GitHub Models step is
+   **skipped** (an optional first-line `<!-- SUMMARY: … -->` marker becomes the title suffix,
+   stripped from the body). When no file exists, GitHub Models (`openai/gpt-4.1`) drafts it from
+   the commit range and the `persist-notes` job records it. To author/curate the notes yourself
+   (or to "play the model" when Models is unavailable), use **`/release-with-changelog`** — it
+   writes the file, commits it, then calls this skill. Don't author notes here unless asked.
 
 6. **Confirm, then push.** Pushing a release tag is **irreversible and public** (it cuts
    a GitHub Release, publishes the `.pkg`, and bumps the ports fork). Confirm the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,14 +338,22 @@ jobs:
             echo "__FL__"
           } >> "$GITHUB_OUTPUT"
           echo "prompt_file=${PROMPT_FILE}" >> "$GITHUB_OUTPUT"
-          echo "Range: ${RANGE}"
+          # A committed docs/release-notes/<tag>.md is the curated/authoritative notes for
+          # this release; when present it WINS and the Models step is skipped (below).
+          if [ -f "docs/release-notes/${TAG}.md" ]; then HAS_FILE=true; else HAS_FILE=false; fi
+          echo "has_file=${HAS_FILE}" >> "$GITHUB_OUTPUT"
+          echo "Range: ${RANGE}  (committed notes file: ${HAS_FILE})"
 
       - name: Draft release notes (GitHub Models)
         id: ai
         # Single-shot inference on GitHub Models with the built-in token (no secret, free
         # tier; needs permissions: models:read on this job). The system prompt is the
         # static instruction file; the user prompt is the Context + commit list above.
-        # continue-on-error so a Models hiccup/rate-limit falls through to the fallback.
+        # SKIPPED when a committed docs/release-notes/<tag>.md already exists — a curated
+        # (or previously-persisted) file is authoritative, so there's no point spending an
+        # inference call. continue-on-error so a Models hiccup/rate-limit falls through to
+        # the fallback when it does run.
+        if: ${{ steps.notes_prep.outputs.has_file != 'true' }}
         continue-on-error: true
         uses: actions/ai-inference@v1
         with:
@@ -371,27 +379,31 @@ jobs:
           set -u
           SUMMARY=""
           BODY=""
+          NOTES_FILE="docs/release-notes/${TAG}.md"
+          USED_COMMITTED=false
 
-          # The model response is read from its file (never interpolated as shell text).
-          if [ -n "${RESP_FILE:-}" ] && [ -s "${RESP_FILE}" ]; then
+          # Precedence: a committed notes file wins (curated, or persisted from a prior AI
+          # run); else the GitHub Models response; else a placeholder.
+          if [ -f "$NOTES_FILE" ]; then
+            echo "Using committed ${NOTES_FILE}"
+            USED_COMMITTED=true
+            # Optional first-line marker '<!-- SUMMARY: ... -->' becomes the title suffix
+            # and is stripped from the rendered body.
+            SUMMARY=$(sed -n 's/^<!-- SUMMARY:[[:space:]]*\(.*[^[:space:]]\)[[:space:]]*-->[[:space:]]*$/\1/p' "$NOTES_FILE" | head -1 | tr -d '\r') || true
+            BODY=$(sed '/^<!-- SUMMARY:.*-->[[:space:]]*$/d' "$NOTES_FILE")
+          elif [ -n "${RESP_FILE:-}" ] && [ -s "${RESP_FILE}" ]; then
+            echo "Using the GitHub Models draft."
             SUMMARY=$(grep -m1 '^SUMMARY:' "$RESP_FILE" | sed 's/^SUMMARY:[[:space:]]*//' | tr -d '\r') || true
             # Extract the content of the FIRST ```-fenced block (the description).
             BODY=$(awk '/^```/{fence++; next} fence==1{print}' "$RESP_FILE")
-          else
-            echo "No model response — falling back to committed notes / placeholder."
           fi
 
-          # Fallbacks: a committed notes file, else a placeholder. Never block the release.
           if [ -z "$BODY" ]; then
-            if [ -f "docs/release-notes/${TAG}.md" ]; then
-              echo "Using committed docs/release-notes/${TAG}.md"
-              BODY=$(cat "docs/release-notes/${TAG}.md")
-            else
-              BODY=$(printf '_Release notes unavailable; see the full changelog below._\n\n%s' "$FULL_LINK")
-            fi
+            echo "No committed notes and no model response — using a placeholder."
+            BODY=$(printf '_Release notes unavailable; see the full changelog below._\n\n%s' "$FULL_LINK")
           fi
 
-          # Guarantee the compare link is present (append if the model / file omitted it).
+          # Guarantee the compare link is present (append if the source omitted it).
           case "$BODY" in
             *"${CMP_URL}"*) ;;
             *) BODY=$(printf '%s\n\n%s' "$BODY" "$FULL_LINK") ;;
@@ -404,9 +416,13 @@ jobs:
             NAME="pfBlockerNG ${VERSION}"
           fi
 
-          # Persist the rendered notes for the persist-notes job to commit under docs/.
+          # Persist the rendered notes for the persist-notes job to commit under docs/ —
+          # but only when we GENERATED them; a committed file is already in the repo (leave
+          # it untouched so persist-notes is a clean no-op and the SUMMARY marker survives).
           mkdir -p docs/release-notes
-          printf '%s\n' "$BODY" > "docs/release-notes/${TAG}.md"
+          if [ "$USED_COMMITTED" != true ]; then
+            printf '%s\n' "$BODY" > "$NOTES_FILE"
+          fi
 
           # Emit name + body to the step output (consumed by the publish step) …
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -871,20 +871,24 @@ odd/even conventions:
   `.githooks/pre-push` consume it, so the rule never drifts. Behaviour pinned by
   `tests/test_release_version.py`.
 
-**Release notes.** `release.yml` drafts the body with **GitHub Models** (`actions/ai-inference`,
-model `openai/gpt-4.1`) — **no secret**, the built-in token + `permissions: models:read`, free
-tier. A shell step gathers the commits since the **previous same-channel release** (`prev_tag`
-classifies each tag's channel via `release-version.sh`), feeds them to the model with the static
-system prompt in **`scripts/release-notes-prompt.txt`**, and the model returns a `SUMMARY:` line
-(→ the Release **title** suffix, `pfBlockerNG VER — 3-word summary`) plus a Markdown code block
-grouping user-facing changes under **Features / Improvements / Bug Fixes** with PR/issue links
-(CI/test/tooling/ADR noise filtered out), ending with the compare link. Resilient: if inference is
-unavailable/empty it falls back to a committed `docs/release-notes/TAG.md`, else a placeholder —
-the release never blocks on the generator. The rendered notes are **persisted** to
-`docs/release-notes/TAG.md` by the `persist-notes` job (committed to the channel branch; docs-only
-⇒ CI-skipped). To swap models, change the `model:` input; to use Claude Haiku on a Max plan instead,
-flip the step to the Claude CLI with `CLAUDE_CODE_OAUTH_TOKEN` (the prompt file + parser are reused).
-**Nightly builds get no GitHub Release.**
+**Release notes.** Body precedence: a **committed `docs/release-notes/TAG.md` wins** (curated, or
+persisted from a prior run) — when present the Models step is **skipped**; else **GitHub Models**
+(`actions/ai-inference`, model `openai/gpt-4.1` — **no secret**, the built-in token +
+`permissions: models:read`, free tier) drafts it; else a placeholder (the release never blocks on
+the generator). When Models runs, a shell step gathers the commits since the **previous
+same-channel release** (`prev_tag` classifies each tag's channel via `release-version.sh`) and
+feeds them with the static system prompt in **`scripts/release-notes-prompt.txt`**; the model
+returns a `SUMMARY:` line (→ the Release **title** suffix, `pfBlockerNG VER — 3-word summary`) plus
+a Markdown code block grouping user-facing changes under **Features / Improvements / Bug Fixes**
+with PR/issue links (CI/test/tooling/ADR noise filtered out), ending with the compare link. A
+**committed file** carries the same notes; its title summary rides in an optional first-line
+`<!-- SUMMARY: … -->` marker (stripped from the rendered body). Generated notes are **persisted**
+to `docs/release-notes/TAG.md` by the `persist-notes` job (committed to the channel branch;
+docs-only ⇒ CI-skipped); a pre-committed file is left untouched. To author notes by hand (or to
+"play the model" when Models is unavailable), commit `docs/release-notes/TAG.md` — same format,
+optional `<!-- SUMMARY: … -->` first line. To swap models, change the `model:` input; to use Claude
+Haiku on a Max plan instead, flip the step to the Claude CLI with `CLAUDE_CODE_OAUTH_TOKEN` (the
+prompt file + parser are reused). **Nightly builds get no GitHub Release.**
 
 **Dry-run.** `release.yml`'s `workflow_dispatch` is a no-publish harness: pass the `tag` to
 simulate (e.g. `v4.0.0.alpha.1`) with `dry_run=true` (default) to validate the scheme, build the

--- a/docs/release-notes/v4.0.0.alpha.1.md
+++ b/docs/release-notes/v4.0.0.alpha.1.md
@@ -1,0 +1,72 @@
+<!-- SUMMARY: DNSBL, performance & zero-downtime -->
+**This is the first alpha of the 4.0.0 series — a large rework of pfBlockerNG.**
+It is intended for testing only: expect rough edges, and do not run it on a
+production firewall without a config backup. Feedback and bug reports are very
+welcome.
+
+## Features
+
+- **Python-only DNSBL engine.** The domain-blocklist path now runs entirely
+  through a single in-resolver Python matcher — faster, simpler, and the only
+  mode going forward (the legacy Unbound mode has been removed).
+- **ABP / EasyList feed support.** Feeds written in Adblock Plus / EasyList
+  syntax are parsed natively, with reliable host extraction regardless of feed
+  header style.
+- **Homoglyph (confusable) blocking.** Optional protection against look-alike
+  internationalized domains (e.g. a Cyrillic `аpple`), using Unicode confusable
+  analysis.
+- **Zero-downtime blocklist updates.** DNSBL list swaps no longer drop in-flight
+  queries during a reload.
+- **Unified decision cache** for consistent, lower-latency block decisions.
+- **Group-policy DNSBL** — apply different DNSBL behaviour per client source.
+- **Permit-action DNSBL rows.** A per-row Deny/Permit action lets a feed allow
+  specific domains, so an allow feed can carve exceptions out of a blocked set.
+- **Automatic sinkhole VIP** (opt-in) and a **setup wizard** that can create the
+  DNSBL VIP for you instead of configuring it by hand.
+- **Aggregated ("Uber") aliases** — opt-in, per-action unioned urltable aliases
+  for downstream consumers such as HAProxy. Native reference sets, no extra
+  firewall rules.
+- **Scheduled log rotation & retention.** Per-log calendar schedules reset logs
+  on your cadence, optionally keeping the last N lines on reset
+  ([#416](https://github.com/pfBlockerNG/pfBlockerNG/issues/416)).
+- **Self-hosted package repository** — install and upgrade pfBlockerNG directly
+  from the project's own repository, alongside the Netgate channel — plus a
+  **nightly channel** for early testers, **CE- and Plus-aware delivery** of the
+  correct package variant for your pfSense edition, and **release rollback &
+  retention** so you can pin to an older build.
+
+## Improvements
+
+- **Reworked Feeds UI** with a clearer tabbed layout.
+- **DoH/DoT/DoQ blocking** moved from SafeSearch to the DNSBL page, where it
+  belongs, with clearer in-page guidance.
+- **DNSBL IPs alias** action clarified, with a new **Alias Native** option.
+- **Reverse DNS lookup** for log entries is now a toggle and defaults **off** for
+  new installs (faster, quieter logging).
+- **Safer configuration handling** — a single config access layer with a
+  downgrade-safe storage contract, so rolling back a release will not corrupt
+  stored settings.
+- **Correct locale handling** across blocklist processing, to avoid silently
+  dropping entries.
+- **pfSense Plus support**, validated in CI.
+- The discontinued **AlienVault** feed is now marked as such
+  ([#319](https://github.com/pfBlockerNG/pfBlockerNG/issues/319)).
+
+## Bug Fixes
+
+- Store the **XMLRPC sync password verbatim** instead of HTML-escaped, so synced
+  passwords are no longer corrupted
+  ([#339](https://github.com/pfBlockerNG/pfBlockerNG/issues/339)).
+- Recognize **local IPv6 hosts** in the alert external-host attribution
+  ([#361](https://github.com/pfBlockerNG/pfBlockerNG/issues/361)).
+- Keep **whitelist descriptions** intact and validate the wizard's allow-type
+  fields correctly ([#353](https://github.com/pfBlockerNG/pfBlockerNG/issues/353)).
+
+## Versioning
+
+Starting with this release the development channel uses semantic pre-release
+tags: `vX.Y.Z.alpha.N` (alpha), `vX.Y.Z.beta.N` (beta), and `vX.Y.Z.rc.N`
+(release candidate), cut from `devel`; stable releases are plain `vX.Y.Z`, cut
+from `main`.
+
+**Full changelog:** [`v3.2.15` → `v4.0.0.alpha.1`](https://github.com/pfBlockerNG/pfBlockerNG/compare/v3.2.15...v4.0.0.alpha.1)


### PR DESCRIPTION
Adds the curated release notes for `v4.0.0.alpha.1` and makes a committed notes file authoritative — the GitHub Models step is skipped when a file is present.

## Changes

- **`docs/release-notes/v4.0.0.alpha.1.md`** — curated notes for the first 4.0 alpha (written by applying the same `scripts/release-notes-prompt.txt` system prompt to the commit range), grouped Features / Improvements / Bug Fixes with issue/PR links, ending in the compare link. First line carries an optional `<!-- SUMMARY: DNSBL, performance & zero-downtime -->` marker for the title.
- **`release.yml` precedence flip** — a committed `docs/release-notes/<tag>.md` now wins:
  - `notes_prep` emits `has_file`; the **Models step is skipped** (`if: has_file != 'true'`) when a file exists — no wasted inference call.
  - `assemble` reads the committed file first (parsing the `<!-- SUMMARY: … -->` marker into the title suffix, stripping it from the body), then the Models draft, then a placeholder.
  - A pre-committed file is left untouched on disk, so `persist-notes` is a clean no-op and the marker survives.
- **`CLAUDE.md`** — documents the file-first precedence and the `<!-- SUMMARY: … -->` convention.

Net effect: the release body for `v4.0.0.alpha.1` comes from the committed file (title `pfBlockerNG 4.0.0.alpha.1 — DNSBL, performance & zero-downtime`); when no file exists, Models drafts and `persist-notes` records it — same format either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uHiRAb1dGjCUqh9km94WY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * v4.0.0.alpha.1 released with a Python-only DNSBL engine, feed parsing for ABP/EasyList, zero-downtime blocklist updates, homoglyph/confusable blocking, optional sinkhole VIP, and scheduled log rotation.

* **Bug Fixes**
  * Fixed XMLRPC sync password storage and alert attribution for local IPv6.

* **Documentation**
  * Added v4.0.0.alpha.1 release notes with full changelog comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->