### PR TITLE
tests/smoke: enforce per-module clean baseline + deterministic isolation

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -460,9 +460,17 @@ def lan_socket_port() -> Iterator[int]:
 # Session-scoped VM fixture
 # --------------------------------------------------------------------------- #
 
+# Records the booted pfSense VM on the session so the per-module isolation teardown
+# (`_pfb_module_baseline`) can find it WITHOUT calling getfixturevalue — which would
+# re-enter fixture setup (deprecated in pytest 9.1 for a not-already-requested fixture)
+# and could boot a VM purely to reset a module that never used one. None once torn down.
+SMOKE_VM_KEY: pytest.StashKey[SmokeVM | None] = pytest.StashKey()
+
 
 @pytest.fixture(scope="session")
-def smoke_vm(lan_socket_port: int, tmp_path_factory: pytest.TempPathFactory) -> Iterator[SmokeVM]:
+def smoke_vm(
+    lan_socket_port: int, tmp_path_factory: pytest.TempPathFactory, request: pytest.FixtureRequest
+) -> Iterator[SmokeVM]:
     """Pull -> boot -> wait-ready -> yield -> teardown, once per session.
 
     Per-case isolation (Phase 4 provides the reset verbs): cases run against
@@ -520,9 +528,11 @@ def smoke_vm(lan_socket_port: int, tmp_path_factory: pytest.TempPathFactory) -> 
         log_path=work / "vm.log",
         boot_timeout=DEFAULT_BOOT_TIMEOUT,
     )
+    request.session.stash[SMOKE_VM_KEY] = handle.vm
     try:
         yield handle.vm
     finally:
+        request.session.stash[SMOKE_VM_KEY] = None
         _kill(handle.process)
         with contextlib.suppress(Exception):
             handle.log_file.close()
@@ -1364,8 +1374,10 @@ def _pfb_module_baseline(request: pytest.FixtureRequest) -> Generator[None, None
 
     Scoped to the SMOKE tier only — the UI tier (``tests/smoke/ui/``) shares a session-scoped
     login + box and is reset separately, so it is excluded here. A strict no-op unless
-    ``SMOKE_PKG`` is set (a package was actually deployed), so off-box modules that never touch
-    the VM are untouched. Wrapped in suppress so a teardown reset can never MASK a test failure.
+    ``SMOKE_PKG`` is set (a package was actually deployed) AND the VM was actually booted, so
+    off-box modules that never touch the VM are untouched (and never boot one just to reset).
+    A genuine reset failure is allowed to SURFACE — silently swallowing it would leak dirty
+    state into the next module, defeating the isolation this fixture exists to provide.
     """
     yield
     # UI tier shares session state (deferred to its own per-test reset) — leave it alone.
@@ -1374,15 +1386,18 @@ def _pfb_module_baseline(request: pytest.FixtureRequest) -> Generator[None, None
     # No-op outside a real deployed smoke run, so off-box modules (no VM) are unaffected.
     if not os.environ.get("SMOKE_PKG"):
         return
+    # Read the already-booted VM from the session stash — NEVER getfixturevalue (it re-enters
+    # setup and could boot a VM just to reset it). None ⇒ the VM was never booted this run, so
+    # there is nothing to reset.
+    vm = request.session.stash.get(SMOKE_VM_KEY, None)
+    if vm is None:
+        return
     from . import helpers  # local import: helpers imports from conftest (avoid cycle)
 
-    try:
-        # Resolve the already-booted session VM lazily — never FORCE a boot just to reset.
-        vm = request.getfixturevalue("smoke_vm")
-    except Exception:
-        return
-    with contextlib.suppress(Exception):
-        helpers.reset_pfb_baseline(vm)
+    # Let a genuine baseline-reset failure propagate rather than silently leaking dirty state
+    # into the next module. The module's test results are already recorded before this teardown
+    # runs, so a teardown error is reported separately and cannot mask a test outcome.
+    helpers.reset_pfb_baseline(vm)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1341,3 +1341,62 @@ def _dump_vm_on_failure(request: pytest.FixtureRequest) -> Iterator[None]:
     from . import helpers  # local import: helpers imports from conftest (avoid cycle)
 
     helpers.dump_diagnostics(vm)
+
+
+# --------------------------------------------------------------------------- #
+# Cross-test isolation — the session VM is ONE boot whose disk persists across every
+# test/module. reset() clears only the pf tables, NOT config.xml, so without these two
+# autouse guards injected feeds/settings/toggles/host-overrides and a runner egress block
+# bleed into the next test along collection order (a real false-green source).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _pfb_module_baseline(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+    """Wipe pfBlockerNG config to a clean baseline AFTER each smoke module (cross-module isolation).
+
+    Each module's ``deployed_vm`` deploys on top of whatever the PREVIOUS module left behind,
+    and ``reset()`` only drops the pf tables — so injected feeds/settings/global toggles and
+    the smoke control Host Overrides leak forward (e.g. ``killstates`` leaving ``enable_float``
+    on flips the next module's intended non-floating rule to floating). This teardown calls
+    :func:`helpers.reset_pfb_baseline` so the next module starts from an empty pfBlockerNG
+    config; module 1 is already clean from the fresh boot.
+
+    Scoped to the SMOKE tier only — the UI tier (``tests/smoke/ui/``) shares a session-scoped
+    login + box and is reset separately, so it is excluded here. A strict no-op unless
+    ``SMOKE_PKG`` is set (a package was actually deployed), so off-box modules that never touch
+    the VM are untouched. Wrapped in suppress so a teardown reset can never MASK a test failure.
+    """
+    yield
+    # UI tier shares session state (deferred to its own per-test reset) — leave it alone.
+    if Path(str(request.path)).parent.name == "ui":
+        return
+    # No-op outside a real deployed smoke run, so off-box modules (no VM) are unaffected.
+    if not os.environ.get("SMOKE_PKG"):
+        return
+    from . import helpers  # local import: helpers imports from conftest (avoid cycle)
+
+    try:
+        # Resolve the already-booted session VM lazily — never FORCE a boot just to reset.
+        vm = request.getfixturevalue("smoke_vm")
+    except Exception:
+        return
+    with contextlib.suppress(Exception):
+        helpers.reset_pfb_baseline(vm)
+
+
+@pytest.fixture(autouse=True)
+def _restore_egress() -> Generator[None, None, None]:
+    """Restore the runner's egress after every test (cross-test guard).
+
+    ``block_egress()`` / ``unblock_egress()`` flip the runner's GLOBAL iptables OUTPUT policy;
+    a test that blocks egress (e.g. a ``CaseContext`` probe) and dies before unblocking would
+    leave dark egress for every later test — every later ``pkg``/feed fetch then fails. This
+    always unblocks on teardown. A strict no-op unless ``SMOKE_BLOCK_EGRESS`` is set, so a local
+    run never touches the dev machine's firewall.
+    """
+    yield
+    from . import helpers  # local import: helpers imports from conftest (avoid cycle)
+
+    with contextlib.suppress(Exception):
+        helpers.unblock_egress()

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -725,6 +725,10 @@ def _b64_textarea(lines: list[str]) -> str:
 # Control records — DNS-Resolver Host Overrides, set IN CONFIG before update
 # --------------------------------------------------------------------------- #
 
+# The descr stamped on every smoke control Host Override row. reset_pfb_baseline prunes
+# unbound/hosts rows by this marker, so the two MUST stay in sync — keep it a constant.
+CONTROL_DESCR = "pfBlockerNG smoke control"
+
 
 def _host_override_rows(local_data: dict[str, dict[str, str]]) -> list[dict[str, str]]:
     """Build ``unbound/hosts`` rows from ``{name: {rtype: ip}}``.
@@ -745,7 +749,7 @@ def _host_override_rows(local_data: dict[str, dict[str, str]]) -> list[dict[str,
                 "host": label,
                 "domain": domain,
                 "ip": ",".join(ips),
-                "descr": "pfBlockerNG smoke control",
+                "descr": CONTROL_DESCR,
                 "aliases": "",
             }
         )
@@ -1946,6 +1950,32 @@ def _dnsbl_list_php(spec: DnsblCase, row_action: str = "Deny") -> str:
     )
 
 
+# DNSBL settings keys that are INFRASTRUCTURE (set by ensure_dnsbl_vip / set_dnsvip_auto),
+# not per-case behaviour. _dnsbl_settings_replace_php preserves these across a settings
+# replace — dropping them would leave DNSBL with no VIP/ports and force-disable it.
+_DNSBL_INFRA_KEYS = ("pfb_dnsvip4", "pfb_dnsport", "pfb_dnsport_ssl", "pfb_dnsvip_auto")
+
+
+def _dnsbl_settings_replace_php(settings: dict[str, str]) -> str:
+    """PHP that sets the DNSBL settings to EXACTLY ``{infra keys} + settings`` (replace, not merge).
+
+    Keeps only the VIP/port infrastructure (:data:`_DNSBL_INFRA_KEYS`) the deployed_vm fixture
+    set and REPLACES every behaviour toggle. A plain ``array_merge`` would let a prior case's
+    ``pfb_idn`` / ``pfb_hsts`` / ``pfb_regex`` survive into this one — :func:`reset` never clears
+    config, so within a module a case would inherit toggles it never declared. Shared by
+    :func:`_dnsbl_inject_snippet` and :func:`inject_dnsbl_lists`."""
+    keep = ", ".join(_php_str(k) for k in _DNSBL_INFRA_KEYS)
+    return (
+        f"$prev = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
+        "$keep = array();\n"
+        f"foreach (array({keep}) as $k) {{\n"
+        "  if (isset($prev[$k])) { $keep[$k] = $prev[$k]; }\n"
+        "}\n"
+        f"$s = array_merge($keep, {_php_kv_array(settings)});\n"
+        f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $s);\n"
+    )
+
+
 def inject_dnsbl_lists(
     vm: SmokeVM,
     specs_and_actions: list[tuple[DnsblCase, str]],
@@ -2004,9 +2034,7 @@ def inject_dnsbl_lists(
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['enable_cb'] = 'on';\n"
         f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
-        f"$s = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
-        f"$s = array_merge($s, {_php_kv_array(settings)});\n"
-        f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $s);\n"
+        f"{_dnsbl_settings_replace_php(settings)}"
         f"config_set_path({_php_str(CFG_DNSBL_LISTS)}, array({lists_php}));\n"
         "write_config('pfBlockerNG smoke: DNSBL multi-list (ADR-31)');\n"
         "echo 'OK';"
@@ -2090,9 +2118,7 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['enable_cb'] = 'on';\n"
         f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
-        f"$s = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
-        f"$s = array_merge($s, {_php_kv_array(settings)});\n"
-        f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $s);\n"
+        f"{_dnsbl_settings_replace_php(settings)}"
         f"$list = {_php_kv_array(listcfg)};\n"
         f"$list['row'] = {rows_php};\n"
         # 'logging' is a per-LIST field — pfBlockerNG reads $list['logging']
@@ -2272,6 +2298,94 @@ def reset(vm: SmokeVM, *, timeout: float = 600.0) -> None:
         if result.returncode != 0:
             raise RuntimeError(f"reset {verb} failed: rc={result.returncode} stderr={result.stderr!r}")
     reload(vm, "update", timeout=timeout)
+
+
+# Whole config sections a smoke case injects into. reset_pfb_baseline DELETES these — they
+# are pure test-injected (feed lists) or fully re-established by each module's deployed_vm
+# fixture on setup (the DNSBL VIP/ports via ensure_dnsbl_vip, the IP/DNSBL settings via
+# inject()), so wiping them between modules costs nothing the next setup does not rebuild.
+# CFG_GLOBAL (config/0) is deliberately NOT here: it also holds the package's install
+# defaults + wizard flag, so only the toggles a case writes are unset there (below).
+_BASELINE_DEL_SECTIONS = (
+    CFG_DNSBL_LISTS,
+    CFG_IP_V4_LISTS,
+    CFG_IP_V6_LISTS,
+    CFG_DNSBL_SETTINGS,
+    CFG_IP_SETTINGS,
+)
+# Behaviour toggles a case writes into CFG_GLOBAL (config/0). Derived from every config/0
+# write-site in this module + the apply/tick tests: the IP master switch (enable_cb), the
+# ADR-38 syslog toggle (log_syslog), the cron knobs (pfb_dailystart/pfb_reuse), the
+# managed-objects keep flag (pfb_keep), the ADR-11 aggregate selector (pfb_agg_types) and
+# the ADR-43 PfbConfig knobs (pfb_quiet_hours/pfb_tick_interval). Unset (not section-
+# deleted) so the section's install defaults survive.
+_BASELINE_GLOBAL_KEYS = (
+    "enable_cb",
+    "log_syslog",
+    "pfb_dailystart",
+    "pfb_keep",
+    "pfb_reuse",
+    "pfb_agg_types",
+    "pfb_quiet_hours",
+    "pfb_tick_interval",
+)
+
+
+def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
+    """Wipe pfBlockerNG config to a known-EMPTY baseline (cross-module isolation).
+
+    The session VM is ONE long-lived boot whose copy-on-write disk persists across every
+    test and module; :func:`reset` only drops the pf tables/sqlite, NOT ``config.xml``, so
+    injected feeds / settings / host-overrides / global toggles bleed into the NEXT module
+    along collection order (the #532-style false-green this guards against). This is the
+    missing clean slate: it
+
+      * deletes every test-injected pfBlockerNG config section (:data:`_BASELINE_DEL_SECTIONS`
+        + the update hooks + the SafeSearch toggle);
+      * unsets the behaviour toggles a case writes into ``config/0``
+        (:data:`_BASELINE_GLOBAL_KEYS`), leaving the package's install defaults intact;
+      * removes the ``pfBlockerNG smoke control`` Host Overrides (so a stale ``local-data``
+        row cannot answer a later module's probe before the DNSBL module) and regenerates
+        the resolver config so the live daemon matches;
+      * drops the derived state — ``clearip``/``cleardnsbl`` (tables/sqlite) then a blocking
+        ``apply_filter_sync`` (pf rules).
+
+    NO forced ``update`` (unlike :func:`reset`): the config is now empty, so there is nothing
+    to rebuild — the next module's ``deployed_vm`` re-establishes the VIP/DNS/feed config it
+    needs. Used by the module-scoped autouse teardown in ``conftest.py``; safe to call
+    directly. Raises on a non-zero ``pfSsh.php`` eval so a broken baseline surfaces loudly.
+    """
+    del_sections = "".join(f"config_del_path({_php_str(s)});\n" for s in _BASELINE_DEL_SECTIONS)
+    unset_keys = "".join(f"unset($g[{_php_str(k)}]);\n" for k in _BASELINE_GLOBAL_KEYS)
+    snippet = (
+        f"{del_sections}"
+        f"config_del_path({_php_str(CFG_HOOKS)});\n"
+        f"config_del_path({_php_str(CFG_SAFESEARCH_ENABLE)});\n"
+        f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
+        f"{unset_keys}"
+        f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
+        # Drop the smoke control Host Overrides (descr-tagged) so a stale local-data row
+        # cannot answer a later module's probe before the DNSBL python module runs.
+        f"$hosts = config_get_path({_php_str(CFG_UNBOUND_HOSTS)}, array());\n"
+        "$hosts = array_values(array_filter($hosts, function($r) {\n"
+        f"  return ($r['descr'] ?? '') !== {_php_str(CONTROL_DESCR)};\n"
+        "}));\n"
+        f"config_set_path({_php_str(CFG_UNBOUND_HOSTS)}, $hosts);\n"
+        "write_config('pfBlockerNG smoke: reset to clean baseline');\n"
+        # Regenerate host_entries.conf so the live resolver matches the emptied config —
+        # the control-record removal only takes effect after an unbound reconfigure.
+        "services_unbound_configure();\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"reset_pfb_baseline failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+    # Drop the derived state: tables/sqlite (clearip/cleardnsbl) + pf rules (blocking sync).
+    for verb in ("clearip", "cleardnsbl"):
+        cleared = vm.ssh(PHP_BIN, PFB_CLI, verb, timeout=120.0)
+        if cleared.returncode != 0:
+            raise RuntimeError(f"reset_pfb_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}")
+    apply_filter_sync(vm)
 
 
 # --------------------------------------------------------------------------- #
@@ -4151,6 +4265,12 @@ class CaseContext:
         if isinstance(self.spec, IpCase):
             reload(self.vm, "update")
         reload(self.vm, self.scope)
+        if isinstance(self.spec, IpCase):
+            # filter_configure() is async (send_event); the pf table + Deny rule land a few
+            # seconds AFTER reload() returns. Force a blocking apply so the case's FIRST
+            # pfctl read is authoritative, not racing the apply. DNSBL cases probe DNS (gated
+            # by reload's wait_unbound_ready), so they need no pf gate.
+            apply_filter_sync(self.vm)
         snap_state(self.vm, f"{self.spec.aliasname}_reloaded")
         # NOW block egress: the per-case probe must prove the block/pass with no
         # upstream (a non-blocked name would hang, not silently resolve upstream).

--- a/tests/smoke/test_smoke_isolation.py
+++ b/tests/smoke/test_smoke_isolation.py
@@ -1,0 +1,154 @@
+"""Live-VM coverage for the smoke-harness ISOLATION keystone (helpers.reset_pfb_baseline
++ the DNSBL settings replace-not-merge).
+
+The session VM is ONE long-lived boot whose copy-on-write disk persists across every test
+and module, and ``helpers.reset()`` clears only the pf tables/sqlite — NOT ``config.xml`` —
+so injected feeds / settings / global toggles / Host Overrides bleed into the next module
+along collection order. ``reset_pfb_baseline`` is the missing clean slate; the autouse
+``_pfb_module_baseline`` teardown in ``conftest.py`` runs it after every smoke module.
+
+These two tests pin the keystone's behaviour (red→green vs the old ``reset()``):
+
+* ``test_reset_pfb_baseline_clears_injected_config`` — the wipe deletes the injected IP list
+  config, unsets ``enable_cb``, AND removes the smoke control Host Override. ``reset()`` would
+  LEAVE all three (it keeps ``config.xml`` and only drops/rebuilds the pf tables), so each
+  assertion fails on the old path and passes on the new one. (The derived-state teardown —
+  tables/sqlite/pf rules — is ``reset()``'s existing ``clearip``/``cleardnsbl`` path, already
+  covered; the NEW behaviour proved here is the config deletion.)
+* ``test_dnsbl_inject_replaces_leaked_toggle`` — a later DNSBL case's settings are EXACTLY what
+  it declares: a prior case's ``pfb_hsts`` does not survive (replace-not-merge), while the
+  VIP/port infrastructure ``ensure_dnsbl_vip`` set IS preserved (so DNSBL is not force-disabled).
+  A plain ``array_merge`` leaves ``pfb_hsts=on`` leaked → the first ``Then`` fails on the old path.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+
+pytestmark = pytest.mark.smoke
+
+# host_entries.conf is the Unbound-included file pfSense generates from the DNS-Resolver Host
+# Overrides (unbound/hosts). A smoke control name lands here after set_control_records and must
+# be GONE after reset_pfb_baseline removes the row + regenerates the resolver config.
+HOST_ENTRIES_CONF = "/var/unbound/host_entries.conf"
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg + the DNSBL VIP baseline for the isolation tests.
+
+    No stub DNS / client VM / feed fetch: these tests assert at the config + host_entries.conf
+    level, so they never load a feed or resolve a name. ``ensure_dnsbl_vip`` is what sets the
+    VIP/port infra keys the replace-not-merge test asserts are preserved.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.collect_host_diagnostics(smoke_vm)
+
+
+def _host_entry_present(vm: SmokeVM, name: str) -> bool:
+    """True iff ``name`` is a line in the live host_entries.conf (the resolver's view)."""
+    return vm.ssh("grep", "-Fq", name, HOST_ENTRIES_CONF).returncode == 0
+
+
+_COUNT_OPEN, _COUNT_CLOSE = "<<PFBCOUNT>>", "<</PFBCOUNT>>"
+
+
+def _section_count(vm: SmokeVM, path: str) -> int:
+    """Number of elements in a config section (0 when absent), read via the config API."""
+    snippet = f"echo '{_COUNT_OPEN}' . count((array) config_get_path('{path}', array())) . '{_COUNT_CLOSE}';"
+    out = h.php_eval(vm, snippet).stdout
+    start, end = out.find(_COUNT_OPEN), out.find(_COUNT_CLOSE)
+    assert start != -1 and end != -1, f"could not read element count for {path}: {out!r}"
+    return int(out[start + len(_COUNT_OPEN) : end])
+
+
+def test_reset_pfb_baseline_clears_injected_config(deployed_vm: SmokeVM) -> None:
+    """reset_pfb_baseline DELETES the injected list config, unsets enable_cb, AND removes the
+    control Host Override — the three config surfaces reset() would LEAVE behind (it keeps
+    config.xml and only touches the pf tables). This is what makes the next module start clean.
+
+    Scenario:
+      Given a clean box (no IP list config, the control override absent),
+      When an IP list + a smoke control Host Override are injected,
+      Then the IP list section is populated, enable_cb is 'on', and the override is live;
+      When reset_pfb_baseline runs,
+      Then the IP list section is gone, enable_cb is unset, and the override is gone.
+    """
+    vm = deployed_vm
+    # The feed_url is never fetched — inject() only WRITES config; we assert config, no reload.
+    spec = h.IpCase(aliasname="smokeisoip4", feed_url="http://10.10.0.2/ip_plain_cidr.txt", header="smokeisoip4")
+    control_name = h.unique_domain()
+    enable_cb_key = h.CFG_GLOBAL + "/enable_cb"
+
+    # GIVEN a clean baseline: no IP list config, the control name not in host_entries.conf.
+    assert _section_count(vm, h.CFG_IP_V4_LISTS) == 0, "IP list section non-empty before any inject"
+    assert not _host_entry_present(vm, control_name), f"{control_name} in host_entries.conf before it was added"
+
+    # WHEN we inject an IP list + a smoke control Host Override.
+    h.set_control_records(vm, {control_name: {"A": "203.0.113.9"}}, {})
+    h.inject(vm, spec)
+
+    # THEN all three config surfaces are LIVE (the before-state the wipe below must clear).
+    assert _section_count(vm, h.CFG_IP_V4_LISTS) == 1, "inject did not write the IP list section"
+    assert h.config_get(vm, enable_cb_key) == "on", "inject did not set enable_cb — fixture broken"
+    assert _host_entry_present(vm, control_name), f"{control_name} not in host_entries.conf after set_control_records"
+
+    # WHEN the clean-baseline reset runs.
+    h.reset_pfb_baseline(vm)
+
+    # THEN every injected config surface is gone (reset() would keep all three).
+    surviving = _section_count(vm, h.CFG_IP_V4_LISTS)
+    assert surviving == 0, f"IP list section survived reset_pfb_baseline ({surviving} rows; reset() keeps it)"
+    leftover_cb = h.config_get(vm, enable_cb_key)
+    assert leftover_cb == "", f"enable_cb survived reset_pfb_baseline: {leftover_cb!r} (reset() leaves it 'on')"
+    assert not _host_entry_present(vm, control_name), f"{control_name} survived reset_pfb_baseline in host_entries.conf"
+
+
+def test_dnsbl_inject_replaces_leaked_toggle(deployed_vm: SmokeVM) -> None:
+    """A DNSBL case's settings are EXACTLY what it declares: a prior case's pfb_hsts does not
+    leak into a later one (replace-not-merge), while the VIP/port infrastructure is preserved.
+
+    Scenario:
+      Given the DNSBL VIP infra is set (deployed_vm ran ensure_dnsbl_vip),
+      When a case with HSTS-null blocking is injected,
+      Then pfb_hsts is 'on';
+      When a later case WITHOUT hsts is injected (reset() between cases never clears config, so a
+        plain array_merge would keep pfb_hsts=on),
+      Then pfb_hsts is gone AND the VIP infra key is still present (DNSBL stays enabled).
+    """
+    vm = deployed_vm
+    hsts_key = h.CFG_DNSBL_SETTINGS + "/pfb_hsts"
+    vip_key = h.CFG_DNSBL_SETTINGS + "/pfb_dnsvip4"
+    # The feed_url is never fetched here — inject() only WRITES config; we read it back, no reload.
+    feed = "http://10.10.0.2/dnsbl_plain.txt"
+
+    # GIVEN the VIP infrastructure is in place. Establish it HERE (idempotent), not via the
+    # module fixture alone: a sibling test's reset_pfb_baseline wipes CFG_DNSBL_SETTINGS (incl.
+    # pfb_dnsvip4), so this test owns its own precondition rather than depending on test order.
+    h.ensure_dnsbl_vip(vm)
+    assert h.config_get(vm, vip_key) != "", "precondition: ensure_dnsbl_vip should set pfb_dnsvip4"
+
+    # WHEN a case that enables HSTS-null blocking is injected, THEN pfb_hsts is written 'on'.
+    h.inject(vm, h.DnsblCase(aliasname="smokeisohsts", feed_url=feed, header="smokeisohsts", hsts=True))
+    assert h.config_get(vm, hsts_key) == "on", "inject(hsts=True) did not set pfb_hsts=on"
+
+    # WHEN a later case WITHOUT hsts is injected in the same module.
+    h.inject(vm, h.DnsblCase(aliasname="smokeisoplain", feed_url=feed, header="smokeisoplain"))
+
+    # THEN the leaked toggle is gone (replace, not merge) ...
+    leaked = h.config_get(vm, hsts_key)
+    assert leaked == "", f"pfb_hsts leaked across DNSBL cases: {leaked!r} (array_merge would keep 'on')"
+    # ... and the VIP infrastructure key is PRESERVED (a naive config_del would force-disable DNSBL).
+    assert h.config_get(vm, vip_key) != "", "replace dropped pfb_dnsvip4 — would force-disable DNSBL"


### PR DESCRIPTION
## Why

The live-VM smoke/UI suite breaks often because it does not isolate tests. It runs against **one** session-long VM boot whose disk persists across every test and module, and `reset()` clears the pf tables but **not** `config.xml` — and there was no enforced clean baseline. So injected feeds/settings/global toggles, the runner's global egress block, and the smoke control Host Overrides leak into the next module along collection order, and the async `filter_configure()` apply races post-reload `pfctl` reads.

Concrete example: `killstates` leaves `enable_float=on`, so the next module (`lan_rule_preserve`) builds its *intended non-floating* LAN rule as floating — the #532 regression path is never exercised (a false-green on broken code).

This is the **harness keystone** of a broader smoke-reliability audit (66 verified per-test findings). It fixes the systemic isolation gaps that make everything else deterministic; the per-test fixes (single-branch / coverage-theater / weak-assertion) are a follow-up, and the UI-tier per-test reset is a separate step.

## What

No test-body or per-module `deployed_vm` changes — one helper + two autouse fixtures + a `CaseContext` gate:

- **`helpers.reset_pfb_baseline()`** — wipe pfBlockerNG config to empty: delete the test-injected sections, unset the `config/0` behaviour toggles (leaving install defaults), prune the smoke control Host Overrides + regenerate the resolver, then drop derived state (`clearip`/`cleardnsbl` + a blocking `apply_filter_sync`). No forced rebuild — the next module's `deployed_vm` re-establishes what it needs.
- **`conftest.py` `_pfb_module_baseline`** — autouse module-scoped teardown running the above after each smoke module. UI subpackage excluded (handled separately); no-op without `SMOKE_PKG`; VM resolved lazily so off-box modules are untouched.
- **`conftest.py` `_restore_egress`** — autouse per-test guard unblocking the runner's global egress (no-op unless `SMOKE_BLOCK_EGRESS`), so a test that blocks then fails can't darken egress for the rest of the run.
- **`CaseContext`** — `apply_filter_sync()` after an IP case's reload so the first `pfctl` read is authoritative, not racing the async `filter_configure()` apply.
- **`_dnsbl_settings_replace_php`** — DNSBL settings are **replaced** (keeping only the VIP/port infrastructure) instead of `array_merge`'d, so a prior case's `pfb_idn`/`pfb_hsts`/`pfb_regex` can't leak into a later case in the same module.

## Validation

`test_smoke_isolation.py` pins the keystone, validated **red→green on a live CE 2.8.1 VM**:

- baseline wipe clears the injected IP-list config (`enable_cb` unset) and the smoke control Host Override where `reset()` keeps them;
- DNSBL replace drops a leaked `pfb_hsts` while preserving `pfb_dnsvip4` (so DNSBL stays enabled).

Run against a pre-change copy (config kept / settings merged), both assertions fail for exactly the intended reasons (`IP list section survived reset_pfb_baseline (1 rows)`, `pfb_hsts leaked across DNSBL cases: 'on'`).

Per the repo's contract these Tier-B live-VM suites are dispatch-only (not PR-gating); the comprehensive validation is a full CE+Plus smoke fan-out, which should be dispatched once on this change since it alters every module's starting state.

> Note (pre-existing, out of scope): on the local box, `test_smoke_aggregate::test_aggregate_deny_builds_table_native_no_rule` already fails at the **base** commit (its `deployed_vm` lacks `set_feed_internal_allowlist`, so the SSRF feed filter rejects the RFC1918 mock feed). Confirmed identical with the keystone stripped — not introduced here; a candidate for the per-test follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved smoke-test isolation so temporary settings and network blocking no longer leak between test modules.
  * Added stronger cleanup for DNSBL and firewall state, helping later tests start from a clean baseline.
* **Tests**
  * Added coverage for clearing injected configuration and restoring DNSBL settings behavior between cases.
  * Added verification that host overrides and related test artifacts are removed after each module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->