### PR TITLE
pfblockerng: route all filemtime reads through stat-cache-fresh pfb_file_mtime() (#536)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3477,8 +3477,7 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			@file_put_contents($memberlist, $members ? (implode("\n", $members) . "\n") : '', LOCK_EX);
 
 			// mtime BEFORE the build, to detect whether the action actually rebuilt.
-			clearstatcache();
-			$mtime_before = file_exists($aggout) ? filemtime($aggout) : 0;
+			$mtime_before = file_exists($aggout) ? pfb_file_mtime($aggout) : 0;
 
 			$family_esc	= escapeshellarg($family);
 			$memberlist_esc	= escapeshellarg($memberlist);
@@ -3486,8 +3485,7 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			$consumer_esc	= escapeshellarg($consumer);
 			exec("{$pfb['script']} aggregate {$family_esc} {$memberlist_esc} {$aggout_esc} {$consumer_esc} 2>&1");
 
-			clearstatcache();
-			$rebuilt = file_exists($aggout) && (filemtime($aggout) > $mtime_before);
+			$rebuilt = file_exists($aggout) && (pfb_file_mtime($aggout) > $mtime_before);
 
 			// Register the Native urltable alias (mirror the member-alias shape).
 			// NEVER pfb_firewall_rule() -- Native means no firewall rule.
@@ -9276,20 +9274,28 @@ function pfb_rdns_seed_value(array $gconfig, array $ipconfig): ?string {
 }
 
 
+// Read $path's modification time with the per-process stat cache CLEARED first, so a
+// long-lived process (e.g. the filterlog daemon) — and any caller — always sees the true
+// on-disk mtime rather than a value PHP cached on an earlier stat of the same path. Single
+// choke point so no call site has to remember to clear the cache. Returns the mtime, or
+// FALSE if $path is absent.
+function pfb_file_mtime($path) {
+	clearstatcache(TRUE, $path);
+	return @filemtime($path);
+}
+
 // ADR-38 Amendment 1: keep the long-running filterlog daemon's view of the
 // log_syslog toggle fresh. The daemon loads $config once at start; a live toggle
 // (GUI save / CLI) writes config.xml, but the daemon's in-memory $config is stale,
 // so the syslog gate would not change until a restart (a bug: enabled+syslog-on
 // must emit; enabled+syslog-off must not, with no restart). Reload $config from
-// disk ONLY when config.xml actually changes (mtime-gated) — a cheap filemtime()
-// per block event, a full read only on an actual change. Called on the block-emit
-// path (low volume), not per packet.
+// disk ONLY when config.xml actually changes (mtime-gated) — a cheap
+// pfb_file_mtime() per block event, a full read only on an actual change.
+// Called on the block-emit path (low volume), not per packet.
 function pfb_filterlog_refresh_config() {
-	// PHP caches filemtime() per process (the stat cache), so in this long-lived
-	// daemon a later config.xml write would otherwise read the STALE cached mtime and
-	// the live toggle would be missed. Clear the cache for this path before stat'ing.
-	clearstatcache(TRUE, '/conf/config.xml');
-	$cur = @filemtime('/conf/config.xml');
+	// pfb_file_mtime() clears PHP's per-process stat cache before stat'ing,
+	// so in this long-lived daemon a later config.xml write is always detected.
+	$cur = pfb_file_mtime('/conf/config.xml');
 	if ($cur === FALSE) {
 		return;
 	}
@@ -9311,7 +9317,10 @@ function pfb_daemon_filterlog() {
 	// ADR-38 Amendment 1: baseline mtime for the live log_syslog refresh (see
 	// pfb_filterlog_refresh_config). Captured at daemon start — when $config was
 	// loaded — so any later config.xml change is detected on the block path.
-	$GLOBALS['pfb_daemon_config_mtime'] = @filemtime('/conf/config.xml');
+	// pfb_file_mtime() clears the stat cache first (#536: without this the
+	// baseline could read a PHP-cached mtime from before the daemon's config load,
+	// defeating the change-detection on the very first reload check).
+	$GLOBALS['pfb_daemon_config_mtime'] = pfb_file_mtime('/conf/config.xml');
 
 	// ASN Reporting - cached setting
 	if ($pfb['asn_reporting'] != 'disabled') {

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -471,8 +471,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		}
 
 		if ($localfile) {
-			clearstatcache();
-			$remote_tds = gmdate('D, j M Y H:i:s T', @filemtime("{$list_download}"));
+			$remote_tds = gmdate('D, j M Y H:i:s T', pfb_file_mtime("{$list_download}"));
 		}
 		else {
 			// Download URL headers and compare previously downloaded file with remote timestamp
@@ -556,8 +555,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		else {
 			$log = "  Remote timestamp: {$remote_tds}\n";
 			pfb_logger("{$log}", 1);
-			clearstatcache();
-			$local_tds = gmdate('D, j M Y H:i:s T', @filemtime($local_file));
+			$local_tds = gmdate('D, j M Y H:i:s T', pfb_file_mtime($local_file));
 			$log = "  Local  timestamp: {$local_tds}\t";
 			pfb_logger("{$log}", 1);
 	
@@ -799,7 +797,7 @@ function pfblockerng_uc_countries() {
 	}
 
 	// Save Date/Time stamp to MaxMind version file
-	$local_tds	 = @gmdate('D, j M Y H:i:s T', @filemtime($maxmind_cont));
+	$local_tds	 = @gmdate('D, j M Y H:i:s T', pfb_file_mtime($maxmind_cont));
 	$maxmind_ver	 = "MaxMind GeoLite2 Date/Time Stamp\n";
 	$maxmind_ver	.= "Last-Modified: {$local_tds}\n";
 	@file_put_contents("{$pfb['logdir']}/maxmind_ver", $maxmind_ver, LOCK_EX);

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -4602,9 +4602,9 @@ elseif ($alert_summary):
 if (!$pfb['filterlogentries']):?>
 
 <form action="/pfblockerng/pfblockerng_alerts.php" method="post" name="iform_stats" id="iform_stats" class="form-horizontal">
-<script src="../vendor/d3/d3.min.js?v=<?=filemtime('/usr/local/www/vendor/d3/d3.min.js')?>"></script>
+<script src="../vendor/d3/d3.min.js?v=<?=pfb_file_mtime('/usr/local/www/vendor/d3/d3.min.js')?>"></script>
 <script src="../vendor/d3pie/d3pie.min.js"></script>
-<script src="../vendor/nvd3/nv.d3.min.js?v=<?=filemtime('/usr/local/www/vendor/nvd3/nv.d3.min.js')?>"></script>
+<script src="../vendor/nvd3/nv.d3.min.js?v=<?=pfb_file_mtime('/usr/local/www/vendor/nvd3/nv.d3.min.js')?>"></script>
 <link href="../vendor/nvd3/nv.d3.min.css" media="screen, projection" rel="stylesheet" type="text/css">
 
 <div class="panel panel-default">

--- a/tests/php/FileMtimeTest.php
+++ b/tests/php/FileMtimeTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_file_mtime() — reads a file's mtime with PHP's per-process stat cache cleared
+ * first (issue #536), so a long-lived process (e.g. the filterlog daemon) — and any
+ * caller — always sees the true on-disk mtime rather than a value PHP cached on an
+ * earlier stat of the same path. A single choke point: every filemtime read in the tree
+ * routes through it, so no call site has to remember to clear the cache.
+ *
+ * The bug it fixes: PHP's per-process stat cache holds the mtime from the first stat of
+ * a path. If the file is then changed by ANOTHER process, a bare filemtime() in this
+ * process keeps returning the cached (stale) value until clearstatcache() is called.
+ * The filterlog daemon captured its config.xml baseline that way and could miss the very
+ * first config-change event.
+ */
+#[CoversFunction('pfb_file_mtime')]
+final class FileMtimeTest extends TestCase
+{
+	/** @var string */
+	private string $tmp;
+
+	protected function setUp(): void
+	{
+		$tmp = tempnam(sys_get_temp_dir(), 'pfb_mtime_test_');
+		if ($tmp === FALSE) {
+			$this->fail('Could not create temp file');
+		}
+		$this->tmp = $tmp;
+	}
+
+	protected function tearDown(): void
+	{
+		if (file_exists($this->tmp)) {
+			unlink($this->tmp);
+		}
+	}
+
+	/**
+	 * Read a file's true on-disk mtime via a FRESH PHP process (empty stat cache, so no
+	 * shared cache with this process). Uses PHP_BINARY rather than shelling out to `stat`
+	 * because `stat`'s mtime flag differs by platform (BSD `-f %m` vs GNU `-c %Y`) — a fresh
+	 * `php -r filemtime()` is identical on macOS and the Linux CI runner. Returns the epoch int.
+	 */
+	private function onDiskMtime(string $path): int
+	{
+		$out = shell_exec(
+			escapeshellarg(PHP_BINARY) . ' -r ' . escapeshellarg('echo (int) filemtime($argv[1]);')
+			. ' ' . escapeshellarg($path)
+		);
+		return (int) trim((string) $out);
+	}
+
+	/**
+	 * THE FIX. pfb_file_mtime() returns the true on-disk mtime even when PHP's stat
+	 * cache was primed with the pre-mutation value.
+	 *
+	 * Fail-before: without clearstatcache the helper returns the cached pre-mutation
+	 * mtime; this assertion goes red on Linux/CI. macOS local can't show red (the VFS
+	 * provides stat coherency, so a bare filemtime is already fresh after an external
+	 * mutation) — CI (Linux) is the proving platform.
+	 *
+	 *   GIVEN a temp file whose mtime is read in-process, priming PHP's stat cache;
+	 *    WHEN a SEPARATE process changes the file's mtime (so PHP's in-process cache is
+	 *         NOT auto-cleared — unlike PHP's own touch(), which clears its own cache);
+	 *    THEN pfb_file_mtime() returns the NEW on-disk mtime, not the primed value.
+	 */
+	public function test_pfb_file_mtime_returns_fresh_mtime_after_out_of_process_change(): void
+	{
+		$tmp = $this->tmp;
+
+		// GIVEN: create content and prime PHP's stat cache for this path (records t0).
+		file_put_contents($tmp, 'a');
+		$primed = filemtime($tmp);
+		$this->assertIsInt($primed, 'filemtime() must prime with an int mtime (t0)');
+
+		// WHEN: mutate the mtime OUT-OF-PROCESS to an explicit year-2030 value, so PHP's
+		// in-process stat cache is not auto-invalidated (POSIX `touch -t CCYYMMDDhhmm.SS`).
+		$touch_rc = -1;
+		exec('/usr/bin/touch -t 203001010000.00 ' . escapeshellarg($tmp), $touch_out, $touch_rc);
+		$this->assertSame(0, $touch_rc, 'out-of-process `touch -t` must succeed (test setup)');
+		$expected = $this->onDiskMtime($tmp);
+		$this->assertGreaterThan(
+			$primed,
+			$expected,
+			sprintf(
+				'Out-of-process touch must advance the on-disk mtime above the primed value '
+				. '(primed=%d, on-disk=%d)',
+				$primed,
+				$expected
+			)
+		);
+
+		// Control (soft, documents the bug across platforms): a bare filemtime() now.
+		// On Linux this is the STALE primed t0 (cache primed, not cleared); on macOS VFS
+		// coherency it may already read fresh. We do not hard-assert this (it is
+		// platform-dependent) — we surface what the platform did so the diagnostic is honest.
+		$bare = filemtime($tmp);
+		if ($bare === $primed) {
+			fwrite(STDERR, sprintf(
+				"[FileMtimeTest] per-process stat cache is STALE here: bare filemtime()=%d (primed), "
+				. "on-disk=%d — the bug is reproducible on this platform.\n",
+				$bare,
+				$expected
+			));
+		} else {
+			fwrite(STDERR, sprintf(
+				"[FileMtimeTest] VFS stat coherency here: bare filemtime()=%d already matches "
+				. "on-disk=%d — staleness not reproducible locally (expected on macOS); Linux/CI proves it.\n",
+				$bare,
+				$expected
+			));
+		}
+
+		// THEN (the real failable assertion): the helper returns the fresh on-disk value.
+		$result = pfb_file_mtime($tmp);
+		$this->assertSame(
+			$expected,
+			$result,
+			sprintf(
+				'Expected pfb_file_mtime() to return the fresh on-disk mtime %d, got %s '
+				. '(primed/stale value was %d — a missing clearstatcache returns that on Linux/CI).',
+				$expected,
+				var_export($result, TRUE),
+				$primed
+			)
+		);
+	}
+
+	/**
+	 * Contract: pfb_file_mtime() returns the on-disk mtime of a freshly-written file.
+	 *
+	 *  GIVEN a file with content just written;
+	 *   WHEN pfb_file_mtime() is called with its path;
+	 *   THEN the returned mtime matches the on-disk value (read by a fresh process).
+	 */
+	public function test_pfb_file_mtime_returns_correct_mtime_for_existing_file(): void
+	{
+		file_put_contents($this->tmp, 'x');
+		$expected = $this->onDiskMtime($this->tmp);
+
+		$result = pfb_file_mtime($this->tmp);
+
+		$this->assertSame(
+			$expected,
+			$result,
+			sprintf(
+				'Expected pfb_file_mtime() to return on-disk mtime %d, got %s',
+				$expected,
+				var_export($result, TRUE)
+			)
+		);
+	}
+
+	/**
+	 * Contract: pfb_file_mtime() returns FALSE for a path that does not exist.
+	 * Proves the @filemtime() error-suppression and FALSE-return path.
+	 *
+	 *  GIVEN a path that does not exist on disk;
+	 *   WHEN pfb_file_mtime() is called with it;
+	 *   THEN it returns FALSE (not an exception, not 0, not '').
+	 */
+	public function test_pfb_file_mtime_returns_false_for_missing_path(): void
+	{
+		$missing = $this->tmp . '_does_not_exist';
+
+		$result = pfb_file_mtime($missing);
+
+		$this->assertFalse(
+			$result,
+			sprintf('Expected FALSE for missing path, got %s', var_export($result, TRUE))
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a single `pfb_file_mtime($path)` helper that clears PHP's per-process stat cache for
`$path` **before** calling `filemtime($path)`, and routes **every** `filemtime` read in the tree
through it — so all mtime reads are guaranteed fresh and no call site has to remember to clear
the cache.

## Motivation

PHP caches `filemtime()` per process. In the long-lived filterlog daemon (ADR-38 Amendment 1)
the config-change gate captured its baseline `config.xml` mtime with a bare `filemtime()` — no
`clearstatcache()` — unlike its sibling refresh path. That baseline could read a stale cached
value rather than the true on-disk mtime the in-memory `$config` was loaded from. Rather than
patch just that one site, this generalises: one choke point, every reader fresh, the per-site
"does this one need `clearstatcache`?" judgment (the omission that caused this) eliminated.

## Changes

- **`pfblockerng.inc`** — new `pfb_file_mtime($path)` helper. Routed through it: both filterlog
  daemon config-gate sites (the baseline capture is the original fix), and the ADR-11 aggregate
  mtime-gate's two reads (dropping their now-redundant bare `clearstatcache()` calls — the helper
  clears per-path).
- **`pfblockerng.php`** — the feed-remote / feed-local / MaxMind `Last-Modified` timestamp reads.
- **`pfblockerng_alerts.php`** — the d3 / nvd3 cache-bust `?v=` query strings.

After the change, the only `filemtime(` in `src/` is the one inside `pfb_file_mtime()` itself.

## Behaviour

- **Daemon baseline** — now reads the true on-disk mtime (the fix).
- **All other sites** — behaviour-identical: same path, same value. The aggregate gate already
  cleared the cache (now via the helper); the `www/` date-string and cache-bust reads produce
  byte-identical output (same `Last-Modified` string, same `?v=` value). No observable front-end
  change, so no new UI-tier coverage is required beyond the existing render gate; `php -l` +
  PHPStan confirm the helper resolves in the page context (both pages already `require_once` the
  `.inc`).

## Test

`tests/php/FileMtimeTest.php` pins the helper: a temp file is stat'd (priming PHP's per-process
cache), then mutated **out-of-process** (`touch -t`, so PHP's cache is not auto-cleared), and
`pfb_file_mtime()` must return the fresh on-disk mtime. Without the `clearstatcache()` this
assertion is red on Linux/CI; macOS local cannot reproduce the staleness (APFS/VFS stat
coherency), documented in the test — CI (Linux) is the proving platform. Plus contract tests
(correct mtime for an existing file; `FALSE` for an absent path).

Fixes #536

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file change detection so updates and background checks notice modified files more reliably.
  * The alerts page now refreshes chart assets more consistently after updates.
  * Config changes are now picked up more reliably without needing a restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->