### PR TITLE
pfblockerng: fix typo'd $ufound reset causing spurious Unbound restart on upgrade

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -555,7 +555,7 @@ if (file_exists('/var/db/pfblockerng/dnsbl_info') &&
 unlink_if_exists('/var/db/pfblockerng/dnsbl_info');
 
 // Move dnsbl_levent.sqlite -> /var/unbound folder
-$u_found = FALSE;
+$ufound = FALSE;
 if (file_exists('/var/db/pfblockerng/dnsbl_levent.sqlite') && !file_exists($pfb['dnsbl_resolver'])) {
 	$ufound = TRUE;
 	@copy('/var/db/pfblockerng/dnsbl_levent.sqlite', $pfb['dnsbl_resolver']);

--- a/tests/php/InstallDnsblMoveRestartGuardTest.php
+++ b/tests/php/InstallDnsblMoveRestartGuardTest.php
@@ -38,7 +38,9 @@ final class InstallDnsblMoveRestartGuardTest extends TestCase
 		$src = self::installSource();
 
 		// The section runs from its "Move dnsbl_levent.sqlite" header to the guarded
-		// pfb_stop_start_unbound() call.
+		// pfb_stop_start_unbound() call. NOTE: this header string is load-bearing — it
+		// bounds the window this test inspects; testNoOrphanUfoundTypo() is the
+		// header-independent backstop for the exact regression class.
 		$start = strpos($src, '// Move dnsbl_levent.sqlite');
 		$this->assertNotFalse($start, 'the "Move dnsbl_levent.sqlite" migration block is missing');
 		$guard = strpos($src, 'pfb_stop_start_unbound', $start);

--- a/tests/php/InstallDnsblMoveRestartGuardTest.php
+++ b/tests/php/InstallDnsblMoveRestartGuardTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression guard: the "Move dnsbl_*.sqlite -> /var/unbound" migration block in
+ * pfblockerng_install.inc must reset its Unbound-restart guard ($ufound) before the
+ * block, so a TRUE left by an EARLIER migration block (e.g. the pfBlockerNGSuppress
+ * alias upgrade) cannot leak through and trigger a spurious pfb_stop_start_unbound()
+ * on a plain pkg upgrade.
+ *
+ * The bug: the reset was misspelled `$u_found = FALSE;` (an orphan that is assigned
+ * but never read), so `$ufound` was NOT reset and carried the prior block's value
+ * into the `if ($ufound) { pfb_stop_start_unbound('') }` guard.
+ *
+ * install.inc is a procedural migration script (host-absolute requires, sqlite,
+ * exec, real Unbound control) and is not loadable by the unit harness, so this pins
+ * the invariant at the source level — the same approach as the custom-sniff tests.
+ */
+final class InstallDnsblMoveRestartGuardTest extends TestCase
+{
+	private static function installSource(): string
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
+		$src = @file_get_contents($path);
+		self::assertIsString($src, "could not read {$path}");
+		return $src;
+	}
+
+	/**
+	 * Given the dnsbl-sqlite-move block, the restart guard it tests ($ufound) is reset
+	 * to FALSE before the move attempts — so the restart fires iff THIS block moved a file.
+	 */
+	public function testDnsblMoveBlockResetsRestartGuardBeforeUse(): void
+	{
+		$src = self::installSource();
+
+		// The section runs from its "Move dnsbl_levent.sqlite" header to the guarded
+		// pfb_stop_start_unbound() call.
+		$start = strpos($src, '// Move dnsbl_levent.sqlite');
+		$this->assertNotFalse($start, 'the "Move dnsbl_levent.sqlite" migration block is missing');
+		$guard = strpos($src, 'pfb_stop_start_unbound', $start);
+		$this->assertNotFalse($guard, 'the dnsbl-move block no longer guards a pfb_stop_start_unbound() call');
+
+		$section = substr($src, $start, $guard - $start);
+
+		// Before: $ufound = FALSE; reset must appear at the top of the block, ahead of
+		// the conditional `$ufound = TRUE;` move flags — else a prior block's TRUE leaks
+		// into the restart guard.
+		$reset = strpos($section, '$ufound = FALSE;');
+		$this->assertNotFalse($reset, 'the dnsbl-move block does not reset $ufound before its restart guard');
+		$firstSet = strpos($section, '$ufound = TRUE;');
+		$this->assertNotFalse($firstSet, 'expected the dnsbl-move block to set $ufound = TRUE on a move');
+		$this->assertLessThan(
+			$firstSet,
+			$reset,
+			'$ufound must be reset to FALSE BEFORE the move flags set it TRUE'
+		);
+	}
+
+	/**
+	 * No orphaned `$u_found` (a typo of `$ufound`) anywhere in install.inc: such a
+	 * variable is assigned but never read and silently breaks the restart-guard reset.
+	 */
+	public function testNoOrphanUfoundTypo(): void
+	{
+		$this->assertStringNotContainsString(
+			'$u_found',
+			self::installSource(),
+			'install.inc assigns $u_found — a typo of $ufound that leaves the Unbound-restart guard unreset'
+		);
+	}
+}


### PR DESCRIPTION
## Bug

On a pkg upgrade, `pfblockerng_install.inc` can fire a **spurious Unbound restart** (`pfb_stop_start_unbound('')`).

`install.inc` resets a guard `$ufound = FALSE;` at the top of each migration block whose match should restart Unbound. The **"Move dnsbl_*.sqlite → /var/unbound"** block's reset was misspelled **`$u_found`** (assigned, never read), so `$ufound` was not reset and **carried over** from the preceding *pfBlockerNGSuppress alias → IPv4 Suppression* block.

Trigger: an upgrade that **migrated the suppression alias** (sets `$ufound = TRUE`) **and had no `dnsbl_levent.sqlite`/`dnsbl.sqlite` to move** (so neither move sets the flag) → the stale `TRUE` reaches `if ($ufound)` and restarts Unbound needlessly.

## Fix

Restore the intended `$ufound = FALSE;` reset (one character) — matches the per-block idiom used throughout the file.

## Test

`install.inc` is a procedural migration script (host-absolute requires, sqlite, `exec`, real Unbound control) and is not loadable by the unit harness, so the dnsbl-move block isn't an extractable function. A **source-level regression test** (`InstallDnsblMoveRestartGuardTest`, same family as the repo's custom-sniff tests) pins the invariant: the dnsbl-move block resets `$ufound` *before* its restart guard, and `install.inc` carries no orphaned `$u_found` typo. Verified **fail-before** (2 failures on the buggy code) / **pass-after**.

Gates: PHPUnit 1281 pass (was 1279 + 2 new; 3 pre-existing skips), PHPStan clean, PHPCS clean, `php -l` clean.

Found via the #524 cleanup audit (this was the `$u_found` item I flagged as a latent bug rather than dead code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a migration issue that could incorrectly affect service restart behavior during DNSBL database upgrades.
  * Corrected a variable typo to ensure the upgrade path follows the intended logic.

* **Tests**
  * Added regression coverage to verify the upgrade flow resets the restart guard correctly.
  * Added a check to catch similar typo-related issues in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->