### PR TITLE
dev: fix local-smoke on-box ref checkout (FETCH_HEAD, not stale local branch)

### DIFF
--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -111,15 +111,17 @@ fi
 
 # The bootstrap string:
 #   1. cd to the repo on the box
-#   2. git fetch + checkout the requested ref (the repo's scripts/smoke-on-box.sh
-#      may be at a different ref — smoke-on-box.sh re-execs itself at the right ref)
-#   3. exec smoke-on-box.sh (which re-execs at the checked-out ref's version)
-# This is the ref-stable bootstrap: the one-liner is the only part that has to work
-# across refs; smoke-on-box.sh handles everything else.
+#   2. fetch the requested ref and check out its FETCHED TIP (FETCH_HEAD) — NOT a
+#      bare `git checkout <ref>`, which lands the box's possibly-stale LOCAL branch
+#      (a clone whose local devel predates an upstream commit would miss files added
+#      since, e.g. scripts/smoke-on-box.sh itself → "cannot open" + no run).
+#   3. exec smoke-on-box.sh (which re-fetches + re-execs at that ref's version)
+# Ref-stable: the one-liner is the only part that has to work across refs;
+# smoke-on-box.sh handles everything else.
 # shellcheck disable=SC2089  # quoting: _ob_flags is pre-encoded for remote sh
 _bootstrap="cd /root/pfBlockerNG \
- && git fetch --quiet \
- && git checkout --quiet '$_REF_Q' \
+ && git fetch --quiet origin '$_REF_Q' \
+ && git checkout --quiet --force FETCH_HEAD \
  && exec sh scripts/smoke-on-box.sh $_ob_flags"
 
 printf 'local-smoke: leasing box (REF=%s marker=%s%s)\n' \

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -90,6 +90,10 @@ if [ -z "$_REF" ]; then
     fi
 fi
 
+# Normalize a remote-qualified ref (origin/devel) to its bare name: the on-box
+# `git fetch origin <ref>` wants the REMOTE ref name (devel), not `origin/devel`.
+_REF="${_REF#origin/}"
+
 # ── Build the on-box bootstrap command string ─────────────────────────────── #
 # The bootstrap runs on the box via ssh; it must be a single shell command string.
 # Use single-quote encoding for values that may contain shell metacharacters.

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -78,6 +78,9 @@ if [ "${PFB_ONBOX_REEXEC:-}" != "1" ]; then
         _REF="$(git rev-parse HEAD)"
         printf 'smoke-on-box: no --ref; staying on current HEAD %s\n' "$_REF" >&2
     else
+        # Normalize a remote-qualified ref (origin/devel → devel): git fetch origin
+        # wants the REMOTE ref name, not the origin/-prefixed tracking name.
+        _REF="${_REF#origin/}"
         printf 'smoke-on-box: fetching + checking out ref %s\n' "$_REF" >&2
         # Check out the FETCHED TIP, not a bare `git checkout <ref>` — the latter
         # lands the box's possibly-stale LOCAL branch (git fetch only moves the

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -221,6 +221,17 @@ if [ ! -f "$SMOKE_SSH_KEY" ]; then
     exit 2
 fi
 
+# ── Step 5b: provision the Python test deps into a repo-root venv ──────────── #
+# The box ships python3 but not pytest; install the harness deps (version-pinned
+# by the checked-out ref's tests/smoke/requirements.txt, + pytest explicitly, the
+# same set CI installs) into ${REPO_ROOT}/.venv so run-smoke.sh's non-CI .venv
+# preference uses it. Idempotent: reuse an existing venv; pip is a no-op when the
+# pinned deps are already satisfied.
+printf 'smoke-on-box: provisioning test venv (.venv)...\n' >&2
+[ -x "${REPO_ROOT}/.venv/bin/python" ] || python3 -m venv "${REPO_ROOT}/.venv"
+"${REPO_ROOT}/.venv/bin/python" -m pip install --quiet --upgrade pip
+"${REPO_ROOT}/.venv/bin/python" -m pip install --quiet -r "${REPO_ROOT}/tests/smoke/requirements.txt" pytest
+
 # ── Step 6: run smoke ─────────────────────────────────────────────────────── #
 printf 'smoke-on-box: running smoke (marker=%s%s)\n' \
     "$_MARKER" "${_K:+ k=$_K}" >&2

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -73,14 +73,18 @@ done
 # Guard: PFB_ONBOX_REEXEC=1 skips re-exec (we are already at the right ref).
 if [ "${PFB_ONBOX_REEXEC:-}" != "1" ]; then
     cd "$REPO_ROOT"
-    printf 'smoke-on-box: fetching latest refs...\n' >&2
-    git fetch --quiet
     if [ -z "$_REF" ]; then
         # No explicit ref — stay on whatever HEAD the bootstrap checked out.
         _REF="$(git rev-parse HEAD)"
+        printf 'smoke-on-box: no --ref; staying on current HEAD %s\n' "$_REF" >&2
+    else
+        printf 'smoke-on-box: fetching + checking out ref %s\n' "$_REF" >&2
+        # Check out the FETCHED TIP, not a bare `git checkout <ref>` — the latter
+        # lands the box's possibly-stale LOCAL branch (git fetch only moves the
+        # remote-tracking ref), which can predate files added upstream.
+        git fetch --quiet origin "$_REF"
+        git checkout --quiet --force FETCH_HEAD
     fi
-    printf 'smoke-on-box: checking out ref %s\n' "$_REF" >&2
-    git checkout --quiet "$_REF"
 
     # Re-exec the now-checked-out version with properly quoted args.
     # Build via set -- so each arg is a distinct word (no word-split on _K spaces).


### PR DESCRIPTION
## What

The ADR-47 on-box smoke path (`local-smoke.sh` bootstrap + `smoke-on-box.sh` step 1) did `git fetch && git checkout <ref>`, which checks out the box's **local** branch. `git fetch` only advances the remote-tracking ref, so a box whose local `devel` is behind `origin/devel` checks out a **stale tree** — missing files added upstream, including `scripts/smoke-on-box.sh` itself → `sh: cannot open scripts/smoke-on-box.sh` and the smoke never runs.

## How it surfaced

The **first live §8 2-box concurrent smoke** (the ADR-47 out-of-CI acceptance, run after #595 merged). box-1's local `devel` was **36 commits behind** `origin/devel` and lacked `smoke-on-box.sh`. The hermetic specs can't catch this — it only manifests against a real box with a stale local clone.

## Fix

Both checkouts fetch the **specific ref** and check out its **fetched tip**:

```sh
git fetch --quiet origin "$REF" && git checkout --quiet --force FETCH_HEAD
```

so the tree is exactly the requested ref regardless of stale local branches.

## Validation

Re-ran the **§8 2-box concurrent smoke against this branch**: both runs lease distinct boxes (box-1/box-2), check out `FETCH_HEAD`, and progress through the on-box pipeline (ref-checkout → FreeBSD-ports update → image refresh → build → smoke) — the "cannot open" failure is gone. These orchestration scripts have no hermetic spec by design (live-VM only); the live run is their red→green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFkFbcdpFPdgcUij8ok4z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local smoke test consistency by ensuring the requested version is checked out exactly as fetched, reducing mismatches caused by stale local branch state.
  * Made re-run behavior more predictable when no version is specified by using the currently checked-out code as the baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->