### PR TITLE
pfblockerng: use str_starts_with/str_ends_with over substr prefix checks (ADR-28)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -521,8 +521,8 @@ function pfb_iso_timestamp(string $raw): string {
 // fixes issue #360: a 'pfB_*_v6' alias must never become 'pfB_*_v6_v4').
 function pfb_rule_alias_needs_v4_suffix($address, $ipprotocol) {
 	return str_starts_with((string) $address, 'pfB_') &&
-	       substr((string) $address, -3) !== '_v4' &&
-	       substr((string) $address, -3) !== '_v6' &&
+	       !str_ends_with((string) $address, '_v4') &&
+	       !str_ends_with((string) $address, '_v6') &&
 	       $ipprotocol === 'inet';
 }
 
@@ -1989,7 +1989,7 @@ function pfbng_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 	$customlist = explode("\r\n", base64_decode($text));
 	if (!empty($customlist)) {
 		foreach ($customlist as $line) {
-			if (substr(trim($line), 0, 1) != '#' && !empty($line)) {
+			if (!str_starts_with(trim($line), '#') && !empty($line)) {
 				if ($idn && !ctype_print($line)) {
 					$line_old = $line;
 					// Convert encodings to UTF-8
@@ -1997,7 +1997,7 @@ function pfbng_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 						mb_detect_encoding($line, 'UTF-8, ASCII, ISO-8859-1'));
 					if (strpos($line, '#') !== FALSE) {
 						$tmpline = preg_split('/(?=#)/', $line);
-						if (substr($tmpline[0], 0, 1) == '.') {
+						if (str_starts_with($tmpline[0], '.')) {
 							// idn_to_ascii() returns empty string if it starts with '.' 
 							$tmpline[0] = idn_to_ascii(ltrim($tmpline[0], '.'));
 							if (!empty($tmpline[0])) {
@@ -2013,7 +2013,7 @@ function pfbng_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 						}
 						$line = implode(' ', $tmpline);
 					} else {
-						if (substr($line, 0, 1) == '.') {
+						if (str_starts_with($line, '.')) {
 							$line = idn_to_ascii(ltrim($line, '.'));
 							if (!empty($line)) {
 								$line = '.' . $line;
@@ -4466,7 +4466,7 @@ function pfb_unbound_python_whitelist($mode='') {
 	if (!empty($dnsbl_white)) {
 		foreach ($dnsbl_white as $key => $line) {
 			if (!empty($line)) {
-				if (substr($line, 0, 4) == 'www.') {
+				if (str_starts_with($line, 'www.')) {
 					$line = substr($line, 4);
 				}
 
@@ -4476,7 +4476,7 @@ function pfb_unbound_python_whitelist($mode='') {
 				}
 				$tld_segments = @min((array((substr_count($line, '.') +1), $tld_segments) ?: 1));
 
-				if (substr($line, 0, 1) == '.') {
+				if (str_starts_with($line, '.')) {
 					$line = ltrim($line, '.');
 					$dnsbl_whitelist .= "{$line},1\n";
 				} else {
@@ -4589,7 +4589,7 @@ function pfb_dnsbl_abp_extract_ip($line) {
 	}
 
 	// ABP network anchor: ||host^[$options]
-	if (substr($s, 0, 2) == '||') {
+	if (str_starts_with($s, '||')) {
 		$rest	= substr($s, 2);
 		// Drop any $options modifier suffix.
 		if (($dpos = strpos($rest, '$')) !== FALSE) {
@@ -5671,7 +5671,7 @@ EOF;
 			$noaaaa_list = pfbng_text_area_decode($pfb['dnsbl_noaaaa_list'], TRUE, TRUE, TRUE);
 			if (!empty($noaaaa_list)) {
 				foreach ($noaaaa_list as $key => $list) {
-					if (substr($list[0], 0, 1) == '.') {
+					if (str_starts_with($list[0], '.')) {
 						$list[0] = ltrim($list[0], '.');
 						$noaaaa .= "{$key} = {$list[0]},1\n";
 					} else {
@@ -6551,7 +6551,7 @@ function pfblockerng_top1m() {
 
 			if (isset($pfb_include[$tld])) {
 				// Whitelist both 'www.example.com' and 'example.com'
-				if (substr($csvline[1], 0, 4) == 'www.') {
+				if (str_starts_with($csvline[1], 'www.')) {
 					$csvline[1] = substr($csvline[1], 4);
 				}
 				$x++;
@@ -6883,7 +6883,7 @@ function pfb_ip_is_internal($ip) {
 
 	// Unwrap an IPv4-mapped IPv6 address (::ffff:0:0/96) to its IPv4 form so it is
 	// vetted against the IPv4 ranges, not skipped by the v6 set.
-	if (strlen($bin) === 16 && substr($bin, 0, 12) === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff") {
+	if (strlen($bin) === 16 && str_starts_with($bin, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff")) {
 		$ip = inet_ntop(substr($bin, 12));
 		$bin = substr($bin, 12);
 	}
@@ -8601,7 +8601,7 @@ function pfb_filterrules() {
 	exec("{$pfb['pfctl']} -vvsr 2>&1", $results);
 	if (!empty($results)) {
 		foreach ($results as $result) {
-			if (substr($result, 0, 1) == '@') {
+			if (str_starts_with($result, '@')) {
 
 				$type = strstr(ltrim(strstr($result, ' ', FALSE), ' '), ' ', TRUE);
 				if (in_array($type, array('block', 'pass', 'match'))) {
@@ -8960,8 +8960,8 @@ function pfb_collect_localip() {
 		$ipaddr = $ifcfg['ipaddr'] ?? '';
 		$if     = $ifcfg['if'] ?? '';
 		$has_gateway = in_array($ipaddr, array('dhcp', 'pppoe', 'pptp', 'l2tp', 'ppp'), TRUE)
-			|| substr($if, 0, 4) == 'ovpn'
-			|| substr($if, 0, 5) == 'ipsec'
+			|| str_starts_with($if, 'ovpn')
+			|| str_starts_with($if, 'ipsec')
 			|| !empty($ifcfg['gateway']);
 		if ($has_gateway) {
 			$pfb_local[] = get_interface_ip($ifname) ?: 'Disabled';
@@ -9505,7 +9505,7 @@ function pfb_daemon_filterlog() {
 
 			$log_type = 'BSD';
 			$f_pos = 5;
-			if (substr($line, 0, 1) == '<') {
+			if (str_starts_with($line, '<')) {
 				$log_type = 'syslog';
 				$f_pos = 7;
 			}
@@ -10219,7 +10219,7 @@ function pfb_daemon_dnsbl_index() {
 			$pfb_buffer = @fgets($i_handle);
 			$pfb_buffer = str_replace($p1, $p2, $pfb_buffer);
 
-			if (substr($pfb_buffer, 0, 6) == 'INDEX,' && substr_count($pfb_buffer, ',') == 4) {
+			if (str_starts_with($pfb_buffer, 'INDEX,') && substr_count($pfb_buffer, ',') == 4) {
 				$csvline = str_getcsv($pfb_buffer, ',', '"', '"');
 
 				// Determine blocked domain type (Full, 1x1 or JS)
@@ -11737,14 +11737,14 @@ function sync_package_pfblockerng($cron='') {
 					if (!empty($safesearch_file)) {
 						foreach ($safesearch_file as $host) {
 
-							if (substr($host, 0, 1) == '#') {
+							if (str_starts_with($host, '#')) {
 								continue;
 							}
 
 							$line = str_replace('"', '', strstr($host, '"', FALSE));
 							$host_ip = trim(str_replace('A ', '', strstr($line, 'A ', FALSE)));
 							$domain = strstr($line, ' ', TRUE);
-							if (substr($domain, 0, 4) == 'www.') {
+							if (str_starts_with($domain, 'www.')) {
 								$domain = substr($domain, 4);
 							}
 
@@ -11830,13 +11830,13 @@ function sync_package_pfblockerng($cron='') {
 				foreach ($pfb_white as $line) {
 					if (!empty($line)) {
 						$wildcard = FALSE;
-						if (substr($line, 0, 1) == '.') {
+						if (str_starts_with($line, '.')) {
 							$line = ltrim($line, '.');
 							$wildcard = TRUE;
 						}
 
 						// Remove 'www.' prefix
-						if (substr($line, 0, 4) == 'www.') {
+						if (str_starts_with($line, 'www.')) {
 							$line = substr($line, 4);
 						}
 
@@ -12245,7 +12245,7 @@ function sync_package_pfblockerng($cron='') {
 													$easylist = $validate_header = TRUE;
 													continue;
 												}
-												elseif (substr($line, 0, 1) === '!') {
+												elseif (str_starts_with($line, '!')) {
 													continue;
 												}
 												else {
@@ -12318,8 +12318,8 @@ function sync_package_pfblockerng($cron='') {
 
 												// Skip ABP comment / control lines so the raw feed
 												// passed to Python is dense (Python skips them too).
-												if ($line === '' || substr($line, 0, 1) === '!' ||
-												    substr($line, 0, 1) === '[') {
+												if ($line === '' || str_starts_with($line, '!') ||
+												    str_starts_with($line, '[')) {
 													continue;
 												}
 
@@ -12342,7 +12342,7 @@ function sync_package_pfblockerng($cron='') {
 												}
 
 												// Remove comment lines and special format considerations
-												if (substr($line, 0, 1) == '#') {
+												if (str_starts_with($line, '#')) {
 													// Exit (hpHosts) when end of domain names found.
 													if (strpos($line, 'Append critical updates below') !== FALSE) {
 														break;
@@ -12362,7 +12362,7 @@ function sync_package_pfblockerng($cron='') {
 												}
 
 												// Remove slash comment lines
-												if (substr($line, 0, 2) == '//') {
+												if (str_starts_with($line, '//')) {
 													continue;
 												}
 
@@ -12647,7 +12647,7 @@ function sync_package_pfblockerng($cron='') {
 												$liteparser = FALSE;
 
 												// Skip yHost '@' prefixed lines
-												if (substr($line, 0, 1) == '@') {
+												if (str_starts_with($line, '@')) {
 													continue;
 												}
 
@@ -13947,7 +13947,7 @@ function sync_package_pfblockerng($cron='') {
 									$line = trim($line);
 
 									// Remove commentlines and blank lines
-									if (substr($line, 0, 1) == '#' || empty($line)) {
+									if (str_starts_with($line, '#') || empty($line)) {
 										continue;
 									}
 
@@ -14504,7 +14504,7 @@ function sync_package_pfblockerng($cron='') {
 	$exist_aliases = config_get_path('aliases/alias', []);
 	foreach ($exist_aliases as $cbalias) {
 
-		if (substr($cbalias['name'], 0, 4) == 'pfB_') {
+		if (str_starts_with($cbalias['name'], 'pfB_')) {
 			// Remove unreferenced pfB aliastable files
 			if (!in_array($cbalias['name'], $new_aliases_list)) {
 				unlink_if_exists("{$pfb['aliasdir']}/{$cbalias['name']}.*");
@@ -14572,7 +14572,7 @@ function sync_package_pfblockerng($cron='') {
 					// Remove all existing rules that start with 'pfB_' in the Rule Description
 					// (the legacy auto-rules this region rebuilds) — but keep user rules and
 					// the DNS-bypass rules above.
-					if (substr($rule['descr'], 0, 4) != 'pfB_' || $is_dns_bypass_rule) {
+					if (!str_starts_with($rule['descr'], 'pfB_') || $is_dns_bypass_rule) {
 
 						// Upgrade previous IPv4 pfBlockerNG 'alias type' aliasnames to new '_v4' suffix format
 						foreach (array('source', 'destination') as $rtype) {
@@ -14626,7 +14626,7 @@ function sync_package_pfblockerng($cron='') {
 
 					// Track pfB aliases referenced by rules.
 					foreach (array('source', 'destination') as $rtype) {
-						if ((substr($rule[$rtype]['address'], 0, 4) == 'pfB_') &&
+						if ((str_starts_with($rule[$rtype]['address'], 'pfB_')) &&
 						    !in_array($rule[$rtype]['address'], $pfb_active_aliases)) {
 							$pfb_active_aliases[] = $rule[$rtype]['address'];
 						}
@@ -15008,7 +15008,7 @@ function sync_package_pfblockerng($cron='') {
 
 	foreach (config_get_path('nat/rule', []) as $key => $ex_nat) {
 		foreach (array('source', 'destination') as $rtype) {
-			if (isset($ex_nat[$rtype]['address']) && substr($ex_nat[$rtype]['address'], 0, 4) == 'pfB_') {
+			if (isset($ex_nat[$rtype]['address']) && str_starts_with($ex_nat[$rtype]['address'], 'pfB_')) {
 				$pfb_suffix = substr($ex_nat[$rtype]['address'], -3);
 
 				if ($pfb_suffix == '_v6') {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -534,7 +534,7 @@ if (file_exists('/var/db/pfblockerng/dnsbl_info') &&
 		if (!empty($dnsbl_info)) {
 			foreach ($dnsbl_info as $group) {
 				$group = str_getcsv($group, ',', '"', "\\");
-				if (substr($group[0], 0, 1) != '#') {
+				if (!str_starts_with($group[0], '#')) {
 					$db_update = "INSERT INTO dnsbl ( groupname, timestamp, entries, counter )"
 							. " VALUES ( :group0, :group1, :group2, :group3 );\n";
 

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1452,7 +1452,7 @@ function pfblockerng_get_countries() {
 				while (($line = @fgets($handle)) !== FALSE) {
 
 					$line = trim($line);
-					if (substr($line, 0, 1) == '#') {
+					if (str_starts_with($line, '#')) {
 						if ($pfb['complete']) {
 							if (file_exists("{$pfb['ccdir']}/{$isocode}_v{$type}.txt")) {
 
@@ -1496,7 +1496,7 @@ function pfblockerng_get_countries() {
 						}
 					}
 
-					elseif (substr($line, 0, 1) != '#') {
+					elseif (!str_starts_with($line, '#')) {
 						if (!empty(pfb_filter($isocode, PFB_FILTER_WORD, 'php'))) {
 							if ($cont == 'Top Spammers') {
 								$isocode_esc = escapeshellarg("{$pfb['ccdir']}/{$isocode}_v{$type}.txt");

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -878,7 +878,7 @@ if (isset($_POST) && !empty($_POST)) {
 		// DNSBL structures from the manifest raws, never those legacy CSVs -- see
 		// pfb_unbound.py's 'if not dnsbl_built' guard.)
 		$wl_base = $domain;
-		if (substr($wl_base, 0, 4) == 'www.') {
+		if (str_starts_with($wl_base, 'www.')) {
 			$wl_base = substr($wl_base, 4);
 		}
 		$wl_variants = array($wl_base, "www.{$wl_base}");
@@ -995,7 +995,7 @@ if (isset($_POST) && !empty($_POST)) {
 		}
 
 		// Remove 'www.' prefix
-		if (substr($domain, 0, 4) == 'www.') {
+		if (str_starts_with($domain, 'www.')) {
 			$domain = substr($domain, 4);
 		}
 
@@ -1536,7 +1536,7 @@ if (isset($_POST) && !empty($_POST)) {
 		}
 
 		// Create new IP Whitelist Alias
-		if (substr($table, 0, 4) == 'NEW_') {
+		if (str_starts_with($table, 'NEW_')) {
 			$table = substr($table, 4);
 			header("Location: /pfblockerng/pfblockerng_category_edit.php?type=ipv{$vtype}&act=addgroup&atype=Whitelist|{$ip}|{$descr}#Customlist");
 			exit;
@@ -1938,7 +1938,7 @@ function pfb_match_filter_field($flent, $fields) {
 		foreach ($fields as $key => $field) {
 
 			$not_filter = FALSE;
-			if (substr($field, 0, 1) == '!') {
+			if (str_starts_with($field, '!')) {
 				$not_filter = TRUE;
 				$field = substr($field, 1);
 			}

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -61,7 +61,7 @@ if (!empty($blacklist_types)) {
 			foreach ($list['CONTENTS'] as $line => $data) {
 
 				$data = trim($data);
-				if (substr($data, 0, 1) == '#' || empty($data)) {
+				if (str_starts_with($data, '#') || empty($data)) {
 					unset($list['CONTENTS'][$line]);
 					continue;
 				}

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -101,7 +101,7 @@ if (isset($_GET)) {
 	}
 	if (isset($_GET['atype']) && !empty($_GET['atype'])) {
 		$raw_atype = $_GET['atype'];
-		if (substr($raw_atype, 0, 10) === 'Whitelist|') {
+		if (str_starts_with($raw_atype, 'Whitelist|')) {
 			$atype = pfb_filter_whitelist_atype($raw_atype);
 		} else {
 			$temp_value = pfb_filter($raw_atype, PFB_FILTER_ATYPE, 'Category_edit');
@@ -140,7 +140,7 @@ if (isset($_POST)) {
 	}
 	if (isset($_POST['atype']) && !empty($_POST['atype'])) {
 		$raw_atype = $_POST['atype'];
-		if (substr($raw_atype, 0, 10) === 'Whitelist|') {
+		if (str_starts_with($raw_atype, 'Whitelist|')) {
 			$atype = pfb_filter_whitelist_atype($raw_atype);
 		} else {
 			$temp_value = pfb_filter($raw_atype, PFB_FILTER_ATYPE, 'Category_edit');
@@ -203,7 +203,7 @@ if (($action == 'add' || $action == 'addgroup') && !empty($atype) && !isset($_PO
 
 	$feed_info = convert_feeds_json();			// Load/convert Feeds (w/alternative aliasname(s), if user-configured
 	if (is_array($feed_info) &&
-	    substr($atype, 0, 9) != 'Whitelist') {
+	    !str_starts_with($atype, 'Whitelist')) {
 		foreach ($feed_info as $ftype => $info) {
 
 			if (empty($info) || $gtype != $ftype) {
@@ -294,7 +294,7 @@ if (($action == 'add' || $action == 'addgroup') && !empty($atype) && !isset($_PO
 		$rowid = count($rowdata);
 
 		// Create new IP Whitelist Alias via Reports Tab
-		if (substr($atype, 0, 9) == 'Whitelist') {
+		if (str_starts_with($atype, 'Whitelist')) {
 			$rowdata[$rowid]['aliasname']	= 'Whitelist';
 			$rowdata[$rowid]['description']	= 'pfBlockerNG Whitelist';
 			$rowdata[$rowid]['cron']	= 'EveryDay';
@@ -674,7 +674,7 @@ if ($_POST && isset($_POST['save'])) {
 		if (!empty($customlist)) {
 			foreach ($customlist as $line) {
 
-				if (substr($line, 0, 1) == '#' || empty($line)) {
+				if (str_starts_with($line, '#') || empty($line)) {
 					continue;
 				}
 				$value = array_map('trim', preg_split('/(?=#)/', $line));

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -626,7 +626,7 @@ if ($_POST) {
 					if (!empty($customlist)) {
 						foreach ($customlist as $line) {
 
-							if (substr($line, 0, 1) == '#' || empty($line)) {
+							if (str_starts_with($line, '#') || empty($line)) {
 								continue;
 							}
 							$value = array_map('trim', preg_split('/(?=#)/', $line));

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -73,7 +73,7 @@ if (is_array($pfb['feeds_list']) && isset($pfb['feeds_list'][$gtype]) && is_arra
 $feed_alt_selected = array();
 if (is_array($fconfig)) {
 	foreach ($fconfig as $key => $line) {
-		if (substr($key, 0, 9) == 'feed_alt_') {
+		if (str_starts_with($key, 'feed_alt_')) {
 			$feed_alt_selected[] = str_replace('alt_', '', $line);
 		}
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -143,7 +143,7 @@ if ($_POST) {
 		if (!empty($v4suppression)) {
 			foreach ($v4suppression as $line) {
 
-				if (substr($line, 0, 1) == '#' || empty($line)) {
+				if (str_starts_with($line, '#') || empty($line)) {
 					continue;
 				}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -214,7 +214,7 @@ function pfb_validate_filepath($validate, $pfb_logtypes) {
 	$path = pathinfo($validate, PATHINFO_DIRNAME) . '/';
 	$file = basename($validate);
 
-	if ($path == '/var/unbound/' && substr($file, 0, 4) != 'pfb_' && !file_exists("{$file}")) {
+	if ($path == '/var/unbound/' && !str_starts_with($file, 'pfb_') && !file_exists("{$file}")) {
 		return FALSE;
 	}
 

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -300,7 +300,7 @@ function pfBlockerNG_update_table() {
 	if (!empty($pfb_pfctl)) {
 		foreach($pfb_pfctl as $line) {
 			$line = trim(str_replace(array( '[', ']' ), '', $line));
-			if (substr($line, 0, 1) == '-') {
+			if (str_starts_with($line, '-')) {
 				$pfb_alias = trim(strstr($line, 'pfB', FALSE));
 				if (pfb_widget_alias_hidden($pfb_alias, $show_agg)) {
 					unset($pfb_alias);
@@ -320,7 +320,7 @@ function pfBlockerNG_update_table() {
 			}
 
 			if (isset($pfb_alias)) {
-				if (substr($line, 0, 9) == 'Addresses') {
+				if (str_starts_with($line, 'Addresses')) {
 					$addr = trim(exec_command(implode(' ', [
 						$pfb['pfctl'], '-t',
 						escapeshellarg($pfb_alias),
@@ -712,7 +712,7 @@ function pfBlockerNG_get_header($mode='') {
 
 				$gcount = 0;
 				foreach (pfbng_text_area_decode($config_path, TRUE, FALSE, TRUE) as $cline) {
-					if (substr(trim($cline), 0, 1) != '#' && !empty($cline)) {
+					if (!str_starts_with(trim($cline), '#') && !empty($cline)) {
 						$gcount++;
 					}
 				}


### PR DESCRIPTION
## What

Behaviour-preserving cleanup (ADR-28 §4, "string-ops over substr"): replace `substr($x, 0, N) == 'LIT'` prefix and `substr($x, -N) == 'LIT'` suffix comparisons with `str_starts_with()` / `str_ends_with()` (PHP 8.0+, our 8.3 target). **51 sites across 11 files**, net-zero line count.

## Why

`substr($x, 0, N)` allocates a throwaway string on every call; `str_starts_with` compares in place (no allocation, bails at first mismatch). The intent also reads clearer. Applied for consistency across the codebase, not just hot paths.

## Equivalence — only absolutely-equivalent rewrites

Every converted site has `N === strlen('LIT')`, so the rewrite is provably equivalent. Two checks were **deliberately excluded** because they are *not* byte-equivalent:

- `substr($s_ip, 0, 2) == '0.'` and `substr($s_ip, 0, 4) == '127.'` — loose `==` against a **numeric** string literal. PHP 8 compares two numeric strings *numerically*, so `str_starts_with` would change behaviour (e.g. `"0127…"` matches `== '127.'` numerically but not as a prefix). Left as-is.

Two-`substr` comparisons and extraction `substr`s are out of scope.

## Testing

Behaviour-preserving refactor → the existing suite is the regression oracle (CLAUDE.md test-coverage exception; no new red→green tests). All gates green: `php -l`, PHPUnit (1279 tests, 4999 assertions, 3 pre-existing skips), PHPStan (no errors), PHPCS (clean). The `www/` edits are pure-equivalent (no behaviour/visual change), so no new Tier A coverage is required.
