### PR TITLE
pfblockerng: route the update save through PfbConfig (Class B)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10347,7 +10347,6 @@ function sync_package_pfblockerng($cron='') {
 	global $g, $pfb, $pfbarr;
 	pfb_global();
 
-	$pfb['conf_mod']		= FALSE;	// Flag to check for mods to the config.xml file. ('$pfb_config' array to hold changes)
 	$pfb['filter_configure']	= FALSE;	// Flag to call filter_configure once
 
 	// ADR-12 Phase 6: TWO pass-scoped accumulators of the names UPDATED this pass,
@@ -14106,25 +14105,21 @@ function sync_package_pfblockerng($cron='') {
 	#	SAVE CONFIGURATION	#
 	#################################
 
-	// Uncheck reusing existing downloads check box
+	// Uncheck the "reuse existing downloads" flag — this update consumed the request,
+	// so clear the one-shot. It is the only setting pfBlockerNG persists on the way out
+	// of the update, so the save is gated directly on it (no staging array needed).
 	if (!$pfb['save'] && $pfb['enable'] == 'on' &&
 	    pfb_cfg_toggle_read($pfb['config']['pfb_reuse']) === PfbToggle::On) {
-		// Stage the off-value via the ADR-28 write adapter (legacy stored '')
-		// rather than a hardcoded literal. This is a deferred staged-merge write:
-		// it rides $pfb_config through the config_read_file() + array_replace_recursive()
-		// merge below, NOT PfbConfig::write() — whose immediate config_set_path() the
-		// reload on the save path would discard.
-		$pfb_config['installedpackages']['pfblockerng']['config'][0]['pfb_reuse'] = pfb_cfg_toggle_write(PfbToggle::Off);
-		$pfb['conf_mod'] = TRUE;
-	}
 
-	// Only save config.xml, if changes are found.
-	if ($pfb['conf_mod'] && isset($pfb_config)) {
 		pfb_logger("\nSaving config changes", 1);
 
-		// Reload config.xml to get any recent changes and merge/save changes.
+		// Reload config.xml FIRST to pick up edits made concurrently during this
+		// (long-running) update, THEN clear the flag through the gateway so the write
+		// lands on the freshly-reloaded config. Writing before the reload would be
+		// discarded by it; a single registered-key write needs no whole-config
+		// array_replace_recursive() merge. ADR-29: registered key -> PfbConfig.
 		config_read_file(FALSE, TRUE);
-		config_set_path('', array_replace_recursive(config_get_path(''), $pfb_config));
+		PfbConfig::write('pfb_reuse', PfbToggle::Off);
 		write_config('pfBlockerNG: save settings');
 
 		pfb_logger("... completed", 1);


### PR DESCRIPTION
## Summary

Follow-up to the enum-adoption review (see #463). That review classified the `config_read_file()` call sites; this PR addresses the one routable case — **Class B, the end-of-update save**.

## Background

The save block at the tail of `sync_package_pfblockerng()` staged a single delta into a `$pfb_config` array and persisted it via:

```php
config_read_file(FALSE, TRUE);
config_set_path('', array_replace_recursive(config_get_path(''), $pfb_config));
write_config(...);
```

Investigation found `$pfb_config` carried **exactly one key** — `pfb_reuse` — and `$pfb['conf_mod']` had **exactly one setter** (that same branch). The whole staging + whole-config `array_replace_recursive` apparatus existed to persist one boolean unset of a registered key.

## Change

Collapse it to a single gateway write:

```php
config_read_file(FALSE, TRUE);                 // pick up concurrent edits first
PfbConfig::write('pfb_reuse', PfbToggle::Off);  // lands on the fresh config
write_config(...);
```

- **Reload-before-write ordering preserved** — the write must follow the reload (an earlier write would be discarded by it). This is the concurrency safety the original pattern provided.
- A single registered-key write needs no whole-config `array_replace_recursive()` merge.
- Drops the now-dead `$pfb_config` staging array and the `conf_mod` flag (incl. its initializer).
- ADR-29: the registered `pfb_reuse` key now flows through `PfbConfig` instead of a raw array mutation.

**Behaviour-preserving:** same gate condition, same reload-then-write ordering, same stored `''` (off) value persisted.

## Relationship to #463

This supersedes #463's hunk in the same block (#463 was the minimal adapter-only cleanup; this is the structural routing that needed more scrutiny). The net diff vs `devel` reads as one clean change. If #463 merges first, this rebases cleanly (the #463 patch collapses as already-applied).

## Verification

- `php -l` clean, PHPCS clean (the `RequireConfigGateway` sniff is now satisfied — the raw array write is gone), PHPUnit 1174 tests green.
- The save-block runtime ordering is **live-VM territory (ADR-04)**, not unit-testable; the gateway round-trip (`pfb_reuse` → `''`) is already pinned in `CfgGatewayTest`. Recommend an ADR-04 smoke run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJJgguTZVDCa3B9BaweT97)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal configuration handling logic to improve system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->