### PR TITLE
ci: rename smoke filter flag to --filter (fixes broken --k/-k dispatch)

### DIFF
--- a/.ADRs/ADR_47_Local_CI_Execution_Parity/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_47_Local_CI_Execution_Parity/RESULTS/04_Results.txt
@@ -58,7 +58,7 @@ All seven file deliverables + two test deliverables + doc + handoff in a single 
    ```sh
    RUN_ID="$(sh scripts/select-box.sh --print-id)"; export RUN_ID
    set -- --paths tests/smoke -m "${PYTEST_MARKER}" --timeout 30
-   [ -n "${PYTEST_K:-}" ] && set -- "$@" --k "${PYTEST_K}"
+   [ -n "${PYTEST_K:-}" ] && set -- "$@" --filter "${PYTEST_K}"
    sh scripts/run-smoke.sh "$@"
    ```
 

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -72,7 +72,7 @@ on:
         description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
         required: false
         default: "smoke"
-      pytest_k:
+      pytest_filter:
         description: "pytest -k selector to run only a subset of the marker's tests (e.g. 'test_dns_redirect' or 'redirect and not browser'). Blank = the whole marker."
         required: false
         default: ""
@@ -130,7 +130,7 @@ on:
         required: false
         type: string
         default: "smoke"
-      pytest_k:
+      pytest_filter:
         description: "pytest -k selector to run only a subset of the marker's tests. Blank = the whole marker."
         required: false
         type: string
@@ -477,7 +477,7 @@ jobs:
           PYTEST_MARKER: ${{ inputs.pytest_marker || 'smoke' }}
           # Optional -k selector to run only a subset of the marker's tests
           # (blank = the whole marker). Lets a dispatcher fire a specific set.
-          PYTEST_K: ${{ inputs.pytest_k }}
+          PYTEST_FILTER: ${{ inputs.pytest_filter }}
           # SMOKE_IMAGE_DIR points the fixture at the ALREADY-PULLED qcow2 so the
           # boot needs no network. SMOKE_IMAGE_REF is kept for provenance/logs.
           SMOKE_IMAGE_DIR: ${{ github.workspace }}/image
@@ -545,10 +545,10 @@ jobs:
           # --print-id emits the id without acquiring a real lease).
           RUN_ID="$(sh scripts/select-box.sh --print-id)"
           export RUN_ID
-          # Build argv via set -- so -k rides as ONE quoted arg (word-split on a
+          # Build argv via set -- so --filter rides as ONE quoted arg (word-split on a
           # multi-token expression like "a and not b" would break pytest matching).
           set -- --paths tests/smoke -m "${PYTEST_MARKER}" --timeout 30
-          [ -n "${PYTEST_K:-}" ] && set -- "$@" --k "${PYTEST_K}"
+          [ -n "${PYTEST_FILTER:-}" ] && set -- "$@" --filter "${PYTEST_FILTER}"
           sh scripts/run-smoke.sh "$@"
 
       # ADR-24 / ADR-47 P5: runner-side scrub delegated to the shared script.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -54,7 +54,7 @@ on:
         description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
         required: false
         default: "smoke"
-      pytest_k:
+      pytest_filter:
         description: "pytest -k selector — OVERRIDES the impacted auto-derivation. Blank in impacted scope = the tests changed vs origin/devel (whole marker if none). e.g. 'test_dns_redirect' or 'redirect and not browser'."
         required: false
         default: ""
@@ -78,7 +78,7 @@ on:
         required: false
         type: string
         default: "smoke"
-      pytest_k:
+      pytest_filter:
         description: "pytest -k selector (overrides impacted auto-derivation). Blank = scope decides."
         required: false
         type: string
@@ -105,7 +105,7 @@ jobs:
       ci_matrix: ${{ steps.filter.outputs.ci_matrix }}
       leg_count: ${{ steps.count.outputs.leg_count }}
       pytest_marker: ${{ steps.filter.outputs.pytest_marker }}
-      pytest_k: ${{ steps.filter.outputs.pytest_k }}
+      pytest_filter: ${{ steps.filter.outputs.pytest_filter }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -127,12 +127,12 @@ jobs:
           VERSION_INPUT: ${{ inputs.version }}
           SCOPE_INPUT: ${{ inputs.scope }}
           MARKER_INPUT: ${{ inputs.pytest_marker }}
-          PYTEST_K_INPUT: ${{ inputs.pytest_k }}
+          PYTEST_FILTER_INPUT: ${{ inputs.pytest_filter }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -eu
           # ADR-47 P5: scope + legs + -k resolved by the shared script.
-          # Writes scope=, ci_matrix=, pytest_k= to $GITHUB_OUTPUT.
+          # Writes scope=, ci_matrix=, pytest_filter= to $GITHUB_OUTPUT.
           sh scripts/resolve-legs.sh legs --test-dir tests/smoke --label marker
           printf 'pytest_marker=%s\n' "${MARKER_INPUT:-smoke}" >> "$GITHUB_OUTPUT"
 
@@ -215,7 +215,7 @@ jobs:
       # Resolved by the prepare step: the marker, and the effective -k (an explicit
       # input, else the impacted auto-derivation, else blank = whole marker).
       pytest_marker: ${{ needs.prepare.outputs.pytest_marker || 'smoke' }}
-      pytest_k: ${{ needs.prepare.outputs.pytest_k }}
+      pytest_filter: ${{ needs.prepare.outputs.pytest_filter }}
     secrets: inherit
 
   # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -85,7 +85,7 @@ on:
         required: false
         type: string
         default: ""
-      pytest_k:
+      pytest_filter:
         description: "pytest -k selector — overrides the impacted auto-derivation. Blank = scope decides."
         required: false
         type: string
@@ -128,7 +128,7 @@ on:
         options:
           - impacted
           - full
-      pytest_k:
+      pytest_filter:
         description: "pytest -k selector — OVERRIDES the impacted auto-derivation. Blank in impacted scope = the UI tests changed vs origin/devel (whole tier if none). e.g. 'test_dnsbl' or 'feeds and not browser'."
         required: false
         default: ""
@@ -195,7 +195,7 @@ jobs:
       matrix: ${{ steps.gen.outputs.matrix }}
       build_matrix: ${{ steps.gen.outputs.build_matrix }}
       run: ${{ steps.gen.outputs.run }}
-      pytest_k: ${{ steps.gen.outputs.pytest_k }}
+      pytest_filter: ${{ steps.gen.outputs.pytest_filter }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -222,7 +222,7 @@ jobs:
           # Run scope: impacted (default for a bare dispatch) | full.
           SCOPE_INPUT: ${{ inputs.scope }}
           # -k override for the auto-derivation.
-          PYTEST_K_INPUT: ${{ inputs.pytest_k }}
+          PYTEST_FILTER_INPUT: ${{ inputs.pytest_filter }}
           # The ci:true legs (CE + Plus) read from ci-metadata.
           CI_MATRIX: ${{ steps.matrix.outputs.ci_matrix }}
         run: |
@@ -258,7 +258,7 @@ jobs:
           echo "run=${RUN}" >> "$GITHUB_OUTPUT"
 
           # ADR-47 P5: scope + legs + -k resolved by the shared script.
-          # Writes scope=, ci_matrix=, pytest_k= to $GITHUB_OUTPUT; prints filtered legs JSON to stdout.
+          # Writes scope=, ci_matrix=, pytest_filter= to $GITHUB_OUTPUT; prints filtered legs JSON to stdout.
           LEGS="$(sh scripts/resolve-legs.sh legs --test-dir tests/smoke/ui --label tier)"
 
           # Build matrix: ONE .pkg per distinct leg (version/ABI), independent of
@@ -497,7 +497,7 @@ jobs:
           SMOKE_DNSBL_VIP4: ${{ secrets.SMOKE_DNSBL_VIP4 || vars.SMOKE_DNSBL_VIP4 }}
           # Resolved by the prepare step: an explicit -k input, else the impacted
           # auto-derivation (UI tests changed vs origin/devel), else blank = whole tier.
-          PYTEST_K: ${{ needs.prepare.outputs.pytest_k }}
+          PYTEST_FILTER: ${{ needs.prepare.outputs.pytest_filter }}
           MARKER: ${{ steps.tier.outputs.marker }}
         run: |
           set -eu
@@ -505,9 +505,9 @@ jobs:
           # RUN_ID minted here (CI is the degenerate lease: runner IS the box).
           RUN_ID="$(sh scripts/select-box.sh --print-id)"
           export RUN_ID
-          # Build argv via set -- so -k rides as ONE quoted arg.
+          # Build argv via set -- so --filter rides as ONE quoted arg.
           set -- --paths tests/smoke/ui -m "${MARKER}" --timeout 300
-          [ -n "${PYTEST_K:-}" ] && set -- "$@" --k "${PYTEST_K}"
+          [ -n "${PYTEST_FILTER:-}" ] && set -- "$@" --filter "${PYTEST_FILTER}"
           sh scripts/run-smoke.sh "$@"
 
       # ADR-24: runner-side scrub of the Plus secret identity from the diagnostics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -831,7 +831,7 @@ mechanics, CI wiring (`ui-tests.yml`), gate status — are documented in
   SKIP, never fail).
 - **Selective dispatch (validate your own change cheaply).** A bare `gh workflow run
   smoke.yml`/`ui-tests.yml` defaults to **`scope=impacted`**: the **min CE leg** + only the test
-  modules **changed vs `origin/devel`** (auto-derived). Pass **`-f pytest_k="a or b"`** to add the
+  modules **changed vs `origin/devel`** (auto-derived). Pass **`-f pytest_filter="a or b"`** to add the
   tests covering changed *non-test* code (a live-VM suite can't map src→test for you);
   `-f version=` / `-f pytest_marker=` (smoke) / `-f tier=` (UI) narrow further; **`-f scope=full`**
   is the every-leg whole-marker run. The nightly `schedule`, `version-tracker`'s post-bump

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -210,23 +210,23 @@ run release `ui-suite` as `tier: functional`). Full design: `.ADRs/ADR_14_UI_UX_
 
 **Selective dispatch (ADR-14 + smoke).** A bare `gh workflow run ui-tests.yml` (and
 `smoke.yml`) defaults to **`scope=impacted`**: the **min CE leg only** plus, with no `-f
-pytest_k`, the test modules **changed vs `origin/devel`** (auto-derived by
-`scripts/impacted-tests.sh` from the `prepare`/`gen` step). `-f pytest_k="..."` **overrides** the
+pytest_filter`, the test modules **changed vs `origin/devel`** (auto-derived by
+`scripts/impacted-tests.sh` from the `prepare`/`gen` step). `-f pytest_filter="..."` **overrides** the
 auto-derivation — pass it for the tests covering changed *non-test* code, which a live-VM suite
 can't map automatically. `-f scope=full` restores the every-ci:true-leg whole-tier run.
 `schedule`, `workflow_call` (`test.yml` Tier-A gate, `release.yml` `tier: all`), and
 `version-tracker.yml`'s post-bump dispatch (which now passes `scope=full`) all stay **full** —
-only a bare `workflow_dispatch` is lean. Local runs are pytest-native: pass `-k`/`-m` straight
-through (`scripts/local-smoke.sh` forwards them and treats `-m smoke` as a default).
+only a bare `workflow_dispatch` is lean. Local runs are pytest-native: pass `--filter`/`-m`
+through (`scripts/local-smoke.sh` forwards them — `--filter` becomes pytest `-k` — and treats `-m smoke` as a default).
 
 **CI as parallel dispatch (ADR-47 P5).** Workflows are thin dispatch wrappers; all step logic
 lives in shared scripts that run identically locally and in CI:
 
 - `scripts/resolve-legs.sh` — six subcommands covering the inline blocks previously
   repeated across `smoke.yml`, `smoke-single.yml`, and `ui-tests.yml`:
-  `legs` (scope ladder + THREE-WAY jq + `-k` derivation), `image-ref`, `digest`,
+  `legs` (scope ladder + THREE-WAY jq + filter derivation), `image-ref`, `digest`,
   `exact-image-name`, `vm-identity`, `scrub`. `legs` prints the resolved JSON to
-  stdout for same-step capture and also writes `scope=`, `ci_matrix=`, `pytest_k=`
+  stdout for same-step capture and also writes `scope=`, `ci_matrix=`, `pytest_filter=`
   to `$GITHUB_OUTPUT` for cross-step consumption.
 - `scripts/lib/git-env-scrub.sh` — sourceable POSIX-sh lib exporting `pfb_scrub_git_env()`,
   which unsets the six GIT_\* vars that the pre-commit hook exports and that corrupt

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -31,8 +31,8 @@ export PFB_BOXES="root@10.0.0.23 root@10.0.0.24"   # space-separated SSH targets
 # Full smoke (marker=smoke, current HEAD):
 scripts/local-smoke.sh
 
-# Specific -k filter (expression rides as one quoted arg, no word-split):
-scripts/local-smoke.sh --k "test_dns_redirect or test_killstates"
+# Specific --filter (pytest -k expression rides as one quoted arg, no word-split):
+scripts/local-smoke.sh --filter "test_dns_redirect or test_killstates"
 
 # Different marker:
 scripts/local-smoke.sh --marker ui_render
@@ -57,7 +57,7 @@ the bootstrap command string.
    - `oras` digest-compare → pull pfSense + civm images to `/root/images/{pfsense,civm}` if stale.
    - `sysctl net.ipv4.ip_unprivileged_port_start=53` + `pkill -9 -f qemu-system-x86_64`.
    - `build-leg.sh` → `SMOKE_PKG`.
-   - `run-smoke.sh --paths tests/smoke --marker <M> --timeout 30 [--k <K>]`.
+   - `run-smoke.sh --paths tests/smoke --marker <M> --timeout 30 [--filter <K>]`.
 3. `run-smoke.sh` is the ONE canonical pytest argv — same script CI uses.
 
 The CI `scope=impacted` / min-CE / auto-derived-`-k` defaulting (see
@@ -91,7 +91,7 @@ sudo sysctl -w net.ipv4.ip_unprivileged_port_start=53
 pkill -9 -f qemu-system-x86_64 2>/dev/null || true
 
 # Run (same argv as CI):
-sh scripts/run-smoke.sh --paths tests/smoke -m smoke --timeout 30 --k "test_dns_redirect"
+sh scripts/run-smoke.sh --paths tests/smoke -m smoke --timeout 30 --filter "test_dns_redirect"
 ```
 
 ## The two-VM topology

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -9,7 +9,7 @@
 # Full background + rationale: docs/misc/local-smoke-debian.md
 #
 # Usage:
-#   scripts/local-smoke.sh [--ref REF] [--abi ABI] [--marker M] [--k K]
+#   scripts/local-smoke.sh [--ref REF] [--abi ABI] [--marker M] [--filter EXPR]
 #                          [--no-two-vm]
 #
 # Required (env):
@@ -19,8 +19,8 @@
 #   PFB_REF     git ref (commit/branch) to test (default: current HEAD)
 #   --ref REF   same; flag takes precedence over PFB_REF
 #   --abi ABI   build ABI (default: FreeBSD:15:amd64)
-#   --marker M  pytest -m marker (default: smoke); see also --k
-#   --k K       pytest -k filter expression (optional)
+#   --marker M  pytest -m marker (default: smoke); see also --filter
+#   --filter EXPR  pytest -k filter expression (optional)
 #   --no-two-vm skip civm image pull and LAN-client tests
 #
 # The leased box runs scripts/smoke-on-box.sh, which:
@@ -59,7 +59,7 @@ export PFB_BOXES
 _REF="${PFB_REF:-}"
 _ABI="FreeBSD:15:amd64"
 _MARKER="smoke"
-_K=""
+_FILTER=""
 _NO_TWO_VM=0
 
 while [ "$#" -gt 0 ]; do
@@ -67,7 +67,7 @@ while [ "$#" -gt 0 ]; do
         --ref)      shift; _REF="$1";    shift ;;
         --abi)      shift; _ABI="$1";    shift ;;
         --marker|-m) shift; _MARKER="$1"; shift ;;
-        --k|-k)     shift; _K="$1";      shift ;;
+        --filter)   shift; _FILTER="$1";      shift ;;
         --no-two-vm) _NO_TWO_VM=1;       shift ;;
         --) shift; break ;;
         -*) printf 'local-smoke: unknown flag: %s\n' "$1" >&2; exit 2 ;;
@@ -75,7 +75,7 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 if [ "$#" -gt 0 ]; then
-    printf 'local-smoke: unexpected positional args (use --marker/--k): %s\n' "$*" >&2
+    printf 'local-smoke: unexpected positional args (use --marker/--filter): %s\n' "$*" >&2
     exit 2
 fi
 
@@ -106,8 +106,8 @@ _MARKER_Q="$(_sq "$_MARKER")"
 
 # Build the smoke-on-box.sh flags string (structured, no word-split risk after encoding).
 _ob_flags="--ref '$_REF_Q' --abi '$_ABI_Q' --marker '$_MARKER_Q'"
-if [ -n "$_K" ]; then
-    _ob_flags="$_ob_flags --k '$(_sq "$_K")'"
+if [ -n "$_FILTER" ]; then
+    _ob_flags="$_ob_flags --filter '$(_sq "$_FILTER")'"
 fi
 if [ "$_NO_TWO_VM" -eq 1 ]; then
     _ob_flags="$_ob_flags --no-two-vm"
@@ -129,7 +129,7 @@ _bootstrap="cd /root/pfBlockerNG \
  && exec sh scripts/smoke-on-box.sh $_ob_flags"
 
 printf 'local-smoke: leasing box (REF=%s marker=%s%s)\n' \
-    "$_REF" "$_MARKER" "${_K:+ k=$_K}" >&2
+    "$_REF" "$_MARKER" "${_FILTER:+ filter=$_FILTER}" >&2
 
 # ── Lease a box and run the bootstrap on it ────────────────────────────────── #
 # select-box.sh -- <cmd>: acquires a lease, runs <cmd> on the box over ssh,

--- a/scripts/resolve-legs.sh
+++ b/scripts/resolve-legs.sh
@@ -7,7 +7,7 @@
 #   legs        [--test-dir DIR] [--label LABEL]
 #                 Resolve scope ladder + THREE-WAY jq + -k derivation.
 #                 Prints the filtered legs JSON to stdout.
-#                 Writes scope= / ci_matrix= / pytest_k= to $GITHUB_OUTPUT.
+#                 Writes scope= / ci_matrix= / pytest_filter= to $GITHUB_OUTPUT.
 #
 #   image-ref   Compose the pfSense/civm image ref from env vars.
 #               Reads: INPUT_REF, INPUT_VERSION, INPUT_IMAGE_NAME,
@@ -95,11 +95,11 @@ _rl_legs() {
     fi
 
     # ── -k derivation ─────────────────────────────────────────────────────── #
-    # Explicit PYTEST_K_INPUT always wins. In impacted scope without a -k,
+    # Explicit PYTEST_FILTER_INPUT always wins. In impacted scope without a -k,
     # auto-derive from changed test modules. full never auto-derives.
     K=""
-    if [ -n "${PYTEST_K_INPUT:-}" ]; then
-        K="$PYTEST_K_INPUT"
+    if [ -n "${PYTEST_FILTER_INPUT:-}" ]; then
+        K="$PYTEST_FILTER_INPUT"
     elif [ "$SCOPE" = "impacted" ]; then
         # BASE_REF is origin/devel (the merge-base branch); allow override.
         _l_base="${PFB_BASE_REF:-origin/devel}"
@@ -108,7 +108,7 @@ _rl_legs() {
         if [ -n "$K" ]; then
             printf 'impacted: auto-derived -k from changed %s modules: %s\n' "$_l_label" "$K" >&2
         else
-            printf 'impacted: no changed %s modules vs %s — running the whole %s on the min CE leg. Pass -f pytest_k=... to narrow.\n' \
+            printf 'impacted: no changed %s modules vs %s — running the whole %s on the min CE leg. Pass -f pytest_filter=... to narrow.\n' \
                 "$_l_label" "$_l_base" "$_l_label" >&2
         fi
     fi
@@ -121,7 +121,7 @@ _rl_legs() {
         {
             printf 'scope=%s\n' "$SCOPE"
             printf 'ci_matrix<<__EOF__\n%s\n__EOF__\n' "$FILTERED"
-            printf 'pytest_k<<__EOF__\n%s\n__EOF__\n' "$K"
+            printf 'pytest_filter<<__EOF__\n%s\n__EOF__\n' "$K"
         } >> "$GITHUB_OUTPUT"
     fi
 

--- a/scripts/run-smoke.sh
+++ b/scripts/run-smoke.sh
@@ -16,7 +16,7 @@
 #   --paths P      default tests/smoke   (UI: tests/smoke/ui)
 #   -m/--marker M  default smoke         (CI smoke: smoke|repo; UI: ui_render|...)
 #   --timeout N    default 30            (UI: 300)
-#   -k EXPR        optional; ONE arg, no word-split (passes as -k "expr" to pytest)
+#   --filter EXPR  optional; ONE arg, no word-split (passed to pytest as -k "expr")
 #   trailing passthrough → forwarded to pytest verbatim
 #
 # AMENDMENTS:
@@ -45,7 +45,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 _PATHS="tests/smoke"
 _MARKER="smoke"
 _TIMEOUT=30
-_K=""
+_FILTER=""
 _MARKER_EXPLICIT=0  # set to 1 when -m/--marker was given as a structured flag
 
 # ── Phase 1: parse structured flags; remaining "$@" = passthrough ─────────── #
@@ -68,9 +68,9 @@ while [ "$#" -gt 0 ]; do
             _TIMEOUT="${1:?run-smoke: --timeout requires an argument}"
             shift
             ;;
-        -k)
+        --filter)
             shift
-            _K="${1:?run-smoke: -k requires an argument}"
+            _FILTER="${1:?run-smoke: --filter requires an argument}"
             shift
             ;;
         *)
@@ -121,8 +121,8 @@ fi
 # Final order: [PATH?] [-m MARKER?] [fixed...] [-k K?] [passthrough...]
 
 # 4a. Prepend -k K so it lands between the fixed flags and the passthrough.
-if [ -n "$_K" ]; then
-    set -- -k "$_K" "$@"
+if [ -n "$_FILTER" ]; then
+    set -- -k "$_FILTER" "$@"
 fi
 
 # 4b. Prepend the fixed canonical flags (the drift-kill; see ADR §5.3).

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -5,13 +5,13 @@
 # Single-writer per lease; no other smoke runs share this box concurrently.
 #
 # USAGE (always via select-box.sh -- "... sh /root/pfBlockerNG/scripts/smoke-on-box.sh <flags>"):
-#   smoke-on-box.sh [--ref REF] [--abi ABI] [--marker M] [--k K] [--no-two-vm]
+#   smoke-on-box.sh [--ref REF] [--abi ABI] [--marker M] [--filter EXPR] [--no-two-vm]
 #
 # FLAGS:
 #   --ref REF      git ref to check out (default: current HEAD)
 #   --abi ABI      build ABI string (default: FreeBSD:15:amd64)
 #   --marker M     pytest -m marker (default: smoke)
-#   --k K          pytest -k filter expr (default: none)
+#   --filter EXPR  pytest -k filter expr (default: none)
 #   --no-two-vm    skip civm image pull and set NO_TWO_VM=1
 #
 # ENV (set by the select-box.sh lease or inherited):
@@ -38,7 +38,7 @@ set -eu
 _REF=""        # resolved below (HEAD) if not given
 _ABI="FreeBSD:15:amd64"
 _MARKER="smoke"
-_K=""
+_FILTER=""
 _NO_TWO_VM=0
 
 REPO_ROOT="/root/pfBlockerNG"
@@ -61,7 +61,7 @@ while [ "$#" -gt 0 ]; do
         --ref)      shift; _REF="$1";    shift ;;
         --abi)      shift; _ABI="$1";    shift ;;
         --marker)   shift; _MARKER="$1"; shift ;;
-        --k)        shift; _K="$1";      shift ;;
+        --filter)   shift; _FILTER="$1";      shift ;;
         --no-two-vm) _NO_TWO_VM=1;       shift ;;
         *) printf 'smoke-on-box: unknown argument: %s\n' "$1" >&2; exit 1 ;;
     esac
@@ -90,9 +90,9 @@ if [ "${PFB_ONBOX_REEXEC:-}" != "1" ]; then
     fi
 
     # Re-exec the now-checked-out version with properly quoted args.
-    # Build via set -- so each arg is a distinct word (no word-split on _K spaces).
+    # Build via set -- so each arg is a distinct word (no word-split on _FILTER spaces).
     set -- --ref "$_REF" --abi "$_ABI" --marker "$_MARKER"
-    [ -n "$_K" ] && set -- "$@" --k "$_K"
+    [ -n "$_FILTER" ] && set -- "$@" --filter "$_FILTER"
     [ "$_NO_TWO_VM" -eq 1 ] && set -- "$@" --no-two-vm
     PFB_ONBOX_REEXEC=1 exec sh "$REPO_ROOT/scripts/smoke-on-box.sh" "$@"
 fi
@@ -237,8 +237,8 @@ printf 'smoke-on-box: provisioning test venv (.venv)...\n' >&2
 
 # ── Step 6: run smoke ─────────────────────────────────────────────────────── #
 printf 'smoke-on-box: running smoke (marker=%s%s)\n' \
-    "$_MARKER" "${_K:+ k=$_K}" >&2
+    "$_MARKER" "${_FILTER:+ filter=$_FILTER}" >&2
 
 set -- --paths tests/smoke --marker "$_MARKER" --timeout 30
-[ -n "$_K" ] && set -- "$@" -k "$_K"
+[ -n "$_FILTER" ] && set -- "$@" --filter "$_FILTER"
 exec sh scripts/run-smoke.sh "$@"

--- a/tests/shell/resolve_legs_spec.sh
+++ b/tests/shell/resolve_legs_spec.sh
@@ -24,7 +24,7 @@ Describe 'resolve-legs.sh legs — scope + leg selection'
 
     setup() {
         scrub_git_env
-        unset SCOPE_INPUT VERSION_INPUT PYTEST_K_INPUT GITHUB_OUTPUT GITHUB_ENV PFB_BASE_REF
+        unset SCOPE_INPUT VERSION_INPUT PYTEST_FILTER_INPUT GITHUB_OUTPUT GITHUB_ENV PFB_BASE_REF
     }
     BeforeEach 'setup'
 
@@ -158,17 +158,17 @@ Describe 'resolve-legs.sh legs — -k derivation'
 
     setup() {
         scrub_git_env
-        unset SCOPE_INPUT VERSION_INPUT PYTEST_K_INPUT GITHUB_OUTPUT GITHUB_ENV PFB_BASE_REF
+        unset SCOPE_INPUT VERSION_INPUT PYTEST_FILTER_INPUT GITHUB_OUTPUT GITHUB_ENV PFB_BASE_REF
     }
     BeforeEach 'setup'
 
-    It 'explicit PYTEST_K_INPUT → used verbatim as -k'
+    It 'explicit PYTEST_FILTER_INPUT → used verbatim as -k'
         # stdout = legs JSON; stderr = -k value + scope banner (informational).
         When run env \
             CI_MATRIX="$FIXTURE_MATRIX" \
             EVENT_NAME="workflow_dispatch" \
             SCOPE_INPUT="full" \
-            PYTEST_K_INPUT="test_foo or test_bar" \
+            PYTEST_FILTER_INPUT="test_foo or test_bar" \
             sh "$SCRIPT" legs --test-dir tests/smoke --label marker
         The status should be success
         The output should include '"pfsense_version"'
@@ -177,7 +177,7 @@ Describe 'resolve-legs.sh legs — -k derivation'
 
     It 'impacted scope with PFB_IMPACTED_CHANGED_FILES seam → auto-derives -k'
         # Given: a changed test module visible via the PFB_IMPACTED_CHANGED_FILES seam.
-        # When: impacted scope with no explicit PYTEST_K_INPUT.
+        # When: impacted scope with no explicit PYTEST_FILTER_INPUT.
         # Then: stdout = legs JSON; stderr = auto-derived -k expression.
         When run env \
             CI_MATRIX="$FIXTURE_MATRIX" \

--- a/tests/shell/run_smoke_spec.sh
+++ b/tests/shell/run_smoke_spec.sh
@@ -2,7 +2,7 @@
 # run_smoke_spec.sh — shellspec suite for scripts/run-smoke.sh
 #
 # Verifies the canonical pytest argv emitted by run-smoke.sh across all three
-# caller shapes (local default, UI, CI smoke 'repo'), the single-arg -k, the
+# caller shapes (local default, UI, CI smoke 'repo'), the single-arg --filter, the
 # -m passthrough guard (default -m NOT added when caller's passthrough has one),
 # the bare-path REPLACE amendment (positional path in passthrough replaces the
 # default tests/smoke), and PYTHON resolution.
@@ -114,19 +114,20 @@ PY3EOF
     End
   End
 
-  # ── -k as a single arg (no word-split) ───────────────────────────────────── #
-  # The expression "a and not b" must ride as one arg; if word-split, it becomes
-  # three separate args and the assertion "-k|a and not b" would NOT match.
-  run_k_expr() {
+  # ── --filter as a single arg → pytest -k (no word-split) ─────────────────── #
+  # The caller flag is --filter (translated to pytest's -k); the expression
+  # "a and not b" must ride as one arg. If word-split, it becomes three separate
+  # args and the assertion "-k|a and not b" would NOT match.
+  run_filter_expr() {
     PYTHON="${FAKE_BIN}/python"
     export PYTHON
-    sh "$SCRIPT" -k "a and not b"
+    sh "$SCRIPT" --filter "a and not b"
     argv_joined
   }
 
-  Describe '-k "a and not b" rides as ONE arg'
-    It 'passes the expression as a single -k argument (no word-split)'
-      When call run_k_expr
+  Describe '--filter "a and not b" → pytest -k as ONE arg'
+    It 'passes the expression to pytest as a single -k argument (no word-split)'
+      When call run_filter_expr
       The output should include "-k|a and not b"
     End
   End


### PR DESCRIPTION
The `pytest_k` dispatch input is broken in two CI workflows: `smoke-single.yml` and `ui-tests.yml` forward it to `run-smoke.sh` as `--k`, but the script parses `-k` (single dash). The unrecognised `--k` falls through as a pytest passthrough arg, so any `-f pytest_k=…` dispatch dies with `python -m pytest: error: unrecognized arguments: --k …` (exit 4) before a single test runs.

This is the same bug already fixed for `scripts/smoke-on-box.sh` in 636b6de4 — these two CI workflows were missed. Fix: pass `-k`.

Discovered while dispatching a targeted smoke run to profile the compressed-feed tests (issue #605 timing). CI/tooling only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--filter` option for smoke test commands to select tests using a pytest expression.
  * Updated smoke workflows and local run scripts to pass the new selection flag consistently.

* **Bug Fixes**
  * Improved argument handling so test selection is forwarded more reliably through local and CI smoke test flows.

* **Documentation**
  * Revised smoke test docs and examples to reflect the new `--filter` syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->