### PR TITLE
Revert #462 — ipv6 Unbound teardown/diagnostics (did not fix the cascade)

### DIFF
--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -65,16 +65,12 @@ echo "==> Copying $(basename "$PKGFILE") to ${SSH_TARGET}:${REMOTE}"
 # shellcheck disable=SC2086
 scp ${SCP_OPTS} "$PKGFILE" "${SSH_TARGET}:${REMOTE}"
 
-# `pkg add -f` of a LOCAL file resolves RUN_DEPENDS from the LOCAL pkg db — it
-# does not reach the repos when the deps are already installed. The smoke image
-# bakes pfBlockerNG's RUN_DEPENDS (convention), so this runs offline and then
-# executes the package's POST-INSTALL hooks. A "Missing dependency" error here =
-# bad image. The -f (force) flag reinstalls even when the same version is already
-# present, ensuring POST-INSTALL re-runs on every deploy; without it a repeat
-# deploy is a silent no-op ("already installed") and POST-INSTALL never reruns,
-# leaving Unbound in whatever state the previous module left it.
-echo "==> pkg add -f ${REMOTE} (deps pre-baked; offline; -f forces POST-INSTALL)"
-ssh_t "env ASSUME_ALWAYS_YES=yes pkg add -f '${REMOTE}'"
+# `pkg add` of a LOCAL file resolves RUN_DEPENDS from the LOCAL pkg db — it does
+# not reach the repos when the deps are already installed. The smoke image bakes
+# pfBlockerNG's RUN_DEPENDS (convention), so this runs offline and then executes
+# the package's POST-INSTALL hooks. A "Missing dependency" error here = bad image.
+echo "==> pkg add ${REMOTE} (deps pre-baked; offline)"
+ssh_t "env ASSUME_ALWAYS_YES=yes pkg add '${REMOTE}'"
 
 # POST-INSTALL restarts Unbound asynchronously; wait for it before the caller
 # queries the resolver (see feedback: poll the real readiness signal).
@@ -84,14 +80,6 @@ until ssh_t '/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status
     i=$((i + 1))
     if [ "$i" -ge 30 ]; then
         echo "install-pkg: Unbound did not become ready after install" >&2
-        echo "---- diagnostics: unbound-checkconf ----" >&2
-        ssh_t '/usr/local/sbin/unbound-checkconf /var/unbound/unbound.conf 2>&1 | tail -n 40' >&2 || true
-        echo "---- diagnostics: unbound-control status ----" >&2
-        ssh_t '/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status 2>&1 | tail -n 20' >&2 || true
-        echo "---- diagnostics: resolver.log tail ----" >&2
-        ssh_t 'tail -n 40 /var/log/resolver.log 2>&1' >&2 || true
-        echo "---- diagnostics: unbound process ----" >&2
-        ssh_t 'ps auxww | grep -i "[u]nbound" 2>&1' >&2 || true
         exit 1
     fi
     sleep 2

--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -65,18 +65,16 @@ echo "==> Copying $(basename "$PKGFILE") to ${SSH_TARGET}:${REMOTE}"
 # shellcheck disable=SC2086
 scp ${SCP_OPTS} "$PKGFILE" "${SSH_TARGET}:${REMOTE}"
 
-# `pkg add` of a LOCAL file resolves RUN_DEPENDS from the LOCAL pkg db — it does
-# not reach the repos when the deps are already installed. The smoke image bakes
-# pfBlockerNG's RUN_DEPENDS (convention), so this runs offline and then executes
-# the package's POST-INSTALL hooks. A "Missing dependency" error here = bad image.
-# Do NOT add -f to force a same-version reinstall: a forced reinstall mid-suite
-# disrupts the chroot copy of pfb_unbound.py that Unbound's python module loads,
-# so unbound-checkconf then fails ("pythonmod: can't open file pfb_unbound.py")
-# and the resolver won't start. Keeping a same-version redeploy a no-op leaves the
-# working chroot intact; per-module Unbound recovery is the test teardown's job
-# (see tests/smoke/helpers.py::reconfigure_unbound).
-echo "==> pkg add ${REMOTE} (deps pre-baked; offline)"
-ssh_t "env ASSUME_ALWAYS_YES=yes pkg add '${REMOTE}'"
+# `pkg add -f` of a LOCAL file resolves RUN_DEPENDS from the LOCAL pkg db — it
+# does not reach the repos when the deps are already installed. The smoke image
+# bakes pfBlockerNG's RUN_DEPENDS (convention), so this runs offline and then
+# executes the package's POST-INSTALL hooks. A "Missing dependency" error here =
+# bad image. The -f (force) flag reinstalls even when the same version is already
+# present, ensuring POST-INSTALL re-runs on every deploy; without it a repeat
+# deploy is a silent no-op ("already installed") and POST-INSTALL never reruns,
+# leaving Unbound in whatever state the previous module left it.
+echo "==> pkg add -f ${REMOTE} (deps pre-baked; offline; -f forces POST-INSTALL)"
+ssh_t "env ASSUME_ALWAYS_YES=yes pkg add -f '${REMOTE}'"
 
 # POST-INSTALL restarts Unbound asynchronously; wait for it before the caller
 # queries the resolver (see feedback: poll the real readiness signal).

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2267,21 +2267,6 @@ def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 30, delay: float = 2.0) -
     raise RuntimeError("Unbound did not become ready after reload")
 
 
-def reconfigure_unbound(vm: SmokeVM, *, timeout: float = 120.0) -> None:
-    """Regenerate the Unbound config + restart it, then wait until it is ready.
-
-    Runs ``services_unbound_configure()`` in the fully-bootstrapped pfSense env
-    via pfSsh.php (it stops Unbound, regenerates the config, and starts it), then
-    polls readiness. Used by module teardowns that mutate interface/gateway state
-    to guarantee the box is left with a live resolver for sibling modules.
-    """
-    snippet = "require_once('interfaces.inc');\nservices_unbound_configure();\necho 'OK';"
-    result = php_eval(vm, snippet, timeout=timeout)
-    if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(f"reconfigure_unbound failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
-    wait_unbound_ready(vm)
-
-
 # --------------------------------------------------------------------------- #
 # ADR-10 zero-downtime swap — no-restart readiness + invariants
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2275,13 +2275,9 @@ def reconfigure_unbound(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     polls readiness. Used by module teardowns that mutate interface/gateway state
     to guarantee the box is left with a live resolver for sibling modules.
     """
-    # Capture the function's return value (0 == success) rather than an unconditional
-    # sentinel: a non-zero return must fail the reconfigure even when no PHP fatal fired.
-    # intval() maps a void/null return (some pfSense versions return nothing) to 0 == success;
-    # wait_unbound_ready() below is the authoritative functional gate either way.
-    snippet = "require_once('interfaces.inc');\n$rv = services_unbound_configure();\necho 'RECONFIG_RV=' . intval($rv);"
+    snippet = "require_once('interfaces.inc');\nservices_unbound_configure();\necho 'OK';"
     result = php_eval(vm, snippet, timeout=timeout)
-    if result.returncode != 0 or "RECONFIG_RV=0" not in result.stdout:
+    if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"reconfigure_unbound failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
     wait_unbound_ready(vm)
 

--- a/tests/smoke/test_smoke_ipv6_alerts.py
+++ b/tests/smoke/test_smoke_ipv6_alerts.py
@@ -97,13 +97,6 @@ def ipv6_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
                 )
                 if fb.returncode != 0:
                     print(f"WARNING: raw Unbound restart also failed: rc={fb.returncode} {fb.stderr!r} {fb.stdout!r}")
-                else:
-                    # Confirm the resolver is actually live before handing the box to the next
-                    # module — a clean exit code alone does not prove Unbound came back up.
-                    try:
-                        h.wait_unbound_ready(smoke_vm)
-                    except Exception as ready_exc:
-                        print(f"WARNING: raw restart completed but Unbound is not ready: {ready_exc!r}")
             except Exception as fb_exc:
                 print(f"WARNING: raw Unbound restart raised: {fb_exc!r}")
         h.collect_host_diagnostics(smoke_vm)

--- a/tests/smoke/test_smoke_ipv6_alerts.py
+++ b/tests/smoke/test_smoke_ipv6_alerts.py
@@ -64,41 +64,6 @@ def ipv6_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
     try:
         yield smoke_vm
     finally:
-        # Leave the box with a live resolver so sibling modules can deploy()
-        # successfully — services_unbound_configure() may have left Unbound
-        # stopped if the gateway-group resolution threw mid-regen (issue #361).
-        try:
-            h.reconfigure_unbound(smoke_vm)
-        except Exception as exc:
-            print(
-                f"WARNING: reconfigure_unbound failed in ipv6_vm teardown: {exc!r}; "
-                "attempting raw Unbound restart as fallback"
-            )
-            # Fallback: raw restart via /etc/rc.d — does not regenerate config
-            # but brings the daemon back up for the next module's deploy().
-            try:
-                bounce_cmd = (
-                    "kill -TERM $(cat /var/run/unbound.pid) 2>/dev/null || true\n"
-                    "for i in $(seq 1 30); do\n"
-                    "  pgrep -x unbound >/dev/null || break\n"
-                    "  sleep 1\n"
-                    "done\n"
-                    "/usr/local/sbin/unbound -c /var/unbound/unbound.conf\n"
-                )
-                import subprocess
-
-                fb = subprocess.run(
-                    smoke_vm.ssh_argv("/bin/sh"),
-                    input=bounce_cmd,
-                    capture_output=True,
-                    text=True,
-                    timeout=120.0,
-                    check=False,
-                )
-                if fb.returncode != 0:
-                    print(f"WARNING: raw Unbound restart also failed: rc={fb.returncode} {fb.stderr!r} {fb.stdout!r}")
-            except Exception as fb_exc:
-                print(f"WARNING: raw Unbound restart raised: {fb_exc!r}")
         h.collect_host_diagnostics(smoke_vm)
 
 


### PR DESCRIPTION
Reverts PR #462 in full — its three commits (`e9a5651`, `60f8bf3`, `9697c55`).

## Why

PR #462 was built on an incorrect diagnosis of the live-VM smoke readiness cascade and **did not fix it**. Validation runs #182 and #183 (on `devel`, with the build unblocked) reproduce the same failure — `pythonmod: can't open file pfb_unbound.py` → Unbound won't start → ~31 downstream errors — with plain `pkg add` and with `reconfigure_unbound` succeeding. So:

- The `ipv6_vm` teardown `reconfigure_unbound`/fallback does not prevent the cascade (proven across both runs).
- The `pkg add -f` → `pkg add` flip was chasing a red herring (the pythonmod error occurs without `-f`).

This restores the three touched files (`scripts/install-pkg.sh`, `tests/smoke/helpers.py`, `tests/smoke/test_smoke_ipv6_alerts.py`) to their pre-#462 state so the next investigation starts from a clean baseline. The real cause (chroot staging of `pfb_unbound.py`) is captured in a handoff document for a fresh investigation; issue #461 (an unrelated, intermittent core `get_interfaces_with_gateway` TypeError) remains open and separate.

No production (`src/`) code is touched — harness/CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TF2uW8hio45YxKwVeAWHYW)_