### PR TITLE
pfblockerng: Update page — Force modes, Cron Status fix, button/radio spacing

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -779,9 +779,15 @@ midnight-wrapping ranges.
 ### Operator surface — the Update page & the knobs
 
 The **Update page** (`www/pfblockerng/pfblockerng_update.php`) is rebuilt on the API: an explicit
-**Run Scope** selector (`pfb_scope`: ip/dnsbl/both) + a **Force Reparse** toggle (`pfb_run_force`)
-feeding one **Run now** that POSTs `pfb_trigger`; a read-only **Schedule** view sourced from the
-ledger (last-run / next-due per job); a tidied update-log pane. No raw verb strings in the UI.
+**Run Scope** selector (`pfb_scope`: ip/dnsbl/both) + a **Force** radio group (`pfb_force_mode`:
+none/parse/download/both) feeding one **Run now**. **None** — plain detector-respecting pass via
+`pfb_trigger`. **Parse** — reparse cached lists without re-downloading (`force=true`). **Download**
+— clear `.etag`/`.lastmod` sidecars for in-scope feeds, then run the per-feed detector
+on-demand (bypassing the hour-gate) via the `forcecheck` verb so every feed is re-fetched; feeds
+whose body is unchanged are still skipped. **Both** — also clears `.xxhash128`/`.md5` hash sidecars
+so every re-fetched feed re-ingests regardless of content. A read-only **Schedule** view is sourced
+from the ledger (last-run / next-due per job); a tidied update-log pane. No raw verb strings in
+the UI.
 
 Two registered `PfbConfig` knobs (ADR-29), both with safe defaults and **no GUI control** — set via
 config/CLI for advanced tuning:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10154,6 +10154,31 @@ function pfb_validator_write($base, $etag, $lastmod) {
 	}
 }
 
+// ADR-43 Force modes: clear the per-feed conditional-GET sidecars so an on-demand detector
+// run re-fetches every in-scope list file (no ETag/Last-Modified to send => the server returns
+// 200 + body instead of 304).  Sweeps {dir}/*.orig.etag and *.orig.lastmod in each $dir; when
+// $clear_hashes is TRUE also removes *.orig.xxhash128 and *.orig.md5 so a re-fetched body has no
+// baseline to compare against and every list re-ingests regardless of content.  The .orig content
+// files are left intact.  Returns the number of sidecars removed.
+function pfb_force_clear_validators(array $dirs, bool $clear_hashes): int {
+	$suffixes = array('etag', 'lastmod');
+	if ($clear_hashes) {
+		$suffixes[] = 'xxhash128';
+		$suffixes[] = 'md5';
+	}
+	$removed = 0;
+	foreach ($dirs as $dir) {
+		foreach ($suffixes as $sfx) {
+			foreach (glob("{$dir}/*.orig.{$sfx}") ?: array() as $sidecar) {
+				if (unlink_if_exists($sidecar)) {
+					$removed++;
+				}
+			}
+		}
+	}
+	return $removed;
+}
+
 // ADR-42 Phase 3: pure decision helper for the remote conditional-GET result.
 // Called by the detector after pfb_download returns the probe response.
 //

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10179,6 +10179,20 @@ function pfb_force_clear_validators(array $dirs, bool $clear_hashes): int {
 	return $removed;
 }
 
+// ADR-43 Force modes: map a Run Now scope to the feed orig dir(s) it covers — 'ip' => the IP
+// orig dir, 'dnsbl' => the DNSBL orig dir, 'both' (and any unrecognized scope, fail-safe) =>
+// both. Pure (the two dir paths are passed in) so it is unit-testable off-appliance; the
+// Update page feeds it $pfb['origdir'] and $pfb['dnsorigdir'].
+function pfb_force_scope_dirs(string $scope, string $ip_origdir, string $dnsbl_origdir): array {
+	if ($scope === 'ip') {
+		return array($ip_origdir);
+	}
+	if ($scope === 'dnsbl') {
+		return array($dnsbl_origdir);
+	}
+	return array($ip_origdir, $dnsbl_origdir);
+}
+
 // ADR-42 Phase 3: pure decision helper for the remote conditional-GET result.
 // Called by the detector after pfb_download returns the probe response.
 //

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2238,6 +2238,34 @@ function pfb_tick_interval_clamp(string $raw): int
 }
 
 /**
+ * pfb_next_tick_boundary — when does the next cron tick fire?
+ *
+ * The ADR-43 scheduler is one cron tick that fires every $tick_min minutes (the cron minute
+ * field is "star-slash-N"), so it runs at each minute-of-hour that is a multiple of $tick_min,
+ * rolling to :00 of the next hour. Given the current wall-clock, returns the next boundary so
+ * the Update page can show "next run at" and "time remaining" for the actual scheduled cron
+ * (not the legacy per-feed interval cadence).
+ *
+ * @param int $tick_min  Clamped tick interval in minutes (see pfb_tick_interval_clamp).
+ * @param int $cur_hour  Current hour (0–23).
+ * @param int $cur_min   Current minute (0–59).
+ * @param int $cur_sec   Current second (0–59).
+ * @return array{0:int,1:int,2:int}  [next_hour (0–23), next_min (0–59), seconds_remaining].
+ */
+function pfb_next_tick_boundary(int $tick_min, int $cur_hour, int $cur_min, int $cur_sec): array
+{
+	$tick_min = max(1, $tick_min);
+	$cur_hour_sec = ($cur_min * 60) + $cur_sec;
+
+	$next_min = (intdiv($cur_min, $tick_min) + 1) * $tick_min;
+	if ($next_min >= 60) {
+		// The minute field never fires past :59, so it rolls to :00 of the next hour.
+		return [($cur_hour + 1) % 24, 0, 3600 - $cur_hour_sec];
+	}
+	return [$cur_hour, $next_min, ($next_min * 60) - $cur_hour_sec];
+}
+
+/**
  * pfb_tick_seed — stable per-install seed for the due-ledger jitter.
  *
  * Uses the system hostname (stable across reboots unless the admin changes it).

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -234,7 +234,7 @@ if ($argv[1] == 'bl' || $argv[1] == 'bls') {
 }
 
 // Call include file and collect updated Global settings
-if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', 'bu', 'uc', 'gc', 'al', 'asn', 'asn_shell', 'bl', 'bls', 'cron', 'ugc', 'pfb_trigger', 'tick'))) {
+if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', 'bu', 'uc', 'gc', 'al', 'asn', 'asn_shell', 'bl', 'bls', 'cron', 'ugc', 'pfb_trigger', 'tick', 'forcecheck'))) {
 	pfb_global();
 
 	$pfb['extras_update'] = FALSE;  // Flag when Extras (MaxMind/TOP1M) are updateded via cron job
@@ -277,6 +277,23 @@ if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', '
 				$pfb_ttrigger = 'manual';
 			}
 			sync_package_pfblockerng(array('scope' => $pfb_tscope, 'force' => $pfb_tforce, 'trigger' => $pfb_ttrigger));
+			break;
+		case 'forcecheck':	// On-demand detector: bypass hour-gate, run pfb_update_check for all in-scope feeds.
+			// Usage: pfblockerng.php forcecheck scope=<both|ip|dnsbl>
+			// Validators (and optionally hashes) must be cleared by the caller before dispatching
+			// this verb so the detector re-fetches and re-evaluates feed content.
+			$pfb_fcscope = 'both';
+			foreach (array_slice($argv, 2) as $pfb_fcarg) {
+				if (str_starts_with($pfb_fcarg, 'scope=')) {
+					$pfb_fcscope = substr($pfb_fcarg, 6);
+				}
+			}
+			if (!in_array($pfb_fcscope, array('ip', 'dnsbl', 'both'), TRUE)) {
+				pfb_logger("forcecheck: unknown scope={$pfb_fcscope} ignored — defaulting to 'both'\n", 1);
+				$pfb_fcscope = 'both';
+			}
+			pfb_logger("\n [ Force check - scope={$pfb_fcscope} ]\n", 1);
+			pfblockerng_sync_cron(TRUE, $pfb_fcscope);
 			break;
 		case 'dc':		// Update Extras - MaxMind/TOP1M/ASN database files
 		case 'dcc':
@@ -689,8 +706,13 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 	}
 }
 
-// Function to update Lists/Feeds as per Cron
-function pfblockerng_sync_cron() {
+// Function to update Lists/Feeds as per Cron.
+// $force_all — when TRUE, bypass the per-list hour-gate and call pfb_update_check()
+//   unconditionally for every non-disabled, non-Hold, non-Never row (used by forcecheck).
+//   Defaults to FALSE to preserve the existing cron behaviour byte-identically.
+// $scope — 'both' (default), 'ip', or 'dnsbl'; filters which list types are probed.
+//   Defaults to 'both' so existing callers (case 'cron') are unchanged.
+function pfblockerng_sync_cron($force_all = FALSE, $scope = 'both') {
 	global $pfb, $pfbarr;
 
 	$hour = date('G');
@@ -701,6 +723,11 @@ function pfblockerng_sync_cron() {
 
 	$list_type = array('pfblockernglistsv4' => '_v4', 'pfblockernglistsv6' => '_v6', 'pfblockerngdnsbl' => '_v4');
 	foreach ($list_type as $ltype => $vtype) {
+		// Scope filter: skip list types not covered by $scope.
+		$is_dnsbl = ($ltype === 'pfblockerngdnsbl');
+		if ($scope === 'ip'    &&  $is_dnsbl) { continue; }
+		if ($scope === 'dnsbl' && !$is_dnsbl) { continue; }
+
 		foreach (config_get_path("installedpackages/{$ltype}/config", []) as $list) {
 			if (isset($list['row']) && $list['action'] != 'Disabled' && $list['cron'] != 'Never') {
 				foreach ($list['row'] as $row) {
@@ -742,23 +769,28 @@ function pfblockerng_sync_cron() {
 							$pflex = TRUE;
 						}
 
-						switch ($list['cron']) {
-							case 'EveryDay':
-								if ($hour == $pfb['24hour']) {
-									pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
-								}
-								break;
-							case 'Weekly':
-								if ($hour == $pfb['24hour'] && $dow == $list['dow']) {
-									pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
-								}
-								break;
-							default:
-								$pfb_sch = pfb_cron_base_hour($list['cron']);
-								if (in_array($hour, $pfb_sch)) {
-									pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
-								}
-								break;
+						if ($force_all) {
+							// Bypass the hour-gate: check every in-scope feed unconditionally.
+							pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
+						} else {
+							switch ($list['cron']) {
+								case 'EveryDay':
+									if ($hour == $pfb['24hour']) {
+										pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
+									}
+									break;
+								case 'Weekly':
+									if ($hour == $pfb['24hour'] && $dow == $list['dow']) {
+										pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
+									}
+									break;
+								default:
+									$pfb_sch = pfb_cron_base_hour($list['cron']);
+									if (in_array($hour, $pfb_sch)) {
+										pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
+									}
+									break;
+							}
 						}
 					}
 				}

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -75,7 +75,7 @@ function pfb_runnow(string $scope, bool $force): void {
 
 	// Check for any active pfBlockerNG process before dispatching.
 	exec('/bin/ps -wax', $result_ps);
-	if (preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick)/', $result_ps)) {
+	if (preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick|forcecheck)/', $result_ps)) {
 		pfbupdate_status(gettext('Run Now skipped — an active pfBlockerNG task is running.'));
 		return;
 	}
@@ -114,6 +114,43 @@ function pfb_runnow(string $scope, bool $force): void {
 	}
 }
 
+// Dispatch the on-demand detector (forcecheck verb) via mwexec_bg, stream log output,
+// and update the due ledger — same active-process guard and livetail as pfb_runnow().
+// Callers must clear the appropriate sidecars (pfb_force_clear_validators) BEFORE calling
+// this so pfblockerng_sync_cron($force_all=TRUE) re-fetches every in-scope feed.
+function pfb_runnow_forcecheck(string $scope): void {
+	global $pfb;
+
+	// Active-process guard — same check as pfb_runnow().
+	exec('/bin/ps -wax', $result_ps);
+	if (preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick|forcecheck)/', $result_ps)) {
+		pfbupdate_status(gettext('Run Now skipped — an active pfBlockerNG task is running.'));
+		return;
+	}
+
+	if (!file_exists("{$pfb['log']}")) {
+		touch("{$pfb['log']}");
+	}
+
+	$scope_esc = escapeshellarg($scope);
+
+	pfbupdate_status(gettext("Running: scope={$scope} force=download/both (on-demand detector)"));
+
+	install_cron_job('pfblockerng.php tick', FALSE);
+
+	pfb_logger("\n [ Force check - scope={$scope} ]\n", 1);
+
+	$now = time();
+	mwexec_bg("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php forcecheck scope={$scope_esc} >> {$pfb['log']} 2>&1");
+
+	pfb_livetail($pfb['log'], 'force');
+
+	if ($scope === 'both') {
+		$interval = ((int)($pfb['interval'] ?: 1)) * 3600;
+		pfb_due_ledger_mark_ran('cron', $interval, $now, pfb_tick_seed(), 0, $pfb['dbdir']);
+	}
+}
+
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Update'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '@self');
 $shortcut_section = 'pfblockerng';
@@ -124,13 +161,13 @@ if ($_POST) {
 	$pconfig = $_POST;
 }
 
-// Wizard handler (updated to Phase-3 API: scope=both force-reparse).
+// Wizard handler (updated to Phase-3 API: scope=both, force=parse).
 $pfb_wizard = FALSE;
 if (isset($_GET) && isset($_GET['wizard']) && $_GET['wizard'] == 'reload') {
-	$pconfig['run']           = '';
-	$pconfig['pfb_scope']     = 'both';
-	$pconfig['pfb_run_force'] = 'on';	// reparse = Force Reload equivalent
-	$pfb_wizard               = TRUE;
+	$pconfig['run']            = '';
+	$pconfig['pfb_scope']      = 'both';
+	$pconfig['pfb_force_mode'] = 'parse';	// reparse cached lists, no re-download
+	$pfb_wizard                = TRUE;
 }
 
 // Validate user-supplied scope; default to 'both' for unexpected input.
@@ -200,7 +237,7 @@ $status = 'NEXT Scheduled CRON Event will run at'
 
 // Query for any active pfBlockerNG task
 exec('/bin/ps -wax', $result_ps);
-if (preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick)/', $result_ps)) {
+if (preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick|forcecheck)/', $result_ps)) {
 	$status = '<span style="color: red;">&emsp;&emsp;'
 		. 'Active pfBlockerNG CRON JOB'
 		. '</span>&emsp;<i class="fa-solid fa-spinner fa-pulse fa-lg"></i>';
@@ -268,15 +305,20 @@ $group->add(new Form_Checkbox(
 $group->setHelp('Which lists to sync on Run Now: Both, IP-only, or DNSBL-only.');
 $section->add($group);
 
-// Force Reparse toggle
-$group = new Form_Group('Force Reparse');
-$group->add(new Form_Checkbox(
-	'pfb_run_force',
-	NULL,
-	'Reparse',
-	isset($pconfig['pfb_run_force']) && $pconfig['pfb_run_force'] === 'on'
-))->setAttribute('title', 'Reparse cached downloads even if no changes are detected.');
-$group->setHelp('When checked, reprocesses existing downloaded files without re-checking for changes.');
+// Force mode — mutually-exclusive radios. None = a plain detector-respecting run.
+$pfb_force_mode = $pconfig['pfb_force_mode'] ?? 'none';
+$group = new Form_Group('Force');
+$group->add(new Form_Checkbox('pfb_force_mode', NULL, 'None',     $pfb_force_mode === 'none',     'none'))
+	->displayAsRadio('pfb_force_none')->setAttribute('title', 'Normal run — reload only what changed.')->setWidth(2);
+$group->add(new Form_Checkbox('pfb_force_mode', NULL, 'Parse',    $pfb_force_mode === 'parse',    'parse'))
+	->displayAsRadio('pfb_force_parse')->setAttribute('title', 'Reload all lists regardless of changes (no re-download).')->setWidth(2);
+$group->add(new Form_Checkbox('pfb_force_mode', NULL, 'Download', $pfb_force_mode === 'download', 'download'))
+	->displayAsRadio('pfb_force_download')->setAttribute('title', 'Re-fetch all list files (reload only if changes are detected).')->setWidth(2);
+$group->add(new Form_Checkbox('pfb_force_mode', NULL, 'Both',     $pfb_force_mode === 'both',     'both'))
+	->displayAsRadio('pfb_force_both')->setAttribute('title', 'Re-fetch all list files and reload all lists regardless of changes.')->setWidth(2);
+$group->setHelp('Parse: reload all lists regardless of changes (no re-download). '
+	. 'Download: re-fetch all list files (reload only if changes are detected). '
+	. 'Both: re-fetch all list files and reload all lists regardless of changes.');
 $section->add($group);
 
 $group = new Form_Group(NULL);
@@ -371,12 +413,26 @@ if (isset($pconfig['log_view'])) {
 	}
 }
 
-// Run Now handler — dispatches pfb_trigger via the Phase-3 explicit API.
+// Run Now handler — dispatches pfb_trigger or forcecheck depending on force mode.
 if (pfb_cfg_toggle_read($pfb['enable']) === PfbToggle::On && isset($pconfig['run']) &&
     isset($pconfig['pfb_scope']) && !empty($pconfig['pfb_scope'])) {
-	$scope = in_array($pconfig['pfb_scope'], $pfb_allowed_scopes, TRUE) ? $pconfig['pfb_scope'] : 'both';
-	$force = isset($pconfig['pfb_run_force']) && $pconfig['pfb_run_force'] === 'on';
-	pfb_runnow($scope, $force);
+	$scope      = in_array($pconfig['pfb_scope'], $pfb_allowed_scopes, TRUE) ? $pconfig['pfb_scope'] : 'both';
+	$force_mode = $pconfig['pfb_force_mode'] ?? 'none';
+	if (!in_array($force_mode, array('none', 'parse', 'download', 'both'), TRUE)) {
+		$force_mode = 'none';
+	}
+	if ($force_mode === 'download' || $force_mode === 'both') {
+		// Clear the scoped conditional-GET sidecars, then run the detector on-demand so it
+		// re-fetches (200) and re-ingests changed feeds (Both also clears the hash => all).
+		$dirs = ($scope === 'ip')    ? array($pfb['origdir'])
+		      : (($scope === 'dnsbl') ? array($pfb['dnsorigdir'])
+		      : array($pfb['origdir'], $pfb['dnsorigdir']));
+		pfb_force_clear_validators($dirs, $force_mode === 'both');
+		pfb_runnow_forcecheck($scope);
+	} else {
+		// none -> plain pass; parse -> reuse=on (reparse cached, no download).
+		pfb_runnow($scope, $force_mode === 'parse');
+	}
 
 	if ($pfb_wizard) {
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -161,104 +161,35 @@ $tab_array_sub[]	= array(gettext('Run'),		TRUE,	'/pfblockerng/pfblockerng_update
 $tab_array_sub[]	= array(gettext('Hooks'),	FALSE,	'/pfblockerng/pfblockerng_hooks.php');
 display_top_tabs($tab_array_sub, TRUE);
 
+// ADR-43: the scheduler is a single */pfb_tick_interval cron tick that fires every hour ('*'),
+// installed iff pfBlockerNG is enabled (the feed `interval` only gates the feed job *inside* the
+// tick, not the tick itself). So the "NEXT Scheduled CRON Event" tracks the tick boundary; the
+// per-feed cadence lives in the Schedule view below.
+$pfb_tick_min = pfb_tick_interval_clamp(PfbConfig::read('pfb_tick_interval'));
+
 if (pfb_cfg_toggle_read($pfb['enable']) === PfbToggle::On) {
-	/* Legend - Time variables
+	list($next_hour, $next_min, $sec_remain) =
+	    pfb_next_tick_boundary($pfb_tick_min, (int) date('G'), (int) date('i'), (int) date('s'));
 
-	$pfb['interval']	Hour interval setting	(1,2,3,4,6,8,12,24)
-	$pfb['min']		Cron minute start time	(0-23)
-	$pfb['hour']		Cron start hour		(0-23)
-	$pfb['24hour']		Cron daily/wk start hr	(0-23)
+	$sec_final	= str_pad(($sec_remain % 60),          2, '0', STR_PAD_LEFT);
+	$min_remain	= (int) floor($sec_remain / 60);
+	$min_final	= str_pad(($min_remain % 60),          2, '0', STR_PAD_LEFT);
+	$hour_final	= str_pad((int) floor($min_remain / 60), 2, '0', STR_PAD_LEFT);
 
-	$currenthour		Current hour
-	$currentmin		Current minute
-	$currentsec		Current second
-	$currentdaysec		Total number of seconds elapsed so far in the day
-	$cron_hour_begin	First cron hour setting (interval 2-24)
-	$cron_hour_next		Next cron hour setting  (interval 2-24)
-
-	$nextcron		Next cron event in hour:mins
-	$cronreal		Time remaining to next cron in hours:mins:secs		*/
-
-	$currenthour	= date('G');
-	$currentmin	= date('i');
-	$currentsec	= date('s');
-	$currentdaysec	= ($currenthour * 3600) + ($currentmin * 60) + $currentsec;
-
-	if (!is_numeric($pfb['min'])) {
-		$pfb['min'] = 0;
-	}
-
-	if ($pfb['interval'] == 1) {
-		if ($currentmin < $pfb['min']) {
-			$cron_hour_next = $currenthour;
-		} else {
-			$cron_hour_next = ($currenthour + 1) % 24;
-		}
-	}
-	elseif ($pfb['interval'] == 24) {
-		$cron_hour_next = $cron_hour_begin = $pfb['24hour'] ?: '00';
-	}
-	else {
-		// Find next cron hour schedule
-		$crondata = pfb_cron_base_hour($pfb['interval']);
-		$cron_hour_begin = 0;
-		$cron_hour_next  = '';
-		if (!empty($crondata)) {
-			foreach ($crondata as $key => $line) {
-				if ($key == 0) {
-					$cron_hour_begin = $line;
-				}
-				if (($line * 3600) + ($pfb['min'] * 60) > $currentdaysec) {
-					$cron_hour_next = $line;
-					break;
-				}
-			}
-		}
-		// Roll over to the first cron hour setting
-		if (empty($cron_hour_next)) {
-			$cron_hour_next = $cron_hour_begin;
-		}
-	}
-
-	$cron_seconds_next = ($cron_hour_next * 3600) + ($pfb['min'] * 60);
-	if ($currentdaysec < $cron_seconds_next) {
-		// The next cron job is ahead of us in the day
-		$sec_remain = $cron_seconds_next - $currentdaysec;
-	} else {
-		// The next cron job is tomorrow
-		$sec_remain = (24*60*60) + $cron_seconds_next - $currentdaysec;
-	}
-
-	// Ensure hour:min:sec variables are two digit
-	$pfb['min']	= str_pad($pfb['min'], 2, '0', STR_PAD_LEFT);
-	$sec_final	= str_pad(($sec_remain % 60),  2, '0', STR_PAD_LEFT);
-	$min_remain	= str_pad(floor($sec_remain / 60), 2, '0', STR_PAD_LEFT);
-	$min_final	= str_pad(($min_remain % 60), 2, '0', STR_PAD_LEFT);
-	$hour_final	= str_pad(floor($min_remain / 60), 2, '0', STR_PAD_LEFT);
-	$cron_hour_next = str_pad($cron_hour_next, 2, '0', STR_PAD_LEFT);
-
-	$cronreal = "{$cron_hour_next}:{$pfb['min']}";
-	$nextcron = "{$hour_final}:{$min_final}:{$sec_final}";
+	$cronreal	= str_pad($next_hour, 2, '0', STR_PAD_LEFT) . ':' . str_pad($next_min, 2, '0', STR_PAD_LEFT);
+	$nextcron	= "{$hour_final}:{$min_final}:{$sec_final}";
 }
 
+// Probe for the exact tick signature install_cron_job() registers in pfblockerng.inc, so an
+// installed tick is not misreported as "[ Missing cron task ]".
 $pfb_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> {$pfb['log']} 2>&1";
-if ($pfb['interval'] == 1) {
-	$pfb_hour = '*';
-} elseif ($pfb['interval'] == 24) {
-	$pfb_hour = $pfb['24hour'];
+
+if (pfb_cfg_toggle_read($pfb['enable']) === PfbToggle::On) {
+	if (!pfblockerng_cron_exists($pfb_cmd, '*/' . $pfb_tick_min, '*', '*', '*')) {
+		$cronreal = ' [ Missing cron task ]';
+		$nextcron = '--';
+	}
 } else {
-	$pfb_hour = implode(',', pfb_cron_base_hour($pfb['interval']));
-}
-
-// Determine if the tick CRON job is missing
-if (pfb_cfg_toggle_read($pfb['enable']) === PfbToggle::On && $pfb['interval'] != 'Disabled' &&
-    !pfblockerng_cron_exists($pfb_cmd, $pfb['min'], $pfb_hour, '*', '*')) {
-	$cronreal = ' [ Missing cron task ]';
-	$nextcron = '--';
-}
-
-// Determine if CRON job is disabled
-elseif (empty($pfb['enable']) || empty($cron_hour_next) || $pfb['interval'] == 'Disabled') {
 	$cronreal = ' [ Disabled ]';
 	$nextcron = '--';
 }

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -68,14 +68,20 @@ function pfbupdate_status($status) {
 }
 
 
+// TRUE when a pfBlockerNG feed task (cron/update/trigger/tick/forcecheck) is already running.
+// Single source for the active-process guard used by the Run Now dispatchers and the status line.
+function pfb_active_task_running(): bool {
+	exec('/bin/ps -wax', $result_ps);
+	return (bool) preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick|forcecheck)/', $result_ps);
+}
+
 // Dispatch pfb_trigger via the Phase-3 explicit API, stream log output,
 // then update the due ledger so the Schedule view reflects the manual run.
 function pfb_runnow(string $scope, bool $force): void {
 	global $pfb;
 
 	// Check for any active pfBlockerNG process before dispatching.
-	exec('/bin/ps -wax', $result_ps);
-	if (preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick|forcecheck)/', $result_ps)) {
+	if (pfb_active_task_running()) {
 		pfbupdate_status(gettext('Run Now skipped — an active pfBlockerNG task is running.'));
 		return;
 	}
@@ -121,9 +127,9 @@ function pfb_runnow(string $scope, bool $force): void {
 function pfb_runnow_forcecheck(string $scope): void {
 	global $pfb;
 
-	// Active-process guard — same check as pfb_runnow().
-	exec('/bin/ps -wax', $result_ps);
-	if (preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick|forcecheck)/', $result_ps)) {
+	// Active-process guard — TOCTOU backstop; the POST handler also pre-checks before
+	// clearing any sidecars (so a skipped run never leaves the box primed for a re-fetch).
+	if (pfb_active_task_running()) {
 		pfbupdate_status(gettext('Run Now skipped — an active pfBlockerNG task is running.'));
 		return;
 	}
@@ -236,8 +242,7 @@ $status = 'NEXT Scheduled CRON Event will run at'
 	. '&emsp;</span></strong> time remaining.';
 
 // Query for any active pfBlockerNG task
-exec('/bin/ps -wax', $result_ps);
-if (preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick|forcecheck)/', $result_ps)) {
+if (pfb_active_task_running()) {
 	$status = '<span style="color: red;">&emsp;&emsp;'
 		. 'Active pfBlockerNG CRON JOB'
 		. '</span>&emsp;<i class="fa-solid fa-spinner fa-pulse fa-lg"></i>';
@@ -422,13 +427,20 @@ if (pfb_cfg_toggle_read($pfb['enable']) === PfbToggle::On && isset($pconfig['run
 		$force_mode = 'none';
 	}
 	if ($force_mode === 'download' || $force_mode === 'both') {
-		// Clear the scoped conditional-GET sidecars, then run the detector on-demand so it
-		// re-fetches (200) and re-ingests changed feeds (Both also clears the hash => all).
-		$dirs = ($scope === 'ip')    ? array($pfb['origdir'])
-		      : (($scope === 'dnsbl') ? array($pfb['dnsorigdir'])
-		      : array($pfb['origdir'], $pfb['dnsorigdir']));
-		pfb_force_clear_validators($dirs, $force_mode === 'both');
-		pfb_runnow_forcecheck($scope);
+		// Pre-check the active-task guard BEFORE clearing any sidecars: if a run is already
+		// in progress, clearing them here (then skipping the dispatch) would leave the box
+		// primed for an unrequested re-fetch on the next scheduled tick.
+		if (pfb_active_task_running()) {
+			pfbupdate_status(gettext('Run Now skipped — an active pfBlockerNG task is running.'));
+		} else {
+			// Clear the scoped conditional-GET sidecars, then run the detector on-demand so it
+			// re-fetches (200) and re-ingests changed feeds (Both also clears the hash => all).
+			$dirs = ($scope === 'ip')    ? array($pfb['origdir'])
+			      : (($scope === 'dnsbl') ? array($pfb['dnsorigdir'])
+			      : array($pfb['origdir'], $pfb['dnsorigdir']));
+			pfb_force_clear_validators($dirs, $force_mode === 'both');
+			pfb_runnow_forcecheck($scope);
+		}
 	} else {
 		// none -> plain pass; parse -> reuse=on (reparse cached, no download).
 		pfb_runnow($scope, $force_mode === 'parse');

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -316,7 +316,7 @@ $group->add(new Form_Checkbox(
 	'Both',
 	$pfb_scope_val === 'both',
 	'both'
-))->displayAsRadio('pfb_scope_both')->setAttribute('title', 'Sync IP and DNSBL feeds.')->setWidth(1);
+))->displayAsRadio('pfb_scope_both')->setAttribute('title', 'Sync IP and DNSBL feeds.')->setWidth(2);
 
 $group->add(new Form_Checkbox(
 	'pfb_scope',
@@ -324,7 +324,7 @@ $group->add(new Form_Checkbox(
 	'IP',
 	$pfb_scope_val === 'ip',
 	'ip'
-))->displayAsRadio('pfb_scope_ip')->setAttribute('title', 'Sync IP feeds only.')->setWidth(1);
+))->displayAsRadio('pfb_scope_ip')->setAttribute('title', 'Sync IP feeds only.')->setWidth(2);
 
 $group->add(new Form_Checkbox(
 	'pfb_scope',
@@ -332,7 +332,7 @@ $group->add(new Form_Checkbox(
 	'DNSBL',
 	$pfb_scope_val === 'dnsbl',
 	'dnsbl'
-))->displayAsRadio('pfb_scope_dnsbl')->setAttribute('title', 'Sync DNSBL feeds only.')->setWidth(1);
+))->displayAsRadio('pfb_scope_dnsbl')->setAttribute('title', 'Sync DNSBL feeds only.')->setWidth(2);
 
 $group->setHelp('Which lists to sync on Run Now: Both, IP-only, or DNSBL-only.');
 $section->add($group);
@@ -382,7 +382,7 @@ $btn_logview->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setWid
 	    ->setAttribute('title', $btn_logview_title);
 $group->add(new Form_StaticText(
 		NULL,
-		$btn_run . $btn_logview
+		$btn_run . '&emsp;' . $btn_logview
 ));
 
 $section->add($group);

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -435,9 +435,7 @@ if (pfb_cfg_toggle_read($pfb['enable']) === PfbToggle::On && isset($pconfig['run
 		} else {
 			// Clear the scoped conditional-GET sidecars, then run the detector on-demand so it
 			// re-fetches (200) and re-ingests changed feeds (Both also clears the hash => all).
-			$dirs = ($scope === 'ip')    ? array($pfb['origdir'])
-			      : (($scope === 'dnsbl') ? array($pfb['dnsorigdir'])
-			      : array($pfb['origdir'], $pfb['dnsorigdir']));
+			$dirs = pfb_force_scope_dirs($scope, $pfb['origdir'], $pfb['dnsorigdir']);
 			pfb_force_clear_validators($dirs, $force_mode === 'both');
 			pfb_runnow_forcecheck($scope);
 		}

--- a/tests/php/ConditionalGetHelpersTest.php
+++ b/tests/php/ConditionalGetHelpersTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_validator_write')]
 #[CoversFunction('pfb_conditional_get_decision')]
 #[CoversFunction('pfb_conditional_get_validator_base')]
+#[CoversFunction('pfb_force_clear_validators')]
 final class ConditionalGetHelpersTest extends TestCase
 {
 	/** @var string Writable temp directory for this test class. */
@@ -509,6 +510,159 @@ final class ConditionalGetHelpersTest extends TestCase
 			'/x/a.md5b.orig',
 			pfb_conditional_get_validator_base('/x/a.md5b'),
 			'only a trailing `.md5` is the probe-infix; a mid-string .md5 is preserved'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// pfb_force_clear_validators() — sidecar sweep for Force Download / Both
+	//
+	// These tests are RED on the pre-change code (pfb_force_clear_validators
+	// is a new function — calling it before the change gives a fatal error).
+	// -------------------------------------------------------------------------
+
+	/**
+	 * clear_hashes=FALSE removes only .etag and .lastmod; leaves .orig, .xxhash128, .md5.
+	 *
+	 *  GIVEN feedA.orig, feedA.orig.etag, feedA.orig.lastmod, feedA.orig.xxhash128,
+	 *        feedB.orig, feedB.orig.md5;
+	 *   WHEN pfb_force_clear_validators([$dir], FALSE) is called;
+	 *   THEN .etag and .lastmod are removed; .orig, .xxhash128, .md5 are kept;
+	 *   AND  the return value is 2 (two sidecars removed).
+	 */
+	public function test_force_clear_validators_etag_lastmod_only(): void
+	{
+		$dir = $this->dir;
+		// Arrange: plant fixture files.
+		file_put_contents("{$dir}/feedA.orig",          'content');
+		file_put_contents("{$dir}/feedA.orig.etag",     '"abc"');
+		file_put_contents("{$dir}/feedA.orig.lastmod",  '1700000000');
+		file_put_contents("{$dir}/feedA.orig.xxhash128", 'deadbeef');
+		file_put_contents("{$dir}/feedB.orig",          'content2');
+		file_put_contents("{$dir}/feedB.orig.md5",      'abc123');
+
+		// Assert BEFORE: all files exist.
+		$this->assertFileExists("{$dir}/feedA.orig.etag",     'fixture: .etag must exist before clear');
+		$this->assertFileExists("{$dir}/feedA.orig.lastmod",  'fixture: .lastmod must exist before clear');
+		$this->assertFileExists("{$dir}/feedA.orig.xxhash128",'fixture: .xxhash128 must exist before clear');
+		$this->assertFileExists("{$dir}/feedB.orig.md5",      'fixture: .md5 must exist before clear');
+
+		// Act.
+		$removed = pfb_force_clear_validators([$dir], FALSE);
+
+		// Assert: only validators removed; hashes and .orig content kept.
+		$this->assertFileDoesNotExist(
+			"{$dir}/feedA.orig.etag",
+			'clear_hashes=FALSE must remove .etag sidecars'
+		);
+		$this->assertFileDoesNotExist(
+			"{$dir}/feedA.orig.lastmod",
+			'clear_hashes=FALSE must remove .lastmod sidecars'
+		);
+		$this->assertFileExists(
+			"{$dir}/feedA.orig.xxhash128",
+			'clear_hashes=FALSE must NOT remove .xxhash128 (hash sidecars must survive)'
+		);
+		$this->assertFileExists(
+			"{$dir}/feedB.orig.md5",
+			'clear_hashes=FALSE must NOT remove .md5 (hash sidecars must survive)'
+		);
+		$this->assertFileExists(
+			"{$dir}/feedA.orig",
+			'clear_hashes=FALSE must never remove .orig content files'
+		);
+
+		$this->assertSame(
+			2,
+			$removed,
+			sprintf('Expected 2 sidecars removed (etag + lastmod), got %d', $removed)
+		);
+	}
+
+	/**
+	 * clear_hashes=TRUE removes .etag, .lastmod, .xxhash128, and .md5; leaves .orig content.
+	 *
+	 *  GIVEN the same fixture set as above;
+	 *   WHEN pfb_force_clear_validators([$dir], TRUE) is called;
+	 *   THEN .etag, .lastmod, .xxhash128, and .md5 are removed; .orig is kept;
+	 *   AND  the return value is 4.
+	 */
+	public function test_force_clear_validators_clears_hashes_too(): void
+	{
+		$dir = $this->dir;
+		file_put_contents("{$dir}/feedA.orig",          'content');
+		file_put_contents("{$dir}/feedA.orig.etag",     '"abc"');
+		file_put_contents("{$dir}/feedA.orig.lastmod",  '1700000000');
+		file_put_contents("{$dir}/feedA.orig.xxhash128", 'deadbeef');
+		file_put_contents("{$dir}/feedB.orig",          'content2');
+		file_put_contents("{$dir}/feedB.orig.md5",      'abc123');
+
+		$this->assertFileExists("{$dir}/feedA.orig.etag",      'fixture: .etag must exist before clear');
+		$this->assertFileExists("{$dir}/feedA.orig.lastmod",   'fixture: .lastmod must exist before clear');
+		$this->assertFileExists("{$dir}/feedA.orig.xxhash128", 'fixture: .xxhash128 must exist before clear');
+		$this->assertFileExists("{$dir}/feedB.orig.md5",       'fixture: .md5 must exist before clear');
+
+		$removed = pfb_force_clear_validators([$dir], TRUE);
+
+		$this->assertFileDoesNotExist("{$dir}/feedA.orig.etag",      'clear_hashes=TRUE must remove .etag');
+		$this->assertFileDoesNotExist("{$dir}/feedA.orig.lastmod",   'clear_hashes=TRUE must remove .lastmod');
+		$this->assertFileDoesNotExist("{$dir}/feedA.orig.xxhash128", 'clear_hashes=TRUE must remove .xxhash128');
+		$this->assertFileDoesNotExist("{$dir}/feedB.orig.md5",       'clear_hashes=TRUE must remove .md5');
+		$this->assertFileExists(
+			"{$dir}/feedA.orig",
+			'clear_hashes=TRUE must never remove .orig content files'
+		);
+
+		$this->assertSame(
+			4,
+			$removed,
+			sprintf('Expected 4 sidecars removed (etag + lastmod + xxhash128 + md5), got %d', $removed)
+		);
+	}
+
+	/**
+	 * Two dirs each with one .orig.etag → returns 2.
+	 *
+	 *  GIVEN dirA with feedA.orig.etag and dirB with feedB.orig.etag;
+	 *   WHEN pfb_force_clear_validators([dirA, dirB], FALSE) is called;
+	 *   THEN both .etag files are removed and the return value is 2.
+	 */
+	public function test_force_clear_validators_two_dirs(): void
+	{
+		$dirA = $this->dir . '/origA';
+		$dirB = $this->dir . '/origB';
+		mkdir($dirA, 0777, TRUE);
+		mkdir($dirB, 0777, TRUE);
+		file_put_contents("{$dirA}/feedA.orig.etag", '"etagA"');
+		file_put_contents("{$dirB}/feedB.orig.etag", '"etagB"');
+
+		$this->assertFileExists("{$dirA}/feedA.orig.etag", 'fixture: dirA etag must exist');
+		$this->assertFileExists("{$dirB}/feedB.orig.etag", 'fixture: dirB etag must exist');
+
+		$removed = pfb_force_clear_validators([$dirA, $dirB], FALSE);
+
+		$this->assertFileDoesNotExist("{$dirA}/feedA.orig.etag", 'dirA .etag must be removed');
+		$this->assertFileDoesNotExist("{$dirB}/feedB.orig.etag", 'dirB .etag must be removed');
+		$this->assertSame(
+			2,
+			$removed,
+			sprintf('Expected 2 removed across two dirs, got %d', $removed)
+		);
+	}
+
+	/**
+	 * Nonexistent dir → returns 0, no error.
+	 *
+	 *  GIVEN a dir path that does not exist;
+	 *   WHEN pfb_force_clear_validators(['/nonexistent/xyz'], FALSE) is called;
+	 *   THEN it returns 0 without throwing.
+	 */
+	public function test_force_clear_validators_nonexistent_dir_returns_zero(): void
+	{
+		$removed = pfb_force_clear_validators(['/nonexistent/xyz_pfb_test_' . getmypid()], FALSE);
+		$this->assertSame(
+			0,
+			$removed,
+			'A nonexistent dir must produce 0 removals and no error'
 		);
 	}
 }

--- a/tests/php/ConditionalGetHelpersTest.php
+++ b/tests/php/ConditionalGetHelpersTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_conditional_get_decision')]
 #[CoversFunction('pfb_conditional_get_validator_base')]
 #[CoversFunction('pfb_force_clear_validators')]
+#[CoversFunction('pfb_force_scope_dirs')]
 final class ConditionalGetHelpersTest extends TestCase
 {
 	/** @var string Writable temp directory for this test class. */
@@ -663,6 +664,52 @@ final class ConditionalGetHelpersTest extends TestCase
 			0,
 			$removed,
 			'A nonexistent dir must produce 0 removals and no error'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_force_scope_dirs — Run Now scope -> orig dir(s). Covers all three scope
+	// branches deterministically so the live (scope x force-mode) matrix does not
+	// have to retest the dir selection on a VM. Red->green: the function is new.
+	// -----------------------------------------------------------------------
+
+	private const IP_DIR = '/var/db/pfblockerng/original';
+	private const DNSBL_DIR = '/var/db/pfblockerng/dnsblorig';
+
+	public function test_force_scope_dirs_ip_is_ip_origdir_only(): void
+	{
+		$this->assertSame(
+			[self::IP_DIR],
+			pfb_force_scope_dirs('ip', self::IP_DIR, self::DNSBL_DIR),
+			"scope=ip must map to the IP orig dir only"
+		);
+	}
+
+	public function test_force_scope_dirs_dnsbl_is_dnsbl_origdir_only(): void
+	{
+		$this->assertSame(
+			[self::DNSBL_DIR],
+			pfb_force_scope_dirs('dnsbl', self::IP_DIR, self::DNSBL_DIR),
+			"scope=dnsbl must map to the DNSBL orig dir only"
+		);
+	}
+
+	public function test_force_scope_dirs_both_is_both_origdirs(): void
+	{
+		$this->assertSame(
+			[self::IP_DIR, self::DNSBL_DIR],
+			pfb_force_scope_dirs('both', self::IP_DIR, self::DNSBL_DIR),
+			"scope=both must map to both orig dirs (IP first, then DNSBL)"
+		);
+	}
+
+	public function test_force_scope_dirs_unknown_scope_fails_safe_to_both(): void
+	{
+		// An unrecognized scope falls through to 'both' so a clear never under-covers.
+		$this->assertSame(
+			[self::IP_DIR, self::DNSBL_DIR],
+			pfb_force_scope_dirs('bogus', self::IP_DIR, self::DNSBL_DIR),
+			"an unrecognized scope must fail safe to both orig dirs"
 		);
 	}
 }

--- a/tests/php/TickCronTest.php
+++ b/tests/php/TickCronTest.php
@@ -334,4 +334,91 @@ final class TickCronTest extends TestCase
 		$this->assertSame(self::NOW + self::DAILY, $entry['next_due'],
 			"cron next_due: expected " . (self::NOW + self::DAILY) . " got {$entry['next_due']}");
 	}
+
+	// -----------------------------------------------------------------------
+	// pfb_next_tick_boundary — the Update page's "NEXT Scheduled CRON Event".
+	//
+	// The ADR-43 tick is a star-slash-N minute cron, so the next event is the
+	// next minute-of-hour that is a multiple of $tick_min. The Update page used
+	// to compute this from the legacy per-feed interval/min/24hour knobs, which
+	// described the feed cadence, NOT the tick — so it could show "[ Missing
+	// cron task ]" and a wrong time even though the tick was scheduled.
+	//
+	// Red→green: before this helper existed, calling pfb_next_tick_boundary()
+	// raised "Call to undefined function pfb_next_tick_boundary()".
+	// -----------------------------------------------------------------------
+
+	/**
+	 * The next tick is later in the same hour when one is still ahead.
+	 *
+	 * Scenario:
+	 *   Given a 15-minute tick and the clock at 10:20:00.
+	 *   When pfb_next_tick_boundary(15, 10, 20, 0).
+	 *   Then the next event is 10:30 with 600 s remaining.
+	 */
+	public function testNextTickLaterThisHour(): void
+	{
+		$this->assertSame([10, 30, 600], pfb_next_tick_boundary(15, 10, 20, 0),
+			'15-min tick at 10:20:00 must fire next at 10:30 (600 s remaining)');
+	}
+
+	/**
+	 * The next tick rolls to :00 of the next hour after the last in-hour slot.
+	 *
+	 * Scenario:
+	 *   Given a 15-minute tick (slots :00/:15/:30/:45) and the clock at 10:50:30.
+	 *   When pfb_next_tick_boundary(15, 10, 50, 30).
+	 *   Then the next event is 11:00 with 570 s remaining (no :60 slot exists).
+	 */
+	public function testNextTickRollsToNextHour(): void
+	{
+		$this->assertSame([11, 0, 570], pfb_next_tick_boundary(15, 10, 50, 30),
+			'15-min tick at 10:50:30 must roll to 11:00 (570 s remaining)');
+	}
+
+	/**
+	 * The hour wraps from 23 back to 0 across midnight.
+	 *
+	 * Scenario:
+	 *   Given a 15-minute tick and the clock at 23:50:00.
+	 *   When pfb_next_tick_boundary(15, 23, 50, 0).
+	 *   Then the next event is 00:00 with 600 s remaining.
+	 */
+	public function testNextTickWrapsPastMidnight(): void
+	{
+		$this->assertSame([0, 0, 600], pfb_next_tick_boundary(15, 23, 50, 0),
+			'15-min tick at 23:50:00 must wrap to 00:00 (600 s remaining)');
+	}
+
+	/**
+	 * On an exact boundary the NEXT slot is returned, not the current one.
+	 *
+	 * Scenario:
+	 *   Given a 15-minute tick and the clock at exactly 10:00:00.
+	 *   When pfb_next_tick_boundary(15, 10, 0, 0).
+	 *   Then the next event is 10:15 (the :00 tick just fired) with 900 s remaining.
+	 */
+	public function testNextTickAtExactBoundaryReturnsFollowingSlot(): void
+	{
+		$this->assertSame([10, 15, 900], pfb_next_tick_boundary(15, 10, 0, 0),
+			'15-min tick at 10:00:00 must advance to 10:15 (900 s remaining)');
+	}
+
+	/**
+	 * An interval that does not divide 60 has its discontinuity at the hour edge.
+	 *
+	 * A 7-minute tick fires at :00,:07,…,:56 then jumps to the next :00 (never
+	 * :63), so the gap between :56 and the next :00 is only 4 minutes.
+	 *
+	 * Scenario:
+	 *   Given a 7-minute tick.
+	 *   When at 10:50:00 → next is 10:56 (360 s); when at 10:56:00 → rolls to 11:00 (240 s).
+	 */
+	public function testNextTickNonDivisorInterval(): void
+	{
+		$this->assertSame([10, 56, 360], pfb_next_tick_boundary(7, 10, 50, 0),
+			'7-min tick at 10:50:00 must fire next at 10:56 (360 s remaining)');
+		$this->assertSame([11, 0, 240], pfb_next_tick_boundary(7, 10, 56, 0),
+			'7-min tick at 10:56:00 must roll to 11:00 (240 s remaining, no :63 slot)');
+	}
 }

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2822,6 +2822,39 @@ def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.
     )
 
 
+# Mirrors the Update page's active-task guard (pfblockerng_update.php pfb_active_task_running).
+_PFB_TASK_RE = re.compile(r"pfblockerng[.]php\s+(cron|update|pfb_trigger|tick|forcecheck)")
+
+
+def wait_no_active_pfb_task(vm: SmokeVM, *, timeout: float = 90.0, delay: float = 1.0) -> None:
+    """Block until no pfBlockerNG feed task is running on the box.
+
+    The Update page's Run Now guard skips when a cron/update/pfb_trigger/tick/forcecheck
+    process is already running -- so a test that POSTs Run Now while a PRIOR test's
+    backgrounded run is still alive gets skipped (no reload, no sidecar clear) and fails
+    spuriously. ``pfb_runnow*`` blocks on the log marker, but ``pfblockerng_sync_cron``
+    lingers briefly after writing it (a trailing sleep + the ADR-19 software-update check),
+    so the process outlives the POST. This polls the SAME ``ps`` signal the page checks so a
+    test establishes a quiescent box itself (self-encapsulated; never order-dependent).
+
+    Last-resort poll of production-side state we cannot signal (issue #456); the timeout
+    RAISES loudly with the offending process lines rather than returning on a still-busy box.
+    """
+    deadline = time.monotonic() + timeout
+    last: list[str] = []
+    while time.monotonic() < deadline:
+        out = vm.ssh("/bin/ps", "-wax").stdout
+        last = [ln.strip() for ln in out.splitlines() if _PFB_TASK_RE.search(ln)]
+        if not last:
+            return
+        time.sleep(delay)
+    raise AssertionError(
+        f"pfBlockerNG task still running after {timeout:.0f}s -- Run Now would be skipped.\n"
+        f"  expected: no cron/update/pfb_trigger/tick/forcecheck process\n"
+        f"  actual:   {last!r}"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # ADR-10 zero-downtime swap — no-restart readiness + invariants
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -1380,6 +1380,7 @@ def test_update_page_cron_status_reports_scheduled_tick(
 # ---------------------------------------------------------------------------
 
 _IP_ORIG_DIR = f"{helpers.PFB_DBDIR}/original"
+_DNSBL_ORIG_DIR = f"{helpers.PFB_DBDIR}/dnsblorig"
 
 
 def test_force_mode_download_clears_validators(
@@ -1465,15 +1466,20 @@ def test_force_mode_both_clears_hash_sidecars(
 ) -> None:
     """Force=Both clears .orig.etag AND .orig.xxhash128 before dispatching forcecheck.
 
-    Scenario: Both mode removes validator AND hash sidecars for in-scope feeds.
+    Scenario: Both mode removes validator AND hash sidecars in EVERY in-scope orig dir.
 
-    Given synthetic pfbtest.orig.etag AND pfbtest.orig.xxhash128 in the IP orig dir,
-    And both files EXIST (pre-state confirmed),
+    Given synthetic pfbtest.orig.etag AND pfbtest.orig.xxhash128 planted in BOTH the IP
+      orig dir and the DNSBL orig dir,
+    And all four files EXIST (pre-state confirmed),
 
-    When the Update page is submitted with pfb_force_mode=both and pfb_scope=ip,
+    When the Update page is submitted with pfb_force_mode=both and pfb_scope=both,
 
-    Then BOTH the .orig.etag and .orig.xxhash128 sidecars are GONE —
-      proving pfb_force_clear_validators() was called with clear_hashes=TRUE.
+    Then all four sidecars are GONE — proving pfb_force_clear_validators(clear_hashes=TRUE)
+      ran over the scope=both dir set (both $pfb['origdir'] and $pfb['dnsorigdir']).
+
+    scope=both is used deliberately so this covers the both-branch of the handler's
+    scope→dirs map (both dirs at once); scope=dnsbl-alone is symmetric to the scope=ip
+    download test and is the one documented out-of-CI gap.
 
     Red→green: before this change, force=both did not exist; no sidecar was cleared.
     """
@@ -1482,19 +1488,25 @@ def test_force_mode_both_clears_hash_sidecars(
     if original_enabled != "on":
         helpers.set_package_enabled(vm, True)
 
-    sidecar_etag = f"{_IP_ORIG_DIR}/pfbtest.orig.etag"
-    sidecar_hash = f"{_IP_ORIG_DIR}/pfbtest.orig.xxhash128"
+    # One etag + one hash sidecar in EACH in-scope orig dir (IP + DNSBL).
+    planted = [
+        (f"{_IP_ORIG_DIR}/pfbtest.orig.etag", '"test-etag-both"'),
+        (f"{_IP_ORIG_DIR}/pfbtest.orig.xxhash128", "deadbeef"),
+        (f"{_DNSBL_ORIG_DIR}/pfbtest.orig.etag", '"test-etag-both"'),
+        (f"{_DNSBL_ORIG_DIR}/pfbtest.orig.xxhash128", "deadbeef"),
+    ]
     try:
-        mk = subprocess.run(
-            vm.ssh_argv("/bin/mkdir", "-p", _IP_ORIG_DIR),
-            capture_output=True,
-            text=True,
-            timeout=30.0,
-            check=False,
-        )
-        assert mk.returncode == 0, f"mkdir {_IP_ORIG_DIR} failed: {mk.stderr!r}"
+        for orig_dir in (_IP_ORIG_DIR, _DNSBL_ORIG_DIR):
+            mk = subprocess.run(
+                vm.ssh_argv("/bin/mkdir", "-p", orig_dir),
+                capture_output=True,
+                text=True,
+                timeout=30.0,
+                check=False,
+            )
+            assert mk.returncode == 0, f"mkdir {orig_dir} failed: {mk.stderr!r}"
 
-        for path, content in ((sidecar_etag, '"test-etag-both"'), (sidecar_hash, "deadbeef")):
+        for path, content in planted:
             p = subprocess.run(
                 vm.ssh_argv("tee", path),
                 input=content,
@@ -1505,30 +1517,30 @@ def test_force_mode_both_clears_hash_sidecars(
             )
             assert p.returncode == 0, f"plant {path} failed: {p.stderr!r}"
 
-        # BEFORE: both sidecars must exist.
-        for path in (sidecar_etag, sidecar_hash):
+        # BEFORE: every planted sidecar must exist.
+        for path, _ in planted:
             r = vm.ssh("/bin/test", "-f", path)
             assert r.returncode == 0, f"{path} not found before POST — cannot prove the POST caused removal"
 
-        # ACT.
+        # ACT: scope=both exercises both orig dirs.
         resp = webui.post(
             UPDATE_PAGE,
-            overrides={"pfb_scope": "ip", "pfb_force_mode": "both"},
+            overrides={"pfb_scope": "both", "pfb_force_mode": "both"},
             submit=("run", "Run Now"),
             timeout=SAVE_TIMEOUT,
         )
         assert not looks_like_login_page(resp.text), "force=both POST returned the login form (session lost)"
 
-        # AFTER: both sidecars must be gone.
-        for path, label in ((sidecar_etag, ".orig.etag"), (sidecar_hash, ".orig.xxhash128")):
+        # AFTER: every sidecar (etag + hash) in BOTH dirs must be gone.
+        for path, _ in planted:
             r = vm.ssh("/bin/test", "-f", path)
             assert r.returncode != 0, (
-                f"{path} ({label}) still exists after force=both POST — "
-                "pfb_force_clear_validators(clear_hashes=TRUE) was not called for scope=ip"
+                f"{path} still exists after force=both/scope=both POST — "
+                "pfb_force_clear_validators(clear_hashes=TRUE) did not clear this in-scope orig dir"
             )
 
     finally:
-        for path in (sidecar_etag, sidecar_hash):
+        for path, _ in planted:
             vm.ssh("/bin/rm", "-f", path)
         if original_enabled != "on":
             helpers.set_package_enabled(vm, False)

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -1437,7 +1437,9 @@ def test_force_mode_download_clears_validators(
         before = vm.ssh("/bin/test", "-f", sidecar_etag)
         assert before.returncode == 0, f"{sidecar_etag} not found after planting — cannot prove the POST caused removal"
 
-        # ACT: POST force_mode=download, scope=ip.
+        # ACT: POST force_mode=download, scope=ip. Wait for a quiescent box first — the page's
+        # guard skips Run Now (and the sidecar clear) if a prior test's run is still alive.
+        helpers.wait_no_active_pfb_task(vm)
         resp = webui.post(
             UPDATE_PAGE,
             overrides={"pfb_scope": "ip", "pfb_force_mode": "download"},
@@ -1522,7 +1524,9 @@ def test_force_mode_both_clears_hash_sidecars(
             r = vm.ssh("/bin/test", "-f", path)
             assert r.returncode == 0, f"{path} not found before POST — cannot prove the POST caused removal"
 
-        # ACT: scope=both exercises both orig dirs.
+        # ACT: scope=both exercises both orig dirs. Wait for a quiescent box first — the page's
+        # guard skips Run Now (and the sidecar clear) if a prior test's run is still alive.
+        helpers.wait_no_active_pfb_task(vm)
         resp = webui.post(
             UPDATE_PAGE,
             overrides={"pfb_scope": "both", "pfb_force_mode": "both"},
@@ -1542,5 +1546,78 @@ def test_force_mode_both_clears_hash_sidecars(
     finally:
         for path, _ in planted:
             vm.ssh("/bin/rm", "-f", path)
+        if original_enabled != "on":
+            helpers.set_package_enabled(vm, False)
+
+
+def test_force_mode_parse_keeps_sidecars(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Force=Parse reparses cached lists (reuse=on) and does NOT clear any sidecars.
+
+    Scenario: Parse is the one Force mode that takes the reuse=on path — reparse cached,
+      no re-download — so it must NOT touch the conditional-GET sidecars (unlike
+      Download/Both, which clear them to force a re-fetch).
+
+    Given a synthetic pfbtest.orig.etag in the IP orig dir,
+    And the .orig.etag EXISTS (pre-state confirmed),
+
+    When the Update page is submitted with pfb_force_mode=parse and pfb_scope=ip,
+
+    Then the .orig.etag sidecar STILL EXISTS afterwards — proving Parse routes to
+      pfb_runnow(force=TRUE) and does NOT call pfb_force_clear_validators.
+
+    Red→green: before this change there was no pfb_force_mode dispatch split; this pins
+    that Parse and Download/Both take different paths (the former never clears sidecars).
+    """
+    vm = smoke_vm
+    original_enabled = helpers.config_get(vm, _ENABLE_CB_CFG)
+    if original_enabled != "on":
+        helpers.set_package_enabled(vm, True)
+
+    sidecar_etag = f"{_IP_ORIG_DIR}/pfbtest.orig.etag"
+    try:
+        mk = subprocess.run(
+            vm.ssh_argv("/bin/mkdir", "-p", _IP_ORIG_DIR),
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            check=False,
+        )
+        assert mk.returncode == 0, f"mkdir {_IP_ORIG_DIR} failed: {mk.stderr!r}"
+
+        plant = subprocess.run(
+            vm.ssh_argv("tee", sidecar_etag),
+            input='"test-etag-parse"',
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            check=False,
+        )
+        assert plant.returncode == 0, f"plant {sidecar_etag} failed: {plant.stderr!r}"
+
+        # BEFORE: the sidecar exists.
+        before = vm.ssh("/bin/test", "-f", sidecar_etag)
+        assert before.returncode == 0, f"{sidecar_etag} not found after planting — cannot prove non-removal"
+
+        # ACT: Parse. Wait for quiescence first (the page skips Run Now if a task runs).
+        helpers.wait_no_active_pfb_task(vm)
+        resp = webui.post(
+            UPDATE_PAGE,
+            overrides={"pfb_scope": "ip", "pfb_force_mode": "parse"},
+            submit=("run", "Run Now"),
+            timeout=SAVE_TIMEOUT,
+        )
+        assert not looks_like_login_page(resp.text), "force=parse POST returned the login form (session lost)"
+
+        # AFTER: Parse must NOT clear the sidecar (reuse=on path, not the forcecheck clear).
+        after = vm.ssh("/bin/test", "-f", sidecar_etag)
+        assert after.returncode == 0, (
+            f"{sidecar_etag} was removed after force=parse POST — Parse must take the reuse=on "
+            "path (reparse cached, no sidecar clear), NOT the Download/Both clear path"
+        )
+    finally:
+        vm.ssh("/bin/rm", "-f", sidecar_etag)
         if original_enabled != "on":
             helpers.set_package_enabled(vm, False)

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -30,6 +30,7 @@ the output filter per render -- it must be re-extracted, never cached).
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -1300,6 +1301,67 @@ def test_update_runnow_scope_guard_and_ledger(
             "Schedule section missing after Run Now re-render — ledger section not rendered"
         )
 
+    finally:
+        if original_enabled != "on":
+            helpers.set_package_enabled(vm, False)
+
+
+def test_update_page_cron_status_reports_scheduled_tick(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Cron Status reports the scheduled tick, NOT "[ Missing cron task ]".
+
+    ADR-43 installs ONE ``*/pfb_tick_interval`` cron tick whenever pfBlockerNG is
+    enabled. The Update page previously probed the crontab with the legacy
+    interval/min/24hour signature, which never matches that tick, so it falsely
+    rendered "[ Missing cron task ]" and a time derived from the feed cadence. This
+    pins the fix: with the tick installed, the page must report the next-tick
+    wall-clock time and time-remaining instead.
+
+    Scenario:
+      Given pfBlockerNG is enabled and a full reload has installed the tick cron,
+      And /etc/crontab actually contains the ``pfblockerng.php tick`` entry (precondition,
+        so "not Missing" is meaningful and not a false pass from a disabled box),
+      When the Update page is rendered,
+      Then the Cron Status shows "NEXT Scheduled CRON Event will run at" and does NOT
+        contain "[ Missing cron task ]", and renders a HH:MM next-tick time (unless a
+        run happens to be active at render time).
+
+    Red→green: before the fix, pfblockerng_cron_exists() was called with the legacy
+    minute/hour fields, so this asserted body still contained "[ Missing cron task ]".
+    """
+    vm = smoke_vm
+    original_enabled = helpers.config_get(vm, _ENABLE_CB_CFG)
+    if original_enabled != "on":
+        helpers.set_package_enabled(vm, True)
+    try:
+        # Install/refresh the tick cron via a full reload (no feeds configured => no egress).
+        helpers.reload(vm, "update")
+
+        # PRECONDITION (effective state, not the HTTP body): the tick IS in the crontab.
+        crontab = vm.ssh("/usr/bin/grep", "pfblockerng.php tick", "/etc/crontab")
+        assert crontab.returncode == 0 and "tick" in crontab.stdout, (
+            "tick cron absent from /etc/crontab after an enabled reload "
+            f"(rc={crontab.returncode} stdout={crontab.stdout!r}) — "
+            "cannot assert the page reports a scheduled tick"
+        )
+
+        body = webui.get(UPDATE_PAGE).text
+        assert not looks_like_login_page(body), "Update page GET returned the login form (session lost)"
+        assert "Missing cron task" not in body, (
+            "Cron Status still shows '[ Missing cron task ]' although the tick cron IS "
+            "installed — the page must probe the */N tick signature, not the legacy "
+            "interval/min/24hour cron"
+        )
+        assert "NEXT Scheduled CRON Event will run at" in body, "Cron Status header missing from the Update page"
+        # The next-tick HH:MM time, unless a run is active at render (which replaces the
+        # status line with the spinner) — accept either so the assertion is not racy.
+        at = body.find("will run at")
+        excerpt = body[at : at + 160] if at >= 0 else ""
+        assert re.search(r"\d{2}:\d{2}", excerpt) or "Active pfBlockerNG CRON JOB" in body, (
+            f"no HH:MM next-tick time rendered in the Cron Status; excerpt={excerpt!r}"
+        )
     finally:
         if original_enabled != "on":
             helpers.set_package_enabled(vm, False)

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -1363,5 +1364,171 @@ def test_update_page_cron_status_reports_scheduled_tick(
             f"no HH:MM next-tick time rendered in the Cron Status; excerpt={excerpt!r}"
         )
     finally:
+        if original_enabled != "on":
+            helpers.set_package_enabled(vm, False)
+
+
+# ---------------------------------------------------------------------------
+# Force mode — Download / Both sidecar-clear wiring (ADR-43)
+#
+# These tests prove that pfb_force_clear_validators() is called by the handler
+# and clears the right sidecar files before dispatching forcecheck.
+#
+# Full re-fetch / reload-if-changed / reload-all behaviour requires configured
+# feeds and is validated on a maintainer live-VM run; the hermetic harness has
+# no feeds, so these tests pin the side-effect (sidecar removal) only.
+# ---------------------------------------------------------------------------
+
+_IP_ORIG_DIR = f"{helpers.PFB_DBDIR}/original"
+
+
+def test_force_mode_download_clears_validators(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Force=Download clears .orig.etag before dispatching forcecheck.
+
+    Scenario: Download mode removes validator sidecars for in-scope feeds.
+      Background: pfBlockerNG deployed and enabled.
+
+    Given a synthetic feedA.orig.etag sidecar planted in the IP orig dir,
+    And the .orig.etag file EXISTS (pre-state confirmed),
+
+    When the Update page Run Now form is submitted with pfb_force_mode=download
+      and pfb_scope=ip,
+
+    Then the .orig.etag sidecar is GONE (the handler cleared it before dispatch) —
+      proving pfb_force_clear_validators() was called with the correct dir and
+      clear_hashes=FALSE.
+
+    Red→green: before this change, force=download did not exist and no sidecar
+    was cleared; the test would fail on the assertFileDoesNotExist equivalent.
+    """
+    vm = smoke_vm
+    original_enabled = helpers.config_get(vm, _ENABLE_CB_CFG)
+    if original_enabled != "on":
+        helpers.set_package_enabled(vm, True)
+
+    # Plant a synthetic validator sidecar under the IP orig dir.
+    sidecar_etag = f"{_IP_ORIG_DIR}/pfbtest.orig.etag"
+    try:
+        # Ensure the orig dir exists and plant the sidecar.
+        mk = subprocess.run(
+            vm.ssh_argv("/bin/mkdir", "-p", _IP_ORIG_DIR),
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            check=False,
+        )
+        assert mk.returncode == 0, f"mkdir {_IP_ORIG_DIR} failed: {mk.stderr!r}"
+
+        plant = subprocess.run(
+            vm.ssh_argv("tee", sidecar_etag),
+            input='"test-etag-download"',
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            check=False,
+        )
+        assert plant.returncode == 0, f"plant {sidecar_etag} failed: {plant.stderr!r}"
+
+        # BEFORE: confirm the sidecar exists.
+        before = vm.ssh("/bin/test", "-f", sidecar_etag)
+        assert before.returncode == 0, f"{sidecar_etag} not found after planting — cannot prove the POST caused removal"
+
+        # ACT: POST force_mode=download, scope=ip.
+        resp = webui.post(
+            UPDATE_PAGE,
+            overrides={"pfb_scope": "ip", "pfb_force_mode": "download"},
+            submit=("run", "Run Now"),
+            timeout=SAVE_TIMEOUT,
+        )
+        assert not looks_like_login_page(resp.text), "force=download POST returned the login form (session lost)"
+
+        # AFTER: the .etag sidecar must be gone (handler cleared it).
+        after = vm.ssh("/bin/test", "-f", sidecar_etag)
+        assert after.returncode != 0, (
+            f"{sidecar_etag} still exists after force=download POST — "
+            "pfb_force_clear_validators(clear_hashes=FALSE) was not called for scope=ip"
+        )
+
+    finally:
+        # Clean up: remove any leftover sidecar; restore enable state.
+        vm.ssh("/bin/rm", "-f", sidecar_etag)
+        if original_enabled != "on":
+            helpers.set_package_enabled(vm, False)
+
+
+def test_force_mode_both_clears_hash_sidecars(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Force=Both clears .orig.etag AND .orig.xxhash128 before dispatching forcecheck.
+
+    Scenario: Both mode removes validator AND hash sidecars for in-scope feeds.
+
+    Given synthetic pfbtest.orig.etag AND pfbtest.orig.xxhash128 in the IP orig dir,
+    And both files EXIST (pre-state confirmed),
+
+    When the Update page is submitted with pfb_force_mode=both and pfb_scope=ip,
+
+    Then BOTH the .orig.etag and .orig.xxhash128 sidecars are GONE —
+      proving pfb_force_clear_validators() was called with clear_hashes=TRUE.
+
+    Red→green: before this change, force=both did not exist; no sidecar was cleared.
+    """
+    vm = smoke_vm
+    original_enabled = helpers.config_get(vm, _ENABLE_CB_CFG)
+    if original_enabled != "on":
+        helpers.set_package_enabled(vm, True)
+
+    sidecar_etag = f"{_IP_ORIG_DIR}/pfbtest.orig.etag"
+    sidecar_hash = f"{_IP_ORIG_DIR}/pfbtest.orig.xxhash128"
+    try:
+        mk = subprocess.run(
+            vm.ssh_argv("/bin/mkdir", "-p", _IP_ORIG_DIR),
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            check=False,
+        )
+        assert mk.returncode == 0, f"mkdir {_IP_ORIG_DIR} failed: {mk.stderr!r}"
+
+        for path, content in ((sidecar_etag, '"test-etag-both"'), (sidecar_hash, "deadbeef")):
+            p = subprocess.run(
+                vm.ssh_argv("tee", path),
+                input=content,
+                capture_output=True,
+                text=True,
+                timeout=30.0,
+                check=False,
+            )
+            assert p.returncode == 0, f"plant {path} failed: {p.stderr!r}"
+
+        # BEFORE: both sidecars must exist.
+        for path in (sidecar_etag, sidecar_hash):
+            r = vm.ssh("/bin/test", "-f", path)
+            assert r.returncode == 0, f"{path} not found before POST — cannot prove the POST caused removal"
+
+        # ACT.
+        resp = webui.post(
+            UPDATE_PAGE,
+            overrides={"pfb_scope": "ip", "pfb_force_mode": "both"},
+            submit=("run", "Run Now"),
+            timeout=SAVE_TIMEOUT,
+        )
+        assert not looks_like_login_page(resp.text), "force=both POST returned the login form (session lost)"
+
+        # AFTER: both sidecars must be gone.
+        for path, label in ((sidecar_etag, ".orig.etag"), (sidecar_hash, ".orig.xxhash128")):
+            r = vm.ssh("/bin/test", "-f", path)
+            assert r.returncode != 0, (
+                f"{path} ({label}) still exists after force=both POST — "
+                "pfb_force_clear_validators(clear_hashes=TRUE) was not called for scope=ip"
+            )
+
+    finally:
+        for path in (sidecar_etag, sidecar_hash):
+            vm.ssh("/bin/rm", "-f", path)
         if original_enabled != "on":
             helpers.set_package_enabled(vm, False)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -369,13 +369,13 @@ def test_update_log_textareas_are_readonly(webui: WebUI) -> None:
 
 
 def test_update_revamp_controls_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
-    """Phase-6 Update page revamp: new scope/force controls present; old opaque ones gone.
+    """Update page revamp: new scope + force-mode controls present; old opaque ones gone.
 
     The opaque Force/Update/Cron/Reload radio trio was replaced with an explicit Run
-    Scope radio (ip / dnsbl / both) and a Force Reparse checkbox.  A read-only Schedule
-    section now shows last-run and next-due per ledger job.
+    Scope radio (ip / dnsbl / both) and a Force radio group (none / parse / download /
+    both).  A read-only Schedule section shows last-run and next-due per ledger job.
 
-    Scenario: Update page revamp controls render after Phase 6.
+    Scenario: Update page revamp controls render after Phase 6 + Force-mode addition.
       Background: pfBlockerNG deployed; Update page renders cleanly.
 
     Given the Update page renders via the clean-render oracle (200, no PHP diagnostic,
@@ -385,14 +385,15 @@ def test_update_revamp_controls_render(webui: WebUI, php_error_log_guard: PhpErr
 
     Then the new scope radio IDs are PRESENT (``pfb_scope_both``, ``pfb_scope_ip``,
       ``pfb_scope_dnsbl``) — proving the scope selector rendered;
-    And the Force Reparse checkbox name is PRESENT (``pfb_run_force``) — proving the
-      force toggle rendered;
-    And ``Run Scope`` and ``Force Reparse`` group labels are PRESENT — proving the new
-      form groups rendered;
+    And the Force radio group field name is PRESENT (``pfb_force_mode``) — proving the
+      four-mode force selector rendered (none / parse / download / both);
+    And ``Run Scope`` and ``Force`` group labels are PRESENT — proving the new form
+      groups rendered;
     And ``Schedule`` section text is PRESENT — proving the new section rendered;
     And the old opaque radio IDs are ABSENT (``pfb_force_update``, ``pfb_force_cron``,
       ``pfb_force_reload``, ``pfb_reload_option_all``) — PRESENT before Phase 6 in the
-      old Force/Reload radio groups, so their absence is the before/after fail guard.
+      old Force/Reload radio groups, so their absence is the before/after fail guard;
+    And the old ``pfb_run_force`` checkbox name is ABSENT — replaced by ``pfb_force_mode``.
 
     ``php_error_log_guard`` enrolls this GET in the module-level no-growth sweep.
     """
@@ -405,11 +406,14 @@ def test_update_revamp_controls_render(webui: WebUI, php_error_log_guard: PhpErr
     for needle in ('id="pfb_scope_both"', 'id="pfb_scope_ip"', 'id="pfb_scope_dnsbl"'):
         assert needle in body, f"Update page missing new scope radio {needle!r}"
 
-    # PRESENT: Force Reparse checkbox
-    assert 'name="pfb_run_force"' in body, "Update page missing 'pfb_run_force' checkbox"
+    # PRESENT: Force radio group (four-mode: none / parse / download / both)
+    assert 'name="pfb_force_mode"' in body, (
+        "Update page missing 'pfb_force_mode' Force radio group — "
+        "the four-mode force selector (none/parse/download/both) did not render"
+    )
 
     # PRESENT: section / group labels confirming the new design
-    for needle in ("Run Scope", "Force Reparse", "Schedule"):
+    for needle in ("Run Scope", "Force", "Schedule"):
         assert needle in body, f"Update page missing new label {needle!r}"
 
     # ABSENT: old opaque force/reload radio IDs (PRESENT in old code → fail before Phase 6)
@@ -420,6 +424,11 @@ def test_update_revamp_controls_render(webui: WebUI, php_error_log_guard: PhpErr
         'id="pfb_reload_option_all"',
     ):
         assert needle not in body, f"Update page still has old control {needle!r} — Phase-6 revamp not applied"
+
+    # ABSENT: old single-checkbox force name (replaced by the four-mode radio group)
+    assert 'name="pfb_run_force"' not in body, (
+        "Update page still has old 'pfb_run_force' checkbox — it must be replaced by the 'pfb_force_mode' radio group"
+    )
 
 
 def test_dnsbl_idn_blocking_fields_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:


### PR DESCRIPTION
## Update page improvements

Three independent fixes/features on the Update (Run) page, one commit each.

### 1. Run Now / View button spacing + Run Scope radio alignment
The Run Now and View buttons rendered flush together; spaced them to match the
side-by-side button idiom used elsewhere (`&emsp;`). Run Scope radio option
labels were misaligned; widened them so the labels line up.

### 2. Cron Status: fix false "[ Missing cron task ]" + show the next tick
The Cron Status probed the crontab with the legacy `interval`/`min`/`24hour`
signature and derived the next-run time from the per-feed cadence. Post-ADR-43
the scheduler is a single `*/pfb_tick_interval` tick installed whenever
pfBlockerNG is enabled, so the page falsely reported the tick missing and a wrong
time. It now probes the exact tick signature the installer registers and shows
the next `*/N` tick boundary (`pfb_next_tick_boundary()`). The per-feed cadence
remains in the Schedule view.

### 3. Force modes — None / Parse / Download / Both
Replace the single "Force Reparse" checkbox with a four-mode Force radio group:

- **None** — normal run (reload only what changed).
- **Parse** — reload all lists regardless of changes, no re-download.
- **Download** — re-fetch all list files, reload only if changes are detected.
- **Both** — re-fetch all list files and reload all lists regardless of changes.

Download/Both clear the scoped conditional-GET sidecars (`.etag`/`.lastmod`, plus
the hash baseline for Both) then run the change detector on demand for all
in-scope feeds (a new `forcecheck` verb; `pfblockerng_sync_cron()` gains
`$force_all`/`$scope` params whose defaults keep the scheduled `cron` path
byte-identical). The detector's per-feed contract is unchanged. Parse keeps the
existing reparse-from-cache path.

## Tests
- New PHPUnit coverage for `pfb_next_tick_boundary()` (5 cases) and
  `pfb_force_clear_validators()` (4 cases), both red→green vs the pre-change code.
- Tier-A render: asserts the new `pfb_force_mode` control renders and the old
  `pfb_run_force` checkbox is gone.
- Tier-B `ui_e2e`: the cron status reports the scheduled tick (not "Missing"), and
  Download/Both clear the planted sidecars before dispatch. (Dispatch-only;
  validated on a live-VM UI-tier run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
