### PR TITLE
ADR-44: Normalise MIME-type strings before the allow-list gate in pfb_filter()

### DIFF
--- a/.ADRs/ADR_44_MIME_Normalization/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_44_MIME_Normalization/RESULTS/01_Results.txt
@@ -1,0 +1,135 @@
+ADR-44 Phase 1 — Extract pfb_mime_in_allowlist() + oracle tests
+================================================================
+Status: COMPLETE — 1542 tests, 0 failures
+
+---
+
+1. Helper extraction
+--------------------
+Function added to pfblockerng.inc at line 640:
+
+    function pfb_mime_in_allowlist(string $mime, array $allowlist): bool {
+        return isset($allowlist[$mime]);
+    }
+
+Behaviour is exactly behaviour-preserving: isset() on the array_flip'ed
+allow-list is the existing membership test; the helper is a named wrapper only.
+
+Wired into:
+  - PFB_FILTER_FILE_MIME (17) branch, line 1017:
+      !pfb_mime_in_allowlist($output[0], $pfb['mime_types'])
+    replacing: !isset($pfb['mime_types'][$output[0]])
+
+  - PFB_FILTER_FILE_MIME_COMPRESSED (18) branch, line 1052:
+      !pfb_mime_in_allowlist($output[0], $pfb['mime_types'])
+    replacing: !isset($pfb['mime_types'][$output[0]])
+
+Constant 16 (PFB_FILTER_FILE_MIME_COMPARE) is UNTOUCHED — still uses
+$output[0] !== $input[1] (exact-match; no allow-list lookup).
+
+$pfb['mime_types'] (lines 274–287) is UNTOUCHED.
+
+---
+
+2. Oracle test file
+-------------------
+tests/php/PfbMimeAllowlistTest.php (PascalCase + Test.php, final class,
+strict_types=1, CoversFunction('pfb_mime_in_allowlist'))
+
+All 7 oracle tests — all GREEN (pass) on Phase 1 code:
+
+  a. test_pfb_mime_allowlist_accepts_canonical_zip()
+       assertsTrue  — 'application/zip' is in the allow-list
+       PASS
+
+  b. test_pfb_mime_allowlist_rejects_x_zip_compressed()
+       assertsFalse — 'application/x-zip-compressed' NOT in allow-list (RED BASELINE)
+       PASS
+
+  c. test_pfb_mime_allowlist_rejects_x_zip()
+       assertsFalse — 'application/x-zip' NOT in allow-list (RED BASELINE)
+       PASS
+
+  d. test_pfb_mime_allowlist_accepts_canonical_gzip()
+       assertsTrue  — 'application/gzip' is in the allow-list
+       PASS
+
+  e. test_pfb_mime_allowlist_accepts_x_gzip()
+       assertsTrue  — 'application/x-gzip' IS in the allow-list (confirmed)
+       PASS
+
+  f. test_pfb_mime_allowlist_rejects_octet_stream()
+       assertsFalse — 'application/octet-stream' NOT in allow-list
+       PASS
+
+  g. test_pfb_mime_allowlist_accepts_text_plain()
+       assertsTrue  — 'text/plain' is in the allow-list
+       PASS
+
+---
+
+3. Explicit RED-BASELINE record
+--------------------------------
+These are the bug entries Phase 2 will fix via normalisation before the
+allow-list lookup:
+
+  application/x-zip-compressed  →  pfb_mime_in_allowlist == FALSE
+    (file(1) returns this for ZIPs made by Info-ZIP, Windows Explorer, etc.)
+    Phase 2 normalises → 'application/zip' before the allow-list check.
+
+  application/x-zip             →  pfb_mime_in_allowlist == FALSE
+    (file(1) returns this for some ZIP creators)
+    Phase 2 normalises → 'application/zip' before the allow-list check.
+
+---
+
+4. PHPUnit summary
+------------------
+Tests: 1542, Assertions: 14897, Skipped: 3, Failures: 0
+
+Suite is FULLY GREEN. The 3 skips are pre-existing (unrelated to this phase).
+
+---
+
+5. Linting / static analysis
+-----------------------------
+  php -l pfblockerng.inc      → No syntax errors (pre-existing Deprecated notices
+                                 for optional-before-required params are unchanged)
+  phpcs --standard=phpcs.xml.dist src/  → 0 errors (no new violations)
+
+---
+
+6. Test isolation note
+-----------------------
+PfbFileMimeSinkEscapeTest::tearDown() calls unset($GLOBALS['pfb']['mime_types']),
+which clobbers the bootstrap-populated global. PfbMimeAllowlistTest::setUp()
+detects an empty global and falls back to constructing array_flip([...]) from
+the exact shipped strings (pfblockerng.inc:274-287). This is intentional and
+documented in the setUp comment.
+
+---
+
+7. Watch-outs for Phase 2
+--------------------------
+Insertion point in const-17 (PFB_FILTER_FILE_MIME):
+  ~line 1015: exec("/usr/bin/file -b --mime-type ...") populates $output[0].
+  ~line 1017: the allow-list check (now via pfb_mime_in_allowlist).
+  Phase 2 inserts pfb_mime_normalise($output[0]) between these two lines,
+  i.e. $output[0] = pfb_mime_normalise($output[0]) before the check.
+
+Debug log sink: pfb_logger level 5 → /tmp/pfb_debug is the "Print to debugger"
+  path. Phase 2 adds a level-5 log recording raw→normalised when normalisation
+  fires. The pfb_logger call at ~line 1021 (failed/invalid) is level 2 (warning);
+  the normalisation-event log is a separate level-5 call inserted just after
+  the normalise call.
+
+Const-18 (PFB_FILTER_FILE_MIME_COMPRESSED): Phase 2 does NOT add normalisation
+  here (per ADR §2 decision table: "No change" for const-18). Only const-17
+  gets the normalise call.
+
+---
+
+8. Commit hash + push
+----------------------
+See git log for the commit hash (appended after push completes).
+Branch: adr/44-mime-normalisation

--- a/.ADRs/ADR_44_MIME_Normalization/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_44_MIME_Normalization/RESULTS/02_Results.txt
@@ -1,0 +1,159 @@
+ADR-44 Phase 2 — Add pfb_mime_normalise() + wire into MIME gate (const-17)
+==========================================================================
+Status: COMPLETE — 1553 tests, 0 failures, 3 pre-existing skips
+
+---
+
+1. Helper added
+---------------
+Function pfb_mime_normalise(string $raw): string added to pfblockerng.inc at
+line 644 (immediately before pfb_filter(), next to pfb_mime_in_allowlist()).
+
+Design:
+  a. switch/case exact-match first — maps x-zip-compressed and x-zip to
+     application/zip, and x-gzip to application/gzip.  The switch runs BEFORE
+     the substring guard so 'application/x-gzip' → 'application/gzip', NOT
+     'application/zip' (the switch short-circuits the catch-all).
+  b. Substring catch-all: stripos($raw, 'zip') !== FALSE for any remaining
+     unknown ZIP-variant string, BUT guarded by:
+       stripos($raw, 'gzip') === FALSE
+       stripos($raw, 'bzip') === FALSE
+     These guards are REQUIRED because "zip" is a substring of "gzip" and
+     "bzip2". Without them, application/gzip and application/x-bzip2 (both
+     already valid, allow-listed archive types) would be misrouted to
+     application/zip → pfb_download() would put them into the ZIP/tar handler
+     instead of their correct processing path → feed corruption.
+
+Pinned by tests:
+  test_normalise_x_gzip_to_gzip()     — x-gzip → gzip (NOT zip)
+  test_normalise_x_bzip2_unchanged()  — x-bzip2 passes through unchanged
+  test_normalise_gzip_unchanged()     — gzip passes through unchanged
+
+Constants 16 (PFB_FILTER_FILE_MIME_COMPARE) and 18 (PFB_FILTER_FILE_MIME_COMPRESSED)
+are NOT modified. $pfb['mime_types'] is NOT modified.
+git diff line counts: 31 insertions, 0 deletions — pfblockerng.inc only.
+
+---
+
+2. Wiring into const-17 (PFB_FILTER_FILE_MIME) only
+------------------------------------------------------
+Insertion point: between the exec() call and the pfb_mime_in_allowlist() check.
+After Phase 2, the sequence at ~line 1039 is:
+
+    exec("/usr/bin/file -b --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);
+    if (!empty($output[0])) {
+        $mime_raw = $output[0];
+        $output[0] = pfb_mime_normalise($mime_raw);
+        if ($output[0] !== $mime_raw) {
+            // ADR-44: debug-log every normalisation event (raw -> canonical).
+            pfb_logger("MIME normalised: raw=\"" . htmlspecialchars($mime_raw) . "\" -> canonical=\"" . htmlspecialchars($output[0]) . "\"", 5);
+        }
+    }
+    if ($retval != 0 || empty($output[0]) || !pfb_mime_in_allowlist($output[0], $pfb['mime_types'])) {
+
+$output[0] is overwritten with the canonical value BEFORE the allow-list check.
+This means the canonical type also flows downstream into $result (line 1057:
+`$result = htmlspecialchars($output[0])`) and into pfb_download()'s $file_type
+dispatch — so an x-zip-compressed feed is routed into the correct ZIP handler,
+not just passing the allow-list gate.
+
+The normalise block is guarded by `!empty($output[0])` so the existing
+empty/retval short-circuit behaviour is preserved exactly.
+
+Const-18 (PFB_FILTER_FILE_MIME_COMPRESSED, ~line 1066): NOT modified. ADR §2
+decision table says "No change" for that branch.
+
+---
+
+3. Debug-log sink
+------------------
+pfb_logger level 5 → /tmp/pfb_debug ("Print to debugger" case in pfb_logger,
+~line 2498 post-insertion).
+
+Log line format (emitted ONLY when normalisation changes the string):
+  MIME normalised: raw="<raw>" -> canonical="<canonical>"
+
+Both values are htmlspecialchars()-escaped before logging. Phase 4 smoke
+checklist: `tail -f /tmp/pfb_debug` on the pfSense VM during a feed reload
+to observe normalisation events for real x-zip-compressed feeds.
+
+---
+
+4. Red → green evidence
+------------------------
+RED (before adding pfb_mime_normalise() to pfblockerng.inc):
+
+  vendor/bin/phpunit tests/php/PfbMimeNormaliseTest.php
+  ERRORS!
+  Tests: 11, Assertions: 1, Errors: 11.
+  All 11: "Error: Call to undefined function pfb_mime_normalise()"
+
+GREEN (after adding function + wiring):
+
+  vendor/bin/phpunit
+  Tests: 1553, Assertions: 14909, Skipped: 3.
+  OK (no failures)
+
+Tests passing (all 11 new + all 1542 Phase 1 oracle tests):
+  PfbMimeNormaliseTest::test_normalise_x_zip_compressed_to_zip
+  PfbMimeNormaliseTest::test_normalise_x_zip_to_zip
+  PfbMimeNormaliseTest::test_normalise_zip_substring_case_insensitive
+  PfbMimeNormaliseTest::test_normalise_x_gzip_to_gzip
+  PfbMimeNormaliseTest::test_normalise_x_bzip2_unchanged
+  PfbMimeNormaliseTest::test_normalise_gzip_unchanged
+  PfbMimeNormaliseTest::test_normalise_octet_stream_unchanged
+  PfbMimeNormaliseTest::test_normalise_text_plain_unchanged
+  PfbMimeNormaliseTest::test_normalise_empty_string_unchanged
+  PfbMimeNormaliseTest::test_normalise_canonical_zip_unchanged
+  PfbMimeNormaliseTest::test_pfb_filter_mime_accepts_x_zip_compressed_after_normalise
+
+The integration test asserts before-state (raw x-zip-compressed → assertFalse)
+and after-state (normalised → assertTrue) in one test, proving normalisation
+caused the change.
+
+---
+
+5. Linting / static analysis
+------------------------------
+  php -l pfblockerng.inc       → No syntax errors
+  phpcs --standard=phpcs.xml.dist src/  → 0 errors (no violations)
+
+---
+
+6. For Phase 3
+---------------
+Phase 3 is a COMMENT-ONLY cleanup. Per the Phase 3 prompt and ADR-44 §1, it
+must NOT re-enable the commented-out PFB_FILTER_FILE_MIME_COMPRESSED call —
+inner-content/ZIP-container validation is explicitly OUT OF SCOPE (deferred to a
+future ADR). Phase 3 only removes the now-stale TODO *text* and replaces it with
+an ADR-44 reference; the commented-out _COMPRESSED call STAYS commented out.
+
+Relevant TODO comments in pfblockerng.inc (line numbers post-Phase-2 insertion):
+
+  Line 8354: /* TODO: FIX - Bypass ZIP Compression file mime type validation due
+             to incompatability with ZIP files
+             if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}",
+               "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download')) {
+                 return FALSE;
+             }
+             */
+
+  Line 8374: // TODO: Validate file contents after extraction (to be removed once
+             ZIP compression file mime type is fixed above)
+
+Phase 3 should (behaviour-preserving, comment lines only):
+  a. Replace the stale "TODO: FIX - Bypass ZIP Compression..." text with a brief
+     comment referencing ADR-44, KEEPING the commented-out _COMPRESSED call block
+     itself untouched (do NOT uncomment or delete the call).
+  b. Update/remove the line-8374 TODO text so it no longer implies the call will
+     be re-enabled.
+
+Note: Use `grep -n "TODO.*Bypass ZIP\|TODO.*Validate file"` after checkout to
+confirm exact line numbers, as they shift with each insertion.
+
+---
+
+7. Commit hash + push
+----------------------
+Commit: this phase's HEAD commit on adr/44-mime-normalisation (see `git log`)
+Push:   adr/44-mime-normalisation → origin/adr/44-mime-normalisation (SUCCESS)

--- a/.ADRs/ADR_44_MIME_Normalization/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_44_MIME_Normalization/RESULTS/03_Results.txt
@@ -1,0 +1,113 @@
+ADR-44 Phase 3 — Comment-only cleanup: remove stale ZIP-MIME TODOs
+==================================================================
+Status: COMPLETE — 1553 tests, 0 failures, 3 pre-existing skips
+
+---
+
+1. Comment blocks reworded
+--------------------------
+Two stale TODO comment blocks were updated in
+src/usr/local/pkg/pfblockerng/pfblockerng.inc. Exact line numbers after Phase 2
+insertions (confirmed via grep before editing):
+
+a. Line 8363 (post-edit: 8362–8371): the /* TODO: FIX - Bypass ZIP Compression
+   file mime type validation due to incompatability with ZIP files */ opening prose
+   was replaced with a 5-line block comment that accurately describes the current
+   state:
+
+   - MIME variant strings are now canonicalised via pfb_mime_normalise() (ADR-44).
+   - The outer ZIP MIME gate therefore no longer false-rejects valid feeds.
+   - The post-extraction inner-content MIME check (the _COMPRESSED call) remains
+     disabled — inner-content validation is deferred to a future ADR.
+
+   The commented-out `if (!pfb_filter(..., PFB_FILTER_FILE_MIME_COMPRESSED, ...))
+   { return FALSE; }` block was NOT removed, NOT uncommented. It remains verbatim
+   inside the /* ... */ block.
+
+b. Line 8383 (post-edit: 8384–8386): the single-line
+   // TODO: Validate file contents after extraction (to be removed once ZIP
+   // compression file mime type is fixed above)
+   was replaced with a 3-line comment that accurately describes the active
+   pfb_filter(..., PFB_FILTER_FILE_MIME, ...) call that follows it: post-extraction
+   content validation, with a note that outer-container variant handling is now
+   covered by ADR-44's pfb_mime_normalise().
+
+---
+
+2. Commented-out PFB_FILTER_FILE_MIME_COMPRESSED call — confirmed NOT touched
+-------------------------------------------------------------------------------
+The `if (!pfb_filter(array(...), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download'))
+{ return FALSE; }` lines inside the /* ... */ block at ~line 8362 were NOT removed
+and NOT uncommented. They remain exactly as written in Phase 2, only the leading
+prose comment line changed.
+
+---
+
+3. No executable code changed
+------------------------------
+`git diff` for this phase contains only comment-line changes in pfblockerng.inc.
+No executable line was added, removed, or modified. The diff covers exactly:
+  - 5 comment lines added (new `/* ... */` opening prose, 5 lines)
+  - 1 comment line removed (old `/* TODO: FIX - ...` single line)
+  - 3 comment lines added (new `// Post-extraction ...` 3-line comment)
+  - 1 comment line removed (old `// TODO: Validate ...` single line)
+
+The `if (!pfb_filter(..., PFB_FILTER_FILE_MIME, ...))` active code at ~line 8387
+was not touched.
+
+---
+
+4. Const-16/17/18 inline comments — no stale text found
+---------------------------------------------------------
+Reviewed all inline comments for PFB_FILTER_FILE_MIME_COMPARE (const-16, ~line 1003),
+PFB_FILTER_FILE_MIME (const-17, ~line 1023), and PFB_FILTER_FILE_MIME_COMPRESSED
+(const-18, ~line 1067). None contained stale text describing the old un-normalised
+flow. The `// ADR-44: debug-log every normalisation event (raw -> canonical).`
+comment added in Phase 2 at ~line 1044 is accurate and was not modified.
+
+---
+
+5. PHPUnit summary
+-------------------
+vendor/bin/phpunit
+Tests: 1553, Assertions: 14909, Skipped: 3.
+OK (no failures) — identical to Phase 2 baseline, confirming no behaviour change.
+
+---
+
+6. Linting / static analysis
+------------------------------
+  php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc
+    → No syntax errors (pre-existing Deprecated notices unchanged)
+  vendor/bin/phpcs --standard=phpcs.xml.dist src/usr/local/pkg/pfblockerng/pfblockerng.inc
+    → 0 errors
+
+---
+
+7. git diff --stat
+-------------------
+ src/usr/local/pkg/pfblockerng/pfblockerng.inc | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+---
+
+8. Commit + push
+-----------------
+Commit subject: pfb_filter: remove stale ZIP-MIME TODO; reference ADR-44 (ADR-44 P3)
+Commit hash: this phase's HEAD commit on adr/44-mime-normalisation (see git log)
+Push: adr/44-mime-normalisation → origin/adr/44-mime-normalisation (SUCCESS)
+
+---
+
+9. Go-ahead for Phase 4
+------------------------
+Phase 3 is complete and all gates are green. Phase 4 (smoke checklist) may proceed.
+
+Phase 4 smoke items to verify on a live pfSense CE VM with a real x-zip-compressed
+feed:
+  a. Feed reload completes without a MIME-rejection error for a feed whose server
+     returns Content-Type: application/x-zip-compressed (or similar variant).
+  b. /tmp/pfb_debug shows "MIME normalised: raw=..." log line when normalisation fires.
+  c. No regression on feeds already returning application/zip.
+  d. The disabled _COMPRESSED inner-content check has no runtime effect (it is inside
+     /* ... */ and is not reached).

--- a/.ADRs/ADR_44_MIME_Normalization/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_44_MIME_Normalization/RESULTS/04_Results.txt
@@ -1,0 +1,43 @@
+ADR-44 — Phase 4 Results (smoke checklist + acceptance prep)
+============================================================
+
+Phase 4 of 4 — documentation/acceptance phase. No code change.
+Branch: adr/44-mime-normalisation.
+
+1. What was done
+-----------------
+- Created .ADRs/ADR_44_MIME_Normalization/RESULTS/SMOKE_CHECKLIST.md — the manual
+  live-box smoke checklist for the maintainer, expanded from ADR-44 §7.
+  * TC-1/TC-2: ZIP feeds (x-zip-compressed) now pass the MIME gate.
+  * TC-3: gzip AND x-bzip2 feeds still pass (regression guard for the
+    gzip/bzip2 substring-guard in pfb_mime_normalise()).
+  * TC-4: references the real debug sink /tmp/pfb_debug (pfb_logger level 5) and
+    the exact log line format:
+        MIME normalised: raw="application/x-zip-compressed" -> canonical="application/zip"
+  * TC-5: HTML/non-archive bodies still rejected (octet-stream never promoted).
+  * Reject criteria include the x-bzip2/gzip misroute guard and the const-16
+    no-change invariant.
+- ADR.md Status was NOT changed (still "Proposed"). Per the Phase 4 prompt, the
+  flip to Accepted is a maintainer action after the live-box smoke run passes.
+
+2. Verification
+----------------
+- markdownlint-cli2 on SMOKE_CHECKLIST.md: clean (0 errors).
+- vendor/bin/phpunit: 1553 tests, 14909 assertions, 0 failures, 3 pre-existing
+  skips (unchanged from Phases 1-3 — this phase adds no code).
+
+3. Commit + push
+-----------------
+Commit: this phase's HEAD commit on adr/44-mime-normalisation (see `git log`).
+Push:   adr/44-mime-normalisation -> origin/adr/44-mime-normalisation.
+
+4. Instruction to the maintainer
+---------------------------------
+Run RESULTS/SMOKE_CHECKLIST.md on a live pfSense box (CE and Plus). If PASS, flip
+the ADR.md Status line from "Proposed" to "Accepted (YYYY-MM-DD)" and land the
+branch (PR rebase-merge, or commit the status flip on adr/44-mime-normalisation).
+
+Note: the §7 manual smoke is an out-of-CI item (no live Unbound / real feed
+download in CI). The automated PHPUnit coverage (oracle + red->green normalise
+tests, incl. the gzip/bzip2 guard) is the in-CI proof; the checklist covers the
+live download/extraction path that cannot run in CI.

--- a/.ADRs/ADR_44_MIME_Normalization/RESULTS/SMOKE_CHECKLIST.md
+++ b/.ADRs/ADR_44_MIME_Normalization/RESULTS/SMOKE_CHECKLIST.md
@@ -1,0 +1,57 @@
+# ADR-44 Manual Smoke Checklist
+
+Owner: maintainer (requires a live pfSense box with pfBlockerNG installed).
+Branch: `adr/44-mime-normalisation`.
+
+ADR-44 adds `pfb_mime_normalise()` in `pfb_filter()`: before the MIME allow-list
+gate (constant `PFB_FILTER_FILE_MIME`, 17), known ZIP variant strings from
+`file(1)` (`application/x-zip-compressed`, `application/x-zip`, and other
+`zip`-bearing variants) are canonicalised to `application/zip`, and
+`application/x-gzip` to `application/gzip`. `application/gzip`, `application/x-bzip2`,
+`application/octet-stream`, and any non-archive string pass through unchanged.
+
+## Pre-conditions
+
+- [ ] Branch `adr/44-mime-normalisation` is installed on the test box.
+- [ ] pfBlockerNG is enabled with at least one IP or DNSBL feed configured.
+
+## Test cases
+
+- [ ] TC-1: Download a blocklist feed served as a ZIP created by Python `zipfile`
+  (or 7-Zip / Windows Explorer). Confirm it passes the MIME gate and the feed is
+  processed normally (entries imported, no MIME-rejection line in the pfBlockerNG
+  log).
+- [ ] TC-2: If a feed previously triggered an `application/x-zip-compressed`
+  rejection, re-run it. Confirm it now succeeds.
+- [ ] TC-3: Download a feed served as `application/gzip` (and, if available, one
+  served as `application/x-bzip2`). Confirm both still pass and are processed —
+  no regression from normalisation (these must NOT be rewritten to
+  `application/zip`).
+- [ ] TC-4: Inspect the debug sink `/tmp/pfb_debug` after TC-1/TC-2. Confirm a
+  normalisation event is logged when a variant string is encountered, e.g.:
+
+  ```text
+  MIME normalised: raw="application/x-zip-compressed" -> canonical="application/zip"
+  ```
+
+- [ ] TC-5: Download a feed that returns a genuine HTML error page (or simulate
+  with a test URL whose body is HTML). Confirm it is still rejected by the MIME
+  gate (`text/html` is allow-listed but the downstream parse yields no valid
+  entries; an `application/octet-stream` or other non-archive body is rejected and
+  never promoted).
+
+## Reject criteria (if any occur, do NOT mark ADR-44 Accepted)
+
+- Any feed that previously succeeded now fails after this change.
+- `application/octet-stream` (or any non-archive string) is ever promoted through
+  the normalisation path.
+- `application/x-bzip2` or `application/gzip` is rewritten to `application/zip`
+  (misrouted into the ZIP handler).
+- `PFB_FILTER_FILE_MIME_COMPARE` (constant 16) behaviour changes in any way.
+
+## Sign-off
+
+- Tester: _______________
+- Date: _______________
+- Result: PASS / FAIL
+- Notes: _______________

--- a/.ADRs/ADR_44_MIME_Normalization/RESULTS/SMOKE_CHECKLIST.md
+++ b/.ADRs/ADR_44_MIME_Normalization/RESULTS/SMOKE_CHECKLIST.md
@@ -35,10 +35,11 @@ gate (constant `PFB_FILTER_FILE_MIME`, 17), known ZIP variant strings from
   ```
 
 - [ ] TC-5: Download a feed that returns a genuine HTML error page (or simulate
-  with a test URL whose body is HTML). Confirm it is still rejected by the MIME
-  gate (`text/html` is allow-listed but the downstream parse yields no valid
-  entries; an `application/octet-stream` or other non-archive body is rejected and
-  never promoted).
+  with a test URL whose body is HTML). `text/html` is allow-listed, so the MIME
+  gate accepts it; confirm the downstream parser still rejects it because no valid
+  entries are extracted.
+- [ ] TC-5b: Download a non-archive body (e.g. `application/octet-stream`). Confirm
+  it is rejected at the MIME gate and never promoted through normalisation.
 
 ## Reject criteria (if any occur, do NOT mark ADR-44 Accepted)
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -633,6 +633,14 @@ function pfb_sync_filter_password(string $value): string {
 	return $value;
 }
 
+// Pure allow-list membership test for a MIME-type string.
+// Encapsulates the isset($pfb['mime_types'][...]) lookup used by the
+// PFB_FILTER_FILE_MIME (17) and PFB_FILTER_FILE_MIME_COMPRESSED (18) branches
+// so that Phase 2 normalisation has a clean, single insertion point.
+function pfb_mime_in_allowlist(string $mime, array $allowlist): bool {
+	return isset($allowlist[$mime]);
+}
+
 // Function to filter/sanitize user input
 function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE) {
 	global $pfb;
@@ -1006,7 +1014,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				return FALSE;
 			}
 			exec("/usr/bin/file -b --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);
-			if ($retval != 0 || empty($output[0]) || !isset($pfb['mime_types'][$output[0]])) {
+			if ($retval != 0 || empty($output[0]) || !pfb_mime_in_allowlist($output[0], $pfb['mime_types'])) {
 
 				// Exceptions
 				$hostname = parse_url($input[2], PHP_URL_HOST);
@@ -1041,7 +1049,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				return FALSE;
 			}
 			exec("/usr/bin/file -bZ --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);
-			if ($retval != 0 || empty($output[0]) || !isset($pfb['mime_types'][$output[0]])) {
+			if ($retval != 0 || empty($output[0]) || !pfb_mime_in_allowlist($output[0], $pfb['mime_types'])) {
 				pfb_logger("{$header} Failed or invalid Mime Type Compressed: [" .  htmlspecialchars($output[0]) . "|" . htmlspecialchars($retval) . "]", 2);
 				unlink_if_exists($input[1]);
 				return FALSE;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -641,6 +641,29 @@ function pfb_mime_in_allowlist(string $mime, array $allowlist): bool {
 	return isset($allowlist[$mime]);
 }
 
+// ADR-44: canonicalise known archive MIME variants so valid feeds packaged by
+// non-canonical tools pass the allow-list gate. Pure: string in -> string out,
+// never promotes a non-archive string.
+function pfb_mime_normalise(string $raw): string {
+	// Exact-match canonicalisations first (so x-gzip maps to gzip, NOT zip).
+	switch ($raw) {
+		case 'application/x-zip-compressed':
+		case 'application/x-zip':
+			return 'application/zip';
+		case 'application/x-gzip':
+			return 'application/gzip';
+	}
+	// Generic catch-all for other ZIP-creator variant strings — but the literal
+	// substring "zip" also lives inside "gzip"/"bzip2", which are distinct valid
+	// archive types that MUST pass through unchanged. Exclude them explicitly.
+	if (stripos($raw, 'zip') !== FALSE
+	    && stripos($raw, 'gzip') === FALSE
+	    && stripos($raw, 'bzip') === FALSE) {
+		return 'application/zip';
+	}
+	return $raw;
+}
+
 // Function to filter/sanitize user input
 function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE) {
 	global $pfb;
@@ -1014,6 +1037,14 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				return FALSE;
 			}
 			exec("/usr/bin/file -b --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);
+			if (!empty($output[0])) {
+				$mime_raw = $output[0];
+				$output[0] = pfb_mime_normalise($mime_raw);
+				if ($output[0] !== $mime_raw) {
+					// ADR-44: debug-log every normalisation event (raw -> canonical).
+					pfb_logger("MIME normalised: raw=\"" . htmlspecialchars($mime_raw) . "\" -> canonical=\"" . htmlspecialchars($output[0]) . "\"", 5);
+				}
+			}
 			if ($retval != 0 || empty($output[0]) || !pfb_mime_in_allowlist($output[0], $pfb['mime_types'])) {
 
 				// Exceptions

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8360,7 +8360,11 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 			pfb_logger('.', 1);
 
-			/* TODO: FIX - Bypass ZIP Compression file mime type validation due to incompatability with ZIP files
+			/* ZIP MIME variant strings (e.g. application/x-zip-compressed) are now
+			   canonicalised to application/zip in pfb_filter() via pfb_mime_normalise()
+			   (ADR-44), so the outer ZIP MIME gate no longer false-rejects valid feeds.
+			   The post-extraction inner-content MIME check below stays disabled —
+			   ZIP inner-content validation is deferred to a future ADR.
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download')) {
 				return FALSE;
 			}
@@ -8380,7 +8384,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				exec("/usr/bin/tar -xOf {$file_dwn_esc} | /usr/bin/sed 's/,[[:space:]]/; /g' | /usr/bin/tr ',' '\n' > {$file_org_esc}", $output, $retval);
 			}
 
-			// TODO: Validate file contents after extraction (to be removed once ZIP compression file mime type is fixed above)
+			// Post-extraction content validation: re-run the MIME gate on the extracted
+			// file (the outer-container variant handling is covered by ADR-44's
+			// pfb_mime_normalise()).
 			if (!pfb_filter(array("{$file_org_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download')) {
 				unlink_if_exists("{$file_org_esc}");
 				return FALSE;

--- a/tests/php/PfbMimeAllowlistTest.php
+++ b/tests/php/PfbMimeAllowlistTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Oracle tests for pfb_mime_in_allowlist() — extracted pure helper that
+ * encapsulates the $pfb['mime_types'] membership lookup.
+ *
+ * These tests pin the CURRENT shipped allow-list behaviour before Phase 2
+ * normalisation is introduced. They use $GLOBALS['pfb']['mime_types'] as
+ * populated by bootstrap (the real shipped array_flip list) so they are
+ * genuine oracles of the shipped allow-list, not a private copy.
+ *
+ * Entries (b) and (c) record known RED baselines — types file(1) can return
+ * for a valid ZIP that the current allow-list rejects. Phase 2 will flip
+ * these to true via normalisation before the lookup.
+ */
+#[CoversFunction('pfb_mime_in_allowlist')]
+final class PfbMimeAllowlistTest extends TestCase
+{
+	private array $allowlist;
+
+	protected function setUp(): void
+	{
+		// Prefer the real shipped allow-list as populated by bootstrap (the
+		// array_flip of pfblockerng.inc:274-287). Fall back to constructing it
+		// directly when a sibling test's tearDown() has unset the global
+		// (PfbFileMimeSinkEscapeTest does this), so these oracles stay
+		// isolated and always test against the canonical shipped list.
+		$global = $GLOBALS['pfb']['mime_types'] ?? [];
+		$this->allowlist = !empty($global) ? $global : array_flip([
+			'inode/x-empty', 'text/x-file',
+			'text/plain', 'text/html', 'text/xml', 'text/csv',
+			'application/csv', 'application/json', 'application/x-ndjson',
+			'application/x-tar',
+			'application/gzip', 'application/x-gzip',
+			'application/x-bzip2',
+			'application/zip',
+		]);
+	}
+
+	public function test_pfb_mime_allowlist_accepts_canonical_zip(): void
+	{
+		// 'application/zip' is in the shipped allow-list → must be accepted.
+		$this->assertTrue(pfb_mime_in_allowlist('application/zip', $this->allowlist));
+	}
+
+	public function test_pfb_mime_allowlist_rejects_x_zip_compressed(): void
+	{
+		// RED BASELINE (Phase 2 will fix via normalisation):
+		// file(1) returns 'application/x-zip-compressed' for many valid ZIPs.
+		// Current allow-list does NOT include it → currently rejected.
+		$this->assertFalse(pfb_mime_in_allowlist('application/x-zip-compressed', $this->allowlist));
+	}
+
+	public function test_pfb_mime_allowlist_rejects_x_zip(): void
+	{
+		// RED BASELINE (Phase 2 will fix via normalisation):
+		// file(1) may return 'application/x-zip' for some ZIP creators.
+		// Current allow-list does NOT include it → currently rejected.
+		$this->assertFalse(pfb_mime_in_allowlist('application/x-zip', $this->allowlist));
+	}
+
+	public function test_pfb_mime_allowlist_accepts_canonical_gzip(): void
+	{
+		// 'application/gzip' is in the shipped allow-list → must be accepted.
+		$this->assertTrue(pfb_mime_in_allowlist('application/gzip', $this->allowlist));
+	}
+
+	public function test_pfb_mime_allowlist_accepts_x_gzip(): void
+	{
+		// 'application/x-gzip' IS in the shipped allow-list → must be accepted.
+		$this->assertTrue(pfb_mime_in_allowlist('application/x-gzip', $this->allowlist));
+	}
+
+	public function test_pfb_mime_allowlist_rejects_octet_stream(): void
+	{
+		// 'application/octet-stream' is NOT in the allow-list and must never
+		// be promoted — normalisation must not touch this string.
+		$this->assertFalse(pfb_mime_in_allowlist('application/octet-stream', $this->allowlist));
+	}
+
+	public function test_pfb_mime_allowlist_accepts_text_plain(): void
+	{
+		// 'text/plain' is in the shipped allow-list → must be accepted.
+		$this->assertTrue(pfb_mime_in_allowlist('text/plain', $this->allowlist));
+	}
+}

--- a/tests/php/PfbMimeNormaliseTest.php
+++ b/tests/php/PfbMimeNormaliseTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for pfb_mime_normalise() — ADR-44 Phase 2.
+ *
+ * pfb_mime_normalise() canonicalises variant MIME strings returned by file(1)
+ * so valid feeds packaged by non-canonical tools pass the allow-list gate.
+ * It is a pure function: string in, string out, never promotes a non-archive.
+ *
+ * Critical correctness: the substring "zip" also appears inside "gzip" and
+ * "bzip2". Those are distinct, valid archive types that MUST pass through
+ * unchanged. test_normalise_x_bzip2_unchanged and test_normalise_gzip_unchanged
+ * pin the guards that prevent them from being misrouted to application/zip.
+ */
+#[CoversFunction('pfb_mime_normalise')]
+final class PfbMimeNormaliseTest extends TestCase
+{
+	public function test_normalise_x_zip_compressed_to_zip(): void
+	{
+		// file(1) returns this for ZIPs made by Info-ZIP / Windows Explorer etc.
+		// Must be canonicalised to application/zip to pass the allow-list gate.
+		$this->assertSame('application/zip', pfb_mime_normalise('application/x-zip-compressed'));
+	}
+
+	public function test_normalise_x_zip_to_zip(): void
+	{
+		// file(1) returns application/x-zip for some ZIP creators.
+		// Must be canonicalised to application/zip.
+		$this->assertSame('application/zip', pfb_mime_normalise('application/x-zip'));
+	}
+
+	public function test_normalise_zip_substring_case_insensitive(): void
+	{
+		// Substring "zip" match is case-insensitive (stripos), so upper-cased
+		// variant strings are also normalised to application/zip.
+		$this->assertSame('application/zip', pfb_mime_normalise('Application/X-ZIP'));
+	}
+
+	public function test_normalise_x_gzip_to_gzip(): void
+	{
+		// application/x-gzip is a known variant of application/gzip.
+		// The switch-case maps it to application/gzip — NOT application/zip —
+		// because "gzip" contains "zip" and must not be caught by the substring rule.
+		$this->assertSame('application/gzip', pfb_mime_normalise('application/x-gzip'));
+	}
+
+	public function test_normalise_x_bzip2_unchanged(): void
+	{
+		// application/x-bzip2 contains the substring "zip" (via "bzip").
+		// The bzip guard in the catch-all ensures it is NOT rewritten to
+		// application/zip — it must pass through unchanged.
+		$this->assertSame('application/x-bzip2', pfb_mime_normalise('application/x-bzip2'));
+	}
+
+	public function test_normalise_gzip_unchanged(): void
+	{
+		// application/gzip is already canonical and in the allow-list.
+		// The gzip guard ensures the substring "zip" inside "gzip" does NOT
+		// trigger the catch-all rewrite — it must pass through unchanged.
+		$this->assertSame('application/gzip', pfb_mime_normalise('application/gzip'));
+	}
+
+	public function test_normalise_octet_stream_unchanged(): void
+	{
+		// application/octet-stream is not an archive type and must never be promoted.
+		$this->assertSame('application/octet-stream', pfb_mime_normalise('application/octet-stream'));
+	}
+
+	public function test_normalise_text_plain_unchanged(): void
+	{
+		// Non-archive types must pass through unchanged.
+		$this->assertSame('text/plain', pfb_mime_normalise('text/plain'));
+	}
+
+	public function test_normalise_empty_string_unchanged(): void
+	{
+		// Empty string must not be modified (no division-by-zero-equivalent path).
+		$this->assertSame('', pfb_mime_normalise(''));
+	}
+
+	public function test_normalise_canonical_zip_unchanged(): void
+	{
+		// application/zip is already canonical; calling normalise must be idempotent.
+		$this->assertSame('application/zip', pfb_mime_normalise('application/zip'));
+	}
+
+	public function test_pfb_filter_mime_accepts_x_zip_compressed_after_normalise(): void
+	{
+		// Integration: before normalisation, application/x-zip-compressed is rejected
+		// by pfb_mime_in_allowlist() (Phase 1 RED baseline).
+		// After normalisation it resolves to application/zip → accepted.
+		// Asserting the before-state first proves normalisation caused the change.
+		$global = $GLOBALS['pfb']['mime_types'] ?? [];
+		$allowlist = !empty($global) ? $global : array_flip([
+			'inode/x-empty', 'text/x-file',
+			'text/plain', 'text/html', 'text/xml', 'text/csv',
+			'application/csv', 'application/json', 'application/x-ndjson',
+			'application/x-tar',
+			'application/gzip', 'application/x-gzip',
+			'application/x-bzip2',
+			'application/zip',
+		]);
+
+		// Before-state: raw string is rejected.
+		$this->assertFalse(
+			pfb_mime_in_allowlist('application/x-zip-compressed', $allowlist),
+			'Pre-condition: raw x-zip-compressed must be absent from the allow-list'
+		);
+
+		// After normalisation: canonical string is accepted.
+		$this->assertTrue(
+			pfb_mime_in_allowlist(pfb_mime_normalise('application/x-zip-compressed'), $allowlist),
+			'Post-condition: normalised x-zip-compressed must be accepted by the allow-list'
+		);
+	}
+}


### PR DESCRIPTION
## ADR-44 — Normalise MIME-type strings before the allow-list gate in `pfb_filter()`

Implements [ADR-44](.ADRs/ADR_44_MIME_Normalization/ADR.md). Valid blocklist ZIPs packaged by non-canonical tools (Info-ZIP, 7-Zip, Windows Explorer, Python `zipfile`, …) make `file(1)` return variant MIME strings such as `application/x-zip-compressed` / `application/x-zip`, which are not in the `$pfb['mime_types']` allow-list. They were rejected before the ZIP dispatch branch was reached. This normalises the known variant strings to their canonical form **before** the allow-list lookup, without touching the allow-list itself.

### Change

- New pure helper `pfb_mime_in_allowlist(string $mime, array $allowlist): bool` — the allow-list membership lookup, extracted from the constant-17/18 branches (behaviour-preserving).
- New pure helper `pfb_mime_normalise(string $raw): string` — canonicalises `application/x-zip-compressed` / `application/x-zip` (and other `zip`-bearing variants) to `application/zip`, and `application/x-gzip` to `application/gzip`. Wired into the `PFB_FILTER_FILE_MIME` (17) branch only, before the lookup; a debug-level event (`pfb_logger` level 5 → `/tmp/pfb_debug`) is logged whenever it rewrites a string.
- Stale ZIP-MIME `TODO` comments in `pfb_download()` updated to reference ADR-44 (comment-only; the commented-out `_COMPRESSED` call is intentionally left disabled — inner-content validation is out of scope).

### Correctness note

The substring `zip` also occurs inside `gzip` and `bzip2`, both already-valid allow-listed types. The catch-all `contains "zip"` rule explicitly excludes `gzip`/`bzip` so `application/gzip` and `application/x-bzip2` are **not** rewritten to `application/zip` (which would misroute them into the ZIP/tar handler). `application/octet-stream` and any other non-archive string are never promoted.

Constant 16 (`PFB_FILTER_FILE_MIME_COMPARE`, exact-match), constant 18, and `$pfb['mime_types']` are unchanged.

### Tests

- `tests/php/PfbMimeAllowlistTest.php` — 7 oracle tests pinning the shipped allow-list (incl. the `x-zip-compressed` / `x-zip` red baselines).
- `tests/php/PfbMimeNormaliseTest.php` — 11 tests for the normaliser, including the `gzip`/`bzip2` guard (`test_normalise_x_bzip2_unchanged`, `test_normalise_gzip_unchanged`, `test_normalise_x_gzip_to_gzip`) and a before→after integration test (`x-zip-compressed` rejected raw, accepted after normalise).
- Full suite green: 1553 tests, 0 failures.

### Out of CI (maintainer smoke)

The live download/extraction path cannot run in CI (no real feed download / live Unbound). `RESULTS/SMOKE_CHECKLIST.md` covers it: ZIP-variant feed accepted, `gzip`/`bzip2` not regressed, the debug log line, and a rejected HTML/non-archive body. Status stays **Proposed** until that smoke passes; the maintainer flips it to **Accepted**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of downloaded feed file MIME types so common archive variants are recognized more consistently.
  * Added support for MIME normalization, helping ZIP and GZIP files pass validation when reported under alternate names.

* **Bug Fixes**
  * Reduced false rejections for archive feeds detected with non-canonical MIME strings.
  * Preserved existing behavior for non-archive and BZIP2 content, avoiding unintended MIME rewrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->