### PR TITLE
pfblockerng: drop dead .each() wrapper + fix stale feeds comments — #502

### DIFF
--- a/src/usr/local/www/pfblockerng/pfBlockerNG.js
+++ b/src/usr/local/www/pfblockerng/pfBlockerNG.js
@@ -113,10 +113,7 @@ function pfb_autocomplete() {
 
 // Remove label columns that contain 'XXXX' (To gain full page width)
 function pfb_remove_label() {
-
-	$('label[class="col-sm-2 control-label"]').each(function() {
-		$("label:contains('XXXX')").remove();
-	});
+	$("label:contains('XXXX')").remove();
 }
 
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -160,8 +160,8 @@ if ($_POST) {
 
 // Render the Feed Settings alias-name override inputs for a single $type
 // ('ipv4'|'ipv6'|'dnsbl'). Emits that type's StaticText label + its 'feed_<alias>'
-// Form_Input set into $section, identical to the inline loops it replaces. The page
-// calls it for ipv4, ipv6, dnsbl in turn (Phase 3 calls it for the active type only).
+// Form_Input set into $section. The page calls it once, for the active (?type=)
+// tab only (ADR-16 type-scoped UI).
 function pfb_feeds_render_aliasname_inputs($section, $type, $feeds_list, $pconfig) {
 
 	$labels = array(
@@ -284,8 +284,8 @@ function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url,
 // per-type block it replaces. The cross-type accumulators ($alt_selected CSV,
 // $feed_info_row separator counter, $aliasname_found) and the state shared with
 // url_compare ($ex_feeds, $alt_feeds, $icon) live at page (global) scope and are bound
-// via `global` so calling this once per type reproduces the original interleaved render.
-// The page loops it for ipv4+ipv6+dnsbl today; Phase 3 calls it for the active type only.
+// via `global`. The page calls it once, for the active (?type=) tab only
+// (ADR-16 type-scoped UI).
 function pfb_feeds_render_predefined_type($ftype, $info) {
 
 	global $ex_feeds, $alt_feeds, $icon, $fconfig, $feed_alt_selected;


### PR DESCRIPTION
## What

Two small dead-flexibility cleanups in shipped `www/` code — from the "small / judgment-call" set of #502.

### `pfBlockerNG.js` — drop the no-op `.each()` wrapper

`pfb_remove_label()` wrapped an idempotent global removal in a loop that ignored `this`:

```js
$('label[class="col-sm-2 control-label"]').each(function() {
    $("label:contains('XXXX')").remove();   // global, ignores `this`
});
```

The `XXXX` placeholder labels **are** `col-sm-2 control-label` labels, so the loop always ran ≥1× whenever any existed — behaviourally identical to a single unconditional `remove()`. Collapsed to that one call.

### `pfblockerng_feeds.php` — fix stale docblocks

`pfb_feeds_render_aliasname_inputs()` / `pfb_feeds_render_predefined_type()` docblocks still claimed the page "loops it for ipv4+ipv6+dnsbl". ADR-16 made the page type-scoped (`?type=`); both are now called **once for the active tab only** (the inline call-site comments already say so). Corrected the docblocks to match.

## Testing

No behaviour change. The JS is jQuery/DOM-bound and has no unit-test harness (the `widget-js-tests` suite covers only the pure widget helpers via `module.exports`); page render is guarded by the Tier A `ui_render` smoke. The PHP change is comment-only.

## Scope notes — audit items investigated and deliberately NOT changed

- **`PFB_STATUS` env var** (hooks): a documented ADR-12 hook-ABI **reserved placeholder** (`architecture-notes.md`: "the sole remaining stable reserved placeholder"). Removing it would break user hook scripts that read `$PFB_STATUS` and contradicts the ADR. Kept.
- **`_idn_dual_form` `worst is None` branch** (`pfb_unbound.py`): an explicitly-documented defensive fallback in the homoglyph-**block** (security) path. Not simplified away.

Part of #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
