### PR TITLE
tests/smoke: fix dnsbl_control + cron_spurious markers and compressed-feed CI timeouts

### DIFF
--- a/tests/smoke/test_smoke_dnsbl_control.py
+++ b/tests/smoke/test_smoke_dnsbl_control.py
@@ -61,11 +61,14 @@ def control_vm(smoke_vm: SmokeVM, client_vm: SmokeVM) -> Iterator[tuple[SmokeVM,
     feed = h.write_local_feed(smoke_vm, "smoke_ctl_feed.txt", f"{blocked}\n")
     spec = h.DnsblCase(aliasname="smokectl", feed_url=feed, header="smokectl", mode=h.DnsblMode.VIP)
 
-    # DNSBL Control on (reader thread runs), legacy DNS-TXT off (default) — set BEFORE
-    # the reload so the ini is generated with the right flags.
+    # Inject FIRST: inject()'s DNSBL-settings replace keeps only the infra keys + the
+    # case's behaviour toggles (not pfb_control), so setting DNSBL Control before inject
+    # would be wiped. Set the control toggles AFTER inject, BEFORE the reload, so the ini
+    # is generated with python_control on (reader thread runs) and the legacy DNS-TXT path
+    # off (its default).
+    h.inject(smoke_vm, spec)
     h.set_dnsbl_control(smoke_vm, True)
     h.set_dnsbl_control_legacy(smoke_vm, False)
-    h.inject(smoke_vm, spec)
     h.reload(smoke_vm, "update")
 
     # Guard the gate: the reader thread is enabled and the DNS-TXT path is inert by default.

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -1867,6 +1867,10 @@ def test_cron_spurious_200_same_bytes_no_reingest(
         feed_url = mock_feeds.feed_url(feed_name)
 
         spec = h.IpCase(aliasname="smokep3spur200", feed_url=feed_url, header=header, family="v4")
+        # pfBlockerNG logs IP-feed activity under the family-suffixed alias name
+        # ([ <aliasname>_<family> ]), NOT the row header — so the per-feed log marker
+        # is aliasname_family, not the bare header.
+        feed_marker = f"{spec.aliasname}_{spec.family}"
         with h.CaseContext(deployed_vm, spec):
             members_before = h.wait_pfctl_table(deployed_vm, spec.alias)
             assert h.member_present(members_before, member_ip), (
@@ -1876,14 +1880,14 @@ def test_cron_spurious_200_same_bytes_no_reingest(
             # Pin cron due (inside CaseContext so config is active).
             _pin_cron_due(deployed_vm)
             not_unch_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "content unchanged")
-            dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
-            hdr_before = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
+            dl_before = _feed_log_count(deployed_vm, feed_marker, "Downloading update")
+            hdr_before = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {feed_marker} ]")
 
             # WHEN — cron; server returns 200 (no ETag → no If-None-Match → plain 200).
             h.reload(deployed_vm, "cron")
 
-            hdr_after = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
-            assert hdr_after > hdr_before, f"cron did not evaluate [ {header} ] — EveryDay feed not due; re-run"
+            hdr_after = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {feed_marker} ]")
+            assert hdr_after > hdr_before, f"cron did not evaluate [ {feed_marker} ] — EveryDay feed not due; re-run"
 
             # THEN — "content unchanged" appeared (spurious 200 detected by hash).
             not_unch_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "content unchanged")
@@ -1893,9 +1897,9 @@ def test_cron_spurious_200_same_bytes_no_reingest(
             )
 
             # THEN — no re-ingest.
-            dl_after = _feed_log_count(deployed_vm, header, "Downloading update")
+            dl_after = _feed_log_count(deployed_vm, feed_marker, "Downloading update")
             assert dl_after == dl_before, (
-                f"Expected NO '[ {header} ] ... Downloading update' (identical bytes) "
+                f"Expected NO '[ {feed_marker} ] ... Downloading update' (identical bytes) "
                 f"(before={dl_before}, after={dl_after}) — spurious 200 triggered wrong re-ingest"
             )
 
@@ -1940,6 +1944,7 @@ _ADR44_BODY = "203.0.113.7\n198.51.100.23\n"
 _ADR44_MEMBER = "203.0.113.7"
 
 
+@pytest.mark.timeout(120)  # full update + targeted reload + file-detect/decompress/re-validate > the 30s cap on slow CI
 def test_zip_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """ADR-44: a zip-compressed IP feed downloads, decompresses, and loads (application/zip path).
 
@@ -1975,6 +1980,7 @@ def test_zip_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> 
         )
 
 
+@pytest.mark.timeout(120)  # full update + targeted reload + file-detect/decompress/re-validate > the 30s cap on slow CI
 def test_gzip_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """ADR-44 REGRESSION GUARD: a gzip-compressed IP feed downloads, decompresses, and loads.
 
@@ -2012,6 +2018,7 @@ def test_gzip_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) ->
         )
 
 
+@pytest.mark.timeout(120)  # full update + targeted reload + file-detect/decompress/re-validate > the 30s cap on slow CI
 def test_bzip2_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """ADR-44 REGRESSION GUARD: a bzip2-compressed IP feed downloads, decompresses, and loads.
 


### PR DESCRIPTION
## Why

The full smoke fan-out has been red since ADR-43 landed (2026-06-25). Recent commits
fixed the `trigger_api` / `apply_on_change` / `tick` failures, leaving exactly two
clusters on devel HEAD (confirmed by run 28318460190): the `dnsbl_control` module (4
errors) and three feed tests. All are ADR-42/ADR-43/ADR-44 smoke tests that **never ran
in a green full smoke** (live smoke is dispatch-only), so latent defects shipped.

## Fixes

1. **`dnsbl_control` (4 errors — `python_control != on`).** The `control_vm` fixture set
   `pfb_control='on'` *before* `inject()`, whose DNSBL-settings replace keeps only the
   infra keys + the case toggles (not `pfb_control`) — wiping it, so the reload emitted
   `python_control=off`. Set the control toggles *after* `inject`, before the reload.

2. **`test_cron_spurious_200` (mislabeled "EveryDay feed not due").** The cron pass
   actually evaluated the feed and correctly logged `( content unchanged ) Update not
   required`. The test counted the bare row-header marker `[ smokep3spur200 ]`, but
   pfBlockerNG logs IP-feed activity under the family-suffixed alias
   `[ smokep3spur200_v4 ]`, so both before/after counts were 0. Count the real
   `{aliasname}_{family}` marker.

3. **`test_{zip,gzip,bzip2}_feed_imports` (CI-only 30s timeouts).** The logic is correct
   (they pass fast on a local box). The CaseContext full update + targeted reload +
   file-detect/decompress/post-extraction re-validate exceeds the 30s per-test cap on the
   slower CI runner. Give them `@pytest.mark.timeout(120)`, matching the ADR-10 matrix
   convention. (Not a product bug.)

## Validation

Local live-VM run (Debian/KVM box, branch checked out): **8 passed** — all four
`dnsbl_control`, `cron_spurious_200`, and the three compressed-feed tests. `cron_spurious`
was red before fix 2 and green after (red→green). The compressed-feed timeout (fix 3) is
proven by the full GHA fan-out dispatched on this branch (the local box is too fast to
trigger the cap).

Tests only — no `src/` change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of feed-related checks so updates are matched against the correct feed entry.
  * Adjusted DNS blocklist control setup during smoke testing to better reflect the expected operational sequence.
  * Increased timeout limits for archive import regression checks to reduce false test failures during slower runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->