### PR TITLE
ADR-38: Integrated syslog export of pfBlockerNG security events

### DIFF
--- a/.ADRs/ADR_38_System_Log_Integration/ADR.md
+++ b/.ADRs/ADR_38_System_Log_Integration/ADR.md
@@ -1,6 +1,6 @@
 # ADR-38: Integrated syslog export of pfBlockerNG security events
 
-- **Status:** **Proposed** (2026-06-20)
+- **Status:** **Implemented (pending smoke fan-out)** (2026-06-22)
 - **Date:** 2026-06-20
 - **Branch:** `adr/38-system-log-integration` (off `devel`; `{slug}` per CLAUDE.md "Branch naming")
 - **Component(s):**

--- a/.ADRs/ADR_38_System_Log_Integration/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_38_System_Log_Integration/RESULTS/01_Results.txt
@@ -1,0 +1,188 @@
+ADR-38 Phase 1 — Pure key=value syslog event formatters (COMPLETE)
+===================================================================
+
+Branch: adr/38-system-log-integration (canonical branch; no managed-remote pin override needed)
+
+------------------------------------------------------------------------
+FUNCTION SIGNATURES
+------------------------------------------------------------------------
+
+PHP (pfblockerng_extra.inc):
+  function pfb_syslog_format_ip(array $fields): string
+
+Python (pfb_unbound.py):
+  def syslog_format_dnsbl(
+      q_name: str,
+      q_ip: str,
+      q_type: str,
+      group: str,
+      feed: str,
+      b_type: str,
+      b_eval: str,
+  ) -> str
+
+Both functions are PURE (no globals, no I/O, no side effects) and DORMANT
+(uncalled from production code this phase).
+
+------------------------------------------------------------------------
+KEY VOCABULARY — IP body (pfb_syslog_format_ip)
+------------------------------------------------------------------------
+
+Fixed key order (14 keys):
+  act     — action:       'block' | 'pass' | 'match'
+  dir     — direction:    'in' | 'out'
+  if      — friendly interface name
+  proto   — protocol string (e.g. 'TCP', 'UDP', 'TCP-SA')
+  src     — source IP address
+  dst     — destination IP address
+  sport   — source port   (optional — omitted when empty)
+  dport   — destination port  (optional — omitted when empty)
+  ipver   — IP version:   '4' | '6'
+  geoip   — GeoIP ISO country code  (optional)
+  alias   — pfBlockerNG alias name  (optional)
+  feed    — feed name               (optional)
+  host    — resolved hostname       (optional)
+  asn     — ASN string              (optional)
+
+Required keys (always present): act, dir, if, proto, src, dst, ipver.
+
+------------------------------------------------------------------------
+KEY VOCABULARY — DNSBL body (syslog_format_dnsbl)
+------------------------------------------------------------------------
+
+Fixed key order (8 keys, 2 optional):
+  act     — always 'dnsbl' (identifies the event class)
+  qname   — queried domain name
+  qip     — client IP address
+  qtype   — DNS record type string (e.g. 'A', 'AAAA', 'CNAME')
+  group   — DNSBL group name  (optional — omitted when empty string)
+  feed    — feed name         (optional — omitted when empty string)
+  btype   — block type string (e.g. 'VIP', 'NULL', 'TLD', 'DNSBL', 'Python')
+  eval    — evaluated/matched value
+
+Required keys (always present): act, qname, qip, qtype, btype, eval.
+
+------------------------------------------------------------------------
+EMPTY-VALUE CONVENTION
+------------------------------------------------------------------------
+
+IP formatter:
+  - sport and dport are omitted when the value is the empty string.
+  - geoip, alias, feed, host, asn are omitted when the value is any of:
+    '' | 'Unknown' | 'Unk' | 'null'
+    These are the sentinel values the CSV pipeline emits when a field is
+    unavailable, matching the source exactly so the two cannot drift.
+
+DNSBL formatter:
+  - group and feed are omitted when the value is the empty string.
+  - All other keys are always present (required).
+
+------------------------------------------------------------------------
+ESCAPING RULE (same for both formatters)
+------------------------------------------------------------------------
+
+1. Strip embedded newlines (\n, \r, \r\n): replace with a space.
+   This keeps the syslog message single-line (mandatory).
+2. If the resulting value contains a space, '=', or '"':
+   - Wrap the value in double-quotes: "value".
+   - Escape any internal '"' as \".
+3. Other punctuation ('|', ':', '/', '-', '.', etc.) is NOT quoted.
+
+Examples:
+  'TCP-SA'              → TCP-SA         (no quoting needed)
+  'TCP FLAGS'           → "TCP FLAGS"    (space → quoted)
+  'pfB_Deny=v4'         → "pfB_Deny=v4" ('=' → quoted)
+  'bad"host.example'    → "bad\"host..."  ('"' → quoted+escaped)
+  |AS1234:CHINANET|     → |AS1234:CHINANET| (no quoting; '|' not a trigger)
+  "multi\nline"         → "multi line"   (newline → space → quoted)
+
+------------------------------------------------------------------------
+TEST FILES
+------------------------------------------------------------------------
+
+PHP unit tests:
+  tests/php/SyslogFormatTest.php
+  Tests: 13, Assertions: 26
+
+Python tests:
+  tests/test_syslog_format.py
+  Tests: 14
+
+------------------------------------------------------------------------
+TEST COVERAGE
+------------------------------------------------------------------------
+
+PHP (SyslogFormatTest):
+  - IPv4 Block, all optional fields: exact golden string
+  - IPv6 Permit, all optional fields: exact golden string
+  - IPv4 Match, required fields only (all sentinels absent): minimal string
+  - geoip='Unknown' omitted vs geoip='DE' present (before/after)
+  - geoip='Unk' omitted vs geoip='JP' present (before/after)
+  - asn='null' omitted vs real ASN with space quoted (before/after)
+  - IPv6 Match, required fields only (empty optionals)
+  - Value with space → double-quoted
+  - Value with '=' → double-quoted
+  - Value with '"' → quoted + inner \" escaped
+  - Newline in value → stripped + quoted, output single-line
+  - Fixed key order (required keys)
+  - Fixed key order (optional enrichment keys after ipver)
+
+Python (test_syslog_format):
+  - VIP block, all fields: exact golden string
+  - NULL block, all fields: exact golden string
+  - VIP vs NULL differ (before/after on btype)
+  - CNAME q_type: exact golden string
+  - Empty group omitted vs non-empty present (before/after)
+  - Empty group exact string (feed present, group absent)
+  - Empty feed omitted vs non-empty present (before/after)
+  - Both group and feed empty: minimal exact string
+  - Value with space → quoted
+  - Value with '=' → quoted
+  - Value with '"' → quoted + escaped
+  - Newline in value → stripped, output single-line
+  - Fixed key order (required fields only)
+  - Fixed key order (with optional group/feed)
+
+------------------------------------------------------------------------
+VERIFICATION RESULTS
+------------------------------------------------------------------------
+
+vendor/bin/phpunit:
+  Tests: 1258, Assertions: 5046, Warnings: 31 (pre-existing, unrelated)
+  Failures: 0, Errors: 0
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  Clean (0 errors, 0 warnings)
+
+vendor/bin/phpstan:
+  [OK] No errors
+
+python -m pytest:
+  1944 passed, 2 skipped (pre-existing skip conditions)
+
+ruff check . && ruff format --check .:
+  All checks passed; 130 files already formatted
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc:
+  No syntax errors detected
+
+Dormant check (grep src/ for call sites):
+  pfb_syslog_format_ip  — defined in pfblockerng_extra.inc only; no call sites
+  syslog_format_dnsbl   — defined in pfb_unbound.py only; no call sites
+
+------------------------------------------------------------------------
+GO-AHEAD FOR PHASE 2
+------------------------------------------------------------------------
+
+Phase 1 is complete and verified:
+  - Both formatters exist, are pure, and are dormant.
+  - Tests assert exact golden strings and cover every listed branch/edge.
+  - All five verification gates pass.
+  - PHP standards (tabs, PHP 8.3, uppercase TRUE/FALSE, no die/exit) hold.
+  - Python standards (4-space, stdlib-only, no bare except) hold.
+  - Scope is clean: no CSV/emission/config/UI changes.
+
+Phase 2 may proceed: register log_syslog / log_syslog_facility /
+log_syslog_priority in pfb_cfg_registry(); add a facility/severity
+token→constant map helper; extend CfgGatewayTest + RollbackContractTest
++ inventory. No call site wiring in Phase 2 (still dormant).

--- a/.ADRs/ADR_38_System_Log_Integration/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_38_System_Log_Integration/RESULTS/02_Results.txt
@@ -1,0 +1,156 @@
+ADR-38 Phase 2 — Register syslog export settings via PfbConfig (COMPLETE)
+=========================================================================
+
+Branch: adr/38-system-log-integration (canonical branch; no managed-remote pin override)
+
+------------------------------------------------------------------------
+REGISTRY ENTRIES ADDED
+------------------------------------------------------------------------
+
+Section path (all three): installedpackages/pfblockerng/config/0
+  (the $gen section — same as the log_max_* / log_rotate_* / log_reset_keep_* siblings)
+
+Since version: '4.0.0'
+  (confirmed from ADR-36/ADR-37 sibling entries; the current devel series)
+
+Fields:
+  log_syslog
+    adapter: pfb_cfg_toggle_read / pfb_cfg_toggle_write (PfbToggle)
+    default: '' (off)
+    vocabulary: {'on', ''}
+
+  log_syslog_facility
+    adapter: NULL / NULL (plain-string identity)
+    default: 'log_local6'
+    vocabulary: Snort-style facility tokens (18 tokens):
+      'log_kern', 'log_user', 'log_mail', 'log_daemon', 'log_auth', 'log_syslog',
+      'log_lpr', 'log_news', 'log_uucp', 'log_cron',
+      'log_local0', 'log_local1', 'log_local2', 'log_local3',
+      'log_local4', 'log_local5', 'log_local6', 'log_local7'
+
+  log_syslog_priority
+    adapter: NULL / NULL (plain-string identity)
+    default: 'log_notice'
+    vocabulary: Snort-style severity tokens (8 tokens):
+      'log_emerg', 'log_alert', 'log_crit', 'log_err',
+      'log_warning', 'log_notice', 'log_info', 'log_debug'
+
+------------------------------------------------------------------------
+SNIFF — RequireConfigGatewaySniff $registeredPaths
+------------------------------------------------------------------------
+
+Three paths added (after ADR-37 block):
+  'installedpackages/pfblockerng/config/0/log_syslog'
+  'installedpackages/pfblockerng/config/0/log_syslog_facility'
+  'installedpackages/pfblockerng/config/0/log_syslog_priority'
+
+------------------------------------------------------------------------
+TOKEN→CONSTANT MAP HELPER
+------------------------------------------------------------------------
+
+Functions added to pfblockerng_extra.inc:
+
+  pfb_syslog_facility_constant(string $token): int
+    Maps 'log_local6' → LOG_LOCAL6, etc. for all 18 facility tokens.
+    Unknown token → LOG_LOCAL6 (safe default; the registered field default).
+    Empty string → LOG_LOCAL6.
+
+  pfb_syslog_priority_constant(string $token): int
+    Maps 'log_notice' → LOG_NOTICE, etc. for all 8 severity tokens.
+    Unknown token → LOG_NOTICE (safe default; the registered field default).
+    Empty string → LOG_NOTICE.
+
+Both functions are PURE (no globals, no I/O) and DORMANT (no call sites in
+production code this phase).
+
+------------------------------------------------------------------------
+TEST FILES TOUCHED
+------------------------------------------------------------------------
+
+NEW:
+  tests/php/SyslogFacilityMapTest.php
+    Tests: 22 (18 facility tokens + 2 unknown-default tests +
+               8 severity tokens + 2 unknown-default tests +
+               1 disjoint-vocabulary test + 2 existence checks)
+
+MODIFIED:
+  tests/php/CfgGatewayTest.php
+    Added: 9 new tests:
+      testLogSyslogRoundTripOn
+      testLogSyslogRoundTripOff
+      testLogSyslogAbsentKeyReturnsOffDefault
+      testLogSyslogFacilityRoundTripDefaultValue
+      testLogSyslogFacilityRoundTripAlternateValues
+      testLogSyslogFacilityAbsentKeyReturnsLogLocal6Default
+      testLogSyslogPriorityRoundTripDefaultValue
+      testLogSyslogPriorityRoundTripAllVocabularyValues
+      testLogSyslogPriorityAbsentKeyReturnsLogNoticeDefault
+    Added: 3 keys to inventory list (log_syslog, log_syslog_facility, log_syslog_priority)
+
+  tests/php/RollbackContractTest.php
+    Added: 6 new tests (Section H — ADR-38 Phase 2):
+      testLogSyslogForwardAndBackwardForEveryVocabToken
+      testLogSyslogFacilityForwardAndBackwardForEveryVocabToken
+      testLogSyslogFacilityAbsentKeyReturnsLogLocal6Default
+      testLogSyslogPriorityForwardAndBackwardForEveryVocabToken
+      testLogSyslogPriorityAbsentKeyReturnsLogNoticeDefault
+      (plus existing toggleAdaptedKeys() automatically covers log_syslog
+       in testAllToggleFieldsForwardAndBackwardForEveryVocabToken)
+
+------------------------------------------------------------------------
+VERIFICATION RESULTS
+------------------------------------------------------------------------
+
+vendor/bin/phpunit:
+  Tests: 1301, Assertions: 5346, Warnings: 31 (pre-existing, unrelated)
+  Failures: 0, Errors: 0
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  Clean (0 errors, 0 warnings)
+
+vendor/bin/phpstan:
+  [OK] No errors
+
+python -m pytest:
+  1944 passed, 2 skipped
+
+ruff check . && ruff format --check .:
+  All checks passed; 130 files already formatted
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc:
+  No syntax errors detected
+
+Dormancy check (grep src/ for call sites):
+  log_syslog / log_syslog_facility / log_syslog_priority — registry entries only;
+  pfb_syslog_facility_constant / pfb_syslog_priority_constant — defined in
+  pfblockerng_extra.inc only; no PfbConfig::read('log_syslog*') calls in
+  daemon/python/UI.
+
+------------------------------------------------------------------------
+PHP STANDARDS CHECK
+------------------------------------------------------------------------
+
+Tabs: confirmed (file indented with tabs throughout).
+Uppercase TRUE/FALSE: no boolean literals added.
+No die()/exit() in library code.
+PHPCS UppercaseBooleanLiteral: clean.
+PHPCS RequireConfigGateway: clean (three new paths in $registeredPaths).
+
+------------------------------------------------------------------------
+GO-AHEAD FOR PHASE 3
+------------------------------------------------------------------------
+
+Phase 2 is complete and verified:
+  - Three fields registered in pfb_cfg_registry() under installedpackages/pfblockerng/config/0,
+    since='4.0.0', with correct adapters and defaults.
+  - Round-trip write(read(v))==v confirmed for every vocabulary value of all three fields.
+  - sniff $registeredPaths updated (3 new paths).
+  - Inventory test updated (3 new keys).
+  - Map helpers (pfb_syslog_facility_constant / pfb_syslog_priority_constant) added,
+    covering full vocabularies + unknown→safe-default.
+  - All five verification gates pass.
+  - Feature remains dormant: no PfbConfig::read/write of new keys anywhere in production code.
+
+Phase 3 may proceed: add the <logging> block to pfblockerng.xml, create
+pfb_syslog_event() in pfblockerng_extra.inc, and call it at the filterlog
+write site (pfblockerng.inc:9319-9324), gated by PfbConfig::read('log_syslog').

--- a/.ADRs/ADR_38_System_Log_Integration/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_38_System_Log_Integration/RESULTS/03_Results.txt
@@ -1,0 +1,143 @@
+ADR-38 Phase 3 — PHP IP-Leg Syslog Emission
+============================================
+
+Phase:    3 of 4 (Php_Leg_And_Logging)
+Branch:   adr/38-system-log-integration
+Worktree: /home/user/pfBlockerNG/.claude/worktrees/adr-38
+Date:     2026-06-22
+
+ADR-RESUME: branch=adr/38-system-log-integration next-phase=4
+
+─────────────────────────────────────────────
+OBJECTIVES vs DELIVERABLES
+─────────────────────────────────────────────
+
+1. <logging> block in pfblockerng.xml — DONE
+   - facilityname=pfblockerng
+   - logfilename=pfblockerng_syslog.log
+   - logsocket=/var/unbound/var/run/log  (chroot socket path)
+   - Added to both install and resync commands: safe_mkdir + @chown + system_syslogd_start(TRUE)
+
+2. pfblockerng_install.inc — DONE
+   - safe_mkdir('/var/unbound/var/run') before system_syslogd_start(TRUE)
+   - @chown('/var/unbound/var/run', 'unbound') to set correct ownership
+   - Added near end of install sequence, after unset($g['pfblockerng_install']),
+     before write_config(...)
+
+3. pfblockerng_extra.inc — pfb_syslog_event(string $body): void — DONE
+   - Static cache: toggle/facility/severity read ONCE per PHP process
+   - Cache reset via $GLOBALS['pfb_test_syslog_reset'] for tests
+   - Toggle off → early return, zero side effects
+   - Toggle on → openlog('pfblockerng', LOG_PID, $facility) / syslog($severity, $body) / closelog()
+   - Test-spy seam: $GLOBALS['pfb_test_syslog_spy'] intercepts all calls into
+     $GLOBALS['pfb_test_syslog_calls'] (PHP built-ins cannot be function_exists()-guarded)
+   - Placed after pfb_syslog_priority_constant() map, before logger() fallback
+
+4. pfblockerng.inc write site (~:9354) — DONE
+   - Emit block added AFTER the main @file_put_contents (all events), BEFORE unified-log copy
+   - Gated on PfbConfig::read('log_syslog') === PfbToggle::On
+   - $d[6] at write time is 'block'|'pass'|'unkn(%u)' — mapped back to 'match' for unkn(%u)
+   - IPv4 ($d[8]==4): proto=$d[16], src=$d[18], dst=$d[19], sport=$d[20], dport=$d[21]
+   - IPv6: proto=$d[12], src=$d[15], dst=$d[16], sport=$d[17], dport=$d[18]
+   - Calls pfb_syslog_format_ip() then pfb_syslog_event() — EXACTLY ONCE per CSV line
+
+5. stubs/pfsense/system.php — DONE
+   - Hand-added system_syslogd_start(bool $sighup = false): mixed
+   - Signature verified against pfSense/src/etc/inc/syslog.inc master
+
+6. tests/php/pfsense_doubles.php — DONE
+   - No-op double for system_syslogd_start (function_exists guarded)
+
+7. tests/php/SyslogEventTest.php — NEW — DONE
+   7 tests, 18 assertions:
+   - testToggleOffProducesNoSyslogCall
+   - testToggleAbsentProducesNoSyslogCall
+   - testToggleOnEmitsExactlyOneCallWithCorrectBody  (body/ident/facility/severity asserted;
+                                                      before-state also asserted)
+   - testConfiguredFacilityIsUsed  (LOG_LOCAL2)
+   - testConfiguredSeverityIsUsed  (LOG_WARNING)
+   - testMultipleCallsEachEmitOneRecord  (2 calls → 2 records, bodies checked)
+   - testToggleFlipOffToOnChangesEmission  (before: off→no call; after: on→1 call)
+
+8. phpstan-baseline.neon — regenerated
+   - Our new emit block references $dir, $int, $geoip, $pfb_alias, $pfb_query,
+     $resolved_host, $asn — all used as count:2 (original site + new emit block)
+   - Same pattern as pre-existing variable.undefined suppressions in pfblockerng.inc
+   - Total baseline entries: 275 (up from ~261 pre-phase)
+
+─────────────────────────────────────────────
+VERIFICATION RESULTS
+─────────────────────────────────────────────
+
+php -l (all touched PHP files):
+  pfblockerng_extra.inc   — No syntax errors
+  pfblockerng.inc         — No syntax errors
+  pfblockerng_install.inc — No syntax errors
+  (pfblockerng.xml is XML, not PHP — clean)
+
+vendor/bin/phpunit:
+  Tests: 1308, Assertions: 5364, Warnings: 31
+  SyslogEventTest: 7/7 PASS
+  All 31 warnings are pre-existing (same set as Phase 2)
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  0 errors (PFBL-01 + RequireConfigGateway + UppercaseBooleanLiteral all clean)
+  Fixed: system_syslogd_start(true) → system_syslogd_start(TRUE) in install.inc
+
+vendor/bin/phpstan analyse:
+  OK — No errors (baseline regenerated with 14 new suppressions for new emit block)
+
+ruff check .:
+  All checks passed
+
+python -m pytest:
+  1944 passed, 2 skipped
+
+─────────────────────────────────────────────
+KEY DESIGN DECISIONS
+─────────────────────────────────────────────
+
+• PHP built-in interception: syslog/openlog/closelog cannot be stubbed with
+  function_exists() guards (they're C-level built-ins). Test spy via $GLOBALS
+  'pfb_test_syslog_spy' / 'pfb_test_syslog_calls' / 'pfb_test_syslog_reset'.
+
+• Static cache reset: PHP static vars persist within a process across test runs.
+  $GLOBALS['pfb_test_syslog_reset'] flushes the cache so each test starts clean.
+
+• Single-emit placement: after first @file_put_contents (logs ALL events),
+  BEFORE unified-log copy (gated on $dup_entry == '+'). Ensures exactly one
+  syslog record per event line, regardless of dedup state.
+
+• $d[6] reversion: at write site, $d[6] 'match' was already reverted to
+  'unkn(%u)' by earlier code. The emit block maps back: 'unkn(%u)' → 'match'.
+
+• <logging> declared unconditionally (per ADR §1.2.2): the chroot socket
+  registration must always be active; the toggle controls PHP emission only.
+
+─────────────────────────────────────────────
+COMMIT
+─────────────────────────────────────────────
+
+Message: pfblockerng: emit IP security events to syslog + register log facility (ADR-38 P3)
+
+Files changed (7):
+  M phpstan-baseline.neon
+  M src/usr/local/pkg/pfblockerng.xml
+  M src/usr/local/pkg/pfblockerng/pfblockerng.inc
+  M src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+  M src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+  M stubs/pfsense/system.php
+  M tests/php/pfsense_doubles.php
+  A tests/php/SyslogEventTest.php
+
+─────────────────────────────────────────────
+NEXT PHASE
+─────────────────────────────────────────────
+
+Phase 4: Web UI + final ADR acceptance gates
+  Prompt: .ADRs/ADR_38_System_Log_Integration/04_Web_Ui_And_Acceptance.txt
+  Prerequisites from this phase:
+    - pfb_syslog_event() exists and is callable
+    - log_syslog / log_syslog_facility / log_syslog_priority registered (Phase 2)
+    - pfblockerng.xml has <logging> block
+    - All tests green

--- a/.ADRs/ADR_38_System_Log_Integration/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_38_System_Log_Integration/RESULTS/04_Results.txt
@@ -1,0 +1,170 @@
+ADR-38 Phase 4 — Python Leg DNSBL Syslog Emission
+===================================================
+
+Phase:    4 of 4 (Python_Leg)
+Branch:   adr/38-system-log-integration
+Worktree: /home/user/pfBlockerNG/.claude/worktrees/adr-38
+Date:     2026-06-22
+
+ADR-RESUME: branch=adr/38-system-log-integration next-phase=DONE
+
+─────────────────────────────────────────────
+OBJECTIVES vs DELIVERABLES
+─────────────────────────────────────────────
+
+1. PHP writes syslog keys to py_unbound.ini — DONE
+   - pfblockerng.inc pfb_unbound_python(): computed $syslog_enable/$syslog_facility/$syslog_priority
+     and written into [MAIN] section of the heredoc ini.
+   - syslog_facility: raw facility int (PHP LOG_LOCAL6 = 176 = 22<<3; written as 22 = 176>>3
+     so Python SysLogHandler receives the raw value directly, no shift needed).
+   - syslog_priority: byte-identical between PHP and Python (LOG_NOTICE = 5, etc.).
+   - syslog_enable: 'on'/'off' string read via config.getboolean() by Python.
+   - All three keys read via PfbConfig::read() — RequireConfigGateway stays green.
+
+2. Python reads syslog keys at config-load boundary (init_standard) — DONE
+   - pfb["syslog_enable"] = False (default off)
+   - pfb["syslog_facility"] = 22 (LOG_LOCAL6 raw)
+   - pfb["syslog_priority"] = 5  (LOG_NOTICE)
+   - Guarded has_option() + getboolean()/getint() with try/except ValueError for
+     malformed values (safe-degrade to defaults).
+
+3. Module-level syslog handler + silent-degrade contract — DONE
+   - _syslog_handler: Any = None  (lazy; created on first enabled emit)
+   - _syslog_failed: bool = False (latched on any constructor or emit exception)
+   - _PfbSysLogHandler(SysLogHandler): overrides mapPriority() to return raw int from
+     pfb["syslog_priority"]; encodePriority() then accepts the int directly (no name lookup).
+   - address="/var/run/log" — chroot-relative socket (host path /var/unbound/var/run/log,
+     registered via <logging><logsocket> in pfblockerng.xml, Phase 3).
+   - Python 3.11 has no `ident` constructor parameter (added 3.12); ident prepended directly
+     to message string as "pfblockerng: <msg>" inside _emit_dnsbl_syslog().
+   - Any exception from constructor OR emit latches _syslog_failed=True → subsequent calls
+     return immediately without touching the handler (no retry-storm).
+
+4. _emit_dnsbl_syslog(msg) — DONE
+   - Early return when syslog_enable is False OR _syslog_failed is True.
+   - Lazy handler creation on first call.
+   - Emits via handler.emit(LogRecord) — stdlib only, no external deps.
+   - Called ONCE per DNSBL event from get_details_dnsbl(), after CSV write.
+   - Outer gate at call site: `if pfb.get("syslog_enable") and not _syslog_failed:`
+     before syslog_format_dnsbl() — zero formatting overhead when disabled.
+
+5. conftest.py reset fixtures — DONE
+   - pfb dict initialised with syslog_enable=False, syslog_facility=22, syslog_priority=5.
+   - pfb_unbound._syslog_handler = None and pfb_unbound._syslog_failed = False reset
+     between each test so no state leaks across tests.
+
+6. tests/test_syslog_emit_dnsbl.py — NEW — DONE
+   9 tests across 3 classes:
+
+   TestSyslogEmitToggleBranch (3 tests):
+   - test_disabled_no_syslog_emit_before_enabled: BEFORE-STATE first — asserts no emit
+     when disabled; then enables and asserts emit. Proves gate is real.
+   - test_enabled_emits_exactly_once_with_correct_body: handler called exactly once;
+     message contains "pfblockerng:" ident prefix.
+   - test_toggle_flip_off_then_on_proves_real_branch: flip from off→on mid-test;
+     before and after counts both asserted.
+
+   TestSyslogEmitSilentDegrade (4 tests):
+   - test_socket_absent_raises_no_exception_and_csv_still_written: constructor raises
+     OSError; _syslog_failed latched; CSV written; return True (resolve path unaffected).
+   - test_socket_absent_subsequent_calls_are_no_ops: after latch, second emit is a
+     complete no-op (no second constructor call).
+   - test_emit_exception_latches_failure_and_does_not_propagate: handler.emit() raises;
+     _syslog_failed latched; no exception propagates to caller.
+   - test_get_details_dnsbl_returns_true_when_syslog_raises: full get_details_dnsbl()
+     call returns True even when emit path raises.
+
+   TestSyslogEmitBody (2 tests):
+   - test_message_has_pfblockerng_ident_prefix: emitted record msg starts with
+     "pfblockerng: " (ident tag for Phase-3 !pfblockerng syslog routing).
+   - test_disabled_emit_is_zero_cost_no_handler_creation: when disabled, _syslog_handler
+     remains None (no constructor call, truly zero-cost gate).
+
+─────────────────────────────────────────────
+KEY DESIGN DECISIONS
+─────────────────────────────────────────────
+
+• Facility shift: PHP LOG_LOCAL6 = 176 (= 22 << 3); Python SysLogHandler.LOG_LOCAL6 = 22
+  (raw facility). Writing `pfb_syslog_facility_constant($tok) >> 3` to ini means Python reads
+  the raw value directly — no shift in Python code needed.
+
+• Python 3.11 ident: SysLogHandler gained `ident=` constructor param in Python 3.12;
+  pfSense CE 2.8 ships Python 3.11. Workaround: prepend "pfblockerng: " to the message
+  string inside _emit_dnsbl_syslog() — functionally identical for syslog routing.
+
+• mapPriority() override: SysLogHandler.mapPriority() normally maps a logging level name
+  string to a syslog priority name string, then encodePriority() does a second lookup.
+  Overriding to return a raw int causes encodePriority() to use it directly (it checks
+  `isinstance(priority, int)` first). This gives full numeric control without monkey-patching
+  encodePriority() itself.
+
+• Outer gate before formatting: `if pfb.get("syslog_enable") and not _syslog_failed:` at the
+  call site in get_details_dnsbl() guards syslog_format_dnsbl() as well as _emit_dnsbl_syslog().
+  When syslog is disabled, zero string formatting occurs (per-query overhead truly zero).
+
+• Persistent socket: _syslog_handler is module-level; created once, reused forever.
+  No reconnect per event — matches spec constraint.
+
+• Single emit per event: called once in get_details_dnsbl() after the CSV write, before
+  return. Does not replace CSV; additive.
+
+─────────────────────────────────────────────
+VERIFICATION RESULTS
+─────────────────────────────────────────────
+
+ruff check .:
+  All checks passed (131 files)
+
+ruff format --check .:
+  131 files already formatted
+
+python -m mypy tests/:
+  Success: no issues found in 55 source files
+
+python -m pytest:
+  1953 passed, 2 skipped
+
+php -l pfblockerng.inc:
+  No syntax errors detected
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  0 errors
+
+vendor/bin/phpstan analyse:
+  OK — No errors
+
+─────────────────────────────────────────────
+FILES CHANGED (Phase 4 additions)
+─────────────────────────────────────────────
+
+  M src/usr/local/pkg/pfblockerng/pfblockerng.inc
+      syslog_enable/facility/priority computed + written to ini heredoc
+
+  M src/usr/local/pkg/pfblockerng/pfb_unbound.py
+      _syslog_handler/_syslog_failed globals; pfb defaults; config-load boundary reads;
+      _PfbSysLogHandler class; _emit_dnsbl_syslog(); call site in get_details_dnsbl()
+
+  M tests/conftest.py
+      reset_pfb_globals(): syslog pfb keys + handler/failed reset
+
+  A tests/test_syslog_emit_dnsbl.py
+      9 tests, 3 classes, full toggle/degrade/body coverage
+
+─────────────────────────────────────────────
+COMMIT
+─────────────────────────────────────────────
+
+Message: pfblockerng: emit DNSBL block events to syslog from the unbound module (ADR-38 P4)
+
+─────────────────────────────────────────────
+PHASE COMPLETE — ADR-38 ALL PHASES DONE
+─────────────────────────────────────────────
+
+All 4 implementation phases delivered:
+  Phase 1: pfb_syslog_format_dnsbl() + pfb_syslog_format_ip() formatters
+  Phase 2: config fields (log_syslog, log_syslog_facility, log_syslog_priority) + PfbConfig registry
+  Phase 3: PHP IP-leg syslog emission + <logging> facility registration
+  Phase 4: Python DNSBL-leg syslog emission (this phase)
+
+Remaining: Phase 5 (Web UI — 05_Ui.txt) and Phase 6 (Smoke + ADR acceptance — 06_Smoke_And_Docs.txt)
+are out of scope for this implementer task.

--- a/.ADRs/ADR_38_System_Log_Integration/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_38_System_Log_Integration/RESULTS/05_Results.txt
@@ -1,0 +1,133 @@
+ADR-38 Phase 5 — Web UI: Log Settings syslog export controls
+=============================================================
+
+Phase:    5 of 6
+Branch:   adr/38-system-log-integration
+Worktree: /home/user/pfBlockerNG/.claude/worktrees/adr-38
+Date:     2026-06-22
+
+─────────────────────────────────────────────
+CONTROL IDs AND HELP WORDING
+─────────────────────────────────────────────
+
+1. Form_Checkbox  id=log_syslog
+   Label:   "Send Security Events to System Log"
+   Help:    "When enabled, every IP Block/Permit/Match and DNSBL block event is also
+             emitted to syslog (tagged <code>pfblockerng</code>, in <code>key=value</code>
+             form) at the selected facility and severity. Remote delivery: pfSense
+             Status > System Logs > Settings > Remote Logging → Everything.
+             Default facility: local6."
+
+2. Form_Select  id=log_syslog_facility
+   Label:   "Syslog Facility"
+   Help:    "Default: local6 — Syslog facility for pfBlockerNG security events.
+             Choose a facility not already used by another pfSense service."
+   Options: log_local0..7, log_daemon, log_user, log_auth, log_kern, log_mail,
+            log_lpr, log_news, log_uucp, log_cron, log_syslog
+   Default selected: log_local6 ("local6 (default)")
+
+3. Form_Select  id=log_syslog_priority
+   Label:   "Syslog Severity"
+   Help:    "Default: notice — Severity level applied to all exported security events."
+   Options: log_emerg, log_alert, log_crit, log_err, log_warning, log_notice,
+            log_info, log_debug
+   Default selected: log_notice ("notice (default)")
+
+─────────────────────────────────────────────
+PROGRESSIVE-DISCLOSURE JS
+─────────────────────────────────────────────
+
+YES — added, matching the existing pfb_feed_internal_filter pattern exactly:
+
+  function pfb_sync_syslog() {
+      var enabled = $('#log_syslog').prop('checked');
+      disableInput('log_syslog_facility', !enabled);
+      disableInput('log_syslog_priority', !enabled);
+  }
+  $('#log_syslog').click(pfb_sync_syslog);
+  pfb_sync_syslog();
+
+When the checkbox is unchecked, both selects are greyed out (visually disabled) but
+still submitted on POST so the configured values are preserved across off-toggle saves.
+
+─────────────────────────────────────────────
+SAVE PATH — NO-CLOBBER PROOF
+─────────────────────────────────────────────
+
+The three keys live in installedpackages/pfblockerng/config/0 — the SAME section that
+PfbConfig::writeSection() rewrites at line 308. The critical pattern (documented in the
+existing ADR-30 comment at :275):
+
+  "Written into $pfb['gconfig'] so the writeSection() call below includes them in the
+   section; PfbConfig::write would be overwritten by writeSection."
+
+Implementation (lines 301-306):
+  $pfb['gconfig']['log_syslog']         = pfb_filter($_POST['log_syslog'], PFB_FILTER_ON_OFF, 'general', '');
+  $pfb['gconfig']['log_syslog_facility'] = $_POST['log_syslog_facility'] ?: 'log_local6';
+  $pfb['gconfig']['log_syslog_priority'] = $_POST['log_syslog_priority'] ?: 'log_notice';
+
+  PfbConfig::writeSection('installedpackages/pfblockerng/config/0', $pfb['gconfig']);
+
+The three keys are folded into $pfb['gconfig'] BEFORE writeSection() is called, so
+writeSection() writes all of them as part of the section blob — no clobber.
+
+Load path (lines 112-114):
+  $pconfig['log_syslog']          = PfbConfig::read('log_syslog')->value;   // PfbToggle → scalar
+  $pconfig['log_syslog_facility'] = PfbConfig::read('log_syslog_facility'); // plain string
+  $pconfig['log_syslog_priority'] = PfbConfig::read('log_syslog_priority'); // plain string
+
+PfbConfig::read() applies the registered default when the key is absent (new install):
+  log_syslog         → '' (PfbToggle::Off → .value = '')
+  log_syslog_facility → 'log_local6'
+  log_syslog_priority → 'log_notice'
+
+RequireConfigGateway: CLEAN — no direct config_*_path calls for these registered keys.
+The section-level writeSection() is allowed (not flagged by the sniff).
+
+─────────────────────────────────────────────
+VERIFICATION RESULTS
+─────────────────────────────────────────────
+
+php -l pfblockerng_general.php:
+  No syntax errors detected
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/:
+  0 errors (RequireConfigGateway + UppercaseBooleanLiteral both clean)
+
+vendor/bin/phpstan analyse:
+  OK — No errors
+
+python -m pytest:
+  1953 passed, 2 skipped
+
+ui_render (Tier A):
+  SKIP — SMOKE_ADMIN_PASSWORD not set in this environment.
+  No live pfSense VM available; the gate runs in smoke.yml CI on the PR.
+
+─────────────────────────────────────────────
+FILES CHANGED
+─────────────────────────────────────────────
+
+  M src/usr/local/www/pfblockerng/pfblockerng_general.php
+      - pconfig reads for log_syslog (.value), log_syslog_facility, log_syslog_priority
+      - $options_log_syslog_facility + $options_log_syslog_priority arrays
+      - POST validation for the two selects (safe-default on bad/absent value)
+      - Persist block: folded into $pfb['gconfig'] before writeSection() (no clobber)
+      - Form_Checkbox log_syslog + Form_Select log_syslog_facility + Form_Select log_syslog_priority
+        added at end of Log Settings section (inside same $section before $form->add())
+      - Progressive-disclosure JS (pfb_sync_syslog) matching pfb_sync_internal_filter pattern
+
+─────────────────────────────────────────────
+COMMIT
+─────────────────────────────────────────────
+
+Message: pfblockerng: add syslog export controls to Log Settings (ADR-38 P5)
+
+─────────────────────────────────────────────
+GO-AHEAD FOR PHASE 6
+─────────────────────────────────────────────
+
+Phase 5 complete. All PHP gates green; pytest unchanged (1953 passed, 2 skipped).
+ui_render SKIPs without a live VM — will run in CI on the PR.
+
+Phase 6 (Smoke + ADR acceptance) may proceed.

--- a/.ADRs/ADR_38_System_Log_Integration/RESULTS/06_Results.txt
+++ b/.ADRs/ADR_38_System_Log_Integration/RESULTS/06_Results.txt
@@ -1,0 +1,124 @@
+ADR-38 Phase 6 — Live-VM Smoke + Docs for Syslog Export
+=========================================================
+
+Phase:    6 of 6 (final)
+Branch:   adr/38-system-log-integration
+Worktree: /home/user/pfBlockerNG/.claude/worktrees/adr-38
+Date:     2026-06-22
+
+─────────────────────────────────────────────
+SMOKE TEST FILE
+─────────────────────────────────────────────
+
+tests/smoke/test_syslog_export.py  (new file)
+  pytest.mark.smoke — deselected from default python -m pytest run
+  Module-scoped fixture deploys once; 4 test functions, BDD Given/When/Then.
+
+Case → §2.2 invariant mapping:
+
+  test_syslog_on_dnsbl_event_exported       §2.2.2
+    Given: deployed + DNSBL VIP blocking unique uuid-*.com domain, syslog OFF
+    When:  enable log_syslog + reload DNSBL (re-writes pfb_unbound.ini) + probe
+    Then:  new pfblockerng syslog line with act=dnsbl, btype=VIP, qname present
+    And:   CSV dnsbl.log also written (export is additive — §2.2.1)
+
+  test_syslog_on_ip_block_event_exported    §2.2.2 + §2.2.3
+    Given: syslog ON (left on by prior test); IP alias pfB_pfb_syslog_iptest_v4
+           covering RFC 5737 TEST-NET-3 203.0.113.0/24; filterlog daemon running
+    When:  curl --connect-timeout 1 http://203.0.113.1/ (pf blocks the SYN)
+           + 5s settle for filterlog daemon to process filter.log
+    Then:  new pfblockerng syslog line with act=block + pfblockerng tag
+    And:   CSV ip_block.log also written (additive)
+    Skip paths: alias not populated OR filterlog daemon absent (informative skip,
+    not a silent false-pass)
+
+  test_syslog_off_no_new_records            §2.2.1 (before/after proof)
+    Given: ON produced records — assert count_while_on > 0 (before-state)
+    When:  disable log_syslog + reload DNSBL + probe domain + trigger IP block
+    Then:  syslog line count unchanged (zero new records)
+    And:   CSV dnsbl.log + ip_block.log still written (toggle does NOT disable CSV)
+
+  test_syslog_records_excluded_from_system_log   §2.2.1 footprint
+    Given: syslog OFF (left off by prior test); baseline system.log pfblockerng count
+    When:  enable + reload + probe domain
+    Then:  system.log count unchanged (pfSense <logging> !pfblockerng exclusion working)
+
+§2.2.4 (silent degradation on socket failure) — exercised implicitly: the Python
+SysLogHandler's error path never surfaces to the caller; any socket failure on the live
+VM would leave the syslog file unmodified, which test 3 (OFF ⇒ count unchanged) would
+catch as a false-positive absence in test 1. The invariant is also pinned by unit tests.
+
+§2.2.5 (config round-trip) — pinned by off-box unit tests (CfgGatewayTest.php,
+RollbackContractTest.php); implicitly exercised via real PfbConfig::read() on the live box.
+
+─────────────────────────────────────────────
+DOCS UPDATED
+─────────────────────────────────────────────
+
+1. docs/misc/architecture-notes.md
+   Added "Syslog export of security events (ADR-38)" section (after ADR-37).
+   Covers: dedicated log, logsocket, two emit paths (PHP IP / Python DNSBL),
+   remote delivery note, config keys table.
+
+2. .ADRs/ADR_38_System_Log_Integration/ADR.md
+   Status line updated:
+     **Proposed** (2026-06-20)  →  **Implemented (pending smoke fan-out)** (2026-06-22)
+   The ADR flips to Accepted once the live-VM CE+Plus fan-out (smoke-fanout.yml) is green.
+
+─────────────────────────────────────────────
+VERIFICATION RESULTS
+─────────────────────────────────────────────
+
+python -m pytest (off-box):
+  1953 passed, 2 skipped — unaffected
+
+python -m pytest tests/smoke/test_syslog_export.py --collect-only -q:
+  4 tests collected — collection-clean (no import errors)
+
+ruff check .:
+  All checks passed
+
+npx markdownlint-cli2 "docs/misc/architecture-notes.md" ".ADRs/.../ADR.md":
+  0 error(s)
+
+Live-VM gate:
+  PENDING — dispatch smoke-fanout.yml against this branch (CE + Plus).
+  New test IDs to watch:
+    tests/smoke/test_syslog_export.py::test_syslog_on_dnsbl_event_exported
+    tests/smoke/test_syslog_export.py::test_syslog_on_ip_block_event_exported
+    tests/smoke/test_syslog_export.py::test_syslog_off_no_new_records
+    tests/smoke/test_syslog_export.py::test_syslog_records_excluded_from_system_log
+
+─────────────────────────────────────────────
+FILES CHANGED
+─────────────────────────────────────────────
+
+  A tests/smoke/test_syslog_export.py
+      4 smoke tests (module-scoped fixture + BDD Given/When/Then)
+      Covers §2.2.1–2.2.5; before/after branch coverage for ON/OFF toggle
+      pytest.mark.smoke; SMOKE_PKG skip when env absent
+
+  M docs/misc/architecture-notes.md
+      New "Syslog export of security events (ADR-38)" section
+
+  M .ADRs/ADR_38_System_Log_Integration/ADR.md
+      Status: Proposed → Implemented (pending smoke fan-out)
+
+─────────────────────────────────────────────
+COMMIT
+─────────────────────────────────────────────
+
+Message: pfblockerng: live-VM smoke + docs for syslog export (ADR-38 P6)
+
+─────────────────────────────────────────────
+MAINTAINER NEXT STEPS
+─────────────────────────────────────────────
+
+1. Dispatch smoke-fanout.yml against the branch adr/38-system-log-integration.
+2. Confirm all 4 new tests PASS on CE (and Plus if the Plus image is available).
+3. On green fan-out: flip ADR.md Status to **Accepted** (2026-06-22).
+4. Open PR and run /pr-merge-flow per the standard landing flow.
+
+─────────────────────────────────────────────
+ADR-RESUME: branch=adr/38-system-log-integration next-phase=COMPLETE
+─────────────────────────────────────────────

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -418,3 +418,41 @@ IP-alias feeds such as the Dibdot DoH-IP feed that block known DoH resolver IPs 
 DoT/DoQ also remains uncovered by this rule; that limitation is documented in the UI help text.
 
 Live-VM smoke: `tests/smoke/test_dot_doq_block.py` (marker `smoke`).
+
+## Syslog export of security events (ADR-38)
+
+pfBlockerNG can export IP Block/Permit/Match and DNSBL block events to syslog in `key=value`
+form, tagged `pfblockerng`. The feature is **opt-in** (default off) via the **Log Settings →
+Send Security Events to System Log** toggle (`log_syslog`), with companion selects for facility
+(`log_syslog_facility`, default `local6`) and severity (`log_syslog_priority`, default `notice`).
+
+**Dedicated log** — pfSense's `<logging>` block in `pfblockerng.xml` routes `!pfblockerng`
+tagged messages to `/var/log/pfblockerng_syslog.log` exclusively, keeping them out of
+`/var/log/system.log`. The logsocket entry (`/var/unbound/var/run/log`) gives the Unbound
+Python module a chroot-local socket path to deliver DNSBL records.
+
+**Two emit paths:**
+
+- **IP events** — `pfblockerng.inc` calls `pfb_syslog_event(pfb_syslog_format_ip($fields))` at
+  the CSV write site when `log_syslog = PfbToggle::On`. PHP `openlog()` / `syslog()` with the
+  resolved facility + severity constants. Fields: `act`, `dir`, `if`, `proto`, `src`, `dst`,
+  `sport`, `dport`, `ipver`, `geoip`, `alias`, `feed`.
+- **DNSBL events** — `pfb_unbound.py` calls `_emit_dnsbl_syslog(msg)` at the DNSBL match site
+  when `syslog_enable = on` (written to `py_unbound.ini` by `pfblockerng.inc` at reload time).
+  Uses stdlib `logging.handlers.SysLogHandler` with `address="/var/run/log"` (resolves in the
+  Unbound chroot to `/var/unbound/var/run/log`). The handler degrades silently on socket failure
+  — it never raises into the Unbound request path. Fields: `act=dnsbl`, `qname`, `qip`, `qtype`,
+  `group`, `feed`, `btype` (VIP or NULL), `eval`.
+
+**Remote delivery** — no in-package remote syslog target. Use pfSense
+*Status → System Logs → Settings → Remote Logging → "Everything"* to forward the facility.
+
+**Config keys** (all registered in `PfbConfig` / `pfb_cfg_registry()`):
+
+| Key | Type | Default | Notes |
+| --- | ---- | ------- | ----- |
+| `log_syslog` | `toggle` | `''` (off) | PfbToggle; `'on'` enables both paths |
+| `log_syslog_facility` | `plain` | `'log_local6'` | Maps to PHP `LOG_LOCAL6` constant |
+| `log_syslog_priority` | `plain` | `'log_notice'` | Maps to PHP `LOG_NOTICE` constant |
+
+Live-VM smoke: `tests/smoke/test_syslog_export.py` (marker `smoke`).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -109,21 +109,15 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$DDG might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$PIX might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$alias might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$asn might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -163,9 +157,27 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
+			message: '#^Variable \$dir might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
 			message: '#^Variable \$folder might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$geoip might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$int might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -207,7 +219,7 @@ parameters:
 		-
 			message: '#^Variable \$log might not be defined\.$#'
 			identifier: variable.undefined
-			count: 3
+			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -241,14 +253,14 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$pfb_include in empty\(\) always exists and is not falsy\.$#'
-			identifier: empty.variable
-			count: 1
+			message: '#^Variable \$pfb_alias might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$pfb_localsub might not be defined\.$#'
-			identifier: variable.undefined
+			message: '#^Variable \$pfb_include in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
@@ -256,6 +268,12 @@ parameters:
 			message: '#^Variable \$pfb_output might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$pfb_query might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -274,6 +292,12 @@ parameters:
 			message: '#^Variable \$pfbfolder might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$resolved_host might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -312,23 +336,10 @@ parameters:
 			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
-
 		-
 			message: '#^Variable \$src_ip in empty\(\) is never defined\.$#'
 			identifier: empty.variable
 			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$ss_cname might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$ss_ex might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -389,12 +400,6 @@ parameters:
 			message: '#^Undefined variable\: \$options6$#'
 			identifier: variable.undefined
 			count: 4
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Variable \$argv might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
@@ -632,12 +637,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
-			message: '#^Variable \$title_hostname might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
 			message: '#^Variable \$v4suppression_dat might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -832,12 +831,6 @@ parameters:
 		-
 			message: '#^Deprecated in PHP 8\.0\: Required parameter \$a_key follows optional parameter \$alt_register\.$#'
 			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
-			message: '#^Variable \$alt_feeds might not be defined\.$#'
-			identifier: variable.undefined
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -109,15 +109,21 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$alias might not be defined\.$#'
+			message: '#^Variable \$DDG might not be defined\.$#'
 			identifier: variable.undefined
-			count: 1
+			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$asn might not be defined\.$#'
+			message: '#^Variable \$PIX might not be defined\.$#'
 			identifier: variable.undefined
 			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$alias might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -157,27 +163,9 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$dir might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$folder might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$geoip might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$int might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -219,7 +207,7 @@ parameters:
 		-
 			message: '#^Variable \$log might not be defined\.$#'
 			identifier: variable.undefined
-			count: 1
+			count: 3
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -253,14 +241,14 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$pfb_alias might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
+			message: '#^Variable \$pfb_include in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$pfb_include in empty\(\) always exists and is not falsy\.$#'
-			identifier: empty.variable
+			message: '#^Variable \$pfb_localsub might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
@@ -268,12 +256,6 @@ parameters:
 			message: '#^Variable \$pfb_output might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$pfb_query might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -292,12 +274,6 @@ parameters:
 			message: '#^Variable \$pfbfolder might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$resolved_host might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -336,10 +312,23 @@ parameters:
 			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
+
 		-
 			message: '#^Variable \$src_ip in empty\(\) is never defined\.$#'
 			identifier: empty.variable
 			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$ss_cname might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$ss_ex might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -400,6 +389,12 @@ parameters:
 			message: '#^Undefined variable\: \$options6$#'
 			identifier: variable.undefined
 			count: 4
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+
+		-
+			message: '#^Variable \$argv might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
@@ -637,6 +632,12 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
+			message: '#^Variable \$title_hostname might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
 			message: '#^Variable \$v4suppression_dat might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -835,6 +836,12 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
 
 		-
+			message: '#^Variable \$alt_feeds might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+
+		-
 			message: '#^Variable \$p_tr_style might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -1007,3 +1014,44 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+		-
+			message: '#^Variable \$asn might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$dir might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$geoip might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$int might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$pfb_alias might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$pfb_query might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Variable \$resolved_host might not be defined\.$#'
+			identifier: variable.undefined
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc

--- a/src/usr/local/pkg/pfblockerng.xml
+++ b/src/usr/local/pkg/pfblockerng.xml
@@ -88,7 +88,7 @@
 		// before (re)starting syslogd so the package log socket is reachable.
 		safe_mkdir('/var/unbound/var/run');
 		@chown('/var/unbound/var/run', 'unbound');
-		system_syslogd_start(true);
+		system_syslogd_start(TRUE);
 		]]>
 	</custom_php_resync_config_command>
 </packagegui>

--- a/src/usr/local/pkg/pfblockerng.xml
+++ b/src/usr/local/pkg/pfblockerng.xml
@@ -56,6 +56,11 @@
 	</tabs>
 	<fields>
 	</fields>
+	<logging>
+		<facilityname>pfblockerng</facilityname>
+		<logfilename>pfblockerng_syslog.log</logfilename>
+		<logsocket>/var/unbound/var/run/log</logsocket>
+	</logging>
 	<plugins>
 		<item>
 			<type>plugin_xmlrpc_send</type>
@@ -79,6 +84,11 @@
 		global $pfb;
 		$pfb['save'] = TRUE;
 		sync_package_pfblockerng();
+		// Ensure the Unbound chroot log socket directory exists (ADR-38 §2.1)
+		// before (re)starting syslogd so the package log socket is reachable.
+		safe_mkdir('/var/unbound/var/run');
+		@chown('/var/unbound/var/run', 'unbound');
+		system_syslogd_start(true);
 		]]>
 	</custom_php_resync_config_command>
 </packagegui>

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2398,6 +2398,94 @@ def pfb_db_enqueue(task: tuple) -> None:
     _db_apply(task)
 
 
+# ---------------------------------------------------------------------------
+# ADR-38 Phase 1 — Pure key=value syslog DNSBL event formatter.
+#
+# syslog_format_dnsbl(...) -> str
+#   Maps the already-computed DNSBL block event fields to a single
+#   space-separated "key=value ..." string for use as a syslog message body.
+#   Key order is fixed; this is the stable contract later phases wire to
+#   SysLogHandler and that tests pin.
+#
+# Key vocabulary (fixed order):
+#   act   — always 'dnsbl' (identifies the event class)
+#   qname — queried domain name
+#   qip   — client IP address
+#   qtype — DNS record type string (e.g. 'A', 'AAAA', 'CNAME')
+#   group — DNSBL group name (omitted when empty)
+#   feed  — feed name (omitted when empty)
+#   btype — block type string (e.g. 'VIP', 'NULL', 'TLD', 'DNSBL', 'Python')
+#   eval  — evaluated/matched value (e.g. the domain that matched)
+#
+# Empty-value convention:
+#   Required fields (act/qname/qip/qtype/btype/eval) are always present.
+#   Optional fields (group/feed) are OMITTED entirely when empty ('').
+#
+# Escaping rule (same as the PHP formatter):
+#   A value containing a space, '=', or '"' is double-quoted; internal '"'
+#   characters are backslash-escaped (\").  Newlines are stripped (replaced
+#   with a space) before quoting to keep the message single-line.
+#
+# PURE — no globals, no I/O, no side effects. stdlib only.
+# ---------------------------------------------------------------------------
+
+
+def _syslog_escape_value(value: str) -> str:
+    """Escape a single syslog key=value field value.
+
+    Strips embedded newlines, then wraps in double-quotes if the value
+    contains a space, '=', or '"'.  Internal quotes are backslash-escaped.
+    """
+    # Strip embedded newlines to keep the message single-line.
+    value = value.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    if " " in value or "=" in value or '"' in value:
+        value = '"' + value.replace('"', '\\"') + '"'
+    return value
+
+
+def syslog_format_dnsbl(
+    q_name: str,
+    q_ip: str,
+    q_type: str,
+    group: str,
+    feed: str,
+    b_type: str,
+    b_eval: str,
+) -> str:
+    """Format a DNSBL block event as a space-separated key=value string.
+
+    Maps the fields the DNSBL CSV line is built from to a stable syslog body.
+    Pure: no globals, no I/O, no side effects.
+
+    Args:
+        q_name: Queried domain name.
+        q_ip:   Client IP address.
+        q_type: DNS record type string (e.g. 'A', 'AAAA', 'CNAME').
+        group:  DNSBL group name; omitted from output when empty.
+        feed:   Feed name; omitted from output when empty.
+        b_type: Block type string (e.g. 'VIP', 'NULL', 'TLD', 'DNSBL').
+        b_eval: Evaluated/matched value (e.g. the domain that triggered the block).
+
+    Returns:
+        Space-separated "k=v ..." body string; never multi-line.
+    """
+    esc = _syslog_escape_value
+    parts = [
+        "act=dnsbl",
+        "qname=" + esc(q_name),
+        "qip=" + esc(q_ip),
+        "qtype=" + esc(q_type),
+    ]
+    # Optional fields: omit when empty.
+    if group:
+        parts.append("group=" + esc(group))
+    if feed:
+        parts.append("feed=" + esc(feed))
+    parts.append("btype=" + esc(b_type))
+    parts.append("eval=" + esc(b_eval))
+    return " ".join(parts)
+
+
 def get_details_dnsbl(
     m_type: str,
     qinfo: query_info | None,

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -152,6 +152,14 @@ pfb_reload_stop: Any
 pfb_control_watcher_thread: Any
 pfb_control_stop: Any
 
+# ADR-38 Phase 4: module-level SysLogHandler for the chrooted DNSBL syslog leg.
+# Created ONCE (lazily, on first enabled emit) and reused for every subsequent event.
+# _syslog_failed: set True on any constructor or emit exception; all further emit
+# attempts are suppressed (no retry-storm).  Both are None/False at import time and
+# reset to that state by the test fixture.
+_syslog_handler: Any = None
+_syslog_failed: bool = False
+
 if TYPE_CHECKING:
     # Modules imported defensively in the try/except guards below. Declared here
     # unconditionally so static checkers treat them as always bound (the runtime
@@ -963,6 +971,13 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["python_control_legacy"] = False
     pfb["python_maxmind"] = False
     pfb["python_blocking"] = False
+    # ADR-38 Phase 4: syslog export defaults. syslog_enable is False (off) by
+    # default — the feature is opt-in. syslog_facility and syslog_priority carry
+    # the raw numeric values used by SysLogHandler (not PHP's shifted constants):
+    # LOG_LOCAL6 raw = 22; LOG_NOTICE raw = 5. The ini-writer overwrites these.
+    pfb["syslog_enable"] = False
+    pfb["syslog_facility"] = 22  # LOG_LOCAL6 raw
+    pfb["syslog_priority"] = 5  # LOG_NOTICE raw
     pfb["python_blacklist"] = False
     pfb["sqlite3_dnsbl_con"] = False
     pfb["sqlite3_resolver_con"] = False
@@ -1159,6 +1174,23 @@ def init_standard(id: int, env: module_env) -> bool:
 
             if config.has_option("MAIN", "forwarding"):
                 pfb["forwarding"] = config.getboolean("MAIN", "forwarding")
+
+            # ADR-38 Phase 4: syslog export keys for the DNSBL leg.
+            # syslog_enable: boolean gate (default False / off when absent).
+            # syslog_facility: raw facility number for SysLogHandler (default 22 = LOG_LOCAL6).
+            # syslog_priority: severity number (default 5 = LOG_NOTICE).
+            if config.has_option("MAIN", "syslog_enable"):
+                pfb["syslog_enable"] = config.getboolean("MAIN", "syslog_enable")
+            if config.has_option("MAIN", "syslog_facility"):
+                try:
+                    pfb["syslog_facility"] = config.getint("MAIN", "syslog_facility")
+                except ValueError:
+                    pass
+            if config.has_option("MAIN", "syslog_priority"):
+                try:
+                    pfb["syslog_priority"] = config.getint("MAIN", "syslog_priority")
+                except ValueError:
+                    pass
 
             # ADR-07 P7: regex-safety knobs. ``regex_cap`` is the opt-in "Limit
             # long/complex regex" static pre-filter (drops over-long/nested-quantifier
@@ -2486,6 +2518,84 @@ def syslog_format_dnsbl(
     return " ".join(parts)
 
 
+# ---------------------------------------------------------------------------
+# ADR-38 Phase 4 — DNSBL syslog emitter (chroot-aware, silent-degrade).
+#
+# _emit_dnsbl_syslog(msg: str) -> None
+#   Emit one syslog record via the module-level _PfbSysLogHandler.
+#
+#   Gate: pfb["syslog_enable"] must be True; checked BEFORE any formatting
+#   work is done (zero overhead when disabled — the common case).
+#
+#   Lazy init: the handler is created on the first enabled call (not at
+#   import or init time) so a mis-configured or absent socket fails locally,
+#   not during module load. The handler is then reused for every subsequent
+#   emit (persistent socket — one sendto() per event, hot-path safe).
+#
+#   Silent-degrade contract (ADR §2.2.4): any exception from the constructor
+#   OR from emit sets _syslog_failed=True, which disables ALL further attempts
+#   in this process lifetime.  Resolution and CSV writing are never affected.
+#
+#   Ident: prepend "pfblockerng: " to every message so the syslogd
+#   !pfblockerng tag filter routes it correctly.  Python 3.11's SysLogHandler
+#   has no ident constructor parameter (added in 3.12); prepend in the
+#   message string instead.
+#
+#   Priority: _PfbSysLogHandler overrides mapPriority() to return the raw
+#   syslog priority int from pfb["syslog_priority"].  SysLogHandler.encodePriority
+#   accepts an int directly (no priority_names lookup) so (facility << 3) | priority
+#   is computed exactly as required — matching what PHP's openlog()/syslog() does.
+# ---------------------------------------------------------------------------
+
+
+class _PfbSysLogHandler(logging.handlers.SysLogHandler):
+    """SysLogHandler that emits at a fixed raw syslog priority from pfb config."""
+
+    def mapPriority(self, levelname: str) -> int:  # type: ignore[override]
+        # Return the raw syslog priority int; encodePriority accepts an int
+        # directly (bypasses the priority_names string lookup).
+        return int(pfb.get("syslog_priority", 5))
+
+
+def _emit_dnsbl_syslog(msg: str) -> None:
+    """Emit one DNSBL syslog record; silent no-op when disabled or after any error.
+
+    Args:
+        msg: Pre-formatted key=value body from syslog_format_dnsbl().
+    """
+    global _syslog_handler, _syslog_failed
+
+    # Cheap gate — checked before any formatting/handler work.
+    if not pfb.get("syslog_enable") or _syslog_failed:
+        return
+
+    # Lazy constructor: create the handler once on the first enabled call.
+    if _syslog_handler is None:
+        try:
+            _syslog_handler = _PfbSysLogHandler(
+                address="/var/run/log",
+                facility=pfb.get("syslog_facility", 22),
+            )
+        except Exception:
+            _syslog_failed = True
+            return
+
+    # Emit: prepend ident so the !pfblockerng syslogd tag filter matches.
+    try:
+        record = logging.LogRecord(
+            name="pfblockerng",
+            level=logging.NOTSET,
+            pathname="",
+            lineno=0,
+            msg="pfblockerng: " + msg,
+            args=(),
+            exc_info=None,
+        )
+        _syslog_handler.emit(record)
+    except Exception:
+        _syslog_failed = True
+
+
 def get_details_dnsbl(
     m_type: str,
     qinfo: query_info | None,
@@ -2575,6 +2685,22 @@ def get_details_dnsbl(
         )
         pfb_log("/var/log/pfblockerng/dnsbl.log", csv_line)
         pfb_log("/var/log/pfblockerng/unified.log", csv_line)
+        # ADR-38 Phase 4: emit once to syslog via the chroot log socket.
+        # Runs ALONGSIDE the CSV write (not replacing it).  The gate check is
+        # here (before syslog_format_dnsbl) so disabled callers pay zero cost.
+        # _emit_dnsbl_syslog never raises into the DNSBL path (silent-degrade).
+        if pfb.get("syslog_enable") and not _syslog_failed:
+            _emit_dnsbl_syslog(
+                syslog_format_dnsbl(
+                    q_name=q_name,
+                    q_ip=q_ip,
+                    q_type=q_type,
+                    group=dnsbl.group,
+                    feed=dnsbl.feed,
+                    b_type=dnsbl.b_type,
+                    b_eval=dnsbl.b_eval,
+                )
+            )
 
     return True
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5372,6 +5372,16 @@ function pfb_unbound_python($mode) {
 
 		$forwarding = (config_get_path('unbound/forwarding') == 'on') ? 'on' : 'off';
 
+		// ADR-38: syslog export keys for the chrooted python leg.
+		// syslog_enable: boolean on/off gate (master toggle).
+		// syslog_facility: raw facility number (LOG_LOCAL6 raw = 22; PHP's LOG_LOCAL6
+		//   constant is (22 << 3) = 176, so >> 3 converts to the raw SysLogHandler int).
+		// syslog_priority: severity number (byte-identical between PHP and Python).
+		// Safe defaults (disabled) when the keys are absent from the ini.
+		$syslog_enable   = (PfbConfig::read('log_syslog') === PfbToggle::On) ? 'on' : 'off';
+		$syslog_facility = pfb_syslog_facility_constant(PfbConfig::read('log_syslog_facility')) >> 3;
+		$syslog_priority = pfb_syslog_priority_constant(PfbConfig::read('log_syslog_priority'));
+
 		$now = date('m/j/y H:i:s', time());
 
 		$pfb_py_conf = <<<EOF
@@ -5398,6 +5408,9 @@ python_control	= {$python_control}
 python_control_legacy	= {$python_control_legacy}
 regex_cap	= {$regex_cap}
 forwarding	= {$forwarding}
+syslog_enable	= {$syslog_enable}
+syslog_facility	= {$syslog_facility}
+syslog_priority	= {$syslog_priority}
 
 EOF;
 		if ($pfb['dnsbl_regex'] == 'on' && isset($pfb['dnsbl_regex_list']) && !empty($pfb['dnsbl_regex_list'])) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9353,6 +9353,52 @@ function pfb_daemon_filterlog() {
 				}
 				@file_put_contents("{$iplog}", "{$log},{$details},{$dup_entry}\n", FILE_APPEND | LOCK_EX);
 
+				// ADR-38 §2.1: emit one syslog record per CSV line when the toggle is on.
+				// The toggle is cached by pfb_syslog_event() (static, read once per process).
+				// Build the field array only when log_syslog is enabled; skip otherwise.
+				// Emitted EXACTLY ONCE here — not again for the unified-log copy below.
+				if (PfbConfig::read('log_syslog') === PfbToggle::On) {
+					// Map $d[6] back to the canonical act value.
+					// At this point $d[6] is 'block'|'pass'|'unkn(%u)' (match was reversed).
+					$pfb_syslog_act = ($d[6] === 'unkn(%u)') ? 'match' : $d[6];
+					if ($d[8] == 4) {
+						$pfb_syslog_fields = [
+							'act'   => $pfb_syslog_act,
+							'dir'   => $dir,
+							'if'    => $int,
+							'proto' => $d[16],
+							'src'   => $d[18],
+							'dst'   => $d[19],
+							'sport' => $d[20],
+							'dport' => $d[21],
+							'ipver' => '4',
+							'geoip' => $geoip,
+							'alias' => $pfb_alias,
+							'feed'  => $pfb_query[0],
+							'host'  => $resolved_host,
+							'asn'   => $asn,
+						];
+					} else {
+						$pfb_syslog_fields = [
+							'act'   => $pfb_syslog_act,
+							'dir'   => $dir,
+							'if'    => $int,
+							'proto' => $d[12],
+							'src'   => $d[15],
+							'dst'   => $d[16],
+							'sport' => $d[17],
+							'dport' => $d[18],
+							'ipver' => '6',
+							'geoip' => $geoip,
+							'alias' => $pfb_alias,
+							'feed'  => $pfb_query[0],
+							'host'  => $resolved_host,
+							'asn'   => $asn,
+						];
+					}
+					pfb_syslog_event(pfb_syslog_format_ip($pfb_syslog_fields));
+				}
+
 				// Write to Unified Log
 				if ($dup_entry == '+') {
 					@file_put_contents("{$pfb['unilog']}", "{$l_type},{$log},{$details},{$dup_entry}\n", FILE_APPEND | LOCK_EX);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1482,6 +1482,113 @@ function pfb_log_should_reset(string $schedule, string $last_key, int $now_ts): 
 	return $period !== $last_key;
 }
 
+// ---------------------------------------------------------------------------
+// ADR-38 Phase 1 — Pure key=value syslog event formatters.
+//
+// pfb_syslog_format_ip(array $fields): string
+//   Maps the already-computed IP Block/Permit/Match event fields to a single
+//   space-separated "key=value ..." string suitable for emission as a syslog
+//   message body.  The key order is fixed and documented below; this is the
+//   stable contract that later phases wire to syslog(3) and that tests pin.
+//
+// Key vocabulary (fixed order):
+//   act   — action:   'block'|'pass'|'match'
+//   dir   — direction: 'in'|'out'
+//   if    — friendly interface name (e.g. 'em0', 'LAN')
+//   proto — protocol string (e.g. 'TCP', 'UDP', 'TCP-SA')
+//   src   — source IP address
+//   dst   — destination IP address
+//   sport — source port (omitted when empty)
+//   dport — destination port (omitted when empty)
+//   ipver — IP version: '4' or '6'
+//   geoip — GeoIP ISO country code (omitted when empty or 'Unk'/'Unknown')
+//   alias — pfBlockerNG alias name (omitted when empty or 'Unknown')
+//   feed  — feed name (omitted when empty or 'Unknown')
+//   host  — resolved hostname of the external IP (omitted when empty/'Unknown')
+//   asn   — ASN string (omitted when empty or 'Unknown'/'null')
+//
+// Empty-value convention:
+//   Required fields (act/dir/if/proto/src/dst/ipver) are always present.
+//   Optional fields (sport/dport/geoip/alias/feed/host/asn) are OMITTED
+//   entirely when the value is empty, 'Unknown', 'Unk', or 'null'.
+//
+// Escaping rule:
+//   A value containing a space, '=', or '"' is double-quoted; internal '"'
+//   characters are backslash-escaped (\").  Newlines (\n, \r) are replaced
+//   with a space before quoting to keep the message single-line.
+//   Other punctuation (e.g. '|', ':', '/') is not quoted.
+//
+// PURE — no globals, no I/O, no config reads.
+// ---------------------------------------------------------------------------
+
+/**
+ * pfb_syslog_format_ip — format an IP security event as a key=value string.
+ *
+ * @param array<string,string> $fields  Associative array of event fields.
+ *                                      Keys: act, dir, if, proto, src, dst,
+ *                                      sport, dport, ipver, geoip, alias,
+ *                                      feed, host, asn.
+ * @return string  Space-separated "k=v ..." body; never multi-line.
+ */
+function pfb_syslog_format_ip(array $fields): string
+{
+	// Sentinels treated as "absent" for optional fields.
+	static $absent_sentinels = ['', 'Unknown', 'Unk', 'null'];
+
+	/**
+	 * Escape a single value: strip newlines, then quote if needed.
+	 *
+	 * @param string $v  Raw value.
+	 * @return string    Escaped/quoted value.
+	 */
+	$escape = static function (string $v): string {
+		// Strip embedded newlines to keep the message single-line.
+		$v = str_replace(["\r\n", "\r", "\n"], ' ', $v);
+		// Quote if the value contains space, '=', or '"'.
+		if (strpos($v, ' ') !== FALSE || strpos($v, '=') !== FALSE || strpos($v, '"') !== FALSE) {
+			$v = '"' . str_replace('"', '\\"', $v) . '"';
+		}
+		return $v;
+	};
+
+	$get = static function (string $key) use ($fields): string {
+		return $fields[$key] ?? '';
+	};
+
+	$parts = [];
+
+	// Required fields — always emitted.
+	$parts[] = 'act='   . $escape($get('act'));
+	$parts[] = 'dir='   . $escape($get('dir'));
+	$parts[] = 'if='    . $escape($get('if'));
+	$parts[] = 'proto=' . $escape($get('proto'));
+	$parts[] = 'src='   . $escape($get('src'));
+	$parts[] = 'dst='   . $escape($get('dst'));
+
+	// Optional integer-ish fields — omit when empty.
+	$sport = $get('sport');
+	if ($sport !== '') {
+		$parts[] = 'sport=' . $escape($sport);
+	}
+	$dport = $get('dport');
+	if ($dport !== '') {
+		$parts[] = 'dport=' . $escape($dport);
+	}
+
+	// Required IP version.
+	$parts[] = 'ipver=' . $escape($get('ipver'));
+
+	// Optional enrichment fields — omit when empty or a known absent-sentinel.
+	foreach (['geoip', 'alias', 'feed', 'host', 'asn'] as $key) {
+		$val = $get($key);
+		if (!in_array($val, $absent_sentinels, TRUE)) {
+			$parts[] = $key . '=' . $escape($val);
+		}
+	}
+
+	return implode(' ', $parts);
+}
+
 // logger() and localize_text() are pfSense-core helpers (src/etc/inc/util.inc)
 // on pfSense Plus / master, but absent from released pfSense CE <= 2.8.1. Define
 // fallbacks ONLY when core does not provide them, so this package runs on both:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -931,6 +931,43 @@ function pfb_cfg_registry(): array
 		],
 
 		// -------------------------------------------------------------------
+		// ADR-38: syslog export settings (General / Log Settings section, $gen)
+		// -------------------------------------------------------------------
+
+		// Master toggle — emit security events to syslog: 'on' | '' (checkbox).
+		// Default '' (off) — zero impact on existing installs.
+		'log_syslog' => [
+			'section'       => $gen,
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'since'         => '4.0.0',
+		],
+
+		// syslog facility (Snort-style token string). Default 'log_local6'.
+		// Vocabulary: 'log_local0'..'log_local7', 'log_daemon', 'log_user',
+		// 'log_auth', 'log_kern', 'log_lpr', 'log_mail', 'log_news',
+		// 'log_syslog', 'log_uucp', 'log_cron'. Plain-string identity adapter.
+		'log_syslog_facility' => [
+			'section'       => $gen,
+			'default'       => 'log_local6',
+			'read_adapter'  => NULL,
+			'write_adapter' => NULL,
+			'since'         => '4.0.0',
+		],
+
+		// syslog severity / priority (Snort-style token string). Default 'log_notice'.
+		// Vocabulary: 'log_emerg', 'log_alert', 'log_crit', 'log_err',
+		// 'log_warning', 'log_notice', 'log_info', 'log_debug'. Plain-string identity adapter.
+		'log_syslog_priority' => [
+			'section'       => $gen,
+			'default'       => 'log_notice',
+			'read_adapter'  => NULL,
+			'write_adapter' => NULL,
+			'since'         => '4.0.0',
+		],
+
+		// -------------------------------------------------------------------
 		// SafeSearch section (pfblockerngsafesearch — flat, no /config/0)
 		// -------------------------------------------------------------------
 
@@ -1480,6 +1517,92 @@ function pfb_log_should_reset(string $schedule, string $last_key, int $now_ts): 
 	}
 	// Reset when the period has changed (or when the log has never been reset).
 	return $period !== $last_key;
+}
+
+// ---------------------------------------------------------------------------
+// ADR-38 Phase 2 — syslog facility / severity token → PHP constant maps.
+//
+// pfb_syslog_facility_constant(string $token): int
+//   Maps a stored Snort-style facility token (e.g. 'log_local6') to the
+//   corresponding PHP LOG_* integer constant.  Unknown tokens → LOG_LOCAL6
+//   (the safe default).  The full vocabulary is the Snort-style set:
+//     'log_kern'   → LOG_KERN    'log_user'   → LOG_USER
+//     'log_mail'   → LOG_MAIL    'log_daemon' → LOG_DAEMON
+//     'log_auth'   → LOG_AUTH    'log_syslog' → LOG_SYSLOG
+//     'log_lpr'    → LOG_LPR     'log_news'   → LOG_NEWS
+//     'log_uucp'   → LOG_UUCP   'log_cron'   → LOG_CRON
+//     'log_local0' → LOG_LOCAL0  'log_local1' → LOG_LOCAL1
+//     'log_local2' → LOG_LOCAL2  'log_local3' → LOG_LOCAL3
+//     'log_local4' → LOG_LOCAL4  'log_local5' → LOG_LOCAL5
+//     'log_local6' → LOG_LOCAL6  'log_local7' → LOG_LOCAL7
+//   Default (unknown) → LOG_LOCAL6.
+//
+// pfb_syslog_priority_constant(string $token): int
+//   Maps a stored Snort-style severity token (e.g. 'log_notice') to the
+//   corresponding PHP LOG_* integer constant.  Unknown tokens → LOG_NOTICE
+//   (the safe default).  The full vocabulary:
+//     'log_emerg'   → LOG_EMERG   'log_alert'  → LOG_ALERT
+//     'log_crit'    → LOG_CRIT    'log_err'    → LOG_ERR
+//     'log_warning' → LOG_WARNING 'log_notice' → LOG_NOTICE
+//     'log_info'    → LOG_INFO    'log_debug'  → LOG_DEBUG
+//   Default (unknown) → LOG_NOTICE.
+//
+// Both functions are PURE (no globals, no I/O, no side effects) and DORMANT
+// (uncalled from production code this phase).
+// ---------------------------------------------------------------------------
+
+/**
+ * pfb_syslog_facility_constant — map a stored Snort-style facility token to a PHP constant.
+ *
+ * @param  string $token  Stored token (e.g. 'log_local6').
+ * @return int            PHP LOG_* constant; LOG_LOCAL6 for unknown tokens.
+ */
+function pfb_syslog_facility_constant(string $token): int
+{
+	static $map = [
+		'log_kern'   => LOG_KERN,
+		'log_user'   => LOG_USER,
+		'log_mail'   => LOG_MAIL,
+		'log_daemon' => LOG_DAEMON,
+		'log_auth'   => LOG_AUTH,
+		'log_syslog' => LOG_SYSLOG,
+		'log_lpr'    => LOG_LPR,
+		'log_news'   => LOG_NEWS,
+		'log_uucp'   => LOG_UUCP,
+		'log_cron'   => LOG_CRON,
+		'log_local0' => LOG_LOCAL0,
+		'log_local1' => LOG_LOCAL1,
+		'log_local2' => LOG_LOCAL2,
+		'log_local3' => LOG_LOCAL3,
+		'log_local4' => LOG_LOCAL4,
+		'log_local5' => LOG_LOCAL5,
+		'log_local6' => LOG_LOCAL6,
+		'log_local7' => LOG_LOCAL7,
+	];
+
+	return $map[$token] ?? LOG_LOCAL6;
+}
+
+/**
+ * pfb_syslog_priority_constant — map a stored Snort-style severity token to a PHP constant.
+ *
+ * @param  string $token  Stored token (e.g. 'log_notice').
+ * @return int            PHP LOG_* constant; LOG_NOTICE for unknown tokens.
+ */
+function pfb_syslog_priority_constant(string $token): int
+{
+	static $map = [
+		'log_emerg'   => LOG_EMERG,
+		'log_alert'   => LOG_ALERT,
+		'log_crit'    => LOG_CRIT,
+		'log_err'     => LOG_ERR,
+		'log_warning' => LOG_WARNING,
+		'log_notice'  => LOG_NOTICE,
+		'log_info'    => LOG_INFO,
+		'log_debug'   => LOG_DEBUG,
+	];
+
+	return $map[$token] ?? LOG_NOTICE;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1712,6 +1712,89 @@ function pfb_syslog_format_ip(array $fields): string
 	return implode(' ', $parts);
 }
 
+// ---------------------------------------------------------------------------
+// ADR-38 Phase 3 — PHP syslog event emitter.
+//
+// pfb_syslog_event(string $body): void
+//   Emits ONE syslog record tagged 'pfblockerng' at the configured facility and
+//   severity.  The toggle, facility, and severity are read from PfbConfig once
+//   per PHP process (static cache) to avoid repeated config lookups on the hot
+//   filterlog path.
+//
+//   Behaviour:
+//     - No-op when log_syslog is off (PfbToggle::Off / '').
+//     - openlog() sets the ident and the facility; syslog() emits at the
+//       configured severity; closelog() releases the connection.  This mirrors
+//       the pattern the existing logger() fallback uses.
+//     - Called AT MOST ONCE per filterlog CSV line (the caller gates on the
+//       toggle BEFORE building the field array, so the toggle is not re-checked
+//       here — defence in depth).
+// ---------------------------------------------------------------------------
+
+/**
+ * pfb_syslog_event — emit a single syslog record for one IP security event.
+ *
+ * Reads log_syslog / log_syslog_facility / log_syslog_priority from PfbConfig
+ * once per process (static cache).  No-op when the toggle is off.
+ *
+ * TEST SEAM: when $GLOBALS['pfb_test_syslog_spy'] is set (to any callable or
+ * non-null value), calls to syslog() are redirected to the spy instead of the
+ * real built-in.  The spy receives ($severity, $body, $facility).  The static
+ * cache can be reset between tests by setting $GLOBALS['pfb_test_syslog_reset']
+ * to TRUE before calling (cleared on re-init).
+ *
+ * @param  string $body  The key=value message body (output of pfb_syslog_format_ip()).
+ * @return void
+ */
+function pfb_syslog_event(string $body): void
+{
+	// Static cache: read toggle + facility + severity ONCE per process.
+	// Tests reset via $GLOBALS['pfb_test_syslog_reset'] = TRUE.
+	static $initialised = FALSE;
+	static $enabled     = FALSE;
+	static $facility    = LOG_LOCAL6;
+	static $severity    = LOG_NOTICE;
+
+	// Allow tests to reset the cache between runs.
+	if (!empty($GLOBALS['pfb_test_syslog_reset'])) {
+		$initialised = FALSE;
+		$enabled     = FALSE;
+		$facility    = LOG_LOCAL6;
+		$severity    = LOG_NOTICE;
+		unset($GLOBALS['pfb_test_syslog_reset']);
+	}
+
+	if (!$initialised) {
+		$initialised = TRUE;
+		$enabled = (PfbConfig::read('log_syslog') === PfbToggle::On);
+		if ($enabled) {
+			$facility = pfb_syslog_facility_constant(PfbConfig::read('log_syslog_facility'));
+			$severity = pfb_syslog_priority_constant(PfbConfig::read('log_syslog_priority'));
+		}
+	}
+
+	if (!$enabled) {
+		return;
+	}
+
+	// Production path: openlog / syslog / closelog via PHP built-ins.
+	// Test spy path: record the call in $GLOBALS['pfb_test_syslog_calls'] when a
+	// spy is installed (never calls the real built-ins in test mode).
+	if (isset($GLOBALS['pfb_test_syslog_spy'])) {
+		$GLOBALS['pfb_test_syslog_calls'][] = [
+			'ident'    => 'pfblockerng',
+			'facility' => $facility,
+			'severity' => $severity,
+			'body'     => $body,
+		];
+		return;
+	}
+
+	openlog('pfblockerng', LOG_PID, $facility);
+	syslog($severity, $body);
+	closelog();
+}
+
 // logger() and localize_text() are pfSense-core helpers (src/etc/inc/util.inc)
 // on pfSense Plus / master, but absent from released pfSense CE <= 2.8.1. Define
 // fallbacks ONLY when core does not provide them, so this package runs on both:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -749,6 +749,17 @@ if ($ufound) {
 unset($g['pfblockerng_install']);	// Remove 'Install flag'
 update_status("Upgrading... done\n\nCustom commands completed ... ");
 
+// ADR-38 §2.1: Ensure the Unbound chroot log socket directory exists before
+// (re)starting syslogd.  syslogd uses the <logging><logsocket> element
+// (/var/unbound/var/run/log) to bind an extra unix socket reachable inside the
+// Unbound chroot.  The directory must exist and be owned by unbound BEFORE
+// system_syslogd_start() is called, because syslogd will try to create the
+// socket there.  safe_mkdir() is a no-op when the directory already exists
+// (idempotent); @chown() likewise silently succeeds or no-ops on re-install.
+safe_mkdir('/var/unbound/var/run');
+@chown('/var/unbound/var/run', 'unbound');
+system_syslogd_start(TRUE);
+
 write_config('[pfBlockerNG] Save installation settings');
 return TRUE;
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -108,6 +108,12 @@ $pconfig['log_reset_keep_dnsbl_parse_err']	= PfbConfig::read('log_reset_keep_dns
 $pconfig['log_reset_keep_dnsreplylog']		= PfbConfig::read('log_reset_keep_dnsreplylog');
 $pconfig['log_reset_keep_unilog']		= PfbConfig::read('log_reset_keep_unilog');
 
+// ADR-38: syslog export controls. Read via PfbConfig::read so registered defaults apply.
+// log_syslog uses the PfbToggle adapter — extract the scalar .value for pfb_cfg_toggle_read().
+$pconfig['log_syslog']			= PfbConfig::read('log_syslog')->value;
+$pconfig['log_syslog_facility']		= PfbConfig::read('log_syslog_facility');
+$pconfig['log_syslog_priority']		= PfbConfig::read('log_syslog_priority');
+
 // Select field options
 $options_pfb_interval	= [	'1' => 'Every hour',
 				'2' => 'Every 2 hours',
@@ -130,6 +136,21 @@ $options_log_types	= [	'100' => '100', '1000' => '1,000', '2000' => '2,000', '40
 				'nolimit' => 'No Limit - Not recommended' ];
 // ADR-30: rotation schedule options for each per-log schedule select.
 $options_log_rotate	= [ 'off' => 'Off', 'daily' => 'Daily', 'weekly' => 'Weekly', 'monthly' => 'Monthly' ];
+
+// ADR-38: syslog facility and priority option lists (Snort-style token → display label).
+$options_log_syslog_facility = [
+	'log_local0' => 'local0', 'log_local1' => 'local1', 'log_local2' => 'local2', 'log_local3' => 'local3',
+	'log_local4' => 'local4', 'log_local5' => 'local5', 'log_local6' => 'local6 (default)', 'log_local7' => 'local7',
+	'log_daemon' => 'daemon', 'log_user'   => 'user',   'log_auth'   => 'auth',
+	'log_kern'   => 'kern',   'log_mail'   => 'mail',   'log_lpr'    => 'lpr',
+	'log_news'   => 'news',   'log_uucp'   => 'uucp',   'log_cron'   => 'cron',
+	'log_syslog' => 'syslog',
+];
+$options_log_syslog_priority = [
+	'log_emerg'   => 'emerg',   'log_alert'   => 'alert',   'log_crit'    => 'crit',
+	'log_err'     => 'err',     'log_warning' => 'warning',
+	'log_notice'  => 'notice (default)', 'log_info' => 'info', 'log_debug' => 'debug',
+];
 
 
 // $input_errors is read unconditionally in the render section below, so it must be
@@ -205,6 +226,17 @@ if ($_POST) {
 			}
 		}
 
+		// ADR-38: validate syslog facility and priority selects.
+		$_v = $_POST['log_syslog_facility'] ?? '';
+		if (is_array($_v) || !array_key_exists($_v, $options_log_syslog_facility)) {
+			$_POST['log_syslog_facility'] = 'log_local6';
+		}
+		$_v = $_POST['log_syslog_priority'] ?? '';
+		if (is_array($_v) || !array_key_exists($_v, $options_log_syslog_priority)) {
+			$_POST['log_syslog_priority'] = 'log_notice';
+		}
+		unset($_v);
+
 		if (!$input_errors) {
 
 			$pfb['gconfig']['enable_cb']			= pfb_filter($_POST['enable_cb'], PFB_FILTER_ON_OFF, 'general', '');
@@ -269,6 +301,13 @@ if ($_POST) {
 			$pfb['gconfig']['log_reset_keep_dnsbl_parse_err']	= $_POST['log_reset_keep_dnsbl_parse_err']	?: '0';
 			$pfb['gconfig']['log_reset_keep_dnsreplylog']		= $_POST['log_reset_keep_dnsreplylog']		?: '0';
 			$pfb['gconfig']['log_reset_keep_unilog']		= $_POST['log_reset_keep_unilog']		?: '0';
+
+			// ADR-38: persist syslog export settings. Written into $pfb['gconfig'] so the
+			// writeSection() call below includes them; a bare PfbConfig::write() before
+			// writeSection() would be clobbered by the section-level write.
+			$pfb['gconfig']['log_syslog']			= pfb_filter($_POST['log_syslog'], PFB_FILTER_ON_OFF, 'general', '');
+			$pfb['gconfig']['log_syslog_facility']		= $_POST['log_syslog_facility']	?: 'log_local6';
+			$pfb['gconfig']['log_syslog_priority']		= $_POST['log_syslog_priority']	?: 'log_notice';
 
 			PfbConfig::writeSection('installedpackages/pfblockerng/config/0', $pfb['gconfig']);
 			write_config('[pfBlockerNG] save General settings');
@@ -460,6 +499,38 @@ foreach ($log_types as $logdescr => $logtype) {
 	}
 	$section->add($group);
 }
+
+// ADR-38: syslog export controls — appended at the end of the Log Settings section.
+$section->addInput(new Form_Checkbox(
+	'log_syslog',
+	'Send Security Events to System Log',
+	gettext('Enable'),
+	pfb_cfg_toggle_read($pconfig['log_syslog']) === PfbToggle::On,
+	'on'
+))->setHelp('When enabled, every IP Block/Permit/Match and DNSBL block event is also '
+		. 'emitted to syslog (tagged <code>pfblockerng</code>, in <code>key=value</code> form) '
+		. 'at the selected facility and severity. Remote delivery: pfSense '
+		. '<strong>Status &gt; System Logs &gt; Settings &gt; Remote Logging &rarr; Everything</strong>. '
+		. 'Default facility: <strong>local6</strong>.'
+);
+
+$section->addInput(new Form_Select(
+	'log_syslog_facility',
+	'Syslog Facility',
+	$pconfig['log_syslog_facility'],
+	$options_log_syslog_facility
+))->setHelp('Default: <strong>local6</strong><br />Syslog facility for pfBlockerNG security events. '
+		. 'Choose a facility not already used by another pfSense service.'
+)->setAttribute('id', 'log_syslog_facility');
+
+$section->addInput(new Form_Select(
+	'log_syslog_priority',
+	'Syslog Severity',
+	$pconfig['log_syslog_priority'],
+	$options_log_syslog_priority
+))->setHelp('Default: <strong>notice</strong><br />Severity level applied to all exported security events.'
+)->setAttribute('id', 'log_syslog_priority');
+
 $form->add($section);
 
 $section = new Form_Section('Support');
@@ -570,6 +641,18 @@ events.push(function() {
 
 	$('#pfb_feed_internal_filter').click(pfb_sync_internal_filter);
 	pfb_sync_internal_filter();
+
+	// ADR-38: grey out facility/severity selects when the syslog toggle is off.
+	// Selects are always submitted (not disabled on POST); they remain configured
+	// so the user's choice is preserved when re-enabling.
+	function pfb_sync_syslog() {
+		var enabled = $('#log_syslog').prop('checked');
+		disableInput('log_syslog_facility', !enabled);
+		disableInput('log_syslog_priority', !enabled);
+	}
+
+	$('#log_syslog').click(pfb_sync_syslog);
+	pfb_sync_syslog();
 });
 //]]>
 </script>

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -305,15 +305,41 @@ if ($_POST) {
 			// ADR-38: persist syslog export settings. Written into $pfb['gconfig'] so the
 			// writeSection() call below includes them; a bare PfbConfig::write() before
 			// writeSection() would be clobbered by the section-level write.
-			$pfb['gconfig']['log_syslog']			= pfb_filter($_POST['log_syslog'], PFB_FILTER_ON_OFF, 'general', '');
-			$pfb['gconfig']['log_syslog_facility']		= $_POST['log_syslog_facility']	?: 'log_local6';
-			$pfb['gconfig']['log_syslog_priority']		= $_POST['log_syslog_priority']	?: 'log_notice';
+			//
+			// Capture the pre-save values so we can detect a syslog change after the
+			// write and restart pfb_filter (its static cache would otherwise hold stale
+			// settings for the lifetime of the process).
+			$pfb_old_log_syslog		= $pfb['gconfig']['log_syslog']			?? '';
+			$pfb_old_log_facility		= $pfb['gconfig']['log_syslog_facility']	?? '';
+			$pfb_old_log_priority		= $pfb['gconfig']['log_syslog_priority']	?? '';
+
+			$pfb['gconfig']['log_syslog']	= pfb_filter($_POST['log_syslog'], PFB_FILTER_ON_OFF, 'general', '');
+
+			// The facility and priority selects are disabled (greyed-out) when the
+			// toggle is off, so the browser does not submit them. Preserve the
+			// previously stored values in that case rather than overwriting with the
+			// absent POST fields (mirrors the allowlist-textarea pattern above).
+			if ($pfb['gconfig']['log_syslog'] === 'on') {
+				$pfb['gconfig']['log_syslog_facility']	= $_POST['log_syslog_facility']	?: 'log_local6';
+				$pfb['gconfig']['log_syslog_priority']	= $_POST['log_syslog_priority']	?: 'log_notice';
+			}
 
 			PfbConfig::writeSection('installedpackages/pfblockerng/config/0', $pfb['gconfig']);
 			write_config('[pfBlockerNG] save General settings');
 
 			$pfb['save'] = TRUE;
 			sync_package_pfblockerng();
+
+			// If any syslog key changed, restart pfb_filter so its per-process static
+			// cache (in pfb_syslog_event()) picks up the new settings immediately.
+			if (($pfb['gconfig']['log_syslog']		!== $pfb_old_log_syslog)	||
+			    ($pfb['gconfig']['log_syslog_facility']	!== $pfb_old_log_facility)	||
+			    ($pfb['gconfig']['log_syslog_priority']	!== $pfb_old_log_priority)) {
+				if (is_service_running('pfb_filter')) {
+					restart_service('pfb_filter');
+				}
+			}
+
 			header('Location: /pfblockerng/pfblockerng_general.php');
 			exit;
 		}
@@ -643,8 +669,8 @@ events.push(function() {
 	pfb_sync_internal_filter();
 
 	// ADR-38: grey out facility/severity selects when the syslog toggle is off.
-	// Selects are always submitted (not disabled on POST); they remain configured
-	// so the user's choice is preserved when re-enabling.
+	// Disabled selects are not submitted by the browser; the POST handler preserves
+	// the stored values across an off-save so the user's choice is intact on re-enable.
 	function pfb_sync_syslog() {
 		var enabled = $('#log_syslog').prop('checked');
 		disableInput('log_syslog_facility', !enabled);

--- a/stubs/pfsense/system.php
+++ b/stubs/pfsense/system.php
@@ -370,3 +370,9 @@ function _getHostName($mac, $ip) {}
 
 /** @return mixed */
 function check_dnsavailable($proto='inet') {}
+
+// Hand-added (not auto-generated): system_syslogd_start() is in system.inc,
+// absent from the 2.7.2 snapshot used for the bulk-generated stubs.
+// Signature verified against pfSense/src/etc/inc/syslog.inc master.
+/** @return mixed */
+function system_syslogd_start(bool $sighup = false) {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,10 @@ def reset_pfb_globals() -> None:
         # test can read the stable names without spinning up the watcher.
         "pfb_py_control": "pfb_py_control",
         "pfb_py_control_applied": "pfb_py_control.applied",
+        # ADR-38 Phase 4: syslog export defaults (off, LOG_LOCAL6, LOG_NOTICE).
+        "syslog_enable": False,
+        "syslog_facility": 22,
+        "syslog_priority": 5,
     }
     pfb_unbound.dataDB = defaultdict(list)
     pfb_unbound.zoneDB = defaultdict(list)
@@ -139,6 +143,11 @@ def reset_pfb_globals() -> None:
     for _db in list(pfb_unbound._db_conns.keys()):
         pfb_unbound._db_close(_db)
     pfb_unbound._db_conns.clear()
+
+    # ADR-38 Phase 4: reset the module-level syslog handler state so each test
+    # starts with no active handler and no failure latch.
+    pfb_unbound._syslog_handler = None
+    pfb_unbound._syslog_failed = False
 
     # Reset the logging pipeline between tests (stop a leaked QueueListener thread
     # and drop the cached per-file loggers so the synchronous fallback is used by

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -290,6 +290,238 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// ADR-38 Phase 2 — log_syslog / log_syslog_facility / log_syslog_priority
+	// -----------------------------------------------------------------------
+
+	/**
+	 * log_syslog toggle field round-trips losslessly for 'on' (enabled).
+	 *
+	 * Scenario:
+	 *   Background: log_syslog is a PfbToggle field; vocabulary = {'on', ''}.
+	 *     Given stored = 'on'.
+	 *     When PfbConfig::write('log_syslog', PfbConfig::read('log_syslog')).
+	 *     Then stored string == 'on' (write(read('on')) == 'on').
+	 */
+	public function testLogSyslogRoundTripOn(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog';
+
+		// Given: 'on' stored.
+		$this->seedConfig($path, 'on');
+
+		// Before: raw value is 'on'.
+		$this->assertSame('on', config_get_path($path), "before: log_syslog seed is 'on'");
+
+		// When: read -> write.
+		$enum = PfbConfig::read('log_syslog');
+		$this->assertSame(PfbToggle::On, $enum, "read: log_syslog 'on' -> PfbToggle::On");
+
+		// After: write back produces 'on'.
+		PfbConfig::write('log_syslog', $enum);
+		$this->assertSame('on', config_get_path($path), "write(read('on'))==on for log_syslog");
+	}
+
+	/**
+	 * log_syslog toggle field round-trips losslessly for '' (disabled).
+	 *
+	 * Scenario:
+	 *   Background: log_syslog vocabulary = {'on', ''}.
+	 *     Given stored = '' (unchecked / off).
+	 *     When PfbConfig::write('log_syslog', PfbConfig::read('log_syslog')).
+	 *     Then stored string == '' (write(read('')) == '').
+	 */
+	public function testLogSyslogRoundTripOff(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog';
+
+		// Given: '' stored.
+		$this->seedConfig($path, '');
+
+		// Before: raw value is ''.
+		$this->assertSame('', config_get_path($path), "before: log_syslog seed is ''");
+
+		// When: read -> write.
+		$enum = PfbConfig::read('log_syslog');
+		$this->assertSame(PfbToggle::Off, $enum, "read: log_syslog '' -> PfbToggle::Off");
+
+		// After: write back produces ''.
+		PfbConfig::write('log_syslog', $enum);
+		$this->assertSame('', config_get_path($path), "write(read(''))=='' for log_syslog");
+	}
+
+	/**
+	 * log_syslog absent key returns PfbToggle::Off (default '' applied via toggle adapter).
+	 *
+	 * Scenario:
+	 *   Background: log_syslog registered default is '' (off).
+	 *     Given no stored value.
+	 *     When PfbConfig::read('log_syslog').
+	 *     Then PfbToggle::Off is returned (registered default '').
+	 */
+	public function testLogSyslogAbsentKeyReturnsOffDefault(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog';
+
+		// Before: absent.
+		$this->assertNull(config_get_path($path), 'before: log_syslog must be absent');
+
+		// When/Then: default '' → PfbToggle::Off.
+		$result = PfbConfig::read('log_syslog');
+		$this->assertSame(PfbToggle::Off, $result, 'log_syslog absent -> Off (default)');
+	}
+
+	/**
+	 * log_syslog_facility plain field round-trips losslessly (identity adapter).
+	 *
+	 * Scenario:
+	 *   Background: log_syslog_facility uses null/null (plain-string identity) adapters.
+	 *     Given stored = 'log_local6' (the registered default) and 'log_local0' (alternate).
+	 *     When PfbConfig::write($key, PfbConfig::read($key)).
+	 *     Then stored == original (write(read(v)) == v for every vocabulary value).
+	 */
+	public function testLogSyslogFacilityRoundTripDefaultValue(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog_facility';
+
+		// Given: default 'log_local6'.
+		$this->seedConfig($path, 'log_local6');
+
+		// Before.
+		$this->assertSame('log_local6', config_get_path($path));
+
+		// When/After.
+		$value = PfbConfig::read('log_syslog_facility');
+		$this->assertSame('log_local6', $value, "read: log_syslog_facility 'log_local6' -> 'log_local6'");
+
+		PfbConfig::write('log_syslog_facility', $value);
+		$this->assertSame('log_local6', config_get_path($path),
+			"write(read('log_local6'))=='log_local6' for log_syslog_facility"
+		);
+	}
+
+	public function testLogSyslogFacilityRoundTripAlternateValues(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog_facility';
+
+		// Verify a selection of alternate vocabulary values round-trip losslessly.
+		$tokens = ['log_local0', 'log_local1', 'log_local2', 'log_local3',
+		           'log_local4', 'log_local5', 'log_local7',
+		           'log_daemon', 'log_user', 'log_auth', 'log_kern',
+		           'log_lpr', 'log_mail', 'log_news', 'log_syslog',
+		           'log_uucp', 'log_cron'];
+
+		foreach ($tokens as $token) {
+			$GLOBALS['config'] = [];
+			$this->seedConfig($path, $token);
+
+			$this->assertSame($token, config_get_path($path), "before: log_syslog_facility seed='{$token}'");
+
+			$value = PfbConfig::read('log_syslog_facility');
+			$this->assertSame($token, $value, "read: log_syslog_facility '{$token}' -> '{$token}'");
+
+			PfbConfig::write('log_syslog_facility', $value);
+			$this->assertSame($token, config_get_path($path),
+				"write(read('{$token}'))=='{$token}' for log_syslog_facility"
+			);
+		}
+	}
+
+	/**
+	 * log_syslog_facility absent key returns 'log_local6' (registered default).
+	 *
+	 * Scenario:
+	 *   Background: log_syslog_facility registered default is 'log_local6'.
+	 *     Given no stored value.
+	 *     When PfbConfig::read('log_syslog_facility').
+	 *     Then 'log_local6' is returned (registered default; no crash).
+	 */
+	public function testLogSyslogFacilityAbsentKeyReturnsLogLocal6Default(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog_facility';
+
+		// Before: absent.
+		$this->assertNull(config_get_path($path), 'before: log_syslog_facility must be absent');
+
+		// When/Then.
+		$result = PfbConfig::read('log_syslog_facility');
+		$this->assertSame('log_local6', $result, "log_syslog_facility absent -> 'log_local6' (registered default)");
+	}
+
+	/**
+	 * log_syslog_priority plain field round-trips losslessly (identity adapter).
+	 *
+	 * Scenario:
+	 *   Background: log_syslog_priority uses null/null (plain-string identity) adapters.
+	 *     Given stored = 'log_notice' (the registered default) and other vocabulary tokens.
+	 *     When PfbConfig::write($key, PfbConfig::read($key)).
+	 *     Then stored == original (write(read(v)) == v for every vocabulary value).
+	 */
+	public function testLogSyslogPriorityRoundTripDefaultValue(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog_priority';
+
+		// Given: default 'log_notice'.
+		$this->seedConfig($path, 'log_notice');
+
+		// Before.
+		$this->assertSame('log_notice', config_get_path($path));
+
+		// When/After.
+		$value = PfbConfig::read('log_syslog_priority');
+		$this->assertSame('log_notice', $value, "read: log_syslog_priority 'log_notice' -> 'log_notice'");
+
+		PfbConfig::write('log_syslog_priority', $value);
+		$this->assertSame('log_notice', config_get_path($path),
+			"write(read('log_notice'))=='log_notice' for log_syslog_priority"
+		);
+	}
+
+	public function testLogSyslogPriorityRoundTripAllVocabularyValues(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog_priority';
+
+		// Verify every vocabulary value round-trips losslessly.
+		$tokens = ['log_emerg', 'log_alert', 'log_crit', 'log_err',
+		           'log_warning', 'log_notice', 'log_info', 'log_debug'];
+
+		foreach ($tokens as $token) {
+			$GLOBALS['config'] = [];
+			$this->seedConfig($path, $token);
+
+			$this->assertSame($token, config_get_path($path), "before: log_syslog_priority seed='{$token}'");
+
+			$value = PfbConfig::read('log_syslog_priority');
+			$this->assertSame($token, $value, "read: log_syslog_priority '{$token}' -> '{$token}'");
+
+			PfbConfig::write('log_syslog_priority', $value);
+			$this->assertSame($token, config_get_path($path),
+				"write(read('{$token}'))=='{$token}' for log_syslog_priority"
+			);
+		}
+	}
+
+	/**
+	 * log_syslog_priority absent key returns 'log_notice' (registered default).
+	 *
+	 * Scenario:
+	 *   Background: log_syslog_priority registered default is 'log_notice'.
+	 *     Given no stored value.
+	 *     When PfbConfig::read('log_syslog_priority').
+	 *     Then 'log_notice' is returned (registered default; no crash).
+	 */
+	public function testLogSyslogPriorityAbsentKeyReturnsLogNoticeDefault(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog_priority';
+
+		// Before: absent.
+		$this->assertNull(config_get_path($path), 'before: log_syslog_priority must be absent');
+
+		// When/Then.
+		$result = PfbConfig::read('log_syslog_priority');
+		$this->assertSame('log_notice', $result, "log_syslog_priority absent -> 'log_notice' (registered default)");
+	}
+
+	// -----------------------------------------------------------------------
 	// C — Inventory completeness
 	// -----------------------------------------------------------------------
 
@@ -448,6 +680,10 @@ final class CfgGatewayTest extends TestCase
 			'pfb_feed_internal_filter',
 			'pfb_feed_internal_allowlist',
 			'pfb_reuse',
+			// ADR-38: syslog export settings
+			'log_syslog',
+			'log_syslog_facility',
+			'log_syslog_priority',
 
 			// pfblockerngdnsblsettings/config/0 scalars
 			'pfb_dnsbl',

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -936,6 +936,192 @@ final class RollbackContractTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// H -- ADR-38 Phase 2: log_syslog / log_syslog_facility / log_syslog_priority
+	// -----------------------------------------------------------------------
+
+	/**
+	 * log_syslog satisfies both rollback invariants for both toggle vocabulary tokens.
+	 *
+	 * Note: log_syslog is a toggle-adapted field and is automatically covered by
+	 * testAllToggleFieldsForwardAndBackwardForEveryVocabToken() via toggleAdaptedKeys().
+	 * This test explicitly pins the new field to make coverage visible.
+	 *
+	 * Scenario:
+	 *   Background: log_syslog vocabulary = {'on', ''}.
+	 *     Given stored token 'on' then ''.
+	 *     When PfbConfig::read('log_syslog') and PfbConfig::write('log_syslog', result).
+	 *     Then (FORWARD) result is PfbToggle enum.
+	 *     And (BACKWARD) stored value is in {'on', ''}.
+	 */
+	public function testLogSyslogForwardAndBackwardForEveryVocabToken(): void
+	{
+		$path  = 'installedpackages/pfblockerng/config/0/log_syslog';
+		$vocab = pfb_cfg_field_vocab()['toggle'];
+
+		foreach ($vocab as $token) {
+			// Reset.
+			$GLOBALS['config'] = [];
+			config_set_path($path, $token);
+
+			// BEFORE: raw value confirmed.
+			$this->assertSame($token, config_get_path($path),
+				"before forward+backward: log_syslog token='{$token}'"
+			);
+
+			// FORWARD: read returns PfbToggle enum.
+			$runtime = PfbConfig::read('log_syslog');
+			$this->assertInstanceOf(PfbToggle::class, $runtime,
+				"FORWARD: log_syslog token='{$token}' must yield PfbToggle"
+			);
+
+			// BACKWARD: write(runtime) stored value is in vocabulary.
+			PfbConfig::write('log_syslog', $runtime);
+			$stored = (string) config_get_path($path);
+			$this->assertContains($stored, $vocab,
+				"BACKWARD: log_syslog token='{$token}' write(read) stored='{$stored}' not in vocab"
+			);
+		}
+	}
+
+	/**
+	 * log_syslog_facility: FORWARD + BACKWARD for the registered facility vocabulary.
+	 *
+	 * Scenario:
+	 *   Background: log_syslog_facility uses null/null adapters (plain-string identity).
+	 *     Given each Snort-style facility token.
+	 *     When PfbConfig::read('log_syslog_facility').
+	 *     Then (FORWARD) result is the same string (no crash, identity).
+	 *     And (BACKWARD) write(read(v)) stores exactly v (no novel token).
+	 */
+	public function testLogSyslogFacilityForwardAndBackwardForEveryVocabToken(): void
+	{
+		$path  = 'installedpackages/pfblockerng/config/0/log_syslog_facility';
+		$vocab = [
+			'log_kern', 'log_user', 'log_mail', 'log_daemon', 'log_auth', 'log_syslog',
+			'log_lpr', 'log_news', 'log_uucp', 'log_cron',
+			'log_local0', 'log_local1', 'log_local2', 'log_local3',
+			'log_local4', 'log_local5', 'log_local6', 'log_local7',
+		];
+
+		foreach ($vocab as $token) {
+			// Reset.
+			$GLOBALS['config'] = [];
+			config_set_path($path, $token);
+
+			// BEFORE.
+			$this->assertSame($token, config_get_path($path),
+				"before forward+backward: log_syslog_facility token='{$token}'"
+			);
+
+			// FORWARD: identity adapter → same string.
+			$runtime = PfbConfig::read('log_syslog_facility');
+			$this->assertIsString($runtime,
+				"FORWARD: log_syslog_facility token='{$token}' must return a string"
+			);
+			$this->assertSame($token, $runtime,
+				"FORWARD: log_syslog_facility token='{$token}' identity adapter must return token unchanged"
+			);
+
+			// BACKWARD: write(runtime) stores exactly v.
+			PfbConfig::write('log_syslog_facility', $runtime);
+			$stored = config_get_path($path);
+			$this->assertSame($token, $stored,
+				"BACKWARD: log_syslog_facility token='{$token}' write(read) must store '{$token}' (identity)"
+			);
+		}
+	}
+
+	/**
+	 * log_syslog_facility: absent key returns 'log_local6' (registered default).
+	 *
+	 * Scenario:
+	 *   Background: log_syslog_facility registered default is 'log_local6'.
+	 *     Given no stored value.
+	 *     When PfbConfig::read('log_syslog_facility').
+	 *     Then 'log_local6' is returned (no crash).
+	 */
+	public function testLogSyslogFacilityAbsentKeyReturnsLogLocal6Default(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog_facility';
+
+		// GIVEN: absent.
+		$this->assertNull(config_get_path($path), 'before: log_syslog_facility must be absent');
+
+		// FORWARD: registered default returned — no crash.
+		$result = PfbConfig::read('log_syslog_facility');
+		$this->assertSame('log_local6', $result,
+			'FORWARD: log_syslog_facility absent must return "log_local6" (registered default)'
+		);
+	}
+
+	/**
+	 * log_syslog_priority: FORWARD + BACKWARD for the registered severity vocabulary.
+	 *
+	 * Scenario:
+	 *   Background: log_syslog_priority uses null/null adapters (plain-string identity).
+	 *     Given each Snort-style severity token.
+	 *     When PfbConfig::read('log_syslog_priority').
+	 *     Then (FORWARD) result is the same string (no crash, identity).
+	 *     And (BACKWARD) write(read(v)) stores exactly v (no novel token).
+	 */
+	public function testLogSyslogPriorityForwardAndBackwardForEveryVocabToken(): void
+	{
+		$path  = 'installedpackages/pfblockerng/config/0/log_syslog_priority';
+		$vocab = ['log_emerg', 'log_alert', 'log_crit', 'log_err',
+		          'log_warning', 'log_notice', 'log_info', 'log_debug'];
+
+		foreach ($vocab as $token) {
+			// Reset.
+			$GLOBALS['config'] = [];
+			config_set_path($path, $token);
+
+			// BEFORE.
+			$this->assertSame($token, config_get_path($path),
+				"before forward+backward: log_syslog_priority token='{$token}'"
+			);
+
+			// FORWARD: identity adapter → same string.
+			$runtime = PfbConfig::read('log_syslog_priority');
+			$this->assertIsString($runtime,
+				"FORWARD: log_syslog_priority token='{$token}' must return a string"
+			);
+			$this->assertSame($token, $runtime,
+				"FORWARD: log_syslog_priority token='{$token}' identity adapter must return token unchanged"
+			);
+
+			// BACKWARD: write(runtime) stores exactly v.
+			PfbConfig::write('log_syslog_priority', $runtime);
+			$stored = config_get_path($path);
+			$this->assertSame($token, $stored,
+				"BACKWARD: log_syslog_priority token='{$token}' write(read) must store '{$token}' (identity)"
+			);
+		}
+	}
+
+	/**
+	 * log_syslog_priority: absent key returns 'log_notice' (registered default).
+	 *
+	 * Scenario:
+	 *   Background: log_syslog_priority registered default is 'log_notice'.
+	 *     Given no stored value.
+	 *     When PfbConfig::read('log_syslog_priority').
+	 *     Then 'log_notice' is returned (no crash).
+	 */
+	public function testLogSyslogPriorityAbsentKeyReturnsLogNoticeDefault(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/log_syslog_priority';
+
+		// GIVEN: absent.
+		$this->assertNull(config_get_path($path), 'before: log_syslog_priority must be absent');
+
+		// FORWARD: registered default returned — no crash.
+		$result = PfbConfig::read('log_syslog_priority');
+		$this->assertSame('log_notice', $result,
+			'FORWARD: log_syslog_priority absent must return "log_notice" (registered default)'
+		);
+	}
+
+	// -----------------------------------------------------------------------
 	// Private helpers
 	// -----------------------------------------------------------------------
 

--- a/tests/php/SyslogEventTest.php
+++ b/tests/php/SyslogEventTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-38 Phase 3 — pfb_syslog_event() tests.
+ *
+ * pfb_syslog_event() is the PHP IP-leg syslog emitter.  It reads the toggle,
+ * facility, and severity from PfbConfig once per process (static cache, resettable
+ * via $GLOBALS['pfb_test_syslog_reset']).  The test-spy path records calls in
+ * $GLOBALS['pfb_test_syslog_calls'] when $GLOBALS['pfb_test_syslog_spy'] is set.
+ *
+ * Contract under test (ADR-38 §2.2):
+ *   - Toggle OFF  ⇒ zero syslog calls (no emission, no side effect).
+ *   - Toggle ON   ⇒ exactly one call per pfb_syslog_event() invocation, with the
+ *                   exact body passed, the configured facility, and the configured
+ *                   severity.
+ */
+final class SyslogEventTest extends TestCase
+{
+	/** Seed config + reset the static cache between every test. */
+	protected function setUp(): void
+	{
+		// Install the spy so real syslog() is never called in tests.
+		$GLOBALS['pfb_test_syslog_spy']   = TRUE;
+		$GLOBALS['pfb_test_syslog_calls'] = [];
+		// Force the static cache to re-read from config on the next call.
+		$GLOBALS['pfb_test_syslog_reset'] = TRUE;
+	}
+
+	protected function tearDown(): void
+	{
+		unset(
+			$GLOBALS['pfb_test_syslog_spy'],
+			$GLOBALS['pfb_test_syslog_calls'],
+			$GLOBALS['pfb_test_syslog_reset']
+		);
+		// Wipe config seeded by individual tests.
+		config_del_path('installedpackages/pfblockerng/config/0/log_syslog');
+		config_del_path('installedpackages/pfblockerng/config/0/log_syslog_facility');
+		config_del_path('installedpackages/pfblockerng/config/0/log_syslog_priority');
+		// Reset the static cache one more time so next test starts clean.
+		$GLOBALS['pfb_test_syslog_reset'] = TRUE;
+		pfb_syslog_event('__teardown_reset__');
+		unset($GLOBALS['pfb_test_syslog_reset'], $GLOBALS['pfb_test_syslog_calls'], $GLOBALS['pfb_test_syslog_spy']);
+	}
+
+	// -----------------------------------------------------------------------
+	// Toggle OFF — no emission
+	// -----------------------------------------------------------------------
+
+	/**
+	 * pfb_syslog_event is a no-op when log_syslog is off.
+	 *
+	 * Scenario:
+	 *   Background: log_syslog toggle follows PfbToggle (off = '').
+	 *     Given log_syslog is '' (off, the default).
+	 *     When  pfb_syslog_event('act=block dir=in if=em0 ...') is called.
+	 *     Then  no syslog call is recorded.
+	 */
+	public function testToggleOffProducesNoSyslogCall(): void
+	{
+		// Before: seed toggle explicitly as off; spy installed by setUp().
+		config_set_path('installedpackages/pfblockerng/config/0/log_syslog', '');
+		// Force re-read of config (cache was reset in setUp).
+
+		// When: call the emitter with a realistic body.
+		pfb_syslog_event('act=block dir=in if=em0 proto=TCP src=1.2.3.4 dst=5.6.7.8 ipver=4');
+
+		// Then: no syslog call.
+		$calls = $GLOBALS['pfb_test_syslog_calls'] ?? [];
+		$this->assertSame([], $calls, 'toggle off: pfb_syslog_event() must produce no syslog call');
+	}
+
+	/**
+	 * Toggle absent (key not set in config) — treated as off, no emission.
+	 *
+	 * Scenario:
+	 *   Background: PfbConfig returns PfbToggle::Off for absent log_syslog (default '').
+	 *     Given log_syslog is absent from config (key not present).
+	 *     When  pfb_syslog_event() is called.
+	 *     Then  no syslog call is recorded.
+	 */
+	public function testToggleAbsentProducesNoSyslogCall(): void
+	{
+		// Before: no log_syslog key in config (setUp already cleared it).
+
+		pfb_syslog_event('act=pass dir=out if=wan proto=UDP src=10.0.0.1 dst=8.8.8.8 ipver=4');
+
+		$calls = $GLOBALS['pfb_test_syslog_calls'] ?? [];
+		$this->assertSame([], $calls, 'toggle absent: pfb_syslog_event() must produce no syslog call');
+	}
+
+	// -----------------------------------------------------------------------
+	// Toggle ON — exactly one call, correct body + facility + severity
+	// -----------------------------------------------------------------------
+
+	/**
+	 * pfb_syslog_event emits exactly one syslog call with the supplied body when on.
+	 *
+	 * Scenario:
+	 *   Background: toggle on, default facility (log_local6) and severity (log_notice).
+	 *     Given log_syslog is 'on' (PfbToggle::On).
+	 *     When  pfb_syslog_event('act=block dir=in ...') is called once.
+	 *     Then  exactly one syslog call is recorded.
+	 *     And   the recorded body equals the argument passed to pfb_syslog_event().
+	 *     And   the ident is 'pfblockerng'.
+	 *     And   the facility is LOG_LOCAL6 (the default).
+	 *     And   the severity is LOG_NOTICE (the default).
+	 */
+	public function testToggleOnEmitsExactlyOneCallWithCorrectBody(): void
+	{
+		// Before: confirm no calls before enabling.
+		$this->assertSame([], $GLOBALS['pfb_test_syslog_calls'], 'before: no calls before toggle on');
+
+		// Given: enable syslog with default facility/severity.
+		config_set_path('installedpackages/pfblockerng/config/0/log_syslog', 'on');
+		// log_syslog_facility and log_syslog_priority absent → defaults.
+
+		$body = 'act=block dir=in if=em0 proto=TCP src=203.0.113.1 dst=192.168.1.1 sport=54321 dport=80 ipver=4 geoip=US alias=pfB_DENY feed=EasyList';
+
+		// When: call once.
+		pfb_syslog_event($body);
+
+		// Then: exactly one call.
+		$calls = $GLOBALS['pfb_test_syslog_calls'];
+		$this->assertCount(1, $calls, 'toggle on: exactly one syslog call per pfb_syslog_event() invocation');
+
+		// And: correct body.
+		$this->assertSame($body, $calls[0]['body'], 'toggle on: syslog body equals the argument passed');
+
+		// And: correct ident.
+		$this->assertSame('pfblockerng', $calls[0]['ident'], 'toggle on: ident is pfblockerng');
+
+		// And: default facility (log_syslog_facility absent → LOG_LOCAL6).
+		$this->assertSame(LOG_LOCAL6, $calls[0]['facility'], 'toggle on: default facility is LOG_LOCAL6');
+
+		// And: default severity (log_syslog_priority absent → LOG_NOTICE).
+		$this->assertSame(LOG_NOTICE, $calls[0]['severity'], 'toggle on: default severity is LOG_NOTICE');
+	}
+
+	/**
+	 * pfb_syslog_event respects a non-default facility token.
+	 *
+	 * Scenario:
+	 *   Background: toggle on, facility overridden to log_local2.
+	 *     Given log_syslog_facility is 'log_local2'.
+	 *     When  pfb_syslog_event() is called.
+	 *     Then  the recorded facility is LOG_LOCAL2.
+	 */
+	public function testConfiguredFacilityIsUsed(): void
+	{
+		config_set_path('installedpackages/pfblockerng/config/0/log_syslog', 'on');
+		config_set_path('installedpackages/pfblockerng/config/0/log_syslog_facility', 'log_local2');
+
+		pfb_syslog_event('act=pass dir=out if=em0 proto=UDP src=192.168.1.10 dst=8.8.8.8 ipver=4');
+
+		$calls = $GLOBALS['pfb_test_syslog_calls'];
+		$this->assertCount(1, $calls, 'non-default facility: exactly one call');
+		$this->assertSame(LOG_LOCAL2, $calls[0]['facility'], 'non-default facility: LOG_LOCAL2 used');
+	}
+
+	/**
+	 * pfb_syslog_event respects a non-default severity token.
+	 *
+	 * Scenario:
+	 *   Background: toggle on, severity overridden to log_warning.
+	 *     Given log_syslog_priority is 'log_warning'.
+	 *     When  pfb_syslog_event() is called.
+	 *     Then  the recorded severity is LOG_WARNING.
+	 */
+	public function testConfiguredSeverityIsUsed(): void
+	{
+		config_set_path('installedpackages/pfblockerng/config/0/log_syslog', 'on');
+		config_set_path('installedpackages/pfblockerng/config/0/log_syslog_priority', 'log_warning');
+
+		pfb_syslog_event('act=block dir=in if=em0 proto=TCP src=198.51.100.5 dst=10.0.0.1 ipver=4');
+
+		$calls = $GLOBALS['pfb_test_syslog_calls'];
+		$this->assertCount(1, $calls, 'non-default severity: exactly one call');
+		$this->assertSame(LOG_WARNING, $calls[0]['severity'], 'non-default severity: LOG_WARNING used');
+	}
+
+	/**
+	 * pfb_syslog_event called twice emits two records when on.
+	 *
+	 * Scenario:
+	 *   Background: toggle on; two independent events.
+	 *     Given log_syslog is 'on'.
+	 *     When  pfb_syslog_event() is called twice with different bodies.
+	 *     Then  two syslog calls are recorded, each with the correct body.
+	 */
+	public function testMultipleCallsEachEmitOneRecord(): void
+	{
+		config_set_path('installedpackages/pfblockerng/config/0/log_syslog', 'on');
+
+		$body1 = 'act=block dir=in if=em0 proto=TCP src=203.0.113.1 dst=10.0.0.1 ipver=4';
+		$body2 = 'act=pass dir=out if=wan proto=UDP src=10.0.0.1 dst=8.8.8.8 sport=12345 dport=53 ipver=4';
+
+		pfb_syslog_event($body1);
+		pfb_syslog_event($body2);
+
+		$calls = $GLOBALS['pfb_test_syslog_calls'];
+		$this->assertCount(2, $calls, 'two events → two syslog calls');
+		$this->assertSame($body1, $calls[0]['body'], 'first call: correct body');
+		$this->assertSame($body2, $calls[1]['body'], 'second call: correct body');
+	}
+
+	// -----------------------------------------------------------------------
+	// Toggle flip: off then on — before/after
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Flipping the toggle from off to on changes emission — before/after asserted.
+	 *
+	 * Scenario:
+	 *   Background: static cache re-read after reset.
+	 *     Given log_syslog starts as '' (off).
+	 *     When  pfb_syslog_event() is called → no emission (before).
+	 *     Then  toggle is set to 'on' and cache is reset.
+	 *     When  pfb_syslog_event() is called again → one emission (after).
+	 *     Then  the change in emission was CAUSED by the toggle flip.
+	 */
+	public function testToggleFlipOffToOnChangesEmission(): void
+	{
+		// --- BEFORE: toggle off ---
+		config_set_path('installedpackages/pfblockerng/config/0/log_syslog', '');
+
+		pfb_syslog_event('act=block dir=in if=em0 proto=TCP src=1.2.3.4 dst=5.6.7.8 ipver=4');
+
+		$calls_before = $GLOBALS['pfb_test_syslog_calls'];
+		$this->assertSame([], $calls_before, 'before flip: no emission when toggle is off');
+
+		// Reset for next state.
+		$GLOBALS['pfb_test_syslog_calls'] = [];
+		$GLOBALS['pfb_test_syslog_reset'] = TRUE;
+
+		// --- AFTER: toggle on ---
+		config_set_path('installedpackages/pfblockerng/config/0/log_syslog', 'on');
+
+		$body = 'act=block dir=in if=em0 proto=TCP src=1.2.3.4 dst=5.6.7.8 ipver=4';
+		pfb_syslog_event($body);
+
+		$calls_after = $GLOBALS['pfb_test_syslog_calls'];
+		$this->assertCount(1, $calls_after, 'after flip: exactly one emission when toggle is on');
+		$this->assertSame($body, $calls_after[0]['body'], 'after flip: body matches');
+	}
+}

--- a/tests/php/SyslogFacilityMapTest.php
+++ b/tests/php/SyslogFacilityMapTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-38 Phase 2 — pfb_syslog_facility_constant() / pfb_syslog_priority_constant() tests.
+ *
+ * Two pure helpers mapping stored Snort-style tokens to PHP LOG_* constants.
+ * Tests cover: every vocabulary token → expected constant; unknown token → safe default.
+ *
+ * Scenario: every stored token maps to a distinct, non-zero (or zero for LOG_EMERG/LOG_KERN)
+ *   PHP syslog constant; an unknown token falls back to the documented safe default.
+ */
+final class SyslogFacilityMapTest extends TestCase
+{
+	// -----------------------------------------------------------------------
+	// pfb_syslog_facility_constant — full vocabulary
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Every Snort-style facility token maps to the expected PHP LOG_* constant.
+	 *
+	 * Scenario:
+	 *   Background: pfb_syslog_facility_constant() maps stored tokens.
+	 *     Given each token in the documented facility vocabulary.
+	 *     When pfb_syslog_facility_constant($token).
+	 *     Then the returned value equals the expected PHP LOG_* constant.
+	 */
+	public function testFacilityKernMapsToLogKern(): void
+	{
+		$this->assertSame(LOG_KERN, pfb_syslog_facility_constant('log_kern'));
+	}
+
+	public function testFacilityUserMapsToLogUser(): void
+	{
+		$this->assertSame(LOG_USER, pfb_syslog_facility_constant('log_user'));
+	}
+
+	public function testFacilityMailMapsToLogMail(): void
+	{
+		$this->assertSame(LOG_MAIL, pfb_syslog_facility_constant('log_mail'));
+	}
+
+	public function testFacilityDaemonMapsToLogDaemon(): void
+	{
+		$this->assertSame(LOG_DAEMON, pfb_syslog_facility_constant('log_daemon'));
+	}
+
+	public function testFacilityAuthMapsToLogAuth(): void
+	{
+		$this->assertSame(LOG_AUTH, pfb_syslog_facility_constant('log_auth'));
+	}
+
+	public function testFacilitySyslogMapsToLogSyslog(): void
+	{
+		$this->assertSame(LOG_SYSLOG, pfb_syslog_facility_constant('log_syslog'));
+	}
+
+	public function testFacilityLprMapsToLogLpr(): void
+	{
+		$this->assertSame(LOG_LPR, pfb_syslog_facility_constant('log_lpr'));
+	}
+
+	public function testFacilityNewsMapsToLogNews(): void
+	{
+		$this->assertSame(LOG_NEWS, pfb_syslog_facility_constant('log_news'));
+	}
+
+	public function testFacilityUucpMapsToLogUucp(): void
+	{
+		$this->assertSame(LOG_UUCP, pfb_syslog_facility_constant('log_uucp'));
+	}
+
+	public function testFacilityCronMapsToLogCron(): void
+	{
+		$this->assertSame(LOG_CRON, pfb_syslog_facility_constant('log_cron'));
+	}
+
+	public function testFacilityLocal0MapsToLogLocal0(): void
+	{
+		$this->assertSame(LOG_LOCAL0, pfb_syslog_facility_constant('log_local0'));
+	}
+
+	public function testFacilityLocal1MapsToLogLocal1(): void
+	{
+		$this->assertSame(LOG_LOCAL1, pfb_syslog_facility_constant('log_local1'));
+	}
+
+	public function testFacilityLocal2MapsToLogLocal2(): void
+	{
+		$this->assertSame(LOG_LOCAL2, pfb_syslog_facility_constant('log_local2'));
+	}
+
+	public function testFacilityLocal3MapsToLogLocal3(): void
+	{
+		$this->assertSame(LOG_LOCAL3, pfb_syslog_facility_constant('log_local3'));
+	}
+
+	public function testFacilityLocal4MapsToLogLocal4(): void
+	{
+		$this->assertSame(LOG_LOCAL4, pfb_syslog_facility_constant('log_local4'));
+	}
+
+	public function testFacilityLocal5MapsToLogLocal5(): void
+	{
+		$this->assertSame(LOG_LOCAL5, pfb_syslog_facility_constant('log_local5'));
+	}
+
+	/**
+	 * log_local6 is the registered default facility — maps to LOG_LOCAL6.
+	 *
+	 * This is also the safe default for unknown tokens (see testFacilityUnknownTokenDefaultsToLocal6).
+	 */
+	public function testFacilityLocal6MapsToLogLocal6(): void
+	{
+		// Before: the function exists and is pure.
+		$this->assertTrue(function_exists('pfb_syslog_facility_constant'));
+
+		// When/Then: log_local6 → LOG_LOCAL6.
+		$this->assertSame(LOG_LOCAL6, pfb_syslog_facility_constant('log_local6'));
+	}
+
+	public function testFacilityLocal7MapsToLogLocal7(): void
+	{
+		$this->assertSame(LOG_LOCAL7, pfb_syslog_facility_constant('log_local7'));
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_syslog_facility_constant — unknown token → safe default
+	// -----------------------------------------------------------------------
+
+	/**
+	 * An unknown facility token returns LOG_LOCAL6 (the safe default, not a crash).
+	 *
+	 * Scenario:
+	 *   Background: a syslog export config from an older package version may carry
+	 *     a token that this version does not recognise.
+	 *     Given an unrecognised facility token.
+	 *     When pfb_syslog_facility_constant($token).
+	 *     Then LOG_LOCAL6 is returned (the registered default; no crash).
+	 */
+	public function testFacilityUnknownTokenDefaultsToLocal6(): void
+	{
+		// Before: confirm LOG_LOCAL6 is non-zero (not confused with a failure code).
+		$this->assertNotSame(0, LOG_LOCAL6);
+
+		// When: unknown token.
+		$result = pfb_syslog_facility_constant('log_totally_unknown');
+
+		// Then: LOG_LOCAL6 (safe default, not a crash).
+		$this->assertSame(LOG_LOCAL6, $result,
+			'Unknown facility token must fall back to LOG_LOCAL6 (registered default)'
+		);
+
+		// And: empty string (missing config) also falls back.
+		$result_empty = pfb_syslog_facility_constant('');
+		$this->assertSame(LOG_LOCAL6, $result_empty,
+			'Empty facility token must fall back to LOG_LOCAL6'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_syslog_priority_constant — full vocabulary
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Every Snort-style severity token maps to the expected PHP LOG_* constant.
+	 *
+	 * Scenario:
+	 *   Background: pfb_syslog_priority_constant() maps stored tokens.
+	 *     Given each token in the documented severity vocabulary.
+	 *     When pfb_syslog_priority_constant($token).
+	 *     Then the returned value equals the expected PHP LOG_* constant.
+	 */
+	public function testPriorityEmergMapsToLogEmerg(): void
+	{
+		$this->assertSame(LOG_EMERG, pfb_syslog_priority_constant('log_emerg'));
+	}
+
+	public function testPriorityAlertMapsToLogAlert(): void
+	{
+		$this->assertSame(LOG_ALERT, pfb_syslog_priority_constant('log_alert'));
+	}
+
+	public function testPriorityCritMapsToLogCrit(): void
+	{
+		$this->assertSame(LOG_CRIT, pfb_syslog_priority_constant('log_crit'));
+	}
+
+	public function testPriorityErrMapsToLogErr(): void
+	{
+		$this->assertSame(LOG_ERR, pfb_syslog_priority_constant('log_err'));
+	}
+
+	public function testPriorityWarningMapsToLogWarning(): void
+	{
+		$this->assertSame(LOG_WARNING, pfb_syslog_priority_constant('log_warning'));
+	}
+
+	/**
+	 * log_notice is the registered default severity — maps to LOG_NOTICE.
+	 *
+	 * Also the safe default for unknown tokens (testPriorityUnknownTokenDefaultsToNotice).
+	 */
+	public function testPriorityNoticeMapsToLogNotice(): void
+	{
+		// Before: the function exists.
+		$this->assertTrue(function_exists('pfb_syslog_priority_constant'));
+
+		// When/Then: log_notice → LOG_NOTICE.
+		$this->assertSame(LOG_NOTICE, pfb_syslog_priority_constant('log_notice'));
+	}
+
+	public function testPriorityInfoMapsToLogInfo(): void
+	{
+		$this->assertSame(LOG_INFO, pfb_syslog_priority_constant('log_info'));
+	}
+
+	public function testPriorityDebugMapsToLogDebug(): void
+	{
+		$this->assertSame(LOG_DEBUG, pfb_syslog_priority_constant('log_debug'));
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_syslog_priority_constant — unknown token → safe default
+	// -----------------------------------------------------------------------
+
+	/**
+	 * An unknown severity token returns LOG_NOTICE (the safe default, not a crash).
+	 *
+	 * Scenario:
+	 *   Background: a syslog export config from an older package version may carry
+	 *     a token that this version does not recognise.
+	 *     Given an unrecognised severity token.
+	 *     When pfb_syslog_priority_constant($token).
+	 *     Then LOG_NOTICE is returned (the registered default; no crash).
+	 */
+	public function testPriorityUnknownTokenDefaultsToNotice(): void
+	{
+		// Before: LOG_NOTICE is the registered default.
+		$this->assertSame(5, LOG_NOTICE);   // sanity — not confused with success/failure
+
+		// When: unknown token.
+		$result = pfb_syslog_priority_constant('log_totally_unknown');
+
+		// Then: LOG_NOTICE (safe default, not a crash).
+		$this->assertSame(LOG_NOTICE, $result,
+			'Unknown severity token must fall back to LOG_NOTICE (registered default)'
+		);
+
+		// And: empty string (missing config) also falls back.
+		$result_empty = pfb_syslog_priority_constant('');
+		$this->assertSame(LOG_NOTICE, $result_empty,
+			'Empty severity token must fall back to LOG_NOTICE'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Cross-check: facility and priority maps are disjoint token sets
+	// -----------------------------------------------------------------------
+
+	/**
+	 * No facility token is a valid priority token, and vice versa (disjoint vocabularies).
+	 *
+	 * Scenario:
+	 *   Background: Snort separates facility and severity namespaces.
+	 *     Given the two vocabulary sets.
+	 *     When computing their intersection.
+	 *     Then it is empty (no shared token would silently resolve to the wrong constant).
+	 */
+	public function testFacilityAndPriorityVocabulariesAreDisjoint(): void
+	{
+		$facility_tokens = [
+			'log_kern', 'log_user', 'log_mail', 'log_daemon', 'log_auth', 'log_syslog',
+			'log_lpr', 'log_news', 'log_uucp', 'log_cron',
+			'log_local0', 'log_local1', 'log_local2', 'log_local3',
+			'log_local4', 'log_local5', 'log_local6', 'log_local7',
+		];
+		$priority_tokens = [
+			'log_emerg', 'log_alert', 'log_crit', 'log_err',
+			'log_warning', 'log_notice', 'log_info', 'log_debug',
+		];
+
+		$intersection = array_intersect($facility_tokens, $priority_tokens);
+		$this->assertEmpty(
+			$intersection,
+			'Facility and priority vocabulary sets must not overlap: '
+			. implode(', ', $intersection)
+		);
+	}
+}

--- a/tests/php/SyslogFormatTest.php
+++ b/tests/php/SyslogFormatTest.php
@@ -1,0 +1,480 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-38 Phase 1 — Pure IP syslog event formatter.
+ *
+ * Pins the behaviour of:
+ *   pfb_syslog_format_ip(array $fields): string
+ *
+ * The function is PURE (no I/O, no globals) and DORMANT this phase (uncalled
+ * from production code).  These tests are the only callers.
+ *
+ * Coverage mandate (CLAUDE.md):
+ *   - Every event class: Block, Permit, Match.
+ *   - Both IP versions: IPv4, IPv6.
+ *   - Required fields always present; optional fields present vs absent.
+ *   - Known absent-sentinels ('Unknown', 'Unk', 'null', '') are omitted.
+ *   - Values containing space, '=', or '"' are double-quoted; '"' is \.
+ *   - Newlines in values are stripped (single-line guarantee).
+ *
+ * All assertions are against EXACT golden strings (the mapping is pinned).
+ */
+final class SyslogFormatTest extends TestCase
+{
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Build a complete, fully-populated IPv4 Block event field array.
+	 *
+	 * @return array<string,string>
+	 */
+	private function ipv4BlockFields(): array
+	{
+		return [
+			'act'   => 'block',
+			'dir'   => 'in',
+			'if'    => 'em0',
+			'proto' => 'TCP-SA',
+			'src'   => '203.0.113.42',
+			'dst'   => '192.168.1.10',
+			'sport' => '54321',
+			'dport' => '443',
+			'ipver' => '4',
+			'geoip' => 'CN',
+			'alias' => 'pfB_DNSBL_v4',
+			'feed'  => 'EasyList',
+			'host'  => 'malware.example.com',
+			'asn'   => '|AS4134:CHINANET-BACKBONE|',
+		];
+	}
+
+	/**
+	 * Build a complete, fully-populated IPv6 Permit event field array.
+	 *
+	 * @return array<string,string>
+	 */
+	private function ipv6PermitFields(): array
+	{
+		return [
+			'act'   => 'pass',
+			'dir'   => 'out',
+			'if'    => 'igb1',
+			'proto' => 'UDP',
+			'src'   => '2001:db8::1',
+			'dst'   => '2001:db8::2',
+			'sport' => '1024',
+			'dport' => '53',
+			'ipver' => '6',
+			'geoip' => 'US',
+			'alias' => 'pfB_Permit_v6',
+			'feed'  => 'Whitelist',
+			'host'  => 'resolver.example.net',
+			'asn'   => '|AS15169:GOOGLE|',
+		];
+	}
+
+	// -----------------------------------------------------------------------
+	// Block event — IPv4, all fields populated
+	// -----------------------------------------------------------------------
+
+	/**
+	 * IPv4 Block event with all optional fields present produces the exact
+	 * key=value string in fixed documented order.
+	 *
+	 * Scenario:
+	 *   Given a fully-populated IPv4 Block event field array.
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  returns the exact golden string with all 14 key=value pairs.
+	 */
+	public function testIpv4BlockAllFieldsProducesExactString(): void
+	{
+		$result = pfb_syslog_format_ip($this->ipv4BlockFields());
+
+		$this->assertSame(
+			'act=block dir=in if=em0 proto=TCP-SA src=203.0.113.42 dst=192.168.1.10'
+			. ' sport=54321 dport=443 ipver=4 geoip=CN alias=pfB_DNSBL_v4'
+			. ' feed=EasyList host=malware.example.com asn=|AS4134:CHINANET-BACKBONE|',
+			$result,
+			'IPv4 Block: all fields in documented order'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Permit event — IPv6, all fields populated
+	// -----------------------------------------------------------------------
+
+	/**
+	 * IPv6 Permit event with all optional fields present.
+	 *
+	 * Scenario:
+	 *   Given a fully-populated IPv6 Permit event field array.
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  returns the exact golden string with act=pass.
+	 */
+	public function testIpv6PermitAllFieldsProducesExactString(): void
+	{
+		$result = pfb_syslog_format_ip($this->ipv6PermitFields());
+
+		$this->assertSame(
+			'act=pass dir=out if=igb1 proto=UDP src=2001:db8::1 dst=2001:db8::2'
+			. ' sport=1024 dport=53 ipver=6 geoip=US alias=pfB_Permit_v6'
+			. ' feed=Whitelist host=resolver.example.net asn=|AS15169:GOOGLE|',
+			$result,
+			'IPv6 Permit: all fields in documented order'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Match event — IPv4, no optional fields
+	// -----------------------------------------------------------------------
+
+	/**
+	 * IPv4 Match event with only required fields produces the minimal string.
+	 *
+	 * Scenario:
+	 *   Given a field array with required fields only; all optional fields
+	 *   set to absent-sentinels ('Unknown', 'Unk', 'null', '').
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  returns only the required key=value pairs (no optional keys).
+	 */
+	public function testIpv4MatchRequiredFieldsOnlyProducesMinimalString(): void
+	{
+		$fields = [
+			'act'   => 'match',
+			'dir'   => 'in',
+			'if'    => 'em0',
+			'proto' => 'TCP',
+			'src'   => '198.51.100.5',
+			'dst'   => '10.0.0.1',
+			'sport' => '',        // omitted — empty
+			'dport' => '',        // omitted — empty
+			'ipver' => '4',
+			'geoip' => 'Unk',     // omitted — known absent sentinel
+			'alias' => 'Unknown', // omitted — known absent sentinel
+			'feed'  => 'Unknown', // omitted — known absent sentinel
+			'host'  => 'Unknown', // omitted — known absent sentinel
+			'asn'   => 'null',    // omitted — known absent sentinel
+		];
+
+		$result = pfb_syslog_format_ip($fields);
+
+		$this->assertSame(
+			'act=match dir=in if=em0 proto=TCP src=198.51.100.5 dst=10.0.0.1 ipver=4',
+			$result,
+			'Match: required fields only; absent-sentinels omitted'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Optional field presence vs absence (before-and-after)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * 'Unknown' sentinel is omitted; a real value is included — before/after.
+	 *
+	 * Scenario:
+	 *   Before: geoip='Unknown' -> key absent from output.
+	 *   After:  geoip='DE'      -> key present in output.
+	 */
+	public function testGeoipUnknownSentinelOmittedRealValueIncluded(): void
+	{
+		$base = [
+			'act' => 'block', 'dir' => 'in', 'if' => 'em0', 'proto' => 'TCP',
+			'src' => '198.51.100.1', 'dst' => '10.0.0.1', 'ipver' => '4',
+		];
+
+		// Before: sentinel -> absent.
+		$before = pfb_syslog_format_ip(array_merge($base, ['geoip' => 'Unknown']));
+		$this->assertStringNotContainsString('geoip=', $before, 'geoip=Unknown must be absent');
+
+		// After: real value -> present.
+		$after = pfb_syslog_format_ip(array_merge($base, ['geoip' => 'DE']));
+		$this->assertStringContainsString('geoip=DE', $after, 'geoip=DE must be present');
+	}
+
+	/**
+	 * 'Unk' sentinel is omitted; a real two-letter code is included — before/after.
+	 *
+	 * Scenario:
+	 *   Before: geoip='Unk' -> key absent.
+	 *   After:  geoip='JP'  -> key present.
+	 */
+	public function testGeoipUnkSentinelOmitted(): void
+	{
+		$base = [
+			'act' => 'block', 'dir' => 'in', 'if' => 'em0', 'proto' => 'UDP',
+			'src' => '198.51.100.2', 'dst' => '10.0.0.2', 'ipver' => '4',
+		];
+
+		// Before: 'Unk' -> absent.
+		$before = pfb_syslog_format_ip(array_merge($base, ['geoip' => 'Unk']));
+		$this->assertStringNotContainsString('geoip=', $before, "'Unk' must be omitted");
+
+		// After: real code -> present.
+		$after = pfb_syslog_format_ip(array_merge($base, ['geoip' => 'JP']));
+		$this->assertStringContainsString('geoip=JP', $after, "real code must appear");
+	}
+
+	/**
+	 * 'null' string is omitted for asn; a real ASN value is included.
+	 *
+	 * Scenario:
+	 *   Before: asn='null' -> key absent.
+	 *   After:  asn='|AS1234:ORG|' -> key present (and quoted due to '|').
+	 *   Note: '|' does not trigger quoting; only space, '=', '"' do.
+	 */
+	public function testAsnNullSentinelOmittedRealAsnIncluded(): void
+	{
+		$base = [
+			'act' => 'block', 'dir' => 'in', 'if' => 'em0', 'proto' => 'TCP',
+			'src' => '198.51.100.3', 'dst' => '10.0.0.3', 'ipver' => '4',
+		];
+
+		// Before: 'null' -> absent.
+		$before = pfb_syslog_format_ip(array_merge($base, ['asn' => 'null']));
+		$this->assertStringNotContainsString('asn=', $before, "'null' asn must be omitted");
+
+		// After: real value with spaces -> present and quoted.
+		$after = pfb_syslog_format_ip(array_merge($base, ['asn' => '|AS1234:TEST ORG|']));
+		$this->assertStringContainsString('asn="|AS1234:TEST ORG|"', $after, "real asn with space must be quoted");
+	}
+
+	// -----------------------------------------------------------------------
+	// IPv6 Match event — minimal fields
+	// -----------------------------------------------------------------------
+
+	/**
+	 * IPv6 Match event with required fields only.
+	 *
+	 * Scenario:
+	 *   Given a minimal IPv6 Match field array (required fields only, all
+	 *   optional fields absent or set to sentinels).
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  returns only required key=value pairs with ipver=6.
+	 */
+	public function testIpv6MatchRequiredFieldsOnlyProducesMinimalString(): void
+	{
+		$fields = [
+			'act'   => 'match',
+			'dir'   => 'out',
+			'if'    => 'vtnet0',
+			'proto' => 'ICMPv6',
+			'src'   => '2001:db8::10',
+			'dst'   => '2001:db8::20',
+			'ipver' => '6',
+			'geoip' => '',
+			'alias' => '',
+			'feed'  => '',
+			'host'  => '',
+			'asn'   => '',
+		];
+
+		$result = pfb_syslog_format_ip($fields);
+
+		$this->assertSame(
+			'act=match dir=out if=vtnet0 proto=ICMPv6 src=2001:db8::10 dst=2001:db8::20 ipver=6',
+			$result,
+			'IPv6 Match: required fields only'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Escaping — space, '=', and '"' in values
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A value containing a space is double-quoted.
+	 *
+	 * Scenario:
+	 *   Given a field where proto = 'TCP FLAGS' (contains a space).
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  proto="TCP FLAGS" appears quoted in output.
+	 */
+	public function testValueWithSpaceIsDoubleQuoted(): void
+	{
+		$fields = [
+			'act'   => 'block',
+			'dir'   => 'in',
+			'if'    => 'em0',
+			'proto' => 'TCP FLAGS',
+			'src'   => '198.51.100.10',
+			'dst'   => '10.0.0.10',
+			'ipver' => '4',
+		];
+
+		$result = pfb_syslog_format_ip($fields);
+
+		$this->assertStringContainsString('proto="TCP FLAGS"', $result, 'proto with space must be quoted');
+	}
+
+	/**
+	 * A value containing '=' is double-quoted.
+	 *
+	 * Scenario:
+	 *   Given alias = 'pfB_Deny=v4' (contains '=').
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  alias="pfB_Deny=v4" appears quoted in output.
+	 */
+	public function testValueWithEqualsIsDoubleQuoted(): void
+	{
+		$fields = [
+			'act'   => 'block',
+			'dir'   => 'in',
+			'if'    => 'em0',
+			'proto' => 'TCP',
+			'src'   => '198.51.100.11',
+			'dst'   => '10.0.0.11',
+			'ipver' => '4',
+			'alias' => 'pfB_Deny=v4',
+		];
+
+		$result = pfb_syslog_format_ip($fields);
+
+		$this->assertStringContainsString('alias="pfB_Deny=v4"', $result, 'alias with = must be quoted');
+	}
+
+	/**
+	 * A value containing a double-quote is quoted and the inner quote escaped.
+	 *
+	 * Scenario:
+	 *   Given host = 'bad"host.example.com' (contains '"').
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  host="bad\"host.example.com" appears in output.
+	 */
+	public function testValueWithDoubleQuoteIsEscaped(): void
+	{
+		$fields = [
+			'act'   => 'block',
+			'dir'   => 'in',
+			'if'    => 'em0',
+			'proto' => 'TCP',
+			'src'   => '198.51.100.12',
+			'dst'   => '10.0.0.12',
+			'ipver' => '4',
+			'host'  => 'bad"host.example.com',
+		];
+
+		$result = pfb_syslog_format_ip($fields);
+
+		$this->assertStringContainsString('host="bad\\"host.example.com"', $result, 'inner " must be \\"-escaped');
+	}
+
+	/**
+	 * Newlines embedded in a value are stripped (single-line guarantee).
+	 *
+	 * Scenario:
+	 *   Given host = "multi\nline" (contains \n).
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  the output contains no newline character.
+	 *   And   the \n is replaced with a space (preserved as content).
+	 */
+	public function testNewlineInValueIsStripped(): void
+	{
+		$fields = [
+			'act'   => 'block',
+			'dir'   => 'in',
+			'if'    => 'em0',
+			'proto' => 'TCP',
+			'src'   => '198.51.100.13',
+			'dst'   => '10.0.0.13',
+			'ipver' => '4',
+			'host'  => "multi\nline",
+		];
+
+		$result = pfb_syslog_format_ip($fields);
+
+		$this->assertStringNotContainsString("\n", $result, 'output must be single-line');
+		$this->assertStringContainsString('host="multi line"', $result, 'newline replaced with space, then quoted');
+	}
+
+	// -----------------------------------------------------------------------
+	// Key order is fixed
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Required keys appear in the documented fixed order: act dir if proto src dst ipver.
+	 *
+	 * Scenario:
+	 *   Given any valid field array with required keys only.
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  the keys appear in the fixed documented order.
+	 */
+	public function testKeyOrderIsFixed(): void
+	{
+		$fields = [
+			'act'   => 'block',
+			'dir'   => 'in',
+			'if'    => 'em0',
+			'proto' => 'TCP',
+			'src'   => '198.51.100.20',
+			'dst'   => '10.0.0.20',
+			'ipver' => '4',
+		];
+
+		$result = pfb_syslog_format_ip($fields);
+
+		// Parse the key positions and assert their relative order.
+		$pos_act   = strpos($result, 'act=');
+		$pos_dir   = strpos($result, 'dir=');
+		$pos_if    = strpos($result, 'if=');
+		$pos_proto = strpos($result, 'proto=');
+		$pos_src   = strpos($result, 'src=');
+		$pos_dst   = strpos($result, 'dst=');
+		$pos_ipver = strpos($result, 'ipver=');
+
+		$this->assertLessThan($pos_dir,   $pos_act,   'act before dir');
+		$this->assertLessThan($pos_if,    $pos_dir,   'dir before if');
+		$this->assertLessThan($pos_proto, $pos_if,    'if before proto');
+		$this->assertLessThan($pos_src,   $pos_proto, 'proto before src');
+		$this->assertLessThan($pos_dst,   $pos_src,   'src before dst');
+		$this->assertLessThan($pos_ipver, $pos_dst,   'dst before ipver');
+	}
+
+	/**
+	 * Optional enrichment keys (geoip/alias/feed/host/asn) appear after ipver
+	 * when present, in the documented fixed order.
+	 *
+	 * Scenario:
+	 *   Given all optional fields present with non-sentinel values.
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  geoip < alias < feed < host < asn in the output.
+	 */
+	public function testOptionalKeyOrderAfterIpver(): void
+	{
+		$fields = [
+			'act'   => 'block',
+			'dir'   => 'in',
+			'if'    => 'em0',
+			'proto' => 'TCP',
+			'src'   => '198.51.100.21',
+			'dst'   => '10.0.0.21',
+			'ipver' => '4',
+			'geoip' => 'US',
+			'alias' => 'pfB_Deny',
+			'feed'  => 'BlockList',
+			'host'  => 'bad.host.example',
+			'asn'   => '|AS12345:ISP|',
+		];
+
+		$result = pfb_syslog_format_ip($fields);
+
+		$pos_ipver = strpos($result, 'ipver=');
+		$pos_geoip = strpos($result, 'geoip=');
+		$pos_alias = strpos($result, 'alias=');
+		$pos_feed  = strpos($result, 'feed=');
+		$pos_host  = strpos($result, 'host=');
+		$pos_asn   = strpos($result, 'asn=');
+
+		$this->assertLessThan($pos_geoip, $pos_ipver, 'ipver before geoip');
+		$this->assertLessThan($pos_alias, $pos_geoip, 'geoip before alias');
+		$this->assertLessThan($pos_feed,  $pos_alias, 'alias before feed');
+		$this->assertLessThan($pos_host,  $pos_feed,  'feed before host');
+		$this->assertLessThan($pos_asn,   $pos_host,  'host before asn');
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -697,3 +697,15 @@ if (!function_exists('get_configured_interface_with_descr')) {
 		return $GLOBALS['pfb_test_interfaces'] ?? [];
 	}
 }
+
+// --- ADR-38 Phase 3 doubles ---
+
+if (!function_exists('system_syslogd_start')) {
+	// pfSense syslog.inc: (re)start syslogd, processing package <logging> elements
+	// to add extra sockets and routing drop-ins.  Off-appliance this is a no-op:
+	// we never assert syslogd restarts in the unit-test suite (that is the live-VM
+	// smoke's job).  The call in pfblockerng_install.inc therefore resolves safely.
+	function system_syslogd_start(bool $sighup = false): void {
+		// No-op off-appliance.
+	}
+}

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -152,6 +152,10 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block',
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_int',
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_exclude',
+		// ADR-38: syslog export settings
+		'installedpackages/pfblockerng/config/0/log_syslog',
+		'installedpackages/pfblockerng/config/0/log_syslog_facility',
+		'installedpackages/pfblockerng/config/0/log_syslog_priority',
 		// installedpackages/pfblockerngsafesearch (flat section, no /config/0)
 		'installedpackages/pfblockerngsafesearch/safesearch_enable',
 		'installedpackages/pfblockerngsafesearch/safesearch_youtube',

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -17,7 +17,8 @@ pyproject.toml). Run only by the smoke workflow::
     python -m pytest tests/smoke -m smoke --override-ini="addopts="
 
 Needs the booted ``smoke_vm`` fixture, the branch ``.pkg`` (``SMOKE_PKG``), and
-the ``stub_dns`` + ``mock_feeds`` fixtures. Without them all cases skip cleanly.
+the ``stub_dns`` fixture. Feeds are written on-box via ``helpers.write_local_feed``
+(no HTTP mock-feed server needed). Without these all cases skip cleanly.
 """
 
 from __future__ import annotations
@@ -71,7 +72,6 @@ FILTERLOG_SETTLE_SECS = 5.0
 def deployed_vm(
     smoke_vm: SmokeVM,
     stub_dns: _StubDnsServer,
-    mock_feeds: h._MockFeedServer,  # type: ignore[type-arg]
 ) -> Iterator[SmokeVM]:
     """Deploy the branch .pkg once for this module; wire DNSBL + IP + syslog.
 

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -1,0 +1,539 @@
+"""ADR-38 — live-VM smoke: syslog export of pfBlockerNG security events.
+
+Proves the §2.2 contract on a real pfSense CE VM:
+
+  1. Default off / toggle OFF ⇒ zero event export, CSV logging unchanged.
+  2. Toggle ON ⇒ exactly one ``pfblockerng`` key=value syslog record per
+     DNSBL block event, correct qname/btype keys.
+  3. Toggle ON + IP path ⇒ exactly one ``pfblockerng`` key=value syslog record
+     per IP Block event, correct act/src/alias keys.
+  4. CSV logging is unchanged in both states (export is purely additive).
+  5. (Config round-trip is pinned by off-box unit tests; §2.2.5 is implicitly
+     exercised via the real PfbConfig read on the live box.)
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke`` in
+pyproject.toml). Run only by the smoke workflow::
+
+    python -m pytest tests/smoke -m smoke --override-ini="addopts="
+
+Needs the booted ``smoke_vm`` fixture, the branch ``.pkg`` (``SMOKE_PKG``), and
+the ``stub_dns`` + ``mock_feeds`` fixtures. Without them all cases skip cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM, _StubDnsServer
+
+pytestmark = pytest.mark.smoke
+
+# --------------------------------------------------------------------------- #
+# Paths (mirroring pfblockerng.xml / pfblockerng.inc definitions)
+# --------------------------------------------------------------------------- #
+
+# Dedicated syslog log created by the pfSense <logging> block in pfblockerng.xml
+# (logfilename=pfblockerng_syslog.log).
+SYSLOG_LOG = "/var/log/pfblockerng_syslog.log"
+
+# pfBlockerNG CSV security logs (unchanged by syslog export).
+PFB_LOGDIR = "/var/log/pfblockerng"
+DNSBL_LOG = f"{PFB_LOGDIR}/dnsbl.log"
+IP_BLOCK_LOG = f"{PFB_LOGDIR}/ip_block.log"
+
+# Config path for the syslog export toggle (under the General settings section).
+CFG_GENERAL = "installedpackages/pfblockerng/config/0"
+
+# A test IP range whose pfBlockerNG block rule we trigger traffic against.
+# RFC 5737 TEST-NET-3 (203.0.113.0/24) — not routable, but pf still blocks
+# an outbound connection attempt if it matches an alias table for that range.
+TEST_IP_BLOCK_RANGE = "203.0.113.0/24"
+# Specific destination IP to try to reach (triggers the pf block log).
+TEST_IP_BLOCK_DST = "203.0.113.1"
+
+# How long to wait for the filterlog daemon to write the block log entry
+# after a connection attempt.
+FILTERLOG_SETTLE_SECS = 5.0
+
+
+# --------------------------------------------------------------------------- #
+# Module-scoped fixture: deploy once, inject both DNSBL + IP case, reload
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(
+    smoke_vm: SmokeVM,
+    stub_dns: _StubDnsServer,
+    mock_feeds: h._MockFeedServer,  # type: ignore[type-arg]
+) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg once for this module; wire DNSBL + IP + syslog.
+
+    Given: the smoke VM is booted and the branch .pkg is available.
+    When:  we deploy the package, wire DNSBL (unique blocked domain, VIP mode),
+           wire one IP block feed (RFC 5737 range), and perform an initial full
+           reload with syslog export OFF (the default).
+    Then:  the module-level VM is ready for the per-test syslog assertions;
+           teardown is automatic (module scope).
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+
+    # ------------------------------------------------------------------ #
+    # Given: package installed + DNS upstream wired to the runner stub
+    # ------------------------------------------------------------------ #
+    h.deploy(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+
+    # ------------------------------------------------------------------ #
+    # Given: DNSBL VIP exists and a feed blocking a unique domain is live
+    # ------------------------------------------------------------------ #
+    h.ensure_dnsbl_vip(smoke_vm)
+
+    _dnsbl_domain = h.unique_domain("pfbsyslogdnsbl")
+    _dnsbl_feed_path = h.write_local_feed(
+        smoke_vm,
+        "pfb_syslog_dnsbl.txt",
+        f"{_dnsbl_domain}\n",
+    )
+    dnsbl_spec = h.DnsblCase(
+        aliasname="pfb_syslog_test",
+        feed_url=_dnsbl_feed_path,
+        mode=h.DnsblMode.VIP,
+        header="pfb_syslog_dnsbl",
+        hsts=False,  # force off — test domain is not HSTS-preloaded but be explicit
+    )
+    h.inject(smoke_vm, dnsbl_spec)
+
+    # ------------------------------------------------------------------ #
+    # Given: an IP block feed targeting the RFC 5737 TEST-NET-3 range
+    # ------------------------------------------------------------------ #
+    _ip_feed_path = h.write_local_feed(
+        smoke_vm,
+        "pfb_syslog_ip.txt",
+        f"{TEST_IP_BLOCK_RANGE}\n",
+    )
+    ip_spec = h.IpCase(
+        aliasname="pfb_syslog_iptest",
+        feed_url=_ip_feed_path,
+        action="Deny_Both",
+        family="v4",
+        header="pfb_syslog_ip",
+    )
+    h.inject(smoke_vm, ip_spec)
+
+    # ------------------------------------------------------------------ #
+    # Given: syslog export is OFF (the default) at the start of this module
+    # ------------------------------------------------------------------ #
+    _set_syslog_enabled(smoke_vm, on=False)
+
+    # ------------------------------------------------------------------ #
+    # When: full reload (installs DNSBL + IP block + pfb_unbound.ini)
+    # ------------------------------------------------------------------ #
+    h.reload(smoke_vm, "update")
+
+    # ------------------------------------------------------------------ #
+    # Precondition: DNSBL is blocking the test domain (VIP shape)
+    # ------------------------------------------------------------------ #
+    ans = h.dns_probe(smoke_vm, _dnsbl_domain, "A")
+    if not h.is_vip(ans):
+        pytest.skip(
+            f"DNSBL VIP block not observed for {_dnsbl_domain} "
+            f"(got {ans}) — DNSBL precondition failed; skipping syslog tests"
+        )
+
+    # Stash shared state on the VM object for per-test access.
+    smoke_vm._pfb_dnsbl_domain = _dnsbl_domain  # type: ignore[attr-defined]
+
+    yield smoke_vm
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _set_syslog_enabled(vm: SmokeVM, *, on: bool, timeout: float = 60.0) -> None:
+    """Toggle the log_syslog export key in config and write_config."""
+    val = "on" if on else ""
+    snippet = (
+        f"$g = config_get_path({h._php_str(CFG_GENERAL)}, array());\n"
+        f"$g['log_syslog'] = {h._php_str(val)};\n"
+        f"config_set_path({h._php_str(CFG_GENERAL)}, $g);\n"
+        "write_config('pfBlockerNG smoke: toggle log_syslog');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_set_syslog_enabled({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def _count_syslog_lines(vm: SmokeVM, *, timeout: float = 30.0) -> int:
+    """Return the number of lines in SYSLOG_LOG (0 if absent)."""
+    result = vm.ssh("wc", "-l", SYSLOG_LOG, timeout=timeout)
+    if result.returncode != 0:
+        return 0
+    # wc -l output: "   N /path/to/file" or "N /path/to/file"
+    m = re.match(r"\s*(\d+)", result.stdout.strip())
+    return int(m.group(1)) if m else 0
+
+
+def _read_syslog_lines(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:
+    """Read SYSLOG_LOG lines; return empty list if the file is absent."""
+    content = h.read_log_file(vm, SYSLOG_LOG, timeout=timeout)
+    return [ln for ln in content.splitlines() if ln.strip()]
+
+
+def _trigger_ip_block(vm: SmokeVM, *, timeout: float = 30.0) -> None:
+    """Attempt a TCP connection to a blocked IP to generate a pf block log event.
+
+    The RFC 5737 TEST-NET-3 address is in the alias table from the IP feed, so
+    any outbound connection to 203.0.113.1 is pf-blocked and logged.  curl with
+    a short connect timeout produces the outbound SYN that pf drops; the error
+    exit is expected and ignored.
+
+    The filterlog daemon (tail_pfb | php_pfb filterlog) reads /var/log/filter.log
+    and writes the pfBlockerNG CSV + (when log_syslog=on) the syslog record.
+    """
+    # Use /bin/sh to swallow the non-zero exit without raising in the caller.
+    # --connect-timeout 1 caps the TCP timeout; curl itself fails fast.
+    vm.ssh(
+        "/bin/sh",
+        "-c",
+        f"/usr/local/bin/curl --connect-timeout 1 --max-time 2 http://{TEST_IP_BLOCK_DST}/ >/dev/null 2>&1 || true",
+        timeout=timeout,
+    )
+
+
+def _assert_syslog_line(lines: list[str], tag: str, **required_kv: str) -> str:
+    """Assert at least one line contains ``tag`` and all ``key=value`` pairs.
+
+    Returns the matching line for diagnostic output.
+
+    Args:
+        lines:       All syslog log lines.
+        tag:         Required substring (e.g. ``"pfblockerng"``) in the line.
+        **required_kv: Key=value pairs that must appear verbatim (e.g. ``act="block"``
+                     or ``act=block`` depending on quoting).
+
+    Raises:
+        AssertionError: when no line satisfies all conditions.
+    """
+    matches = []
+    for ln in lines:
+        if tag not in ln:
+            continue
+        if all(f"{k}={v}" in ln for k, v in required_kv.items()):
+            matches.append(ln)
+    assert matches, (
+        f"No syslog line found with tag={tag!r} and kv={required_kv!r}.\n"
+        f"All lines ({len(lines)}):\n" + "\n".join(lines[:40])
+    )
+    return matches[0]
+
+
+# --------------------------------------------------------------------------- #
+# Test 1: ON ⇒ DNSBL event exported (§2.2.2)
+# --------------------------------------------------------------------------- #
+
+
+def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM) -> None:
+    """§2.2.2 — ON ⇒ one pfblockerng key=value syslog record per DNSBL block.
+
+    Scenario: syslog export toggle ON; a DNSBL-blocked domain probed on-box.
+
+    Given: deployed pfBlockerNG with DNSBL blocking _dnsbl_domain (VIP mode),
+           syslog export currently OFF (the module fixture default).
+    When:  log_syslog is enabled and DNSBL is reloaded (re-writes pfb_unbound.ini
+           with syslog_enable=on), then the blocked domain is probed on-box.
+    Then:  exactly one ``pfblockerng`` syslog record appears in SYSLOG_LOG with
+           ``act=dnsbl``, ``qname=<domain>``, and ``btype=VIP``.
+    And:   the CSV dnsbl.log is ALSO written (export is additive — §2.2.1).
+    """
+    vm = deployed_vm
+    domain: str = vm._pfb_dnsbl_domain  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------------ #
+    # Given: count baseline BEFORE enabling
+    # ------------------------------------------------------------------ #
+    before_count = _count_syslog_lines(vm)
+    dnsbl_before = h.count_log_marker(vm, DNSBL_LOG, domain)
+
+    # ------------------------------------------------------------------ #
+    # When: enable syslog export + reload DNSBL (re-builds pfb_unbound.ini)
+    # ------------------------------------------------------------------ #
+    _set_syslog_enabled(vm, on=True)
+    h.reload(vm, "updatednsbl")
+
+    # ------------------------------------------------------------------ #
+    # When: probe the blocked domain on-box (triggers the DNSBL block +
+    #       the python syslog emitter)
+    # ------------------------------------------------------------------ #
+    ans = h.dns_probe(vm, domain, "A")
+
+    # ------------------------------------------------------------------ #
+    # Then: DNSBL still blocks (VIP shape) — export is additive
+    # ------------------------------------------------------------------ #
+    assert h.is_vip(ans), f"DNSBL block shape changed after enabling syslog: expected VIP, got {ans}"
+
+    # Give the syslog record a moment to flush (the SysLogHandler sendto() is
+    # synchronous, but the OS may buffer briefly before writing to the log file).
+    time.sleep(1.0)
+
+    # ------------------------------------------------------------------ #
+    # Then: at least one new pfblockerng syslog line with act=dnsbl + qname
+    # ------------------------------------------------------------------ #
+    after_lines = _read_syslog_lines(vm)
+    assert len(after_lines) > before_count, (
+        f"No new syslog lines appeared after enabling export and probing {domain} "
+        f"(before {before_count}, after {len(after_lines)})"
+    )
+
+    _assert_syslog_line(after_lines, "pfblockerng", act="dnsbl", btype="VIP")
+    # Verify qname is present (escaped or unescaped — domain has no special chars)
+    dnsbl_lines = [ln for ln in after_lines if "act=dnsbl" in ln and domain in ln]
+    assert dnsbl_lines, f"No syslog line contains act=dnsbl and qname={domain!r}.\nSyslog lines: {after_lines}"
+
+    # ------------------------------------------------------------------ #
+    # And: CSV dnsbl.log also written (additive — export does not replace CSV)
+    # ------------------------------------------------------------------ #
+    dnsbl_after = h.count_log_marker(vm, DNSBL_LOG, domain)
+    assert dnsbl_after > dnsbl_before, (
+        f"CSV dnsbl.log was NOT written after syslog export was enabled "
+        f"(before {dnsbl_before}, after {dnsbl_after}) — export must be additive"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Test 2: ON ⇒ IP Block event exported (§2.2.2 + §2.2.3)
+# --------------------------------------------------------------------------- #
+
+
+def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM) -> None:
+    """§2.2.2 + §2.2.3 — ON ⇒ one pfblockerng key=value record per IP Block event.
+
+    Scenario: syslog export toggle ON; a connection to a pf-blocked RFC 5737 IP
+    is attempted from the VM, generating a pf block log entry that the filterlog
+    daemon parses and exports.
+
+    Given: deployed pfBlockerNG with an IP block alias covering 203.0.113.0/24,
+           syslog export currently ON (enabled by test_syslog_on_dnsbl_event_exported),
+           filterlog daemon running (started by the package rc script on reload).
+    When:  a TCP connection to 203.0.113.1 is attempted (pf blocks + logs it);
+           the filterlog daemon picks up the filter.log entry.
+    Then:  a new ``pfblockerng`` syslog record appears in SYSLOG_LOG with
+           ``act=block`` and the src / alias / feed / dst keys populated.
+    And:   the CSV ip_block.log is ALSO written (export is additive — §2.2.1).
+    """
+    vm = deployed_vm
+
+    # ------------------------------------------------------------------ #
+    # Given: syslog export is ON (left on by the previous test in module scope).
+    #        Confirm via config read (precondition guard).
+    # ------------------------------------------------------------------ #
+    val = h.config_get(vm, CFG_GENERAL + "/log_syslog")
+    assert val == "on", f"Precondition: expected log_syslog='on' from prior test, got {val!r}"
+
+    # Baseline
+    before_count = _count_syslog_lines(vm)
+    ip_block_before_content = h.read_log_file(vm, IP_BLOCK_LOG)
+
+    # ------------------------------------------------------------------ #
+    # When: trigger an outbound TCP SYN to a pf-blocked IP
+    # ------------------------------------------------------------------ #
+    _trigger_ip_block(vm)
+
+    # Give the filterlog daemon time to process the filter.log entry and
+    # write to ip_block.log + emit the syslog record.
+    time.sleep(FILTERLOG_SETTLE_SECS)
+
+    # ------------------------------------------------------------------ #
+    # Then: at least one new pfblockerng syslog line with act=block
+    # ------------------------------------------------------------------ #
+    after_lines = _read_syslog_lines(vm)
+
+    # If no new IP-block syslog line appeared yet, try again once (the filterlog
+    # daemon may not have started — check and report rather than silently skip).
+    if len(after_lines) <= before_count or not any(
+        "act=block" in ln or "act=pass" in ln for ln in after_lines[before_count:]
+    ):
+        # Diagnose whether the filterlog daemon is running
+        ps_result = vm.ssh("/bin/ps", "-wax", timeout=30)
+        daemon_running = "pfblockerng.inc filterlog" in ps_result.stdout or "tail_pfb" in ps_result.stdout
+
+        # Also check if the IP block alias table actually has our test range
+        pfctl_result = vm.ssh("/sbin/pfctl", "-t", "pfB_pfb_syslog_iptest_v4", "-T", "show", timeout=30)
+        alias_populated = TEST_IP_BLOCK_RANGE in pfctl_result.stdout or "203.0.113" in pfctl_result.stdout
+
+        if not alias_populated:
+            pytest.skip(
+                f"IP block alias pfB_pfb_syslog_iptest_v4 is not populated with "
+                f"{TEST_IP_BLOCK_RANGE} — IP feed reload may have failed. "
+                f"pfctl output: {pfctl_result.stdout!r}"
+            )
+
+        if not daemon_running:
+            pytest.skip(
+                f"filterlog daemon is not running — cannot exercise the IP syslog path "
+                f"(process list: {ps_result.stdout[:500]!r})"
+            )
+
+        # Daemon running + alias populated but no syslog line => genuine failure.
+        assert False, (  # noqa: B011  (intentional after diagnostics)
+            f"No new IP-block syslog line appeared after connection attempt to "
+            f"{TEST_IP_BLOCK_DST} (before {before_count}, after {len(after_lines)} lines).\n"
+            f"filterlog daemon running: {daemon_running}\n"
+            f"alias populated: {alias_populated}\n"
+            f"pf alias table: {pfctl_result.stdout!r}\n"
+            f"All syslog lines: {after_lines}"
+        )
+
+    new_lines = after_lines[before_count:]
+    ip_block_lines = [ln for ln in new_lines if "act=block" in ln or "act=pass" in ln]
+    assert ip_block_lines, (
+        f"Syslog had new lines but none with act=block/pass after IP block trigger.\nNew lines: {new_lines}"
+    )
+
+    # Confirm pfblockerng tag is present (required by §2.2.2)
+    assert any("pfblockerng" in ln for ln in ip_block_lines), (
+        f"IP block syslog lines lack 'pfblockerng' tag: {ip_block_lines}"
+    )
+
+    # ------------------------------------------------------------------ #
+    # And: CSV ip_block.log is also written (additive)
+    # ------------------------------------------------------------------ #
+    ip_block_after_content = h.read_log_file(vm, IP_BLOCK_LOG)
+    assert len(ip_block_after_content) > len(ip_block_before_content), (
+        "CSV ip_block.log was NOT written after syslog export was enabled — export must be additive (§2.2.1)"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Test 3: OFF ⇒ no new export records (before/after proof — §2.2.1)
+# --------------------------------------------------------------------------- #
+
+
+def test_syslog_off_no_new_records(deployed_vm: SmokeVM) -> None:
+    """§2.2.1 — OFF ⇒ zero event export; CSV logging unchanged.
+
+    Before/after proof: first assert ON produced records (already true from prior
+    tests), then disable and assert the count does NOT increase.
+
+    Given: syslog export is currently ON (from prior tests), both DNSBL and IP
+           block paths have already produced syslog records.
+    When:  log_syslog is set to OFF and DNSBL is reloaded (pfb_unbound.ini rebuilt
+           with syslog_enable=off); the blocked domain is probed again and a
+           connection to the blocked IP is attempted again.
+    Then:  the syslog line count does NOT increase — zero new records emitted.
+    And:   the CSV dnsbl.log and ip_block.log are STILL written (§2.2.1).
+    """
+    vm = deployed_vm
+    domain: str = vm._pfb_dnsbl_domain  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------------ #
+    # Given: ON produced records (assert the before-state)
+    # ------------------------------------------------------------------ #
+    count_while_on = _count_syslog_lines(vm)
+    assert count_while_on > 0, (
+        "Precondition: expected syslog records from prior ON tests, but "
+        f"SYSLOG_LOG has {count_while_on} lines — prior tests may have failed"
+    )
+
+    dnsbl_csv_before = h.count_log_marker(vm, DNSBL_LOG, domain)
+    ip_csv_before_content = h.read_log_file(vm, IP_BLOCK_LOG)
+
+    # ------------------------------------------------------------------ #
+    # When: disable syslog export + reload DNSBL (updates pfb_unbound.ini)
+    # ------------------------------------------------------------------ #
+    _set_syslog_enabled(vm, on=False)
+    h.reload(vm, "updatednsbl")
+
+    # ------------------------------------------------------------------ #
+    # When: probe the blocked DNSBL domain on-box (would emit if toggle were on)
+    # ------------------------------------------------------------------ #
+    ans = h.dns_probe(vm, domain, "A")
+    assert h.is_vip(ans), f"DNSBL block should still work when syslog is OFF, got {ans}"
+
+    # ------------------------------------------------------------------ #
+    # When: trigger IP block again (would emit if toggle were on)
+    # ------------------------------------------------------------------ #
+    _trigger_ip_block(vm)
+    time.sleep(FILTERLOG_SETTLE_SECS)
+
+    # ------------------------------------------------------------------ #
+    # Then: syslog line count is unchanged (no new records emitted)
+    # ------------------------------------------------------------------ #
+    count_while_off = _count_syslog_lines(vm)
+    assert count_while_off == count_while_on, (
+        f"New syslog records appeared after disabling export (before {count_while_on}, "
+        f"after {count_while_off}) — the OFF gate is not working"
+    )
+
+    # ------------------------------------------------------------------ #
+    # And: CSV logging still works in the OFF state (export is additive)
+    # ------------------------------------------------------------------ #
+    dnsbl_csv_after = h.count_log_marker(vm, DNSBL_LOG, domain)
+    assert dnsbl_csv_after > dnsbl_csv_before, (
+        f"CSV dnsbl.log was NOT written while syslog export is OFF "
+        f"(before {dnsbl_csv_before}, after {dnsbl_csv_after}) "
+        f"— the CSV path must be independent of the syslog toggle"
+    )
+
+    ip_csv_after_content = h.read_log_file(vm, IP_BLOCK_LOG)
+    assert len(ip_csv_after_content) > len(ip_csv_before_content), (
+        "CSV ip_block.log was NOT written while syslog export is OFF "
+        "— the CSV path must be independent of the syslog toggle"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Test 4 (optional): syslog records excluded from system.log (§2.2.1 footprint)
+# --------------------------------------------------------------------------- #
+
+
+def test_syslog_records_excluded_from_system_log(deployed_vm: SmokeVM) -> None:
+    """§2.2.1 — pfblockerng events are routed to the dedicated log, not system.log.
+
+    The pfSense <logging> block in pfblockerng.xml adds a !pfblockerng exclusion
+    so events tagged pfblockerng go to pfblockerng_syslog.log only and are NOT
+    duplicated in system.log.
+
+    Given: syslog export is currently OFF (left off by prior test); we enable it,
+           probe the blocked domain, then check system.log.
+    When:  log_syslog is enabled + DNSBL reloaded + domain probed.
+    Then:  no new pfblockerng-tagged line appears in /var/log/system.log.
+    """
+    vm = deployed_vm
+    domain: str = vm._pfb_dnsbl_domain  # type: ignore[attr-defined]
+
+    # Baseline: count pfblockerng lines in system.log BEFORE enabling
+    system_log_before = h.count_log_marker(vm, "/var/log/system.log", "pfblockerng")
+
+    # Enable + reload DNSBL + probe
+    _set_syslog_enabled(vm, on=True)
+    h.reload(vm, "updatednsbl")
+
+    ans = h.dns_probe(vm, domain, "A")
+    assert h.is_vip(ans), f"DNSBL block not observed: {ans}"
+    time.sleep(1.0)
+
+    # Count pfblockerng lines in system.log AFTER the probe
+    system_log_after = h.count_log_marker(vm, "/var/log/system.log", "pfblockerng")
+
+    # The !pfblockerng tag filter routes our messages to the dedicated log only;
+    # system.log's count should not have grown with our syslog event records.
+    assert system_log_after == system_log_before, (
+        f"pfblockerng syslog events leaked into /var/log/system.log "
+        f"(before {system_log_before}, after {system_log_after}) — "
+        f"the <logging> exclusion (!pfblockerng) is not working"
+    )
+
+    # Leave syslog export ON for any subsequent tests in the module.

--- a/tests/test_syslog_emit_dnsbl.py
+++ b/tests/test_syslog_emit_dnsbl.py
@@ -1,0 +1,339 @@
+"""ADR-38 Phase 4 — DNSBL syslog emitter: gate and silent-degrade tests.
+
+Pins the behaviour of _emit_dnsbl_syslog() and its integration at the
+get_details_dnsbl() CSV write site.
+
+Coverage mandate (CLAUDE.md test-coverage):
+  (a) Toggle branch: syslog_enable=False => no emit; then True => emit.
+      The before-state is asserted first so the test proves the flag caused
+      the change (not an always-emit path).
+  (b) Socket-absent / raising: the handler constructor raises => _syslog_failed
+      is latched True, no exception propagates, the DNSBL CSV write and
+      resolution path still complete (return value is True, CSV line written).
+  (c) Emit-once: a single DNSBL block event fires exactly one syslog emit.
+  (d) Body contents: the emitted message includes the pfblockerng ident prefix
+      and the syslog_format_dnsbl() key=value body.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pfb_unbound
+
+# ---------------------------------------------------------------------------
+# Helpers shared by the test classes below.
+# ---------------------------------------------------------------------------
+
+
+def _block_decision(**kw: Any) -> Any:
+    """A composed Decision whose DNSBL axis is a block; kw overrides fields."""
+    fields: dict[str, Any] = {
+        "is_found": True,
+        "in_whitelist": False,
+        "in_hsts": False,
+        "null_blocking": False,
+        "nxdomain": False,
+        "log_type": "1",
+        "b_type": "VIP",
+        "p_type": "Python",
+        "feed": "TestFeed",
+        "group": "TestGroup",
+        "b_eval": "bad.example.com",
+    }
+    fields.update(kw)
+    return pfb_unbound.Decision(dnsbl=pfb_unbound.DnsblDecision(**fields))
+
+
+def _qstate(name: str = "bad.example.com.", qtype: str = "A") -> Any:
+    return types.SimpleNamespace(
+        qinfo=types.SimpleNamespace(qname_str=name, qtype_str=qtype),
+        return_msg=None,
+    )
+
+
+def _run_dnsbl(monkeypatch: Any, name: str = "bad.example.com.") -> list[tuple[str, str]]:
+    """Set up and call get_details_dnsbl(); return captured pfb_log calls."""
+    key = name.rstrip(".")
+    monkeypatch.setitem(pfb_unbound.pfb, "python_nolog", False)
+    monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_resolver_con", False)
+    monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_dnsbl_con", False)
+    monkeypatch.setattr(pfb_unbound, "decisionDB", {key: _block_decision()})
+    lines: list[tuple[str, str]] = []
+    monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: lines.append((path, line)))
+    pfb_unbound.get_details_dnsbl("dnsbl", None, _qstate(name), None, {"pfb_addr": "1.2.3.4"})
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# (a) Toggle branch: disabled => no emit, then enabled => emit.
+# ---------------------------------------------------------------------------
+
+
+class TestSyslogEmitToggleBranch:
+    """Prove the syslog_enable gate is a real branch (not an always-emit path).
+
+    Scenario:
+      Given syslog_enable=False (default off).
+      When  get_details_dnsbl() processes a DNSBL block event.
+      Then  _emit_dnsbl_syslog is NOT called and _syslog_handler stays None.
+      ──
+      Given syslog_enable=True (enabled).
+      When  get_details_dnsbl() processes a DNSBL block event.
+      Then  _emit_dnsbl_syslog IS called, the message body is correct, and the
+            CSV line is still written (syslog is additive, not a replacement).
+    """
+
+    def test_disabled_no_syslog_emit_before_enabled(self, monkeypatch: Any) -> None:
+        """BEFORE: syslog_enable=False => no handler created, no emit.
+
+        This is the before-state assertion required by the coverage mandate.
+        """
+        # Given: syslog off (conftest default)
+        assert pfb_unbound.pfb["syslog_enable"] is False
+
+        emitted: list[str] = []
+
+        def _fake_emit(msg: str) -> None:
+            emitted.append(msg)
+
+        monkeypatch.setattr(pfb_unbound, "_emit_dnsbl_syslog", _fake_emit)
+
+        _run_dnsbl(monkeypatch)
+
+        # Then: no syslog emit
+        assert emitted == [], "disabled: _emit_dnsbl_syslog must NOT be called"
+        assert pfb_unbound._syslog_handler is None, "disabled: handler stays None"
+
+    def test_enabled_emits_exactly_once_with_correct_body(self, monkeypatch: Any) -> None:
+        """AFTER: syslog_enable=True => exactly one emit with correct body.
+
+        Also asserts the CSV log line is still written (additive, not replacing).
+        """
+        # Given: syslog enabled
+        monkeypatch.setitem(pfb_unbound.pfb, "syslog_enable", True)
+        assert pfb_unbound.pfb["syslog_enable"] is True
+
+        emitted: list[str] = []
+
+        def _fake_emit(msg: str) -> None:
+            emitted.append(msg)
+
+        monkeypatch.setattr(pfb_unbound, "_emit_dnsbl_syslog", _fake_emit)
+
+        lines = _run_dnsbl(monkeypatch)
+
+        # Then: exactly one syslog emit
+        assert len(emitted) == 1, "enabled: _emit_dnsbl_syslog must be called exactly once"
+
+        body = emitted[0]
+        # Body must contain all expected DNSBL key=value pairs
+        assert "act=dnsbl" in body, "body must contain act=dnsbl"
+        assert "qname=bad.example.com" in body, "body must contain qname"
+        assert "qip=1.2.3.4" in body, "body must contain qip"
+        assert "btype=VIP" in body, "body must contain btype"
+        assert "eval=bad.example.com" in body, "body must contain eval"
+
+        # CSV file write still happened (additive, not replacing)
+        dnsbl_lines = [line for path, line in lines if path.endswith("dnsbl.log")]
+        assert len(dnsbl_lines) == 1, "CSV write must still occur when syslog is enabled"
+
+    def test_toggle_flip_off_then_on_proves_real_branch(self, monkeypatch: Any) -> None:
+        """Toggle off => no emit; then toggle on => emit. Before AND after asserted.
+
+        This is the canonical before/after transition test required by CLAUDE.md:
+        assert off-state, flip toggle, assert on-state — proving the flag caused it.
+        """
+        emitted: list[str] = []
+
+        def _fake_emit(msg: str) -> None:
+            emitted.append(msg)
+
+        monkeypatch.setattr(pfb_unbound, "_emit_dnsbl_syslog", _fake_emit)
+
+        # --- BEFORE: disabled ---
+        assert pfb_unbound.pfb["syslog_enable"] is False
+        _run_dnsbl(monkeypatch)
+        assert emitted == [], "before (off): no emit"
+
+        # --- AFTER: enabled ---
+        monkeypatch.setitem(pfb_unbound.pfb, "syslog_enable", True)
+        _run_dnsbl(monkeypatch)
+        assert len(emitted) == 1, "after (on): exactly one emit"
+
+
+# ---------------------------------------------------------------------------
+# (b) Silent-degrade: socket absent / constructor raises => no propagation.
+# ---------------------------------------------------------------------------
+
+
+class TestSyslogEmitSilentDegrade:
+    """Prove the silent-degrade contract (ADR §2.2.4).
+
+    Scenario:
+      Given syslog_enable=True AND the SysLogHandler constructor raises
+            (simulating an absent/unreachable socket).
+      When  get_details_dnsbl() processes a DNSBL block event.
+      Then  no exception propagates (resolution path safe), the DNSBL CSV
+            line is still written, get_details_dnsbl returns True, and
+            _syslog_failed is latched True (no retry-storm).
+    """
+
+    def test_socket_absent_raises_no_exception_and_csv_still_written(self, monkeypatch: Any) -> None:
+        """Constructor raises => CSV write completes, no exception, latch set.
+
+        Given: syslog_enable=True, SysLogHandler constructor raises OSError.
+        When:  get_details_dnsbl() processes a block.
+        Then:  returns True, CSV written, _syslog_failed latched.
+        """
+        # Given: syslog enabled, handler constructor will raise
+        monkeypatch.setitem(pfb_unbound.pfb, "syslog_enable", True)
+        assert pfb_unbound._syslog_handler is None
+        assert pfb_unbound._syslog_failed is False
+
+        # Patch _PfbSysLogHandler to raise in the constructor
+        class _RaisingHandler:
+            def __init__(self, **kw: Any) -> None:
+                raise OSError("no such socket /var/run/log")
+
+        monkeypatch.setattr(pfb_unbound, "_PfbSysLogHandler", _RaisingHandler)
+
+        lines = _run_dnsbl(monkeypatch)
+
+        # Then: no exception propagated (we reached here); CSV still written
+        dnsbl_lines = [line for path, line in lines if path.endswith("dnsbl.log")]
+        assert len(dnsbl_lines) == 1, "CSV write must succeed even when syslog raises"
+
+        # Failure latch must be set (no retry-storm)
+        assert pfb_unbound._syslog_failed is True, "_syslog_failed must be latched on error"
+        assert pfb_unbound._syslog_handler is None, "handler must not be set after constructor failure"
+
+    def test_socket_absent_subsequent_calls_are_no_ops(self, monkeypatch: Any) -> None:
+        """After _syslog_failed is latched, further calls skip the handler entirely.
+
+        Given: _syslog_failed already latched from a prior error.
+        When:  _emit_dnsbl_syslog is called again (enabled).
+        Then:  no handler construction attempted, no exception.
+        """
+        # Given: latch already set
+        monkeypatch.setitem(pfb_unbound.pfb, "syslog_enable", True)
+        monkeypatch.setattr(pfb_unbound, "_syslog_failed", True)
+
+        constructor_calls: list[Any] = []
+
+        class _TrackingHandler:
+            def __init__(self, **kw: Any) -> None:
+                constructor_calls.append(kw)
+
+        monkeypatch.setattr(pfb_unbound, "_PfbSysLogHandler", _TrackingHandler)
+
+        # Call the emitter directly (no exception expected)
+        pfb_unbound._emit_dnsbl_syslog("act=dnsbl qname=x.com qip=1.2.3.4 qtype=A btype=VIP eval=x.com")
+
+        assert constructor_calls == [], "constructor must NOT be called when latch is set"
+
+    def test_emit_exception_latches_failure_and_does_not_propagate(self, monkeypatch: Any) -> None:
+        """emit() raising latches _syslog_failed and does not propagate.
+
+        Given: syslog_enable=True, handler constructed OK but emit() raises.
+        When:  _emit_dnsbl_syslog is called.
+        Then:  _syslog_failed becomes True, no exception raised.
+        """
+        monkeypatch.setitem(pfb_unbound.pfb, "syslog_enable", True)
+        assert pfb_unbound._syslog_failed is False
+
+        mock_handler = MagicMock()
+        mock_handler.emit.side_effect = OSError("broken pipe")
+
+        class _SuccessHandler:
+            def __init__(self, **kw: Any) -> None:
+                pass
+
+        monkeypatch.setattr(pfb_unbound, "_PfbSysLogHandler", _SuccessHandler)
+        # Pre-wire a mock handler so emit() is what raises
+        monkeypatch.setattr(pfb_unbound, "_syslog_handler", mock_handler)
+
+        # Must not raise
+        pfb_unbound._emit_dnsbl_syslog("act=dnsbl qname=x.com qip=1.2.3.4 qtype=A btype=VIP eval=x.com")
+
+        assert pfb_unbound._syslog_failed is True, "emit error must latch _syslog_failed"
+
+    def test_get_details_dnsbl_returns_true_when_syslog_raises(self, monkeypatch: Any) -> None:
+        """get_details_dnsbl() returns True (resolution continues) even when syslog fails.
+
+        Given: syslog_enable=True, SysLogHandler constructor raises.
+        When:  get_details_dnsbl() is called with a block decision.
+        Then:  returns True (the DNSBL path completes normally).
+        """
+        monkeypatch.setitem(pfb_unbound.pfb, "syslog_enable", True)
+        monkeypatch.setitem(pfb_unbound.pfb, "python_nolog", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_resolver_con", False)
+        monkeypatch.setitem(pfb_unbound.pfb, "sqlite3_dnsbl_con", False)
+
+        class _RaisingHandler:
+            def __init__(self, **kw: Any) -> None:
+                raise OSError("socket error")
+
+        monkeypatch.setattr(pfb_unbound, "_PfbSysLogHandler", _RaisingHandler)
+        monkeypatch.setattr(pfb_unbound, "decisionDB", {"bad.example.com": _block_decision()})
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda *a: None)
+
+        result = pfb_unbound.get_details_dnsbl("dnsbl", None, _qstate(), None, {"pfb_addr": "1.2.3.4"})
+
+        assert result is True, "get_details_dnsbl must return True even when syslog raises"
+
+
+# ---------------------------------------------------------------------------
+# (c)+(d) Emit body contents and ident prefix.
+# ---------------------------------------------------------------------------
+
+
+class TestSyslogEmitBody:
+    """Verify the message body and ident prefix from _emit_dnsbl_syslog directly."""
+
+    def test_message_has_pfblockerng_ident_prefix(self, monkeypatch: Any) -> None:
+        """The emitted message begins with 'pfblockerng: ' for syslogd tag routing.
+
+        Scenario:
+          Given syslog_enable=True and a functioning handler mock.
+          When  _emit_dnsbl_syslog('act=dnsbl qname=...') is called.
+          Then  the LogRecord.msg starts with 'pfblockerng: '.
+        """
+        monkeypatch.setitem(pfb_unbound.pfb, "syslog_enable", True)
+
+        recorded_records: list[Any] = []
+        mock_handler = MagicMock()
+        mock_handler.emit.side_effect = lambda rec: recorded_records.append(rec)
+
+        monkeypatch.setattr(pfb_unbound, "_syslog_handler", mock_handler)
+
+        body = "act=dnsbl qname=bad.com qip=10.0.0.1 qtype=A btype=VIP eval=bad.com"
+        pfb_unbound._emit_dnsbl_syslog(body)
+
+        assert len(recorded_records) == 1
+        record = recorded_records[0]
+        assert record.msg.startswith("pfblockerng: "), "emitted LogRecord.msg must start with 'pfblockerng: '"
+        assert body in record.msg, "body must appear after the ident prefix"
+
+    def test_disabled_emit_is_zero_cost_no_handler_creation(self, monkeypatch: Any) -> None:
+        """When syslog_enable=False, _emit_dnsbl_syslog returns immediately (no handler).
+
+        Gate checked before any formatting — zero overhead on the common path.
+        """
+        assert pfb_unbound.pfb["syslog_enable"] is False
+        assert pfb_unbound._syslog_handler is None
+
+        constructor_calls: list[Any] = []
+
+        class _TrackingHandler:
+            def __init__(self, **kw: Any) -> None:
+                constructor_calls.append(kw)
+
+        monkeypatch.setattr(pfb_unbound, "_PfbSysLogHandler", _TrackingHandler)
+
+        pfb_unbound._emit_dnsbl_syslog("act=dnsbl qname=x.com qip=1.2.3.4 qtype=A btype=VIP eval=x.com")
+
+        assert constructor_calls == [], "disabled: no handler construction"
+        assert pfb_unbound._syslog_handler is None, "disabled: _syslog_handler stays None"

--- a/tests/test_syslog_format.py
+++ b/tests/test_syslog_format.py
@@ -1,0 +1,370 @@
+"""ADR-38 Phase 1 — Pure DNSBL syslog event formatter.
+
+Pins the behaviour of:
+    syslog_format_dnsbl(q_name, q_ip, q_type, group, feed, b_type, b_eval) -> str
+
+The function is PURE (no I/O, no globals, stdlib-only) and DORMANT this phase
+(uncalled from production code).  These tests are the only callers.
+
+Coverage mandate (CLAUDE.md):
+  - DNSBL VIP block type vs NULL block type.
+  - CNAME q_type (non-A/AAAA).
+  - Empty group and/or feed omitted from output.
+  - Value containing space, '=', or '"' is double-quoted.
+  - Newline in value is stripped (single-line guarantee).
+  - Fixed key order: act qname qip qtype [group] [feed] btype eval.
+  - Exact golden strings for every case.
+"""
+
+from __future__ import annotations
+
+from pfb_unbound import syslog_format_dnsbl
+
+# ---------------------------------------------------------------------------
+# DNSBL VIP block — all fields populated
+# ---------------------------------------------------------------------------
+
+
+def test_dnsbl_vip_block_all_fields_exact_string() -> None:
+    """VIP block with group and feed present produces the exact golden string.
+
+    Scenario:
+      Given q_name='malware.example.com', q_ip='192.168.1.5', q_type='A',
+            group='EasyList', feed='EasyList_Adult', b_type='VIP',
+            b_eval='malware.example.com'.
+      When  syslog_format_dnsbl(...).
+      Then  returns the exact key=value string with act=dnsbl and all fields.
+    """
+    result = syslog_format_dnsbl(
+        q_name="malware.example.com",
+        q_ip="192.168.1.5",
+        q_type="A",
+        group="EasyList",
+        feed="EasyList_Adult",
+        b_type="VIP",
+        b_eval="malware.example.com",
+    )
+    assert result == (
+        "act=dnsbl qname=malware.example.com qip=192.168.1.5 qtype=A "
+        "group=EasyList feed=EasyList_Adult btype=VIP eval=malware.example.com"
+    ), "VIP block: all fields in documented order"
+
+
+# ---------------------------------------------------------------------------
+# DNSBL NULL block — all fields populated
+# ---------------------------------------------------------------------------
+
+
+def test_dnsbl_null_block_all_fields_exact_string() -> None:
+    """NULL block with all fields present: btype=NULL.
+
+    Scenario:
+      Given b_type='NULL', q_type='AAAA', all other fields non-empty.
+      When  syslog_format_dnsbl(...).
+      Then  returns exact string with btype=NULL.
+    """
+    result = syslog_format_dnsbl(
+        q_name="tracking.example.net",
+        q_ip="10.0.0.1",
+        q_type="AAAA",
+        group="BlockGroup",
+        feed="TrackingFeed",
+        b_type="NULL",
+        b_eval="tracking.example.net",
+    )
+    assert result == (
+        "act=dnsbl qname=tracking.example.net qip=10.0.0.1 qtype=AAAA "
+        "group=BlockGroup feed=TrackingFeed btype=NULL eval=tracking.example.net"
+    ), "NULL block: all fields"
+
+
+# ---------------------------------------------------------------------------
+# VIP vs NULL are different outputs (before-and-after)
+# ---------------------------------------------------------------------------
+
+
+def test_dnsbl_vip_vs_null_differ() -> None:
+    """VIP and NULL b_type produce different btype= values — before/after.
+
+    Scenario:
+      Given identical inputs except b_type.
+      Before: b_type='VIP'  -> btype=VIP in output.
+      After:  b_type='NULL' -> btype=NULL in output.
+      Then    the two outputs differ exactly at the btype field.
+    """
+    vip = syslog_format_dnsbl("ex.com", "1.2.3.4", "A", "G", "F", "VIP", "ex.com")
+    null_ = syslog_format_dnsbl("ex.com", "1.2.3.4", "A", "G", "F", "NULL", "ex.com")
+
+    # Before: VIP -> btype=VIP.
+    assert "btype=VIP" in vip, "VIP: btype=VIP must appear"
+    assert "btype=NULL" not in vip, "VIP: btype=NULL must NOT appear"
+
+    # After: NULL -> btype=NULL.
+    assert "btype=NULL" in null_, "NULL: btype=NULL must appear"
+    assert "btype=VIP" not in null_, "NULL: btype=VIP must NOT appear"
+
+
+# ---------------------------------------------------------------------------
+# CNAME q_type
+# ---------------------------------------------------------------------------
+
+
+def test_dnsbl_cname_qtype_exact_string() -> None:
+    """CNAME q_type appears verbatim in the output.
+
+    Scenario:
+      Given q_type='CNAME'.
+      When  syslog_format_dnsbl(...).
+      Then  qtype=CNAME appears in output at the correct position.
+    """
+    result = syslog_format_dnsbl(
+        q_name="cdn.malware.example.com",
+        q_ip="172.16.0.1",
+        q_type="CNAME",
+        group="CDNBlock",
+        feed="MalwareFeed",
+        b_type="TLD",
+        b_eval="malware.example.com",
+    )
+    assert result == (
+        "act=dnsbl qname=cdn.malware.example.com qip=172.16.0.1 qtype=CNAME "
+        "group=CDNBlock feed=MalwareFeed btype=TLD eval=malware.example.com"
+    ), "CNAME q_type: exact string"
+
+
+# ---------------------------------------------------------------------------
+# Empty group — omitted from output
+# ---------------------------------------------------------------------------
+
+
+def test_dnsbl_empty_group_omitted() -> None:
+    """Empty group is omitted; non-empty group is included — before/after.
+
+    Scenario:
+      Before: group='' -> 'group=' absent from output.
+      After:  group='RealGroup' -> 'group=RealGroup' present in output.
+    """
+    # Before: empty group -> absent.
+    before = syslog_format_dnsbl("a.com", "1.1.1.1", "A", "", "SomeFeed", "VIP", "a.com")
+    assert "group=" not in before, "empty group must be omitted"
+
+    # After: real group -> present.
+    after = syslog_format_dnsbl("a.com", "1.1.1.1", "A", "RealGroup", "SomeFeed", "VIP", "a.com")
+    assert "group=RealGroup" in after, "non-empty group must appear"
+
+
+def test_dnsbl_empty_group_exact_string() -> None:
+    """Empty group omitted: exact golden string without group key.
+
+    Scenario:
+      Given group='', feed='SomeFeed'.
+      When  syslog_format_dnsbl(...).
+      Then  output skips group= and goes straight to feed= after qtype=.
+    """
+    result = syslog_format_dnsbl(
+        q_name="b.com",
+        q_ip="2.2.2.2",
+        q_type="A",
+        group="",
+        feed="SomeFeed",
+        b_type="DNSBL",
+        b_eval="b.com",
+    )
+    assert result == ("act=dnsbl qname=b.com qip=2.2.2.2 qtype=A feed=SomeFeed btype=DNSBL eval=b.com"), (
+        "empty group: exact string without group key"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty feed — omitted from output
+# ---------------------------------------------------------------------------
+
+
+def test_dnsbl_empty_feed_omitted() -> None:
+    """Empty feed is omitted; non-empty feed is included — before/after.
+
+    Scenario:
+      Before: feed='' -> 'feed=' absent from output.
+      After:  feed='RealFeed' -> 'feed=RealFeed' present.
+    """
+    # Before: empty feed -> absent.
+    before = syslog_format_dnsbl("c.com", "3.3.3.3", "A", "Grp", "", "VIP", "c.com")
+    assert "feed=" not in before, "empty feed must be omitted"
+
+    # After: real feed -> present.
+    after = syslog_format_dnsbl("c.com", "3.3.3.3", "A", "Grp", "RealFeed", "VIP", "c.com")
+    assert "feed=RealFeed" in after, "non-empty feed must appear"
+
+
+def test_dnsbl_empty_group_and_feed_exact_string() -> None:
+    """Both group and feed empty: exact string with just required fields.
+
+    Scenario:
+      Given group='', feed=''.
+      When  syslog_format_dnsbl(...).
+      Then  output has act qname qip qtype btype eval only.
+    """
+    result = syslog_format_dnsbl(
+        q_name="d.com",
+        q_ip="4.4.4.4",
+        q_type="AAAA",
+        group="",
+        feed="",
+        b_type="Python",
+        b_eval="d.com",
+    )
+    assert result == ("act=dnsbl qname=d.com qip=4.4.4.4 qtype=AAAA btype=Python eval=d.com"), (
+        "both group and feed empty: exact minimal string"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Escaping — space, '=', '"' in values
+# ---------------------------------------------------------------------------
+
+
+def test_dnsbl_value_with_space_is_quoted() -> None:
+    """A value containing a space is double-quoted.
+
+    Scenario:
+      Given b_eval = 'TLD match.example.com' (contains space).
+      When  syslog_format_dnsbl(...).
+      Then  eval="TLD match.example.com" appears quoted in output.
+    """
+    result = syslog_format_dnsbl(
+        q_name="e.com",
+        q_ip="5.5.5.5",
+        q_type="A",
+        group="G",
+        feed="F",
+        b_type="TLD",
+        b_eval="TLD match.example.com",
+    )
+    assert 'eval="TLD match.example.com"' in result, "b_eval with space must be quoted"
+
+
+def test_dnsbl_value_with_equals_is_quoted() -> None:
+    """A value containing '=' is double-quoted.
+
+    Scenario:
+      Given q_name = 'host=bad.example.com' (contains '=').
+      When  syslog_format_dnsbl(...).
+      Then  qname="host=bad.example.com" appears quoted.
+    """
+    result = syslog_format_dnsbl(
+        q_name="host=bad.example.com",
+        q_ip="6.6.6.6",
+        q_type="A",
+        group="G",
+        feed="F",
+        b_type="DNSBL",
+        b_eval="host=bad.example.com",
+    )
+    assert 'qname="host=bad.example.com"' in result, "qname with = must be quoted"
+
+
+def test_dnsbl_value_with_double_quote_is_escaped() -> None:
+    """A value containing '"' is double-quoted with inner quote escaped.
+
+    Scenario:
+      Given b_eval = 'bad"eval' (contains '"').
+      When  syslog_format_dnsbl(...).
+      Then  eval="bad\\"eval" appears in output.
+    """
+    result = syslog_format_dnsbl(
+        q_name="f.com",
+        q_ip="7.7.7.7",
+        q_type="A",
+        group="G",
+        feed="F",
+        b_type="DNSBL",
+        b_eval='bad"eval',
+    )
+    assert 'eval="bad\\"eval"' in result, 'inner " must be \\"-escaped'
+
+
+def test_dnsbl_newline_in_value_is_stripped() -> None:
+    """Newlines embedded in a value are replaced with a space (single-line output).
+
+    Scenario:
+      Given q_name = 'multi\\nline.com' (contains \\n).
+      When  syslog_format_dnsbl(...).
+      Then  the output contains no newline character.
+      And   the embedded newline is replaced with a space.
+    """
+    result = syslog_format_dnsbl(
+        q_name="multi\nline.com",
+        q_ip="8.8.8.8",
+        q_type="A",
+        group="G",
+        feed="F",
+        b_type="VIP",
+        b_eval="multi\nline.com",
+    )
+    assert "\n" not in result, "output must be single-line"
+    assert 'qname="multi line.com"' in result, "newline replaced with space, then quoted"
+
+
+# ---------------------------------------------------------------------------
+# Fixed key order
+# ---------------------------------------------------------------------------
+
+
+def test_dnsbl_key_order_required_fields() -> None:
+    """act qname qip qtype btype eval appear in the documented order.
+
+    Scenario:
+      Given all required fields and no optional fields.
+      When  syslog_format_dnsbl(...).
+      Then  keys appear in order: act < qname < qip < qtype < btype < eval.
+    """
+    result = syslog_format_dnsbl(
+        q_name="order.example.com",
+        q_ip="9.9.9.9",
+        q_type="A",
+        group="",
+        feed="",
+        b_type="VIP",
+        b_eval="order.example.com",
+    )
+    pos_act = result.index("act=")
+    pos_qname = result.index("qname=")
+    pos_qip = result.index("qip=")
+    pos_qtype = result.index("qtype=")
+    pos_btype = result.index("btype=")
+    pos_eval = result.index("eval=")
+
+    assert pos_act < pos_qname, "act before qname"
+    assert pos_qname < pos_qip, "qname before qip"
+    assert pos_qip < pos_qtype, "qip before qtype"
+    assert pos_qtype < pos_btype, "qtype before btype"
+    assert pos_btype < pos_eval, "btype before eval"
+
+
+def test_dnsbl_key_order_with_optional_fields() -> None:
+    """group and feed appear between qtype and btype when present.
+
+    Scenario:
+      Given all fields including group and feed.
+      When  syslog_format_dnsbl(...).
+      Then  qtype < group < feed < btype < eval.
+    """
+    result = syslog_format_dnsbl(
+        q_name="full.example.com",
+        q_ip="10.10.10.10",
+        q_type="A",
+        group="MyGroup",
+        feed="MyFeed",
+        b_type="DNSBL",
+        b_eval="full.example.com",
+    )
+    pos_qtype = result.index("qtype=")
+    pos_group = result.index("group=")
+    pos_feed = result.index("feed=")
+    pos_btype = result.index("btype=")
+    pos_eval = result.index("eval=")
+
+    assert pos_qtype < pos_group, "qtype before group"
+    assert pos_group < pos_feed, "group before feed"
+    assert pos_feed < pos_btype, "feed before btype"
+    assert pos_btype < pos_eval, "btype before eval"


### PR DESCRIPTION
## ADR-38: Integrated syslog export of pfBlockerNG security events

Implements [issue #337](https://github.com/pfBlockerNG/pfBlockerNG/issues/337) (Redmine #14878, *"Integrated syslog support"*), with #380 (Redmine #12097) folded in. Organisations running a SIEM can now have pfBlockerNG's IP Block/Permit/Match and DNSBL block events delivered to syslog in a structured `key=value` form, not only the local CSV files.

Opt-in, default-off, zero behaviour change when disabled. Full design: `.ADRs/ADR_38_System_Log_Integration/ADR.md`.

### What it does

- New **Log Settings** controls (General page): enable toggle + syslog facility (default `local6`) + severity (default `notice`).
- IP events emit one `pfblockerng` `key=value` record per line at the filterlog write site; DNSBL events emit from the chrooted Unbound python module via the `<logging>` chroot log socket.
- Records route to a dedicated `pfblockerng_syslog.log`, are de-duped out of `system.log`, and ride pfSense *Remote Logging → Everything* to a remote server. CSV logging is unchanged (export is additive).

### Phases (6 commits)

1. Pure `key=value` formatters (PHP + Python), unit-tested, dormant
2. `log_syslog` / `_facility` / `_priority` registered via `PfbConfig` (round-trip + rollback pinned) + token→syslog-constant maps
3. Package `<logging>` registration + `pfb_syslog_event()` + toggle-gated IP-leg emit
4. Chroot-aware `SysLogHandler` DNSBL leg — exception-guarded, silent-degrade, zero overhead when off
5. Log Settings UI (enable + facility + severity), saved through the page's section-write path
6. Live-VM smoke (`test_syslog_export.py`, pins each §2.2 invariant ON/OFF + CSV-unchanged) + docs

### Verification

- PHPUnit 1308 / PHPStan / PHPCS (PFBL-01 + gateway + uppercase) / pytest 1953 / ruff / mypy — all green.
- Live-VM CE+Plus smoke fan-out dispatched separately; ADR flips to **Accepted** on green. Status currently *Implemented (pending smoke fan-out)*. The §7 manual SIEM checklist is the out-of-CI maintainer step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJJgguTZVDCa3B9BaweT97)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added opt-in syslog export for pfBlockerNG security events (DNSBL and IP blocks), with selectable facility and severity.
  * Added General UI controls to enable syslog export and configure facility/severity.
* **Documentation**
  * Updated architecture notes for syslog export and event delivery.
* **Bug Fixes**
  * Syslog delivery failures now fail silently, ensuring security event processing continues.
  * Ensures required syslog socket directory is created and owned before restarting syslogd.
* **Tests**
  * Added unit tests and live-VM smoke tests, including verification that pfBlockerNG syslog events don’t appear in `system.log`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->