### PR TITLE
pfblockerng: regroup General Log Settings into aligned per-log rows

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -476,57 +476,61 @@ $section->addInput(new Form_Select(
 
 $form->add($section);
 
-// ADR-30: section title includes "(max lines)" for backward-compat label; schedule
-// and reset-keep controls are added inline per log, with a single help note shown per group.
-$section = new Form_Section('Log Settings (max lines / rotation schedule)');
-$log_types = array (	'General'	=> array('pfBlockerNG' => 'log', 'Unified Log' => 'unilog', 'Error' => 'errlog', 'Extras' => 'extraslog'),
-			'IP'		=> array('IP Block' => 'ip_blocklog', 'IP Permit' => 'ip_permitlog', 'IP Match' => 'ip_matchlog'),
-			'DNSBL'		=> array('DNSBL' => 'dnslog', 'DNSBL Parse Error' => 'dnsbl_parse_err'),
-			'DNS Reply'	=> array('DNS Reply' => 'dnsreplylog')
-			);
+// issue #489: Log Settings redesigned — grouped by category with aligned column headers.
+// Three columns (Max lines / Schedule / Keep lines) are explained once in an intro row;
+// each category has a header row then one row per log. No per-field repeated help.
+$section = new Form_Section('Log Settings');
+$log_types = array(
+	'General'	=> array('pfBlockerNG' => 'log', 'Unified' => 'unilog', 'Error' => 'errlog', 'Extras' => 'extraslog'),
+	'IP'		=> array('IP Block' => 'ip_blocklog', 'IP Permit' => 'ip_permitlog', 'IP Match' => 'ip_matchlog'),
+	'DNSBL'		=> array('DNSBL' => 'dnslog', 'DNSBL Parse Error' => 'dnsbl_parse_err'),
+	'DNS Reply'	=> array('DNS Reply' => 'dnsreplylog'),
+);
 
-// Help text for the schedule column — shown once per group (first log in each group).
-$rotate_help = 'Resets this log at the start of each calendar period (day/week/month) so '
-	. 'statistics reflect the current period only. Independent of the max-lines limit. '
-	. '<strong>A reset discards that period\'s data</strong> &mdash; export first if you need history.';
-// Help text for the keep-lines column — shown once per group (first log in each group).
-$reset_keep_help = 'Lines to retain at the tail of this log when the scheduled reset fires. '
-	. 'Default: <strong>0</strong> (clear fully). '
-	. 'Set &gt; 0 as an opt-in cushion for remote log shippers that need a few moments to drain the file.';
+// Single intro explaining all three columns — replaces the former per-field repeated help.
+$section->addInput(new Form_StaticText(
+	'',
+	'<ul style="margin-bottom:0">'
+	. '<li><strong>Max lines</strong> &mdash; rolling cap; the log keeps only its most recent N lines.</li>'
+	. '<li><strong>Schedule</strong> &mdash; resets the log at the start of each calendar period '
+	. '(Daily/Weekly/Monthly); independent of Max lines. '
+	. '<strong>A reset discards that period\'s data</strong> &mdash; export first if you need history.</li>'
+	. '<li><strong>Keep lines</strong> &mdash; lines retained at the tail on a scheduled reset '
+	. '(default 0 = clear fully); set &gt; 0 as a cushion for remote log shippers.</li>'
+	. '</ul>'
+));
 
 foreach ($log_types as $logdescr => $logtype) {
-	$group    = new Form_Group($logdescr);
-	$first    = TRUE;
+	// Header row: left label = category name; three StaticText children label the columns.
+	$header = new Form_Group($logdescr);
+	$header->add(new Form_StaticText('', '<strong>Max lines</strong>'))->setWidth(4);
+	$header->add(new Form_StaticText('', '<strong>Schedule</strong>'))->setWidth(3);
+	$header->add(new Form_StaticText('', '<strong>Keep lines</strong>'))->setWidth(3);
+	$section->add($header);
+
+	// One row per log in this category.
 	foreach ($logtype as $descr => $type) {
+		$group = new Form_Group($descr);
 		$group->add(new Form_Select(
 			'log_max_' . $type,
-			$descr,
+			'',
 			$pconfig['log_max_' . $type],
 			$options_log_types
-		))->setHelp("Default: <strong>20000<br />{$descr}</strong> Log")
-		  ->setWidth(2);
-		$rotate_sel = $group->add(new Form_Select(
+		))->setWidth(4);
+		$group->add(new Form_Select(
 			'log_rotate_' . $type,
-			'Schedule',
+			'',
 			$pconfig['log_rotate_' . $type],
 			$options_log_rotate
-		))->setWidth(2);
-		if ($first) {
-			$rotate_sel->setHelp($rotate_help);
-		}
-		$keep_inp = $group->add(new Form_Input(
+		))->setWidth(3);
+		$group->add((new Form_Input(
 			'log_reset_keep_' . $type,
-			'Keep lines',
+			'',
 			'number',
 			$pconfig['log_reset_keep_' . $type]
-		))->setAttribute('min', '0')
-		  ->setWidth(2);
-		if ($first) {
-			$keep_inp->setHelp($reset_keep_help);
-			$first = FALSE;
-		}
+		))->setAttribute('min', '0'))->setWidth(3);
+		$section->add($group);
 	}
-	$section->add($group);
 }
 
 // ADR-38: syslog export controls — appended at the end of the Log Settings section.

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -183,23 +183,23 @@ def test_log_settings_grouped_layout(
 
     When the DOM is inspected for the new grouped-column structure,
 
-    Then each of the four category header texts ("General", "IP", "DNSBL", "DNS Reply") is
-      present in the page — proving the per-category header Form_Group rows were rendered;
+    Then the three column-header texts are visible on the page ("Max lines", "Schedule",
+      "Keep lines") — these are NEW elements (the per-category header ``Form_StaticText``
+      children); the old layout had no such header row, so this discriminates new from old;
     And the ``log_max_log`` control is present and its enclosing ``.form-group`` left label
       (``col-sm-2.control-label``) shows the log name "pfBlockerNG" — proving per-log rows
-      carry the individual log name as the left label, not the category name;
-    And the three column-header texts are visible on the page ("Max lines", "Schedule",
-      "Keep lines") — proving the header ``Form_StaticText`` children rendered.
+      carry the individual log name as the left label, where the OLD layout carried the
+      category name "General" on that group, so this too discriminates new from old.
+
+    (Category-name presence is deliberately NOT asserted: "General"/"IP"/"DNSBL" also appear
+    as top tabs and the old group labels, so they would pass on the old layout and add no
+    signal. The two checks above are the real before/after discriminators.)
 
     A full-page screenshot is saved as a human-review artifact (not an asserted baseline).
     """
     page = browser_page
     _open(page, webui, GENERAL_PAGE)
     _shot(page, screenshot_dir, "log_settings_grouped_layout")
-
-    # Category header texts present in the page (the Form_Group left labels for each category).
-    for cat in ("General", "IP", "DNSBL", "DNS Reply"):
-        expect(page.get_by_text(cat, exact=True).first).to_be_visible(timeout=JS_TIMEOUT_MS)
 
     # Column header texts visible (emitted by the header Form_Group's StaticText children).
     for col_header in ("Max lines", "Schedule", "Keep lines"):

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -162,3 +162,52 @@ def test_gateway_pfb_keep_save_roundtrip(
                 {"pfb_keep": original} if original == "on" else {"pfb_keep": original},
                 timeout=_GENERAL_POST_TIMEOUT,
             )
+
+
+# --------------------------------------------------------------------------- #
+# issue #489 — Log Settings grouped-column layout (Tier B structural check)
+# --------------------------------------------------------------------------- #
+
+
+def test_log_settings_grouped_layout(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """Log Settings section renders with aligned per-category grouped rows in the live DOM.
+
+    Scenario: Log Settings regrouped into aligned per-log rows with category headers (issue #489).
+      Background: pfBlockerNG deployed; General page authenticated and settled.
+
+    Given the General page is loaded in the authenticated browser,
+
+    When the DOM is inspected for the new grouped-column structure,
+
+    Then each of the four category header texts ("General", "IP", "DNSBL", "DNS Reply") is
+      present in the page — proving the per-category header Form_Group rows were rendered;
+    And the ``log_max_log`` control is present and its enclosing ``.form-group`` left label
+      (``col-sm-2.control-label``) shows the log name "pfBlockerNG" — proving per-log rows
+      carry the individual log name as the left label, not the category name;
+    And the three column-header texts are visible on the page ("Max lines", "Schedule",
+      "Keep lines") — proving the header ``Form_StaticText`` children rendered.
+
+    A full-page screenshot is saved as a human-review artifact (not an asserted baseline).
+    """
+    page = browser_page
+    _open(page, webui, GENERAL_PAGE)
+    _shot(page, screenshot_dir, "log_settings_grouped_layout")
+
+    # Category header texts present in the page (the Form_Group left labels for each category).
+    for cat in ("General", "IP", "DNSBL", "DNS Reply"):
+        expect(page.get_by_text(cat, exact=True).first).to_be_visible(timeout=JS_TIMEOUT_MS)
+
+    # Column header texts visible (emitted by the header Form_Group's StaticText children).
+    for col_header in ("Max lines", "Schedule", "Keep lines"):
+        expect(page.get_by_text(col_header).first).to_be_visible(timeout=JS_TIMEOUT_MS)
+
+    # The log_max_log control's enclosing form-group carries the per-log label "pfBlockerNG".
+    log_max_log = page.locator('select[name="log_max_log"]')
+    expect(log_max_log).to_be_attached(timeout=JS_TIMEOUT_MS)
+    form_group = log_max_log.locator("xpath=ancestor::div[contains(@class,'form-group')]")
+    label = form_group.locator(".control-label")
+    expect(label).to_contain_text("pfBlockerNG", timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -610,6 +610,79 @@ def test_software_page_hidden_when_override_forces_off(
         assert _SOFTWARE_PANEL_MARKER not in resp.text, "forced-off must NOT render the Software panel"
 
 
+def test_log_settings_section_redesign_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:  # noqa: ARG001
+    """The Log Settings section was regrouped into aligned per-log rows with a single 3-item
+    column-help intro and category header rows (issue #489).
+
+    Scenario: Log Settings section redesigned — grouped by category, aligned columns.
+      Background: pfBlockerNG deployed; General page renders cleanly.
+
+    Given the General page renders via the clean-render oracle (200, no Fatal/Warning/Notice,
+      "General Settings" section marker present),
+
+    When the body is inspected for the new grouped-column structure,
+
+    Then the three column-header texts are present in the body, emitted by the per-category
+      header ``Form_Group`` rows (PRESENT: new design);
+    And the 3-item intro wording markers are present (the column-purpose ``<ul>`` sentences
+      written in issue #489's intro ``Form_StaticText``);
+    And a representative set of field names spanning all four categories are present —
+      proving no control was dropped by the redesign;
+    And the old repeated per-field help suffix ("</strong> Log", the pattern emitted by
+      ``setHelp("Default: <strong>20000<br />{$descr}</strong> Log")`` on every row) is
+      ABSENT — the repetition was removed (ABSENT: old design, before/after evidence);
+    And the old "Unified Log" label is ABSENT — the trailing " Log" was dropped to "Unified"
+      (ABSENT: old design, before/after evidence). ``php_error_log_guard`` enrolls this GET
+      in the module-level no-growth sweep.
+
+    Source-inspection proof of fail-before/pass-after:
+    - PRESENT markers ("rolling cap", "discards that period", "cushion for remote log
+      shippers", ">Max lines<", ">Schedule<", ">Keep lines<") exist ONLY in the new
+      PHP code (the intro ``Form_StaticText`` and header ``Form_Group`` rows); they are
+      absent from ``origin/devel``, so the test FAILS on the old code and PASSES after.
+    - ABSENT markers ("</strong> Log", "Unified Log") exist ONLY in the old
+      ``setHelp("Default: <strong>20000<br />{$descr}</strong> Log")`` calls and the old
+      ``'Unified Log'`` key; they are absent from the new code, so the test PASSES after
+      the change and would FAIL if the old code were reinstated.
+    """
+    resp = webui.get(_GENERAL_PAGE)
+    result = evaluate_render(_GENERAL_PAGE, resp.status_code, resp.text, ("General Settings",))
+    assert result.ok, f"General page render oracle failed: {result.detail}"
+    body = resp.text
+
+    # PRESENT: new 3-item intro wording (emitted by the intro Form_StaticText).
+    for needle in (
+        "rolling cap",
+        "discards that period",
+        "cushion for remote log shippers",
+    ):
+        assert needle in body, f"Log Settings intro wording {needle!r} missing — redesign intro not rendered"
+
+    # PRESENT: column headers (emitted by the per-category header Form_Group rows).
+    for needle in (">Max lines<", ">Schedule<", ">Keep lines<"):
+        assert needle in body, f"Log Settings column header {needle!r} missing — header rows not rendered"
+
+    # PRESENT: field names spanning all four categories — no control dropped.
+    for field_name in (
+        'name="log_max_log"',  # General: pfBlockerNG
+        'name="log_rotate_dnslog"',  # DNSBL
+        'name="log_reset_keep_unilog"',  # General: Unified
+        'name="log_max_ip_blocklog"',  # IP
+        'name="log_rotate_dnsreplylog"',  # DNS Reply
+    ):
+        assert field_name in body, f"Log Settings field {field_name!r} missing — control dropped by redesign"
+
+    # ABSENT: old repeated per-field help suffix (was emitted by every row in the old code).
+    assert "</strong> Log" not in body, (
+        'old repeated per-field help suffix "</strong> Log" still present — setHelp repetition not removed'
+    )
+
+    # ABSENT: old "Unified Log" label (renamed to "Unified" in the redesign).
+    assert "Unified Log" not in body, (
+        '"Unified Log" label still present — label not updated to "Unified" (issue #489 rename)'
+    )
+
+
 def test_page_table_covers_every_pfblockerng_page() -> None:
     """Guard: the table (plus the recorded exclusions) covers the on-disk page set.
 


### PR DESCRIPTION
## Summary

Redesigns the **Log Settings** section of the General settings page so the per-log
controls are aligned and not repetitive (issue #489). On both desktop and mobile the
old layout crammed multiple logs × 3 fields into one wrapping `Form_Group` per
category, with the same help text repeated on every row and the word "Log" duplicated
throughout.

The section is now **grouped by category** with one aligned row per log:

- A single 3-item intro explains the three columns once (Max lines / Schedule / Keep
  lines), replacing the repeated per-field help.
- Each category (General / IP / DNSBL / DNS Reply) gets a header row labelling the
  three columns, then one `Form_Group` per log whose left label is the log name.
- The repeated trailing "Log" is dropped (`Unified Log` → `Unified`; the
  `</strong> Log` help suffix removed).

Purely presentational: every field `name`, the option arrays, the `$pconfig` reads,
and the POST handler are unchanged, so ADR-30 rotation/reset behaviour and the syslog
export block are untouched.

## Tests

- **Tier A** (`test_render_smoke.py::test_log_settings_section_redesign_render`):
  asserts the new column headers + 3-item intro wording render, every field name
  across all four categories is still present (no control dropped), and the old
  repeated `</strong> Log` suffix / `Unified Log` label are gone — red on the old
  code, green after.
- **Tier B** (`test_browser_general.py::test_log_settings_grouped_layout`): live-DOM
  structural check that the four category headers and three column headers render and
  that a per-log row carries the log name as its left label; saves a screenshot
  artifact.

Fixes #489
