### PR TITLE
release: pass --repo to gh release edit in publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1021,7 +1021,7 @@ jobs:
             exit 0
           fi
           if [ "$PRERELEASE" = "true" ]; then PRE_FLAG="--prerelease"; else PRE_FLAG="--latest"; fi
-          gh release edit "$TAG" --draft=false $PRE_FLAG
+          gh release edit "$TAG" --repo "$REPO" --draft=false $PRE_FLAG
           echo "Published release ${TAG} (prerelease=${PRERELEASE})."
 
   # ── 2d. Poke the self-hosted pkg repository to republish (ADR-17) ──────────


### PR DESCRIPTION
## Problem

The `v4.0.0.alpha.2` release got all the way through: draft created, **all 3 `.pkg` built** (CE-2.8-amd64, Plus-26.03-amd64, Plus-26.03-aarch64) + source archive attached, and the **healthcheck passed** (`Expected .pkg: 3 | found .pkg: 3 | source archives: 1`). The final publish step then failed:

```
gh release edit "$TAG" --draft=false ...
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `publish-release` job has no `actions/checkout`, so `gh` couldn't resolve the repo from a local git dir. The healthcheck's `gh release view` already passed `--repo "$REPO"`; the `gh release edit` was missing it.

## Fix

Add `--repo "$REPO"` to `gh release edit` in the publish step. One line.

The draft `v4.0.0.alpha.2` is already complete (all assets attached, healthcheck green). After merge, re-dispatching `release.yml` resumes that same draft (idempotent: tag reused, draft updated, healthcheck re-passes) and publishes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uHiRAb1dGjCUqh9km94WY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release automation workflow configuration to ensure proper release publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->