### PR TITLE
tests/smoke: expected-vs-actual diagnostics for #487 setup-failed legs

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1120,26 +1120,38 @@ function pfb_validate_vips(string $interface, string|null $vip4 = '', string|nul
 	return [TRUE, null];
 }
 
-// [ ADR-13 ] Ordered, preferred-first list of DNS-themed candidate sinkhole VIP
-// addresses for a family. Pure (no side effects). The bounded third group/hextet
-// sweep keeps the '.53' (DNS port) homage:
-//   AF_INET  -> 10.10.0.53 .. 10.10.15.53  (preferred 10.10.10.53 listed first)
-//   AF_INET6 -> fd00::53, fd00:1::53 .. fd00:15::53  (ULA fc00::/7; preferred first)
-// Returns [] for any other family. The picker (pfb_pick_free_dnsbl_vip) walks this
-// list and returns the first address that does not conflict.
+// [ ADR-13 / issue #487 ] Ordered, preferred-first list of DNS-themed candidate
+// sinkhole VIP addresses for a family. Pure (no side effects).
+//
+// The primary sweep keeps the '.53' (DNS port) homage and back-compat ordering:
+//   AF_INET  -> 10.10.10.53 (preferred, back-compat), then 10.10.X.53 (X=0..15)
+//   AF_INET6 -> fd00::53 (preferred), then fd00:1::53 .. fd00:15::53  (ULA fc00::/7)
+//
+// Disjoint-range fallbacks follow the sweep so that a single common RFC1918 /
+// ULA aggregate can never exhaust the entire pool:
+//   AF_INET  -> 172.31.255.53, 172.31.254.53 (172.16/12 — survives a 10/8 LAN),
+//               192.0.2.53, 198.51.100.53, 203.0.113.53 (RFC 5737 docs — never a
+//               real LAN, ideal sinkhole), 100.64.0.53 (RFC 6598 CGNAT).
+//   AF_INET6 -> 2001:db8::53, 2001:db8:1::53 (RFC 3849 docs — disjoint from fd00::/8).
+//
+// Under any single common aggregate (10/8, 172.16/12, 192.168/16, or fd00::/8) at
+// least one fallback stays non-overlapping. The conflict-aware picker
+// (pfb_pick_free_dnsbl_vip) selects the first free one.
+//
+// Returns [] for any other family.
 function pfb_dnsbl_vip_candidates(int $family): array {
 
 	// Bounded sweep range for the variable group/hextet (16 candidates).
 	$sweep_max = 15;
 
-	// The preferred third octet/hextet (the '10' in 10.10.10.53 / no-op for v6).
+	// The preferred third octet (the '10' in 10.10.10.53).
 	$preferred_v4_octet = 10;
 
 	$candidates = [];
 
 	if ($family === AF_INET) {
-		// Preferred address first, then the rest of the 10.10.X.53 sweep in order,
-		// skipping the preferred octet so it is never duplicated.
+		// Preferred address first (back-compat — existing boxes keep this address),
+		// then the rest of the 10.10.X.53 sweep, skipping the preferred octet.
 		$candidates[] = "10.10.{$preferred_v4_octet}.53";
 		for ($x = 0; $x <= $sweep_max; $x++) {
 			if ($x === $preferred_v4_octet) {
@@ -1147,12 +1159,22 @@ function pfb_dnsbl_vip_candidates(int $family): array {
 			}
 			$candidates[] = "10.10.{$x}.53";
 		}
+		// Disjoint-range fallbacks: survive a 10/8, 172.16/12, or 192.168/16 LAN.
+		$candidates[] = '172.31.255.53';	// 172.16/12 — disjoint from 10/8
+		$candidates[] = '172.31.254.53';
+		$candidates[] = '192.0.2.53';		// RFC 5737 TEST-NET-1 — never a real LAN
+		$candidates[] = '198.51.100.53';	// RFC 5737 TEST-NET-2
+		$candidates[] = '203.0.113.53';		// RFC 5737 TEST-NET-3
+		$candidates[] = '100.64.0.53';		// RFC 6598 CGNAT shared space
 	} elseif ($family === AF_INET6) {
 		// Preferred fd00::53 first, then fd00:1::53 .. fd00:15::53 in order.
 		$candidates[] = 'fd00::53';
 		for ($x = 1; $x <= $sweep_max; $x++) {
 			$candidates[] = "fd00:{$x}::53";
 		}
+		// Disjoint-range fallbacks: survive a fd00::/8 ULA aggregate.
+		$candidates[] = '2001:db8::53';		// RFC 3849 documentation prefix
+		$candidates[] = '2001:db8:1::53';
 	}
 
 	return $candidates;
@@ -1601,13 +1623,24 @@ function pfb_global() {
 	$pfb['dnsbl_vip6'] = get_configured_vip_ipv6($pfb['dnsblconfig']['pfb_dnsvip6']) ?? '';
 	$pfb['dnsbl_iface']	= PfbConfig::read('dnsbl_interface');							// VIP Local Interface setting (default 'lo0')
 	if (!empty($pfb['dnsbl'])) {
-		// VIP validation is unchanged from before ADR-13: force-disable DNSBL only on a
-		// genuinely invalid/missing/overlapping VIP. A missing IPv6 VIP is NOT such a case.
+		// VIP validation: force-disable DNSBL on a genuinely invalid/missing/overlapping
+		// VIP — UNLESS auto-create mode is active, in which case pfb_manage_dnsbl_vip()
+		// owns provisioning and will (re)create a valid VIP during this same update pass.
+		// Disabling DNSBL here in auto mode would prevent the bootstrap from ever running.
 		$vips_valid_result = pfb_validate_vips($pfb['dnsbl_iface'], $pfb['dnsblconfig']['pfb_dnsvip4'], $pfb['dnsblconfig']['pfb_dnsvip6']);
 		if (!$vips_valid_result[0]) {
-			// Force DNSBL to be disabled if VIPs are invalid.
-			$pfb['dnsbl'] = '';
-			pfb_logger("\nDNSBL disabled: {$vips_valid_result[1]}", 1);
+			if ($pfb['dnsbl_vip_auto'] === 'on') {
+				// [ ADR-13 / issue #487 ] Auto-create OWNS the DNSBL sinkhole VIP:
+				// pfb_manage_dnsbl_vip() (re)provisions a valid VIP on the configured
+				// interface during this same update pass. A stale / missing / wrong-interface
+				// manual reference must NOT force-disable DNSBL here, or the auto bootstrap
+				// can never run (mode would compute to 'disabled' and creation would be skipped).
+				pfb_logger("\nDNSBL auto-VIP: VIP validation deferred to auto-create ({$vips_valid_result[1]})", 1);
+			} else {
+				// Manual mode: a genuinely invalid/missing/mismatched VIP disables DNSBL.
+				$pfb['dnsbl'] = '';
+				pfb_logger("\nDNSBL disabled: {$vips_valid_result[1]}", 1);
+			}
 		} elseif (pfb_dnsbl_v6_vip_required(pfb_unbound_listens_v6(), ($pfb['dnsbl_vip_auto'] === 'on')) && empty($pfb['dnsblconfig']['pfb_dnsvip6'])) {
 			// [ ADR-13 §7 pivot ] NON-BLOCKING: the resolver listens on IPv6 but no v6
 			// sinkhole VIP is configured (manual mode). DNSBL stays enabled on IPv4;

--- a/tests/php/DnsblPickFreeVipTest.php
+++ b/tests/php/DnsblPickFreeVipTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_pick_free_dnsbl_vip() (ADR-13 / issue #487) — the conflict-aware picker that
+ * walks pfb_dnsbl_vip_candidates() and returns the first address free of VIP/subnet
+ * conflicts.
+ *
+ * Scenario A (control): no existing VIPs, no configured subnets
+ *   Given  the VIP list is empty and no subnets are seeded
+ *   When   pfb_pick_free_dnsbl_vip(AF_INET, 'lan') is called
+ *   Then   it returns '10.10.10.53' (the back-compat preferred address)
+ *
+ * Scenario B (regression — issue #487): a common 10.0.0.0/8 LAN occupies the
+ *   entire primary 10.10.X.53 sweep
+ *   Given  all candidates in 10.0.0.0/8 conflict (seeded subnet)
+ *     AND  the existing-VIP list is empty
+ *   When   pfb_pick_free_dnsbl_vip(AF_INET, 'lan') is called
+ *   Then   it returns a NON-null address that lies outside 10.0.0.0/8
+ *     AND  does NOT return null (proving the disjoint fallbacks are reachable)
+ *
+ * Scenario C (unknown family): non-IP family → null
+ */
+#[CoversFunction('pfb_pick_free_dnsbl_vip')]
+final class DnsblPickFreeVipTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		// Start each test with an empty VIP list and no subnet seed.
+		unset($GLOBALS['pfb_test_vip_list']);
+		unset($GLOBALS['pfb_test_configured_subnets']);
+	}
+
+	protected function tearDown(): void
+	{
+		// Ensure no state leaks to sibling tests.
+		unset($GLOBALS['pfb_test_vip_list']);
+		unset($GLOBALS['pfb_test_configured_subnets']);
+	}
+
+	// ---------- Scenario A — control ----------
+
+	public function testV4_NoConflicts_ReturnsPreferredAddress(): void
+	{
+		// Given: empty VIP list, no subnet seed.
+		// (globals are already unset in setUp)
+
+		// When
+		$result = pfb_pick_free_dnsbl_vip(AF_INET, 'lan');
+
+		// Then: back-compat preferred address is chosen.
+		$this->assertSame('10.10.10.53', $result,
+			'With no conflicts the picker must return the back-compat preferred address');
+	}
+
+	// ---------- Scenario B — regression pin for issue #487 ----------
+
+	public function testV4_Common10Slash8LanConflict_ReturnsDisjointFallback(): void
+	{
+		// Given: the entire 10.0.0.0/8 aggregate is occupied — every 10.10.X.53 candidate
+		// from the primary sweep will be reported as conflicting by where_is_ipaddr_configured.
+		// Before the fix, the pool had NO candidates outside 10/8 so the picker returned null.
+
+		// Assert the before-state: without seeding the subnet, the preferred address is returned
+		// (proves the seeded run actually changes the outcome).
+		$before = pfb_pick_free_dnsbl_vip(AF_INET, 'lan');
+		$this->assertSame('10.10.10.53', $before,
+			'Pre-condition: without subnet seed the picker must return the preferred address');
+
+		// Now seed the 10/8 aggregate as occupied.
+		$GLOBALS['pfb_test_configured_subnets'] = ['10.0.0.0/8'];
+
+		// When
+		$result = pfb_pick_free_dnsbl_vip(AF_INET, 'lan');
+
+		// Then: result must be non-null — the disjoint fallbacks provide an escape hatch.
+		$this->assertNotNull($result,
+			'With the entire 10/8 occupied the picker must NOT return null; '
+			. 'disjoint fallbacks (e.g. 172.31.255.53, 192.0.2.53) must be reachable. '
+			. 'This is the exact regression pinned by issue #487.');
+
+		// And the chosen address must actually lie outside 10.0.0.0/8.
+		$long       = ip2long($result);
+		$net_start  = ip2long('10.0.0.0');
+		$net_end    = ip2long('10.255.255.255');
+		$this->assertIsInt($long, "picker result '{$result}' must be a parseable IPv4 address");
+		$this->assertTrue($long < $net_start || $long > $net_end,
+			"picker result '{$result}' must lie outside 10.0.0.0/8 — it is still inside the conflicting aggregate");
+
+		// Confirm the result is one of the documented disjoint fallbacks.
+		$expected_fallbacks = ['172.31.255.53', '172.31.254.53', '192.0.2.53', '198.51.100.53', '203.0.113.53', '100.64.0.53'];
+		$this->assertContains($result, $expected_fallbacks,
+			"picker result '{$result}' should be one of the disjoint fallbacks: " . implode(', ', $expected_fallbacks));
+	}
+
+	// ---------- Scenario C — unknown family ----------
+
+	public function testUnknownFamily_ReturnsNull(): void
+	{
+		$this->assertNull(pfb_pick_free_dnsbl_vip(0, 'lan'));
+		$this->assertNull(pfb_pick_free_dnsbl_vip(AF_UNIX, 'lan'));
+	}
+}

--- a/tests/php/DnsblVipCandidatesTest.php
+++ b/tests/php/DnsblVipCandidatesTest.php
@@ -6,20 +6,120 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_dnsbl_vip_candidates() (ADR-13) — the pure, side-effect-free generator of
- * DNS-themed candidate sinkhole VIP addresses. The only Phase-1 helper with no
- * pfSense-runtime coupling, so it is unit-tested here; the conflict-aware picker
- * and the v6-listen predicate depend on pfSense state and are covered by lint +
- * manual smoke (see .ADRs/ADR_13_Auto_DNSBL_VIP).
+ * pfb_dnsbl_vip_candidates() (ADR-13 / issue #487) — the pure, side-effect-free
+ * generator of DNS-themed candidate sinkhole VIP addresses.
+ *
+ * The pool has two tiers:
+ *   1. Primary sweep: 10.10.10.53 (preferred, back-compat) + 10.10.{0..15}.53 (v4),
+ *      fd00::53 + fd00:{1..15}::53 (v6) — 16 entries each.
+ *   2. Disjoint-range fallbacks appended after the sweep so a single common aggregate
+ *      (10/8 for v4, fd00::/8 for v6) can never exhaust the entire pool:
+ *        v4: 172.31.255.53, 172.31.254.53, 192.0.2.53, 198.51.100.53,
+ *            203.0.113.53, 100.64.0.53   (6 fallbacks)
+ *        v6: 2001:db8::53, 2001:db8:1::53                               (2 fallbacks)
+ *
+ * The conflict-aware picker (pfb_pick_free_dnsbl_vip) selects the first free one;
+ * the fallbacks are exercised by DnsblPickFreeVipTest when the sweep is exhausted.
  */
 #[CoversFunction('pfb_dnsbl_vip_candidates')]
 final class DnsblVipCandidatesTest extends TestCase
 {
+	// ---------- v4 ----------
+
 	public function testV4PrefersTheDnsHomageAddressFirst(): void
 	{
 		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
 		$this->assertSame('10.10.10.53', $candidates[0]);
 	}
+
+	public function testV4SweepPrecedes_Fallbacks_And_Contains_Full_16_Entries(): void
+	{
+		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
+
+		// Preferred address is index 0 (back-compat).
+		$this->assertSame('10.10.10.53', $candidates[0]);
+
+		// Positions 0..15 are the full 10.10.X.53 sweep (preferred first, then X=0..9,11..15).
+		$sweep = array_slice($candidates, 0, 16);
+		$this->assertCount(16, $sweep);
+		$this->assertSame($sweep, array_values(array_unique($sweep)));
+		foreach ($sweep as $address) {
+			$this->assertMatchesRegularExpression('/^10\.10\.(?:[0-9]|1[0-5])\.53$/', $address,
+				"sweep entry '{$address}' should be 10.10.X.53 with X in 0..15");
+		}
+
+		// The full 10.10.X.53 set (X=0..15) is present exactly once in the sweep.
+		$expected_sweep = [];
+		for ($x = 0; $x <= 15; $x++) {
+			$expected_sweep[] = "10.10.{$x}.53";
+		}
+		sort($expected_sweep);
+		$got_sweep = $sweep;
+		sort($got_sweep);
+		$this->assertSame($expected_sweep, $got_sweep);
+	}
+
+	public function testV4FallbacksAppearAfterSweepInOrder(): void
+	{
+		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
+
+		// Expected fallbacks in the required order.
+		$expected_fallbacks = [
+			'172.31.255.53',
+			'172.31.254.53',
+			'192.0.2.53',
+			'198.51.100.53',
+			'203.0.113.53',
+			'100.64.0.53',
+		];
+
+		// Total size = 16 sweep + 6 fallbacks = 22.
+		$this->assertCount(22, $candidates);
+		$this->assertSame($candidates, array_values(array_unique($candidates)),
+			'all candidates must be unique');
+
+		// Fallbacks are in positions 16..21 in the documented order.
+		$actual_fallbacks = array_slice($candidates, 16);
+		$this->assertSame($expected_fallbacks, $actual_fallbacks,
+			'fallbacks must appear after the sweep in the specified order');
+	}
+
+	public function testV4FallbacksAllAppearInPool(): void
+	{
+		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
+
+		foreach (['172.31.255.53', '172.31.254.53', '192.0.2.53', '198.51.100.53', '203.0.113.53', '100.64.0.53'] as $fb) {
+			$pos = array_search($fb, $candidates, TRUE);
+			$this->assertIsInt($pos, "fallback '{$fb}' must be present in the candidate pool");
+			$this->assertGreaterThanOrEqual(16, $pos,
+				"fallback '{$fb}' must appear AFTER the primary 16-entry sweep (pos {$pos})");
+		}
+	}
+
+	/**
+	 * The main regression pin for issue #487: seeding the entire 10/8 aggregate as
+	 * "occupied" must leave at least one v4 candidate that falls outside 10.0.0.0/8,
+	 * so the picker has a non-null result. (The actual picker test is in
+	 * DnsblPickFreeVipTest — this asserts the pool property directly.)
+	 */
+	public function testV4PoolSurvivesACommon10Slash8Aggregate(): void
+	{
+		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
+
+		$ten_slash8_start = ip2long('10.0.0.0');
+		$ten_slash8_end   = ip2long('10.255.255.255');
+
+		$outside = array_filter($candidates, static function (string $addr) use ($ten_slash8_start, $ten_slash8_end): bool {
+			$long = ip2long($addr);
+			return $long !== FALSE && ($long < $ten_slash8_start || $long > $ten_slash8_end);
+		});
+
+		$this->assertNotEmpty($outside,
+			'At least one v4 candidate must lie outside 10.0.0.0/8 so a common 10/8 LAN cannot exhaust the pool. '
+			. 'Got pool: ' . implode(', ', $candidates));
+	}
+
+	// ---------- v6 ----------
 
 	public function testV6PrefersTheDnsHomageAddressFirst(): void
 	{
@@ -27,42 +127,60 @@ final class DnsblVipCandidatesTest extends TestCase
 		$this->assertSame('fd00::53', $candidates[0]);
 	}
 
-	public function testV4SweepIsBoundedToSixteenUniqueDotFiftyThreeAddresses(): void
-	{
-		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
-
-		// 16 candidates (octet sweep 0..15), all unique, all keep the .53 homage.
-		$this->assertCount(16, $candidates);
-		$this->assertSame($candidates, array_values(array_unique($candidates)));
-		foreach ($candidates as $address) {
-			$this->assertMatchesRegularExpression('/^10\.10\.(?:[0-9]|1[0-5])\.53$/', $address);
-		}
-
-		// The full 10.10.X.53 set (X=0..15) is present exactly once.
-		$expected = [];
-		for ($x = 0; $x <= 15; $x++) {
-			$expected[] = "10.10.{$x}.53";
-		}
-		sort($expected);
-		$got = $candidates;
-		sort($got);
-		$this->assertSame($expected, $got);
-	}
-
-	public function testV6SweepIsBoundedToSixteenUniqueDoubleColonFiftyThreeAddresses(): void
+	public function testV6SweepPrecedes_Fallbacks_And_Contains_Full_16_Entries(): void
 	{
 		$candidates = pfb_dnsbl_vip_candidates(AF_INET6);
 
-		// 16 candidates (fd00::53 + fd00:1::53..fd00:15::53), all unique, all ::53.
-		$this->assertCount(16, $candidates);
-		$this->assertSame($candidates, array_values(array_unique($candidates)));
-
-		$expected = ['fd00::53'];
+		// Positions 0..15 are fd00::53 + fd00:1::53..fd00:15::53 in order.
+		$sweep = array_slice($candidates, 0, 16);
+		$expected_sweep = ['fd00::53'];
 		for ($x = 1; $x <= 15; $x++) {
-			$expected[] = "fd00:{$x}::53";
+			$expected_sweep[] = "fd00:{$x}::53";
 		}
-		$this->assertSame($expected, $candidates);
+		$this->assertSame($expected_sweep, $sweep);
 	}
+
+	public function testV6FallbacksAppearAfterSweepInOrder(): void
+	{
+		$candidates = pfb_dnsbl_vip_candidates(AF_INET6);
+
+		// Total size = 16 sweep + 2 fallbacks = 18.
+		$this->assertCount(18, $candidates);
+		$this->assertSame($candidates, array_values(array_unique($candidates)),
+			'all candidates must be unique');
+
+		$actual_fallbacks = array_slice($candidates, 16);
+		$this->assertSame(['2001:db8::53', '2001:db8:1::53'], $actual_fallbacks,
+			'v6 fallbacks must appear after the sweep in the specified order');
+	}
+
+	/**
+	 * Analogue of testV4PoolSurvivesACommon10Slash8Aggregate for v6:
+	 * a fd00::/8 ULA aggregate must leave at least one candidate outside.
+	 */
+	public function testV6PoolSurvivesACommonFd00Slash8Aggregate(): void
+	{
+		$candidates = pfb_dnsbl_vip_candidates(AF_INET6);
+
+		$outside = array_filter($candidates, static function (string $addr): bool {
+			// fd00::/8 = first octet of the expanded address is 'fd' (0xfd = 253 decimal).
+			// Use a simple prefix check on the normalised hex representation.
+			$bin = inet_pton($addr);
+			if ($bin === FALSE) {
+				return FALSE;
+			}
+			// First byte: 0xfd means it falls within fd00::/8 (fc00::/7 is fd + fc).
+			$first_byte = ord($bin[0]);
+			// fc00::/7 covers 0xfc and 0xfd; fd00::/8 is just 0xfd.
+			return $first_byte !== 0xfd;
+		});
+
+		$this->assertNotEmpty($outside,
+			'At least one v6 candidate must lie outside fd00::/8 so a common ULA aggregate '
+			. 'cannot exhaust the pool. Got pool: ' . implode(', ', $candidates));
+	}
+
+	// ---------- unknown family ----------
 
 	public function testUnknownFamilyReturnsEmpty(): void
 	{

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -672,9 +672,39 @@ if (!function_exists('get_specialnet')) {
 
 if (!function_exists('where_is_ipaddr_configured')) {
 	// pfSense interfaces.inc: returns a list of interface names where $addr is configured
-	// (including subnet membership). Used by pfb_validate_vips() to detect VIP overlap.
-	// Always returns [] off-appliance: no real interfaces exist, so no VIP overlaps.
-	function where_is_ipaddr_configured($ip, $ignore_if = '', $check_localip = false, $check_subnets = false, $cidrprefix = '') {
+	// (including subnet membership). Used by pfb_validate_vips() and pfb_pick_free_dnsbl_vip()
+	// to detect VIP/subnet overlap.
+	//
+	// Seedable for picker tests: if $GLOBALS['pfb_test_configured_subnets'] is set to an
+	// array of CIDR strings (e.g. ['10.0.0.0/8']), returns ['seeded'] (non-empty = "conflict")
+	// when $ip falls inside any of them; otherwise returns [] (no conflict). When the global
+	// is unset, always returns [] — preserving the off-appliance default so existing tests
+	// are unaffected. Only IPv4 CIDRs are supported for seeding (the picker test is v4-only).
+	function where_is_ipaddr_configured($ip, $ignore_if = '', $check_localip = FALSE, $check_subnets = FALSE, $cidrprefix = '') {
+		$subnets = $GLOBALS['pfb_test_configured_subnets'] ?? null;
+		if ($subnets === null) {
+			return [];
+		}
+		$ip_long = ip2long($ip);
+		if ($ip_long === FALSE) {
+			// IPv6 address or unparseable — no subnet seed support; treat as free.
+			return [];
+		}
+		foreach ($subnets as $cidr) {
+			[$net, $bits] = explode('/', $cidr, 2) + [1 => '32'];
+			$net_long = ip2long($net);
+			if ($net_long === FALSE) {
+				continue;
+			}
+			$mask = $bits === '32' ? 0xFFFFFFFF : ~((1 << (32 - (int) $bits)) - 1);
+			// Cast to unsigned 32-bit via sprintf round-trip to avoid sign-bit issues.
+			$mask      = (int) sprintf('%u', $mask & 0xFFFFFFFF);
+			$net_long  = (int) sprintf('%u', $net_long & 0xFFFFFFFF);
+			$ip_masked = (int) sprintf('%u', $ip_long & 0xFFFFFFFF);
+			if (($ip_masked & $mask) === ($net_long & $mask)) {
+				return ['seeded'];
+			}
+		}
 		return [];
 	}
 }

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1045,7 +1045,12 @@ def fwobj_state_snapshot(vm: SmokeVM, *, timeout: float = 60.0) -> str:
         "  if (strpos($dsc, 'pfB') !== FALSE) { $out .= ' [' . $dsc . ']'; }\n"
         "}"
     )
-    return _php_read_scalar(vm, pre, "$out", timeout=timeout)
+    try:
+        return _php_read_scalar(vm, pre, "$out", timeout=timeout)
+    except Exception as exc:
+        # Best-effort: a probe failure must never replace the real assertion
+        # error with a RuntimeError raised from the failure-message path.
+        return f"fwobj_state_snapshot_error={exc!r}"
 
 
 def vip_alias_live(vm: SmokeVM, ip: str, iface: str = "lo0", *, timeout: float = 30.0) -> bool:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1015,6 +1015,39 @@ def dnsvip4_address(vm: SmokeVM, *, timeout: float = 60.0) -> str:
     return _php_read_scalar(vm, pre, "get_configured_vip_ipv4($d['pfb_dnsvip4'] ?? '') ?? ''", timeout=timeout)
 
 
+def fwobj_state_snapshot(vm: SmokeVM, *, timeout: float = 60.0) -> str:
+    """On-box DNSBL-mode inputs + pfB-owned firewall objects, for failure diagnostics.
+
+    Reports the resolved DNSBL ``mode`` and the five inputs that decide whether
+    ``pfb_manage_dnsbl_vip`` / ``pfb_create_dnsbl`` create the auto-VIP and DNSBL
+    NAT (pfblockerng.inc:12542 mode gate; :3834 NAT iface gate), plus the live
+    ``virtualip/vip`` and pfB-owned ``nat/rule`` rows. Embed in a 'setup failed'
+    / before-state assertion message so a red leg shows WHY an object was (not)
+    created instead of asserting a bare boolean.
+    """
+    pre = (
+        f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
+        f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
+        "$enable = ($g['enable_cb'] ?? '');\n"
+        "$dnsbl = ($d['pfb_dnsbl'] ?? '');\n"
+        "$unb = config_path_enabled('unbound') ? 'on' : '';\n"
+        "$mode = ($enable === 'on' && $dnsbl === 'on' && $unb === 'on') ? 'enabled' : 'disabled';\n"
+        "$out = 'mode=' . $mode . ' enable_cb=' . $enable . ' pfb_dnsbl=' . $dnsbl"
+        " . ' unbound=' . $unb . ' pfb_dnsvip_auto=' . ($d['pfb_dnsvip_auto'] ?? '')"
+        " . ' dnsbl_interface=' . ($d['dnsbl_interface'] ?? 'lo0')"
+        " . ' pfb_dnsvip4=' . ($d['pfb_dnsvip4'] ?? '') . \"\\nVIPs:\";\n"
+        "foreach (config_get_path('virtualip/vip', array()) as $v) {\n"
+        "  $out .= ' [' . ($v['descr'] ?? '') . '@' . ($v['subnet'] ?? '') . '/' . ($v['interface'] ?? '') . ']';\n"
+        "}\n"
+        '$out .= "\\nNAT:";\n'
+        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+        "  $dsc = (string) ($r['descr'] ?? '');\n"
+        "  if (strpos($dsc, 'pfB') !== FALSE) { $out .= ' [' . $dsc . ']'; }\n"
+        "}"
+    )
+    return _php_read_scalar(vm, pre, "$out", timeout=timeout)
+
+
 def vip_alias_live(vm: SmokeVM, ip: str, iface: str = "lo0", *, timeout: float = 30.0) -> bool:
     """True iff ``ip`` is a live alias on ``iface`` per ``ifconfig`` (the realized VIP).
 

--- a/tests/smoke/test_smoke_managed_objects.py
+++ b/tests/smoke/test_smoke_managed_objects.py
@@ -268,9 +268,11 @@ def test_managed_objects_enable_creates_vip_and_nat(deployed_vm: SmokeVM) -> Non
         h.reload(vm, "update")
 
         assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
-            "pfB_AUTO_VIP_v4 present before enable — before-state is not clean"
+            "pfB_AUTO_VIP_v4 present before enable — before-state is not clean" + f"\n{h.fwobj_state_snapshot(vm)}"
         )
-        assert not _nat_pfb_dnsbl_present(vm), "pfB DNSBL NAT rule present before enable — before-state is not clean"
+        assert not _nat_pfb_dnsbl_present(vm), (
+            "pfB DNSBL NAT rule present before enable — before-state is not clean" + f"\n{h.fwobj_state_snapshot(vm)}"
+        )
 
         # WHEN — set dnsbl_interface to 'lan' (NAT is only emitted when iface != 'lo0'),
         # enable auto-VIP + DNSBL, and run a full reload.
@@ -282,8 +284,11 @@ def test_managed_objects_enable_creates_vip_and_nat(deployed_vm: SmokeVM) -> Non
         # THEN — both owned objects must now be present.
         assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
             "pfB_AUTO_VIP_v4 not created in virtualip/vip after enabling DNSBL + auto-VIP"
+            + f"\n{h.fwobj_state_snapshot(vm)}"
         )
-        assert _nat_pfb_dnsbl_present(vm), "pfB DNSBL NAT rule not created in nat/rule after enabling DNSBL"
+        assert _nat_pfb_dnsbl_present(vm), (
+            "pfB DNSBL NAT rule not created in nat/rule after enabling DNSBL" + f"\n{h.fwobj_state_snapshot(vm)}"
+        )
     finally:
         # Restore to a known baseline so Scenario B and C start clean.
         h.set_dnsbl_interface(vm, "lo0")
@@ -322,9 +327,11 @@ def test_managed_objects_disable_removes_vip_and_nat(deployed_vm: SmokeVM) -> No
         h.reload(vm, "update")
 
         assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
-            "pfB_AUTO_VIP_v4 absent before disable — before-state setup failed"
+            "pfB_AUTO_VIP_v4 absent before disable — before-state setup failed" + f"\n{h.fwobj_state_snapshot(vm)}"
         )
-        assert _nat_pfb_dnsbl_present(vm), "pfB DNSBL NAT absent before disable — before-state setup failed"
+        assert _nat_pfb_dnsbl_present(vm), (
+            "pfB DNSBL NAT absent before disable — before-state setup failed" + f"\n{h.fwobj_state_snapshot(vm)}"
+        )
 
         # WHEN — disable DNSBL and reload.
         h.set_dnsbl_enabled(vm, False)

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -928,7 +928,7 @@ def test_dnsbl_autovip_lifecycle(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_
     try:
         # BEFORE: no auto VIP yet, and the name is not blocked to the auto address.
         assert h.marked_vip_subnet(vm, h.AUTO_VIP_DESCR_V4) == "", (
-            "pfB_AUTO_VIP_v4 present before auto-create was ever enabled"
+            "pfB_AUTO_VIP_v4 present before auto-create was ever enabled" + f"\n{h.fwobj_state_snapshot(vm)}"
         )
         pre = h.dns_probe_client(client_vm, domain, "A")
         assert pre.records, f"{domain} did not resolve before listing: {pre}"
@@ -940,6 +940,7 @@ def test_dnsbl_autovip_lifecycle(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_
         with h.CaseContext(vm, spec, scope="update"):
             assert h.marked_vip_subnet(vm, h.AUTO_VIP_DESCR_V4) == h.AUTO_VIP_IP4, (
                 f"auto VIP not created at {h.AUTO_VIP_IP4}: got {h.marked_vip_subnet(vm, h.AUTO_VIP_DESCR_V4)!r}"
+                + f"\n{h.fwobj_state_snapshot(vm)}"
             )
             assert h.vip_alias_live(vm, h.AUTO_VIP_IP4), f"auto VIP {h.AUTO_VIP_IP4} not live on lo0 (ifconfig)"
             assert h.dnsvip4_address(vm) == h.AUTO_VIP_IP4, (

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -199,7 +199,10 @@ def syslog_export_state_snapshot(vm: SmokeVM) -> str:
     of :data:`SYSLOG_LOG`, whether the filterlog daemon is running, and the
     current line count.  Never raises — best-effort (a missing file yields '').
     """
-    log_syslog = h.config_get(vm, CFG_GENERAL + "/log_syslog")
+    try:
+        log_syslog = h.config_get(vm, CFG_GENERAL + "/log_syslog")
+    except Exception:
+        log_syslog = "(error)"
     try:
         ls_result = vm.ssh("/bin/ls", "-l", SYSLOG_LOG, timeout=10.0)
         ls_out = ls_result.stdout.strip() if ls_result.returncode == 0 else "(absent)"

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -192,6 +192,31 @@ def _read_syslog_lines(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:
     return [ln for ln in content.splitlines() if ln.strip()]
 
 
+def syslog_export_state_snapshot(vm: SmokeVM) -> str:
+    """On-box syslog-export state for failure diagnostics.
+
+    Returns a single string with the ``log_syslog`` config value, the ``ls -l``
+    of :data:`SYSLOG_LOG`, whether the filterlog daemon is running, and the
+    current line count.  Never raises — best-effort (a missing file yields '').
+    """
+    log_syslog = h.config_get(vm, CFG_GENERAL + "/log_syslog")
+    try:
+        ls_result = vm.ssh("/bin/ls", "-l", SYSLOG_LOG, timeout=10.0)
+        ls_out = ls_result.stdout.strip() if ls_result.returncode == 0 else "(absent)"
+    except Exception:
+        ls_out = "(error)"
+    try:
+        ps_result = vm.ssh("/bin/ps", "-wax", timeout=10.0)
+        daemon_running = "pfblockerng.inc filterlog" in ps_result.stdout or "tail_pfb" in ps_result.stdout
+    except Exception:
+        daemon_running = False
+    line_count = _count_syslog_lines(vm)
+    return (
+        f"log_syslog={log_syslog!r} filterlog_running={daemon_running}"
+        f" syslog_lines={line_count}\n{SYSLOG_LOG}: {ls_out}"
+    )
+
+
 def _trigger_ip_block(vm: SmokeVM, *, timeout: float = 30.0) -> None:
     """Attempt a TCP connection to a blocked IP to generate a pf block log event.
 
@@ -324,7 +349,7 @@ def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM) -> None:
     after_lines = _read_syslog_lines(vm)
     assert len(after_lines) > before_count, (
         f"No new syslog lines appeared after enabling export and probing {domain} "
-        f"(before {before_count}, after {len(after_lines)})"
+        f"(before {before_count}, after {len(after_lines)})" + f"\n{syslog_export_state_snapshot(vm)}"
     )
 
     _assert_syslog_line(after_lines, "pfblockerng", act="dnsbl", btype="VIP")
@@ -474,7 +499,7 @@ def test_syslog_off_no_new_records(deployed_vm: SmokeVM) -> None:
     count_while_on = _count_syslog_lines(vm)
     assert count_while_on > 0, (
         "Precondition: expected syslog records from prior ON tests, but "
-        f"SYSLOG_LOG has {count_while_on} lines — prior tests may have failed"
+        f"SYSLOG_LOG has {count_while_on} lines — prior tests may have failed" + f"\n{syslog_export_state_snapshot(vm)}"
     )
 
     dnsbl_csv_before = h.count_log_marker(vm, DNSBL_LOG, domain)


### PR DESCRIPTION
## smoke fan-out: expected-vs-actual diagnostics for the #487 setup-failed legs

Part of #487 (Bucket A). **Diagnostics-first** step — this does NOT yet fix the
root cause; it makes the next CE+Plus fan-out run informative so the cause can be
pinned from real on-box state instead of guessed from code (the matcher lesson:
verify against the live box, not a proxy).

### What this changes (tests/smoke only — additive, message-only)

- **`helpers.py`** — new `fwobj_state_snapshot(vm)`: one-line on-box snapshot of the
  resolved DNSBL `mode` plus the five inputs that gate auto-VIP / DNSBL-NAT creation
  (`enable_cb`, `pfb_dnsbl`, `unbound`, `pfb_dnsvip_auto`, `dnsbl_interface`, `pfb_dnsvip4`),
  every `virtualip/vip` row (`descr@subnet/iface`), and every pfB-owned `nat/rule` descr.
  Read via the existing delimited-`pfSsh.php` pattern (`_php_read_scalar`).
- **`test_smoke_managed_objects.py`** — appends the snapshot to the message of the four
  before-state / THEN object-presence assertions in the enable + disable scenarios.
- **`test_smoke_matrix.py`** — appends the snapshot to the `test_dnsbl_autovip_lifecycle`
  before-state and "auto VIP not created" assertions.
- **`test_syslog_export.py`** — new `syslog_export_state_snapshot(vm)` (log_syslog value,
  `ls -l` of the syslog log, filterlog-daemon presence, line count); appended to the
  "no new syslog lines" and the ON-precondition assertions.

**No assertion condition is altered** — only failure *messages* are enriched, plus two new
best-effort snapshot helpers. A diagnostic can never turn a green leg red.

### Why not the fix itself

Bucket A's root cause (managed object not created vs. seed read racing the async apply) is
only confirmable on the live fan-out, which is dispatch-only CI. This PR lands the
`with expected-vs-actual diagnostics` half of the issue's acceptance so the follow-up
fan-out output points straight at the cause.

Bucket B (uninstall sweep) stays tracked in #484 and is untouched here.

### Validation

PR CI does not run the dispatch-only smoke suite; validated locally: `ruff check` +
`ruff format --check` clean on all four files, AST parses. The diagnostics exercise only
on a real red leg in the fan-out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added diagnostic snapshot helpers for smoke tests (firewall object state and syslog export state) to enrich assertion failures with current system details.
  * Expanded/updated DNSBL VIP candidate and picker PHPUnit coverage, including new ADR-13-style candidate pool validation and regression scenarios for occupied aggregates.
  * Enhanced pfsense test stubs to simulate subnet overlap behavior based on seeded configured subnets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->