### PR TITLE
dev: archive completed Redmine→GitHub migration — #502 Bucket B (B2)

### DIFF
--- a/archive/README.md
+++ b/archive/README.md
@@ -1,0 +1,21 @@
+# Archive
+
+Completed one-shot tooling, kept for provenance and removed from active
+maintenance scope. Nothing here runs in CI or ships in a release archive
+(release archives contain only `src/`).
+
+## `redmine_to_github.py` + `redmine-import.yml` + `test_redmine_to_github.py`
+
+One-shot migration of open pfBlockerNG issues from the pfSense Redmine tracker
+(<https://redmine.pfsense.org>) to GitHub issues on this repository, preserving
+comment threads. The migration is **complete** — imported issues carry the
+`redmine-imported` label.
+
+The workflow was moved out of `.github/workflows/` so it can no longer be
+dispatched. To run the migration again (idempotent), move `redmine-import.yml`
+back under `.github/workflows/` and dispatch it, or run the script directly
+(requires `REDMINE_API_KEY` + `GITHUB_TOKEN` in the environment).
+
+The test exercises the script's pure helpers; it lives here beside the script
+as provenance and is not part of the active `pytest` suite (`testpaths =
+["tests"]`).

--- a/archive/redmine-import.yml
+++ b/archive/redmine-import.yml
@@ -109,4 +109,4 @@ jobs:
           if [ -n "$ISSUE_IDS" ]; then
             ARGS+=(--issue-ids "$ISSUE_IDS")
           fi
-          python scripts/redmine_to_github.py "${ARGS[@]}"
+          python archive/redmine_to_github.py "${ARGS[@]}"

--- a/archive/redmine_to_github.py
+++ b/archive/redmine_to_github.py
@@ -13,10 +13,13 @@
 # Existing GH issues are discovered via the "redmine-imported" label; existing
 # comments are discovered by parsing their journal-id markers.
 #
-# Run via the workflow:
-#   .github/workflows/redmine-import.yml
-# or locally (requires REDMINE_API_KEY + GITHUB_TOKEN in env):
-#   python scripts/redmine_to_github.py [--dry-run] [--limit N] ...
+# ARCHIVED: the one-shot migration is complete (see archive/README.md). This
+# file and its workflow are kept for provenance only; the workflow no longer
+# lives under .github/workflows so it cannot be dispatched.
+#
+# To run it again, move archive/redmine-import.yml back under
+# .github/workflows/ (requires REDMINE_API_KEY + GITHUB_TOKEN in env):
+#   python archive/redmine_to_github.py [--dry-run] [--limit N] ...
 """
 Migrate open pfBlockerNG Redmine issues to GitHub, preserving comment threads.
 
@@ -25,9 +28,9 @@ and date.  Re-runs are idempotent: issues are not duplicated, and any missing
 comments are posted.
 
 Usage:
-  REDMINE_API_KEY=... GITHUB_TOKEN=... python scripts/redmine_to_github.py
-  python scripts/redmine_to_github.py --dry-run
-  python scripts/redmine_to_github.py --issue 12345 --dry-run
+  REDMINE_API_KEY=... GITHUB_TOKEN=... python archive/redmine_to_github.py
+  python archive/redmine_to_github.py --dry-run
+  python archive/redmine_to_github.py --issue 12345 --dry-run
 """
 
 from __future__ import annotations

--- a/archive/test_redmine_to_github.py
+++ b/archive/test_redmine_to_github.py
@@ -1,4 +1,4 @@
-"""Tests for scripts/redmine_to_github.py — pure helper functions.
+"""Tests for archive/redmine_to_github.py — pure helper functions.
 
 All network/env I/O is excluded: only the pure helpers are covered here.
 The test suite honours CLAUDE.md's coverage mandate:
@@ -42,7 +42,7 @@ from typing import Any
 
 # ── Load the script as a module (hyphened name → importlib) ───────────────────
 
-_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "redmine_to_github.py"
+_SCRIPT = Path(__file__).resolve().parent / "redmine_to_github.py"
 _spec = importlib.util.spec_from_file_location("redmine_to_github", _SCRIPT)
 assert _spec is not None and _spec.loader is not None
 rtg = importlib.util.module_from_spec(_spec)


### PR DESCRIPTION
## What

Archive the completed Redmine→GitHub one-shot migration tooling — **Bucket B item B2** of #502.

The migration is complete: imported issues carry the `redmine-imported` label (e.g. #383–#387). The script, its `workflow_dispatch`-only workflow, and its test are moved out of active maintenance scope into a new `archive/` directory.

## Changes

- `scripts/redmine_to_github.py` → `archive/redmine_to_github.py`
- `.github/workflows/redmine-import.yml` → `archive/redmine-import.yml` — out of `.github/workflows/`, so it can no longer be dispatched
- `tests/test_redmine_to_github.py` → `archive/test_redmine_to_github.py` — out of the `pytest` suite (`testpaths = ["tests"]`)
- Internal path references updated; `archive/README.md` documents provenance + how to re-run if ever needed

## Notes

Nothing here ships (release archives are `src/` only) or runs in CI. `ruff check .` still lints `archive/`, and the moved test still passes from its new location (69 passed).

Part of #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
