### PR TITLE
ci: build kcov from source (cached) to restore shell coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,13 +233,43 @@ jobs:
         # Config in .shellspec (--shell sh). Functional gate for the shell scripts.
         run: shellspec
 
-      - name: Install kcov (coverage; best-effort)
-        # Coverage is informational. kcov is no longer packaged for current
-        # ubuntu-latest, so a bare `apt-get install` exits non-zero and leaves a
-        # spurious error annotation on an otherwise-green run. Swallow the failure
-        # (exit 0); the coverage step below skips cleanly when kcov is absent.
+      - name: Restore cached kcov binary
+        # kcov was removed from ubuntu-latest's apt repos; build from source and
+        # cache the install dir so subsequent runs skip the compile step.
+        id: cache-kcov
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.local/kcov
+          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ env.ImageVersion }}
+
+      - name: Build kcov from source (cache miss)
+        # Only runs when the cache is cold. best-effort: a compile failure still
+        # leaves CI green (coverage is informational).
+        if: steps.cache-kcov.outputs.cache-hit != 'true'
         continue-on-error: true
-        run: sudo apt-get install -y kcov || echo "kcov unavailable on this runner; shell coverage will be skipped (informational)"
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libdw-dev zlib1g-dev cmake g++
+          git clone --depth 1 --branch v43 https://github.com/SimonKagstrom/kcov
+          cmake -S kcov -B kcov/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/.local/kcov"
+          cmake --build kcov/build
+          cmake --install kcov/build
+
+      - name: Save kcov binary to cache
+        # Persist the install dir so the next run restores instead of rebuilding.
+        if: steps.cache-kcov.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.local/kcov
+          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ env.ImageVersion }}
+
+      - name: Install kcov runtime deps and add to PATH
+        # Runtime shared libs (libcurl, libelf, libdw) needed on both cache hit
+        # and fresh build; also adds the install dir to PATH for the coverage step.
+        continue-on-error: true
+        run: |
+          sudo apt-get update && sudo apt-get install -y libcurl4 libelf1 libdw1
+          echo "$HOME/.local/kcov/bin" >> "$GITHUB_PATH"
 
       - name: Coverage (kcov) — informational
         # Informational only (no floor yet, mirroring #38); never gates CI. Guard on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,6 +245,7 @@ jobs:
       - name: Build kcov from source (cache miss)
         # Only runs when the cache is cold. best-effort: a compile failure still
         # leaves CI green (coverage is informational).
+        id: build-kcov
         if: steps.cache-kcov.outputs.cache-hit != 'true'
         continue-on-error: true
         run: |
@@ -252,12 +253,14 @@ jobs:
             binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libdw-dev zlib1g-dev cmake g++
           git clone --depth 1 --branch v43 https://github.com/SimonKagstrom/kcov
           cmake -S kcov -B kcov/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/.local/kcov"
-          cmake --build kcov/build
+          cmake --build kcov/build --parallel "$(nproc)"
           cmake --install kcov/build
 
       - name: Save kcov binary to cache
         # Persist the install dir so the next run restores instead of rebuilding.
-        if: steps.cache-kcov.outputs.cache-hit != 'true'
+        # Gate on build success: a failed (swallowed) build would otherwise cache an
+        # empty/partial dir and poison the key until the runner image rolls over.
+        if: steps.cache-kcov.outputs.cache-hit != 'true' && steps.build-kcov.outcome == 'success'
         uses: actions/cache/save@v5
         with:
           path: ~/.local/kcov


### PR DESCRIPTION
## What

Restore shell-test coverage in CI by building **kcov from source** (v43, cached), replacing the broken `apt-get install -y kcov` in the `shell-tests` job of `.github/workflows/test.yml`.

## Why

kcov was removed from `ubuntu-latest`'s apt repos, so the previous install silently failed (`|| echo …`) and the `Coverage (kcov)` step skipped on its `command -v kcov` guard. Net effect: no error annotation, but **shell coverage was no longer produced**.

## How

- **Restore cached kcov binary** — `actions/cache/restore@v5`, path `~/.local/kcov`, key `kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ env.ImageVersion }}` (auto-invalidates on runner-image / version change).
- **Build from source on cache miss only** (`if: cache-hit != 'true'`, `continue-on-error: true`): clone v43, cmake configure/build/install into `$HOME/.local/kcov`.
- **Save to cache on cache miss only** — `actions/cache/save@v5`, same path + key (matches the repo's split restore/save convention in `ui-tests.yml`).
- **Install runtime libs + extend PATH** unconditionally (`libcurl4 libelf1 libdw1`; `~/.local/kcov/bin` → `$GITHUB_PATH`).
- The existing `Coverage (kcov) — informational` step is unchanged: still `continue-on-error: true` with its `command -v kcov` guard, so coverage stays **best-effort / non-gating**.

## Testing

A GitHub Actions workflow change has no unit test — acceptance is the live CI run producing a kcov report under the `shell-coverage` artifact. `actionlint` passes locally; the build recipe was validated on Ubuntu 24.04 per the issue.

Fixes #475
