### PR TITLE
tests/smoke: fix trigger_api DNSBL tests (allowlist mock host + probe feed member)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2328,6 +2328,10 @@ _BASELINE_GLOBAL_KEYS = (
     "pfb_agg_types",
     "pfb_quiet_hours",
     "pfb_tick_interval",
+    # Feed-host SSRF-guard allowlist: a module that allowlists the SLIRP mock net
+    # (test_trigger_api / test_smoke_feeds) must not leak the exemption forward, or a
+    # later module runs with the default-ON guard effectively disabled (false-green).
+    "pfb_feed_internal_allowlist",
 )
 
 

--- a/tests/smoke/test_trigger_api.py
+++ b/tests/smoke/test_trigger_api.py
@@ -85,7 +85,11 @@ def test_pfb_trigger_verb_reloads_dnsbl(deployed_vm: SmokeVM, mock_feeds: _MockF
     )
     with h.CaseContext(deployed_vm, spec):
         # CaseContext.__enter__ already called reload("update") via pfb_trigger.
-        # Assert the block is live.
+        # The probe name is a FIXED member shared with test_smoke_feeds, so an earlier
+        # module may have cached a resolved answer (a feed/cron allow->block is
+        # TTL-bounded by design and does NOT flush Unbound's C-cache). Flush that one
+        # name so the block assertion is not order-dependent.
+        h.flush_unbound_name(deployed_vm, domain)
         answer = h.dns_probe(deployed_vm, domain)
         assert h.is_vip(answer), (
             f"domain {domain!r} must be VIP-blocked after pfb_trigger reload\ngot answer: {answer!r}"
@@ -143,6 +147,8 @@ def test_deprecated_update_verb_still_reloads_dnsbl(deployed_vm: SmokeVM, mock_f
     # Inject manually (no CaseContext — we control the reload verb ourselves)
     h.inject(deployed_vm, spec)
     h.reload_deprecated_verb(deployed_vm, "update")
+    # Flush the shared fixed name (an earlier module may have cached it) before probing.
+    h.flush_unbound_name(deployed_vm, domain)
     answer = h.dns_probe(deployed_vm, domain)
     assert h.is_vip(answer), (
         f"domain {domain!r} must be VIP-blocked after deprecated 'update' reload\ngot answer: {answer!r}"

--- a/tests/smoke/test_trigger_api.py
+++ b/tests/smoke/test_trigger_api.py
@@ -41,6 +41,13 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
+    # The DNSBL tests below fetch their feed over HTTP from the SLIRP mock host
+    # 192.168.89.2 (RFC1918). The default-ON feed-host SSRF guard
+    # (pfb_feed_internal_filter) rejects an internal-resolving feed host, so the
+    # download is terminated ("Invalid URL") and 0 entries load — the name never
+    # blocks. Allowlist the WAN SLIRP test network so the filter stays ON yet the
+    # mock fetch is exempt (same fix test_smoke_feeds applies).
+    h.set_feed_internal_allowlist(smoke_vm, "192.168.89.0/24")
     h.ensure_dnsbl_vip(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
     try:
@@ -66,7 +73,9 @@ def test_pfb_trigger_verb_reloads_dnsbl(deployed_vm: SmokeVM, mock_feeds: _MockF
     This pins the pfb_trigger-via-helpers.reload() path: if the verb is not wired, the
     PHP CLI returns rc!=0 and reload() raises RuntimeError before any DNS assertion.
     """
-    domain = h.unique_domain()
+    # dnsbl_plain.txt lists this exact member (see the fixture + test_smoke_feeds);
+    # probe IT, not a random unique_domain() the static feed can never contain.
+    domain = "uuid-a344db4286a4.com"
     feed_url = mock_feeds.feed_url("dnsbl_plain.txt")
     spec = h.DnsblCase(
         aliasname="pfb_trigger_dnsbl",
@@ -121,7 +130,9 @@ def test_deprecated_update_verb_still_reloads_dnsbl(deployed_vm: SmokeVM, mock_f
     This is the adapter coverage test: reload_deprecated_verb() exercises the
     deprecated string path directly (bypassing the pfb_trigger abstraction in reload()).
     """
-    domain = h.unique_domain()
+    # dnsbl_plain.txt lists this exact member (see the fixture + test_smoke_feeds);
+    # probe IT, not a random unique_domain() the static feed can never contain.
+    domain = "uuid-a344db4286a4.com"
     feed_url = mock_feeds.feed_url("dnsbl_plain.txt")
     spec = h.DnsblCase(
         aliasname="pfb_dep_update_dnsbl",


### PR DESCRIPTION
## Summary

Both `test_trigger_api` DNSBL-reload tests were red on `devel` — and, because the
live-VM smoke suite is dispatch-only (not PR-gating), they had merged without ever
running live. Two independent **test** bugs (the ADR-43 product behaviour is correct):

1. **The feed-host SSRF guard blocked the mock feed.** The tests fetch their DNSBL
   feed over HTTP from the SLIRP mock host `192.168.89.2` (RFC1918). The default-ON
   feed-host filter (`pfb_feed_internal_filter`) correctly rejects an
   internal-resolving feed host, so the download terminated with
   `Invalid URL. Terminating Download!`, `0` entries loaded, and the name never
   blocked. Fixed by allowlisting the WAN SLIRP test network (`192.168.89.0/24`) in
   the module fixture — exactly as `test_smoke_feeds` already does.

2. **The probe domain is never in the feed.** The tests probed a random
   `unique_domain()`, which the static `dnsbl_plain.txt` fixture can never contain,
   so the name always resolved to the stub sentinel instead of blocking. Fixed by
   probing the feed's actual member (`uuid-a344db4286a4.com`), matching
   `test_smoke_feeds`.

## Validation

Run live on the pfSense VM pool against this branch:

- `test_trigger_api` → **5 passed** (was 2 failed, 3 passed), confirmed green both
  standalone and inside a parallel fan-out.

Surfaced by a live parallel-fanout run across the box pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of DNS blocklist reload checks so the app uses the expected feed data during smoke testing.
  * Made DNS lookup verification more stable by testing against a known domain instead of a randomly generated one.

* **Tests**
  * Strengthened smoke test coverage for DNS blocklist trigger and update flows.
  * Reduced flakiness in test assertions by aligning probe targets with the loaded test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->