### PR TITLE
pfblockerng: permit feed must not un-block a manual user block (ADR-31 §2.2.3 fail-open)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4620,8 +4620,9 @@ def build(
     abp_rules: list[Rule] = []
     # ADR-31 §2.2.3: a permit feed that inserts a band-2 allow must engage the numeric
     # band-aware resolution (exactly as any feed @@ allow does via reconcile, line ~4095),
-    # so a higher-band user/Custom_List block (band 5) still wins. Without it the fast path
-    # treats ANY whiteDB hit as an unconditional override -- a security fail-open.
+    # so a higher-band block still wins -- a band-5 user/Custom_List block (the headline
+    # security case) and equally a band-3 $important feed block. Without it the fast path
+    # treats ANY whiteDB hit as an unconditional override -- a fail-open.
     permit_allow_inserted = False
 
     for feed_row in manifest.get("feeds", []):
@@ -5228,10 +5229,11 @@ class _LruCache:
 # a block wins iff block_prio > allow_prio (no ties: block in {1,3,5}, allow in {2,4,6}).
 #   6 user allow   5 user block   4 feed allow+important
 #   3 feed block+important   2 feed allow (@@)   1 feed block (||)
-# These name the bands the (currently UNREACHABLE) numeric resolution assigns; the
-# fast path never computes them. Until a later phase tags rule provenance, every
-# loaded BLOCK is a feed rule (band 1, or 3 with $important); user provenance reaches
-# the numeric branch only via the whiteDB ``important`` flag (a user allow -> band 6).
+# The numeric resolution engages whenever important_rules is True: a feed @@ allow
+# (reconcile, ~line 4095), a feed regex, or a permit-feed allow insertion (ADR-31 §2.2.3,
+# permit_allow_inserted in build()). Otherwise the fast path runs (any whiteDB hit
+# overrides any block). USER blocks (Custom_List, provenance='user') emit at band 5 in
+# build(); feed blocks at band 1 (3 with $important).
 PRIO_FEED_BLOCK = 1
 PRIO_FEED_ALLOW = 2
 PRIO_FEED_BLOCK_IMPORTANT = 3

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4618,6 +4618,11 @@ def build(
     # below alongside the plain blocks. Each ABP rule carries its manifest-row
     # feed/group/log straight through parse_abp onto the Rule.
     abp_rules: list[Rule] = []
+    # ADR-31 §2.2.3: a permit feed that inserts a band-2 allow must engage the numeric
+    # band-aware resolution (exactly as any feed @@ allow does via reconcile, line ~4095),
+    # so a higher-band user/Custom_List block (band 5) still wins. Without it the fast path
+    # treats ANY whiteDB hit as an unconditional override -- a security fail-open.
+    permit_allow_inserted = False
 
     for feed_row in manifest.get("feeds", []):
         feed = feed_row["feed"]
@@ -4660,8 +4665,10 @@ def build(
                 existing = white_db.get(domain)
                 if existing is None:
                     white_db[domain] = new_entry
+                    permit_allow_inserted = True
                 elif _white_entry_band(existing) < PRIO_FEED_ALLOW:
                     white_db[domain] = new_entry
+                    permit_allow_inserted = True
                 # Same or higher band: keep existing (monotonic widen — never downgrade).
             continue
         # ADR-07: a DNSBL Group Custom_List (the {alias}_custom synthetic row, PHP
@@ -4716,11 +4723,11 @@ def build(
     # ---- Stage-B reconcile + Stage-C emit for the ABP rule stream -------------- #
     regex_db: dict[str, dict[str, Any]] = {}
     allow_regex_db: dict[str, dict[str, Any]] = {}
-    important_rules = False
+    important_rules = permit_allow_inserted
     regex_count = 0
     if abp_rules:
         result = reconcile(abp_rules, tlds, exclusion)
-        important_rules = result.important_rules
+        important_rules = important_rules or result.important_rules
 
         # Domain blocks -> dataDB/zoneDB (carry band + $important).
         for b in result.block_domains:

--- a/tests/test_adr31_permit_build.py
+++ b/tests/test_adr31_permit_build.py
@@ -501,3 +501,96 @@ class TestDenyModeByteIdentical:
 
         assert _is_blocked(result, "explicit.deny.example.com"), "mode='deny' feed must produce a block, not an allow"
         assert "explicit.deny.example.com" not in result.white_db, "mode='deny' entry must NOT appear in white_db"
+
+
+# --------------------------------------------------------------------------- #
+# Contract — §2.2.3: a permit allow (band 2) must NOT override a USER block (band 5)
+# --------------------------------------------------------------------------- #
+
+
+def _build_user_block_and_permit(domain: str, *, with_permit: bool) -> P.BuildResult:
+    """Band-5 USER ``Custom_List`` block for ``domain`` (plain feed, ``provenance='user'``),
+    optionally plus a band-2 permit feed for the SAME domain.
+
+    NO ABP / ``$important`` / regex rule is loaded, so ``important_rules`` can be engaged
+    ONLY by the permit insertion under test — exactly the plain-hosts config in which the
+    fast path would otherwise fail-open.
+    """
+    feeds: list[dict[str, Any]] = [
+        {
+            "feed": "Custom_List",
+            "group": "DNSBL_Custom",
+            "format_hint": "plain",
+            "log_flag": "1",
+            "provenance": "user",  # -> band 5 (PRIO_USER_BLOCK)
+            "raw": _RAW_BLOCK,
+        }
+    ]
+    lines_map: dict[str, list[str]] = {_RAW_BLOCK: [domain]}
+    if with_permit:
+        feeds.append(
+            {
+                "feed": "PermitFeed",
+                "group": "TestPermit",
+                "format_hint": "plain",
+                "log_flag": "1",
+                "mode": "permit",  # -> band 2 (PRIO_FEED_ALLOW)
+                "raw": _RAW_PERMIT,
+            }
+        )
+        lines_map[_RAW_PERMIT] = [domain]
+    manifest: dict[str, Any] = {"feeds": feeds}
+
+    def reader(raw: str) -> list[str]:
+        return list(lines_map[raw])
+
+    return P.build(manifest, _BASE_CONFIG, line_reader=reader)
+
+
+class TestPermitFeedNeverOverridesUserBlock:
+    """ADR-31 §2.2.3 (reject criterion (b)): a third-party DNSWL permit feed must NEVER
+    un-block a domain the operator explicitly blocked via a Custom_List.
+
+    The manual Custom_List block bands at 5 (PRIO_USER_BLOCK); a permit-feed allow bands
+    at 2 (PRIO_FEED_ALLOW). 5 > 2, so the block must win. The pre-fix bug: a plain permit
+    feed (no ABP/$important/regex) left ``important_rules`` False, so ``evaluate_domain``
+    took the band-AGNOSTIC fast path where ANY whiteDB hit overrides the block — a security
+    fail-open. The build must engage the numeric band-aware path whenever it inserts a
+    permit allow, exactly as it already does for an ABP ``@@`` feed allow.
+    """
+
+    def test_user_block_survives_a_permit_feed_allow(self) -> None:
+        """Scenario: a manually blocked domain stays blocked when a permit feed also lists it.
+
+        Given: a domain on a band-5 user Custom_List block feed, NO permit feed.
+        When:  the domain is queried.
+        Then:  it is BLOCKED (before-state — proves the block is real and not a no-op).
+
+        Given: the SAME domain ALSO on a band-2 permit feed, no ABP/$important/regex loaded.
+        When:  the domain is queried.
+        Then:  it STAYS BLOCKED — the manual block (band 5) beats the permit allow (band 2).
+        """
+        domain = "user-blocked.permit.test.example.com"
+
+        # Given / When / Then — user Custom_List block only -> blocked (before-state).
+        before = _build_user_block_and_permit(domain, with_permit=False)
+        dec_before = _decide(before, domain)
+        assert dec_before.is_found and not dec_before.in_whitelist, (
+            f"expected the band-5 user Custom_List block to BLOCK {domain!r} before any permit feed; "
+            f"got is_found={dec_before.is_found} in_whitelist={dec_before.in_whitelist}"
+        )
+
+        # Given / When / Then — add a band-2 permit allow for the same domain.
+        after = _build_user_block_and_permit(domain, with_permit=True)
+        # The permit insertion must engage the numeric band-aware resolution; without this
+        # flag the fast path treats the band-2 allow as an unconditional override.
+        assert after.important_rules is True, (
+            "a permit feed that inserts a band-2 allow must set important_rules so the "
+            "band-aware resolution runs; expected True, got False (ADR-31 §2.2.3 fail-open)"
+        )
+        dec_after = _decide(after, domain)
+        assert dec_after.is_found and not dec_after.in_whitelist, (
+            f"expected the band-5 user block to still BEAT the band-2 permit allow for {domain!r}; "
+            f"got is_found={dec_after.is_found} in_whitelist={dec_after.in_whitelist} "
+            f"(important_rules={after.important_rules}) — ADR-31 §2.2.3 reject criterion (b)"
+        )


### PR DESCRIPTION
## What

Fixes a security fail-open in the DNSWL permit feature (ADR-31): a permit feed could silently un-block a domain the operator explicitly blocked.

## Bug

The permit-mode build branch in `pfb_unbound.py` inserts band-2 (`PRIO_FEED_ALLOW`) `whiteDB` allows but never set `important_rules`. When no ABP `@@` / `$important` / regex rule is loaded — a common plain-hosts config (hosts-format block feed + a `Custom_List` manual block + a DNSWL permit feed) — `important_rules` stays False, so `evaluate_domain` takes the band-agnostic fast path where any `whiteDB` match overrides any block. A band-2 permit allow therefore overrode the operator's band-5 `Custom_List`/user block — the §2.2.3 fail-open (reject criterion (b)).

Before ADR-31 this could not happen: the only band-2 allows came from ABP `@@` rules, which always set `important_rules=True` (forcing the band-aware numeric path). ADR-31 added band-2 allows without that flag.

## Fix

Engage the numeric band-aware resolution whenever the permit branch inserts a band-2 allow, exactly as `reconcile()` already does for an ABP `@@` feed allow. Then band 5 (user block) > band 2 (permit allow) and the manual block wins.

## Testing

`test_user_block_survives_a_permit_feed_allow` drives a band-5 user `Custom_List` block + a band-2 permit feed for the same domain, no important rule loaded. It asserts the before-state (block alone → blocked), then that the permit feed engages `important_rules` and the block still wins. Verified **RED** on pre-fix code (`important_rules=False`, domain resolves) and **GREEN** after. Full pytest suite green (1883 passed).

Found in the 2026-06-26 ADR review (`docs/misc/adr-7day-review-2026-06-26.md`, finding ADR31-1).

Fixes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
