### PR TITLE
smoke: add SMOKE_NET_MODE bridge/slirp toggle to boot_vm.sh (rollout P1)

### DIFF
--- a/tests/shell/boot_vm_spec.sh
+++ b/tests/shell/boot_vm_spec.sh
@@ -129,12 +129,13 @@ QIEOF
       The contents of file "$ARGV_FILE" should include 'socket,id=net1,connect=127.0.0.1:12340'
     End
 
-    It 'bridge: MGMT net0 is a tap; data net1 stays the connect socket'
+    It 'bridge: MGMT net0 is a tap; data net1 stays the connect socket; no hostfwd'
       When run env SMOKE_NET_MODE=bridge SMOKE_CLIENT_MGMT_TAP=tap-cli0 sh "$SCRIPT" --role client "$BASE" "$OVERLAY"
       The status should be success
       The stderr should include 'boot_vm:'
       The contents of file "$ARGV_FILE" should include 'tap,id=net0,ifname=tap-cli0,script=no,downscript=no'
       The contents of file "$ARGV_FILE" should include 'socket,id=net1,connect=127.0.0.1:12340'
+      The contents of file "$ARGV_FILE" should not include 'hostfwd='
     End
   End
 
@@ -147,10 +148,22 @@ QIEOF
       The stderr should include "SMOKE_NET_MODE must be 'slirp' or 'bridge'"
     End
 
-    It 'bridge mode fails fast (non-zero) when SMOKE_WAN_TAP is unset'
+    It 'pfsense bridge mode fails fast (exit 1) when SMOKE_WAN_TAP is unset'
       When run env SMOKE_NET_MODE=bridge SMOKE_MGMT_TAP=tap-mgmt0 sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
-      The status should not equal 0
+      The status should equal 1
       The stderr should include 'SMOKE_WAN_TAP'
+    End
+
+    It 'pfsense bridge mode fails fast (exit 1) when SMOKE_MGMT_TAP is unset'
+      When run env SMOKE_NET_MODE=bridge SMOKE_WAN_TAP=tap-wan0 sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should equal 1
+      The stderr should include 'SMOKE_MGMT_TAP'
+    End
+
+    It 'client bridge mode fails fast (exit 1) when SMOKE_CLIENT_MGMT_TAP is unset'
+      When run env SMOKE_NET_MODE=bridge sh "$SCRIPT" --role client "$BASE" "$OVERLAY"
+      The status should equal 1
+      The stderr should include 'SMOKE_CLIENT_MGMT_TAP'
     End
   End
 End

--- a/tests/shell/boot_vm_spec.sh
+++ b/tests/shell/boot_vm_spec.sh
@@ -1,0 +1,156 @@
+#shellcheck shell=sh
+# boot_vm_spec.sh — shellspec suite for tests/smoke/boot_vm.sh's SMOKE_NET_MODE toggle.
+#
+# Pins the assembled QEMU -netdev argv for BOTH network backends, BOTH roles:
+#   - slirp (default): user-net + hostfwd, EXACTLY as before this toggle existed
+#     (behaviour-preserving oracle — these assertions must stay green across the change).
+#   - bridge: tap devices on the named bridges (SMOKE_WAN_TAP / SMOKE_MGMT_TAP /
+#     SMOKE_CLIENT_MGMT_TAP), with the LAN crossover socket (net2/net1) and the
+#     unassigned net3-7 IDENTICAL to slirp (only WAN+MGMT switch backend).
+# Also pins that an error path exits NON-ZERO (the cleanup trap must not mask it).
+#
+# Hermetic: stubs qemu-system-x86_64 (records its argv) + qemu-img (touches the
+# overlay) via SMOKE_QEMU_BIN / SMOKE_QEMU_IMG_BIN — no real VM boots.
+
+Describe 'boot_vm.sh SMOKE_NET_MODE toggle'
+  SCRIPT="${PFB_ROOT}/tests/smoke/boot_vm.sh"
+
+  setup() {
+    scrub_git_env
+    unset SMOKE_NET_MODE SMOKE_WAN_TAP SMOKE_MGMT_TAP SMOKE_CLIENT_MGMT_TAP
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/bootvmspec.XXXXXX")"
+    ARGV_FILE="${WORK}/argv"
+    BASE="${WORK}/base.qcow2"; : > "$BASE"
+    OVERLAY="${WORK}/ovl.qcow2"
+    BIN="${WORK}/bin"; mkdir -p "$BIN"
+
+    # Stub qemu: record argv (one per line), don't boot.
+    cat > "${BIN}/qemu" << 'QEOF'
+#!/bin/sh
+printf '%s\n' "$@" > "$ARGV_FILE"
+QEOF
+    chmod +x "${BIN}/qemu"
+    # Stub qemu-img: create the overlay (its LAST arg) so the -drive path is valid.
+    cat > "${BIN}/qemu-img" << 'QIEOF'
+#!/bin/sh
+while [ "$#" -gt 1 ]; do shift; done
+: > "$1"
+QIEOF
+    chmod +x "${BIN}/qemu-img"
+
+    SMOKE_QEMU_BIN="${BIN}/qemu"
+    SMOKE_QEMU_IMG_BIN="${BIN}/qemu-img"
+    export WORK ARGV_FILE BASE OVERLAY SMOKE_QEMU_BIN SMOKE_QEMU_IMG_BIN
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # ---- slirp (default) — behaviour-preserving oracle -------------------------
+
+  Describe 'slirp mode (default), role pfsense'
+    It 'WAN net0 is user-net with the 192.168.89.2 host alias'
+      When run sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should include 'user,id=net0,net=192.168.89.0/24,host=192.168.89.2'
+    End
+
+    It 'MGMT net1 is user-net with the ssh + web hostfwd'
+      When run sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should include 'hostfwd=tcp::2222-192.168.43.15:22'
+    End
+
+    It 'LAN net2 is the crossover socket listener'
+      When run sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should include 'socket,id=net2,listen=127.0.0.1:12340'
+    End
+
+    It 'net3 is an isolated restrict user-net'
+      When run sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should include 'user,id=net3,net=10.30.0.0/24,restrict=on'
+    End
+
+    It 'emits NO tap backend'
+      When run sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should not include 'tap,id=net0'
+    End
+  End
+
+  # ---- bridge mode, role pfsense --------------------------------------------
+
+  Describe 'bridge mode, role pfsense'
+    It 'WAN net0 is a tap on the named WAN device'
+      When run env SMOKE_NET_MODE=bridge SMOKE_WAN_TAP=tap-wan0 SMOKE_MGMT_TAP=tap-mgmt0 sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should include 'tap,id=net0,ifname=tap-wan0,script=no,downscript=no'
+    End
+
+    It 'MGMT net1 is a tap on the named MGMT device'
+      When run env SMOKE_NET_MODE=bridge SMOKE_WAN_TAP=tap-wan0 SMOKE_MGMT_TAP=tap-mgmt0 sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should include 'tap,id=net1,ifname=tap-mgmt0,script=no,downscript=no'
+    End
+
+    It 'keeps the LAN crossover socket (net2) and net3 restrict unchanged'
+      When run env SMOKE_NET_MODE=bridge SMOKE_WAN_TAP=tap-wan0 SMOKE_MGMT_TAP=tap-mgmt0 sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should include 'socket,id=net2,listen=127.0.0.1:12340'
+      The contents of file "$ARGV_FILE" should include 'user,id=net3,net=10.30.0.0/24,restrict=on'
+    End
+
+    It 'emits NO user-net hostfwd on WAN/MGMT'
+      When run env SMOKE_NET_MODE=bridge SMOKE_WAN_TAP=tap-wan0 SMOKE_MGMT_TAP=tap-mgmt0 sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should not include 'hostfwd='
+    End
+  End
+
+  # ---- role client -----------------------------------------------------------
+
+  Describe 'role client'
+    It 'slirp: MGMT net0 is user-net hostfwd; data net1 is the connect socket'
+      When run sh "$SCRIPT" --role client "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should include 'user,id=net0,hostfwd=tcp::2223-:22'
+      The contents of file "$ARGV_FILE" should include 'socket,id=net1,connect=127.0.0.1:12340'
+    End
+
+    It 'bridge: MGMT net0 is a tap; data net1 stays the connect socket'
+      When run env SMOKE_NET_MODE=bridge SMOKE_CLIENT_MGMT_TAP=tap-cli0 sh "$SCRIPT" --role client "$BASE" "$OVERLAY"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "$ARGV_FILE" should include 'tap,id=net0,ifname=tap-cli0,script=no,downscript=no'
+      The contents of file "$ARGV_FILE" should include 'socket,id=net1,connect=127.0.0.1:12340'
+    End
+  End
+
+  # ---- guards (must exit NON-ZERO — the cleanup trap must not mask it) --------
+
+  Describe 'guards'
+    It 'rejects an invalid SMOKE_NET_MODE'
+      When run env SMOKE_NET_MODE=wat sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should equal 2
+      The stderr should include "SMOKE_NET_MODE must be 'slirp' or 'bridge'"
+    End
+
+    It 'bridge mode fails fast (non-zero) when SMOKE_WAN_TAP is unset'
+      When run env SMOKE_NET_MODE=bridge SMOKE_MGMT_TAP=tap-mgmt0 sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
+      The status should not equal 0
+      The stderr should include 'SMOKE_WAN_TAP'
+    End
+  End
+End

--- a/tests/smoke/boot_vm.sh
+++ b/tests/smoke/boot_vm.sh
@@ -60,8 +60,10 @@
 
 set -eu
 
-QEMU=/usr/bin/qemu-system-x86_64
-QEMU_IMG=/usr/bin/qemu-img
+# Overridable for tests (the shellspec injects stubs to assert the assembled argv
+# without booting); falls through to command -v below when the path isn't executable.
+QEMU="${SMOKE_QEMU_BIN:-/usr/bin/qemu-system-x86_64}"
+QEMU_IMG="${SMOKE_QEMU_IMG_BIN:-/usr/bin/qemu-img}"
 
 # Source-VM hardware profile (mirror — do not change without re-baking image).
 # DEFAULT_CE_MAC is the CE source VM's own 8 NIC MACs (net0..net7, in order),
@@ -118,6 +120,22 @@ PFSENSE_MGT_TARGET="${SMOKE_PFSENSE_MGT_TARGET-$PFSENSE_MGMT_IP}"
 
 # pfSense<->civm LAN crossover socket (point-to-point; pfSense listens, civm connects).
 LAN_SOCKET_PORT="${SMOKE_LAN_SOCKET_PORT:-12340}"
+
+# Network backend for the WAN + MGMT NICs (the LAN crossover socket + the unassigned
+# net3-7 are identical either way):
+#   slirp  (default) — QEMU user-net: built-in DHCP/DNS/NAT, host alias 192.168.89.2,
+#                      host->guest ssh/web via hostfwd. Zero host setup. Today's behaviour.
+#   bridge — tap devices on host Linux bridges (br-wan 192.168.89.0/24, br-mgmt
+#                      192.168.43.0/24) that a per-box setup created + put dnsmasq on; the
+#                      runner IS 192.168.89.2 / 192.168.43.2. Lower latency/CPU than slirp's
+#                      userspace path. The tap names are passed in (SMOKE_WAN_TAP /
+#                      SMOKE_MGMT_TAP / SMOKE_CLIENT_MGMT_TAP) by that setup; no hostfwd
+#                      (the harness ssh's the guest's MGMT bridge IP directly).
+NET_MODE="${SMOKE_NET_MODE:-slirp}"
+case "$NET_MODE" in
+    slirp|bridge) ;;
+    *) echo "boot_vm: SMOKE_NET_MODE must be 'slirp' or 'bridge' (got '$NET_MODE')" >&2; exit 2 ;;
+esac
 
 ROLE=pfsense
 
@@ -183,9 +201,17 @@ if [ -z "$OVERLAY" ]; then
 fi
 
 cleanup() {
+    # Preserve the triggering exit status: without capturing $? first, the trap's
+    # last command (the rm / the if) would reset it to 0 and MASK every error-path
+    # exit (base-not-found, qemu-not-found, the bridge tap guards) as success — a
+    # caller could not tell a failed boot from a good one. The happy path execs qemu
+    # and never runs this trap. trap - EXIT avoids re-entry from the explicit exit.
+    _rc=$?
     if [ "$CLEANUP_OVERLAY" -eq 1 ] && [ -n "$OVERLAY" ]; then
         rm -f "$OVERLAY"
     fi
+    trap - EXIT
+    exit "$_rc"
 }
 trap cleanup EXIT INT TERM
 
@@ -225,7 +251,11 @@ if [ "$ROLE" = pfsense ]; then
     # SMBIOS identity (license/NDI-keyed for Plus; public pin for CE).
     set -- "$@" -smbios "type=1,uuid=${VM_SMBIOS_UUID}"
 
-    echo "boot_vm: pfsense hostfwd ssh=${SSH_HOSTPORT}->${PFSENSE_MGT_TARGET}:22 web=${WEB_HOSTPORT}->${PFSENSE_MGT_TARGET}:80 (mgmt net1)" >&2
+    if [ "$NET_MODE" = bridge ]; then
+        echo "boot_vm: pfsense WAN=tap:${SMOKE_WAN_TAP:-?} MGMT=tap:${SMOKE_MGMT_TAP:-?} (bridge; ssh the guest MGMT bridge IP)" >&2
+    else
+        echo "boot_vm: pfsense hostfwd ssh=${SSH_HOSTPORT}->${PFSENSE_MGT_TARGET}:22 web=${WEB_HOSTPORT}->${PFSENSE_MGT_TARGET}:80 (mgmt net1)" >&2
+    fi
     echo "boot_vm: pfsense LAN socket LISTEN 127.0.0.1:${LAN_SOCKET_PORT} (net2)" >&2
 
     i=0
@@ -235,12 +265,25 @@ if [ "$ROLE" = pfsense ]; then
             # VIP (10.10.10.1) or the auto-VIP (10.10.10.53) — pfBlockerNG refuses
             # a VIP that overlaps an interface subnet and disables DNSBL wholesale.
             # 192.168.89.0/24 keeps the host alias 192.168.89.2 while leaving 10.10.10.x free.
-            0) netdev="user,id=net0,net=192.168.89.0/24,host=192.168.89.2" ;;
+            # bridge: a pre-created tap on br-wan (same subnet; the runner is .2).
+            0)  if [ "$NET_MODE" = bridge ]; then
+                    [ -n "${SMOKE_WAN_TAP:-}" ] || { echo "boot_vm: bridge mode needs SMOKE_WAN_TAP (the per-box setup creates it)" >&2; exit 1; }
+                    netdev="tap,id=net0,ifname=${SMOKE_WAN_TAP},script=no,downscript=no"
+                else
+                    netdev="user,id=net0,net=192.168.89.0/24,host=192.168.89.2"
+                fi ;;
             # net1 MGMT: a /24 (NOT a /16). A /16 made qemu's SLIRP DHCP lease the
             # guest an unexpected address (10.0.2.x) the forwards never reached; a
             # /24 is predictable (net|.15), mirroring net0. 192.168.43.0/24 avoids
-            # the DNSBL VIP ranges and the LAN (192.168.1.0/24).
-            1) netdev="user,id=net1,net=192.168.43.0/24,host=192.168.43.2,hostfwd=tcp::${SSH_HOSTPORT}-${PFSENSE_MGT_TARGET}:22,hostfwd=tcp::${WEB_HOSTPORT}-${PFSENSE_MGT_TARGET}:80" ;;
+            # the DNSBL VIP ranges and the LAN (192.168.1.0/24). bridge: a pre-created
+            # tap on br-mgmt (separate subnet from WAN — two NICs on one subnet break
+            # pfSense routing/anti-spoof); the harness ssh's the guest's MGMT lease IP.
+            1)  if [ "$NET_MODE" = bridge ]; then
+                    [ -n "${SMOKE_MGMT_TAP:-}" ] || { echo "boot_vm: bridge mode needs SMOKE_MGMT_TAP (the per-box setup creates it)" >&2; exit 1; }
+                    netdev="tap,id=net1,ifname=${SMOKE_MGMT_TAP},script=no,downscript=no"
+                else
+                    netdev="user,id=net1,net=192.168.43.0/24,host=192.168.43.2,hostfwd=tcp::${SSH_HOSTPORT}-${PFSENSE_MGT_TARGET}:22,hostfwd=tcp::${WEB_HOSTPORT}-${PFSENSE_MGT_TARGET}:80"
+                fi ;;
             2) netdev="socket,id=net2,listen=127.0.0.1:${LAN_SOCKET_PORT}" ;;
             # net3..7: present so the 8-NIC image sees no hardware change, but
             # isolated (restrict=on) with distinct dummy subnets — pfSense leaves
@@ -257,13 +300,21 @@ if [ "$ROLE" = pfsense ]; then
         i=$((i + 1))
     done
 else
-    # civm: net0 management (ssh hostfwd, DHCP, don't-care MAC); net1 data
-    # (socket CONNECT to the pfSense LAN listener, MAC = static-lease key).
+    # civm: net0 management (ssh, DHCP, don't-care MAC); net1 data (socket CONNECT
+    # to the pfSense LAN listener, MAC = static-lease key). slirp: ssh via hostfwd.
+    # bridge: a pre-created tap on br-mgmt; the harness ssh's the civm's MGMT lease IP.
     set -- "$@" -smbios "type=1,uuid=${CLIENT_SMBIOS_UUID}"
-    echo "boot_vm: client hostfwd ssh=${CLIENT_SSH_HOSTPORT}->:22 (mgmt net0)" >&2
+    if [ "$NET_MODE" = bridge ]; then
+        [ -n "${SMOKE_CLIENT_MGMT_TAP:-}" ] || { echo "boot_vm: bridge mode needs SMOKE_CLIENT_MGMT_TAP (the per-box setup creates it)" >&2; exit 1; }
+        client_mgmt_netdev="tap,id=net0,ifname=${SMOKE_CLIENT_MGMT_TAP},script=no,downscript=no"
+        echo "boot_vm: client MGMT=tap:${SMOKE_CLIENT_MGMT_TAP} (bridge; ssh the civm MGMT bridge IP)" >&2
+    else
+        client_mgmt_netdev="user,id=net0,hostfwd=tcp::${CLIENT_SSH_HOSTPORT}-:22"
+        echo "boot_vm: client hostfwd ssh=${CLIENT_SSH_HOSTPORT}->:22 (mgmt net0)" >&2
+    fi
     echo "boot_vm: client DATA socket CONNECT 127.0.0.1:${LAN_SOCKET_PORT} mac=${CLIENT_MAC} (net1)" >&2
     set -- "$@" \
-        -netdev "user,id=net0,hostfwd=tcp::${CLIENT_SSH_HOSTPORT}-:22" \
+        -netdev "$client_mgmt_netdev" \
         -device "virtio-net-pci,mac=${CLIENT_MGMT_MAC},netdev=net0,id=nic0" \
         -netdev "socket,id=net1,connect=127.0.0.1:${LAN_SOCKET_PORT}" \
         -device "virtio-net-pci,mac=${CLIENT_MAC},netdev=net1,id=nic1" \


### PR DESCRIPTION
First phase of the smoke SLIRP→bridge rollout (the topology proven on both local LXC boxes and a GH runner during de-risking). **Behaviour-preserving**: `slirp` is the default and is byte-identical to today; `bridge` is dormant until the per-box setup + conftest phases land.

## What

`boot_vm.sh` gains `SMOKE_NET_MODE`:

- **`slirp`** (default) — QEMU user-net + hostfwd, exactly as before.
- **`bridge`** — the WAN/MGMT NICs become `tap` devices on host bridges (names passed in via `SMOKE_WAN_TAP` / `SMOKE_MGMT_TAP` / `SMOKE_CLIENT_MGMT_TAP`, created by a per-box setup landing in a later phase). The LAN crossover socket (net2) and the unassigned net3-7 are identical in both modes; no hostfwd in bridge mode (the harness will ssh the guest's MGMT bridge IP).

## Latent bug fixed (exposed by the new spec)

`cleanup()` (the `EXIT` trap) ended with status `0`, so **every** error-path exit — base-not-found, qemu-not-found, the new tap guards — was masked as success; a caller could not tell a failed boot from a good one. It now preserves `$?`. (bash 3.2 reports `$?`=0 for `${VAR:?}` under an EXIT trap, so the guards use explicit `exit 1`, which propagates.) `QEMU`/`QEMU_IMG` are env-overridable (`SMOKE_QEMU_BIN`/`SMOKE_QEMU_IMG_BIN`) so the spec is hermetic.

## Tests

`tests/shell/boot_vm_spec.sh` pins the assembled `-netdev` argv for **both modes × both roles** (the slirp assertions are the behaviour-preserving oracle) plus the fatal guards (invalid mode → exit 2; missing tap → non-zero). 208/0 in the full shellspec suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional bridge-based network mode alongside the default network setup.
  * Client and VM boot flows now adapt their management networking based on the selected mode.

* **Bug Fixes**
  * Improved cleanup so failures now preserve the original exit status.
  * Added validation and clearer errors for invalid network settings and missing required tap interfaces.

* **Tests**
  * Added end-to-end shell coverage for both network modes, including client and VM scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->