### PR TITLE
pfblockerng: restore 4-way pass_order auto-rule assembly (ADR-41)

### DIFF
--- a/.ADRs/ADR_41_Immutable_User_Firewall_Rules/ADR.md
+++ b/.ADRs/ADR_41_Immutable_User_Firewall_Rules/ADR.md
@@ -10,7 +10,7 @@
   floating and interface pf groups), keeping the genuine ADR-41 wins (never duplicate/drop/mutate a
   user rule). Off-appliance contract pinned **red→green** in `AutoruleListOracleTest` (the
   pfB-Permit-vs-user-Block trap per order + behavioural equivalence to the frozen `8c4c482`
-  reference on every dup-free config). Full analysis: **`RESULTS/05`** (supersedes the binary-anchor
+  reference on every config it handles correctly). Full analysis: **`RESULTS/05`** (supersedes the binary-anchor
   `RESULTS/02`). Flips to **Accepted** once the §7 live-VM fan-out (CE + Plus) — the per-`pass_order`
   data-plane precedence sweep in `test_smoke_autorule_immutable.py` (still skipped pending Phase-4
   wiring) — is green.
@@ -244,8 +244,10 @@ once, verbatim — while the `pass_order` table still governs where the buckets 
   Pass — documented `pass_order` semantics, preserved here. (The binary-anchor revision wrongly
   deleted it by freezing user-rule order; that was a regression, not a feature.) The only visible
   `config.xml` change vs PR #561's behaviour is restoring the correct per-`pass_order` ordering;
-  vs the pre-ADR-41 baseline, behaviour is preserved on every dup-free config (the DROP/DUP cases
-  are the fixes). Release-notes call-out: the order_1/order_2 Permit-vs-Block precedence fix.
+  vs the pre-ADR-41 baseline, behaviour matches the proven `8c4c482` emission on every config except
+  the three it mishandled — the order_1/order_2 user-pass DUP, the empty-order DROP, and the
+  order_2+float-on floating mis-order — which are the fixes (the floating group now follows the
+  ORDER table there too). Release-notes call-out: the order_1/order_2 Permit-vs-Block precedence fix.
 - **Multi-interface / mixed pfB permit+deny configs are under-represented in the factory image.**
   The live image's user rules are LAN/opt1 pass rules; pfB permit rules (`Permit_*` actions) and
   inbound≠outbound need explicit fixtures. **Mitigation:** Phase 1 PHPUnit fixtures cover them

--- a/.ADRs/ADR_41_Immutable_User_Firewall_Rules/ADR.md
+++ b/.ADRs/ADR_41_Immutable_User_Firewall_Rules/ADR.md
@@ -1,12 +1,19 @@
 # ADR-41: Immutable user firewall rules in the IP autorule reconciliation
 
-- **Status:** **Implemented (pending live-VM smoke)** (2026-06-25) — Phases 1–3 landed: the
-  emission is extracted + the reconciliation rewritten to the immutable-user splice (binary anchor),
-  with the off-appliance contract (user-rule fidelity, pfB-set-identical, idempotence) pinned
-  red→green in `AutoruleListOracleTest`. Phase 2's pf-precedence kill-gate returned **GO** (live
-  first-match confirmed; `RESULTS/02`). Flips to **Accepted** once the §7 live-VM fan-out (CE + Plus)
-  — the per-`pass_order` data-plane precedence sweep in `test_smoke_autorule_immutable.py` (currently
-  skipped pending Phase-4 wiring) — is green.
+- **Status:** **Implemented — 4-way restored (pending live-VM smoke)** (2026-06-25). PR #561
+  shipped a **flawed** binary-anchor design (Phase 3): its Phase-2 kill-gate (`RESULTS/02`) returned
+  a **false GO** — its precedence reduction omitted the **pfB-Permit (pass) vs user-Block**
+  interaction, so the single anchor broke that precedence for `order_1`/`order_2` (a pfB Permit list
+  could not override a user Block) and dropped `order_4`'s **intended** user-block-before-user-pass
+  emission. Corrected on `fix/adr-41-restore-pass-order` to the **4-way bucket stable reorder** (pfB
+  p/m · pfB b/r · user p/m · user b/r, ordered per `pass_order`, applied independently to the
+  floating and interface pf groups), keeping the genuine ADR-41 wins (never duplicate/drop/mutate a
+  user rule). Off-appliance contract pinned **red→green** in `AutoruleListOracleTest` (the
+  pfB-Permit-vs-user-Block trap per order + behavioural equivalence to the frozen `8c4c482`
+  reference on every dup-free config). Full analysis: **`RESULTS/05`** (supersedes the binary-anchor
+  `RESULTS/02`). Flips to **Accepted** once the §7 live-VM fan-out (CE + Plus) — the per-`pass_order`
+  data-plane precedence sweep in `test_smoke_autorule_immutable.py` (still skipped pending Phase-4
+  wiring) — is green.
 - **Date:** 2026-06-25
 - **Branch:** `adr/41-immutable-user-firewall-rules` (off **`devel`**; `{slug}` = sanitised
   ADR-title slug per CLAUDE.md "Branch naming"). / **Component(s):** the IP-side autorule
@@ -76,9 +83,19 @@ swept across every `pass_order` × float on/off, asserting the exact user-rule m
    `order_4` emitted the `opt1` rules *before* the `lan` rules, inverting their `config.xml`
    order vs the factory layout.
 
-These are three symptoms of **one** fragile design: *strip everything and rebuild, re-bucketing
-user rules*. Patching each symptom (the #539 empty-order default; a dedup guard for #2) is
-whack-a-mole on code that should never be touching user rules in the first place.
+> **Correction (`fix/adr-41-restore-pass-order`).** Only **DROP (#1)** and **DUPLICATE (#2)** are
+> genuine defects. The "REORDER" (#3) is two separate things, and neither is a removable bug:
+> (a) `order_4` placing a user **Block** before a user **Pass** is the *intended* `pass_order`
+> semantics (GUI `order_4 = pfB p/m | pfB b/r | pfSense Block/Reject | pfSense Pass/Match`); and
+> (b) the cross-interface reposition (`opt1` before `lan`) is **behaviourally inert** under
+> per-interface first-match (different-interface rules never interact). The fix keeps both: it
+> restores the 4-way `pass_order` bucketing and eliminates only the DROP and the DUP. The
+> binary-anchor design (PR #561) wrongly "fixed" #3 by freezing user-rule order — which deleted
+> order_4's intended reorder **and** broke pfB-Permit-vs-user-Block precedence (see §2/§3).
+
+These symptoms come from **one** fragile design: *strip everything and rebuild, re-bucketing
+user rules*. The fix removes the DROP and DUP while preserving the intended `pass_order` bucketing
+— not by abandoning the bucketing, but by making it a stable reorder that never dups/drops/mutates.
 
 ### 1.3 Load-bearing facts
 
@@ -127,25 +144,38 @@ tests — not an inline edit.
 
 ## 2. Decision
 
-Stop rebuilding the rule list. Treat **user rules as immutable** and only **move pfBlockerNG's own
-rules**:
+Stop *mutating* user rules. Reconcile by a **stable bucket reorder** — the same `pass_order`
+bucketing as before, but one that can never drop, duplicate, or content-mutate a user rule:
 
-> Take the live `filter/rule` list. **Remove only the pfB-owned rules** this region regenerates
-> (descr starts `pfB_`, excluding the DNS-redirect/DoT bypass rules). Keep every remaining rule —
-> user rules and bypass rules — **exactly where it is, in its existing order, with its existing
-> count**. **Generate** the pfB rules (unchanged generation). **Splice** them into the kept list
-> at a single anchor computed from `pass_order`. Write back.
+> Sort every surviving rule (user rules and the regenerated pfB rules) into one of four buckets —
+> **pfB pass/match**, **pfB block/reject**, **user pass/match**, **user block/reject** — preserving
+> each rule's content verbatim (bar the legacy `_v4` upgrade) and the original order **within** each
+> bucket. Concatenate the buckets in the `pass_order` sequence (the ORDER table), applying it
+> **independently** to the two pf groups pf evaluates separately — the **floating** group (DNSBL/
+> match pass rules; plus pfB permit/deny when float mode is on) and the **interface** group (pfB
+> permit/deny when float mode is off). pfB-owned rules (descr starts `pfB_`, excluding the
+> DNS-redirect/DoT bypass rules) are regenerated; everything else passes through. Write back.
+>
+> **Correction (`fix/adr-41-restore-pass-order`).** The original Decision below said "keep every
+> remaining rule **exactly where it is, in its existing order**" and splice the pfB block at a
+> **single anchor**. That is wrong: `order_1`/`order_2` deliberately **split** the user rules around
+> the pfB block (user pass/match in front, user block/reject behind), and `order_4` places the
+> user's own Block before its Pass — so the buckets *must* be reordered relative to one another.
+> Freezing user-rule order (the single-anchor design) breaks pfB-Permit-vs-user-Block precedence
+> and deletes order_4's intended layout. The corrected invariant is **no DROP, no DUP, no content
+> mutation, and within-bucket order preserved** — *cross*-bucket placement is exactly what
+> `pass_order` controls.
 
-Drop, duplicate, and reorder of user rules become **structurally impossible** for every
-`pass_order` and interface config, because the code never buckets, filters, or re-emits a user
-rule — it only deletes pfB rules and inserts pfB rules.
+DROP, DUPLICATE, and content-MUTATION of user rules become **structurally impossible** for every
+`pass_order` and interface config, because each user rule lands in exactly one bucket and is emitted
+once, verbatim — while the `pass_order` table still governs where the buckets sit.
 
 | Area | Decision |
 | --- | --- |
-| **User rules** | **Immutable.** Never bucketed, filtered, duplicated, or reordered. The kept list = the live `filter/rule` minus the pfB-owned rules this region regenerates, in original order. |
-| **Bypass rules** | DNS-redirect / DoT-block (`pfB_` descr, but inline-managed) are **kept** in place like user rules — not stripped, not regenerated here. |
+| **User rules** | **Content-immutable.** Never duplicated, dropped, or content-mutated; within-bucket order preserved. They ARE sorted into the user pass/match and user block/reject buckets and placed per `pass_order` (that cross-bucket placement is what `pass_order` means). |
+| **Bypass rules** | DNS-redirect / DoT-block (`pfB_` descr, but inline-managed) are **kept** like user rules — not stripped, not regenerated here. |
 | **pfB rule generation** | **Unchanged.** `pfb_firewall_rule()` and the `$pfb['permit_*']`/`$pfb['deny_*']`/DNSBL-float builders produce the same rules (same trackers, interfaces, types) as today. |
-| **Placement** | A single **insertion anchor** per `pass_order`, derived from the ORDER table and **validated against live pf first-match precedence (Phase 2)**: the contiguous pfB block(s) are spliced before/after the kept user rules so the intended pfB-vs-user precedence holds **per interface** (where pf actually evaluates them). The `order_2`/`order_3`/`order_4` pfB-pm-vs-pfB-br distinction is preserved by splicing the pfB pass/match block and the pfB block/reject block at their table positions — still without touching user rules. |
+| **Placement** | The **4-bucket stable reorder** (pfB p/m · pfB b/r · user p/m · user b/r), concatenated in the ORDER-table sequence and applied **independently** to the floating and interface pf groups. NOT a single before/after anchor: `order_1`/`order_2` split the user rules around the pfB block so a pfB **Permit** precedes a user **Block**, and `order_4` places the user's own Block before its Pass — neither expressible with one contiguous anchor. (The Phase-2 "single anchor" claim was a false GO; see `RESULTS/02` correction + `RESULTS/05`.) |
 | **Float vs non-float** | Both paths use the same immutable-user model. The floating path is already correct (live-confirmed); the rewrite must not regress it. Floating rules' relative order is preserved by keeping user rules verbatim (pf separates floating from interface rules regardless of `config.xml` interleaving). |
 | **Empty/unknown `pass_order`** | Sanely defaulted (subsumes the #539 fix): an unrecognised order maps to the `order_0` anchor. With user rules immutable, an unknown order can at worst mis-*position* the pfB block — it can never drop a user rule. |
 | **Write gate** | Unchanged: write + `filter_configure()` only when the rebuilt list differs from the original. |
@@ -153,8 +183,10 @@ rule — it only deletes pfB rules and inserts pfB rules.
 ### Semantics that MUST be preserved (the contract — pin with tests before swapping)
 
 1. **User-rule fidelity.** Every non-pfB rule present before the reconciliation is present after,
-   **exactly once**, in its **original relative order** — set, count, and order identical.
-   (red→green for `order_1`/`order_2` dup and `order_4` reorder; oracle-green for `order_0`/`order_3`.)
+   **exactly once**, with its **content intact** and its order preserved **within its bucket** —
+   no drop, no dup, no mutation. (Cross-bucket placement follows `pass_order`; a global "same
+   order" check would be wrong — it would forbid order_1/2/4's intended reorder.) Pinned red→green:
+   the pfB-Permit-vs-user-Block precedence trap fails on the binary helper, green on the 4-way.
 2. **Bypass-rule fidelity.** DNS-redirect/DoT-block rules are preserved (not stripped, not
    duplicated) — same as today.
 3. **pfB rule set identical.** The pfB rules emitted (descr, type, interface, tracker, ipprotocol,
@@ -199,14 +231,21 @@ rule — it only deletes pfB rules and inserts pfB rules.
 
 **Negative / risks**
 
-- **Precedence premise (ADR-01 trap).** If a single anchor per `pass_order` cannot reproduce the
-  intended precedence for some config without splitting user pass vs user block rules (which would
-  violate immutability), the design must narrow. **Mitigation:** Phase 2 proves the anchor model on
-  live pf *before* Phase 3; if it fails, re-scope (see §7 reject criteria).
-- **Deliberate behaviour change.** `order_4` (and the managed/non-managed split) no longer reorders
-  user rules; some installs' `config.xml` rule order changes. Functionally inert where pf is
-  per-interface first-match, but visible. **Mitigation:** documented; Phase 2 confirms no
-  precedence regression on the same interface; release-notes call-out.
+- **Precedence premise (ADR-01 trap) — this is exactly what bit PR #561.** The premise "a single
+  anchor per `pass_order` reproduces the intended precedence" is **false**: `order_1`/`order_2` need
+  the pfB block *between* the user pass/match and user block/reject rules, so a pfB **Permit** can
+  override a user **Block** — impossible with one contiguous anchor. The Phase-2 gate false-GO'd by
+  reducing the table to "pfB-block vs user-pass" and omitting the **pfB-pass vs user-block**
+  interaction, then testing only a Deny-only config (pfB-pass bucket empty). **Resolution:** the
+  4-way bucket assembly (this revision); the off-appliance trap fixture is the gate the Deny-only
+  live probe should have been. The genuine ADR-01 lesson holds: a kill-gate that does not exercise
+  the falsifying case (mixed pfB permit+deny + user pass+block) proves nothing.
+- **`order_4` reorder is INTENDED, not removed.** `order_4` emits the user's own Block before its
+  Pass — documented `pass_order` semantics, preserved here. (The binary-anchor revision wrongly
+  deleted it by freezing user-rule order; that was a regression, not a feature.) The only visible
+  `config.xml` change vs PR #561's behaviour is restoring the correct per-`pass_order` ordering;
+  vs the pre-ADR-41 baseline, behaviour is preserved on every dup-free config (the DROP/DUP cases
+  are the fixes). Release-notes call-out: the order_1/order_2 Permit-vs-Block precedence fix.
 - **Multi-interface / mixed pfB permit+deny configs are under-represented in the factory image.**
   The live image's user rules are LAN/opt1 pass rules; pfB permit rules (`Permit_*` actions) and
   inbound≠outbound need explicit fixtures. **Mitigation:** Phase 1 PHPUnit fixtures cover them
@@ -244,6 +283,13 @@ rule — it only deletes pfB rules and inserts pfB rules.
   `src/`/`tests/` phase uses the full worktree + rebase-only-PR flow.
 
 ## 6. Action plan
+
+> **Correction (`fix/adr-41-restore-pass-order`).** The Phases below are the *original* plan, which
+> built the **binary-anchor** design. Phase 2's GO was false and Phase 3 shipped a flawed helper
+> (PR #561). The course correction (Phase 5, `RESULTS/05`) replaces it with the **4-way bucket
+> stable reorder** and supersedes the "single anchor" / "remove the bucketing" / "order_4 reorder
+> removed" framing here: the `pass_order` bucketing is **kept** (as a no-dup/no-drop/no-mutate
+> stable reorder), not deleted. Read the §0 Status, §2, and §3 corrections for the current design.
 
 Front-loaded with behaviour-preserving prep (extract + oracle-pin the emission) and a **precedence
 kill-gate** before any splice. The core rewrite (Phase 3) only proceeds once Phase 2 proves the

--- a/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/02_Results.txt
@@ -1,8 +1,27 @@
 ADR-41 Phase 2 Results — pf-precedence kill-gate
 ================================================
 Branch: adr/41-immutable-user-firewall-rules   Phase: 2 (measurement / design-proof; NO production code)
-Verdict: GO  (single contiguous anchor per pass_order reproduces the intended pfB-vs-user
-              precedence WITHOUT splitting/reordering user rules)
+Verdict: GO  -- *** SUPERSEDED: THIS GO WAS FALSE *** (see CORRECTION below and RESULTS/05)
+
+*** CORRECTION (post-merge, fix/adr-41-restore-pass-order) **************************************
+The GO verdict below is WRONG. Section 2's "first-match reduction" enumerated pfB-block-vs-user-PASS,
+pfB-pass-vs-user-PASS, and pfB-block-vs-user-block -- but OMITTED the pfB-PASS (Permit list) vs
+user-BLOCK interaction, which is SIGNIFICANT: a pfB Permit rule placed AFTER a user Block loses, so
+a Permit list cannot override a user block. Because that interaction was missed, Section 2's claim
+that the 4-way ORDER table "collapses to one binary question" (pfB block before/after user pass) is
+false, and so is Section 5's proof that a single contiguous anchor suffices. The binary anchor that
+Phase 3 then shipped breaks pfB-Permit-vs-user-Block precedence for order_1/order_2 (and dropped
+order_4's INTENDED user-block-before-user-pass reorder, mis-classified as a defect in Section 6).
+This was not caught because the only live kill-gate case was Deny-only (the pfB-pass bucket empty) --
+exactly the "mixed pfB permit+deny + user rules" config the ADR's own S7 reject criterion named.
+
+CORRECT verdict: a single contiguous anchor does NOT reproduce the precedence; the 4-way bucket
+assembly (pfB p/m, pfB b/r, user p/m, user b/r, ordered per pass_order, applied independently to the
+floating and interface pf groups) is required. Restored on fix/adr-41-restore-pass-order; full
+analysis in RESULTS/05. The Section 1 pf-evaluation facts (per-interface first-match; floating a
+separate group) remain correct; only the Section 2 reduction, the Section 5 GO, and the Section 6
+"order_4 reorder is a removable defect" claim are wrong.
+************************************************************************************************
 
 This phase establishes (a) the real pf evaluation model on a live VM, (b) the
 pass_order -> insertion-anchor mapping the Phase-3 immutable splice implements, and (c) that a

--- a/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_41_Immutable_User_Firewall_Rules/RESULTS/05_Results.txt
@@ -1,0 +1,111 @@
+ADR-41 Phase 5 Results — course correction: restore the 4-way pass_order assembly
+=================================================================================
+Branch: fix/adr-41-restore-pass-order (off devel)   Supersedes: the binary-anchor design (Phase 3)
+Verdict: the Phase-2 GO (RESULTS/02) was FALSE; the binary anchor is replaced by the 4-bucket
+         stable reorder. Off-appliance contract red->green; live data-plane sweep still deferred.
+
+
+1. THE FLAW (what shipped wrong on PR #561)
+-------------------------------------------
+Phase 3 collapsed the five pass_order layouts into ONE before/after anchor for the whole
+contiguous pfB rule block:
+
+    order_1 / order_2        -> pfB block AFTER  the kept user rules
+    order_0 / 3 / 4 / absent -> pfB block BEFORE the kept user rules
+
+That is incorrect. RESULTS/02 S2 reduced the 4-way ORDER table to a single binary question
+("does the pfB block sit before or after the user PASS rules?") by enumerating only:
+    pfB-block vs user-PASS   (significant)
+    pfB-pass  vs user-PASS   (moot)
+    pfB-block vs user-block  (moot)
+It OMITTED the fourth cross-action interaction:
+    pfB-PASS (Permit list) vs user-BLOCK  -> SIGNIFICANT.
+
+A pfB Permit (pass) rule is an admin allowlist; it must override a user Block (the ORDER table
+puts pfB p/m ahead of user b/r in EVERY order_1..order_4). The binary anchor puts the WHOLE user
+block of rules -- including user Block rules -- ahead of the pfB block for order_1/order_2, so a
+pfB Permit lands behind a user Block and loses. order_3/order_4 happened to work (pfB before all
+user rules), which is why a Deny-only kill-gate (the pfB-pass bucket empty) never saw it -- the
+exact "mixed pfB permit+deny + user rules" config the ADR's own S7 reject criterion named as the
+falsifier. The single live case in Phase 2 was Deny-only, so the gate false-GO'd.
+
+Second error: RESULTS/02 S6 and ADR S3 called order_4's user-block-before-user-pass emission a
+"deliberate behaviour change ADR-41 removes". It is NOT a defect -- it is the documented order_4
+semantics (GUI: order_4 = pfB p/m | pfB b/r | pfSense Block/Reject | pfSense Pass/Match). The
+binary anchor, by keeping user rules in original order, silently DROPPED that intended reorder.
+
+
+2. CONFIRMED pf FACTS (re-verified)
+-----------------------------------
+Re-checked against upstream pfSense src/etc/inc/filter.inc (master + RELENG_2_7_2, byte-identical):
+  * filter_generate_user_rule: `if (!isset($rule['floating']) || isset($rule['quick'])) quick`.
+    A NON-floating rule => always quick (first-match). NOTE: a rule that carries floating='' (key
+    present, as pfB rules and many config rows do) does NOT auto-get quick -- so "interface rules
+    are always quick" is an over-claim, and the precedence argument should NOT lean on it.
+  * Floating rules are emitted as a SEPARATE group, BEFORE interface rules (util.inc PFCONFIG
+    category order; RELENG_2_7_2 explicit "Floating, then if-group, then regular" comment).
+The corrected design does NOT depend on the quick claim at all: pfBlockerNG's contract is simply to
+emit its rules in the documented pass_order sequence; the binary anchor violated that sequence.
+
+
+3. THE CORRECT DESIGN — 4-bucket stable reorder
+-----------------------------------------------
+Four buckets: pfB pass/match, pfB block/reject, user pass/match, user block/reject. Concatenate
+them in the pass_order sequence; apply the SAME table INDEPENDENTLY to the two pf groups (because
+pf evaluates them separately):
+  * FLOATING group: always the DNSBL/match pass rules; ALSO the pfB permit/deny when float mode is
+    on (the call site builds them from base_rule_float, so they are floating).
+  * INTERFACE group: the per-interface pfB permit/deny when float mode is off.
+
+    order_0 | pfB p/m | pfB b/r | user (not split)
+    order_1 | user p/m | pfB p/m | pfB b/r | user b/r
+    order_2 | pfB p/m | user p/m | pfB b/r | user b/r
+    order_3 | pfB p/m | pfB b/r | user p/m | user b/r
+    order_4 | pfB p/m | pfB b/r | user b/r | user p/m
+    absent / unknown -> order_0
+
+Whole buckets move; within-bucket order is preserved; no user rule is duplicated (#532), dropped,
+or content-mutated (bar the legacy _v4 upgrade). The ADR-41 "good parts" are kept: bypass rules
+(pfB_DNS_Redirect_ / pfB_DoT_Block_) treated as user-managed; pfB generation unchanged; the
+floating-match-emitted-once invariant; null-$order/$float tolerance; write iff changed.
+
+
+4. VALIDATION (off-appliance; red->green)
+-----------------------------------------
+tests/php/AutoruleListOracleTest.php (rewritten):
+  * Per-order fixtures for the pfB-Permit + pfB-Deny + user-Pass + user-Block trap on one
+    interface, all five orders -- pfB Permit precedes user Block for order_1..4; order_4 emits
+    user Block before user Pass. RED on the binary helper (testTrapOrder1/2/4 + the float-on +
+    differential fail), GREEN on the 4-bucket helper.
+  * Headline guard: the years-proven 8c4c482 emission is embedded FROZEN as
+    pfb_autorule_reference_8c4c482() and the helper is asserted BEHAVIOURALLY identical to it on
+    every dup-free config (per-interface, per-direction projection) -- proving the restore
+    reproduces the proven behaviour everywhere except the two reference defects it fixes (the
+    order_1/order_2 user-pass DUP across the in/out loops, and the empty-order / order_2-float-on
+    DROP). Those dup/drop-trigger configs are skipped from the differential and pinned to the
+    corrected behaviour by the fixtures + a dedicated no-drop test.
+  * Kept: user-rule fidelity (no drop/dup/mutation), idempotence, match-emitted-once, dnsbl lead,
+    bypass preservation, pfB-owned stripping, within-bucket order, null tolerance.
+  Result: 17 tests, 7703 assertions GREEN on the 4-bucket helper; 5 of them FAIL on the binary
+  helper (the precedence + order-table + differential tests). PHPUnit (full 1453), PHPStan,
+  PHPCS, php -l all green.
+
+A development-time differential harness (PHP, 4000 randomized configs) confirmed the helper is
+behaviourally == the 8c4c482 reference on every dup-free config and never duplicates a user rule;
+its logic is committed as the in-suite differential.
+
+
+5. LIVE (out-of-CI; the acceptance gate)
+----------------------------------------
+tests/smoke/test_smoke_autorule_immutable.py updated to a pfB-Permit + pfB-Deny + user-pass/block
+per-pass_order data-plane precedence sweep (blocked-vs-allowed probe), CE + Plus fan-out. Still
+skip-deferred (pytest.mark.skip) pending Phase-4 live wiring -- the off-appliance contract above is
+the proof for now. ADR flips to Accepted only once that live CE+Plus fan-out is green. This is the
+kill-gate the Deny-only Phase-2 probe should have been.
+
+
+6. STATUS
+---------
+Implemented (4-way restored) pending live-VM smoke. ADR S2 (binary -> 4-bucket), S3 (order_4
+reorder is intended, not removed), and Status corrected; RESULTS/02 GO marked FALSE; architecture
+-notes rewritten. Lands via PR on fix/adr-41-restore-pass-order (touches src/ + tests/).

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -462,30 +462,42 @@ Full design: ADR-39.
 
 The IP-side autorule pass in `sync_package_pfblockerng()` reconciles pfBlockerNG's own
 `filter/rule` entries each update via the pure helper `pfb_build_autorule_list($existing_rules,
-$pfb_generated, $order, $float, $in_ifaces, $out_ifaces)` (pfblockerng.inc). It treats **user
-rules as immutable**: the kept list is the live `filter/rule` minus only the pfB-owned rules this
-region regenerates (descr starts `pfB_`, **excluding** the DNS-redirect/DoT-block bypass rules,
-which are kept like user rules), in their **original order**; pfBlockerNG's rules are generated
-unchanged and **spliced as one contiguous block at a single anchor**. No user rule is ever
-bucketed, filtered, duplicated, split, or reordered — eliminating the #532 drop / order_1·2
-duplication / order_4 reorder as a class.
+$pfb_generated, $order, $float, $in_ifaces, $out_ifaces)` (pfblockerng.inc). It is a **stable
+bucket reorder**: every surviving rule is sorted into one of four buckets — pfB pass/match, pfB
+block/reject, user pass/match, user block/reject — and the buckets are concatenated in the
+sequence the `pass_order` setting dictates. The pfB-owned rules (descr starts `pfB_`, **excluding**
+the DNS-redirect/DoT-block bypass rules, which are kept like user rules) are regenerated unchanged;
+user rules pass through verbatim. Whole buckets move — nothing **inside** a bucket is reordered,
+and **no user rule is duplicated (#532), dropped, or content-mutated** (bar the legacy `_v4`
+alias-suffix upgrade). Cross-bucket movement is exactly what `pass_order` means and is allowed.
 
-The anchor is **binary**, because pf is per-interface first-match (`quick`) so the only
-user-visible interaction is pfB-block-vs-user-**pass** (pass-vs-pass and block-vs-block are moot):
+The reorder is applied **independently to the two pf rule groups**, because pf evaluates them
+separately: the **floating** group (always carries the DNSBL/match pass rules; also the pfB
+permit/deny when float mode is on, since the call site then builds them from `base_rule_float`) and
+the **interface** group (the per-interface pfB permit/deny when float mode is off). Each group
+orders its own four buckets by the same ORDER table (GUI `pfblockerng_ip.php`):
 
-- `order_0` / `order_3` / `order_4` / absent / unknown → pfB block **before** the kept user rules
-  (pfB wins; absent→order_0 subsumes the #539 default).
-- `order_1` / `order_2` → pfB block **after** the kept user rules (user pass wins).
+```text
+order_0 | pfB p/m | pfB b/r | user (not split)
+order_1 | user p/m | pfB p/m | pfB b/r | user b/r
+order_2 | pfB p/m | user p/m | pfB b/r | user b/r
+order_3 | pfB p/m | pfB b/r | user p/m | user b/r
+order_4 | pfB p/m | pfB b/r | user b/r | user p/m
+absent / unknown → order_0
+```
 
-The contract (user-rule fidelity, pfB-rule-set identical, idempotence) is pinned off-appliance in
+A single before/after anchor for the whole pfB block **cannot** express this: `order_1`/`order_2`
+split the user rules (user pass/match in front, user block/reject behind the pfB block), so a pfB
+**Permit** list (pass) must precede a user **Block** — putting the whole user block of rules ahead
+of the pfB block lets a user Block shadow a pfB Permit. `order_4` likewise places the user's own
+**Block** before its **Pass** (intended `pass_order` semantics, not a removable reorder).
+
+The contract (per-order placement incl. the pfB-Permit-vs-user-Block trap, user-rule fidelity,
+pfB-rule-set identical, idempotence, and behavioural equivalence to the years-proven `8c4c482`
+emission on every dup-free config) is pinned off-appliance in
 `tests/php/AutoruleListOracleTest.php`; the live data-plane precedence sweep is
-`tests/smoke/test_smoke_autorule_immutable.py` (ADR-04). Design + the live pf-precedence kill-gate
-evidence: `.ADRs/ADR_41_Immutable_User_Firewall_Rules/`.
-
-**Deliberate behaviour change (release notes):** `order_4` (and the old managed/non-managed split)
-no longer **reorders** the user's own rules — user rules are now kept verbatim. Functionally inert
-under per-interface first-match, but some installs' `config.xml` rule order changes on
-`order_1`/`order_2`/`order_4`.
+`tests/smoke/test_smoke_autorule_immutable.py` (ADR-04). Design + the corrected pf-precedence
+analysis: `.ADRs/ADR_41_Immutable_User_Firewall_Rules/` (`RESULTS/05`).
 
 ## Managed firewall object ownership and teardown (ADR-35)
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11716,10 +11716,12 @@ function pfb_syslog_logging_needs_update($current, $want) {
  *                                  'inbound_floating' => interface string for match_inbound floating
  *                                  'outbound_floating'=> interface string for match_outbound floating
  *                                  'dnsbl_float'      => array of 0-2 pre-built DNSBL ping/permit rules
- * @param ?string $order          The pass_order value ('order_0' .. 'order_4', or ''); null (the
- *                                unconfigured $pfb['order']) is coerced to '' (matches no order).
+ * @param ?string $order          The pass_order value ('order_0' .. 'order_4'). The production
+ *                                call site already passes `$pfb['order'] ?: 'order_0'`, so this is
+ *                                never null/empty there (#532); nullable + the order_0 normalisation
+ *                                below are defensive so any empty/unknown value behaves as order_0.
  * @param ?string $float          Float mode: 'on' or '' (off); null (the unconfigured
- *                                $pfb['float']) is coerced to '' (off).
+ *                                $pfb['float']) is coerced to '' (off) — this one IS passed unset.
  * @param array  $in_ifaces       Inbound interface names.
  * @param array  $out_ifaces      Outbound interface names.
  * @return array The new filter/rule array to write back to config.xml.
@@ -11732,11 +11734,12 @@ function pfb_build_autorule_list(
 	array   $in_ifaces,
 	array   $out_ifaces
 ): array {
-	// $order/$float come straight from $pfb['order']/$pfb['float'], which are unset (null)
-	// until configured. The historical inline code used those raw values in loose comparisons
-	// ('== on' / '== order_N'), where null simply matches nothing -- so a null is behaviour-
-	// equivalent to ''. Coerce here (the params are nullable) rather than let a strict string
-	// typehint TypeError on the null the call site legitimately passes (e.g. enable_float unset).
+	// $float comes straight from $pfb['float'], which is unset (null) until configured; $order
+	// arrives pre-defaulted to 'order_0' from the call site (#532) but is accepted nullable too.
+	// The historical inline code used these raw values in loose comparisons ('== on' / '== order_N'),
+	// where null simply matches nothing -- so a null is behaviour-equivalent to ''. Coerce here
+	// (the params are nullable) rather than let a strict string typehint TypeError on the null the
+	// call site legitimately passes (e.g. enable_float unset).
 	$order = $order ?? '';
 	$float = $float ?? '';
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11683,15 +11683,25 @@ function pfb_syslog_logging_needs_update($current, $want) {
 /**
  * pfb_build_autorule_list() — pure emission helper extracted from sync_package_pfblockerng().
  *
- * Keeps all non-pfB rules verbatim (same set, count, and original relative order) and splices
- * the regenerated pfB rules at a single anchor determined by pass_order. No user rule is ever
- * bucketed, filtered, duplicated, split, or reordered — the only operations are "keep in place"
- * for user rules and "regenerate at anchor" for pfB rules.
+ * Reconciles the firewall auto-rules by a STABLE bucket reorder: every surviving rule is sorted
+ * into one of four buckets — pfB pass/match, pfB block/reject, user pass/match, user block/reject
+ * — and the buckets are concatenated in the sequence the `pass_order` setting dictates. Whole
+ * buckets move; nothing INSIDE a bucket is reordered, and no user rule is ever duplicated,
+ * dropped, or content-mutated (the one exception is the legacy `_v4` alias-suffix upgrade). pfB
+ * rules are regenerated from $pfb_generated; user rules pass through verbatim.
  *
- * Anchor mapping (per-interface first-match semantics — ADR-41 Phase 2):
- *   order_1 / order_2           → pfB block AFTER kept user rules  (user pass wins)
- *   order_0 / order_3 / order_4 → pfB block BEFORE kept user rules (pfB wins)
- *   absent / unknown            → order_0 anchor / BEFORE           [subsumes #539]
+ * The reorder is applied INDEPENDENTLY to the two pf rule groups, because pf evaluates them
+ * separately: the FLOATING group (always carries the DNSBL/match pass rules; also the pfB
+ * permit/deny when float mode is on, since the call site then builds them from base_rule_float)
+ * and the INTERFACE group (the per-interface pfB permit/deny when float mode is off). Each group
+ * orders its own four buckets by the same ORDER table:
+ *
+ *   order_0 | pfB pass/match | pfB block/reject | user (not split) |
+ *   order_1 | user pass/match | pfB pass/match | pfB block/reject | user block/reject |
+ *   order_2 | pfB pass/match | user pass/match | pfB block/reject | user block/reject |
+ *   order_3 | pfB pass/match | pfB block/reject | user pass/match | user block/reject |
+ *   order_4 | pfB pass/match | pfB block/reject | user block/reject | user pass/match |
+ *   absent / unknown → order_0
  *
  * Returns the new filter/rule array. No I/O, no config writes, no pfctl — pure array logic.
  *
@@ -11723,100 +11733,165 @@ function pfb_build_autorule_list(
 	array   $out_ifaces
 ): array {
 	// $order/$float come straight from $pfb['order']/$pfb['float'], which are unset (null)
-	// until configured. The original inline code used those raw values in loose comparisons
+	// until configured. The historical inline code used those raw values in loose comparisons
 	// ('== on' / '== order_N'), where null simply matches nothing -- so a null is behaviour-
 	// equivalent to ''. Coerce here (the params are nullable) rather than let a strict string
 	// typehint TypeError on the null the call site legitimately passes (e.g. enable_float unset).
 	$order = $order ?? '';
 	$float = $float ?? '';
 
-	// Step 1: build $keep — all non-pfB-owned rules in original order, alias-upgraded.
-	// A rule is pfB-owned iff its descr starts with 'pfB_' AND it is NOT a bypass rule
-	// (DNS-redirect / DoT-block bypass rules keep their pfB_ prefix but stay user-managed).
-	$keep = [];
+	// Any value that is not a known order_1..4 behaves as order_0 -- the IP-settings default.
+	// An empty/unknown order must never drop a user rule (issue #532/#539): normalise up front so
+	// the bucketing and the order switch below always have a defined sequence.
+	if (!in_array($order, ['order_1', 'order_2', 'order_3', 'order_4'], TRUE)) {
+		$order = 'order_0';
+	}
+	$managed = array_merge($in_ifaces, $out_ifaces);
+
+	// --- Partition surviving user rules into stable buckets --------------------------------
+	// A rule is pfB-owned (regenerated below) iff its descr starts 'pfB_' AND it is not a
+	// DNS-redirect / DoT-block bypass rule (those keep the prefix but stay user-managed). Every
+	// surviving user rule lands in EXACTLY ONE bucket -- never duplicated -- and its content is
+	// left untouched bar the legacy _v4 alias-suffix upgrade. The split mirrors the historical
+	// sync_package_pfblockerng() "Assign Rules" logic verbatim; the four floating sub-buckets
+	// only fill when pfB float mode is on (so user floating rules order relative to the floating
+	// pfB rules), and $user_pm only fills when float mode is off (interface-group ordering).
+	$user_pm = [];   // user pass/match on a managed iface  (float off, order != order_0)
+	$user_br = [];   // every other non-floating user rule  (block/reject, order_0 catch-all, unmanaged)
+	$fpermit = [];   // user floating pass   (float on)
+	$fmatch  = [];   // user floating match  (float on)
+	$fother  = [];   // user floating other  (float-on block/reject; ALL floating user rules when float off)
+
 	foreach ($existing_rules as $rule) {
-		$descr      = $rule['descr'] ?? '';
-		$is_bypass  = str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
-		              str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
+		$descr     = $rule['descr'] ?? '';
+		$is_bypass = str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
+		             str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
 
 		if (str_starts_with($descr, 'pfB_') && !$is_bypass) {
-			continue;  // pfB-owned — will be regenerated below
+			continue;  // pfB-owned — regenerated below
 		}
 
-		// Upgrade previous IPv4 pfBlockerNG alias names to '_v4' suffix format.
+		// Upgrade previous IPv4 pfBlockerNG alias names to '_v4' suffix format — the ONLY
+		// permitted content change to a user rule.
 		foreach (array('source', 'destination') as $rtype) {
 			if (pfb_rule_alias_needs_v4_suffix($rule[$rtype]['address'] ?? '', $rule['ipprotocol'] ?? '')) {
 				$rule[$rtype]['address'] = "{$rule[$rtype]['address']}_v4";
 			}
 		}
 
-		$keep[] = $rule;
+		$is_floating = ($rule['floating'] ?? '') === 'yes';
+		$type        = $rule['type'] ?? '';
+
+		if ($float === 'on') {
+			if ($order === 'order_0' && $is_floating) {
+				$fother[]  = $rule;
+			} elseif ($is_floating && $type === 'pass') {
+				$fpermit[] = $rule;
+			} elseif ($is_floating && $type === 'match') {
+				$fmatch[]  = $rule;
+			} elseif ($is_floating) {
+				$fother[]  = $rule;
+			} else {
+				$user_br[] = $rule;
+			}
+		} elseif ($is_floating) {
+			$fother[] = $rule;
+		} elseif (in_array($rule['interface'] ?? '', $managed, TRUE) &&
+		          ($type === 'pass' || isset($rule['associated-rule-id'])) &&
+		          $order !== 'order_0') {
+			$user_pm[] = $rule;
+		} else {
+			$user_br[] = $rule;
+		}
 	}
 
-	// Step 2: build the pfB block — same generation order as before (dnsbl_float first,
-	// then per-inbound permit/match/deny, then per-outbound permit/match/deny).
-	$pfb_block = [];
+	// --- Regenerate the pfB rule buckets ---------------------------------------------------
+	// DNSBL floating pass pair and the floating match rules ALWAYS belong to the floating pf
+	// group; the per-interface permit/deny join the floating group when float mode is on and the
+	// interface group otherwise (handled in the assembly below). The match rule is floating-only
+	// and emitted ONCE across all interfaces; it rides in the pass/match bucket. (Grouping it
+	// after the per-interface permits rather than mid-loop is inert: a match rule does not
+	// short-circuit, and interface-scoped permits on different interfaces never interact.)
+	$dnsbl   = [];   // pfB floating DNSBL pass (ping/permit pair, or empty)
+	$ppermit = [];   // pfB permit (per managed interface)
+	$pmatch  = [];   // pfB floating match (emitted once)
+	$pdeny   = [];   // pfB block/reject (per managed interface)
 
-	// DNSBL floating pass rules (ping + permit pair, or empty) — emitted before interface rules.
 	foreach ($pfb_generated['dnsbl_float'] as $cb_rules) {
-		$pfb_block[] = $cb_rules;
+		$dnsbl[] = $cb_rules;
 	}
 
-	// Inbound interface rules.
 	$pfbrunonce = TRUE;
 	foreach ($in_ifaces as $inbound_interface) {
 		foreach ($pfb_generated['permit_inbound'] as $cb_rules) {
 			$cb_rules['interface'] = $inbound_interface;
 			$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'permit_in');
-			$pfb_block[]           = $cb_rules;
+			$ppermit[]             = $cb_rules;
 		}
-		// Match inbound rules are floating-only (emit once across all inbound interfaces).
 		if ($pfbrunonce && !empty($pfb_generated['match_inbound'])) {
 			foreach ($pfb_generated['match_inbound'] as $cb_rules) {
 				$cb_rules['interface'] = $pfb_generated['inbound_floating'];
 				$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'match_in');
-				$pfb_block[]           = $cb_rules;
+				$pmatch[]              = $cb_rules;
 				$pfbrunonce            = FALSE;
 			}
 		}
 		foreach ($pfb_generated['deny_inbound'] as $cb_rules) {
 			$cb_rules['interface'] = $inbound_interface;
 			$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'deny_in');
-			$pfb_block[]           = $cb_rules;
+			$pdeny[]               = $cb_rules;
 		}
 	}
 
-	// Outbound interface rules.
 	$pfbrunonce = TRUE;
 	foreach ($out_ifaces as $outbound_interface) {
 		foreach ($pfb_generated['permit_outbound'] as $cb_rules) {
 			$cb_rules['interface'] = $outbound_interface;
 			$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'permit_out');
-			$pfb_block[]           = $cb_rules;
+			$ppermit[]             = $cb_rules;
 		}
-		// Match outbound rules are floating-only (emit once across all outbound interfaces).
 		if ($pfbrunonce && !empty($pfb_generated['match_outbound'])) {
 			foreach ($pfb_generated['match_outbound'] as $cb_rules) {
 				$cb_rules['interface'] = $pfb_generated['outbound_floating'];
 				$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'match_out');
-				$pfb_block[]           = $cb_rules;
+				$pmatch[]              = $cb_rules;
 				$pfbrunonce            = FALSE;
 			}
 		}
 		foreach ($pfb_generated['deny_outbound'] as $cb_rules) {
 			$cb_rules['interface'] = $outbound_interface;
 			$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'deny_out');
-			$pfb_block[]           = $cb_rules;
+			$pdeny[]               = $cb_rules;
 		}
 	}
 
-	// Step 3: splice at anchor.
-	// order_1/order_2 → AFTER the kept user rules (user pass wins under per-iface first-match).
-	// Everything else (order_0/3/4, absent, unknown) → BEFORE (pfB wins). Subsumes #539.
-	if ($order === 'order_1' || $order === 'order_2') {
-		return array_values(array_merge($keep, $pfb_block));
+	// --- Assemble each pf group's four buckets in pass_order sequence -----------------------
+	// $apply moves whole buckets per the ORDER table; order_0 and order_3 share a sequence
+	// (order_0 leaves $upm empty by construction, so user pass/match is never split out).
+	$apply = static function (string $o, array $pm, array $br, array $upm, array $ubr): array {
+		return match ($o) {
+			'order_1' => array_merge($upm, $pm, $br, $ubr),
+			'order_2' => array_merge($pm, $upm, $br, $ubr),
+			'order_4' => array_merge($pm, $br, $ubr, $upm),
+			default   => array_merge($pm, $br, $upm, $ubr),  // order_0 / order_3
+		};
+	};
+
+	if ($float === 'on') {
+		// Float mode on: the pfB permit/deny are floating too, so the whole pass_order reorder
+		// happens in the floating group; the interface group carries only non-floating user rules.
+		$float_seq = $apply($order, array_merge($dnsbl, $ppermit, $pmatch), $pdeny,
+		                    array_merge($fpermit, $fmatch), $fother);
+		$iface_seq = $apply($order, [], [], [], $user_br);
+	} else {
+		// Float mode off: pfB permit/deny are interface rules; only DNSBL/match are floating.
+		// In the floating group the user's floating rules ($fother) historically lead for
+		// order_1 and trail otherwise — the $upm slot reproduces exactly that placement.
+		$float_seq = $apply($order, array_merge($dnsbl, $pmatch), [], $fother, []);
+		$iface_seq = $apply($order, $ppermit, $pdeny, $user_pm, $user_br);
 	}
-	return array_values(array_merge($pfb_block, $keep));
+
+	return array_values(array_merge($float_seq, $iface_seq));
 }
 
 // Main pfBlockerNG function
@@ -15641,14 +15716,14 @@ function sync_package_pfblockerng($cron='') {
 			#  ORDER 3 |	pfB (p/m)	| pfB (b/r) 	| pfSense (p/m)	| pfSense (b/r)	#
 			#  ORDER 4 |	pfB (p/m)	| pfB (b/r)	| pfSense (b/r)	| pfSense (p/m)	#
 			#################################################################################
-			# NOTE (ADR-41): the 4-column interleaving above is the ORIGINAL strip-and-rebuild
-			# intent. pfb_build_autorule_list() now keeps user rules IMMUTABLE and reduces this to a
-			# BINARY anchor for the contiguous pfB block:
-			#   order_1 / order_2        -> pfB block AFTER  the kept user rules (user pass wins)
-			#   order_0 / 3 / 4 / absent -> pfB block BEFORE the kept user rules (pfB wins)
-			# The pfB-p/m-vs-pfSense-p/m distinction is moot under per-interface first-match pf
-			# (interface rules are always `quick`; proven live in ADR-41 Phase 2 -> RESULTS/02), so
-			# it is no longer reproduced. order_4 no longer reorders the user's own rules.
+			# NOTE (ADR-41): pfb_build_autorule_list() implements this table as a STABLE bucket
+			# reorder -- it sorts every surviving rule into one of the four buckets (pfB p/m, pfB
+			# b/r, user p/m, user b/r) and concatenates them in the column order above, applied
+			# independently to the FLOATING and INTERFACE pf groups. Whole buckets move; nothing
+			# inside a bucket is reordered, and no user rule is duplicated, dropped, or mutated.
+			# All four columns are reproduced (a single before/after anchor cannot: order_1/order_2
+			# split the user rules around the pfB block, so a pfB Permit must precede a user Block;
+			# order_4 places the user's own Block before its Pass). Absent/unknown order -> order_0.
 
 			$new_rules = pfb_build_autorule_list(
 				$rules ?? [],

--- a/tests/php/AutoruleListOracleTest.php
+++ b/tests/php/AutoruleListOracleTest.php
@@ -33,11 +33,15 @@ use PHPUnit\Framework\TestCase;
  *
  * The headline regression guard is testBehaviourEqualsProvenReferenceOnDupFreeMatrix(): the helper
  * is asserted BEHAVIOURALLY identical to the years-proven pre-ADR-41 emission
- * (pfb_autorule_reference_8c4c482, frozen below) across a matrix of dup-free configs — same
- * per-(interface, direction) evaluation sequence. The reference's two known defects (the user-pass
- * DUP across the in/out loops, and the empty-order DROP) are exactly what this change fixes, so the
- * differential is asserted only where the reference is dup-free; the dup-trigger cases are pinned
- * to the corrected ORDER-table behaviour by the explicit per-order fixtures.
+ * (pfb_autorule_reference_8c4c482, frozen below) across a matrix of configs — same
+ * per-(interface, direction) evaluation sequence AND the same full rule set (field-level, tracker
+ * aside). The reference mishandles three config classes — exactly what this change fixes — which
+ * are therefore SKIPPED from the differential and pinned to the corrected ORDER table by the
+ * explicit per-order fixtures instead: (1) the user-pass DUP when an interface is both in and out
+ * (order_1/order_2); (2) the order_2+float-on floating mis-order (it wedges the floating user
+ * pass/match into the inbound loop). The empty/unknown-order DROP (3) is NOT skipped — the
+ * differential feeds the reference the same `?: 'order_0'` normalization the production call site
+ * applies, so that case is compared, not excluded.
  *
  * Loads the real pfblockerng.inc off-appliance via tests/php/bootstrap.php (shims + doubles).
  */
@@ -481,24 +485,25 @@ final class AutoruleListOracleTest extends TestCase
 	}
 
 	/**
-	 * Fidelity contract (a): user rules survive as a multiset — no DROP, no DUP, content
-	 * untouched (bar the _v4 upgrade). Deliberately order-INDEPENDENT: cross-bucket reorder is
-	 * exactly what pass_order does, so a global-order check would be wrong. Within-bucket order
-	 * is pinned by the explicit per-order fixtures (and testWithinBucketOrderPreserved).
+	 * Fidelity contract (a): user rules survive as a multiset — no DROP, no DUP, and the FULL
+	 * content untouched (every field: source, destination, ipprotocol, associated-rule-id, …, not
+	 * just the descr/type/interface/floating/direction shape). Uses canonical (order-insensitive)
+	 * equality so cross-bucket reorder — exactly what pass_order does — is allowed while any
+	 * content mutation goes red. Within-bucket order is pinned by the explicit per-order fixtures.
+	 * (Callers that legitimately mutate content — the _v4 upgrade — assert that transform directly
+	 * instead of via this helper.)
 	 */
 	private function assertUserRulesIntact(array $input, array $output, string $ctx): void
 	{
-		$inUser  = $this->shapes(array_values(array_filter($input,  fn ($r) => $this->isUserRule($r))));
-		$outUser = $this->shapes(array_values(array_filter($output, fn ($r) => $this->isUserRule($r))));
-		sort($inUser);
-		sort($outUser);
-		$this->assertEquals(
+		$inUser  = array_values(array_filter($input,  fn ($r) => $this->isUserRule($r)));
+		$outUser = array_values(array_filter($output, fn ($r) => $this->isUserRule($r)));
+		$this->assertEqualsCanonicalizing(
 			$inUser,
 			$outUser,
-			"User-rule fidelity failure [{$ctx}]: user rules must survive exactly once, content "
-				. "intact (no drop, no dup, no mutation).\n\nExpected (multiset):\n"
-				. json_encode($inUser, JSON_PRETTY_PRINT) . "\n\nActual (multiset):\n"
-				. json_encode($outUser, JSON_PRETTY_PRINT)
+			"User-rule fidelity failure [{$ctx}]: every user rule must survive exactly once with its "
+				. "FULL content intact (no drop, no dup, no source/destination/ipprotocol mutation).\n\n"
+				. "Input user rules:\n" . json_encode($inUser, JSON_PRETTY_PRINT)
+				. "\n\nOutput user rules:\n" . json_encode($outUser, JSON_PRETTY_PRINT)
 		);
 	}
 
@@ -646,6 +651,37 @@ final class AutoruleListOracleTest extends TestCase
 		}
 	}
 
+	public function testOrder2FloatOnMatchPlacement(): void
+	{
+		// order_2 + float-on is the one case the proven-reference differential cannot oracle (the
+		// reference mis-orders it), so the floating MATCH placement must be pinned by a fixture:
+		// the pfB Match rides in the pfB pass/match bucket and the user float Match in the user
+		// pass/match bucket — both BEFORE the pfB Deny (order_2 = pfB p/m | user p/m | pfB b/r | …).
+		$gen = $this->genWithMatch();
+		$gen['permit_inbound'] = [
+			['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass', 'interface' => '', 'direction' => 'in',
+			 'ipprotocol' => 'inet', 'floating' => 'yes', 'source' => ['address' => 'pfB_PermitList_v4'], 'destination' => ['any' => '']],
+		];
+		$gen['deny_inbound'][0]['floating'] = 'yes';
+		$gen['match_inbound'][0]['floating'] = 'yes';
+		$existing = [
+			$this->userPass('User float allow', 'lan', 'yes'),
+			$this->userMatch('User float match', 'lan'),
+			$this->userBlock('User float block', 'lan', 'yes'),
+		];
+		$result = pfb_build_autorule_list($existing, $gen, 'order_2', 'on', ['lan'], []);
+
+		$this->assertShapes([
+			['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+			['descr' => 'pfB_MatchList_v4 Auto Rule',  'type' => 'match', 'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+			['descr' => 'User float allow',            'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+			['descr' => 'User float match',            'type' => 'match', 'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+			['descr' => 'User float block',            'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+		], $result, 'order_2 float-on with match');
+		$this->assertUserRulesIntact($existing, $result, 'order_2 float-on with match');
+	}
+
 	// =======================================================================
 	// pfB rule generation invariants
 	// =======================================================================
@@ -698,6 +734,33 @@ final class AutoruleListOracleTest extends TestCase
 		$this->assertContains('pfB_DNS_Redirect_lan_v4', $descrs, 'DNS-redirect bypass kept');
 		$this->assertContains('pfB_DoT_Block_lan', $descrs, 'DoT-block bypass kept');
 		$this->assertUserRulesIntact($existing, $result, 'bypass kept');
+	}
+
+	public function testV4AliasSuffixUpgradeAppliedToUserRuleAddress(): void
+	{
+		// The ONE sanctioned content mutation: a user rule referencing a bare pfB_ alias on an
+		// inet rule has its source/destination address upgraded to the '_v4' form. A '_v6' alias
+		// on an inet6 rule is left untouched (the issue #360 guard — appending '_v4' would point
+		// at the nonexistent pfB_*_v6_v4). This is the only field-level change the helper may make
+		// to a user rule; assertUserRulesIntact would (correctly) reject it, so assert it directly.
+		$inetRule = ['descr' => 'User via pfB alias v4', 'type' => 'pass', 'interface' => 'lan',
+		             'ipprotocol' => 'inet', 'floating' => '', 'source' => ['address' => 'pfB_CustomList'],
+		             'destination' => ['any' => '']];
+		$inet6Rule = ['descr' => 'User via pfB alias v6', 'type' => 'pass', 'interface' => 'lan',
+		              'ipprotocol' => 'inet6', 'floating' => '', 'source' => ['address' => 'pfB_CustomList_v6'],
+		              'destination' => ['any' => '']];
+		$result = pfb_build_autorule_list([$inetRule, $inet6Rule], $this->genDenyOnly(), 'order_0', '', ['lan'], []);
+
+		$byDescr = [];
+		foreach ($result as $r) {
+			$byDescr[$r['descr'] ?? ''] = $r;
+		}
+		$this->assertSame('pfB_CustomList_v4', $byDescr['User via pfB alias v4']['source']['address'] ?? null,
+			"bare pfB_ alias on an inet rule must be upgraded to '_v4'.\nActual: "
+				. json_encode($byDescr['User via pfB alias v4'] ?? null, JSON_PRETTY_PRINT));
+		$this->assertSame('pfB_CustomList_v6', $byDescr['User via pfB alias v6']['source']['address'] ?? null,
+			"a '_v6' alias on an inet6 rule must be left untouched (#360 guard).\nActual: "
+				. json_encode($byDescr['User via pfB alias v6'] ?? null, JSON_PRETTY_PRINT));
 	}
 
 	// =======================================================================
@@ -842,6 +905,16 @@ final class AutoruleListOracleTest extends TestCase
 					);
 				}
 			}
+			// Field-level fidelity (order-insensitive): the full rule set — source / destination /
+			// ipprotocol / every field EXCEPT the tracker — must match the proven reference, not
+			// just the descr/type/interface/floating/direction shape the eval-sequence compares.
+			// The tracker is stripped: pfb_tracker() is stateful (a per-call counter), so new and
+			// the reference legitimately mint different tracker ids; tracker PRESENCE is checked by
+			// assertTrackersSet, and tracker order/position by the eval-sequence above.
+			$strip = static fn (array $rules): array => array_map(
+				static function (array $r): array { unset($r['tracker']); return $r; }, $rules);
+			$this->assertEqualsCanonicalizing($strip($refClean), $strip($new),
+				"[{$label}] full rule set (field-level, tracker aside) diverges from the proven reference");
 			$compared++;
 		}
 

--- a/tests/php/AutoruleListOracleTest.php
+++ b/tests/php/AutoruleListOracleTest.php
@@ -6,256 +6,295 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Contract tests for pfb_build_autorule_list() — ADR-41 Phase 3.
+ * Oracle for pfb_build_autorule_list() — the IP auto-rule reconciler (ADR-41).
  *
- * Three invariants hold for every fixture (ADR-41 §2 Decision table):
- *   (a) USER-RULE FIDELITY: every non-pfB rule in $existing_rules appears in the output
- *       in the SAME relative order and with the SAME count (no drop, no dup, no reorder).
- *   (b) PFB-SET IDENTICAL: the pfB rules emitted are the same set (descr/type/interface/
- *       floating) as would have been generated from the same $pfb_generated inputs.
- *   (c) IDEMPOTENCE: running the helper on its own output is a no-op (second pass
- *       produces the same result as the first).
+ * pfBlockerNG regenerates its own firewall rules on every sync and must splice them around the
+ * user's rules. The helper does a STABLE bucket reorder: each surviving rule is sorted into one
+ * of four buckets — pfB pass/match, pfB block/reject, user pass/match, user block/reject — and
+ * the buckets are concatenated in the sequence the `pass_order` setting dictates. The reorder is
+ * applied independently to the two pf rule groups (FLOATING and INTERFACE), because pf evaluates
+ * them separately. The ORDER table (GUI: pfblockerng_ip.php):
  *
- * Anchor mapping (per-interface first-match — live-confirmed, ADR-41 Phase 2):
- *   order_1 / order_2           → pfB block AFTER  kept user rules (user pass wins)
- *   order_0 / order_3 / order_4 → pfB block BEFORE kept user rules (pfB wins)
- *   absent / unknown            → BEFORE (subsumes #539 drop bug)
+ *   order_0 | pfB p/m | pfB b/r | user (not split)               (default)
+ *   order_1 | user p/m | pfB p/m | pfB b/r | user b/r
+ *   order_2 | pfB p/m | user p/m | pfB b/r | user b/r
+ *   order_3 | pfB p/m | pfB b/r | user p/m | user b/r
+ *   order_4 | pfB p/m | pfB b/r | user b/r | user p/m
+ *   absent / unknown → order_0
  *
- * Fixture matrix covered (each pass_order × float on/off unless noted):
- *   A. order_0,  float=off, inbound==outbound ('lan'), Deny_* only
- *   B. order_0,  float=on,  inbound==outbound ('lan'), Deny_* only
- *   C. order_1,  float=off, inbound==outbound ('lan'), Deny_* only
- *   D. order_1,  float=off, inbound!=outbound ('lan'+'opt1'), Deny_* only
- *   E. order_1,  float=on,  inbound==outbound ('lan'), Deny_* only
- *   F. order_2,  float=off, inbound==outbound ('lan'), Deny_* only
- *   G. order_2,  float=off, inbound!=outbound ('lan'+'opt1'), Deny_* only
- *   H. order_2,  float=on,  inbound==outbound ('lan'), Deny_* only
- *   I. order_3,  float=off, inbound==outbound ('lan'), Deny_* only
- *   J. order_3,  float=on,  inbound==outbound ('lan'), Deny_* only
- *   K. order_4,  float=off, inbound==outbound ('lan'), Deny_* only
- *   L. order_4,  float=off, two ifaces (opt1 in, lan out)
- *   M. order_4,  float=on,  inbound==outbound ('lan'), Deny_* only
- *   N. absent/empty pass_order, float=off — treated as BEFORE (same as order_0)
- *   O. Permit_* (permit_inbound + permit_outbound) present, order_1, float=off
- *   P. DNS-redirect bypass rule present (pfB_ descr but NOT stripped), order_0, float=off
- *   Q. DoT-block bypass rule present, order_0, float=off
- *   R. pfB_ rules stripped and rebuilt (sanity)
- *   S. DNSBL float rules emitted before iface loop
- *   T. Empty existing rules → only pfB rules
- *   U. Non-managed iface user rule preserved in output
+ * Contract pinned here:
+ *   (a) every non-pfB (user) rule survives exactly once, with its content untouched (bar the
+ *       legacy `_v4` alias-suffix upgrade) — no DROP (#532), no DUP, no mutation. Cross-bucket
+ *       reorder IS allowed (it is what pass_order means); within-bucket order is preserved.
+ *   (b) the pfB rules are regenerated and ordered per the ORDER table — in particular a pfB
+ *       Permit list (pass) precedes a user Block for order_1..4 (the precedence a single binary
+ *       anchor broke), and order_4 places the user's own Block before its Pass (intended).
+ *   (c) running the helper on its own output is a no-op (idempotent).
  *
- * No live pfSense state involved — pfb_tracker() is called via the existing
- * doubles (get_real_interface/get_interface_ip/etc. all seeded to deterministic
- * no-op values by default).
+ * The headline regression guard is testBehaviourEqualsProvenReferenceOnDupFreeMatrix(): the helper
+ * is asserted BEHAVIOURALLY identical to the years-proven pre-ADR-41 emission
+ * (pfb_autorule_reference_8c4c482, frozen below) across a matrix of dup-free configs — same
+ * per-(interface, direction) evaluation sequence. The reference's two known defects (the user-pass
+ * DUP across the in/out loops, and the empty-order DROP) are exactly what this change fixes, so the
+ * differential is asserted only where the reference is dup-free; the dup-trigger cases are pinned
+ * to the corrected ORDER-table behaviour by the explicit per-order fixtures.
+ *
+ * Loads the real pfblockerng.inc off-appliance via tests/php/bootstrap.php (shims + doubles).
  */
+
+/**
+ * FROZEN reference — pfb_build_autorule_list() exactly as it stood at commit 8c4c482 (ADR-41 P1,
+ * a behaviour-preserving extraction of the inline auto-rule emission that shipped for years). It
+ * carries the historical DUP/DROP defects on purpose: it is the behavioural oracle for every
+ * dup-free config. DO NOT "fix" or refactor it — its value is being an independent, unchanging
+ * witness of the proven pre-change behaviour. Calls the real pfb_tracker()/constants/
+ * pfb_rule_alias_needs_v4_suffix() from the loaded pfblockerng.inc.
+ */
+function pfb_autorule_reference_8c4c482(
+	array   $existing_rules,
+	array   $pfb_generated,
+	?string $order,
+	?string $float,
+	array   $in_ifaces,
+	array   $out_ifaces
+): array {
+	$order = $order ?? '';
+	$float = $float ?? '';
+	$new_rules     = [];
+	$permit_rules  = [];
+	$match_rules   = [];
+	$other_rules   = [];
+	$fpermit_rules = [];
+	$fmatch_rules  = [];
+	$fother_rules  = [];
+
+	foreach ($existing_rules as $rule) {
+		$descr              = $rule['descr'] ?? '';
+		$is_dns_bypass_rule =
+		    str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
+		    str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
+
+		if (!str_starts_with($rule['descr'], 'pfB_') || $is_dns_bypass_rule) {
+			foreach (array('source', 'destination') as $rtype) {
+				if (pfb_rule_alias_needs_v4_suffix($rule[$rtype]['address'] ?? '', $rule['ipprotocol'] ?? '')) {
+					$rule[$rtype]['address'] = "{$rule[$rtype]['address']}_v4";
+				}
+			}
+
+			if ($float == 'on') {
+				if ($order == 'order_0' && $rule['floating'] == 'yes') {
+					$fother_rules[] = $rule;
+				}
+				else {
+					if ($rule['type'] == 'pass' && $rule['floating'] == 'yes') {
+						$fpermit_rules[] = $rule;
+					} elseif ($rule['type'] == 'match' && $rule['floating'] == 'yes') {
+						$fmatch_rules[] = $rule;
+					} elseif ($rule['floating'] == 'yes') {
+						$fother_rules[] = $rule;
+					} else {
+						$other_rules[] = $rule;
+					}
+				}
+			} else {
+				if (in_array($rule['interface'], $in_ifaces) ||
+				    in_array($rule['interface'], $out_ifaces)) {
+					if ($rule['floating'] == 'yes') {
+						$fother_rules[] = $rule;
+					} elseif ($rule['type'] == 'pass' || isset($rule['associated-rule-id'])) {
+						if ($order == 'order_0') {
+							$other_rules[] = $rule;
+						} else {
+							$permit_rules[] = $rule;
+						}
+					} else {
+						$other_rules[] = $rule;
+					}
+				} else {
+					if ($rule['floating'] == 'yes') {
+						$fother_rules[] = $rule;
+					} else {
+						$other_rules[] = $rule;
+					}
+				}
+			}
+		}
+	}
+
+	if ($float == '' && $order == 'order_1' && !empty($fother_rules)) {
+		foreach ($fother_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($float == 'on' && $order == 'order_1') {
+		foreach (array($fpermit_rules, $fmatch_rules) as $rtype) {
+			if (!empty($rtype)) {
+				foreach ($rtype as $cb_rules) {
+					$new_rules[] = $cb_rules;
+				}
+			}
+		}
+	}
+
+	foreach ($pfb_generated['dnsbl_float'] as $cb_rules) {
+		$new_rules[] = $cb_rules;
+	}
+
+	if (!empty($in_ifaces)) {
+		$pfbrunonce = TRUE;
+		foreach ($in_ifaces as $inbound_interface) {
+			if ($order == 'order_1' && !empty($permit_rules)) {
+				foreach ($permit_rules as $cb_rules) {
+					if ($cb_rules['interface'] == $inbound_interface) {
+						$new_rules[] = $cb_rules;
+					}
+				}
+			}
+			if (!empty($pfb_generated['permit_inbound'])) {
+				foreach ($pfb_generated['permit_inbound'] as $cb_rules) {
+					$cb_rules['interface'] = $inbound_interface;
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'permit_in');
+					$new_rules[]           = $cb_rules;
+				}
+			}
+			if ($pfbrunonce && !empty($pfb_generated['match_inbound'])) {
+				foreach ($pfb_generated['match_inbound'] as $cb_rules) {
+					$cb_rules['interface'] = $pfb_generated['inbound_floating'];
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'match_in');
+					$new_rules[]           = $cb_rules;
+					$pfbrunonce            = FALSE;
+				}
+			}
+			if ($order == 'order_2') {
+				foreach (array($fpermit_rules, $fmatch_rules) as $rtype) {
+					if (!empty($rtype)) {
+						foreach ($rtype as $cb_rules) {
+							$new_rules[] = $cb_rules;
+						}
+					}
+				}
+				if (!empty($permit_rules)) {
+					foreach ($permit_rules as $cb_rules) {
+						if ($cb_rules['interface'] == $inbound_interface) {
+							$new_rules[] = $cb_rules;
+						}
+					}
+				}
+			}
+			if (!empty($pfb_generated['deny_inbound'])) {
+				foreach ($pfb_generated['deny_inbound'] as $cb_rules) {
+					$cb_rules['interface'] = $inbound_interface;
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $inbound_interface, 'deny_in');
+					$new_rules[]           = $cb_rules;
+				}
+			}
+		}
+	}
+
+	if (!empty($out_ifaces)) {
+		$pfbrunonce = TRUE;
+		foreach ($out_ifaces as $outbound_interface) {
+			if ($order == 'order_1' && !empty($permit_rules)) {
+				foreach ($permit_rules as $cb_rules) {
+					if ($cb_rules['interface'] == $outbound_interface) {
+						$new_rules[] = $cb_rules;
+					}
+				}
+			}
+			if (!empty($pfb_generated['permit_outbound'])) {
+				foreach ($pfb_generated['permit_outbound'] as $cb_rules) {
+					$cb_rules['interface'] = $outbound_interface;
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'permit_out');
+					$new_rules[]           = $cb_rules;
+				}
+			}
+			if ($pfbrunonce && !empty($pfb_generated['match_outbound'])) {
+				foreach ($pfb_generated['match_outbound'] as $cb_rules) {
+					$cb_rules['interface'] = $pfb_generated['outbound_floating'];
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'match_out');
+					$new_rules[]           = $cb_rules;
+					$pfbrunonce            = FALSE;
+				}
+			}
+			if ($order == 'order_2' && !empty($permit_rules)) {
+				foreach ($permit_rules as $cb_rules) {
+					if ($cb_rules['interface'] == $outbound_interface) {
+						$new_rules[] = $cb_rules;
+					}
+				}
+			}
+			if (!empty($pfb_generated['deny_outbound'])) {
+				foreach ($pfb_generated['deny_outbound'] as $cb_rules) {
+					$cb_rules['interface'] = $outbound_interface;
+					$cb_rules['tracker']   = pfb_tracker($cb_rules['descr'], $outbound_interface, 'deny_out');
+					$new_rules[]           = $cb_rules;
+				}
+			}
+		}
+	}
+
+	if ($float == 'on' && in_array($order, array('order_0', 'order_3', 'order_4'))) {
+		if ($order != 'order_3') {
+			$rule_order = array($fother_rules, $fpermit_rules, $fmatch_rules);
+		} else {
+			$rule_order = array($fpermit_rules, $fmatch_rules, $fother_rules);
+		}
+		foreach ($rule_order as $rtype) {
+			if (!empty($rtype)) {
+				foreach ($rtype as $cb_rules) {
+					$new_rules[] = $cb_rules;
+				}
+			}
+		}
+	}
+	if ($float == 'on' && in_array($order, array('order_1', 'order_2')) && !empty($fother_rules)) {
+		foreach ($fother_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($float == '' && $order != 'order_1' && !empty($fother_rules)) {
+		foreach ($fother_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($order == 'order_4' && !empty($other_rules)) {
+		foreach ($other_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($order == 'order_4' && !empty($permit_rules)) {
+		foreach ($permit_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($order == 'order_3' && !empty($permit_rules)) {
+		foreach ($permit_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+	if ($order != 'order_4' && !empty($other_rules)) {
+		foreach ($other_rules as $cb_rules) {
+			$new_rules[] = $cb_rules;
+		}
+	}
+
+	return $new_rules;
+}
+
 #[CoversFunction('pfb_build_autorule_list')]
 final class AutoruleListOracleTest extends TestCase
 {
 	// -----------------------------------------------------------------------
-	// Fixtures
+	// $GLOBALS['pfb'] sandbox (pfb_tracker() reads trackerids off it)
 	// -----------------------------------------------------------------------
 
-	/** A minimal user 'pass' rule on 'lan'. */
-	private function userPassLan(string $descr = 'Default allow LAN to any'): array
-	{
-		return [
-			'descr'       => $descr,
-			'type'        => 'pass',
-			'interface'   => 'lan',
-			'ipprotocol'  => 'inet',
-			'floating'    => '',
-			'source'      => ['any' => ''],
-			'destination' => ['any' => ''],
-		];
-	}
-
-	/** A minimal user 'pass' rule on 'opt1'. */
-	private function userPassOpt1(string $descr = 'Default allow OPT1 to any'): array
-	{
-		return [
-			'descr'       => $descr,
-			'type'        => 'pass',
-			'interface'   => 'opt1',
-			'ipprotocol'  => 'inet',
-			'floating'    => '',
-			'source'      => ['any' => ''],
-			'destination' => ['any' => ''],
-		];
-	}
-
-	/** A minimal user floating 'pass' rule. */
-	private function userFloatPass(string $descr = 'User Float Pass'): array
-	{
-		return [
-			'descr'       => $descr,
-			'type'        => 'pass',
-			'interface'   => '',
-			'ipprotocol'  => 'inet',
-			'floating'    => 'yes',
-			'direction'   => 'any',
-			'source'      => ['any' => ''],
-			'destination' => ['any' => ''],
-		];
-	}
-
-	/** A pfB_ deny rule — should be STRIPPED by the helper (it rebuilds these). */
-	private function pfbDenyRule(string $iface = 'lan'): array
-	{
-		return [
-			'descr'       => 'pfB_DenyAlias_v4 Auto Rule',
-			'type'        => 'block',
-			'interface'   => $iface,
-			'ipprotocol'  => 'inet',
-			'floating'    => '',
-			'source'      => ['address' => 'pfB_DenyAlias_v4'],
-			'destination' => ['any' => ''],
-		];
-	}
-
-	/** A DNS-redirect bypass rule — pfB_ descr but must NOT be stripped. */
-	private function dnsRedirectBypassRule(): array
-	{
-		return [
-			'descr'       => 'pfB_DNS_Redirect_lan_v4',  // starts with PFB_DNS_REDIR_DESCR_V4_PFX
-			'type'        => 'pass',
-			'interface'   => 'lan',
-			'ipprotocol'  => 'inet',
-			'floating'    => '',
-			'source'      => ['any' => ''],
-			'destination' => ['any' => ''],
-		];
-	}
-
-	/** A DoT-block bypass rule — pfB_ descr but must NOT be stripped. */
-	private function dotBlockBypassRule(): array
-	{
-		return [
-			'descr'       => 'pfB_DoT_Block_lan',  // starts with PFB_DOT_BLOCK_DESCR_PFX
-			'type'        => 'block',
-			'interface'   => 'lan',
-			'ipprotocol'  => 'inet',
-			'floating'    => '',
-			'source'      => ['any' => ''],
-			'destination' => ['any' => ''],
-		];
-	}
-
-	/**
-	 * A minimal $pfb_generated with one deny_inbound rule (deny 'lan' inbound).
-	 * The deny template has no interface/tracker yet — those are set per-interface in the helper.
-	 */
-	private function pfbGeneratedDenyOnly(): array
-	{
-		return [
-			'permit_inbound'    => [],
-			'permit_outbound'   => [],
-			'deny_inbound'      => [
-				[
-					'descr'       => 'pfB_DenyList_v4 Auto Rule',
-					'type'        => 'block',
-					'interface'   => '',  // set by helper
-					'ipprotocol'  => 'inet',
-					'floating'    => '',
-					'source'      => ['address' => 'pfB_DenyList_v4'],
-					'destination' => ['any' => ''],
-					'created'     => ['time' => 0, 'username' => 'Auto'],
-				],
-			],
-			'deny_outbound'     => [
-				[
-					'descr'       => 'pfB_DenyList_v4 Auto Rule',
-					'type'        => 'reject',
-					'interface'   => '',  // set by helper
-					'ipprotocol'  => 'inet',
-					'floating'    => '',
-					'source'      => ['any' => ''],
-					'destination' => ['address' => 'pfB_DenyList_v4'],
-					'created'     => ['time' => 0, 'username' => 'Auto'],
-				],
-			],
-			'match_inbound'     => [],
-			'match_outbound'    => [],
-			'inbound_floating'  => '',
-			'outbound_floating' => '',
-			'dnsbl_float'       => [],
-		];
-	}
-
-	/**
-	 * $pfb_generated with permit_inbound + deny_inbound (Permit_* action present).
-	 */
-	private function pfbGeneratedPermitAndDeny(): array
-	{
-		return [
-			'permit_inbound'    => [
-				[
-					'descr'       => 'pfB_PermitList_v4 Auto Rule',
-					'type'        => 'pass',
-					'interface'   => '',
-					'ipprotocol'  => 'inet',
-					'floating'    => '',
-					'source'      => ['address' => 'pfB_PermitList_v4'],
-					'destination' => ['any' => ''],
-					'created'     => ['time' => 0, 'username' => 'Auto'],
-				],
-			],
-			'permit_outbound'   => [
-				[
-					'descr'       => 'pfB_PermitList_v4 Auto Rule',
-					'type'        => 'pass',
-					'interface'   => '',
-					'ipprotocol'  => 'inet',
-					'floating'    => '',
-					'source'      => ['any' => ''],
-					'destination' => ['address' => 'pfB_PermitList_v4'],
-					'created'     => ['time' => 0, 'username' => 'Auto'],
-				],
-			],
-			'deny_inbound'      => [
-				[
-					'descr'       => 'pfB_DenyList_v4 Auto Rule',
-					'type'        => 'block',
-					'interface'   => '',
-					'ipprotocol'  => 'inet',
-					'floating'    => '',
-					'source'      => ['address' => 'pfB_DenyList_v4'],
-					'destination' => ['any' => ''],
-					'created'     => ['time' => 0, 'username' => 'Auto'],
-				],
-			],
-			'deny_outbound'     => [
-				[
-					'descr'       => 'pfB_DenyList_v4 Auto Rule',
-					'type'        => 'reject',
-					'interface'   => '',
-					'ipprotocol'  => 'inet',
-					'floating'    => '',
-					'source'      => ['any' => ''],
-					'destination' => ['address' => 'pfB_DenyList_v4'],
-					'created'     => ['time' => 0, 'username' => 'Auto'],
-				],
-			],
-			'match_inbound'     => [],
-			'match_outbound'    => [],
-			'inbound_floating'  => '',
-			'outbound_floating' => '',
-			'dnsbl_float'       => [],
-		];
-	}
-
-	// -----------------------------------------------------------------------
-	// $GLOBALS['pfb'] sandbox helpers
-	// -----------------------------------------------------------------------
-
-	private array $origPfb    = [];
-	private bool  $hadPfb     = FALSE;
+	private array $origPfb = [];
+	private bool  $hadPfb  = FALSE;
 
 	protected function setUp(): void
 	{
-		$this->hadPfb   = array_key_exists('pfb', $GLOBALS);
-		$this->origPfb  = $GLOBALS['pfb'] ?? [];
-
-		// Minimal pfb globals needed by pfb_tracker() (trackerids collision check).
+		$this->hadPfb  = array_key_exists('pfb', $GLOBALS);
+		$this->origPfb = $GLOBALS['pfb'] ?? [];
 		$GLOBALS['pfb'] = [
 			'trackerids'         => [],
 			'foreign_trackerids' => [],
@@ -273,913 +312,647 @@ final class AutoruleListOracleTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// Rule fixtures
+	// -----------------------------------------------------------------------
+
+	private function userPass(string $descr, string $iface = 'lan', string $floating = ''): array
+	{
+		return ['descr' => $descr, 'type' => 'pass', 'interface' => $iface, 'ipprotocol' => 'inet',
+		        'floating' => $floating, 'source' => ['any' => ''], 'destination' => ['any' => '']];
+	}
+
+	private function userBlock(string $descr, string $iface = 'lan', string $floating = ''): array
+	{
+		return ['descr' => $descr, 'type' => 'block', 'interface' => $iface, 'ipprotocol' => 'inet',
+		        'floating' => $floating, 'source' => ['address' => 'EvilHosts'], 'destination' => ['any' => '']];
+	}
+
+	private function userMatch(string $descr, string $iface = 'lan', string $floating = 'yes'): array
+	{
+		return ['descr' => $descr, 'type' => 'match', 'interface' => $iface, 'ipprotocol' => 'inet',
+		        'floating' => $floating, 'source' => ['any' => ''], 'destination' => ['any' => '']];
+	}
+
+	/** A pfB-owned auto rule — the helper must STRIP and regenerate these (not keep them). */
+	private function pfbOwnedDeny(string $iface = 'lan'): array
+	{
+		return ['descr' => 'pfB_DenyAlias_v4 Auto Rule', 'type' => 'block', 'interface' => $iface,
+		        'ipprotocol' => 'inet', 'floating' => '', 'direction' => 'in',
+		        'source' => ['address' => 'pfB_DenyAlias_v4'], 'destination' => ['any' => '']];
+	}
+
+	/** DNS-redirect bypass rule — pfB_ descr but must NOT be stripped (stays user-managed). */
+	private function dnsRedirectBypass(): array
+	{
+		return ['descr' => 'pfB_DNS_Redirect_lan_v4', 'type' => 'pass', 'interface' => 'lan',
+		        'ipprotocol' => 'inet', 'floating' => '', 'source' => ['any' => ''], 'destination' => ['any' => '']];
+	}
+
+	/** DoT-block bypass rule — pfB_ descr but must NOT be stripped. */
+	private function dotBlockBypass(): array
+	{
+		return ['descr' => 'pfB_DoT_Block_lan', 'type' => 'block', 'interface' => 'lan',
+		        'ipprotocol' => 'inet', 'floating' => '', 'source' => ['any' => ''], 'destination' => ['any' => '']];
+	}
+
+	// -----------------------------------------------------------------------
+	// pfB-generated templates (direction-faithful: inbound rules carry
+	// direction='in', outbound direction='out' — as filter.inc emits them)
+	// -----------------------------------------------------------------------
+
+	/** @param string $float 'on' makes the per-interface permit/deny floating (base_rule_float). */
+	private function genPermitDeny(string $float = ''): array
+	{
+		$flo = $float === 'on' ? 'yes' : '';
+		return [
+			'permit_inbound'  => [['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass', 'interface' => '',
+			    'direction' => 'in', 'ipprotocol' => 'inet', 'floating' => $flo,
+			    'source' => ['address' => 'pfB_PermitList_v4'], 'destination' => ['any' => '']]],
+			'permit_outbound' => [['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass', 'interface' => '',
+			    'direction' => 'out', 'ipprotocol' => 'inet', 'floating' => $flo,
+			    'source' => ['any' => ''], 'destination' => ['address' => 'pfB_PermitList_v4']]],
+			'deny_inbound'    => [['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block', 'interface' => '',
+			    'direction' => 'in', 'ipprotocol' => 'inet', 'floating' => $flo,
+			    'source' => ['address' => 'pfB_DenyList_v4'], 'destination' => ['any' => '']]],
+			'deny_outbound'   => [['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => '',
+			    'direction' => 'out', 'ipprotocol' => 'inet', 'floating' => $flo,
+			    'source' => ['any' => ''], 'destination' => ['address' => 'pfB_DenyList_v4']]],
+			'match_inbound'   => [], 'match_outbound' => [],
+			'inbound_floating' => '', 'outbound_floating' => '', 'dnsbl_float' => [],
+		];
+	}
+
+	/** Permit-list inbound only (the common case used by the precedence-trap fixtures). */
+	private function genPermitDenyInbound(): array
+	{
+		$g = $this->genPermitDeny('');
+		$g['permit_outbound'] = [];
+		$g['deny_outbound']   = [];
+		return $g;
+	}
+
+	private function genDenyOnly(): array
+	{
+		$g = $this->genPermitDeny('');
+		$g['permit_inbound']  = [];
+		$g['permit_outbound'] = [];
+		$g['deny_outbound']   = [];
+		return $g;
+	}
+
+	/** Deny + a floating Match rule (inbound + outbound); inbound_floating='lan'. */
+	private function genWithMatch(): array
+	{
+		$g = $this->genDenyOnly();
+		$g['match_inbound']  = [['descr' => 'pfB_MatchList_v4 Auto Rule', 'type' => 'match', 'interface' => '',
+		    'direction' => 'in', 'ipprotocol' => 'inet', 'floating' => 'yes',
+		    'source' => ['address' => 'pfB_MatchList_v4'], 'destination' => ['any' => '']]];
+		$g['match_outbound'] = [['descr' => 'pfB_MatchList_v4 Auto Rule', 'type' => 'match', 'interface' => '',
+		    'direction' => 'out', 'ipprotocol' => 'inet', 'floating' => 'yes',
+		    'source' => ['any' => ''], 'destination' => ['address' => 'pfB_MatchList_v4']]];
+		$g['inbound_floating']  = 'lan';
+		$g['outbound_floating'] = 'lan';
+		return $g;
+	}
+
+	/** Deny + the DNSBL floating pass pair (always floating). */
+	private function genWithDnsbl(): array
+	{
+		$g = $this->genDenyOnly();
+		$g['dnsbl_float'] = [
+			['descr' => 'pfB_DNSBL_Permit', 'type' => 'pass', 'interface' => 'lan', 'direction' => '',
+			 'ipprotocol' => 'inet', 'floating' => 'yes', 'source' => ['any' => ''], 'destination' => ['address' => 'pfB_DNSBL_VIPs']],
+		];
+		return $g;
+	}
+
+	// -----------------------------------------------------------------------
 	// Assertion helpers
 	// -----------------------------------------------------------------------
 
-	/**
-	 * Extract [descr, type, interface, floating] from each rule in $result.
-	 * This is the "shape" used for oracle assertions — enough to pin ORDER and
-	 * presence without being brittle about tracker/created timestamps.
-	 *
-	 * @param array<int, array<string, mixed>> $result
-	 * @return list<array{descr: string, type: string, interface: string, floating: string}>
-	 */
-	private function shapes(array $result): array
+	/** [descr, type, interface, floating, direction] per rule — enough to pin ORDER + presence. */
+	private function shapes(array $rules): array
 	{
-		return array_map(static function (array $rule): array {
-			return [
-				'descr'     => $rule['descr']     ?? '',
-				'type'      => $rule['type']       ?? '',
-				'interface' => $rule['interface']  ?? '',
-				'floating'  => $rule['floating']   ?? '',
-			];
-		}, array_values($result));
+		return array_map(static fn (array $r): array => [
+			'descr'     => $r['descr']     ?? '',
+			'type'      => $r['type']      ?? '',
+			'interface' => $r['interface'] ?? '',
+			'floating'  => $r['floating']  ?? '',
+			'direction' => $r['direction'] ?? '',
+		], array_values($rules));
 	}
 
-	/**
-	 * Assert the full ordered shape list equals $expected.
-	 * On failure, print expected vs actual for diagnosis.
-	 *
-	 * @param list<array{descr: string, type: string, interface: string, floating: string}> $expected
-	 * @param array<int, array<string, mixed>> $result
-	 */
-	private function assertShapes(array $expected, array $result, string $context = ''): void
+	private function assertShapes(array $expected, array $result, string $ctx): void
 	{
-		$actual = $this->shapes($result);
-		$label  = $context !== '' ? " [{$context}]" : '';
 		$this->assertSame(
 			$expected,
-			$actual,
-			"Rule shape mismatch{$label}."
-				. "\n\nExpected:\n" . json_encode($expected, JSON_PRETTY_PRINT)
-				. "\n\nActual:\n"   . json_encode($actual,   JSON_PRETTY_PRINT)
+			$this->shapes($result),
+			"Rule shape mismatch [{$ctx}].\n\nExpected:\n" . json_encode($expected, JSON_PRETTY_PRINT)
+				. "\n\nActual:\n" . json_encode($this->shapes($result), JSON_PRETTY_PRINT)
 		);
 	}
 
-	/** Assert each rule in $result has a 'tracker' key (set by pfb_tracker). */
-	private function assertTrackersSet(array $result, string $context = ''): void
+	/** Every pfB-generated rule must carry a 'tracker' (user/bypass rules pass through without). */
+	private function assertTrackersSet(array $result, string $ctx): void
 	{
 		foreach ($result as $i => $rule) {
 			$descr = $rule['descr'] ?? "(rule {$i})";
-			// Only pfB-generated rules (those from $pfb_generated) get trackers assigned;
-			// user rules pass through without tracker. Skip user rules.
-			if (!str_starts_with($descr, 'pfB_') || str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX)
-			    || str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX)) {
+			if (!$this->isPfbOwned($rule)) {
 				continue;
 			}
 			$this->assertArrayHasKey('tracker', $rule,
-				"pfB rule [{$i}] '{$descr}' must have 'tracker' key set by pfb_tracker()");
+				"pfB rule [{$i}] '{$descr}' must carry a tracker [{$ctx}]");
 		}
 	}
 
-	/**
-	 * CONTRACT (a): every non-pfB rule from $input appears in $output in the same
-	 * relative order with the same count. A rule is pfB-owned iff its descr starts
-	 * with 'pfB_' AND it is NOT a bypass rule (DNS-redirect / DoT-block).
-	 *
-	 * Fails on: user-rule drop (count < input), duplication (count > input), or reorder.
-	 *
-	 * @param array<int, array<string, mixed>> $input
-	 * @param array<int, array<string, mixed>> $output
-	 */
-	private function assertUserRulesPreserved(array $input, array $output, string $context = ''): void
+	private function isUserRule(array $rule): bool
 	{
-		$is_user = static function (array $rule): bool {
-			$descr = $rule['descr'] ?? '';
-			if (!str_starts_with($descr, 'pfB_')) {
-				return TRUE;
-			}
-			return str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
-			       str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
-		};
+		$descr = $rule['descr'] ?? '';
+		if (!str_starts_with($descr, 'pfB_')) {
+			return TRUE;
+		}
+		return str_starts_with($descr, PFB_DNS_REDIR_DESCR_V4_PFX) ||
+		       str_starts_with($descr, PFB_DOT_BLOCK_DESCR_PFX);
+	}
 
-		$user_in  = array_values(array_filter($input,  $is_user));
-		$user_out = array_values(array_filter($output, $is_user));
-
-		$label = $context !== '' ? " [{$context}]" : '';
-		$this->assertSame(
-			$this->shapes($user_in),
-			$this->shapes($user_out),
-			"User-rule fidelity failure{$label}: non-pfB rules must be preserved exactly "
-				. "(same set, count, and original relative order — no drop, dup, or reorder)."
-				. "\n\nExpected (input user rules):\n"  . json_encode($this->shapes($user_in),  JSON_PRETTY_PRINT)
-				. "\n\nActual (output user rules):\n"   . json_encode($this->shapes($user_out), JSON_PRETTY_PRINT)
-		);
+	private function isPfbOwned(array $rule): bool
+	{
+		return !$this->isUserRule($rule);
 	}
 
 	/**
-	 * CONTRACT (c): running the helper on its own output is a no-op.
-	 *
-	 * Second-pass $existing_rules = first-pass $output. Same $pfb_generated / $order / $float /
-	 * $in_ifaces / $out_ifaces. Result must be shape-identical to the first pass.
-	 *
-	 * @param array<int, array<string, mixed>> $output
-	 * @param array<int, string>               $in_ifaces
-	 * @param array<int, string>               $out_ifaces
+	 * Fidelity contract (a): user rules survive as a multiset — no DROP, no DUP, content
+	 * untouched (bar the _v4 upgrade). Deliberately order-INDEPENDENT: cross-bucket reorder is
+	 * exactly what pass_order does, so a global-order check would be wrong. Within-bucket order
+	 * is pinned by the explicit per-order fixtures (and testWithinBucketOrderPreserved).
 	 */
-	private function assertIdempotent(
-		array  $output,
-		array  $gen,
-		string $order,
-		string $float,
-		array  $in_ifaces,
-		array  $out_ifaces,
-		string $context = ''
-	): void {
-		$second = pfb_build_autorule_list($output, $gen, $order, $float, $in_ifaces, $out_ifaces);
-		$label  = $context !== '' ? " [{$context}]" : '';
+	private function assertUserRulesIntact(array $input, array $output, string $ctx): void
+	{
+		$inUser  = $this->shapes(array_values(array_filter($input,  fn ($r) => $this->isUserRule($r))));
+		$outUser = $this->shapes(array_values(array_filter($output, fn ($r) => $this->isUserRule($r))));
+		sort($inUser);
+		sort($outUser);
+		$this->assertEquals(
+			$inUser,
+			$outUser,
+			"User-rule fidelity failure [{$ctx}]: user rules must survive exactly once, content "
+				. "intact (no drop, no dup, no mutation).\n\nExpected (multiset):\n"
+				. json_encode($inUser, JSON_PRETTY_PRINT) . "\n\nActual (multiset):\n"
+				. json_encode($outUser, JSON_PRETTY_PRINT)
+		);
+	}
+
+	/** Contract (c): running the helper on its own output is a no-op. */
+	private function assertIdempotent(array $output, array $gen, ?string $order, ?string $float,
+	                                  array $in, array $out, string $ctx): void
+	{
+		$second = pfb_build_autorule_list($output, $gen, $order, $float, $in, $out);
 		$this->assertSame(
 			$this->shapes($output),
 			$this->shapes($second),
-			"Idempotence failure{$label}: running the helper on its own output must be a no-op."
-				. "\n\nFirst pass:\n"  . json_encode($this->shapes($output), JSON_PRETTY_PRINT)
-				. "\n\nSecond pass:\n" . json_encode($this->shapes($second), JSON_PRETTY_PRINT)
+			"Idempotence failure [{$ctx}]: a second pass must be a no-op.\n\nFirst:\n"
+				. json_encode($this->shapes($output), JSON_PRETTY_PRINT) . "\n\nSecond:\n"
+				. json_encode($this->shapes($second), JSON_PRETTY_PRINT)
 		);
 	}
 
-	// -----------------------------------------------------------------------
-	// A. order_0, float=off, inbound==outbound='lan', Deny_* only
-	// -----------------------------------------------------------------------
+	// =======================================================================
+	// THE PRECEDENCE TRAP — pfB Permit + pfB Deny + user Pass + user Block on
+	// one interface. This is the case a single binary anchor got wrong: it put
+	// the whole block of user rules (incl. the user Block) before the pfB block,
+	// so a pfB Permit could not override a user Block for order_1/order_2, and
+	// order_4 stopped reordering the user's own Pass/Block. RED on that helper.
+	// =======================================================================
 
-	public function testOrder0FloatOffSingleIfaceDenyOnly(): void
+	public function testTrapOrder0KeepsUserRulesTogetherAfterPfb(): void
 	{
-		/**
-		 * Scenario: ORDER 0, float off, single managed iface (lan), Deny_* pfB rules.
-		 *
-		 * Given: existing rules = [pfB deny (stripped), user pass LAN].
-		 *        pfB generated = deny_inbound + deny_outbound templates.
-		 *        order=order_0, float=off, in+out ifaces = ['lan'].
-		 *
-		 * ORDER 0 anchor = BEFORE: pfB block first, then kept user rules.
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
-		 */
-
-		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
-		$gen      = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
+		// order_0: pfB pass, pfB block, then ALL user rules (not split), original order.
+		$existing = [$this->userPass('User allow LAN'), $this->userBlock('User block evil')];
+		$result   = pfb_build_autorule_list($existing, $this->genPermitDenyInbound(), 'order_0', '', ['lan'], ['lan']);
 
 		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_0 float=off single iface');
-		$this->assertTrackersSet($result, 'order_0 float=off');
-		$this->assertUserRulesPreserved($existing, $result, 'order_0 float=off');
-		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'order_0 float=off');
+			['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'User allow LAN',              'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => ''],
+			['descr' => 'User block evil',             'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => ''],
+		], $result, 'trap order_0');
+		$this->assertUserRulesIntact($existing, $result, 'trap order_0');
 	}
 
-	// -----------------------------------------------------------------------
-	// B. order_0, float=on, single iface, Deny_* only
-	// -----------------------------------------------------------------------
-
-	public function testOrder0FloatOnSingleIfaceDenyOnly(): void
+	public function testTrapOrder1PfbPermitBeatsUserBlock(): void
 	{
-		/**
-		 * Scenario: ORDER 0, float=on.
-		 *
-		 * ORDER 0 anchor = BEFORE: pfB block first, then kept user rules verbatim.
-		 * keep = [user_float_pass, user_pass(lan)] (original order; pfB deny stripped).
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_float_pass, user_pass(lan).
-		 *
-		 * pf evaluates floating rules in a separate group regardless of config.xml
-		 * interleaving, so the relative position of user_float_pass vs interface rules
-		 * in config.xml does not affect pf precedence.
-		 */
+		// order_1: user p/m, pfB p/m, pfB b/r, user b/r. The pfB Permit MUST precede the user
+		// Block (the binary anchor put the user Block first -> pfB Permit lost).
+		$existing = [$this->userPass('User allow LAN'), $this->userBlock('User block evil')];
+		$result   = pfb_build_autorule_list($existing, $this->genPermitDenyInbound(), 'order_1', '', ['lan'], ['lan']);
 
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->userFloatPass(),
-			$this->userPassLan(),
+		$this->assertShapes([
+			['descr' => 'User allow LAN',              'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => ''],
+			['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'User block evil',             'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => ''],
+		], $result, 'trap order_1');
+		$this->assertUserRulesIntact($existing, $result, 'trap order_1');
+	}
+
+	public function testTrapOrder2PfbPermitBeatsUserBlock(): void
+	{
+		// order_2: pfB p/m, user p/m, pfB b/r, user b/r. pfB Permit still precedes the user Block.
+		$existing = [$this->userPass('User allow LAN'), $this->userBlock('User block evil')];
+		$result   = pfb_build_autorule_list($existing, $this->genPermitDenyInbound(), 'order_2', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'User allow LAN',              'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'User block evil',             'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => ''],
+		], $result, 'trap order_2');
+		$this->assertUserRulesIntact($existing, $result, 'trap order_2');
+	}
+
+	public function testTrapOrder3PfbBlockBeforeUserRules(): void
+	{
+		// order_3: pfB p/m, pfB b/r, user p/m, user b/r.
+		$existing = [$this->userPass('User allow LAN'), $this->userBlock('User block evil')];
+		$result   = pfb_build_autorule_list($existing, $this->genPermitDenyInbound(), 'order_3', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'User allow LAN',              'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => ''],
+			['descr' => 'User block evil',             'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => ''],
+		], $result, 'trap order_3');
+		$this->assertUserRulesIntact($existing, $result, 'trap order_3');
+	}
+
+	public function testTrapOrder4ReordersUserBlockBeforeUserPass(): void
+	{
+		// order_4: pfB p/m, pfB b/r, user b/r, user p/m. The user's OWN Block precedes its Pass —
+		// an intended pass_order reorder the binary anchor wrongly dropped.
+		$existing = [$this->userPass('User allow LAN'), $this->userBlock('User block evil')];
+		$result   = pfb_build_autorule_list($existing, $this->genPermitDenyInbound(), 'order_4', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'User block evil',             'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => ''],
+			['descr' => 'User allow LAN',              'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => ''],
+		], $result, 'trap order_4');
+		$this->assertUserRulesIntact($existing, $result, 'trap order_4');
+	}
+
+	// =======================================================================
+	// Float mode ON — the per-interface pfB rules become floating, so pass_order
+	// orders the FLOATING group (same ORDER table applied symmetrically).
+	// =======================================================================
+
+	public function testFloatOnAppliesOrderTableToFloatingGroup(): void
+	{
+		$existing = [$this->userPass('User float allow', 'lan', 'yes'), $this->userBlock('User float block', 'lan', 'yes')];
+		$gen      = $this->genPermitDeny('on');
+		$gen['permit_outbound'] = [];
+		$gen['deny_outbound']   = [];
+
+		$expected = [
+			'order_1' => [
+				['descr' => 'User float allow',            'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+				['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+				['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+				['descr' => 'User float block',            'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+			],
+			'order_2' => [
+				['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+				['descr' => 'User float allow',            'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+				['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+				['descr' => 'User float block',            'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+			],
+			'order_3' => [
+				['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+				['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+				['descr' => 'User float allow',            'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+				['descr' => 'User float block',            'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+			],
+			'order_4' => [
+				['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+				['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => 'in'],
+				['descr' => 'User float block',            'type' => 'block', 'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+				['descr' => 'User float allow',            'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+			],
 		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_0', 'on', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_0 float=on');
-		$this->assertTrackersSet($result, 'order_0 float=on');
-		$this->assertUserRulesPreserved($existing, $result, 'order_0 float=on');
-		$this->assertIdempotent($result, $gen, 'order_0', 'on', ['lan'], ['lan'], 'order_0 float=on');
+		foreach ($expected as $order => $shape) {
+			$result = pfb_build_autorule_list($existing, $gen, $order, 'on', ['lan'], []);
+			$this->assertShapes($shape, $result, "float-on {$order}");
+			$this->assertUserRulesIntact($existing, $result, "float-on {$order}");
+		}
 	}
 
-	// -----------------------------------------------------------------------
-	// C. order_1, float=off, inbound==outbound='lan'  [KNOWN-BAD: duplication]
-	// -----------------------------------------------------------------------
+	// =======================================================================
+	// pfB rule generation invariants
+	// =======================================================================
 
-	public function testOrder1FloatOffSingleIfaceDenyOnly(): void
+	public function testMatchRuleEmittedOnceAcrossInterfaces(): void
 	{
-		/**
-		 * Scenario: ORDER 1, float=off, SAME interface for inbound AND outbound ('lan').
-		 *
-		 * ORDER 1 anchor = AFTER: kept user rules first, then pfB block.
-		 * keep = [user_pass(lan)] (pfB deny stripped; no dup — verbatim keep).
-		 * pfB block = [deny_in(lan), deny_out(lan)].
-		 * Expected: user_pass(lan), pfB deny_in(lan), pfB deny_out(lan).
-		 *
-		 * Fail-before: old bucket-per-iface code emitted user_pass TWICE (once per loop
-		 * over the shared 'lan' interface). The immutable-splice model strips pfB rules
-		 * and keeps the verbatim user list exactly once — no dup possible.
-		 */
-
-		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
-		$gen      = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_1', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_1 float=off single iface');
-		$this->assertTrackersSet($result, 'order_1 float=off single');
-		$this->assertUserRulesPreserved($existing, $result, 'order_1 float=off single');
-		$this->assertIdempotent($result, $gen, 'order_1', '', ['lan'], ['lan'], 'order_1 float=off single');
-	}
-
-	// -----------------------------------------------------------------------
-	// D. order_1, float=off, inbound!=outbound ('lan' in, 'opt1' out)
-	// -----------------------------------------------------------------------
-
-	public function testOrder1FloatOffSeparateIfacesDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 1, float=off, separate inbound (lan) and outbound (opt1).
-		 *
-		 * ORDER 1 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
-		 * keep = [user_pass(lan), user_pass(opt1)] (original order).
-		 * pfB block = [deny_in(lan), deny_out(opt1)].
-		 * Expected: user_pass(lan), user_pass(opt1), pfB deny_in(lan), pfB deny_out(opt1).
-		 *
-		 * Under per-interface first-match pf semantics the pfB-block-vs-user-BLOCK ordering
-		 * is moot; only pfB-block-vs-user-PASS matters, and both user pass rules precede
-		 * both pfB deny rules — user wins on both interfaces.
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->pfbDenyRule('opt1'),
-			$this->userPassLan(),
-			$this->userPassOpt1(),
-		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_1', '', ['lan'], ['opt1']);
-
-		$this->assertShapes([
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
-			['descr' => 'Default allow OPT1 to any', 'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan',  'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'opt1', 'floating' => ''],
-		], $result, 'order_1 float=off separate ifaces');
-		$this->assertTrackersSet($result, 'order_1 float=off separate');
-		$this->assertUserRulesPreserved($existing, $result, 'order_1 float=off separate');
-		$this->assertIdempotent($result, $gen, 'order_1', '', ['lan'], ['opt1'], 'order_1 float=off separate');
-	}
-
-	// -----------------------------------------------------------------------
-	// E. order_1, float=on, single iface
-	// -----------------------------------------------------------------------
-
-	public function testOrder1FloatOnSingleIfaceDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 1, float=on.
-		 *
-		 * ORDER 1 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
-		 * keep = [user_float_pass, user_pass(lan)] (original order; pfB deny stripped).
-		 * pfB block = [deny_in(lan), deny_out(lan)].
-		 * Expected: user_float_pass, user_pass(lan), pfB deny_in(lan), pfB deny_out(lan).
-		 *
-		 * pf evaluates floating rules in a separate group regardless of config.xml
-		 * interleaving, so the relative position of user_float_pass vs interface rules
-		 * in config.xml does not affect pf precedence.
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->userFloatPass(),
-			$this->userPassLan(),
-		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_1', 'on', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_1 float=on single iface');
-		$this->assertTrackersSet($result, 'order_1 float=on');
-		$this->assertUserRulesPreserved($existing, $result, 'order_1 float=on');
-		$this->assertIdempotent($result, $gen, 'order_1', 'on', ['lan'], ['lan'], 'order_1 float=on');
-	}
-
-	// -----------------------------------------------------------------------
-	// F. order_2, float=off, inbound==outbound='lan'  [KNOWN-BAD: duplication]
-	// -----------------------------------------------------------------------
-
-	public function testOrder2FloatOffSingleIfaceDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 2, float=off, SAME interface for inbound AND outbound ('lan').
-		 *
-		 * ORDER 2 anchor = AFTER: kept user rules first (verbatim), then pfB block.
-		 * keep = [user_pass(lan)] (pfB deny stripped; no dup).
-		 * pfB block = [deny_in(lan), deny_out(lan)].
-		 * Expected: user_pass(lan), pfB deny_in(lan), pfB deny_out(lan).
-		 *
-		 * Fail-before: old bucket-based code emitted user_pass TWICE (once per iface loop
-		 * iteration). The immutable-splice model keeps the verbatim list exactly once.
-		 */
-
-		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
-		$gen      = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_2', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_2 float=off single iface');
-		$this->assertTrackersSet($result, 'order_2 float=off single');
-		$this->assertUserRulesPreserved($existing, $result, 'order_2 float=off single');
-		$this->assertIdempotent($result, $gen, 'order_2', '', ['lan'], ['lan'], 'order_2 float=off single');
-	}
-
-	// -----------------------------------------------------------------------
-	// G. order_2, float=off, inbound!=outbound
-	// -----------------------------------------------------------------------
-
-	public function testOrder2FloatOffSeparateIfacesDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 2, float=off, separate ifaces (lan in, opt1 out).
-		 *
-		 * ORDER 2 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
-		 * keep = [user_pass(lan), user_pass(opt1)] (original order).
-		 * pfB block = [deny_in(lan), deny_out(opt1)].
-		 * Expected: user_pass(lan), user_pass(opt1), pfB deny_in(lan), pfB deny_out(opt1).
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->pfbDenyRule('opt1'),
-			$this->userPassLan(),
-			$this->userPassOpt1(),
-		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_2', '', ['lan'], ['opt1']);
-
-		$this->assertShapes([
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
-			['descr' => 'Default allow OPT1 to any', 'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan',  'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'opt1', 'floating' => ''],
-		], $result, 'order_2 float=off separate ifaces');
-		$this->assertTrackersSet($result, 'order_2 float=off separate');
-		$this->assertUserRulesPreserved($existing, $result, 'order_2 float=off separate');
-		$this->assertIdempotent($result, $gen, 'order_2', '', ['lan'], ['opt1'], 'order_2 float=off separate');
-	}
-
-	// -----------------------------------------------------------------------
-	// H. order_2, float=on, single iface
-	// -----------------------------------------------------------------------
-
-	public function testOrder2FloatOnSingleIfaceDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 2, float=on.
-		 *
-		 * ORDER 2 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
-		 * keep = [user_float_pass, user_pass(lan)] (original order; pfB deny stripped).
-		 * pfB block = [deny_in(lan), deny_out(lan)].
-		 * Expected: user_float_pass, user_pass(lan), pfB deny_in(lan), pfB deny_out(lan).
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->userFloatPass(),
-			$this->userPassLan(),
-		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_2', 'on', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_2 float=on single iface');
-		$this->assertTrackersSet($result, 'order_2 float=on');
-		$this->assertUserRulesPreserved($existing, $result, 'order_2 float=on');
-		$this->assertIdempotent($result, $gen, 'order_2', 'on', ['lan'], ['lan'], 'order_2 float=on');
-	}
-
-	// -----------------------------------------------------------------------
-	// I. order_3, float=off, single iface
-	// -----------------------------------------------------------------------
-
-	public function testOrder3FloatOffSingleIfaceDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 3, float=off.
-		 *
-		 * ORDER 3 anchor = BEFORE: pfB block first, then kept user rules.
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan).
-		 */
-
-		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
-		$gen      = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_3', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_3 float=off single iface');
-		$this->assertTrackersSet($result, 'order_3 float=off');
-		$this->assertUserRulesPreserved($existing, $result, 'order_3 float=off');
-		$this->assertIdempotent($result, $gen, 'order_3', '', ['lan'], ['lan'], 'order_3 float=off');
-	}
-
-	// -----------------------------------------------------------------------
-	// J. order_3, float=on, single iface
-	// -----------------------------------------------------------------------
-
-	public function testOrder3FloatOnSingleIfaceDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 3, float=on.
-		 *
-		 * ORDER 3 anchor = BEFORE: pfB block first, then kept user rules verbatim.
-		 * keep = [user_float_pass, user_pass(lan)] (original order).
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_float_pass, user_pass(lan).
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->userFloatPass(),
-			$this->userPassLan(),
-		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_3', 'on', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_3 float=on single iface');
-		$this->assertTrackersSet($result, 'order_3 float=on');
-		$this->assertUserRulesPreserved($existing, $result, 'order_3 float=on');
-		$this->assertIdempotent($result, $gen, 'order_3', 'on', ['lan'], ['lan'], 'order_3 float=on');
-	}
-
-	// -----------------------------------------------------------------------
-	// K. order_4, float=off, inbound==outbound='lan'  [KNOWN-BAD: reorder]
-	// -----------------------------------------------------------------------
-
-	public function testOrder4FloatOffSingleIfaceDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 4, float=off, single managed iface (lan).
-		 *
-		 * ORDER 4 anchor = BEFORE: pfB block first, then kept user rules verbatim.
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan).
-		 */
-
-		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
-		$gen      = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_4', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_4 float=off single iface');
-		$this->assertTrackersSet($result, 'order_4 float=off');
-		$this->assertUserRulesPreserved($existing, $result, 'order_4 float=off');
-		$this->assertIdempotent($result, $gen, 'order_4', '', ['lan'], ['lan'], 'order_4 float=off');
-	}
-
-	public function testOrder4FloatOffTwoIfacesDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 4, float=off, two managed ifaces (opt1 inbound, lan outbound).
-		 *
-		 * ORDER 4 anchor = BEFORE: pfB block first, then kept user rules verbatim.
-		 * keep = [user_pass(lan), user_pass(opt1)] (original order in existing_rules).
-		 * pfB block = [deny_in(opt1), deny_out(lan)].
-		 * Expected: pfB deny_in(opt1), pfB deny_out(lan), user_pass(lan), user_pass(opt1).
-		 *
-		 * The deliberate behaviour change from Phase 1's KNOWN-BAD oracle: the old bucket-based
-		 * code emitted user rules in accumulated-bucket order (also lan then opt1 for this
-		 * fixture, but would diverge for a different existing_rules order). The immutable-splice
-		 * always preserves the original config.xml order verbatim.
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('opt1'),
-			$this->pfbDenyRule('lan'),
-			$this->userPassLan(),
-			$this->userPassOpt1(),
-		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		// inbound='opt1', outbound='lan' — mimics a config where opt1 is the inbound iface.
-		$result = pfb_build_autorule_list($existing, $gen, 'order_4', '', ['opt1'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'opt1', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan',  'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
-			['descr' => 'Default allow OPT1 to any', 'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
-		], $result, 'order_4 float=off two ifaces');
-		$this->assertTrackersSet($result, 'order_4 float=off two ifaces');
-		$this->assertUserRulesPreserved($existing, $result, 'order_4 float=off two ifaces');
-		$this->assertIdempotent($result, $gen, 'order_4', '', ['opt1'], ['lan'], 'order_4 float=off two ifaces');
-	}
-
-	// -----------------------------------------------------------------------
-	// L. order_4, float=on, single iface
-	// -----------------------------------------------------------------------
-
-	public function testOrder4FloatOnSingleIfaceDenyOnly(): void
-	{
-		/**
-		 * Scenario: ORDER 4, float=on.
-		 *
-		 * ORDER 4 anchor = BEFORE: pfB block first, then kept user rules verbatim.
-		 * keep = [user_float_pass, user_pass(lan)] (original order).
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_float_pass, user_pass(lan).
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->userFloatPass(),
-			$this->userPassLan(),
-		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_4', 'on', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'User Float Pass',            'type' => 'pass',   'interface' => '',    'floating' => 'yes'],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'order_4 float=on single iface');
-		$this->assertTrackersSet($result, 'order_4 float=on');
-		$this->assertUserRulesPreserved($existing, $result, 'order_4 float=on');
-		$this->assertIdempotent($result, $gen, 'order_4', 'on', ['lan'], ['lan'], 'order_4 float=on');
-	}
-
-	// -----------------------------------------------------------------------
-	// M. absent/empty pass_order -> treated as order_0 (the #532 default fix)
-	// -----------------------------------------------------------------------
-
-	public function testAbsentOrderTreatedAsBefore(): void
-	{
-		/**
-		 * Scenario: empty pass_order string (absent / unknown).
-		 *
-		 * The immutable-splice model maps any unknown order to the BEFORE anchor (pfB
-		 * block first, then kept user rules). This makes the drop bug (#532) impossible
-		 * by construction — user rules are never bucketed and cannot be omitted.
-		 *
-		 * Fail-before: the old bucket-based code sent user pass rules to $permit_rules
-		 * for unrecognised orders, which had no tail emission → user rule DROPPED.
-		 * The caller's order_0 default (#539) defended against that; the immutable-splice
-		 * makes the helper itself safe regardless of what the caller passes.
-		 *
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)  (same as order_0).
-		 */
-
-		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
-		$gen      = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, '', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'empty order -> BEFORE anchor (user rule preserved, same as order_0)');
-		$this->assertTrackersSet($result, 'absent order');
-		$this->assertUserRulesPreserved($existing, $result, 'absent order');
-		$this->assertIdempotent($result, $gen, '', '', ['lan'], ['lan'], 'absent order');
-	}
-
-	// -----------------------------------------------------------------------
-	// N. Permit_* config present (order_1, float=off, separate ifaces)
-	// -----------------------------------------------------------------------
-
-	public function testOrder1FloatOffPermitAndDenyRulesPresent(): void
-	{
-		/**
-		 * Scenario: pfB has BOTH permit_inbound and deny_inbound (Permit_* list present).
-		 * order_1, float=off, separate ifaces (lan in, opt1 out).
-		 *
-		 * ORDER 1 anchor = AFTER: all kept user rules first (verbatim), then pfB block.
-		 * keep = [user_pass(lan), user_pass(opt1)] (original order; pfB deny rules stripped).
-		 * pfB block = [permit_in(lan), deny_in(lan), permit_out(opt1), deny_out(opt1)].
-		 * Expected: user_pass(lan), user_pass(opt1), pfB permit_in(lan), pfB deny_in(lan),
-		 *           pfB permit_out(opt1), pfB deny_out(opt1).
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->pfbDenyRule('opt1'),
-			$this->userPassLan(),
-			$this->userPassOpt1(),
-		];
-		$gen = $this->pfbGeneratedPermitAndDeny();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_1', '', ['lan'], ['opt1']);
-
-		$this->assertShapes([
-			['descr' => 'Default allow LAN to any',      'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
-			['descr' => 'Default allow OPT1 to any',     'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
-			['descr' => 'pfB_PermitList_v4 Auto Rule',   'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule',     'type' => 'block',  'interface' => 'lan',  'floating' => ''],
-			['descr' => 'pfB_PermitList_v4 Auto Rule',   'type' => 'pass',   'interface' => 'opt1', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule',     'type' => 'reject', 'interface' => 'opt1', 'floating' => ''],
-		], $result, 'order_1 float=off Permit_* + Deny_* separate ifaces');
-		$this->assertTrackersSet($result, 'order_1 permit+deny');
-		$this->assertUserRulesPreserved($existing, $result, 'order_1 permit+deny');
-		$this->assertIdempotent($result, $gen, 'order_1', '', ['lan'], ['opt1'], 'order_1 permit+deny');
-	}
-
-	// -----------------------------------------------------------------------
-	// O. DNS-redirect bypass rule present — must survive (not stripped)
-	// -----------------------------------------------------------------------
-
-	public function testDnsRedirectBypassRulePreserved(): void
-	{
-		/**
-		 * Scenario: existing rules include a DNS-redirect bypass rule.
-		 * Its descr starts with PFB_DNS_REDIR_DESCR_V4_PFX ('pfB_DNS_Redirect_').
-		 * The helper must treat it like a user rule — NOT strip it.
-		 *
-		 * order_0 anchor = BEFORE: pfB block first, then kept user rules verbatim.
-		 * keep = [bypass_rule(lan), user_pass(lan)] (original order; pfB deny stripped).
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), bypass_rule(lan), user_pass(lan).
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->dnsRedirectBypassRule(),
-			$this->userPassLan(),
-		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DNS_Redirect_lan_v4',   'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'DNS-redirect bypass rule preserved (not stripped)');
-		$this->assertTrackersSet($result, 'dns-redirect bypass');
-		$this->assertUserRulesPreserved($existing, $result, 'dns-redirect bypass');
-		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'dns-redirect bypass');
-	}
-
-	// -----------------------------------------------------------------------
-	// P. DoT-block bypass rule present — must survive (not stripped)
-	// -----------------------------------------------------------------------
-
-	public function testDotBlockBypassRulePreserved(): void
-	{
-		/**
-		 * Scenario: existing rules include a DoT-block bypass rule.
-		 * Its descr starts with PFB_DOT_BLOCK_DESCR_PFX ('pfB_DoT_Block_').
-		 * Must be preserved like a user rule — NOT stripped.
-		 *
-		 * order_0 anchor = BEFORE. keep = [dot_block_rule(lan), user_pass(lan)].
-		 * Expected: pfB deny_in(lan), pfB deny_out(lan), dot_block_rule(lan), user_pass(lan).
-		 */
-
-		$existing = [
-			$this->pfbDenyRule('lan'),
-			$this->dotBlockBypassRule(),
-			$this->userPassLan(),
-		];
-		$gen = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DoT_Block_lan',         'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'DoT-block bypass rule preserved (not stripped)');
-		$this->assertTrackersSet($result, 'dot-block bypass');
-		$this->assertUserRulesPreserved($existing, $result, 'dot-block bypass');
-		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'dot-block bypass');
-	}
-
-	// -----------------------------------------------------------------------
-	// Q. pfB_ rules stripped (sanity check)
-	// -----------------------------------------------------------------------
-
-	public function testPfbRulesAreStripped(): void
-	{
-		/**
-		 * Scenario: existing rules contain only a pfB_ deny rule (no bypass prefix).
-		 * It must be stripped and rebuilt from the template.
-		 * Result: exactly the rebuilt pfB rules, no user rules (keep = []).
-		 */
-
-		$existing = [$this->pfbDenyRule('lan')];
-		$gen      = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-		], $result, 'pfB_ rules stripped and rebuilt');
-		$this->assertTrackersSet($result, 'pfB stripped');
-		$this->assertUserRulesPreserved($existing, $result, 'pfB stripped');
-		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'pfB stripped');
-	}
-
-	// -----------------------------------------------------------------------
-	// R. DNSBL float rules emitted when present
-	// -----------------------------------------------------------------------
-
-	public function testDnsblFloatRulesEmittedBeforeIfaceLoop(): void
-	{
-		/**
-		 * Scenario: pfb_generated['dnsbl_float'] contains the pre-built ping+permit pair.
-		 * They must appear BEFORE the inbound/outbound interface rules.
-		 *
-		 * order_0, float=off.
-		 * Expected: dnsbl_ping, dnsbl_permit, pfB deny_in(lan), pfB deny_out(lan), user_pass(lan)
-		 */
-
-		$existing = [$this->userPassLan()];
-
-		$gen                 = $this->pfbGeneratedDenyOnly();
-		$gen['dnsbl_float']  = [
-			['descr' => 'pfB_DNSBL_Ping Auto Rule',   'type' => 'pass', 'interface' => 'opt2', 'floating' => 'yes',
-			 'direction' => 'any', 'ipprotocol' => 'inet', 'source' => ['any' => ''],
-			 'destination' => ['address' => '10.0.0.1'], 'created' => ['time' => 0, 'username' => 'Auto']],
-			['descr' => 'pfB_DNSBL_Permit Auto Rule', 'type' => 'pass', 'interface' => 'opt2', 'floating' => 'yes',
-			 'direction' => 'any', 'ipprotocol' => 'inet', 'source' => ['any' => ''],
-			 'destination' => ['address' => '10.0.0.1', 'port' => 'pfB_DNSBL_Ports'],
-			 'created' => ['time' => 0, 'username' => 'Auto']],
-		];
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DNSBL_Ping Auto Rule',   'type' => 'pass',   'interface' => 'opt2', 'floating' => 'yes'],
-			['descr' => 'pfB_DNSBL_Permit Auto Rule', 'type' => 'pass',   'interface' => 'opt2', 'floating' => 'yes'],
-			['descr' => 'pfB_DenyList_v4 Auto Rule',  'type' => 'block',  'interface' => 'lan',  'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule',  'type' => 'reject', 'interface' => 'lan',  'floating' => ''],
-			['descr' => 'Default allow LAN to any',   'type' => 'pass',   'interface' => 'lan',  'floating' => ''],
-		], $result, 'DNSBL float rules emitted before iface loop');
-		$this->assertUserRulesPreserved($existing, $result, 'dnsbl float');
-		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'dnsbl float');
-	}
-
-	// -----------------------------------------------------------------------
-	// S. Empty existing rules — no user rules, no pfB old rules
-	// -----------------------------------------------------------------------
-
-	public function testEmptyExistingRulesProducesOnlyPfbRules(): void
-	{
-		/**
-		 * Scenario: no existing rules at all. Only pfB templates.
-		 */
-
-		$gen    = $this->pfbGeneratedDenyOnly();
-		$result = pfb_build_autorule_list([], $gen, 'order_0', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-		], $result, 'empty existing rules');
-		$this->assertTrackersSet($result, 'empty existing');
-		$this->assertUserRulesPreserved([], $result, 'empty existing');
-		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'empty existing');
-	}
-
-	// -----------------------------------------------------------------------
-	// T. Non-managed iface user rule goes to other_rules (float=off)
-	// -----------------------------------------------------------------------
-
-	public function testNonManagedIfaceRulePreservedVerbatim(): void
-	{
-		/**
-		 * Scenario: user rule on 'wan' — NOT in the managed inbound/outbound iface list.
-		 * order_0, float=off, managed=['lan'].
-		 *
-		 * The immutable splice keeps ALL non-pfB-owned rules verbatim, regardless of
-		 * interface. Non-managed rules are not singled out — they stay in their original
-		 * position relative to other user rules in $keep.
-		 * Expected: pfB BEFORE, then keep = [wan_rule, user_pass(lan)] (original order).
-		 */
-
-		$nonManagedRule = [
-			'descr'       => 'WAN rule',
-			'type'        => 'pass',
-			'interface'   => 'wan',
-			'ipprotocol'  => 'inet',
-			'floating'    => '',
-			'source'      => ['any' => ''],
-			'destination' => ['any' => ''],
-		];
-
-		$existing = [$nonManagedRule, $this->userPassLan()];
-		$gen      = $this->pfbGeneratedDenyOnly();
-
-		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan'], ['lan']);
-
-		$this->assertShapes([
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block',  'interface' => 'lan', 'floating' => ''],
-			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'reject', 'interface' => 'lan', 'floating' => ''],
-			['descr' => 'WAN rule',                  'type' => 'pass',   'interface' => 'wan', 'floating' => ''],
-			['descr' => 'Default allow LAN to any',  'type' => 'pass',   'interface' => 'lan', 'floating' => ''],
-		], $result, 'non-managed iface rule preserved verbatim in original position');
-		$this->assertUserRulesPreserved($existing, $result, 'non-managed iface');
-		$this->assertIdempotent($result, $gen, 'order_0', '', ['lan'], ['lan'], 'non-managed iface');
-	}
-
-	/**
-	 * Regression: a null $float / $order must be tolerated exactly as ''.
-	 *
-	 * The call site passes $pfb['float'] / $pfb['order'] straight through, and those are
-	 * unset (null) until configured (e.g. enable_float not set). The original inline code
-	 * used the raw null in loose comparisons, so null is behaviour-equivalent to ''. The
-	 * Phase-1 extraction's strict `string` typehint instead TypeError'd on the null the call
-	 * site legitimately passes -- which on a live VM aborted `pfblockerng.php update` with a
-	 * fatal ("Argument #4 ($float) must be of type string, null given"), so no pfB rule was
-	 * built. This pins that the null path produces the SAME output as the empty-string path.
-	 */
-	public function testNullOrderAndFloatTreatedAsEmptyString(): void
-	{
-		$existing = [$this->pfbDenyRule('lan'), $this->userPassLan()];
-		$gen      = $this->pfbGeneratedDenyOnly();
-
-		$withEmpty = pfb_build_autorule_list($existing, $gen, '', '', ['lan'], ['lan']);
-		$withNull  = pfb_build_autorule_list($existing, $gen, null, null, ['lan'], ['lan']);
-
-		$this->assertSame(
-			$this->shapes($withEmpty),
-			$this->shapes($withNull),
-			'null $order/$float must behave identically to empty-string (regression for the live '
-				. 'TypeError that aborted the update verb when enable_float was unset)'
-		);
-	}
-
-	/**
-	 * A pfB match rule is floating-only and emitted ONCE across all inbound interfaces (the
-	 * $pfbrunonce gate), carrying $pfb_generated['inbound_floating'] as its interface — not once
-	 * per interface. Pins that emit-once logic, which no fixture above exercises (all leave
-	 * match_inbound empty), so a regression in $pfbrunonce can't slip past the off-appliance suite.
-	 */
-	public function testMatchInboundEmittedOnceAcrossMultipleInterfaces(): void
-	{
-		$existing = [$this->userPassLan()];
-		$gen = $this->pfbGeneratedDenyOnly();
-		$gen['inbound_floating'] = 'lan,opt1';   // the floating interface group set by the package
-		$gen['match_inbound'] = [[
-			'descr'       => 'pfB_DenyList_v4 Auto Rule',
-			'type'        => 'match',
-			'interface'   => '',  // set by helper to inbound_floating
-			'ipprotocol'  => 'inet',
-			'floating'    => 'yes',
-			'source'      => ['address' => 'pfB_DenyList_v4'],
-			'destination' => ['any' => ''],
-			'created'     => ['time' => 0, 'username' => 'Auto'],
-		]];
-
-		// Two inbound interfaces — the match rule must still appear EXACTLY ONCE.
-		$result = pfb_build_autorule_list($existing, $gen, 'order_0', '', ['lan', 'opt1'], ['lan', 'opt1']);
-
-		$matches = array_values(array_filter($result, static fn (array $r): bool => ($r['type'] ?? '') === 'match'));
+		// Match rules are floating-only and must be emitted ONCE even with multiple inbound ifaces.
+		$result = pfb_build_autorule_list([$this->userPass('User allow LAN')], $this->genWithMatch(),
+		                                  'order_0', '', ['lan', 'opt1'], []);
+		$matches = array_filter($result, static fn ($r) => ($r['descr'] ?? '') === 'pfB_MatchList_v4 Auto Rule');
 		$this->assertCount(1, $matches,
-			'pfB match rule must be emitted once across all inbound interfaces ($pfbrunonce), got '
-				. count($matches) . ': ' . json_encode($this->shapes($result), JSON_PRETTY_PRINT));
-		$this->assertSame('lan,opt1', $matches[0]['interface'] ?? null,
-			'the match rule carries inbound_floating as its interface');
-		$this->assertUserRulesPreserved($existing, $result, 'match-once');
+			"Floating Match rule must be emitted exactly once across interfaces.\n\nActual:\n"
+				. json_encode($this->shapes($result), JSON_PRETTY_PRINT));
+		// The single Match carries the inbound_floating interface, not a per-iface value.
+		$this->assertSame('lan', array_values($matches)[0]['interface'], 'match interface = inbound_floating');
+		$this->assertTrackersSet($result, 'match-once');
+	}
+
+	public function testDnsblFloatPairLeadsThePfbPassBucket(): void
+	{
+		$result = pfb_build_autorule_list([$this->userPass('User allow LAN')], $this->genWithDnsbl(),
+		                                  'order_0', '', ['lan'], []);
+		$this->assertShapes([
+			['descr' => 'pfB_DNSBL_Permit',          'type' => 'pass',  'interface' => 'lan', 'floating' => 'yes', 'direction' => ''],
+			['descr' => 'pfB_DenyList_v4 Auto Rule', 'type' => 'block', 'interface' => 'lan', 'floating' => '',    'direction' => 'in'],
+			['descr' => 'User allow LAN',            'type' => 'pass',  'interface' => 'lan', 'floating' => '',    'direction' => ''],
+		], $result, 'dnsbl lead');
+	}
+
+	public function testPfbOwnedRulesStrippedAndRegenerated(): void
+	{
+		// A stale pfB_DenyAlias auto rule in the input must be removed; the fresh pfB Deny appears.
+		$existing = [$this->pfbOwnedDeny('lan'), $this->userPass('User allow LAN')];
+		$result   = pfb_build_autorule_list($existing, $this->genDenyOnly(), 'order_0', '', ['lan'], []);
+
+		$descrs = array_column($result, 'descr');
+		$this->assertNotContains('pfB_DenyAlias_v4 Auto Rule', $descrs,
+			"Stale pfB-owned rule must be stripped.\n\nActual:\n" . json_encode($descrs, JSON_PRETTY_PRINT));
+		$this->assertContains('pfB_DenyList_v4 Auto Rule', $descrs, 'fresh pfB Deny regenerated');
+		$this->assertContains('User allow LAN', $descrs, 'user rule kept');
+	}
+
+	public function testBypassRulesAreKeptNotStripped(): void
+	{
+		// DNS-redirect / DoT-block bypass rules keep their pfB_ prefix but are user-managed.
+		$existing = [$this->dnsRedirectBypass(), $this->dotBlockBypass(), $this->userPass('User allow LAN')];
+		$result   = pfb_build_autorule_list($existing, $this->genDenyOnly(), 'order_0', '', ['lan'], []);
+
+		$descrs = array_column($result, 'descr');
+		$this->assertContains('pfB_DNS_Redirect_lan_v4', $descrs, 'DNS-redirect bypass kept');
+		$this->assertContains('pfB_DoT_Block_lan', $descrs, 'DoT-block bypass kept');
+		$this->assertUserRulesIntact($existing, $result, 'bypass kept');
+	}
+
+	// =======================================================================
+	// Immutability contract (no drop / no dup / no mutation) + within-bucket order
+	// =======================================================================
+
+	public function testNoUserRuleDuplicationWhenInterfaceIsBothInAndOut(): void
+	{
+		// The #532 dup: a Permit list whose interface is BOTH inbound and outbound previously
+		// emitted the user pass rule twice (once per loop). It must now appear exactly once.
+		$existing = [$this->userPass('User allow LAN'), $this->userBlock('User block evil')];
+		$result   = pfb_build_autorule_list($existing, $this->genPermitDeny(''), 'order_2', '', ['lan'], ['lan']);
+
+		foreach (['User allow LAN', 'User block evil'] as $descr) {
+			$count = count(array_filter($result, static fn ($r) => ($r['descr'] ?? '') === $descr));
+			$this->assertSame(1, $count,
+				"User rule '{$descr}' must appear exactly once (in==out dup guard).\n\nActual:\n"
+					. json_encode($this->shapes($result), JSON_PRETTY_PRINT));
+		}
+		$this->assertUserRulesIntact($existing, $result, 'in==out no-dup');
+	}
+
+	public function testFloatingUserRulesNotDroppedWhenNoInboundInterface(): void
+	{
+		// Reference DROP bug: order_2 + float-on emitted floating user pass/match only inside the
+		// inbound loop, so with NO inbound interface (outbound-only list) they vanished. They must
+		// survive — a user rule is never dropped, whatever the iface/order/float combination.
+		$existing = [$this->userPass('User float allow', 'lan', 'yes'), $this->userMatch('User float match', 'lan')];
+		$result   = pfb_build_autorule_list($existing, $this->genPermitDeny('on'), 'order_2', 'on', [], ['lan']);
+
+		$descrs = array_column($result, 'descr');
+		$this->assertContains('User float allow', $descrs,
+			"Floating user pass must survive with no inbound iface.\n\nActual:\n" . json_encode($descrs, JSON_PRETTY_PRINT));
+		$this->assertContains('User float match', $descrs, 'floating user match must survive');
+		$this->assertUserRulesIntact($existing, $result, 'order_2 float-on outbound-only no-drop');
+	}
+
+	public function testWithinBucketOrderPreserved(): void
+	{
+		// Two user pass rules on the same managed iface land in the same bucket; order_1 must keep
+		// their RELATIVE order (only whole buckets move, never the rules inside one).
+		$existing = [$this->userPass('User allow LAN'), $this->userPass('User allow LAN 2')];
+		$result   = pfb_build_autorule_list($existing, $this->genPermitDenyInbound(), 'order_1', '', ['lan'], ['lan']);
+
+		$this->assertShapes([
+			['descr' => 'User allow LAN',              'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => ''],
+			['descr' => 'User allow LAN 2',            'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => ''],
+			['descr' => 'pfB_PermitList_v4 Auto Rule', 'type' => 'pass',  'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+			['descr' => 'pfB_DenyList_v4 Auto Rule',   'type' => 'block', 'interface' => 'lan', 'floating' => '', 'direction' => 'in'],
+		], $result, 'within-bucket order');
+	}
+
+	public function testEmptyAndUnknownOrderBehaveAsOrder0(): void
+	{
+		// An empty/unknown pass_order must NOT drop a user rule (#532/#539) — it acts as order_0.
+		$existing = [$this->userPass('User allow LAN'), $this->userBlock('User block evil')];
+		$order0   = $this->shapes(pfb_build_autorule_list($existing, $this->genDenyOnly(), 'order_0', '', ['lan'], ['lan']));
+
+		foreach (['', 'totally_bogus', null] as $order) {
+			$result = pfb_build_autorule_list($existing, $this->genDenyOnly(), $order, '', ['lan'], ['lan']);
+			$this->assertSame($order0, $this->shapes($result),
+				'order ' . var_export($order, TRUE) . ' must match order_0');
+			$this->assertUserRulesIntact($existing, $result, 'empty/unknown order');
+		}
+	}
+
+	public function testNullFloatTolerated(): void
+	{
+		// $pfb['float'] is null until configured; the helper coerces it to off, never TypeErrors.
+		$existing = [$this->userPass('User allow LAN')];
+		$result   = pfb_build_autorule_list($existing, $this->genDenyOnly(), 'order_0', null, ['lan'], []);
+		$this->assertSame(
+			$this->shapes(pfb_build_autorule_list($existing, $this->genDenyOnly(), 'order_0', '', ['lan'], [])),
+			$this->shapes($result),
+			'null float == off'
+		);
+	}
+
+	public function testIdempotentAcrossOrdersAndFloat(): void
+	{
+		$existing = [$this->userPass('User allow LAN'), $this->userBlock('User block evil'),
+		             $this->userPass('User allow OPT1', 'opt1')];
+		foreach (['order_0', 'order_1', 'order_2', 'order_3', 'order_4'] as $order) {
+			foreach (['', 'on'] as $float) {
+				$gen   = $this->genPermitDeny($float);
+				$first = pfb_build_autorule_list($existing, $gen, $order, $float, ['lan'], ['opt1']);
+				$this->assertIdempotent($first, $gen, $order, $float, ['lan'], ['opt1'], "{$order} float='{$float}'");
+			}
+		}
+	}
+
+	// =======================================================================
+	// HEADLINE GUARD — behavioural equivalence to the proven 8c4c482 reference
+	// on every dup-free config (the dup-trigger configs are the bug we fix and
+	// are pinned to the corrected ORDER table by the fixtures above).
+	// =======================================================================
+
+	public function testBehaviourEqualsProvenReferenceOnDupFreeMatrix(): void
+	{
+		$compared = 0;
+
+		foreach ($this->differentialMatrix() as $label => $c) {
+			[$existing, $gen, $order, $float, $in, $out] = $c;
+
+			$new = pfb_build_autorule_list($existing, $gen, $order, $float, $in, $out);
+
+			// (1) the dup fix holds for EVERY config: no user rule appears more than once.
+			$userShapes = $this->shapes(array_values(array_filter($new, fn ($r) => $this->isUserRule($r))));
+			$dups = array_filter(array_count_values(array_map('json_encode', $userShapes)), fn ($n) => $n > 1);
+			$this->assertSame([], $dups,
+				"[{$label}] user rule duplicated:\n" . json_encode(array_keys($dups), JSON_PRETTY_PRINT));
+
+			// (2) behavioural equivalence to the proven reference — asserted ONLY where the
+			//     reference is itself defect-free; the configs skipped here are exactly the bugs
+			//     this change fixes, pinned to the corrected behaviour by the fixtures above:
+			//       * an interface in BOTH in+out dups the user-pass rule (order_1/order_2);
+			//       * order_2 + float-on wedges the floating user pass/match into the inbound loop
+			//         (dropping them with no inbound iface, dup'ing them with >1) and emits the
+			//         pfB match_outbound only later in the outbound loop — so the reference
+			//         mis-orders that whole case. Our helper applies the ORDER table cleanly to
+			//         the floating group (pinned by testFloatOnAppliesOrderTableToFloatingGroup).
+			$overlap        = array_intersect($in, $out) !== [];
+			$userDup        = ($order === 'order_1' || $order === 'order_2') && $overlap;
+			$order2FloatBug = ($order === 'order_2' && $float === 'on');
+			if ($userDup || $order2FloatBug) {
+				continue;
+			}
+
+			// The production call site feeds the helper `pass_order ?: 'order_0'`, so the proven
+			// reference only ever saw order_0..4 — never '' / unknown (its empty-order path is the
+			// #532 drop we fix). Feed it the normalised order, exactly as the call site would.
+			$refOrder = in_array($order, ['order_1', 'order_2', 'order_3', 'order_4'], TRUE) ? $order : 'order_0';
+			$refClean = $this->dedup(pfb_autorule_reference_8c4c482($existing, $gen,
+			    $refOrder, $float, $in, $out));
+
+			foreach ($this->allIfaces($existing, $in, $out) as $iface) {
+				foreach (['in', 'out'] as $dir) {
+					$this->assertSame(
+						$this->evalSeq($refClean, $iface, $dir),
+						$this->evalSeq($new, $iface, $dir),
+						"[{$label}] iface '{$iface}' dir '{$dir}' eval-sequence diverges from the proven reference"
+					);
+				}
+			}
+			$compared++;
+		}
+
+		// Guard against an accidentally-empty matrix silently passing.
+		$this->assertGreaterThan(60, $compared, 'differential must compare a meaningful number of dup-free configs');
+	}
+
+	/**
+	 * Deterministic enumerated config matrix: orders × float × iface layouts × user-rule sets ×
+	 * pfB generators. Disjoint iface layouts keep most configs dup-free; the few dup-trigger ones
+	 * are filtered inside the test. No RNG — fully reproducible.
+	 *
+	 * @return array<string, array{0: array, 1: array, 2: ?string, 3: ?string, 4: array, 5: array}>
+	 */
+	private function differentialMatrix(): array
+	{
+		$ifaceLayouts = [
+			'in-lan'              => [['lan'], []],
+			'out-lan'             => [[], ['lan']],
+			'in-lan/out-opt1'     => [['lan'], ['opt1']],
+			'in-lanopt1/out-opt2' => [['lan', 'opt1'], ['opt2']],
+			'in-lanopt1'          => [['lan', 'opt1'], []],
+			'in-lan/out-lan'      => [['lan'], ['lan']],     // overlap (dup-trigger, filtered)
+		];
+		$userSets = [
+			'empty'        => [],
+			'pass+block'   => [$this->userPass('U-pass', 'lan'), $this->userBlock('U-block', 'lan')],
+			'mixed-ifaces' => [$this->userPass('U-pass-lan', 'lan'), $this->userBlock('U-block-opt1', 'opt1'),
+			                   $this->userBlock('U-float', 'lan', 'yes')],
+			'floatpass+match+unmanaged' => [$this->userPass('U-float-pass', 'lan', 'yes'),
+			                   $this->userMatch('U-float-match', 'lan'), $this->userPass('U-wan', 'wan')],
+			'bypass+stale' => [$this->dnsRedirectBypass(), $this->pfbOwnedDeny('lan'), $this->userPass('U-keep', 'lan')],
+		];
+		$orders = ['order_0', 'order_1', 'order_2', 'order_3', 'order_4', '', 'bogus'];
+
+		$cases = [];
+		foreach ($orders as $order) {
+			foreach (['', 'on'] as $float) {
+				foreach ($ifaceLayouts as $ilabel => [$in, $out]) {
+					foreach ($userSets as $ulabel => $users) {
+						foreach (['permit+deny', 'deny-only', 'with-match', 'with-dnsbl'] as $glabel) {
+							$gen = match ($glabel) {
+								'permit+deny' => $this->genPermitDeny($float),
+								'deny-only'   => $this->genDenyOnly(),
+								'with-match'  => $this->genWithMatch(),
+								'with-dnsbl'  => $this->genWithDnsbl(),
+							};
+							$cases["o={$order};f={$float};if={$ilabel};u={$ulabel};g={$glabel}"]
+								= [$users, $gen, $order, $float, $in, $out];
+						}
+					}
+				}
+			}
+		}
+		return $cases;
+	}
+
+	// --- differential projection primitives (mirror the pf evaluation model) ---------------
+
+	/** Remove genuinely-identical duplicate rules, keeping first occurrence. */
+	private function dedup(array $arr): array
+	{
+		$seen = []; $out = [];
+		foreach ($arr as $r) {
+			$k = json_encode($r);
+			if (isset($seen[$k])) {
+				continue;
+			}
+			$seen[$k] = TRUE;
+			$out[]    = $r;
+		}
+		return $out;
+	}
+
+	private function dirOk(array $r, string $dir): bool
+	{
+		$d = $r['direction'] ?? '';
+		return $d === '' || $d === 'any' || $d === $dir;
+	}
+
+	/**
+	 * Rules a packet on ($iface,$dir) actually sees, in evaluation order: the floating rules that
+	 * apply to it (in $dir, and either unscoped or scoped to $iface), then this interface's own
+	 * non-floating rules. A floating rule scoped to another interface is NOT seen — so a reorder
+	 * of two different-interface floating rules is inert, and this projection treats it as such.
+	 */
+	private function evalSeq(array $arr, string $iface, string $dir): array
+	{
+		$float = []; $ifc = [];
+		foreach ($arr as $r) {
+			if (!$this->dirOk($r, $dir)) {
+				continue;
+			}
+			$ri = $r['interface'] ?? '';
+			if (($r['floating'] ?? '') === 'yes') {
+				if ($ri === '' || $ri === 'any' || $ri === $iface) {
+					$float[] = $r;
+				}
+			} elseif ($ri === $iface) {
+				$ifc[] = $r;
+			}
+		}
+		return $this->shapes(array_merge($float, $ifc));
+	}
+
+	private function allIfaces(array $existing, array $in, array $out): array
+	{
+		$s = array_merge($in, $out);
+		foreach ($existing as $r) {
+			$s[] = $r['interface'] ?? '';
+		}
+		return array_values(array_unique($s));
 	}
 }

--- a/tests/smoke/test_smoke_autorule_immutable.py
+++ b/tests/smoke/test_smoke_autorule_immutable.py
@@ -1,24 +1,34 @@
 """
-Live-VM oracle: immutable-user-rule splice (ADR-41 Phase 3).
+Live-VM oracle: the IP auto-rule reconciler (ADR-41), 4-way pass_order assembly.
 
 Verifies that pfb_build_autorule_list() applied by sync_package_pfblockerng()
-never drops, duplicates, or reorders user-authored firewall rules across an
-Enable/Force-Update cycle.
+(a) never drops, duplicates, or content-mutates a user-authored firewall rule
+across an Enable/Force-Update cycle, and (b) orders pfBlockerNG's own rules
+around the user's per the pass_order ORDER table — in particular that a pfB
+**Permit** list (pass) precedes a user **Block** for order_1..order_4.
+
+THE PRECEDENCE TRAP (why this file exists)
+------------------------------------------
+The binary-anchor design (PR #561) put the whole block of user rules — including
+user Block rules — ahead of the pfB block for order_1/order_2, so a pfB Permit
+list could not override a user Block. The Deny-only kill-gate never saw it
+(the pfB-pass bucket was empty). The acceptance sweep here MUST use a config
+with BOTH a pfB Permit and a pfB Deny list AND a user pass AND a user block on
+the same interface, and assert the data-plane verdict per pass_order — this is
+the falsifying case the Phase-2 gate omitted (RESULTS/05).
 
 LIVE RUN DEFERRED TO PHASE 4
 -----------------------------
 The live-VM harness (ADR-04) proves the on-box pf state after pfBlockerNG reloads;
-Phase 4 is the designated phase for the per-pass_order precedence sweep.
-This file is written in Phase 3 so Phase 4 can extend and execute it without
-rewriting the fixture structure from scratch.
+Phase 4 wires the fixtures + the per-pass_order data-plane sweep. This file is
+written so Phase 4 can extend and execute it without rebuilding the structure.
+The off-appliance contract (incl. the Permit-vs-Block trap, all five orders) is
+already pinned in tests/php/AutoruleListOracleTest.php.
 
 To run manually once Phase 4 is underway (box at 10.0.0.23, NO_TWO_VM=1):
 
     python -m pytest tests/smoke/test_smoke_autorule_immutable.py \
         --override-ini="addopts=" -v
-
-All tests in this file are marked ``immutable_autorule`` (a Phase-4 gate marker
-— not yet wired into CI).
 """
 
 from __future__ import annotations
@@ -276,5 +286,112 @@ def test_order1_user_pass_before_pfb_block(smoke_vm: h.SmokeVM) -> None:
     assert user_pass_idx < pfb_block_idx, (
         f"order_1: user pass must appear BEFORE pfB block (user wins).\n"
         f"User pass at index {user_pass_idx}, pfB block at index {pfb_block_idx}.\n"
+        f"Actual rule descrs:\n  {descrs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture + sweep: THE PRECEDENCE TRAP — pfB Permit + pfB Deny + user pass + block
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def pfb_enabled_permit_and_deny(smoke_vm: h.SmokeVM) -> h.SmokeVM:  # type: ignore[return]
+    """
+    Given:
+        pfBlockerNG enabled with BOTH a Permit_* and a Deny_* v4 IP list active on LAN
+        (RFC-5737 addresses), plus a user PASS rule and a user BLOCK rule on LAN.
+
+    This is the config the binary-anchor design got wrong and the Deny-only gate missed:
+    the pfB Permit (pass) must precede the user Block for order_1..order_4.
+    """
+    # Phase 4: wire h.ensure_pfblockerng_enabled() + a Permit_* list + a Deny_* list +
+    # inject a user pass and a user block rule on LAN via h.php_eval(config_set_path).
+    raise NotImplementedError(
+        "Phase 4: wire pfb_enabled_permit_and_deny (Permit_* + Deny_* lists + user pass + user "
+        "block on LAN) using h.deploy() + h.write_local_feed() + h.reload()."
+    )
+
+
+# order -> (does pfB Permit precede the user Block?  does the user Pass precede the pfB Deny?)
+# Per the ORDER table, the pfB Permit (pass) precedes the user Block in EVERY order_1..order_4
+# (and order_0); order_1/order_2 additionally place the user Pass ahead of the pfB Deny.
+_TRAP_ORDERS = ["order_0", "order_1", "order_2", "order_3", "order_4"]
+
+
+@pytest.mark.parametrize("pass_order", _TRAP_ORDERS)
+@pytest.mark.usefixtures("pfb_enabled_permit_and_deny")
+def test_pfb_permit_precedes_user_block_every_order(smoke_vm: h.SmokeVM, pass_order: str) -> None:
+    """
+    Scenario: with a pfB Permit list AND a user Block on LAN, the pfB Permit (pass) must precede
+    the user Block for every pass_order — so the admin's allowlist overrides the user's block.
+
+    THIS IS THE TRAP. The binary-anchor design failed it for order_1/order_2 (it put the whole
+    user block of rules, including the user Block, ahead of the pfB Permit).
+
+    Given:
+        pass_order=<param>; pfB Permit_* + Deny_* lists; user pass + user block on LAN.
+
+    When:
+        Force-Update applied with pass_order set to <param>.
+
+    Then:
+        config.xml index(pfB Permit pass) < index(user Block) on LAN, AND a data-plane probe
+        confirms a host on the Permit list is REACHABLE despite the user Block (pf first-match).
+
+    Evidence requirement: assert the data-plane verdict (a permit-listed host reachable, a
+    block-listed host unreachable), not just config.xml index order — see ADR-41 §7.
+    """
+    # Phase 4: set pass_order=<param> via h.php_eval(config_set_path) before the reload, then
+    # probe the data plane (e.g. a TCP connect / ICMP to a permit-listed vs block-listed host).
+    h.reload(smoke_vm)
+    rules = _get_filter_rules(smoke_vm)
+    descrs = _descr_list(rules)
+
+    pfb_permit_idx = next(
+        (i for i, r in enumerate(rules) if r.get("descr", "").startswith("pfB_") and r.get("type") == "pass"),
+        None,
+    )
+    user_block_idx = next(
+        (
+            i
+            for i, r in enumerate(rules)
+            if not r.get("descr", "").startswith("pfB_") and r.get("type") in ("block", "reject")
+        ),
+        None,
+    )
+
+    assert pfb_permit_idx is not None, f"No pfB Permit (pass) rule found.\nActual rule descrs:\n  {descrs}"
+    assert user_block_idx is not None, f"No user block rule found.\nActual rule descrs:\n  {descrs}"
+    assert pfb_permit_idx < user_block_idx, (
+        f"{pass_order}: pfB Permit (pass) must precede the user Block — a pfB allowlist must "
+        f"override a user block.\npfB Permit at index {pfb_permit_idx}, user block at index "
+        f"{user_block_idx}.\nActual rule descrs:\n  {descrs}"
+    )
+
+
+@pytest.mark.usefixtures("pfb_enabled_permit_and_deny")
+def test_order4_reorders_user_block_before_user_pass(smoke_vm: h.SmokeVM) -> None:
+    """
+    Scenario: order_4 places the user's own Block before its Pass (intended pass_order semantics:
+    order_4 = pfB p/m | pfB b/r | pfSense Block/Reject | pfSense Pass/Match).
+
+    The binary-anchor design wrongly dropped this (it froze user-rule order). Confirm the user
+    Block precedes the user Pass under order_4.
+    """
+    # Phase 4: set pass_order=order_4 via h.php_eval() before the reload.
+    h.reload(smoke_vm)
+    rules = _get_filter_rules(smoke_vm)
+    descrs = _descr_list(rules)
+    user_rules = _user_rules(rules)
+
+    user_block_idx = next((i for i, r in enumerate(user_rules) if r.get("type") in ("block", "reject")), None)
+    user_pass_idx = next((i for i, r in enumerate(user_rules) if r.get("type") == "pass"), None)
+
+    assert user_block_idx is not None, f"No user block rule found.\nActual rule descrs:\n  {descrs}"
+    assert user_pass_idx is not None, f"No user pass rule found.\nActual rule descrs:\n  {descrs}"
+    assert user_block_idx < user_pass_idx, (
+        f"order_4: the user's own Block must precede its Pass (intended pass_order layout).\n"
+        f"user block at index {user_block_idx}, user pass at index {user_pass_idx}.\n"
         f"Actual rule descrs:\n  {descrs}"
     )


### PR DESCRIPTION
## Summary

Course-correction for ADR-41. PR #561 ("immutable user firewall rules") shipped a **flawed
binary-anchor** reconciler in `pfb_build_autorule_list()`: it collapsed the five `pass_order`
layouts into a single before/after splice of the contiguous pfB rule block. That cannot reproduce
`order_1`/`order_2`, which **split** the user's rules around the pfB block — so a pfB **Permit**
list (pass) must precede a user **Block**. The binary anchor put *every* user rule (including the
Block) ahead of the pfB block, so a pfB Permit silently lost to a user Block. It also deleted
`order_4`'s **intended** user-Block-before-user-Pass layout.

The Phase-2 kill-gate false-GO'd: its first-match reduction enumerated `pfB-block vs user-pass`,
`pfB-pass vs user-pass`, and `pfB-block vs user-block`, but **omitted `pfB-pass (Permit) vs
user-block`** — and the only live case was Deny-only (the pfB-pass bucket empty), exactly the
falsifying config the ADR's own §7 reject criterion named.

## The fix

Restore the **4-bucket stable reorder** — pfB pass/match · pfB block/reject · user pass/match ·
user block/reject — concatenated in the `pass_order` ORDER-table sequence, applied **independently**
to the two pf groups (floating / interface). Whole buckets move; within-bucket order is preserved;
**no user rule is duplicated (#532), dropped, or content-mutated**. pfB generation is unchanged.

## Validation (off-appliance, red→green)

- Per-order fixtures for the **pfB-Permit + user-Block trap**, all five orders — pfB Permit precedes
  user Block for order_1..4; order_4 emits user Block before user Pass. **RED on the binary helper,
  GREEN on the 4-way** (5 tests fail on the binary helper).
- Headline guard: the years-proven `8c4c482` emission is embedded **frozen** and the helper is
  asserted **behaviourally identical** to it (per-interface, per-direction) on every dup-free config
  — proving the restore reproduces the proven behaviour everywhere except the dup/drop defects it
  fixes.
- Kept: user-rule fidelity, idempotence, match-emitted-once, dnsbl lead, bypass preservation,
  pfB-owned stripping, within-bucket order, null tolerance.
- **17 tests, 7703 assertions** green; full PHPUnit (1453), PHPStan, PHPCS, `php -l`, ruff,
  markdownlint all green.

## Docs

ADR.md (Status, §2 Decision, §3 Consequences, order_4-is-intended), RESULTS/02 (GO marked FALSE),
RESULTS/05 (correction analysis), architecture-notes (4-bucket model; drop the `quick` over-claim),
and the smoke sweep updated to the Permit-vs-Block precedence case (still skip-deferred to Phase 4 —
the live CE+Plus fan-out is the acceptance gate).

Part of ADR-41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated firewall rule handling to preserve user rules while applying a stable four-bucket ordering.
  * Added broader validation coverage for rule precedence across multiple ordering modes.

* **Bug Fixes**
  * Corrected cases where user block/pass ordering could be wrong.
  * Fixed issues that could drop, duplicate, or misplace rules during reconciliation.

* **Tests**
  * Reworked automated checks to compare behavior against a known-good reference and cover key ordering edge cases.
  * Added smoke coverage for rule precedence and order-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->