### PR TITLE
pfblockerng: fingerprint the shipped HSTS list so a change triggers a zero-downtime DNSBL reload (#520)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -13336,9 +13336,10 @@ function sync_package_pfblockerng($cron='') {
 		: ($pfb_fp_old !== $pfb_fp_new);
 
 	// An explicit "Force Reload DNSBL" (the updatednsbl trigger) must ALWAYS reload — the
-	// operator forces it to apply a change the fingerprint can't see, e.g. an out-of-band
-	// edit to the HSTS list (pfb_py_hsts.txt is loaded at module init and is NOT part of
-	// the fingerprinted feed data). reuse_dnsbl / the .reload marker can't serve as this
+	// operator forces it to apply a change the fingerprint can't see (e.g. an out-of-band
+	// edit to a chroot file outside the fingerprinted input set, or to recover from
+	// suspected runtime drift), independent of the fingerprint. reuse_dnsbl / the .reload
+	// marker can't serve as this
 	// signal — cron-reuse mode and the dnsbl-missing path also set them, which would
 	// reintroduce the every-pass reload this gate removes; $pfb['updatednsbl'] is set ONLY
 	// by the Force-Reload-DNSBL path (see the $cron switch).

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -115,6 +115,7 @@ $pfb['unbound_py_wh']	= '/var/unbound/pfb_py_whitelist.txt';
 $pfb['unbound_py_data']	= '/var/unbound/pfb_py_data.txt';
 $pfb['unbound_py_zone'] = '/var/unbound/pfb_py_zone.txt';
 $pfb['unbound_py_ss']	= '/var/unbound/pfb_py_ss.txt';
+$pfb['unbound_py_hsts']	= '/var/unbound/pfb_py_hsts.txt';	// SHIPPED file re-staged by dnsbl_cache_stage() cp -f; fingerprinted so a package update ships a new list and triggers a zero-downtime reload
 $pfb['unbound_py_count']= '/var/unbound/pfb_py_count';
 $pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07 P8: Python-emitted ADMITTED (cap-filtered) feed+user regex total for the DNSBL_Regex alias
 $pfb['unbound_py_sources']= '/var/unbound/pfb_py_sources.json';	// ADR-06: per-feed manifest consumed by pfb_unbound.py init
@@ -1120,6 +1121,9 @@ function pfb_resolve_list_script($name, $dirs = null) {
 
 /* Return the ordered list of input paths the Python DNSBL module loads.
    These are fingerprinted before/after a pass to detect real changes.
+   Includes unbound_py_hsts: the shipped HSTS preload list re-staged by dnsbl_cache_stage()
+   via cp -f between the two fingerprint snapshots, so a package update that ships a new
+   list is detected (old chroot copy vs freshly staged copy differ) and triggers a reload.
    Excluded: unbound_py_count / unbound_py_regex_count (Python-emitted outputs —
    including them makes every pass look changed) and unbound_py_ss (has its own
    md5 gate via $safesearch_update; double-gating would suppress SafeSearch restarts).
@@ -1128,7 +1132,7 @@ function pfb_dnsbl_loaded_input_paths(array $pfb): array {
 	$raw_files = glob("{$pfb['unbound_py_rawdir']}/*.raw") ?: array();
 	sort($raw_files, SORT_STRING);
 	return array_merge(
-		array($pfb['unbound_py_data'], $pfb['unbound_py_zone'], $pfb['unbound_py_wh'], $pfb['unbound_py_sources']),
+		array($pfb['unbound_py_data'], $pfb['unbound_py_zone'], $pfb['unbound_py_wh'], $pfb['unbound_py_sources'], $pfb['unbound_py_hsts']),
 		$raw_files
 	);
 }
@@ -13373,6 +13377,12 @@ function sync_package_pfblockerng($cron='') {
 		// the next reboot. Gated like the IP side (archive only inside the change branch):
 		// DNSBL active ($mode === 'enabled', i.e. enable + dnsbl + resolver on) +
 		// use_mfs_tmpvar. Read $pfb directly (not $mode) to keep the gate self-contained.
+		// #520 NOTE: an HSTS-only change now enters this branch too ($pfb_data_changed
+		// fingerprints the shipped pfb_py_hsts.txt), so the archive is re-saved even
+		// though it EXCLUDES the shipped files -- a harmless no-op re-compress of
+		// identical generated content. Deliberately NOT separately gated: the shipped
+		// HSTS list ships per-release (changes ~never), so the rare extra save isn't
+		// worth a second generated-only fingerprint.
 		if ($pfb['enable'] == 'on' && $pfb['dnsbl'] == 'on' && $pfb['unbound_state'] == 'on' &&
 		    config_path_enabled('system', 'use_mfs_tmpvar')) {
 			pfb_dnsbl_cache('save');

--- a/tests/php/DnsblLoadedFingerprintTest.php
+++ b/tests/php/DnsblLoadedFingerprintTest.php
@@ -186,11 +186,11 @@ final class DnsblLoadedFingerprintTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Scenario: returns the four flat inputs plus sorted *.raw from rawdir.
+	 * Scenario: returns the five flat inputs (incl. HSTS) plus sorted *.raw from rawdir.
 	 *
 	 * Given:  a $pfb array with the standard keys and two .raw files in rawdir
 	 * When:   pfb_dnsbl_loaded_input_paths() is called
-	 * Then:   result contains data/zone/wh/sources plus both .raw paths, in sorted order
+	 * Then:   result contains data/zone/wh/sources/hsts plus both .raw paths, in sorted order
 	 */
 	public function testReturnsFlatInputsPlusSortedRaws(): void
 	{
@@ -203,6 +203,7 @@ final class DnsblLoadedFingerprintTest extends TestCase
 			'unbound_py_zone'    => "{$this->tmpDir}/pfb_py_zone.txt",
 			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
 			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
+			'unbound_py_hsts'    => "{$this->tmpDir}/pfb_py_hsts.txt",
 			'unbound_py_rawdir'  => $rawDir,
 			// Keys that must NOT appear in the result:
 			'unbound_py_count'       => "{$this->tmpDir}/pfb_py_count",
@@ -212,11 +213,12 @@ final class DnsblLoadedFingerprintTest extends TestCase
 
 		$result = pfb_dnsbl_loaded_input_paths($pfb);
 
-		// The four flat inputs must be present.
+		// The five flat inputs must be present (incl. HSTS shipped list — #520 fix).
 		$this->assertContains($pfb['unbound_py_data'],    $result, 'unbound_py_data must be in the path list');
 		$this->assertContains($pfb['unbound_py_zone'],    $result, 'unbound_py_zone must be in the path list');
 		$this->assertContains($pfb['unbound_py_wh'],      $result, 'unbound_py_wh must be in the path list');
 		$this->assertContains($pfb['unbound_py_sources'], $result, 'unbound_py_sources must be in the path list');
+		$this->assertContains($pfb['unbound_py_hsts'],    $result, 'unbound_py_hsts must be in the path list (shipped HSTS preload; #520)');
 
 		// Both .raw files must be present.
 		$this->assertContains("{$rawDir}/aa_feed.raw", $result, 'aa_feed.raw must be in the path list');
@@ -235,11 +237,11 @@ final class DnsblLoadedFingerprintTest extends TestCase
 	}
 
 	/**
-	 * Scenario: empty rawdir — no .raw files, just the four flat inputs.
+	 * Scenario: empty rawdir — no .raw files, just the five flat inputs (incl. HSTS).
 	 *
 	 * Given:  a rawdir that is empty (no .raw files)
 	 * When:   pfb_dnsbl_loaded_input_paths() is called
-	 * Then:   result has exactly 4 entries (the flat inputs only)
+	 * Then:   result has exactly 5 entries (the flat inputs only, including HSTS)
 	 */
 	public function testEmptyRawdirReturnsOnlyFlatInputs(): void
 	{
@@ -248,6 +250,7 @@ final class DnsblLoadedFingerprintTest extends TestCase
 			'unbound_py_zone'    => "{$this->tmpDir}/pfb_py_zone.txt",
 			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
 			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
+			'unbound_py_hsts'    => "{$this->tmpDir}/pfb_py_hsts.txt",
 			'unbound_py_rawdir'  => "{$this->tmpDir}/raw",
 			'unbound_py_count'       => "{$this->tmpDir}/pfb_py_count",
 			'unbound_py_regex_count' => "{$this->tmpDir}/pfb_py_regex_count",
@@ -256,6 +259,77 @@ final class DnsblLoadedFingerprintTest extends TestCase
 
 		$result = pfb_dnsbl_loaded_input_paths($pfb);
 
-		$this->assertCount(4, $result, 'With no .raw files, exactly the four flat inputs are returned');
+		$this->assertCount(5, $result, 'With no .raw files, exactly the five flat inputs are returned (data/zone/wh/sources/hsts)');
+	}
+
+	/**
+	 * Scenario: HSTS file content change is detected by the fingerprint — #520 regression guard.
+	 *
+	 * The shipped pfb_py_hsts.txt is re-staged by dnsbl_cache_stage() (cp -f) between the
+	 * $pfb_fp_old and $pfb_fp_new snapshots.  Before the #520 fix, hsts was absent from the
+	 * path list so a package update shipping a new HSTS list never flipped the fingerprint
+	 * and the zero-downtime reload was skipped.
+	 *
+	 * Given:  an HSTS file included in the path set via pfb_dnsbl_loaded_input_paths()
+	 * When:   the file content changes (simulating a package update staging a new list)
+	 * Then:   the fingerprint differs (reload is triggered)
+	 *
+	 * Before-state assertion is mandatory: proves the flip is caused by the HSTS file change.
+	 */
+	public function testHstsFileChangeChangesFingerprint(): void
+	{
+		$hsts = "{$this->tmpDir}/pfb_py_hsts.txt";
+		file_put_contents($hsts, "preload-domain.example\n");
+
+		$pfb = [
+			'unbound_py_data'    => "{$this->tmpDir}/pfb_py_data.txt",
+			'unbound_py_zone'    => "{$this->tmpDir}/pfb_py_zone.txt",
+			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
+			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
+			'unbound_py_hsts'    => $hsts,
+			'unbound_py_rawdir'  => "{$this->tmpDir}/raw",
+		];
+
+		// Before: record fingerprint with the original HSTS content.
+		$fp_before = pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+
+		// Simulate dnsbl_cache_stage() cp -f staging a new shipped list.
+		file_put_contents($hsts, "preload-domain.example\nnew-preload.example\n");
+
+		// After: fingerprint must differ (reload fires).
+		$fp_after = pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+
+		$this->assertNotSame(
+			$fp_before,
+			$fp_after,
+			'A change to pfb_py_hsts.txt must produce a different fingerprint (#520: shipped HSTS update must trigger a zero-downtime reload)'
+		);
+	}
+
+	/**
+	 * Scenario: HSTS file unchanged between snapshots — no spurious reload.
+	 *
+	 * Given:  an HSTS file that does not change between two fingerprint calls
+	 * When:   the fingerprint is computed twice via pfb_dnsbl_loaded_input_paths()
+	 * Then:   fingerprints are equal (no reload on an identical re-stage)
+	 */
+	public function testHstsFileUnchangedProducesEqualFingerprint(): void
+	{
+		$hsts = "{$this->tmpDir}/pfb_py_hsts.txt";
+		file_put_contents($hsts, "preload-domain.example\n");
+
+		$pfb = [
+			'unbound_py_data'    => "{$this->tmpDir}/pfb_py_data.txt",
+			'unbound_py_zone'    => "{$this->tmpDir}/pfb_py_zone.txt",
+			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
+			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
+			'unbound_py_hsts'    => $hsts,
+			'unbound_py_rawdir'  => "{$this->tmpDir}/raw",
+		];
+
+		$fp1 = pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+		$fp2 = pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+
+		$this->assertSame($fp1, $fp2, 'Unchanged HSTS file must not cause a spurious fingerprint change');
 	}
 }

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -547,16 +547,18 @@ def write_local_feed(vm: SmokeVM, name: str, contents: str, *, timeout: float = 
 
 
 # --------------------------------------------------------------------------- #
-# HSTS preload set — pin a name into the in-chroot list pfb_unbound.py reads
+# HSTS preload set — pin a name into the shipped list pfb_unbound.py reads
 # --------------------------------------------------------------------------- #
 # pfb_unbound.py loads /var/unbound/pfb_py_hsts.txt (chroot-relative
-# ``pfb_py_hsts.txt``, init line ~752) into hstsDB on every reload. pfBlockerNG
-# copies the shipped list into the chroot ONLY when it is missing
-# (inc:2238 ``if (!file_exists(...))``), so a name appended here SURVIVES a DNSBL
-# reload — letting a test put an arbitrary domain into the EFFECTIVE HSTS set
-# instead of coupling to whatever the shipped preload list happens to contain.
+# ``pfb_py_hsts.txt``, init line ~752) into hstsDB on every reload.
+# dnsbl_cache_stage() (pfblockerng.sh) uses ``cp -f`` to ALWAYS overwrite the
+# chroot copy from the shipped source at /usr/local/pkg/pfblockerng/pfb_py_hsts.txt
+# — so any name appended directly to the chroot file is LOST on the next reload.
+# A test domain must be written to the SHIPPED SOURCE so ``cp -f`` propagates it.
 
 UNBOUND_HSTS_FILE = "/var/unbound/pfb_py_hsts.txt"
+# Shipped source that dnsbl_cache_stage() copies into the chroot via cp -f.
+SHIPPED_HSTS_FILE = "/usr/local/pkg/pfblockerng/pfb_py_hsts.txt"
 UNBOUND_PFB_INI = "/var/unbound/pfb_unbound.ini"
 # pfb_unbound.py loads SafeSearch redirect entries from this chroot-relative CSV
 # (5-col format: domain,cname,target,baked_v4,baked_v6; see inject_safesearch_cname_entries).
@@ -572,15 +574,16 @@ SS_BAKED_AAAA = "2001:db8:5350::20"  # RFC 3849 (≠ STUB_DNS_AAAA ::99): baked 
 
 
 def add_hsts_name(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> None:
-    """Append ``name`` (one line) to the in-chroot HSTS preload list.
+    """Append ``name`` (one line) to the shipped HSTS preload source.
 
-    Use AFTER the case's first reload has (re)created ``pfb_py_hsts.txt`` from the
-    shipped list, then reload again so the module re-reads hstsDB with ``name``
-    included (copy-if-missing won't clobber the now-existing file). ``tee -a``
-    appends and creates the file if absent (mirrors :func:`write_local_feed`).
+    dnsbl_cache_stage() uses ``cp -f`` to overwrite the chroot copy from
+    ``SHIPPED_HSTS_FILE`` on every reload, so the test name must live in the
+    shipped source — not in the chroot file — to survive a DNSBL reload.
+    ``assert_hsts_loaded`` still checks the chroot copy to verify that
+    ``cp -f`` propagated the entry into the file the module actually reads.
     """
     result = subprocess.run(
-        vm.ssh_argv("tee", "-a", UNBOUND_HSTS_FILE),
+        vm.ssh_argv("tee", "-a", SHIPPED_HSTS_FILE),
         input=f"{name}\n",
         capture_output=True,
         text=True,

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -274,11 +274,10 @@ def test_dnsbl_hsts_override_forces_null(deployed_vm: SmokeVM, client_vm: SmokeV
     explicitly. Rationale: a browser refuses the plaintext VIP sinkhole for an
     HSTS host, so NULL is the correct block.
 
-    Self-contained: we pin a unique ``.com`` into the in-chroot HSTS set
-    (``add_hsts_name``) rather than depend on the shipped preload list. The case's
-    first reload (in ``CaseContext``) recreates ``pfb_py_hsts.txt`` from the shipped
-    list; we then append our name and reload again — copy-if-missing leaves the now-
-    existing file alone, so the module reloads hstsDB WITH our name. Paired with
+    Self-contained: we pin a unique ``.com`` into the shipped HSTS source
+    (``add_hsts_name`` → ``SHIPPED_HSTS_FILE``) rather than depend on the preload list.
+    ``dnsbl_cache_stage()`` ``cp -f`` propagates it into the chroot on the reload, which
+    the module re-reads hstsDB WITH our name. Paired with
     ``test_dnsbl_hsts_disabled_keeps_vip`` (same name, same VIP list, HSTS off →
     VIP) to prove this is the override, not an always-null path.
     """


### PR DESCRIPTION
## What

The DNSBL reload fingerprint gate (`9ac427b`) hashes `pfb_dnsbl_loaded_input_paths()` to decide whether to reload — but that set OMITTED the shipped `pfb_py_hsts.txt`, which `pfb_unbound.py` loads (in `_build_swap_snapshot()`, the zero-downtime swap). So a change to the shipped HSTS list (e.g. a new list shipped in a release) re-stages into the chroot (`dnsbl_cache_stage` `cp -f`) but does NOT flip the fingerprint → the DNSBL reload is skipped → the new list never loads. The live smoke (`test_dnsbl_hsts_override_forces_null`) is red on `devel`.

Principle: a file `pfb_unbound.py` loads as input, when it changes, must trigger a reload — being a module-loaded input is exactly the reason to fingerprint it.

## Fix

- Add `$pfb['unbound_py_hsts']` and include it in `pfb_dnsbl_loaded_input_paths()`. The re-stage (`pfb_unbound_dnsbl()`) runs BETWEEN the before/after fingerprint snapshots, so old-vs-newly-staged chroot copy detects a shipped-file change → **zero-downtime** reload, with no steady-state false positive (identical re-stage = identical md5). `cp -f` (always copy) stays.
- Smoke helper `add_hsts_name()` now injects the test domain into the **shipped source** (`/usr/local/pkg/pfblockerng/pfb_py_hsts.txt`) so the `cp -f` re-stage propagates it into the chroot — the old helper appended to the chroot copy, which `cp -f` overwrote (the stale copy-if-missing assumption; root of the red test).
- `DnsblLoadedFingerprintTest`: pins `unbound_py_hsts` in the input set + that an HSTS change flips the fingerprint (stable when unchanged).

A documented, deliberately-not-gated side effect: an HSTS-only change also re-saves the RAM-disk archive (which excludes shipped files) — a harmless no-op re-compress; HSTS ships per-release so it's not worth a second fingerprint.

Found while fixing #517 (the smoke fan-out went red on HSTS). Static-shipped HSTS list ⇒ no user-facing edit ⇒ no GUI change.

Fixes #520


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HSTS list updates now trigger DNSBL reload detection, so changes are picked up consistently.
  * Prevented unnecessary reloads when the HSTS list content has not changed.
* **Tests**
  * Expanded fingerprint coverage to include the HSTS input file.
  * Added regression checks for both changed and unchanged HSTS file behavior.
* **Documentation**
  * Updated inline test and workflow notes to match the new HSTS handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->