### PR TITLE
pfblockerng: add widget setting to optionally show Aggregated aliases

### DIFF
--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -45,7 +45,7 @@ $pfb['err']	= '<i class="fa-solid fa-minus-circle text-danger" title="pf Errors 
 
 // Widget customizations
 $wglobal_array = array ('popup' => 'off', 'sortcolumn' => 'none', 'sortmix' => 'off', 'sortdir' => 'asc', 'dnsblquery' => 5,
-			'maxfails' => 3, 'maxheight' => 2500, 'clearip' => 'never', 'cleardnsbl' => 'never');
+			'maxfails' => 3, 'maxheight' => 2500, 'clearip' => 'never', 'cleardnsbl' => 'never', 'show_agg' => 'off');
 
 $pfb['wglobal'] = PfbConfig::readSection('installedpackages/pfblockerngglobal');
 foreach ($wglobal_array as $type => $value) {
@@ -74,10 +74,13 @@ if ($_POST) {
 	if (isset($_POST['pfb_submit'])) {
 		$pfb['wglobal']['widget-popup']			= pfb_filter($_POST['pfb_popup'], PFB_FILTER_ON_OFF, 'widget');
 		$pfb['wglobal']['widget-sortmix']		= pfb_filter($_POST['pfb_sortmix'], PFB_FILTER_ON_OFF, 'widget');
+		$pfb['wglobal']['widget-show_agg']		= pfb_filter($_POST['pfb_show_agg'], PFB_FILTER_ON_OFF, 'widget');
 		// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 		config_set_path('installedpackages/pfblockerngglobal/widget-popup', $pfb['wglobal']['widget-popup']);
 		// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 		config_set_path('installedpackages/pfblockerngglobal/widget-sortmix', $pfb['wglobal']['widget-sortmix']);
+		// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
+		config_set_path('installedpackages/pfblockerngglobal/widget-show_agg', $pfb['wglobal']['widget-show_agg']);
 
 		if (in_array($_POST['pfb_sortcolumn'], array('none', 'alias', 'count', 'packets', 'update'))) {
 			$pfb['wglobal']['widget-sortcolumn']	= $_POST['pfb_sortcolumn'];
@@ -263,10 +266,18 @@ function pfbsort(&$array, $subkey, $sort_ascending) {
 //     by their source lists. <Type> is exactly Deny|Permit|Match|Native; GeoIP folds into
 //     those action types, so there is no separate pfB_Geo_Aggregated alias to match.
 //
-// Hides from display only -- the aliases / pf tables stay wired and functional.
-function pfb_widget_alias_hidden($pfb_alias) {
-	return empty($pfb_alias) || $pfb_alias == 'pfB_DNSBL_VIPs' ||
-	    preg_match('/^pfB_(Deny|Permit|Match|Native)_Aggregated_v[46]$/', $pfb_alias) === 1;
+// The aggregate aliases are revealed when $show_agg is TRUE (the widget's
+// "Show Aggregated Aliases" setting); pfB_DNSBL_VIPs and empty names stay hidden
+// regardless. Hides from display only -- the aliases / pf tables stay wired and
+// functional.
+function pfb_widget_alias_hidden($pfb_alias, $show_agg = FALSE) {
+	if (empty($pfb_alias) || $pfb_alias == 'pfB_DNSBL_VIPs') {
+		return TRUE;
+	}
+	if (preg_match('/^pfB_(Deny|Permit|Match|Native)_Aggregated_v[46]$/', $pfb_alias) === 1) {
+		return $show_agg !== TRUE;
+	}
+	return FALSE;
 }
 
 // Collect all pfBlockerNG statistics
@@ -274,6 +285,9 @@ function pfBlockerNG_update_table() {
 	global $pfb;
 	$pfb_table = $pfb_dtable = array();
 	$pfb['pfctlerr'] = FALSE;
+
+	// Reveal the ADR-11 aggregate aliases only when the widget setting opts in.
+	$show_agg = (($pfb['show_agg'] ?? 'off') == 'on');
 
 	/* Alias Table Definitions -	'update'	- Last Updated Timestamp
 					'rule'		- Total number of Firewall rules per alias
@@ -288,7 +302,7 @@ function pfBlockerNG_update_table() {
 			$line = trim(str_replace(array( '[', ']' ), '', $line));
 			if (substr($line, 0, 1) == '-') {
 				$pfb_alias = trim(strstr($line, 'pfB', FALSE));
-				if (pfb_widget_alias_hidden($pfb_alias)) {
+				if (pfb_widget_alias_hidden($pfb_alias, $show_agg)) {
 					unset($pfb_alias);
 					continue;
 				}
@@ -1078,6 +1092,13 @@ function pfBlockerNG_get_table($mode='', $pfb_table) {
 		<div class="col-sm-2 checkbox">
 			<label><input type="checkbox" name="pfb_popup" value="on"
 				<?=($pfb['popup'] == "on" ? 'checked' : '')?> /></label>
+		</div>
+	</div>
+	<div class="form-group">
+		<label for="pfb_show_agg" class="col-sm-8 control-label"><?=gettext('Show Aggregated Aliases')?></label>
+		<div class="col-sm-2 checkbox">
+			<label><input type="checkbox" name="pfb_show_agg" value="on"
+				<?=($pfb['show_agg'] == "on" ? 'checked' : '')?> /></label>
 		</div>
 	</div>
 	<div class="form-group">

--- a/tests/php/WidgetAliasHiddenTest.php
+++ b/tests/php/WidgetAliasHiddenTest.php
@@ -42,9 +42,9 @@ final class WidgetAliasHiddenTest extends TestCase
 		}
 
 		// Extract just the function definition (signature through its closing brace).
-		// The body is a single return statement, so the first '}' after the signature
-		// closes the function.
-		if (!preg_match('/function\s+pfb_widget_alias_hidden\s*\([^)]*\)\s*\{.*?\}/s', $src, $m)) {
+		// The body's inner braces are tab-indented, so the function's own closing brace
+		// is the first '}' at the start of a line (\n followed by '}').
+		if (!preg_match('/function\s+pfb_widget_alias_hidden\s*\([^)]*\).*?\n\}/s', $src, $m)) {
 			throw new RuntimeException('test bootstrap: pfb_widget_alias_hidden() not found in widget source');
 		}
 		eval($m[0]);
@@ -76,10 +76,13 @@ final class WidgetAliasHiddenTest extends TestCase
 			pfb_widget_alias_hidden($alias),
 			"alias {$alias} should be displayed in the widget"
 		);
+		// The toggle governs aggregates only — an ordinary alias is shown either way.
+		$this->assertFalse(pfb_widget_alias_hidden($alias, TRUE));
 	}
 
 	/**
-	 * Every one of the eight ADR-11 aggregate aliases is HIDDEN.
+	 * The eight ADR-11 aggregate aliases — used to assert BOTH branches of the
+	 * "Show Aggregated Aliases" widget setting (issue #494).
 	 *
 	 * @return list<array{string}>
 	 */
@@ -94,24 +97,42 @@ final class WidgetAliasHiddenTest extends TestCase
 		return $out;
 	}
 
+	// Default (setting OFF, $show_agg defaults to false): every aggregate is HIDDEN —
+	// the "before" state that proves the toggle actually changes behaviour.
 	#[\PHPUnit\Framework\Attributes\DataProvider('aggregateAliasProvider')]
-	public function testAggregateAliasIsHidden(string $alias): void
+	public function testAggregateAliasIsHiddenByDefault(string $alias): void
 	{
 		$this->assertTrue(
 			pfb_widget_alias_hidden($alias),
-			"aggregate alias {$alias} must be hidden from the widget"
+			"aggregate alias {$alias} must be hidden when the setting is off"
+		);
+		// Explicit false is identical to the default.
+		$this->assertTrue(pfb_widget_alias_hidden($alias, FALSE));
+	}
+
+	// Setting ON ($show_agg = true): the same aggregate is now SHOWN — the "after"
+	// state, proving the flip is caused by the toggle and not an always-hidden path.
+	#[\PHPUnit\Framework\Attributes\DataProvider('aggregateAliasProvider')]
+	public function testAggregateAliasIsShownWhenSettingEnabled(string $alias): void
+	{
+		$this->assertFalse(
+			pfb_widget_alias_hidden($alias, TRUE),
+			"aggregate alias {$alias} must be shown when the setting is on"
 		);
 	}
 
-	// The pre-existing DNSBL VIP exclusion is preserved by the refactor.
-	public function testDnsblVipsIsHidden(): void
+	// The pre-existing DNSBL VIP exclusion is preserved by the refactor and is NOT
+	// governed by the toggle — it stays hidden whether the setting is off or on.
+	public function testDnsblVipsIsHiddenRegardlessOfSetting(): void
 	{
 		$this->assertTrue(pfb_widget_alias_hidden('pfB_DNSBL_VIPs'));
+		$this->assertTrue(pfb_widget_alias_hidden('pfB_DNSBL_VIPs', TRUE));
 	}
 
-	// An empty alias name (strstr() found no 'pfB' token) is hidden, as before.
-	public function testEmptyAliasIsHidden(): void
+	// An empty alias name (strstr() found no 'pfB' token) is hidden either way.
+	public function testEmptyAliasIsHiddenRegardlessOfSetting(): void
 	{
 		$this->assertTrue(pfb_widget_alias_hidden(''));
+		$this->assertTrue(pfb_widget_alias_hidden('', TRUE));
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #481 / #491. Those hid the eight ADR-11 aggregate ("Uber") aliases (`pfB_<Type>_Aggregated_v4/v6`) from the pfBlockerNG dashboard widget unconditionally. The maintainer floated the idea of a toggle to show them on demand — this adds it.

- New **"Show Aggregated Aliases"** checkbox in the widget settings panel, persisted as the foreign `installedpackages/pfblockerngglobal/widget-show_agg` key in the existing `pfb_submit` POST handler — the same pattern as `widget-popup` / `widget-sortmix`.
- **Default off** — the #481 behaviour (aggregates hidden) is preserved unless the user enables it. `pfb_widget_alias_hidden()` gains a `$show_agg` parameter; when on, the aggregate aliases are revealed. `pfB_DNSBL_VIPs` and empty names stay hidden regardless.

## Tests

- `WidgetAliasHiddenTest` extended to assert **both** branches of the toggle: each aggregate is hidden when off and shown when on (before/after, proving the flip is caused by the setting); ordinary aliases and the VIP table are unaffected either way.
- Gates run locally: `php -l`, PHPCS (CI scope), PHPStan, full `vendor/bin/phpunit` (1272 pass).

Fixes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Show Aggregated Aliases” checkbox to the pfBlockerNG widget settings to control whether aggregated alias entries are displayed.
* **Bug Fixes**
  * Updated alias display logic so aggregated aliases are hidden by default and only shown when the setting is enabled (with existing exclusions still enforced).
* **Tests**
  * Refined and expanded unit tests to verify aggregated, ordinary, VIP, and empty alias visibility for both enabled/disabled states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->