### PR TITLE
tests+docs(adr-44): failable pfb_filter wiring test + propagate corrected premise

### DIFF
--- a/.ADRs/ADR_44_MIME_Normalization/ADR.md
+++ b/.ADRs/ADR_44_MIME_Normalization/ADR.md
@@ -118,11 +118,14 @@ Rules:
 
 ### Positive
 
-- Eliminates false rejections of valid ZIP feeds packaged by non-canonical tools.
-- Normalisation is isolated to a single named helper — easy to audit and extend.
+- Isolates the MIME allow-list lookup in a named helper (`pfb_mime_in_allowlist()`)
+  — easy to audit, test, and extend.
+- The `stripos('zip')` catch-all handles live `…+zip` archive types (e.g.
+  `application/epub+zip`) that libmagic does emit, in addition to the defensive
+  exact-match rewrites for variant strings a non-stock magic database could produce.
+- The gzip/bzip2 guards prevent the catch-all from mis-rewriting those valid,
+  already-allowed types to `application/zip`.
 - No new external tool dependencies; no allow-list changes.
-- Unblocks ADR-44 (ZIP inner-content validation), which was deferred because ZIPs
-  were being rejected before reaching the validation branch.
 
 ### Negative / Risks
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -641,9 +641,10 @@ function pfb_mime_in_allowlist(string $mime, array $allowlist): bool {
 	return isset($allowlist[$mime]);
 }
 
-// ADR-44: canonicalise known archive MIME variants so valid feeds packaged by
-// non-canonical tools pass the allow-list gate. Pure: string in -> string out,
-// never promotes a non-archive string.
+// ADR-44: canonicalise known archive MIME variant strings before the allow-list
+// gate. Pure: string in -> string out. The stripos('zip') catch-all rewrites any
+// non-gzip/bzip string containing "zip" (e.g. application/epub+zip) to
+// application/zip; it does not promote unrelated types like application/octet-stream.
 function pfb_mime_normalise(string $raw): string {
 	// Exact-match canonicalisations first (so x-gzip maps to gzip, NOT zip).
 	switch ($raw) {
@@ -8360,11 +8361,12 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 			pfb_logger('.', 1);
 
-			/* ZIP MIME variant strings (e.g. application/x-zip-compressed) are now
-			   canonicalised to application/zip in pfb_filter() via pfb_mime_normalise()
-			   (ADR-44), so the outer ZIP MIME gate no longer false-rejects valid feeds.
-			   The post-extraction inner-content MIME check below stays disabled —
-			   ZIP inner-content validation is deferred to a future ADR.
+			/* pfb_mime_normalise() (ADR-44) canonicalises ZIP-bearing MIME variants before
+			   the allow-list gate. On a stock pfSense box, /usr/bin/file already returns
+			   application/zip for real ZIP bytes (no false rejections occur without it);
+			   normalisation is defensive — it handles custom magic databases and live
+			   epub+zip-style archive types. The post-extraction inner-content MIME check
+			   below stays disabled — ZIP inner-content validation is deferred to a future ADR.
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download')) {
 				return FALSE;
 			}

--- a/tests/php/PfbFileMimeNormaliseWiringTest.php
+++ b/tests/php/PfbFileMimeNormaliseWiringTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wiring test for pfb_mime_normalise() at L1042 of pfb_filter() — proves the
+ * normalise call is actually wired into the PFB_FILTER_FILE_MIME gate.
+ *
+ * Scenario: EPUB file whose file(1) MIME type is application/epub+zip.
+ * The allow-list contains application/zip but NOT application/epub+zip.
+ * Without the normalise call at L1042 the raw type fails the allow-list →
+ * pfb_filter() returns FALSE. With it, the stripos('zip') catch-all maps
+ * epub+zip → application/zip → allow-listed → pfb_filter() returns 'application/zip'.
+ *
+ * The EPUB fixture is a real zip whose first member is "mimetype" stored
+ * uncompressed (the EPUB Open Container spec §3.3 requirement that file(1) uses
+ * to identify EPUBs). Embedded as base64 for hermeticity — no shell dependency
+ * in the test path itself.
+ *
+ * Guard: if this host's file(1) cannot detect EPUBs, the test is skipped
+ * (markTestSkipped) so CI on boxes with an older magic database does not fail
+ * instead of the real wiring.
+ */
+#[CoversFunction('pfb_filter')]
+final class PfbFileMimeNormaliseWiringTest extends TestCase
+{
+	// Minimal valid EPUB: zip with "mimetype" stored/uncompressed as first member.
+	// Generated with: printf 'application/epub+zip' > mimetype;
+	//   zip -X -0 -q book.epub mimetype;
+	//   zip -X -q book.epub META-INF/container.xml
+	// Verified: /usr/bin/file -b --mime-type book.epub == application/epub+zip
+	private const EPUB_B64 = 'UEsDBAoAAAAAAPt+21xvYassFAAAABQAAAAIAAAAbWltZXR5cGVhcHBsaWNh'
+		. 'dGlvbi9lcHViK3ppcFBLAwQKAAAAAAD7fttckVPT0iEAAAAhAAAAFgAAAE1FVEEtSU5GL2Nv'
+		. 'bnRhaW5lci54bWw8P3htbCB2ZXJzaW9uPSIxLjAiPz48Y29udGFpbmVyLz5QSwECHgMKAA'
+		. 'AAAAD7fttcb2GrLBQAAAAUAAAACAAAAAAAAAAAAAAApIEAAAAAbWltZXR5cGVQSwECHgMKAAAA'
+		. 'AAD7fttckVPT0iEAAAAhAAAAFgAAAAAAAAABAAAApIE6AAAATUVUQS1JTkYvY29udGFpbmVy'
+		. 'LnhtbFBLBQYAAAAAAgACAHoAAACPAAAAAAA=';
+
+	private string $dir;
+	private string $cwd;
+	private string $epubPath;
+
+	protected function setUp(): void
+	{
+		$this->dir      = sys_get_temp_dir() . '/pfb_mime_wiring_' . uniqid('', TRUE);
+		mkdir($this->dir);
+		$this->cwd      = (string) getcwd();
+		$this->epubPath = $this->dir . '/book.epub';
+
+		file_put_contents($this->epubPath, base64_decode(self::EPUB_B64, TRUE));
+
+		// Only the wiring test's allow-list: application/zip is present,
+		// application/epub+zip is deliberately absent.
+		$GLOBALS['pfb']['mime_types'] = ['application/zip' => 1];
+	}
+
+	protected function tearDown(): void
+	{
+		chdir($this->cwd);
+		@unlink($this->epubPath);
+		@rmdir($this->dir);
+		unset($GLOBALS['pfb']['mime_types']);
+	}
+
+	/**
+	 * Scenario: EPUB whose file(1) type contains "zip"
+	 * Given  an EPUB file that file(1) identifies as application/epub+zip
+	 *        and an allow-list containing application/zip but not epub+zip
+	 * When   pfb_filter() runs the FILE_MIME gate (which calls pfb_mime_normalise
+	 *        at L1042 before the allow-list lookup)
+	 * Then   the catch-all normalises epub+zip → application/zip, which is
+	 *        allow-listed, so pfb_filter() returns 'application/zip'
+	 *        — proving the normalise call at L1042 is wired into the gate.
+	 *        Without L1042 the raw type fails the allow-list → returns FALSE.
+	 */
+	public function test_epub_zip_passes_via_normalise_wiring(): void
+	{
+		// Guard: verify host file(1) can detect this EPUB as application/epub+zip.
+		// If not, skip gracefully — the test relies on a live file(1) call.
+		$probe = [];
+		exec('/usr/bin/file -b --mime-type ' . escapeshellarg($this->epubPath), $probe);
+		if (($probe[0] ?? '') !== 'application/epub+zip') {
+			$this->markTestSkipped(
+				'host file(1) returned ' . ($probe[0] ?? '(empty)') . ' for the EPUB fixture; '
+				. 'expected application/epub+zip — skipping wiring test on this host'
+			);
+		}
+
+		// Given: EPUB on disk, allow-list has application/zip (not epub+zip).
+		// The pfb_filter() $input array: [0]=path (legacy unused), [1]=path, [2]=URL.
+		$result = pfb_filter(
+			["'unused'", $this->epubPath, 'http://feed.example/'],
+			PFB_FILTER_FILE_MIME,
+			'test'
+		);
+
+		// Then: normalise wired at L1042 maps epub+zip → application/zip → allowed.
+		$this->assertSame('application/zip', $result,
+			'Expected application/zip after epub+zip normalisation; '
+			. 'if FALSE, pfb_mime_normalise() is not wired into pfb_filter()'
+		);
+	}
+}

--- a/tests/php/PfbMimeAllowlistTest.php
+++ b/tests/php/PfbMimeAllowlistTest.php
@@ -9,14 +9,15 @@ use PHPUnit\Framework\TestCase;
  * Oracle tests for pfb_mime_in_allowlist() — extracted pure helper that
  * encapsulates the $pfb['mime_types'] membership lookup.
  *
- * These tests pin the CURRENT shipped allow-list behaviour before Phase 2
- * normalisation is introduced. They use $GLOBALS['pfb']['mime_types'] as
- * populated by bootstrap (the real shipped array_flip list) so they are
- * genuine oracles of the shipped allow-list, not a private copy.
+ * These tests pin the shipped allow-list behaviour. setUp() repopulates
+ * $pfb['mime_types'] from the canonical list on every run so sibling-test
+ * tearDown() calls that unset the global do not affect these oracles.
  *
- * Entries (b) and (c) record known RED baselines — types file(1) can return
- * for a valid ZIP that the current allow-list rejects. Phase 2 will flip
- * these to true via normalisation before the lookup.
+ * Entries (b) and (c) pin defensive baseline strings — types NOT emitted by
+ * stock FreeBSD libmagic for real ZIPs, but canonicalised by pfb_mime_normalise()
+ * (ADR-44) in case a non-stock magic database emits them. The raw strings remain
+ * absent from the allow-list; pfb_mime_normalise() maps them to application/zip
+ * before the lookup — wiring proven by PfbFileMimeNormaliseWiringTest.
  */
 #[CoversFunction('pfb_mime_in_allowlist')]
 final class PfbMimeAllowlistTest extends TestCase
@@ -25,13 +26,10 @@ final class PfbMimeAllowlistTest extends TestCase
 
 	protected function setUp(): void
 	{
-		// Prefer the real shipped allow-list as populated by bootstrap (the
-		// array_flip of pfblockerng.inc:274-287). Fall back to constructing it
-		// directly when a sibling test's tearDown() has unset the global
-		// (PfbFileMimeSinkEscapeTest does this), so these oracles stay
-		// isolated and always test against the canonical shipped list.
-		$global = $GLOBALS['pfb']['mime_types'] ?? [];
-		$this->allowlist = !empty($global) ? $global : array_flip([
+		// Always repopulate from the canonical shipped list (pfblockerng.inc:274-287)
+		// so sibling-test tearDown() calls that unset $pfb['mime_types'] cannot
+		// affect these oracles. If the shipped list changes, update this mirror.
+		$GLOBALS['pfb']['mime_types'] = array_flip([
 			'inode/x-empty', 'text/x-file',
 			'text/plain', 'text/html', 'text/xml', 'text/csv',
 			'application/csv', 'application/json', 'application/x-ndjson',
@@ -40,6 +38,12 @@ final class PfbMimeAllowlistTest extends TestCase
 			'application/x-bzip2',
 			'application/zip',
 		]);
+		$this->allowlist = $GLOBALS['pfb']['mime_types'];
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['pfb']['mime_types']);
 	}
 
 	public function test_pfb_mime_allowlist_accepts_canonical_zip(): void
@@ -50,17 +54,17 @@ final class PfbMimeAllowlistTest extends TestCase
 
 	public function test_pfb_mime_allowlist_rejects_x_zip_compressed(): void
 	{
-		// RED BASELINE (Phase 2 will fix via normalisation):
-		// file(1) returns 'application/x-zip-compressed' for many valid ZIPs.
-		// Current allow-list does NOT include it → currently rejected.
+		// application/x-zip-compressed is NOT emitted by stock FreeBSD libmagic for
+		// real ZIPs (it is a Windows / HTTP-header MIME). The allow-list does not
+		// include it; pfb_mime_normalise() maps it to application/zip before lookup.
 		$this->assertFalse(pfb_mime_in_allowlist('application/x-zip-compressed', $this->allowlist));
 	}
 
 	public function test_pfb_mime_allowlist_rejects_x_zip(): void
 	{
-		// RED BASELINE (Phase 2 will fix via normalisation):
-		// file(1) may return 'application/x-zip' for some ZIP creators.
-		// Current allow-list does NOT include it → currently rejected.
+		// application/x-zip is bound only to Mozilla omni.ja in libmagic — not
+		// emitted for ordinary ZIPs. The allow-list does not include it;
+		// pfb_mime_normalise() maps it to application/zip before lookup.
 		$this->assertFalse(pfb_mime_in_allowlist('application/x-zip', $this->allowlist));
 	}
 

--- a/tests/php/PfbMimeNormaliseTest.php
+++ b/tests/php/PfbMimeNormaliseTest.php
@@ -8,9 +8,11 @@ use PHPUnit\Framework\TestCase;
 /**
  * Unit tests for pfb_mime_normalise() — ADR-44 Phase 2.
  *
- * pfb_mime_normalise() canonicalises variant MIME strings returned by file(1)
- * so valid feeds packaged by non-canonical tools pass the allow-list gate.
- * It is a pure function: string in, string out, never promotes a non-archive.
+ * pfb_mime_normalise() canonicalises known ZIP-variant strings and any other
+ * non-gzip/bzip "zip"-bearing string (via a stripos catch-all) to application/zip.
+ * It is a pure function: string in, string out. Non-archive strings (e.g.
+ * application/octet-stream) pass through unchanged; the catch-all is bounded by
+ * the gzip/bzip guards, not by an explicit whitelist of archive MIME types.
  *
  * Critical correctness: the substring "zip" also appears inside "gzip" and
  * "bzip2". Those are distinct, valid archive types that MUST pass through
@@ -22,15 +24,18 @@ final class PfbMimeNormaliseTest extends TestCase
 {
 	public function test_normalise_x_zip_compressed_to_zip(): void
 	{
-		// file(1) returns this for ZIPs made by Info-ZIP / Windows Explorer etc.
-		// Must be canonicalised to application/zip to pass the allow-list gate.
+		// application/x-zip-compressed is absent from stock FreeBSD libmagic (it
+		// is a Windows / HTTP-header MIME). This normalisation is defensive — it
+		// canonicalises the string should a custom magic file or future libmagic
+		// build ever emit it, ensuring it passes the allow-list gate.
 		$this->assertSame('application/zip', pfb_mime_normalise('application/x-zip-compressed'));
 	}
 
 	public function test_normalise_x_zip_to_zip(): void
 	{
-		// file(1) returns application/x-zip for some ZIP creators.
-		// Must be canonicalised to application/zip.
+		// application/x-zip is bound only to Mozilla omni.ja in libmagic — not
+		// emitted for ordinary ZIPs. Defensive: canonicalised to application/zip
+		// in case a non-stock magic database emits it for a feed archive.
 		$this->assertSame('application/zip', pfb_mime_normalise('application/x-zip'));
 	}
 
@@ -89,12 +94,12 @@ final class PfbMimeNormaliseTest extends TestCase
 		$this->assertSame('application/zip', pfb_mime_normalise('application/zip'));
 	}
 
-	public function test_pfb_filter_mime_accepts_x_zip_compressed_after_normalise(): void
+	public function test_normalise_then_allowlist_composes_for_x_zip_compressed(): void
 	{
-		// Integration: before normalisation, application/x-zip-compressed is rejected
-		// by pfb_mime_in_allowlist() (Phase 1 RED baseline).
-		// After normalisation it resolves to application/zip → accepted.
-		// Asserting the before-state first proves normalisation caused the change.
+		// Composes the two pure helpers (pfb_mime_normalise + pfb_mime_in_allowlist)
+		// to show their intended contract: raw x-zip-compressed is rejected by the
+		// allow-list alone, but passes after normalisation maps it to application/zip.
+		// Does NOT call pfb_filter() — see PfbFileMimeNormaliseWiringTest for the gate.
 		$global = $GLOBALS['pfb']['mime_types'] ?? [];
 		$allowlist = !empty($global) ? $global : array_flip([
 			'inode/x-empty', 'text/x-file',


### PR DESCRIPTION
## What

Follow-up to ADR-44 (MIME normalisation before the download allow-list gate),
addressing the confirmed findings of an adversarial self-review. **No shipped bug,
no behaviour change** — a real test-coverage gap plus documentation drift.

### 1. A failable wiring test for the normalise call (the real gap)

The only line ADR-44 adds to the gate (`pfb_mime_normalise()` in the
`PFB_FILTER_FILE_MIME` branch) had **no failable test through `pfb_filter()`** — the
existing test composed the two pure helpers directly, so removing the wiring left the
whole suite green. New `PfbFileMimeNormaliseWiringTest` drives `pfb_filter()` with a
hermetic EPUB fixture whose `file -b --mime-type` is `application/epub+zip` — a *real,
live* `stripos('zip')` catch-all trigger — and asserts the gate returns
`application/zip`. It passes only with the wiring present (returns FALSE without it).
**Proven red→green.** A host-`file(1)` guard skips gracefully where EPUB magic is
unavailable. The misnamed helper-composition test was renamed to match what it does.

### 2. Propagate the corrected premise (#590)

`#590` corrected §1: libmagic reads the *bytes*, so real ZIP feeds already report
`application/zip` and were never false-rejected; the exact-match variant rewrites are
defensive. That correction was only half-applied. This reworps ADR §3, the shipped
`pfb_download` comment, the `pfb_mime_normalise()` docblock (the "never promotes a
non-archive string" claim was false — the catch-all rewrites any non-gzip/bzip
`zip`-bearing string), and the unit-test comments so none still claims a
false-rejection bug was fixed.

### 3. Nit

`PfbMimeAllowlistTest::setUp()` now repopulates the allow-list global from the
canonical list each run, removing silent oracle-drift when a sibling test unsets it.

## Tests

- `vendor/bin/phpunit` — 1554 tests, 0 failures (new wiring test runs, proven red→green).
- `phpstan` / `phpcs` / `php -l` / markdownlint — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ZIP-related file types so archive variants are recognized more consistently before allow-list checks.
  * EPUB files that report as ZIP archives are now more likely to pass validation when ZIP is permitted.
  * Added guardrails so already-allowed gzip/bzip2 MIME types are not rewritten incorrectly.

* **Documentation**
  * Clarified the MIME normalization behavior and related validation notes in the project documentation.

* **Tests**
  * Added and updated test coverage for MIME normalization and allow-list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->