### PR TITLE
tests/smoke/ui: pin DNSBL + widget Tier A markers for #478/#480/#494

### DIFF
--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -71,10 +71,23 @@ PAGE_TABLE: tuple[Page, ...] = (
     Page("ip", "/pfblockerng/pfblockerng_ip.php", ("IP Configuration", "ASN configuration", "Aggregated Aliases")),
     # "DNS Redirect" is the ADR-36 section title added to this page (Phase 3).
     # "DoT/DoQ Block" is the ADR-37 section title added to this page (Phase 3).
+    # "Permit Firewall Rules" + "Interface(s)" are the two field labels of the #478
+    # stacked layout (the toggle and the interface selector now render as separate
+    # rows) -- the markers prove both fields render; the *visual* stacking is the
+    # ui_browser/maintainer tier. "no-AAAA" is the #480 label/section text (verbatim
+    # hyphenated form, guarding the #480 text against a casing/hyphen regression).
     Page(
         "dnsbl",
         "/pfblockerng/pfblockerng_dnsbl.php",
-        ("DNSBL Webserver Configuration", "DNSBL Configuration", "DNS Redirect", "DoT/DoQ Block"),
+        (
+            "DNSBL Webserver Configuration",
+            "DNSBL Configuration",
+            "DNS Redirect",
+            "DoT/DoQ Block",
+            "Permit Firewall Rules",
+            "Interface(s)",
+            "no-AAAA",
+        ),
     ),
     # feeds.php is split into IPv4/IPv6/DNSBL ?type sub-tabs (ADR-16 Phase 3). Each type
     # is probed; the type-specific marker is the active type's "Feed Settings" alias-name
@@ -143,8 +156,14 @@ PAGE_TABLE: tuple[Page, ...] = (
     Page("hooks", "/pfblockerng/pfblockerng_hooks.php", ("Update Hooks", "Hook Entries")),
     # The dashboard widget (auth-gated; $nocsrf=true). A direct GET renders the alias-table panel
     # whose hidden inputs (id="pfblockerngack") are a stable marker; the AJAX getNew* paths need a
-    # query param, so the plain GET exercises the full-render branch.
-    Page("widget", "/widgets/widgets/pfblockerng.widget.php", ('id="pfblockerngack"', "Alias")),
+    # query param, so the plain GET exercises the full-render branch. "Show Aggregated Aliases" is
+    # the #494 settings checkbox label (rendered in the widget's settings panel), proving the new
+    # toggle renders.
+    Page(
+        "widget",
+        "/widgets/widgets/pfblockerng.widget.php",
+        ('id="pfblockerngack"', "Alias", "Show Aggregated Aliases"),
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

Test-only follow-up adding the Tier A `ui_render` (PR-gate) markers that were missed when the recent UI fixes landed (#478/#480 on the DNSBL page, #494 on the dashboard widget). Each marker asserts that a string/field those issues introduced actually renders, so a future edit that silently reverts it is caught at the PR gate.

- **DNSBL page** (`pfblockerng_dnsbl.php`): `"Permit Firewall Rules"` + `"Interface(s)"` — the two field labels of the #478 stacked layout — and `"no-AAAA"`, the #480 hyphenated label/section text.
- **Dashboard widget** (`pfblockerng.widget.php`): `"Show Aggregated Aliases"` — the #494 settings checkbox label.

Added by extending the existing `PAGE_TABLE` marker tuples (same mechanism as the IP page's "Aggregated Aliases" marker); `test_page_renders_clean` requires every marker present.

## Scope note

These guard each field's **presence / clean render**. The *visual* stacking of the #478 layout (control on its own row vs. side-by-side) is genuinely visual and stays the `ui_browser` / maintainer tier — an ADR-14 out-of-CI item — so it is not over-claimed here. No live-VM **smoke** coverage applies: none of these changes altered DNS/feed behaviour, and the widget's actual aggregate hide/show needs the ADR-11 aggregate feature populated (Tier B / maintainer-manual), not a hermetic CI scenario.

## Tests

Test-only change. Local gates: `ruff check` + `ruff format --check`, `mypy tests/` (clean), pytest collection (37 tests). The markers themselves run on the live-VM `ui_render` tier (dispatch/scheduled), which is not a PR-blocking gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation markers for smoke tests to ensure proper rendering of UI components and page elements. Enhanced test coverage for page-specific rendered content verification.

---

**Note:** This is an internal testing update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->