### PR TITLE
landing: cap stacked cards to container width on mobile

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -222,7 +222,7 @@ header h1{margin:0 0 .25rem;font-size:2rem}
 header p{margin:0;color:var(--mut)}
 h2{margin:2.5rem 0 1rem;font-size:1.3rem;border-bottom:1px solid var(--bd);padding-bottom:.4rem}
 h3{margin:1.6rem 0 .5rem;font-size:1.05rem}
-.cards{display:grid;gap:1rem;grid-template-columns:1fr}
+.cards{display:grid;gap:1rem;grid-template-columns:minmax(0,1fr)}
 .card{background:var(--card);border:1px solid var(--bd);border-radius:10px;padding:1rem 1.1rem}
 .card h3{margin:0 0 .15rem;font-size:1.1rem}
 .card .ver{color:var(--mut);font-size:.9rem;margin:0 0 .6rem}


### PR DESCRIPTION
## Problem

After #446 stacked the channel cards in a single column (`grid-template-columns:1fr`), the cards overflowed narrow (mobile) viewports.

`1fr` is `minmax(auto,1fr)`. The `auto` minimum sizes the grid track to the item's **min-content** width, which for these cards is the widest unbreakable string — the `fetch … | sh` / `pkg install pfSense-pkg-pfBlockerNG-nightly` one-liners. So the track grew wider than the screen instead of being capped to it. (The previous `minmax(260px,1fr)` had a fixed 260px minimum, not a content-based one, so it never grew past the viewport.)

## Fix

`grid-template-columns:minmax(0,1fr)` — still a single column (cards stay stacked), but the track minimum is `0`, so it's capped to the container width and the inner `<pre>` blocks scroll horizontally (they already carry `overflow:auto`) rather than stretching the card.

## Verification

- `tests/test_gen_landing.py` — 33 passed; full PHPUnit/pytest green via pre-commit.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TF2uW8hio45YxKwVeAWHYW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved card layout responsiveness and overflow behavior for optimal display across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->