### PR TITLE
tests/smoke: fix flaky hook no-op race + dot_doq teardown + smoke-on-box -k forwarding

### DIFF
--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -240,5 +240,5 @@ printf 'smoke-on-box: running smoke (marker=%s%s)\n' \
     "$_MARKER" "${_K:+ k=$_K}" >&2
 
 set -- --paths tests/smoke --marker "$_MARKER" --timeout 30
-[ -n "$_K" ] && set -- "$@" --k "$_K"
+[ -n "$_K" ] && set -- "$@" -k "$_K"
 exec sh scripts/run-smoke.sh "$@"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2381,10 +2381,17 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"reset_pfb_baseline failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
     # Drop the derived state: tables/sqlite (clearip/cleardnsbl) + pf rules (blocking sync).
-    for verb in ("clearip", "cleardnsbl"):
-        cleared = vm.ssh(PHP_BIN, PFB_CLI, verb, timeout=120.0)
-        if cleared.returncode != 0:
-            raise RuntimeError(f"reset_pfb_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}")
+    # Skip the CLI-driven clears when the package is uninstalled — a prior test's `pkg delete`
+    # (e.g. test_dot_doq_block's uninstall case) removes PFB_CLI, so shelling it here fails with
+    # "Could not open input file". The uninstall already dropped the tables/rules, so there is no
+    # pfBlockerNG derived state left to clear; the config-section wipe above ran via pfSsh.php
+    # (core, no package needed). Without this guard the module-scoped teardown ERRORs after any
+    # uninstall test that happens to be last in its module.
+    if pkg_installed(vm):
+        for verb in ("clearip", "cleardnsbl"):
+            cleared = vm.ssh(PHP_BIN, PFB_CLI, verb, timeout=120.0)
+            if cleared.returncode != 0:
+                raise RuntimeError(f"reset_pfb_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}")
     apply_filter_sync(vm)
 
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2391,7 +2391,9 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
         for verb in ("clearip", "cleardnsbl"):
             cleared = vm.ssh(PHP_BIN, PFB_CLI, verb, timeout=120.0)
             if cleared.returncode != 0:
-                raise RuntimeError(f"reset_pfb_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}")
+                raise RuntimeError(
+                    f"reset_pfb_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}"
+                )
     apply_filter_sync(vm)
 
 

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -567,7 +567,9 @@ def test_hooks_changed_aliases_ip_and_dnsbl(deployed_vm: SmokeVM, mock_feeds: _M
     # $pfctlck read (slow/contended box), the no-op pass sees an empty table, self-heals, and reports
     # the alias — a non-deterministic false failure of the "empty changed-list" assertion below.
     # Polling the table non-empty here removes that race (it stays loaded between the two passes).
-    h.wait_pfctl_table(deployed_vm, ip_spec.alias)
+    assert h.wait_pfctl_table(deployed_vm, ip_spec.alias), (
+        f"IP kernel table {ip_spec.alias} did not populate after the settle update"
+    )
 
     # BEFORE: a second update over the UNCHANGED feeds reuse-caches both ⇒ both lists empty.
     h.clear_hook_markers(deployed_vm, token)
@@ -668,7 +670,9 @@ def test_hooks_webhook_fires_on_ip_change(
     # Settle the IP kernel table before the no-op pass — see the race note in
     # test_hooks_changed_aliases_ip_and_dnsbl: an unloaded table makes the no-op pass self-heal
     # (#468) and populate PFB_CHANGED_IP_ALIASES, firing the guard and producing a flaky callback.
-    h.wait_pfctl_table(deployed_vm, ip_spec.alias)
+    assert h.wait_pfctl_table(deployed_vm, ip_spec.alias), (
+        f"IP kernel table {ip_spec.alias} did not populate after the settle update"
+    )
 
     # BEFORE (guard off): a second update over the UNCHANGED feed hits the reuse cache ⇒
     # PFB_CHANGED_IP_ALIASES empty ⇒ the guard short-circuits ⇒ curl never runs ⇒ no callback.
@@ -767,7 +771,9 @@ def test_hooks_webhook_dnsbl_guard_branch(
     # Settle the IP kernel table before the DNSBL-only pass — see the race note in
     # test_hooks_changed_aliases_ip_and_dnsbl: an unloaded IP table makes the no-op pass self-heal
     # (#468) and populate PFB_CHANGED_IP_ALIASES, firing the IP guard on a DNSBL-only change.
-    h.wait_pfctl_table(deployed_vm, ip_spec.alias)
+    assert h.wait_pfctl_table(deployed_vm, ip_spec.alias), (
+        f"IP kernel table {ip_spec.alias} did not populate after the settle update"
+    )
     webhook_sink.clear()
 
     # DNSBL-only change: rewrite ONLY the DNSBL feed, leave the IP feed untouched, and

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -561,6 +561,13 @@ def test_hooks_changed_aliases_ip_and_dnsbl(deployed_vm: SmokeVM, mock_feeds: _M
     # Settle: a first full update processes both feeds (their aliases ARE updated here).
     h.clear_hook_markers(deployed_vm, token)
     h.reload(deployed_vm, "update")
+    # Wait until the IP alias kernel table is actually LOADED before the no-op pass. ADR-40's gate
+    # lists an alias on a reuse-cached pass iff its kernel table is empty (empty($pfctlck) → the #468
+    # empty-table self-heal). If the settle update's `pfctl -T replace` load races the next pass's
+    # $pfctlck read (slow/contended box), the no-op pass sees an empty table, self-heals, and reports
+    # the alias — a non-deterministic false failure of the "empty changed-list" assertion below.
+    # Polling the table non-empty here removes that race (it stays loaded between the two passes).
+    h.wait_pfctl_table(deployed_vm, ip_spec.alias)
 
     # BEFORE: a second update over the UNCHANGED feeds reuse-caches both ⇒ both lists empty.
     h.clear_hook_markers(deployed_vm, token)
@@ -658,6 +665,10 @@ def test_hooks_webhook_fires_on_ip_change(
     # this pass WOULD fire the hook — clear the sink afterwards so the no-op assertion
     # below is clean).
     h.reload(deployed_vm, "update")
+    # Settle the IP kernel table before the no-op pass — see the race note in
+    # test_hooks_changed_aliases_ip_and_dnsbl: an unloaded table makes the no-op pass self-heal
+    # (#468) and populate PFB_CHANGED_IP_ALIASES, firing the guard and producing a flaky callback.
+    h.wait_pfctl_table(deployed_vm, ip_spec.alias)
 
     # BEFORE (guard off): a second update over the UNCHANGED feed hits the reuse cache ⇒
     # PFB_CHANGED_IP_ALIASES empty ⇒ the guard short-circuits ⇒ curl never runs ⇒ no callback.
@@ -753,6 +764,10 @@ def test_hooks_webhook_dnsbl_guard_branch(
     # Settle: a first full update processes both feeds (both WOULD fire here); clear the
     # sink afterwards so the DNSBL-only assertion below is clean.
     h.reload(deployed_vm, "update")
+    # Settle the IP kernel table before the DNSBL-only pass — see the race note in
+    # test_hooks_changed_aliases_ip_and_dnsbl: an unloaded IP table makes the no-op pass self-heal
+    # (#468) and populate PFB_CHANGED_IP_ALIASES, firing the IP guard on a DNSBL-only change.
+    h.wait_pfctl_table(deployed_vm, ip_spec.alias)
     webhook_sink.clear()
 
     # DNSBL-only change: rewrite ONLY the DNSBL feed, leave the IP feed untouched, and


### PR DESCRIPTION
## What

Fix three smoke-suite **test/harness defects** surfaced by the now-runnable live smoke. None is a pfBlockerNG product bug — the product behaves correctly in every case; the tests/harness had unguarded timing and lifecycle assumptions.

These account for the `test_smoke_hooks` (ADR-12) and `test_dot_doq_block` (ADR-36) failures seen on the CE 2.8 + Plus 26.03 smoke fan-out. The ADR-43 cluster (`apply_on_change`/`tick`/`trigger_api`) is tracked separately in #568 and is **not** touched here.

## Root cause + fixes

### 1. Flaky `test_smoke_hooks` no-op assertions (3 tests)

`test_hooks_changed_aliases_ip_and_dnsbl`, `test_hooks_webhook_fires_on_ip_change`, and `test_hooks_webhook_dnsbl_guard_branch` assert `PFB_CHANGED_IP_ALIASES` is empty on a reuse-cached no-op update pass.

Under ADR-40, an alias is listed on a reuse-cached pass **iff its kernel pf table is empty** (`empty($pfctlck)` → the #468 empty-table self-heal; `pfb_alias_set_different` canonicalizes both sides so it cannot mis-fire on identical content). When the settle update's `pfctl -T replace` load races the next pass's table read on a slow/contended box, the no-op pass sees an empty table, **correctly self-heals**, and reports the alias — a non-deterministic false failure.

Evidence it is a race, not a product over-report: the failing subset differs per environment — CI fails all 3, an on-box `-k` run failed only 1, an isolated run failed none. `/var` is plain UFS (not MFS), ruling out a between-pass table wipe.

**Fix:** poll the IP table non-empty (`wait_pfctl_table`) after the settle update, before the no-op pass, so it is loaded and stays loaded across both passes. The assertion then holds deterministically.

### 2. `reset_pfb_baseline` ERROR after an uninstall test (`test_dot_doq_block`)

`reset_pfb_baseline` shells `PFB_CLI` for `clearip`/`cleardnsbl`, but `test_dot_doq_block`'s uninstall case `pkg delete`s pfBlockerNG (correctly removing the CLI). When that test is last in its module, the module-scoped baseline teardown ERRORs with `Could not open input file`.

**Fix:** guard the CLI-driven clears behind the existing `pkg_installed()` probe — the uninstall already dropped the tables/rules, and the config-section wipe runs via `pfSsh.php` (no package needed).

### 3. `smoke-on-box.sh` forwarded `--k` to `run-smoke.sh` (harness)

`run-smoke.sh`'s pytest-filter flag is `-k`; `smoke-on-box.sh` passed `--k`, so the unknown flag reached pytest (`unrecognized arguments: --k`). The on-box `-k` path was never exercised (CI smoke legs use markers), so it went unnoticed.

**Fix:** forward `-k`.

## Validation (live, ADR-04, box-1)

- **Fail-before:** CI fan-out fails all 3 hooks tests + the dot_doq teardown on both legs; an on-box unfixed run reproduced 1 hooks failure.
- **Pass-after:** 3 consecutive on-box rounds (`-k 'hook or dot'`) → **27 passed, 0 failed, 0 error** each, including all 3 hooks tests and the dot_doq uninstall + module teardown. The `-k` fix is exercised by these runs.

Live-VM smoke is dispatch-only (not PR-gating), so this validation was run by hand on the box.

## Related

- #568 — the ADR-43 smoke cluster (separate; not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke test reliability by preventing intermittent failures during cached no-op updates.
  * Made reset steps more resilient when the related package is not installed, avoiding unnecessary failures.
  * Corrected command-line argument handling in the smoke test runner so filter options work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->