### PR TITLE
pfblockerng: DoT/DoQ block — Reject default, Rule Action selector, opt-in Floating Rule

### DIFF
--- a/.ADRs/ADR_37_DoT_DoQ_Block/ADR.md
+++ b/.ADRs/ADR_37_DoT_DoQ_Block/ADR.md
@@ -6,8 +6,9 @@
 - **Folds in maintainer's working config** (config.xml filter "Block DNS-over-TLS (DoT)" —
   ground truth for the exact rule shape; see §2.2)
 - **Component(s):** `src/usr/local/pkg/pfblockerng/pfblockerng.inc` (rule builder + sync
-  wiring), `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` (PfbConfig registry — 3 new
-  fields), `src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc` (ADR-35 registration),
+  wiring), `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` (PfbConfig registry — 4 new
+  fields, incl. `dnsbl_dot_block_action`; see Addendum 2026-06-25),
+  `src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc` (ADR-35 registration),
   `src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php` (UI control block)
 - **Target runtime:** PHP 8.3 (pfSense CE 2.8)
 - **Test suite:** `tests/php/` (PHPUnit, off-appliance), `tests/smoke/` (ADR-04 live-VM),
@@ -25,6 +26,19 @@
 > `inet46` `filter/rule` per interface, carrying a deterministic managed-rule tracker so the GUI can
 > manage it and change-detection doesn't churn. The "Depends on: ADR-35" and `pfblockerng_fwobj.inc`
 > references above are historical; the object-shape decisions in §2 still hold and are what ships.
+>
+> **Addendum (2026-06-25) — rule action is now selectable; default Reject.** The DoT/DoQ block
+> rules are outbound (LAN→WAN) rules. The original shape hardcoded `type=block` (a silent drop),
+> but pfBlockerNG's own outbound deny auto-rules default to **Reject** (`outbound_deny_action`,
+> IP settings) so the client fast-fails to plain DNS instead of letting the encrypted-DNS
+> connection hang until timeout. The rules now **default to Reject** and expose a user-selectable
+> **Rule Action** (Block | Reject) on the DNSBL settings page, mirroring the inbound/outbound Rule
+> Action selector on the IP settings page. This adds a **fourth** registered field,
+> `dnsbl_dot_block_action` (default `'reject'`). The `<type>block</type>` invariant in §2.2 is
+> superseded accordingly — see the updated invariant there. Because the feature is unreleased
+> (4.0.0 alpha), the absent-key default flips existing alpha installs to Reject on upgrade with no
+> grandfather seed: there was no user-chosen disposition to preserve (the prior value was an
+> implicit hardcode), and Reject is the corrected default the change exists to establish.
 
 ## 1. Context
 
@@ -95,7 +109,8 @@ and removed through the ADR-35 seam. No ADR-35 marker/teardown logic is re-inven
 | Rule count per interface | 1 filter BLOCK rule per selected interface (not 4 like ADR-36 — no NAT, no associated filter; just the single block rule). |
 | Ownership + lifecycle | Each rule carries a pfBlockerNG descr marker (`pfB_DoT_Block_<iface>` — exact naming confirmed at implementation time against the `pfB_` codebase convention). Registered via `pfb_fwobj_register()` per ADR-35. Created/reconciled idempotently on `sync_package_pfblockerng()`; removed on disable; swept on uninstall via `pfb_fwobj_sweep()`. |
 | Reconcile (stale-interface pruning) | On each sync, rules for interfaces no longer in the selected set are pruned by the marker sweep. An interface removed from config is treated as absent. |
-| Config fields | 3 new registered `PfbConfig` fields in `pfblockerngdnsblsettings/config/0` (see §2.2). ADR-29 5-step adding process. |
+| Config fields | 4 new registered `PfbConfig` fields in `pfblockerngdnsblsettings/config/0` (see §2.2). The fourth, `dnsbl_dot_block_action` (Rule Action; default `reject`), was added in the Addendum 2026-06-25. ADR-29 5-step adding process. |
+| Rule action (disposition) | **Reject by default**, user-selectable Block \| Reject (Addendum 2026-06-25). These are outbound LAN→WAN rules, so Reject matches `outbound_deny_action` and fast-fails the client to plain DNS; Block silently drops. |
 | UI location | DNSBL settings page (`pfblockerng_dnsbl.php`) — new control block adjacent to ADR-36's redirect control and the existing DoH/DoT/DoQ blocking section. Enable checkbox + interface multi-select + quick-fill + optional exception-alias field + brief help text. Server-side PFBL-01 validation before any rule build. |
 | Naming (config keys + marker) | **Provisional** — follow the `dnsbl_*` / `*_int` sibling convention beside `dnsbl_allow_int` and the ADR-36 keys: `dnsbl_dot_block` (enable toggle), `dnsbl_dot_block_int` (interface list), `dnsbl_dot_block_exclude` (exception alias). Final names aligned with the maintainer before keys are frozen (CLAUDE.md "Naming — follow the established pattern"; storage freeze applies once chosen). |
 | Complementary features | Port-853 block + ADR-36 port-53 redirect together close the standard-port bypass paths. Port 443 DoH is handled by the DoH-IP feed (IP-alias layer) and DNSBL domain blocking — not by this ADR. |
@@ -107,7 +122,7 @@ mandatory and exactly matched):
 
 ```xml
 <rule>                                          <!-- filter/rule -->
-  <type>block</type>
+  <type>reject</type>                           <!-- default; 'block' selectable (Addendum 2026-06-25) -->
   <interface>lan</interface>                    <!-- one rule per selected interface -->
   <ipprotocol>inet46</ipprotocol>              <!-- single rule covers IPv4 + IPv6 -->
   <protocol>tcp/udp</protocol>                 <!-- DoT (TCP 853) + DoQ (UDP 853) -->
@@ -125,7 +140,9 @@ mandatory and exactly matched):
 
 Invariants (each asserted by PHPUnit tests with full branch coverage):
 
-- **Type is always `block`.** No generated rule has any other type.
+- **Type follows the Rule Action setting** (Addendum 2026-06-25): `reject` by default, `block`
+  when the user selects it. No generated rule has any other type; an unknown/absent stored value
+  resolves to the Reject default. Both dispositions are asserted by PHPUnit branch-coverage tests.
 - **`ipprotocol` is always `inet46`.** One rule covers both families; no per-family split.
 - **`protocol` is always `tcp/udp`.** Covers both DoT (TCP) and DoQ (UDP) in one rule.
 - **Destination is always negated `(self)` with port 853** — the firewall-self-exempt is
@@ -222,9 +239,11 @@ designed to be upgraded to floating cleanly (a single field change in the rule a
   (set/empty), and number of interfaces.
 - The builder registered via `pfb_fwobj_register()` (ADR-35); create/reconcile/remove/sweep
   wired into `sync_package_pfblockerng()` and the disable/uninstall paths.
-- Three new `PfbConfig`-registered fields: `dnsbl_dot_block` (toggle), `dnsbl_dot_block_int`
-  (plain string), `dnsbl_dot_block_exclude` (plain string) — ADR-29 5-step process, including
-  `CfgGatewayTest.php` round-trip tests + inventory update + `$registeredPaths` in the sniff.
+- Four new `PfbConfig`-registered fields: `dnsbl_dot_block` (toggle), `dnsbl_dot_block_int`
+  (plain string), `dnsbl_dot_block_exclude` (plain string), and `dnsbl_dot_block_action` (plain
+  string, `block` | `reject`, default `reject` — Addendum 2026-06-25) — ADR-29 5-step process,
+  including `CfgGatewayTest.php` round-trip tests + inventory update + `$registeredPaths` in the
+  sniff.
 - UI control block on `pfblockerng_dnsbl.php`: enable checkbox + interface multi-select +
   quick-fill + exception-alias field + help text (noting DoH/443 is handled by the DoH-IP feed,
   not this control); server-side PFBL-01 validation.

--- a/.ADRs/ADR_37_DoT_DoQ_Block/ADR.md
+++ b/.ADRs/ADR_37_DoT_DoQ_Block/ADR.md
@@ -6,8 +6,8 @@
 - **Folds in maintainer's working config** (config.xml filter "Block DNS-over-TLS (DoT)" —
   ground truth for the exact rule shape; see §2.2)
 - **Component(s):** `src/usr/local/pkg/pfblockerng/pfblockerng.inc` (rule builder + sync
-  wiring), `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` (PfbConfig registry — 4 new
-  fields, incl. `dnsbl_dot_block_action`; see Addendum 2026-06-25),
+  wiring), `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` (PfbConfig registry — 5 new
+  fields, incl. `dnsbl_dot_block_action` + `dnsbl_dot_block_floating`; see Addendum 2026-06-25),
   `src/usr/local/pkg/pfblockerng/pfblockerng_fwobj.inc` (ADR-35 registration),
   `src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php` (UI control block)
 - **Target runtime:** PHP 8.3 (pfSense CE 2.8)
@@ -39,6 +39,15 @@
 > (4.0.0 alpha), the absent-key default flips existing alpha installs to Reject on upgrade with no
 > grandfather seed: there was no user-chosen disposition to preserve (the prior value was an
 > implicit hardcode), and Reject is the corrected default the change exists to establish.
+>
+> The same addendum adds the **Floating Rule** option (`dnsbl_dot_block_floating`, toggle,
+> default off) — the "future maintainer decision moves to floating" path anticipated in the
+> §3 alternative below. **On** builds a **single floating rule** (`floating=yes`, `quick=yes`,
+> **`direction=in`** — explicitly set, per that note) over all selected interfaces, with the
+> shared `pfB_DoT_Block_Floating` marker; **off** keeps the per-interface default. The action
+> (Reject/Block), interface selection, and exception alias apply unchanged in both modes. The
+> sync reconcile prunes the other mode's rule(s) when the toggle flips. This brings the field
+> count to **five**.
 
 ## 1. Context
 
@@ -109,8 +118,9 @@ and removed through the ADR-35 seam. No ADR-35 marker/teardown logic is re-inven
 | Rule count per interface | 1 filter BLOCK rule per selected interface (not 4 like ADR-36 — no NAT, no associated filter; just the single block rule). |
 | Ownership + lifecycle | Each rule carries a pfBlockerNG descr marker (`pfB_DoT_Block_<iface>` — exact naming confirmed at implementation time against the `pfB_` codebase convention). Registered via `pfb_fwobj_register()` per ADR-35. Created/reconciled idempotently on `sync_package_pfblockerng()`; removed on disable; swept on uninstall via `pfb_fwobj_sweep()`. |
 | Reconcile (stale-interface pruning) | On each sync, rules for interfaces no longer in the selected set are pruned by the marker sweep. An interface removed from config is treated as absent. |
-| Config fields | 4 new registered `PfbConfig` fields in `pfblockerngdnsblsettings/config/0` (see §2.2). The fourth, `dnsbl_dot_block_action` (Rule Action; default `reject`), was added in the Addendum 2026-06-25. ADR-29 5-step adding process. |
+| Config fields | 5 new registered `PfbConfig` fields in `pfblockerngdnsblsettings/config/0` (see §2.2). The fourth (`dnsbl_dot_block_action`, Rule Action; default `reject`) and fifth (`dnsbl_dot_block_floating`, Floating Rule; default off) were added in the Addendum 2026-06-25. ADR-29 5-step adding process. |
 | Rule action (disposition) | **Reject by default**, user-selectable Block \| Reject (Addendum 2026-06-25). These are outbound LAN→WAN rules, so Reject matches `outbound_deny_action` and fast-fails the client to plain DNS; Block silently drops. |
+| Rule mode | **Per-interface by default** (one rule per selected interface). Opt-in **Floating Rule** (Addendum 2026-06-25) builds a single floating rule (`floating=yes`, `quick=yes`, `direction=in`) over all selected interfaces instead. Marker `pfB_DoT_Block_Floating`. |
 | UI location | DNSBL settings page (`pfblockerng_dnsbl.php`) — new control block adjacent to ADR-36's redirect control and the existing DoH/DoT/DoQ blocking section. Enable checkbox + interface multi-select + quick-fill + optional exception-alias field + brief help text. Server-side PFBL-01 validation before any rule build. |
 | Naming (config keys + marker) | **Provisional** — follow the `dnsbl_*` / `*_int` sibling convention beside `dnsbl_allow_int` and the ADR-36 keys: `dnsbl_dot_block` (enable toggle), `dnsbl_dot_block_int` (interface list), `dnsbl_dot_block_exclude` (exception alias). Final names aligned with the maintainer before keys are frozen (CLAUDE.md "Naming — follow the established pattern"; storage freeze applies once chosen). |
 | Complementary features | Port-853 block + ADR-36 port-53 redirect together close the standard-port bypass paths. Port 443 DoH is handled by the DoH-IP feed (IP-alias layer) and DNSBL domain blocking — not by this ADR. |
@@ -232,6 +242,13 @@ If a future maintainer decision moves to floating, the direction MUST be set exp
 and the smoke test MUST verify the pf rule is active and effective. The block-rule builder is
 designed to be upgraded to floating cleanly (a single field change in the rule array).
 
+**Update (Addendum 2026-06-25): floating is now an opt-in option, not the default.** Rather than
+choosing one model, the **Floating Rule** toggle (`dnsbl_dot_block_floating`, default off) lets the
+user pick: off keeps the safe per-interface default; on builds the single floating rule with
+`direction=in` set explicitly (honouring the requirement above), verified by a live-VM smoke case
+(`test_dot_doq_block_floating_mode_single_rule`). The per-interface model remains the default
+precisely because of the direction footgun described above.
+
 ## 4. Requirements (acceptance)
 
 - A pure `pfb_build_dot_block_rule($settings)` builder function returning the exact rule array
@@ -239,11 +256,11 @@ designed to be upgraded to floating cleanly (a single field change in the rule a
   (set/empty), and number of interfaces.
 - The builder registered via `pfb_fwobj_register()` (ADR-35); create/reconcile/remove/sweep
   wired into `sync_package_pfblockerng()` and the disable/uninstall paths.
-- Four new `PfbConfig`-registered fields: `dnsbl_dot_block` (toggle), `dnsbl_dot_block_int`
-  (plain string), `dnsbl_dot_block_exclude` (plain string), and `dnsbl_dot_block_action` (plain
-  string, `block` | `reject`, default `reject` — Addendum 2026-06-25) — ADR-29 5-step process,
-  including `CfgGatewayTest.php` round-trip tests + inventory update + `$registeredPaths` in the
-  sniff.
+- Five new `PfbConfig`-registered fields: `dnsbl_dot_block` (toggle), `dnsbl_dot_block_int`
+  (plain string), `dnsbl_dot_block_exclude` (plain string), `dnsbl_dot_block_action` (plain
+  string, `block` | `reject`, default `reject`), and `dnsbl_dot_block_floating` (toggle, default
+  off — both Addendum 2026-06-25) — ADR-29 5-step process, including `CfgGatewayTest.php`
+  round-trip tests + inventory update + `$registeredPaths` in the sniff.
 - UI control block on `pfblockerng_dnsbl.php`: enable checkbox + interface multi-select +
   quick-fill + exception-alias field + help text (noting DoH/443 is handled by the DoH-IP feed,
   not this control); server-side PFBL-01 validation.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -339,6 +339,11 @@ define('PFB_DNS_REDIR_DESCR_V4_SFX', '_v4');
 define('PFB_DNS_REDIR_DESCR_V6_SFX', '_v6');
 // Descr prefix for DoT/DoQ block filter rules. Pattern: pfB_DoT_Block_<iface>
 define('PFB_DOT_BLOCK_DESCR_PFX', 'pfB_DoT_Block_');
+// Descr marker for the single floating DoT/DoQ block rule (floating mode). Carries the
+// shared prefix so the disable/uninstall sweep removes it like the per-interface rules.
+// 'Floating' is never a real (WAN-excluded) interface key, so it cannot collide with a
+// per-interface marker.
+define('PFB_DOT_BLOCK_FLOATING_DESCR', PFB_DOT_BLOCK_DESCR_PFX . 'Floating');
 
 // Returns TRUE iff $descr indicates pfBlockerNG ownership.
 // Recognised patterns (UNION — any one match → owned):
@@ -511,6 +516,33 @@ function pfb_dot_block_rule(string $iface, string $exclude_alias, string $action
 		'destination' => ['network' => '(self)', 'not' => '', 'port' => '853'],
 		'statetype'   => 'keep state',
 		'descr'       => PFB_DOT_BLOCK_DESCR_PFX . $iface,
+	];
+}
+
+// Build the SINGLE floating DoT/DoQ block filter/rule covering all selected $ifaces in
+// one rule (floating mode), instead of one rule per interface. $action is the disposition
+// ('block' | 'reject', default Reject via pfb_dot_block_action()). The rule is floating +
+// quick with direction 'in' (matches client egress entering the firewall on the selected
+// interfaces — the direction ADR-37 mandates for a floating variant) and carries the same
+// negated-(self):853 destination + optional exception-alias source as the per-interface
+// rule. The caller appends the 'tracker' (last key) after build.
+function pfb_dot_block_floating_rule(array $ifaces, string $exclude_alias, string $action): array {
+	$source = ($exclude_alias !== '')
+		? ['address' => $exclude_alias, 'not' => '']
+		: ['any' => ''];
+
+	return [
+		'type'        => pfb_dot_block_action($action),
+		'interface'   => implode(',', $ifaces),
+		'floating'    => 'yes',
+		'quick'       => 'yes',
+		'direction'   => 'in',
+		'ipprotocol'  => 'inet46',
+		'protocol'    => 'tcp/udp',
+		'source'      => $source,
+		'destination' => ['network' => '(self)', 'not' => '', 'port' => '853'],
+		'statetype'   => 'keep state',
+		'descr'       => PFB_DOT_BLOCK_FLOATING_DESCR,
 	];
 }
 
@@ -14028,10 +14060,12 @@ function sync_package_pfblockerng($cron='') {
 				$dot_changed = TRUE;
 			}
 		} else {
-			// ENABLED: read interfaces (comma-separated), exception alias, rule action.
+			// ENABLED: read interfaces (comma-separated), exception alias, rule action, floating mode.
 			$dot_iface_raw    = (string) PfbConfig::read('dnsbl_dot_block_int');
 			$dot_exclude_alias = trim((string) PfbConfig::read('dnsbl_dot_block_exclude'));
 			$dot_action       = pfb_dot_block_action((string) PfbConfig::read('dnsbl_dot_block_action'));
+			$dot_floating_cfg = PfbConfig::read('dnsbl_dot_block_floating');
+			$dot_floating     = ($dot_floating_cfg instanceof PfbToggle && $dot_floating_cfg === PfbToggle::On);
 
 			$dot_ifaces_raw = array_filter(array_map('trim', explode(',', $dot_iface_raw)), 'strlen');
 			$dot_ifaces     = [];
@@ -14053,10 +14087,17 @@ function sync_package_pfblockerng($cron='') {
 					$dot_changed = TRUE;
 				}
 			} else {
-				// Build the expected marker set for the current iface set.
-				$dot_expected_descrs = [];
-				foreach ($dot_ifaces as $dot_iface) {
-					$dot_expected_descrs[] = PFB_DOT_BLOCK_DESCR_PFX . $dot_iface;
+				// Build the expected marker set for the current mode. Floating mode owns a
+				// single marker (one rule for all interfaces); per-interface mode owns one
+				// marker per interface. The stale-prune below removes any owned row not in
+				// this set — so switching modes drops the other mode's rule(s) automatically.
+				if ($dot_floating) {
+					$dot_expected_descrs = [PFB_DOT_BLOCK_FLOATING_DESCR];
+				} else {
+					$dot_expected_descrs = [];
+					foreach ($dot_ifaces as $dot_iface) {
+						$dot_expected_descrs[] = PFB_DOT_BLOCK_DESCR_PFX . $dot_iface;
+					}
 				}
 
 				// Stale-interface prune: remove pfB_DoT_Block_* rows no longer in the expected set.
@@ -14097,16 +14138,24 @@ function sync_package_pfblockerng($cron='') {
 					}
 				}
 
-				// Build new DoT/DoQ block filter rules for each interface. The rule
-				// shape (incl. the configurable block/reject disposition) is built by
-				// pfb_dot_block_rule(); the deterministic tracker is appended here
-				// (last key) so the change-detection compare below stays stable.
+				// Build the new owned rule(s). The rule shape (incl. the configurable
+				// block/reject disposition) is built by the per-mode builder; the
+				// deterministic tracker is appended here (last key) so the change-detection
+				// compare below stays stable. Floating mode = one rule for all interfaces;
+				// per-interface mode = one rule each.
 				$dot_new_owned = [];
-				foreach ($dot_ifaces as $dot_iface) {
-					$dot_descr = PFB_DOT_BLOCK_DESCR_PFX . $dot_iface;
-					$dot_rule  = pfb_dot_block_rule($dot_iface, $dot_exclude_alias, $dot_action);
+				if ($dot_floating) {
+					$dot_descr = PFB_DOT_BLOCK_FLOATING_DESCR;
+					$dot_rule  = pfb_dot_block_floating_rule($dot_ifaces, $dot_exclude_alias, $dot_action);
 					$dot_rule['tracker'] = $dot_existing_trackers[$dot_descr] ?? (string) pfb_managed_rule_tracker($dot_descr);
 					$dot_new_owned[] = $dot_rule;
+				} else {
+					foreach ($dot_ifaces as $dot_iface) {
+						$dot_descr = PFB_DOT_BLOCK_DESCR_PFX . $dot_iface;
+						$dot_rule  = pfb_dot_block_rule($dot_iface, $dot_exclude_alias, $dot_action);
+						$dot_rule['tracker'] = $dot_existing_trackers[$dot_descr] ?? (string) pfb_managed_rule_tracker($dot_descr);
+						$dot_new_owned[] = $dot_rule;
+					}
 				}
 
 				if ($dot_ex_owned !== $dot_new_owned) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -446,14 +446,28 @@ function pfb_validate_dns_redirect_post(
 	return $errors;
 }
 
+// The two valid dispositions for a DoT/DoQ block rule. 'reject' is the default
+// (an outbound LAN->WAN block, so Reject fast-fails the client to plain DNS rather
+// than letting the encrypted-DNS connection hang); 'block' silently drops. Mirrors
+// the inbound/outbound Rule Action selector on the IP settings page.
+define('PFB_DOT_BLOCK_ACTION_DEFAULT', 'reject');
+
+// Normalise a stored/posted DoT/DoQ-block action to one of the two valid
+// dispositions. Any unknown/empty value falls back to the default ('reject').
+function pfb_dot_block_action(string $action): string {
+	return ($action === 'block') ? 'block' : PFB_DOT_BLOCK_ACTION_DEFAULT;
+}
+
 // Validate the DoT/DoQ-block fields submitted via the DNSBL settings POST form.
 // Each interface name is checked against the allow-list; the exception alias is
-// validated by is_validaliasname() when non-empty.
+// validated by is_validaliasname() when non-empty; the rule action must be one of
+// the two known dispositions ('block' | 'reject').
 // Returns an array of validation error messages (empty = all inputs valid).
 function pfb_validate_dot_block_post(
 	array $posted_ifaces,
 	array $valid_iface_list,
-	string $posted_alias
+	string $posted_alias,
+	string $posted_action = PFB_DOT_BLOCK_ACTION_DEFAULT
 ): array {
 	$errors = [];
 	foreach ($posted_ifaces as $iface) {
@@ -468,7 +482,36 @@ function pfb_validate_dot_block_post(
 				htmlspecialchars($posted_alias, ENT_QUOTES);
 		}
 	}
+	if (!in_array($posted_action, ['block', 'reject'], TRUE)) {
+		$errors[] = 'DoT/DoQ Block: Invalid rule action: ' .
+			htmlspecialchars($posted_action, ENT_QUOTES);
+	}
 	return $errors;
+}
+
+// Build a single DoT/DoQ block filter/rule array for $iface. $action is the rule
+// disposition ('block' | 'reject'); any other value falls back to the default
+// (Reject) via pfb_dot_block_action(). When $exclude_alias is non-empty it becomes a
+// negated source so listed hosts bypass the block; empty -> source 'any'. The
+// destination is always the firewall itself ('(self)') on port 853, negated so the
+// box's own resolver is exempt. The caller assigns the 'tracker' (last key) after
+// build, preserving the stored key order so the sync change-detection compare stays
+// stable when nothing changed.
+function pfb_dot_block_rule(string $iface, string $exclude_alias, string $action): array {
+	$source = ($exclude_alias !== '')
+		? ['address' => $exclude_alias, 'not' => '']
+		: ['any' => ''];
+
+	return [
+		'type'        => pfb_dot_block_action($action),
+		'interface'   => $iface,
+		'ipprotocol'  => 'inet46',
+		'protocol'    => 'tcp/udp',
+		'source'      => $source,
+		'destination' => ['network' => '(self)', 'not' => '', 'port' => '853'],
+		'statetype'   => 'keep state',
+		'descr'       => PFB_DOT_BLOCK_DESCR_PFX . $iface,
+	];
 }
 
 // Allowlist the alias-type suffix ($vtype) before it is interpolated into an
@@ -13985,9 +14028,10 @@ function sync_package_pfblockerng($cron='') {
 				$dot_changed = TRUE;
 			}
 		} else {
-			// ENABLED: read interfaces (comma-separated) and exception alias.
+			// ENABLED: read interfaces (comma-separated), exception alias, rule action.
 			$dot_iface_raw    = (string) PfbConfig::read('dnsbl_dot_block_int');
 			$dot_exclude_alias = trim((string) PfbConfig::read('dnsbl_dot_block_exclude'));
+			$dot_action       = pfb_dot_block_action((string) PfbConfig::read('dnsbl_dot_block_action'));
 
 			$dot_ifaces_raw = array_filter(array_map('trim', explode(',', $dot_iface_raw)), 'strlen');
 			$dot_ifaces     = [];
@@ -14053,24 +14097,16 @@ function sync_package_pfblockerng($cron='') {
 					}
 				}
 
-				// Build new DoT/DoQ block filter rules for each interface.
+				// Build new DoT/DoQ block filter rules for each interface. The rule
+				// shape (incl. the configurable block/reject disposition) is built by
+				// pfb_dot_block_rule(); the deterministic tracker is appended here
+				// (last key) so the change-detection compare below stays stable.
 				$dot_new_owned = [];
 				foreach ($dot_ifaces as $dot_iface) {
-					$dot_descr  = PFB_DOT_BLOCK_DESCR_PFX . $dot_iface;
-					$dot_source = ($dot_exclude_alias !== '')
-						? ['address' => $dot_exclude_alias, 'not' => '']
-						: ['any' => ''];
-					$dot_new_owned[] = [
-						'type'        => 'block',
-						'interface'   => $dot_iface,
-						'ipprotocol'  => 'inet46',
-						'protocol'    => 'tcp/udp',
-						'source'      => $dot_source,
-						'destination' => ['network' => '(self)', 'not' => '', 'port' => '853'],
-						'statetype'   => 'keep state',
-						'descr'       => $dot_descr,
-						'tracker'     => $dot_existing_trackers[$dot_descr] ?? (string) pfb_managed_rule_tracker($dot_descr),
-					];
+					$dot_descr = PFB_DOT_BLOCK_DESCR_PFX . $dot_iface;
+					$dot_rule  = pfb_dot_block_rule($dot_iface, $dot_exclude_alias, $dot_action);
+					$dot_rule['tracker'] = $dot_existing_trackers[$dot_descr] ?? (string) pfb_managed_rule_tracker($dot_descr);
+					$dot_new_owned[] = $dot_rule;
 				}
 
 				if ($dot_ex_owned !== $dot_new_owned) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -66,6 +66,14 @@ trait PfbStoredEnumAdapter
 {
 	public static function fromStored(mixed $stored): static
 	{
+		// Idempotency: a value already adapted to this enum (e.g. a PfbConfig::read()
+		// result fed back through the read adapter) returns itself. Without this, the
+		// non-scalar guard below would collapse a valid enum to default() — a double-apply
+		// footgun that silently mis-rendered toggle checkboxes (always-unchecked) on the
+		// settings pages.
+		if ($stored instanceof static) {
+			return $stored;
+		}
 		if (!is_scalar($stored) && $stored !== NULL) {
 			return static::default();		// subtree / non-scalar guard
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1015,6 +1015,17 @@ function pfb_cfg_registry(): array
 			'since'         => '4.0.0',
 		],
 
+		// ADR-37: DoT/DoQ block floating mode: 'on' | '' (checkbox). Default '' (off).
+		// On = a single floating rule (direction 'in') over the selected interfaces
+		// instead of one rule per interface. Off preserves the per-interface default.
+		'dnsbl_dot_block_floating' => [
+			'section'       => $dnsbl,
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'since'         => '4.0.0',
+		],
+
 		// -------------------------------------------------------------------
 		// ADR-38: syslog export settings (General / Log Settings section, $gen)
 		// -------------------------------------------------------------------

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1004,6 +1004,17 @@ function pfb_cfg_registry(): array
 			'since'         => '4.0.0',
 		],
 
+		// ADR-37: DoT/DoQ block rule action: 'reject' (default) | 'block'.
+		// Mirrors the IP-settings inbound/outbound Rule Action selector. Reject
+		// fast-fails the client (outbound LAN->WAN rule); block silently drops.
+		'dnsbl_dot_block_action' => [
+			'section'       => $dnsbl,
+			'default'       => 'reject',
+			'read_adapter'  => NULL,
+			'write_adapter' => NULL,
+			'since'         => '4.0.0',
+		],
+
 		// -------------------------------------------------------------------
 		// ADR-38: syslog export settings (General / Log Settings section, $gen)
 		// -------------------------------------------------------------------

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -134,6 +134,7 @@ $pconfig['dnsbl_dot_block']		= PfbConfig::read('dnsbl_dot_block');
 $pfb_dot_block_int_raw			= (string) PfbConfig::read('dnsbl_dot_block_int');
 $pconfig['dnsbl_dot_block_int']		= ($pfb_dot_block_int_raw !== '') ? explode(',', $pfb_dot_block_int_raw) : [];
 $pconfig['dnsbl_dot_block_exclude']	= (string) PfbConfig::read('dnsbl_dot_block_exclude');
+$pconfig['dnsbl_dot_block_action']	= (string) PfbConfig::read('dnsbl_dot_block_action');
 
 // Select field options
 
@@ -148,6 +149,9 @@ $options_dnsbl_redir_int	= $options_dnsbl_interface;
 
 // [ ADR-37 ] DoT/DoQ Block: WAN-excluded interface list (same filter as Permit Firewall Rules).
 $options_dnsbl_dot_block_int	= $options_dnsbl_interface;
+
+// [ ADR-37 ] DoT/DoQ Block: rule action selector (mirrors the IP-settings Rule Action).
+$options_dnsbl_dot_block_action	= [ 'block' => 'Block', 'reject' => 'Reject' ];
 
 $options_global_log_txt = 'Default: <strong>No Global mode</strong><br />'
 			. 'Enabling this option will override the individual DNSBL Group "Logging/Blocking" settings!<br /><br />'
@@ -735,10 +739,12 @@ if ($_POST) {
 		// Validate DoT/DoQ Block fields.
 		$dot_block_ifaces_raw = (array)($_POST['dnsbl_dot_block_int'] ?? []);
 		$dot_block_alias_raw  = trim((string)($_POST['dnsbl_dot_block_exclude'] ?? ''));
+		$dot_block_action_raw = (string)($_POST['dnsbl_dot_block_action'] ?? 'reject');
 		$dot_block_errors     = pfb_validate_dot_block_post(
 			$dot_block_ifaces_raw,
 			array_keys($options_dnsbl_dot_block_int),
-			$dot_block_alias_raw
+			$dot_block_alias_raw,
+			$dot_block_action_raw
 		);
 		$input_errors = array_merge($input_errors, $dot_block_errors);
 
@@ -868,6 +874,7 @@ if ($_POST) {
 			PfbConfig::write('dnsbl_dot_block', pfb_filter($_POST['dnsbl_dot_block'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '');
 			PfbConfig::write('dnsbl_dot_block_int', implode(',', $dot_block_ifaces_raw));
 			PfbConfig::write('dnsbl_dot_block_exclude', $dot_block_alias_raw);
+			PfbConfig::write('dnsbl_dot_block_action', pfb_dot_block_action($dot_block_action_raw));
 
 			PfbConfig::writeSection('installedpackages/pfblockerngdnsblsettings/config/0', $pfb['dconfig']);
 			write_config('[pfBlockerNG] save DNSBL settings');
@@ -2901,6 +2908,16 @@ $section->addInput(new Form_Input(
 	['placeholder' => 'Firewall alias name (optional)']
 ))->setHelp('Optional. Name of an existing Firewall Alias. Hosts/subnets in this alias bypass the DoT/DoQ block.<br />'
 		. 'The alias must be created separately at <a href="/firewall_aliases.php" target="_blank">Firewall &gt; Aliases</a>.');
+
+$section->addInput(new Form_Select(
+	'dnsbl_dot_block_action',
+	gettext('Rule Action'),
+	pfb_dot_block_action($pconfig['dnsbl_dot_block_action']),
+	$options_dnsbl_dot_block_action
+))->setHelp('Default: <strong>Reject</strong><br />'
+		. 'Select the action for the DoT/DoQ block rules. <strong>Reject</strong> fast-fails the client '
+		. '(so it falls back to plain DNS) while <strong>Block</strong> silently drops the connection.')
+  ->setAttribute('style', 'width: auto');
 
 $form->add($section);
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -539,7 +539,8 @@ if ($_POST) {
 						'autoproto_in'		=> 'any',
 						'autoproto_out'		=> 'any',
 						'agateway_in'		=> 'default',
-						'agateway_out'		=> 'default'
+						'agateway_out'		=> 'default',
+						'dnsbl_dot_block_action'=> 'reject'
 						);
 
 		foreach ($select_options as $s_option => $s_default) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -135,6 +135,7 @@ $pfb_dot_block_int_raw			= (string) PfbConfig::read('dnsbl_dot_block_int');
 $pconfig['dnsbl_dot_block_int']		= ($pfb_dot_block_int_raw !== '') ? explode(',', $pfb_dot_block_int_raw) : [];
 $pconfig['dnsbl_dot_block_exclude']	= (string) PfbConfig::read('dnsbl_dot_block_exclude');
 $pconfig['dnsbl_dot_block_action']	= (string) PfbConfig::read('dnsbl_dot_block_action');
+$pconfig['dnsbl_dot_block_floating']	= PfbConfig::read('dnsbl_dot_block_floating');
 
 // Select field options
 
@@ -875,6 +876,7 @@ if ($_POST) {
 			PfbConfig::write('dnsbl_dot_block_int', implode(',', $dot_block_ifaces_raw));
 			PfbConfig::write('dnsbl_dot_block_exclude', $dot_block_alias_raw);
 			PfbConfig::write('dnsbl_dot_block_action', pfb_dot_block_action($dot_block_action_raw));
+			PfbConfig::write('dnsbl_dot_block_floating', pfb_filter($_POST['dnsbl_dot_block_floating'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '');
 
 			PfbConfig::writeSection('installedpackages/pfblockerngdnsblsettings/config/0', $pfb['dconfig']);
 			write_config('[pfBlockerNG] save DNSBL settings');
@@ -2918,6 +2920,17 @@ $section->addInput(new Form_Select(
 		. 'Select the action for the DoT/DoQ block rules. <strong>Reject</strong> fast-fails the client '
 		. '(so it falls back to plain DNS) while <strong>Block</strong> silently drops the connection.')
   ->setAttribute('style', 'width: auto');
+
+$section->addInput(new Form_Checkbox(
+	'dnsbl_dot_block_floating',
+	gettext('Floating Rule'),
+	gettext('Use a single floating rule instead of one rule per interface'),
+	pfb_cfg_toggle_read($pconfig['dnsbl_dot_block_floating']) === PfbToggle::On,
+	'on'
+))->setHelp('Default: <strong>off</strong> (one rule per selected interface).<br />'
+		. 'When enabled, a single floating rule (direction <strong>in</strong>, quick) is created over '
+		. 'all selected interfaces instead of a separate rule per interface. The action, interface '
+		. 'selection, and exception alias all apply unchanged.');
 
 $form->add($section);
 

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -82,6 +82,30 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame(PfbToggle::Off, pfb_cfg_toggle_read('off'));
 	}
 
+	public function testToggleReadIsIdempotentForEnumInput(): void
+	{
+		// A PfbToggle fed back through the read adapter must return itself, NOT collapse to
+		// the default. This is the double-apply footgun that silently mis-rendered toggle
+		// checkboxes as always-unchecked: a settings page does
+		//   pfb_cfg_toggle_read($pconfig['x']) === PfbToggle::On
+		// where $pconfig['x'] = PfbConfig::read('x') is ALREADY a PfbToggle. Without the
+		// idempotency guard, fromStored(PfbToggle::On) hits the non-scalar guard -> Off,
+		// so the comparison is always false. With it, the enum round-trips through the read.
+		$this->assertSame(PfbToggle::On, pfb_cfg_toggle_read(PfbToggle::On),
+			'reading an already-On toggle must stay On (idempotent), not collapse to Off');
+		$this->assertSame(PfbToggle::Off, pfb_cfg_toggle_read(PfbToggle::Off),
+			'reading an already-Off toggle must stay Off');
+	}
+
+	public function testStoredEnumReadIsIdempotentAcrossAllEnums(): void
+	{
+		// The idempotency guard lives in the shared PfbStoredEnumAdapter trait, so it holds
+		// for every enum using it — not just PfbToggle.
+		$this->assertSame(PfbLenient::On, PfbLenient::fromStored(PfbLenient::On));
+		$this->assertSame(PfbIdnMode::Confusable, PfbIdnMode::fromStored(PfbIdnMode::Confusable));
+		$this->assertSame(PfbAliasDeltaMode::Delta, PfbAliasDeltaMode::fromStored(PfbAliasDeltaMode::Delta));
+	}
+
 	public function testToggleRoundTripOn(): void
 	{
 		// Given: canonical 'on'.  write(read(v)) == v.

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -346,6 +346,18 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('reject', $result, 'dnsbl_dot_block_action absent -> reject (default)');
 	}
 
+	public function testReadReturnsOffDefaultForDotBlockFloatingAbsentKey(): void
+	{
+		// dnsbl_dot_block_floating default is '' -> PfbToggle::Off (ADR-37): absent key
+		// preserves the per-interface default; floating is strictly opt-in.
+		$this->assertNull(
+			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_floating')
+		);
+
+		$result = PfbConfig::read('dnsbl_dot_block_floating');
+		$this->assertSame(PfbToggle::Off, $result, 'dnsbl_dot_block_floating absent -> Off (per-interface default)');
+	}
+
 	public function testReadReturnsRegisteredDefaultForSafeSearchAbsentKey(): void
 	{
 		// safesearch_enable default is 'Disable'.
@@ -664,6 +676,7 @@ final class CfgGatewayTest extends TestCase
 			'dnsbl_dot_block_int',
 			'dnsbl_dot_block_exclude',
 			'dnsbl_dot_block_action',
+			'dnsbl_dot_block_floating',
 
 			// pfblockerngsafesearch scalars
 			'safesearch_enable',

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -334,6 +334,18 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('lo0', $result);
 	}
 
+	public function testReadReturnsRejectDefaultForDotBlockActionAbsentKey(): void
+	{
+		// dnsbl_dot_block_action default is 'reject' (ADR-37): an existing install
+		// upgrading with the key absent reads to Reject, the corrected outbound default.
+		$this->assertNull(
+			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_action')
+		);
+
+		$result = PfbConfig::read('dnsbl_dot_block_action');
+		$this->assertSame('reject', $result, 'dnsbl_dot_block_action absent -> reject (default)');
+	}
+
 	public function testReadReturnsRegisteredDefaultForSafeSearchAbsentKey(): void
 	{
 		// safesearch_enable default is 'Disable'.
@@ -651,6 +663,7 @@ final class CfgGatewayTest extends TestCase
 			'dnsbl_dot_block',
 			'dnsbl_dot_block_int',
 			'dnsbl_dot_block_exclude',
+			'dnsbl_dot_block_action',
 
 			// pfblockerngsafesearch scalars
 			'safesearch_enable',

--- a/tests/php/DotBlockRuleBuilderTest.php
+++ b/tests/php/DotBlockRuleBuilderTest.php
@@ -9,8 +9,9 @@ use PHPUnit\Framework\TestCase;
  * ADR-37 — DoT/DoQ block rule builder + action-normalisation unit tests.
  *
  * Functions under test:
- *   pfb_dot_block_action()  — normalise a stored/posted action to 'block' | 'reject'.
- *   pfb_dot_block_rule()    — build the per-interface filter/rule array.
+ *   pfb_dot_block_action()        — normalise a stored/posted action to 'block' | 'reject'.
+ *   pfb_dot_block_rule()          — build the per-interface filter/rule array.
+ *   pfb_dot_block_floating_rule() — build the single floating filter/rule (floating mode).
  *
  * Intent: the DoT/DoQ block rules are outbound (LAN->WAN) rules, so they DEFAULT to
  * Reject (fast-fail the client to plain DNS) — matching the outbound Rule Action
@@ -22,6 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversFunction('pfb_dot_block_action')]
 #[CoversFunction('pfb_dot_block_rule')]
+#[CoversFunction('pfb_dot_block_floating_rule')]
 final class DotBlockRuleBuilderTest extends TestCase
 {
 	// -----------------------------------------------------------------------
@@ -134,5 +136,63 @@ final class DotBlockRuleBuilderTest extends TestCase
 		$rule = pfb_dot_block_rule('lan', '', 'reject');
 		$this->assertArrayNotHasKey('tracker', $rule, 'builder must not set tracker (caller appends it last)');
 		$this->assertSame('descr', array_key_last($rule), 'descr must be the last key before the tracker is appended');
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_dot_block_floating_rule() — single floating rule (floating mode)
+	// -----------------------------------------------------------------------
+
+	public function testFloatingRuleIsFloatingQuickDirectionIn(): void
+	{
+		// Given floating mode, the single rule must be floating + quick with direction 'in'
+		// (the direction ADR-37 mandates for a floating variant — matches client egress
+		// entering the firewall on the selected interfaces).
+		$rule = pfb_dot_block_floating_rule(['lan', 'opt1'], '', 'reject');
+
+		$this->assertSame('yes', $rule['floating'], 'floating rule must set floating=yes');
+		$this->assertSame('yes', $rule['quick'], 'floating rule must set quick=yes');
+		$this->assertSame('in', $rule['direction'], 'floating rule direction must be in');
+	}
+
+	public function testFloatingRuleJoinsAllInterfacesIntoOneRule(): void
+	{
+		// Given multiple interfaces, floating mode produces ONE rule whose interface field
+		// is the comma-joined list (not one rule per interface).
+		$rule = pfb_dot_block_floating_rule(['lan', 'opt1', 'opt2'], '', 'reject');
+		$this->assertSame('lan,opt1,opt2', $rule['interface'], 'interface = comma-joined selected ifaces');
+		$this->assertSame('pfB_DoT_Block_Floating', $rule['descr'], 'floating rule carries the single floating marker');
+	}
+
+	public function testFloatingRuleTypeFollowsActionBlock(): void
+	{
+		// Action drives the floating rule's disposition too (block branch).
+		$rule = pfb_dot_block_floating_rule(['lan'], '', 'block');
+		$this->assertSame('block', $rule['type'], 'floating action=block must yield a block rule');
+	}
+
+	public function testFloatingRuleTypeDefaultsToRejectForEmptyAction(): void
+	{
+		// And defaults to reject for an empty/unknown action (proves block above is a real branch).
+		$rule = pfb_dot_block_floating_rule(['lan'], '', '');
+		$this->assertSame('reject', $rule['type'], 'floating default (empty action) must be reject');
+	}
+
+	public function testFloatingRuleCarriesFixedDestinationAndSourceBranches(): void
+	{
+		// Destination is the same negated (self):853 as the per-interface rule.
+		$rule = pfb_dot_block_floating_rule(['lan'], '', 'reject');
+		$this->assertSame('(self)', $rule['destination']['network'], 'floating destination.network = (self)');
+		$this->assertSame('853', $rule['destination']['port'], 'floating destination.port = 853');
+		$this->assertSame('inet46', $rule['ipprotocol'], 'floating ipprotocol = inet46');
+		$this->assertSame('tcp/udp', $rule['protocol'], 'floating protocol = tcp/udp');
+		$this->assertSame(['any' => ''], $rule['source'], 'no alias -> source any');
+
+		// Exception alias negates the source, same as the per-interface rule.
+		$withAlias = pfb_dot_block_floating_rule(['lan'], 'DoT_Exceptions', 'reject');
+		$this->assertSame(
+			['address' => 'DoT_Exceptions', 'not' => ''],
+			$withAlias['source'],
+			'alias present -> negated alias source'
+		);
 	}
 }

--- a/tests/php/DotBlockRuleBuilderTest.php
+++ b/tests/php/DotBlockRuleBuilderTest.php
@@ -195,4 +195,14 @@ final class DotBlockRuleBuilderTest extends TestCase
 			'alias present -> negated alias source'
 		);
 	}
+
+	public function testFloatingBuilderOmitsTrackerAndEndsOnDescr(): void
+	{
+		// Same key-order invariant as the per-interface builder: the caller appends 'tracker'
+		// last, so the builder must not set it and 'descr' must be the final key. The sync
+		// change-detection compare ($dot_ex_owned !== $dot_new_owned) relies on this order.
+		$rule = pfb_dot_block_floating_rule(['lan'], '', 'reject');
+		$this->assertArrayNotHasKey('tracker', $rule, 'floating builder must not set tracker (caller appends it last)');
+		$this->assertSame('descr', array_key_last($rule), 'descr must be the last key before the tracker is appended');
+	}
 }

--- a/tests/php/DotBlockRuleBuilderTest.php
+++ b/tests/php/DotBlockRuleBuilderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-37 — DoT/DoQ block rule builder + action-normalisation unit tests.
+ *
+ * Functions under test:
+ *   pfb_dot_block_action()  — normalise a stored/posted action to 'block' | 'reject'.
+ *   pfb_dot_block_rule()    — build the per-interface filter/rule array.
+ *
+ * Intent: the DoT/DoQ block rules are outbound (LAN->WAN) rules, so they DEFAULT to
+ * Reject (fast-fail the client to plain DNS) — matching the outbound Rule Action
+ * convention on the IP settings page — while remaining user-selectable as Block.
+ *
+ * Coverage mandate: branch coverage — the action drives the rule 'type' in BOTH
+ * directions (reject AND block), with the unknown/empty value falling back to the
+ * Reject default; the exclude-alias source is asserted present AND absent.
+ */
+#[CoversFunction('pfb_dot_block_action')]
+#[CoversFunction('pfb_dot_block_rule')]
+final class DotBlockRuleBuilderTest extends TestCase
+{
+	// -----------------------------------------------------------------------
+	// pfb_dot_block_action() — normalisation
+	// -----------------------------------------------------------------------
+
+	public function testActionDefaultsToRejectForEmptyValue(): void
+	{
+		// Given an unconfigured (absent/empty) action — the upgrade-from-old-config case
+		// Then it resolves to Reject (the new default), NOT Block (the old hardcoded type)
+		$this->assertSame('reject', pfb_dot_block_action(''), 'empty action must default to reject');
+	}
+
+	public function testActionDefaultsToRejectForUnknownValue(): void
+	{
+		// Given a garbage/unknown token
+		// Then it falls back to the Reject default rather than passing through
+		$this->assertSame('reject', pfb_dot_block_action('drop'), 'unknown action must fall back to reject');
+	}
+
+	public function testActionPreservesExplicitBlock(): void
+	{
+		// Given the user explicitly selected Block
+		$this->assertSame('block', pfb_dot_block_action('block'), 'block must be preserved');
+	}
+
+	public function testActionPreservesExplicitReject(): void
+	{
+		// Given the user explicitly selected Reject
+		$this->assertSame('reject', pfb_dot_block_action('reject'), 'reject must be preserved');
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_dot_block_rule() — rule disposition follows the action (both branches)
+	// -----------------------------------------------------------------------
+
+	public function testRuleTypeDefaultsToRejectForEmptyAction(): void
+	{
+		// Given an empty action (an existing install upgrading with no action stored)
+		$rule = pfb_dot_block_rule('lan', '', '');
+
+		// Then the rule is a Reject — the corrected default for an outbound block rule
+		$this->assertSame('reject', $rule['type'], 'default (empty action) DoT rule must be reject');
+	}
+
+	public function testRuleTypeIsBlockWhenActionIsBlock(): void
+	{
+		// Given the action is explicitly Block, the rule must drop silently
+		$rule = pfb_dot_block_rule('lan', '', 'block');
+		$this->assertSame('block', $rule['type'], 'action=block must yield a block rule');
+	}
+
+	public function testRuleTypeIsRejectWhenActionIsReject(): void
+	{
+		// Given the action is explicitly Reject (proves block above is a real branch,
+		// not an always-reject path)
+		$rule = pfb_dot_block_rule('lan', '', 'reject');
+		$this->assertSame('reject', $rule['type'], 'action=reject must yield a reject rule');
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_dot_block_rule() — fixed rule shape (ADR-37 §2.2 field values)
+	// -----------------------------------------------------------------------
+
+	public function testRuleCarriesFixedFieldValues(): void
+	{
+		$rule = pfb_dot_block_rule('opt1', '', 'reject');
+
+		$this->assertSame('opt1', $rule['interface'], 'interface = the passed iface');
+		$this->assertSame('inet46', $rule['ipprotocol'], 'ipprotocol must be inet46 (dual-stack)');
+		$this->assertSame('tcp/udp', $rule['protocol'], 'protocol must be tcp/udp (DoT TCP + DoQ UDP)');
+		$this->assertSame('keep state', $rule['statetype'], 'statetype must be keep state');
+		$this->assertSame('pfB_DoT_Block_opt1', $rule['descr'], 'descr = prefix + iface');
+
+		// Destination: the firewall itself on port 853, negated (self-exempt).
+		$this->assertSame('(self)', $rule['destination']['network'], 'destination.network = (self)');
+		$this->assertArrayHasKey('not', $rule['destination'], 'destination must carry the negation key');
+		$this->assertSame('853', $rule['destination']['port'], 'destination.port = 853');
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_dot_block_rule() — exception-alias source (both branches)
+	// -----------------------------------------------------------------------
+
+	public function testSourceIsAnyWhenNoExcludeAlias(): void
+	{
+		// Given no exception alias, the source is 'any' (block from every host)
+		$rule = pfb_dot_block_rule('lan', '', 'reject');
+		$this->assertSame(['any' => ''], $rule['source'], 'no alias -> source any');
+	}
+
+	public function testSourceIsNegatedAliasWhenExcludeAliasGiven(): void
+	{
+		// Given an exception alias, the source negates that alias so listed hosts bypass
+		$rule = pfb_dot_block_rule('lan', 'DoT_Exceptions', 'reject');
+		$this->assertSame(
+			['address' => 'DoT_Exceptions', 'not' => ''],
+			$rule['source'],
+			'alias present -> negated alias source'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Key order — the 'tracker' is appended by the caller, so the builder's last
+	// key must be 'descr'. Pins the stored-rule key order the sync compare relies on.
+	// -----------------------------------------------------------------------
+
+	public function testBuilderOmitsTrackerAndEndsOnDescr(): void
+	{
+		$rule = pfb_dot_block_rule('lan', '', 'reject');
+		$this->assertArrayNotHasKey('tracker', $rule, 'builder must not set tracker (caller appends it last)');
+		$this->assertSame('descr', array_key_last($rule), 'descr must be the last key before the tracker is appended');
+	}
+}

--- a/tests/php/DotDoQBlockUiValidatorTest.php
+++ b/tests/php/DotDoQBlockUiValidatorTest.php
@@ -179,4 +179,50 @@ final class DotDoQBlockUiValidatorTest extends TestCase
 		$this->assertStringContainsString('DoT/DoQ Block', $errors[0]);
 		$this->assertStringContainsString('DoT/DoQ Block', $errors[1]);
 	}
+
+	// -----------------------------------------------------------------------
+	// RULE ACTION — block/reject selector (both directions + rejection)
+	// -----------------------------------------------------------------------
+
+	public function testActionRejectIsAccepted(): void
+	{
+		// Given the default rule action (reject)
+		$errors = pfb_validate_dot_block_post(['lan'], $this->validIfaceList, '', 'reject');
+
+		// Then no errors are returned
+		$this->assertSame([], $errors, 'action=reject must be accepted');
+	}
+
+	public function testActionBlockIsAccepted(): void
+	{
+		// Given the user selected the Block action
+		$errors = pfb_validate_dot_block_post(['lan'], $this->validIfaceList, '', 'block');
+
+		// Then no errors are returned
+		$this->assertSame([], $errors, 'action=block must be accepted');
+	}
+
+	public function testOmittedActionDefaultsToAcceptedReject(): void
+	{
+		// Given the action argument is omitted (defaults to reject)
+		$errors = pfb_validate_dot_block_post(['lan'], $this->validIfaceList, '');
+
+		// Then the default action passes validation
+		$this->assertSame([], $errors, 'omitted action must default to an accepted value');
+	}
+
+	public function testInvalidActionIsRejected(): void
+	{
+		// Given: before -> a valid action is accepted
+		$errorsBefore = pfb_validate_dot_block_post(['lan'], $this->validIfaceList, '', 'block');
+		$this->assertSame([], $errorsBefore, 'pre-condition: block is accepted');
+
+		// When an unknown action token is submitted
+		$errors = pfb_validate_dot_block_post(['lan'], $this->validIfaceList, '', 'drop');
+
+		// Then an error naming the feature is returned
+		$this->assertNotEmpty($errors, 'an unknown rule action must be rejected');
+		$this->assertStringContainsString('DoT/DoQ Block', $errors[0]);
+		$this->assertStringContainsString('action', $errors[0]);
+	}
 }

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -157,6 +157,7 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_int',
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_exclude',
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_action',
+		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_floating',
 		// ADR-38: syslog export toggle
 		'installedpackages/pfblockerng/config/0/log_syslog',
 		// installedpackages/pfblockerngsafesearch (flat section, no /config/0)

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -156,6 +156,7 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block',
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_int',
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_exclude',
+		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_action',
 		// ADR-38: syslog export toggle
 		'installedpackages/pfblockerng/config/0/log_syslog',
 		// installedpackages/pfblockerngsafesearch (flat section, no /config/0)

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -316,9 +316,18 @@ def _set_dot_block(
     """
     toggle = "on" if enabled else ""
     iface_val = ",".join(ifaces)
-    action_line = f"$d['dnsbl_dot_block_action'] = {h._php_str(action)};\n" if action is not None else ""
+    # When action/floating is None, UNSET the key so the gateway's registered default applies
+    # (reject / per-interface). Merely omitting the assignment would leave a prior test's value
+    # in config.xml, making the default-path cases depend on VM state and test order.
+    action_line = (
+        f"$d['dnsbl_dot_block_action'] = {h._php_str(action)};\n"
+        if action is not None
+        else "unset($d['dnsbl_dot_block_action']);\n"
+    )
     floating_line = (
-        f"$d['dnsbl_dot_block_floating'] = {h._php_str('on' if floating else '')};\n" if floating is not None else ""
+        f"$d['dnsbl_dot_block_floating'] = {h._php_str('on' if floating else '')};\n"
+        if floating is not None
+        else "unset($d['dnsbl_dot_block_floating']);\n"
     )
     snippet = (
         f"$d = config_get_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, array());\n"

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -22,6 +22,8 @@ Proves on a real pfSense CE VM that:
 * **Case 7 (Self-exempt guard):** ``pfctl -sr`` output contains the block rule for
   port 853 and the rule includes the ``self``-negation token confirming the
   firewall-self exemption is active.
+* **Rule Action selector:** the action field flips the rule ``type`` — default
+  ``reject`` (before-state) switches to ``block`` when the selector is set.
 
 Cases 1–3 and 5–7 require at least one non-WAN interface and skip cleanly on a
 WAN-only VM (e.g. the default smoke image). The interface is discovered at runtime
@@ -288,16 +290,29 @@ def _discover_non_wan_ifaces(vm: SmokeVM, *, timeout: float = 60.0) -> list[str]
 
 
 def _set_dot_block(
-    vm: SmokeVM, *, enabled: bool, ifaces: list[str], exception: str = "", timeout: float = 60.0
+    vm: SmokeVM,
+    *,
+    enabled: bool,
+    ifaces: list[str],
+    exception: str = "",
+    action: str | None = None,
+    timeout: float = 60.0,
 ) -> None:
-    """Write the three DoT/DoQ-block config fields and persist config.xml."""
+    """Write the DoT/DoQ-block config fields and persist config.xml.
+
+    ``action`` selects the rule disposition ('block' | 'reject'). When None the
+    key is left ABSENT, so the gateway's registered default (reject) applies —
+    exercising the default path an upgrading install takes.
+    """
     toggle = "on" if enabled else ""
     iface_val = ",".join(ifaces)
+    action_line = f"$d['dnsbl_dot_block_action'] = {h._php_str(action)};\n" if action is not None else ""
     snippet = (
         f"$d = config_get_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, array());\n"
         f"$d['dnsbl_dot_block']         = {h._php_str(toggle)};\n"
         f"$d['dnsbl_dot_block_int']     = {h._php_str(iface_val)};\n"
         f"$d['dnsbl_dot_block_exclude'] = {h._php_str(exception)};\n"
+        f"{action_line}"
         f"config_set_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, $d);\n"
         "write_config('pfBlockerNG smoke: set DoT/DoQ block config');\n"
         "echo 'OK';"
@@ -432,7 +447,7 @@ def test_dot_doq_block_rule_appears_on_enable(deployed_vm: SmokeVM, primary_ifac
 
       Then filter/rule contains exactly 1 pfB_DoT_Block_<iface> entry.
         And the entry carries the correct §2.2 field values:
-            - type: block
+            - type: reject (the default for the outbound LAN->WAN block rule)
             - ipprotocol: inet46
             - protocol: tcp/udp
             - destination.network: (self), not-negated
@@ -471,8 +486,9 @@ def test_dot_doq_block_rule_appears_on_enable(deployed_vm: SmokeVM, primary_ifac
         count = _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface)
         assert count == 1, f"Expected 1 pfB_DoT_Block_{iface} filter/rule entry after enable, got {count}"
 
-        # THEN — field-by-field verification.
-        assert _filter_rule_field(vm, descr, "type") == "block", f"{descr}: type != 'block'"
+        # THEN — field-by-field verification. Default action is Reject (the rule is an
+        # outbound LAN->WAN block, so Reject fast-fails the client to plain DNS).
+        assert _filter_rule_field(vm, descr, "type") == "reject", f"{descr}: type != 'reject' (default)"
         assert _filter_rule_field(vm, descr, "ipprotocol") == "inet46", f"{descr}: ipprotocol != 'inet46'"
         assert _filter_rule_field(vm, descr, "protocol") == "tcp/udp", f"{descr}: protocol != 'tcp/udp'"
         assert _filter_rule_field(vm, descr, "statetype") == "keep state", f"{descr}: statetype != 'keep state'"
@@ -494,6 +510,49 @@ def test_dot_doq_block_rule_appears_on_enable(deployed_vm: SmokeVM, primary_ifac
             + _dot_block_match_report(vm, expected_present=True)
             + "\n"
             + h.pf_state_dump(vm)
+        )
+
+    finally:
+        _cleanup_dot_block(vm)
+
+
+def test_dot_doq_block_action_selector_sets_rule_type(deployed_vm: SmokeVM, primary_iface: str) -> None:
+    """ADR-37: the Rule Action selector drives the DoT/DoQ block rule disposition.
+
+    Scenario: the action field flips the rule 'type' between reject and block.
+
+      Background: pfBlockerNG installed; master + DNSBL enabled.
+
+      Given DoT/DoQ block enabled with the default action (reject),
+        And the rule 'type' is 'reject' (before-state — proves the flip causes the change),
+
+      When the action is changed to 'block' and a full reload runs,
+
+      Then the same pfB_DoT_Block_<iface> rule now carries type 'block'.
+    """
+    vm = deployed_vm
+    iface = primary_iface
+    descr = _DOT_BLOCK_DESCR_PFX + iface
+
+    try:
+        # GIVEN — $mode='enabled' so DoT/DoQ block rules are created on reload.
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
+
+        # GIVEN — enable with the DEFAULT action (key absent → reject); assert before-state.
+        _set_dot_block(vm, enabled=True, ifaces=[iface], exception="", action=None)
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
+        assert _filter_rule_field(vm, descr, "type") == "reject", f"{descr}: default type != 'reject' (before-state)"
+
+        # WHEN — switch the action to Block and reload.
+        _set_dot_block(vm, enabled=True, ifaces=[iface], exception="", action="block")
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
+
+        # THEN — the rule disposition follows the selector.
+        assert _filter_rule_field(vm, descr, "type") == "block", (
+            f"{descr}: type != 'block' after selecting the Block action"
         )
 
     finally:

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -622,8 +622,14 @@ def test_dot_doq_block_floating_mode_single_rule(deployed_vm: SmokeVM, primary_i
         assert _filter_rule_field(vm, _DOT_BLOCK_FLOATING_DESCR, "floating") == "yes", (
             "floating rule must carry floating=yes"
         )
+        assert _filter_rule_field(vm, _DOT_BLOCK_FLOATING_DESCR, "quick") == "yes", (
+            "floating rule must carry quick=yes (first-match)"
+        )
         assert _filter_rule_field(vm, _DOT_BLOCK_FLOATING_DESCR, "direction") == "in", (
             "floating rule direction must be in"
+        )
+        assert _filter_rule_field(vm, _DOT_BLOCK_FLOATING_DESCR, "type") == "reject", (
+            "floating rule type must be reject (default action carried into floating mode)"
         )
         assert iface in _filter_rule_field(vm, _DOT_BLOCK_FLOATING_DESCR, "interface").split(","), (
             f"floating rule interface list must contain {iface}"

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -24,6 +24,8 @@ Proves on a real pfSense CE VM that:
   firewall-self exemption is active.
 * **Rule Action selector:** the action field flips the rule ``type`` — default
   ``reject`` (before-state) switches to ``block`` when the selector is set.
+* **Floating mode:** the Floating Rule option replaces the per-interface rule(s) with a
+  single floating rule (``floating=yes``, ``direction=in``) over the selected interfaces.
 
 Cases 1–3 and 5–7 require at least one non-WAN interface and skip cleanly on a
 WAN-only VM (e.g. the default smoke image). The interface is discovered at runtime
@@ -61,6 +63,9 @@ _PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"
 
 # Marker prefix for DoT/DoQ-block owned rules (mirrors PFB_DOT_BLOCK_DESCR_PFX).
 _DOT_BLOCK_DESCR_PFX = "pfB_DoT_Block_"
+
+# Marker for the single floating DoT/DoQ-block rule (mirrors PFB_DOT_BLOCK_FLOATING_DESCR).
+_DOT_BLOCK_FLOATING_DESCR = "pfB_DoT_Block_Floating"
 
 # User filter rule descriptor seeded in Cases 3 and 6 to prove survival.
 _USER_FILTER_DESCR = "my-user-filter-dot-block-smoke"
@@ -296,6 +301,7 @@ def _set_dot_block(
     ifaces: list[str],
     exception: str = "",
     action: str | None = None,
+    floating: bool | None = None,
     timeout: float = 60.0,
 ) -> None:
     """Write the DoT/DoQ-block config fields and persist config.xml.
@@ -303,16 +309,24 @@ def _set_dot_block(
     ``action`` selects the rule disposition ('block' | 'reject'). When None the
     key is left ABSENT, so the gateway's registered default (reject) applies —
     exercising the default path an upgrading install takes.
+
+    ``floating`` selects the rule mode: True = a single floating rule, False =
+    one rule per interface. When None the key is left ABSENT (gateway default =
+    off = per-interface).
     """
     toggle = "on" if enabled else ""
     iface_val = ",".join(ifaces)
     action_line = f"$d['dnsbl_dot_block_action'] = {h._php_str(action)};\n" if action is not None else ""
+    floating_line = (
+        f"$d['dnsbl_dot_block_floating'] = {h._php_str('on' if floating else '')};\n" if floating is not None else ""
+    )
     snippet = (
         f"$d = config_get_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, array());\n"
         f"$d['dnsbl_dot_block']         = {h._php_str(toggle)};\n"
         f"$d['dnsbl_dot_block_int']     = {h._php_str(iface_val)};\n"
         f"$d['dnsbl_dot_block_exclude'] = {h._php_str(exception)};\n"
         f"{action_line}"
+        f"{floating_line}"
         f"config_set_path({h._php_str(h.CFG_DNSBL_SETTINGS)}, $d);\n"
         "write_config('pfBlockerNG smoke: set DoT/DoQ block config');\n"
         "echo 'OK';"
@@ -553,6 +567,66 @@ def test_dot_doq_block_action_selector_sets_rule_type(deployed_vm: SmokeVM, prim
         # THEN — the rule disposition follows the selector.
         assert _filter_rule_field(vm, descr, "type") == "block", (
             f"{descr}: type != 'block' after selecting the Block action"
+        )
+
+    finally:
+        _cleanup_dot_block(vm)
+
+
+def test_dot_doq_block_floating_mode_single_rule(deployed_vm: SmokeVM, primary_iface: str) -> None:
+    """ADR-37: the Floating Rule option replaces per-interface rules with one floating rule.
+
+    Scenario: switching to floating mode prunes the per-interface rule and creates a single
+    floating rule (direction in) covering the selected interface(s).
+
+      Background: pfBlockerNG installed; master + DNSBL enabled.
+
+      Given DoT/DoQ block enabled per-interface (floating off),
+        And a pfB_DoT_Block_<iface> rule exists and no floating marker exists (before-state),
+
+      When the Floating Rule option is enabled and a full reload runs,
+
+      Then the per-interface rule is gone, replaced by a single pfB_DoT_Block_Floating rule
+        carrying floating=yes, direction=in, and the selected interface in its interface list.
+    """
+    vm = deployed_vm
+    iface = primary_iface
+    per_iface_descr = _DOT_BLOCK_DESCR_PFX + iface
+
+    try:
+        # GIVEN — $mode='enabled' and per-interface DoT block; assert before-state.
+        h.set_package_enabled(vm, True)
+        h.set_dnsbl_enabled(vm, True)
+        _set_dot_block(vm, enabled=True, ifaces=[iface], exception="", floating=False)
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
+        assert _filter_dot_block_count(vm, per_iface_descr) == 1, (
+            f"{per_iface_descr}: per-interface rule absent before floating switch (before-state)"
+        )
+        assert _filter_dot_block_count(vm, _DOT_BLOCK_FLOATING_DESCR) == 0, (
+            "floating rule present before floating switch (before-state not clean)"
+        )
+
+        # WHEN — enable the floating option and reload.
+        _set_dot_block(vm, enabled=True, ifaces=[iface], exception="", floating=True)
+        h.reload(vm, "update", wait_unbound=False)
+        h.apply_filter_sync(vm)
+
+        # THEN — per-interface rule pruned; exactly one floating rule with the right shape.
+        assert _filter_dot_block_count(vm, per_iface_descr) == 0, (
+            f"{per_iface_descr}: per-interface rule not pruned after switching to floating"
+        )
+        assert _filter_dot_block_count(vm, _DOT_BLOCK_FLOATING_DESCR) == 1, (
+            "expected exactly one pfB_DoT_Block_Floating rule after enabling floating mode"
+        )
+        assert _filter_rule_field(vm, _DOT_BLOCK_FLOATING_DESCR, "floating") == "yes", (
+            "floating rule must carry floating=yes"
+        )
+        assert _filter_rule_field(vm, _DOT_BLOCK_FLOATING_DESCR, "direction") == "in", (
+            "floating rule direction must be in"
+        )
+        assert iface in _filter_rule_field(vm, _DOT_BLOCK_FLOATING_DESCR, "interface").split(","), (
+            f"floating rule interface list must contain {iface}"
         )
 
     finally:


### PR DESCRIPTION
## Summary

Two related improvements to the ADR-37 DoT/DoQ block rules (which are outbound LAN→WAN rules):

1. **Default to Reject + Rule Action selector.** The rules were hardcoded to `block` (silent drop). pfBlockerNG's own outbound deny auto-rules default to **Reject** (`outbound_deny_action`) so the client fast-fails to plain DNS instead of hanging until timeout. The rules now **default to Reject** with a user-selectable **Rule Action** (Block | Reject), mirroring the IP-settings selector.
2. **Opt-in Floating Rule mode.** A new **Floating Rule** toggle (default **off**) builds a single floating rule (`floating=yes`, `quick=yes`, `direction=in`) over all selected interfaces instead of one rule per interface. This realizes the "future floating decision" ADR-37 explicitly anticipated, with the mandated explicit `direction=in`. The action, interface selection, and exception alias apply unchanged in both modes.

## Details

- New registered `PfbConfig` fields: `dnsbl_dot_block_action` (plain string `block`|`reject`, default `reject`) and `dnsbl_dot_block_floating` (toggle, default off). Both via the ADR-29 5-step process (registry + `$registeredPaths` sniff + `CfgGatewayTest` inventory + default-read tests).
- Extracted builders `pfb_dot_block_rule()` / `pfb_dot_block_floating_rule()` / `pfb_dot_block_action()`. The sync reconcile branches on the mode and prunes the other mode's rule(s) when the toggle flips; rule key order preserved so change-detection stays stable.
- UI: `Rule Action` select + `Floating Rule` checkbox in the DoT/DoQ Block section; server-side validation extended.
- ADR-37 amended (dated addendum) recording both changes; supersedes the "type is always block" invariant and the per-interface-only rule model.

### Upgrade behaviour

The feature is unreleased (4.0.0 alpha). The action default flips existing alpha installs to Reject with **no grandfather seed** (there was no user-chosen disposition to preserve — the prior value was an implicit hardcode). Floating defaults **off**, preserving the per-interface behavior.

## Tests

- **PHPUnit** — `DotBlockRuleBuilderTest` (per-interface + floating builders, both action branches, source/dest branches), `DotDoQBlockUiValidatorTest` action cases, `CfgGatewayTest` default-reads + inventory. Full suite green (1456 tests).
- **Smoke** (`test_dot_doq_block.py`) — default-enable expects `reject`; action-flip case; floating-mode case asserting the per-interface→floating switch prunes and rebuilds (`floating=yes`, `direction=in`).
- PHPCS, PHPStan, ruff, mypy all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a selectable action for DoT/DoQ blocking, letting you choose between Block and Reject.
  * Added an optional floating-rule mode that creates one shared rule across selected interfaces instead of separate per-interface rules.

* **Bug Fixes**
  * Updated the default DoT/DoQ block behavior to Reject when no action is set.
  * Improved rule handling so switching between per-interface and floating mode keeps the expected firewall rules in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->