### PR TITLE
pfblockerng: hide ADR-11 aggregate aliases from the dashboard widget

### DIFF
--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -253,6 +253,22 @@ function pfbsort(&$array, $subkey, $sort_ascending) {
 }
 
 
+// Decide whether a pfB alias must be hidden from the dashboard widget.
+//
+//   - pfB_DNSBL_VIPs       : the DNSBL sinkhole VIP table, not a feed list.
+//   - pfB_<Type>_Aggregated_v4/v6 : the ADR-11 aggregate ("Uber") aliases. They are
+//     internal Native reference IP-sets (deduped unions, no firewall rule of their own)
+//     consumed by the aggregate feature / HAProxy input, not user-facing block/permit
+//     lists -- listing them clutters the widget and double-counts entries already shown
+//     by their source lists. <Type> is exactly Deny|Permit|Match|Native; GeoIP folds into
+//     those action types, so there is no separate pfB_Geo_Aggregated alias to match.
+//
+// Hides from display only -- the aliases / pf tables stay wired and functional.
+function pfb_widget_alias_hidden($pfb_alias) {
+	return empty($pfb_alias) || $pfb_alias == 'pfB_DNSBL_VIPs' ||
+	    preg_match('/^pfB_(Deny|Permit|Match|Native)_Aggregated_v[46]$/', $pfb_alias) === 1;
+}
+
 // Collect all pfBlockerNG statistics
 function pfBlockerNG_update_table() {
 	global $pfb;
@@ -272,7 +288,7 @@ function pfBlockerNG_update_table() {
 			$line = trim(str_replace(array( '[', ']' ), '', $line));
 			if (substr($line, 0, 1) == '-') {
 				$pfb_alias = trim(strstr($line, 'pfB', FALSE));
-				if (empty($pfb_alias) || $pfb_alias == 'pfB_DNSBL_VIPs') {
+				if (pfb_widget_alias_hidden($pfb_alias)) {
 					unset($pfb_alias);
 					continue;
 				}

--- a/tests/php/WidgetAliasHiddenTest.php
+++ b/tests/php/WidgetAliasHiddenTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_widget_alias_hidden() — the dashboard widget's display-only exclusion
+ * predicate (issue #481).
+ *
+ * The widget enumerates every pfB_* pf table and renders one row per alias. A
+ * handful of those tables are internal and must NOT be shown:
+ *
+ *   - pfB_DNSBL_VIPs                : the DNSBL sinkhole VIP table.
+ *   - pfB_<Type>_Aggregated_v4/v6   : the ADR-11 aggregate ("Uber") aliases —
+ *     deduped Native reference IP-sets with no firewall rule of their own. Listing
+ *     them clutters the widget and double-counts entries already shown by their
+ *     source lists.
+ *
+ * The predicate lives inside pfblockerng.widget.php, which carries top-level
+ * execution (it is a rendered web page, not a library) and therefore cannot be
+ * require()d off-appliance. So — like the wizard-function extraction in
+ * tests/php/bootstrap.php — this test reads the widget source and evals ONLY the
+ * pfb_widget_alias_hidden() definition, pinning the predicate without pulling in
+ * the page's runtime wiring.
+ */
+#[CoversFunction('pfb_widget_alias_hidden')]
+final class WidgetAliasHiddenTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_widget_alias_hidden')) {
+			return;
+		}
+
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.widget.php');
+		}
+
+		// Extract just the function definition (signature through its closing brace).
+		// The body is a single return statement, so the first '}' after the signature
+		// closes the function.
+		if (!preg_match('/function\s+pfb_widget_alias_hidden\s*\([^)]*\)\s*\{.*?\}/s', $src, $m)) {
+			throw new RuntimeException('test bootstrap: pfb_widget_alias_hidden() not found in widget source');
+		}
+		eval($m[0]);
+	}
+
+	/**
+	 * A normal, user-facing feed alias is SHOWN (the predicate returns false) — the
+	 * "before" half that proves hiding is a real branch, not an always-true path.
+	 *
+	 * @return list<array{string}>
+	 */
+	public static function shownAliasProvider(): array
+	{
+		return [
+			['pfB_Example_v4'],          // ordinary IPv4 feed alias
+			['pfB_Example_v6'],          // ordinary IPv6 feed alias
+			['pfB_PRI1_v4'],             // a real shipped alias name shape
+			['pfB_Deny_Aggregated_v5'],  // wrong family digit — must NOT match the pattern
+			['pfB_Geo_Aggregated_v4'],   // GeoIP folds into action types; no such alias, stays shown
+			['pfB_Deny_Aggregated_v4_x'],// trailing suffix — anchored regex must reject
+			['xpfB_Deny_Aggregated_v4'], // leading prefix — anchored regex must reject
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('shownAliasProvider')]
+	public function testOrdinaryAliasIsShown(string $alias): void
+	{
+		$this->assertFalse(
+			pfb_widget_alias_hidden($alias),
+			"alias {$alias} should be displayed in the widget"
+		);
+	}
+
+	/**
+	 * Every one of the eight ADR-11 aggregate aliases is HIDDEN.
+	 *
+	 * @return list<array{string}>
+	 */
+	public static function aggregateAliasProvider(): array
+	{
+		$out = [];
+		foreach (['Deny', 'Permit', 'Match', 'Native'] as $type) {
+			foreach (['v4', 'v6'] as $fam) {
+				$out[] = ["pfB_{$type}_Aggregated_{$fam}"];
+			}
+		}
+		return $out;
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('aggregateAliasProvider')]
+	public function testAggregateAliasIsHidden(string $alias): void
+	{
+		$this->assertTrue(
+			pfb_widget_alias_hidden($alias),
+			"aggregate alias {$alias} must be hidden from the widget"
+		);
+	}
+
+	// The pre-existing DNSBL VIP exclusion is preserved by the refactor.
+	public function testDnsblVipsIsHidden(): void
+	{
+		$this->assertTrue(pfb_widget_alias_hidden('pfB_DNSBL_VIPs'));
+	}
+
+	// An empty alias name (strstr() found no 'pfB' token) is hidden, as before.
+	public function testEmptyAliasIsHidden(): void
+	{
+		$this->assertTrue(pfb_widget_alias_hidden(''));
+	}
+}


### PR DESCRIPTION
## Summary

In the pfBlockerNG dashboard widget, hide the eight ADR-11 aggregate ("Uber") aliases:

```text
pfB_Deny_Aggregated_v4    pfB_Deny_Aggregated_v6
pfB_Permit_Aggregated_v4  pfB_Permit_Aggregated_v6
pfB_Match_Aggregated_v4   pfB_Match_Aggregated_v6
pfB_Native_Aggregated_v4  pfB_Native_Aggregated_v6
```

These are internal Native reference IP-sets (deduped unions, no firewall rule of their own) consumed by the aggregate feature / HAProxy input, not user-facing block/permit lists. Listing them in the widget cluttered the view and double-counted entries already shown by their source lists.

The widget's existing display-only exclusion (`pfB_DNSBL_VIPs`) is extracted into a pure predicate `pfb_widget_alias_hidden()` and extended with an anchored regex `^pfB_(Deny|Permit|Match|Native)_Aggregated_v[46]$`. Filtering happens at the single enumeration source in `pfBlockerNG_update_table()`, so rows, counts, and totals are all consistent. **Display-only** — the aliases and pf tables stay wired and functional.

GeoIP folds into the action types (no separate `pfB_Geo_Aggregated` alias exists), so the four covered types match every aggregate alias.

## Tests

- New `WidgetAliasHiddenTest` pins every branch: an ordinary feed alias is shown; all eight aggregates, the DNSBL VIP table, and an empty name are hidden; the anchored regex rejects near-misses (wrong family digit, leading/trailing junk). The widget page carries top-level execution and can't be `require()`d off-appliance, so the test evals just the predicate (the same technique `tests/php/bootstrap.php` uses for the wizard functions).
- Gates run locally: `php -l`, PHPCS, PHPStan, `vendor/bin/phpunit` (17/17).

Note: the maintainer floated an optional widget-settings toggle to show them on demand — deferred as a separate enhancement; this PR implements the hide requested in the issue.

Fixes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard widget now automatically hides internal system aliases and aggregated feeds, significantly reducing visual clutter in the interface
  * All hidden items continue functioning fully in the background with no impact on filtering or protection capabilities
  * The streamlined widget interface improves user experience and makes monitoring clearer and more efficient

<!-- end of auto-generated comment: release notes by coderabbit.ai -->