### PR TITLE
pfblockerng: finish ADR-28 enum wiring (pfb_idn + lenient) — #502 Bucket A

### DIFF
--- a/.ADRs/ADR_28_Code_Quality_Conventions/ADR.md
+++ b/.ADRs/ADR_28_Code_Quality_Conventions/ADR.md
@@ -87,26 +87,38 @@ one commit, each leaving the full suite green, each reviewed before the next. Pe
 | 4 — string-ops over regex | `str_*`/`strpos`/`str_contains` over `preg_*` where equivalent; **hot loops first** | `str` methods over `re` in per-query/per-line paths | parameter-expansion / `case` over `grep -E`/`sed` where equivalent | `String.prototype` methods over `RegExp` |
 | 5 — uppercase `TRUE`/`FALSE` | **uppercase** literals | `True`/`False` (Python is correct as-is) | N/A | `true`/`false` (JS is lowercase) |
 
-### 2.2 Enums are internal; the config storage format is hard-frozen (the adapter rule)
+### 2.2 Enums are internal; the config storage adapter rule — preserve behaviour on upgrade
 
-- **`config.xml` stored values never change** — every checkbox `'on'`/`''` and every option string
-  stays byte-identical across upgrade. This is the contract from §1.3.
-- Enums/booleans are an **internal runtime representation only**. The conversion happens at a
-  **read-boundary adapter** (centred on `pfb_global()` and any sibling read site): stored string →
-  internal enum/bool on read; internal enum/bool → the **exact same legacy stored string** on write.
-- A **backed enum's backing value equals the stored string** where a direct map is natural
-  (`case On = 'on'`), so `Enum::tryFrom($stored) ?? Enum::default()` is the adapter and `$e->value`
-  is the writer. Where a field's "off" is `''` vs `'off'`, the adapter is **field-aware** of that
-  field's exact legacy vocabulary — there is no single global toggle.
-- **Round-trip identity is mandatory and pinned by tests**: for every adapted field, every existing
-  stored value (incl. empty / unset / any legacy variant) must satisfy `write(read(v)) == v`. **If a
-  field cannot round-trip losslessly, it is excluded** — it stays a string, documented as such. This
-  is the falsifiable gate (§7).
+- **Storage is NOT frozen — we keep it consistent for back-compat where practical, not
+  byte-for-byte.** There is no versioned migration routine. New options add new stored strings;
+  the read-boundary adapters absorb legacy tokens and writes emit a canonical token (which **may**
+  differ from the legacy one when behaviour-equivalent). The goal is to preserve *behaviour* on
+  upgrade, not bytes.
+- **Forward-compat (upgrade) has two cases:** an **existing config with the key absent** reads to a
+  value that **preserves that user's prior behaviour**; a **brand-new config** gets the **new
+  default**. When those differ, a one-time grandfather seed sets the key for existing installs at
+  upgrade (e.g. `pfb_rdns_seed_value`, `pfb_feed_filter_install_default`).
+- **Downgrade-tolerant.** Older releases string-compared these values, so an unknown token falls
+  through to that release's safe default. Reusing a legacy token as the canonical value keeps
+  downgrade behaviour intact; a genuinely new token (e.g. `'confusable'`) simply reads as off on
+  an old release — acceptable, the feature didn't exist there.
+- Enums/booleans are the **internal runtime representation**. Conversion at the boundary:
+  stored string → enum on read; enum → canonical stored string on write.
+- A **backed enum's backing value equals its canonical stored string** (`case On = 'on'`).
+  `EnumClass::fromStored($raw)` handles legacy → runtime; `$enum->toStored()` writes the
+  canonical token. Where a field's "off" is `''` vs `'off'`, the enum is **field-aware** — no
+  single global toggle.
+- **Round-trip of canonical tokens is mandatory and pinned by tests**: `write(read(v)) == v` for
+  every canonical stored token; a legacy token reads to the correct runtime value and writes to
+  its behaviour-equivalent canonical token. **If a field cannot satisfy this, it is excluded** —
+  kept as a string, documented as such. This is the falsifiable gate (§7).
 
 ### 2.3 Semantics that MUST be preserved (the contract — pinned before each swap)
 
-1. **Every `config.xml` stored value is byte-identical before/after** any phase — proven by the
-   per-field round-trip tests (§2.2) and the smoke upgrade check (§7).
+1. **Every adapted config field preserves its user's behaviour before/after** any phase — proven
+   by the per-field round-trip tests (§2.2): canonical tokens round-trip unchanged; legacy tokens
+   read to the correct runtime value and write to a behaviour-equivalent canonical token. Proven by
+   the smoke upgrade check (§7).
 2. **No behavioural change** from any enum adoption, conditional reorder, or regex→string swap —
    the DNSBL/IP/Geo decisions, UI output, and feed processing are identical. Proven by PHPUnit +
    pytest golden tests over touched logic and the ADR-04 smoke fan-out.
@@ -117,7 +129,9 @@ one commit, each leaving the full suite green, each reviewed before the next. Pe
 
 ### 2.4 Explicitly kept / out of scope
 
-- **`config.xml` storage format** (§2.2) — frozen, never migrated.
+- **`config.xml` storage format** (§2.2) — no versioned schema or migration pass; legacy tokens
+  are absorbed at the read-boundary adapter and writes emit the canonical (behaviour-equivalent)
+  token.
 - **`py_unbound.ini`** and any **manifest / serialized / wire** value the Python or shell side
   reads — these are contracts with other processes; kept as strings.
 - **ADR-26 shell locale prefixes** (`LC_ALL=C` on collation sinks) — untouched; the shell phase
@@ -160,7 +174,7 @@ one commit, each leaving the full suite green, each reviewed before the next. Pe
 ## 4. Requirements (acceptance)
 
 - All five conventions documented in `CLAUDE.md` as the policy of record, with the per-language
-  table (§2.1), the hard-freeze + adapter rule (§2.2), and the out-of-scope carve-outs (§2.4).
+  table (§2.1), the storage adapter rule (§2.2), and the out-of-scope carve-outs (§2.4).
 - The retroactive sweep completed across PHP, Python, and shell in the §6 phases, each
   behaviour-preserving and green.
 - A targeted PHPCS sniff enforcing uppercase PHP `TRUE`/`FALSE` (cheap, mechanical) added and
@@ -277,9 +291,10 @@ Prompt: `11_Smoke_And_Validation.txt` — the acceptance gate.
 
 - Build an **automated upgrade-contract smoke case** (`tests/smoke`, `repo`/upgrade marker): install
   the prior release `.pkg` with a representative settings spread, capture `config.xml`, `pkg upgrade`
-  to the branch build, then assert every adapted field's stored value is **byte-identical** and a
-  representative runtime behaviour (a blocked DNSBL name, an IP block) is unchanged. This automates
-  the §7 contract proof so acceptance needs no manual sign-off (CLAUDE.md "ADR acceptance").
+  to the branch build, then assert every adapted field's **behaviour is preserved** (canonical tokens
+  round-trip; legacy tokens read to the correct runtime value) and a representative runtime behaviour
+  (a blocked DNSBL name, an IP block) is unchanged. This automates the §7 contract proof so
+  acceptance needs no manual sign-off (CLAUDE.md "ADR acceptance").
 - **Dispatch the live-VM validation:** `smoke-fanout.yml` (ADR-04 suite, **CE + Plus**, AND-gated)
   and the **UI tiers** (`ui_render` is the PR gate; dispatch `ui_e2e`/`ui_browser` too). Record the
   green run links. Confirm the full DoD (§7).
@@ -292,9 +307,11 @@ Prompt: `11_Smoke_And_Validation.txt` — the acceptance gate.
 - The PHPCS uppercase-`TRUE`/`FALSE` sniff active and green.
 - **Automated upgrade-contract smoke (Phase 11)** green on the live-VM fan-out: install prior
   release → configure a representative settings spread (DNSBL on/off, IDN mode, lenient, auto-VIP, a
-  couple of feeds) → `pkg upgrade` to the branch build → assert every adapted field's `config.xml`
-  value is **byte-identical** and a representative runtime behaviour (blocked DNSBL name, IP block) is
-  unchanged. This automates the contract proof — **no manual sign-off** (CLAUDE.md "ADR acceptance").
+  couple of feeds) → `pkg upgrade` to the branch build → assert every adapted field's **behaviour is
+  preserved** (canonical tokens round-trip; legacy tokens read to the correct runtime value and write
+  to a behaviour-equivalent canonical token) and a representative runtime behaviour (blocked DNSBL
+  name, IP block) is unchanged. This automates the contract proof — **no manual sign-off** (CLAUDE.md
+  "ADR acceptance").
 - **Smoke fan-out (CE + Plus) + UI tiers green** — `smoke-fanout.yml` AND-gate passes; `ui_render`
   PR gate green; `ui_e2e`/`ui_browser` dispatched green.
 - **Residual manual check (owner: maintainer, out-of-CI):** true *visual* GUI correctness only — a

--- a/.ADRs/ADR_29_Config_Gateway/ADR.md
+++ b/.ADRs/ADR_29_Config_Gateway/ADR.md
@@ -18,8 +18,9 @@ Originates from **issue #281** (config-loss-on-upgrade) and its maintainer follo
 configuration reader/writer … all reads and writes go through it and it owns all
 migration/adapters required to ensure the configuration can be read … and to avoid as many
 contract breaks as possible (so rolling back is tentatively smooth)."* Builds directly on **ADR-28
-§2.2** (config storage hard-freeze + field-aware read/write adapters), which this ADR generalises
-from a per-call-site convention into a single enforced gateway. The #281 point-fix (a `pfb_keep`
+§2.2** (config storage adapter rule — preserve behaviour on upgrade — + field-aware read/write
+adapters), which this ADR generalises from a per-call-site convention into a single enforced
+gateway. The #281 point-fix (a `pfb_keep`
 default + seed migration) already landed (`1e2904f`); this ADR removes the *class* of bug.
 
 ---
@@ -54,10 +55,10 @@ default + seed migration) already landed (`1e2904f`); this ADR removes the *clas
 
 ### 1.2 Load-bearing constraints
 
-- **`config.xml` stored values are hard-frozen** (ADR-28 §1.3/§2.2): no config-version routine
-  exists; the stored representation **is** the upgrade contract. Any change that alters a stored
-  value is a silent settings-loss regression with no repair path. The gateway **must not** change
-  stored bytes.
+- **Behaviour must be preserved across upgrade** (ADR-28 §2.2): no config-version routine
+  exists. The read-boundary adapters absorb legacy tokens; writes emit canonical tokens that are
+  behaviour-equivalent (and downgrade-safe — recognised by older releases). The gateway must not
+  silently alter a stored value in a way that changes an existing user's behaviour.
 - **PHP is the sole writer.** No concurrent cross-language writer to coordinate (Python/shell read
   generated files). The gateway needs no locking beyond what pfSense's `write_config()` already
   provides.
@@ -70,7 +71,7 @@ There is **no performance premise** — per-key config reads are unmeasurably ch
 justification is **correctness and maintainability**: (a) a single canonical default per key
 removes the #281 class (divergent defaults between read sites); (b) an **explicit rollback /
 backward-compatibility contract** — older code reading values written by newer code — which ADR-28's
-*forward-only* freeze never addressed. The risk to weigh is **over-build** (ADR-01): a 204/132-site
+adapter rule (behaviour-on-upgrade) did not fully address for the downgrade direction. The risk to weigh is **over-build** (ADR-01): a 204/132-site
 refactor whose payoff is structural, not behavioural. Mitigation is the phasing discipline (§6) and
 a falsifiable rollback gate (§7) — and the explicit reject path (§7) to narrow scope if the churn
 cannot be contained.
@@ -92,8 +93,8 @@ phases** (§6). Adopt "all reads/writes go through the gateway" as **policy of r
   scattered call-site logic. The #281 `pfb_keep` default (`'on'`) becomes one registry default,
   defined **once**.
 - **Read** applies the registered default + read-adapter (stored string → runtime enum/bool/string).
-  **Write** applies the write-adapter (runtime value → the **exact legacy stored string**), upholding
-  the ADR-28 §2.2 byte-identity freeze and round-trip identity.
+  **Write** applies the write-adapter (runtime value → canonical stored string), upholding the
+  ADR-28 §2.2 behaviour-preserving round-trip and downgrade safety.
 - **Section-level helpers** for the bulk section read/write/delete the `www/` pages and
   `pfb_remove_config_settings()` use, so the broad wipe and the per-page `$pconfig` round-trips also
   flow through one place.
@@ -132,8 +133,10 @@ contract, scoped per field by `since-version`:
 
 ### 2.4 Semantics that MUST be preserved (the contract — pinned before each swap)
 
-1. **Every `config.xml` stored value is byte-identical** before/after every phase (the ADR-28
-   freeze) — proven per field by round-trip tests + the upgrade smoke (§7).
+1. **Every adapted config field preserves its user's behaviour** before/after every phase (the
+   ADR-28 §2.2 adapter rule) — canonical tokens round-trip unchanged; legacy tokens read to the
+   correct runtime value and write to a behaviour-equivalent canonical token — proven per field by
+   round-trip tests + the upgrade smoke (§7).
 2. **No behavioural change** from routing a read/write through the gateway — the DNSBL/IP/Geo
    decisions, UI page output, install/upgrade side effects, and the wipe surface are identical.
    Proven by PHPUnit golden tests over touched logic + the ADR-04 smoke fan-out + `ui_render`.
@@ -146,7 +149,9 @@ contract, scoped per field by `since-version`:
 
 ### 2.5 Explicitly kept / out of scope
 
-- **`config.xml` stored format** — frozen (ADR-28 §2.2); the gateway never migrates stored bytes.
+- **`config.xml` stored format** — no versioned schema or migration pass (ADR-28 §2.2); the
+  gateway writes canonical (behaviour-equivalent) tokens; it never introduces a novel on-disk
+  token an older release would misread.
 - **`py_unbound.ini`, manifests, and any serialized/wire value** read by Python or shell — those are
   generated artifacts / inter-process contracts, not `config.xml`; unchanged.
 - **Non-pfBlockerNG config** (`system/*`, `installedpackages/shellcmdsettings`, widgets sequence,
@@ -196,7 +201,7 @@ contract, scoped per field by `since-version`:
   in the §6 phases — `pfb_global()`, install/migrations, the wipe, and every `www/` page.
 - A **rollback/backward-compat** test gate: off-box per-field `since-version` invariants + the
   `tests/smoke/test_upgrade_config_stability.py` smoke extended with a **downgrade leg** (install
-  newer build, write settings, downgrade to older build, assert sane reads + byte-identical store).
+  newer build, write settings, downgrade to older build, assert sane reads + config values intact).
 - A targeted **enforcement sniff** (PHPCS/PHPStan) forbidding raw `config_*_path` on a registered
   key outside the gateway; wired into `phpcs.xml.dist` + CI; pinned by a fixture test.
 - Policy of record in `CLAUDE.md`; full suite green at every phase (`python -m pytest`,
@@ -211,7 +216,8 @@ contract, scoped per field by `since-version`:
 - **PHP** — tabs; PHP 8.3; uppercase `TRUE`/`FALSE`/`NULL` (ADR-28 sniff); no `die()`/`exit()` in
   library code; keep the PFBL-01 `RequirePfbFilter` sniff green; stub any newly-reached pfSense
   function from upstream.
-- **Hard-freeze** — never change a stored `config.xml` value/format (ADR-28 §2.2).
+- **Behaviour-preserving writes** — writes emit canonical (downgrade-safe) tokens; never a novel
+  on-disk token an older release would misread (ADR-28 §2.2).
 - **Clean the diff** — each phase minimal and intentional; no gratuitous reformatting of untouched
   lines; alignment opportunistic within touched blocks only.
 - **Plan with a higher model, implement with Sonnet** — each phase executed by a Sonnet sub-agent
@@ -255,7 +261,7 @@ Prompt: `03_Rollback_Contract.txt` — behaviour-preserving (tests + doc).
 
 - Encode each field's `since-version` and the forward+backward invariant (§2.3). Add off-box
   per-field rollback tests, and extend `tests/smoke/test_upgrade_config_stability.py` with a
-  **downgrade leg** (newer→older `pkg` install; assert sane reads + byte-identical store). Document
+  **downgrade leg** (newer→older `pkg` install; assert sane reads + config values preserved). Document
   any field excluded for rollback.
 
 ### Phase 4 — Route the high-risk seam: `pfb_global()` reads + the wipe + pre-deinstall
@@ -322,9 +328,10 @@ Prompt: `10_Smoke_And_Validation.txt` — the acceptance gate.
 - **Migration registry** reproduces the four legacy migrations' outcomes on representative install
   states (ordered, idempotent, run-once).
 - **Upgrade + rollback smoke green** on the live-VM fan-out: install older build → write a
-  representative settings spread → `pkg upgrade` to branch build → assert byte-identical store +
-  unchanged runtime behaviour (the #281 case); **and** the reverse downgrade leg → assert older code
-  reads sane values. No manual sign-off (CLAUDE.md "ADR acceptance").
+  representative settings spread → `pkg upgrade` to branch build → assert behaviour preserved
+  (canonical tokens round-trip; legacy tokens read correctly) + unchanged runtime behaviour (the
+  #281 case); **and** the reverse downgrade leg → assert older code reads sane values and config
+  values are intact. No manual sign-off (CLAUDE.md "ADR acceptance").
 - **Smoke fan-out (CE + Plus) + UI tiers green**; the enforcement sniff active and green.
 - **Residual manual check (owner: maintainer, out-of-CI):** true *visual* GUI correctness — a
   spot-check that the settings pages render unchanged. Documented out-of-CI limitation, not a

--- a/.ADRs/ADR_29_Config_Gateway/ADR.md
+++ b/.ADRs/ADR_29_Config_Gateway/ADR.md
@@ -150,8 +150,9 @@ contract, scoped per field by `since-version`:
 ### 2.5 Explicitly kept / out of scope
 
 - **`config.xml` stored format** — no versioned schema or migration pass (ADR-28 §2.2); the
-  gateway writes canonical (behaviour-equivalent) tokens; it never introduces a novel on-disk
-  token an older release would misread.
+  gateway writes canonical (behaviour-equivalent) tokens within each field's vocabulary. A newer
+  feature value (e.g. `'confusable'`) is naturally unknown to an older release, which degrades it
+  safely to off — it is never misread into a different setting.
 - **`py_unbound.ini`, manifests, and any serialized/wire value** read by Python or shell — those are
   generated artifacts / inter-process contracts, not `config.xml`; unchanged.
 - **Non-pfBlockerNG config** (`system/*`, `installedpackages/shellcmdsettings`, widgets sequence,
@@ -216,8 +217,9 @@ contract, scoped per field by `since-version`:
 - **PHP** — tabs; PHP 8.3; uppercase `TRUE`/`FALSE`/`NULL` (ADR-28 sniff); no `die()`/`exit()` in
   library code; keep the PFBL-01 `RequirePfbFilter` sniff green; stub any newly-reached pfSense
   function from upstream.
-- **Behaviour-preserving writes** — writes emit canonical (downgrade-safe) tokens; never a novel
-  on-disk token an older release would misread (ADR-28 §2.2).
+- **Behaviour-preserving writes** — writes emit canonical tokens from each field's vocabulary; an
+  older release either understands the token or degrades an unknown one safely to off — never a
+  misread into a different setting (ADR-28 §2.2).
 - **Clean the diff** — each phase minimal and intentional; no gratuitous reformatting of untouched
   lines; alignment opportunistic within touched blocks only.
 - **Plan with a higher model, implement with Sonnet** — each phase executed by a Sonnet sub-agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,41 +258,56 @@ Five conventions adopted as policy of record. Apply across the codebase in progr
 | 4 — string-ops over regex | `str_*`/`strpos`/`str_contains` over `preg_*` where equivalent; **hot loops first** | `str` methods over `re` in per-query/per-line paths | parameter-expansion / `case` over `grep -E`/`sed` where equivalent | `String.prototype` methods over `RegExp` |
 | 5 — uppercase `TRUE`/`FALSE` | **uppercase** literals | `True`/`False` (already correct) | N/A | `true`/`false` (JS is lowercase) |
 
-#### Config storage hard-freeze + field-aware adapter rule (ADR-28 §2.2)
+#### Config storage adapter rule — preserve behaviour on upgrade (ADR-28 §2.2)
 
-- **`config.xml` stored values never change** — every checkbox `'on'`/`''` and every option
-  string stays byte-identical across upgrade. No migration routine exists in this package.
-- Enums/booleans are an **internal runtime representation only**. Conversion at the
-  **read-boundary** (`pfb_global()` and sibling read sites): stored string → enum on read;
-  enum → the **exact same legacy stored string** on write.
-- A **backed enum's backing value equals the stored string** (`case On = 'on'`) so
-  `Enum::tryFrom($stored) ?? Enum::default()` is the read adapter and `$e->value` is the
-  write adapter. Where a field's "off" is `''` vs `'off'` the adapter is **field-aware** of
-  that exact legacy vocabulary — no single global toggle.
-- **Round-trip identity mandatory and pinned by tests**: `write(read(v)) == v` for every
-  existing stored value. A field that cannot round-trip losslessly is **excluded** (kept as
-  a string). The legacy `'on'` value for `pfb_idn` is the only known exception: it
-  normalises to `'all'` on read (one-way migration, intentional — `pfb_idn` is excluded from
-  enum adoption on the PHP side; see below).
-- **PHP adapters** (`pfb_cfg_toggle_read/write`, `pfb_cfg_lenient_read/write`,
-  `pfb_cfg_idn_mode_read/write`) in `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc`:
-  - **Adopted** (round-trip clean): `dnsbl_lenient` → `PfbLenient`; `dnsbl_vip_auto` and
-    ~76 other `'on'`/`''` checkbox fields read via `pfb_global()` → `PfbToggle`. Every
-    adapted field's full stored vocabulary passes `write(read(v)) == v`.
-  - **Excluded** (`pfb_idn` / config key `dnsbl_idn`): the stored vocabulary has a legacy
-    `'on'` value that cannot round-trip (it normalises to `'all'` on read); this field is
-    read/written as a plain string and **not** converted through `pfb_cfg_idn_mode_read/write`
-    on the PHP side. The `pfb_cfg_idn_mode_*` adapters exist but are not wired to this
-    config key to avoid the one-way migration.
-- **Python** (`pfb_unbound.py`): adopts the **`IdnMode` enum** internally — `pfb["idn_mode"]`
-  is converted from the ini string at the read boundary (preserving the legacy `python_idn`
-  fallback for absent/unrecognised keys; ini string contract unchanged). Toggle/lenient enums
-  have **no Python consumer** — `pfb_unbound.py` reads all boolean toggles via
-  `config.getboolean()` — so `PfbToggle`/`PfbLenient` are PHP-only adapters.
+- **Storage is NOT frozen — we keep it consistent for back-compat where practical, not byte-for-byte.**
+  There is no versioned migration routine. New options add new stored strings; the read-boundary
+  adapters absorb legacy tokens and writes emit a canonical token (which **may** differ from the
+  legacy one when **behaviour-equivalent**). The goal is to preserve *behaviour* on upgrade, not
+  bytes.
+- **Forward-compat (upgrade) has two cases:** an **existing config with the key absent** reads to a
+  value that **preserves that user's prior behaviour**; a **brand-new config** gets the **new
+  default**. When those differ, a one-time grandfather seed sets the key for existing installs at
+  upgrade (e.g. `pfb_rdns_seed_value`, `pfb_feed_filter_install_default`) so the absent-default
+  (= the new-install default) never silently changes an existing user's behaviour.
+- **Downgrade-tolerant.** Older releases string-compared these values, so an unknown token falls
+  through to that release's safe default. Reusing a legacy token as the canonical value (see
+  `pfb_idn`) keeps downgrade behaviour intact; a genuinely new token (e.g. `'confusable'`) simply
+  reads as off on an old release — acceptable, the feature didn't exist there.
+- Enums/booleans are the **internal runtime representation**. Conversion at the boundary:
+  stored string → enum on read; enum → canonical stored string on write.
+- **The enum owns its stored-value semantics** via the `PfbStoredEnum` interface +
+  `PfbStoredEnumAdapter` trait: `EnumClass::fromStored($raw)` (read) and `$enum->toStored()`
+  (write) — so the gateway and the `pfb_cfg_*` helpers stay trivial. The per-field **absent
+  default** is the registry's `$entry['default']` (applied by `PfbConfig::read()` *before* the
+  adapter); the enum's `default()` is only the **parse-fallback** for unknown/non-scalar
+  tokens, never the absent-default. A field's `''` vs `'off'` off-value is handled by its own enum.
+- **Round-trip pinned by tests** (`CfgAdaptersTest`, `RollbackContractTest`): every canonical
+  token round-trips (`write(read(v)) == v`); a legacy token reads to the right runtime value
+  and writes to its behaviour-equivalent canonical token (itself a legacy-valid token, so no
+  novel on-disk value reaches an older release).
+- **PHP adapters / enums** (`PfbToggle`, `PfbLenient`, `PfbIdnMode` + the thin
+  `pfb_cfg_*_read/write` delegations) in `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc`:
+  - `dnsbl_lenient` / `pfb_keep` → `PfbLenient` (`'on'`/`'off'`); `dnsbl_vip_auto` and ~76 other
+    `'on'`/`''` checkbox fields → `PfbToggle` (off-value `''`).
+  - **`pfb_idn` → `PfbIdnMode`** (registry adapters `pfb_cfg_idn_mode_read/write`): tokens
+    `'on'` (= All) / `'confusable'` / `'off'`. `All` **reuses the original `'on'`** block-all
+    token, so a pre-4.0.0 install round-trips with no migration *and* an older release reading
+    `'on'` still blocks all IDN. `PfbConfig::read('pfb_idn')` returns the enum;
+    `PfbConfig::write()` and the `py_unbound.ini` build both emit `toStored()`; consumers compare
+    `=== PfbIdnMode::All` / `::Confusable`. The 4.0.0-alpha-only `'all'` token is **not** carried
+    (alpha compatibility is intentionally not maintained) — it reads as Off. One canonical
+    vocabulary spans `config.xml`, the ini, and the Python `IdnMode` enum.
+- **Python** (`pfb_unbound.py`): the **`IdnMode` enum** shares that vocabulary — `All = 'on'`,
+  `Confusable = 'confusable'`, `Off = 'off'` — and reads the ini `idn_mode` token directly (the
+  legacy `python_idn` fallback is retained for a config predating the key). Toggle/lenient enums
+  have **no Python consumer** (`config.getboolean()` reads all bool toggles), so they are
+  PHP-only adapters.
 
 #### Explicitly out of scope (ADR-28 §2.4)
 
-- `config.xml` storage format — frozen, never migrated.
+- `config.xml` — no versioned schema or migration pass; legacy tokens are absorbed at the
+  read-boundary adapter and writes emit the canonical (behaviour-equivalent) token.
 - `py_unbound.ini` and any manifest / serialized / wire value read by Python or shell.
 - ADR-26 shell locale prefixes (`LC_ALL=C`) — untouched by shell phase.
 - Genuine boolean predicates (yes/no functions) — return `bool`, not an enum.
@@ -344,10 +359,12 @@ registered field, asserted per-field by `tests/php/RollbackContractTest.php`:
 - **FORWARD invariant** (old store → new code): `PfbConfig::read($key)` on any legacy stored
   token returns a well-formed runtime value — no crash, correct type, sane default for absent.
 - **BACKWARD invariant** (new code → old store → old code): `PfbConfig::write($key, $v)` only
-  ever emits a string that is a member of the field's **legacy stored vocabulary** — it never
-  introduces a novel on-disk token that an older release wouldn't understand. This is guaranteed
-  by construction: backed enums use their backing value (the exact legacy stored string), and
-  plain-string fields use identity adapters.
+  ever emits a token from the field's **known vocabulary** — never a novel on-disk token an
+  older release wouldn't understand. A write **may normalise** a legacy token to a
+  behaviour-equivalent canonical one (e.g. `pfb_idn`: `All` persists as the legacy-understood
+  `'on'`, and the dropped `'all'` normalises to `'off'`); the emitted token is always one an
+  older release string-compares correctly. Guaranteed by construction: backed enums emit
+  `toStored()` (a member of the vocabulary), and plain-string fields use identity adapters.
 
 **Scope limit (no versioned schema).** This is *not* full backward compatibility — that needs a
 versioned config schema this package deliberately lacks (ADR-28 §1.3). The invariants cover the
@@ -360,18 +377,16 @@ migration.
 
 **Field vocabularies** (`pfb_cfg_field_vocab()`):
 
-| Adapter type | Legacy stored vocabulary |
-| ------------ | ------------------------ |
+| Adapter type | Stored vocabulary |
+| ------------ | ----------------- |
 | `toggle`     | `{'on', ''}` |
 | `lenient`    | `{'on', 'off', ''}` — `''` is a LEGACY READ token (pre-ADR-22 absent); write emits `'off'` |
+| `idn`        | write `{'on' (=All), 'confusable', 'off'}`; legacy reads `'all'`→Off, `''`→Off (4.0.0-alpha `'all'` not carried) |
 | `plain`      | identity — any stored value passes through unchanged |
 
-**Excluded fields** — backward-safe at the `PfbConfig` level (no novel token risk); documented
-exclusions from adapter adoption per ADR-28 §2.2:
-
-- **`pfb_idn`** — uses `NULL`/`NULL` adapters (identity). The `'on'→'all'` normalisation
-  happens only at the `pfb_global()` seam outside `PfbConfig`. All stored tokens (`'on'`,
-  `'all'`, `'confusable'`, `'off'`, `''`) round-trip unchanged through the gateway.
+**Excluded fields** — none. `pfb_idn` was previously excluded (`NULL`/`NULL` identity adapters);
+it is now adopted as `PfbIdnMode` (see ADR-28 §2.2 above). `All` reuses the legacy `'on'` token,
+so the adoption is migration-free and downgrade-safe.
 
 **Since-version convention:**
 
@@ -385,8 +400,9 @@ registry, the earliest still-shipped release is the baseline (`'1.0.0'` for orig
 
 `tests/smoke/test_upgrade_config_stability.py::test_pkg_downgrade_preserves_config_values`
 carries the `repo` marker (deselected from `-m smoke`). Install HIGHER build → write config →
-downgrade to LOWER build via `pkg delete` + reinstall → assert byte-identical store AND DNSBL
-probe still returns VIP. Skips cleanly when `SMOKE_PKG`/`repo_vm` is absent.
+downgrade to LOWER build via `pkg delete` + reinstall → assert the stored config values are
+preserved (sane reads, behaviour intact) AND the DNSBL probe still returns VIP. Skips cleanly
+when `SMOKE_PKG`/`repo_vm` is absent.
 
 **Foreign-key exclusion list (use `config_*_path` directly — NOT via `PfbConfig`):**
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1664,15 +1664,15 @@ def init_standard(id: int, env: module_env) -> bool:
 # a three-valued mode so a later phase can add a surgical cross-script-homoglyph tier
 # without disturbing the two behaviour-preserving modes:
 #   IDN_MODE_OFF        -- the IDN feed never fires (every xn-- query resolves normally).
-#   IDN_MODE_ALL        -- TODAY'S behaviour: EVERY xn-- query is blocked as feed="IDN"
-#                          (pure prefix match, no punycode decode).
-#   IDN_MODE_CONFUSABLE  -- reserved for the Phase-5 TR39 mixed-script analyzer. INERT
-#                          this phase: behaves exactly like OFF until the analyzer is wired
-#                          (no decode, no script work, no block).
-# Migration (RESULTS/01 SS1): the PHP ini still writes only python_idn=on|off, so 'on'
-# maps to IDN_MODE_ALL and off/absent to IDN_MODE_OFF -- byte-identical to today.
+#   IDN_MODE_ALL        -- block EVERY xn-- query as feed="IDN" (pure prefix match, no
+#                          punycode decode). Token "on" (reused from the pre-ADR-08 binary
+#                          IDN toggle): the PHP gateway, py_unbound.ini, and this enum all
+#                          share the one vocabulary 'on'|'confusable'|'off' (ADR-28).
+#   IDN_MODE_CONFUSABLE  -- the TR39 mixed-script analyzer tier.
+# Legacy: a config predating the idn_mode key (only python_idn=on|off) still maps via
+# idn_mode_from_legacy() -- on->All, off/absent->Off.
 IDN_MODE_OFF = "off"
-IDN_MODE_ALL = "all"
+IDN_MODE_ALL = "on"
 IDN_MODE_CONFUSABLE = "confusable"
 
 
@@ -1688,9 +1688,14 @@ IDN_MODE_CONFUSABLE = "confusable"
 
 
 class IdnMode(Enum):
-    """IDN-feature mode selector (ADR-08 §2.2, backed by canonical stored string)."""
+    """IDN-feature mode selector (ADR-08 §2.2, backed by canonical stored string).
 
-    All = "all"
+    The backing values are the single shared vocabulary used by config.xml, py_unbound.ini,
+    and the PHP PfbIdnMode enum: All reuses the legacy 'on' token (block-all-IDN), so a
+    pre-4.0.0 install round-trips with no migration.
+    """
+
+    All = "on"
     Confusable = "confusable"
     Off = "off"
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1664,8 +1664,8 @@ function pfb_global() {
 	$pfb['dnsbl_py_reply']	= $pfb['dnsblconfig']['pfb_py_reply'];			// DNSBL Resolver python DNS Reply logging
 	$pfb['dnsbl_hsts']	= PfbConfig::read('pfb_hsts')->value;			// DNSBL Resolver python block HSTS via Null Blocking mode
 	// ADR-08: IDN mode selector. PfbConfig::read() returns a PfbIdnMode enum via the
-	// registry adapter: legacy 'on' -> All (preserves block-all-IDN on upgrade);
-	// 'all' -> All; 'confusable' -> Confusable; '' / 'off' / absent -> Off. Downstream
+	// registry adapter: 'on' -> All (preserves block-all-IDN on upgrade); 'confusable'
+	// -> Confusable; '' / 'off' / absent / the dropped 4.0.0-alpha 'all' -> Off. Downstream
 	// consumers compare against the enum; the ini build serialises the canonical token.
 	$pfb['dnsbl_idn']	= PfbConfig::read('pfb_idn');				// DNSBL Resolver python IDN mode (PfbIdnMode enum)
 	$pfb['dnsbl_idn_block_malicious']	= PfbConfig::read('pfb_idn_block_malicious');		// Confusable: block malicious homoglyphs (default 'on')

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1659,16 +1659,15 @@ function pfb_global() {
 	// ADR-22: lenient feed parsing. 'on' = permissive scheme strip (today); anything else =
 	// strict RFC 3986 scheme validation + URL-path rejection. New installs default OFF
 	// (strict); existing installs are migrated to 'on' on upgrade (pfb_dnsbl_lenient_migrate).
-	$pfb['dnsbl_lenient']	= PfbConfig::read('pfb_dnsbl_lenient')->value;						// DNSBL scheme-parsing leniency
+	$pfb['dnsbl_lenient']	= PfbConfig::read('pfb_dnsbl_lenient');							// DNSBL scheme-parsing leniency (PfbLenient enum)
 
 	$pfb['dnsbl_py_reply']	= $pfb['dnsblconfig']['pfb_py_reply'];			// DNSBL Resolver python DNS Reply logging
 	$pfb['dnsbl_hsts']	= PfbConfig::read('pfb_hsts')->value;			// DNSBL Resolver python block HSTS via Null Blocking mode
-	// ADR-08: IDN mode selector (off | all | confusable). Legacy on/off migrates:
-	// 'on' -> 'all' (today's block-all-IDN). Downstream consumers see the normalized value.
-	// Null-coalesce the source: a config predating the key (dnsblconfig loaded via
-	// config_get_path(..., [])) must read as '' (Off) without an undefined-key warning.
-	$pfb_idn_raw		= PfbConfig::read('pfb_idn');
-	$pfb['dnsbl_idn']	= ($pfb_idn_raw === 'on') ? 'all' : $pfb_idn_raw;	// DNSBL Resolver python IDN mode (legacy 'on' -> 'all')
+	// ADR-08: IDN mode selector. PfbConfig::read() returns a PfbIdnMode enum via the
+	// registry adapter: legacy 'on' -> All (preserves block-all-IDN on upgrade);
+	// 'all' -> All; 'confusable' -> Confusable; '' / 'off' / absent -> Off. Downstream
+	// consumers compare against the enum; the ini build serialises the canonical token.
+	$pfb['dnsbl_idn']	= PfbConfig::read('pfb_idn');				// DNSBL Resolver python IDN mode (PfbIdnMode enum)
 	$pfb['dnsbl_idn_block_malicious']	= PfbConfig::read('pfb_idn_block_malicious');		// Confusable: block malicious homoglyphs (default 'on')
 	$pfb['dnsbl_idn_escalate_suspicious']	= PfbConfig::read('pfb_idn_escalate_suspicious');	// Confusable: escalate suspicious mixed-script to block (opt-in)
 	$pfb['dnsbl_regex']	= $pfb['dnsblconfig']['pfb_regex'];			// DNSBL Resolver python regex
@@ -5476,11 +5475,13 @@ function pfb_unbound_python($mode) {
 		// ADR-08: emit the IDN mode + the legacy python_idn flag + the Confusable sub-toggles.
 		// python_idn = on ONLY for All-IDN, so the legacy flag (and its blacklist side-effect)
 		// stays byte-identical to today; Confusable rides the explicit idn_mode key instead.
-		$idn_mode = in_array($pfb['dnsbl_idn'], array('all', 'confusable'), TRUE) ? $pfb['dnsbl_idn'] : 'off';
-		$python_idn = ($idn_mode == 'all') ? 'on' : 'off';
+		// py_unbound.ini IDN mode: the SAME canonical token as config.xml (toStored):
+		// 'on' (= All) | 'confusable' | 'off'. The Python IdnMode enum reads it directly.
+		$idn_mode = $pfb['dnsbl_idn']->toStored();
+		$python_idn = ($pfb['dnsbl_idn'] === PfbIdnMode::All) ? 'on' : 'off';
 
-		$python_idn_block_malicious = ($pfb['dnsbl_idn_block_malicious'] == 'on') ? 'on' : 'off';
-		$python_idn_escalate_suspicious = ($pfb['dnsbl_idn_escalate_suspicious'] == 'on') ? 'on' : 'off';
+		$python_idn_block_malicious = (pfb_cfg_toggle_read($pfb['dnsbl_idn_block_malicious']) === PfbToggle::On) ? 'on' : 'off';
+		$python_idn_escalate_suspicious = (pfb_cfg_toggle_read($pfb['dnsbl_idn_escalate_suspicious']) === PfbToggle::On) ? 'on' : 'off';
 
 		$python_cname = 'off';
 		if ($pfb['dnsbl_cname'] == 'on') {
@@ -12266,7 +12267,7 @@ function sync_package_pfblockerng($cron='') {
 												// scheme against RFC 3986 and rejects URL paths -- a rejected
 												// line is skipped, recorded per-line in the parse-error log, and
 												// counted for the once-per-feed summary WARNING below.
-												$strict = ($pfb['dnsbl_lenient'] !== 'on');
+												$strict = ($pfb['dnsbl_lenient'] !== PfbLenient::On);
 												$line = pfb_dnsbl_scheme_line($line, $strict, $header, $oline,
 													$pfb['dnsbl_parse_err'], $pfb_scheme_skipped);
 												if ($line === FALSE) {
@@ -12549,12 +12550,12 @@ function sync_package_pfblockerng($cron='') {
 		// DNSBL_IDN alias exactly as before; Confusable mode surfaces the homoglyph +
 		// suspect groups so the Reports/Alerts pages render their counts. Counts are
 		// symbolic (=1) markers -- the Python matcher decides per-query at runtime.
-		if ($pfb['dnsbl_idn'] == 'all') {
+		if ($pfb['dnsbl_idn'] === PfbIdnMode::All) {
 			$idn_cnt = 1;
 			$pfb['alias_dnsbl_all'][] = 'DNSBL_IDN';
 			dnsbl_alias_update('update', 'DNSBL_IDN', '', '', $idn_cnt);
 		}
-		elseif ($pfb['dnsbl_idn'] == 'confusable') {
+		elseif ($pfb['dnsbl_idn'] === PfbIdnMode::Confusable) {
 			$pfb['alias_dnsbl_all'][] = 'DNSBL_Homoglyph';
 			dnsbl_alias_update('update', 'DNSBL_Homoglyph', '', '', 1);
 			$pfb['alias_dnsbl_all'][] = 'DNSBL_Homoglyph_Suspect';

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -35,10 +35,10 @@
 //
 // Policy (ADR-28 §2.2, reframed): the goal is PRESERVE BEHAVIOUR ON UPGRADE, not
 // byte-identical storage. A write may persist a normalised canonical token when it
-// is behaviour-equivalent to the legacy one (e.g. pfb_idn 'on' -> 'all', which
-// reproduces the prior block-all-IDN behaviour). Downgrade is tolerated: older
-// releases string-compared these values, so an unknown token falls through to the
-// safe default there.
+// is behaviour-equivalent to the legacy one (e.g. pfb_idn All persists the legacy
+// 'on' token, reproducing the prior block-all-IDN behaviour). Downgrade is tolerated:
+// older releases string-compared these values, so an unknown token falls through to
+// the safe default there.
 //
 // Tests: tests/php/CfgAdaptersTest.php, tests/php/RollbackContractTest.php.
 // Naming follows pfb_* conventions (CLAUDE.md "Naming").
@@ -196,8 +196,8 @@ function pfb_cfg_idn_mode_read(mixed $stored): PfbIdnMode
 
 /**
  * Write a PfbIdnMode (enum or legacy string) back to its canonical stored token
- * ('all' | 'confusable' | 'off'). Legacy 'on' normalises to 'all' (one-way; it
- * reproduces the prior block-all-IDN behaviour on upgrade).
+ * ('on' | 'confusable' | 'off'). All persists as the legacy 'on' token (reproduces
+ * the prior block-all-IDN behaviour); the 4.0.0-alpha 'all' token is dropped to 'off'.
  */
 function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 {
@@ -1259,11 +1259,11 @@ function pfb_run_migrations(): void
 //     field's legacy stored vocabulary.  The gateway always writes legacy
 //     tokens, so downgrades leave older code reading values it already
 //     understands.
-//   - A field EXCLUDED from backward-safety testing is one where write()
-//     CANNOT guarantee a legacy token — those are excluded from adapter
-//     adoption entirely (like pfb_idn's 'on'→'all' normalisation at the
-//     pfb_global() seam, which bypasses PfbConfig).  At the PfbConfig level,
-//     no field is excluded because all write adapters emit legacy tokens.
+//   - At the PfbConfig level no field is excluded: every write adapter emits a
+//     token from the field's known vocabulary. A write may NORMALISE a legacy
+//     token to a behaviour-equivalent canonical one (e.g. pfb_idn: All persists
+//     the legacy 'on' token, and the dropped 4.0.0-alpha 'all' normalises to
+//     'off') — the emitted token is always one an older release understands.
 //
 // SINCE-VERSION CONVENTION:
 //   The 'since' field in pfb_cfg_registry() records the package release that
@@ -1297,9 +1297,10 @@ function pfb_run_migrations(): void
  *   'lenient' — PfbLenient fields: 'on' | 'off' | '' ('' = pre-ADR-22 absent).
  *   'plain'   — null/null adapters: any string; identity through (no novel token).
  *
- * The idn-mode adapter (pfb_cfg_idn_mode_read/write) is NOT wired at PfbConfig
- * level for pfb_idn (excluded; legacy 'on' cannot round-trip through the adapter
- * without normalisation — pfb_idn uses null adapters and is backward-safe as-is).
+ * The idn-mode adapter (pfb_cfg_idn_mode_read/write) IS wired at PfbConfig level
+ * for pfb_idn. All canonicalises to the legacy 'on' token, so writes only emit the
+ * idn vocabulary ('on'|'confusable'|'off'); the dropped 4.0.0-alpha 'all' token is
+ * read as Off and never written.
  *
  * @return array<string,list<string>>
  */

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -23,33 +23,82 @@
 // This file is used to 'include functions' not yet merged into pfSense
 
 // ---------------------------------------------------------------------------
-// ADR-28 Phase 1 — field-aware config adapters.
+// ADR-28 — config field enums + the PfbStoredEnum adapter contract.
 //
-// Internal backed enums for recurring config flags + field-aware read/write
-// adapter helpers.  Rule (ADR-28 §2.2):
-//   - config.xml stored values NEVER change (no migration routine exists).
-//   - Enums are an INTERNAL runtime representation only.
-//   - read adapter: Enum::tryFrom($stored) ?? Enum::default()
-//   - write adapter: $enum->value  (equals the exact legacy stored string)
-//   - A field whose "off" is '' for one field and 'off' for another uses a
-//     FIELD-SPECIFIC default — there is no single global toggle.
+// Backed string enums for recurring config flags. Each enum OWNS its stored-value
+// semantics (the PfbStoredEnum interface + PfbStoredEnumAdapter trait) so the
+// PfbConfig gateway and the pfb_cfg_* helpers stay trivial:
+//   - read : EnumClass::fromStored($raw)   — the NULL/absent default is the registry's
+//             $entry['default'] (applied by PfbConfig::read() BEFORE the adapter);
+//             '', legacy aliases, and junk are resolved by the enum itself.
+//   - write: $enum->toStored()             — the canonical persisted token.
 //
-// Round-trip tests: tests/php/CfgAdaptersTest.php.
+// Policy (ADR-28 §2.2, reframed): the goal is PRESERVE BEHAVIOUR ON UPGRADE, not
+// byte-identical storage. A write may persist a normalised canonical token when it
+// is behaviour-equivalent to the legacy one (e.g. pfb_idn 'on' -> 'all', which
+// reproduces the prior block-all-IDN behaviour). Downgrade is tolerated: older
+// releases string-compared these values, so an unknown token falls through to the
+// safe default there.
+//
+// Tests: tests/php/CfgAdaptersTest.php, tests/php/RollbackContractTest.php.
 // Naming follows pfb_* conventions (CLAUDE.md "Naming").
 // ---------------------------------------------------------------------------
 
-// PfbToggle — checkbox fields stored as 'on' (checked) or '' (unchecked).
-//
-// Used by: pfb_dnsvip_auto (pfb_dnsblconfig['pfb_dnsvip_auto']).
-//   Stored vocabulary: 'on' | '' (missing/unchecked = '').
-//   pfb_global() normalisation at :1334:
-//     pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_dnsvip_auto'] ?? '')->value
-enum PfbToggle: string
+// PfbStoredEnum — the contract every config-backed enum implements. Keeps the
+// reader/writer dumb: read = EnumClass::fromStored($raw), write = $enum->toStored().
+interface PfbStoredEnum
 {
+	// Parse-fallback for unknown/non-scalar input. NOT the per-field absent default
+	// (that is the registry's $entry['default'], applied by PfbConfig::read()).
+	public static function default(): static;
+
+	// Stored config value (string, NULL, or non-scalar) -> enum. The enum owns its
+	// '' (EMPTY), legacy-alias, and junk handling.
+	public static function fromStored(mixed $stored): static;
+
+	// Enum -> the canonical token persisted to config.xml / py_unbound.ini.
+	public function toStored(): string;
+}
+
+// PfbStoredEnumAdapter — shared fromStored/toStored mechanics. An enum customises
+// its semantics by setting default() (fallback) and overriding fromLegacy() (aliases).
+trait PfbStoredEnumAdapter
+{
+	public static function fromStored(mixed $stored): static
+	{
+		if (!is_scalar($stored) && $stored !== NULL) {
+			return static::default();		// subtree / non-scalar guard
+		}
+		// NULL collapses to '' here — a gateway read has already applied the registry
+		// per-field default, so NULL only reaches this path from direct callers.
+		$raw = (string) ($stored ?? '');
+		return self::tryFrom($raw) ?? static::fromLegacy($raw);
+	}
+
+	// '' (EMPTY) and any non-canonical token. Override per enum for legacy aliases.
+	protected static function fromLegacy(string $raw): static
+	{
+		return static::default();
+	}
+
+	public function toStored(): string
+	{
+		return $this->value;
+	}
+}
+
+// PfbToggle — checkbox fields stored as 'on' (checked) or '' (unchecked).
+//   Stored vocabulary: 'on' | '' (missing/unchecked = ''). '' is the Off case, so
+//   tryFrom('') resolves it directly; the per-field absent default is the registry's.
+enum PfbToggle: string implements PfbStoredEnum
+{
+	use PfbStoredEnumAdapter;
+
 	case On  = 'on';
 	case Off = '';
 
-	public static function default(): self
+	// Parse-fallback ONLY (unknown/non-scalar -> "not On"). NOT the absent default.
+	public static function default(): static
 	{
 		return self::Off;
 	}
@@ -61,161 +110,98 @@ enum PfbToggle: string
 // Used by: pfb_dnsbl_lenient (pfb_dnsblconfig['pfb_dnsbl_lenient'], ADR-22 scheme-parsing
 //   leniency) and pfb_keep (#484 — so a default-on keep flag can store 'off' explicitly).
 //   Stored vocabulary: 'on' | 'off' | '' (legacy: a missing pre-ADR-22 / pre-#484 install).
-//   pfb_global() normalisation at :1364:
-//     pfb_cfg_lenient_read($pfb['dnsblconfig']['pfb_dnsbl_lenient'] ?? '')->value
+//   pfb_global() reads pfb_dnsbl_lenient as a PfbLenient enum via PfbConfig::read()
+//   (the registry wires pfb_cfg_lenient_read/write); consumers compare === PfbLenient::On.
 //   Note: '' (missing key) maps to Off ('off'), NOT to the PfbToggle '' value.
 //   This field's "off" stored value is 'off', distinct from PfbToggle::Off = ''.
-enum PfbLenient: string
+enum PfbLenient: string implements PfbStoredEnum
 {
+	use PfbStoredEnumAdapter;
+
 	case On  = 'on';
 	case Off = 'off';
 
-	public static function default(): self
+	// NULL/absent -> registry default; '' (legacy missing) and junk -> Off (via fromLegacy).
+	public static function default(): static
 	{
 		return self::Off;
 	}
 }
 
-// PfbIdnMode — ADR-08 IDN-feature mode selector.
+// PfbIdnMode — ADR-08 IDN-feature mode selector. Adopted into the PfbConfig gateway.
 //
-// Used by: dnsbl_idn (pfb_dnsblconfig['pfb_idn']).
-//   Stored vocabulary: 'all' | 'confusable' | 'off' | '' | 'on' (legacy).
-//   pfb_global() :1372-1373 passes the raw value through unchanged EXCEPT
-//   for the legacy 'on' -> 'all' migration.  Because '' passes through as ''
-//   (not 'off'), the seam for dnsbl_idn is kept as-is (excluded from adapter
-//   adoption); PfbIdnMode is still used via the adapter at call sites that
-//   need the normalised canonical value — see ADR-28 Phase 4 handoff.
-//   IMPORTANT: 'on' is a LEGACY stored value — new saves always write 'all'.
-//   The adapter read fn below replicates the pfb_global() normalisation so
-//   downstream code sees the canonical value ('all'/'off'/'confusable').
-//   The write fn returns the canonical stored string (never 'on').
-//   Round-trip note: read('on') -> All -> write -> 'all' != 'on'.
-//   This is the INTENDED behaviour: the legacy value is normalised on read
-//   and the canonical value is stored on write (a one-way migration for 'on').
-//   This field is therefore EXCLUDED from write(read(v))==v for v='on' only;
-//   all other values round-trip losslessly.  Documented in 01_Results.txt.
-enum PfbIdnMode: string
+// Used by: pfb_idn (config key) / $pfb['dnsbl_idn'] (runtime).
+//   Canonical tokens (config.xml AND py_unbound.ini AND the Python IdnMode enum, all the
+//   same vocabulary): 'on' (= All), 'confusable', 'off'. '' / unknown -> Off.
+//   Reusing the original 'on' token for All is the key move — pre-4.0.0 installs round-trip
+//   with no migration and an older release reading 'on' still blocks all IDN (behaviour
+//   preserved on downgrade). 'confusable' is the only genuinely new token; an old release
+//   treats it as off (acceptable). PfbConfig::read('pfb_idn') returns the enum;
+//   PfbConfig::write() persists toStored(); the ini build emits the same toStored() token.
+enum PfbIdnMode: string implements PfbStoredEnum
 {
-	case All        = 'all';
+	use PfbStoredEnumAdapter;
+
+	// All reuses the original 'on' token (pre-ADR-08 block-all-IDN) as its backing value:
+	// it round-trips with ZERO migration AND is downgrade-safe — an older release reading
+	// 'on' still blocks all IDN. Only Confusable is a genuinely new token (an old release
+	// treats it as off, which is acceptable). The SAME token feeds config.xml, py_unbound.ini,
+	// and the Python IdnMode enum — one canonical vocabulary, no per-consumer serialisation.
+	case All        = 'on';
 	case Confusable = 'confusable';
 	case Off        = 'off';
 
-	public static function default(): self
+	// Parse-fallback (unknown / '' -> Off via the trait); the per-field absent default is
+	// the registry's. No legacy alias: the only other historical token was the 4.0.0-alpha
+	// 'all', and breaking alpha-only compatibility is acceptable.
+	public static function default(): static
 	{
 		return self::Off;
 	}
 }
 
-/**
- * pfb_cfg_toggle_read — read a PfbToggle from a raw stored value.
- *
- * Maps 'on' -> On, anything else -> Off (matches pfb_global() :1334 logic).
- *
- * @param mixed $stored  Raw value from config_get_path / $pfb['dnsblconfig'][...].
- */
+// Thin delegations to the enum adapters (PfbStoredEnum::fromStored / toStored).
+// Kept so the registry callables + the direct www/ callers have a free-function
+// handle; all semantics live on the enums.
+
+/** Read a PfbToggle from a raw stored value. */
 function pfb_cfg_toggle_read(mixed $stored): PfbToggle
 {
-	if (!is_scalar($stored) && $stored !== null) {
-		return PfbToggle::default();
-	}
-	return PfbToggle::tryFrom((string) ($stored ?? '')) ?? PfbToggle::default();
+	return PfbToggle::fromStored($stored);
 }
 
-/**
- * pfb_cfg_toggle_write — write a PfbToggle back to its stored string.
- *
- * Returns the exact legacy stored string ('on' or '').  Accepts either the
- * runtime enum or a raw legacy string (normalised through the read adapter),
- * matching the PfbConfig::write() "enum or string" contract.
- *
- * @param PfbToggle|string $toggle  Runtime enum or raw stored string.
- */
+/** Write a PfbToggle (enum or legacy string) back to its stored string. */
 function pfb_cfg_toggle_write(PfbToggle|string $toggle): string
 {
-	if (is_string($toggle)) {
-		$toggle = pfb_cfg_toggle_read($toggle);
-	}
-	return $toggle->value;
+	return ($toggle instanceof PfbToggle ? $toggle : PfbToggle::fromStored($toggle))->toStored();
 }
 
-/**
- * pfb_cfg_lenient_read — read a PfbLenient from a raw stored value.
- *
- * Maps 'on' -> On, anything else (incl. '', missing, 'off') -> Off.
- * Replicates pfb_global() :1364 normalisation.
- *
- * @param mixed $stored  Raw value from config_get_path / $pfb['dnsblconfig'][...].
- */
+/** Read a PfbLenient from a raw stored value. */
 function pfb_cfg_lenient_read(mixed $stored): PfbLenient
 {
-	if (!is_scalar($stored) && $stored !== null) {
-		return PfbLenient::default();
-	}
-	if ((string) ($stored ?? '') === 'on') {
-		return PfbLenient::On;
-	}
-	return PfbLenient::default();
+	return PfbLenient::fromStored($stored);
 }
 
-/**
- * pfb_cfg_lenient_write — write a PfbLenient back to its stored string.
- *
- * Returns 'on' or 'off' (never '').  Accepts either the runtime enum or a raw
- * legacy string (normalised through the read adapter), matching the
- * PfbConfig::write() "enum or string" contract.
- *
- * @param PfbLenient|string $lenient  Runtime enum or raw stored string.
- */
+/** Write a PfbLenient (enum or legacy string) back to its stored string. */
 function pfb_cfg_lenient_write(PfbLenient|string $lenient): string
 {
-	if (is_string($lenient)) {
-		$lenient = pfb_cfg_lenient_read($lenient);
-	}
-	return $lenient->value;
+	return ($lenient instanceof PfbLenient ? $lenient : PfbLenient::fromStored($lenient))->toStored();
 }
 
-/**
- * pfb_cfg_idn_mode_read — read a PfbIdnMode from a raw stored value.
- *
- * Replicates pfb_global() :1372-1373 normalisation:
- *   'on'         -> All (legacy migration — new saves write 'all')
- *   'all'        -> All
- *   'confusable' -> Confusable
- *   anything else (incl. '', 'off', missing) -> Off
- *
- * @param mixed $stored  Raw value from config_get_path / $pfb['dnsblconfig'][...].
- */
+/** Read a PfbIdnMode from a raw stored value (legacy 'on' -> All). */
 function pfb_cfg_idn_mode_read(mixed $stored): PfbIdnMode
 {
-	if (!is_scalar($stored) && $stored !== null) {
-		return PfbIdnMode::default();
-	}
-	$raw = (string) ($stored ?? '');
-	if ($raw === 'on') {
-		// Legacy: 'on' migrates to All at runtime; canonical stored value is 'all'.
-		return PfbIdnMode::All;
-	}
-	return PfbIdnMode::tryFrom($raw) ?? PfbIdnMode::default();
+	return PfbIdnMode::fromStored($stored);
 }
 
 /**
- * pfb_cfg_idn_mode_write — write a PfbIdnMode back to its stored string.
- *
- * Returns the canonical stored string ('all', 'confusable', or 'off').
- * NOTE: 'on' (legacy) is never re-emitted; it normalises to 'all' on read
- * and is stored as 'all' on write.  This is the intended one-way migration.
- *
- * Accepts either the runtime enum or a raw legacy string (normalised through
- * the read adapter), matching the PfbConfig::write() "enum or string" contract.
- *
- * @param PfbIdnMode|string $mode  Runtime enum or raw stored string.
+ * Write a PfbIdnMode (enum or legacy string) back to its canonical stored token
+ * ('all' | 'confusable' | 'off'). Legacy 'on' normalises to 'all' (one-way; it
+ * reproduces the prior block-all-IDN behaviour on upgrade).
  */
 function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 {
-	if (is_string($mode)) {
-		$mode = pfb_cfg_idn_mode_read($mode);
-	}
-	return $mode->value;
+	return ($mode instanceof PfbIdnMode ? $mode : PfbIdnMode::fromStored($mode))->toStored();
 }
 
 // ---------------------------------------------------------------------------
@@ -656,15 +642,18 @@ function pfb_cfg_registry(): array
 			'since'         => '3.0.0',
 		],
 
-		// ADR-08: IDN mode — EXCLUDED from adapter adoption (legacy 'on' cannot
-		// round-trip; write(read('on')) == 'all' != 'on'). Kept as plain string.
-		// The pfb_cfg_idn_mode_read/write adapters exist but are NOT wired here.
-		// See ADR-28 §2.2 + CfgAdaptersTest testIdnModeLegacyOnNormalisesToAll.
+		// ADR-08: IDN mode — adopted into the gateway as a PfbIdnMode enum (ADR-28
+		// reframe: preserve behaviour on upgrade, not byte-identical storage). Read
+		// normalises legacy 'on' -> All; write persists the canonical token
+		// ('all'|'confusable'|'off'), so a stored legacy 'on'/'' migrates on next save
+		// to a behaviour-equivalent value. Downgrade-safe: older releases string-compared
+		// these tokens, so an unknown token falls through to their off default.
+		// See ADR-28 §2.2 + CfgAdaptersTest + RollbackContractTest.
 		'pfb_idn' => [
 			'section'       => $dnsbl,
 			'default'       => '',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_idn_mode_read',
+			'write_adapter' => 'pfb_cfg_idn_mode_write',
 			'since'         => '3.0.0',
 		],
 
@@ -1327,6 +1316,12 @@ function pfb_cfg_field_vocab(): array
 		// older release that reads 'off' treats it as "disabled", which is correct.
 		'lenient' => ['on', 'off', ''],
 
+		// IDN mode (PfbIdnMode): the tokens a write can emit. 'on' = All (reuses the
+		// pre-4.0.0 block-all token, so it round-trips and an older release still blocks
+		// all IDN), 'confusable', 'off'. Legacy reads '' / 'all' (4.0.0-alpha) -> Off, but
+		// neither is ever WRITTEN, so they are not in the backward (write) vocabulary.
+		'idn'     => ['on', 'confusable', 'off'],
+
 		// Plain string (null/null adapters): identity. Backward-safe by construction.
 		// The 'plain' vocabulary contains the sentinel empty string; individual
 		// field values are arbitrary strings (numeric, named option, etc.) but the
@@ -1352,6 +1347,9 @@ function pfb_cfg_field_adapter_type(array $entry): string
 	}
 	if ($read === 'pfb_cfg_lenient_read') {
 		return 'lenient';
+	}
+	if ($read === 'pfb_cfg_idn_mode_read') {
+		return 'idn';
 	}
 	// All other adapters are toggle (pfb_cfg_toggle_read).
 	return 'toggle';

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -58,14 +58,10 @@ $pconfig['pfb_cache']		= isset($pfb['dconfig']['pfb_cache'])			? $pfb['dconfig']
 
 $pconfig['pfb_py_reply']	= isset($pfb['dconfig']['pfb_py_reply'])		? $pfb['dconfig']['pfb_py_reply'] : 'on';
 $pconfig['pfb_hsts']		= isset($pfb['dconfig']['pfb_hsts'])			? $pfb['dconfig']['pfb_hsts'] : 'on';
-// ADR-08: IDN mode selector (Off | All-IDN | Confusable). Legacy on/off migrates:
-// 'on' -> 'all' (today's block-all-IDN), empty/'off' -> '' (Off).
-$pconfig['pfb_idn']		= $pfb['dconfig']['pfb_idn']				?: '';
-if ($pconfig['pfb_idn'] === 'on') {
-	$pconfig['pfb_idn'] = 'all';
-} elseif ($pconfig['pfb_idn'] === 'off') {
-	$pconfig['pfb_idn'] = '';
-}
+// ADR-08: IDN mode selector (Off | All-IDN | Confusable). PfbConfig::read() returns a
+// PfbIdnMode enum (legacy 'on'/'all' -> All, '' -> Off); toStored() gives the canonical
+// config token ('on' | 'confusable' | 'off') that the <select> options below carry.
+$pconfig['pfb_idn']		= PfbConfig::read('pfb_idn')->toStored();
 // Confusable-mode sub-toggles: block clearly-malicious homoglyphs is default-on;
 // escalate suspicious mixed-script (else alert only) is opt-in (default off).
 // Default 'on' owned by the registry (ADR-29); PfbConfig::read applies it when absent.
@@ -763,13 +759,10 @@ if ($_POST) {
 
 			$pfb['dconfig']['pfb_py_reply']		= pfb_filter($_POST['pfb_py_reply'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_hsts']		= pfb_filter($_POST['pfb_hsts'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
-			// ADR-08: IDN mode selector. Validate the raw word, migrate legacy 'on' -> 'all',
-			// then whitelist to Off ('') | All-IDN ('all') | Confusable ('confusable').
+			// ADR-08: IDN mode selector. Validate the raw word, then canonicalise via the
+			// PfbIdnMode adapter to the stored config token ('on' = All | 'confusable' | 'off').
 			$pfb_idn_mode = pfb_filter($_POST['pfb_idn'], PFB_FILTER_WORD, 'dnsbl');
-			if ($pfb_idn_mode === 'on') {
-				$pfb_idn_mode = 'all';
-			}
-			$pfb['dconfig']['pfb_idn']		= in_array($pfb_idn_mode, array('all', 'confusable'), TRUE) ? $pfb_idn_mode : '';
+			$pfb['dconfig']['pfb_idn']		= pfb_cfg_idn_mode_write($pfb_idn_mode);
 			$pfb['dconfig']['pfb_idn_block_malicious']	= pfb_filter($_POST['pfb_idn_block_malicious'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_idn_escalate_suspicious']	= pfb_filter($_POST['pfb_idn_escalate_suspicious'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_regex']		= pfb_filter($_POST['pfb_regex'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
@@ -2692,9 +2685,9 @@ $section->addInput(new Form_Select(
 	gettext('IDN Blocking'),
 	$pconfig['pfb_idn'],
 	array(
-		''		=> 'Off',
+		'off'		=> 'Off',
 		'confusable'	=> 'Confusable',
-		'all'		=> 'Always',
+		'on'		=> 'Always',
 	)
 ))->setHelp('IDN handling (not Regex based).<ul>'
 		. '<li><strong>Off</strong> - no IDN action.</li>'

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -59,8 +59,8 @@ $pconfig['pfb_cache']		= isset($pfb['dconfig']['pfb_cache'])			? $pfb['dconfig']
 $pconfig['pfb_py_reply']	= isset($pfb['dconfig']['pfb_py_reply'])		? $pfb['dconfig']['pfb_py_reply'] : 'on';
 $pconfig['pfb_hsts']		= isset($pfb['dconfig']['pfb_hsts'])			? $pfb['dconfig']['pfb_hsts'] : 'on';
 // ADR-08: IDN mode selector (Off | All-IDN | Confusable). PfbConfig::read() returns a
-// PfbIdnMode enum (legacy 'on'/'all' -> All, '' -> Off); toStored() gives the canonical
-// config token ('on' | 'confusable' | 'off') that the <select> options below carry.
+// PfbIdnMode enum (legacy 'on' -> All; alpha-only 'all' and '' -> Off); toStored() gives the
+// canonical config token ('on' | 'confusable' | 'off') that the <select> options below carry.
 $pconfig['pfb_idn']		= PfbConfig::read('pfb_idn')->toStored();
 // Confusable-mode sub-toggles: block clearly-malicious homoglyphs is default-on;
 // escalate suspicious mixed-script (else alert only) is opt-in (default off).
@@ -603,6 +603,14 @@ if ($_POST) {
 		// Non-ascii characters are not allowed for DNSBL Regex
 		if (!mb_detect_encoding($_POST['pfb_regex_list'], 'ASCII', TRUE)) {
 			$input_errors[] = 'DNSBL Regex list contains non-ascii characters';
+		}
+
+		// ADR-08: IDN Blocking mode must be one of the <select> options. PFB_FILTER_WORD
+		// only checks shape, so without this an out-of-vocabulary value (e.g. a tampered
+		// POST) would canonicalise to 'off' and silently disable IDN blocking.
+		if (!in_array(pfb_filter($_POST['pfb_idn'] ?? '', PFB_FILTER_WORD, 'dnsbl'),
+			array('off', 'confusable', 'on'), TRUE)) {
+			$input_errors[] = 'DNSBL IDN Blocking mode is invalid!';
 		}
 
 		// Validate customlists

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -7,11 +7,11 @@ use PHPUnit\Framework\TestCase;
 /**
  * ADR-28 Phase 1 — round-trip identity tests for the field-aware config adapters.
  *
- * Rule (ADR-28 §2.2): for every adapted field, every existing stored value
- * (incl. empty / unset / any legacy variant) must satisfy write(read(v)) == v
- * for canonical values, or must map to the documented canonical value for
- * legacy migration values.  Any field that cannot round-trip losslessly is
- * excluded (documented in 01_Results.txt).
+ * Rule (ADR-28 §2.2 reframe): for every adapted field, every existing stored value
+ * (incl. empty / unset / any legacy variant) must satisfy write(read(v)) == v for
+ * canonical values, or must map to a behaviour-equivalent canonical token for legacy
+ * migration values (behaviour preserved on upgrade, downgrade-safe).  Fields that
+ * cannot satisfy this are excluded (documented in 01_Results.txt).
  *
  * Scenario A — PfbToggle (pfb_dnsvip_auto): 'on' / '' checkbox.
  *   Background: stored as 'on' (checked) or '' (unchecked / missing key).
@@ -25,13 +25,17 @@ use PHPUnit\Framework\TestCase;
  *     When pfb_cfg_lenient_read(v) -> enum, pfb_cfg_lenient_write(enum) -> stored.
  *     Then write(read(v)) == v for 'on'/'off'; '' maps to 'off' (normalised default).
  *
- * Scenario C — PfbIdnMode (pfb_idn / dnsbl_idn): 'all'/'confusable'/'off'/''/'on'.
- *   Background: stored as 'all', 'confusable', 'off', '' (off/absent), or 'on' (legacy).
+ * Scenario C — PfbIdnMode (pfb_idn / dnsbl_idn): backing values 'on'/'confusable'/'off'.
+ *   Background: config.xml stores 'on' (= All, block-all-IDN), 'confusable', 'off'.
+ *     Legacy transitional devel token 'all' normalises to 'on' (behaviour-equivalent;
+ *     older releases reading 'on' still block all IDN — downgrade-safe).
+ *     '' (absent/disabled) normalises to 'off'.
  *     Given a raw stored value v.
  *     When pfb_cfg_idn_mode_read(v) -> enum, pfb_cfg_idn_mode_write(enum) -> stored.
- *     Then write(read(v)) == v for canonical values ('all','confusable','off').
- *     And write(read('on')) == 'all'  (documented one-way legacy migration — excluded
- *     from strict round-trip; 'on' never re-emitted; see ADR-28 §2.2 + 01_Results.txt).
+ *     Then write(read('on')) == 'on'  (canonical identity).
+ *     And write(read('all')) == 'on'  (transitional devel token migrates to canonical).
+ *     And write(read('confusable')) == 'confusable'  (identity).
+ *     And write(read('off')) == 'off'  (identity).
  *     And write(read('')) == 'off'    (normalised default).
  */
 final class CfgAdaptersTest extends TestCase
@@ -218,11 +222,18 @@ final class CfgAdaptersTest extends TestCase
 	// Scenario C — PfbIdnMode
 	// -----------------------------------------------------------------------
 
-	public function testIdnModeReadAllReturnsAll(): void
+	public function testIdnModeReadCanonicalOnReturnsAll(): void
 	{
-		// Given canonical 'all'.
-		$enum = pfb_cfg_idn_mode_read('all');
-		$this->assertSame(PfbIdnMode::All, $enum);
+		// 'on' is the canonical block-all token (PfbIdnMode::All backing value), reused
+		// from the pre-4.0.0 binary IDN toggle.
+		$this->assertSame(PfbIdnMode::All, pfb_cfg_idn_mode_read('on'));
+	}
+
+	public function testIdnModeReadTransitionalAllReturnsOff(): void
+	{
+		// 'all' was the 4.0.0-alpha transitional token; alpha compatibility is not
+		// maintained, so it is now an unrecognised token -> Off.
+		$this->assertSame(PfbIdnMode::Off, pfb_cfg_idn_mode_read('all'));
 	}
 
 	public function testIdnModeReadConfusableReturnsConfusable(): void
@@ -248,21 +259,6 @@ final class CfgAdaptersTest extends TestCase
 	{
 		$enum = pfb_cfg_idn_mode_read(null);
 		$this->assertSame(PfbIdnMode::Off, $enum);
-	}
-
-	public function testIdnModeReadLegacyOnReturnsAll(): void
-	{
-		// 'on' is the LEGACY stored value (pre-ADR-08 UI). pfb_global() maps
-		// 'on' -> 'all' at runtime; the adapter replicates that normalisation.
-		// Before: legacy value.
-		$raw = 'on';
-		$this->assertSame('on', $raw);
-
-		// When read.
-		$enum = pfb_cfg_idn_mode_read($raw);
-
-		// Then All (normalised).
-		$this->assertSame(PfbIdnMode::All, $enum);
 	}
 
 	public function testIdnModeReadJunkReturnsDefault(): void
@@ -298,14 +294,20 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame(PfbIdnMode::Off, pfb_cfg_idn_mode_read(['all']));
 	}
 
-	public function testIdnModeRoundTripAll(): void
+	public function testIdnModeDroppedAlphaAllNormalisesToOff(): void
 	{
-		// Canonical 'all' round-trips losslessly.
+		// 'all' (4.0.0-alpha only; compatibility intentionally dropped) is unrecognised
+		// -> Off, so a write-back emits 'off' — NOT the legacy 'all'.
 		$v = 'all';
 		// Before: raw.
 		$this->assertSame('all', $v);
-		// After.
-		$this->assertSame($v, pfb_cfg_idn_mode_write(pfb_cfg_idn_mode_read($v)));
+
+		// When round-tripped.
+		$result = pfb_cfg_idn_mode_write(pfb_cfg_idn_mode_read($v));
+
+		// Then: 'off' (unrecognised -> Off).
+		$this->assertSame('off', $result);
+		$this->assertNotSame('all', $result);
 	}
 
 	public function testIdnModeRoundTripConfusable(): void
@@ -320,18 +322,22 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame($v, pfb_cfg_idn_mode_write(pfb_cfg_idn_mode_read($v)));
 	}
 
-	public function testIdnModeLegacyOnNormalisesToAll(): void
+	public function testIdnModeCanonicalOnRoundTripsLosslessly(): void
 	{
-		// 'on' (legacy) normalises to 'all' on write — documented one-way migration.
-		// This is the ONLY non-lossless case; all canonical values round-trip.
-		// Before: raw legacy value.
+		// 'on' is now the CANONICAL stored token for PfbIdnMode::All (the backing
+		// value). It reads back as All and writes as 'on' — perfect identity.
+		// (Previously 'on' was treated as "legacy" and normalised to 'all'; the
+		// ADR-28 reframe reclaimed 'on' as the canonical token: older releases reading
+		// 'on' still block all IDN, so this is behaviour-preserving + downgrade-safe.)
+		// Before: raw canonical value.
 		$raw = 'on';
 		$this->assertSame('on', $raw);
 
-		// After: canonical 'all' (one-way migration — 'on' is never re-emitted).
+		// When round-tripped.
 		$result = pfb_cfg_idn_mode_write(pfb_cfg_idn_mode_read($raw));
-		$this->assertSame('all', $result);
-		$this->assertNotSame('on', $result);
+
+		// Then: 'on' — canonical identity.
+		$this->assertSame('on', $result, "'on' is the canonical token for All — round-trips losslessly");
 	}
 
 	public function testIdnModeEmptyNormalisesToOff(): void
@@ -349,21 +355,25 @@ final class CfgAdaptersTest extends TestCase
 
 	public function testIdnModeWriteValues(): void
 	{
-		$this->assertSame('all', pfb_cfg_idn_mode_write(PfbIdnMode::All));
+		// PfbIdnMode::All backing value is 'on' (the original pre-ADR-08 block-all
+		// token, reused for round-trip correctness + downgrade safety).
+		$this->assertSame('on', pfb_cfg_idn_mode_write(PfbIdnMode::All));
 		$this->assertSame('confusable', pfb_cfg_idn_mode_write(PfbIdnMode::Confusable));
 		$this->assertSame('off', pfb_cfg_idn_mode_write(PfbIdnMode::Off));
 	}
 
 	public function testIdnModeWriteAcceptsLegacyString(): void
 	{
-		// "enum or string" contract: raw legacy string normalises through read.
-		// Canonical values round-trip; legacy 'on' -> 'all'; '' and junk -> 'off'.
-		$this->assertSame('all', pfb_cfg_idn_mode_write('all'));
-		$this->assertSame('confusable', pfb_cfg_idn_mode_write('confusable'));
-		$this->assertSame('off', pfb_cfg_idn_mode_write('off'));
-		$this->assertSame('all', pfb_cfg_idn_mode_write('on'));
-		$this->assertSame('off', pfb_cfg_idn_mode_write(''));
-		$this->assertSame('off', pfb_cfg_idn_mode_write('yes'));
+		// "enum or string" contract: raw string normalises through read adapter.
+		// 'on'  -> All (canonical) — round-trips losslessly.
+		// 'confusable' and 'off' are canonical and round-trip.
+		// '', junk, and the dropped 4.0.0-alpha 'all' normalise to Off -> 'off'.
+		$this->assertSame('on',          pfb_cfg_idn_mode_write('on'));
+		$this->assertSame('confusable',  pfb_cfg_idn_mode_write('confusable'));
+		$this->assertSame('off',         pfb_cfg_idn_mode_write('off'));
+		$this->assertSame('off',         pfb_cfg_idn_mode_write(''));
+		$this->assertSame('off',         pfb_cfg_idn_mode_write('yes'));
+		$this->assertSame('off',         pfb_cfg_idn_mode_write('all'));   // dropped alpha token
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -26,16 +26,16 @@ use PHPUnit\Framework\TestCase;
  *     Then write(read(v)) == v for 'on'/'off'; '' maps to 'off' (normalised default).
  *
  * Scenario C — PfbIdnMode (pfb_idn / dnsbl_idn): backing values 'on'/'confusable'/'off'.
- *   Background: config.xml stores 'on' (= All, block-all-IDN), 'confusable', 'off'.
- *     Legacy transitional devel token 'all' normalises to 'on' (behaviour-equivalent;
- *     older releases reading 'on' still block all IDN — downgrade-safe).
- *     '' (absent/disabled) normalises to 'off'.
+ *   Background: config.xml stores 'on' (= All, block-all-IDN), 'confusable', 'off'. 'on'
+ *     reuses the pre-4.0.0 block-all token, so older releases reading it still block all
+ *     IDN (downgrade-safe). The 4.0.0-alpha-only 'all' token is dropped (unrecognised ->
+ *     Off), and '' (absent/disabled) is Off.
  *     Given a raw stored value v.
  *     When pfb_cfg_idn_mode_read(v) -> enum, pfb_cfg_idn_mode_write(enum) -> stored.
  *     Then write(read('on')) == 'on'  (canonical identity).
- *     And write(read('all')) == 'on'  (transitional devel token migrates to canonical).
  *     And write(read('confusable')) == 'confusable'  (identity).
  *     And write(read('off')) == 'off'  (identity).
+ *     And write(read('all')) == 'off'  (dropped alpha token -> Off).
  *     And write(read('')) == 'off'    (normalised default).
  */
 final class CfgAdaptersTest extends TestCase

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -1072,61 +1072,66 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// D (extra) — pfb_idn exclusion from adapter adoption is documented and enforced
+	// D (extra) — pfb_idn PfbIdnMode adapter adoption is documented and enforced
 	// -----------------------------------------------------------------------
 
 	/**
-	 * pfb_idn is excluded from adapter adoption: stored plain (no PfbIdnMode adapter).
+	 * pfb_idn is now adapted via PfbIdnMode: read returns an enum, write persists
+	 * the canonical stored token.
 	 *
-	 * The legacy 'on' value cannot round-trip (write(read('on')) == 'all' != 'on').
-	 * The registry entry uses null adapters (plain string) to preserve the stored value.
-	 * This test documents and pins the exclusion.
+	 * ADR-28 reframe: PfbIdnMode::All backing value is 'on' — the original
+	 * pre-ADR-08 block-all token.  This reuse means 'on' round-trips losslessly
+	 * AND old releases reading 'on' still block all IDN (downgrade-safe).
 	 *
 	 * Scenario:
-	 *   Background: pfb_idn stored as 'on' (legacy) or 'all'/'confusable'/'off'.
+	 *   Background: pfb_idn stored as 'on' (canonical, = All).
 	 *     Given pfb_idn = 'on'.
 	 *     When PfbConfig::read('pfb_idn').
-	 *     Then the raw string 'on' is returned (no adapter normalisation).
-	 *     And write(read('on')) == 'on' (identity — NOT 'all').
+	 *     Then PfbIdnMode::All is returned (adapter is wired).
+	 *     And write(read('on')) stores 'on' (canonical identity — the backing value).
 	 */
-	public function testIdnFieldExcludedFromAdapterReturnsRawStringOn(): void
+	public function testIdnFieldAdaptedReturnsEnumForCanonicalOn(): void
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn';
 
-		// Given: legacy 'on' stored.
+		// Given: canonical 'on' stored (= block-all-IDN).
 		$this->seedConfig($path, 'on');
 
 		// Before: raw 'on'.
 		$this->assertSame('on', config_get_path($path));
 
 		// When: read.
-		$raw = PfbConfig::read('pfb_idn');
+		$result = PfbConfig::read('pfb_idn');
 
-		// Then: raw string 'on' (NOT PfbIdnMode::All — the adapter is NOT wired).
-		$this->assertSame('on', $raw, 'pfb_idn returns raw string, not adapted enum');
-		$this->assertNotInstanceOf(PfbIdnMode::class, $raw, 'pfb_idn must not return an enum');
+		// Then: PfbIdnMode::All (adapter IS wired — NOT raw string).
+		$this->assertInstanceOf(PfbIdnMode::class, $result, 'pfb_idn must return a PfbIdnMode enum');
+		$this->assertSame(PfbIdnMode::All, $result, "pfb_idn 'on' -> PfbIdnMode::All");
 
-		// And: write(read('on')) == 'on' (lossless identity — exclusion confirmed).
-		PfbConfig::write('pfb_idn', $raw);
-		$this->assertSame('on', config_get_path($path), 'write(read("on")) == "on" for pfb_idn');
+		// And: write(read('on')) stores 'on' — canonical identity.
+		PfbConfig::write('pfb_idn', $result);
+		$this->assertSame('on', config_get_path($path), "write(read('on')) == 'on' for pfb_idn");
 	}
 
-	public function testIdnFieldExcludedFromAdapterReturnsRawStringAll(): void
+	public function testIdnFieldAdaptedDroppedAlphaAllNormalisesToOff(): void
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn';
 
-		// Given: canonical 'all'.
+		// Given: the 4.0.0-alpha-only token 'all' (alpha compatibility intentionally dropped).
 		$this->seedConfig($path, 'all');
 
 		// Before: raw 'all'.
 		$this->assertSame('all', config_get_path($path));
 
-		// When/After: identity — 'all' stays 'all'.
-		$raw = PfbConfig::read('pfb_idn');
-		$this->assertSame('all', $raw);
+		// When/Then: 'all' is unrecognised -> PfbIdnMode::Off (canonical block-all is 'on').
+		$result = PfbConfig::read('pfb_idn');
+		$this->assertInstanceOf(PfbIdnMode::class, $result, 'pfb_idn must return a PfbIdnMode enum');
+		$this->assertSame(PfbIdnMode::Off, $result, "pfb_idn 'all' (dropped alpha token) -> PfbIdnMode::Off");
 
-		PfbConfig::write('pfb_idn', $raw);
-		$this->assertSame('all', config_get_path($path));
+		// Write emits the canonical 'off' — 'all' is not re-emitted.
+		PfbConfig::write('pfb_idn', $result);
+		$stored = config_get_path($path);
+		$this->assertSame('off', $stored, "write(read('all')) == 'off' for pfb_idn");
+		$this->assertNotSame('all', $stored, "'all' must not be re-emitted");
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbGlobalParityTest.php
+++ b/tests/php/PfbGlobalParityTest.php
@@ -320,19 +320,34 @@ final class PfbGlobalParityTest extends TestCase
 	}
 
 	/**
-	 * pfb_idn: OLD = $pfb['dnsblconfig']['pfb_idn'] ?? '' = '' when absent.
-	 * Via gateway: PfbConfig::read('pfb_idn') = '' (plain string, identity adapter).
-	 * PARITY: identical (both '' — IDN excluded from adapter adoption, ADR-28 §2.2).
+	 * pfb_idn: OLD = $pfb['dnsblconfig']['pfb_idn'] ?? '' = '' when absent (null-coalesce).
+	 * Via gateway (ADR-28 reframe): PfbConfig::read('pfb_idn') = PfbIdnMode::Off when absent.
+	 *
+	 * PARITY: the registry default is '' which the PfbIdnMode adapter normalises to Off.
+	 * OLD code compared the raw string against 'on'/'all'/'confusable' — Off ('off') and
+	 * the old '' both result in IDN being disabled, so the effective behaviour is the same.
+	 * pfb_idn is now adapted (no longer excluded from adapter adoption, ADR-28 reframe).
 	 */
-	public function testParityPfbIdnAbsentYieldsEmpty(): void
+	public function testParityPfbIdnAbsentYieldsOff(): void
 	{
 		$this->assertNull(
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn')
 		);
 
+		// Before: absent — old code produced null ?? '' = ''.
+		$old_result = config_get_path(
+			'installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn'
+		) ?? '';
+		$this->assertSame('', $old_result, 'before: old code produces empty string for absent pfb_idn');
+
+		// When: gateway read.
 		$result = PfbConfig::read('pfb_idn');
 
-		$this->assertSame('', $result, 'pfb_idn absent -> "" (plain string, excluded from adapter)');
+		// Then: PfbIdnMode::Off (adapted; '' normalises to Off — IDN disabled).
+		// Effective behaviour unchanged: both '' (old) and Off (new) mean IDN disabled.
+		$this->assertInstanceOf(PfbIdnMode::class, $result, 'pfb_idn absent -> PfbIdnMode enum');
+		$this->assertSame(PfbIdnMode::Off, $result, 'pfb_idn absent -> PfbIdnMode::Off');
+		$this->assertSame('off', $result->value, 'pfb_idn absent -> Off value is "off" (IDN disabled)');
 	}
 
 	/**

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -16,24 +16,29 @@ use PHPUnit\Framework\TestCase;
  *
  * BACKWARD invariant (new code -> old store -> old code):
  *   PfbConfig::write($key, <runtime_value>) only ever emits a string that is a
- *   member of the field's legacy stored vocabulary.  Because the gateway never
- *   introduces a novel on-disk token, a downgrade leaves older code reading values
- *   it already understands -- no crash, no silent settings-loss.
+ *   member of the field's legacy stored vocabulary or a behaviour-equivalent token.
+ *   Because the gateway never introduces a novel on-disk token that changes behaviour,
+ *   a downgrade leaves older code reading values it already understands -- no crash,
+ *   no silent settings-loss.
  *
  * ROLLBACK SAFETY BY CONSTRUCTION:
- *   Every write adapter (pfb_cfg_toggle_write, pfb_cfg_lenient_write) returns a
- *   value whose backing is the exact legacy stored string (ADR-28 SS2.2).  Plain-
- *   string (null-adapter) fields are identity, so they cannot introduce novel tokens
- *   either.  This phase asserts these properties explicitly per field so a future
- *   adapter addition cannot silently break the contract.
+ *   Toggle/lenient write adapters return the exact legacy stored string.  Plain-
+ *   string (null-adapter) fields are identity.  The idn-mode adapter (pfb_idn)
+ *   emits only 'on'/'confusable'/'off' -- all tokens a pre-ADR-08 release already
+ *   handled (older code treats 'on' as block-all, 'confusable'/'off' as off).
+ *   This phase asserts these properties explicitly per field so a future adapter
+ *   addition cannot silently break the contract.
  *
- * EXCLUDED FIELDS (not backward-unsafe at the PfbConfig level):
- *   pfb_idn -- uses null/null adapters at PfbConfig level (identity; backward-safe).
- *              The legacy 'on'->'all' normalisation happens only at the pfb_global()
- *              seam, outside PfbConfig.  This exclusion is documented in ADR-29 SS2.3
- *              and mirrors the ADR-28 adapter-adoption exclusion (01_Results.txt).
- *              pfb_idn is included in the plain-string backward test (identity
- *              adapter; any stored value is passed through unchanged).
+ * pfb_idn (ADR-28 reframe): now uses the PfbIdnMode adapter (NOT null/null).
+ *   PfbIdnMode::All backing value is 'on' — the original pre-ADR-08 block-all token.
+ *   Legacy transitional devel token 'all' normalises to 'on' on write-back (migration;
+ *   behaviour-preserving + downgrade-safe). Backward vocabulary: {'on', 'confusable',
+ *   'off'} — no novel token introduced; see testPfbIdnModeAdapterForwardAndBackward().
+ *
+ * NOTE on pfb_cfg_field_adapter_type():
+ *   It classifies pfb_idn ('pfb_cfg_idn_mode_read' adapter) as type 'idn', so it is
+ *   naturally excluded from the toggle-only forward/backward tests (which assert
+ *   instanceof PfbToggle). pfb_idn is covered by the dedicated idn-mode tests.
  *
  * SINCE-VERSION COVERAGE:
  *   The rollback contract applies to every registered key regardless of its
@@ -47,7 +52,8 @@ use PHPUnit\Framework\TestCase;
  *   When PfbConfig::read($key) and PfbConfig::write($key, <result>) are called.
  *   Then (FORWARD) the read result is a well-formed runtime value -- not NULL,
  *     not a crash, and of the correct type.
- *   And (BACKWARD) the write result is a string in the field's legacy vocabulary.
+ *   And (BACKWARD) the write result is a string in the field's legacy vocabulary
+ *     or a behaviour-equivalent canonical token.
  *   And the since-version field is a non-empty string for every registered field.
  */
 final class RollbackContractTest extends TestCase
@@ -362,10 +368,15 @@ final class RollbackContractTest extends TestCase
 	 *     Given a representative canonical stored string for each plain field.
 	 *     When PfbConfig::read($key).
 	 *     Then the result is the same string (identity; no crash, no type change).
+	 *
+	 * Note: pfb_idn is now adapted via PfbIdnMode (NOT plain-string). See
+	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn coverage.
 	 */
 	public function testForwardPlainStringFieldsPassLegacyTokensUnchanged(): void
 	{
 		// Representative plain-string fields with canonical legacy stored values.
+		// pfb_idn is intentionally excluded: it uses the PfbIdnMode adapter (not
+		// null/null) so it returns a PfbIdnMode enum, not a plain string.
 		$cases = [
 			// General section
 			'pfb_interval'          => ['installedpackages/pfblockerng/config/0/pfb_interval', '1'],
@@ -376,8 +387,6 @@ final class RollbackContractTest extends TestCase
 			'alexa_count'           => ['installedpackages/pfblockerngdnsblsettings/config/0/alexa_count', '1000'],
 			'action'                => ['installedpackages/pfblockerngdnsblsettings/config/0/action', 'Disabled'],
 			'pfb_dnsbl_rule'        => ['installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_rule', 'Disabled'],
-			// pfb_idn: excluded from adapter adoption; plain-string (identity).
-			'pfb_idn'               => ['installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn', 'all'],
 			// SafeSearch section
 			'safesearch_enable'     => ['installedpackages/pfblockerngsafesearch/safesearch_enable', 'Disable'],
 		];
@@ -403,22 +412,23 @@ final class RollbackContractTest extends TestCase
 	}
 
 	/**
-	 * pfb_idn legacy 'on' token passes through unchanged (identity adapter at PfbConfig level).
+	 * pfb_idn 'on' token: now adapted via PfbIdnMode — read returns PfbIdnMode::All.
 	 *
-	 * This is distinct from pfb_cfg_idn_mode_read() which normalises 'on'->All.
-	 * PfbConfig excludes pfb_idn from adapter adoption, so 'on' must round-trip.
+	 * ADR-28 reframe: pfb_idn is no longer excluded from adapter adoption.
+	 * PfbIdnMode::All.value == 'on' (the backing value reuses the canonical token),
+	 * so 'on' both reads as PfbIdnMode::All and writes back as 'on' — perfect identity.
 	 *
 	 * Scenario:
-	 *   Background: pfb_idn uses null/null adapters (identity; not PfbIdnMode).
-	 *     Given pfb_idn stored as 'on' (legacy).
+	 *   Background: pfb_idn now uses the PfbIdnMode read/write adapters.
+	 *     Given pfb_idn stored as 'on' (canonical = block-all-IDN).
 	 *     When PfbConfig::read('pfb_idn').
-	 *     Then 'on' is returned unchanged (identity; NOT 'all').
+	 *     Then PfbIdnMode::All is returned (adapter normalises; 'on' is the canonical token).
 	 */
-	public function testForwardPfbIdnLegacyOnPassesThroughAsIdentity(): void
+	public function testForwardPfbIdnCanonicalOnYieldsAllEnum(): void
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn';
 
-		// Given: legacy 'on'.
+		// Given: canonical 'on'.
 		config_set_path($path, 'on');
 
 		// Before.
@@ -427,12 +437,12 @@ final class RollbackContractTest extends TestCase
 		// When.
 		$result = PfbConfig::read('pfb_idn');
 
-		// Then: identity -- 'on' passes through (no adapter normalisation at PfbConfig level).
-		$this->assertSame('on', $result,
-			"FORWARD: pfb_idn 'on' must pass through as 'on' (identity adapter; not 'all')"
+		// Then: PfbIdnMode::All (adapter IS wired; returns enum, not plain string).
+		$this->assertInstanceOf(PfbIdnMode::class, $result,
+			"FORWARD: pfb_idn must return a PfbIdnMode enum"
 		);
-		$this->assertNotInstanceOf(PfbIdnMode::class, $result,
-			"FORWARD: pfb_idn must NOT return a PfbIdnMode enum"
+		$this->assertSame(PfbIdnMode::All, $result,
+			"FORWARD: pfb_idn 'on' -> PfbIdnMode::All (canonical backing value)"
 		);
 	}
 
@@ -636,15 +646,21 @@ final class RollbackContractTest extends TestCase
 	 *     Given a canonical stored string.
 	 *     When PfbConfig::write($key, $str).
 	 *     Then stored == $str (the adapter cannot introduce any novel token).
+	 *
+	 * Note: pfb_idn is now adapted via PfbIdnMode (NOT plain-string). See
+	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn backward coverage.
 	 */
 	public function testBackwardPlainStringFieldsIdentityAdapterCannotIntroduceNovelTokens(): void
 	{
+		// pfb_idn is intentionally excluded: it now uses the PfbIdnMode write adapter,
+		// which normalises to the canonical vocabulary ('on'|'confusable'|'off') rather
+		// than emitting identity for every input (e.g. the dropped alpha 'all' -> 'off').
+		// See testPfbIdnModeAdapterForwardAndBackward().
 		$cases = [
 			'pfb_interval'      => ['installedpackages/pfblockerng/config/0/pfb_interval', '6'],
 			'dnsbl_interface'   => ['installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_interface', 'lo0'],
 			'alexa_type'        => ['installedpackages/pfblockerngdnsblsettings/config/0/alexa_type', 'tranco'],
 			'safesearch_enable' => ['installedpackages/pfblockerngsafesearch/safesearch_enable', 'Disable'],
-			'pfb_idn'           => ['installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn', 'all'],
 		];
 
 		foreach ($cases as $key => $spec) {
@@ -666,33 +682,68 @@ final class RollbackContractTest extends TestCase
 	}
 
 	/**
-	 * pfb_idn: write of ANY canonical stored value is identity.
-	 * 'on'/'all'/'confusable'/'off'/'' all pass through unchanged.
-	 * Backward-safe: no novel token introduced at the PfbConfig level.
+	 * pfb_idn FORWARD + BACKWARD: PfbIdnMode adapter — every legacy token yields a
+	 * sane enum and write emits only downgrade-safe tokens.
+	 *
+	 * ADR-28 reframe: pfb_idn now uses the PfbIdnMode adapter. PfbIdnMode::All
+	 * backing value is 'on' (canonical; reuses the original block-all token so older
+	 * releases reading 'on' still block all IDN — downgrade-safe). The transitional
+	 * devel token 'all' normalises to 'on' on write-back (behaviour-equivalent).
+	 *
+	 * Backward vocabulary (tokens an older release might have stored / might read back):
+	 *   'on'         -> All -> 'on'  (canonical identity; downgrade-safe)
+	 *   'all'        -> All -> 'on'  (transitional devel token; behaviour-equivalent)
+	 *   'confusable' -> Confusable -> 'confusable' (identity; new token, old code treats
+	 *                                               as off — acceptable, same as unset)
+	 *   'off'        -> Off  -> 'off' (identity)
+	 *   ''           -> Off  -> 'off' (normalised default; '' -> Off -> 'off')
 	 *
 	 * Scenario:
-	 *   Background: pfb_idn is excluded from adapter adoption; uses identity adapter.
-	 *     Given each canonical or legacy pfb_idn stored value.
-	 *     When PfbConfig::write('pfb_idn', $v).
-	 *     Then stored == $v (round-trip; no novel token).
+	 *   Background: pfb_idn uses the PfbIdnMode read/write adapters.
+	 *     Given each canonical or legacy pfb_idn stored token.
+	 *     When PfbConfig::read('pfb_idn').
+	 *     Then (FORWARD) result is a PfbIdnMode enum — not NULL, not a crash.
+	 *     And (BACKWARD) PfbConfig::write('pfb_idn', result) stores a downgrade-safe
+	 *     token that older code already understands.
 	 */
-	public function testBackwardPfbIdnAllCanonicalTokensRoundTripAsIdentity(): void
+	public function testPfbIdnModeAdapterForwardAndBackward(): void
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn';
-		// All tokens an existing install might have (including legacy 'on').
-		$tokens = ['on', 'all', 'confusable', 'off', ''];
 
-		foreach ($tokens as $token) {
+		// All tokens an existing install might have stored (full vocabulary).
+		$cases = [
+			// stored       => [expected_enum,         expected_stored_after_write]
+			'on'         => [PfbIdnMode::All,        'on'],         // canonical block-all; identity
+			'confusable' => [PfbIdnMode::Confusable, 'confusable'], // identity
+			'off'        => [PfbIdnMode::Off,        'off'],        // identity
+			''           => [PfbIdnMode::Off,        'off'],        // absent/disabled -> Off
+			'all'        => [PfbIdnMode::Off,        'off'],        // 4.0.0-alpha-only token, dropped -> Off
+		];
+
+		foreach ($cases as $token => [$expected_enum, $expected_stored]) {
 			// Reset.
 			$GLOBALS['config'] = [];
+			config_set_path($path, $token);
 
-			// When: write each token.
-			PfbConfig::write('pfb_idn', $token);
+			// BEFORE: raw token confirmed.
+			$this->assertSame($token, config_get_path($path),
+				"before forward+backward: pfb_idn token='{$token}'"
+			);
 
-			// Then: same token stored (identity).
+			// FORWARD: read yields PfbIdnMode enum.
+			$runtime = PfbConfig::read('pfb_idn');
+			$this->assertInstanceOf(PfbIdnMode::class, $runtime,
+				"FORWARD: pfb_idn token='{$token}' must yield PfbIdnMode"
+			);
+			$this->assertSame($expected_enum, $runtime,
+				"FORWARD: pfb_idn token='{$token}' must yield {$expected_enum->name}"
+			);
+
+			// BACKWARD: write(runtime) stores a downgrade-safe token.
+			PfbConfig::write('pfb_idn', $runtime);
 			$stored = config_get_path($path);
-			$this->assertSame($token, $stored,
-				"BACKWARD: pfb_idn write('{$token}') must store exactly '{$token}'"
+			$this->assertSame($expected_stored, $stored,
+				"BACKWARD: pfb_idn token='{$token}' write(read) must store '{$expected_stored}'"
 			);
 		}
 	}
@@ -713,7 +764,7 @@ final class RollbackContractTest extends TestCase
 	public function testAdapterTypeHelperReturnsValidTypeForEveryRegisteredField(): void
 	{
 		$registry    = pfb_cfg_registry();
-		$valid_types = ['toggle', 'lenient', 'plain'];
+		$valid_types = ['toggle', 'lenient', 'idn', 'plain'];
 
 		foreach ($registry as $key => $entry) {
 			$type = pfb_cfg_field_adapter_type($entry);
@@ -1304,6 +1355,13 @@ final class RollbackContractTest extends TestCase
 	/**
 	 * Return all toggle-adapted keys with their full config.xml paths.
 	 *
+	 * IMPORTANT: pfb_idn is EXCLUDED here even though pfb_cfg_field_adapter_type()
+	 * returns 'toggle' for it (the production helper uses 'toggle' as its fallback for
+	 * any adapter that is neither NULL nor 'pfb_cfg_lenient_read', including the new
+	 * 'pfb_cfg_idn_mode_read' idn adapter). pfb_idn uses the PfbIdnMode adapter and
+	 * returns a PfbIdnMode enum, not a PfbToggle. It is covered by the dedicated
+	 * testPfbIdnModeAdapterForwardAndBackward() test instead.
+	 *
 	 * @return array<string,string>  key => full config path
 	 */
 	private function toggleAdaptedKeys(): array
@@ -1311,6 +1369,8 @@ final class RollbackContractTest extends TestCase
 		$registry = pfb_cfg_registry();
 		$result   = [];
 		foreach ($registry as $key => $entry) {
+			// pfb_idn (adapter type 'idn') is naturally excluded by the type filter;
+			// it is covered by testPfbIdnModeAdapterForwardAndBackward().
 			if (pfb_cfg_field_adapter_type($entry) === 'toggle') {
 				$result[$key] = $entry['section'] . '/' . $key;
 			}

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -30,10 +30,10 @@ use PHPUnit\Framework\TestCase;
  *   addition cannot silently break the contract.
  *
  * pfb_idn (ADR-28 reframe): now uses the PfbIdnMode adapter (NOT null/null).
- *   PfbIdnMode::All backing value is 'on' — the original pre-ADR-08 block-all token.
- *   Legacy transitional devel token 'all' normalises to 'on' on write-back (migration;
- *   behaviour-preserving + downgrade-safe). Backward vocabulary: {'on', 'confusable',
- *   'off'} — no novel token introduced; see testPfbIdnModeAdapterForwardAndBackward().
+ *   PfbIdnMode::All backing value is 'on' — the original pre-ADR-08 block-all token, so
+ *   an older release reading 'on' still blocks all IDN (downgrade-safe). The 4.0.0-alpha
+ *   'all' token is dropped (unrecognised -> Off -> 'off'). Backward vocabulary: {'on',
+ *   'confusable', 'off'} — no novel token; see testPfbIdnModeAdapterForwardAndBackward().
  *
  * NOTE on pfb_cfg_field_adapter_type():
  *   It classifies pfb_idn ('pfb_cfg_idn_mode_read' adapter) as type 'idn', so it is
@@ -687,12 +687,12 @@ final class RollbackContractTest extends TestCase
 	 *
 	 * ADR-28 reframe: pfb_idn now uses the PfbIdnMode adapter. PfbIdnMode::All
 	 * backing value is 'on' (canonical; reuses the original block-all token so older
-	 * releases reading 'on' still block all IDN — downgrade-safe). The transitional
-	 * devel token 'all' normalises to 'on' on write-back (behaviour-equivalent).
+	 * releases reading 'on' still block all IDN — downgrade-safe). The 4.0.0-alpha
+	 * 'all' token is dropped (unrecognised -> Off -> 'off').
 	 *
 	 * Backward vocabulary (tokens an older release might have stored / might read back):
 	 *   'on'         -> All -> 'on'  (canonical identity; downgrade-safe)
-	 *   'all'        -> All -> 'on'  (transitional devel token; behaviour-equivalent)
+	 *   'all'        -> Off -> 'off' (dropped 4.0.0-alpha token; unrecognised)
 	 *   'confusable' -> Confusable -> 'confusable' (identity; new token, old code treats
 	 *                                               as off — acceptable, same as unset)
 	 *   'off'        -> Off  -> 'off' (identity)
@@ -774,6 +774,23 @@ final class RollbackContractTest extends TestCase
 				"pfb_cfg_field_adapter_type({$key}) returned unknown type: '{$type}'"
 			);
 		}
+	}
+
+	/**
+	 * Every adapter type a registered field can resolve to (toggle / lenient / idn)
+	 * has a non-empty vocabulary in pfb_cfg_field_vocab(). Guards against a missing or
+	 * empty entry (e.g. the 'idn' vocabulary added with the PfbIdnMode adoption).
+	 */
+	public function testFieldVocabNonEmptyForEveryAdapterTypeInUse(): void
+	{
+		$vocab = pfb_cfg_field_vocab();
+		foreach (pfb_cfg_registry() as $key => $entry) {
+			$type = pfb_cfg_field_adapter_type($entry);
+			$this->assertArrayHasKey($type, $vocab, "no vocabulary for adapter type '{$type}' (field {$key})");
+			$this->assertNotEmpty($vocab[$type], "vocabulary for adapter type '{$type}' is empty (field {$key})");
+		}
+		// The 'idn' adoption must contribute its canonical write tokens.
+		$this->assertSame(['on', 'confusable', 'off'], $vocab['idn']);
 	}
 
 	/**
@@ -1355,12 +1372,10 @@ final class RollbackContractTest extends TestCase
 	/**
 	 * Return all toggle-adapted keys with their full config.xml paths.
 	 *
-	 * IMPORTANT: pfb_idn is EXCLUDED here even though pfb_cfg_field_adapter_type()
-	 * returns 'toggle' for it (the production helper uses 'toggle' as its fallback for
-	 * any adapter that is neither NULL nor 'pfb_cfg_lenient_read', including the new
-	 * 'pfb_cfg_idn_mode_read' idn adapter). pfb_idn uses the PfbIdnMode adapter and
-	 * returns a PfbIdnMode enum, not a PfbToggle. It is covered by the dedicated
-	 * testPfbIdnModeAdapterForwardAndBackward() test instead.
+	 * pfb_idn is excluded here because pfb_cfg_field_adapter_type() classifies it as
+	 * type 'idn' (its 'pfb_cfg_idn_mode_read' adapter), not 'toggle' — so the type
+	 * filter below skips it naturally. pfb_idn returns a PfbIdnMode enum (not a
+	 * PfbToggle) and is covered by testPfbIdnModeAdapterForwardAndBackward() instead.
 	 *
 	 * @return array<string,string>  key => full config path
 	 */

--- a/tests/test_adr28_cfg_adapters.py
+++ b/tests/test_adr28_cfg_adapters.py
@@ -182,13 +182,17 @@ class TestIdnModeDecisionEnum:
 _TRUTH_TABLE: list[tuple[str | None, bool, IdnMode, str]] = [
     # (ini_value, python_idn, expected_IdnMode, pre_adoption_string)
     # Canonical ini values — python_idn is IGNORED when ini is recognised.
+    # 'on' (reused legacy token) is the canonical block-all value (IdnMode.All).
     ("off", True, IdnMode.Off, IDN_MODE_OFF),
     ("off", False, IdnMode.Off, IDN_MODE_OFF),
-    ("all", True, IdnMode.All, IDN_MODE_ALL),
-    ("all", False, IdnMode.All, IDN_MODE_ALL),
+    ("on", True, IdnMode.All, IDN_MODE_ALL),
+    ("on", False, IdnMode.All, IDN_MODE_ALL),
     ("confusable", True, IdnMode.Confusable, IDN_MODE_CONFUSABLE),
     ("confusable", False, IdnMode.Confusable, IDN_MODE_CONFUSABLE),
-    # Unrecognised string -> legacy fallback (python_idn decides).
+    # Unrecognised string -> legacy fallback (python_idn decides). Includes the dropped
+    # 4.0.0-alpha 'all' token: no longer canonical, so it falls back via python_idn.
+    ("all", True, IdnMode.All, IDN_MODE_ALL),
+    ("all", False, IdnMode.Off, IDN_MODE_OFF),
     ("bogus", True, IdnMode.All, IDN_MODE_ALL),
     ("bogus", False, IdnMode.Off, IDN_MODE_OFF),
     # Empty string -> treated as unrecognised (not in canonical set) -> legacy fallback.


### PR DESCRIPTION
## Summary

Implements **Bucket A** of #502 — finishing the ADR-28 enum adoption that was built but never wired through. The config enums were read and then immediately unwrapped back to strings (`->value`), so downstream code kept string-comparing the exact values the enums were meant to replace.

This focuses on the IDN + lenient cluster (the self-contained fields). The high-volume generic toggle conversion (A0 — `enable`/`dnsbl`/`keep`/… ~70 sites) stays deferred per the ticket's "incremental, retire on contact" guidance.

## What changed

**New adapter contract — the enum owns its semantics**
- `PfbStoredEnum` interface + `PfbStoredEnumAdapter` trait: read = `EnumClass::fromStored($raw)`, write = `$enum->toStored()`. The gateway and the `pfb_cfg_*` helpers become trivial (one-line delegations). The per-field absent default stays the registry's `$entry['default']` (applied before the adapter); the enum's `default()` is only the parse-fallback for unknown/non-scalar tokens.

**`pfb_idn` adopted into the gateway as `PfbIdnMode`** (was excluded with `NULL`/`NULL` adapters)
- `PfbConfig::read('pfb_idn')` now returns the enum; `pfb_global()` stores it; consumers compare `=== PfbIdnMode::All` / `::Confusable`; the `dnsbl.php` save + Form `<select>` use the canonical token.
- **`All` reuses the original `'on'` token.** A pre-4.0.0 install round-trips with no migration *and* an older release reading `'on'` still blocks all IDN (downgrade-safe). One vocabulary — `'on'` (=All) / `'confusable'` / `'off'` — now spans `config.xml`, `py_unbound.ini`, and the Python `IdnMode` enum (so the config/ini token split is gone). The 4.0.0-**alpha-only** `'all'` token is dropped (reads as Off; alpha compatibility intentionally not maintained).

**Confusable sub-toggles** (`pfb_idn_block_malicious` / `pfb_idn_escalate_suspicious`) now compare via `PfbToggle` instead of raw `== 'on'`.

**`lenient`** read keeps the `PfbLenient` enum end-to-end (drops the `->value` flatten); the consumer compares `!== PfbLenient::On`.

**Policy reframe** (CLAUDE.md + ADR-28/29): the config store is **not frozen**. The guarantee is *behaviour preservation on upgrade* — an existing config with the key absent reads to a value that preserves that user's prior behaviour, a brand-new config gets the new default, writes may emit a normalised behaviour-equivalent canonical token, and downgrade is tolerated (older releases string-compare; an unknown token falls through to their safe default).

## Tests

Updated `CfgAdaptersTest`, `CfgGatewayTest`, `PfbGlobalParityTest`, `RollbackContractTest`, and `tests/test_adr28_cfg_adapters.py` to the new contract (enum reads, behaviour-preserving writes, `'on'` canonical / `'all'` dropped, the new `idn` adapter type + vocabulary). Coverage kept per branch (off / on / confusable, absent / empty / legacy / junk).

Local gate: **PHPUnit** (1282), **pytest** (1967), **ruff**, **PHPStan**, **PHPCS** all green.

## Not in this PR

Bucket A's high-volume generic toggle conversion (A0) and all of Bucket B remain tracked in #502.

Part of #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved configuration handling for upgrades and rollbacks, preserving user-visible behavior while using canonical stored values.
  * Updated IDN mode support so the current “on/off/confusable” options are handled consistently across the interface and saved settings.

* **Bug Fixes**
  * Fixed IDN settings to load and save more reliably, including legacy values from older releases.
  * Improved downgrade safety so older versions read configuration values sensibly instead of misinterpreting them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->