### PR TITLE
pfblockerng: move Aggregated Aliases selector to the IP tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -651,7 +651,7 @@ are summarized in **`docs/misc/architecture-notes.md`**; read it before touching
 `.ADRs/ADR_NN_*/`.
 
 **Aggregated "Uber" aliases (ADR-11, IP side — `pfblockerng.inc` + `pfblockerng.sh`).** The
-`pfb_agg_types` multi-select (General settings, **opt-in, default none**) builds, per selected
+`pfb_agg_types` multi-select (IP settings, **opt-in, default none**) builds, per selected
 action type, the Native urltable aliases **`pfB_<Type>_Aggregated_v4`/`_v6`** = the deduped,
 `iprange`d union of that type's effective set (Deny = post-suppression block set incl. DNSBLIP;
 GeoIP folds in by each continent's action — no separate Geo alias). **Native (no firewall

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -67,10 +67,6 @@ $pconfig['pfb_feed_internal_allowlist']	= (string) base64_decode($pfb['gconfig']
 
 $pconfig['pfb_interval']		= $pfb['gconfig']['pfb_interval']			?: 1;
 
-// ADR-11: opt-in per-type aggregate ("Uber") Native aliases. CSV scalar (like
-// blacklist_selected) so it round-trips with no '<0>' list XML; default none selected.
-$pconfig['pfb_agg_types']		= explode(',', (string) ($pfb['gconfig']['pfb_agg_types'] ?? ''));
-
 $pconfig['pfb_min']			= $pfb['gconfig']['pfb_min']				?: 0;
 $pconfig['pfb_hour']			= $pfb['gconfig']['pfb_hour']				?: 0;
 $pconfig['pfb_dailystart']		= $pfb['gconfig']['pfb_dailystart']			?: 0;
@@ -126,7 +122,6 @@ $options_pfb_min	= [ '0' => '00', '15' => '15', '30' => '30', '45' => '45' ];
 $options_pfb_hour	= range(0, 23, 1);
 $options_pfb_dailystart	= range(0, 23, 1);
 $options_skipfeed	= [ '0' => 'No Limit', '1' => '1', '2' => '2', '3' => '3', '4' => '4', '5' => '5', '6' => '6' ];
-$options_pfb_agg_types	= [ 'Deny' => 'Deny', 'Permit' => 'Permit', 'Match' => 'Match', 'Native' => 'Native' ];
 $options_log_types	= [	'100' => '100', '1000' => '1,000', '2000' => '2,000', '4000' => '4,000', '6000' => '6,000',
 				'8000' => '8,000', '10000' => '10,000', '20000' => '20,000', '40000' => '40,000', '60000' => '60,000',
 				'80000' => '80,000', '100000' => '100,000', '200000' => '200,000 - Memory intensive...', '400000' => '400,000',
@@ -232,13 +227,6 @@ if ($_POST) {
 			$pfb['gconfig']['pfb_hour']			= $_POST['pfb_hour']				?: 0;
 			$pfb['gconfig']['pfb_dailystart']		= $_POST['pfb_dailystart']			?: 0;
 			$pfb['gconfig']['skipfeed']			= $_POST['skipfeed']				?: 0;
-
-			// ADR-11: per-type aggregate aliases multi-select -> CSV scalar (sanitised to
-			// the known {Deny,Permit,Match,Native} options; default none). Stored as a
-			// single string so it persists with no '<0>' list XML.
-			$agg_types_post	= (array) ($_POST['pfb_agg_types'] ?? array());
-			$agg_types_post	= array_values(array_intersect(array_keys($options_pfb_agg_types), $agg_types_post));
-			$pfb['gconfig']['pfb_agg_types']		= implode(',', $agg_types_post);
 
 			// Remove old Line Limit setting
 			if (isset($pfb['gconfig']['log_maxlines'])) {
@@ -416,20 +404,6 @@ $section->addInput(new Form_Select(
 ))->setHelp('Default: <strong>No limit</strong><br />'
 		. 'Select max daily download failure threshold via CRON. Clear widget \'failed downloads\' to reset.<br />'
 		. 'On a download failure, the previously downloaded list is reloaded.')
-  ->setAttribute('style', 'width: auto');
-
-$section->addInput(new Form_Select(
-	'pfb_agg_types',
-	'Aggregated Aliases',
-	$pconfig['pfb_agg_types'],
-	$options_pfb_agg_types,
-	TRUE
-))->setHelp('Default: <strong>none</strong><br />'
-		. 'For each selected type, build a Native <strong>pfB_&lt;Type&gt;_Aggregated_v4/_v6</strong> alias '
-		. 'holding that type\'s combined, CIDR-aggregated IP set.<br />'
-		. 'Reference only &mdash; <strong>no firewall rule</strong> is added; use it by name where needed '
-		. '(e.g. in your own rule or an HAProxy ACL). Each loads as a pf table, so enable only the type(s) you use.')
-  ->setAttribute('size', count($options_pfb_agg_types))
   ->setAttribute('style', 'width: auto');
 
 $form->add($section);

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -33,6 +33,14 @@ $pconfig = array();
 $pconfig['enable_dup']		= $pfb['iconfig']['enable_dup']				?: '';
 $pconfig['enable_agg']		= $pfb['iconfig']['enable_agg']				?: '';
 
+// ADR-11: opt-in per-type aggregate ("Uber") aliases. CSV scalar, gateway-registered
+// (general section); presented here beside CIDR Aggregation. Default none -> [''] selects
+// nothing in the multi-select. Options defined here (before the POST handler) so the
+// save-time sanitiser and the rendered select share one source of allowed values.
+// Stored VALUES are Deny/Permit/Match/Native; the labels show the reference-only alias.
+$options_pfb_agg_types		= [ 'Deny' => 'Alias Deny', 'Permit' => 'Alias Permit', 'Match' => 'Alias Match', 'Native' => 'Alias Native' ];
+$pconfig['pfb_agg_types']	= explode(',', (string) PfbConfig::read('pfb_agg_types'));
+
 // Default to 'on' for new installation only
 $pconfig['suppression']		= isset($pfb['iconfig']['suppression'])			? $pfb['iconfig']['suppression'] : 'on';
 
@@ -205,6 +213,15 @@ if ($_POST) {
 			$pfb['iconfig']['killstates']		= pfb_filter($_POST['killstates'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['v4suppression']	= base64_encode($_POST['v4suppression'])			?: '';
 
+			// ADR-11: per-type aggregate aliases multi-select -> CSV scalar (sanitised to the
+			// known option keys; default none). Gateway-registered in the general section, so
+			// written via PfbConfig::write (not the IP section blob). array_keys() keeps the
+			// allowed set in lockstep with $options_pfb_agg_types (defined above).
+			$agg_types_post	= array_values(array_intersect(
+						array_keys($options_pfb_agg_types),
+						(array) ($_POST['pfb_agg_types'] ?? array())));
+			PfbConfig::write('pfb_agg_types', implode(',', $agg_types_post));
+
 			PfbConfig::writeSection('installedpackages/pfblockerngipsettings/config/0', $pfb['iconfig']);
 			write_config('[pfBlockerNG] save IP settings');
 			if (!empty($savemsg)) {
@@ -281,6 +298,23 @@ $section->addInput(new Form_Checkbox(
 	pfb_cfg_toggle_read($pconfig['enable_agg']) === PfbToggle::On,
 	'on'
 ))->setHelp('Optimise CIDRs - merge contiguous CIDRs into larger CIDR blocks.');
+
+// $options_pfb_agg_types is defined near the top (shared with the POST sanitiser).
+$section->addInput(new Form_Select(
+	'pfb_agg_types',
+	'Aggregated Aliases',
+	$pconfig['pfb_agg_types'],
+	$options_pfb_agg_types,
+	TRUE
+))->setHelp('Default: <strong>none</strong><br />'
+		. 'For each selected type, build a <strong>pfB_&lt;Type&gt;_Aggregated_v4/_v6</strong> alias holding the '
+		. 'CIDR-aggregated union of every feed of that action class &mdash; its directional and Alias variants alike '
+		. '(e.g. <em>Alias Deny</em> covers Deny Inbound/Outbound/Both and Alias Deny; <em>Alias Native</em> the '
+		. 'Alias&nbsp;Native feeds).<br />'
+		. 'Every aggregate is <strong>reference only &mdash; no firewall rule</strong> is added; use it by name where '
+		. 'needed (e.g. your own rule or an HAProxy ACL). Each loads as a pf table, so enable only the type(s) you use.')
+  ->setAttribute('size', count($options_pfb_agg_types))
+  ->setAttribute('style', 'width: auto');
 
 $section->addInput(new Form_Checkbox(
 	'suppression',

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1485,7 +1485,7 @@ def read_hook_env(vm: SmokeVM, path: str, *, timeout: float = 30.0) -> dict[str,
 # --------------------------------------------------------------------------- #
 # Aggregate ("Uber") aliases (ADR-11) — the opt-in per-type aggregate selector
 # --------------------------------------------------------------------------- #
-# The General-settings multi-select ``pfb_agg_types`` is a CSV SCALAR at
+# The IP-settings multi-select ``pfb_agg_types`` is a CSV SCALAR at
 # CFG_GLOBAL/pfb_agg_types (e.g. "Deny,Permit"; default "" = none) — a single string
 # (NOT a listtag) so it round-trips with no '<0>' list XML (mirrors blacklist_selected;
 # see pfblockerng.inc:1174). For each selected Type x family, the update pass

--- a/tests/smoke/test_smoke_aggregate.py
+++ b/tests/smoke/test_smoke_aggregate.py
@@ -3,7 +3,7 @@
 pfBlockerNG can build, per SELECTED action type x family, a Native ``urltable`` alias
 ``pfB_<Type>_Aggregated_<family>`` (Type in {Deny,Permit,Match,Native}, family in
 {v4,v6}) = the deduped/``iprange``d union of that type's effective dir. The multi-select
-``pfb_agg_types`` (General settings, opt-in, default ``""`` = none) gates it. The build
+``pfb_agg_types`` (IP settings, opt-in, default ``""`` = none) gates it. The build
 runs IN the update pass (``sync_package_pfblockerng`` -> ``pfb_build_aggregate_aliases``,
 ``inc:2144``, called ``inc:11116``): for each selected type it writes the member union,
 runs ``pfblockerng.sh aggregate`` (cat | sort -u | iprange, mtime-gated), registers the

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -1,22 +1,18 @@
-"""Tier-B browser test (ADR-14) for the ADR-11 General-settings "Aggregated Aliases"
-multi-select.
+"""Tier-B browser test (ADR-14) for the General-settings ADR-29 gateway round-trip.
 
 Drives a headless Chromium on the live ADR-04 smoke VM (the ``browser_page``
-fixture's cookie-authed context — no second login) to exercise the ``pfb_agg_types``
-multi-select that ADR-11 adds to ``pfblockerng_general.php`` (Form_Select 'multiple',
-options Deny/Permit/Match/Native). It is a real before->after test AND the source of
-the human-review screenshots of the new field (empty default vs a populated selection).
+fixture's cookie-authed context — no second login) to exercise the ``pfb_keep``
+gateway field on ``pfblockerng_general.php``: a real save→reload→assert round-trip
+proving the ADR-29 gateway stores the exact legacy token and the page re-renders the
+checkbox state.
 
-The select + its options are taken from the page's own markup
-(``Form_Select('pfb_agg_types', 'Aggregated Aliases', …, $options_pfb_agg_types, TRUE)``,
-``$options_pfb_agg_types = ['Deny'=>'Deny','Permit'=>'Permit','Match'=>'Match',
-'Native'=>'Native']``) — no ``src/`` change. Selecting options is a pure client-side DOM
-change (no Save is clicked), so it never persists.
+Screenshots are written to ``screenshot_dir`` for human review (artifacts, not asserted
+baselines); the assertions are the real gate. Playwright is imported lazily via
+``pytest.importorskip`` so collecting this module without it installed does not
+hard-error.
 
-Screenshots (full page + the field's own form-group) are written to ``screenshot_dir``
-for human review (artifacts, not asserted baselines); the assertions are the real gate.
-Playwright is imported lazily via ``pytest.importorskip`` so collecting this module
-without it installed does not hard-error.
+(The ADR-11 "Aggregated Aliases" multi-select moved to the IP tab — its browser test
+lives in ``test_browser_ip.py``.)
 """
 
 from __future__ import annotations
@@ -33,21 +29,13 @@ sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not ins
 expect = sync_api.expect
 
 if TYPE_CHECKING:
-    from playwright.sync_api import Locator, Page
+    from playwright.sync_api import Page
 
     from .webui import WebUI
 
 pytestmark = pytest.mark.ui_browser
 
 GENERAL_PAGE = "/pfblockerng/pfblockerng_general.php"
-# The ADR-11 multi-select's four option VALUES (the action-type labels the GUI action
-# dropdown / Logs page already use). Order is the canonical type order.
-AGG_OPTIONS = ("Deny", "Permit", "Match", "Native")
-# Locate the select by its LABEL, not an id: pfSense Form_Select(multiple) renders
-# name="pfb_agg_types[]" and the id carries the brackets, so a bare ``#pfb_agg_types``
-# CSS id selector does not match. The form-group carrying the "Aggregated Aliases"
-# label is unambiguous and id-rendering-agnostic; the <select> within it is the field.
-AGG_LABEL = "Aggregated Aliases"
 
 # JS-driven DOM settles synchronously; this is a flake ceiling, not a wait knob.
 JS_TIMEOUT_MS = 10_000
@@ -72,80 +60,6 @@ def _shot(page: Page, screenshot_dir: Path, name: str) -> None:
     """
     mask_page_identity(page)
     page.screenshot(path=str(screenshot_dir / f"{name}.png"), full_page=True)
-
-
-def _shot_field(locator: Locator, screenshot_dir: Path, name: str) -> None:
-    """Write a screenshot of just the field's form-group ``<screenshot_dir>/<name>.png``.
-
-    Scrolls the element into view (Playwright auto-scroll) and captures only its box —
-    a focused image of the "Aggregated Aliases" row (label + multi-select + help text).
-    Value-redacts the Plus VM identity from the (whole) DOM first (ADR-24); a strict
-    no-op on a CE leg, so the CE shot is unchanged.
-    """
-    mask_page_identity(locator.page)
-    locator.scroll_into_view_if_needed(timeout=JS_TIMEOUT_MS)
-    locator.screenshot(path=str(screenshot_dir / f"{name}.png"))
-
-
-def _selected_values(select: Locator) -> list[str]:
-    """The currently-selected option values of the multi-select, in DOM order."""
-    return select.evaluate("el => Array.from(el.selectedOptions).map(o => o.value)")
-
-
-def test_general_aggregate_types_multiselect(
-    browser_page: Page,
-    webui: WebUI,
-    screenshot_dir: Path,
-) -> None:
-    """The ADR-11 "Aggregated Aliases" multi-select renders empty and accepts a selection.
-
-    Before->after (CLAUDE.md): on load the ``pfb_agg_types`` multi-select is a real
-    ``<select multiple>`` carrying exactly the four action-type options
-    (Deny/Permit/Match/Native) with NONE selected (the opt-in default — no aggregate is
-    built). Selecting Deny + Permit makes exactly those two the selected options; the
-    before-state (nothing selected) proves the selection CAUSED the change. No Save is
-    clicked, so nothing persists — this exercises the rendered control + produces the
-    field screenshots (empty vs populated).
-    """
-    page = browser_page
-    _open(page, webui, GENERAL_PAGE)
-    # Confirm we are on the real General page, not the first-run wizard (the webui
-    # fixture dismisses it; assert it here so a regression points at the wizard, not
-    # at the field). The wizard form has no "General Settings" panel title.
-    assert "wizard.php" not in page.url, f"landed on the setup wizard, not General settings: {page.url}"
-
-    # The field's enclosing form-group (label + multi-select + help-block) — located by
-    # its LABEL, id-rendering-agnostic (see AGG_LABEL). Exactly one such group.
-    field = page.locator("div.form-group").filter(has_text=AGG_LABEL)
-    expect(field).to_have_count(1, timeout=JS_TIMEOUT_MS)
-    select = field.locator("select")
-    expect(select).to_be_visible(timeout=JS_TIMEOUT_MS)
-
-    # It is a genuine MULTIPLE select (the opt-in multi-select, not a single dropdown).
-    assert select.evaluate("el => el.multiple") is True, "the Aggregated Aliases field is not a multiple-select"
-    # Exactly the four action-type options, by value.
-    for opt in AGG_OPTIONS:
-        expect(select.locator(f"option[value='{opt}']")).to_have_count(1, timeout=JS_TIMEOUT_MS)
-    assert select.locator("option").count() == len(AGG_OPTIONS), (
-        "unexpected option count on the Aggregated Aliases select"
-    )
-
-    # BEFORE: the opt-in default is NONE selected.
-    assert _selected_values(select) == [], (
-        f"Aggregated Aliases should start with no types selected, got {_selected_values(select)}"
-    )
-    _shot(page, screenshot_dir, "general_full_aggregate_none")
-    _shot_field(field, screenshot_dir, "general_aggregate_types_none")
-
-    # WHEN: select Deny + Permit (a pure client-side DOM change; no Save).
-    select.select_option(["Deny", "Permit"])
-
-    # AFTER: exactly Deny + Permit are selected — the selection took.
-    assert _selected_values(select) == ["Deny", "Permit"], (
-        f"selecting Deny+Permit did not take: selected={_selected_values(select)}"
-    )
-    _shot(page, screenshot_dir, "general_full_aggregate_selected")
-    _shot_field(field, screenshot_dir, "general_aggregate_types_selected")
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_browser_ip.py
+++ b/tests/smoke/ui/test_browser_ip.py
@@ -1,0 +1,149 @@
+"""Tier-B browser test (ADR-14) for the ADR-11 IP-settings "Aggregated Aliases"
+multi-select.
+
+Drives a headless Chromium on the live ADR-04 smoke VM (the ``browser_page``
+fixture's cookie-authed context — no second login) to exercise the ``pfb_agg_types``
+multi-select that ADR-11 adds to ``pfblockerng_ip.php`` (Form_Select 'multiple';
+display labels Alias Deny/Permit/Match/Native, stored values Deny/Permit/Match/Native).
+It is a real before->after test AND the source of the human-review screenshots of the
+field (empty default vs a populated selection).
+
+The select + its options are read from the page's own rendered markup
+(``Form_Select('pfb_agg_types', 'Aggregated Aliases', …, $options_pfb_agg_types, TRUE)``,
+``$options_pfb_agg_types = ['Deny'=>'Alias Deny','Permit'=>'Alias Permit',
+'Match'=>'Alias Match','Native'=>'Alias Native']``). Selecting options is a pure
+client-side DOM change (no Save is clicked), so it never persists.
+
+Screenshots (full page + the field's own form-group) are written to ``screenshot_dir``
+for human review (artifacts, not asserted baselines); the assertions are the real gate.
+Playwright is imported lazily via ``pytest.importorskip`` so collecting this module
+without it installed does not hard-error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .conftest import mask_page_identity
+
+sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
+expect = sync_api.expect
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Locator, Page
+
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_browser
+
+IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
+# The ADR-11 multi-select's four option VALUES (the action-type labels the GUI action
+# dropdown / Logs page already use). Order is the canonical type order. Each names the
+# destination folder/class an aggregate unions (its Alias variant folds in).
+AGG_OPTIONS = ("Deny", "Permit", "Match", "Native")
+# Locate the select by its LABEL, not an id: pfSense Form_Select(multiple) renders
+# name="pfb_agg_types[]" and the id carries the brackets, so a bare ``#pfb_agg_types``
+# CSS id selector does not match. The form-group carrying the "Aggregated Aliases"
+# label is unambiguous and id-rendering-agnostic; the <select> within it is the field.
+AGG_LABEL = "Aggregated Aliases"
+
+# JS-driven DOM settles synchronously; this is a flake ceiling, not a wait knob.
+JS_TIMEOUT_MS = 10_000
+
+
+def _open(page: Page, webui: WebUI, path: str) -> None:
+    """Navigate the cookie-authenticated page to ``path`` and settle the DOM.
+
+    Asserts the load did NOT bounce to the login form (proves the injected session
+    cookie authenticated the browser — no second login).
+    """
+    page.goto(webui.url(path), wait_until="domcontentloaded", timeout=JS_TIMEOUT_MS * 3)
+    page.wait_for_load_state("networkidle", timeout=JS_TIMEOUT_MS * 3)
+    assert page.locator("#usernamefld").count() == 0, f"GET {path} showed the login form -- cookie not authenticated"
+
+
+def _shot(page: Page, screenshot_dir: Path, name: str) -> None:
+    """Write a full-page screenshot artifact ``<screenshot_dir>/<name>.png``.
+
+    Value-redacts the Plus VM identity from the DOM first (ADR-24 ``mask_page_identity``);
+    a strict no-op on a CE leg (empty redaction set), so CE shots are unchanged.
+    """
+    mask_page_identity(page)
+    page.screenshot(path=str(screenshot_dir / f"{name}.png"), full_page=True)
+
+
+def _shot_field(locator: Locator, screenshot_dir: Path, name: str) -> None:
+    """Write a screenshot of just the field's form-group ``<screenshot_dir>/<name>.png``.
+
+    Scrolls the element into view (Playwright auto-scroll) and captures only its box —
+    a focused image of the "Aggregated Aliases" row (label + multi-select + help text).
+    Value-redacts the Plus VM identity from the (whole) DOM first (ADR-24); a strict
+    no-op on a CE leg, so the CE shot is unchanged.
+    """
+    mask_page_identity(locator.page)
+    locator.scroll_into_view_if_needed(timeout=JS_TIMEOUT_MS)
+    locator.screenshot(path=str(screenshot_dir / f"{name}.png"))
+
+
+def _selected_values(select: Locator) -> list[str]:
+    """The currently-selected option values of the multi-select, in DOM order."""
+    return select.evaluate("el => Array.from(el.selectedOptions).map(o => o.value)")
+
+
+def test_ip_aggregate_types_multiselect(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """The ADR-11 "Aggregated Aliases" multi-select renders empty and accepts a selection.
+
+    Before->after (CLAUDE.md): on load the ``pfb_agg_types`` multi-select is a real
+    ``<select multiple>`` carrying exactly the four action-type options
+    (Deny/Permit/Match/Native) with NONE selected (the opt-in default — no aggregate is
+    built). Selecting Deny + Permit makes exactly those two the selected options; the
+    before-state (nothing selected) proves the selection CAUSED the change. No Save is
+    clicked, so nothing persists — this exercises the rendered control + produces the
+    field screenshots (empty vs populated).
+    """
+    page = browser_page
+    _open(page, webui, IP_PAGE)
+    # Confirm we are on the real IP page, not the first-run wizard (the webui fixture
+    # dismisses it; assert it here so a regression points at the wizard, not at the
+    # field). The wizard form carries no IP-settings panel.
+    assert "wizard.php" not in page.url, f"landed on the setup wizard, not IP settings: {page.url}"
+
+    # The field's enclosing form-group (label + multi-select + help-block) — located by
+    # its LABEL, id-rendering-agnostic (see AGG_LABEL). Exactly one such group.
+    field = page.locator("div.form-group").filter(has_text=AGG_LABEL)
+    expect(field).to_have_count(1, timeout=JS_TIMEOUT_MS)
+    select = field.locator("select")
+    expect(select).to_be_visible(timeout=JS_TIMEOUT_MS)
+
+    # It is a genuine MULTIPLE select (the opt-in multi-select, not a single dropdown).
+    assert select.evaluate("el => el.multiple") is True, "the Aggregated Aliases field is not a multiple-select"
+    # Exactly the four action-type options, by value.
+    for opt in AGG_OPTIONS:
+        expect(select.locator(f"option[value='{opt}']")).to_have_count(1, timeout=JS_TIMEOUT_MS)
+    assert select.locator("option").count() == len(AGG_OPTIONS), (
+        "unexpected option count on the Aggregated Aliases select"
+    )
+
+    # BEFORE: the opt-in default is NONE selected.
+    assert _selected_values(select) == [], (
+        f"Aggregated Aliases should start with no types selected, got {_selected_values(select)}"
+    )
+    _shot(page, screenshot_dir, "ip_full_aggregate_none")
+    _shot_field(field, screenshot_dir, "ip_aggregate_types_none")
+
+    # WHEN: select Deny + Permit (a pure client-side DOM change; no Save).
+    select.select_option(["Deny", "Permit"])
+
+    # AFTER: exactly Deny + Permit are selected — the selection took.
+    assert _selected_values(select) == ["Deny", "Permit"], (
+        f"selecting Deny+Permit did not take: selected={_selected_values(select)}"
+    )
+    _shot(page, screenshot_dir, "ip_full_aggregate_selected")
+    _shot_field(field, screenshot_dir, "ip_aggregate_types_selected")

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -65,10 +65,10 @@ class Page:
 # coverage): pfblockerng_category.php and _category_edit.php render an IP view by
 # default and a DNSBL view under ?type=dnsbl; both are listed.
 PAGE_TABLE: tuple[Page, ...] = (
+    Page("general", "/pfblockerng/pfblockerng_general.php", ("pfBlockerNG", "General Settings")),
     # "Aggregated Aliases" is the ADR-11 pfb_agg_types multi-select label (rendered
-    # verbatim) — a third marker so the gate also proves that field renders on the page.
-    Page("general", "/pfblockerng/pfblockerng_general.php", ("pfBlockerNG", "General Settings", "Aggregated Aliases")),
-    Page("ip", "/pfblockerng/pfblockerng_ip.php", ("IP Configuration", "ASN configuration")),
+    # verbatim) — a third marker so the gate also proves that field renders on the IP page.
+    Page("ip", "/pfblockerng/pfblockerng_ip.php", ("IP Configuration", "ASN configuration", "Aggregated Aliases")),
     Page("dnsbl", "/pfblockerng/pfblockerng_dnsbl.php", ("DNSBL Webserver Configuration", "DNSBL Configuration")),
     # feeds.php is split into IPv4/IPv6/DNSBL ?type sub-tabs (ADR-16 Phase 3). Each type
     # is probed; the type-specific marker is the active type's "Feed Settings" alias-name
@@ -228,37 +228,38 @@ def test_page_renders_clean(page: Page, webui: WebUI, php_error_log_guard: PhpEr
     assert result.ok, f"render oracle failed for {page.name} ({path}): {result.detail}"
 
 
-# ADR-11: the General page's pfb_agg_types multi-select must render with ALL FOUR
+# ADR-11: the IP page's pfb_agg_types multi-select must render with ALL FOUR
 # option branches (Deny/Permit/Match/Native) AND its no-rule help caveat. Asserting
 # every option proves each branch of the select is emitted (not just the label), and the
 # caveat substring proves the help text — the user's only signal that an aggregate is
-# Native (no firewall rule) — actually rendered. Substrings verified against the real
-# pfblockerng_general.php: the four $options_pfb_agg_types keys render as Form_Select
+# reference-only (no firewall rule) — actually rendered. Substrings verified against the
+# real pfblockerng_ip.php: the four $options_pfb_agg_types keys render as Form_Select
 # option values ('value="<Type>"'), and the setHelp() copy contains "no firewall rule".
 _AGG_TYPE_OPTIONS = ("Deny", "Permit", "Match", "Native")
 _AGG_HELP_CAVEAT = "no firewall rule"
 _GENERAL_PAGE = "/pfblockerng/pfblockerng_general.php"
+_IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
 
 
-def test_general_page_renders_aggregate_select(webui: WebUI) -> None:
-    """The General page renders the pfb_agg_types select: all four options + the caveat.
+def test_ip_page_renders_aggregate_select(webui: WebUI) -> None:
+    """The IP page renders the pfb_agg_types select: all four options + the caveat.
 
-    Hermetic (no network — the General page renders from local config alone). GET the
+    Hermetic (no network — the IP page renders from local config alone). GET the
     page and assert: (1) the ``pfb_agg_types`` field is present; (2) EACH of the four
     option values (Deny/Permit/Match/Native) is emitted — every branch of the multi-
     select, not just one (CLAUDE.md branch coverage); and (3) the "no firewall rule" help
-    caveat — the load-bearing "these are Native reference IP-sets" wording — is present.
+    caveat — the load-bearing "these are reference-only IP-sets" wording — is present.
     Pairs with the PAGE_TABLE "Aggregated Aliases" label marker (the field's presence) to
     pin both the field and its full option set + help.
     """
-    resp = webui.get(_GENERAL_PAGE)
-    assert resp.status_code == 200, f"GET {_GENERAL_PAGE} -> HTTP {resp.status_code} (expected 200)"
+    resp = webui.get(_IP_PAGE)
+    assert resp.status_code == 200, f"GET {_IP_PAGE} -> HTTP {resp.status_code} (expected 200)"
     body = resp.text
-    assert "pfb_agg_types" in body, "pfb_agg_types select not present on the General page"
+    assert "pfb_agg_types" in body, "pfb_agg_types select not present on the IP page"
     missing = [opt for opt in _AGG_TYPE_OPTIONS if f'value="{opt}"' not in body]
     assert not missing, f"pfb_agg_types select missing option value(s) {missing} (each is a branch that must render)"
     assert _AGG_HELP_CAVEAT in body, (
-        f"pfb_agg_types help caveat {_AGG_HELP_CAVEAT!r} (the Native/no-rule wording) not rendered on the General page"
+        f"pfb_agg_types help caveat {_AGG_HELP_CAVEAT!r} (the no-rule wording) not rendered on the IP page"
     )
 
 


### PR DESCRIPTION
## What

Relocate the **Aggregated Aliases** (`pfb_agg_types`) multi-select from **General settings** to the **IP** tab, placing it beside **CIDR Aggregation** — its natural sibling. Relabel the options and let the help text carry the coverage detail.

## Why

`pfb_agg_types` is an IP-feature control (it builds per-action-type aggregate IP aliases), so it belongs on the IP tab next to the other IP-set options, not under General settings.

## Details

- **UI move only — storage unchanged.** The field stays the gateway-registered (general-section) config key, read/written via `PfbConfig::read`/`PfbConfig::write`, so existing stored values carry over untouched (no migration). The IP-page save stages it via the gateway before the existing `write_config()`, independent of the IP-settings section blob.
- **Option labels → `Alias Deny / Alias Permit / Alias Match / Alias Native`.** Each builds a reference-only (no-rule) *alias* of that action class's set, so the "Alias \<Class\>" label names the output. **Stored values are unchanged** (`Deny`/`Permit`/`Match`/`Native`) — label-only change; the runtime match set is untouched.
- **Help text does the work.** Each option unions every feed of that action class — its directional and Alias variants alike (e.g. *Alias Deny* covers Deny Inbound/Outbound/Both and Alias Deny; *Alias Native* the Alias Native feeds). Every aggregate is reference-only — **no firewall rule** is added. The four options map one-to-one to the four destination folders (`denydir`/`permitdir`/`matchdir`/`nativedir`).

## Tests

- Tier-B browser coverage moved to a new `tests/smoke/ui/test_browser_ip.py` (was `test_browser_general.py`); the General-page browser file keeps its `pfb_keep` gateway round-trip.
- Tier-A render gate (`test_render_smoke.py`) retargeted: the "Aggregated Aliases" marker + the all-four-options (by value) / help-caveat assertion now run against the IP page.
- Doc comments (`helpers.py`, `test_smoke_aggregate.py`, `CLAUDE.md`) updated to note the IP-tab location.

All gates green locally: PHPCS sniffs, PHPUnit (1132), PHPStan, pytest (1930), ruff, markdownlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3xptAPbvUqfJa6xgCWXsG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved the **“Aggregated Aliases”** per-type (Uber) aliases selector from the **General Settings** page to the **IP Settings** page, removing it from General while adding it to IP configuration.

* **Tests**
  * Updated smoke/UI coverage to validate the **Aggregated Aliases** multi-select on the IP Settings page (rendering, option values, and selection state).
  * Adjusted General-page browser smoke tests to focus on the **pfb_keep** save→reload round-trip and updated render expectations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->