### PR TITLE
ci(smoke): silence ssh known-hosts warning in install-pkg.sh

### DIFF
--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -43,9 +43,9 @@ done
 # shellcheck disable=SC2015
 [ -n "$PKGFILE" ] && [ -f "$PKGFILE" ] || { echo "install-pkg: --pkg file not found: ${PKGFILE}" >&2; exit 1; }
 
-SSH_OPTS="-p ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+SSH_OPTS="-p ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 # scp uses -P (capital) for the port; -p means "preserve times" there.
-SCP_OPTS="-P ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+SCP_OPTS="-P ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
 if [ -n "$SSH_KEY" ]; then
     SSH_OPTS="-i ${SSH_KEY} ${SSH_OPTS}"
     SCP_OPTS="-i ${SSH_KEY} ${SCP_OPTS}"


### PR DESCRIPTION
## What

Add `-o LogLevel=ERROR` to `SSH_OPTS`/`SCP_OPTS` in `scripts/install-pkg.sh`.

## Why

Every `ssh`/`scp` connect in `install-pkg.sh` printed:

```
Warning: Permanently added '[127.0.0.1]:2222' (ED25519) to the list of known hosts.
```

at the default `INFO` log level. The Unbound-readiness loop alone connects up to 30 times, so this floods the smoke job log and the diagnostics dumps. `LogLevel=ERROR` suppresses the warning — matching the Python harness SSH options (`conftest.py`/`helpers.py`), which already set it. No behavioural change otherwise (`StrictHostKeyChecking=no` + `UserKnownHostsFile=/dev/null` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TF2uW8hio45YxKwVeAWHYW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package installation process with reduced output verbosity for a cleaner installation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->