### PR TITLE
dev: document the tcsh / always-/bin/sh guest-SSH rule; harden install-pkg.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,6 +701,14 @@ relearn:
   (`::` == `::0`).
 - **Unbound is chrooted at `/var/unbound`** — files its python module reads must be
   chroot-relative; a host-absolute path silently fails to load.
+- **pfSense root's login shell is `tcsh`, not `sh` — always drive the guest via `/bin/sh`.**
+  A command sent to the bare login shell over SSH is parsed by **tcsh**, which mangles POSIX-sh
+  syntax (`2>&1`/`>&` redirection, here-docs, and a `grep -E` whose pattern contains `()`/`|`/`$`),
+  so it can silently mis-parse rather than error — it once produced a false `rules.debug:0` read
+  and sent an investigation down the wrong path. `SmokeVM.ssh` already wraps every guest command
+  in `/bin/sh -c`; when you add a new on-box command (or run one by hand), assume tcsh and force
+  `/bin/sh` — never rely on the login shell being POSIX. (`pfSsh.php` snippets are the separate
+  stdin/`exec`/`exit` contract, not a tcsh command line.)
 - **Enable chain:** DNSBL `mode=='enabled'` needs `enable_cb=on` + `pfb_dnsbl=on` + the DNS
   Resolver enabled (`unbound_state`). On `devel`, `dnsbl_mode`/`pfb_py_block` are dead keys
   (python is the only mode); on `main` they're still required.

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -86,6 +86,38 @@ python3 scripts/build-pkg-portable.py \
 `pkg add` checks a dep is PRESENT, not its version, so this `.pkg` installs on the
 baked-deps image.
 
+## Driving the pfSense guest — tcsh vs `/bin/sh`
+
+**pfSense `root`'s login shell is `tcsh`, not a POSIX `sh`.** A command sent to the bare
+login shell over SSH is therefore parsed by **tcsh**, and tcsh is *not* sh-compatible — so a
+script that works in your terminal can silently mis-parse on the guest, producing wrong output
+rather than an error. This bit a real investigation: a `grep -E` probe returned a false
+`rules.debug:0` (rule "absent") purely because tcsh mangled the command.
+
+**Rule: always wrap guest commands in `/bin/sh -c`.** Never assume the login shell is POSIX.
+
+```sh
+# WRONG — runs under tcsh:
+ssh root@pf "/usr/bin/grep -nE 'rdr|\\(self\\)|port (53|853)' /tmp/rules.debug"
+# RIGHT — force /bin/sh:
+ssh root@pf /bin/sh -c "'/usr/bin/grep -nE \"rdr|\\(self\\)|port (53|853)\" /tmp/rules.debug'"
+```
+
+tcsh specifically mishandles, vs `sh`:
+
+- redirection — `2>&1` is a syntax error in tcsh (it wants `>&`); a stray `2>&1` mis-parses;
+- here-documents and `$(...)` command substitution differ;
+- a `grep -E` / `awk` pattern containing `(`, `)`, `|`, `$`, `{` `}` — tcsh's history/glob/var
+  parsing can eat them before the program sees them;
+- quoting rules and `!` (history expansion) differ.
+
+In the harness this is already handled — `SmokeVM.ssh` routes **every** guest command through
+`/bin/sh -c` (the remote argv is re-quoted into one POSIX-sh command line; see
+`tests/smoke/conftest.py`). When you add a new on-box command (in the harness or by hand),
+keep that contract. The one exception is a **`pfSsh.php`** snippet, which is piped on **stdin**
+and ends with `exec` then `exit` (the pfSense developer-shell contract) — that is not a tcsh
+command line at all (see the `pfSsh.php` gotcha below).
+
 ## Gotchas that cost time
 
 - **Background VM boots get killed.** A plain `nohup boot_vm.sh ... &` from a tool/CI

--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -51,12 +51,26 @@ if [ -n "$SSH_KEY" ]; then
     SCP_OPTS="-i ${SSH_KEY} ${SCP_OPTS}"
 fi
 
+# Always run the remote command under /bin/sh. pfSense's root login shell is tcsh,
+# and sshd re-parses the command string with it; tcsh mangles POSIX sh constructs
+# (`;` chains, `||`, `2>&1` redirects) and any `grep -E`/glob pattern containing
+# `|` `(` `)` `[` `$` — exactly what the diagnostic commands below use. Single-quote
+# the whole command into one token so tcsh only sees `/bin/sh -c '<blob>'` and hands
+# the blob to sh for real parsing. Mirrors roundtrip.sh / conftest SmokeVM.ssh_argv.
 ssh_t() {
+    if [ "$#" -eq 1 ]; then
+        _cmd=$1
+    else
+        _cmd=""
+        for _a in "$@"; do
+            _q=$(printf '%s' "$_a" | sed "s/'/'\\\\''/g")
+            _cmd="${_cmd:+$_cmd }'${_q}'"
+        done
+    fi
+    _sq="'$(printf '%s' "$_cmd" | sed "s/'/'\\\\''/g")'"
     # SC2086: SSH_OPTS is a deliberate word-split option list.
-    # SC2029: callers pass literal remote-command strings — client-side
-    # expansion of "$@" into the remote command is intended.
-    # shellcheck disable=SC2086,SC2029
-    ssh ${SSH_OPTS} "$SSH_TARGET" "$@"
+    # shellcheck disable=SC2086
+    ssh ${SSH_OPTS} "$SSH_TARGET" /bin/sh -c "$_sq"
 }
 
 REMOTE="/tmp/$(basename "$PKGFILE")"

--- a/tests/smoke/wait_ready.sh
+++ b/tests/smoke/wait_ready.sh
@@ -89,6 +89,10 @@ while :; do
     fi
 
     SSH_READY=0
+    # The probe is a bare `true` ON PURPOSE: pfSense root's login shell is tcsh, which
+    # sshd uses to parse the remote command, and tcsh mangles POSIX-sh syntax. `true` has
+    # no metacharacters so it is tcsh-safe; if this ever needs a richer command, wrap it in
+    # `/bin/sh -c '<single-quoted blob>'` (see scripts/install-pkg.sh / tests/smoke/roundtrip.sh).
     # shellcheck disable=SC2086
     if "$SSH" $SSH_OPTS "root@${HOST}" true 2>/dev/null; then
         SSH_READY=1


### PR DESCRIPTION
Pin the tcsh gotcha that cost a real investigation (a `grep -E` probe returned a false
`rules.debug:0` because pfSense root's **tcsh** login shell mangled the command).

- **Document it** — a dedicated "tcsh vs `/bin/sh`" section in `docs/misc/local-smoke-debian.md`
  and a bullet in `CLAUDE.md`'s smoke section (loaded every session).
- **Harden `scripts/install-pkg.sh`** — `ssh_t()` now wraps every guest command in
  `/bin/sh -c '<single-quoted blob>'` (mirroring `roundtrip.sh` / conftest `SmokeVM.ssh_argv`,
  both already wrapped). Its diagnostic commands use exactly the `;`/`|`/`grep -E`/`2>&1`
  syntax tcsh would mis-parse. Quoting round-trip verified locally.
- **Note in `tests/smoke/wait_ready.sh`** why its probe is a bare (tcsh-safe) `true`.

Docs are CI-skipped; the shell changes are lint-clean (sh -n + ShellCheck).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on executing remote commands safely in test environments.
  * Clarified best practices for developers running commands on guest systems during smoke testing.

* **Chores**
  * Enhanced test infrastructure scripts to ensure reliable command execution across different shell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->