### PR TITLE
fix(smoke): add ssh liveness floor to wait_ready web role

### DIFF
--- a/tests/smoke/wait_ready.sh
+++ b/tests/smoke/wait_ready.sh
@@ -90,6 +90,8 @@ INITIAL_GRACE=8
 
 START="$(date +%s)"
 ATTEMPT=0
+# SSH liveness floor observed (web/pfSense role only); logged once.
+WEB_SSH_SEEN=""
 
 while :; do
     NOW="$(date +%s)"
@@ -115,14 +117,23 @@ while :; do
     ATTEMPT=$((ATTEMPT + 1))
 
     if [ -n "$WEB_PORT" ]; then
-        # pfSense: readiness = the webConfigurator answering. nginx + PHP come up
-        # AFTER sshd, so a live admin panel implies SSH is already usable — gate on
-        # the web server alone (the meaningful "appliance ready" signal).
+        # Staggered liveness chain: an SSH FLOOR (sshd is up before nginx/PHP) then the
+        # web 200 (readiness). Logging the floor once means a slow-but-alive cold box reads
+        # as "alive — web warming" instead of looking dead while the webConfigurator renders.
+        # (No TCP/ping rung: over SLIRP both are false-green before the guest is up, so the
+        # floor must be a real `ssh true`, not a connect.)
+        # shellcheck disable=SC2086
+        if [ -z "$WEB_SSH_SEEN" ] && \
+           "$SSH" -i "$SSH_KEY" $SSH_OPTS "root@${HOST}" true 2>/dev/null; then
+            WEB_SSH_SEEN=1
+            echo "wait_ready: [${ELAPSED}s] ssh alive — system up, webConfigurator warming" >&2
+        fi
+        # Readiness = the webConfigurator answering. A live admin panel implies SSH is up.
         if "$CURL" -fsSL --connect-timeout 1 --max-time 2 -o /dev/null "http://${HOST}:${WEB_PORT}/" 2>/dev/null; then
             echo "boot-to-ready: ${ELAPSED} seconds"
             exit 0
         fi
-        PENDING=web
+        if [ -n "$WEB_SSH_SEEN" ]; then PENDING="web (ssh alive — warming)"; else PENDING="web (ssh not yet up)"; fi
     else
         # civm: no web server — gate on SSH over the host-forwarded management NIC.
         # The probe is a bare `true` ON PURPOSE: a remote command is parsed by the

--- a/tests/test_wait_ready_poll.py
+++ b/tests/test_wait_ready_poll.py
@@ -10,6 +10,8 @@ The new shape:
 * an **8s initial grace** (no VM answers sooner) before the first probe;
 * a **1s** poll while readiness is imminent (< 30s), relaxing to **5s** after;
 * a **1s** connect timeout (local loopback — slower than that is dead);
+* a **staggered liveness chain** for pfSense: a real ``ssh true`` floor (alive) logged once,
+  then the web 200 (ready), so a slow-but-alive cold box is never misread as dead;
 * a **per-role gate**: pfSense gates on the **web** server (admin panel; nginx+PHP
   come up after sshd, so a live panel implies SSH), civm on **SSH** (no web server).
 
@@ -72,6 +74,20 @@ def test_connect_timeouts_are_one_second() -> None:
     # The old 5s SSH connect timeout, and the too-tight 1s curl total, must be gone.
     assert "ConnectTimeout=5" not in text
     assert "--max-time 1" not in text
+
+
+def test_pfsense_web_role_has_ssh_liveness_floor() -> None:
+    """The pfSense/web role exercises a real ``ssh true`` liveness FLOOR, logged once.
+
+    The staggered chain: a slow-but-alive box (web warming) is distinguishable from a dead
+    one because the SSH floor is observed and logged before the web 200. A TCP/ping rung
+    would be a false-green over SLIRP, so the floor is a real ssh command, not a connect.
+    The floor only logs; the web 200 still owns the readiness exit (per-role gate unchanged).
+    """
+    text = _wait_ready_text()
+    assert "WEB_SSH_SEEN" in text  # the floor-observed flag (logged once)
+    assert '"root@${HOST}" true' in text  # the real ssh liveness probe
+    assert "warming" in text  # the "alive — web warming" diagnostic that makes the state clear
 
 
 def test_default_timeout_has_headroom_over_slow_boot() -> None:

--- a/tests/test_wait_ready_poll.py
+++ b/tests/test_wait_ready_poll.py
@@ -85,9 +85,21 @@ def test_pfsense_web_role_has_ssh_liveness_floor() -> None:
     The floor only logs; the web 200 still owns the readiness exit (per-role gate unchanged).
     """
     text = _wait_ready_text()
-    assert "WEB_SSH_SEEN" in text  # the floor-observed flag (logged once)
-    assert '"root@${HOST}" true' in text  # the real ssh liveness probe
-    assert "warming" in text  # the "alive — web warming" diagnostic that makes the state clear
+    ssh_guard = 'if [ -z "$WEB_SSH_SEEN" ] &&'  # the one-shot floor guard
+    ssh_probe = '"root@${HOST}" true'  # the real ssh liveness probe
+    web_probe = (
+        'if "$CURL" -fsSL --connect-timeout 1 --max-time 2 -o /dev/null "http://${HOST}:${WEB_PORT}/" 2>/dev/null; then'
+    )
+    warming_log = "ssh alive — system up, webConfigurator warming"
+
+    assert ssh_guard in text
+    assert ssh_probe in text
+    assert warming_log in text
+    # Staggered order: the floor (guard + ssh probe) must precede the web-200 readiness probe.
+    assert text.index(ssh_guard) < text.index(web_probe)
+    assert text.index(ssh_probe) < text.index(web_probe)
+    # One-shot: the warming diagnostic is emitted once (guarded by WEB_SSH_SEEN), never per poll.
+    assert text.count(warming_log) == 1
 
 
 def test_default_timeout_has_headroom_over_slow_boot() -> None:


### PR DESCRIPTION
## What

Add an SSH **liveness floor** to `wait_ready.sh`'s pfSense/web readiness gate, turning it into a staggered "is this alive" chain:

1. **Floor (alive):** a real `ssh true` (sshd is up before nginx/PHP), logged once.
2. **Readiness (ready):** the existing web-200 probe — unchanged.

A slow-but-alive cold box (nested-KVM CI) now logs `ssh alive — webConfigurator warming` instead of looking dead while the panel renders, and `PENDING` distinguishes `web (ssh alive — warming)` from `web (ssh not yet up)` so a stuck poll's log says which.

## Behaviourally a no-op to the gate

Log-only. The web 200 still owns the readiness exit and devel's `--connect-timeout 1 --max-time 2` curl bound is **untouched**, so the per-role gate is identical — this only makes the in-between state legible.

No TCP/ping rung: over SLIRP both are false-green before the guest is up, so the floor is a real `ssh true`, not a connect.

## Relationship to #592

This is the **still-valid half** of #592 (the staggered floor). #592's other half — drop the connect-timeout, bump to `WEB_MAX_TIME=15` — is **superseded** by devel's `845a9f2c` (`--connect-timeout 1 --max-time 2`): #592's rationale was "the connect-timeout is meaningless over SLIRP", but the real cause was a wrong SLIRP mgmt IP range (fixed separately), so the connect-timeout is meaningful again and devel's bound is correct. Merging #592 as-is would revert that. #592 is being closed in favour of this minimal change.

## Tests

`tests/test_wait_ready_poll.py::test_pfsense_web_role_has_ssh_liveness_floor` pins the floor (`WEB_SSH_SEEN`, the real `ssh true` probe, the "warming" diagnostic). Full poll suite green; shellcheck + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFkFbcdpFPdgcUij8ok4z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checking so systems now recognize SSH as responsive while the web interface is still warming up.
  * Status messages are more accurate during startup, reducing false “not ready” indications when web services are still loading.
  * Added automated coverage to verify the new readiness behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->