### PR TITLE
tests/smoke: enable master switch so managed-object legs run standalone (#487)

### DIFF
--- a/tests/smoke/test_smoke_managed_objects.py
+++ b/tests/smoke/test_smoke_managed_objects.py
@@ -70,12 +70,21 @@ def deployed_vm(  # noqa: ARG001
     DNSBL update path runs ``pfb_create_dnsbl`` which touches pfSense state.
     ``ensure_dnsbl_vip`` + ``use_system_dns_upstream`` give DNSBL a sinkhole
     VIP and a reachable upstream so the full update completes cleanly.
+
+    The master switch ``enable_cb`` is turned ON here so DNSBL ``$mode`` can
+    reach ``'enabled'`` (the enable chain is ``enable_cb`` AND ``pfb_dnsbl`` AND
+    the resolver up). The per-test toggles then flip ``pfb_dnsbl`` /
+    ``pfb_dnsvip_auto`` / the interface. Without this the module silently relied
+    on an earlier test in the full fan-out leaking ``enable_cb='on'`` — so the
+    managed-object legs failed when run in isolation (the #487 selective-dispatch
+    leg).
     """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
     h.snapshot_unbound_conf(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
+    h.set_package_enabled(smoke_vm, True)
     h.use_system_dns_upstream(smoke_vm)
     try:
         yield smoke_vm
@@ -97,6 +106,7 @@ def _ensure_pkg_installed(deployed_vm: SmokeVM) -> None:
         h.deploy(deployed_vm)
         h.snapshot_unbound_conf(deployed_vm)
         h.ensure_dnsbl_vip(deployed_vm)
+        h.set_package_enabled(deployed_vm, True)
         h.use_system_dns_upstream(deployed_vm)
 
 


### PR DESCRIPTION
## What

The ADR-35 managed-object lifecycle smoke tests (`test_smoke_managed_objects.py`:
enable / disable / nonat) toggle `pfb_dnsbl` + `pfb_dnsvip_auto` + the DNSBL
interface, but never set the package **master switch** `enable_cb`.

DNSBL `$mode` only reaches `'enabled'` when `enable_cb` **and** `pfb_dnsbl` are on
(plus the resolver up — the enable chain). So when these modules run **in
isolation** (the #487 selective-dispatch leg), `$mode` stayed `'disabled'`,
`pfb_manage_dnsbl_vip()` no-oped, and no `pfB_AUTO_VIP_v4` / NAT rule was created:

```
mode=disabled enable_cb= pfb_dnsbl=on unbound=on pfb_dnsvip_auto=on dnsbl_interface=lan ...
VIPs: [pfBlockerNG DNSBL@10.10.10.1/lo0]
```

The tests only "passed" in the full fan-out by **leaking** `enable_cb='on'` from an
earlier module — and even there they recently flipped to `Timeout >30.0s` (polling
`marked_vip_subnet` for a VIP that never appears). This is a test-isolation bug, not
a product bug: the auto-VIP code is correct (`test_dnsbl_autovip_lifecycle` proves it
via `CaseContext`, which sets `enable_cb`).

## Fix

Set `enable_cb='on'` as the module baseline — in the `deployed_vm` fixture and the
post-uninstall re-seed — removing the hidden cross-module dependency. The per-test
toggles still flip `pfb_dnsbl` / `pfb_dnsvip_auto` / the interface and assert their
own before/after state.

## Validation

- **Fail-before:** CE + Plus fan-out on `devel` (run 28174460842) — both legs FAIL
  `enable_creates_vip_and_nat` ("pfB_AUTO_VIP_v4 not created") + the disable cascade.
- **Pass-after:** CE + Plus fan-out on this branch (`managed_objects` module) — see
  the dispatched run linked in the PR checks.
- `test_dnsbl_autovip_lifecycle` and the three `test_syslog_export.py` legs (the rest
  of #487 Bucket A) already pass on `devel` — fixed by #492 / #493 / #504.

Test-only change (`tests/smoke/`); no `src/` touched.

Fixes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)
