### PR TITLE
ADR-50: bridge networking for the smoke VMs (P2–P4)

### DIFF
--- a/.ADRs/ADR_50_Smoke_Bridge_Networking/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_50_Smoke_Bridge_Networking/RESULTS/02_Results.txt
@@ -1,0 +1,100 @@
+ADR-50 Phase 2 — Per-box bridge+dnsmasq setup for SMOKE_NET_MODE=bridge
+
+BRANCH:  smoke/bridge-networking
+STATUS:  COMPLETE — all gates green; ready for P3
+
+═══════════════════════════════════════════════════════
+DELIVERABLES
+═══════════════════════════════════════════════════════
+
+1. scripts/bridge-net.sh  (NEW)
+   - POSIX sh; ShellCheck-clean; sh -n passes.
+   - Subcommands: up | down.
+   - 'up': creates br-wan (192.168.89.2/24) + br-mgmt (192.168.43.2/24),
+     3 per-lane tap devices (tap-wan<lane>, tap-mgmt<lane>, tap-cli<lane>),
+     starts dnsmasq DHCP-only (--port=0) with static MGMT leases.
+   - Static leases: pfSense net1/MGMT → SMOKE_PFSENSE_MGMT_IP (default 192.168.43.15),
+     civm MGMT → SMOKE_CLIENT_MGMT_IP (default 192.168.43.16).
+   - MAC resolution: SMOKE_VM_MAC line 2 (= sed -n '2p') drives pfSense lease MAC,
+     mirroring boot_vm.sh's nth_mac 1.  Default CE MAC = BC:24:11:80:42:35.
+   - 'up' is idempotent: calls _do_down first.
+   - Emits 5 eval-able KEY=value on stdout; diagnostics to stderr.
+   - Binary paths overridable: SMOKE_IP_BIN, SMOKE_DNSMASQ_BIN (shellspec stubs).
+   - ponytail ceiling: bridges/dnsmasq are singletons; only tap names are per-lane.
+     Multi-lane → per-lane subnets; deferred to P5.
+
+2. tests/shell/bridge_net_spec.sh  (NEW)
+   - Hermetic shellspec (no real ip/dnsmasq); stubs write argv to files.
+   - 16 examples, 0 failures, 0 warnings (verified).
+   - Red→green proven: breaking PFSENSE_MGMT_IP default (→.99) fails exactly 3
+     relevant assertions; restoring gives green.
+   - Covers: bridge creation, tap attachment, dnsmasq DHCP args, eval-able stdout,
+     idempotency (down-first), per-lane names, SMOKE_VM_MAC override,
+     down teardown, unknown/missing subcommand.
+
+3. scripts/smoke-on-box.sh  (EDITED)
+   - Added --net-mode slirp|bridge flag (default: slirp).
+   - Validation: unknown value → exit 1 + stderr.
+   - --net-mode propagates through reexec set.
+   - Step 4 bridge setup block: eval "$(sh bridge-net.sh up)" + exports
+     SMOKE_WAN_TAP, SMOKE_MGMT_TAP, SMOKE_CLIENT_MGMT_TAP,
+     SMOKE_PFSENSE_MGMT_IP, SMOKE_CLIENT_MGMT_IP, SMOKE_NET_MODE.
+
+4. scripts/local-smoke.sh  (EDITED)
+   - Added --net-mode slirp|bridge flag (default: slirp).
+   - Threads through _ob_flags to smoke-on-box.sh via _NET_MODE_Q.
+
+5. docs/misc/local-smoke-debian.md  (EDITED)
+   - New subsection: "## Bridge networking (ADR-50, opt-in)" before
+     "## Building the .pkg off-FreeBSD".
+   - Documents: apt-get install dnsmasq prerequisite, LXC /dev/net/tun passthrough,
+     usage (--net-mode bridge), note that live correctness is P5.
+
+═══════════════════════════════════════════════════════
+GATES PASSED
+═══════════════════════════════════════════════════════
+
+  sh -n scripts/bridge-net.sh                  OK
+  sh -n scripts/smoke-on-box.sh                OK
+  sh -n scripts/local-smoke.sh                 OK
+  shellcheck scripts/bridge-net.sh             0 issues
+  shellcheck scripts/smoke-on-box.sh           0 issues
+  shellcheck scripts/local-smoke.sh            0 issues
+  shellspec tests/shell/bridge_net_spec.sh     16/16, 0 failures, 0 warnings
+  Red→green proof (PFSENSE_MGMT_IP .15→.99)    3 failures → restore → 0 failures
+  python -m pytest tests/test_smoke_net_mode.py 15 passed
+  npx markdownlint-cli2 local-smoke-debian.md  0 errors
+
+═══════════════════════════════════════════════════════
+CONTRACTS FOR P3 (conftest.py)
+═══════════════════════════════════════════════════════
+
+P3 reads these env vars to configure the smoke harness:
+
+  SMOKE_NET_MODE              slirp (default) | bridge
+  SMOKE_WAN_TAP               tap-wan<lane>   (bridge mode)
+  SMOKE_MGMT_TAP              tap-mgmt<lane>  (bridge mode)
+  SMOKE_CLIENT_MGMT_TAP       tap-cli<lane>   (bridge mode)
+  SMOKE_PFSENSE_MGMT_IP       192.168.43.15   (static, matches P3 default)
+  SMOKE_CLIENT_MGMT_IP        192.168.43.16   (static, matches P3 default)
+
+Slirp mode: none of the bridge vars are set; boot_vm.sh uses SLIRP hostfwds
+as before (no change to P1 boot_vm.sh).
+
+Bridge mode: smoke-on-box.sh evaluates bridge-net.sh up and exports all six
+vars.  P3 conftest must consume SMOKE_NET_MODE to switch boot_vm.sh's QEMU
+net args from -netdev user,... to -netdev tap,ifname=SMOKE_WAN_TAP,... etc.
+
+boot_vm.sh already has bridge-mode tap consumption logic from P1; P3 only
+needs to pass the correct env.
+
+═══════════════════════════════════════════════════════
+DEFERRED (P3+)
+═══════════════════════════════════════════════════════
+
+- conftest.py bridge-mode QEMU args (P3)
+- Live correctness smoke (P5 A/B test)
+- Multi-lane subnets (ponytail ceiling; needs P5 justification)
+- bridge-net.sh down wired into smoke-on-box.sh EXIT trap (P3 can add)
+
+ADR-RESUME: branch=smoke/bridge-networking next-phase=3

--- a/.ADRs/ADR_50_Smoke_Bridge_Networking/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_50_Smoke_Bridge_Networking/RESULTS/03_Results.txt
@@ -1,0 +1,98 @@
+ADR-50 P3 — conftest SSH→MGMT-IP + stub-DNS rebind
+====================================================
+
+Files changed
+-------------
+  tests/smoke/conftest.py       — mode-aware connection-endpoint block + client_vm + stub DNS
+  tests/test_smoke_net_mode.py  — new off-box unit test (15 tests, 4 classes)
+
+Changes to conftest.py (added after the env write-back block, ~line 148)
+-------------------------------------------------------------------------
+New constants:
+
+  NET_MODE = os.environ.get("SMOKE_NET_MODE", "slirp")
+    # raises ValueError on unrecognised value (mirrors boot_vm.sh's guard)
+
+  PFSENSE_MGMT_IP = os.environ.get("SMOKE_PFSENSE_MGMT_IP") or "192.168.43.15"
+  CLIENT_MGMT_IP  = os.environ.get("SMOKE_CLIENT_MGMT_IP")  or "192.168.43.16"
+
+  # Bridge override block (slirp path: nothing changes):
+  if NET_MODE == "bridge":
+      DEFAULT_HOST          = PFSENSE_MGMT_IP   # "192.168.43.15"
+      DEFAULT_SSH_PORT      = 22
+      DEFAULT_WEB_PORT      = 80
+      DEFAULT_CLIENT_SSH_PORT = 22
+
+  DEFAULT_CLIENT_HOST: str  = CLIENT_MGMT_IP if NET_MODE == "bridge" else DEFAULT_HOST
+  DEFAULT_STUB_DNS_ADDR: str = GUEST_TO_HOST_ALIAS if NET_MODE == "bridge" else "127.0.0.1"
+
+  # GUEST_TO_HOST_ALIAS = "192.168.89.2" (pre-existing WAN host-alias constant)
+
+client_vm fixture:
+  - wait_ready.sh call: DEFAULT_HOST → DEFAULT_CLIENT_HOST  (civm SSH target)
+  - SmokeVM(host=...):  DEFAULT_HOST → DEFAULT_CLIENT_HOST
+
+_StubDnsServer.__init__:
+  addr = os.environ.get("SMOKE_STUB_DNS_ADDR") or DEFAULT_STUB_DNS_ADDR
+  (was hardcoded "127.0.0.1"; an explicit env still wins in both modes)
+
+Constant values by mode (lane 0, no env overrides)
+---------------------------------------------------
+Constant               slirp           bridge
+--------------------- --------------- ---------------
+DEFAULT_HOST           127.0.0.1       192.168.43.15
+DEFAULT_SSH_PORT       2222            22
+DEFAULT_WEB_PORT       8080            80
+DEFAULT_CLIENT_HOST    127.0.0.1       192.168.43.16
+DEFAULT_CLIENT_SSH_PORT 2223           22
+DEFAULT_STUB_DNS_ADDR  127.0.0.1       192.168.89.2
+
+New env knobs (consumed by P3; exported by P2's per-box setup)
+--------------------------------------------------------------
+  SMOKE_NET_MODE          "slirp" | "bridge" (default "slirp")
+  SMOKE_PFSENSE_MGMT_IP   pfSense MGMT bridge static-lease IP (default 192.168.43.15)
+  SMOKE_CLIENT_MGMT_IP    civm MGMT bridge static-lease IP (default 192.168.43.16)
+  SMOKE_STUB_DNS_ADDR     stub DNS bind address override (default from DEFAULT_STUB_DNS_ADDR)
+
+Red→green evidence
+------------------
+With conftest.py REVERTED (pre-P3):
+
+  FAILED test_bridge_flips_endpoints:
+    AssertionError: expected 192.168.43.15; got '127.0.0.1'
+    assert '127.0.0.1' == '192.168.43.15'
+
+  FAILED test_bridge_client_host:
+    AttributeError: module 'tests.smoke.conftest' has no attribute 'DEFAULT_CLIENT_HOST'.
+    Did you mean: 'DEFAULT_CLIENT_SSH_PORT'?
+
+  FAILED test_bridge_stub_dns_addr:
+    AttributeError: module 'tests.smoke.conftest' has no attribute 'DEFAULT_STUB_DNS_ADDR'
+
+After P3: all 15 tests in test_smoke_net_mode.py PASS.
+
+Gate results
+------------
+  python -m pytest tests/test_smoke_net_mode.py tests/test_adr47_conftest_lane.py
+                   tests/test_smoke_harness_defaults.py -v
+    → 37 passed in 0.13s  (no regression in the two existing conftest/harness suites)
+
+  python -m pytest -q (full off-box suite)
+    → 1936 passed, 4 skipped in 34.97s  (the 4 skips are pre-existing, unrelated)
+
+  ruff check + ruff format --check
+    → All checks passed (clean after auto-format)
+
+Notes for P2
+------------
+P2 (per-box bridge+dnsmasq setup) MUST provide static dnsmasq leases for:
+  - pfSense MGMT NIC MAC  → 192.168.43.15  (matches PFSENSE_MGMT_IP default)
+  - civm    MGMT NIC MAC  → 192.168.43.16  (matches CLIENT_MGMT_IP default)
+
+If the leases use different IPs, export SMOKE_PFSENSE_MGMT_IP / SMOKE_CLIENT_MGMT_IP
+before pytest so conftest picks them up.
+
+P4 (CI wiring) picks up from here — the NET_MODE=bridge path in conftest is live; P4
+needs the bridge-setup step in smoke-single.yml / ui-tests.yml.
+
+ADR-RESUME: branch=smoke/bridge-networking next-phase=4

--- a/.ADRs/ADR_50_Smoke_Bridge_Networking/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_50_Smoke_Bridge_Networking/RESULTS/04_Results.txt
@@ -1,0 +1,70 @@
+ADR-50 P4 — CI bridge-setup wiring (smoke-single.yml + ui-tests.yml + smoke.yml)
+================================================================================
+
+OBJECTIVE (ADR §5.4)
+  Make the live-VM CI workflows able to run under SMOKE_NET_MODE=bridge: add a
+  `net_mode` toggle (default slirp) + a gated per-box bridge-setup step that calls the
+  P2 script (scripts/bridge-net.sh up), before the VM boots, and thread SMOKE_NET_MODE
+  into the pytest env so conftest (P3) + boot_vm.sh (P1) pick up bridge mode.
+
+WHAT CHANGED
+  .github/workflows/smoke-single.yml
+    - New `net_mode` input on BOTH workflow_dispatch (type: choice slirp|bridge) and
+      workflow_call (type: string, default "slirp").
+    - New step "Set up bridge networking (SMOKE_NET_MODE=bridge)", `if: inputs.net_mode
+      == 'bridge'`, placed AFTER "Resolve VM identity" (so RESOLVED_VM_MAC — the Plus
+      net1 MAC — is in $GITHUB_ENV; the pfSense MGMT static lease keys on it) and BEFORE
+      the pytest step. It: apt-installs dnsmasq; runs `sudo env SMOKE_VM_MAC=... sh
+      scripts/bridge-net.sh up` (root needed for ip/dnsmasq; SMOKE_VM_MAC passed through
+      sudo's env reset explicitly); appends the 5 emitted vars (SMOKE_WAN_TAP /
+      SMOKE_MGMT_TAP / SMOKE_CLIENT_MGMT_TAP / SMOKE_PFSENSE_MGMT_IP /
+      SMOKE_CLIENT_MGMT_IP) to $GITHUB_ENV.
+    - pytest step env: added `SMOKE_NET_MODE: ${{ inputs.net_mode }}` and made the
+      previously-hardcoded `SMOKE_STUB_DNS_ADDR` mode-aware:
+      `${{ inputs.net_mode == 'bridge' && '192.168.89.2' || '127.0.0.1' }}`.
+      (CRITICAL: without this the hardcoded loopback would override P3's conftest bridge
+      default — a step-level env wins over $GITHUB_ENV — so the stub DNS would bind
+      loopback in bridge mode and the guest's 192.168.89.2:53 would answer nothing.)
+
+  .github/workflows/ui-tests.yml
+    - Same `net_mode` input (call: string; dispatch: choice) + same bridge-setup step
+      after "Resolve VM identity". UI-tier env: added `SMOKE_NET_MODE: ${{ inputs.net_mode }}`.
+      No SMOKE_STUB_DNS_ADDR change needed — ui-tests never set it, so P3's conftest
+      default (bridge -> 192.168.89.2, slirp -> loopback) applies automatically.
+
+  .github/workflows/smoke.yml (fan-out)
+    - New `net_mode` input (dispatch: choice; call: string) forwarded to the smoke-single
+      call: `net_mode: ${{ inputs.net_mode || 'slirp' }}`. Lets P5 dispatch the WHOLE
+      CE+Plus fan-out under bridge in one shot.
+
+SLIRP IS BYTE-IDENTICAL (the regression guarantee)
+  net_mode defaults to "slirp" on every trigger AND every existing caller (test.yml /
+  release.yml / version-tracker / schedule pass nothing -> slirp). On slirp: the
+  bridge-setup step is skipped (if=false), SMOKE_NET_MODE='slirp' (conftest's own
+  default), and SMOKE_STUB_DNS_ADDR -> '127.0.0.1' (the prior literal). Nothing else
+  changes.
+
+VERIFICATION
+  - actionlint .github/workflows/{smoke-single,ui-tests,smoke}.yml -> exit 0 (clean;
+    actionlint does full YAML + workflow-schema + expression + run-block shellcheck).
+  - Slirp no-op reasoned above (gated step + ternary -> prior literal).
+  - NO runnable red->green unit test exists for CI-workflow wiring (it is not behaviour
+    executable off GitHub Actions). Per CLAUDE.md ADR-acceptance, this is a DOCUMENTED
+    out-of-CI item: the live validation of bridge mode end-to-end IS P5's A/B dispatch.
+
+P5 / LIVE ITEMS STILL OPEN (cannot be validated off a live runner; maintainer/P5)
+  - tap ownership vs non-root QEMU: bridge-net.sh creates root-owned taps; whether QEMU
+    (launched by boot_vm.sh as the runner user) can open them, or needs a `user <runner>`
+    on `ip tuntap add` (or QEMU-as-root), is a LIVE detail P5 must confirm/finalize. The
+    ADR §7 de-risk proved a bridge boot works on the GH runner, but the exact tap-user
+    wiring is not pinned here. If P5 finds it needs a tap user, add an optional
+    SMOKE_TAP_USER to bridge-net.sh + the CI step.
+  - dnsmasq actually serving DHCP + auto-announcing option 3/6 (§7.3) is runtime behaviour
+    the shellspec cannot assert (it stubs dnsmasq); P5's live boot is the proof.
+  - The A/B itself (slirp vs bridge timing on the CE+Plus fan-out) + the default flip
+    decision (§5.5) remain P5 / maintainer.
+
+NEXT
+  Landing: rebase the branch onto current origin/devel (it gained `54688477 adr: add
+  ADR-45 phase prompts` during the run), open the PR, run /pr-merge-flow. ADR.md §6 phase
+  statuses (P2/P3/P4 -> done) are an ADR-TEXT change -> direct to devel, NOT in this PR.

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -488,14 +488,14 @@ jobs:
           set -eu
           sudo apt-get install -y dnsmasq
           # `ip`/`dnsmasq` need root; pass SMOKE_VM_MAC through sudo's env reset explicitly.
-          eval "$(sudo env SMOKE_VM_MAC="${SMOKE_VM_MAC:-}" sh scripts/bridge-net.sh up)"
-          {
-            echo "SMOKE_WAN_TAP=${SMOKE_WAN_TAP}"
-            echo "SMOKE_MGMT_TAP=${SMOKE_MGMT_TAP}"
-            echo "SMOKE_CLIENT_MGMT_TAP=${SMOKE_CLIENT_MGMT_TAP}"
-            echo "SMOKE_PFSENSE_MGMT_IP=${SMOKE_PFSENSE_MGMT_IP}"
-            echo "SMOKE_CLIENT_MGMT_IP=${SMOKE_CLIENT_MGMT_IP}"
-          } >> "$GITHUB_ENV"
+          # Strict allowlist parse — never eval bridge-net.sh output (the values are env-derived).
+          _bridge_env="$(sudo env SMOKE_VM_MAC="${SMOKE_VM_MAC:-}" sh scripts/bridge-net.sh up)"
+          printf '%s\n' "$_bridge_env" | while IFS='=' read -r _k _v; do
+            case "$_k" in
+              SMOKE_WAN_TAP|SMOKE_MGMT_TAP|SMOKE_CLIENT_MGMT_TAP|SMOKE_PFSENSE_MGMT_IP|SMOKE_CLIENT_MGMT_IP)
+                printf '%s=%s\n' "$_k" "$_v" >> "$GITHUB_ENV" ;;
+            esac
+          done
 
       # HERMETICITY (ADR §2/§4): the egress block is done INSIDE pytest, by the
       # matrix's `deployed_vm` fixture, after deploy() and before the per-case

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -88,6 +88,14 @@ on:
         description: "FreeBSD-ports branch (blank = build-pkg-linux default pfblockerng/use-github)."
         required: false
         default: ""
+      net_mode:
+        description: "Smoke VM network backend (ADR-50): slirp (default, QEMU user-net) | bridge (tap+dnsmasq on host bridges; runs the per-box bridge-net.sh setup first)."
+        required: false
+        type: choice
+        options:
+          - slirp
+          - bridge
+        default: "slirp"
   workflow_call:
     inputs:
       image_ref:
@@ -150,6 +158,11 @@ on:
         required: false
         type: string
         default: ""
+      net_mode:
+        description: "Smoke VM network backend (ADR-50): slirp (default) | bridge. The fan-out (smoke.yml) forwards its own net_mode input here."
+        required: false
+        type: string
+        default: "slirp"
   # Nightly gated run — enable once the wall-time is confirmed within budget.
   # schedule:
   #   - cron: "0 5 * * *"
@@ -458,6 +471,32 @@ jobs:
           # --civm-mac passes the civm data-NIC MAC for masking + redaction (deny-by-default: empty).
           sh scripts/resolve-legs.sh vm-identity --civm-mac "${CLIENT_MAC:-}"
 
+      # ADR-50 P2/P4 — bridge networking (opt-in; default slirp skips this step entirely).
+      # GH-hosted runners ship /dev/net/tun natively, so no host change is needed (the §7.1
+      # LXC tun passthrough is a local-box-only prerequisite). bridge-net.sh creates
+      # br-wan/br-mgmt + per-lane taps + a DHCP-only dnsmasq with static MGMT leases, then
+      # emits the tap names + MGMT IPs we forward to $GITHUB_ENV so boot_vm.sh (bridge mode)
+      # and conftest pick them up. Runs AFTER "Resolve VM identity" so RESOLVED_VM_MAC (the
+      # Plus net1 MAC, secret-derived) is available; the pfSense MGMT static lease keys on it.
+      - name: Set up bridge networking (SMOKE_NET_MODE=bridge)
+        if: ${{ inputs.net_mode == 'bridge' }}
+        env:
+          # net1/MGMT MAC for the static lease: CE -> empty -> bridge-net.sh's CE default;
+          # Plus -> the secret-derived RESOLVED_VM_MAC list (bridge-net.sh reads line 2).
+          SMOKE_VM_MAC: ${{ env.RESOLVED_VM_MAC }}
+        run: |
+          set -eu
+          sudo apt-get install -y dnsmasq
+          # `ip`/`dnsmasq` need root; pass SMOKE_VM_MAC through sudo's env reset explicitly.
+          eval "$(sudo env SMOKE_VM_MAC="${SMOKE_VM_MAC:-}" sh scripts/bridge-net.sh up)"
+          {
+            echo "SMOKE_WAN_TAP=${SMOKE_WAN_TAP}"
+            echo "SMOKE_MGMT_TAP=${SMOKE_MGMT_TAP}"
+            echo "SMOKE_CLIENT_MGMT_TAP=${SMOKE_CLIENT_MGMT_TAP}"
+            echo "SMOKE_PFSENSE_MGMT_IP=${SMOKE_PFSENSE_MGMT_IP}"
+            echo "SMOKE_CLIENT_MGMT_IP=${SMOKE_CLIENT_MGMT_IP}"
+          } >> "$GITHUB_ENV"
+
       # HERMETICITY (ADR §2/§4): the egress block is done INSIDE pytest, by the
       # matrix's `deployed_vm` fixture, after deploy() and before the per-case
       # assertions (helpers.block_egress, gated by SMOKE_BLOCK_EGRESS=1 below;
@@ -526,10 +565,16 @@ jobs:
           SMOKE_DNSBL_VIP4: ${{ secrets.SMOKE_DNSBL_VIP4 || vars.SMOKE_DNSBL_VIP4 }}
           SMOKE_CONTROL_NAME: ${{ secrets.SMOKE_CONTROL_NAME || vars.SMOKE_CONTROL_NAME }}
           SMOKE_CONTROL_IP: ${{ secrets.SMOKE_CONTROL_IP || vars.SMOKE_CONTROL_IP }}
+          # Network backend (ADR-50): slirp (default) | bridge. conftest + boot_vm.sh
+          # branch on this; boot_vm.sh also reads the SMOKE_*_TAP vars the bridge-setup
+          # step wrote to $GITHUB_ENV.
+          SMOKE_NET_MODE: ${{ inputs.net_mode }}
           # System-DNS upstream wiring: the mock binds the runner loopback :53, and
-          # pfSense forwards to the SLIRP host alias 10.0.2.2 which libslirp NATs
+          # pfSense forwards to the SLIRP host alias 192.168.89.2 which libslirp NATs
           # (port-preserving) straight to that mock — no /etc/resolv.conf involvement.
-          SMOKE_STUB_DNS_ADDR: "127.0.0.1"
+          # bridge mode has no NAT alias: the mock binds the WAN BRIDGE IP 192.168.89.2:53
+          # directly (the guest reaches it on the bridge), so the bind address flips.
+          SMOKE_STUB_DNS_ADDR: ${{ inputs.net_mode == 'bridge' && '192.168.89.2' || '127.0.0.1' }}
           SMOKE_STUB_DNS_PORT: "53"
         run: |
           set -eu

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -58,6 +58,14 @@ on:
         description: "pytest -k selector — OVERRIDES the impacted auto-derivation. Blank in impacted scope = the tests changed vs origin/devel (whole marker if none). e.g. 'test_dns_redirect' or 'redirect and not browser'."
         required: false
         default: ""
+      net_mode:
+        description: "Smoke VM network backend (ADR-50): slirp (default) | bridge. Forwarded to each leg's smoke-single.yml; used for the P5 A/B fan-out."
+        required: false
+        type: choice
+        default: "slirp"
+        options:
+          - slirp
+          - bridge
 
   # Called by other workflows. Defaults to the FULL suite so existing callers
   # that pass nothing are unchanged (workflow_call -> scope=full by default).
@@ -83,6 +91,11 @@ on:
         required: false
         type: string
         default: ""
+      net_mode:
+        description: "Smoke VM network backend (ADR-50): slirp (default) | bridge. Forwarded to each leg's smoke-single.yml."
+        required: false
+        type: string
+        default: "slirp"
 
   # Daily nightly run — runs the full CE suite every night.
   schedule:
@@ -216,6 +229,9 @@ jobs:
       # input, else the impacted auto-derivation, else blank = whole marker).
       pytest_marker: ${{ needs.prepare.outputs.pytest_marker || 'smoke' }}
       pytest_filter: ${{ needs.prepare.outputs.pytest_filter }}
+      # ADR-50: forward the network backend so the P5 A/B can run the whole fan-out
+      # under bridge mode. Defaults to slirp -> byte-identical to today.
+      net_mode: ${{ inputs.net_mode || 'slirp' }}
     secrets: inherit
 
   # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -396,14 +396,14 @@ jobs:
         run: |
           set -eu
           sudo apt-get install -y dnsmasq
-          eval "$(sudo env SMOKE_VM_MAC="${SMOKE_VM_MAC:-}" sh scripts/bridge-net.sh up)"
-          {
-            echo "SMOKE_WAN_TAP=${SMOKE_WAN_TAP}"
-            echo "SMOKE_MGMT_TAP=${SMOKE_MGMT_TAP}"
-            echo "SMOKE_CLIENT_MGMT_TAP=${SMOKE_CLIENT_MGMT_TAP}"
-            echo "SMOKE_PFSENSE_MGMT_IP=${SMOKE_PFSENSE_MGMT_IP}"
-            echo "SMOKE_CLIENT_MGMT_IP=${SMOKE_CLIENT_MGMT_IP}"
-          } >> "$GITHUB_ENV"
+          # Strict allowlist parse — never eval bridge-net.sh output (the values are env-derived).
+          _bridge_env="$(sudo env SMOKE_VM_MAC="${SMOKE_VM_MAC:-}" sh scripts/bridge-net.sh up)"
+          printf '%s\n' "$_bridge_env" | while IFS='=' read -r _k _v; do
+            case "$_k" in
+              SMOKE_WAN_TAP|SMOKE_MGMT_TAP|SMOKE_CLIENT_MGMT_TAP|SMOKE_PFSENSE_MGMT_IP|SMOKE_CLIENT_MGMT_IP)
+                printf '%s=%s\n' "$_k" "$_v" >> "$GITHUB_ENV" ;;
+            esac
+          done
 
       - name: Install oras
         uses: oras-project/setup-oras@v2

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -100,6 +100,11 @@ on:
         required: false
         type: string
         default: ""
+      net_mode:
+        description: "Smoke VM network backend (ADR-50): slirp (default) | bridge (tap+dnsmasq on host bridges)."
+        required: false
+        type: string
+        default: "slirp"
   workflow_dispatch:
     inputs:
       image_ref:
@@ -140,6 +145,14 @@ on:
         description: "FreeBSD-ports branch (blank = build-pkg-linux default pfblockerng/use-github)."
         required: false
         default: ""
+      net_mode:
+        description: "Smoke VM network backend (ADR-50): slirp (default, QEMU user-net) | bridge (tap+dnsmasq on host bridges; runs the per-box bridge-net.sh setup first)."
+        required: false
+        type: choice
+        options:
+          - slirp
+          - bridge
+        default: "slirp"
   # Daily Tier-B run (functional + browser). Non-PR-blocking by construction.
   # The `prepare` job guards it to SKIP when there were no commits in the last
   # day (mirrors a smoke-style nightly guard) so an idle repo does not boot a VM.
@@ -371,6 +384,27 @@ jobs:
           # UI job has no civm data-NIC MAC — no --civm-mac flag (deny-by-default: empty).
           sh scripts/resolve-legs.sh vm-identity
 
+      # ADR-50 P2/P4 — bridge networking (opt-in; default slirp skips this step entirely).
+      # Same per-box setup as smoke-single.yml: br-wan/br-mgmt + per-lane taps + a DHCP-only
+      # dnsmasq with static MGMT leases; emits the tap names + MGMT IPs to $GITHUB_ENV for
+      # boot_vm.sh (bridge mode) + conftest. GH runners have /dev/net/tun natively. Runs after
+      # "Resolve VM identity" so RESOLVED_VM_MAC (Plus net1 MAC) keys the pfSense MGMT lease.
+      - name: Set up bridge networking (SMOKE_NET_MODE=bridge)
+        if: ${{ inputs.net_mode == 'bridge' }}
+        env:
+          SMOKE_VM_MAC: ${{ env.RESOLVED_VM_MAC }}
+        run: |
+          set -eu
+          sudo apt-get install -y dnsmasq
+          eval "$(sudo env SMOKE_VM_MAC="${SMOKE_VM_MAC:-}" sh scripts/bridge-net.sh up)"
+          {
+            echo "SMOKE_WAN_TAP=${SMOKE_WAN_TAP}"
+            echo "SMOKE_MGMT_TAP=${SMOKE_MGMT_TAP}"
+            echo "SMOKE_CLIENT_MGMT_TAP=${SMOKE_CLIENT_MGMT_TAP}"
+            echo "SMOKE_PFSENSE_MGMT_IP=${SMOKE_PFSENSE_MGMT_IP}"
+            echo "SMOKE_CLIENT_MGMT_IP=${SMOKE_CLIENT_MGMT_IP}"
+          } >> "$GITHUB_ENV"
+
       - name: Install oras
         uses: oras-project/setup-oras@v2
 
@@ -499,6 +533,11 @@ jobs:
           # auto-derivation (UI tests changed vs origin/devel), else blank = whole tier.
           PYTEST_FILTER: ${{ needs.prepare.outputs.pytest_filter }}
           MARKER: ${{ steps.tier.outputs.marker }}
+          # Network backend (ADR-50): slirp (default) | bridge. conftest + boot_vm.sh
+          # branch on it; the SMOKE_*_TAP vars come from the bridge-setup step's $GITHUB_ENV.
+          # No SMOKE_STUB_DNS_ADDR override here — conftest defaults it to the WAN bridge IP
+          # (192.168.89.2) in bridge mode, loopback in slirp.
+          SMOKE_NET_MODE: ${{ inputs.net_mode }}
         run: |
           set -eu
           # Delegate to the canonical argv emitter (ADR-47 P4 — drift-kill).

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -107,6 +107,54 @@ lie**; the image is the Debian client, not pfSense.
 `SMOKE_CLIENT_IMAGE_DIR` must hold **exactly one** `*.qcow2`, so keep it in its own directory
 separate from `SMOKE_IMAGE_DIR`.
 
+## Bridge networking (ADR-50, opt-in)
+
+`SMOKE_NET_MODE=bridge` replaces QEMU SLIRP with tap devices on host Linux bridges for lower
+SSH round-trip latency. **Default is `slirp`** — nothing changes unless you opt in.
+
+### One-time box prerequisites
+
+1. **Install dnsmasq** on each LXC box (it is not installed by default; add it to the box
+   image / LXC template):
+
+   ```sh
+   apt-get install -y dnsmasq
+   ```
+
+   This is a **host** dependency (the bridge DHCP daemon), not a pfSense guest dep — do **not**
+   add it to `scripts/misc/install_deps_CE_2.8.sh`.
+
+2. **LXC `/dev/net/tun` passthrough** (Proxmox host, per container `.conf`, then restart).
+   SLIRP never needed `/dev/net/tun`; LXC's default cgroup policy denies it. Run on the
+   Proxmox host:
+
+   ```text
+   lxc.cgroup2.devices.allow: c 10:200 rwm
+   lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file 0 0
+   ```
+
+   GitHub-hosted runners are VMs with `/dev/net/tun` present — no change needed there.
+
+### Running in bridge mode
+
+```sh
+# Bridge mode: creates br-wan/br-mgmt, taps, and dnsmasq before the first leg.
+scripts/local-smoke.sh --net-mode bridge
+
+# Combined with a filter:
+scripts/local-smoke.sh --net-mode bridge --filter "test_dns_redirect"
+```
+
+`smoke-on-box.sh` calls `scripts/bridge-net.sh up` (ADR-50 P2) which creates the bridges,
+taps, and starts dnsmasq; `bridge-net.sh down` runs as part of each `up` for idempotent
+cleanup of prior state. The tap names (`SMOKE_WAN_TAP`, `SMOKE_MGMT_TAP`,
+`SMOKE_CLIENT_MGMT_TAP`) and the MGMT IPs (`SMOKE_PFSENSE_MGMT_IP=192.168.43.15`,
+`SMOKE_CLIENT_MGMT_IP=192.168.43.16`) are exported into the environment inherited by pytest →
+`boot_vm.sh`.
+
+**Live correctness** (actual network bring-up, DHCP, SSH reachability) is validated by ADR-50
+P5's A/B run — this phase ships the script and its command-contract shellspec, not a live boot.
+
 ## Building the `.pkg` off-FreeBSD (CI reference)
 
 The portable Linux builder reproduces `make package` for this `NO_BUILD` port. For CE 2.8

--- a/scripts/bridge-net.sh
+++ b/scripts/bridge-net.sh
@@ -80,7 +80,9 @@ _do_down() {
     # Stop dnsmasq by PID file; silent when absent or already gone.
     if [ -f "${PIDFILE}" ]; then
         _pid="$(cat "${PIDFILE}" 2>/dev/null)" || _pid=""
-        [ -n "${_pid}" ] && kill "${_pid}" 2>/dev/null || true
+        if [ -n "${_pid}" ]; then
+            kill "${_pid}" 2>/dev/null || true
+        fi
         rm -f "${PIDFILE}"
     fi
     # Delete taps first (they are attached to bridges), then the bridges.

--- a/scripts/bridge-net.sh
+++ b/scripts/bridge-net.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+#shellcheck shell=sh
+# bridge-net.sh — per-box bridge + dnsmasq setup for SMOKE_NET_MODE=bridge (ADR-50 P2).
+#
+# Runs on the Linux host (LXC box or CI runner), once per box, before any test leg.
+# Creates two host bridges (br-wan 192.168.89.2/24 + br-mgmt 192.168.43.2/24),
+# per-lane tap devices attached to them, and a dnsmasq DHCP-only daemon with static
+# MGMT leases so the pfSense + civm MGMT NICs get deterministic IPs.
+#
+# Subcommands:
+#   up    create bridges, taps, start dnsmasq; emit eval-able KEY=value on stdout.
+#   down  stop dnsmasq, delete taps + bridges (safe when nothing exists).
+#
+# Env read:
+#   SMOKE_LANE              lane index (default 0); tap names are tap-{wan,mgmt,cli}<lane>
+#   SMOKE_PFSENSE_MGMT_IP   pfSense MGMT static-lease IP (default 192.168.43.15) — matches P3
+#   SMOKE_CLIENT_MGMT_IP    civm MGMT static-lease IP (default 192.168.43.16) — matches P3
+#   SMOKE_VM_MAC            newline-separated NIC MACs; line 2 = net1/MGMT MAC (mirrors
+#                           boot_vm.sh's nth_mac 1 = sed -n '2p'); default CE source-VM list
+#   SMOKE_CLIENT_MGMT_MAC   civm MGMT MAC (default BC:24:11:29:A4:1B)
+#
+# Overridable binaries (shellspec injects stubs via these):
+#   SMOKE_IP_BIN       ip command (default: ip)
+#   SMOKE_DNSMASQ_BIN  dnsmasq command (default: dnsmasq)
+#
+# Eval-able output of 'up' (progress + diagnostics go to stderr):
+#   SMOKE_WAN_TAP=tap-wan<lane>
+#   SMOKE_MGMT_TAP=tap-mgmt<lane>
+#   SMOKE_CLIENT_MGMT_TAP=tap-cli<lane>
+#   SMOKE_PFSENSE_MGMT_IP=192.168.43.15
+#   SMOKE_CLIENT_MGMT_IP=192.168.43.16
+#
+# ponytail: single-bridge-pair-per-box ceiling — bridges (br-wan / br-mgmt) and dnsmasq
+# are singletons; only tap NAMES are per-lane. Multi-lane would need per-lane subnets;
+# deferred until P5's A/B justifies bridge mode at all.
+
+set -eu
+
+LANE="${SMOKE_LANE:-0}"
+
+# ponytail: ip + dnsmasq are privileged/add-on binaries — keep as overridable vars so
+# the shellspec can inject stubs without PATH manipulation. Do NOT hardcode absolute paths.
+IP_BIN="${SMOKE_IP_BIN:-ip}"
+DNSMASQ_BIN="${SMOKE_DNSMASQ_BIN:-dnsmasq}"
+
+# Bridge names + addresses (singletons — not per-lane; see ceiling note above).
+WAN_BRIDGE="br-wan"
+WAN_ADDR="192.168.89.2/24"
+MGMT_BRIDGE="br-mgmt"
+MGMT_ADDR="192.168.43.2/24"
+
+# DHCP ranges (dnsmasq auto-associates each range with the interface by subnet match).
+WAN_RANGE="192.168.89.50,192.168.89.150,255.255.255.0"
+MGMT_RANGE="192.168.43.50,192.168.43.150,255.255.255.0"
+
+# Static-lease IPs — MUST match P3 conftest defaults (PFSENSE_MGMT_IP / CLIENT_MGMT_IP).
+PFSENSE_MGMT_IP="${SMOKE_PFSENSE_MGMT_IP:-192.168.43.15}"
+CLIENT_MGMT_IP="${SMOKE_CLIENT_MGMT_IP:-192.168.43.16}"
+
+# Per-lane tap names (Linux IFNAMSIZ=15; tap-wan0..tap-cli9 are 9 chars — all fit).
+WAN_TAP="tap-wan${LANE}"
+MGMT_TAP="tap-mgmt${LANE}"
+CLI_TAP="tap-cli${LANE}"
+
+# Lane-scoped dnsmasq PID file so 'down' can stop the right instance.
+PIDFILE="/tmp/pfb-dnsmasq-${LANE}.pid"
+
+# MGMT MACs for dnsmasq static leases.
+# pfSense net1/MGMT MAC: line 2 of SMOKE_VM_MAC (mirrors boot_vm.sh's nth_mac 1
+# = printf '%s\n' "$VM_MAC" | sed -n '2p'). Default = CE source-VM net1 MAC.
+# civm MGMT MAC: SMOKE_CLIENT_MGMT_MAC, mirrors boot_vm.sh's CLIENT_MGMT_MAC.
+if [ -n "${SMOKE_VM_MAC:-}" ]; then
+    _pfsense_mgmt_mac="$(printf '%s\n' "${SMOKE_VM_MAC}" | sed -n '2p')"
+else
+    _pfsense_mgmt_mac="BC:24:11:80:42:35"
+fi
+_client_mgmt_mac="${SMOKE_CLIENT_MGMT_MAC:-BC:24:11:29:A4:1B}"
+
+_do_down() {
+    # Stop dnsmasq by PID file; silent when absent or already gone.
+    if [ -f "${PIDFILE}" ]; then
+        _pid="$(cat "${PIDFILE}" 2>/dev/null)" || _pid=""
+        [ -n "${_pid}" ] && kill "${_pid}" 2>/dev/null || true
+        rm -f "${PIDFILE}"
+    fi
+    # Delete taps first (they are attached to bridges), then the bridges.
+    # Each deletion is guarded: a missing device is not an error.
+    "${IP_BIN}" link del "${WAN_TAP}"    2>/dev/null || true
+    "${IP_BIN}" link del "${MGMT_TAP}"   2>/dev/null || true
+    "${IP_BIN}" link del "${CLI_TAP}"    2>/dev/null || true
+    "${IP_BIN}" link del "${WAN_BRIDGE}" 2>/dev/null || true
+    "${IP_BIN}" link del "${MGMT_BRIDGE}" 2>/dev/null || true
+}
+
+_do_up() {
+    # ponytail: idempotent recreate IS the teardown; the select-box lease trap is
+    # intentionally untouched (CI runners are ephemeral; local boxes have one lane).
+    printf 'bridge-net: teardown any stale config (lane=%s)\n' "${LANE}" >&2
+    _do_down
+
+    printf 'bridge-net: creating bridges and taps (lane=%s)\n' "${LANE}" >&2
+
+    # WAN bridge.
+    "${IP_BIN}" link add "${WAN_BRIDGE}" type bridge
+    "${IP_BIN}" addr add "${WAN_ADDR}" dev "${WAN_BRIDGE}"
+    "${IP_BIN}" link set "${WAN_BRIDGE}" up
+
+    # MGMT bridge (separate subnet from WAN — two NICs on one subnet break pfSense
+    # routing/anti-spoof; proven in the ADR §7.2 derisk).
+    "${IP_BIN}" link add "${MGMT_BRIDGE}" type bridge
+    "${IP_BIN}" addr add "${MGMT_ADDR}" dev "${MGMT_BRIDGE}"
+    "${IP_BIN}" link set "${MGMT_BRIDGE}" up
+
+    # WAN tap → br-wan.
+    "${IP_BIN}" tuntap add "${WAN_TAP}" mode tap
+    "${IP_BIN}" link set "${WAN_TAP}" master "${WAN_BRIDGE}"
+    "${IP_BIN}" link set "${WAN_TAP}" up
+
+    # MGMT tap → br-mgmt (pfSense net1).
+    "${IP_BIN}" tuntap add "${MGMT_TAP}" mode tap
+    "${IP_BIN}" link set "${MGMT_TAP}" master "${MGMT_BRIDGE}"
+    "${IP_BIN}" link set "${MGMT_TAP}" up
+
+    # Client tap → br-mgmt (civm MGMT NIC; same subnet, separate MAC/static-lease).
+    "${IP_BIN}" tuntap add "${CLI_TAP}" mode tap
+    "${IP_BIN}" link set "${CLI_TAP}" master "${MGMT_BRIDGE}"
+    "${IP_BIN}" link set "${CLI_TAP}" up
+
+    printf 'bridge-net: starting dnsmasq DHCP on %s %s (lane=%s)\n' \
+        "${WAN_BRIDGE}" "${MGMT_BRIDGE}" "${LANE}" >&2
+
+    # dnsmasq: DHCP-only (port=0), bound to the two bridges.
+    # §7.3: dnsmasq auto-announces option 3 (gateway) + option 6 (DNS) = its own
+    # per-subnet address, so the WAN guest gets DNS→192.168.89.2 (the stub DNS)
+    # and gw→192.168.89.2. Rely on that — do NOT fight it with explicit options.
+    "${DNSMASQ_BIN}" \
+        --port=0 \
+        --bind-interfaces \
+        --except-interface=lo \
+        --interface="${WAN_BRIDGE}" \
+        --interface="${MGMT_BRIDGE}" \
+        --dhcp-range="${WAN_RANGE}" \
+        --dhcp-range="${MGMT_RANGE}" \
+        --dhcp-host="${_pfsense_mgmt_mac},${PFSENSE_MGMT_IP}" \
+        --dhcp-host="${_client_mgmt_mac},${CLIENT_MGMT_IP}" \
+        --pid-file="${PIDFILE}"
+
+    printf 'bridge-net: up (lane=%s); emitting eval-able env\n' "${LANE}" >&2
+
+    # Emit eval-able KEY=value on stdout; caller: eval "$(sh scripts/bridge-net.sh up)"
+    printf 'SMOKE_WAN_TAP=%s\n'         "${WAN_TAP}"
+    printf 'SMOKE_MGMT_TAP=%s\n'        "${MGMT_TAP}"
+    printf 'SMOKE_CLIENT_MGMT_TAP=%s\n' "${CLI_TAP}"
+    printf 'SMOKE_PFSENSE_MGMT_IP=%s\n' "${PFSENSE_MGMT_IP}"
+    printf 'SMOKE_CLIENT_MGMT_IP=%s\n'  "${CLIENT_MGMT_IP}"
+}
+
+case "${1:-}" in
+    up)   _do_up ;;
+    down) _do_down ;;
+    *)
+        printf 'Usage: %s up|down\n' "$0" >&2
+        printf '  up    create bridges, taps, dnsmasq; emit eval-able env vars on stdout\n' >&2
+        printf '  down  stop dnsmasq, delete taps and bridges\n' >&2
+        exit 2
+        ;;
+esac

--- a/scripts/bridge-net.sh
+++ b/scripts/bridge-net.sh
@@ -8,7 +8,7 @@
 # MGMT leases so the pfSense + civm MGMT NICs get deterministic IPs.
 #
 # Subcommands:
-#   up    create bridges, taps, start dnsmasq; emit eval-able KEY=value on stdout.
+#   up    create bridges, taps, start dnsmasq; emit KEY=value on stdout.
 #   down  stop dnsmasq, delete taps + bridges (safe when nothing exists).
 #
 # Env read:
@@ -20,10 +20,13 @@
 #   SMOKE_CLIENT_MGMT_MAC   civm MGMT MAC (default BC:24:11:29:A4:1B)
 #
 # Overridable binaries (shellspec injects stubs via these):
-#   SMOKE_IP_BIN       ip command (default: ip)
-#   SMOKE_DNSMASQ_BIN  dnsmasq command (default: dnsmasq)
+#   SMOKE_IP_BIN       ip command (default: /usr/sbin/ip, then command -v fallback)
+#   SMOKE_DNSMASQ_BIN  dnsmasq command (default: /usr/sbin/dnsmasq, then command -v fallback)
 #
-# Eval-able output of 'up' (progress + diagnostics go to stderr):
+# Overridable runtime dir (shellspec points at a tmp dir via this):
+#   SMOKE_BRIDGE_RUN_DIR  runtime dir for PID file (default: /run/pfb-smoke)
+#
+# Output of 'up' (progress + diagnostics go to stderr):
 #   SMOKE_WAN_TAP=tap-wan<lane>
 #   SMOKE_MGMT_TAP=tap-mgmt<lane>
 #   SMOKE_CLIENT_MGMT_TAP=tap-cli<lane>
@@ -38,10 +41,21 @@ set -eu
 
 LANE="${SMOKE_LANE:-0}"
 
-# ponytail: ip + dnsmasq are privileged/add-on binaries — keep as overridable vars so
-# the shellspec can inject stubs without PATH manipulation. Do NOT hardcode absolute paths.
-IP_BIN="${SMOKE_IP_BIN:-ip}"
-DNSMASQ_BIN="${SMOKE_DNSMASQ_BIN:-dnsmasq}"
+# ponytail: absolute default per CLAUDE.md privileged-binary rule; command -v fallback
+# mirrors boot_vm.sh so the path is robust on varied installs; SMOKE_*_BIN stub override
+# is honoured because an executable stub path is taken as-is (skips the fallback).
+IP_BIN="${SMOKE_IP_BIN:-/usr/sbin/ip}"
+DNSMASQ_BIN="${SMOKE_DNSMASQ_BIN:-/usr/sbin/dnsmasq}"
+if [ ! -x "$IP_BIN" ]; then IP_BIN="$(command -v ip || true)"; fi
+if [ ! -x "$DNSMASQ_BIN" ]; then DNSMASQ_BIN="$(command -v dnsmasq || true)"; fi
+if [ -z "$IP_BIN" ] || [ ! -x "$IP_BIN" ]; then
+    printf 'bridge-net: ip binary not found (set SMOKE_IP_BIN or install iproute2)\n' >&2
+    exit 1
+fi
+if [ -z "$DNSMASQ_BIN" ] || [ ! -x "$DNSMASQ_BIN" ]; then
+    printf 'bridge-net: dnsmasq binary not found (set SMOKE_DNSMASQ_BIN or install dnsmasq)\n' >&2
+    exit 1
+fi
 
 # Bridge names + addresses (singletons — not per-lane; see ceiling note above).
 WAN_BRIDGE="br-wan"
@@ -63,7 +77,9 @@ MGMT_TAP="tap-mgmt${LANE}"
 CLI_TAP="tap-cli${LANE}"
 
 # Lane-scoped dnsmasq PID file so 'down' can stop the right instance.
-PIDFILE="/tmp/pfb-dnsmasq-${LANE}.pid"
+# Root-owned runtime dir (not /tmp) prevents symlink/pre-create attacks on the PID file.
+RUNDIR="${SMOKE_BRIDGE_RUN_DIR:-/run/pfb-smoke}"
+PIDFILE="${RUNDIR}/dnsmasq-${LANE}.pid"
 
 # MGMT MACs for dnsmasq static leases.
 # pfSense net1/MGMT MAC: line 2 of SMOKE_VM_MAC (mirrors boot_vm.sh's nth_mac 1
@@ -75,6 +91,33 @@ else
     _pfsense_mgmt_mac="BC:24:11:80:42:35"
 fi
 _client_mgmt_mac="${SMOKE_CLIENT_MGMT_MAC:-BC:24:11:29:A4:1B}"
+
+# Validate env-derived inputs — values flow into shell args; reject metacharacters fail-closed.
+case "$LANE" in
+    ''|*[!0-9]*)
+        printf 'bridge-net: SMOKE_LANE must be a non-negative integer (got: %s)\n' "${LANE}" >&2
+        exit 2 ;;
+esac
+case "$PFSENSE_MGMT_IP" in
+    *[!0-9.]*)
+        printf 'bridge-net: SMOKE_PFSENSE_MGMT_IP contains invalid characters (got: %s)\n' "${PFSENSE_MGMT_IP}" >&2
+        exit 2 ;;
+esac
+case "$CLIENT_MGMT_IP" in
+    *[!0-9.]*)
+        printf 'bridge-net: SMOKE_CLIENT_MGMT_IP contains invalid characters (got: %s)\n' "${CLIENT_MGMT_IP}" >&2
+        exit 2 ;;
+esac
+case "$_pfsense_mgmt_mac" in
+    ''|*[!0-9A-Fa-f:]*)
+        printf 'bridge-net: pfSense MGMT MAC contains invalid characters (got: %s)\n' "${_pfsense_mgmt_mac}" >&2
+        exit 2 ;;
+esac
+case "$_client_mgmt_mac" in
+    ''|*[!0-9A-Fa-f:]*)
+        printf 'bridge-net: client MGMT MAC contains invalid characters (got: %s)\n' "${_client_mgmt_mac}" >&2
+        exit 2 ;;
+esac
 
 _do_down() {
     # Stop dnsmasq by PID file; silent when absent or already gone.
@@ -99,6 +142,9 @@ _do_up() {
     # intentionally untouched (CI runners are ephemeral; local boxes have one lane).
     printf 'bridge-net: teardown any stale config (lane=%s)\n' "${LANE}" >&2
     _do_down
+    # Create the runtime dir (root-owned 700) before starting dnsmasq.
+    mkdir -p "${RUNDIR}"
+    chmod 700 "${RUNDIR}"
 
     printf 'bridge-net: creating bridges and taps (lane=%s)\n' "${LANE}" >&2
 
@@ -147,9 +193,9 @@ _do_up() {
         --dhcp-host="${_client_mgmt_mac},${CLIENT_MGMT_IP}" \
         --pid-file="${PIDFILE}"
 
-    printf 'bridge-net: up (lane=%s); emitting eval-able env\n' "${LANE}" >&2
+    printf 'bridge-net: up (lane=%s); emitting env\n' "${LANE}" >&2
 
-    # Emit eval-able KEY=value on stdout; caller: eval "$(sh scripts/bridge-net.sh up)"
+    # Emit KEY=value on stdout; caller parses with a strict allowlist (no eval).
     printf 'SMOKE_WAN_TAP=%s\n'         "${WAN_TAP}"
     printf 'SMOKE_MGMT_TAP=%s\n'        "${MGMT_TAP}"
     printf 'SMOKE_CLIENT_MGMT_TAP=%s\n' "${CLI_TAP}"

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -61,6 +61,7 @@ _ABI="FreeBSD:15:amd64"
 _MARKER="smoke"
 _FILTER=""
 _NO_TWO_VM=0
+_NET_MODE="slirp"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -68,12 +69,17 @@ while [ "$#" -gt 0 ]; do
         --abi)      shift; _ABI="$1";    shift ;;
         --marker|-m) shift; _MARKER="$1"; shift ;;
         --filter)   shift; _FILTER="$1";      shift ;;
-        --no-two-vm) _NO_TWO_VM=1;       shift ;;
+        --no-two-vm) _NO_TWO_VM=1;        shift ;;
+        --net-mode)  shift; _NET_MODE="$1"; shift ;;
         --) shift; break ;;
         -*) printf 'local-smoke: unknown flag: %s\n' "$1" >&2; exit 2 ;;
         *)  break ;;  # extra positionals not supported in new model
     esac
 done
+case "$_NET_MODE" in
+    slirp|bridge) ;;
+    *) printf 'local-smoke: --net-mode must be slirp or bridge\n' >&2; exit 2 ;;
+esac
 if [ "$#" -gt 0 ]; then
     printf 'local-smoke: unexpected positional args (use --marker/--filter): %s\n' "$*" >&2
     exit 2
@@ -105,7 +111,8 @@ _ABI_Q="$(_sq "$_ABI")"
 _MARKER_Q="$(_sq "$_MARKER")"
 
 # Build the smoke-on-box.sh flags string (structured, no word-split risk after encoding).
-_ob_flags="--ref '$_REF_Q' --abi '$_ABI_Q' --marker '$_MARKER_Q'"
+_NET_MODE_Q="$(_sq "$_NET_MODE")"
+_ob_flags="--ref '$_REF_Q' --abi '$_ABI_Q' --marker '$_MARKER_Q' --net-mode '$_NET_MODE_Q'"
 if [ -n "$_FILTER" ]; then
     _ob_flags="$_ob_flags --filter '$(_sq "$_FILTER")'"
 fi

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -217,9 +217,16 @@ pkill -9 -f qemu-system-x86_64 2>/dev/null || true
 # SMOKE_PFSENSE_MGMT_IP / SMOKE_CLIENT_MGMT_IP — consumed by boot_vm.sh via env
 # inheritance through exec run-smoke.sh → pytest → boot_vm.sh.
 if [ "$_NET_MODE" = bridge ]; then
-    eval "$(sh "$REPO_ROOT/scripts/bridge-net.sh" up)"
-    export SMOKE_WAN_TAP SMOKE_MGMT_TAP SMOKE_CLIENT_MGMT_TAP \
-           SMOKE_PFSENSE_MGMT_IP SMOKE_CLIENT_MGMT_IP
+    _bridge_env="$(sh "$REPO_ROOT/scripts/bridge-net.sh" up)"
+    # Strict allowlist parse — never eval bridge-net.sh output (the values are env-derived).
+    while IFS='=' read -r _k _v; do
+        case "$_k" in
+            SMOKE_WAN_TAP|SMOKE_MGMT_TAP|SMOKE_CLIENT_MGMT_TAP|SMOKE_PFSENSE_MGMT_IP|SMOKE_CLIENT_MGMT_IP)
+                export "${_k}=${_v}" ;;
+        esac
+    done <<BRIDGE_ENV
+${_bridge_env}
+BRIDGE_ENV
     SMOKE_NET_MODE=bridge
     export SMOKE_NET_MODE
 fi

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -40,6 +40,7 @@ _ABI="FreeBSD:15:amd64"
 _MARKER="smoke"
 _FILTER=""
 _NO_TWO_VM=0
+_NET_MODE="slirp"
 
 REPO_ROOT="/root/pfBlockerNG"
 
@@ -63,9 +64,15 @@ while [ "$#" -gt 0 ]; do
         --marker)   shift; _MARKER="$1"; shift ;;
         --filter)   shift; _FILTER="$1";      shift ;;
         --no-two-vm) _NO_TWO_VM=1;       shift ;;
+        --net-mode)  shift; _NET_MODE="$1"; shift ;;
         *) printf 'smoke-on-box: unknown argument: %s\n' "$1" >&2; exit 1 ;;
     esac
 done
+case "$_NET_MODE" in
+    slirp|bridge) ;;
+    *) printf 'smoke-on-box: --net-mode must be slirp or bridge (got: %s)\n' \
+           "$_NET_MODE" >&2; exit 1 ;;
+esac
 
 # ── Step 1: ref-checkout + re-exec ────────────────────────────────────────── #
 # The bootstrap (run by select-box.sh) may be at any ref; we git checkout the
@@ -91,7 +98,7 @@ if [ "${PFB_ONBOX_REEXEC:-}" != "1" ]; then
 
     # Re-exec the now-checked-out version with properly quoted args.
     # Build via set -- so each arg is a distinct word (no word-split on _FILTER spaces).
-    set -- --ref "$_REF" --abi "$_ABI" --marker "$_MARKER"
+    set -- --ref "$_REF" --abi "$_ABI" --marker "$_MARKER" --net-mode "$_NET_MODE"
     [ -n "$_FILTER" ] && set -- "$@" --filter "$_FILTER"
     [ "$_NO_TWO_VM" -eq 1 ] && set -- "$@" --no-two-vm
     PFB_ONBOX_REEXEC=1 exec sh "$REPO_ROOT/scripts/smoke-on-box.sh" "$@"
@@ -204,6 +211,18 @@ export SMOKE_STUB_DNS_PORT="${SMOKE_STUB_DNS_PORT:-53}"
 # Kill any stale qemu from a previous run on this box (lease guarantees we are
 # the only writer; pkill -9 never touches another box's VMs).
 pkill -9 -f qemu-system-x86_64 2>/dev/null || true
+
+# Bridge-mode host setup (ADR-50 P2): create host bridges, taps, and start dnsmasq.
+# Eval output is SMOKE_WAN_TAP / SMOKE_MGMT_TAP / SMOKE_CLIENT_MGMT_TAP /
+# SMOKE_PFSENSE_MGMT_IP / SMOKE_CLIENT_MGMT_IP — consumed by boot_vm.sh via env
+# inheritance through exec run-smoke.sh → pytest → boot_vm.sh.
+if [ "$_NET_MODE" = bridge ]; then
+    eval "$(sh "$REPO_ROOT/scripts/bridge-net.sh" up)"
+    export SMOKE_WAN_TAP SMOKE_MGMT_TAP SMOKE_CLIENT_MGMT_TAP \
+           SMOKE_PFSENSE_MGMT_IP SMOKE_CLIENT_MGMT_IP
+    SMOKE_NET_MODE=bridge
+    export SMOKE_NET_MODE
+fi
 
 # ── Step 5: build .pkg ─────────────────────────────────────────────────────── #
 printf 'smoke-on-box: building .pkg (abi=%s)...\n' "$_ABI" >&2

--- a/tests/shell/bridge_net_spec.sh
+++ b/tests/shell/bridge_net_spec.sh
@@ -1,0 +1,264 @@
+#shellcheck shell=sh
+# bridge_net_spec.sh — shellspec suite for scripts/bridge-net.sh's 'up'/'down' API.
+#
+# Pins the command contract:
+#   - 'up' creates br-wan (192.168.89.2/24) + br-mgmt (192.168.43.2/24) and lane-named taps
+#   - 'up' starts dnsmasq DHCP-only (port=0) with static MGMT leases at .15 / .16
+#   - 'up' emits eval-able SMOKE_* vars on stdout
+#   - 'up' is idempotent: calls 'down' first (link del AND link add both present)
+#   - per-lane tap names: SMOKE_LANE=1 → tap-wan1 / tap-mgmt1 / tap-cli1
+#   - SMOKE_VM_MAC line-2 override drives the pfSense MGMT lease MAC
+#   - 'down' deletes taps + bridges; exits 0 even when nothing exists
+#   - unknown subcommand → exit 2 with usage on stderr
+#
+# Hermetic: stubs ip (SMOKE_IP_BIN) and dnsmasq (SMOKE_DNSMASQ_BIN) that record
+# their argv to files; no real bridges, taps, or DHCP.
+
+Describe 'bridge-net.sh'
+  SCRIPT="${PFB_ROOT}/scripts/bridge-net.sh"
+
+  setup() {
+    scrub_git_env
+    unset SMOKE_LANE SMOKE_VM_MAC SMOKE_CLIENT_MGMT_MAC \
+          SMOKE_PFSENSE_MGMT_IP SMOKE_CLIENT_MGMT_IP
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/bridgenetspec.XXXXXX")"
+    IP_ARGV_FILE="${WORK}/ip_argv"
+    DNSMASQ_ARGV_FILE="${WORK}/dnsmasq_argv"
+    BIN="${WORK}/bin"
+    mkdir -p "${BIN}"
+
+    # ip stub: each invocation appends one space-joined line to IP_ARGV_FILE.
+    # "$*" (space-joined) lets assertions match multi-word argv like
+    # "link add br-wan type bridge" as a single substring.
+    cat > "${BIN}/ip" << 'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$IP_ARGV_FILE"
+EOF
+    chmod +x "${BIN}/ip"
+
+    # dnsmasq stub: records all args as one space-joined line; exits 0 (no daemonize).
+    cat > "${BIN}/dnsmasq" << 'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$DNSMASQ_ARGV_FILE"
+EOF
+    chmod +x "${BIN}/dnsmasq"
+
+    SMOKE_IP_BIN="${BIN}/ip"
+    SMOKE_DNSMASQ_BIN="${BIN}/dnsmasq"
+    export WORK IP_ARGV_FILE DNSMASQ_ARGV_FILE SMOKE_IP_BIN SMOKE_DNSMASQ_BIN
+  }
+  teardown() { rm -rf "${WORK}"; }
+  BeforeEach 'setup'
+  AfterEach  'teardown'
+
+  # ---- up: bridge creation -----------------------------------------------
+
+  Describe 'up creates br-wan (192.168.89.2/24)'
+    It 'adds br-wan, assigns 192.168.89.2/24, and brings it up'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_WAN_TAP=tap-wan0'
+      # Contract: ip link add br-wan type bridge + addr add 192.168.89.2/24 + link set up
+      The contents of file "$IP_ARGV_FILE" should include 'link add br-wan type bridge'
+      The contents of file "$IP_ARGV_FILE" should include 'addr add 192.168.89.2/24 dev br-wan'
+      The contents of file "$IP_ARGV_FILE" should include 'link set br-wan up'
+    End
+  End
+
+  Describe 'up creates br-mgmt (192.168.43.2/24)'
+    It 'adds br-mgmt, assigns 192.168.43.2/24, and brings it up'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_MGMT_TAP=tap-mgmt0'
+      The contents of file "$IP_ARGV_FILE" should include 'link add br-mgmt type bridge'
+      The contents of file "$IP_ARGV_FILE" should include 'addr add 192.168.43.2/24 dev br-mgmt'
+    End
+  End
+
+  # ---- up: tap creation and bridge attachment ----------------------------
+
+  Describe 'up creates lane-0 taps attached to the correct bridges'
+    It 'creates tap-wan0 and attaches it to br-wan'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_WAN_TAP=tap-wan0'
+      # Contract: tuntap add tap-wan0 mode tap + link set tap-wan0 master br-wan
+      The contents of file "$IP_ARGV_FILE" should include 'tuntap add tap-wan0 mode tap'
+      The contents of file "$IP_ARGV_FILE" should include 'link set tap-wan0 master br-wan'
+    End
+
+    It 'creates tap-mgmt0 and attaches it to br-mgmt'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_MGMT_TAP=tap-mgmt0'
+      The contents of file "$IP_ARGV_FILE" should include 'tuntap add tap-mgmt0 mode tap'
+      The contents of file "$IP_ARGV_FILE" should include 'link set tap-mgmt0 master br-mgmt'
+    End
+
+    It 'creates tap-cli0 (civm MGMT) and attaches it to br-mgmt'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_CLIENT_MGMT_TAP=tap-cli0'
+      # civm shares the MGMT bridge — different MAC/static-lease, same subnet
+      The contents of file "$IP_ARGV_FILE" should include 'tuntap add tap-cli0 mode tap'
+      The contents of file "$IP_ARGV_FILE" should include 'link set tap-cli0 master br-mgmt'
+    End
+  End
+
+  # ---- up: dnsmasq DHCP --------------------------------------------------
+
+  Describe 'up starts dnsmasq DHCP-only with correct ranges and static leases'
+    It 'passes --port=0 (DHCP-only; stub DNS owns :53) and per-bridge ranges'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_WAN_TAP=tap-wan0'
+      # §5.2 + §7.3: DHCP-only; dnsmasq auto-announces itself as gw+DNS per subnet
+      The contents of file "$DNSMASQ_ARGV_FILE" should include '--port=0'
+      The contents of file "$DNSMASQ_ARGV_FILE" \
+        should include '--dhcp-range=192.168.89.50,192.168.89.150,255.255.255.0'
+      The contents of file "$DNSMASQ_ARGV_FILE" \
+        should include '--dhcp-range=192.168.43.50,192.168.43.150,255.255.255.0'
+    End
+
+    It 'adds static leases for pfSense MGMT (→.15) and civm MGMT (→.16)'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_PFSENSE_MGMT_IP=192.168.43.15'
+      # Default CE net1 MAC → .15 (P3 PFSENSE_MGMT_IP); civm MAC → .16 (P3 CLIENT_MGMT_IP)
+      The contents of file "$DNSMASQ_ARGV_FILE" \
+        should include '--dhcp-host=BC:24:11:80:42:35,192.168.43.15'
+      The contents of file "$DNSMASQ_ARGV_FILE" \
+        should include '--dhcp-host=BC:24:11:29:A4:1B,192.168.43.16'
+    End
+
+    It 'passes a lane-scoped --pid-file so down can stop the right dnsmasq instance'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_CLIENT_MGMT_IP=192.168.43.16'
+      The contents of file "$DNSMASQ_ARGV_FILE" \
+        should include '--pid-file=/tmp/pfb-dnsmasq-0.pid'
+    End
+  End
+
+  # ---- up: eval-able stdout exports --------------------------------------
+
+  Describe 'up emits all five eval-able SMOKE_* vars on stdout'
+    It 'emits tap names and MGMT IPs that match P3 conftest defaults'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      # All five required by smoke-on-box.sh's eval + export block
+      The stdout should include 'SMOKE_WAN_TAP=tap-wan0'
+      The stdout should include 'SMOKE_MGMT_TAP=tap-mgmt0'
+      The stdout should include 'SMOKE_CLIENT_MGMT_TAP=tap-cli0'
+      The stdout should include 'SMOKE_PFSENSE_MGMT_IP=192.168.43.15'
+      The stdout should include 'SMOKE_CLIENT_MGMT_IP=192.168.43.16'
+    End
+  End
+
+  # ---- up: idempotency (down-first) --------------------------------------
+
+  Describe 'up is idempotent: runs down first, then creates'
+    It 'ip-argv contains both link del (from down-first) and link add (from create)'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_WAN_TAP=tap-wan0'
+      # down-first: stale taps/bridges deleted before recreating
+      The contents of file "$IP_ARGV_FILE" should include 'link del br-wan'
+      # create pass follows immediately after
+      The contents of file "$IP_ARGV_FILE" should include 'link add br-wan type bridge'
+    End
+  End
+
+  # ---- per-lane tap names ------------------------------------------------
+
+  Describe 'per-lane tap names: SMOKE_LANE=1 → tap-wan1, tap-mgmt1, tap-cli1'
+    It 'WAN tap is tap-wan1, not tap-wan0, in both stdout and ip-argv'
+      When run env SMOKE_LANE=1 sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      # Before/after: lane-1 names present, lane-0 names absent (lane isolation)
+      The stdout should include 'SMOKE_WAN_TAP=tap-wan1'
+      The stdout should not include 'SMOKE_WAN_TAP=tap-wan0'
+      The contents of file "$IP_ARGV_FILE" should include 'tuntap add tap-wan1 mode tap'
+      The contents of file "$IP_ARGV_FILE" should not include 'tuntap add tap-wan0 mode tap'
+    End
+
+    It 'MGMT and client taps are tap-mgmt1 and tap-cli1'
+      When run env SMOKE_LANE=1 sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_MGMT_TAP=tap-mgmt1'
+      The stdout should include 'SMOKE_CLIENT_MGMT_TAP=tap-cli1'
+    End
+  End
+
+  # ---- SMOKE_VM_MAC line-2 override for the pfSense MGMT lease -----------
+
+  Describe 'SMOKE_VM_MAC line-2 override drives the pfSense MGMT static lease'
+    setup_mac() {
+      # Outer BeforeEach 'setup' already ran; add the MAC override on top.
+      # Provide an 8-line SMOKE_VM_MAC where line 2 (net1/MGMT) is a distinct MAC.
+      SMOKE_VM_MAC="$(printf '%s\n' \
+          'AA:BB:CC:DD:EE:00' \
+          'AA:BB:CC:DD:EE:11' \
+          'AA:BB:CC:DD:EE:22' \
+          'AA:BB:CC:DD:EE:33' \
+          'AA:BB:CC:DD:EE:44' \
+          'AA:BB:CC:DD:EE:55' \
+          'AA:BB:CC:DD:EE:66' \
+          'AA:BB:CC:DD:EE:77')"
+      export SMOKE_VM_MAC
+    }
+    BeforeEach 'setup_mac'
+
+    It 'uses line 2 of SMOKE_VM_MAC (net1) not the hardcoded CE default for the .15 lease'
+      When run sh "$SCRIPT" up
+      The status should be success
+      The stderr should include 'bridge-net:'
+      The stdout should include 'SMOKE_PFSENSE_MGMT_IP=192.168.43.15'
+      # Proves bridge-net.sh mirrors boot_vm.sh's nth_mac 1 = sed -n '2p'
+      The contents of file "$DNSMASQ_ARGV_FILE" \
+        should include 'AA:BB:CC:DD:EE:11,192.168.43.15'
+      The contents of file "$DNSMASQ_ARGV_FILE" \
+        should not include 'BC:24:11:80:42:35'
+    End
+  End
+
+  # ---- down: idempotent teardown -----------------------------------------
+
+  Describe 'down deletes taps and bridges; exits 0 even when nothing exists'
+    It 'issues ip link del for all taps and both bridges'
+      When run sh "$SCRIPT" down
+      The status should be success
+      The contents of file "$IP_ARGV_FILE" should include 'link del br-wan'
+      The contents of file "$IP_ARGV_FILE" should include 'link del br-mgmt'
+      The contents of file "$IP_ARGV_FILE" should include 'link del tap-wan0'
+    End
+  End
+
+  # ---- unknown / missing subcommand --------------------------------------
+
+  Describe 'unknown or missing subcommand'
+    It 'exits 2 with usage on stderr for an unknown subcommand'
+      When run sh "$SCRIPT" blah
+      The status should equal 2
+      The stderr should include 'Usage:'
+    End
+
+    It 'exits 2 with usage on stderr when no subcommand is given'
+      When run sh "$SCRIPT"
+      The status should equal 2
+      The stderr should include 'Usage:'
+    End
+  End
+End

--- a/tests/shell/bridge_net_spec.sh
+++ b/tests/shell/bridge_net_spec.sh
@@ -4,15 +4,18 @@
 # Pins the command contract:
 #   - 'up' creates br-wan (192.168.89.2/24) + br-mgmt (192.168.43.2/24) and lane-named taps
 #   - 'up' starts dnsmasq DHCP-only (port=0) with static MGMT leases at .15 / .16
-#   - 'up' emits eval-able SMOKE_* vars on stdout
+#   - 'up' emits SMOKE_* vars on stdout (strict allowlist KEY=value format)
 #   - 'up' is idempotent: calls 'down' first (link del AND link add both present)
 #   - per-lane tap names: SMOKE_LANE=1 → tap-wan1 / tap-mgmt1 / tap-cli1
 #   - SMOKE_VM_MAC line-2 override drives the pfSense MGMT lease MAC
 #   - 'down' deletes taps + bridges; exits 0 even when nothing exists
+#   - 'down' exits 0 even when ip link del returns non-zero (missing devices)
+#   - invalid SMOKE_LANE (non-numeric) → exit 2 for both up and down
+#   - metacharacters in SMOKE_PFSENSE_MGMT_IP → exit 2 (injection rejected)
 #   - unknown subcommand → exit 2 with usage on stderr
 #
-# Hermetic: stubs ip (SMOKE_IP_BIN) and dnsmasq (SMOKE_DNSMASQ_BIN) that record
-# their argv to files; no real bridges, taps, or DHCP.
+# Hermetic: stubs ip (SMOKE_IP_BIN), dnsmasq (SMOKE_DNSMASQ_BIN), and the runtime
+# dir (SMOKE_BRIDGE_RUN_DIR) so no real bridges, taps, DHCP, or root-owned dirs.
 
 Describe 'bridge-net.sh'
   SCRIPT="${PFB_ROOT}/scripts/bridge-net.sh"
@@ -20,7 +23,7 @@ Describe 'bridge-net.sh'
   setup() {
     scrub_git_env
     unset SMOKE_LANE SMOKE_VM_MAC SMOKE_CLIENT_MGMT_MAC \
-          SMOKE_PFSENSE_MGMT_IP SMOKE_CLIENT_MGMT_IP
+          SMOKE_PFSENSE_MGMT_IP SMOKE_CLIENT_MGMT_IP SMOKE_BRIDGE_RUN_DIR
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/bridgenetspec.XXXXXX")"
     IP_ARGV_FILE="${WORK}/ip_argv"
     DNSMASQ_ARGV_FILE="${WORK}/dnsmasq_argv"
@@ -43,9 +46,13 @@ printf '%s\n' "$*" >> "$DNSMASQ_ARGV_FILE"
 EOF
     chmod +x "${BIN}/dnsmasq"
 
+    # Runtime dir override: keeps the PID file out of the real /run/pfb-smoke.
+    RUNDIR="${WORK}/run"
     SMOKE_IP_BIN="${BIN}/ip"
     SMOKE_DNSMASQ_BIN="${BIN}/dnsmasq"
-    export WORK IP_ARGV_FILE DNSMASQ_ARGV_FILE SMOKE_IP_BIN SMOKE_DNSMASQ_BIN
+    SMOKE_BRIDGE_RUN_DIR="${RUNDIR}"
+    export WORK IP_ARGV_FILE DNSMASQ_ARGV_FILE SMOKE_IP_BIN SMOKE_DNSMASQ_BIN \
+           SMOKE_BRIDGE_RUN_DIR RUNDIR
   }
   teardown() { rm -rf "${WORK}"; }
   BeforeEach 'setup'
@@ -144,7 +151,7 @@ EOF
       The stderr should include 'bridge-net:'
       The stdout should include 'SMOKE_CLIENT_MGMT_IP=192.168.43.16'
       The contents of file "$DNSMASQ_ARGV_FILE" \
-        should include '--pid-file=/tmp/pfb-dnsmasq-0.pid'
+        should include "--pid-file=${RUNDIR}/dnsmasq-0.pid"
     End
   End
 
@@ -259,6 +266,58 @@ EOF
       When run sh "$SCRIPT"
       The status should equal 2
       The stderr should include 'Usage:'
+    End
+  End
+
+  # ---- down: tolerates ip link del errors --------------------------------
+
+  Describe 'down tolerates ip link del errors (missing devices are not an error)'
+    setup_fail_ip() {
+      # Override the ip stub (setup() already ran) with one that exits 1 on
+      # 'link del *' to simulate missing devices.  Proves the || true guards work.
+      cat > "${BIN}/ip" << 'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$IP_ARGV_FILE"
+case "$*" in link\ del*) exit 1 ;; esac
+EOF
+      chmod +x "${BIN}/ip"
+    }
+    BeforeEach 'setup_fail_ip'
+
+    It 'exits 0 even when ip link del returns non-zero (|| true guards protect it)'
+      When run sh "$SCRIPT" down
+      The status should be success
+      The contents of file "$IP_ARGV_FILE" should include 'link del br-wan'
+    End
+  End
+
+  # ---- input validation: invalid SMOKE_LANE ------------------------------
+
+  Describe 'input validation: non-numeric SMOKE_LANE is rejected before any command runs'
+    It 'down with SMOKE_LANE=bad exits 2 with a message about SMOKE_LANE'
+      # RED→GREEN: pre-validation code has no exit 2 for bad LANE → status was 0 or 1.
+      # After validation: exits 2 with the SMOKE_LANE message.
+      When run env SMOKE_LANE=bad sh "$SCRIPT" down
+      The status should equal 2
+      The stderr should include 'SMOKE_LANE'
+    End
+
+    It 'up with SMOKE_LANE=bad exits 2 with a message about SMOKE_LANE'
+      When run env SMOKE_LANE=bad sh "$SCRIPT" up
+      The status should equal 2
+      The stderr should include 'SMOKE_LANE'
+    End
+  End
+
+  # ---- input validation: injection in SMOKE_PFSENSE_MGMT_IP -------------
+
+  Describe 'input validation: metacharacters in SMOKE_PFSENSE_MGMT_IP are rejected'
+    It 'up with a semicolon-injection in SMOKE_PFSENSE_MGMT_IP exits 2'
+      # RED→GREEN: pre-validation code passes the value straight to dnsmasq args;
+      # after validation: exits 2 before any binary is called.
+      When run env SMOKE_PFSENSE_MGMT_IP='1.2.3.4; rm -rf /' sh "$SCRIPT" up
+      The status should equal 2
+      The stderr should include 'invalid characters'
     End
   End
 End

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -146,6 +146,39 @@ os.environ["SMOKE_WEB_HOSTPORT"] = str(DEFAULT_WEB_PORT)
 os.environ["SMOKE_CLIENT_SSH_HOSTPORT"] = str(DEFAULT_CLIENT_SSH_PORT)
 os.environ["SMOKE_LAN_SOCKET_PORT"] = str(DEFAULT_LAN_SOCKET_PORT)
 
+# --------------------------------------------------------------------------- #
+# Network mode — bridge vs slirp SSH/DNS targeting (ADR-50 P3)
+# --------------------------------------------------------------------------- #
+#
+# slirp (default): QEMU user-net hostfwd; DEFAULT_HOST/SSH_PORT/WEB_PORT are the
+#   loopback hostfwd values computed above.  No change to slirp behaviour.
+# bridge: tap devices on host Linux bridges; the harness SSHes the guest MGMT bridge
+#   IPs directly (no hostfwd) and the stub DNS binds the WAN bridge IP.
+#   The env write-back above (SMOKE_*_HOSTPORT) is a harmless no-op in bridge mode
+#   because boot_vm.sh ignores hostfwd when NET_MODE=bridge — left unbranched.
+NET_MODE = os.environ.get("SMOKE_NET_MODE", "slirp")
+if NET_MODE not in ("slirp", "bridge"):
+    raise ValueError(f"SMOKE_NET_MODE must be 'slirp' or 'bridge' (got {NET_MODE!r})")
+
+# Bridge MGMT static lease IPs, env-overridable so P2's per-box setup can export them.
+# Defaults match boot_vm.sh PFSENSE_MGMT_IP (.15) and the civm static lease on br-mgmt (.16).
+PFSENSE_MGMT_IP = os.environ.get("SMOKE_PFSENSE_MGMT_IP") or "192.168.43.15"
+CLIENT_MGMT_IP = os.environ.get("SMOKE_CLIENT_MGMT_IP") or "192.168.43.16"
+
+if NET_MODE == "bridge":
+    # Override the slirp loopback-hostfwd values with the bridge MGMT IPs + standard ports.
+    DEFAULT_HOST = PFSENSE_MGMT_IP
+    DEFAULT_SSH_PORT = 22
+    DEFAULT_WEB_PORT = 80
+    DEFAULT_CLIENT_SSH_PORT = 22
+
+# civm SSH target: slirp → loopback hostfwd (same as DEFAULT_HOST); bridge → civm MGMT IP.
+DEFAULT_CLIENT_HOST: str = CLIENT_MGMT_IP if NET_MODE == "bridge" else DEFAULT_HOST
+
+# Stub DNS bind address: bridge → WAN bridge IP 192.168.89.2 (systemd-resolved sits on
+# 127.0.0.53:53 so loopback :53 is taken; the bridge IP :53 is free); slirp → loopback.
+DEFAULT_STUB_DNS_ADDR: str = GUEST_TO_HOST_ALIAS if NET_MODE == "bridge" else "127.0.0.1"
+
 # The address civm uses to reach pfSense (pfSense LAN side of the socket crossover).
 PFSENSE_LAN_IP = "192.168.1.1"  # pfSense LAN IP baked in the two-VM image
 
@@ -704,7 +737,7 @@ def client_vm(
                 "sh",
                 str(WAIT_READY_SH),
                 ssh_key_path,
-                DEFAULT_HOST,
+                DEFAULT_CLIENT_HOST,
                 str(DEFAULT_CLIENT_SSH_PORT),
                 str(DEFAULT_BOOT_TIMEOUT),
                 str(process.pid),
@@ -734,7 +767,7 @@ def client_vm(
 
     vm = SmokeVM(
         ssh_key_path=ssh_key_path,
-        host=DEFAULT_HOST,
+        host=DEFAULT_CLIENT_HOST,
         ssh_port=DEFAULT_CLIENT_SSH_PORT,
         vm_pid=process.pid,
         log_path=str(log_path),
@@ -1062,7 +1095,9 @@ class _StubDnsServer:
         # with systemd-resolved on 127.0.0.53:53. ``port`` overrides the env (the pure
         # unit tests pass ``port=0`` to force an ephemeral port, so they never collide
         # with the session mock holding :53).
-        addr = os.environ.get("SMOKE_STUB_DNS_ADDR") or "127.0.0.1"
+        # bridge mode: DEFAULT_STUB_DNS_ADDR is the WAN bridge IP 192.168.89.2; an explicit
+        # SMOKE_STUB_DNS_ADDR env still wins in both modes.
+        addr = os.environ.get("SMOKE_STUB_DNS_ADDR") or DEFAULT_STUB_DNS_ADDR
         if port is None:
             port = int(os.environ.get("SMOKE_STUB_DNS_PORT") or "0")
         # Bind TCP first so the shared port number is proven free for both (issue #243).

--- a/tests/test_smoke_net_mode.py
+++ b/tests/test_smoke_net_mode.py
@@ -62,10 +62,13 @@ def _load_conftest(
 ) -> types.ModuleType:
     """Import tests.smoke.conftest with controlled env vars.
 
-    Saves and restores all conftest-side-effected env vars so tests are fully
-    isolated from one another.  Mirrors the pattern in test_adr47_conftest_lane.
+    Saves and restores all conftest-side-effected env vars AND the affected
+    sys.modules entries so tests are fully order-independent.
     """
     saved = {k: os.environ.get(k) for k in _CONFTEST_ENV_KEYS}
+    saved_modules = {
+        k: sys.modules[k] for k in list(sys.modules) if "smoke.conftest" in k or k == "tests.smoke.conftest"
+    }
 
     os.environ["SMOKE_LANE"] = str(lane)
     # Set or unset each NET_MODE-related env var.
@@ -89,6 +92,11 @@ def _load_conftest(
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
+        # Restore sys.modules to the pre-call state (delete any entries this call added).
+        for key in list(sys.modules):
+            if "smoke.conftest" in key or key == "tests.smoke.conftest":
+                del sys.modules[key]
+        sys.modules.update(saved_modules)
 
 
 def _set_or_pop(key: str, value: str | None) -> None:
@@ -267,21 +275,5 @@ class TestInvalidNetMode:
 
     def test_invalid_mode_raises(self) -> None:
         """SMOKE_NET_MODE='garbage' → ValueError on import (same guard as boot_vm.sh)."""
-        # Force a fresh import attempt with the bad value.
-        saved = os.environ.get("SMOKE_NET_MODE")
-        for key in list(sys.modules):
-            if "smoke.conftest" in key or key == "tests.smoke.conftest":
-                del sys.modules[key]
-        os.environ["SMOKE_NET_MODE"] = "garbage"
-        try:
-            with pytest.raises(ValueError, match="SMOKE_NET_MODE"):
-                importlib.import_module("tests.smoke.conftest")
-        finally:
-            if saved is None:
-                os.environ.pop("SMOKE_NET_MODE", None)
-            else:
-                os.environ["SMOKE_NET_MODE"] = saved
-            # Clean up the partial/failed module import.
-            for key in list(sys.modules):
-                if "smoke.conftest" in key or key == "tests.smoke.conftest":
-                    del sys.modules[key]
+        with pytest.raises(ValueError, match="SMOKE_NET_MODE"):
+            _load_conftest(net_mode="garbage")

--- a/tests/test_smoke_net_mode.py
+++ b/tests/test_smoke_net_mode.py
@@ -1,0 +1,287 @@
+"""tests/test_smoke_net_mode.py — ADR-50 P3: SMOKE_NET_MODE bridge/slirp conftest unit tests.
+
+Pins the NET_MODE-aware endpoint selection added to tests/smoke/conftest.py:
+  1. slirp (default/unset) is behaviour-preserving: DEFAULT_HOST/CLIENT_HOST stay on
+     127.0.0.1, SSH/WEB/CLIENT_SSH ports stay at the historical lane-0 hostfwd values,
+     DEFAULT_STUB_DNS_ADDR stays on loopback.
+  2. bridge flips the endpoints: DEFAULT_HOST → 192.168.43.15, DEFAULT_SSH_PORT → 22,
+     DEFAULT_WEB_PORT → 80, DEFAULT_CLIENT_HOST → 192.168.43.16,
+     DEFAULT_CLIENT_SSH_PORT → 22, DEFAULT_STUB_DNS_ADDR → 192.168.89.2.
+  3. Bridge MGMT IPs are env-overridable via SMOKE_PFSENSE_MGMT_IP / SMOKE_CLIENT_MGMT_IP.
+  4. An invalid SMOKE_NET_MODE value raises ValueError at import time.
+
+RED→GREEN evidence (tests that FAIL on pre-P3 code, PASS after):
+  - test_bridge_flips_endpoints: before P3 the bridge branch does not exist, so the
+    constants stay at loopback/slirp values.  Asserting DEFAULT_HOST == "192.168.43.15"
+    FAILS with: AssertionError: expected 192.168.43.15; got 127.0.0.1.
+    After P3: PASSES.
+  - test_bridge_client_host: DEFAULT_CLIENT_HOST does not exist before P3 →
+    AttributeError.  After P3: exists and equals 192.168.43.16.
+  - test_bridge_stub_dns_addr: DEFAULT_STUB_DNS_ADDR does not exist before P3 →
+    AttributeError.  After P3: exists and equals 192.168.89.2.
+
+Run: python -m pytest tests/test_smoke_net_mode.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers — load conftest in an isolated environment
+# ---------------------------------------------------------------------------
+
+# All env vars that conftest reads or writes at import time (superset of
+# test_adr47_conftest_lane._CONFTEST_ENV_KEYS, extended with the NET_MODE vars).
+_CONFTEST_ENV_KEYS: tuple[str, ...] = (
+    "SMOKE_LANE",
+    "SMOKE_SSH_HOSTPORT",
+    "SMOKE_WEB_HOSTPORT",
+    "SMOKE_CLIENT_SSH_HOSTPORT",
+    "SMOKE_LAN_SOCKET_PORT",
+    "PFB_DIAG_DIR",
+    "SMOKE_NET_MODE",
+    "SMOKE_PFSENSE_MGMT_IP",
+    "SMOKE_CLIENT_MGMT_IP",
+    "SMOKE_STUB_DNS_ADDR",
+)
+
+
+def _load_conftest(
+    *,
+    net_mode: str | None = None,
+    pfsense_mgmt_ip: str | None = None,
+    client_mgmt_ip: str | None = None,
+    stub_dns_addr: str | None = None,
+    lane: int = 0,
+) -> types.ModuleType:
+    """Import tests.smoke.conftest with controlled env vars.
+
+    Saves and restores all conftest-side-effected env vars so tests are fully
+    isolated from one another.  Mirrors the pattern in test_adr47_conftest_lane.
+    """
+    saved = {k: os.environ.get(k) for k in _CONFTEST_ENV_KEYS}
+
+    os.environ["SMOKE_LANE"] = str(lane)
+    # Set or unset each NET_MODE-related env var.
+    _set_or_pop("SMOKE_NET_MODE", net_mode)
+    _set_or_pop("SMOKE_PFSENSE_MGMT_IP", pfsense_mgmt_ip)
+    _set_or_pop("SMOKE_CLIENT_MGMT_IP", client_mgmt_ip)
+    _set_or_pop("SMOKE_STUB_DNS_ADDR", stub_dns_addr)
+    # PFB_DIAG_DIR: unset so DIAG_DIR defaults to 'smoke-diag' (avoids cwd Path("")).
+    os.environ.pop("PFB_DIAG_DIR", None)
+
+    # Force a fresh import — conftest reads env at module level.
+    for key in list(sys.modules):
+        if "smoke.conftest" in key or key == "tests.smoke.conftest":
+            del sys.modules[key]
+
+    try:
+        return importlib.import_module("tests.smoke.conftest")
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _set_or_pop(key: str, value: str | None) -> None:
+    if value is None:
+        os.environ.pop(key, None)
+    else:
+        os.environ[key] = value
+
+
+# ---------------------------------------------------------------------------
+# 1 — slirp (default) is behaviour-preserving
+# ---------------------------------------------------------------------------
+
+
+class TestSlirpDefault:
+    """slirp mode (SMOKE_NET_MODE unset or 'slirp') keeps today's loopback/hostfwd values.
+
+    Scenario: existing runs without SMOKE_NET_MODE set must be byte-for-behaviour
+    identical before and after P3.  This class is the 'before' oracle: the values
+    it pins were the only values possible pre-P3, so if they change for slirp, P3
+    broke something.
+    """
+
+    def test_default_host_is_loopback(self) -> None:
+        """Given SMOKE_NET_MODE unset, DEFAULT_HOST is 127.0.0.1 (slirp hostfwd)."""
+        mod = _load_conftest()
+        assert mod.DEFAULT_HOST == "127.0.0.1", f"expected 127.0.0.1; got {mod.DEFAULT_HOST!r}"
+
+    def test_client_host_is_loopback(self) -> None:
+        """Given SMOKE_NET_MODE unset, DEFAULT_CLIENT_HOST is 127.0.0.1."""
+        mod = _load_conftest()
+        assert mod.DEFAULT_CLIENT_HOST == "127.0.0.1", f"expected 127.0.0.1; got {mod.DEFAULT_CLIENT_HOST!r}"
+
+    def test_ssh_port_is_historical_default(self) -> None:
+        """Given SMOKE_NET_MODE unset, DEFAULT_SSH_PORT is 2222 at lane 0."""
+        mod = _load_conftest(lane=0)
+        assert mod.DEFAULT_SSH_PORT == 2222, f"expected 2222; got {mod.DEFAULT_SSH_PORT}"
+
+    def test_web_port_is_historical_default(self) -> None:
+        """Given SMOKE_NET_MODE unset, DEFAULT_WEB_PORT is 8080 at lane 0."""
+        mod = _load_conftest(lane=0)
+        assert mod.DEFAULT_WEB_PORT == 8080, f"expected 8080; got {mod.DEFAULT_WEB_PORT}"
+
+    def test_client_ssh_port_is_historical_default(self) -> None:
+        """Given SMOKE_NET_MODE unset, DEFAULT_CLIENT_SSH_PORT is 2223 at lane 0."""
+        mod = _load_conftest(lane=0)
+        assert mod.DEFAULT_CLIENT_SSH_PORT == 2223, f"expected 2223; got {mod.DEFAULT_CLIENT_SSH_PORT}"
+
+    def test_stub_dns_addr_is_loopback(self) -> None:
+        """Given SMOKE_NET_MODE unset, DEFAULT_STUB_DNS_ADDR is 127.0.0.1."""
+        mod = _load_conftest()
+        assert mod.DEFAULT_STUB_DNS_ADDR == "127.0.0.1", f"expected 127.0.0.1; got {mod.DEFAULT_STUB_DNS_ADDR!r}"
+
+    def test_explicit_slirp_same_as_unset(self) -> None:
+        """SMOKE_NET_MODE='slirp' gives the same result as unset."""
+        mod = _load_conftest(net_mode="slirp")
+        assert mod.DEFAULT_HOST == "127.0.0.1"
+        assert mod.DEFAULT_CLIENT_HOST == "127.0.0.1"
+        assert mod.DEFAULT_SSH_PORT == 2222
+        assert mod.DEFAULT_WEB_PORT == 8080
+        assert mod.DEFAULT_CLIENT_SSH_PORT == 2223
+        assert mod.DEFAULT_STUB_DNS_ADDR == "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# 2 — bridge flips the endpoints (RED→GREEN: fails on pre-P3 code)
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeFlipsEndpoints:
+    """bridge mode routes SSH/DNS to the MGMT bridge IPs, not the loopback hostfwd.
+
+    Scenario / Given–When–Then:
+      Given SMOKE_NET_MODE=bridge (the per-box setup exports this before pytest)
+      When tests/smoke/conftest.py is imported
+      Then DEFAULT_HOST == 192.168.43.15 (pfSense MGMT bridge static lease)
+           DEFAULT_SSH_PORT == 22
+           DEFAULT_WEB_PORT == 80
+           DEFAULT_CLIENT_HOST == 192.168.43.16 (civm MGMT bridge static lease)
+           DEFAULT_CLIENT_SSH_PORT == 22
+           DEFAULT_STUB_DNS_ADDR == 192.168.89.2 (WAN bridge IP; no loopback conflict)
+
+    RED→GREEN evidence:
+      Before P3: DEFAULT_HOST stays '127.0.0.1' → first assert FAILS.
+      After  P3: all six asserts PASS.
+    """
+
+    def test_bridge_flips_endpoints(self) -> None:
+        """SMOKE_NET_MODE=bridge → pfSense SSH/web target the MGMT bridge IP."""
+        # Assert the slirp baseline first (the 'before' state).
+        slirp = _load_conftest()
+        assert slirp.DEFAULT_HOST == "127.0.0.1", "slirp baseline: DEFAULT_HOST must be loopback"
+        assert slirp.DEFAULT_SSH_PORT == 2222, "slirp baseline: DEFAULT_SSH_PORT must be 2222"
+        assert slirp.DEFAULT_WEB_PORT == 8080, "slirp baseline: DEFAULT_WEB_PORT must be 8080"
+
+        # Now load with bridge mode and assert the flip.
+        bridge = _load_conftest(net_mode="bridge")
+        assert bridge.DEFAULT_HOST == "192.168.43.15", f"expected 192.168.43.15; got {bridge.DEFAULT_HOST!r}"
+        assert bridge.DEFAULT_SSH_PORT == 22, f"expected 22; got {bridge.DEFAULT_SSH_PORT}"
+        assert bridge.DEFAULT_WEB_PORT == 80, f"expected 80; got {bridge.DEFAULT_WEB_PORT}"
+
+    def test_bridge_client_host(self) -> None:
+        """SMOKE_NET_MODE=bridge → civm SSH targets the civm MGMT bridge IP."""
+        # Assert the slirp baseline first.
+        slirp = _load_conftest()
+        assert slirp.DEFAULT_CLIENT_HOST == "127.0.0.1", "slirp baseline: DEFAULT_CLIENT_HOST must be loopback"
+        assert slirp.DEFAULT_CLIENT_SSH_PORT == 2223, "slirp baseline: DEFAULT_CLIENT_SSH_PORT must be 2223"
+
+        bridge = _load_conftest(net_mode="bridge")
+        assert bridge.DEFAULT_CLIENT_HOST == "192.168.43.16", (
+            f"expected 192.168.43.16; got {bridge.DEFAULT_CLIENT_HOST!r}"
+        )
+        assert bridge.DEFAULT_CLIENT_SSH_PORT == 22, f"expected 22; got {bridge.DEFAULT_CLIENT_SSH_PORT}"
+
+    def test_bridge_stub_dns_addr(self) -> None:
+        """SMOKE_NET_MODE=bridge → stub DNS binds the WAN bridge IP 192.168.89.2."""
+        slirp = _load_conftest()
+        assert slirp.DEFAULT_STUB_DNS_ADDR == "127.0.0.1", "slirp baseline: DEFAULT_STUB_DNS_ADDR must be loopback"
+
+        bridge = _load_conftest(net_mode="bridge")
+        assert bridge.DEFAULT_STUB_DNS_ADDR == "192.168.89.2", (
+            f"expected 192.168.89.2; got {bridge.DEFAULT_STUB_DNS_ADDR!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3 — bridge MGMT IPs are env-overridable
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeMgmtIpOverrides:
+    """SMOKE_PFSENSE_MGMT_IP / SMOKE_CLIENT_MGMT_IP override the bridge static-lease defaults.
+
+    P2's per-box setup exports these when its dnsmasq static leases differ from the
+    defaults.  An explicit env value must win over the hardcoded fallback.
+    """
+
+    def test_pfsense_mgmt_ip_override(self) -> None:
+        """SMOKE_PFSENSE_MGMT_IP overrides the DEFAULT_HOST in bridge mode."""
+        mod = _load_conftest(net_mode="bridge", pfsense_mgmt_ip="10.99.1.100")
+        assert mod.DEFAULT_HOST == "10.99.1.100", f"expected 10.99.1.100; got {mod.DEFAULT_HOST!r}"
+
+    def test_client_mgmt_ip_override(self) -> None:
+        """SMOKE_CLIENT_MGMT_IP overrides the DEFAULT_CLIENT_HOST in bridge mode."""
+        mod = _load_conftest(net_mode="bridge", client_mgmt_ip="10.99.1.101")
+        assert mod.DEFAULT_CLIENT_HOST == "10.99.1.101", f"expected 10.99.1.101; got {mod.DEFAULT_CLIENT_HOST!r}"
+
+    def test_both_overrides_together(self) -> None:
+        """Both overrides in bridge mode are independent and both honoured."""
+        mod = _load_conftest(
+            net_mode="bridge",
+            pfsense_mgmt_ip="10.1.2.3",
+            client_mgmt_ip="10.1.2.4",
+        )
+        assert mod.DEFAULT_HOST == "10.1.2.3", f"expected 10.1.2.3; got {mod.DEFAULT_HOST!r}"
+        assert mod.DEFAULT_CLIENT_HOST == "10.1.2.4", f"expected 10.1.2.4; got {mod.DEFAULT_CLIENT_HOST!r}"
+
+    def test_overrides_have_no_effect_in_slirp_mode(self) -> None:
+        """MGMT IP overrides in slirp mode do not affect DEFAULT_HOST or DEFAULT_CLIENT_HOST."""
+        mod = _load_conftest(
+            net_mode="slirp",
+            pfsense_mgmt_ip="10.1.2.3",
+            client_mgmt_ip="10.1.2.4",
+        )
+        assert mod.DEFAULT_HOST == "127.0.0.1", f"slirp must keep loopback; got {mod.DEFAULT_HOST!r}"
+        assert mod.DEFAULT_CLIENT_HOST == "127.0.0.1", f"slirp must keep loopback; got {mod.DEFAULT_CLIENT_HOST!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4 — invalid SMOKE_NET_MODE raises ValueError
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidNetMode:
+    """An unrecognised SMOKE_NET_MODE raises ValueError at import time."""
+
+    def test_invalid_mode_raises(self) -> None:
+        """SMOKE_NET_MODE='garbage' → ValueError on import (same guard as boot_vm.sh)."""
+        # Force a fresh import attempt with the bad value.
+        saved = os.environ.get("SMOKE_NET_MODE")
+        for key in list(sys.modules):
+            if "smoke.conftest" in key or key == "tests.smoke.conftest":
+                del sys.modules[key]
+        os.environ["SMOKE_NET_MODE"] = "garbage"
+        try:
+            with pytest.raises(ValueError, match="SMOKE_NET_MODE"):
+                importlib.import_module("tests.smoke.conftest")
+        finally:
+            if saved is None:
+                os.environ.pop("SMOKE_NET_MODE", None)
+            else:
+                os.environ["SMOKE_NET_MODE"] = saved
+            # Clean up the partial/failed module import.
+            for key in list(sys.modules):
+                if "smoke.conftest" in key or key == "tests.smoke.conftest":
+                    del sys.modules[key]


### PR DESCRIPTION
## ADR-50 P2–P4 — bridge networking for the smoke VMs (`SMOKE_NET_MODE=bridge`)

Implements phases **P2, P3, P4** of [ADR-50](.ADRs/ADR_50_Smoke_Bridge_Networking/ADR.md). P1 (the `boot_vm.sh` `SMOKE_NET_MODE` toggle) already landed (#615). This adds the per-box bridge+dnsmasq setup the toggle consumes, makes the harness target the guest over the bridge, and wires it into CI — all **opt-in**, with `slirp` the default and **byte-identical** behaviour when unset.

### P3 — conftest mode-aware targeting (`tests/smoke/conftest.py`)
- New `SMOKE_NET_MODE` read (validated `slirp`|`bridge`). In `bridge` mode the harness SSHes the guest's **MGMT bridge IP** directly (`192.168.43.15`, port 22; civm `192.168.43.16`) instead of the SLIRP `hostfwd`, and the stub DNS binds the **WAN bridge IP** `192.168.89.2:53` instead of loopback.
- New env knobs `SMOKE_PFSENSE_MGMT_IP` / `SMOKE_CLIENT_MGMT_IP` (the P2 setup exports them; defaults match).
- Off-box unit test `tests/test_smoke_net_mode.py` (15 tests) pins both modes + overrides + invalid-mode rejection, with red→green evidence (bridge endpoints fail on the pre-change code).

### P2 — per-box bridge+dnsmasq setup (the keystone)
- New `scripts/bridge-net.sh up|down`: creates `br-wan` (`192.168.89.2/24`) + `br-mgmt` (`192.168.43.2/24`), per-lane taps, and a DHCP-only `dnsmasq` with static MGMT leases keyed off the real pfSense net1 + civm MGMT MACs. Idempotent (`up` tears down first); `ip`/`dnsmasq` overridable for the hermetic shellspec.
- Wired into the ADR-47 box-setup path: `scripts/smoke-on-box.sh` gains `--net-mode` + a Step-4 `eval`/export block; `scripts/local-smoke.sh` threads `--net-mode` through.
- `tests/shell/bridge_net_spec.sh` (16 examples) pins the full command contract (bridges, taps, dnsmasq static leases, the eval-able exports, idempotency, per-lane names, MAC override) with red→green evidence.
- `docs/misc/local-smoke-debian.md`: documents the `dnsmasq` box-image dep + the one-time LXC `/dev/net/tun` host passthrough + how to run bridge mode locally.

### P4 — CI wiring (`smoke-single.yml`, `ui-tests.yml`, `smoke.yml`)
- A `net_mode` input (default `slirp`) + a gated bridge-setup step (calls `bridge-net.sh up`, exports the tap names + MGMT IPs to `$GITHUB_ENV`) that runs after VM-identity resolution and before the VM boots. The fan-out forwards `net_mode` so the P5 A/B is dispatchable across CE+Plus.
- The previously-hardcoded `SMOKE_STUB_DNS_ADDR` in `smoke-single.yml` is now mode-aware (so bridge mode binds `192.168.89.2:53`, not loopback).

### Safety / scope
- **`slirp` is byte-identical:** the bridge step is gated `if net_mode == 'bridge'`, the stub-DNS address ternary resolves to the prior literal, and every existing caller passes nothing → `slirp`.
- Gates green: `shellcheck` clean, `shellspec` 226/0 failures, `actionlint` exit 0, the off-box pytest suite green, `markdownlint` clean.

### Out of scope / pending (P5 + maintainer — live-VM only, per the ADR)
- **P5 A/B** (slirp vs bridge timing on the CE+Plus fan-out) + the default-flip decision (§5.5).
- **Live-only details** the shellspec/actionlint can't assert: tap ownership vs non-root QEMU (may need a `user` on the tap), and that `dnsmasq` actually serves DHCP + auto-announces option 3/6. The §7 de-risk proved a bridge boot works on a GH runner; P5 finalizes the exact wiring.
- The `dnsmasq` box-image bake + the LXC `/dev/net/tun` host passthrough are documented maintainer/infra prerequisites for the local path (GH runners have `tun` natively).

ADR.md §6 phase-status updates land separately direct to `devel` (ADR-text carve-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in bridge networking mode for local and CI smoke/UI runs.
  * Added a new bridge networking helper and a dedicated test suite for it.
  * Expanded smoke workflows and CLI flags to choose between default and bridge networking.

* **Bug Fixes**
  * Improved endpoint selection and DNS behavior when running in bridge mode.
  * Added validation and overrides for management IP settings in different network modes.

* **Documentation**
  * Updated local smoke documentation with bridge-mode setup and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->