### PR TITLE
pfblockerng: persist DNS-Redirect & DoT/DoQ block settings (writeSection clobber)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -863,6 +863,14 @@ if ($_POST) {
 				@copy("/usr/local/www/pfblockerng/www/{$pfb['dconfig']['dnsbl_webpage']}", '/usr/local/www/pfblockerng/www/dnsbl_active.php');
 			}
 
+			// Flush the bulk DNSBL settings snapshot FIRST. writeSection() replaces the whole
+			// pfblockerngdnsblsettings/config/0 section with $pfb['dconfig'], which does NOT carry
+			// the per-field registered keys written via PfbConfig::write() below (dnsbl_redir*,
+			// dnsbl_dot_block*). Those leaf writes MUST therefore follow the section write — done
+			// before it they are silently clobbered before write_config() flushes, so enabling DNS
+			// Redirect or DoT/DoQ Block never persists. (safesearch_doh* target a different section.)
+			PfbConfig::writeSection('installedpackages/pfblockerngdnsblsettings/config/0', $pfb['dconfig']);
+
 			// Save DoH/DoT/DoQ blocking fields via gateway (registered keys in pfblockerngsafesearch)
 			PfbConfig::write('safesearch_doh', $_POST['safesearch_doh'] ?: 'Disable');
 			PfbConfig::write('safesearch_doh_list', implode(',', (array)$_POST['safesearch_doh_list']) ?: '');
@@ -879,7 +887,6 @@ if ($_POST) {
 			PfbConfig::write('dnsbl_dot_block_action', pfb_dot_block_action($dot_block_action_raw));
 			PfbConfig::write('dnsbl_dot_block_floating', pfb_filter($_POST['dnsbl_dot_block_floating'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '');
 
-			PfbConfig::writeSection('installedpackages/pfblockerngdnsblsettings/config/0', $pfb['dconfig']);
 			write_config('[pfBlockerNG] save DNSBL settings');
 			if ($savemsg) {
 				header("Location: /pfblockerng/pfblockerng_dnsbl.php?savemsg={$savemsg}");


### PR DESCRIPTION
## What

Fixes the DNSBL settings save handler so that DNS Redirect (ADR-36) and DoT/DoQ Block (ADR-37) settings actually persist.

## Bug

`pfblockerng_dnsbl.php` wrote the six registered keys (`dnsbl_redir*`, `dnsbl_dot_block*`) as leaves via `PfbConfig::write()`, then called `PfbConfig::writeSection()` to replace the **whole** `installedpackages/pfblockerngdnsblsettings/config/0` section with the page-load snapshot `$pfb['dconfig']` — which never received those keys. `write_config()` then flushed the snapshot, discarding the leaf writes. Enabling DNS Redirect or DoT/DoQ Block (including the Block/Reject action and Floating mode) from the UI silently never persisted, in either direction, leaving both security features unreachable from their own settings page.

## Fix

Flush the section snapshot first, then apply the registered-key leaf writes, so the section replace can no longer clobber them. `safesearch_doh*` target a different section and are order-independent.

## Testing

The page is not loadable off-appliance, so there is no PR-gating unit guard for its save path — the exact gap that let this ship. The regression guard is a Tier-B UI persistence test (save → reload → assert the six fields persisted, asserting the off before-state first), to be added in the smoke/UI review pass.

Found in the 2026-06-26 ADR review (`docs/misc/adr-7day-review-2026-06-26.md`, finding ADR36-1).

Fixes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where DNSBL page settings for DNS Redirect and DoT/DoQ Block could be lost after saving.
  * Improved settings persistence so these options now remain intact when the page is saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->