### PR TITLE
tests/smoke: signal-based pf waits replace fixed-timeout polling

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2146,7 +2146,9 @@ def _ip_inject_snippet(spec: IpCase) -> str:
 # --------------------------------------------------------------------------- #
 
 
-def reload(vm: SmokeVM, scope: str = "update", *, data_path: bool = False, timeout: float = 600.0) -> None:
+def reload(
+    vm: SmokeVM, scope: str = "update", *, data_path: bool = False, wait_unbound: bool = True, timeout: float = 600.0
+) -> None:
     """Run a pfBlockerNG reload via the PHP CLI cron verb.
 
     ``scope`` is the verb: ``updatednsbl`` / ``updateip`` (targeted, faster per
@@ -2172,6 +2174,13 @@ def reload(vm: SmokeVM, scope: str = "update", *, data_path: bool = False, timeo
       :func:`wait_zero_downtime_swap` (the swap-applied signal). The caller is asserting
       the no-restart invariant (pid unchanged), so use this only when a config-clean
       python-mode DNSBL data update is expected; it RAISES if the swap line never appears.
+
+    ``wait_unbound=False`` (only honoured on the default ``data_path=False`` path) SKIPS the
+    ``wait_unbound_ready`` poll. Pass it from a test that asserts only pf-level state (NAT/
+    filter rules via ``pfctl``) and never probes DNS resolution — the resolver-readiness wait
+    is pure wasted wall-clock there. Pair it with :func:`apply_filter_sync` so the live pf
+    ruleset is authoritative on the next read. The ``data_path=True`` path ignores this flag:
+    it must wait on the zero-downtime swap signal regardless.
     """
     if scope not in ("update", "updateip", "updatednsbl", "cron"):
         raise ValueError(f"reload scope must be update/updateip/updatednsbl/cron, got {scope!r}")
@@ -2184,8 +2193,32 @@ def reload(vm: SmokeVM, scope: str = "update", *, data_path: bool = False, timeo
         # Forward the caller's remaining budget so a slow box honours `timeout` instead
         # of wait_zero_downtime_swap's shorter default.
         wait_zero_downtime_swap(vm, since=swap_before, timeout=max(1.0, deadline - time.monotonic()))
-    else:
+    elif wait_unbound:
         wait_unbound_ready(vm)
+
+
+def apply_filter_sync(vm: SmokeVM, *, timeout: float = 60.0) -> None:
+    """Force a BLOCKING pf filter reload via ``/etc/rc.filter_configure_sync``.
+
+    pfBlockerNG's reload triggers ``filter_configure()`` ASYNCHRONOUSLY (``send_event
+    ("filter reload")``), so a pf-level rule (rdr / block) lands a few seconds AFTER
+    ``reload()`` returns — which is why the older tests wrapped every ``pfctl`` read in a
+    bounded :func:`wait_until` poll, racing the event against a fixed timeout. This runs the
+    documented synchronous pfSense entrypoint instead: it returns only once the ruleset has
+    been rebuilt and applied, so the FIRST ``pfctl -sn`` / ``-sr`` read afterwards is
+    authoritative — assert once, no poll, no flake.
+
+    A bare ``filter_configure_sync()`` from ``pfSsh.php`` eval is NOT equivalent — it needs
+    the full rc environment (``shaper.inc`` / ``interfaces.inc`` globals) and throws
+    "undefined function" or builds a degraded result; the ``/etc/rc.*`` entrypoint is the
+    supported path (see ``docs/misc/local-smoke-debian.md``). Raises ``RuntimeError`` on a
+    non-zero exit.
+    """
+    result = vm.ssh("/etc/rc.filter_configure_sync", timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"apply_filter_sync failed: rc={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
 
 
 def reset(vm: SmokeVM, *, timeout: float = 600.0) -> None:

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -454,7 +454,8 @@ def _cleanup_redirect(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     """Disable redirect and reload — shared teardown used by finally blocks."""
     try:
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update", timeout=timeout)
+        h.reload(vm, "update", timeout=timeout, wait_unbound=False)
+        h.apply_filter_sync(vm)
     except Exception:
         pass  # best-effort in teardown; don't mask the test failure
 
@@ -526,7 +527,8 @@ def test_dns_redirect_enable_creates_nat_and_filter_rules(deployed_vm: SmokeVM, 
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — disable redirect; assert before-state clean.
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         assert _nat_redir_count(vm, _REDIR_DESCR_PFX) == 0, (
             "pfB_DNS_Redirect_* nat/rule entries present before enable — before-state not clean"
@@ -534,7 +536,7 @@ def test_dns_redirect_enable_creates_nat_and_filter_rules(deployed_vm: SmokeVM, 
         assert _filter_redir_count(vm, _REDIR_DESCR_PFX) == 0, (
             "pfB_DNS_Redirect_* filter/rule entries present before enable — before-state not clean"
         )
-        assert h.wait_until(lambda: not _pfctl_sn_has_redir(vm, iface)), (
+        assert not _pfctl_sn_has_redir(vm, iface), (
             f"pfctl -sn shows an rdr rule on {iface} before enable — before-state not clean\n"
             + _redir_match_report(vm, iface, expected_present=False)
         )
@@ -546,7 +548,8 @@ def test_dns_redirect_enable_creates_nat_and_filter_rules(deployed_vm: SmokeVM, 
         # localising where a "in config, absent from pf" failure happens on the VM.
         h.snap_state(vm, "redir_pre")
         _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
         h.snap_state(vm, "redir_enabled")
 
         # THEN — exactly 2 nat/rule entries (v4 + v6).
@@ -607,7 +610,7 @@ def test_dns_redirect_enable_creates_nat_and_filter_rules(deployed_vm: SmokeVM, 
 
         # THEN — pfctl -sn confirms the rdr rules are ACTIVE in the live pf ruleset.
         # This is the key gate that proves associated-rule-id='pass' actually renders.
-        assert h.wait_until(lambda: _pfctl_sn_has_redir(vm, iface)), (
+        assert _pfctl_sn_has_redir(vm, iface), (
             f"pfctl -sn shows no rdr rule on {iface} for port 53 after enable — "
             f"associated-rule-id='pass' did NOT render in the live pf ruleset\n"
             + _redir_match_report(vm, iface, expected_present=True)
@@ -651,7 +654,8 @@ def test_dns_redirect_disable_removes_nat_and_filter_rules(deployed_vm: SmokeVM,
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — enable on the primary interface; assert before-state with rules present.
         _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         assert _nat_redir_count(vm, _REDIR_DESCR_PFX + iface) == 2, (
             f"pfB_DNS_Redirect_{iface}_* nat/rule entries absent before disable — setup failed"
@@ -662,14 +666,15 @@ def test_dns_redirect_disable_removes_nat_and_filter_rules(deployed_vm: SmokeVM,
             f"pfB_DNS_Redirect_{iface}_* filter/rule entries present before disable — unexpected "
             f"(associated-rule-id='pass' means no hand-rolled companions should exist)"
         )
-        assert h.wait_until(lambda: _pfctl_sn_has_redir(vm, iface)), (
+        assert _pfctl_sn_has_redir(vm, iface), (
             f"pfctl -sn shows no rdr on {iface} before disable — setup failed\n"
             + _redir_match_report(vm, iface, expected_present=True)
         )
 
         # WHEN — disable and reload.
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — all pfB_DNS_Redirect_* entries must be gone.
         assert _nat_redir_count(vm, _REDIR_DESCR_PFX) == 0, (
@@ -679,8 +684,8 @@ def test_dns_redirect_disable_removes_nat_and_filter_rules(deployed_vm: SmokeVM,
             "pfB_DNS_Redirect_* filter/rule entries still present after disable"
         )
 
-        # THEN — pfctl -sn must show no rdr rule for port 53 on the primary interface (async: poll until absent).
-        assert h.wait_until(lambda: not _pfctl_sn_has_redir(vm, iface)), (
+        # THEN — pfctl -sn must show no rdr rule for port 53 on the primary interface.
+        assert not _pfctl_sn_has_redir(vm, iface), (
             f"pfctl -sn still shows an rdr rule on {iface} after disable\n"
             + _redir_match_report(vm, iface, expected_present=False)
         )
@@ -719,7 +724,8 @@ def test_dns_redirect_user_nat_rule_survives_enable_disable(deployed_vm: SmokeVM
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — seed the user NAT rule; assert redirect is disabled.
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
         _seed_user_nat(vm, _USER_NAT_DESCR)
 
         assert _nat_rule_present(vm, _USER_NAT_DESCR), "user NAT rule not present before enable — seeding failed"
@@ -729,7 +735,8 @@ def test_dns_redirect_user_nat_rule_survives_enable_disable(deployed_vm: SmokeVM
 
         # WHEN — enable on the primary interface.
         _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — pfB rules appear; user rule survives.
         assert _nat_rule_present(vm, _redir_descr_for(iface, "inet")), (
@@ -741,7 +748,8 @@ def test_dns_redirect_user_nat_rule_survives_enable_disable(deployed_vm: SmokeVM
 
         # WHEN — disable.
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — pfB rules gone; user rule still present.
         assert not _nat_rule_present(vm, _redir_descr_for(iface, "inet")), (
@@ -796,7 +804,8 @@ def test_dns_redirect_stale_interface_pruned_on_reduce(deployed_vm: SmokeVM) -> 
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — enable on both interfaces; assert both nat/rule sets present.
         _set_dns_redirect(vm, enabled=True, ifaces=[iface_keep, iface_drop], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         assert _nat_redir_count(vm, _REDIR_DESCR_PFX + iface_keep) == 2, (
             f"pfB_DNS_Redirect_{iface_keep}_* nat/rule entries absent before prune — setup failed"
@@ -816,7 +825,8 @@ def test_dns_redirect_stale_interface_pruned_on_reduce(deployed_vm: SmokeVM) -> 
 
         # WHEN — reduce to keep-interface only.
         _set_dns_redirect(vm, enabled=True, ifaces=[iface_keep], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — drop-interface nat/rule entries removed; filter/rule was and remains 0.
         drop_nat = _nat_redir_count(vm, _REDIR_DESCR_PFX + iface_drop)
@@ -876,7 +886,8 @@ def test_dns_redirect_exception_alias_branch(deployed_vm: SmokeVM, primary_iface
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — start from disabled state.
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
         assert _nat_redir_count(vm, _REDIR_DESCR_PFX) == 0, (
             "pfB_DNS_Redirect_* entries present before Case 5 — state not clean"
         )
@@ -887,7 +898,8 @@ def test_dns_redirect_exception_alias_branch(deployed_vm: SmokeVM, primary_iface
 
         # WHEN — enable with exception alias set.
         _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception=_EXCEPTION_ALIAS)
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — v4 rule has negated-alias source.
         v4_src_addr = _nat_rule_nested_field(vm, descr_v4, "source", "address")
@@ -909,7 +921,8 @@ def test_dns_redirect_exception_alias_branch(deployed_vm: SmokeVM, primary_iface
 
         # WHEN — clear the exception alias.
         _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — v4 rule source is <any> (source.any key present; address absent).
         assert _nat_rule_has_key(vm, descr_v4, "source", "any"), (
@@ -971,7 +984,8 @@ def test_dns_redirect_uninstall_sweeps_owned_rules_preserves_user_nat(deployed_v
     # uninstall path (owned objects swept, settings retained) is tracked in #484.
     _set_pfb_keep(vm, keep=False)
     _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
-    h.reload(vm, "update")
+    h.reload(vm, "update", wait_unbound=False)
+    h.apply_filter_sync(vm)
     _seed_user_nat(vm, _USER_NAT_DESCR)
 
     # BEFORE-STATE: assert nat/rule entries present; filter/rule entries are 0 (no companions).
@@ -1044,20 +1058,22 @@ def test_dns_redirect_master_disable_removes_rules_despite_toggle_on(deployed_vm
         h.set_package_enabled(vm, True)
         h.set_dnsbl_enabled(vm, True)
         _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         before_count = _nat_redir_count(vm, _REDIR_DESCR_PFX + iface)
         assert before_count == 2, (
             f"Expected 2 pfB_DNS_Redirect_{iface}_* nat/rule entries before master-disable, got {before_count}"
         )
-        assert h.wait_until(lambda: _pfctl_sn_has_redir(vm, iface)), (
+        assert _pfctl_sn_has_redir(vm, iface), (
             f"pfctl -sn shows no rdr on {iface} before master-disable — before-state setup failed\n"
             + _redir_match_report(vm, iface, expected_present=True)
         )
 
         # WHEN — turn master OFF; reload (dnsbl_redir toggle remains ON).
         h.set_package_enabled(vm, False)
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — all redirect nat rules must be gone (force-removed by $mode coupling).
         after_count = _nat_redir_count(vm, _REDIR_DESCR_PFX)
@@ -1067,8 +1083,8 @@ def test_dns_redirect_master_disable_removes_rules_despite_toggle_on(deployed_vm
             + _redir_match_report(vm, iface, expected_present=False)
         )
 
-        # THEN — pfctl confirms no rdr rule (async: poll until absent).
-        assert h.wait_until(lambda: not _pfctl_sn_has_redir(vm, iface)), (
+        # THEN — pfctl confirms no rdr rule.
+        assert not _pfctl_sn_has_redir(vm, iface), (
             f"pfctl -sn still shows an rdr rule on {iface} after master-disable\n"
             + _redir_match_report(vm, iface, expected_present=False)
         )
@@ -1111,21 +1127,23 @@ def test_dns_redirect_dnsbl_disable_removes_rules_despite_toggle_on(deployed_vm:
         h.set_package_enabled(vm, True)
         h.set_dnsbl_enabled(vm, True)
         _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         before_count = _nat_redir_count(vm, _REDIR_DESCR_PFX + iface)
         assert before_count == 2, (
             f"Expected 2 pfB_DNS_Redirect_{iface}_* nat/rule entries before DNSBL-disable (positive guard), "
             f"got {before_count} — rules absent even when all enablers are ON"
         )
-        assert h.wait_until(lambda: _pfctl_sn_has_redir(vm, iface)), (
+        assert _pfctl_sn_has_redir(vm, iface), (
             f"pfctl -sn shows no rdr on {iface} before DNSBL-disable — before-state setup failed\n"
             + _redir_match_report(vm, iface, expected_present=True)
         )
 
         # WHEN — turn DNSBL OFF; reload (master ON; dnsbl_redir toggle remains ON).
         h.set_dnsbl_enabled(vm, False)
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — all redirect nat rules must be gone (force-removed by $mode coupling).
         after_count = _nat_redir_count(vm, _REDIR_DESCR_PFX)
@@ -1135,8 +1153,8 @@ def test_dns_redirect_dnsbl_disable_removes_rules_despite_toggle_on(deployed_vm:
             + _redir_match_report(vm, iface, expected_present=False)
         )
 
-        # THEN — pfctl confirms no rdr rule (async: poll until absent).
-        assert h.wait_until(lambda: not _pfctl_sn_has_redir(vm, iface)), (
+        # THEN — pfctl confirms no rdr rule.
+        assert not _pfctl_sn_has_redir(vm, iface), (
             f"pfctl -sn still shows an rdr rule on {iface} after DNSBL-disable\n"
             + _redir_match_report(vm, iface, expected_present=False)
         )
@@ -1183,7 +1201,8 @@ def test_dns_redirect_uninstall_keep_on_removes_rules_retains_sections(
         # GIVEN — set keep=on; enable redirect; seed user NAT; assert all before-states.
         h.set_pfb_keep(vm, True)
         _set_dns_redirect(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
         _seed_user_nat(vm, _USER_NAT_DESCR)
 
         before_nat = _nat_redir_count(vm, _REDIR_DESCR_PFX + iface)

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -455,7 +455,7 @@ def _cleanup_redirect(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     try:
         _set_dns_redirect(vm, enabled=False, ifaces=[], exception="")
         h.reload(vm, "update", timeout=timeout, wait_unbound=False)
-        h.apply_filter_sync(vm)
+        h.apply_filter_sync(vm, timeout=timeout)
     except Exception:
         pass  # best-effort in teardown; don't mask the test failure
 

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -383,7 +383,8 @@ def _cleanup_dot_block(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     """Disable DoT/DoQ block and reload — shared teardown used by finally blocks."""
     try:
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update", timeout=timeout)
+        h.reload(vm, "update", wait_unbound=False, timeout=timeout)
+        h.apply_filter_sync(vm)
     except Exception:
         pass  # best-effort in teardown; don't mask the test failure
 
@@ -450,19 +451,21 @@ def test_dot_doq_block_rule_appears_on_enable(deployed_vm: SmokeVM, primary_ifac
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — disable DoT block; assert before-state clean.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX) == 0, (
             "pfB_DoT_Block_* filter/rule entries present before enable — before-state not clean"
         )
-        assert h.wait_until(lambda: not _pfctl_sr_has_block_853(vm)), (
+        assert not _pfctl_sr_has_block_853(vm), (
             "pfctl -sr shows a port-853 block rule before enable — before-state not clean\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
 
         # WHEN — enable on the primary interface and reload.
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — exactly 1 filter/rule entry for the primary interface.
         count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface)
@@ -485,8 +488,8 @@ def test_dot_doq_block_rule_appears_on_enable(deployed_vm: SmokeVM, primary_ifac
             f"{descr}: destination.port != '853'"
         )
 
-        # THEN — pfctl -sr confirms the block rule is active (async: poll until present).
-        assert h.wait_until(lambda: _pfctl_sr_has_block_853(vm)), (
+        # THEN — pfctl -sr confirms the block rule is active.
+        assert _pfctl_sr_has_block_853(vm), (
             "pfctl -sr shows no block rule for port 853 after enable\n"
             + _dot_block_match_report(vm, expected_present=True)
             + "\n"
@@ -526,27 +529,29 @@ def test_dot_doq_block_rule_removed_on_disable(deployed_vm: SmokeVM, primary_ifa
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — enable on the primary interface; assert before-state with rule present.
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface) == 1, (
             f"pfB_DoT_Block_{iface} filter/rule entry absent before disable — setup failed"
         )
-        assert h.wait_until(lambda: _pfctl_sr_has_block_853(vm)), (
+        assert _pfctl_sr_has_block_853(vm), (
             "pfctl -sr shows no port-853 block before disable — setup failed\n"
             + _dot_block_match_report(vm, expected_present=True)
         )
 
         # WHEN — disable and reload.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — all pfB_DoT_Block_* entries must be gone.
         assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX) == 0, (
             "pfB_DoT_Block_* filter/rule entries still present after disable"
         )
 
-        # THEN — pfctl -sr must show no port-853 block rule (async: poll until absent).
-        assert h.wait_until(lambda: not _pfctl_sr_has_block_853(vm)), (
+        # THEN — pfctl -sr must show no port-853 block rule.
+        assert not _pfctl_sr_has_block_853(vm), (
             "pfctl -sr still shows port-853 block rule after disable\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -593,7 +598,8 @@ def test_user_filter_rule_survives_disable_and_uninstall(deployed_vm: SmokeVM, p
         h.set_pfb_keep(vm, False)
         # GIVEN — seed the user filter rule; assert block is disabled.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
         _seed_user_filter(vm, _USER_FILTER_DESCR)
 
         assert _filter_rule_present(vm, _USER_FILTER_DESCR), (
@@ -605,7 +611,8 @@ def test_user_filter_rule_survives_disable_and_uninstall(deployed_vm: SmokeVM, p
 
         # WHEN — enable on the primary interface.
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — pfB rule appears; user rule survives enable.
         assert _filter_rule_present(vm, _DOT_BLOCK_DESCR_PFX + iface), f"pfB_DoT_Block_{iface} not created after enable"
@@ -615,7 +622,8 @@ def test_user_filter_rule_survives_disable_and_uninstall(deployed_vm: SmokeVM, p
 
         # WHEN — disable.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — pfB rule gone; user rule survives disable.
         assert not _filter_rule_present(vm, _DOT_BLOCK_DESCR_PFX + iface), (
@@ -627,7 +635,8 @@ def test_user_filter_rule_survives_disable_and_uninstall(deployed_vm: SmokeVM, p
 
         # WHEN — re-enable for the uninstall step.
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
         assert _filter_rule_present(vm, _DOT_BLOCK_DESCR_PFX + iface), (
             f"pfB_DoT_Block_{iface} not recreated before uninstall step"
         )
@@ -695,7 +704,8 @@ def test_stale_interface_rule_pruned_on_reconcile(deployed_vm: SmokeVM) -> None:
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — enable on both interfaces; assert both rules present.
         _set_dot_block(vm, enabled=True, ifaces=[iface_keep, iface_drop], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface_keep) == 1, (
             f"pfB_DoT_Block_{iface_keep} rule absent before prune — setup failed"
@@ -706,7 +716,8 @@ def test_stale_interface_rule_pruned_on_reconcile(deployed_vm: SmokeVM) -> None:
 
         # WHEN — reduce to keep-interface only.
         _set_dot_block(vm, enabled=True, ifaces=[iface_keep], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — drop-interface rule removed.
         drop_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface_drop)
@@ -756,7 +767,8 @@ def test_exception_alias_source_in_config_xml_when_set(deployed_vm: SmokeVM, pri
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — start from disabled state.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
         assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX) == 0, (
             "pfB_DoT_Block_* entries present before Case 5 — state not clean"
         )
@@ -767,7 +779,8 @@ def test_exception_alias_source_in_config_xml_when_set(deployed_vm: SmokeVM, pri
 
         # WHEN — enable with exception alias set.
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception=_EXCEPTION_ALIAS)
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — rule has negated-alias source.
         src_addr = _filter_rule_nested_field(vm, descr, "source", "address")
@@ -778,7 +791,8 @@ def test_exception_alias_source_in_config_xml_when_set(deployed_vm: SmokeVM, pri
 
         # WHEN — clear the exception alias.
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — rule source is <any> (source.any key present; address absent).
         assert _filter_rule_has_key(vm, descr, "source", "any"), (
@@ -829,7 +843,8 @@ def test_uninstall_sweep_removes_all_dot_block_rules(deployed_vm: SmokeVM, prima
     h.set_pfb_keep(vm, False)
     # GIVEN — enable DoT block on the primary interface and seed a user filter rule.
     _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-    h.reload(vm, "update")
+    h.reload(vm, "update", wait_unbound=False)
+    h.apply_filter_sync(vm)
     _seed_user_filter(vm, _USER_FILTER_DESCR)
 
     # BEFORE-STATE: assert all objects are present before uninstall.
@@ -895,23 +910,25 @@ def test_self_exempt_guard_in_pfctl_output(deployed_vm: SmokeVM, primary_iface: 
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — disable DoT block; assert before-state clean.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
-        assert h.wait_until(lambda: not _pfctl_sr_has_block_853(vm)), (
+        assert not _pfctl_sr_has_block_853(vm), (
             "pfctl -sr shows a port-853 block rule before enable — before-state not clean\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
-        assert h.wait_until(lambda: not _pfctl_sr_block_853_has_self_exempt(vm)), (
+        assert not _pfctl_sr_block_853_has_self_exempt(vm), (
             "pfctl -sr shows self-exempt port-853 rule before enable — before-state not clean\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
 
         # WHEN — enable on the primary interface and reload.
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
-        # THEN — pfctl -sr contains the block rule for port 853 (async: poll until present).
-        assert h.wait_until(lambda: _pfctl_sr_has_block_853(vm)), (
+        # THEN — pfctl -sr contains the block rule for port 853.
+        assert _pfctl_sr_has_block_853(vm), (
             "pfctl -sr shows no block rule for port 853 after enable\n"
             + _dot_block_match_report(vm, expected_present=True)
             + "\n"
@@ -919,7 +936,7 @@ def test_self_exempt_guard_in_pfctl_output(deployed_vm: SmokeVM, primary_iface: 
         )
 
         # THEN — the rule carries the self-exempt guard ('!' + 'self' on the block line).
-        assert h.wait_until(lambda: _pfctl_sr_block_853_has_self_exempt(vm)), (
+        assert _pfctl_sr_block_853_has_self_exempt(vm), (
             "pfctl -sr block rule for port 853 does not carry the self-exempt negation guard "
             "('!' + 'self' tokens absent on the block-853 line) — the firewall is NOT exempt from its own rule\n"
             + _dot_block_match_report(vm, expected_present=True)
@@ -962,20 +979,22 @@ def test_dot_block_master_disable_removes_rules_despite_toggle_on(deployed_vm: S
         h.set_package_enabled(vm, True)
         h.set_dnsbl_enabled(vm, True)
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         before_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface)
         assert before_count == 1, (
             f"Expected 1 pfB_DoT_Block_{iface} filter/rule entry before master-disable, got {before_count}"
         )
-        assert h.wait_until(lambda: _pfctl_sr_has_block_853(vm)), (
+        assert _pfctl_sr_has_block_853(vm), (
             "pfctl -sr shows no port-853 block before master-disable — before-state setup failed\n"
             + _dot_block_match_report(vm, expected_present=True)
         )
 
         # WHEN — turn master OFF; reload (dnsbl_dot_block toggle remains ON).
         h.set_package_enabled(vm, False)
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — all DoT block filter rules must be gone (force-removed by $mode coupling).
         after_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX)
@@ -985,8 +1004,8 @@ def test_dot_block_master_disable_removes_rules_despite_toggle_on(deployed_vm: S
             + _dot_block_match_report(vm, expected_present=False)
         )
 
-        # THEN — pfctl confirms no port-853 block (async: poll until absent).
-        assert h.wait_until(lambda: not _pfctl_sr_has_block_853(vm)), (
+        # THEN — pfctl confirms no port-853 block.
+        assert not _pfctl_sr_has_block_853(vm), (
             "pfctl -sr still shows a port-853 block rule after master-disable\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -1029,21 +1048,23 @@ def test_dot_block_dnsbl_disable_removes_rules_despite_toggle_on(deployed_vm: Sm
         h.set_package_enabled(vm, True)
         h.set_dnsbl_enabled(vm, True)
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         before_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface)
         assert before_count == 1, (
             f"Expected 1 pfB_DoT_Block_{iface} filter/rule entry before DNSBL-disable (positive guard), "
             f"got {before_count} — rule absent even when all enablers are ON"
         )
-        assert h.wait_until(lambda: _pfctl_sr_has_block_853(vm)), (
+        assert _pfctl_sr_has_block_853(vm), (
             "pfctl -sr shows no port-853 block before DNSBL-disable — before-state setup failed\n"
             + _dot_block_match_report(vm, expected_present=True)
         )
 
         # WHEN — turn DNSBL OFF; reload (master ON; dnsbl_dot_block toggle remains ON).
         h.set_dnsbl_enabled(vm, False)
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
 
         # THEN — all DoT block filter rules must be gone (force-removed by $mode coupling).
         after_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX)
@@ -1053,8 +1074,8 @@ def test_dot_block_dnsbl_disable_removes_rules_despite_toggle_on(deployed_vm: Sm
             + _dot_block_match_report(vm, expected_present=False)
         )
 
-        # THEN — pfctl confirms no port-853 block (async: poll until absent).
-        assert h.wait_until(lambda: not _pfctl_sr_has_block_853(vm)), (
+        # THEN — pfctl confirms no port-853 block.
+        assert not _pfctl_sr_has_block_853(vm), (
             "pfctl -sr still shows a port-853 block rule after DNSBL-disable\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -1103,7 +1124,8 @@ def test_dot_block_uninstall_keep_on_removes_rules_retains_sections(deployed_vm:
         # GIVEN — set keep=on; enable DoT block; seed user filter; assert all before-states.
         h.set_pfb_keep(vm, True)
         _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
-        h.reload(vm, "update")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
         _seed_user_filter(vm, _USER_FILTER_DESCR)
 
         before_count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface)

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -384,7 +384,7 @@ def _cleanup_dot_block(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     try:
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
         h.reload(vm, "update", wait_unbound=False, timeout=timeout)
-        h.apply_filter_sync(vm)
+        h.apply_filter_sync(vm, timeout=timeout)
     except Exception:
         pass  # best-effort in teardown; don't mask the test failure
 


### PR DESCRIPTION
## What

The DNS-redirect and DoT/DoQ-block live-VM smoke suites polled pf state with bounded `wait_until` loops because pfBlockerNG's `filter_configure()` applies **asynchronously** — a rule lands a few seconds after `reload()` returns. That polling is the exact "fixed-timeout" flakiness #483 calls out: a correct rule that lands just past the window reads as a red test, and tuning the timeout chases a moving target.

This replaces the polling with a deterministic completion signal:

- **`helpers.apply_filter_sync(vm)`** — runs the documented blocking `/etc/rc.filter_configure_sync` entrypoint, so the live pf ruleset is authoritative on the very next read.
- **`reload(..., wait_unbound=False)`** — opt out of the `wait_unbound_ready` poll on the default path. Both suites assert pf rules only and never probe DNS, so that resolver-readiness wait was pure wasted wall-clock.

Every `reload → wait_until(poll) → assert` becomes `reload → apply_filter_sync → single-read assert`. No `wait_until` remains in either file.

## Coverage

Behaviour-preserving: same 9 + 10 cases, same asserted values. Before-state assertions are **kept** (now single-read, not polled) per the test-coverage mandate — so each transition still proves absent-before / present-after.

## Live validation

Built the branch `.pkg` and ran the enable-path cases on a real pfSense CE 2.8 VM:

```
tests/smoke/test_dns_redirect.py::test_dns_redirect_enable_creates_nat_and_filter_rules PASSED
tests/smoke/test_dot_doq_block.py::test_dot_doq_block_rule_appears_on_enable           PASSED
2 passed, 17 deselected in 122.51s
```

Both rdr / port-853 rules render deterministically under `apply_filter_sync`, and the preserved before-state `assert not present` passes — confirming the signal-based wait is correct in both directions. (The remaining wall-clock levers the issue lists — targeted `updateip` verbs, VM-reuse audit, QEMU tuning — are intentionally out of scope here.)

Part of #483.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of DNS redirect and DoT/DoQ block smoke checks by making firewall reloads and rule updates more deterministic.
  * Reduced flaky waiting/polling during configuration changes, leading to more stable end-to-end validation after reloads.
  * Adjusted cleanup steps to better ensure firewall state is applied consistently before assertions run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->