### PR TITLE
Adr 44 mime normalization

### DIFF
--- a/.ADRs/ADR_44_MIME_Normalization/01_Extract_Oracle_Tests.txt
+++ b/.ADRs/ADR_44_MIME_Normalization/01_Extract_Oracle_Tests.txt
@@ -1,0 +1,110 @@
+================================================================================
+PHASE 1 PROMPT — Extract and oracle-pin the current pfb_filter() MIME path
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_44_MIME_Normalization/ADR.md   (read §1 and §6 Phase 1 first)
+================================================================================
+
+ROLE
+Branch: adr/44-mime-normalisation (off devel)
+Phase 1 of 4 — behaviour-preserving preparatory phase.
+Inline on adr/44-mime-normalisation, one commit, push directly.
+
+WHY THIS PHASE EXISTS
+The MIME-type validation logic in pfb_filter() (constants 16–18) currently
+rejects valid ZIP feeds because `file(1)` returns variant strings like
+`application/x-zip-compressed` that are not in $pfb['mime_types']. Before
+introducing normalisation (Phase 2), we must:
+  1. Extract the MIME-string handling into clearly named helper functions so
+     the normalisation has a clean insertion point.
+  2. Pin the CURRENT behaviour with oracle/regression tests — including
+     explicitly recording that `application/x-zip-compressed` currently FAILS
+     (this is the bug we fix in Phase 2; the red result belongs in the handoff).
+
+This phase is behaviour-preserving: no functional change to pfb_filter().
+
+REQUIRED READING
+- .ADRs/ADR_44_MIME_Normalization/ADR.md  (§1 Context, §2 Decision, §5 Constraints, §6 Phase 1)
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc
+    pfb_filter() — constants PFB_FILTER_FILE_MIME (17), PFB_FILTER_FILE_MIME_COMPRESSED (18),
+    PFB_FILTER_FILE_MIME_COMPARE (16), and $pfb['mime_types'] array definition.
+- CLAUDE.md  (commit style, branch policy, test coverage non-negotiables)
+- Existing PHPUnit test suite (discover path from CLAUDE.md or composer.json)
+
+ACTION PLAN (ordered — oracle tests FIRST)
+
+1. Read pfb_filter() in full. Locate the three MIME filter constants (16, 17, 18)
+   and understand the allow-list lookup against $pfb['mime_types'].
+
+2. Extract a pure helper:
+       pfb_mime_in_allowlist(string $mime, array $allowlist): bool
+   that encapsulates the array_key_exists / isset lookup currently inline in
+   constant-17 and constant-18 branches. This is a behaviour-preserving refactor;
+   callers pass the same $pfb['mime_types'] they do today.
+
+3. Write oracle/regression PHPUnit tests (these must ALL pass on the current code
+   with NO changes to pfb_filter() logic — they pin today's behaviour):
+
+   a. test_pfb_mime_allowlist_accepts_canonical_zip()
+      — 'application/zip' is in the allow-list → true.
+
+   b. test_pfb_mime_allowlist_rejects_x_zip_compressed()
+      — 'application/x-zip-compressed' is NOT in the allow-list → false.
+      *** Record the failure (false/rejected) in the handoff as the baseline.
+          This is the bug; Phase 2 fixes it via normalisation, not allow-list change. ***
+
+   c. test_pfb_mime_allowlist_rejects_x_zip()
+      — 'application/x-zip' → false. Record in handoff.
+
+   d. test_pfb_mime_allowlist_accepts_canonical_gzip()
+      — 'application/gzip' → true.
+
+   e. test_pfb_mime_allowlist_accepts_x_gzip()
+      — 'application/x-gzip' → true (it IS in the current allow-list; confirm this).
+
+   f. test_pfb_mime_allowlist_rejects_octet_stream()
+      — 'application/octet-stream' → false.
+
+   g. test_pfb_mime_allowlist_accepts_text_plain()
+      — 'text/plain' → true.
+
+4. Confirm all existing pfBlockerNG PHPUnit tests still pass (no regressions from
+   the extract refactor).
+
+CONSTRAINTS
+- Do NOT change any logic in pfb_filter() beyond extracting pfb_mime_in_allowlist().
+- Do NOT modify $pfb['mime_types'].
+- Do NOT touch PFB_FILTER_FILE_MIME_COMPARE (16) logic.
+- Do NOT add normalisation in this phase — that is Phase 2.
+- Hostname exception paths in pfb_filter() are untouched.
+- PHP 8.3; no new Composer production dependencies.
+
+VERIFICATION (must all pass before this phase is done)
+- vendor/bin/phpunit                → green (all existing + new oracle tests)
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc  → no syntax errors
+- git diff --stat                   → only pfblockerng.inc and the new test file(s)
+
+EXPECTED RESULT
+- pfb_mime_in_allowlist() exists in pfblockerng.inc, called from constant-17 and
+  constant-18 branches.
+- Oracle test suite exists and is green.
+- Handoff records the confirmed-red results for x-zip-compressed and x-zip
+  (the baseline evidence the Phase 2 tests will flip to green).
+- No functional change to pfb_filter() behaviour.
+
+COMMIT (single)
+    pfb_filter: extract pfb_mime_in_allowlist() + oracle tests (ADR-44 P1)
+Push directly to adr/44-mime-normalisation.
+Open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_44_MIME_Normalization/RESULTS/01_Results.txt
+Include:
+- Confirmation that pfb_mime_in_allowlist() was extracted and wired.
+- Full list of oracle test names and their results (green/red as appropriate).
+- Explicit record of the red baselines:
+    application/x-zip-compressed → allowlist result: FALSE (bug; Phase 2 fixes)
+    application/x-zip            → allowlist result: FALSE (bug; Phase 2 fixes)
+- PHPUnit summary line (X tests, Y assertions, 0 failures — except the deliberate
+  red-baseline items which should be noted, not left as test failures; use
+  assertFalse to pin them as expected-false).
+- Commit hash and push confirmation.
+- Any deviation or watch-out for Phase 2.

--- a/.ADRs/ADR_44_MIME_Normalization/02_Implement_Normalise.txt
+++ b/.ADRs/ADR_44_MIME_Normalization/02_Implement_Normalise.txt
@@ -1,0 +1,124 @@
+================================================================================
+PHASE 2 PROMPT — Implement pfb_mime_normalise() and wire into constant 17
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_44_MIME_Normalization/ADR.md   (read §2 Decision and §6 Phase 2 first)
+================================================================================
+
+ROLE
+Branch: adr/44-mime-normalisation (off devel)
+Phase 2 of 4 — core behaviour-changing phase.
+Inline on adr/44-mime-normalisation, one commit, push directly.
+
+WHY THIS PHASE EXISTS
+Phase 1 pinned the current (buggy) behaviour: valid ZIPs packaged by non-canonical
+tools produce MIME strings like `application/x-zip-compressed` that are rejected
+by pfb_filter() because only `application/zip` is in the allow-list. This phase
+introduces the normalisation pass that rewrites those variant strings to their
+canonical forms BEFORE the allow-list lookup — fixing the rejections without
+modifying the allow-list itself.
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_44_MIME_Normalization/RESULTS/01_Results.txt
+  Confirm it records the red-baseline for application/x-zip-compressed and
+  application/x-zip, and that pfb_mime_in_allowlist() was extracted. If this file
+  is missing, the previous phase is not complete; STOP and report.
+- .ADRs/ADR_44_MIME_Normalization/ADR.md  (§2 Decision — normalisation map, rules, logging)
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc
+    pfb_filter(), pfb_mime_in_allowlist() (from Phase 1), $pfb['mime_types'],
+    PFB_FILTER_FILE_MIME (17), existing debug-log helpers.
+- CLAUDE.md  (commit style, test coverage non-negotiables — red→green evidence required)
+
+ACTION PLAN (ordered)
+
+1. Add the pure helper function to pfblockerng.inc:
+
+       function pfb_mime_normalise(string $raw): string
+
+   Normalisation map (exact match first, then substring):
+     'application/x-zip-compressed'  → 'application/zip'
+     'application/x-zip'             → 'application/zip'
+     any string where stripos($raw, 'zip') !== false → 'application/zip'
+     'application/x-gzip'            → 'application/gzip'
+   Any string NOT matching a rule is returned unchanged.
+
+   The function is pure (no I/O, no globals).
+
+2. Wire pfb_mime_normalise() into the PFB_FILTER_FILE_MIME (17) branch of
+   pfb_filter(), immediately after the raw `file` output is obtained and BEFORE
+   the pfb_mime_in_allowlist() call:
+
+       $mime_raw = <existing file exec result>;
+       $mime     = pfb_mime_normalise($mime_raw);
+       if ($mime !== $mime_raw) {
+           pfb_logger("MIME normalised: raw=\"{$mime_raw}\" -> canonical=\"{$mime}\"", <debug_level>);
+       }
+       // then pfb_mime_in_allowlist($mime, $pfb['mime_types']) as before
+
+   Use the existing pfb_logger() / pfb_log() debug helper — match the log-level
+   constant used elsewhere in pfb_filter() for debug output.
+
+3. Do NOT change PFB_FILTER_FILE_MIME_COMPRESSED (18) or PFB_FILTER_FILE_MIME_COMPARE (16).
+   Do NOT modify $pfb['mime_types'].
+   Do NOT modify hostname exception paths.
+
+4. Write PHPUnit tests. These MUST fail on the Phase 1 code (before this commit)
+   and pass after. Prove and record the red→green evidence in the handoff.
+
+   Unit tests for pfb_mime_normalise():
+     test_normalise_x_zip_compressed_to_zip()
+     test_normalise_x_zip_to_zip()
+     test_normalise_zip_substring_case_insensitive()   — e.g. 'Application/X-ZIP'
+     test_normalise_x_gzip_to_gzip()
+     test_normalise_octet_stream_unchanged()
+     test_normalise_text_plain_unchanged()
+     test_normalise_empty_string_unchanged()
+     test_normalise_canonical_zip_unchanged()           — 'application/zip' → 'application/zip'
+
+   Integration test (uses pfb_filter() or pfb_mime_in_allowlist() + normalise together):
+     test_pfb_filter_mime_accepts_x_zip_compressed_after_normalise()
+       — simulate: raw='application/x-zip-compressed'; after normalise → 'application/zip';
+         pfb_mime_in_allowlist('application/zip', $pfb['mime_types']) → true.
+
+5. Re-run the full oracle suite from Phase 1. All must still pass (the previously-
+   red assertFalse pins for x-zip-compressed and x-zip should now be re-examined:
+   those tests pin the allow-list lookup in isolation — they should still be false
+   for the raw strings because pfb_mime_in_allowlist() itself hasn't changed; the
+   integration test above demonstrates the end-to-end fix).
+
+CONSTRAINTS
+- pfb_mime_normalise() is a pure function — no exec(), no file I/O, no globals.
+- Only constant 17 (PFB_FILTER_FILE_MIME) is modified; 16 and 18 are untouched.
+- No changes to $pfb['mime_types'] array.
+- No new Composer production dependencies.
+- PHP 8.3 compatible.
+
+VERIFICATION (must all pass before this phase is done)
+- vendor/bin/phpunit                → green (all Phase 1 oracle + all Phase 2 tests)
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc  → no syntax errors
+- git diff --stat                   → only pfblockerng.inc and test file(s)
+- Review your own git diff: confirm pfb_mime_normalise() is wired BEFORE the
+  allow-list lookup in constant-17 branch; confirm 16 and 18 are untouched.
+
+EXPECTED RESULT
+- pfb_mime_normalise() exists, is pure, maps variant strings correctly.
+- It is called in constant-17 branch before pfb_mime_in_allowlist().
+- Debug-level log fires when normalisation changes the string.
+- All Phase 2 unit and integration tests are green.
+- All Phase 1 oracle tests remain green.
+- Handoff records red→green evidence (run tests against Phase 1 commit first to
+  capture the red; then against this commit to capture the green).
+
+COMMIT (single)
+    pfb_filter: add pfb_mime_normalise() + wire into MIME gate (ADR-42 P2)
+Push directly to adr/42-mime-normalisation.
+Open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_42_MIME_Normalization/RESULTS/02_Results.txt
+Include:
+- Confirmation pfb_mime_normalise() was added and wired into constant-17.
+- Red→green evidence: test names + result before (red) and after (green) this commit.
+- PHPUnit summary line (all tests, assertions, 0 failures).
+- Confirmation that constants 16 and 18 were NOT modified (cite git diff line count).
+- Commit hash and push confirmation.
+- Any watch-out for Phase 3 (TODO comment location in ZIP branch, line reference).

--- a/.ADRs/ADR_44_MIME_Normalization/03_Cleanup_TODO.txt
+++ b/.ADRs/ADR_44_MIME_Normalization/03_Cleanup_TODO.txt
@@ -1,0 +1,88 @@
+================================================================================
+PHASE 3 PROMPT — Remove stale TODO; update inline documentation
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_44_MIME_Normalization/ADR.md   (read §1 and §6 Phase 3 first)
+================================================================================
+
+ROLE
+Branch: adr/44-mime-normalisation (off devel)
+Phase 3 of 4 — behaviour-preserving cleanup phase.
+Inline on adr/44-mime-normalisation, one commit, push directly.
+
+WHY THIS PHASE EXISTS
+After Phase 2, pfb_mime_normalise() is live and the MIME gate correctly handles
+ZIP variant strings. However, the ZIP dispatch branch in pfb_download() still
+contains:
+  - A TODO comment explaining why PFB_FILTER_FILE_MIME_COMPRESSED was commented
+    out for ZIP ("incompatability with ZIP files").
+  - Possibly other inline comments that describe the old, pre-normalisation flow.
+
+These are now misleading. This phase removes the stale TODO and updates inline
+documentation to reflect the ADR-44 decision. No functional change.
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_44_MIME_Normalization/RESULTS/02_Results.txt
+  Confirm normalisation is wired, all tests are green, and the handoff notes the
+  TODO comment location. If this file is missing; STOP and report.
+- .ADRs/ADR_44_MIME_Normalization/ADR.md  (§1, §6 Phase 3)
+- src/usr/local/pkg/pfblockerng/pfblockerng.inc
+    pfb_download() ZIP branch — the TODO comment block referencing
+    "incompatability with ZIP files" and the commented-out
+    PFB_FILTER_FILE_MIME_COMPRESSED call.
+    pfb_filter() — any comments describing the pre-normalisation MIME flow.
+- CLAUDE.md
+
+ACTION PLAN (ordered)
+
+1. Locate the TODO comment block in the pfb_download() ZIP branch. It references
+   "incompatability with ZIP files" and explains why the _COMPRESSED check was
+   commented out. Remove this block.
+
+2. In its place, add a brief comment referencing the resolution:
+       // ZIP MIME variant normalisation is handled in pfb_filter() via
+       // pfb_mime_normalise() — see ADR-44. Inner-content validation for
+       // ZIP is addressed by ADR-44.
+
+3. Review all other inline comments in pfb_filter() constants 16, 17, 18 that
+   describe MIME handling. Update any that still describe the old un-normalised
+   flow to reflect that normalisation now precedes the allow-list lookup in
+   constant 17.
+
+4. Do NOT remove the commented-out PFB_FILTER_FILE_MIME_COMPRESSED call in the
+   ZIP branch if it exists — that is addressed by ADR-44, not this ADR. Only
+   update its accompanying TODO/comment text.
+
+5. Run the full test suite to confirm behaviour-preserving (all Phase 1 + Phase 2
+   tests remain green).
+
+CONSTRAINTS
+- No functional changes to pfb_filter() or pfb_download() in this phase.
+- Only comment/documentation changes in pfblockerng.inc.
+- Do not remove the commented-out _COMPRESSED call itself — only its TODO text.
+- PHP 8.3; no new dependencies.
+
+VERIFICATION (must all pass before this phase is done)
+- vendor/bin/phpunit                → green (all Phase 1 + Phase 2 tests; no regressions)
+- php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc  → no syntax errors
+- git diff --stat                   → only pfblockerng.inc (comment changes only)
+- Eyeball git diff: confirm no logic lines changed, only comment lines.
+
+EXPECTED RESULT
+- Stale TODO comment is removed; ADR-44 / ADR-44 reference comment is in its place.
+- pfb_filter() inline docs accurately describe the normalise-then-lookup flow.
+- All tests remain green. No functional change.
+
+COMMIT (single)
+    pfb_filter: remove stale ZIP-MIME TODO; reference ADR-44/ADR-44 (ADR-44 P3)
+Push directly to adr/44-mime-normalisation.
+Open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_44_MIME_Normalization/RESULTS/03_Results.txt
+Include:
+- Confirmation of which comment block(s) were removed/updated and their line refs.
+- Confirmation that the commented-out _COMPRESSED call was NOT removed.
+- PHPUnit summary (all green, same count as Phase 2).
+- git diff --stat output (expected: pfblockerng.inc only, small line delta).
+- Commit hash and push confirmation.
+- Go-ahead for Phase 4 (smoke checklist + ADR acceptance).

--- a/.ADRs/ADR_44_MIME_Normalization/04_Smoke_And_Accept.txt
+++ b/.ADRs/ADR_44_MIME_Normalization/04_Smoke_And_Accept.txt
@@ -1,0 +1,100 @@
+================================================================================
+PHASE 4 PROMPT — Smoke checklist + mark ADR Accepted
+Target model: Claude Sonnet 4.6
+ADR: .ADRs/ADR_44_MIME_Normalization/ADR.md   (read §7 Definition of Done first)
+================================================================================
+
+ROLE
+Branch: adr/44-mime-normalisation (off devel)
+Phase 4 of 4 — documentation/acceptance phase. No code change.
+Inline on adr/44-mime-normalisation, one commit, push directly.
+
+WHY THIS PHASE EXISTS
+Phases 1–3 implemented and cleaned up the MIME normalisation. This phase
+produces the manual smoke checklist document for the maintainer, and — after
+the maintainer confirms smoke results — updates ADR.md status from Proposed to
+Accepted.
+
+NOTE: This phase produces the checklist document and commits it. Status update
+to Accepted is a SEPARATE commit made by the maintainer (or on their explicit
+instruction) after the live-box smoke run passes.
+
+REQUIRED READING
+- FIRST, read the prior phase's handoff:
+  .ADRs/ADR_44_MIME_Normalization/RESULTS/03_Results.txt
+  Confirm all tests are green and the TODO cleanup is done. If missing; STOP.
+- .ADRs/ADR_44_MIME_Normalization/ADR.md  (§7 Definition of Done — smoke checklist)
+- CLAUDE.md
+
+ACTION PLAN (ordered)
+
+1. Create the file:
+   .ADRs/ADR_44_MIME_Normalization/RESULTS/SMOKE_CHECKLIST.md
+
+   Contents (copy and expand from ADR.md §7 manual smoke checklist):
+
+   # ADR-44 Manual Smoke Checklist
+   Owner: maintainer (requires live pfSense box with pfBlockerNG installed)
+   Branch: adr/44-mime-normalisation
+
+   ## Pre-conditions
+   - [ ] pfBlockerNG debug logging is enabled.
+   - [ ] Branch adr/44-mime-normalisation is installed on the test box.
+
+   ## Test cases
+   - [ ] TC-1: Download a blocklist feed served as a ZIP created by Python zipfile
+         (or 7-Zip / Windows Explorer). Confirm it passes the MIME gate and the
+         feed is processed normally (lines imported, no rejection log).
+   - [ ] TC-2: If a feed previously triggered `application/x-zip-compressed`
+         rejection, re-run it. Confirm it now succeeds.
+   - [ ] TC-3: Download a feed served as `application/gzip`. Confirm it still
+         passes (no regression).
+   - [ ] TC-4: Check pfBlockerNG debug log. Confirm normalisation events appear
+         when a variant string is encountered, e.g.:
+             MIME normalised: raw="application/x-zip-compressed" -> canonical="application/zip"
+   - [ ] TC-5: Download a feed that returns a genuine HTML error page (or simulate
+         with a test URL). Confirm it is still rejected by the MIME gate.
+
+   ## Reject criteria (if any of these occur, do NOT accept ADR-44)
+   - Any feed that previously succeeded now fails after this change.
+   - `application/octet-stream` is ever promoted through the normalisation path.
+   - PFB_FILTER_FILE_MIME_COMPARE (constant 16) behaviour changes.
+
+   ## Sign-off
+   - Tester: _______________
+   - Date: _______________
+   - Result: PASS / FAIL
+   - Notes: _______________
+
+2. Do NOT update ADR.md status in this commit. The status update to Accepted
+   is a maintainer action after smoke sign-off.
+
+3. Run the full test suite one final time to confirm green baseline.
+
+CONSTRAINTS
+- No code changes in this phase.
+- Only the SMOKE_CHECKLIST.md file is new.
+- PHP/shell lints still clean.
+
+VERIFICATION
+- vendor/bin/phpunit                → green (all phases)
+- git diff --stat                   → only RESULTS/SMOKE_CHECKLIST.md added
+
+EXPECTED RESULT
+- SMOKE_CHECKLIST.md exists in RESULTS/.
+- All automated tests green.
+- Maintainer has a clear, actionable checklist to run on a live box.
+
+COMMIT (single)
+    adr-44: add smoke checklist; ready for maintainer sign-off (ADR-44 P4)
+Push directly to adr/44-mime-normalisation.
+Open a PR only if the direct push is rejected.
+
+HANDOFF — write .ADRs/ADR_44_MIME_Normalization/RESULTS/04_Results.txt
+Include:
+- Confirmation SMOKE_CHECKLIST.md was created.
+- Final PHPUnit summary (all green).
+- Commit hash and push confirmation.
+- Instruction to maintainer: run smoke checklist on live box; if PASS, update
+  ADR.md Status line from "Proposed" to "Accepted (YYYY-MM-DD)" and commit
+  directly to adr/44-mime-normalisation or merge the PR.

--- a/.ADRs/ADR_44_MIME_Normalization/ADR.md
+++ b/.ADRs/ADR_44_MIME_Normalization/ADR.md
@@ -31,6 +31,7 @@ $pfb['mime_types'] = array_flip([
 ```
 
 Constants involved:
+
 - `PFB_FILTER_FILE_MIME` (17) — outer MIME check, raw `file -b --mime-type`
 - `PFB_FILTER_FILE_MIME_COMPRESSED` (18) — inner MIME via `file -bZ --mime-type`
 - `PFB_FILTER_FILE_MIME_COMPARE` (16) — strict exact-match variant
@@ -47,6 +48,7 @@ comment and the commented-out `PFB_FILTER_FILE_MIME_COMPRESSED` call in the ZIP
 branch.
 
 **Semantics that MUST be preserved (the contract — pin with tests before swapping):**
+
 - Files whose raw `file` output is not a known archive variant string must never
   be promoted through normalisation (e.g. `application/octet-stream` → nothing).
 - Existing hostname-based exceptions in `pfb_filter()` are unchanged.
@@ -56,6 +58,7 @@ branch.
   exact-match comparisons and must continue to do so.
 
 **Explicitly kept out of scope:**
+
 - Structural integrity tests for archives (ADR-43).
 - ZIP path-traversal hardening (ADR-44).
 - Logging format standardisation (ADR-45).
@@ -77,6 +80,7 @@ pass using a small, explicit map:
 | `application/x-gzip` | `application/gzip` (already in allow-list; make explicit) |
 
 Rules:
+
 - Normalisation is a **string-rewrite** applied only when the raw value matches a
   known variant pattern. It never promotes `application/octet-stream` or any
   other non-archive string.
@@ -101,6 +105,7 @@ Rules:
 ## 3. Consequences
 
 ### Positive
+
 - Eliminates false rejections of valid ZIP feeds packaged by non-canonical tools.
 - Normalisation is isolated to a single named helper — easy to audit and extend.
 - No new external tool dependencies; no allow-list changes.
@@ -108,6 +113,7 @@ Rules:
   were being rejected before reaching the validation branch.
 
 ### Negative / Risks
+
 - **Risk:** A too-broad `zip`-substring match promotes a misidentified file.
   **Mitigation:** Normalisation fires only when `file` already returned something
   containing `zip` — random `octet-stream` is never promoted. Oracle tests
@@ -127,8 +133,7 @@ Rules:
   the map → returned unchanged; case-insensitive `zip` variants; `application/octet-stream`
   → unchanged.
 - All existing `pfb_filter()` call-sites remain green (oracle regression suite).
-- `vendor/bin/phpunit` → green; `ruff check` / `shellcheck` → clean (no PHP files
-  other than `pfblockerng.inc` touched in the implementation phases).
+- `vendor/bin/phpunit` → green; `ruff check` / `shellcheck` → clean.
 - Debug log output is observable in a manual smoke run.
 
 ---
@@ -154,10 +159,10 @@ Rules:
 
 Extract the MIME-string handling logic from `pfb_filter()` (constants 16–18) into
 clearly named, pure helper functions, and lay down oracle/regression tests that
-pin the current behaviour **before** the normalisation change is made. These tests
-stay green through all subsequent phases.
+pin the current behaviour **before** the normalisation change is made.
 
 Tests this phase adds:
+
 - `test_pfb_filter_mime_allows_canonical_zip()` — `application/zip` passes gate.
 - `test_pfb_filter_mime_rejects_x_zip_compressed()` — `application/x-zip-compressed`
   currently **fails** gate (this is the bug; record the red result in handoff).
@@ -172,52 +177,54 @@ Tests this phase adds:
 Add the `pfb_mime_normalise(string $raw): string` helper and call it inside the
 `PFB_FILTER_FILE_MIME` (17) branch of `pfb_filter()`. Add debug-level logging.
 
-Tests this phase adds (these must **fail on Phase 1 code, pass after**):
+Tests this phase adds (must **fail on Phase 1 code, pass after**):
+
 - `test_normalise_x_zip_compressed_to_zip()`
 - `test_normalise_x_zip_to_zip()`
 - `test_normalise_zip_substring_variants()`
 - `test_normalise_x_gzip_to_gzip()`
 - `test_normalise_octet_stream_unchanged()`
 - `test_normalise_unknown_string_unchanged()`
-- Integration: `test_pfb_filter_mime_accepts_x_zip_compressed_after_normalise()`
+- `test_pfb_filter_mime_accepts_x_zip_compressed_after_normalise()`
 
 ### Phase 3 — Remove stale TODO; update inline documentation
 
 **Prompt:** `03_Cleanup_TODO.txt`
 
 Remove the TODO comment block referencing the `_COMPRESSED` incompatibility in
-the ZIP branch. Replace with a reference to ADR-42 and ADR-44. Update any other
-inline comments in `pfb_filter()` that describe the old, un-normalised flow.
-Behaviour-preserving; all oracle tests from Phase 1 stay green.
+the ZIP branch. Replace with a reference to ADR-42 and ADR-44. Behaviour-preserving;
+all oracle tests from Phase 1 stay green.
 
 ### Phase 4 — Smoke checklist + mark Accepted
 
 **Prompt:** `04_Smoke_And_Accept.txt`
 
-Produce the manual smoke checklist document (see §7). Update ADR.md status to
-`Accepted` once the maintainer confirms smoke results. No code change in this
-phase.
+Produce the manual smoke checklist document. Update ADR.md status to `Accepted`
+once the maintainer confirms smoke results.
 
 ---
 
 ## 7. Definition of Done
 
 **Automated (CI must be green):**
+
 - `vendor/bin/phpunit` → all tests green, including the red→green suite from Phase 2.
 - `shellcheck` → clean on any shell fragments touched.
 - No regressions in the existing pfBlockerNG test suite.
 
 **Manual smoke checklist (owner: maintainer — no live Unbound in CI):**
-- [ ] Download a blocklist feed served as a ZIP created by Python `zipfile` (or 7-Zip / Windows
-  Explorer); confirm it passes the MIME gate and is processed normally.
-- [ ] Download a feed whose ZIP previously triggered the `x-zip-compressed` rejection; confirm
-  it now succeeds.
+
+- [ ] Download a blocklist feed served as a ZIP created by Python `zipfile` (or 7-Zip /
+  Windows Explorer); confirm it passes the MIME gate and is processed normally.
+- [ ] Download a feed whose ZIP previously triggered the `x-zip-compressed` rejection;
+  confirm it now succeeds.
 - [ ] Download a feed served as `application/gzip`; confirm it still passes (no regression).
 - [ ] Enable pfBlockerNG debug logging; confirm normalisation events appear when a variant
-  string is encountered (`raw: "application/x-zip-compressed" -> canonical: "application/zip"`).
+  string is encountered.
 - [ ] Download a feed that returns a genuine HTML error page; confirm it is still rejected.
 
 **Reject criteria:**
+
 - Any feed that previously succeeded now fails after normalisation.
 - `application/octet-stream` is ever promoted through the normalisation path.
 - `PFB_FILTER_FILE_MIME_COMPARE` (16) behaviour changes in any way.

--- a/.ADRs/ADR_44_MIME_Normalization/ADR.md
+++ b/.ADRs/ADR_44_MIME_Normalization/ADR.md
@@ -1,0 +1,223 @@
+# ADR-44: Normalise MIME-type strings before the allow-list gate in pfb_filter()
+
+- **Status:** **Proposed** (2026-06-25)
+- **Date:** 2026-06-25
+- **Branch:** `adr/44-mime-normalisation` (off `devel`) / **Component(s):** `src/usr/local/pkg/pfblockerng/pfblockerng.inc`
+- **Target runtime:** PHP 8.3, FreeBSD / pfSense; shell via `exec()` to `/usr/bin/file`
+- **Test suite:** `vendor/bin/phpunit` (unit), `shellcheck` (shell fragments)
+
+---
+
+## 1. Context
+
+`pfb_filter()` in `pfblockerng.inc` validates downloaded feed files by running:
+
+```sh
+/usr/bin/file -b --mime-type "$path"
+```
+
+and checking the result against a fixed PHP allow-list (`$pfb['mime_types']`):
+
+```php
+$pfb['mime_types'] = array_flip([
+    'inode/x-empty', 'text/x-file',
+    'text/plain', 'text/html', 'text/xml', 'text/csv',
+    'application/csv', 'application/json', 'application/x-ndjson',
+    'application/x-tar',
+    'application/gzip', 'application/x-gzip',
+    'application/x-bzip2',
+    'application/zip'
+]);
+```
+
+Constants involved:
+- `PFB_FILTER_FILE_MIME` (17) — outer MIME check, raw `file -b --mime-type`
+- `PFB_FILTER_FILE_MIME_COMPRESSED` (18) — inner MIME via `file -bZ --mime-type`
+- `PFB_FILTER_FILE_MIME_COMPARE` (16) — strict exact-match variant
+
+**The problem:** Different archive creators (Info-ZIP, 7-Zip, Windows Explorer,
+Python `zipfile`, .NET, Go, Rust) and ZIP options (extra fields, ZIP64 on small
+files, Unicode filename flags, store vs. deflate) cause `file(1)` to return
+`application/x-zip-compressed`, `application/x-zip`, or occasionally
+`application/octet-stream` for structurally valid ZIPs. Only `application/zip`
+is in the allow-list, so valid blocklist ZIPs from some maintainers are rejected
+before the ZIP dispatch branch is reached. Similar (lower-frequency) variant
+strings exist for gzip variants. This is the direct cause of the existing TODO
+comment and the commented-out `PFB_FILTER_FILE_MIME_COMPRESSED` call in the ZIP
+branch.
+
+**Semantics that MUST be preserved (the contract — pin with tests before swapping):**
+- Files whose raw `file` output is not a known archive variant string must never
+  be promoted through normalisation (e.g. `application/octet-stream` → nothing).
+- Existing hostname-based exceptions in `pfb_filter()` are unchanged.
+- The allow-list itself (`$pfb['mime_types']`) is not modified; normalisation
+  happens before the lookup, not inside it.
+- `PFB_FILTER_FILE_MIME_COMPARE` (constant 16) is unaffected — it performs
+  exact-match comparisons and must continue to do so.
+
+**Explicitly kept out of scope:**
+- Structural integrity tests for archives (ADR-43).
+- ZIP path-traversal hardening (ADR-44).
+- Logging format standardisation (ADR-45).
+- Plain-text heuristic scanning (ADR-46).
+
+---
+
+## 2. Decision
+
+Inside the `PFB_FILTER_FILE_MIME` (17) branch of `pfb_filter()`, after the raw
+`file` output is obtained and before the allow-list lookup, apply a normalisation
+pass using a small, explicit map:
+
+| Raw string (from `file`) | Normalised to |
+|---|---|
+| `application/x-zip-compressed` | `application/zip` |
+| `application/x-zip` | `application/zip` |
+| any string containing `zip` (case-insensitive) | `application/zip` |
+| `application/x-gzip` | `application/gzip` (already in allow-list; make explicit) |
+
+Rules:
+- Normalisation is a **string-rewrite** applied only when the raw value matches a
+  known variant pattern. It never promotes `application/octet-stream` or any
+  other non-archive string.
+- Every normalisation event is logged at pfBlockerNG debug level, recording both
+  the original and normalised string.
+- All existing hostname exceptions are preserved without change.
+- `PFB_FILTER_FILE_MIME_COMPARE` (16) is not modified.
+
+### Per-area decision table
+
+| Area | Decision |
+|---|---|
+| `pfb_filter()` constant 17 | Add `pfb_mime_normalise()` helper; call before allow-list lookup |
+| `pfb_filter()` constant 18 | No change |
+| `pfb_filter()` constant 16 | No change (exact-match; must stay exact) |
+| `$pfb['mime_types']` array | No change |
+| Hostname exceptions | Preserved unchanged |
+| Logging | Debug-level log of raw → normalised, only when normalisation fires |
+
+---
+
+## 3. Consequences
+
+### Positive
+- Eliminates false rejections of valid ZIP feeds packaged by non-canonical tools.
+- Normalisation is isolated to a single named helper — easy to audit and extend.
+- No new external tool dependencies; no allow-list changes.
+- Unblocks ADR-44 (ZIP inner-content validation), which was deferred because ZIPs
+  were being rejected before reaching the validation branch.
+
+### Negative / Risks
+- **Risk:** A too-broad `zip`-substring match promotes a misidentified file.
+  **Mitigation:** Normalisation fires only when `file` already returned something
+  containing `zip` — random `octet-stream` is never promoted. Oracle tests
+  enumerate the exact variant strings; any new variant requires an explicit entry.
+- **Risk:** Normalisation masks a real format change in a feed.
+  **Mitigation:** Debug-level logging records the raw string; always visible when
+  investigating a download.
+- The normalisation table must be maintained as new creators or magic-db changes
+  surface (expected to be low frequency; low burden).
+
+---
+
+## 4. Requirements (acceptance)
+
+- `pfb_mime_normalise()` is a pure PHP function (string in → string out; no I/O).
+- Unit tests cover: all listed variant strings → correct canonical; strings NOT in
+  the map → returned unchanged; case-insensitive `zip` variants; `application/octet-stream`
+  → unchanged.
+- All existing `pfb_filter()` call-sites remain green (oracle regression suite).
+- `vendor/bin/phpunit` → green; `ruff check` / `shellcheck` → clean (no PHP files
+  other than `pfblockerng.inc` touched in the implementation phases).
+- Debug log output is observable in a manual smoke run.
+
+---
+
+## 5. Constraints (from CLAUDE.md)
+
+- PHP 8.3; FreeBSD stdlib only (no Composer packages added for production code).
+- Commit style: `<scope>: <imperative summary> (ADR-42 PN)`.
+- Branch: `adr/42-mime-normalisation` off `devel`; inline commits, push directly;
+  PR only if direct push rejected.
+- No live Unbound in CI — PHP unit tests only; manual smoke checklist for the
+  live-box run.
+- Every behaviour-changing phase must have a test that **fails before / passes after**
+  (red → green evidence recorded in handoff).
+
+---
+
+## 6. Action plan
+
+### Phase 1 — Extract and oracle-pin the current `pfb_filter()` MIME path
+
+**Prompt:** `01_Extract_Oracle_Tests.txt`
+
+Extract the MIME-string handling logic from `pfb_filter()` (constants 16–18) into
+clearly named, pure helper functions, and lay down oracle/regression tests that
+pin the current behaviour **before** the normalisation change is made. These tests
+stay green through all subsequent phases.
+
+Tests this phase adds:
+- `test_pfb_filter_mime_allows_canonical_zip()` — `application/zip` passes gate.
+- `test_pfb_filter_mime_rejects_x_zip_compressed()` — `application/x-zip-compressed`
+  currently **fails** gate (this is the bug; record the red result in handoff).
+- `test_pfb_filter_mime_rejects_x_zip()` — `application/x-zip` currently fails gate.
+- `test_pfb_filter_mime_allows_canonical_gzip()` — `application/gzip` passes.
+- `test_pfb_filter_mime_rejects_octet_stream()` — `application/octet-stream` fails.
+
+### Phase 2 — Implement `pfb_mime_normalise()` and wire into constant 17
+
+**Prompt:** `02_Implement_Normalise.txt`
+
+Add the `pfb_mime_normalise(string $raw): string` helper and call it inside the
+`PFB_FILTER_FILE_MIME` (17) branch of `pfb_filter()`. Add debug-level logging.
+
+Tests this phase adds (these must **fail on Phase 1 code, pass after**):
+- `test_normalise_x_zip_compressed_to_zip()`
+- `test_normalise_x_zip_to_zip()`
+- `test_normalise_zip_substring_variants()`
+- `test_normalise_x_gzip_to_gzip()`
+- `test_normalise_octet_stream_unchanged()`
+- `test_normalise_unknown_string_unchanged()`
+- Integration: `test_pfb_filter_mime_accepts_x_zip_compressed_after_normalise()`
+
+### Phase 3 — Remove stale TODO; update inline documentation
+
+**Prompt:** `03_Cleanup_TODO.txt`
+
+Remove the TODO comment block referencing the `_COMPRESSED` incompatibility in
+the ZIP branch. Replace with a reference to ADR-42 and ADR-44. Update any other
+inline comments in `pfb_filter()` that describe the old, un-normalised flow.
+Behaviour-preserving; all oracle tests from Phase 1 stay green.
+
+### Phase 4 — Smoke checklist + mark Accepted
+
+**Prompt:** `04_Smoke_And_Accept.txt`
+
+Produce the manual smoke checklist document (see §7). Update ADR.md status to
+`Accepted` once the maintainer confirms smoke results. No code change in this
+phase.
+
+---
+
+## 7. Definition of Done
+
+**Automated (CI must be green):**
+- `vendor/bin/phpunit` → all tests green, including the red→green suite from Phase 2.
+- `shellcheck` → clean on any shell fragments touched.
+- No regressions in the existing pfBlockerNG test suite.
+
+**Manual smoke checklist (owner: maintainer — no live Unbound in CI):**
+- [ ] Download a blocklist feed served as a ZIP created by Python `zipfile` (or 7-Zip / Windows
+  Explorer); confirm it passes the MIME gate and is processed normally.
+- [ ] Download a feed whose ZIP previously triggered the `x-zip-compressed` rejection; confirm
+  it now succeeds.
+- [ ] Download a feed served as `application/gzip`; confirm it still passes (no regression).
+- [ ] Enable pfBlockerNG debug logging; confirm normalisation events appear when a variant
+  string is encountered (`raw: "application/x-zip-compressed" -> canonical: "application/zip"`).
+- [ ] Download a feed that returns a genuine HTML error page; confirm it is still rejected.
+
+**Reject criteria:**
+- Any feed that previously succeeded now fails after normalisation.
+- `application/octet-stream` is ever promoted through the normalisation path.
+- `PFB_FILTER_FILE_MIME_COMPARE` (16) behaviour changes in any way.


### PR DESCRIPTION
## ADR-44: Normalise MIME-type strings before the allow-list gate in pfb_filter()

### Problem

Valid blocklist feeds packaged as ZIP files by non-canonical tools (Python zipfile,
7-Zip, Windows Explorer, .NET, Go, Rust) are rejected by pfb_filter() because
file(1) returns variant strings like `application/x-zip-compressed` or
`application/x-zip` that are not in $pfb['mime_types']. Only `application/zip`
is in the allow-list, so the feed is dropped before the ZIP dispatch branch is
even reached.

### This ADR

Introduces a pure PHP helper `pfb_mime_normalise()` that rewrites known variant
strings to their canonical forms before the allow-list lookup — fixing the
rejections without modifying the allow-list itself.

### Phases

| Phase | Description | Type |
|---|---|---|
| P1 | Extract `pfb_mime_in_allowlist()` + oracle tests | Behaviour-preserving |
| P2 | Add `pfb_mime_normalise()` + wire into constant 17 | Fix (red → green) |
| P3 | Remove stale ZIP-MIME TODO; reference ADR-42/ADR-44 | Behaviour-preserving |
| P4 | Smoke checklist + maintainer sign-off | Documentation |

### Files

- `.ADRs/ADR_44_MIME_Normalization/ADR.md` — decision record
- `.ADRs/ADR_44_MIME_Normalization/01_Extract_Oracle_Tests.txt`
- `.ADRs/ADR_44_MIME_Normalization/02_Implement_Normalise.txt`
- `.ADRs/ADR_44_MIME_Normalization/03_Cleanup_TODO.txt`
- `.ADRs/ADR_44_MIME_Normalization/04_Smoke_And_Accept.txt`

### Status

Proposed — pending implementation via `/adr-phase 44 all` and maintainer smoke sign-off.

Relates to ADR-45 (structural integrity tests), ADR-46 (ZIP inner-content + path traversal).