### PR TITLE
ci: upgrade CE + Plus smoke images (matrix, gated on ci-metadata upgrade flag)

### DIFF
--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -1,8 +1,19 @@
-name: Refresh CE smoke image
+name: Upgrade pfSense smoke images
 
-# Upgrade a published pfSense CE GHCR image to a new CE release and publish the
-# result. Fail-closed: a bad upgrade MUST NEVER be published and the old tag MUST
-# be left untouched.
+# Upgrade published pfSense CE and Plus GHCR smoke base images to new releases and
+# publish the results as new tags. Runs as a matrix fan-out: one parallel leg per
+# entry in ci-metadata that has upgrade.available == true (CE and Plus alike). Fail-
+# closed: a bad upgrade MUST NEVER be published and the old tag MUST be left untouched.
+#
+# AVAILABILITY FLAG:
+#   Each supported-versions.json entry MAY carry an optional "upgrade" block:
+#     "upgrade": {
+#       "available": true,           # absent or false → skip this variant
+#       "branch":    "devel-x",      # optional: pfSense update branch (default: image's own)
+#       "target":    "2.8.1",        # informational: full version string being targeted
+#       "from":      "2.8"           # optional: GHCR floating tag to pull FROM (default: same as pfsense_version)
+#     }
+#   Today no entry has this block, so the workflow skips everything — correct default.
 #
 # PUBLISH GUARD (inside scripts/image-upgrade.sh):
 #   1. Prior GHCR tag pulled and booted writable under QEMU/KVM.
@@ -28,13 +39,13 @@ name: Refresh CE smoke image
 # manual seed) to publish the image for that version.
 #
 # Required secrets/vars (shared with build-image.yml and smoke-single.yml):
-#   SMOKE_GHCR_USER     username for `oras login ghcr.io` (defaults to github.actor)
-#   SMOKE_GHCR_TOKEN    token with write:packages (publish) / read:packages (defaults to GITHUB_TOKEN)
-#   SMOKE_SSH_PRIV_KEY  guest SSH private key baked into the image          (secret)
-#   SMOKE_IMAGE_REPO    GHCR namespace, e.g. ghcr.io/pfblockerng            (variable)
-#                       (default ghcr.io/<owner-lowercased>); the untagged image
-#                       is ${SMOKE_IMAGE_REPO}/${SMOKE_IMAGE_NAME}.
-#   SMOKE_IMAGE_NAME    image name appended to it (default pfsense-ce)        (variable)
+#   SMOKE_GHCR_USER         username for `oras login ghcr.io` (defaults to github.actor)
+#   SMOKE_GHCR_TOKEN        token with write:packages (publish) / read:packages (defaults to GITHUB_TOKEN)
+#   SMOKE_SSH_PRIV_KEY      guest SSH private key baked into the image            (secret)
+#   SMOKE_PLUS_MAC          Plus VM: newline-separated list of 8 MAC addresses    (secret)
+#   SMOKE_PLUS_SMBIOS_UUID  Plus VM: SMBIOS type-1 UUID (Netgate Device ID key)   (secret)
+#   SMOKE_IMAGE_REPO        GHCR namespace, e.g. ghcr.io/pfblockerng             (variable)
+#                           (default ghcr.io/<owner-lowercased>)
 #
 # INVARIANT: this workflow NEVER writes to main/devel/next or any channel branch.
 # It writes ONLY to GHCR (packages). The tracker dispatches it; it publishes or fails.
@@ -43,15 +54,7 @@ on:
   workflow_dispatch:
     inputs:
       pfsense_version:
-        description: "Target pfSense CE floating tag (e.g. 2.8). The tracker passes the exact version from supported-versions.json."
-        required: true
-        type: string
-      freebsd_version:
-        description: "FreeBSD base version for this CE release (e.g. 15.0-RELEASE). The tracker reads this from supported-versions.json."
-        required: true
-        type: string
-      from_version:
-        description: "Prior published CE floating tag to upgrade from (e.g. 2.7). Leave empty to auto-detect from the matrix (the most recent prior CE tag, or self for a patch refresh)."
+        description: "Optional filter: only the entry whose pfsense_version matches. Leave blank to run all entries with upgrade.available == true."
         required: false
         default: ""
         type: string
@@ -81,81 +84,82 @@ permissions:
   packages: write
 
 jobs:
-  # ── Resolve prior published tag (from_version) ─────────────────────────────
-  # Determine which existing GHCR tag to upgrade FROM, and whether --force is
-  # needed (patch refresh: target tag already exists and will be overwritten).
-  #
-  # With the floating-tag scheme, pfsense_version IS the GHCR tag (e.g. "2.8").
-  # Two cases:
-  #   New minor/major (e.g. "2.9"): upgrade FROM the previous version (e.g. "2.8").
-  #   Patch refresh (e.g. "2.8" is the only/oldest entry): upgrade FROM itself,
-  #     overwriting :2.8 in place (--force required since the tag already exists).
-  resolve-from:
-    name: Resolve upgrade source tag
+  # ── Resolve refresh matrix (CE + Plus) ─────────────────────────────────────
+  # Read ci-metadata, filter entries with upgrade.available == true (and optionally
+  # by pfsense_version input), and emit the matrix include array for the refresh job.
+  # If no entry qualifies (the common case today) the include array is empty and the
+  # refresh job runs zero legs — a clean no-op.
+  plan:
+    name: Resolve refresh matrix (CE + Plus)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      from_tag: ${{ steps.resolve.outputs.from_tag }}
-      force_flag: ${{ steps.resolve.outputs.force_flag }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+      count: ${{ steps.plan.outputs.count }}
     steps:
-      - name: Checkout (for read-version-matrix action)
+      - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Resolve prior CE tag to upgrade from
-        id: resolve
+      - name: Build refresh matrix from ci-metadata
+        id: plan
         env:
-          FROM_VERSION: ${{ inputs.from_version }}
-          TARGET_VERSION: ${{ inputs.pfsense_version }}
+          FILTER_VERSION: ${{ inputs.pfsense_version }}
         run: |
           set -eu
-          if [ -n "$FROM_VERSION" ]; then
-            # Caller supplied an explicit prior tag — use it directly.
-            # Self-refresh (same tag) still needs --force.
-            FORCE=""
-            [ "$FROM_VERSION" = "$TARGET_VERSION" ] && FORCE="--force"
-            printf 'from_tag=%s\n' "$FROM_VERSION" >> "$GITHUB_OUTPUT"
-            printf 'force_flag=%s\n' "$FORCE" >> "$GITHUB_OUTPUT"
-            printf 'Using caller-supplied from_version: %s%s\n' "$FROM_VERSION" \
-              "${FORCE:+ (self-refresh, --force)}"
-            exit 0
-          fi
-
-          # Auto-detect: read all CE entries sorted by version, find the one
-          # immediately before TARGET_VERSION. Uses sort -V (version sort) so
-          # "2.9" < "2.10" is handled correctly regardless of jq string ordering.
-          git fetch origin ci-metadata
+          git fetch origin ci-metadata -q
           MATRIX_JSON="$(git show origin/ci-metadata:supported-versions.json)"
 
-          ALL_CE="$(printf '%s' "$MATRIX_JSON" | jq -r '
-            .versions[] | select(.channel == "CE") | .pfsense_version
-          ' | sort -V)"
-
-          FROM_TAG="$(printf '%s\n' "$ALL_CE" | awk -v target="$TARGET_VERSION" '
-            prev != "" && $0 == target { print prev; exit }
-            { prev = $0 }
+          # Build the include array: one entry per ci==true version with upgrade.available==true.
+          # from defaults to pfsense_version (self); force_flag is "--force" when from==pfsense_version.
+          INCLUDE="$(printf '%s' "$MATRIX_JSON" | jq -c --arg filter "$FILTER_VERSION" '
+            [
+              .versions[]
+              | select(.ci == true)
+              | select((.upgrade.available // false) == true)
+              | select($filter == "" or .pfsense_version == $filter)
+              | {
+                  variant:          (.channel | ascii_downcase),
+                  label:            .channel,
+                  pfsense_version:  .pfsense_version,
+                  freebsd_version:  .freebsd_version,
+                  image_name:       ("pfsense-" + (.channel | ascii_downcase)),
+                  branch:           (.upgrade.branch // ""),
+                  target:           (.upgrade.target // .pfsense_version),
+                  from:             (.upgrade.from // .pfsense_version),
+                  force_flag:       (if ((.upgrade.from // .pfsense_version) == .pfsense_version) then "--force" else "" end)
+                }
+            ]
           ')"
 
-          # Patch-refresh fallback: target is the oldest/only CE entry — upgrade
-          # in-place, overwriting the floating tag (--force required).
-          FORCE=""
-          if [ -z "$FROM_TAG" ] || [ "$FROM_TAG" = "null" ]; then
-            FROM_TAG="$TARGET_VERSION"
-            FORCE="--force"
-            printf 'Patch refresh: self-upgrade %s -> %s (--force)\n' \
-              "$FROM_TAG" "$TARGET_VERSION"
-          else
-            printf 'New-version upgrade: %s -> %s\n' "$FROM_TAG" "$TARGET_VERSION"
-          fi
+          printf 'matrix={"include":%s}\n' "$INCLUDE" >> "$GITHUB_OUTPUT"
+          # Count of eligible legs — the refresh job is gated on this so an empty
+          # matrix (the common case) is an unambiguous clean skip, not a matrix edge case.
+          printf 'count=%s\n' "$(printf '%s' "$INCLUDE" | jq 'length')" >> "$GITHUB_OUTPUT"
 
-          printf 'from_tag=%s\n' "$FROM_TAG" >> "$GITHUB_OUTPUT"
-          printf 'force_flag=%s\n' "$FORCE" >> "$GITHUB_OUTPUT"
+          # Human-readable summary for the run log.
+          printf '%s' "$MATRIX_JSON" | jq -r --arg filter "$FILTER_VERSION" '
+            .versions[] |
+            if .ci != true then
+              "  \(.channel) \(.pfsense_version): skip (ci != true)"
+            elif ((.upgrade.available // false) != true) then
+              "  \(.channel) \(.pfsense_version): skip (upgrade.available != true)"
+            elif ($filter != "" and .pfsense_version != $filter) then
+              "  \(.channel) \(.pfsense_version): skip (filtered out by pfsense_version input)"
+            else
+              "  \(.channel) \(.pfsense_version): WILL RUN (from=\(.upgrade.from // .pfsense_version) target=\(.upgrade.target // .pfsense_version) branch=\(.upgrade.branch // "(image default)"))"
+            end
+          '
 
   # ── Upgrade in place → health gate → publish; then non-blocking smoke ──────
   refresh:
-    name: Refresh CE ${{ inputs.pfsense_version }} image
-    needs: resolve-from
+    name: Upgrade pfSense ${{ matrix.label }} Smoke Image
+    needs: plan
+    if: ${{ needs.plan.outputs.count != '0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Checkout (for scripts/ + tests/smoke/)
         uses: actions/checkout@v6
@@ -197,13 +201,12 @@ jobs:
         id: ref
         env:
           SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
-          SMOKE_IMAGE_NAME: ${{ vars.SMOKE_IMAGE_NAME }}
         run: |
           set -eu
-          # Compose the untagged image from the namespace + name vars (org-transfer
-          # scheme). Fallback: lowercased owner (GHCR refs MUST be lowercase).
+          # Compose the untagged image from the namespace var + per-matrix image_name.
+          # Fallback: lowercased owner (GHCR refs MUST be lowercase).
           REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
-          IMAGE="${REPO%/}/${SMOKE_IMAGE_NAME:-pfsense-ce}"
+          IMAGE="${REPO%/}/${{ matrix.image_name }}"
           printf 'image=%s\n' "$IMAGE" >> "$GITHUB_OUTPUT"
           printf 'Image base ref: %s\n' "$IMAGE"
 
@@ -219,23 +222,31 @@ jobs:
       #   5. Shuts down cleanly, compresses to qcow2 (zstd), oras-pushes new tag.
       # The published image is a CLEAN upgraded qcow2; pfBlockerNG is NEVER
       # installed on it (the non-blocking step below uses a discarded overlay).
-      - name: Upgrade in place + health gate + publish (${{ needs.resolve-from.outputs.from_tag }} -> ${{ inputs.pfsense_version }})
+      - name: >-
+          Upgrade ${{ matrix.label }} in place + publish
+          (${{ matrix.from }} -> ${{ matrix.pfsense_version }}${{ matrix.branch != '' && format(' @ {0}', matrix.branch) || '' }})
         id: upgrade
         env:
           SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
           SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
           SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_USER || github.actor }}
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_TOKEN || secrets.GITHUB_TOKEN }}
-          FROM_TAG: ${{ needs.resolve-from.outputs.from_tag }}
-          TARGET: ${{ inputs.pfsense_version }}
-          FORCE_FLAG: ${{ needs.resolve-from.outputs.force_flag }}
+          SMOKE_PLUS_MAC: ${{ secrets.SMOKE_PLUS_MAC }}
+          SMOKE_PLUS_SMBIOS_UUID: ${{ secrets.SMOKE_PLUS_SMBIOS_UUID }}
+          FROM_TAG: ${{ matrix.from }}
+          TARGET_TAG: ${{ matrix.pfsense_version }}
+          VARIANT: ${{ matrix.variant }}
+          FORCE_FLAG: ${{ matrix.force_flag }}
+          BRANCH: ${{ matrix.branch }}
         run: |
           set -eu
           sh scripts/image-upgrade.sh \
             ${FORCE_FLAG:+"$FORCE_FLAG"} \
             --from "$FROM_TAG" \
-            --to "$TARGET" \
-            --image "${{ steps.ref.outputs.image }}" \
+            --to "$TARGET_TAG" \
+            --type "$VARIANT" \
+            ${BRANCH:+--branch "$BRANCH"} \
+            --image "$SMOKE_IMAGE" \
             --ssh-key "$PWD/smoke_key" \
             --compression "${{ inputs.compression }}" \
             --upgrade-timeout "${{ inputs.upgrade_timeout }}" \
@@ -248,6 +259,13 @@ jobs:
       # continue-on-error: true + post-publish overlay → can NEVER pollute the
       # published image and can NEVER fail the refresh job.
       # The authoritative pfBlockerNG validation is smoke.yml.
+      #
+      # CE: single NIC, standard SLIRP hostfwd to 127.0.0.1:$GUEST_PORT.
+      # Plus: 8-NIC topology matching image-upgrade.sh + smoke boot_vm.sh; full
+      #       Plus identity (SMBIOS + 8 MACs from SMOKE_PLUS_MAC) required — NEVER
+      #       boot Plus with wrong identity (Netgate Device ID derives from MAC +
+      #       SMBIOS uuid; a mismatch breaks licensing). If identity secrets are
+      #       absent or the MAC list is malformed the step warns and exits cleanly.
       - name: pfBlockerNG smoke (non-blocking)
         continue-on-error: true
         env:
@@ -255,16 +273,32 @@ jobs:
           SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
           SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_USER || github.actor }}
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          SMOKE_PLUS_MAC: ${{ secrets.SMOKE_PLUS_MAC }}
+          SMOKE_PLUS_SMBIOS_UUID: ${{ secrets.SMOKE_PLUS_SMBIOS_UUID }}
+          VARIANT: ${{ matrix.variant }}
         run: |
           set -eu
           LOCAL_DATA_NAME="${{ inputs.sanity_local_data_name }}"
           LOCAL_DATA_IP="${{ inputs.sanity_local_data_ip }}"
           IMAGE="${SMOKE_IMAGE}"
-          TAG="${{ inputs.pfsense_version }}"
+          TAG="${{ matrix.pfsense_version }}"
           GUEST_PORT=2223
-          MAC="BC:24:11:37:9C:AC"
           WORK_DIR="$(mktemp -d)"
           printf 'SMOKE_WORK_DIR=%s\n' "$WORK_DIR" >> "$GITHUB_ENV"
+
+          # Plus: validate identity secrets before booting (wrong identity breaks licensing).
+          if [ "$VARIANT" = "plus" ]; then
+            if [ -z "${SMOKE_PLUS_MAC:-}" ] || [ -z "${SMOKE_PLUS_SMBIOS_UUID:-}" ]; then
+              printf '::warning::[non-blocking smoke] Plus identity secrets absent — skipping Plus post-publish smoke\n'
+              exit 0
+            fi
+            # Count non-empty MAC lines.
+            _mac_count="$(printf '%s\n' "$SMOKE_PLUS_MAC" | grep -c '[^[:space:]]' || true)"
+            if [ "${_mac_count:-0}" -ne 8 ]; then
+              printf '::warning::[non-blocking smoke] Plus identity secrets absent/invalid — skipping Plus post-publish smoke\n'
+              exit 0
+            fi
+          fi
 
           # Pull the just-published image.
           printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io \
@@ -278,19 +312,66 @@ jobs:
           OVERLAY="${WORK_DIR}/smoke-overlay.qcow2"
           qemu-img create -b "$BASE_IMG" -F qcow2 -f qcow2 "$OVERLAY"
 
-          printf '==> [non-blocking smoke] booting overlay (guest :%d -> 127.0.0.1:%d)\n' 22 "$GUEST_PORT"
-          qemu-system-x86_64 \
-            -enable-kvm -machine pc -cpu host \
-            -smp 2,sockets=1,cores=2 -m 4096 \
-            -device virtio-scsi-pci,id=virtioscsi0 \
-            -drive "file=${OVERLAY},if=none,id=drive-scsi0,format=qcow2,discard=unmap,detect-zeroes=unmap" \
-            -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
-            -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${GUEST_PORT}-:22" \
-            -device "virtio-net-pci,mac=${MAC},netdev=net0,id=net0" \
-            -display none \
-            -serial "file:${WORK_DIR}/smoke-console.log" \
-            -pidfile "${WORK_DIR}/smoke-qemu.pid" \
-            -daemonize
+          printf '==> [non-blocking smoke] booting overlay (%s, guest :%d -> 127.0.0.1:%d)\n' "$VARIANT" 22 "$GUEST_PORT"
+
+          if [ "$VARIANT" = "ce" ]; then
+            # CE: single NIC, standard SLIRP.
+            CE_MAC="BC:24:11:37:9C:AC"
+            qemu-system-x86_64 \
+              -enable-kvm -machine pc -cpu host \
+              -smp 2,sockets=1,cores=2 -m 4096 \
+              -device virtio-scsi-pci,id=virtioscsi0 \
+              -drive "file=${OVERLAY},if=none,id=drive-scsi0,format=qcow2,discard=unmap,detect-zeroes=unmap" \
+              -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
+              -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${GUEST_PORT}-:22" \
+              -device "virtio-net-pci,mac=${CE_MAC},netdev=net0,id=net0" \
+              -display none \
+              -serial "file:${WORK_DIR}/smoke-console.log" \
+              -pidfile "${WORK_DIR}/smoke-qemu.pid" \
+              -daemonize
+          else
+            # Plus: 8-NIC topology matching image-upgrade.sh + boot_vm.sh.
+            # net0 WAN  10.10.0.0/24 (internet egress for pfSense-upgrade downloads)
+            # net1 MGMT 10.0.0.0/16  (SSH hostfwd → static MGMT IP 10.0.0.20)
+            # net2..net7 isolated stub NICs (must be present; unassigned in image)
+            SMBIOS_UUID="${SMOKE_PLUS_SMBIOS_UUID}"
+            _mac0="$(printf '%s\n' "$SMOKE_PLUS_MAC" | sed -n '1p')"
+            _mac1="$(printf '%s\n' "$SMOKE_PLUS_MAC" | sed -n '2p')"
+            _mac2="$(printf '%s\n' "$SMOKE_PLUS_MAC" | sed -n '3p')"
+            _mac3="$(printf '%s\n' "$SMOKE_PLUS_MAC" | sed -n '4p')"
+            _mac4="$(printf '%s\n' "$SMOKE_PLUS_MAC" | sed -n '5p')"
+            _mac5="$(printf '%s\n' "$SMOKE_PLUS_MAC" | sed -n '6p')"
+            _mac6="$(printf '%s\n' "$SMOKE_PLUS_MAC" | sed -n '7p')"
+            _mac7="$(printf '%s\n' "$SMOKE_PLUS_MAC" | sed -n '8p')"
+            qemu-system-x86_64 \
+              -enable-kvm -machine pc -cpu host \
+              -smp 2,sockets=1,cores=2 -m 4096 \
+              -smbios "type=1,uuid=${SMBIOS_UUID}" \
+              -device virtio-scsi-pci,id=virtioscsi0 \
+              -drive "file=${OVERLAY},if=none,id=drive-scsi0,format=qcow2,discard=unmap,detect-zeroes=unmap" \
+              -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1 \
+              -netdev "user,id=net0,net=10.10.0.0/24,host=10.10.0.2" \
+              -device "virtio-net-pci,mac=${_mac0},netdev=net0,id=nic0" \
+              -netdev "user,id=net1,net=10.0.0.0/16,host=10.0.0.2,hostfwd=tcp:127.0.0.1:${GUEST_PORT}-10.0.0.20:22" \
+              -device "virtio-net-pci,mac=${_mac1},netdev=net1,id=nic1" \
+              -netdev "user,id=net2,net=10.20.0.0/24,restrict=on" \
+              -device "virtio-net-pci,mac=${_mac2},netdev=net2,id=nic2" \
+              -netdev "user,id=net3,net=10.30.0.0/24,restrict=on" \
+              -device "virtio-net-pci,mac=${_mac3},netdev=net3,id=nic3" \
+              -netdev "user,id=net4,net=10.40.0.0/24,restrict=on" \
+              -device "virtio-net-pci,mac=${_mac4},netdev=net4,id=nic4" \
+              -netdev "user,id=net5,net=10.50.0.0/24,restrict=on" \
+              -device "virtio-net-pci,mac=${_mac5},netdev=net5,id=nic5" \
+              -netdev "user,id=net6,net=10.60.0.0/24,restrict=on" \
+              -device "virtio-net-pci,mac=${_mac6},netdev=net6,id=nic6" \
+              -netdev "user,id=net7,net=10.70.0.0/24,restrict=on" \
+              -device "virtio-net-pci,mac=${_mac7},netdev=net7,id=nic7" \
+              -display none \
+              -serial "file:${WORK_DIR}/smoke-console.log" \
+              -pidfile "${WORK_DIR}/smoke-qemu.pid" \
+              -daemonize
+          fi
+
           SMOKE_QPID="$(cat "${WORK_DIR}/smoke-qemu.pid" 2>/dev/null | tr -d '\r' || true)"
 
           # Wait for SSH (180 s).
@@ -375,7 +456,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: image-refresh-diagnostics-${{ inputs.pfsense_version }}
+          name: image-refresh-diagnostics-${{ matrix.variant }}-${{ matrix.pfsense_version }}
           path: |
             ${{ env.SMOKE_WORK_DIR }}/smoke-console.log
           if-no-files-found: ignore

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -114,6 +114,7 @@ jobs:
           INCLUDE="$(printf '%s' "$MATRIX_JSON" | jq -c --arg filter "$FILTER_VERSION" '
             [
               .versions[]
+              | select((.role // "build") != "route-only")
               | select(.ci == true)
               | select((.upgrade.available // false) == true)
               | select($filter == "" or .pfsense_version == $filter)
@@ -122,7 +123,7 @@ jobs:
                   label:            .channel,
                   pfsense_version:  .pfsense_version,
                   freebsd_version:  .freebsd_version,
-                  image_name:       ("pfsense-" + (.channel | ascii_downcase)),
+                  image_name:       (.image_name // ("pfsense-" + (.channel | ascii_downcase))),
                   branch:           (.upgrade.branch // ""),
                   target:           (.upgrade.target // .pfsense_version),
                   from:             (.upgrade.from // .pfsense_version),
@@ -139,7 +140,9 @@ jobs:
           # Human-readable summary for the run log.
           printf '%s' "$MATRIX_JSON" | jq -r --arg filter "$FILTER_VERSION" '
             .versions[] |
-            if .ci != true then
+            if ((.role // "build") == "route-only") then
+              "  \(.channel) \(.pfsense_version): skip (role == route-only)"
+            elif .ci != true then
               "  \(.channel) \(.pfsense_version): skip (ci != true)"
             elif ((.upgrade.available // false) != true) then
               "  \(.channel) \(.pfsense_version): skip (upgrade.available != true)"
@@ -201,12 +204,21 @@ jobs:
         id: ref
         env:
           SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
+          # Pass the matrix value through env (never interpolate ${{ }} into the
+          # shell body — template-injection hardening), then validate before use.
+          MATRIX_IMAGE_NAME: ${{ matrix.image_name }}
         run: |
           set -eu
           # Compose the untagged image from the namespace var + per-matrix image_name.
           # Fallback: lowercased owner (GHCR refs MUST be lowercase).
+          case "$MATRIX_IMAGE_NAME" in
+            ''|*[!a-z0-9._-]*)
+              echo "::error::invalid matrix.image_name: '$MATRIX_IMAGE_NAME'"
+              exit 1
+              ;;
+          esac
           REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
-          IMAGE="${REPO%/}/${{ matrix.image_name }}"
+          IMAGE="${REPO%/}/${MATRIX_IMAGE_NAME}"
           printf 'image=%s\n' "$IMAGE" >> "$GITHUB_OUTPUT"
           printf 'Image base ref: %s\n' "$IMAGE"
 

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -187,49 +187,34 @@ jobs:
             fi
           done
 
-          # ── Iterate over CI matrix (ci:true CE entries only) ───────────────
-          # For each CI-eligible entry:
-          #   b) Trigger image-refresh.yml (Phase 5) — upgrade-in-place + sanity gate.
-          #   c) Trigger smoke.yml (Phase 6) — live-VM smoke across all CE images.
-          #
-          # NOTE ON FORWARD REFERENCES:
-          #   image-refresh.yml and smoke.yml do NOT yet exist on this branch.
-          #   They will be created by Phases 5 and 6 respectively.  The dispatch calls
-          #   below are wired now; they become live when those phases land.
-          #   The exact workflow names and their expected dispatch inputs are documented
-          #   in RESULTS/04_Results.txt (handoff section).
+          # ── CI image refresh + smoke fan-out ───────────────────────────────
+          #   b) Trigger image-refresh.yml — upgrade the CE + Plus smoke images.
+          #      It reads ci-metadata itself and refreshes only the variants whose
+          #      upgrade.available flag is set (a curated signal that a public
+          #      pre-release / GA / patch exists), so most days this is a clean no-op.
+          #   c) Trigger smoke.yml — live-VM smoke across all ci:true images.
           echo ""
-          echo "--- Step B: CI image refresh (image-refresh.yml, Phase 5) ---"
+          echo "--- Step B: CI image refresh (image-refresh.yml) ---"
           CI_COUNT=$(printf '%s\n' "$CI_MATRIX" | jq 'length')
-          if [ "$CI_COUNT" -eq 0 ]; then
-            echo "  [skip] No ci:true CE entries — CI image refresh not triggered."
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "  [DRY-RUN] WOULD dispatch image-refresh.yml${TARGET_VERSION:+ (pfsense_version=$TARGET_VERSION)}"
+            echo "    (reads ci-metadata; refreshes each variant whose upgrade.available is true)"
           else
-            printf '%s\n' "$CI_MATRIX" | jq -c '.[]' | while IFS= read -r ENTRY; do
-              PFSENSE=$(printf '%s\n' "$ENTRY" | jq -r '.pfsense_version')
-              FREEBSD_VERSION=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_version')
-              MAJOR=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_major')
-
-              if [ -n "$TARGET_VERSION" ] && [ "$PFSENSE" != "$TARGET_VERSION" ]; then
-                echo "  [skip] ${PFSENSE} — does not match target '${TARGET_VERSION}'"
-                continue
-              fi
-
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "  [DRY-RUN] WOULD dispatch image-refresh.yml:"
-                echo "    pfsense_version=${PFSENSE}  freebsd_version=${FREEBSD_VERSION}  freebsd_major=${MAJOR}"
-              else
-                echo "  [TRIGGER] image-refresh.yml for CE ${PFSENSE} (FreeBSD ${MAJOR})"
-                # Phase 5 contract: image-refresh.yml accepts pfsense_version and
-                # freebsd_version as workflow_dispatch inputs.
-                # See RESULTS/04_Results.txt for the exact expected input contract.
-                gh workflow run image-refresh.yml \
-                  --repo "$REPO" \
-                  --ref "$REF" \
-                  --field "pfsense_version=${PFSENSE}" \
-                  --field "freebsd_version=${FREEBSD_VERSION}" \
-                  || echo "  ::warning::Dispatch of image-refresh.yml for ${PFSENSE} failed — Phase 5 may not yet be landed"
-              fi
-            done
+            echo "  [TRIGGER] image-refresh.yml (CE + Plus; gated on upgrade.available)"
+            # Pass the narrow filter only when a target version was requested; the
+            # workflow defaults to all eligible variants when none is given.
+            if [ -n "$TARGET_VERSION" ]; then
+              gh workflow run image-refresh.yml \
+                --repo "$REPO" \
+                --ref "$REF" \
+                --field "pfsense_version=${TARGET_VERSION}" \
+                || echo "  ::warning::Dispatch of image-refresh.yml failed"
+            else
+              gh workflow run image-refresh.yml \
+                --repo "$REPO" \
+                --ref "$REF" \
+                || echo "  ::warning::Dispatch of image-refresh.yml failed"
+            fi
           fi
 
           echo ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -859,19 +859,27 @@ When the min CE version changes, also:
    from the `SMOKE_PLUS_MAC`/`SMOKE_PLUS_SMBIOS_UUID` (+ optional `SMOKE_PLUS_NDI`) secrets —
    **never** the matrix — and the harness redacts it from diagnostics. Adding the entry + letting
    **version-tracker** (`version-tracker.yml`) run (or dispatching it) triggers
-   `build-pkg-linux.yml`, `image-refresh.yml` (CE only — see step 2), `smoke.yml`
+   `build-pkg-linux.yml`, `image-refresh.yml` (CE **and** Plus — see step 2), `smoke.yml`
    automatically — **no workflow YAML edit needed**.
-2. **Refresh the CE smoke image** (ADR-04 + ADR-09) — dispatch `image-refresh.yml` with
-   `pfsense_version` + `freebsd_version` from the new entry. It runs `scripts/image-upgrade.sh
-   --upgrade-pkgs`: pulls the current GHCR tag, conditionally upgrades baked deps (`pkg upgrade
-   -n` dry-run gate; `pkg upgrade -y` + reboot only if pending), runs `pfSense-upgrade` (any bump
-   incl. major), then an **alive health gate** (polls ≤300 s for the webConfigurator to answer
-   HTTP or `pfctl` to show a live ruleset) and publishes only when healthy — fail-closed. A
-   non-blocking post-publish smoke (`continue-on-error`) runs on a discarded overlay
-   (informational; authoritative validation is the fan-out, step 3). Manual seed via
-   `scripts/image-publish.sh` is the fallback when the gate fails. **`image-refresh.yml` is
-   CE-only** — the **Plus** image is refreshed **manually** with `scripts/image-publish.sh`
-   (re-export + push the licensed qcow2; the MAC/SMBIOS uuid must stay constant — ADR-24). See
+2. **Refresh the smoke images** (ADR-04 + ADR-09) — `image-refresh.yml` (`Upgrade pfSense smoke
+   images`) is a **CE + Plus matrix fan-out**: a `plan` job reads `ci-metadata`, and each
+   `ci:true` variant is refreshed **only when its `upgrade.available` flag is set** (a curated
+   per-variant signal that a public pre-release / GA / patch exists). Absent/`false` → that
+   variant is skipped, so most days the run is a clean no-op. Each leg runs
+   `scripts/image-upgrade.sh --type ce|plus --upgrade-pkgs` (and `--branch <id>` when
+   `upgrade.branch` is set, to reach a **pre-release / development** build — the branch is stored
+   in pfSense's `system/pkg_repo_conf_path` and applied via `pkg_switch_repo()`): pulls the
+   current GHCR tag, conditionally upgrades baked deps, runs `pfSense-upgrade`, then an **alive
+   health gate** (≤300 s for webConfigurator HTTP or a live `pfctl` ruleset) and publishes only
+   when healthy — fail-closed. GA/patches within a floating tag (2.8.0→2.8.1, both tag `2.8`)
+   self-replace that tag (`--force`); a new Major.Minor publishes a new tag. The **Plus** leg
+   takes its license/NDI identity from the `SMOKE_PLUS_MAC`/`SMOKE_PLUS_SMBIOS_UUID` secrets and
+   refuses to boot on mismatch. A non-blocking post-publish smoke runs per variant on a discarded
+   overlay (informational; authoritative validation is the fan-out, step 3; the Plus post-smoke
+   skips cleanly if the Plus secrets are absent). Manual seed via `scripts/image-publish.sh`
+   remains the fallback when the gate fails (and for the initial Plus image seed). To enable an
+   upgrade, set the entry's `upgrade` block in `ci-metadata` (`{available, branch, target, from}`;
+   `from` defaults to the entry's own floating tag = self-replace). See
    `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`. (ADR-09 supersedes ADR-04 §2's "re-baseline on
    a major jump": `image-refresh.yml` handles all jumps via upgrade-in-place; a fresh re-seed is
    triggered only by a gate failure. Reconciling the ADR-04 §2 text is a tracked follow-up.)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -135,18 +135,24 @@ After `supported-versions.json` is updated on `ci-metadata`, the next
 
 1. **`build-pkg-linux.yml`** — validates the new entry's `(freebsd_version, php_version)`
    pair by building an installable `.pkg`. One dispatch per BUILD entry.
-2. **`image-refresh.yml`** — upgrade-in-place: pulls the current GHCR tag for the CE
-   version, runs `pfSense-upgrade`, applies the **six-check sanity gate**, and publishes
-   the new tag to GHCR **only on gate pass** (fail-closed — a bad image is never
-   published). One dispatch per `ci: true` CE entry.
+2. **`image-refresh.yml`** (`Upgrade pfSense smoke images`) — a **CE + Plus matrix
+   fan-out**. A `plan` job reads `ci-metadata` and refreshes each `ci: true` variant
+   **only when its `upgrade.available` flag is set** (a curated signal that a public
+   pre-release / GA / patch exists); absent/`false` → that variant is skipped, so most
+   days the run is a clean no-op. Each leg runs `scripts/image-upgrade.sh --type ce|plus`
+   (plus `--branch <id>` when `upgrade.branch` is set, to reach a pre-release/development
+   build), applies the health gate, and publishes the new tag to GHCR **only on gate pass**
+   (fail-closed). GA/patches self-replace the floating tag; a new Major.Minor gets a new tag.
 3. **`smoke.yml`** — runs the ADR-04 live-VM smoke suite across **all** `ci: true`
    entries — **CE and Plus** (ADR-24) — in parallel (`fail-fast: false`). The
    **`all-smoke-passed` AND-gate** fails if any single leg fails — one failed leg makes the
    whole gate red, no partial pass.
 
-The tracker dispatches step 1 (build) and step 3 (smoke) for every `ci: true` entry,
-CE and Plus. Step 2 (`image-refresh.yml`) is **CE-only** — the Plus image is refreshed
-**manually** with `scripts/image-publish.sh` (re-export + push the licensed qcow2).
+The tracker dispatches step 1 (build), step 2 (image refresh), and step 3 (smoke). Step 2
+now covers **CE and Plus** in one run (gated per variant on `upgrade.available`); the Plus
+leg takes its license/NDI identity from the `SMOKE_PLUS_MAC`/`SMOKE_PLUS_SMBIOS_UUID`
+secrets. `scripts/image-publish.sh` remains the manual fallback (gate failure, or the
+initial Plus image seed).
 
 ### ADR-04 §2 reconciliation (flagged — not edited here)
 

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -89,6 +89,19 @@
 #                    Default OFF; pass this flag to enable. build-image.yml does NOT
 #                    pass this flag (it calls this script directly), so callers that
 #                    only want the pfSense-upgrade step are unaffected.
+#   --branch NAME    switch the pfSense update branch to NAME before running the OS
+#                    upgrade. pfSense stores the selected branch in config.xml key
+#                    system/pkg_repo_conf_path; applying the change calls
+#                    pkg_switch_repo() (runs pfSense-repo-setup -U and refreshes pkg
+#                    metadata), followed by an explicit `pkg update -f` so the
+#                    subsequent pfSense-upgrade -c check sees the new branch's
+#                    versions. Use this to upgrade TO a pre-release or development
+#                    build. Branch names are dynamic — use the exact name reported by
+#                    pkg_list_repos() on that pfSense version. The script validates
+#                    NAME against the list of available repos on the booted image and
+#                    fails if it is not found. Default empty = leave the image's
+#                    configured branch unchanged. Example (Plus pre-release):
+#                    --branch pfSense-plus-v26.07-DEVTEST
 #   --keep           keep the work dirs (image copies, console log) afterwards
 #   --force          overwrite the target tag if it already exists
 #
@@ -141,6 +154,7 @@ SMBIOS_UUID="${SMOKE_VM_SMBIOS_UUID:-}"
 COMPRESSION=zstd
 UPGRADE_TIMEOUT=1200
 UPGRADE_PKGS=0
+BRANCH=""
 KEEP=0
 FORCE=0
 
@@ -181,9 +195,10 @@ while [ $# -gt 0 ]; do
         --compression)     COMPRESSION="$2"; shift 2 ;;
         --upgrade-timeout) UPGRADE_TIMEOUT="$2"; shift 2 ;;
         --upgrade-pkgs)    UPGRADE_PKGS=1; shift ;;
+        --branch)          BRANCH="$2"; shift 2 ;;
         --keep)            KEEP=1; shift ;;
         --force)           FORCE=1; shift ;;
-        -h|--help)         sed -n '2,95p' "$0"; exit 0 ;;
+        -h|--help)         sed -n '2,108p' "$0"; exit 0 ;;
         *)                 die "unknown option: $1" ;;
     esac
 done
@@ -416,6 +431,55 @@ if [ "$UPGRADE_PKGS" -eq 1 ]; then
         wait_guest_ssh 300
         log "box is back after pkg-upgrade reboot"
     fi
+fi
+
+# --- optional: switch the pfSense update branch ----------------------------
+# When --branch is given, validate the name against the repos available on the
+# booted image, write it into config.xml via pkg_switch_repo(), then refresh
+# the pkg catalogue so the subsequent pfSense-upgrade -c check sees the new
+# branch's versions. Fail-closed: a wrong/missing branch name aborts the run
+# rather than silently upgrading on the wrong (stable) branch.
+if [ -n "$BRANCH" ]; then
+    # Guard against a branch name containing a single quote (it would break the
+    # PHP string literal below). Branch names from ci-metadata are safe, but
+    # reject anything surprising rather than silently truncating or injecting.
+    case "$BRANCH" in
+        *\'*) die "--branch name must not contain a single quote: $BRANCH" ;;
+    esac
+
+    log "switching pfSense update branch to '$BRANCH' (via pkg_switch_repo)"
+
+    # Build the pfSsh.php snippet. pfSsh.php reads PHP statements on stdin,
+    # then the literal line "exec", then "exit". It runs the snippet inside the
+    # pfSense PHP environment with all pfSense functions available.
+    _php=$(printf '%s\n' \
+        "require_once('pkg-utils.inc');" \
+        "\$repos = pkg_list_repos();" \
+        "\$names = array_column(\$repos, 'name');" \
+        "\$avail = implode(' ', \$names);" \
+        "if (!in_array('$BRANCH', \$names, true)) {" \
+        "    echo 'PFB_BRANCH_NOT_FOUND available=' . \$avail . PHP_EOL;" \
+        "} else {" \
+        "    config_set_path('system/pkg_repo_conf_path', '$BRANCH');" \
+        "    write_config('image-upgrade: switch update branch to $BRANCH');" \
+        "    pkg_switch_repo();" \
+        "    echo 'PFB_BRANCH_OK' . PHP_EOL;" \
+        "}" \
+        "exec" \
+        "exit")
+
+    _branch_out=$(printf '%s\n' "$_php" | ssh_guest 'pfSsh.php' 2>&1 | tee "$LOCAL_DIR/branch-switch.log" || true)
+
+    if printf '%s' "$_branch_out" | grep -q 'PFB_BRANCH_NOT_FOUND'; then
+        _avail=$(printf '%s' "$_branch_out" | grep 'PFB_BRANCH_NOT_FOUND' | sed 's/.*available=//')
+        die "branch '$BRANCH' not found on this image. Available repos: ${_avail:-<none listed; see $LOCAL_DIR/branch-switch.log>}"
+    fi
+    if ! printf '%s' "$_branch_out" | grep -q 'PFB_BRANCH_OK'; then
+        die "branch switch to '$BRANCH' did not confirm success (PFB_BRANCH_OK not in output; see $LOCAL_DIR/branch-switch.log)"
+    fi
+
+    log "branch switch confirmed — refreshing pkg catalogue (pkg update -f)"
+    ssh_guest 'pkg update -f' 2>&1 | tee "$LOCAL_DIR/pkg-update-branch.log" || true
 fi
 
 # --- check whether an OS upgrade is available ------------------------------


### PR DESCRIPTION
## What

Turn `image-refresh.yml` (now **`Upgrade pfSense smoke images`**) into a CE + Plus matrix fan-out — parallel **`Upgrade pfSense CE Smoke Image`** / **`Upgrade pfSense Plus Smoke Image`** legs, both driven by `scripts/image-upgrade.sh`. Previously it was CE-only and Plus images were refreshed manually.

## Why

The renewed `image-upgrade.sh` already supports `--type ce|plus` with license-safe identity enforcement, so the Plus refresh can be automated alongside CE. An image should only be upgraded when there is actually a newer public build, so the run is gated per variant.

## How

- **`plan` job** reads `ci-metadata` and emits a matrix leg per `ci:true` variant **only when its `upgrade.available` flag is set** — a curated signal that a public **pre-release / GA / patch** exists. Absent/`false` → skipped; empty matrix → the refresh job is skipped (clean no-op, the common case most days).
- **Floating-tag semantics:** GA/patch within a `Major.Minor` tag (2.8.0→2.8.1, both tag `2.8`) self-replace that tag (`--force`); a new `Major.Minor` publishes a new tag. `upgrade.from` selects the source (defaults to self).
- **`image-upgrade.sh --branch <name>`** (new): switch the pfSense update branch (`system/pkg_repo_conf_path` + `pkg_switch_repo()`) before `pfSense-upgrade`, so a **pre-release/development** build is reachable. Validated against `pkg_list_repos()`, **fail-closed** if not found.
- **Plus identity:** the Plus leg passes `--type plus` and the `SMOKE_PLUS_MAC`/`SMOKE_PLUS_SMBIOS_UUID` secrets; `image-upgrade.sh` refuses to boot on mismatch. The per-variant non-blocking post-publish smoke boots Plus with the **full 8-NIC + SMBIOS identity** and **skips cleanly** if the Plus secrets are absent (never boots Plus with a wrong NDI).
- **`version-tracker.yml`** dispatches `image-refresh.yml` **once** (no per-version loop); the per-variant gate now lives in the workflow.
- **Docs:** `CLAUDE.md` + `scripts/README.md` updated (no longer CE-only / Plus-manual).

## Enabling an upgrade

Set the entry's `upgrade` block in `ci-metadata`'s `supported-versions.json` (separate PR on that branch):

```json
"upgrade": { "available": true, "branch": "<pfSense update-branch id>", "target": "2.8.1", "from": "2.8" }
```

`branch`/`from` are optional (`branch` empty = stay on the image's configured/stable branch; `from` defaults to the entry's floating tag = self-replace). The workflow tolerates the block being absent (skips), so this PR is inert until a block is added.

## Validation

- `actionlint` clean on both workflows; `shellcheck` + `sh -n` clean on `image-upgrade.sh`; markdownlint 0 errors; pre-commit hooks pass.
- plan jq tested: real `ci-metadata` → empty matrix (no-op); synthetic `available:true` → correct CE + Plus legs.
- Live-VM legs are exercised when an `upgrade` block is enabled (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded smoke-image refresh to run a unified CE+Plus fan-out driven by an upgrade matrix, with per-leg diagnostics.
  * Image upgrades now support selecting a pfSense package repository branch for pre-release/development builds.
* **Bug Fixes**
  * Improved Plus smoke boot by validating required Plus identity settings (and MAC list length) before proceeding, avoiding erroneous failures.
* **Documentation**
  * Updated CI and smoke-suite documentation to reflect CE+Plus variant handling and the new branch selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->