### PR TITLE
tests: scrub inherited git env in read-version-matrix shellspec

### DIFF
--- a/tests/shell/read_version_matrix_test_spec.sh
+++ b/tests/shell/read_version_matrix_test_spec.sh
@@ -21,6 +21,13 @@ Describe 'read-version-matrix.sh derived test matrices'
     _mm_repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/vermx.XXXXXX")"
     (
       cd "$_mm_repo" || exit 1
+      # Scrub inherited git context. Under the pre-commit hook, git exports
+      # GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / GIT_PREFIX pointing at the
+      # REAL repo; those override `cd`, so the fixture identity below and the
+      # `commit -qm fixture` would otherwise land on the live branch (resetting
+      # user.* + polluting history). Mirrors tests/test_read_version_matrix.py.
+      unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX \
+        GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
       git init -q
       git config user.email ci@example.invalid
       git config user.name CI
@@ -36,7 +43,15 @@ Describe 'read-version-matrix.sh derived test matrices'
   # observable to the caller.
   run_print_test() {
     _rt_repo="$(make_matrix_repo "$1")"
-    ( cd "$_rt_repo" && sh "$READER" --ref HEAD --file supported-versions.json --print-test )
+    (
+      cd "$_rt_repo" || exit 1
+      # Same scrub as make_matrix_repo: the reader shells out to git
+      # (`git show <ref>:<file>`, `git fetch origin`) and must address the
+      # fixture repo, not an inherited GIT_DIR pointing at the real repo.
+      unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX \
+        GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+      sh "$READER" --ref HEAD --file supported-versions.json --print-test
+    )
     _rt_status=$?
     rm -rf "$_rt_repo"
     return "$_rt_status"


### PR DESCRIPTION
## Problem

`tests/shell/read_version_matrix_test_spec.sh` builds a throwaway fixture git repo to feed `read-version-matrix.sh`:

```sh
(
  cd "$_mm_repo" || exit 1
  git init -q
  git config user.email ci@example.invalid
  git config user.name CI
  ...
  git -c commit.gpgsign=false commit -qm fixture
)
```

The subshell `cd`s into a `mktemp` repo, but when the spec runs **under the pre-commit hook**, git has already exported `GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE` / `GIT_PREFIX` into the hook's environment, pointing at the **real** repo. Those environment variables **override** the subshell `cd`, so every git command — `git config user.*` and `git commit -qm fixture` — operates on the live repository instead of the fixture.

The observable damage on a contributor's checkout that has `shellspec` installed (so the pre-commit hook runs it):

- the committer identity is reset to `CI <ci@example.invalid>`,
- a `fixture` commit (and a staged `supported-versions.json`) is dumped onto whatever branch is being committed.

CI is unaffected — there `shellspec` runs standalone, with no `GIT_DIR` in the environment — so this is a **local-only footgun**.

## Fix

Unset `GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_OBJECT_DIRECTORY GIT_COMMON_DIR` inside both git-driving subshells (the fixture-repo builder and the reader runner), so the temp repo is the sole git context. This mirrors the scrub the Python sibling `tests/test_read_version_matrix.py` already documents and applies (its module docstring describes the exact same trap).

No change to any assertion; behaviour is identical when run standalone.

## Verification

- `shellspec tests/shell/read_version_matrix_test_spec.sh` → 6 examples, 0 failures.
- Committing this change **with** the pre-commit hook active (which runs `shellspec`) no longer pollutes the working repo — committer stays correct, no `fixture` commit, no stray `supported-versions.json`. Before the fix, the same commit reset the identity to `CI` and appended `fixture` commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by preventing Git environment variables from interfering with test execution in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->