### PR TITLE
fix(smoke): wait_ready staggered ssh->web liveness + generous web total cap

### DIFF
--- a/tests/smoke/wait_ready.sh
+++ b/tests/smoke/wait_ready.sh
@@ -16,18 +16,20 @@
 # comes up (e.g. the image failed to open, KVM aborted), we exit 1 IMMEDIATELY
 # rather than burning the whole timeout polling a guest that will never answer.
 #
-# Readiness, by role:
-#   - <web-port> GIVEN (pfSense): the webConfigurator answering an HTTP request.
-#     nginx + PHP come up AFTER sshd, so a live admin panel implies SSH is already
-#     usable — the web server is the meaningful "appliance ready" signal, gated on
-#     alone (no separate SSH wait).
-#   - <web-port> OMITTED (civm): a working SSH command (`true`) over the
-#     host-forwarded management NIC with the baked test key.
+# Readiness, by role (a STAGGERED liveness chain — see the probe loop):
+#   - <web-port> GIVEN (pfSense): the liveness floor is a real `ssh true` (sshd comes up
+#     before nginx/PHP); readiness is the webConfigurator answering a FULL HTTP request
+#     within a generous total cap. The SSH floor makes "alive but web warming" visible, so
+#     a slow cold box is never misread as dead.
+#   - <web-port> OMITTED (civm): a working SSH command (`true`) over the host-forwarded
+#     management NIC with the baked test key.
 #
-# Poll cadence: no VM answers in under ~8s, so wait out an initial grace, then
-# poll every 1s while readiness is plausible (< 75s elapsed) and every 5s after
-# that, up to the hard timeout (~3 min). A local-loopback connect that cannot
-# complete in 1s is dead, so the per-probe connect timeout is 1s.
+# Poll cadence: no VM answers in under ~8s, so wait out an initial grace, then poll every
+# 1s while readiness is plausible (< 75s elapsed) and every 5s after that, up to the hard
+# timeout (~3 min). The SSH probe's ConnectTimeout is 1s (a real ssh handshake that slow is
+# dead); the web probe is bounded by the generous TOTAL cap (WEB_MAX_TIME), NOT a 1s cap —
+# over SLIRP the TCP connect is a false-green (the hostfwd listener accepts before the guest
+# is up), so a connect timeout means nothing and only the full HTTP response is a real signal.
 #
 # The windows fit MEASURED boots, not the rule of thumb: pfSense reaches
 # web-ready in ~15s on a fast bare-metal host but ~55-60s on a nested-KVM /
@@ -84,8 +86,17 @@ SSH_OPTS="-p ${PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 # the qemu PID so a dead boot fails immediately — then start polling.
 INITIAL_GRACE=8
 
+# Generous TOTAL cap for the web probe (NOT a 1s cap). A cold, CPU-starved nested-KVM
+# webConfigurator accepts the connection instantly but can take several seconds to render
+# the first response; a 1s total killed every poll while the box was alive. Over SLIRP the
+# connect is a false-green (see the probe below), so this total time is the only meaningful
+# bound. Env-overridable for an especially slow box.
+WEB_MAX_TIME="${SMOKE_WEB_MAX_TIME:-15}"
+
 START="$(date +%s)"
 ATTEMPT=0
+# Whether the SSH liveness floor has been observed (pfSense/web role only); logged once.
+WEB_SSH_SEEN=""
 
 while :; do
     NOW="$(date +%s)"
@@ -111,14 +122,40 @@ while :; do
     ATTEMPT=$((ATTEMPT + 1))
 
     if [ -n "$WEB_PORT" ]; then
-        # pfSense: readiness = the webConfigurator answering. nginx + PHP come up
-        # AFTER sshd, so a live admin panel implies SSH is already usable — gate on
-        # the web server alone (the meaningful "appliance ready" signal).
-        if "$CURL" -fsSL --max-time 1 -o /dev/null "http://${HOST}:${WEB_PORT}/" 2>/dev/null; then
+        # pfSense readiness is a STAGGERED liveness chain so a slow-but-alive box is never
+        # misread as dead. (The bug the old web-only gate hit on cold nested-KVM CI: its 1s
+        # TOTAL curl cap killed every poll because the webConfigurator ACCEPTS instantly but
+        # takes >1s to render — while SSH was fine the whole time but unexercised, so the box
+        # read as dead.)
+        #
+        # Why no TCP/ping rung, and why connect-timeout is meaningless here: over QEMU SLIRP
+        # the hostfwd listener ACCEPTS the host-side connect (and answers a gateway ping)
+        # BEFORE the guest is up — both are false-green at 0s, and curl's connect always
+        # "succeeds" at the SLIRP layer so --connect-timeout never fires. The only signal that
+        # actually separates alive-and-ready from dead is a FULL HTTP response: a down web is
+        # RST fast by SLIRP (poll fails quick), a warming web answers within seconds. So the
+        # bound that matters is the generous total ${WEB_MAX_TIME}s cap, never a 1s one.
+
+        # Liveness floor: a real `ssh true` (NOT a TCP connect — that is the false-green
+        # above). sshd comes up before nginx/PHP; log the crossing once so a CI log makes
+        # "alive, web warming" unmistakable versus a genuinely dead boot.
+        # shellcheck disable=SC2086
+        if [ -z "$WEB_SSH_SEEN" ] && \
+           "$SSH" -i "$SSH_KEY" $SSH_OPTS "root@${HOST}" true 2>/dev/null; then
+            WEB_SSH_SEEN=1
+            echo "wait_ready: [${ELAPSED}s] ssh alive — system up, webConfigurator warming" >&2
+        fi
+
+        # Readiness: a FULL webConfigurator response, bounded only by the generous total cap.
+        if "$CURL" -fsSL --max-time "$WEB_MAX_TIME" -o /dev/null "http://${HOST}:${WEB_PORT}/" 2>/dev/null; then
             echo "boot-to-ready: ${ELAPSED} seconds"
             exit 0
         fi
-        PENDING=web
+        if [ -n "$WEB_SSH_SEEN" ]; then
+            PENDING="web (ssh alive — warming)"
+        else
+            PENDING="web (ssh not yet up)"
+        fi
     else
         # civm: no web server — gate on SSH over the host-forwarded management NIC.
         # The probe is a bare `true` ON PURPOSE: a remote command is parsed by the

--- a/tests/test_wait_ready_poll.py
+++ b/tests/test_wait_ready_poll.py
@@ -8,8 +8,12 @@ not learned ready until a much later poll, and the suite "waited for nothing".
 The new shape:
 
 * an **8s initial grace** (no VM answers sooner) before the first probe;
-* a **1s** poll while readiness is imminent (< 30s), relaxing to **5s** after;
-* a **1s** connect timeout (local loopback — slower than that is dead);
+* a **1s** poll while readiness is plausible (< 75s), relaxing to **5s** after;
+* SSH connect timeout **1s** (a real handshake that slow is dead); the **web** probe bounded
+  by a **generous total cap** (``WEB_MAX_TIME``), never a 1s cap — over SLIRP the TCP connect
+  is a false-green, so only the full HTTP response is a real signal;
+* a **staggered liveness chain** for pfSense: a real ``ssh true`` floor (alive) then a full
+  web 200 (ready), so a slow-but-alive cold box is never misread as dead;
 * a **per-role gate**: pfSense gates on the **web** server (admin panel; nginx+PHP
   come up after sshd, so a live panel implies SSH), civm on **SSH** (no web server).
 
@@ -56,14 +60,37 @@ def test_poll_cadence_is_one_then_five_seconds_not_exponential() -> None:
     assert "BACKOFF" not in text
 
 
-def test_connect_timeouts_are_one_second() -> None:
-    """SSH and web probes time out after 1s — a local-loopback connect that slow is dead."""
+def test_ssh_connect_is_one_second_web_total_is_generous() -> None:
+    """SSH connect stays 1s; the web probe is bounded by a GENEROUS total cap, NOT a 1s cap.
+
+    The old ``curl --max-time 1`` capped TOTAL time (connect + response): a cold nested-KVM
+    webConfigurator accepts instantly but renders in >1s, so every poll was killed while the
+    box was alive. The fix raises the web bound to ``WEB_MAX_TIME`` (default 15s). Over SLIRP
+    the TCP connect is a false-green, so there is deliberately NO web connect-timeout — only
+    the full response, within the generous cap, is a real signal. SSH keeps ConnectTimeout=1
+    (a real handshake that slow is dead).
+    """
     text = _wait_ready_text()
-    assert "ConnectTimeout=1" in text  # ssh
-    assert "--max-time 1" in text  # curl
-    # The old 5s connect timeouts must be gone.
+    assert "ConnectTimeout=1" in text  # ssh handshake — the real liveness probe
+    assert 'WEB_MAX_TIME="${SMOKE_WEB_MAX_TIME:-15}"' in text
+    assert '--max-time "$WEB_MAX_TIME"' in text  # curl bound by the generous total cap
+    # The 1s TOTAL cap that starved a slow-but-alive webConfigurator must be gone.
+    assert "--max-time 1" not in text
+    # The old 5s connect timeout must be gone.
     assert "ConnectTimeout=5" not in text
-    assert "--max-time 5" not in text
+
+
+def test_pfsense_web_role_has_ssh_liveness_floor() -> None:
+    """The pfSense/web role exercises a real ``ssh true`` liveness FLOOR, logged once.
+
+    This is the staggered chain: a slow-but-alive box (web warming) is distinguishable from a
+    dead one because the SSH floor is observed and logged before the web 200. A bare TCP/ping
+    rung would be a false-green over SLIRP, so the floor is a real ssh command — not a connect.
+    """
+    text = _wait_ready_text()
+    assert "WEB_SSH_SEEN" in text  # the floor-observed flag (logged once)
+    assert '"root@${HOST}" true' in text  # the real ssh liveness probe
+    assert "warming" in text  # the "alive, web warming" diagnostic that makes the state clear
 
 
 def test_default_timeout_has_headroom_over_slow_boot() -> None:


### PR DESCRIPTION
## What

`tests/smoke/wait_ready.sh`: make the pfSense boot-readiness probe a **staggered liveness chain** and stop the web probe's 1s **total**-time cap from starving a slow-but-alive webConfigurator.

## Why

Another session hit this in GitHub Actions: the VM was declared dead though it was alive. The web probe was `curl -fsSL --max-time 1`, and `--max-time` caps **total** time (connect + response). On a cold, CPU-starved nested-KVM box the webConfigurator **accepts the connection instantly** but takes **>1s to render** the first response — so every poll was killed by the 1s cap, and `wait_ready` timed out. SSH (a fast handshake) was fine the whole time but, for the pfSense role, was never exercised — so there was no signal that the box was alive-but-warming versus dead.

## How

- **Generous web total cap.** The web probe is now bounded by `WEB_MAX_TIME` (default **15s**, env `SMOKE_WEB_MAX_TIME`), not a 1s cap. Over QEMU SLIRP the TCP connect is a **false-green** — the hostfwd listener accepts before the guest is up — so a connect timeout is meaningless; only a **full HTTP response** within the generous cap is a real signal (a down web is RST fast, so polling stays responsive).
- **Staggered liveness chain.** A real `ssh true` floor is exercised (sshd comes up before nginx/PHP) and logged once — so a CI log reads `ssh alive — system up, webConfigurator warming` instead of a silent dead-looking box. Readiness still gates on the full web 200; SSH keeps `ConnectTimeout=1` (a real handshake that slow *is* dead). No ICMP/TCP rung — those are false-green over SLIRP.

## Tests

`tests/test_wait_ready_poll.py` pins the web total cap (`WEB_MAX_TIME`, no `--max-time 1`) and the SSH liveness floor (`WEB_SSH_SEEN` + the `ssh true` + the "warming" log). Both new pins are **red against the old 1s-cap web-only gate**, green after. Live-VM boot timing remains the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved readiness checks so systems can be recognized as “still warming up” instead of being marked dead too early.
  * Added a configurable total timeout for web readiness checks.

* **Bug Fixes**
  * Reduced false failure reports by requiring a full successful web response before considering the service ready.
  * Added clearer status messaging when SSH is reachable but the web service is not yet ready.

* **Documentation**
  * Updated readiness-polling notes to reflect the new boot sequence and timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->