### PR TITLE
smoke: UI tier fails in CI when SMOKE_ADMIN_PASSWORD unset (no skip-as-pass)

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -189,7 +189,8 @@ to drive the live webConfigurator. It is off the default `pytest` like the rest 
   (`python -m playwright install chromium`); module-level `importorskip` SKIPs cleanly without it.
 
 Run a tier against a smoke VM exactly like the smoke suite — re-enable the package and select
-the marker (`SMOKE_ADMIN_PASSWORD` must be set, else the UI fixtures SKIP, never fail):
+the marker (`SMOKE_ADMIN_PASSWORD` must be set; if unset the UI fixtures SKIP off-CI but FAIL
+under CI — `CI`/`GITHUB_ACTIONS` — so a missing secret can't pass the tier by skipping it):
 
 ```sh
 python -m pytest tests/smoke/ui -m ui_render --override-ini="addopts="

--- a/tests/smoke/ui/conftest.py
+++ b/tests/smoke/ui/conftest.py
@@ -8,9 +8,11 @@ touches a default ``python -m pytest`` run.
 Credentials: the pfSense ``admin`` password is the ADR-04 baked
 ``SMOKE_ADMIN_PASSWORD`` (bcrypt in ``config.xml``, plaintext in the secret).
 It is NOT yet exported to pytest by ``smoke-single.yml`` (ADR-04 used SSH-key auth and
-reachability-only WebUI). :func:`admin_credentials` reads it from the
-environment and SKIPS (not fails) when absent, so a local ``pytest -m ui_render``
-without the secret skips cleanly. Phase 5 wires ``SMOKE_ADMIN_PASSWORD`` (and an
+reachability-only WebUI). :func:`admin_credentials` reads it from the environment.
+Off-CI (a credential-less local run) an unset password is a clean skip; under CI
+(``CI`` / ``GITHUB_ACTIONS`` set) it is a HARD FAILURE -- the secret is required
+there, and skipping the whole tier while the job reports green is a false pass (see
+:mod:`tests.smoke.ui.credgate`). Phase 5 wires ``SMOKE_ADMIN_PASSWORD`` (and an
 optional ``SMOKE_ADMIN_USER``) into the workflow's pytest ``env:`` block -- this
 phase does NOT edit any workflow.
 """

--- a/tests/smoke/ui/conftest.py
+++ b/tests/smoke/ui/conftest.py
@@ -27,6 +27,7 @@ import pytest
 
 from ..conftest import SmokeVM
 from ..helpers import REDACTED, parse_redact_values
+from .credgate import admin_password_decision
 from .webui import SESSION_COOKIE, WebUI
 
 if TYPE_CHECKING:
@@ -43,8 +44,7 @@ PFB_READY_PATH = "/pfblockerng/pfblockerng_general.php"
 PFB_READY_ATTEMPTS = 60
 PFB_READY_DELAY = 2.0
 
-# Env var carrying the baked admin password (ADR-04 SMOKE_ADMIN_PASSWORD).
-ADMIN_PASSWORD_ENV = "SMOKE_ADMIN_PASSWORD"
+# The admin password env var ("SMOKE_ADMIN_PASSWORD") + its skip/fail decision live in .credgate.
 # Optional override of the admin username; pfSense's default is "admin".
 ADMIN_USER_ENV = "SMOKE_ADMIN_USER"
 DEFAULT_ADMIN_USER = "admin"
@@ -148,15 +148,18 @@ __all__ = ["REDACTED", "mask_page_identity"]
 def admin_credentials() -> tuple[str, str]:
     """``(username, password)`` for the webConfigurator, from the environment.
 
-    Skips when ``SMOKE_ADMIN_PASSWORD`` is unset so a credential-less local run
-    is a clean skip rather than a login failure.
+    Off-CI (a credential-less local run) an unset ``SMOKE_ADMIN_PASSWORD`` is a clean
+    skip. Under CI it is a HARD FAILURE: the secret is required there, and skipping the
+    whole UI tier while the job still reports green is a false pass (see :mod:`.credgate`).
     """
-    password: str | None = os.environ.get(ADMIN_PASSWORD_ENV)
-    if not password:
-        pytest.skip(f"{ADMIN_PASSWORD_ENV} not set -- no webConfigurator admin password")
-    assert password is not None  # narrow for the type checker (pytest.skip is NoReturn)
+    action, value = admin_password_decision(os.environ)
+    if action == "fail":
+        pytest.fail(value)
+    if action == "skip":
+        pytest.skip(value)
+    # action == "ok": value is the password.
     username = os.environ.get(ADMIN_USER_ENV) or DEFAULT_ADMIN_USER
-    return username, password
+    return username, value
 
 
 @pytest.fixture(scope="session")

--- a/tests/smoke/ui/credgate.py
+++ b/tests/smoke/ui/credgate.py
@@ -12,12 +12,13 @@ correct; under CI the secret is required, so an unset password is a hard failure
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Literal
 
 # Env var carrying the baked webConfigurator admin password (ADR-04 SMOKE_ADMIN_PASSWORD).
 ADMIN_PASSWORD_ENV = "SMOKE_ADMIN_PASSWORD"
 
 
-def admin_password_decision(env: Mapping[str, str]) -> tuple[str, str]:
+def admin_password_decision(env: Mapping[str, str]) -> tuple[Literal["ok", "fail", "skip"], str]:
     """Decide how the ``admin_credentials`` fixture resolves the admin password.
 
     Returns ``(action, value)``:

--- a/tests/smoke/ui/credgate.py
+++ b/tests/smoke/ui/credgate.py
@@ -1,0 +1,41 @@
+"""Credential-gate decision for the UI tier — a pure, dependency-free helper.
+
+Kept in its own module (no ``requests``/VM imports) so the default unit suite can
+import and test it; ``tests/smoke`` itself is ``--ignore``d by the default
+``python -m pytest``, so a meta-test must live under ``tests/`` and import THIS.
+
+The point: a missing ``SMOKE_ADMIN_PASSWORD`` must NOT let the whole UI tier skip and
+still report the job green (a false pass). Off-CI (a credential-less local run) a skip is
+correct; under CI the secret is required, so an unset password is a hard failure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+# Env var carrying the baked webConfigurator admin password (ADR-04 SMOKE_ADMIN_PASSWORD).
+ADMIN_PASSWORD_ENV = "SMOKE_ADMIN_PASSWORD"
+
+
+def admin_password_decision(env: Mapping[str, str]) -> tuple[str, str]:
+    """Decide how the ``admin_credentials`` fixture resolves the admin password.
+
+    Returns ``(action, value)``:
+
+    * ``("ok", password)``  — the password is set; use it.
+    * ``("fail", message)`` — the password is unset AND we are running under CI
+      (``CI`` or ``GITHUB_ACTIONS`` set): a required secret is misconfigured, so the
+      UI tier must FAIL loudly rather than skip the whole tier and report green.
+    * ``("skip", message)`` — the password is unset off-CI (a credential-less local
+      run): a clean skip, as before.
+    """
+    password = env.get(ADMIN_PASSWORD_ENV)
+    if password:
+        return ("ok", password)
+    if env.get("CI") or env.get("GITHUB_ACTIONS"):
+        return (
+            "fail",
+            f"{ADMIN_PASSWORD_ENV} not set in CI — the UI tier requires the webConfigurator "
+            "admin password; refusing to skip the tier and report a false pass.",
+        )
+    return ("skip", f"{ADMIN_PASSWORD_ENV} not set -- no webConfigurator admin password")

--- a/tests/test_ui_admin_password_gate.py
+++ b/tests/test_ui_admin_password_gate.py
@@ -50,5 +50,7 @@ def test_unset_password_off_ci_skips() -> None:
 
 def test_empty_password_treated_as_unset() -> None:
     """An empty-string password is not a real credential — treated as unset."""
-    assert admin_password_decision({ADMIN_PASSWORD_ENV: ""})[0] == "skip"
-    assert admin_password_decision({ADMIN_PASSWORD_ENV: "", "CI": "true"})[0] == "fail"
+    action, _ = admin_password_decision({ADMIN_PASSWORD_ENV: ""})
+    assert action == "skip", f"empty password off-CI must skip (treated as unset), got {action!r}"
+    action, _ = admin_password_decision({ADMIN_PASSWORD_ENV: "", "CI": "true"})
+    assert action == "fail", f"empty password under CI must fail (treated as unset), got {action!r}"

--- a/tests/test_ui_admin_password_gate.py
+++ b/tests/test_ui_admin_password_gate.py
@@ -1,0 +1,54 @@
+"""The UI tier must not skip-as-pass when its required secret is missing in CI.
+
+Pins :func:`tests.smoke.ui.credgate.admin_password_decision`: the pure decision the
+``admin_credentials`` fixture acts on. ``tests/smoke`` is ``--ignore``d by the default
+``python -m pytest`` (it needs a live VM), so this meta-test lives under ``tests/`` to run
+in the PR unit gate — exactly where the false-green would otherwise hide.
+
+Red->green: before the fix the fixture unconditionally ``pytest.skip``ed on an unset
+password, so a CI run with the secret missing skipped the whole UI tier and the job still
+reported success. Now an unset password under CI maps to ``"fail"`` (a hard failure);
+off-CI it still maps to ``"skip"``.
+"""
+
+from __future__ import annotations
+
+from tests.smoke.ui.credgate import ADMIN_PASSWORD_ENV, admin_password_decision
+
+
+def test_password_present_is_ok() -> None:
+    """A set password yields ('ok', password) regardless of CI."""
+    action, value = admin_password_decision({ADMIN_PASSWORD_ENV: "hunter2"})
+    assert action == "ok", f"expected 'ok' with the password set, got {action!r}"
+    assert value == "hunter2", f"expected the password back, got {value!r}"
+
+
+def test_present_password_wins_even_in_ci() -> None:
+    """The password being set short-circuits the CI-required check."""
+    action, value = admin_password_decision({ADMIN_PASSWORD_ENV: "pw", "CI": "true"})
+    assert action == "ok" and value == "pw", f"set password under CI must be 'ok'/pw, got {action!r}/{value!r}"
+
+
+def test_unset_password_in_ci_fails() -> None:
+    """Unset password + CI marker => hard FAIL (no skip-as-pass).
+
+    This is the regression guard: with `CI`/`GITHUB_ACTIONS` set, a missing secret must
+    NOT skip the tier. Pre-fix this returned a skip (false green).
+    """
+    for ci_env in ({"CI": "true"}, {"GITHUB_ACTIONS": "true"}, {"CI": "1", "GITHUB_ACTIONS": "true"}):
+        action, msg = admin_password_decision(ci_env)
+        assert action == "fail", f"unset password under {ci_env!r} must FAIL, got {action!r}"
+        assert ADMIN_PASSWORD_ENV in msg, f"failure message should name the env var, got {msg!r}"
+
+
+def test_unset_password_off_ci_skips() -> None:
+    """Unset password with no CI marker => clean skip (credential-less local run)."""
+    action, msg = admin_password_decision({})
+    assert action == "skip", f"unset password off-CI must skip, got {action!r}"
+    assert ADMIN_PASSWORD_ENV in msg, f"skip message should name the env var, got {msg!r}"
+
+
+def test_empty_password_treated_as_unset() -> None:
+    """An empty-string password is not a real credential — treated as unset."""
+    assert admin_password_decision({ADMIN_PASSWORD_ENV: ""})[0] == "skip"
+    assert admin_password_decision({ADMIN_PASSWORD_ENV: "", "CI": "true"})[0] == "fail"


### PR DESCRIPTION
## UI tier must not skip-as-pass when its secret is missing in CI

The session-scoped `admin_credentials` fixture (`tests/smoke/ui/conftest.py`) `pytest.skip`ed
when `SMOKE_ADMIN_PASSWORD` was unset, and **every** UI test depends on it — so a missing
secret skipped the *entire* UI tier while the job still reported **success**. A skip that
reads as a pass is a false green: a misconfigured/empty secret in CI silently disabled the
whole tier.

### Fix
- A pure, dependency-free decision helper `admin_password_decision(env)` in a new
  `tests/smoke/ui/credgate.py` returns `'ok'` / `'skip'` / `'fail'`:
  - password set → `ok`;
  - unset **under CI** (`CI` / `GITHUB_ACTIONS` set) → `fail` (the secret is required there);
  - unset **off-CI** (credential-less local run) → `skip` (unchanged).
- The fixture acts on it (`pytest.fail` vs `pytest.skip`). No workflow change — CI is detected
  via the runner-provided env vars.

### Why a separate module + a meta-test under `tests/`
`tests/smoke` is `--ignore`d by the default `python -m pytest` (it needs a live VM), so a
meta-test there would not gate the PR. The helper lives in its own module (no `requests`/VM
imports) so the default unit suite can import it, and `tests/test_ui_admin_password_gate.py`
runs in PR CI — exactly where the false green would otherwise hide. It pins every branch
(present→ok, unset+CI→fail, unset+off-CI→skip, empty-string→unset), red→green vs the old
unconditional skip.

Tests/CI only — no `src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
