### PR TITLE
smoke: correct stale 'pkg add pulls RUN_DEPENDS' comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,11 @@ effective live state**; never infer presence/absence from one generated artifact
   under `/var/db/pkg/repos/<repo>/db`); `curl -v` for raw HTTP. Gotcha: pfSense pkg uses the
   **`pkg+https`** scheme (mirror indirection) — `pkg.pfsense.org` doesn't resolve directly (a
   plain `dig` looks "broken") but pkg resolves it to a Netgate mirror (e.g.
-  `pkg00-atx.netgate.com`). Hence the smoke harness keeps egress OPEN during `deploy()`/reload
-  — `pkg add` pulls RUN_DEPENDS from that mirror.
+  `pkg00-atx.netgate.com`). The smoke harness keeps egress OPEN during the `deploy()`/reload
+  phase for the **resolver + feed-update path** (the DNSBL update needs a working resolver);
+  `pkg add` itself is **OFFLINE** — pfBlockerNG's RUN_DEPENDS are baked into the smoke image
+  (`scripts/misc/install_deps_CE_2.8.sh`), so it resolves them from the local pkg db with no
+  mirror round-trip.
 - **Confirm what's installed with `pkg`.** `pkg info` / `pkg info <pkg>` / `pkg info -l <pkg>`
   (files) / `pkg which <path>` (owner); available: `pkg search` / `pkg rquery`. The smoke
   image ships `ldns` (→ `drill`), `bind-tools` (→ `dig`/`host`/`nslookup`), `python311`,

--- a/tests/smoke/boot_vm.sh
+++ b/tests/smoke/boot_vm.sh
@@ -9,7 +9,8 @@
 #       assigned in the image:
 #         net0 WAN  — SLIRP user-net, 192.168.89.0/24, host alias 192.168.89.2 (the
 #                     guest reaches the runner-side mock feed / stub-DNS /
-#                     sinkhole servers here); DHCP; egress for `pkg add`.
+#                     sinkhole servers here); DHCP; egress for the resolver +
+#                     feed-update path (`pkg add` is offline — RUN_DEPENDS baked).
 #         net1 MGMT — SLIRP user-net, 192.168.43.0/24 (a /24 like net0, NOT a /16:
 #                     a /16 made qemu's SLIRP DHCP hand the guest an unexpected
 #                     address the forwards never reached); the host->guest forwards

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -366,7 +366,9 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
     """Install the branch's built .pkg onto the guest via install-pkg.sh.
 
     ``pkg add`` registers the package in pkg's DB, resolves RUN_DEPENDS from the
-    repos, and runs POST-INSTALL (menus, services, Unbound wiring) — fidelity
+    LOCAL pkg db (the smoke image bakes them — scripts/misc/install_deps_CE_2.8.sh
+    — so this is OFFLINE, no repo round-trip), and runs POST-INSTALL (menus,
+    services, Unbound wiring) — fidelity
     the rsync overlay (``deploy.sh``) does not give. The .pkg is produced by the
     portable Linux build job (build-pkg-linux.yml); its path is ``pkg_path`` or ``SMOKE_PKG``.
     install-pkg.sh polls ``unbound-control status`` after POST-INSTALL, so on
@@ -628,13 +630,16 @@ def assert_hsts_loaded(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> None
 # --------------------------------------------------------------------------- #
 # Hermetic gate — block the runner's egress for the test phase (ADR §4 req 4)
 # --------------------------------------------------------------------------- #
-# MUST run only AFTER deploy(): `pkg add` pulls pfBlockerNG's RUN_DEPENDS from
-# the pfSense repo, and the guest reaches the internet THROUGH the runner's
-# SLIRP NAT — so blocking the runner's egress before the package is installed
-# hangs the install. Guarded by SMOKE_BLOCK_EGRESS (CI sets it) so a local
-# `pytest -m smoke` never touches the dev machine's firewall. Loopback stays up
-# (the mock feed server is reached via SLIRP 192.168.89.2 -> runner 127.0.0.1) and
-# established flows (the live SSH session) are kept.
+# This is the per-case HERMETIC PROBE gate: dropped around the probe so a "blocked"
+# name cannot secretly resolve upstream. Egress stays OPEN through deploy + the
+# reload/DNSBL-update phase instead — that path needs a working resolver (see
+# CaseContext.__enter__) — and is restored for teardown. NOTE: `pkg add` (deploy)
+# is OFFLINE: pfBlockerNG's RUN_DEPENDS are baked into the smoke image
+# (scripts/misc/install_deps_CE_2.8.sh), so the install never needs egress.
+# Guarded by SMOKE_BLOCK_EGRESS (CI sets it) so a local `pytest -m smoke` never
+# touches the dev machine's firewall. Loopback stays up (the mock feed server is
+# reached via SLIRP 192.168.89.2 -> runner 127.0.0.1) and established flows (the
+# live SSH session) are kept.
 
 
 @timed_step("block_egress")


### PR DESCRIPTION
Comment-only correction — no behaviour change.

Three places claimed the smoke harness's `pkg add` **pulls RUN_DEPENDS from the pfSense repo/mirror**, and used that as the reason egress is kept open during `deploy()`:

- `tests/smoke/helpers.py` — `deploy()` docstring
- `tests/smoke/helpers.py` — the `block_egress` hermetic-gate comment
- `CLAUDE.md` — a "Investigate, don't assume" working-principles line

That's wrong, and it contradicts the same CLAUDE.md ("pkg add runs offline") **and** the image-bake script's own header: `scripts/misc/install_deps_CE_2.8.sh` installs *exactly* the port RUN_DEPENDS so "the harness `pkg add` of the branch .pkg resolves its RUN_DEPENDS from the local pkg db **OFFLINE (no repo round-trip)**."

Corrected all three to state the truth: `pkg add` is offline (deps baked); egress stays open through `deploy()`/reload for the **resolver + DNSBL-update path** (the reload needs a working resolver — see `CaseContext.__enter__`), and is dropped only for the per-case **hermetic probe**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
