### PR TITLE
pfblockerng: fix Update page live log (read-only fields, hook output no longer truncated)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15309,11 +15309,6 @@ function sync_package_pfblockerng($cron='') {
 		}
 	}
 
-	if ($pfb['enable'] == 'on' && !$pfb['save'] || $pfb['summary']) {
-		$log = "\n UPDATE PROCESS ENDED [ NOW ]\n";
-		pfb_logger("{$log}", 1);
-	}
-
 	// ADR-12: post-update hooks. Fire at the closing tail -- AFTER the IP/DNSBL
 	// reloads, filter_configure(), and the FINAL REPORTING 'closing' step above --
 	// so the change flags are final. Context is derived ONLY from existing flags
@@ -15362,6 +15357,15 @@ function sync_package_pfblockerng($cron='') {
 		'CHANGED_IP_ALIASES'	=> implode(' ', array_unique($pfb['changed_ip_aliases'])),
 		'CHANGED_DNSBL_GROUPS'	=> implode(' ', array_unique($pfb['changed_dnsbl_groups'])),
 	));
+
+	// Terminal marker -- emitted AFTER the post-update hooks so it is genuinely the
+	// last line of the update log. The Update-page live tail (pfb_livetail) stops on
+	// this marker; emitting it before the hooks truncated their progressive output
+	// from the live view (e.g. a HAProxy reload hook running up to its timeout) -- it
+	// then only reappeared on a manual 'View'.
+	if ($pfb['enable'] == 'on' && !$pfb['save'] || $pfb['summary']) {
+		pfb_logger("\n UPDATE PROCESS ENDED [ NOW ]\n", 1);
+	}
 }
 
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -419,14 +419,14 @@ $section->addInput(new Form_Textarea(
 	NULL,
 	'Log Viewer Standby'
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '1')->setAttribute('wrap', 'off')
-  ->setAttribute('style', 'background:#fafafa; width: 100%');
+  ->setAttribute('readonly', 'readonly')->setAttribute('style', 'background:#fafafa; width: 100%');
 
 $section->addInput(new Form_Textarea(
 	'pfb_output',
 	NULL,
 	NULL
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '30')->setAttribute('wrap', 'off')
-  ->setAttribute('style', 'background:#fafafa; width: 100%');
+  ->setAttribute('readonly', 'readonly')->setAttribute('style', 'background:#fafafa; width: 100%');
 
 $form->add($section);
 print($form);

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -246,6 +246,48 @@ def test_hooks_pre_and_post_fire_with_context(deployed_vm: SmokeVM, mock_feeds: 
     h.clear_update_hooks(deployed_vm)
 
 
+def test_post_hook_output_precedes_end_marker(deployed_vm: SmokeVM) -> None:
+    """The "UPDATE PROCESS ENDED" marker is logged AFTER the post-update hooks.
+
+    The Update-page live tail (``pfb_livetail``, 'force' mode) stops streaming when
+    the log reaches the ``UPDATE PROCESS ENDED`` marker. The ADR-12 post-update hooks
+    log their output (``[ pfB Hook ] post <name> ...``) progressively — a HAProxy
+    reload hook can run up to its timeout — so emitting the marker BEFORE the hooks
+    truncated their output from the live view (it only reappeared on a manual 'View').
+    The marker is now emitted after ``pfb_run_hooks('post', ...)``.
+
+    Given a clean update log and an enabled post hook,
+    When a force update runs,
+    Then the post hook's runner line appears in the log BEFORE the terminal marker.
+    Pre-fix the order was reversed (marker first), so this assertion FAILED then and
+    passes only after the relocation.
+    """
+    token = "endorder"
+    h.set_update_hooks(deployed_vm, [h.env_dump_hook(token, "post")])
+    h.clear_hook_markers(deployed_vm, token)
+
+    # Truncate the update log so the slice we read is exactly this one pass (truncate(1)
+    # is a clean argv command — no shell redirection through the guest login shell).
+    deployed_vm.ssh("/usr/bin/truncate", "-s", "0", h.PFB_LOG)
+
+    h.reload(deployed_vm, "update")
+
+    log = deployed_vm.ssh("cat", h.PFB_LOG).stdout
+    hook_line = "[ pfB Hook ] post"
+    marker = "UPDATE PROCESS ENDED"
+    hook_pos = log.find(hook_line)
+    marker_pos = log.find(marker)
+
+    assert hook_pos != -1, f"post hook runner line {hook_line!r} absent from the update log:\n{log[-2000:]}"
+    assert marker_pos != -1, f"terminal marker {marker!r} absent from the update log:\n{log[-2000:]}"
+    assert hook_pos < marker_pos, (
+        "post-hook output must be logged BEFORE the terminal marker so the live tail "
+        f"streams it; got hook@{hook_pos} marker@{marker_pos} (marker emitted too early):\n{log[-2000:]}"
+    )
+
+    h.clear_update_hooks(deployed_vm)
+
+
 # --------------------------------------------------------------------------- #
 # 4) PFB_TRIGGER — both reachable values (branch coverage of pfb_hook_trigger)
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -342,6 +342,28 @@ def test_update_hooks_subtab_relocation(webui: WebUI) -> None:
     assert _UPDATE_PAGE in body, "the General page no longer links the Update tab"
 
 
+def test_update_log_textareas_are_readonly(webui: WebUI) -> None:
+    """The Update page's two log windows are display-only — they render readonly.
+
+    The 'pfb_status' (progress) and 'pfb_output' (log) textareas are live-tail
+    viewers, not input fields; before this change they were plain editable
+    textareas, so a user could accidentally cut/type into them (the content is
+    harmless — it is repopulated from the log file on refresh — but it is confusing
+    and a footgun). Each must now carry the readonly attribute.
+
+    Given the rendered Update page,
+    When each log textarea opening tag is located by name,
+    Then it contains the readonly attribute. (Pre-fix the tags had no readonly, so
+      these assertions FAIL on the old markup and pass only after it.)
+    """
+    body = webui.get(_UPDATE_PAGE).text
+    for name in ("pfb_status", "pfb_output"):
+        m = re.search(r"<textarea\b[^>]*\bname=([\"'])" + re.escape(name) + r"\1[^>]*>", body)
+        assert m is not None, f"update page is missing the '{name}' textarea"
+        tag = m.group(0)
+        assert "readonly" in tag, f"'{name}' textarea is editable (no readonly): {tag}"
+
+
 def test_dnsbl_idn_blocking_fields_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """The ADR-08 'IDN Blocking' selector + its two Confusable sub-toggles render
     cleanly on the DNSBL page — so a regression that drops or breaks the field is

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -361,7 +361,7 @@ def test_update_log_textareas_are_readonly(webui: WebUI) -> None:
         m = re.search(r"<textarea\b[^>]*\bname=([\"'])" + re.escape(name) + r"\1[^>]*>", body)
         assert m is not None, f"update page is missing the '{name}' textarea"
         tag = m.group(0)
-        assert "readonly" in tag, f"'{name}' textarea is editable (no readonly): {tag}"
+        assert re.search(r"\breadonly\b", tag), f"'{name}' textarea is editable (no readonly): {tag}"
 
 
 def test_dnsbl_idn_blocking_fields_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:


### PR DESCRIPTION
## Summary

Two fixes to the **Firewall > pfBlockerNG > Update** page log view.

### 1. Read-only log textareas

The two log windows on the Update page (`pfb_status`, `pfb_output`) were editable `<textarea>` fields — a click let a user type into the rendered log, with no effect on anything but a confusing edit. Both now render `readonly`. They stay scrollable/selectable/copyable; they are output, not input.

### 2. Live tail no longer truncates post-update hook output

The Force/Reload live tail (`pfb_livetail`) stops streaming when the log reaches the `UPDATE PROCESS ENDED` marker. The ADR-12 **post-update hooks** (e.g. a HAProxy reload that can run up to its timeout) fire *after* that marker was logged, so their progressive output was written to the log but never shown in the live view — it only reappeared on a manual **View**.

Fix: emit the terminal marker **after** `pfb_run_hooks('post', …)` so it is genuinely the last log line. The hooks still fire last with final change flags (ADR-12 semantics unchanged); only the marker's log position moved, and its sole consumer is the live tail.

## Tests

- **Read-only fields** — Tier A `ui_render` assertion that each Update-page log textarea carries the `readonly` attribute.
- **Hook ordering** — ADR-12 hook smoke case (`test_post_hook_output_precedes_end_marker`): truncates the update log, runs a force update with an enabled `post` hook, and asserts the `[ pfB Hook ] post …` runner line precedes `UPDATE PROCESS ENDED` in the log. Fails before the relocation (marker first), passes after.

## Gates

`php -l` clean · PHPUnit 1304 pass · PHPCS clean · PHPStan no errors · ruff lint+format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcQyZXqvLSxiUfmJtQgTfK)_