### PR TITLE
pfblockerng: dedup firewall-rule trackers against foreign filter rules (#482)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8033,6 +8033,25 @@ function pfb_failures() {
 }
 
 
+// Collect tracker IDs from non-pfBlockerNG filter/rule rows so both tracker generators
+// can avoid minting an ID that collides with a GUI or third-party rule. Only filter/rule
+// is consulted -- NAT rules carry no tracker. Rows owned by pfBlockerNG (pfb_is_managed_obj)
+// are excluded so we never treat our own prior rules as foreign, preventing re-mint churn.
+function pfb_collect_foreign_trackers(): array {
+	$trackers = array();
+	foreach (config_get_path('filter/rule', array()) as $row) {
+		if (!isset($row['tracker']) || $row['tracker'] === '') {
+			continue;
+		}
+		if (pfb_is_managed_obj($row['descr'] ?? '')) {
+			continue;
+		}
+		$trackers[] = (int) $row['tracker'];
+	}
+	return $trackers;
+}
+
+
 // Convert unique Alias details (via ascii table number) and return a 10 digit tracker ID
 function pfb_tracker($alias, $int, $text) {
 	global $pfb;
@@ -8064,14 +8083,23 @@ function pfb_tracker($alias, $int, $text) {
         	$pfbtracker = substr($pfbtracker, 0, 10);
 	}
 	
-	// If duplicate Tracker ID found, pre-define a Tracker ID (Starts at 1700000010)
-	if (in_array($pfbtracker, $pfb['trackerids'])) {
+	// If duplicate Tracker ID found, pre-define a Tracker ID (Starts at 1700000010).
+	// Also skip IDs already in use by non-pfBlockerNG filter rules (foreign_trackerids).
+	if (in_array($pfbtracker, $pfb['trackerids']) || in_array($pfbtracker, $pfb['foreign_trackerids'] ?? [])) {
 		$pfbtracker = ($pfb['last_trackerid'] + 1);
-		
+
 		// Increment prefix (digits 1&2) and reset Last_tracker ID after 10 digits
 		if (strlen($pfbtracker) > 10) {
 			$tracker_prefix = substr($pfbtracker, 0, 2);
 			$pfbtracker	= ($tracker_prefix + 1) . '00000010';
+		}
+		// Keep bumping until free in both sets (handles runs of foreign collisions).
+		while (in_array($pfbtracker, $pfb['trackerids']) || in_array($pfbtracker, $pfb['foreign_trackerids'] ?? [])) {
+			$pfbtracker++;
+			if (strlen($pfbtracker) > 10) {
+				$tracker_prefix = substr($pfbtracker, 0, 2);
+				$pfbtracker	= ($tracker_prefix + 1) . '00000010';
+			}
 		}
 		$pfb['last_trackerid'] = $pfbtracker;
 	}
@@ -8120,7 +8148,7 @@ function pfb_managed_rule_tracker(string $descr): int {
 	// tracker exists for. Stays inside the '176' + 7-digit namespace (<= uint32) via
 	// the modulo, and loops past any further collision so it never returns a duplicate.
 	$probe = 0;
-	while (in_array($tracker, $pfb['trackerids'], TRUE)) {
+	while (in_array($tracker, $pfb['trackerids'], TRUE) || in_array($tracker, $pfb['foreign_trackerids'] ?? [], TRUE)) {
 		$probe++;
 		$tracker = (int) ('176' . str_pad((string) (($sum + $probe) % 10000000), 7, '0', STR_PAD_LEFT));
 	}
@@ -11116,8 +11144,9 @@ function sync_package_pfblockerng($cron='') {
 	#	Tracker IDs		#
 	#################################
 
-	$pfb['trackerids']	= array();		// An array of pfBlockerNG Firewall rule Tracker IDs.
-	$pfb['last_trackerid']	= 1700000009;		// Pre-defined 'starting' Tracker ID (Only used if duplicates found)
+	$pfb['trackerids']	    = array();					// An array of pfBlockerNG Firewall rule Tracker IDs.
+	$pfb['last_trackerid']	= 1700000009;				// Pre-defined 'starting' Tracker ID (Only used if duplicates found)
+	$pfb['foreign_trackerids'] = pfb_collect_foreign_trackers();	// Tracker IDs already in use by non-pfB rules.
 
 
 	#########################################

--- a/tests/php/ForeignTrackerCollectionTest.php
+++ b/tests/php/ForeignTrackerCollectionTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_collect_foreign_trackers() (#482) — collect tracker IDs from non-pfBlockerNG
+ * filter/rule rows so both tracker generators can exclude them and never mint an ID
+ * that collides with a GUI or third-party rule, preventing stale rule edit/delete ops.
+ *
+ * These tests are INTENTIONALLY RED until Step 2 adds pfb_collect_foreign_trackers()
+ * to pfblockerng.inc. They pin the contract that function must satisfy.
+ */
+#[CoversFunction('pfb_collect_foreign_trackers')]
+final class ForeignTrackerCollectionTest extends TestCase
+{
+	/** @var array<string,mixed> Saved config, restored in tearDown. */
+	private array $savedConfig = [];
+	private bool $hadConfig    = false;
+
+	protected function setUp(): void
+	{
+		$this->hadConfig    = array_key_exists('config', $GLOBALS);
+		$this->savedConfig  = $GLOBALS['config'] ?? [];
+		$GLOBALS['config']  = [];
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Scenario: the function exists (red until Step 2 implements it)
+	// -------------------------------------------------------------------------
+
+	public function testFunctionExists(): void
+	{
+		// THEN pfb_collect_foreign_trackers() must be defined.
+		// RED until Step 2 adds it.
+		$this->assertTrue(
+			function_exists('pfb_collect_foreign_trackers'),
+			'pfb_collect_foreign_trackers() is not defined — Step 2 must add it to pfblockerng.inc'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Scenario: empty / absent filter/rule → returns empty array
+	// -------------------------------------------------------------------------
+
+	public function testEmptyConfigReturnsEmptyArray(): void
+	{
+		// GIVEN no filter/rule key in config at all,
+		$GLOBALS['config'] = [];
+
+		// WHEN collecting foreign trackers,
+		$result = pfb_collect_foreign_trackers();
+
+		// THEN the result is an empty array.
+		$this->assertIsArray($result, 'Expected array, got: ' . gettype($result));
+		$this->assertEmpty(
+			$result,
+			'Expected empty array for absent filter/rule, got: ' . json_encode($result)
+		);
+	}
+
+	public function testEmptyRuleListReturnsEmptyArray(): void
+	{
+		// GIVEN an explicitly empty filter/rule array,
+		$GLOBALS['config'] = ['filter' => ['rule' => []]];
+
+		$result = pfb_collect_foreign_trackers();
+
+		$this->assertIsArray($result, 'Expected array, got: ' . gettype($result));
+		$this->assertEmpty(
+			$result,
+			'Expected empty array for empty filter/rule, got: ' . json_encode($result)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Scenario: foreign rules contribute their tracker IDs
+	// -------------------------------------------------------------------------
+
+	public function testForeignRuleTrackerIsIncluded(): void
+	{
+		// GIVEN a single foreign rule with tracker 9991234567,
+		$GLOBALS['config'] = [
+			'filter' => [
+				'rule' => [
+					['descr' => 'GUI LAN rule', 'tracker' => '9991234567'],
+				],
+			],
+		];
+
+		// WHEN collecting,
+		$result = pfb_collect_foreign_trackers();
+
+		// THEN 9991234567 (as int) is in the result.
+		$this->assertContains(
+			9991234567,
+			$result,
+			'Expected foreign tracker 9991234567 in result, got: ' . json_encode($result)
+		);
+	}
+
+	public function testMultipleForeignRulesContributeAllTrackers(): void
+	{
+		// GIVEN two foreign rules,
+		$GLOBALS['config'] = [
+			'filter' => [
+				'rule' => [
+					['descr' => 'Rule A',  'tracker' => '1111111111'],
+					['descr' => 'Rule B',  'tracker' => '2222222222'],
+				],
+			],
+		];
+
+		$result = pfb_collect_foreign_trackers();
+
+		$this->assertContains(1111111111, $result,
+			'Expected tracker 1111111111 in result, got: ' . json_encode($result));
+		$this->assertContains(2222222222, $result,
+			'Expected tracker 2222222222 in result, got: ' . json_encode($result));
+	}
+
+	// -------------------------------------------------------------------------
+	// Scenario: pfBlockerNG-owned rows are EXCLUDED
+	// -------------------------------------------------------------------------
+
+	public function testPfbOwnedRowWithPfBUnderscorePrefixIsExcluded(): void
+	{
+		// GIVEN a pfB_-prefixed rule (owned by pfBlockerNG) and a foreign rule,
+		$foreignTracker = 8881234567;
+		$pfbTracker     = 1760000001;
+		$GLOBALS['config'] = [
+			'filter' => [
+				'rule' => [
+					['descr' => 'pfB_Deny_Inbound',       'tracker' => (string) $pfbTracker],
+					['descr' => 'Third-party VPN rule',   'tracker' => (string) $foreignTracker],
+				],
+			],
+		];
+
+		$result = pfb_collect_foreign_trackers();
+
+		// THEN the pfB_-owned tracker is absent,
+		$this->assertNotContains(
+			$pfbTracker,
+			$result,
+			'pfB_-prefixed row should be excluded; got: ' . json_encode($result)
+		);
+		// AND the foreign tracker is present.
+		$this->assertContains(
+			$foreignTracker,
+			$result,
+			'Foreign tracker should be included; got: ' . json_encode($result)
+		);
+	}
+
+	public function testPfbOwnedRowWithLegacyDnsblMarkerIsExcluded(): void
+	{
+		// GIVEN a row whose descr contains 'pfB DNSBL' (the legacy NAT marker),
+		$pfbTracker     = 1760000002;
+		$foreignTracker = 7771234567;
+		$GLOBALS['config'] = [
+			'filter' => [
+				'rule' => [
+					['descr' => 'some pfB DNSBL rule',  'tracker' => (string) $pfbTracker],
+					['descr' => 'GUI WAN out',           'tracker' => (string) $foreignTracker],
+				],
+			],
+		];
+
+		$result = pfb_collect_foreign_trackers();
+
+		$this->assertNotContains(
+			$pfbTracker,
+			$result,
+			'Legacy pfB DNSBL row should be excluded; got: ' . json_encode($result)
+		);
+		$this->assertContains(
+			$foreignTracker,
+			$result,
+			'Foreign tracker should be included; got: ' . json_encode($result)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Scenario: rows with missing or empty tracker are skipped
+	// -------------------------------------------------------------------------
+
+	public function testRowWithMissingTrackerIsSkipped(): void
+	{
+		// GIVEN a rule row with no 'tracker' key,
+		$GLOBALS['config'] = [
+			'filter' => [
+				'rule' => [
+					['descr' => 'No tracker here'],
+					['descr' => 'Has tracker', 'tracker' => '5551234567'],
+				],
+			],
+		];
+
+		$result = pfb_collect_foreign_trackers();
+
+		// THEN only the row with a tracker contributes,
+		$this->assertContains(5551234567, $result,
+			'Row with tracker should be included; got: ' . json_encode($result));
+		$this->assertCount(
+			1,
+			$result,
+			'Only one row has a tracker; expected count 1, got: ' . json_encode($result)
+		);
+	}
+
+	public function testRowWithEmptyTrackerIsSkipped(): void
+	{
+		// GIVEN a rule row with an empty 'tracker' string,
+		$GLOBALS['config'] = [
+			'filter' => [
+				'rule' => [
+					['descr' => 'Empty tracker', 'tracker' => ''],
+					['descr' => 'Valid tracker',  'tracker' => '4441234567'],
+				],
+			],
+		];
+
+		$result = pfb_collect_foreign_trackers();
+
+		$this->assertContains(4441234567, $result,
+			'Row with valid tracker should be included; got: ' . json_encode($result));
+		$this->assertCount(
+			1,
+			$result,
+			'Only one row has a non-empty tracker; expected count 1, got: ' . json_encode($result)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Scenario: NAT rules (nat/rule) are NOT read — only filter/rule
+	// -------------------------------------------------------------------------
+
+	public function testNatRuleTrackersAreNotIncluded(): void
+	{
+		// GIVEN a nat/rule row with a tracker (NAT rules don't carry a meaningful
+		// tracker in pfSense — but the point is we must never read nat/rule at all),
+		$natOnlyTracker = 6661234567;
+		$GLOBALS['config'] = [
+			'nat'    => ['rule' => [['descr' => 'NAT redirect', 'tracker' => (string) $natOnlyTracker]]],
+			'filter' => ['rule' => []],
+		];
+
+		$result = pfb_collect_foreign_trackers();
+
+		// THEN the NAT tracker does NOT appear — only filter/rule is consulted.
+		$this->assertNotContains(
+			$natOnlyTracker,
+			$result,
+			'NAT rule trackers must not be included; got: ' . json_encode($result)
+		);
+		$this->assertEmpty(
+			$result,
+			'Expected empty result when only nat/rule has rows; got: ' . json_encode($result)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Scenario: trackers are cast to int
+	// -------------------------------------------------------------------------
+
+	public function testTrackerIsCastToInt(): void
+	{
+		// GIVEN a tracker stored as a string (as pfSense serialises it),
+		$GLOBALS['config'] = [
+			'filter' => [
+				'rule' => [['descr' => 'GUI rule', 'tracker' => '3331234567']],
+			],
+		];
+
+		$result = pfb_collect_foreign_trackers();
+
+		// THEN the result contains an int, not a string.
+		$this->assertContains(
+			3331234567,
+			$result,
+			'Tracker must be cast to int; got: ' . json_encode($result)
+		);
+		foreach ($result as $id) {
+			$this->assertIsInt($id,
+				'Every returned tracker must be int; got ' . gettype($id) . ' in: ' . json_encode($result));
+		}
+	}
+}

--- a/tests/php/TrackerForeignCollisionTest.php
+++ b/tests/php/TrackerForeignCollisionTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Collision avoidance against $pfb['foreign_trackerids'] (#482).
+ *
+ * Both tracker generators (pfb_tracker / pfb_managed_rule_tracker) must refuse to
+ * mint an ID that appears in $pfb['foreign_trackerids'] — the set seeded at registry
+ * init from pfb_collect_foreign_trackers(). Without this guard a new pfBlockerNG rule
+ * can silently collide with a GUI/third-party rule's tracker, causing pfSense to edit
+ * or delete the wrong rule.
+ *
+ * These tests are INTENTIONALLY RED until Step 2 expands BOTH generators' collision
+ * checks to also reject IDs in $pfb['foreign_trackerids']. The tests that exercise
+ * pfb_managed_rule_tracker() will go red on the "foreign set avoidance" assertions;
+ * the pfb_tracker() tests will go red too. The "before-state" determinism assertions
+ * stay green (they pin existing behaviour), so any red is exclusively the missing guard.
+ */
+#[CoversFunction('pfb_managed_rule_tracker')]
+#[CoversFunction('pfb_tracker')]
+final class TrackerForeignCollisionTest extends TestCase
+{
+	/** @var mixed Saved $pfb, restored in tearDown. */
+	private $savedPfb;
+	private bool $hadPfb = false;
+
+	/** @var array<string,mixed> Saved config. */
+	private array $savedConfig = [];
+	private bool $hadConfig    = false;
+
+	protected function setUp(): void
+	{
+		global $pfb;
+		$this->hadPfb  = array_key_exists('pfb', $GLOBALS);
+		$this->savedPfb = $pfb ?? null;
+		$pfb = [
+			'trackerids'         => [],
+			'foreign_trackerids' => [],
+			'last_trackerid'     => 1700000009,
+		];
+
+		$this->hadConfig   = array_key_exists('config', $GLOBALS);
+		$this->savedConfig = $GLOBALS['config'] ?? [];
+		$GLOBALS['config'] = [];
+
+		// Seed interface doubles used by pfb_tracker() tests.
+		// get_real_interface: identity mapping.
+		$GLOBALS['pfb_test_real_interface']    = [];
+		// get_interface_ip: 'lan' -> '192.0.2.1' (TEST-NET, deterministic).
+		$GLOBALS['pfb_test_interface_ip']      = ['lan' => '192.0.2.1'];
+		// ip2long32: already handled by the double (it calls ip2long + unsigned-cast).
+		// find_interface_subnet: 'lan' -> '24'.
+		$GLOBALS['pfb_test_find_interface_subnet'] = ['lan' => '24'];
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->savedPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+		unset(
+			$GLOBALS['pfb_test_real_interface'],
+			$GLOBALS['pfb_test_interface_ip'],
+			$GLOBALS['pfb_test_find_interface_subnet']
+		);
+	}
+
+	// =========================================================================
+	// pfb_managed_rule_tracker() — foreign-set collision avoidance
+	// =========================================================================
+
+	/**
+	 * Scenario: pfb_managed_rule_tracker() avoids IDs in foreign_trackerids.
+	 *
+	 * Background: the natural (deterministic) ID for a given descr is computed once
+	 * with an empty foreign set, confirmed as the before-state, then seeded into
+	 * foreign_trackerids and the function is called again. The returned ID must differ
+	 * and must NOT be in the foreign set.
+	 */
+	public function testManagedRuleTrackerAvoidsIdInForeignSet(): void
+	{
+		global $pfb;
+
+		// GIVEN a fresh registry (empty foreign set),
+		$pfb = [
+			'trackerids'         => [],
+			'foreign_trackerids' => [],
+			'last_trackerid'     => 1700000009,
+		];
+
+		// WHEN we derive the natural ID (before-state — existing behaviour, stays green),
+		$naturalId = pfb_managed_rule_tracker('pfB_DoT_Block_lan');
+
+		// THEN it is in the 176 namespace (sanity: existing behaviour).
+		$this->assertStringStartsWith(
+			'176',
+			(string) $naturalId,
+			'Before-state: natural ID must be in the 176 namespace'
+		);
+
+		// WHEN we reset and seed that ID into foreign_trackerids,
+		$pfb = [
+			'trackerids'         => [],
+			'foreign_trackerids' => [$naturalId],  // Step 2 seeds this key
+			'last_trackerid'     => 1700000009,
+		];
+		$avoidedId = pfb_managed_rule_tracker('pfB_DoT_Block_lan');
+
+		// THEN the returned ID differs from the one in the foreign set
+		// (RED until Step 2 expands the collision check to include foreign_trackerids).
+		$this->assertNotSame(
+			$naturalId,
+			$avoidedId,
+			sprintf(
+				'pfb_managed_rule_tracker() must not return an ID in foreign_trackerids. ' .
+				'Expected something other than %d, got %d. ' .
+				'foreign_trackerids=%s',
+				$naturalId,
+				$avoidedId,
+				json_encode($pfb['foreign_trackerids'] ?? [])
+			)
+		);
+
+		// AND the fallback is not in the foreign set either.
+		$this->assertNotContains(
+			$avoidedId,
+			$pfb['foreign_trackerids'] ?? [],
+			'Returned ID must not be in foreign_trackerids; got: ' . (string) $avoidedId .
+			', foreign_trackerids: ' . json_encode($pfb['foreign_trackerids'] ?? [])
+		);
+
+		// AND the fallback is still in the 176 namespace.
+		$this->assertStringStartsWith(
+			'176',
+			(string) $avoidedId,
+			'Fallback ID must still be in the 176 namespace; got: ' . (string) $avoidedId
+		);
+	}
+
+	/**
+	 * Scenario: determinism is preserved when the foreign set is empty.
+	 *
+	 * A same descr across two syncs (each with an empty foreign set) must yield the
+	 * same ID. This is existing behaviour — the test stays green before and after Step 2.
+	 */
+	public function testManagedRuleTrackerDeterminismWithEmptyForeignSet(): void
+	{
+		global $pfb;
+
+		// GIVEN a fresh sync with an empty foreign set,
+		$pfb = ['trackerids' => [], 'foreign_trackerids' => [], 'last_trackerid' => 1700000009];
+		$first = pfb_managed_rule_tracker('pfB_DoT_Block_lan');
+
+		// WHEN the next sync also starts with an empty foreign set,
+		$pfb = ['trackerids' => [], 'foreign_trackerids' => [], 'last_trackerid' => 1700000009];
+		$second = pfb_managed_rule_tracker('pfB_DoT_Block_lan');
+
+		// THEN the IDs are identical (determinism preserved).
+		$this->assertSame(
+			$first,
+			$second,
+			sprintf(
+				'Same descr with empty foreign set must yield the same ID across syncs. ' .
+				'First sync: %d, second sync: %d',
+				$first,
+				$second
+			)
+		);
+	}
+
+	/**
+	 * Scenario: foreign_trackerids key absence is handled gracefully.
+	 *
+	 * When Step 2 is NOT yet applied, $pfb['foreign_trackerids'] may be absent.
+	 * Existing code must not crash — this tests for a PHP notice / TypeError.
+	 * After Step 2 the key is always seeded at registry init, so this is belt-and-
+	 * suspenders; the test stays green before and after.
+	 */
+	public function testManagedRuleTrackerWithAbsentForeignSetDoesNotCrash(): void
+	{
+		global $pfb;
+		$pfb = ['trackerids' => [], 'last_trackerid' => 1700000009];
+		// 'foreign_trackerids' deliberately absent.
+
+		// WHEN called with no foreign set in $pfb,
+		$id = pfb_managed_rule_tracker('pfB_DoT_Block_lan');
+
+		// THEN it returns a valid 176-namespace int (no crash, no TypeError).
+		$this->assertIsInt($id, 'Expected int return; got: ' . gettype($id));
+		$this->assertStringStartsWith('176', (string) $id);
+	}
+
+	// =========================================================================
+	// pfb_tracker() — foreign-set collision avoidance
+	// =========================================================================
+
+	/**
+	 * Scenario: pfb_tracker() avoids IDs in foreign_trackerids.
+	 *
+	 * Uses a deterministic interface fixture so char-sum → natural ID is stable.
+	 * We derive the natural ID with an empty foreign set (before-state), then seed it
+	 * into foreign_trackerids and assert the next call produces a different ID.
+	 */
+	public function testPfbTrackerAvoidsIdInForeignSet(): void
+	{
+		global $pfb;
+
+		// GIVEN a fresh registry with a known interface fixture (IPv4 path),
+		// get_real_interface('lan') -> 'lan' (identity), get_interface_ip('lan') -> '192.0.2.1',
+		// ip2long32('192.0.2.1') -> deterministic, find_interface_subnet('lan') -> '24'.
+		$pfb = [
+			'trackerids'         => [],
+			'foreign_trackerids' => [],
+			'last_trackerid'     => 1700000009,
+		];
+
+		// WHEN we derive the natural ID (before-state),
+		$naturalId = pfb_tracker('pfB_Test_Alias', 'lan', 'Deny');
+
+		// THEN it is in the 177 namespace (existing behaviour, stays green).
+		$this->assertStringStartsWith(
+			'177',
+			(string) $naturalId,
+			'Before-state: pfb_tracker() natural ID must be in the 177 namespace'
+		);
+
+		// WHEN we reset and seed that ID into foreign_trackerids,
+		$pfb = [
+			'trackerids'         => [],
+			'foreign_trackerids' => [$naturalId],  // Step 2 seeds this key
+			'last_trackerid'     => 1700000009,
+		];
+		$avoidedId = pfb_tracker('pfB_Test_Alias', 'lan', 'Deny');
+
+		// THEN the returned ID differs from the one in the foreign set
+		// (RED until Step 2 expands the collision check to include foreign_trackerids).
+		$this->assertNotSame(
+			$naturalId,
+			$avoidedId,
+			sprintf(
+				'pfb_tracker() must not return an ID in foreign_trackerids. ' .
+				'Expected something other than %d, got %d. ' .
+				'foreign_trackerids=%s, trackerids=%s',
+				$naturalId,
+				$avoidedId,
+				json_encode($pfb['foreign_trackerids'] ?? []),
+				json_encode($pfb['trackerids'] ?? [])
+			)
+		);
+
+		// AND the fallback is not in the foreign set.
+		$this->assertNotContains(
+			$avoidedId,
+			$pfb['foreign_trackerids'] ?? [],
+			'Returned ID must not be in foreign_trackerids; got: ' . (string) $avoidedId .
+			', foreign_trackerids: ' . json_encode($pfb['foreign_trackerids'] ?? [])
+		);
+	}
+
+	/**
+	 * Scenario: pfb_tracker() still registers its chosen ID in trackerids.
+	 *
+	 * Whether or not a foreign-set skip occurred, the ID must be appended to
+	 * $pfb['trackerids'] so future calls within the same sync cannot reuse it.
+	 * This is existing behaviour for the non-collision path (stays green); after
+	 * Step 2 it must hold for the foreign-collision-avoidance path too.
+	 */
+	public function testPfbTrackerRegistersIdInTrackerids(): void
+	{
+		global $pfb;
+
+		$pfb = [
+			'trackerids'         => [],
+			'foreign_trackerids' => [],
+			'last_trackerid'     => 1700000009,
+		];
+
+		$id = pfb_tracker('pfB_Test_Alias', 'lan', 'Deny');
+
+		// pfb_tracker() stores trackerids as strings (the '177'.$padded concatenation).
+		// assertContains with strict=false to match int vs string interchangeably.
+		$this->assertContains(
+			(string) $id,
+			array_map('strval', $pfb['trackerids']),
+			'pfb_tracker() must register its ID in $pfb[\'trackerids\']; got trackerids: ' .
+			json_encode($pfb['trackerids'])
+		);
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -750,3 +750,55 @@ if (!function_exists('system_syslogd_start')) {
 		// No-op off-appliance.
 	}
 }
+
+// --- pfb_tracker() doubles (#482) ---
+//
+// pfb_tracker() calls four pfSense interface helpers that have no off-appliance
+// equivalent and were not previously exercised by the unit suite.  These minimal
+// doubles make pfb_tracker() callable in tests; each is seedable via $GLOBALS so
+// tests can control the char-sum and thus the natural tracker ID.
+
+if (!function_exists('get_real_interface')) {
+	// pfSense interfaces.inc: map friendly interface name to the real OS interface
+	// (e.g. 'lan' -> 'em1').  Tests seed $GLOBALS['pfb_test_real_interface'] (map
+	// of name => real-name); absent key returns the input unchanged (identity).
+	function get_real_interface($interface = 'wan', $type = '') {
+		$map = $GLOBALS['pfb_test_real_interface'] ?? [];
+		return $map[$interface] ?? $interface;
+	}
+}
+
+if (!function_exists('ip2long32')) {
+	// pfSense util.inc: like ip2long() but returns an UNSIGNED 32-bit integer
+	// (avoids sign issues on 64-bit PHP where ip2long returns a signed int for
+	// addresses >= 128.0.0.0).  Faithful: cast the signed result to unsigned via
+	// sprintf('%u').
+	function ip2long32($ip) {
+		$long = ip2long((string) $ip);
+		if ($long === false) {
+			return 0;
+		}
+		return (int) sprintf('%u', $long);
+	}
+}
+
+if (!function_exists('find_interface_subnet')) {
+	// pfSense interfaces.inc: returns the IPv4 prefix-length (as a string) for the
+	// REAL interface name (i.e. after get_real_interface() has resolved it).
+	// Tests seed $GLOBALS['pfb_test_find_interface_subnet'] (map of real-name =>
+	// bits string, default []); absent key returns null.
+	function find_interface_subnet($real_interface) {
+		$map = $GLOBALS['pfb_test_find_interface_subnet'] ?? [];
+		return $map[$real_interface] ?? null;
+	}
+}
+
+if (!function_exists('find_interface_subnetv6')) {
+	// pfSense interfaces.inc: IPv6 counterpart of find_interface_subnet.
+	// Tests seed $GLOBALS['pfb_test_find_interface_subnetv6'] (map of real-name =>
+	// bits string, default []); absent key returns null.
+	function find_interface_subnetv6($real_interface) {
+		$map = $GLOBALS['pfb_test_find_interface_subnetv6'] ?? [];
+		return $map[$real_interface] ?? null;
+	}
+}


### PR DESCRIPTION
## Summary

Both firewall-rule tracker generators deduped a newly-minted `tracker` only against pfBlockerNG's own in-run registry (`$pfb['trackerids']`), never against trackers already on **foreign** `filter/rule` rows (GUI- or other-package-created rules). pfSense keys rule edit/delete and separators on a unique numeric `tracker`, so a collision between a pfBlockerNG tracker and a foreign rule's tracker could make a GUI operation act on the wrong rule. Latent and never observed, but a real gap worth closing.

## Change

- New `pfb_collect_foreign_trackers(): array` — gathers tracker IDs from `filter/rule` rows that are **not** pfBlockerNG-owned (`pfb_is_managed_obj()` exclusion, so we never treat our own prior rules as foreign and re-mint them every sync). Only `filter/rule` is consulted: pfSense NAT rules carry no tracker, so `nat/rule` is irrelevant.
- Seeded once per update run into `$pfb['foreign_trackerids']` at the tracker-registry init, before any rule is processed.
- Both generators now reject foreign IDs in addition to their own registry:
  - `pfb_tracker()` (`177…`) — expanded collision check plus a bump-until-free loop so an incremented fallback ID that also lands on a foreign tracker keeps stepping.
  - `pfb_managed_rule_tracker()` (`176…`) — expanded the deterministic probe `while` to skip foreign IDs too (determinism preserved: the foreign set is fixed for the run).

Deliberately **not** a namespace migration — existing `176…`/`177…` trackers are left as-is (non-goals: no re-mint, no namespace change).

## Tests

- `tests/php/ForeignTrackerCollectionTest.php` — pins `pfb_collect_foreign_trackers()`: foreign rows collected, pfB-owned rows and missing/empty trackers excluded, `nat/rule` ignored, empty config → empty.
- `tests/php/TrackerForeignCollisionTest.php` — pins foreign-set collision avoidance in both generators (asserts the before-state so green proves causation) and determinism preservation.
- Added faithful doubles (`get_real_interface`, `ip2long32`, `find_interface_subnet`, `find_interface_subnetv6`) so `pfb_tracker()` is callable off-appliance.

Tests fail on the pre-fix commit and pass after. Full PHP suite green (1304), PHPStan/PHPCS clean.

Fixes #482


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rule ID handling to avoid conflicts with existing firewall rules, reducing the chance of sync issues.
  * Made tracker assignment more reliable for managed and automatically created rules, even when IDs are already in use.
* **Tests**
  * Added coverage for tracker ID discovery and collision avoidance to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->