### PR TITLE
pfblockerng: option to disable DNSBL NAT rule creation (#381)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4038,7 +4038,7 @@ function pfb_create_dnsbl_cert() {
 // [ #381 ] DNSBL sinkhole NAT generation is gated on a real (non-lo0) listening
 // interface AND the user not having opted out via pfb_dnsbl_nonat. Pure predicate so
 // the branch is unit-testable off-appliance (PfbDnsblNatEnabledTest).
-function pfb_dnsbl_nat_enabled(string $iface, $nonat): bool {
+function pfb_dnsbl_nat_enabled(string $iface, string $nonat): bool {
 	return $iface !== 'lo0' && empty($nonat);
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1657,6 +1657,7 @@ function pfb_global() {
 
 	$pfb['dnsbl']		= PfbConfig::read('pfb_dnsbl')->value;							// Enabled state of DNSBL
 	$pfb['dnsbl_vip_auto']	= PfbConfig::read('pfb_dnsvip_auto')->value;						// [ ADR-13 ] Auto-create/remove the DNSBL sinkhole VIP(s) (default off)
+	$pfb['dnsbl_nonat']	= PfbConfig::read('pfb_dnsbl_nonat')->value;						// [ #381 ] Opt out of automatic DNSBL NAT rule generation (default off)
 	$pfb['dnsbl_vip4'] = get_configured_vip_ipv4($pfb['dnsblconfig']['pfb_dnsvip4']) ?? '';
 	$pfb['dnsbl_vip6'] = get_configured_vip_ipv6($pfb['dnsblconfig']['pfb_dnsvip6']) ?? '';
 	$pfb['dnsbl_iface']	= PfbConfig::read('dnsbl_interface');							// VIP Local Interface setting (default 'lo0')
@@ -4034,6 +4035,13 @@ function pfb_create_dnsbl_cert() {
 }
 
 
+// [ #381 ] DNSBL sinkhole NAT generation is gated on a real (non-lo0) listening
+// interface AND the user not having opted out via pfb_dnsbl_nonat. Pure predicate so
+// the branch is unit-testable off-appliance (PfbDnsblNatEnabledTest).
+function pfb_dnsbl_nat_enabled(string $iface, $nonat): bool {
+	return $iface !== 'lo0' && empty($nonat);
+}
+
 // Create DNSBL VIP and NAT rules, lighttpd conf and services
 function pfb_create_dnsbl($mode) {
 	global $pfb;
@@ -4069,7 +4077,7 @@ function pfb_create_dnsbl($mode) {
 
 			// Generate new DNSBL NAT per DNSBL listening ports except for 'localhost' interface setting.
 			$dnsbl_new_nat = array();
-			if ($pfb['dnsbl_iface'] != 'lo0') {
+			if (pfb_dnsbl_nat_enabled($pfb['dnsbl_iface'], $pfb['dnsbl_nonat'])) {
 				$selected_ports = array("{$pfb['dnsbl_port']}" => '80', "{$pfb['dnsbl_port_ssl']}" => '443');
 				foreach ($selected_ports as $port => $lport) {
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -515,6 +515,16 @@ function pfb_cfg_registry(): array
 			'since'         => '3.0.0',
 		],
 
+		// [ #381 ] Opt out of automatic DNSBL sinkhole NAT rule generation: 'on' | '' (checkbox).
+		// Default '' = NAT generated (current behaviour); 'on' = user manages NAT manually.
+		'pfb_dnsbl_nonat' => [
+			'section'       => $dnsbl,
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'since'         => '4.0.0',
+		],
+
 		// VIP interface for DNSBL sinkhole. Default 'lo0'.
 		'dnsbl_interface' => [
 			'section'       => $dnsbl,

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2981,7 +2981,7 @@ $section->addInput(new Form_Checkbox(
 	'pfb_dnsbl_nonat',
 	gettext('Auto NAT'),
 	gettext('Disable automatic NAT rule creation'),
-	($pconfig['pfb_dnsbl_nonat'] == 'on'),
+	(pfb_cfg_toggle_read($pconfig['pfb_dnsbl_nonat']) === PfbToggle::On),
 	'on'
 ))->setHelp('When set, pfBlockerNG will not auto-create the DNSBL NAT port-forward rules (non-Localhost interface only); manage them manually.');
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -47,6 +47,7 @@ $pconfig['pfb_control_legacy']	= $pfb['dconfig']['pfb_control_legacy']			?: '';
 $pconfig['pfb_dnsvip4'] = $pfb['dconfig']['pfb_dnsvip4'] ?: 'none';
 $pconfig['pfb_dnsvip6'] = $pfb['dconfig']['pfb_dnsvip6'] ?: 'none';
 $pconfig['pfb_dnsvip_auto']	= $pfb['dconfig']['pfb_dnsvip_auto']			?: '';
+$pconfig['pfb_dnsbl_nonat']	= $pfb['dconfig']['pfb_dnsbl_nonat']			?: '';
 $pconfig['pfb_dnsport']		= $pfb['dconfig']['pfb_dnsport']			?: '8081';
 $pconfig['pfb_dnsport_ssl']	= $pfb['dconfig']['pfb_dnsport_ssl']			?: '8443';
 $pconfig['dnsbl_interface']	= $pfb['dconfig']['dnsbl_interface']			?: 'lo0';
@@ -747,6 +748,7 @@ if ($_POST) {
 			$pfb['dconfig']['pfb_tld']		= pfb_filter($_POST['pfb_tld'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_control']		= pfb_filter($_POST['pfb_control'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_control_legacy']	= pfb_filter($_POST['pfb_control_legacy'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
+			$pfb['dconfig']['pfb_dnsbl_nonat']	= pfb_filter($_POST['pfb_dnsbl_nonat'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 
 			// [ ADR-13 ] Persist the auto-create decision. When ON, leave the stored
 			// pfb_dnsvip4/6 ids untouched here (the manual dropdowns are disabled): the
@@ -2974,6 +2976,14 @@ $section->addInput(new Form_Select(
 	$options_dnsbl_interface_all
 ))->setHelp('Select the interface which DNSBL Web Server will Listen on.<br />'
 	. 'Default: <strong>Localhost (ports 80/443)</strong> - Selected Interface should be a Local Interface only.');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_dnsbl_nonat',
+	gettext('Auto NAT'),
+	gettext('Disable automatic NAT rule creation'),
+	($pconfig['pfb_dnsbl_nonat'] == 'on'),
+	'on'
+))->setHelp('When set, pfBlockerNG will not auto-create the DNSBL NAT port-forward rules (non-Localhost interface only); manage them manually.');
 
 // [ ADR-13 ] Compute the address(es) the package WOULD auto-create, for the currently
 // selected DNSBL Web Server interface, so the UI can pre-fill them and detect conflict

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -69,11 +69,12 @@ final class CfgGatewayTest extends TestCase
 	{
 		// Representative toggle-adapted fields (pfb_keep is now lenient — see below).
 		$toggle_fields = [
-			'enable_cb'       => 'installedpackages/pfblockerng/config/0/enable_cb',
-			'pfb_dnsbl'       => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
-			'pfb_dnsvip_auto' => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
-			'pfb_reuse'       => 'installedpackages/pfblockerng/config/0/pfb_reuse',
-			'pfb_hsts'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
+			'enable_cb'        => 'installedpackages/pfblockerng/config/0/enable_cb',
+			'pfb_dnsbl'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
+			'pfb_dnsvip_auto'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
+			'pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
+			'pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
+			'pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
 		];
 
 		foreach ($toggle_fields as $key => $path) {
@@ -97,11 +98,12 @@ final class CfgGatewayTest extends TestCase
 	{
 		// pfb_keep is now lenient — see testPfbKeepLenientRoundTrip*() below.
 		$toggle_fields = [
-			'enable_cb'       => 'installedpackages/pfblockerng/config/0/enable_cb',
-			'pfb_dnsbl'       => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
-			'pfb_dnsvip_auto' => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
-			'pfb_reuse'       => 'installedpackages/pfblockerng/config/0/pfb_reuse',
-			'pfb_hsts'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
+			'enable_cb'        => 'installedpackages/pfblockerng/config/0/enable_cb',
+			'pfb_dnsbl'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
+			'pfb_dnsvip_auto'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
+			'pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
+			'pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
+			'pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
 		];
 
 		foreach ($toggle_fields as $key => $path) {
@@ -598,6 +600,7 @@ final class CfgGatewayTest extends TestCase
 			// pfblockerngdnsblsettings/config/0 scalars
 			'pfb_dnsbl',
 			'pfb_dnsvip_auto',
+			'pfb_dnsbl_nonat',
 			'dnsbl_interface',
 			'pfb_dnsvip4',
 			'pfb_dnsvip6',

--- a/tests/php/PfbDnsblNatEnabledTest.php
+++ b/tests/php/PfbDnsblNatEnabledTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_nat_enabled() (#381) — pure predicate that gates DNSBL sinkhole NAT
+ * generation. NAT is generated only when BOTH conditions hold:
+ *   (1) the listening interface is NOT localhost (lo0), and
+ *   (2) the user has NOT opted out via pfb_dnsbl_nonat ('on' = opted out, '' = NAT on).
+ *
+ * All four branches of the 2×2 (iface × nonat) are pinned here so a regression is
+ * immediately visible without a live VM.
+ */
+#[CoversFunction('pfb_dnsbl_nat_enabled')]
+final class PfbDnsblNatEnabledTest extends TestCase
+{
+	// Scenario: localhost interface — NAT never generated regardless of nonat flag.
+
+	public function testLocalhostWithNatEnabledReturnsFalse(): void
+	{
+		// Given: interface is lo0 (localhost), nonat opt-out is off (default).
+		// Then: no NAT — localhost never ports to an external sinkhole.
+		$this->assertFalse(pfb_dnsbl_nat_enabled('lo0', ''));
+	}
+
+	public function testLocalhostWithNatOptedOutReturnsFalse(): void
+	{
+		// Given: interface is lo0, nonat opt-out is on.
+		// Then: still no NAT (lo0 guard fires before the nonat check).
+		$this->assertFalse(pfb_dnsbl_nat_enabled('lo0', 'on'));
+	}
+
+	// Scenario: real (non-lo0) interface — NAT controlled by the nonat toggle.
+
+	public function testRealIfaceWithNatEnabledReturnsTrue(): void
+	{
+		// Given: real interface (lan), nonat opt-out is off ('' = NAT generated, the default).
+		// Then: NAT IS generated — this is the existing/default behaviour.
+		$this->assertTrue(pfb_dnsbl_nat_enabled('lan', ''));
+	}
+
+	public function testRealIfaceWithNatOptedOutReturnsFalse(): void
+	{
+		// Given: real interface (lan), nonat opt-out is on ('on' = user manages NAT manually).
+		// Then: NAT is NOT generated — this is the new #381 behaviour.
+		$this->assertFalse(pfb_dnsbl_nat_enabled('lan', 'on'));
+	}
+}

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -105,6 +105,7 @@ class RequireConfigGatewaySniff implements Sniff
 		// installedpackages/pfblockerngdnsblsettings/config/0 (DNSBL settings)
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
+		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_interface',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip4',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip6',

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -991,6 +991,27 @@ def set_dnsbl_interface(vm: SmokeVM, iface: str, *, timeout: float = 60.0) -> No
         )
 
 
+def set_dnsbl_nonat(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Set the issue-#381 DNSBL NAT opt-out toggle (``pfb_dnsbl_nonat``).
+
+    When ``on`` is True, the package skips creating the DNSBL
+    ``pfB DNSBL - DO NOT EDIT`` NAT port-forward rules and removes any existing
+    managed ``pfB DNSBL`` NAT on the next reload.  When False (the default),
+    the NAT is created whenever ``dnsbl_interface`` is not ``lo0``.
+    """
+    val = "on" if on else ""
+    snippet = (
+        f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
+        f"$d['pfb_dnsbl_nonat'] = {_php_str(val)};\n"
+        f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $d);\n"
+        "write_config('pfBlockerNG smoke: set pfb_dnsbl_nonat');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"set_dnsbl_nonat({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
 def set_dnsbl_lenient(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     """Set the ADR-22 ``pfb_dnsbl_lenient`` toggle in the DNSBL-settings section.
 

--- a/tests/smoke/test_smoke_managed_objects.py
+++ b/tests/smoke/test_smoke_managed_objects.py
@@ -370,6 +370,69 @@ def test_managed_objects_disable_removes_vip_and_nat(deployed_vm: SmokeVM) -> No
 
 
 # --------------------------------------------------------------------------- #
+# Scenario B2 — pfb_dnsbl_nonat opt-out skips NAT creation (issue #381)
+# --------------------------------------------------------------------------- #
+
+
+def test_managed_objects_nonat_skips_nat(deployed_vm: SmokeVM) -> None:
+    """Issue #381 Scenario B2: pfb_dnsbl_nonat=on skips the managed DNSBL NAT rule.
+
+    Scenario: DNSBL NAT opt-out prevents pfB DNSBL port-forward creation.
+      Background: pfBlockerNG installed; DNSBL interface set to lan.
+
+      Given pfb_dnsbl_nonat is OFF, DNSBL is disabled, and interface is lo0,
+        Then no nat/rule[] entry starts with 'pfB DNSBL' (before-state is clean).
+
+      When pfb_dnsbl_nonat is OFF, interface=lan, auto-VIP ON, and DNSBL is enabled,
+        Then nat/rule[] CONTAINS a 'pfB DNSBL' entry — the NAT is created by default.
+        (This is the before-state for the opt-out; it would remain True on pre-fix code.)
+
+      Then (opt-out ON) pfb_dnsbl_nonat is set ON and a reload runs,
+        Then nat/rule[] has NO 'pfB DNSBL' entry — the managed NAT is removed.
+        (This assertion is RED on pre-fix code where the toggle is ignored.)
+    """
+    vm = deployed_vm
+    try:
+        # GIVEN — baseline: DNSBL off, opt-out cleared, interface lo0.
+        h.set_dnsbl_nonat(vm, False)
+        h.set_dnsbl_interface(vm, "lo0")
+        h.set_dnsbl_enabled(vm, False)
+        h.reload(vm, "update")
+
+        assert not _nat_pfb_dnsbl_present(vm), (
+            "pfB DNSBL NAT present before test — before-state is not clean" + f"\n{h.fwobj_state_snapshot(vm)}"
+        )
+
+        # WHEN (opt-out OFF) — enable DNSBL on lan with auto-VIP: NAT must be created.
+        h.set_dnsbl_interface(vm, "lan")
+        h.set_dnsvip_auto(vm, True)
+        h.set_dnsbl_nonat(vm, False)
+        h.set_dnsbl_enabled(vm, True)
+        h.reload(vm, "update")
+
+        assert _nat_pfb_dnsbl_present(vm), (
+            "pfB DNSBL NAT not created when pfb_dnsbl_nonat=off — default NAT path broken"
+            + f"\n{h.fwobj_state_snapshot(vm)}"
+        )
+
+        # THEN (opt-out ON) — flip pfb_dnsbl_nonat and reload: NAT must be gone.
+        h.set_dnsbl_nonat(vm, True)
+        h.reload(vm, "update")
+
+        assert not _nat_pfb_dnsbl_present(vm), (
+            "pfB DNSBL NAT still present after pfb_dnsbl_nonat=on reload"
+            " — expected: no pfB DNSBL nat/rule[]; actual:" + f"\n{h.fwobj_state_snapshot(vm)}"
+        )
+    finally:
+        h.set_dnsbl_nonat(vm, False)
+        h.set_dnsbl_interface(vm, "lo0")
+        h.set_dnsvip_auto(vm, False)
+        h.set_dnsbl_enabled(vm, False)
+        h.ensure_dnsbl_vip(vm)
+        h.reload(vm, "update")
+
+
+# --------------------------------------------------------------------------- #
 # Scenario C — orphan + user objects on uninstall
 # --------------------------------------------------------------------------- #
 

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -234,6 +234,14 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="pfb_idn_escalate_suspicious",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_escalate_suspicious",
     ),
+    # issue #381: opt out of automatic DNSBL NAT-rule creation (default '' = NAT on).
+    # The form POST exercises the new save handler; config.xml is the oracle.
+    ToggleFlow(
+        name="dnsbl_nonat",
+        page="/pfblockerng/pfblockerng_dnsbl.php",
+        field="pfb_dnsbl_nonat",
+        config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat",
+    ),
 )
 
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -87,6 +87,7 @@ PAGE_TABLE: tuple[Page, ...] = (
             "Permit Firewall Rules",
             "Interface(s)",
             "no-AAAA",
+            "pfb_dnsbl_nonat",  # issue-#381 NAT opt-out checkbox (name= attr in rendered HTML)
         ),
     ),
     # feeds.php is split into IPv4/IPv6/DNSBL ?type sub-tabs (ADR-16 Phase 3). Each type


### PR DESCRIPTION
## Summary

Adds an opt-out toggle for the automatic DNSBL sinkhole **NAT rule** generation, as requested in the issue and confirmed by @BBcan177 ("a toggle to disable the NAT generation … enabled by default … needs an infoblock help text").

DNSBL still auto-creates the `pfB DNSBL - DO NOT EDIT` port-forward NAT (80/443 → sinkhole VIP) **by default** — existing installs are unaffected. A new **Disable automatic NAT rule creation** checkbox on the DNSBL settings page lets the user opt out and manage the NAT manually.

## Behaviour

- New registered config field `pfb_dnsbl_nonat` (`PfbToggle`, default `''` — NAT generated, current behaviour). No migration/grandfather seed: absent reads as off for every install.
- NAT is generated when the DNSBL Web Server Interface is non-`lo0` **and** `pfb_dnsbl_nonat` is off. When the toggle is on, no NAT is created and any existing managed `pfB DNSBL` NAT is removed on the next reload (same code path as the `lo0` case).
- The decision is centralised in a pure predicate `pfb_dnsbl_nat_enabled($iface, $nonat)` so the branch is unit-testable off-appliance.

## Scope

- `pfblockerng.inc` — predicate helper, `pfb_global` read, single guard at the NAT-generation site (the only `pfB DNSBL` NAT creator; the `pfB_DNS_Redirect_*` rdr is a separate feature and untouched).
- `pfblockerng_extra.inc` — registry entry (`since 4.0.0`); RequireConfigGateway sniff `$registeredPaths`.
- `pfblockerng_dnsbl.php` — read/save + the checkbox in the *DNSBL Webserver Configuration* section.

## Tests

- `PfbDnsblNatEnabledTest` — pins all four branches of the predicate (lo0/non-lo0 × off/on); fail-before (function absent) → pass-after verified.
- `CfgGatewayTest` — round-trip + inventory completeness for the new toggle.
- Tier-A render proof — the checkbox's field name added as a render marker for the DNSBL page.
- Live-VM smoke (`test_managed_objects_nonat_skips_nat`) — default reload creates the NAT, then `pfb_dnsbl_nonat=on` reload removes it (red on pre-fix code where the toggle is ignored). Dispatch-only; validated via a smoke fan-out.

Gates green locally: PHPUnit (1283), PHPStan, PHPCS, ruff/format.

Fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
