### PR TITLE
ci: selectively dispatch smoke/UI tests, impacted-by-default

### DIFF
--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -72,6 +72,10 @@ on:
         description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
         required: false
         default: "smoke"
+      pytest_k:
+        description: "pytest -k selector to run only a subset of the marker's tests (e.g. 'test_dns_redirect' or 'redirect and not browser'). Blank = the whole marker."
+        required: false
+        default: ""
       smoke_nightly_live_url:
         description: "Live nightly Pages base URL for test_install_from_live_nightly_url (e.g. https://pfblockerng.github.io/pkg/nightly). Blank -> SKIP."
         required: false
@@ -126,6 +130,11 @@ on:
         required: false
         type: string
         default: "smoke"
+      pytest_k:
+        description: "pytest -k selector to run only a subset of the marker's tests. Blank = the whole marker."
+        required: false
+        type: string
+        default: ""
       smoke_nightly_live_url:
         description: "Live nightly Pages base URL for test_install_from_live_nightly_url. Blank -> SKIP."
         required: false
@@ -531,6 +540,9 @@ jobs:
           # Selected marker: 'smoke' by default (byte-identical to before); 'repo'
           # for the ADR-17 repository-install flow (repo-install.yml calls in with it).
           PYTEST_MARKER: ${{ inputs.pytest_marker || 'smoke' }}
+          # Optional -k selector to run only a subset of the marker's tests
+          # (blank = the whole marker). Lets a dispatcher fire a specific set.
+          PYTEST_K: ${{ inputs.pytest_k }}
           # SMOKE_IMAGE_DIR points the fixture at the ALREADY-PULLED qcow2 so the
           # boot needs no network. SMOKE_IMAGE_REF is kept for provenance/logs.
           SMOKE_IMAGE_DIR: ${{ github.workspace }}/image
@@ -599,9 +611,14 @@ jobs:
           # (inject->reload->probe; slowest observed ~6s), NOT the slow module fixtures
           # (deploy ~1-2 min) — so a per-case stall fails fast (vs the old 300s -> job-
           # timeout wipe) while leaving comfortable margin over the real per-case time.
-          python3 -m pytest tests/smoke -m "${PYTEST_MARKER}" \
+          # Build the argv so an optional -k selector rides as a SINGLE arg (a
+          # bare-var splice would word-split a multi-token expression like
+          # "a and not b"). Blank PYTEST_K -> no -k, identical to before.
+          set -- tests/smoke -m "${PYTEST_MARKER}" \
             --override-ini="addopts=" --override-ini="timeout_func_only=true" \
             --timeout=30 --timeout-method=signal -v
+          [ -n "${PYTEST_K:-}" ] && set -- "$@" -k "${PYTEST_K}"
+          python3 -m pytest "$@"
 
       # ADR-24: runner-side scrub of the Plus secret identity from the diagnostics
       # BEFORE upload. For a non-CE (Plus) image: drop the console screenshots

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,11 +32,57 @@ name: Smoke fan-out (all CI legs, live pfSense VM)
 
 on:
   # Manual trigger — dispatched by version-tracker.yml (Step C) with no inputs.
-  # Also usable for ad-hoc full-suite runs.
+  # Also usable for ad-hoc full-suite runs, OR a selective run: a dispatcher
+  # (human or AI) can narrow to one leg (version), one marker, and/or a -k
+  # subset. All three default to blank/whole-suite, so a no-input dispatch (and
+  # the scheduled/called paths below) run the full fan-out exactly as before.
   workflow_dispatch:
+    inputs:
+      scope:
+        description: "impacted (DEFAULT for a bare dispatch): min CE leg + only the tests changed on this branch vs origin/devel. full: every ci:true leg (CE + Plus), whole marker — the nightly/release behaviour. Blank = impacted on dispatch."
+        required: false
+        type: choice
+        default: "impacted"
+        options:
+          - impacted
+          - full
+      version:
+        description: "Narrow the fan-out to the ci:true leg whose pfsense_version matches (e.g. \"2.8\"). Overrides scope's leg selection. Blank = scope decides (min CE for impacted, all legs for full)."
+        required: false
+        default: ""
+      pytest_marker:
+        description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
+        required: false
+        default: "smoke"
+      pytest_k:
+        description: "pytest -k selector — OVERRIDES the impacted auto-derivation. Blank in impacted scope = the tests changed vs origin/devel (whole marker if none). e.g. 'test_dns_redirect' or 'redirect and not browser'."
+        required: false
+        default: ""
 
-  # Called by other workflows (e.g. release.yml) without version inputs.
+  # Called by other workflows. Defaults to the FULL suite so existing callers
+  # that pass nothing are unchanged (workflow_call -> scope=full by default).
   workflow_call:
+    inputs:
+      scope:
+        description: "impacted | full. Blank on a call = full (preserve existing callers)."
+        required: false
+        type: string
+        default: ""
+      version:
+        description: "Narrow the fan-out to the ci:true leg whose pfsense_version matches. Blank = scope decides."
+        required: false
+        type: string
+        default: ""
+      pytest_marker:
+        description: "pytest marker to select (default 'smoke')."
+        required: false
+        type: string
+        default: "smoke"
+      pytest_k:
+        description: "pytest -k selector (overrides impacted auto-derivation). Blank = scope decides."
+        required: false
+        type: string
+        default: ""
 
   # Daily nightly run — runs the full CE suite every night.
   schedule:
@@ -56,20 +102,94 @@ jobs:
     name: Read CI matrix
     runs-on: ubuntu-latest
     outputs:
-      ci_matrix: ${{ steps.read.outputs.ci_matrix }}
+      ci_matrix: ${{ steps.filter.outputs.ci_matrix }}
       leg_count: ${{ steps.count.outputs.leg_count }}
+      pytest_marker: ${{ steps.filter.outputs.pytest_marker }}
+      pytest_k: ${{ steps.filter.outputs.pytest_k }}
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0   # reach the ci-metadata orphan ref
+          fetch-depth: 0   # reach the ci-metadata orphan ref + branch history (impacted diff)
 
       - name: Read CI matrix from ci-metadata
         id: read
         uses: ./.github/actions/read-version-matrix
 
-      - name: Log CI matrix
+      # Resolve the run scope, the leg set, and the effective -k. Default for a
+      # bare DISPATCH is `impacted` (min CE leg + only the tests changed vs
+      # origin/devel); schedule and workflow_call default to `full` (every ci:true
+      # leg, whole marker) so the nightly run, the post-version-bump dispatch
+      # (version-tracker passes scope=full), and any caller stay unchanged.
+      - name: Resolve scope, legs, and -k
+        id: filter
         env:
           CI_MATRIX: ${{ steps.read.outputs.ci_matrix }}
+          VERSION_INPUT: ${{ inputs.version }}
+          SCOPE_INPUT: ${{ inputs.scope }}
+          MARKER_INPUT: ${{ inputs.pytest_marker }}
+          PYTEST_K_INPUT: ${{ inputs.pytest_k }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -eu
+
+          # SCOPE: schedule is always full; otherwise honour an explicit input;
+          # otherwise default by trigger — a call preserves the old full behaviour,
+          # a bare dispatch is the new lean `impacted` default.
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            SCOPE="full"
+          elif [ -n "${SCOPE_INPUT:-}" ]; then
+            SCOPE="$SCOPE_INPUT"
+          elif [ "$EVENT_NAME" = "workflow_call" ]; then
+            SCOPE="full"
+          else
+            SCOPE="impacted"
+          fi
+          case "$SCOPE" in impacted|full) ;; *) echo "::error::unknown scope '$SCOPE' (impacted|full)"; exit 1 ;; esac
+
+          # LEGS: an explicit version always wins (exact match). Else `full` keeps
+          # every ci:true leg; `impacted` narrows to the minimum-version CE leg
+          # (numeric component sort, so 2.8 < 2.10 — not lexical).
+          if [ -n "${VERSION_INPUT:-}" ]; then
+            FILTERED="$(printf '%s\n' "$CI_MATRIX" | jq -c --arg v "$VERSION_INPUT" \
+              '[ .[] | select(.pfsense_version == $v) ]')"
+            [ "$(printf '%s' "$FILTERED" | jq 'length')" -ne 0 ] \
+              || { echo "::error::version filter '${VERSION_INPUT}' matched no ci:true leg"; exit 1; }
+          elif [ "$SCOPE" = "full" ]; then
+            FILTERED="$(printf '%s\n' "$CI_MATRIX" | jq -c '.')"
+          else
+            FILTERED="$(printf '%s\n' "$CI_MATRIX" | jq -c \
+              '[ .[] | select(.channel == "CE") ] | sort_by(.pfsense_version | split(".") | map(tonumber)) | .[0:1]')"
+            [ "$(printf '%s' "$FILTERED" | jq 'length')" -ne 0 ] \
+              || { echo "::error::impacted scope found no CE leg in the CI matrix"; exit 1; }
+          fi
+
+          # EFFECTIVE -k: an explicit -k always overrides. In `impacted` scope with
+          # no -k, auto-derive from the smoke test modules changed vs origin/devel
+          # (empty -> whole marker, a safe over-approximation). `full` never
+          # auto-derives — it runs the whole marker unless a -k was passed.
+          K=""
+          if [ -n "${PYTEST_K_INPUT:-}" ]; then
+            K="$PYTEST_K_INPUT"
+          elif [ "$SCOPE" = "impacted" ]; then
+            git fetch --no-tags --depth=200 origin devel:refs/remotes/origin/devel 2>/dev/null || true
+            K="$(sh scripts/impacted-tests.sh origin/devel tests/smoke || true)"
+            if [ -n "$K" ]; then
+              echo "impacted: auto-derived -k from changed smoke test modules: ${K}"
+            else
+              echo "impacted: no changed smoke test modules vs origin/devel — running the whole '${MARKER_INPUT:-smoke}' marker on the min CE leg. Pass -f pytest_k=... to narrow to the tests covering your change."
+            fi
+          fi
+
+          echo "scope=${SCOPE}  legs=$(printf '%s' "$FILTERED" | jq 'length')  marker=${MARKER_INPUT:-smoke}  -k=[${K}]"
+          {
+            printf 'ci_matrix<<__EOF__\n%s\n__EOF__\n' "$FILTERED"
+            printf 'pytest_marker=%s\n' "${MARKER_INPUT:-smoke}"
+            printf 'pytest_k<<__EOF__\n%s\n__EOF__\n' "$K"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log CI matrix
+        env:
+          CI_MATRIX: ${{ steps.filter.outputs.ci_matrix }}
         run: |
           echo "=== CI matrix (ci:true entries, CE + Plus — fed to smoke strategy.matrix) ==="
           printf '%s\n' "$CI_MATRIX" | jq .
@@ -77,7 +197,7 @@ jobs:
       - name: Count legs + assert every leg is ci:true
         id: count
         env:
-          CI_MATRIX: ${{ steps.read.outputs.ci_matrix }}
+          CI_MATRIX: ${{ steps.filter.outputs.ci_matrix }}
         run: |
           set -eu
           COUNT=$(printf '%s\n' "$CI_MATRIX" | jq 'length')
@@ -143,6 +263,10 @@ jobs:
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
       php_version: ${{ matrix.php_version }}
       py_flavor: ${{ matrix.py_flavor }}
+      # Resolved by the prepare step: the marker, and the effective -k (an explicit
+      # input, else the impacted auto-derivation, else blank = whole marker).
+      pytest_marker: ${{ needs.prepare.outputs.pytest_marker || 'smoke' }}
+      pytest_k: ${{ needs.prepare.outputs.pytest_k }}
     secrets: inherit
 
   # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -80,6 +80,16 @@ on:
         required: false
         type: string
         default: "all"
+      scope:
+        description: "impacted | full. Blank on a call = full (preserve existing callers like test.yml/release.yml)."
+        required: false
+        type: string
+        default: ""
+      pytest_k:
+        description: "pytest -k selector — overrides the impacted auto-derivation. Blank = scope decides."
+        required: false
+        type: string
+        default: ""
       ports_repo:
         description: "FreeBSD-ports repo carrying the port + Mk framework (blank = build-pkg-linux default)."
         required: false
@@ -110,6 +120,18 @@ on:
           - functional
           - browser
           - all
+      scope:
+        description: "impacted (DEFAULT for a bare dispatch): min CE leg + only the UI tests changed vs origin/devel. full: every ci:true leg, whole tier — the nightly/release behaviour."
+        required: false
+        type: choice
+        default: "impacted"
+        options:
+          - impacted
+          - full
+      pytest_k:
+        description: "pytest -k selector — OVERRIDES the impacted auto-derivation. Blank in impacted scope = the UI tests changed vs origin/devel (whole tier if none). e.g. 'test_dnsbl' or 'feeds and not browser'."
+        required: false
+        default: ""
       ports_repo:
         description: "FreeBSD-ports repo carrying the port + Mk framework (blank = build-pkg-linux default). Point a pre-merge run at a ports branch carrying a new plist entry."
         required: false
@@ -173,6 +195,7 @@ jobs:
       matrix: ${{ steps.gen.outputs.matrix }}
       build_matrix: ${{ steps.gen.outputs.build_matrix }}
       run: ${{ steps.gen.outputs.run }}
+      pytest_k: ${{ steps.gen.outputs.pytest_k }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -194,12 +217,30 @@ jobs:
           # ignores it and always runs the daily Tier-B set.
           TIER_INPUT: ${{ inputs.tier }}
           # Optional narrow-to-one filter: a pfsense_version (e.g. "2.8"). Blank =
-          # ALL ci:true legs (CE + Plus).
+          # scope decides (min CE for impacted, all legs for full).
           VERSION_INPUT: ${{ inputs.version }}
+          # Run scope: impacted (default for a bare dispatch) | full.
+          SCOPE_INPUT: ${{ inputs.scope }}
+          # -k override for the auto-derivation.
+          PYTEST_K_INPUT: ${{ inputs.pytest_k }}
           # The ci:true legs (CE + Plus) read from ci-metadata.
           CI_MATRIX: ${{ steps.matrix.outputs.ci_matrix }}
         run: |
           set -eu
+
+          # SCOPE: schedule is always full; otherwise honour an explicit input;
+          # otherwise default by trigger — a call (test.yml/release.yml) preserves
+          # the old full behaviour, a bare dispatch is the new lean `impacted`.
+          if [ "${EVENT_NAME}" = "schedule" ]; then
+            SCOPE="full"
+          elif [ -n "${SCOPE_INPUT:-}" ]; then
+            SCOPE="$SCOPE_INPUT"
+          elif [ "${EVENT_NAME}" = "workflow_call" ]; then
+            SCOPE="full"
+          else
+            SCOPE="impacted"
+          fi
+          case "$SCOPE" in impacted|full) ;; *) echo "::error::unknown scope '$SCOPE' (impacted|full)"; exit 1 ;; esac
 
           # Tier set the daily schedule runs (Tier B). DROP `browser` here to
           # disable the nightly browser leg (§7 demote/drop one-liner).
@@ -230,17 +271,42 @@ jobs:
           fi
           echo "run=${RUN}" >> "$GITHUB_OUTPUT"
 
-          # The legs: every ci:true entry (CE + Plus), optionally narrowed to one
-          # pfsense_version by the `version` input. jq emits one
-          # {pfsense_version,image_name,channel} object per surviving leg.
-          LEGS="$(printf '%s\n' "$CI_MATRIX" | jq -c \
-            --arg v "${VERSION_INPUT:-}" \
-            '[ .[] | select($v == "" or .pfsense_version == $v)
-               | {pfsense_version, image_name, channel, freebsd_major, php_version, py_flavor} ]')"
+          # The legs: an explicit `version` always wins (exact match). Else `full`
+          # keeps every ci:true leg (CE + Plus); `impacted` narrows to the
+          # minimum-version CE leg (numeric component sort, so 2.8 < 2.10). jq
+          # emits one {pfsense_version,image_name,channel,...} object per leg.
+          PROJECT='{pfsense_version, image_name, channel, freebsd_major, php_version, py_flavor}'
+          if [ -n "${VERSION_INPUT:-}" ]; then
+            LEGS="$(printf '%s\n' "$CI_MATRIX" | jq -c --arg v "$VERSION_INPUT" \
+              "[ .[] | select(.pfsense_version == \$v) | ${PROJECT} ]")"
+          elif [ "$SCOPE" = "full" ]; then
+            LEGS="$(printf '%s\n' "$CI_MATRIX" | jq -c "[ .[] | ${PROJECT} ]")"
+          else
+            LEGS="$(printf '%s\n' "$CI_MATRIX" | jq -c \
+              "[ .[] | select(.channel == \"CE\") ] | sort_by(.pfsense_version | split(\".\") | map(tonumber)) | .[0:1] | map(${PROJECT})")"
+          fi
           LEG_COUNT="$(printf '%s\n' "$LEGS" | jq 'length')"
           if [ "${VERSION_INPUT:-}" != "" ] && [ "$LEG_COUNT" -eq 0 ]; then
             echo "::error::version filter '${VERSION_INPUT}' matched no ci:true leg"; exit 1
           fi
+
+          # EFFECTIVE -k: an explicit -k overrides. In `impacted` scope with no -k,
+          # auto-derive from the UI test modules changed vs origin/devel (empty ->
+          # whole tier, a safe over-approximation). `full` never auto-derives.
+          K=""
+          if [ -n "${PYTEST_K_INPUT:-}" ]; then
+            K="$PYTEST_K_INPUT"
+          elif [ "$SCOPE" = "impacted" ]; then
+            git fetch --no-tags --depth=200 origin devel:refs/remotes/origin/devel 2>/dev/null || true
+            K="$(sh scripts/impacted-tests.sh origin/devel tests/smoke/ui || true)"
+            if [ -n "$K" ]; then
+              echo "impacted: auto-derived -k from changed UI test modules: ${K}"
+            else
+              echo "impacted: no changed UI test modules vs origin/devel — running the whole tier on the min CE leg. Pass -f pytest_k=... to narrow."
+            fi
+          fi
+          { printf 'pytest_k<<__EOF__\n%s\n__EOF__\n' "$K"; } >> "$GITHUB_OUTPUT"
+          echo "scope=${SCOPE}  legs=${LEG_COUNT}  -k=[${K}]"
 
           # Build matrix: ONE .pkg per distinct leg (version/ABI), independent of
           # the tier axis — the tiers for a version all install the SAME package.
@@ -527,6 +593,10 @@ jobs:
           SMOKE_UI_VERSION: ${{ matrix.version }}
           # The functional DNSBL flow injects the sinkhole VIP; match the baked image.
           SMOKE_DNSBL_VIP4: ${{ secrets.SMOKE_DNSBL_VIP4 || vars.SMOKE_DNSBL_VIP4 }}
+          # Resolved by the prepare step: an explicit -k input, else the impacted
+          # auto-derivation (UI tests changed vs origin/devel), else blank = whole tier.
+          PYTEST_K: ${{ needs.prepare.outputs.pytest_k }}
+          MARKER: ${{ steps.tier.outputs.marker }}
         run: |
           set -eu
           # The smoke package is --ignore'd by the default addopts; re-enable it
@@ -535,9 +605,13 @@ jobs:
           # (not the slow module fixtures: deploy ~1-2 min, the General save's
           # sync pass up to 300s) — so a wedged check fails fast without aborting
           # a legitimately slow fixture. No assertion auto-retry (C1).
-          python3 -m pytest tests/smoke/ui -m "${{ steps.tier.outputs.marker }}" \
+          # Build the argv so an optional -k selector rides as a SINGLE arg (a
+          # bare-var splice would word-split a multi-token "a and not b").
+          set -- tests/smoke/ui -m "${MARKER}" \
             --override-ini="addopts=" --override-ini="timeout_func_only=true" \
             --timeout=300 --timeout-method=signal -v
+          [ -n "${PYTEST_K:-}" ] && set -- "$@" -k "${PYTEST_K}"
+          python3 -m pytest "$@"
 
       # ADR-24: runner-side scrub of the Plus secret identity from the diagnostics
       # BEFORE upload. For a non-CE (Plus) image: drop ONLY the QEMU CONSOLE

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -226,15 +226,17 @@ jobs:
               echo "  [DRY-RUN] WOULD dispatch smoke.yml with ci_matrix:"
               printf '%s\n' "$CI_MATRIX" | jq .
             else
-              echo "  [TRIGGER] smoke.yml (all ci:true CE entries)"
-              # Phase 6 contract: smoke.yml accepts no explicit version inputs —
-              # it reads the ci_matrix from the version-matrix reader itself.
-              # The tracker triggers it once; the fan-out workflow reads and expands
-              # the matrix internally into parallel strategy.matrix legs.
-              # See RESULTS/04_Results.txt for the exact expected input contract.
+              echo "  [TRIGGER] smoke.yml (scope=full — all ci:true entries)"
+              # Phase 6 contract: smoke.yml reads the ci_matrix from the
+              # version-matrix reader itself and expands it into parallel legs.
+              # A bare dispatch now defaults to scope=impacted (min CE + only the
+              # tests changed vs origin/devel); a post-version-bump validation
+              # wants the WHOLE fan-out, so pass scope=full explicitly.
+              # See RESULTS/04_Results.txt for the input contract.
               gh workflow run smoke.yml \
                 --repo "$REPO" \
                 --ref "$REF" \
+                -f scope=full \
                 || echo "  ::warning::Dispatch of smoke.yml failed — Phase 6 may not yet be landed"
             fi
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -760,6 +760,15 @@ mechanics, CI wiring (`ui-tests.yml`), gate status — are documented in
   schedule/dispatch-only (non-PR-blocking). Run a tier: `python -m pytest tests/smoke/ui -m
   ui_render --override-ini="addopts="` (`SMOKE_ADMIN_PASSWORD` must be set, else the UI fixtures
   SKIP, never fail).
+- **Selective dispatch (validate your own change cheaply).** A bare `gh workflow run
+  smoke.yml`/`ui-tests.yml` defaults to **`scope=impacted`**: the **min CE leg** + only the test
+  modules **changed vs `origin/devel`** (auto-derived). Pass **`-f pytest_k="a or b"`** to add the
+  tests covering changed *non-test* code (a live-VM suite can't map src→test for you);
+  `-f version=` / `-f pytest_marker=` (smoke) / `-f tier=` (UI) narrow further; **`-f scope=full`**
+  is the every-leg whole-marker run. The nightly `schedule`, `version-tracker`'s post-bump
+  dispatch, and the `workflow_call` gates (`test.yml`, `release.yml`) stay **full**. Locally it's
+  pytest-native — pass `-k`/`-m` to `scripts/local-smoke.sh`. Full reference:
+  `docs/misc/architecture-notes.md` ("Selective dispatch").
 - Smoke feed fixtures live in `tests/smoke/fixtures/` (inert data — RFC 5737/3849 IPs,
   `uuid-*.com`; never RFC 6761 TLDs or HSTS-preload names). Add one: drop the file there, update
   `tests/smoke/fixtures/README.md`, add a case in `test_smoke_feeds.py` via

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -157,6 +157,17 @@ The §7 browser reliability numbers are **CI-pending**; the
 browser leg has a one-line demote/drop switch (drop `browser` from `DEFAULT_SCHEDULE_TIERS` +
 run release `ui-suite` as `tier: functional`). Full design: `.ADRs/ADR_14_UI_UX_Testing/`.
 
+**Selective dispatch (ADR-14 + smoke).** A bare `gh workflow run ui-tests.yml` (and
+`smoke.yml`) defaults to **`scope=impacted`**: the **min CE leg only** plus, with no `-f
+pytest_k`, the test modules **changed vs `origin/devel`** (auto-derived by
+`scripts/impacted-tests.sh` from the `prepare`/`gen` step). `-f pytest_k="..."` **overrides** the
+auto-derivation — pass it for the tests covering changed *non-test* code, which a live-VM suite
+can't map automatically. `-f scope=full` restores the every-ci:true-leg whole-tier run.
+`schedule`, `workflow_call` (`test.yml` Tier-A gate, `release.yml` `tier: all`), and
+`version-tracker.yml`'s post-bump dispatch (which now passes `scope=full`) all stay **full** —
+only a bare `workflow_dispatch` is lean. Local runs are pytest-native: pass `-k`/`-m` straight
+through (`scripts/local-smoke.sh` forwards them and treats `-m smoke` as a default).
+
 ---
 
 ## HTTP mock-feed load smoke (ADR-16 Part C) — `tests/smoke/test_smoke_feeds.py`

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -69,7 +69,19 @@ SMOKE_STUB_DNS_ADDR=127.0.0.1 SMOKE_STUB_DNS_PORT=53 \
 `--ignore=tests/smoke`, so a plain `pytest` collects nothing here.
 
 `scripts/local-smoke.sh` wraps the env setup (sysctl, civm pull, defaults) — see its
-`--help`.
+`--help`. It **forwards any pytest args**, so selecting tests locally is pytest-native — no
+workflow involved:
+
+```sh
+# only specific tests (pytest -k is a boolean expr: `a or b`, `x and not y`)
+scripts/local-smoke.sh -k "test_dns_redirect or test_killstates"
+# a different marker — `-m smoke` is only a DEFAULT; your own -m is respected
+scripts/local-smoke.sh tests/smoke/ui -m ui_render -k test_dnsbl
+```
+
+The CI `scope=impacted` / min-CE / auto-derived-`-k` defaulting (see
+[architecture-notes.md](architecture-notes.md) "Selective dispatch") is **CI-only** — locally
+you pick the target and `-k` yourself.
 
 ## Building the `.pkg` off-FreeBSD
 

--- a/scripts/impacted-tests.sh
+++ b/scripts/impacted-tests.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# impacted-tests.sh BASE_REF TEST_DIR
+#
+# Emit a pytest `-k` expression selecting the test MODULES changed on this branch
+# since it diverged from BASE_REF, under TEST_DIR (e.g. `tests/smoke` for the
+# smoke marker, `tests/smoke/ui` for the Web-UI tiers). Each changed
+# `TEST_DIR/test_*.py` becomes an OR term of its module stem — pytest `-k` matches
+# the module name — so a dispatcher gets "only the tests I created/touched" for
+# free, with no coverage map to maintain.
+#
+# Empty output = no changed test modules under TEST_DIR. The caller then runs the
+# whole marker (a SAFE over-approximation — never under-runs), and the dispatcher
+# can pass an explicit `-k` to narrow to the tests covering changed NON-test code
+# (which a live-VM suite can't map automatically — the code runs on the guest,
+# out of any runner-side coverage).
+#
+# The `tests/smoke/test_*.py` glob deliberately does NOT match `tests/smoke/ui/`
+# (case `*` spans `/`, but the literal `test_` after the dir prefix doesn't), so
+# the smoke and UI workflows each pick up only their own changed tests.
+#
+# Test seam: PFB_IMPACTED_CHANGED_FILES (newline-separated paths) overrides the
+# git diff, so the pure filtering is exercisable without a git fixture.
+
+set -eu
+
+base="${1:?usage: impacted-tests.sh BASE_REF TEST_DIR}"
+dir="${2:?usage: impacted-tests.sh BASE_REF TEST_DIR}"
+dir="${dir%/}"
+
+if [ -n "${PFB_IMPACTED_CHANGED_FILES+x}" ]; then
+	changed="$PFB_IMPACTED_CHANGED_FILES"
+else
+	# Three-dot: files changed on HEAD since the merge-base with BASE_REF.
+	# Tolerate a missing/unfetched base ref — an empty diff routes the caller to
+	# the safe full-marker path rather than erroring the run.
+	changed="$(git diff --name-only "${base}...HEAD" 2>/dev/null || true)"
+fi
+
+# Build the OR expression in a subshell fed by the pipe; the trailing printf runs
+# in that SAME subshell, so $expr is in scope when emitted.
+printf '%s\n' "$changed" | {
+	expr=""
+	while IFS= read -r f; do
+		[ -n "$f" ] || continue
+		case "$f" in
+			"$dir"/test_*.py) ;;   # a direct test module of THIS dir
+			*) continue ;;
+		esac
+		stem="${f##*/}"; stem="${stem%.py}"
+		if [ -z "$expr" ]; then expr="$stem"; else expr="$expr or $stem"; fi
+	done
+	printf '%s' "$expr"
+}

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -102,11 +102,22 @@ pkill -9 -f qemu-system-x86_64 2>/dev/null || true
 
 target="${SMOKE_PYTEST_TARGET:-tests/smoke}"
 
+# Inject `-m smoke` only as a DEFAULT — if the caller passed their own `-m`
+# (e.g. `-m ui_render` for a Tier-A run, `-m repo`), respect it instead of
+# silently appending a second, winning `-m smoke`. A `-k` selector and every
+# other pytest arg always pass straight through.
+# ponytail: bare `-m` token detection; refine only if someone needs the `-m=foo` form.
+marker_args="-m smoke"
+for a in "$@"; do
+	[ "$a" = "-m" ] && { marker_args=""; break; }
+done
+
 # Explicit pytest args (if any) override the default target; quote everything (repo
 # shell rule) and branch instead of relying on word-splitting an unquoted $target.
 if [ "$#" -gt 0 ]; then
-	echo "local-smoke: running smoke suite ($*)" >&2
-	exec "$PYTHON" -m pytest "$@" -m smoke --override-ini="addopts="
+	echo "local-smoke: running smoke suite ($* ${marker_args})" >&2
+	# shellcheck disable=SC2086  # marker_args is a deliberate 0-or-2-word default
+	exec "$PYTHON" -m pytest "$@" $marker_args --override-ini="addopts="
 fi
 echo "local-smoke: running smoke suite ($target)" >&2
 exec "$PYTHON" -m pytest "$target" -m smoke --override-ini="addopts="

--- a/tests/shell/impacted_tests_spec.sh
+++ b/tests/shell/impacted_tests_spec.sh
@@ -1,0 +1,47 @@
+#shellcheck shell=sh
+# impacted-tests.sh — derive a pytest `-k` from the test modules changed on a
+# branch, so a default smoke/UI dispatch runs "only the tests you created or
+# touched" without a coverage map. The PFB_IMPACTED_CHANGED_FILES seam feeds the
+# changed-file list directly, so these specs pin the pure filtering with no git
+# fixture. Mirrors the smoke/UI fan-out's auto-derive step.
+
+Describe 'impacted-tests.sh'
+  SCRIPT="${PFB_ROOT}/scripts/impacted-tests.sh"
+
+  # Run the resolver with a fixed changed-file list (one path per line).
+  run_with() {
+    PFB_IMPACTED_CHANGED_FILES="$1" sh "$SCRIPT" origin/devel "$2"
+  }
+
+  Describe 'smoke dir (tests/smoke)'
+    It 'ORs the changed top-level smoke test modules'
+      changed="tests/smoke/test_dns_redirect.py
+tests/smoke/test_killstates.py"
+      When call run_with "$changed" tests/smoke
+      The output should equal 'test_dns_redirect or test_killstates'
+    End
+
+    It 'excludes the ui/ subtree, src, and non-test infra (owned elsewhere / unmappable)'
+      changed="tests/smoke/test_dns_redirect.py
+tests/smoke/ui/test_render.py
+src/usr/local/pkg/pfblockerng/pfb_unbound.py
+tests/smoke/conftest.py"
+      When call run_with "$changed" tests/smoke
+      The output should equal 'test_dns_redirect'
+    End
+
+    It 'emits nothing when only non-test code changed (caller runs the full marker)'
+      When call run_with "src/usr/local/pkg/pfblockerng/pfb_unbound.py" tests/smoke
+      The output should equal ''
+    End
+  End
+
+  Describe 'ui dir (tests/smoke/ui)'
+    It 'picks only the changed UI test modules, not the smoke-root ones'
+      changed="tests/smoke/test_dns_redirect.py
+tests/smoke/ui/test_render.py"
+      When call run_with "$changed" tests/smoke/ui
+      The output should equal 'test_render'
+    End
+  End
+End


### PR DESCRIPTION
## What

Make the live-VM **smoke** (`smoke.yml`) and **Web-UI** (`ui-tests.yml`) fan-outs selectively dispatchable, and default a bare `workflow_dispatch` to a lean **`scope=impacted`** run instead of the full fan-out, so an agent (or human) validating a change can fire just the relevant tests cheaply.

## Default behaviour by trigger

| Trigger | Scope | Legs | Tests |
| --- | --- | --- | --- |
| bare `workflow_dispatch` | **impacted** (new default) | min CE leg (numeric min-version CE) | only the test modules changed vs `origin/devel` (auto-derived) |
| `schedule` (nightly) | full | all `ci:true` (CE + Plus) | whole marker/tier |
| `version-tracker.yml` post-version-bump dispatch | full (now passes `scope=full`) | all | whole |
| `workflow_call` (`test.yml` Tier-A gate, `release.yml` `tier: all`) | full | all | whole |

So nothing that gates a release or runs nightly changes — only an ad-hoc dispatch is lean.

## Selecting tests

- **`-f pytest_k="a or b"`** — OVERRIDES the impacted auto-derivation. Pass it for tests covering changed *non-test* code: a live-VM suite can't map src→test automatically (the code runs on the guest, out of any runner-side coverage). `-k` is a pytest boolean expression (`and`/`or`/`not`); a comma is not an operator.
- **`-f version=2.8`** narrows to one `ci:true` leg.
- **`-f pytest_marker=repo`** (smoke) / **`-f tier=render|functional|browser|all`** (UI).
- **`-f scope=full`** restores the every-leg, whole-marker run.
- `smoke-single.yml` also gains `-f pytest_k=` (alongside the existing `pytest_marker`).

## How the impacted set is derived

`scripts/impacted-tests.sh BASE_REF TEST_DIR` emits a `-k` expression from the changed `TEST_DIR/test_*.py` modules (the smoke root excludes `tests/smoke/ui/`, which the UI workflow owns). The fan-out `prepare`/`gen` step resolves scope → legs → `-k` and threads it down. If only non-test code changed and no `-k` is given, it runs the **whole marker/tier** on the min CE leg — a safe over-approximation — and logs a note to pass `-k`.

## Local runs

Unchanged conceptually — local is pytest-native. `scripts/local-smoke.sh` forwards any pytest args and now treats `-m smoke` as a *default* (so `-m ui_render` / `-m repo` are respected):

```sh
scripts/local-smoke.sh -k "test_dns_redirect or test_killstates"
scripts/local-smoke.sh tests/smoke/ui -m ui_render -k test_dnsbl
```

## Tests / validation

- `tests/shell/impacted_tests_spec.sh` (shellspec, 4 examples) pins the `-k` derivation: ORs changed smoke modules, excludes the `ui/` subtree + src + infra, empty when only non-test code changed, and the UI variant picks only `tests/smoke/ui` modules.
- `actionlint` clean on the changed workflows; `shellcheck` clean; the jq resolver paths (impacted→min CE, full→all, explicit version, numeric version sort) verified by simulation.

Docs updated: `CLAUDE.md` (smoke operative facts), `docs/misc/architecture-notes.md` ("Selective dispatch"), `docs/misc/local-smoke-debian.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCpw7N4vXC37E7vjejhwUu
