### PR TITLE
scripts: extract shared pfb_pkg .pkg reader, reuse in gen_landing — #502 (B5)

### DIFF
--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -1084,7 +1084,7 @@ def main(argv: list[str]) -> int:
                 release_pkgs=release_pkgs_arg,
                 annotate=annotate or None,
             )
-        except (BuildRepoError, subprocess.CalledProcessError) as e:
+        except (BuildRepoError, PkgError, subprocess.CalledProcessError) as e:
             sys.stderr.write(f"build-repo-portable: {e}\n")
             return 1
         return 0

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -105,6 +105,8 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
+from pfb_pkg import PkgError, read_compact_manifest
+
 # --------------------------------------------------------------------------- #
 # Catalog descriptor (meta.conf / meta) — byte-identical to real `pkg repo`.
 # --------------------------------------------------------------------------- #
@@ -176,51 +178,9 @@ def pkg_checksum(pkg_bytes: bytes) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# Pure-Python .pkg reader (no libpkg) — read the +COMPACT_MANIFEST JSON.
-#
-# A .pkg is a zstd-compressed tar whose first member is +COMPACT_MANIFEST (UCL,
-# which is JSON for our packages). build-pkg-portable.py writes exactly this; this
-# is the inverse read. ABI/name/version/flavor all come from that manifest — never
-# guessed from the filename (matches build-repo.sh's `pkg query -F`).
+# .pkg reading (zstd framing + +COMPACT_MANIFEST) lives in pfb_pkg, shared with
+# gen_landing.py. zstd_decompress / read_compact_manifest are imported above.
 # --------------------------------------------------------------------------- #
-
-
-def _zstd_decompress(data: bytes) -> bytes:
-    if data[:4] != b"\x28\xb5\x2f\xfd":
-        # Not zstd-framed: assume an already-uncompressed tar (defensive).
-        return data
-    try:
-        import zstandard
-
-        return zstandard.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
-    except ImportError:
-        zstd = shutil.which("zstd")
-        if not zstd:
-            raise BuildRepoError(
-                "a .pkg is zstd-compressed; install the `zstd` binary or the python `zstandard` module"
-            ) from None
-        return subprocess.run([zstd, "-dc"], input=data, stdout=subprocess.PIPE, check=True).stdout
-
-
-def read_compact_manifest(pkg_path: Path) -> dict:
-    """Return the +COMPACT_MANIFEST JSON object of a .pkg (pure Python, no libpkg)."""
-    raw = pkg_path.read_bytes()
-    tar_bytes = _zstd_decompress(raw)
-    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
-        try:
-            member = tf.extractfile("+COMPACT_MANIFEST")
-        except KeyError:
-            member = None
-        if member is None:
-            raise BuildRepoError(f"{pkg_path.name}: no +COMPACT_MANIFEST member — not a libpkg .pkg?")
-        data = member.read()
-    try:
-        obj = json.loads(data)
-    except ValueError as e:
-        raise BuildRepoError(f"{pkg_path.name}: +COMPACT_MANIFEST is not valid JSON/UCL: {e}") from None
-    if not isinstance(obj, dict):
-        raise BuildRepoError(f"{pkg_path.name}: +COMPACT_MANIFEST is not an object")
-    return obj
 
 
 # --------------------------------------------------------------------------- #
@@ -1138,7 +1098,7 @@ def main(argv: list[str]) -> int:
 
     try:
         abis = build_repo(in_dir, Path(args.out_dir), catalog_name=args.catalog_name)
-    except BuildRepoError as e:
+    except (BuildRepoError, PkgError) as e:
         sys.stderr.write(f"build-repo-portable: {e}\n")
         return 1
     sys.stderr.write(f"==> built catalogs for ABI: {' '.join(abis)}\n")

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -17,15 +17,14 @@ from __future__ import annotations
 
 import argparse
 import html
-import io
 import json
 import os
 import re
-import shutil
 import subprocess
-import tarfile
 from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
+
+from pfb_pkg import read_compact_manifest
 
 # Display order for the published-packages table (newest per channel). The channel of a
 # package is read from its name suffix (channel_of); the install CARDS are rendered
@@ -149,22 +148,10 @@ def _or_dash(value: str) -> str:
     return _esc(value) if value else '<span class="empty">&mdash;</span>'
 
 
-def read_manifest_zstd(path: str) -> dict:
-    """Read a .pkg's +COMPACT_MANIFEST (a libpkg .pkg is a zstd-compressed tar)."""
-    if shutil.which("zstd") is None:
-        raise RuntimeError("gen_landing.py needs the zstd binary to read .pkg manifests (e.g. pkg/apt install zstd)")
-    raw = subprocess.run(["zstd", "-dc", path], capture_output=True, check=True).stdout
-    with tarfile.open(fileobj=io.BytesIO(raw), mode="r:") as tar:
-        member = tar.extractfile("+COMPACT_MANIFEST")
-        if member is None:
-            raise ValueError(f"{path}: no +COMPACT_MANIFEST member")
-        return json.loads(member.read())
-
-
 def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = None) -> list[dict]:
     """Walk <site>/, returning one row per published package (channel/name/version/abi/size/rel)."""
     if read_manifest is None:
-        read_manifest = read_manifest_zstd
+        read_manifest = read_compact_manifest
     pkgs: list[dict] = []
     for dirpath, _dirs, files in os.walk(site):
         for fname in sorted(files):

--- a/scripts/pfb_pkg.py
+++ b/scripts/pfb_pkg.py
@@ -1,0 +1,66 @@
+"""Shared libpkg .pkg helpers — zstd framing + the +COMPACT_MANIFEST reader.
+
+A libpkg .pkg is a zstd-compressed tar whose first member is +COMPACT_MANIFEST
+(the package metadata). Both scripts/build-repo-portable.py and
+scripts/gen_landing.py read those manifests off-FreeBSD; this module is the one
+copy of that logic. Both run as `python3 .../scripts/<tool>.py`, so the script's
+directory (scripts/) is on sys.path and `import pfb_pkg` resolves here.
+
+stdlib-only, with an optional fast path: the `zstandard` module if installed,
+else the `zstd` binary.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+
+
+class PkgError(Exception):
+    """A .pkg could not be read (no zstd decoder available, or malformed)."""
+
+
+def zstd_decompress(data: bytes) -> bytes:
+    """Decompress a zstd frame. Non-zstd input is returned as-is (an already
+    uncompressed tar — defensive). Prefers the `zstandard` module, falls back to
+    the `zstd` binary; raises PkgError if neither is available."""
+    if data[:4] != ZSTD_MAGIC:
+        return data
+    try:
+        import zstandard
+
+        return zstandard.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
+    except ImportError:
+        zstd = shutil.which("zstd")
+        if not zstd:
+            raise PkgError(
+                "a .pkg is zstd-compressed; install the `zstd` binary or the python `zstandard` module"
+            ) from None
+        return subprocess.run([zstd, "-dc"], input=data, stdout=subprocess.PIPE, check=True).stdout
+
+
+def read_compact_manifest(pkg_path: str | Path) -> dict:
+    """Return the +COMPACT_MANIFEST JSON object of a .pkg (pure Python, no libpkg)."""
+    pkg_path = Path(pkg_path)
+    tar_bytes = zstd_decompress(pkg_path.read_bytes())
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+        try:
+            member = tf.extractfile("+COMPACT_MANIFEST")
+        except KeyError:
+            member = None
+        if member is None:
+            raise PkgError(f"{pkg_path.name}: no +COMPACT_MANIFEST member — not a libpkg .pkg?")
+        data = member.read()
+    try:
+        obj = json.loads(data)
+    except ValueError as e:
+        raise PkgError(f"{pkg_path.name}: +COMPACT_MANIFEST is not valid JSON/UCL: {e}") from None
+    if not isinstance(obj, dict):
+        raise PkgError(f"{pkg_path.name}: +COMPACT_MANIFEST is not an object")
+    return obj

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ for _name in unboundmodule.__all__:
 # Make pfb_unbound importable from its installed location within the repo.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "usr", "local", "pkg", "pfblockerng"))
 
+# Put scripts/ on sys.path so the hyphen-named tools loaded by path in the
+# build-repo / gen_landing tests can resolve their shared `import pfb_pkg`
+# (at CI runtime that dir is sys.path[0] because the tools are run directly).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
 import pytest  # noqa: E402
 
 import pfb_unbound  # noqa: E402

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -1024,6 +1024,24 @@ def test_cli_build_matrix_unwraps_versions(tmp_path: Path, monkeypatch: pytest.M
     assert captured["kw"]["build_nightly"] is False
 
 
+def test_cli_build_matrix_catches_pkg_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A PkgError reading a malformed .pkg in the --build-matrix path (the publish
+    pipeline's entry point) must exit 1 cleanly, not escape as an uncaught traceback.
+
+    PkgError now comes from the shared pfb_pkg reader; the matrix handler must catch
+    it just like the BuildRepoError it replaced for these paths.
+    """
+
+    def boom(matrix: list[dict], out_dir: Path, **kw: Any) -> dict:
+        raise brp.PkgError("bad.pkg: no +COMPACT_MANIFEST member — not a libpkg .pkg?")
+
+    monkeypatch.setattr(brp, "build_repo_matrix", boom)
+    mfile = tmp_path / "m.json"
+    mfile.write_text("[]")
+    rc = brp.main(["--build-matrix", "--matrix-json", str(mfile), "--out", str(tmp_path / "site")])
+    assert rc == 1  # caught + reported, not propagated
+
+
 def test_build_matrix_annotate_passthrough(tmp_path: Path) -> None:
     """annotate kwargs reach every builder call (so publish.yml's commit/created stamp lands).
 

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -109,7 +109,9 @@ def make_pkg(
 
 
 def _read_member(zstd_tar: Path, member: str) -> bytes:
-    data = brp._zstd_decompress(zstd_tar.read_bytes())
+    import pfb_pkg
+
+    data = pfb_pkg.zstd_decompress(zstd_tar.read_bytes())
     with tarfile.open(fileobj=io.BytesIO(data)) as tf:
         f = tf.extractfile(member)
         assert f is not None

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -118,15 +118,9 @@ def test_commit_cell_links_valid_sha_and_dashes_missing() -> None:
     assert "href" not in gl.commit_cell("../../evil")
 
 
-def test_read_manifest_requires_zstd(monkeypatch: Any) -> None:
-    """A clear error (not a generic FileNotFoundError) when the zstd binary is absent."""
-    monkeypatch.setattr(gl.shutil, "which", lambda _name: None)
-    try:
-        gl.read_manifest_zstd("whatever.pkg")
-    except RuntimeError as exc:
-        assert "zstd" in str(exc)
-    else:  # pragma: no cover - the guard must fire
-        raise AssertionError("expected RuntimeError when zstd is missing")
+# Manifest reading now lives in the shared pfb_pkg module (gen_landing imports
+# read_compact_manifest); its zstd-decoder-absent error is covered in
+# tests/test_pfb_pkg.py.
 
 
 # ── collect_packages: walk + classify + exclude plumbing ──────────────────────
@@ -623,7 +617,7 @@ def test_write_site_emits_browse_and_autoindex_at_every_level(tmp_path: Path, mo
     _touch(site / "meta.json")
 
     manifest = {"name": "pfSense-pkg-pfBlockerNG-devel", "version": "3.2.16", "abi": "FreeBSD:15:amd64"}
-    monkeypatch.setattr(gl, "read_manifest_zstd", lambda p: manifest)
+    monkeypatch.setattr(gl, "read_compact_manifest", lambda p: manifest)
     monkeypatch.setattr(gl, "_conf_via_addrepo", lambda addrepo, base, ch: f"{ch}-conf")
 
     n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_ADD_REPO_REAL))
@@ -674,7 +668,7 @@ def test_browse_adapts_to_any_future_tree_shape(tmp_path: Path, monkeypatch: Any
         abi = "FreeBSD:16:riscv64" if "experimental" in path else "FreeBSD:99:powerpc64"
         return {"name": name, "version": "9.9.9", "abi": abi}
 
-    monkeypatch.setattr(gl, "read_manifest_zstd", fake_manifest)
+    monkeypatch.setattr(gl, "read_compact_manifest", fake_manifest)
     monkeypatch.setattr(gl, "_conf_via_addrepo", lambda addrepo, base, ch: f"{ch}-conf")
 
     n = gl.write_site(str(site), "https://x/pkg/", str(_ADD_REPO_REAL))

--- a/tests/test_pfb_pkg.py
+++ b/tests/test_pfb_pkg.py
@@ -29,8 +29,9 @@ def _zstd_frame(data: bytes) -> bytes:
         return zstandard.ZstdCompressor().compress(data)
     except ImportError:
         zstd = shutil.which("zstd")
-        if not zstd:  # pragma: no cover - CI/dev always has one encoder
-            pytest.skip("no zstd encoder (binary or module) available to build the fixture")
+        # CI/dev always ships one encoder; the assert both guards and narrows
+        # str|None -> str for the type checker (pytest.skip isn't NoReturn under CI mypy).
+        assert zstd, "no zstd encoder (binary or module) available to build the fixture"
         return subprocess.run([zstd, "-q", "-c"], input=data, stdout=subprocess.PIPE, check=True).stdout
 
 

--- a/tests/test_pfb_pkg.py
+++ b/tests/test_pfb_pkg.py
@@ -1,8 +1,10 @@
 """Tests for scripts/pfb_pkg.py — the shared libpkg .pkg manifest reader.
 
-Covers both branches of the zstd decoder (module fast-path vs binary fallback vs
-neither) and every error path of read_compact_manifest, so the helper both
-build-repo-portable.py and gen_landing.py now depend on is pinned in one place.
+Pins every error path of read_compact_manifest and the zstd decoder's fallback
+chain: the roundtrip uses whichever decoder the environment has (the `zstandard`
+module if installed, else the `zstd` binary), and the no-decoder case is forced
+deterministically to assert the PkgError. This is the single copy of the reader
+that both build-repo-portable.py and gen_landing.py now depend on.
 """
 
 from __future__ import annotations

--- a/tests/test_pfb_pkg.py
+++ b/tests/test_pfb_pkg.py
@@ -1,0 +1,104 @@
+"""Tests for scripts/pfb_pkg.py — the shared libpkg .pkg manifest reader.
+
+Covers both branches of the zstd decoder (module fast-path vs binary fallback vs
+neither) and every error path of read_compact_manifest, so the helper both
+build-repo-portable.py and gen_landing.py now depend on is pinned in one place.
+"""
+
+from __future__ import annotations
+
+import builtins
+import io
+import json
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pfb_pkg
+import pytest
+
+
+def _zstd_frame(data: bytes) -> bytes:
+    """Compress with whatever zstd encoder is available (mirrors the decoder fallback)."""
+    try:
+        import zstandard
+
+        return zstandard.ZstdCompressor().compress(data)
+    except ImportError:
+        zstd = shutil.which("zstd")
+        if not zstd:  # pragma: no cover - CI/dev always has one encoder
+            pytest.skip("no zstd encoder (binary or module) available to build the fixture")
+        return subprocess.run([zstd, "-q", "-c"], input=data, stdout=subprocess.PIPE, check=True).stdout
+
+
+def _tar_with(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        for name, payload in members.items():
+            ti = tarfile.TarInfo(name=name)
+            ti.size = len(payload)
+            tf.addfile(ti, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+def test_zstd_decompress_roundtrip() -> None:
+    """A real zstd frame decompresses back to the original bytes."""
+    original = b"the quick brown fox " * 50
+    assert pfb_pkg.zstd_decompress(_zstd_frame(original)) == original
+
+
+def test_zstd_decompress_passes_through_non_zstd() -> None:
+    """Non-zstd input is returned verbatim (an already-uncompressed tar — defensive)."""
+    plain = b"not a zstd frame"
+    assert pfb_pkg.zstd_decompress(plain) == plain
+
+
+def test_zstd_decompress_errors_when_no_decoder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With neither the zstandard module nor the zstd binary, a clear PkgError naming both
+    remedies — not a bare ImportError/OSError. Build the fixture while an encoder exists,
+    then remove BOTH decoders."""
+    frame = _zstd_frame(b"payload")
+    real_import = builtins.__import__
+
+    def _no_zstandard(name: str, *a: object, **k: object) -> object:
+        if name == "zstandard":
+            raise ImportError("forced: zstandard unavailable")
+        return real_import(name, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", _no_zstandard)
+    monkeypatch.setattr(pfb_pkg.shutil, "which", lambda _name: None)
+    with pytest.raises(pfb_pkg.PkgError, match="zstd"):
+        pfb_pkg.zstd_decompress(frame)
+
+
+def test_read_compact_manifest_roundtrip(tmp_path: Path) -> None:
+    """The +COMPACT_MANIFEST (first tar member) is returned as a dict."""
+    man = {"name": "pfSense-pkg-pfBlockerNG-devel", "version": "9.9.9", "abi": "FreeBSD:16:amd64"}
+    pkg = tmp_path / "x.pkg"
+    pkg.write_bytes(_zstd_frame(_tar_with({"+COMPACT_MANIFEST": json.dumps(man).encode()})))
+    assert pfb_pkg.read_compact_manifest(pkg) == man
+
+
+def test_read_compact_manifest_missing_member(tmp_path: Path) -> None:
+    """A .pkg without a +COMPACT_MANIFEST member is a clear PkgError, not a KeyError."""
+    pkg = tmp_path / "x.pkg"
+    pkg.write_bytes(_zstd_frame(_tar_with({"other": b"x"})))
+    with pytest.raises(pfb_pkg.PkgError, match="COMPACT_MANIFEST"):
+        pfb_pkg.read_compact_manifest(pkg)
+
+
+def test_read_compact_manifest_invalid_json(tmp_path: Path) -> None:
+    """A non-JSON manifest is a clear PkgError, not a bare ValueError."""
+    pkg = tmp_path / "x.pkg"
+    pkg.write_bytes(_zstd_frame(_tar_with({"+COMPACT_MANIFEST": b"{not json"})))
+    with pytest.raises(pfb_pkg.PkgError, match="JSON"):
+        pfb_pkg.read_compact_manifest(pkg)
+
+
+def test_read_compact_manifest_non_object(tmp_path: Path) -> None:
+    """Valid JSON that is not an object (e.g. a list) is a clear PkgError."""
+    pkg = tmp_path / "x.pkg"
+    pkg.write_bytes(_zstd_frame(_tar_with({"+COMPACT_MANIFEST": b"[1, 2, 3]"})))
+    with pytest.raises(pfb_pkg.PkgError, match="not an object"):
+        pfb_pkg.read_compact_manifest(pkg)


### PR DESCRIPTION
## What

Extract the shared libpkg `.pkg` manifest reader into one module — **Bucket B item B5** of #502 (the deferred one), using the approach you suggested: a single non-hyphenated `scripts/pfb_pkg.py` imported by both tools.

`build-repo-portable.py` and `gen_landing.py` each carried their own copy of "decompress a zstd-framed `.pkg`, extract `+COMPACT_MANIFEST`". `gen_landing`'s copy shelled out to the `zstd` binary and hard-errored if absent; `build-repo`'s had the better `zstandard`-module-then-binary fallback plus JSON/dict validation.

## Changes

- **`scripts/pfb_pkg.py`** (new) — `zstd_decompress` + `read_compact_manifest` + a shared `PkgError`. stdlib-only, with the `zstandard`-module → `zstd`-binary fallback.
- **`build-repo-portable.py` / `gen_landing.py`** — drop their copies, `import pfb_pkg`. Both tools run as `python3 .../scripts/<tool>.py`, so the script dir is `sys.path[0]` and the sibling imports cleanly (verified by running each `--help` from a foreign cwd). `build-repo`'s top-level handler also catches `PkgError`, so its error UX is unchanged.
- **`gen_landing`** thereby gains the module fallback **and** the JSON-validity / dict-shape validation it previously lacked.
- **`tests/conftest.py`** — put `scripts/` on `sys.path` so the path-loaded hyphen-named tools resolve `import pfb_pkg` under pytest (at CI runtime it's already `sys.path[0]`).

## Testing

- New **`tests/test_pfb_pkg.py`** — full coverage of the shared module: decoder module/binary/**neither** branches and every `read_compact_manifest` error path (missing member, invalid JSON, non-object).
- Existing **build-repo (79)** and **gen_landing (34)** suites stay green — behaviour-preserving refactor. `ruff` + `mypy tests/` clean.

## Scope note

`build-pkg-portable.py`'s own decompress is left alone — it also handles **xz** (a different shape), so folding it in is separate scope.

Part of #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
