### PR TITLE
smoke: tune QEMU boot for disk I/O + paravirt (mirror Proxmox prod)

### DIFF
--- a/tests/smoke/boot_vm.sh
+++ b/tests/smoke/boot_vm.sh
@@ -207,11 +207,17 @@ else
     SMP="$VM_SMP"; MEM="$VM_MEM"
 fi
 
+# Perf tuning (mirrors a Proxmox prod pfSense VM):
+#   - +kvm_pv_eoi,+kvm_pv_unhalt: paravirt interrupt/spinlock hints -> fewer VM exits.
+#   - iothread + virtio-scsi: disk I/O runs on its own thread, off QEMU's main loop.
+#   - aio=io_uring: modern async I/O backend (lower syscall overhead than aio=threads).
+#   cache=unsafe stays (throwaway overlay; host page cache, skips all flushes = fastest).
 set -- \
-    -enable-kvm -machine pc -cpu host \
+    -enable-kvm -machine pc -cpu host,+kvm_pv_eoi,+kvm_pv_unhalt \
     -smp "$SMP" -m "$MEM" \
-    -device virtio-scsi-pci,id=virtioscsi0 \
-    -drive "file=${OVERLAY},if=none,id=drive-scsi0,format=qcow2,cache=unsafe,discard=unmap,detect-zeroes=unmap" \
+    -object iothread,id=iothread0 \
+    -device virtio-scsi-pci,id=virtioscsi0,iothread=iothread0 \
+    -drive "file=${OVERLAY},if=none,id=drive-scsi0,format=qcow2,aio=io_uring,cache=unsafe,discard=unmap,detect-zeroes=unmap" \
     -device scsi-hd,bus=virtioscsi0.0,drive=drive-scsi0,bootindex=100,rotation_rate=1
 
 if [ "$ROLE" = pfsense ]; then


### PR DESCRIPTION
Tune the smoke VM's QEMU boot to mirror a production Proxmox pfSense VM, targeting the I/O-bound portion of the heavy pfBlockerNG reloads.

## Change (`tests/smoke/boot_vm.sh`)

- **`iothread` + virtio-scsi** — disk I/O runs on its own thread, off QEMU's main loop.
- **`aio=io_uring`** on the overlay drive — modern async I/O backend (lower syscall overhead than the default `aio=threads`).
- **`+kvm_pv_eoi,+kvm_pv_unhalt`** on `-cpu host` — paravirt interrupt/spinlock hints, fewer VM exits.

`cache=unsafe` stays (the overlay is throwaway — host page cache, skips all flushes = fastest). These match a real Proxmox prod box; the non-portable bits of that config (PCI device passthrough, vhost tap, q35) are deliberately not adopted here.

## Validation (live box)

`local-smoke.sh --filter "feed_imports"` → **3 passed, 0 failed (67s)**. The new QEMU line boots and reloads cleanly on both VM roles (the args are shared by the pfSense and civm boots).

## Scope / honesty

Applied without an isolated A/B (per maintainer call), so the *benefit* is unverified — it lands as a low-risk, parity-with-prod improvement. The CPU-bound part of the reload cost is addressed separately by #611; this targets the I/O/interrupt overhead. ADR-47: the change is in the shared `boot_vm.sh` both CI and local invoke, so parity holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
