### PR TITLE
release: mint sync-ports-fork token from the PKG GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1097,12 +1097,28 @@ jobs:
       contents: read
 
     steps:
+      - name: Generate GitHub App token (FreeBSD-ports)
+        id: ports-token
+        # Mint a short-lived installation token from the PKG GitHub App, scoped to
+        # pfBlockerNG/FreeBSD-ports with Contents:write — the same App used by
+        # repo-publish, no standalone PAT to rotate. REQUIRES the App to be installed
+        # on FreeBSD-ports with Contents:write; if it is not, this step fails loudly
+        # ('not installed on ... repositories' / permission error) — the clear signal
+        # to grant it, rather than a confusing empty-token checkout failure.
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
+          owner: pfBlockerNG
+          repositories: FreeBSD-ports
+          permission-contents: write
+
       - name: Checkout the FreeBSD-ports fork (use-github branch)
         uses: actions/checkout@v6
         with:
           repository: pfBlockerNG/FreeBSD-ports
           ref: pfblockerng/use-github
-          token: ${{ secrets.PORTS_TOKEN }}
+          token: ${{ steps.ports-token.outputs.token }}
           fetch-depth: 0
 
       - name: Checkout pfBlockerNG (scripts only — sparse)


### PR DESCRIPTION
## What

`sync-ports-fork` failed in the `v4.0.0.alpha.2` release run with `Input required and not supplied: token` — the `PORTS_TOKEN` secret is unset, so the cross-repo checkout of `pfBlockerNG/FreeBSD-ports` couldn't authenticate.

Replace the standalone PAT with a short-lived installation token minted from the **existing PKG GitHub App** (`PKG_GITHUB_APP_ID` / `PKG_GITHUB_APP_PRIVATE_KEY`, already used by `repo-publish`), scoped to `pfBlockerNG/FreeBSD-ports` with `Contents: write`. No standalone PAT to rotate.

## Requirement

The PKG App must be **installed on `pfBlockerNG/FreeBSD-ports` with `Contents: write`** (it's currently scoped to `pfBlockerNG/pkg`). If it isn't, the new token-mint step fails loudly (`not installed on … repositories` / permission error) — a clear signal to grant it, rather than the opaque empty-token checkout failure we hit.

This fixes the port bump for **future** releases; `v4.0.0.alpha.2`'s release is already published with all `.pkg` (the self-hosted pkg repo consumes the Release assets directly, so alpha.2 is installable regardless of the ports-fork label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uHiRAb1dGjCUqh9km94WY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow authentication mechanism to enhance security practices in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->