### PR TITLE
pfblockerng: drop the stray label on the DNSBL IPs advanced note

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3191,7 +3191,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 
 	$section = new Form_Section("DNSBL IPs - Advanced {$adv_mode}bound Firewall Rule Settings", "adv{$advmode}boundsettings", COLLAPSIBLE|SEC_CLOSED);
 	$section->addInput(new Form_StaticText(
-		"dnsbl_ip_text_{$adv_type}",
+		null,
 		"<span class=\"text-danger\">Note:</span>&nbsp; In general, Auto-Rules are created as follows:<br />
 			<dl class=\"dl-horizontal\">
 				<dt>{$adv_mode}bound</dt><dd>'any' port, 'any' protocol, 'any' destination and 'any' gateway</dd>


### PR DESCRIPTION
## Problem

On the **DNSBL** page, the *DNSBL IPs → Advanced Inbound/Outbound Firewall Rule Settings* note shows its internal id string as the field label:

> **dnsbl_ip_text_Source** / **dnsbl_ip_text_Destination**

`Form_StaticText($title, $value)` takes the **label** as its first argument; the note passed `"dnsbl_ip_text_{$adv_type}"` there (an id-like string), so it rendered literally as the left-column label.

## Change

Pass `null` as the label — the note-only idiom already used elsewhere (e.g. `pfblockerng_software.php`). The note text is unchanged; it now renders without the stray label. Nothing references that id (it's the only occurrence in the tree), so there's no JS/styling dependency.

`php -l` clean. The `ui_render` gate covers this page's GET render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3xptAPbvUqfJa6xgCWXsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3xptAPbvUqfJa6xgCWXsG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated how labels are rendered in the advanced DNSBL IP settings for inbound and outbound rule configuration, improving consistency in the displayed text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->