### PR TITLE
pfblockerng: detect local-file feed content changes and re-ingest (#533)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3199,6 +3199,61 @@ function pfb_hook_trigger($cron) {
 }
 
 
+// Detect a content change in a LOCAL-FILE feed and force its re-ingest (issue #533).
+//
+// A remote feed is re-fetched + re-parsed when it changes (pfb_download sets the
+// '{header}.update' marker on a real download); a local-file feed has no such signal, so
+// the IP/DNSBL reuse gate keeps serving the cached parse and an edited file is never picked
+// up until '.update' is forced or the cache cleared. This restores parity: for a feed whose
+// URL is an actual local file, compare the source against the last ingest and, on a change,
+// touch '{header}.update' so the existing gate re-reads/re-parses it.
+//
+// Change detection is a full md5 of the source content compared against the md5 recorded at
+// the last ingest. We deliberately do NOT gate on mtime: PHP's filemtime() is whole-second
+// granular (no sub-second in core PHP) AND stat-cached per-process, so an mtime gate both
+// misses a same-second rewrite and risks reading a stale timestamp. md5_file() reads the
+// content directly (no stat cache) and has no granularity blind spot; hashing a local file
+// each pass is cheap and only local-file feeds reach here (remote feeds are untouched).
+//
+// Returns TRUE when a change was detected (and '{header}.update' was touched).
+function pfb_localfile_feed_changed($url, $pfbfolder, $header) {
+
+	$url = trim((string) $url);
+
+	// Only ACTUAL local file paths -- anything with a scheme (http/https/ftp/rsync, or
+	// file://) is a URL handled by the download path, not here. A custom (inline) list has
+	// no URL and is skipped too.
+	if ($url === '' || parse_url($url, PHP_URL_SCHEME) !== NULL) {
+		return FALSE;
+	}
+
+	$real = realpath($url);
+	if ($real === FALSE || !is_file($real)) {
+		return FALSE;
+	}
+
+	$cur_md5 = md5_file($real);
+	if ($cur_md5 === FALSE) {
+		return FALSE;
+	}
+
+	// Last-ingest fingerprint: the source's md5, persisted next to the feed's cache. The
+	// '.lmd5' marker is excluded from the '*.txt' member glob, like '.update'/'.fail'.
+	$marker		= "{$pfbfolder}/{$header}.lmd5";
+	$stored_md5	= is_file($marker) ? trim((string) @file_get_contents($marker)) : '';
+
+	$changed = ($cur_md5 !== $stored_md5);
+	if ($changed) {
+		// Force the reuse gate below to re-read/re-parse, and record the new baseline so an
+		// unchanged file is not re-flagged next pass.
+		touch("{$pfbfolder}/{$header}.update");
+		@file_put_contents($marker, $cur_md5, LOCK_EX);
+	}
+
+	return $changed;
+}
+
+
 // Record failed IP/DNSBL Feed parse errors
 function pfb_parsed_fail($header, $line='', $oline, $logfile) {
 
@@ -12124,6 +12179,10 @@ function sync_package_pfblockerng($cron='') {
 							$pfbreuse	= $pfbarr['reuse'];
 							$logtab		= $pfbarr['logtab'];
 
+							// issue #533: a changed LOCAL-FILE feed has no download-side change
+							// signal; detect it here so the reuse gate below re-reads/re-parses it.
+							pfb_localfile_feed_changed($row['url'], $pfbfolder, $header);
+
 							if (file_exists("{$pfbfolder}/{$header}.txt") &&
 							    !file_exists("{$pfbfolder}/{$header}.update") &&
 							    !file_exists("{$pfbfolder}/{$header}.fail") &&
@@ -13770,6 +13829,10 @@ function sync_package_pfblockerng($cron='') {
 						if ($row['format'] == 'asn' && file_exists("{$pfb['dbdir']}/asn.update")) {
 							touch("{$pfbfolder}/{$header}.update");
 						}
+
+						// issue #533: a changed LOCAL-FILE DNSBL feed has no download-side
+						// change signal; detect it here so the reuse gate below re-parses it.
+						pfb_localfile_feed_changed($row['url'], $pfbfolder, $header);
 
 						if (file_exists("{$pfbfolder}/{$header}.txt") &&
 						    !file_exists("{$pfbfolder}/{$header}.update") &&

--- a/tests/php/LocalFileFeedChangedTest.php
+++ b/tests/php/LocalFileFeedChangedTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_localfile_feed_changed() — issue #533.
+ *
+ * Local-file feeds had no content-change detection: a remote feed is re-fetched + re-parsed
+ * when it changes (pfb_download sets the '{header}.update' marker), but a local file was
+ * reused from cache until '.update' was forced or the cache cleared, so edits were never
+ * picked up. This helper restores parity — for a feed whose URL is an actual local file it
+ * compares the source's md5 against the md5 recorded at the last ingest and touches
+ * '{header}.update' on a real change, so the existing IP/DNSBL reuse gate re-parses it.
+ *
+ * Detection is content-based (a full md5), deliberately not mtime-gated: PHP's filemtime() is
+ * whole-second granular and stat-cached, which would miss a same-second rewrite. The live
+ * re-parse driven by the marker is the smoke's job (ADR-04); here every branch (first-seen,
+ * unchanged, changed, non-local URL, missing/empty path) is pinned off-appliance.
+ */
+#[CoversFunction('pfb_localfile_feed_changed')]
+final class LocalFileFeedChangedTest extends TestCase
+{
+	private string $dir;
+	private string $src;
+	private string $header = 'feedx';
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_lff_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0755, true);
+		$this->src = $this->dir . '/source.txt';
+	}
+
+	protected function tearDown(): void
+	{
+		array_map('unlink', glob($this->dir . '/*') ?: []);
+		@rmdir($this->dir);
+	}
+
+	private function updateMarker(): string
+	{
+		return "{$this->dir}/{$this->header}.update";
+	}
+
+	private function lmd5(): string
+	{
+		return "{$this->dir}/{$this->header}.lmd5";
+	}
+
+	private function call(string $url): bool
+	{
+		return pfb_localfile_feed_changed($url, $this->dir, $this->header);
+	}
+
+	public function testFirstSeenLocalFileIsTreatedAsChanged(): void
+	{
+		// Given a local feed never ingested before (no .lmd5 baseline)...
+		file_put_contents($this->src, "1.1.1.1\n");
+		// When the helper runs...
+		$changed = $this->call($this->src);
+		// Then it reports a change, touches .update (forcing the reuse gate to re-parse),
+		// and records the source md5 as the baseline.
+		$this->assertTrue($changed, 'a first-seen local feed must be treated as changed');
+		$this->assertFileExists($this->updateMarker());
+		$this->assertSame(md5_file($this->src), trim((string) file_get_contents($this->lmd5())));
+	}
+
+	public function testUnchangedContentIsNotReingested(): void
+	{
+		file_put_contents($this->src, "1.1.1.1\n");
+		$this->call($this->src);            // establish the baseline
+		@unlink($this->updateMarker());     // clear the marker the first call set
+		// When the content is byte-identical, no re-parse is forced.
+		$changed = $this->call($this->src);
+		$this->assertFalse($changed, 'an unchanged feed must not be re-ingested');
+		$this->assertFileDoesNotExist($this->updateMarker());
+	}
+
+	public function testChangedContentForcesReingest(): void
+	{
+		file_put_contents($this->src, "1.1.1.1\n");
+		$this->call($this->src);
+		@unlink($this->updateMarker());
+		// When the content changes (even with the same byte length), it must be re-ingested.
+		file_put_contents($this->src, "2.2.2.2\n");
+		$changed = $this->call($this->src);
+		$this->assertTrue($changed, 'a changed local feed must be re-ingested');
+		$this->assertFileExists($this->updateMarker());
+		$this->assertSame(md5_file($this->src), trim((string) file_get_contents($this->lmd5())));
+	}
+
+	public function testRemoteUrlIsIgnored(): void
+	{
+		// A real URL is the download path's job, not local-file change detection.
+		$this->assertFalse($this->call('https://example.com/list.txt'));
+		$this->assertFileDoesNotExist($this->updateMarker());
+	}
+
+	public function testEmptyOrMissingPathIsIgnored(): void
+	{
+		$this->assertFalse($this->call(''), 'a custom/inline list has no URL');
+		$this->assertFalse($this->call("{$this->dir}/does-not-exist.txt"), 'a missing file is not a change');
+		$this->assertFileDoesNotExist($this->updateMarker());
+	}
+}

--- a/tests/smoke/test_smoke_localfeed.py
+++ b/tests/smoke/test_smoke_localfeed.py
@@ -1,0 +1,96 @@
+"""Live-VM smoke: a changed LOCAL-FILE feed is re-ingested on a plain update (issue #533).
+
+Before the fix, pfBlockerNG only re-parsed a feed when the download path flagged it changed
+(remote feeds) or the cache was force-invalidated; an edited *local-file* feed was reused from
+cache and never picked up. The fix (`pfb_localfile_feed_changed`) compares the source's md5
+against the last ingest and touches `{header}.update` on a change, so the existing reuse gate
+re-parses it — WITHOUT the `force_ip_refetch` marker the cache reuse otherwise requires.
+
+The assertion target is pfBlockerNG's parsed member file (``deny/<header>_v4.txt``): that is
+the direct output of re-parsing the feed, and proves the re-ingest without depending on the
+pf alias-table load (a separate pfSense filter-reload concern in the headless package
+context). The first ingest is bootstrapped with ``force_ip_refetch`` (the cache-reuse gate
+blocks a brand-new local feed otherwise); the change under test is then a PLAIN ``update``
+with no force — run pre-fix it FAILS (member keeps IP_A), post-fix it PASSES (member is IP_B).
+
+DESELECTED from the default ``python -m pytest`` (smoke-only). Run via::
+
+    python -m pytest tests/smoke/test_smoke_localfeed.py -m smoke --override-ini="addopts="
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+
+pytestmark = pytest.mark.smoke
+
+# RFC 5737 TEST-NET-3 (inert). IP_A is the initial feed entry; IP_B replaces it.
+IP_A = "203.0.113.10"
+IP_B = "203.0.113.20"
+HEADER = "pfblocalfeed"
+FEED_FILE = "pfb_localfeed_ip.txt"
+# pfBlockerNG's parsed member file for this IPv4 feed (the deny-dir cache it serves from).
+MEMBER = f"/var/db/pfblockerng/deny/{HEADER}_v4.txt"
+
+
+def _member(vm: SmokeVM, *, timeout: float = 30.0) -> str:
+    """The parsed member file pfBlockerNG built from the feed (empty string if absent)."""
+    return vm.ssh(
+        "/bin/sh", "-c", f"cat {MEMBER} 2>/dev/null || true", timeout=timeout
+    ).stdout
+
+
+def test_localfile_ip_feed_change_is_reingested(smoke_vm: SmokeVM) -> None:
+    """A plain update re-ingests an edited local IP feed — no force/clear needed (#533).
+
+    Given: an IP feed whose URL is a local file containing IP_A, ingested into its member file
+           (bootstrapped with force_ip_refetch, since the reuse gate blocks a new local feed).
+    When:  the local file is edited in place to IP_B and a PLAIN pfBlockerNG ``update`` runs
+           (NOT force_ip_refetch, NOT clearip — the path that previously reused the cache).
+    Then:  the parsed member file now contains IP_B and no longer IP_A — the edit was detected
+           by the local-file md5 change check and re-parsed.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+
+    vm = smoke_vm
+    h.deploy(vm)
+
+    # Given: a local-file IP feed with IP_A. Bootstrap the first ingest (force past the reuse
+    # gate that blocks a brand-new local feed); this also seeds the .lmd5 md5 baseline.
+    feed = h.write_local_feed(vm, FEED_FILE, f"{IP_A}/32\n")
+    h.inject(
+        vm,
+        h.IpCase(
+            aliasname=HEADER,
+            feed_url=feed,
+            action="Deny_Outbound",
+            family="v4",
+            header=HEADER,
+        ),
+    )
+    h.force_ip_refetch(vm, f"{HEADER}_v4")
+    h.reload(vm, "update")
+    before = _member(vm)
+    assert IP_A in before, (
+        f"precondition: expected {IP_A} in the parsed member {MEMBER}, got:\n{before!r}"
+    )
+
+    # When: edit the local file in place to IP_B and run a PLAIN update (no force_ip_refetch).
+    h.write_local_feed(vm, FEED_FILE, f"{IP_B}/32\n")
+    h.reload(vm, "update")
+
+    # Then: the edit was detected (md5 change) and re-parsed into the member file.
+    after = _member(vm)
+    assert IP_B in after, (
+        f"a changed local feed was NOT re-ingested on a plain update — {IP_B} missing from "
+        f"{MEMBER} (the #533 local-file change detection did not fire).\n  after: {after!r}"
+    )
+    assert IP_A not in after, (
+        f"the stale entry {IP_A} survived the re-ingest of the edited local feed.\n  after: {after!r}"
+    )


### PR DESCRIPTION
## What

Fixes #533 — a feed whose URL is a **local file** had no content-change detection, so an edited local feed was reused from cache and never re-ingested until `.update` was forced or the cache cleared. Remote feeds get re-fetched + re-parsed via the download path; local files had no equivalent signal.

Adds `pfb_localfile_feed_changed()`: for a feed whose URL is an actual local file, it compares the source's md5 against the md5 recorded at the last ingest (`{header}.lmd5`) and, on a change, touches `{header}.update` so the existing reuse gate re-reads/re-parses it. Wired into **both** the IP and DNSBL feed loops (both reuse gates were identically affected).

## Design notes

- **Content md5, not mtime.** PHP `filemtime()` is whole-second granular (no sub-second in core PHP) and stat-cached per-process, so an mtime gate would miss a same-second rewrite and could read a stale timestamp. `md5_file()` reads content directly (no stat cache) with no granularity blind spot; only local-file feeds reach here, so the per-update hash is negligible.
- **A dedicated `.lmd5` marker, not the `.orig` copy.** `.orig` is the *post-download, decompressed* copy — for a gzip/bzip2 local feed it differs from the raw source, so comparing the source to it would false-positive and re-parse on every run. `.lmd5` hashes the raw source consistently, so it's correct for plain **and** compressed local feeds (cost: one 32-byte marker, excluded from the `*.txt` member glob like `.update`/`.fail`).
- Non-local URLs (http/https/ftp/rsync, `file://`) and custom/inline lists are skipped — they're the download path's job.

## Tests

- **`LocalFileFeedChangedTest`** (PHPUnit, off-appliance) pins every branch: first-seen → changed, unchanged → no re-parse, changed content → re-parse, remote URL ignored, empty/missing path ignored.
- **`test_smoke_localfeed`** (live VM) proves the end-to-end re-ingest: an edited local feed is picked up by a **plain `update`** (no force/clear). Validated on the local two-VM box — **red→green**: fails on a no-fix pkg, passes on the fixed pkg. (Asserts pfBlockerNG's parsed member file, which is the direct re-parse output; the pf alias-table load is a separate filter-reload concern.)

Gates run locally: `php -l`, PHPCS, PHPStan, full PHPUnit suite (1290 ok), ruff — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local file DNSBL/IP feeds now detect when the source content changes and automatically reprocess the feed.
  * Edited local feed files are no longer served from stale cached output after an update.
  * Remote URLs and missing/unreadable paths continue to be ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->