### PR TITLE
deps(smoke): bump requests to 2.34.2 for CVE-2026-25645

### DIFF
--- a/tests/smoke/requirements.txt
+++ b/tests/smoke/requirements.txt
@@ -25,7 +25,8 @@ pytest-timeout==2.3.1
 # (tests/smoke/ui/webui.py) drives the CSRF form login + page GETs over HTTP.
 # Imported lazily (inside WebUI), so default collection -- which --ignore's
 # tests/smoke -- never needs it.
-requests==2.32.3
+# >=2.33.0 fixes CVE-2026-25645 (predictable tmp filenames in extract_zipped_paths).
+requests==2.34.2
 # ADR-14 Tier-B (browser): headless Chromium drives the JS-only UX
 # (tests/smoke/ui/test_browser.py) + captures per-page screenshot artifacts.
 # Imported lazily via pytest.importorskip (conftest + the test module), so a host


### PR DESCRIPTION
## What

Bump `requests` **2.32.3 → 2.34.2** in `tests/smoke/requirements.txt` to remediate **CVE-2026-25645**.

`requests <2.33.0` uses predictable temp filenames in `requests.utils.extract_zipped_paths()` (insecure temporary file → a local attacker can pre-place a malicious file at the predictable path). Fixed in **2.33.0** (non-deterministic extraction); 2.34.2 is the current stable on the same line.

## Scope / risk

- **Dev-only** dependency — `tests/smoke/` is the ADR-04 smoke harness, never shipped (release archives are `src/` only). Used by the ADR-14 Web-UI tier client (`tests/smoke/ui/webui.py`) for the CSRF login + page GETs.
- `requests`' public API is stable across 2.3x, so the `Session`/`get`/`post` the harness uses are unaffected.
- Only pin in the repo (`benchmarks/requirements.txt` has no `requests`).

## Verification

Version confirmed on PyPI (2.34.2 latest stable; 2.33.0+ all post-date the fix). No code paths change.

Sources: [CVE-2026-25645](https://www.sentinelone.com/vulnerability-database/cve-2026-25645/) · [requests changelog](https://requests.readthedocs.io/en/latest/community/updates/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
