### PR TITLE
pfblockerng: pfb_keep stores explicit 'off' so keep=off survives live config (#484 follow-up)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15105,6 +15105,12 @@ function pfblockerng_php_pre_deinstall_command() {
 	// Remove incorrect xml setting
 	config_del_path('installedpackages/pfblockerngantartica');
 
+	// Persist the config-section removals above. config_del_path()/pfb_remove_config_settings()
+	// only mutate the in-memory config; without this final write the uninstall's section wipe
+	// (keep=off) and the legacy-misspelled-section cleanup are lost on disk — the package
+	// reads back as "still installed" in config.xml (#484 fan-out).
+	write_config('pfBlockerNG: remove package config sections on deinstall');
+
 	update_status(" done.\n");
 }
 
@@ -15113,31 +15119,21 @@ function pfblockerng_php_pre_deinstall_command() {
 function pfb_remove_config_settings() {
 	global $pfb;
 
-	foreach (array(	'pfblockerng',
-			'pfblockerngglobal',
-			'pfblockerngsync',
-			'pfblockerngreputation',
-			'pfblockerngipsettings',
-			'pfblockernglistsv4',
-			'pfblockernglistsv6',
-			'pfblockerngdnsbl',
-			'pfblockerngdnsblsettings',
-			'pfblockerngsafesearch',
-			'pfblockerngblacklist',
-			'pfblockerngafrica',
-			'pfblockerngantarctica',
-			'pfblockerngasia',
-			'pfblockerngeurope',
-			'pfblockerngnorthamerica',
-			'pfblockerngoceania',
-			'pfblockerngsouthamerica',
-			'pfblockerngtopspammers',
-			'pfblockerngproxyandsatellite' ) as $type) {
-
-		// ADR-29 foreign-key exclusion: a deinstall wipes whole package sections
-		// (dynamic per-row lists, blacklist, continent structures) — a section-level
-		// operation, not a registered scalar-field access. Use config_del_path directly.
-		config_del_path("installedpackages/{$type}");
+	// Sweep EVERY installedpackages/pfblockerng* section dynamically rather than a
+	// hardcoded list. A fixed list silently leaves behind any section a later feature
+	// adds — e.g. pfblockerngdnsbleasylist (ADR-07 ABP/EasyList), the wizard temp
+	// section, or the misspelled legacy 'pfblockerngantartica' — so a keep=off
+	// uninstall did not fully remove the package (#484 fan-out). Removing every
+	// pfblockerng-prefixed section is exactly the keep=off "full removal" contract and
+	// is future-proof.
+	//
+	// ADR-29 foreign-key exclusion: a deinstall wipes whole package sections
+	// (dynamic per-row lists, blacklist, continent structures) — a section-level
+	// operation, not a registered scalar-field access. Use config_del_path directly.
+	foreach (array_keys(config_get_path('installedpackages', array())) as $type) {
+		if (strpos((string) $type, 'pfblockerng') === 0) {
+			config_del_path("installedpackages/{$type}");
+		}
 	}
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6398,7 +6398,8 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 	}
 
 	// When pfBlockerNG is disabled and 'keep blocklists' is disabled.
-	if ($pfb['enable'] == '' && $pfb['keep'] == '' && !$pfb['install']) {
+	// pfb['keep'] is now 'on'/'off' (PfbLenient); != 'on' covers both 'off' and legacy ''.
+	if ($pfb['enable'] == '' && $pfb['keep'] != 'on' && !$pfb['install']) {
 		unlink_if_exists("{$pfb['dnsbl_file']}{$ext}");
 	}
 
@@ -11273,7 +11274,8 @@ function sync_package_pfblockerng($cron='') {
 	#########################################################
 
 	// When pfBlockerNG is Disabled and 'Keep Blocklists' is Disabled.
-	if ($pfb['enable'] == '' && $pfb['keep'] == '' && !$pfb['install']) {
+	// pfb['keep'] is now 'on'/'off' (PfbLenient); != 'on' covers both 'off' and legacy ''.
+	if ($pfb['enable'] == '' && $pfb['keep'] != 'on' && !$pfb['install']) {
 		$log = "\n  Removing DB Files/Folders \n";
 		pfb_logger("{$log}", 1);
 		pfb_clear_contents();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -55,10 +55,12 @@ enum PfbToggle: string
 	}
 }
 
-// PfbLenient — the ADR-22 scheme-parsing leniency flag.
+// PfbLenient — a tri-state {on, off, legacy ''} flag (the explicit 'off' token
+// survives the live config round-trip where a toggle's '' off-value would not).
 //
-// Used by: pfb_dnsbl_lenient (pfb_dnsblconfig['pfb_dnsbl_lenient']).
-//   Stored vocabulary: 'on' | 'off' | '' (missing pre-ADR-22 install).
+// Used by: pfb_dnsbl_lenient (pfb_dnsblconfig['pfb_dnsbl_lenient'], ADR-22 scheme-parsing
+//   leniency) and pfb_keep (#484 — so a default-on keep flag can store 'off' explicitly).
+//   Stored vocabulary: 'on' | 'off' | '' (legacy: a missing pre-ADR-22 / pre-#484 install).
 //   pfb_global() normalisation at :1364:
 //     pfb_cfg_lenient_read($pfb['dnsblconfig']['pfb_dnsbl_lenient'] ?? '')->value
 //   Note: '' (missing key) maps to Off ('off'), NOT to the PfbToggle '' value.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -296,13 +296,19 @@ function pfb_cfg_registry(): array
 			'since'         => '1.0.0',
 		],
 
-		// Keep blocklists when pfBlockerNG is disabled: 'on' | '' (checkbox).
+		// Keep blocklists when pfBlockerNG is disabled: 'on' | 'off' | ''.
 		// Default ON — the #281 canonical default; GUI and pfb_global() agree.
+		// Uses the lenient adapter so an unchecked-save (off) is stored as the
+		// explicit 'off' token, distinguishable from a never-configured install
+		// (key absent) which the registry default returns as 'on'. The empty-string
+		// '' is a LEGACY READ token for installs written before this fix; it maps
+		// to Off on read, same as 'off'. Write always emits 'off' (backward-safe:
+		// older releases that read 'off' for pfb_keep treat it as "disabled").
 		'pfb_keep' => [
 			'section'       => $gen,
 			'default'       => 'on',
-			'read_adapter'  => 'pfb_cfg_toggle_read',
-			'write_adapter' => 'pfb_cfg_toggle_write',
+			'read_adapter'  => 'pfb_cfg_lenient_read',
+			'write_adapter' => 'pfb_cfg_lenient_write',
 			'since'         => '2.1.0',
 		],
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -240,7 +240,10 @@ if ($_POST) {
 		if (!$input_errors) {
 
 			$pfb['gconfig']['enable_cb']			= pfb_filter($_POST['enable_cb'], PFB_FILTER_ON_OFF, 'general', '');
-			$pfb['gconfig']['pfb_keep']			= pfb_filter($_POST['pfb_keep'], PFB_FILTER_ON_OFF, 'general', '');
+			// Store as explicit 'on'/'off' (not '' for unchecked) so an unchecked save
+			// (off) is distinguishable from a never-configured install (key absent =>
+			// default on). Mirrors the pfb_feed_internal_filter precedent.
+			$pfb['gconfig']['pfb_keep']			= (($_POST['pfb_keep'] ?? '') === 'on') ? 'on' : 'off';
 
 			// Store the master feed-host filter toggle as an explicit 'on'/'off' (a
 			// checkbox submits 'on' when checked, nothing when unchecked) so the
@@ -403,7 +406,7 @@ $section->addInput(new Form_Checkbox(
 	'pfb_keep',
 	'Keep Settings',
 	gettext('Enable'),
-	pfb_cfg_toggle_read($pconfig['pfb_keep']) === PfbToggle::On,
+	pfb_cfg_lenient_read($pconfig['pfb_keep']) === PfbLenient::On,
 	'on'
 ))->setHelp('<span class="text-danger">Note: </span>'
 		. 'With \'Keep settings\' enabled, pfBlockerNG will maintain run state on Installation/Upgrade.<br />'

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -67,15 +67,13 @@ final class CfgGatewayTest extends TestCase
 	 */
 	public function testToggleFieldsRoundTripOn(): void
 	{
-		// All toggle-adapted fields: we pick a representative one (pfb_keep) and
-		// also verify pfb_dnsbl and pfb_dnsvip_auto to cover every adapter instance.
+		// Representative toggle-adapted fields (pfb_keep is now lenient — see below).
 		$toggle_fields = [
-			'enable_cb'     => 'installedpackages/pfblockerng/config/0/enable_cb',
-			'pfb_keep'      => 'installedpackages/pfblockerng/config/0/pfb_keep',
-			'pfb_dnsbl'     => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
+			'enable_cb'       => 'installedpackages/pfblockerng/config/0/enable_cb',
+			'pfb_dnsbl'       => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
 			'pfb_dnsvip_auto' => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
-			'pfb_reuse'     => 'installedpackages/pfblockerng/config/0/pfb_reuse',
-			'pfb_hsts'      => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
+			'pfb_reuse'       => 'installedpackages/pfblockerng/config/0/pfb_reuse',
+			'pfb_hsts'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
 		];
 
 		foreach ($toggle_fields as $key => $path) {
@@ -97,9 +95,9 @@ final class CfgGatewayTest extends TestCase
 
 	public function testToggleFieldsRoundTripOff(): void
 	{
+		// pfb_keep is now lenient — see testPfbKeepLenientRoundTrip*() below.
 		$toggle_fields = [
 			'enable_cb'       => 'installedpackages/pfblockerng/config/0/enable_cb',
-			'pfb_keep'        => 'installedpackages/pfblockerng/config/0/pfb_keep',
 			'pfb_dnsbl'       => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
 			'pfb_dnsvip_auto' => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
 			'pfb_reuse'       => 'installedpackages/pfblockerng/config/0/pfb_reuse',
@@ -187,6 +185,70 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('off', config_get_path($path));
 	}
 
+	/**
+	 * pfb_keep (lenient adapter): 'on'/'off'/'' round-trips and legacy '' normalises.
+	 *
+	 * Scenario:
+	 *   Background: pfb_keep stored as 'on', 'off', or '' (pre-#484-fix legacy empty).
+	 *     Given v.  When read/write.
+	 *     Then 'on' round-trips to 'on'; 'off' round-trips to 'off'.
+	 *     And '' (legacy) normalises to 'off' on write (backward-safe).
+	 */
+	public function testPfbKeepLenientRoundTripOn(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_keep';
+
+		// Given: canonical 'on'.
+		$this->seedConfig($path, 'on');
+
+		// Before: raw 'on'.
+		$this->assertSame('on', config_get_path($path), 'before: pfb_keep seed is on');
+
+		// When/After: read -> PfbLenient::On; write -> 'on'.
+		$enum = PfbConfig::read('pfb_keep');
+		$this->assertSame(PfbLenient::On, $enum, "read: pfb_keep 'on' -> PfbLenient::On");
+
+		PfbConfig::write('pfb_keep', $enum);
+		$this->assertSame('on', config_get_path($path), "write(read('on'))==on for pfb_keep");
+	}
+
+	public function testPfbKeepLenientRoundTripOff(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_keep';
+
+		// Given: canonical 'off' (the new stored value for unchecked-save after #484 fix).
+		$this->seedConfig($path, 'off');
+
+		// Before: raw 'off'.
+		$this->assertSame('off', config_get_path($path), 'before: pfb_keep seed is off');
+
+		// When/After: read -> PfbLenient::Off; write -> 'off'.
+		$enum = PfbConfig::read('pfb_keep');
+		$this->assertSame(PfbLenient::Off, $enum, "read: pfb_keep 'off' -> PfbLenient::Off");
+
+		PfbConfig::write('pfb_keep', $enum);
+		$this->assertSame('off', config_get_path($path), "write(read('off'))==off for pfb_keep");
+	}
+
+	public function testPfbKeepLenientLegacyEmptyNormalisesToOff(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_keep';
+
+		// Given: '' (pre-#484 install — toggle OFF value written by old GUI).
+		$this->seedConfig($path, '');
+
+		// Before: raw ''.
+		$this->assertSame('', config_get_path($path), 'before: pfb_keep seed is empty string');
+
+		// When: read maps '' to PfbLenient::Off (legacy token, same as 'off').
+		$enum = PfbConfig::read('pfb_keep');
+		$this->assertSame(PfbLenient::Off, $enum, "read: pfb_keep '' -> PfbLenient::Off (legacy)");
+
+		// After: write emits 'off' (not ''); normalises the legacy token.
+		PfbConfig::write('pfb_keep', $enum);
+		$this->assertSame('off', config_get_path($path), "write(read(''))==off for pfb_keep");
+	}
+
 	// -----------------------------------------------------------------------
 	// B — Default on absent key
 	// -----------------------------------------------------------------------
@@ -213,14 +275,15 @@ final class CfgGatewayTest extends TestCase
 	public function testReadReturnsRegisteredDefaultForPfbKeepAbsentKey(): void
 	{
 		// pfb_keep default is 'on' (On enum) — the #281 canonical default.
+		// Uses the lenient adapter so absent key → PfbLenient::On (not PfbToggle::On).
 		// Before: key absent.
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_keep'));
 
 		// When: read with no seed.
 		$result = PfbConfig::read('pfb_keep');
 
-		// Then: returns On (the registered default 'on', applied through toggle adapter).
-		$this->assertSame(PfbToggle::On, $result, 'pfb_keep absent -> On (default on)');
+		// Then: returns On (the registered default 'on', applied through lenient adapter).
+		$this->assertSame(PfbLenient::On, $result, 'pfb_keep absent -> PfbLenient::On (default on)');
 	}
 
 	public function testReadReturnsRegisteredDefaultForLenientAbsentKey(): void
@@ -1119,6 +1182,33 @@ final class CfgGatewayTest extends TestCase
 			// since must be a non-empty string.
 			$this->assertIsString($entry['since'],    "'{$field_key}'.since must be a string");
 			$this->assertNotEmpty($entry['since'],    "'{$field_key}'.since must not be empty");
+		}
+	}
+
+	/**
+	 * No registered field may be a TOGGLE adapter (off-value '') while defaulting
+	 * to 'on'. Such a field cannot represent "off" on a live pfSense config: an
+	 * empty stored value does not persist distinguishably from absent, and an
+	 * absent value re-applies the registry default 'on' — silently flipping a
+	 * deliberate "off" back to "on". (This is the pfb_keep bug: #484 fan-out.)
+	 *
+	 * A default-'on' field MUST therefore use the LENIENT adapter (off persists as
+	 * the explicit 'off' token) or a PLAIN field that writes an explicit 'on'/'off'
+	 * (as pfb_feed_internal_filter does). This guard makes the rule mechanical so
+	 * the class of bug cannot recur — the off-box config doubles round-trip ''
+	 * faithfully and would otherwise never catch it.
+	 */
+	public function testNoToggleFieldDefaultsToOn(): void
+	{
+		foreach (pfb_cfg_registry() as $field_key => $entry) {
+			if ($entry['read_adapter'] === 'pfb_cfg_toggle_read') {
+				$this->assertNotSame(
+					'on', $entry['default'],
+					"'{$field_key}': a TOGGLE field must not default to 'on' — its '' off-value "
+					. "cannot survive the live config round-trip (becomes absent -> default 'on'). "
+					. "Use the lenient adapter (explicit 'off') or a plain explicit-on/off field."
+				);
+			}
 		}
 	}
 

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -1200,8 +1200,10 @@ final class CfgGatewayTest extends TestCase
 	 */
 	public function testNoToggleFieldDefaultsToOn(): void
 	{
+		$toggle_count = 0;
 		foreach (pfb_cfg_registry() as $field_key => $entry) {
 			if ($entry['read_adapter'] === 'pfb_cfg_toggle_read') {
+				$toggle_count++;
 				$this->assertNotSame(
 					'on', $entry['default'],
 					"'{$field_key}': a TOGGLE field must not default to 'on' — its '' off-value "
@@ -1210,6 +1212,11 @@ final class CfgGatewayTest extends TestCase
 				);
 			}
 		}
+		// Anchor against a vacuous pass: if no toggle field exists the loop above
+		// asserts nothing, so this guard would silently stop guarding.
+		$this->assertGreaterThan(0, $toggle_count,
+			'Registry must contain at least one toggle-adapter field for this guard to be meaningful'
+		);
 	}
 
 	/**

--- a/tests/php/PfbGlobalParityTest.php
+++ b/tests/php/PfbGlobalParityTest.php
@@ -59,12 +59,15 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * pfb_keep: OLD pfb_global() = $pfb['config']['pfb_keep'] ?? 'on' = 'on' when absent.
-	 * Via gateway: PfbConfig::read('pfb_keep')->value = 'on' (PfbToggle::On).
+	 * Via gateway: PfbConfig::read('pfb_keep')->value = 'on' (PfbLenient::On, #484 fix).
 	 *
 	 * #281 DEFAULT REPAIR: This is the canonical defect class. The registry default
 	 * is 'on', matching the old ?? 'on' fallback. Both old code and gateway agree.
 	 * The issue #281 migration (pfb_keep_migrate) seeds this into config.xml for
 	 * EXISTING installs; new installs and the runtime both default to 'on'.
+	 *
+	 * #484 FIX: pfb_keep now uses the lenient adapter (PfbLenient) so the GUI stores
+	 * 'off' for unchecked-save — distinguishable from absent (default 'on').
 	 */
 	public function testParityPfbKeepAbsentYieldsOn(): void
 	{
@@ -75,9 +78,8 @@ final class PfbGlobalParityTest extends TestCase
 		$result = PfbConfig::read('pfb_keep');
 
 		// Then: 'on' — matches OLD ?? 'on' AND the repaired registry default.
-		// Deliberate note: the old pfb_global() code had ?? 'on' which is now
-		// the formal registry default 'on'. No behaviour change — same value.
-		$this->assertSame(PfbToggle::On, $result);
+		// Adapter is now PfbLenient (not PfbToggle), but the value is unchanged.
+		$this->assertSame(PfbLenient::On, $result);
 		$this->assertSame('on', $result->value, 'pfb_keep absent -> "on" (#281: default repaired via registry)');
 	}
 
@@ -469,6 +471,10 @@ final class PfbGlobalParityTest extends TestCase
 	 * The structural fix: the default is now FORMAL (in the registry) instead of
 	 * a scattered per-site ?? fallback. The pfb_keep_migrate() migration seeds
 	 * this into config.xml for existing installs; the runtime default is identical.
+	 *
+	 * #484 FIX: pfb_keep now uses the lenient adapter (PfbLenient) so the GUI stores
+	 * 'off' for unchecked-save — distinguishable from absent (default 'on'). The legacy
+	 * '' token (written by old GUI) still reads as PfbLenient::Off — backward-safe.
 	 */
 	public function testRepair281PfbKeepDefaultIsFormallyOn(): void
 	{
@@ -481,14 +487,16 @@ final class PfbGlobalParityTest extends TestCase
 		// Then: value is 'on' — same as old ?? 'on' fallback.
 		// The #281 class is now structurally closed: the default is formal,
 		// not scattered, and a missing key cannot diverge from the GUI default.
-		$this->assertSame(PfbToggle::On, $result);
+		// Adapter is now PfbLenient (not PfbToggle); value is unchanged.
+		$this->assertSame(PfbLenient::On, $result);
 		$this->assertSame('on', $result->value);
 
-		// Also prove that with an explicit '' (user opted out), the gateway
-		// returns PfbToggle::Off -> '' — a deliberate opt-out is still honoured.
+		// Also prove that with an explicit '' (pre-#484 legacy opt-out), the gateway
+		// returns PfbLenient::Off -> value 'off' — a deliberate opt-out is still honoured.
+		// (Write emits 'off', not '' — normalises the legacy empty-string token.)
 		config_set_path('installedpackages/pfblockerng/config/0/pfb_keep', '');
 		$result_off = PfbConfig::read('pfb_keep');
-		$this->assertSame(PfbToggle::Off, $result_off);
-		$this->assertSame('', $result_off->value, 'explicit "" pfb_keep -> off (user opt-out honoured)');
+		$this->assertSame(PfbLenient::Off, $result_off);
+		$this->assertSame('off', $result_off->value, "legacy '' pfb_keep -> PfbLenient::Off (value 'off')");
 	}
 }

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -734,7 +734,7 @@ final class RollbackContractTest extends TestCase
 	 *     When collecting all fields whose type is 'lenient'.
 	 *     Then exactly 'pfb_keep' and 'pfb_dnsbl_lenient' appear (registry insertion order).
 	 */
-	public function testAdapterTypeHelperLenientAssignedOnlyToPfbDnsblLenient(): void
+	public function testAdapterTypeHelperLenientAssignedToPfbKeepAndPfbDnsblLenient(): void
 	{
 		$registry       = pfb_cfg_registry();
 		$lenient_fields = [];

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -278,6 +278,83 @@ final class RollbackContractTest extends TestCase
 	}
 
 	/**
+	 * pfb_keep (lenient adapter, #484 fix): 'on' -> PfbLenient::On (no crash).
+	 *
+	 * Scenario:
+	 *   Background: pfb_keep vocabulary = {'on', 'off', ''} ('' = pre-#484 legacy).
+	 *     Given stored = 'on'.
+	 *     When PfbConfig::read('pfb_keep').
+	 *     Then PfbLenient::On is returned.
+	 */
+	public function testForwardPfbKeepOnYieldsOnEnum(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_keep';
+
+		// Given: 'on' stored (keep=enabled — retain settings on uninstall).
+		config_set_path($path, 'on');
+
+		// Before.
+		$this->assertSame('on', config_get_path($path));
+
+		// When/Then.
+		$result = PfbConfig::read('pfb_keep');
+		$this->assertInstanceOf(PfbLenient::class, $result);
+		$this->assertSame(PfbLenient::On, $result, "FORWARD: pfb_keep 'on' must yield PfbLenient::On");
+	}
+
+	/**
+	 * pfb_keep (lenient adapter, #484 fix): 'off' -> PfbLenient::Off (no crash).
+	 *
+	 * Scenario:
+	 *   Background: 'off' is the canonical disabled value written by the GUI after #484.
+	 *     Given stored = 'off'.
+	 *     When PfbConfig::read('pfb_keep').
+	 *     Then PfbLenient::Off is returned.
+	 */
+	public function testForwardPfbKeepOffYieldsOffEnum(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_keep';
+
+		// Given: 'off' stored (new canonical value for unchecked-save after #484 fix).
+		config_set_path($path, 'off');
+
+		// Before.
+		$this->assertSame('off', config_get_path($path));
+
+		// When/Then.
+		$result = PfbConfig::read('pfb_keep');
+		$this->assertInstanceOf(PfbLenient::class, $result);
+		$this->assertSame(PfbLenient::Off, $result, "FORWARD: pfb_keep 'off' must yield PfbLenient::Off");
+	}
+
+	/**
+	 * pfb_keep (lenient adapter, #484 fix): '' -> PfbLenient::Off (pre-#484 legacy empty).
+	 *
+	 * Scenario:
+	 *   Background: '' is the old toggle-OFF value written by the GUI before the #484 fix.
+	 *     Given stored = '' (pre-#484 install — toggle::Off empty string).
+	 *     When PfbConfig::read('pfb_keep').
+	 *     Then PfbLenient::Off is returned (normalised; same as 'off').
+	 *
+	 * Backward-safety: pfb['keep'] != 'on' in the deinstall gate covers both 'off' and ''.
+	 */
+	public function testForwardPfbKeepLegacyEmptyYieldsOffEnum(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_keep';
+
+		// Given: '' stored (pre-#484 toggle-OFF value).
+		config_set_path($path, '');
+
+		// Before.
+		$this->assertSame('', config_get_path($path));
+
+		// When/Then: '' normalises to Off — the deinstall gate (keep != 'on') fires correctly.
+		$result = PfbConfig::read('pfb_keep');
+		$this->assertInstanceOf(PfbLenient::class, $result);
+		$this->assertSame(PfbLenient::Off, $result, "FORWARD: pfb_keep '' must yield PfbLenient::Off (legacy token)");
+	}
+
+	/**
 	 * Plain-string fields: legacy stored value passes through unchanged (no crash).
 	 *
 	 * Scenario:
@@ -492,6 +569,66 @@ final class RollbackContractTest extends TestCase
 	}
 
 	/**
+	 * pfb_keep (lenient, #484 fix): write(On) emits 'on' -- a legacy token.
+	 *
+	 * Scenario:
+	 *   Background: pfb_keep legacy vocabulary = {'on', 'off', ''}.
+	 *     Given PfbLenient::On.
+	 *     When PfbConfig::write('pfb_keep', PfbLenient::On).
+	 *     Then stored == 'on' (in vocabulary; no novel token).
+	 */
+	public function testBackwardPfbKeepOnEmitsLegacyToken(): void
+	{
+		$path          = 'installedpackages/pfblockerng/config/0/pfb_keep';
+		$lenient_vocab = pfb_cfg_field_vocab()['lenient'];
+
+		// Before: absent.
+		$this->assertNull(config_get_path($path), "before backward pfb_keep On: absent");
+
+		// When: write On.
+		PfbConfig::write('pfb_keep', PfbLenient::On);
+
+		// Then: 'on' -- in vocabulary; no novel token.
+		$stored = (string) config_get_path($path);
+		$this->assertContains($stored, $lenient_vocab,
+			"BACKWARD: pfb_keep write(On) stored='{$stored}' not in vocab"
+		);
+		$this->assertSame('on', $stored, "BACKWARD: pfb_keep write(On) must store 'on'");
+	}
+
+	/**
+	 * pfb_keep (lenient, #484 fix): write(Off) emits 'off' -- a legacy token.
+	 *
+	 * Scenario:
+	 *   Background: pfb_keep legacy vocabulary = {'on', 'off', ''}.
+	 *     Given PfbLenient::Off.
+	 *     When PfbConfig::write('pfb_keep', PfbLenient::Off).
+	 *     Then stored == 'off' (in vocabulary; backward-safe — older releases treat 'off'
+	 *     as "disabled", which is the correct interpretation for pfb_keep=Off).
+	 */
+	public function testBackwardPfbKeepOffEmitsLegacyToken(): void
+	{
+		$path          = 'installedpackages/pfblockerng/config/0/pfb_keep';
+		$lenient_vocab = pfb_cfg_field_vocab()['lenient'];
+
+		// Before: seed 'on' so we see the write actually changes it.
+		config_set_path($path, 'on');
+		$this->assertSame('on', config_get_path($path), "before backward pfb_keep Off: is 'on'");
+
+		// When: write Off.
+		PfbConfig::write('pfb_keep', PfbLenient::Off);
+
+		// Then: 'off' -- in the legacy vocabulary (no novel token introduced).
+		// Older releases read '' for PfbToggle::Off (disable path). 'off' was previously
+		// stored by pfb_feed_internal_filter — a pre-existing legacy vocabulary member.
+		$stored = (string) config_get_path($path);
+		$this->assertContains($stored, $lenient_vocab,
+			"BACKWARD: pfb_keep write(Off) stored='{$stored}' not in vocab"
+		);
+		$this->assertSame('off', $stored, "BACKWARD: pfb_keep write(Off) must store 'off'");
+	}
+
+	/**
 	 * Plain-string fields: write($str) emits $str (identity -- no novel token possible).
 	 *
 	 * Scenario:
@@ -589,13 +726,13 @@ final class RollbackContractTest extends TestCase
 	}
 
 	/**
-	 * pfb_cfg_field_adapter_type() assigns 'lenient' only to pfb_dnsbl_lenient.
+	 * pfb_cfg_field_adapter_type() assigns 'lenient' to pfb_keep and pfb_dnsbl_lenient.
 	 *
 	 * Scenario:
-	 *   Background: only pfb_dnsbl_lenient uses the lenient adapter.
+	 *   Background: pfb_keep (#484 fix) and pfb_dnsbl_lenient use the lenient adapter.
 	 *     Given the full registry.
 	 *     When collecting all fields whose type is 'lenient'.
-	 *     Then only 'pfb_dnsbl_lenient' appears.
+	 *     Then exactly 'pfb_keep' and 'pfb_dnsbl_lenient' appear (registry insertion order).
 	 */
 	public function testAdapterTypeHelperLenientAssignedOnlyToPfbDnsblLenient(): void
 	{
@@ -607,11 +744,9 @@ final class RollbackContractTest extends TestCase
 			}
 		}
 
-		$this->assertSame(
-			['pfb_dnsbl_lenient'],
-			$lenient_fields,
-			'Only pfb_dnsbl_lenient should have adapter type "lenient"'
-		);
+		$this->assertContains('pfb_keep',        $lenient_fields, 'pfb_keep must be lenient (#484 fix)');
+		$this->assertContains('pfb_dnsbl_lenient', $lenient_fields, 'pfb_dnsbl_lenient must be lenient');
+		$this->assertCount(2, $lenient_fields, 'Exactly two lenient fields: pfb_keep + pfb_dnsbl_lenient');
 	}
 
 	/**
@@ -727,6 +862,47 @@ final class RollbackContractTest extends TestCase
 			$stored = (string) config_get_path($path);
 			$this->assertContains($stored, $vocab,
 				"BACKWARD: pfb_dnsbl_lenient token='{$token}' write(read) stored='{$stored}' not in vocab"
+			);
+		}
+	}
+
+	/**
+	 * pfb_keep (lenient, #484 fix) satisfies both invariants for all three legacy tokens.
+	 *
+	 * Scenario:
+	 *   Background: pfb_keep vocabulary = {'on', 'off', ''} ('' = pre-#484 legacy).
+	 *     Given each token.
+	 *     When read + write.
+	 *     Then FORWARD: PfbLenient enum.
+	 *     And BACKWARD: stored value is in {'on', 'off', ''}.
+	 *     Note: '' (pre-#484) read->Off; write->Off emits 'off'; 'off' in vocab -> BACKWARD passes.
+	 */
+	public function testPfbKeepForwardAndBackwardForEveryVocabToken(): void
+	{
+		$vocab = pfb_cfg_field_vocab()['lenient'];
+		$path  = 'installedpackages/pfblockerng/config/0/pfb_keep';
+
+		foreach ($vocab as $token) {
+			// Reset.
+			$GLOBALS['config'] = [];
+			config_set_path($path, $token);
+
+			// BEFORE.
+			$this->assertSame($token, config_get_path($path),
+				"before forward+backward: pfb_keep token='{$token}'"
+			);
+
+			// FORWARD.
+			$runtime = PfbConfig::read('pfb_keep');
+			$this->assertInstanceOf(PfbLenient::class, $runtime,
+				"FORWARD: pfb_keep token='{$token}' must yield PfbLenient"
+			);
+
+			// BACKWARD: write(runtime) stored value is in vocabulary.
+			PfbConfig::write('pfb_keep', $runtime);
+			$stored = (string) config_get_path($path);
+			$this->assertContains($stored, $vocab,
+				"BACKWARD: pfb_keep token='{$token}' write(read) stored='{$stored}' not in vocab"
 			);
 		}
 	}

--- a/tests/php/WwwGroupAGatewayTest.php
+++ b/tests/php/WwwGroupAGatewayTest.php
@@ -53,9 +53,10 @@ final class WwwGroupAGatewayTest extends TestCase
 
 	/**
 	 * pfb_keep: page used `isset($pfb['gconfig']['pfb_keep']) ? ... : 'on'` — default 'on'.
-	 * Registry default = 'on' (PfbToggle::On). Page default REMOVED; gateway owns it.
+	 * Registry default = 'on' (PfbLenient::On after #484 fix). Page default REMOVED; gateway owns it.
 	 *
 	 * Parity: absent key → PfbConfig::read('pfb_keep')->value === 'on' (was: 'on').
+	 * (#484: adapter changed from PfbToggle to PfbLenient; value unchanged.)
 	 */
 	public function testGeneralPfbKeepAbsentDefaultMatchesPriorPageDefault(): void
 	{
@@ -67,8 +68,9 @@ final class WwwGroupAGatewayTest extends TestCase
 		// When: gateway read (replaces the removed isset() ? ... : 'on').
 		$result = PfbConfig::read('pfb_keep');
 
-		// Then: PfbToggle::On, value 'on' — matches prior page default 'on'.
-		$this->assertSame(PfbToggle::On, $result, 'pfb_keep absent -> PfbToggle::On');
+		// Then: PfbLenient::On, value 'on' — matches prior page default 'on'.
+		// (#484 fix: pfb_keep now uses the lenient adapter; the value is unchanged.)
+		$this->assertSame(PfbLenient::On, $result, 'pfb_keep absent -> PfbLenient::On');
 		$this->assertSame('on', $result->value, 'pfb_keep absent -> value "on" (parity with prior isset default)');
 	}
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -938,11 +938,12 @@ def set_package_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None
 
 def set_pfb_keep(vm: SmokeVM, keep: bool, *, timeout: float = 60.0) -> None:
     """Set ``pfb_keep`` at ``CFG_GLOBAL``: ``True`` → ``'on'`` (retain settings + data on
-    uninstall); ``False`` → ``''`` (full removal — live objects + settings + data all gone).
+    uninstall); ``False`` → ``'off'`` (full removal — live objects + settings + data all gone).
 
-    ``pfb_keep`` is a toggle whose stored vocabulary is ``{'on', ''}`` (off is the empty
-    string, matching ``PfbToggle::Off``), so the off case writes ``''`` — the canonical
-    value, like ``set_package_enabled`` / ``set_dnsbl_enabled``.
+    ``pfb_keep`` uses the lenient adapter (``PfbLenient``) whose stored vocabulary is
+    ``{'on', 'off', ''}``; the off case writes ``'off'`` — the canonical PfbLenient::Off
+    backing value.  The empty string ``''`` is a legacy READ token (installs written before
+    the #484 fix) that maps to Off on read; write always emits ``'off'``.
 
     ``pfb_keep`` defaults to ``'on'`` (issue #281), so a test that asserts sections are
     swept after uninstall MUST call ``set_pfb_keep(vm, False)`` explicitly to select the
@@ -950,7 +951,7 @@ def set_pfb_keep(vm: SmokeVM, keep: bool, *, timeout: float = 60.0) -> None:
     #484 fix) uses ``set_pfb_keep(vm, True)`` (or relies on the default, but explicit
     is clearer).
     """
-    val = "on" if keep else ""
+    val = "on" if keep else "off"
     snippet = (
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         f"$g['pfb_keep'] = {_php_str(val)};\n"


### PR DESCRIPTION
## Fix keep=off uninstall: fully remove + persist all pfblockerng* config sections (#484)

A keep=off `pkg delete` left the package "still installed" in config.xml (the smoke uninstall tests failed: `installedpackages/pfblockerng* still present — pfb_remove_config_settings did not run`). On-box instrumentation disproved the obvious guess — the deinstall keep-gate **does** enter the removal branch (`pfb_keep='off'` reads correctly). The real cause was two gaps in the removal itself:

1. **Incomplete list.** `pfb_remove_config_settings()` deleted a hardcoded list of 20 section names that omitted `pfblockerngdnsbleasylist` (ADR-07 ABP/EasyList) and would miss any future section → now sweeps **every** `installedpackages/pfblockerng*` section dynamically.
2. **Unpersisted.** `config_del_path()` only mutates the in-memory config, and the deinstall's last `write_config()` was **before** the keep gate → the section wipe was lost on disk → a fresh read still saw the sections. Added a `write_config()` after the removals.

Validated on the fan-out: the keep=off uninstall + keep=on scenarios (dns_redirect / dot_doq / managed_objects) now **pass** (7 green; the suite went 31→15 failures, the rest being the unrelated open C/D clusters).

### Also in this PR (hardening, not the failure cause)
- `pfb_keep` switched to the **lenient adapter** so "off" stores the explicit `'off'` token (the empty-string off-value of a *default-on* toggle is fragile on live config — `''` can serialize to absent → re-defaults to `'on'`; the GUI wrote `''` too). Gate-proven to read `'off'`.
- New `CfgGatewayTest::testNoToggleFieldDefaultsToOn` makes that class of bug mechanical — a toggle field may never default to `'on'` (must use lenient/plain explicit-on/off). Shown red-before/green-after.

Part of #484 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed “keep blocklists” handling so the setting is correctly interpreted and persisted using the intended on/off semantics, including normalization of legacy stored values and consistent off-state saving.

* **Tests**
  * Updated and expanded test coverage for configuration round-trips, UI parity, rollback/compat behavior, registry invariants, and smoke flows to reflect the corrected lenient handling of the “keep blocklists” setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->