### PR TITLE
tests/smoke: fix ADR-43 smoke harness wiring (deployed_vm, php_eval, CompletedProcess)

### DIFF
--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -15,12 +15,37 @@ Tests:
 """
 
 import json
+import os
 import time
+from collections.abc import Iterator
 
 import pytest
 
+from . import helpers as h
+from .conftest import SmokeVM, _StubDnsServer
+
 # Module mark: 'apply_on_change' on every test; 'smoke' per-test.
 pytestmark = [pytest.mark.apply_on_change]
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped deployed_vm: install the branch .pkg once for all tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+    """Deploy the branch .pkg once for the apply_on_change module."""
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.unblock_egress()
+        h.collect_host_diagnostics(smoke_vm)
 
 
 # ---------------------------------------------------------------------------
@@ -39,7 +64,7 @@ _PFB_PHP = "/usr/local/www/pfblockerng/pfblockerng.php"
 
 def _read_ledger(vm) -> dict:
     """Return the parsed ledger from the box (empty on absent/corrupt)."""
-    raw, _, _ = vm.ssh(f"/bin/sh -c 'cat {LEDGER_PATH} 2>/dev/null || echo {{}}'")
+    raw = vm.ssh(f"cat {LEDGER_PATH} 2>/dev/null || echo '{{}}'").stdout
     try:
         return json.loads(raw.strip()) if raw.strip() else {}
     except json.JSONDecodeError:
@@ -66,8 +91,11 @@ def _set_quiet_hours(vm, window: str) -> None:
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');"
         f"PfbConfig::write('pfb_quiet_hours', {json.dumps(window)});"
         "write_config('ADR-43 smoke: set quiet-hours');"
+        "echo 'OK';"
     )
-    vm.pfssh(snippet)
+    result = h.php_eval(vm, snippet)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_set_quiet_hours({window!r}) failed: rc={result.returncode} {result.stderr!r}")
 
 
 def _clear_quiet_hours(vm) -> None:
@@ -82,8 +110,7 @@ def _force_cron_due(vm) -> None:
 
 def _run_tick(vm) -> str:
     """Fire one tick synchronously and return combined stdout+stderr."""
-    out, _, _ = vm.ssh(f"{_PHP} {_PFB_PHP} tick 2>&1")
-    return out
+    return vm.ssh(f"{_PHP} {_PFB_PHP} tick 2>&1").stdout
 
 
 def _cron_ledger(vm) -> dict | None:
@@ -104,7 +131,7 @@ def _is_pending(vm) -> bool:
 
 @pytest.mark.smoke
 @pytest.mark.apply_on_change
-def test_apply_no_window_dispatches_immediately(smoke_vm):
+def test_apply_no_window_dispatches_immediately(deployed_vm: SmokeVM):
     """No quiet-hours window → tick dispatches a due job without deferral.
 
     Scenario:
@@ -120,7 +147,7 @@ def test_apply_no_window_dispatches_immediately(smoke_vm):
     pfb_quiet_hours_in_window(). This test pins that the default behaviour is
     preserved after Phase 5.
     """
-    vm = smoke_vm
+    vm = deployed_vm
     now = int(time.time())
 
     _clear_quiet_hours(vm)
@@ -142,7 +169,7 @@ def test_apply_no_window_dispatches_immediately(smoke_vm):
 
 @pytest.mark.smoke
 @pytest.mark.apply_on_change
-def test_apply_inside_window_dispatches(smoke_vm):
+def test_apply_inside_window_dispatches(deployed_vm: SmokeVM):
     """Window that covers now → tick dispatches, pending NOT set.
 
     Scenario:
@@ -153,7 +180,7 @@ def test_apply_inside_window_dispatches(smoke_vm):
       Then last_run is updated (job ran).
       And pending_apply is NOT set (was inside window).
     """
-    vm = smoke_vm
+    vm = deployed_vm
     now = int(time.time())
 
     _set_quiet_hours(vm, "00:00-23:59")  # always-open window covers any real clock
@@ -175,7 +202,7 @@ def test_apply_inside_window_dispatches(smoke_vm):
 
 @pytest.mark.smoke
 @pytest.mark.apply_on_change
-def test_apply_outside_window_defers(smoke_vm):
+def test_apply_outside_window_defers(deployed_vm: SmokeVM):
     """Window that excludes now → tick defers (pending set, job NOT dispatched).
 
     Scenario:
@@ -193,7 +220,7 @@ def test_apply_outside_window_defers(smoke_vm):
     """
     import datetime
 
-    vm = smoke_vm
+    vm = deployed_vm
 
     # Assert we are not inside the 1-minute test window before proceeding.
     now_local = datetime.datetime.now()
@@ -229,7 +256,7 @@ def test_apply_outside_window_defers(smoke_vm):
 
 @pytest.mark.smoke
 @pytest.mark.apply_on_change
-def test_apply_pending_cleared_by_window_open(smoke_vm):
+def test_apply_pending_cleared_by_window_open(deployed_vm: SmokeVM):
     """Pending job is applied when window opens (pending cleared, last_run updated).
 
     Scenario:
@@ -244,7 +271,7 @@ def test_apply_pending_cleared_by_window_open(smoke_vm):
     Red→green: before Phase 5, is_pending/set_pending didn't exist — a
     "pending" entry written manually would be silently ignored.
     """
-    vm = smoke_vm
+    vm = deployed_vm
     now = int(time.time())
 
     # Arrange: force due + set pending manually (simulates a prior deferred tick).

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -15,16 +15,39 @@ Tests:
 """
 
 import json
+import os
+from collections.abc import Iterator
 
 import pytest
 
 from . import helpers as h
+from .conftest import SmokeVM, _StubDnsServer
 
 # Module mark: 'tick' on every test. 'smoke' is applied PER-TEST (not module-wide)
 # so the reboot test — which reboots the shared session VM — carries 'reboot' but
 # NOT 'smoke', keeping it out of the -m smoke run (see the 'reboot' marker rationale
 # in pyproject.toml; mirrors test_smoke_boot_reload.py).
 pytestmark = [pytest.mark.tick]
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped deployed_vm: install the branch .pkg once for all tick tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+    """Deploy the branch .pkg once for the tick module."""
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.unblock_egress()
+        h.collect_host_diagnostics(smoke_vm)
 
 
 # ---------------------------------------------------------------------------
@@ -43,7 +66,7 @@ _PFB_PHP = "/usr/local/www/pfblockerng/pfblockerng.php"
 
 def _read_ledger(vm) -> dict:
     """Return the parsed ledger as a dict (empty on absent/corrupt)."""
-    raw, _, _ = vm.ssh(f"/bin/sh -c 'cat {LEDGER_PATH} 2>/dev/null || echo {{}}'")
+    raw = vm.ssh(f"cat {LEDGER_PATH} 2>/dev/null || echo '{{}}'").stdout
     try:
         return json.loads(raw.strip()) if raw.strip() else {}
     except json.JSONDecodeError:
@@ -66,8 +89,7 @@ def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: 
 
 def _run_tick(vm) -> str:
     """Fire one tick synchronously and return its combined stdout+stderr."""
-    out, _, _ = vm.ssh(f"{_PHP} {_PFB_PHP} tick 2>&1")
-    return out
+    return vm.ssh(f"{_PHP} {_PFB_PHP} tick 2>&1").stdout
 
 
 # ---------------------------------------------------------------------------
@@ -77,7 +99,7 @@ def _run_tick(vm) -> str:
 
 @pytest.mark.smoke
 @pytest.mark.tick
-def test_tick_dispatches_due_feed(smoke_vm):
+def test_tick_dispatches_due_feed(deployed_vm: SmokeVM):
     """Tick fires a due feed sync when the cron ledger entry is past.
 
     Scenario:
@@ -87,9 +109,9 @@ def test_tick_dispatches_due_feed(smoke_vm):
             Then the log contains 'Tick: dispatching feed cron.'
             And  the 'cron' ledger entry's next_due is updated to the future.
     """
-    vm = smoke_vm
+    vm = deployed_vm
 
-    now_ts = int(vm.ssh("date +%s")[0].strip())
+    now_ts = int(vm.ssh("date +%s").stdout.strip())
 
     # Given: force cron past.
     _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
@@ -115,7 +137,7 @@ def test_tick_dispatches_due_feed(smoke_vm):
 
 @pytest.mark.smoke
 @pytest.mark.tick
-def test_tick_skips_non_due_feed(smoke_vm):
+def test_tick_skips_non_due_feed(deployed_vm: SmokeVM):
     """Tick does NOT fire a feed sync when cron next_due is in the future.
 
     Scenario:
@@ -124,9 +146,9 @@ def test_tick_skips_non_due_feed(smoke_vm):
             When pfblockerng.php tick runs.
             Then the log does NOT contain 'Tick: dispatching feed cron.'
     """
-    vm = smoke_vm
+    vm = deployed_vm
 
-    now_ts = int(vm.ssh("date +%s")[0].strip())
+    now_ts = int(vm.ssh("date +%s").stdout.strip())
     future = now_ts + 3600
 
     _write_ledger_entry(vm, "cron", now_ts - 86400, future)
@@ -140,7 +162,7 @@ def test_tick_skips_non_due_feed(smoke_vm):
 
 @pytest.mark.smoke
 @pytest.mark.tick
-def test_tick_wiped_ledger_jittered(smoke_vm):
+def test_tick_wiped_ledger_jittered(deployed_vm: SmokeVM):
     """After the ledger is wiped, the tick runs jobs but schedules them jittered.
 
     Scenario:
@@ -150,7 +172,7 @@ def test_tick_wiped_ledger_jittered(smoke_vm):
             Then all jobs run (due-now after absent ledger).
             And  the 'dcc' next_due has non-zero jitter (not exactly last_run+86400).
     """
-    vm = smoke_vm
+    vm = deployed_vm
 
     # Wipe the ledger.
     vm.ssh(f"rm -f {LEDGER_PATH}")
@@ -166,7 +188,7 @@ def test_tick_wiped_ledger_jittered(smoke_vm):
 
     # dcc should have run and have a non-zero jitter.
     assert "dcc" in ledger, f"dcc ledger entry missing after wiped-ledger tick; ledger={ledger}"
-    now_ts = int(vm.ssh("date +%s")[0].strip())
+    now_ts = int(vm.ssh("date +%s").stdout.strip())
     no_jitter_next_due = ledger["dcc"]["last_run"] + 86400
     actual_next = ledger["dcc"]["next_due"]
     assert actual_next != no_jitter_next_due, (
@@ -179,7 +201,7 @@ def test_tick_wiped_ledger_jittered(smoke_vm):
 
 @pytest.mark.reboot
 @pytest.mark.tick
-def test_tick_reboot_persists_ledger(smoke_vm):
+def test_tick_reboot_persists_ledger(deployed_vm: SmokeVM):
     """A clean reboot keeps the due-ledger (restored via #468 earlyshellcmd).
 
     Scenario:
@@ -189,15 +211,15 @@ def test_tick_reboot_persists_ledger(smoke_vm):
             Then the ledger is restored.
             And  the cron next_due is still in the future (no spurious dispatch).
     """
-    vm = smoke_vm
+    vm = deployed_vm
 
-    now_ts = int(vm.ssh("date +%s")[0].strip())
+    now_ts = int(vm.ssh("date +%s").stdout.strip())
     future = now_ts + 7200  # 2 hours out
 
     _write_ledger_entry(vm, "cron", now_ts, future)
 
     # Reboot.
-    vm.reboot()
+    h.reboot_vm(vm)
 
     # After reboot: verify ledger was restored.
     after = _read_ledger(vm)

--- a/tests/smoke/test_trigger_api.py
+++ b/tests/smoke/test_trigger_api.py
@@ -19,12 +19,35 @@ Local (docs/misc/local-smoke-debian.md):
 
 from __future__ import annotations
 
+import os
+from collections.abc import Iterator
+
 import pytest
 
 from . import helpers as h
-from .conftest import SmokeVM, _MockFeedServer
+from .conftest import SmokeVM, _MockFeedServer, _StubDnsServer
 
 pytestmark = pytest.mark.smoke
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped deployed_vm: install the branch .pkg once for all tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+    """Deploy the branch .pkg once for the trigger_api module."""
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.unblock_egress()
+        h.collect_host_diagnostics(smoke_vm)
 
 
 # ---------------------------------------------------------------------------
@@ -33,7 +56,7 @@ pytestmark = pytest.mark.smoke
 
 
 @pytest.mark.smoke
-def test_pfb_trigger_verb_reloads_dnsbl(smoke_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_pfb_trigger_verb_reloads_dnsbl(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """Scenario: pfb_trigger scope=both force=false trigger=cron reloads DNSBL.
 
     Given a DNSBL feed containing a unique test domain.
@@ -51,10 +74,10 @@ def test_pfb_trigger_verb_reloads_dnsbl(smoke_vm: SmokeVM, mock_feeds: _MockFeed
         header="pfb_trigger_dnsbl",
         mode=h.DnsblMode.VIP,
     )
-    with h.CaseContext(smoke_vm, spec):
+    with h.CaseContext(deployed_vm, spec):
         # CaseContext.__enter__ already called reload("update") via pfb_trigger.
         # Assert the block is live.
-        answer = h.dns_probe(smoke_vm, domain)
+        answer = h.dns_probe(deployed_vm, domain)
         assert h.is_vip(answer), (
             f"domain {domain!r} must be VIP-blocked after pfb_trigger reload\ngot answer: {answer!r}"
         )
@@ -67,7 +90,7 @@ def test_pfb_trigger_verb_reloads_dnsbl(smoke_vm: SmokeVM, mock_feeds: _MockFeed
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("verb", ["update", "updateip", "updatednsbl"])
-def test_deprecated_verb_logs_deprecation_warning(smoke_vm: SmokeVM, verb: str) -> None:
+def test_deprecated_verb_logs_deprecation_warning(deployed_vm: SmokeVM, verb: str) -> None:
     """Scenario: deprecated verb emits DEPRECATED line in pfblockerng.log.
 
     Given the count of 'DEPRECATED: pfblockerng verb {verb}' lines in pfblockerng.log.
@@ -79,16 +102,16 @@ def test_deprecated_verb_logs_deprecation_warning(smoke_vm: SmokeVM, verb: str) 
     the result is written via pfb_logger(). A future removal of the log line breaks this.
     """
     marker = f"DEPRECATED: pfblockerng verb '{verb}'"
-    before = h.count_log_marker(smoke_vm, h.PFB_LOG, marker)
-    h.reload_deprecated_verb(smoke_vm, verb)
-    after = h.count_log_marker(smoke_vm, h.PFB_LOG, marker)
+    before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+    h.reload_deprecated_verb(deployed_vm, verb)
+    after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
     assert after > before, (
         f"deprecated verb {verb!r}: expected a new '{marker}' line in {h.PFB_LOG}\nbefore={before}, after={after}"
     )
 
 
 @pytest.mark.smoke
-def test_deprecated_update_verb_still_reloads_dnsbl(smoke_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_deprecated_update_verb_still_reloads_dnsbl(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """Scenario: deprecated 'update' verb adapter still completes a DNSBL reload.
 
     Given a DNSBL feed containing a unique test domain.
@@ -107,9 +130,9 @@ def test_deprecated_update_verb_still_reloads_dnsbl(smoke_vm: SmokeVM, mock_feed
         mode=h.DnsblMode.VIP,
     )
     # Inject manually (no CaseContext — we control the reload verb ourselves)
-    h.inject(smoke_vm, spec)
-    h.reload_deprecated_verb(smoke_vm, "update")
-    answer = h.dns_probe(smoke_vm, domain)
+    h.inject(deployed_vm, spec)
+    h.reload_deprecated_verb(deployed_vm, "update")
+    answer = h.dns_probe(deployed_vm, domain)
     assert h.is_vip(answer), (
         f"domain {domain!r} must be VIP-blocked after deprecated 'update' reload\ngot answer: {answer!r}"
     )


### PR DESCRIPTION
## Fix the ADR-43 live-VM smoke harness wiring

The three ADR-43 smoke modules (`test_smoke_tick.py`, `test_smoke_apply_on_change.py`, `test_trigger_api.py`) were merged in #565 but **failed the entire CE+Plus fan-out** — all test-harness wiring bugs (the tests were authored but never run live before merge; `--collect-only` can't catch a bad method/fixture). No production logic changed; this restores the tests so they actually exercise the tick/apply/trigger code.

### Bugs fixed (tests only — `src/` untouched)

- **Wrong fixture (dominant).** The modules took bare `smoke_vm` (booted VM, **pfBlockerNG not installed**) → `php …/pfblockerng.php` → *"Could not open input file"*; empty DNSBL state. Added a module-local `deployed_vm` fixture (`h.deploy()` + `h.ensure_dnsbl_vip()`, matching `test_dot_doq_block.py`) and switched every test to it.
- **`vm.pfssh(...)`** — no such method (`_set_quiet_hours`). Now `h.php_eval(vm, …)` with the `OK`-sentinel + rc guard.
- **`CompletedProcess` mishandled** — `raw,_,_ = vm.ssh(...)` / `vm.ssh(...)[0]` assumed a tuple; `SmokeVM.ssh` returns `subprocess.CompletedProcess`. Now `.stdout`. The reboot test uses `h.reboot_vm()`.

Reboot test stays `-m reboot` (not `-m smoke`). 13 tests collect cleanly; ruff + the default unit suite green. Live validation is on dispatch (these are dispatch-only live-VM tests); the CE+Plus fan-out will be re-run after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
