### PR TITLE
ci: address review on selective test dispatch (follow-up to #553)

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -289,6 +289,9 @@ jobs:
           if [ "${VERSION_INPUT:-}" != "" ] && [ "$LEG_COUNT" -eq 0 ]; then
             echo "::error::version filter '${VERSION_INPUT}' matched no ci:true leg"; exit 1
           fi
+          if [ "$SCOPE" = "impacted" ] && [ -z "${VERSION_INPUT:-}" ] && [ "$LEG_COUNT" -eq 0 ]; then
+            echo "::error::impacted scope found no CE leg in the CI matrix"; exit 1
+          fi
 
           # EFFECTIVE -k: an explicit -k overrides. In `impacted` scope with no -k,
           # auto-derive from the UI test modules changed vs origin/devel (empty ->

--- a/scripts/impacted-tests.sh
+++ b/scripts/impacted-tests.sh
@@ -15,8 +15,9 @@
 # out of any runner-side coverage).
 #
 # The `tests/smoke/test_*.py` glob deliberately does NOT match `tests/smoke/ui/`
-# (case `*` spans `/`, but the literal `test_` after the dir prefix doesn't), so
-# the smoke and UI workflows each pick up only their own changed tests.
+# tests: the literal `test_` in the pattern must follow `$dir/` directly, and a
+# ui/ path has `ui/` there instead — so the smoke and UI workflows each pick up
+# only their own changed tests.
 #
 # Test seam: PFB_IMPACTED_CHANGED_FILES (newline-separated paths) overrides the
 # git diff, so the pure filtering is exercisable without a git fixture.

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -115,7 +115,7 @@ done
 # Explicit pytest args (if any) override the default target; quote everything (repo
 # shell rule) and branch instead of relying on word-splitting an unquoted $target.
 if [ "$#" -gt 0 ]; then
-	echo "local-smoke: running smoke suite ($* ${marker_args})" >&2
+	echo "local-smoke: running smoke suite ($*${marker_args:+ $marker_args})" >&2
 	# shellcheck disable=SC2086  # marker_args is a deliberate 0-or-2-word default
 	exec "$PYTHON" -m pytest "$@" $marker_args --override-ini="addopts="
 fi


### PR DESCRIPTION
## Follow-up to #553 (review fixes)

PR #553 (selective smoke/UI test dispatch) merged off a feature-branch tip that was missing this commit, so these Sonnet-review fixes were stranded. They are behaviour-preserving except for one small robustness guard.

- **`ui-tests.yml`** — add the impacted-scope empty-CE-leg guard, for parity with `smoke.yml`: if `scope=impacted` finds no CE leg in the CI matrix, fail loudly (`::error::`) instead of silently producing an empty matrix that skips `build-pkg` + `ui`.
- **`scripts/impacted-tests.sh`** — correct the glob comment (the real reason `tests/smoke/test_*.py` excludes `tests/smoke/ui/` is that the literal `test_` must follow `$dir/` directly; a `ui/` path has `ui/` there). Code unchanged.
- **`scripts/local-smoke.sh`** — drop the trailing space in the run banner when the caller supplied its own `-m`.

Validation: `shellcheck` clean, `actionlint` clean on `ui-tests.yml`, `tests/shell/impacted_tests_spec.sh` 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCpw7N4vXC37E7vjejhwUu
