### PR TITLE
pfblockerng: unmount chroot python data nullfs on uninstall before deleting the include (#484)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15060,6 +15060,29 @@ function pfblockerng_php_pre_deinstall_command() {
 	unlink_if_exists("{$pfb['dnsbl_info']}");
 	unlink_if_exists("{$pfb['dnsbl_resolver']}");
 
+	// The chrooted Unbound python integration nullfs-mounts host dirs into the chroot
+	// (var/log/pfblockerng for the DNSBL logs, usr/local/share/GeoIP).  A disable goes
+	// through pfb_unbound_include.inc, which unmounts them; an uninstall instead just
+	// deletes that include (below) and only pfb_unbound_python_unmount()s bin/lib — so
+	// these data mounts are left ORPHANED on every uninstall.  A keep=off uninstall then
+	// rmdir's the host log source under the live mount, leaving it stale: chrooted
+	// dnsbl.log writes fail "No such file or directory" for the rest of the session
+	// (surfaced once #484 added the first live keep=off uninstall coverage).  Unmount
+	// them here, before the include is removed, so every uninstall (keep on or off) tears
+	// the chroot down as cleanly as a disable.  Bounded loop clears any stacked mounts.
+	foreach (array('var/log/pfblockerng', 'usr/local/share/GeoIP') as $pfb_cmnt) {
+		$pfb_cmnt_path = "{$g['unbound_chroot_path']}/{$pfb_cmnt}";
+		for ($pfb_cmnt_i = 0; $pfb_cmnt_i < 8; $pfb_cmnt_i++) {
+			if (empty(exec("/sbin/mount | {$pfb['grep']} " . escapeshellarg($pfb_cmnt_path) . " 2>&1"))) {
+				break;
+			}
+			exec("/sbin/umount -t nullfs " . escapeshellarg($pfb_cmnt_path) . " 2>&1", $pfb_cmnt_out, $pfb_cmnt_rv);
+			if ($pfb_cmnt_rv != 0) {
+				break;
+			}
+		}
+	}
+
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");


### PR DESCRIPTION
## Fix latent stale chroot-mount on uninstall (surfaced by #484 keep=off coverage)

The chrooted Unbound python integration nullfs-mounts host dirs into the chroot — `var/log/pfblockerng` (where the DNSBL logs land for the GUI viewer / reports / host log rotation) and `usr/local/share/GeoIP`.

A **disable/toggle** tears the integration down through `pfb_unbound_include.inc`, whose `pfb_python_mount()` unmounts those data nullfs. An **uninstall** does not: it `unlink`s the include and only `pfb_unbound_python_unmount()`s the transient `bin`/`lib`, so the data mounts are left **orphaned**. A **keep=off** uninstall then `rmdir`s the host log dir *under the still-live nullfs* → the mount goes **stale**, and every chrooted `dnsbl.log` write fails `No such file or directory` for the rest of the session.

That broke the log-rotate, DNSBL block-log, and Upstream_Block-log smoke tests, and (cascade) the ABP tests — the async log writer wedged on the stale mount → >30s timeouts. VIP-block tests pass throughout: they never touch the chroot log.

### Latent, not a regression
The `rmdir` and the mounts are old. It stayed hidden because no test ever ran a **keep=off uninstall** until #484 added live keep-matrix coverage — and because #484 also made this teardown **unconditional**, the same orphaning now reaches keep=on uninstalls too. So #484 *surfaced and widened* the bug; it didn't introduce it.

### Fix
In the unconditional uninstall teardown, unmount the data nullfs (`var/log/pfblockerng` + GeoIP; bounded loop for any stacked mounts) **before** the include is removed — so every uninstall, keep on or off, tears the chroot down as cleanly as a disable.

### Validation (live fan-out, CE + Plus)
The #484 fan-out went **15 → 4** failures with this one fix: the 7 chroot-log tests and the 3 ABP cascade tests now pass, no new failures. The remaining 4 (syslog ×3, feeds ×1) are independent and tracked separately.

Part of #484 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall cleanup to remove leftover mounted chroot files and related data.
  * Prevents stale mounts from persisting after removal, helping avoid issues on future installs or reinstalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->