### PR TITLE
pfblockerng: skip malformed interface nodes in pfb_collect_localip (#461)

### DIFF
--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -80,6 +80,8 @@ until ssh_t '/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status
     i=$((i + 1))
     if [ "$i" -ge 30 ]; then
         echo "install-pkg: Unbound did not become ready after install" >&2
+        echo "==> Unbound readiness diagnostics (resolver did not come up):" >&2
+        ssh_t 'echo "---- unbound-checkconf ----"; /usr/local/sbin/unbound-checkconf /var/unbound/unbound.conf 2>&1; echo "---- unbound-control status ----"; /usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status 2>&1; echo "---- ls -la /var/unbound ----"; ls -la /var/unbound 2>&1; echo "---- unbound.conf python block ----"; grep -nE "python|module-config" /var/unbound/unbound.conf 2>&1; echo "---- config unbound/python flag ----"; /usr/local/sbin/read_xml_tag.sh string unbound/python 2>&1; /usr/local/sbin/read_xml_tag.sh string unbound/python_script 2>&1; echo "---- resolver.log tail ----"; tail -n 40 /var/log/resolver.log 2>&1; echo "---- unbound processes ----"; ps auxww | grep -i "[u]nbound" 2>&1' >&2 || true
         exit 1
     fi
     sleep 2

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8560,11 +8560,25 @@ function pfb_local_ip($subnet, $pfb_localsub) {
 function pfb_collect_localip() {
 	$pfb_local = $pfb_localsub = array();
 
-	// Collect gateway IP addresses for inbound/outbound list matching
-	$int_gateway = get_interfaces_with_gateway();
-	if (isset($int_gateway)) {
-		foreach ($int_gateway as $gateway) {
-			$pfb_local[] = get_interface_ip($gateway) ?: 'Disabled';
+	// Collect gateway IP addresses for inbound/outbound list matching.
+	// Enumerate interfaces locally rather than calling core get_interfaces_with_gateway():
+	// pfSense's XML parser stores an EMPTY interface element (e.g. <lan></lan>) as an empty
+	// STRING, not an array, and core dereferences $ifcfg['ipaddr'] on every node -- a fatal
+	// "Cannot access offset of type string on string" under PHP 8. Skip any non-array node so
+	// a malformed/empty interface cannot abort the whole walk; behaviour is otherwise identical
+	// to core for well-formed configs (dynamic-WAN ipaddr types, ovpn/ipsec, or an explicit gateway).
+	foreach (config_get_path('interfaces', []) as $ifname => $ifcfg) {
+		if (!is_array($ifcfg)) {
+			continue;
+		}
+		$ipaddr = $ifcfg['ipaddr'] ?? '';
+		$if     = $ifcfg['if'] ?? '';
+		$has_gateway = in_array($ipaddr, array('dhcp', 'pppoe', 'pptp', 'l2tp', 'ppp'), TRUE)
+			|| substr($if, 0, 4) == 'ovpn'
+			|| substr($if, 0, 5) == 'ipsec'
+			|| !empty($ifcfg['gateway']);
+		if ($has_gateway) {
+			$pfb_local[] = get_interface_ip($ifname) ?: 'Disabled';
 		}
 	}
 
@@ -8613,6 +8627,9 @@ function pfb_collect_localip() {
 
 	// Collect all interface addresses for inbound/outbound list matching
 	foreach (config_get_path('interfaces', []) as $int) {
+		if (!is_array($int)) {
+			continue;
+		}
 		if ($int['ipaddr'] != 'dhcp') {
 			if (!empty($int['ipaddr']) && !empty($int['subnet']) && is_subnet("{$int['ipaddr']}/{$int['subnet']}")) {
 				if (is_ipaddrv4($int['ipaddr'])) {

--- a/tests/php/CollectLocalIpV6Test.php
+++ b/tests/php/CollectLocalIpV6Test.php
@@ -205,4 +205,58 @@ final class CollectLocalIpV6Test extends TestCase
 			)
 		);
 	}
+
+	// -------------------------------------------------------------------------
+	// Case D — #461 regression guard: empty-string interface node is skipped
+	// -------------------------------------------------------------------------
+
+	public function testEmptyStringInterfaceNodeIsSkippedWithoutFatal(): void
+	{
+		// Scenario: pfb_collect_localip() must not fatal when an interfaces config
+		//           entry is an empty string (pfSense parses <lan></lan> as "").
+		//
+		// Background:
+		//   pfSense's XML parser stores an EMPTY element (e.g. <opt1></opt1>) as the
+		//   empty string "" rather than an array. Core get_interfaces_with_gateway()
+		//   dereferences $ifcfg['ipaddr'] on every node without an array guard, which
+		//   throws "Cannot access offset of type string on string" under PHP 8 (#461).
+		//   The fix enumerates interfaces directly and skips any non-array node.
+		//
+		// Given  a config with a well-formed dynamic-WAN interface ('wan' => dhcp)
+		//        and a malformed empty-string node ('opt1' => '')
+		// When   pfb_collect_localip() runs
+		// Then   it does NOT fatal (reaching the asserts proves no exception)
+		//        AND the gateway interface's IP is collected into $pfb_local
+		//        AND the empty-string node is silently skipped (no error)
+
+		// Override the config for this specific test case.
+		$GLOBALS['config']['interfaces'] = [
+			'wan'  => ['if' => 'vtnet0', 'ipaddr' => 'dhcp'],
+			'lan'  => ['if' => 'vtnet1', 'ipaddr' => '192.168.1.1', 'subnet' => '24'],
+			'opt1' => '',
+		];
+		$GLOBALS['pfb_test_interface_ip'] = ['wan' => '203.0.113.5'];
+
+		// When: call the function under test (a fatal/TypeError would abort here)
+		[$pfb_local, ] = pfb_collect_localip();
+
+		// Then: the gateway WAN IP must appear in $pfb_local (keyed by IP value)
+		$this->assertArrayHasKey(
+			'203.0.113.5',
+			$pfb_local,
+			"The dynamic-WAN IP 203.0.113.5 must be collected into \$pfb_local "
+			. "even when an empty-string interface node ('opt1' => '') is present. "
+			. "pfb_local keys: " . implode(', ', array_keys($pfb_local))
+		);
+
+		// The empty-string 'opt1' node must not surface as an IP or cause a crash —
+		// reaching this line without a TypeError is the primary regression guard.
+		// (No explicit assertNotContains needed: the key '' cannot be a valid IP address,
+		// and reaching this assertion with $pfb_local populated proves the walk completed.)
+		$this->assertNotContains(
+			'',
+			array_keys($pfb_local),
+			"The empty-string 'opt1' node must not produce a '' key in \$pfb_local"
+		);
+	}
 }

--- a/tests/php/CollectLocalIpV6Test.php
+++ b/tests/php/CollectLocalIpV6Test.php
@@ -92,7 +92,6 @@ final class CollectLocalIpV6Test extends TestCase
 		];
 
 		// Seed the test-visible globals the doubles key on.
-		$GLOBALS['pfb_test_interfaces_with_gateway'] = [];
 		$GLOBALS['pfb_test_interface_ip']            = [];
 		$GLOBALS['pfb_test_configured_ipv6']         = ['lan' => self::LAN_IPV6_ADDR];
 		$GLOBALS['pfb_test_interface_subnetv6']      = ['lan' => (string) self::LAN_IPV6_BITS];
@@ -106,7 +105,6 @@ final class CollectLocalIpV6Test extends TestCase
 			unset($GLOBALS['config']);
 		}
 		unset(
-			$GLOBALS['pfb_test_interfaces_with_gateway'],
 			$GLOBALS['pfb_test_interface_ip'],
 			$GLOBALS['pfb_test_configured_ipv6'],
 			$GLOBALS['pfb_test_interface_subnetv6'],

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3206,6 +3206,11 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
         '/usr/bin/sockstat > "$D/sockstat.txt" 2>&1; /usr/bin/netstat -rn > "$D/netstat_rn.txt" 2>&1; '
         'cp /var/unbound/*.conf /var/unbound/*.ini "$D/unbound/" 2>/dev/null; '
         'cp /var/unbound/pfb_py_* "$D/unbound/" 2>/dev/null; '
+        # The chroot python script + its include — NOT matched by the globs above, yet
+        # central to a "pythonmod: can't open file" resolver failure, so capture them
+        # explicitly (their presence/absence is the ground truth for a staging desync).
+        'cp /var/unbound/pfb_unbound.py "$D/unbound/" 2>/dev/null; '
+        'cp /var/unbound/pfb_unbound_include.inc "$D/unbound/" 2>/dev/null; '
         # pfBlockerNG database (feeds / masterfiles / orig / deny / dnsbl / …) and
         # pfSense's pf alias-table files — the IP/domain state behind the rules.
         'tar czf "$D/var_db_pfblockerng.tgz" -C /var/db pfblockerng 2>/dev/null; '


### PR DESCRIPTION
## What

Fixes the live-VM smoke cascade by hardening `pfb_collect_localip()` against a malformed interface config node, and re-adds failure-moment resolver diagnostics to the smoke installer.

### `pfb_collect_localip()` — resilience to an empty interface element (#461)

pfSense parses an **empty** interface element (e.g. `<lan></lan>`) as an empty **string**, not an array. `pfb_collect_localip()` walked `interfaces` and dereferenced `$node['ipaddr']` on every entry — a fatal `TypeError: Cannot access offset of type string on string` under PHP 8 (CE 8.3 and Plus 8.5) whenever such a node exists. Because the function runs on every IP-list update, this crashed the update path and (via a sibling core crash in the same gateway-resolution family) left Unbound stopped, cascading into ~31 downstream smoke fixture timeouts.

The fix enumerates interfaces locally and **skips any non-array node** in both `interfaces` loops of the function. Behaviour is unchanged for well-formed configs (same dynamic-WAN / ovpn / ipsec / explicit-gateway selection core uses). Implements issue #461 option B (resilient local enumeration).

### `scripts/install-pkg.sh` — failure-moment diagnostics

When the installer times out waiting for the resolver, it now dumps `unbound-checkconf`, `unbound-control status`, `ls -la /var/unbound`, the `unbound.conf` python block, the config `unbound/python*` flags, the `resolver.log` tail, and the unbound process list before exiting — so a readiness failure is diagnosable from the job log instead of an opaque timeout.

## Tests

- New PHPUnit regression test `CollectLocalIpV6Test::testEmptyStringInterfaceNodeIsSkippedWithoutFatal` (empty-string node skipped, gateway IP still collected, no fatal).
- Full PHPUnit suite green (1211/1211); pytest, mypy, markdownlint, `sh -n`, PHPStan, PHPCS all clean.
- Live-VM smoke dispatched on this branch to confirm the cascade clears.

Closes #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TF2uW8hio45YxKwVeAWHYW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Unbound installation failure diagnostics with an added troubleshooting block that outputs resolver, configuration, filesystem/process, and recent log context before exiting.

* **Bug Fixes**
  * Prevented errors/crashes when interface configuration contains malformed or empty nodes in PHP 8 by skipping invalid entries during local IP collection.

* **Tests**
  * Added a regression test covering empty-string interface nodes and improved test setup/teardown to avoid relying on an extra test global.

* **Chores**
  * Improved smoke-test diagnostics bundling to ensure Unbound entrypoint/include files are always included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->