### PR TITLE
tests: make ADR-10 watcher waiters deterministic and fail loud (#456)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,15 @@ off-pattern name is a smell even when it works.
 - Type-hint new functions; leave existing untyped code alone unless touching it.
 - No bare `except:` — `except Exception` minimum.
 - `pfb_unbound.py` runs in Unbound's Python loader — **stdlib only, no external deps**.
+- **No fixed-time waits to coordinate concurrency (issue #456).** Synchronising async work
+  (threads, daemon loops, test harnesses) with `time.sleep()` or a polling deadline is a
+  classical anti-pattern — flaky under load, needlessly slow otherwise. Use a synchronisation
+  primitive so one side **signals** and the other **blocks deterministically**:
+  `threading.Event` / `Condition` / `Semaphore`, or `queue.Queue`. A timeout is allowed **only**
+  as a deadlock safety-guard, and must then **raise an explicit assertion** (never return
+  silently) — exemplar `_Harness.wait_builds` in `tests/test_adr10_watcher.py`. (A poll is a last
+  resort only when the other side is production code you cannot signal — keep the loud-timeout
+  assertion regardless.)
 - Unbound injects API symbols (`log_info`, `RR_TYPE_*`, `DNSMessage`, …) as runtime globals,
   used as bare names. Declared once in `stubs/python/unboundmodule.py` (Pylance/mypy resolve
   via the `TYPE_CHECKING` import; the suite copies them onto `builtins`, see

--- a/tests/test_adr10_watcher.py
+++ b/tests/test_adr10_watcher.py
@@ -25,6 +25,8 @@ import threading
 import time
 from typing import Any
 
+import pytest
+
 import pfb_unbound as P
 
 # --------------------------------------------------------------------------- #
@@ -210,6 +212,10 @@ class _Harness:
         self._gate = threading.Event()
         self._gate.set()  # un-gated by default; tests can clear() to make a build block
         self._lock = threading.Lock()
+        # issue #456: the builder SIGNALS each recorded build on this Condition so
+        # wait_builds blocks deterministically on the daemon thread instead of polling
+        # a deadline and hoping -- the latter races (and returns silently) under load.
+        self._builds_cond = threading.Condition(self._lock)
         self.fail = False
         self.os = os
         P.pfb_reload_stop = threading.Event()
@@ -219,8 +225,9 @@ class _Harness:
         # Record the generation observed at build time; optionally block to simulate a
         # slow ABP build so a concurrent trigger can be tested for coalescing.
         gen = P._reload_read_generation(self.sentinel) or 0
-        with self._lock:
+        with self._builds_cond:
             self.builds.append(gen)
+            self._builds_cond.notify_all()  # wake any wait_builds waiter.
         self._gate.wait(1.0)
         if self.fail:
             return None
@@ -240,27 +247,63 @@ class _Harness:
         return P._reload_read_generation(self.applied)
 
     def wait_builds(self, n: int, timeout: float = 3.0) -> None:
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            with self._lock:
-                if len(self.builds) >= n:
-                    return
-            time.sleep(0.01)
+        # Block on the builder's signal until >= n builds are recorded. The timeout is a
+        # deadlock safety-guard only: on expiry FAIL LOUD (issue #456) so a starved daemon
+        # surfaces as an honest timeout, not a misleading downstream equality mismatch.
+        with self._builds_cond:
+            if not self._builds_cond.wait_for(lambda: len(self.builds) >= n, timeout=timeout):
+                raise AssertionError(
+                    "wait_builds timed out after {:.1f}s: expected >= {} build(s), got {} ({!r})".format(
+                        timeout, n, len(self.builds), self.builds
+                    )
+                )
 
     def wait_snapshot_changed(self, old: Any, timeout: float = 3.0) -> None:
-        # wait_builds returns when a build is RECORDED (before the builder returns),
-        # so P._snapshot may not be swapped yet. Poll until the swap completes.
+        # wait_builds returns when a build is RECORDED (before the builder returns), so
+        # P._snapshot may not be swapped yet. The swap is done by production code on a
+        # module-level variable we cannot signal from here, so this stays a poll -- but
+        # with a loud timeout assertion (safety-guard, never a silent return; issue #456).
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if P._snapshot is not old:
                 return
             time.sleep(0.005)
+        raise AssertionError(
+            "wait_snapshot_changed timed out after {:.1f}s: P._snapshot was never swapped "
+            "from the old snapshot (expected a new snapshot to be installed)".format(timeout)
+        )
 
     def stop_join(self, timeout: float = 5.0) -> None:
         P.pfb_reload_stop.set()
         self._gate.set()  # release a blocked build so the thread can exit promptly
         if self.thread is not None:
             self.thread.join(timeout=timeout)
+
+
+class TestHarnessWaiterDiagnostics:
+    """issue #456: the harness waiters must FAIL LOUD on timeout, never return silently.
+
+    The original flake (TestWatcherLoop::test_single_flight_coalesces_concurrent_triggers)
+    came from wait_builds returning silently when the daemon thread was starved, so the
+    real symptom -- "the build never happened in time" -- was masked into a misleading
+    downstream ``builds == [2, 3]`` equality mismatch. These pin the contract directly:
+    when the awaited condition is never met, the waiter raises a descriptive AssertionError.
+    (Against the pre-fix silent-return waiters these tests FAIL -- no exception is raised.)
+    """
+
+    def test_wait_builds_raises_on_timeout(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # No watcher thread started -> no build is ever recorded. wait_builds must raise.
+        h = _Harness(tmp_path, monkeypatch)
+        with pytest.raises(AssertionError, match=r"wait_builds timed out.*expected >= 1"):
+            h.wait_builds(1, timeout=0.1)
+
+    def test_wait_snapshot_changed_raises_on_timeout(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # No swap ever happens -> the snapshot stays the old object. wait_snapshot_changed must raise.
+        h = _Harness(tmp_path, monkeypatch)
+        old = _snapshot(tag="old.example.com", counts=0)
+        P._snapshot = old
+        with pytest.raises(AssertionError, match=r"wait_snapshot_changed timed out"):
+            h.wait_snapshot_changed(old, timeout=0.1)
 
 
 class TestWatcherLoop:


### PR DESCRIPTION
## Issue

#456 — `TestWatcherLoop::test_single_flight_coalesces_concurrent_triggers` flakes under load. `_Harness.wait_builds` (in `tests/test_adr10_watcher.py`) polled a deadline and **returned silently** on timeout, so a starved daemon thread surfaced as a misleading `builds == [2, 3]` equality mismatch instead of an honest "waited Ns, got 1 build".

## Fix

- **`wait_builds` → event-based.** The stub `builder` now appends each recorded build under a `threading.Condition` and `notify_all()`s; `wait_builds` blocks on `wait_for(len(builds) >= n)`. No more race against a `sleep`.
- **Both waiters fail loud.** On timeout (a deadlock safety-guard only) each raises a descriptive `AssertionError` with expected-vs-actual, never a silent return. `wait_snapshot_changed` stays a poll — the swap is done by production code on a module-level variable the harness cannot signal — but with the same loud-timeout assertion.

## Coverage

`TestHarnessWaiterDiagnostics` pins the contract directly: both new tests **fail** against the old silent-return waiters (`DID NOT RAISE`) and **pass** with the fix. Verified red→green by temporarily restoring the old waiter bodies. The formerly-flaky test ran 30× green under deliberate CPU starvation; full suite 1882 passed / 4 skipped.

## Directive

@andrebrait asked that this become a standing rule. Added to `CLAUDE.md` (Python code standards): no fixed-time waits to coordinate concurrency — use a synchronisation primitive (`threading.Event`/`Condition`/`Semaphore`, `queue.Queue`); a timeout is allowed only as a deadlock safety-guard and must raise an explicit assertion. Matches the CodeRabbit learning recorded on the issue.

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
