### PR TITLE
tests: per-step + phase timing (PFB_TIMING + --durations)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ testpaths = ["tests"]
 # cleanly and runs the exact same unit set. The smoke workflow re-enables it
 # with `pytest -m smoke --override-ini="addopts=" tests/smoke` (or
 # `-p no:cacheprovider tests/smoke -m smoke`); see tests/smoke/conftest.py.
-addopts   = "-v --ignore=tests/smoke"
+# --durations=25 surfaces the 25 slowest setup/call/teardown phases each run (issue
+# #605 Layer A) — cheap signal on which unit tests/fixtures dominate, no plugin.
+addopts   = "-v --ignore=tests/smoke --durations=25"
 markers = [
     "smoke: live-VM end-to-end smoke test (ADR-04); needs KVM + the GHCR pfSense image; deselected from the default run",
     "ui_render: live-VM Web-UI render-smoke (ADR-14 Tier A); authenticated HTTP; deselected from the default run",

--- a/scripts/run-smoke.sh
+++ b/scripts/run-smoke.sh
@@ -5,8 +5,12 @@
 # Emits and executes:
 #   $PYTHON -m pytest $PATHS -m $MARKER
 #     --override-ini="addopts=" --override-ini="timeout_func_only=true"
-#     --timeout=$TIMEOUT --timeout-method=signal -v
+#     --timeout=$TIMEOUT --timeout-method=signal --durations=0 --capture=tee-sys -v
 #     [-k $K] [passthrough...]
+#
+# --durations=0 reports every test's setup/call/teardown phase timing (issue #605
+#   Layer A); --capture=tee-sys streams stdout live so the per-step PFB_TIMING lines
+#   (Layer B, tests/timing.py) show on a PASSING run, not only on failure.
 #
 # Params + defaults (structured flags must precede passthrough):
 #   --paths P      default tests/smoke   (UI: tests/smoke/ui)
@@ -127,6 +131,8 @@ set -- \
     --override-ini="timeout_func_only=true" \
     --timeout="$_TIMEOUT" \
     --timeout-method=signal \
+    --durations=0 \
+    --capture=tee-sys \
     -v \
     "$@"
 
@@ -140,5 +146,13 @@ fi
 if [ "$_CALLER_GAVE_PATH" -eq 0 ]; then
     set -- "$_PATHS" "$@"
 fi
+
+# issue #605: export the diagnostics dir so the pytest process (and tests/timing.py's
+# per-step timing.log) sees it — resolved here in the LAUNCHER, never mutated in-program.
+# Mirrors tests/smoke/conftest.py's DIAG_DIR default; the on-box pytest otherwise has it
+# unset (the orchestrator's value doesn't cross the ssh boundary), so timing.log would
+# never join the uploaded smoke-diag/. The unit suite runs plain pytest (not this script),
+# so PFB_DIAG_DIR stays unset there — timing is terminal-only, no stray file.
+export PFB_DIAG_DIR="${PFB_DIAG_DIR:-smoke-diag}"
 
 exec "$PYTHON" -m pytest "$@"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import builtins
 import os
 import sys
 from collections import defaultdict
+from collections.abc import Iterator
 
 # pfb_unbound.py is designed to run inside Unbound's Python plugin loader, which
 # injects Unbound-specific functions and integer constants as module-level
@@ -28,6 +29,29 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 import pytest  # noqa: E402
 
 import pfb_unbound  # noqa: E402
+from tests.timing import close_log, open_log  # noqa: E402
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _pfb_timing_log() -> Iterator[None]:
+    """Open the per-step timing log once for the whole session, close it once at the end.
+
+    issue #605: this is the single setup/teardown for the PFB_TIMING file sink —
+    ``tests.timing._emit`` only writes to the already-open handle, never sets up per call.
+    ``open_log`` is a no-op when ``PFB_DIAG_DIR`` is unset (the unit suite — terminal-only),
+    so nothing is written there. At teardown, surface where the log landed and how many
+    steps it captured.
+    """
+    open_log()
+    yield
+    path = close_log()
+    if path:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                count = sum(1 for _ in handle)
+            print(f"\nPFB_TIMING_SUMMARY {path} ({count} steps)", flush=True)
+        except OSError:
+            pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -54,6 +54,7 @@ from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
+from ..timing import timed  # issue #605 — per-step timing (PFB_TIMING)
 from . import stub_responses
 
 # --------------------------------------------------------------------------- #
@@ -156,6 +157,33 @@ CLIENT_LAN_IP = "192.168.1.10"  # civm's static lease on the pfSense LAN
 # Connection object yielded by the VM fixture
 # --------------------------------------------------------------------------- #
 
+# issue #605: a leading interpreter is noise in an ssh timing label ("ssh:php" tells you
+# nothing) — drop it so the script + verb surface ("ssh:pfblockerng.php pfb_trigger").
+_SSH_INTERPRETERS = frozenset({"php", "php83", "php-cgi", "python", "python3", "python3.11", "sh", "bash"})
+
+
+def _ssh_timing_label(remote: tuple[str, ...]) -> str:
+    """Build a descriptive PFB_TIMING label for an ssh command (issue #605).
+
+    Shows the meaningful command, not just the interpreter: the first few non-flag tokens
+    (basename'd), with a leading php/python/sh dropped, capped for the log.
+    """
+    cmd = " ".join(str(part) for part in remote).strip()
+    if not cmd:
+        return "ssh"
+    parts: list[str] = []
+    for token in cmd.split():
+        if token.startswith("-"):  # skip flags/options
+            continue
+        base = os.path.basename(token)
+        if not parts and base in _SSH_INTERPRETERS:
+            continue  # drop the leading interpreter; surface the script/verb instead
+        parts.append(base)
+        if len(parts) >= 3:
+            break
+    label = " ".join(parts) if parts else os.path.basename(cmd.split()[0])
+    return f"ssh:{label}"[:60]
+
 
 @dataclass
 class SmokeVM:
@@ -239,13 +267,16 @@ class SmokeVM:
 
     def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
         """Run a command on the guest over SSH and capture its output."""
-        return subprocess.run(
-            self.ssh_argv(*remote),
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-        )
+        # issue #605: time each guest command, but emit only the heavy ones (>=1s) so the
+        # tight poll loops (wait_*, snap_state) don't flood the log with sub-second lines.
+        with timed(_ssh_timing_label(remote), min_seconds=1.0):
+            return subprocess.run(
+                self.ssh_argv(*remote),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -54,6 +54,7 @@ from enum import Enum
 from pathlib import Path
 from typing import NamedTuple
 
+from ..timing import timed, timed_step  # issue #605 — per-step timing (PFB_TIMING)
 from .conftest import (
     DEFAULT_BOOT_TIMEOUT,
     GUEST_TO_HOST_ALIAS,
@@ -360,6 +361,7 @@ class SafeSearchEntry(NamedTuple):
 # --------------------------------------------------------------------------- #
 
 
+@timed_step("deploy")
 def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) -> None:
     """Install the branch's built .pkg onto the guest via install-pkg.sh.
 
@@ -674,14 +676,17 @@ def php_eval(vm: SmokeVM, snippet: str, *, timeout: float = 60.0) -> subprocess.
     writers just emit an 'OK' sentinel the caller greps for.
     """
     program = snippet + "\nexec\nexit\n"
-    return subprocess.run(
-        vm.ssh_argv(PFSSH_BIN),
-        input=program,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=False,
-    )
+    # issue #605: php_eval runs its OWN subprocess (not SmokeVM.ssh), so time it here —
+    # threshold-gated like ssh so the many fast config writes don't flood the log.
+    with timed("php_eval", min_seconds=1.0):
+        return subprocess.run(
+            vm.ssh_argv(PFSSH_BIN),
+            input=program,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
 
 
 _CFG_VAL_OPEN = "<<<CFGVAL>>>"
@@ -1851,6 +1856,7 @@ def _dnsbl_list_logging(mode: DnsblMode) -> str:
     }[mode]
 
 
+@timed_step(lambda vm, spec, **_k: f"inject:{spec.aliasname}")
 def inject(vm: SmokeVM, spec: DnsblCase | IpCase, *, timeout: float = 90.0) -> None:
     """Apply a case's pfBlockerNG config AND control records, then write_config.
 
@@ -2201,6 +2207,7 @@ _SCOPE_TO_PFBTRIGGER: dict[str, tuple[str, str, str]] = {
 }
 
 
+@timed_step(lambda vm, scope="update", **_k: f"reload:{scope}")
 def reload(
     vm: SmokeVM, scope: str = "update", *, data_path: bool = False, wait_unbound: bool = True, timeout: float = 600.0
 ) -> None:
@@ -3591,6 +3598,7 @@ def pfctl_tables(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
+@timed_step(lambda vm, name, **_k: f"wait_pfctl_table:{name}")
 def wait_pfctl_table(vm: SmokeVM, name: str, *, timeout: float = 30.0, interval: float = 2.0) -> list[str]:
     """Poll ``pfctl -t <name> -T show`` until the table EXISTS and is NON-EMPTY.
 

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,166 @@
+"""Unit coverage for the per-step timing helper (issue #605).
+
+Pins the contract the parsers rely on: every timed step emits exactly one
+``PFB_TIMING <label> <seconds>.2fs`` line to stdout, and — only when the session log is
+open (``PFB_DIAG_DIR`` set + :func:`open_log` called) — the same line lands in
+``$PFB_DIAG_DIR/timing.log``. Also pins that the decorator is transparent (return value +
+exceptions pass through), that a step which raises still emits its line, and the
+open-once/close-once session-log lifecycle (fresh file per session).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests.timing import close_log, open_log, timed, timed_step
+
+# PFB_TIMING <label> <float>s — the one parseable shape the diagnostics consumer greps.
+_LINE = re.compile(r"^PFB_TIMING (?P<label>\S+) (?P<secs>\d+\.\d{2})s$")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_timing_log() -> Iterator[None]:
+    """Close the module-global session log around each test so an open handle from one
+    file-sink test never leaks into the next (the handle is process-global state)."""
+    close_log()
+    yield
+    close_log()
+
+
+def test_timed_emits_one_parseable_line(capsys: pytest.CaptureFixture[str]) -> None:
+    with timed("mystep"):
+        pass
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert len(lines) == 1, f"expected exactly one PFB_TIMING line, got: {lines}"
+    m = _LINE.match(lines[0])
+    assert m is not None, f"line not in 'PFB_TIMING <label> <secs>s' shape: {lines[0]!r}"
+    assert m.group("label") == "mystep"
+    float(m.group("secs"))  # the 2-decimal seconds field parses as a number
+
+
+def test_timed_step_decorator_is_transparent(capsys: pytest.CaptureFixture[str]) -> None:
+    @timed_step()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    # return value passes through
+    assert add(2, 3) == 5
+    # and it emits a line labelled by the function's qualname
+    out = capsys.readouterr().out.strip()
+    m = _LINE.match(out)
+    assert m is not None and "add" in m.group("label"), f"unexpected timing line: {out!r}"
+
+
+def test_timed_step_callable_label_names_from_args(capsys: pytest.CaptureFixture[str]) -> None:
+    # A callable label receives the wrapped function's args and builds the label from them.
+    @timed_step(lambda _vm, scope="update", **_k: f"reload:{scope}")
+    def reload(_vm: str, scope: str = "update") -> None:
+        return None
+
+    reload("vm", "updateip")
+    m = _LINE.match(capsys.readouterr().out.strip())
+    assert m is not None and m.group("label") == "reload:updateip"
+
+
+def test_timed_step_label_callable_error_falls_back_to_qualname(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A buggy label callable must never break the wrapped call — fall back to the qualname.
+    @timed_step(lambda *_a, **_k: str(1 / 0))  # raises ZeroDivisionError (return-types as str)
+    def work() -> int:
+        return 42
+
+    assert work() == 42  # the call still succeeds
+    m = _LINE.match(capsys.readouterr().out.strip())
+    assert m is not None and "work" in m.group("label")
+
+
+def test_timed_step_explicit_label_overrides_qualname(capsys: pytest.CaptureFixture[str]) -> None:
+    @timed_step("custom-label")
+    def noop() -> None:
+        return None
+
+    noop()
+    m = _LINE.match(capsys.readouterr().out.strip())
+    assert m is not None and m.group("label") == "custom-label"
+
+
+def test_timed_emits_even_when_block_raises(capsys: pytest.CaptureFixture[str]) -> None:
+    # A step that fails must still report how long it ran before failing.
+    with pytest.raises(ValueError), timed("boom"):
+        raise ValueError("kaboom")
+    m = _LINE.match(capsys.readouterr().out.strip())
+    assert m is not None and m.group("label") == "boom"
+
+
+def test_timed_min_seconds_suppresses_fast_blocks(capsys: pytest.CaptureFixture[str]) -> None:
+    # A block faster than the threshold emits nothing (the poll-flood guard) ...
+    with timed("fastpoll", min_seconds=10.0):
+        pass
+    assert capsys.readouterr().out == "", "a sub-threshold block must not emit a timing line"
+    # ... while min_seconds=0 (the default behaviour) always emits.
+    with timed("always", min_seconds=0.0):
+        pass
+    assert _LINE.match(capsys.readouterr().out.strip()) is not None
+
+
+def test_timed_writes_to_open_log_when_env_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Given PFB_DIAG_DIR set + the session log opened (as the _pfb_timing_log fixture does)
+    monkeypatch.setenv("PFB_DIAG_DIR", str(tmp_path))
+    open_log()
+    # When two steps run
+    with timed("step-a"):
+        pass
+    with timed("step-b"):
+        pass
+    # Then both lines land in $PFB_DIAG_DIR/timing.log (flushed per line, same shape as stdout)
+    log = tmp_path / "timing.log"
+    assert log.exists(), "timing.log was not created under PFB_DIAG_DIR"
+    file_lines = log.read_text(encoding="utf-8").strip().splitlines()
+    assert len(file_lines) == 2
+    matches = [_LINE.match(ln) for ln in file_lines]
+    assert all(matches), f"file lines not parseable: {file_lines}"
+    labels = {m.group("label") for m in matches if m}
+    assert labels == {"step-a", "step-b"}
+
+
+def test_open_log_creates_missing_diag_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The smoke harness's PFB_DIAG_DIR may not exist yet when the session log opens, so
+    # open_log() must create it ONCE — otherwise the lines never reach timing.log.
+    diag = tmp_path / "does" / "not" / "exist" / "smoke-diag"
+    assert not diag.exists()
+    monkeypatch.setenv("PFB_DIAG_DIR", str(diag))
+    open_log()
+    with timed("step"):
+        pass
+    log = diag / "timing.log"
+    assert log.exists(), "open_log() must create the missing PFB_DIAG_DIR and the log"
+    assert _LINE.match(log.read_text(encoding="utf-8").strip()) is not None
+
+
+def test_open_log_starts_a_fresh_file_each_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # open_log() opens in 'w' mode, so a new session does NOT accumulate the prior run's lines.
+    monkeypatch.setenv("PFB_DIAG_DIR", str(tmp_path))
+    open_log()
+    with timed("first-session"):
+        pass
+    close_log()
+    open_log()  # second "session"
+    with timed("second-session"):
+        pass
+    file_lines = (tmp_path / "timing.log").read_text(encoding="utf-8").strip().splitlines()
+    assert len(file_lines) == 1, f"second session must truncate, not append: {file_lines}"
+    assert "second-session" in file_lines[0]
+
+
+def test_no_log_when_env_unset(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Given PFB_DIAG_DIR is NOT set, open_log() is a no-op and nothing is written (terminal-only)
+    monkeypatch.delenv("PFB_DIAG_DIR", raising=False)
+    open_log()
+    with timed("nofile"):
+        pass
+    assert not (tmp_path / "timing.log").exists()

--- a/tests/timing.py
+++ b/tests/timing.py
@@ -1,0 +1,140 @@
+"""Per-step timing for the test suites (issue #605) — stdlib only, no plugin.
+
+pytest's ``--durations`` reports per-test setup/call/teardown phases (Layer A), but it
+cannot see *inside* a test body. This module is Layer B: a tiny ``time.perf_counter``
+timer that emits one greppable line per timed STEP — each ``reload`` / ``ssh`` / feed
+download — so the cost of a slow live-VM test (e.g. "where do the 80s go") is visible
+rather than guessed.
+
+Each step emits a single consistent, parseable line::
+
+    PFB_TIMING <label> <seconds>.2fs
+
+to the terminal (live, via ``print``) AND, when the timing log is open, to
+``$PFB_DIAG_DIR/timing.log`` so the lines ride the uploaded diagnostics for offline
+parsing. The log is opened ONCE per session by :func:`open_log` and closed by
+:func:`close_log` (the ``_pfb_timing_log`` session fixture in ``tests/conftest.py``
+drives both) — ``_emit`` only writes to the already-open handle, never sets up per call.
+``PFB_DIAG_DIR`` is set by the smoke launcher (``scripts/run-smoke.sh``); the unit suite
+leaves it unset, so the log stays closed there and timing is terminal-only. Timing is
+best-effort: a write error is swallowed, never failing a test.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import os
+import time
+from collections.abc import Callable, Iterator
+from typing import IO, ParamSpec, TypeVar
+
+_PREFIX = "PFB_TIMING"
+_DIAG_DIR_ENV = "PFB_DIAG_DIR"
+_LOG_NAME = "timing.log"
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+# The per-session timing log handle, opened once by open_log() and closed by close_log().
+# None means "no file sink" (terminal-only) — the unit suite, where PFB_DIAG_DIR is unset.
+_log_file: IO[str] | None = None
+
+
+def open_log() -> None:
+    """Open the per-step timing log once for the session (idempotent).
+
+    No-op when ``PFB_DIAG_DIR`` is unset (the unit suite) — timing is terminal-only then.
+    Opens in ``w`` mode so each session starts a fresh log (no cross-run accumulation).
+    The directory is created here, ONCE — ``_emit`` never sets up per call.
+    """
+    global _log_file
+    if _log_file is not None:
+        return
+    diag_dir = os.environ.get(_DIAG_DIR_ENV)
+    if not diag_dir:
+        return
+    try:
+        os.makedirs(diag_dir, exist_ok=True)
+        _log_file = open(os.path.join(diag_dir, _LOG_NAME), "w", encoding="utf-8")
+    except OSError:
+        _log_file = None  # best-effort — fall back to terminal-only
+
+
+def close_log() -> str | None:
+    """Close the session timing log and return its path (for a teardown summary), or None."""
+    global _log_file
+    if _log_file is None:
+        return None
+    path = _log_file.name
+    try:
+        _log_file.close()
+    except OSError:
+        pass
+    _log_file = None
+    return path
+
+
+def _emit(label: str, seconds: float) -> None:
+    """Emit one ``PFB_TIMING`` line to the terminal and (if open) the session log."""
+    line = f"{_PREFIX} {label} {seconds:.2f}s"
+    print(line, flush=True)
+    if _log_file is not None:
+        try:
+            _log_file.write(line + "\n")
+            _log_file.flush()  # flush per line so the log survives an unclean teardown
+        except (OSError, ValueError):
+            pass  # best-effort — a log-write failure must never fail a test
+
+
+@contextlib.contextmanager
+def timed(label: str, min_seconds: float = 0.0) -> Iterator[None]:
+    """Time the wrapped block and emit one ``PFB_TIMING <label> <seconds>`` line.
+
+    The line is emitted even when the block raises, so a step that errors still reports
+    how long it ran before failing.
+
+    ``min_seconds`` suppresses the emit for blocks faster than the threshold — use it on
+    a chokepoint that fires in a tight poll loop (e.g. ``SmokeVM.ssh``) so only the
+    genuinely heavy calls surface and the fast polls don't flood the log. The default
+    (0.0) always emits.
+    """
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed = time.perf_counter() - start
+        if elapsed >= min_seconds:
+            _emit(label, elapsed)
+
+
+def timed_step(
+    label: str | Callable[..., str] | None = None,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    """Decorator: time a function call under ``label`` (defaults to its qualname).
+
+    ``label`` may be a plain string, or a callable taking the SAME arguments as the
+    wrapped function and returning the label — so a step can name itself from its args
+    (e.g. ``lambda vm, scope="update", **k: f"reload:{scope}"``). A label callable that
+    raises is swallowed and falls back to the qualname: timing must never break the call.
+
+    Transparent — preserves the wrapped function's signature, return value, and raised
+    exceptions; it only adds the timing emit around the call.
+    """
+
+    def decorate(fn: Callable[_P, _R]) -> Callable[_P, _R]:
+        @functools.wraps(fn)
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            if callable(label):
+                try:
+                    name = label(*args, **kwargs)
+                except Exception:
+                    name = fn.__qualname__
+            else:
+                name = label or fn.__qualname__
+            with timed(name):
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorate


### PR DESCRIPTION
Fixes #605.

Adds per-step + phase timing to the test suites so a slow test's cost is visible instead of guessed (the trigger: the ADR-44 compressed-feed smoke tests turned out to spend ~80s in the CaseContext reload chain, not in decompression — invisible at test level).

## What it does

**Layer A — phase/fixture timing (built-in, free).** `--durations=0` in `run-smoke.sh` (every smoke setup/call/teardown phase) and `--durations=25` in `pyproject.toml` addopts (unit: 25 slowest). No plugin.

**Layer B — per-step timing (custom, stdlib).** `tests/timing.py`: `timed()` context manager + `timed_step()` decorator emit one parseable line per step — `PFB_TIMING <label> <secs>.2fs` — to the terminal and to `$PFB_DIAG_DIR/timing.log`. Applied at the smoke chokepoints: `deploy`/`inject`/`reload`/`wait_pfctl_table` get always-on rollups (labels carry the verb/alias/table), while `SmokeVM.ssh` and `php_eval` are threshold-gated (≥1s) so tight poll loops don't flood. ssh labels drop the bare interpreter — `ssh:pfblockerng.php pfb_trigger`, not `ssh:php`.

## Design notes (review feedback folded in)

- **Open once / close once.** The timing log is opened by a session-scoped autouse fixture (`tests/conftest.py`) and closed at teardown (which prints `PFB_TIMING_SUMMARY <path> (<n> steps)`); `_emit` only writes to the already-open handle — no per-call setup. Fresh file per session (`w` mode).
- **No runtime env mutation.** `PFB_DIAG_DIR` is resolved + exported by the launcher (`run-smoke.sh`), so both `conftest` and `timing.py` just read it. The unit suite runs plain pytest (not the launcher) → var unset → timing is terminal-only, no stray file.
- No new dependencies (pytest-durations / pytest-print rejected — they're test/fixture-level, can't see inside a test).

## Validation

- Unit: `tests/test_timing.py` (11 tests) — line shape, decorator transparency, emit-on-raise, threshold, open/close lifecycle, fresh-per-session truncate, missing-dir creation, env-unset no-file. Full unit suite green (1920 passed). ruff + mypy clean.
- Live VM (local box, same `run-smoke.sh` path as CI): transparent (tests still pass), terminal + `timing.log` both written, `PFB_TIMING_SUMMARY` printed, and the real breakdown surfaced — e.g. `reload:cron 5.37s` / `ssh:pfblockerng.php cron 5.25s`.

Tests/CI-tooling only — no `src/` change.
