### PR TITLE
smoke: two-VM topology + DNS-bypass firewall-rule fixes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,13 +1,19 @@
 #!/bin/sh
-# Runs the project's fast linters (and the unit suite) before each commit and
-# blocks the commit on any failure. Mirrors the commands in CLAUDE.md and
+# Runs the project's fast linters / static-analysis gates before each commit and
+# blocks the commit on any failure. Mirrors the lint commands in CLAUDE.md and
 # .github/workflows/test.yml.
 #
-# Each check runs only when its tool is available: a contributor missing a tool
-# is warned and that check is skipped, never blocked (CI is the hard gate).
-# PHPStan is run only when the Composer vendor tree is present (too heavy to
-# require locally). All checks run even after one fails, so every problem is
-# reported in a single pass. Bypass in an emergency with `git commit --no-verify`.
+# Two deliberate scoping rules keep this hook fast:
+#   1. The UNIT SUITES are NOT run here (no `pytest`, no `phpunit`) — too slow for
+#      a per-commit gate. CI (test.yml) is the correctness gate for both suites;
+#      run `python -m pytest` / `vendor/bin/phpunit` yourself while iterating.
+#   2. Each language's gates run ONLY when this commit stages a file of that type
+#      (a PHP-only commit doesn't pay for the markdown/python/shell linters, etc.).
+#
+# Each check also runs only when its tool is available: a contributor missing a
+# tool is warned and that check is skipped, never blocked (CI is the hard gate).
+# All applicable checks run even after one fails, so every problem is reported in
+# a single pass. Bypass in an emergency with `git commit --no-verify`.
 #
 # Enable: git config core.hooksPath .githooks
 
@@ -39,23 +45,51 @@ step() { printf '[pre-commit] %s\n' "$1"; }
 failed() { printf '[pre-commit] FAILED: %s\n' "$1" >&2; fail=1; }
 skip() { skipped="${skipped} $1"; }
 
-# --- Python: ruff lint + format (canonical per CLAUDE.md; also enforced in CI) ---
-ruff_bin=''
-if [ -x .venv/bin/ruff ]; then
-	ruff_bin=.venv/bin/ruff
-elif have ruff; then
-	ruff_bin=ruff
-fi
-if [ -n "$ruff_bin" ]; then
-	step 'ruff check'
-	"$ruff_bin" check . || failed 'ruff check .'
-	step 'ruff format --check'
-	"$ruff_bin" format --check . || failed 'ruff format --check .'
-else
-	skip ruff
+# --- Stage classification: run a language's gates ONLY when this commit stages a
+#     file of that type. (diff-filter ACMR = added/copied/modified/renamed; a pure
+#     deletion stages nothing to lint.) Nothing staged -> nothing to do. ---
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+[ -n "$staged" ] || exit 0
+staged_has() { printf '%s\n' "$staged" | grep -qE "$1"; }
+staged_py=0;  staged_has '\.py$'        && staged_py=1
+staged_md=0;  staged_has '\.md$'        && staged_md=1
+staged_php=0; staged_has '\.(php|inc)$' && staged_php=1
+staged_sh=0;  staged_has '\.sh$'        && staged_sh=1
+
+# =============================== Python (*.py) =============================== #
+if [ "$staged_py" = 1 ]; then
+	# ruff lint + format (canonical per CLAUDE.md; also enforced in CI).
+	ruff_bin=''
+	if [ -x .venv/bin/ruff ]; then
+		ruff_bin=.venv/bin/ruff
+	elif have ruff; then
+		ruff_bin=ruff
+	fi
+	if [ -n "$ruff_bin" ]; then
+		step 'ruff check'
+		"$ruff_bin" check . || failed 'ruff check .'
+		step 'ruff format --check'
+		"$ruff_bin" format --check . || failed 'ruff format --check .'
+	else
+		skip ruff
+	fi
+
+	# mypy: type-check the test suite (config + tests.* strictness in pyproject.toml).
+	mypy_bin=''
+	if [ -x .venv/bin/mypy ]; then
+		mypy_bin=.venv/bin/mypy
+	elif have mypy; then
+		mypy_bin=mypy
+	fi
+	if [ -n "$mypy_bin" ]; then
+		step 'mypy tests/'
+		"$mypy_bin" tests/ || failed 'mypy tests/'
+	else
+		skip mypy
+	fi
 fi
 
-# --- Python: unit suite (fast; the CI correctness gate) ---
+# Python interpreter resolution (used by the URL-encoding check below).
 py_bin=''
 if [ -x .venv/bin/python ]; then
 	py_bin=.venv/bin/python
@@ -64,114 +98,95 @@ elif have python; then
 elif have python3; then
 	py_bin=python3
 fi
-if [ -n "$py_bin" ]; then
-	step 'pytest'
-	"$py_bin" -m pytest -q || failed 'python -m pytest'
-else
-	skip pytest
+
+# =============================== Markdown (*.md) ============================= #
+if [ "$staged_md" = 1 ]; then
+	if have npx; then
+		step 'markdownlint'
+		npx --yes markdownlint-cli2 || failed 'markdownlint-cli2'
+	else
+		skip markdownlint
+	fi
 fi
 
-# --- Python: type-check the test suite (mypy; config + tests.* strictness in
-#     pyproject.toml). Heavy-ish and not always installed locally -> run only when
-#     present (CI is the hard gate). ---
-mypy_bin=''
-if [ -x .venv/bin/mypy ]; then
-	mypy_bin=.venv/bin/mypy
-elif have mypy; then
-	mypy_bin=mypy
-fi
-if [ -n "$mypy_bin" ]; then
-	step 'mypy tests/'
-	"$mypy_bin" tests/ || failed 'mypy tests/'
-else
-	skip mypy
-fi
+# =============================== Shell (*.sh) =============================== #
+if [ "$staged_sh" = 1 ]; then
+	# Forbid bash shebangs. The repo is #!/bin/sh POSIX (the FreeBSD/pfSense target
+	# has no /bin/bash, and macOS /bin/bash is the ancient 3.2). Scans ALL tracked
+	# files, so it also covers tests/ (not lint-globbed below).
+	step 'shebang policy (no #!bash)'
+	git ls-files | while IFS= read -r f; do
+		case $(head -n1 "$f" 2>/dev/null) in
+		'#!'*bash*)
+			printf '[pre-commit] bash shebang not allowed (use #!/bin/sh): %s\n' "$f" >&2
+			exit 1
+			;;
+		esac
+	done || failed 'shebang policy'
 
-# --- Markdown: markdownlint-cli2 (reads .markdownlint*.jsonc) ---
-if have npx; then
-	step 'markdownlint'
-	npx --yes markdownlint-cli2 || failed 'markdownlint-cli2'
-else
-	skip markdownlint
+	# sh -n parse gate (src + scripts + tests; cheap, tool-free).
+	step 'shell (sh -n)'
+	find src scripts tests -name '*.sh' | sort | while IFS= read -r f; do
+		sh -n "$f" || exit 1
+	done || failed 'sh -n'
+
+	# shellcheck (src + scripts only; tests/ shellspec specs trip SC2034
+	# false-positives — tracked as a separate cleanup).
+	if have shellcheck; then
+		step 'shellcheck'
+		find src scripts -name '*.sh' | sort \
+			| xargs shellcheck --severity=info || failed 'shellcheck'
+	else
+		skip shellcheck
+	fi
+
+	# shellspec functional suite (gated on the tool, like shellcheck).
+	if have shellspec; then
+		step 'shellspec'
+		shellspec || failed 'shellspec'
+	else
+		skip shellspec
+	fi
 fi
-
-# --- Shell: forbid bash shebangs. The repo is #!/bin/sh POSIX (the FreeBSD/pfSense
-#     target has no /bin/bash, and macOS /bin/bash is the ancient 3.2). Scans ALL
-#     tracked files, so it also covers tests/ (not lint-globbed below). ---
-step 'shebang policy (no #!bash)'
-git ls-files | while IFS= read -r f; do
-	case $(head -n1 "$f" 2>/dev/null) in
-	'#!'*bash*)
-		printf '[pre-commit] bash shebang not allowed (use #!/bin/sh): %s\n' "$f" >&2
-		exit 1
-		;;
-	esac
-done || failed 'shebang policy'
-
-# --- Shell: sh -n parse gate (src + scripts + tests; cheap, tool-free) ---
-step 'shell (sh -n)'
-find src scripts tests -name '*.sh' | sort | while IFS= read -r f; do
-	sh -n "$f" || exit 1
-done || failed 'sh -n'
 
 # --- Shell + docs: forbid naked $var interpolation into curl/wget/fetch URLs.
-#     Reuses the python found above for pytest (CI is the hard gate when absent).
-#     Scans tracked src shell + Markdown shell fences via the checker's defaults. ---
-if [ -n "$py_bin" ]; then
-	step 'url-encoding (no naked $var in curl URLs)'
-	"$py_bin" scripts/check_url_encoding.py || failed 'url-encoding'
-else
-	skip url-encoding
+#     Relevant to shell scripts AND Markdown shell fences, so it runs when either
+#     is staged. Reuses the python resolved above (CI is the hard gate when absent). ---
+if [ "$staged_sh" = 1 ] || [ "$staged_md" = 1 ]; then
+	if [ -n "$py_bin" ]; then
+		step 'url-encoding (no naked $var in curl URLs)'
+		"$py_bin" scripts/check_url_encoding.py || failed 'url-encoding'
+	else
+		skip url-encoding
+	fi
 fi
 
-# --- Shell: shellcheck (src + scripts only; tests/ shellspec specs trip SC2034
-#     false-positives — tracked as a separate cleanup) ---
-if have shellcheck; then
-	step 'shellcheck'
-	find src scripts -name '*.sh' | sort \
-		| xargs shellcheck --severity=info || failed 'shellcheck'
-else
-	skip shellcheck
-fi
+# =============================== PHP (*.php, *.inc) ========================== #
+if [ "$staged_php" = 1 ]; then
+	# php -l syntax check (output shown only for files that fail).
+	if have php; then
+		step 'php -l'
+		find src \( -name '*.php' -o -name '*.inc' \) | sort | while IFS= read -r f; do
+			out=$(php -l "$f" 2>&1) || { printf '%s\n' "$out" >&2; exit 1; }
+		done || failed 'php -l'
+	else
+		skip php
+	fi
 
-# --- Shell: shellspec functional suite (gated on the tool, like shellcheck) ---
-if have shellspec; then
-	step 'shellspec'
-	shellspec || failed 'shellspec'
-else
-	skip shellspec
-fi
+	# PHPStan (heavy; only when the Composer vendor tree is installed).
+	if [ -x vendor/bin/phpstan ]; then
+		step 'phpstan'
+		vendor/bin/phpstan analyse --no-progress --memory-limit=1G || failed 'phpstan'
+	fi
 
-# --- PHP: php -l syntax check (output shown only for files that fail) ---
-if have php; then
-	step 'php -l'
-	find src \( -name '*.php' -o -name '*.inc' \) | sort | while IFS= read -r f; do
-		out=$(php -l "$f" 2>&1) || { printf '%s\n' "$out" >&2; exit 1; }
-	done || failed 'php -l'
-else
-	skip php
-fi
-
-# --- PHP: PHPStan (heavy; only when the Composer vendor tree is installed) ---
-if [ -x vendor/bin/phpstan ]; then
-	step 'phpstan'
-	vendor/bin/phpstan analyse --no-progress --memory-limit=1G || failed 'phpstan'
-fi
-
-# --- PHP: PHPCS PFBL-01 RequirePfbFilter sniff (only when the vendor tree is installed).
-#     Config auto-discovered from phpcs.xml.dist (the RequirePfbFilter rule over the
-#     in-scope package include). ---
-if [ -x vendor/bin/phpcs ]; then
-	step 'phpcs (PFBL-01)'
-	vendor/bin/phpcs || failed 'phpcs'
-else
-	skip phpcs
-fi
-
-# --- PHP: PHPUnit (only when the Composer vendor tree is installed) ---
-if [ -x vendor/bin/phpunit ]; then
-	step 'phpunit'
-	vendor/bin/phpunit || failed 'phpunit'
+	# PHPCS sniffs (only when the vendor tree is installed). Config auto-discovered
+	# from phpcs.xml.dist.
+	if [ -x vendor/bin/phpcs ]; then
+		step 'phpcs'
+		vendor/bin/phpcs || failed 'phpcs'
+	else
+		skip phpcs
+	fi
 fi
 
 [ -n "$skipped" ] && printf '[pre-commit] skipped (tool not found):%s\n' "$skipped" >&2

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -183,7 +183,7 @@ jobs:
     name: pytest -m smoke (live pfSense VM)
     needs: build-pkg
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -325,6 +325,65 @@ jobs:
           path: image
           key: pfsense-img-${{ steps.digest.outputs.k }}
 
+      # The civm client VM (ADR-04 two-VM topology) — the realistic LAN client the
+      # DNS probes run on. Resolve its digest (cache key), restore-or-pull, and
+      # cache it exactly like the pfSense image. The oras login from the digest
+      # step above persists in-job. SMOKE_CLIENT_IMAGE_NAME/_TAG are repo VARIABLES
+      # (default civm:v1).
+      - name: Resolve civm image ref + digest (cache key)
+        id: civm
+        env:
+          SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
+          CLIENT_NAME: ${{ vars.SMOKE_CLIENT_IMAGE_NAME }}
+          CLIENT_TAG: ${{ vars.SMOKE_CLIENT_IMAGE_TAG }}
+        run: |
+          set -eu
+          REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
+          NAME="${CLIENT_NAME:-civm}"
+          TAG="${CLIENT_TAG:-v1}"
+          REF="${REPO%/}/${NAME}:${TAG}"
+          DIGEST="$(oras resolve "$REF" 2>/dev/null || true)"
+          if [ -z "$DIGEST" ]; then
+            # Fallback for oras builds without `resolve`: read the descriptor.
+            DIGEST="$(oras manifest fetch "$REF" --descriptor | jq -r '.digest')"
+          fi
+          case "$DIGEST" in
+            sha256:*) ;;
+            *) echo "::error::could not resolve a sha256 digest for ${REF} (got '${DIGEST}')"; exit 1 ;;
+          esac
+          {
+            echo "ref=${REF}"
+            echo "digest=${DIGEST}"
+            echo "k=${DIGEST#sha256:}"   # cache-key-safe hex
+          } >> "$GITHUB_OUTPUT"
+          echo "resolved ${REF} -> ${DIGEST}"
+
+      - name: Restore cached civm image
+        id: civmcache
+        uses: actions/cache/restore@v5
+        with:
+          path: client-image
+          key: civm-img-${{ steps.civm.outputs.k }}
+
+      - name: Pull civm image from GHCR (by digest)
+        if: steps.civmcache.outputs.cache-hit != 'true'
+        env:
+          CIVM_REF: ${{ steps.civm.outputs.ref }}
+          DIGEST: ${{ steps.civm.outputs.digest }}
+        run: |
+          set -eu
+          mkdir -p client-image
+          # Pull by digest (content matches the cache key exactly — no tag race).
+          oras pull "${CIVM_REF%@*}@${DIGEST}" --output client-image
+          ls -l client-image
+
+      - name: Save civm image to cache
+        if: steps.civmcache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: client-image
+          key: civm-img-${{ steps.civm.outputs.k }}
+
       - name: Write private SSH key (mode 600)
         env:
           SMOKE_SSH_PRIV_KEY: ${{ secrets.SMOKE_SSH_PRIV_KEY }}
@@ -404,6 +463,9 @@ jobs:
           PLUS_MAC: ${{ secrets.SMOKE_PLUS_MAC }}
           PLUS_UUID: ${{ secrets.SMOKE_PLUS_SMBIOS_UUID }}
           PLUS_NDI: ${{ secrets.SMOKE_PLUS_NDI }}
+          # The civm data-NIC MAC is a secret in BOTH editions (it keys pfSense's
+          # static DHCP lease for the client). Mask + redact it regardless of edition.
+          CLIENT_MAC: ${{ secrets.SMOKE_CLIENT_MAC_ADDRESS }}
         run: |
           set -eu
           # Resolve the EXACT image name (strip ghcr path, @digest, :tag) — a substring
@@ -412,22 +474,35 @@ jobs:
           if [ -n "${IMAGE_REF:-}" ]; then
             REF_NO_DIGEST="${IMAGE_REF%@*}"; IMG_NAME="${REF_NO_DIGEST##*/}"; IMG_NAME="${IMG_NAME%%:*}"
           fi
+          # The civm data MAC is secret in every edition — mask it now and seed the
+          # diagnostics redaction set (REDACT_EXTRA, folded into both branches below).
+          REDACT_EXTRA=""
+          if [ -n "${CLIENT_MAC:-}" ]; then
+            printf '::add-mask::%s\n' "$CLIENT_MAC"
+            REDACT_EXTRA="$CLIENT_MAC"
+          fi
           case "$IMG_NAME" in
             pfsense-ce)
-              # CE: the public pin. No identity is secret -> nothing to redact.
-              echo "RESOLVED_VM_MAC=${INPUT_MAC:-BC:24:11:37:9C:AC}" >> "$GITHUB_ENV"
+              # CE identity is don't-care: empty MAC -> QEMU assigns each NIC a
+              # default. Only the (secret) civm MAC needs redacting.
+              echo "RESOLVED_VM_MAC=" >> "$GITHUB_ENV"
               echo "RESOLVED_VM_SMBIOS_UUID=58fd7964-c40c-4f47-bf02-3fdad18f8b00" >> "$GITHUB_ENV"
-              echo "RESOLVED_REDACT=" >> "$GITHUB_ENV" ;;
-            *)  # non-CE (Plus): license/NDI-keyed identity comes from secrets, never the matrix
+              { printf 'RESOLVED_REDACT<<__EOF__\n'; [ -n "$REDACT_EXTRA" ] && printf '%s\n' "$REDACT_EXTRA"; printf '__EOF__\n'; } >> "$GITHUB_ENV" ;;
+            *)  # non-CE (Plus): license/NDI-keyed identity comes from secrets, never the matrix.
+                # SMOKE_PLUS_MAC is the NEWLINE-separated 8-MAC list (one per NIC, in order).
               if [ -z "${PLUS_MAC:-}" ] || [ -z "${PLUS_UUID:-}" ]; then
                 echo "::error::non-CE image '$IMG_NAME' requires the SMOKE_PLUS_MAC and SMOKE_PLUS_SMBIOS_UUID secrets (the Plus source-VM identity); one or both are empty."; exit 1
               fi
-              # Mask before anything echoes them; NDI optional.
-              printf '::add-mask::%s\n' "$PLUS_MAC" "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '::add-mask::%s\n' "$PLUS_NDI" || true
-              echo "RESOLVED_VM_MAC=$PLUS_MAC" >> "$GITHUB_ENV"
+              # Mask each MAC line individually — a multiline mask value would not
+              # match a single MAC in the logs. NDI optional.
+              printf '%s\n' "$PLUS_MAC" | while IFS= read -r _m; do [ -n "$_m" ] && printf '::add-mask::%s\n' "$_m"; done
+              printf '::add-mask::%s\n' "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '::add-mask::%s\n' "$PLUS_NDI" || true
+              # RESOLVED_VM_MAC carries the full newline-separated list (heredoc env);
+              # boot_vm.sh splits it per NIC.
+              { printf 'RESOLVED_VM_MAC<<__MAC_EOF__\n%s\n__MAC_EOF__\n' "$PLUS_MAC"; } >> "$GITHUB_ENV"
               echo "RESOLVED_VM_SMBIOS_UUID=$PLUS_UUID" >> "$GITHUB_ENV"
-              # newline-joined redaction set for the diagnostics scrub (MAC + uuid [+ NDI])
-              { printf 'RESOLVED_REDACT<<__EOF__\n%s\n%s\n' "$PLUS_MAC" "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '%s\n' "$PLUS_NDI"; printf '__EOF__\n'; } >> "$GITHUB_ENV" ;;
+              # newline-joined redaction set for the scrub (MACs + uuid [+ NDI] [+ civm MAC])
+              { printf 'RESOLVED_REDACT<<__EOF__\n%s\n%s\n' "$PLUS_MAC" "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '%s\n' "$PLUS_NDI"; [ -n "$REDACT_EXTRA" ] && printf '%s\n' "$REDACT_EXTRA"; printf '__EOF__\n'; } >> "$GITHUB_ENV" ;;
           esac
 
       # HERMETICITY (ADR §2/§4): the egress block is done INSIDE pytest, by the
@@ -460,6 +535,11 @@ jobs:
           SMOKE_VM_MAC: ${{ env.RESOLVED_VM_MAC }}
           SMOKE_VM_SMBIOS_UUID: ${{ env.RESOLVED_VM_SMBIOS_UUID }}
           SMOKE_REDACT_VALUES: ${{ env.RESOLVED_REDACT }}
+          # civm client VM (ADR-04): the pre-pulled image dir + its data-NIC MAC
+          # (the static-lease key). conftest's client_vm fixture boots it after
+          # pfSense and auto-allocates the shared LAN socket port.
+          SMOKE_CLIENT_IMAGE_DIR: ${{ github.workspace }}/client-image
+          SMOKE_CLIENT_MAC_ADDRESS: ${{ secrets.SMOKE_CLIENT_MAC_ADDRESS }}
           SMOKE_SSH_KEY: smoke_key
           SMOKE_PKG: ${{ steps.paths.outputs.pkg }}
           # Matrix-derived build target (ADR-24): the per-leg ABI / PHP / Python flavor

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -367,19 +367,24 @@ jobs:
           fi
           case "$IMG_NAME" in
             pfsense-ce)
-              # CE: the public pin. No identity is secret -> nothing to redact.
-              echo "RESOLVED_VM_MAC=BC:24:11:37:9C:AC" >> "$GITHUB_ENV"
+              # CE identity is don't-care: empty MAC -> QEMU assigns each NIC a default.
+              echo "RESOLVED_VM_MAC=" >> "$GITHUB_ENV"
               echo "RESOLVED_VM_SMBIOS_UUID=58fd7964-c40c-4f47-bf02-3fdad18f8b00" >> "$GITHUB_ENV"
               echo "RESOLVED_REDACT=" >> "$GITHUB_ENV" ;;
-            *)  # non-CE (Plus): license/NDI-keyed identity comes from secrets, never the matrix
+            *)  # non-CE (Plus): license/NDI-keyed identity comes from secrets, never the matrix.
+                # SMOKE_PLUS_MAC is the NEWLINE-separated 8-MAC list (one per NIC, in order).
               if [ -z "${PLUS_MAC:-}" ] || [ -z "${PLUS_UUID:-}" ]; then
                 echo "::error::non-CE image '$IMG_NAME' requires the SMOKE_PLUS_MAC and SMOKE_PLUS_SMBIOS_UUID secrets (the Plus source-VM identity); one or both are empty."; exit 1
               fi
-              # Mask before anything echoes them; NDI optional.
-              printf '::add-mask::%s\n' "$PLUS_MAC" "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '::add-mask::%s\n' "$PLUS_NDI" || true
-              echo "RESOLVED_VM_MAC=$PLUS_MAC" >> "$GITHUB_ENV"
+              # Mask each MAC line individually — a multiline mask value would not
+              # match a single MAC in the logs/screenshots. NDI optional.
+              printf '%s\n' "$PLUS_MAC" | while IFS= read -r _m; do [ -n "$_m" ] && printf '::add-mask::%s\n' "$_m"; done
+              printf '::add-mask::%s\n' "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '::add-mask::%s\n' "$PLUS_NDI" || true
+              # RESOLVED_VM_MAC carries the full newline-separated list (heredoc env);
+              # boot_vm.sh splits it per NIC.
+              { printf 'RESOLVED_VM_MAC<<__MAC_EOF__\n%s\n__MAC_EOF__\n' "$PLUS_MAC"; } >> "$GITHUB_ENV"
               echo "RESOLVED_VM_SMBIOS_UUID=$PLUS_UUID" >> "$GITHUB_ENV"
-              # newline-joined redaction set for the diagnostics scrub (MAC + uuid [+ NDI])
+              # newline-joined redaction set for the diagnostics scrub (MACs + uuid [+ NDI])
               { printf 'RESOLVED_REDACT<<__EOF__\n%s\n%s\n' "$PLUS_MAC" "$PLUS_UUID"; [ -n "${PLUS_NDI:-}" ] && printf '%s\n' "$PLUS_NDI"; printf '__EOF__\n'; } >> "$GITHUB_ENV" ;;
           esac
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -601,12 +601,15 @@ Activate once after cloning: `sh scripts/setup-hooks.sh` (sets `core.hooksPath` 
 Actions workflow that commits code must run it after checkout, before commit/push** — so
 automated commits hit the same checks (subject to the runner's installed tools).
 
-- **`.githooks/pre-commit`** runs the fast linters + unit suites, blocking on failure:
-  `ruff check`/`ruff format --check`, `python -m pytest`, `mypy tests/` (the suite is fully
-  typed — `tests.*` is `disallow_untyped_defs`; `tests/smoke` excluded), `markdownlint-cli2`,
-  `sh -n` + `shellcheck`, `php -l`. Each runs only when its tool is installed (missing =
-  reported + skipped; CI is the hard gate); PHPStan/PHPCS/PHPUnit run only when `vendor/bin/`
-  has them. Emergency bypass: `git commit --no-verify`.
+- **`.githooks/pre-commit`** runs the fast **linters / static-analysis gates** — **not** the
+  unit suites (no `pytest`, no `phpunit`: too slow for a commit gate; CI is their correctness
+  gate). It is **path-scoped to the staged file types** so a commit only pays for the languages
+  it touches: **`*.py`** → `ruff check`/`ruff format --check` + `mypy tests/`; **`*.md`** →
+  `markdownlint-cli2`; **`*.sh`** → the no-`#!bash` shebang gate + `sh -n` + `shellcheck` +
+  `shellspec`; **`*.php`/`*.inc`** → `php -l` + PHPStan + PHPCS; the URL-encoding check runs when
+  `*.sh` or `*.md` is staged. Each check still runs only when its tool is installed (missing =
+  reported + skipped; CI is the hard gate); PHPStan/PHPCS run only when `vendor/bin/` has them.
+  Emergency bypass: `git commit --no-verify`.
 - **`.githooks/prepare-commit-msg`** appends a `Co-authored-by:` trailer for the human owner so
   GitHub credits them even when an agent is the committer (see *Commit style → Author, committer,
   and signing*). It resolves the owner generically — `coauthor.email`/`coauthor.name` git config,
@@ -626,8 +629,9 @@ python -m pytest
 ```
 
 From repo root (`pyproject.toml` sets `testpaths` + `-v`; no `cd` needed). Run after **any**
-change to `src/usr/local/pkg/pfblockerng/pfb_unbound.py` or `tests/`. The pre-commit hook
-re-runs it and CI is final, so no separate manual pre-commit run is needed.
+change to `src/usr/local/pkg/pfblockerng/pfb_unbound.py` or `tests/`. The pre-commit hook does
+**not** run the unit suite (linters only — too slow for a commit gate), so run `python -m pytest`
+yourself while iterating; CI is the hard correctness gate.
 
 PHP — the fast PHPUnit suite for the pure/extractable helpers of `pfblockerng.inc` (issue #39):
 

--- a/scripts/image-publish.sh
+++ b/scripts/image-publish.sh
@@ -20,6 +20,12 @@
 #   ./scripts/image-publish.sh 2.8.1 --proxmox root@pve.lan
 #   ./scripts/image-publish.sh 2.8.1 --proxmox pve.lan --proxmox-port 2222 --vmid 103
 #   ./scripts/image-publish.sh 2.8.1            # run locally, on the Proxmox host
+#   # a non-pfSense image (e.g. the smoke client VM):
+#   ./scripts/image-publish.sh v1 --vmid 104 --image ghcr.io/pfblockerng/civm \
+#       --artifact-type application/vnd.pfblockerng.smoke-client.disk.v1 \
+#       --description "pfBlockerNG smoke client VM v1"
+#   # just print the VM's NIC MACs + SMBIOS UUID (no export/push):
+#   ./scripts/image-publish.sh --vmid 104 --print-identity
 #
 # Proxmox connection (where the disk lives):
 #   --proxmox [USER@]HOST   SSH target of the Proxmox host. If omitted (and
@@ -40,6 +46,10 @@
 #   --out FILE       local working qcow2 path (default: a temp file, removed after)
 #   --keep           keep the local qcow2 after publishing
 #   --force          overwrite the tag if it already exists
+#   --artifact-type T  OCI artifact-type annotation (default: the pfSense CE type)
+#   --description D    OCI image-description annotation (default: pfSense CE wording)
+#   --print-identity   print every NIC's MAC + the SMBIOS UUID from the VM config,
+#                      then exit (no export/push). <version> is not required.
 #
 # Auth: be logged in to GHCR (`oras login ghcr.io -u USER -p TOKEN`), or export
 # SMOKE_GHCR_USER + SMOKE_GHCR_TOKEN to have this script log in for you. The
@@ -62,6 +72,11 @@ OUT=""
 KEEP=0
 FORCE=0
 VERSION=""
+PRINT_IDENTITY=0
+# Default OCI annotations describe the pfSense CE base image. Shared with
+# image-upgrade.sh + IMAGE_RUNBOOK.md — keep this default in sync there.
+ARTIFACT_TYPE="application/vnd.netgate.pfsense-ce.disk.v1"
+DESCRIPTION=""
 
 # Proxmox SSH coordinates (env fallbacks; --proxmox overrides).
 PX_HOST="${PROXMOX_SSH_HOST:-}"
@@ -83,7 +98,10 @@ while [ $# -gt 0 ]; do
         --out)             OUT="$2"; shift 2 ;;
         --keep)            KEEP=1; shift ;;
         --force)           FORCE=1; shift ;;
-        -h|--help)         sed -n '2,45p' "$0"; exit 0 ;;
+        --artifact-type)   ARTIFACT_TYPE="$2"; shift 2 ;;
+        --description)     DESCRIPTION="$2"; shift 2 ;;
+        --print-identity)  PRINT_IDENTITY=1; shift ;;
+        -h|--help)         sed -n '2,56p' "$0"; exit 0 ;;
         -*)                die "unknown option: $1" ;;
         *)
             [ -z "$VERSION" ] || die "unexpected argument: $1"
@@ -99,7 +117,8 @@ if [ -n "${PX_TARGET:-}" ]; then
     esac
 fi
 
-[ -n "$VERSION" ] || die "missing <pfsense-ce-version> (e.g. 2.8.1)"
+# --print-identity needs only a VM id; a version tag is required for a real publish.
+[ "$PRINT_IDENTITY" -eq 1 ] || [ -n "$VERSION" ] || die "missing <pfsense-ce-version> (e.g. 2.8.1); or use --print-identity"
 case "$COMPRESSION" in zstd|zlib|off) ;; *) die "--compression must be zstd|zlib|off" ;; esac
 
 # Remote when a Proxmox host is given, else everything runs locally.
@@ -122,8 +141,22 @@ px() {
     fi
 }
 
-# Local tooling: oras always; ssh only when driving a remote host.
-command -v oras >/dev/null 2>&1 || die "required local tool not found: oras"
+# print_vm_identity QMCFG — print every NIC's MAC + the SMBIOS UUID from a
+# `qm config <vmid>` dump. These feed the fixed-MAC-series + SMBIOS-UUID secrets
+# that keep the Netgate Device ID (Plus licensing) constant across re-publishes.
+print_vm_identity() {
+    log "VM $VMID identity (capture for your MAC-series + SMBIOS UUID secrets):"
+    printf '%s\n' "$1" | grep -E '^net[0-9]+:' | sort -V | while IFS= read -r line; do
+        ifc=${line%%:*}
+        mac=$(printf '%s\n' "$line" | grep -oE '([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}' | head -1)
+        printf '    %s  MAC %s\n' "$ifc" "$mac"
+    done
+    uuid=$(printf '%s\n' "$1" | sed -n 's/^smbios1:.*uuid=\([0-9A-Fa-f-]*\).*/\1/p' | head -1)
+    printf '    SMBIOS UUID: %s\n' "${uuid:-<not set in VM config>}"
+}
+
+# Local tooling: oras for a real publish; ssh only when driving a remote host.
+[ "$PRINT_IDENTITY" -eq 1 ] || command -v oras >/dev/null 2>&1 || die "required local tool not found: oras"
 if [ "$PX_REMOTE" -eq 1 ]; then
     command -v ssh >/dev/null 2>&1 || die "required local tool not found: ssh"
     log "Proxmox host: ${PX_USER}@${PX_HOST}${PX_PORT:+:$PX_PORT} (native steps run there over SSH)"
@@ -131,10 +164,23 @@ else
     log "running locally (assuming this IS the Proxmox host)"
 fi
 
-# Proxmox-side tooling (all native to Proxmox VE — nothing to install).
-for bin in qm pvesm qemu-img; do
-    px "command -v $bin >/dev/null 2>&1" || die "tool not found on Proxmox host: $bin"
-done
+# Proxmox-side tooling (all native to Proxmox VE — nothing to install). A real
+# publish needs the full export chain; --print-identity only reads `qm config`.
+if [ "$PRINT_IDENTITY" -eq 1 ]; then
+    px "command -v qm >/dev/null 2>&1" || die "tool not found on Proxmox host: qm"
+else
+    for bin in qm pvesm qemu-img; do
+        px "command -v $bin >/dev/null 2>&1" || die "tool not found on Proxmox host: $bin"
+    done
+fi
+
+# Read the VM config once — both --print-identity and the VOLID resolve use it.
+QMCFG=$(px "qm config $VMID") || die "could not read 'qm config $VMID'"
+
+if [ "$PRINT_IDENTITY" -eq 1 ]; then
+    print_vm_identity "$QMCFG"
+    exit 0
+fi
 
 # Optional non-interactive GHCR login (local oras).
 if [ -n "${SMOKE_GHCR_TOKEN:-}" ] && [ -n "${SMOKE_GHCR_USER:-}" ]; then
@@ -153,12 +199,16 @@ if ! px "qm status $VMID 2>/dev/null" | grep -q 'status: stopped'; then
 fi
 
 # Resolve the disk's backing device (e.g. /dev/zvol/rpool/data/vm-103-disk-1).
-VOLID=$(px "qm config $VMID" | sed -n "s/^${DISK}: \\([^,]*\\).*/\\1/p")
+VOLID=$(printf '%s\n' "$QMCFG" | sed -n "s/^${DISK}: \\([^,]*\\).*/\\1/p")
 [ -n "$VOLID" ] || die "disk '$DISK' not found in VM $VMID config"
 DEV=$(px "pvesm path '$VOLID'")
 [ -n "$DEV" ] || die "could not resolve a device for $VOLID"
 px "test -e '$DEV'" || die "resolved device does not exist on Proxmox: $DEV"
 log "source: VM $VMID $DISK -> $VOLID -> $DEV"
+
+# Informational: surface the NIC MACs + SMBIOS UUID so a re-publish can confirm
+# the VM identity (Netgate Device ID inputs) is unchanged.
+print_vm_identity "$QMCFG"
 
 # Local output path for the streamed-back qcow2.
 CREATED_OUT=0
@@ -198,15 +248,18 @@ px "cat '$REMOTE_TMP'" > "$OUT"
 [ -s "$OUT" ] || die "streamed image is empty: $OUT"
 log "local image: $(qemu-img info --output=human "$OUT" 2>/dev/null | sed -n 's/^disk size: /qcow2 size /p' || echo "$(wc -c < "$OUT") bytes")"
 
+# Default the description to the pfSense CE wording unless overridden.
+[ -n "$DESCRIPTION" ] || DESCRIPTION="pfSense CE ${VERSION} pfBlockerNG smoke-test base"
+
 log "pushing ${IMAGE}:${VERSION}"
 # cd so the stored layer title is the bare filename (predictable on pull).
 (
     cd "$(dirname "$OUT")"
     oras push \
-        --artifact-type application/vnd.netgate.pfsense-ce.disk.v1 \
+        --artifact-type "$ARTIFACT_TYPE" \
         --annotation "org.opencontainers.image.title=$(basename "$OUT")" \
         --annotation "org.opencontainers.image.version=${VERSION}" \
-        --annotation "org.opencontainers.image.description=pfSense CE ${VERSION} pfBlockerNG smoke-test base" \
+        --annotation "org.opencontainers.image.description=${DESCRIPTION}" \
         "${IMAGE}:${VERSION}" \
         "$(basename "$OUT"):application/vnd.qemu.qcow2"
 )

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -44,7 +44,12 @@
 #   --ssh-key PATH   GUEST SSH private key (default: $SMOKE_SSH_KEY) — its public
 #                    half is baked into the image's root authorized_keys
 #   --ssh-port N     Proxmox-local port forwarded to the guest's :22 (default: 2222)
-#   --mac ADDR       guest NIC MAC (default: BC:24:11:37:9C:AC — must match the image)
+#   --mac ADDR       guest NIC MAC (default: $SMOKE_VM_MAC or BC:24:11:37:9C:AC —
+#                    must match the image; mirror of boot_vm.sh's SMOKE_VM_MAC)
+#   --smbios-uuid U  SMBIOS type-1 uuid (default: $SMOKE_VM_SMBIOS_UUID or the CE
+#                    pin — must match the image; mirror of boot_vm.sh). The
+#                    Netgate Device ID (Plus) derives from MAC + this uuid, so a
+#                    Plus image MUST set both --mac and --smbios-uuid to its own.
 #   --compression T  qcow2 compression for the published image: zstd|zlib|off (default: zstd)
 #   --upgrade-timeout S  MAX seconds to wait for the pfSense-upgrade+reboot
 #                    (default: 1200). The poll exits the instant /etc/version
@@ -75,7 +80,11 @@ IMAGE="${SMOKE_IMAGE_REPO:-ghcr.io/pfblockerng}"
 IMAGE="${IMAGE%/}/${SMOKE_IMAGE_NAME:-pfsense-ce}"
 GUEST_KEY="${SMOKE_SSH_KEY:-}"
 GUEST_PORT=2222
-MAC="BC:24:11:37:9C:AC"
+# Source-VM hardware identity — MUST match the image (mirror of boot_vm.sh's
+# SMOKE_VM_MAC / SMOKE_VM_SMBIOS_UUID). The Netgate Device ID (Plus) derives from
+# MAC + SMBIOS uuid, so a Plus image MUST override both; CE pins by default.
+MAC="${SMOKE_VM_MAC:-BC:24:11:37:9C:AC}"
+SMBIOS_UUID="${SMOKE_VM_SMBIOS_UUID:-58fd7964-c40c-4f47-bf02-3fdad18f8b00}"
 COMPRESSION=zstd
 UPGRADE_TIMEOUT=1200
 UPGRADE_PKGS=0
@@ -111,12 +120,13 @@ while [ $# -gt 0 ]; do
         --ssh-key)         GUEST_KEY="$2"; shift 2 ;;
         --ssh-port)        GUEST_PORT="$2"; shift 2 ;;
         --mac)             MAC="$2"; shift 2 ;;
+        --smbios-uuid)     SMBIOS_UUID="$2"; shift 2 ;;
         --compression)     COMPRESSION="$2"; shift 2 ;;
         --upgrade-timeout) UPGRADE_TIMEOUT="$2"; shift 2 ;;
         --upgrade-pkgs)    UPGRADE_PKGS=1; shift ;;
         --keep)            KEEP=1; shift ;;
         --force)           FORCE=1; shift ;;
-        -h|--help)         sed -n '2,62p' "$0"; exit 0 ;;
+        -h|--help)         sed -n '2,67p' "$0"; exit 0 ;;
         *)                 die "unknown option: $1" ;;
     esac
 done
@@ -232,15 +242,42 @@ px "cat > '$REMOTE_DIR/work.qcow2'" < "$BASE"
 px "test -s '$REMOTE_DIR/work.qcow2'" || die "streamed image is empty on the KVM host"
 
 # --- boot under QEMU on the KVM host (internet ON for the upgrade) ----------
-log "booting VM on the KVM host (guest :22 -> 127.0.0.1:$GUEST_PORT there)"
+# Mirror the smoke 8-NIC topology (tests/smoke/boot_vm.sh) so the image boots
+# without pfSense re-detecting hardware and dropping to the interface-reassignment
+# console prompt. Only the first three are assigned in the image:
+#   net0 WAN  — SLIRP 10.10.0.0/24, NATs to the internet (the upgrade download).
+#   net1 MGMT — SLIRP 10.0.0.0/16; the ssh host-forward targets the static
+#               management IP 10.0.0.20 (the upgrade's control path). WAN uses
+#               10.10.0.0/24 so it overlaps neither mgmt 10.0/16 nor the DNSBL
+#               sinkhole VIP 10.10.10.1 (matches tests/smoke/boot_vm.sh).
+#   net2 LAN  — present but isolated (no civm peer during an upgrade).
+#   net3..7   — unassigned; present only so the 8-NIC image sees no change.
+# CE identity is don't-care, so only net0 carries the (cosmetic) --mac value;
+# the rest take QEMU defaults.
+log "booting VM on the KVM host (guest mgmt :22 -> 127.0.0.1:$GUEST_PORT there)"
 QEMU_CMD="$QEMU_BIN \
     -enable-kvm -machine pc -cpu host \
     -smp 2,sockets=1,cores=2 -m 4096 \
+    -smbios type=1,uuid=$SMBIOS_UUID \
     -device virtio-scsi-pci,id=virtioscsi0 \
     -drive file=$REMOTE_DIR/work.qcow2,if=none,id=drive-scsi0,format=qcow2,discard=unmap,detect-zeroes=unmap \
     -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
-    -netdev user,id=net0,hostfwd=tcp:127.0.0.1:$GUEST_PORT-:22 \
-    -device virtio-net-pci,mac=$MAC,netdev=net0,id=net0 \
+    -netdev user,id=net0,net=10.10.0.0/24,host=10.10.0.2 \
+    -device virtio-net-pci,mac=$MAC,netdev=net0,id=nic0 \
+    -netdev user,id=net1,net=10.0.0.0/16,host=10.0.0.2,hostfwd=tcp:127.0.0.1:$GUEST_PORT-10.0.0.20:22 \
+    -device virtio-net-pci,netdev=net1,id=nic1 \
+    -netdev user,id=net2,net=10.20.0.0/24,restrict=on \
+    -device virtio-net-pci,netdev=net2,id=nic2 \
+    -netdev user,id=net3,net=10.30.0.0/24,restrict=on \
+    -device virtio-net-pci,netdev=net3,id=nic3 \
+    -netdev user,id=net4,net=10.40.0.0/24,restrict=on \
+    -device virtio-net-pci,netdev=net4,id=nic4 \
+    -netdev user,id=net5,net=10.50.0.0/24,restrict=on \
+    -device virtio-net-pci,netdev=net5,id=nic5 \
+    -netdev user,id=net6,net=10.60.0.0/24,restrict=on \
+    -device virtio-net-pci,netdev=net6,id=nic6 \
+    -netdev user,id=net7,net=10.70.0.0/24,restrict=on \
+    -device virtio-net-pci,netdev=net7,id=nic7 \
     -display none -serial file:$REMOTE_DIR/console.log \
     -pidfile $REMOTE_DIR/qemu.pid -daemonize"
 px "$QEMU_CMD"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12577,6 +12577,10 @@ function sync_package_pfblockerng($cron='') {
 	if ($mode === 'disabled') {
 		pfb_fwobj_init_registrations();
 		if (pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule'])) {
+			// Removed owned nat/rule + filter/rule rows — flag a pf reload so the
+			// live ruleset drops them too (the disabled mode does not always reach
+			// the auto-rule region that would otherwise set this flag).
+			$pfb['filter_configure'] = TRUE;
 			write_config('pfBlockerNG: sweep orphan firewall objects on disable');
 		}
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12564,6 +12564,23 @@ function sync_package_pfblockerng($cron='') {
 	// Modify DNSBL NAT and VIP and lighttpd web server conf, as required.
 	pfb_create_dnsbl($mode);
 
+	// [ ADR-35 P4 ] Defensive sweep on disable: after pfb_manage_dnsbl_vip + pfb_create_dnsbl
+	// have removed VIP and NAT, ensure no owned objects remain (catches half-written state where
+	// the reference was cleared but the VIP/NAT entry survived). Sweep is marker-only and
+	// idempotent: returns FALSE (no write) when everything was already cleaned.
+	//
+	// MUST run BEFORE the ADR-36/37 syncs below: pfb_fwobj_sweep() removes EVERY pfB_-owned row
+	// (pfb_fwobj_is_owned matches the shared 'pfB_' prefix), which includes the pfB_DNS_Redirect_*
+	// and pfB_DoT_Block_* rules. Those features are independent of DNSBL mode (they can be enabled
+	// while DNSBL is disabled), so the sweep would otherwise clobber rules the syncs just created.
+	// Running the sweep first lets each feature's sync re-assert its own objects last.
+	if ($mode === 'disabled') {
+		pfb_fwobj_init_registrations();
+		if (pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule'])) {
+			write_config('pfBlockerNG: sweep orphan firewall objects on disable');
+		}
+	}
+
 	// [ ADR-36 ] Sync DNS-redirect NAT + filter rules (create / reconcile / prune / remove).
 	// Reads dnsbl_redir (toggle) via PfbConfig; manages nat/rule + filter/rule directly
 	// (pfSense-core foreign sections). No write_config() here — a single flush below covers both.
@@ -12572,6 +12589,10 @@ function sync_package_pfblockerng($cron='') {
 		pfb_fwobj_init_dns_redirect_registrations();
 		if (pfb_sync_dns_redirect_rules()) {
 			write_config('pfBlockerNG: saving DNS-redirect rule changes');
+			// The rdr/filter rows changed in config — flag a pf reload so
+			// filter_configure() (below) actually loads them into the ruleset;
+			// the legacy auto-rule diff does not see these foreign-section edits.
+			$pfb['filter_configure'] = TRUE;
 		}
 	}
 
@@ -12583,17 +12604,8 @@ function sync_package_pfblockerng($cron='') {
 		pfb_fwobj_init_dot_block_registrations();
 		if (pfb_sync_dot_block_rules()) {
 			write_config('pfBlockerNG: saving DoT/DoQ block rule changes');
-		}
-	}
-
-	// [ ADR-35 P4 ] Defensive sweep on disable: after pfb_manage_dnsbl_vip + pfb_create_dnsbl
-	// have removed VIP and NAT, ensure no owned objects remain (catches half-written state where
-	// the reference was cleared but the VIP/NAT entry survived). Sweep is marker-only and
-	// idempotent: returns FALSE (no write) when everything was already cleaned.
-	if ($mode === 'disabled') {
-		pfb_fwobj_init_registrations();
-		if (pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule'])) {
-			write_config('pfBlockerNG: sweep orphan firewall objects on disable');
+			// As above — the block rule changed; force a pf reload so it loads.
+			$pfb['filter_configure'] = TRUE;
 		}
 	}
 
@@ -13802,8 +13814,19 @@ function sync_package_pfblockerng($cron='') {
 			if (!empty($rules)) {
 				foreach ($rules as $rule) {
 
+					// The ADR-36/37 DNS-bypass filter rules (DNS redirect + DoT/DoQ block)
+					// carry a 'pfB_' descr but are owned by pfb_sync_dns_redirect_rules() /
+					// pfb_sync_dot_block_rules(), NOT this legacy auto-rule rebuild. Preserve
+					// them like user rules so the rebuild below does not strip them.
+					$descr = $rule['descr'] ?? '';
+					$is_dns_bypass_rule =
+					    (defined('PFB_DNS_REDIR_DESCR_V4_PFX') && str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX)) ||
+					    (defined('PFB_DOT_BLOCK_DESCR_PFX') && str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX));
+
 					// Remove all existing rules that start with 'pfB_' in the Rule Description
-					if (substr($rule['descr'], 0, 4) != 'pfB_') {
+					// (the legacy auto-rules this region rebuilds) — but keep user rules and
+					// the DNS-bypass rules above.
+					if (substr($rule['descr'], 0, 4) != 'pfB_' || $is_dns_bypass_rule) {
 
 						// Upgrade previous IPv4 pfBlockerNG 'alias type' aliasnames to new '_v4' suffix format
 						foreach (array('source', 'destination') as $rtype) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_dns_bypass.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_dns_bypass.inc
@@ -44,6 +44,46 @@ define('PFB_DNS_REDIR_DESCR_V4_SFX', '_v4');
 define('PFB_DNS_REDIR_DESCR_V6_SFX', '_v6');
 
 // ---------------------------------------------------------------------------
+// pfb_dns_bypass_stamp_rule — add the pfSense rule metadata a hand-built
+// nat/rule or filter/rule row needs to be EMITTED by filter_configure().
+// ---------------------------------------------------------------------------
+
+/**
+ * Stamp a rule with a unique 'tracker' plus 'created'/'updated' provenance.
+ *
+ * pfSense's rule generator (filter_generate_user_rule_arr) keys every rule on
+ * its 'tracker' (the ridentifier / "id:" label); a row written to
+ * config.xml WITHOUT one is silently dropped from /tmp/rules.debug and never
+ * reaches pf. pfBlockerNG's own auto-rules already stamp a tracker (pfb_tracker)
+ * + created — the ADR-36/37 DNS-bypass rows must do the same to load.
+ *
+ * Uniqueness uses pfSense's canonical filter_get_next_tracker() when present
+ * (on-box); off-appliance it falls back to a monotonic microtime-based id so
+ * the same builder/sync paths work under PHPUnit without a stub.
+ *
+ * @param  array<string,mixed> $rule
+ * @return array<string,mixed>
+ */
+function pfb_dns_bypass_stamp_rule(array $rule): array
+{
+	if (function_exists('filter_get_next_tracker')) {
+		$tracker = (int) filter_get_next_tracker();
+	} else {
+		// Off-box fallback: monotonic, unique within a pass (microtime collides
+		// for rows built back-to-back, so add a per-call sequence).
+		static $seq = 0;
+		$tracker = (int) (microtime(TRUE) * 1000) + ($seq++);
+	}
+
+	$rule['tracker'] = $tracker;
+	$stamp = ['time' => (int) microtime(TRUE), 'username' => 'pfBlockerNG'];
+	$rule['created'] = $stamp;
+	$rule['updated'] = $stamp;
+
+	return $rule;
+}
+
+// ---------------------------------------------------------------------------
 // pfb_build_dns_redirect_rules — per-interface, per-family rule-set builder
 // ---------------------------------------------------------------------------
 
@@ -433,8 +473,11 @@ function pfb_sync_dns_redirect_rules(): bool
 				continue;
 			}
 
-			// Build the rule pair.
+			// Build the rule pair, then stamp each with the tracker + provenance
+			// pfSense needs to actually emit it into the ruleset.
 			[$nat_rule, $filter_rule] = pfb_build_dns_redirect_rules($iface, $family, $exception);
+			$nat_rule    = pfb_dns_bypass_stamp_rule($nat_rule);
+			$filter_rule = pfb_dns_bypass_stamp_rule($filter_rule);
 
 			if (!$nat_exists) {
 				$nat_rows   = config_get_path('nat/rule', []);
@@ -698,8 +741,9 @@ function pfb_sync_dot_block_rules(): bool
 			continue;
 		}
 
-		// Build the rule and append.
-		$filter_rule    = pfb_build_dot_block_rule($iface, $exclude_alias);
+		// Build the rule, stamp it with the tracker + provenance pfSense needs to
+		// emit it, then append.
+		$filter_rule    = pfb_dns_bypass_stamp_rule(pfb_build_dot_block_rule($iface, $exclude_alias));
 		$filter_rows    = config_get_path('filter/rule', []);
 		$filter_rows[]  = $filter_rule;
 		config_set_path('filter/rule', $filter_rows);

--- a/tests/php/DnsRedirectLifecycleTest.php
+++ b/tests/php/DnsRedirectLifecycleTest.php
@@ -536,4 +536,134 @@ final class DnsRedirectLifecycleTest extends TestCase
 		$this->assertSame(0, $this->countRedirNatRules(), 'after: still no redirect NAT rules');
 		$this->assertSame(0, $this->countRedirFilterRules(), 'after: still no redirect filter rules');
 	}
+
+	// -----------------------------------------------------------------------
+	// Regression: the DNSBL "disable" sweep must run BEFORE the redirect sync.
+	//
+	// pfb_fwobj_sweep() removes EVERY pfB_-owned row (pfb_fwobj_is_owned matches
+	// the shared 'pfB_' prefix), so it also matches pfB_DNS_Redirect_* rows. The
+	// DNS-redirect feature is independent of DNSBL mode (it can be ON while DNSBL
+	// is disabled — mode 'disabled'), so when sync_package_pfblockerng() runs its
+	// defensive disable-sweep it MUST do so before this sync re-asserts its rules;
+	// otherwise the sweep wipes the freshly-created redirect rules. The two tests
+	// pin the contract from both directions.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario: the hazard — a broad disable-sweep AFTER the sync wipes redirect rules.
+	 *   Background: redirect enabled on 'lan', DNSBL disabled (only redirect rows exist).
+	 *     Given the redirect sync has created its 2 NAT + 2 filter rules.
+	 *     When the broad pfB_ disable-sweep runs afterwards.
+	 *     Then the redirect rules are gone — the ordering bug this fix prevents.
+	 */
+	public function testDisableSweepAfterSyncWipesRedirectRulesHazard(): void
+	{
+		// Given: redirect enabled on 'lan'; the sync creates its rules.
+		$this->seedRedirEnable('on');
+		$this->seedRedirInt('lan');
+		$this->seedRedirExclude('');
+		$this->runSync();
+		$this->assertSame(2, $this->countRedirNatRules(), 'precondition: 2 redirect NAT rules created');
+		$this->assertSame(2, $this->countRedirFilterRules(), 'precondition: 2 redirect filter rules created');
+
+		// When: the broad disable-sweep runs AFTER the sync.
+		$swept = pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule']);
+
+		// Then: the redirect rules were wiped (demonstrates why the sweep must precede the sync).
+		$this->assertTrue($swept, 'sweep after sync must report a removal');
+		$this->assertSame(0, $this->countRedirNatRules(),
+			'hazard: a disable-sweep AFTER the sync wipes the redirect NAT rules'
+		);
+		$this->assertSame(0, $this->countRedirFilterRules(),
+			'hazard: a disable-sweep AFTER the sync wipes the redirect filter rules'
+		);
+	}
+
+	/**
+	 * Scenario: the fix — the disable-sweep runs BEFORE the sync, redirect rules survive.
+	 *   Background: redirect enabled on 'lan', DNSBL disabled, plus a stale pfB DNSBL NAT row.
+	 *     Given a stale 'pfB DNSBL' NAT row in config (the orphan the sweep targets).
+	 *     When the disable-sweep runs FIRST (removing the stale DNSBL row),
+	 *       And the redirect sync then re-asserts its own rules.
+	 *     Then the redirect rules are present and the stale DNSBL row stays gone.
+	 */
+	public function testDisableSweepBeforeSyncLeavesRedirectRulesIntactFix(): void
+	{
+		// Given: redirect enabled on 'lan' and a stale pfB-owned DNSBL NAT row.
+		$this->seedRedirEnable('on');
+		$this->seedRedirInt('lan');
+		$this->seedRedirExclude('');
+		config_set_path('nat/rule', [
+			['descr' => 'pfB DNSBL - DO NOT EDIT', 'interface' => 'lan'],
+		]);
+
+		// When: the disable-sweep runs FIRST (the fixed sync_package_pfblockerng order).
+		$swept = pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule']);
+		$this->assertTrue($swept, 'sweep must remove the stale DNSBL NAT row');
+		$this->assertSame(0, $this->countRedirNatRules(), 'after sweep, before sync: no redirect rules yet');
+		$this->assertCount(0, $this->getNatRules(), 'after sweep: stale DNSBL NAT row removed too');
+
+		// And: the redirect sync re-asserts its rules.
+		$this->runSync();
+
+		// Then: the redirect rules survive; only redirect rows remain.
+		$this->assertSame(2, $this->countRedirNatRules(),
+			'fixed order: redirect NAT rules survive when the sweep precedes the sync'
+		);
+		$this->assertSame(2, $this->countRedirFilterRules(),
+			'fixed order: redirect filter rules survive when the sweep precedes the sync'
+		);
+		foreach ($this->getNatRules() as $rule) {
+			$this->assertStringStartsWith(
+				PFB_DNS_REDIR_DESCR_V4_PFX, $rule['descr'] ?? '',
+				'fixed order: only redirect rows remain (stale DNSBL NAT row swept)'
+			);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Regression: every emitted rule carries the pfSense rule metadata
+	// (a unique 'tracker' + created/updated provenance). Without a tracker the
+	// pfSense rule generator drops the row from /tmp/rules.debug and it never
+	// reaches pf — the live-VM failure these features hit on first run.
+	// -----------------------------------------------------------------------
+
+	public function testSyncedRedirectRulesAreStampedWithUniqueTrackerAndProvenance(): void
+	{
+		// Given redirect enabled on one interface.
+		$this->seedRedirEnable('on');
+		$this->seedRedirInt('lan');
+		$this->seedRedirExclude('');
+
+		// When the sync builds + writes the rules.
+		$this->runSync();
+
+		// Then the NAT row carries a positive integer tracker + provenance.
+		$nat = $this->findNatRule('lan', 'inet');
+		$this->assertNotNull($nat, 'lan/inet NAT rule must exist');
+		$this->assertArrayHasKey('tracker', $nat, 'NAT rule must carry a tracker (else filter_configure drops it)');
+		$this->assertIsInt($nat['tracker'], 'tracker must be an int');
+		$this->assertGreaterThan(0, $nat['tracker'], 'tracker must be a positive id');
+		$this->assertArrayHasKey('created', $nat, 'NAT rule must carry created provenance');
+		$this->assertArrayHasKey('time', $nat['created'] ?? [], 'created must carry a time');
+		$this->assertArrayHasKey('updated', $nat, 'NAT rule must carry updated provenance');
+
+		// And the paired filter row is stamped with a DISTINCT tracker (the
+		// generator keys on it, so a collision would coalesce/drop a rule).
+		$marker = PFB_DNS_REDIR_DESCR_V4_PFX . 'lan' . PFB_DNS_REDIR_DESCR_V4_SFX;
+		$filter = NULL;
+		foreach ($this->getFilterRules() as $r) {
+			if (($r['descr'] ?? '') === $marker) {
+				$filter = $r;
+				break;
+			}
+		}
+		$this->assertNotNull($filter, 'lan/inet filter rule must exist');
+		$this->assertArrayHasKey('tracker', $filter, 'filter rule must carry a tracker');
+		$this->assertNotSame(
+			$nat['tracker'],
+			$filter['tracker'],
+			'each emitted rule must get a UNIQUE tracker'
+		);
+	}
 }

--- a/tests/php/DnsRedirectLifecycleTest.php
+++ b/tests/php/DnsRedirectLifecycleTest.php
@@ -660,6 +660,9 @@ final class DnsRedirectLifecycleTest extends TestCase
 		}
 		$this->assertNotNull($filter, 'lan/inet filter rule must exist');
 		$this->assertArrayHasKey('tracker', $filter, 'filter rule must carry a tracker');
+		$this->assertArrayHasKey('created', $filter, 'filter rule must carry created provenance');
+		$this->assertArrayHasKey('time', $filter['created'] ?? [], 'filter created must carry a time');
+		$this->assertArrayHasKey('updated', $filter, 'filter rule must carry updated provenance');
 		$this->assertNotSame(
 			$nat['tracker'],
 			$filter['tracker'],

--- a/tests/php/DotDoQBlockLifecycleTest.php
+++ b/tests/php/DotDoQBlockLifecycleTest.php
@@ -524,4 +524,114 @@ final class DotDoQBlockLifecycleTest extends TestCase
 		$this->assertFalse($changed, 'sync when disabled with no rules must return FALSE');
 		$this->assertSame(0, $this->countDotBlockFilterRules(), 'after: still no DoT block filter rules');
 	}
+
+	// -----------------------------------------------------------------------
+	// Regression: the DNSBL "disable" sweep must run BEFORE the DoT-block sync.
+	//
+	// pfb_fwobj_sweep() removes EVERY pfB_-owned row (pfb_fwobj_is_owned matches
+	// the shared 'pfB_' prefix), so it also matches pfB_DoT_Block_* rows. The
+	// DoT/DoQ-block feature is independent of DNSBL mode (it can be ON while DNSBL
+	// is disabled — mode 'disabled'), so when sync_package_pfblockerng() runs its
+	// defensive disable-sweep it MUST do so before this sync re-asserts its rules;
+	// otherwise the sweep wipes the freshly-created block rules. Pinned both ways.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario: the hazard — a broad disable-sweep AFTER the sync wipes the block rule.
+	 *   Background: DoT block enabled on 'lan', DNSBL disabled (only block rows exist).
+	 *     Given the DoT sync has created its filter rule.
+	 *     When the broad pfB_ disable-sweep runs afterwards.
+	 *     Then the block rule is gone — the ordering bug this fix prevents.
+	 */
+	public function testDisableSweepAfterSyncWipesDotBlockRuleHazard(): void
+	{
+		// Given: DoT block enabled on 'lan'; the sync creates its rule.
+		$this->seedDotBlockEnable('on');
+		$this->seedDotBlockInt('lan');
+		$this->seedDotBlockExclude('');
+		$this->runSync();
+		$this->assertSame(1, $this->countDotBlockFilterRules(), 'precondition: 1 DoT block filter rule created');
+
+		// When: the broad disable-sweep runs AFTER the sync.
+		$swept = pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule']);
+
+		// Then: the block rule was wiped (demonstrates why the sweep must precede the sync).
+		$this->assertTrue($swept, 'sweep after sync must report a removal');
+		$this->assertSame(0, $this->countDotBlockFilterRules(),
+			'hazard: a disable-sweep AFTER the sync wipes the DoT block filter rule'
+		);
+	}
+
+	/**
+	 * Scenario: the fix — the disable-sweep runs BEFORE the sync, the block rule survives.
+	 *   Background: DoT block enabled on 'lan', DNSBL disabled, plus a stale pfB DNSBL NAT row.
+	 *     Given a stale 'pfB DNSBL' NAT row in config (the orphan the sweep targets).
+	 *     When the disable-sweep runs FIRST (removing the stale DNSBL row),
+	 *       And the DoT sync then re-asserts its own rule.
+	 *     Then the block rule is present and the stale DNSBL row stays gone.
+	 */
+	public function testDisableSweepBeforeSyncLeavesDotBlockRuleIntactFix(): void
+	{
+		// Given: DoT block enabled on 'lan' and a stale pfB-owned DNSBL NAT row.
+		$this->seedDotBlockEnable('on');
+		$this->seedDotBlockInt('lan');
+		$this->seedDotBlockExclude('');
+		config_set_path('nat/rule', [
+			['descr' => 'pfB DNSBL - DO NOT EDIT', 'interface' => 'lan'],
+		]);
+
+		// When: the disable-sweep runs FIRST (the fixed sync_package_pfblockerng order).
+		$swept = pfb_fwobj_sweep(['virtualip/vip', 'nat/rule', 'filter/rule']);
+		$this->assertTrue($swept, 'sweep must remove the stale DNSBL NAT row');
+		$this->assertSame(0, $this->countDotBlockFilterRules(), 'after sweep, before sync: no block rule yet');
+
+		// And: the DoT sync re-asserts its rule.
+		$this->runSync();
+
+		// Then: the block rule survives and the stale DNSBL NAT row stays gone.
+		$this->assertSame(1, $this->countDotBlockFilterRules(),
+			'fixed order: DoT block filter rule survives when the sweep precedes the sync'
+		);
+		foreach (config_get_path('nat/rule', []) as $rule) {
+			$this->assertStringNotContainsString(
+				'pfB DNSBL', $rule['descr'] ?? '',
+				'fixed order: the stale DNSBL NAT row remains swept'
+			);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Regression: the emitted block rule carries the pfSense rule metadata
+	// (a positive 'tracker' + created/updated). Without a tracker the pfSense
+	// rule generator drops the row from /tmp/rules.debug and it never reaches
+	// pf — the live-VM failure this feature hit on first run.
+	// -----------------------------------------------------------------------
+
+	public function testSyncedDotBlockRuleIsStampedWithTrackerAndProvenance(): void
+	{
+		// Given DoT block enabled on one interface.
+		$this->seedDotBlockEnable('on');
+		$this->seedDotBlockInt('lan');
+		$this->seedDotBlockExclude('');
+
+		// When the sync builds + writes the rule.
+		$this->runSync();
+
+		// Then the block row carries a positive integer tracker + provenance.
+		$marker = PFB_DOT_BLOCK_DESCR_PFX . 'lan';
+		$rule = NULL;
+		foreach ($this->getFilterRules() as $r) {
+			if (($r['descr'] ?? '') === $marker) {
+				$rule = $r;
+				break;
+			}
+		}
+		$this->assertNotNull($rule, 'lan DoT block rule must exist');
+		$this->assertArrayHasKey('tracker', $rule, 'block rule must carry a tracker (else filter_configure drops it)');
+		$this->assertIsInt($rule['tracker'], 'tracker must be an int');
+		$this->assertGreaterThan(0, $rule['tracker'], 'tracker must be a positive id');
+		$this->assertArrayHasKey('created', $rule, 'block rule must carry created provenance');
+		$this->assertArrayHasKey('time', $rule['created'] ?? [], 'created must carry a time');
+		$this->assertArrayHasKey('updated', $rule, 'block rule must carry updated provenance');
+	}
 }

--- a/tests/smoke/boot_vm.sh
+++ b/tests/smoke/boot_vm.sh
@@ -1,39 +1,57 @@
 #!/bin/sh
-# boot_vm.sh — boot a hand-built pfSense CE qcow2 headless under QEMU/KVM
-# for the ADR-04 Phase-1 de-risking spike.
+# boot_vm.sh — boot a smoke-test qcow2 headless under QEMU/KVM.
+#
+# Two roles (ADR-04 two-VM topology):
+#
+#   --role pfsense  (default) — the pfSense appliance, 8 virtio-net NICs that
+#       MIRROR the source VM so pfSense does not re-detect hardware and drop to
+#       the interface-reassignment console prompt. Only the first three are
+#       assigned in the image:
+#         net0 WAN  — SLIRP user-net, 10.10.0.0/24, host alias 10.10.0.2 (the
+#                     guest reaches the runner-side mock feed / stub-DNS /
+#                     sinkhole servers here); DHCP; egress for `pkg add`.
+#         net1 MGMT — SLIRP user-net, 10.0.0.0/16; the host->guest forwards
+#                     (ssh, web) target the image's static management IP
+#                     10.0.0.20. This is the harness control path.
+#         net2 LAN  — a QEMU `socket` LISTENER (point-to-point L2 "crossover"
+#                     to the civm data NIC); pfSense LAN is 192.168.1.1/24.
+#         net3..7   — unassigned; present only so the 8-NIC image sees no
+#                     hardware change. Isolated (restrict=on), no host access.
+#
+#   --role client — the Debian client VM ("civm"), 2 virtio-net NICs:
+#         net0 MGMT — SLIRP user-net; host->guest ssh forward (the harness runs
+#                     `dig @192.168.1.1` here). DHCP; MAC is don't-care.
+#         net1 DATA — a QEMU `socket` CONNECTOR to the pfSense LAN listener; its
+#                     MAC is SMOKE_CLIENT_MAC_ADDRESS so pfSense's static DHCP
+#                     lease hands it 192.168.1.10.
 #
 # Usage:
-#   tests/smoke/boot_vm.sh <base-image.qcow2> [overlay.qcow2]
+#   tests/smoke/boot_vm.sh [--role pfsense|client] <base-image.qcow2> [overlay.qcow2]
 #
-# Boots the image headless with KVM acceleration and a QEMU user-net
-# (SLIRP) host-forward map so the runner can reach the guest:
-#   host 2222/tcp -> guest 22   (SSH)
-#   host 8080/tcp -> guest 80   (WebUI, HTTP)
-#   host 5353/tcp -> guest 53   (DNS, TCP)
-#   host 5353/udp -> guest 53   (DNS, UDP)
-# The guest reaches the runner at the SLIRP host alias 10.0.2.2.
+# Boots headless with KVM acceleration. The base qcow2 is NEVER mutated: an
+# ephemeral copy-on-write overlay is created over it and the guest writes only to
+# the overlay (removed on a clean exit; pass an explicit overlay path to keep it).
 #
-# Hardware MIRRORS the source Proxmox VM (qm showcmd 103 --pretty) so the
-# published qcow2 boots without pfSense re-detecting hardware and dropping
-# to the interface-reassignment console prompt:
-#   - single virtio-net-pci NIC, MAC pinned to BC:24:11:37:9C:AC
-#     (the CE source VM's MAC; a MAC is not sensitive). The MAC is per-image
-#     and defaults to the CE pin; override it with SMOKE_VM_MAC. A pfSense Plus
-#     image MUST set SMOKE_VM_MAC to its OWN source-VM MAC: the Plus license/NDI
-#     registration is keyed to it, so the CE pin would deregister/reassign it
-#     (see ADR-24 and scripts/README.md § "pfSense Plus images").
-#   - SMBIOS type-1 uuid pinned, per-image. The Plus Netgate Device ID (NDI) is
-#     derived from the source VM's MAC + this SMBIOS uuid, so the uuid is as
-#     license-keyed as the MAC. CE defaults to the public CE source-VM uuid;
-#     a Plus image MUST set SMOKE_VM_SMBIOS_UUID to its OWN source-VM uuid (held
-#     in a secret, NOT the public ci-metadata matrix — license/NDI-keyed).
-#   - VirtIO-SCSI disk (guest sees da0)
-#   - machine type pc (i440fx; Proxmox pc+pve0), -cpu host, 2 vCPU, 4 GB RAM
+# Identity (per-image; ADR-24). pfSense:
+#   - SMOKE_VM_MAC — the NIC MAC(s), NEWLINE-SEPARATED, one MAC per NIC in order
+#     (net0..net7); NIC i takes line i. Defaults to the CE source-VM's own 8 MACs
+#     (committed below — a MAC is not sensitive). A pfSense Plus image overrides
+#     it with its license/NDI-keyed source-VM MAC list (from a secret).
+#   - SMOKE_VM_SMBIOS_UUID — SMBIOS type-1 uuid (Plus: the source-VM uuid, held
+#     in a secret; CE: the public pin). The Plus Netgate Device ID derives from
+#     MAC + uuid, so a Plus image MUST set both.
+# civm: net MACs default to the civm source VM's own (committed below — net0
+#   management, net1 data). The data-NIC MAC (SMOKE_CLIENT_MAC_ADDRESS) keys
+#   pfSense's static-lease mapping, so it must match the pfSense image's lease.
+#   SMBIOS type-1 uuid also defaults to the civm source VM's (SMOKE_CLIENT_SMBIOS_UUID).
 #
-# The base image is NEVER mutated: an ephemeral copy-on-write overlay is
-# created over it and the guest writes only to the overlay. The overlay is
-# removed on a clean exit; pass an explicit overlay path to keep it for
-# post-mortem. The base qcow2 stays read-only.
+# Shared:
+#   - SMOKE_LAN_SOCKET_PORT — TCP port (on 127.0.0.1) for the pfSense<->civm LAN
+#     socket link. pfSense LISTENs, civm CONNECTs; both roles must use the same
+#     port. Default 12340 (a lone pfSense boot just has no LAN carrier).
+#   - SMOKE_SSH_HOSTPORT / SMOKE_WEB_HOSTPORT — pfSense host-forward ports
+#     (defaults 2222 / 8080). SMOKE_CLIENT_SSH_HOSTPORT — civm ssh host port
+#     (default 2223).
 #
 # POSIX sh; quoted expansions; absolute binary paths (pfSense convention).
 
@@ -43,21 +61,67 @@ QEMU=/usr/bin/qemu-system-x86_64
 QEMU_IMG=/usr/bin/qemu-img
 
 # Source-VM hardware profile (mirror — do not change without re-baking image).
-# MAC + SMBIOS uuid are per-image: CE pins by default, SMOKE_VM_MAC /
-# SMOKE_VM_SMBIOS_UUID override (Plus MUST set both — its NDI is derived from
-# MAC + uuid, so both are license-keyed and come from secrets, not the matrix).
-VM_MAC="${SMOKE_VM_MAC:-BC:24:11:37:9C:AC}"
+# DEFAULT_CE_MAC is the CE source VM's own 8 NIC MACs (net0..net7, in order),
+# committed as non-secret defaults so a CE boot mirrors the source hardware. A
+# Plus image overrides via SMOKE_VM_MAC (its NDI-keyed secret list); an empty or
+# unset SMOKE_VM_MAC falls back to these.
+DEFAULT_CE_MAC="$(printf '%s\n' \
+    BC:24:11:37:9C:AC \
+    BC:24:11:80:42:35 \
+    BC:24:11:D6:90:DD \
+    BC:24:11:FB:41:8A \
+    BC:24:11:2D:95:0A \
+    BC:24:11:36:D3:34 \
+    BC:24:11:02:0B:68 \
+    BC:24:11:46:D1:DE)"
+VM_MAC="${SMOKE_VM_MAC:-$DEFAULT_CE_MAC}"
 VM_SMBIOS_UUID="${SMOKE_VM_SMBIOS_UUID:-58fd7964-c40c-4f47-bf02-3fdad18f8b00}"
 VM_SMP="2,sockets=1,cores=2"
 VM_MEM="4096"
 
+# civm is a lightweight client — fewer resources than the appliance.
+CLIENT_SMP="1,sockets=1,cores=1"
+CLIENT_MEM="1024"
+# civm source-VM NIC MACs (committed non-secret defaults): net0 management, net1
+# data. The data MAC keys pfSense's static DHCP lease (-> 192.168.1.10), so it
+# must match the lease baked into the pfSense image. Override either via env.
+CLIENT_MGMT_MAC="${SMOKE_CLIENT_MGMT_MAC:-BC:24:11:29:A4:1B}"
+CLIENT_MAC="${SMOKE_CLIENT_MAC_ADDRESS:-02:49:E4:CE:92:72}"
+# civm SMBIOS type-1 uuid (committed non-secret default — the civm source VM's
+# own uuid; keeps machine-id / DHCP identity stable across overlay boots).
+CLIENT_SMBIOS_UUID="${SMOKE_CLIENT_SMBIOS_UUID:-7dc13783-e65c-4f62-8fd8-45eeae4c77b9}"
+
+# Host<->guest exposure (mirrors conftest's DEFAULT_*_PORT + the management IP).
+SSH_HOSTPORT="${SMOKE_SSH_HOSTPORT:-2222}"
+WEB_HOSTPORT="${SMOKE_WEB_HOSTPORT:-8080}"
+CLIENT_SSH_HOSTPORT="${SMOKE_CLIENT_SSH_HOSTPORT:-2223}"
+PFSENSE_MGMT_IP="10.0.0.20"   # static management IP baked into the pfSense image
+
+# pfSense<->civm LAN crossover socket (point-to-point; pfSense listens, civm connects).
+LAN_SOCKET_PORT="${SMOKE_LAN_SOCKET_PORT:-12340}"
+
+ROLE=pfsense
+
 usage() {
-    echo "Usage: $0 <base-image.qcow2> [overlay.qcow2]" >&2
+    echo "Usage: $0 [--role pfsense|client] <base-image.qcow2> [overlay.qcow2]" >&2
     exit 2
 }
 
-[ "$#" -ge 1 ] || usage
+# --- option parsing (optional --role, then positionals) --------------------- #
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --role) [ "$#" -ge 2 ] || usage; ROLE="$2"; shift 2 ;;
+        --)     shift; break ;;
+        -*)     echo "boot_vm: unknown option: $1" >&2; usage ;;
+        *)      break ;;
+    esac
+done
+case "$ROLE" in
+    pfsense|client) ;;
+    *) echo "boot_vm: --role must be 'pfsense' or 'client'" >&2; exit 2 ;;
+esac
 
+[ "$#" -ge 1 ] || usage
 BASE_IMG="$1"
 OVERLAY="${2:-}"
 
@@ -110,28 +174,81 @@ trap cleanup EXIT INT TERM
 # never written. (Equivalent to -snapshot, but explicit + inspectable.)
 "$QEMU_IMG" create -q -f qcow2 -b "$BASE_IMG" -F qcow2 "$OVERLAY" >/dev/null
 
-echo "boot_vm: booting $BASE_IMG via overlay $OVERLAY" >&2
-echo "boot_vm: hostfwd ssh=2222->22 web=8080->80 dns=5353->53(tcp+udp)" >&2
+echo "boot_vm: role=$ROLE booting $BASE_IMG via overlay $OVERLAY" >&2
 
-# KVM acceleration is required for a FreeBSD guest at usable speed. The
-# caller (workflow) asserts /dev/kvm before invoking this helper.
-#
-# Build the arg list incrementally so the control/diagnostic channel is
-# optional. If QMP_SOCK is set in the environment, expose a QMP control socket
-# there (used by screendump.py to capture the VGA framebuffer of a wedged,
-# headless boot) and keep the serial console on stdio for the run log. If it is
-# unset (local interactive use), mux the monitor + serial on stdio as before.
+# nth_mac N — echo the Nth line (0-based) of the newline-separated VM_MAC, or
+# nothing when that line is absent (CE: empty list -> QEMU default per NIC).
+nth_mac() {
+    printf '%s\n' "$VM_MAC" | sed -n "$(($1 + 1))p"
+}
+
+# Machine + disk args (identical for both roles, aside from CPU/RAM sizing).
+if [ "$ROLE" = client ]; then
+    SMP="$CLIENT_SMP"; MEM="$CLIENT_MEM"
+else
+    SMP="$VM_SMP"; MEM="$VM_MEM"
+fi
+
 set -- \
     -enable-kvm -machine pc -cpu host \
-    -smp "$VM_SMP" -m "$VM_MEM" \
-    -smbios "type=1,uuid=${VM_SMBIOS_UUID}" \
+    -smp "$SMP" -m "$MEM" \
     -device virtio-scsi-pci,id=virtioscsi0 \
     -drive "file=${OVERLAY},if=none,id=drive-scsi0,format=qcow2,cache=unsafe,discard=unmap,detect-zeroes=unmap" \
-    -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
-    -netdev user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::8080-:80,hostfwd=tcp::5353-:53,hostfwd=udp::5353-:53 \
-    -device "virtio-net-pci,mac=${VM_MAC},netdev=net0,id=nic0" \
-    -display none
+    -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1
 
+if [ "$ROLE" = pfsense ]; then
+    # SMBIOS identity (license/NDI-keyed for Plus; public pin for CE).
+    set -- "$@" -smbios "type=1,uuid=${VM_SMBIOS_UUID}"
+
+    echo "boot_vm: pfsense hostfwd ssh=${SSH_HOSTPORT}->${PFSENSE_MGMT_IP}:22 web=${WEB_HOSTPORT}->${PFSENSE_MGMT_IP}:80 (mgmt net1)" >&2
+    echo "boot_vm: pfsense LAN socket LISTEN 127.0.0.1:${LAN_SOCKET_PORT} (net2)" >&2
+
+    i=0
+    while [ "$i" -lt 8 ]; do
+        case "$i" in
+            # net0 WAN: a /24 (NOT a /16). It must NOT contain the DNSBL sinkhole
+            # VIP (10.10.10.1) or the auto-VIP (10.10.10.53) — pfBlockerNG refuses
+            # a VIP that overlaps an interface subnet and disables DNSBL wholesale.
+            # 10.10.0.0/24 keeps the host alias 10.10.0.2 while leaving 10.10.10.x free.
+            0) netdev="user,id=net0,net=10.10.0.0/24,host=10.10.0.2" ;;
+            1) netdev="user,id=net1,net=10.0.0.0/16,host=10.0.0.2,hostfwd=tcp::${SSH_HOSTPORT}-${PFSENSE_MGMT_IP}:22,hostfwd=tcp::${WEB_HOSTPORT}-${PFSENSE_MGMT_IP}:80" ;;
+            2) netdev="socket,id=net2,listen=127.0.0.1:${LAN_SOCKET_PORT}" ;;
+            # net3..7: present so the 8-NIC image sees no hardware change, but
+            # isolated (restrict=on) with distinct dummy subnets — pfSense leaves
+            # them unassigned so they never get an IP.
+            *) netdev="user,id=net${i},net=10.${i}0.0.0/24,restrict=on" ;;
+        esac
+        mac="$(nth_mac "$i")"
+        if [ -n "$mac" ]; then
+            dev="virtio-net-pci,mac=${mac},netdev=net${i},id=nic${i}"
+        else
+            dev="virtio-net-pci,netdev=net${i},id=nic${i}"
+        fi
+        set -- "$@" -netdev "$netdev" -device "$dev"
+        i=$((i + 1))
+    done
+else
+    # civm: net0 management (ssh hostfwd, DHCP, don't-care MAC); net1 data
+    # (socket CONNECT to the pfSense LAN listener, MAC = static-lease key).
+    set -- "$@" -smbios "type=1,uuid=${CLIENT_SMBIOS_UUID}"
+    echo "boot_vm: client hostfwd ssh=${CLIENT_SSH_HOSTPORT}->:22 (mgmt net0)" >&2
+    echo "boot_vm: client DATA socket CONNECT 127.0.0.1:${LAN_SOCKET_PORT} mac=${CLIENT_MAC} (net1)" >&2
+    set -- "$@" \
+        -netdev "user,id=net0,hostfwd=tcp::${CLIENT_SSH_HOSTPORT}-:22" \
+        -device "virtio-net-pci,mac=${CLIENT_MGMT_MAC},netdev=net0,id=nic0" \
+        -netdev "socket,id=net1,connect=127.0.0.1:${LAN_SOCKET_PORT}" \
+        -device "virtio-net-pci,mac=${CLIENT_MAC},netdev=net1,id=nic1"
+fi
+
+set -- "$@" -display none
+
+# KVM acceleration is required for a FreeBSD guest at usable speed. The caller
+# (workflow) asserts /dev/kvm before invoking this helper.
+#
+# If QMP_SOCK is set, expose a QMP control socket there (used by screendump.py to
+# capture the VGA framebuffer of a wedged, headless boot) and keep the serial
+# console on stdio for the run log. If unset (local interactive use), mux the
+# monitor + serial on stdio as before.
 if [ -n "${QMP_SOCK:-}" ]; then
     rm -f "$QMP_SOCK"
     set -- "$@" -qmp "unix:${QMP_SOCK},server,nowait" -serial stdio

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -25,7 +25,7 @@ What this module provides:
 * ``mock_feeds`` — a FUNCTION-scoped fixture serving files from
   ``tests/smoke/fixtures/`` (plus per-test registered content) over stdlib
   ``http.server`` on the runner, reachable by the guest at
-  ``http://10.0.2.2:<port>/<name>`` via the QEMU user-net (SLIRP) host alias.
+  ``http://10.10.0.2:<port>/<name>`` via the QEMU WAN user-net (SLIRP) host alias.
 
 The boot+probe core lives in :func:`boot_and_probe`, separate from the pytest
 fixtures, so it can double as a reusable health/sanity gate (ADR-09 fans the
@@ -40,6 +40,7 @@ import os
 import shutil
 import socket
 import subprocess
+import tempfile
 import threading
 import time
 from collections.abc import Generator, Iterator, Mapping
@@ -69,8 +70,13 @@ DEFAULT_SSH_PORT = 2222  # host -> guest 22
 DEFAULT_WEB_PORT = 8080  # host -> guest 80
 DEFAULT_DNS_PORT = 5353  # host -> guest 53 (tcp+udp)
 
-# The SLIRP host alias the guest uses to reach the runner (mock feed server).
-GUEST_TO_HOST_ALIAS = "10.0.2.2"
+# The WAN SLIRP host alias the guest uses to reach the runner (mock feed server,
+# stub DNS, webhook sink). Corresponds to boot_vm.sh net0: net=10.10.0.0/24,
+# host=10.10.0.2. The old 10.0.2.2 was the classic libslirp default; the two-VM
+# topology uses 10.10.0.0/24 — it avoids the management net (10.0.0.0/16) AND
+# leaves the DNSBL sinkhole VIP 10.10.10.1 outside the WAN subnet (an overlap
+# makes pfBlockerNG disable DNSBL).
+GUEST_TO_HOST_ALIAS = "10.10.0.2"
 
 # Sentinel answers the runner-side stub upstream returns for any forwarded query
 # (see _StubDnsServer / helpers.configure_upstream). Distinct from every DNSBL
@@ -82,6 +88,16 @@ STUB_DNS_AAAA = stub_responses.STUB_DNS_AAAA  # RFC 3849 documentation range
 
 # Hard readiness ceiling; wait_ready.sh polls (no fixed sleep) up to this.
 DEFAULT_BOOT_TIMEOUT = int(os.environ.get("SMOKE_BOOT_TIMEOUT", "300"))
+
+# civm client VM ssh host-forward port (host -> civm:22). Matches boot_vm.sh
+# SMOKE_CLIENT_SSH_HOSTPORT default.
+DEFAULT_CLIENT_SSH_PORT = 2223  # host -> civm 22
+
+# The address civm uses to reach pfSense (pfSense LAN side of the socket crossover).
+PFSENSE_LAN_IP = "192.168.1.1"  # pfSense LAN IP baked in the two-VM image
+
+# civm's pfSense static-DHCP lease address (informational; keyed by SMOKE_CLIENT_MAC_ADDRESS).
+CLIENT_LAN_IP = "192.168.1.10"  # civm's static lease on the pfSense LAN
 
 
 # --------------------------------------------------------------------------- #
@@ -107,8 +123,8 @@ class SmokeVM:
     # once mock_feeds is up (it allocates the port); None until then.
     feed_base_url: str | None = None
     # Runner-side port of the stub DNS upstream (reached by the guest at
-    # 10.0.2.2:<port> via SLIRP). Set once the stub_dns fixture is up; None
-    # otherwise. Unbound is pointed here so it never recurses into dark egress.
+    # 10.10.0.2:<port> via the WAN SLIRP alias). Set once the stub_dns fixture is
+    # up; None otherwise. Unbound is pointed here so it never recurses into dark egress.
     upstream_dns_port: int | None = None
     # qemu PID + overlay are bookkeeping for teardown.
     vm_pid: int | None = None
@@ -209,6 +225,7 @@ def boot_and_probe(
     web_port: int = DEFAULT_WEB_PORT,
     dns_port: int = DEFAULT_DNS_PORT,
     boot_timeout: int = DEFAULT_BOOT_TIMEOUT,
+    diag_name: str = "pfsense",
 ) -> BootHandle:
     """Boot ``base_image`` and block until the guest is usable.
 
@@ -224,12 +241,17 @@ def boot_and_probe(
     image sanity gate).
     """
     log_file = log_path.open("wb")
+    # Expose a QMP control socket so a wedged, no-serial boot can be screendumped
+    # (the only diagnostic window when SSH/web never come up). boot_vm.sh keeps
+    # the serial console on stdio (-> log_file) alongside QMP.
+    qmp_sock = _qmp_sock_path(diag_name)
     # boot_vm.sh backgrounds nothing itself (it execs qemu); we background it
     # via Popen and pass its PID to wait_ready.sh so a dead boot is caught fast.
     process: subprocess.Popen[bytes] = subprocess.Popen(
         ["sh", str(BOOT_VM_SH), str(base_image)],
         stdout=log_file,
         stderr=subprocess.STDOUT,
+        env={**os.environ, "QMP_SOCK": qmp_sock},
     )
 
     vm = SmokeVM(
@@ -261,11 +283,13 @@ def boot_and_probe(
             check=False,
         )
     except Exception:
+        _capture_boot_failure(diag_name, qmp_sock, log_path, process)
         _kill(process)
         log_file.close()
         raise
 
     if result.returncode != 0:
+        _capture_boot_failure(diag_name, qmp_sock, log_path, process)
         _kill(process)
         log_file.close()
         tail = _tail(log_path)
@@ -299,13 +323,102 @@ def _tail(path: Path, lines: int = 40) -> str:
     return "\n".join(text.splitlines()[-lines:])
 
 
+# Diagnostics for a wedged boot are written here, RELATIVE to the workspace cwd
+# (where pytest runs). The smoke workflow's "Upload diagnostics" step globs
+# ``smoke-diag/**`` + ``**/screen-*.png`` — so anything dropped here is uploaded.
+# This is the ONLY window into a setup-time boot failure: the session VM fixture
+# errors before any test runs, so the on-failure ``_dump_vm_on_failure`` hook
+# (which needs SSH) never fires, and the boot log otherwise lives under pytest's
+# tmp dir (outside the artifact globs).
+DIAG_DIR = Path("smoke-diag")
+
+
+def _qmp_sock_path(tag: str) -> str:
+    """A short unix-socket path for QEMU's QMP control channel.
+
+    Unix socket paths are capped at ~108 bytes, so we anchor under RUNNER_TEMP
+    (or /tmp), NOT pytest's deep tmp_path_factory dir. boot_vm.sh ``rm -f``s and
+    recreates it; we only need a unique, short name.
+    """
+    base = os.environ.get("RUNNER_TEMP") or "/tmp"
+    return tempfile.mktemp(prefix=f"pfb-qmp-{tag}-", suffix=".sock", dir=base)
+
+
+def _capture_boot_failure(tag: str, qmp_sock: str | None, log_path: Path, process: subprocess.Popen[bytes]) -> None:
+    """Snapshot a wedged boot into ``smoke-diag/`` before the VM is killed.
+
+    These images may have NO serial console (screendump.py's whole reason for
+    being), so the boot log can be empty and the VGA framebuffer is the only
+    window into a stuck/unreachable boot. Captures both, best-effort, into the
+    workflow-uploaded ``smoke-diag/`` dir:
+
+      * ``boot-<tag>.log`` — whatever the guest wrote to the serial/stdio channel;
+      * ``screen-<tag>.png`` — the VGA framebuffer via QEMU's QMP ``screendump``
+        (the same mechanism ``build-image.yml`` uses for a stuck headless boot).
+
+    MUST run BEFORE the qemu process is killed — QMP needs the process alive.
+    """
+    with contextlib.suppress(Exception):
+        DIAG_DIR.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(Exception):
+        shutil.copyfile(log_path, DIAG_DIR / f"boot-{tag}.log")
+    if qmp_sock and process.poll() is None and Path(qmp_sock).exists():
+        with contextlib.suppress(Exception):
+            subprocess.run(
+                ["python3", str(SMOKE_DIR / "screendump.py"), qmp_sock, str(DIAG_DIR / f"screen-{tag}.png")],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# LAN socket port allocation — shared by pfSense (LISTENER) and civm (CONNECTOR)
+# --------------------------------------------------------------------------- #
+
+
+def _alloc_free_tcp_port() -> int:
+    """Allocate one free TCP port on 127.0.0.1 and release it.
+
+    Binds a TCP socket to port 0 (OS picks a free ephemeral port), reads the
+    assigned port, closes the socket, and returns the port number. The caller
+    is responsible for using the port quickly before something else claims it;
+    for the boot_vm.sh socket crossover this window is fine because the port is
+    consumed moments later by QEMU's socket LISTENER.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+@pytest.fixture(scope="session")
+def lan_socket_port() -> Iterator[int]:
+    """Allocate the shared TCP port for the pfSense<->civm LAN socket crossover.
+
+    Picks one free port, sets ``SMOKE_LAN_SOCKET_PORT`` so BOTH boot_vm.sh
+    invocations (pfSense LISTENER, civm CONNECTOR) inherit the same value, yields
+    the port, and removes the env var on teardown. Must be acquired BEFORE pfSense
+    boots (so the LISTENER uses it) — ``smoke_vm`` depends on this fixture.
+    """
+    port = _alloc_free_tcp_port()
+    os.environ["SMOKE_LAN_SOCKET_PORT"] = str(port)
+    try:
+        yield port
+    finally:
+        os.environ.pop("SMOKE_LAN_SOCKET_PORT", None)
+
+
 # --------------------------------------------------------------------------- #
 # Session-scoped VM fixture
 # --------------------------------------------------------------------------- #
 
 
 @pytest.fixture(scope="session")
-def smoke_vm(tmp_path_factory: pytest.TempPathFactory) -> Iterator[SmokeVM]:
+def smoke_vm(lan_socket_port: int, tmp_path_factory: pytest.TempPathFactory) -> Iterator[SmokeVM]:
     """Pull -> boot -> wait-ready -> yield -> teardown, once per session.
 
     Per-case isolation (Phase 4 provides the reset verbs): cases run against
@@ -375,6 +488,144 @@ def smoke_vm(tmp_path_factory: pytest.TempPathFactory) -> Iterator[SmokeVM]:
 
 
 # --------------------------------------------------------------------------- #
+# Client VM fixture (civm — the Debian behind-the-firewall client)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="session")
+def client_vm(
+    smoke_vm: SmokeVM,
+    lan_socket_port: int,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[SmokeVM]:
+    """Boot the civm Debian client and yield its SSH connection object, once per session.
+
+    Ordering is critical: pfSense (the LAN socket LISTENER) MUST be up before
+    civm (the CONNECTOR) tries to connect — hence the ``smoke_vm`` dependency.
+    Without pfSense's LISTENER the civm QEMU socket CONNECT would fail
+    immediately. The ``lan_socket_port`` dependency guarantees the shared TCP port
+    is set in ``SMOKE_LAN_SOCKET_PORT`` before either VM boots.
+
+    NIC topology (from boot_vm.sh --role client):
+      net0 MGMT — SLIRP user-net; host->guest SSH forward at
+                  host:``DEFAULT_CLIENT_SSH_PORT`` (2223). This is the harness
+                  control path for running ``dig`` probes on civm.
+      net1 DATA — QEMU socket CONNECTOR to the pfSense LAN LISTENER; its MAC is
+                  ``SMOKE_CLIENT_MAC_ADDRESS``, which pfSense matches to a static
+                  DHCP lease handing civm ``CLIENT_LAN_IP`` (192.168.1.10).
+
+    Readiness: SSH-only (no web server on civm). ``wait_ready.sh`` is called
+    WITHOUT a web-port argument so the gate is SSH-only.
+
+    The ``SmokeVM`` object's DNS-specific fields (``dns_port``, ``feed_base_url``,
+    ``upstream_dns_port``) are unused for the client VM; its ``ssh()`` method is
+    what matters for running ``dig @192.168.1.1`` probes.
+
+    The civm data-NIC MAC (the pfSense static-lease key) defaults in boot_vm.sh,
+    so ``SMOKE_CLIENT_MAC_ADDRESS`` is an OVERRIDE (CI sets it from the secret),
+    not a precondition.
+
+    Skips (not fails) when:
+      * ``SMOKE_CLIENT_IMAGE_DIR``/``SMOKE_CLIENT_IMAGE_REF`` are both unset
+        (pfSense-only suites can run without a client image).
+      * The same prerequisites as ``smoke_vm`` (KVM, ssh, qemu binaries).
+    """
+    client_image_dir = os.environ.get("SMOKE_CLIENT_IMAGE_DIR")
+    client_image_ref = os.environ.get("SMOKE_CLIENT_IMAGE_REF")
+    if not client_image_dir and not client_image_ref:
+        pytest.skip("no civm client image (SMOKE_CLIENT_IMAGE_DIR/REF unset)")
+
+    # The civm data-NIC MAC (static-lease key) has a committed default in
+    # boot_vm.sh, so SMOKE_CLIENT_MAC_ADDRESS is an OVERRIDE, not a requirement;
+    # CI still sets it from the secret. No skip on its absence.
+
+    ssh_key_path = os.environ.get("SMOKE_SSH_KEY")
+    if not ssh_key_path or not Path(ssh_key_path).is_file():
+        pytest.skip("SMOKE_SSH_KEY not set or not a file — no guest SSH key")
+
+    if not Path("/dev/kvm").exists():
+        pytest.skip("/dev/kvm absent — KVM acceleration required for the smoke VM")
+
+    required: tuple[str, ...] = ("qemu-system-x86_64", "qemu-img", "ssh")
+    if not client_image_dir:
+        required = ("oras", *required)
+    for binary in required:
+        if shutil.which(binary) is None:
+            pytest.skip(f"required binary `{binary}` not on PATH")
+
+    work = tmp_path_factory.mktemp("client-vm")
+    if client_image_dir:
+        qcows = sorted(Path(client_image_dir).glob("*.qcow2"))
+        if len(qcows) != 1:
+            raise RuntimeError(f"SMOKE_CLIENT_IMAGE_DIR must hold exactly one .qcow2, found {len(qcows)}: {qcows}")
+        client_image = qcows[0]
+    else:
+        client_image = oras_pull_image(client_image_ref, work / "image")  # type: ignore[arg-type]
+
+    log_path = work / "client-vm.log"
+    log_file = log_path.open("wb")
+    qmp_sock = _qmp_sock_path("civm")
+
+    # pfSense (LISTENER) is already up (smoke_vm dependency); boot civm (CONNECTOR).
+    process: subprocess.Popen[bytes] = subprocess.Popen(
+        ["sh", str(BOOT_VM_SH), "--role", "client", str(client_image)],
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        env={**os.environ, "QMP_SOCK": qmp_sock},
+    )
+
+    try:
+        # SSH-only readiness: omit web-port arg so wait_ready.sh uses SSH gate only.
+        result = subprocess.run(
+            [
+                "sh",
+                str(WAIT_READY_SH),
+                ssh_key_path,
+                DEFAULT_HOST,
+                str(DEFAULT_CLIENT_SSH_PORT),
+                str(DEFAULT_BOOT_TIMEOUT),
+                str(process.pid),
+                # No web-port arg → SSH-only readiness gate.
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except Exception:
+        _capture_boot_failure("civm", qmp_sock, log_path, process)
+        _kill(process)
+        log_file.close()
+        raise
+
+    if result.returncode != 0:
+        _capture_boot_failure("civm", qmp_sock, log_path, process)
+        _kill(process)
+        log_file.close()
+        tail = _tail(log_path)
+        raise RuntimeError(
+            f"civm never became ready (wait_ready exit {result.returncode}).\n"
+            f"wait_ready stderr:\n{result.stderr}\n--- client boot log tail ---\n{tail}"
+        )
+
+    print(result.stdout.strip())
+
+    vm = SmokeVM(
+        ssh_key_path=ssh_key_path,
+        host=DEFAULT_HOST,
+        ssh_port=DEFAULT_CLIENT_SSH_PORT,
+        vm_pid=process.pid,
+        log_path=str(log_path),
+    )
+
+    try:
+        yield vm
+    finally:
+        _kill(process)
+        with contextlib.suppress(Exception):
+            log_file.close()
+
+
+# --------------------------------------------------------------------------- #
 # Mock HTTP feed server (stdlib only)
 # --------------------------------------------------------------------------- #
 
@@ -384,7 +635,7 @@ class _MockFeedServer:
 
     Files under ``tests/smoke/fixtures/`` are served by name; a test may also
     register ad-hoc content in memory via :meth:`register`. The guest fetches
-    them at ``feed_url(name)`` (``http://10.0.2.2:<port>/<name>``).
+    them at ``feed_url(name)`` (``http://10.10.0.2:<port>/<name>``).
     """
 
     def __init__(self, root: Path) -> None:
@@ -410,8 +661,8 @@ class _MockFeedServer:
                 # Stay quiet in pytest output; failures surface via assertions.
                 return
 
-        # Bind to all interfaces so the SLIRP alias 10.0.2.2 (which maps to the
-        # runner) can reach it; port 0 lets the OS pick a free port.
+        # Bind to all interfaces so the WAN SLIRP alias 10.10.0.2 (which maps to
+        # the runner) can reach it; port 0 lets the OS pick a free port.
         handler = partial(Handler, directory=str(root))
         self._httpd = ThreadingHTTPServer(("0.0.0.0", 0), handler)
         self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
@@ -463,9 +714,9 @@ class _MockCallbackSink:
     HAProxy): a recipe-shaped ``post`` hook ``curl``s this sink and forwards the
     url-encoded changed-alias env vars. The sink is OBSERVE-ONLY — it parses the
     body/query into a thread-safe :class:`CallbackRecord` list and answers ``200``,
-    nothing more (no side effect on the guest). Bound to ``0.0.0.0`` so the SLIRP
-    host alias ``10.0.2.2`` reaches it, exactly like :class:`_MockFeedServer`; the
-    guest hits :meth:`guest_url`.
+    nothing more (no side effect on the guest). Bound to ``0.0.0.0`` so the WAN
+    SLIRP host alias ``10.10.0.2`` reaches it, exactly like :class:`_MockFeedServer`;
+    the guest hits :meth:`guest_url`.
     """
 
     def __init__(self) -> None:
@@ -551,12 +802,12 @@ class _StubDnsServer:
     """A controlled, OBSERVABLE DNS upstream for the guest's Unbound (over SLIRP).
 
     This is the smoke matrix's upstream: pfSense forwards every non-local query to its
-    System DNS server ``10.0.2.2`` (QEMU/libslirp's host alias — see
-    ``helpers.use_system_dns_upstream``), and libslirp NATs guest->10.0.2.2:53 straight
+    System DNS server ``10.10.0.2`` (QEMU/libslirp's WAN host alias — see
+    ``helpers.use_system_dns_upstream``), and libslirp NATs guest->10.10.0.2:53 straight
     to this server on the RUNNER's loopback (``127.0.0.1:53``), port-preserving — the
-    same host-alias path the mock-feed HTTP server already rides, and the runner's own
-    ``/etc/resolv.conf`` is never touched. So what reaches this server is EXACTLY what
-    Unbound did not answer locally. That makes
+    same WAN host-alias path the mock-feed HTTP server already rides, and the runner's
+    own ``/etc/resolv.conf`` is never touched. So what reaches this server is EXACTLY
+    what Unbound did not answer locally. That makes
     blocking VERIFIABLE from the upstream side rather than inferred from a bare
     SERVFAIL: every query is recorded (:meth:`received`), so a DNSBL-blocked name must
     NEVER appear here, while a not-blocked name DOES — and resolves to a known answer,
@@ -624,13 +875,14 @@ class _StubDnsServer:
     def __init__(self, *, port: int | None = None) -> None:
         # Bind address/port are env-overridable so the smoke workflow can put the session
         # mock on the runner's loopback :53 — the System-DNS host-alias path: pfSense
-        # forwards to 10.0.2.2 (libslirp's host alias), which NATs guest->10.0.2.2:53 to
-        # the runner's 127.0.0.1:53 (this mock), port-preserving. The runner's own
-        # /etc/resolv.conf is NEVER touched. ``net.ipv4.ip_unprivileged_port_start`` is
-        # lowered by the workflow so this non-root process can bind :53; binding
-        # 127.0.0.1 (not 0.0.0.0) avoids clashing with systemd-resolved on 127.0.0.53:53.
-        # ``port`` overrides the env (the pure unit tests pass ``port=0`` to force an
-        # ephemeral port, so they never collide with the session mock holding :53).
+        # forwards to 10.10.0.2 (libslirp's WAN host alias), which NATs
+        # guest->10.10.0.2:53 to the runner's 127.0.0.1:53 (this mock), port-preserving.
+        # The runner's own /etc/resolv.conf is NEVER touched.
+        # ``net.ipv4.ip_unprivileged_port_start`` is lowered by the workflow so this
+        # non-root process can bind :53; binding 127.0.0.1 (not 0.0.0.0) avoids clashing
+        # with systemd-resolved on 127.0.0.53:53. ``port`` overrides the env (the pure
+        # unit tests pass ``port=0`` to force an ephemeral port, so they never collide
+        # with the session mock holding :53).
         addr = os.environ.get("SMOKE_STUB_DNS_ADDR") or "127.0.0.1"
         if port is None:
             port = int(os.environ.get("SMOKE_STUB_DNS_PORT") or "0")
@@ -821,11 +1073,33 @@ class _StubDnsServer:
 
 
 @pytest.fixture(scope="session")
+def lan_interface(smoke_vm: SmokeVM, client_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Gate on civm being connected so the pfSense LAN link has carrier, then yield the VM.
+
+    In the two-VM topology the LAN (net2) is a baked QEMU socket crossover between
+    pfSense and civm — 192.168.1.1/24 on pfSense, 192.168.1.10 on civm (static DHCP
+    lease keyed by ``SMOKE_CLIENT_MAC_ADDRESS``). No VLAN provisioning is needed: the
+    LAN interface is configured in the image and is live once both VMs are booted and
+    the socket link is connected.
+
+    Depending on ``client_vm`` guarantees civm is up and its data NIC is connected
+    (the QEMU socket CONNECTOR has joined the pfSense LISTENER) before any test that
+    needs a LAN client runs. Yields the pfSense ``SmokeVM`` object so callers use the
+    same reference they always have.
+
+    Inherits both fixtures' skip behaviour: if either ``smoke_vm`` or ``client_vm``
+    skips (no image, no KVM, no MAC), this fixture is never entered.
+    """
+    yield smoke_vm
+
+
+@pytest.fixture(scope="session")
 def stub_dns(smoke_vm: SmokeVM) -> Iterator[_StubDnsServer]:
     """Run the stub DNS upstream and record its port on the VM object.
 
-    Reachable by the guest at 10.0.2.2:<port> via SLIRP (survives the egress
-    block, same as mock_feeds). helpers.configure_upstream() points Unbound here.
+    Reachable by the guest at 10.10.0.2:<port> via the WAN SLIRP alias (survives
+    the egress block, same as mock_feeds). helpers.configure_upstream() points
+    Unbound here.
     """
     server = _StubDnsServer()
     server.start()
@@ -843,8 +1117,8 @@ def mock_feeds(smoke_vm: SmokeVM) -> Iterator[_MockFeedServer]:
 
     Hermeticity note (ADR §2): the egress block is sequenced pull -> block ->
     run and is wired by Phase 6 (the workflow blocks the runner's outbound
-    after the GHCR pull). SLIRP-internal ``10.0.2.2`` feeds survive the block,
-    so this server stays reachable; do NOT assume real internet egress.
+    after the GHCR pull). WAN SLIRP-internal ``10.10.0.2`` feeds survive the
+    block, so this server stays reachable; do NOT assume real internet egress.
     """
     FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
     server = _MockFeedServer(FIXTURES_DIR)
@@ -863,8 +1137,8 @@ def webhook_sink(smoke_vm: SmokeVM) -> Iterator[_MockCallbackSink]:
 
     FUNCTION-scoped for per-test isolation: each case gets a fresh sink (empty
     callback list, its own ephemeral port). Reachable from the guest at
-    ``sink.guest_url(path)`` (``http://10.0.2.2:<port><path>``) via the SLIRP host
-    alias — the same path the mock-feed server rides, so it survives the egress
+    ``sink.guest_url(path)`` (``http://10.10.0.2:<port><path>``) via the WAN SLIRP
+    host alias — the same path the mock-feed server rides, so it survives the egress
     block. Shut down on teardown.
     """
     server = _MockCallbackSink()
@@ -958,6 +1232,10 @@ def _dump_vm_on_failure(request: pytest.FixtureRequest) -> Iterator[None]:
             print(f"  {entry['client']:>15}  {entry['type']:<5} {entry['name']}")
         print("========== END STUB DNS UPSTREAM ==========")
     vm = request.node.funcargs.get("deployed_vm") or request.node.funcargs.get("smoke_vm")
+    # Some deployed_vm fixtures yield a (pfSense, civm) tuple in the two-VM topology;
+    # dump_diagnostics wants the pfSense SmokeVM, so unwrap to the first element.
+    if isinstance(vm, tuple):
+        vm = vm[0] if vm else None
     if vm is None:
         return
     from . import helpers  # local import: helpers imports from conftest (avoid cycle)

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -89,9 +89,10 @@ STUB_DNS_AAAA = stub_responses.STUB_DNS_AAAA  # RFC 3849 documentation range
 # Hard readiness ceiling; wait_ready.sh polls (no fixed sleep) up to this.
 DEFAULT_BOOT_TIMEOUT = int(os.environ.get("SMOKE_BOOT_TIMEOUT", "300"))
 
-# civm client VM ssh host-forward port (host -> civm:22). Matches boot_vm.sh
-# SMOKE_CLIENT_SSH_HOSTPORT default.
-DEFAULT_CLIENT_SSH_PORT = 2223  # host -> civm 22
+# civm client VM ssh host-forward port (host -> civm:22). Honour the same
+# SMOKE_CLIENT_SSH_HOSTPORT override boot_vm.sh reads (default 2223), so a custom
+# host port reaches the client instead of a hardcoded 2223.
+DEFAULT_CLIENT_SSH_PORT = int(os.environ.get("SMOKE_CLIENT_SSH_HOSTPORT", "2223"))  # host -> civm 22
 
 # The address civm uses to reach pfSense (pfSense LAN side of the socket crossover).
 PFSENSE_LAN_IP = "192.168.1.1"  # pfSense LAN IP baked in the two-VM image

--- a/tests/smoke/fixtures/README.md
+++ b/tests/smoke/fixtures/README.md
@@ -2,7 +2,7 @@
 
 Inert sample feed bodies served to the live pfSense smoke VM by `_MockFeedServer`
 (`tests/smoke/conftest.py`, the `mock_feeds` fixture). Each file is the raw body
-`curl` fetches; the guest reaches it at `http://10.0.2.2:<port>/<filename>` over
+`curl` fetches; the guest reaches it at `http://10.10.0.2:<port>/<filename>` over
 SLIRP. **Phase 4 authors these fixtures only** — Phase 5 registers them on an
 `IpCase`/`DnsblCase`, runs Force Update, and asserts the load on the box.
 

--- a/tests/smoke/fixtures/dnsbl_abp.txt
+++ b/tests/smoke/fixtures/dnsbl_abp.txt
@@ -6,7 +6,7 @@
 ! a name that is also '||'-blocked resolves). uuid-style '.com' names ONLY
 ! (smoke-domain rule: never RFC-6761 / HSTS-preload).
 !
-! Served by mock_feeds at http://10.0.2.2:<port>/dnsbl_abp.txt
+! Served by mock_feeds at http://10.10.0.2:<port>/dnsbl_abp.txt
 !
 ! Phase 5 asserts (dns_probe block-shape on the box):
 !   MEMBER (||  -> must BLOCK):                      uuid-22f166f56cca.com

--- a/tests/smoke/fixtures/dnsbl_hosts.txt
+++ b/tests/smoke/fixtures/dnsbl_hosts.txt
@@ -5,7 +5,7 @@
 # A full-line '#' comment and blank lines are dropped.
 # uuid-style '.com' names ONLY (smoke-domain rule, see dnsbl_plain.txt).
 #
-# Served by mock_feeds at http://10.0.2.2:<port>/dnsbl_hosts.txt
+# Served by mock_feeds at http://10.10.0.2:<port>/dnsbl_hosts.txt
 #
 # Phase 5 asserts (dns_probe block-shape on the box):
 #   MEMBER (must BLOCK - VIP/NULL per list logging):  uuid-947e69114606.com

--- a/tests/smoke/fixtures/dnsbl_plain.txt
+++ b/tests/smoke/fixtures/dnsbl_plain.txt
@@ -5,7 +5,7 @@
 # uuid-style '.com' names ONLY (smoke-domain rule: never RFC-6761 .test/.example/
 # .invalid -> Unbound built-in local-zones shadow them; never HSTS-preload names).
 #
-# Served by mock_feeds at http://10.0.2.2:<port>/dnsbl_plain.txt
+# Served by mock_feeds at http://10.10.0.2:<port>/dnsbl_plain.txt
 #
 # Phase 5 asserts (dns_probe block-shape on the box):
 #   MEMBER (must BLOCK - VIP/NULL per list logging):  uuid-a344db4286a4.com

--- a/tests/smoke/fixtures/ip_ipv6.txt
+++ b/tests/smoke/fixtures/ip_ipv6.txt
@@ -4,7 +4,7 @@
 # table; an inline '#' truncates the line, and a full-line '#'/blank is skipped.
 # RFC 3849 documentation prefix (2001:db8::/32) ONLY; never a real host.
 #
-# Served by mock_feeds at http://10.0.2.2:<port>/ip_ipv6.txt
+# Served by mock_feeds at http://10.10.0.2:<port>/ip_ipv6.txt
 #
 # Phase 5 asserts (pfctl_table_members(pfB_<alias>_v6), compare by value, ::==::0):
 #   MEMBER (single host):              2001:db8::1

--- a/tests/smoke/fixtures/ip_plain_cidr.txt
+++ b/tests/smoke/fixtures/ip_plain_cidr.txt
@@ -4,7 +4,7 @@
 # (sanitize_ipaddr + validate_ipv4) into the pfB_<alias>_v4 table.
 # RFC 5737 documentation ranges ONLY (TEST-NET-2/3); never a real/abusable host.
 #
-# Served by mock_feeds at http://10.0.2.2:<port>/ip_plain_cidr.txt
+# Served by mock_feeds at http://10.10.0.2:<port>/ip_plain_cidr.txt
 #
 # Phase 5 asserts (pfctl_table_members(pfB_<alias>_v4)):
 #   MEMBER (must be in the table):     203.0.113.5      (the plain host)

--- a/tests/smoke/fixtures/ip_range.txt
+++ b/tests/smoke/fixtures/ip_range.txt
@@ -4,7 +4,7 @@
 # blocks that exactly covers a..b; those CIDRs populate the pfB_<alias>_v4 table.
 # RFC 5737 documentation range (TEST-NET-3) ONLY; never a real/abusable host.
 #
-# Served by mock_feeds at http://10.0.2.2:<port>/ip_range.txt
+# Served by mock_feeds at http://10.10.0.2:<port>/ip_range.txt
 #
 # 198.51.100.10-198.51.100.20 expands to 10/31,12/30,16/30,20/32 -> covers exactly
 # .10 through .20 inclusive.

--- a/tests/smoke/fixtures/sample_ip_feed.txt
+++ b/tests/smoke/fixtures/sample_ip_feed.txt
@@ -1,7 +1,7 @@
 # Sample IP feed fixture (ADR-04 smoke harness).
 # One CIDR/host per line; '#' comments and blank lines are ignored by
 # pfBlockerNG. The mock feed server (tests/smoke/conftest.py :: mock_feeds)
-# serves this at http://10.0.2.2:<port>/sample_ip_feed.txt for the guest.
+# serves this at http://10.10.0.2:<port>/sample_ip_feed.txt for the guest.
 # Documentation/test ranges only (RFC 5737 / RFC 3849); never real targets.
 # Phase 5 adds the real per-case feeds + assertions; this is a placeholder so
 # the fixtures/ directory is tracked and the server has something to serve.

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -436,7 +436,10 @@ def pf_state_dump(vm: SmokeVM, *, timeout: float = 30.0) -> str:
     meta = vm.ssh(
         "/bin/sh",
         "-c",
-        "ls -l --time-style=+%s /tmp/rules.debug 2>&1; date +%s; wc -l /tmp/rules.debug",
+        # BSD stat (pfSense/FreeBSD): %m = mtime epoch, %z = size. GNU `ls
+        # --time-style` is not portable here ('Illegal option'). `now=` is the
+        # epoch at capture so the mtime can be read as fresh-vs-stale.
+        "stat -f 'mtime=%m size=%z' /tmp/rules.debug 2>&1; echo now=$(date +%s); wc -l /tmp/rules.debug",
         timeout=timeout,
     )
     dbg = vm.ssh(

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -44,6 +44,7 @@ import ipaddress
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import time
 import uuid
@@ -378,6 +379,106 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
         )
 
 
+def pkg_installed(vm: SmokeVM, *, timeout: float = 30.0) -> bool:
+    """True iff the pfBlockerNG package files are present on the guest.
+
+    A test that uninstalls the package (``pkg delete``) removes
+    ``/usr/local/www/pfblockerng/pfblockerng.php``; a later test in the same
+    (module-scoped) deploy then fails to reload. Used by the redeploy guard to
+    detect that state. Probes the CLI entrypoint file, not pkg's DB, so it is a
+    cheap single SSH round-trip.
+    """
+    result = vm.ssh("/bin/test", "-f", PFB_CLI, timeout=timeout)
+    return result.returncode == 0
+
+
+def pf_state_dump(vm: SmokeVM, *, timeout: float = 30.0) -> str:
+    """Return a layered pf snapshot that localises where a bypass rule is lost.
+
+    A redirect/DoT rule can vanish at three stages: config.xml (the sync wrote
+    it) -> /tmp/rules.debug (filter_configure emitted it) -> live pf (pfctl
+    loaded it). This dumps all three so the pytest log shows the exact stage:
+
+      * CONFIG  — count of pfB_DNS_Redirect_*/pfB_DoT_Block_* rows in
+                  config.xml nat/rule + filter/rule (the sync's output);
+      * RULES.DEBUG — port-53/853 lines in the generated ruleset
+                  (what filter_configure produced for pf);
+      * LIVE PF — rdr (``pfctl -sn``) + block (``pfctl -sr``) 53/853 lines.
+
+    A rule in CONFIG but absent from RULES.DEBUG => the pfSense rule generator
+    dropped it (rule-shape problem). Present in RULES.DEBUG but absent from
+    LIVE PF => a pfctl load error. Absent from CONFIG => the sync did not run.
+    """
+    # CONFIG: enumerate the pfB redirect/DoT rows (descr|type|interface|ipprotocol)
+    # through pfSsh.php (fully bootstrapped — a bare `php -r` cannot read config).
+    snippet = (
+        "$o=array();\n"
+        "foreach(config_get_path('nat/rule',array()) as $r){\n"
+        "  $d=(string)($r['descr']??'');\n"
+        "  if(strpos($d,'pfB_DNS_Redirect_')===0){\n"
+        "    $o[]='NAT '.$d.'|'.($r['interface']??'').'|'.($r['ipprotocol']??'').'|tgt='.($r['target']??'');}\n"
+        "}\n"
+        "foreach(config_get_path('filter/rule',array()) as $r){\n"
+        "  $d=(string)($r['descr']??'');\n"
+        "  if(strpos($d,'pfB_DNS_Redirect_')===0||strpos($d,'pfB_DoT_Block_')===0){\n"
+        "    $o[]='FILT '.$d.'|'.($r['type']??'').'|'.($r['interface']??'').'|'.($r['ipprotocol']??'')\n"
+        "      .'|disabled='.(isset($r['disabled'])?'1':'0').'|tracker='.($r['tracker']??'-');}\n"
+        "}\n"
+        "echo '<<CFG>>'.implode(' ## ',$o).'<<END>>';"
+    )
+    cfg_res = php_eval(vm, snippet, timeout=timeout)
+    cfg = ""
+    if "<<CFG>>" in cfg_res.stdout and "<<END>>" in cfg_res.stdout:
+        cfg = cfg_res.stdout.split("<<CFG>>", 1)[1].split("<<END>>", 1)[0]
+    # rules.debug freshness (mtime + total lines) tells us whether filter_configure()
+    # actually re-ran this reload, plus the LAN/rdr/self lines so we see if the rule
+    # was emitted at all.
+    meta = vm.ssh(
+        "/bin/sh",
+        "-c",
+        "ls -l --time-style=+%s /tmp/rules.debug 2>&1; date +%s; wc -l /tmp/rules.debug",
+        timeout=timeout,
+    )
+    dbg = vm.ssh(
+        "/usr/bin/grep",
+        "-nE",
+        "Redirect|DoT|rdr|\\(self\\)|port (= )?(53|853)|on \\$LAN|on \\$OPT",
+        "/tmp/rules.debug",
+        timeout=timeout,
+    )
+    sn = vm.ssh(PFCTL, "-sn", timeout=timeout)
+    sr = vm.ssh(PFCTL, "-sr", timeout=timeout)
+    rdr = [ln for ln in sn.stdout.splitlines() if "rdr" in ln and ("53" in ln or "853" in ln)]
+    blk = [ln for ln in sr.stdout.splitlines() if "block" in ln and ("53" in ln or "853" in ln)]
+    dbg_lines = [ln for ln in dbg.stdout.splitlines() if ln.strip()]
+    return (
+        f"[CONFIG rows] {cfg.strip()}\n"
+        f"[rules.debug meta] {' '.join(meta.stdout.split())}\n"
+        f"[RULES.DEBUG lan/rdr/self/53/853: {len(dbg_lines)}] " + " || ".join(dbg_lines[:12]) + "\n"
+        f"[LIVE PF rdr: {len(rdr)}] " + " || ".join(rdr[:6]) + "\n"
+        f"[LIVE PF block: {len(blk)}] " + " || ".join(blk[:6])
+    )
+
+
+def deinstall_debug(vm: SmokeVM, *, timeout: float = 30.0) -> str:
+    """Return deinstall-sweep evidence for the uninstall-survival failures.
+
+    After ``pkg delete`` the pfBlockerNG log persists at /var/log/pfblockerng.
+    Surfaces the deinstall/sweep lines so a 'rule survived uninstall' failure
+    shows whether pfblockerng_php_pre_deinstall_command + pfb_fwobj_sweep ran at
+    all (vs ran but missed the rows). Best-effort; tolerates a missing log.
+    """
+    log = vm.ssh(
+        "/usr/bin/grep",
+        "-iE",
+        "deinstall|sweep|orphan firewall",
+        "/var/log/pfblockerng/pfblockerng.log",
+        timeout=timeout,
+    )
+    lines = [ln for ln in log.stdout.splitlines() if ln.strip()]
+    return f"[deinstall/sweep log lines: {len(lines)}]\n" + "\n".join(lines[-12:])
+
+
 # --------------------------------------------------------------------------- #
 # Local feed file — write a list directly under /var/db/pfblockerng/<name> and
 # use its PATH as the source (pfBlockerNG accepts a local path in a source's URL
@@ -497,7 +598,7 @@ def assert_hsts_loaded(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> None
 # SLIRP NAT — so blocking the runner's egress before the package is installed
 # hangs the install. Guarded by SMOKE_BLOCK_EGRESS (CI sets it) so a local
 # `pytest -m smoke` never touches the dev machine's firewall. Loopback stays up
-# (the mock feed server is reached via SLIRP 10.0.2.2 -> runner 127.0.0.1) and
+# (the mock feed server is reached via SLIRP 10.10.0.2 -> runner 127.0.0.1) and
 # established flows (the live SSH session) are kept.
 
 
@@ -899,10 +1000,10 @@ def set_feed_internal_allowlist(vm: SmokeVM, value: str, *, timeout: float = 60.
     The feed-host filter (``pfb_feed_internal_filter``, default-ON SSRF guard) rejects a feed
     whose host resolves to an internal/private address — but EXEMPTS any IP covered by this
     allowlist (IPs/CIDRs, whitespace/comma-separated, stored base64-encoded; ``pfb_feed_internal_allowlist()``
-    parses it, ``pfb_ip_in_allowlist()`` matches by CIDR). The smoke mock feed server is the SLIRP
-    host alias ``10.0.2.2`` (RFC1918, and NOT the box's own IP, so the self-exemption does not
-    apply), so the HTTP-feed smoke allowlists the SLIRP test network ``10.0.2.0/24`` — keeping the
-    filter ON while letting the mock fetch through.
+    parses it, ``pfb_ip_in_allowlist()`` matches by CIDR). The smoke mock feed server is the WAN
+    SLIRP host alias ``10.10.0.2`` (RFC1918, and NOT the box's own IP, so the self-exemption does
+    not apply), so the HTTP-feed smoke allowlists the WAN SLIRP test network ``10.10.0.0/16`` —
+    keeping the filter ON while letting the mock fetch through.
 
     The field is stored base64-encoded (the pfBlockerNG textarea convention; the reader
     base64_decodes it), so ``value`` is encoded here before it is written.
@@ -923,22 +1024,22 @@ def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     """Point pfSense at the runner-side mock via its REAL System-DNS path (no custom zone).
 
     The realistic wiring: pfSense forwards (forwarding mode) to its System DNS server
-    ``10.0.2.2`` — QEMU/libslirp's host alias — which NATs ``guest->10.0.2.2:53`` straight
-    to the mock on the runner's loopback (``127.0.0.1:53``), port-preserving. This is the
-    SAME host-alias path the in-runner mock-feed HTTP server already rides
-    (``http://10.0.2.2:<port>/...``), so the chain is:
+    ``10.10.0.2`` — QEMU/libslirp's WAN host alias — which NATs ``guest->10.10.0.2:53``
+    straight to the mock on the runner's loopback (``127.0.0.1:53``), port-preserving.
+    This is the SAME WAN host-alias path the in-runner mock-feed HTTP server already rides
+    (``http://10.10.0.2:<port>/...``), so the chain is:
 
-        guest Unbound --(forward)--> 10.0.2.2:53 (SLIRP host alias) --(NAT)--> 127.0.0.1:53 (mock)
+        guest Unbound --(forward)--> 10.10.0.2:53 (WAN SLIRP alias) --(NAT)--> 127.0.0.1:53 (mock)
 
     Crucially this needs NO ``/etc/resolv.conf`` override on the runner (the SLIRP virtual
-    DNS at 10.0.2.3 would read resolv.conf; the 10.0.2.2 host alias does not) — the runner's
+    DNS at 10.10.0.3 would read resolv.conf; the 10.10.0.2 host alias does not) — the runner's
     own resolver is left fully intact, so nothing on the host loses DNS during the run and
     there is no teardown to restore. No custom ``forward-zone`` and no guestfwd either. The
     mock records every query (``stub.received(...)``), so blocking is read off the upstream.
     Loopback survives the per-case egress block (``-o lo ACCEPT``), so it stays hermetic.
 
     Config set (idempotent; written + ``services_unbound_configure``):
-      * ``system/dnsserver = [10.0.2.2]`` and DHCP-override OFF — so ``10.0.2.2`` is the
+      * ``system/dnsserver = [10.10.0.2]`` and DHCP-override OFF — so ``10.10.0.2`` is the
         SOLE forwarder (drops the baked image's dead 1.1.1.1/1.0.0.1, which egress-block
         makes unreachable and would only add forward timeouts).
       * ``unbound/forwarding = on`` — forward to the System DNS server.
@@ -949,7 +1050,7 @@ def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     snippet = (
         "$s = config_get_path('system', array());\n"
         f"$s['dnsserver'] = array({_php_str(GUEST_TO_HOST_ALIAS)});\n"
-        # Disable 'Allow DNS server list to be overridden by DHCP' so only 10.0.2.2 is used.
+        # Disable 'Allow DNS server list to be overridden by DHCP' so only 10.10.0.2 is used.
         "unset($s['dnsallowoverride']);\n"
         "config_set_path('system', $s);\n"
         "$u = config_get_path('unbound', array());\n"
@@ -970,7 +1071,7 @@ def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     wait_unbound_ready(vm)
     # READINESS + RELAY SELF-CHECK (fail fast, don't let the matrix hang): resolve one
     # throwaway name on-box. With the mock as upstream it MUST come back as the sentinel
-    # (pfSense -> 10.0.2.2 SLIRP host alias -> runner 127.0.0.1:53 mock). The FIRST response
+    # (pfSense -> 10.10.0.2 WAN SLIRP alias -> runner 127.0.0.1:53 mock). The FIRST response
     # is authoritative; if it isn't the sentinel, the relay isn't wired — raise NOW with
     # the answer, rather than letting every per-case forward time out (~300s each).
     probe = unique_domain("sysdnsselfcheck")
@@ -978,8 +1079,8 @@ def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     if not resolves_to(ans, STUB_DNS_A):
         raise RuntimeError(
             f"System-DNS relay self-check FAILED: {probe} -> {ans} (expected the mock sentinel "
-            f"{STUB_DNS_A}). pfSense's 10.0.2.2 host alias -> runner 127.0.0.1:53 mock path is not "
-            f"working (libslirp not NATing the host alias to the mock, or unbound not forwarding)."
+            f"{STUB_DNS_A}). pfSense's 10.10.0.2 WAN alias -> runner 127.0.0.1:53 mock path is not "
+            f"working (libslirp not NATing the WAN host alias to the mock, or unbound not forwarding)."
         )
 
 
@@ -1035,14 +1136,14 @@ def use_stub_for_safesearch(vm: SmokeVM, forwarding_on: bool, *, timeout: float 
     the stub wiring:
 
     ``forwarding_on=True`` (FORWARDING mode): delegates to the same config as
-    :func:`use_system_dns_upstream` — sets ``system/dnsserver = [10.0.2.2]``,
+    :func:`use_system_dns_upstream` — sets ``system/dnsserver = [10.10.0.2]``,
     ``unbound/forwarding = on``, clears ``dnssec`` and ``custom_options``.
-    Queries forward to ``10.0.2.2`` (the SLIRP host alias), which NATs
-    ``guest->10.0.2.2:53`` to the stub on the runner's loopback.
+    Queries forward to ``10.10.0.2`` (the WAN SLIRP host alias), which NATs
+    ``guest->10.10.0.2:53`` to the stub on the runner's loopback.
 
     ``forwarding_on=False`` (RECURSIVE mode): keeps ``unbound/forwarding`` UNSET
     (Unbound recurses normally) but injects a catch-all ``forward-zone`` in
-    ``unbound/custom_options`` pointing every query at ``10.0.2.2``, so the stub
+    ``unbound/custom_options`` pointing every query at ``10.10.0.2``, so the stub
     still answers all queries while Unbound operates in recursive mode.
     ``custom_options`` is stored base64-encoded in ``config.xml`` (the pfBlockerNG
     textarea convention: the GUI base64-encodes on save, the renderer decodes on
@@ -1068,7 +1169,7 @@ def use_stub_for_safesearch(vm: SmokeVM, forwarding_on: bool, *, timeout: float 
     # via a catch-all forward-zone in custom_options.  pfSense stores
     # custom_options base64-encoded (pfbng_text_area_decode / base64_encode on
     # save), so encode before writing.
-    forward_zone = 'forward-zone:\n    name: "."\n    forward-addr: 10.0.2.2\n'
+    forward_zone = f'forward-zone:\n    name: "."\n    forward-addr: {GUEST_TO_HOST_ALIAS}\n'
     encoded = base64.b64encode(forward_zone.encode()).decode()
     snippet = (
         "$s = config_get_path('system', array());\n"
@@ -1100,7 +1201,7 @@ def use_stub_for_safesearch(vm: SmokeVM, forwarding_on: bool, *, timeout: float 
         raise RuntimeError(
             f"SafeSearch stub relay self-check FAILED (recursive mode): "
             f"{probe} -> {ans} (expected sentinel {STUB_DNS_A}). "
-            f"The catch-all forward-zone -> 10.0.2.2 -> runner 127.0.0.1:53 path is not working."
+            f"The catch-all forward-zone -> 10.10.0.2 -> runner 127.0.0.1:53 path is not working."
         )
 
 
@@ -2187,7 +2288,7 @@ def unbound_access_control(vm: SmokeVM, *, timeout: float = 30.0) -> set[str]:
 
     This is the authoritative source (includes resolved, live state) — not a
     grep of one generated file. Returns the normalised set of access-control
-    entries (e.g. ``{"10.0.2.0/24 allow", ...}``).
+    entries (e.g. ``{"10.10.0.0/24 allow", ...}``).
     """
     result = vm.ssh(
         "/usr/local/sbin/unbound-control",
@@ -2632,6 +2733,187 @@ def dns_probe_until(
     raise RuntimeError(
         f"dns_probe_until({name}, {rtype}) predicate never held within {timeout}s "
         f"(last answer: {last}) — the zero-downtime swap decision did not apply in budget"
+    )
+
+
+def _parse_dig(output: str, rtype: str) -> DnsAnswer:
+    """Parse ``dig`` text output into an rcode + the records of ``rtype``.
+
+    Mirrors :func:`_parse_drill` for the Debian client VM where ``dig`` (from
+    bind-tools) is the default query tool. ``dig`` prints the status token in
+    the header line::
+
+        ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 12345
+
+    and the answer section as::
+
+        ;; ANSWER SECTION:
+        name. ttl IN <type> <rdata>
+
+    Extracts rcode from the ``status:`` token and the rdata of records whose
+    type matches ``rtype``. Stops collecting at the first blank line or ``;;``
+    comment after the ANSWER header, identical to :func:`_parse_drill`'s stop
+    condition.
+    """
+    rcode = "UNKNOWN"
+    records: list[str] = []
+    in_answer = False
+    for line in output.splitlines():
+        # Header line: ";; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: ..."
+        if "status:" in line:
+            m = re.search(r"status:\s*([A-Z]+)", line)
+            if m:
+                rcode = m.group(1)
+        if line.startswith(";; ANSWER SECTION"):
+            in_answer = True
+            continue
+        if in_answer:
+            stripped = line.strip()
+            if not stripped or line.startswith(";;"):
+                in_answer = False
+                continue
+            # "<name>. <ttl> IN <type> <rdata>"
+            parts = stripped.split()
+            if len(parts) >= 5 and parts[3] == rtype:
+                records.append(parts[4])
+    return DnsAnswer(rcode=rcode, records=records)
+
+
+def dns_probe_client(
+    client_vm: SmokeVM,
+    name: str,
+    rtype: str = "A",
+    *,
+    server: str = "192.168.1.1",
+    timeout: float = 30.0,
+    attempts: int = 3,
+    delay: float = 5.0,
+) -> DnsAnswer:
+    """Resolve ``(name, rtype)`` FROM civm via ``dig`` over SSH, querying pfSense's LAN IP.
+
+    The realistic behind-the-firewall DNS path: civm runs ``dig`` on 192.168.1.1
+    (pfSense LAN, ``PFSENSE_LAN_IP``) over its data NIC (net1, the socket crossover).
+    This is the probe that proves pfBlockerNG's DNSBL actually affects traffic from a
+    real LAN client — not just on-box queries.
+
+    Probe semantics: identical to :func:`dns_probe` — the first parsed DNS response is
+    authoritative (caller has already ensured Unbound is ready). Retry only when ``dig``
+    produced NO DNS response at all (e.g. the LAN socket link is still settling), bounded
+    at ``attempts`` × ``delay`` (~5 s). A response that came back but contains an
+    unexpected answer is returned as-is for the caller to assert — we never re-query
+    hoping for a "better" answer.
+
+    ``server`` is the resolver civm queries — defaults to ``PFSENSE_LAN_IP`` (192.168.1.1).
+    Override to probe a different resolver (e.g. a secondary DNS).
+
+    Caller MUST use a non-RFC-6761, non-HSTS-preload domain (see :func:`unique_domain`)
+    for the same reasons as :func:`dns_probe`.
+    """
+    cmd = f"dig +tries=1 +time=5 {shlex.quote(rtype)} {shlex.quote(name)} @{shlex.quote(server)}"
+    last = ""
+    for attempt in range(attempts):
+        result = client_vm.ssh(cmd, timeout=timeout)
+        if "status:" in result.stdout:
+            # dig returned a DNS response — authoritative; return as-is.
+            return _parse_dig(result.stdout, rtype)
+        # No DNS response (dig produced no status line) — only here do we retry.
+        last = f"rc={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
+        if attempt < attempts - 1:
+            time.sleep(delay)
+    raise RuntimeError(
+        f"dns_probe_client({name}, {rtype}) got no dig answer from {server} after {attempts} attempts: {last}"
+    )
+
+
+def dns_probe_client_until(
+    client_vm: SmokeVM,
+    name: str,
+    predicate: Callable[[DnsAnswer], bool],
+    rtype: str = "A",
+    *,
+    server: str = "192.168.1.1",
+    timeout: float = 60.0,
+    interval: float = 3.0,
+) -> DnsAnswer:
+    """Poll ``dig @server <name> <rtype>`` from civm until ``predicate(answer)`` holds; raise on timeout.
+
+    The client-side analog of :func:`dns_probe_until` — for the zero-downtime swap
+    transition (ADR-10) observed from a real LAN client. Polls with bounded backoff and
+    raises on timeout (a genuine failure, never a silent infinite loop).
+
+    Use ONLY for swap/toggle transitions. Keep :func:`dns_probe_client` for steady-state
+    reads. Caller MUST pass a non-RFC-6761, non-HSTS-preload name (see :func:`unique_domain`).
+    """
+    deadline = time.time() + timeout
+    last: DnsAnswer | None = None
+    while time.time() < deadline:
+        last = dns_probe_client(client_vm, name, rtype, server=server, timeout=15.0, attempts=2, delay=2.0)
+        if predicate(last):
+            return last
+        time.sleep(interval)
+    raise RuntimeError(
+        f"dns_probe_client_until({name}, {rtype}) predicate never held within {timeout}s "
+        f"(last answer: {last}) — the zero-downtime swap decision did not apply in budget"
+    )
+
+
+def assert_link_health(
+    client_vm: SmokeVM,
+    vm: SmokeVM,
+    *,
+    control_name: str,
+    timeout: float = 60.0,
+) -> None:
+    """Assert the pfSense LAN → civm link is healthy by probing a known-good control name.
+
+    Polls until civm can get ANY DNS response (any rcode) from pfSense's LAN IP
+    (192.168.1.1 / ``PFSENSE_LAN_IP``) for ``control_name``. On timeout, runs an
+    ON-BOX :func:`dns_probe` as a differentiator to localise the fault:
+
+    * If the on-box probe answers: pfSense is healthy — the fault is in the civm/LAN
+      link (QEMU socket crossover not carrying traffic, civm data NIC not configured,
+      or pfSense DHCP not handing out the static lease).
+    * If the on-box probe also fails: pfSense itself is not answering DNS — the fault
+      is in Unbound or pfBlockerNG, not the link.
+
+    ``control_name`` MUST resolve to a real DNS answer on-box (use a name that is in
+    Unbound's local data or that the stub upstream will answer). Typically the baked
+    control name from :func:`tests.smoke.conftest.expected_control_answer`.
+
+    This is a one-time link gate — call it at the start of any test that relies on
+    the client path, not in a polling loop.
+    """
+    from .conftest import PFSENSE_LAN_IP  # local import; avoids a circular reference at module level
+
+    deadline = time.time() + timeout
+    last_client_error = ""
+    while time.time() < deadline:
+        try:
+            answer = dns_probe_client(
+                client_vm, control_name, server=PFSENSE_LAN_IP, timeout=10.0, attempts=1, delay=0.0
+            )
+            if answer.rcode != "UNKNOWN":
+                # Any real DNS response from pfSense means the link is up.
+                return
+        except RuntimeError as exc:
+            last_client_error = str(exc)
+        time.sleep(3.0)
+
+    # Timeout — run on-box differentiator.
+    try:
+        on_box = dns_probe(vm, control_name, timeout=10.0, attempts=2, delay=2.0)
+        on_box_summary = f"on-box answered: {on_box}"
+        fault = "civm/LAN link (pfSense Unbound is healthy on-box but civm cannot reach it)"
+    except RuntimeError as exc:
+        on_box_summary = f"on-box also failed: {exc}"
+        fault = "pfSense Unbound or pfBlockerNG (on-box probe also failed)"
+
+    raise RuntimeError(
+        f"assert_link_health: civm could not get a DNS response from {PFSENSE_LAN_IP} "
+        f"for {control_name!r} within {timeout}s. "
+        f"Fault localised to: {fault}. "
+        f"On-box differentiator — {on_box_summary}. "
+        f"Last client error: {last_client_error}"
     )
 
 
@@ -3202,6 +3484,10 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
         + var_log_capture
         + '/sbin/dmesg > "$D/dmesg.txt" 2>&1; cp /var/run/dmesg.boot "$D/dmesg.boot" 2>/dev/null; '
         '/sbin/pfctl -sa > "$D/pfctl_sa.txt" 2>&1; '
+        # The generated pf ruleset — ground truth for whether filter_configure()
+        # emitted a rule (a config row that never reaches here was dropped by the
+        # pfSense rule generator; ADR-36/37 DNS-bypass debugging).
+        'cp /tmp/rules.debug "$D/rules.debug" 2>/dev/null; '
         '/sbin/ifconfig -a > "$D/ifconfig.txt" 2>&1; '
         '/usr/bin/sockstat > "$D/sockstat.txt" 2>&1; /usr/bin/netstat -rn > "$D/netstat_rn.txt" 2>&1; '
         'cp /var/unbound/*.conf /var/unbound/*.ini "$D/unbound/" 2>/dev/null; '
@@ -3248,6 +3534,19 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
             print(f"[smoke] collected full guest diagnostics -> {dest_dir}/pfb_smoke_diag.tgz")
         else:
             print(f"[smoke] guest-diagnostics scp failed (non-fatal): {result.stderr!r}")
+        # Surface the VM SERIAL CONSOLE in the uploaded artifact. boot_vm.sh runs
+        # QEMU with ``-serial stdio`` into this log, but it lives under the runner
+        # tmp dir — OUTSIDE the workflow's artifact globs — so a TEST failure (as
+        # opposed to a boot failure, which _capture_boot_failure already snapshots)
+        # never carried it. Copy it into dest_dir named ``vm-*.log`` so BOTH the
+        # ``**/vm*.log`` upload glob picks it up AND the Plus secret-scrub step
+        # (``find . -name 'vm*.log'``) redacts it. Best-effort; never fatal.
+        if vm.log_path and os.path.exists(vm.log_path):
+            try:
+                shutil.copy(vm.log_path, os.path.join(dest_dir, "vm-serial.log"))
+                print(f"[smoke] copied VM serial console -> {dest_dir}/vm-serial.log")
+            except OSError as exc:
+                print(f"[smoke] vm serial-console copy failed (non-fatal): {exc!r}")
     except Exception as exc:  # noqa: BLE001
         print(f"[smoke] collect_host_diagnostics failed (non-fatal): {exc!r}")
 

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -74,8 +74,16 @@ _EXCEPTION_ALIAS = "DNS_Exceptions_Test"
 
 
 @pytest.fixture(scope="module")
-def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+def deployed_vm(  # noqa: ARG001
+    smoke_vm: SmokeVM,
+    stub_dns: _StubDnsServer,
+    lan_interface: SmokeVM,
+) -> Iterator[SmokeVM]:
     """Deploy the branch .pkg once for the dns_redirect module.
+
+    Depends on ``lan_interface`` to ensure a LAN VLAN subinterface is
+    provisioned before these tests run (the single-NIC smoke image boots with
+    no LAN assigned; DNS redirect tests create LAN-scoped NAT/VIP rules).
 
     Egress stays OPEN across reloads: ``pkg add`` pulls RUN_DEPENDS from the
     pfSense repo. ``ensure_dnsbl_vip`` gives DNSBL a sinkhole VIP (required for
@@ -411,7 +419,9 @@ def test_dns_redirect_enable_creates_nat_and_filter_rules(deployed_vm: SmokeVM, 
         )
 
         # THEN — pfctl -sn confirms the rdr rules are active.
-        assert _pfctl_sn_has_redir(vm, iface), f"pfctl -sn shows no rdr rule on {iface} for port 53 after enable"
+        assert _pfctl_sn_has_redir(vm, iface), (
+            f"pfctl -sn shows no rdr rule on {iface} for port 53 after enable\n" + h.pf_state_dump(vm)
+        )
 
     finally:
         _cleanup_redirect(vm)
@@ -746,7 +756,8 @@ def test_dns_redirect_uninstall_sweeps_owned_rules_preserves_user_nat(deployed_v
 
     # THEN — all pfB_DNS_Redirect_* entries are gone.
     assert _nat_redir_count(vm, _REDIR_DESCR_PFX) == 0, (
-        "pfB_DNS_Redirect_* nat/rule entries still present after uninstall — ADR-35/36 sweep did not run"
+        "pfB_DNS_Redirect_* nat/rule entries still present after uninstall — ADR-35/36 sweep did not run\n"
+        + h.deinstall_debug(vm)
     )
     assert _filter_redir_count(vm, _REDIR_DESCR_PFX) == 0, (
         "pfB_DNS_Redirect_* filter/rule entries still present after uninstall"

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -94,6 +94,22 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
         h.collect_host_diagnostics(smoke_vm)
 
 
+@pytest.fixture(autouse=True)
+def _ensure_pkg_installed(deployed_vm: SmokeVM) -> None:
+    """Redeploy the package if a prior test in this module uninstalled it.
+
+    The uninstall cases ``pkg delete`` the package mid-module; without this,
+    every subsequent test under the module-scoped ``deployed_vm`` would fail to
+    reload ('Could not open input file ... pfblockerng.php'). Cheap install-state
+    probe; redeploy + re-seed only when the package is actually missing.
+    """
+    if not h.pkg_installed(deployed_vm):
+        h.deploy(deployed_vm)
+        h.snapshot_unbound_conf(deployed_vm)
+        h.ensure_dnsbl_vip(deployed_vm)
+        h.use_system_dns_upstream(deployed_vm)
+
+
 @pytest.fixture(scope="module")
 def primary_iface(deployed_vm: SmokeVM) -> str:
     """Return the first discovered non-WAN interface short name.
@@ -373,7 +389,9 @@ def test_dot_doq_block_rule_appears_on_enable(deployed_vm: SmokeVM, primary_ifac
         )
 
         # THEN — pfctl -sr confirms the block rule is active.
-        assert _pfctl_sr_has_block_853(vm), "pfctl -sr shows no block rule for port 853 after enable"
+        assert _pfctl_sr_has_block_853(vm), (
+            "pfctl -sr shows no block rule for port 853 after enable\n" + h.pf_state_dump(vm)
+        )
 
     finally:
         _cleanup_dot_block(vm)
@@ -502,7 +520,8 @@ def test_user_filter_rule_survives_disable_and_uninstall(deployed_vm: SmokeVM, p
 
         # THEN — pfB rules gone; user rule survives; pfblockerng sections gone.
         assert not _filter_rule_present(vm, _DOT_BLOCK_DESCR_PFX + iface), (
-            f"pfB_DoT_Block_{iface} still present after uninstall — ADR-35/37 sweep did not run"
+            f"pfB_DoT_Block_{iface} still present after uninstall — ADR-35/37 sweep did not run\n"
+            + h.deinstall_debug(vm)
         )
         assert _filter_rule_present(vm, _USER_FILTER_DESCR), (
             "user filter rule was DELETED during uninstall — ADR-35 sweep incorrectly removed a user object"
@@ -689,7 +708,8 @@ def test_uninstall_sweep_removes_all_dot_block_rules(deployed_vm: SmokeVM, prima
 
     # THEN — all pfB_DoT_Block_* entries are gone.
     assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX) == 0, (
-        "pfB_DoT_Block_* filter/rule entries still present after uninstall — ADR-35/37 sweep did not run"
+        "pfB_DoT_Block_* filter/rule entries still present after uninstall — ADR-35/37 sweep did not run\n"
+        + h.deinstall_debug(vm)
     )
 
     # THEN — user filter rule survives.
@@ -748,7 +768,9 @@ def test_self_exempt_guard_in_pfctl_output(deployed_vm: SmokeVM, primary_iface: 
         h.reload(vm, "update")
 
         # THEN — pfctl -sr contains the block rule for port 853.
-        assert _pfctl_sr_has_block_853(vm), "pfctl -sr shows no block rule for port 853 after enable"
+        assert _pfctl_sr_has_block_853(vm), (
+            "pfctl -sr shows no block rule for port 853 after enable\n" + h.pf_state_dump(vm)
+        )
 
         # THEN — the rule carries the self-exempt guard ('!' + 'self' on the block line).
         assert _pfctl_sr_block_853_has_self_exempt(vm), (

--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -73,13 +73,13 @@ PASS_IP2 = "198.51.100.61"
 
 
 @pytest.fixture(scope="module")
-def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
+def deployed_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
     """Deploy the branch .pkg once for the ABP matrix (mirrors the ADR-04 matrix).
 
     Egress is managed per-case by ``CaseContext``; the DNSBL VIP is injected once
     (DNSBL force-disables itself without one). pfSense forwards to the runner-side mock
     via its real System-DNS path (``use_system_dns_upstream``: System DNS = the SLIRP
-    host alias 10.0.2.2, which libslirp NATs to the runner-loopback mock) so a not-blocked name resolves to
+    host alias 10.10.0.2, which libslirp NATs to the runner-loopback mock) so a not-blocked name resolves to
     a known answer AND is recorded on the mock. A full guest snapshot is collected on
     teardown for the workflow to upload.
     """
@@ -88,6 +88,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     h.deploy(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
+    h.assert_link_health(client_vm, smoke_vm, control_name=h.unique_domain())
     try:
         yield smoke_vm
     finally:
@@ -111,7 +112,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
 # --------------------------------------------------------------------------- #
 
 
-def test_abp_exception_unblocks(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_exception_unblocks(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """An ABP feed that blocks ``||base^`` and exempts ``@@||good.base^``:
     ``good.base`` resolves; ``base`` and a non-exempt subdomain stay VIP-blocked.
 
@@ -134,11 +135,11 @@ def test_abp_exception_unblocks(deployed_vm: SmokeVM, mock_feeds: _MockFeedServe
         control_local_data={good: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
-        ans_base = h.dns_probe(deployed_vm, base, "A")
+        ans_base = h.dns_probe_client(client_vm, base, "A")
         assert h.is_vip(ans_base), f"{base} expected VIP block, got {ans_base}"
-        ans_bad = h.dns_probe(deployed_vm, bad, "A")
+        ans_bad = h.dns_probe_client(client_vm, bad, "A")
         assert h.is_vip(ans_bad), f"{bad} (non-exempt subdomain) expected VIP block, got {ans_bad}"
-        ans_good = h.dns_probe(deployed_vm, good, "A")
+        ans_good = h.dns_probe_client(client_vm, good, "A")
         assert h.resolves_to(ans_good, PASS_IP), f"exempted {good} should resolve to {PASS_IP}, got {ans_good}"
         assert not h.is_vip(ans_good), f"exempted {good} wrongly VIP-blocked: {ans_good}"
 
@@ -148,7 +149,7 @@ def test_abp_exception_unblocks(deployed_vm: SmokeVM, mock_feeds: _MockFeedServe
 # --------------------------------------------------------------------------- #
 
 
-def test_abp_cross_feed_exception(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_cross_feed_exception(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """Feed A blocks ``||base^``; feed B exempts ``@@||base^`` → ``base`` resolves.
 
     The two feeds are two ROWS of ONE DNSBL group (each header-sniffed ABP
@@ -167,7 +168,7 @@ def test_abp_cross_feed_exception(deployed_vm: SmokeVM, mock_feeds: _MockFeedSer
         control_local_data={base: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
-        ans = h.dns_probe(deployed_vm, base, "A")
+        ans = h.dns_probe_client(client_vm, base, "A")
         assert h.resolves_to(ans, PASS_IP), f"cross-feed @@ should un-block {base} -> {PASS_IP}, got {ans}"
         assert not h.is_vip(ans), f"{base} wrongly VIP-blocked despite cross-feed @@: {ans}"
 
@@ -177,7 +178,9 @@ def test_abp_cross_feed_exception(deployed_vm: SmokeVM, mock_feeds: _MockFeedSer
 # --------------------------------------------------------------------------- #
 
 
-def test_abp_important_block_beats_feed_allow(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_important_block_beats_feed_allow(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """Feed ``||x^$important`` (band 3) beats a feed ``@@||x^`` (band 2): x stays blocked.
 
     block_band 3 > allow_band 2 → block wins → VIP. (The ``@@`` makes the numeric
@@ -188,11 +191,11 @@ def test_abp_important_block_beats_feed_allow(deployed_vm: SmokeVM, mock_feeds: 
     feed_url = h.write_local_feed(deployed_vm, "smoke_abp_important.txt", body)
     spec = h.DnsblCase(aliasname="smokeabpimp", feed_url=feed_url, header="smokeabpimp", mode=h.DnsblMode.VIP)
     with h.CaseContext(deployed_vm, spec):
-        ans = h.dns_probe(deployed_vm, x, "A")
+        ans = h.dns_probe_client(client_vm, x, "A")
         assert h.is_vip(ans), f"{x}: $important block must beat feed @@ (VIP), got {ans}"
 
 
-def test_abp_badfilter_prunes_feed_block(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_badfilter_prunes_feed_block(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """Feed ``||y^$badfilter`` prunes the matching feed ``||y^`` → y resolves.
 
     ``$badfilter`` removes every FEED rule with the matching signature (``(y, ())``),
@@ -211,7 +214,7 @@ def test_abp_badfilter_prunes_feed_block(deployed_vm: SmokeVM, mock_feeds: _Mock
         control_local_data={y: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
-        ans = h.dns_probe(deployed_vm, y, "A")
+        ans = h.dns_probe_client(client_vm, y, "A")
         assert h.resolves_to(ans, PASS_IP), f"$badfilter should prune the block on {y} -> {PASS_IP}, got {ans}"
         assert not h.is_vip(ans), f"{y} wrongly VIP-blocked despite $badfilter: {ans}"
 
@@ -221,7 +224,7 @@ def test_abp_badfilter_prunes_feed_block(deployed_vm: SmokeVM, mock_feeds: _Mock
 # --------------------------------------------------------------------------- #
 
 
-def test_abp_regex_block_and_allow(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_regex_block_and_allow(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """An ABP feed regex blocks a matching name; an ``@@/re/`` allow un-blocks an
     also-matching name.
 
@@ -243,9 +246,9 @@ def test_abp_regex_block_and_allow(deployed_vm: SmokeVM, mock_feeds: _MockFeedSe
         control_local_data={unblocked: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
-        ans_block = h.dns_probe(deployed_vm, blocked, "A")
+        ans_block = h.dns_probe_client(client_vm, blocked, "A")
         assert h.is_vip(ans_block), f"regex-matched {blocked} expected VIP, got {ans_block}"
-        ans_allow = h.dns_probe(deployed_vm, unblocked, "A")
+        ans_allow = h.dns_probe_client(client_vm, unblocked, "A")
         assert h.resolves_to(ans_allow, PASS_IP), f"@@ regex should un-block {unblocked} -> {PASS_IP}, got {ans_allow}"
 
 
@@ -318,7 +321,9 @@ def test_abp_catastrophic_regex_dropped(deployed_vm: SmokeVM, mock_feeds: _MockF
 # --------------------------------------------------------------------------- #
 
 
-def test_abp_whitelist_sovereign_over_important(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_whitelist_sovereign_over_important(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """A whitelisted name resolves even against a feed ``||w^$important``.
 
     The settings whitelist (``suppression``) loads into whiteDB as a user allow
@@ -339,12 +344,12 @@ def test_abp_whitelist_sovereign_over_important(deployed_vm: SmokeVM, mock_feeds
         control_local_data={w: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
-        ans = h.dns_probe(deployed_vm, w, "A")
+        ans = h.dns_probe_client(client_vm, w, "A")
         assert h.resolves_to(ans, PASS_IP), f"whitelisted {w} must resolve to {PASS_IP} despite $important, got {ans}"
         assert not h.is_vip(ans), f"whitelisted {w} wrongly VIP-blocked: {ans}"
 
 
-def test_user_regex_blocks(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_user_regex_blocks(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """A user "Python Regex List" pattern blocks a matching name (VIP shape).
 
     The user regex loads into regexDB (bare compiled pattern); a regex block forces
@@ -364,11 +369,13 @@ def test_user_regex_blocks(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) ->
         user_regex=[r"trackerx-"],
     )
     with h.CaseContext(deployed_vm, spec):
-        ans = h.dns_probe(deployed_vm, blocked, "A")
+        ans = h.dns_probe_client(client_vm, blocked, "A")
         assert h.is_vip(ans), f"user-regex-matched {blocked} expected VIP block, got {ans}"
 
 
-def test_user_regex_beats_feed_important_allow(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_user_regex_beats_feed_important_allow(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """A user regex is SOVEREIGN over an ABP feed allow — even ``@@…$important``.
 
     A user ``pfb_regex_list`` pattern matching the name (band 5, user block) vs a feed
@@ -389,11 +396,13 @@ def test_user_regex_beats_feed_important_allow(deployed_vm: SmokeVM, mock_feeds:
         user_regex=[r"trackerx-"],
     )
     with h.CaseContext(deployed_vm, spec):
-        ans = h.dns_probe(deployed_vm, name, "A")
+        ans = h.dns_probe_client(client_vm, name, "A")
         assert h.is_vip(ans), f"user regex (band 5) must beat feed @@$important (band 4): {name} -> {ans}"
 
 
-def test_custom_list_block_beats_feed_important_allow(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_custom_list_block_beats_feed_important_allow(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """A DNSBL Group Custom_List entry is SOVEREIGN over a feed ``@@…$important``.
 
     The user is the sovereign: an explicit Custom_List block (band 5, the
@@ -414,7 +423,7 @@ def test_custom_list_block_beats_feed_important_allow(deployed_vm: SmokeVM, mock
         custom_domains=[name],
     )
     with h.CaseContext(deployed_vm, spec):
-        ans = h.dns_probe(deployed_vm, name, "A")
+        ans = h.dns_probe_client(client_vm, name, "A")
         assert h.is_vip(ans), f"Custom_List block (band 5) must beat feed @@$important (band 4): {name} -> {ans}"
 
 
@@ -423,7 +432,9 @@ def test_custom_list_block_beats_feed_important_allow(deployed_vm: SmokeVM, mock
 # --------------------------------------------------------------------------- #
 
 
-def test_cname_validation_on_off(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer, stub_dns: _StubDnsServer) -> None:
+def test_cname_validation_on_off(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer, stub_dns: _StubDnsServer
+) -> None:
     """A→CNAME→B with B blocklisted: A blocks IFF CNAME validation is ON; B always blocks.
 
     Proves a REAL Unbound populates ``qstate.return_msg.rep`` with the CNAME chain
@@ -437,7 +448,7 @@ def test_cname_validation_on_off(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
     Unbound ``local-data`` CNAME does NOT work either: Unbound returns the bare CNAME
     without chasing it (a single rrset, so ``an_numrrsets`` stays 1 and the walk never
     runs). So the mock — pfSense's upstream via its System-DNS path
-    (``use_system_dns_upstream``: forward to 10.0.2.2 → libslirp host-alias NAT → mock) — crafts
+    (``use_system_dns_upstream``: forward to 10.10.0.2 → libslirp host-alias NAT → mock) — crafts
     the 2-rrset chain: ``stub_dns.register_cname(A, B)`` answers a forwarded query for A
     with ``A CNAME B`` + ``B A <addr>``, which Unbound forwards whole.
 
@@ -475,7 +486,7 @@ def test_cname_validation_on_off(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
         )
         with h.CaseContext(deployed_vm, spec_off):
             stub_dns.reset_queries()
-            ans_src = h.dns_probe(deployed_vm, src, "A")
+            ans_src = h.dns_probe_client(client_vm, src, "A")
             assert h.resolves_to(ans_src, tgt_ip), (
                 f"CNAME validation OFF: {src} should resolve to its CNAME target's address {tgt_ip}, got {ans_src}"
             )
@@ -488,7 +499,7 @@ def test_cname_validation_on_off(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
             # Reset the stub log too, so received(B) reflects only this direct query.
             h.flush_unbound_cache(deployed_vm)
             stub_dns.reset_queries()
-            ans_tgt = h.dns_probe(deployed_vm, tgt, "A")
+            ans_tgt = h.dns_probe_client(client_vm, tgt, "A")
             assert h.is_vip(ans_tgt), f"listed target {tgt} expected VIP block (validation OFF), got {ans_tgt}"
             assert not stub_dns.received(tgt), f"blocked {tgt} must NOT reach the upstream: {stub_dns.received(tgt)}"
 
@@ -502,13 +513,13 @@ def test_cname_validation_on_off(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
         )
         with h.CaseContext(deployed_vm, spec_on):
             h.flush_unbound_cache(deployed_vm)
-            ans_src = h.dns_probe(deployed_vm, src, "A")
+            ans_src = h.dns_probe_client(client_vm, src, "A")
             assert h.is_vip(ans_src), (
                 f"CNAME validation ON: {src} must be VIP-blocked via its CNAME target {tgt}, got {ans_src}"
             )
             # Flush so the direct B probe is evaluated fresh (not served A's cached chain).
             h.flush_unbound_cache(deployed_vm)
-            ans_tgt = h.dns_probe(deployed_vm, tgt, "A")
+            ans_tgt = h.dns_probe_client(client_vm, tgt, "A")
             assert h.is_vip(ans_tgt), f"listed target {tgt} expected VIP block (validation ON), got {ans_tgt}"
     finally:
         stub_dns.clear_cname()
@@ -519,7 +530,7 @@ def test_cname_validation_on_off(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
 # --------------------------------------------------------------------------- #
 
 
-def test_abp_no_regression_plain_feed(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_no_regression_plain_feed(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """A plain (non-ABP) feed blocks exactly as before and pfb_py_count renders.
 
     The body carries no ABP header, so it is NOT tagged ABP — it takes the ADR-06
@@ -530,7 +541,7 @@ def test_abp_no_regression_plain_feed(deployed_vm: SmokeVM, mock_feeds: _MockFee
     feed_url = h.write_local_feed(deployed_vm, "smoke_plain_noreg.txt", f"{domain}\n")
     spec = h.DnsblCase(aliasname="smokenoreg", feed_url=feed_url, header="smokenoreg", mode=h.DnsblMode.VIP)
     with h.CaseContext(deployed_vm, spec):
-        ans = h.dns_probe(deployed_vm, domain, "A")
+        ans = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(ans), f"plain feed {domain} expected VIP block (no regression), got {ans}"
         count = h.py_loaded_count(deployed_vm)
         assert count is not None and count >= 1, f"pfb_py_count must render >=1, got {count!r}"

--- a/tests/smoke/test_smoke_boot.py
+++ b/tests/smoke/test_smoke_boot.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 
 import pytest
 
-from .conftest import SmokeVM, expected_control_answer, resolve_a
+from . import helpers as h
+from .conftest import SmokeVM, expected_control_answer
 
 pytestmark = pytest.mark.smoke
 
@@ -32,7 +33,7 @@ def test_pfctl_ruleset_nonempty(smoke_vm: SmokeVM) -> None:
     assert rules, f"pfctl returned no rules; stdout was: {result.stdout!r}"
 
 
-def test_control_name_resolves(smoke_vm: SmokeVM) -> None:
+def test_control_name_resolves(smoke_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """A baked local-data control name resolves to its known answer.
 
     Optional: only the maintainer's image *may* bake a control name. The matrix
@@ -42,7 +43,7 @@ def test_control_name_resolves(smoke_vm: SmokeVM) -> None:
     name, expected_ip = expected_control_answer()
     if not name:
         pytest.skip("no baked control name (SMOKE_CONTROL_NAME unset); matrix injects per-case")
-    answers = resolve_a(name, smoke_vm.host, smoke_vm.dns_port)
-    assert answers, f"control name {name!r} returned no A record"
+    answer = h.dns_probe_client(client_vm, name)
+    assert answer.records, f"control name {name!r} returned no A record"
     if expected_ip is not None:
-        assert expected_ip in answers, f"{name!r} resolved to {answers}, expected {expected_ip!r}"
+        assert expected_ip in answer.records, f"{name!r} resolved to {answer.records}, expected {expected_ip!r}"

--- a/tests/smoke/test_smoke_dnsbl_control.py
+++ b/tests/smoke/test_smoke_dnsbl_control.py
@@ -37,13 +37,13 @@ from collections.abc import Iterator
 import pytest
 
 from . import helpers as h
-from .conftest import SmokeVM
+from .conftest import CLIENT_LAN_IP, SmokeVM
 
 pytestmark = pytest.mark.smoke
 
 
 @pytest.fixture(scope="module")
-def control_vm(smoke_vm: SmokeVM) -> Iterator[tuple[SmokeVM, str]]:
+def control_vm(smoke_vm: SmokeVM, client_vm: SmokeVM) -> Iterator[tuple[SmokeVM, str]]:
     """Deploy once with DNSBL + DNSBL Control on and a single feed-listed blocked domain.
 
     DNSBL Control is enabled (``pfb_control`` -> ini ``python_control`` on) so the reader
@@ -70,6 +70,7 @@ def control_vm(smoke_vm: SmokeVM) -> Iterator[tuple[SmokeVM, str]]:
 
     # Guard the gate: the reader thread is enabled and the DNS-TXT path is inert by default.
     h.assert_control_ini(smoke_vm, control=True, legacy=False)
+    h.assert_link_health(client_vm, smoke_vm, control_name=h.unique_domain())
     try:
         yield smoke_vm, blocked
     finally:
@@ -81,7 +82,7 @@ def control_vm(smoke_vm: SmokeVM) -> Iterator[tuple[SmokeVM, str]]:
         h.collect_host_diagnostics(smoke_vm)
 
 
-def test_cli_disable_then_enable_drives_dnsbl(control_vm: tuple[SmokeVM, str]) -> None:
+def test_cli_disable_then_enable_drives_dnsbl(control_vm: tuple[SmokeVM, str], client_vm: SmokeVM) -> None:
     """Scenario: the CLI disable/enable toggles DNSBL blocking at runtime.
 
     Background: DNSBL Control is on (reader thread running) and ``blocked`` is feed-listed.
@@ -96,7 +97,7 @@ def test_cli_disable_then_enable_drives_dnsbl(control_vm: tuple[SmokeVM, str]) -
     vm, blocked = control_vm
 
     # GIVEN: blocked first (the before-state, so the disable's effect is causal).
-    before = h.dns_probe(vm, blocked, "A")
+    before = h.dns_probe_client(client_vm, blocked, "A")
     assert h.is_vip(before), f"{blocked} expected VIP block before disable, got {before}"
     applied0 = h.read_control_applied(vm)
 
@@ -104,14 +105,14 @@ def test_cli_disable_then_enable_drives_dnsbl(control_vm: tuple[SmokeVM, str]) -
     seq_disable = h.dnsbl_control_cli(vm, "disable")
     h.wait_control_applied(vm, seq_disable)
     h.flush_unbound_cache(vm)
-    disabled = h.dns_probe(vm, blocked, "A")
+    disabled = h.dns_probe_client(client_vm, blocked, "A")
     assert not h.is_vip(disabled), f"{blocked} should resolve clean after disable, still VIP-blocked: {disabled}"
 
     # WHEN: enable. THEN: VIP-blocked again.
     seq_enable = h.dnsbl_control_cli(vm, "enable")
     h.wait_control_applied(vm, seq_enable)
     h.flush_unbound_cache(vm)
-    reenabled = h.dns_probe(vm, blocked, "A")
+    reenabled = h.dns_probe_client(client_vm, blocked, "A")
     assert h.is_vip(reenabled), f"{blocked} should be VIP-blocked again after enable, got {reenabled}"
 
     # AND: the applied marker advanced across both commands.
@@ -123,29 +124,29 @@ def test_cli_disable_then_enable_drives_dnsbl(control_vm: tuple[SmokeVM, str]) -
     )
 
 
-def test_cli_addbypass_then_removebypass_exempts_client(control_vm: tuple[SmokeVM, str]) -> None:
-    """Scenario: the CLI add/remove a per-client DNSBL bypass for the on-box client.
+def test_cli_addbypass_then_removebypass_exempts_client(control_vm: tuple[SmokeVM, str], client_vm: SmokeVM) -> None:
+    """Scenario: the CLI add/remove a per-client DNSBL bypass for the civm client.
 
-    Background: DNSBL Control is on and ``blocked`` is feed-listed; an on-box drill
-    presents as client 127.0.0.1, and the bypass keys on the client IP.
+    Background: DNSBL Control is on and ``blocked`` is feed-listed; the civm queries
+    pfSense DNS from CLIENT_LAN_IP (192.168.1.10), and the bypass keys on the client IP.
     Given the domain is VIP-blocked for that client,
-    When ``dnsbl-control addbypass 127.0.0.1`` is applied,
+    When ``dnsbl-control addbypass <CLIENT_LAN_IP>`` is applied,
     Then the domain resolves clean for that client (the bypass stands);
-    When ``dnsbl-control removebypass 127.0.0.1`` is applied,
+    When ``dnsbl-control removebypass <CLIENT_LAN_IP>`` is applied,
     Then it is VIP-blocked again.
     """
     vm, blocked = control_vm
-    client = "127.0.0.1"
+    client = CLIENT_LAN_IP
 
-    # GIVEN: blocked first for the on-box client (the before-state).
-    before = h.dns_probe(vm, blocked, "A")
+    # GIVEN: blocked first for the civm client (the before-state).
+    before = h.dns_probe_client(client_vm, blocked, "A")
     assert h.is_vip(before), f"{blocked} expected VIP block before addbypass, got {before}"
 
-    # WHEN: addbypass the on-box client. THEN: resolves clean for it.
+    # WHEN: addbypass the civm client. THEN: resolves clean for it.
     seq_add = h.dnsbl_control_cli(vm, "addbypass", client)
     h.wait_control_applied(vm, seq_add)
     h.flush_unbound_cache(vm)
-    bypassed = h.dns_probe(vm, blocked, "A")
+    bypassed = h.dns_probe_client(client_vm, blocked, "A")
     assert not h.is_vip(bypassed), (
         f"{blocked} should resolve clean for bypassed client {client}, still VIP-blocked: {bypassed}"
     )
@@ -154,12 +155,12 @@ def test_cli_addbypass_then_removebypass_exempts_client(control_vm: tuple[SmokeV
     seq_remove = h.dnsbl_control_cli(vm, "removebypass", client)
     h.wait_control_applied(vm, seq_remove)
     h.flush_unbound_cache(vm)
-    restored = h.dns_probe(vm, blocked, "A")
+    restored = h.dns_probe_client(client_vm, blocked, "A")
     assert h.is_vip(restored), f"{blocked} should be VIP-blocked again after removebypass, got {restored}"
     assert seq_remove > seq_add, f"removebypass seq {seq_remove} did not advance past addbypass seq {seq_add}"
 
 
-def test_legacy_dns_txt_control_inert_by_default(control_vm: tuple[SmokeVM, str]) -> None:
+def test_legacy_dns_txt_control_inert_by_default(control_vm: tuple[SmokeVM, str], client_vm: SmokeVM) -> None:
     """Scenario: the deprecated DNS-TXT control path is inert by default.
 
     Background: DNSBL Control is on but the legacy DNS-TXT sub-toggle is OFF (its default),
@@ -173,19 +174,19 @@ def test_legacy_dns_txt_control_inert_by_default(control_vm: tuple[SmokeVM, str]
 
     # GIVEN: the gate is off and the domain is blocked.
     h.assert_control_ini(vm, control=True, legacy=False)
-    before = h.dns_probe(vm, blocked, "A")
+    before = h.dns_probe_client(client_vm, blocked, "A")
     assert h.is_vip(before), f"{blocked} expected VIP block before the TXT query, got {before}"
 
     # WHEN: issue the in-band TXT control query. THEN: still VIP-blocked (path inert).
     h.drill_txt(vm, "python_control.disable")
     h.flush_unbound_cache(vm)
-    after = h.dns_probe(vm, blocked, "A")
+    after = h.dns_probe_client(client_vm, blocked, "A")
     assert h.is_vip(after), (
         f"{blocked} should STAY VIP-blocked — the legacy DNS-TXT control path must be inert by default, got {after}"
     )
 
 
-def test_legacy_dns_txt_control_active_when_enabled(control_vm: tuple[SmokeVM, str]) -> None:
+def test_legacy_dns_txt_control_active_when_enabled(control_vm: tuple[SmokeVM, str], client_vm: SmokeVM) -> None:
     """Scenario (branch coverage): turning the legacy sub-toggle on re-activates DNS-TXT control.
 
     Background: the same VM, but the legacy DNS-TXT sub-toggle is flipped ON (ini
@@ -208,13 +209,13 @@ def test_legacy_dns_txt_control_active_when_enabled(control_vm: tuple[SmokeVM, s
     h.assert_control_ini(vm, control=True, legacy=True)
 
     # GIVEN: blocked first (the reload re-enabled blocking).
-    before = h.dns_probe(vm, blocked, "A")
+    before = h.dns_probe_client(client_vm, blocked, "A")
     assert h.is_vip(before), f"{blocked} expected VIP block after legacy-on reload, got {before}"
 
     # WHEN: the in-band TXT control query. THEN: blocking is disabled — resolves clean.
     h.drill_txt(vm, "python_control.disable")
     h.flush_unbound_cache(vm)
-    after = h.dns_probe(vm, blocked, "A")
+    after = h.dns_probe_client(client_vm, blocked, "A")
     assert not h.is_vip(after), (
         f"{blocked} should resolve clean — with the legacy sub-toggle ON the DNS-TXT control path "
         f"must disable DNSBL, still blocked: {after}"

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -5,7 +5,7 @@ LOCAL file (``write_local_feed``) — chosen partly for HTTP-fetch reliability (
 Context 5). This module is the one place the suite drives the REAL HTTP feed-fetch
 path: each case points a ``IpCase``/``DnsblCase`` at a ``mock_feeds.feed_url(<name>)``
 URL (the stdlib ``_MockFeedServer`` serving ``tests/smoke/fixtures/``, reachable by
-the guest at ``http://10.0.2.2:<port>/<name>`` over SLIRP — survives the egress
+the guest at ``http://10.10.0.2:<port>/<name>`` over SLIRP — survives the egress
 block), runs a real Force Update, and asserts the feed loaded on the box. This
 exercises pfBlockerNG's ``curl`` contract (gzip / redirects / no-304) end-to-end —
 the gap Part C closes.
@@ -60,7 +60,7 @@ pytestmark = pytest.mark.smoke
 
 
 @pytest.fixture(scope="module")
-def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
+def deployed_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
     """Deploy the branch .pkg once for the HTTP-feed-load matrix (mirrors the ADR-04
     matrix / ABP modules).
 
@@ -73,14 +73,15 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
-    # The mock feed server is the SLIRP host alias 10.0.2.2 (RFC1918) — the default-ON
+    # The mock feed server is the SLIRP host alias 10.10.0.2 (RFC1918) — the default-ON
     # feed-host internal-address filter (SSRF guard, pfb_feed_internal_filter) would reject
     # every HTTP mock fetch as an internal-resolving host. Allowlist the SLIRP test network
     # so the filter stays ON yet the mock is reachable (the fix for the regression these
     # HTTP-feed tests hit after the filter landed default-on).
-    h.set_feed_internal_allowlist(smoke_vm, "10.0.2.0/24")
+    h.set_feed_internal_allowlist(smoke_vm, "10.10.0.0/24")
     h.ensure_dnsbl_vip(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
+    h.assert_link_health(client_vm, smoke_vm, control_name=h.unique_domain())
     try:
         yield smoke_vm
     finally:
@@ -145,7 +146,7 @@ def test_ip_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -
         assert h.rule_references(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
 
 
-def test_dnsbl_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_http_feed_loads(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """KILL-GATE (DNSBL): a plain-domain feed served over HTTP loads into the matcher.
 
     Scenario: the Phase-4 ``dnsbl_plain.txt`` fixture is fetched by a real Force
@@ -165,7 +166,7 @@ def test_dnsbl_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
     spec = h.DnsblCase(aliasname="smokefeeddnsbl", feed_url=feed_url, header="smokefeeddnsbl", mode=h.DnsblMode.VIP)
 
     # BEFORE: the member is not on any feed yet -> it resolves via the stub sentinel.
-    before = h.dns_probe(deployed_vm, member, "A")
+    before = h.dns_probe_client(client_vm, member, "A")
     assert h.resolves_to(before, STUB_DNS_A), f"{member} should resolve via stub BEFORE listing, got {before}"
     assert not h.is_vip(before), f"{member} unexpectedly VIP-blocked before any feed: {before}"
 
@@ -179,9 +180,9 @@ def test_dnsbl_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
         # name (as test_smoke_matrix.py's unlock lifecycle does), then poll until the
         # async swap's VIP block lands.
         h.flush_unbound_name(deployed_vm, member)
-        blocked = h.dns_probe_until(deployed_vm, member, h.is_vip)
+        blocked = h.dns_probe_client_until(client_vm, member, h.is_vip)
         assert not h.resolves_to(blocked, STUB_DNS_A), f"{member} still resolving after the feed block: {blocked}"
-        passed = h.dns_probe(deployed_vm, non_member, "A")
+        passed = h.dns_probe_client(client_vm, non_member, "A")
         assert h.resolves_to(passed, STUB_DNS_A), f"non-member {non_member} should resolve via stub, got {passed}"
         assert not h.is_vip(passed), f"non-member {non_member} wrongly VIP-blocked: {passed}"
 
@@ -194,16 +195,16 @@ def test_dnsbl_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
 def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """The default-ON feed-host filter BLOCKS an internal-resolving feed; the allowlist EXEMPTS it.
 
-    The mock feed server is the SLIRP host alias 10.0.2.2 (RFC1918) — exactly the
+    The mock feed server is the SLIRP host alias 10.10.0.2 (RFC1918) — exactly the
     internal-pivot the filter (``pfb_feed_internal_filter``, default ON) guards against.
     This pins BOTH branches end to end over the live box (the module fixture allowlists
-    10.0.2.0/24 so the other HTTP-feed cases load at all; this test brackets it).
+    10.10.0.0/24 so the other HTTP-feed cases load at all; this test brackets it).
 
     Scenario:
-      Given the filter ON and the allowlist EMPTY (so 10.0.2.2 is not exempt),
+      Given the filter ON and the allowlist EMPTY (so 10.10.0.2 is not exempt),
       When  the mock IP feed is Force-Updated,
       Then  the download is REFUSED and the pf table is never built (the block branch).
-      When  the SLIRP net 10.0.2.0/24 is then allowlisted and re-updated,
+      When  the SLIRP net 10.10.0.0/24 is then allowlisted and re-updated,
       Then  the SAME feed downloads and its pf table IS built (the exempt branch).
     """
     feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
@@ -226,7 +227,7 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
         )
 
         # EXEMPT branch: allowlist the SLIRP net => the SAME feed now downloads + loads.
-        h.set_feed_internal_allowlist(deployed_vm, "10.0.2.0/24")
+        h.set_feed_internal_allowlist(deployed_vm, "10.10.0.0/24")
         h.reload(deployed_vm, "update")
         h.reload(deployed_vm, "updateip")
         members = h.pfctl_table_members(deployed_vm, spec.alias)
@@ -234,7 +235,7 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
         assert h.member_present(members, "203.0.113.5"), f"listed host missing after exemption: {members}"
     finally:
         # Restore the module-default allowlist (siblings rely on it) and baseline the box.
-        h.set_feed_internal_allowlist(deployed_vm, "10.0.2.0/24")
+        h.set_feed_internal_allowlist(deployed_vm, "10.10.0.0/24")
         h.reset(deployed_vm)
 
 
@@ -298,7 +299,7 @@ def test_ipv6_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer)
         assert h.rule_references(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
 
 
-def test_dnsbl_http_hosts_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_http_hosts_feed_loads(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """DNSBL hosts format over HTTP: ``dnsbl_hosts.txt`` (``0.0.0.0 <domain>``) blocks.
 
     The leading sink IP is stripped, leaving the domain to block. Before-state: the
@@ -312,7 +313,7 @@ def test_dnsbl_http_hosts_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeed
     feed_url = mock_feeds.feed_url("dnsbl_hosts.txt")
     spec = h.DnsblCase(aliasname="smokefeedhosts", feed_url=feed_url, header="smokefeedhosts", mode=h.DnsblMode.VIP)
 
-    before = h.dns_probe(deployed_vm, member, "A")
+    before = h.dns_probe_client(client_vm, member, "A")
     assert h.resolves_to(before, STUB_DNS_A), f"{member} should resolve via stub BEFORE listing, got {before}"
     assert not h.is_vip(before), f"{member} unexpectedly VIP-blocked before any feed: {before}"
 
@@ -320,14 +321,14 @@ def test_dnsbl_http_hosts_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeed
         h.unblock_egress()  # the non-member "resolves" probe must reach the stub upstream
         # before-probe warmed the C-cache; a feed swap is TTL-bounded (see kill-gate) -> flush + poll.
         h.flush_unbound_name(deployed_vm, member)
-        blocked = h.dns_probe_until(deployed_vm, member, h.is_vip)
+        blocked = h.dns_probe_client_until(client_vm, member, h.is_vip)
         assert not h.resolves_to(blocked, STUB_DNS_A), f"{member} still resolving after the feed block: {blocked}"
-        passed = h.dns_probe(deployed_vm, non_member, "A")
+        passed = h.dns_probe_client(client_vm, non_member, "A")
         assert h.resolves_to(passed, STUB_DNS_A), f"non-member {non_member} should resolve via stub, got {passed}"
         assert not h.is_vip(passed), f"non-member {non_member} wrongly VIP-blocked: {passed}"
 
 
-def test_dnsbl_http_abp_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_http_abp_feed_loads(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """DNSBL ABP/EasyList over HTTP: ``dnsbl_abp.txt`` is header-sniffed ABP and loads.
 
     The body starts with ``[Adblock Plus 2.0]`` -> pfBlockerNG sniffs it as ABP
@@ -354,7 +355,7 @@ def test_dnsbl_http_abp_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedSe
     spec = h.DnsblCase(aliasname="smokefeedabp", feed_url=feed_url, header="smokefeedabp", mode=h.DnsblMode.VIP)
 
     # BEFORE: the ||-only name is not yet on any feed -> it resolves via the stub.
-    before = h.dns_probe(deployed_vm, blocked_name, "A")
+    before = h.dns_probe_client(client_vm, blocked_name, "A")
     assert h.resolves_to(before, STUB_DNS_A), f"{blocked_name} should resolve via stub BEFORE listing, got {before}"
     assert not h.is_vip(before), f"{blocked_name} unexpectedly VIP-blocked before any feed: {before}"
 
@@ -365,16 +366,16 @@ def test_dnsbl_http_abp_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedSe
         h.unblock_egress()
         # before-probe warmed the C-cache; a feed swap is TTL-bounded (see kill-gate) -> flush + poll.
         h.flush_unbound_name(deployed_vm, blocked_name)
-        ans_blocked = h.dns_probe_until(deployed_vm, blocked_name, h.is_vip)
+        ans_blocked = h.dns_probe_client_until(client_vm, blocked_name, h.is_vip)
         assert not h.resolves_to(ans_blocked, STUB_DNS_A), (
             f"{blocked_name} still resolving after the || block: {ans_blocked}"
         )
-        ans_allow = h.dns_probe(deployed_vm, allow_exception, "A")
+        ans_allow = h.dns_probe_client(client_vm, allow_exception, "A")
         assert h.resolves_to(ans_allow, STUB_DNS_A), (
             f"ABP @@ allow-exception {allow_exception} must RESOLVE via the stub (@@ beats ||), got {ans_allow}"
         )
         assert not h.is_vip(ans_allow), f"ABP @@ allow-exception {allow_exception} wrongly VIP-blocked: {ans_allow}"
-        ans_non = h.dns_probe(deployed_vm, non_member, "A")
+        ans_non = h.dns_probe_client(client_vm, non_member, "A")
         assert h.resolves_to(ans_non, STUB_DNS_A), f"non-member {non_member} should resolve via stub, got {ans_non}"
         assert not h.is_vip(ans_non), f"non-member {non_member} wrongly VIP-blocked: {ans_non}"
 
@@ -392,7 +393,9 @@ def test_dnsbl_http_abp_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedSe
 
 
 @pytest.mark.timeout(300)
-def test_abp_perline_detection_in_plain_feed(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_perline_detection_in_plain_feed(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """ADR-21: ``||block^`` / ``@@||allow^`` in a HEADER-LESS feed resolve correctly.
 
     Scenario: a header-less DNSBL feed row (NOT whole-feed ABP — ``format_hint='plain'``)
@@ -442,7 +445,7 @@ def test_abp_perline_detection_in_plain_feed(deployed_vm: SmokeVM, mock_feeds: _
 
     # BEFORE: none of the three names is on any feed yet -> each resolves via the stub.
     for name in (block_name, allow_name, plain_name):
-        before = h.dns_probe(deployed_vm, name, "A")
+        before = h.dns_probe_client(client_vm, name, "A")
         assert h.resolves_to(before, STUB_DNS_A), f"{name} should resolve via stub BEFORE listing, got {before}"
         assert not h.is_vip(before), f"{name} unexpectedly VIP-blocked before any feed: {before}"
 
@@ -456,13 +459,13 @@ def test_abp_perline_detection_in_plain_feed(deployed_vm: SmokeVM, mock_feeds: _
         for name in (block_name, allow_name, plain_name):
             h.flush_unbound_name(deployed_vm, name)
 
-        ans_block = h.dns_probe_until(deployed_vm, block_name, h.is_vip)
+        ans_block = h.dns_probe_client_until(client_vm, block_name, h.is_vip)
         assert not h.resolves_to(ans_block, STUB_DNS_A), f"{block_name} still resolving after ||block^: {ans_block}"
 
-        ans_plain = h.dns_probe_until(deployed_vm, plain_name, h.is_vip)
+        ans_plain = h.dns_probe_client_until(client_vm, plain_name, h.is_vip)
         assert not h.resolves_to(ans_plain, STUB_DNS_A), f"{plain_name} still resolving after plain block: {ans_plain}"
 
-        ans_allow = h.dns_probe(deployed_vm, allow_name, "A")
+        ans_allow = h.dns_probe_client(client_vm, allow_name, "A")
         assert h.resolves_to(ans_allow, STUB_DNS_A), (
             f"@@||{allow_name}^ must RESOLVE via the stub (its @@ allow beats the same-feed plain block): {ans_allow}"
         )
@@ -479,7 +482,7 @@ def test_abp_perline_detection_in_plain_feed(deployed_vm: SmokeVM, mock_feeds: _
 
 
 @pytest.mark.timeout(300)
-def test_abp_bom_header_still_detected(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_bom_header_still_detected(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """ADR-21: a UTF-8 BOM before ``[Adblock Plus 2.0]`` must not mask ABP detection.
 
     Scenario: a feed whose first bytes are a UTF-8 BOM (``EF BB BF``) followed by the
@@ -503,7 +506,7 @@ def test_abp_bom_header_still_detected(deployed_vm: SmokeVM, mock_feeds: _MockFe
     spec = h.DnsblCase(aliasname="smokeadr21bom", feed_url=feed_url, header="smokeadr21bom", mode=h.DnsblMode.VIP)
 
     # BEFORE: the name is on no feed yet -> it resolves via the stub sentinel.
-    before = h.dns_probe(deployed_vm, blocked, "A")
+    before = h.dns_probe_client(client_vm, blocked, "A")
     assert h.resolves_to(before, STUB_DNS_A), f"{blocked} should resolve via stub BEFORE listing, got {before}"
     assert not h.is_vip(before), f"{blocked} unexpectedly VIP-blocked before any feed: {before}"
 
@@ -512,7 +515,7 @@ def test_abp_bom_header_still_detected(deployed_vm: SmokeVM, mock_feeds: _MockFe
         # contrast is real (a would-be resolve still reaches the stub, no false-green).
         h.unblock_egress()
         h.flush_unbound_name(deployed_vm, blocked)
-        ans = h.dns_probe_until(deployed_vm, blocked, h.is_vip)
+        ans = h.dns_probe_client_until(client_vm, blocked, h.is_vip)
         assert not h.resolves_to(ans, STUB_DNS_A), (
             f"{blocked} still resolving after a BOM-led ABP feed regex block "
             f"(a BOM-masked header would leave the feed 'plain' and drop the regex): {ans}"
@@ -520,7 +523,9 @@ def test_abp_bom_header_still_detected(deployed_vm: SmokeVM, mock_feeds: _MockFe
 
 
 @pytest.mark.timeout(300)
-def test_abp_perline_path_anchor_not_overblocked(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_perline_path_anchor_not_overblocked(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """ADR-21: a path-anchored ``||domain/path^`` in a plain feed must NOT block the domain.
 
     Per-line ABP capture writes the anchor VERBATIM ahead of the plain pipeline's
@@ -544,7 +549,7 @@ def test_abp_perline_path_anchor_not_overblocked(deployed_vm: SmokeVM, mock_feed
 
     # BEFORE: neither name is on any feed yet -> each resolves via the stub sentinel.
     for name in (blk, path_dom):
-        before = h.dns_probe(deployed_vm, name, "A")
+        before = h.dns_probe_client(client_vm, name, "A")
         assert h.resolves_to(before, STUB_DNS_A), f"{name} should resolve via stub BEFORE listing, got {before}"
         assert not h.is_vip(before), f"{name} unexpectedly VIP-blocked before any feed: {before}"
 
@@ -555,10 +560,10 @@ def test_abp_perline_path_anchor_not_overblocked(deployed_vm: SmokeVM, mock_feed
         for name in (blk, path_dom):
             h.flush_unbound_name(deployed_vm, name)
 
-        ans_blk = h.dns_probe_until(deployed_vm, blk, h.is_vip)
+        ans_blk = h.dns_probe_client_until(client_vm, blk, h.is_vip)
         assert not h.resolves_to(ans_blk, STUB_DNS_A), f"{blk} still resolving after ||{blk}^: {ans_blk}"
 
-        ans_path = h.dns_probe(deployed_vm, path_dom, "A")
+        ans_path = h.dns_probe_client(client_vm, path_dom, "A")
         assert h.resolves_to(ans_path, STUB_DNS_A), (
             f"||{path_dom}/ads^ is a PATH anchor -> parse_abp must skip it, so {path_dom} must RESOLVE "
             f"(pre-fix truncation to ||{path_dom} would over-block it): {ans_path}"
@@ -599,7 +604,7 @@ def _scheme_feed_path(vm: SmokeVM, name: str, lines: list[str]) -> str:
 
 
 @pytest.mark.timeout(300)
-def test_strict_skips_invalid_scheme_and_path_and_logs(deployed_vm: SmokeVM) -> None:
+def test_strict_skips_invalid_scheme_and_path_and_logs(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """ADR-22 strict (lenient OFF): invalid-scheme + path lines are skipped AND logged.
 
     Scenario: a DNSBL feed mixes two well-formed scheme lines (a valid RFC 3986 scheme,
@@ -641,7 +646,7 @@ def test_strict_skips_invalid_scheme_and_path_and_logs(deployed_vm: SmokeVM) -> 
         # BEFORE: none of the four is on a feed yet -> each resolves via the stub.
         h.unblock_egress()
         for name in (http_dom, evil_dom, bad_dom, path_dom):
-            before = h.dns_probe(deployed_vm, name, "A")
+            before = h.dns_probe_client(client_vm, name, "A")
             assert h.resolves_to(before, STUB_DNS_A), f"{name} should resolve via stub BEFORE listing, got {before}"
             assert not _blocked(before), f"{name} unexpectedly blocked before any feed: {before}"
 
@@ -659,20 +664,20 @@ def test_strict_skips_invalid_scheme_and_path_and_logs(deployed_vm: SmokeVM) -> 
         # blocked names; the skipped names were never listed so they keep resolving.
         h.flush_unbound_name(deployed_vm, http_dom)
         h.flush_unbound_name(deployed_vm, evil_dom)
-        ans_http = h.dns_probe_until(deployed_vm, http_dom, _blocked)
+        ans_http = h.dns_probe_client_until(client_vm, http_dom, _blocked)
         assert not h.resolves_to(ans_http, STUB_DNS_A), (
             f"http://{http_dom} still resolving after strict load: {ans_http}"
         )
-        ans_evil = h.dns_probe_until(deployed_vm, evil_dom, _blocked)
+        ans_evil = h.dns_probe_client_until(client_vm, evil_dom, _blocked)
         assert not h.resolves_to(ans_evil, STUB_DNS_A), (
             f"evil://{evil_dom} still resolving after strict load: {ans_evil}"
         )
-        ans_bad = h.dns_probe(deployed_vm, bad_dom, "A")
+        ans_bad = h.dns_probe_client(client_vm, bad_dom, "A")
         assert h.resolves_to(ans_bad, STUB_DNS_A), (
             f"123://{bad_dom} must be SKIPPED under strict (digit-start scheme) -> still resolves, got {ans_bad}"
         )
         assert not _blocked(ans_bad), f"123://{bad_dom} wrongly blocked under strict (should be skipped): {ans_bad}"
-        ans_path = h.dns_probe(deployed_vm, path_dom, "A")
+        ans_path = h.dns_probe_client(client_vm, path_dom, "A")
         assert h.resolves_to(ans_path, STUB_DNS_A), (
             f"http://{path_dom}/path must be SKIPPED under strict (URL path) -> still resolves, got {ans_path}"
         )
@@ -697,7 +702,7 @@ def test_strict_skips_invalid_scheme_and_path_and_logs(deployed_vm: SmokeVM) -> 
 
 
 @pytest.mark.timeout(300)
-def test_lenient_blocks_invalid_scheme_and_path(deployed_vm: SmokeVM) -> None:
+def test_lenient_blocks_invalid_scheme_and_path(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """ADR-22 lenient (ON): invalid-scheme + path lines are BLOCKED, no WARNING (today's behaviour).
 
     The lenient counterpart of the strict test: with ``pfb_dnsbl_lenient='on'`` the SAME
@@ -731,7 +736,7 @@ def test_lenient_blocks_invalid_scheme_and_path(deployed_vm: SmokeVM) -> None:
         # BEFORE: neither host is on a feed yet -> each resolves via the stub.
         h.unblock_egress()
         for name in (bad_dom, path_dom):
-            before = h.dns_probe(deployed_vm, name, "A")
+            before = h.dns_probe_client(client_vm, name, "A")
             assert h.resolves_to(before, STUB_DNS_A), f"{name} should resolve via stub BEFORE listing, got {before}"
             assert not _blocked(before), f"{name} unexpectedly blocked before any feed: {before}"
 
@@ -750,11 +755,11 @@ def test_lenient_blocks_invalid_scheme_and_path(deployed_vm: SmokeVM) -> None:
         # THEN (DNS shapes): both malformed lines are now BLOCKED (today's behaviour).
         for name in (bad_dom, path_dom):
             h.flush_unbound_name(deployed_vm, name)
-        ans_bad = h.dns_probe_until(deployed_vm, bad_dom, _blocked)
+        ans_bad = h.dns_probe_client_until(client_vm, bad_dom, _blocked)
         assert not h.resolves_to(ans_bad, STUB_DNS_A), (
             f"123://{bad_dom} must be BLOCKED under lenient (today's strip), still resolving: {ans_bad}"
         )
-        ans_path = h.dns_probe_until(deployed_vm, path_dom, _blocked)
+        ans_path = h.dns_probe_client_until(client_vm, path_dom, _blocked)
         assert not h.resolves_to(ans_path, STUB_DNS_A), (
             f"http://{path_dom}/path must be BLOCKED under lenient (path stripped downstream), got {ans_path}"
         )
@@ -869,7 +874,7 @@ def test_migration_sets_lenient_on_for_existing_install(deployed_vm: SmokeVM) ->
 
 
 @pytest.mark.timeout(600)
-def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM) -> None:
+def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """ADR-31 §2.2 end-to-end: a Permit feed allow-overrides a block feed and teardown re-blocks.
 
     All test domains use :func:`helpers.unique_domain` (uuid-*.com) — never RFC 6761
@@ -946,7 +951,7 @@ def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM) -> N
         # GIVEN — before-state: nothing is on any feed yet, all names RESOLVE.
         # ------------------------------------------------------------------ #
         for name in (s_domain, b_domain, m_domain, p_domain, child_p, x_domain):
-            before = h.dns_probe(deployed_vm, name, "A")
+            before = h.dns_probe_client(client_vm, name, "A")
             assert h.resolves_to(before, STUB_DNS_A), (
                 f"{name} should resolve via stub BEFORE any feed is loaded, got {before}"
             )
@@ -966,26 +971,26 @@ def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM) -> N
             h.flush_unbound_name(deployed_vm, name)
 
         # §2.2.1: S is blocked by the block feed (no permit feed yet).
-        ans_s_blk = h.dns_probe_until(deployed_vm, s_domain, h.is_vip)
+        ans_s_blk = h.dns_probe_client_until(client_vm, s_domain, h.is_vip)
         assert not h.resolves_to(ans_s_blk, STUB_DNS_A), (
             f"§2.2.1: {s_domain} should be VIP-blocked by the block feed (no permit feed yet): {ans_s_blk}"
         )
 
         # §2.2.1: B is blocked by the block feed (block-only, never on permit).
-        ans_b_blk = h.dns_probe_until(deployed_vm, b_domain, h.is_vip)
+        ans_b_blk = h.dns_probe_client_until(client_vm, b_domain, h.is_vip)
         assert not h.resolves_to(ans_b_blk, STUB_DNS_A), (
             f"§2.2.1: {b_domain} should be VIP-blocked by the block feed: {ans_b_blk}"
         )
 
         # §2.2.1/§2.2.3: M is blocked via the block feed AND via band-5 Custom_List.
-        ans_m_blk = h.dns_probe_until(deployed_vm, m_domain, h.is_vip)
+        ans_m_blk = h.dns_probe_client_until(client_vm, m_domain, h.is_vip)
         assert not h.resolves_to(ans_m_blk, STUB_DNS_A), (
             f"§2.2.3: {m_domain} should be VIP-blocked (Custom_List band-5 + block feed): {ans_m_blk}"
         )
 
         # §2.2.4: P and child.P RESOLVE (not on any block feed); X RESOLVES (not listed).
         for name in (p_domain, child_p, x_domain):
-            ans = h.dns_probe(deployed_vm, name, "A")
+            ans = h.dns_probe_client(client_vm, name, "A")
             assert h.resolves_to(ans, STUB_DNS_A), (
                 f"§2.2.4/non-listed: {name} should RESOLVE via stub (not on block feed): {ans}"
             )
@@ -1015,7 +1020,7 @@ def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM) -> N
         h.flush_unbound_name(deployed_vm, child_p)
 
         # §2.2.2: S RESOLVES — permit feed (band 2) overrides block feed (band 1).
-        ans_s_pmt = h.dns_probe_until(deployed_vm, s_domain, lambda a: h.resolves_to(a, STUB_DNS_A))
+        ans_s_pmt = h.dns_probe_client_until(client_vm, s_domain, lambda a: h.resolves_to(a, STUB_DNS_A))
         assert h.resolves_to(ans_s_pmt, STUB_DNS_A), (
             f"§2.2.2: {s_domain} must RESOLVE via stub (permit feed band 2 beats block band 1): {ans_s_pmt}"
         )
@@ -1024,7 +1029,7 @@ def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM) -> N
         )
 
         # §2.2.2: B remains VIP-blocked — only on the block feed, not the permit feed.
-        ans_b_pmt = h.dns_probe(deployed_vm, b_domain, "A")
+        ans_b_pmt = h.dns_probe_client(client_vm, b_domain, "A")
         assert h.is_vip(ans_b_pmt), (
             f"§2.2.2: {b_domain} must remain VIP-blocked (only on block feed, not on permit feed): {ans_b_pmt}"
         )
@@ -1033,7 +1038,7 @@ def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM) -> N
         )
 
         # §2.2.3: M remains VIP-blocked — Custom_List (band 5) beats permit (band 2).
-        ans_m_pmt = h.dns_probe(deployed_vm, m_domain, "A")
+        ans_m_pmt = h.dns_probe_client(client_vm, m_domain, "A")
         assert h.is_vip(ans_m_pmt), (
             f"§2.2.3: {m_domain} must remain VIP-blocked (Custom_List band 5 > permit band 2): {ans_m_pmt}"
         )
@@ -1042,13 +1047,13 @@ def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM) -> N
         )
 
         # §2.2.4: P RESOLVES — on the permit feed; child.P RESOLVES — subdomain covering.
-        ans_p = h.dns_probe(deployed_vm, p_domain, "A")
+        ans_p = h.dns_probe_client(client_vm, p_domain, "A")
         assert h.resolves_to(ans_p, STUB_DNS_A), (
             f"§2.2.4: {p_domain} must RESOLVE via stub (permit feed allow): {ans_p}"
         )
         assert not h.is_vip(ans_p), f"§2.2.4: {p_domain} wrongly VIP-blocked despite permit feed: {ans_p}"
 
-        ans_child = h.dns_probe(deployed_vm, child_p, "A")
+        ans_child = h.dns_probe_client(client_vm, child_p, "A")
         assert h.resolves_to(ans_child, STUB_DNS_A), (
             f"§2.2.4: {child_p} must RESOLVE via stub (subdomain of permit-listed parent): {ans_child}"
         )
@@ -1057,7 +1062,7 @@ def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM) -> N
         )
 
         # §2.2.4 (non-listed unaffected): X still RESOLVES — no feed entry for X.
-        ans_x = h.dns_probe(deployed_vm, x_domain, "A")
+        ans_x = h.dns_probe_client(client_vm, x_domain, "A")
         assert h.resolves_to(ans_x, STUB_DNS_A), (
             f"§2.2.4: non-listed {x_domain} must RESOLVE via stub (not on any feed): {ans_x}"
         )
@@ -1075,7 +1080,7 @@ def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM) -> N
         # gone so S should now be VIP-blocked. ADR-10 allow->block is TTL-bounded ->
         # flush S then poll until the block lands.
         h.flush_unbound_name(deployed_vm, s_domain)
-        ans_s_teardown = h.dns_probe_until(deployed_vm, s_domain, h.is_vip)
+        ans_s_teardown = h.dns_probe_client_until(client_vm, s_domain, h.is_vip)
         assert h.is_vip(ans_s_teardown), (
             f"teardown: {s_domain} must be VIP-blocked again after removing the permit feed "
             f"(no whiteDB residue): {ans_s_teardown}"

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -880,8 +880,9 @@ def test_dnswl_permit_feed_allow_overrides_block_feed(deployed_vm: SmokeVM, clie
     All test domains use :func:`helpers.unique_domain` (uuid-*.com) — never RFC 6761
     TLDs (.test/.example/.invalid) which Unbound's built-in local-zones shadow before
     pfBlockerNG runs, and never HSTS-preload names (HSTS default-ON forces NULL on a
-    VIP block, masking whether a name actually resolved). Probed on-box via
-    ``drill @127.0.0.1``; the first response after each reload is authoritative.
+    VIP block, masking whether a name actually resolved). Probed from the civm
+    LAN client via :func:`helpers.dns_probe_client` (pfSense's LAN resolver); the
+    first response after each reload is authoritative.
 
     Background — the feed layout used:
       * Block feed  (Deny action, aliasname=smokednyblk):  S, B, M (+ M in Custom_List -> band 5)

--- a/tests/smoke/test_smoke_fwobj.py
+++ b/tests/smoke/test_smoke_fwobj.py
@@ -55,8 +55,16 @@ _USER_NAT_DESCR = "my-test-user-nat-do-not-delete"
 
 
 @pytest.fixture(scope="module")
-def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+def deployed_vm(  # noqa: ARG001
+    smoke_vm: SmokeVM,
+    stub_dns: _StubDnsServer,
+    lan_interface: SmokeVM,
+) -> Iterator[SmokeVM]:
     """Deploy the branch .pkg once for the fwobj module.
+
+    Depends on ``lan_interface`` to ensure a LAN VLAN subinterface is
+    provisioned before these tests run (the single-NIC smoke image boots with
+    no LAN assigned; fwobj tests create LAN-scoped VIP and NAT rules).
 
     Egress stays OPEN across reloads: ``pkg add`` pulls RUN_DEPENDS and the
     DNSBL update path runs ``pfb_create_dnsbl`` which touches pfSense state.

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -29,13 +29,14 @@ pytestmark = pytest.mark.smoke
 
 
 @pytest.fixture(scope="module")
-def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> SmokeVM:
+def deployed_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer) -> SmokeVM:
     """Deploy the branch .pkg once for the helper self-tests; configure the System-DNS
-    upstream (``use_system_dns_upstream`` -> the mock via the 10.0.2.2 host alias)."""
+    upstream (``use_system_dns_upstream`` -> the mock via the 10.10.0.2 host alias)."""
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
+    h.assert_link_health(client_vm, smoke_vm, control_name=h.unique_domain())
     return smoke_vm
 
 
@@ -71,14 +72,14 @@ def test_inject_value_roundtrips(deployed_vm: SmokeVM) -> None:
     assert back.strip() == "on", f"read-back mismatch: {back!r}"
 
 
-def test_inject_control_record_resolves(deployed_vm: SmokeVM) -> None:
+def test_inject_control_record_resolves(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """A control local-data injected in CONFIG resolves after a reload."""
     name = h.unique_domain("selftest-control")
     ip = "192.0.2.250"
     h.set_control_records(deployed_vm, {name: {"A": ip}}, {})
     # The reload regenerates unbound.conf; the config-baked record must survive.
     h.reload(deployed_vm, "update")
-    answer = h.dns_probe(deployed_vm, name, "A")
+    answer = h.dns_probe_client(client_vm, name, "A")
     assert h.resolves_to(answer, ip), f"{name} -> {answer.records}, expected {ip}"
 
 
@@ -87,14 +88,14 @@ def test_inject_control_record_resolves(deployed_vm: SmokeVM) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_reset_returns_to_baseline(deployed_vm: SmokeVM) -> None:
+def test_reset_returns_to_baseline(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """reset() runs clear* + a forced update and leaves Unbound ready."""
     h.reset(deployed_vm)
     # The baked control name still resolves (reset didn't break the resolver).
     name, expected_ip = expected_control_answer()
     if not name:
         pytest.skip("no baked control name (SMOKE_CONTROL_NAME unset)")
-    answer = h.dns_probe(deployed_vm, name, "A")
+    answer = h.dns_probe_client(client_vm, name, "A")
     assert answer.records, f"baked control {name!r} gone after reset"
     if expected_ip is not None:
         assert h.resolves_to(answer, expected_ip)
@@ -132,7 +133,7 @@ def test_false_green_guard() -> None:
     assert not h.is_nxdomain(real_pass)
 
 
-def test_dns_probe_absent_resolves_via_stub(deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+def test_dns_probe_absent_resolves_via_stub(deployed_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
     """An otherwise-unknown name resolves to the STUB SENTINEL and is recorded upstream.
 
     With the stub as Unbound's sole upstream, a name with no local-data / block is
@@ -142,7 +143,7 @@ def test_dns_probe_absent_resolves_via_stub(deployed_vm: SmokeVM, stub_dns: _Stu
     """
     name = h.unique_domain("definitely-absent")
     stub_dns.reset_queries()
-    answer = h.dns_probe(deployed_vm, name, "A")
+    answer = h.dns_probe_client(client_vm, name, "A")
     assert h.resolves_to(answer, STUB_DNS_A), f"absent name should resolve to the stub sentinel, got {answer}"
     assert stub_dns.received(name), f"{name} should have been forwarded to the stub upstream"
 

--- a/tests/smoke/test_smoke_ipv6_alerts.py
+++ b/tests/smoke/test_smoke_ipv6_alerts.py
@@ -50,8 +50,12 @@ pytestmark = pytest.mark.smoke
 
 
 @pytest.fixture(scope="module")
-def ipv6_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+def ipv6_vm(smoke_vm: SmokeVM, lan_interface: SmokeVM) -> Iterator[SmokeVM]:  # noqa: ARG001
     """Deploy the branch .pkg once; yield the VM for the locality tests.
+
+    Depends on ``lan_interface`` to ensure a LAN VLAN subinterface is
+    provisioned before these tests run (the single-NIC smoke image boots with
+    no LAN assigned; IPv6 locality tests set an IPv6 address on LAN).
 
     No DNSBL config is required — ``pfb_collect_localip()`` runs before any
     reload and has no dependency on the DNSBL pipeline being active.  The

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -72,7 +72,7 @@ pytestmark = pytest.mark.smoke
 
 
 @pytest.fixture(scope="module")
-def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
+def deployed_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
     """Deploy the branch .pkg once for the matrix; the per-case egress block is
     managed by ``CaseContext``, NOT here.
 
@@ -83,7 +83,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     the forwarder, and a control/whitelist name answers from its injected host
     override — so the probe never needs the real internet. A not-blocked,
     no-control name resolves via the runner-side mock (``use_system_dns_upstream``:
-    pfSense forwards to the SLIRP host alias 10.0.2.2, which libslirp NATs to the mock) — a known
+    pfSense forwards to the SLIRP host alias 10.10.0.2, which libslirp NATs to the mock) — a known
     answer, AND recorded, so "was it blocked?" is read off the upstream, not inferred
     from a SERVFAIL. deploy() needs no egress for dependencies either — the pre-baked
     image ships pfBlockerNG's RUN_DEPENDS, so ``pkg add`` resolves them from the local
@@ -107,6 +107,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     # config is part of the baseline and the DNSBL reload still adds only python.
     h.use_system_dns_upstream(smoke_vm)
     h.snap_state(smoke_vm, "vip")
+    h.assert_link_health(client_vm, smoke_vm, control_name=h.unique_domain())
     try:
         yield smoke_vm
     finally:
@@ -178,7 +179,7 @@ def test_dnsbl_unbound_config_immutable(deployed_vm: SmokeVM, mock_feeds: _MockF
         )
 
 
-def test_dnsbl_python_exact_vip(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_python_exact_vip(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """Python-mode exact block: NOERROR + VIP for the listed domain; subdomain passes.
 
     Verified on the live box: python mode writes the feed to ``pfb_py_data.txt``
@@ -201,15 +202,15 @@ def test_dnsbl_python_exact_vip(deployed_vm: SmokeVM, mock_feeds: _MockFeedServe
         control_local_data={sub: {"A": sub_ip}},
     )
     with h.CaseContext(deployed_vm, spec):
-        blocked = h.dns_probe(deployed_vm, domain, "A")
+        blocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(blocked), f"{domain} expected VIP {h.DEFAULT_DNSBL_VIP4}, got {blocked}"
         # EXACT match: subdomain NOT in dataDB, resolves to its control answer.
-        passed = h.dns_probe(deployed_vm, sub, "A")
+        passed = h.dns_probe_client(client_vm, sub, "A")
         assert h.resolves_to(passed, sub_ip), f"{sub} should resolve to {sub_ip} (exact != wildcard), got {passed}"
         assert not h.is_vip(passed), f"{sub} wrongly VIP-blocked (exact match, not wildcard): {passed}"
 
 
-def test_dnsbl_exact_null(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_exact_null(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """Python-mode null sinkhole: NOERROR + 0.0.0.0/::0 for a logging='disabled' feed.
 
     ``logging='disabled'`` → ``logging_type='2'`` → ``null_blocking=True`` →
@@ -226,15 +227,15 @@ def test_dnsbl_exact_null(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> 
         mode=h.DnsblMode.NULL,
     )
     with h.CaseContext(deployed_vm, spec):
-        a = h.dns_probe(deployed_vm, domain, "A")
+        a = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_null_ip(a), f"{domain} A expected {h.NULL_IP4}, got {a}"
-        aaaa = h.dns_probe(deployed_vm, domain, "AAAA")
+        aaaa = h.dns_probe_client(client_vm, domain, "AAAA")
         assert h.is_null_ip(aaaa, null_ip="::0") or not aaaa.records, (
             f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
         )
 
 
-def test_dnsbl_exact_nxdomain(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_exact_nxdomain(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """Python-mode NXDOMAIN block (issue #31): a bare NXDOMAIN, no records.
 
     ``logging='nxdomain_log'`` → ``logging_type='3'`` → ``operate()`` returns
@@ -255,14 +256,14 @@ def test_dnsbl_exact_nxdomain(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer)
         mode=h.DnsblMode.NXDOMAIN,
     )
     with h.CaseContext(deployed_vm, spec):
-        a = h.dns_probe(deployed_vm, domain, "A")
+        a = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_nxdomain(a), f"{domain} A expected NXDOMAIN (no records), got {a}"
         assert not h.is_vip(a) and not h.is_null_ip(a), f"{domain} must be a bare NXDOMAIN, not a VIP/null record: {a}"
-        aaaa = h.dns_probe(deployed_vm, domain, "AAAA")
+        aaaa = h.dns_probe_client(client_vm, domain, "AAAA")
         assert h.is_nxdomain(aaaa), f"{domain} AAAA expected NXDOMAIN (no records), got {aaaa}"
 
 
-def test_dnsbl_hsts_override_forces_null(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_hsts_override_forces_null(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """HSTS override: a VIP-mode block on an HSTS-preload name is forced to NULL.
 
     The load-bearing branch the rest of the matrix deliberately avoids. For a
@@ -296,16 +297,16 @@ def test_dnsbl_hsts_override_forces_null(deployed_vm: SmokeVM, mock_feeds: _Mock
         h.add_hsts_name(deployed_vm, domain)
         h.reload(deployed_vm, "updatednsbl")
         h.assert_hsts_loaded(deployed_vm, domain)
-        a = h.dns_probe(deployed_vm, domain, "A")
+        a = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_null_ip(a), f"HSTS override should force A=0.0.0.0, got {a} (VIP leak?)"
         assert not h.is_vip(a), f"HSTS-preload VIP-list block must NOT be the VIP {h.DEFAULT_DNSBL_VIP4}: {a}"
-        aaaa = h.dns_probe(deployed_vm, domain, "AAAA")
+        aaaa = h.dns_probe_client(client_vm, domain, "AAAA")
         assert h.is_null_ip(aaaa, null_ip="::0") or not aaaa.records, (
             f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
         )
 
 
-def test_dnsbl_hsts_disabled_keeps_vip(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_hsts_disabled_keeps_vip(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """Non-tautology guard: the SAME VIP-list HSTS-listed name, HSTS OFF → VIP.
 
     With ``pfb_hsts`` off → ini ``python_hsts=off``, pfb_unbound.py never loads
@@ -329,7 +330,7 @@ def test_dnsbl_hsts_disabled_keeps_vip(deployed_vm: SmokeVM, mock_feeds: _MockFe
         # only delta vs the positive case is pfb_hsts.
         h.add_hsts_name(deployed_vm, domain)
         h.reload(deployed_vm, "updatednsbl")
-        blocked = h.dns_probe(deployed_vm, domain, "A")
+        blocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(blocked), f"HSTS off: VIP-list block should be the VIP {h.DEFAULT_DNSBL_VIP4}, got {blocked}"
         assert not h.is_null_ip(blocked), f"HSTS off must NOT force NULL: {blocked}"
 
@@ -341,7 +342,7 @@ def test_dnsbl_hsts_disabled_keeps_vip(deployed_vm: SmokeVM, mock_feeds: _MockFe
 
 
 def test_dnsbl_idn_confusable_blocks_homoglyph_resolves_legit(
-    deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
 ) -> None:
     """Confusable mode blocks a cross-script homoglyph (VIP) but resolves a legit IDN.
 
@@ -371,18 +372,18 @@ def test_dnsbl_idn_confusable_blocks_homoglyph_resolves_legit(
     )
     with h.CaseContext(deployed_vm, spec):
         # Before-state: the legit single-script IDN is NOT blocked — it resolves.
-        legit_ans = h.dns_probe(deployed_vm, legit, "A")
+        legit_ans = h.dns_probe_client(client_vm, legit, "A")
         assert h.resolves_to(legit_ans, legit_ip), f"legit IDN {legit} should resolve to {legit_ip}, got {legit_ans}"
         assert not h.is_vip(legit_ans), f"legit IDN {legit} must NOT be homoglyph-blocked (FALSE POSITIVE): {legit_ans}"
         # The confusable homograph blocks with the DNSBL VIP.
-        blocked = h.dns_probe(deployed_vm, homoglyph, "A")
+        blocked = h.dns_probe_client(client_vm, homoglyph, "A")
         assert h.is_vip(blocked), (
             f"homoglyph {homoglyph} (Latin+Cyrillic) expected VIP {h.DEFAULT_DNSBL_VIP4}, got {blocked}"
         )
 
 
 def test_dnsbl_idn_confusable_block_malicious_off_alerts_only(
-    deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
 ) -> None:
     """The ``block_malicious`` sub-toggle is a real branch: OFF → the SAME homograph
     only alerts (resolves), not blocks.
@@ -406,14 +407,14 @@ def test_dnsbl_idn_confusable_block_malicious_off_alerts_only(
         control_local_data={homoglyph: {"A": homoglyph_ip}},
     )
     with h.CaseContext(deployed_vm, spec):
-        ans = h.dns_probe(deployed_vm, homoglyph, "A")
+        ans = h.dns_probe_client(client_vm, homoglyph, "A")
         assert h.resolves_to(ans, homoglyph_ip), (
             f"block_malicious OFF: {homoglyph} should resolve to {homoglyph_ip}, got {ans}"
         )
         assert not h.is_vip(ans), f"block_malicious OFF must NOT block the homograph (alert only): {ans}"
 
 
-def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """WHITELIST: a domain on the whitelist AND in the block feed RESOLVES.
 
     ``suppression`` short-circuits before any block shape, so the name resolves
@@ -431,7 +432,7 @@ def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, mock_feeds: _MockFeed
         control_local_data={domain: {"A": pass_ip}},
     )
     with h.CaseContext(deployed_vm, spec):
-        answer = h.dns_probe(deployed_vm, domain, "A")
+        answer = h.dns_probe_client(client_vm, domain, "A")
         assert h.resolves_to(answer, pass_ip), f"whitelisted {domain} should resolve to {pass_ip}, got {answer}"
         assert not h.is_vip(answer), f"whitelisted {domain} wrongly VIP-blocked: {answer}"
         assert not h.is_null_ip(answer), f"whitelisted {domain} wrongly null-IP: {answer}"
@@ -441,7 +442,9 @@ def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, mock_feeds: _MockFeed
 # until the watcher confirms the applied generation -- seconds, not the old async poll)
 # plus per-case setup exceed the smoke harness's 30s per-test cap; override it.
 @pytest.mark.timeout(120)
-def test_dnsbl_resolve_block_unlock_relock_lifecycle(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_resolve_block_unlock_relock_lifecycle(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """#51 FULL lifecycle, asserting the ACTUAL resolution at every transition:
 
       (a) BEFORE any list  -> the domain RESOLVES (forwarded to the stub sentinel);
@@ -478,7 +481,7 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(deployed_vm: SmokeVM, mock_
 
     # (a) BEFORE any blocklist: forwarded to the controlled stub -> resolves to the
     #     sentinel (a real, observable baseline — not yet on any feed, not blocked).
-    before = h.dns_probe(deployed_vm, domain, "A")
+    before = h.dns_probe_client(client_vm, domain, "A")
     assert h.resolves_to(before, STUB_DNS_A), f"{domain} should resolve via stub BEFORE listing, got {before}"
     assert not h.is_vip(before) and not h.is_null_ip(before), f"{domain} unexpectedly blocked before any feed: {before}"
 
@@ -494,7 +497,7 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(deployed_vm: SmokeVM, mock_
         # cached real answer would serve past the swap; clear that one name (mirroring a
         # #51 Lock's targeted delta-flush) then poll until the swapped VIP block lands.
         h.flush_unbound_name(deployed_vm, domain)
-        blocked = h.dns_probe_until(deployed_vm, domain, h.is_vip)
+        blocked = h.dns_probe_client_until(client_vm, domain, h.is_vip)
         assert not h.resolves_to(blocked, STUB_DNS_A), f"{domain} still resolving after block: {blocked}"
 
         # NO-RESTART invariant: capture Unbound's pid before the #51 Unlock/Lock flips.
@@ -506,14 +509,14 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(deployed_vm: SmokeVM, mock_
         #     The swap is async, so poll until the decision flips (bounded; raises on
         #     timeout) — the block->allow direction is immediate (blocks not cached, #43).
         h.dnsbl_alert_lock_toggle(deployed_vm, domain, "unlock")
-        unlocked = h.dns_probe_until(deployed_vm, domain, lambda a: h.resolves_to(a, STUB_DNS_A))
+        unlocked = h.dns_probe_client_until(client_vm, domain, lambda a: h.resolves_to(a, STUB_DNS_A))
         assert not h.is_vip(unlocked), f"unlocked {domain} still VIP-blocked (the #51 no-op): {unlocked}"
 
         # (d) Re-Lock -> the temporary allow is removed: blocked again (VIP). allow->block
         #     here clears the prior resolved answer via the production targeted C-cache
         #     delta-flush inside pfb_reload_unbound, so the VIP block is observable.
         h.dnsbl_alert_lock_toggle(deployed_vm, domain, "lock")
-        relocked = h.dns_probe_until(deployed_vm, domain, h.is_vip)
+        relocked = h.dns_probe_client_until(client_vm, domain, h.is_vip)
         assert not h.resolves_to(relocked, STUB_DNS_A), f"re-locked {domain} still resolving: {relocked}"
 
         # The whole Unlock/Lock sequence applied with NO restart: pid unchanged.
@@ -525,7 +528,9 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(deployed_vm: SmokeVM, mock_
 
 
 @pytest.mark.timeout(120)  # ADR-10: multiple wait-for-apply round-trips > the 30s smoke cap.
-def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_temp_unlock_cleared_by_force_update(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """#51: a temporary Unlock is re-locked by a Cron/Force update — even with NO feed
     change (parity with main).
 
@@ -558,7 +563,7 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
         # locally, so there is no false-green from leaving egress open.
         h.unblock_egress()
         # Blocked by the feed -> VIP (the "before" of the Unlock operation).
-        blocked = h.dns_probe(deployed_vm, domain, "A")
+        blocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(blocked), f"{domain} expected VIP block, got {blocked}"
 
         # NO-RESTART invariant: capture pid before the Unlock + Force-update re-lock.
@@ -567,7 +572,7 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
         # Unlock -> resolves again (forwarded to the stub sentinel). Async swap: poll until
         # the block->allow flip lands (immediate direction since blocks aren't C-cached, #43).
         h.dnsbl_alert_lock_toggle(deployed_vm, domain, "unlock")
-        unlocked = h.dns_probe_until(deployed_vm, domain, lambda a: h.resolves_to(a, STUB_DNS_A))
+        unlocked = h.dns_probe_client_until(client_vm, domain, lambda a: h.resolves_to(a, STUB_DNS_A))
         assert not h.is_vip(unlocked), f"unlocked {domain} still VIP-blocked: {unlocked}"
 
         # A Cron/Force update over the UNCHANGED feed re-locks it: the pending unlock store
@@ -579,7 +584,7 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
         # prior resolved answer (cached by the unlock probe above) would serve until TTL.
         # Clear it, then observe the swapped re-block (mirrors test_dnsbl_feed_update).
         h.flush_unbound_name(deployed_vm, domain)
-        relocked = h.dns_probe_until(deployed_vm, domain, h.is_vip)
+        relocked = h.dns_probe_client_until(client_vm, domain, h.is_vip)
         assert not h.resolves_to(relocked, STUB_DNS_A), f"re-locked {domain} still resolving: {relocked}"
 
         # Both the Unlock and the Force-update re-lock applied with NO restart: pid unchanged.
@@ -600,7 +605,7 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(deployed_vm: SmokeVM, mock_fe
 
 
 @pytest.mark.timeout(120)  # ADR-10: setup restart + a wait-for-apply swap > the 30s smoke cap.
-def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """A feed-content DNSBL update applies WITHOUT restarting Unbound (ADR-10 zero-downtime).
 
     Branch-coverage partner of ``test_dnsbl_config_change_restarts`` (data fork vs config
@@ -637,7 +642,7 @@ def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, mock_feeds: _MockFee
         h.unblock_egress()  # the allowed (before-state) probe must reach the controlled stub
 
         # BEFORE: the target is not on the feed yet -> it RESOLVES via the stub sentinel.
-        before = h.dns_probe(deployed_vm, domain, "A")
+        before = h.dns_probe_client(client_vm, domain, "A")
         assert h.resolves_to(before, STUB_DNS_A), f"{domain} should resolve via stub BEFORE the feed edit, got {before}"
         assert not h.is_vip(before), f"{domain} unexpectedly VIP-blocked before being listed: {before}"
 
@@ -658,7 +663,7 @@ def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, mock_feeds: _MockFee
         # Clear the target's TTL-bounded prior resolved answer (feed/cron allow->block is
         # not targeted-flushed by PHP — RESULTS/05 SS3), then observe the swapped block.
         h.flush_unbound_name(deployed_vm, domain)
-        blocked = h.dns_probe_until(deployed_vm, domain, h.is_vip)
+        blocked = h.dns_probe_client_until(client_vm, domain, h.is_vip)
         assert not h.resolves_to(blocked, STUB_DNS_A), f"{domain} still resolving after the feed block: {blocked}"
 
         # AFTER: pid unchanged (no restart) AND a fresh fast-path swap line was logged.
@@ -675,7 +680,7 @@ def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, mock_feeds: _MockFee
 
 
 @pytest.mark.timeout(120)  # ADR-10: two full Unbound restarts (disable + enable) > the 30s cap.
-def test_dnsbl_config_change_restarts(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_config_change_restarts(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """A CONFIG change DOES restart Unbound — the other fork of the data/config split.
 
     Branch-coverage partner of ``test_dnsbl_feed_update_no_restart``: ADR-10 keeps the
@@ -703,7 +708,7 @@ def test_dnsbl_config_change_restarts(deployed_vm: SmokeVM, mock_feeds: _MockFee
     spec = h.DnsblCase(aliasname="smokecfgrestart", feed_url=feed_url, header="smokecfgrestart", mode=h.DnsblMode.VIP)
     with h.CaseContext(deployed_vm, spec):
         # BEFORE: the name is blocked (VIP) and DNSBL is live. Capture the running pid.
-        blocked = h.dns_probe(deployed_vm, domain, "A")
+        blocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(blocked), f"{domain} expected VIP block before the config change, got {blocked}"
         pid_before = h.unbound_pid(deployed_vm)
 
@@ -726,12 +731,14 @@ def test_dnsbl_config_change_restarts(deployed_vm: SmokeVM, mock_feeds: _MockFee
             f"re-enabling DNSBL is a config change and MUST restart Unbound, but pid was unchanged ({pid_mid})"
         )
         # The list is restored: the name blocks again after the config round-trip.
-        reblocked = h.dns_probe(deployed_vm, domain, "A")
+        reblocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(reblocked), f"{domain} expected VIP block after re-enabling DNSBL, got {reblocked}"
 
 
 @pytest.mark.timeout(120)  # ADR-10: setup + a watcher build-fail observation window > the 30s cap.
-def test_dnsbl_fail_closed_broken_manifest(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_fail_closed_broken_manifest(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """A broken manifest does NOT swap — the last-good lists keep serving (ADR-10 fail-closed).
 
     The ADR-10 safety contract: if a rebuild fails (bad/partial manifest), the watcher keeps
@@ -758,7 +765,7 @@ def test_dnsbl_fail_closed_broken_manifest(deployed_vm: SmokeVM, mock_feeds: _Mo
     spec = h.DnsblCase(aliasname="smokefailclosed", feed_url=feed_url, header="smokefailclosed", mode=h.DnsblMode.VIP)
     with h.CaseContext(deployed_vm, spec):
         # BEFORE: the name is blocked (VIP) by the last-good snapshot.
-        blocked = h.dns_probe(deployed_vm, domain, "A")
+        blocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(blocked), f"{domain} expected VIP block before corrupting the manifest, got {blocked}"
         pid_before = h.unbound_pid(deployed_vm)
         pyerr_before = h.count_log_marker(deployed_vm, h.PY_ERROR_LOG, "Failed to load DNSBL manifest")
@@ -790,10 +797,10 @@ def test_dnsbl_fail_closed_broken_manifest(deployed_vm: SmokeVM, mock_feeds: _Mo
             now = h.count_log_marker(deployed_vm, h.PY_ERROR_LOG, "Failed to load DNSBL manifest")
             return now > pyerr_before
 
-        # dns_probe_until polls the (still-blocked) name; the predicate also confirms the
-        # py_error line appeared — both must hold within the window (raises otherwise).
-        still = h.dns_probe_until(
-            deployed_vm,
+        # dns_probe_client_until polls the (still-blocked) name; the predicate also confirms
+        # the py_error line appeared — both must hold within the window (raises otherwise).
+        still = h.dns_probe_client_until(
+            client_vm,
             domain,
             lambda a: h.is_vip(a) and _pyerr_logged(a),
             timeout=45.0,
@@ -889,7 +896,7 @@ def _is_v4_literal(member: str) -> bool:
 # --------------------------------------------------------------------------- #
 
 
-def test_dnsbl_autovip_lifecycle(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_autovip_lifecycle(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """ADR-13 'Create VIPs automatically': provision a marked sinkhole VIP on
     enable, sink a block to it, remove ONLY it on disable.
 
@@ -923,7 +930,7 @@ def test_dnsbl_autovip_lifecycle(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
         assert h.marked_vip_subnet(vm, h.AUTO_VIP_DESCR_V4) == "", (
             "pfB_AUTO_VIP_v4 present before auto-create was ever enabled"
         )
-        pre = h.dns_probe(vm, domain, "A")
+        pre = h.dns_probe_client(client_vm, domain, "A")
         assert pre.records, f"{domain} did not resolve before listing: {pre}"
         assert not h.is_vip(pre, vip=h.AUTO_VIP_IP4), f"{domain} already sinks to the auto VIP before enable: {pre}"
 
@@ -938,7 +945,7 @@ def test_dnsbl_autovip_lifecycle(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
             assert h.dnsvip4_address(vm) == h.AUTO_VIP_IP4, (
                 f"pfb_dnsvip4 does not point at the auto VIP: {h.dnsvip4_address(vm)!r}"
             )
-            blocked = h.dns_probe(vm, domain, "A")
+            blocked = h.dns_probe_client(client_vm, domain, "A")
             assert h.is_vip(blocked, vip=h.AUTO_VIP_IP4), f"{domain} expected auto VIP {h.AUTO_VIP_IP4}, got {blocked}"
             assert not h.is_vip(blocked, vip=h.DEFAULT_DNSBL_VIP4), (
                 f"block leaked to the manual VIP {h.DEFAULT_DNSBL_VIP4} instead of the auto VIP: {blocked}"
@@ -963,7 +970,7 @@ def test_dnsbl_autovip_lifecycle(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
 
 
 @pytest.mark.xfail(strict=True, reason="deliberately-wrong expectation: a real VIP block is NOT a pass")
-def test_false_green_guard_vm(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_false_green_guard_vm(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """STRICT-xfail guard: assert a real block RESOLVES — it must NOT.
 
     Blocks a unique domain (VIP) then asserts it resolves to a pass IP.
@@ -983,7 +990,7 @@ def test_false_green_guard_vm(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer)
         mode=h.DnsblMode.VIP,
     )
     with h.CaseContext(deployed_vm, spec):
-        answer = h.dns_probe(deployed_vm, domain, "A")
+        answer = h.dns_probe_client(client_vm, domain, "A")
         # WRONG on purpose: a VIP block does not resolve to a pass IP.
         assert h.resolves_to(answer, "198.51.100.250"), "expected (wrongly) to resolve — must fail"
 
@@ -1017,7 +1024,9 @@ def _dnsbl_log_hits(vm: SmokeVM, needle: str, *, timeout: float = 30.0) -> int:
     return sum(int(tok) for tok in res.stdout.split() if tok.isdigit())
 
 
-def test_dnsbl_block_writes_persistent_log_line(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_dnsbl_block_writes_persistent_log_line(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
     """ADR-03: a VIP (``log_type='1'``) block is written to ``dnsbl.log`` via the persistent handle.
 
     Scenario: ADR-03 replaced per-call open/close with a persistent ``WatchedFileHandler``
@@ -1039,7 +1048,7 @@ def test_dnsbl_block_writes_persistent_log_line(deployed_vm: SmokeVM, mock_feeds
     assert _dnsbl_log_hits(deployed_vm, domain) == 0, f"{domain} already in dnsbl.log before listing"
 
     with h.CaseContext(deployed_vm, spec):
-        blocked = h.dns_probe(deployed_vm, domain, "A")
+        blocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(blocked), f"{domain} expected VIP block, got {blocked}"
         # The log write rides the async QueueListener -> poll briefly for the line.
         deadline = time.monotonic() + 20.0

--- a/tests/smoke/test_smoke_safesearch.py
+++ b/tests/smoke/test_smoke_safesearch.py
@@ -16,7 +16,7 @@ Both resolver modes are covered (the fixture is parametrized):
 
 * **recursive** — Unbound recurses; a catch-all ``forward-zone`` in
   ``custom_options`` redirects all queries to the stub.
-* **forwarding** — Unbound forwards to ``10.0.2.2`` (SLIRP host alias → stub).
+* **forwarding** — Unbound forwards to ``10.10.0.2`` (SLIRP host alias → stub).
 
 All heavy setup (Unbound reconfigure + pfBlockerNG reloads) lives in the fixture
 so the 30 s per-test-body cap (``smoke.yml: timeout_func_only``) does not bite.
@@ -44,6 +44,7 @@ class _SSFixture(NamedTuple):
     """Everything the SafeSearch tests need, yielded by :func:`safesearch_vm`."""
 
     vm: SmokeVM
+    client_vm: SmokeVM
     forwarding_on: bool
     src_chase: str  # the CNAME-redirect source name for the #1 chase test
     target_chase: str  # the CNAME target name served with SS_TARGET_A/AAAA by the stub
@@ -52,25 +53,26 @@ class _SSFixture(NamedTuple):
 
 
 @pytest.fixture(scope="module")
-def _ss_deployed(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+def _ss_deployed(smoke_vm: SmokeVM, client_vm: SmokeVM) -> Iterator[tuple[SmokeVM, SmokeVM]]:
     """One-time deploy + DNSBL VIP (shared by both resolver-mode parametrizations)."""
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
-    yield smoke_vm
+    h.assert_link_health(client_vm, smoke_vm, control_name=h.unique_domain())
+    yield smoke_vm, client_vm
 
 
 @pytest.fixture(scope="module", params=[False, True], ids=["recursive", "forwarding"])
 def safesearch_vm(
-    _ss_deployed: SmokeVM,
+    _ss_deployed: tuple[SmokeVM, SmokeVM],
     stub_dns: _StubDnsServer,
     request: pytest.FixtureRequest,
 ) -> Iterator[_SSFixture]:
     """Wire Unbound to the stub, inject fabricated SafeSearch CNAME rows, yield fixture.
 
     Parametrized on ``forwarding_on``.  Egress is BLOCKED for the duration so the
-    test is hermetic; the stub is reachable via the SLIRP ``10.0.2.2`` loopback path
+    test is hermetic; the stub is reachable via the SLIRP ``10.10.0.2`` loopback path
     regardless.
 
     Sequence:
@@ -92,7 +94,7 @@ def safesearch_vm(
     9. Yield the :class:`_SSFixture`.
     10. Teardown: drop stub records, restore egress, collect diagnostics.
     """
-    vm: SmokeVM = _ss_deployed
+    vm, cvm = _ss_deployed
     forwarding_on: bool = request.param
 
     # Step 1: block egress — all DNS must route through the stub.
@@ -128,7 +130,7 @@ def safesearch_vm(
         # Step 6: capture the BEFORE answer (redirect not active yet).
         # src_chase is an unregistered name -> stub sentinel STUB_DNS_A.
         # This is DISTINCT from SS_TARGET_A so the before≠after transition is provable.
-        before = h.dns_probe(vm, src_chase, "A")
+        before = h.dns_probe_client(cvm, src_chase, "A")
 
         # Step 7: inject the fabricated SafeSearch CNAME rows and bounce Unbound.
         h.inject_safesearch_cname_entries(
@@ -145,6 +147,7 @@ def safesearch_vm(
 
         yield _SSFixture(
             vm=vm,
+            client_vm=cvm,
             forwarding_on=forwarding_on,
             src_chase=src_chase,
             target_chase=target_chase,
@@ -174,7 +177,7 @@ def test_safesearch_cname_redirect_takes_effect(safesearch_vm: _SSFixture) -> No
         would mean the synthesized CNAME hop went DNSSEC-bogus), and DIFFERS from the
         BEFORE sentinel — proving the redirect CAUSED the change.
     """
-    vm, forwarding_on, src_chase, _target_chase, _src_fallback, before = safesearch_vm
+    vm, cvm, forwarding_on, src_chase, _target_chase, _src_fallback, before = safesearch_vm
 
     # Given: assert the before-state (sentinel) so green proves the redirect CAUSED the change.
     assert h.resolves_to(before, STUB_DNS_A), (
@@ -183,7 +186,7 @@ def test_safesearch_cname_redirect_takes_effect(safesearch_vm: _SSFixture) -> No
     )
 
     # When: redirect is active (injected in the fixture).
-    after = h.dns_probe(vm, src_chase, "A")
+    after = h.dns_probe_client(cvm, src_chase, "A")
 
     # Then: NOERROR with records, not SERVFAIL, and different from the sentinel before-state.
     assert after.rcode != "SERVFAIL", (
@@ -215,10 +218,10 @@ def test_safesearch_cname_chase_reaches_target(safesearch_vm: _SSFixture) -> Non
     And a direct lookup of target_chase returns the same fixture address (cache-population
         / chase-consistency check: the iterator populated target_chase's cache entry).
     """
-    vm, forwarding_on, src_chase, target_chase, _src_fallback, _before = safesearch_vm
+    vm, cvm, forwarding_on, src_chase, target_chase, _src_fallback, _before = safesearch_vm
 
     for rtype, expected in (("A", h.SS_TARGET_A), ("AAAA", h.SS_TARGET_AAAA)):
-        redirected = h.dns_probe(vm, src_chase, rtype)
+        redirected = h.dns_probe_client(cvm, src_chase, rtype)
         assert redirected.rcode == "NOERROR" and redirected.records, (
             f"[forwarding={forwarding_on}] {src_chase} {rtype} did not resolve after redirect: {redirected}"
         )
@@ -230,7 +233,7 @@ def test_safesearch_cname_chase_reaches_target(safesearch_vm: _SSFixture) -> Non
         )
 
         # Cache-population check: target_chase itself resolves to the same fixture address.
-        target_ans = h.dns_probe(vm, target_chase, rtype)
+        target_ans = h.dns_probe_client(cvm, target_chase, rtype)
         assert target_ans.rcode == "NOERROR" and target_ans.records, (
             f"[forwarding={forwarding_on}] {target_chase} {rtype} did not resolve "
             f"(expected cache hit from the chase): {target_ans}"
@@ -261,13 +264,13 @@ def test_safesearch_cname_fallback_to_baked_ip(safesearch_vm: _SSFixture) -> Non
     This test pairs with test_safesearch_cname_chase_reaches_target to prove #1 (chase)
     and #2 (baked fallback) are DISTINCT real branches — not the same code path.
     """
-    vm, forwarding_on, _src_chase, _target_chase, src_fallback, _before = safesearch_vm
+    vm, cvm, forwarding_on, _src_chase, _target_chase, src_fallback, _before = safesearch_vm
 
     for rtype, expected, not_expected_label, not_expected in (
         ("A", h.SS_BAKED_A, "chase/sentinel", {h.SS_TARGET_A, STUB_DNS_A}),
         ("AAAA", h.SS_BAKED_AAAA, "chase/sentinel", {h.SS_TARGET_AAAA}),
     ):
-        ans = h.dns_probe(vm, src_fallback, rtype)
+        ans = h.dns_probe_client(cvm, src_fallback, rtype)
         assert ans.rcode == "NOERROR" and ans.records, (
             f"[forwarding={forwarding_on}] {src_fallback} {rtype} should resolve via baked "
             f"fallback (NODATA target); got {ans}"

--- a/tests/smoke/test_smoke_upstream_block.py
+++ b/tests/smoke/test_smoke_upstream_block.py
@@ -53,11 +53,11 @@ pytestmark = [pytest.mark.smoke, pytest.mark.upstream]
 
 
 @pytest.fixture(scope="module")
-def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+def deployed_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[tuple[SmokeVM, SmokeVM]]:  # noqa: ARG001
     """Deploy the branch .pkg once with DNSBL/python active and forwarding to the stub.
 
     ``use_system_dns_upstream`` wires forwarding:
-      guest Unbound → 10.0.2.2:53 (SLIRP NAT) → runner 127.0.0.1:53 (stub).
+      guest Unbound → 10.10.0.2:53 (SLIRP NAT) → runner 127.0.0.1:53 (stub).
 
     pfBlockerNG force-disables DNSBL — and so never injects the Unbound ``python:``
     module, meaning ``inplace_cb_query_response`` is never registered — unless at least
@@ -83,8 +83,9 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     )
     h.reload(smoke_vm, "update")
     h.wait_unbound_ready(smoke_vm)
+    h.assert_link_health(client_vm, smoke_vm, control_name=h.unique_domain())
     try:
-        yield smoke_vm
+        yield smoke_vm, client_vm
     finally:
         h.unblock_egress()
         h.collect_host_diagnostics(smoke_vm)
@@ -143,7 +144,9 @@ class TestUpstreamBlockNXRA:
     The classifier detects this as NXRA and logs it.
     """
 
-    def test_nxra_block_detected_and_logged(self, deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+    def test_nxra_block_detected_and_logged(
+        self, deployed_vm: tuple[SmokeVM, SmokeVM], stub_dns: _StubDnsServer
+    ) -> None:
         """
         Given: Unbound forwards to the stub; stub answers NXDOMAIN (RA=0, AA=0) for a name.
         When: the on-box resolver resolves that name.
@@ -151,17 +154,18 @@ class TestUpstreamBlockNXRA:
           - Client gets NXDOMAIN (upstream answer passed through).
           - A log line with b_type=Upstream_Block and b_eval=NXRA appears in dnsbl.log.
         """
+        vm, cvm = deployed_vm
         name = h.unique_domain("pfbsmoke-upstream-nxra")
         stub_dns.register_nxdomain(name)  # default: RA=0, AA=0
 
-        # Resolve on-box; first response is authoritative.
-        ans = h.dns_probe(deployed_vm, name, "A")
+        # Resolve via civm; first response is authoritative.
+        ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
-        lines = _wait_for_upstream_block_lines(deployed_vm, name)
+        lines = _wait_for_upstream_block_lines(vm, name)
         assert lines, (
             f"No Upstream_Block log line for {name} after NXRA probe.\n"
-            f"Log excerpt (last 3000 chars):\n{_read_dnsbl_log(deployed_vm)[-3000:]}"
+            f"Log excerpt (last 3000 chars):\n{_read_dnsbl_log(vm)[-3000:]}"
         )
         assert any("NXRA" in line for line in lines), (
             f"Upstream_Block line found but b_eval is not NXRA.\nLines: {lines}"
@@ -171,7 +175,9 @@ class TestUpstreamBlockNXRA:
 class TestUpstreamBlockEDE15:
     """EDE 15 (Blocked) signal: upstream NXDOMAIN with RFC 8914 EDE option."""
 
-    def test_ede15_block_detected_with_provider(self, deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+    def test_ede15_block_detected_with_provider(
+        self, deployed_vm: tuple[SmokeVM, SmokeVM], stub_dns: _StubDnsServer
+    ) -> None:
         """
         Given: stub answers NXDOMAIN + EDE INFO-CODE 15 with EXTRA-TEXT "Quad9".
         When: the on-box resolver resolves that name.
@@ -180,16 +186,15 @@ class TestUpstreamBlockEDE15:
           - b_eval is "EDE15 (Blocked)".
           - feed/provider column contains "Quad9".
         """
+        vm, cvm = deployed_vm
         name = h.unique_domain("pfbsmoke-upstream-ede15")
         stub_dns.register_nxdomain(name, ede_info_code=15, ede_text="Quad9")
 
-        ans = h.dns_probe(deployed_vm, name, "A")
+        ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
-        lines = _wait_for_upstream_block_lines(deployed_vm, name)
-        assert lines, (
-            f"No Upstream_Block log line for {name} (EDE15).\nLog excerpt:\n{_read_dnsbl_log(deployed_vm)[-3000:]}"
-        )
+        lines = _wait_for_upstream_block_lines(vm, name)
+        assert lines, f"No Upstream_Block log line for {name} (EDE15).\nLog excerpt:\n{_read_dnsbl_log(vm)[-3000:]}"
         assert any("EDE15 (Blocked)" in line for line in lines), f"b_eval is not 'EDE15 (Blocked)'.\nLines: {lines}"
         assert any("Quad9" in line for line in lines), (
             f"Provider 'Quad9' not found in Upstream_Block line.\nLines: {lines}"
@@ -203,7 +208,9 @@ class TestUpstreamBlockEDE17:
     signals are exercised on the live-VM path (test-coverage mandate: every branch).
     """
 
-    def test_ede17_block_detected_with_provider(self, deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+    def test_ede17_block_detected_with_provider(
+        self, deployed_vm: tuple[SmokeVM, SmokeVM], stub_dns: _StubDnsServer
+    ) -> None:
         """
         Given: stub answers NXDOMAIN + EDE INFO-CODE 17 (Filtered) with EXTRA-TEXT "Quad9".
         When: the on-box resolver resolves that name.
@@ -212,16 +219,15 @@ class TestUpstreamBlockEDE17:
           - b_eval is "EDE17 (Filtered)".
           - feed/provider column contains "Quad9".
         """
+        vm, cvm = deployed_vm
         name = h.unique_domain("pfbsmoke-upstream-ede17")
         stub_dns.register_nxdomain(name, ede_info_code=17, ede_text="Quad9")
 
-        ans = h.dns_probe(deployed_vm, name, "A")
+        ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
-        lines = _wait_for_upstream_block_lines(deployed_vm, name)
-        assert lines, (
-            f"No Upstream_Block log line for {name} (EDE17).\nLog excerpt:\n{_read_dnsbl_log(deployed_vm)[-3000:]}"
-        )
+        lines = _wait_for_upstream_block_lines(vm, name)
+        assert lines, f"No Upstream_Block log line for {name} (EDE17).\nLog excerpt:\n{_read_dnsbl_log(vm)[-3000:]}"
         assert any("EDE17 (Filtered)" in line for line in lines), f"b_eval is not 'EDE17 (Filtered)'.\nLines: {lines}"
         assert any("Quad9" in line for line in lines), (
             f"Provider 'Quad9' not found in Upstream_Block line.\nLines: {lines}"
@@ -236,7 +242,9 @@ class TestUpstreamBlockAuthoritativeControl:
     resolver. The classifier must return None.
     """
 
-    def test_authoritative_nxdomain_not_logged(self, deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+    def test_authoritative_nxdomain_not_logged(
+        self, deployed_vm: tuple[SmokeVM, SmokeVM], stub_dns: _StubDnsServer
+    ) -> None:
         """
         Given: stub answers NXDOMAIN with AA=1, RA=0 (authoritative NXDOMAIN).
         When: the on-box resolver resolves that name.
@@ -246,15 +254,16 @@ class TestUpstreamBlockAuthoritativeControl:
 
         Before-state: same name would be detected if AA=0 (the NXRA case above).
         """
+        vm, cvm = deployed_vm
         name = h.unique_domain("pfbsmoke-upstream-auth")
         stub_dns.register_nxdomain(name, authoritative=True)  # AA=1, RA=0
 
         # Before: confirm the name returns NXDOMAIN (the upstream answered).
-        ans = h.dns_probe(deployed_vm, name, "A")
+        ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
         time.sleep(2)
-        log = _read_dnsbl_log(deployed_vm)
+        log = _read_dnsbl_log(vm)
         lines = _upstream_block_lines(log, name)
         assert not lines, (
             f"Authoritative NXDOMAIN (AA=1) produced an Upstream_Block line — "
@@ -269,7 +278,9 @@ class TestUpstreamBlockForwarderNaturalControl:
     (a recursive resolver relaying a real NXDOMAIN). The classifier must return None.
     """
 
-    def test_forwarder_natural_nxdomain_not_logged(self, deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+    def test_forwarder_natural_nxdomain_not_logged(
+        self, deployed_vm: tuple[SmokeVM, SmokeVM], stub_dns: _StubDnsServer
+    ) -> None:
         """
         Given: stub answers NXDOMAIN with RA=1, AA=0 (forwarder-relayed natural NXDOMAIN).
         When: the on-box resolver resolves that name.
@@ -277,14 +288,15 @@ class TestUpstreamBlockForwarderNaturalControl:
           - Client gets NXDOMAIN.
           - NO Upstream_Block log line appears (RA=1 excludes it).
         """
+        vm, cvm = deployed_vm
         name = h.unique_domain("pfbsmoke-upstream-fwdnat")
         stub_dns.register_nxdomain(name, recursion_available=True)  # RA=1, AA=0
 
-        ans = h.dns_probe(deployed_vm, name, "A")
+        ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
         time.sleep(2)
-        log = _read_dnsbl_log(deployed_vm)
+        log = _read_dnsbl_log(vm)
         lines = _upstream_block_lines(log, name)
         assert not lines, (
             f"Forwarder-natural NXDOMAIN (RA=1) produced an Upstream_Block line — "
@@ -295,7 +307,7 @@ class TestUpstreamBlockForwarderNaturalControl:
 class TestUpstreamBlockNormalControl:
     """Control: a name resolving normally must NOT produce an Upstream_Block line."""
 
-    def test_normal_resolution_not_logged(self, deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+    def test_normal_resolution_not_logged(self, deployed_vm: tuple[SmokeVM, SmokeVM], stub_dns: _StubDnsServer) -> None:
         """
         Given: an unregistered name (stub answers NOERROR with sentinel A record).
         When: the on-box resolver resolves it.
@@ -304,15 +316,16 @@ class TestUpstreamBlockNormalControl:
         Before-state: the name resolves to the stub sentinel, proving the forwarding
         path works. After: no Upstream_Block line in the log.
         """
+        vm, cvm = deployed_vm
         name = h.unique_domain("pfbsmoke-upstream-ctrl")
         # Not registered → stub answers NOERROR + sentinel STUB_DNS_A.
 
         # Before: confirm normal resolution works (forwarding active, stub reachable).
-        ans = h.dns_probe(deployed_vm, name, "A")
+        ans = h.dns_probe_client(cvm, name, "A")
         assert h.resolves_to(ans, h.STUB_DNS_A), f"Control name should resolve to sentinel {h.STUB_DNS_A}, got {ans}"
 
         time.sleep(2)
-        log = _read_dnsbl_log(deployed_vm)
+        log = _read_dnsbl_log(vm)
         lines = _upstream_block_lines(log, name)
         assert not lines, (
             f"Normal resolution produced Upstream_Block lines — over-triggering.\n"
@@ -390,18 +403,21 @@ class TestUpstreamCounterIncrement:
     strict increase so that the test fails if the counter is stuck.
     """
 
-    def test_upstream_counter_increments_on_nxra_block(self, deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
+    def test_upstream_counter_increments_on_nxra_block(
+        self, deployed_vm: tuple[SmokeVM, SmokeVM], stub_dns: _StubDnsServer
+    ) -> None:
         """
         Given: DNSBL active, forwarding to stub, dnsbl table seeded with Upstream row.
         When: stub answers NXDOMAIN (RA=0, AA=0) — an NXRA upstream block is logged.
         Then: the on-box dnsbl counter for groupname='Upstream' strictly increases.
         """
+        vm, cvm = deployed_vm
         name = h.unique_domain("pfbsmoke-upstream-ctr")
         stub_dns.register_nxdomain(name)  # RA=0, AA=0 -> NXRA block
 
         # Before: record the baseline counter (row may already have a count from
         # earlier tests in this session).
-        baseline = _read_upstream_counter(deployed_vm)
+        baseline = _read_upstream_counter(vm)
         assert baseline >= 0, (
             "Upstream row not found in dnsbl table before probe — "
             "the Python DB-init seed (_db_create) did not create it. "
@@ -409,20 +425,20 @@ class TestUpstreamCounterIncrement:
         )
 
         # When: trigger a block (first response is authoritative — assert it arrived).
-        ans = h.dns_probe(deployed_vm, name, "A")
+        ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
         # Confirm the block line was logged (proves the detection fired, not just a
         # natural NXDOMAIN — the counter increment is meaningless without this).
-        lines = _wait_for_upstream_block_lines(deployed_vm, name)
+        lines = _wait_for_upstream_block_lines(vm, name)
         assert lines, (
             f"No Upstream_Block log line for {name} — detection did not fire; "
             f"counter increment cannot be attributed to an upstream block.\n"
-            f"Log excerpt:\n{_read_dnsbl_log(deployed_vm)[-2000:]}"
+            f"Log excerpt:\n{_read_dnsbl_log(vm)[-2000:]}"
         )
 
         # Then: wait for the async flush and assert strict increase.
-        final = _wait_for_counter_above(deployed_vm, baseline)
+        final = _wait_for_counter_above(vm, baseline)
         assert final > baseline, (
             f"Upstream counter did not increase after NXRA block: "
             f"baseline={baseline}, final={final}. "

--- a/tests/test_smoke_harness_defaults.py
+++ b/tests/test_smoke_harness_defaults.py
@@ -1,37 +1,36 @@
-"""Pin the smoke-harness boot defaults that ADR-24 parameterizes.
+"""Pin the smoke-harness boot defaults for the two-VM topology (ADR-04 / ADR-24).
 
-The pfSense Plus smoke image (ADR-24) must boot with ITS source-VM identity (NIC
-MAC + SMBIOS type-1 uuid), distinct from the CE pins, because pfSense matches
-interface assignment by MAC AND the Plus license/NDI registration is keyed to the
-MAC + uuid pair (the NDI is derived from both). ``tests/smoke/conftest.py`` boots
-exclusively via ``boot_vm.sh``, so single ``SMOKE_VM_MAC`` / ``SMOKE_VM_SMBIOS_UUID``
-env overrides parameterize the whole harness while keeping CE byte-identical when
-unset (the Plus values come from the SMOKE_PLUS_* secrets, never the public matrix).
+``tests/smoke/conftest.py`` boots exclusively via ``boot_vm.sh``, which takes a
+``--role pfsense|client`` selector and is parameterized by env:
 
-These tests read ``boot_vm.sh`` as text (no QEMU/VM needed) and pin, for BOTH the
-MAC and the SMBIOS uuid:
+* ``SMOKE_VM_MAC`` — the pfSense NIC MAC(s). CE identity is don't-care, so the
+  default is EMPTY (QEMU assigns each NIC a default MAC). A pfSense Plus image
+  sets it to the license/NDI-keyed, NEWLINE-separated 8-MAC list (one per NIC in
+  order), split per-NIC by ``nth_mac``. The Plus values come from the
+  SMOKE_PLUS_* secrets, never the public matrix.
+* ``SMOKE_VM_SMBIOS_UUID`` — SMBIOS type-1 uuid. CE pins the public source-VM
+  uuid; a Plus image overrides it (its NDI is derived from MAC + uuid).
+* ``SMOKE_CLIENT_MAC_ADDRESS`` — the civm data-NIC MAC, matched by pfSense's
+  static DHCP lease so the client always gets 192.168.1.10.
 
-* the CE default string is present — a regression pin guarding against accidental
-  drift of the documented CE source-VM value (each appears in both the header
-  comment and the assignment); and
-* the assignment is the env-override form ``${SMOKE_VM_*:-<CE pin>}`` — so a Plus
-  run can override it while CE keeps the pin as the default.
-
-Both branches of each override are covered: CE (env unset -> pin) by the default
-string assertion, Plus (env set -> override) by the override-form assertion.
+These tests read ``boot_vm.sh`` as text (no QEMU/VM needed) and pin the
+load-bearing topology contract: the management/LAN/WAN addressing the harness
+and the image agree on, and the identity override forms.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-# The CE source-VM MAC pin (also documented in boot_vm.sh's header + the ADR).
-CE_DEFAULT_MAC = "BC:24:11:37:9C:AC"
-# The CE source-VM SMBIOS type-1 uuid pin. Like the MAC it is per-image: CE pins
-# the public source-VM uuid; a Plus image overrides via SMOKE_VM_SMBIOS_UUID (its
-# NDI is derived from MAC + uuid, so the uuid is as license-keyed as the MAC and
-# comes from the SMOKE_PLUS_SMBIOS_UUID secret, never the public matrix).
+# The CE source-VM SMBIOS type-1 uuid pin (also in boot_vm.sh's header + the ADR).
+# CE pins the public source-VM uuid; a Plus image overrides via
+# SMOKE_VM_SMBIOS_UUID (its NDI is derived from MAC + uuid, so the uuid is as
+# license-keyed as the MAC and comes from the SMOKE_PLUS_SMBIOS_UUID secret).
 CE_DEFAULT_SMBIOS_UUID = "58fd7964-c40c-4f47-bf02-3fdad18f8b00"
+
+# The static management IP baked into every pfSense image — the host->guest
+# ssh/web forwards target it, so a drift here silently breaks the control path.
+PFSENSE_MGMT_IP = "10.0.0.20"
 
 _BOOT_VM_SH = Path(__file__).resolve().parent.parent / "tests" / "smoke" / "boot_vm.sh"
 
@@ -40,36 +39,116 @@ def _boot_vm_text() -> str:
     return _BOOT_VM_SH.read_text(encoding="utf-8")
 
 
-def test_ce_default_mac_pin_present() -> None:
-    """The CE source-VM MAC pin is present in boot_vm.sh.
+# The CE source VM's 8 NIC MACs (net0..net7, in order), committed in boot_vm.sh
+# as non-secret defaults so a CE boot mirrors the source hardware. net0 is the
+# long-standing WAN pin. A MAC is not sensitive; the Plus NDI identity is, and
+# stays in the SMOKE_PLUS_MAC secret.
+CE_DEFAULT_MACS = (
+    "BC:24:11:37:9C:AC",
+    "BC:24:11:80:42:35",
+    "BC:24:11:D6:90:DD",
+    "BC:24:11:FB:41:8A",
+    "BC:24:11:2D:95:0A",
+    "BC:24:11:36:D3:34",
+    "BC:24:11:02:0B:68",
+    "BC:24:11:46:D1:DE",
+)
 
-    Regression pin: the documented CE source-VM MAC must stay the harness
-    default; a typo'd or drifted pin would drop it and fail. (It legitimately
-    appears more than once — the header comment plus the assignment default —
-    so this asserts presence, not a count.)
+
+def test_vm_mac_defaults_to_ce_source_macs() -> None:
+    """VM_MAC defaults to the CE source VM's 8 NIC MACs; SMOKE_VM_MAC overrides.
+
+    With SMOKE_VM_MAC empty/unset the expansion falls back to the committed
+    DEFAULT_CE_MAC list, so each NIC gets its source MAC (net0..net7 in order). A
+    Plus run sets SMOKE_VM_MAC to its NDI-keyed list, taking precedence (the
+    per-NIC split is pinned by the test below). Pins the fallback form and every
+    default MAC, in NIC order.
     """
     text = _boot_vm_text()
-    assert CE_DEFAULT_MAC in text
+    assert 'VM_MAC="${SMOKE_VM_MAC:-$DEFAULT_CE_MAC}"' in text
+    # Every CE default MAC present, in NIC order, within the DEFAULT_CE_MAC block.
+    block = text[text.index("DEFAULT_CE_MAC=") :]
+    last = -1
+    for mac in CE_DEFAULT_MACS:
+        pos = block.find(mac)
+        assert pos != -1, f"missing CE default MAC {mac}"
+        assert pos > last, f"CE default MAC {mac} out of NIC order"
+        last = pos
 
 
-def test_vm_mac_is_env_override_with_ce_default() -> None:
-    """VM_MAC is the SMOKE_VM_MAC override form, defaulting to the CE pin.
+def test_plus_mac_list_split_per_nic() -> None:
+    """The MAC list is split per-NIC by line (Plus: 8 MACs, one per NIC in order).
 
-    With SMOKE_VM_MAC unset the expansion yields the CE pin (default path,
-    byte-identical to pre-ADR-24); a Plus run sets SMOKE_VM_MAC to override it.
+    ``nth_mac`` selects the Nth line of the newline-separated SMOKE_VM_MAC, and
+    the device is emitted WITH ``mac=`` only when that line is non-empty (CE
+    omits it). Pins the split mechanism + the conditional application.
     """
     text = _boot_vm_text()
-    expected = f'VM_MAC="${{SMOKE_VM_MAC:-{CE_DEFAULT_MAC}}}"'
-    assert expected in text
+    assert "nth_mac()" in text
+    assert "printf '%s\\n' \"$VM_MAC\" | sed -n" in text
+    assert 'mac="$(nth_mac "$i")"' in text
+
+
+def test_client_nic_macs_default_with_env_override() -> None:
+    """The civm NICs default to the source VM's MACs; env overrides each.
+
+    net1 (data) connects to the pfSense LAN socket and carries the static-lease
+    MAC so the DHCP mapping hands the client 192.168.1.10; net0 (management) gets
+    its own MAC. Both have committed defaults, overridable via
+    SMOKE_CLIENT_MAC_ADDRESS / SMOKE_CLIENT_MGMT_MAC — so the client role needs
+    no env to boot.
+    """
+    text = _boot_vm_text()
+    assert 'CLIENT_MGMT_MAC="${SMOKE_CLIENT_MGMT_MAC:-BC:24:11:29:A4:1B}"' in text
+    assert 'CLIENT_MAC="${SMOKE_CLIENT_MAC_ADDRESS:-02:49:E4:CE:92:72}"' in text
+
+
+def test_client_smbios_uuid_default_with_env_override() -> None:
+    """civm SMBIOS type-1 uuid defaults to the civm source VM's; env overrides.
+
+    Mirrors the pfSense SMBIOS pin: the client role boots with a stable SMBIOS
+    uuid (so machine-id / DHCP identity stay stable across overlay boots),
+    overridable via SMOKE_CLIENT_SMBIOS_UUID. The arg is applied for the client
+    role (`-smbios type=1,uuid=...`).
+    """
+    text = _boot_vm_text()
+    assert 'CLIENT_SMBIOS_UUID="${SMOKE_CLIENT_SMBIOS_UUID:-7dc13783-e65c-4f62-8fd8-45eeae4c77b9}"' in text
+    assert "type=1,uuid=${CLIENT_SMBIOS_UUID}" in text
+
+
+def test_pfsense_management_path_targets_static_ip() -> None:
+    """The host->guest ssh/web forwards target the image's static management IP.
+
+    The forwards live on net1 (management, 10.0.0.0/16) and point at
+    10.0.0.20 — the harness control path. A drift in either the subnet or the IP
+    would break SSH/Web reachability.
+    """
+    text = _boot_vm_text()
+    assert f'PFSENSE_MGMT_IP="{PFSENSE_MGMT_IP}"' in text
+    assert "net=10.0.0.0/16" in text
+    assert "hostfwd=tcp::${SSH_HOSTPORT}-${PFSENSE_MGMT_IP}:22" in text
+
+
+def test_pfsense_wan_and_lan_topology() -> None:
+    """WAN is the 10.10.0.0/16 runner-services net; LAN is the socket crossover.
+
+    The guest reaches the runner-side mock servers via the WAN host alias
+    10.10.0.2; the LAN (net2) is a QEMU socket LISTENER that the civm data NIC
+    connects to. Pins both addressing facts the rest of the harness assumes.
+    """
+    text = _boot_vm_text()
+    assert "net=10.10.0.0/24,host=10.10.0.2" in text
+    assert "socket,id=net2,listen=127.0.0.1:${LAN_SOCKET_PORT}" in text
+    assert "socket,id=net1,connect=127.0.0.1:${LAN_SOCKET_PORT}" in text
 
 
 def test_ce_default_smbios_uuid_pin_present() -> None:
     """The CE source-VM SMBIOS uuid pin is present in boot_vm.sh.
 
-    Regression pin (mirror of the MAC pin): the documented CE source-VM SMBIOS
-    uuid must stay the harness default; a typo'd or drifted pin would drop it and
-    fail. It legitimately appears more than once (header comment + assignment),
-    so this asserts presence, not a count.
+    Regression pin: the documented CE source-VM SMBIOS uuid must stay the harness
+    default; a typo'd or drifted pin would drop it and fail. It legitimately
+    appears more than once (header comment + assignment), so this asserts
+    presence, not a count.
     """
     text = _boot_vm_text()
     assert CE_DEFAULT_SMBIOS_UUID in text
@@ -78,11 +157,10 @@ def test_ce_default_smbios_uuid_pin_present() -> None:
 def test_vm_smbios_uuid_is_env_override_with_ce_default() -> None:
     """VM_SMBIOS_UUID is the SMOKE_VM_SMBIOS_UUID override form, defaulting to the CE uuid.
 
-    With SMOKE_VM_SMBIOS_UUID unset the expansion yields the CE pin (default path,
-    byte-identical to pre-ADR-24); a Plus run sets SMOKE_VM_SMBIOS_UUID (from the
-    SMOKE_PLUS_SMBIOS_UUID secret) to override it. Both branches of the override are
-    covered: CE (env unset -> pin) by the default-string assertion above, Plus (env
-    set -> override) by this override-form assertion.
+    With SMOKE_VM_SMBIOS_UUID unset the expansion yields the CE pin; a Plus run
+    sets SMOKE_VM_SMBIOS_UUID (from the SMOKE_PLUS_SMBIOS_UUID secret) to override
+    it. Both branches covered: CE (unset -> pin) by the presence test above, Plus
+    (set -> override) by this override-form assertion.
     """
     text = _boot_vm_text()
     expected = f'VM_SMBIOS_UUID="${{SMOKE_VM_SMBIOS_UUID:-{CE_DEFAULT_SMBIOS_UUID}}}"'

--- a/tests/test_smoke_harness_defaults.py
+++ b/tests/test_smoke_harness_defaults.py
@@ -3,11 +3,11 @@
 ``tests/smoke/conftest.py`` boots exclusively via ``boot_vm.sh``, which takes a
 ``--role pfsense|client`` selector and is parameterized by env:
 
-* ``SMOKE_VM_MAC`` — the pfSense NIC MAC(s). CE identity is don't-care, so the
-  default is EMPTY (QEMU assigns each NIC a default MAC). A pfSense Plus image
-  sets it to the license/NDI-keyed, NEWLINE-separated 8-MAC list (one per NIC in
-  order), split per-NIC by ``nth_mac``. The Plus values come from the
-  SMOKE_PLUS_* secrets, never the public matrix.
+* ``SMOKE_VM_MAC`` — the pfSense NIC MAC(s). CE identity is don't-care, so when
+  unset it falls back to the pinned CE source-VM 8-MAC list (``DEFAULT_CE_MAC``,
+  one per NIC in order). A pfSense Plus image overrides it with the
+  license/NDI-keyed, NEWLINE-separated 8-MAC list, split per-NIC by ``nth_mac``.
+  The Plus values come from the SMOKE_PLUS_* secrets, never the public matrix.
 * ``SMOKE_VM_SMBIOS_UUID`` — SMBIOS type-1 uuid. CE pins the public source-VM
   uuid; a Plus image overrides it (its NDI is derived from MAC + uuid).
 * ``SMOKE_CLIENT_MAC_ADDRESS`` — the civm data-NIC MAC, matched by pfSense's
@@ -130,7 +130,7 @@ def test_pfsense_management_path_targets_static_ip() -> None:
 
 
 def test_pfsense_wan_and_lan_topology() -> None:
-    """WAN is the 10.10.0.0/16 runner-services net; LAN is the socket crossover.
+    """WAN is the 10.10.0.0/24 runner-services net; LAN is the socket crossover.
 
     The guest reaches the runner-side mock servers via the WAN host alias
     10.10.0.2; the LAN (net2) is a QEMU socket LISTENER that the civm data NIC


### PR DESCRIPTION
## Summary

Rewires the ADR-04 live-VM smoke harness to a **two-VM topology** (an 8-NIC pfSense appliance + a Debian client VM behind the LAN, so DNS/DNSBL tests probe from a real LAN client), and fixes several firewall-object bugs the new topology surfaced — most of them in the ADR-36 DNS-redirect and ADR-37 DoT/DoQ-block features, which run on a live VM for the first time here.

## Firewall-object fixes (`sync_package_pfblockerng`)

- **Sweep ordering** — the defensive disable-sweep (`pfb_fwobj_sweep`) removes every `pfB_`-owned `nat/rule`/`filter/rule` row, so it must run **before** the ADR-36/37 syncs re-assert their objects; otherwise it wiped the redirect/DoT NAT rules they had just created.
- **Auto-rule rebuild** — the legacy auto-rule region strips every `pfB_`-descr filter row to rebuild pfBlockerNG's own rules; it now **exempts** the `pfB_DNS_Redirect_*` / `pfB_DoT_Block_*` rows (owned by their own syncs).
- **Filter reload** — the redirect/DoT syncs now flag `filter_configure` when they change config, so the rules are actually loaded into `pf`.
- **Rule metadata** — the redirect/DoT rule builders now stamp a unique `tracker` + `created`/`updated` (mirroring pfBlockerNG's own auto-rules), without which the pfSense rule generator drops the rows.

## Smoke harness

- Two-VM boot (`boot_vm.sh` dual role), civm client fixture + LAN-path `dig` probes, image wiring/caching.
- VM **serial console** is now copied into the uploaded diagnostics (`vm-serial.log`), redacted on Plus legs.
- Redeploy-after-uninstall guard so an uninstall case no longer breaks later tests in the same module.
- Layered firewall diagnostics (config.xml rows → `/tmp/rules.debug` → live `pfctl`) to localise where a rule is lost.

## Tests

- Off-box PHPUnit regression coverage for the sweep ordering, the auto-rule exemption, and the rule-metadata stamp (unique tracker + provenance). Full PHP suite green.

## Known-remaining (tracked, not regressions)

The live-VM smoke suite is **workflow-dispatch only** (not a PR gate). It is currently at 18 failing, all either feature bring-up or further two-VM topology adaptation:

- DNS-redirect / DoT-block rules are still dropped by the pfSense rule generator for rules carrying a `destination = (self)` — the feature's firewall-rule contract needs finishing; these features had never been exercised on a live VM before.
- `dnsbl_interface` defaults to `lo0` in the fwobj fixture (no DNSBL NAT by design); syslog block-probe should originate from the LAN client; IP-feed allowlist / aggregate timing / IPv6 local-subnet representation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TF2uW8hio45YxKwVeAWHYW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a role-based two-VM smoke harness (pfSense + client) with improved VM identity handling.
  * Enhanced image publishing (OCI metadata overrides + “print identity” mode) and image upgrades (SMBIOS support + expanded 8-NIC layout).
* **Bug Fixes**
  * pfBlockerNG disable-sweep and sync ordering now preserves DNS redirect/DoT/DoQ rules; synced redirect/bypass rules are stamped with unique tracker + provenance.
* **Tests**
  * Added lifecycle regression tests for DNS redirect and DoT/DoQ, plus richer smoke diagnostics; smoke queries now run via the dedicated client VM.
* **Chores**
  * Pre-commit now performs staged-file-only fast checks; CI smoke/UI workflows updated for identity resolution, masking, caching, and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->