### PR TITLE
dev: bump default reasoning effort to xhigh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## What

Bump the committed `effortLevel` in `.claude/settings.json` from `high` to `xhigh`.

## Why

The project's committed `.claude/settings.json` set `effortLevel: high`, which
**overrides** a contributor's higher user-level default (project settings outrank
user settings). So Opus ran at `high` in this repo regardless of personal config.

`xhigh` still satisfies the CLAUDE.md baseline ("Run at effort High or better when
available — set as the session default in `.claude/settings.json`"). This makes the
deeper default apply to every contributor/agent working in the repo.

## Scope

- One-line config change; no `src/`/`tests/`/CI behaviour touched.
- Contributors can still override per-session with `/effort` or locally via
  `.claude/settings.local.json` / `CLAUDE_CODE_EFFORT_LEVEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
