### PR TITLE
release: set git identity before tagging in prepare-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,6 +294,11 @@ jobs:
           TAG:    ${{ steps.resolve.outputs.tag }}
           BRANCH: ${{ steps.resolve.outputs.branch }}
         run: |
+          # Annotated tags need a committer identity. The changelog step also sets
+          # this, but it is skipped when a committed notes file already exists, so set
+          # it here unconditionally (idempotent if already set).
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           # Push the branch only if we have new commits ahead of the remote.
           if ! git diff --quiet "origin/${BRANCH}..HEAD" 2>/dev/null; then
             git push origin "HEAD:${BRANCH}"


### PR DESCRIPTION
## Problem

The first real release dispatch (`v4.0.0.alpha.1`) failed in `prepare-release` at the `git tag -a` step:

```
Committer identity unknown
fatal: empty ident name (...) not allowed
```

The annotated-tag step needs a git committer identity. That identity was only configured inside the **"Write + commit the changelog"** step — which is **skipped** when a committed `docs/release-notes/<tag>.md` already exists (`has_file=true`). For `v4.0.0.alpha.1` the notes file is pre-committed, so the changelog step was skipped and the tag step ran with no identity.

The failure happened before the tag was created, so no `v4.0.0.alpha.1` tag exists — a retry is clean.

## Fix

Set `user.name`/`user.email` unconditionally at the start of the tag step, so the identity is present regardless of whether the changelog step ran. Idempotent if already set.

Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uHiRAb1dGjCUqh9km94WY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->