### PR TITLE
pfblockerng: accept legacy string in config toggle write adapters

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -122,10 +122,17 @@ function pfb_cfg_toggle_read(mixed $stored): PfbToggle
 /**
  * pfb_cfg_toggle_write — write a PfbToggle back to its stored string.
  *
- * Returns the exact legacy stored string ('on' or '').
+ * Returns the exact legacy stored string ('on' or '').  Accepts either the
+ * runtime enum or a raw legacy string (normalised through the read adapter),
+ * matching the PfbConfig::write() "enum or string" contract.
+ *
+ * @param PfbToggle|string $toggle  Runtime enum or raw stored string.
  */
-function pfb_cfg_toggle_write(PfbToggle $toggle): string
+function pfb_cfg_toggle_write(PfbToggle|string $toggle): string
 {
+	if (is_string($toggle)) {
+		$toggle = pfb_cfg_toggle_read($toggle);
+	}
 	return $toggle->value;
 }
 
@@ -151,10 +158,17 @@ function pfb_cfg_lenient_read(mixed $stored): PfbLenient
 /**
  * pfb_cfg_lenient_write — write a PfbLenient back to its stored string.
  *
- * Returns 'on' or 'off' (never '').
+ * Returns 'on' or 'off' (never '').  Accepts either the runtime enum or a raw
+ * legacy string (normalised through the read adapter), matching the
+ * PfbConfig::write() "enum or string" contract.
+ *
+ * @param PfbLenient|string $lenient  Runtime enum or raw stored string.
  */
-function pfb_cfg_lenient_write(PfbLenient $lenient): string
+function pfb_cfg_lenient_write(PfbLenient|string $lenient): string
 {
+	if (is_string($lenient)) {
+		$lenient = pfb_cfg_lenient_read($lenient);
+	}
 	return $lenient->value;
 }
 
@@ -188,9 +202,17 @@ function pfb_cfg_idn_mode_read(mixed $stored): PfbIdnMode
  * Returns the canonical stored string ('all', 'confusable', or 'off').
  * NOTE: 'on' (legacy) is never re-emitted; it normalises to 'all' on read
  * and is stored as 'all' on write.  This is the intended one-way migration.
+ *
+ * Accepts either the runtime enum or a raw legacy string (normalised through
+ * the read adapter), matching the PfbConfig::write() "enum or string" contract.
+ *
+ * @param PfbIdnMode|string $mode  Runtime enum or raw stored string.
  */
-function pfb_cfg_idn_mode_write(PfbIdnMode $mode): string
+function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 {
+	if (is_string($mode)) {
+		$mode = pfb_cfg_idn_mode_read($mode);
+	}
 	return $mode->value;
 }
 

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -113,6 +113,18 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame('', pfb_cfg_toggle_write(PfbToggle::Off));
 	}
 
+	public function testToggleWriteAcceptsLegacyString(): void
+	{
+		// PfbConfig::write() advertises an "enum or string" contract; a raw
+		// legacy string must normalise through the read adapter (it was a
+		// TypeError before — pfblockerng_update.php Force Reload passes 'on').
+		// Canonical strings round-trip; junk normalises to the '' default.
+		$this->assertSame('on', pfb_cfg_toggle_write('on'));
+		$this->assertSame('', pfb_cfg_toggle_write(''));
+		$this->assertSame('', pfb_cfg_toggle_write('off'));
+		$this->assertSame('', pfb_cfg_toggle_write('yes'));
+	}
+
 	// -----------------------------------------------------------------------
 	// Scenario B — PfbLenient
 	// -----------------------------------------------------------------------
@@ -190,6 +202,16 @@ final class CfgAdaptersTest extends TestCase
 	{
 		$this->assertSame('on', pfb_cfg_lenient_write(PfbLenient::On));
 		$this->assertSame('off', pfb_cfg_lenient_write(PfbLenient::Off));
+	}
+
+	public function testLenientWriteAcceptsLegacyString(): void
+	{
+		// "enum or string" contract: raw legacy string normalises through read.
+		// 'on'/'off' round-trip; '' and junk normalise to the 'off' default.
+		$this->assertSame('on', pfb_cfg_lenient_write('on'));
+		$this->assertSame('off', pfb_cfg_lenient_write('off'));
+		$this->assertSame('off', pfb_cfg_lenient_write(''));
+		$this->assertSame('off', pfb_cfg_lenient_write('yes'));
 	}
 
 	// -----------------------------------------------------------------------
@@ -330,6 +352,18 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame('all', pfb_cfg_idn_mode_write(PfbIdnMode::All));
 		$this->assertSame('confusable', pfb_cfg_idn_mode_write(PfbIdnMode::Confusable));
 		$this->assertSame('off', pfb_cfg_idn_mode_write(PfbIdnMode::Off));
+	}
+
+	public function testIdnModeWriteAcceptsLegacyString(): void
+	{
+		// "enum or string" contract: raw legacy string normalises through read.
+		// Canonical values round-trip; legacy 'on' -> 'all'; '' and junk -> 'off'.
+		$this->assertSame('all', pfb_cfg_idn_mode_write('all'));
+		$this->assertSame('confusable', pfb_cfg_idn_mode_write('confusable'));
+		$this->assertSame('off', pfb_cfg_idn_mode_write('off'));
+		$this->assertSame('all', pfb_cfg_idn_mode_write('on'));
+		$this->assertSame('off', pfb_cfg_idn_mode_write(''));
+		$this->assertSame('off', pfb_cfg_idn_mode_write('yes'));
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -611,6 +611,24 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('on', config_get_path($path));
 	}
 
+	public function testWriteToggleFieldAcceptsLegacyStringValue(): void
+	{
+		// Regression: pfblockerng_update.php Force Reload calls
+		// PfbConfig::write('pfb_reuse', 'on') with a raw string. The toggle
+		// write adapter must accept it (enum-or-string contract) and store
+		// the exact legacy token — previously a TypeError.
+		$path = 'installedpackages/pfblockerng/config/0/pfb_reuse';
+
+		// Before: absent.
+		$this->assertNull(config_get_path($path));
+
+		// When: write the raw legacy string (not the enum).
+		PfbConfig::write('pfb_reuse', 'on');
+
+		// After: stored as the string 'on'.
+		$this->assertSame('on', config_get_path($path));
+	}
+
 	public function testWriteAppliesLenientAdapterBeforeStorage(): void
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_lenient';


### PR DESCRIPTION
## Problem

Running a feed update with **Force → Reload** crashed:

```text
Uncaught TypeError: pfb_cfg_toggle_write(): Argument #1 ($toggle) must be of type PfbToggle, string given,
called in pfblockerng_extra.inc on line 956 ... PfbConfig::write() ... pfblockerng_update.php(454)
```

`pfblockerng_update.php` writes `PfbConfig::write('pfb_reuse', 'on')` with a raw string. `pfb_reuse` carries the `pfb_cfg_toggle_write` adapter, which strict-typed `PfbToggle` only → `TypeError`. The `PfbConfig::write()` gateway docblock advertises an "enum **or** string" value contract, and every NULL-adapter field already accepts plain strings, so adapted fields rejecting a string was an inconsistency.

## Fix

Widened the three write adapters (`pfb_cfg_toggle_write` / `pfb_cfg_lenient_write` / `pfb_cfg_idn_mode_write`) to `Enum|string`. A string argument is normalised through the matching read adapter, so:

- the gateway honours its documented "enum or string" contract uniformly;
- the BACKWARD invariant holds — output is still only the legacy stored vocabulary (`string → read → enum → ->value`).

## Tests

- `CfgAdaptersTest` — string-acceptance for all three adapters (canonical round-trips, junk → default, legacy `'on' → 'all'` for idn).
- `CfgGatewayTest` — regression mirroring the exact crash: `PfbConfig::write('pfb_reuse', 'on')` stores `'on'`.

## Verification

- PHPUnit 1132 ✅ · PHPCS clean ✅ · PHPStan `No errors` ✅ · `php -l` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TF2uW8hio45YxKwVeAWHYW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced configuration adapters to accept and properly normalize legacy configuration string values alongside modern formats, ensuring backward compatibility and correct value storage.

* **Tests**
  * Added test coverage for adapter functions accepting legacy string values.
  * Added regression test to verify legacy toggle field configurations are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->