### PR TITLE
pfblockerng: restore per-list feed frequency, scheduled log reset & force-both (ADR-43)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12013,6 +12013,17 @@ function sync_package_pfblockerng($cron='') {
 	if ($pfb_is_noups) {
 		// Cron pass with no feed changes: save the configuration; nothing to reload.
 		$pfb['save'] = TRUE;
+	} elseif ($pfb_req['scope'] === 'both' && $pfb_req['force']) {
+		// Force Reload BOTH (Update page Run-now with force on, and the wizard reload):
+		// apply IP tables AND DNSBL from cached lists, no re-download — the union of the
+		// scope=ip and scope=dnsbl force branches. Without this, scope=both + force fell
+		// through with no adjustment (identical to force=false), so the most prominent
+		// "Force" control did nothing beyond a plain detector-respecting pass.
+		$pfb['reuse']        = 'on';
+		$pfb['reuse_dnsbl']  = 'on';
+		$pfb['updatednsbl']  = TRUE;
+		unlink_if_exists("{$pfb['dbdir']}/masterfile");
+		unlink_if_exists("{$pfb['dbdir']}/mastercat");
 	} elseif ($pfb_req['scope'] === 'ip' && $pfb_req['force']) {
 		// updateip: Force Reload IP — apply IP tables from cached lists, no re-download.
 		$pfb['reuse']       = 'on';

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -854,11 +854,18 @@ function pfblockerng_tick(): void
 
 	// --- Dispatch due (or pending) jobs; defer when outside the apply window ---
 
-	// Feed cron: apply via ADR-40 (IP) + ADR-10 (DNSBL) inside sync_package_pfblockerng().
+	// Feed cron: dispatch the `cron` verb (-> pflblockerng_sync_cron), NOT pfb_trigger
+	// directly.  pflblockerng_sync_cron applies each feed's per-list Update Frequency
+	// ($list['cron']: EveryDay/Weekly/NNhour) before its final sync_package_pfblockerng('cron'),
+	// and runs the scheduled log trim + reset (pfb_log_mgmt/pfb_log_reset) and the ADR-19
+	// software-update check at the end -- all of which a bare `pfb_trigger scope=both` skips
+	// (it would poll every feed every tick and never rotate the report logs).  Apply-on-change
+	// still happens via ADR-40 (IP) + ADR-10 (DNSBL) inside that final sync.  Backgrounded so
+	// the tick stays fast.
 	if (!$cron_disabled && ($due['cron'] || pfb_due_ledger_is_pending('cron', $dbdir))) {
 		if ($in_win) {
 			logger(LOG_NOTICE, localize_text('Tick: dispatching feed cron.'), LOG_PREFIX_PKG_PFBLOCKERNG);
-			exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php pfb_trigger scope=both force=false trigger=cron >> {$pfb['log']} 2>&1 &");
+			exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> {$pfb['log']} 2>&1 &");
 			pfb_due_ledger_mark_ran('cron', $cron_secs, $now, $seed, 0, $dbdir);
 		} else {
 			logger(LOG_INFO, localize_text('Tick: feed cron deferred (outside apply window).'), LOG_PREFIX_PKG_PFBLOCKERNG);

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -854,8 +854,8 @@ function pfblockerng_tick(): void
 
 	// --- Dispatch due (or pending) jobs; defer when outside the apply window ---
 
-	// Feed cron: dispatch the `cron` verb (-> pflblockerng_sync_cron), NOT pfb_trigger
-	// directly.  pflblockerng_sync_cron applies each feed's per-list Update Frequency
+	// Feed cron: dispatch the `cron` verb (-> pfblockerng_sync_cron), NOT pfb_trigger
+	// directly.  pfblockerng_sync_cron applies each feed's per-list Update Frequency
 	// ($list['cron']: EveryDay/Weekly/NNhour) before its final sync_package_pfblockerng('cron'),
 	// and runs the scheduled log trim + reset (pfb_log_mgmt/pfb_log_reset) and the ADR-19
 	// software-update check at the end -- all of which a bare `pfb_trigger scope=both` skips

--- a/tests/smoke/test_log_rotate.py
+++ b/tests/smoke/test_log_rotate.py
@@ -65,14 +65,17 @@ CFG_GENERAL = "installedpackages/pfblockerng/config/0"
 def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
     """Deploy the branch .pkg once for this module and set up the base state.
 
-    Log rotation does not require DNSBL to be active — it runs purely from the
-    cron tick (``pfblockerng.php cron`` → ``pfblockerng_sync_cron()``), driven
-    via ``helpers.reload(vm, 'cron')``.  The scheduled reset (``pfb_log_reset()``)
-    lives in ``pfblockerng_sync_cron()`` and runs ONLY on the ``cron`` verb; the
-    ``update`` (Force-Update) verb calls ``sync_package_pfblockerng('cron')``
-    directly and bypasses it, so these cases must drive ``cron``.  We still need
-    pfBlockerNG installed and ``enable_cb=on`` so the cron function body executes.
-    The DNSBL VIP and feed infrastructure are NOT needed for these cases.
+    Log rotation does not require DNSBL to be active — it runs from
+    ``pfblockerng_sync_cron()``, driven here directly via ``helpers.reload(vm, 'cron')``.
+    The scheduled reset (``pfb_log_reset()``) and the line-cap trim (``pfb_log_mgmt()``)
+    live in ``pfblockerng_sync_cron()``.  On a live appliance that function is reached by
+    the scheduled tick, which dispatches the ``cron`` verb (issue #570: the tick routes
+    through ``pflblockerng_sync_cron`` — a bare ``pfb_trigger`` would skip both); the
+    end-to-end tick path is pinned by ``test_smoke_tick.test_tick_feed_cron_routes_through_sync_cron``.
+    These cases drive the ``cron`` verb directly to exercise the reset LOGIC without
+    waiting on the tick cadence.  We still need pfBlockerNG installed and ``enable_cb=on``
+    so the cron function body executes.  The DNSBL VIP and feed infrastructure are NOT
+    needed for these cases.
     """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")

--- a/tests/smoke/test_log_rotate.py
+++ b/tests/smoke/test_log_rotate.py
@@ -70,7 +70,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     The scheduled reset (``pfb_log_reset()``) and the line-cap trim (``pfb_log_mgmt()``)
     live in ``pfblockerng_sync_cron()``.  On a live appliance that function is reached by
     the scheduled tick, which dispatches the ``cron`` verb (issue #570: the tick routes
-    through ``pflblockerng_sync_cron`` — a bare ``pfb_trigger`` would skip both); the
+    through ``pfblockerng_sync_cron`` — a bare ``pfb_trigger`` would skip both); the
     end-to-end tick path is pinned by ``test_smoke_tick.test_tick_feed_cron_routes_through_sync_cron``.
     These cases drive the ``cron`` verb directly to exercise the reset LOGIC without
     waiting on the tick cadence.  We still need pfBlockerNG installed and ``enable_cb=on``

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -232,6 +232,8 @@ def test_tick_reboot_persists_ledger(deployed_vm: SmokeVM):
 
 @pytest.mark.smoke
 @pytest.mark.tick
+@pytest.mark.timeout(120)  # the cron pass is backgrounded + serialised behind sibling ticks'
+#                            crons; its CRON PROCESS marker can land past the 30s body cap.
 def test_tick_feed_cron_routes_through_sync_cron(deployed_vm: SmokeVM):
     """The tick's due feed-cron dispatches the ``cron`` verb (-> pflblockerng_sync_cron),
     NOT a bare ``pfb_trigger scope=both`` (issue #570).

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -121,13 +121,12 @@ def test_tick_dispatches_due_feed(deployed_vm: SmokeVM):
         f"before: cron next_due should be in the past; ledger={before}"
     )
 
-    # When: tick fires.
-    tick_out = _run_tick(vm)
+    # When: tick fires. Its "Tick: dispatching feed cron." line goes to SYSLOG via logger()
+    # (NOT stdout), and the cron pass is backgrounded to the log file — so the tick's stdout
+    # is empty. Observe the dispatch through the ledger (mark_ran updates next_due), not stdout.
+    _run_tick(vm)
 
-    # Then: dispatch log line present.
-    assert "Tick: dispatching feed cron" in tick_out, f"expected dispatch log line; tick output:\n{tick_out}"
-
-    # Poll until mark_ran has persisted the updated next_due (VM clock as reference).
+    # Then: mark_ran persisted the updated next_due — proves the tick dispatched the cron.
     assert h.wait_until(
         lambda: _read_ledger(vm).get("cron", {}).get("next_due", 0) > now_ts,
         timeout=30,
@@ -153,10 +152,12 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM):
 
     _write_ledger_entry(vm, "cron", now_ts - 86400, future)
 
-    tick_out = _run_tick(vm)
+    # The tick logs to syslog, not stdout, so observe via the ledger: a non-due cron is
+    # NOT dispatched, so mark_ran does not run and next_due stays at the future value.
+    _run_tick(vm)
 
-    assert "Tick: dispatching feed cron" not in tick_out, (
-        f"expected no dispatch (not yet due); tick output:\n{tick_out}"
+    assert _read_ledger(vm).get("cron", {}).get("next_due", 0) == future, (
+        f"expected NO dispatch (cron not yet due) — next_due should stay {future}; ledger={_read_ledger(vm)}"
     )
 
 
@@ -261,11 +262,10 @@ def test_tick_feed_cron_routes_through_sync_cron(deployed_vm: SmokeVM):
     _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
     before = h.count_log_marker(vm, h.PFB_LOG, marker)
 
-    # When: the tick fires (backgrounds the cron pass via the `cron` verb).
-    tick_out = _run_tick(vm)
-    assert "Tick: dispatching feed cron" in tick_out, (
-        f"tick should dispatch the due feed cron; tick output:\n{tick_out}"
-    )
+    # When: the tick fires (backgrounds the cron pass via the `cron` verb). The tick's
+    # "Tick: dispatching feed cron." line goes to syslog, not stdout, so do not assert on
+    # tick stdout — the CRON PROCESS marker below is the actual discriminator.
+    _run_tick(vm)
 
     # Then: the backgrounded pass ran through pflblockerng_sync_cron (marker count rose).
     assert h.wait_until(

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -232,7 +232,7 @@ def test_tick_reboot_persists_ledger(deployed_vm: SmokeVM):
 
 @pytest.mark.smoke
 @pytest.mark.tick
-@pytest.mark.timeout(120)  # the cron pass is backgrounded + serialised behind sibling ticks'
+@pytest.mark.timeout(220)  # the cron pass is backgrounded + serialised behind sibling ticks'
 #                            crons; its CRON PROCESS marker can land past the 30s body cap.
 def test_tick_feed_cron_routes_through_sync_cron(deployed_vm: SmokeVM):
     """The tick's due feed-cron dispatches the ``cron`` verb (-> pfblockerng_sync_cron),
@@ -259,6 +259,18 @@ def test_tick_feed_cron_routes_through_sync_cron(deployed_vm: SmokeVM):
     marker = "CRON  PROCESS  START"
 
     now_ts = int(vm.ssh("date +%s").stdout.strip())
+
+    # Drain any in-flight backgrounded cron from a prior tick test first: a sync pass holds
+    # a lock, so a second cron launched while one is running exits early WITHOUT its own
+    # CRON PROCESS pass — which would leave our marker count flat even though the tick
+    # dispatched correctly. Wait until no `pfblockerng.php cron` process remains.
+    assert h.wait_until(
+        lambda: (
+            vm.ssh("pgrep -f 'pfblockerng[.]php cron' >/dev/null && echo BUSY || echo CLEAR").stdout.strip() == "CLEAR"
+        ),
+        timeout=90,
+        interval=3,
+    ), "a prior backgrounded cron never finished; cannot isolate this tick's sync_cron pass"
 
     # Given: cron due, and the sync_cron marker count BEFORE this tick.
     _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -99,39 +99,61 @@ def _run_tick(vm) -> str:
 
 @pytest.mark.smoke
 @pytest.mark.tick
+@pytest.mark.timeout(150)  # the cron pass is backgrounded; its CRON PROCESS marker lands async
 def test_tick_dispatches_due_feed(deployed_vm: SmokeVM):
-    """Tick fires a due feed sync when the cron ledger entry is past.
+    """Tick fires a due feed sync, dispatched THROUGH pfblockerng_sync_cron (issue #570).
+
+    Two observables (the tick logs to syslog, not stdout, so we never assert on tick stdout):
+      1. mark_ran updates the 'cron' ledger next_due (the tick dispatched a cron job), and
+      2. a ' CRON  PROCESS  START' marker appears in pfblockerng.log — that marker is logged
+         ONLY by pfblockerng_sync_cron, so it proves the tick dispatches the `cron` verb
+         (-> per-list Update Frequency + scheduled log reset) and NOT a bare
+         `pfb_trigger scope=both` (which logs no CRON PROCESS pass). This is the FIRST tick
+         test, so it runs on a clean box (no prior backgrounded cron holding the sync lock).
 
     Scenario:
         Background: pfBlockerNG installed with at least one enabled feed.
             Given the 'cron' ledger entry has next_due in the past.
             When pfblockerng.php tick runs.
-            Then the log contains 'Tick: dispatching feed cron.'
-            And  the 'cron' ledger entry's next_due is updated to the future.
+            Then the 'cron' ledger entry's next_due is updated to the future,
+            And  a ' CRON  PROCESS  START' marker appears (dispatched via pfblockerng_sync_cron).
     """
     vm = deployed_vm
+    marker = "CRON  PROCESS  START"
 
     now_ts = int(vm.ssh("date +%s").stdout.strip())
 
-    # Given: force cron past.
+    # Given: force cron past; snapshot the sync_cron marker count before the tick.
     _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
+    cron_marker_before = h.count_log_marker(vm, h.PFB_LOG, marker)
 
     before = _read_ledger(vm)
     assert before.get("cron", {}).get("next_due", 0) < now_ts, (
         f"before: cron next_due should be in the past; ledger={before}"
     )
 
-    # When: tick fires. Its "Tick: dispatching feed cron." line goes to SYSLOG via logger()
-    # (NOT stdout), and the cron pass is backgrounded to the log file — so the tick's stdout
-    # is empty. Observe the dispatch through the ledger (mark_ran updates next_due), not stdout.
+    # When: tick fires (backgrounds the `cron` verb).
     _run_tick(vm)
 
-    # Then: mark_ran persisted the updated next_due — proves the tick dispatched the cron.
+    # Then (1): mark_ran persisted the updated next_due — proves the tick dispatched the cron.
     assert h.wait_until(
         lambda: _read_ledger(vm).get("cron", {}).get("next_due", 0) > now_ts,
         timeout=30,
         interval=2,
     ), f"after: cron next_due should be in the future;\n  ledger={_read_ledger(vm)}, now_ts={now_ts}"
+
+    # Then (2): the backgrounded pass ran through pfblockerng_sync_cron (marker count rose) —
+    # a bare pfb_trigger would never log CRON PROCESS, so this is the routing discriminator.
+    assert h.wait_until(
+        lambda: h.count_log_marker(vm, h.PFB_LOG, marker) > cron_marker_before,
+        timeout=90,
+        interval=3,
+    ), (
+        "tick must route the feed cron through pfblockerng_sync_cron — the "
+        f"' {marker}' marker count did not increase (before={cron_marker_before}, "
+        f"after={h.count_log_marker(vm, h.PFB_LOG, marker)}).  A bare pfb_trigger would "
+        "skip per-list Update Frequency and the scheduled log reset (issue #570 / ADR-30)."
+    )
 
 
 @pytest.mark.smoke
@@ -227,68 +249,4 @@ def test_tick_reboot_persists_ledger(deployed_vm: SmokeVM):
     assert "cron" in after, f"cron ledger entry missing after reboot; ledger={after}"
     assert after["cron"]["next_due"] == future, (
         f"cron next_due changed across reboot;\n  before={future} after={after['cron']['next_due']}"
-    )
-
-
-@pytest.mark.smoke
-@pytest.mark.tick
-@pytest.mark.timeout(220)  # the cron pass is backgrounded + serialised behind sibling ticks'
-#                            crons; its CRON PROCESS marker can land past the 30s body cap.
-def test_tick_feed_cron_routes_through_sync_cron(deployed_vm: SmokeVM):
-    """The tick's due feed-cron dispatches the ``cron`` verb (-> pfblockerng_sync_cron),
-    NOT a bare ``pfb_trigger scope=both`` (issue #570).
-
-    Only ``pfblockerng_sync_cron()`` applies each feed's per-list Update Frequency
-    (``$list['cron']``: EveryDay/Weekly/NNhour) and runs the scheduled log trim + reset
-    (``pfb_log_mgmt``/``pfb_log_reset``).  A bare ``pfb_trigger`` does neither — it would
-    poll every feed on every tick (provider-ban risk) and never rotate the report logs
-    (ADR-30 dead on-box).  The discriminator is the `` CRON  PROCESS  START`` marker that
-    ONLY ``pfblockerng_sync_cron()`` logs; if the tick regresses to dispatching
-    ``pfb_trigger`` directly the marker count never increases.
-
-    Scenario:
-        Background: pfBlockerNG installed.
-            Given the 'cron' ledger entry is due (next_due in the past).
-            And   a count of the ' CRON  PROCESS  START' marker taken BEFORE the tick.
-            When  pfblockerng.php tick runs (it backgrounds the cron pass).
-            Then  the tick logs 'Tick: dispatching feed cron.'
-            And   the ' CRON  PROCESS  START' marker count increases — proving the pass
-                  ran through pfblockerng_sync_cron, not a bare pfb_trigger.
-    """
-    vm = deployed_vm
-    marker = "CRON  PROCESS  START"
-
-    now_ts = int(vm.ssh("date +%s").stdout.strip())
-
-    # Drain any in-flight backgrounded cron from a prior tick test first: a sync pass holds
-    # a lock, so a second cron launched while one is running exits early WITHOUT its own
-    # CRON PROCESS pass — which would leave our marker count flat even though the tick
-    # dispatched correctly. Wait until no `pfblockerng.php cron` process remains.
-    assert h.wait_until(
-        lambda: (
-            vm.ssh("pgrep -f 'pfblockerng[.]php cron' >/dev/null && echo BUSY || echo CLEAR").stdout.strip() == "CLEAR"
-        ),
-        timeout=90,
-        interval=3,
-    ), "a prior backgrounded cron never finished; cannot isolate this tick's sync_cron pass"
-
-    # Given: cron due, and the sync_cron marker count BEFORE this tick.
-    _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
-    before = h.count_log_marker(vm, h.PFB_LOG, marker)
-
-    # When: the tick fires (backgrounds the cron pass via the `cron` verb). The tick's
-    # "Tick: dispatching feed cron." line goes to syslog, not stdout, so do not assert on
-    # tick stdout — the CRON PROCESS marker below is the actual discriminator.
-    _run_tick(vm)
-
-    # Then: the backgrounded pass ran through pfblockerng_sync_cron (marker count rose).
-    assert h.wait_until(
-        lambda: h.count_log_marker(vm, h.PFB_LOG, marker) > before,
-        timeout=90,
-        interval=3,
-    ), (
-        "tick must route the feed cron through pfblockerng_sync_cron — the "
-        f"' {marker}' marker count did not increase (before={before}, "
-        f"after={h.count_log_marker(vm, h.PFB_LOG, marker)}).  A bare pfb_trigger would "
-        "skip per-list Update Frequency and the scheduled log reset (issue #570 / ADR-30)."
     )

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -235,15 +235,15 @@ def test_tick_reboot_persists_ledger(deployed_vm: SmokeVM):
 @pytest.mark.timeout(120)  # the cron pass is backgrounded + serialised behind sibling ticks'
 #                            crons; its CRON PROCESS marker can land past the 30s body cap.
 def test_tick_feed_cron_routes_through_sync_cron(deployed_vm: SmokeVM):
-    """The tick's due feed-cron dispatches the ``cron`` verb (-> pflblockerng_sync_cron),
+    """The tick's due feed-cron dispatches the ``cron`` verb (-> pfblockerng_sync_cron),
     NOT a bare ``pfb_trigger scope=both`` (issue #570).
 
-    Only ``pflblockerng_sync_cron()`` applies each feed's per-list Update Frequency
+    Only ``pfblockerng_sync_cron()`` applies each feed's per-list Update Frequency
     (``$list['cron']``: EveryDay/Weekly/NNhour) and runs the scheduled log trim + reset
     (``pfb_log_mgmt``/``pfb_log_reset``).  A bare ``pfb_trigger`` does neither — it would
     poll every feed on every tick (provider-ban risk) and never rotate the report logs
     (ADR-30 dead on-box).  The discriminator is the `` CRON  PROCESS  START`` marker that
-    ONLY ``pflblockerng_sync_cron()`` logs; if the tick regresses to dispatching
+    ONLY ``pfblockerng_sync_cron()`` logs; if the tick regresses to dispatching
     ``pfb_trigger`` directly the marker count never increases.
 
     Scenario:
@@ -253,7 +253,7 @@ def test_tick_feed_cron_routes_through_sync_cron(deployed_vm: SmokeVM):
             When  pfblockerng.php tick runs (it backgrounds the cron pass).
             Then  the tick logs 'Tick: dispatching feed cron.'
             And   the ' CRON  PROCESS  START' marker count increases — proving the pass
-                  ran through pflblockerng_sync_cron, not a bare pfb_trigger.
+                  ran through pfblockerng_sync_cron, not a bare pfb_trigger.
     """
     vm = deployed_vm
     marker = "CRON  PROCESS  START"
@@ -269,13 +269,13 @@ def test_tick_feed_cron_routes_through_sync_cron(deployed_vm: SmokeVM):
     # tick stdout — the CRON PROCESS marker below is the actual discriminator.
     _run_tick(vm)
 
-    # Then: the backgrounded pass ran through pflblockerng_sync_cron (marker count rose).
+    # Then: the backgrounded pass ran through pfblockerng_sync_cron (marker count rose).
     assert h.wait_until(
         lambda: h.count_log_marker(vm, h.PFB_LOG, marker) > before,
         timeout=90,
         interval=3,
     ), (
-        "tick must route the feed cron through pflblockerng_sync_cron — the "
+        "tick must route the feed cron through pfblockerng_sync_cron — the "
         f"' {marker}' marker count did not increase (before={before}, "
         f"after={h.count_log_marker(vm, h.PFB_LOG, marker)}).  A bare pfb_trigger would "
         "skip per-list Update Frequency and the scheduled log reset (issue #570 / ADR-30)."

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -158,29 +158,51 @@ def test_tick_dispatches_due_feed(deployed_vm: SmokeVM):
 
 @pytest.mark.smoke
 @pytest.mark.tick
+@pytest.mark.timeout(150)  # drain + bounded no-dispatch poll can exceed the 30s body cap
 def test_tick_skips_non_due_feed(deployed_vm: SmokeVM):
-    """Tick does NOT fire a feed sync when cron next_due is in the future.
+    """Tick does NOT dispatch a feed sync when the cron ledger entry is not yet due.
+
+    The tick logs to syslog (not stdout), so observe the NON-dispatch via the
+    ' CRON  PROCESS  START' marker (logged only by pfblockerng_sync_cron): a non-due cron
+    must produce NO new marker. Drain any in-flight cron from a prior tick test first so the
+    marker baseline is stable. This is marker-based (not ledger-value-based) so it is immune
+    to a prior test's mark_ran overwriting the cron entry — both values stay 'future' anyway.
+    (Positive-control hardening — proving the tick itself ran — is tracked in #582.)
 
     Scenario:
         Background: pfBlockerNG installed.
             Given the 'cron' ledger entry has next_due = now + 1 hour.
             When pfblockerng.php tick runs.
-            Then the log does NOT contain 'Tick: dispatching feed cron.'
+            Then NO new ' CRON  PROCESS  START' marker appears (the cron was skipped).
     """
     vm = deployed_vm
+    marker = "CRON  PROCESS  START"
+
+    # Drain any in-flight backgrounded cron from a prior tick test so the marker baseline
+    # is stable (a still-running prior cron would log a marker unrelated to this tick).
+    assert h.wait_until(
+        lambda: (
+            vm.ssh("pgrep -f 'pfblockerng[.]php cron' >/dev/null && echo BUSY || echo CLEAR").stdout.strip() == "CLEAR"
+        ),
+        timeout=90,
+        interval=3,
+    ), "a prior backgrounded cron never finished; cannot isolate this tick"
 
     now_ts = int(vm.ssh("date +%s").stdout.strip())
-    future = now_ts + 3600
+    _write_ledger_entry(vm, "cron", now_ts - 86400, now_ts + 3600)
+    before = h.count_log_marker(vm, h.PFB_LOG, marker)
 
-    _write_ledger_entry(vm, "cron", now_ts - 86400, future)
-
-    # The tick logs to syslog, not stdout, so observe via the ledger: a non-due cron is
-    # NOT dispatched, so mark_ran does not run and next_due stays at the future value.
+    # When: tick fires — cron is not due.
     _run_tick(vm)
 
-    assert _read_ledger(vm).get("cron", {}).get("next_due", 0) == future, (
-        f"expected NO dispatch (cron not yet due) — next_due should stay {future}; ledger={_read_ledger(vm)}"
-    )
+    # Then: no new CRON PROCESS pass appeared (cron skipped). The bounded poll gives any
+    # erroneous late dispatch a window to show; wait_until returns False (good) when the
+    # count never rises.
+    assert not h.wait_until(
+        lambda: h.count_log_marker(vm, h.PFB_LOG, marker) > before,
+        timeout=20,
+        interval=4,
+    ), f"tick dispatched a cron for a NON-due feed — ' {marker}' marker count rose from {before}"
 
 
 @pytest.mark.smoke

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -227,3 +227,54 @@ def test_tick_reboot_persists_ledger(deployed_vm: SmokeVM):
     assert after["cron"]["next_due"] == future, (
         f"cron next_due changed across reboot;\n  before={future} after={after['cron']['next_due']}"
     )
+
+
+@pytest.mark.smoke
+@pytest.mark.tick
+def test_tick_feed_cron_routes_through_sync_cron(deployed_vm: SmokeVM):
+    """The tick's due feed-cron dispatches the ``cron`` verb (-> pflblockerng_sync_cron),
+    NOT a bare ``pfb_trigger scope=both`` (issue #570).
+
+    Only ``pflblockerng_sync_cron()`` applies each feed's per-list Update Frequency
+    (``$list['cron']``: EveryDay/Weekly/NNhour) and runs the scheduled log trim + reset
+    (``pfb_log_mgmt``/``pfb_log_reset``).  A bare ``pfb_trigger`` does neither — it would
+    poll every feed on every tick (provider-ban risk) and never rotate the report logs
+    (ADR-30 dead on-box).  The discriminator is the `` CRON  PROCESS  START`` marker that
+    ONLY ``pflblockerng_sync_cron()`` logs; if the tick regresses to dispatching
+    ``pfb_trigger`` directly the marker count never increases.
+
+    Scenario:
+        Background: pfBlockerNG installed.
+            Given the 'cron' ledger entry is due (next_due in the past).
+            And   a count of the ' CRON  PROCESS  START' marker taken BEFORE the tick.
+            When  pfblockerng.php tick runs (it backgrounds the cron pass).
+            Then  the tick logs 'Tick: dispatching feed cron.'
+            And   the ' CRON  PROCESS  START' marker count increases — proving the pass
+                  ran through pflblockerng_sync_cron, not a bare pfb_trigger.
+    """
+    vm = deployed_vm
+    marker = "CRON  PROCESS  START"
+
+    now_ts = int(vm.ssh("date +%s").stdout.strip())
+
+    # Given: cron due, and the sync_cron marker count BEFORE this tick.
+    _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
+    before = h.count_log_marker(vm, h.PFB_LOG, marker)
+
+    # When: the tick fires (backgrounds the cron pass via the `cron` verb).
+    tick_out = _run_tick(vm)
+    assert "Tick: dispatching feed cron" in tick_out, (
+        f"tick should dispatch the due feed cron; tick output:\n{tick_out}"
+    )
+
+    # Then: the backgrounded pass ran through pflblockerng_sync_cron (marker count rose).
+    assert h.wait_until(
+        lambda: h.count_log_marker(vm, h.PFB_LOG, marker) > before,
+        timeout=90,
+        interval=3,
+    ), (
+        "tick must route the feed cron through pflblockerng_sync_cron — the "
+        f"' {marker}' marker count did not increase (before={before}, "
+        f"after={h.count_log_marker(vm, h.PFB_LOG, marker)}).  A bare pfb_trigger would "
+        "skip per-list Update Frequency and the scheduled log reset (issue #570 / ADR-30)."
+    )


### PR DESCRIPTION
## What

Restores three behaviours ADR-43's cron-fleet collapse silently broke.

> **Needs live-VM validation before merge.** The tick / `sync_package_pfblockerng` paths are not off-appliance unit-testable. The authored smoke guard (`test_tick_feed_cron_routes_through_sync_cron`) and the existing `test_log_rotate` cases must run green on the live-VM fan-out before this merges.

## Bugs (all from the ADR-43 cron-fleet collapse)

The tick dispatched `pfb_trigger scope=both force=false trigger=cron` directly, bypassing `pflblockerng_sync_cron()` — which held two responsibilities the rework never migrated — and `force` was never wired for `scope=both`:

1. **Scheduled log reset + size-cap trim dead** (regressed ADR-30). `pfb_log_reset()`/`pfb_log_mgmt()` run only at the end of `pflblockerng_sync_cron()`; the tick never reached it, so report logs never rotated on schedule (MFS `/var` pressure).
2. **Per-list feed Update Frequency ignored.** The `$list['cron']` gate (EveryDay/Weekly/NNhour) lives only in `pflblockerng_sync_cron()`; the tick downloaded every enabled feed on every due pass at the global `pfb_interval` — a Weekly feed hit ~168×/week (provider-ban risk).
3. **Default Run-now "Force" a no-op.** `scope=both` + `force=true` fell through the if/elseif chain (force consumed only for `scope=ip`/`dnsbl`), so the most prominent control did nothing.

## Fix

- **(1 + 2)** The tick's due feed-cron now dispatches the `cron` verb → `pflblockerng_sync_cron()` (per-list frequency gate + log trim/reset + ADR-19 software check + its own `sync_package_pfblockerng('cron')` which applies on change via ADR-40/ADR-10). Still backgrounded.
- **(3)** Add a `scope==='both' && force` branch = the union of the ip + dnsbl force reloads (reuse both, clear masterfile/mastercat).

A follow-up (#573) proposes the ADR-43-native alternative (per-feed scheduling in the due-ledger).

## Testing

`test_smoke_tick.test_tick_feed_cron_routes_through_sync_cron` drives the real tick and asserts the `CRON  PROCESS  START` marker (logged **only** by `pflblockerng_sync_cron`) appears — the discriminator that catches a regression to a bare `pfb_trigger`. The stale `test_log_rotate` docstring (which claimed the reset runs "only on the cron verb") is corrected. Off-box: php -l, PHPCS, and PHPUnit (1532 tests) green; this PR's behaviour is live-VM-only.

Found in the 2026-06-26 ADR review (`docs/misc/adr-7day-review-2026-06-26.md`, findings ADR30-1 + ADR43-1 + ADR43-2).

Fixes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved force-reload when updating both IP and DNSBL, ensuring both sides refresh and DNSBL updates are handled correctly.
  * Updated feed cron execution to follow the intended cron/scheduled path, keeping due-feed processing and end-of-cron maintenance consistent.

* **Tests**
  * Enhanced smoke tests to confirm tick-based cron routing via the expected “CRON PROCESS START” marker and due-ledger timing, with updated assertions for due vs non-due feeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->