### PR TITLE
pfblockerng: add title-bar shortcut icon to the package syslog

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1832,6 +1832,7 @@ if ($_POST) {
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('IP'), gettext('GeoIP'), $continent_display);
 $pglinks = array( '', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblockerng_ip.php',
 		'/pfblockerng/pfblockerng_category.php?type=geoip', '@self');
+$shortcut_section = 'pfblockerng';
 
 include_once('head.inc');
 
@@ -2378,6 +2379,7 @@ if ($_POST) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('IP'), gettext('Reputation'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblockerng_ip.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 // Define default Alerts Tab href link (Top row)

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -3309,6 +3309,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Alerts'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 ?>
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -302,6 +302,7 @@ if ($_POST && !$_POST['enableall'] && !$_POST['disableall']) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('DNSBL'), gettext('DNSBL Category'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblockerng_dnsbl.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 if ($input_errors) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -328,6 +328,7 @@ if ($gtype == 'dnsbl') {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext($pgtype), gettext($type));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', "{$pg_url}", '@self');
+$shortcut_section = 'pfblockerng';
 
 include_once('head.inc');
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -341,6 +341,7 @@ if ($gtype == 'dnsbl') {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext($pgtype), gettext($type));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', "{$pg_url}", '@self');
+$shortcut_section = 'pfblockerng';
 
 include_once('head.inc');
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -886,6 +886,7 @@ if ($_POST) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('DNSBL'));
 $pglinks = array('', '/pfblockerng/pfblockerng_dnsbl.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 if ($input_errors) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -600,6 +600,7 @@ $type_label = array('ipv4' => 'IPv4', 'ipv6' => 'IPv6', 'dnsbl' => 'DNSBL');
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Feeds'), gettext($type_label[$gtype]));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', "/pfblockerng/pfblockerng_feeds.php?type={$gtype}", '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 if ($input_errors) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -299,6 +299,7 @@ if ($_POST) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'));
 $pglinks = array('', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 if ($input_errors) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
@@ -171,6 +171,7 @@ if ($_POST) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Update'), gettext('Hooks'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblockerng_update.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 if ($input_errors) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -239,6 +239,7 @@ if ($_POST) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('IP'));
 $pglinks = array('', '/pfblockerng/pfblockerng_ip.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 if ($input_errors) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -350,6 +350,7 @@ if (isset($pconfig['logFile']) && !empty($pconfig['logFile']) && (isset($pconfig
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Log Browser'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 // Define default Alerts Tab href link (Top row)

--- a/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
@@ -76,6 +76,7 @@ if (isset($_POST['save'])) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('DNSBL'), gettext('DNSBL SafeSearch'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblockerng_dnsbl.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 if ($input_errors) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -157,6 +157,7 @@ if ($pfb_sw_action === 'check') {
 	exit;
 }
 
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 // Tab bar (the Software tab is the active one here; gated like every page).

--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -160,6 +160,7 @@ if ($_POST) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Sync'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 if ($input_errors) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_threats.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_threats.php
@@ -21,6 +21,7 @@
  */
 
 require('guiconfig.inc');
+$shortcut_section = 'pfblockerng';
 include('head.inc');
 
 $title = $host = $domain = $port = '';

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -124,6 +124,7 @@ function pfb_cron_update($type) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Update'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '@self');
+$shortcut_section = 'pfblockerng';
 include_once('head.inc');
 
 $pconfig = array();

--- a/src/usr/local/www/shortcuts/pkg_pfblockerng.inc
+++ b/src/usr/local/www/shortcuts/pkg_pfblockerng.inc
@@ -1,0 +1,37 @@
+<?php
+/*
+ * pkg_pfblockerng.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2016-2026 Rubicon Communications, LLC (Netgate)
+ * Copyright (c) 2015-2024 BBcan177@gmail.com
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+global $shortcuts;
+
+$shortcuts['pfblockerng'] = array();
+
+// pfBlockerNG's syslog (ADR-38) is a <logging>-registered package log, surfaced under
+// Status > System Logs > Packages. Resolve the channel-correct package name
+// (pfBlockerNG vs pfBlockerNG-devel) from its configurationfile so the link is right on
+// either channel. installedpackages/package is a pfSense-core section (not a registered
+// pfblockerng config scalar), so this read is outside the ADR-29 config-gateway scope.
+foreach (config_get_path('installedpackages/package', array()) as $pfb_pkg) {
+	if (($pfb_pkg['configurationfile'] ?? '') === 'pfblockerng.xml') {
+		$shortcuts['pfblockerng']['log'] = 'status_logs_packages.php?pkg=' . $pfb_pkg['name'];
+		break;
+	}
+}

--- a/tests/smoke/ui/test_render_shortcut.py
+++ b/tests/smoke/ui/test_render_shortcut.py
@@ -1,0 +1,132 @@
+"""Tier-A (ui_render) + Tier-B (ui_browser) tests for the pfBlockerNG title-bar
+syslog shortcut icon.
+
+Every pfBlockerNG page sets ``$shortcut_section = 'pfblockerng'`` before including
+``head.inc``.  ``head.inc`` reads ``$shortcuts['pfblockerng']['log']`` from
+``shortcuts/pkg_pfblockerng.inc`` and renders a log-link anchor whose ``href``
+contains ``status_logs_packages.php?pkg=``.  These tests pin that contract.
+
+Tier-A (``ui_render``) -- hermetic HTTP GET only:
+  ``test_shortcut_log_link_rendered`` — GET the General page and assert the rendered
+  body contains ``status_logs_packages.php?pkg=``.  On pre-change code (no shortcut
+  file, no ``$shortcut_section``) that substring is absent, so this is a real
+  fail-before / pass-after discriminator.
+
+Tier-B (``ui_browser``) -- Playwright DOM inspection:
+  ``test_shortcut_log_anchor_in_dom`` — load the General page in the authenticated
+  browser and assert the title-bar log-shortcut anchor is present with an ``href``
+  containing ``status_logs_packages.php?pkg=``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+# The General page is the lightest pfBlockerNG page -- always hermetic, no external
+# data needed, good witness for the shortcut chrome that appears on every page.
+_GENERAL_PAGE = "/pfblockerng/pfblockerng_general.php"
+
+# The substring that head.inc renders when $shortcuts['pfblockerng']['log'] is set.
+# Present in the href of the log-shortcut anchor ("<a href='...' ...>").
+_SHORTCUT_NEEDLE = "status_logs_packages.php?pkg="
+
+
+# ---------------------------------------------------------------------------
+# Tier-A: ui_render
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ui_render
+def test_shortcut_log_link_rendered(webui: WebUI) -> None:
+    """The General page body contains the rendered syslog shortcut link.
+
+    Scenario: pfBlockerNG title-bar shortcut icon links to the package syslog.
+      Background: pfBlockerNG deployed; shortcuts/pkg_pfblockerng.inc installed;
+        every pfBlockerNG page sets $shortcut_section = 'pfblockerng'.
+
+      Given the authenticated webConfigurator session,
+
+      When GET /pfblockerng/pfblockerng_general.php,
+
+      Then the response body contains the rendered log-shortcut href substring
+        ``status_logs_packages.php?pkg=`` — proving head.inc rendered the anchor
+        from $shortcuts['pfblockerng']['log'] (absent on pre-change code where
+        neither the shortcut file nor $shortcut_section existed).
+
+    Fail-before / pass-after: on origin/devel (before this change) the shortcut
+    file does not exist and no page sets $shortcut_section, so the substring is
+    absent and this assertion FAILS.  After the change both are present, the
+    assertion PASSES.
+    """
+    resp = webui.get(_GENERAL_PAGE)
+    assert resp.status_code == 200, f"GET {_GENERAL_PAGE} -> HTTP {resp.status_code} (expected 200)"
+    assert _SHORTCUT_NEEDLE in resp.text, (
+        f"Syslog shortcut href {_SHORTCUT_NEEDLE!r} not found in {_GENERAL_PAGE} body "
+        f"-- expected head.inc to render the log-shortcut anchor from "
+        f"$shortcuts['pfblockerng']['log'] (pkg_pfblockerng.inc + $shortcut_section)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier-B: ui_browser
+# ---------------------------------------------------------------------------
+# NOTE: the playwright import is scoped to the Tier-B test (not module-level) so a
+# module-level importorskip does NOT skip the Tier-A ui_render test above, which is
+# hermetic HTTP-only and must run in the render tier (no playwright installed there).
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+# JS-driven DOM settles synchronously; this is a flake ceiling, not a wait knob.
+JS_TIMEOUT_MS = 10_000
+
+
+@pytest.mark.ui_browser
+def test_shortcut_log_anchor_in_dom(
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """The title-bar log-shortcut anchor is present in the live DOM with the correct href.
+
+    Scenario: pfBlockerNG title-bar shortcut icon links to the package syslog (Tier B).
+      Background: pfBlockerNG deployed with the shortcut file + $shortcut_section wired.
+
+      Given the General page is loaded in the authenticated browser,
+
+      When the DOM is inspected for the pfSense shortcuts log-link anchor,
+
+      Then exactly one anchor whose href contains ``status_logs_packages.php?pkg=``
+        is attached to the document -- proving the title-bar shortcut icon rendered
+        the correct log link.
+
+    Fail-before / pass-after: without $shortcut_section + the shortcut file, head.inc
+    emits no such anchor, so the ``count() > 0`` assertion FAILS on pre-change code
+    and PASSES after the change.
+    """
+    # The browser_page fixture already importorskips playwright, so it is present here.
+    expect = pytest.importorskip("playwright.sync_api").expect
+
+    page = browser_page
+    page.goto(
+        webui.url(_GENERAL_PAGE),
+        wait_until="domcontentloaded",
+        timeout=JS_TIMEOUT_MS * 3,
+    )
+    page.wait_for_load_state("networkidle", timeout=JS_TIMEOUT_MS * 3)
+    assert page.locator("#usernamefld").count() == 0, (
+        f"GET {_GENERAL_PAGE} showed the login form -- cookie not authenticated"
+    )
+
+    # head.inc renders the log-shortcut as an <a href="...status_logs_packages.php?pkg=...">
+    # anchor in the title-bar shortcuts area.  Assert it is present in the live DOM.
+    log_anchor = page.locator(f'a[href*="{_SHORTCUT_NEEDLE}"]')
+    assert log_anchor.count() > 0, (
+        f"No anchor with href containing {_SHORTCUT_NEEDLE!r} found in the DOM "
+        f"of {_GENERAL_PAGE} -- title-bar syslog shortcut not rendered"
+    )
+    expect(log_anchor.first).to_be_attached(timeout=JS_TIMEOUT_MS)


### PR DESCRIPTION
Adds a pfSense title-bar "Related log entries" shortcut icon (next to the help icon) to every pfBlockerNG page, linking to the package syslog under **Status > System Logs > Packages** — where the ADR-38 host-side syslog lands.

## How it works (pfSense "shortcuts" system)

- New `src/usr/local/www/shortcuts/pkg_pfblockerng.inc` defines `$shortcuts['pfblockerng']['log']`. `head.inc` (via `shortcuts.inc`, which globs that directory) renders the log-link icon from it.
- The package log is a `<logging>`-registered package log, so the viewer is `status_logs_packages.php?pkg=<name>`. The name is resolved at runtime from `installedpackages/package` (the `configurationfile === 'pfblockerng.xml'` row) so it is channel-correct on both `pfBlockerNG` and `pfBlockerNG-devel`. That section is pfSense-core (not a registered pfblockerng scalar), so the read is outside the ADR-29 config-gateway.
- Every pfBlockerNG page sets `$shortcut_section = 'pfblockerng'` immediately before its `head.inc` include (16 pages; `pfblockerng.php` has two render paths).

**Always shown, not syslog-conditional:** the shortcut file is globbed by `head.inc` on *every* pfSense GUI page, so a `log_syslog`-conditional read would have to pull the config gateway into all of pfSense's chrome or bypass the ADR-29 gateway sniff — both hacky. The Packages log tab exists regardless of the toggle (registration is unconditional; the toggle only gates emission), and other packages (HAProxy) show their log icon unconditionally too.

## Tests

- **Tier-A `ui_render`** — GET the General page, assert the rendered body contains the `status_logs_packages.php?pkg=` href (absent on pre-change code: real fail-before / pass-after).
- **Tier-B `ui_browser`** — assert the title-bar log anchor is attached in the live DOM with the right href.

(Tier-A/B are dispatch-only on this repo; the maintainer validates them live.)

## Companion FreeBSD-ports change (build-input fork)

A new shipped file needs matching `pkg-plist` + `do-install` entries, and the portable builder hard-fails on any plist↔staged drift. The companion change adds, in **all three ports** (`pfSense-pkg-pfBlockerNG`, `-devel`, `-nightly`): the `www/shortcuts/pkg_pfblockerng.inc` plist line and the `do-install` `MKDIR ${PREFIX}/www/shortcuts` + `INSTALL_DATA` line. `build-pkg-portable.py --dry-run` validates plist↔staged green for devel/stable/nightly against this branch's `src/`. It lands on `pfblockerng/use-github` in lockstep with this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVKv7EKzn7EbfWDw4MQRi9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pfBlockerNG shortcut link to the page header across multiple sections, making quick access to package logs available from the interface.
* **Tests**
  * Added smoke coverage to verify the shortcut link appears in both page content and the live browser view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->