### PR TITLE
pfblockerng: regroup Log Settings and fix the mobile layout

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -59,17 +59,25 @@ fi
 
 echo "==> Deploying pfBlockerNG ($CHANNEL) to $SSH_TARGET"
 
-# Sync all source files, preserving permissions. src/ mirrors the filesystem
-# root, so src/usr/local/ maps to /usr/local/ — syncing src/usr/ -> /usr/local/
-# would land everything under /usr/local/local/ (silently a no-op on a running
-# box). Matches the port's WRKSRC${PREFIX} -> ${PREFIX} install.
-rsync -az --rsync-path="rsync" \
+# Sync all source files. src/ mirrors the filesystem root, so src/usr/local/ maps
+# to /usr/local/ — syncing src/usr/ -> /usr/local/ would land everything under
+# /usr/local/local/ (silently a no-op on a running box). Matches the port's
+# WRKSRC${PREFIX} -> ${PREFIX} install.
+#
+# OVERWRITE CONTENTS ONLY — never touch the box's ownership/permissions. We push
+# from a dev checkout where the files are owned by the local user (uid 501/staff),
+# NOT root:wheel; with -a's -o/-g/-p, root rsync would rewrite the live files'
+# owner/group/mode to those bogus dev values. --no-owner/--no-group/--no-perms
+# leave each existing file's owner/group/mode exactly as pfSense installed them
+# and only replace the bytes (-t still preserved for an efficient size+mtime sync;
+# a freshly edited file carries a recent mtime, so php-fpm opcache revalidates it).
+rsync -az --no-owner --no-group --no-perms --rsync-path="rsync" \
     --exclude="*.pyc" \
     --exclude="__pycache__/" \
     "${REPO_ROOT}/src/usr/local/" \
     "${SSH_TARGET}:${PKG_PREFIX}/"
 
-rsync -az --rsync-path="rsync" \
+rsync -az --no-owner --no-group --no-perms --rsync-path="rsync" \
     "${REPO_ROOT}/src/etc/" \
     "${SSH_TARGET}:/etc/"
 
@@ -78,7 +86,7 @@ sed "s|%%PKGNAME%%|${PKG_NAME}|g" \
     "${REPO_ROOT}/src/usr/local/share/pfSense-pkg-pfBlockerNG/info.xml" \
     > "${REPO_ROOT}/.info.xml.tmp"
 ssh "$SSH_TARGET" mkdir -p "${PKG_PREFIX}/share/pfSense-pkg-${PKG_NAME}"
-rsync -az "${REPO_ROOT}/.info.xml.tmp" \
+rsync -az --no-owner --no-group --no-perms --rsync-path="rsync" "${REPO_ROOT}/.info.xml.tmp" \
     "${SSH_TARGET}:${PKG_PREFIX}/share/pfSense-pkg-${PKG_NAME}/info.xml"
 rm -f "${REPO_ROOT}/.info.xml.tmp"
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -424,39 +424,52 @@ $section->addInput(new Form_Select(
 
 $form->add($section);
 
-// issue #489: Log Settings redesigned — grouped by category with aligned column headers.
-// Three columns (Max lines / Schedule / Keep lines) are explained once in an intro row;
-// each category has a header row then one row per log. No per-field repeated help.
+// issue #489: Log Settings — grouped by category, one row per log. A shaded header row
+// opens each category; the three columns (Max lines / Schedule / Keep lines) are labelled
+// once per category on desktop (the header row) and per-control on mobile, where the
+// columns stack (the desktop header row is hidden on xs, the per-control labels shown).
 $section = new Form_Section('Log Settings');
 $log_types = array(
 	'General'	=> array('pfBlockerNG' => 'log', 'Unified' => 'unilog', 'Error' => 'errlog', 'Extras' => 'extraslog'),
-	'IP'		=> array('IP Block' => 'ip_blocklog', 'IP Permit' => 'ip_permitlog', 'IP Match' => 'ip_matchlog'),
-	'DNSBL'		=> array('DNSBL' => 'dnslog', 'DNSBL Parse Error' => 'dnsbl_parse_err'),
-	'DNS Reply'	=> array('DNS Reply' => 'dnsreplylog'),
+	'IP'		=> array('Block' => 'ip_blocklog', 'Permit' => 'ip_permitlog', 'Match' => 'ip_matchlog'),
+	'DNS'		=> array('Block' => 'dnslog', 'Reply' => 'dnsreplylog', 'Parse Error' => 'dnsbl_parse_err'),
 );
 
 // Single intro explaining all three columns — replaces the former per-field repeated help.
+// ponytail: the media query is the whole responsive trick — per-control labels (Form_Input
+// label-start, class form-label) carry the columns on mobile; on >=sm the desktop header
+// row carries them, so the per-control copies are hidden to avoid double-labelling.
 $section->addInput(new Form_StaticText(
 	'',
-	'<ul style="margin-bottom:0">'
+	'<style>'
+	. '@media (min-width: 768px) { label.form-label { display: none; } }'
+	. '.pfb-loghdr { background-color: #f0f0f0; border-top: 1px solid #ddd; }'
+	. '.pfb-loghdr .control-label > span { font-weight: 700; }'
+	. '</style>'
+	. '<ul style="margin-bottom:0">'
 	. '<li><strong>Max lines</strong> &mdash; rolling cap; the log keeps only its most recent N lines.</li>'
 	. '<li><strong>Schedule</strong> &mdash; resets the log at the start of each calendar period '
-	. '(Daily/Weekly/Monthly); independent of Max lines. '
-	. '<strong>A reset discards that period\'s data</strong> &mdash; export first if you need history.</li>'
+	. '(Daily/Weekly/Monthly); independent of Max lines.'
+	. '<ul><li><strong>A reset discards that period\'s data</strong> &mdash; export first if you need history.</li></ul></li>'
 	. '<li><strong>Keep lines</strong> &mdash; lines retained at the tail on a scheduled reset '
 	. '(default 0 = clear fully); set &gt; 0 as a cushion for remote log shippers.</li>'
 	. '</ul>'
 ));
 
 foreach ($log_types as $logdescr => $logtype) {
-	// Header row: left label = category name; three StaticText children label the columns.
+	// Header row: shaded category divider; the StaticText children label the columns on
+	// desktop and are hidden on xs (where the columns stack and the labels would mislead).
 	$header = new Form_Group($logdescr);
-	$header->add(new Form_StaticText('', '<strong>Max lines</strong>'))->setWidth(4);
-	$header->add(new Form_StaticText('', '<strong>Schedule</strong>'))->setWidth(3);
-	$header->add(new Form_StaticText('', '<strong>Keep lines</strong>'))->setWidth(3);
+	$header->addClass('pfb-loghdr');
+	// form-control-static gives the column titles the same top padding as the category
+	// control-label, so the label and the titles sit on one line (hidden-xs: desktop only).
+	$header->add(new Form_StaticText('', '<p class="form-control-static hidden-xs"><strong>Max lines</strong></p>'))->setWidth(4);
+	$header->add(new Form_StaticText('', '<p class="form-control-static hidden-xs"><strong>Schedule</strong></p>'))->setWidth(3);
+	$header->add(new Form_StaticText('', '<p class="form-control-static hidden-xs"><strong>Keep lines</strong></p>'))->setWidth(3);
 	$section->add($header);
 
-	// One row per log in this category.
+	// One row per log in this category. Each control carries a label-start so the column is
+	// named on mobile (hidden on desktop via the media query above).
 	foreach ($logtype as $descr => $type) {
 		$group = new Form_Group($descr);
 		$group->add(new Form_Select(
@@ -464,19 +477,19 @@ foreach ($log_types as $logdescr => $logtype) {
 			'',
 			$pconfig['log_max_' . $type],
 			$options_log_types
-		))->setWidth(4);
+		))->setWidth(4)->setAttribute('label-start', 'Max lines');
 		$group->add(new Form_Select(
 			'log_rotate_' . $type,
 			'',
 			$pconfig['log_rotate_' . $type],
 			$options_log_rotate
-		))->setWidth(3);
+		))->setWidth(3)->setAttribute('label-start', 'Schedule');
 		$group->add((new Form_Input(
 			'log_reset_keep_' . $type,
 			'',
 			'number',
 			$pconfig['log_reset_keep_' . $type]
-		))->setAttribute('min', '0'))->setWidth(3);
+		))->setAttribute('min', '0'))->setWidth(3)->setAttribute('label-start', 'Keep lines');
 		$section->add($group);
 	}
 }

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -184,16 +184,20 @@ def test_log_settings_grouped_layout(
     When the DOM is inspected for the new grouped-column structure,
 
     Then the three column-header texts are visible on the page ("Max lines", "Schedule",
-      "Keep lines") — these are NEW elements (the per-category header ``Form_StaticText``
-      children); the old layout had no such header row, so this discriminates new from old;
+      "Keep lines") — emitted by the per-category header ``Form_StaticText`` children;
     And the ``log_max_log`` control is present and its enclosing ``.form-group`` left label
       (``col-sm-2.control-label``) shows the log name "pfBlockerNG" — proving per-log rows
-      carry the individual log name as the left label, where the OLD layout carried the
-      category name "General" on that group, so this too discriminates new from old.
+      carry the individual log name as the left label.
 
-    (Category-name presence is deliberately NOT asserted: "General"/"IP"/"DNSBL" also appear
-    as top tabs and the old group labels, so they would pass on the old layout and add no
-    signal. The two checks above are the real before/after discriminators.)
+    Plus the issue #489 follow-up polish (this commit), each a before/after discriminator:
+    And each category header row is a SHADED divider — its ``.form-group`` carries the
+      ``pfb-loghdr`` class (absent in the pre-polish layout);
+    And the IP rows are renamed to bare "Block"/"Permit"/"Match": the ``log_max_ip_blocklog``
+      row's left label reads "Block", NOT the old "IP Block" (so it fails on the old layout);
+    And the DNS-Reply log is now folded into the merged "DNS" category as the "Reply" row:
+      the ``log_max_dnsreplylog`` row's left label reads "Reply", NOT the old "DNS Reply";
+    And every control carries a per-control ``label.form-label`` (the mobile column label) —
+      the pre-polish layout emitted none.
 
     A full-page screenshot is saved as a human-review artifact (not an asserted baseline).
     """
@@ -209,5 +213,17 @@ def test_log_settings_grouped_layout(
     log_max_log = page.locator('select[name="log_max_log"]')
     expect(log_max_log).to_be_attached(timeout=JS_TIMEOUT_MS)
     form_group = log_max_log.locator("xpath=ancestor::div[contains(@class,'form-group')]")
-    label = form_group.locator(".control-label")
-    expect(label).to_contain_text("pfBlockerNG", timeout=JS_TIMEOUT_MS)
+    expect(form_group.locator(".control-label")).to_contain_text("pfBlockerNG", timeout=JS_TIMEOUT_MS)
+
+    # Polish discriminators: shaded category headers, the IP/DNS renames, per-control labels.
+    expect(page.locator(".form-group.pfb-loghdr").first).to_be_attached(timeout=JS_TIMEOUT_MS)
+
+    def _row_label(field: str):
+        ctl = page.locator(f'select[name="{field}"], input[name="{field}"]').first
+        return ctl.locator("xpath=ancestor::div[contains(@class,'form-group')]").locator(".control-label")
+
+    expect(_row_label("log_max_ip_blocklog")).to_have_text("Block", timeout=JS_TIMEOUT_MS)
+    expect(_row_label("log_max_dnsreplylog")).to_have_text("Reply", timeout=JS_TIMEOUT_MS)
+
+    # Per-control mobile labels exist (label.form-label, emitted by Form_Input label-start).
+    expect(page.locator('label.form-label').first).to_be_attached(timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -29,7 +29,7 @@ sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not ins
 expect = sync_api.expect
 
 if TYPE_CHECKING:
-    from playwright.sync_api import Page
+    from playwright.sync_api import Locator, Page
 
     from .webui import WebUI
 
@@ -216,14 +216,21 @@ def test_log_settings_grouped_layout(
     expect(form_group.locator(".control-label")).to_contain_text("pfBlockerNG", timeout=JS_TIMEOUT_MS)
 
     # Polish discriminators: shaded category headers, the IP/DNS renames, per-control labels.
-    expect(page.locator(".form-group.pfb-loghdr").first).to_be_attached(timeout=JS_TIMEOUT_MS)
+    # EXACTLY three shaded category headers (General / IP / DNS) -- assert the count, not just
+    # "at least one", so a dropped/extra category divider fails the test.
+    expect(page.locator(".form-group.pfb-loghdr")).to_have_count(3, timeout=JS_TIMEOUT_MS)
 
-    def _row_label(field: str):
+    def _row_label(field: str) -> Locator:
         ctl = page.locator(f'select[name="{field}"], input[name="{field}"]').first
         return ctl.locator("xpath=ancestor::div[contains(@class,'form-group')]").locator(".control-label")
 
     expect(_row_label("log_max_ip_blocklog")).to_have_text("Block", timeout=JS_TIMEOUT_MS)
     expect(_row_label("log_max_dnsreplylog")).to_have_text("Reply", timeout=JS_TIMEOUT_MS)
 
-    # Per-control mobile labels exist (label.form-label, emitted by Form_Input label-start).
-    expect(page.locator('label.form-label').first).to_be_attached(timeout=JS_TIMEOUT_MS)
+    # EVERY log control carries a per-control mobile label (Form_Input label-start): three per
+    # log row (Max lines / Schedule / Keep lines). Derive the row count from the page (one
+    # log_max_* select per row) so the assertion tracks the real log list, then assert the full
+    # label count rather than just one -- proving every control is labelled, not merely some.
+    log_rows = page.locator('select[name^="log_max_"]').count()
+    assert log_rows >= 1, f"expected at least one log row (select[name^=log_max_]), found {log_rows}"
+    expect(page.locator("label.form-label")).to_have_count(log_rows * 3, timeout=JS_TIMEOUT_MS)


### PR DESCRIPTION
Follow-up polish on the issue #489 Log Settings redesign — the desktop table looked good but the category headers were ambiguous and the layout fell apart on mobile.

## Log Settings (`pfblockerng_general.php`)

- **Merge DNSBL + DNS Reply into one `DNS` category** with `Block` / `Reply` / `Parse Error` rows — removes the confusing "header DNSBL vs item DNSBL" clash.
- **Drop the redundant `IP` prefix** from the IP rows (`IP Block`→`Block`, etc.) now that the `IP` header already names them.
- **Shade each category header row** (`pfb-loghdr`) so headers read as dividers, not data.
- **Fix mobile:** on a narrow screen the columns stack and the desktop column-header row became meaningless. Each control now carries a per-row label (`Form_Input` `label-start`) shown only on mobile, and the desktop column-header row is hidden there — a single media query toggles between the two, so desktop is unchanged.
- **Line up the category name** with the column titles via the pre-existing `form-control-static` class (same top padding as `control-label`).

Field names and the POST handler are untouched — pure presentation. The Tier-B browser test gains before/after discriminators for the renames, the shaded header row, and the per-control mobile labels.

## Tooling (`scripts/deploy.sh`)

`deploy.sh` pushes from a dev checkout where files are owned by the local user (uid 501/staff), not `root:wheel`. With `rsync -a`'s `-o/-g/-p`, a root-side rsync rewrote each live file's owner/group/mode to those bogus dev values. Added `--no-owner --no-group --no-perms` to every rsync call: existing files keep the owner/group/mode pfSense installed, only their bytes are replaced (`-t` kept for an efficient size+mtime sync).

## Verification

Deployed to a live pfSense box and visually confirmed on both desktop (headers line up, categories shaded) and a narrow window (every control labelled). Tier-B UI assertions are dispatch-only (not PR-gating) per ADR-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVKv7EKzn7EbfWDw4MQRi9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reworked the Log Settings page into clearer grouped sections with improved column labels.
  * Updated the layout for smaller screens so log controls are easier to read and use on mobile devices.

* **Bug Fixes**
  * Adjusted log category grouping so DNS-related entries are shown together more consistently.
  * Refined the labels shown for individual log options to better match the displayed settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->