### PR TITLE
pfblockerng: stack Permit Firewall Rules row + title-case/hyphenate DNSBL labels

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2746,7 +2746,7 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'pfb_dnsbl_lenient',
-	gettext('Lenient feed parsing'),
+	gettext('Lenient Feed Parsing'),
 	'Enable',
 	pfb_cfg_toggle_read($pconfig['pfb_dnsbl_lenient']) === PfbToggle::On,
 	'on'
@@ -2756,11 +2756,11 @@ $section->addInput(new Form_Checkbox(
 
 $section->addInput(new Form_Checkbox(
 	'pfb_noaaaa',
-	gettext('no AAAA'),
+	gettext('no-AAAA'),
 	'Enable',
 	pfb_cfg_toggle_read($pconfig['pfb_noaaaa']) === PfbToggle::On,
 	'on'
-))->setHelp('Enable the no-AAAA feature. This will block all (IPv6) AAAA DNS requests for the defined domains. no AAAA List below.');
+))->setHelp('Enable the no-AAAA feature. This will block all (IPv6) AAAA DNS requests for the defined domains. no-AAAA List below.');
 
 $section->addInput(new Form_Checkbox(
 	'pfb_gp',
@@ -2943,10 +2943,10 @@ $section->addInput(new Form_Textarea(
 
 $form->add($section);
 
-$noaaaa_text = 'List of no AAAA domains to block the (IPv6) AAAA DNS Resolution.<br /><br />
+$noaaaa_text = 'List of no-AAAA domains to block the (IPv6) AAAA DNS Resolution.<br /><br />
 		Enter a single domain per line.<br />
-		Prefix domain with a "." to apply wildcard no AAAA to all Sub-Domains. &emsp;IE: (.example.com)<br /><br />
-		Any domain added to the no AAAA list, will never be filtered by any DNSBL blocking.<br /><br />
+		Prefix domain with a "." to apply wildcard no-AAAA to all Sub-Domains. &emsp;IE: (.example.com)<br /><br />
+		Any domain added to the no-AAAA list, will never be filtered by any DNSBL blocking.<br /><br />
 		This List is stored as \'Base64\' format in the config.xml file.<br /><br />
 		Changes to this option will require a Force Update to take effect.';
 
@@ -3072,29 +3072,27 @@ $form->add($section);
 
 $section = new Form_Section('DNSBL Configuration');
 
-$group = new Form_Group('Permit Firewall Rules');
-$group->add(new Form_Checkbox(
+$section->addInput(new Form_Checkbox(
 	'pfb_dnsbl_rule',
-	NULL,
+	gettext('Permit Firewall Rules'),
 	gettext('Enable'),
 	pfb_cfg_toggle_read($pconfig['pfb_dnsbl_rule']) === PfbToggle::On,
 	'on'
-))->setWidth(7)
-  ->setHelp('This will create \'Floating\' Firewall permit rules to allow traffic from the Selected Interface(s) to access<br />'
+))->setHelp('This will create \'Floating\' Firewall permit rules to allow traffic from the Selected Interface(s) to access<br />'
 		. 'the <strong>DNSBL Webserver</strong>. (ICMP and Webserver ports only).'
 		. '<br /><br />'
 		. 'This option is not designed to bypass DNSBL for the non-selected LAN segments<br />'
 		. 'This option is only required for networks with multiple LAN Segments.');
 
-$group->add(new Form_Select(
+$section->addInput(new Form_Select(
 	'dnsbl_allow_int',
-	NULL,
+	gettext('Interface(s)'),
 	$pconfig['dnsbl_allow_int'],
 	$options_dnsbl_interface,
 	TRUE
 ))->setAttribute('style', 'width: auto')
-  ->setAttribute('size', $options_dnsbl_interface_cnt);
-$section->add($group);
+  ->setAttribute('size', $options_dnsbl_interface_cnt)
+  ->setHelp('Interface(s) permitted to reach the DNSBL Webserver by the Permit Firewall Rules above.');
 
 $section->addInput(new Form_Select(
 	'global_log',

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -370,12 +370,12 @@ def test_dnsbl_control_fields_render(webui: WebUI, php_error_log_guard: PhpError
 
 
 def test_dnsbl_lenient_parsing_field_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
-    """The ADR-22 'Lenient feed parsing' toggle renders cleanly on the DNSBL page — so a
+    """The ADR-22 'Lenient Feed Parsing' toggle renders cleanly on the DNSBL page — so a
     regression that drops or breaks the field is caught at the render tier (not only by the
     feed-parsing smoke).
 
     Asserts the page passes the clean-render oracle AND that the POST field name
-    (``pfb_dnsbl_lenient``) and its 'Lenient feed parsing' label are present in the body.
+    (``pfb_dnsbl_lenient``) and its 'Lenient Feed Parsing' label are present in the body.
     ``php_error_log_guard`` enrolls this GET in the module-level no-growth sweep.
     """
     path = "/pfblockerng/pfblockerng_dnsbl.php"
@@ -385,7 +385,7 @@ def test_dnsbl_lenient_parsing_field_renders(webui: WebUI, php_error_log_guard: 
     body = resp.text
     for needle in (
         'name="pfb_dnsbl_lenient"',
-        "Lenient feed parsing",
+        "Lenient Feed Parsing",
     ):
         assert needle in body, f"DNSBL page is missing the lenient-parsing marker {needle!r}"
 


### PR DESCRIPTION
## Summary

Three small UI fixes on the DNSBL settings page (`pfblockerng_dnsbl.php`), grouped into one PR because they all touch the same file.

- **Permit Firewall Rules layout** (#478): the interface multiselect was added to the same `Form_Group` as the enable toggle, so it rendered side-by-side on one row. Split it into two stacked `addInput()` rows — the toggle keeps its help text, and the interface selector now sits on its own labelled row below it (matching the Floating-rules layout the reporter referenced). Added a short help line for the interface row.
- **Label casing** (#479): `Lenient feed parsing` → `Lenient Feed Parsing`, matching the title-case convention of the neighbouring field labels.
- **Text hyphenation** (#480): `no AAAA` → `no-AAAA` in the toggle label, its help text, and the no-AAAA list help block (the section title and textarea label were already hyphenated).

No configuration storage or processing logic changed — presentation only.

## Tests

- Updated the Tier A `ui_render` lenient-field marker (`test_render_smoke.py`) to assert the new `Lenient Feed Parsing` casing.
- Gates run locally: `php -l`, PHPCS (`phpcs.xml.dist`), PHPStan, `ruff check`/`ruff format --check`.

Fixes #478
Fixes #479
Fixes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated DNSBL configuration UI text for consistent capitalization.
  * Standardized the “no-AAAA” feature naming across the checkbox label and help text.
  * Reorganized the “Permit Firewall Rules” controls layout for improved usability.  
* **Tests**
  * Updated the DNSBL render smoke test to match the corrected “Lenient Feed Parsing” UI label capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->