### PR TITLE
ADR-41: Immutable user firewall rules in the IP autorule reconciliation

### DIFF
--- a/.ADRs/ADR_41_Immutable_User_Firewall_Rules/ADR.md
+++ b/.ADRs/ADR_41_Immutable_User_Firewall_Rules/ADR.md
@@ -1,6 +1,12 @@
 # ADR-41: Immutable user firewall rules in the IP autorule reconciliation
 
-- **Status:** **Proposed** (2026-06-25)
+- **Status:** **Implemented (pending live-VM smoke)** (2026-06-25) — Phases 1–3 landed: the
+  emission is extracted + the reconciliation rewritten to the immutable-user splice (binary anchor),
+  with the off-appliance contract (user-rule fidelity, pfB-set-identical, idempotence) pinned
+  red→green in `AutoruleListOracleTest`. Phase 2's pf-precedence kill-gate returned **GO** (live
+  first-match confirmed; `RESULTS/02`). Flips to **Accepted** once the §7 live-VM fan-out (CE + Plus)
+  — the per-`pass_order` data-plane precedence sweep in `test_smoke_autorule_immutable.py` (currently
+  skipped pending Phase-4 wiring) — is green.
 - **Date:** 2026-06-25
 - **Branch:** `adr/41-immutable-user-firewall-rules` (off **`devel`**; `{slug}` = sanitised
   ADR-title slug per CLAUDE.md "Branch naming"). / **Component(s):** the IP-side autorule

--- a/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/01_Results.txt
@@ -1,0 +1,160 @@
+ADR-41 Phase 1 — Extract + oracle-pin the rule reconciliation
+=============================================================
+
+STATUS: COMPLETE — green on all gates. Go-ahead for Phase 2.
+
+
+HELPER SIGNATURE + LOCATION
+----------------------------
+
+Function: pfb_build_autorule_list()
+File:     src/usr/local/pkg/pfblockerng/pfblockerng.inc
+Line:     10987 (inserted just before sync_package_pfblockerng())
+
+Signature:
+    function pfb_build_autorule_list(
+        array  $existing_rules,
+        array  $pfb_generated,
+        string $order,
+        string $float,
+        array  $in_ifaces,
+        array  $out_ifaces
+    ): array
+
+Parameters:
+  $existing_rules  — the current filter/rule array from config.xml
+  $pfb_generated   — keyed array of pre-built pfB rule templates:
+                       permit_inbound, permit_outbound,
+                       deny_inbound, deny_outbound,
+                       match_inbound, match_outbound,
+                       inbound_floating, outbound_floating,
+                       dnsbl_float (0-2 pre-built DNSBL ping/permit rules)
+  $order           — pass_order value ('order_0'..'order_4' or '')
+  $float           — float mode: 'on' or '' (off)
+  $in_ifaces       — inbound interface name array
+  $out_ifaces      — outbound interface name array
+
+Returns: new filter/rule array (pure; no I/O, no config writes, no pfctl).
+
+
+ORACLE TEST FILE
+----------------
+
+File: tests/php/AutoruleListOracleTest.php
+
+21 tests, all green. Covers:
+
+  A. order_0,  float=off, inbound==outbound (lan), Deny_* only
+  B. order_0,  float=on,  inbound==outbound (lan), Deny_* only
+  C. order_1,  float=off, inbound==outbound (lan), Deny_* only  [KNOWN-BAD: dup]
+  D. order_1,  float=off, inbound!=outbound (lan+opt1), Deny_* only
+  E. order_1,  float=on,  inbound==outbound (lan), Deny_* only
+  F. order_2,  float=off, inbound==outbound (lan), Deny_* only  [KNOWN-BAD: dup]
+  G. order_2,  float=off, inbound!=outbound (lan+opt1), Deny_* only
+  H. order_2,  float=on,  inbound==outbound (lan), Deny_* only
+  I. order_3,  float=off, inbound==outbound (lan), Deny_* only
+  J. order_3,  float=on,  inbound==outbound (lan), Deny_* only
+  K. order_4,  float=off, inbound==outbound (lan), Deny_* only  [KNOWN-BAD: reorder pin]
+  L. order_4,  float=off, two ifaces (opt1 in, lan out)         [KNOWN-BAD: reorder]
+  M. order_4,  float=on,  inbound==outbound (lan), Deny_* only
+  N. empty/absent order  — user pass DROPPED (pin the DROP so Phase 3 can show fix)
+  O. order_1,  float=off, Permit_* + Deny_* present, separate ifaces
+  P. DNS-redirect bypass rule preserved (pfB_ prefix but not stripped)
+  Q. DoT-block bypass rule preserved (pfB_ prefix but not stripped)
+  R. pfB_ rules stripped and rebuilt (sanity)
+  S. DNSBL float rules emitted before iface loop
+  T. empty existing rules → only pfB rules
+  U. non-managed iface user rule → other_rules (emitted after managed rules)
+
+Each test asserts the FULL ordered [descr, type, interface, floating] list.
+
+
+KNOWN-BAD CASES (PINNED — Phase 3 flips them)
+----------------------------------------------
+
+C: testOrder1FloatOffSingleIfaceDenyOnlyKnownBadDuplicate
+   — order_1, float=off, inbound==outbound='lan':
+     user pass LAN emitted TWICE (once per loop: inbound + outbound).
+     Expected output has user_pass duplicated. Phase 3 removes the duplicate.
+
+F: testOrder2FloatOffSingleIfaceDenyOnlyKnownBadDuplicate
+   — order_2, float=off, inbound==outbound='lan':
+     Same duplication as C via the order_2 permit_rules block in both loops.
+     Expected output has user_pass duplicated. Phase 3 removes the duplicate.
+
+K/L: testOrder4FloatOff*KnownBadReorder
+   — order_4, float=off:
+     User pass rules are re-positioned relative to each other (emitted via
+     $permit_rules tail instead of original order). Phase 3 restores verbatim order.
+
+N: testAbsentOrderTreatedAsOrder0
+   — empty order string: user pass rule is DROPPED (goes to permit_rules but
+     no tail emits it). This pin documents WHY the caller defaults empty→order_0.
+     The fix (in the caller before calling the helper) already exists (#532/#539).
+     Phase 3 makes the drop structurally impossible (user rules never bucketed).
+
+
+CALL SITE CHANGES
+-----------------
+
+sync_package_pfblockerng() "Assign Rules" region:
+  - The large inline bucketing + per-interface emission loops REPLACED by:
+    1. Existing rule scan (for $pfb_active_aliases + $orig_rules_nocreated) —
+       kept in caller as a pure read loop (no bucketing).
+    2. DNSBL float pair built in caller ($pfb_dnsbl_float array, 0-2 rules).
+    3. $pfb_generated assembled from $pfb['permit_inbound'] etc.
+    4. pfb_build_autorule_list() called; result → $new_rules.
+  - Write gate unchanged: $orig_rules_nocreated != $new_rules_nocreated.
+  - Behaviour identical to before: same $new_rules array for same inputs.
+
+
+PFENSE DOUBLES ADDED
+--------------------
+
+None. All pfSense functions reached by pfb_build_autorule_list() (via pfb_tracker:
+get_real_interface, get_interface_ip, ip2long32, find_interface_subnet,
+get_interface_ipv6, find_interface_subnetv6) were already doubled in
+tests/php/pfsense_doubles.php before this phase.
+
+
+GATE RESULTS
+------------
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc
+  -> No syntax errors detected (pre-existing E_DEPRECATED warnings are irrelevant)
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/
+  -> (no output = clean)
+
+vendor/bin/phpstan analyse --no-progress --memory-limit=1G
+  -> No errors
+
+vendor/bin/phpunit --no-coverage
+  -> Tests: 1340, Assertions: 5162, Skipped: 3. OK
+     (1319 pre-existing + 21 new oracle tests)
+
+
+COMMIT
+------
+
+Commit subject (exact):
+  pfblockerng: extract autorule emission into pinned pfb_build_autorule_list() (ADR-41 P1)
+
+Files changed:
+  src/usr/local/pkg/pfblockerng/pfblockerng.inc  (helper added + call site rewired)
+  tests/php/AutoruleListOracleTest.php            (21 oracle tests)
+  .ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/01_Results.txt  (this file)
+
+
+GO-AHEAD FOR PHASE 2
+---------------------
+
+Phase 2 (live-VM precedence kill-gate) can proceed:
+  - The pure helper pfb_build_autorule_list() is extracted and off-appliance-tested.
+  - Its current behaviour (including known-bad cases) is pinned.
+  - No production behaviour changed in this phase.
+  - Phase 2 does NO production code changes — it only proves the anchor model on
+    the live VM and records the pass_order → insertion-anchor mapping.
+  - Phase 3 will: (a) replace the helper's bucketing+interleaving with the
+    immutable-user splice, (b) flip the KNOWN-BAD oracle tests to the correct
+    expected output, and (c) add live-VM smoke tests.

--- a/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/02_Results.txt
@@ -1,0 +1,140 @@
+ADR-41 Phase 2 Results — pf-precedence kill-gate
+================================================
+Branch: adr/41-immutable-user-firewall-rules   Phase: 2 (measurement / design-proof; NO production code)
+Verdict: GO  (single contiguous anchor per pass_order reproduces the intended pfB-vs-user
+              precedence WITHOUT splitting/reordering user rules)
+
+This phase establishes (a) the real pf evaluation model on a live VM, (b) the
+pass_order -> insertion-anchor mapping the Phase-3 immutable splice implements, and (c) that a
+single anchor suffices. It proves the falsifiable premise BEFORE Phase 3 builds (ADR-01 lesson).
+
+
+1. CONFIRMED pf EVALUATION MODEL (live evidence)
+------------------------------------------------
+Measured on the ADR-04 live CE 2.8 VM (box 10.0.0.23, NO_TWO_VM). Throwaway probe
+`tests/smoke/_p2_precedence.py` (removed; not committed). For the order_0 case it dumped
+`pfctl -sr` for the LAN interface:
+
+    pass in quick on vtnet2 inet from <LAN__NETWORK> to any ... label "USER_RULE: Default Allow LAN to any rule" ...
+    pass in quick on vtnet2 inet6 from fd00::/64 to any   ... label "USER_RULE: Default Allow LAN IPv6 to any rule" ...
+
+KEY FACTS, verified not assumed:
+  * Interface rules carry `quick` => pf is FIRST-MATCH PER INTERFACE. The first matching rule on
+    the packet's interface decides; rules on OTHER interfaces are irrelevant to it. So inter-
+    interface ordering in config.xml does NOT affect precedence -- only the relative order of
+    rules ON THE SAME interface does. (LAN = vtnet2; the friendly name 'lan' maps to that device.)
+  * Floating rules are evaluated as a separate group (pf separates floating from interface rules
+    regardless of config.xml interleaving), so keeping user rules verbatim cannot change the
+    float-vs-interface relationship -- consistent with the live-confirmed "float=on path is already
+    correct" finding in ADR.md S1.3.
+
+Consequence: the ONLY precedence that the anchor controls is the SAME-interface ordering of the
+pfB rules relative to the kept user rules.
+
+
+2. WHAT PRECEDENCE ACTUALLY MATTERS (first-match reduction)
+----------------------------------------------------------
+Under per-interface first-match, only interactions that change a packet's verdict matter:
+  * pfB-block vs user-PASS    -> SIGNIFICANT (a pass shadows a later block and vice-versa).
+  * pfB-pass  vs user-PASS    -> moot (both pass; whichever is first, the packet passes).
+  * pfB-block vs user-block   -> moot (both block; the packet is dropped either way).
+  * pfB-pass  vs pfB-block    -> internal to pfB, unchanged by this ADR (generation untouched).
+
+So the 4-way ORDER table (pfB p/m vs pfB b/r vs pfSense p/m vs pfSense b/r) COLLAPSES, for the
+user-visible precedence, to ONE binary question: does the pfB BLOCK sit BEFORE or AFTER the
+user's PASS rules on that interface?
+
+
+3. INTENDED PRECEDENCE PER pass_order (from the current emission = the oracle)
+-----------------------------------------------------------------------------
+"Intended precedence" is DEFINED by today's strip-and-rebuild emission (the behaviour the
+immutable splice must reproduce). Traced in pfb_build_autorule_list() (pfblockerng.inc), single
+managed interface, inbound==outbound, float=off:
+
+  order_0  : pfB deny emitted; managed-iface user-pass routed to $other_rules (tail) -> pfB BEFORE
+             user rules.  [LIVE-CONFIRMED: config shows `reject lan pfB_..._v4` then the user pass.]
+  order_1  (:11362): inbound loop emits $permit_rules (user-pass) FIRST, then pfB permit, then pfB
+             deny (:11401) -> user-pass BEFORE pfB-deny -> USER WINS.
+  order_2  (:11385): pfB permit, then $permit_rules (user-pass :11393), then pfB deny (:11401)
+             -> user-pass BEFORE pfB-deny -> USER WINS.
+  order_3  : pfB permit+deny in the loop, user buckets in the tail -> pfB BEFORE user rules.
+  order_4  : pfB permit+deny in the loop, then tail emits $other_rules (user-block) then
+             $permit_rules (user-pass) -> pfB BEFORE user rules (+ user block reordered before
+             user pass -- the deliberate reorder ADR-41 removes; see S6).
+  absent   : caller defaults order to 'order_0' (#539) -> same as order_0.
+
+Binary precedence classes:
+  pfB-WINS  (pfB block before user pass): order_0, order_3, order_4, absent.
+  USER-WINS (user pass before pfB block): order_1, order_2.
+
+
+4. pass_order -> INSERTION-ANCHOR MAPPING (what Phase 3 implements)
+------------------------------------------------------------------
+Keep the kept list = existing filter/rule minus the pfB-owned rules this region regenerates
+(descr starts 'pfB_', EXCLUDING the DNS-redirect/DoT bypass rules), in ORIGINAL order. Generate
+the pfB rules unchanged. Splice the contiguous pfB block at ONE anchor:
+
+    pass_order            | anchor (per managed interface)
+    ----------------------+--------------------------------------------------
+    order_0 / order_3 /   | pfB block spliced BEFORE the kept user rules
+      order_4 / absent    |   (pfB wins)
+    order_1 / order_2     | pfB block spliced AFTER the kept user rules
+                          |   (user pass wins)
+    unknown/other         | -> order_0 anchor (BEFORE)  [subsumes #539]
+
+  * pfB pass/match rules ride WITH the pfB block at the anchor. Their position relative to
+    user-pass is moot (pass-vs-pass), so this preserves precedence.
+  * NO user rule is ever bucketed, filtered, duplicated, split, or reordered -- the splice only
+    deletes pfB rules and inserts pfB rules around the verbatim user list.
+
+
+5. PROOF THE SINGLE ANCHOR REPRODUCES IT (no user-rule splitting)
+----------------------------------------------------------------
+The falsification risk (ADR S3 / S7) was: order_1/order_2 want pfB "between user pass/match and
+user block/reject", which -- if user rules interleave pass and block -- a single contiguous anchor
+cannot express without splitting the user list.
+
+It does NOT arise, because (S2) the pfB-block-vs-user-BLOCK ordering is MOOT. order_1/order_2 only
+require pfB-block to sit AFTER the user PASS rules; where it sits relative to user BLOCK rules is
+irrelevant (two blocks -> same drop). So "pfB block AFTER the entire kept user list" reproduces
+order_1/order_2 precedence exactly, with the user list kept verbatim. Likewise order_0/3/4 only
+require pfB-block BEFORE the user PASS rules; "pfB block BEFORE the entire kept user list" reproduces
+it. A single contiguous anchor per order therefore suffices for EVERY order. => GO, no re-scope.
+
+
+6. DELIBERATE BEHAVIOUR CHANGE (record for release notes)
+---------------------------------------------------------
+order_4 today reorders the user's own rules (emits user block before user pass) and the
+managed/non-managed split repositions managed-interface user rules. Under the immutable model the
+user list is kept verbatim, so these reorderings GO AWAY. Functionally inert (pf is per-interface
+first-match over the user's own rules in their config order), but config.xml rule order changes for
+some installs on order_1/order_2/order_4. Documented; Phase 4 confirms no precedence regression.
+
+
+7. EVIDENCE COMPLETENESS + LIMITATION (honest)
+----------------------------------------------
+LIVE-CONFIRMED this phase: the pf evaluation model (per-interface first-match / `quick`) and the
+order_0 anchor (pfB before user, on real pf). The order_1..4 anchors are derived from the emission
+oracle (the code that DEFINES the intended precedence) + the first-match reduction above; they were
+NOT each independently re-dumped live because the box's guest SSH dropped during repeated reloads
+(`Connection timed out during banner exchange` -- a state-flush/VM-flakiness artifact, NOT a code
+issue) and defeated the multi-reload sweep. This is acceptable for the kill-gate: the mapping is
+proven from the oracle + the live-confirmed pf model, and Phase 4 (its designated phase) asserts the
+pfB-vs-user precedence LIVE in the data plane for every pass_order (a blocked-vs-allowed probe), so
+the full per-order live proof is delivered there, not lost.
+
+MEASUREMENT NOTE for Phase 3/4: a state-flushing reload can transiently cut the harness's control
+SSH on some boxes; prefer fewer reloads per session / fresh-boot-per-case, or a reload that polls
+for completion over fresh connections, when scripting the live precedence sweep.
+
+
+8. GO-AHEAD FOR PHASE 3
+-----------------------
+GO. Implement the immutable-user reconciliation per the S4 mapping:
+  - keep = existing filter/rule minus pfB-owned (excl. bypass), ORIGINAL order;
+  - generate pfB rules (unchanged);
+  - splice the pfB block BEFORE the kept user rules for order_0/3/4/absent, AFTER for order_1/2
+    (unknown -> order_0 anchor);
+  - write iff changed; remove the dead bucketing/$permit_rules/per-interface user emission.
+Reshape the Phase-1 oracle to assert user-rule fidelity (multiset+order preserved), pfB-set
+identical, and idempotence; red on today's order_1/order_2 dup + order_4 reorder, green after.

--- a/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/03_Results.txt
@@ -1,0 +1,176 @@
+ADR-41 Phase 3 Results — Immutable-user-splice implementation
+=============================================================
+Branch: adr/41-immutable-user-firewall-rules   Phase: 3 (implementation)
+Verdict: GREEN — all gates pass; push to branch; no PR yet.
+
+
+1. WHAT WAS BUILT
+-----------------
+
+(A) pfb_build_autorule_list() rewritten in
+    src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+    Replaced the ~270-line bucketing + per-interface interleaving with an
+    ~80-line immutable-splice model (3 steps):
+
+      1. Build $keep: scan $existing_rules, strip pfB-owned rules
+         (descr starts 'pfB_' AND NOT a bypass rule), preserve everything
+         else verbatim in original order. Apply pfb_rule_alias_needs_v4_suffix()
+         upgrade in the same pass (no second loop).
+
+      2. Build $pfb_block: dnsbl_float first (unchanged), then per-inbound
+         loop (permit_in, match_in once via $pfbrunonce, deny_in), then
+         per-outbound loop (permit_out, match_out once, deny_out).
+         Rule templates and tracker assignment unchanged from Phase 1.
+
+      3. Splice: order_1/order_2 -> array_merge($keep, $pfb_block) (AFTER);
+         everything else -> array_merge($pfb_block, $keep) (BEFORE).
+         Unknown/absent order falls to BEFORE, making the #532 drop bug
+         structurally impossible.
+
+    Dead code removed: the 6 bucket variables ($permit_rules, $match_rules,
+    $other_rules, $fpermit_rules, $fmatch_rules, $fother_rules) and their
+    per-interface user re-emission loops are gone entirely.
+
+    PHP type hint: $order and $float are now ?string (nullable) — resolves the
+    Phase 1 TypeError on a live VM when $pfb['float'] or $pfb['order'] was
+    unset (null), which aborted `pfblockerng.php update` with a fatal.
+
+(B) tests/php/AutoruleListOracleTest.php reshaped
+
+    22 tests, all green (up from 21 — one renamed + method name updated).
+
+    Contract assertions added to every test:
+      - assertUserRulesPreserved($input, $output) — same non-pfB-owned multiset
+        and original relative order; prints before/after on failure.
+      - assertIdempotent($output, $gen, ...) — second pass on own output is a no-op;
+        prints first/second pass on failure.
+
+    KNOWN-BAD cases flipped (proven RED on old code, GREEN on new):
+      C: testOrder1FloatOffSingleIfaceDenyOnly — dup eliminated.
+      F: testOrder2FloatOffSingleIfaceDenyOnly — dup eliminated.
+      K: testOrder4FloatOffSingleIfaceDenyOnly — reorder gone (renamed from
+         testOrder4FloatOffSingleIfaceDenyOnlyKnownBadReorder).
+      L: testOrder4FloatOffTwoIfacesDenyOnly — reorder gone (renamed from
+         testOrder4FloatOffTwoIfacesKnownBadReorder).
+      N: testAbsentOrderTreatedAsBefore — was documenting the DROP of user rules
+         for unknown order; now asserts user rules are preserved (BEFORE anchor).
+      O: testOrder1FloatOffPermitAndDenyRulesPresent — expected output updated
+         from per-interface interleaving to single-anchor: keep first, pfB second.
+
+    Tests whose expected output was already correct now carry the new contract
+    assertions (A, B, D, E, G, H, I, J, M, P, Q, R, S, T, U + null test).
+
+    Deliberate behaviour change documented in test K/L docstrings:
+      order_4's user-block-before-user-pass reorder and the managed/non-managed
+      split go away. Functionally inert under per-interface first-match pf
+      (documented in Phase 2 Results §6).
+
+(C) tests/smoke/test_smoke_autorule_immutable.py written (NOT run)
+
+    4 live-VM oracle tests (marked ``immutable_autorule``):
+      T1 — user-rule fidelity: LAN pass rule survives Force-Update (before/after).
+      T2 — idempotence: second Force-Update produces identical rule list.
+      T3 — order_0 anchor: pfB block before user pass (pfB wins).
+      T4 — order_1 anchor: user pass before pfB block (user wins).
+
+    All 4 raise NotImplementedError via pfb_enabled_deny_only fixture until
+    Phase 4 wires the fixture. File structure and assertions are Phase-4-ready.
+    Live run deferred — box was flaky/occupied during Phase 3 session.
+
+
+2. GATE RESULTS
+---------------
+
+php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc
+  -> No syntax errors detected (pre-existing E_DEPRECATED warnings, not introduced here)
+
+vendor/bin/phpcs --standard=phpcs.xml.dist src/
+  -> (no output = clean)
+
+vendor/bin/phpstan analyse --no-progress --memory-limit=1G
+  -> No errors
+
+vendor/bin/phpunit --no-coverage
+  -> Tests: 1374, Assertions: 5284, Skipped: 3. OK
+     (1352 pre-existing + 22 oracle tests; +1 net from Phase 1 count due to rename)
+
+ruff check tests/smoke/test_smoke_autorule_immutable.py
+  -> All checks passed!
+
+ruff format --check tests/smoke/test_smoke_autorule_immutable.py
+  -> (reformatted once, then clean)
+
+mypy tests/
+  -> (no output = clean)
+
+
+3. FILES CHANGED
+----------------
+
+src/usr/local/pkg/pfblockerng/pfblockerng.inc
+  - pfb_build_autorule_list() rewritten (immutable-splice; ~270→~80 lines in body)
+  - $order/$float type hint: string -> ?string (null-safe; fixes live TypeError)
+
+tests/php/AutoruleListOracleTest.php
+  - KNOWN-BAD cases C, F, K, L, N, O: expected output updated + labels removed
+  - All tests: contract assertions added (assertUserRulesPreserved + assertIdempotent)
+  - Test M (absent order) renamed + docstring updated (drop -> BEFORE anchor)
+  - Test K/L renamed (KnownBadReorder suffix removed)
+  - Test T (non-managed iface) renamed + comment updated (no "other_rules" concept)
+  - Two new private helper methods: assertUserRulesPreserved, assertIdempotent
+
+tests/smoke/test_smoke_autorule_immutable.py  (new)
+  - Phase-4-ready live oracle; 4 tests; NotImplementedError until fixture wired
+
+.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/03_Results.txt  (this file)
+
+
+4. DESIGN DECISIONS (record for Phase 4)
+-----------------------------------------
+
+Single anchor suffices: proven in Phase 2. order_1/2 need pfB block AFTER user
+pass; unknown-order falls to BEFORE. No user-list splitting needed.
+
+Null-safe hint: ?string on $order/$float absorbs the live null that came from an
+unset $pfb['float']. The old Phase 1 strict `string` hint TypeError'd on that
+path. The new code treats null as '' (BEFORE anchor), matching the prior behaviour
+of the loose == comparisons in the original inline code.
+
+order_4 reorder removed deliberately: the bucket code emitted user-block before
+user-pass for order_4, and the managed/non-managed split repositioned rules.
+Both gone — user list verbatim. Functionally inert under per-interface first-match
+(Phase 2 §6). Documented in test K/L docstrings.
+
+Bypass rule detection: `str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX)` and
+`str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX)`. Both constants were already
+defined; no new strings.
+
+Alias upgrade inline: pfb_rule_alias_needs_v4_suffix() call moved into the $keep
+scan (Step 1). Equivalent to before — the old code called it in the same per-rule
+loop before bucketing.
+
+
+5. WHAT PHASE 4 MUST DO
+------------------------
+
+Phase 4 is the designated live-VM precedence sweep (ADR §7):
+
+  1. Wire pfb_enabled_deny_only fixture in test_smoke_autorule_immutable.py.
+     - h.write_local_feed() with RFC-5737 deny entries.
+     - h.deploy() + h.reload() to activate.
+     - Register h.force_update() in helpers.py (run pfblockerng.php update).
+
+  2. Assert T1/T2/T3/T4 live (the fixture raises NotImplementedError until wired).
+
+  3. Per-pass_order data-plane sweep:
+     - For each of order_0, order_1, order_2, order_3, order_4:
+       set pass_order via h.php_eval(), Force-Update, then probe:
+       * A domain in the deny list: must be blocked (T3 / T4).
+       * A domain NOT in the deny list: must resolve (sanity).
+     - This is the Phase 2 kill-gate completed live (Phase 2 §7 deferral note).
+
+  4. Flip ADR status to Accepted once Phase 4 smoke suite is green on CE + Plus.
+
+COMMIT (Phase 3):
+  pfblockerng: reconcile autorules without mutating user rules (ADR-41 P3, fixes #532 dup/reorder)

--- a/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/04_Results.txt
@@ -1,0 +1,52 @@
+ADR-41 Phase 4 Results — docs + DoD (off-box parts; live precedence sweep deferred)
+===================================================================================
+Branch: adr/41-immutable-user-firewall-rules
+Status set: Implemented (pending live-VM smoke)
+
+SCOPE NOTE: the live pfSense VM was flaky/occupied this session (a state-flushing reload
+transiently cut the harness control SSH — see RESULTS/02 §7), and the maintainer opted to run the
+live precedence fan-out later. So this phase delivered the OFF-BOX parts; the live data-plane
+precedence sweep is the one remaining acceptance item.
+
+DONE THIS PHASE
+---------------
+- docs/misc/architecture-notes.md: added "IP autorule reconciliation — immutable user rules
+  (ADR-41)" — the immutable-user splice, the binary anchor mapping, where the contract is pinned,
+  and the deliberate order_4 (no-reorder) behaviour change for release notes.
+- ADR.md Status -> "Implemented (pending live-VM smoke)" with the path to Accepted.
+- tests/smoke/test_smoke_autorule_immutable.py (the Phase-3 live oracle) hardened for landing:
+  * `_get_filter_rules` fixed to the proven h.php_eval(<<RULES>>..<<END>>) delimiter pattern
+    (was a non-existent `vm.php_eval`);
+  * relative import `from . import helpers as h` + `import json` (was an absolute import + a
+    function-local import);
+  * module mark changed from an UNREGISTERED `immutable_autorule` to
+    `[pytest.mark.smoke, pytest.mark.skip(...)]` — so it JOINS the ADR-04 fan-out but SKIPS cleanly
+    (4 skipped, no error) until Phase 4 removes the skip and wires the live fixtures. Verified it
+    collects + skips under `-m smoke`; ruff/format/mypy clean.
+
+OFF-APPLIANCE EVIDENCE (the landed proof)
+-----------------------------------------
+- pfb_build_autorule_list() = immutable splice: keep (non-pfB, original order) + contiguous pfB
+  block, spliced AFTER keep for order_1/order_2, BEFORE otherwise. All bucketing/per-interface user
+  emission removed.
+- AutoruleListOracleTest: 22 tests assert the CONTRACT (user-rule fidelity multiset+order,
+  pfB-set-identical, idempotence). Proven RED on the old Phase-1 bucketing helper (8 failures =
+  order_1/2 dup + order_4 reorder/drop), GREEN (100 assertions) on the new splice. Full PHP suite
+  green; phpcs/phpstan/php-l clean.
+
+REMAINING FOR ACCEPTANCE (maintainer / stable box — §7 DoD)
+----------------------------------------------------------
+- Wire the live fixtures in test_smoke_autorule_immutable.py (h.deploy + a Deny_* feed +
+  force-update), remove the module skip, and run the live-VM fan-out (CE + Plus):
+  * user-rule preservation sweep across pass_order x float (exact multiset + stability);
+  * per-pass_order DATA-PLANE precedence (a blocked-vs-allowed probe — pfB block effective AND the
+    LAN allow still passes), including an inbound!=outbound and a Permit_* case;
+  * keep #544's test_smoke_lan_rule_preserve.py green.
+- Then flip ADR.md Status -> Accepted.
+- MEASUREMENT TIP (RESULTS/02 §7): a state-flushing reload can transiently drop the control SSH;
+  prefer fewer reloads per session / fresh-boot-per-case, or a completion-polling reload.
+
+DoD VERDICT
+-----------
+Implemented (pending live-VM smoke). Off-appliance contract proven; pf-precedence kill-gate GO;
+docs updated. Acceptance gated only on the live fan-out above.

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -458,6 +458,35 @@ Full design: ADR-39.
   URL — post-merge (a new `workflow_dispatch` workflow is only dispatchable from the default
   branch).
 
+## IP autorule reconciliation — immutable user rules (ADR-41)
+
+The IP-side autorule pass in `sync_package_pfblockerng()` reconciles pfBlockerNG's own
+`filter/rule` entries each update via the pure helper `pfb_build_autorule_list($existing_rules,
+$pfb_generated, $order, $float, $in_ifaces, $out_ifaces)` (pfblockerng.inc). It treats **user
+rules as immutable**: the kept list is the live `filter/rule` minus only the pfB-owned rules this
+region regenerates (descr starts `pfB_`, **excluding** the DNS-redirect/DoT-block bypass rules,
+which are kept like user rules), in their **original order**; pfBlockerNG's rules are generated
+unchanged and **spliced as one contiguous block at a single anchor**. No user rule is ever
+bucketed, filtered, duplicated, split, or reordered — eliminating the #532 drop / order_1·2
+duplication / order_4 reorder as a class.
+
+The anchor is **binary**, because pf is per-interface first-match (`quick`) so the only
+user-visible interaction is pfB-block-vs-user-**pass** (pass-vs-pass and block-vs-block are moot):
+
+- `order_0` / `order_3` / `order_4` / absent / unknown → pfB block **before** the kept user rules
+  (pfB wins; absent→order_0 subsumes the #539 default).
+- `order_1` / `order_2` → pfB block **after** the kept user rules (user pass wins).
+
+The contract (user-rule fidelity, pfB-rule-set identical, idempotence) is pinned off-appliance in
+`tests/php/AutoruleListOracleTest.php`; the live data-plane precedence sweep is
+`tests/smoke/test_smoke_autorule_immutable.py` (ADR-04). Design + the live pf-precedence kill-gate
+evidence: `.ADRs/ADR_41_Immutable_User_Firewall_Rules/`.
+
+**Deliberate behaviour change (release notes):** `order_4` (and the old managed/non-managed split)
+no longer **reorders** the user's own rules — user rules are now kept verbatim. Functionally inert
+under per-interface first-match, but some installs' `config.xml` rule order changes on
+`order_1`/`order_2`/`order_4`.
+
 ## Managed firewall object ownership and teardown (ADR-35)
 
 A small shared ownership-and-teardown layer for pfBlockerNG-managed objects in pfSense-core sections

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11520,9 +11520,16 @@ function pfb_syslog_logging_needs_update($current, $want) {
 /**
  * pfb_build_autorule_list() — pure emission helper extracted from sync_package_pfblockerng().
  *
- * Takes the current filter/rule list and the pre-built pfB rule templates, buckets the
- * surviving user rules (same logic as the "Assign Rules" region of sync_package_pfblockerng()),
- * and re-emits them interleaved with the generated pfB rules according to the ORDER table.
+ * Keeps all non-pfB rules verbatim (same set, count, and original relative order) and splices
+ * the regenerated pfB rules at a single anchor determined by pass_order. No user rule is ever
+ * bucketed, filtered, duplicated, split, or reordered — the only operations are "keep in place"
+ * for user rules and "regenerate at anchor" for pfB rules.
+ *
+ * Anchor mapping (per-interface first-match semantics — ADR-41 Phase 2):
+ *   order_1 / order_2           → pfB block AFTER kept user rules  (user pass wins)
+ *   order_0 / order_3 / order_4 → pfB block BEFORE kept user rules (pfB wins)
+ *   absent / unknown            → order_0 anchor / BEFORE           [subsumes #539]
+ *
  * Returns the new filter/rule array. No I/O, no config writes, no pfctl — pure array logic.
  *
  * @param array  $existing_rules  The current filter/rule array from config.xml.
@@ -11559,234 +11566,94 @@ function pfb_build_autorule_list(
 	// typehint TypeError on the null the call site legitimately passes (e.g. enable_float unset).
 	$order = $order ?? '';
 	$float = $float ?? '';
-	$new_rules     = [];
-	$permit_rules  = [];
-	$match_rules   = [];
-	$other_rules   = [];
-	$fpermit_rules = [];
-	$fmatch_rules  = [];
-	$fother_rules  = [];
 
-	// Bucket surviving user rules (same logic as sync_package_pfblockerng() "Assign Rules").
+	// Step 1: build $keep — all non-pfB-owned rules in original order, alias-upgraded.
+	// A rule is pfB-owned iff its descr starts with 'pfB_' AND it is NOT a bypass rule
+	// (DNS-redirect / DoT-block bypass rules keep their pfB_ prefix but stay user-managed).
+	$keep = [];
 	foreach ($existing_rules as $rule) {
-		$descr              = $rule['descr'] ?? '';
-		$is_dns_bypass_rule =
-		    str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
-		    str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
+		$descr      = $rule['descr'] ?? '';
+		$is_bypass  = str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
+		              str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
 
-		if (!str_starts_with($rule['descr'], 'pfB_') || $is_dns_bypass_rule) {
-			// Upgrade previous IPv4 pfBlockerNG alias names to '_v4' suffix format.
-			foreach (array('source', 'destination') as $rtype) {
-				if (pfb_rule_alias_needs_v4_suffix($rule[$rtype]['address'] ?? '', $rule['ipprotocol'] ?? '')) {
-					$rule[$rtype]['address'] = "{$rule[$rtype]['address']}_v4";
-				}
-			}
+		if (str_starts_with($descr, 'pfB_') && !$is_bypass) {
+			continue;  // pfB-owned — will be regenerated below
+		}
 
-			if ($float == 'on') {
-				if ($order == 'order_0' && $rule['floating'] == 'yes') {
-					$fother_rules[] = $rule;
-				}
-				else {
-					if ($rule['type'] == 'pass' && $rule['floating'] == 'yes') {
-						$fpermit_rules[] = $rule;
-					} elseif ($rule['type'] == 'match' && $rule['floating'] == 'yes') {
-						$fmatch_rules[] = $rule;
-					} elseif ($rule['floating'] == 'yes') {
-						$fother_rules[] = $rule;
-					} else {
-						$other_rules[] = $rule;
-					}
-				}
-			} else {
-				if (in_array($rule['interface'], $in_ifaces) ||
-				    in_array($rule['interface'], $out_ifaces)) {
-					if ($rule['floating'] == 'yes') {
-						$fother_rules[] = $rule;
-					} elseif ($rule['type'] == 'pass' || isset($rule['associated-rule-id'])) {
-						if ($order == 'order_0') {
-							$other_rules[] = $rule;
-						} else {
-							$permit_rules[] = $rule;
-						}
-					} else {
-						$other_rules[] = $rule;
-					}
-				} else {
-					if ($rule['floating'] == 'yes') {
-						$fother_rules[] = $rule;
-					} else {
-						$other_rules[] = $rule;
-					}
-				}
+		// Upgrade previous IPv4 pfBlockerNG alias names to '_v4' suffix format.
+		foreach (array('source', 'destination') as $rtype) {
+			if (pfb_rule_alias_needs_v4_suffix($rule[$rtype]['address'] ?? '', $rule['ipprotocol'] ?? '')) {
+				$rule[$rtype]['address'] = "{$rule[$rtype]['address']}_v4";
 			}
 		}
+
+		$keep[] = $rule;
 	}
 
-	// Pre-interface-loop emission (ORDER 1 non-float: user-permit first; ORDER 1 float: fpermit/fmatch first).
-	if ($float == '' && $order == 'order_1' && !empty($fother_rules)) {
-		foreach ($fother_rules as $cb_rules) {
-			$new_rules[] = $cb_rules;
-		}
-	}
-	if ($float == 'on' && $order == 'order_1') {
-		foreach (array($fpermit_rules, $fmatch_rules) as $rtype) {
-			if (!empty($rtype)) {
-				foreach ($rtype as $cb_rules) {
-					$new_rules[] = $cb_rules;
-				}
-			}
-		}
-	}
+	// Step 2: build the pfB block — same generation order as before (dnsbl_float first,
+	// then per-inbound permit/match/deny, then per-outbound permit/match/deny).
+	$pfb_block = [];
 
-	// Emit pre-built DNSBL floating pass rules (ping + permit pair, or empty).
+	// DNSBL floating pass rules (ping + permit pair, or empty) — emitted before interface rules.
 	foreach ($pfb_generated['dnsbl_float'] as $cb_rules) {
-		$new_rules[] = $cb_rules;
+		$pfb_block[] = $cb_rules;
 	}
 
 	// Inbound interface rules.
-	if (!empty($in_ifaces)) {
-		$pfbrunonce = TRUE;
-		foreach ($in_ifaces as $inbound_interface) {
-			if ($order == 'order_1' && !empty($permit_rules)) {
-				foreach ($permit_rules as $cb_rules) {
-					if ($cb_rules['interface'] == $inbound_interface) {
-						$new_rules[] = $cb_rules;
-					}
-				}
+	$pfbrunonce = TRUE;
+	foreach ($in_ifaces as $inbound_interface) {
+		foreach ($pfb_generated['permit_inbound'] as $cb_rules) {
+			$cb_rules['interface'] = $inbound_interface;
+			$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'permit_in');
+			$pfb_block[]           = $cb_rules;
+		}
+		// Match inbound rules are floating-only (emit once across all inbound interfaces).
+		if ($pfbrunonce && !empty($pfb_generated['match_inbound'])) {
+			foreach ($pfb_generated['match_inbound'] as $cb_rules) {
+				$cb_rules['interface'] = $pfb_generated['inbound_floating'];
+				$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'match_in');
+				$pfb_block[]           = $cb_rules;
+				$pfbrunonce            = FALSE;
 			}
-			if (!empty($pfb_generated['permit_inbound'])) {
-				foreach ($pfb_generated['permit_inbound'] as $cb_rules) {
-					$cb_rules['interface'] = $inbound_interface;
-					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'permit_in');
-					$new_rules[]           = $cb_rules;
-				}
-			}
-			// Match inbound rules are floating-only (emit once).
-			if ($pfbrunonce && !empty($pfb_generated['match_inbound'])) {
-				foreach ($pfb_generated['match_inbound'] as $cb_rules) {
-					$cb_rules['interface'] = $pfb_generated['inbound_floating'];
-					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'match_in');
-					$new_rules[]           = $cb_rules;
-					$pfbrunonce            = FALSE;
-				}
-			}
-			if ($order == 'order_2') {
-				foreach (array($fpermit_rules, $fmatch_rules) as $rtype) {
-					if (!empty($rtype)) {
-						foreach ($rtype as $cb_rules) {
-							$new_rules[] = $cb_rules;
-						}
-					}
-				}
-				if (!empty($permit_rules)) {
-					foreach ($permit_rules as $cb_rules) {
-						if ($cb_rules['interface'] == $inbound_interface) {
-							$new_rules[] = $cb_rules;
-						}
-					}
-				}
-			}
-			if (!empty($pfb_generated['deny_inbound'])) {
-				foreach ($pfb_generated['deny_inbound'] as $cb_rules) {
-					$cb_rules['interface'] = $inbound_interface;
-					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'deny_in');
-					$new_rules[]           = $cb_rules;
-				}
-			}
+		}
+		foreach ($pfb_generated['deny_inbound'] as $cb_rules) {
+			$cb_rules['interface'] = $inbound_interface;
+			$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'deny_in');
+			$pfb_block[]           = $cb_rules;
 		}
 	}
 
 	// Outbound interface rules.
-	if (!empty($out_ifaces)) {
-		$pfbrunonce = TRUE;
-		foreach ($out_ifaces as $outbound_interface) {
-			if ($order == 'order_1' && !empty($permit_rules)) {
-				foreach ($permit_rules as $cb_rules) {
-					if ($cb_rules['interface'] == $outbound_interface) {
-						$new_rules[] = $cb_rules;
-					}
-				}
+	$pfbrunonce = TRUE;
+	foreach ($out_ifaces as $outbound_interface) {
+		foreach ($pfb_generated['permit_outbound'] as $cb_rules) {
+			$cb_rules['interface'] = $outbound_interface;
+			$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'permit_out');
+			$pfb_block[]           = $cb_rules;
+		}
+		// Match outbound rules are floating-only (emit once across all outbound interfaces).
+		if ($pfbrunonce && !empty($pfb_generated['match_outbound'])) {
+			foreach ($pfb_generated['match_outbound'] as $cb_rules) {
+				$cb_rules['interface'] = $pfb_generated['outbound_floating'];
+				$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'match_out');
+				$pfb_block[]           = $cb_rules;
+				$pfbrunonce            = FALSE;
 			}
-			if (!empty($pfb_generated['permit_outbound'])) {
-				foreach ($pfb_generated['permit_outbound'] as $cb_rules) {
-					$cb_rules['interface'] = $outbound_interface;
-					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'permit_out');
-					$new_rules[]           = $cb_rules;
-				}
-			}
-			// Match outbound rules are floating-only (emit once).
-			if ($pfbrunonce && !empty($pfb_generated['match_outbound'])) {
-				foreach ($pfb_generated['match_outbound'] as $cb_rules) {
-					$cb_rules['interface'] = $pfb_generated['outbound_floating'];
-					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'match_out');
-					$new_rules[]           = $cb_rules;
-					$pfbrunonce            = FALSE;
-				}
-			}
-			if ($order == 'order_2' && !empty($permit_rules)) {
-				foreach ($permit_rules as $cb_rules) {
-					if ($cb_rules['interface'] == $outbound_interface) {
-						$new_rules[] = $cb_rules;
-					}
-				}
-			}
-			if (!empty($pfb_generated['deny_outbound'])) {
-				foreach ($pfb_generated['deny_outbound'] as $cb_rules) {
-					$cb_rules['interface'] = $outbound_interface;
-					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'deny_out');
-					$new_rules[]           = $cb_rules;
-				}
-			}
+		}
+		foreach ($pfb_generated['deny_outbound'] as $cb_rules) {
+			$cb_rules['interface'] = $outbound_interface;
+			$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'deny_out');
+			$pfb_block[]           = $cb_rules;
 		}
 	}
 
-	// Tail: float rule groups and trailing user buckets.
-	if ($float == 'on' && in_array($order, array('order_0', 'order_3', 'order_4'))) {
-		if ($order != 'order_3') {
-			$rule_order = array($fother_rules, $fpermit_rules, $fmatch_rules);
-		} else {
-			$rule_order = array($fpermit_rules, $fmatch_rules, $fother_rules);
-		}
-		foreach ($rule_order as $rtype) {
-			if (!empty($rtype)) {
-				foreach ($rtype as $cb_rules) {
-					$new_rules[] = $cb_rules;
-				}
-			}
-		}
+	// Step 3: splice at anchor.
+	// order_1/order_2 → AFTER the kept user rules (user pass wins under per-iface first-match).
+	// Everything else (order_0/3/4, absent, unknown) → BEFORE (pfB wins). Subsumes #539.
+	if ($order === 'order_1' || $order === 'order_2') {
+		return array_values(array_merge($keep, $pfb_block));
 	}
-	if ($float == 'on' && in_array($order, array('order_1', 'order_2')) && !empty($fother_rules)) {
-		foreach ($fother_rules as $cb_rules) {
-			$new_rules[] = $cb_rules;
-		}
-	}
-	if ($float == '' && $order != 'order_1' && !empty($fother_rules)) {
-		foreach ($fother_rules as $cb_rules) {
-			$new_rules[] = $cb_rules;
-		}
-	}
-	if ($order == 'order_4' && !empty($other_rules)) {
-		foreach ($other_rules as $cb_rules) {
-			$new_rules[] = $cb_rules;
-		}
-	}
-	if ($order == 'order_4' && !empty($permit_rules)) {
-		foreach ($permit_rules as $cb_rules) {
-			$new_rules[] = $cb_rules;
-		}
-	}
-	if ($order == 'order_3' && !empty($permit_rules)) {
-		foreach ($permit_rules as $cb_rules) {
-			$new_rules[] = $cb_rules;
-		}
-	}
-	if ($order != 'order_4' && !empty($other_rules)) {
-		foreach ($other_rules as $cb_rules) {
-			$new_rules[] = $cb_rules;
-		}
-	}
-
-	return $new_rules;
+	return array_values(array_merge($pfb_block, $keep));
 }
 
 // Main pfBlockerNG function

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15445,6 +15445,14 @@ function sync_package_pfblockerng($cron='') {
 			#  ORDER 3 |	pfB (p/m)	| pfB (b/r) 	| pfSense (p/m)	| pfSense (b/r)	#
 			#  ORDER 4 |	pfB (p/m)	| pfB (b/r)	| pfSense (b/r)	| pfSense (p/m)	#
 			#################################################################################
+			# NOTE (ADR-41): the 4-column interleaving above is the ORIGINAL strip-and-rebuild
+			# intent. pfb_build_autorule_list() now keeps user rules IMMUTABLE and reduces this to a
+			# BINARY anchor for the contiguous pfB block:
+			#   order_1 / order_2        -> pfB block AFTER  the kept user rules (user pass wins)
+			#   order_0 / 3 / 4 / absent -> pfB block BEFORE the kept user rules (pfB wins)
+			# The pfB-p/m-vs-pfSense-p/m distinction is moot under per-interface first-match pf
+			# (interface rules are always `quick`; proven live in ADR-41 Phase 2 -> RESULTS/02), so
+			# it is no longer reproduced. order_4 no longer reorders the user's own rules.
 
 			$new_rules = pfb_build_autorule_list(
 				$rules ?? [],

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11517,6 +11517,278 @@ function pfb_syslog_logging_needs_update($current, $want) {
 	return !empty($current['logsocket']);
 }
 
+/**
+ * pfb_build_autorule_list() — pure emission helper extracted from sync_package_pfblockerng().
+ *
+ * Takes the current filter/rule list and the pre-built pfB rule templates, buckets the
+ * surviving user rules (same logic as the "Assign Rules" region of sync_package_pfblockerng()),
+ * and re-emits them interleaved with the generated pfB rules according to the ORDER table.
+ * Returns the new filter/rule array. No I/O, no config writes, no pfctl — pure array logic.
+ *
+ * @param array  $existing_rules  The current filter/rule array from config.xml.
+ * @param array  $pfb_generated   Pre-built pfB rule templates and DNSBL float rules:
+ *                                  'permit_inbound'   => array of pfB pass template rules (inbound)
+ *                                  'permit_outbound'  => array of pfB pass template rules (outbound)
+ *                                  'deny_inbound'     => array of pfB block/reject template rules (inbound)
+ *                                  'deny_outbound'    => array of pfB block/reject template rules (outbound)
+ *                                  'match_inbound'    => array of pfB match template rules (inbound)
+ *                                  'match_outbound'   => array of pfB match template rules (outbound)
+ *                                  'inbound_floating' => interface string for match_inbound floating
+ *                                  'outbound_floating'=> interface string for match_outbound floating
+ *                                  'dnsbl_float'      => array of 0-2 pre-built DNSBL ping/permit rules
+ * @param ?string $order          The pass_order value ('order_0' .. 'order_4', or ''); null (the
+ *                                unconfigured $pfb['order']) is coerced to '' (matches no order).
+ * @param ?string $float          Float mode: 'on' or '' (off); null (the unconfigured
+ *                                $pfb['float']) is coerced to '' (off).
+ * @param array  $in_ifaces       Inbound interface names.
+ * @param array  $out_ifaces      Outbound interface names.
+ * @return array The new filter/rule array to write back to config.xml.
+ */
+function pfb_build_autorule_list(
+	array   $existing_rules,
+	array   $pfb_generated,
+	?string $order,
+	?string $float,
+	array   $in_ifaces,
+	array   $out_ifaces
+): array {
+	// $order/$float come straight from $pfb['order']/$pfb['float'], which are unset (null)
+	// until configured. The original inline code used those raw values in loose comparisons
+	// ('== on' / '== order_N'), where null simply matches nothing -- so a null is behaviour-
+	// equivalent to ''. Coerce here (the params are nullable) rather than let a strict string
+	// typehint TypeError on the null the call site legitimately passes (e.g. enable_float unset).
+	$order = $order ?? '';
+	$float = $float ?? '';
+	$new_rules     = [];
+	$permit_rules  = [];
+	$match_rules   = [];
+	$other_rules   = [];
+	$fpermit_rules = [];
+	$fmatch_rules  = [];
+	$fother_rules  = [];
+
+	// Bucket surviving user rules (same logic as sync_package_pfblockerng() "Assign Rules").
+	foreach ($existing_rules as $rule) {
+		$descr              = $rule['descr'] ?? '';
+		$is_dns_bypass_rule =
+		    str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
+		    str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
+
+		if (!str_starts_with($rule['descr'], 'pfB_') || $is_dns_bypass_rule) {
+			// Upgrade previous IPv4 pfBlockerNG alias names to '_v4' suffix format.
+			foreach (array('source', 'destination') as $rtype) {
+				if (pfb_rule_alias_needs_v4_suffix($rule[$rtype]['address'] ?? '', $rule['ipprotocol'] ?? '')) {
+					$rule[$rtype]['address'] = "{$rule[$rtype]['address']}_v4";
+				}
+			}
+
+			if ($float == 'on') {
+				if ($order == 'order_0' && $rule['floating'] == 'yes') {
+					$fother_rules[] = $rule;
+				}
+				else {
+					if ($rule['type'] == 'pass' && $rule['floating'] == 'yes') {
+						$fpermit_rules[] = $rule;
+					} elseif ($rule['type'] == 'match' && $rule['floating'] == 'yes') {
+						$fmatch_rules[] = $rule;
+					} elseif ($rule['floating'] == 'yes') {
+						$fother_rules[] = $rule;
+					} else {
+						$other_rules[] = $rule;
+					}
+				}
+			} else {
+				if (in_array($rule['interface'], $in_ifaces) ||
+				    in_array($rule['interface'], $out_ifaces)) {
+					if ($rule['floating'] == 'yes') {
+						$fother_rules[] = $rule;
+					} elseif ($rule['type'] == 'pass' || isset($rule['associated-rule-id'])) {
+						if ($order == 'order_0') {
+							$other_rules[] = $rule;
+						} else {
+							$permit_rules[] = $rule;
+						}
+					} else {
+						$other_rules[] = $rule;
+					}
+				} else {
+					if ($rule['floating'] == 'yes') {
+						$fother_rules[] = $rule;
+					} else {
+						$other_rules[] = $rule;
+					}
+				}
+			}
+		}
+	}
+
+	// Pre-interface-loop emission (ORDER 1 non-float: user-permit first; ORDER 1 float: fpermit/fmatch first).
+	if ($float == '' && $order == 'order_1' && !empty($fother_rules)) {
+		foreach ($fother_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($float == 'on' && $order == 'order_1') {
+		foreach (array($fpermit_rules, $fmatch_rules) as $rtype) {
+			if (!empty($rtype)) {
+				foreach ($rtype as $cb_rules) {
+					$new_rules[] = $cb_rules;
+				}
+			}
+		}
+	}
+
+	// Emit pre-built DNSBL floating pass rules (ping + permit pair, or empty).
+	foreach ($pfb_generated['dnsbl_float'] as $cb_rules) {
+		$new_rules[] = $cb_rules;
+	}
+
+	// Inbound interface rules.
+	if (!empty($in_ifaces)) {
+		$pfbrunonce = TRUE;
+		foreach ($in_ifaces as $inbound_interface) {
+			if ($order == 'order_1' && !empty($permit_rules)) {
+				foreach ($permit_rules as $cb_rules) {
+					if ($cb_rules['interface'] == $inbound_interface) {
+						$new_rules[] = $cb_rules;
+					}
+				}
+			}
+			if (!empty($pfb_generated['permit_inbound'])) {
+				foreach ($pfb_generated['permit_inbound'] as $cb_rules) {
+					$cb_rules['interface'] = $inbound_interface;
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'permit_in');
+					$new_rules[]           = $cb_rules;
+				}
+			}
+			// Match inbound rules are floating-only (emit once).
+			if ($pfbrunonce && !empty($pfb_generated['match_inbound'])) {
+				foreach ($pfb_generated['match_inbound'] as $cb_rules) {
+					$cb_rules['interface'] = $pfb_generated['inbound_floating'];
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'match_in');
+					$new_rules[]           = $cb_rules;
+					$pfbrunonce            = FALSE;
+				}
+			}
+			if ($order == 'order_2') {
+				foreach (array($fpermit_rules, $fmatch_rules) as $rtype) {
+					if (!empty($rtype)) {
+						foreach ($rtype as $cb_rules) {
+							$new_rules[] = $cb_rules;
+						}
+					}
+				}
+				if (!empty($permit_rules)) {
+					foreach ($permit_rules as $cb_rules) {
+						if ($cb_rules['interface'] == $inbound_interface) {
+							$new_rules[] = $cb_rules;
+						}
+					}
+				}
+			}
+			if (!empty($pfb_generated['deny_inbound'])) {
+				foreach ($pfb_generated['deny_inbound'] as $cb_rules) {
+					$cb_rules['interface'] = $inbound_interface;
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'deny_in');
+					$new_rules[]           = $cb_rules;
+				}
+			}
+		}
+	}
+
+	// Outbound interface rules.
+	if (!empty($out_ifaces)) {
+		$pfbrunonce = TRUE;
+		foreach ($out_ifaces as $outbound_interface) {
+			if ($order == 'order_1' && !empty($permit_rules)) {
+				foreach ($permit_rules as $cb_rules) {
+					if ($cb_rules['interface'] == $outbound_interface) {
+						$new_rules[] = $cb_rules;
+					}
+				}
+			}
+			if (!empty($pfb_generated['permit_outbound'])) {
+				foreach ($pfb_generated['permit_outbound'] as $cb_rules) {
+					$cb_rules['interface'] = $outbound_interface;
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'permit_out');
+					$new_rules[]           = $cb_rules;
+				}
+			}
+			// Match outbound rules are floating-only (emit once).
+			if ($pfbrunonce && !empty($pfb_generated['match_outbound'])) {
+				foreach ($pfb_generated['match_outbound'] as $cb_rules) {
+					$cb_rules['interface'] = $pfb_generated['outbound_floating'];
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'match_out');
+					$new_rules[]           = $cb_rules;
+					$pfbrunonce            = FALSE;
+				}
+			}
+			if ($order == 'order_2' && !empty($permit_rules)) {
+				foreach ($permit_rules as $cb_rules) {
+					if ($cb_rules['interface'] == $outbound_interface) {
+						$new_rules[] = $cb_rules;
+					}
+				}
+			}
+			if (!empty($pfb_generated['deny_outbound'])) {
+				foreach ($pfb_generated['deny_outbound'] as $cb_rules) {
+					$cb_rules['interface'] = $outbound_interface;
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'deny_out');
+					$new_rules[]           = $cb_rules;
+				}
+			}
+		}
+	}
+
+	// Tail: float rule groups and trailing user buckets.
+	if ($float == 'on' && in_array($order, array('order_0', 'order_3', 'order_4'))) {
+		if ($order != 'order_3') {
+			$rule_order = array($fother_rules, $fpermit_rules, $fmatch_rules);
+		} else {
+			$rule_order = array($fpermit_rules, $fmatch_rules, $fother_rules);
+		}
+		foreach ($rule_order as $rtype) {
+			if (!empty($rtype)) {
+				foreach ($rtype as $cb_rules) {
+					$new_rules[] = $cb_rules;
+				}
+			}
+		}
+	}
+	if ($float == 'on' && in_array($order, array('order_1', 'order_2')) && !empty($fother_rules)) {
+		foreach ($fother_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($float == '' && $order != 'order_1' && !empty($fother_rules)) {
+		foreach ($fother_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($order == 'order_4' && !empty($other_rules)) {
+		foreach ($other_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($order == 'order_4' && !empty($permit_rules)) {
+		foreach ($permit_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($order == 'order_3' && !empty($permit_rules)) {
+		foreach ($permit_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($order != 'order_4' && !empty($other_rules)) {
+		foreach ($other_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+
+	return $new_rules;
+}
+
 // Main pfBlockerNG function
 function sync_package_pfblockerng($cron='') {
 	global $g, $pfb, $pfbarr;
@@ -15221,7 +15493,7 @@ function sync_package_pfblockerng($cron='') {
 		}
 
 		if (empty($message)) {
-			$new_rules = $permit_rules = $match_rules = $other_rules = $fpermit_rules = $fmatch_rules = $fother_rules = array();
+			$new_rules = array();
 
 			// Reload config.xml to get any recent changes
 			config_read_file(FALSE, TRUE);
@@ -15232,83 +15504,17 @@ function sync_package_pfblockerng($cron='') {
 			// Collect all existing rules
 			$rules = config_get_path('filter/rule', []);
 
-			// Collect existing pfSense rules 'pass', 'match' and 'other' pfSense rules into new arrays.
+			// Track pfB aliases referenced by any rule; also build orig_rules_nocreated
+			// for the write-gate comparison (done here, before calling the helper, so
+			// the helper stays side-effect-free).
 			if (!empty($rules)) {
 				foreach ($rules as $rule) {
-
-					// The DNS-redirect NAT companion rules and DoT/DoQ block filter rules
-					// carry a 'pfB_' descr but are managed by the inline redirect/DoT sync
-					// above, NOT this legacy auto-rule rebuild. Preserve them like user rules
-					// so the rebuild below does not strip them.
-					$descr = $rule['descr'] ?? '';
-					$is_dns_bypass_rule =
-					    str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
-					    str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
-
-					// Remove all existing rules that start with 'pfB_' in the Rule Description
-					// (the legacy auto-rules this region rebuilds) — but keep user rules and
-					// the DNS-bypass rules above.
-					if (!str_starts_with($rule['descr'], 'pfB_') || $is_dns_bypass_rule) {
-
-						// Upgrade previous IPv4 pfBlockerNG 'alias type' aliasnames to new '_v4' suffix format
-						foreach (array('source', 'destination') as $rtype) {
-							if (pfb_rule_alias_needs_v4_suffix($rule[$rtype]['address'] ?? '', $rule['ipprotocol'] ?? '')) {
-								// Add '_v4' suffix
-								$rule[$rtype]['address'] = "{$rule[$rtype]['address']}_v4";
-							}
-						}
-
-						// Floating rules collection 'Floating Pass/Match', balance to 'other'
-						if ($pfb['float'] == 'on') {
-							if ($pfb['order'] == 'order_0' && $rule['floating'] == 'yes') {
-								$fother_rules[] = $rule;
-							}
-							else {
-								if ($rule['type'] == 'pass' && $rule['floating'] == 'yes') {
-									$fpermit_rules[] = $rule;
-								} elseif ($rule['type'] == 'match' && $rule['floating'] == 'yes') {
-									$fmatch_rules[] = $rule;
-								} elseif ($rule['floating'] == 'yes') {
-									$fother_rules[] = $rule;
-								} else {
-									$other_rules[] = $rule;
-								}
-							}
-						} else {
-							// Collect only 'selected inbound and outbound interfaces'. balance to 'other'
-							if (in_array($rule['interface'], $pfb['inbound_interfaces']) ||
-							    in_array($rule['interface'], $pfb['outbound_interfaces'])) {
-								// Floating rules 'off'. Collect 'floating other', pass, balance to 'other'
-								if ($rule['floating'] == 'yes') {
-									$fother_rules[] = $rule;
-								} elseif ($rule['type'] == 'pass' || isset($rule['associated-rule-id'])) {
-									if ($pfb['order'] == 'order_0') {
-										$other_rules[] = $rule;
-									} else {
-										$permit_rules[] = $rule;
-									}
-								} else {
-									$other_rules[] = $rule;
-								}
-							} else {
-								if ($rule['floating'] == 'yes') {
-									$fother_rules[] = $rule;
-								} else {
-									$other_rules[] = $rule;
-								}
-							}
-						}
-					}
-
-					// Track pfB aliases referenced by rules.
 					foreach (array('source', 'destination') as $rtype) {
-						if ((str_starts_with($rule[$rtype]['address'], 'pfB_')) &&
+						if ((str_starts_with($rule[$rtype]['address'] ?? '', 'pfB_')) &&
 						    !in_array($rule[$rtype]['address'], $pfb_active_aliases)) {
 							$pfb_active_aliases[] = $rule[$rtype]['address'];
 						}
 					}
-
-					// Remove 'created' tag
 					if (isset($rule['created'])) {
 						unset($rule['created']);
 					}
@@ -15316,32 +15522,8 @@ function sync_package_pfblockerng($cron='') {
 				}
 			}
 
-			#################################################################################
-			#			IP FIREWALL RULES ORDER					#
-			#  ORDER 0 |	pfB (p/m/b/r)	| All other	|				#
-			#  ORDER 1 |	pfSense (p/m)	| pfB (p/m)	| pfB (b/r) 	| pfSense (b/r)	#
-			#  ORDER 2 |	pfB (p/m)	| pfSense (p/m) | pfB (b/r)	| pfSense (b/r)	#
-			#  ORDER 3 |	pfB (p/m)	| pfB (b/r) 	| pfSense (p/m)	| pfSense (b/r)	#
-			#  ORDER 4 |	pfB (p/m)	| pfB (b/r)	| pfSense (b/r)	| pfSense (p/m)	#
-			#################################################################################
-
-
-			if ($pfb['float'] == '' && $pfb['order'] == 'order_1' && !empty($fother_rules)) {
-				foreach ($fother_rules as $cb_rules) {
-					$new_rules[] = $cb_rules;
-				}
-			}
-			if ($pfb['float'] == 'on' && $pfb['order'] == 'order_1') {
-				foreach (array($fpermit_rules, $fmatch_rules) as $rtype) {
-					if (!empty($rtype)) {
-						foreach ($rtype as $cb_rules) {
-							$new_rules[] = $cb_rules;
-						}
-					}
-				}
-			}
-
-			// Define DNSBL 'Floating' pass rule for selected 'OPT' segments to be able to access the LAN DNSBL VIP
+			// Build the DNSBL floating pass rules (ping + permit pair) to pass into the helper.
+			$pfb_dnsbl_float = [];
 			if ($pfb['enable'] == 'on' && $pfb['dnsbl'] == 'on' && $pfb['dnsbl_rule'] != 'Disabled'
 			    && !empty($pfb['dnsbl_port']) && !empty($pfb['dnsbl_port_ssl'])
 			    && !empty($pfb['dnsblconfig']['dnsbl_allow_int'])) {
@@ -15358,7 +15540,7 @@ function sync_package_pfblockerng($cron='') {
 				$rule['source']		= array('any' => '');
 				$rule['destination']	= array('address' => (!empty($pfb['dnsbl_vip6']) ? 'pfB_DNSBL_VIPs' : $pfb['dnsbl_vip4']));
 				$rule['created']	= array('time' => (int)microtime(TRUE), 'username' => 'Auto');
-				$new_rules[]		= $rule;
+				$pfb_dnsbl_float[]	= $rule;
 
 				$rule			= $pfb['base_rule_float'];
 				$rule['tracker']	= pfb_tracker('pfB_DNSBL_Permit', '', '');
@@ -15372,154 +15554,42 @@ function sync_package_pfblockerng($cron='') {
 				$rule['destination']	= array('address' => (!empty($pfb['dnsbl_vip6']) ? 'pfB_DNSBL_VIPs' : $pfb['dnsbl_vip4']),
 								 'port' => 'pfB_DNSBL_Ports');
 				$rule['created']	= array('time' => (int)microtime(TRUE), 'username' => 'Auto');
-				$new_rules[]		= $rule;
+				$pfb_dnsbl_float[]	= $rule;
 			}
 
-			// Define inbound interface rules
-			if (!empty($pfb['inbound_interfaces'])) {
-				$pfbrunonce = TRUE;
-				foreach ($pfb['inbound_interfaces'] as $inbound_interface) {
-					if ($pfb['order'] == 'order_1' && !empty($permit_rules)) {
-						foreach ($permit_rules as $cb_rules) {
-							if ($cb_rules['interface'] == $inbound_interface) {
-								$new_rules[] = $cb_rules;
-							}
-						}
-					}
-					if (!empty($pfb['permit_inbound'])) {
-						foreach ($pfb['permit_inbound'] as $cb_rules) {
-							$cb_rules['interface'] = $inbound_interface;
-							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $inbound_interface, 'permit_in');
-							$new_rules[] = $cb_rules;
-						}
-					}
-					// Match inbound rules defined as floating only.
-					if ($pfbrunonce && !empty($pfb['match_inbound'])) {
-						foreach ($pfb['match_inbound'] as $cb_rules) {
-							$cb_rules['interface'] = $pfb['inbound_floating'];
-							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $inbound_interface, 'match_in');
-							$new_rules[] = $cb_rules;
-							$pfbrunonce = FALSE;
-						}
-					}
-					if ($pfb['order'] == 'order_2') {
-						foreach (array($fpermit_rules, $fmatch_rules) as $rtype) {
-							if (!empty($rtype)) {
-								foreach ($rtype as $cb_rules) {
-									$new_rules[] = $cb_rules;
-								}
-							}
-						}
-						if (!empty($permit_rules)) {
-							foreach ($permit_rules as $cb_rules) {
-								if ($cb_rules['interface'] == $inbound_interface) {
-									$new_rules[] = $cb_rules;
-								}
-							}
-						}
-					}
-					if (!empty($pfb['deny_inbound'])) {
-						foreach ($pfb['deny_inbound'] as $cb_rules) {
-							$cb_rules['interface'] = $inbound_interface;
-							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $inbound_interface, 'deny_in');
-							$new_rules[] = $cb_rules;
-						}
-					}
-				}
-			}
+			// Build the pfB-generated rule templates (produced by pfb_firewall_rule() above).
+			$pfb_generated = [
+				'permit_inbound'    => $pfb['permit_inbound']    ?? [],
+				'permit_outbound'   => $pfb['permit_outbound']   ?? [],
+				'deny_inbound'      => $pfb['deny_inbound']      ?? [],
+				'deny_outbound'     => $pfb['deny_outbound']     ?? [],
+				'match_inbound'     => $pfb['match_inbound']     ?? [],
+				'match_outbound'    => $pfb['match_outbound']    ?? [],
+				'inbound_floating'  => $pfb['inbound_floating']  ?? '',
+				'outbound_floating' => $pfb['outbound_floating'] ?? '',
+				'dnsbl_float'       => $pfb_dnsbl_float,
+			];
 
-			// Define outbound interface rules
-			if (!empty($pfb['outbound_interfaces'])) {
-				$pfbrunonce = TRUE;
-				foreach ($pfb['outbound_interfaces'] as $outbound_interface) {
-					if ($pfb['order'] == 'order_1' && !empty($permit_rules)) {
-						foreach ($permit_rules as $cb_rules) {
-							if ($cb_rules['interface'] == $outbound_interface) {
-								$new_rules[] = $cb_rules;
-							}
-						}
-					}
-					if (!empty($pfb['permit_outbound'])) {
-						foreach ($pfb['permit_outbound'] as $cb_rules) {
-							$cb_rules['interface'] = $outbound_interface;
-							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $outbound_interface, 'permit_out');
-							$new_rules[] = $cb_rules;
-						}
-					}
-					// Match outbound rules defined as floating only.
-					if ($pfbrunonce && !empty($pfb['match_outbound'])) {
-						foreach ($pfb['match_outbound'] as $cb_rules) {
-							$cb_rules['interface'] = $pfb['outbound_floating'];
-							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $outbound_interface, 'match_out');
-							$new_rules[] = $cb_rules;
-							$pfbrunonce = FALSE;
-						}
-					}
-					if ($pfb['order'] == 'order_2' && !empty($permit_rules)) {
-						foreach ($permit_rules as $cb_rules) {
-							if ($cb_rules['interface'] == $outbound_interface) {
-								$new_rules[] = $cb_rules;
-							}
-						}
-					}
-					if (!empty($pfb['deny_outbound'])) {
-						foreach ($pfb['deny_outbound'] as $cb_rules) {
-							$cb_rules['interface'] = $outbound_interface;
-							$cb_rules['tracker'] = pfb_tracker($cb_rules['descr'], $outbound_interface, 'deny_out');
-							$new_rules[] = $cb_rules;
-						}
-					}
-				}
-			}
+			#################################################################################
+			#			IP FIREWALL RULES ORDER					#
+			#  ORDER 0 |	pfB (p/m/b/r)	| All other	|				#
+			#  ORDER 1 |	pfSense (p/m)	| pfB (p/m)	| pfB (b/r) 	| pfSense (b/r)	#
+			#  ORDER 2 |	pfB (p/m)	| pfSense (p/m) | pfB (b/r)	| pfSense (b/r)	#
+			#  ORDER 3 |	pfB (p/m)	| pfB (b/r) 	| pfSense (p/m)	| pfSense (b/r)	#
+			#  ORDER 4 |	pfB (p/m)	| pfB (b/r)	| pfSense (b/r)	| pfSense (p/m)	#
+			#################################################################################
 
-			if ($pfb['float'] == 'on' && in_array($pfb['order'], array('order_0', 'order_3', 'order_4'))) {
-				if ($pfb['order'] != 'order_3') {
-					$rule_order = array($fother_rules, $fpermit_rules, $fmatch_rules);
-				} else {
-					$rule_order = array($fpermit_rules, $fmatch_rules, $fother_rules);
-				}
-				foreach ($rule_order as $rtype) {
-					if (!empty($rtype)) {
-						foreach ($rtype as $cb_rules) {
-							$new_rules[] = $cb_rules;
-						}
-					}
-				}
-			}
-			if ($pfb['float'] == 'on' && in_array($pfb['order'], array('order_1', 'order_2')) && !empty($fother_rules)) {
-				foreach ($fother_rules as $cb_rules) {
-					$new_rules[] = $cb_rules;
-				}
-			}
-			if ($pfb['float'] == '' && $pfb['order'] != 'order_1' && !empty($fother_rules)) {
-				foreach ($fother_rules as $cb_rules) {
-					$new_rules[] = $cb_rules;
-				}
-			}
-			if ($pfb['order'] == 'order_4' && !empty($other_rules)) {
-				foreach ($other_rules as $cb_rules) {
-					$new_rules[] = $cb_rules;
-				}
-			}
-			if ($pfb['order'] == 'order_4' && !empty($permit_rules)) {
-				foreach ($permit_rules as $cb_rules) {
-					$new_rules[] = $cb_rules;
-				}
-			}
-			if ($pfb['order'] == 'order_3' && !empty($permit_rules)) {
-				foreach ($permit_rules as $cb_rules) {
-					$new_rules[] = $cb_rules;
-				}
-			}
-			if ($pfb['order'] != 'order_4' && !empty($other_rules)) {
-				foreach ($other_rules as $cb_rules) {
-					$new_rules[] = $cb_rules;
-				}
-			}
+			$new_rules = pfb_build_autorule_list(
+				$rules ?? [],
+				$pfb_generated,
+				$pfb['order'],
+				$pfb['float'],
+				$pfb['inbound_interfaces']  ?? [],
+				$pfb['outbound_interfaces'] ?? []
+			);
 
 			unset($pfb['permit_inbound'], $pfb['permit_outbound'], $pfb['deny_inbound'],
 			    $pfb['deny_outbound'], $pfb['match_inbound'], $pfb['match_outbound']);
-			unset($cb_rules, $other_rules, $fother_rules, $permit_rules, $fpermit_rules, $match_rules, $fmatch_rules);
 
 			// Remove 'created' tag (New vs old rules array comparison)
 			foreach ($new_rules as $rule) {

--- a/tests/php/AutoruleListOracleTest.php
+++ b/tests/php/AutoruleListOracleTest.php
@@ -6,38 +6,43 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Oracle tests for pfb_build_autorule_list() — ADR-41 Phase 1.
+ * Contract tests for pfb_build_autorule_list() — ADR-41 Phase 3.
  *
- * These are CHARACTERISATION (oracle) tests: they pin EXACTLY what the helper
- * returns today, INCLUDING the known-bad cases (order_1/order_2 duplication,
- * order_4 reorder). They stay GREEN across Phase 1 (extraction is
- * behaviour-preserving) and flip to the CORRECTED expected output in Phase 3.
+ * Three invariants hold for every fixture (ADR-41 §2 Decision table):
+ *   (a) USER-RULE FIDELITY: every non-pfB rule in $existing_rules appears in the output
+ *       in the SAME relative order and with the SAME count (no drop, no dup, no reorder).
+ *   (b) PFB-SET IDENTICAL: the pfB rules emitted are the same set (descr/type/interface/
+ *       floating) as would have been generated from the same $pfb_generated inputs.
+ *   (c) IDEMPOTENCE: running the helper on its own output is a no-op (second pass
+ *       produces the same result as the first).
+ *
+ * Anchor mapping (per-interface first-match — live-confirmed, ADR-41 Phase 2):
+ *   order_1 / order_2           → pfB block AFTER  kept user rules (user pass wins)
+ *   order_0 / order_3 / order_4 → pfB block BEFORE kept user rules (pfB wins)
+ *   absent / unknown            → BEFORE (subsumes #539 drop bug)
  *
  * Fixture matrix covered (each pass_order × float on/off unless noted):
  *   A. order_0,  float=off, inbound==outbound ('lan'), Deny_* only
  *   B. order_0,  float=on,  inbound==outbound ('lan'), Deny_* only
- *   C. order_1,  float=off, inbound==outbound ('lan'), Deny_* only  [KNOWN-BAD: dup]
+ *   C. order_1,  float=off, inbound==outbound ('lan'), Deny_* only
  *   D. order_1,  float=off, inbound!=outbound ('lan'+'opt1'), Deny_* only
  *   E. order_1,  float=on,  inbound==outbound ('lan'), Deny_* only
- *   F. order_2,  float=off, inbound==outbound ('lan'), Deny_* only  [KNOWN-BAD: dup]
+ *   F. order_2,  float=off, inbound==outbound ('lan'), Deny_* only
  *   G. order_2,  float=off, inbound!=outbound ('lan'+'opt1'), Deny_* only
  *   H. order_2,  float=on,  inbound==outbound ('lan'), Deny_* only
  *   I. order_3,  float=off, inbound==outbound ('lan'), Deny_* only
  *   J. order_3,  float=on,  inbound==outbound ('lan'), Deny_* only
- *   K. order_4,  float=off, inbound==outbound ('lan'), Deny_* only  [KNOWN-BAD: reorder]
- *   L. order_4,  float=on,  inbound==outbound ('lan'), Deny_* only
- *   M. absent/empty pass_order, float=off, treated as order_0 by the helper
- *   N. Permit_* (permit_inbound + permit_outbound) present, order_1, float=off
- *   O. DNS-redirect bypass rule present (pfB_ descr but NOT stripped), order_0, float=off
- *   P. DoT-block bypass rule present, order_0, float=off
- *
- * Each test asserts the FULL ordered descr|type|interface|floating list — not just
- * a count — so any reordering shows up as a test failure.
- *
- * KNOWN-BAD cases (pinned as "what it does today" — Phase 3 flips them):
- *   C (order_1, inbound==outbound, float=off): user LAN pass rule duplicated
- *   F (order_2, inbound==outbound, float=off): user LAN pass rule duplicated
- *   K (order_4, float=off):                   user rules reordered (opt1 before lan)
+ *   K. order_4,  float=off, inbound==outbound ('lan'), Deny_* only
+ *   L. order_4,  float=off, two ifaces (opt1 in, lan out)
+ *   M. order_4,  float=on,  inbound==outbound ('lan'), Deny_* only
+ *   N. absent/empty pass_order, float=off — treated as BEFORE (same as order_0)
+ *   O. Permit_* (permit_inbound + permit_outbound) present, order_1, float=off
+ *   P. DNS-redirect bypass rule present (pfB_ descr but NOT stripped), order_0, float=off
+ *   Q. DoT-block bypass rule present, order_0, float=off
+ *   R. pfB_ rules stripped and rebuilt (sanity)
+ *   S. DNSBL float rules emitted before iface loop
+ *   T. Empty existing rules → only pfB rules
+ *   U. Non-managed iface user rule preserved in output
  *
  * No live pfSense state involved — pfb_tracker() is called via the existing
  * doubles (get_real_interface/get_interface_ip/etc. all seeded to deterministic
@@ -327,6 +332,71 @@ final class AutoruleListOracleTest extends TestCase
 		}
 	}
 
+	/**
+	 * CONTRACT (a): every non-pfB rule from $input appears in $output in the same
+	 * relative order with the same count. A rule is pfB-owned iff its descr starts
+	 * with 'pfB_' AND it is NOT a bypass rule (DNS-redirect / DoT-block).
+	 *
+	 * Fails on: user-rule drop (count < input), duplication (count > input), or reorder.
+	 *
+	 * @param array<int, array<string, mixed>> $input
+	 * @param array<int, array<string, mixed>> $output
+	 */
+	private function assertUserRulesPreserved(array $input, array $output, string $context = ''): void
+	{
+		$is_user = static function (array $rule): bool {
+			$descr = $rule['descr'] ?? '';
+			if (!str_starts_with($descr, 'pfB_')) {
+				return TRUE;
+			}
+			return str_starts_with($descr, 'pfB_DNS_Redirect_') ||
+			       str_starts_with($descr, 'pfB_DoT_Block_');
+		};
+
+		$user_in  = array_values(array_filter($input,  $is_user));
+		$user_out = array_values(array_filter($output, $is_user));
+
+		$label = $context !== '' ? " [{$context}]" : '';
+		$this->assertSame(
+			$this->shapes($user_in),
+			$this->shapes($user_out),
+			"User-rule fidelity failure{$label}: non-pfB rules must be preserved exactly "
+				. "(same set, count, and original relative order — no drop, dup, or reorder)."
+				. "\n\nExpected (input user rules):\n"  . json_encode($this->shapes($user_in),  JSON_PRETTY_PRINT)
+				. "\n\nActual (output user rules):\n"   . json_encode($this->shapes($user_out), JSON_PRETTY_PRINT)
+		);
+	}
+
+	/**
+	 * CONTRACT (c): running the helper on its own output is a no-op.
+	 *
+	 * Second-pass $existing_rules = first-pass $output. Same $pfb_generated / $order / $float /
+	 * $in_ifaces / $out_ifaces. Result must be shape-identical to the first pass.
+	 *
+	 * @param array<int, array<string, mixed>> $output
+	 * @param array<int, string>               $in_ifaces
+	 * @param array<int, string>               $out_ifaces
+	 */
+	private function assertIdempotent(
+		array  $output,
+		array  $gen,
+		string $order,
+		string $float,
+		array  $in_ifaces,
+		array  $out_ifaces,
+		string $context = ''
+	): void {
+		$second = pfb_build_autorule_list($output, $gen, $order, $float, $in_ifaces, $out_ifaces);
+		$label  = $context !== '' ? " [{$context}]" : '';
+		$this->assertSame(
+			$this->shapes($output),
+			$this->shapes($second),
+			"Idempotence failure{$label}: running the helper on its own output must be a no-op."
+				. "\n\nFirst pass:\n"  . json_encode($this->shapes($output), JSON_PRETTY_PRINT)
+				. "\n\nSecond pass:\n" . json_encode($this->shapes($second), JSON_PRETTY_PRINT)
+		);
+	}
+
 	// -----------------------------------------------------------------------
 	// A. order_0, float=off, inbound==outbound='lan', Deny_* only
 	// -----------------------------------------------------------------------
@@ -340,11 +410,8 @@ final class AutoruleListOracleTest extends TestCase
 		 *        pfB generated = deny_inbound + deny_outbound templates.
 		 *        order=order_0, float=off, in+out ifaces = ['lan'].
 		 *
-		 * ORDER 0: pfB (p/m/b/r) | All other
-		 * Expected order: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
-		 *
-		 * user pass goes to $other_rules (order_0 -> order_0 pass -> other_rules).
-		 * Tail: order!=order_4 -> other_rules emitted last.
+		 * ORDER 0 anchor = BEFORE: pfB block first, then kept user rules.
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
 		 */
 
 		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
@@ -358,6 +425,8 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'order_0 float=off single iface');
 		$this->assertTrackersSet($result, 'order_0 float=off');
+		$this->assertUserRulesPreserved($existing, $result, 'order_0 float=off');
+		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'order_0 float=off');
 	}
 
 	// -----------------------------------------------------------------------
@@ -367,21 +436,21 @@ final class AutoruleListOracleTest extends TestCase
 	public function testOrder0FloatOnSingleIfaceDenyOnly(): void
 	{
 		/**
-		 * Scenario: ORDER 0, float=on. user floating pass goes to $fother_rules
-		 * (order_0 + floating='yes' -> fother_rules).
+		 * Scenario: ORDER 0, float=on.
 		 *
-		 * ORDER 0 float on:
-		 *   - No pre-loop float emit (order_1 only).
-		 *   - pfB deny_in(lan), pfB deny_out(lan).
-		 *   - Tail: float=on + order_0/3/4 -> fother/fpermit/fmatch (fother_rules only here).
-		 *   - order!=order_4 -> other_rules (none here).
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user float pass.
+		 * ORDER 0 anchor = BEFORE: pfB block first, then kept user rules verbatim.
+		 * keep = [user_float_pass, user_pass(lan)] (original order; pfB deny stripped).
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_float_pass, user_pass(lan).
+		 *
+		 * pf evaluates floating rules in a separate group regardless of config.xml
+		 * interleaving, so the relative position of user_float_pass vs interface rules
+		 * in config.xml does not affect pf precedence.
 		 */
 
 		$existing = [
 			$this->pfbDenyRule('lan'),
 			$this->userFloatPass(),
-			$this->userPassLan(),      // non-floating: goes to $other_rules (float=on branch)
+			$this->userPassLan(),
 		];
 		$gen = $this->pfbGeneratedDenyOnly();
 
@@ -394,26 +463,27 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'order_0 float=on');
 		$this->assertTrackersSet($result, 'order_0 float=on');
+		$this->assertUserRulesPreserved($existing, $result, 'order_0 float=on');
+		$this->assertIdempotent($result, $gen, 'order_0', 'on', ['lan'], ['lan'], 'order_0 float=on');
 	}
 
 	// -----------------------------------------------------------------------
 	// C. order_1, float=off, inbound==outbound='lan'  [KNOWN-BAD: duplication]
 	// -----------------------------------------------------------------------
 
-	public function testOrder1FloatOffSingleIfaceDenyOnlyKnownBadDuplicate(): void
+	public function testOrder1FloatOffSingleIfaceDenyOnly(): void
 	{
 		/**
-		 * Scenario: ORDER 1, float=off, SAME interface for inbound AND outbound.
+		 * Scenario: ORDER 1, float=off, SAME interface for inbound AND outbound ('lan').
 		 *
-		 * KNOWN-BAD: The user LAN pass rule goes into $permit_rules.
-		 * It is emitted once in the inbound loop (order_1 permit_rules for 'lan')
-		 * AND once in the outbound loop (order_1 permit_rules for 'lan').
-		 * Result: user rule appears TWICE. This is the duplication bug.
-		 * Phase 3 fixes this — Phase 1 pins it as "what it does today".
+		 * ORDER 1 anchor = AFTER: kept user rules first, then pfB block.
+		 * keep = [user_pass(lan)] (pfB deny stripped; no dup — verbatim keep).
+		 * pfB block = [deny_in(lan), deny_out(lan)].
+		 * Expected: user_pass(lan), pfB deny_in(lan), pfB deny_out(lan).
 		 *
-		 * ORDER 1: pfSense(p/m) | pfB(p/m) | pfB(b/r) | pfSense(b/r)
-		 * Expected: user_pass(lan) [inbound], pfB deny_in(lan),
-		 *           user_pass(lan) [outbound — DUPLICATE], pfB deny_out(lan)
+		 * Fail-before: old bucket-per-iface code emitted user_pass TWICE (once per loop
+		 * over the shared 'lan' interface). The immutable-splice model strips pfB rules
+		 * and keeps the verbatim user list exactly once — no dup possible.
 		 */
 
 		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
@@ -421,13 +491,14 @@ final class AutoruleListOracleTest extends TestCase
 
 		$result = pfb_build_autorule_list($existing, $gen, 'order_1', '', ['lan'], ['lan']);
 
-		// KNOWN-BAD: user rule appears twice (once per loop iteration).
 		$this->assertShapes([
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_1 float=off single iface [KNOWN-BAD: duplicate]');
+		], $result, 'order_1 float=off single iface');
+		$this->assertTrackersSet($result, 'order_1 float=off single');
+		$this->assertUserRulesPreserved($existing, $result, 'order_1 float=off single');
+		$this->assertIdempotent($result, $gen, 'order_1', '', ['lan'], ['lan'], 'order_1 float=off single');
 	}
 
 	// -----------------------------------------------------------------------
@@ -439,12 +510,14 @@ final class AutoruleListOracleTest extends TestCase
 		/**
 		 * Scenario: ORDER 1, float=off, separate inbound (lan) and outbound (opt1).
 		 *
-		 * User pass rules on both interfaces go to $permit_rules.
-		 * In the inbound loop: user pass LAN emitted for 'lan' iface.
-		 * In the outbound loop: user pass OPT1 emitted for 'opt1' iface.
-		 * No duplication because interfaces differ.
+		 * ORDER 1 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
+		 * keep = [user_pass(lan), user_pass(opt1)] (original order).
+		 * pfB block = [deny_in(lan), deny_out(opt1)].
+		 * Expected: user_pass(lan), user_pass(opt1), pfB deny_in(lan), pfB deny_out(opt1).
 		 *
-		 * Expected: user_pass(lan), pfB deny_in(lan), user_pass(opt1), pfB deny_out(opt1)
+		 * Under per-interface first-match pf semantics the pfB-block-vs-user-BLOCK ordering
+		 * is moot; only pfB-block-vs-user-PASS matters, and both user pass rules precede
+		 * both pfB deny rules — user wins on both interfaces.
 		 */
 
 		$existing = [
@@ -459,11 +532,13 @@ final class AutoruleListOracleTest extends TestCase
 
 		$this->assertShapes([
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan',  'floating' => ''],
 			['descr' => 'Default allow OPT1 to any', 'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan',  'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'opt1', 'floating' => ''],
 		], $result, 'order_1 float=off separate ifaces');
 		$this->assertTrackersSet($result, 'order_1 float=off separate');
+		$this->assertUserRulesPreserved($existing, $result, 'order_1 float=off separate');
+		$this->assertIdempotent($result, $gen, 'order_1', '', ['lan'], ['opt1'], 'order_1 float=off separate');
 	}
 
 	// -----------------------------------------------------------------------
@@ -473,16 +548,16 @@ final class AutoruleListOracleTest extends TestCase
 	public function testOrder1FloatOnSingleIfaceDenyOnly(): void
 	{
 		/**
-		 * Scenario: ORDER 1, float=on. User float pass goes to $fpermit_rules.
-		 * Non-floating user pass goes to $other_rules (float=on, non-floating).
+		 * Scenario: ORDER 1, float=on.
 		 *
-		 * ORDER 1 float=on:
-		 *   Pre-loop: fpermit_rules + fmatch_rules emitted.
-		 *   Inbound loop: pfB deny_in(lan).
-		 *   Outbound loop: pfB deny_out(lan).
-		 *   Tail: float=on + order_1/2 -> fother_rules (none here).
-		 *   order!=order_4 -> other_rules (non-floating user pass).
-		 * Expected: user_float_pass, pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
+		 * ORDER 1 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
+		 * keep = [user_float_pass, user_pass(lan)] (original order; pfB deny stripped).
+		 * pfB block = [deny_in(lan), deny_out(lan)].
+		 * Expected: user_float_pass, user_pass(lan), pfB deny_in(lan), pfB deny_out(lan).
+		 *
+		 * pf evaluates floating rules in a separate group regardless of config.xml
+		 * interleaving, so the relative position of user_float_pass vs interface rules
+		 * in config.xml does not affect pf precedence.
 		 */
 
 		$existing = [
@@ -496,35 +571,31 @@ final class AutoruleListOracleTest extends TestCase
 
 		$this->assertShapes([
 			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'order_1 float=on single iface');
 		$this->assertTrackersSet($result, 'order_1 float=on');
+		$this->assertUserRulesPreserved($existing, $result, 'order_1 float=on');
+		$this->assertIdempotent($result, $gen, 'order_1', 'on', ['lan'], ['lan'], 'order_1 float=on');
 	}
 
 	// -----------------------------------------------------------------------
 	// F. order_2, float=off, inbound==outbound='lan'  [KNOWN-BAD: duplication]
 	// -----------------------------------------------------------------------
 
-	public function testOrder2FloatOffSingleIfaceDenyOnlyKnownBadDuplicate(): void
+	public function testOrder2FloatOffSingleIfaceDenyOnly(): void
 	{
 		/**
-		 * Scenario: ORDER 2, float=off, SAME interface for inbound AND outbound.
+		 * Scenario: ORDER 2, float=off, SAME interface for inbound AND outbound ('lan').
 		 *
-		 * KNOWN-BAD: The user LAN pass rule goes into $permit_rules.
-		 * ORDER 2 emits permit_rules in the inbound loop (matching iface) AND
-		 * in the outbound loop (matching iface). Same duplication as order_1.
+		 * ORDER 2 anchor = AFTER: kept user rules first (verbatim), then pfB block.
+		 * keep = [user_pass(lan)] (pfB deny stripped; no dup).
+		 * pfB block = [deny_in(lan), deny_out(lan)].
+		 * Expected: user_pass(lan), pfB deny_in(lan), pfB deny_out(lan).
 		 *
-		 * ORDER 2: pfB(p/m) | pfSense(p/m) | pfB(b/r) | pfSense(b/r)
-		 * Expected: pfB deny_in(lan), user_pass(lan) [inbound],
-		 *           pfB deny_out(lan) [outbound], user_pass(lan) [outbound — DUPLICATE]
-		 *
-		 * Wait — order_2 emits: (inbound loop) pfB permit_in, [order_2: fpermit+fmatch+permit],
-		 * pfB deny_in. Then (outbound loop) pfB permit_out, [order_2: permit], pfB deny_out.
-		 * Here no pfB permit rules, so:
-		 *   inbound:  [order_2: permit_rules matching lan] = user_pass(lan), pfB deny_in(lan)
-		 *   outbound: [order_2: permit_rules matching lan] = user_pass(lan), pfB deny_out(lan)
+		 * Fail-before: old bucket-based code emitted user_pass TWICE (once per iface loop
+		 * iteration). The immutable-splice model keeps the verbatim list exactly once.
 		 */
 
 		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
@@ -532,13 +603,14 @@ final class AutoruleListOracleTest extends TestCase
 
 		$result = pfb_build_autorule_list($existing, $gen, 'order_2', '', ['lan'], ['lan']);
 
-		// KNOWN-BAD: user rule appears twice.
 		$this->assertShapes([
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_2 float=off single iface [KNOWN-BAD: duplicate]');
+		], $result, 'order_2 float=off single iface');
+		$this->assertTrackersSet($result, 'order_2 float=off single');
+		$this->assertUserRulesPreserved($existing, $result, 'order_2 float=off single');
+		$this->assertIdempotent($result, $gen, 'order_2', '', ['lan'], ['lan'], 'order_2 float=off single');
 	}
 
 	// -----------------------------------------------------------------------
@@ -549,10 +621,11 @@ final class AutoruleListOracleTest extends TestCase
 	{
 		/**
 		 * Scenario: ORDER 2, float=off, separate ifaces (lan in, opt1 out).
-		 * No duplication because inbound and outbound filters by iface.
 		 *
-		 * Inbound: [order_2 permit(lan)], pfB deny_in(lan)
-		 * Outbound: [order_2 permit(opt1)], pfB deny_out(opt1)
+		 * ORDER 2 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
+		 * keep = [user_pass(lan), user_pass(opt1)] (original order).
+		 * pfB block = [deny_in(lan), deny_out(opt1)].
+		 * Expected: user_pass(lan), user_pass(opt1), pfB deny_in(lan), pfB deny_out(opt1).
 		 */
 
 		$existing = [
@@ -567,11 +640,13 @@ final class AutoruleListOracleTest extends TestCase
 
 		$this->assertShapes([
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan',  'floating' => ''],
 			['descr' => 'Default allow OPT1 to any', 'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan',  'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'opt1', 'floating' => ''],
 		], $result, 'order_2 float=off separate ifaces');
 		$this->assertTrackersSet($result, 'order_2 float=off separate');
+		$this->assertUserRulesPreserved($existing, $result, 'order_2 float=off separate');
+		$this->assertIdempotent($result, $gen, 'order_2', '', ['lan'], ['opt1'], 'order_2 float=off separate');
 	}
 
 	// -----------------------------------------------------------------------
@@ -581,15 +656,12 @@ final class AutoruleListOracleTest extends TestCase
 	public function testOrder2FloatOnSingleIfaceDenyOnly(): void
 	{
 		/**
-		 * Scenario: ORDER 2, float=on. User float pass -> fpermit_rules.
-		 * Non-floating user pass -> other_rules.
+		 * Scenario: ORDER 2, float=on.
 		 *
-		 * float=on order_2: fpermit+fmatch emitted inside the first inbound loop iter
-		 * (order_2 block).  No pfB permit_in templates.
-		 * Outbound loop: order_2 block skipped (no permit_rules when float=on).
-		 * Tail: float=on, order_2 -> fother_rules (none).
-		 * order!=order_4 -> other_rules.
-		 * Expected: fpermit(first inbound iter), pfB deny_in, pfB deny_out, user_pass(lan)
+		 * ORDER 2 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
+		 * keep = [user_float_pass, user_pass(lan)] (original order; pfB deny stripped).
+		 * pfB block = [deny_in(lan), deny_out(lan)].
+		 * Expected: user_float_pass, user_pass(lan), pfB deny_in(lan), pfB deny_out(lan).
 		 */
 
 		$existing = [
@@ -603,11 +675,13 @@ final class AutoruleListOracleTest extends TestCase
 
 		$this->assertShapes([
 			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'order_2 float=on single iface');
 		$this->assertTrackersSet($result, 'order_2 float=on');
+		$this->assertUserRulesPreserved($existing, $result, 'order_2 float=on');
+		$this->assertIdempotent($result, $gen, 'order_2', 'on', ['lan'], ['lan'], 'order_2 float=on');
 	}
 
 	// -----------------------------------------------------------------------
@@ -618,15 +692,9 @@ final class AutoruleListOracleTest extends TestCase
 	{
 		/**
 		 * Scenario: ORDER 3, float=off.
-		 * ORDER 3: pfB(p/m) | pfB(b/r) | pfSense(p/m) | pfSense(b/r)
 		 *
-		 * permit_rules used in the tail (order_3 -> emit permit_rules after interface loops).
-		 * user pass LAN -> $permit_rules (order_3, not order_0).
-		 *
-		 * Inbound: pfB deny_in(lan)  [no permit_rules in inbound loop for order_3]
-		 * Outbound: pfB deny_out(lan) [same]
-		 * Tail: order_3 -> permit_rules (user pass), other_rules (none)
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
+		 * ORDER 3 anchor = BEFORE: pfB block first, then kept user rules.
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan).
 		 */
 
 		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
@@ -640,6 +708,8 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'order_3 float=off single iface');
 		$this->assertTrackersSet($result, 'order_3 float=off');
+		$this->assertUserRulesPreserved($existing, $result, 'order_3 float=off');
+		$this->assertIdempotent($result, $gen, 'order_3', '', ['lan'], ['lan'], 'order_3 float=off');
 	}
 
 	// -----------------------------------------------------------------------
@@ -649,12 +719,11 @@ final class AutoruleListOracleTest extends TestCase
 	public function testOrder3FloatOnSingleIfaceDenyOnly(): void
 	{
 		/**
-		 * Scenario: ORDER 3, float=on. User float pass -> $fpermit_rules.
-		 * Non-floating user pass -> other_rules.
+		 * Scenario: ORDER 3, float=on.
 		 *
-		 * float=on order_3: tail emits fpermit+fmatch+fother (order_3 rule_order).
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan),
-		 *           user_float_pass (in fpermit tail), user_pass(lan) (other_rules tail)
+		 * ORDER 3 anchor = BEFORE: pfB block first, then kept user rules verbatim.
+		 * keep = [user_float_pass, user_pass(lan)] (original order).
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_float_pass, user_pass(lan).
 		 */
 
 		$existing = [
@@ -673,24 +742,21 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'order_3 float=on single iface');
 		$this->assertTrackersSet($result, 'order_3 float=on');
+		$this->assertUserRulesPreserved($existing, $result, 'order_3 float=on');
+		$this->assertIdempotent($result, $gen, 'order_3', 'on', ['lan'], ['lan'], 'order_3 float=on');
 	}
 
 	// -----------------------------------------------------------------------
 	// K. order_4, float=off, inbound==outbound='lan'  [KNOWN-BAD: reorder]
 	// -----------------------------------------------------------------------
 
-	public function testOrder4FloatOffSingleIfaceDenyOnlyKnownBadReorder(): void
+	public function testOrder4FloatOffSingleIfaceDenyOnly(): void
 	{
 		/**
-		 * Scenario: ORDER 4, float=off.
-		 * ORDER 4: pfB(p/m) | pfB(b/r) | pfSense(b/r) | pfSense(p/m)
+		 * Scenario: ORDER 4, float=off, single managed iface (lan).
 		 *
-		 * user pass LAN -> $permit_rules.
-		 * Inbound: pfB deny_in(lan).
-		 * Outbound: pfB deny_out(lan).
-		 * Tail: order_4 -> other_rules (none here), then permit_rules.
-		 *       order_4: NOT emitting other_rules at the end.
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
+		 * ORDER 4 anchor = BEFORE: pfB block first, then kept user rules verbatim.
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan).
 		 */
 
 		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
@@ -698,28 +764,30 @@ final class AutoruleListOracleTest extends TestCase
 
 		$result = pfb_build_autorule_list($existing, $gen, 'order_4', '', ['lan'], ['lan']);
 
-		// order_4 tail: other_rules first (empty), then permit_rules.
-		// No duplication because neither inbound nor outbound loops emit permit_rules for order_4.
 		$this->assertShapes([
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'order_4 float=off single iface');
 		$this->assertTrackersSet($result, 'order_4 float=off');
+		$this->assertUserRulesPreserved($existing, $result, 'order_4 float=off');
+		$this->assertIdempotent($result, $gen, 'order_4', '', ['lan'], ['lan'], 'order_4 float=off');
 	}
 
-	public function testOrder4FloatOffTwoIfacesKnownBadReorder(): void
+	public function testOrder4FloatOffTwoIfacesDenyOnly(): void
 	{
 		/**
 		 * Scenario: ORDER 4, float=off, two managed ifaces (opt1 inbound, lan outbound).
 		 *
-		 * KNOWN-BAD: The original code has TWO managed ifaces but the opt1 rule
-		 * comes from the inbound loop and the lan rule from the outbound loop.
-		 * Both go to $permit_rules, emitted in the tail in config.xml ORDER (opt1 first,
-		 * lan second) — which inverts their original position relative to each other
-		 * if the factory config had lan before opt1.
+		 * ORDER 4 anchor = BEFORE: pfB block first, then kept user rules verbatim.
+		 * keep = [user_pass(lan), user_pass(opt1)] (original order in existing_rules).
+		 * pfB block = [deny_in(opt1), deny_out(lan)].
+		 * Expected: pfB deny_in(opt1), pfB deny_out(lan), user_pass(lan), user_pass(opt1).
 		 *
-		 * This test pins the existing reorder behaviour as-is.
+		 * The deliberate behaviour change from Phase 1's KNOWN-BAD oracle: the old bucket-based
+		 * code emitted user rules in accumulated-bucket order (also lan then opt1 for this
+		 * fixture, but would diverge for a different existing_rules order). The immutable-splice
+		 * always preserves the original config.xml order verbatim.
 		 */
 
 		$existing = [
@@ -733,16 +801,15 @@ final class AutoruleListOracleTest extends TestCase
 		// inbound='opt1', outbound='lan' — mimics a config where opt1 is the inbound iface.
 		$result = pfb_build_autorule_list($existing, $gen, 'order_4', '', ['opt1'], ['lan']);
 
-		// ORDER 4 tail: other_rules (none), permit_rules (lan then opt1 — in $permit_rules order),
-		// NOT order_4 "other_rules at end" — the condition is order!=order_4.
-		// permit_rules order: userPassLan first (appears before userPassOpt1 in existing_rules
-		// and both match managed ifaces), so lan first then opt1.
 		$this->assertShapes([
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'opt1', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan',  'floating' => ''],
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
 			['descr' => 'Default allow OPT1 to any', 'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
-		], $result, 'order_4 float=off two ifaces [KNOWN-BAD: reorder]');
+		], $result, 'order_4 float=off two ifaces');
+		$this->assertTrackersSet($result, 'order_4 float=off two ifaces');
+		$this->assertUserRulesPreserved($existing, $result, 'order_4 float=off two ifaces');
+		$this->assertIdempotent($result, $gen, 'order_4', '', ['opt1'], ['lan'], 'order_4 float=off two ifaces');
 	}
 
 	// -----------------------------------------------------------------------
@@ -752,12 +819,11 @@ final class AutoruleListOracleTest extends TestCase
 	public function testOrder4FloatOnSingleIfaceDenyOnly(): void
 	{
 		/**
-		 * Scenario: ORDER 4, float=on. User float pass -> fpermit_rules.
-		 * Non-floating user pass -> other_rules.
+		 * Scenario: ORDER 4, float=on.
 		 *
-		 * float=on order_4: tail emits fother+fpermit+fmatch (order_4 rule_order).
-		 * order_4: other_rules tail (before permit_rules). No permit_rules.
-		 * Expected: pfB deny_in, pfB deny_out, user_float_pass (fpermit), user_pass(other_rules tail)
+		 * ORDER 4 anchor = BEFORE: pfB block first, then kept user rules verbatim.
+		 * keep = [user_float_pass, user_pass(lan)] (original order).
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_float_pass, user_pass(lan).
 		 */
 
 		$existing = [
@@ -776,47 +842,44 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'order_4 float=on single iface');
 		$this->assertTrackersSet($result, 'order_4 float=on');
+		$this->assertUserRulesPreserved($existing, $result, 'order_4 float=on');
+		$this->assertIdempotent($result, $gen, 'order_4', 'on', ['lan'], ['lan'], 'order_4 float=on');
 	}
 
 	// -----------------------------------------------------------------------
 	// M. absent/empty pass_order -> treated as order_0 (the #532 default fix)
 	// -----------------------------------------------------------------------
 
-	public function testAbsentOrderTreatedAsOrder0(): void
+	public function testAbsentOrderTreatedAsBefore(): void
 	{
 		/**
-		 * Scenario: empty pass_order string (absent). Should behave identically to
-		 * order_0 — user pass rule goes to other_rules, never to permit_rules.
+		 * Scenario: empty pass_order string (absent / unknown).
 		 *
-		 * (The order_0 default is applied by the caller before pfb_build_autorule_list();
-		 *  this test passes an empty string to verify the helper doesn't mis-handle it.)
+		 * The immutable-splice model maps any unknown order to the BEFORE anchor (pfB
+		 * block first, then kept user rules). This makes the drop bug (#532) impossible
+		 * by construction — user rules are never bucketed and cannot be omitted.
 		 *
-		 * With empty order: no branch matches order_1/2/3/4, so:
-		 *   - bucket: pass rule on managed iface, empty string != 'order_0', so
-		 *     the helper uses else -> permit_rules.
-		 * Wait — the helper checks: if ($order == 'order_0') -> other_rules, else -> permit_rules.
-		 * So empty order -> permit_rules, NOT other_rules. The rule is then emitted only in
-		 * the tail if order_3/order_4... neither matches, so it is NEVER emitted.
+		 * Fail-before: the old bucket-based code sent user pass rules to $permit_rules
+		 * for unrecognised orders, which had no tail emission → user rule DROPPED.
+		 * The caller's order_0 default (#539) defended against that; the immutable-splice
+		 * makes the helper itself safe regardless of what the caller passes.
 		 *
-		 * This is the DROP bug (#532). The caller defaults empty to 'order_0' before calling
-		 * the helper. This test verifies the helper with a raw empty string to pin what
-		 * IT does (the drop) — the protection lives in the caller's defaulting.
-		 *
-		 * With empty order string: permit_rules populated but no order_1/2/3/4 tail emits them.
-		 * Result: pfB rules emitted, user pass rule DROPPED.
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)  (same as order_0).
 		 */
 
 		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
 		$gen      = $this->pfbGeneratedDenyOnly();
 
-		// Empty order: user pass goes to permit_rules but no tail emits permit_rules for ''.
 		$result = pfb_build_autorule_list($existing, $gen, '', '', ['lan'], ['lan']);
 
-		// User pass is dropped (no tail for unknown order); pfB rules still emitted.
 		$this->assertShapes([
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-		], $result, 'empty order -> user rule dropped (caller must default to order_0)');
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'empty order -> BEFORE anchor (user rule preserved, same as order_0)');
+		$this->assertTrackersSet($result, 'absent order');
+		$this->assertUserRulesPreserved($existing, $result, 'absent order');
+		$this->assertIdempotent($result, $gen, '', '', ['lan'], ['lan'], 'absent order');
 	}
 
 	// -----------------------------------------------------------------------
@@ -829,9 +892,11 @@ final class AutoruleListOracleTest extends TestCase
 		 * Scenario: pfB has BOTH permit_inbound and deny_inbound (Permit_* list present).
 		 * order_1, float=off, separate ifaces (lan in, opt1 out).
 		 *
-		 * ORDER 1: pfSense(p/m) first, then pfB(p/m), then pfB(b/r), then pfSense(b/r).
-		 * Inbound: user_pass(lan) [permit_rules, order_1], pfB permit_in(lan), pfB deny_in(lan)
-		 * Outbound: user_pass(opt1) [permit_rules, order_1], pfB permit_out(opt1), pfB deny_out(opt1)
+		 * ORDER 1 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
+		 * keep = [user_pass(lan), user_pass(opt1)] (original order; pfB deny rules stripped).
+		 * pfB block = [permit_in(lan), deny_in(lan), permit_out(opt1), deny_out(opt1)].
+		 * Expected: user_pass(lan), user_pass(opt1), pfB permit_in(lan), pfB deny_in(lan),
+		 *           pfB permit_out(opt1), pfB deny_out(opt1).
 		 */
 
 		$existing = [
@@ -846,13 +911,15 @@ final class AutoruleListOracleTest extends TestCase
 
 		$this->assertShapes([
 			['descr' => 'Default allow LAN to any',      'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
+			['descr' => 'Default allow OPT1 to any',     'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
 			['descr' => 'pfB_PermitList_v4 Auto Rule',   'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule',     'type' => 'block',  'interface' => 'lan',  'floating' => ''],
-			['descr' => 'Default allow OPT1 to any',     'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
 			['descr' => 'pfB_PermitList_v4 Auto Rule',   'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule',     'type' => 'reject', 'interface' => 'opt1', 'floating' => ''],
 		], $result, 'order_1 float=off Permit_* + Deny_* separate ifaces');
 		$this->assertTrackersSet($result, 'order_1 permit+deny');
+		$this->assertUserRulesPreserved($existing, $result, 'order_1 permit+deny');
+		$this->assertIdempotent($result, $gen, 'order_1', '', ['lan'], ['opt1'], 'order_1 permit+deny');
 	}
 
 	// -----------------------------------------------------------------------
@@ -866,10 +933,9 @@ final class AutoruleListOracleTest extends TestCase
 		 * Its descr starts with PFB_DNS_REDIR_DESCR_V4_PFX ('pfB_DNS_Redirect_').
 		 * The helper must treat it like a user rule — NOT strip it.
 		 *
-		 * order_0, float=off. Bypass rule is on 'lan', treated as other_rules (non-pass? no —
-		 * it's type='pass', so order_0 -> other_rules because order_0 pass -> other_rules).
-		 *
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), bypass_rule(lan), user_pass(lan)
+		 * order_0 anchor = BEFORE: pfB block first, then kept user rules verbatim.
+		 * keep = [bypass_rule(lan), user_pass(lan)] (original order; pfB deny stripped).
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), bypass_rule(lan), user_pass(lan).
 		 */
 
 		$existing = [
@@ -887,6 +953,8 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'pfB_DNS_Redirect_lan_v4',   'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'DNS-redirect bypass rule preserved (not stripped)');
+		$this->assertUserRulesPreserved($existing, $result, 'dns-redirect bypass');
+		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'dns-redirect bypass');
 	}
 
 	// -----------------------------------------------------------------------
@@ -898,10 +966,10 @@ final class AutoruleListOracleTest extends TestCase
 		/**
 		 * Scenario: existing rules include a DoT-block bypass rule.
 		 * Its descr starts with PFB_DOT_BLOCK_DESCR_PFX ('pfB_DoT_Block_').
-		 * Must be preserved like a user rule.
+		 * Must be preserved like a user rule — NOT stripped.
 		 *
-		 * order_0, float=off. DoT rule type='block' -> not a pass rule -> other_rules.
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), dot_block_rule(lan), user_pass(lan)
+		 * order_0 anchor = BEFORE. keep = [dot_block_rule(lan), user_pass(lan)].
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), dot_block_rule(lan), user_pass(lan).
 		 */
 
 		$existing = [
@@ -919,6 +987,8 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'pfB_DoT_Block_lan',         'type' => 'block',  'interface' => 'lan', 'floating' => ''],
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'DoT-block bypass rule preserved (not stripped)');
+		$this->assertUserRulesPreserved($existing, $result, 'dot-block bypass');
+		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'dot-block bypass');
 	}
 
 	// -----------------------------------------------------------------------
@@ -930,7 +1000,7 @@ final class AutoruleListOracleTest extends TestCase
 		/**
 		 * Scenario: existing rules contain only a pfB_ deny rule (no bypass prefix).
 		 * It must be stripped and rebuilt from the template.
-		 * Result: exactly the rebuilt pfB rules, no user rules.
+		 * Result: exactly the rebuilt pfB rules, no user rules (keep = []).
 		 */
 
 		$existing = [$this->pfbDenyRule('lan')];
@@ -943,6 +1013,8 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
 		], $result, 'pfB_ rules stripped and rebuilt');
 		$this->assertTrackersSet($result, 'pfB stripped');
+		$this->assertUserRulesPreserved($existing, $result, 'pfB stripped');
+		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'pfB stripped');
 	}
 
 	// -----------------------------------------------------------------------
@@ -981,6 +1053,8 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'pfB_DenyList_v4 Auto Rule',  'type' => 'reject', 'interface' => 'lan',  'floating' => ''],
 			['descr' => 'Default allow LAN to any',   'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
 		], $result, 'DNSBL float rules emitted before iface loop');
+		$this->assertUserRulesPreserved($existing, $result, 'dnsbl float');
+		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'dnsbl float');
 	}
 
 	// -----------------------------------------------------------------------
@@ -993,25 +1067,32 @@ final class AutoruleListOracleTest extends TestCase
 		 * Scenario: no existing rules at all. Only pfB templates.
 		 */
 
-		$result = pfb_build_autorule_list([], $this->pfbGeneratedDenyOnly(), 'order_0', '', ['lan'], ['lan']);
+		$gen    = $this->pfbGeneratedDenyOnly();
+		$result = pfb_build_autorule_list([], $gen, 'order_0', '', ['lan'], ['lan']);
 
 		$this->assertShapes([
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
 		], $result, 'empty existing rules');
 		$this->assertTrackersSet($result, 'empty existing');
+		$this->assertUserRulesPreserved([], $result, 'empty existing');
+		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'empty existing');
 	}
 
 	// -----------------------------------------------------------------------
 	// T. Non-managed iface user rule goes to other_rules (float=off)
 	// -----------------------------------------------------------------------
 
-	public function testNonManagedIfaceRuleGoesToOtherRules(): void
+	public function testNonManagedIfaceRulePreservedVerbatim(): void
 	{
 		/**
 		 * Scenario: user rule on 'wan' — NOT in the managed inbound/outbound iface list.
-		 * float=off. Should go to $other_rules, emitted at the end.
-		 * order_0, managed=['lan'].
+		 * order_0, float=off, managed=['lan'].
+		 *
+		 * The immutable splice keeps ALL non-pfB-owned rules verbatim, regardless of
+		 * interface. Non-managed rules are not singled out — they stay in their original
+		 * position relative to other user rules in $keep.
+		 * Expected: pfB BEFORE, then keep = [wan_rule, user_pass(lan)] (original order).
 		 */
 
 		$nonManagedRule = [
@@ -1029,13 +1110,14 @@ final class AutoruleListOracleTest extends TestCase
 
 		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
 
-		// Non-managed rules go to other_rules (with order_0 managed rules too).
 		$this->assertShapes([
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
 			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
 			['descr' => 'WAN rule',                  'type' => 'pass',   'interface' => 'wan', 'floating' => ''],
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'non-managed iface rule goes to other_rules (after managed)');
+		], $result, 'non-managed iface rule preserved verbatim in original position');
+		$this->assertUserRulesPreserved($existing, $result, 'non-managed iface');
+		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'non-managed iface');
 	}
 
 	/**

--- a/tests/php/AutoruleListOracleTest.php
+++ b/tests/php/AutoruleListOracleTest.php
@@ -1,0 +1,1067 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Oracle tests for pfb_build_autorule_list() — ADR-41 Phase 1.
+ *
+ * These are CHARACTERISATION (oracle) tests: they pin EXACTLY what the helper
+ * returns today, INCLUDING the known-bad cases (order_1/order_2 duplication,
+ * order_4 reorder). They stay GREEN across Phase 1 (extraction is
+ * behaviour-preserving) and flip to the CORRECTED expected output in Phase 3.
+ *
+ * Fixture matrix covered (each pass_order × float on/off unless noted):
+ *   A. order_0,  float=off, inbound==outbound ('lan'), Deny_* only
+ *   B. order_0,  float=on,  inbound==outbound ('lan'), Deny_* only
+ *   C. order_1,  float=off, inbound==outbound ('lan'), Deny_* only  [KNOWN-BAD: dup]
+ *   D. order_1,  float=off, inbound!=outbound ('lan'+'opt1'), Deny_* only
+ *   E. order_1,  float=on,  inbound==outbound ('lan'), Deny_* only
+ *   F. order_2,  float=off, inbound==outbound ('lan'), Deny_* only  [KNOWN-BAD: dup]
+ *   G. order_2,  float=off, inbound!=outbound ('lan'+'opt1'), Deny_* only
+ *   H. order_2,  float=on,  inbound==outbound ('lan'), Deny_* only
+ *   I. order_3,  float=off, inbound==outbound ('lan'), Deny_* only
+ *   J. order_3,  float=on,  inbound==outbound ('lan'), Deny_* only
+ *   K. order_4,  float=off, inbound==outbound ('lan'), Deny_* only  [KNOWN-BAD: reorder]
+ *   L. order_4,  float=on,  inbound==outbound ('lan'), Deny_* only
+ *   M. absent/empty pass_order, float=off, treated as order_0 by the helper
+ *   N. Permit_* (permit_inbound + permit_outbound) present, order_1, float=off
+ *   O. DNS-redirect bypass rule present (pfB_ descr but NOT stripped), order_0, float=off
+ *   P. DoT-block bypass rule present, order_0, float=off
+ *
+ * Each test asserts the FULL ordered descr|type|interface|floating list — not just
+ * a count — so any reordering shows up as a test failure.
+ *
+ * KNOWN-BAD cases (pinned as "what it does today" — Phase 3 flips them):
+ *   C (order_1, inbound==outbound, float=off): user LAN pass rule duplicated
+ *   F (order_2, inbound==outbound, float=off): user LAN pass rule duplicated
+ *   K (order_4, float=off):                   user rules reordered (opt1 before lan)
+ *
+ * No live pfSense state involved — pfb_tracker() is called via the existing
+ * doubles (get_real_interface/get_interface_ip/etc. all seeded to deterministic
+ * no-op values by default).
+ */
+#[CoversFunction('pfb_build_autorule_list')]
+final class AutoruleListOracleTest extends TestCase
+{
+	// -----------------------------------------------------------------------
+	// Fixtures
+	// -----------------------------------------------------------------------
+
+	/** A minimal user 'pass' rule on 'lan'. */
+	private function userPassLan(string $descr = 'Default allow LAN to any'): array
+	{
+		return [
+			'descr'       => $descr,
+			'type'        => 'pass',
+			'interface'   => 'lan',
+			'ipprotocol'  => 'inet',
+			'floating'    => '',
+			'source'      => ['any' => ''],
+			'destination' => ['any' => ''],
+		];
+	}
+
+	/** A minimal user 'pass' rule on 'opt1'. */
+	private function userPassOpt1(string $descr = 'Default allow OPT1 to any'): array
+	{
+		return [
+			'descr'       => $descr,
+			'type'        => 'pass',
+			'interface'   => 'opt1',
+			'ipprotocol'  => 'inet',
+			'floating'    => '',
+			'source'      => ['any' => ''],
+			'destination' => ['any' => ''],
+		];
+	}
+
+	/** A minimal user floating 'pass' rule. */
+	private function userFloatPass(string $descr = 'User Float Pass'): array
+	{
+		return [
+			'descr'       => $descr,
+			'type'        => 'pass',
+			'interface'   => '',
+			'ipprotocol'  => 'inet',
+			'floating'    => 'yes',
+			'direction'   => 'any',
+			'source'      => ['any' => ''],
+			'destination' => ['any' => ''],
+		];
+	}
+
+	/** A pfB_ deny rule — should be STRIPPED by the helper (it rebuilds these). */
+	private function pfbDenyRule(string $iface = 'lan'): array
+	{
+		return [
+			'descr'       => 'pfB_DenyAlias_v4 Auto Rule',
+			'type'        => 'block',
+			'interface'   => $iface,
+			'ipprotocol'  => 'inet',
+			'floating'    => '',
+			'source'      => ['address' => 'pfB_DenyAlias_v4'],
+			'destination' => ['any' => ''],
+		];
+	}
+
+	/** A DNS-redirect bypass rule — pfB_ descr but must NOT be stripped. */
+	private function dnsRedirectBypassRule(): array
+	{
+		return [
+			'descr'       => 'pfB_DNS_Redirect_lan_v4',  // starts with PFB_DNS_REDIR_DESCR_V4_PFX
+			'type'        => 'pass',
+			'interface'   => 'lan',
+			'ipprotocol'  => 'inet',
+			'floating'    => '',
+			'source'      => ['any' => ''],
+			'destination' => ['any' => ''],
+		];
+	}
+
+	/** A DoT-block bypass rule — pfB_ descr but must NOT be stripped. */
+	private function dotBlockBypassRule(): array
+	{
+		return [
+			'descr'       => 'pfB_DoT_Block_lan',  // starts with PFB_DOT_BLOCK_DESCR_PFX
+			'type'        => 'block',
+			'interface'   => 'lan',
+			'ipprotocol'  => 'inet',
+			'floating'    => '',
+			'source'      => ['any' => ''],
+			'destination' => ['any' => ''],
+		];
+	}
+
+	/**
+	 * A minimal $pfb_generated with one deny_inbound rule (deny 'lan' inbound).
+	 * The deny template has no interface/tracker yet — those are set per-interface in the helper.
+	 */
+	private function pfbGeneratedDenyOnly(): array
+	{
+		return [
+			'permit_inbound'    => [],
+			'permit_outbound'   => [],
+			'deny_inbound'      => [
+				[
+					'descr'       => 'pfB_DenyList_v4 Auto Rule',
+					'type'        => 'block',
+					'interface'   => '',  // set by helper
+					'ipprotocol'  => 'inet',
+					'floating'    => '',
+					'source'      => ['address' => 'pfB_DenyList_v4'],
+					'destination' => ['any' => ''],
+					'created'     => ['time' => 0, 'username' => 'Auto'],
+				],
+			],
+			'deny_outbound'     => [
+				[
+					'descr'       => 'pfB_DenyList_v4 Auto Rule',
+					'type'        => 'reject',
+					'interface'   => '',  // set by helper
+					'ipprotocol'  => 'inet',
+					'floating'    => '',
+					'source'      => ['any' => ''],
+					'destination' => ['address' => 'pfB_DenyList_v4'],
+					'created'     => ['time' => 0, 'username' => 'Auto'],
+				],
+			],
+			'match_inbound'     => [],
+			'match_outbound'    => [],
+			'inbound_floating'  => '',
+			'outbound_floating' => '',
+			'dnsbl_float'       => [],
+		];
+	}
+
+	/**
+	 * $pfb_generated with permit_inbound + deny_inbound (Permit_* action present).
+	 */
+	private function pfbGeneratedPermitAndDeny(): array
+	{
+		return [
+			'permit_inbound'    => [
+				[
+					'descr'       => 'pfB_PermitList_v4 Auto Rule',
+					'type'        => 'pass',
+					'interface'   => '',
+					'ipprotocol'  => 'inet',
+					'floating'    => '',
+					'source'      => ['address' => 'pfB_PermitList_v4'],
+					'destination' => ['any' => ''],
+					'created'     => ['time' => 0, 'username' => 'Auto'],
+				],
+			],
+			'permit_outbound'   => [
+				[
+					'descr'       => 'pfB_PermitList_v4 Auto Rule',
+					'type'        => 'pass',
+					'interface'   => '',
+					'ipprotocol'  => 'inet',
+					'floating'    => '',
+					'source'      => ['any' => ''],
+					'destination' => ['address' => 'pfB_PermitList_v4'],
+					'created'     => ['time' => 0, 'username' => 'Auto'],
+				],
+			],
+			'deny_inbound'      => [
+				[
+					'descr'       => 'pfB_DenyList_v4 Auto Rule',
+					'type'        => 'block',
+					'interface'   => '',
+					'ipprotocol'  => 'inet',
+					'floating'    => '',
+					'source'      => ['address' => 'pfB_DenyList_v4'],
+					'destination' => ['any' => ''],
+					'created'     => ['time' => 0, 'username' => 'Auto'],
+				],
+			],
+			'deny_outbound'     => [
+				[
+					'descr'       => 'pfB_DenyList_v4 Auto Rule',
+					'type'        => 'reject',
+					'interface'   => '',
+					'ipprotocol'  => 'inet',
+					'floating'    => '',
+					'source'      => ['any' => ''],
+					'destination' => ['address' => 'pfB_DenyList_v4'],
+					'created'     => ['time' => 0, 'username' => 'Auto'],
+				],
+			],
+			'match_inbound'     => [],
+			'match_outbound'    => [],
+			'inbound_floating'  => '',
+			'outbound_floating' => '',
+			'dnsbl_float'       => [],
+		];
+	}
+
+	// -----------------------------------------------------------------------
+	// $GLOBALS['pfb'] sandbox helpers
+	// -----------------------------------------------------------------------
+
+	private array $origPfb    = [];
+	private bool  $hadPfb     = FALSE;
+
+	protected function setUp(): void
+	{
+		$this->hadPfb   = array_key_exists('pfb', $GLOBALS);
+		$this->origPfb  = $GLOBALS['pfb'] ?? [];
+
+		// Minimal pfb globals needed by pfb_tracker() (trackerids collision check).
+		$GLOBALS['pfb'] = [
+			'trackerids'         => [],
+			'foreign_trackerids' => [],
+			'last_trackerid'     => 1700000010,
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->origPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Assertion helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Extract [descr, type, interface, floating] from each rule in $result.
+	 * This is the "shape" used for oracle assertions — enough to pin ORDER and
+	 * presence without being brittle about tracker/created timestamps.
+	 *
+	 * @param array<int, array<string, mixed>> $result
+	 * @return list<array{descr: string, type: string, interface: string, floating: string}>
+	 */
+	private function shapes(array $result): array
+	{
+		return array_map(static function (array $rule): array {
+			return [
+				'descr'     => $rule['descr']     ?? '',
+				'type'      => $rule['type']       ?? '',
+				'interface' => $rule['interface']  ?? '',
+				'floating'  => $rule['floating']   ?? '',
+			];
+		}, array_values($result));
+	}
+
+	/**
+	 * Assert the full ordered shape list equals $expected.
+	 * On failure, print expected vs actual for diagnosis.
+	 *
+	 * @param list<array{descr: string, type: string, interface: string, floating: string}> $expected
+	 * @param array<int, array<string, mixed>> $result
+	 */
+	private function assertShapes(array $expected, array $result, string $context = ''): void
+	{
+		$actual = $this->shapes($result);
+		$label  = $context !== '' ? " [{$context}]" : '';
+		$this->assertSame(
+			$expected,
+			$actual,
+			"Rule shape mismatch{$label}."
+				. "\n\nExpected:\n" . json_encode($expected, JSON_PRETTY_PRINT)
+				. "\n\nActual:\n"   . json_encode($actual,   JSON_PRETTY_PRINT)
+		);
+	}
+
+	/** Assert each rule in $result has a 'tracker' key (set by pfb_tracker). */
+	private function assertTrackersSet(array $result, string $context = ''): void
+	{
+		foreach ($result as $i => $rule) {
+			$descr = $rule['descr'] ?? "(rule {$i})";
+			// Only pfB-generated rules (those from $pfb_generated) get trackers assigned;
+			// user rules pass through without tracker. Skip user rules.
+			if (!str_starts_with($descr, 'pfB_') || str_starts_with($descr, 'pfB_DNS_Redirect_')
+			    || str_starts_with($descr, 'pfB_DoT_Block_')) {
+				continue;
+			}
+			$this->assertArrayHasKey('tracker', $rule,
+				"pfB rule [{$i}] '{$descr}' must have 'tracker' key set by pfb_tracker()");
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// A. order_0, float=off, inbound==outbound='lan', Deny_* only
+	// -----------------------------------------------------------------------
+
+	public function testOrder0FloatOffSingleIfaceDenyOnly(): void
+	{
+		/**
+		 * Scenario: ORDER 0, float off, single managed iface (lan), Deny_* pfB rules.
+		 *
+		 * Given: existing rules = [pfB deny (stripped), user pass LAN].
+		 *        pfB generated = deny_inbound + deny_outbound templates.
+		 *        order=order_0, float=off, in+out ifaces = ['lan'].
+		 *
+		 * ORDER 0: pfB (p/m/b/r) | All other
+		 * Expected order: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
+		 *
+		 * user pass goes to $other_rules (order_0 -> order_0 pass -> other_rules).
+		 * Tail: order!=order_4 -> other_rules emitted last.
+		 */
+
+		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
+		$gen      = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_0 float=off single iface');
+		$this->assertTrackersSet($result, 'order_0 float=off');
+	}
+
+	// -----------------------------------------------------------------------
+	// B. order_0, float=on, single iface, Deny_* only
+	// -----------------------------------------------------------------------
+
+	public function testOrder0FloatOnSingleIfaceDenyOnly(): void
+	{
+		/**
+		 * Scenario: ORDER 0, float=on. user floating pass goes to $fother_rules
+		 * (order_0 + floating='yes' -> fother_rules).
+		 *
+		 * ORDER 0 float on:
+		 *   - No pre-loop float emit (order_1 only).
+		 *   - pfB deny_in(lan), pfB deny_out(lan).
+		 *   - Tail: float=on + order_0/3/4 -> fother/fpermit/fmatch (fother_rules only here).
+		 *   - order!=order_4 -> other_rules (none here).
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user float pass.
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->userFloatPass(),
+			$this->userPassLan(),      // non-floating: goes to $other_rules (float=on branch)
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_0', 'on', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_0 float=on');
+		$this->assertTrackersSet($result, 'order_0 float=on');
+	}
+
+	// -----------------------------------------------------------------------
+	// C. order_1, float=off, inbound==outbound='lan'  [KNOWN-BAD: duplication]
+	// -----------------------------------------------------------------------
+
+	public function testOrder1FloatOffSingleIfaceDenyOnlyKnownBadDuplicate(): void
+	{
+		/**
+		 * Scenario: ORDER 1, float=off, SAME interface for inbound AND outbound.
+		 *
+		 * KNOWN-BAD: The user LAN pass rule goes into $permit_rules.
+		 * It is emitted once in the inbound loop (order_1 permit_rules for 'lan')
+		 * AND once in the outbound loop (order_1 permit_rules for 'lan').
+		 * Result: user rule appears TWICE. This is the duplication bug.
+		 * Phase 3 fixes this — Phase 1 pins it as "what it does today".
+		 *
+		 * ORDER 1: pfSense(p/m) | pfB(p/m) | pfB(b/r) | pfSense(b/r)
+		 * Expected: user_pass(lan) [inbound], pfB deny_in(lan),
+		 *           user_pass(lan) [outbound — DUPLICATE], pfB deny_out(lan)
+		 */
+
+		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
+		$gen      = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_1', '', ['lan'], ['lan']);
+
+		// KNOWN-BAD: user rule appears twice (once per loop iteration).
+		$this->assertShapes([
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_1 float=off single iface [KNOWN-BAD: duplicate]');
+	}
+
+	// -----------------------------------------------------------------------
+	// D. order_1, float=off, inbound!=outbound ('lan' in, 'opt1' out)
+	// -----------------------------------------------------------------------
+
+	public function testOrder1FloatOffSeparateIfacesDenyOnly(): void
+	{
+		/**
+		 * Scenario: ORDER 1, float=off, separate inbound (lan) and outbound (opt1).
+		 *
+		 * User pass rules on both interfaces go to $permit_rules.
+		 * In the inbound loop: user pass LAN emitted for 'lan' iface.
+		 * In the outbound loop: user pass OPT1 emitted for 'opt1' iface.
+		 * No duplication because interfaces differ.
+		 *
+		 * Expected: user_pass(lan), pfB deny_in(lan), user_pass(opt1), pfB deny_out(opt1)
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->pfbDenyRule('opt1'),
+			$this->userPassLan(),
+			$this->userPassOpt1(),
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_1', '', ['lan'], ['opt1']);
+
+		$this->assertShapes([
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan',  'floating' => ''],
+			['descr' => 'Default allow OPT1 to any', 'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'opt1', 'floating' => ''],
+		], $result, 'order_1 float=off separate ifaces');
+		$this->assertTrackersSet($result, 'order_1 float=off separate');
+	}
+
+	// -----------------------------------------------------------------------
+	// E. order_1, float=on, single iface
+	// -----------------------------------------------------------------------
+
+	public function testOrder1FloatOnSingleIfaceDenyOnly(): void
+	{
+		/**
+		 * Scenario: ORDER 1, float=on. User float pass goes to $fpermit_rules.
+		 * Non-floating user pass goes to $other_rules (float=on, non-floating).
+		 *
+		 * ORDER 1 float=on:
+		 *   Pre-loop: fpermit_rules + fmatch_rules emitted.
+		 *   Inbound loop: pfB deny_in(lan).
+		 *   Outbound loop: pfB deny_out(lan).
+		 *   Tail: float=on + order_1/2 -> fother_rules (none here).
+		 *   order!=order_4 -> other_rules (non-floating user pass).
+		 * Expected: user_float_pass, pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->userFloatPass(),
+			$this->userPassLan(),
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_1', 'on', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_1 float=on single iface');
+		$this->assertTrackersSet($result, 'order_1 float=on');
+	}
+
+	// -----------------------------------------------------------------------
+	// F. order_2, float=off, inbound==outbound='lan'  [KNOWN-BAD: duplication]
+	// -----------------------------------------------------------------------
+
+	public function testOrder2FloatOffSingleIfaceDenyOnlyKnownBadDuplicate(): void
+	{
+		/**
+		 * Scenario: ORDER 2, float=off, SAME interface for inbound AND outbound.
+		 *
+		 * KNOWN-BAD: The user LAN pass rule goes into $permit_rules.
+		 * ORDER 2 emits permit_rules in the inbound loop (matching iface) AND
+		 * in the outbound loop (matching iface). Same duplication as order_1.
+		 *
+		 * ORDER 2: pfB(p/m) | pfSense(p/m) | pfB(b/r) | pfSense(b/r)
+		 * Expected: pfB deny_in(lan), user_pass(lan) [inbound],
+		 *           pfB deny_out(lan) [outbound], user_pass(lan) [outbound — DUPLICATE]
+		 *
+		 * Wait — order_2 emits: (inbound loop) pfB permit_in, [order_2: fpermit+fmatch+permit],
+		 * pfB deny_in. Then (outbound loop) pfB permit_out, [order_2: permit], pfB deny_out.
+		 * Here no pfB permit rules, so:
+		 *   inbound:  [order_2: permit_rules matching lan] = user_pass(lan), pfB deny_in(lan)
+		 *   outbound: [order_2: permit_rules matching lan] = user_pass(lan), pfB deny_out(lan)
+		 */
+
+		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
+		$gen      = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_2', '', ['lan'], ['lan']);
+
+		// KNOWN-BAD: user rule appears twice.
+		$this->assertShapes([
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_2 float=off single iface [KNOWN-BAD: duplicate]');
+	}
+
+	// -----------------------------------------------------------------------
+	// G. order_2, float=off, inbound!=outbound
+	// -----------------------------------------------------------------------
+
+	public function testOrder2FloatOffSeparateIfacesDenyOnly(): void
+	{
+		/**
+		 * Scenario: ORDER 2, float=off, separate ifaces (lan in, opt1 out).
+		 * No duplication because inbound and outbound filters by iface.
+		 *
+		 * Inbound: [order_2 permit(lan)], pfB deny_in(lan)
+		 * Outbound: [order_2 permit(opt1)], pfB deny_out(opt1)
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->pfbDenyRule('opt1'),
+			$this->userPassLan(),
+			$this->userPassOpt1(),
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_2', '', ['lan'], ['opt1']);
+
+		$this->assertShapes([
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan',  'floating' => ''],
+			['descr' => 'Default allow OPT1 to any', 'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'opt1', 'floating' => ''],
+		], $result, 'order_2 float=off separate ifaces');
+		$this->assertTrackersSet($result, 'order_2 float=off separate');
+	}
+
+	// -----------------------------------------------------------------------
+	// H. order_2, float=on, single iface
+	// -----------------------------------------------------------------------
+
+	public function testOrder2FloatOnSingleIfaceDenyOnly(): void
+	{
+		/**
+		 * Scenario: ORDER 2, float=on. User float pass -> fpermit_rules.
+		 * Non-floating user pass -> other_rules.
+		 *
+		 * float=on order_2: fpermit+fmatch emitted inside the first inbound loop iter
+		 * (order_2 block).  No pfB permit_in templates.
+		 * Outbound loop: order_2 block skipped (no permit_rules when float=on).
+		 * Tail: float=on, order_2 -> fother_rules (none).
+		 * order!=order_4 -> other_rules.
+		 * Expected: fpermit(first inbound iter), pfB deny_in, pfB deny_out, user_pass(lan)
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->userFloatPass(),
+			$this->userPassLan(),
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_2', 'on', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_2 float=on single iface');
+		$this->assertTrackersSet($result, 'order_2 float=on');
+	}
+
+	// -----------------------------------------------------------------------
+	// I. order_3, float=off, single iface
+	// -----------------------------------------------------------------------
+
+	public function testOrder3FloatOffSingleIfaceDenyOnly(): void
+	{
+		/**
+		 * Scenario: ORDER 3, float=off.
+		 * ORDER 3: pfB(p/m) | pfB(b/r) | pfSense(p/m) | pfSense(b/r)
+		 *
+		 * permit_rules used in the tail (order_3 -> emit permit_rules after interface loops).
+		 * user pass LAN -> $permit_rules (order_3, not order_0).
+		 *
+		 * Inbound: pfB deny_in(lan)  [no permit_rules in inbound loop for order_3]
+		 * Outbound: pfB deny_out(lan) [same]
+		 * Tail: order_3 -> permit_rules (user pass), other_rules (none)
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
+		 */
+
+		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
+		$gen      = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_3', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_3 float=off single iface');
+		$this->assertTrackersSet($result, 'order_3 float=off');
+	}
+
+	// -----------------------------------------------------------------------
+	// J. order_3, float=on, single iface
+	// -----------------------------------------------------------------------
+
+	public function testOrder3FloatOnSingleIfaceDenyOnly(): void
+	{
+		/**
+		 * Scenario: ORDER 3, float=on. User float pass -> $fpermit_rules.
+		 * Non-floating user pass -> other_rules.
+		 *
+		 * float=on order_3: tail emits fpermit+fmatch+fother (order_3 rule_order).
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan),
+		 *           user_float_pass (in fpermit tail), user_pass(lan) (other_rules tail)
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->userFloatPass(),
+			$this->userPassLan(),
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_3', 'on', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_3 float=on single iface');
+		$this->assertTrackersSet($result, 'order_3 float=on');
+	}
+
+	// -----------------------------------------------------------------------
+	// K. order_4, float=off, inbound==outbound='lan'  [KNOWN-BAD: reorder]
+	// -----------------------------------------------------------------------
+
+	public function testOrder4FloatOffSingleIfaceDenyOnlyKnownBadReorder(): void
+	{
+		/**
+		 * Scenario: ORDER 4, float=off.
+		 * ORDER 4: pfB(p/m) | pfB(b/r) | pfSense(b/r) | pfSense(p/m)
+		 *
+		 * user pass LAN -> $permit_rules.
+		 * Inbound: pfB deny_in(lan).
+		 * Outbound: pfB deny_out(lan).
+		 * Tail: order_4 -> other_rules (none here), then permit_rules.
+		 *       order_4: NOT emitting other_rules at the end.
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
+		 */
+
+		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
+		$gen      = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_4', '', ['lan'], ['lan']);
+
+		// order_4 tail: other_rules first (empty), then permit_rules.
+		// No duplication because neither inbound nor outbound loops emit permit_rules for order_4.
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_4 float=off single iface');
+		$this->assertTrackersSet($result, 'order_4 float=off');
+	}
+
+	public function testOrder4FloatOffTwoIfacesKnownBadReorder(): void
+	{
+		/**
+		 * Scenario: ORDER 4, float=off, two managed ifaces (opt1 inbound, lan outbound).
+		 *
+		 * KNOWN-BAD: The original code has TWO managed ifaces but the opt1 rule
+		 * comes from the inbound loop and the lan rule from the outbound loop.
+		 * Both go to $permit_rules, emitted in the tail in config.xml ORDER (opt1 first,
+		 * lan second) — which inverts their original position relative to each other
+		 * if the factory config had lan before opt1.
+		 *
+		 * This test pins the existing reorder behaviour as-is.
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('opt1'),
+			$this->pfbDenyRule('lan'),
+			$this->userPassLan(),
+			$this->userPassOpt1(),
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		// inbound='opt1', outbound='lan' — mimics a config where opt1 is the inbound iface.
+		$result = pfb_build_autorule_list($existing, $gen, 'order_4', '', ['opt1'], ['lan']);
+
+		// ORDER 4 tail: other_rules (none), permit_rules (lan then opt1 — in $permit_rules order),
+		// NOT order_4 "other_rules at end" — the condition is order!=order_4.
+		// permit_rules order: userPassLan first (appears before userPassOpt1 in existing_rules
+		// and both match managed ifaces), so lan first then opt1.
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'opt1', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan',  'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
+			['descr' => 'Default allow OPT1 to any', 'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
+		], $result, 'order_4 float=off two ifaces [KNOWN-BAD: reorder]');
+	}
+
+	// -----------------------------------------------------------------------
+	// L. order_4, float=on, single iface
+	// -----------------------------------------------------------------------
+
+	public function testOrder4FloatOnSingleIfaceDenyOnly(): void
+	{
+		/**
+		 * Scenario: ORDER 4, float=on. User float pass -> fpermit_rules.
+		 * Non-floating user pass -> other_rules.
+		 *
+		 * float=on order_4: tail emits fother+fpermit+fmatch (order_4 rule_order).
+		 * order_4: other_rules tail (before permit_rules). No permit_rules.
+		 * Expected: pfB deny_in, pfB deny_out, user_float_pass (fpermit), user_pass(other_rules tail)
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->userFloatPass(),
+			$this->userPassLan(),
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_4', 'on', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'order_4 float=on single iface');
+		$this->assertTrackersSet($result, 'order_4 float=on');
+	}
+
+	// -----------------------------------------------------------------------
+	// M. absent/empty pass_order -> treated as order_0 (the #532 default fix)
+	// -----------------------------------------------------------------------
+
+	public function testAbsentOrderTreatedAsOrder0(): void
+	{
+		/**
+		 * Scenario: empty pass_order string (absent). Should behave identically to
+		 * order_0 — user pass rule goes to other_rules, never to permit_rules.
+		 *
+		 * (The order_0 default is applied by the caller before pfb_build_autorule_list();
+		 *  this test passes an empty string to verify the helper doesn't mis-handle it.)
+		 *
+		 * With empty order: no branch matches order_1/2/3/4, so:
+		 *   - bucket: pass rule on managed iface, empty string != 'order_0', so
+		 *     the helper uses else -> permit_rules.
+		 * Wait — the helper checks: if ($order == 'order_0') -> other_rules, else -> permit_rules.
+		 * So empty order -> permit_rules, NOT other_rules. The rule is then emitted only in
+		 * the tail if order_3/order_4... neither matches, so it is NEVER emitted.
+		 *
+		 * This is the DROP bug (#532). The caller defaults empty to 'order_0' before calling
+		 * the helper. This test verifies the helper with a raw empty string to pin what
+		 * IT does (the drop) — the protection lives in the caller's defaulting.
+		 *
+		 * With empty order string: permit_rules populated but no order_1/2/3/4 tail emits them.
+		 * Result: pfB rules emitted, user pass rule DROPPED.
+		 */
+
+		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
+		$gen      = $this->pfbGeneratedDenyOnly();
+
+		// Empty order: user pass goes to permit_rules but no tail emits permit_rules for ''.
+		$result = pfb_build_autorule_list($existing, $gen, '', '', ['lan'], ['lan']);
+
+		// User pass is dropped (no tail for unknown order); pfB rules still emitted.
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+		], $result, 'empty order -> user rule dropped (caller must default to order_0)');
+	}
+
+	// -----------------------------------------------------------------------
+	// N. Permit_* config present (order_1, float=off, separate ifaces)
+	// -----------------------------------------------------------------------
+
+	public function testOrder1FloatOffPermitAndDenyRulesPresent(): void
+	{
+		/**
+		 * Scenario: pfB has BOTH permit_inbound and deny_inbound (Permit_* list present).
+		 * order_1, float=off, separate ifaces (lan in, opt1 out).
+		 *
+		 * ORDER 1: pfSense(p/m) first, then pfB(p/m), then pfB(b/r), then pfSense(b/r).
+		 * Inbound: user_pass(lan) [permit_rules, order_1], pfB permit_in(lan), pfB deny_in(lan)
+		 * Outbound: user_pass(opt1) [permit_rules, order_1], pfB permit_out(opt1), pfB deny_out(opt1)
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->pfbDenyRule('opt1'),
+			$this->userPassLan(),
+			$this->userPassOpt1(),
+		];
+		$gen = $this->pfbGeneratedPermitAndDeny();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_1', '', ['lan'], ['opt1']);
+
+		$this->assertShapes([
+			['descr' => 'Default allow LAN to any',      'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
+			['descr' => 'pfB_PermitList_v4 Auto Rule',   'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',     'type' => 'block',  'interface' => 'lan',  'floating' => ''],
+			['descr' => 'Default allow OPT1 to any',     'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
+			['descr' => 'pfB_PermitList_v4 Auto Rule',   'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',     'type' => 'reject', 'interface' => 'opt1', 'floating' => ''],
+		], $result, 'order_1 float=off Permit_* + Deny_* separate ifaces');
+		$this->assertTrackersSet($result, 'order_1 permit+deny');
+	}
+
+	// -----------------------------------------------------------------------
+	// O. DNS-redirect bypass rule present — must survive (not stripped)
+	// -----------------------------------------------------------------------
+
+	public function testDnsRedirectBypassRulePreserved(): void
+	{
+		/**
+		 * Scenario: existing rules include a DNS-redirect bypass rule.
+		 * Its descr starts with PFB_DNS_REDIR_DESCR_V4_PFX ('pfB_DNS_Redirect_').
+		 * The helper must treat it like a user rule — NOT strip it.
+		 *
+		 * order_0, float=off. Bypass rule is on 'lan', treated as other_rules (non-pass? no —
+		 * it's type='pass', so order_0 -> other_rules because order_0 pass -> other_rules).
+		 *
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), bypass_rule(lan), user_pass(lan)
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->dnsRedirectBypassRule(),
+			$this->userPassLan(),
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DNS_Redirect_lan_v4',   'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'DNS-redirect bypass rule preserved (not stripped)');
+	}
+
+	// -----------------------------------------------------------------------
+	// P. DoT-block bypass rule present — must survive (not stripped)
+	// -----------------------------------------------------------------------
+
+	public function testDotBlockBypassRulePreserved(): void
+	{
+		/**
+		 * Scenario: existing rules include a DoT-block bypass rule.
+		 * Its descr starts with PFB_DOT_BLOCK_DESCR_PFX ('pfB_DoT_Block_').
+		 * Must be preserved like a user rule.
+		 *
+		 * order_0, float=off. DoT rule type='block' -> not a pass rule -> other_rules.
+		 * Expected: pfB deny_in(lan), pfB deny_out(lan), dot_block_rule(lan), user_pass(lan)
+		 */
+
+		$existing = [
+			$this->pfbDenyRule('lan'),
+			$this->dotBlockBypassRule(),
+			$this->userPassLan(),
+		];
+		$gen = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DoT_Block_lan',         'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'DoT-block bypass rule preserved (not stripped)');
+	}
+
+	// -----------------------------------------------------------------------
+	// Q. pfB_ rules stripped (sanity check)
+	// -----------------------------------------------------------------------
+
+	public function testPfbRulesAreStripped(): void
+	{
+		/**
+		 * Scenario: existing rules contain only a pfB_ deny rule (no bypass prefix).
+		 * It must be stripped and rebuilt from the template.
+		 * Result: exactly the rebuilt pfB rules, no user rules.
+		 */
+
+		$existing = [$this->pfbDenyRule('lan')];
+		$gen      = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+		], $result, 'pfB_ rules stripped and rebuilt');
+		$this->assertTrackersSet($result, 'pfB stripped');
+	}
+
+	// -----------------------------------------------------------------------
+	// R. DNSBL float rules emitted when present
+	// -----------------------------------------------------------------------
+
+	public function testDnsblFloatRulesEmittedBeforeIfaceLoop(): void
+	{
+		/**
+		 * Scenario: pfb_generated['dnsbl_float'] contains the pre-built ping+permit pair.
+		 * They must appear BEFORE the inbound/outbound interface rules.
+		 *
+		 * order_0, float=off.
+		 * Expected: dnsbl_ping, dnsbl_permit, pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
+		 */
+
+		$existing = [$this->userPassLan()];
+
+		$gen                 = $this->pfbGeneratedDenyOnly();
+		$gen['dnsbl_float']  = [
+			['descr' => 'pfB_DNSBL_Ping Auto Rule',   'type' => 'pass', 'interface' => 'opt2', 'floating' => 'yes',
+			 'direction' => 'any', 'ipprotocol' => 'inet', 'source' => ['any' => ''],
+			 'destination' => ['address' => '10.0.0.1'], 'created' => ['time' => 0, 'username' => 'Auto']],
+			['descr' => 'pfB_DNSBL_Permit Auto Rule', 'type' => 'pass', 'interface' => 'opt2', 'floating' => 'yes',
+			 'direction' => 'any', 'ipprotocol' => 'inet', 'source' => ['any' => ''],
+			 'destination' => ['address' => '10.0.0.1', 'port' => 'pfB_DNSBL_Ports'],
+			 'created' => ['time' => 0, 'username' => 'Auto']],
+		];
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DNSBL_Ping Auto Rule',   'type' => 'pass',   'interface' => 'opt2', 'floating' => 'yes'],
+			['descr' => 'pfB_DNSBL_Permit Auto Rule', 'type' => 'pass',   'interface' => 'opt2', 'floating' => 'yes'],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',  'type' => 'block',  'interface' => 'lan',  'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',  'type' => 'reject', 'interface' => 'lan',  'floating' => ''],
+			['descr' => 'Default allow LAN to any',   'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
+		], $result, 'DNSBL float rules emitted before iface loop');
+	}
+
+	// -----------------------------------------------------------------------
+	// S. Empty existing rules — no user rules, no pfB old rules
+	// -----------------------------------------------------------------------
+
+	public function testEmptyExistingRulesProducesOnlyPfbRules(): void
+	{
+		/**
+		 * Scenario: no existing rules at all. Only pfB templates.
+		 */
+
+		$result = pfb_build_autorule_list([], $this->pfbGeneratedDenyOnly(), 'order_0', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+		], $result, 'empty existing rules');
+		$this->assertTrackersSet($result, 'empty existing');
+	}
+
+	// -----------------------------------------------------------------------
+	// T. Non-managed iface user rule goes to other_rules (float=off)
+	// -----------------------------------------------------------------------
+
+	public function testNonManagedIfaceRuleGoesToOtherRules(): void
+	{
+		/**
+		 * Scenario: user rule on 'wan' — NOT in the managed inbound/outbound iface list.
+		 * float=off. Should go to $other_rules, emitted at the end.
+		 * order_0, managed=['lan'].
+		 */
+
+		$nonManagedRule = [
+			'descr'       => 'WAN rule',
+			'type'        => 'pass',
+			'interface'   => 'wan',
+			'ipprotocol'  => 'inet',
+			'floating'    => '',
+			'source'      => ['any' => ''],
+			'destination' => ['any' => ''],
+		];
+
+		$existing = [$nonManagedRule, $this->userPassLan()];
+		$gen      = $this->pfbGeneratedDenyOnly();
+
+		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
+
+		// Non-managed rules go to other_rules (with order_0 managed rules too).
+		$this->assertShapes([
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
+			['descr' => 'WAN rule',                  'type' => 'pass',   'interface' => 'wan', 'floating' => ''],
+			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
+		], $result, 'non-managed iface rule goes to other_rules (after managed)');
+	}
+
+	/**
+	 * Regression: a null $float / $order must be tolerated exactly as ''.
+	 *
+	 * The call site passes $pfb['float'] / $pfb['order'] straight through, and those are
+	 * unset (null) until configured (e.g. enable_float not set). The original inline code
+	 * used the raw null in loose comparisons, so null is behaviour-equivalent to ''. The
+	 * Phase-1 extraction's strict `string` typehint instead TypeError'd on the null the call
+	 * site legitimately passes -- which on a live VM aborted `pfblockerng.php update` with a
+	 * fatal ("Argument #4 ($float) must be of type string, null given"), so no pfB rule was
+	 * built. This pins that the null path produces the SAME output as the empty-string path.
+	 */
+	public function testNullOrderAndFloatTreatedAsEmptyString(): void
+	{
+		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
+		$gen      = $this->pfbGeneratedDenyOnly();
+
+		$withEmpty = pfb_build_autorule_list($existing, $gen, '', '', ['lan'], ['lan']);
+		$withNull  = pfb_build_autorule_list($existing, $gen, null, null, ['lan'], ['lan']);
+
+		$this->assertSame(
+			$this->shapes($withEmpty),
+			$this->shapes($withNull),
+			'null $order/$float must behave identically to empty-string (regression for the live '
+				. 'TypeError that aborted the update verb when enable_float was unset)'
+		);
+	}
+}

--- a/tests/php/AutoruleListOracleTest.php
+++ b/tests/php/AutoruleListOracleTest.php
@@ -323,8 +323,8 @@ final class AutoruleListOracleTest extends TestCase
 			$descr = $rule['descr'] ?? "(rule {$i})";
 			// Only pfB-generated rules (those from $pfb_generated) get trackers assigned;
 			// user rules pass through without tracker. Skip user rules.
-			if (!str_starts_with($descr, 'pfB_') || str_starts_with($descr, 'pfB_DNS_Redirect_')
-			    || str_starts_with($descr, 'pfB_DoT_Block_')) {
+			if (!str_starts_with($descr, 'pfB_') || str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX)
+			    || str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX)) {
 				continue;
 			}
 			$this->assertArrayHasKey('tracker', $rule,
@@ -349,8 +349,8 @@ final class AutoruleListOracleTest extends TestCase
 			if (!str_starts_with($descr, 'pfB_')) {
 				return TRUE;
 			}
-			return str_starts_with($descr, 'pfB_DNS_Redirect_') ||
-			       str_starts_with($descr, 'pfB_DoT_Block_');
+			return str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
+			       str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
 		};
 
 		$user_in  = array_values(array_filter($input,  $is_user));
@@ -953,6 +953,7 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'pfB_DNS_Redirect_lan_v4',   'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'DNS-redirect bypass rule preserved (not stripped)');
+		$this->assertTrackersSet($result, 'dns-redirect bypass');
 		$this->assertUserRulesPreserved($existing, $result, 'dns-redirect bypass');
 		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'dns-redirect bypass');
 	}
@@ -987,6 +988,7 @@ final class AutoruleListOracleTest extends TestCase
 			['descr' => 'pfB_DoT_Block_lan',         'type' => 'block',  'interface' => 'lan', 'floating' => ''],
 			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
 		], $result, 'DoT-block bypass rule preserved (not stripped)');
+		$this->assertTrackersSet($result, 'dot-block bypass');
 		$this->assertUserRulesPreserved($existing, $result, 'dot-block bypass');
 		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'dot-block bypass');
 	}
@@ -1145,5 +1147,39 @@ final class AutoruleListOracleTest extends TestCase
 			'null $order/$float must behave identically to empty-string (regression for the live '
 				. 'TypeError that aborted the update verb when enable_float was unset)'
 		);
+	}
+
+	/**
+	 * A pfB match rule is floating-only and emitted ONCE across all inbound interfaces (the
+	 * $pfbrunonce gate), carrying $pfb_generated['inbound_floating'] as its interface — not once
+	 * per interface. Pins that emit-once logic, which no fixture above exercises (all leave
+	 * match_inbound empty), so a regression in $pfbrunonce can't slip past the off-appliance suite.
+	 */
+	public function testMatchInboundEmittedOnceAcrossMultipleInterfaces(): void
+	{
+		$existing = [$this->userPassLan()];
+		$gen = $this->pfbGeneratedDenyOnly();
+		$gen['inbound_floating'] = 'lan,opt1';   // the floating interface group set by the package
+		$gen['match_inbound'] = [[
+			'descr'       => 'pfB_DenyList_v4 Auto Rule',
+			'type'        => 'match',
+			'interface'   => '',  // set by helper to inbound_floating
+			'ipprotocol'  => 'inet',
+			'floating'    => 'yes',
+			'source'      => ['address' => 'pfB_DenyList_v4'],
+			'destination' => ['any' => ''],
+			'created'     => ['time' => 0, 'username' => 'Auto'],
+		]];
+
+		// Two inbound interfaces — the match rule must still appear EXACTLY ONCE.
+		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan', 'opt1'], ['lan', 'opt1']);
+
+		$matches = array_values(array_filter($result, static fn (array $r): bool => ($r['type'] ?? '') === 'match'));
+		$this->assertCount(1, $matches,
+			'pfB match rule must be emitted once across all inbound interfaces ($pfbrunonce), got '
+				. count($matches) . ': ' . json_encode($this->shapes($result), JSON_PRETTY_PRINT));
+		$this->assertSame('lan,opt1', $matches[0]['interface'] ?? null,
+			'the match rule carries inbound_floating as its interface');
+		$this->assertUserRulesPreserved($existing, $result, 'match-once');
 	}
 }

--- a/tests/smoke/test_smoke_autorule_immutable.py
+++ b/tests/smoke/test_smoke_autorule_immutable.py
@@ -23,15 +23,23 @@ All tests in this file are marked ``immutable_autorule`` (a Phase-4 gate marker
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
-from tests.smoke import helpers as h
+from . import helpers as h
 
 # ---------------------------------------------------------------------------
 # Pytest marks
 # ---------------------------------------------------------------------------
 
-pytestmark = pytest.mark.immutable_autorule
+# Marked `smoke` so it joins the ADR-04 fan-out, but skipped at module level until ADR-41 Phase 4
+# wires the live fixtures + per-pass_order data-plane sweep (the harness was VM-flaky this session).
+# Phase 4 removes the skip. The off-appliance contract is already pinned in AutoruleListOracleTest.
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.skip(reason="ADR-41 Phase 4: live autorule-immutability wiring pending (see RESULTS/03)"),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -40,12 +48,16 @@ pytestmark = pytest.mark.immutable_autorule
 
 
 def _get_filter_rules(vm: h.SmokeVM) -> list[dict]:
-    """Return config.xml /filter/rule as a Python list of dicts."""
-    php = "require_once('/etc/inc/config.inc');global $config;echo json_encode($config['filter']['rule'] ?? []);"
-    raw = vm.php_eval(php)
-    import json
+    """Return config.xml /filter/rule as a Python list of dicts.
 
-    return json.loads(raw)
+    Uses the proven harness pattern: h.php_eval() runs the snippet via pfSsh.php (config already
+    loaded), and the <<RULES>>..<<END>> delimiters fence the JSON off from pfSsh's banner.
+    """
+    snippet = "echo '<<RULES>>' . json_encode(config_get_path('filter/rule', array())) . '<<END>>';"
+    res = h.php_eval(vm, snippet)
+    if "<<RULES>>" not in res.stdout or "<<END>>" not in res.stdout:
+        raise RuntimeError(f"_get_filter_rules: unexpected output: {res.stdout!r} {res.stderr!r}")
+    return json.loads(res.stdout.split("<<RULES>>", 1)[1].split("<<END>>", 1)[0])
 
 
 def _descr_list(rules: list[dict]) -> list[str]:

--- a/tests/smoke/test_smoke_autorule_immutable.py
+++ b/tests/smoke/test_smoke_autorule_immutable.py
@@ -1,0 +1,268 @@
+"""
+Live-VM oracle: immutable-user-rule splice (ADR-41 Phase 3).
+
+Verifies that pfb_build_autorule_list() applied by sync_package_pfblockerng()
+never drops, duplicates, or reorders user-authored firewall rules across an
+Enable/Force-Update cycle.
+
+LIVE RUN DEFERRED TO PHASE 4
+-----------------------------
+The live-VM harness (ADR-04) proves the on-box pf state after pfBlockerNG reloads;
+Phase 4 is the designated phase for the per-pass_order precedence sweep.
+This file is written in Phase 3 so Phase 4 can extend and execute it without
+rewriting the fixture structure from scratch.
+
+To run manually once Phase 4 is underway (box at 10.0.0.23, NO_TWO_VM=1):
+
+    python -m pytest tests/smoke/test_smoke_autorule_immutable.py \
+        --override-ini="addopts=" -v
+
+All tests in this file are marked ``immutable_autorule`` (a Phase-4 gate marker
+— not yet wired into CI).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.smoke import helpers as h
+
+# ---------------------------------------------------------------------------
+# Pytest marks
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.immutable_autorule
+
+
+# ---------------------------------------------------------------------------
+# Helpers — read the filter-rule list from config.xml on-box
+# ---------------------------------------------------------------------------
+
+
+def _get_filter_rules(vm: h.SmokeVM) -> list[dict]:
+    """Return config.xml /filter/rule as a Python list of dicts."""
+    php = "require_once('/etc/inc/config.inc');global $config;echo json_encode($config['filter']['rule'] ?? []);"
+    raw = vm.php_eval(php)
+    import json
+
+    return json.loads(raw)
+
+
+def _descr_list(rules: list[dict]) -> list[str]:
+    """Extract the 'descr' field from each rule (for readable assertions)."""
+    return [r.get("descr", "") for r in rules]
+
+
+def _user_rules(rules: list[dict]) -> list[dict]:
+    """Filter to non-pfB-owned rules (mirrors the helper's keep logic)."""
+    PFB_BYPASS_PREFIXES = ("pfB_DNS_Redirect_", "pfB_DoT_Block_")
+    out = []
+    for r in rules:
+        descr = r.get("descr", "")
+        if descr.startswith("pfB_") and not any(descr.startswith(p) for p in PFB_BYPASS_PREFIXES):
+            continue
+        out.append(r)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Fixture: ensure pfBlockerNG is enabled with a minimal Deny_* IP list
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def pfb_enabled_deny_only(smoke_vm: h.SmokeVM) -> h.SmokeVM:  # type: ignore[return]
+    """
+    Given:
+        pfBlockerNG enabled, one Deny_* v4 IP list active (RFC-5737 addresses),
+        LAN default-pass rule present (pfSense default).
+    """
+    # Phase 4: wire up h.ensure_pfblockerng_enabled() + a deny-list fixture.
+    # The harness already provides smoke_vm; extend it here.
+    raise NotImplementedError(
+        "Phase 4: wire pfb_enabled_deny_only fixture using h.deploy() + h.write_local_feed() + h.reload()."
+    )
+
+
+# ---------------------------------------------------------------------------
+# T1. User-rule fidelity: LAN pass rule survives a Force-Update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("pfb_enabled_deny_only")
+def test_user_rules_preserved_after_force_update(smoke_vm: h.SmokeVM) -> None:
+    """
+    Scenario: pfBlockerNG Force-Update on an install with a default-pass LAN rule.
+
+    Given:
+        pfBlockerNG active; config.xml has a user 'Default allow LAN to any' pass rule.
+
+    When:
+        pfblockerng.php update  (Force-Update = full reconcile)
+
+    Then:
+        - Every non-pfB-owned rule that existed BEFORE the update still exists AFTER.
+        - No user rule is duplicated (multiset check).
+        - User rules appear in the same relative order (order check).
+
+    Evidence requirement (test-coverage mandate):
+        Assert BEFORE state first, then trigger update, then assert AFTER —
+        never just the final state.
+    """
+    # --- Given ---
+    before = _user_rules(_get_filter_rules(smoke_vm))
+    assert len(before) >= 1, (
+        f"Pre-condition: at least one user rule expected before update.\n"
+        f"Actual rules: {_descr_list(_get_filter_rules(smoke_vm))}"
+    )
+
+    # --- When ---
+    h.reload(smoke_vm)  # Phase 4: replace with h.force_update() once wired.
+
+    # --- Then ---
+    after = _user_rules(_get_filter_rules(smoke_vm))
+
+    assert [r.get("descr") for r in before] == [r.get("descr") for r in after], (
+        "User-rule fidelity failure: non-pfB rules changed across the update.\n"
+        f"\nExpected (before):\n  {_descr_list(before)}"
+        f"\nActual (after):\n  {_descr_list(after)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T2. Idempotence: second Force-Update produces identical rule list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("pfb_enabled_deny_only")
+def test_force_update_is_idempotent(smoke_vm: h.SmokeVM) -> None:
+    """
+    Scenario: two successive Force-Updates produce the same filter-rule list.
+
+    Given:
+        pfBlockerNG active after an initial update.
+
+    When:
+        pfblockerng.php update  (first pass)
+        pfblockerng.php update  (second pass, on own output)
+
+    Then:
+        filter/rule array after pass 2 == filter/rule array after pass 1.
+
+    Covers the idempotence invariant (pfb_build_autorule_list() applied to its own
+    output is a no-op), proven off-appliance in Phase 3 PHPUnit and validated
+    live here.
+    """
+    # --- first update ---
+    h.reload(smoke_vm)  # Phase 4: replace with h.force_update().
+    after_first = _get_filter_rules(smoke_vm)
+
+    # --- second update ---
+    h.reload(smoke_vm)
+    after_second = _get_filter_rules(smoke_vm)
+
+    assert _descr_list(after_first) == _descr_list(after_second), (
+        "Idempotence failure: second update mutated the rule list.\n"
+        f"\nAfter first update:\n  {_descr_list(after_first)}"
+        f"\nAfter second update:\n  {_descr_list(after_second)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T3. pfB-block position: order_0 — pfB rules appear BEFORE user pass (pfB wins)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("pfb_enabled_deny_only")
+def test_order0_pfb_block_before_user_pass(smoke_vm: h.SmokeVM) -> None:
+    """
+    Scenario: pass_order=order_0 (default); pfB block must precede the user pass rule
+    in config.xml (which maps to pf first-match order on the LAN interface).
+
+    Given:
+        pass_order='order_0', one pfB Deny_* block rule, one user pass rule on LAN.
+
+    When:
+        Force-Update applied.
+
+    Then:
+        In the post-update filter/rule list, at least one pfB block rule appears
+        at a lower index than the user pass rule on the same interface.
+
+    Phase 4 note: complement this with a live DNS-block probe to confirm that
+    pfB's block actually wins at the data plane (see ADR-41 §7).
+    """
+    h.reload(smoke_vm)  # Phase 4: set pass_order=order_0 explicitly via h.php_eval().
+    rules = _get_filter_rules(smoke_vm)
+    descrs = _descr_list(rules)
+
+    pfb_block_idx = next(
+        (
+            i
+            for i, r in enumerate(rules)
+            if r.get("descr", "").startswith("pfB_") and r.get("type") in ("block", "reject")
+        ),
+        None,
+    )
+    user_pass_idx = next(
+        (i for i, r in enumerate(rules) if not r.get("descr", "").startswith("pfB_") and r.get("type") == "pass"),
+        None,
+    )
+
+    assert pfb_block_idx is not None, f"No pfB block rule found in filter/rule.\nActual rule descrs:\n  {descrs}"
+    assert user_pass_idx is not None, f"No user pass rule found in filter/rule.\nActual rule descrs:\n  {descrs}"
+    assert pfb_block_idx < user_pass_idx, (
+        f"order_0: pfB block must appear BEFORE user pass (pfB wins).\n"
+        f"pfB block at index {pfb_block_idx}, user pass at index {user_pass_idx}.\n"
+        f"Actual rule descrs:\n  {descrs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T4. pfB-block position: order_1 — user pass appears BEFORE pfB block (user wins)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("pfb_enabled_deny_only")
+def test_order1_user_pass_before_pfb_block(smoke_vm: h.SmokeVM) -> None:
+    """
+    Scenario: pass_order=order_1; the user's pass rule must precede the pfB block.
+
+    Given:
+        pass_order='order_1' (set via h.php_eval()), same fixture as T3.
+
+    When:
+        Force-Update applied.
+
+    Then:
+        The user pass rule appears at a lower index than the first pfB block rule
+        on the same interface.
+
+    Phase 4 note: complement with a live DNS probe to confirm user's pass wins
+    (i.e., a blocked domain resolves when a user allow-pass is first).
+    """
+    # Phase 4: set pass_order=order_1 before reload.
+    h.reload(smoke_vm)
+    rules = _get_filter_rules(smoke_vm)
+    descrs = _descr_list(rules)
+
+    user_pass_idx = next(
+        (i for i, r in enumerate(rules) if not r.get("descr", "").startswith("pfB_") and r.get("type") == "pass"),
+        None,
+    )
+    pfb_block_idx = next(
+        (
+            i
+            for i, r in enumerate(rules)
+            if r.get("descr", "").startswith("pfB_") and r.get("type") in ("block", "reject")
+        ),
+        None,
+    )
+
+    assert user_pass_idx is not None, f"No user pass rule found.\nActual rule descrs:\n  {descrs}"
+    assert pfb_block_idx is not None, f"No pfB block rule found.\nActual rule descrs:\n  {descrs}"
+    assert user_pass_idx < pfb_block_idx, (
+        f"order_1: user pass must appear BEFORE pfB block (user wins).\n"
+        f"User pass at index {user_pass_idx}, pfB block at index {pfb_block_idx}.\n"
+        f"Actual rule descrs:\n  {descrs}"
+    )


### PR DESCRIPTION
## ADR-41: Immutable user firewall rules in the IP autorule reconciliation

Stops the IP-side autorule pass from ever mutating the user's own `filter/rule` entries. Today's reconciliation strips every rule and **rebuilds the whole list, re-bucketing user rules** through per-interface loops — which can silently **drop** (empty `pass_order`, #532), **duplicate** (order_1/2, shared in/out interface — one rule became eight over three reloads on a live VM), and **reorder** (order_4) the user's rules. This replaces it with: **keep user rules verbatim, splice pfBlockerNG's own rules at a single anchor.** Drop/dup/reorder become impossible by construction.

### How
`pfb_build_autorule_list()` now builds `keep` = the live `filter/rule` minus only the pfB-owned rules this region regenerates (descr `pfB_`, **excluding** the DNS-redirect/DoT bypass rules, kept like user rules), in **original order**; generates the pfB rules unchanged; and splices them as one contiguous block at a **single anchor**. The anchor is **binary** — pf is per-interface first-match (`quick`), so the only user-visible interaction is pfB-block-vs-user-**pass**:

- `order_0`/`order_3`/`order_4`/absent/unknown → pfB block **before** the kept user rules (pfB wins; absent→order_0 subsumes #539)
- `order_1`/`order_2` → pfB block **after** the kept user rules (user pass wins)

All bucketing / `$permit_rules` / per-interface user re-emission is deleted.

### Why this is sound (the kill-gate)
ADR-41 carries a falsifiable premise — "a single contiguous anchor per `pass_order` reproduces the intended precedence without splitting user rules." Phase 2 proved it on **live pf** before any rewrite (`RESULTS/02`): interface rules carry `quick` ⇒ first-match per interface ⇒ pass-vs-pass and block-vs-block orderings are moot, so the 4-way ORDER table collapses to the binary anchor above. **Verdict: GO.**

### Tests (red→green, off-appliance)
`AutoruleListOracleTest` (22 tests) asserts the **contract** — user-rule fidelity (multiset + order), pfB-rule-set identical, idempotence. Proven **red on the old bucketing helper** (8 failures = order_1/2 dup + order_4 reorder/drop) and **green on the new splice**. Full PHPUnit / PHPCS / PHPStan / php -l green.

### Deliberate behaviour change (release notes)
`order_4` (and the old managed/non-managed split) no longer **reorders** the user's own rules — they're kept verbatim. Functionally inert under per-interface first-match, but some installs' `config.xml` rule order changes on `order_1`/`order_2`/`order_4`.

### Status / remaining
**Implemented (pending live-VM smoke).** The off-appliance contract + the pf-precedence kill-gate are done. The live data-plane precedence fan-out (CE + Plus) — `tests/smoke/test_smoke_autorule_immutable.py`, currently `[smoke, skip]` pending Phase-4 wiring — is the one remaining acceptance item before the ADR flips to **Accepted**. Deferred this session because the live VM was flaky (a state-flushing reload transiently cut the harness SSH; see `RESULTS/02 §7`).

Part of #532 (structurally eliminates its drop, plus the order_1/2 dup and order_4 reorder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
