### PR TITLE
pfblockerng: route pfb_reuse uncheck through the enum adapter

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14107,8 +14107,14 @@ function sync_package_pfblockerng($cron='') {
 	#################################
 
 	// Uncheck reusing existing downloads check box
-	if (!$pfb['save'] && $pfb['enable'] == 'on' && $pfb['config']['pfb_reuse'] == 'on') {
-		$pfb_config['installedpackages']['pfblockerng']['config'][0]['pfb_reuse'] = '';
+	if (!$pfb['save'] && $pfb['enable'] == 'on' &&
+	    pfb_cfg_toggle_read($pfb['config']['pfb_reuse']) === PfbToggle::On) {
+		// Stage the off-value via the ADR-28 write adapter (legacy stored '')
+		// rather than a hardcoded literal. This is a deferred staged-merge write:
+		// it rides $pfb_config through the config_read_file() + array_replace_recursive()
+		// merge below, NOT PfbConfig::write() — whose immediate config_set_path() the
+		// reload on the save path would discard.
+		$pfb_config['installedpackages']['pfblockerng']['config'][0]['pfb_reuse'] = pfb_cfg_toggle_write(PfbToggle::Off);
 		$pfb['conf_mod'] = TRUE;
 	}
 


### PR DESCRIPTION
## Summary

Follow-up from a thorough review of the ADR-28/29 enum (string/boolean → enum) adoption.

The review confirmed the enum work is sound: the one genuine regression — a `TypeError` when writing a raw string to an adapted field — was already fixed in `98500b3`. This PR cleans up the **only residual smell** found: a config-gateway bypass.

## The change

`pfblockerng.inc` — the Force-Reload save path cleared the registered `pfb_reuse` key with a hardcoded `''` literal and a raw `== 'on'` read, bypassing the ADR-28 adapter layer (the enforcement sniff doesn't catch it because it's a direct array mutation, not a `config_*_path` call). Now:

- read via `pfb_cfg_toggle_read(...) === PfbToggle::On` (the codebase idiom)
- off-value sourced from `pfb_cfg_toggle_write(PfbToggle::Off)`, tying it to the enum's legacy stored vocabulary

It intentionally **stays a deferred staged-merge array write** (it rides `$pfb_config` through the `config_read_file()` + `array_replace_recursive()` merge on the save path) rather than `PfbConfig::write()` — whose immediate `config_set_path()` the reload on that path would discard. The reasoning is captured in an inline comment.

## Verification

- `php -l` clean, PHPCS clean (gateway sniff passes), PHPUnit 1174 tests green.
- No behaviour change: `pfb_reuse` still stores the legacy `''` (off) value byte-identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJJgguTZVDCa3B9BaweT97)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration system for the pfb_reuse setting to use an improved framework for reading and writing configuration values. This modernization aligns configuration handling with current system standards and improves consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->