### PR TITLE
pfblockerng: report unlock-forced DNSBL reload as a change to post-hooks (#517)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -13347,9 +13347,11 @@ function sync_package_pfblockerng($cron='') {
 	// Force re-locks it even when no feed changed -- parity with main, where the
 	// ungated whitelist regeneration sets $pfbpython for the same effect. The reload
 	// path (pfb_update_unbound) then drops the store and clears the manifest's
-	// user_unlock.
+	// user_unlock. Captured BEFORE the reload: pfb_update_unbound() unlinks the file,
+	// so a post-reload file_exists() would always return false (issue #517).
+	$pfb_dnsbl_unlock_forced = file_exists($pfb['dnsbl_unlock']);
 	if ($pfb_data_changed || $pfbupdate || $pfbpython || $safesearch_update ||
-	    file_exists($pfb['dnsbl_unlock'])) {
+	    $pfb_dnsbl_unlock_forced) {
 
 		// Create backup of existing DNSBL Unbound database
 
@@ -15264,7 +15266,9 @@ function sync_package_pfblockerng($cron='') {
 	//       aliastable changes were found and a filter reload was applied (the IP side).
 	//   PFB_DNSBL_CHANGED = mirrors the gate that drives pfb_update_unbound above:
 	//       $pfb_data_changed (fingerprint-derived, or domain_update/domain_clear when
-	//       TLD mode / DNSBL inactive), || $pfbupdate || $pfbpython || $safesearch_update.
+	//       TLD mode / DNSBL inactive), || $pfbupdate || $pfbpython || $safesearch_update,
+	//       || $pfb_dnsbl_unlock_forced (a pending /tmp/dnsbl_unlock file forced the
+	//       reload — captured before pfb_update_unbound() unlinks it, issue #517).
 	//       Reports '1' only when a reload actually fired, so a skipped pass (unchanged
 	//       blocklist, fingerprints equal) correctly emits '0'. !empty() guards any flag
 	//       whose block did not run — no undefined-variable warning.
@@ -15294,7 +15298,7 @@ function sync_package_pfblockerng($cron='') {
 		'TRIGGER'		=> pfb_hook_trigger($cron),
 		'IP_CHANGED'		=> !empty($pfb['filter_configure'])	? '1' : '0',
 		'DNSBL_CHANGED'		=> (!empty($pfb_data_changed) || !empty($pfbupdate) || !empty($pfbpython) ||
-						!empty($safesearch_update)) ? '1' : '0',
+						!empty($safesearch_update) || !empty($pfb_dnsbl_unlock_forced)) ? '1' : '0',
 		'STATUS'		=> 'ok',
 		'CHANGED_IP_ALIASES'	=> implode(' ', array_unique($pfb['changed_ip_aliases'])),
 		'CHANGED_DNSBL_GROUPS'	=> implode(' ', array_unique($pfb['changed_dnsbl_groups'])),

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -747,3 +747,99 @@ def test_hooks_webhook_dnsbl_guard_branch(
         )
 
     h.clear_update_hooks(deployed_vm)
+
+
+# --------------------------------------------------------------------------- #
+# 11) issue #517 — unlock-forced DNSBL reload must report PFB_DNSBL_CHANGED=1
+# --------------------------------------------------------------------------- #
+
+
+def test_hooks_dnsbl_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
+    """An unlock-forced DNSBL reload (sole trigger: /tmp/dnsbl_unlock) reports
+    ``PFB_DNSBL_CHANGED='1'`` to post-hooks (issue #517).
+
+    Scenario: the reload gate in ``sync_package_pfblockerng`` fires because
+    ``file_exists($pfb['dnsbl_unlock'])`` is true — no feed change, no fingerprint
+    delta.  Before the fix, ``PFB_DNSBL_CHANGED`` was built from
+    ``$pfb_data_changed || $pfbupdate || $pfbpython || $safesearch_update`` only,
+    omitting the unlock condition, so the post-hook saw ``'0'`` even though the
+    reload did fire.  A HAProxy-style recipe keyed on ``PFB_DNSBL_CHANGED`` would
+    therefore MISS the re-lock.
+
+    **Given** a post env-dump hook is enabled; DNSBL has been deployed (``deployed_vm``
+    fixture guarantees this); there is NO pending feed change (a prior settling
+    ``updatednsbl`` leaves the blocklist stable so ``$pfb_data_changed``,
+    ``$pfbupdate``, ``$pfbpython``, and ``$safesearch_update`` are all false on the
+    test pass).
+
+    **And** a ``/tmp/dnsbl_unlock`` file is written on the guest with a valid
+    ``domain,type`` row so the gate's ``file_exists($pfb['dnsbl_unlock'])`` is true.
+
+    **When** ``helpers.reload(vm, 'updatednsbl')`` fires the pass.
+
+    **Then** the captured ``PFB_DNSBL_CHANGED`` from the post-hook env == ``'1'``
+    (the unlock-forced reload is reported as a DNSBL change to post-hooks).
+
+    FAILS on pre-fix code (``PFB_DNSBL_CHANGED`` is ``'0'``); PASSES after the fix.
+    """
+    import subprocess
+
+    token = "unlkchg"
+    marker = h.hook_marker_path(token, "post")
+
+    h.set_update_hooks(deployed_vm, [h.env_dump_hook(token, "post")])
+
+    # Settle: run a pass so the blocklist is stable and no feed change is pending.
+    # 'updatednsbl' reloads DNSBL from cache (reuse_dnsbl), which is exactly the
+    # no-feed-change pass we need for the subsequent assertion.
+    h.clear_hook_markers(deployed_vm, token)
+    h.reload(deployed_vm, "updatednsbl")
+    env_settle = h.read_hook_env(deployed_vm, marker)
+    assert env_settle is not None, "post hook did not run during the settling pass"
+
+    # Before-state: after settle, no unlock file present => PFB_DNSBL_CHANGED must be
+    # '0' (the four feed-change flags are all false, and no unlock file is present).
+    # This proves the *subsequent* '1' is caused by the unlock file, not leftover state.
+    h.clear_hook_markers(deployed_vm, token)
+    h.reload(deployed_vm, "updatednsbl")
+    env_before = h.read_hook_env(deployed_vm, marker)
+    assert env_before is not None, "post hook did not run for the before-state pass"
+    assert env_before.get("PFB_DNSBL_CHANGED") == "0", (
+        "before-state: expected PFB_DNSBL_CHANGED='0' with no feed change and no unlock file, "
+        f"got {env_before.get('PFB_DNSBL_CHANGED')!r} — {env_before}"
+    )
+
+    # Write /tmp/dnsbl_unlock on the guest with a valid domain,type row.
+    # SmokeVM.ssh routes through /bin/sh (CLAUDE.md tcsh rule) so tee is safe here.
+    domain = h.unique_domain("unlkchg")
+    unlock_path = "/tmp/dnsbl_unlock"
+    unlock_content = f"{domain},DNSBL\n"
+    result = subprocess.run(
+        deployed_vm.ssh_argv("tee", unlock_path),
+        input=unlock_content,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"test_hooks_dnsbl_changed_unlock_forced: failed to write {unlock_path}: "
+            f"rc={result.returncode} {result.stderr!r}"
+        )
+
+    # After-state: reload with the unlock file present; the gate fires solely on
+    # file_exists($pfb['dnsbl_unlock']). pfb_update_unbound() unlinks the file
+    # during the reload, so the post-hook expression must have been captured before
+    # the reload (the fix: $pfb_dnsbl_unlock_forced local var).
+    h.clear_hook_markers(deployed_vm, token)
+    h.reload(deployed_vm, "updatednsbl")
+    env_after = h.read_hook_env(deployed_vm, marker)
+    assert env_after is not None, "post hook did not run for the unlock-forced pass"
+    got = env_after.get("PFB_DNSBL_CHANGED")
+    assert got == "1", (
+        "unlock-forced DNSBL reload must set PFB_DNSBL_CHANGED='1' to post-hooks (issue #517): "
+        f"expected '1', got {got!r}\nfull hook env: {env_after}"
+    )
+
+    h.clear_update_hooks(deployed_vm)

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -767,15 +767,16 @@ def test_hooks_dnsbl_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
     therefore MISS the re-lock.
 
     **Given** a post env-dump hook is enabled; DNSBL has been deployed (``deployed_vm``
-    fixture guarantees this); there is NO pending feed change (a prior settling
-    ``updatednsbl`` leaves the blocklist stable so ``$pfb_data_changed``,
-    ``$pfbupdate``, ``$pfbpython``, and ``$safesearch_update`` are all false on the
-    test pass).
+    fixture guarantees this); there is NO pending feed change — a full ``update`` over
+    the UNCHANGED on-disk feed reuse-caches the DNSBL data (no re-parse), so
+    ``$pfb_data_changed``, ``$pfbupdate``, ``$pfbpython``, and ``$safesearch_update``
+    are all false (the before-state asserts ``PFB_DNSBL_CHANGED='0'``).
 
     **And** a ``/tmp/dnsbl_unlock`` file is written on the guest with a valid
     ``domain,type`` row so the gate's ``file_exists($pfb['dnsbl_unlock'])`` is true.
 
-    **When** ``helpers.reload(vm, 'updatednsbl')`` fires the pass.
+    **When** ``helpers.reload(vm, 'update')`` fires the pass (still no feed change, so
+    the unlock file is the SOLE reload trigger).
 
     **Then** the captured ``PFB_DNSBL_CHANGED`` from the post-hook env == ``'1'``
     (the unlock-forced reload is reported as a DNSBL change to post-hooks).
@@ -789,11 +790,12 @@ def test_hooks_dnsbl_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
 
     h.set_update_hooks(deployed_vm, [h.env_dump_hook(token, "post")])
 
-    # Settle: run a pass so the blocklist is stable and no feed change is pending.
-    # 'updatednsbl' reloads DNSBL from cache (reuse_dnsbl), which is exactly the
-    # no-feed-change pass we need for the subsequent assertion.
+    # Settle: a full 'update' over the UNCHANGED on-disk feed reuse-caches the DNSBL
+    # data (inc:8917) -- no re-parse, the builders report no change -- which is exactly
+    # the no-feed-change pass we need. ('updatednsbl' force-reloads and re-marks the
+    # group as updated, so it can never yield the '0' baseline -- it is the wrong verb.)
     h.clear_hook_markers(deployed_vm, token)
-    h.reload(deployed_vm, "updatednsbl")
+    h.reload(deployed_vm, "update")
     env_settle = h.read_hook_env(deployed_vm, marker)
     assert env_settle is not None, "post hook did not run during the settling pass"
 
@@ -801,7 +803,7 @@ def test_hooks_dnsbl_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
     # '0' (the four feed-change flags are all false, and no unlock file is present).
     # This proves the *subsequent* '1' is caused by the unlock file, not leftover state.
     h.clear_hook_markers(deployed_vm, token)
-    h.reload(deployed_vm, "updatednsbl")
+    h.reload(deployed_vm, "update")
     env_before = h.read_hook_env(deployed_vm, marker)
     assert env_before is not None, "post hook did not run for the before-state pass"
     assert env_before.get("PFB_DNSBL_CHANGED") == "0", (
@@ -828,12 +830,12 @@ def test_hooks_dnsbl_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
             f"rc={result.returncode} {result.stderr!r}"
         )
 
-    # After-state: reload with the unlock file present; the gate fires solely on
-    # file_exists($pfb['dnsbl_unlock']). pfb_update_unbound() unlinks the file
-    # during the reload, so the post-hook expression must have been captured before
-    # the reload (the fix: $pfb_dnsbl_unlock_forced local var).
+    # After-state: same no-feed-change 'update', but now the unlock file is present, so
+    # the gate fires SOLELY on file_exists($pfb['dnsbl_unlock']). pfb_update_unbound()
+    # unlinks the file during the reload, so the post-hook expression must have been
+    # captured before the reload (the fix: $pfb_dnsbl_unlock_forced local var).
     h.clear_hook_markers(deployed_vm, token)
-    h.reload(deployed_vm, "updatednsbl")
+    h.reload(deployed_vm, "update")
     env_after = h.read_hook_env(deployed_vm, marker)
     assert env_after is not None, "post hook did not run for the unlock-forced pass"
     got = env_after.get("PFB_DNSBL_CHANGED")


### PR DESCRIPTION
## What

`PFB_DNSBL_CHANGED` (the ADR-12 `post`-hook context) was built from
`$pfb_data_changed || $pfbupdate || $pfbpython || $safesearch_update` only. But the DNSBL
reload gate in `sync_package_pfblockerng` ALSO fires on a pending temporary-unlock
(`file_exists($pfb['dnsbl_unlock'])`). So an unlock-forced reload (a Cron/Force re-lock with no
feed change) fired the reload but reported `PFB_DNSBL_CHANGED=0` — a `post` hook keyed on it
(e.g. a HAProxy reload recipe) would miss the re-lock.

`pfb_update_unbound()` unlinks the unlock file during the reload, so the value must be captured
**before** the reload, not re-`file_exists()`d at the hook tail.

## Fix

Capture `$pfb_dnsbl_unlock_forced = file_exists($pfb['dnsbl_unlock'])` just before the gate
(reusing it in the gate condition, behaviour-identical), and add `|| !empty($pfb_dnsbl_unlock_forced)`
to the `DNSBL_CHANGED` expression. The gate and the hook report are in the same function, so the
local carries.

## Test

`tests/smoke/test_smoke_hooks.py::test_hooks_dnsbl_changed_unlock_forced` (ADR-12 hook smoke):
asserts `PFB_DNSBL_CHANGED=0` on a no-change reload with no unlock file, then writes
`/tmp/dnsbl_unlock` and asserts `=1` after an otherwise-identical reload — the unlock is the sole
trigger. Fails on pre-fix code (`0`), passes after.

Found by CodeRabbit during #504 review; deferred there as pre-existing/out-of-scope.

Fixes #517


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNSBL reload handling so forced unlock situations are detected reliably, even after a temporary file is cleared during processing.
  * Kept the reported “changed” status consistent with the actual reload behavior in post-run hook output.

* **Tests**
  * Added smoke coverage for DNSBL change detection when an unlock is forced, including verification of hook-reported status before and after cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->