### PR TITLE
tests/smoke: faster boot-readiness poll (Phase 0c)

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -117,8 +117,11 @@ GUEST_TO_HOST_ALIAS = "10.10.0.2"
 STUB_DNS_A = stub_responses.STUB_DNS_A  # RFC 5737 documentation range
 STUB_DNS_AAAA = stub_responses.STUB_DNS_AAAA  # RFC 3849 documentation range
 
-# Hard readiness ceiling; wait_ready.sh polls (no fixed sleep) up to this.
-DEFAULT_BOOT_TIMEOUT = int(os.environ.get("SMOKE_BOOT_TIMEOUT", "300"))
+# Hard readiness ceiling for wait_ready.sh's poll (8s grace -> 1s, then 5s past
+# 30s). Both VMs reach ready in well under a minute, and a dead qemu fails the poll
+# IMMEDIATELY via its PID watch (not by burning this ceiling), so ~1 min is ample;
+# raise SMOKE_BOOT_TIMEOUT for an unusually slow runner.
+DEFAULT_BOOT_TIMEOUT = int(os.environ.get("SMOKE_BOOT_TIMEOUT", "60"))
 
 # civm client VM ssh host-forward port (host -> civm:22). Honour the same
 # SMOKE_CLIENT_SSH_HOSTPORT override boot_vm.sh reads (default 2223), so a custom
@@ -293,9 +296,10 @@ def boot_and_probe(
     REUSES the shell helpers over subprocess:
       * ``boot_vm.sh`` creates the ephemeral copy-on-write overlay (the base is
         read-only and never mutated — run-level immutability) and execs qemu;
-      * ``wait_ready.sh`` polls SSH + WebUI readiness with bounded backoff and a
-        hard timeout (NO fixed sleep), and bails immediately if the qemu PID
-        dies (bad image / KVM abort).
+      * ``wait_ready.sh`` polls WebUI readiness (the pfSense gate; nginx+PHP up
+        implies sshd is too) on an 8s-grace -> 1s -> 5s cadence with a hard
+        timeout (NO fixed sleep), and bails immediately if the qemu PID dies
+        (bad image / KVM abort).
 
     On readiness, returns a :class:`BootHandle`. On timeout or a dead qemu it
     raises, after killing qemu. Designed to be callable outside pytest (a CE
@@ -327,7 +331,8 @@ def boot_and_probe(
 
     try:
         # wait_ready.sh <ssh-key> [host] [port] [timeout] [vm-pid] [web-port].
-        # Passing web_port makes readiness require nginx+PHP, not just sshd.
+        # Passing web_port selects the pfSense gate: readiness = the webConfigurator
+        # answering (nginx+PHP), which comes up after sshd.
         result = subprocess.run(
             [
                 "sh",

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -118,10 +118,11 @@ STUB_DNS_A = stub_responses.STUB_DNS_A  # RFC 5737 documentation range
 STUB_DNS_AAAA = stub_responses.STUB_DNS_AAAA  # RFC 3849 documentation range
 
 # Hard readiness ceiling for wait_ready.sh's poll (8s grace -> 1s, then 5s past
-# 30s). Both VMs reach ready in well under a minute, and a dead qemu fails the poll
-# IMMEDIATELY via its PID watch (not by burning this ceiling), so ~1 min is ample;
-# raise SMOKE_BOOT_TIMEOUT for an unusually slow runner.
-DEFAULT_BOOT_TIMEOUT = int(os.environ.get("SMOKE_BOOT_TIMEOUT", "60"))
+# 75s). Measured web-ready is ~15s on a fast bare-metal host but ~55-60s on a
+# nested-KVM / low-power box, and parallel-lane CPU contention pushes it higher, so
+# ~3 min leaves headroom; a dead qemu still fails IMMEDIATELY via its PID watch (not
+# by burning this ceiling). Raise SMOKE_BOOT_TIMEOUT for an unusually slow runner.
+DEFAULT_BOOT_TIMEOUT = int(os.environ.get("SMOKE_BOOT_TIMEOUT", "180"))
 
 # civm client VM ssh host-forward port (host -> civm:22). Honour the same
 # SMOKE_CLIENT_SSH_HOSTPORT override boot_vm.sh reads (default 2223), so a custom

--- a/tests/smoke/wait_ready.sh
+++ b/tests/smoke/wait_ready.sh
@@ -6,7 +6,7 @@
 #   tests/smoke/wait_ready.sh <ssh-key> [host] [port] [timeout-seconds] \
 #       [vm-pid] [web-port]
 #
-# Defaults: host 127.0.0.1, port 2222, timeout 600s, vm-pid (none),
+# Defaults: host 127.0.0.1, port 2222, timeout 60s, vm-pid (none),
 # web-port (none → SSH-only readiness).
 #
 # On success: prints "boot-to-ready: <N> seconds", then exits 0. On timeout:
@@ -16,13 +16,18 @@
 # comes up (e.g. the image failed to open, KVM aborted), we exit 1 IMMEDIATELY
 # rather than burning the whole timeout polling a guest that will never answer.
 #
-# Readiness requires BOTH:
-#   - a working SSH command (`true`) over the host-forwarded port with the baked
-#     test key — sshd is up and the WAN pass rule lets the runner in; and
-#   - if <web-port> is given, the webConfigurator answering an HTTP request
-#     (nginx + PHP are fully started, not just sshd) — so callers that install
-#     packages / restart nginx don't race a still-starting web stack.
-# Backoff grows 2s..15s.
+# Readiness, by role:
+#   - <web-port> GIVEN (pfSense): the webConfigurator answering an HTTP request.
+#     nginx + PHP come up AFTER sshd, so a live admin panel implies SSH is already
+#     usable — the web server is the meaningful "appliance ready" signal, gated on
+#     alone (no separate SSH wait).
+#   - <web-port> OMITTED (civm): a working SSH command (`true`) over the
+#     host-forwarded management NIC with the baked test key.
+#
+# Poll cadence: no VM answers in under ~8s, so wait out an initial grace, then
+# poll every 1s while readiness is imminent (< 30s elapsed) and every 5s after
+# that, up to the hard timeout (~1 min). A local-loopback connect that cannot
+# complete in 1s is dead, so the per-probe connect timeout is 1s.
 #
 # POSIX sh; quoted expansions; absolute binary paths.
 
@@ -41,7 +46,7 @@ usage() {
 SSH_KEY="$1"
 HOST="${2:-127.0.0.1}"
 PORT="${3:-2222}"
-TIMEOUT="${4:-600}"
+TIMEOUT="${4:-60}"
 VM_PID="${5:-}"
 WEB_PORT="${6:-}"
 
@@ -65,14 +70,17 @@ if [ -n "$WEB_PORT" ]; then
 fi
 
 # Throwaway VM: skip host-key verification, but keep the private key private.
-SSH_OPTS="-i ${SSH_KEY} -p ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -o BatchMode=yes -o LogLevel=ERROR"
+SSH_OPTS="-i ${SSH_KEY} -p ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=1 -o BatchMode=yes -o LogLevel=ERROR"
+
+# Neither VM becomes reachable in under ~8s, so probing before then is pure waste
+# (the old exponential backoff's early probes). Wait out this grace — still watching
+# the qemu PID so a dead boot fails immediately — then start polling.
+INITIAL_GRACE=8
 
 START="$(date +%s)"
-BACKOFF=2
 ATTEMPT=0
 
 while :; do
-    ATTEMPT=$((ATTEMPT + 1))
     NOW="$(date +%s)"
     ELAPSED=$((NOW - START))
 
@@ -81,48 +89,49 @@ while :; do
         exit 1
     fi
 
-    # If we're watching a VM PID and it has exited, the boot died — don't keep
-    # polling for the full timeout against a guest that will never come up.
+    # A dead qemu (bad image / KVM abort) will never answer — fail fast, even while
+    # still inside the initial grace.
     if [ -n "$VM_PID" ] && ! kill -0 "$VM_PID" 2>/dev/null; then
         echo "wait_ready: VM process ${VM_PID} exited after ${ELAPSED}s — boot failed, not waiting" >&2
         exit 1
     fi
 
-    SSH_READY=0
-    # The probe is a bare `true` ON PURPOSE: pfSense root's login shell is tcsh, which
-    # sshd uses to parse the remote command, and tcsh mangles POSIX-sh syntax. `true` has
-    # no metacharacters so it is tcsh-safe; if this ever needs a richer command, wrap it in
-    # `/bin/sh -c '<single-quoted blob>'` (see scripts/install-pkg.sh / tests/smoke/roundtrip.sh).
-    # shellcheck disable=SC2086
-    if "$SSH" $SSH_OPTS "root@${HOST}" true 2>/dev/null; then
-        SSH_READY=1
+    if [ "$ELAPSED" -lt "$INITIAL_GRACE" ]; then
+        sleep 1
+        continue
     fi
 
-    # Web readiness is optional; when no web port is given it's a no-op so the
-    # gate reduces to SSH-only.
-    WEB_READY=1
+    ATTEMPT=$((ATTEMPT + 1))
+
     if [ -n "$WEB_PORT" ]; then
-        WEB_READY=0
-        if "$CURL" -fsSL --max-time 5 -o /dev/null "http://${HOST}:${WEB_PORT}/" 2>/dev/null; then
-            WEB_READY=1
+        # pfSense: readiness = the webConfigurator answering. nginx + PHP come up
+        # AFTER sshd, so a live admin panel implies SSH is already usable — gate on
+        # the web server alone (the meaningful "appliance ready" signal).
+        if "$CURL" -fsSL --max-time 1 -o /dev/null "http://${HOST}:${WEB_PORT}/" 2>/dev/null; then
+            echo "boot-to-ready: ${ELAPSED} seconds"
+            exit 0
         fi
+        PENDING=web
+    else
+        # civm: no web server — gate on SSH over the host-forwarded management NIC.
+        # The probe is a bare `true` ON PURPOSE: a remote command is parsed by the
+        # guest login shell; `true` has no metacharacters so it stays safe even under
+        # tcsh (pfSense). A richer command must be wrapped in `/bin/sh -c '<blob>'`
+        # (see scripts/install-pkg.sh / tests/smoke/roundtrip.sh).
+        # shellcheck disable=SC2086
+        if "$SSH" $SSH_OPTS "root@${HOST}" true 2>/dev/null; then
+            echo "boot-to-ready: ${ELAPSED} seconds"
+            exit 0
+        fi
+        PENDING=ssh
     fi
 
-    if [ "$SSH_READY" -eq 1 ] && [ "$WEB_READY" -eq 1 ]; then
-        NOW="$(date +%s)"
-        ELAPSED=$((NOW - START))
-        echo "boot-to-ready: ${ELAPSED} seconds"
-        exit 0
+    # Tight 1s cadence while readiness is imminent; relax to 5s past the 30s mark.
+    if [ "$ELAPSED" -lt 30 ]; then
+        INTERVAL=1
+    else
+        INTERVAL=5
     fi
-
-    PENDING=""
-    [ "$SSH_READY" -eq 1 ] || PENDING="${PENDING}ssh "
-    [ "$WEB_READY" -eq 1 ] || PENDING="${PENDING}web "
-    echo "wait_ready: attempt ${ATTEMPT} waiting for: ${PENDING}(${ELAPSED}s elapsed), retry in ${BACKOFF}s" >&2
-    sleep "$BACKOFF"
-
-    BACKOFF=$((BACKOFF * 2))
-    if [ "$BACKOFF" -gt 15 ]; then
-        BACKOFF=15
-    fi
+    echo "wait_ready: attempt ${ATTEMPT} waiting for: ${PENDING} (${ELAPSED}s elapsed), retry in ${INTERVAL}s" >&2
+    sleep "$INTERVAL"
 done

--- a/tests/smoke/wait_ready.sh
+++ b/tests/smoke/wait_ready.sh
@@ -25,9 +25,14 @@
 #     host-forwarded management NIC with the baked test key.
 #
 # Poll cadence: no VM answers in under ~8s, so wait out an initial grace, then
-# poll every 1s while readiness is imminent (< 30s elapsed) and every 5s after
-# that, up to the hard timeout (~1 min). A local-loopback connect that cannot
+# poll every 1s while readiness is plausible (< 75s elapsed) and every 5s after
+# that, up to the hard timeout (~3 min). A local-loopback connect that cannot
 # complete in 1s is dead, so the per-probe connect timeout is 1s.
+#
+# The windows fit MEASURED boots, not the rule of thumb: pfSense reaches
+# web-ready in ~15s on a fast bare-metal host but ~55-60s on a nested-KVM /
+# low-power box (the boot is single-threaded + CPU-bound; see the ADR-04 notes).
+# The 1s window spans both; 180s leaves headroom for parallel-lane CPU contention.
 #
 # POSIX sh; quoted expansions; absolute binary paths.
 
@@ -46,7 +51,7 @@ usage() {
 SSH_KEY="$1"
 HOST="${2:-127.0.0.1}"
 PORT="${3:-2222}"
-TIMEOUT="${4:-60}"
+TIMEOUT="${4:-180}"
 VM_PID="${5:-}"
 WEB_PORT="${6:-}"
 
@@ -70,7 +75,9 @@ if [ -n "$WEB_PORT" ]; then
 fi
 
 # Throwaway VM: skip host-key verification, but keep the private key private.
-SSH_OPTS="-i ${SSH_KEY} -p ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=1 -o BatchMode=yes -o LogLevel=ERROR"
+# The key path is passed quoted at the callsite (it may contain spaces); only the
+# space-free static options live in this word-split string.
+SSH_OPTS="-p ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=1 -o BatchMode=yes -o LogLevel=ERROR"
 
 # Neither VM becomes reachable in under ~8s, so probing before then is pure waste
 # (the old exponential backoff's early probes). Wait out this grace — still watching
@@ -119,15 +126,16 @@ while :; do
         # tcsh (pfSense). A richer command must be wrapped in `/bin/sh -c '<blob>'`
         # (see scripts/install-pkg.sh / tests/smoke/roundtrip.sh).
         # shellcheck disable=SC2086
-        if "$SSH" $SSH_OPTS "root@${HOST}" true 2>/dev/null; then
+        if "$SSH" -i "$SSH_KEY" $SSH_OPTS "root@${HOST}" true 2>/dev/null; then
             echo "boot-to-ready: ${ELAPSED} seconds"
             exit 0
         fi
         PENDING=ssh
     fi
 
-    # Tight 1s cadence while readiness is imminent; relax to 5s past the 30s mark.
-    if [ "$ELAPSED" -lt 30 ]; then
+    # Tight 1s cadence while readiness is plausible (covers a ~15s fast boot and a
+    # ~55-60s slow/contended one); relax to 5s past the 75s mark.
+    if [ "$ELAPSED" -lt 75 ]; then
         INTERVAL=1
     else
         INTERVAL=5

--- a/tests/test_wait_ready_poll.py
+++ b/tests/test_wait_ready_poll.py
@@ -41,14 +41,15 @@ def test_initial_grace_skips_early_probes() -> None:
 
 
 def test_poll_cadence_is_one_then_five_seconds_not_exponential() -> None:
-    """Poll every 1s while readiness is imminent (< 30s), then every 5s — no backoff.
+    """Poll every 1s while readiness is plausible (< 75s), then every 5s — no backoff.
 
-    Pins both branches of the cadence (1s and 5s at the 30s boundary) AND that the
-    old exponential backoff is gone: a `BACKOFF` doubling toward a 15s cap would
-    reintroduce the overshoot this change removes.
+    The 75s window spans both a ~15s fast boot and a ~55-60s slow/contended one (so
+    the real readiness is caught within 1s, not 5s). Pins both branches of the
+    cadence (1s and 5s at the 75s boundary) AND that the old exponential backoff is
+    gone: a `BACKOFF` doubling toward a 15s cap would reintroduce the overshoot.
     """
     text = _wait_ready_text()
-    assert 'if [ "$ELAPSED" -lt 30 ]; then' in text
+    assert 'if [ "$ELAPSED" -lt 75 ]; then' in text
     assert "INTERVAL=1" in text
     assert "INTERVAL=5" in text
     # The exponential backoff (BACKOFF=2; BACKOFF*2; cap 15) must be gone.
@@ -65,14 +66,16 @@ def test_connect_timeouts_are_one_second() -> None:
     assert "--max-time 5" not in text
 
 
-def test_default_timeout_is_about_one_minute() -> None:
-    """The hard readiness ceiling defaults to ~1 min (was 600s).
+def test_default_timeout_has_headroom_over_slow_boot() -> None:
+    """The hard readiness ceiling defaults to ~3 min (was 600s).
 
-    A dead qemu fails the poll immediately via its PID watch, so the ceiling only
-    bounds an alive-but-hung boot; ~1 min is ample and surfaces a wedge fast.
+    Web-ready is ~55-60s on a nested-KVM / low-power box and higher under
+    parallel-lane CPU contention, so ~1 min was too tight; ~3 min leaves headroom.
+    A dead qemu still fails the poll immediately via its PID watch, so the ceiling
+    only bounds an alive-but-hung boot.
     """
     text = _wait_ready_text()
-    assert 'TIMEOUT="${4:-60}"' in text
+    assert 'TIMEOUT="${4:-180}"' in text
 
 
 def test_pfsense_gates_on_web_and_civm_on_ssh() -> None:

--- a/tests/test_wait_ready_poll.py
+++ b/tests/test_wait_ready_poll.py
@@ -1,0 +1,94 @@
+"""Pin wait_ready.sh's boot-readiness poll cadence and per-role gate (ADR-04).
+
+``tests/smoke/wait_ready.sh`` is what the harness blocks on between "qemu launched"
+and "guest usable". Its OLD shape probed from t=0 on an exponential 2s..15s backoff
+and required SSH **and** (optionally) web — so a guest that became ready at ~20s was
+not learned ready until a much later poll, and the suite "waited for nothing".
+
+The new shape:
+
+* an **8s initial grace** (no VM answers sooner) before the first probe;
+* a **1s** poll while readiness is imminent (< 30s), relaxing to **5s** after;
+* a **1s** connect timeout (local loopback — slower than that is dead);
+* a **per-role gate**: pfSense gates on the **web** server (admin panel; nginx+PHP
+  come up after sshd, so a live panel implies SSH), civm on **SSH** (no web server).
+
+These read wait_ready.sh as text (no VM) and pin that cadence + gate, so a regression
+back to the slow exponential backoff or the SSH-and-web gate fails here. The real
+boot-time win is proven by the live-VM smoke (boot-to-ready timing).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_WAIT_READY_SH = Path(__file__).resolve().parent.parent / "tests" / "smoke" / "wait_ready.sh"
+
+
+def _wait_ready_text() -> str:
+    return _WAIT_READY_SH.read_text(encoding="utf-8")
+
+
+def test_initial_grace_skips_early_probes() -> None:
+    """An 8s grace precedes the first probe — no VM answers sooner, so probing is waste.
+
+    The grace is a real branch: while elapsed < INITIAL_GRACE the loop only sleeps
+    (still watching the qemu PID) and continues, rather than firing an SSH/web probe.
+    """
+    text = _wait_ready_text()
+    assert "INITIAL_GRACE=8" in text
+    assert 'if [ "$ELAPSED" -lt "$INITIAL_GRACE" ]; then' in text
+
+
+def test_poll_cadence_is_one_then_five_seconds_not_exponential() -> None:
+    """Poll every 1s while readiness is imminent (< 30s), then every 5s — no backoff.
+
+    Pins both branches of the cadence (1s and 5s at the 30s boundary) AND that the
+    old exponential backoff is gone: a `BACKOFF` doubling toward a 15s cap would
+    reintroduce the overshoot this change removes.
+    """
+    text = _wait_ready_text()
+    assert 'if [ "$ELAPSED" -lt 30 ]; then' in text
+    assert "INTERVAL=1" in text
+    assert "INTERVAL=5" in text
+    # The exponential backoff (BACKOFF=2; BACKOFF*2; cap 15) must be gone.
+    assert "BACKOFF" not in text
+
+
+def test_connect_timeouts_are_one_second() -> None:
+    """SSH and web probes time out after 1s — a local-loopback connect that slow is dead."""
+    text = _wait_ready_text()
+    assert "ConnectTimeout=1" in text  # ssh
+    assert "--max-time 1" in text  # curl
+    # The old 5s connect timeouts must be gone.
+    assert "ConnectTimeout=5" not in text
+    assert "--max-time 5" not in text
+
+
+def test_default_timeout_is_about_one_minute() -> None:
+    """The hard readiness ceiling defaults to ~1 min (was 600s).
+
+    A dead qemu fails the poll immediately via its PID watch, so the ceiling only
+    bounds an alive-but-hung boot; ~1 min is ample and surfaces a wedge fast.
+    """
+    text = _wait_ready_text()
+    assert 'TIMEOUT="${4:-60}"' in text
+
+
+def test_pfsense_gates_on_web_and_civm_on_ssh() -> None:
+    """Readiness is per-role: web-port set -> web gate; unset -> SSH gate.
+
+    pfSense passes a web-port and is ready when the webConfigurator answers; civm
+    passes none and is ready when SSH works. The OLD combined "SSH and web" gate
+    (the `SSH_READY`/`WEB_READY` AND) must be gone — that is what made pfSense wait
+    on SSH it does not need to gate on.
+    """
+    text = _wait_ready_text()
+    # pfSense branch: web probe guarded by a non-empty WEB_PORT.
+    assert 'if [ -n "$WEB_PORT" ]; then' in text
+    assert "http://${HOST}:${WEB_PORT}/" in text
+    # civm branch: the tcsh-safe bare-`true` SSH probe.
+    assert '"root@${HOST}" true' in text
+    # The old AND-gate is gone.
+    assert "SSH_READY" not in text
+    assert "WEB_READY" not in text


### PR DESCRIPTION
## Phase 0c — faster boot-readiness poll

`tests/smoke/wait_ready.sh` is what the harness blocks on between "qemu launched"
and "guest usable", and it ran on an exponential **2s..15s** backoff that probed
from t=0 and overshot actual readiness by up to a full backoff step — the smoke
suite was, much of the time, simply waiting for nothing.

### What changed

- **8s initial grace** before the first probe (neither VM answers sooner), then a
  **1s** poll while readiness is imminent (`< 30s` elapsed), relaxing to **5s**
  after — replacing the exponential backoff.
- **1s connect timeout** (`ssh ConnectTimeout=1` / `curl --max-time 1`): a
  local-loopback connect that can't complete in 1s is dead.
- **Per-role gate** instead of SSH-and-web: **pfSense** gates on the
  webConfigurator answering (nginx+PHP come up after sshd, so a live admin panel
  implies SSH is usable); **civm** gates on SSH (no web server).
- Hard ceiling **600s → ~60s** (`SMOKE_BOOT_TIMEOUT` still overrides). A dead qemu
  already fails the poll instantly via its PID watch, so the ceiling only bounds an
  alive-but-hung boot.

### Tests

`tests/test_wait_ready_poll.py` pins the cadence + per-role gate as text (the way
`test_smoke_harness_defaults.py` pins `boot_vm.sh`); it is **red on the old
exponential backoff and green on the new poll**. The boot-time win itself is
behavioural and proven by the live-VM smoke (boot-to-ready timing) — validated on a
live CE + civm pair before merge.

### Deferred to Phase 1 (lane orchestration)

Parallel pfSense/civm boot and the civm LAN-lease + `networkctl reconfigure` renew
are **coupled** and only pay off / become validatable under a deliberate lane-start
co-boot: today `client_vm` depends on a fully-ready `smoke_vm`, so civm always boots
against an already-serving pfSense DHCP (no race, no parallelism to reclaim). They
land with the Phase 1 lane work, where co-booting each lane's VM set is the natural
structure and the DHCP race that exercises the renew actually exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boot readiness checks now fail faster when a VM stops unexpectedly.
  * Default wait time for smoke VM startup is now shorter, reducing long delays during stalled boots.
  * Readiness detection is more consistent, using either web access or SSH depending on the selected check.

* **Tests**
  * Added coverage to verify the updated boot polling behavior and timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->