### PR TITLE
pfblockerng: fix stale 'Kill States' tab reference in States Removal help

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1452,7 +1452,7 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 		'States Removal',
 		$pconfig['stateremoval'],
 		$options_stateremoval
-	))->setHelp('With the \'Kill States\' option (General Tab), you can disable States removal for this Alias.');
+	))->setHelp('With the \'Kill States\' option (IP Tab), you can disable States removal for this Alias.');
 
 	$form->add($section);
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -522,6 +522,37 @@ def test_feeds_custom_panel_heading_renders(webui: WebUI, php_error_log_guard: P
     )
 
 
+def test_states_removal_help_references_ip_tab(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The category-edit 'States Removal' help points at the IP tab, where 'Kill States' lives.
+
+    The 'Kill States' (``killstates``) checkbox is on the IP tab (pfblockerng_ip.php), so the
+    cross-reference in the IP-alias edit page's 'States Removal' help must read '(IP Tab)', not
+    the stale '(General Tab)'.  The field renders only for the IPv4/IPv6 alias type, so this
+    probes category_edit with ``?type=ipv4``.
+
+    Fail-before / pass-after: before the fix the States Removal help reads '(General Tab)', so
+    the '(IP Tab)' assertion fails; the negative assertion guards against the stale wording
+    returning.
+
+    Both needles are scoped to the States Removal sentence ('... you can disable States
+    removal') so they cannot be satisfied by the sibling 'Enable Logging' help on the same
+    page, which legitimately references the General tab (for the Global Logging override).
+    """
+    path = "/pfblockerng/pfblockerng_category_edit.php?type=ipv4"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("States Removal",))
+    assert result.ok, f"category_edit (ipv4) render oracle failed: {result.detail}"
+    body = resp.text
+    assert "(IP Tab), you can disable States removal" in body, (
+        "States Removal help is missing the corrected '(IP Tab)' cross-reference "
+        "(the 'Kill States' option lives on the IP tab)"
+    )
+    assert "(General Tab), you can disable States removal" not in body, (
+        "States Removal help still carries the stale '(General Tab)' cross-reference -- "
+        "'Kill States' is on the IP tab, not the General tab"
+    )
+
+
 # ADR-23: the setup wizard's DNSBL step now surfaces ADR-13's pfb_dnsvip_auto auto-VIP
 # toggle. Core wizard.php renders ONE step per GET, indexed by a 0-based `stepid` (verified
 # against pfSense upstream wizard.php: `$stepid` defaults to "0" and indexes $pkg['step']


### PR DESCRIPTION
## Problem

The IP-alias edit page's **States Removal** help text cross-references the wrong tab:

> With the 'Kill States' option (General Tab), you can disable States removal for this Alias.

The **Kill States** (`killstates`) checkbox lives on the **IP tab** (`pfblockerng_ip.php`), not the General tab — so the reference is stale.

## Fix

`(General Tab)` → `(IP Tab)` in `pfblockerng_category_edit.php`.

## Tests

Added a Tier-A (`ui_render`) test that GETs the IP-alias edit page (`?type=ipv4`, where the States Removal field renders) and asserts the help reads `(IP Tab)` and **not** `(General Tab)` — fail-before / pass-after, with the negative assertion guarding against the stale wording returning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
