### PR TITLE
pfblockerng: GUI Uninstall + Package Manager priv gate on the Software page (#485)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -44,6 +44,20 @@ if (!pfb_software_provenance_ok()) {
 	exit;
 }
 
+// SECONDARY PRIVILEGE GATE (issue #485). The framework page-guard already requires
+// page-firewall-pfblockerng to reach here; this page can now UNINSTALL the package, so
+// additionally require the Package Manager "Installed" privilege — the priv pfSense uses for
+// its own package-Remove page (page-system-packagemanager-installed, match 'pkg_mgr_installed.php*').
+// pfSense match-based privilege is OR across groups, so this AND can only be enforced by an
+// explicit in-page check. Use isAllowedPage() against that page, NOT userHasPrivilege() with the
+// raw priv id: isAllowedPage honours the admin (uid 0) short-circuit AND the 'page-all' wildcard
+// match, whereas userHasPrivilege does an exact priv-id membership test that wrongly excludes a
+// page-all admin (who lacks the literal '…-installed' priv) — that would lock admins out.
+if (!isAllowedPage('pkg_mgr_installed.php')) {
+	header('Location: /index.php');
+	exit;
+}
+
 // Resolve the installed package + channel ONCE (used by display + the actions).
 $pfb_sw_pkgname	= pfb_pkg_installed_name();
 $pfb_sw_channel	= pfb_channel_from_pkgname($pfb_sw_pkgname);
@@ -103,10 +117,10 @@ function pfb_software_run_stream($cmd) {
 // status are shown. Navigates (GET) to the page URL rather than reloading the current
 // request, so the Update POST is never resubmitted. The delay lets the final terminal
 // output settle on screen first.
-function pfb_software_reload() {
+function pfb_software_reload($url = '/pfblockerng/pfblockerng_software.php') {
 	print("\n<script type=\"text/javascript\">");
 	print("\n//<![CDATA[");
-	print("\nsetTimeout(function(){ window.location.assign('/pfblockerng/pfblockerng_software.php'); }, 1500);");
+	print("\nsetTimeout(function(){ window.location.assign(" . json_encode($url) . "); }, 1500);");
 	print("\n//]]>");
 	print("\n</script>");
 	ob_flush();
@@ -244,6 +258,24 @@ if (!$update_available) {
 }
 $section->addInput(new Form_StaticText(null, $btn_update))
 	->setHelp('Install the latest version. Available only when an update is found.');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_sw_uninstall_confirm',
+	'Confirm uninstall',
+	'Confirm I want to uninstall pfBlockerNG',
+	FALSE
+))->setHelp('Required before the Uninstall button is enabled. Uninstalling removes pfBlockerNG entirely.');
+
+$btn_uninstall = new Form_Button(
+	'pfb_sw_uninstall',
+	'Uninstall',
+	null,
+	'fa-solid fa-trash-can'
+);
+$btn_uninstall->removeClass('btn-primary')->addClass('btn-danger btn-xs')->setWidth(2);
+$btn_uninstall->setAttribute('disabled', 'disabled');
+$section->addInput(new Form_StaticText(null, $btn_uninstall))
+	->setHelp('Remove pfBlockerNG from this firewall. Enabled only after the confirmation box is checked.');
 $form->add($section);
 
 // Live terminal window (shown when an Update is streaming).
@@ -289,6 +321,30 @@ if ($pfb_sw_action === 'update') {
 		}
 	}
 }
+
+// Uninstall streams AFTER the form renders (textareas must exist for the JS). POST-guarded.
+if ($pfb_sw_action === 'uninstall') {
+	// Defense-in-depth: the Uninstall button is only disabled client-side, so re-check the
+	// confirmation server-side and refuse without it. (CSRF token enforces request authenticity.)
+	if (!isset($_POST['pfb_sw_uninstall_confirm'])) {
+		pfb_software_status(gettext('Uninstall not confirmed — tick the confirmation box first.'));
+	} elseif ($pfb_sw_pkgname === '') {
+		pfb_software_status(gettext('No pfBlockerNG package detected — cannot uninstall.'));
+	} else {
+		pfb_software_status(gettext('Uninstalling pfBlockerNG...'));
+		$bin = escapeshellarg(PFB_PKG_BIN);
+		$pkg = escapeshellarg($pfb_sw_pkgname);
+		$pfb_sw_rc = pfb_software_run_stream("{$bin} delete -y {$pkg}");
+		// Success removes the very package serving this page; redirect somewhere safe instead
+		// of leaving the user on a now-404 tab. Failure leaves the log on screen to inspect.
+		if ($pfb_sw_rc === 0) {
+			pfb_software_status(gettext('Uninstall complete — redirecting...'));
+			pfb_software_reload('/pkg_mgr_installed.php');
+		} else {
+			pfb_software_status(gettext('Uninstall task finished with errors — see the log above.'));
+		}
+	}
+}
 ?>
 
 <script type="text/javascript">
@@ -315,6 +371,19 @@ events.push(function() {
 		e.preventDefault();
 		if (confirm('Update pfBlockerNG to the latest version now?')) {
 			pfb_sw_submit('update');
+		}
+	});
+
+	function pfb_sw_uninstall_sync() {
+		document.getElementById('pfb_sw_uninstall').disabled = !document.getElementById('pfb_sw_uninstall_confirm').checked;
+	}
+	$('#pfb_sw_uninstall_confirm').on('change', pfb_sw_uninstall_sync);
+	pfb_sw_uninstall_sync();
+
+	$('#pfb_sw_uninstall').click(function(e) {
+		e.preventDefault();
+		if (confirm('Uninstall pfBlockerNG from this firewall? This cannot be undone.')) {
+			pfb_sw_submit('uninstall');
 		}
 	});
 });

--- a/stubs/pfsense/supplemental.php
+++ b/stubs/pfsense/supplemental.php
@@ -18,3 +18,6 @@
 
 /** Read and parse the pfSense configuration (config.lib.inc; pfSense CE 2.8+). */
 function config_read_file(bool $use_backup = false, bool $use_cache = true): array {}
+
+/** Return true if the current logged-in user may access $page, per their privilege match list (priv.inc). */
+function isAllowedPage($page) {}

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -345,3 +345,55 @@ def test_software_panel_screenshot_when_enabled(
         _open(browser_page, webui, SOFTWARE_PAGE)
         assert SOFTWARE_PANEL_MARKER in browser_page.content(), "Software panel marker absent when forced on"
         _shot(browser_page, screenshot_dir, "software_panel_enabled")
+
+
+def test_software_uninstall_confirm_gate(
+    smoke_vm: SmokeVM,
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """Ticking the confirm checkbox enables the (initially disabled) Uninstall button.
+
+    Scenario: the JS confirm gate (``pfb_sw_uninstall_sync``) wires the button's
+    enabled/disabled state to the checkbox (issue #485).
+
+      Given the Software page forced on and loaded in the browser,
+
+      Then ``#pfb_sw_uninstall`` is DISABLED while ``#pfb_sw_uninstall_confirm`` is
+        unchecked (OFF branch — the initial state on page load);
+
+      When ``#pfb_sw_uninstall_confirm`` is checked,
+
+      Then ``#pfb_sw_uninstall`` becomes ENABLED (ON branch — JS handler fired).
+
+    The Uninstall button is NOT clicked — clicking it would trigger an uninstall,
+    removing the package from the smoke VM and breaking subsequent tests. Only the
+    disabled→enabled JS transition is verified here.
+
+    Fail-before / pass-after: the confirm checkbox, the Uninstall button, and the
+    ``pfb_sw_uninstall_sync`` JS handler were all added in issue #485 Step 1. Pre-Step-1,
+    neither id exists on the page, so the locator assertions would fail.
+    """
+    page = browser_page
+    with software_panel_forced(smoke_vm, "on"):
+        _open(page, webui, SOFTWARE_PAGE)
+
+        confirm_cb = page.locator("#pfb_sw_uninstall_confirm")
+        uninstall_btn = page.locator("#pfb_sw_uninstall")
+
+        expect(confirm_cb).to_be_attached(timeout=JS_TIMEOUT_MS)
+        expect(uninstall_btn).to_be_attached(timeout=JS_TIMEOUT_MS)
+        _shot(page, screenshot_dir, "software_uninstall_before_confirm")
+
+        # BEFORE: checkbox unchecked -> button disabled (OFF branch).
+        expect(confirm_cb).not_to_be_checked(timeout=JS_TIMEOUT_MS)
+        expect(uninstall_btn).to_be_disabled(timeout=JS_TIMEOUT_MS)
+
+        # FLIP: tick the confirm checkbox -> JS fires -> button enabled (ON branch).
+        confirm_cb.check()
+        expect(confirm_cb).to_be_checked(timeout=JS_TIMEOUT_MS)
+        expect(uninstall_btn).to_be_enabled(timeout=JS_TIMEOUT_MS)
+        _shot(page, screenshot_dir, "software_uninstall_after_confirm")
+        # DO NOT click uninstall_btn — clicking it would uninstall the package and
+        # break every subsequent test in this smoke run.

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -23,6 +23,7 @@ with the reason and the access note for Phase 5, NOT silently dropped.
 
 from __future__ import annotations
 
+import re
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -627,9 +628,7 @@ def test_software_page_renders_uninstall_controls(
         # The button must carry the `disabled` attribute on initial render (JS enables it
         # only after the confirm checkbox is ticked). Match the button tag itself to avoid
         # false-matching the id string in an unrelated attribute or script block.
-        import re as _re
-
-        btn_tag_match = _re.search(r'<button\b[^>]*id=["\']pfb_sw_uninstall["\'][^>]*>', body)
+        btn_tag_match = re.search(r'<button\b[^>]*id=["\']pfb_sw_uninstall["\'][^>]*>', body)
         assert btn_tag_match is not None, f"Uninstall button tag not found in {_SOFTWARE_PAGE} body"
         btn_tag = btn_tag_match.group(0)
         assert "disabled" in btn_tag, (

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -593,6 +593,50 @@ def test_software_page_renders_when_override_forces_on(
         assert _SOFTWARE_TAB_HREF in general.text, "the Software tab must be PRESENT when the gate is forced on"
 
 
+def test_software_page_renders_uninstall_controls(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """The Software page renders the Uninstall confirm checkbox and button, button disabled by default.
+
+    Scenario: the Uninstall Controls (issue #485) are present in the forced-on render.
+      Given the override sentinel set to 'on' (so the provenance gate passes),
+      When the Software page is GET,
+      Then the confirm checkbox ``id="pfb_sw_uninstall_confirm"`` is in the body;
+      And the Uninstall button ``id="pfb_sw_uninstall"`` is in the body;
+      And the button tag carries a ``disabled`` attribute by default (JS enables it only
+          after the checkbox is ticked) — the OFF branch of the confirm gate;
+      And the clean render oracle (200, no Fatal/Warning/Notice, marker present) holds.
+
+    Fail-before / pass-after: the ids ``pfb_sw_uninstall_confirm`` / ``pfb_sw_uninstall``
+    and the ``disabled`` attribute on the button were added in issue #485 Step 1. Running
+    against the pre-Step-1 Software page yields a 200 but the ids are absent, failing
+    the ``in body`` assertions.
+    """
+    with software_panel_forced(smoke_vm, "on"):
+        resp = webui.get(_SOFTWARE_PAGE)
+        result = evaluate_render(_SOFTWARE_PAGE, resp.status_code, resp.text, (_SOFTWARE_PANEL_MARKER,))
+        assert result.ok, f"Software page render oracle failed: {result.detail}"
+        body = resp.text
+
+        assert 'id="pfb_sw_uninstall_confirm"' in body, (
+            f"confirm checkbox id='pfb_sw_uninstall_confirm' not found in {_SOFTWARE_PAGE} body"
+        )
+        assert 'id="pfb_sw_uninstall"' in body, (
+            f"Uninstall button id='pfb_sw_uninstall' not found in {_SOFTWARE_PAGE} body"
+        )
+        # The button must carry the `disabled` attribute on initial render (JS enables it
+        # only after the confirm checkbox is ticked). Match the button tag itself to avoid
+        # false-matching the id string in an unrelated attribute or script block.
+        import re as _re
+
+        btn_tag_match = _re.search(r'<button\b[^>]*id=["\']pfb_sw_uninstall["\'][^>]*>', body)
+        assert btn_tag_match is not None, f"Uninstall button tag not found in {_SOFTWARE_PAGE} body"
+        btn_tag = btn_tag_match.group(0)
+        assert "disabled" in btn_tag, (
+            f"Uninstall button expected 'disabled' attribute on initial render, got: {btn_tag!r}"
+        )
+
+
 def test_software_page_hidden_when_override_forces_off(
     smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:

--- a/tests/smoke/ui/test_software_uninstall.py
+++ b/tests/smoke/ui/test_software_uninstall.py
@@ -77,6 +77,21 @@ def test_software_uninstall_server_rejects_without_confirm(
     ``pfb_sw_action=uninstall``, so the response body would NOT contain the refusal
     string, failing the ``in body`` assertion.
     """
+
+    def pfb_installed() -> tuple[bool, str]:
+        """(installed?, stdout) — rc 0 + non-empty `pkg query %n` stdout means installed."""
+        r = smoke_vm.ssh("/usr/local/sbin/pkg", "query", "-g", "%n", "pfSense-pkg-pfBlockerNG*")
+        return (r.returncode == 0 and bool(r.stdout.strip()), r.stdout.strip())
+
+    # Precondition (before-state, per the test-coverage mandate): the package MUST be installed
+    # before the unconfirmed POST, so a green after-state genuinely proves "pkg delete did not
+    # run" rather than "it was already gone".
+    pre_installed, pre_stdout = pfb_installed()
+    assert pre_installed, (
+        f"precondition: pfBlockerNG must be installed before testing the unconfirmed uninstall.\n"
+        f"  pkg query stdout: {pre_stdout!r}"
+    )
+
     with software_panel_forced(smoke_vm, "on"):
         resp = webui.post(
             _SOFTWARE_PAGE,
@@ -89,16 +104,7 @@ def test_software_uninstall_server_rejects_without_confirm(
     refusal_string = "Uninstall not confirmed"
     refusal_found = refusal_string in body
 
-    # pkg query for the installed package (rc 0 + non-empty stdout = still installed).
-    pkg_result = smoke_vm.ssh(
-        "/usr/local/sbin/pkg",
-        "query",
-        "-g",
-        "%n",
-        "pfSense-pkg-pfBlockerNG*",
-    )
-    pkg_installed = pkg_result.returncode == 0 and bool(pkg_result.stdout.strip())
-    pkg_stdout = pkg_result.stdout.strip()
+    pkg_installed, pkg_stdout = pfb_installed()
 
     assert refusal_found, (
         f"Expected refusal string {refusal_string!r} in POST response body but it was absent.\n"
@@ -107,7 +113,6 @@ def test_software_uninstall_server_rejects_without_confirm(
     )
     assert pkg_installed, (
         f"pfBlockerNG package unexpectedly gone after unconfirmed uninstall POST.\n"
-        f"  pkg query rc    : {pkg_result.returncode}\n"
         f"  pkg query stdout: {pkg_stdout!r}\n"
         f"  (Expected the package to still be installed; pkg delete must NOT have run.)"
     )

--- a/tests/smoke/ui/test_software_uninstall.py
+++ b/tests/smoke/ui/test_software_uninstall.py
@@ -1,0 +1,113 @@
+"""Tier-B e2e tests for the Software-page Uninstall confirm gate (issue #485).
+
+Marker ``ui_e2e`` — daily / on-demand; NOT in the PR gate and NOT in the default
+``python -m pytest`` run (the whole ``tests/smoke`` tree is ``--ignore``d there).
+Run with: ``pytest tests/smoke -m ui_e2e --override-ini="addopts="``.
+
+What these tests cover
+-----------------------
+Step 1 of issue #485 added an Uninstall section to ``pfblockerng_software.php``:
+
+* a privilege gate (``isAllowedPage('pkg_mgr_installed.php')``);
+* a confirm checkbox ``id="pfb_sw_uninstall_confirm"`` (default UNCHECKED);
+* an Uninstall button ``id="pfb_sw_uninstall"`` (rendered ``disabled`` by default);
+* a POST handler for ``pfb_sw_action=uninstall`` that re-checks the confirm field
+  server-side — if ``pfb_sw_uninstall_confirm`` is absent it emits the refusal
+  status ``"Uninstall not confirmed"`` without running ``pkg delete``.
+
+The browser-tier confirm gate (disabled→enabled on checkbox tick) is in
+``test_browser_misc.py::test_software_uninstall_confirm_gate``.
+
+Out-of-CI limitations (ADR-04 §7 / CLAUDE.md "ADR acceptance")
+----------------------------------------------------------------
+Two branches are intentionally NOT exercised in CI:
+
+1. **Successful uninstall** (``pkg delete`` removes pfBlockerNG + redirect to
+   ``/pkg_mgr_installed.php``) — executing this removes the SUT from the smoke VM
+   and breaks every subsequent test in the run. Only the NON-destructive branches
+   are tested here.
+
+2. **Privilege-denial** (``isAllowedPage`` returns false, redirects to
+   ``/index.php``) — the smoke session authenticates as admin (uid 0), which
+   passes ``isAllowedPage`` unconditionally. Exercising the denial branch requires
+   a non-admin user holding the pfBlockerNG GUI priv but NOT the Package Manager
+   Installed priv; the smoke harness has no such fixture. The *authorised* branch
+   IS covered — every render/e2e/browser test reaches the page as admin.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .test_render_smoke import _SOFTWARE_PAGE, software_panel_forced
+
+if TYPE_CHECKING:
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+
+def test_software_uninstall_server_rejects_without_confirm(
+    smoke_vm: SmokeVM,
+    webui: WebUI,
+) -> None:
+    """Server-side confirm re-check rejects an uninstall POST with no confirm field.
+
+    Scenario: the Uninstall handler refuses when the confirm checkbox is absent.
+
+      Given the Software page forced on (``software_panel_forced(smoke_vm, 'on')``)
+        and an authenticated admin session (``webui``),
+
+      When the Software page is POSTed with ``pfb_sw_action=uninstall`` but WITHOUT
+        ticking ``pfb_sw_uninstall_confirm`` — ``webui.post`` with an empty overrides
+        dict uses ``submit=('pfb_sw_action', 'uninstall')``; ``scrape_form_fields``
+        omits the unchecked checkbox (exactly like a browser), so ``pfb_sw_uninstall_confirm``
+        is absent from the payload — the unconfirmed case,
+
+      Then the response body contains ``"Uninstall not confirmed"`` (the server-side
+        refusal status emitted by the handler when the field is absent);
+      And pfBlockerNG is STILL installed — ``pkg query -g %n 'pfSense-pkg-pfBlockerNG*'``
+        returns rc 0 with a non-empty package name — proving ``pkg delete`` did NOT run.
+
+    Fail-before / pass-after: the POST handler and the refusal status string were added
+    in issue #485 Step 1. Pre-Step-1 the page had no POST handler for
+    ``pfb_sw_action=uninstall``, so the response body would NOT contain the refusal
+    string, failing the ``in body`` assertion.
+    """
+    with software_panel_forced(smoke_vm, "on"):
+        resp = webui.post(
+            _SOFTWARE_PAGE,
+            {},
+            submit=("pfb_sw_action", "uninstall"),
+        )
+
+    status = resp.status_code
+    body = resp.text
+    refusal_string = "Uninstall not confirmed"
+    refusal_found = refusal_string in body
+
+    # pkg query for the installed package (rc 0 + non-empty stdout = still installed).
+    pkg_result = smoke_vm.ssh(
+        "/usr/local/sbin/pkg",
+        "query",
+        "-g",
+        "%n",
+        "pfSense-pkg-pfBlockerNG*",
+    )
+    pkg_installed = pkg_result.returncode == 0 and bool(pkg_result.stdout.strip())
+    pkg_stdout = pkg_result.stdout.strip()
+
+    assert refusal_found, (
+        f"Expected refusal string {refusal_string!r} in POST response body but it was absent.\n"
+        f"  HTTP status : {status}\n"
+        f"  Body excerpt: {body[:500]!r}"
+    )
+    assert pkg_installed, (
+        f"pfBlockerNG package unexpectedly gone after unconfirmed uninstall POST.\n"
+        f"  pkg query rc    : {pkg_result.returncode}\n"
+        f"  pkg query stdout: {pkg_stdout!r}\n"
+        f"  (Expected the package to still be installed; pkg delete must NOT have run.)"
+    )


### PR DESCRIPTION
## Summary

Adds a GUI **Uninstall** action to the pfBlockerNG **Software** page (ADR-19) and tightens the
page's access control, per #485.

The Software page is shown only on a build installed from one of our repos (provenance guard),
which the Netgate Package Manager cannot remove. Until now there was no way to uninstall such a
build from the GUI. This adds that, behind a confirmation gate, and requires the same privilege
the pfSense Package Manager uses for its own *Remove* page.

## What changed

- **Uninstall action** (`pfblockerng_software.php`): a `btn-danger` Uninstall button + a
  "Confirm I want to uninstall pfBlockerNG" checkbox in the Actions section. The button is
  rendered `disabled`; JS enables it only while the checkbox is ticked. The POST handler
  **re-checks the confirmation server-side** (never trusts the client for a destructive action),
  then streams `pkg delete -y <installed-pkg-name>` into the existing live terminal — symmetric
  with the existing Update action's `pkg upgrade -y`. On success it redirects to
  `/pkg_mgr_installed.php` (the page that served the action is itself removed).

- **Page privilege gate**: an in-page `isAllowedPage('pkg_mgr_installed.php')` check after the
  provenance guard. The framework page-guard already requires `page-firewall-pfblockerng` to
  reach the page, so this ANDs in the Package Manager **Installed** privilege
  (`page-system-packagemanager-installed`).

  **Correction to the issue's premise:** pfSense splits the Package Manager into three distinct
  privileges (`page-system-packagemanager` → `pkg_mgr.php*`, `-installpackage` →
  `pkg_mgr_install.php*`, `-installed` → `pkg_mgr_installed.php*`), not one. The privilege that
  authorises removing an installed package via the GUI is `-installed` (the page hosting the
  Remove button), so the gate targets that. `isAllowedPage()` is used rather than
  `userHasPrivilege()` with the raw priv id because the former honours the admin (uid 0)
  short-circuit and the `page-all` wildcard, whereas an exact priv-id membership test would lock
  out `page-all` admins who lack the literal `…-installed` priv.

- **Stubs**: added `isAllowedPage()` to `stubs/pfsense/supplemental.php` for PHPStan.

## Test coverage (ADR-14 Web-UI tiers)

- **Tier A `ui_render`** (PR gate): the forced-on Software page renders the Uninstall controls —
  confirm checkbox present, Uninstall button present and `disabled` by default.
- **Tier B `ui_e2e`**: an uninstall POST **without** the confirm field is rejected server-side
  (`"Uninstall not confirmed"`), and pfBlockerNG remains installed (`pkg query` still resolves
  the package) — proving `pkg delete` did not run. Non-destructive.
- **Tier B `ui_browser`**: the confirm checkbox toggles the Uninstall button disabled→enabled
  (the button is never clicked).

**Documented out-of-CI limitations** (ADR-04 §7): the *successful* uninstall path is destructive
(it removes the SUT) and the privilege-**denial** branch needs a non-admin limited user the smoke
harness has no fixture for; the *authorised* branch is covered (every UI test reaches the page as
admin).

Fixes #485

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
