### PR TITLE
smoke: live IP-block coverage — syslog export leg + Clear-States (killstates)

### DIFF
--- a/.ADRs/ADR_38_System_Log_Integration/ADR.md
+++ b/.ADRs/ADR_38_System_Log_Integration/ADR.md
@@ -469,24 +469,31 @@ the fidelity gate).
 - **Smoke** targets `/var/log/pfblockerng_syslog.log`: proves live toggle (no restart), exclusion from
   system.log, routing+rotation registration, and CSV-additive — via the **DNSBL leg** (civm-sourced).
 
-### A2.4 IP-block live leg — deferred (documented out-of-CI follow-up, §7)
+### A2.4 IP-block live leg — RESOLVED (now a live, CI smoke leg)
 
-The IP-block syslog leg is **xfailed** in the smoke and tracked as an immediate follow-up. The syslog
-**mechanism** is identical to the DNSBL leg (the same host-side `pfb_syslog_event` + `pfb_daemon_filterlog`
-path, proven live) and `pfb_syslog_format_ip` is unit-tested — what is missing is a way to **trigger a
-pf-logged IP block from the civm client** in the single-runner smoke. Findings (live, on the local
-two-VM box):
+The IP-block syslog leg is now exercised **live** (`test_syslog_on_ip_block_event_exported`, un-xfailed):
+civm reaches a blocked WAN-subnet IP through a **floating, logged** Deny_Outbound rule on WAN, and the
+host daemon exports the `act=block` event. The syslog **mechanism** is identical to the DNSBL leg (the
+same host-side `pfb_syslog_event` + `pfb_daemon_filterlog` path) and `pfb_syslog_format_ip` is unit-tested;
+what was missing was a way to **trigger a pf-logged IP block from the civm client** in the single-runner
+smoke. Findings (live, on the local two-VM box) that shaped the working recipe:
 
 - A **LAN-interface** pfBlockerNG rule breaks **all** civm→pfSense traffic: adding any pfB rule to the
   LAN interface triggers a filter rebuild that drops the LAN's permissive allow, so civm's DNS/ICMP fall
   through to the default block (filterlog-confirmed: civm→`192.168.1.1:53` dropped by rule `1000000103`,
-  not the pfB rule). So the rule must NOT be on LAN.
-- A **WAN** rule to the unreachable TEST-NET target (`203.0.113.1`) never logs (the SYN never traverses
-  the WAN-outbound path), and that range also overlaps the stub-DNS sentinel.
-- The only IP civm can reach **through** pfSense is the runner (`10.10.0.2`) — the stub DNS + mock-feed
-  server — so blocking it breaks the harness.
+  not the pfB rule). So the rule must **not** be on LAN.
+- A **non-floating WAN** Deny_Outbound is a `block in` rule (`inc:8142`) — it never matches civm's
+  forwarded traffic **leaving** via WAN. `enable_float` flips it to a floating `block out quick`
+  (`direction=out`, `inc:8148`), which does. Floating-on-WAN also leaves the LAN allow intact (it matches
+  only `dst=<alias>`).
+- The victim must sit in the **WAN subnet** (`10.10.0.0/24`, directly connected) so the SYN routes out
+  WAN with no dependency on the flaky SLIRP default gateway; an off-subnet TEST-NET target never
+  traverses the WAN-out path. `.9` is unused (not the SLIRP gateway `.1`, the runner/stub-DNS `.2`, or
+  DNS `.3`).
+- The rule must **log**: pfBlockerNG only stamps `log` on the rule when global IP logging is on or the
+  list's `aliaslog='enabled'` (`inc:8175`). Without it the rule blocks **silently** — no filter.log line,
+  so the daemon never sees the event. `enable_log='on'` closes this.
 
-The follow-up adds a **reachable, non-infra victim target** for civm plus a **WAN or floating rule**
-(exercising floating `inbound`/`outbound`/`any` modes), then un-xfails the IP-block test. Per §7 this is
-a documented out-of-CI limitation, not an acceptance blocker — the live DNSBL proof + the IP unit test
-cover the syslog behaviour.
+Net recipe: WAN-subnet victim + `enable_float` + `enable_log`, with the civm trigger pinning a host route
+for the victim via pfSense so the SYN takes the LAN→WAN path. This leg now runs in the CI smoke fan-out;
+the §7 manual-SIEM checklist remains the only out-of-CI item.

--- a/tests/smoke/test_smoke_killstates.py
+++ b/tests/smoke/test_smoke_killstates.py
@@ -1,0 +1,299 @@
+"""Live-VM smoke: pfBlockerNG "Clear firewall states" (killstates) on an IP block.
+
+Proves the pf state-preservation behaviour and the killstates remedy, end to end on a
+real two-VM pfSense CE setup (civm = the LAN client behind the firewall):
+
+  1. killstates OFF ⇒ a firewall state created BEFORE an IP is blocked SURVIVES the
+     pfBlockerNG update that blocks it. pf matches established flows by state before
+     rules, so that flow keeps bypassing the brand-new block — the classic gotcha
+     (a new connection IS rejected; the pre-existing one is not).
+  2. killstates ON ⇒ pfBlockerNG kills the state for the newly-blocked IP on Update
+     (``pfb_remove_states`` → ``pfctl -k``), so the block takes effect immediately for
+     the existing flow too.
+
+Non-obvious facts this exercises (each cost a live investigation):
+
+* The pfB Deny_Outbound rule is FLOATING (on WAN), not on the LAN interface. A LAN-
+  interface pfB IP rule was found to DROP the baked "Default allow LAN to any" rule on a
+  second reload — cutting the client off entirely (a real, reproducible side effect). A
+  floating Deny_Outbound blocks the client's forwarded traffic at WAN egress without
+  touching the LAN ruleset, so the client stays connected across reloads. killstates
+  kills states by the blocked IP regardless of which interface the rule is on.
+* The victim is a PUBLIC IP (RFC 5737 TEST-NET-3). killstates deliberately EXCLUDES
+  RFC1918 / local-subnet / reserved IPs (pfblockerng.inc:8827-8838), so a private or
+  WAN-subnet victim would never be cleared — a public dst is what a real blocked
+  outbound connection targets anyway.
+* killstates only fires on an update that does NOT rebuild the ruleset
+  (``!filter_configure``, inc:15081). Adding an IP to an EXISTING rule's alias is a
+  table-content change (no rule change) ⇒ filter_configure stays FALSE ⇒ killstates runs.
+  ``force_ip_refetch`` defeats the per-feed reuse gate so the edited local feed is
+  actually re-parsed (a plain update reuses the cached copy).
+* The state is a pending TCP state (``SYN_SENT``): the harness has no civm-reachable
+  responding public target, but the SYN still PASSES the LAN rule and creates the
+  state, and killstates behaves identically for pending and established states.
+
+DESELECTED from the default ``python -m pytest`` (smoke-only). Run via::
+
+    python -m pytest tests/smoke/test_smoke_killstates.py -m smoke --override-ini="addopts="
+
+Needs the booted ``smoke_vm`` + ``client_vm`` (civm) fixtures and the branch ``.pkg``
+(``SMOKE_PKG``); without these the cases skip cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import PFSENSE_LAN_IP, SmokeVM, _StubDnsServer
+
+pytestmark = pytest.mark.smoke
+
+# pfBlockerNG IP settings section (killstates / interface / logging live here).
+CFG_IP_SETTINGS = "installedpackages/pfblockerngipsettings/config/0"
+
+# The blocked victim: a PUBLIC IP (RFC 5737 TEST-NET-3, inert/non-routable) — public so
+# killstates does not suppress it as local/private. DUMMY keeps the alias non-empty (the
+# rule built) while the victim is UNBLOCKED, so the pre-block state can be created.
+VICTIM = "203.0.113.9"
+DUMMY = "203.0.113.77"
+HEADER = "pfbkillstates"  # IP feed header → on-disk file pfbkillstates_v4.txt
+ALIAS_TABLE = f"pfB_{HEADER}_v4"  # the pf alias table the rule references
+FEED_FILE = "pfb_killstates_ip.txt"
+
+# Settle budget for the alias replace + kill-states to land after a reload.
+SETTLE_SECS = 2.0
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _set_ipcfg(vm: SmokeVM, kv: dict[str, str], *, timeout: float = 60.0) -> None:
+    """Merge key=value pairs into the pfBlockerNG IP settings section + write_config."""
+    sets = "".join(f"$ip[{h._php_str(k)}] = {h._php_str(v)};\n" for k, v in kv.items())
+    snippet = (
+        f"$ip = config_get_path({h._php_str(CFG_IP_SETTINGS)}, array());\n{sets}"
+        f"config_set_path({h._php_str(CFG_IP_SETTINGS)}, $ip);\n"
+        "write_config('pfBlockerNG smoke: killstates ipcfg');\necho 'OK';"
+    )
+    r = h.php_eval(vm, snippet, timeout=timeout)
+    if r.returncode != 0 or "OK" not in r.stdout:
+        raise RuntimeError(f"_set_ipcfg failed: rc={r.returncode} {r.stderr!r} {r.stdout!r}")
+
+
+def _civm_connect(cl: SmokeVM, *, timeout: float = 20.0) -> int:
+    """civm attempts a TCP connection to the victim through pfSense; return curl's rc.
+
+    Pins a host route for the victim via pfSense (civm has two equal-metric default
+    routes; without the pin the SYN may egress the mgmt NIC). The SYN passes the LAN
+    rule (when unblocked) and creates a firewall state, or is rejected (when blocked).
+    """
+    r = cl.ssh(
+        "/bin/sh",
+        "-c",
+        f"dev=$(ip -4 -o addr show | awk '/192\\.168\\.1\\./{{print $2; exit}}'); "
+        f'ip route replace {VICTIM}/32 via {PFSENSE_LAN_IP} dev "$dev" 2>/dev/null || true; '
+        f"curl -s -o /dev/null --connect-timeout 3 --max-time 4 http://{VICTIM}/ >/dev/null 2>&1; echo rc=$?",
+        timeout=timeout,
+    )
+    marker = "rc="
+    line = next((ln for ln in r.stdout.splitlines() if ln.startswith(marker)), "rc=-1")
+    return int(line[len(marker) :] or -1)
+
+
+def _establish_victim_state(vm: SmokeVM, cl: SmokeVM, *, attempts: int = 6) -> str:
+    """civm opens a connection to the (unblocked) victim until a pf state appears.
+
+    The SYN passing the LAN allow creates a SYN_SENT state (pf tcp.first ~120s). A fresh
+    reload can briefly leave the WAN gateway re-initialising, so retry until the state is
+    observed; once created it persists well past the per-test window. Returns the state
+    lines. Raises with rich civm/pfSense diagnostics if no state forms.
+    """
+    for _ in range(attempts):
+        _civm_connect(cl)
+        time.sleep(1.0)
+        st = _victim_states(vm)
+        if VICTIM in st:
+            return st
+        time.sleep(2.0)
+    raise AssertionError(
+        f"could not create a firewall state to {VICTIM} from civm after {attempts} attempts.\n"
+        f"{_civm_diag(cl)}\n{_state_diag(vm)}"
+    )
+
+
+def _civm_diag(cl: SmokeVM) -> str:
+    """civm-side reachability diagnostics. Never raises."""
+    try:
+        out = cl.ssh(
+            "/bin/sh",
+            "-c",
+            "echo rc=$(curl -s -o /dev/null --connect-timeout 3 --max-time 4 -w '%{http_code}' "
+            f"http://{VICTIM}/ 2>&1; echo :$?); "
+            f"ping -c1 -W2 {PFSENSE_LAN_IP} >/dev/null 2>&1 && echo pf_ping=ok || echo pf_ping=FAIL; "
+            "ip route get " + VICTIM + " 2>&1 | head -1",
+            timeout=20,
+        ).stdout.strip()
+    except Exception:
+        out = "(error)"
+    return f"  civm: {out}"
+
+
+def _victim_states(vm: SmokeVM, *, timeout: float = 30.0) -> str:
+    """The pf state-table lines referencing the victim (empty string if none)."""
+    return vm.ssh("/bin/sh", "-c", f"pfctl -ss 2>/dev/null | grep '{VICTIM}' || true", timeout=timeout).stdout.strip()
+
+
+def _state_diag(vm: SmokeVM) -> str:
+    """On-box diagnostics for a killstates failure. Never raises."""
+
+    def _try(cmd: str) -> str:
+        try:
+            return vm.ssh("/bin/sh", "-c", cmd, timeout=20).stdout.strip()
+        except Exception:
+            return "(error)"
+
+    tbl = _try(f"pfctl -t {ALIAS_TABLE} -T show 2>/dev/null | tr -d ' ' || true")
+    rule = _try(f"pfctl -sr 2>/dev/null | grep -i {HEADER} || echo '(no rule)'")
+    lan_allow = _try("pfctl -sr 2>/dev/null | grep -i 'Default Allow LAN' || echo '(no LAN allow!)'")
+    log = _try(
+        "grep -iE 'Removed .* state|Kill States|Filter Reload' "
+        "/var/log/pfblockerng/pfblockerng.log 2>/dev/null | tail -6 || true"
+    )
+    return f"  alias {ALIAS_TABLE}: {tbl!r}\n  rule: {rule!r}\n  lan_allow: {lan_allow!r}\n  log:\n{log}"
+
+
+def _block_victim(vm: SmokeVM, *, timeout: float = 600.0) -> None:
+    """Add the victim to the existing rule's alias and run an Update.
+
+    Feed CONTENT change only (the rule already exists) ⇒ no rule change ⇒
+    ``filter_configure`` stays FALSE ⇒ killstates is eligible to run. ``force_ip_refetch``
+    defeats the per-feed reuse gate so the edited feed is actually re-parsed.
+    """
+    h.write_local_feed(vm, FEED_FILE, f"{VICTIM}/32\n")
+    h.force_ip_refetch(vm, f"{HEADER}_v4")
+    h.reload(vm, "update", timeout=timeout)
+    time.sleep(SETTLE_SECS)
+
+
+def _unblock_baseline(vm: SmokeVM, *, kill_on: bool, timeout: float = 600.0) -> None:
+    """Reset to the per-test baseline: victim UNBLOCKED, killstates flag set as wanted."""
+    h.write_local_feed(vm, FEED_FILE, f"{DUMMY}/32\n")
+    _set_ipcfg(vm, {"killstates": "on" if kill_on else ""})
+    h.force_ip_refetch(vm, f"{HEADER}_v4")
+    h.reload(vm, "update", timeout=timeout)
+
+
+# --------------------------------------------------------------------------- #
+# Module fixture: deploy once, configure a LAN reject IP rule (victim unblocked)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def ip_block_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg; wire a LAN Deny_Outbound (reject) IP rule, victim unblocked.
+
+    Given: the smoke VM is booted and the branch .pkg is available; civm is up.
+    When:  we deploy and inject one IP block feed (header ``pfbkillstates``) whose alias
+           starts with only DUMMY (so the rule is built but the victim is NOT blocked),
+           on the LAN interface with logging on.
+    Then:  the module VM is ready: the reject rule exists, the victim is reachable enough
+           for civm to create a firewall state to it.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+
+    h.deploy(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+
+    feed = h.write_local_feed(smoke_vm, FEED_FILE, f"{DUMMY}/32\n")
+    h.inject(
+        smoke_vm,
+        h.IpCase(aliasname=HEADER, feed_url=feed, action="Deny_Outbound", family="v4", header=HEADER),
+    )
+    # FLOATING rule (inject wired the interface to wan): enable_float flips Deny_Outbound to
+    # a floating `block out quick` on WAN that catches the client's forwarded traffic without
+    # disturbing the LAN allow. Global IP logging on so the block is visible in filter.log.
+    # outbound_deny_action defaults to 'reject'.
+    _set_ipcfg(smoke_vm, {"enable_float": "on", "enable_log": "on"})
+    h.reload(smoke_vm, "update")
+    yield smoke_vm
+
+
+# --------------------------------------------------------------------------- #
+# Test 1: killstates OFF ⇒ the pre-existing state SURVIVES the block
+# --------------------------------------------------------------------------- #
+
+
+def test_killstates_off_preserves_state_bypassing_new_block(ip_block_vm: SmokeVM, client_vm: SmokeVM) -> None:
+    """killstates OFF: a state created before the block SURVIVES the update (the gotcha).
+
+    Given: a LAN reject rule whose alias does NOT yet contain the victim, Clear-States OFF,
+           and a civm connection that created a firewall state to the victim.
+    When:  the victim is added to the block alias and pfBlockerNG runs an Update.
+    Then:  the pre-existing state is STILL present — pf matches it before rules, so that
+           flow bypasses the brand-new block.
+    And:   the victim IS in the live block alias (the rule is genuinely active) — proving the
+           survival is state-preservation, not an inert rule.
+    """
+    vm = ip_block_vm
+    _unblock_baseline(vm, kill_on=False)
+
+    # When: civm creates a state to the still-unblocked victim.
+    before = _establish_victim_state(vm, client_vm)
+
+    # When: block the victim (Clear-States OFF).
+    _block_victim(vm)
+
+    # Then: the pre-existing state SURVIVED (killstates off) — pf matches it before rules,
+    # so that flow keeps bypassing the brand-new block.
+    after = _victim_states(vm)
+    assert VICTIM in after, (
+        f"killstates OFF must PRESERVE the existing state to {VICTIM}, but it was cleared.\n"
+        f"  before: {before!r}\n  after: {after!r}\n{_state_diag(vm)}"
+    )
+
+    # And: the block is genuinely loaded for NEW flows — the victim is in the live pf alias
+    # table the floating reject rule references (so the survival above is state-preservation,
+    # not an inert rule).
+    table = vm.ssh("/bin/sh", "-c", f"pfctl -t {ALIAS_TABLE} -T show 2>/dev/null | tr -d ' '", timeout=30).stdout
+    assert VICTIM in table, (
+        f"expected {VICTIM} in the live block alias {ALIAS_TABLE} (the rule is active), got:\n{table}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Test 2: killstates ON ⇒ the state is CLEARED so the block takes effect
+# --------------------------------------------------------------------------- #
+
+
+def test_killstates_on_clears_state_so_block_takes_effect(ip_block_vm: SmokeVM, client_vm: SmokeVM) -> None:
+    """killstates ON: pfBlockerNG kills the state on Update, so the block takes effect.
+
+    Given: a LAN reject rule whose alias does NOT yet contain the victim, Clear-States ON,
+           and a civm connection that created a firewall state to the victim.
+    When:  the victim is added to the block alias and pfBlockerNG runs an Update.
+    Then:  the state for the victim is GONE — pfBlockerNG's pfb_remove_states killed it,
+           so the existing flow now hits the reject too (no state to bypass the block).
+    """
+    vm = ip_block_vm
+    _unblock_baseline(vm, kill_on=True)
+
+    # When: civm creates a state to the still-unblocked victim.
+    before = _establish_victim_state(vm, client_vm)
+
+    # When: block the victim (Clear-States ON).
+    _block_victim(vm)
+
+    # Then: the state was KILLED (killstates on) — the block now applies to that flow too.
+    after = _victim_states(vm)
+    assert VICTIM not in after, (
+        f"killstates ON must CLEAR the state to {VICTIM} on update, but it survived.\n"
+        f"  before: {before!r}\n  after: {after!r}\n{_state_diag(vm)}"
+    )

--- a/tests/smoke/test_smoke_killstates.py
+++ b/tests/smoke/test_smoke_killstates.py
@@ -191,18 +191,18 @@ def _unblock_baseline(vm: SmokeVM, *, kill_on: bool, timeout: float = 600.0) -> 
 
 
 # --------------------------------------------------------------------------- #
-# Module fixture: deploy once, configure a LAN reject IP rule (victim unblocked)
+# Module fixture: deploy once, wire a floating WAN Deny_Outbound rule (victim unblocked)
 # --------------------------------------------------------------------------- #
 
 
 @pytest.fixture(scope="module")
 def ip_block_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:
-    """Deploy the branch .pkg; wire a LAN Deny_Outbound (reject) IP rule, victim unblocked.
+    """Deploy the branch .pkg; wire a floating WAN Deny_Outbound (reject) rule, victim unblocked.
 
     Given: the smoke VM is booted and the branch .pkg is available; civm is up.
     When:  we deploy and inject one IP block feed (header ``pfbkillstates``) whose alias
            starts with only DUMMY (so the rule is built but the victim is NOT blocked),
-           on the LAN interface with logging on.
+           as a floating rule (enable_float) with logging on.
     Then:  the module VM is ready: the reject rule exists, the victim is reachable enough
            for civm to create a firewall state to it.
     """
@@ -234,8 +234,8 @@ def ip_block_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer)
 def test_killstates_off_preserves_state_bypassing_new_block(ip_block_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """killstates OFF: a state created before the block SURVIVES the update (the gotcha).
 
-    Given: a LAN reject rule whose alias does NOT yet contain the victim, Clear-States OFF,
-           and a civm connection that created a firewall state to the victim.
+    Given: a floating WAN reject rule whose alias does NOT yet contain the victim, Clear-States
+           OFF, and a civm connection that created a firewall state to the victim.
     When:  the victim is added to the block alias and pfBlockerNG runs an Update.
     Then:  the pre-existing state is STILL present — pf matches it before rules, so that
            flow bypasses the brand-new block.
@@ -276,8 +276,8 @@ def test_killstates_off_preserves_state_bypassing_new_block(ip_block_vm: SmokeVM
 def test_killstates_on_clears_state_so_block_takes_effect(ip_block_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """killstates ON: pfBlockerNG kills the state on Update, so the block takes effect.
 
-    Given: a LAN reject rule whose alias does NOT yet contain the victim, Clear-States ON,
-           and a civm connection that created a firewall state to the victim.
+    Given: a floating WAN reject rule whose alias does NOT yet contain the victim, Clear-States
+           ON, and a civm connection that created a firewall state to the victim.
     When:  the victim is added to the block alias and pfBlockerNG runs an Update.
     Then:  the state for the victim is GONE — pfBlockerNG's pfb_remove_states killed it,
            so the existing flow now hits the reject too (no state to bypass the block).

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -6,11 +6,9 @@ Proves the §2.2 contract (as revised by Amendment 1) on a real pfSense CE VM:
   2. Toggle ON  ⇒ a ``pfblockerng`` key=value record per DNSBL block event in the
      dedicated /var/log/pfblockerng_syslog.log, emitted HOST-SIDE by
      ``pfb_daemon_filterlog`` — not by the chrooted python.
-  3. Toggle ON + IP path ⇒ a ``pfblockerng`` record per IP Block event. DEFERRED
-     (xfail) — the IP-block LIVE trigger needs harness work (a reachable non-infra
-     victim target + a WAN/floating rule; a LAN rule breaks civm connectivity).
-     The IP syslog mechanism is the same host-side path the DNSBL leg proves, and
-     ``pfb_syslog_format_ip`` is unit-tested. Tracked as a follow-up.
+  3. Toggle ON + IP path ⇒ a ``pfblockerng`` record per IP Block event, exercised
+     LIVE: civm reaches a blocked WAN-subnet IP through a floating, logged
+     Deny_Outbound rule on WAN, and the host daemon exports the act=block event.
   4. CSV logging is unchanged in both states (export is purely additive).
   5. The toggle takes effect LIVE — no service restart between flipping it and
      the next event (the daemon re-reads config on config.xml change).
@@ -41,7 +39,7 @@ from collections.abc import Iterator
 import pytest
 
 from . import helpers as h
-from .conftest import SmokeVM, _StubDnsServer
+from .conftest import PFSENSE_LAN_IP, SmokeVM, _StubDnsServer
 
 pytestmark = pytest.mark.smoke
 
@@ -67,11 +65,14 @@ IP_BLOCK_LOG = f"{PFB_LOGDIR}/ip_block.log"
 # Config path for the syslog export toggle (under the General settings section).
 CFG_GENERAL = "installedpackages/pfblockerng/config/0"
 
-# A test IP range whose pfBlockerNG block rule we trigger traffic against.
-# RFC 5737 TEST-NET-3 (203.0.113.0/24) — not routable, but pf still blocks
-# an outbound connection attempt if it matches an alias table for that range.
-TEST_IP_BLOCK_RANGE = "203.0.113.0/24"
-TEST_IP_BLOCK_DST = "203.0.113.1"
+# The IP the pfBlockerNG floating Deny_Outbound rule blocks, exercised by civm.
+# It MUST sit in the pfSense WAN subnet (10.10.0.0/24, the QEMU SLIRP net) so the
+# forwarded SYN is routed straight out the directly-connected WAN — a non-WAN
+# TEST-NET dst depends on the SLIRP default gateway (flaky/down in CI) and never
+# traverses the WAN-out path, so the rule never matches. .9 is unused: NOT the
+# SLIRP gateway (.1), the runner/stub-DNS/mock-feed host alias (.2), or DNS (.3).
+TEST_IP_BLOCK_RANGE = "10.10.0.9/32"
+TEST_IP_BLOCK_DST = "10.10.0.9"
 
 # Settle budget for the tail_pfb → daemon → syslogd → file path.
 FILTERLOG_SETTLE_SECS = 5.0
@@ -121,11 +122,12 @@ def deployed_vm(
         ),
     )
 
-    # IP feed (alias only; default WAN rule). NOTE: the IP-block LIVE leg is deferred
-    # (see test_syslog_on_ip_block_event_exported xfail + follow-up). A LAN-interface
-    # rule was found to break ALL civm->pfSense traffic (the LAN filter rebuild drops
-    # the permissive allow), and a WAN rule to an unreachable TEST-NET IP never logs;
-    # a clean live test needs a reachable non-infra target + a WAN/floating rule.
+    # IP feed: a floating, LOGGED Deny_Outbound rule for a WAN-subnet victim IP.
+    # inject() wires inbound/outbound_interface=wan (SMOKE_IP_IFACE);
+    # _enable_ip_floating_logged_rule then flips it to a floating `block out quick log`
+    # on WAN — which catches civm's forwarded SYN leaving WAN (a non-floating WAN rule
+    # is block-IN and never matches forwarded-out traffic; a LAN-interface rule breaks
+    # civm connectivity) and emits a filter.log line the daemon can export.
     _ip_feed_path = h.write_local_feed(smoke_vm, "pfb_syslog_ip.txt", f"{TEST_IP_BLOCK_RANGE}\n")
     h.inject(
         smoke_vm,
@@ -137,6 +139,7 @@ def deployed_vm(
             header="pfb_syslog_ip",
         ),
     )
+    _enable_ip_floating_logged_rule(smoke_vm)
 
     # Syslog export OFF (the default) at module start.
     _set_syslog_enabled(smoke_vm, on=False)
@@ -193,6 +196,37 @@ def _set_syslog_enabled(vm: SmokeVM, *, on: bool, timeout: float = 60.0) -> None
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(
             f"_set_syslog_enabled({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def _enable_ip_floating_logged_rule(vm: SmokeVM, *, timeout: float = 60.0) -> None:
+    """Make pfBlockerNG emit the IP deny rule as a FLOATING, LOGGED ``out`` rule.
+
+    Two ipsettings flags, both required for the IP-block syslog leg:
+
+    * ``enable_float``: inject() wires inbound/outbound_interface=wan (SMOKE_IP_IFACE).
+      A *non*-floating Deny_Outbound on WAN is a block-IN rule (pfblockerng.inc:8142) —
+      it never sees civm's forwarded traffic LEAVING via WAN. enable_float flips it to
+      ``direction=out`` (inc:8148): a floating ``block out quick`` on WAN that DOES match
+      the forwarded SYN. Floating-on-WAN also leaves the LAN allow intact — a
+      per-interface LAN rule rebuild drops the "allow LAN→any" and breaks civm's DNS.
+    * ``enable_log`` (global IP logging): pfBlockerNG only stamps ``log`` on the rule when
+      global logging is on or the list's aliaslog='enabled' (inc:8175). Without it the
+      rule blocks SILENTLY — no filter.log line — so the host filterlog daemon never sees
+      the event and nothing is exported. This is the flag the IP syslog leg hinges on.
+    """
+    snippet = (
+        f"$ip = config_get_path({h._php_str(h.CFG_IP_SETTINGS)}, array());\n"
+        "$ip['enable_float'] = 'on';\n"
+        "$ip['enable_log'] = 'on';\n"
+        f"config_set_path({h._php_str(h.CFG_IP_SETTINGS)}, $ip);\n"
+        "write_config('pfBlockerNG smoke: enable floating + logged IP rule');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_enable_ip_floating_logged_rule failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
         )
 
 
@@ -291,17 +325,23 @@ def syslog_export_state_snapshot(vm: SmokeVM) -> str:
 
 
 def _trigger_ip_block(client: SmokeVM, *, timeout: float = 30.0) -> None:
-    """Generate a pf-logged IP block by curling a blocked IP FROM the civm client.
+    """Generate a pf-logged IP block by curling the blocked WAN IP FROM civm.
 
     The block must be triggered by PASS-THROUGH traffic — a client BEHIND the
-    firewall (civm, 192.168.1.10) reaching a blocked WAN IP — not by the pfSense
-    box itself: pfBlockerNG's deny rule acts on forwarded traffic, so a curl from
-    pfSense's own stack would not hit it. civm's outbound to 203.0.113.1 is routed
-    out WAN and dropped+logged by the pfB rule (curl uses busybox/debian on civm).
+    firewall (civm) reaching the blocked WAN IP — not by pfSense's own stack: the
+    floating Deny_Outbound rule acts on forwarded traffic leaving WAN, so a curl
+    from pfSense itself would not hit it.
+
+    civm has TWO equal-metric default routes (mgmt ens4 via the QEMU mgmt SLIRP,
+    and LAN ens5 via pfSense), so a bare curl may egress the mgmt NIC and never
+    reach pfSense. Pin a host route for the victim via pfSense (192.168.1.1) out
+    the LAN device first, forcing the SYN civm -> pfSense -> WAN-out -> the block.
     """
     client.ssh(
         "/bin/sh",
         "-c",
+        "dev=$(ip -4 -o addr show | awk '/192\\.168\\.1\\./{print $2; exit}'); "
+        f'ip route replace {TEST_IP_BLOCK_DST}/32 via {PFSENSE_LAN_IP} dev "$dev" 2>/dev/null || true; '
         f"curl --connect-timeout 2 --max-time 4 http://{TEST_IP_BLOCK_DST}/ >/dev/null 2>&1 || true",
         timeout=timeout,
     )
@@ -396,39 +436,33 @@ def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM
 
 
 # --------------------------------------------------------------------------- #
-# Test 2: ON ⇒ IP Block event exported to the dedicated file
+# Test 2: ON ⇒ IP Block event exported to the dedicated file (LIVE).
 #
-# DEFERRED (xfail) — the IP-block LIVE leg needs harness work, tracked as a
-# follow-up. The IP syslog *mechanism* is the same host-side pfb_syslog_event +
-# daemon path proven live by the DNSBL leg, and pfb_syslog_format_ip is unit-
-# tested (tests/php/SyslogFormatTest.php). What is missing is a way to TRIGGER a
-# pf-logged IP block from civm in the single-runner smoke:
-#   * a LAN-interface pfB rule breaks ALL civm->pfSense traffic (the LAN filter
-#     rebuild drops the permissive allow; civm DNS/ICMP then hit the default
-#     block, rule 1000000103 — filterlog-confirmed);
-#   * a WAN rule to the unreachable TEST-NET IP never logs (the SYN never
-#     traverses the WAN-outbound path);
-#   * the only IP civm can reach through pfSense is the runner (10.10.0.2), which
-#     is the stub DNS + mock-feed server — blocking it breaks the harness.
-# The follow-up adds a reachable, non-infra victim target + a WAN/floating rule
-# (floating inbound/outbound/any) and un-xfails this.
+# The IP-block leg is exercised live via a FLOATING, LOGGED Deny_Outbound rule on
+# WAN (_enable_ip_floating_logged_rule) blocking a WAN-subnet victim (TEST_IP_BLOCK_DST):
+#   * a LAN-interface pfB rule was found to break ALL civm->pfSense traffic (the
+#     LAN filter rebuild drops the permissive allow; civm DNS/ICMP then hit the
+#     default block, rule 1000000103 — filterlog-confirmed);
+#   * a NON-floating WAN Deny_Outbound is a block-IN rule (inc:8142), so it never
+#     matches civm's forwarded traffic LEAVING via WAN;
+#   * a non-WAN TEST-NET dst depends on the (flaky) SLIRP default gateway and
+#     never traverses the WAN-out path;
+#   * without global IP logging the rule blocks SILENTLY (no `log`, inc:8175), so
+#     filter.log/the daemon never see it — enable_log is what makes it exportable.
+# The floating `block out quick log` on WAN matches the forwarded SYN AND leaves the
+# LAN allow intact (it matches only dst=<alias>); the WAN-subnet victim is
+# directly connected so it routes out WAN with no default-gateway dependency.
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(
-    reason="IP-block live trigger needs a reachable non-infra target + WAN/floating rule "
-    "(LAN rule breaks civm connectivity). Tracked as a follow-up; mechanism proven by the "
-    "DNSBL leg + pfb_syslog_format_ip unit test.",
-    strict=False,
-)
 def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """ON ⇒ a pfblockerng record per IP Block event in the dedicated file.
 
-    Given: an IP block alias covering 203.0.113.0/24; syslog export ON (from the
-           DNSBL test); the filterlog daemon running; the civm client behind the
-           firewall.
-    When:  the civm client (192.168.1.10) curls a blocked IP (pass-through traffic
-           pf blocks + logs — NOT pfSense's own traffic, which the rule misses).
+    Given: a floating Deny_Outbound rule covering TEST_IP_BLOCK_RANGE; syslog export
+           ON (from the DNSBL test); the filterlog daemon running; the civm client
+           behind the firewall.
+    When:  the civm client curls the blocked WAN IP (pass-through traffic pf blocks
+           + logs on WAN-out — NOT pfSense's own traffic, which the rule misses).
     Then:  a new pfblockerng record appears in the dedicated file with an IP action
            token (act=block/pass/match).
     And:   the CSV ip_block.log is also written (additive).
@@ -448,7 +482,7 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
         ps = vm.ssh("/bin/ps", "-wax", timeout=30)
         daemon_running = "pfblockerng.inc filterlog" in ps.stdout
         pfctl = vm.ssh("/sbin/pfctl", "-t", "pfB_pfb_syslog_iptest_v4", "-T", "show", timeout=30)
-        alias_populated = TEST_IP_BLOCK_RANGE in pfctl.stdout or "203.0.113" in pfctl.stdout
+        alias_populated = TEST_IP_BLOCK_DST in pfctl.stdout
         if not alias_populated:
             pytest.skip(
                 f"IP block alias pfB_pfb_syslog_iptest_v4 not populated with {TEST_IP_BLOCK_RANGE} "
@@ -479,7 +513,7 @@ def test_syslog_off_no_new_records(deployed_vm: SmokeVM, client_vm: SmokeVM) -> 
 
     Before/after proof: first assert ON produced records (true from prior tests),
     then disable LIVE and assert the count does NOT increase. Exercised via the
-    DNSBL leg (the IP-block live trigger is deferred — see the xfail above).
+    DNSBL leg (a re-probe of the blocked domain from civm).
 
     Given: syslog export ON (from prior tests), records already in the dedicated file.
     When:  log_syslog set OFF (write_config ONLY — no restart); the blocked domain is

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -477,7 +477,7 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
 
     _trigger_ip_block(client_vm)
 
-    line = _wait_for_event(vm, baseline_len=len(before), want=("act=",), any_of=IP_ACT_TOKENS)
+    line = _wait_for_event(vm, baseline_len=len(before), want=(), any_of=IP_ACT_TOKENS)
     if not line:
         ps = vm.ssh("/bin/ps", "-wax", timeout=30)
         daemon_running = "pfblockerng.inc filterlog" in ps.stdout


### PR DESCRIPTION
## What

Adds live two-VM smoke coverage for two pfBlockerNG IP-block behaviours that were previously unverified end-to-end. Both are **smoke-only** (dispatch/schedule), so they do not run in PR CI; they were validated on a local two-VM Debian/KVM box (pfSense CE 2.8 + civm), CE leg green.

### 1. IP-block syslog export leg (ADR-38)

Un-xfails `test_syslog_on_ip_block_event_exported`. The IP leg now blocks a WAN-subnet victim via a **floating, logged** Deny_Outbound rule and asserts the host filterlog daemon exports the `act=block` event — the same host-side path the DNSBL leg already proved.

Mechanics nailed down live:

- A non-floating WAN Deny_Outbound is a `block in` rule (`inc:8142`) that never matches the client's forwarded traffic *leaving* WAN; `enable_float` flips it to a floating `block out quick` (`direction=out`, `inc:8148`) that does — without a LAN-interface rule.
- Without global IP logging the rule blocks **silently** (no `log`, `inc:8175`), so the daemon never sees it; `enable_log` makes the event exportable.
- The victim sits in the WAN subnet so the SYN routes out WAN with no dependency on the (flaky in CI) SLIRP default gateway; the civm trigger pins a host route via pfSense.

ADR-38 §A2.4 updated: the IP-block live leg is now a CI smoke leg, not a deferred out-of-CI item.

### 2. Clear-Firewall-States (`killstates`) on IP block

Two new cases (`test_smoke_killstates.py`) proving the classic pf state-preservation gotcha and pfBlockerNG's remedy:

- **killstates OFF** — a firewall state created *before* an IP is blocked **survives** the update that blocks it (pf matches established flows by state before rules), so that flow keeps bypassing the brand-new block.
- **killstates ON** — `pfb_remove_states` kills the state for the newly-blocked IP on Update (`pfctl -k`), so the block takes effect for the existing flow too.

Mechanics established live:

- The rule is **floating**, not on the LAN interface: a LAN-interface pfB IP rule was found to drop the baked "Default allow LAN to any" rule on a *second* reload, cutting the client off entirely. A floating Deny_Outbound blocks the client's forwarded traffic without touching the LAN ruleset.
- The victim is a **public** IP (RFC 5737 TEST-NET-3): `killstates` deliberately excludes RFC1918 / local-subnet / reserved IPs (`inc:8827-8838`).
- The block is a feed-content change on an *existing* rule, so `filter_configure` stays FALSE and `killstates` is eligible to run (`inc:15081`); `force_ip_refetch` defeats the per-feed reuse gate so the edited feed is re-parsed.

## Test evidence (local two-VM box)

- `test_syslog_export.py` — 4 passed (incl. the un-xfailed IP leg).
- `test_smoke_killstates.py` — 2 passed; killstates-OFF observes the state surviving, killstates-ON observes `Removed 1 state(s) for [203.0.113.9]` and the state gone — contrasting branches, real before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
