### PR TITLE
pfblockerng: report PFB_IP_CHANGED on ip_unlock-forced re-block (#519)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14870,6 +14870,8 @@ function sync_package_pfblockerng($cron='') {
 	#################################
 
 	// If 'Rule Changes' are found, utilize the 'filter_configure()' function, if not, utilize 'pfctl replace' command
+	// Captured here (before the if/else) so it is always defined at the post-hook emit.
+	$pfb_ip_unlock_forced = FALSE;
 	if ($pfb['autorules'] && $orig_rules_nocreated != $new_rules_nocreated || $pfb['enable'] == '' || $pfb['remove']) {
 
 		if (!$pfb['save']) {
@@ -14926,6 +14928,10 @@ function sync_package_pfblockerng($cron='') {
 
 			// Remove Alerts IP unlock file and force Reload of all Aliastables
 			if (file_exists("{$pfb['ip_unlock']}")) {
+				// Captured BEFORE unlink: flag that a temporary unlock forced a re-block this
+				// pass, so PFB_IP_CHANGED reports '1' even though filter_configure() did NOT
+				// run (issue #519 -- mirrors $pfb_dnsbl_unlock_forced / issue #517 on the DNSBL side).
+				$pfb_ip_unlock_forced = TRUE;
 				unlink_if_exists("{$pfb['ip_unlock']}");
 				$pfb['repcheck'] = TRUE;
 			}
@@ -15273,8 +15279,11 @@ function sync_package_pfblockerng($cron='') {
 	// reloads, filter_configure(), and the FINAL REPORTING 'closing' step above --
 	// so the change flags are final. Context is derived ONLY from existing flags
 	// (no new tracking):
-	//   PFB_IP_CHANGED    = $pfb['filter_configure'] -- set TRUE when firewall rule/
-	//       aliastable changes were found and a filter reload was applied (the IP side).
+	//   PFB_IP_CHANGED    = $pfb['filter_configure'] || $pfb_ip_unlock_forced -- set TRUE
+	//       when firewall rule/aliastable changes were found and a filter reload was
+	//       applied (the IP side), OR when a pending /tmp/ip_unlock file forced a
+	//       pfctl-replace re-block without a filter reload -- captured before the unlink,
+	//       issue #519 (mirrors $pfb_dnsbl_unlock_forced / issue #517 on the DNSBL side).
 	//   PFB_DNSBL_CHANGED = mirrors the gate that drives pfb_update_unbound above:
 	//       $pfb_data_changed (fingerprint-derived, or domain_update/domain_clear when
 	//       TLD mode / DNSBL inactive), || $pfbupdate || $pfbpython || $safesearch_update,
@@ -15307,7 +15316,7 @@ function sync_package_pfblockerng($cron='') {
 	}
 	pfb_run_hooks('post', array(
 		'TRIGGER'		=> pfb_hook_trigger($cron),
-		'IP_CHANGED'		=> !empty($pfb['filter_configure'])	? '1' : '0',
+		'IP_CHANGED'		=> (!empty($pfb['filter_configure']) || !empty($pfb_ip_unlock_forced)) ? '1' : '0',
 		'DNSBL_CHANGED'		=> (!empty($pfb_data_changed) || !empty($pfbupdate) || !empty($pfbpython) ||
 						!empty($safesearch_update) || !empty($pfb_dnsbl_unlock_forced)) ? '1' : '0',
 		'STATUS'		=> 'ok',

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -845,3 +845,115 @@ def test_hooks_dnsbl_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
     )
 
     h.clear_update_hooks(deployed_vm)
+
+
+# --------------------------------------------------------------------------- #
+# 12) issue #519 — unlock-forced IP re-block must report PFB_IP_CHANGED=1
+# --------------------------------------------------------------------------- #
+
+
+def test_hooks_ip_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
+    """An unlock-forced IP re-block (sole trigger: /tmp/ip_unlock) reports
+    ``PFB_IP_CHANGED='1'`` to post-hooks (issue #519).
+
+    Scenario: the no-rule-change ``else`` branch in ``sync_package_pfblockerng``
+    fires because ``file_exists($pfb['ip_unlock'])`` is true — no feed change, no
+    firewall rule change.  Before the fix, ``PFB_IP_CHANGED`` was emitted as
+    ``!empty($pfb['filter_configure'])`` only (``inc:15310``), which is FALSE in the
+    ``else`` branch, so the post-hook saw ``'0'`` even though the ``pfctl -T
+    replace`` re-block did run.  A HAProxy-style recipe keyed on ``PFB_IP_CHANGED``
+    would therefore MISS the re-lock.
+
+    **Given** a post env-dump hook is enabled; an IP feed has been injected and
+    settled so the pf aliastable ``pfB_smokehookilkchg_v4`` is active on the guest;
+    there is NO pending feed change — a full ``update`` over the UNCHANGED on-disk
+    feed reuse-caches the IP alias (``$pfbreuse`` path, ``inc:10211``), so
+    ``$pfb['filter_configure']`` is FALSE (the before-state asserts
+    ``PFB_IP_CHANGED='0'``).
+
+    **And** a ``/tmp/ip_unlock`` file is written on the guest with a valid
+    ``ip,table`` CSV row (RFC 5737 IP ``192.0.2.123`` and the settled table
+    ``pfB_smokehookilkchg_v4``) so the ``else`` branch's
+    ``file_exists($pfb['ip_unlock'])`` gate is true.
+
+    **When** ``helpers.reload(vm, 'update')`` fires the pass (still no feed
+    change, so the unlock file is the SOLE trigger).
+
+    **Then** the captured ``PFB_IP_CHANGED`` from the post-hook env == ``'1'``
+    (the unlock-forced re-block is reported as an IP change to post-hooks).
+
+    FAILS on pre-fix code (``PFB_IP_CHANGED`` is ``'0'`` because the emit keys
+    only on ``filter_configure``); PASSES after the fix adds a separate
+    ``$pfb_ip_unlock_forced`` flag captured before the ``else`` branch unlinks the
+    file and emits it alongside ``filter_configure``.
+    """
+    import subprocess
+
+    token = "iulkchg"
+    marker = h.hook_marker_path(token, "post")
+
+    # Inject and settle an IP feed so the pf aliastable is active on the guest.
+    # RFC 5737 test address; the table is the one this feed creates.
+    inert_ip = "192.0.2.123"
+    ip_feed = h.write_local_feed(deployed_vm, "smoke_hook_iulkchg_ip.txt", f"{inert_ip}\n")
+    ip_spec = h.IpCase(aliasname="smokehookilkchg", feed_url=ip_feed, header="smokehookilkchg")
+    h.inject(deployed_vm, ip_spec)
+    h.set_update_hooks(deployed_vm, [h.env_dump_hook(token, "post")])
+
+    # Settle: a full 'update' lands the IP feed and creates the pf aliastable.
+    # After this pass, the on-disk feed is reuse-cached (inc:10211) so subsequent
+    # 'update' runs over the same unchanged feed do NOT set filter_configure.
+    h.clear_hook_markers(deployed_vm, token)
+    h.reload(deployed_vm, "update")
+    env_settle = h.read_hook_env(deployed_vm, marker)
+    assert env_settle is not None, "post hook did not run during the settling pass"
+
+    # Before-state: no unlock file present => PFB_IP_CHANGED must be '0'.
+    # filter_configure is FALSE (feed is reuse-cached, no rule change), and no
+    # unlock file exists to trigger the else-branch re-block.  This proves the
+    # subsequent '1' is caused by the unlock file, not leftover state.
+    h.clear_hook_markers(deployed_vm, token)
+    h.reload(deployed_vm, "update")
+    env_before = h.read_hook_env(deployed_vm, marker)
+    assert env_before is not None, "post hook did not run for the before-state pass"
+    assert env_before.get("PFB_IP_CHANGED") == "0", (
+        "before-state: expected PFB_IP_CHANGED='0' with no feed change and no unlock file, "
+        f"got {env_before.get('PFB_IP_CHANGED')!r} — {env_before}"
+    )
+
+    # Write /tmp/ip_unlock on the guest with a valid ip,table CSV row.
+    # Format: "<ip>,<aliastable>\n" — matches pfb_unlock() fwrite at inc:10844.
+    # SmokeVM.ssh routes through /bin/sh (CLAUDE.md tcsh rule) so tee is safe here.
+    unlock_path = "/tmp/ip_unlock"
+    unlock_content = f"{inert_ip},{ip_spec.alias}\n"
+    result = subprocess.run(
+        deployed_vm.ssh_argv("tee", unlock_path),
+        input=unlock_content,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"test_hooks_ip_changed_unlock_forced: failed to write {unlock_path}: "
+            f"rc={result.returncode} {result.stderr!r}"
+        )
+
+    # After-state: same no-feed-change 'update', but now the unlock file is present,
+    # so the else branch sets $pfb['repcheck']=TRUE (inc:14930) and runs
+    # pfctl -T replace for the active aliastable, re-inserting the IP.  The unlock
+    # file is unlinked during the pass (inc:14929), so the fix must capture the
+    # forced-re-block flag BEFORE the unlink and include it in the PFB_IP_CHANGED
+    # expression at the emit site (the fix: $pfb_ip_unlock_forced local var).
+    h.clear_hook_markers(deployed_vm, token)
+    h.reload(deployed_vm, "update")
+    env_after = h.read_hook_env(deployed_vm, marker)
+    assert env_after is not None, "post hook did not run for the unlock-forced pass"
+    got = env_after.get("PFB_IP_CHANGED")
+    assert got == "1", (
+        "unlock-forced IP re-block must set PFB_IP_CHANGED='1' to post-hooks (issue #519): "
+        f"expected '1', got {got!r}\nfull hook env: {env_after}"
+    )
+
+    h.clear_update_hooks(deployed_vm)


### PR DESCRIPTION
Fixes #519.

## Problem

The ADR-12 `post`-hook context `PFB_IP_CHANGED` is emitted as `!empty($pfb['filter_configure'])` (`pfblockerng.inc:15310`). But an **IP-unlock-forced re-block** — the temporary-unlock store `/tmp/ip_unlock` re-blocking a previously-unlocked IP on the next Cron/Force pass — runs in the no-rule-change `else` branch (`:14928`), which does a real `pfctl -t <alias> -T replace` (live-table change) but sets only `$pfb['repcheck']`, never `filter_configure`. So that pass reported `PFB_IP_CHANGED=0`, and a `post` hook keyed on it (e.g. a HAProxy reload recipe) missed the change.

This is the IP-side twin of #517 (where the DNSBL `dnsbl_unlock` trigger was omitted from `PFB_DNSBL_CHANGED`).

## Why no reload is involved

The unlock path is pure `pfctl` end to end and the fix keeps it that way:

- Immediate Alerts-page unlock/lock = `pfctl -T delete` / `-T add` (`pfblockerng_alerts.php:1498-1508`).
- The next-pass re-block = `pfctl -T replace` from the on-disk `.txt` (`:14928`).
- A full `filter_configure()` reload (`:15030`) only fires for actual firewall **rule** changes — never for an unlock re-block.

Setting `filter_configure=TRUE` would force that heavy reload, which the unlock does not need. So the fix uses a **separate** report-only flag rather than reusing `filter_configure`.

## Fix

Mirror the #517 `$pfb_dnsbl_unlock_forced` pattern on the IP side:

- Initialize `$pfb_ip_unlock_forced = FALSE` before the rule-change `if`/`else` so it is always defined at the emit.
- Set it `TRUE` inside `if (file_exists($pfb['ip_unlock']))` — captured **before** the `unlink_if_exists`, since the file is consumed during the pass.
- OR it into the `PFB_IP_CHANGED` emit: `(!empty($pfb['filter_configure']) || !empty($pfb_ip_unlock_forced)) ? '1' : '0'`.
- `filter_configure` is **not** touched, so no reload is introduced.

## Tests

New ADR-12 hook smoke case `test_hooks_ip_changed_unlock_forced` (mirrors `test_hooks_dnsbl_changed_unlock_forced`): settle an IP feed → assert `PFB_IP_CHANGED='0'` with no unlock file (before-state, proves causation) → write `/tmp/ip_unlock` with a valid `ip,table` row → assert `PFB_IP_CHANGED='1'` on the unlock-forced pass. Fails on pre-fix code (emit keys only on `filter_configure`), passes after. Live red→green runs on the smoke fan-out.

## Gates

`php -l`, `vendor/bin/phpcs` (PFBL-01 + UppercaseBooleanLiteral + RequireConfigGateway), `vendor/bin/phpstan` (no errors), `vendor/bin/phpunit` (1279/1279), `ruff check`/`ruff format` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvkatSj2cSBXY7iGmZQy15)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed post-update hook reporting so IP change events are triggered when an unlock file forces a re-block, even without a full firewall reload.
  * Improved handling of temporary unlock-driven re-blocks to match expected behavior in related update flows.
* **Tests**
  * Added smoke coverage to verify that unlock-forced re-blocks correctly set the IP change flag in hook output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->