### PR TITLE
pfblockerng: fixed Class-B/C/A DNSBL auto-VIP candidate list (#473)

### DIFF
--- a/.ADRs/ADR_13_Auto_DNSBL_VIP/ADR.md
+++ b/.ADRs/ADR_13_Auto_DNSBL_VIP/ADR.md
@@ -187,3 +187,42 @@ Prompt: `05_Docs_Smoke_DoD.txt`
 - [ ] **IPv6 recommendation (softened — §7 pivot).** With the resolver listening on IPv6: auto mode provisions `pfB_AUTO_VIP_v6` `fd00::53/128`; manual mode without a v6 VIP does **not** force-disable — DNSBL keeps running on IPv4 and `pfb_global` logs the non-blocking warning. *(CI-proven that the predicate fires on the smoke box — the resolver listens on `lo0` `::1`; the live smoke matrix confirms manual-mode DNSBL is NOT force-disabled. On-box still worth confirming the auto v6 VIP is created + a real AAAA block sinks to it.)*
 - [ ] **HA sync.** On a CARP pair, the flag + VIP replicate and each node creates/removes its own lo0 VIP on its own enable/disable.
 - [ ] **Uninstall.** Removing the package deletes the marked VIP(s); no orphan alias on lo0.
+
+---
+
+## Amendment (#473) — fixed Class-B/C/A candidate list
+
+**Status:** Accepted (2026-06-24). Supersedes the §2 `10.10.X.53` / `fd00:X::53`
+bounded sweep *and* the interim #487 disjoint-fallback pool.
+
+**Motivation.** The original preferred address `10.10.10.53` (and its `10.10.X.53`
+sweep) sits inside `10/8` — the RFC1918 range almost every install routes via a
+`/8`, so it conflicts on a large share of deployments (issue #473; the two-VM smoke
+topology, WAN `10.10.0.0/24`, exposed it). #487 widened the pool with documentation
+(RFC 5737) and CGNAT fallbacks, but those are awkward sinkhole homes and over-built
+for the need.
+
+**Decision.** `pfb_dnsbl_vip_candidates()` returns a small fixed ordered list,
+least-collision-first:
+
+- IPv4: `172.16.53.53` (Class B, least-used on end-user LANs) → `192.168.53.53`
+  (Class C) → `10.53.53.53` (Class A, most-used, last). Each a `/32` `.53` host.
+- IPv6: a single ULA candidate `fd00:53:53:53:53:53:53:53/128`.
+
+`pfb_pick_free_dnsbl_vip()` is unchanged — it still returns the first candidate free
+of VIP/subnet conflict, else `null`.
+
+**Contract preserved (§2 "Semantics that MUST be preserved").** Unchanged: marker
+reuse on upgrade (existing auto-VIPs keep their address), the `null` → checkbox
+disabled + warning ("warn and ask") last resort, and teardown. Only the candidate
+set and its order change. An IPv6 user already on `fd00:53:53:.../…` resolves the
+single-candidate conflict manually (manual VIP) — by design, no larger v6 pool.
+
+**Alternatives rejected.** A per-base /16 sweep or 48-candidate pool — over-built;
+three well-chosen RFC1918 hosts plus warn-and-ask cover all realistic topologies.
+RFC 5737 / CGNAT sinkholes (#487) — non-RFC1918, awkward as a routed sinkhole home.
+
+**Coverage.** `tests/php/DnsblVipCandidatesTest.php` (exact list + order) and
+`tests/php/DnsblPickFreeVipTest.php` (first-free, skip-to-second, skip-to-tertiary,
+all-conflict → `null`, v6 free + v6-taken → `null`). The live-VM matrix
+(`test_smoke_matrix.py`) now expects `172.16.53.53` as the elected auto address.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1163,64 +1163,31 @@ function pfb_validate_vips(string $interface, string|null $vip4 = '', string|nul
 	return [TRUE, null];
 }
 
-// [ ADR-13 / issue #487 ] Ordered, preferred-first list of DNS-themed candidate
-// sinkhole VIP addresses for a family. Pure (no side effects).
+// [ ADR-13 / issue #473 / issue #487 ] Small fixed ordered list of DNS-themed
+// candidate sinkhole VIP addresses for a family. Pure (no side effects).
 //
-// The primary sweep keeps the '.53' (DNS port) homage and back-compat ordering:
-//   AF_INET  -> 10.10.10.53 (preferred, back-compat), then 10.10.X.53 (X=0..15)
-//   AF_INET6 -> fd00::53 (preferred), then fd00:1::53 .. fd00:15::53  (ULA fc00::/7)
+// IPv4 — three candidates, Class B first (least-used RFC1918 on end-user LANs),
+// then Class C, then Class A (most-used, so last). Each is a /32 .53 host
+// (DNS-port homage):
+//   172.16.53.53  (172.16/12)
+//   192.168.53.53 (192.168/16)
+//   10.53.53.53   (10/8)
 //
-// Disjoint-range fallbacks follow the sweep so that a single common RFC1918 /
-// ULA aggregate can never exhaust the entire pool:
-//   AF_INET  -> 172.31.255.53, 172.31.254.53 (172.16/12 — survives a 10/8 LAN),
-//               192.0.2.53, 198.51.100.53, 203.0.113.53 (RFC 5737 docs — never a
-//               real LAN, ideal sinkhole), 100.64.0.53 (RFC 6598 CGNAT).
-//   AF_INET6 -> 2001:db8::53, 2001:db8:1::53 (RFC 3849 docs — disjoint from fd00::/8).
+// IPv6 — single ULA candidate: fd00:53:53:53:53:53:53:53 (/128). On conflict
+// the picker returns null and the user resolves it manually (an IPv6 user on
+// that exact ULA can address it themselves without a larger pool).
 //
-// Under any single common aggregate (10/8, 172.16/12, 192.168/16, or fd00::/8) at
-// least one fallback stays non-overlapping. The conflict-aware picker
-// (pfb_pick_free_dnsbl_vip) selects the first free one.
-//
+// The conflict-aware picker (pfb_pick_free_dnsbl_vip) returns the first free one.
 // Returns [] for any other family.
 function pfb_dnsbl_vip_candidates(int $family): array {
 
-	// Bounded sweep range for the variable group/hextet (16 candidates).
-	$sweep_max = 15;
-
-	// The preferred third octet (the '10' in 10.10.10.53).
-	$preferred_v4_octet = 10;
-
-	$candidates = [];
-
 	if ($family === AF_INET) {
-		// Preferred address first (back-compat — existing boxes keep this address),
-		// then the rest of the 10.10.X.53 sweep, skipping the preferred octet.
-		$candidates[] = "10.10.{$preferred_v4_octet}.53";
-		for ($x = 0; $x <= $sweep_max; $x++) {
-			if ($x === $preferred_v4_octet) {
-				continue;
-			}
-			$candidates[] = "10.10.{$x}.53";
-		}
-		// Disjoint-range fallbacks: survive a 10/8, 172.16/12, or 192.168/16 LAN.
-		$candidates[] = '172.31.255.53';	// 172.16/12 — disjoint from 10/8
-		$candidates[] = '172.31.254.53';
-		$candidates[] = '192.0.2.53';		// RFC 5737 TEST-NET-1 — never a real LAN
-		$candidates[] = '198.51.100.53';	// RFC 5737 TEST-NET-2
-		$candidates[] = '203.0.113.53';		// RFC 5737 TEST-NET-3
-		$candidates[] = '100.64.0.53';		// RFC 6598 CGNAT shared space
+		return ['172.16.53.53', '192.168.53.53', '10.53.53.53'];
 	} elseif ($family === AF_INET6) {
-		// Preferred fd00::53 first, then fd00:1::53 .. fd00:15::53 in order.
-		$candidates[] = 'fd00::53';
-		for ($x = 1; $x <= $sweep_max; $x++) {
-			$candidates[] = "fd00:{$x}::53";
-		}
-		// Disjoint-range fallbacks: survive a fd00::/8 ULA aggregate.
-		$candidates[] = '2001:db8::53';		// RFC 3849 documentation prefix
-		$candidates[] = '2001:db8:1::53';
+		return ['fd00:53:53:53:53:53:53:53'];
 	}
 
-	return $candidates;
+	return [];
 }
 
 // [ ADR-13 ] Return the first candidate sinkhole address (pfb_dnsbl_vip_candidates)

--- a/tests/php/DnsblPickFreeVipTest.php
+++ b/tests/php/DnsblPickFreeVipTest.php
@@ -6,24 +6,33 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_pick_free_dnsbl_vip() (ADR-13 / issue #487) — the conflict-aware picker that
- * walks pfb_dnsbl_vip_candidates() and returns the first address free of VIP/subnet
- * conflicts.
+ * pfb_pick_free_dnsbl_vip() (ADR-13 / issue #473 / issue #487) — the conflict-aware
+ * picker that walks pfb_dnsbl_vip_candidates() and returns the first address free of
+ * VIP/subnet conflicts.
  *
  * Scenario A (control): no existing VIPs, no configured subnets
  *   Given  the VIP list is empty and no subnets are seeded
  *   When   pfb_pick_free_dnsbl_vip(AF_INET, 'lan') is called
- *   Then   it returns '10.10.10.53' (the back-compat preferred address)
+ *   Then   it returns '172.16.53.53' (the first Class-B candidate)
  *
- * Scenario B (regression — issue #487): a common 10.0.0.0/8 LAN occupies the
- *   entire primary 10.10.X.53 sweep
- *   Given  all candidates in 10.0.0.0/8 conflict (seeded subnet)
- *     AND  the existing-VIP list is empty
+ * Scenario B: first candidate conflicts — skip to next
+ *   Given  172.16.53.53 is a configured subnet
  *   When   pfb_pick_free_dnsbl_vip(AF_INET, 'lan') is called
- *   Then   it returns a NON-null address that lies outside 10.0.0.0/8
- *     AND  does NOT return null (proving the disjoint fallbacks are reachable)
+ *   Then   it returns '192.168.53.53' (second candidate)
  *
- * Scenario C (unknown family): non-IP family → null
+ * Scenario B2: first two candidates conflict — fall to the tertiary
+ *   Given  172.16/12 and 192.168/16 are occupied
+ *   Then   it returns '10.53.53.53' (third/last candidate)
+ *
+ * Scenario C: all three candidates conflict — pool exhausted → null
+ *   Given  172.16/12, 192.168/16, and 10/8 are all occupied
+ *   When   pfb_pick_free_dnsbl_vip(AF_INET, 'lan') is called
+ *   Then   it returns null (user must resolve manually)
+ *
+ * Scenario E (IPv6): the single ULA candidate is returned when free, and null
+ *   when it is already a configured VIP (the user resolves the conflict manually)
+ *
+ * Scenario D (unknown family): non-IP family → null
  */
 #[CoversFunction('pfb_pick_free_dnsbl_vip')]
 final class DnsblPickFreeVipTest extends TestCase
@@ -44,60 +53,104 @@ final class DnsblPickFreeVipTest extends TestCase
 
 	// ---------- Scenario A — control ----------
 
-	public function testV4_NoConflicts_ReturnsPreferredAddress(): void
+	public function testV4_NoConflicts_ReturnsFirstCandidate(): void
 	{
-		// Given: empty VIP list, no subnet seed.
-		// (globals are already unset in setUp)
+		// Given: empty VIP list, no subnet seed (globals unset in setUp).
 
 		// When
 		$result = pfb_pick_free_dnsbl_vip(AF_INET, 'lan');
 
-		// Then: back-compat preferred address is chosen.
-		$this->assertSame('10.10.10.53', $result,
-			'With no conflicts the picker must return the back-compat preferred address');
+		// Then: Class-B first candidate is chosen (least-used RFC1918 on end-user LANs).
+		$this->assertSame('172.16.53.53', $result,
+			'With no conflicts the picker must return the first (Class-B) candidate');
 	}
 
-	// ---------- Scenario B — regression pin for issue #487 ----------
+	// ---------- Scenario B — first candidate conflicts ----------
 
-	public function testV4_Common10Slash8LanConflict_ReturnsDisjointFallback(): void
+	public function testV4_FirstCandidateConflicts_ReturnsSecond(): void
 	{
-		// Given: the entire 10.0.0.0/8 aggregate is occupied — every 10.10.X.53 candidate
-		// from the primary sweep will be reported as conflicting by where_is_ipaddr_configured.
-		// Before the fix, the pool had NO candidates outside 10/8 so the picker returned null.
-
-		// Assert the before-state: without seeding the subnet, the preferred address is returned
-		// (proves the seeded run actually changes the outcome).
+		// Given: before seeding the conflict the first candidate is returned.
 		$before = pfb_pick_free_dnsbl_vip(AF_INET, 'lan');
-		$this->assertSame('10.10.10.53', $before,
-			'Pre-condition: without subnet seed the picker must return the preferred address');
+		$this->assertSame('172.16.53.53', $before,
+			'Pre-condition: without subnet seed the picker must return the first candidate');
 
-		// Now seed the 10/8 aggregate as occupied.
-		$GLOBALS['pfb_test_configured_subnets'] = ['10.0.0.0/8'];
+		// Seed 172.16/12 as occupied.
+		$GLOBALS['pfb_test_configured_subnets'] = ['172.16.0.0/12'];
 
 		// When
 		$result = pfb_pick_free_dnsbl_vip(AF_INET, 'lan');
 
-		// Then: result must be non-null — the disjoint fallbacks provide an escape hatch.
-		$this->assertNotNull($result,
-			'With the entire 10/8 occupied the picker must NOT return null; '
-			. 'disjoint fallbacks (e.g. 172.31.255.53, 192.0.2.53) must be reachable. '
-			. 'This is the exact regression pinned by issue #487.');
-
-		// And the chosen address must actually lie outside 10.0.0.0/8.
-		$long       = ip2long($result);
-		$net_start  = ip2long('10.0.0.0');
-		$net_end    = ip2long('10.255.255.255');
-		$this->assertIsInt($long, "picker result '{$result}' must be a parseable IPv4 address");
-		$this->assertTrue($long < $net_start || $long > $net_end,
-			"picker result '{$result}' must lie outside 10.0.0.0/8 — it is still inside the conflicting aggregate");
-
-		// Confirm the result is one of the documented disjoint fallbacks.
-		$expected_fallbacks = ['172.31.255.53', '172.31.254.53', '192.0.2.53', '198.51.100.53', '203.0.113.53', '100.64.0.53'];
-		$this->assertContains($result, $expected_fallbacks,
-			"picker result '{$result}' should be one of the disjoint fallbacks: " . implode(', ', $expected_fallbacks));
+		// Then: second candidate (Class-C) is chosen.
+		$this->assertSame('192.168.53.53', $result,
+			"With 172.16/12 occupied the picker must skip to '192.168.53.53'. "
+			. "Got: '{$result}'");
 	}
 
-	// ---------- Scenario C — unknown family ----------
+	// ---------- Scenario C — all candidates conflict → null ----------
+
+	public function testV4_FirstTwoCandidatesConflict_ReturnsThird(): void
+	{
+		// Given: 172.16/12 (Class B) and 192.168/16 (Class C) are both occupied.
+		$GLOBALS['pfb_test_configured_subnets'] = ['172.16.0.0/12', '192.168.0.0/16'];
+
+		// When
+		$result = pfb_pick_free_dnsbl_vip(AF_INET, 'lan');
+
+		// Then: the Class-A tertiary candidate is chosen (last in the fixed list).
+		$this->assertSame('10.53.53.53', $result,
+			"With 172.16/12 and 192.168/16 occupied the picker must fall to the Class-A '10.53.53.53'. "
+			. "Got: '{$result}'");
+	}
+
+	public function testV4_AllCandidatesConflict_ReturnsNull(): void
+	{
+		// Given: all three RFC1918 ranges are occupied simultaneously.
+		$GLOBALS['pfb_test_configured_subnets'] = [
+			'172.16.0.0/12',   // covers 172.16.53.53
+			'192.168.0.0/16',  // covers 192.168.53.53
+			'10.0.0.0/8',      // covers 10.53.53.53
+		];
+
+		// When
+		$result = pfb_pick_free_dnsbl_vip(AF_INET, 'lan');
+
+		// Then: pool exhausted → null; user must set the VIP manually.
+		$this->assertNull($result,
+			'With all three RFC1918 ranges occupied the fixed pool is exhausted and the picker must return null');
+	}
+
+	// ---------- Scenario E — IPv6 single ULA candidate ----------
+
+	public function testV6_NoConflicts_ReturnsUlaCandidate(): void
+	{
+		// Given: empty VIP list, no seed.
+		// When
+		$result = pfb_pick_free_dnsbl_vip(AF_INET6, 'lan');
+
+		// Then: the single ULA candidate is returned.
+		$this->assertSame('fd00:53:53:53:53:53:53:53', $result,
+			'With no conflicts the v6 picker must return the single ULA candidate');
+	}
+
+	public function testV6_CandidateIsExistingVip_ReturnsNull(): void
+	{
+		// Given: before seeding, the ULA candidate is returned (transition pre-state).
+		$before = pfb_pick_free_dnsbl_vip(AF_INET6, 'lan');
+		$this->assertSame('fd00:53:53:53:53:53:53:53', $before,
+			'Pre-condition: without a conflicting VIP the v6 picker returns the ULA candidate');
+
+		// The single ULA candidate already exists as a configured VIP.
+		$GLOBALS['pfb_test_vip_list'] = ['_vip6test' => 'fd00:53:53:53:53:53:53:53'];
+
+		// When
+		$result = pfb_pick_free_dnsbl_vip(AF_INET6, 'lan');
+
+		// Then: no free candidate -> null -> the user resolves the ULA conflict manually.
+		$this->assertNull($result,
+			'With the sole ULA candidate already taken by a VIP the picker must return null');
+	}
+
+	// ---------- Scenario D — unknown family ----------
 
 	public function testUnknownFamily_ReturnsNull(): void
 	{

--- a/tests/php/DnsblVipCandidatesTest.php
+++ b/tests/php/DnsblVipCandidatesTest.php
@@ -6,178 +6,87 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_dnsbl_vip_candidates() (ADR-13 / issue #487) — the pure, side-effect-free
- * generator of DNS-themed candidate sinkhole VIP addresses.
+ * pfb_dnsbl_vip_candidates() (ADR-13 / issue #473 / issue #487) — the pure,
+ * side-effect-free fixed ordered list of DNS-themed candidate sinkhole VIP addresses.
  *
- * The pool has two tiers:
- *   1. Primary sweep: 10.10.10.53 (preferred, back-compat) + 10.10.{0..15}.53 (v4),
- *      fd00::53 + fd00:{1..15}::53 (v6) — 16 entries each.
- *   2. Disjoint-range fallbacks appended after the sweep so a single common aggregate
- *      (10/8 for v4, fd00::/8 for v6) can never exhaust the entire pool:
- *        v4: 172.31.255.53, 172.31.254.53, 192.0.2.53, 198.51.100.53,
- *            203.0.113.53, 100.64.0.53   (6 fallbacks)
- *        v6: 2001:db8::53, 2001:db8:1::53                               (2 fallbacks)
+ * IPv4: three candidates in Class-B-first order (least-used RFC1918 on end-user LANs first):
+ *   172.16.53.53  (172.16/12)
+ *   192.168.53.53 (192.168/16)
+ *   10.53.53.53   (10/8, most common, so last)
  *
- * The conflict-aware picker (pfb_pick_free_dnsbl_vip) selects the first free one;
- * the fallbacks are exercised by DnsblPickFreeVipTest when the sweep is exhausted.
+ * IPv6: single ULA candidate fd00:53:53:53:53:53:53:53.
+ * On conflict the picker returns null and the user resolves it manually.
+ *
+ * Supersedes the prior sweep+disjoint-fallback pool from issue #487.
  */
 #[CoversFunction('pfb_dnsbl_vip_candidates')]
 final class DnsblVipCandidatesTest extends TestCase
 {
 	// ---------- v4 ----------
 
-	public function testV4PrefersTheDnsHomageAddressFirst(): void
+	public function testV4ReturnsExactFixedList(): void
 	{
 		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
-		$this->assertSame('10.10.10.53', $candidates[0]);
+		$this->assertSame(
+			['172.16.53.53', '192.168.53.53', '10.53.53.53'],
+			$candidates,
+			'IPv4 candidate list must be the exact Class-B/C/A fixed list in that order'
+		);
 	}
 
-	public function testV4SweepPrecedes_Fallbacks_And_Contains_Full_16_Entries(): void
+	public function testV4FirstCandidateIsClassB(): void
 	{
 		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
-
-		// Preferred address is index 0 (back-compat).
-		$this->assertSame('10.10.10.53', $candidates[0]);
-
-		// Positions 0..15 are the full 10.10.X.53 sweep (preferred first, then X=0..9,11..15).
-		$sweep = array_slice($candidates, 0, 16);
-		$this->assertCount(16, $sweep);
-		$this->assertSame($sweep, array_values(array_unique($sweep)));
-		foreach ($sweep as $address) {
-			$this->assertMatchesRegularExpression('/^10\.10\.(?:[0-9]|1[0-5])\.53$/', $address,
-				"sweep entry '{$address}' should be 10.10.X.53 with X in 0..15");
-		}
-
-		// The full 10.10.X.53 set (X=0..15) is present exactly once in the sweep.
-		$expected_sweep = [];
-		for ($x = 0; $x <= 15; $x++) {
-			$expected_sweep[] = "10.10.{$x}.53";
-		}
-		sort($expected_sweep);
-		$got_sweep = $sweep;
-		sort($got_sweep);
-		$this->assertSame($expected_sweep, $got_sweep);
+		$this->assertSame('172.16.53.53', $candidates[0],
+			'First IPv4 candidate must be the Class-B address (least-used RFC1918 on end-user LANs)');
 	}
 
-	public function testV4FallbacksAppearAfterSweepInOrder(): void
+	public function testV4SecondCandidateIsClassC(): void
 	{
 		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
-
-		// Expected fallbacks in the required order.
-		$expected_fallbacks = [
-			'172.31.255.53',
-			'172.31.254.53',
-			'192.0.2.53',
-			'198.51.100.53',
-			'203.0.113.53',
-			'100.64.0.53',
-		];
-
-		// Total size = 16 sweep + 6 fallbacks = 22.
-		$this->assertCount(22, $candidates);
-		$this->assertSame($candidates, array_values(array_unique($candidates)),
-			'all candidates must be unique');
-
-		// Fallbacks are in positions 16..21 in the documented order.
-		$actual_fallbacks = array_slice($candidates, 16);
-		$this->assertSame($expected_fallbacks, $actual_fallbacks,
-			'fallbacks must appear after the sweep in the specified order');
+		$this->assertSame('192.168.53.53', $candidates[1],
+			'Second IPv4 candidate must be the Class-C address');
 	}
 
-	public function testV4FallbacksAllAppearInPool(): void
+	public function testV4ThirdCandidateIsClassA(): void
 	{
 		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
-
-		foreach (['172.31.255.53', '172.31.254.53', '192.0.2.53', '198.51.100.53', '203.0.113.53', '100.64.0.53'] as $fb) {
-			$pos = array_search($fb, $candidates, TRUE);
-			$this->assertIsInt($pos, "fallback '{$fb}' must be present in the candidate pool");
-			$this->assertGreaterThanOrEqual(16, $pos,
-				"fallback '{$fb}' must appear AFTER the primary 16-entry sweep (pos {$pos})");
-		}
+		$this->assertSame('10.53.53.53', $candidates[2],
+			'Third (last) IPv4 candidate must be the Class-A address (most-used, so last)');
 	}
 
-	/**
-	 * The main regression pin for issue #487: seeding the entire 10/8 aggregate as
-	 * "occupied" must leave at least one v4 candidate that falls outside 10.0.0.0/8,
-	 * so the picker has a non-null result. (The actual picker test is in
-	 * DnsblPickFreeVipTest — this asserts the pool property directly.)
-	 */
-	public function testV4PoolSurvivesACommon10Slash8Aggregate(): void
+	public function testV4ExactlyThreeCandidates(): void
 	{
-		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
-
-		$ten_slash8_start = ip2long('10.0.0.0');
-		$ten_slash8_end   = ip2long('10.255.255.255');
-
-		$outside = array_filter($candidates, static function (string $addr) use ($ten_slash8_start, $ten_slash8_end): bool {
-			$long = ip2long($addr);
-			return $long !== FALSE && ($long < $ten_slash8_start || $long > $ten_slash8_end);
-		});
-
-		$this->assertNotEmpty($outside,
-			'At least one v4 candidate must lie outside 10.0.0.0/8 so a common 10/8 LAN cannot exhaust the pool. '
-			. 'Got pool: ' . implode(', ', $candidates));
+		$this->assertCount(3, pfb_dnsbl_vip_candidates(AF_INET));
 	}
 
 	// ---------- v6 ----------
 
-	public function testV6PrefersTheDnsHomageAddressFirst(): void
+	public function testV6ReturnsExactFixedList(): void
 	{
 		$candidates = pfb_dnsbl_vip_candidates(AF_INET6);
-		$this->assertSame('fd00::53', $candidates[0]);
+		$this->assertSame(
+			['fd00:53:53:53:53:53:53:53'],
+			$candidates,
+			'IPv6 candidate list must be the single ULA fixed address'
+		);
 	}
 
-	public function testV6SweepPrecedes_Fallbacks_And_Contains_Full_16_Entries(): void
+	public function testV6ExactlyOneCandidate(): void
 	{
-		$candidates = pfb_dnsbl_vip_candidates(AF_INET6);
-
-		// Positions 0..15 are fd00::53 + fd00:1::53..fd00:15::53 in order.
-		$sweep = array_slice($candidates, 0, 16);
-		$expected_sweep = ['fd00::53'];
-		for ($x = 1; $x <= 15; $x++) {
-			$expected_sweep[] = "fd00:{$x}::53";
-		}
-		$this->assertSame($expected_sweep, $sweep);
+		$this->assertCount(1, pfb_dnsbl_vip_candidates(AF_INET6));
 	}
 
-	public function testV6FallbacksAppearAfterSweepInOrder(): void
+	public function testV6CandidateIsUla(): void
 	{
 		$candidates = pfb_dnsbl_vip_candidates(AF_INET6);
-
-		// Total size = 16 sweep + 2 fallbacks = 18.
-		$this->assertCount(18, $candidates);
-		$this->assertSame($candidates, array_values(array_unique($candidates)),
-			'all candidates must be unique');
-
-		$actual_fallbacks = array_slice($candidates, 16);
-		$this->assertSame(['2001:db8::53', '2001:db8:1::53'], $actual_fallbacks,
-			'v6 fallbacks must appear after the sweep in the specified order');
-	}
-
-	/**
-	 * Analogue of testV4PoolSurvivesACommon10Slash8Aggregate for v6:
-	 * a fd00::/8 ULA aggregate must leave at least one candidate outside.
-	 */
-	public function testV6PoolSurvivesACommonFd00Slash8Aggregate(): void
-	{
-		$candidates = pfb_dnsbl_vip_candidates(AF_INET6);
-
-		$outside = array_filter($candidates, static function (string $addr): bool {
-			// fd00::/8 = first octet of the expanded address is 'fd' (0xfd = 253 decimal).
-			// Use a simple prefix check on the normalised hex representation.
-			$bin = inet_pton($addr);
-			if ($bin === FALSE) {
-				return FALSE;
-			}
-			// First byte: 0xfd means it falls within fd00::/8 (fc00::/7 is fd + fc).
-			$first_byte = ord($bin[0]);
-			// fc00::/7 covers 0xfc and 0xfd; fd00::/8 is just 0xfd.
-			return $first_byte !== 0xfd;
-		});
-
-		$this->assertNotEmpty($outside,
-			'At least one v6 candidate must lie outside fd00::/8 so a common ULA aggregate '
-			. 'cannot exhaust the pool. Got pool: ' . implode(', ', $candidates));
+		$addr       = $candidates[0];
+		$bin        = inet_pton($addr);
+		$this->assertNotFalse($bin, "'{$addr}' must be a parseable IPv6 address");
+		// ULA = fc00::/7, first byte 0xfc or 0xfd.
+		$first_byte = ord($bin[0]);
+		$this->assertTrue($first_byte === 0xfc || $first_byte === 0xfd,
+			"'{$addr}' must be a ULA address (fc00::/7)");
 	}
 
 	// ---------- unknown family ----------

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -49,9 +49,17 @@ if (!function_exists('is_ipaddrv6')) {
 }
 
 if (!function_exists('is_ipaddr')) {
-	// pfSense util.inc: v4 OR v6.
+	// pfSense util.inc: returns 4 for an IPv4 address, 6 for an IPv6 address, FALSE
+	// otherwise (verbatim upstream semantics — pfb_get_vips() switches on case 4/6,
+	// so a bool double would mis-bucket every v6 VIP into v4 via loose TRUE==4).
 	function is_ipaddr($ipaddr) {
-		return (is_ipaddrv4($ipaddr) || is_ipaddrv6($ipaddr));
+		if (is_ipaddrv4($ipaddr)) {
+			return 4;
+		}
+		if (is_ipaddrv6($ipaddr)) {
+			return 6;
+		}
+		return FALSE;
 	}
 }
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -852,13 +852,15 @@ def ensure_dnsbl_vip(vm: SmokeVM, *, ip4: str = DEFAULT_DNSBL_VIP4, timeout: flo
 
 # The descr marker the package stamps on an auto-created v4 sinkhole VIP and the
 # first candidate address pfb_pick_free_dnsbl_vip() returns. Mirror the PHP
-# constants (PFB_AUTO_VIP_DESCR_V4) / candidate sweep in pfblockerng.inc. The
-# matrix's MANUAL VIP sits at 10.10.10.1 (DEFAULT_DNSBL_VIP4), so the first auto
-# candidate 10.10.10.53 is free and is the one auto-create picks — the two
-# coexist, which is exactly what lets the auto-VIP case run on the same VM
-# without disturbing the manual-VIP matrix.
+# constants (PFB_AUTO_VIP_DESCR_V4) / fixed candidate list in pfblockerng.inc
+# (issue #473): Class B 172.16.53.53, then Class C 192.168.53.53, then Class A
+# 10.53.53.53. This two-VM topology uses 10.10.0.0/24 (WAN) + 192.168.1.0/24
+# (LAN) and no 172.16/12, so the first candidate 172.16.53.53 is free and is the
+# one auto-create picks — distinct from the matrix's MANUAL VIP at 10.10.10.1
+# (DEFAULT_DNSBL_VIP4), so the two coexist and the auto-VIP case runs on the same
+# VM without disturbing the manual-VIP matrix.
 AUTO_VIP_DESCR_V4 = "pfB_AUTO_VIP_v4"
-AUTO_VIP_IP4 = "10.10.10.53"
+AUTO_VIP_IP4 = "172.16.53.53"
 
 
 def _php_read_scalar(vm: SmokeVM, pre: str, expr: str, *, timeout: float = 60.0) -> str:

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -907,8 +907,8 @@ def test_dnsbl_autovip_lifecycle(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_
       NOT blocked (it forwards to the stub upstream, so it resolves to a non-VIP
       address).
     * ENABLE (``pfb_dnsvip_auto`` on + DNSBL on): the package creates an IP-Alias
-      VIP at ``10.10.10.53/32`` on ``lo0`` (live in ``ifconfig``), points
-      ``pfb_dnsvip4`` at it, and the listed name now sinks to ``10.10.10.53`` —
+      VIP at ``172.16.53.53/32`` on ``lo0`` (live in ``ifconfig``), points
+      ``pfb_dnsvip4`` at it, and the listed name now sinks to ``172.16.53.53`` —
       the AUTO address, NOT the harness's manual ``10.10.10.1`` VIP.
     * DISABLE: the marked VIP is removed from config AND ``lo0``.
 
@@ -916,10 +916,11 @@ def test_dnsbl_autovip_lifecycle(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_
     touched (only marker-owned VIPs are managed). Teardown restores the manual
     VIP + auto-off so the rest of the matrix runs against its own baseline.
 
-    Auto-create picks ``10.10.10.53`` precisely because the manual VIP holds
-    ``10.10.10.1`` — the first free ``.53`` candidate — so the two coexist and
-    this case needs no second VM. Uses ``scope='update'`` (a full Force Update)
-    so ``pfb_create_dnsbl`` -> ``pfb_manage_dnsbl_vip`` actually runs.
+    Auto-create picks ``172.16.53.53`` (issue #473's first Class-B candidate)
+    because this topology uses no 172.16/12 — it is free and distinct from the
+    manual ``10.10.10.1`` VIP, so the two coexist and this case needs no second
+    VM. Uses ``scope='update'`` (a full Force Update) so ``pfb_create_dnsbl`` ->
+    ``pfb_manage_dnsbl_vip`` actually runs.
     """
     vm = deployed_vm
     domain = h.unique_domain("autovip")

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -1087,8 +1087,9 @@ def test_dnsbl_adv_inbound_proto_any_guard(
 # `set_dnsvip_auto`. The UI tier's DISTINCT value is proving the DNSBL settings
 # PAGE persists pfb_dnsvip_auto through a real CSRF form POST, with the same
 # package machinery (pfb_create_dnsbl -> pfb_manage_dnsbl_vip) then provisioning
-# the marked VIP end-to-end. Auto picks 10.10.10.53, free alongside the manual VIP
-# at 10.10.10.1 (dnsbl_vip_ready), so the two coexist on one VM.
+# the marked VIP end-to-end. Auto picks 172.16.53.53 (issue #473's first Class-B
+# candidate, free in this topology), distinct from the manual VIP at 10.10.10.1
+# (dnsbl_vip_ready), so the two coexist on one VM.
 #
 # TODO(ADR-12): add update-hooks UI coverage (add/toggle/remove a hook row + its
 # config persistence) once ADR-12 lands on devel -- it is not merged there yet.
@@ -1113,7 +1114,7 @@ def test_dnsvip_auto_form_provisions_and_removes_marked_vip(
     * ENABLE via the form: the CSRF POST must PERSIST pfb_dnsvip_auto=on (the
       UI-specific assertion -- config.xml, not the HTTP body); the next Force
       Update runs pfb_create_dnsbl('enabled') -> pfb_manage_dnsbl_vip, which
-      creates the marked VIP at 10.10.10.53 and brings it up live on lo0.
+      creates the marked VIP at 172.16.53.53 and brings it up live on lo0.
     * DISABLE via the form: the POST persists it off; a Force Update removes the
       marked VIP from config AND lo0.
 


### PR DESCRIPTION
Fixes #473.

## Problem

The DNSBL auto-VIP picker preferred `10.10.10.53` and swept `10.10.X.53` — all inside `10/8`, the RFC1918 range almost every install routes via a `/8`, so it conflicts on a large share of deployments. The interim #487 pool added RFC 5737 / CGNAT fallbacks, which are awkward sinkhole homes and over-built.

## Change

Per the maintainer's decision in the issue thread, `pfb_dnsbl_vip_candidates()` now returns a small **fixed, least-collision-first** list:

- **IPv4:** `172.16.53.53` (Class B, least-used on end-user LANs) → `192.168.53.53` (Class C) → `10.53.53.53` (Class A, last)
- **IPv6:** single ULA `fd00:53:53:53:53:53:53:53`

The picker (`pfb_pick_free_dnsbl_vip()`) is unchanged: first candidate free of VIP/subnet conflict, else `null` → the existing checkbox-disabled "warn and ask" path (no new logic). Marker reuse preserves existing installs' auto-VIP address on upgrade.

## Tests

- `DnsblVipCandidatesTest` — exact list + order, v6 single candidate, unknown family.
- `DnsblPickFreeVipTest` — first-free, skip-to-second, skip-to-tertiary, all-conflict → `null`, v6 free + v6-taken → `null` (before/after transition asserts).
- Fixed the `is_ipaddr()` test double to return `4`/`6`/`FALSE` (verbatim upstream pfSense semantics) — the bool double mis-bucketed every v6 VIP into v4 in `pfb_get_vips()` via loose `TRUE == 4`, masking v6 conflict detection in tests.
- Live-VM smoke (`test_smoke_matrix.py`, UI functional) now expect `172.16.53.53` as the elected auto address (free in the WAN `10.10.0.0/24` / LAN `192.168.1.0/24` topology).
- ADR-13 amended to document the fixed candidate list (supersedes the §2 sweep + #487 fallbacks).

Full PHPUnit suite green (1301 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-created VIP selection now uses a fixed priority list for DNSBL addresses, with clearer fallback behavior when a candidate is already in use.
  * IPv6 auto-VIP handling now uses a single ULA address candidate.

* **Bug Fixes**
  * Improved VIP selection consistency when existing addresses conflict with the preferred candidate.
  * Updated automated checks to reflect the new default auto-VIP address and expected lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->