### PR TITLE
tests/smoke: anchor rule_references' loose fallback to pfB-owned aliases

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3610,12 +3610,21 @@ def rule_references(vm: SmokeVM, alias: str, *, timeout: float = 30.0, attempts:
     update CLI returns, so poll rather than read once (the rule was observed
     present in on-failure diagnostics dumped moments after a single-shot read
     returned False — a pure timing race).
+
+    CONTRACT: ``alias`` SHOULD be a pfBlockerNG-owned table name (``pfB_<header>_v{4,6}``,
+    ``pfB_DNSBLIP_v4``, ``pfB_*_Aggregated_v4`` …) — every in-tree caller passes one. The
+    exact ``<alias>`` pf table-reference is always matched; the looser bare-substring
+    fallback (a rule that names the table without the ``<>`` syntax) is gated behind the
+    ``pfB_`` prefix so a generic token can NEVER coincidentally match a FOREIGN rule — e.g.
+    a baked ``CI HARNESS RULE`` or the floating ``REJECT ALL OUT MGT1``. A non-``pfB_``
+    alias is still honoured, via the exact table-reference match alone.
     """
+    pfb_owned = alias.startswith("pfB_")
     for attempt in range(attempts):
         result = vm.ssh(PFCTL, "-sr", timeout=timeout)
         if result.returncode != 0:
             raise RuntimeError(f"pfctl -sr failed: rc={result.returncode} stderr={result.stderr!r}")
-        if any(f"<{alias}>" in line or alias in line for line in result.stdout.splitlines()):
+        if any(f"<{alias}>" in line or (pfb_owned and alias in line) for line in result.stdout.splitlines()):
             return True
         if attempt < attempts - 1:
             time.sleep(delay)


### PR DESCRIPTION
## What

`rule_references()` matched a pf rule via an exact `<alias>` table-reference **or** a bare `alias in line` substring. The substring fallback could coincidentally match a **foreign** rule whose text contains the token — e.g. the baked, immutable `CI HARNESS RULE` or the floating `REJECT ALL OUT MGT1` rule the new smoke image will ship. This gates the loose fallback behind the `pfB_` prefix so a generic token can never match a non-pfB rule; the exact `<alias>` table-reference still matches any alias.

## Why it's safe

Behaviour-preserving: every in-tree caller passes a pfBlockerNG-owned table name (`pfB_<header>_v{4,6}`, `pfB_DNSBLIP_v4`, `pfB_*_Aggregated_v4`), so the gated fallback is identical for all of them — the change only removes a latent foreign-rule false-match and documents the alias-ownership contract. No live VM needed to validate.

## Context

This is the safe slice of the `CI HARNESS RULE` collision-audit hardening. Two other candidate matchers were **not** changed:

- **`test_dot_doq_block._is_block_853_line`** — anchoring its loose `block`+`853` match on the pfB DoT descr was attempted but the descr does **not** render into plain `pfctl -sr` (pfBlockerNG sets no custom pf `label`), and the DoT rule could not be created on the minimal single-VM hermetic box to validate a correct anchor. Left as-is; the baked rules are not port-853 blocks so it cannot false-match them anyway.
- **`test_syslog_export._wait_for_event`** — the filterlog daemon emits **only pfB-owned** events, so a foreign rule produces no matchable line; a victim-dst anchor needs a two-VM (civm) dispatch to verify the event line format.

Both are tracked as defensive follow-ups in #582 (to anchor against the real rendered output once the image is baked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
