### PR TITLE
pfblockerng: ADR-28 cleanups — dead else-branch + greyout dedup (#524)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1009,8 +1009,6 @@ EOF
 		elif [ "${ccblack}" = 'match' ]; then
 			sed 's/$/0\/24/' "${dupfile}" >> "${tempmatchfile}"
 			sed 's/^/\!/' "${tempfile2}" >> "${tempmatchfile}"
-		else
-			:
 		fi
 	fi
 

--- a/src/usr/local/www/pfblockerng/pfBlockerNG.js
+++ b/src/usr/local/www/pfblockerng/pfBlockerNG.js
@@ -118,20 +118,25 @@ function pfb_remove_label() {
 
 
 // Greyout 'Disabled' State fields
-function pfb_chg_state_bkgd() {
+// Greyout selects whose value is 'Disabled' (live on change + on initial load).
+function pfb_greyout(sel) {
 
-	$("select[id^='state-']").click(function() {
+	$(sel).click(function() {
 		if ($(this).val() == 'Disabled') {
 			$(this).css('background-color', 'lightgrey');
 		} else {
 			$(this).css('background-color', '');
 		}
 	});
-	$("select[id^='state-']").each(function() {
+	$(sel).each(function() {
 		if ($(this).val() == 'Disabled') {
 			$(this).css('background-color', 'lightgrey');
 		}
 	});
+}
+
+function pfb_chg_state_bkgd() {
+	pfb_greyout("select[id^='state-']");
 }
 
 
@@ -152,18 +157,7 @@ events.push(function() {
 	pfb_remove_label();
 
 	// Greyout 'Disabled' Action fields
-	$("select[id^='action']").click(function() {
-		if ($(this).val() == 'Disabled') {
-			$(this).css('background-color', 'lightgrey');
-		} else {
-			$(this).css('background-color', '');
-		}
-	});
-	$("select[id^='action']").each(function() {
-		if ($(this).val() == 'Disabled') {
-			$(this).css('background-color', 'lightgrey');
-		}
-	});
+	pfb_greyout("select[id^='action']");
 
 	// Greyout 'Disabled' State fields
 	pfb_chg_state_bkgd();

--- a/tests/smoke/ui/test_browser.py
+++ b/tests/smoke/ui/test_browser.py
@@ -21,9 +21,10 @@ and ``src/usr/local/www/widgets/javascript/pfblockerng.js``:
 * the jQuery-UI autocomplete bound to ``#aliasports_in`` (pfBlockerNG.js:253-255,
   ``source: portsarray``): focusing the field and typing surfaces a
   ``.ui-autocomplete`` menu in the DOM.
-* ``pfb_chg_state_bkgd()`` (pfBlockerNG.js:124-138): a ``select[id^='state-']``
-  whose value is ``Disabled`` is greyed (``background-color: lightgrey``) on
-  load; selecting a non-``Disabled`` value and clicking the select clears it.
+* ``pfb_chg_state_bkgd()`` -> ``pfb_greyout()`` in ``pfBlockerNG.js``: a
+  ``select[id^='state-']`` whose value is ``Disabled`` is greyed
+  (``background-color: lightgrey``) on load; selecting a non-``Disabled`` value
+  and clicking the select clears it.
 * the dashboard widget (``widgets/widgets/pfblockerng.widget.php`` +
   ``widgets/javascript/pfblockerng.js``): the widget renders ``#pfblockerngack``,
   ``#formicons``, ``.PFBSTATUS`` and the ``#pfBNG-table`` body.


### PR DESCRIPTION
## What

Two small behaviour-preserving cleanups from the #524 audit:

1. **`pfblockerng.sh` — drop a dead `else: :` no-op** in `reputation_max()` (the `ccblack` block/match/`else` chain; the `else` arm did nothing).
2. **`pfBlockerNG.js` — dedup the 'Disabled' greyout** into `pfb_greyout(sel)`. The action-field greyout was a verbatim copy of `pfb_chg_state_bkgd()`'s body (only the selector differed); both now call `pfb_greyout(sel)`. `pfb_chg_state_bkgd()` stays as a thin wrapper so its call sites are unchanged.

## Why

Tracked in #524 (ADR-28 §3/§4 code-quality cleanups). Net −10 lines, no behaviour change.

## Testing

Behaviour-preserving → existing coverage is the regression oracle:

- Shell: `pfblockerng_reputation_max_spec.sh` stays green (3/3); full shellspec suite 116 pass / 2 pre-existing skips; `sh -n` + ShellCheck clean.
- JS: the extraction is a 1:1 equivalent (same handler bodies, selector parameterized); `node --check` clean. The rendered HTML is unchanged, so the Tier-A `ui_render` gate is unaffected; the interactive greyout is exercised by the existing Tier-B browser suite (`tests/smoke/ui/test_browser.py`), which loads this file — no new behaviour to add a test for.

## Note on the other #524 items

Verified and intentionally **not** included: `pkg_nv` now has two callers (justified DRY, not a one-caller wrapper); `DISK_NAME` collapse reduces clarity for −1 line; `_LruCache` dunders are used; `IdnMode.default()` is part of the ADR-28 enum contract; `strpos`→`str_contains` has zero runtime benefit. Details on #524.
