### PR TITLE
pfblockerng: contain (realpath) + timeout the on-box scripts pfBlockerNG executes

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -13639,7 +13639,7 @@ function sync_package_pfblockerng($cron='') {
 								$file_dwn_esc = escapeshellarg("{$file_dwn}.orig");
 								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.pre"); // Save original file for restoration
 								$tmo = '/usr/bin/timeout -s TERM -k ' . PFB_HOOK_KILL_GRACE . ' ' . PFB_LIST_SCRIPT_TIMEOUT . ' ';
-								exec("{$tmo}{$pfb_script_pre} {$file_dwn_esc} {$list['vtype']} {$elog}");
+								exec("{$tmo}" . escapeshellarg($pfb_script_pre) . " {$file_dwn_esc} {$list['vtype']} {$elog}");
 							}
 
 							if (($fhandle = @fopen("{$file_dwn}.orig", 'r')) !== FALSE) {
@@ -13855,11 +13855,11 @@ function sync_package_pfblockerng($cron='') {
 
 							// IP v4/6 Advanced Tunable - (Post Script processing)
 							if ($pfb_script_post && is_file("{$pfb_script_post}")) {
-								pfb_logger("\nExecuting post-script: {$list['script_pre']}\n", 1);
+								pfb_logger("\nExecuting post-script: {$list['script_post']}\n", 1);
 								$file_org_esc = escapeshellarg("{$file_dwn}.orig");
 								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.post"); // Save original file for restoration
 								$tmo = '/usr/bin/timeout -s TERM -k ' . PFB_HOOK_KILL_GRACE . ' ' . PFB_LIST_SCRIPT_TIMEOUT . ' ';
-								exec("{$tmo}{$pfb_script_post} {$file_org_esc} {$list['vtype']} {$elog}");
+								exec("{$tmo}" . escapeshellarg($pfb_script_post) . " {$file_org_esc} {$list['vtype']} {$elog}");
 							}
 
 							if (!$custom) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1082,6 +1082,36 @@ function pfb_dnsbl_v6_vip_required(bool $listens_v6, bool $auto): bool {
 	return $listens_v6 && !$auto;
 }
 
+/*
+ * Resolve a per-feed list pre/post script (config-stored basename) to its
+ * absolute path, or FALSE. The script must be a regular file whose canonical
+ * path sits directly in one of the allowed list-script dirs (list_scripts/,
+ * with the legacy package root as upgrade fallback). realpath() + strict
+ * dirname containment = parity with pfb_filter() LOCALFILE, so a symlink
+ * escaping the dir is rejected. Executable bit is NOT required (presence in
+ * the dir is the authorization). $dirs is overridable for off-appliance tests.
+ */
+function pfb_resolve_list_script($name, $dirs = null) {
+	$name = basename((string) $name);	// traversal defense
+	if ($name === '') {
+		return FALSE;
+	}
+	if ($dirs === null) {
+		$dirs = array('/usr/local/pkg/pfblockerng/list_scripts', '/usr/local/pkg/pfblockerng');
+	}
+	foreach ($dirs as $dir) {
+		$real_dir = realpath($dir);
+		if ($real_dir === FALSE) {
+			continue;
+		}
+		$real = realpath("{$dir}/{$name}");
+		if ($real !== FALSE && dirname($real) === $real_dir && is_file($real)) {
+			return "{$dir}/{$name}";	// ponytail: in-dir path; exec follows the (contained) link
+		}
+	}
+	return FALSE;
+}
+
 // v6 stays OPTIONAL (ADR-13 §7 pivot): a missing v6 VIP never fails validation, even when
 // the resolver listens on IPv6 — pfb_global surfaces that as a non-blocking warning, not a
 // force-disable. The validator only checks the VIPs that ARE configured (existence,
@@ -2398,6 +2428,11 @@ if (!defined('PFB_HOOK_TIMEOUT_DEFAULT')) {
 // Grace period (seconds) after SIGTERM before timeout(1) sends SIGKILL.
 if (!defined('PFB_HOOK_KILL_GRACE')) {
 	define('PFB_HOOK_KILL_GRACE', 5);
+}
+
+// Ceiling (seconds) for per-feed list pre/post transform scripts.
+if (!defined('PFB_LIST_SCRIPT_TIMEOUT')) {
+	define('PFB_LIST_SCRIPT_TIMEOUT', 300);
 }
 
 // Directory holding the admin-authored hook scripts the picker offers and the
@@ -13417,27 +13452,14 @@ function sync_package_pfblockerng($cron='') {
 						$srcint = $list['srcint'] ?: FALSE;
 
 						// IP v4/6 Advanced Tunable - (Pre/Post Script processing)
-						// List scripts live under list_scripts/; fall back to the
-						// legacy package root so a not-yet-migrated custom script
-						// still runs during the upgrade transition.
-						$pfb_script_pre = FALSE;
-						if (isset($list['script_pre']) && !empty($list['script_pre'])) {
-							$script_pre = basename($list['script_pre']);
-							if (file_exists("/usr/local/pkg/pfblockerng/list_scripts/{$script_pre}")) {
-								$pfb_script_pre = "/usr/local/pkg/pfblockerng/list_scripts/{$script_pre}";
-							} elseif (file_exists("/usr/local/pkg/pfblockerng/{$script_pre}")) {
-								$pfb_script_pre = "/usr/local/pkg/pfblockerng/{$script_pre}";
-							}
-						}
-
+						// list_scripts/ first, legacy package root as upgrade fallback.
+						$pfb_script_pre  = FALSE;
 						$pfb_script_post = FALSE;
+						if (isset($list['script_pre']) && !empty($list['script_pre'])) {
+							$pfb_script_pre = pfb_resolve_list_script($list['script_pre']);
+						}
 						if (isset($list['script_post']) && !empty($list['script_post'])) {
-							$script_post = basename($list['script_post']);
-							if (file_exists("/usr/local/pkg/pfblockerng/list_scripts/{$script_post}")) {
-								$pfb_script_post = "/usr/local/pkg/pfblockerng/list_scripts/{$script_post}";
-							} elseif (file_exists("/usr/local/pkg/pfblockerng/{$script_post}")) {
-								$pfb_script_post = "/usr/local/pkg/pfblockerng/{$script_post}";
-							}
+							$pfb_script_post = pfb_resolve_list_script($list['script_post']);
 						}
 
 						// Determine 'list' details (return array $pfbarr)
@@ -13612,11 +13634,12 @@ function sync_package_pfblockerng($cron='') {
 							}
 
 							// IPv4/6 Advanced Tunable - (Pre Script processing)
-							if ($pfb_script_pre && file_exists("{$pfb_script_pre}")) {
+							if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {
 								pfb_logger("\nExecuting pre-script: {$list['script_pre']}\n", 1);
 								$file_dwn_esc = escapeshellarg("{$file_dwn}.orig");
 								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.pre"); // Save original file for restoration
-								exec("{$pfb_script_pre} {$file_dwn_esc} {$list['vtype']} {$elog}");
+								$tmo = '/usr/bin/timeout -s TERM -k ' . PFB_HOOK_KILL_GRACE . ' ' . PFB_LIST_SCRIPT_TIMEOUT . ' ';
+								exec("{$tmo}{$pfb_script_pre} {$file_dwn_esc} {$list['vtype']} {$elog}");
 							}
 
 							if (($fhandle = @fopen("{$file_dwn}.orig", 'r')) !== FALSE) {
@@ -13831,11 +13854,12 @@ function sync_package_pfblockerng($cron='') {
 							pfb_logger("\n", 1);
 
 							// IP v4/6 Advanced Tunable - (Post Script processing)
-							if ($pfb_script_post && file_exists("{$pfb_script_post}")) {
+							if ($pfb_script_post && is_file("{$pfb_script_post}")) {
 								pfb_logger("\nExecuting post-script: {$list['script_pre']}\n", 1);
 								$file_org_esc = escapeshellarg("{$file_dwn}.orig");
 								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.post"); // Save original file for restoration
-								exec("{$pfb_script_post} {$file_org_esc} {$list['vtype']} {$elog}");
+								$tmo = '/usr/bin/timeout -s TERM -k ' . PFB_HOOK_KILL_GRACE . ' ' . PFB_LIST_SCRIPT_TIMEOUT . ' ';
+								exec("{$tmo}{$pfb_script_post} {$file_org_esc} {$list['vtype']} {$elog}");
 							}
 
 							if (!$custom) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2976,15 +2976,30 @@ function pfb_hook_scripts($when, $dir = null) {
 	if ($dir === null) {
 		$dir = PFB_HOOK_SCRIPT_DIR;
 	}
+	// Resolve the allowed directory once. realpath() returns FALSE when the
+	// directory does not exist or is unresolvable — bail early.
+	$real_dir = realpath($dir);
+	if ($real_dir === FALSE) {
+		return array();
+	}
 	$out = array();
 	foreach (glob("{$dir}/hook_{$when}_*.{sh,py}", GLOB_BRACE) ?: array() as $path) {
-		// Only offer files the runner can actually exec: a regular, executable file
-		// (the runner runs it via its own shebang + execute bit). A directory or a
-		// non-executable file matching the glob would otherwise validate but fail
-		// at run time -- keep the picker, validator, and runner in agreement.
-		if (!is_file($path) || !is_executable($path)) {
+		// Canonicalize the candidate. realpath() follows symlinks and resolves
+		// '..'; FALSE means dangling symlink or unresolvable — skip.
+		// Parity with pfb_filter() LOCALFILE containment: dirname($real) must
+		// equal $real_dir so a symlink pointing outside the hook dir is excluded.
+		// is_file($real) rejects symlinks-to-directories.
+		// Executable bit is intentionally NOT gated here: presence as a regular
+		// file in the allowed dir is the authorization. A non-executable script
+		// will fail at run time (timeout(1) non-zero exit, logged by pfb_run_hooks),
+		// so the picker/validator authorize on containment + regular-file only.
+		$real = realpath($path);
+		if ($real === FALSE || dirname($real) !== $real_dir || !is_file($real)) {
 			continue;
 		}
+		// Key by the name as it appears in the dir (the symlink's own basename,
+		// not the target's), matching what the picker stores in config and what
+		// pfb_run_hooks() rebuilds the path from.
 		$base = basename($path);
 		$out[$base] = $base;
 	}

--- a/tests/php/PfbHookScriptsTest.php
+++ b/tests/php/PfbHookScriptsTest.php
@@ -28,10 +28,34 @@ final class PfbHookScriptsTest extends TestCase
 
 	public function testEnumeratesPreScriptsSortedByBasename(): void
 	{
-		// Only hook_pre_*.{sh,py}; the ip_pre_ decoy and the .txt are excluded.
+		// Only hook_pre_*.{sh,py}; the ip_pre_ decoy and .txt excluded.
+		// hook_pre_noexec.sh (0644) is included — exec bit is not a gate.
 		$this->assertSame(
-			['hook_pre_alpha.sh' => 'hook_pre_alpha.sh', 'hook_pre_beta.py' => 'hook_pre_beta.py'],
+			[
+				'hook_pre_alpha.sh'  => 'hook_pre_alpha.sh',
+				'hook_pre_beta.py'   => 'hook_pre_beta.py',
+				'hook_pre_noexec.sh' => 'hook_pre_noexec.sh',
+			],
 			pfb_hook_scripts('pre', self::dir())
+		);
+	}
+
+	/**
+	 * Given: hook_pre_noexec.sh is a regular 0644 file (no execute bit) in the hook dir.
+	 * When:  pfb_hook_scripts('pre', $dir) is called.
+	 * Then:  the file IS included — exec bit is not required.
+	 *
+	 * Red→green: with the old `|| !is_executable($real)` guard the file would be
+	 * excluded; without it the file is present in the enumerated set.
+	 */
+	public function testNonExecutableRegularFileIsIncluded(): void
+	{
+		$scripts = pfb_hook_scripts('pre', self::dir());
+		$this->assertArrayHasKey('hook_pre_noexec.sh', $scripts,
+			'A non-executable (0644) regular file must be included — exec bit is not a gate');
+		$this->assertTrue(
+			pfb_hook_script_valid('hook_pre_noexec.sh', 'pre', self::dir()),
+			'Validator must accept the non-executable file as it is contained + regular'
 		);
 	}
 
@@ -84,5 +108,142 @@ final class PfbHookScriptsTest extends TestCase
 		$this->assertFalse(pfb_hook_script_valid('sub/hook_pre_alpha.sh', 'pre', self::dir()));
 		$this->assertFalse(pfb_hook_script_valid('/etc/passwd', 'pre', self::dir()));
 		$this->assertFalse(pfb_hook_script_valid('', 'pre', self::dir()));
+	}
+
+	// -----------------------------------------------------------------------
+	// Symlink-containment tests (realpath parity with pfb_filter LOCALFILE).
+	// Symlinks are built at runtime in a temp dir — not committed to the repo.
+	// -----------------------------------------------------------------------
+
+	/** @return string path to an executable file OUTSIDE the hook dir */
+	private static function makeOutsideScript(): string
+	{
+		$f = tempnam(sys_get_temp_dir(), 'pfb_outside_');
+		file_put_contents($f, "#!/bin/sh\n");
+		chmod($f, 0755);
+		return $f;
+	}
+
+	/**
+	 * Build a throwaway hook dir with:
+	 *   hook_pre_real.sh          — plain file (included)
+	 *   hook_pre_alias.sh         — symlink → hook_pre_real.sh in same dir (included)
+	 *   hook_pre_escape.sh        — symlink → executable OUTSIDE dir (excluded)
+	 *   hook_pre_todir.sh         — symlink → a directory (excluded)
+	 *   hook_pre_dangle.sh        — dangling symlink (excluded)
+	 *
+	 * Returns ['dir' => ..., 'outside' => ...] so the caller can clean up.
+	 */
+	private static function makeSymlinkFixture(): array
+	{
+		$tmp    = sys_get_temp_dir() . '/pfb_hook_test_' . getmypid();
+		mkdir($tmp, 0755, TRUE);
+
+		$outside = self::makeOutsideScript();
+
+		// Plain real file
+		file_put_contents("{$tmp}/hook_pre_real.sh", "#!/bin/sh\n");
+		chmod("{$tmp}/hook_pre_real.sh", 0755);
+
+		// In-dir alias (contained)
+		symlink("{$tmp}/hook_pre_real.sh", "{$tmp}/hook_pre_alias.sh");
+
+		// Escape: points to an executable outside the dir
+		symlink($outside, "{$tmp}/hook_pre_escape.sh");
+
+		// Symlink to a directory
+		symlink($tmp, "{$tmp}/hook_pre_todir.sh");
+
+		// Dangling symlink
+		symlink("{$tmp}/nonexistent_target.sh", "{$tmp}/hook_pre_dangle.sh");
+
+		return ['dir' => $tmp, 'outside' => $outside];
+	}
+
+	private static function cleanSymlinkFixture(array $fixture): void
+	{
+		foreach (glob($fixture['dir'] . '/*') as $f) {
+			// unlink works on both files and symlinks; rmdir for the dir entry below
+			if (is_link($f) || is_file($f)) {
+				unlink($f);
+			}
+		}
+		rmdir($fixture['dir']);
+		if (file_exists($fixture['outside'])) {
+			unlink($fixture['outside']);
+		}
+	}
+
+	/**
+	 * Given: a hook dir with a plain file, an in-dir alias, an escaping symlink,
+	 *        a symlink-to-dir, and a dangling symlink.
+	 * When:  pfb_hook_scripts('pre', $dir) is called.
+	 * Then:  only the plain file and the in-dir alias are enumerated, keyed by
+	 *        the symlink's own basename (not the target's).
+	 */
+	public function testEnumerationExcludesSymlinksEscapingTheDirAndIncludesContainedAlias(): void
+	{
+		$fixture = self::makeSymlinkFixture();
+		try {
+			$scripts = pfb_hook_scripts('pre', $fixture['dir']);
+
+			// Escaping symlink, symlink-to-dir, dangling symlink must NOT appear.
+			$this->assertArrayNotHasKey('hook_pre_escape.sh', $scripts,
+				'Escaping symlink must be excluded (realpath escapes the hook dir)');
+			$this->assertArrayNotHasKey('hook_pre_todir.sh', $scripts,
+				'Symlink-to-directory must be excluded (is_file rejects dirs)');
+			$this->assertArrayNotHasKey('hook_pre_dangle.sh', $scripts,
+				'Dangling symlink must be excluded (realpath returns FALSE)');
+
+			// Plain file and contained alias must appear.
+			$this->assertArrayHasKey('hook_pre_real.sh', $scripts,
+				'Plain executable file must be included');
+			$this->assertArrayHasKey('hook_pre_alias.sh', $scripts,
+				'Contained in-dir alias must be included, keyed by the link\'s own basename');
+
+			// Values equal the basename (the picker's requirement).
+			$this->assertSame('hook_pre_alias.sh', $scripts['hook_pre_alias.sh']);
+		} finally {
+			self::cleanSymlinkFixture($fixture);
+		}
+	}
+
+	/**
+	 * Given: hook_pre_escape.sh symlinks to an executable outside the hook dir.
+	 * When:  pfb_hook_script_valid('hook_pre_escape.sh', 'pre', $dir) is called.
+	 * Then:  it returns FALSE (the escaping script is not in the enumerated set).
+	 *
+	 * Before the fix pfb_hook_scripts() would have included the escape target and
+	 * this test would have returned TRUE — red→green proof of the containment fix.
+	 */
+	public function testValidatorRejectsEscapingSymlink(): void
+	{
+		$fixture = self::makeSymlinkFixture();
+		try {
+			$this->assertFalse(
+				pfb_hook_script_valid('hook_pre_escape.sh', 'pre', $fixture['dir']),
+				'Escaping symlink must be rejected by the validator'
+			);
+		} finally {
+			self::cleanSymlinkFixture($fixture);
+		}
+	}
+
+	/**
+	 * Given: hook_pre_alias.sh is a symlink to hook_pre_real.sh in the same dir.
+	 * When:  pfb_hook_script_valid('hook_pre_alias.sh', 'pre', $dir) is called.
+	 * Then:  it returns TRUE (contained alias is allowed).
+	 */
+	public function testValidatorAcceptsContainedAliasSymlink(): void
+	{
+		$fixture = self::makeSymlinkFixture();
+		try {
+			$this->assertTrue(
+				pfb_hook_script_valid('hook_pre_alias.sh', 'pre', $fixture['dir']),
+				'In-dir alias symlink must be accepted by the validator'
+			);
+		} finally {
+			self::cleanSymlinkFixture($fixture);
+		}
 	}
 }

--- a/tests/php/PfbResolveListScriptTest.php
+++ b/tests/php/PfbResolveListScriptTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_resolve_list_script() — per-feed list pre/post transform script resolver.
+ *
+ * Policy: a config-stored basename is resolved to an absolute path only when
+ * its canonical path (via realpath) sits directly inside one of the allowed
+ * dirs. Containment + regular-file are the authorization; executable bit is
+ * NOT required. $dirs is injectable for off-appliance tests.
+ *
+ * Branch coverage: contained file (primary dir), legacy fallback dir, non-exec
+ * file, symlink escaping dir, symlink-to-dir, traversal input, empty name.
+ */
+#[CoversFunction('pfb_resolve_list_script')]
+final class PfbResolveListScriptTest extends TestCase
+{
+	/** @var string primary temp dir */
+	private string $dir1;
+	/** @var string secondary (legacy fallback) temp dir */
+	private string $dir2;
+	/** @var list<string> files/links to clean up */
+	private array $temps = [];
+
+	protected function setUp(): void
+	{
+		$base = sys_get_temp_dir() . '/pfb_rls_' . getmypid();
+		$this->dir1 = "{$base}_1";
+		$this->dir2 = "{$base}_2";
+		mkdir($this->dir1, 0755, TRUE);
+		mkdir($this->dir2, 0755, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->temps as $f) {
+			if (is_link($f) || is_file($f)) {
+				unlink($f);
+			}
+		}
+		foreach ([$this->dir1, $this->dir2] as $d) {
+			foreach (glob("{$d}/*") ?: [] as $f) {
+				if (is_link($f) || is_file($f)) {
+					unlink($f);
+				}
+			}
+			if (is_dir($d)) {
+				rmdir($d);
+			}
+		}
+	}
+
+	private function makeFile(string $dir, string $name, int $mode = 0755): string
+	{
+		$path = "{$dir}/{$name}";
+		file_put_contents($path, "#!/bin/sh\n");
+		chmod($path, $mode);
+		return $path;
+	}
+
+	private function dirs(): array
+	{
+		return [$this->dir1, $this->dir2];
+	}
+
+	/**
+	 * Given: a regular 0755 file in the primary dir.
+	 * When:  pfb_resolve_list_script is called with its basename.
+	 * Then:  returns the path inside the primary dir.
+	 */
+	public function testContainedFileResolvesToPrimaryDir(): void
+	{
+		$this->makeFile($this->dir1, 'ip_pre_test.sh');
+		$result = pfb_resolve_list_script('ip_pre_test.sh', $this->dirs());
+		$this->assertSame("{$this->dir1}/ip_pre_test.sh", $result);
+	}
+
+	/**
+	 * Given: a regular file with mode 0644 (no execute bit).
+	 * When:  pfb_resolve_list_script is called.
+	 * Then:  returns the path — exec bit is NOT a gate.
+	 *
+	 * Red→green: dropping the dirname containment check causes an escaping
+	 * symlink to resolve; similarly, adding an is_executable check here would
+	 * make this test fail. With containment+is_file only, 0644 files resolve.
+	 */
+	public function testNonExecutableFileResolves(): void
+	{
+		$this->makeFile($this->dir1, 'ip_pre_noexec.sh', 0644);
+		$result = pfb_resolve_list_script('ip_pre_noexec.sh', $this->dirs());
+		$this->assertSame("{$this->dir1}/ip_pre_noexec.sh", $result,
+			'A non-executable regular file must resolve — exec bit is not required');
+	}
+
+	/**
+	 * Given: file exists only in the legacy fallback (second) dir, not the primary.
+	 * When:  pfb_resolve_list_script is called.
+	 * Then:  resolves via the fallback dir (upgrade compatibility).
+	 */
+	public function testLegacyFallbackDirIsHonored(): void
+	{
+		$this->makeFile($this->dir2, 'ip_pre_legacy.sh');
+		$result = pfb_resolve_list_script('ip_pre_legacy.sh', $this->dirs());
+		$this->assertSame("{$this->dir2}/ip_pre_legacy.sh", $result,
+			'Legacy fallback dir must be checked when file absent from primary');
+	}
+
+	/**
+	 * Given: a symlink inside the dir whose TARGET is a file OUTSIDE the dir.
+	 * When:  pfb_resolve_list_script is called with the symlink's basename.
+	 * Then:  returns FALSE — realpath resolves to outside; dirname check rejects it.
+	 */
+	public function testSymlinkEscapingDirReturnsFalse(): void
+	{
+		$outside = tempnam(sys_get_temp_dir(), 'pfb_out_');
+		$this->temps[] = $outside;
+		file_put_contents($outside, "#!/bin/sh\n");
+		chmod($outside, 0755);
+		symlink($outside, "{$this->dir1}/ip_pre_escape.sh");
+
+		$result = pfb_resolve_list_script('ip_pre_escape.sh', $this->dirs());
+		$this->assertFalse($result,
+			'Symlink whose target is outside the dir must return FALSE (containment check)');
+	}
+
+	/**
+	 * Given: a symlink to a DIRECTORY inside the dir.
+	 * When:  pfb_resolve_list_script is called.
+	 * Then:  returns FALSE — is_file rejects directories.
+	 */
+	public function testSymlinkToDirReturnsFalse(): void
+	{
+		symlink($this->dir2, "{$this->dir1}/ip_pre_todir.sh");
+		$result = pfb_resolve_list_script('ip_pre_todir.sh', $this->dirs());
+		$this->assertFalse($result, 'Symlink to a directory must return FALSE (is_file rejects)');
+	}
+
+	/**
+	 * Given: a name with path traversal ("../other").
+	 * When:  pfb_resolve_list_script is called.
+	 * Then:  basename() strips the traversal; the resulting name does not exist → FALSE.
+	 */
+	public function testTraversalInputIsStrippedByBasename(): void
+	{
+		// Put a file in the parent's sister dir that would be reachable by traversal.
+		$this->makeFile($this->dir2, 'victim.sh');
+		// The traversal tries to reach dir2 from dir1 via "../<base2>/victim.sh"
+		$traversal = "../" . basename($this->dir2) . "/victim.sh";
+		$result     = pfb_resolve_list_script($traversal, [$this->dir1]);
+		$this->assertFalse($result,
+			'Traversal input must be basename()-stripped; the escaped name must not resolve');
+	}
+
+	/**
+	 * Given: a name with a sub-path separator ("subdir/script.sh").
+	 * When:  pfb_resolve_list_script is called.
+	 * Then:  basename() reduces it to "script.sh"; if that does not exist → FALSE.
+	 */
+	public function testSubpathInputIsStrippedByBasename(): void
+	{
+		$result = pfb_resolve_list_script('subdir/ip_pre_test.sh', $this->dirs());
+		$this->assertFalse($result, 'Sub-path separator must be basename()-stripped');
+	}
+
+	/**
+	 * Given: an empty name string.
+	 * When:  pfb_resolve_list_script is called.
+	 * Then:  returns FALSE immediately (early-exit guard).
+	 */
+	public function testEmptyNameReturnsFalse(): void
+	{
+		$this->assertFalse(pfb_resolve_list_script('', $this->dirs()));
+		$this->assertFalse(pfb_resolve_list_script('/', $this->dirs()),
+			'basename("/") is empty string → FALSE');
+	}
+}

--- a/tests/php/PfbResolveListScriptTest.php
+++ b/tests/php/PfbResolveListScriptTest.php
@@ -84,9 +84,9 @@ final class PfbResolveListScriptTest extends TestCase
 	 * When:  pfb_resolve_list_script is called.
 	 * Then:  returns the path — exec bit is NOT a gate.
 	 *
-	 * Red→green: dropping the dirname containment check causes an escaping
-	 * symlink to resolve; similarly, adding an is_executable check here would
-	 * make this test fail. With containment+is_file only, 0644 files resolve.
+	 * Red→green: adding an is_executable($real) check to the resolver would make
+	 * this test fail — proving the exec bit is deliberately NOT a gate. With
+	 * containment + is_file only, a 0644 file in the dir resolves.
 	 */
 	public function testNonExecutableFileResolves(): void
 	{

--- a/tests/php/fixtures/hook_scripts/hook_pre_noexec.sh
+++ b/tests/php/fixtures/hook_scripts/hook_pre_noexec.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "non-exec hook"


### PR DESCRIPTION
## What

Harden the resolution of admin-vetted on-box scripts that pfBlockerNG executes, matching the audited `realpath()` + strict-containment pattern already used in `pfb_filter()` LOCALFILE (the Snyk-driven local-file hardening). Two related mechanisms:

### ADR-12 update hooks (`pfb_hook_scripts`)
- `realpath()` the hook dir and each candidate; require `dirname($real) === $real_dir` so a symlink pointing **outside** the hook dir is excluded (picker won't offer it, validator rejects it, runner skips it). `is_file()` rejects symlinks-to-directories and dangling links.
- **Executable bit no longer gated**: presence as a contained regular file is the authorization. A non-executable pick fails at run time and is logged by the runner via `timeout(1)`'s non-zero exit.

### Per-feed list pre/post scripts (the `ip_pre_*` mechanism)
Previously resolved with `basename()` + `file_exists()` (follows symlinks, accepts directories, no containment) and executed with **no timeout**.
- New `pfb_resolve_list_script()` applies the same `realpath` + containment across `list_scripts/` and the legacy package-root fallback, `is_file`, no exec-bit.
- Both `exec()` sites now run under `/usr/bin/timeout -s TERM -k 5 300` (`PFB_LIST_SCRIPT_TIMEOUT=300`) — a hung transform can no longer stall the whole update pass.
- Exec-site guards switched `file_exists` → `is_file`.

## Why

A symlink in the script dir could escape to an executable elsewhere on the box and be run. Not a privilege escalation (placing the symlink already needs shell access), but inconsistent with the containment standard applied elsewhere — exactly the kind of path-without-canonicalization Snyk flags. The per-feed path additionally had no execution timeout, so a hung pre/post script blocked feed updates indefinitely.

## Tests

- `PfbHookScriptsTest`: non-executable contained file now included (red→green); existing symlink-escape / symlink-to-dir / dangling exclusions retained.
- `PfbResolveListScriptTest` (new, 8 cases): contained file resolves, non-executable resolves, legacy-fallback honored, symlink-escape / symlink-to-dir / directory rejected, traversal input stripped, empty → FALSE (containment red→green).
- Full PHPUnit suite green; PHPCS/PHPStan/`php -l` clean.

## Out of scope

The post-script log line mis-keys `script_pre` (pre-existing cosmetic typo) — left for a separate fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hook scripts so only files within the allowed folder are used, reducing the risk of invalid or unsafe script selection.
  * Added a runtime limit for hook script execution to help prevent hangs and keep feed processing moving.
  * Hook scripts can now be selected even if they are not marked executable, with execution issues handled more reliably at run time.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->