### PR TITLE
tests/smoke: instrument every harness operation with PFB_TIMING

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -54,7 +54,7 @@ from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
-from ..timing import timed  # issue #605 — per-step timing (PFB_TIMING)
+from ..timing import step_min_seconds, timed, timed_step  # issue #605 — per-step timing (PFB_TIMING)
 from . import stub_responses
 
 # --------------------------------------------------------------------------- #
@@ -269,7 +269,7 @@ class SmokeVM:
         """Run a command on the guest over SSH and capture its output."""
         # issue #605: time each guest command, but emit only the heavy ones (>=1s) so the
         # tight poll loops (wait_*, snap_state) don't flood the log with sub-second lines.
-        with timed(_ssh_timing_label(remote), min_seconds=1.0):
+        with timed(_ssh_timing_label(remote), min_seconds=step_min_seconds()):
             return subprocess.run(
                 self.ssh_argv(*remote),
                 capture_output=True,
@@ -322,6 +322,7 @@ class BootHandle:
     log_file: object = field(repr=False)
 
 
+@timed_step("boot_and_probe")
 def boot_and_probe(
     base_image: Path,
     ssh_key_path: str,

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -54,7 +54,7 @@ from enum import Enum
 from pathlib import Path
 from typing import NamedTuple
 
-from ..timing import timed, timed_step  # issue #605 — per-step timing (PFB_TIMING)
+from ..timing import step_min_seconds, timed, timed_step  # issue #605 — per-step timing (PFB_TIMING)
 from .conftest import (
     DEFAULT_BOOT_TIMEOUT,
     GUEST_TO_HOST_ALIAS,
@@ -637,6 +637,7 @@ def assert_hsts_loaded(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> None
 # established flows (the live SSH session) are kept.
 
 
+@timed_step("block_egress")
 def block_egress() -> None:
     """Drop the runner's new outbound traffic (loopback + established kept)."""
     if not os.environ.get("SMOKE_BLOCK_EGRESS"):
@@ -649,6 +650,7 @@ def block_egress() -> None:
         subprocess.run(argv, check=True, timeout=30)
 
 
+@timed_step("unblock_egress")
 def unblock_egress() -> None:
     """Restore egress (teardown counterpart of :func:`block_egress`)."""
     if not os.environ.get("SMOKE_BLOCK_EGRESS"):
@@ -678,7 +680,7 @@ def php_eval(vm: SmokeVM, snippet: str, *, timeout: float = 60.0) -> subprocess.
     program = snippet + "\nexec\nexit\n"
     # issue #605: php_eval runs its OWN subprocess (not SmokeVM.ssh), so time it here —
     # threshold-gated like ssh so the many fast config writes don't flood the log.
-    with timed("php_eval", min_seconds=1.0):
+    with timed("php_eval", min_seconds=step_min_seconds()):
         return subprocess.run(
             vm.ssh_argv(PFSSH_BIN),
             input=program,
@@ -819,6 +821,7 @@ def set_control_records(
         raise RuntimeError(f"set_control_records failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
+@timed_step("ensure_dnsbl_vip")
 def ensure_dnsbl_vip(vm: SmokeVM, *, ip4: str = DEFAULT_DNSBL_VIP4, timeout: float = 120.0) -> None:
     """Inject the lo0 IP-Alias VIP DNSBL requires and point pfb_dnsvip4 at it.
 
@@ -1197,6 +1200,7 @@ def set_feed_internal_allowlist(vm: SmokeVM, value: str, *, timeout: float = 60.
         )
 
 
+@timed_step("use_system_dns_upstream")
 def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     """Point pfSense at the runner-side mock via its REAL System-DNS path (no custom zone).
 
@@ -2287,6 +2291,7 @@ def reload_deprecated_verb(vm: SmokeVM, verb: str, *, timeout: float = 600.0) ->
     wait_unbound_ready(vm)
 
 
+@timed_step("apply_filter_sync")
 def apply_filter_sync(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     """Force a BLOCKING pf filter reload via ``/etc/rc.filter_configure_sync``.
 
@@ -2311,6 +2316,7 @@ def apply_filter_sync(vm: SmokeVM, *, timeout: float = 60.0) -> None:
         )
 
 
+@timed_step("reset")
 def reset(vm: SmokeVM, *, timeout: float = 600.0) -> None:
     """Return the VM to the per-case baseline (Phase-3 isolation strategy).
 
@@ -2590,6 +2596,7 @@ def snapshot_unbound_conf(vm: SmokeVM, *, timeout: float = 30.0) -> None:
 PFB_LOGDIR = "/var/log/pfblockerng"
 
 
+@timed_step(lambda vm, tag, **_k: f"snap_state:{tag}")
 def snap_state(vm: SmokeVM, tag: str, *, timeout: float = 30.0) -> None:
     """Snapshot full state into SNAP_DIR/<NN>_<tag>/ (best-effort), SECRET-SCRUBBED.
 
@@ -2758,6 +2765,7 @@ def assert_unbound_adds_only_python_config(vm: SmokeVM, *, timeout: float = 30.0
     )
 
 
+@timed_step("wait_unbound_ready")
 def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 30, delay: float = 2.0) -> None:
     """Poll ``unbound-control status`` until ready (mirrors install-pkg.sh)."""
     cmd = "/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status"
@@ -2887,6 +2895,7 @@ def count_log_marker(vm: SmokeVM, path: str, marker: str, *, timeout: float = 30
         return 0
 
 
+@timed_step("wait_zero_downtime_swap")
 def wait_zero_downtime_swap(vm: SmokeVM, *, since: int, timeout: float = 60.0, interval: float = 2.0) -> None:
     """Block until a NEW fast-path swap line appears in the pfBlockerNG log (no restart).
 
@@ -3298,6 +3307,7 @@ def dns_probe_client_until(
     )
 
 
+@timed_step("assert_link_health")
 def assert_link_health(
     client_vm: SmokeVM,
     vm: SmokeVM,
@@ -3950,6 +3960,7 @@ def parse_redact_values(raw: str | None) -> list[str]:
     return values
 
 
+@timed_step("collect_host_diagnostics")
 def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeout: float = 240.0) -> None:
     """Tar a COMPREHENSIVE pfSense-GUEST snapshot and pull it to ``dest_dir/`` on
     the runner, for the workflow to upload as an artifact.
@@ -4281,6 +4292,7 @@ class CaseContext:
         else:
             self.scope = "updateip"
 
+    @timed_step(lambda self: f"casecontext_enter:{self.spec.aliasname}")
     def __enter__(self) -> CaseContext:
         # Egress stays OPEN across inject + reload: the DNSBL update path needs a
         # working resolver/network and deadlocks the guest if egress is dark.
@@ -4310,6 +4322,7 @@ class CaseContext:
             block_egress()
         return self
 
+    @timed_step(lambda self, *exc: f"casecontext_exit:{self.spec.aliasname}")
     def __exit__(self, *exc: object) -> None:
         # Restore egress before reset() — its forced update reloads pfBlockerNG.
         unblock_egress()

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.timing import close_log, open_log, timed, timed_step
+from tests.timing import close_log, open_log, step_min_seconds, timed, timed_step
 
 # PFB_TIMING <label> <float>s — the one parseable shape the diagnostics consumer greps.
 _LINE = re.compile(r"^PFB_TIMING (?P<label>\S+) (?P<secs>\d+\.\d{2})s$")
@@ -164,3 +164,17 @@ def test_no_log_when_env_unset(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     with timed("nofile"):
         pass
     assert not (tmp_path / "timing.log").exists()
+
+
+def test_step_min_seconds_default_and_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Default threshold (env unset) is 1.0 — the poll-flood guard for ssh/php_eval.
+    monkeypatch.delenv("PFB_TIMING_MIN", raising=False)
+    assert step_min_seconds() == 1.0
+    # PFB_TIMING_MIN overrides it — 0 means "emit every command" (full detail).
+    monkeypatch.setenv("PFB_TIMING_MIN", "0")
+    assert step_min_seconds() == 0.0
+    monkeypatch.setenv("PFB_TIMING_MIN", "2.5")
+    assert step_min_seconds() == 2.5
+    # A non-numeric value falls back to the default rather than raising.
+    monkeypatch.setenv("PFB_TIMING_MIN", "nonsense")
+    assert step_min_seconds() == 1.0

--- a/tests/timing.py
+++ b/tests/timing.py
@@ -32,9 +32,28 @@ from typing import IO, ParamSpec, TypeVar
 _PREFIX = "PFB_TIMING"
 _DIAG_DIR_ENV = "PFB_DIAG_DIR"
 _LOG_NAME = "timing.log"
+_STEP_MIN_ENV = "PFB_TIMING_MIN"
+_STEP_MIN_DEFAULT = 1.0
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
+
+
+def step_min_seconds() -> float:
+    """Emit threshold (seconds) for high-frequency chokepoints (``ssh`` / ``php_eval``).
+
+    Env-tunable via ``PFB_TIMING_MIN`` (default 1.0) so the tight poll loops don't flood the
+    log — set ``PFB_TIMING_MIN=0`` to emit EVERY command. Read per call so a test (or a run)
+    can change it without reimporting. A non-numeric value falls back to the default.
+    """
+    raw = os.environ.get(_STEP_MIN_ENV, "")
+    if not raw:
+        return _STEP_MIN_DEFAULT
+    try:
+        return float(raw)
+    except ValueError:
+        return _STEP_MIN_DEFAULT
+
 
 # The per-session timing log handle, opened once by open_log() and closed by close_log().
 # None means "no file sink" (terminal-only) — the unit suite, where PFB_DIAG_DIR is unset.


### PR DESCRIPTION
Follow-up to #605 (per-step `PFB_TIMING`). #605 timed only `deploy`/`inject`/`reload`/`wait_pfctl_table` + `ssh`/`php_eval`. That left the per-case **teardown** (`reset` = clearip + cleardnsbl + a full `update`) and the fixture prep uninstrumented — exactly where a compressed-feed test's ~80s (in a full run) hides. This instruments the rest so a full-run breakdown shows where every second goes, with no guessing.

## What it adds

Always-on `PFB_TIMING` on every remaining harness operation:
- **teardown:** `reset`, `CaseContext.__exit__` (labelled by case aliasname)
- **per-case:** `CaseContext.__enter__`, `snap_state`
- **fixture prep:** `ensure_dnsbl_vip`, `use_system_dns_upstream`, `assert_link_health`, the session boot (`boot_and_probe`)
- **fixture teardown:** `collect_host_diagnostics`
- **misc:** `apply_filter_sync`, `block_egress`/`unblock_egress`, `wait_unbound_ready`, `wait_zero_downtime_swap`

The `ssh`/`php_eval` threshold is now env-tunable via **`PFB_TIMING_MIN`** (default `1.0` to skip poll-flood; set `0` to emit every command for full detail). `timing.step_min_seconds()` is unit-tested.

## Validation

Unit: `tests/test_timing.py` (12 tests, incl. `step_min_seconds`), full suite 1921 passed, ruff + mypy clean. Smoke collection clean (decorators load at import). Live-VM breakdown verified on a box (the previously-invisible `reset`/`casecontext_exit` now report).

Tests-only — no `src/` change.
