### PR TITLE
tests/smoke: cover DNSBL Control OFF — CLI channel inert (exercise set_dnsbl_control)

### DIFF
--- a/tests/smoke/test_smoke_dnsbl_control.py
+++ b/tests/smoke/test_smoke_dnsbl_control.py
@@ -200,7 +200,8 @@ def test_dnsbl_control_off_makes_cli_channel_inert(control_vm: tuple[SmokeVM, st
     h.assert_control_ini(vm, control=False, legacy=False)
 
     # AND: issue a disable. The CLI writer still validates + publishes it (returns a seq),
-    # but with no reader thread nothing consumes it.
+    # but with no reader thread nothing consumes it — the writer waits up to 5s for the
+    # (absent) reader to confirm, logs "not confirmed applied", then returns the seq.
     applied_before = h.read_control_applied(vm)
     seq = h.dnsbl_control_cli(vm, "disable")
     h.flush_unbound_cache(vm)

--- a/tests/smoke/test_smoke_dnsbl_control.py
+++ b/tests/smoke/test_smoke_dnsbl_control.py
@@ -20,6 +20,9 @@ These tests drive the REAL paths on a live VM:
   before and after each command), and the applied-sequence marker advances across them.
 * The CLI adds then removes a per-client bypass for the on-box client (127.0.0.1), so a
   blocked name resolves clean for that client while the bypass stands.
+* Turning the DNSBL Control toggle OFF (``python_control = off``) stops the reader thread,
+  so a CLI ``disable`` is published but never consumed — blocking is unchanged and the
+  applied marker is frozen, proving ``python_control`` is a real gate, not an always-on path.
 * The deprecated DNS-TXT control path is inert by default (a TXT ``python_control.disable``
   leaves blocking unchanged), and turning its sub-toggle on re-enables that path — proving
   it is a real gate, not an always-off branch.
@@ -163,6 +166,63 @@ def test_cli_addbypass_then_removebypass_exempts_client(control_vm: tuple[SmokeV
     restored = h.dns_probe_client(client_vm, blocked, "A")
     assert h.is_vip(restored), f"{blocked} should be VIP-blocked again after removebypass, got {restored}"
     assert seq_remove > seq_add, f"removebypass seq {seq_remove} did not advance past addbypass seq {seq_add}"
+
+
+def test_dnsbl_control_off_makes_cli_channel_inert(control_vm: tuple[SmokeVM, str], client_vm: SmokeVM) -> None:
+    """Scenario (branch coverage): with DNSBL Control OFF the CLI control channel is inert.
+
+    Background: the fixture runs with DNSBL Control ON, so the ``pfb_control_watcher`` reader
+    thread consumes CLI commands — that is the gate the disable/enable test above relies on.
+    This flips the toggle OFF (``set_dnsbl_control`` -> ini ``python_control = off``) and
+    reloads, proving the reader is a REAL gate (not always-on): with it off, a queued CLI
+    ``disable`` is published but never consumed, so DNSBL blocking is unchanged and the
+    applied-sequence marker does not advance. The control-ON half is already covered above, so
+    together they are the on/off branch pair. Restores the fixture baseline (Control ON +
+    reload) so the legacy tests that follow see ``python_control = on`` and a fresh block.
+
+    Given DNSBL Control is ON (reader running) and the domain is VIP-blocked,
+    When Control is turned OFF and reloaded (``python_control = off``, reader thread stops),
+    And a ``dnsbl-control disable`` is issued (the writer still publishes it),
+    Then the domain STAYS VIP-blocked — no reader consumed the command — and the applied
+    marker is unchanged, proving the reader is gated on ``python_control``.
+    """
+    vm, blocked = control_vm
+
+    # GIVEN: the fixture baseline — Control on, reader live, domain blocked. Establish it
+    # explicitly (don't depend on a sibling test's end state).
+    h.assert_control_ini(vm, control=True, legacy=False)
+    before = h.dns_probe_client(client_vm, blocked, "A")
+    assert h.is_vip(before), f"{blocked} expected VIP block with DNSBL Control on, got {before}"
+
+    # WHEN: turn DNSBL Control OFF and reload so the reader thread does not start.
+    h.set_dnsbl_control(vm, False)
+    h.reload(vm, "update")
+    h.assert_control_ini(vm, control=False, legacy=False)
+
+    # AND: issue a disable. The CLI writer still validates + publishes it (returns a seq),
+    # but with no reader thread nothing consumes it.
+    applied_before = h.read_control_applied(vm)
+    seq = h.dnsbl_control_cli(vm, "disable")
+    h.flush_unbound_cache(vm)
+
+    # THEN: blocking is UNCHANGED — the domain stays VIP-blocked (the disable never applied).
+    still = h.dns_probe_client(client_vm, blocked, "A")
+    assert h.is_vip(still), (
+        f"{blocked} should STAY VIP-blocked — with DNSBL Control OFF no reader thread consumes "
+        f"the CLI disable (seq {seq}), got {still}"
+    )
+    # AND: the applied marker did not advance to the queued command (no reader ran).
+    applied_after = h.read_control_applied(vm)
+    assert applied_after == applied_before, (
+        f"applied marker moved to {applied_after} (was {applied_before}); with DNSBL Control OFF "
+        f"the reader thread must be stopped, so command seq {seq} must NOT be applied"
+    )
+
+    # Restore the fixture baseline for the legacy tests below: Control back ON + reload
+    # re-initialises python_blacklist (blocking on) and restarts the reader thread.
+    h.set_dnsbl_control(vm, True)
+    h.reload(vm, "update")
+    h.assert_control_ini(vm, control=True, legacy=False)
 
 
 def test_legacy_dns_txt_control_inert_by_default(control_vm: tuple[SmokeVM, str], client_vm: SmokeVM) -> None:


### PR DESCRIPTION
## What

Add the **OFF** half of the DNSBL Control branch pair. The `control_vm` fixture only ever runs with `python_control = on`, so the `pfb_control_watcher` reader-thread gate was tested one-sided. This adds `test_dnsbl_control_off_makes_cli_channel_inert`:

1. **Given** DNSBL Control ON, the domain is VIP-blocked (reader live).
2. **When** Control is turned OFF via `set_dnsbl_control(vm, False)` + reload (`python_control = off`), and a `dnsbl-control disable` is issued,
3. **Then** the domain **stays** VIP-blocked (no reader consumed the command) and the applied-sequence marker is **unchanged** — proving the reader thread is gated on `python_control`, not always-on.
4. Restores the fixture baseline (Control ON + reload) so the legacy tests that follow see `python_control = on` and a fresh block.

Together with the existing CLI disable/enable test (the ON half), this is the complete on/off branch pair — mirroring the `test_legacy_dns_txt_control_inert_by_default` / `…_active_when_enabled` pair.

## Why

After #606 moved the fixture's initial control state onto `DnsblCase`, `set_dnsbl_control` had no caller. This gives it a real one **and** closes the genuinely-untested control-disabled branch — not coverage theater: the assertions (domain stays blocked + marker frozen) fail if the gate regresses to always-on.

Follow-up to #588 / #606.

## Test plan

- `ruff check` / `ruff format --check` / `mypy tests/` — green; all 5 tests in the module collect in order.
- Live (dispatch-only, not PR-gated): `gh workflow run smoke.yml -f pytest_k="dnsbl_control"` (CE + Plus), or `scripts/local-smoke.sh --ref issue/588-control-off-smoke -k dnsbl_control` on a box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
