### PR TITLE
build: make sparse-clone-ports.sh idempotent (shared CI/local ports prep)

### DIFF
--- a/scripts/sparse-clone-ports.sh
+++ b/scripts/sparse-clone-ports.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# sparse-clone-ports.sh — blobless + sparse clone of the FreeBSD-ports tree.
+# sparse-clone-ports.sh — prepare the FreeBSD-ports tree at REF (blobless + sparse):
+# a fresh clone when DEST is absent, or an idempotent reuse of an existing clone.
 #
 # A full --depth 1 clone is ~1.3 GB; the portable builder reads only the port dir
 # plus a handful of dep Makefiles.  A blobless+sparse clone of those directories
@@ -57,8 +58,9 @@ PORT_DIR="$(python3 "$BUILDER" --print-port-origin --channel "$CHANNEL")" || exi
 # 1. Acquire the tree at REF — fresh blobless clone if DEST is absent, else fetch REF
 #    into an EXISTING git work-tree and check it out (idempotent reuse). Either way the
 #    tree ends on REF; no blobs are fetched yet, git knows all tree paths.
-if [ -d "${DEST}/.git" ]; then
-	# Reuse: point origin at the canonical URL (the clone's origin may differ) and fetch REF
+if [ -e "${DEST}/.git" ]; then
+	# Reuse an existing git work-tree (-e, not -d: a linked worktree's .git is a FILE). Point
+	# origin at the canonical URL (the clone's origin may differ) and fetch REF
 	# blobless FROM the named remote, so git registers it as the partial-clone promisor and the
 	# sparse checkout below lazy-fetches only the needed blobs — exactly like the fresh clone.
 	# Checking out REF corrects a tree left on the wrong branch instead of building from it.

--- a/scripts/sparse-clone-ports.sh
+++ b/scripts/sparse-clone-ports.sh
@@ -9,11 +9,20 @@
 #   sparse-clone-ports.sh URL REF DEST CHANNEL PHP PYFLAVOR
 #
 #   URL        FreeBSD-ports HTTPS clone URL
-#   REF        branch or ref to clone (e.g. pfblockerng/use-github)
-#   DEST       destination directory (must not exist)
+#   REF        branch or ref to fetch (e.g. pfblockerng/use-github)
+#   DEST       destination directory — created (fresh clone) if absent; an EXISTING
+#              git work-tree is fetched + checked out at REF (idempotent reuse)
 #   CHANNEL    build-pkg-portable --channel value (devel|stable|nightly)
 #   PHP        build-pkg-portable --php value (e.g. 8.3)
 #   PYFLAVOR   build-pkg-portable --py-flavor value (e.g. py311)
+#
+# This is the SINGLE 'prepare the ports tree at REF' step shared by CI and local
+# builds — CI hits the fresh-clone branch on an empty runner dir, a local/repeat build
+# hits the reuse branch on a persistent clone, and both end on REF with the same sparse
+# checkout. Reuse FETCHES + checks out REF rather than trusting whatever branch happens
+# to be checked out: a tree left on e.g. devel installs an EMPTY pfblockerng_extra.inc
+# stub and builds a silently-broken .pkg. So the build never depends on a human having
+# remembered to switch branches.
 #
 # The script leaves DEST ready for:
 #   python3 scripts/build-pkg-portable.py --ports DEST ...
@@ -45,12 +54,29 @@ BUILDER="${SCRIPT_DIR}/build-pkg-portable.py"
 # builder (_CHANNEL_PORT_SUB); validates the channel name and errors on unknown values.
 PORT_DIR="$(python3 "$BUILDER" --print-port-origin --channel "$CHANNEL")" || exit 1
 
-# 1. Blobless clone — no blobs fetched yet; git knows all tree paths.
-git clone --depth 1 --filter=blob:none --no-checkout -b "$REF" "$URL" "$DEST"
+# 1. Acquire the tree at REF — fresh blobless clone if DEST is absent, else fetch REF
+#    into an EXISTING git work-tree and check it out (idempotent reuse). Either way the
+#    tree ends on REF; no blobs are fetched yet, git knows all tree paths.
+if [ -d "${DEST}/.git" ]; then
+	# Reuse: point origin at the canonical URL (the clone's origin may differ) and fetch REF
+	# blobless FROM the named remote, so git registers it as the partial-clone promisor and the
+	# sparse checkout below lazy-fetches only the needed blobs — exactly like the fresh clone.
+	# Checking out REF corrects a tree left on the wrong branch instead of building from it.
+	git -C "$DEST" remote set-url origin "$URL" 2>/dev/null || git -C "$DEST" remote add origin "$URL"
+	git -C "$DEST" fetch --depth 1 --filter=blob:none origin "$REF"
+	co_target=FETCH_HEAD
+elif [ -e "$DEST" ]; then
+	printf '%s: %s exists but is not a git work-tree — refusing to overwrite\n' "$0" "$DEST" >&2
+	exit 1
+else
+	git clone --depth 1 --filter=blob:none --no-checkout -b "$REF" "$URL" "$DEST"
+	co_target="$REF"
+fi
 
-# 2. Sparse-checkout the pfBlockerNG port dir so its Makefile is readable.
+# 2. Sparse-checkout the pfBlockerNG port dir so its Makefile is readable, then check out
+#    REF — setting the cone first limits an existing full clone's materialisation too.
 git -C "$DEST" sparse-checkout set --cone "$PORT_DIR"
-git -C "$DEST" checkout
+git -C "$DEST" checkout "$co_target"
 
 # 3. Ask the builder which origins the build needs.
 #    --print-build-origins reads only the port Makefile (already checked out) plus

--- a/tests/shell/sparse_clone_ports_spec.sh
+++ b/tests/shell/sparse_clone_ports_spec.sh
@@ -1,0 +1,117 @@
+#shellcheck shell=sh
+# sparse-clone-ports.sh — the SINGLE 'prepare the FreeBSD-ports tree at REF' step shared by
+# BOTH CI (fresh clone on an empty runner dir) and local/repeat builds (reuse a persistent
+# clone). One script, two callers; CI is just the fresh-clone special case of the local flow.
+#
+# Behavioural contracts pinned here:
+#   fresh-clone    — DEST absent -> blobless clone of REF; the materialised port Makefile is
+#                    the REF variant (USE_GITHUB=yes).
+#   reuse-fixes    — DEST is a git clone left on the WRONG branch (devel — whose port installs
+#                    an EMPTY pfblockerng_extra.inc stub, the silently-broken .pkg) -> the
+#                    script FETCHES + checks out REF. before: NOT the build-input variant;
+#                    after: USE_GITHUB=yes — green proves the switch CAUSED the fix (red on the
+#                    old script, whose `git clone` into an existing DEST aborts).
+#   refuse-foreign — DEST exists but is NOT a git work-tree -> exit nonzero, nothing overwritten.
+#
+# Why it matters: a build that trusts whatever branch a stale local clone happens to be on
+# silently ships a broken .pkg. Sharing this one branch-ensuring step between CI and local
+# removes that divergence — the bug that cost a long debugging session.
+#
+# The real build-pkg-portable.py query interface (--print-port-origin / --print-build-origins)
+# is stubbed by a fake python3 on PATH, so the spec needs no real ports tree or dep Makefiles;
+# only the git acquisition logic under test runs, against a local file:// remote.
+
+Describe 'sparse-clone-ports.sh'
+  SCRIPT="${PFB_ROOT}/scripts/sparse-clone-ports.sh"
+  PORT_SUB="net/pfSense-pkg-pfBlockerNG-devel"
+
+  # Build a local git 'remote' with two branches at the port Makefile (devel = stub; the
+  # use-github branch = USE_GITHUB=yes) and a fake python3 covering the builder's two query
+  # subcommands. file:// + uploadpack.allowFilter so the blobless clone/fetch work locally.
+  setup() {
+    # Scrub inherited git context. Under the pre-commit hook git exports GIT_DIR /
+    # GIT_INDEX_FILE / GIT_WORK_TREE / ... pointing at the REAL repo; without this the
+    # fixture's git init/clone AND the script-under-test's `git -C` would hit it, not the
+    # file:// fixture. (BeforeEach runs in-context, so the unset reaches the When too.)
+    unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/sparseclone.XXXXXX")"
+    REMOTE="${WORK}/remote"
+    DEST="${WORK}/dest"
+    URL="file://${REMOTE}"
+    MAKEFILE="${DEST}/${PORT_SUB}/Makefile"
+    mkdir -p "${REMOTE}/${PORT_SUB}"
+    (
+      cd "$REMOTE" || exit 1
+      git init -q
+      git config user.email ci@example.invalid
+      git config user.name CI
+      git config uploadpack.allowFilter true
+      git checkout -q -b devel
+      printf 'PORTNAME=pfBlockerNG-devel\n# classic: pfblockerng_extra.inc from FILESDIR (stub)\n' > "${PORT_SUB}/Makefile"
+      git add -A && git -c commit.gpgsign=false commit -qm devel
+      git checkout -q -b pfblockerng/use-github
+      printf 'PORTNAME=pfBlockerNG-devel\nUSE_GITHUB=yes\n' > "${PORT_SUB}/Makefile"
+      git add -A && git -c commit.gpgsign=false commit -qm use-github
+      git checkout -q devel
+    ) >/dev/null 2>&1
+    BIN="${WORK}/bin"
+    mkdir -p "$BIN"
+    cat > "${BIN}/python3" <<'PYEOF'
+#!/bin/sh
+# stand-in for `python3 build-pkg-portable.py ...` — only the clone script's two query
+# subcommands; echo the devel port dir for both, ignore everything else.
+for _a in "$@"; do
+	case "$_a" in
+		--print-port-origin|--print-build-origins) echo "net/pfSense-pkg-pfBlockerNG-devel"; exit 0 ;;
+	esac
+done
+exit 0
+PYEOF
+    chmod +x "${BIN}/python3"
+    PATH="${BIN}:${PATH}"
+  }
+  cleanup() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # Discard git's incidental clone/checkout chatter and echo only the meaningful outcome, so
+  # the assertions pin behaviour (which branch variant materialised) not volatile git wording.
+  run_clone() { sh "$SCRIPT" "$URL" pfblockerng/use-github "$DEST" devel 8.3 py311; }
+  is_build_input_variant() { grep -q '^USE_GITHUB=yes' "$MAKEFILE"; }
+
+  fresh_result() {
+    run_clone >/dev/null 2>&1 || { echo "script-failed=$?"; return 1; }
+    if is_build_input_variant; then echo 'variant=usegithub'; else echo 'variant=stub'; fi
+  }
+  It 'fresh-clone: clones REF into an absent DEST as the build-input variant'
+    When call fresh_result
+    The status should be success
+    The output should equal 'variant=usegithub'
+  End
+
+  # GIVEN an existing clone parked on the wrong branch (devel, the stub), WHEN the shared
+  # prepare step runs, THEN the tree ends on REF (use-github). before/after both asserted so
+  # green proves the switch caused it — and the old `git clone`-into-existing-DEST path is red.
+  reuse_before_after() {
+    git clone -q "$URL" "$DEST" >/dev/null 2>&1            # full clone, checks out devel
+    if is_build_input_variant; then echo 'before=usegithub'; else echo 'before=stub'; fi
+    run_clone >/dev/null 2>&1 || { echo "script-failed=$?"; return 1; }
+    if is_build_input_variant; then echo 'after=usegithub'; else echo 'after=stub'; fi
+  }
+  It 'reuse-fixes: switches an existing clone off the wrong branch onto REF'
+    When call reuse_before_after
+    The status should be success
+    The line 1 of output should equal 'before=stub'
+    The line 2 of output should equal 'after=usegithub'
+  End
+
+  refuse_result() {
+    mkdir -p "$DEST" && : > "${DEST}/not-a-clone"
+    run_clone 2>&1  # merge the refusal (stderr) into output for a single clean assertion
+  }
+  It 'refuse-foreign: a non-git DEST is refused, not overwritten'
+    When call refuse_result
+    The status should be failure
+    The output should include 'not a git work-tree'
+  End
+End


### PR DESCRIPTION
## What

Make `scripts/sparse-clone-ports.sh` the single shared "prepare the FreeBSD-ports tree at REF" step used by **both** CI and local builds, so neither can silently build a broken `.pkg` from the wrong ports branch.

## Why

The portable `.pkg` build needs the FreeBSD-ports tree on the build-input branch `pfblockerng/use-github` — there `USE_GITHUB=yes`, so the port installs the **real** `pfblockerng_extra.inc` from `${WRKSRC}`. The classic/`devel` port installs an **empty `${FILESDIR}` stub**, which produces a package that fatals at runtime on the missing `localize_text()` shim (this cost a long debugging session — DNSBL never set up because `sync_package_pfblockerng()` aborted).

CI was safe (it sparse-clones `pfblockerng/use-github` into a fresh runner dir), but a local/repeat build that hands the builder a **pre-existing `--ports` tree** had no branch guarantee — a stale clone left on `devel` built the stub silently.

## How

`sparse-clone-ports.sh` now branches on the destination:

- **absent DEST** → fresh blobless+sparse clone of REF (the CI case — unchanged).
- **existing git work-tree** → point `origin` at the canonical URL and fetch+checkout REF (blobless via the named remote, so the sparse checkout still lazy-fetches only the needed blobs), correcting a tree on the wrong branch instead of building from it.
- **non-git DEST** → refused, not overwritten.

CI is now just the fresh-clone special case of the local flow; no workflow changes needed (CI already passes a fresh `runner.temp/ports`).

## Tests

`tests/shell/sparse_clone_ports_spec.sh` (shellspec) against a local `file://` remote with `devel` (stub) and `pfblockerng/use-github` (`USE_GITHUB=yes`) branches:

- `fresh-clone` — absent DEST → the build-input variant (behaviour-preserving oracle).
- `reuse-fixes` — a clone parked on `devel` is switched onto REF (before=stub / after=usegithub asserted).
- `refuse-foreign` — a non-git DEST exits nonzero.

`reuse-fixes` + `refuse-foreign` are **red** against the old clone-only script, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
