### PR TITLE
tests/smoke: carry DNSBL Control on DnsblCase (folds into inject replace, #588)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -292,6 +292,16 @@ class DnsblCase:
     idn_mode: str | None = None
     idn_block_malicious: bool | None = None
     idn_escalate_suspicious: bool | None = None
+    # control -> "DNSBL Control" (CFG_DNSBL_SETTINGS/pfb_control -> ini python_control). On:
+    # the next reload starts the pfb_control_watcher reader thread so CLI commands take
+    # effect. Carried on the case so inject()'s settings replace writes it with the other
+    # toggles (#588) — nothing relies on a pre-inject write surviving. None (default) emits
+    # nothing -> the existing matrix is unchanged.
+    control: bool | None = None
+    # control_legacy -> the deprecated DNS-TXT control sub-path (pfb_control_legacy -> ini
+    # python_control_legacy, emitted `on` only when BOTH pfb_control and pfb_control_legacy
+    # are on, inc:4744). None (default) emits nothing.
+    control_legacy: bool | None = None
 
     @property
     def alias(self) -> str:
@@ -2089,6 +2099,14 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         settings["pfb_idn_block_malicious"] = "on" if spec.idn_block_malicious else ""
     if spec.idn_escalate_suspicious is not None:
         settings["pfb_idn_escalate_suspicious"] = "on" if spec.idn_escalate_suspicious else ""
+    if spec.control is not None:
+        # "DNSBL Control" (CFG_DNSBL_SETTINGS/pfb_control -> ini python_control). Folded into
+        # the replace so the control state rides the same write as every other toggle — see
+        # set_dnsbl_control for the reader-thread semantics.
+        settings["pfb_control"] = "on" if spec.control else ""
+    if spec.control_legacy is not None:
+        # The deprecated DNS-TXT sub-path (pfb_control_legacy -> ini python_control_legacy).
+        settings["pfb_control_legacy"] = "on" if spec.control_legacy else ""
     # The primary feed row + any ABP extra rows, all in ONE DNSBL list group. Each
     # row is downloaded + header-sniffed independently (inc:7934), so an ABP body
     # per row yields one ABP feed per row whose rules the Python build merges.

--- a/tests/smoke/test_smoke_dnsbl_control.py
+++ b/tests/smoke/test_smoke_dnsbl_control.py
@@ -59,16 +59,18 @@ def control_vm(smoke_vm: SmokeVM, client_vm: SmokeVM) -> Iterator[tuple[SmokeVM,
 
     blocked = h.unique_domain("ctlblocked")
     feed = h.write_local_feed(smoke_vm, "smoke_ctl_feed.txt", f"{blocked}\n")
-    spec = h.DnsblCase(aliasname="smokectl", feed_url=feed, header="smokectl", mode=h.DnsblMode.VIP)
-
-    # Inject FIRST: inject()'s DNSBL-settings replace keeps only the infra keys + the
-    # case's behaviour toggles (not pfb_control), so setting DNSBL Control before inject
-    # would be wiped. Set the control toggles AFTER inject, BEFORE the reload, so the ini
-    # is generated with python_control on (reader thread runs) and the legacy DNS-TXT path
-    # off (its default).
+    # DNSBL Control on (reader thread runs), legacy DNS-TXT off (default), carried on the
+    # case so inject()'s DNSBL-settings replace writes them with the other toggles. Setting
+    # them via a separate pre-inject write would be wiped by that replace (#588).
+    spec = h.DnsblCase(
+        aliasname="smokectl",
+        feed_url=feed,
+        header="smokectl",
+        mode=h.DnsblMode.VIP,
+        control=True,
+        control_legacy=False,
+    )
     h.inject(smoke_vm, spec)
-    h.set_dnsbl_control(smoke_vm, True)
-    h.set_dnsbl_control_legacy(smoke_vm, False)
     h.reload(smoke_vm, "update")
 
     # Guard the gate: the reader thread is enabled and the DNS-TXT path is inert by default.


### PR DESCRIPTION
## What

Make **DNSBL Control** (`pfb_control` / `pfb_control_legacy`) a first-class `DnsblCase` field, folded into the DNSBL-settings replace in `_dnsbl_inject_snippet` alongside `pfb_hsts` / `pfb_idn` / `pfb_regex`. The `control_vm` fixture now carries the control state on the case instead of writing `pfb_control` separately before the reload.

This is the **isolation-consistent** form the #588 root-cause analysis preferred over the minimal reorder already on `devel` (`c3a6ca3b`): nothing relies on a pre-`inject` write surviving #576's replace-not-merge, because the control state travels with the case through the same write as every other toggle.

Part of #588 (already closed by the minimal fix; this is the follow-up it flagged).

## Why now

A DNSBL-control matrix case is likely to land soon; carrying control on `DnsblCase` (the documented setup path for every other toggle) means that work won't re-discover the #576 wipe and re-litigate the ordering.

## Behaviour-preserving

- The `control_vm` fixture generates the **same** ini — `python_control = on`, `python_control_legacy = off` — so all four `control_vm`-gated tests are unchanged.
- A case that sets no `control` field emits **no** `pfb_control` key, so the existing matrix is byte-for-byte unchanged.
- Verified off-box (the `_dnsbl_inject_snippet` renderer is importable without a VM): baseline case emits no `pfb_control`; `control=True, control_legacy=False` → `'pfb_control' => 'on'` + `'pfb_control_legacy' => ''`; `control=False` → `'pfb_control' => ''` (both branches covered). Live re-validation is the dispatch-only `test_smoke_dnsbl_control.py` suite.

## Note for review

`set_dnsbl_control` (the non-legacy PHP setter) now has no caller — kept intentionally as the symmetric pair of `set_dnsbl_control_legacy` (still used for the runtime toggle at `test_smoke_dnsbl_control.py:212`) and the natural runtime-toggle helper for the upcoming control case. Referenced from the new `DnsblCase.control` docstring.

## Test plan

- `ruff check` / `ruff format --check` / `mypy tests/` — green.
- Off-box oracle on `_dnsbl_inject_snippet` (above) — green.
- Dispatch-only live smoke: `gh workflow run smoke.yml -f pytest_k="dnsbl_control"` (CE + Plus) — harness-only change, not PR-gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNSBL control settings are now applied consistently during setup, preventing manual toggles from being lost.
  * Improved handling of control-related DNSBL options so test scenarios can preserve the intended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->