### PR TITLE
pfb_unbound: drop unused _regex_exceeds_static_cap helper (#524)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4394,18 +4394,6 @@ def _regex_is_catastrophic_shape(pattern: str) -> bool:
     return budget > _REGEX_BUDGET_MAX
 
 
-def _regex_exceeds_static_cap(pattern: str) -> bool:
-    """Pure static-cap check (NO execution): True if ``pattern`` is over the length
-    ceiling OR carries a catastrophic shape. Used at LOAD time for the opt-in "Limit
-    long/complex regex" setting -- when the setting is OFF the length ceiling is NOT
-    enforced (long-but-safe patterns load). The catastrophic-shape half is also enforced
-    UNCONDITIONALLY via ``_regex_is_catastrophic_shape`` regardless of this setting; this
-    wrapper folds in the additional length ceiling for the gated path."""
-    if len(pattern) > REGEX_STATIC_LEN_CAP:
-        return True
-    return _regex_is_catastrophic_shape(pattern)
-
-
 def _regex_timed_search(pattern: Any, q_name: str) -> tuple[Any, float]:
     """Run ``pattern.search(q_name)`` and return ``(match, elapsed_ms)`` where
     ``elapsed_ms`` is per-thread CPU time (``time.thread_time``) when available, else

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -239,10 +239,13 @@ class DnsblCase:
                        and count toward pfb_py_regex_count.
       regex_cap     -> the opt-in "Limit long/complex regex" static cap
                        (CFG_DNSBL_SETTINGS/pfb_regex_cap 'on', inc:2685 -> ini
-                       regex_cap=on). When on, an over-length (>200) / nested-
-                       quantifier / alternation-overlap pattern is DROPPED at load
-                       for FEED and USER regex (pfb_unbound.py:_regex_exceeds_
-                       static_cap), so it never enters regexDB or the admitted count.
+                       regex_cap=on). When on, an over-length (>200) pattern is
+                       DROPPED at load for FEED and USER regex (the inlined
+                       len > REGEX_STATIC_LEN_CAP check), so it never enters regexDB
+                       or the admitted count. Catastrophic shapes (nested-quantifier
+                       / alternation-overlap) are dropped always-on via
+                       pfb_unbound.py:_regex_is_catastrophic_shape, independent of
+                       this flag.
       custom_domains -> the DNSBL Group "Custom_List" (the list's base64 'custom'
                        field). pfBlockerNG auto-generates a synthetic
                        '{aliasname}_custom' row from it (inc:7752) which the manifest

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -38,7 +38,6 @@ from pfb_unbound import (
     PRIO_FEED_BLOCK,
     RegexRule,
     _dnsbl_compile_regex_rules,
-    _regex_exceeds_static_cap,
     _regex_is_catastrophic_shape,
     _scan_allow_regex_band,
     evaluate_domain,
@@ -187,26 +186,6 @@ class TestCatastrophicShapeHeuristic:
         assert _regex_is_catastrophic_shape(_long_benign_pattern()) is False
         # And a SHORT catastrophic shape IS flagged regardless of being well under length.
         assert _regex_is_catastrophic_shape(r"(a+)+") is True
-
-
-# --------------------------------------------------------------------------- #
-# (1b) STATIC LENGTH CAP -- combined length-OR-shape helper (gated path)
-# --------------------------------------------------------------------------- #
-class TestStaticCapHeuristic:
-    def test_normal_pattern_passes(self) -> None:
-        assert _regex_exceeds_static_cap(r"^(.+\.)?doubleclick\.net$") is False
-        assert _regex_exceeds_static_cap(r"ad[0-9]\.example\.com$") is False
-
-    def test_over_length_flagged(self) -> None:
-        long_pat = "a" * (pfb_unbound.REGEX_STATIC_LEN_CAP + 1)
-        assert _regex_exceeds_static_cap(long_pat) is True
-        # Exactly at the cap is allowed (strictly greater is the cap).
-        assert _regex_exceeds_static_cap("a" * pfb_unbound.REGEX_STATIC_LEN_CAP) is False
-
-    def test_catastrophic_shape_also_flagged(self) -> None:
-        # The combined helper folds in the shape gate too (used only on the gated path).
-        for pat in (r"(a+)+$", r"^(a|a)+$", r"(a+)(a+)+", r"a{500}{500}"):
-            assert _regex_exceeds_static_cap(pat) is True, pat
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Remove the unused `_regex_exceeds_static_cap()` helper from `pfb_unbound.py` (and its `TestStaticCapHeuristic` test class). −33 lines.

## Why

The ADR-07 P7 regex-safety load path does **not** use this combined helper, and can't cleanly — production keeps the two static-cap tiers **separate**:

- **Always-on shape gate** — `_regex_is_catastrophic_shape()` drops nested/overlapping/stacked quantifier shapes (+ the complexity budget) unconditionally, with its own "catastrophic shape" log line.
- **Opt-in length cap** — the inlined `pfb["regex_cap"] and len(pattern) > REGEX_STATIC_LEN_CAP` check, with its own "static length cap" log line, gated behind the "Limit long/complex regex" setting.

`_regex_exceeds_static_cap()` folded both into one boolean (`len > CAP OR shape`), which doesn't fit that two-tier gating — so production inlines the two checks at both load sites instead. The helper had **zero production callers**; it survived only for its own test.

`_regex_is_catastrophic_shape()` and the length-cap behaviour keep their existing coverage (the load-site drop tests, the shape-gate tests). The always-on runtime warn/evict timing layer is untouched.

Tracked in #524 (the one item left for a maintainer decision; the decision is: remove, since wiring prod to call it would conflate the two tiers).

## Testing

Behaviour-preserving (dead-code removal). `tests/test_adr07_regex_safety.py` stays green (26 pass, the 3 helper-only tests removed); full suite **1880 pass / 2 pre-existing skips**; ruff + ruff format + mypy clean.
