### PR TITLE
pfblockerng: remove dead helpers validate_ip() and pfb_parse_line()

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6688,15 +6688,6 @@ function validate_ipv6($ipaddr) {
 }
 
 
-// Validate IP addresses
-function validate_ip($ipaddr) {
-	if (strpos($ipaddr, '/') !== FALSE) {
-		return is_subnet($ipaddr);
-	}
-	return is_ipaddr($ipaddr);
-}
-
-
 // Function to check for loopback addresses (IPv4 range: 127.0.0.0/8, excluding IPv6)
 function FILTER_FLAG_NO_LOOPBACK_RANGE($value) {
 	// http://www.php.net/manual/en/filter.filters.flags.php
@@ -9902,17 +9893,6 @@ function pfb_parse_query($line) {
 	$rx = explode('.txt:', $line);
 	$rx[0] = ltrim(strrchr($rx[0], '/'), '/');
 	return $rx;
-}
-
-
-// Function to output Alias/Feed name string
-function pfb_parse_line($line) {
-	$match = strstr($line, ':local', TRUE);
-	if (strpos($match, '.txt') !== FALSE) {
-		$match = strstr($match, '.txt', TRUE);
-	}
-	$match = substr($match, strrpos($match, '/') + 1);
-	return $match;
 }
 
 


### PR DESCRIPTION
## What

Remove two dead PHP helpers from `pfblockerng.inc`:

- `validate_ip($ipaddr)` — a thin `is_subnet()`/`is_ipaddr()` wrapper.
- `pfb_parse_line($line)` — extracted an alias/feed name from a `:local`/`.txt` log line.

## Why / verification

Both are **legacy upstream helpers** present since the initial `src/` import (`815ef64`), predating every ADR — so neither is a half-implemented-ADR leftover. Confirmed **zero callers** by exhaustive `git grep` across `src/`, `tests/`, `www/`, and `scripts/`, including string/dynamic-dispatch forms; neither is a pfSense plugin-hook name, and neither is referenced by any test or ADR contract. The live log-parsing path uses `pfb_dnsbl_parse()` / `pfb_parse_query()`, which are untouched.

Part of the cleanup tracked in #524 (the other audit findings there were checked and deliberately **not** removed: the `$u_found` line is a latent reset-typo bug, `_regex_exceeds_static_cap` is ADR-07 tested surface, the `_LruCache` dunders are used, and `IdnMode.default()` is part of the ADR-28 enum contract).

## Testing

Behaviour-preserving (dead-code removal) → the existing suite is the regression oracle. All gates green: `php -l`, PHPUnit (1279 pass, 4999 assertions, 3 pre-existing skips), PHPStan (no errors), PHPCS (clean).
