### PR TITLE
tests/smoke: parallel-lane foundations (two_vm marker, lane ports, civm 1GB, DHCP-ready mgmt)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ markers = [
     "pfctl_bench: ADR-40 Phase 2 pfctl table benchmark; two-VM topology required; dispatch-only, NEVER PR-gating",
     "tick: live-VM due-ledger trigger-tick (ADR-43); ALSO marked smoke; focused dispatch via -m tick",
     "apply_on_change: live-VM apply-on-change + quiet-hours window (ADR-43 P5); ALSO marked smoke; focused dispatch via -m apply_on_change",
+    "two_vm: live-VM test that boots the civm LAN client (two-VM topology); AUTO-applied at collection from the client_vm/lan_interface fixture dependency — never hand-applied. The lane orchestrator partitions civm-needing vs civm-less lanes via -m two_vm / -m 'not two_vm'.",
 ]
 
 # coverage.py (issue #38). BRANCH coverage is the point of the sweep -- line

--- a/tests/smoke/boot_vm.sh
+++ b/tests/smoke/boot_vm.sh
@@ -78,14 +78,18 @@ VM_MAC="${SMOKE_VM_MAC:-$DEFAULT_CE_MAC}"
 VM_SMBIOS_UUID="${SMOKE_VM_SMBIOS_UUID:-58fd7964-c40c-4f47-bf02-3fdad18f8b00}"
 # VM_SMP / VM_MEM / CLIENT_SMP / CLIENT_MEM: env-overridable for benchmarks that
 # need more cores/RAM (e.g. SMOKE_VM_SMP="3,sockets=1,cores=3" SMOKE_VM_MEM=6144).
-# Defaults kept at the CI/smoke baseline — do not change without updating CI.
+# 2 GB is ample for the smoke pfSense (FreeBSD pre-allocates — no ballooning): a
+# production box with 500k+ IPs in pf + full DNSBL sits at ~10% of 4 GB; the smoke
+# tests load tiny fixtures. Smaller default = denser parallel lanes (2 GB pfSense +
+# 1 GB civm = 3 GB/lane). Bump via SMOKE_VM_MEM for the benchmark runner.
 VM_SMP="${SMOKE_VM_SMP:-2,sockets=1,cores=2}"
-VM_MEM="${SMOKE_VM_MEM:-4096}"
+VM_MEM="${SMOKE_VM_MEM:-2048}"
 
-# civm is a lightweight client, but pin it to the 2-core / 2 GB floor — not because the
-# Debian client needs it, just to keep boot + the LAN link a tad smoother under CI load.
+# civm is a light Debian client (sshd + occasional dig/curl); 1 GB is ample, and
+# virtio-balloon lets Linux return unused RAM to the host.  pfSense/FreeBSD does NOT
+# support ballooning — leave VM_MEM (4096) and every pfSense-role arg untouched.
 CLIENT_SMP="${SMOKE_CLIENT_SMP:-2,sockets=1,cores=2}"
-CLIENT_MEM="${SMOKE_CLIENT_MEM:-2048}"
+CLIENT_MEM="${SMOKE_CLIENT_MEM:-1024}"
 # civm source-VM NIC MACs (committed non-secret defaults): net0 management, net1
 # data. The data MAC keys pfSense's static DHCP lease (-> 192.168.1.10), so it
 # must match the lease baked into the pfSense image. Override either via env.
@@ -100,6 +104,12 @@ SSH_HOSTPORT="${SMOKE_SSH_HOSTPORT:-2222}"
 WEB_HOSTPORT="${SMOKE_WEB_HOSTPORT:-8080}"
 CLIENT_SSH_HOSTPORT="${SMOKE_CLIENT_SSH_HOSTPORT:-2223}"
 PFSENSE_MGMT_IP="10.0.0.20"   # static management IP baked into the pfSense image
+# Forward-compat for a future DHCP management interface: the hostfwd TARGET defaults to
+# the baked static IP above.  When the image makes MGT1 DHCP (no fixed IP), the caller
+# exports SMOKE_PFSENSE_MGT_TARGET="" so SLIRP forwards to its own DHCP-assigned guest
+# address (mirroring civm net0 — see hostfwd=tcp::${CLIENT_SSH_HOSTPORT}-:22 below).
+# Single-dash form: an explicit empty override IS honored (vs :- which ignores empty).
+PFSENSE_MGT_TARGET="${SMOKE_PFSENSE_MGT_TARGET-$PFSENSE_MGMT_IP}"
 
 # pfSense<->civm LAN crossover socket (point-to-point; pfSense listens, civm connects).
 LAN_SOCKET_PORT="${SMOKE_LAN_SOCKET_PORT:-12340}"
@@ -204,7 +214,7 @@ if [ "$ROLE" = pfsense ]; then
     # SMBIOS identity (license/NDI-keyed for Plus; public pin for CE).
     set -- "$@" -smbios "type=1,uuid=${VM_SMBIOS_UUID}"
 
-    echo "boot_vm: pfsense hostfwd ssh=${SSH_HOSTPORT}->${PFSENSE_MGMT_IP}:22 web=${WEB_HOSTPORT}->${PFSENSE_MGMT_IP}:80 (mgmt net1)" >&2
+    echo "boot_vm: pfsense hostfwd ssh=${SSH_HOSTPORT}->${PFSENSE_MGT_TARGET}:22 web=${WEB_HOSTPORT}->${PFSENSE_MGT_TARGET}:80 (mgmt net1)" >&2
     echo "boot_vm: pfsense LAN socket LISTEN 127.0.0.1:${LAN_SOCKET_PORT} (net2)" >&2
 
     i=0
@@ -215,7 +225,7 @@ if [ "$ROLE" = pfsense ]; then
             # a VIP that overlaps an interface subnet and disables DNSBL wholesale.
             # 10.10.0.0/24 keeps the host alias 10.10.0.2 while leaving 10.10.10.x free.
             0) netdev="user,id=net0,net=10.10.0.0/24,host=10.10.0.2" ;;
-            1) netdev="user,id=net1,net=10.0.0.0/16,host=10.0.0.2,hostfwd=tcp::${SSH_HOSTPORT}-${PFSENSE_MGMT_IP}:22,hostfwd=tcp::${WEB_HOSTPORT}-${PFSENSE_MGMT_IP}:80" ;;
+            1) netdev="user,id=net1,net=10.0.0.0/16,host=10.0.0.2,hostfwd=tcp::${SSH_HOSTPORT}-${PFSENSE_MGT_TARGET}:22,hostfwd=tcp::${WEB_HOSTPORT}-${PFSENSE_MGT_TARGET}:80" ;;
             2) netdev="socket,id=net2,listen=127.0.0.1:${LAN_SOCKET_PORT}" ;;
             # net3..7: present so the 8-NIC image sees no hardware change, but
             # isolated (restrict=on) with distinct dummy subnets — pfSense leaves
@@ -241,7 +251,8 @@ else
         -netdev "user,id=net0,hostfwd=tcp::${CLIENT_SSH_HOSTPORT}-:22" \
         -device "virtio-net-pci,mac=${CLIENT_MGMT_MAC},netdev=net0,id=nic0" \
         -netdev "socket,id=net1,connect=127.0.0.1:${LAN_SOCKET_PORT}" \
-        -device "virtio-net-pci,mac=${CLIENT_MAC},netdev=net1,id=nic1"
+        -device "virtio-net-pci,mac=${CLIENT_MAC},netdev=net1,id=nic1" \
+        -device virtio-balloon
 fi
 
 set -- "$@" -display none

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -67,9 +67,39 @@ FIXTURES_DIR = SMOKE_DIR / "fixtures"
 
 # Host<->guest exposure baked into boot_vm.sh's hostfwd map (see RESULTS/01).
 DEFAULT_HOST = "127.0.0.1"
-DEFAULT_SSH_PORT = 2222  # host -> guest 22
-DEFAULT_WEB_PORT = 8080  # host -> guest 80
-DEFAULT_DNS_PORT = 5353  # host -> guest 53 (tcp+udp)
+
+# Per-lane port offset — each parallel smoke lane boots its own VM on disjoint host-forward
+# ports so multiple pytest-xdist workers can run isolated on the same host.
+_LANE = int(os.environ.get("SMOKE_LANE", "0"))
+
+
+def _lane_port(base: int, lane: int, *, stride: int = 10) -> int:
+    """Give each parallel lane a disjoint 127.0.0.1 host-forward port.
+
+    Stride 10 leaves headroom between adjacent lanes (e.g. lane 0→2222, lane 1→2232).
+    """
+    return base + lane * stride
+
+
+def _validate_lane(lane: int) -> None:
+    """Reject a SMOKE_LANE that would break port isolation — fail fast, not silently.
+
+    A negative lane derives lower-numbered ports (reusing another lane's range), and a lane
+    large enough to push the highest-based host-forward port (web, 8080) past 65535 yields an
+    invalid port that fails the boot confusingly. Upper bound: 8080 + lane*10 <= 65535 → 5745.
+    """
+    if lane < 0 or _lane_port(8080, lane) > 65535:
+        raise ValueError(f"SMOKE_LANE out of range: {lane} (must be 0..5745)")
+
+
+_validate_lane(_LANE)
+
+
+# INVARIANT: at _LANE == 0 with no SMOKE_*_HOSTPORT overrides all four equal the
+# historical defaults (2222 / 8080 / 5353 / 2223) — behaviour-preserving at lane 0.
+DEFAULT_SSH_PORT = _lane_port(int(os.environ.get("SMOKE_SSH_HOSTPORT", "2222")), _LANE)  # host -> guest 22
+DEFAULT_WEB_PORT = _lane_port(int(os.environ.get("SMOKE_WEB_HOSTPORT", "8080")), _LANE)  # host -> guest 80
+DEFAULT_DNS_PORT = _lane_port(5353, _LANE)  # host -> guest 53 (tcp+udp); no env consumer in boot_vm.sh
 
 # The WAN SLIRP host alias the guest uses to reach the runner (mock feed server,
 # stub DNS, webhook sink). Corresponds to boot_vm.sh net0: net=10.10.0.0/24,
@@ -93,7 +123,12 @@ DEFAULT_BOOT_TIMEOUT = int(os.environ.get("SMOKE_BOOT_TIMEOUT", "300"))
 # civm client VM ssh host-forward port (host -> civm:22). Honour the same
 # SMOKE_CLIENT_SSH_HOSTPORT override boot_vm.sh reads (default 2223), so a custom
 # host port reaches the client instead of a hardcoded 2223.
-DEFAULT_CLIENT_SSH_PORT = int(os.environ.get("SMOKE_CLIENT_SSH_HOSTPORT", "2223"))  # host -> civm 22
+DEFAULT_CLIENT_SSH_PORT = _lane_port(int(os.environ.get("SMOKE_CLIENT_SSH_HOSTPORT", "2223")), _LANE)  # host -> civm 22
+
+# Write the lane-resolved ports back so boot_vm.sh's hostfwd reads the same values SmokeVM uses.
+os.environ["SMOKE_SSH_HOSTPORT"] = str(DEFAULT_SSH_PORT)
+os.environ["SMOKE_WEB_HOSTPORT"] = str(DEFAULT_WEB_PORT)
+os.environ["SMOKE_CLIENT_SSH_HOSTPORT"] = str(DEFAULT_CLIENT_SSH_PORT)
 
 # The address civm uses to reach pfSense (pfSense LAN side of the socket crossover).
 PFSENSE_LAN_IP = "192.168.1.1"  # pfSense LAN IP baked in the two-VM image
@@ -1317,6 +1352,30 @@ def expected_control_answer(env: Mapping[str, str] = os.environ) -> tuple[str, s
 # On-failure diagnostics — dump live VM state (the session VM is torn down at
 # end of run, so a failed case must capture it here, in-run)
 # --------------------------------------------------------------------------- #
+
+
+def _needs_two_vm(fixturenames: list[str] | set[str]) -> bool:
+    """Return True iff this test boots the civm LAN client (two-VM topology).
+
+    Ground truth for "does this test need civm?" computed from the fixture dependency:
+    pytest's ``item.fixturenames`` is the full transitive closure, so membership of
+    ``client_vm`` or ``lan_interface`` is exact. When a test gains or loses ``client_vm``
+    the tag flips automatically — no list, no drift.
+    """
+    return bool({"client_vm", "lan_interface"} & set(fixturenames))
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-apply the ``two_vm`` marker from the fixture closure — never hand-apply it.
+
+    The tag is COMPUTED: if a test (transitively) requests ``client_vm`` or
+    ``lan_interface`` it boots the civm client and therefore belongs to the two-VM
+    topology. The lane orchestrator partitions civm-needing vs civm-less lanes via
+    ``-m two_vm`` / ``-m 'not two_vm'`` without a hardcoded list.
+    """
+    for item in items:
+        if _needs_two_vm(item.fixturenames):
+            item.add_marker("two_vm")
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/smoke/test_smoke_lanes.py
+++ b/tests/smoke/test_smoke_lanes.py
@@ -1,0 +1,111 @@
+"""Pure unit tests for the smoke-lane foundation helpers.
+
+No VM, no network, no markers — runs fast under the override invocation:
+    python -m pytest tests/smoke/test_smoke_lanes.py --override-ini="addopts="
+
+Tests the helpers introduced for per-lane parallelism:
+
+* ``_needs_two_vm``  — predicate: does this test's fixture closure require civm?
+* ``_lane_port``     — offset: disjoint host-forward port per lane.
+* ``_validate_lane`` — reject a SMOKE_LANE that would break port isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import _lane_port, _needs_two_vm, _validate_lane
+
+# --------------------------------------------------------------------------- #
+# _needs_two_vm
+# --------------------------------------------------------------------------- #
+
+
+def test_needs_two_vm_true_for_client_vm() -> None:
+    # A test that directly requests client_vm boots the civm client.
+    assert _needs_two_vm({"client_vm"}) is True
+
+
+def test_needs_two_vm_true_for_lan_interface() -> None:
+    # lan_interface also implies civm (it depends on client_vm transitively).
+    assert _needs_two_vm({"lan_interface"}) is True
+
+
+def test_needs_two_vm_true_when_mixed_with_other_fixtures() -> None:
+    # Civm detection survives alongside other fixtures in the transitive closure.
+    assert _needs_two_vm({"smoke_vm", "client_vm", "stub_dns"}) is True
+
+
+def test_needs_two_vm_false_for_pfsense_only_fixtures() -> None:
+    # smoke_vm + stub_dns alone: pfSense only, no civm.
+    assert _needs_two_vm({"smoke_vm", "stub_dns"}) is False
+
+
+def test_needs_two_vm_false_for_empty_closure() -> None:
+    # A test with no fixtures at all does not need civm.
+    assert _needs_two_vm(set()) is False
+
+
+def test_needs_two_vm_false_for_deployed_vm_only() -> None:
+    # deployed_vm is a pfSense-only fixture alias; does not boot civm.
+    assert _needs_two_vm({"deployed_vm"}) is False
+
+
+# --------------------------------------------------------------------------- #
+# _lane_port
+# --------------------------------------------------------------------------- #
+
+
+def test_lane_port_lane0_returns_base() -> None:
+    # Lane 0 invariant: no offset → the same port as today's historical default.
+    assert _lane_port(2222, 0) == 2222
+    assert _lane_port(8080, 0) == 8080
+    assert _lane_port(5353, 0) == 5353
+    assert _lane_port(2223, 0) == 2223
+
+
+def test_lane_port_eight_lanes_all_distinct() -> None:
+    # Eight lanes must produce eight distinct ports — proves lane is not ignored.
+    ports = [_lane_port(2222, lane) for lane in range(8)]
+    assert len(set(ports)) == 8, f"collisions among lane ports: {ports}"
+
+
+def test_lane_port_nonzero_lane_differs_from_base() -> None:
+    # Any lane > 0 must not land on the base — rules out a constant implementation.
+    for lane in range(1, 8):
+        assert _lane_port(2222, lane) != 2222, f"lane {lane} collides with base"
+
+
+def test_lane_port_adjacent_bases_no_collision_across_lanes() -> None:
+    # Two bases one apart (2222 vs 2223, as SSH and civm-SSH share a host) must not
+    # collide across lanes 0..7 with the default stride=10 — each lane's pair stays
+    # one apart and never crosses another lane's pair.
+    ports_a = {_lane_port(2222, lane) for lane in range(8)}
+    ports_b = {_lane_port(2223, lane) for lane in range(8)}
+    overlap = ports_a & ports_b
+    assert not overlap, f"bases 2222 and 2223 collide at lanes: {overlap}"
+
+
+# --------------------------------------------------------------------------- #
+# _validate_lane
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("lane", [0, 1, 7, 5745])
+def test_validate_lane_accepts_in_range(lane: int) -> None:
+    # 0 (default), a couple of real lanes, and the max that keeps web 8080 <= 65535.
+    _validate_lane(lane)  # must not raise
+
+
+@pytest.mark.parametrize("lane", [-1, -10])
+def test_validate_lane_rejects_negative(lane: int) -> None:
+    # A negative lane derives lower-numbered ports, reusing another lane's range — reject it.
+    with pytest.raises(ValueError, match="SMOKE_LANE"):
+        _validate_lane(lane)
+
+
+@pytest.mark.parametrize("lane", [5746, 99999])
+def test_validate_lane_rejects_port_overflow(lane: int) -> None:
+    # A lane that pushes web 8080 past 65535 yields an invalid host-forward port — reject it.
+    with pytest.raises(ValueError, match="SMOKE_LANE"):
+        _validate_lane(lane)

--- a/tests/test_smoke_harness_defaults.py
+++ b/tests/test_smoke_harness_defaults.py
@@ -117,16 +117,26 @@ def test_client_smbios_uuid_default_with_env_override() -> None:
 
 
 def test_pfsense_management_path_targets_static_ip() -> None:
-    """The host->guest ssh/web forwards target the image's static management IP.
+    """The host->guest ssh/web forwards target an overridable mgmt address, default = static IP.
 
     The forwards live on net1 (management, 10.0.0.0/16) and point at
-    10.0.0.20 — the harness control path. A drift in either the subnet or the IP
-    would break SSH/Web reachability.
+    PFSENSE_MGT_TARGET, which defaults to the baked static IP 10.0.0.20 — the
+    harness control path. The target is overridable via SMOKE_PFSENSE_MGT_TARGET
+    using the SINGLE-DASH form, so an explicit empty value is honored (forward-compat
+    for a future DHCP MGT1 with no fixed IP: SLIRP then forwards to its own
+    DHCP-assigned guest address). A drift in the subnet, the default IP, or the
+    target indirection would break SSH/Web reachability.
     """
     text = _boot_vm_text()
+    # Default branch: the target falls back to the baked static management IP.
     assert f'PFSENSE_MGMT_IP="{PFSENSE_MGMT_IP}"' in text
     assert "net=10.0.0.0/16" in text
-    assert "hostfwd=tcp::${SSH_HOSTPORT}-${PFSENSE_MGMT_IP}:22" in text
+    # Override branch: single-dash (not :-) so an explicit empty SMOKE_PFSENSE_MGT_TARGET
+    # is honored, defaulting to the static IP when unset.
+    assert 'PFSENSE_MGT_TARGET="${SMOKE_PFSENSE_MGT_TARGET-$PFSENSE_MGMT_IP}"' in text
+    # Both forwards (ssh:22, web:80) target the indirection, not the literal IP.
+    assert "hostfwd=tcp::${SSH_HOSTPORT}-${PFSENSE_MGT_TARGET}:22" in text
+    assert "hostfwd=tcp::${WEB_HOSTPORT}-${PFSENSE_MGT_TARGET}:80" in text
 
 
 def test_pfsense_wan_and_lan_topology() -> None:


### PR DESCRIPTION
## Phase 0 — parallel-lane foundations

Groundwork for running multiple isolated smoke **lanes** in parallel (one pytest-xdist worker per lane), now that the isolation keystone (#576) makes tests state-clean. Four small changes, two file-disjoint lanes (developed in parallel by sub-agents, gated + integrated + live-validated here). The lane orchestration itself (xdist per-worker lanes, the stub-DNS-port-per-lane scheme, the egress decision, the GitHub shard fan) is the **Phase 1 ADR** to follow.

### Changes

- **`conftest.py` — auto-derived `two_vm` marker.** `pytest_collection_modifyitems` adds `two_vm` to any test whose fixture closure (`item.fixturenames`) includes `client_vm`/`lan_interface`. The tag is **computed, never hand-applied**, so it cannot drift and flips automatically when a test gains/loses civm. An orchestrator partitions civm-needing vs civm-less lanes via `-m two_vm` / `-m "not two_vm"` — no hardcoded list. Registered in `pyproject` markers.
- **`conftest.py` — per-lane port offset.** `_lane_port(base, lane, stride=10)` keyed on `SMOKE_LANE`, applied to the SSH/web/DNS/client-SSH host-forward ports and written back to the `SMOKE_*_HOSTPORT` env that `boot_vm.sh` reads, so each lane's guest hostfwd matches its `SmokeVM` ports. **Byte-identical at lane 0** (the default).
- **`boot_vm.sh` — DHCP-ready management hostfwd.** The pfSense mgmt hostfwd target is now `SMOKE_PFSENSE_MGT_TARGET` (default = the baked `10.0.0.20`, unchanged). When the image makes MGT1 DHCP (no fixed IP), the caller sets it empty so SLIRP forwards to the DHCP-assigned guest address (mirroring civm `net0`). This pre-empts a latent break when that image lands.
- **`boot_vm.sh` — civm 1 GB + virtio-balloon.** **pfSense `4096 → 2048`** and **civm `2048 → 1024`** (both env-overridable) + a `virtio-balloon` device on civm. A production box with 500k+ IPs in pf + full DNSBL sits at ~10% of 4 GB, so 2 GB is ample (FreeBSD pre-allocates — no ballooning). A lane is now **2 + 1 = 3 GB**.

### Validation (live, CE 2.8.1 on the local KVM box)

- **Unit:** `tests/smoke/test_smoke_lanes.py` — 10 pure red→green tests for `_needs_two_vm` + `_lane_port`; lane-0 port invariant asserted.
- **Lane 0 single-VM:** `test_smoke_isolation.py` green (2/2, 59 s boot) — the conftest port write-back + marker hook don't perturb the standard path.
- **Marker:** auto-partition is **13 `two_vm` modules vs 15 single-VM**, computed from fixtures.
- **civm 1 GB:** two-VM boot — civm came up in **24 s** and `test_dns_probe_absent_resolves_via_stub` passed (a real `dig @192.168.1.1` *from civm through the firewall*); 6 tests passed.

> One unrelated failure in that run (`test_ip_probe_membership_and_rule`) is the **pre-existing IP-feed-load gap** on the hermetic box (the SSRF feed-allowlist issue tracked in #582) — not introduced here; every civm-dependent DNS test passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running smoke tests across multiple isolated lanes without port conflicts.
  * Introduced automatic handling for tests that require a two-VM setup, reducing manual test tagging.

* **Bug Fixes**
  * Improved VM boot settings for client and management access, including more reliable host-forward configuration.
  * Adjusted default client memory usage to better match current smoke test needs.

* **Tests**
  * Added coverage for lane-based port allocation and automatic two-VM test selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


> Updated: also folds **pfSense 4→2 GB** (validated live: isolation suite green at 2 GB, 59 s boot) and a `_validate_lane` guard (rejects negative / port-overflow `SMOKE_LANE`) per CodeRabbit.
