### PR TITLE
ci: order repo-publish after sync-ports-fork to fix stale nightly version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1039,12 +1039,19 @@ jobs:
   # release must be fully attached, healthchecked, AND flipped to published first.
   # publish-release only publishes a COMPLETE draft (healthcheck), so by the time this
   # fires the published release carries every expected .pkg.
-  # ADDITIVE + ISOLATED — sync-ports-fork does NOT `needs:` this, so a failure here can
-  # NEVER gate or break release / sync-ports-fork / attach-pkgs.
+  # ISOLATED — sync-ports-fork does NOT `needs:` this, so a failure here can NEVER gate or
+  # break release / sync-ports-fork / attach-pkgs.
+  # ORDERED AFTER sync-ports-fork — pfBlockerNG/pkg's publish.yml derives the NIGHTLY version
+  # from the `-nightly` port's PORTVERSION in the FreeBSD-ports fork, which sync-ports-fork
+  # bumps. If this dispatch raced sync-ports-fork, the pkg repo read the OLD PORTVERSION and
+  # shipped a stale-versioned nightly (e.g. 4.0.0.alpha.3.* on the alpha.4 commit). Waiting for
+  # sync-ports-fork guarantees the bump has landed before the pkg repo reads it. The retained
+  # `always()` keeps this running even if sync-ports-fork fails — it ORDERS, never hard-gates;
+  # the `if` still requires the release itself to have published.
   repo-publish:
     name: Trigger pkg repository publish
     runs-on: ubuntu-latest
-    needs: [prepare-release, release, attach-pkgs, publish-release]
+    needs: [prepare-release, release, attach-pkgs, publish-release, sync-ports-fork]
     if: always() && needs.release.result == 'success' && needs.publish-release.result == 'success' && needs.release.outputs.dry_run != 'true'
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

The published **nightly** for the `v4.0.0.alpha.4` commit was versioned `4.0.0.alpha.3.*` — one release behind.

`pfBlockerNG/pkg`'s `publish.yml` derives the nightly version as `<TARGET>.YYYYMMDD.<seq>`, where `TARGET` is the **`-nightly` port's `PORTVERSION`** read from the FreeBSD-ports fork (`pfblockerng/use-github`). That `PORTVERSION` is bumped by `release.yml`'s **`sync-ports-fork`** job.

In `release.yml`, **`repo-publish`** (which dispatches the pkg repo's `publish.yml`) and **`sync-ports-fork`** both `needs: [..., publish-release]` and ran **in parallel**. So `repo-publish` could fire the pkg-repo build *before* `sync-ports-fork` pushed the bump — the pkg repo then read the previous `PORTVERSION` and shipped a stale-versioned nightly.

## Fix

Add `sync-ports-fork` to `repo-publish`'s `needs:` so the dispatch waits until the fork bump has landed. The existing `always()` is retained, so a `sync-ports-fork` failure only **orders** the republish — it never hard-gates it (the `if` still requires the release itself to have published). One-directional: `sync-ports-fork` still does not depend on `repo-publish`, so its isolation is preserved (no cycle).

## Validation

- `actionlint` parses the workflow with no new findings (the two pre-existing notes at lines 184/375 are unrelated).
- No dependency cycle: `sync-ports-fork` needs `[prepare-release, release, publish-release]`; `repo-publish` now needs that plus `sync-ports-fork`.

The already-published stale nightly was corrected out-of-band by re-dispatching the pkg repo publish now that the fork is at `4.0.0.alpha.4`; this change prevents the race on future releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process so publishing now waits for an earlier sync step to finish first.
  * Improved the ordering of release automation to better ensure package updates land before publishing.
  * Kept the workflow resilient so publishing can still proceed if the sync step fails, while still requiring a successful release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->