### PR TITLE
tests/smoke: rewrite test_smoke_tick ledger writes in PHP + per-test ledger isolation

### DIFF
--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -50,6 +50,19 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
         h.collect_host_diagnostics(smoke_vm)
 
 
+@pytest.fixture(autouse=True)
+def _reset_ledger(deployed_vm: SmokeVM) -> None:
+    """Per-test isolation for the due-ledger.
+
+    The module baseline reset (``_pfb_module_baseline``) is module-scoped and does NOT touch
+    ``pfb_due_ledger.json``, so without this each test would inherit the previous test's ledger —
+    e.g. a dispatch's ``mark_ran`` leaving a future ``next_due``. That coupling is what let
+    ``test_tick_skips_non_due_feed`` pass only because an earlier test had run. Wipe the ledger
+    before every test so each one establishes its own state from a known-empty baseline.
+    """
+    deployed_vm.ssh(f"rm -f {LEDGER_PATH}")
+
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -55,8 +55,10 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
 # ---------------------------------------------------------------------------
 
 LEDGER_PATH = "/var/db/pfblockerng/pfb_due_ledger.json"
+_LEDGER_DIR = "/var/db/pfblockerng"
 _PHP = "/usr/local/bin/php"
 _PFB_PHP = "/usr/local/www/pfblockerng/pfblockerng.php"
+_PFB_EXTRA = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 
 
 # ---------------------------------------------------------------------------
@@ -74,17 +76,22 @@ def _read_ledger(vm) -> dict:
 
 
 def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: int = 0) -> None:
-    """Merge one entry into the on-box ledger via a small Python snippet."""
-    # Build the JSON snippet inline (no shell escaping needed beyond basic quoting).
-    entry_json = json.dumps({"last_run": last_run, "next_due": next_due, "jitter": jitter})
-    script = (
-        "import json, os; "
-        f"p='{LEDGER_PATH}'; "
-        "d=json.load(open(p)) if os.path.exists(p) else {}; "
-        f"d['{job_key}']={entry_json}; "
-        "open(p,'w').write(json.dumps(d))"
+    """Merge one entry into the on-box ledger via the package's own PHP ledger writer.
+
+    pfSense ships no ``python3`` (python3.11 only, no symlink), and the product already owns the
+    ledger format, so ``pfb_due_ledger_write_entry()`` (PHP) is the right tool — not a here-doc
+    Python snippet, which silently no-op'd at rc=127 and left these writes ineffective.
+    """
+    snippet = (
+        f"require_once('{_PFB_EXTRA}');"
+        f"pfb_due_ledger_write_entry('{job_key}', array("
+        f"'last_run' => {int(last_run)}, 'next_due' => {int(next_due)}, 'jitter' => {int(jitter)}"
+        f"), '{_LEDGER_DIR}');"
+        "echo 'OK';"
     )
-    vm.ssh(f"/usr/local/bin/python3 -c {json.dumps(script)}")
+    result = h.php_eval(vm, snippet)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_write_ledger_entry failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
 def _run_tick(vm) -> str:

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -60,7 +60,13 @@ def _reset_ledger(deployed_vm: SmokeVM) -> None:
     ``test_tick_skips_non_due_feed`` pass only because an earlier test had run. Wipe the ledger
     before every test so each one establishes its own state from a known-empty baseline.
     """
-    deployed_vm.ssh(f"rm -f {LEDGER_PATH}")
+    # SmokeVM.ssh() is check=False, so verify the wipe took — a silently-failed rm would leave
+    # the prior test's ledger in place and defeat the isolation this fixture exists to provide.
+    result = deployed_vm.ssh("rm", "-f", LEDGER_PATH)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"_reset_ledger failed to wipe {LEDGER_PATH}: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two fixes to the `test_smoke_tick` module — the second half of the "no Python on the appliance" cleanup started in #600.

1. **PHP ledger writes.** `_write_ledger_entry` shelled out to `/usr/local/bin/python3`, which the appliance does not ship (python3.11 only, no `python3` symlink) → `rc=127` silent no-op. The writes never landed, so the tests passed/failed by accident of the absent-ledger *due-now* fallback and prior-test state:
   - `test_tick_dispatches_due_feed`'s "before: next_due in the past" assertion was vacuous (absent ledger reads `next_due=0 < now`);
   - `test_tick_skips_non_due_feed` only skipped because a **prior** test's `mark_ran` left a future `next_due` (its own docstring noted this);
   - `test_tick_reboot_persists_ledger` (`-m reboot`) was broken (absent `cron` entry → `KeyError`).

   Rewritten in PHP via the package's own `pfb_due_ledger_write_entry()`, matching #600.

2. **Per-test ledger isolation.** The module baseline reset is module-scoped and never touches `pfb_due_ledger.json`, so tests could inherit each other's ledger — the coupling above. Added an autouse, idempotent `_reset_ledger` fixture that wipes the ledger before every test, so each test is fully self-encapsulated and establishes its own state from a known-empty baseline.

## Validation

Live on the pfSense VM pool against this branch — the 3 `-m smoke` tick tests pass in full-module order, twice (with and without the isolation fixture):

```
test_tick_dispatches_due_feed   PASSED
test_tick_skips_non_due_feed    PASSED
test_tick_wiped_ledger_jittered PASSED
```

## Not in this PR

`test_tick_reboot_persists_ledger` (`-m reboot`, dispatch-only) gets past the ledger write now, but fails on a separate `reboot_vm` timeout (the helper's `kern.boottime`-change poll consumes the readiness budget). That's a shared-helper concern affecting all reboot tests — fixed in a follow-up PR (reboot → settle → reuse the startup `wait_ready` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke test reliability by isolating state between test runs, reducing flaky failures caused by leftover ledger data.
* **Tests**
  * Updated smoke test helpers to use the application’s native ledger-writing flow, keeping test behavior aligned with real-world execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->