### PR TITLE
landing: stack channel cards in a single column

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -222,7 +222,7 @@ header h1{margin:0 0 .25rem;font-size:2rem}
 header p{margin:0;color:var(--mut)}
 h2{margin:2.5rem 0 1rem;font-size:1.3rem;border-bottom:1px solid var(--bd);padding-bottom:.4rem}
 h3{margin:1.6rem 0 .5rem;font-size:1.05rem}
-.cards{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+.cards{display:grid;gap:1rem;grid-template-columns:1fr}
 .card{background:var(--card);border:1px solid var(--bd);border-radius:10px;padding:1rem 1.1rem}
 .card h3{margin:0 0 .15rem;font-size:1.1rem}
 .card .ver{color:var(--mut);font-size:.9rem;margin:0 0 .6rem}


### PR DESCRIPTION
## What

Stack the landing-page channel install cards (**Stable & development** and **Nightly**) in a single column instead of side by side on wide screens.

## Why

`scripts/gen_landing.py` rendered `.cards` with `grid-template-columns:repeat(auto-fit,minmax(260px,1fr))`, so the two cards sat side by side once the viewport cleared ~540px. The request is to stack them vertically on large screens.

## Change

One CSS line — `.cards` now uses `grid-template-columns:1fr`, a single-column track at every width (the cards already collapsed to one column on narrow screens).

## Scope

This is the source of the deployed page at https://pfblockerng.github.io/pkg/ — `pfBlockerNG/pkg`'s `publish.yml` runs this repo's `scripts/gen_landing.py` to render it. No change needed in the `pkg` repo.

## Verification

- `tests/test_gen_landing.py` — 33 passed; full pytest 1915 passed.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TF2uW8hio45YxKwVeAWHYW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the landing page cards grid layout to display in a single column instead of a responsive multi-column layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->