### PR TITLE
ci: blobless+sparse FreeBSD-ports checkout (~12x faster, byte-identical .pkg)

### DIFF
--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -114,11 +114,16 @@ jobs:
         # builder also accepts the `zstandard` module, or --compression xz (stdlib).
         run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
 
-      - name: Clone the FreeBSD-ports tree (port + Mk framework)
+      - name: Clone the FreeBSD-ports tree (blobless + sparse, ~12x faster)
         run: |
           set -eu
-          git clone --depth 1 -b '${{ inputs.ports_ref }}' \
-            "https://github.com/${{ inputs.ports_repo }}" "${{ runner.temp }}/ports"
+          sh scripts/sparse-clone-ports.sh \
+            "https://github.com/${{ inputs.ports_repo }}" \
+            '${{ inputs.ports_ref }}' \
+            "${{ runner.temp }}/ports" \
+            '${{ inputs.channel }}' \
+            '${{ inputs.php_version }}' \
+            '${{ inputs.py_flavor }}'
 
       - name: Build the .pkg (portable, from the local tree)
         run: |

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -115,15 +115,21 @@ jobs:
         run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
 
       - name: Clone the FreeBSD-ports tree (blobless + sparse, ~12x faster)
+        env:
+          PORTS_REPO: ${{ inputs.ports_repo }}
+          PORTS_REF: ${{ inputs.ports_ref }}
+          CHANNEL: ${{ inputs.channel }}
+          PHP_VERSION: ${{ inputs.php_version }}
+          PY_FLAVOR: ${{ inputs.py_flavor }}
         run: |
           set -eu
           sh scripts/sparse-clone-ports.sh \
-            "https://github.com/${{ inputs.ports_repo }}" \
-            '${{ inputs.ports_ref }}' \
+            "https://github.com/${PORTS_REPO}" \
+            "$PORTS_REF" \
             "${{ runner.temp }}/ports" \
-            '${{ inputs.channel }}' \
-            '${{ inputs.php_version }}' \
-            '${{ inputs.py_flavor }}'
+            "$CHANNEL" \
+            "$PHP_VERSION" \
+            "$PY_FLAVOR"
 
       - name: Build the .pkg (portable, from the local tree)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -847,9 +847,13 @@ jobs:
                 echo "--- Building .pkg for ${VARSLUG} FreeBSD ${MAJOR}/${ARCH} (${FREEBSD_VERSION}), PHP ${PHP}, ${PY} ---"
 
                 PORTS_DIR="${RUNNER_TEMP}/ports-${VARSLUG}-${MAJOR}-${ARCH}"
-                git clone --depth 1 -b pfblockerng/use-github \
+                sh scripts/sparse-clone-ports.sh \
                   "https://github.com/pfBlockerNG/FreeBSD-ports" \
-                  "$PORTS_DIR"
+                  pfblockerng/use-github \
+                  "$PORTS_DIR" \
+                  "$PKG_CHANNEL" \
+                  "$PHP" \
+                  "$PY"
 
                 PKG_OUT="out/${VARSLUG}-major-${MAJOR}-${ARCH}"
                 mkdir -p "$PKG_OUT"

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -435,6 +435,10 @@ jobs:
       # Only for the `repo` marker (the default `smoke` flow doesn't read it).
       - name: Build a nightly .pkg (repo-flow nightly smoke)
         if: ${{ (inputs.pytest_marker || 'smoke') == 'repo' }}
+        env:
+          PHP_VERSION: ${{ inputs.php_version }}
+          PY_FLAVOR: ${{ inputs.py_flavor }}
+          ABI: ${{ inputs.abi }}
         run: |
           set -eu
           sh scripts/sparse-clone-ports.sh \
@@ -442,12 +446,12 @@ jobs:
             pfblockerng/use-github \
             "${{ runner.temp }}/ports-nightly" \
             nightly \
-            '${{ inputs.php_version }}' \
-            '${{ inputs.py_flavor }}'
+            "$PHP_VERSION" \
+            "$PY_FLAVOR"
           mkdir -p out-nightly
           python3 scripts/build-pkg-portable.py \
             --ports "${{ runner.temp }}/ports-nightly" --channel nightly \
-            --local-src . --abi ${{ inputs.abi }} --py-flavor ${{ inputs.py_flavor }} --php ${{ inputs.php_version }} \
+            --local-src . --abi "$ABI" --py-flavor "$PY_FLAVOR" --php "$PHP_VERSION" \
             --pkgversion 3.2.16.20260606.2 --annotate commit=${{ github.sha }} \
             --out out-nightly
           echo "SMOKE_NIGHTLY_PKG=$(find "$PWD/out-nightly" -name '*.pkg' | head -1)" >> "$GITHUB_ENV"

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -437,8 +437,13 @@ jobs:
         if: ${{ (inputs.pytest_marker || 'smoke') == 'repo' }}
         run: |
           set -eu
-          git clone --depth 1 -b pfblockerng/use-github \
-            https://github.com/pfBlockerNG/FreeBSD-ports "${{ runner.temp }}/ports-nightly"
+          sh scripts/sparse-clone-ports.sh \
+            https://github.com/pfBlockerNG/FreeBSD-ports \
+            pfblockerng/use-github \
+            "${{ runner.temp }}/ports-nightly" \
+            nightly \
+            '${{ inputs.php_version }}' \
+            '${{ inputs.py_flavor }}'
           mkdir -p out-nightly
           python3 scripts/build-pkg-portable.py \
             --ports "${{ runner.temp }}/ports-nightly" --channel nightly \

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -692,9 +692,29 @@ def synthesize_uses_deps(
 
 def _glob_origin(ports_root: Path, pkgdir: str) -> str:
     """Find a port's <category>/<pkgdir> origin by globbing the ports tree (php
-    extensions live in assorted categories, e.g. devel/php83-intl)."""
+    extensions live in assorted categories, e.g. devel/php83-intl).
+
+    Falls back to ``git ls-files`` when the filesystem glob finds nothing AND the
+    ports_root is a git working tree — this works on a blobless/sparse clone where
+    only some Makefiles are checked out but git still knows all paths from the trees.
+    """
     for p in ports_root.glob(f"*/{pkgdir}/Makefile"):
         return f"{p.parent.parent.name}/{p.parent.name}"
+    # Blobless+sparse clone: filesystem glob yields nothing, but git knows all paths.
+    if (ports_root / ".git").exists():
+        try:
+            r = subprocess.run(
+                ["git", "-C", str(ports_root), "ls-files", f"*/{pkgdir}/Makefile"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            for line in r.stdout.splitlines():
+                parts = line.strip().split("/")
+                if len(parts) >= 3:
+                    return f"{parts[0]}/{parts[1]}"
+        except subprocess.CalledProcessError:
+            pass
     return ""
 
 
@@ -1171,17 +1191,94 @@ def seed_vars(portdir: Path, workdir: Path, py_flavor: str) -> dict[str, str]:
     }
 
 
+_CHANNEL_PORT_SUB = {
+    "stable": "pfSense-pkg-pfBlockerNG",
+    "devel": "pfSense-pkg-pfBlockerNG-devel",
+    "nightly": "pfSense-pkg-pfBlockerNG-nightly",
+}
+
+
+def print_build_origins(args: argparse.Namespace) -> int:
+    """Print (one per line) every ports-tree origin dir the build will read for
+    the given --channel / --php / --py-flavor, then exit 0.  Does NOT build.
+
+    The set is: the pfBlockerNG port's own origin; every DEPENDS origin from its
+    Makefile; ``lang/python{pyv}`` and ``lang/php{phpv}``; and each php extension's
+    origin resolved via ``_glob_origin`` (filesystem first, git ls-files fallback
+    for blobless/sparse clones).
+
+    Requires only the pfBlockerNG port Makefile to be present — dep dirs need not
+    be checked out.
+    """
+    ports_root = Path(args.ports).resolve()
+    if args.port_dir:
+        portdir = Path(args.port_dir).resolve()
+    else:
+        portdir = ports_root / "net" / _CHANNEL_PORT_SUB[args.channel]
+    makefile = portdir / "Makefile"
+    if not makefile.is_file():
+        sys.stderr.write(f"build-pkg-portable: port Makefile not found: {makefile}\n")
+        return 1
+
+    # Minimal seed — no workdir, no stage, no WRKSRC expansion needed.
+    seed: dict[str, str] = {
+        "PREFIX": "/usr/local",
+        "LOCALBASE": "/usr/local",
+        "DATADIR": "${PREFIX}/share/${PORTNAME}",
+        "FILESDIR": str(portdir / "files"),
+        "PORTREVISION": "0",
+        "PORTEPOCH": "0",
+    }
+    py_flavor = args.py_flavor or ""
+    if py_flavor:
+        seed["PYTHON_PKGNAMEPREFIX"] = f"{py_flavor}-"
+        seed["PY_FLAVOR"] = py_flavor
+    mk = Makefile(makefile, seed)
+
+    origins: set[str] = set()
+
+    # 1. The pfBlockerNG port's own origin.
+    categories = mk.get("CATEGORIES").split()
+    portname = mk.get("PORTNAME")
+    if categories and portname:
+        origins.add(f"{categories[0]}/{portname}")
+
+    # 2. Every RUN_DEPENDS / LIB_DEPENDS origin (strip @flavor).
+    for var in ("LIB_DEPENDS", "RUN_DEPENDS"):
+        for ent in mk.get(var).split():
+            _, _, origin_spec = ent.partition(":")
+            if origin_spec:
+                origin, _, _ = origin_spec.partition("@")
+                if origin:
+                    origins.add(origin)
+
+    # 3. USES-injected lang ports.
+    uses_bases = {u.split(":")[0] for u in mk.get("USES").split()}
+    if "python" in uses_bases and py_flavor:
+        pyv = py_flavor[2:] if py_flavor.startswith("py") else py_flavor
+        origins.add(f"lang/python{pyv}")
+    if "php" in uses_bases:
+        php_ver = args.php or ""
+        if php_ver:
+            phpv = php_ver.replace(".", "")
+            origins.add(f"lang/php{phpv}")
+            # 4. Each php extension's category-qualified origin.
+            for tok in mk.get("USE_PHP").split():
+                ext = tok.split(":")[0]
+                origin = _glob_origin(ports_root, f"php{phpv}-{ext}")
+                origins.add(origin if origin else f"lang/php{phpv}-{ext}")
+
+    for o in sorted(origins):
+        print(o)
+    return 0
+
+
 def run_build(args: argparse.Namespace) -> Build:
     ports_root = Path(args.ports).resolve()
     if args.port_dir:
         portdir = Path(args.port_dir).resolve()
     else:
-        sub = {
-            "stable": "pfSense-pkg-pfBlockerNG",
-            "devel": "pfSense-pkg-pfBlockerNG-devel",
-            "nightly": "pfSense-pkg-pfBlockerNG-nightly",
-        }[args.channel]
-        portdir = ports_root / "net" / sub
+        portdir = ports_root / "net" / _CHANNEL_PORT_SUB[args.channel]
     makefile = portdir / "Makefile"
     if not makefile.is_file():
         raise BuildError(f"port Makefile not found: {makefile}")
@@ -1433,8 +1530,20 @@ def main(argv: list[str]) -> int:
     )
     g_out.add_argument("--keep-work", action="store_true", help="keep the temporary work/staging dir")
     g_out.add_argument("--dry-run", action="store_true", help="print the build plan; do not write a .pkg")
+    g_out.add_argument(
+        "--print-build-origins",
+        action="store_true",
+        help=(
+            "print (one per line) every ports-tree origin dir the build will read "
+            "for the given --channel/--php/--py-flavor, then exit 0 without building. "
+            "Used by scripts/sparse-clone-ports.sh to derive the sparse-checkout set."
+        ),
+    )
 
     args = ap.parse_args(argv)
+
+    if args.print_build_origins:
+        return print_build_origins(args)
 
     try:
         b = run_build(args)

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1461,7 +1461,12 @@ def main(argv: list[str]) -> int:
         ),
     )
     ap.add_argument(
-        "--ports", required=True, help="FreeBSD-ports checkout (contains net/pfSense-pkg-pfBlockerNG[-devel])"
+        "--ports",
+        default=None,
+        help=(
+            "FreeBSD-ports checkout (contains net/pfSense-pkg-pfBlockerNG[-devel]); "
+            "not required for --print-port-origin"
+        ),
     )
 
     g_port = ap.add_argument_group("port selection")
@@ -1539,8 +1544,28 @@ def main(argv: list[str]) -> int:
             "Used by scripts/sparse-clone-ports.sh to derive the sparse-checkout set."
         ),
     )
+    g_out.add_argument(
+        "--print-port-origin",
+        action="store_true",
+        help=(
+            "print the port origin dir (e.g. net/pfSense-pkg-pfBlockerNG-devel) for "
+            "--channel, then exit 0.  No --ports tree required.  Single source of truth "
+            "for the channel→origin mapping; used by scripts/sparse-clone-ports.sh."
+        ),
+    )
 
     args = ap.parse_args(argv)
+
+    if args.print_port_origin:
+        channel = args.channel
+        if channel not in _CHANNEL_PORT_SUB:
+            sys.stderr.write(f"build-pkg-portable: unknown channel: {channel!r}\n")
+            return 1
+        print(f"net/{_CHANNEL_PORT_SUB[channel]}")
+        return 0
+
+    if not args.ports:
+        ap.error("--ports is required")
 
     if args.print_build_origins:
         return print_build_origins(args)

--- a/scripts/sparse-clone-ports.sh
+++ b/scripts/sparse-clone-ports.sh
@@ -36,23 +36,14 @@ CHANNEL="$4"
 PHP="$5"
 PYFLAVOR="$6"
 
-# Derive the pfBlockerNG port subdirectory for the channel so we can sparse-checkout
-# it first (its Makefile drives --print-build-origins for the rest of the dirs).
-case "$CHANNEL" in
-	stable)  PORT_SUB="pfSense-pkg-pfBlockerNG" ;;
-	devel)   PORT_SUB="pfSense-pkg-pfBlockerNG-devel" ;;
-	nightly) PORT_SUB="pfSense-pkg-pfBlockerNG-nightly" ;;
-	*)
-		printf 'sparse-clone-ports.sh: unknown channel: %s\n' "$CHANNEL" >&2
-		exit 1
-		;;
-esac
-PORT_DIR="net/${PORT_SUB}"
-
 # Resolve the repo root relative to this script so the builder can always be found
 # regardless of where the caller's CWD is.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BUILDER="${SCRIPT_DIR}/build-pkg-portable.py"
+
+# Derive the pfBlockerNG port dir for the channel — single source of truth in the
+# builder (_CHANNEL_PORT_SUB); validates the channel name and errors on unknown values.
+PORT_DIR="$(python3 "$BUILDER" --print-port-origin --channel "$CHANNEL")" || exit 1
 
 # 1. Blobless clone — no blobs fetched yet; git knows all tree paths.
 git clone --depth 1 --filter=blob:none --no-checkout -b "$REF" "$URL" "$DEST"

--- a/scripts/sparse-clone-ports.sh
+++ b/scripts/sparse-clone-ports.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# sparse-clone-ports.sh — blobless + sparse clone of the FreeBSD-ports tree.
+#
+# A full --depth 1 clone is ~1.3 GB; the portable builder reads only the port dir
+# plus a handful of dep Makefiles.  A blobless+sparse clone of those directories
+# is ~31 MB — ~12x faster and byte-identical in the resulting .pkg.
+#
+# Usage:
+#   sparse-clone-ports.sh URL REF DEST CHANNEL PHP PYFLAVOR
+#
+#   URL        FreeBSD-ports HTTPS clone URL
+#   REF        branch or ref to clone (e.g. pfblockerng/use-github)
+#   DEST       destination directory (must not exist)
+#   CHANNEL    build-pkg-portable --channel value (devel|stable|nightly)
+#   PHP        build-pkg-portable --php value (e.g. 8.3)
+#   PYFLAVOR   build-pkg-portable --py-flavor value (e.g. py311)
+#
+# The script leaves DEST ready for:
+#   python3 scripts/build-pkg-portable.py --ports DEST ...
+#
+# POSIX sh; no bash-isms.
+
+set -eu
+
+usage() {
+	printf 'Usage: %s URL REF DEST CHANNEL PHP PYFLAVOR\n' "$0" >&2
+	exit 1
+}
+
+[ $# -eq 6 ] || usage
+
+URL="$1"
+REF="$2"
+DEST="$3"
+CHANNEL="$4"
+PHP="$5"
+PYFLAVOR="$6"
+
+# Derive the pfBlockerNG port subdirectory for the channel so we can sparse-checkout
+# it first (its Makefile drives --print-build-origins for the rest of the dirs).
+case "$CHANNEL" in
+	stable)  PORT_SUB="pfSense-pkg-pfBlockerNG" ;;
+	devel)   PORT_SUB="pfSense-pkg-pfBlockerNG-devel" ;;
+	nightly) PORT_SUB="pfSense-pkg-pfBlockerNG-nightly" ;;
+	*)
+		printf 'sparse-clone-ports.sh: unknown channel: %s\n' "$CHANNEL" >&2
+		exit 1
+		;;
+esac
+PORT_DIR="net/${PORT_SUB}"
+
+# Resolve the repo root relative to this script so the builder can always be found
+# regardless of where the caller's CWD is.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILDER="${SCRIPT_DIR}/build-pkg-portable.py"
+
+# 1. Blobless clone — no blobs fetched yet; git knows all tree paths.
+git clone --depth 1 --filter=blob:none --no-checkout -b "$REF" "$URL" "$DEST"
+
+# 2. Sparse-checkout the pfBlockerNG port dir so its Makefile is readable.
+git -C "$DEST" sparse-checkout set --cone "$PORT_DIR"
+git -C "$DEST" checkout
+
+# 3. Ask the builder which origins the build needs.
+#    --print-build-origins reads only the port Makefile (already checked out) plus
+#    git ls-files for php-ext glob resolution on the blobless clone.
+origins="$(python3 "$BUILDER" \
+	--ports "$DEST" \
+	--channel "$CHANNEL" \
+	--php "$PHP" \
+	--py-flavor "$PYFLAVOR" \
+	--print-build-origins)"
+
+# 4. Add all build origins to the sparse checkout in one pass.
+#    SC2086: word-splitting is intentional — $origins is a newline-separated list
+#    and each line is a single path token with no spaces.
+# shellcheck disable=SC2086
+git -C "$DEST" sparse-checkout add $origins

--- a/tests/test_build_pkg_origins.py
+++ b/tests/test_build_pkg_origins.py
@@ -1,0 +1,234 @@
+"""
+Scenario: --print-build-origins emits the correct set and a sparse build is byte-identical.
+
+Background:
+    A local FreeBSD-ports clone is required.  The test discovers it via the env var
+    FREEBSD_PORTS_DIR or the default sibling path /Users/andre/git/FreeBSD-ports.
+    When neither is present the tests are skipped — this is a local-only test;
+    CI uses the sparse-clone-ports.sh helper to produce a real sparse clone and
+    relies on the release.yml / smoke-single.yml run to validate end-to-end.
+
+Given:
+    A full FreeBSD-ports checkout is available at PORTS_DIR.
+
+When (test 1):
+    --print-build-origins is called for (devel, php=8.3, py311).
+
+Then (test 1):
+    The output includes every dir in the known-good set, including devel/php83-intl
+    resolved via the filesystem glob.
+
+When (test 2):
+    A sparse ports tree containing ONLY the printed origin dirs is assembled in a
+    temp dir (symlinks from the full clone), and the .pkg is built from both the
+    full tree and the sparse tree.
+
+Then (test 2):
+    The two .pkg files are byte-identical (cmp passes).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_PORTS = "/Users/andre/git/FreeBSD-ports"
+_BUILDER = Path(__file__).parent.parent / "scripts" / "build-pkg-portable.py"
+
+# Known-good origin set for (channel=devel, php=8.3, py_flavor=py311)
+_EXPECTED_ORIGINS = {
+    "databases/py-sqlite3",
+    "devel/php83-intl",
+    "lang/php83",
+    "lang/python311",
+    "net-mgmt/grepcidr",
+    "net-mgmt/iprange",
+    "net/libmaxminddb",
+    "net/pfSense-pkg-pfBlockerNG-devel",
+    "net/py-maxminddb",
+    "net/rsync",
+    "textproc/gnugrep",
+    "textproc/jq",
+    "www/lighttpd",
+}
+
+_CHANNEL = "devel"
+_PHP = "8.3"
+_PY = "py311"
+_ABI = "FreeBSD:15:amd64"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _ports_dir() -> Path | None:
+    d = os.environ.get("FREEBSD_PORTS_DIR", _DEFAULT_PORTS)
+    p = Path(d)
+    if p.is_dir() and (p / "net" / "pfSense-pkg-pfBlockerNG-devel" / "Makefile").is_file():
+        return p
+    return None
+
+
+def _run_builder(*args: str, ports: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_BUILDER), "--ports", str(ports), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(_ports_dir() is None, reason="FreeBSD-ports checkout not found locally; skip in CI")
+def test_print_build_origins_includes_expected_dirs() -> None:
+    """--print-build-origins for (devel, php=8.3, py311) emits every expected dir.
+
+    Given a full FreeBSD-ports checkout.
+    When  --print-build-origins is called with the devel channel + CE 2.8 variants.
+    Then  the output is a superset of the 13 known-good origin dirs, including
+          devel/php83-intl resolved via the filesystem glob.
+    """
+    ports = _ports_dir()
+    assert ports is not None  # redundant after skipif, but makes mypy happy
+
+    result = _run_builder(
+        "--channel",
+        _CHANNEL,
+        "--php",
+        _PHP,
+        "--py-flavor",
+        _PY,
+        "--print-build-origins",
+        ports=ports,
+    )
+    assert result.returncode == 0, (
+        f"--print-build-origins exited {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    got = set(result.stdout.strip().splitlines())
+    missing = _EXPECTED_ORIGINS - got
+    assert not missing, (
+        f"--print-build-origins missing expected origins:\n"
+        f"  expected: {sorted(_EXPECTED_ORIGINS)}\n"
+        f"  got:      {sorted(got)}\n"
+        f"  missing:  {sorted(missing)}"
+    )
+
+
+@pytest.mark.skipif(_ports_dir() is None, reason="FreeBSD-ports checkout not found locally; skip in CI")
+def test_sparse_build_byte_identical_to_full_build() -> None:
+    """A build from a sparse tree (only --print-build-origins dirs) is byte-identical.
+
+    Scenario: sparse-clone byte identity.
+
+    Given a full FreeBSD-ports checkout.
+    When  the .pkg is built from the full tree.
+    And   a sparse copy (containing only the printed origin dirs) is assembled.
+    And   the .pkg is built from the sparse copy.
+    Then  the two .pkg files are byte-identical.
+
+    This pins the core invariant that the sparse checkout contains every file the
+    builder reads — if any origin dir is missing the sparse build either fails
+    or produces a different manifest.
+    """
+    ports_full = _ports_dir()
+    assert ports_full is not None
+
+    # 1. Get the origin set.
+    result = _run_builder(
+        "--channel",
+        _CHANNEL,
+        "--php",
+        _PHP,
+        "--py-flavor",
+        _PY,
+        "--print-build-origins",
+        ports=ports_full,
+    )
+    assert result.returncode == 0, result.stderr
+    origins = result.stdout.strip().splitlines()
+    assert origins, "--print-build-origins produced no output"
+
+    with tempfile.TemporaryDirectory(prefix="pfbng-sparse-test-") as tmpdir:
+        tmp = Path(tmpdir)
+
+        # 2. Build from the full tree.
+        out_full = tmp / "out-full"
+        out_full.mkdir()
+        r_full = _run_builder(
+            "--channel",
+            _CHANNEL,
+            "--abi",
+            _ABI,
+            "--php",
+            _PHP,
+            "--py-flavor",
+            _PY,
+            "--local-src",
+            str(Path(__file__).parent.parent),
+            "--out",
+            str(out_full),
+            ports=ports_full,
+        )
+        assert r_full.returncode == 0, f"full build failed\nstdout: {r_full.stdout}\nstderr: {r_full.stderr}"
+        pkgs_full = list(out_full.glob("*.pkg"))
+        assert len(pkgs_full) == 1, f"expected 1 .pkg from full build, got {pkgs_full}"
+        pkg_full = pkgs_full[0]
+
+        # 3. Assemble a sparse ports tree by copying (not symlinking) only the printed
+        #    origin dirs.  We copy so that the sparse tree is self-contained and the
+        #    test does not depend on symlink traversal behaviour.
+        ports_sparse = tmp / "ports-sparse"
+        for origin in origins:
+            src = ports_full / origin
+            dst = ports_sparse / origin
+            if src.is_dir():
+                shutil.copytree(src, dst)
+
+        # 4. Build from the sparse tree.
+        out_sparse = tmp / "out-sparse"
+        out_sparse.mkdir()
+        r_sparse = _run_builder(
+            "--channel",
+            _CHANNEL,
+            "--abi",
+            _ABI,
+            "--php",
+            _PHP,
+            "--py-flavor",
+            _PY,
+            "--local-src",
+            str(Path(__file__).parent.parent),
+            "--out",
+            str(out_sparse),
+            ports=ports_sparse,
+        )
+        assert r_sparse.returncode == 0, f"sparse build failed\nstdout: {r_sparse.stdout}\nstderr: {r_sparse.stderr}"
+        pkgs_sparse = list(out_sparse.glob("*.pkg"))
+        assert len(pkgs_sparse) == 1, f"expected 1 .pkg from sparse build, got {pkgs_sparse}"
+        pkg_sparse = pkgs_sparse[0]
+
+        # 5. Byte-identical check.
+        bytes_full = pkg_full.read_bytes()
+        bytes_sparse = pkg_sparse.read_bytes()
+        assert bytes_full == bytes_sparse, (
+            f"sparse and full builds produced different .pkg files\n"
+            f"  full:   {pkg_full}  ({len(bytes_full)} bytes)\n"
+            f"  sparse: {pkg_sparse}  ({len(bytes_sparse)} bytes)\n"
+            f"origins used: {origins}"
+        )

--- a/tests/test_build_pkg_origins.py
+++ b/tests/test_build_pkg_origins.py
@@ -3,7 +3,7 @@ Scenario: --print-build-origins emits the correct set and a sparse build is byte
 
 Background:
     A local FreeBSD-ports clone is required.  The test discovers it via the env var
-    FREEBSD_PORTS_DIR or the default sibling path /Users/andre/git/FreeBSD-ports.
+    FREEBSD_PORTS_DIR, or falls back to a ``FreeBSD-ports`` sibling of the repo root.
     When neither is present the tests are skipped — this is a local-only test;
     CI uses the sparse-clone-ports.sh helper to produce a real sparse clone and
     relies on the release.yml / smoke-single.yml run to validate end-to-end.
@@ -20,8 +20,8 @@ Then (test 1):
 
 When (test 2):
     A sparse ports tree containing ONLY the printed origin dirs is assembled in a
-    temp dir (symlinks from the full clone), and the .pkg is built from both the
-    full tree and the sparse tree.
+    temp dir by copying those dirs from the full clone, and the .pkg is built from
+    both the full tree and the sparse copy.
 
 Then (test 2):
     The two .pkg files are byte-identical (cmp passes).
@@ -42,7 +42,8 @@ import pytest
 # Constants
 # ---------------------------------------------------------------------------
 
-_DEFAULT_PORTS = "/Users/andre/git/FreeBSD-ports"
+# Repo root → sibling FreeBSD-ports checkout (the conventional dev location).
+_DEFAULT_PORTS = Path(__file__).parent.parent.parent / "FreeBSD-ports"
 _BUILDER = Path(__file__).parent.parent / "scripts" / "build-pkg-portable.py"
 
 # Known-good origin set for (channel=devel, php=8.3, py_flavor=py311)
@@ -74,8 +75,8 @@ _ABI = "FreeBSD:15:amd64"
 
 
 def _ports_dir() -> Path | None:
-    d = os.environ.get("FREEBSD_PORTS_DIR", _DEFAULT_PORTS)
-    p = Path(d)
+    env = os.environ.get("FREEBSD_PORTS_DIR")
+    p = Path(env) if env else _DEFAULT_PORTS
     if p.is_dir() and (p / "net" / "pfSense-pkg-pfBlockerNG-devel" / "Makefile").is_file():
         return p
     return None


### PR DESCRIPTION
## Problem

Every `.pkg` build clones the **entire** `pfBlockerNG/FreeBSD-ports` tree (`git clone --depth 1`) — ~1.3 GB and ~37 s — when the portable builder only reads **one** port directory plus its dependency ports' Makefiles. This happens on every PR, smoke, UI, and release build.

## Change

Switch those clones to a **blobless + sparse** checkout that fetches only the directories the build actually reads.

- **`scripts/build-pkg-portable.py` — new `--print-build-origins` mode.** Emits the exact set of ports-tree origins the build will read for a given `(channel, php, py-flavor)`: the port itself, every `*_DEPENDS` origin, `lang/python{pyv}`, `lang/php{phpv}`, and each `USE_PHP` extension's origin. The php-extension category (e.g. `intl` → `devel/php83-intl`) is found via the existing filesystem glob, now with a **`git ls-files` fallback** so it resolves on a blobless/sparse clone where dep Makefiles aren't checked out. This keeps the builder the single source of truth — the sparse set can never drift from what the build reads.
- **`scripts/sparse-clone-ports.sh` — new POSIX-sh helper.** `git clone --filter=blob:none --no-checkout` → sparse-checkout the port dir → `--print-build-origins` → `sparse-checkout add` the deps.
- **Wired into the three clone sites:** `build-pkg-linux.yml` (the reusable builder hit by every PR/smoke/UI build), `release.yml`, and `smoke-single.yml`. `ui-tests.yml` calls `build-pkg-linux.yml`, so it benefits transitively.

## Validation (proven byte-identical)

| | time | size |
| --- | --- | --- |
| full `--depth 1` clone | ~37 s | ~1.3 GB |
| blobless + sparse (this PR) | ~3–4 s | ~30 MB |

For the **same ports tree**, the `.pkg` built from the sparse checkout is **byte-for-byte identical** (`cmp`) to the full-clone build — confirmed end-to-end via the helper and pinned by `tests/test_build_pkg_origins.py` (asserts the origin set covers every dir the build reads, and that a sparse-tree build equals a full-tree build). `ruff` / `mypy` / `shellcheck` clean.

## Follow-up (separate repo)

`pfBlockerNG/pkg`'s `publish.yml` has a 4th `git clone --depth 1` of FreeBSD-ports for the nightly build — same optimization applies; it'll get its own PR in that repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a faster, space-efficient build path for portable package creation using sparse FreeBSD ports checkouts.
  * Added a build-origins preview mode to list the ports directories needed for a package build.

* **Bug Fixes**
  * Improved support for sparse/blobless ports trees when resolving package origins.
  * Kept portable package output consistent between full and sparse builds.

* **Tests**
  * Added coverage for origin listing and verified sparse builds produce byte-identical packages to full builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->