### PR TITLE
pfblockerng: register the syslog logtab on the pkg-add path

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10930,6 +10930,35 @@ function pfb_clear_contents() {
 }
 
 
+// ADR-38: the canonical installedpackages/package <logging> block pfBlockerNG registers for its
+// dedicated syslog. The `pkg add` install path does NOT copy the package XML's <logging> block,
+// so sync_package_pfblockerng() asserts it here. 'logtab' pins the Status > System Logs > Packages
+// subtab label to "pfBlockerNG" on both channels (core else falls back to the package short name,
+// which reads "pfBlockerNG-devel" on the devel package).
+function pfb_syslog_logging_want() {
+	return array(
+		'logtab' => 'pfBlockerNG',
+		'facilityname' => 'pfblockerng',
+		'logfilename' => 'pfblockerng_syslog.log',
+	);
+}
+
+// TRUE when the stored <logging> block must be rewritten to the canonical one: any tracked field
+// (logtab / facilityname / logfilename) mismatches, or a stale <logsocket> is present (the removed
+// in-chroot socket, which core would otherwise regenerate). An already-canonical block with no
+// logsocket is left untouched.
+function pfb_syslog_logging_needs_update($current, $want) {
+	if (!is_array($current)) {
+		$current = array();
+	}
+	foreach (array('logtab', 'facilityname', 'logfilename') as $pfb_k) {
+		if (($current[$pfb_k] ?? '') !== ($want[$pfb_k] ?? '')) {
+			return TRUE;
+		}
+	}
+	return !empty($current['logsocket']);
+}
+
 // Main pfBlockerNG function
 function sync_package_pfblockerng($cron='') {
 	global $g, $pfb, $pfbarr;
@@ -10965,20 +10994,19 @@ function sync_package_pfblockerng($cron='') {
 	// section (only a GUI install does), so register it here, keyed on the
 	// configurationfile (channel-independent: pfBlockerNG vs pfBlockerNG-devel).
 	$pfb_pkg_logged = FALSE;
-	$pfb_log_want = array('facilityname' => 'pfblockerng', 'logfilename' => 'pfblockerng_syslog.log');
+	$pfb_log_want = pfb_syslog_logging_want();
 	foreach (config_get_path('installedpackages/package', array()) as $pfb_idx => $pfb_pkg) {
 		if (($pfb_pkg['configurationfile'] ?? '') !== 'pfblockerng.xml') {
 			continue;
 		}
-		// Write the canonical block when it is missing OR carries STALE values — not
-		// only when empty. An upgrade from a pre-Amendment-2 config can leave a row with
-		// a wrong facility/filename or a leftover <logsocket> (which would make core
-		// regenerate the now-removed in-chroot socket). Replacing the whole block on any
-		// mismatch drops the stale logsocket; an already-canonical row is left untouched.
-		$pfb_log_cur = $pfb_pkg['logging'] ?? array();
-		if (($pfb_log_cur['facilityname'] ?? '') !== $pfb_log_want['facilityname'] ||
-		    ($pfb_log_cur['logfilename'] ?? '') !== $pfb_log_want['logfilename'] ||
-		    !empty($pfb_log_cur['logsocket'])) {
+		// Write the canonical block when it is missing OR carries STALE values — not only
+		// when empty. An upgrade from an older config can leave a row with a wrong
+		// facility/filename, a missing 'logtab' (the pre-241302e block, which makes the
+		// Packages subtab read "pfBlockerNG-devel"), or a leftover <logsocket> (which would
+		// make core regenerate the now-removed in-chroot socket). Replacing the whole block
+		// on any mismatch fixes the label and drops the stale logsocket; an already-canonical
+		// row is left untouched.
+		if (pfb_syslog_logging_needs_update($pfb_pkg['logging'] ?? array(), $pfb_log_want)) {
 			config_set_path("installedpackages/package/{$pfb_idx}/logging", $pfb_log_want);
 			write_config('[pfBlockerNG] register syslog routing');
 		}

--- a/tests/php/SyslogLoggingRegistrationTest.php
+++ b/tests/php/SyslogLoggingRegistrationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-38 — the installedpackages/package <logging> block pfBlockerNG self-registers for its
+ * dedicated syslog on the pkg-add path (which does not copy the package XML's <logging>).
+ *
+ * Pins the two pure helpers in pfblockerng.inc:
+ *   pfb_syslog_logging_want(): array            — the canonical block.
+ *   pfb_syslog_logging_needs_update($cur,$want) — TRUE when the stored block must be rewritten.
+ *
+ * The intent: the block carries 'logtab' => 'pfBlockerNG' so the Status > System Logs > Packages
+ * subtab reads "pfBlockerNG" on BOTH channels (commit 241302e added <logtab> only to the package
+ * XML, which the pkg-add path ignores — so without 'logtab' here the devel package's tab falls
+ * back to "pfBlockerNG-devel"). A pre-241302e config row (facilityname + logfilename, NO logtab)
+ * MUST therefore be detected as needing a rewrite so existing installs self-heal on the next sync.
+ */
+final class SyslogLoggingRegistrationTest extends TestCase
+{
+	// -----------------------------------------------------------------------
+	// pfb_syslog_logging_want() — the canonical block
+	// -----------------------------------------------------------------------
+
+	public function testWantBlockCarriesLogtabFacilityAndFilename(): void
+	{
+		$want = pfb_syslog_logging_want();
+
+		// 'logtab' is the fix: it pins the Packages subtab label to "pfBlockerNG".
+		$this->assertSame('pfBlockerNG', $want['logtab'] ?? null,
+			"the canonical <logging> block must carry logtab='pfBlockerNG' to pin the subtab label");
+		$this->assertSame('pfblockerng', $want['facilityname'] ?? null);
+		$this->assertSame('pfblockerng_syslog.log', $want['logfilename'] ?? null);
+		// No stale <logsocket> in the canonical block (the in-chroot socket was removed).
+		$this->assertArrayNotHasKey('logsocket', $want);
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_syslog_logging_needs_update() — branch coverage on every condition
+	// -----------------------------------------------------------------------
+
+	public function testCanonicalBlockNeedsNoUpdate(): void
+	{
+		// Given a stored block already equal to the canonical one, no rewrite is needed.
+		$want = pfb_syslog_logging_want();
+		$this->assertFalse(pfb_syslog_logging_needs_update($want, $want),
+			"an already-canonical block must be left untouched (no needless write_config)");
+	}
+
+	public function testPre241302eBlockWithoutLogtabNeedsUpdate(): void
+	{
+		// This is the live state on every pkg-add install (e.g. Prod) before this fix: the block
+		// has facilityname + logfilename but NO logtab. It MUST be rewritten so the subtab label
+		// stops falling back to the package short name ("pfBlockerNG-devel").
+		// Fail-before/pass-after: the old inline check only compared facilityname/logfilename, so
+		// it returned FALSE here (no rewrite) and the label stayed wrong.
+		$want = pfb_syslog_logging_want();
+		$legacy = array(
+			'facilityname' => 'pfblockerng',
+			'logfilename' => 'pfblockerng_syslog.log',
+		);
+		$this->assertTrue(pfb_syslog_logging_needs_update($legacy, $want),
+			"a block missing 'logtab' must be detected as needing a rewrite (self-heal the label)");
+	}
+
+	public function testWrongLogtabNeedsUpdate(): void
+	{
+		$want = pfb_syslog_logging_want();
+		$cur = $want;
+		$cur['logtab'] = 'pfBlockerNG-devel';
+		$this->assertTrue(pfb_syslog_logging_needs_update($cur, $want),
+			"a stale logtab label must trigger a rewrite");
+	}
+
+	public function testFacilityMismatchNeedsUpdate(): void
+	{
+		$want = pfb_syslog_logging_want();
+		$cur = $want;
+		$cur['facilityname'] = 'wrongfacility';
+		$this->assertTrue(pfb_syslog_logging_needs_update($cur, $want));
+	}
+
+	public function testFilenameMismatchNeedsUpdate(): void
+	{
+		$want = pfb_syslog_logging_want();
+		$cur = $want;
+		$cur['logfilename'] = 'old.log';
+		$this->assertTrue(pfb_syslog_logging_needs_update($cur, $want));
+	}
+
+	public function testStaleLogsocketNeedsUpdate(): void
+	{
+		// Even an otherwise-canonical block must be rewritten if it carries the removed
+		// in-chroot <logsocket> (core would else regenerate the socket).
+		$want = pfb_syslog_logging_want();
+		$cur = $want;
+		$cur['logsocket'] = '/var/unbound/pfb_syslog.sock';
+		$this->assertTrue(pfb_syslog_logging_needs_update($cur, $want));
+	}
+
+	public function testMissingOrNonArrayCurrentNeedsUpdate(): void
+	{
+		// A fresh pkg-add has no <logging> block at all (empty / non-array) — must register it.
+		$want = pfb_syslog_logging_want();
+		$this->assertTrue(pfb_syslog_logging_needs_update(array(), $want),
+			"an absent block must be registered");
+		$this->assertTrue(pfb_syslog_logging_needs_update('', $want),
+			"a non-array stored value must be treated as absent and registered");
+	}
+}


### PR DESCRIPTION
Follow-up to `241302e` ("pin syslog Packages subtab label to pfBlockerNG on both channels"), which was incomplete.

## The gap

`241302e` added `<logtab>pfBlockerNG</logtab>` to `pfblockerng.xml` so the **Status → System Logs → Packages** subtab reads "pfBlockerNG" on both channels (core otherwise falls back to the package short name → "pfBlockerNG-devel" on the devel package).

But that only helps **GUI Package-Manager installs**, which copy the package XML's `<logging>` block into `config.xml`. The **pkg-add path** — the self-hosted pkg repo (ADR-17), the smoke harness, and dev deploys — does **not** copy it (see `pfblockerng.inc:10964`); instead `sync_package_pfblockerng()` self-registers the block via `$pfb_log_want`, which **lacked `logtab`**. So every pkg-add install kept registering a `logtab`-less block and the subtab stayed "pfBlockerNG-devel".

Verified live on a devel box: `installedpackages/package/.../logging` = `{ facilityname, logfilename }` — no `logtab`.

## The fix

- Add `'logtab' => 'pfBlockerNG'` to the registered block.
- Rewrite the stored block when **`logtab`** mismatches (not only `facilityname` / `logfilename` / `logsocket`), so existing pkg-add installs **self-heal on the next sync**.
- Extracted the canonical block + the staleness check into pure helpers — `pfb_syslog_logging_want()` and `pfb_syslog_logging_needs_update()` — so the behaviour is unit-testable off-appliance.

## Tests

New `tests/php/SyslogLoggingRegistrationTest.php` (8 tests): the want-block carries `logtab='pfBlockerNG'`; `needs_update` returns TRUE for a pre-`241302e` block (no `logtab`), a wrong `logtab`, a `facilityname`/`logfilename` mismatch, a stale `logsocket`, and an absent/non-array block, and FALSE for an already-canonical block. The pre-`241302e`-block case is the fail-before/pass-after discriminator — the old inline check (facility/filename only) returned FALSE there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVKv7EKzn7EbfWDw4MQRi9
