### PR TITLE
ci: minimal clone for the ports-fork bump (shallow+blobless+sparse)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1126,7 +1126,17 @@ jobs:
           repository: pfBlockerNG/FreeBSD-ports
           ref: pfblockerng/use-github
           token: ${{ steps.ports-token.outputs.token }}
-          fetch-depth: 0
+          # Minimal clone: the bump only edits the port Makefile(s), then commits + pushes.
+          # Shallow (depth-1) + blobless + sparse to the bumped port dirs avoids cloning the
+          # full ~1.3 GB ports tree. The commit is a fast-forward the remote accepts; the
+          # push-reject rebase retry below reaches the racing tip via an on-demand fetch.
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: |
+            net/pfSense-pkg-pfBlockerNG
+            net/pfSense-pkg-pfBlockerNG-devel
+            net/pfSense-pkg-pfBlockerNG-nightly
+          sparse-checkout-cone-mode: true
 
       - name: Checkout pfBlockerNG (scripts only — sparse)
         uses: actions/checkout@v6


### PR DESCRIPTION
## Minimal clone for the FreeBSD-ports fork bump

The `sync-ports-fork` job (release pipeline) checked out the FreeBSD-ports fork with `fetch-depth: 0` — the full ~1.3 GB tree with all history and all blobs — solely to `sed` the `PORTVERSION`/`PORTREVISION` in one or two port Makefiles, then one commit + push. That's the slow `Sync port on FreeBSD-ports fork` step.

This switches that checkout to a minimal clone:
- `fetch-depth: 1` (shallow), `filter: blob:none` (blobless partial clone), `sparse-checkout` limited to the bumped port dirs (`net/pfSense-pkg-pfBlockerNG{,-devel,-nightly}`), cone mode.

The same blobless+sparse approach the build path already uses (`sparse-clone-ports.sh`, ~30 MB/3 s vs ~1.3 GB/37 s).

### Why it's commit/push-safe
- The job only edits/commits the port Makefile(s), which are in the sparse set; the rest of the tree rides along by reference, so the push carries an intact tree.
- The bump commit is a fast-forward on the branch tip the remote already has.
- The push-reject **rebase retry** (`git pull --rebase origin pfblockerng/use-github`) reaches a racing tip via an on-demand fetch; `use-github` advances ~one commit per release, so the merge-base is the cloned tip — within reach of depth-1.

The pfBlockerNG full-history checkouts (tag ancestry / ci-metadata / changelog) are deliberately left at `fetch-depth: 0`.

Validated by the **next** release's port bump (no off-CI unit test for a workflow checkout-options change; actionlint clean on this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
