### PR TITLE
ci: forbid Python on the pfSense appliance (use PHP/sh) + codify test isolation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -161,6 +161,18 @@ if [ "$staged_sh" = 1 ] || [ "$staged_md" = 1 ]; then
 	fi
 fi
 
+# --- Forbid invoking a Python interpreter ON the pfSense appliance (no python3
+#     symlink there -> rc=127 silent no-op). Relevant to appliance code: smoke
+#     tests (*.py) and the package's PHP/shell (*.php/*.inc/*.sh). ---
+if [ "$staged_py" = 1 ] || [ "$staged_php" = 1 ] || [ "$staged_sh" = 1 ]; then
+	if [ -n "$py_bin" ]; then
+		step 'no-appliance-python (use PHP/sh on the box)'
+		"$py_bin" scripts/check_appliance_python.py || failed 'no-appliance-python'
+	else
+		skip no-appliance-python
+	fi
+fi
+
 # =============================== PHP (*.php, *.inc) ========================== #
 if [ "$staged_php" = 1 ]; then
 	# php -l syntax check (output shown only for files that fail).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,6 +211,13 @@ jobs:
         # fences (the checker's defaults). ubuntu-latest ships python3.
         run: python3 scripts/check_url_encoding.py
 
+      - name: Forbid Python on the pfSense appliance
+        # The appliance ships python3.11 with no `python3` symlink, so a
+        # `/usr/local/bin/python*` invocation is rc=127 (and silent under check=False
+        # ssh). Use PHP/pfSsh.php or POSIX sh on the box; only pfb_unbound.py is Python
+        # (Unbound's embedded loader). Scans tracked src/ + tests/ (the checker's defaults).
+        run: python3 scripts/check_appliance_python.py
+
   shell-tests:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,17 @@ off-pattern name is a smell even when it works.
 - Type-hint new functions; leave existing untyped code alone unless touching it.
 - No bare `except:` — `except Exception` minimum.
 - `pfb_unbound.py` runs in Unbound's Python loader — **stdlib only, no external deps**.
+- **No Python interpreter ON the pfSense appliance — use PHP or POSIX sh (HARD CONSTRAINT).** The
+  appliance ships `python3.11` with **no `python3` symlink**, so any `/usr/local/bin/python*`
+  invocation is `rc=127` "not found" — and SILENT under `SmokeVM.ssh`'s `check=False`, so the
+  command no-ops and the caller proceeds on stale/empty state (this bit the `apply_on_change` +
+  `tick` smoke modules — their ledger writes did nothing). Drive the box via **PHP** (`php` /
+  `pfSsh.php` / `h.php_eval` — it owns the package's data structures, e.g. the `pfb_due_ledger_*`
+  API) or **POSIX sh**. `pfb_unbound.py` is the **sole** exception: it runs in Unbound's *embedded*
+  Python loader (`python-script:`), never spawned through the appliance interpreter. Enforced by
+  `scripts/check_appliance_python.py` (pre-commit + CI; forbids `/usr/local/bin/python*` across
+  `src/` + `tests/`; unit-tested in `tests/test_appliance_python_check.py`). Bare `python3` in
+  dev/CI-host tooling under `scripts/` is fine — it names the developer's interpreter, not the box's.
 - **Content hashing = `md5` on the Python side (ADR-42 policy).** `hashlib` has no xxhash and the
   module is stdlib-only + chrooted, so Python uses `hashlib.md5` for its own self-comparisons only
   — never a cross-language digest (PHP/shell use `xxh128`). No Python hashing code lands in ADR-42;
@@ -454,6 +465,15 @@ of it:
   `i=true`, **then** assert `a→y` — never just the final state. Extends to any lifecycle (a
   "blocked after listing" test first asserts the domain *resolved* before listing, and again
   after unblock — see the `tests/smoke` DNSBL lock/unlock cases).
+- **Self-encapsulated — never order-dependent.** Tests may SHARE setup/teardown (fixtures), but no
+  test may depend on another running before or after it. Each test establishes everything it needs
+  from a known baseline (minus what is baked into the test *image*); the shared setup/teardown must
+  be **idempotent** and provide that baseline. A test that passes only because a sibling ran first
+  is a defect, not coverage — it masks the real behaviour. It bit the `tick` smoke module: one
+  test's `mark_ran` left a future `next_due` that a later "skip" test silently relied on, so the
+  skip never tested its own setup. Reset per-test state explicitly (e.g. an autouse fixture that
+  wipes the artifact and **fails loudly** if the wipe doesn't take) rather than leaning on
+  collection order; a module-scoped baseline reset does NOT give per-test isolation.
 - **Specify complex behaviour BDD-style; keep trivial tests trivial.** A util / small rule /
   simple mapping needs only a plain, intent-named assertion. Non-trivial behaviour (state
   transitions, precedence, multi-step flows — DNSBL/ABP decision logic, the decision cache,

--- a/scripts/check_appliance_python.py
+++ b/scripts/check_appliance_python.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Forbid invoking a Python interpreter ON the pfSense appliance.
+
+PROBLEM
+-------
+pfSense ships ``python3.11`` but NO ``python3`` symlink, so a command that
+shells out to the interpreter on the box —
+
+    vm.ssh(f"/usr/local/bin/python3 -c {snippet}")     # smoke test -> pfSense VM
+    exec("/usr/local/bin/python3 ...")                 # package code on the box
+
+— fails with ``rc=127`` ("not found"). Worse, when the caller ignores the exit
+code (``SmokeVM.ssh`` is ``check=False``) the failure is SILENT: the command
+no-ops and the surrounding logic proceeds on stale/empty state. This bit the
+``apply_on_change`` and ``tick`` smoke modules — their ledger writes silently did
+nothing, leaving the tests passing or failing by accident of unrelated state.
+
+The right tool on the appliance is **PHP** (``/usr/local/bin/php`` / ``pfSsh.php``,
+which pfSense ships and which already owns the package's data structures) or
+**POSIX sh**. Python on the appliance is reserved for ``pfb_unbound.py`` alone —
+and that runs inside Unbound's *embedded* Python loader (configured via
+``python-script:``), never spawned through ``/usr/local/bin/python``.
+
+This check is the mechanical backstop for that rule (CLAUDE.md, "Python"). It is
+PREVENTATIVE — there are no offenders in shipped code today; it guards against
+re-introducing the footgun.
+
+SCOPE (deliberately low false-positive)
+---------------------------------------
+* Scans tracked files under ``src/`` (package code that runs on the appliance)
+  and ``tests/`` (the smoke suite, whose ``vm.ssh`` commands run on the appliance).
+  ``scripts/`` is dev/CI-host tooling (it runs on the developer's box, which DOES
+  have ``python3``) and is intentionally NOT scanned.
+* Flags the literal appliance interpreter path ``/usr/local/bin/python`` (covers
+  ``python``, ``python3``, ``python3.11``, ...). Bare ``python3`` is NOT flagged:
+  it legitimately names the dev-host / client-VM interpreter, and the appliance
+  footgun has always used the full path. The CLAUDE.md rule covers the rest as
+  human discipline.
+
+Exit status: 0 = clean, 1 = one or more violations (printed with file:line).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# The appliance interpreter path. pfSense has no python3 symlink here, so any
+# invocation of it is a runtime rc=127 footgun. (Built so this file does not
+# match its own check — though scripts/ is not scanned anyway.)
+_FORBIDDEN = re.compile(r"/usr/local/bin/" + r"python")
+
+# Tracked-tree roots that run ON the appliance.
+_SCAN_ROOTS = ("src", "tests")
+
+
+def _tracked_files(roots: tuple[str, ...]) -> list[Path]:
+    """Return the git-tracked files under the given roots (text files only)."""
+    out = subprocess.run(
+        ["git", "ls-files", "-z", *roots],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [Path(p) for p in out.stdout.split("\0") if p]
+
+
+def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
+    """Return ``(path, lineno, line)`` for every line invoking appliance Python."""
+    violations: list[tuple[Path, int, str]] = []
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except (OSError, UnicodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if _FORBIDDEN.search(line):
+                violations.append((path, lineno, line.strip()))
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    paths = [Path(a) for a in argv] if argv else _tracked_files(_SCAN_ROOTS)
+    violations = find_violations(paths)
+    if not violations:
+        return 0
+    print("Forbidden Python interpreter invocation on the pfSense appliance:\n", file=sys.stderr)
+    for path, lineno, line in violations:
+        print(f"  {path}:{lineno}: {line}", file=sys.stderr)
+    print(
+        "\nThe appliance ships python3.11 with no `python3` symlink, so "
+        "`/usr/local/bin/python*` is rc=127 (and silent under check=False ssh).\n"
+        "Use PHP (php / pfSsh.php / h.php_eval — it owns the package's data structures) "
+        "or POSIX sh instead.\n"
+        "Only pfb_unbound.py may be Python, and it runs in Unbound's embedded loader, "
+        'not via /usr/local/bin/python. See CLAUDE.md ("Python").',
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_appliance_python.py
+++ b/scripts/check_appliance_python.py
@@ -42,22 +42,23 @@ Exit status: 0 = clean, 1 = one or more violations (printed with file:line).
 
 from __future__ import annotations
 
-import re
 import subprocess
 import sys
 from pathlib import Path
 
 # The appliance interpreter path. pfSense has no python3 symlink here, so any
-# invocation of it is a runtime rc=127 footgun. (Built so this file does not
-# match its own check — though scripts/ is not scanned anyway.)
-_FORBIDDEN = re.compile(r"/usr/local/bin/" + r"python")
+# invocation of it is a runtime rc=127 footgun. A plain substring beats a regex
+# for this per-line scan (ADR-28). This file lives under scripts/, which is not
+# scanned, so the literal here is harmless.
+_FORBIDDEN = "/usr/local/bin/python"
 
 # Tracked-tree roots that run ON the appliance.
 _SCAN_ROOTS = ("src", "tests")
 
 
 def _tracked_files(roots: tuple[str, ...]) -> list[Path]:
-    """Return the git-tracked files under the given roots (text files only)."""
+    """Return every git-tracked file under the given roots (binary files are
+    handled gracefully by :func:`find_violations`)."""
     out = subprocess.run(
         ["git", "ls-files", "-z", *roots],
         capture_output=True,
@@ -76,7 +77,7 @@ def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
         except (OSError, UnicodeError):
             continue
         for lineno, line in enumerate(text.splitlines(), start=1):
-            if _FORBIDDEN.search(line):
+            if _FORBIDDEN in line:
                 violations.append((path, lineno, line.strip()))
     return violations
 

--- a/tests/test_appliance_python_check.py
+++ b/tests/test_appliance_python_check.py
@@ -1,0 +1,79 @@
+"""Tests for scripts/check_appliance_python.py.
+
+Per CLAUDE.md's test-coverage rule, every flagged case is paired with the correct
+form that must stay clean, so a green proves the check DISCRIMINATES (the appliance
+interpreter path is rejected) rather than always firing or never firing.
+
+The bad path is assembled at runtime ("/usr/local/bin/" + "python...") so this test
+file does not match its own check when the check scans ``tests/``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_appliance_python.py"
+_spec = importlib.util.spec_from_file_location("check_appliance_python", _TOOL)
+assert _spec is not None and _spec.loader is not None
+cap = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = cap
+_spec.loader.exec_module(cap)
+
+# The forbidden appliance interpreter path, assembled so it is not a literal substring here.
+_APPLIANCE_PY = "/usr/local/bin/" + "python3"
+
+
+def _find(tmp_path: Path, content: str) -> list[Any]:
+    f = tmp_path / "sample.py"
+    f.write_text(content, encoding="utf-8")
+    return cap.find_violations([f])
+
+
+def test_flags_appliance_python_minus_c(tmp_path: Path) -> None:
+    # A smoke test shelling a Python snippet to the pfSense VM is the footgun.
+    line = f'    vm.ssh(f"{_APPLIANCE_PY} -c {{snippet}}")\n'
+    violations = _find(tmp_path, line)
+    assert len(violations) == 1, f"expected the appliance python path to be flagged; got {violations}"
+    assert violations[0][1] == 1
+
+
+def test_flags_any_suffix(tmp_path: Path) -> None:
+    # python / python3 / python3.11 under the appliance bindir are all the same footgun.
+    for suffix in ("python", "python3", "python3.11"):
+        line = f'    vm.ssh("/usr/local/bin/{suffix} /tmp/x.py")\n'
+        assert _find(tmp_path, line), f"/usr/local/bin/{suffix} should be flagged"
+
+
+def test_clean_php_is_not_flagged(tmp_path: Path) -> None:
+    # The correct form: drive the box via PHP / the package's own ledger API.
+    clean = (
+        "    snippet = \"require_once('...extra.inc');pfb_due_ledger_write_entry(...);\"\n"
+        "    result = h.php_eval(vm, snippet)\n"
+    )
+    assert _find(tmp_path, clean) == [], "PHP via php_eval must stay clean"
+
+
+def test_bare_python3_is_not_flagged(tmp_path: Path) -> None:
+    # Bare `python3` names the dev-host / client-VM interpreter (e.g. the civm tcp probe,
+    # or scripts/ bench tooling on the dev box) — out of scope, must NOT be flagged.
+    bare = '    client_vm.ssh("python3 /tmp/tcp_rst_probe.py 2.0")\n'
+    assert _find(tmp_path, bare) == [], "bare python3 (dev/client) must not be flagged"
+
+
+def test_unbound_embedded_loader_not_flagged(tmp_path: Path) -> None:
+    # pfb_unbound.py runs in Unbound's embedded loader (python-script:), not spawned via
+    # the appliance python path — so referencing the module file is fine.
+    loader = '    conf = "python-script: /usr/local/pkg/pfblockerng/pfb_unbound.py"\n'
+    assert _find(tmp_path, loader) == [], "the embedded-loader module path must not be flagged"
+
+
+def test_main_exit_codes(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.py"
+    bad.write_text(f'vm.ssh("{_APPLIANCE_PY} -c x")\n', encoding="utf-8")
+    good = tmp_path / "good.py"
+    good.write_text('h.php_eval(vm, "echo 1;")\n', encoding="utf-8")
+    assert cap.main([str(good)]) == 0
+    assert cap.main([str(bad)]) == 1


### PR DESCRIPTION
## Summary

Two of today's smoke fixes (#600, #601) traced to the same footgun: shelling out to `/usr/local/bin/python3` on the pfSense appliance, which ships `python3.11` with **no `python3` symlink** — so the call is `rc=127`, and SILENT under `SmokeVM.ssh`'s `check=False`, leaving the surrounding logic to proceed on stale state. This makes the rule a **hard constraint** and codifies a related test-discipline principle.

### No Python on the appliance (mechanical)
- `scripts/check_appliance_python.py` — forbids `/usr/local/bin/python*` across `src/` + `tests/` (the surfaces whose commands run on the box). `scripts/` is dev/CI-host tooling (it has `python3`) and is intentionally not scanned; bare `python3` is not flagged (it names the dev/client interpreter). Preventative — zero offenders on `devel` today.
- Wired into `.githooks/pre-commit` + CI (`test.yml`), mirroring `check_url_encoding.py`.
- Unit-tested (`tests/test_appliance_python_check.py`): every flagged case paired with the clean PHP / bare-`python3` form, so green proves it discriminates.
- `CLAUDE.md` ("Python"): drive the box via PHP (`php`/`pfSsh.php`/`h.php_eval`) or POSIX sh; `pfb_unbound.py` is the sole exception (Unbound's embedded loader).

### Test isolation (principle)
`CLAUDE.md` ("Test coverage"): tests may share setup/teardown but must never depend on another test running before or after them — fully self-encapsulated, with idempotent shared setup/teardown that provides the full baseline a test needs. Surfaced by the `tick` module, where one test's `mark_ran` left state a later test silently relied on.

## Validation
- `python -m pytest tests/test_appliance_python_check.py` → 6 passed.
- `python scripts/check_appliance_python.py` on the repo → exit 0 (clean).
- ruff + mypy + markdownlint clean; hook `sh -n` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)