### PR TITLE
tests/smoke: establish $mode=enabled in dns_redirect/dot_doq rule-create tests (#484 follow-up)

### DIFF
--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -520,6 +520,10 @@ def test_dns_redirect_enable_creates_nat_and_filter_rules(deployed_vm: SmokeVM, 
     descr_v6 = _redir_descr_for(iface, "inet6")
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DNS-redirect NAT rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — disable redirect; assert before-state clean.
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
         h.reload(vm, "update")
@@ -641,6 +645,10 @@ def test_dns_redirect_disable_removes_nat_and_filter_rules(deployed_vm: SmokeVM,
     iface = primary_iface
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DNS-redirect NAT rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — enable on the primary interface; assert before-state with rules present.
         _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
         h.reload(vm, "update")
@@ -705,6 +713,10 @@ def test_dns_redirect_user_nat_rule_survives_enable_disable(deployed_vm: SmokeVM
     iface = primary_iface
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DNS-redirect NAT rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — seed the user NAT rule; assert redirect is disabled.
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
         h.reload(vm, "update")
@@ -778,6 +790,10 @@ def test_dns_redirect_stale_interface_pruned_on_reduce(deployed_vm: SmokeVM) -> 
     iface_drop = available[1]  # typically 'opt1'
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DNS-redirect NAT rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — enable on both interfaces; assert both nat/rule sets present.
         _set_dns_redirect(vm, enabled=True, ifaces=[iface_keep, iface_drop], exception="")
         h.reload(vm, "update")
@@ -854,6 +870,10 @@ def test_dns_redirect_exception_alias_branch(deployed_vm: SmokeVM, primary_iface
     descr_v6 = _redir_descr_for(iface, "inet6")
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DNS-redirect NAT rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — start from disabled state.
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
         h.reload(vm, "update")
@@ -941,6 +961,10 @@ def test_dns_redirect_uninstall_sweeps_owned_rules_preserves_user_nat(deployed_v
     vm = deployed_vm
     iface = primary_iface
 
+    # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+    # pfblockerng will create DNS-redirect NAT rules on reload (#484 coupling).
+    h.set_package_enabled(vm, True)
+    h.set_dnsbl_enabled(vm, True)
     # GIVEN — enable redirect on the primary interface and seed a user NAT rule.
     # Select the full-removal uninstall path: the owned-object sweep runs only when
     # pfb_keep != 'on', and pfb_keep defaults to 'on' (issue #281). The keep='on'

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -444,6 +444,10 @@ def test_dot_doq_block_rule_appears_on_enable(deployed_vm: SmokeVM, primary_ifac
     descr = _DOT_BLOCK_DESCR_PFX + iface
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DoT/DoQ block filter rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — disable DoT block; assert before-state clean.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
         h.reload(vm, "update")
@@ -516,6 +520,10 @@ def test_dot_doq_block_rule_removed_on_disable(deployed_vm: SmokeVM, primary_ifa
     iface = primary_iface
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DoT/DoQ block filter rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — enable on the primary interface; assert before-state with rule present.
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
         h.reload(vm, "update")
@@ -576,6 +584,10 @@ def test_user_filter_rule_survives_disable_and_uninstall(deployed_vm: SmokeVM, p
     iface = primary_iface
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DoT/DoQ block filter rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — select the full-removal uninstall path (pfb_keep defaults to 'on'; a test that
         # asserts sections-gone must set pfb_keep=off explicitly — see issue #484).
         h.set_pfb_keep(vm, False)
@@ -677,6 +689,10 @@ def test_stale_interface_rule_pruned_on_reconcile(deployed_vm: SmokeVM) -> None:
     iface_drop = available[1]  # typically 'opt1'
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DoT/DoQ block filter rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — enable on both interfaces; assert both rules present.
         _set_dot_block(vm, enabled=True, ifaces=[iface_keep, iface_drop], exception="")
         h.reload(vm, "update")
@@ -734,6 +750,10 @@ def test_exception_alias_source_in_config_xml_when_set(deployed_vm: SmokeVM, pri
     descr = _DOT_BLOCK_DESCR_PFX + iface
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DoT/DoQ block filter rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — start from disabled state.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
         h.reload(vm, "update")
@@ -800,6 +820,10 @@ def test_uninstall_sweep_removes_all_dot_block_rules(deployed_vm: SmokeVM, prima
     vm = deployed_vm
     iface = primary_iface
 
+    # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+    # pfblockerng will create DoT/DoQ block filter rules on reload (#484 coupling).
+    h.set_package_enabled(vm, True)
+    h.set_dnsbl_enabled(vm, True)
     # GIVEN — select the full-removal uninstall path (pfb_keep defaults to 'on'; a test
     # that asserts sections-gone must set pfb_keep=off explicitly — see issue #484).
     h.set_pfb_keep(vm, False)
@@ -865,6 +889,10 @@ def test_self_exempt_guard_in_pfctl_output(deployed_vm: SmokeVM, primary_iface: 
     iface = primary_iface
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DoT/DoQ block filter rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — disable DoT block; assert before-state clean.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
         h.reload(vm, "update")
@@ -1068,6 +1096,10 @@ def test_dot_block_uninstall_keep_on_removes_rules_retains_sections(deployed_vm:
     iface = primary_iface
 
     try:
+        # GIVEN — establish $mode='enabled' (master ON + DNSBL ON + resolver up) so
+        # pfblockerng will create DoT/DoQ block filter rules on reload (#484 coupling).
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
         # GIVEN — set keep=on; enable DoT block; seed user filter; assert all before-states.
         h.set_pfb_keep(vm, True)
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")


### PR DESCRIPTION
## Fix the #484 fan-out test-compromises (Cluster A)

Follow-up to #484. The post-#484 smoke fan-out went broadly red (36 identical failures on CE + Plus). This PR fixes the **test-compromise** cluster: the original `dns_redirect` / `dot_doq` smoke tests pre-date the #484 `$mode` coupling and never establish `$mode='enabled'`, so they now see 0 owned rules.

### Intent (confirmed)
`$mode === 'enabled'` (master `enable_cb` ON + DNSBL `pfb_dnsbl` ON + the DNS Resolver up) is **the** guard for every pfBlockerNG-created object — the DNSBL VIPs, DNSBL NAT, DNS-Redirect NAT, and DoT/DoQ block rules. None exist when `$mode != 'enabled'`. #484 added new `$mode`-aware tests (`*_master_disable_*`, `*_dnsbl_disable_*`) but did not update the 6+8 original rule-creation tests.

### Change (tests only — no `src/`)
Each affected test's GIVEN now calls `h.set_package_enabled(vm, True)` + `h.set_dnsbl_enabled(vm, True)` to establish `$mode='enabled'` before asserting rule creation — mirroring the #484-added tests. Per-test (not the shared fixture) so it's robust to the `$mode`-toggling tests' teardown.

- `tests/smoke/test_dns_redirect.py` — 6 tests
- `tests/smoke/test_dot_doq_block.py` — 8 tests

### Scope
Part of #484 follow-up. This is **only** the test-compromise cluster. Still open (separate work): the `pfb_keep='off'` deinstall round-trip (a real product bug — `''` reads back as `'on'` on live config), the Unbound reload-hang timeout wave, and the syslog-export cluster (#487).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced stability for DNS redirect smoke tests by explicitly enabling the required pfBlockerNG and DNSBL components before configuration changes and assertions.
  * Enhanced stability for DoT/DoQ block smoke tests by explicitly setting pfBlockerNG master and DNSBL to the expected enabled state before reloads and rule-dependent checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->