### PR TITLE
smoke: treat empty SMOKE_NET_MODE as slirp (fix nightly UI conftest crash)

### DIFF
--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -567,8 +567,9 @@ jobs:
           SMOKE_CONTROL_IP: ${{ secrets.SMOKE_CONTROL_IP || vars.SMOKE_CONTROL_IP }}
           # Network backend (ADR-50): slirp (default) | bridge. conftest + boot_vm.sh
           # branch on this; boot_vm.sh also reads the SMOKE_*_TAP vars the bridge-setup
-          # step wrote to $GITHUB_ENV.
-          SMOKE_NET_MODE: ${{ inputs.net_mode }}
+          # step wrote to $GITHUB_ENV. `|| 'slirp'` keeps it non-empty even if a caller
+          # passes nothing (defensive — callers default to slirp, but never emit "").
+          SMOKE_NET_MODE: ${{ inputs.net_mode || 'slirp' }}
           # System-DNS upstream wiring: the mock binds the runner loopback :53, and
           # pfSense forwards to the SLIRP host alias 192.168.89.2 which libslirp NATs
           # (port-preserving) straight to that mock — no /etc/resolv.conf involvement.

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -537,7 +537,9 @@ jobs:
           # branch on it; the SMOKE_*_TAP vars come from the bridge-setup step's $GITHUB_ENV.
           # No SMOKE_STUB_DNS_ADDR override here — conftest defaults it to the WAN bridge IP
           # (192.168.89.2) in bridge mode, loopback in slirp.
-          SMOKE_NET_MODE: ${{ inputs.net_mode }}
+          # `|| 'slirp'`: this workflow also runs on `schedule`, where `inputs.net_mode` is
+          # empty — without the fallback the env var is "" and conftest would reject it.
+          SMOKE_NET_MODE: ${{ inputs.net_mode || 'slirp' }}
         run: |
           set -eu
           # Delegate to the canonical argv emitter (ADR-47 P4 — drift-kill).

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -156,7 +156,12 @@ os.environ["SMOKE_LAN_SOCKET_PORT"] = str(DEFAULT_LAN_SOCKET_PORT)
 #   IPs directly (no hostfwd) and the stub DNS binds the WAN bridge IP.
 #   The env write-back above (SMOKE_*_HOSTPORT) is a harmless no-op in bridge mode
 #   because boot_vm.sh ignores hostfwd when NET_MODE=bridge — left unbranched.
-NET_MODE = os.environ.get("SMOKE_NET_MODE", "slirp")
+# `or "slirp"` (NOT a get-default): an EMPTY SMOKE_NET_MODE must read as slirp, matching
+# boot_vm.sh's `${SMOKE_NET_MODE:-slirp}`. A workflow expression like `${{ inputs.net_mode }}`
+# sets the env var to "" on a schedule / no-input event (inputs are absent then), and
+# `get("SMOKE_NET_MODE", "slirp")` would keep "" and trip the guard below — crashing the
+# conftest import on the nightly UI run. Empty == unset == slirp.
+NET_MODE = os.environ.get("SMOKE_NET_MODE") or "slirp"
 if NET_MODE not in ("slirp", "bridge"):
     raise ValueError(f"SMOKE_NET_MODE must be 'slirp' or 'bridge' (got {NET_MODE!r})")
 

--- a/tests/test_smoke_net_mode.py
+++ b/tests/test_smoke_net_mode.py
@@ -160,6 +160,19 @@ class TestSlirpDefault:
         assert mod.DEFAULT_CLIENT_SSH_PORT == 2223
         assert mod.DEFAULT_STUB_DNS_ADDR == "127.0.0.1"
 
+    def test_empty_net_mode_reads_as_slirp(self) -> None:
+        """An EMPTY SMOKE_NET_MODE reads as slirp, not a ValueError (regression guard).
+
+        A workflow expression like ``SMOKE_NET_MODE: ${{ inputs.net_mode }}`` sets the env
+        var to "" on a schedule / no-input event. conftest must treat that as slirp (matching
+        boot_vm.sh's ``${SMOKE_NET_MODE:-slirp}``); the pre-fix ``get(key, "slirp")`` kept ""
+        and raised ValueError on import, crashing the nightly UI run (run 28361863025).
+        """
+        mod = _load_conftest(net_mode="")
+        assert mod.NET_MODE == "slirp", f"expected slirp; got {mod.NET_MODE!r}"
+        assert mod.DEFAULT_HOST == "127.0.0.1"
+        assert mod.DEFAULT_STUB_DNS_ADDR == "127.0.0.1"
+
 
 # ---------------------------------------------------------------------------
 # 2 — bridge flips the endpoints (RED→GREEN: fails on pre-P3 code)


### PR DESCRIPTION
## Fix: empty `SMOKE_NET_MODE` crashes the nightly UI suite (ADR-50 regression)

### What broke
The scheduled UI run [#28361863025](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28361863025) failed at conftest import:

```text
SMOKE_NET_MODE:
ValueError: SMOKE_NET_MODE must be 'slirp' or 'bridge' (got '')   ← exit 4
```

### Root cause
ADR-50 P3 added a strict guard to `tests/smoke/conftest.py`:
`NET_MODE = os.environ.get("SMOKE_NET_MODE", "slirp")` — which **keeps an empty string** (the default only applies when the key is *absent*). `ui-tests.yml` runs on a `schedule`, and on a schedule event `inputs.net_mode` is empty, so `SMOKE_NET_MODE: ${{ inputs.net_mode }}` sets the env var to `""`. conftest then imports with `NET_MODE=""`, fails the `in ("slirp","bridge")` check, and raises — crashing the whole UI suite. `boot_vm.sh` was unaffected because it uses `${SMOKE_NET_MODE:-slirp}`, which treats empty as slirp; conftest didn't match that.

### Fix
- **`conftest.py` (root cause):** `os.environ.get("SMOKE_NET_MODE") or "slirp"` — empty == unset == slirp, matching `boot_vm.sh`'s `:-`.
- **`ui-tests.yml` + `smoke-single.yml` (belt):** `SMOKE_NET_MODE: ${{ inputs.net_mode || 'slirp' }}` so the env is never emitted empty.
- **Regression test** `test_empty_net_mode_reads_as_slirp` — fails on the pre-fix code (ValueError on import), passes now.

### Scope
This fixes only the empty-`SMOKE_NET_MODE` regression introduced by ADR-50 (PR #616). The earlier scheduled UI failures (06-26/27/28) predate that change and are a **separate, pre-existing** cause — not addressed here.

Gates: pytest `tests/test_smoke_net_mode.py` 30 passed (incl. the new red→green test), ruff + actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
