### PR TITLE
pkg-landing: pass catalog-path to add-repo --print-conf

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -329,8 +329,10 @@ def _release_card(base: str, latest: dict[str, str], conf_fn: Callable[[str], st
         f"{_copyable(_esc(setup))}"
         f'<ul class="pkgs">{items}</ul>'
         "<details><summary>Manual conf (advanced)</summary>"
-        '<p class="blurb">The bootstrap auto-detects your edition/version/arch; in a hand-written conf, '
-        "replace <code>&lt;varver&gt;/&lt;arch&gt;</code> (e.g. <code>plus-26.03/amd64</code>) with yours.</p>"
+        '<p class="blurb">The bootstrap auto-detects these; in a hand-written conf, replace '
+        "<code>&lt;varver&gt;</code> (the edition-version: <code>ce-2.8</code>, <code>plus-26.03</code>, &hellip;) and "
+        "<code>&lt;arch&gt;</code> (the CPU architecture: <code>amd64</code> or <code>aarch64</code>) "
+        "with your box's values.</p>"
         f"{_copyable(_esc(conf_fn('release')))}</details></div>"
     )
 
@@ -347,8 +349,10 @@ def _nightly_card(base: str, latest: dict[str, str], conf_fn: Callable[[str], st
         "track the very latest, not on a production firewall.</p>"
         f"{_copyable(_esc(one_liner))}"
         "<details><summary>Manual conf (advanced)</summary>"
-        '<p class="blurb">The bootstrap auto-detects your edition/version/arch; in a hand-written conf, '
-        "replace <code>&lt;varver&gt;/&lt;arch&gt;</code> (e.g. <code>ce-2.8/amd64</code>) with yours.</p>"
+        '<p class="blurb">The bootstrap auto-detects these; in a hand-written conf, replace '
+        "<code>&lt;varver&gt;</code> (the edition-version: <code>ce-2.8</code>, <code>plus-26.03</code>, &hellip;) and "
+        "<code>&lt;arch&gt;</code> (the CPU architecture: <code>amd64</code> or <code>aarch64</code>) "
+        "with your box's values.</p>"
         f"{_copyable(_esc(conf_fn('nightly')))}</details></div>"
     )
 

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -39,6 +39,11 @@ SOURCE_REPO_URL = "https://github.com/pfBlockerNG/pfBlockerNG"
 # from the human listing and the package table.
 CATALOG_META = ("packagesite.pkg", "data.pkg")
 
+# Placeholder catalog-path passed to add-repo.sh --print-conf for the manual-conf
+# snippet on the landing page.  The rc.d hook resolves the box's real varver/arch
+# at boot; a hand-written conf must substitute a concrete value (e.g. ce-2.8/amd64).
+_CONF_PLACEHOLDER_PATH = "<varver>/<arch>"
+
 
 def channel_of(name: str) -> str:
     """Map a package NAME to its channel by suffix (-nightly / -devel / stable)."""
@@ -323,7 +328,9 @@ def _release_card(base: str, latest: dict[str, str], conf_fn: Callable[[str], st
         "both packages (they conflict &mdash; install one):</p>"
         f"{_copyable(_esc(setup))}"
         f'<ul class="pkgs">{items}</ul>'
-        "<details><summary>Manual conf (drop in /usr/local/etc/pkg/repos/)</summary>"
+        "<details><summary>Manual conf (advanced)</summary>"
+        '<p class="blurb">The bootstrap auto-detects your edition/version/arch; in a hand-written conf, '
+        "replace <code>&lt;varver&gt;/&lt;arch&gt;</code> (e.g. <code>plus-26.03/amd64</code>) with yours.</p>"
         f"{_copyable(_esc(conf_fn('release')))}</details></div>"
     )
 
@@ -339,7 +346,9 @@ def _nightly_card(base: str, latest: dict[str, str], conf_fn: Callable[[str], st
         "guarantee is that CI passed; unlike <code>devel</code> it carries no stability target. Use it to "
         "track the very latest, not on a production firewall.</p>"
         f"{_copyable(_esc(one_liner))}"
-        "<details><summary>Manual conf (drop in /usr/local/etc/pkg/repos/)</summary>"
+        "<details><summary>Manual conf (advanced)</summary>"
+        '<p class="blurb">The bootstrap auto-detects your edition/version/arch; in a hand-written conf, '
+        "replace <code>&lt;varver&gt;/&lt;arch&gt;</code> (e.g. <code>ce-2.8/amd64</code>) with yours.</p>"
         f"{_copyable(_esc(conf_fn('nightly')))}</details></div>"
     )
 
@@ -818,9 +827,12 @@ def render_autoindex(
 def _conf_via_addrepo(addrepo: str, base: str, channel: str) -> str:
     # add-repo.sh selects the channel by FLAG: the release repo is the default (no arg),
     # --nightly picks the nightly repo. Anything other than "nightly" => the release conf.
+    # --catalog-path is required by --print-conf; we pass a literal placeholder here
+    # because the landing page shows a generic snippet — the rc.d hook resolves the
+    # box's real varver/arch at boot (see _CONF_PLACEHOLDER_PATH).
     extra = ["--nightly"] if channel == "nightly" else []
     out = subprocess.run(
-        ["sh", addrepo, "--print-conf", "--base-url", base, *extra],
+        ["sh", addrepo, "--print-conf", "--base-url", base, "--catalog-path", _CONF_PLACEHOLDER_PATH, *extra],
         capture_output=True,
         text=True,
         check=True,

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -894,3 +894,33 @@ def test_eol_versions_section_present_in_rendered_page_with_route_only() -> None
 
     # Live build version is absent from the EOL section.
     assert "3.2.16" not in eol_block
+
+
+# ── Contract guard: _conf_via_addrepo ↔ add-repo.sh --print-conf ─────────────
+# These tests exercise the REAL add-repo.sh (no monkeypatching) so that any
+# future change to add-repo.sh's --print-conf required-arg contract immediately
+# breaks the unit suite instead of reaching the live publish workflow.
+
+
+def test_conf_via_addrepo_matches_real_add_repo_contract() -> None:
+    """_conf_via_addrepo shells the real add-repo.sh and must produce a valid conf.
+
+    Guards the gen_landing↔add-repo --print-conf contract: on the old code
+    (missing --catalog-path) add-repo.sh exited 2 and raised CalledProcessError,
+    breaking the pfBlockerNG/pkg publish.yml in render_page.  Both channels are
+    exercised (branch coverage).
+    """
+    addrepo: str = str(Path(__file__).resolve().parent.parent / "scripts" / "add-repo.sh")
+    base: str = "https://pfblockerng.github.io/pkg"
+
+    # release channel: repo name `pfblockerng` and URL contains /release/<varver>/<arch>
+    release_conf: str = gl._conf_via_addrepo(addrepo, base, "release")
+    assert release_conf, "release conf must be non-empty"
+    assert "pfblockerng: {" in release_conf
+    assert f"{base}/release/<varver>/<arch>" in release_conf
+
+    # nightly channel: repo name `pfblockerng-nightly` and URL contains /nightly/<varver>/<arch>
+    nightly_conf: str = gl._conf_via_addrepo(addrepo, base, "nightly")
+    assert nightly_conf, "nightly conf must be non-empty"
+    assert "pfblockerng-nightly: {" in nightly_conf
+    assert f"{base}/nightly/<varver>/<arch>" in nightly_conf


### PR DESCRIPTION
## Summary

- `scripts/gen_landing.py` called `add-repo.sh --print-conf` without `--catalog-path`, which became a required argument in a recent commit. This caused `subprocess.CalledProcessError` (exit 2) in `_conf_via_addrepo`, breaking `render_page` in the `pfBlockerNG/pkg` `publish.yml` workflow.
- The manual-conf snippet in both install cards now passes `--catalog-path '<varver>/<arch>'` as a literal placeholder. The `<details>` summary was updated to "Manual conf (advanced)" and an explanatory note was added telling the user that the bootstrap auto-detects their edition/version/arch, while a hand-written conf requires substituting a concrete value (e.g. `ce-2.8/amd64`).
- A new test (`test_conf_via_addrepo_matches_real_add_repo_contract`) shells the real `add-repo.sh` without monkeypatching, covering both the `release` and `nightly` channels. On the old code this test would have raised `CalledProcessError`; going forward any required-arg change to `--print-conf` will fail the unit suite before reaching production.

## Test plan

- [x] `python -m pytest tests/test_gen_landing.py -q` — 34 passed
- [x] `python -m pytest -q` (full suite) — 1929 passed, 2 skipped
- [x] `ruff check scripts/gen_landing.py tests/test_gen_landing.py` — clean
- [x] `ruff format --check scripts/gen_landing.py tests/test_gen_landing.py` — clean
- [x] mypy: not installed locally; pre-commit hook confirmed clean (53 source files, 0 issues)
- [x] Pre-commit hook passed (ruff, pytest, mypy, markdownlint, shellcheck, url-encoding)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3xptAPbvUqfJa6xgCWXsG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the landing-page “Manual conf (advanced)” instructions to explicitly replace `<varver>` and `<arch>` with the user’s actual values, matching the same placeholder format used across release and nightly content.

* **Tests**
  * Added a unit test that runs the real `add-repo.sh` “print-conf” flow for both release and nightly, verifying the generated configuration text includes the correct repo names and URL template paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->