### PR TITLE
pfblockerng: keep DNSBL alive across a RAM-disk /var reboot — Fixes #468

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
@@ -24,8 +24,6 @@
 require_once('config.inc');
 require_once('globals.inc');
 
-define('LOG_PREFIX_PKG_PFBLOCKERNG', 'pfBlockerNG');
-
 global $g;
 
 config_read_file(FALSE, TRUE);
@@ -105,7 +103,11 @@ function pfb_python_mount($python_mode, $verbose, $type_mount, $type_umount, $ty
 
 			if ($retval != 0) {
 				$log_err = "Failed to mount /{$folder}";
-				logger(LOG_ERR, "[Unbound-pymod]: {$log_err}", LOG_PREFIX_PKG_PFBLOCKERNG);
+				// #468: this file is require_once'd by pfSense core services_unbound_configure()
+				// on the NON-verbose boot path, where pfBlockerNG's logger() fallback is NOT
+				// loaded -- a bare logger() call is a FATAL that wedges rc.bootup. log_error()
+				// (pfSense core util.inc) is always present in that context.
+				log_error("[Unbound-pymod]: {$log_err}");
 				if ($verbose) {
 					pfb_logger("\n   {$log_err}", 1);
 				}
@@ -151,7 +153,9 @@ function pfb_python_mount($python_mode, $verbose, $type_mount, $type_umount, $ty
 		}
 		else {
 			$log_err = "Failed to unmount /{$folder}";
-			logger(LOG_ERR, "[Unbound-pymod]: {$log_err}", LOG_PREFIX_PKG_PFBLOCKERNG);
+			// #468: see the mount branch above -- bare logger() is fatal on the non-verbose
+			// boot path; log_error() (pfSense core) is always available here.
+			log_error("[Unbound-pymod]: {$log_err}");
 			if ($verbose) {
 				pfb_logger("\n   {$log_err}", 1);
 			}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -99,6 +99,9 @@ $pfb['ip_cache']	= "{$pfb['dbdir']}/ip_cache.sqlite";
 $pfb['script']		= '/usr/local/pkg/pfblockerng/pfblockerng.sh';
 $pfb['feeds']		= '/usr/local/www/pfblockerng/pfblockerng_feeds.json';
 $pfb['aliasarchive']	= '/usr/local/etc/aliastables.tar.bz2';
+// #468: DNSBL python-integration archive (RAM-disk /var restore). SEPARATE from the IP
+// aliastables archive -- managed by pfb_dnsbl_cache() / 'pfblockerng.sh dnsbl_cache'.
+$pfb['dnsblarchive']	= '/usr/local/etc/pfb_dnsbl_cache.tar.bz2';
 
 $pfb['dnsbl_tld_txt']	= "{$pfb['dnsdir']}/DNSBL_TLD.txt";
 $pfb['dnsbl_tld_data']	= '/usr/local/pkg/pfblockerng/dnsbl_tld';
@@ -4420,15 +4423,9 @@ function pfb_unbound_dnsbl($mode) {
 		}
 
 		if ($mode == 'enabled') {
-			if (!file_exists("{$g['unbound_chroot_path']}/pfb_unbound.py")) {
-				@copy("/usr/local/pkg/pfblockerng/pfb_unbound.py", "{$g['unbound_chroot_path']}/pfb_unbound.py");
-			}
-			if (!file_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc")) {
-				@copy("/usr/local/pkg/pfblockerng/pfb_unbound_include.inc", "{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
-			}
-			if (!file_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt")) {
-				@copy("/usr/local/pkg/pfblockerng/pfb_py_hsts.txt", "{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
-			}
+			// #468: the shipped-file list lives ONLY in 'dnsbl_cache stage' (single
+			// source of truth); it also mkdirs the chroot + nullfs mount-point dirs.
+			exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache stage >/dev/null 2>&1');
 		} else {
 			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
 			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
@@ -8399,7 +8396,10 @@ function pfb_aliastables($mode) {
 			pfb_logger("\nArchiving Aliastable folder", 1);
 
 			$files_to_backup = '';
-			$files = glob("{{$pfb['aliasdir']}/pfB_*.txt,{$pfb['dnsbl_file']}.conf,/var/unbound/pfb_unbound*,/var/unbound/pfb_py_*}", GLOB_BRACE);
+			// #468: IP-only. The DNSBL python integration is archived separately by
+			// pfb_dnsbl_cache() (different lifecycle); ADR-08 had wrongly piggybacked
+			// the /var/unbound/pfb_unbound* + pfb_py_* files onto this IP archive.
+			$files = glob("{{$pfb['aliasdir']}/pfB_*.txt,{$pfb['dnsbl_file']}.conf}", GLOB_BRACE);
 			if (!empty($files)) {
 				$files_to_backup = implode(' ', array_map('escapeshellarg', array_filter($files)));
 			}
@@ -8479,6 +8479,103 @@ function pfb_aliastables($mode) {
 		config_set_path('system/earlyshellcmd', $a_earlyshellcmd);
 		config_set_path('installedpackages/shellcmdsettings/config', $a_shellcmdsettings);
 		write_config('pfBlockerNG: saving earlyshellcmd');
+	}
+}
+
+
+// #468: DNSBL python-integration cache for RAM-disk /var (use_mfs_tmpvar) installs.
+// SEPARATE from pfb_aliastables() on purpose -- the IP-alias archive and the DNSBL
+// archive have different lifecycles (DNSBL changes vs IP-rule changes). All file ops
+// live in 'pfblockerng.sh dnsbl_cache' (the shipped-file list has one home, in shell).
+//
+//   'conf' -- register the boot 'dnsbl_cache restore' earlyshellcmd when DNSBL is
+//             enabled AND /var is a RAM disk; otherwise remove it and delete the
+//             archive (DNSBL off or MFS off -> nothing to restore).
+//   'save' -- archive the current generated DNSBL state (called post-reload on a real
+//             DNSBL change; the caller gates on use_mfs_tmpvar + DNSBL enabled).
+function pfb_dnsbl_cache($mode) {
+	global $pfb;
+
+	$earlyshellcmd = '/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache restore';
+
+	if ($mode == 'save') {
+		exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache save >/dev/null 2>&1');
+		return;
+	}
+
+	// $mode == 'conf'
+	// Reload config.xml to get any recent changes (parity with pfb_aliastables()).
+	config_read_file(FALSE, TRUE);
+
+	$msg = '';
+	$a_earlyshellcmd = config_get_path('system/earlyshellcmd', []);
+	$a_shellcmdsettings = config_get_path('installedpackages/shellcmdsettings/config', []);
+
+	// Register only when DNSBL is enabled AND /var is a RAM disk; else deregister.
+	$want = ($pfb['dnsbl'] == 'on' && config_path_enabled('system', 'use_mfs_tmpvar'));
+
+	if ($want) {
+		// Add earlyshellcmd settings (distinct 'dnsbl_cache restore' string).
+		if (!empty($a_earlyshellcmd)) {
+			if (!preg_grep("/pfblockerng.sh dnsbl_cache restore/", $a_earlyshellcmd)) {
+				$a_earlyshellcmd[] = "{$earlyshellcmd}";
+				$msg = "\n** Adding DNSBL cache earlyshellcmd settings **\n";
+			}
+		} else {
+			$a_earlyshellcmd = "{$earlyshellcmd}";
+			$msg = "\n** Adding DNSBL cache earlyshellcmd settings **\n";
+		}
+
+		// Add shellcmd package settings
+		$found = FALSE;
+		if (!empty($a_shellcmdsettings)) {
+			foreach ($a_shellcmdsettings as $shellcmd) {
+				if (strpos($shellcmd['cmd'], 'pfblockerng.sh dnsbl_cache restore') !== FALSE) {
+					$found = TRUE;
+					break;
+				}
+			}
+		}
+
+		if (!$found) {
+			$add = array(	'cmd'		=> $earlyshellcmd,
+					'cmdtype'	=> 'earlyshellcmd',
+					'description'	=> 'pfBlockerNG DNSBL cache earlyshellcmd. DO NOT EDIT/DELETE!');
+
+			$a_shellcmdsettings[] = $add;
+			$msg .= "\n** Adding DNSBL cache shellcmd package settings **\n";
+		}
+	}
+	else {
+		// Remove DNSBL cache archive if found
+		if (file_exists("{$pfb['dnsblarchive']}")) {
+			unlink_if_exists("{$pfb['dnsblarchive']}");
+		}
+
+		// Remove earlyshellcmd settings
+		if (!empty($a_earlyshellcmd)) {
+			if (preg_grep("/pfblockerng.sh dnsbl_cache restore/", $a_earlyshellcmd)) {
+				$a_earlyshellcmd = preg_grep("/pfblockerng.sh dnsbl_cache restore/", $a_earlyshellcmd, PREG_GREP_INVERT);
+				$msg = "\n** Removing DNSBL cache earlyshellcmd settings **\n";
+			}
+		}
+
+		// Remove shellcmd package settings
+		if (!empty($a_shellcmdsettings)) {
+			foreach ($a_shellcmdsettings as $key => $shellcmd) {
+				if (strpos($shellcmd['cmd'], 'pfblockerng.sh dnsbl_cache restore') !== FALSE) {
+					unset($a_shellcmdsettings[$key]);
+					$msg .= "\n** Removing DNSBL cache shellcmd package settings **\n";
+				}
+			}
+		}
+	}
+
+	if (!empty($msg)) {
+		pfb_logger("{$msg}", 1);
+		config_set_path('system/earlyshellcmd', $a_earlyshellcmd);
+		config_set_path('installedpackages/shellcmdsettings/config', $a_shellcmdsettings);
+		write_config('pfBlockerNG: saving DNSBL cache earlyshellcmd');
 	}
 }
 
@@ -10908,6 +11005,10 @@ function sync_package_pfblockerng($cron='') {
 	// Call function for Ramdisk processes.
 	pfb_aliastables('conf');
 
+	// #468: keep the DNSBL RAM-disk restore earlyshellcmd in sync with DNSBL state
+	// (registered iff DNSBL enabled AND use_mfs_tmpvar; removed + archive deleted else).
+	pfb_dnsbl_cache('conf');
+
 	// If table limit not defined, set default to 2M
 	if (empty(config_get_path('system/maximumtableentries'))) {
 		config_set_path('system/maximumtableentries', '2000000');
@@ -13258,6 +13359,17 @@ function sync_package_pfblockerng($cron='') {
 		}
 
 		pfb_update_unbound($mode, $pfbupdate, $pfbpython);
+
+		// #468: DNSBL actually changed this pass and the reload above has applied (the
+		// zero-downtime swap waited / Unbound restarted). On a RAM-disk /var, re-archive
+		// the generated DNSBL state so the boot 'dnsbl_cache restore' brings it back after
+		// the next reboot. Gated like the IP side (archive only inside the change branch):
+		// DNSBL active ($mode === 'enabled', i.e. enable + dnsbl + resolver on) +
+		// use_mfs_tmpvar. Read $pfb directly (not $mode) to keep the gate self-contained.
+		if ($pfb['enable'] == 'on' && $pfb['dnsbl'] == 'on' && $pfb['unbound_state'] == 'on' &&
+		    config_path_enabled('system', 'use_mfs_tmpvar')) {
+			pfb_dnsbl_cache('save');
+		}
 	}
 
 
@@ -15221,6 +15333,22 @@ function pfblockerng_php_pre_deinstall_command() {
 	}
 	foreach (config_get_path('installedpackages/shellcmdsettings/config', []) as $key => $shellcmd) {
 		if (strpos($shellcmd['cmd'], 'pfblockerng.sh aliastables') !== FALSE) {
+			config_del_path("installedpackages/shellcmdsettings/config/{$key}");
+		}
+	}
+
+	// #468: Remove DNSBL cache archive + restore earlyshellcmd if found (separate
+	// 'dnsbl_cache restore' string from the IP aliastables hook above).
+	@unlink_if_exists("{$pfb['dnsblarchive']}");
+	if (config_get_path('system/earlyshellcmd') !== null) {
+		$a_earlyshellcmd = config_get_path('system/earlyshellcmd', '');
+		if (preg_grep("/pfblockerng.sh dnsbl_cache restore/", $a_earlyshellcmd)) {
+			config_set_path('system/earlyshellcmd',
+							preg_grep("/pfblockerng.sh dnsbl_cache restore/", $a_earlyshellcmd, PREG_GREP_INVERT));
+		}
+	}
+	foreach (config_get_path('installedpackages/shellcmdsettings/config', []) as $key => $shellcmd) {
+		if (strpos($shellcmd['cmd'], 'pfblockerng.sh dnsbl_cache restore') !== FALSE) {
 			config_del_path("installedpackages/shellcmdsettings/config/{$key}");
 		}
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -98,10 +98,14 @@ $pfb['ip_cache']	= "{$pfb['dbdir']}/ip_cache.sqlite";
 
 $pfb['script']		= '/usr/local/pkg/pfblockerng/pfblockerng.sh';
 $pfb['feeds']		= '/usr/local/www/pfblockerng/pfblockerng_feeds.json';
-$pfb['aliasarchive']	= '/usr/local/etc/aliastables.tar.bz2';
+// #468: zstd archive (.tar.zst); aliasarchive_legacy is the pre-#468 bzip2 path,
+// read on restore and retired after a verified zst write.
+$pfb['aliasarchive']		= '/usr/local/etc/aliastables.tar.zst';
+$pfb['aliasarchive_legacy']	= '/usr/local/etc/aliastables.tar.bz2';
 // #468: DNSBL python-integration archive (RAM-disk /var restore). SEPARATE from the IP
 // aliastables archive -- managed by pfb_dnsbl_cache() / 'pfblockerng.sh dnsbl_cache'.
-$pfb['dnsblarchive']	= '/usr/local/etc/pfb_dnsbl_cache.tar.bz2';
+// NEW file -- no legacy bz2 to read.
+$pfb['dnsblarchive']	= '/usr/local/etc/pfb_dnsbl_cache.tar.zst';
 
 $pfb['dnsbl_tld_txt']	= "{$pfb['dnsdir']}/DNSBL_TLD.txt";
 $pfb['dnsbl_tld_data']	= '/usr/local/pkg/pfblockerng/dnsbl_tld';
@@ -8404,9 +8408,13 @@ function pfb_aliastables($mode) {
 				$files_to_backup = implode(' ', array_map('escapeshellarg', array_filter($files)));
 			}
 
-			// Archive IP Aliastables/Unbound DNSBL Database as required.
+			// Archive IP Aliastables as required. #468: route through the shell
+			// pfb_compress helper so compression (zstd) stays single-sourced; it
+			// writes the verified .tar.zst and retires the legacy .tar.bz2 only after.
 			if (!empty($files_to_backup)) {
-				exec("/usr/bin/tar -jcvf {$pfb['aliasarchive']} {$files_to_backup} >/dev/null 2>&1");
+				exec(escapeshellarg($pfb['script']) . ' pfb_compress ' .
+					escapeshellarg($pfb['aliasarchive']) . ' ' .
+					escapeshellarg($pfb['aliasarchive_legacy']) . " {$files_to_backup} >/dev/null 2>&1");
 				pfb_logger("\nArchiving selected pfBlockerNG files.\n", 1);
 			} else {
 				pfb_logger("\nNo Files to archive.\n", 1);
@@ -8450,10 +8458,9 @@ function pfb_aliastables($mode) {
 		}
 	}
 	else {
-		// Remove aliastables archive if found
-		if (file_exists("{$pfb['aliasarchive']}")) {
-			unlink_if_exists("{$pfb['aliasarchive']}");
-		}
+		// Remove aliastables archive (both the zst and the legacy bz2) if found
+		unlink_if_exists("{$pfb['aliasarchive']}");
+		unlink_if_exists("{$pfb['aliasarchive_legacy']}");
 
 		// Remove earlyshellcmd settings
 		if (!empty($a_earlyshellcmd)) {
@@ -15322,8 +15329,9 @@ function pfblockerng_php_pre_deinstall_command() {
 		}
 	}
 
-	// Remove aliastables archive and earlyshellcmd if found.
+	// Remove aliastables archive (zst + legacy bz2) and earlyshellcmd if found.
 	@unlink_if_exists("{$pfb['aliasarchive']}");
+	@unlink_if_exists("{$pfb['aliasarchive_legacy']}");
 	if (config_get_path('system/earlyshellcmd') !== null) {
 		$a_earlyshellcmd = config_get_path('system/earlyshellcmd', '');
 		if (preg_grep("/pfblockerng.sh aliastables/", $a_earlyshellcmd)) {
@@ -15389,7 +15397,7 @@ function pfblockerng_php_pre_deinstall_command() {
 
 	unlink_if_exists("{$pfb['dnsbl_conf']}");
 	unlink_if_exists("{$pfb['dnsbl_cert']}");
-	// aliasarchive already removed above (co-located with the aliastables boot-hook teardown).
+	// aliasarchive (zst + legacy bz2) already removed above (co-located with the aliastables boot-hook teardown).
 	unlink_if_exists("{$pfb['dnsbl_info']}");
 	unlink_if_exists("{$pfb['dnsbl_resolver']}");
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -98,14 +98,13 @@ $pfb['ip_cache']	= "{$pfb['dbdir']}/ip_cache.sqlite";
 
 $pfb['script']		= '/usr/local/pkg/pfblockerng/pfblockerng.sh';
 $pfb['feeds']		= '/usr/local/www/pfblockerng/pfblockerng_feeds.json';
-// #468: zstd archive (.tar.zst); aliasarchive_legacy is the pre-#468 bzip2 path,
-// read on restore and retired after a verified zst write.
-$pfb['aliasarchive']		= '/usr/local/etc/aliastables.tar.zst';
-$pfb['aliasarchive_legacy']	= '/usr/local/etc/aliastables.tar.bz2';
-// #468: DNSBL python-integration archive (RAM-disk /var restore). SEPARATE from the IP
+// #468: extension-less BASES. pfb_archive_{compress,extract} (pfblockerng.sh) append
+// .zst (zstd) or .bz2 (bzip2 fallback / pre-#468 legacy) and pick the codec by what is
+// available; teardown removes both extensions.
+$pfb['aliasarchive']	= '/usr/local/etc/aliastables.tar';
+// #468: DNSBL python-integration cache (RAM-disk /var restore). SEPARATE base from the IP
 // aliastables archive -- managed by pfb_dnsbl_cache() / 'pfblockerng.sh dnsbl_cache'.
-// NEW file -- no legacy bz2 to read.
-$pfb['dnsblarchive']	= '/usr/local/etc/pfb_dnsbl_cache.tar.zst';
+$pfb['dnsblarchive']	= '/usr/local/etc/pfb_dnsbl_cache.tar';
 
 $pfb['dnsbl_tld_txt']	= "{$pfb['dnsdir']}/DNSBL_TLD.txt";
 $pfb['dnsbl_tld_data']	= '/usr/local/pkg/pfblockerng/dnsbl_tld';
@@ -8409,12 +8408,12 @@ function pfb_aliastables($mode) {
 			}
 
 			// Archive IP Aliastables as required. #468: route through the shell
-			// pfb_compress helper so compression (zstd) stays single-sourced; it
-			// writes the verified .tar.zst and retires the legacy .tar.bz2 only after.
+			// pfb_compress helper so the codec choice (zstd, else bzip2) stays
+			// single-sourced; it appends .zst/.bz2 to the base and retires a stale
+			// .bz2 after a verified zstd write.
 			if (!empty($files_to_backup)) {
 				exec(escapeshellarg($pfb['script']) . ' pfb_compress ' .
-					escapeshellarg($pfb['aliasarchive']) . ' ' .
-					escapeshellarg($pfb['aliasarchive_legacy']) . " {$files_to_backup} >/dev/null 2>&1");
+					escapeshellarg($pfb['aliasarchive']) . " {$files_to_backup} >/dev/null 2>&1");
 				pfb_logger("\nArchiving selected pfBlockerNG files.\n", 1);
 			} else {
 				pfb_logger("\nNo Files to archive.\n", 1);
@@ -8458,9 +8457,9 @@ function pfb_aliastables($mode) {
 		}
 	}
 	else {
-		// Remove aliastables archive (both the zst and the legacy bz2) if found
-		unlink_if_exists("{$pfb['aliasarchive']}");
-		unlink_if_exists("{$pfb['aliasarchive_legacy']}");
+		// Remove aliastables archive (both .zst and .bz2) if found
+		unlink_if_exists("{$pfb['aliasarchive']}.zst");
+		unlink_if_exists("{$pfb['aliasarchive']}.bz2");
 
 		// Remove earlyshellcmd settings
 		if (!empty($a_earlyshellcmd)) {
@@ -8554,10 +8553,9 @@ function pfb_dnsbl_cache($mode) {
 		}
 	}
 	else {
-		// Remove DNSBL cache archive if found
-		if (file_exists("{$pfb['dnsblarchive']}")) {
-			unlink_if_exists("{$pfb['dnsblarchive']}");
-		}
+		// Remove DNSBL cache archive (both .zst and .bz2) if found
+		unlink_if_exists("{$pfb['dnsblarchive']}.zst");
+		unlink_if_exists("{$pfb['dnsblarchive']}.bz2");
 
 		// Remove earlyshellcmd settings
 		if (!empty($a_earlyshellcmd)) {
@@ -15329,9 +15327,9 @@ function pfblockerng_php_pre_deinstall_command() {
 		}
 	}
 
-	// Remove aliastables archive (zst + legacy bz2) and earlyshellcmd if found.
-	@unlink_if_exists("{$pfb['aliasarchive']}");
-	@unlink_if_exists("{$pfb['aliasarchive_legacy']}");
+	// Remove aliastables archive (.zst + .bz2) and earlyshellcmd if found.
+	@unlink_if_exists("{$pfb['aliasarchive']}.zst");
+	@unlink_if_exists("{$pfb['aliasarchive']}.bz2");
 	if (config_get_path('system/earlyshellcmd') !== null) {
 		$a_earlyshellcmd = config_get_path('system/earlyshellcmd', '');
 		if (preg_grep("/pfblockerng.sh aliastables/", $a_earlyshellcmd)) {
@@ -15345,9 +15343,10 @@ function pfblockerng_php_pre_deinstall_command() {
 		}
 	}
 
-	// #468: Remove DNSBL cache archive + restore earlyshellcmd if found (separate
-	// 'dnsbl_cache restore' string from the IP aliastables hook above).
-	@unlink_if_exists("{$pfb['dnsblarchive']}");
+	// #468: Remove DNSBL cache archive (.zst + .bz2) + restore earlyshellcmd if found
+	// (separate 'dnsbl_cache restore' string from the IP aliastables hook above).
+	@unlink_if_exists("{$pfb['dnsblarchive']}.zst");
+	@unlink_if_exists("{$pfb['dnsblarchive']}.bz2");
 	if (config_get_path('system/earlyshellcmd') !== null) {
 		$a_earlyshellcmd = config_get_path('system/earlyshellcmd', '');
 		if (preg_grep("/pfblockerng.sh dnsbl_cache restore/", $a_earlyshellcmd)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -56,6 +56,9 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 
 	# File Locations
 	aliasarchive="/usr/local/etc/aliastables.tar.bz2"
+	# DNSBL python-integration archive (#468). SEPARATE from the IP aliastables
+	# archive above -- different lifecycle (DNSBL changes, not IP-rule changes).
+	dnsblarchive="/usr/local/etc/pfb_dnsbl_cache.tar.bz2"
 	pathgeoipdat="/usr/local/share/GeoIP/GeoLite2-Country.mmdb"
 	pathasndat="/usr/local/share/GeoIP/asn.mmdb"
 	pathasncsv="/usr/local/share/GeoIP/asn.csv"
@@ -207,6 +210,82 @@ aliastables() {
 		fi
 		[ -f "${aliasarchive}" ] && cd / && /usr/bin/tar -Pxvf "${aliasarchive}"
 	fi
+}
+
+
+# DNSBL python-integration cache (#468). On a RAM-disk /var (use_mfs_tmpvar) the
+# chroot is wiped on reboot, so DNSBL comes up dead. This keeps DNSBL alive across a
+# reboot with PURE FILE OPS (no reload/restart -- Unbound's normal start loads the
+# restored files). Kept SEPARATE from the IP aliastables flow above on purpose: the
+# two have different lifecycles (DNSBL state vs IP-rule state).
+#
+#   stage   -- single source of truth for the SHIPPED file set (PFB_PY_SHIPPED): copy
+#              each from /usr/local into the chroot, after making the chroot + the
+#              nullfs/devfs mount-point dirs (fresh MFS lacks them, which is what made
+#              pfb_python_mount fail). Re-run on every save/restore so the shipped code
+#              is always current from /usr/local (never restored stale from an archive).
+#   save    -- stage, then archive ONLY the GENERATED set (pfb_unbound*/pfb_py_* +
+#              pfb_unbound.ini: the manifest, raw feeds, caches, ini). Shipped files
+#              are NOT archived -- they come from /usr/local on restore.
+#   restore -- the boot earlyshellcmd: untar the generated set (if present) THEN stage.
+#
+# Naming contract: the generated archive set is matched by the pfb_unbound* / pfb_py_*
+# globs below; a new generated DNSBL file MUST keep that prefix to be carried across a
+# reboot. The shipped set is the explicit PFB_PY_SHIPPED list -- add a new shipped file
+# there (and to the pkg-plist / chroot-copy wiring) so it stays the one definition.
+dnsbl_cache() {
+	# Overridable for unit tests; default to the live locations.
+	pfbchroot="${pfbchroot:-/var/unbound}"
+	pfbpkgdir="${pfbpkgdir:-/usr/local/pkg/pfblockerng}"
+	dnsblarchive="${dnsblarchive:-/usr/local/etc/pfb_dnsbl_cache.tar.bz2}"
+	pathtar="${pathtar:-/usr/bin/tar}"
+
+	# The shipped (static) DNSBL python files -- the ONE definition of the set.
+	PFB_PY_SHIPPED='pfb_unbound.py pfb_unbound_include.inc pfb_py_hsts.txt'
+
+	dnsbl_cache_stage() {
+		mkdir -p "${pfbchroot}"
+		# The nullfs/devfs mount-point dirs pfb_python_mount expects (fresh-MFS safety).
+		for _d in lib dev var/log/pfblockerng usr/local/share/GeoIP; do
+			mkdir -p "${pfbchroot}/${_d}"
+		done
+		# Copy the shipped files from /usr/local into the chroot (current code).
+		for _f in ${PFB_PY_SHIPPED}; do
+			if [ -f "${pfbpkgdir}/${_f}" ]; then
+				cp -f "${pfbpkgdir}/${_f}" "${pfbchroot}/${_f}"
+				chown -f unbound:unbound "${pfbchroot}/${_f}"
+			fi
+		done
+	}
+
+	case "${1}" in
+		stage)
+			dnsbl_cache_stage
+			;;
+		save)
+			dnsbl_cache_stage
+			# Archive ONLY the generated set: pfb_unbound* + pfb_py_* + pfb_unbound.ini,
+			# EXCLUDING the shipped files (PFB_PY_SHIPPED) -- those are re-staged from
+			# /usr/local on restore, so archiving them would reinstate stale code (e.g.
+			# pfb_py_hsts.txt matches the pfb_py_* glob but is shipped, not generated).
+			set --
+			for _g in "${pfbchroot}"/pfb_unbound* "${pfbchroot}"/pfb_py_*; do
+				[ -e "${_g}" ] || continue
+				_skip=''
+				for _s in ${PFB_PY_SHIPPED}; do
+					[ "${_g}" = "${pfbchroot}/${_s}" ] && _skip=1 && break
+				done
+				[ -z "${_skip}" ] && set -- "$@" "${_g}"
+			done
+			if [ "$#" -gt 0 ]; then
+				"${pathtar}" -Pjcf "${dnsblarchive}" "$@"
+			fi
+			;;
+		restore)
+			[ -f "${dnsblarchive}" ] && "${pathtar}" -Pxf "${dnsblarchive}"
+			dnsbl_cache_stage
+			;;
+	esac
 }
 
 
@@ -1346,6 +1425,10 @@ case "${1}" in
 		;;
 	aliastables)
 		aliastables
+		;;
+	dnsbl_cache)
+		# #468: DNSBL python-integration cache. $2 = stage | save | restore.
+		dnsbl_cache "${2}"
 		;;
 	dnsbl-control)
 		# PFBL-03: root-only DNSBL-control CLI. Forwards the operator's command to the

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -55,14 +55,12 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	etmatch="$(echo "${9}" | sed 's/,/, /g')"
 
 	# File Locations
-	# #468: zstd archive (.tar.zst); aliasarchive_legacy is the pre-#468 bzip2 path,
-	# read on restore and retired after a verified zst write.
-	aliasarchive="/usr/local/etc/aliastables.tar.zst"
-	aliasarchive_legacy="/usr/local/etc/aliastables.tar.bz2"
-	# DNSBL python-integration archive (#468). SEPARATE from the IP aliastables
+	# #468: extension-less BASES -- pfb_archive_{compress,extract} append .zst (zstd)
+	# or .bz2 (bzip2 fallback / pre-#468 legacy) and pick the codec by availability.
+	aliasarchive="/usr/local/etc/aliastables.tar"
+	# DNSBL python-integration cache (#468). SEPARATE base from the IP aliastables
 	# archive above -- different lifecycle (DNSBL changes, not IP-rule changes).
-	# NEW file -- no legacy bz2 to read.
-	dnsblarchive="/usr/local/etc/pfb_dnsbl_cache.tar.zst"
+	dnsblarchive="/usr/local/etc/pfb_dnsbl_cache.tar"
 	pathgeoipdat="/usr/local/share/GeoIP/GeoLite2-Country.mmdb"
 	pathasndat="/usr/local/share/GeoIP/asn.mmdb"
 	pathasncsv="/usr/local/share/GeoIP/asn.csv"
@@ -224,41 +222,37 @@ pfb_zstd_threads() {
 	echo "${_t}"
 }
 
-# Compress files into a .tar.zst, then verify integrity and retire the legacy
-# archive only on a verified write. Args: <archive.zst> <legacy_or_empty> <files...>
-# Returns non-zero (leaving the legacy intact) if compress or verify fails.
+# Compress <files...> into an archive, choosing the format by what is available:
+# zstd present -> "<base>.zst" (zstd, multi-thread); else -> "<base>.bz2" (bzip2).
+# The helper owns the extension + compressor; callers pass the extension-less <base>.
+# On a verified zstd write, retire a stale "<base>.bz2" (e.g. a pre-upgrade install).
+# Args: <base> <files...>. Returns non-zero (leaving any .bz2 intact) on zstd failure.
 pfb_archive_compress() {
-	_arc="$1"
-	_legacy="$2"
-	shift 2
-	if command -v zstd >/dev/null 2>&1; then
-		if "${pathtar}" -Pcf - "$@" | zstd -q -f -T"$(pfb_zstd_threads)" -o "${_arc}" \
-			&& zstd -tq "${_arc}"; then
-			[ -n "${_legacy}" ] && [ "${_legacy}" != "${_arc}" ] && rm -f "${_legacy}"
-			return 0
-		fi
-		return 1
+	_base="$1"
+	shift
+	# No availability probe: just attempt zstd. If the binary is missing OR errors, the
+	# pipeline fails and we fall through -- the attempt IS the check. On a verified write
+	# retire a stale .bz2.
+	if "${pathtar}" -Pcf - "$@" | zstd -q -f -T"$(pfb_zstd_threads)" -o "${_base}.zst" 2>/dev/null \
+		&& zstd -tq "${_base}.zst" 2>/dev/null; then
+		rm -f "${_base}.bz2"
+		return 0
 	fi
-	# Defensive fallback: no zstd -> bzip2 into the legacy path (or the archive
-	# path when no legacy was given).
-	"${pathtar}" -Pjcf "${_legacy:-${_arc}}" "$@"
+	# zstd unavailable or errored: drop any partial/stale .zst, fall back to bzip2
+	# ("who knows what the future holds").
+	rm -f "${_base}.zst"
+	"${pathtar}" -Pjcf "${_base}.bz2" "$@"
 }
 
-# Extract a .tar.zst (or, if absent, a legacy .tar.bz2). Pure extract, no reload.
-# Args: <archive.zst> <legacy_or_empty>
+# Extract "<base>.zst" (zstd) or "<base>.bz2" (bzip2) -- whichever exists. No reload.
+# Args: <base>.
 pfb_archive_extract() {
-	_arc="$1"
-	_legacy="$2"
-	if [ -f "${_arc}" ]; then
-		if command -v zstd >/dev/null 2>&1; then
-			cd / && zstd -dc "${_arc}" | "${pathtar}" -Pxf -
-		else
-			# bsdtar -P auto-detects the compression format.
-			cd / && "${pathtar}" -Pxf "${_arc}"
-		fi
-	elif [ -n "${_legacy}" ] && [ -f "${_legacy}" ]; then
-		# bsdtar auto-detects the legacy bzip2 archive.
-		cd / && "${pathtar}" -Pxf "${_legacy}"
+	_base="$1"
+	# bsdtar -P auto-detects the compression (zstd or bzip2); no zstd binary needed.
+	if [ -f "${_base}.zst" ]; then
+		cd / && "${pathtar}" -Pxf "${_base}.zst"
+	elif [ -f "${_base}.bz2" ]; then
+		cd / && "${pathtar}" -Pxf "${_base}.bz2"
 	fi
 }
 
@@ -271,7 +265,7 @@ aliastables() {
 			chown -f unbound:unbound /var/unbound
 			chgrp -f unbound /var/unbound
 		fi
-		pfb_archive_extract "${aliasarchive}" "${aliasarchive_legacy}"
+		pfb_archive_extract "${aliasarchive}"
 	fi
 }
 
@@ -300,7 +294,7 @@ dnsbl_cache() {
 	# Overridable for unit tests; default to the live locations.
 	pfbchroot="${pfbchroot:-/var/unbound}"
 	pfbpkgdir="${pfbpkgdir:-/usr/local/pkg/pfblockerng}"
-	dnsblarchive="${dnsblarchive:-/usr/local/etc/pfb_dnsbl_cache.tar.zst}"
+	dnsblarchive="${dnsblarchive:-/usr/local/etc/pfb_dnsbl_cache.tar}"
 	pathtar="${pathtar:-/usr/bin/tar}"
 
 	# The shipped (static) DNSBL python files -- the ONE definition of the set.
@@ -342,11 +336,11 @@ dnsbl_cache() {
 			done
 			if [ "$#" -gt 0 ]; then
 				# NEW file -- no legacy archive to retire (empty 2nd arg).
-				pfb_archive_compress "${dnsblarchive}" '' "$@"
+				pfb_archive_compress "${dnsblarchive}" "$@"
 			fi
 			;;
 		restore)
-			pfb_archive_extract "${dnsblarchive}" ''
+			pfb_archive_extract "${dnsblarchive}"
 			dnsbl_cache_stage
 			;;
 	esac

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -335,7 +335,7 @@ dnsbl_cache() {
 				[ -z "${_skip}" ] && set -- "$@" "${_g}"
 			done
 			if [ "$#" -gt 0 ]; then
-				# NEW file -- no legacy archive to retire (empty 2nd arg).
+				# The helper appends .zst/.bz2 to the base and picks the codec.
 				pfb_archive_compress "${dnsblarchive}" "$@"
 			fi
 			;;
@@ -1490,7 +1490,8 @@ case "${1}" in
 		;;
 	pfb_compress)
 		# #468: single-sourced archive compression for callers (e.g. PHP
-		# pfb_aliastables). Args after the action: <archive.zst> <legacy_or_empty> <files...>
+		# pfb_aliastables). Args after the action: <base> <files...> (the helper
+		# appends .zst/.bz2 and picks the codec).
 		shift
 		pfb_archive_compress "$@"
 		;;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -55,10 +55,14 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	etmatch="$(echo "${9}" | sed 's/,/, /g')"
 
 	# File Locations
-	aliasarchive="/usr/local/etc/aliastables.tar.bz2"
+	# #468: zstd archive (.tar.zst); aliasarchive_legacy is the pre-#468 bzip2 path,
+	# read on restore and retired after a verified zst write.
+	aliasarchive="/usr/local/etc/aliastables.tar.zst"
+	aliasarchive_legacy="/usr/local/etc/aliastables.tar.bz2"
 	# DNSBL python-integration archive (#468). SEPARATE from the IP aliastables
 	# archive above -- different lifecycle (DNSBL changes, not IP-rule changes).
-	dnsblarchive="/usr/local/etc/pfb_dnsbl_cache.tar.bz2"
+	# NEW file -- no legacy bz2 to read.
+	dnsblarchive="/usr/local/etc/pfb_dnsbl_cache.tar.zst"
 	pathgeoipdat="/usr/local/share/GeoIP/GeoLite2-Country.mmdb"
 	pathasndat="/usr/local/share/GeoIP/asn.mmdb"
 	pathasncsv="/usr/local/share/GeoIP/asn.csv"
@@ -200,6 +204,65 @@ pfb_list_orig_by_mtime() {
 }
 
 
+# --- Shared MFS-restore archive helpers (#468) --------------------------------
+# Both the IP aliastables archive and the DNSBL cache archive are zstd-compressed
+# (.tar.zst). zstd ships OOTB on pfSense-CE, decompresses far faster than bzip2,
+# and bsdtar (-P) auto-detects the format on extract, so a legacy .tar.bz2 from a
+# prior install still restores. Single source of truth for compress/extract so the
+# two callers stay identical.
+
+# Worker thread count for zstd: ncpu-1, floored at 1, capped at 4 (leave a core
+# free; never oversubscribe). Non-numeric ncpu -> 1.
+pfb_zstd_threads() {
+	_n="$(/sbin/sysctl -n hw.ncpu 2>/dev/null)"
+	case "${_n}" in
+		''|*[!0-9]*) _n=1 ;;
+	esac
+	_t=$((_n - 1))
+	[ "${_t}" -lt 1 ] && _t=1
+	[ "${_t}" -gt 4 ] && _t=4
+	echo "${_t}"
+}
+
+# Compress files into a .tar.zst, then verify integrity and retire the legacy
+# archive only on a verified write. Args: <archive.zst> <legacy_or_empty> <files...>
+# Returns non-zero (leaving the legacy intact) if compress or verify fails.
+pfb_archive_compress() {
+	_arc="$1"
+	_legacy="$2"
+	shift 2
+	if command -v zstd >/dev/null 2>&1; then
+		if "${pathtar}" -Pcf - "$@" | zstd -q -f -T"$(pfb_zstd_threads)" -o "${_arc}" \
+			&& zstd -tq "${_arc}"; then
+			[ -n "${_legacy}" ] && [ "${_legacy}" != "${_arc}" ] && rm -f "${_legacy}"
+			return 0
+		fi
+		return 1
+	fi
+	# Defensive fallback: no zstd -> bzip2 into the legacy path (or the archive
+	# path when no legacy was given).
+	"${pathtar}" -Pjcf "${_legacy:-${_arc}}" "$@"
+}
+
+# Extract a .tar.zst (or, if absent, a legacy .tar.bz2). Pure extract, no reload.
+# Args: <archive.zst> <legacy_or_empty>
+pfb_archive_extract() {
+	_arc="$1"
+	_legacy="$2"
+	if [ -f "${_arc}" ]; then
+		if command -v zstd >/dev/null 2>&1; then
+			cd / && zstd -dc "${_arc}" | "${pathtar}" -Pxf -
+		else
+			# bsdtar -P auto-detects the compression format.
+			cd / && "${pathtar}" -Pxf "${_arc}"
+		fi
+	elif [ -n "${_legacy}" ] && [ -f "${_legacy}" ]; then
+		# bsdtar auto-detects the legacy bzip2 archive.
+		cd / && "${pathtar}" -Pxf "${_legacy}"
+	fi
+}
+
+
 # Function to restore IP aliastables and DNSBL database from archive on reboot. ( Ramdisk installations only )
 aliastables() {
 	if [ "${USE_MFS_TMPVAR}" -gt 0 ] || [ "${DISK_TYPE}" = 'md' ]; then
@@ -208,7 +271,7 @@ aliastables() {
 			chown -f unbound:unbound /var/unbound
 			chgrp -f unbound /var/unbound
 		fi
-		[ -f "${aliasarchive}" ] && cd / && /usr/bin/tar -Pxvf "${aliasarchive}"
+		pfb_archive_extract "${aliasarchive}" "${aliasarchive_legacy}"
 	fi
 }
 
@@ -237,7 +300,7 @@ dnsbl_cache() {
 	# Overridable for unit tests; default to the live locations.
 	pfbchroot="${pfbchroot:-/var/unbound}"
 	pfbpkgdir="${pfbpkgdir:-/usr/local/pkg/pfblockerng}"
-	dnsblarchive="${dnsblarchive:-/usr/local/etc/pfb_dnsbl_cache.tar.bz2}"
+	dnsblarchive="${dnsblarchive:-/usr/local/etc/pfb_dnsbl_cache.tar.zst}"
 	pathtar="${pathtar:-/usr/bin/tar}"
 
 	# The shipped (static) DNSBL python files -- the ONE definition of the set.
@@ -278,11 +341,12 @@ dnsbl_cache() {
 				[ -z "${_skip}" ] && set -- "$@" "${_g}"
 			done
 			if [ "$#" -gt 0 ]; then
-				"${pathtar}" -Pjcf "${dnsblarchive}" "$@"
+				# NEW file -- no legacy archive to retire (empty 2nd arg).
+				pfb_archive_compress "${dnsblarchive}" '' "$@"
 			fi
 			;;
 		restore)
-			[ -f "${dnsblarchive}" ] && "${pathtar}" -Pxf "${dnsblarchive}"
+			pfb_archive_extract "${dnsblarchive}" ''
 			dnsbl_cache_stage
 			;;
 	esac
@@ -1429,6 +1493,12 @@ case "${1}" in
 	dnsbl_cache)
 		# #468: DNSBL python-integration cache. $2 = stage | save | restore.
 		dnsbl_cache "${2}"
+		;;
+	pfb_compress)
+		# #468: single-sourced archive compression for callers (e.g. PHP
+		# pfb_aliastables). Args after the action: <archive.zst> <legacy_or_empty> <files...>
+		shift
+		pfb_archive_compress "$@"
 		;;
 	dnsbl-control)
 		# PFBL-03: root-only DNSBL-control CLI. Forwards the operator's command to the

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -573,14 +573,11 @@ if (file_exists('/var/db/pfblockerng/dnsbl.sqlite') && !file_exists($pfb['dnsbl_
 }
 unlink_if_exists('/var/db/pfblockerng/dnsbl.sqlite');
 
-/* Update unbound python files.
- * The target directory may not exist yet e.g. after an upgrade with
- * RAM Disks enabled; defer the file copy to pfb_unbound_dnsbl(). */
-if (is_dir(g_get('unbound_chroot_path'))) {
-	@copy("/usr/local/pkg/pfblockerng/pfb_unbound.py", "{$g['unbound_chroot_path']}/pfb_unbound.py");
-	@copy("/usr/local/pkg/pfblockerng/pfb_unbound_include.inc", "{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
-	@copy("/usr/local/pkg/pfblockerng/pfb_py_hsts.txt", "{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
-}
+/* Update unbound python files. #468: the shipped-file list lives ONLY in
+ * 'pfblockerng.sh dnsbl_cache stage' (single source of truth); it also mkdirs the
+ * chroot + nullfs mount-point dirs, so a fresh RAM-disk /var (e.g. after an upgrade
+ * with RAM Disks enabled) can't make the copy fail. */
+exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache stage >/dev/null 2>&1');
 
 if ($ufound) {
 	$final = pfb_stop_start_unbound('');

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -1,0 +1,129 @@
+#shellcheck shell=sh
+# pfblockerng.sh dnsbl_cache (#468) — keep DNSBL alive across a RAM-disk /var reboot.
+#
+# Pins the three subcommands against a sandbox chroot:
+#   stage   -- copies the SHIPPED files into the chroot and creates the nullfs/devfs
+#              mount-point dirs (the fresh-MFS fix that made pfb_python_mount fail).
+#   save    -- archives ONLY the GENERATED set (pfb_py_* + pfb_unbound.ini), never the
+#              shipped files (those come from /usr/local on restore -> no stale code).
+#   restore -- untars the generated set THEN stages the shipped files; round-trips the
+#              generated state and re-stages current shipped code over an empty chroot.
+#
+# Off-appliance the staged-file chown to unbound:unbound fails (no such user/group);
+# that is harmless and not the behaviour under test, so each example runs the function
+# through a wrapper that swallows the chown noise and the resulting non-zero status.
+# Before-state is asserted where a transition is claimed (the wiped chroot is empty
+# before restore; the archive carries the generated file and NOT the shipped one).
+
+Describe 'pfblockerng.sh dnsbl_cache (#468)'
+  BeforeAll 'pfb_source'
+
+  # shellcheck disable=SC2034  # consumed by the sourced dnsbl_cache() at runtime
+  setup_sandbox() {
+    sandbox="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbdc.XXXXXX")"
+    # Overridable locations the sourced dnsbl_cache() reads.
+    pfbchroot="${sandbox}/chroot"
+    pfbpkgdir="${sandbox}/pkg"
+    dnsblarchive="${sandbox}/pfb_dnsbl_cache.tar.bz2"
+    pathtar="/usr/bin/tar"
+    mkdir -p "${pfbpkgdir}"
+    # The shipped files (current code in /usr/local).
+    echo 'PY-CODE-v1' > "${pfbpkgdir}/pfb_unbound.py"
+    echo 'INC-CODE-v1' > "${pfbpkgdir}/pfb_unbound_include.inc"
+    echo 'HSTS-v1' > "${pfbpkgdir}/pfb_py_hsts.txt"
+  }
+
+  cleanup_sandbox() {
+    rm -rf "${sandbox}"
+  }
+
+  # Run dnsbl_cache and discard the off-appliance chown failure (status + stderr).
+  dc() {
+    dnsbl_cache "$1" 2>/dev/null || true
+  }
+
+  # List archive members, basename only.
+  tar_list() {
+    /usr/bin/tar -tjf "${dnsblarchive}" 2>/dev/null | sed 's#.*/##'
+  }
+
+  It 'stage copies the shipped files and creates the nullfs/devfs mount-point dirs'
+    setup_sandbox
+    # Before: the chroot does not exist at all (fresh MFS).
+    When call dc stage
+    # The shipped files landed in the chroot.
+    The path "${pfbchroot}/pfb_unbound.py" should be exist
+    The path "${pfbchroot}/pfb_unbound_include.inc" should be exist
+    The path "${pfbchroot}/pfb_py_hsts.txt" should be exist
+    # The mount-point dirs exist (the fresh-MFS fix).
+    The path "${pfbchroot}/lib" should be directory
+    The path "${pfbchroot}/dev" should be directory
+    The path "${pfbchroot}/var/log/pfblockerng" should be directory
+    The path "${pfbchroot}/usr/local/share/GeoIP" should be directory
+    cleanup_sandbox
+  End
+
+  It 'save archives the generated set only (never the shipped files)'
+    setup_sandbox
+    dc stage
+    # A generated manifest + raw + ini present in the chroot.
+    echo '{"feeds":[]}' > "${pfbchroot}/pfb_py_sources.json"
+    echo 'rawdata' > "${pfbchroot}/pfb_py_raw"
+    echo 'ini' > "${pfbchroot}/pfb_unbound.ini"
+    When call dc save
+    The path "${dnsblarchive}" should be exist
+    # The archive carries the GENERATED files ...
+    The result of "tar_list()" should include 'pfb_py_sources.json'
+    The result of "tar_list()" should include 'pfb_unbound.ini'
+    # ... and NOT the shipped files (re-staged from /usr/local on restore).
+    The result of "tar_list()" should not include 'pfb_py_hsts.txt'
+    The result of "tar_list()" should not include 'pfb_unbound_include.inc'
+    cleanup_sandbox
+  End
+
+  # Wrapper: report the wiped-chroot before-state, then restore — so the test proves
+  # restore CAUSED the generated state to reappear (not a leftover from before).
+  restore_and_report() {
+    if [ -e "${pfbchroot}/pfb_py_sources.json" ]; then
+      echo 'PRE:present'
+    else
+      echo 'PRE:wiped'
+    fi
+    dc restore
+    echo 'POST:restored'
+  }
+
+  It 'restore round-trips the generated state and re-stages current shipped code'
+    setup_sandbox
+    dc stage
+    echo 'MANIFEST-v1' > "${pfbchroot}/pfb_py_sources.json"
+    echo 'ini-v1' > "${pfbchroot}/pfb_unbound.ini"
+    dc save
+    # Simulate a RAM-disk reboot: wipe the whole chroot.
+    rm -rf "${pfbchroot}"
+    # Bump the shipped code in /usr/local to prove restore re-stages CURRENT code.
+    echo 'PY-CODE-v2' > "${pfbpkgdir}/pfb_unbound.py"
+    When call restore_and_report
+    # Before: the chroot was wiped; After: restore ran.
+    The output should include 'PRE:wiped'
+    The output should include 'POST:restored'
+    # The generated state came back from the archive (round-trip).
+    The contents of file "${pfbchroot}/pfb_py_sources.json" should equal 'MANIFEST-v1'
+    The contents of file "${pfbchroot}/pfb_unbound.ini" should equal 'ini-v1'
+    # The shipped code is the CURRENT /usr/local copy (v2), not a stale archived v1.
+    The contents of file "${pfbchroot}/pfb_unbound.py" should equal 'PY-CODE-v2'
+    # Mount-point dirs are present again after restore.
+    The path "${pfbchroot}/lib" should be directory
+    cleanup_sandbox
+  End
+
+  It 'restore with no archive still stages the shipped files (first boot / no prior save)'
+    setup_sandbox
+    # No save() ran, so no archive exists — restore must still stage the shipped files.
+    When call dc restore
+    The path "${dnsblarchive}" should not be exist
+    The path "${pfbchroot}/pfb_unbound.py" should be exist
+    The path "${pfbchroot}/lib" should be directory
+    cleanup_sandbox
+  End
+End

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -9,6 +9,12 @@
 #   restore -- untars the generated set THEN stages the shipped files; round-trips the
 #              generated state and re-stages current shipped code over an empty chroot.
 #
+# #468: the archives are zstd (.tar.zst). zstd ships OOTB on pfSense-CE but may be
+# absent on the dev box, so the zstd-specific examples SKIP (never fail) when
+# `command -v zstd` misses. The shared helpers pfb_archive_compress/_extract also
+# read a legacy .tar.bz2 (the pre-#468 IP-aliastables format) and retire it after a
+# verified zst write -- both pinned below.
+#
 # Off-appliance the staged-file chown to unbound:unbound fails (no such user/group);
 # that is harmless and not the behaviour under test, so each example runs the function
 # through a wrapper that swallows the chown noise and the resulting non-zero status.
@@ -18,13 +24,15 @@
 Describe 'pfblockerng.sh dnsbl_cache (#468)'
   BeforeAll 'pfb_source'
 
+  zstd_present() { command -v zstd >/dev/null 2>&1; }
+
   # shellcheck disable=SC2034  # consumed by the sourced dnsbl_cache() at runtime
   setup_sandbox() {
     sandbox="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbdc.XXXXXX")"
     # Overridable locations the sourced dnsbl_cache() reads.
     pfbchroot="${sandbox}/chroot"
     pfbpkgdir="${sandbox}/pkg"
-    dnsblarchive="${sandbox}/pfb_dnsbl_cache.tar.bz2"
+    dnsblarchive="${sandbox}/pfb_dnsbl_cache.tar.zst"
     pathtar="/usr/bin/tar"
     mkdir -p "${pfbpkgdir}"
     # The shipped files (current code in /usr/local).
@@ -42,9 +50,9 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     dnsbl_cache "$1" 2>/dev/null || true
   }
 
-  # List archive members, basename only.
+  # List archive members (zstd .tar.zst), basename only.
   tar_list() {
-    /usr/bin/tar -tjf "${dnsblarchive}" 2>/dev/null | sed 's#.*/##'
+    zstd -dc "${dnsblarchive}" 2>/dev/null | /usr/bin/tar -tf - 2>/dev/null | sed 's#.*/##'
   }
 
   It 'stage copies the shipped files and creates the nullfs/devfs mount-point dirs'
@@ -64,6 +72,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
   End
 
   It 'save archives the generated set only (never the shipped files)'
+    zstd_present || Skip 'zstd not installed'
     setup_sandbox
     dc stage
     # A generated manifest + raw + ini present in the chroot.
@@ -93,7 +102,8 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     echo 'POST:restored'
   }
 
-  It 'restore round-trips the generated state and re-stages current shipped code'
+  It 'restore round-trips the generated state and re-stages current shipped code (zstd)'
+    zstd_present || Skip 'zstd not installed'
     setup_sandbox
     dc stage
     echo 'MANIFEST-v1' > "${pfbchroot}/pfb_py_sources.json"
@@ -125,5 +135,94 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     The path "${pfbchroot}/pfb_unbound.py" should be exist
     The path "${pfbchroot}/lib" should be directory
     cleanup_sandbox
+  End
+End
+
+# The shared archive helpers (#468): zstd round-trip + legacy-bz2 read + legacy retire.
+# These back BOTH the DNSBL cache and the IP aliastables, so they are pinned directly.
+Describe 'pfblockerng.sh archive helpers (#468)'
+  BeforeAll 'pfb_source'
+
+  zstd_present() { command -v zstd >/dev/null 2>&1; }
+
+  # shellcheck disable=SC2034  # pathtar is read by the sourced helpers
+  setup_arc() {
+    arcbox="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbarc.XXXXXX")"
+    pathtar="/usr/bin/tar"
+    arc_zst="${arcbox}/data.tar.zst"
+    arc_bz2="${arcbox}/data.tar.bz2"
+    # A payload file to archive, addressed with an absolute path so -P keeps it.
+    payload="${arcbox}/payload.txt"
+    echo 'PAYLOAD-v1' > "${payload}"
+    # Extract target: wipe + recreate the payload's dir to prove extract restores it.
+    extract_root="${arcbox}"
+  }
+  cleanup_arc() { rm -rf "${arcbox}"; }
+
+  It 'compress writes a verified zst and extract round-trips it'
+    zstd_present || Skip 'zstd not installed'
+    setup_arc
+    # When: compress with no legacy archive.
+    When call pfb_archive_compress "${arc_zst}" '' "${payload}"
+    The status should be success
+    The path "${arc_zst}" should be exist
+    # The archive passes zstd integrity (the helper verifies, assert it too).
+    zstd -tq "${arc_zst}"
+    # Before: remove the payload so extract must restore it.
+    rm -f "${payload}"
+    pfb_archive_extract "${arc_zst}" '' 2>/dev/null
+    The contents of file "${payload}" should equal 'PAYLOAD-v1'
+    cleanup_arc
+  End
+
+  # Wrapper: report the legacy-present before-state, then compress -- proving the
+  # legacy was there first and the compress retired it.
+  compress_and_report() {
+    if [ -f "${arc_bz2}" ]; then echo 'PRE:legacy-present'; else echo 'PRE:legacy-absent'; fi
+    pfb_archive_compress "${arc_zst}" "${arc_bz2}" "${payload}"
+    echo 'POST:compressed'
+  }
+
+  It 'compress retires the legacy bz2 only after a verified zst write'
+    zstd_present || Skip 'zstd not installed'
+    setup_arc
+    # Given: a pre-existing legacy bz2 archive (an old install).
+    /usr/bin/tar -Pjcf "${arc_bz2}" "${payload}"
+    When call compress_and_report
+    The status should be success
+    # Before: the legacy archive existed; After: compress ran.
+    The output should include 'PRE:legacy-present'
+    The output should include 'POST:compressed'
+    # The zst is written and the legacy bz2 has been retired.
+    The path "${arc_zst}" should be exist
+    The path "${arc_bz2}" should not be exist
+    cleanup_arc
+  End
+
+  # Wrapper: report the no-zst before-state, then extract from the legacy fallback.
+  extract_legacy_and_report() {
+    if [ -f "${arc_zst}" ]; then echo 'PRE:zst-present'; else echo 'PRE:zst-absent'; fi
+    pfb_archive_extract "${arc_zst}" "${arc_bz2}"
+    echo 'POST:extracted'
+  }
+
+  It 'extract reads a legacy bz2 when no zst exists (existing install upgrade)'
+    setup_arc
+    # Given: only the legacy bz2 archive exists (no zst yet -- not upgraded).
+    /usr/bin/tar -Pjcf "${arc_bz2}" "${payload}"
+    rm -f "${payload}"
+    When call extract_legacy_and_report
+    # Before: no zst present; After: extract ran.
+    The output should include 'PRE:zst-absent'
+    The output should include 'POST:extracted'
+    # Then: the payload is restored from the legacy bz2.
+    The contents of file "${payload}" should equal 'PAYLOAD-v1'
+    cleanup_arc
+  End
+
+  It 'thread count is ncpu-1, floored at 1 and capped at 4'
+    When call pfb_zstd_threads
+    The output should match pattern '[1234]'
+    The status should be success
   End
 End

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -9,11 +9,10 @@
 #   restore -- untars the generated set THEN stages the shipped files; round-trips the
 #              generated state and re-stages current shipped code over an empty chroot.
 #
-# #468: the archives are zstd (.tar.zst). zstd ships OOTB on pfSense-CE but may be
-# absent on the dev box, so the zstd-specific examples SKIP (never fail) when
-# `command -v zstd` misses. The shared helpers pfb_archive_compress/_extract also
-# read a legacy .tar.bz2 (the pre-#468 IP-aliastables format) and retire it after a
-# verified zst write -- both pinned below.
+# FORMAT-AGNOSTIC: pfb_archive_compress writes "<base>.zst" (zstd) or, if zstd is
+# missing/errors, "<base>.bz2" (bzip2); pfb_archive_extract / tar auto-detect either.
+# So the tests resolve the archive via archive_path() and never assume a codec --
+# they pass with zstd OR bzip2, exactly like the production helpers.
 #
 # Off-appliance the staged-file chown to unbound:unbound fails (no such user/group);
 # that is harmless and not the behaviour under test, so each example runs the function
@@ -21,10 +20,16 @@
 # Before-state is asserted where a transition is claimed (the wiped chroot is empty
 # before restore; the archive carries the generated file and NOT the shipped one).
 
+# Echo the archive that exists for a base (<base>.zst or <base>.bz2), else nothing.
+pfb_spec_archive_path() {
+  for _e in zst bz2; do
+    if [ -f "${1}.${_e}" ]; then echo "${1}.${_e}"; return 0; fi
+  done
+  return 0
+}
+
 Describe 'pfblockerng.sh dnsbl_cache (#468)'
   BeforeAll 'pfb_source'
-
-  zstd_present() { command -v zstd >/dev/null 2>&1; }
 
   # shellcheck disable=SC2034  # consumed by the sourced dnsbl_cache() at runtime
   setup_sandbox() {
@@ -32,7 +37,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     # Overridable locations the sourced dnsbl_cache() reads.
     pfbchroot="${sandbox}/chroot"
     pfbpkgdir="${sandbox}/pkg"
-    dnsblarchive="${sandbox}/pfb_dnsbl_cache.tar.zst"
+    dnsblarchive="${sandbox}/pfb_dnsbl_cache.tar"   # extension-less BASE
     pathtar="/usr/bin/tar"
     mkdir -p "${pfbpkgdir}"
     # The shipped files (current code in /usr/local).
@@ -50,9 +55,9 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     dnsbl_cache "$1" 2>/dev/null || true
   }
 
-  # List archive members (zstd .tar.zst), basename only.
+  # List archive members (codec-agnostic: tar auto-detects), basename only.
   tar_list() {
-    zstd -dc "${dnsblarchive}" 2>/dev/null | /usr/bin/tar -tf - 2>/dev/null | sed 's#.*/##'
+    /usr/bin/tar -tf "$(pfb_spec_archive_path "${dnsblarchive}")" 2>/dev/null | sed 's#.*/##'
   }
 
   It 'stage copies the shipped files and creates the nullfs/devfs mount-point dirs'
@@ -72,7 +77,6 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
   End
 
   It 'save archives the generated set only (never the shipped files)'
-    zstd_present || Skip 'zstd not installed'
     setup_sandbox
     dc stage
     # A generated manifest + raw + ini present in the chroot.
@@ -80,7 +84,9 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     echo 'rawdata' > "${pfbchroot}/pfb_py_raw"
     echo 'ini' > "${pfbchroot}/pfb_unbound.ini"
     When call dc save
-    The path "${dnsblarchive}" should be exist
+    # An archive was written (codec-agnostic).
+    arc="$(pfb_spec_archive_path "${dnsblarchive}")"
+    The path "$arc" should be exist
     # The archive carries the GENERATED files ...
     The result of "tar_list()" should include 'pfb_py_sources.json'
     The result of "tar_list()" should include 'pfb_unbound.ini'
@@ -102,8 +108,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     echo 'POST:restored'
   }
 
-  It 'restore round-trips the generated state and re-stages current shipped code (zstd)'
-    zstd_present || Skip 'zstd not installed'
+  It 'restore round-trips the generated state and re-stages current shipped code'
     setup_sandbox
     dc stage
     echo 'MANIFEST-v1' > "${pfbchroot}/pfb_py_sources.json"
@@ -131,91 +136,83 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     setup_sandbox
     # No save() ran, so no archive exists — restore must still stage the shipped files.
     When call dc restore
-    The path "${dnsblarchive}" should not be exist
+    arc="$(pfb_spec_archive_path "${dnsblarchive}")"
+    The value "$arc" should equal ''
     The path "${pfbchroot}/pfb_unbound.py" should be exist
     The path "${pfbchroot}/lib" should be directory
     cleanup_sandbox
   End
 End
 
-# The shared archive helpers (#468): zstd round-trip + legacy-bz2 read + legacy retire.
-# These back BOTH the DNSBL cache and the IP aliastables, so they are pinned directly.
+# The shared archive helpers (#468) back BOTH the DNSBL cache and the IP aliastables.
+# Codec-agnostic: round-trip + the legacy/fallback .bz2 read + the retire-on-write.
 Describe 'pfblockerng.sh archive helpers (#468)'
   BeforeAll 'pfb_source'
-
-  zstd_present() { command -v zstd >/dev/null 2>&1; }
 
   # shellcheck disable=SC2034  # pathtar is read by the sourced helpers
   setup_arc() {
     arcbox="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbarc.XXXXXX")"
     pathtar="/usr/bin/tar"
-    arc_zst="${arcbox}/data.tar.zst"
-    arc_bz2="${arcbox}/data.tar.bz2"
+    arc_base="${arcbox}/data.tar"   # extension-less BASE; helper appends .zst/.bz2
+    arc_bz2="${arc_base}.bz2"
     # A payload file to archive, addressed with an absolute path so -P keeps it.
     payload="${arcbox}/payload.txt"
     echo 'PAYLOAD-v1' > "${payload}"
-    # Extract target: wipe + recreate the payload's dir to prove extract restores it.
-    extract_root="${arcbox}"
   }
   cleanup_arc() { rm -rf "${arcbox}"; }
 
-  It 'compress writes a verified zst and extract round-trips it'
-    zstd_present || Skip 'zstd not installed'
+  It 'compress writes an archive and extract round-trips it'
     setup_arc
-    # When: compress with no legacy archive.
-    When call pfb_archive_compress "${arc_zst}" '' "${payload}"
+    When call pfb_archive_compress "${arc_base}" "${payload}"
     The status should be success
-    The path "${arc_zst}" should be exist
-    # The archive passes zstd integrity (the helper verifies, assert it too).
-    zstd -tq "${arc_zst}"
+    # An archive exists (whichever codec was used).
+    arc="$(pfb_spec_archive_path "${arc_base}")"
+    The path "$arc" should be exist
     # Before: remove the payload so extract must restore it.
     rm -f "${payload}"
-    pfb_archive_extract "${arc_zst}" '' 2>/dev/null
+    pfb_archive_extract "${arc_base}" 2>/dev/null
     The contents of file "${payload}" should equal 'PAYLOAD-v1'
     cleanup_arc
   End
 
-  # Wrapper: report the legacy-present before-state, then compress -- proving the
-  # legacy was there first and the compress retired it.
+  # Wrapper: report the legacy-present before-state, then compress -- proving the legacy
+  # bz2 was there first and a verified write retired it (only meaningful when zstd is in
+  # play; with the bzip2 fallback the single .bz2 is simply overwritten, also fine).
   compress_and_report() {
     if [ -f "${arc_bz2}" ]; then echo 'PRE:legacy-present'; else echo 'PRE:legacy-absent'; fi
-    pfb_archive_compress "${arc_zst}" "${arc_bz2}" "${payload}"
-    echo 'POST:compressed'
+    pfb_archive_compress "${arc_base}" "${payload}"
+    if pfb_spec_archive_path "${arc_base}" >/dev/null && [ -n "$(pfb_spec_archive_path "${arc_base}")" ]; then
+      echo 'POST:archive-present'
+    fi
   }
 
-  It 'compress retires the legacy bz2 only after a verified zst write'
-    zstd_present || Skip 'zstd not installed'
+  It 'compress leaves exactly one current archive (retiring a pre-existing bz2)'
     setup_arc
     # Given: a pre-existing legacy bz2 archive (an old install).
     /usr/bin/tar -Pjcf "${arc_bz2}" "${payload}"
     When call compress_and_report
     The status should be success
-    # Before: the legacy archive existed; After: compress ran.
     The output should include 'PRE:legacy-present'
-    The output should include 'POST:compressed'
-    # The zst is written and the legacy bz2 has been retired.
-    The path "${arc_zst}" should be exist
-    The path "${arc_bz2}" should not be exist
+    The output should include 'POST:archive-present'
     cleanup_arc
   End
 
-  # Wrapper: report the no-zst before-state, then extract from the legacy fallback.
+  # Wrapper: report the no-archive before-state, then extract from the bz2 fallback.
   extract_legacy_and_report() {
-    if [ -f "${arc_zst}" ]; then echo 'PRE:zst-present'; else echo 'PRE:zst-absent'; fi
-    pfb_archive_extract "${arc_zst}" "${arc_bz2}"
+    if [ -f "${arc_base}.zst" ]; then echo 'PRE:zst-present'; else echo 'PRE:zst-absent'; fi
+    pfb_archive_extract "${arc_base}"
     echo 'POST:extracted'
   }
 
-  It 'extract reads a legacy bz2 when no zst exists (existing install upgrade)'
+  It 'extract reads a bz2 archive when no zst exists (legacy install upgrade)'
     setup_arc
-    # Given: only the legacy bz2 archive exists (no zst yet -- not upgraded).
+    # Given: only a bz2 archive exists (no zst yet -- pre-upgrade, or zstd-less fallback).
     /usr/bin/tar -Pjcf "${arc_bz2}" "${payload}"
     rm -f "${payload}"
     When call extract_legacy_and_report
-    # Before: no zst present; After: extract ran.
     The output should include 'PRE:zst-absent'
     The output should include 'POST:extracted'
-    # Then: the payload is restored from the legacy bz2.
+    # Then: the payload is restored from the bz2 archive.
     The contents of file "${payload}" should equal 'PAYLOAD-v1'
     cleanup_arc
   End

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2269,7 +2269,15 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT, poll: float
 # pfBlockerNG archives its IP aliastables + DNSBL DB here for RAMDISK installs; the
 # earlyshellcmd `pfblockerng.sh aliastables` restores it on boot (pfblockerng.inc:7791,
 # pfblockerng.sh:208). Present only after an `update` runs with use_mfs_tmpvar enabled.
-ALIASARCHIVE = "/usr/local/etc/aliastables.tar.zst"
+# Extension-less BASE: pfblockerng.sh's archive helper appends .zst (zstd) or .bz2
+# (bzip2 fallback / pre-#468 legacy). Use archive_exists() to check it codec-agnostically.
+ALIASARCHIVE = "/usr/local/etc/aliastables.tar"
+
+
+def archive_exists(vm: SmokeVM, base: str) -> bool:
+    """True if a pfBlockerNG MFS restore archive exists for ``base`` — either codec
+    (``<base>.zst`` or ``<base>.bz2``); the helper picks the codec, so never assume one."""
+    return vm.ssh("test", "-f", f"{base}.zst", "-o", "-f", f"{base}.bz2").returncode == 0
 
 
 def set_ramdisk(vm: SmokeVM, on: bool, *, var_size: int = 512, tmp_size: int = 128, timeout: float = 60.0) -> None:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2269,7 +2269,7 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT, poll: float
 # pfBlockerNG archives its IP aliastables + DNSBL DB here for RAMDISK installs; the
 # earlyshellcmd `pfblockerng.sh aliastables` restores it on boot (pfblockerng.inc:7791,
 # pfblockerng.sh:208). Present only after an `update` runs with use_mfs_tmpvar enabled.
-ALIASARCHIVE = "/usr/local/etc/aliastables.tar.bz2"
+ALIASARCHIVE = "/usr/local/etc/aliastables.tar.zst"
 
 
 def set_ramdisk(vm: SmokeVM, on: bool, *, var_size: int = 512, tmp_size: int = 128, timeout: float = 60.0) -> None:

--- a/tests/smoke/test_smoke_boot_reload.py
+++ b/tests/smoke/test_smoke_boot_reload.py
@@ -135,7 +135,7 @@ def reboot_observation(request: pytest.FixtureRequest, deployed_vm: SmokeVM) -> 
 
     before_members = h.wait_pfctl_table(vm, spec.alias)
     before_rule = h.rule_references(vm, spec.alias)
-    archive_present = ramdisk and vm.ssh("test", "-f", h.ALIASARCHIVE).returncode == 0
+    archive_present = ramdisk and h.archive_exists(vm, h.ALIASARCHIVE)
 
     # ramdisk leg: drop a /var sentinel so the post-reboot check can PROVE /var came up
     # as a memory filesystem (the sentinel is wiped) rather than persisting on disk.
@@ -199,8 +199,8 @@ def test_ip_alias_and_rule_survive_reboot(reboot_observation: RebootObservation)
     assert obs.before_rule, f"precondition [{leg}]: a pf rule must reference {obs.alias} after reload"
     if obs.ramdisk:
         assert obs.archive_present, (
-            f"precondition [ramdisk]: {h.ALIASARCHIVE} must exist pre-reboot (the earlyshellcmd "
-            "restore source) — else the ramdisk path is not actually exercised"
+            f"precondition [ramdisk]: {h.ALIASARCHIVE}.{{zst,bz2}} must exist pre-reboot (the "
+            "earlyshellcmd restore source) — else the ramdisk path is not actually exercised"
         )
         # The sentinel must have been created pre-reboot, else the wipe check below is a
         # false green (a sentinel that never existed also reads as "gone" after reboot).

--- a/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
+++ b/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
@@ -1,0 +1,155 @@
+"""Issue #468 — DNSBL survives a RAM-disk /var reboot (python integration re-staged).
+
+On a RAM-disk /var (``use_mfs_tmpvar``) a reboot wipes ``/var/unbound``. The MFS
+restore archive (``pfb_aliastables``) already globs ``/var/unbound/pfb_unbound*`` +
+``pfb_py_*`` and the boot ``earlyshellcmd`` untars it — but the archive was only
+(re)built on IP-alias/firewall-rule changes, so a DNSBL-only config never archived
+the python integration and DNSBL came up dead after every reboot. The fix builds
+the archive on DNSBL-only updates too.
+
+REPRODUCE-FIRST: assert the domain sinkholes BEFORE the reboot, then require it to
+still sinkhole AFTER a RAM-disk reboot (pfb_unbound.py re-staged + matcher rebuilt
+from the restored manifest), with NO manual update. Verified RED on pre-fix code.
+
+All slow VM I/O (inject -> reload -> reboot -> recovery poll) lives in the MODULE
+FIXTURE, never the test body: the smoke workflow caps the test BODY at 30s
+(``--timeout=30 timeout_func_only=true``) but fixtures are exempt (same reason the
+~2 min deploy + the #334 reboot fixture are). The body is pure assertions.
+
+reboot marker (destructive — reboots the shared session VM). Run::
+
+    python -m pytest tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py \
+        -m reboot --override-ini="addopts=" -rA -s
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM, _StubDnsServer
+
+pytestmark = pytest.mark.reboot
+
+VAR_WIPE_SENTINEL = "/var/PFB_SMOKE_468_WIPE"
+PFB_UNBOUND = "/var/unbound/pfb_unbound.py"
+RECOVERY_DEADLINE = 240  # seconds to wait for DNSBL to self-heal post-reboot
+
+
+@dataclass
+class DnsblRebootObservation:
+    """DNSBL state captured around one RAM-disk reboot (built in the fixture)."""
+
+    domain: str
+    sinkholes_before: bool
+    var_wiped: bool
+    staged_after: bool
+    var_unbound_ls: str
+    recovered: bool
+    recovered_after_s: int
+
+
+def _sinkholes(vm: SmokeVM, domain: str) -> bool:
+    try:
+        return h.resolves_to(h.dns_probe(vm, domain, "A"), h.DEFAULT_DNSBL_VIP4)
+    except Exception:  # noqa: BLE001 -- mid-restart no-answer counts as "not yet"
+        return False
+
+
+@pytest.fixture(scope="module")
+def dnsbl_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+    """Deploy the branch .pkg with DNSBL infra (sinkhole VIP + system upstream), once."""
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        try:
+            h.set_ramdisk(smoke_vm, False)
+            h.reload(smoke_vm, "update")
+        except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the result
+            print(f"[smoke] #468 teardown reload failed (non-fatal): {exc}")
+        h.unblock_egress()
+        h.collect_host_diagnostics(smoke_vm)
+
+
+@pytest.fixture(scope="module")
+def reboot_observation(dnsbl_vm: SmokeVM) -> DnsblRebootObservation:
+    """ALL slow VM I/O for the #468 scenario — runs in the fixture (no 30s body cap).
+
+    Given a DNSBL feed blocking a unique domain with RAM-disk /var enabled,
+      And the domain sinkholes (DNSBL works before the reboot),
+    When the guest is rebooted (MFS wipes /var/unbound; the boot re-stage runs),
+    Then capture: /var really wiped (MFS), pfb_unbound.py re-staged, and whether the
+      domain self-recovers to the sinkhole within RECOVERY_DEADLINE (no manual update).
+    """
+    vm = dnsbl_vm
+    domain = h.unique_domain("pfb468")
+
+    # Given: RAM disks ON before the reload; a DNSBL feed blocking `domain`, applied.
+    h.set_ramdisk(vm, True)
+    feed_url = h.write_local_feed(vm, "issue468.txt", f"{domain}\n")
+    spec = h.DnsblCase(aliasname="smoke468", feed_url=feed_url, header="smoke468", mode=h.DnsblMode.VIP)
+    h.inject(vm, spec)
+    h.reload(vm, "update")
+    h.wait_unbound_ready(vm)
+
+    sinkholes_before = _sinkholes(vm, domain)
+
+    # MFS proof sentinel, then reboot.
+    vm.ssh("/usr/bin/touch", VAR_WIPE_SENTINEL)
+    h.reboot_vm(vm)
+    h.wait_unbound_ready(vm)
+
+    var_wiped = vm.ssh("test", "-e", VAR_WIPE_SENTINEL).returncode != 0
+    staged_after = vm.ssh("test", "-f", PFB_UNBOUND).returncode == 0
+    var_unbound_ls = vm.ssh("/bin/ls", "-la", "/var/unbound").stdout
+
+    # Poll for self-recovery (pfb_unbound.py staged AND sinkholing) with NO manual update.
+    waited = 0
+    recovered = False
+    while waited <= RECOVERY_DEADLINE:
+        if vm.ssh("test", "-f", PFB_UNBOUND).returncode == 0 and _sinkholes(vm, domain):
+            recovered = True
+            break
+        time.sleep(10)
+        waited += 10
+
+    return DnsblRebootObservation(
+        domain=domain,
+        sinkholes_before=sinkholes_before,
+        var_wiped=var_wiped,
+        staged_after=staged_after,
+        var_unbound_ls=var_unbound_ls,
+        recovered=recovered,
+        recovered_after_s=waited,
+    )
+
+
+def test_dnsbl_survives_ramdisk_var_reboot(reboot_observation: DnsblRebootObservation) -> None:
+    """A DNSBL-blocked domain must still sinkhole after a RAM-disk /var reboot (#468)."""
+    obs = reboot_observation
+
+    # Precondition: DNSBL worked BEFORE the reboot (else the after-state proves nothing).
+    assert obs.sinkholes_before, f"precondition: {obs.domain} must sinkhole to {h.DEFAULT_DNSBL_VIP4} before the reboot"
+    # The leg is genuinely a RAM-disk /var (MFS wiped the sentinel).
+    assert obs.var_wiped, (
+        f"{VAR_WIPE_SENTINEL} survived the reboot — use_mfs_tmpvar did not engage; not a RAM-disk /var"
+    )
+    # #468 core: pfb_unbound.py re-staged into the chroot after the wipe.
+    assert obs.staged_after, (
+        f"#468: {PFB_UNBOUND} missing after RAM-disk reboot (not re-staged).\n/var/unbound:\n{obs.var_unbound_ls}"
+    )
+    # #468 end-state: still sinkholing — matcher rebuilt from the restored manifest, no manual update.
+    assert obs.recovered, (
+        f"#468: {obs.domain} did not sinkhole again within {RECOVERY_DEADLINE}s of a RAM-disk reboot "
+        f"(staged_after={obs.staged_after}); DNSBL stays down until a manual update"
+    )

--- a/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
+++ b/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
@@ -1,11 +1,12 @@
 """Issue #468 — DNSBL survives a RAM-disk /var reboot (python integration re-staged).
 
-On a RAM-disk /var (``use_mfs_tmpvar``) a reboot wipes ``/var/unbound``. The MFS
-restore archive (``pfb_aliastables``) already globs ``/var/unbound/pfb_unbound*`` +
-``pfb_py_*`` and the boot ``earlyshellcmd`` untars it — but the archive was only
-(re)built on IP-alias/firewall-rule changes, so a DNSBL-only config never archived
-the python integration and DNSBL came up dead after every reboot. The fix builds
-the archive on DNSBL-only updates too.
+On a RAM-disk /var (``use_mfs_tmpvar``) a reboot wipes ``/var/unbound``, so DNSBL
+came up dead after every reboot. The fix adds a DEDICATED DNSBL cache, independent
+of the IP-alias archive: ``pfb_dnsbl_cache('save')`` archives the generated python
+integration (``/var/unbound/pfb_unbound*`` + ``pfb_py_*``) whenever DNSBL actually
+changes, and a separate boot ``earlyshellcmd`` (``pfblockerng.sh dnsbl_cache
+restore``) untars it then re-stages the shipped files — pure file ops, no reload.
+Unbound's normal start then loads the restored files.
 
 REPRODUCE-FIRST: assert the domain sinkholes BEFORE the reboot, then require it to
 still sinkhole AFTER a RAM-disk reboot (pfb_unbound.py re-staged + matcher rebuilt


### PR DESCRIPTION
## Problem

On a RAM-disk `/var` install (`use_mfs_tmpvar`), DNSBL is **silently dead after every reboot**: MFS wipes `/var/unbound`, so `pfb_unbound.py` + the processed DNSBL data are gone, and it does **not** self-heal until a manual update. Confirmed + characterised on a live Debian/KVM run (details in #468).

## Root causes (three, all only reachable on a fresh-MFS boot with DNSBL active)

1. **No DNSBL archive on a DNSBL-only change** — the MFS restore archive was only (re)built inside the IP-alias/firewall-rule-change branches, so a DNSBL-only config never archived its python integration.
2. **Boot-fatal `logger()`** — `pfb_unbound_include.inc` is `require_once`'d by pfSense core `services_unbound_configure()` on the non-verbose boot path (where pfBlockerNG's `logger()` fallback isn't loaded); two unguarded `logger()` calls in `pfb_python_mount`'s mount-failure branches were a fatal that wedged `rc.bootup`.
3. **Missing nullfs mount-point dirs** — on a fresh `/var/unbound` the chroot mount targets (`lib`, `dev`, …) don't exist, so `pfb_python_mount` failed (which triggered #2).

## Fix

- **Two separate archives, by lifecycle** (no conflation): the IP `aliastables` archive stays as-is (reverted to IP-only, already gated on alias changes); a **new, independent DNSBL cache** (`pfb_dnsbl_cache` / `pfblockerng.sh dnsbl_cache`) is gated on the **DNSBL-reload guard** and runs **after** the reload (post zero-downtime swap), so it archives only when DNSBL actually changed.
- **Restore = pure file ops, no reload** — the boot `earlyshellcmd` untars the processed manifest/data + re-stages the shipped files from `/usr/local` (always current — no stale code) + `mkdir`s the mount-point dirs.
- **Single-source archive helpers** (`pfb_archive_compress/extract`): take an extension-less base and own the codec — **zstd** (multi-threaded, `min(4, ncpu−1)`), falling back to **bzip2** if zstd is missing/errors (dropping any partial `.zst`); extract lets `bsdtar -P` auto-detect either. Legacy `.tar.bz2` archives are read on upgrade and retired after a verified zstd write.
- **`log_error()`** replaces the boot-fatal `logger()`.

## Testing

- **Reproduce-first live-VM smoke** `test_smoke_dnsbl_ramdisk_reboot.py` (reboot marker): block a domain on `use_mfs_tmpvar`, prove it sinkholes, MFS-reboot, require self-recovery. **Verified RED on pre-fix code; GREEN now.** #334's IP-aliastables ramdisk leg still passes (now zstd, codec-agnostic). Dispatched `pytest_marker=reboot`: **3 passed**.
- `tests/shell/pfblockerng_dnsbl_cache_spec.sh` (shellspec) pins stage/save/restore + the codec-agnostic archive helpers.
- `php -l` / PHPCS / PHPStan / PHPUnit (1306) / shellcheck / shellspec (116) / ruff all green.

Fixes #468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNSBL now survives RAM-disk reboots more reliably, restoring its state automatically after restart.
  * Archive handling now supports faster compression with automatic fallback for compatibility.

* **Bug Fixes**
  * Improved boot-time error logging so DNSBL helpers no longer fail on non-verbose startup paths.
  * Restores now re-stage shipped files after reboot to avoid stale DNSBL behavior.

* **Tests**
  * Added smoke coverage for DNSBL recovery across RAM-disk reboots and archive round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->