### PR TITLE
pfblockerng: confirm a local feed's mtime change with a content hash before re-ingest (#540)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -560,7 +560,24 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 			pfb_logger("{$log}", 1);
 	
 			if ("{$remote_tds}" != "{$local_tds}") {
-				$pfb['cron_update'] = TRUE;
+				// A differing mtime is only a HINT. For a local file the source is
+				// already on disk, so confirm the bytes actually changed with a cheap
+				// content hash before triggering a full re-ingest -- a touch/cp/rsync
+				// that bumps mtime without changing content must not force a needless
+				// re-download. Fail OPEN: if the source hash can't be read, fall back
+				// to the mtime decision (re-ingest) rather than risk missing a change.
+				// Remote feeds stay timestamp-primary -- hashing a remote feed means
+				// downloading it (the work this timestamp check avoids); its
+				// no-Last-Modified case already falls back to md5 above.
+				$src_md5 = @md5_file($list_download);
+				if ($localfile && $src_md5 !== FALSE && $src_md5 === @md5_file($local_file)) {
+					$log = "  ( mtime changed, content identical )\tUpdate not required\n";
+					pfb_logger("{$log}", 1);
+					$pfb['cron_update'] = FALSE;
+				}
+				else {
+					$pfb['cron_update'] = TRUE;
+				}
 			}
 			else {
 				$log = "Update not required\n";

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -1355,3 +1355,83 @@ def test_cron_skips_unchanged_local_feed(deployed_vm: SmokeVM, client_vm: SmokeV
             deployed_vm.ssh("/bin/rm", "-f", feed_path)
         if reset_exc is not None:
             raise reset_exc
+
+
+@pytest.mark.timeout(600)
+def test_cron_skips_local_feed_with_bumped_mtime_but_same_content(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
+    """Local feed change detection: a bumped mtime with IDENTICAL content is NOT re-ingested.
+
+    A differing source mtime is only a hint; ``pfb_update_check`` now confirms the bytes actually
+    changed (md5 source vs ``.orig``) before re-ingesting a LOCAL feed, so a touch/cp/rsync that
+    bumps mtime without changing content takes the reuse path.
+
+    RED on pre-change code: a differing mtime alone logs "Update found" -> re-download
+    ("Downloading update"), and the "( mtime changed, content identical )" marker does not exist.
+    GREEN after the fix: that marker is logged and no re-ingest occurs.
+
+    Scenario (BDD):
+      Given the feed contains ``dom`` (initial ingest blocks it; ``.orig`` == source bytes);
+      When the source mtime is bumped LATER than ``.orig`` (``touch -r`` + ``touch -A``) WITHOUT changing content,
+        pfb_reuse is OFF and pfb_dailystart matches the guest hour, and the ``cron`` verb runs;
+      Then a new "( mtime changed, content identical )" verdict appears (md5 confirmed no change),
+        no "Downloading update" line appears for this header, and ``dom`` remains blocked.
+    """
+    dom = h.unique_domain("cronsame")
+    header = "smokecronsame"
+    feed_path: str | None = None
+    marker = "mtime changed, content identical"
+
+    try:
+        h.unblock_egress()
+
+        # GIVEN — write feed, ingest (a single updatednsbl creates the .orig baseline, a
+        # byte-identical copy of the source).
+        feed_path = h.write_local_feed(deployed_vm, "smoke_cronsame.txt", dom + "\n")
+        spec = h.DnsblCase(aliasname="smokecronsame", feed_url=feed_path, header=header, mode=h.DnsblMode.VIP)
+        h.inject(deployed_vm, spec)
+        h.reload(deployed_vm, "updatednsbl")
+
+        # BEFORE state: dom blocked.
+        h.flush_unbound_name(deployed_vm, dom)
+        ans_before = h.dns_probe_client_until(client_vm, dom, h.is_vip)
+        assert h.is_vip(ans_before), f"BEFORE: {dom} must be VIP-blocked after initial ingest, got {ans_before}"
+
+        # WHEN — bump source mtime LATER than .orig WITHOUT changing content (timezone-free:
+        # copy orig's mtime onto the source, then advance it by +120s — no absolute touch -t).
+        orig_path = f"{h.PFB_DBDIR}/dnsblorig/{header}.orig"
+        _bump_feed_mtime(deployed_vm, feed_path, orig_path, advance="0200")
+
+        # Pin pfb_reuse=off and dailystart=now (just before cron).
+        _pin_cron_due(deployed_vm)
+        marker_before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+        dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
+
+        # WHEN — cron (the genuine detector path).
+        h.reload(deployed_vm, "cron")
+
+        # THEN — md5 content-confirm skipped the re-ingest: new marker present, no download.
+        marker_after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+        assert marker_after > marker_before, (
+            f"Expected a new '{marker}' verdict after cron (before={marker_before}, after={marker_after}) "
+            f"— md5 content-confirm did not run (RED on pre-change code: a mtime diff re-ingests)"
+        )
+        dl_after = _feed_log_count(deployed_vm, header, "Downloading update")
+        assert dl_after == dl_before, (
+            f"Expected NO '[ {header} ] ... Downloading update' (content identical) "
+            f"(before={dl_before}, after={dl_after}) — feed was wrongly re-ingested"
+        )
+
+        # THEN — dom remains blocked (feed not cleared).
+        ans_after = h.dns_probe_client(client_vm, dom, "A")
+        assert h.is_vip(ans_after), f"AFTER cron: {dom} must remain VIP-blocked, got {ans_after}"
+
+    finally:
+        reset_exc = None
+        try:
+            h.reset(deployed_vm)
+        except Exception as exc:  # noqa: BLE001
+            reset_exc = exc
+        if feed_path:
+            deployed_vm.ssh("/bin/rm", "-f", feed_path)
+        if reset_exc is not None:
+            raise reset_exc


### PR DESCRIPTION
## Summary

Makes local-feed change detection in `pfb_update_check()` **confirm a differing mtime with a content hash** before re-ingesting. Today a differing source mtime alone triggers a full re-download/re-ingest; a `touch`/`cp`/`rsync` that bumps mtime without changing bytes therefore forces a needless re-ingest. Because `.orig`'s mtime is set at ingest time (not copied from the source), a static local feed can even re-ingest on *every* cron tick.

## Change

In the local-file branch of `pfb_update_check()` (`src/usr/local/www/pfblockerng/pfblockerng.php`), when the source mtime differs from the `.orig` mtime, confirm with `md5_file(source)` vs `md5_file(.orig)`:

- Identical bytes → log `( mtime changed, content identical )  Update not required` and skip the re-ingest.
- Different bytes → re-ingest as before.
- **Fail open**: if the source hash can't be read, fall back to the mtime decision (re-ingest) — never risk missing a real change.

The `$localfile` guard keeps **remote** feeds on the timestamp-primary path — hashing a remote feed means downloading it (the work the timestamp check avoids; the no-`Last-Modified` case already falls back to md5). The hash is cheap here precisely because the local source is already on disk. This is behaviour-narrowing: it can only suppress *needless* re-ingests, never miss a genuine content change. `.orig` is a byte-identical rename of the downloaded source, so the hashes match exactly when the source is unchanged.

No `filemtime` reads are added — `md5_file` reads content, not the stat cache, so the #537 `pfb_file_mtime()` helper does not apply; the existing mtime reads in this block already go through it.

## Test

Live-VM smoke (builds on the `cron` → `pfb_update_check` harness from #538): `test_cron_skips_local_feed_with_bumped_mtime_but_same_content` bumps a local feed's mtime later than `.orig` **without** changing content, runs `cron`, and asserts a new `( mtime changed, content identical )` verdict with no `Downloading update` (and the domain stays blocked). Red on pre-change code (a mtime diff re-ingests and the marker doesn't exist), green after.

Fixes #540

---

> Note: stacked on #541 (the #538 smoke harness it reuses). Will be rebased onto `devel` once #541 merges.
