### PR TITLE
pfblockerng: skip Unbound restart when DNSBL is enabled with no feeds subscribed

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1112,6 +1112,19 @@ function pfb_resolve_list_script($name, $dirs = null) {
 	return FALSE;
 }
 
+/* Return TRUE if any DNSBL artifact path exists on disk. Used to decide whether the
+   empty-feeds pass (no feeds subscribed) has anything to clear: TRUE => clear + restart
+   once; FALSE => suppress the feed-blind reuse_dnsbl/.reload reload that otherwise
+   restarted Unbound every pass. Pure (file_exists only) so PHPUnit pins both branches. */
+function pfb_dnsbl_artifacts_exist(array $paths): bool {
+	foreach ($paths as $path) {
+		if ($path !== '' && file_exists($path)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
 // v6 stays OPTIONAL (ADR-13 §7 pivot): a missing v6 VIP never fails validation, even when
 // the resolver listens on IPv6 — pfb_global surfaces that as a non-blocking warning, not a
 // force-disable. The validator only checks the VIPs that ARE configured (existence,
@@ -12786,17 +12799,36 @@ function sync_package_pfblockerng($cron='') {
 
 			// When DNSBL is enabled and no Aliases are defined, or all Aliases are Disabled
 			if (empty($lists_dnsbl_all) && !$pfb['save']) {
-				pfb_logger("\nClearing all DNSBL Feeds", 1);
-				$pfb['domain_clear'] = TRUE;
+				$pfb_artifact_paths = array(
+					$pfb['unbound_py_data'],
+					$pfb['unbound_py_zone'],
+					$pfb['unbound_py_wh'],
+					$pfb['unbound_py_count'],
+					$pfb['unbound_py_regex_count'],
+					$pfb['unbound_py_sources'],
+					$pfb['unbound_py_rawdir'],	// dir; file_exists() is TRUE for it too, so a lingering rawdir still triggers the clear
+				);
+				if (pfb_dnsbl_artifacts_exist($pfb_artifact_paths)) {
+					// First pass after the last feed is removed — artifacts exist; clear and
+					// restart once so Unbound stops serving stale DNSBL data.
+					pfb_logger("\nClearing all DNSBL Feeds", 1);
+					$pfb['domain_clear'] = TRUE;
 
-				// Clear out Unbound pfb_dnsbl.conf file
-				unlink_if_exists($pfb['unbound_py_data']);
-				unlink_if_exists($pfb['unbound_py_zone']);
-				unlink_if_exists($pfb['unbound_py_wh']);
-				unlink_if_exists($pfb['unbound_py_count']);
-				unlink_if_exists($pfb['unbound_py_regex_count']);	// ADR-07 P8
-				unlink_if_exists($pfb['unbound_py_sources']);
-				rmdir_recursive("{$pfb['unbound_py_rawdir']}");
+					// Clear out Unbound pfb_dnsbl.conf file
+					unlink_if_exists($pfb['unbound_py_data']);
+					unlink_if_exists($pfb['unbound_py_zone']);
+					unlink_if_exists($pfb['unbound_py_wh']);
+					unlink_if_exists($pfb['unbound_py_count']);
+					unlink_if_exists($pfb['unbound_py_regex_count']);	// ADR-07 P8
+					unlink_if_exists($pfb['unbound_py_sources']);
+					rmdir_recursive("{$pfb['unbound_py_rawdir']}");
+				} else {
+					// Steady state: no feeds subscribed AND nothing on disk — suppress the
+					// feed-blind reuse_dnsbl/.reload flags set by the $dnsbl_missing check
+					// above so this pass is a no-op and Unbound is not restarted.
+					$pfb['reuse_dnsbl'] = '';
+					unlink_if_exists("{$pfb['dnsbl_file']}.reload");
+				}
 			}
 		}
 		else {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12799,6 +12799,11 @@ function sync_package_pfblockerng($cron='') {
 
 			// When DNSBL is enabled and no Aliases are defined, or all Aliases are Disabled
 			if (empty($lists_dnsbl_all) && !$pfb['save']) {
+				// The Unbound DNSBL artifacts this branch clears. NOTE: the stats DB
+				// ($pfb['dnsbl_info']) is intentionally NOT listed — the clear below
+				// never deleted it, so gating on it would keep it perpetually present
+				// and reintroduce the every-pass restart this fix removes. A stale stats
+				// DB with no active feeds is harmless and is overwritten on next subscribe.
 				$pfb_artifact_paths = array(
 					$pfb['unbound_py_data'],
 					$pfb['unbound_py_zone'],

--- a/tests/php/DnsblArtifactsExistTest.php
+++ b/tests/php/DnsblArtifactsExistTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_artifacts_exist() — the pure decider that gates the empty-feeds clear branch.
+ *
+ * When DNSBL is enabled but no feeds are subscribed, the $dnsbl_missing check sets
+ * reuse_dnsbl='on' and touches .reload (feed-blind: the py_data file doesn't exist, so it
+ * declares "missing"). Without a gate, every subsequent pass restarts Unbound even though
+ * there is nothing to clear.
+ *
+ * pfb_dnsbl_artifacts_exist() is called in the empty-feeds branch:
+ *   - TRUE  => artifacts exist on disk (first pass after the last feed is removed): clear +
+ *              restart once so Unbound stops serving stale DNSBL data.
+ *   - FALSE => nothing subscribed AND nothing on disk (steady state): suppress the
+ *              feed-blind reuse_dnsbl/.reload flags; the pass is a no-op.
+ *
+ * Per CLAUDE.md test-coverage rules: both branches are proven with a before-state assertion
+ * (no files => FALSE) and an after-state assertion (one file created => TRUE), so the test
+ * is evidence of a real branch, not always-true.
+ */
+#[CoversFunction('pfb_dnsbl_artifacts_exist')]
+final class DnsblArtifactsExistTest extends TestCase
+{
+	private string $tmpDir;
+
+	protected function setUp(): void
+	{
+		$this->tmpDir = sys_get_temp_dir() . '/pfb_artifact_test_' . getmypid();
+		mkdir($this->tmpDir, 0700, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->tmpDir}/*") ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->tmpDir);
+	}
+
+	/**
+	 * Scenario: steady-state empty — no feeds subscribed and no artifacts on disk.
+	 *
+	 * Given:  an array of paths that do not exist on disk
+	 * When:   pfb_dnsbl_artifacts_exist() is called
+	 * Then:   it returns FALSE, suppressing the restart
+	 */
+	public function testReturnsFalseWhenNoArtifactExists(): void
+	{
+		$paths = [
+			"{$this->tmpDir}/pfb_py.data",
+			"{$this->tmpDir}/pfb_py.zone",
+			"{$this->tmpDir}/pfb_py.wh",
+		];
+
+		// Before state: none of the paths exist (confirm they really don't).
+		foreach ($paths as $p) {
+			$this->assertFileDoesNotExist($p, "precondition: $p must not exist before the test");
+		}
+
+		$this->assertFalse(
+			pfb_dnsbl_artifacts_exist($paths),
+			'Expected FALSE (no artifacts on disk => steady-state no-op, no restart)'
+		);
+	}
+
+	/**
+	 * Scenario: first-removal pass — the last feed was just unsubscribed; py_data still exists.
+	 *
+	 * Given:  an array of paths where at least one file exists (a leftover artifact)
+	 * When:   pfb_dnsbl_artifacts_exist() is called
+	 * Then:   it returns TRUE, allowing the clear-and-restart once
+	 *
+	 * The before-state (FALSE with none present) is proven in testReturnsFalseWhenNoArtifactExists;
+	 * here we assert that creating one file flips the result, proving it's a real branch.
+	 */
+	public function testReturnsTrueWhenAtLeastOneArtifactExists(): void
+	{
+		$dataFile = "{$this->tmpDir}/pfb_py.data";
+		$paths    = [
+			$dataFile,
+			"{$this->tmpDir}/pfb_py.zone",
+		];
+
+		// Before state: no files yet => FALSE.
+		$this->assertFalse(
+			pfb_dnsbl_artifacts_exist($paths),
+			'Before state: no artifacts => FALSE (confirms the flip below is caused by the file)'
+		);
+
+		// Create one artifact (simulates leftover DNSBL data after the last feed is removed).
+		file_put_contents($dataFile, '');
+
+		// After state: one file present => TRUE (triggers clear + restart once).
+		$this->assertTrue(
+			pfb_dnsbl_artifacts_exist($paths),
+			'Expected TRUE (at least one artifact exists => first-removal pass, clear + restart once)'
+		);
+	}
+
+	/**
+	 * Scenario: empty-string paths are ignored (guard against blank $pfb[] entries).
+	 *
+	 * Given:  an array containing only empty strings
+	 * When:   pfb_dnsbl_artifacts_exist() is called
+	 * Then:   it returns FALSE (empty strings are not checked via file_exists)
+	 */
+	public function testIgnoresEmptyStringPaths(): void
+	{
+		$this->assertFalse(
+			pfb_dnsbl_artifacts_exist(['', '', '']),
+			'Empty-string paths must be skipped, not treated as a present file'
+		);
+	}
+}


### PR DESCRIPTION
## What

When DNSBL is enabled but **no feeds are subscribed** (no DNSBL groups/feeds, or all disabled), every update/cron pass needlessly stopped and restarted Unbound.

## Symptom

```
===[  DNSBL Process  ]================================================
 Loading DNSBL Statistics... completed
 Missing DNSBL stats and/or Unbound DNSBL files - Rebuilding
Clearing all DNSBL Feeds
Stopping Unbound Resolver...
Starting Unbound Resolver... completed
Restarting DNSBL Service (DNSBL python)
DNSBL update [ feed lines: 0 | loaded entries:  ]... completed
```

Because the empty state never changes, this fired on **every** pass, not once.

## Root cause

In `pfblockerng.inc`: the `$dnsbl_missing` check is feed-blind — with no feeds the python data file legitimately does not exist, so it declared "missing", set `reuse_dnsbl='on'`, and touched `.reload`. The "Clearing all DNSBL Feeds" branch then unconditionally set `domain_clear=TRUE`. Both force `pfb_update_unbound` → a full Unbound restart.

## Fix

Gate the empty-feeds branch on whether a DNSBL artifact is actually present on disk (`pfb_dnsbl_artifacts_exist()` — the python data/zone/whitelist/count/sources files and the raw dir):
- **Artifact present** → clear + restart once (the first pass after the last feed is removed, so Unbound stops serving stale data).
- **Nothing on disk** → reset the feed-blind `reuse_dnsbl` / `.reload` flags so the pass is a no-op; Unbound is left alone.

A genuine config change (disabling DNSBL, VIP change) still flows through the existing `$pfbpython`/`$pfbupdate` path and is unaffected.

## Tests

- `DnsblArtifactsExistTest` (new): FALSE when no artifact exists, TRUE once one is created (before/after, proving a real branch) — red→green.
- Full PHPUnit suite green; PHPCS/PHPStan/`php -l` clean.

## Follow-up (not in this PR)

Live-VM coverage (ADR-04): a smoke case asserting "DNSBL enabled, zero feeds, second pass logs no `Stopping Unbound`" would pin the steady-state behavior; it needs a no-feeds DNSBL fixture that does not exist yet.
