### PR TITLE
pfblockerng: fix title-bar syslog shortcut 404 (root-absolute href)

### DIFF
--- a/src/usr/local/www/shortcuts/pkg_pfblockerng.inc
+++ b/src/usr/local/www/shortcuts/pkg_pfblockerng.inc
@@ -27,11 +27,19 @@ $shortcuts['pfblockerng'] = array();
 // pfBlockerNG's syslog (ADR-38) is a <logging>-registered package log, surfaced under
 // Status > System Logs > Packages. Resolve the channel-correct package name
 // (pfBlockerNG vs pfBlockerNG-devel) from its configurationfile so the link is right on
-// either channel. installedpackages/package is a pfSense-core section (not a registered
-// pfblockerng config scalar), so this read is outside the ADR-29 config-gateway scope.
+// either channel. The package name is required: status_logs_packages.php selects the log
+// via get_package_id($_GET['pkg']), which matches installedpackages/package/name — so the
+// query string must carry the real variant name, not a fixed "pfBlockerNG".
+// installedpackages/package is a pfSense-core section (not a registered pfblockerng config
+// scalar), so this read is outside the ADR-29 config-gateway scope.
+//
+// The href is ROOT-ABSOLUTE ("/status_logs_packages.php..."): head.inc emits the 'log'
+// value verbatim, and pfBlockerNG's GUI pages live under /pfblockerng/, so a relative
+// value would resolve to /pfblockerng/status_logs_packages.php and 404. (cmp_page_matches
+// ltrim()s the leading slash, so the privilege gate is unaffected.)
 foreach (config_get_path('installedpackages/package', array()) as $pfb_pkg) {
 	if (($pfb_pkg['configurationfile'] ?? '') === 'pfblockerng.xml') {
-		$shortcuts['pfblockerng']['log'] = 'status_logs_packages.php?pkg=' . $pfb_pkg['name'];
+		$shortcuts['pfblockerng']['log'] = '/status_logs_packages.php?pkg=' . $pfb_pkg['name'];
 		break;
 	}
 }

--- a/tests/smoke/ui/test_render_shortcut.py
+++ b/tests/smoke/ui/test_render_shortcut.py
@@ -3,19 +3,23 @@ syslog shortcut icon.
 
 Every pfBlockerNG page sets ``$shortcut_section = 'pfblockerng'`` before including
 ``head.inc``.  ``head.inc`` reads ``$shortcuts['pfblockerng']['log']`` from
-``shortcuts/pkg_pfblockerng.inc`` and renders a log-link anchor whose ``href``
-contains ``status_logs_packages.php?pkg=``.  These tests pin that contract.
+``shortcuts/pkg_pfblockerng.inc`` and renders a log-link anchor whose ``href`` is the
+ROOT-ABSOLUTE ``/status_logs_packages.php?pkg=``.  These tests pin that contract.
+
+The href MUST be root-absolute: pfBlockerNG's GUI pages live under ``/pfblockerng/`` and
+head.inc emits the value verbatim, so a relative ``status_logs_packages.php?pkg=`` would
+resolve to ``/pfblockerng/status_logs_packages.php`` and 404.  The tests therefore assert
+the leading slash, not merely that the substring is present.
 
 Tier-A (``ui_render``) -- hermetic HTTP GET only:
-  ``test_shortcut_log_link_rendered`` — GET the General page and assert the rendered
-  body contains ``status_logs_packages.php?pkg=``.  On pre-change code (no shortcut
-  file, no ``$shortcut_section``) that substring is absent, so this is a real
-  fail-before / pass-after discriminator.
+  ``test_shortcut_log_link_rendered`` — GET the General page and assert the rendered body
+  contains the absolute ``href="/status_logs_packages.php?pkg=`` and does NOT contain the
+  relative (subdir-resolving) ``href="status_logs_packages.php?pkg=``.
 
 Tier-B (``ui_browser``) -- Playwright DOM inspection:
-  ``test_shortcut_log_anchor_in_dom`` — load the General page in the authenticated
-  browser and assert the title-bar log-shortcut anchor is present with an ``href``
-  containing ``status_logs_packages.php?pkg=``.
+  ``test_shortcut_log_anchor_in_dom`` — load the General page in the authenticated browser
+  and assert the title-bar log-shortcut anchor is present with a root-absolute ``href``
+  (starts with ``/status_logs_packages.php?pkg=``).
 """
 
 from __future__ import annotations
@@ -31,9 +35,12 @@ if TYPE_CHECKING:
 # data needed, good witness for the shortcut chrome that appears on every page.
 _GENERAL_PAGE = "/pfblockerng/pfblockerng_general.php"
 
-# The substring that head.inc renders when $shortcuts['pfblockerng']['log'] is set.
-# Present in the href of the log-shortcut anchor ("<a href='...' ...>").
-_SHORTCUT_NEEDLE = "status_logs_packages.php?pkg="
+# head.inc renders the log-shortcut as <a href="..."> with the 'log' value verbatim.
+# The href MUST be root-absolute (leading slash) so it resolves from the web root, not
+# from the /pfblockerng/ subdir the GUI pages live in.
+_ABS_HREF = 'href="/status_logs_packages.php?pkg='
+# The pre-fix relative form, which the browser resolves to /pfblockerng/...  -> 404.
+_REL_HREF = 'href="status_logs_packages.php?pkg='
 
 
 # ---------------------------------------------------------------------------
@@ -43,7 +50,7 @@ _SHORTCUT_NEEDLE = "status_logs_packages.php?pkg="
 
 @pytest.mark.ui_render
 def test_shortcut_log_link_rendered(webui: WebUI) -> None:
-    """The General page body contains the rendered syslog shortcut link.
+    """The General page renders the syslog shortcut link with a root-absolute href.
 
     Scenario: pfBlockerNG title-bar shortcut icon links to the package syslog.
       Background: pfBlockerNG deployed; shortcuts/pkg_pfblockerng.inc installed;
@@ -53,22 +60,28 @@ def test_shortcut_log_link_rendered(webui: WebUI) -> None:
 
       When GET /pfblockerng/pfblockerng_general.php,
 
-      Then the response body contains the rendered log-shortcut href substring
-        ``status_logs_packages.php?pkg=`` — proving head.inc rendered the anchor
-        from $shortcuts['pfblockerng']['log'] (absent on pre-change code where
-        neither the shortcut file nor $shortcut_section existed).
+      Then the response body contains the rendered log-shortcut anchor with a
+        root-absolute href ``href="/status_logs_packages.php?pkg=`` and NOT the
+        relative ``href="status_logs_packages.php?pkg=`` form.
 
-    Fail-before / pass-after: on origin/devel (before this change) the shortcut
-    file does not exist and no page sets $shortcut_section, so the substring is
-    absent and this assertion FAILS.  After the change both are present, the
-    assertion PASSES.
+    Fail-before / pass-after: the GUI pages live under /pfblockerng/, so the
+    relative href the shortcut originally emitted resolved to
+    /pfblockerng/status_logs_packages.php and 404'd.  Before the fix the body
+    carries the relative form (no leading slash), so the absolute assertion FAILS;
+    after the fix it carries the absolute form and PASSES.  The "relative absent"
+    assertion guards against a regression back to the subdir-resolving href.
     """
     resp = webui.get(_GENERAL_PAGE)
     assert resp.status_code == 200, f"GET {_GENERAL_PAGE} -> HTTP {resp.status_code} (expected 200)"
-    assert _SHORTCUT_NEEDLE in resp.text, (
-        f"Syslog shortcut href {_SHORTCUT_NEEDLE!r} not found in {_GENERAL_PAGE} body "
+    assert _ABS_HREF in resp.text, (
+        f"Root-absolute syslog shortcut href {_ABS_HREF!r} not found in {_GENERAL_PAGE} body "
         f"-- expected head.inc to render the log-shortcut anchor from "
-        f"$shortcuts['pfblockerng']['log'] (pkg_pfblockerng.inc + $shortcut_section)"
+        f"$shortcuts['pfblockerng']['log'] with a leading slash (pkg_pfblockerng.inc + "
+        f"$shortcut_section)"
+    )
+    assert _REL_HREF not in resp.text, (
+        f"Relative syslog shortcut href {_REL_HREF!r} found in {_GENERAL_PAGE} body -- it "
+        f"resolves against the /pfblockerng/ subdir and 404s; the href must be root-absolute"
     )
 
 
@@ -91,7 +104,7 @@ def test_shortcut_log_anchor_in_dom(
     browser_page: Page,
     webui: WebUI,
 ) -> None:
-    """The title-bar log-shortcut anchor is present in the live DOM with the correct href.
+    """The title-bar log-shortcut anchor is present in the live DOM with a root-absolute href.
 
     Scenario: pfBlockerNG title-bar shortcut icon links to the package syslog (Tier B).
       Background: pfBlockerNG deployed with the shortcut file + $shortcut_section wired.
@@ -100,13 +113,14 @@ def test_shortcut_log_anchor_in_dom(
 
       When the DOM is inspected for the pfSense shortcuts log-link anchor,
 
-      Then exactly one anchor whose href contains ``status_logs_packages.php?pkg=``
-        is attached to the document -- proving the title-bar shortcut icon rendered
-        the correct log link.
+      Then an anchor whose href STARTS WITH ``/status_logs_packages.php?pkg=``
+        (root-absolute) is attached to the document, and no anchor carries the
+        relative ``status_logs_packages.php?pkg=`` href -- proving the title-bar
+        shortcut links to the web-root log page, not the /pfblockerng/ subdir.
 
-    Fail-before / pass-after: without $shortcut_section + the shortcut file, head.inc
-    emits no such anchor, so the ``count() > 0`` assertion FAILS on pre-change code
-    and PASSES after the change.
+    Fail-before / pass-after: before the fix the anchor's href is relative (no
+    leading slash), so the ``[href^="/status_logs_packages.php?pkg="]`` selector
+    matches nothing and the assertion FAILS; after the fix it matches and PASSES.
     """
     # The browser_page fixture already importorskips playwright, so it is present here.
     expect = pytest.importorskip("playwright.sync_api").expect
@@ -122,11 +136,12 @@ def test_shortcut_log_anchor_in_dom(
         f"GET {_GENERAL_PAGE} showed the login form -- cookie not authenticated"
     )
 
-    # head.inc renders the log-shortcut as an <a href="...status_logs_packages.php?pkg=...">
-    # anchor in the title-bar shortcuts area.  Assert it is present in the live DOM.
-    log_anchor = page.locator(f'a[href*="{_SHORTCUT_NEEDLE}"]')
+    # head.inc renders the log-shortcut as an <a href="/status_logs_packages.php?pkg=...">
+    # anchor in the title-bar shortcuts area.  Assert it is present and root-absolute.
+    log_anchor = page.locator('a[href^="/status_logs_packages.php?pkg="]')
     assert log_anchor.count() > 0, (
-        f"No anchor with href containing {_SHORTCUT_NEEDLE!r} found in the DOM "
-        f"of {_GENERAL_PAGE} -- title-bar syslog shortcut not rendered"
+        'No anchor with a root-absolute href starting "/status_logs_packages.php?pkg=" '
+        f"found in the DOM of {_GENERAL_PAGE} -- title-bar syslog shortcut not rendered "
+        f"or its href is relative (resolves to the /pfblockerng/ subdir and 404s)"
     )
     expect(log_anchor.first).to_be_attached(timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_render_shortcut.py
+++ b/tests/smoke/ui/test_render_shortcut.py
@@ -144,4 +144,13 @@ def test_shortcut_log_anchor_in_dom(
         f"found in the DOM of {_GENERAL_PAGE} -- title-bar syslog shortcut not rendered "
         f"or its href is relative (resolves to the /pfblockerng/ subdir and 404s)"
     )
+    # Negative side: no anchor carries the relative (subdir-resolving) href.  The attribute
+    # selector matches the raw href, so a "status_logs_packages.php?pkg=" prefix (no leading
+    # slash) is the pre-fix regression -- it must be absent.
+    rel_anchor = page.locator('a[href^="status_logs_packages.php?pkg="]')
+    assert rel_anchor.count() == 0, (
+        'Found anchor with a relative href starting "status_logs_packages.php?pkg=" in the DOM '
+        f"of {_GENERAL_PAGE} -- it resolves against the /pfblockerng/ subdir and 404s; the href "
+        f"must be root-absolute"
+    )
     expect(log_anchor.first).to_be_attached(timeout=JS_TIMEOUT_MS)


### PR DESCRIPTION
## Problem

The pfBlockerNG title-bar **"Related log entries"** shortcut icon (added in PR #552) linked to a **relative** URL:

```text
status_logs_packages.php?pkg=pfBlockerNG-devel
```

`head.inc` emits the shortcut's `log` value verbatim into the anchor `href`, and pfBlockerNG's GUI pages live under `/pfblockerng/`. So the browser resolves the relative href against the current directory:

```text
/pfblockerng/status_logs_packages.php?pkg=pfBlockerNG-devel   → 404
```

The page actually lives at the web root (`/status_logs_packages.php`).

## Fix

Make the href root-absolute by prefixing it with `/`:

```php
$shortcuts['pfblockerng']['log'] = '/status_logs_packages.php?pkg=' . $pfb_pkg['name'];
```

The privilege gate is unaffected — `cmp_page_matches()` `ltrim()`s the leading slash and resolves the file against the www root, so `/status_logs_packages.php?...` and `status_logs_packages.php?...` normalize identically.

## On the `?pkg=` value (the cosmetic ask)

The query string keeps the **channel-correct** package name (`pfBlockerNG` vs `pfBlockerNG-devel`), not a fixed `pfBlockerNG`: `status_logs_packages.php` selects the log via `get_package_id($_GET['pkg'])`, which matches `installedpackages/package/name`. A hardcoded `pfBlockerNG` would fail the lookup on the devel package. The Status > System Logs > **Packages** subtab label already reads "pfBlockerNG" on both channels via the `<logging>` `logtab`, so the only place the variant name shows is the URL — where it's required.

## Tests

The existing Tier-A/Tier-B shortcut tests asserted the href merely *contained* `status_logs_packages.php?pkg=`, which matched the broken relative form too — so they never caught this. Tightened to assert the **root-absolute** href and that the relative form is **absent**: a real fail-before / pass-after discriminator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a pfBlockerNG shortcut link so it opens correctly from the expected location.
  * Prevented the syslog shortcut from resolving as a relative path in the UI.
* **Tests**
  * Updated shortcut rendering checks to verify the link uses a root-absolute URL.
  * Added coverage to ensure the relative link format is no longer present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->