### PR TITLE
tests/smoke: gate readiness on boot completion + surface reload stdout

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -334,7 +334,16 @@ def boot_and_probe(
     # module cycle (helpers imports from conftest at module load).
     from . import helpers  # noqa: PLC0415
 
-    helpers.wait_boot_complete(vm)
+    try:
+        helpers.wait_boot_complete(vm)
+    except Exception:
+        # Route a boot-complete failure (its loud timeout, or an SSH/php_eval error) through the
+        # SAME cleanup as a wait_ready failure: capture diagnostics, kill qemu, close the log --
+        # otherwise a never-completing boot leaks the VM and produces no screendump/log tail.
+        _capture_boot_failure(diag_name, qmp_sock, log_path, process)
+        _kill(process)
+        log_file.close()
+        raise
     return BootHandle(process=process, vm=vm, log_file=log_file)
 
 

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -326,6 +326,15 @@ def boot_and_probe(
 
     # Surface "boot-to-ready: N seconds" so it lands in the captured output.
     print(result.stdout.strip())
+
+    # wait_ready.sh keys on the web port, which answers BEFORE pfSense's rc finishes and
+    # removes /var/run/booting. Block until boot is actually complete so the first
+    # pfBlockerNG update does not race it (is_platform_booting() true -> "Sync terminated
+    # during boot process." -> silent no-op). Local import avoids the conftest<->helpers
+    # module cycle (helpers imports from conftest at module load).
+    from . import helpers  # noqa: PLC0415
+
+    helpers.wait_boot_complete(vm)
     return BootHandle(process=process, vm=vm, log_file=log_file)
 
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2188,7 +2188,13 @@ def reload(
     deadline = time.monotonic() + timeout
     result = vm.ssh(PHP_BIN, PFB_CLI, scope, timeout=timeout)
     if result.returncode != 0:
-        raise RuntimeError(f"reload({scope}) failed: rc={result.returncode} stderr={result.stderr!r}")
+        # Report STDOUT too, not just stderr: pfBlockerNG writes a PHP fatal (e.g. an uncaught
+        # TypeError that aborts the verb) to stdout, while stderr may only carry incidental noise
+        # like "pfctl: Table does not exist." A stderr-only message hides the real cause and can
+        # read like a transport failure -- surface both so the actual error is visible.
+        raise RuntimeError(
+            f"reload({scope}) failed: rc={result.returncode} stdout={result.stdout[-2000:]!r} stderr={result.stderr!r}"
+        )
     if data_path:
         # Forward the caller's remaining budget so a slow box honours `timeout` instead
         # of wait_zero_downtime_swap's shorter default.
@@ -2594,6 +2600,39 @@ def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 30, delay: float = 2.0) -
             return
         time.sleep(delay)
     raise RuntimeError("Unbound did not become ready after reload")
+
+
+def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.0) -> None:
+    """Block until pfSense has FINISHED booting (``is_platform_booting()`` false).
+
+    pfSense's rc removes ``/var/run/booting`` only at the very END of bootup -- AFTER
+    the web port (which ``wait_ready.sh`` keys on) already answers. So a fast box can
+    reach "ready" and run a pfBlockerNG update while ``is_platform_booting()`` is still
+    true, and pfBlockerNG ABORTS every sync during boot ("Sync terminated during boot
+    process.", pfblockerng.inc) -- a silent no-op: no feed load, no rule, then a later
+    reload trips "pfctl: Table does not exist". Observed live: at 35s uptime the flag was
+    still set; it cleared by 40s. We gate on the REAL function the package's guard checks,
+    not the bare ``/var/run/booting`` file, so this matches pfBlockerNG's own condition.
+
+    This is a last-resort poll of production-side state we cannot signal (issue #456);
+    the timeout RAISES loudly rather than returning, so a never-completing boot fails the
+    run instead of silently racing.
+    """
+    deadline = time.monotonic() + timeout
+    snippet = "echo '<<BOOT>>' . (is_platform_booting() ? '1' : '0') . '<<END>>';"
+    last = "?"
+    while time.monotonic() < deadline:
+        out = php_eval(vm, snippet, timeout=30.0).stdout
+        if "<<BOOT>>" in out and "<<END>>" in out:
+            last = out.split("<<BOOT>>", 1)[1].split("<<END>>", 1)[0].strip()
+            if last == "0":
+                return
+        time.sleep(delay)
+    raise RuntimeError(
+        f"pfSense still booting after {timeout:.0f}s: is_platform_booting() last returned "
+        f"{last!r} (expected '0'). /var/run/booting never cleared -- pfBlockerNG updates "
+        f"would abort as boot-time syncs."
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2622,7 +2622,14 @@ def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.
     snippet = "echo '<<BOOT>>' . (is_platform_booting() ? '1' : '0') . '<<END>>';"
     last = "?"
     while time.monotonic() < deadline:
-        out = php_eval(vm, snippet, timeout=30.0).stdout
+        # Under boot load pfSsh.php (full config load+lock) can be slow; let one over-30s probe
+        # retry on the remaining budget instead of aborting the whole wait. The deadline still
+        # bounds it -- a persistently slow box times out loudly below.
+        try:
+            out = php_eval(vm, snippet, timeout=30.0).stdout
+        except subprocess.TimeoutExpired:
+            last = "timeout"
+            continue
         if "<<BOOT>>" in out and "<<END>>" in out:
             last = out.split("<<BOOT>>", 1)[1].split("<<END>>", 1)[0].strip()
             if last == "0":


### PR DESCRIPTION
## What

Two small `tests/smoke` reliability fixes, both surfaced while running the live-VM suite on a fast Debian/KVM box:

### 1. Gate readiness on boot completion (`wait_boot_complete`)
`wait_ready.sh` keys on the guest web port, which answers **before** pfSense's rc removes `/var/run/booting`. On a fast box the harness can then deploy + run a pfBlockerNG update while `is_platform_booting()` is still true, and the package **aborts the sync as a boot-time no-op** ("Sync terminated during boot process." — no feed loaded, no rule built; a later reload then trips `pfctl: Table does not exist`).

Observed live: at 35s uptime `/var/run/booting` was still present; it cleared on its own by 40s. So this is a pure boot-completion race — `wait_ready` returns a few seconds too early. The fix adds `wait_boot_complete()` (poll the **real** `is_platform_booting()` the package itself checks, bounded, loud timeout per issue #456) to the boot path so updates never race boot.

### 2. Surface stdout in `reload()` failures
pfBlockerNG writes a PHP fatal to **stdout**, while stderr may carry only incidental noise like `pfctl: Table does not exist.` A stderr-only error message hid the real cause of a failed verb and read like a transport failure — this cost real debugging time. `reload()` now includes a stdout tail in the `RuntimeError`.

## Why it matters
Without (1), any live test that deploys then updates on a fast box silently no-ops the update and fails downstream with a misleading `Table does not exist`. CI's slower/SLIRP-NAT path happened to mask it.

## Validation
- `ruff` / `ruff format` / `mypy tests/` clean.
- Live: `tests/smoke/test_smoke_lan_rule_preserve.py` (#544) went **red → green** on the fast box with this change (run ×2 green for stability). The diagnostic improvement in (2) is what surfaced a separate package bug (a null-`$float` regression, fixed independently) that had been masquerading as the `rc=255`.

## Test coverage note
The default `python -m pytest` gate ignores `tests/smoke` (`addopts = --ignore=tests/smoke`), and there is no precedent for off-appliance unit tests of the smoke helpers, so — per the repo's ADR-04 model (harness validated by the live run) — the evidence here is the live #544 red→green rather than a new default-gate test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke test reliability by waiting for the system to finish booting before continuing, reducing race conditions during early updates.
  * Expanded error reporting for failed reloads so diagnostic output now includes more of the command’s standard output, making failures easier to troubleshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->