### PR TITLE
pfblockerng: fix uninstall/disable leaving managed resources behind (#484)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15054,7 +15054,7 @@ function pfblockerng_php_pre_deinstall_command() {
 
 	unlink_if_exists("{$pfb['dnsbl_conf']}");
 	unlink_if_exists("{$pfb['dnsbl_cert']}");
-	unlink_if_exists("{$pfb['aliasarchive']}");
+	// aliasarchive already removed above (co-located with the aliastables boot-hook teardown).
 	unlink_if_exists("{$pfb['dnsbl_info']}");
 	unlink_if_exists("{$pfb['dnsbl_resolver']}");
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12793,10 +12793,13 @@ function sync_package_pfblockerng($cron='') {
 	// manages the companion firewall pass automatically; no filter/rule entry is written.
 	// Reads dnsbl_redir (toggle) via PfbConfig; manages nat/rule directly
 	// (pfSense-core foreign section — ADR-29 exclusion list).
+	// Coupled to DNSBL being enabled: rules are created only when $mode === 'enabled'
+	// (master enable + DNSBL toggle + resolver up); force-removed otherwise. Feeds/lists
+	// are NOT required — only the DNSBL toggle + resolver state.
 	{
 		$redir_changed = FALSE;
 		$redir_toggle  = PfbConfig::read('dnsbl_redir');
-		$redir_enabled = ($redir_toggle instanceof PfbToggle && $redir_toggle === PfbToggle::On);
+		$redir_enabled = (($mode ?? '') === 'enabled') && ($redir_toggle instanceof PfbToggle && $redir_toggle === PfbToggle::On);
 
 		if (!$redir_enabled) {
 			// DISABLED: remove all pfB_DNS_Redirect_* NAT rules.
@@ -12898,10 +12901,13 @@ function sync_package_pfblockerng($cron='') {
 	// Sync DoT/DoQ block filter rules (create / reconcile / prune / remove).
 	// Reads dnsbl_dot_block (toggle) via PfbConfig; manages filter/rule directly
 	// (pfSense-core foreign section — ADR-29 exclusion list).
+	// Coupled to DNSBL being enabled: rules are created only when $mode === 'enabled'
+	// (master enable + DNSBL toggle + resolver up); force-removed otherwise. Feeds/lists
+	// are NOT required — only the DNSBL toggle + resolver state.
 	{
 		$dot_changed = FALSE;
 		$dot_toggle  = PfbConfig::read('dnsbl_dot_block');
-		$dot_enabled = ($dot_toggle instanceof PfbToggle && $dot_toggle === PfbToggle::On);
+		$dot_enabled = (($mode ?? '') === 'enabled') && ($dot_toggle instanceof PfbToggle && $dot_toggle === PfbToggle::On);
 
 		if (!$dot_enabled) {
 			// DISABLED: remove all pfB_DoT_Block_* filter rules.
@@ -14983,6 +14989,92 @@ function pfblockerng_php_pre_deinstall_command() {
 	update_status("Removing pfBlockerNG...");
 	sync_package_pfblockerng();
 
+	// Live-object teardown always runs regardless of $pfb['keep'], so that uninstalling
+	// with the default keep=on still removes active pf tables, boot hooks, owned firewall
+	// objects, generated DNSBL files, Unbound chroot module, and the dashboard widget.
+	update_status(" Removing live firewall objects and generated files...");
+
+	// Remove all pfB aliastables
+	exec("{$pfb['pfctl']} -s Tables | {$pfb['grep']} '^pfB_'", $pfb_tables);
+	if (isset($pfb_tables)) {
+		foreach ($pfb_tables as $pfb_table) {
+			$pfb_table_esc = escapeshellarg($pfb_table);
+			exec("{$pfb['pfctl']} -t {$pfb_table_esc} -T kill 2>&1", $result);
+		}
+	}
+
+	// Remove aliastables archive and earlyshellcmd if found.
+	@unlink_if_exists("{$pfb['aliasarchive']}");
+	if (config_get_path('system/earlyshellcmd') !== null) {
+		$a_earlyshellcmd = config_get_path('system/earlyshellcmd', '');
+		if (preg_grep("/pfblockerng.sh aliastables/", $a_earlyshellcmd)) {
+			config_set_path('system/earlyshellcmd',
+							preg_grep("/pfblockerng.sh aliastables/", $a_earlyshellcmd, PREG_GREP_INVERT));
+		}
+	}
+	foreach (config_get_path('installedpackages/shellcmdsettings/config', []) as $key => $shellcmd) {
+		if (strpos($shellcmd['cmd'], 'pfblockerng.sh aliastables') !== FALSE) {
+			config_del_path("installedpackages/shellcmdsettings/config/{$key}");
+		}
+	}
+
+	// Remove owned firewall objects (VIP, NAT, filter rules) BEFORE the config
+	// reference data is wiped by pfb_remove_config_settings(). Catches orphans that
+	// the normal disable teardown missed. Idempotent — no write when nothing found.
+	$swept = FALSE;
+	// Sweep all pfB_-owned VIPs, NAT rules, and filter rules.
+	foreach (['virtualip/vip', 'nat/rule', 'filter/rule'] as $deinstall_section) {
+		$deinstall_rows     = config_get_path($deinstall_section, []);
+		$deinstall_filtered = [];
+		$deinstall_removed  = FALSE;
+		foreach ($deinstall_rows as $deinstall_row) {
+			if (pfb_is_managed_obj($deinstall_row['descr'] ?? '')) {
+				$deinstall_removed = TRUE;
+			} else {
+				$deinstall_filtered[] = $deinstall_row;
+			}
+		}
+		if ($deinstall_removed) {
+			config_set_path($deinstall_section, $deinstall_filtered);
+			$swept = TRUE;
+		}
+	}
+	// Also explicitly remove DNS-redirect NAT rules and DoT/DoQ block filter rules
+	// by marker prefix (covers the inline-managed objects).
+	if (pfb_remove_managed_obj('nat/rule', PFB_DNS_REDIR_DESCR_V4_PFX)) {
+		$swept = TRUE;
+	}
+	if (pfb_remove_managed_obj('filter/rule', PFB_DOT_BLOCK_DESCR_PFX)) {
+		$swept = TRUE;
+	}
+
+	if ($swept) {
+		write_config('pfBlockerNG: sweep orphan firewall objects on deinstall');
+	}
+
+	unlink_if_exists("{$pfb['dnsbl_conf']}");
+	unlink_if_exists("{$pfb['dnsbl_cert']}");
+	unlink_if_exists("{$pfb['aliasarchive']}");
+	unlink_if_exists("{$pfb['dnsbl_info']}");
+	unlink_if_exists("{$pfb['dnsbl_resolver']}");
+
+	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
+	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
+	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
+
+	// Remove widget (code from Snort deinstall)
+	$pfb['widgets'] = config_get_path('widgets/sequence', '');
+	if (!empty($pfb['widgets'])) {
+		$widgetlist = explode(',', $pfb['widgets']);
+		foreach ($widgetlist as $key => $widget) {
+			if (strpos($widget, 'pfblockerng') !== FALSE) {
+				unset($widgetlist[$key]);
+			}
+		}
+		config_set_path('widgets/sequence', implode(',', $widgetlist));
+		write_config('pfBlockerNG: Remove widget', FALSE);
+	}
+
 	// Maintain pfBlockerNG settings and database files if $pfb['keep'] is ON.
 	if ($pfb['keep'] != 'on') {
 		update_status(" Removing all customizations/data...");
@@ -14990,89 +15082,8 @@ function pfblockerng_php_pre_deinstall_command() {
 		rmdir_recursive("{$pfb['dbdir']}");
 		rmdir_recursive("{$pfb['logdir']}");
 
-		// Remove all pfB aliastables
-		exec("{$pfb['pfctl']} -s Tables | {$pfb['grep']} '^pfB_'", $pfb_tables);
-		if (isset($pfb_tables)) {
-			foreach ($pfb_tables as $pfb_table) {
-				$pfb_table_esc = escapeshellarg($pfb_table);
-				exec("{$pfb['pfctl']} -t {$pfb_table_esc} -T kill 2>&1", $result);
-			}
-		}
-
-		// Remove aliastables archive and earlyshellcmd if found.
-		@unlink_if_exists("{$pfb['aliasarchive']}");
-		if (config_get_path('system/earlyshellcmd') !== null) {
-			$a_earlyshellcmd = config_get_path('system/earlyshellcmd', '');
-			if (preg_grep("/pfblockerng.sh aliastables/", $a_earlyshellcmd)) {
-				config_set_path('system/earlyshellcmd',
-								preg_grep("/pfblockerng.sh aliastables/", $a_earlyshellcmd, PREG_GREP_INVERT));
-			}
-		}
-		foreach (config_get_path('installedpackages/shellcmdsettings/config', []) as $key => $shellcmd) {
-			if (strpos($shellcmd['cmd'], 'pfblockerng.sh aliastables') !== FALSE) {
-				config_del_path("installedpackages/shellcmdsettings/config/{$key}");
-			}
-		}
-
-		// Remove owned firewall objects (VIP, NAT, filter rules) BEFORE the config
-		// reference data is wiped by pfb_remove_config_settings(). Catches orphans that
-		// the normal disable teardown missed. Idempotent — no write when nothing found.
-		$swept = FALSE;
-		// Sweep all pfB_-owned VIPs, NAT rules, and filter rules.
-		foreach (['virtualip/vip', 'nat/rule', 'filter/rule'] as $deinstall_section) {
-			$deinstall_rows     = config_get_path($deinstall_section, []);
-			$deinstall_filtered = [];
-			$deinstall_removed  = FALSE;
-			foreach ($deinstall_rows as $deinstall_row) {
-				if (pfb_is_managed_obj($deinstall_row['descr'] ?? '')) {
-					$deinstall_removed = TRUE;
-				} else {
-					$deinstall_filtered[] = $deinstall_row;
-				}
-			}
-			if ($deinstall_removed) {
-				config_set_path($deinstall_section, $deinstall_filtered);
-				$swept = TRUE;
-			}
-		}
-		// Also explicitly remove DNS-redirect NAT rules and DoT/DoQ block filter rules
-		// by marker prefix (covers the inline-managed objects).
-		if (pfb_remove_managed_obj('nat/rule', PFB_DNS_REDIR_DESCR_V4_PFX)) {
-			$swept = TRUE;
-		}
-		if (pfb_remove_managed_obj('filter/rule', PFB_DOT_BLOCK_DESCR_PFX)) {
-			$swept = TRUE;
-		}
-
-		if ($swept) {
-			write_config('pfBlockerNG: sweep orphan firewall objects on deinstall');
-		}
-
 		// Remove settings from config.xml
 		pfb_remove_config_settings();
-
-		unlink_if_exists("{$pfb['dnsbl_conf']}");
-		unlink_if_exists("{$pfb['dnsbl_cert']}");
-		unlink_if_exists("{$pfb['aliasarchive']}");
-		unlink_if_exists("{$pfb['dnsbl_info']}");
-		unlink_if_exists("{$pfb['dnsbl_resolver']}");
-
-		unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
-		unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
-		unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
-
-		// Remove widget (code from Snort deinstall)
-		$pfb['widgets'] = config_get_path('widgets/sequence', '');
-		if (!empty($pfb['widgets'])) {
-			$widgetlist = explode(',', $pfb['widgets']);
-			foreach ($widgetlist as $key => $widget) {
-				if (strpos($widget, 'pfblockerng') !== FALSE) {
-					unset($widgetlist[$key]);
-				}
-			}
-			config_set_path('widgets/sequence', implode(',', $widgetlist));
-			write_config('pfBlockerNG: Remove widget', FALSE);
-		}
 	}
 	else {
 		update_status(" All customizations/data will be retained...");

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -912,6 +912,53 @@ def set_dnsbl_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
         )
 
 
+def set_package_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Toggle the pfBlockerNG MASTER switch (``enable_cb``) at ``CFG_GLOBAL``.
+
+    ``enable_cb='on'`` → master ON (``$pfb['enable']=='on'``; ``$mode=='enabled'``
+    when DNSBL is also on and the DNS resolver is up).
+    ``enable_cb=''`` → master OFF (``$mode`` never reaches ``'enabled'``).
+
+    Written via the same section-read/write pattern as :func:`set_dnsbl_enabled`.
+    """
+    val = "on" if on else ""
+    snippet = (
+        f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
+        f"$g['enable_cb'] = {_php_str(val)};\n"
+        f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
+        "write_config('pfBlockerNG smoke: toggle enable_cb');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_package_enabled({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def set_pfb_keep(vm: SmokeVM, keep: bool, *, timeout: float = 60.0) -> None:
+    """Set ``pfb_keep`` at ``CFG_GLOBAL``: ``True`` → ``'on'`` (retain settings + data on
+    uninstall); ``False`` → ``'off'`` (full removal — live objects + settings + data all gone).
+
+    ``pfb_keep`` defaults to ``'on'`` (issue #281), so a test that asserts sections are
+    swept after uninstall MUST call ``set_pfb_keep(vm, False)`` explicitly to select the
+    full-removal path.  A test that asserts sections are RETAINED after uninstall (the
+    #484 fix) uses ``set_pfb_keep(vm, True)`` (or relies on the default, but explicit
+    is clearer).
+    """
+    val = "on" if keep else "off"
+    snippet = (
+        f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
+        f"$g['pfb_keep'] = {_php_str(val)};\n"
+        f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
+        "write_config('pfBlockerNG smoke: set pfb_keep');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"set_pfb_keep({keep}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
 def set_dnsbl_interface(vm: SmokeVM, iface: str, *, timeout: float = 60.0) -> None:
     """Set the DNSBL interface (``dnsbl_interface``) in the DNSBL-settings section.
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -938,7 +938,11 @@ def set_package_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None
 
 def set_pfb_keep(vm: SmokeVM, keep: bool, *, timeout: float = 60.0) -> None:
     """Set ``pfb_keep`` at ``CFG_GLOBAL``: ``True`` → ``'on'`` (retain settings + data on
-    uninstall); ``False`` → ``'off'`` (full removal — live objects + settings + data all gone).
+    uninstall); ``False`` → ``''`` (full removal — live objects + settings + data all gone).
+
+    ``pfb_keep`` is a toggle whose stored vocabulary is ``{'on', ''}`` (off is the empty
+    string, matching ``PfbToggle::Off``), so the off case writes ``''`` — the canonical
+    value, like ``set_package_enabled`` / ``set_dnsbl_enabled``.
 
     ``pfb_keep`` defaults to ``'on'`` (issue #281), so a test that asserts sections are
     swept after uninstall MUST call ``set_pfb_keep(vm, False)`` explicitly to select the
@@ -946,7 +950,7 @@ def set_pfb_keep(vm: SmokeVM, keep: bool, *, timeout: float = 60.0) -> None:
     #484 fix) uses ``set_pfb_keep(vm, True)`` (or relies on the default, but explicit
     is clearer).
     """
-    val = "on" if keep else "off"
+    val = "on" if keep else ""
     snippet = (
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         f"$g['pfb_keep'] = {_php_str(val)};\n"

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -1195,10 +1195,9 @@ def test_dns_redirect_uninstall_keep_on_removes_rules_retains_sections(
             "pfb_keep=on should have retained settings sections (the #484 fix: keep gates only settings/data)"
         )
 
-    except Exception:
-        # Best-effort teardown: package may already be gone after uninstall.
-        try:
-            _cleanup_redirect(vm)
-        except Exception:
-            pass
-        raise
+    finally:
+        # Best-effort teardown — runs on success too so the retained config (keep=on leaves
+        # the DNSBL section in place) does not bleed the redirect toggle into the next module.
+        # _cleanup_redirect is internally best-effort: its config write turns the toggle off
+        # even with the package uninstalled, and its reload no-ops when the package is gone.
+        _cleanup_redirect(vm)

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -120,6 +120,22 @@ def primary_iface(deployed_vm: SmokeVM) -> str:
     return available[0]
 
 
+@pytest.fixture(autouse=True)
+def _ensure_pkg_installed(deployed_vm: SmokeVM) -> None:
+    """Redeploy the package if a prior test in this module uninstalled it.
+
+    The uninstall cases ``pkg delete`` the package mid-module; without this,
+    every subsequent test under the module-scoped ``deployed_vm`` would fail to
+    reload ('Could not open input file ... pfblockerng.php'). Cheap install-state
+    probe; redeploy + re-seed only when the package is actually missing.
+    """
+    if not h.pkg_installed(deployed_vm):
+        h.deploy(deployed_vm)
+        h.snapshot_unbound_conf(deployed_vm)
+        h.ensure_dnsbl_vip(deployed_vm)
+        h.use_system_dns_upstream(deployed_vm)
+
+
 # --------------------------------------------------------------------------- #
 # Internal helpers — config.xml queries for DNS-redirect state
 # --------------------------------------------------------------------------- #
@@ -968,3 +984,221 @@ def test_dns_redirect_uninstall_sweeps_owned_rules_preserves_user_nat(deployed_v
     assert not _pfb_sections_present(vm), (
         "installedpackages/pfblockerng* still present after uninstall — pfb_remove_config_settings did not run"
     )
+
+
+# --------------------------------------------------------------------------- #
+# Case 7 — Master-disable coupling: redirect rules absent when master OFF
+# --------------------------------------------------------------------------- #
+
+
+def test_dns_redirect_master_disable_removes_rules_despite_toggle_on(deployed_vm: SmokeVM, primary_iface: str) -> None:
+    """ADR-36 / issue #484 Case 7: master-disable forces redirect rules absent even with toggle ON.
+
+    Scenario: $mode-coupling — master enable_cb=off removes redirect rules unconditionally.
+
+      Background: pfBlockerNG installed; DNS redirect disabled; DNSBL enabled.
+
+      Given DNS redirect is enabled on the primary non-WAN interface (toggle ON),
+        And the master switch (enable_cb) is ON,
+        And 2 pfB_DNS_Redirect_<iface>_* nat/rule entries are present (before-state),
+        And pfctl -sn shows rdr rules on the primary interface (before-state),
+
+      When the master switch is turned OFF (enable_cb='') and a full reload runs,
+
+      Then nat/rule has 0 pfB_DNS_Redirect_* entries (rules force-removed by $mode coupling).
+        And pfctl -sn shows no rdr rules on the primary interface for port 53.
+
+      Note: the redirect TOGGLE (dnsbl_redir) remains ON throughout; the removal is caused
+      solely by the master switch, proving the $mode-coupling in pfblockerng_php_pre_deinstall
+      and pfb_create_dnsbl (devel: DNS-redirect/DoT rules coupled to $mode==='enabled').
+    """
+    vm = deployed_vm
+    iface = primary_iface
+
+    try:
+        # GIVEN — ensure master ON; enable redirect; assert before-state present.
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
+        _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
+        h.reload(vm, "update")
+
+        before_count = _nat_redir_count(vm, _REDIR_DESCR_PFX + iface)
+        assert before_count == 2, (
+            f"Expected 2 pfB_DNS_Redirect_{iface}_* nat/rule entries before master-disable, got {before_count}"
+        )
+        assert h.wait_until(lambda: _pfctl_sn_has_redir(vm, iface)), (
+            f"pfctl -sn shows no rdr on {iface} before master-disable — before-state setup failed\n"
+            + _redir_match_report(vm, iface, expected_present=True)
+        )
+
+        # WHEN — turn master OFF; reload (dnsbl_redir toggle remains ON).
+        h.set_package_enabled(vm, False)
+        h.reload(vm, "update")
+
+        # THEN — all redirect nat rules must be gone (force-removed by $mode coupling).
+        after_count = _nat_redir_count(vm, _REDIR_DESCR_PFX)
+        assert after_count == 0, (
+            f"pfB_DNS_Redirect_* nat/rule entries still present ({after_count}) after master-disable — "
+            f"$mode-coupling did not force-remove redirect rules when enable_cb='' (master OFF)\n"
+            + _redir_match_report(vm, iface, expected_present=False)
+        )
+
+        # THEN — pfctl confirms no rdr rule (async: poll until absent).
+        assert h.wait_until(lambda: not _pfctl_sn_has_redir(vm, iface)), (
+            f"pfctl -sn still shows an rdr rule on {iface} after master-disable\n"
+            + _redir_match_report(vm, iface, expected_present=False)
+        )
+
+    finally:
+        # Restore baseline: master ON, redirect disabled.
+        h.set_package_enabled(vm, True)
+        _cleanup_redirect(vm)
+
+
+# --------------------------------------------------------------------------- #
+# Case 8 — DNSBL-disable coupling: redirect rules absent when DNSBL toggle OFF
+# --------------------------------------------------------------------------- #
+
+
+def test_dns_redirect_dnsbl_disable_removes_rules_despite_toggle_on(deployed_vm: SmokeVM, primary_iface: str) -> None:
+    """ADR-36 / issue #484 Case 8: DNSBL-off forces redirect rules absent even with toggle ON.
+
+    Scenario: $mode-coupling — DNSBL toggle pfb_dnsbl='' removes redirect rules unconditionally.
+
+      Background: pfBlockerNG installed; master ON; DNS redirect toggle ON.
+
+      Given master ON + DNSBL ON + redirect ON → 2 pfB_DNS_Redirect_<iface>_* entries present
+        (before-state: prove all-ON produces rules — this is the positive guard),
+
+      When DNSBL is turned OFF (pfb_dnsbl='') and a full reload runs
+        (master remains ON; redirect toggle dnsbl_redir remains ON),
+
+      Then nat/rule has 0 pfB_DNS_Redirect_* entries (force-removed by $mode coupling).
+        And pfctl -sn shows no rdr rules on the primary interface for port 53.
+
+      Note: the positive guard (rules present when all enablers are ON) prevents this
+      test from masking a regression where rules are always absent regardless.
+    """
+    vm = deployed_vm
+    iface = primary_iface
+
+    try:
+        # GIVEN — master ON + DNSBL ON + redirect ON; assert before-state with rules present.
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
+        _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
+        h.reload(vm, "update")
+
+        before_count = _nat_redir_count(vm, _REDIR_DESCR_PFX + iface)
+        assert before_count == 2, (
+            f"Expected 2 pfB_DNS_Redirect_{iface}_* nat/rule entries before DNSBL-disable (positive guard), "
+            f"got {before_count} — rules absent even when all enablers are ON"
+        )
+        assert h.wait_until(lambda: _pfctl_sn_has_redir(vm, iface)), (
+            f"pfctl -sn shows no rdr on {iface} before DNSBL-disable — before-state setup failed\n"
+            + _redir_match_report(vm, iface, expected_present=True)
+        )
+
+        # WHEN — turn DNSBL OFF; reload (master ON; dnsbl_redir toggle remains ON).
+        h.set_dnsbl_enabled(vm, False)
+        h.reload(vm, "update")
+
+        # THEN — all redirect nat rules must be gone (force-removed by $mode coupling).
+        after_count = _nat_redir_count(vm, _REDIR_DESCR_PFX)
+        assert after_count == 0, (
+            f"pfB_DNS_Redirect_* nat/rule entries still present ({after_count}) after DNSBL-disable — "
+            f"$mode-coupling did not force-remove redirect rules when pfb_dnsbl='' (DNSBL OFF)\n"
+            + _redir_match_report(vm, iface, expected_present=False)
+        )
+
+        # THEN — pfctl confirms no rdr rule (async: poll until absent).
+        assert h.wait_until(lambda: not _pfctl_sn_has_redir(vm, iface)), (
+            f"pfctl -sn still shows an rdr rule on {iface} after DNSBL-disable\n"
+            + _redir_match_report(vm, iface, expected_present=False)
+        )
+
+    finally:
+        # Restore baseline: DNSBL ON, redirect disabled.
+        h.set_dnsbl_enabled(vm, True)
+        _cleanup_redirect(vm)
+
+
+# --------------------------------------------------------------------------- #
+# Case 9 — Uninstall keep=on: live rules gone; sections + data retained (#484)
+# --------------------------------------------------------------------------- #
+
+
+def test_dns_redirect_uninstall_keep_on_removes_rules_retains_sections(
+    deployed_vm: SmokeVM, primary_iface: str
+) -> None:
+    """ADR-36 / issue #484 Case 9: uninstall with keep=on removes redirect rules but retains sections.
+
+    Scenario: uninstall keep=on — live firewall objects torn down unconditionally;
+    settings sections retained because pfb_keep=on.
+
+      Given pfb_keep is set to 'on' (retain settings + data on uninstall),
+        And DNS redirect is enabled on the primary non-WAN interface (redirect toggle ON),
+        And 2 pfB_DNS_Redirect_<iface>_* nat/rule entries are present (before-state),
+        And a user nat/rule entry (no pfB marker) is present in config.xml (before-state),
+        And installedpackages/pfblockerng* sections are present (before-state),
+
+      When pfBlockerNG is uninstalled via 'pkg delete',
+
+      Then all pfB_DNS_Redirect_* nat/rule entries are GONE (live sweep is unconditional).
+        And the user nat/rule entry is STILL PRESENT (user objects never swept).
+        And installedpackages/pfblockerng* sections are STILL PRESENT (pfb_keep=on retains them).
+
+      This is the core #484 fix: before the fix the deinstall keep-gate blocked the live-object
+      sweep, so pfB-owned rules were left behind. After the fix, live-object teardown runs
+      unconditionally; pfb_keep gates only the settings/data removal.
+    """
+    vm = deployed_vm
+    iface = primary_iface
+
+    try:
+        # GIVEN — set keep=on; enable redirect; seed user NAT; assert all before-states.
+        h.set_pfb_keep(vm, True)
+        _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
+        h.reload(vm, "update")
+        _seed_user_nat(vm, _USER_NAT_DESCR)
+
+        before_nat = _nat_redir_count(vm, _REDIR_DESCR_PFX + iface)
+        assert before_nat == 2, (
+            f"Expected 2 pfB_DNS_Redirect_{iface}_* nat/rule entries before keep=on uninstall, got {before_nat}"
+        )
+        assert _nat_rule_present(vm, _USER_NAT_DESCR), (
+            "user NAT rule not present before keep=on uninstall — seeding failed"
+        )
+        assert _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* absent before keep=on uninstall — unexpected clean state"
+        )
+
+        # WHEN — uninstall pfBlockerNG with pfb_keep=on.
+        _pkg_delete(vm)
+
+        # THEN — pfB-owned redirect rules are GONE (live-object teardown is unconditional).
+        after_nat = _nat_redir_count(vm, _REDIR_DESCR_PFX)
+        assert after_nat == 0, (
+            f"pfB_DNS_Redirect_* nat/rule entries still present ({after_nat}) after keep=on uninstall — "
+            f"live-object teardown did not run unconditionally (the #484 bug: keep-gate blocked the sweep)\n"
+            + h.deinstall_debug(vm)
+        )
+
+        # THEN — user NAT rule survives (never swept).
+        assert _nat_rule_present(vm, _USER_NAT_DESCR), (
+            "user NAT rule was DELETED during keep=on uninstall — sweep incorrectly removed a user object"
+        )
+
+        # THEN — pfblockerng* sections are STILL PRESENT (pfb_keep=on retains settings + data).
+        assert _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* GONE after keep=on uninstall — "
+            "pfb_keep=on should have retained settings sections (the #484 fix: keep gates only settings/data)"
+        )
+
+    except Exception:
+        # Best-effort teardown: package may already be gone after uninstall.
+        try:
+            _cleanup_redirect(vm)
+        except Exception:
+            pass
+        raise

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -1107,10 +1107,9 @@ def test_dot_block_uninstall_keep_on_removes_rules_retains_sections(deployed_vm:
             "pfb_keep=on should have retained settings sections (the #484 fix: keep gates only settings/data)"
         )
 
-    except Exception:
-        # Best-effort teardown: package may already be gone after uninstall.
-        try:
-            _cleanup_dot_block(vm)
-        except Exception:
-            pass
-        raise
+    finally:
+        # Best-effort teardown — runs on success too so the retained config (keep=on leaves
+        # the DNSBL section in place) does not bleed the DoT-block toggle into the next module.
+        # _cleanup_dot_block is internally best-effort: its config write turns the toggle off
+        # even with the package uninstalled, and its reload no-ops when the package is gone.
+        _cleanup_dot_block(vm)

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -576,6 +576,9 @@ def test_user_filter_rule_survives_disable_and_uninstall(deployed_vm: SmokeVM, p
     iface = primary_iface
 
     try:
+        # GIVEN — select the full-removal uninstall path (pfb_keep defaults to 'on'; a test that
+        # asserts sections-gone must set pfb_keep=off explicitly — see issue #484).
+        h.set_pfb_keep(vm, False)
         # GIVEN — seed the user filter rule; assert block is disabled.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
         h.reload(vm, "update")
@@ -797,6 +800,9 @@ def test_uninstall_sweep_removes_all_dot_block_rules(deployed_vm: SmokeVM, prima
     vm = deployed_vm
     iface = primary_iface
 
+    # GIVEN — select the full-removal uninstall path (pfb_keep defaults to 'on'; a test
+    # that asserts sections-gone must set pfb_keep=off explicitly — see issue #484).
+    h.set_pfb_keep(vm, False)
     # GIVEN — enable DoT block on the primary interface and seed a user filter rule.
     _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
     h.reload(vm, "update")
@@ -893,3 +899,218 @@ def test_self_exempt_guard_in_pfctl_output(deployed_vm: SmokeVM, primary_iface: 
 
     finally:
         _cleanup_dot_block(vm)
+
+
+# --------------------------------------------------------------------------- #
+# Case 8 — Master-disable coupling: DoT rules absent when master OFF
+# --------------------------------------------------------------------------- #
+
+
+def test_dot_block_master_disable_removes_rules_despite_toggle_on(deployed_vm: SmokeVM, primary_iface: str) -> None:
+    """ADR-37 / issue #484 Case 8: master-disable forces DoT block rules absent even with toggle ON.
+
+    Scenario: $mode-coupling — master enable_cb=off removes DoT block rules unconditionally.
+
+      Background: pfBlockerNG installed; DoT block disabled; DNSBL enabled.
+
+      Given DoT block is enabled on the primary non-WAN interface (toggle ON),
+        And the master switch (enable_cb) is ON,
+        And 1 pfB_DoT_Block_<iface> filter/rule entry is present (before-state),
+        And pfctl -sr shows the port-853 block rule (before-state),
+
+      When the master switch is turned OFF (enable_cb='') and a full reload runs,
+
+      Then filter/rule has 0 pfB_DoT_Block_* entries (rules force-removed by $mode coupling).
+        And pfctl -sr shows no port-853 block rule.
+
+      Note: the DoT toggle (dnsbl_dot_block) remains ON throughout; the removal is caused
+      solely by the master switch, proving the $mode-coupling in pfb_create_dnsbl.
+    """
+    vm = deployed_vm
+    iface = primary_iface
+
+    try:
+        # GIVEN — ensure master ON; enable DoT block; assert before-state present.
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
+        _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
+        h.reload(vm, "update")
+
+        before_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface)
+        assert before_count == 1, (
+            f"Expected 1 pfB_DoT_Block_{iface} filter/rule entry before master-disable, got {before_count}"
+        )
+        assert h.wait_until(lambda: _pfctl_sr_has_block_853(vm)), (
+            "pfctl -sr shows no port-853 block before master-disable — before-state setup failed\n"
+            + _dot_block_match_report(vm, expected_present=True)
+        )
+
+        # WHEN — turn master OFF; reload (dnsbl_dot_block toggle remains ON).
+        h.set_package_enabled(vm, False)
+        h.reload(vm, "update")
+
+        # THEN — all DoT block filter rules must be gone (force-removed by $mode coupling).
+        after_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX)
+        assert after_count == 0, (
+            f"pfB_DoT_Block_* filter/rule entries still present ({after_count}) after master-disable — "
+            f"$mode-coupling did not force-remove DoT block rules when enable_cb='' (master OFF)\n"
+            + _dot_block_match_report(vm, expected_present=False)
+        )
+
+        # THEN — pfctl confirms no port-853 block (async: poll until absent).
+        assert h.wait_until(lambda: not _pfctl_sr_has_block_853(vm)), (
+            "pfctl -sr still shows a port-853 block rule after master-disable\n"
+            + _dot_block_match_report(vm, expected_present=False)
+        )
+
+    finally:
+        # Restore baseline: master ON, DoT block disabled.
+        h.set_package_enabled(vm, True)
+        _cleanup_dot_block(vm)
+
+
+# --------------------------------------------------------------------------- #
+# Case 9 — DNSBL-disable coupling: DoT rules absent when DNSBL toggle OFF
+# --------------------------------------------------------------------------- #
+
+
+def test_dot_block_dnsbl_disable_removes_rules_despite_toggle_on(deployed_vm: SmokeVM, primary_iface: str) -> None:
+    """ADR-37 / issue #484 Case 9: DNSBL-off forces DoT block rules absent even with toggle ON.
+
+    Scenario: $mode-coupling — DNSBL toggle pfb_dnsbl='' removes DoT block rules unconditionally.
+
+      Background: pfBlockerNG installed; master ON; DoT block toggle ON.
+
+      Given master ON + DNSBL ON + DoT block ON → 1 pfB_DoT_Block_<iface> entry present
+        (before-state: positive guard — proves rules appear when all enablers are ON),
+
+      When DNSBL is turned OFF (pfb_dnsbl='') and a full reload runs
+        (master remains ON; dnsbl_dot_block toggle remains ON),
+
+      Then filter/rule has 0 pfB_DoT_Block_* entries (force-removed by $mode coupling).
+        And pfctl -sr shows no port-853 block rule.
+
+      Note: the positive guard (rule present when all enablers are ON) prevents this test
+      from masking a regression where rules are always absent.
+    """
+    vm = deployed_vm
+    iface = primary_iface
+
+    try:
+        # GIVEN — master ON + DNSBL ON + DoT block ON; assert before-state with rule present.
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
+        _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
+        h.reload(vm, "update")
+
+        before_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface)
+        assert before_count == 1, (
+            f"Expected 1 pfB_DoT_Block_{iface} filter/rule entry before DNSBL-disable (positive guard), "
+            f"got {before_count} — rule absent even when all enablers are ON"
+        )
+        assert h.wait_until(lambda: _pfctl_sr_has_block_853(vm)), (
+            "pfctl -sr shows no port-853 block before DNSBL-disable — before-state setup failed\n"
+            + _dot_block_match_report(vm, expected_present=True)
+        )
+
+        # WHEN — turn DNSBL OFF; reload (master ON; dnsbl_dot_block toggle remains ON).
+        h.set_dnsbl_enabled(vm, False)
+        h.reload(vm, "update")
+
+        # THEN — all DoT block filter rules must be gone (force-removed by $mode coupling).
+        after_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX)
+        assert after_count == 0, (
+            f"pfB_DoT_Block_* filter/rule entries still present ({after_count}) after DNSBL-disable — "
+            f"$mode-coupling did not force-remove DoT block rules when pfb_dnsbl='' (DNSBL OFF)\n"
+            + _dot_block_match_report(vm, expected_present=False)
+        )
+
+        # THEN — pfctl confirms no port-853 block (async: poll until absent).
+        assert h.wait_until(lambda: not _pfctl_sr_has_block_853(vm)), (
+            "pfctl -sr still shows a port-853 block rule after DNSBL-disable\n"
+            + _dot_block_match_report(vm, expected_present=False)
+        )
+
+    finally:
+        # Restore baseline: DNSBL ON, DoT block disabled.
+        h.set_dnsbl_enabled(vm, True)
+        _cleanup_dot_block(vm)
+
+
+# --------------------------------------------------------------------------- #
+# Case 10 — Uninstall keep=on: live rules gone; sections retained (#484)
+# --------------------------------------------------------------------------- #
+
+
+def test_dot_block_uninstall_keep_on_removes_rules_retains_sections(deployed_vm: SmokeVM, primary_iface: str) -> None:
+    """ADR-37 / issue #484 Case 10: uninstall with keep=on removes DoT rules but retains sections.
+
+    Scenario: uninstall keep=on — live firewall objects torn down unconditionally;
+    settings sections retained because pfb_keep=on.
+
+      Given pfb_keep is set to 'on' (retain settings + data on uninstall),
+        And DoT block is enabled on the primary non-WAN interface (toggle ON),
+        And 1 pfB_DoT_Block_<iface> filter/rule entry is present (before-state),
+        And a user filter/rule entry (no pfB marker) is present in config.xml (before-state),
+        And installedpackages/pfblockerng* sections are present (before-state),
+
+      When pfBlockerNG is uninstalled via 'pkg delete',
+
+      Then all pfB_DoT_Block_* filter/rule entries are GONE (live sweep is unconditional).
+        And the user filter/rule entry is STILL PRESENT (user objects never swept).
+        And installedpackages/pfblockerng* sections are STILL PRESENT (pfb_keep=on retains them).
+
+      This is the core #484 fix: before the fix the deinstall keep-gate blocked the live-object
+      sweep, so pfB-owned rules were left behind. After the fix, live-object teardown runs
+      unconditionally; pfb_keep gates only the settings/data removal.
+    """
+    vm = deployed_vm
+    iface = primary_iface
+
+    try:
+        # GIVEN — set keep=on; enable DoT block; seed user filter; assert all before-states.
+        h.set_pfb_keep(vm, True)
+        _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
+        h.reload(vm, "update")
+        _seed_user_filter(vm, _USER_FILTER_DESCR)
+
+        before_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface)
+        assert before_count == 1, (
+            f"Expected 1 pfB_DoT_Block_{iface} filter/rule entry before keep=on uninstall, got {before_count}"
+        )
+        assert _filter_rule_present(vm, _USER_FILTER_DESCR), (
+            "user filter rule not present before keep=on uninstall — seeding failed"
+        )
+        assert _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* absent before keep=on uninstall — unexpected clean state"
+        )
+
+        # WHEN — uninstall pfBlockerNG with pfb_keep=on.
+        _pkg_delete(vm)
+
+        # THEN — pfB-owned DoT block rules are GONE (live-object teardown is unconditional).
+        after_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX)
+        assert after_count == 0, (
+            f"pfB_DoT_Block_* filter/rule entries still present ({after_count}) after keep=on uninstall — "
+            f"live-object teardown did not run unconditionally (the #484 bug: keep-gate blocked the sweep)\n"
+            + h.deinstall_debug(vm)
+        )
+
+        # THEN — user filter rule survives (never swept).
+        assert _filter_rule_present(vm, _USER_FILTER_DESCR), (
+            "user filter rule was DELETED during keep=on uninstall — sweep incorrectly removed a user object"
+        )
+
+        # THEN — pfblockerng* sections are STILL PRESENT (pfb_keep=on retains settings + data).
+        assert _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* GONE after keep=on uninstall — "
+            "pfb_keep=on should have retained settings sections (the #484 fix: keep gates only settings/data)"
+        )
+
+    except Exception:
+        # Best-effort teardown: package may already be gone after uninstall.
+        try:
+            _cleanup_dot_block(vm)
+        except Exception:
+            pass
+        raise

--- a/tests/smoke/test_smoke_managed_objects.py
+++ b/tests/smoke/test_smoke_managed_objects.py
@@ -84,6 +84,22 @@ def deployed_vm(  # noqa: ARG001
         h.collect_host_diagnostics(smoke_vm)
 
 
+@pytest.fixture(autouse=True)
+def _ensure_pkg_installed(deployed_vm: SmokeVM) -> None:
+    """Redeploy the package if a prior test in this module uninstalled it.
+
+    The uninstall scenarios ``pkg delete`` the package mid-module; without this,
+    every subsequent test under the module-scoped ``deployed_vm`` would fail to
+    reload ('Could not open input file ... pfblockerng.php'). Cheap install-state
+    probe; redeploy + re-seed only when the package is actually missing.
+    """
+    if not h.pkg_installed(deployed_vm):
+        h.deploy(deployed_vm)
+        h.snapshot_unbound_conf(deployed_vm)
+        h.ensure_dnsbl_vip(deployed_vm)
+        h.use_system_dns_upstream(deployed_vm)
+
+
 # --------------------------------------------------------------------------- #
 # Internal helpers for config.xml VIP / NAT / section reads
 # --------------------------------------------------------------------------- #
@@ -378,6 +394,9 @@ def test_managed_objects_uninstall_sweeps_orphan_preserves_user_objects(deployed
     """
     vm = deployed_vm
 
+    # GIVEN — select the full-removal uninstall path (pfb_keep defaults to 'on'; a test that
+    # asserts sections-gone must set pfb_keep=off explicitly — see issue #484).
+    h.set_pfb_keep(vm, False)
     # GIVEN — seed the three objects; first confirm DNSBL is disabled / clean.
     h.set_dnsbl_enabled(vm, False)
     h.set_dnsvip_auto(vm, False)
@@ -440,4 +459,98 @@ def test_managed_objects_uninstall_sweeps_orphan_preserves_user_objects(deployed
     # pfBlockerNG config sections must be gone.
     assert not _pfb_sections_present(vm), (
         "installedpackages/pfblockerng* still present after uninstall — pfb_remove_config_settings did not run"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Scenario D — uninstall keep=on: live objects gone; sections retained (#484)
+# --------------------------------------------------------------------------- #
+
+
+def test_managed_objects_uninstall_keep_on_removes_orphan_retains_sections(deployed_vm: SmokeVM) -> None:
+    """ADR-35 / issue #484 Scenario D: uninstall with keep=on removes orphan VIP but retains sections.
+
+    Scenario: uninstall keep=on — live pfB-owned objects torn down unconditionally;
+    user objects and settings sections retained because pfb_keep=on.
+
+      Given pfb_keep is set to 'on' (retain settings + data on uninstall),
+        And an ORPHAN VIP (descr='pfB_AUTO_VIP_v4', pfb_dnsvip4 cleared) is present in
+            virtualip/vip[] (before-state),
+        And a USER VIP (descr='my-test-user-vip-do-not-delete') is present (before-state),
+        And a USER NAT rule (descr='my-test-user-nat-do-not-delete') is present (before-state),
+        And installedpackages/pfblockerng* sections are present (before-state),
+
+      When pfBlockerNG is uninstalled via 'pkg delete',
+
+      Then the orphan VIP is GONE from virtualip/vip[] (live-object sweep is unconditional).
+        And the user VIP is STILL PRESENT in virtualip/vip[] (not a pfB marker; never swept).
+        And the user NAT rule is STILL PRESENT in nat/rule[] (not a pfB marker; never swept).
+        And installedpackages/pfblockerng* sections are STILL PRESENT (pfb_keep=on retains them).
+
+      This is the core #484 fix: before the fix the deinstall keep-gate blocked the live-object
+      sweep entirely, so pfB-owned objects were left behind on uninstall when keep='on'.
+      After the fix, live-object teardown runs unconditionally; pfb_keep gates only
+      the settings/data removal.
+    """
+    vm = deployed_vm
+
+    # GIVEN — set keep=on; confirm DNSBL is disabled; seed orphan + user objects.
+    h.set_pfb_keep(vm, True)
+    h.set_dnsbl_enabled(vm, False)
+    h.set_dnsvip_auto(vm, False)
+    h.reload(vm, "update")
+
+    _seed_orphan_vip(vm, _AUTO_VIP_DESCR_V4)
+    _seed_user_vip(vm, _USER_VIP_DESCR)
+    _seed_user_nat(vm, _USER_NAT_DESCR)
+
+    # BEFORE-STATE: assert all objects present.
+    assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+        "orphan VIP (pfB_AUTO_VIP_v4) not present before keep=on uninstall — seeding failed"
+    )
+    assert _vip_descr_present(vm, _USER_VIP_DESCR), "user VIP not present before keep=on uninstall — seeding failed"
+
+    pre_nat = (
+        "$found = FALSE;\n"
+        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+        f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
+        "}"
+    )
+    assert h._php_read_scalar(vm, pre_nat, "$found ? 'yes' : 'no'") == "yes", (
+        "user NAT rule not present before keep=on uninstall — seeding failed"
+    )
+    assert _pfb_sections_present(vm), (
+        "installedpackages/pfblockerng* absent before keep=on uninstall — unexpected clean state"
+    )
+
+    # WHEN — uninstall pfBlockerNG with pfb_keep=on.
+    _pkg_delete(vm)
+
+    # THEN — orphan VIP is GONE (live-object sweep is unconditional, regardless of pfb_keep).
+    assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+        "orphan pfB_AUTO_VIP_v4 still present after keep=on uninstall — "
+        "live-object teardown did not run unconditionally (the #484 bug: keep-gate blocked the sweep)\n"
+        + h.deinstall_debug(vm)
+    )
+
+    # THEN — user VIP survives (not a pfB marker — never swept).
+    assert _vip_descr_present(vm, _USER_VIP_DESCR), (
+        "user VIP was DELETED during keep=on uninstall — sweep incorrectly removed a user object"
+    )
+
+    # THEN — user NAT rule survives.
+    post_nat = (
+        "$found = FALSE;\n"
+        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+        f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
+        "}"
+    )
+    assert h._php_read_scalar(vm, post_nat, "$found ? 'yes' : 'no'") == "yes", (
+        "user NAT rule was DELETED during keep=on uninstall — sweep incorrectly removed a user object"
+    )
+
+    # THEN — pfblockerng* sections are STILL PRESENT (pfb_keep=on retains settings + data).
+    assert _pfb_sections_present(vm), (
+        "installedpackages/pfblockerng* GONE after keep=on uninstall — "
+        "pfb_keep=on should have retained settings sections (the #484 fix: keep gates only settings/data)"
     )


### PR DESCRIPTION
## Summary

Fixes the lifecycle teardown bugs in issue #484: uninstalling (and disabling) pfBlockerNG could leave managed firewall/resolver objects alive.

### Root causes (verified on current `devel`)

1. **Deinstall keep-gate bug.** In `pfblockerng_php_pre_deinstall_command()` the *entire* cleanup body was gated behind `if ($pfb['keep'] != 'on')`. `pfb_keep` defaults to `'on'` (#281), so a default uninstall tore down **nothing live** — pf tables, aliastables boot hooks, owned VIP/NAT/filter rules, generated DNSBL files, the Unbound chroot module, and the dashboard widget all survived.

2. **DNS-redirect / DoT-block disable gap.** The inlined DNS-redirect NAT and DoT/DoQ block filter syncs in `sync_package_pfblockerng()` keyed only on their own toggle (`dnsbl_redir` / `dnsbl_dot_block`), never on the master enable / DNSBL state, so they outlived a full pfBlockerNG disable.

> Note: the issue's file refs predate #476, which inlined ADR-36/37 (removed `pfblockerng_dns_bypass.inc`/`pfblockerng_fwobj.inc`). The defects are intact; their locations moved into `pfblockerng.inc`.

### Fix

- **Deinstall split** — live-object teardown now runs **unconditionally**; `pfb_keep` gates **only** the settings sections (`installedpackages/pfblockerng*`) + blocklist data (db/log dirs). Uninstall == full disable; `keep` governs only settings/data retention. The owned-object sweep still runs before `pfb_remove_config_settings()` (ordering preserved).
- **Couple DNS-redirect + DoT/DoQ-block to `$mode`** — both are created only when `$mode === 'enabled'` (master `enable_cb` on + DNSBL toggle on + resolver up) and force-removed otherwise, even if their own toggle is still on. Feeds/lists are not required, only the DNSBL toggle + resolver. This closes the disable-survival gap without touching the valid master-on / DNSBL-off case.

### Tests (smoke matrix — ADR-04)

New shared helpers `set_package_enabled` (master `enable_cb`) + `set_pfb_keep`. Added, each asserting per-resource before/after with expected-vs-actual diagnostics:

- **`$mode` coupling** (redirect + DoT): master-disable and DNSBL-disable force-remove the rules **despite the feature toggle staying on**, each with an all-on positive guard so the test can't pass vacuously.
- **Uninstall `keep='on'`** (redirect + DoT + managed-objects): live objects **gone**, user objects preserved, config sections + data **retained** — the core #484 behaviour.
- Fixed the pre-existing DoT and managed-objects uninstall tests to select `keep='off'` explicitly (they asserted sections-gone without setting `pfb_keep`, which defaults on — red on the fan-out today).

Live correctness is validated by the smoke fan-out (CE + Plus) on dispatch; off-box gates (PHPUnit, PHPStan, PHPCS, ruff/mypy, pytest collection) are green.

Fixes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNS redirect rules now correctly respond to the master enable switch, removing them when disabled even if the redirect toggle remains active.
  * DoT/DoQ block rules now properly couple to the master enable switch and DNSBL setting for consistent behavior.
  * Uninstall process now always cleans up live firewall objects and system files, ensuring proper removal regardless of retention settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->