### PR TITLE
build: drop unused cp/ln/rm/install_program recipe commands — #502 (B4)

### DIFF
--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -386,53 +386,19 @@ class Recipe:
         # (installed scripts/binaries are not writable) — NOT 0755.
         self._install(args, "0555")
 
-    def _cmd_install_program(self, args: list[str]) -> None:
-        # INSTALL_PROGRAM also uses ${BINMODE} = 0555.
-        self._install(args, "0555")
-
     def _cmd_mv(self, args: list[str]) -> None:
-        srcs, dest = self._copy_args(args)
-        for s in srcs:
-            shutil.move(s, dest)
-
-    def _cmd_cp(self, args: list[str]) -> None:
-        srcs, dest = self._copy_args(args)
-        dest_p = Path(dest)
-        multi = len(srcs) > 1 or dest_p.is_dir()
-        for s in srcs:
-            sp = Path(s)
-            if sp.is_dir():
-                shutil.copytree(sp, dest_p / sp.name, dirs_exist_ok=True)
-                continue
-            target = dest_p / sp.name if multi else dest_p
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(sp, target)
-
-    @staticmethod
-    def _copy_args(args: list[str]) -> tuple[list[str], str]:
-        # Drop flags (e.g. -R, -p), then split into (sources, dest).
+        # Drop flags (e.g. -f), then split into (sources, dest).
         paths = [a for a in args if not a.startswith("-")]
         if len(paths) < 2:
-            raise BuildError(f"copy/move with too few paths: {args!r}")
-        return paths[:-1], paths[-1]
+            raise BuildError(f"mv with too few paths: {args!r}")
+        for s in paths[:-1]:
+            shutil.move(s, paths[-1])
 
-    def _cmd_ln(self, args: list[str]) -> None:
-        srcs, link = self._copy_args(args)  # validates: raises on too few paths
-        target = srcs[-1]
-        Path(link).parent.mkdir(parents=True, exist_ok=True)
-        if Path(link).exists() or Path(link).is_symlink():
-            Path(link).unlink()
-        os.symlink(target, link)
-
-    def _cmd_rm(self, args: list[str]) -> None:
-        for a in args:
-            if a.startswith("-"):
-                continue
-            p = Path(a)
-            if p.is_dir():
-                shutil.rmtree(p, ignore_errors=True)
-            elif p.exists():
-                p.unlink()
+    # NB: cp / ln / rm / install_program are intentionally NOT implemented. The
+    # three pfBlockerNG port Makefiles drive only MKDIR / INSTALL_DATA /
+    # INSTALL_SCRIPT / SED / REINPLACE_CMD (plus MV, handled above); an unknown
+    # ${MACRO} is a hard error (see _exec), so re-add a command the day a port
+    # actually needs it.
 
     def _cmd_reinplace_cmd(self, args: list[str]) -> None:
         self._sed_inplace(args)

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -248,6 +248,16 @@ def test_recipe_bare_mv_and_unknown_command(tmp_path: Path) -> None:
         bpp.Recipe(bad).run("do-install")
 
 
+def test_recipe_unused_commands_are_unsupported(tmp_path: Path) -> None:
+    # cp / ln / rm / install_program were removed (#502 B2): the port Makefiles
+    # never emit them, so they must now fail as hard errors rather than silently
+    # carrying a maintenance burden. mv stays (exercised above), so it is NOT here.
+    for cmd in ("CP", "LN", "RM", "INSTALL_PROGRAM"):
+        mk = make_mk(tmp_path, f"do-install:\n\t${{{cmd}}} a b\n")
+        with pytest.raises(bpp.BuildError, match="unsupported recipe command"):
+            bpp.Recipe(mk).run("do-install")
+
+
 def test_safe_extract_rejects_traversal(tmp_path: Path) -> None:
     # A path-traversal member must be rejected (the stdlib 'data' filter).
     buf = io.BytesIO()

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -249,7 +249,7 @@ def test_recipe_bare_mv_and_unknown_command(tmp_path: Path) -> None:
 
 
 def test_recipe_unused_commands_are_unsupported(tmp_path: Path) -> None:
-    # cp / ln / rm / install_program were removed (#502 B2): the port Makefiles
+    # cp / ln / rm / install_program were removed (#502 B4): the port Makefiles
     # never emit them, so they must now fail as hard errors rather than silently
     # carrying a maintenance burden. mv stays (exercised above), so it is NOT here.
     for cmd in ("CP", "LN", "RM", "INSTALL_PROGRAM"):


### PR DESCRIPTION
## What

Remove the unused `cp` / `ln` / `rm` / `install_program` recipe commands from `build-pkg-portable.py`'s Makefile-recipe interpreter — **Bucket B item B4** of #502.

## Why it's safe

All three pfBlockerNG port Makefiles (`pfSense-pkg-pfBlockerNG{,-devel,-nightly}`) drive only `MKDIR` / `INSTALL_DATA` / `INSTALL_SCRIPT` / `SED` / `REINPLACE_CMD` (plus `MV`, which the test suite exercises). `_cmd_cp`, `_cmd_ln`, `_cmd_rm`, `_cmd_install_program` are never emitted.

The interpreter already treats an unknown `${MACRO}` as a hard error ("teach build-pkg-portable.py this command"), so a future port that grows one of these fails **loudly at build time** and the command is re-added then. That hard-error design is exactly what makes pre-implementing them unnecessary.

## Changes

- Remove `_cmd_cp` / `_cmd_ln` / `_cmd_rm` / `_cmd_install_program`
- `_copy_args` (shared by cp/ln/mv) inlined into the surviving `_cmd_mv`
- Test: assert `CP`/`LN`/`RM`/`INSTALL_PROGRAM` now raise the hard error — **red before this change** (cp would `FileNotFoundError` instead of the unsupported-command error); `mv` stays covered by the existing modes / bare-mv tests

## Scope note

Audit item **B6** (`--compression xz`) was investigated and **deliberately NOT removed**: the test suite builds packages with `--compression xz` to read them back via stdlib `lzma` without needing the `zstd` binary/module, and it's a documented fallback (see the `_zstd_compress` error message). It's load-bearing, not dead.

Part of #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of move operations during package builds by ignoring extra option flags and validating required paths.
  * Build recipes now clearly fail when unsupported file-manipulation commands are used, while move operations remain supported.

* **Tests**
  * Added coverage for unsupported recipe commands to ensure build failures are raised consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->