### PR TITLE
pfblockerng: stop empty-feed DNSBL pass restarting Unbound every sync (#546)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1137,6 +1137,24 @@ function pfb_dnsbl_loaded_input_paths(array $pfb): array {
 	);
 }
 
+/* TRUE iff genuine FEED-derived DNSBL content is currently loaded — i.e. a non-empty
+   pfb_py_data, an existing pfb_py_zone, or at least one per-feed *.raw file. Deliberately
+   EXCLUDES the shipped pfb_py_hsts and the always-present manifest/whitelist, which are NOT
+   feed-derived: counting them makes a no-feed setup look "loaded" and triggers a clear+reload
+   every cron pass (#546). Pure (no global access). */
+function pfb_dnsbl_has_loaded_feeds(array $pfb): bool {
+	if (is_file($pfb['unbound_py_data']) && filesize($pfb['unbound_py_data']) > 0) {
+		return TRUE;
+	}
+	if (is_file($pfb['unbound_py_zone'])) {
+		return TRUE;
+	}
+	if (!empty(glob("{$pfb['unbound_py_rawdir']}/*.raw") ?: array())) {
+		return TRUE;
+	}
+	return FALSE;
+}
+
 /* Return a stable fingerprint of the given input-file set.
    A missing/unreadable file contributes '-' so that all-missing == all-missing (equal),
    and a first-seen file vs no-file produces a difference. Path list is sorted so
@@ -13051,31 +13069,26 @@ function sync_package_pfblockerng($cron='') {
 
 			// When DNSBL is enabled and no Aliases are defined, or all Aliases are Disabled
 			if (empty($lists_dnsbl_all) && !$pfb['save']) {
-				// Only clear (and flag domain_clear) when something is actually loaded;
-				// otherwise a no-feeds DNSBL setup would log "Clearing all DNSBL Feeds"
-				// and churn every cron. The fingerprint gate below is the reload authority
-				// (empty→empty => equal fingerprints => skip); domain_clear stays for the
-				// TLD-mode fallback path, where the fingerprint is not computed.
-				$pfb_loaded = FALSE;
-				foreach (pfb_dnsbl_loaded_input_paths($pfb) as $pfb_lf) {
-					if (file_exists($pfb_lf)) {
-						$pfb_loaded = TRUE;
-						break;
-					}
-				}
-				if ($pfb_loaded) {
+				// Only log/flag domain_clear when feeds were actually loaded (#546):
+				// pfb_dnsbl_has_loaded_feeds() excludes the shipped pfb_py_hsts and the
+				// always-present manifest/whitelist so a no-feeds setup never looks "loaded".
+				$had_feeds = pfb_dnsbl_has_loaded_feeds($pfb);
+				if ($had_feeds) {
 					pfb_logger("\nClearing all DNSBL Feeds", 1);
 					$pfb['domain_clear'] = TRUE;
-
-					// Clear out Unbound DNSBL files
-					unlink_if_exists($pfb['unbound_py_data']);
-					unlink_if_exists($pfb['unbound_py_zone']);
-					unlink_if_exists($pfb['unbound_py_wh']);
-					unlink_if_exists($pfb['unbound_py_count']);
-					unlink_if_exists($pfb['unbound_py_regex_count']);	// ADR-07 P8
-					unlink_if_exists($pfb['unbound_py_sources']);
-					rmdir_recursive("{$pfb['unbound_py_rawdir']}");
 				}
+
+				// Materialize canonical files as present-but-EMPTY rather than deleting them
+				// (#546). Empty-but-present files are byte-identical pass-to-pass, so the
+				// fingerprint gate treats empty→empty as unchanged (no reload). A genuine
+				// loaded→empty transition still diverges on the first pass (one reload), then
+				// stabilises. DO NOT delete pfb_py_wh: pfb_unbound_python() reads it to detect
+				// a whitelist change; missing=FALSE !== '' triggers $pfbpython=TRUE every pass.
+				pfb_unbound_python_sources(array());		// valid feeds:[] manifest + empty rawdir
+				@file_put_contents($pfb['unbound_py_data'], '', LOCK_EX);	// present-but-empty CSV
+				unlink_if_exists($pfb['unbound_py_zone']);			// python mode: zone must be absent
+				unlink_if_exists($pfb['unbound_py_count']);
+				unlink_if_exists($pfb['unbound_py_regex_count']);		// ADR-07 P8
 			}
 		}
 		else {

--- a/tests/php/DnsblHasLoadedFeedsTest.php
+++ b/tests/php/DnsblHasLoadedFeedsTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_has_loaded_feeds() — detects genuine feed-derived DNSBL content.
+ *
+ * Design intent: distinguish a no-feeds steady-state (empty py_data, no zone, no raw files)
+ * from a setup where feeds were actually loaded. The shipped pfb_py_hsts and the
+ * manifest/whitelist are deliberately EXCLUDED: counting them makes a no-feeds setup
+ * look "loaded", which caused a clear+reload every cron pass (#546).
+ *
+ * The empty-feed clear path now materializes files as present-but-empty rather than
+ * deleting them, so this helper gates the "Clearing all DNSBL Feeds" log/flag on whether
+ * FEED-derived content was present — not merely whether ANY path existed.
+ */
+#[CoversFunction('pfb_dnsbl_has_loaded_feeds')]
+final class DnsblHasLoadedFeedsTest extends TestCase
+{
+	private string $tmpDir;
+	private string $rawDir;
+
+	protected function setUp(): void
+	{
+		$this->tmpDir = sys_get_temp_dir() . '/pfb_hlf_test_' . getmypid() . '_' . mt_rand();
+		$this->rawDir = "{$this->tmpDir}/raw";
+		mkdir($this->tmpDir, 0700, TRUE);
+		mkdir($this->rawDir, 0700, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($this->tmpDir, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($files as $f) {
+			$f->isDir() ? rmdir((string) $f) : unlink((string) $f);
+		}
+		rmdir($this->tmpDir);
+	}
+
+	/** Build a minimal $pfb array with all paths under tmpDir. */
+	private function makePfb(): array
+	{
+		return [
+			'unbound_py_data'    => "{$this->tmpDir}/pfb_py_data.txt",
+			'unbound_py_zone'    => "{$this->tmpDir}/pfb_py_zone.txt",
+			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
+			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
+			'unbound_py_hsts'    => "{$this->tmpDir}/pfb_py_hsts.txt",
+			'unbound_py_rawdir'  => $this->rawDir,
+		];
+	}
+
+	/**
+	 * Scenario: empty setup — no data file, no zone, no raw files → no feeds loaded.
+	 *
+	 * Given:  a clean $pfb with no files on disk
+	 * When:   pfb_dnsbl_has_loaded_feeds() is called
+	 * Then:   returns FALSE (nothing feed-derived is present)
+	 *
+	 * This is the initial install / freshly-cleared state.
+	 */
+	public function testEmptySetupReturnsFalse(): void
+	{
+		$pfb = $this->makePfb();
+		$this->assertFalse(pfb_dnsbl_has_loaded_feeds($pfb), 'No files at all → FALSE');
+	}
+
+	/**
+	 * Scenario: 0-byte py_data (the materialized steady-state) → no feeds loaded (#546).
+	 *
+	 * Given:  pfb_py_data exists but is empty (written by the empty-feed clear path)
+	 * When:   pfb_dnsbl_has_loaded_feeds() is called
+	 * Then:   returns FALSE
+	 *
+	 * This is the key regression case: an empty-but-present py_data must NOT look like a
+	 * loaded feed, otherwise the "Clearing all DNSBL Feeds" log fires on every cron pass.
+	 */
+	public function testZeroByteDataFileReturnsFalse(): void
+	{
+		$pfb = $this->makePfb();
+		file_put_contents($pfb['unbound_py_data'], '');
+
+		$this->assertFalse(pfb_dnsbl_has_loaded_feeds($pfb), '0-byte py_data → FALSE (steady-state empty; #546)');
+	}
+
+	/**
+	 * Scenario: non-empty py_data → feeds are loaded.
+	 *
+	 * Given:  pfb_py_data contains at least one byte of CSV content
+	 * When:   pfb_dnsbl_has_loaded_feeds() is called
+	 * Then:   returns TRUE
+	 *
+	 * Before-state assertion (empty → FALSE) proves the non-empty file caused the flip.
+	 */
+	public function testNonEmptyDataFileReturnsTrue(): void
+	{
+		$pfb = $this->makePfb();
+
+		// Before: no file → FALSE.
+		$this->assertFalse(pfb_dnsbl_has_loaded_feeds($pfb), 'Before: absent py_data → FALSE');
+
+		// Write feed content.
+		file_put_contents($pfb['unbound_py_data'], "blocked.example.com,127.0.0.1\n");
+
+		// After: non-empty py_data → TRUE.
+		$this->assertTrue(pfb_dnsbl_has_loaded_feeds($pfb), 'Non-empty py_data → TRUE');
+	}
+
+	/**
+	 * Scenario: py_zone present → feeds are loaded (TLD mode).
+	 *
+	 * Given:  pfb_py_zone exists (even with no py_data)
+	 * When:   pfb_dnsbl_has_loaded_feeds() is called
+	 * Then:   returns TRUE
+	 *
+	 * Before-state assertion (no zone → FALSE) proves the zone caused the flip.
+	 */
+	public function testZoneFilePresentReturnsTrue(): void
+	{
+		$pfb = $this->makePfb();
+
+		// Before: no zone → FALSE.
+		$this->assertFalse(pfb_dnsbl_has_loaded_feeds($pfb), 'Before: absent py_zone → FALSE');
+
+		// Create zone file (TLD mode writes this).
+		file_put_contents($pfb['unbound_py_zone'], "local-zone: example.com redirect\n");
+
+		// After: zone present → TRUE.
+		$this->assertTrue(pfb_dnsbl_has_loaded_feeds($pfb), 'py_zone present → TRUE');
+	}
+
+	/**
+	 * Scenario: at least one *.raw in rawdir → feeds are loaded.
+	 *
+	 * Given:  a single *.raw file exists in the rawdir
+	 * When:   pfb_dnsbl_has_loaded_feeds() is called
+	 * Then:   returns TRUE
+	 *
+	 * Before-state assertion (empty rawdir → FALSE) proves the raw file caused the flip.
+	 */
+	public function testRawFilePresentReturnsTrue(): void
+	{
+		$pfb = $this->makePfb();
+
+		// Before: empty rawdir → FALSE.
+		$this->assertFalse(pfb_dnsbl_has_loaded_feeds($pfb), 'Before: empty rawdir → FALSE');
+
+		// Drop a raw file (pfb_unbound_python_sources() writes these for each feed).
+		file_put_contents("{$this->rawDir}/some_feed.raw", "blocked.example.com\n");
+
+		// After: *.raw present → TRUE.
+		$this->assertTrue(pfb_dnsbl_has_loaded_feeds($pfb), '*.raw in rawdir → TRUE');
+	}
+
+	/**
+	 * Scenario: only pfb_py_hsts present (no feed-derived files) → FALSE (#546 regression guard).
+	 *
+	 * Given:  pfb_py_hsts exists (the shipped HSTS preload list, always staged),
+	 *         but no py_data, py_zone, or *.raw files
+	 * When:   pfb_dnsbl_has_loaded_feeds() is called
+	 * Then:   returns FALSE
+	 *
+	 * This is the central regression the fix addresses: before #546, the loaded-input-paths
+	 * check included pfb_py_hsts, so a no-feeds setup (hsts always present) always returned
+	 * TRUE → "Clearing all DNSBL Feeds" + unlink(py_wh) + Unbound restart every cron.
+	 */
+	public function testOnlyHstsPresentReturnsFalse(): void
+	{
+		$pfb = $this->makePfb();
+
+		// Stage the shipped HSTS list (always present after package install).
+		file_put_contents($pfb['unbound_py_hsts'], "preload-domain.example\n");
+
+		// Must return FALSE: hsts is NOT a feed-derived file.
+		$this->assertFalse(
+			pfb_dnsbl_has_loaded_feeds($pfb),
+			'Only pfb_py_hsts present → FALSE (hsts is not feed-derived; #546 regression guard)'
+		);
+	}
+
+	/**
+	 * Scenario: whitelist and manifest present (non-feed files) → FALSE.
+	 *
+	 * Given:  pfb_py_wh (whitelist) and pfb_py_sources (manifest) exist but no feeds
+	 * When:   pfb_dnsbl_has_loaded_feeds() is called
+	 * Then:   returns FALSE
+	 *
+	 * pfb_unbound_python() owns py_wh; pfb_unbound_python_sources() maintains py_sources.
+	 * Neither constitutes "loaded feeds".
+	 */
+	public function testOnlyWhitelistAndManifestPresentReturnsFalse(): void
+	{
+		$pfb = $this->makePfb();
+		file_put_contents($pfb['unbound_py_wh'],      "allow.example.com\n");
+		file_put_contents($pfb['unbound_py_sources'], '{"version":1,"feeds":[]}');
+
+		$this->assertFalse(pfb_dnsbl_has_loaded_feeds($pfb), 'Whitelist + manifest only → FALSE');
+	}
+}

--- a/tests/smoke/test_dnsbl_empty_feed.py
+++ b/tests/smoke/test_dnsbl_empty_feed.py
@@ -1,0 +1,135 @@
+"""Smoke leg: DNSBL enabled with no feeds must not churn Unbound on a steady-state pass.
+
+Proves the §2 fix from issue #546 on a real pfSense CE VM:
+
+  An enabled DNSBL with zero feeds configured reaches a stable fingerprint after
+  the first sync pass.  Subsequent passes detect that empty→empty is unchanged and
+  skip the reload: no "Stopping Unbound Resolver", "Clearing all DNSBL Feeds", or
+  "Missing DNSBL stats and/or Unbound DNSBL files - Rebuilding" appear in the pass-2
+  log slice.
+
+  On pre-fix code, "Stopping Unbound Resolver" appears in BOTH passes because the
+  empty-feed branch deleted pfb_py_data/pfb_py_wh/manifest each pass, so every
+  fingerprint compare hit the missing-files fallback and forced a reload.
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke`` in
+pyproject.toml).  Run only by the smoke workflow or locally::
+
+    python -m pytest tests/smoke -m smoke --override-ini="addopts="
+
+Needs the booted ``smoke_vm`` fixture and ``SMOKE_PKG``; without them the module
+skips cleanly.  No feed server is required: this test configures DNSBL with zero feed
+rows and asserts on log content.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM, _StubDnsServer
+
+pytestmark = pytest.mark.smoke
+
+# --------------------------------------------------------------------------- #
+# Log strings whose presence in a pass-2 slice indicates churn (regression)
+# --------------------------------------------------------------------------- #
+
+_CHURN_STRINGS = (
+    "Stopping Unbound Resolver",
+    "Clearing all DNSBL Feeds",
+    "Missing DNSBL stats and/or Unbound DNSBL files - Rebuilding",
+)
+
+# --------------------------------------------------------------------------- #
+# Module-scoped fixture: deploy once, then run the churn assertion
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+    """Deploy the branch .pkg once for this module and configure DNSBL with zero feeds.
+
+    DNSBL is enabled (enable_cb=on, pfb_dnsbl=on, VIP injected, ports set) but the
+    DNSBL feed list is left empty.  The trigger verb is ``update`` (Force Update →
+    ``sync_package_pfblockerng('cron')``), which runs the full DNSBL sync path
+    including the fingerprint gate — exactly the path the #546 fix touches.
+
+    ``cron`` is intentionally NOT used here: with zero DNSBL rows ``pfblockerng_sync_cron``
+    sets ``update_cron=FALSE`` and calls ``sync_package_pfblockerng('noupdates')``, which
+    sets ``$pfb['save']=TRUE`` and bypasses all DNSBL processing — so the churn strings
+    can never appear and the test would be vacuously true.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.set_package_enabled(smoke_vm, on=True)
+    h.set_dnsbl_enabled(smoke_vm, on=True)
+    yield smoke_vm
+
+
+# --------------------------------------------------------------------------- #
+# Test case
+# --------------------------------------------------------------------------- #
+
+
+def test_no_unbound_restart_on_no_feed_steady_state_pass(deployed_vm: SmokeVM) -> None:
+    """Scenario — no-feed DNSBL steady state: a second sync pass must not churn Unbound.
+
+    Given:
+      - DNSBL enabled (enable_cb=on, pfb_dnsbl=on, VIP injected), zero feeds.
+
+    When (pass 1):
+      - Run a full sync pass (``update`` verb → ``sync_package_pfblockerng('cron')``).
+        This is the settle pass: allowed to emit churn strings on the initial install
+        state (files may be absent; the fix materialises them on exit).
+
+    When (pass 2):
+      - Capture the per-churn-string occurrence count in the pfBlockerNG log as the
+        delta baseline (one ``count_log_marker`` call per string, BEFORE pass 2 runs).
+      - Run a second full sync pass (same ``update`` verb).
+
+    Then:
+      - For each churn string, the post-pass-2 count equals the pre-pass-2 count —
+        i.e. the string did NOT appear in the pass-2 log slice.
+      - On failure, print each string that appeared with its pre- and post-count so the
+        reader knows which churn marker fired and how many times.
+    """
+    vm = deployed_vm
+
+    # --- Given: already configured by the deployed_vm fixture ---
+
+    # --- When (pass 1 — settle) ---
+    h.reload(vm, "update")
+
+    # --- When (pass 2 — steady state) ---
+    # Capture per-string occurrence counts BEFORE pass 2 runs.
+    before = {s: h.count_log_marker(vm, h.PFB_LOG, s) for s in _CHURN_STRINGS}
+
+    h.reload(vm, "update")
+
+    # Capture counts AFTER pass 2.
+    after = {s: h.count_log_marker(vm, h.PFB_LOG, s) for s in _CHURN_STRINGS}
+
+    # --- Then ---
+    churn_found = [s for s in _CHURN_STRINGS if after[s] > before[s]]
+    if churn_found:
+        lines = [
+            "AFTER pass 2, the following churn strings appeared in the pfBlockerNG log",
+            f"  (log: {h.PFB_LOG}):",
+        ]
+        for s in churn_found:
+            new_count = after[s] - before[s]
+            lines.append(f"  PRESENT ({new_count}x new): {s!r}")
+        for s in _CHURN_STRINGS:
+            if s not in churn_found:
+                lines.append(f"  absent (ok):            {s!r}")
+        lines.append(
+            "Expected: NONE of the churn strings in the pass-2 log slice.\n"
+            "This means the fix in issue #546 is not effective on this build."
+        )
+        pytest.fail("\n".join(lines))


### PR DESCRIPTION
## Summary

Fixes the DNSBL empty-feed churn from #546: with DNSBL **enabled** but **all feeds empty/disabled**, a sync pass restarted Unbound every time even though nothing changed.

## Root cause

The empty-feed branch in `sync_package_pfblockerng()` **deleted** the canonical DNSBL files (`pfb_py_data`, `pfb_py_wh`, the manifest, the raw dir) every pass. That deletion drove two independent reload triggers on the *next* pass:

- `pfb_unbound_python()` found `pfb_py_wh` missing — `FALSE !== ''` — and set `$pfbpython = TRUE` → full **Stop/Start Unbound** instead of the zero-downtime swap.
- the missing-data detector (`!file_exists(pfb_py_data)`) set `$dnsbl_missing = TRUE` → "Missing DNSBL stats… Rebuilding" + `reuse_dnsbl=on`.

The `$pfb_loaded` guard that was meant to skip the clear in an empty setup was defeated because `pfb_dnsbl_loaded_input_paths()` includes the **shipped, always-present** `pfb_py_hsts` — so a no-feed setup always looked "loaded".

## Fix

Materialize the canonical files **present-but-empty** instead of deleting them, so the existing fingerprint gate treats an empty→empty steady state as unchanged (no reload). A genuine **loaded→empty** transition still diverges once and reloads exactly once, then stabilises.

- New pure helper `pfb_dnsbl_has_loaded_feeds()` — TRUE only for non-empty `pfb_py_data`, a present `pfb_py_zone`, or any per-feed `*.raw`; deliberately **excludes** the shipped `pfb_py_hsts` and the always-present manifest/whitelist. It gates the "Clearing all DNSBL Feeds" log + `domain_clear` flag, so only genuine feed content triggers them.
- On the empty-feed path: write a valid `feeds:[]` manifest (`pfb_unbound_python_sources([])`) + a present-but-empty `pfb_py_data`; keep `pfb_py_zone` absent (python mode); **do not** delete `pfb_py_wh` (deleting it is what forced `$pfbpython`).
- HSTS stays counted in `pfb_dnsbl_loaded_input_paths()` (it is a real divergence input — a user can edit it and it must still drive a zero-downtime reload); it is only excluded from the *was-feed-content-loaded?* helper.

Python tolerance was verified: `csv.reader` over an empty data file is a no-op, and `build()` over a `feeds:[]` manifest returns a clean empty result (`dnsbl_built = True`) — already exercised by `tests/test_adr06_php_boundary.py`. The manifest is deterministic (no timestamps), so empty→empty is byte-identical and the fingerprint stays stable.

## Note on the trigger

The churn is reproduced by **Force Update** (`update` → `sync_package_pfblockerng('cron')`), which runs the full DNSBL sync without forcing a reload. The silent unattended `cron` tick with zero feed changes goes through `noupdates` → `$pfb['save']=TRUE` and **bypasses** the DNSBL block, so it was never the trigger — the issue title's "every cron pass" is more precisely "every Force-Update / full sync pass while feeds are empty".

## Tests

- `tests/php/DnsblHasLoadedFeedsTest.php` — pins the new helper (7 cases incl. the regression guard: only `pfb_py_hsts` present, no feeds → FALSE; 0-byte `pfb_py_data` → FALSE). Fails before the helper exists, passes after.
- `tests/smoke/test_dnsbl_empty_feed.py` — ADR-04 live-VM leg: enabled DNSBL, zero feeds, two `update` passes → asserts the pass-2 log slice is free of `Stopping Unbound Resolver` / `Clearing all DNSBL Feeds` / `Missing DNSBL stats…`. On pre-fix code the 2nd pass still shows `Stopping Unbound Resolver`; post-fix it is silent. (Dispatch/local-smoke; not a PR-blocking leg.)

Full PHP suite green (1311), PHPStan/PHPCS clean; smoke leg ruff/mypy/collection clean.

Fixes #546
