### PR TITLE
ADR-35: unify ownership + teardown of pfBlockerNG-managed firewall objects

### DIFF
--- a/.ADRs/ADR_35_Managed_Firewall_Objects/ADR.md
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/ADR.md
@@ -1,6 +1,6 @@
 # ADR-35: Unify ownership + teardown of pfBlockerNG-managed firewall objects
 
-- **Status:** **Proposed** (2026-06-20)
+- **Status:** **Implemented — pending live-VM smoke** (2026-06-22)
 - **Date:** 2026-06-20
 - **Branch:** `adr/35-managed-firewall-objects` (off `devel`; `{slug}` per CLAUDE.md "Branch naming")
 - **Component(s):** new `src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc` (ownership +
@@ -206,16 +206,17 @@ constants in one new include**, not a class/registry hierarchy (see Alternatives
 
 ## 7. Definition of done
 
-- [ ] `pfblockerng_fwobj.inc` layer (is_owned/find/remove/sweep/register), pure parts unit-tested
+- [x] `pfblockerng_fwobj.inc` layer (is_owned/find/remove/sweep/register), pure parts unit-tested
       (branch coverage: each legacy marker + new prefix; guard on/off; user-row survival).
-- [ ] VIP + DNSBL NAT retrofitted with **no** persisted marker/string change; Phase-1 golden
+- [x] VIP + DNSBL NAT retrofitted with **no** persisted marker/string change; Phase-1 golden
       suite green (behaviour identical, before/after).
-- [ ] Deinstall + disable marker sweep wired before bulk config delete; orphan removed; user
+- [x] Deinstall + disable marker sweep wired before bulk config delete; orphan removed; user
       objects untouched; clean-config sweep is a no-op (asserted).
-- [ ] Registration seam in place and demonstrated (VIP + NAT registered through it); ready for
+- [x] Registration seam in place and demonstrated (VIP + NAT registered through it); ready for
       ADR-36/37.
 - [ ] All gates green: `vendor/bin/phpunit`, PHPStan, PHPCS (PFBL-01 + ADR-28 + ADR-29 sniffs),
       `php -l`, `python -m pytest`; live-VM smoke proves add→remove→uninstall + orphan sweep.
+      *(Off-box gates all green (P1–P4). Live-VM smoke authored — pending dispatch.)*
 
 **Manual smoke (owner: maintainer):**
 

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/01_Results.txt
@@ -1,0 +1,102 @@
+ADR-35 Phase 1 — Pin Current Behaviour (Oracle Tests)
+======================================================
+
+STATUS: COMPLETE — all gates green.
+BRANCH: adr/35-managed-firewall-objects
+COMMIT: (see git log)
+
+ADR-RESUME: branch=adr/35-managed-firewall-objects next-phase=2
+
+────────────────────────────────────────────────────────────────────────────────
+WHAT WAS DONE
+────────────────────────────────────────────────────────────────────────────────
+
+Created tests/php/FwobjCurrentBehaviourTest.php — 11 golden PHPUnit tests
+(cases a–k) pinning today's VIP and NAT behaviour before any Phase 2 refactor.
+
+Added doubles to tests/php/pfsense_doubles.php (existing file, no new files):
+  - interface_vip_bring_down()    — records calls for VIP teardown assertions
+  - interface_ipalias_configure() — records calls for VIP bring-up assertions
+  - is_service_running()          — reads $GLOBALS['pfb_test_service_running']
+  - restart_service()             — no-op double
+  - stop_service()                — no-op double
+  - cert_create()                 — emits empty base64 blobs, returns TRUE
+  - get_configured_vip_list()     — reads $GLOBALS['pfb_test_vip_list']
+  - get_specialnet()              — derives from pfb_test_vip_list or explicit seed
+  - where_is_ipaddr_configured()  — always returns [] (no overlap off-appliance)
+  - SPECIALNET_VIPS constant (12) — pfSense globals.inc constant, needed at runtime
+
+ZERO production code changes — final diff touches only tests/php/*.
+
+────────────────────────────────────────────────────────────────────────────────
+TEST CASES (FwobjCurrentBehaviourTest)
+────────────────────────────────────────────────────────────────────────────────
+
+a. testVipFindByMarkerV4          — pfb_find_marked_vip finds v4 VIP by PFB_AUTO_VIP_DESCR_V4
+b. testVipFindByMarkerV6          — pfb_find_marked_vip finds v6 VIP by PFB_AUTO_VIP_DESCR_V6
+c. testVipFindReturnsNullWhenAbsent — returns null when no VIP matches marker
+d. testVipCreateIsIdempotent      — enable+enable does not create duplicate VIPs
+e. testVipDisableRemovesMarkedVipWithMatchingIp — disable removes pfB VIP when IP matches
+f. testVipDisableDoesNotRemoveVipWithNonMatchingIp — IP guard: different IP leaves VIP untouched
+g. testVipDisableNeverTouchesUserVip — non-pfB descr VIP never removed on disable
+h. testNatAddWritesPfbDnslDescr   — enable writes 'pfB DNSBL - DO NOT EDIT' descr
+i. testNatStripsOnDisable         — disable strips pfB NAT rules, preserves user rules
+j. testNatStripsLegacyPfbDnsblPrefix — strips legacy 'pfB DNSBL' prefix variant too
+k. testNatNeverTouchesUserRule    — user NAT rules never removed on enable or disable
+
+────────────────────────────────────────────────────────────────────────────────
+GATE RESULTS
+────────────────────────────────────────────────────────────────────────────────
+
+vendor/bin/phpunit:
+  Tests: 1143, Assertions: 4403, Warnings: 31 (pre-existing pfb_global noise),
+  Skipped: 3. All 11 new FwobjCurrentBehaviourTest cases PASS.
+
+php -l:
+  No syntax errors in FwobjCurrentBehaviourTest.php or pfsense_doubles.php.
+
+vendor/bin/phpstan analyse (level 1):
+  No errors.
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  0 errors (no src/ files changed).
+
+python -m pytest:
+  1930 passed, 2 skipped.
+
+────────────────────────────────────────────────────────────────────────────────
+KEY DESIGN NOTES FOR PHASE 2
+────────────────────────────────────────────────────────────────────────────────
+
+1. pfb_create_dnsbl('enabled') calls pfb_global() on entry which re-reads ALL
+   $pfb keys from config. For the NAT test (h) to work, the config must contain
+   a valid VIP that passes pfb_validate_vips() — otherwise pfb_global() silently
+   force-sets $pfb['dnsbl'] = '' and the NAT block never fires.
+
+   Test h seeds: pfb_dnsvip4 = '_vip_test_nat4', dnsbl_interface = 'opt-double'
+   (matching get_configured_vip_interface's '_vip_test_*' → 'opt-double' double),
+   and $GLOBALS['pfb_test_vip_list'] = ['_vip_test_nat4' => '10.10.10.53'].
+
+2. pfb_manage_dnsbl_vip()'s double-guard on delete: pfb_find_marked_vip() must
+   find the marker AND get_configured_vip_ipv4(stored_vip_id) must return an IP
+   matching $pfb['dnsbl_vip4']. The get_configured_vip_ipv4 double handles
+   '_vip_test_*' prefix → returns '192.0.2.1' (see pfsense_doubles.php).
+
+3. Pre-existing warnings (31): pfb_global() reads $pfb['pfb_min'], $pfb['pfb_hour'],
+   $pfb['pfb_dailystart'] and many other $pfb[] keys that may be absent when called
+   off-appliance. These are Undefined array key notices — E_WARNING in PHP 8+. Not
+   fatal since phpunit.xml has displayDetailsOnTestsThatTriggerWarnings but NOT
+   failOnWarning. Left as-is: suppressing them would hide real regressions.
+
+────────────────────────────────────────────────────────────────────────────────
+FUNCTIONS COVERED
+────────────────────────────────────────────────────────────────────────────────
+
+  pfb_find_marked_vip()   — pfblockerng.inc ~line 1134
+  pfb_manage_dnsbl_vip()  — pfblockerng.inc ~line 1178
+  pfb_create_dnsbl()      — pfblockerng.inc ~line 3778
+
+Files added/modified:
+  tests/php/FwobjCurrentBehaviourTest.php  (new — 11 tests, ~650 lines)
+  tests/php/pfsense_doubles.php            (modified — 114 lines added)
+  .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/01_Results.txt  (this file)

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/02_Results.txt
@@ -1,0 +1,221 @@
+ADR-35 Phase 2 — Add pfblockerng_fwobj.inc ownership/marker layer
+==================================================================
+
+STATUS: COMPLETE — all gates green.
+BRANCH: adr/35-managed-firewall-objects
+
+ADR-RESUME: branch=adr/35-managed-firewall-objects next-phase=3
+
+────────────────────────────────────────────────────────────────────────────────
+WHAT WAS DONE
+────────────────────────────────────────────────────────────────────────────────
+
+Created src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc — pure helper include
+with all six functions and the three marker constants.
+
+Added require_once block in pfblockerng.inc (same file_exists() guard pattern used
+for pfblockerng_extra.inc):
+
+    if (file_exists('/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc')) {
+        require_once('/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc');  // ADR-35: firewall-object ownership/marker layer
+    }
+
+Added require_once in tests/php/bootstrap.php (same explicit repo-path pattern used
+for pfblockerng_extra.inc — needed because the host-absolute file_exists() guard
+in pfblockerng.inc does NOT fire in the off-appliance test environment):
+
+    require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc';
+
+Created tests/php/FwobjLayerTest.php — 21 PHPUnit tests covering all branches.
+
+ZERO production code changes beyond the new file + the two require_once additions.
+
+────────────────────────────────────────────────────────────────────────────────
+CONSTANT DEFINITIONS (pfblockerng_fwobj.inc)
+────────────────────────────────────────────────────────────────────────────────
+
+define('PFB_FWOBJ_NAT_DESCR',      'pfB DNSBL - DO NOT EDIT');
+define('PFB_FWOBJ_NAT_LEGACY_PFX', 'pfB DNSBL');
+define('PFB_FWOBJ_FILTER_PFX',     'pfB_');
+
+Note: PFB_AUTO_VIP_DESCR_V4 / PFB_AUTO_VIP_DESCR_V6 are NOT redefined here — they
+already exist in pfblockerng.inc; str_starts_with(…, 'pfB_') subsumes them.
+
+────────────────────────────────────────────────────────────────────────────────
+FUNCTION SIGNATURES (pfblockerng_fwobj.inc)
+────────────────────────────────────────────────────────────────────────────────
+
+function pfb_fwobj_is_owned(string $descr): bool
+    Returns TRUE iff $descr is owned by pfBlockerNG.
+    Logic: str_starts_with($descr, 'pfB_') OR str_contains($descr, 'pfB DNSBL').
+    Empty string → FALSE.
+
+function pfb_fwobj_find(string $section, string $marker, ?callable $guard = NULL): array|false
+    Reads config_get_path($section, []), returns FIRST owned row matching $marker.
+    Marker matching: if $marker starts with 'pfB_' → str_starts_with; else exact equality.
+    If $guard is non-null, also calls $guard($row) — must return TRUE to accept.
+    Returns the row array, or FALSE if not found.
+
+function pfb_fwobj_remove(string $section, string $marker, ?callable $guard = NULL): bool
+    Strips owned rows matching $marker (and optional guard) from $section via
+    config_set_path. User rows (pfb_fwobj_is_owned() === FALSE) are NEVER removed.
+    Writes config_set_path only when something was removed. No write_config call.
+    Returns TRUE if ≥1 row removed, FALSE if nothing matched.
+
+function pfb_fwobj_sweep(array $sections): bool
+    Iterates each section string; removes every row where pfb_fwobj_is_owned() is TRUE.
+    Writes config_set_path per section only when something was removed. No write_config.
+    Idempotent: second call when no owned rows remain returns FALSE with no writes.
+    Returns TRUE if anything was removed across any section.
+
+function pfb_fwobj_register(array $spec): void
+    Registers a firewall-object spec into the static $registry keyed by $spec['marker'].
+    $spec shape: {type:string, section:string, marker:string, builder:callable, guard:callable|null}
+    Does not create anything immediately.
+
+function pfb_fwobj_reconcile(string $marker): void
+    Finds the registered spec for $marker. Calls pfb_fwobj_find() with section/marker/guard.
+    If not found: calls $spec['builder']() to build the row and appends via config_set_path.
+    If already found: no-op (builder not called, config not written).
+    Throws InvalidArgumentException for an unregistered $marker.
+
+Internal helper (not public API):
+function &pfb_fwobj_registry(): array
+    Returns a reference to the static $registry array (module-private singleton).
+
+────────────────────────────────────────────────────────────────────────────────
+REQUIRE_ONCE LINE + CONTEXT (pfblockerng.inc)
+────────────────────────────────────────────────────────────────────────────────
+
+Lines 31–36 of pfblockerng.inc (after the change):
+
+    if (file_exists('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc')) {
+        require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');   // 'include functions' not yet merged into pfSense
+    }
+    if (file_exists('/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc')) {
+        require_once('/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc');   // ADR-35: firewall-object ownership/marker layer
+    }
+
+────────────────────────────────────────────────────────────────────────────────
+TEST METHODS IN FwobjLayerTest (21 tests, 52 assertions)
+────────────────────────────────────────────────────────────────────────────────
+
+is_owned truth table:
+  a. testIsOwnedNewPfbPrefix          — 'pfB_MyRule' → TRUE
+  b. testIsOwnedVipV4Marker           — PFB_AUTO_VIP_DESCR_V4 ('pfB_AUTO_VIP_v4') → TRUE
+  c. testIsOwnedVipV6Marker           — PFB_AUTO_VIP_DESCR_V6 ('pfB_AUTO_VIP_v6') → TRUE
+  d. testIsOwnedNatFullDescr          — 'pfB DNSBL - DO NOT EDIT' → TRUE
+  e. testIsOwnedNatLegacyPrefix       — 'pfB DNSBL' → TRUE
+  f. testIsOwnedNatLegacyVariant      — 'pfB DNSBL Redirect' → TRUE
+  g. testIsOwnedReturnsFalseForUserDescr — 'My custom rule' → FALSE
+  h. testIsOwnedReturnsFalseForEmpty  — '' → FALSE
+  i. testIsOwnedReturnsFalseForPartialMatch — 'pfB' → FALSE
+
+find/remove with and without guard:
+  j. testFindReturnsMatchedRow        — two-row section; find returns the pfB row
+  k. testFindReturnsFalseWhenAbsent   — user-only section; find returns FALSE
+  l. testFindWithGuardSkipsNonMatchingGuard — two pfB rows, guard accepts one subnet
+  m. testRemoveDeletesOwnedRow        — one pfB + one user NAT; remove → user survives
+  n. testRemoveReturnsFalseWhenNothingMatches — user-only; returns FALSE, no write
+  o. testRemoveNeverTouchesUserRow    — user-only; user row untouched
+  p. testRemoveWithGuard              — two pfB VIPs; guard removes only matching subnet
+
+sweep:
+  q. testSweepRemovesAllOwnedRows     — two sections; all pfB gone, all user rows survive
+  r. testSweepIsNoopOnCleanConfig     — empty config; returns FALSE
+  s. testSweepIsIdempotent            — first call TRUE, second call FALSE
+
+register/reconcile:
+  t. testRegisterAndReconcileCreatesWhenAbsent — builder called when object absent
+  u. testReconcileIsIdempotentWhenPresent      — builder NOT called when object present
+
+────────────────────────────────────────────────────────────────────────────────
+GATE RESULTS
+────────────────────────────────────────────────────────────────────────────────
+
+vendor/bin/phpunit:
+  Tests: 1164, Assertions: 4455, Warnings: 31 (pre-existing pfb_global noise), Skipped: 3.
+  Phase 1 (FwobjCurrentBehaviourTest): 11 tests, 38 assertions — all PASS.
+  Phase 2 (FwobjLayerTest): 21 tests, 52 assertions — all PASS.
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc:
+  No syntax errors detected.
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc:
+  No syntax errors detected (pre-existing E_DEPRECATED notices are pre-existing, unrelated).
+
+vendor/bin/phpstan analyse --no-progress --memory-limit=1G:
+  [OK] No errors
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  0 errors — PFBL-01 (RequirePfbFilter) and ADR-28 (UppercaseBooleanLiteral) and
+  ADR-29 (RequireConfigGateway) sniffs all clean.
+
+python -m pytest -q:
+  1930 passed, 2 skipped.
+
+ruff check .:
+  All checks passed!
+
+────────────────────────────────────────────────────────────────────────────────
+KEY DESIGN DECISIONS
+────────────────────────────────────────────────────────────────────────────────
+
+1. MARKER MATCHING — prefix vs. exact:
+   pfb_fwobj_find/remove use a single dispatch: if $marker starts with 'pfB_'
+   (PFB_FWOBJ_FILTER_PFX) → str_starts_with match; otherwise → exact string equality.
+   This covers:
+     - VIP rows (exact marker PFB_AUTO_VIP_DESCR_V4/V6, both start with 'pfB_' →
+       prefix match finds them if the marker equals the descr, since pfB_AUTO_VIP_v4
+       str_starts_with('pfB_AUTO_VIP_v4') is TRUE)
+     - NAT rows: marker is 'pfB DNSBL - DO NOT EDIT' (exact) — not a pfB_ prefix →
+       exact equality required
+   Callers pass the exact marker token they want to find/remove.
+
+2. REGISTRY STORAGE:
+   A static variable inside pfb_fwobj_registry() returns a reference to the array.
+   This is the simplest approach that works across all call sites without globals.
+   The registry is keyed by $spec['marker'] (a unique token per registered object).
+   setUp() in the test resets it via the reference (`$registry = []`).
+
+3. NO write_config() INSIDE HELPERS:
+   Mirrors the PfbConfig contract (ADR-29). The caller always decides when to flush.
+   pfb_fwobj_remove/sweep/reconcile only call config_set_path; write_config is
+   deliberately absent.
+
+4. FOREIGN SECTIONS:
+   virtualip/vip, nat/rule, filter/rule are pfSense-core foreign sections (ADR-29
+   exclusion list). Direct config_get_path/config_set_path is correct. The
+   RequireConfigGateway sniff does NOT flag pfSense-core section paths.
+   No new fields are registered in pfb_cfg_registry().
+
+5. BOOTSTRAP REQUIRE_ONCE:
+   The pfblockerng.inc file_exists() guard uses a host-absolute path
+   (/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc) that doesn't exist on the
+   development machine. The test bootstrap explicitly loads the file by its repo-relative
+   path (tests/php/bootstrap.php line ~80), mirroring the existing pattern for
+   pfblockerng_extra.inc. This is the correct approach — no production code changed.
+
+────────────────────────────────────────────────────────────────────────────────
+FILES ADDED / MODIFIED
+────────────────────────────────────────────────────────────────────────────────
+
+  src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc  (new — 230 lines)
+  src/usr/local/pkg/pfblockerng/pfblockerng.inc        (modified — 3 lines added)
+  tests/php/bootstrap.php                              (modified — 4 lines added)
+  tests/php/FwobjLayerTest.php                         (new — 21 tests)
+  .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/02_Results.txt  (this file)
+
+────────────────────────────────────────────────────────────────────────────────
+GO-AHEAD FOR PHASE 3
+────────────────────────────────────────────────────────────────────────────────
+
+Phase 3 may now:
+  - Retrofit pfb_manage_dnsbl_vip() to call pfb_fwobj_find/remove instead of the
+    inline pfb_find_marked_vip() + manual loop.
+  - Retrofit pfb_create_dnsbl() NAT detection to call pfb_fwobj_remove() instead of
+    the inline strpos($descr, 'pfB DNSBL') loop.
+  - Retrofit pfb_firewall_rule() filter/rule handling to call pfb_fwobj_remove()
+    instead of the inline substr() check.
+  Both Phase 1 (FwobjCurrentBehaviourTest) and Phase 2 (FwobjLayerTest) must stay
+  green throughout the retrofit.

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/03_Results.txt
@@ -1,0 +1,220 @@
+ADR-35 Phase 3 — Retrofit VIP + NAT teardown onto fwobj layer
+=============================================================
+
+STATUS: COMPLETE — all gates green.
+BRANCH: adr/35-managed-firewall-objects
+
+ADR-RESUME: branch=adr/35-managed-firewall-objects next-phase=4
+
+────────────────────────────────────────────────────────────────────────────────
+WHAT WAS DONE
+────────────────────────────────────────────────────────────────────────────────
+
+Three call sites in pfblockerng.inc retrofitted to use the Phase-2 shared helpers.
+Additionally, pfblockerng_fwobj.inc received a one-line fix to align its marker
+matching with its own design intent (str_contains for non-pfB_ markers).
+
+────────────────────────────────────────────────────────────────────────────────
+CHANGE 1 — pfblockerng_fwobj.inc: marker matching fix
+────────────────────────────────────────────────────────────────────────────────
+
+Lines 119 (pfb_fwobj_find) and 176 (pfb_fwobj_remove):
+  Before: ($descr === $marker)     — exact equality for non-pfB_ markers
+  After:  str_contains($descr, $marker)  — contains match for non-pfB_ markers
+
+Rationale: PFB_FWOBJ_NAT_LEGACY_PFX = 'pfB DNSBL' is documented as "any descr
+CONTAINING this prefix", and pfb_fwobj_is_owned() already uses str_contains for
+the ownership check. The Phase-2 implementation accidentally used exact equality,
+making it impossible to match 'pfB DNSBL - DO NOT EDIT' via the legacy prefix.
+Changing to str_contains aligns implementation with design intent and passes all
+Phase-2 FwobjLayerTest cases (which all test exact-form or pfB_ prefix markers,
+so the change is additive — no existing test breaks).
+
+────────────────────────────────────────────────────────────────────────────────
+CHANGE 2 — pfb_find_marked_vip() (pfblockerng.inc ~lines 1126–1153)
+────────────────────────────────────────────────────────────────────────────────
+
+Before (lines 1138–1149): manual loop with ($vip['descr'] ?? '') !== $marker
+(exact string equality) and no ownership check.
+
+After: loop uses pfb_fwobj_is_owned() for the ownership gate and the same
+prefix/contains marker matching logic as pfb_fwobj_find:
+
+    $use_prefix = str_starts_with($marker, PFB_FWOBJ_FILTER_PFX);
+    foreach ($vips_config as $idx => $vip) {
+        $descr = $vip['descr'] ?? '';
+        if (!pfb_fwobj_is_owned($descr)) {
+            continue;
+        }
+        $marker_match = $use_prefix
+            ? str_starts_with($descr, $marker)
+            : str_contains($descr, $marker);
+        if (!$marker_match) {
+            continue;
+        }
+        // ... $match_ip and is_int($idx) checks unchanged ...
+    }
+
+Return contract unchanged: ?int (the integer key of the first matching entry,
+or null if none matches). Function signature unchanged.
+
+For VIP markers (PFB_AUTO_VIP_DESCR_V4 = 'pfB_AUTO_VIP_v4', same for V6):
+  str_starts_with('pfB_AUTO_VIP_v4', 'pfB_') = TRUE → uses str_starts_with match.
+  Behaviour identical to old exact match for VIP descrs.
+
+────────────────────────────────────────────────────────────────────────────────
+CHANGE 3 — pfb_manage_dnsbl_vip() disable branch (pfblockerng.inc ~lines 1303–1321)
+────────────────────────────────────────────────────────────────────────────────
+
+Before (lines 1306–1315):
+    $idx = pfb_find_marked_vip($vips_config, $fam['marker'], $match_ip);
+    if ($idx === null) { continue; }
+    interface_vip_bring_down($vips_config[$idx]);
+    pfb_logger(...);
+    unset($vips_config[$idx]);
+    $vips_config = array_values($vips_config);
+
+After:
+    $guard = static function(array $row) use ($match_ip): bool {
+        return ($row['subnet'] ?? '') === $match_ip;
+    };
+    $found_row = pfb_fwobj_find('virtualip/vip', $fam['marker'], $guard);
+    if ($found_row === FALSE) { continue; }
+    interface_vip_bring_down($found_row);
+    pfb_logger(...);
+    pfb_fwobj_remove('virtualip/vip', $fam['marker'], $guard);
+    // Re-sync $vips_config from global config (pfb_fwobj_remove wrote it back).
+    $vips_config = config_get_path('virtualip/vip', []);
+
+The $guard closure is the double-guard predicate: ($row['subnet'] ?? '') === $match_ip.
+It is passed to BOTH pfb_fwobj_find (to locate the row for interface_vip_bring_down)
+AND pfb_fwobj_remove (to constrain removal to the IP-matched VIP only).
+
+The create (enabled) branch and the post-write apply phase (lines 1331-1337) still
+call pfb_find_marked_vip() on $vips_config — unchanged, since pfb_find_marked_vip
+now uses the shared ownership logic internally.
+
+Invariant preserved: testVipDisableDoesNotRemoveVipWithNonMatchingIp — when the
+stored IP resolves to a different address than the marked VIP's subnet, $guard
+rejects the row, pfb_fwobj_find returns FALSE, and the VIP survives.
+
+────────────────────────────────────────────────────────────────────────────────
+CHANGE 4 — pfb_create_dnsbl() NAT removal loop (pfblockerng.inc ~lines 3811–3897)
+────────────────────────────────────────────────────────────────────────────────
+
+Before: a single classify loop over config_get_path('nat/rule', []) that ran for
+BOTH enabled and disabled modes, classifying rules into $dnsbl_ex_nat and $pfb_ex_nat
+using strpos($ex_nat['descr'], 'pfB DNSBL') !== FALSE. On disable, $pfb_ex_nat was
+written back as $new_nat; on enable, it was combined with new NAT rules.
+
+After: the classify loop is moved INSIDE the if ($mode == 'enabled') branch where
+it is needed. pfb_fwobj_is_owned() replaces the inline strpos check. The else
+(disabled) branch uses:
+
+    if (pfb_fwobj_remove('nat/rule', PFB_FWOBJ_NAT_LEGACY_PFX)) {
+        $pfbupdate = TRUE;
+    }
+
+pfb_fwobj_remove('nat/rule', 'pfB DNSBL') matches all NAT rules whose descr
+contains 'pfB DNSBL' — both the canonical 'pfB DNSBL - DO NOT EDIT' form and the
+legacy bare 'pfB DNSBL' form — because PFB_FWOBJ_NAT_LEGACY_PFX does not start with
+'pfB_', triggering the str_contains path in pfb_fwobj_remove (see Change 1).
+
+The final config write is restructured to only call config_set_path('nat/rule', $new_nat)
+on enable (disable has no $new_nat since pfb_fwobj_remove already wrote the config).
+write_config() is called in both cases when $pfbupdate is TRUE.
+
+Dead code removed: the $pfbfound = FALSE reset + subsequent if ($mode != 'enabled')
+block (lines 3879–3886 in the old code) was unreachable — $pfbfound was reset to FALSE
+immediately before the if check. This block is not present in the new code.
+
+The add-on-enable path (writing 'pfB DNSBL - DO NOT EDIT' descr) is UNCHANGED.
+No persisted descr string changed.
+
+────────────────────────────────────────────────────────────────────────────────
+MARKER PASSED TO pfb_fwobj_remove FOR NAT REMOVAL
+────────────────────────────────────────────────────────────────────────────────
+
+    pfb_fwobj_remove('nat/rule', PFB_FWOBJ_NAT_LEGACY_PFX)
+
+where PFB_FWOBJ_NAT_LEGACY_PFX = 'pfB DNSBL'.
+
+Matches (via str_contains, since 'pfB DNSBL' does not start with 'pfB_'):
+  - 'pfB DNSBL'               (bare legacy form)
+  - 'pfB DNSBL - DO NOT EDIT' (canonical current form)
+  - any other 'pfB DNSBL *'   (future variants, future-safe)
+
+User rules (no 'pfB DNSBL' in descr) are NEVER removed (pfb_fwobj_is_owned = FALSE).
+
+────────────────────────────────────────────────────────────────────────────────
+PHASE 1 ORACLE CONFIRMATION
+────────────────────────────────────────────────────────────────────────────────
+
+FwobjCurrentBehaviourTest (11 tests, all PASS, unmodified):
+  a. testVipFindByMarkerV4                          PASS
+  b. testVipFindByMarkerV6                          PASS
+  c. testVipFindReturnsNullWhenAbsent               PASS
+  d. testVipCreateIsIdempotent                      PASS
+  e. testVipDisableRemovesMarkedVipWithMatchingIp   PASS
+  f. testVipDisableDoesNotRemoveVipWithNonMatchingIp  PASS
+  g. testVipDisableNeverTouchesUserVip              PASS
+  h. testNatAddWritesPfbDnslDescr                   PASS
+  i. testNatStripsOnDisable                         PASS
+  j. testNatStripsLegacyPfbDnsblPrefix              PASS
+  k. testNatNeverTouchesUserRule                    PASS
+
+FwobjLayerTest (21 tests, all PASS, unmodified):
+  All 21 Phase-2 unit tests for pfb_fwobj_is_owned/find/remove/sweep/register/reconcile.
+
+────────────────────────────────────────────────────────────────────────────────
+GATE RESULTS
+────────────────────────────────────────────────────────────────────────────────
+
+vendor/bin/phpunit:
+  Tests: 1164, Assertions: 4455, Warnings: 31 (pre-existing pfb_global noise), Skipped: 3.
+  All PASS. FwobjCurrentBehaviourTest: 11 tests — all PASS. FwobjLayerTest: 21 tests — all PASS.
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc:
+  No syntax errors detected.
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc:
+  No syntax errors detected.
+
+vendor/bin/phpstan analyse --no-progress --memory-limit=1G:
+  [OK] No errors
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  0 errors — PFBL-01, ADR-28, ADR-29 sniffs all clean.
+
+.venv/bin/python -m pytest -q:
+  1930 passed, 2 skipped.
+
+.venv/bin/ruff check .:
+  All checks passed!
+
+────────────────────────────────────────────────────────────────────────────────
+FILES MODIFIED
+────────────────────────────────────────────────────────────────────────────────
+
+  src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc  (modified — marker matching fix)
+  src/usr/local/pkg/pfblockerng/pfblockerng.inc        (modified — 3 function retrofits)
+  .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/03_Results.txt  (this file)
+
+────────────────────────────────────────────────────────────────────────────────
+GO-AHEAD FOR PHASE 4
+────────────────────────────────────────────────────────────────────────────────
+
+Phase 4 may now:
+  - Retrofit pfb_firewall_rule() filter/rule handling to call pfb_fwobj_remove()
+    with PFB_FWOBJ_FILTER_PFX instead of the inline substr() check.
+  - Any other sweep/deinstall path that still uses inline strpos/substr ownership
+    detection can be migrated to pfb_fwobj_is_owned() / pfb_fwobj_sweep().
+  Both Phase 1 (FwobjCurrentBehaviourTest) and Phase 2 (FwobjLayerTest) must stay
+  green throughout.
+
+Note for Phase 4: the non-pfB_ marker matching in pfb_fwobj_find/remove now uses
+str_contains (fixed in this phase). Any Phase-4 markers that are NOT pfB_-prefixed
+will use str_contains — pass an exact descr string as the marker if you want to
+match only that exact form (str_contains of itself is str_contains === str_starts_with
+when the haystack IS the marker). For pfB_-prefixed markers (like PFB_FWOBJ_FILTER_PFX),
+the str_starts_with path is used unchanged.

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/04_Results.txt
@@ -1,0 +1,290 @@
+ADR-35 Phase 4 — Sweep wiring + registration seam
+==================================================
+
+STATUS: COMPLETE — all gates green.
+BRANCH: adr/35-managed-firewall-objects
+
+ADR-RESUME: branch=adr/35-managed-firewall-objects next-phase=5
+
+────────────────────────────────────────────────────────────────────────────────
+WHAT WAS DONE
+────────────────────────────────────────────────────────────────────────────────
+
+Three changes across two production files + one new test file:
+
+  1. pfblockerng_fwobj.inc: added pfb_fwobj_init_registrations() — the registration seam.
+  2. pfblockerng.inc: wired sweep into deinstall path (pfblockerng_php_pre_deinstall_command).
+  3. pfblockerng.inc: wired defensive sweep into disable teardown (sync_package_pfblockerng).
+  4. tests/php/FwobjSweepSeamTest.php: 8 new test cases a–h.
+
+────────────────────────────────────────────────────────────────────────────────
+CHANGE 1 — pfblockerng_fwobj.inc: pfb_fwobj_init_registrations()
+────────────────────────────────────────────────────────────────────────────────
+
+New function appended at end of pfblockerng_fwobj.inc (after pfb_fwobj_reconcile()).
+
+Registers three specs into the static registry via pfb_fwobj_register():
+
+  a. VIP V4:
+       pfb_fwobj_register([
+           'type'    => 'vip',
+           'section' => 'virtualip/vip',
+           'marker'  => PFB_AUTO_VIP_DESCR_V4,        // 'pfB_AUTO_VIP_v4'
+           'builder' => 'pfb_manage_dnsbl_vip',
+           'guard'   => NULL,
+       ]);
+
+  b. VIP V6:
+       pfb_fwobj_register([
+           'type'    => 'vip',
+           'section' => 'virtualip/vip',
+           'marker'  => PFB_AUTO_VIP_DESCR_V6,        // 'pfB_AUTO_VIP_v6'
+           'builder' => 'pfb_manage_dnsbl_vip',
+           'guard'   => NULL,
+       ]);
+
+  c. DNSBL NAT:
+       pfb_fwobj_register([
+           'type'    => 'nat',
+           'section' => 'nat/rule',
+           'marker'  => PFB_FWOBJ_NAT_LEGACY_PFX,     // 'pfB DNSBL'
+           'builder' => NULL,                          // NAT is managed by pfb_create_dnsbl; seam-only
+           'guard'   => NULL,
+       ]);
+
+These specs DEMONSTRATE the seam that ADR-36/37 will mirror.
+The builder field for VIP points to pfb_manage_dnsbl_vip (seam-only; actual lifecycle
+managed through the normal pfb_manage_dnsbl_vip/pfb_create_dnsbl paths).
+pfb_fwobj_reconcile() is NOT used by the wired sweep paths — sweep uses pfb_fwobj_sweep()
+which is marker-only and does not consult the registry.
+
+────────────────────────────────────────────────────────────────────────────────
+CHANGE 2 — Deinstall sweep insertion point (pfblockerng.inc)
+────────────────────────────────────────────────────────────────────────────────
+
+Function: pfblockerng_php_pre_deinstall_command()
+Insertion: inside the if ($pfb['keep'] != 'on') block, immediately before
+           pfb_remove_config_settings().
+
+Context (surrounding code):
+
+  Line ~14474:
+      foreach (config_get_path(...)) { ... }    // shellcmdsettings cleanup
+
+  === INSERTED HERE ===
+      // [ ADR-35 P4 ] Sweep owned firewall objects BEFORE config ref data is wiped
+      pfb_fwobj_init_registrations();
+      if (pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule'])) {
+          write_config('pfBlockerNG: sweep orphan firewall objects on deinstall');
+      }
+  === END INSERT ===
+
+  Line ~14489 (after insert):
+      // Remove settings from config.xml
+      pfb_remove_config_settings();
+
+ORDER IS PRESERVED: sweep runs BEFORE pfb_remove_config_settings() wipes
+installedpackages/pfblockerng* (which holds pfb_dnsvip4/6 references).
+
+write_config() is called ONLY when pfb_fwobj_sweep() returns TRUE (something swept).
+If the normal disable teardown already cleaned up, sweep returns FALSE and no
+spurious write_config is issued (idempotent).
+
+────────────────────────────────────────────────────────────────────────────────
+CHANGE 3 — Disable teardown sweep insertion point (pfblockerng.inc)
+────────────────────────────────────────────────────────────────────────────────
+
+Function: sync_package_pfblockerng()
+Insertion: immediately after pfb_create_dnsbl($mode), gated on $mode === 'disabled'.
+           pfb_create_dnsbl() itself calls pfb_manage_dnsbl_vip() internally, so by
+           the time the sweep runs, both the normal VIP and NAT removal paths have
+           already executed.
+
+Context (surrounding code):
+
+  Line ~12484:
+      pfb_create_dnsbl($mode);
+
+  === INSERTED HERE ===
+      // [ ADR-35 P4 ] Defensive sweep on disable: after pfb_manage_dnsbl_vip +
+      // pfb_create_dnsbl have removed VIP and NAT, ensure no owned objects remain
+      // (catches half-written state). Idempotent: returns FALSE when already clean.
+      if ($mode === 'disabled') {
+          pfb_fwobj_init_registrations();
+          if (pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule'])) {
+              write_config('pfBlockerNG: sweep orphan firewall objects on disable');
+          }
+      }
+  === END INSERT ===
+
+  Line ~12498 (after insert):
+      // Load new DNSBL updates to Unbound Resolver...
+      if ($pfb['domain_update'] || $pfbupdate || ...)
+
+────────────────────────────────────────────────────────────────────────────────
+FILE MANIFEST — pfblockerng_fwobj.inc in the shipped package
+────────────────────────────────────────────────────────────────────────────────
+
+pfblockerng_fwobj.inc is ALREADY wired into the load chain:
+  pfblockerng.inc (lines 34–35) uses a conditional require_once:
+      if (file_exists('/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc')) {
+          require_once('/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc');
+      }
+  This is the SAME pattern as pfblockerng_extra.inc (lines 31–33).
+
+pfblockerng.xml only lists pfblockerng.inc as <include_file> — the sibling
+.inc files (pfblockerng_extra.inc, pfblockerng_fwobj.inc, pfblockerng_install.inc,
+pfb_unbound_include.inc) are NOT listed in pfblockerng.xml. They are loaded
+dynamically from within pfblockerng.inc via conditional require_once.
+
+CROSS-REPO PLIST NOTE (for orchestrator):
+pfblockerng_extra.inc does NOT appear in the pfblockerng.xml or pfblockerng_install.inc
+as a manifest entry. The FreeBSD-ports pkg-plist (in the separate pfBlockerNG/FreeBSD-ports
+repo under pfblockerng/use-github branch) is the authoritative file manifest for what
+the .pkg includes. pfblockerng_fwobj.inc was created in Phase 2 (src/ file exists) and
+needs a line in that FreeBSD-ports pkg-plist. The portable builder (scripts/build-pkg-portable.py)
+validates staged files against the plist and will error if pfblockerng_fwobj.inc is staged
+(it IS in src/) but not listed. A pkg-plist line following the pfblockerng_extra.inc pattern
+is needed in the cross-repo pfBlockerNG/FreeBSD-ports repo before CI building the .pkg.
+The orchestrator should track this as a cross-repo plist update.
+
+────────────────────────────────────────────────────────────────────────────────
+TEST FILE — tests/php/FwobjSweepSeamTest.php
+────────────────────────────────────────────────────────────────────────────────
+
+New file: tests/php/FwobjSweepSeamTest.php
+Class: FwobjSweepSeamTest (final, extends TestCase)
+Functions under test: pfb_fwobj_sweep, pfb_fwobj_register, pfb_fwobj_reconcile,
+                       pfb_fwobj_init_registrations
+
+8 test methods:
+
+  a. testSweepRemovesOrphanVip
+     Pins: orphan VIP (pfB_AUTO_VIP_v4 marker, double-guard IP ref = '') is swept
+     even when the double-guard predicate (subnet === cleared_ip) would skip it.
+     Before: orphan VIP present; double-guard mismatch confirmed. After: gone.
+
+  b. testSweepRemovesOrphanNat
+     Pins: orphan NAT rule (pfB DNSBL - DO NOT EDIT marker) removed by sweep even
+     without pfb_create_dnsbl teardown (simulates interrupted disable).
+     Before: orphan NAT present. After: gone.
+
+  c. testUserVipSurvivesSweep
+     Pins: user VIP ('My custom user VIP') survives when orphan pfB VIP is swept.
+     Before: two VIPs (orphan + user). After: only user VIP remains.
+
+  d. testUserNatSurvivesSweep
+     Pins: user NAT rule survives when orphan pfB DNSBL NAT is swept.
+     Before: two NAT rules (orphan + user). After: only user NAT remains.
+
+  e. testSweepIsNoopOnCleanConfig
+     Pins: sweep on empty config returns FALSE; write_config NOT called.
+     Verified via $GLOBALS['pfb_test_write_config_calls'] spy (stays empty).
+
+  f. testSweepIsIdempotent
+     Pins: first sweep returns TRUE (orphan removed); second sweep on same empty
+     section returns FALSE (idempotent). Intermediate state asserted.
+
+  g. testRegisterVipAndReconcileCreatesWhenAbsent
+     Pins: register VIP spec with test builder; reconcile when VIP absent → builder
+     called exactly once; VIP created in virtualip/vip.
+     Before: empty section. After: one VIP with PFB_AUTO_VIP_DESCR_V4 marker.
+
+  h. testRegisterVipAndReconcileIsIdempotent
+     Pins: reconcile twice — builder called only on first (object absent); second
+     call is a no-op (object already present). Builder call count asserted = 1 both
+     after first and after second reconcile.
+
+────────────────────────────────────────────────────────────────────────────────
+GATE RESULTS
+────────────────────────────────────────────────────────────────────────────────
+
+vendor/bin/phpunit:
+  Tests: 1172, Assertions: 4493, Warnings: 31 (pre-existing), Skipped: 3.
+  All PASS.
+  FwobjCurrentBehaviourTest: 11 tests — all PASS (unmodified).
+  FwobjLayerTest: 21 tests — all PASS (unmodified).
+  FwobjSweepSeamTest: 8 tests — all PASS (new).
+  Total Phase 1+2+4: 40 tests — all PASS.
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc:
+  No syntax errors detected. (pre-existing deprecation notices from legacy signatures)
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc:
+  No syntax errors detected.
+
+vendor/bin/phpstan analyse --no-progress --memory-limit=1G:
+  [OK] No errors
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  0 errors — PFBL-01, ADR-28 (UppercaseBooleanLiteral), ADR-29 (RequireConfigGateway)
+  all clean.
+
+.venv/bin/python -m pytest -q:
+  1930 passed, 2 skipped.
+
+.venv/bin/ruff check .:
+  All checks passed!
+
+────────────────────────────────────────────────────────────────────────────────
+EDGE CASES ON write_config CALL SITES
+────────────────────────────────────────────────────────────────────────────────
+
+1. DEINSTALL PATH — write_config called iff sweep returns TRUE:
+   Normal case: sync_package_pfblockerng() (called just before the sweep) already
+   runs pfb_manage_dnsbl_vip('disabled') and pfb_create_dnsbl('disabled'), which
+   remove VIP + NAT and call write_config internally. The subsequent sweep returns
+   FALSE → no extra write_config. Only when orphans exist (half-written state) does
+   the sweep return TRUE and write_config is called once more.
+
+2. DISABLE TEARDOWN PATH — same logic: the sweep after pfb_create_dnsbl is a
+   safety net. In the normal (clean) case pfb_create_dnsbl already cleaned up and
+   write_config was already called there; the sweep returns FALSE and does not
+   add another write_config call.
+
+3. The $mode === 'disabled' guard on the disable-path sweep ensures the sweep
+   is NEVER called during an 'enabled' pass (would incorrectly wipe owned objects
+   that are live and intentionally present).
+
+4. $pfb['install'] during deinstall: pfb_global() (called inside
+   sync_package_pfblockerng) resets $pfb['install'] to FALSE and forces
+   $pfb['enable'] = $pfb['dnsbl'] = '' so the disable branch ($mode = 'disabled')
+   fires inside sync_package_pfblockerng even on the deinstall pass.
+   This means BOTH sweeps execute on deinstall:
+     - disable-path sweep (inside sync_package_pfblockerng): catches orphans in
+       the DNSBL section.
+     - deinstall sweep (in pfblockerng_php_pre_deinstall_command): catch-all
+       BEFORE pfb_remove_config_settings() wipes all reference data.
+   Both are idempotent: the second returns FALSE if the first already cleaned up.
+
+────────────────────────────────────────────────────────────────────────────────
+FILES MODIFIED
+────────────────────────────────────────────────────────────────────────────────
+
+  src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc  (added pfb_fwobj_init_registrations)
+  src/usr/local/pkg/pfblockerng/pfblockerng.inc        (sweep wired in 2 call sites)
+  tests/php/FwobjSweepSeamTest.php                     (new — 8 test cases)
+  .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/04_Results.txt  (this file)
+
+────────────────────────────────────────────────────────────────────────────────
+GO-AHEAD FOR PHASE 5
+────────────────────────────────────────────────────────────────────────────────
+
+Phase 5 may proceed. The sweep is wired and tested. The registration seam is
+demonstrated by pfb_fwobj_init_registrations(). Phase 1 + Phase 2 oracles are
+green. Phase 4 (FwobjSweepSeamTest) adds 8 new tests, all green.
+
+Phase 5 should address the remaining work as defined in ADR-35:
+  - Extend the PHPCS RequireConfigGateway sniff or add a new enforcement mechanism
+    if needed for ADR-35 constraints.
+  - Wire pfb_fwobj_sweep/register/reconcile into filter/rule path if ADR-35 scopes it.
+  - Any remaining deinstall/disable coverage from the ADR-35 DoD checklist.
+  - Both Phase 1 (FwobjCurrentBehaviourTest) and Phase 2 (FwobjLayerTest) and
+    Phase 4 (FwobjSweepSeamTest) must stay green throughout.
+
+CROSS-REPO ACTION REQUIRED (tracked by orchestrator):
+  pfBlockerNG/FreeBSD-ports repo, pfblockerng/use-github branch, pkg-plist:
+  Add an entry for pfblockerng_fwobj.inc following the pfblockerng_extra.inc pattern.
+  Without this, scripts/build-pkg-portable.py will fail with "recipe staged files not
+  in the plist" when building the .pkg (pfblockerng_fwobj.inc is in src/ and will be
+  staged, but the plist won't list it).

--- a/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/05_Results.txt
@@ -1,0 +1,174 @@
+ADR-35 Phase 5 — Live-VM smoke + DoD + docs
+============================================
+
+STATUS: COMPLETE — all off-box gates green; live-VM smoke authored and awaiting CI dispatch.
+BRANCH: adr/35-managed-firewall-objects
+
+ADR-RESUME: branch=adr/35-managed-firewall-objects next-phase=COMPLETE
+
+────────────────────────────────────────────────────────────────────────────────
+SMOKE TEST FUNCTIONS — tests/smoke/test_smoke_fwobj.py
+────────────────────────────────────────────────────────────────────────────────
+
+1. test_fwobj_enable_creates_vip_and_nat
+   Proves: enabling DNSBL with pfb_dnsvip_auto=on creates pfB-owned objects.
+   Before-state: pfB_AUTO_VIP_v4 absent from virtualip/vip[], no pfB DNSBL NAT in nat/rule[].
+   Action: set_dnsvip_auto(True), set_dnsbl_enabled(True), reload('update').
+   After-state: virtualip/vip[] has entry with descr='pfB_AUTO_VIP_v4'; nat/rule[] has entry
+                with descr starting 'pfB DNSBL'.
+
+2. test_fwobj_disable_removes_vip_and_nat
+   Proves: disabling DNSBL removes all pfB-owned VIP and NAT entries from config.xml.
+   Before-state: both owned objects confirmed present (before-state asserted).
+   Action: set_dnsbl_enabled(False), reload('update').
+   After-state: neither pfB_AUTO_VIP_v4 nor pfB_AUTO_VIP_v6 nor pfB DNSBL NAT present.
+
+3. test_fwobj_uninstall_sweeps_orphan_preserves_user_objects
+   Proves: the ADR-35 deinstall sweep removes an orphan VIP (pfB marker, pfb_dnsvip4 cleared)
+           while leaving user-created VIP and NAT untouched, and removes all
+           installedpackages/pfblockerng* from config.xml.
+   Before-state: three objects asserted present (orphan VIP, user VIP, user NAT).
+   Action: pkg delete -y pfSense-pkg-pfBlockerNG-devel.
+   After-state: orphan VIP gone; user VIP present; user NAT present; pfb sections gone.
+
+────────────────────────────────────────────────────────────────────────────────
+ORPHAN SEEDING IN SCENARIO C — SSH command sequence
+────────────────────────────────────────────────────────────────────────────────
+
+Seeding is done via php_eval (pfSsh.php) in two steps:
+
+Step 1: _seed_orphan_vip(vm, 'pfB_AUTO_VIP_v4')
+  - Via pfSsh.php: unset $d['pfb_dnsvip4'] from pfblockerngdnsblsettings/config/0 and write_config.
+  - Then append a virtualip/vip[] row with descr='pfB_AUTO_VIP_v4', subnet='10.10.10.99/32',
+    mode=ipalias, interface=lo0, uniqid=pfborphanvip and write_config.
+  - Result: VIP has the pfB marker but pfb_dnsvip4 is cleared, so pfb_manage_dnsbl_vip's
+    double-guard (subnet == stored IP) cannot match it — it is a genuine orphan.
+
+Step 2: _seed_user_vip(vm, 'my-test-user-vip-do-not-delete')
+  - Via pfSsh.php: append a virtualip/vip[] row with the user descr, subnet='127.0.0.200/32'.
+  - write_config.
+
+Step 3: _seed_user_nat(vm, 'my-test-user-nat-do-not-delete')
+  - Via pfSsh.php: append a nat/rule[] row with the user descr, interface=lo0, protocol=tcp.
+  - write_config.
+
+────────────────────────────────────────────────────────────────────────────────
+CONFIG.XML ASSERTION METHOD + KEY PATHS
+────────────────────────────────────────────────────────────────────────────────
+
+All assertions go through the pfSense config API over SSH via pfSsh.php (php_eval /
+_php_read_scalar), following the smoke-suite pattern. Never read config.xml directly.
+
+Key paths and helpers:
+- virtualip/vip[] presence: helpers.marked_vip_subnet(vm, descr) — returns subnet string
+  or '' if absent. Wraps _php_read_scalar iterating config_get_path('virtualip/vip', array()).
+- nat/rule[] presence: _nat_pfb_dnsbl_present(vm) — iterates config_get_path('nat/rule', array()),
+  checks strpos(descr, 'pfB DNSBL') !== FALSE.
+- installedpackages/pfblockerng* presence: _pfb_sections_present(vm) — iterates
+  config_get_path('installedpackages', array()), checks array_keys for 'pfblockerng' prefix.
+- User object survival: inline _php_read_scalar checks with exact descr match.
+
+────────────────────────────────────────────────────────────────────────────────
+ARCHITECTURE-NOTES.MD
+────────────────────────────────────────────────────────────────────────────────
+
+Section title: "Managed firewall object ownership and teardown (ADR-35)"
+Location: appended at the end of docs/misc/architecture-notes.md (after the ADR-39 section).
+Content: one paragraph covering pfblockerng_fwobj.inc's layer; marker recognition union
+(pfB_ prefix + legacy strings); when the sweep runs (disable + deinstall); the ordering
+constraint (before pfb_remove_config_settings); pfb_fwobj_register() seam for ADR-36/37;
+user-object inviolability. Link to tests/smoke/test_smoke_fwobj.py.
+
+────────────────────────────────────────────────────────────────────────────────
+ADR.MD STATUS
+────────────────────────────────────────────────────────────────────────────────
+
+Status line: "Implemented — pending live-VM smoke" (2026-06-22)
+(Per orchestrator override: NOT "Accepted" — that requires the live-VM smoke fan-out to be
+green, which the orchestrator dispatches separately.)
+
+§7 DoD checkboxes ticked (off-box automated suite satisfies these):
+  [x] pfblockerng_fwobj.inc layer unit-tested (P1 + P2: FwobjLayerTest 21 tests)
+  [x] VIP + DNSBL NAT retrofitted; Phase-1 golden suite green (P3: FwobjCurrentBehaviourTest 11 tests)
+  [x] Deinstall + disable sweep wired; orphan removed; user objects untouched (P4: FwobjSweepSeamTest 8 tests)
+  [x] Registration seam in place and demonstrated (P4: pfb_fwobj_init_registrations)
+
+§7 DoD checkboxes NOT ticked (awaiting live-VM dispatch):
+  [ ] All gates green ... live-VM smoke proves add→remove→uninstall + orphan sweep.
+      (Annotated: off-box gates all green. Live-VM smoke authored — pending dispatch.)
+
+§7 Manual smoke items: all remain unchecked (documented out-of-CI limitations, not blockers).
+
+────────────────────────────────────────────────────────────────────────────────
+LIVE-VM SMOKE OUTCOME
+────────────────────────────────────────────────────────────────────────────────
+
+NOT YET RUN. Tests authored and collected (3 functions, 0 import errors). The orchestrator
+dispatches smoke.yml on the branch; this results file is written before that dispatch.
+
+────────────────────────────────────────────────────────────────────────────────
+VERIFICATION OUTPUT
+────────────────────────────────────────────────────────────────────────────────
+
+vendor/bin/phpunit:
+  Tests: 1172, Assertions: 4493, Warnings: 31 (pre-existing), Skipped: 3. All PASS.
+
+php -l pfblockerng.inc: No syntax errors detected.
+php -l pfblockerng_fwobj.inc: No syntax errors detected.
+
+vendor/bin/phpstan analyse --no-progress --memory-limit=1G:
+  [OK] No errors
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  Exit: 0 (clean — PFBL-01 + ADR-28 + ADR-29 all green)
+
+.venv/bin/python -m pytest -q:
+  1930 passed, 2 skipped.
+
+.venv/bin/ruff check .:
+  All checks passed!
+
+python -m pytest tests/smoke/test_smoke_fwobj.py --collect-only:
+  collected 3 items (test_fwobj_enable_creates_vip_and_nat,
+                      test_fwobj_disable_removes_vip_and_nat,
+                      test_fwobj_uninstall_sweeps_orphan_preserves_user_objects)
+  No import errors.
+
+npx markdownlint-cli2 docs/misc/architecture-notes.md:
+  Summary: 0 error(s)
+
+npx markdownlint-cli2 .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md:
+  Summary: 0 error(s)
+
+────────────────────────────────────────────────────────────────────────────────
+FINAL BRANCH DIFF SUMMARY (against origin/devel)
+────────────────────────────────────────────────────────────────────────────────
+
+P1–P4 (already committed, 4 commits):
+  .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/01–04_Results.txt  (handoffs)
+  src/usr/local/pkg/pfblockerng/pfblockerng.inc    (sweep wired in 2 call sites)
+  src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc  (new file: full layer)
+  tests/php/FwobjCurrentBehaviourTest.php          (11 golden tests, P1)
+  tests/php/FwobjLayerTest.php                     (21 layer tests, P2)
+  tests/php/FwobjSweepSeamTest.php                 (8 sweep/seam tests, P4)
+  tests/php/bootstrap.php                          (fwobj.inc bootstrap)
+  tests/php/pfsense_doubles.php                    (doubles for sweep path)
+
+P5 (this commit):
+  tests/smoke/test_smoke_fwobj.py                  (3 live-VM smoke tests)
+  docs/misc/architecture-notes.md                  (ADR-35 subsection added)
+  .ADRs/ADR_35_Managed_Firewall_Objects/ADR.md     (status + §7 ticks)
+  .ADRs/ADR_35_Managed_Firewall_Objects/RESULTS/05_Results.txt  (this file)
+
+Total P1–P5: 13 files changed, ~3100 insertions, ~36 deletions (all in P1-P4 production changes).
+No debug logging or temporary comments in any src/ file.
+
+────────────────────────────────────────────────────────────────────────────────
+CROSS-REPO ACTION REQUIRED (carried from P4)
+────────────────────────────────────────────────────────────────────────────────
+
+pfBlockerNG/FreeBSD-ports repo, pfblockerng/use-github branch, pkg-plist:
+Add an entry for pfblockerng_fwobj.inc following the pfblockerng_extra.inc pattern.
+Without this, scripts/build-pkg-portable.py will fail with "recipe staged files not in
+the plist" when building the .pkg (pfblockerng_fwobj.inc is in src/ and will be staged,
+but the plist won't list it). The smoke CI also needs this for pkg add to succeed.

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -354,3 +354,29 @@ The published file lives at `pfblockerng.github.io/pkg/add-repo.sh` and is what 
 landing page's copy-paste one-liners point to.
 
 Full design: ADR-39.
+
+## Managed firewall object ownership and teardown (ADR-35)
+
+`pfblockerng_fwobj.inc` provides a small shared ownership-and-teardown layer for pfBlockerNG-managed
+objects in pfSense-core sections (`virtualip/vip`, `nat/rule`, `filter/rule`). A pfBlockerNG object
+is **owned** if and only if its `descr` carries a recognised marker. Marker recognition is the union
+of the `pfB_` prefix (new convention, already in use on the filter side) plus the exact legacy strings
+(`pfB_AUTO_VIP_v4`, `pfB_AUTO_VIP_v6`, `pfB DNSBL`, `pfB DNSBL - DO NOT EDIT`) — never rewritten,
+because stored values are frozen (ADR-28). `pfb_fwobj_is_owned()` is the single recognition predicate;
+`pfb_fwobj_sweep()` removes every owned entry from a given section by marker alone, without consulting
+any secondary guard.
+
+The sweep runs in two places: (1) **on disable**, as a defensive pass after `pfb_manage_dnsbl_vip` and
+`pfb_create_dnsbl` have already run their own teardown — catching any half-written state those paths
+may have left; (2) **on deinstall**, before `pfb_remove_config_settings()` wipes the
+`installedpackages/pfblockerng*` reference data. This ordering is load-bearing: the sweep reads the
+pfBlockerNG config sections to resolve the VIP double-guard reference; if the config were wiped first,
+the reference would be gone and the guard would skip orphans.
+
+`pfb_fwobj_register()` is the registration seam ADR-36 and ADR-37 plug into. A feature declares
+`{ type, section, marker, builder, guard? }` once; the reconcile / remove / sweep machinery covers
+it without per-feature boilerplate. The existing VIP and DNSBL-NAT objects are expressed as the first
+two registrations, demonstrating the seam. User objects (no pfB marker) are **never** touched by any
+remove or sweep — asserted by unit tests that seed sibling user rows and prove they survive.
+
+Live-VM smoke: `tests/smoke/test_smoke_fwobj.py` (marker `smoke`).

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3814,7 +3814,10 @@ function pfb_create_dnsbl($mode) {
 		if ($mode == 'enabled') {
 			// Collect existing pfSense NAT rules for comparison.
 			foreach (config_get_path('nat/rule', []) as $ex_nat) {
-				if (pfb_fwobj_is_owned($ex_nat['descr'] ?? '')) {
+				// Bucket only DNSBL-owned NAT (descr carries 'pfB DNSBL') for rebuild,
+				// matching the original strpos() detection — other pfBlockerNG-owned
+				// NAT (e.g. a future managed rule) stays in the preserved 'other' bucket.
+				if (str_contains($ex_nat['descr'] ?? '', PFB_FWOBJ_NAT_LEGACY_PFX)) {
 					// Collect DNSBL NAT rules
 					$dnsbl_ex_nat[] = $ex_nat;
 				} else {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1126,8 +1126,9 @@ function pfb_unbound_listens_v6(): bool {
 // [ ADR-13 ] Locate the index of the auto-managed DNSBL VIP this package owns inside a
 // virtualip/vip array. Pure (no side effects). Ownership is decided by TWO predicates,
 // both required, mirroring the lifecycle contract:
-//   (1) MARKER  : $vip['descr'] === $marker (PFB_AUTO_VIP_DESCR_V4/_V6) — the package
-//                 only ever touches VIPs it stamped, never a manually-created one.
+//   (1) MARKER  : pfb_fwobj_is_owned($vip['descr']) AND marker match via the same
+//                 prefix/contains logic as pfb_fwobj_find (ADR-35 P3 retrofit). VIP
+//                 markers (PFB_AUTO_VIP_DESCR_V4/V6) start with 'pfB_' → str_starts_with.
 //   (2) IP MATCH: when $match_ip is a non-empty string, $vip['subnet'] must equal it.
 //                 Used on delete to bind removal to the address currently resolved from
 //                 the stored pfb_dnsvip4/6 config, so we never delete a marked VIP whose
@@ -1135,8 +1136,16 @@ function pfb_unbound_listens_v6(): bool {
 //                 marker alone (idempotent reuse on create, before any id is stored).
 // Returns the integer key of the first matching entry, or null if none matches.
 function pfb_find_marked_vip(array $vips_config, string $marker, ?string $match_ip): ?int {
+	$use_prefix = str_starts_with($marker, PFB_FWOBJ_FILTER_PFX);
 	foreach ($vips_config as $idx => $vip) {
-		if (($vip['descr'] ?? '') !== $marker) {
+		$descr = $vip['descr'] ?? '';
+		if (!pfb_fwobj_is_owned($descr)) {
+			continue;
+		}
+		$marker_match = $use_prefix
+			? str_starts_with($descr, $marker)
+			: str_contains($descr, $marker);
+		if (!$marker_match) {
 			continue;
 		}
 		if ($match_ip !== null && $match_ip !== '' && ($vip['subnet'] ?? '') !== $match_ip) {
@@ -1294,16 +1303,23 @@ function pfb_manage_dnsbl_vip(string $mode): void {
 				continue;
 			}
 
-			$idx = pfb_find_marked_vip($vips_config, $fam['marker'], $match_ip);
-			if ($idx === null) {
+			// Double-guard: marker match AND subnet must equal the stored resolved IP.
+			// [ ADR-35 P3 ] Use pfb_fwobj_find with the guard to locate the row, then
+			// pfb_fwobj_remove with the same guard to strip it from config.
+			$guard     = static function(array $row) use ($match_ip): bool {
+				return ($row['subnet'] ?? '') === $match_ip;
+			};
+			$found_row = pfb_fwobj_find('virtualip/vip', $fam['marker'], $guard);
+			if ($found_row === FALSE) {
 				continue;
 			}
 
-			// Bring the alias down live, then drop it from config.
-			interface_vip_bring_down($vips_config[$idx]);
+			// Bring the alias down live, then drop it from config via the shared helper.
+			interface_vip_bring_down($found_row);
 			pfb_logger("\nDNSBL auto-VIP: removed {$fam['marker']} at {$match_ip}", 1);
-			unset($vips_config[$idx]);
-			$vips_config = array_values($vips_config);
+			pfb_fwobj_remove('virtualip/vip', $fam['marker'], $guard);
+			// Re-sync $vips_config from global config (pfb_fwobj_remove wrote it back).
+			$vips_config = config_get_path('virtualip/vip', []);
 
 			if (!empty($dnsblconfig[$fam['idkey']])) {
 				unset($dnsblconfig[$fam['idkey']]);
@@ -3795,20 +3811,17 @@ function pfb_create_dnsbl($mode) {
 	if ((!empty($pfb['dnsbl_port']) && !empty($pfb['dnsbl_port_ssl']) && ($pfb['dnsbl'] == 'on') && $mode == 'enabled') || $mode == 'disabled') {
 
 		// DNSBL NAT rules generation
-		$pfbfound = FALSE;
-		// Collect existing pfSense NAT rules
-		foreach (config_get_path('nat/rule', []) as $ex_nat) {
-			if (strpos($ex_nat['descr'], 'pfB DNSBL') !== FALSE) {
-				// Collect DNSBL NAT rules
-				$dnsbl_ex_nat[] = $ex_nat;
-				$pfbfound = TRUE;
-			} else {
-				// Collect all 'other' NAT rules
-				$pfb_ex_nat[] = $ex_nat;
-			}
-		}
-
 		if ($mode == 'enabled') {
+			// Collect existing pfSense NAT rules for comparison.
+			foreach (config_get_path('nat/rule', []) as $ex_nat) {
+				if (pfb_fwobj_is_owned($ex_nat['descr'] ?? '')) {
+					// Collect DNSBL NAT rules
+					$dnsbl_ex_nat[] = $ex_nat;
+				} else {
+					// Collect all 'other' NAT rules
+					$pfb_ex_nat[] = $ex_nat;
+				}
+			}
 
 			// Generate new DNSBL NAT per DNSBL listening ports except for 'localhost' interface setting.
 			$dnsbl_new_nat = array();
@@ -3853,18 +3866,10 @@ function pfb_create_dnsbl($mode) {
 				$new_nat = array_merge($pfb_ex_nat, $dnsbl_ex_nat);
 			}
 		} else {
-			$new_nat = array_merge($pfb_ex_nat, $new_nat);
-			// Update when DNSBL NAT found but is now disabled.
-			if ($pfbfound) {
-				$pfbupdate = TRUE;
-			}
-		}
-
-		$pfbfound = FALSE;
-
-		if ($mode != 'enabled') {
-			// Update when DNSBL NAT found but is now disabled.
-			if ($pfbfound) {
+			// [ ADR-35 P3 ] DISABLE: strip pfB DNSBL NAT rules via the shared ownership
+			// helper. pfb_fwobj_remove writes user-only rules back to config when any pfB
+			// rules are found; returns TRUE iff anything was removed.
+			if (pfb_fwobj_remove('nat/rule', PFB_FWOBJ_NAT_LEGACY_PFX)) {
 				$pfbupdate = TRUE;
 			}
 		}
@@ -3879,9 +3884,13 @@ function pfb_create_dnsbl($mode) {
 			pfb_logger("{$log}", 1);
 		}
 
-		// Update config.xml, if changes required
+		// Update config.xml, if changes required.
+		// On enable: write the full new NAT set. On disable: pfb_fwobj_remove already
+		// wrote the config change; just persist via write_config.
 		if ($pfbupdate) {
-			config_set_path('nat/rule', $new_nat);
+			if ($mode == 'enabled') {
+				config_set_path('nat/rule', $new_nat);
+			}
 			write_config('pfBlockerNG: saving DNSBL changes');
 		}
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -31,6 +31,9 @@ require_once('service-utils.inc');
 if (file_exists('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc')) {
 	require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');	// 'include functions' not yet merged into pfSense
 }
+if (file_exists('/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc')) {
+	require_once('/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc');	// ADR-35: firewall-object ownership/marker layer
+}
 
 define('LOG_PREFIX_PKG_PFBLOCKERNG', 'pfBlockerNG');
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12483,6 +12483,17 @@ function sync_package_pfblockerng($cron='') {
 	// Modify DNSBL NAT and VIP and lighttpd web server conf, as required.
 	pfb_create_dnsbl($mode);
 
+	// [ ADR-35 P4 ] Defensive sweep on disable: after pfb_manage_dnsbl_vip + pfb_create_dnsbl
+	// have removed VIP and NAT, ensure no owned objects remain (catches half-written state where
+	// the reference was cleared but the VIP/NAT entry survived). Sweep is marker-only and
+	// idempotent: returns FALSE (no write) when everything was already cleaned.
+	if ($mode === 'disabled') {
+		pfb_fwobj_init_registrations();
+		if (pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule'])) {
+			write_config('pfBlockerNG: sweep orphan firewall objects on disable');
+		}
+	}
+
 	// Load new DNSBL updates to Unbound Resolver, as required. ADR-06 (#51): a pending
 	// temporary-unlock store ($pfb['dnsbl_unlock']) also forces the reload so a Cron/
 	// Force re-locks it even when no feed changed -- parity with main, where the
@@ -14471,6 +14482,17 @@ function pfblockerng_php_pre_deinstall_command() {
 			if (strpos($shellcmd['cmd'], 'pfblockerng.sh aliastables') !== FALSE) {
 				config_del_path("installedpackages/shellcmdsettings/config/{$key}");
 			}
+		}
+
+		// [ ADR-35 P4 ] Sweep owned firewall objects (VIP, NAT, filter rules) BEFORE the
+		// config reference data is wiped by pfb_remove_config_settings(). The sweep is
+		// marker-only — it does not rely on the double-guard IP reference — so it catches
+		// orphans that the normal disable teardown missed (e.g. VIP reference cleared but
+		// entry not yet removed). If nothing was swept (normal case: disable already cleaned
+		// up) the call is a no-op and write_config() is NOT called (idempotent).
+		pfb_fwobj_init_registrations();
+		if (pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule'])) {
+			write_config('pfBlockerNG: sweep orphan firewall objects on deinstall');
 		}
 
 		// Remove settings from config.xml

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc
@@ -84,8 +84,9 @@ function pfb_fwobj_is_owned(string $descr): bool
  * Reads config_get_path($section, []) and returns the FIRST row whose 'descr'
  * satisfies pfb_fwobj_is_owned() AND matches $marker:
  *   • If $marker starts with PFB_FWOBJ_FILTER_PFX ('pfB_'): str_starts_with match.
- *   • Otherwise: exact string equality (covers legacy 'pfB DNSBL' variants and
- *     the full 'pfB DNSBL - DO NOT EDIT' marker; caller passes the exact token).
+ *   • Otherwise: str_contains match — aligns with the PFB_FWOBJ_NAT_LEGACY_PFX
+ *     contract ("any descr CONTAINING this prefix") so that passing 'pfB DNSBL'
+ *     matches both the bare form and 'pfB DNSBL - DO NOT EDIT'.
  *
  * If $guard is provided it is called with the candidate row and must return TRUE to
  * accept the row (FALSE skips it — e.g. to filter by interface or subnet).
@@ -95,7 +96,7 @@ function pfb_fwobj_is_owned(string $descr): bool
  * $section: config path string, e.g. 'virtualip/vip', 'nat/rule', 'filter/rule'.
  *
  * @param string        $section  Config path string.
- * @param string        $marker   Descr marker to match (exact, or pfB_ prefix match).
+ * @param string        $marker   Descr marker to match (pfB_ prefix match or str_contains).
  * @param callable|null $guard    Optional row-level predicate; TRUE = accept.
  * @return array<string,mixed>|false  First matching row, or FALSE.
  */
@@ -110,13 +111,13 @@ function pfb_fwobj_find(string $section, string $marker, ?callable $guard = NULL
 			continue;
 		}
 
-		// Marker match: prefix or exact.
+		// Marker match: prefix (pfB_) or contains (legacy NAT prefix and exact forms).
 		if ($use_prefix) {
 			if (!str_starts_with($descr, $marker)) {
 				continue;
 			}
 		} else {
-			if ($descr !== $marker) {
+			if (!str_contains($descr, $marker)) {
 				continue;
 			}
 		}
@@ -139,7 +140,7 @@ function pfb_fwobj_find(string $section, string $marker, ?callable $guard = NULL
 /**
  * Reads config_get_path($section, []), filters OUT every row where:
  *   (a) pfb_fwobj_is_owned($row['descr']) is TRUE, AND
- *   (b) the descr matches $marker (same prefix/exact logic as pfb_fwobj_find), AND
+ *   (b) the descr matches $marker (same prefix/contains logic as pfb_fwobj_find), AND
  *   (c) when $guard is provided, $guard($row) returns TRUE.
  *
  * Any row that fails the ownership check (a) is NEVER removed — user-safety invariant.
@@ -151,7 +152,7 @@ function pfb_fwobj_find(string $section, string $marker, ?callable $guard = NULL
  * Returns TRUE if at least one row was removed, FALSE if nothing matched.
  *
  * @param string        $section  Config path string.
- * @param string        $marker   Descr marker to remove (exact, or pfB_ prefix match).
+ * @param string        $marker   Descr marker to remove (pfB_ prefix match or str_contains).
  * @param callable|null $guard    Optional row-level predicate; TRUE = also remove.
  */
 function pfb_fwobj_remove(string $section, string $marker, ?callable $guard = NULL): bool
@@ -170,10 +171,10 @@ function pfb_fwobj_remove(string $section, string $marker, ?callable $guard = NU
 			continue;
 		}
 
-		// Marker match: prefix or exact.
+		// Marker match: prefix (pfB_) or contains (legacy NAT prefix and exact forms).
 		$marker_match = $use_prefix
 			? str_starts_with($descr, $marker)
-			: ($descr === $marker);
+			: str_contains($descr, $marker);
 
 		if (!$marker_match) {
 			$filtered[] = $row;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc
@@ -304,3 +304,53 @@ function pfb_fwobj_reconcile(string $marker): void
 	$rows[]  = $new_row;
 	config_set_path($spec['section'], $rows);
 }
+
+// ---------------------------------------------------------------------------
+// pfb_fwobj_init_registrations — express owned objects as the first registrations
+// ---------------------------------------------------------------------------
+
+/**
+ * Registers the VIP (V4 + V6) and DNSBL NAT specs into the internal registry.
+ *
+ * This is the registration seam that ADR-36/37 will mirror for their own objects.
+ * Registering these specs demonstrates the pattern; pfb_fwobj_reconcile() may be
+ * called subsequently to ensure presence (or the objects may be managed through
+ * the normal pfb_manage_dnsbl_vip / pfb_create_dnsbl paths — either is valid).
+ *
+ * Idempotent: calling this multiple times replaces the existing registrations for
+ * the same markers (pfb_fwobj_register replaces by key).
+ *
+ * write_config() is NEVER called here — callers own the flush.
+ *
+ * NOTE: PFB_AUTO_VIP_DESCR_V4, PFB_AUTO_VIP_DESCR_V6 are defined in
+ * pfblockerng.inc and available here (pfblockerng_fwobj.inc is included AFTER it).
+ */
+function pfb_fwobj_init_registrations(): void
+{
+	// VIP V4 — the sinkhole IPv4 VIP managed by pfb_manage_dnsbl_vip().
+	pfb_fwobj_register([
+		'type'    => 'vip',
+		'section' => 'virtualip/vip',
+		'marker'  => PFB_AUTO_VIP_DESCR_V4,
+		'builder' => 'pfb_manage_dnsbl_vip',	// builder = reconcile caller invokes pfb_manage_dnsbl_vip
+		'guard'   => NULL,						// guard applied at reconcile time via the stored IP
+	]);
+
+	// VIP V6 — the sinkhole IPv6 VIP (provisioned alongside V4 when DNSBL listens on IPv6).
+	pfb_fwobj_register([
+		'type'    => 'vip',
+		'section' => 'virtualip/vip',
+		'marker'  => PFB_AUTO_VIP_DESCR_V6,
+		'builder' => 'pfb_manage_dnsbl_vip',	// builder = same pattern; V6 provisioned in same call
+		'guard'   => NULL,
+	]);
+
+	// DNSBL NAT — managed by pfb_create_dnsbl(); registration proves the seam for ADR-36/37.
+	pfb_fwobj_register([
+		'type'    => 'nat',
+		'section' => 'nat/rule',
+		'marker'  => PFB_FWOBJ_NAT_LEGACY_PFX,
+		'builder' => NULL,						// NAT is managed by pfb_create_dnsbl; NULL = seam-only
+		'guard'   => NULL,
+	]);
+}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+// [ ADR-35 ] Managed firewall objects — ownership / marker layer.
+//
+// This file is a PURE helper include: no shell/exec, no write_config calls.
+// write_config() is always the CALLER'S responsibility (mirrors PfbConfig contract).
+//
+// The sections handled here (virtualip/vip, nat/rule, filter/rule) are pfSense-core
+// foreign sections (ADR-29 exclusion list) — direct config_get_path/config_set_path
+// is correct; the RequireConfigGateway sniff does NOT flag pfSense-core paths.
+
+// ---------------------------------------------------------------------------
+// Recognised-marker constants
+//
+// NOTE: PFB_AUTO_VIP_DESCR_V4 ('pfB_AUTO_VIP_v4') and PFB_AUTO_VIP_DESCR_V6
+// ('pfB_AUTO_VIP_v6') are defined in pfblockerng.inc — do NOT redefine them here.
+// The str_starts_with($descr, PFB_FWOBJ_FILTER_PFX) check in pfb_fwobj_is_owned()
+// already subsumes them (both start with 'pfB_'), but they are called out explicitly
+// in comments below for clarity.
+// ---------------------------------------------------------------------------
+
+/** Full NAT rule description written by pfBlockerNG (the canonical new form). */
+define('PFB_FWOBJ_NAT_DESCR', 'pfB DNSBL - DO NOT EDIT');
+
+/** Legacy NAT prefix: any descr CONTAINING this prefix is owned (covers bare 'pfB DNSBL'
+ *  and any variant suffixed with extra text, e.g. the ' - DO NOT EDIT' form above). */
+define('PFB_FWOBJ_NAT_LEGACY_PFX', 'pfB DNSBL');
+
+/** Filter-rule prefix: any rule descr that STARTS WITH this prefix is owned. */
+define('PFB_FWOBJ_FILTER_PFX', 'pfB_');
+
+// ---------------------------------------------------------------------------
+// Internal registry (static state; populated by pfb_fwobj_register()).
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a reference to the internal registry array (static singleton).
+ *
+ * @return array<string,array{type:string,section:string,marker:string,builder:callable,guard:callable|null}>
+ */
+function &pfb_fwobj_registry(): array
+{
+	static $registry = [];
+	return $registry;
+}
+
+// ---------------------------------------------------------------------------
+// pfb_fwobj_is_owned — ownership predicate
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns TRUE iff $descr indicates pfBlockerNG ownership.
+ *
+ * Recognised patterns (UNION — any one match → owned):
+ *   • str_starts_with($descr, 'pfB_')    — new prefix (covers PFB_AUTO_VIP_DESCR_V4/V6)
+ *   • str_contains($descr, 'pfB DNSBL') — legacy NAT marker (bare AND ' - DO NOT EDIT' form)
+ *
+ * An empty descr or a user-owned description ('My rule', 'WAN', …) returns FALSE.
+ */
+function pfb_fwobj_is_owned(string $descr): bool
+{
+	if ($descr === '') {
+		return FALSE;
+	}
+	// New prefix — also subsumes PFB_AUTO_VIP_DESCR_V4 ('pfB_AUTO_VIP_v4')
+	//              and PFB_AUTO_VIP_DESCR_V6 ('pfB_AUTO_VIP_v6').
+	if (str_starts_with($descr, PFB_FWOBJ_FILTER_PFX)) {
+		return TRUE;
+	}
+	// Legacy NAT marker: covers 'pfB DNSBL' (bare) and 'pfB DNSBL - DO NOT EDIT'.
+	if (str_contains($descr, PFB_FWOBJ_NAT_LEGACY_PFX)) {
+		return TRUE;
+	}
+	return FALSE;
+}
+
+// ---------------------------------------------------------------------------
+// pfb_fwobj_find — locate the first owned row matching $marker
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads config_get_path($section, []) and returns the FIRST row whose 'descr'
+ * satisfies pfb_fwobj_is_owned() AND matches $marker:
+ *   • If $marker starts with PFB_FWOBJ_FILTER_PFX ('pfB_'): str_starts_with match.
+ *   • Otherwise: exact string equality (covers legacy 'pfB DNSBL' variants and
+ *     the full 'pfB DNSBL - DO NOT EDIT' marker; caller passes the exact token).
+ *
+ * If $guard is provided it is called with the candidate row and must return TRUE to
+ * accept the row (FALSE skips it — e.g. to filter by interface or subnet).
+ *
+ * Returns the matching row array, or FALSE if no row matches.
+ *
+ * $section: config path string, e.g. 'virtualip/vip', 'nat/rule', 'filter/rule'.
+ *
+ * @param string        $section  Config path string.
+ * @param string        $marker   Descr marker to match (exact, or pfB_ prefix match).
+ * @param callable|null $guard    Optional row-level predicate; TRUE = accept.
+ * @return array<string,mixed>|false  First matching row, or FALSE.
+ */
+function pfb_fwobj_find(string $section, string $marker, ?callable $guard = NULL): array|false
+{
+	$use_prefix = str_starts_with($marker, PFB_FWOBJ_FILTER_PFX);
+
+	foreach (config_get_path($section, []) as $row) {
+		$descr = $row['descr'] ?? '';
+
+		if (!pfb_fwobj_is_owned($descr)) {
+			continue;
+		}
+
+		// Marker match: prefix or exact.
+		if ($use_prefix) {
+			if (!str_starts_with($descr, $marker)) {
+				continue;
+			}
+		} else {
+			if ($descr !== $marker) {
+				continue;
+			}
+		}
+
+		// Optional guard: skip when the guard rejects.
+		if ($guard !== NULL && !$guard($row)) {
+			continue;
+		}
+
+		return $row;
+	}
+
+	return FALSE;
+}
+
+// ---------------------------------------------------------------------------
+// pfb_fwobj_remove — strip owned rows matching $marker from a section
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads config_get_path($section, []), filters OUT every row where:
+ *   (a) pfb_fwobj_is_owned($row['descr']) is TRUE, AND
+ *   (b) the descr matches $marker (same prefix/exact logic as pfb_fwobj_find), AND
+ *   (c) when $guard is provided, $guard($row) returns TRUE.
+ *
+ * Any row that fails the ownership check (a) is NEVER removed — user-safety invariant.
+ *
+ * When at least one row was removed the filtered array is written back via
+ * config_set_path(). No write is performed when nothing matched (caller decides when
+ * to flush; write_config() is NEVER called here).
+ *
+ * Returns TRUE if at least one row was removed, FALSE if nothing matched.
+ *
+ * @param string        $section  Config path string.
+ * @param string        $marker   Descr marker to remove (exact, or pfB_ prefix match).
+ * @param callable|null $guard    Optional row-level predicate; TRUE = also remove.
+ */
+function pfb_fwobj_remove(string $section, string $marker, ?callable $guard = NULL): bool
+{
+	$use_prefix = str_starts_with($marker, PFB_FWOBJ_FILTER_PFX);
+	$rows       = config_get_path($section, []);
+	$filtered   = [];
+	$removed    = FALSE;
+
+	foreach ($rows as $row) {
+		$descr = $row['descr'] ?? '';
+
+		// Ownership check: user rows are NEVER removed regardless of $marker.
+		if (!pfb_fwobj_is_owned($descr)) {
+			$filtered[] = $row;
+			continue;
+		}
+
+		// Marker match: prefix or exact.
+		$marker_match = $use_prefix
+			? str_starts_with($descr, $marker)
+			: ($descr === $marker);
+
+		if (!$marker_match) {
+			$filtered[] = $row;
+			continue;
+		}
+
+		// Guard check: when guard rejects, keep the row.
+		if ($guard !== NULL && !$guard($row)) {
+			$filtered[] = $row;
+			continue;
+		}
+
+		// Row matches all criteria — remove it.
+		$removed = TRUE;
+	}
+
+	if ($removed) {
+		config_set_path($section, $filtered);
+	}
+
+	return $removed;
+}
+
+// ---------------------------------------------------------------------------
+// pfb_fwobj_sweep — remove ALL owned rows from a set of sections (deinstall)
+// ---------------------------------------------------------------------------
+
+/**
+ * Iterates each section in $sections. For each, removes every row where
+ * pfb_fwobj_is_owned($row['descr']) is TRUE.
+ *
+ * Idempotent: if no owned rows exist, nothing is written and FALSE is returned.
+ * write_config() is NEVER called here — caller flushes when done.
+ *
+ * Returns TRUE if anything was removed across any section, FALSE otherwise.
+ *
+ * @param list<string> $sections  Config path strings to sweep.
+ */
+function pfb_fwobj_sweep(array $sections): bool
+{
+	$any_removed = FALSE;
+
+	foreach ($sections as $section) {
+		$rows     = config_get_path($section, []);
+		$filtered = [];
+		$removed  = FALSE;
+
+		foreach ($rows as $row) {
+			if (pfb_fwobj_is_owned($row['descr'] ?? '')) {
+				$removed = TRUE;
+			} else {
+				$filtered[] = $row;
+			}
+		}
+
+		if ($removed) {
+			config_set_path($section, $filtered);
+			$any_removed = TRUE;
+		}
+	}
+
+	return $any_removed;
+}
+
+// ---------------------------------------------------------------------------
+// pfb_fwobj_register — register a firewall-object spec
+// ---------------------------------------------------------------------------
+
+/**
+ * Registers a firewall-object spec into the internal static registry.
+ *
+ * $spec shape:
+ *   ['type'    => 'vip'|'nat'|'filter',
+ *    'section' => string,          // config path, e.g. 'virtualip/vip'
+ *    'marker'  => string,          // descr marker (pfB_ prefix or exact legacy)
+ *    'builder' => callable,        // called by pfb_fwobj_reconcile when absent; no args
+ *    'guard'   => callable|null]   // optional find predicate (same as pfb_fwobj_find)
+ *
+ * Keyed by $spec['marker']. Replaces any prior registration for the same marker.
+ * Does NOT immediately create anything — call pfb_fwobj_reconcile() to ensure presence.
+ *
+ * @param array{type:string,section:string,marker:string,builder:callable,guard:callable|null} $spec
+ */
+function pfb_fwobj_register(array $spec): void
+{
+	$registry          = &pfb_fwobj_registry();
+	$registry[$spec['marker']] = $spec;
+}
+
+// ---------------------------------------------------------------------------
+// pfb_fwobj_reconcile — ensure a registered object exists (idempotent)
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds the registration for $marker; if the object is not yet present in config,
+ * calls $spec['builder']() to create it and writes the result via config_set_path.
+ *
+ * Idempotent: when the object already exists (pfb_fwobj_find returns a row) the
+ * builder is NOT called and config is NOT written.
+ *
+ * write_config() is NEVER called here — caller flushes.
+ *
+ * @param string $marker  The marker key as registered via pfb_fwobj_register().
+ * @throws \InvalidArgumentException  When $marker is not registered.
+ */
+function pfb_fwobj_reconcile(string $marker): void
+{
+	$registry = &pfb_fwobj_registry();
+
+	if (!isset($registry[$marker])) {
+		throw new \InvalidArgumentException(
+			"pfb_fwobj_reconcile: marker '" . $marker . "' is not registered"
+		);
+	}
+
+	$spec = $registry[$marker];
+
+	// If the object already exists, nothing to do.
+	$existing = pfb_fwobj_find($spec['section'], $marker, $spec['guard'] ?? NULL);
+	if ($existing !== FALSE) {
+		return;
+	}
+
+	// Object absent — call the builder to create the row and insert it.
+	$new_row = ($spec['builder'])();
+	$rows    = config_get_path($spec['section'], []);
+	$rows[]  = $new_row;
+	config_set_path($spec['section'], $rows);
+}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc
@@ -299,6 +299,14 @@ function pfb_fwobj_reconcile(string $marker): void
 	}
 
 	// Object absent — call the builder to create the row and insert it.
+	// A registration may carry a NULL builder (seam-only, e.g. the DNSBL NAT
+	// whose rows are built by pfb_create_dnsbl) — reconciling such a marker is a
+	// programming error, so fail loudly rather than invoking NULL.
+	if (!is_callable($spec['builder'])) {
+		throw new \LogicException(
+			"pfb_fwobj_reconcile: marker '" . $marker . "' has no callable builder"
+		);
+	}
 	$new_row = ($spec['builder'])();
 	$rows    = config_get_path($spec['section'], []);
 	$rows[]  = $new_row;

--- a/tests/php/FwobjCurrentBehaviourTest.php
+++ b/tests/php/FwobjCurrentBehaviourTest.php
@@ -1,0 +1,638 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-35 Phase 1 — oracle: pin today's VIP ownership + teardown and DNSBL-NAT
+ * add/strip behaviour BEFORE any refactor. These tests are the contract; the Phase-2/3
+ * refactor must not break them.
+ *
+ * Functions under test:
+ *   - pfb_find_marked_vip()       — pure marker-only find
+ *   - pfb_manage_dnsbl_vip()      — create idempotency; disable double-guard (marker AND IP)
+ *   - pfb_create_dnsbl()          — NAT add (descr='pfB DNSBL - DO NOT EDIT');
+ *                                   NAT strip on disable via strpos($descr,'pfB DNSBL') !== FALSE
+ *
+ * Coverage mandate (CLAUDE.md):
+ *   - Every branch exercised (both sides of every conditional).
+ *   - Every transition test asserts the BEFORE state before acting (no false passes).
+ *   - Complex flows use BDD-style Given/When/Then comments.
+ */
+#[CoversFunction('pfb_find_marked_vip')]
+#[CoversFunction('pfb_manage_dnsbl_vip')]
+#[CoversFunction('pfb_create_dnsbl')]
+final class FwobjCurrentBehaviourTest extends TestCase
+{
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Minimal $pfb keys required by pfb_manage_dnsbl_vip() and pfb_global().
+	 * folder_array is preserved from load-time so pfb_global's safe_mkdir loop works.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function basePfb(): array
+	{
+		$pfb = $GLOBALS['pfb'] ?? [];
+		// The only keys pfb_manage_dnsbl_vip reads from global $pfb directly:
+		$pfb['dnsbl_vip_auto']  = '';		// auto-create OFF by default (tests that need ON override)
+		$pfb['dnsbl_iface']     = 'lo0';	// passes PFB_FILTER_WORD; 'lo0' → no NAT (safe default)
+		$pfb['dnsblconfig']     = [];		// pfb_dnsvip4/6 absent → $want_v6 = false
+		// Additional keys pfb_global() reads from config (set via $GLOBALS['config']):
+		// These are set in $GLOBALS['config'] seeds so pfb_global re-reads them cleanly.
+		return $pfb;
+	}
+
+	/**
+	 * Minimal $pfb keys for pfb_create_dnsbl() NAT tests. Sets DNSBL enabled with
+	 * ports so the NAT block fires on mode='enabled', and a non-lo0 interface so
+	 * NAT rules are generated (not skipped for localhost listener).
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function natPfb(): array
+	{
+		$pfb = $this->basePfb();
+		$pfb['dnsbl']          = 'on';		// DNSBL enabled — required for enabled NAT block
+		$pfb['dnsbl_port']     = '8081';	// lighttpd http port
+		$pfb['dnsbl_port_ssl'] = '8443';	// lighttpd https port
+		$pfb['dnsbl_iface']    = 'opt1';	// non-lo0 → NAT rules generated
+		$pfb['dnsbl_vip4']     = '10.10.10.53';	// sinkhole IPv4 address
+		$pfb['dnsbl_vip6']     = '';		// no IPv6 VIP
+		$pfb['dnsbl_cert']     = '/tmp/pfb_fwobj_test_nonexistent_cert.pem';
+		$pfb['dnsbl_conf']     = '/tmp/pfb_fwobj_test_lighttpd.conf';
+		return $pfb;
+	}
+
+	/**
+	 * Minimal config seeded at the DNSBL settings path. Controls what pfb_global()
+	 * reads for dnsbl section, and what pfb_manage_dnsbl_vip() reads via config_get_path.
+	 *
+	 * @param string $dnsvip4  '_vip<uniqid>' id or '' when absent
+	 * @param string $dnsvip6  '_vip<uniqid>' id or '' when absent
+	 * @return array<string,string>
+	 */
+	private function dnsblCfg(string $dnsvip4 = '', string $dnsvip6 = ''): array
+	{
+		$cfg = [];
+		if ($dnsvip4 !== '') {
+			$cfg['pfb_dnsvip4'] = $dnsvip4;
+		}
+		if ($dnsvip6 !== '') {
+			$cfg['pfb_dnsvip6'] = $dnsvip6;
+		}
+		return $cfg;
+	}
+
+	/**
+	 * Seed $GLOBALS['config'] with a virtualip/vip array and optionally a
+	 * DNSBL settings config so both pfb_manage_dnsbl_vip and pfb_global see them.
+	 *
+	 * @param list<array<string,string>> $vips
+	 * @param array<string,string>       $dnsblCfg
+	 */
+	private function seedConfig(array $vips = [], array $dnsblCfg = []): void
+	{
+		$GLOBALS['config'] = [
+			'virtualip' => ['vip' => $vips],
+			'installedpackages' => [
+				'pfblockerng'               => ['config' => [0 => []]],
+				'pfblockerngipsettings'     => ['config' => [0 => []]],
+				'pfblockerngdnsblsettings'  => ['config' => [0 => $dnsblCfg]],
+				'pfblockerngglobal'         => [],
+				'pfblockerngblacklist'      => [],
+			],
+		];
+	}
+
+	/** A user-owned VIP with no pfBlockerNG marker. Must never be touched. */
+	private function userVip(): array
+	{
+		return [
+			'descr'    => 'My custom user VIP',
+			'mode'     => 'ipalias',
+			'interface' => 'lan',
+			'type'     => 'single',
+			'subnet'   => '192.168.1.200',
+			'subnet_bits' => '32',
+			'uniqid'   => 'user0001',
+		];
+	}
+
+	/** A pfBlockerNG auto-managed v4 VIP with the current marker. */
+	private function markedVip4(string $subnet = '10.10.10.53', string $uniqid = 'pfb0001'): array
+	{
+		return [
+			'descr'       => PFB_AUTO_VIP_DESCR_V4,
+			'mode'        => 'ipalias',
+			'interface'   => 'lo0',
+			'type'        => 'single',
+			'subnet'      => $subnet,
+			'subnet_bits' => '32',
+			'uniqid'      => $uniqid,
+		];
+	}
+
+	/** A pfBlockerNG auto-managed v6 VIP with the current marker. */
+	private function markedVip6(string $subnet = 'fd00::53', string $uniqid = 'pfb0002'): array
+	{
+		return [
+			'descr'       => PFB_AUTO_VIP_DESCR_V6,
+			'mode'        => 'ipalias',
+			'interface'   => 'lo0',
+			'type'        => 'single',
+			'subnet'      => $subnet,
+			'subnet_bits' => '128',
+			'uniqid'      => $uniqid,
+		];
+	}
+
+	/** A NAT rule with the current pfBlockerNG DNSBL marker. */
+	private function pfbDnsblNatRule(string $descr = 'pfB DNSBL - DO NOT EDIT'): array
+	{
+		return [
+			'source'             => ['any' => ''],
+			'destination'        => ['address' => '10.10.10.53', 'port' => '80'],
+			'protocol'           => 'tcp',
+			'target'             => '127.0.0.1',
+			'local-port'         => '8081',
+			'interface'          => 'opt1',
+			'descr'              => $descr,
+			'associated-rule-id' => 'pass',
+			'natreflection'      => 'purenat',
+		];
+	}
+
+	/** A user-owned NAT rule with no pfBlockerNG marker. Must survive disable. */
+	private function userNatRule(): array
+	{
+		return [
+			'source'      => ['any' => ''],
+			'destination' => ['address' => '192.168.1.100', 'port' => '80'],
+			'protocol'    => 'tcp',
+			'target'      => '192.168.1.200',
+			'local-port'  => '9000',
+			'interface'   => 'wan',
+			'descr'       => 'My custom rule',
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// setUp / tearDown
+	// -------------------------------------------------------------------------
+
+	protected function setUp(): void
+	{
+		// Reset per-test global state while preserving load-time $pfb path keys.
+		$GLOBALS['config']                        = [];
+		$GLOBALS['pfb_test_write_config_calls']   = [];
+		$GLOBALS['pfb_test_interface_ip']         = [];
+		$GLOBALS['pfb_test_configured_ipv6']      = [];
+		$GLOBALS['pfb_test_interfaces_with_gateway'] = [];
+		// Clear the NAT-test doubles' call log.
+		$GLOBALS['pfb_test_vip_bring_down_calls'] = [];
+		$GLOBALS['pfb_test_ipalias_configure_calls'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		// Restore pfb to a safe state (folder_array is preserved; dynamic keys are cleared).
+		unset(
+			$GLOBALS['config'],
+			$GLOBALS['pfb_test_write_config_calls'],
+			$GLOBALS['pfb_test_vip_bring_down_calls'],
+			$GLOBALS['pfb_test_ipalias_configure_calls']
+		);
+	}
+
+	// =========================================================================
+	// VIP tests (a–g): pfb_find_marked_vip + pfb_manage_dnsbl_vip
+	// =========================================================================
+
+	/**
+	 * a. pfb_find_marked_vip returns the marked v4 VIP and ignores the user VIP.
+	 *
+	 * The ownership predicate must be marker-only (no IP needed for find-by-marker).
+	 * The user VIP at index 0 must never match PFB_AUTO_VIP_DESCR_V4.
+	 */
+	public function testVipFindByMarkerV4(): void
+	{
+		// Given: one user VIP (index 0) and one auto-managed v4 VIP (index 1).
+		$vips = [$this->userVip(), $this->markedVip4()];
+
+		// When/Then: find by v4 marker returns index 1, not index 0.
+		$idx = pfb_find_marked_vip($vips, PFB_AUTO_VIP_DESCR_V4, null);
+		$this->assertSame(1, $idx, 'find by v4 marker must return the marked entry only');
+
+		// And the user VIP at index 0 must never be returned.
+		$this->assertNotSame(0, $idx, 'user VIP (no marker) must never match the v4 marker');
+	}
+
+	/**
+	 * b. pfb_find_marked_vip returns the marked v6 VIP and ignores the user VIP.
+	 */
+	public function testVipFindByMarkerV6(): void
+	{
+		// Given: one user VIP (index 0) and one auto-managed v6 VIP (index 1).
+		$vips = [$this->userVip(), $this->markedVip6()];
+
+		// When/Then: find by v6 marker returns index 1.
+		$idx = pfb_find_marked_vip($vips, PFB_AUTO_VIP_DESCR_V6, null);
+		$this->assertSame(1, $idx, 'find by v6 marker must return the marked entry only');
+		$this->assertNotSame(0, $idx, 'user VIP must never match the v6 marker');
+	}
+
+	/**
+	 * c. pfb_find_marked_vip returns null when no marked VIP is present.
+	 *
+	 * Before any auto-VIP is created, or with only user VIPs, both families return null.
+	 */
+	public function testVipFindReturnsNullWhenAbsent(): void
+	{
+		// Given: only a user VIP (no pfBlockerNG marker).
+		$vips = [$this->userVip()];
+
+		// When/Then: neither v4 nor v6 marker matches anything.
+		$this->assertNull(pfb_find_marked_vip($vips, PFB_AUTO_VIP_DESCR_V4, null));
+		$this->assertNull(pfb_find_marked_vip($vips, PFB_AUTO_VIP_DESCR_V6, null));
+
+		// Also: an empty array returns null.
+		$this->assertNull(pfb_find_marked_vip([], PFB_AUTO_VIP_DESCR_V4, null));
+	}
+
+	/**
+	 * d. pfb_manage_dnsbl_vip('enabled') is idempotent when the marked VIP already exists.
+	 *
+	 * Scenario: VIP auto-create is ON and a marked v4 VIP already exists.
+	 *
+	 *   Background:
+	 *     Given a marked v4 VIP exists in virtualip/vip
+	 *       and dnsbl_vip_auto = 'on'
+	 *
+	 *   When  manage('enabled') is called twice
+	 *   Then  exactly one VIP entry remains in config after each call (no duplicate)
+	 *
+	 * The before-state (one VIP) is asserted before the second call to prove
+	 * the second call did not duplicate it.
+	 */
+	public function testVipCreateIsIdempotent(): void
+	{
+		// Given: one marked v4 VIP with a stored VIP id in DNSBL config.
+		$uniqid = 'pfb_idem01';
+		$vipId  = "_vip{$uniqid}";
+		$this->seedConfig(
+			[$this->markedVip4('10.10.10.53', $uniqid)],
+			$this->dnsblCfg($vipId)
+		);
+		$GLOBALS['pfb']                  = $this->basePfb();
+		$GLOBALS['pfb']['dnsbl_vip_auto'] = 'on';
+		$GLOBALS['pfb']['dnsbl_iface']    = 'lo0';
+		$GLOBALS['pfb']['dnsblconfig']    = $this->dnsblCfg($vipId);
+
+		// Assert before-state: exactly one VIP.
+		$before = config_get_path('virtualip/vip', []);
+		$this->assertCount(1, $before, 'before: exactly one VIP must exist');
+
+		// When: first enabled call (VIP already exists → reuse, no duplicate).
+		pfb_manage_dnsbl_vip('enabled');
+
+		// Then: still exactly one VIP.
+		$after1 = config_get_path('virtualip/vip', []);
+		$this->assertCount(1, $after1, 'after first call: still exactly one VIP (no duplicate)');
+
+		// When: second enabled call (idempotency check).
+		pfb_manage_dnsbl_vip('enabled');
+
+		// Then: still exactly one VIP.
+		$after2 = config_get_path('virtualip/vip', []);
+		$this->assertCount(1, $after2, 'after second call: still exactly one VIP (idempotent)');
+
+		// Marker preserved on the surviving VIP.
+		$survivor = array_values($after2)[0];
+		$this->assertSame(PFB_AUTO_VIP_DESCR_V4, $survivor['descr'], 'surviving VIP must still carry the v4 marker');
+	}
+
+	/**
+	 * e. pfb_manage_dnsbl_vip('disabled') removes the marked VIP when IP matches stored config.
+	 *
+	 * Scenario: double-guard (marker AND IP) both satisfied → VIP is removed.
+	 *
+	 *   Background:
+	 *     Given a marked v4 VIP with subnet='10.10.10.53'
+	 *       and pfb_dnsvip4 pointing to a VIP id that resolves to '10.10.10.53'
+	 *
+	 *   When  manage('disabled') is called
+	 *   Then  the marked VIP is gone from virtualip/vip
+	 */
+	public function testVipDisableRemovesMarkedVipWithMatchingIp(): void
+	{
+		// Given: a marked v4 VIP and a stored VIP id whose subnet matches.
+		$uniqid = 'pfb_del01';
+		$vipId  = "_vip{$uniqid}";
+		$ip     = '10.10.10.53';
+		$this->seedConfig(
+			[$this->markedVip4($ip, $uniqid)],
+			$this->dnsblCfg($vipId)
+		);
+		$GLOBALS['pfb']                   = $this->basePfb();
+		$GLOBALS['pfb']['dnsbl_vip_auto'] = '';	// auto OFF → triggers delete branch
+		$GLOBALS['pfb']['dnsbl_iface']    = 'lo0';
+		$GLOBALS['pfb']['dnsblconfig']    = $this->dnsblCfg($vipId);
+
+		// Assert before-state: the marked VIP is present.
+		$before = config_get_path('virtualip/vip', []);
+		$this->assertCount(1, $before, 'before: marked VIP must be present');
+		$this->assertSame(PFB_AUTO_VIP_DESCR_V4, $before[0]['descr'], 'before: VIP must carry the marker');
+
+		// When: disable with a matching IP (get_configured_vip_ipv4 returns '10.10.10.53').
+		pfb_manage_dnsbl_vip('disabled');
+
+		// Then: the marked VIP is removed.
+		$after = config_get_path('virtualip/vip', []);
+		$this->assertCount(0, $after, 'after disable with matching IP: marked VIP must be removed');
+	}
+
+	/**
+	 * f. The double-guard prevents removal when the stored IP does NOT match the VIP's subnet.
+	 *
+	 * Scenario: marker matches but IP guard fails → VIP survives disable.
+	 *
+	 *   Background:
+	 *     Given a marked v4 VIP with subnet='10.10.10.53'
+	 *       and pfb_dnsvip4 pointing to a VIP id that resolves to a DIFFERENT IP '10.10.1.53'
+	 *
+	 *   When  manage('disabled') is called
+	 *   Then  the marked VIP is still present (double-guard prevented deletion)
+	 */
+	public function testVipDisableDoesNotRemoveVipWithNonMatchingIp(): void
+	{
+		// Given: a marked VIP at '10.10.10.53' but the stored VIP id resolves to '10.10.1.53'.
+		$uniqidVip    = 'pfb_stay01';	// the VIP in virtualip/vip
+		$uniqidStored = 'pfb_other01';	// the VIP id stored in pfb_dnsvip4 (different addr)
+		$vipIdStored  = "_vip{$uniqidStored}";
+
+		// Seed virtualip/vip: only the marked VIP at '10.10.10.53'.
+		// Seed a SECOND VIP row for get_configured_vip_ipv4 to resolve to '10.10.1.53'.
+		$otherVip = [
+			'descr'       => 'other',
+			'mode'        => 'ipalias',
+			'interface'   => 'lo0',
+			'type'        => 'single',
+			'subnet'      => '10.10.1.53',
+			'subnet_bits' => '32',
+			'uniqid'      => $uniqidStored,
+		];
+		$this->seedConfig(
+			[$this->markedVip4('10.10.10.53', $uniqidVip), $otherVip],
+			$this->dnsblCfg($vipIdStored)
+		);
+		$GLOBALS['pfb']                   = $this->basePfb();
+		$GLOBALS['pfb']['dnsbl_vip_auto'] = '';
+		$GLOBALS['pfb']['dnsbl_iface']    = 'lo0';
+		$GLOBALS['pfb']['dnsblconfig']    = $this->dnsblCfg($vipIdStored);
+
+		// Assert before-state: the marked VIP is present.
+		$before = config_get_path('virtualip/vip', []);
+		$markedBefore = array_filter($before, fn($v) => ($v['descr'] ?? '') === PFB_AUTO_VIP_DESCR_V4);
+		$this->assertCount(1, $markedBefore, 'before: the marked VIP must be present');
+
+		// When: disable with a NON-MATCHING stored IP.
+		pfb_manage_dnsbl_vip('disabled');
+
+		// Then: the marked VIP must NOT have been removed (double-guard protected it).
+		$after = config_get_path('virtualip/vip', []);
+		$markedAfter = array_filter($after, fn($v) => ($v['descr'] ?? '') === PFB_AUTO_VIP_DESCR_V4);
+		$this->assertCount(1, $markedAfter, 'after: marked VIP must survive when stored IP does not match');
+	}
+
+	/**
+	 * g. pfb_manage_dnsbl_vip('disabled') never touches a user VIP even when a marked VIP is removed.
+	 *
+	 * Scenario: user VIP survival — the removal is scoped to marked VIPs only.
+	 *
+	 *   Background:
+	 *     Given a marked v4 VIP (matching IP) and a sibling user VIP (no marker)
+	 *
+	 *   When  manage('disabled') is called
+	 *   Then  the marked VIP is removed AND the user VIP survives
+	 */
+	public function testVipDisableNeverTouchesUserVip(): void
+	{
+		// Given: [0] = user VIP, [1] = marked v4 VIP with matching IP.
+		$uniqid = 'pfb_surv01';
+		$vipId  = "_vip{$uniqid}";
+		$ip     = '10.10.10.53';
+		$this->seedConfig(
+			[$this->userVip(), $this->markedVip4($ip, $uniqid)],
+			$this->dnsblCfg($vipId)
+		);
+		$GLOBALS['pfb']                   = $this->basePfb();
+		$GLOBALS['pfb']['dnsbl_vip_auto'] = '';
+		$GLOBALS['pfb']['dnsbl_iface']    = 'lo0';
+		$GLOBALS['pfb']['dnsblconfig']    = $this->dnsblCfg($vipId);
+
+		// Assert before-state: both VIPs are present.
+		$before = config_get_path('virtualip/vip', []);
+		$this->assertCount(2, $before, 'before: user VIP and marked VIP must both be present');
+		$userBefore   = array_filter($before, fn($v) => ($v['descr'] ?? '') === 'My custom user VIP');
+		$markedBefore = array_filter($before, fn($v) => ($v['descr'] ?? '') === PFB_AUTO_VIP_DESCR_V4);
+		$this->assertCount(1, $userBefore,   'before: user VIP must be present');
+		$this->assertCount(1, $markedBefore, 'before: marked VIP must be present');
+
+		// When: disable.
+		pfb_manage_dnsbl_vip('disabled');
+
+		// Then: marked VIP is removed, user VIP survives.
+		$after = config_get_path('virtualip/vip', []);
+		$userAfter   = array_filter($after, fn($v) => ($v['descr'] ?? '') === 'My custom user VIP');
+		$markedAfter = array_filter($after, fn($v) => ($v['descr'] ?? '') === PFB_AUTO_VIP_DESCR_V4);
+		$this->assertCount(1, $userAfter,   'after: user VIP must survive disable');
+		$this->assertCount(0, $markedAfter, 'after: marked VIP must be removed');
+		// Confirm the surviving user VIP is byte-identical to the original.
+		$this->assertSame($this->userVip(), array_values($userAfter)[0], 'user VIP must be unchanged');
+	}
+
+	// =========================================================================
+	// NAT tests (h–k): pfb_create_dnsbl() NAT section
+	// =========================================================================
+
+	/**
+	 * h. pfb_create_dnsbl('enabled') writes 'pfB DNSBL - DO NOT EDIT' as the NAT rule descr.
+	 *
+	 * Scenario: on enable, DNSBL NAT rules are added with the exact ownership descr.
+	 *
+	 *   Background:
+	 *     Given no existing NAT rules
+	 *       and DNSBL is enabled with port 8081 on interface 'opt-double' with VIP 10.10.10.53
+	 *       and a valid VIP id '_vip_test_nat4' is configured (passes pfb_validate_vips)
+	 *
+	 *   When  pfb_create_dnsbl('enabled') is called
+	 *   Then  nat/rule contains a rule with descr='pfB DNSBL - DO NOT EDIT'
+	 *
+	 * Setup note: pfb_create_dnsbl() calls pfb_global() which re-reads $pfb from config.
+	 * To keep DNSBL enabled after pfb_global() we must pass pfb_validate_vips():
+	 *   - pfb_dnsvip4 = '_vip_test_nat4' (uses the get_configured_vip_interface double
+	 *     which returns 'opt-double' for '_vip_test_*' prefixed ids)
+	 *   - dnsbl_interface = 'opt-double' (matches what the double returns)
+	 *   - pfb_test_vip_list seeds get_configured_vip_list so pfb_get_vips finds the VIP
+	 */
+	public function testNatAddWritesPfbDnslDescr(): void
+	{
+		// Given: a valid VIP configuration so pfb_validate_vips passes and $pfb['dnsbl']
+		// remains 'on' after pfb_global() runs inside pfb_create_dnsbl().
+		$vipId  = '_vip_test_nat4';
+		$vipIp  = '10.10.10.53';
+		$this->seedConfig(
+			[],	// virtualip/vip: no VIP entries needed; pfb_get_vips uses get_configured_vip_list
+			[
+				'pfb_dnsbl'         => 'on',
+				'pfb_dnsport'       => '8081',
+				'pfb_dnsport_ssl'   => '8443',
+				'pfb_dnsvip4'       => $vipId,
+				'dnsbl_interface'   => 'opt-double',	// matched by get_configured_vip_interface double
+			]
+		);
+		// Empty NAT rules.
+		$GLOBALS['config']['nat'] = ['rule' => []];
+		// Seed get_configured_vip_list so pfb_get_vips includes the test VIP id.
+		$GLOBALS['pfb_test_vip_list'] = [$vipId => $vipIp];
+		// Seed $pfb['dnsbl_cert'] / dnsbl_conf path (pfb_global reads cert path from config;
+		// these live in pfb_global's path assignments which use $g paths. Set them directly
+		// in $pfb so the file_exists / file_put_contents calls target safe temp paths).
+		$GLOBALS['pfb']['dnsbl_cert'] = '/tmp/pfb_fwobj_nat_test_cert.pem';
+		$GLOBALS['pfb']['dnsbl_conf'] = '/tmp/pfb_fwobj_nat_test_lighttpd.conf';
+
+		// Assert before-state: no NAT rules exist.
+		$before = config_get_path('nat/rule', []);
+		$this->assertCount(0, $before, 'before: nat/rule must be empty');
+
+		// When: enable. pfb_create_dnsbl calls pfb_global() first, then the NAT block.
+		pfb_create_dnsbl('enabled');
+
+		// Then: at least one NAT rule with the exact ownership descr exists.
+		$after = config_get_path('nat/rule', []);
+		$this->assertNotCount(0, $after, 'after enable: nat/rule must not be empty');
+		$pfbRules = array_filter($after, fn($r) => ($r['descr'] ?? '') === 'pfB DNSBL - DO NOT EDIT');
+		$this->assertNotEmpty($pfbRules, 'at least one NAT rule must carry descr="pfB DNSBL - DO NOT EDIT"');
+		// Verify the descr is byte-identical (no truncation, no variant).
+		$rule = array_values($pfbRules)[0];
+		$this->assertSame('pfB DNSBL - DO NOT EDIT', $rule['descr'], 'NAT rule descr must be exactly "pfB DNSBL - DO NOT EDIT"');
+	}
+
+	/**
+	 * i. pfb_create_dnsbl('disabled') removes a NAT rule carrying 'pfB DNSBL - DO NOT EDIT'.
+	 *
+	 * Scenario: on disable, the current-format pfBlockerNG NAT rule is stripped.
+	 *
+	 *   Background:
+	 *     Given a NAT rule with descr='pfB DNSBL - DO NOT EDIT' in nat/rule
+	 *
+	 *   When  pfb_create_dnsbl('disabled') is called
+	 *   Then  that rule is gone from nat/rule
+	 */
+	public function testNatStripsOnDisable(): void
+	{
+		// Given: one pfBlockerNG NAT rule in config.
+		$this->seedConfig();	// no VIPs needed for disabled path
+		$GLOBALS['config']['nat'] = ['rule' => [$this->pfbDnsblNatRule()]];
+		$GLOBALS['pfb']           = $this->basePfb();
+		// dnsbl_vip_auto OFF + no VIP ids → pfb_manage_dnsbl_vip is a no-op on disable.
+		$GLOBALS['pfb']['dnsbl_vip_auto'] = '';
+		$GLOBALS['pfb']['dnsblconfig']    = [];
+
+		// Assert before-state: the pfB DNSBL rule is present.
+		$before = config_get_path('nat/rule', []);
+		$this->assertCount(1, $before, 'before: one pfB DNSBL NAT rule must be present');
+		$this->assertSame('pfB DNSBL - DO NOT EDIT', $before[0]['descr'], 'before: rule must carry the exact descr');
+
+		// When: disable.
+		pfb_create_dnsbl('disabled');
+
+		// Then: the pfB DNSBL rule is removed.
+		$after = config_get_path('nat/rule', []);
+		$pfbRules = array_filter($after, fn($r) => strpos($r['descr'] ?? '', 'pfB DNSBL') !== FALSE);
+		$this->assertCount(0, $pfbRules, 'after disable: pfB DNSBL NAT rule must be removed');
+	}
+
+	/**
+	 * j. pfb_create_dnsbl('disabled') strips legacy 'pfB DNSBL' descr (bare, no suffix).
+	 *
+	 * The detection is strpos($descr, 'pfB DNSBL') !== FALSE, which matches the legacy
+	 * form 'pfB DNSBL' (no ' - DO NOT EDIT' suffix) — important for upgrade safety.
+	 *
+	 *   Background:
+	 *     Given a NAT rule with descr='pfB DNSBL' (legacy form, no ' - DO NOT EDIT')
+	 *
+	 *   When  pfb_create_dnsbl('disabled') is called
+	 *   Then  that rule is removed (strpos detects the legacy prefix)
+	 */
+	public function testNatStripsLegacyPfbDnsblPrefix(): void
+	{
+		// Given: a NAT rule with only the bare legacy prefix.
+		$legacyRule = $this->pfbDnsblNatRule('pfB DNSBL');
+		$this->seedConfig();
+		$GLOBALS['config']['nat'] = ['rule' => [$legacyRule]];
+		$GLOBALS['pfb']           = $this->basePfb();
+		$GLOBALS['pfb']['dnsbl_vip_auto'] = '';
+		$GLOBALS['pfb']['dnsblconfig']    = [];
+
+		// Assert before-state: the legacy rule is present.
+		$before = config_get_path('nat/rule', []);
+		$this->assertCount(1, $before, 'before: one legacy pfB DNSBL NAT rule must be present');
+		$this->assertSame('pfB DNSBL', $before[0]['descr'], 'before: rule must carry the legacy descr');
+
+		// When: disable.
+		pfb_create_dnsbl('disabled');
+
+		// Then: the legacy rule is removed (strpos matched 'pfB DNSBL' prefix).
+		$after = config_get_path('nat/rule', []);
+		$pfbRules = array_filter($after, fn($r) => strpos($r['descr'] ?? '', 'pfB DNSBL') !== FALSE);
+		$this->assertCount(0, $pfbRules, 'after disable: legacy pfB DNSBL rule must be removed');
+	}
+
+	/**
+	 * k. pfb_create_dnsbl('disabled') never removes a user NAT rule.
+	 *
+	 * Scenario: user rule survival — stripping is scoped to pfB DNSBL descr only.
+	 *
+	 *   Background:
+	 *     Given one pfB DNSBL NAT rule and one user-owned NAT rule (no pfB DNSBL descr)
+	 *
+	 *   When  pfb_create_dnsbl('disabled') is called
+	 *   Then  the pfB DNSBL rule is removed AND the user rule survives unchanged
+	 */
+	public function testNatNeverTouchesUserRule(): void
+	{
+		// Given: [0] = pfB DNSBL rule, [1] = user rule.
+		$this->seedConfig();
+		$GLOBALS['config']['nat'] = ['rule' => [$this->pfbDnsblNatRule(), $this->userNatRule()]];
+		$GLOBALS['pfb']           = $this->basePfb();
+		$GLOBALS['pfb']['dnsbl_vip_auto'] = '';
+		$GLOBALS['pfb']['dnsblconfig']    = [];
+
+		// Assert before-state: both rules are present.
+		$before = config_get_path('nat/rule', []);
+		$this->assertCount(2, $before, 'before: both pfB DNSBL and user NAT rules must be present');
+		$pfbBefore  = array_filter($before, fn($r) => strpos($r['descr'] ?? '', 'pfB DNSBL') !== FALSE);
+		$userBefore = array_filter($before, fn($r) => ($r['descr'] ?? '') === 'My custom rule');
+		$this->assertCount(1, $pfbBefore,  'before: pfB DNSBL rule must be present');
+		$this->assertCount(1, $userBefore, 'before: user rule must be present');
+
+		// When: disable.
+		pfb_create_dnsbl('disabled');
+
+		// Then: pfB DNSBL rule removed, user rule survives.
+		$after = config_get_path('nat/rule', []);
+		$pfbAfter  = array_filter($after, fn($r) => strpos($r['descr'] ?? '', 'pfB DNSBL') !== FALSE);
+		$userAfter = array_filter($after, fn($r) => ($r['descr'] ?? '') === 'My custom rule');
+		$this->assertCount(0, $pfbAfter,  'after disable: pfB DNSBL NAT rule must be removed');
+		$this->assertCount(1, $userAfter, 'after disable: user NAT rule must survive');
+		// User rule must be byte-identical to what was put in.
+		$this->assertSame($this->userNatRule(), array_values($userAfter)[0], 'user NAT rule must be unchanged');
+	}
+}

--- a/tests/php/FwobjLayerTest.php
+++ b/tests/php/FwobjLayerTest.php
@@ -585,4 +585,36 @@ final class FwobjLayerTest extends TestCase
 		$this->assertSame('pfB_Deny_v4', $after[0]['descr'],
 			'After: existing rule descr must be unchanged');
 	}
+
+	/**
+	 * v. pfb_fwobj_reconcile fails loud on a seam-only (NULL-builder) marker.
+	 *
+	 * A registration may carry builder => NULL when its rows are built elsewhere
+	 * (e.g. the DNSBL NAT, built by pfb_create_dnsbl) — reconciling such a marker
+	 * is a programming error and must throw, never invoke NULL and fatal.
+	 *
+	 * Given:  a marker registered with builder = NULL; its section is empty.
+	 * When:   pfb_fwobj_reconcile is called for that marker (object absent).
+	 * Then:   a LogicException is thrown (the NULL builder is never invoked).
+	 */
+	public function testReconcileThrowsWhenBuilderNotCallable(): void
+	{
+		// Given: empty nat/rule section + a seam-only registration (NULL builder).
+		$this->seedConfig(['nat' => ['rule' => []]]);
+
+		pfb_fwobj_register([
+			'type'    => 'nat',
+			'section' => 'nat/rule',
+			'marker'  => PFB_FWOBJ_NAT_LEGACY_PFX,
+			'builder' => NULL,
+			'guard'   => NULL,
+		]);
+
+		// Assert before: object absent, so reconcile reaches the builder branch.
+		$this->assertCount(0, $this->getSection('nat/rule'), 'Before: no NAT rules present');
+
+		// When/Then: reconciling a NULL-builder marker must throw, not fatal on NULL().
+		$this->expectException(\LogicException::class);
+		pfb_fwobj_reconcile(PFB_FWOBJ_NAT_LEGACY_PFX);
+	}
 }

--- a/tests/php/FwobjLayerTest.php
+++ b/tests/php/FwobjLayerTest.php
@@ -1,0 +1,588 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-35 Phase 2 — unit tests for the new pfblockerng_fwobj.inc ownership/marker layer.
+ *
+ * Functions under test:
+ *   - pfb_fwobj_is_owned()     — ownership predicate (truth table)
+ *   - pfb_fwobj_find()         — locate first owned row matching a marker
+ *   - pfb_fwobj_remove()       — strip owned rows matching a marker
+ *   - pfb_fwobj_sweep()        — remove all owned rows from a set of sections
+ *   - pfb_fwobj_register()     — register a firewall-object spec
+ *   - pfb_fwobj_reconcile()    — ensure a registered object exists (idempotent)
+ *
+ * Coverage mandate (CLAUDE.md):
+ *   - Every branch exercised (both sides of every conditional).
+ *   - Transition tests assert BEFORE state before mutating (no false passes).
+ *   - Complex flows use BDD-style Given/When/Then comments.
+ */
+#[CoversFunction('pfb_fwobj_is_owned')]
+#[CoversFunction('pfb_fwobj_find')]
+#[CoversFunction('pfb_fwobj_remove')]
+#[CoversFunction('pfb_fwobj_sweep')]
+#[CoversFunction('pfb_fwobj_register')]
+#[CoversFunction('pfb_fwobj_reconcile')]
+final class FwobjLayerTest extends TestCase
+{
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Seed $GLOBALS['config'] so config_get_path() and config_set_path() work
+	 * in each test. Accepts multiple sections by key.
+	 *
+	 * @param array<string,array<int,array<string,mixed>>> $sections  e.g. ['virtualip' => ['vip' => [...]]]
+	 */
+	private function seedConfig(array $sections = []): void
+	{
+		$GLOBALS['config'] = $sections;
+	}
+
+	/**
+	 * Read a section from $GLOBALS['config'] using a slash-delimited path.
+	 *
+	 * @param string $path  e.g. 'virtualip/vip'
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function getSection(string $path): array
+	{
+		$parts  = explode('/', $path);
+		$cursor = $GLOBALS['config'] ?? [];
+		foreach ($parts as $key) {
+			$cursor = $cursor[$key] ?? [];
+		}
+		return (array) $cursor;
+	}
+
+	/** A user-owned VIP — must never be touched by any fwobj function. */
+	private function userVip(string $subnet = '192.168.1.200'): array
+	{
+		return [
+			'descr'       => 'My custom user VIP',
+			'mode'        => 'ipalias',
+			'interface'   => 'lan',
+			'subnet'      => $subnet,
+			'subnet_bits' => '32',
+		];
+	}
+
+	/** A pfBlockerNG auto-managed v4 VIP (uses PFB_AUTO_VIP_DESCR_V4). */
+	private function pfbVip4(string $subnet = '10.10.10.53'): array
+	{
+		return [
+			'descr'       => PFB_AUTO_VIP_DESCR_V4,	// 'pfB_AUTO_VIP_v4'
+			'mode'        => 'ipalias',
+			'interface'   => 'lo0',
+			'subnet'      => $subnet,
+			'subnet_bits' => '32',
+		];
+	}
+
+	/** A pfBlockerNG-owned NAT rule with the canonical full marker. */
+	private function pfbNatRule(string $descr = PFB_FWOBJ_NAT_DESCR): array
+	{
+		return [
+			'descr'      => $descr,
+			'protocol'   => 'tcp',
+			'interface'  => 'opt1',
+			'target'     => '127.0.0.1',
+			'local-port' => '8081',
+		];
+	}
+
+	/** A user-owned NAT rule with no pfBlockerNG marker. */
+	private function userNatRule(): array
+	{
+		return [
+			'descr'      => 'My user NAT rule',
+			'protocol'   => 'tcp',
+			'interface'  => 'wan',
+			'target'     => '10.0.0.1',
+			'local-port' => '80',
+		];
+	}
+
+	/** A pfBlockerNG-owned filter rule using the pfB_ prefix. */
+	private function pfbFilterRule(string $descr = 'pfB_Deny_v4'): array
+	{
+		return [
+			'descr'     => $descr,
+			'type'      => 'block',
+			'interface' => 'wan',
+		];
+	}
+
+	/** A user-owned filter rule with no pfBlockerNG prefix. */
+	private function userFilterRule(): array
+	{
+		return [
+			'descr'     => 'Allow LAN to WAN',
+			'type'      => 'pass',
+			'interface' => 'lan',
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// Teardown: reset registry between tests
+	// -------------------------------------------------------------------------
+
+	protected function setUp(): void
+	{
+		// Clear the static registry via an empty register cycle is not possible
+		// without a reset helper, so we seed it clean by populating then wiping:
+		// pfb_fwobj_registry() returns a reference — clear it directly.
+		$registry = &pfb_fwobj_registry();
+		$registry = [];
+	}
+
+	// -------------------------------------------------------------------------
+	// is_owned truth table (cases a–i)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * a. A description starting with 'pfB_' is owned (new prefix rule).
+	 */
+	public function testIsOwnedNewPfbPrefix(): void
+	{
+		$this->assertTrue(pfb_fwobj_is_owned('pfB_MyRule'));
+	}
+
+	/**
+	 * b. PFB_AUTO_VIP_DESCR_V4 ('pfB_AUTO_VIP_v4') is owned — starts with 'pfB_'.
+	 */
+	public function testIsOwnedVipV4Marker(): void
+	{
+		$this->assertTrue(pfb_fwobj_is_owned(PFB_AUTO_VIP_DESCR_V4));
+	}
+
+	/**
+	 * c. PFB_AUTO_VIP_DESCR_V6 ('pfB_AUTO_VIP_v6') is owned — starts with 'pfB_'.
+	 */
+	public function testIsOwnedVipV6Marker(): void
+	{
+		$this->assertTrue(pfb_fwobj_is_owned(PFB_AUTO_VIP_DESCR_V6));
+	}
+
+	/**
+	 * d. The canonical NAT marker 'pfB DNSBL - DO NOT EDIT' is owned (contains 'pfB DNSBL').
+	 */
+	public function testIsOwnedNatFullDescr(): void
+	{
+		$this->assertTrue(pfb_fwobj_is_owned(PFB_FWOBJ_NAT_DESCR));
+	}
+
+	/**
+	 * e. The bare legacy prefix 'pfB DNSBL' is owned.
+	 */
+	public function testIsOwnedNatLegacyPrefix(): void
+	{
+		$this->assertTrue(pfb_fwobj_is_owned(PFB_FWOBJ_NAT_LEGACY_PFX));
+	}
+
+	/**
+	 * f. A legacy NAT variant 'pfB DNSBL Redirect' is owned (contains 'pfB DNSBL').
+	 */
+	public function testIsOwnedNatLegacyVariant(): void
+	{
+		$this->assertTrue(pfb_fwobj_is_owned('pfB DNSBL Redirect'));
+	}
+
+	/**
+	 * g. A plain user description returns FALSE.
+	 */
+	public function testIsOwnedReturnsFalseForUserDescr(): void
+	{
+		$this->assertFalse(pfb_fwobj_is_owned('My custom rule'));
+	}
+
+	/**
+	 * h. An empty description returns FALSE.
+	 */
+	public function testIsOwnedReturnsFalseForEmpty(): void
+	{
+		$this->assertFalse(pfb_fwobj_is_owned(''));
+	}
+
+	/**
+	 * i. A partial match 'pfB' (no trailing _ and no space DNSBL) returns FALSE.
+	 *    Guards that neither 'pfB_' nor 'pfB DNSBL' matches bare 'pfB'.
+	 */
+	public function testIsOwnedReturnsFalseForPartialMatch(): void
+	{
+		$this->assertFalse(pfb_fwobj_is_owned('pfB'));
+	}
+
+	// -------------------------------------------------------------------------
+	// find/remove with and without guard (cases j–p)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * j. pfb_fwobj_find returns the marked row when it is present.
+	 *
+	 * Scenario: two-row VIP section — one pfBlockerNG row, one user row.
+	 * Given: two rows are present.
+	 * When:  pfb_fwobj_find is called with the pfB_ marker.
+	 * Then:  the pfBlockerNG row is returned; the user row is NOT returned.
+	 */
+	public function testFindReturnsMatchedRow(): void
+	{
+		// Given: two rows present.
+		$vip4 = $this->pfbVip4();
+		$user = $this->userVip();
+		$this->seedConfig(['virtualip' => ['vip' => [$vip4, $user]]]);
+
+		// Sanity: both rows are present before the find.
+		$rows = $this->getSection('virtualip/vip');
+		$this->assertCount(2, $rows, 'Before: both rows must be present');
+
+		// When: find by the pfB_AUTO_VIP_v4 marker.
+		$result = pfb_fwobj_find('virtualip/vip', PFB_AUTO_VIP_DESCR_V4);
+
+		// Then: the pfBlockerNG row is returned.
+		$this->assertIsArray($result);
+		$this->assertSame(PFB_AUTO_VIP_DESCR_V4, $result['descr']);
+		$this->assertSame('10.10.10.53', $result['subnet']);
+	}
+
+	/**
+	 * k. pfb_fwobj_find returns FALSE when no owned row matches the marker.
+	 *
+	 * Scenario: section contains only a user row — no pfBlockerNG rows.
+	 * Given:  one user row.
+	 * When:   pfb_fwobj_find with a pfB_ marker.
+	 * Then:   returns FALSE.
+	 */
+	public function testFindReturnsFalseWhenAbsent(): void
+	{
+		// Given: only a user row.
+		$this->seedConfig(['virtualip' => ['vip' => [$this->userVip()]]]);
+
+		// When/Then: no owned row → FALSE.
+		$result = pfb_fwobj_find('virtualip/vip', PFB_AUTO_VIP_DESCR_V4);
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * l. pfb_fwobj_find with a guard skips rows the guard rejects.
+	 *
+	 * Scenario: two rows with the same pfB_ marker but different subnets;
+	 *           guard accepts only the row with subnet '10.10.10.53'.
+	 * Given:  two pfBlockerNG rows (10.10.10.53 and 10.10.10.54).
+	 * When:   pfb_fwobj_find with a guard accepting only '10.10.10.53'.
+	 * Then:   only the '10.10.10.53' row is returned.
+	 */
+	public function testFindWithGuardSkipsNonMatchingGuard(): void
+	{
+		// Given: two pfBlockerNG rows.
+		$vip_a = $this->pfbVip4('10.10.10.53');
+		$vip_b = $this->pfbVip4('10.10.10.54');
+		$this->seedConfig(['virtualip' => ['vip' => [$vip_a, $vip_b]]]);
+
+		// Sanity: two rows present.
+		$this->assertCount(2, $this->getSection('virtualip/vip'));
+
+		// When: find with guard that accepts only '10.10.10.53'.
+		$result = pfb_fwobj_find(
+			'virtualip/vip',
+			PFB_AUTO_VIP_DESCR_V4,
+			static fn(array $row): bool => ($row['subnet'] ?? '') === '10.10.10.53'
+		);
+
+		// Then: returns the '10.10.10.53' row, not '10.10.10.54'.
+		$this->assertIsArray($result);
+		$this->assertSame('10.10.10.53', $result['subnet']);
+	}
+
+	/**
+	 * m. pfb_fwobj_remove deletes the owned row and leaves the user row intact.
+	 *
+	 * Scenario: one owned NAT rule + one user NAT rule.
+	 * Given:  both rows present.
+	 * When:   remove with the canonical NAT marker.
+	 * Then:   owned row gone; user row survives; returns TRUE.
+	 */
+	public function testRemoveDeletesOwnedRow(): void
+	{
+		// Given: both rows present.
+		$pfb  = $this->pfbNatRule();
+		$user = $this->userNatRule();
+		$this->seedConfig(['nat' => ['rule' => [$pfb, $user]]]);
+
+		// Assert before: two rows.
+		$before = $this->getSection('nat/rule');
+		$this->assertCount(2, $before, 'Before: two NAT rules must be present');
+
+		// When: remove the pfBlockerNG NAT rule.
+		$result = pfb_fwobj_remove('nat/rule', PFB_FWOBJ_NAT_DESCR);
+
+		// Then: returns TRUE, only the user row remains.
+		$this->assertTrue($result);
+		$after = $this->getSection('nat/rule');
+		$this->assertCount(1, $after, 'After: only the user rule must remain');
+		$this->assertSame('My user NAT rule', $after[0]['descr']);
+	}
+
+	/**
+	 * n. pfb_fwobj_remove returns FALSE and does not write when no row matches.
+	 *
+	 * Scenario: section has only a user row.
+	 * Given:  one user row.
+	 * When:   remove with a pfBlockerNG marker.
+	 * Then:   returns FALSE; section unchanged.
+	 */
+	public function testRemoveReturnsFalseWhenNothingMatches(): void
+	{
+		// Given: only a user row.
+		$this->seedConfig(['nat' => ['rule' => [$this->userNatRule()]]]);
+
+		// Assert before: one user row.
+		$before = $this->getSection('nat/rule');
+		$this->assertCount(1, $before, 'Before: one user rule must be present');
+
+		// When: remove with a pfBlockerNG marker that is not present.
+		$result = pfb_fwobj_remove('nat/rule', PFB_FWOBJ_NAT_DESCR);
+
+		// Then: FALSE; the user row is untouched.
+		$this->assertFalse($result);
+		$after = $this->getSection('nat/rule');
+		$this->assertCount(1, $after, 'After: user rule must still be present');
+		$this->assertSame('My user NAT rule', $after[0]['descr']);
+	}
+
+	/**
+	 * o. pfb_fwobj_remove NEVER removes a user-owned row.
+	 *
+	 * Scenario: only a user row in the section — no pfBlockerNG marker present.
+	 * Passing the pfB_ marker must not touch the user row.
+	 */
+	public function testRemoveNeverTouchesUserRow(): void
+	{
+		// Given: only user row.
+		$this->seedConfig(['virtualip' => ['vip' => [$this->userVip()]]]);
+
+		$before = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $before, 'Before: one user VIP must be present');
+
+		// When/Then: remove with a pfB_ marker → FALSE; user row untouched.
+		$result = pfb_fwobj_remove('virtualip/vip', PFB_AUTO_VIP_DESCR_V4);
+		$this->assertFalse($result);
+
+		$after = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $after, 'After: user VIP must still be present');
+		$this->assertSame('My custom user VIP', $after[0]['descr']);
+	}
+
+	/**
+	 * p. pfb_fwobj_remove with a guard removes only the row matching the guard.
+	 *
+	 * Scenario: two owned rows with the same pfB_ marker but different subnets.
+	 *           Guard accepts only subnet '10.10.10.53' → only that row is removed.
+	 * Given:  both pfBlockerNG rows present.
+	 * When:   remove with guard accepting only '10.10.10.53'.
+	 * Then:   '10.10.10.53' row gone; '10.10.10.54' row survives.
+	 */
+	public function testRemoveWithGuard(): void
+	{
+		// Given: two pfBlockerNG rows.
+		$vip_a = $this->pfbVip4('10.10.10.53');
+		$vip_b = $this->pfbVip4('10.10.10.54');
+		$this->seedConfig(['virtualip' => ['vip' => [$vip_a, $vip_b]]]);
+
+		// Assert before: two rows.
+		$before = $this->getSection('virtualip/vip');
+		$this->assertCount(2, $before, 'Before: two pfBlockerNG VIPs must be present');
+
+		// When: remove with guard accepting only '10.10.10.53'.
+		$result = pfb_fwobj_remove(
+			'virtualip/vip',
+			PFB_AUTO_VIP_DESCR_V4,
+			static fn(array $row): bool => ($row['subnet'] ?? '') === '10.10.10.53'
+		);
+
+		// Then: TRUE; only '10.10.10.54' survives.
+		$this->assertTrue($result);
+		$after = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $after, 'After: one VIP must remain');
+		$this->assertSame('10.10.10.54', $after[0]['subnet']);
+	}
+
+	// -------------------------------------------------------------------------
+	// sweep (cases q–s)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * q. pfb_fwobj_sweep removes all owned rows across multiple sections, leaving
+	 *    user rows intact.
+	 *
+	 * Scenario: virtualip/vip (one pfB row + one user row) and
+	 *           nat/rule (one pfB row + one user row).
+	 * Given:  both sections contain mixed owned and user rows.
+	 * When:   sweep(['virtualip/vip', 'nat/rule']).
+	 * Then:   all owned rows removed; all user rows survive; returns TRUE.
+	 */
+	public function testSweepRemovesAllOwnedRows(): void
+	{
+		// Given: mixed rows in two sections.
+		$this->seedConfig([
+			'virtualip' => ['vip'  => [$this->pfbVip4(), $this->userVip()]],
+			'nat'       => ['rule' => [$this->pfbNatRule(), $this->userNatRule()]],
+		]);
+
+		// Assert before: two rows in each section.
+		$this->assertCount(2, $this->getSection('virtualip/vip'), 'Before VIP: two rows');
+		$this->assertCount(2, $this->getSection('nat/rule'),      'Before NAT: two rows');
+
+		// When: sweep both sections.
+		$result = pfb_fwobj_sweep(['virtualip/vip', 'nat/rule']);
+
+		// Then: TRUE; owned rows gone; user rows survive.
+		$this->assertTrue($result);
+		$vips = $this->getSection('virtualip/vip');
+		$nats = $this->getSection('nat/rule');
+		$this->assertCount(1, $vips, 'After VIP: only user row remains');
+		$this->assertSame('My custom user VIP', $vips[0]['descr']);
+		$this->assertCount(1, $nats, 'After NAT: only user row remains');
+		$this->assertSame('My user NAT rule', $nats[0]['descr']);
+	}
+
+	/**
+	 * r. pfb_fwobj_sweep returns FALSE and writes nothing when all sections are clean.
+	 *
+	 * Scenario: empty config — no rows in any section.
+	 * Given:  empty config.
+	 * When:   sweep with two section paths.
+	 * Then:   returns FALSE; config remains empty.
+	 */
+	public function testSweepIsNoopOnCleanConfig(): void
+	{
+		// Given: empty config.
+		$this->seedConfig([]);
+
+		// When: sweep on non-existent / empty sections.
+		$result = pfb_fwobj_sweep(['virtualip/vip', 'nat/rule']);
+
+		// Then: FALSE.
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * s. pfb_fwobj_sweep is idempotent — the second call returns FALSE.
+	 *
+	 * Scenario: one pfBlockerNG VIP. First sweep removes it and returns TRUE.
+	 *           Second sweep finds nothing and returns FALSE.
+	 * Given:  one pfBlockerNG VIP.
+	 * When:   sweep twice.
+	 * Then:   first call → TRUE; second call → FALSE.
+	 */
+	public function testSweepIsIdempotent(): void
+	{
+		// Given: one pfBlockerNG VIP.
+		$this->seedConfig(['virtualip' => ['vip' => [$this->pfbVip4()]]]);
+
+		// Assert before: one row.
+		$before = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $before, 'Before: one owned VIP must be present');
+
+		// When: first sweep — removes it.
+		$first = pfb_fwobj_sweep(['virtualip/vip']);
+		$this->assertTrue($first, 'First sweep must return TRUE (removed something)');
+
+		// When: second sweep — nothing to remove.
+		$second = pfb_fwobj_sweep(['virtualip/vip']);
+		$this->assertFalse($second, 'Second sweep must return FALSE (nothing left)');
+	}
+
+	// -------------------------------------------------------------------------
+	// register / reconcile (cases t–u)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * t. pfb_fwobj_reconcile creates the object via the builder when absent.
+	 *
+	 * Scenario: register a spec for a pfB_ filter rule; rule is absent from config.
+	 * Given:  spec registered; filter/rule section is empty.
+	 * When:   pfb_fwobj_reconcile called.
+	 * Then:   builder was called; rule now present in config.
+	 */
+	public function testRegisterAndReconcileCreatesWhenAbsent(): void
+	{
+		// Given: empty filter/rule section.
+		$this->seedConfig(['filter' => ['rule' => []]]);
+
+		// Assert before: no rules.
+		$before = $this->getSection('filter/rule');
+		$this->assertCount(0, $before, 'Before: no filter rules must exist');
+
+		$builder_called = FALSE;
+		$new_rule       = $this->pfbFilterRule('pfB_Deny_v4');
+
+		pfb_fwobj_register([
+			'type'    => 'filter',
+			'section' => 'filter/rule',
+			'marker'  => 'pfB_Deny_v4',
+			'builder' => static function () use (&$builder_called, $new_rule): array {
+				$builder_called = TRUE;
+				return $new_rule;
+			},
+			'guard' => NULL,
+		]);
+
+		// When: reconcile.
+		pfb_fwobj_reconcile('pfB_Deny_v4');
+
+		// Then: builder was called; rule is now in the section.
+		$this->assertTrue($builder_called, 'Builder must have been called (object was absent)');
+		$after = $this->getSection('filter/rule');
+		$this->assertCount(1, $after, 'After: one filter rule must be present');
+		$this->assertSame('pfB_Deny_v4', $after[0]['descr']);
+	}
+
+	/**
+	 * u. pfb_fwobj_reconcile is idempotent — the builder is NOT called when the
+	 *    object already exists.
+	 *
+	 * Scenario: register a spec for a pfB_ filter rule; rule is already present.
+	 * Given:  spec registered; filter/rule already contains the rule.
+	 * When:   pfb_fwobj_reconcile called.
+	 * Then:   builder was NOT called; config unchanged (still one rule).
+	 */
+	public function testReconcileIsIdempotentWhenPresent(): void
+	{
+		// Given: rule already present.
+		$existing_rule = $this->pfbFilterRule('pfB_Deny_v4');
+		$this->seedConfig(['filter' => ['rule' => [$existing_rule]]]);
+
+		// Assert before: one rule present.
+		$before = $this->getSection('filter/rule');
+		$this->assertCount(1, $before, 'Before: one filter rule must already exist');
+
+		$builder_called = FALSE;
+
+		pfb_fwobj_register([
+			'type'    => 'filter',
+			'section' => 'filter/rule',
+			'marker'  => 'pfB_Deny_v4',
+			'builder' => static function () use (&$builder_called): array {
+				$builder_called = TRUE;
+				return ['descr' => 'pfB_Deny_v4_NEW', 'type' => 'block'];
+			},
+			'guard' => NULL,
+		]);
+
+		// When: reconcile.
+		pfb_fwobj_reconcile('pfB_Deny_v4');
+
+		// Then: builder was NOT called; still exactly one rule.
+		$this->assertFalse($builder_called, 'Builder must NOT be called (object already present)');
+		$after = $this->getSection('filter/rule');
+		$this->assertCount(1, $after, 'After: still exactly one filter rule');
+		$this->assertSame('pfB_Deny_v4', $after[0]['descr'],
+			'After: existing rule descr must be unchanged');
+	}
+}

--- a/tests/php/FwobjNatScopingTest.php
+++ b/tests/php/FwobjNatScopingTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-35 — regression guard for the NAT-classify loop scoping fix in pfb_create_dnsbl().
+ *
+ * Bug (F3 / CodeRabbit): the 'enabled' NAT classify loop used pfb_fwobj_is_owned($descr)
+ * to bucket existing rules into DNSBL-owned (to rebuild) vs other (to preserve). Because
+ * pfb_fwobj_is_owned() matches ANY pfBlockerNG marker — including 'pfB_' prefix rules —
+ * a pfBlockerNG-owned-but-NOT-DNSBL NAT rule (e.g. a future ADR-36 managed rule whose
+ * descr starts with 'pfB_') would be silently dropped into the DNSBL rebuild bucket and
+ * lost on every pfb_create_dnsbl('enabled') call.
+ *
+ * Fix: narrow the DNSBL bucket to str_contains($descr, PFB_FWOBJ_NAT_LEGACY_PFX)
+ * (i.e. descr containing 'pfB DNSBL'). Any pfBlockerNG-owned rule whose descr does NOT
+ * carry that substring stays in the preserved 'other' bucket.
+ *
+ * This test pins that fix: it seeds an owned-non-DNSBL NAT rule, runs
+ * pfb_create_dnsbl('enabled'), and asserts that the rule survives.
+ *
+ * Functions under test:
+ *   - pfb_create_dnsbl()
+ */
+#[CoversFunction('pfb_create_dnsbl')]
+final class FwobjNatScopingTest extends TestCase
+{
+	// -------------------------------------------------------------------------
+	// Helpers — replicated from FwobjCurrentBehaviourTest (that class is a frozen
+	// golden oracle; its helpers are private and cannot be reused here).
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Minimal $pfb keys required by pfb_create_dnsbl() to fire the NAT block
+	 * on mode='enabled': DNSBL on, non-lo0 interface, ports, VIP address.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function natPfb(): array
+	{
+		$pfb = $GLOBALS['pfb'] ?? [];
+		$pfb['dnsbl']          = 'on';
+		$pfb['dnsbl_port']     = '8081';
+		$pfb['dnsbl_port_ssl'] = '8443';
+		$pfb['dnsbl_iface']    = 'opt1';
+		$pfb['dnsbl_vip4']     = '10.10.10.53';
+		$pfb['dnsbl_vip6']     = '';
+		$pfb['dnsbl_cert']     = '/tmp/pfb_fwobj_nat_scoping_test_cert.pem';
+		$pfb['dnsbl_conf']     = '/tmp/pfb_fwobj_nat_scoping_test_lighttpd.conf';
+		$pfb['dnsbl_vip_auto'] = '';
+		$pfb['dnsblconfig']    = [];
+		return $pfb;
+	}
+
+	/**
+	 * Seed $GLOBALS['config'] with the minimal installedpackages structure and DNSBL
+	 * settings so pfb_global() and pfb_validate_vips() pass and keep $pfb['dnsbl']='on'.
+	 *
+	 * @param array<string,string> $dnsblCfg  DNSBL settings section (pfblockerngdnsblsettings)
+	 */
+	private function seedConfig(array $dnsblCfg = []): void
+	{
+		$GLOBALS['config'] = [
+			'virtualip' => ['vip' => []],
+			'installedpackages' => [
+				'pfblockerng'               => ['config' => [0 => []]],
+				'pfblockerngipsettings'     => ['config' => [0 => []]],
+				'pfblockerngdnsblsettings'  => ['config' => [0 => $dnsblCfg]],
+				'pfblockerngglobal'         => [],
+				'pfblockerngblacklist'      => [],
+			],
+		];
+	}
+
+	/**
+	 * A pfBlockerNG-OWNED but NOT-DNSBL NAT rule: descr starts with 'pfB_' (owned per
+	 * pfb_fwobj_is_owned) but does NOT contain 'pfB DNSBL' (not in the DNSBL bucket).
+	 * Stands in for any future managed NAT rule (e.g. ADR-36) that pfBlockerNG owns but
+	 * which must not be destroyed by DNSBL rebuild.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function ownedNonDnsblNatRule(): array
+	{
+		return [
+			'source'      => ['any' => ''],
+			'destination' => ['address' => '10.10.10.100', 'port' => '80'],
+			'protocol'    => 'tcp',
+			'target'      => '10.10.10.200',
+			'local-port'  => '9090',
+			'interface'   => 'opt1',
+			'descr'       => 'pfB_Redirect_test - DO NOT EDIT',
+		];
+	}
+
+	/** A user-owned NAT rule with no pfBlockerNG marker. Must always survive. */
+	private function userNatRule(): array
+	{
+		return [
+			'source'      => ['any' => ''],
+			'destination' => ['address' => '192.168.1.100', 'port' => '80'],
+			'protocol'    => 'tcp',
+			'target'      => '192.168.1.200',
+			'local-port'  => '9000',
+			'interface'   => 'wan',
+			'descr'       => 'my-user-nat',
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// setUp / tearDown
+	// -------------------------------------------------------------------------
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config']                           = [];
+		$GLOBALS['pfb_test_write_config_calls']      = [];
+		$GLOBALS['pfb_test_interface_ip']            = [];
+		$GLOBALS['pfb_test_configured_ipv6']         = [];
+		$GLOBALS['pfb_test_interfaces_with_gateway'] = [];
+		$GLOBALS['pfb_test_vip_bring_down_calls']    = [];
+		$GLOBALS['pfb_test_ipalias_configure_calls'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		unset(
+			$GLOBALS['config'],
+			$GLOBALS['pfb_test_write_config_calls'],
+			$GLOBALS['pfb_test_vip_bring_down_calls'],
+			$GLOBALS['pfb_test_ipalias_configure_calls'],
+			$GLOBALS['pfb_test_vip_list']
+		);
+	}
+
+	// =========================================================================
+	// Regression test
+	// =========================================================================
+
+	/**
+	 * pfb_create_dnsbl('enabled') preserves an owned-but-non-DNSBL NAT rule.
+	 *
+	 * Scenario: the NAT classify loop must bucket by DNSBL ownership only —
+	 * not by the broad pfb_fwobj_is_owned() predicate — so that a future managed
+	 * non-DNSBL NAT rule (descr starts with 'pfB_' but does not carry 'pfB DNSBL')
+	 * survives a DNSBL rebuild.
+	 *
+	 *   Background:
+	 *     Given a valid-VIP DNSBL-on configuration (pfb_validate_vips passes)
+	 *       and nat/rule contains:
+	 *         (a) an owned-non-DNSBL NAT rule (descr='pfB_Redirect_test - DO NOT EDIT')
+	 *         (b) a user-owned NAT rule        (descr='my-user-nat')
+	 *       and no 'pfB DNSBL' rule yet exists
+	 *
+	 *   When  pfb_create_dnsbl('enabled') is called
+	 *
+	 *   Then  (1) the owned-non-DNSBL rule ('pfB_Redirect_test...') STILL present
+	 *         (2) the user rule ('my-user-nat') STILL present
+	 *         (3) a new DNSBL NAT rule with descr='pfB DNSBL - DO NOT EDIT' was created
+	 *
+	 * Regression guarantee: with the old pfb_fwobj_is_owned() bucketing the
+	 * 'pfB_Redirect_test...' rule (owned = TRUE) would have been sorted into the
+	 * DNSBL rebuild bucket and then discarded when the new DNSBL rule set replaced it.
+	 * Assertion (1) catches that exact regression — it would FAIL on unfixed code.
+	 */
+	public function testEnableRebuildPreservesOwnedNonDnsblNat(): void
+	{
+		// Given: a valid VIP configuration so pfb_validate_vips passes and $pfb['dnsbl']
+		// remains 'on' after pfb_global() runs inside pfb_create_dnsbl().
+		$vipId = '_vip_test_nat4';
+		$vipIp = '10.10.10.53';
+		$this->seedConfig([
+			'pfb_dnsbl'       => 'on',
+			'pfb_dnsport'     => '8081',
+			'pfb_dnsport_ssl' => '8443',
+			'pfb_dnsvip4'     => $vipId,
+			'dnsbl_interface' => 'opt-double',	// matched by get_configured_vip_interface double
+		]);
+		// Seed get_configured_vip_list so pfb_get_vips includes the test VIP id.
+		$GLOBALS['pfb_test_vip_list'] = [$vipId => $vipIp];
+		// Set dnsbl_cert / dnsbl_conf to safe temp paths (pfb_global reads them from $pfb;
+		// pfb_create_dnsbl later checks file_exists and writes to dnsbl_conf).
+		$GLOBALS['pfb']['dnsbl_cert'] = '/tmp/pfb_fwobj_nat_scoping_test_cert.pem';
+		$GLOBALS['pfb']['dnsbl_conf'] = '/tmp/pfb_fwobj_nat_scoping_test_lighttpd.conf';
+
+		// Seed nat/rule: (a) owned-non-DNSBL rule, (b) user rule.
+		$ownedNonDnsbl = $this->ownedNonDnsblNatRule();
+		$userRule      = $this->userNatRule();
+		$GLOBALS['config']['nat'] = ['rule' => [$ownedNonDnsbl, $userRule]];
+
+		// Assert before-state: owned-non-DNSBL and user rules present; no DNSBL rule yet.
+		$before = config_get_path('nat/rule', []);
+		$this->assertCount(2, $before, 'before: exactly two NAT rules must be present');
+
+		$ownedBefore = array_filter(
+			$before,
+			fn($r) => ($r['descr'] ?? '') === 'pfB_Redirect_test - DO NOT EDIT'
+		);
+		$userBefore = array_filter(
+			$before,
+			fn($r) => ($r['descr'] ?? '') === 'my-user-nat'
+		);
+		$dnsblBefore = array_filter(
+			$before,
+			fn($r) => str_contains($r['descr'] ?? '', 'pfB DNSBL')
+		);
+		$this->assertCount(1, $ownedBefore, 'before: owned-non-DNSBL rule must be present');
+		$this->assertCount(1, $userBefore,  'before: user NAT rule must be present');
+		$this->assertCount(0, $dnsblBefore, 'before: no pfB DNSBL NAT rule must exist yet');
+
+		// Verify that pfb_fwobj_is_owned() does consider the owned-non-DNSBL rule as owned
+		// (proves the old broad bucket check WOULD have caught it and triggered the bug).
+		$this->assertTrue(
+			pfb_fwobj_is_owned('pfB_Redirect_test - DO NOT EDIT'),
+			'pfb_fwobj_is_owned must return TRUE for a pfB_-prefixed descr (confirming the old bucket was too broad)'
+		);
+		// And confirm it does NOT contain 'pfB DNSBL' (so the fix correctly excludes it).
+		$this->assertFalse(
+			str_contains('pfB_Redirect_test - DO NOT EDIT', PFB_FWOBJ_NAT_LEGACY_PFX),
+			'the owned-non-DNSBL descr must NOT contain PFB_FWOBJ_NAT_LEGACY_PFX'
+		);
+
+		// When: pfb_create_dnsbl('enabled') — fires the NAT classify loop + rebuild.
+		pfb_create_dnsbl('enabled');
+
+		// Then: assert all three post-conditions.
+		$after = config_get_path('nat/rule', []);
+
+		// (1) Owned-non-DNSBL rule STILL present (regression guard — old code drops it).
+		$ownedAfter = array_filter(
+			$after,
+			fn($r) => ($r['descr'] ?? '') === 'pfB_Redirect_test - DO NOT EDIT'
+		);
+		$this->assertCount(
+			1,
+			$ownedAfter,
+			'after enable: owned-non-DNSBL rule must survive (regression: old pfb_fwobj_is_owned bucket would drop it)'
+		);
+		$this->assertSame(
+			$ownedNonDnsbl,
+			array_values($ownedAfter)[0],
+			'after enable: owned-non-DNSBL rule must be byte-identical to what was seeded'
+		);
+
+		// (2) User rule STILL present, byte-identical.
+		$userAfter = array_filter(
+			$after,
+			fn($r) => ($r['descr'] ?? '') === 'my-user-nat'
+		);
+		$this->assertCount(1, $userAfter, 'after enable: user NAT rule must survive');
+		$this->assertSame(
+			$userRule,
+			array_values($userAfter)[0],
+			'after enable: user NAT rule must be byte-identical to what was seeded'
+		);
+
+		// (3) New DNSBL NAT rule created with the exact ownership descr.
+		$dnsblAfter = array_filter(
+			$after,
+			fn($r) => ($r['descr'] ?? '') === 'pfB DNSBL - DO NOT EDIT'
+		);
+		$this->assertNotEmpty(
+			$dnsblAfter,
+			'after enable: at least one NAT rule with descr="pfB DNSBL - DO NOT EDIT" must be created'
+		);
+	}
+}

--- a/tests/php/FwobjSweepSeamTest.php
+++ b/tests/php/FwobjSweepSeamTest.php
@@ -1,0 +1,472 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-35 Phase 4 — sweep wiring + registration seam tests.
+ *
+ * Functions under test (on top of FwobjLayerTest Phase-2 coverage):
+ *   - pfb_fwobj_sweep()              — orphan teardown, user-survival, no-op, idempotency
+ *   - pfb_fwobj_register()           — registration seam for VIP + DNSBL NAT
+ *   - pfb_fwobj_reconcile()          — builder called once when absent; no-op when present
+ *   - pfb_fwobj_init_registrations() — VIP V4/V6 + NAT specs registered
+ *
+ * Coverage mandate (CLAUDE.md):
+ *   - Every branch exercised (both sides of every conditional).
+ *   - Transition tests assert BEFORE state before mutating (no false passes).
+ *   - Complex flows use BDD-style Given/When/Then comments.
+ *
+ * Test cases:
+ *   a. testSweepRemovesOrphanVip           — orphan VIP removed even when double-guard ref cleared
+ *   b. testSweepRemovesOrphanNat           — orphan NAT removed even without pfb_create_dnsbl teardown
+ *   c. testUserVipSurvivesSweep            — user VIP untouched when orphan owned VIP is swept
+ *   d. testUserNatSurvivesSweep            — user NAT untouched when orphan owned NAT is swept
+ *   e. testSweepIsNoopOnCleanConfig        — no owned rows → FALSE, write_config NOT called
+ *   f. testSweepIsIdempotent               — second sweep returns FALSE
+ *   g. testRegisterVipAndReconcileCreatesWhenAbsent — builder called, VIP created
+ *   h. testRegisterVipAndReconcileIsIdempotent      — builder called once only
+ */
+#[CoversFunction('pfb_fwobj_sweep')]
+#[CoversFunction('pfb_fwobj_register')]
+#[CoversFunction('pfb_fwobj_reconcile')]
+#[CoversFunction('pfb_fwobj_init_registrations')]
+final class FwobjSweepSeamTest extends TestCase
+{
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Seed $GLOBALS['config'] so config_get_path() and config_set_path() work
+	 * in each test. Accepts multiple sections by key.
+	 *
+	 * @param array<string,array<int,array<string,mixed>>> $sections
+	 */
+	private function seedConfig(array $sections = []): void
+	{
+		$GLOBALS['config'] = $sections;
+	}
+
+	/**
+	 * Read a section from $GLOBALS['config'] using a slash-delimited path.
+	 *
+	 * @param string $path  e.g. 'virtualip/vip'
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function getSection(string $path): array
+	{
+		$parts  = explode('/', $path);
+		$cursor = $GLOBALS['config'] ?? [];
+		foreach ($parts as $key) {
+			$cursor = $cursor[$key] ?? [];
+		}
+		return (array) $cursor;
+	}
+
+	/**
+	 * An orphan pfBlockerNG auto-VIP (V4): marker-owned but double-guard IP ref cleared.
+	 * Simulates a half-written state where pfb_dnsvip4 was cleared before the VIP entry
+	 * was removed — the double-guard in pfb_manage_dnsbl_vip would skip it; sweep must not.
+	 */
+	private function orphanPfbVip4(string $subnet = '10.10.10.53'): array
+	{
+		return [
+			'descr'       => PFB_AUTO_VIP_DESCR_V4,	// 'pfB_AUTO_VIP_v4'
+			'mode'        => 'ipalias',
+			'interface'   => 'lo0',
+			'subnet'      => $subnet,
+			'subnet_bits' => '32',
+		];
+	}
+
+	/**
+	 * An orphan pfBlockerNG DNSBL NAT rule: marker-owned but pfb_create_dnsbl teardown
+	 * was not called — simulates half-written state on disable.
+	 */
+	private function orphanPfbNat(): array
+	{
+		return [
+			'descr'      => PFB_FWOBJ_NAT_DESCR,	// 'pfB DNSBL - DO NOT EDIT'
+			'protocol'   => 'tcp',
+			'interface'  => 'opt1',
+			'target'     => '127.0.0.1',
+			'local-port' => '8081',
+		];
+	}
+
+	/** A user-owned VIP — must never be touched by any fwobj function. */
+	private function userVip(string $subnet = '192.168.1.200'): array
+	{
+		return [
+			'descr'       => 'My custom user VIP',
+			'mode'        => 'ipalias',
+			'interface'   => 'lan',
+			'subnet'      => $subnet,
+			'subnet_bits' => '32',
+		];
+	}
+
+	/** A user-owned NAT rule — must never be touched by any fwobj function. */
+	private function userNatRule(): array
+	{
+		return [
+			'descr'      => 'My user NAT rule',
+			'protocol'   => 'tcp',
+			'interface'  => 'wan',
+			'target'     => '10.0.0.1',
+			'local-port' => '80',
+		];
+	}
+
+	/** Reset the static registry and write_config spy between tests. */
+	protected function setUp(): void
+	{
+		$registry = &pfb_fwobj_registry();
+		$registry = [];
+		$GLOBALS['pfb_test_write_config_calls'] = [];
+	}
+
+	// -------------------------------------------------------------------------
+	// Orphan teardown — cases a–b
+	// -------------------------------------------------------------------------
+
+	/**
+	 * a. testSweepRemovesOrphanVip
+	 *
+	 * Scenario: A VIP with descr='pfB_AUTO_VIP_v4' exists in virtualip/vip,
+	 * but pfb_dnsvip4 (the double-guard reference) is cleared (empty string).
+	 * The normal pfb_manage_dnsbl_vip disable path would skip it because the
+	 * guard predicate (subnet === cleared_ip) would not match any VIP.
+	 * pfb_fwobj_sweep uses marker-only ownership — it MUST still remove it.
+	 *
+	 * Given:  one orphan pfBlockerNG VIP in virtualip/vip (double-guard ref cleared).
+	 * When:   pfb_fwobj_sweep(['virtualip/vip']).
+	 * Then:   orphan VIP removed; section empty; returns TRUE.
+	 */
+	public function testSweepRemovesOrphanVip(): void
+	{
+		// Given: orphan VIP present; double-guard IP ref intentionally cleared.
+		$orphan_vip    = $this->orphanPfbVip4('10.10.10.53');
+		$cleared_ip_ref = '';	// simulates pfb_dnsvip4 = '' (cleared)
+		$this->seedConfig(['virtualip' => ['vip' => [$orphan_vip]]]);
+
+		// Assert before: orphan VIP is present.
+		$before = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $before, 'Before: orphan VIP must be present');
+		$this->assertSame(PFB_AUTO_VIP_DESCR_V4, $before[0]['descr'],
+			'Before: VIP must carry the pfB_AUTO_VIP_v4 marker');
+
+		// Confirm the double-guard would skip it: no VIP has subnet matching cleared ref.
+		$double_guard_finds = FALSE;
+		foreach ($before as $vip) {
+			if (($vip['subnet'] ?? '') === $cleared_ip_ref) {
+				$double_guard_finds = TRUE;
+			}
+		}
+		$this->assertFalse($double_guard_finds,
+			'Precondition: the double-guard (subnet === cleared_ip_ref) must NOT match the orphan VIP');
+
+		// When: sweep runs (marker-only; ignores the double-guard).
+		$result = pfb_fwobj_sweep(['virtualip/vip']);
+
+		// Then: orphan VIP removed; returns TRUE.
+		$this->assertTrue($result, 'Sweep must return TRUE (orphan was removed)');
+		$after = $this->getSection('virtualip/vip');
+		$this->assertCount(0, $after, 'After: orphan VIP must be gone');
+	}
+
+	/**
+	 * b. testSweepRemovesOrphanNat
+	 *
+	 * Scenario: A NAT rule with descr='pfB DNSBL - DO NOT EDIT' exists in nat/rule,
+	 * but pfb_create_dnsbl teardown was not called (simulates a half-written state
+	 * where disable was interrupted before NAT cleanup). pfb_fwobj_sweep removes it.
+	 *
+	 * Given:  one orphan pfBlockerNG NAT rule in nat/rule.
+	 * When:   pfb_fwobj_sweep(['nat/rule']).
+	 * Then:   orphan NAT rule removed; section empty; returns TRUE.
+	 */
+	public function testSweepRemovesOrphanNat(): void
+	{
+		// Given: orphan NAT rule present (pfb_create_dnsbl teardown was never called).
+		$orphan_nat = $this->orphanPfbNat();
+		$this->seedConfig(['nat' => ['rule' => [$orphan_nat]]]);
+
+		// Assert before: orphan NAT rule is present.
+		$before = $this->getSection('nat/rule');
+		$this->assertCount(1, $before, 'Before: orphan NAT rule must be present');
+		$this->assertSame(PFB_FWOBJ_NAT_DESCR, $before[0]['descr'],
+			'Before: NAT rule must carry the canonical pfB DNSBL marker');
+
+		// When: sweep (without calling pfb_create_dnsbl — proves the orphan gap is closed).
+		$result = pfb_fwobj_sweep(['nat/rule']);
+
+		// Then: orphan NAT rule removed; returns TRUE.
+		$this->assertTrue($result, 'Sweep must return TRUE (orphan was removed)');
+		$after = $this->getSection('nat/rule');
+		$this->assertCount(0, $after, 'After: orphan NAT rule must be gone');
+	}
+
+	// -------------------------------------------------------------------------
+	// User-object survival — cases c–d
+	// -------------------------------------------------------------------------
+
+	/**
+	 * c. testUserVipSurvivesSweep
+	 *
+	 * Scenario: virtualip/vip has ONE orphan pfBlockerNG VIP and ONE user VIP.
+	 * Sweep must remove the orphan and leave the user VIP untouched.
+	 *
+	 * Given:  orphan owned VIP + sibling user VIP in virtualip/vip.
+	 * When:   pfb_fwobj_sweep(['virtualip/vip']).
+	 * Then:   orphan gone; user VIP survives; section has exactly one row.
+	 */
+	public function testUserVipSurvivesSweep(): void
+	{
+		// Given: both rows present.
+		$orphan_vip = $this->orphanPfbVip4();
+		$user_vip   = $this->userVip('192.168.1.200');
+		$this->seedConfig(['virtualip' => ['vip' => [$orphan_vip, $user_vip]]]);
+
+		// Assert before: two rows (one owned, one user).
+		$before = $this->getSection('virtualip/vip');
+		$this->assertCount(2, $before, 'Before: both VIPs must be present');
+		$descrs = array_column($before, 'descr');
+		$this->assertContains(PFB_AUTO_VIP_DESCR_V4, $descrs, 'Before: orphan VIP must be in the section');
+		$this->assertContains('My custom user VIP', $descrs,  'Before: user VIP must be in the section');
+
+		// When: sweep.
+		$result = pfb_fwobj_sweep(['virtualip/vip']);
+
+		// Then: TRUE; only the user VIP remains.
+		$this->assertTrue($result, 'Sweep must return TRUE (orphan was removed)');
+		$after = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $after, 'After: only the user VIP must remain');
+		$this->assertSame('My custom user VIP', $after[0]['descr'],
+			'After: the surviving row must be the user VIP');
+	}
+
+	/**
+	 * d. testUserNatSurvivesSweep
+	 *
+	 * Scenario: nat/rule has ONE orphan pfBlockerNG NAT rule and ONE user NAT rule.
+	 * Sweep removes the orphan; user rule survives.
+	 *
+	 * Given:  orphan owned NAT rule + sibling user NAT rule in nat/rule.
+	 * When:   pfb_fwobj_sweep(['nat/rule']).
+	 * Then:   orphan gone; user NAT rule survives.
+	 */
+	public function testUserNatSurvivesSweep(): void
+	{
+		// Given: both rows present.
+		$orphan_nat = $this->orphanPfbNat();
+		$user_nat   = $this->userNatRule();
+		$this->seedConfig(['nat' => ['rule' => [$orphan_nat, $user_nat]]]);
+
+		// Assert before: two rows.
+		$before = $this->getSection('nat/rule');
+		$this->assertCount(2, $before, 'Before: both NAT rules must be present');
+		$descrs = array_column($before, 'descr');
+		$this->assertContains(PFB_FWOBJ_NAT_DESCR, $descrs,  'Before: orphan NAT must be in the section');
+		$this->assertContains('My user NAT rule', $descrs,    'Before: user NAT must be in the section');
+
+		// When: sweep.
+		$result = pfb_fwobj_sweep(['nat/rule']);
+
+		// Then: TRUE; only the user NAT rule remains.
+		$this->assertTrue($result, 'Sweep must return TRUE (orphan was removed)');
+		$after = $this->getSection('nat/rule');
+		$this->assertCount(1, $after, 'After: only the user NAT rule must remain');
+		$this->assertSame('My user NAT rule', $after[0]['descr'],
+			'After: the surviving row must be the user NAT rule');
+	}
+
+	// -------------------------------------------------------------------------
+	// No-op and idempotency — cases e–f
+	// -------------------------------------------------------------------------
+
+	/**
+	 * e. testSweepIsNoopOnCleanConfig
+	 *
+	 * Scenario: all three sections are empty (or absent) — a clean post-disable state.
+	 * Sweep must return FALSE and write_config must NOT be called.
+	 *
+	 * Given:  empty config (no rows in any of the three sections).
+	 * When:   pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule']).
+	 * Then:   returns FALSE; $GLOBALS['pfb_test_write_config_calls'] remains empty.
+	 */
+	public function testSweepIsNoopOnCleanConfig(): void
+	{
+		// Given: empty config; write_config spy starts empty.
+		$this->seedConfig([]);
+		$GLOBALS['pfb_test_write_config_calls'] = [];
+
+		// Assert before: write_config has not been called.
+		$this->assertEmpty($GLOBALS['pfb_test_write_config_calls'],
+			'Before: write_config must not have been called yet');
+
+		// When: sweep the three sections.
+		$result = pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule']);
+
+		// Then: FALSE (no orphans existed); write_config still not called.
+		$this->assertFalse($result, 'Sweep must return FALSE (nothing to remove)');
+		$this->assertEmpty($GLOBALS['pfb_test_write_config_calls'],
+			'After: write_config must NOT have been called on a no-op sweep');
+	}
+
+	/**
+	 * f. testSweepIsIdempotent
+	 *
+	 * Scenario: one orphan pfBlockerNG VIP. First sweep removes it (→ TRUE).
+	 *           Second sweep finds nothing (→ FALSE).
+	 *
+	 * Given:  one orphan VIP in virtualip/vip.
+	 * When:   sweep called twice in sequence.
+	 * Then:   first call returns TRUE; second call returns FALSE.
+	 */
+	public function testSweepIsIdempotent(): void
+	{
+		// Given: one orphan VIP.
+		$this->seedConfig(['virtualip' => ['vip' => [$this->orphanPfbVip4()]]]);
+
+		// Assert before: one row.
+		$before = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $before, 'Before: one orphan VIP must be present');
+
+		// When: first sweep — removes the orphan.
+		$first = pfb_fwobj_sweep(['virtualip/vip']);
+		$this->assertTrue($first, 'First sweep must return TRUE (orphan was removed)');
+
+		// Assert intermediate: section is now empty.
+		$intermediate = $this->getSection('virtualip/vip');
+		$this->assertCount(0, $intermediate, 'After first sweep: section must be empty');
+
+		// When: second sweep — nothing to remove.
+		$second = pfb_fwobj_sweep(['virtualip/vip']);
+
+		// Then: FALSE (idempotent).
+		$this->assertFalse($second, 'Second sweep must return FALSE (nothing left to remove)');
+	}
+
+	// -------------------------------------------------------------------------
+	// Registration seam — cases g–h
+	// -------------------------------------------------------------------------
+
+	/**
+	 * g. testRegisterVipAndReconcileCreatesWhenAbsent
+	 *
+	 * Scenario: register a VIP spec with a test builder; call pfb_fwobj_reconcile;
+	 * the object is absent → builder is called and the VIP is created in config.
+	 *
+	 * Given:  VIP spec registered with a test builder; virtualip/vip is empty.
+	 * When:   pfb_fwobj_reconcile(PFB_AUTO_VIP_DESCR_V4).
+	 * Then:   builder was called exactly once; VIP entry appears in virtualip/vip.
+	 */
+	public function testRegisterVipAndReconcileCreatesWhenAbsent(): void
+	{
+		// Given: empty virtualip/vip section; VIP is absent.
+		$this->seedConfig(['virtualip' => ['vip' => []]]);
+
+		// Assert before: no VIP present.
+		$before = $this->getSection('virtualip/vip');
+		$this->assertCount(0, $before, 'Before: virtualip/vip must be empty');
+
+		$builder_call_count = 0;
+		$new_vip            = [
+			'descr'       => PFB_AUTO_VIP_DESCR_V4,
+			'mode'        => 'ipalias',
+			'interface'   => 'lo0',
+			'subnet'      => '10.10.10.53',
+			'subnet_bits' => '32',
+		];
+
+		// Register the VIP spec with a test builder (analogous to pfb_fwobj_init_registrations).
+		pfb_fwobj_register([
+			'type'    => 'vip',
+			'section' => 'virtualip/vip',
+			'marker'  => PFB_AUTO_VIP_DESCR_V4,
+			'builder' => static function () use (&$builder_call_count, $new_vip): array {
+				$builder_call_count++;
+				return $new_vip;
+			},
+			'guard'   => NULL,
+		]);
+
+		// When: reconcile — VIP is absent so builder should be invoked.
+		pfb_fwobj_reconcile(PFB_AUTO_VIP_DESCR_V4);
+
+		// Then: builder called exactly once; VIP now present in the section.
+		$this->assertSame(1, $builder_call_count,
+			'Builder must have been called exactly once (VIP was absent)');
+		$after = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $after, 'After: one VIP entry must be present');
+		$this->assertSame(PFB_AUTO_VIP_DESCR_V4, $after[0]['descr'],
+			'After: VIP must carry the PFB_AUTO_VIP_DESCR_V4 marker');
+		$this->assertSame('10.10.10.53', $after[0]['subnet'],
+			'After: VIP must have the subnet the builder returned');
+	}
+
+	/**
+	 * h. testRegisterVipAndReconcileIsIdempotent
+	 *
+	 * Scenario: register a VIP spec; call pfb_fwobj_reconcile twice.
+	 * The builder is called only once (first reconcile creates the VIP;
+	 * second reconcile finds it already present and is a no-op).
+	 *
+	 * Given:  VIP spec registered; virtualip/vip is empty.
+	 * When:   pfb_fwobj_reconcile called twice.
+	 * Then:   after first reconcile: VIP present; builder called once.
+	 *         After second reconcile: still one VIP; builder still called once only.
+	 */
+	public function testRegisterVipAndReconcileIsIdempotent(): void
+	{
+		// Given: empty virtualip/vip section.
+		$this->seedConfig(['virtualip' => ['vip' => []]]);
+
+		// Assert before: no VIP present.
+		$before = $this->getSection('virtualip/vip');
+		$this->assertCount(0, $before, 'Before: virtualip/vip must be empty');
+
+		$builder_call_count = 0;
+		$new_vip            = [
+			'descr'       => PFB_AUTO_VIP_DESCR_V4,
+			'mode'        => 'ipalias',
+			'interface'   => 'lo0',
+			'subnet'      => '10.10.10.53',
+			'subnet_bits' => '32',
+		];
+
+		pfb_fwobj_register([
+			'type'    => 'vip',
+			'section' => 'virtualip/vip',
+			'marker'  => PFB_AUTO_VIP_DESCR_V4,
+			'builder' => static function () use (&$builder_call_count, $new_vip): array {
+				$builder_call_count++;
+				return $new_vip;
+			},
+			'guard'   => NULL,
+		]);
+
+		// When: first reconcile — VIP is absent; builder must be called.
+		pfb_fwobj_reconcile(PFB_AUTO_VIP_DESCR_V4);
+
+		// Assert after first reconcile: VIP present; builder called once.
+		$after_first = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $after_first, 'After first reconcile: exactly one VIP must exist');
+		$this->assertSame(1, $builder_call_count,
+			'After first reconcile: builder must have been called exactly once');
+
+		// When: second reconcile — VIP is already present; builder must NOT be called again.
+		pfb_fwobj_reconcile(PFB_AUTO_VIP_DESCR_V4);
+
+		// Then: still one VIP; builder call count unchanged.
+		$after_second = $this->getSection('virtualip/vip');
+		$this->assertCount(1, $after_second,
+			'After second reconcile: still exactly one VIP (no duplicate created)');
+		$this->assertSame(1, $builder_call_count,
+			'After second reconcile: builder must NOT have been called a second time');
+	}
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -74,6 +74,10 @@ error_reporting($pfb_prev_er);
 //    file_exists() check that is not satisfied off-appliance, so we load it explicitly
 //    here by its repo-relative path.
 require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+// 7. Load the ADR-35 firewall-object ownership layer (pfblockerng_fwobj.inc). On-appliance
+//    pfblockerng.inc loads it via a host-absolute file_exists() check that is not satisfied
+//    off-appliance (no /usr/local/pkg/pfblockerng/ here), so load it explicitly by repo path.
+require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc';
 
 if (!function_exists('step3_submitphpaction')) {
 	$pfb_wizard_src = file_get_contents(

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -561,3 +561,117 @@ if (!function_exists('ip_in_subnet')) {
 		return true;
 	}
 }
+
+// --- ADR-35 Phase 1 doubles — VIP lifecycle + NAT/service management ---
+//
+// SPECIALNET_VIPS: pfSense constant (value 12) from globals.inc. Defined here for
+// the runtime double layer (the PHPStan stubs/pfsense/globals.php value is for static
+// analysis only and is not loaded at runtime off-appliance).
+if (!defined('SPECIALNET_VIPS')) {
+	define('SPECIALNET_VIPS', 12);
+}
+//
+//
+// pfb_manage_dnsbl_vip() calls interface_vip_bring_down() on disable and
+// interface_ipalias_configure() on enable (after VIP create).
+// pfb_create_dnsbl() calls is_service_running(), restart_service(), stop_service(),
+// and pfb_create_dnsbl_cert() which in turn calls cert_create().
+// These are all pfSense runtime functions absent off-appliance; doubles here make
+// the VIP/NAT oracle tests in FwobjCurrentBehaviourTest runnable without a live box.
+
+if (!function_exists('interface_vip_bring_down')) {
+	// pfSense interfaces.inc: un-apply a VIP alias from the interface (live pf change).
+	// Off-appliance: record the call for test inspection; no pf present.
+	function interface_vip_bring_down($vip) {
+		$GLOBALS['pfb_test_vip_bring_down_calls'][] = $vip;
+		return TRUE;
+	}
+}
+
+if (!function_exists('interface_ipalias_configure')) {
+	// pfSense interfaces.inc: apply a VIP alias to the interface (live pf change).
+	// Off-appliance: record the call for test inspection; no pf present.
+	function interface_ipalias_configure($vip) {
+		$GLOBALS['pfb_test_ipalias_configure_calls'][] = $vip;
+		return TRUE;
+	}
+}
+
+if (!function_exists('is_service_running')) {
+	// pfSense service-utils.inc: TRUE when the named rc.d service is running.
+	// Default TRUE so the 'if ($pfbupdate || !is_service_running())' block only
+	// fires when $pfbupdate is TRUE (the NAT/config changed), matching real usage.
+	// Tests can override via $GLOBALS['pfb_test_service_running'] (service => bool).
+	function is_service_running($service, $ps = []) {
+		$map = $GLOBALS['pfb_test_service_running'] ?? [];
+		return (bool) ($map[$service] ?? TRUE);
+	}
+}
+
+if (!function_exists('restart_service')) {
+	// pfSense services.inc: restart a named rc.d service. No-op off-appliance.
+	function restart_service($service) {
+		return TRUE;
+	}
+}
+
+if (!function_exists('stop_service')) {
+	// pfSense services.inc: stop a named rc.d service. No-op off-appliance.
+	function stop_service($service) {
+		return TRUE;
+	}
+}
+
+if (!function_exists('cert_create')) {
+	// pfSense cert.inc: generate a self-signed certificate and populate $cert['prv'/'crt'].
+	// Off-appliance: write empty base64-encoded blobs so the caller's file_put_contents
+	// has valid (though empty) data. Returns TRUE (success) so the error-log branch is
+	// not triggered, keeping the test clean.
+	function cert_create(&$cert, $caref, $keylen, $lifetime, $dn, $type = 'self-signed', $digest = 'sha256', $curve = '', $pkcs_alg = '') {
+		$cert['prv'] = base64_encode('');
+		$cert['crt'] = base64_encode('');
+		return TRUE;
+	}
+}
+
+if (!function_exists('get_configured_vip_list')) {
+	// pfSense interfaces.inc: map of VIP id ('_vip<uniqid>') => resolved IP address for
+	// all configured VIPs. Used by pfb_get_vips() inside pfb_validate_vips().
+	// Tests seed $GLOBALS['pfb_test_vip_list'] (map of id => addr); default empty map
+	// → pfb_get_vips() returns no VIPs, which combined with a '_vip_test_*' id causes
+	// pfb_validate_vips to return an 'invalid IPv4 VIP' error and force-disable DNSBL.
+	// Tests that need DNSBL to stay enabled must seed a matching id => addr entry AND
+	// use the 'opt-double' interface (matched by the get_configured_vip_interface double).
+	function get_configured_vip_list($type = '') {
+		return $GLOBALS['pfb_test_vip_list'] ?? [];
+	}
+}
+
+if (!function_exists('get_specialnet')) {
+	// pfSense interfaces.inc: returns an associative array of special network names/
+	// addresses (VIPs, loopback, etc.) indexed by their IP/address. Used by pfb_get_vips()
+	// to filter VIPs to only the ones in the SPECIALNET_VIPS set.
+	// Tests seed $GLOBALS['pfb_test_specialnet'] (addr => label); default includes all
+	// addresses from pfb_test_vip_list so pfb_get_vips() can match them.
+	function get_specialnet($interface = '', $types = []) {
+		// If a test has explicitly seeded this, use it.
+		if (isset($GLOBALS['pfb_test_specialnet'])) {
+			return $GLOBALS['pfb_test_specialnet'];
+		}
+		// Auto-derive from pfb_test_vip_list: every configured VIP addr counts as special.
+		$map = [];
+		foreach ($GLOBALS['pfb_test_vip_list'] ?? [] as $addr) {
+			$map[$addr] = $addr;
+		}
+		return $map;
+	}
+}
+
+if (!function_exists('where_is_ipaddr_configured')) {
+	// pfSense interfaces.inc: returns a list of interface names where $addr is configured
+	// (including subnet membership). Used by pfb_validate_vips() to detect VIP overlap.
+	// Always returns [] off-appliance: no real interfaces exist, so no VIP overlaps.
+	function where_is_ipaddr_configured($ip, $ignore_if = '', $check_localip = false, $check_subnets = false, $cidrprefix = '') {
+		return [];
+	}
+}

--- a/tests/smoke/test_smoke_fwobj.py
+++ b/tests/smoke/test_smoke_fwobj.py
@@ -2,9 +2,11 @@
 
 Proves on a real pfSense CE VM that:
 
-* Enable → pfBlockerNG-owned VIP (``pfB_AUTO_VIP_v4/v6``) and DNSBL NAT rule
-  (``pfB DNSBL - DO NOT EDIT``) are created in config.xml.
-* Disable → both are removed from config.xml.
+* Enable → the pfBlockerNG-owned sinkhole VIP (``pfB_AUTO_VIP_v4``) and DNSBL NAT
+  rule (``pfB DNSBL - DO NOT EDIT``) are created in config.xml. (The harness
+  provisions only the v4 auto-VIP; the symmetric v6 path is pinned off-box by
+  ``FwobjCurrentBehaviourTest::testVipFindByMarkerV6``.)
+* Disable → the VIP and NAT are removed; no pfB-owned VIP of either family remains.
 * Uninstall → a seeded ORPHAN VIP is swept (before-and-after); user-created VIP
   and NAT rule survive; ``installedpackages/pfblockerng*`` sections are gone.
 

--- a/tests/smoke/test_smoke_fwobj.py
+++ b/tests/smoke/test_smoke_fwobj.py
@@ -1,0 +1,401 @@
+"""ADR-35 — live-VM smoke coverage for managed firewall object ownership and teardown.
+
+Proves on a real pfSense CE VM that:
+
+* Enable → pfBlockerNG-owned VIP (``pfB_AUTO_VIP_v4/v6``) and DNSBL NAT rule
+  (``pfB DNSBL - DO NOT EDIT``) are created in config.xml.
+* Disable → both are removed from config.xml.
+* Uninstall → a seeded ORPHAN VIP is swept (before-and-after); user-created VIP
+  and NAT rule survive; ``installedpackages/pfblockerng*`` sections are gone.
+
+Config.xml assertions are done via the pfSense config API (``php_eval`` /
+``config_get_path`` / ``marked_vip_subnet``), following the smoke-suite pattern —
+never reading the file directly. VIP/NAT assertions are config.xml reads, not DNS
+probes; ``helpers.unique_domain()`` is not needed here.
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke``). Run
+only by the smoke workflow::
+
+    python -m pytest tests/smoke -m smoke --override-ini="addopts="
+
+Needs the booted ``smoke_vm`` fixture, the branch ``.pkg`` (``SMOKE_PKG``), and the
+smoke deps; without them they skip cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM, _StubDnsServer
+
+pytestmark = pytest.mark.smoke
+
+# Package name on the devel channel (matches test_repo_install.py's PKG_NAME).
+_PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"
+
+# Descr markers that identify pfBlockerNG-owned objects (mirrors pfblockerng_fwobj.inc).
+_AUTO_VIP_DESCR_V4 = "pfB_AUTO_VIP_v4"
+_AUTO_VIP_DESCR_V6 = "pfB_AUTO_VIP_v6"
+_DNSBL_NAT_DESCR_PFX = "pfB DNSBL"  # pfb_create_dnsbl uses 'pfB DNSBL - DO NOT EDIT'
+
+# User-object descriptors seeded in Scenario C to prove they survive uninstall.
+_USER_VIP_DESCR = "my-test-user-vip-do-not-delete"
+_USER_NAT_DESCR = "my-test-user-nat-do-not-delete"
+
+
+# --------------------------------------------------------------------------- #
+# Module-scoped deployed_vm: install the branch .pkg once for all three tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+    """Deploy the branch .pkg once for the fwobj module.
+
+    Egress stays OPEN across reloads: ``pkg add`` pulls RUN_DEPENDS and the
+    DNSBL update path runs ``pfb_create_dnsbl`` which touches pfSense state.
+    ``ensure_dnsbl_vip`` + ``use_system_dns_upstream`` give DNSBL a sinkhole
+    VIP and a reachable upstream so the full update completes cleanly.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.snapshot_unbound_conf(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.unblock_egress()
+        h.collect_host_diagnostics(smoke_vm)
+
+
+# --------------------------------------------------------------------------- #
+# Internal helpers for config.xml VIP / NAT / section reads
+# --------------------------------------------------------------------------- #
+
+
+def _vip_descr_present(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> bool:
+    """True iff ``virtualip/vip[]`` contains an entry whose ``descr`` == ``descr``."""
+    return h.marked_vip_subnet(vm, descr, timeout=timeout) != ""
+
+
+def _nat_pfb_dnsbl_present(vm: SmokeVM, *, timeout: float = 60.0) -> bool:
+    """True iff ``nat/rule[]`` contains an entry whose ``descr`` starts with 'pfB DNSBL'."""
+    pre = (
+        "$found = FALSE;\n"
+        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+        f"  if (strpos((string) ($r['descr'] ?? ''), {h._php_str(_DNSBL_NAT_DESCR_PFX)}) !== FALSE)"
+        "  { $found = TRUE; break; }\n"
+        "}"
+    )
+    val = h._php_read_scalar(vm, pre, "$found ? 'yes' : 'no'", timeout=timeout)
+    return val == "yes"
+
+
+def _pfb_sections_present(vm: SmokeVM, *, timeout: float = 60.0) -> bool:
+    """True iff any ``installedpackages/pfblockerng*`` section survives in config.xml."""
+    pre = (
+        "$found = FALSE;\n"
+        "$all = config_get_path('installedpackages', array());\n"
+        "foreach (array_keys($all) as $k) {\n"
+        "  if (strpos((string) $k, 'pfblockerng') === 0) { $found = TRUE; break; }\n"
+        "}"
+    )
+    val = h._php_read_scalar(vm, pre, "$found ? 'yes' : 'no'", timeout=timeout)
+    return val == "yes"
+
+
+def _seed_user_vip(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None:
+    """Inject a minimal user VIP row (descr-only sentinel; no real subnet needed)."""
+    snippet = (
+        "$vips = config_get_path('virtualip/vip', array());\n"
+        "$found = FALSE;\n"
+        f"foreach ($vips as $v) {{\n"
+        f"  if (($v['descr'] ?? '') === {h._php_str(descr)}) {{ $found = TRUE; break; }}\n"
+        "}\n"
+        "if (!$found) {\n"
+        "  $vips[] = array(\n"
+        f"    'descr' => {h._php_str(descr)},\n"
+        "    'mode' => 'ipalias',\n"
+        "    'interface' => 'lo0',\n"
+        "    'type' => 'single',\n"
+        "    'subnet' => '127.0.0.200',\n"
+        "    'subnet_bits' => '32',\n"
+        "    'uniqid' => 'pfbusrvip',\n"
+        "  );\n"
+        "  config_set_path('virtualip/vip', $vips);\n"
+        "  write_config('pfBlockerNG smoke: seed user VIP');\n"
+        "}\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_seed_user_vip({descr!r}) failed: {result.returncode} {result.stderr!r}")
+
+
+def _seed_user_nat(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None:
+    """Inject a minimal user NAT rule row (descr-only sentinel; no real rule needed)."""
+    snippet = (
+        "$rules = config_get_path('nat/rule', array());\n"
+        "$found = FALSE;\n"
+        f"foreach ($rules as $r) {{\n"
+        f"  if (($r['descr'] ?? '') === {h._php_str(descr)}) {{ $found = TRUE; break; }}\n"
+        "}\n"
+        "if (!$found) {\n"
+        "  $rules[] = array(\n"
+        f"    'descr' => {h._php_str(descr)},\n"
+        "    'interface' => 'lo0',\n"
+        "    'protocol' => 'tcp',\n"
+        "    'destination' => array('any' => TRUE),\n"
+        "    'target' => '127.0.0.200',\n"
+        "    'created' => array('time' => '0'),\n"
+        "    'updated' => array('time' => '0'),\n"
+        "  );\n"
+        "  config_set_path('nat/rule', $rules);\n"
+        "  write_config('pfBlockerNG smoke: seed user NAT');\n"
+        "}\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_seed_user_nat({descr!r}) failed: {result.returncode} {result.stderr!r}")
+
+
+def _seed_orphan_vip(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None:
+    """Inject an orphan VIP: carries the pfBlockerNG marker but pfb_dnsvip4 is cleared.
+
+    The VIP double-guard in pfb_manage_dnsbl_vip checks that the VIP's subnet ==
+    the address stored in pfb_dnsvip4/pfb_dnsvip6. With pfb_dnsvip4 cleared the
+    guard would SKIP this entry, making it a genuine orphan that only the ADR-35
+    marker sweep can catch. The sweep reads descr only — so the orphan IS swept
+    despite the double-guard miss.
+    """
+    snippet = (
+        # 1. Clear the pfb_dnsvip4 reference so the double-guard cannot match.
+        f"$d = config_get_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, array());\n"
+        "unset($d['pfb_dnsvip4']);\n"
+        f"config_set_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, $d);\n"
+        # 2. Inject the orphan VIP with the pfBlockerNG marker.
+        "$vips = config_get_path('virtualip/vip', array());\n"
+        "$found = FALSE;\n"
+        f"foreach ($vips as $v) {{\n"
+        f"  if (($v['descr'] ?? '') === {h._php_str(descr)}) {{ $found = TRUE; break; }}\n"
+        "}\n"
+        "if (!$found) {\n"
+        "  $vips[] = array(\n"
+        f"    'descr' => {h._php_str(descr)},\n"
+        "    'mode' => 'ipalias',\n"
+        "    'interface' => 'lo0',\n"
+        "    'type' => 'single',\n"
+        "    'subnet' => '10.10.10.99',\n"
+        "    'subnet_bits' => '32',\n"
+        "    'uniqid' => 'pfborphanvip',\n"
+        "  );\n"
+        "  config_set_path('virtualip/vip', $vips);\n"
+        "}\n"
+        "write_config('pfBlockerNG smoke: seed orphan VIP');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_seed_orphan_vip({descr!r}) failed: {result.returncode} {result.stderr!r}")
+
+
+def _pkg_delete(vm: SmokeVM, *, timeout: float = 300.0) -> None:
+    """Uninstall the package via ``pkg delete`` (triggers pre-deinstall sweep)."""
+    vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "delete", "-y", _PKG_NAME, timeout=timeout)
+
+
+# --------------------------------------------------------------------------- #
+# Scenario A — enable → VIP + NAT present in config.xml
+# --------------------------------------------------------------------------- #
+
+
+def test_fwobj_enable_creates_vip_and_nat(deployed_vm: SmokeVM) -> None:
+    """ADR-35 Scenario A: enabling DNSBL with pfb_dnsvip_auto creates pfB-owned objects.
+
+    Scenario: enable creates pfB-owned VIP and DNSBL NAT.
+      Background: pfBlockerNG installed; auto-VIP feature enabled.
+
+      Given pfb_dnsvip_auto is OFF and DNSBL is disabled,
+        Then pfB_AUTO_VIP_v4 is absent from virtualip/vip[] (before-state).
+        And no nat/rule[] entry has a 'pfB DNSBL' descr prefix (before-state).
+
+      When pfb_dnsvip_auto is toggled ON and DNSBL is enabled, then a full reload runs,
+
+      Then virtualip/vip[] contains an entry with descr='pfB_AUTO_VIP_v4'.
+        And nat/rule[] contains an entry whose descr starts with 'pfB DNSBL'.
+    """
+    vm = deployed_vm
+    try:
+        # GIVEN — disable DNSBL, auto-VIP off; assert the before-state.
+        h.set_dnsvip_auto(vm, False)
+        h.set_dnsbl_enabled(vm, False)
+        h.reload(vm, "update")
+
+        assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+            "pfB_AUTO_VIP_v4 present before enable — before-state is not clean"
+        )
+        assert not _nat_pfb_dnsbl_present(vm), "pfB DNSBL NAT rule present before enable — before-state is not clean"
+
+        # WHEN — enable auto-VIP + DNSBL, run a full reload.
+        h.set_dnsvip_auto(vm, True)
+        h.set_dnsbl_enabled(vm, True)
+        h.reload(vm, "update")
+
+        # THEN — both owned objects must now be present.
+        assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+            "pfB_AUTO_VIP_v4 not created in virtualip/vip after enabling DNSBL + auto-VIP"
+        )
+        assert _nat_pfb_dnsbl_present(vm), "pfB DNSBL NAT rule not created in nat/rule after enabling DNSBL"
+    finally:
+        # Restore to a known baseline so Scenario B and C start clean.
+        h.set_dnsvip_auto(vm, False)
+        h.set_dnsbl_enabled(vm, False)
+        h.ensure_dnsbl_vip(vm)
+        h.reload(vm, "update")
+
+
+# --------------------------------------------------------------------------- #
+# Scenario B — disable → VIP + NAT removed from config.xml
+# --------------------------------------------------------------------------- #
+
+
+def test_fwobj_disable_removes_vip_and_nat(deployed_vm: SmokeVM) -> None:
+    """ADR-35 Scenario B: disabling DNSBL removes pfB-owned VIP and DNSBL NAT.
+
+    Scenario: disable removes pfB-owned VIP and DNSBL NAT.
+
+      Given DNSBL is enabled with pfb_dnsvip_auto ON (auto-VIP in config.xml),
+        And pfB_AUTO_VIP_v4 is present in virtualip/vip[] (before-state),
+        And a pfB DNSBL NAT entry is present in nat/rule[] (before-state),
+
+      When DNSBL is disabled and a full reload runs,
+
+      Then virtualip/vip[] has NO entry with a pfB-owned marker.
+        And nat/rule[] has NO entry whose descr starts with 'pfB DNSBL'.
+    """
+    vm = deployed_vm
+    try:
+        # GIVEN — enable auto-VIP + DNSBL; assert both objects present (before-state).
+        h.set_dnsvip_auto(vm, True)
+        h.set_dnsbl_enabled(vm, True)
+        h.reload(vm, "update")
+
+        assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+            "pfB_AUTO_VIP_v4 absent before disable — before-state setup failed"
+        )
+        assert _nat_pfb_dnsbl_present(vm), "pfB DNSBL NAT absent before disable — before-state setup failed"
+
+        # WHEN — disable DNSBL and reload.
+        h.set_dnsbl_enabled(vm, False)
+        h.reload(vm, "update")
+
+        # THEN — both must be gone.
+        assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+            "pfB_AUTO_VIP_v4 still present in config.xml after disabling DNSBL"
+        )
+        assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V6), (
+            "pfB_AUTO_VIP_v6 still present in config.xml after disabling DNSBL"
+        )
+        assert not _nat_pfb_dnsbl_present(vm), "pfB DNSBL NAT still present in nat/rule after disabling DNSBL"
+    finally:
+        h.set_dnsvip_auto(vm, False)
+        h.set_dnsbl_enabled(vm, False)
+        h.ensure_dnsbl_vip(vm)
+        h.reload(vm, "update")
+
+
+# --------------------------------------------------------------------------- #
+# Scenario C — orphan + user objects on uninstall
+# --------------------------------------------------------------------------- #
+
+
+def test_fwobj_uninstall_sweeps_orphan_preserves_user_objects(deployed_vm: SmokeVM) -> None:
+    """ADR-35 Scenario C: uninstall sweeps the orphan VIP; user VIP and NAT survive.
+
+    Scenario: uninstall sweeps orphan, preserves user objects.
+
+      Given an ORPHAN VIP (descr='pfB_AUTO_VIP_v4', pfb_dnsvip4 cleared so
+            the double-guard cannot match it) is present in virtualip/vip[],
+        And a USER VIP (descr='my-test-user-vip-do-not-delete') is present,
+        And a USER NAT rule (descr='my-test-user-nat-do-not-delete') is present,
+        And all three are confirmed in config.xml (before-state asserted),
+
+      When pfBlockerNG is uninstalled via 'pkg delete',
+
+      Then the orphan VIP is GONE from virtualip/vip[] (swept by ADR-35 deinstall sweep).
+        And the user VIP is STILL PRESENT in virtualip/vip[] (not a pfB marker).
+        And the user NAT rule is STILL PRESENT in nat/rule[] (not a pfB marker).
+        And installedpackages/pfblockerng* sections are GONE from config.xml.
+    """
+    vm = deployed_vm
+
+    # GIVEN — seed the three objects; first confirm DNSBL is disabled / clean.
+    h.set_dnsbl_enabled(vm, False)
+    h.set_dnsvip_auto(vm, False)
+    h.reload(vm, "update")
+
+    # Seed the orphan VIP (pfB marker, but pfb_dnsvip4 cleared so the double-guard
+    # in pfb_manage_dnsbl_vip would skip it — only the ADR-35 sweep catches it).
+    _seed_orphan_vip(vm, _AUTO_VIP_DESCR_V4)
+
+    # Seed user objects (no pfB marker — must survive uninstall).
+    _seed_user_vip(vm, _USER_VIP_DESCR)
+    _seed_user_nat(vm, _USER_NAT_DESCR)
+
+    # BEFORE-STATE: assert all three are present.
+    assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+        "orphan VIP (pfB_AUTO_VIP_v4) not present before uninstall — seeding failed"
+    )
+    assert _vip_descr_present(vm, _USER_VIP_DESCR), "user VIP not present before uninstall — seeding failed"
+
+    # Check user NAT is present.
+    pre = (
+        "$found = FALSE;\n"
+        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+        f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
+        "}"
+    )
+    user_nat_before = h._php_read_scalar(vm, pre, "$found ? 'yes' : 'no'")
+    assert user_nat_before == "yes", "user NAT rule not present before uninstall — seeding failed"
+
+    # Assert installedpackages/pfblockerng* sections exist before uninstall.
+    assert _pfb_sections_present(vm), "installedpackages/pfblockerng* absent before uninstall — unexpected clean state"
+
+    # WHEN — uninstall pfBlockerNG (triggers pfblockerng_php_pre_deinstall_command ->
+    # pfb_fwobj_sweep before pfb_remove_config_settings).
+    _pkg_delete(vm)
+
+    # THEN — read config.xml state after uninstall.
+    # The orphan VIP must be swept by the ADR-35 marker sweep.
+    assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+        "orphan pfB_AUTO_VIP_v4 still present after uninstall — ADR-35 sweep did not run"
+    )
+
+    # User VIP must survive (not a pfB marker — never swept).
+    assert _vip_descr_present(vm, _USER_VIP_DESCR), (
+        "user VIP was DELETED during uninstall — ADR-35 sweep incorrectly removed a user object"
+    )
+
+    # User NAT rule must survive.
+    post_nat = (
+        "$found = FALSE;\n"
+        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+        f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
+        "}"
+    )
+    user_nat_after = h._php_read_scalar(vm, post_nat, "$found ? 'yes' : 'no'")
+    assert user_nat_after == "yes", (
+        "user NAT rule was DELETED during uninstall — ADR-35 sweep incorrectly removed a user object"
+    )
+
+    # pfBlockerNG config sections must be gone.
+    assert not _pfb_sections_present(vm), (
+        "installedpackages/pfblockerng* still present after uninstall — pfb_remove_config_settings did not run"
+    )


### PR DESCRIPTION
## ADR-35: Unify ownership + teardown of pfBlockerNG-managed firewall objects

Introduces a small shared ownership-and-teardown layer for the firewall objects pfBlockerNG writes into the pfSense-core `config.xml` sections (`virtualip/vip`, `nat/rule`, `filter/rule`), and retrofits the existing VIP + DNSBL-NAT management onto it **without changing any persisted marker string or observable behaviour**. It closes the one genuinely missing guarantee — a marker-based defensive sweep on disable and on uninstall — and exposes a registration seam that ADR-36 / ADR-37 plug into.

This is a **refactor + hardening**, not a rewrite: functions + constants in one new include, no class hierarchy.

### What changes

- **New `pfblockerng_fwobj.inc`** — pure helpers `pfb_fwobj_is_owned` / `find` / `remove` / `sweep` / `register` / `reconcile`, plus the recognised-marker constants. No shell, no `write_config` inside the helpers (the caller flushes, mirroring the `PfbConfig` contract). Marker recognition is the **union** of the new `pfB_` prefix and the exact legacy strings (`pfB_AUTO_VIP_v4/v6`, `pfB DNSBL`, `pfB DNSBL - DO NOT EDIT`) — legacy strings matched verbatim, never rewritten (ADR-28 storage freeze).
- **Retrofit (behaviour-preserving)** — `pfb_find_marked_vip()` / `pfb_manage_dnsbl_vip()` and `pfb_create_dnsbl()`'s NAT add/strip now route through the shared find/remove with the **same** markers and the **same** VIP IP double-guard. Pinned identical by the Phase-1 golden suite.
- **Deinstall + disable marker sweep (NEW)** — `pfb_fwobj_sweep()` runs in `pfblockerng_php_pre_deinstall_command()` **before** `pfb_remove_config_settings()` (and on disable), removing every owned object by marker — even an orphan the lifecycle missed (e.g. a VIP whose `pfb_dnsvip4` reference was already cleared). Idempotent; a no-op (no `write_config`) on a clean config. This closes the concrete uninstall gap in §1.
- **Registration seam** — the VIP (v4/v6) and DNSBL NAT are expressed as the first `pfb_fwobj_register()` specs, demonstrating the pattern ADR-36/37 reuse.

### Safety invariant

A removal/sweep **only ever** deletes an object whose `descr` carries a pfBlockerNG marker. User objects (no marker) are never created, modified, or deleted — asserted by tests that seed sibling user VIP/NAT/filter rows and prove they survive.

### Tests

- **PHPUnit (off-appliance, in this PR's CI):** `FwobjCurrentBehaviourTest` (Phase-1 golden oracle pinning today's VIP/NAT behaviour, incl. the double-guard and user-row survival), `FwobjLayerTest` (the pure layer: is_owned truth table, find/remove with and without guard, sweep, register/reconcile), `FwobjSweepSeamTest` (orphan swept when the double-guard reference is cleared, user objects survive, clean-config sweep is a no-op, register+reconcile). All green (1172 tests).
- **Live-VM smoke (ADR-04, dispatch-only):** `tests/smoke/test_smoke_fwobj.py` — enable → VIP + NAT present; disable → removed; seed an orphan + user VIP/NAT, uninstall → orphan swept, user objects survive, `installedpackages/pfblockerng*` gone.

### Status

`Implemented — pending live-VM smoke`. The off-box suite is green; the live-VM smoke fan-out (the authoritative acceptance gate) is dispatched separately and flips the ADR to **Accepted** when green.

### Follow-up (cross-repo, tracked)

`pfblockerng_fwobj.inc` needs a `pkg-plist` entry on `pfBlockerNG/FreeBSD-ports@pfblockerng/use-github` before the `.pkg` build (smoke/release) — sibling `.inc` files are listed there, not in this repo's `pfblockerng.xml`. PR CI does not build the `.pkg`, so it stays green here.

Full design: `.ADRs/ADR_35_Managed_Firewall_Objects/ADR.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed ownership tracking for automatically created virtual IPs and NAT rules, so only pfBlockerNG-owned entries are managed.
  * Improved teardown behavior: orphaned objects are cleaned up automatically during disable and uninstall while preserving user-created VIPs/NAT rules.
* **Bug Fixes**
  * Refined disable/disable-rebuild logic to correctly identify and remove only the intended DNSBL-related VIP/NAT objects (with safer scoping).
* **Documentation**
  * Updated architecture notes for managed firewall object ownership and teardown semantics.
* **Tests**
  * Added/expanded unit, integration, and live-VM smoke coverage; live-VM validation is still being finalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->