### PR TITLE
tests/smoke: ensure ip_block.log exists before IPv6 alert attribution stat

### DIFF
--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -649,6 +649,23 @@ def test_ipv6_alert_external_host_attribution(
     threat_foreign = f"/pfblockerng/pfblockerng_threats.php?host={foreign}"
     threat_local = f"/pfblockerng/pfblockerng_threats.php?host={local}"
 
+    # ip_block.log is created lazily by the package — only after the first real
+    # IP-block event — so on a clean VM (or before any IP has been blocked) it may
+    # not exist yet, while the sibling dnsbl.log test passes because DNSBL activity
+    # creates its log. This test only needs the file PRESENT to append a synthetic
+    # row and check the rendering; it does not need a real block event. Guarantee
+    # the file (and its directory) exist idempotently before the stat below so the
+    # precondition cannot fail on a missing log. mkdir -p / touch are no-ops when
+    # the dir/file already exist, and touch preserves an existing log's content and
+    # size — a freshly created file is empty, so original_size == "0" and the
+    # finally truncate-back still restores it cleanly.
+    log_dir = ip_block_log.rsplit("/", 1)[0]
+    ensure_result = vm.ssh(f"mkdir -p {log_dir} && touch {ip_block_log}", timeout=15)
+    assert ensure_result.returncode == 0, (
+        f"Failed to ensure {ip_block_log!r} exists before mutation: "
+        f"rc={ensure_result.returncode}, stderr={ensure_result.stderr!r}"
+    )
+
     # Capture the original byte size — fail fast so cleanup cannot wipe the log.
     size_result = vm.ssh("stat", "-f", "%z", ip_block_log, timeout=15)
     assert size_result.returncode == 0, (


### PR DESCRIPTION
## Problem

The nightly Tier-B UI run is red on `test_ipv6_alert_external_host_attribution`
(both the `in-` and `out-` parametrizations), failing at its **precondition**:

```text
AssertionError: Failed to stat '/var/log/pfblockerng/ip_block.log' before
mutation: rc=1, stderr='stat: /var/log/pfblockerng/ip_block.log: No such file
or directory'
```

The package creates `ip_block.log` **lazily** — only after the first real
IP-block event — so on a clean VM (or before any IP has actually been blocked)
the file does not exist yet. It is not pre-created in `pfblockerng_install.inc`.
The sibling `dnsbl.log` test passes only because DNSBL activity creates that
log. This is an order-dependent precondition gap **in the test**, not a product
bug: the test only needs the file present to append a synthetic CSV row and
verify the Alerts-page rendering (`convert_ip_log` attribution by direction) —
it does not need a real block event.

## Fix

Guarantee the log file (and its directory) exist **idempotently** immediately
before the stat: `mkdir -p` the `/var/log/pfblockerng` directory, then `touch`
the log, via `vm.ssh` (which wraps commands in `/bin/sh -c`; pfSense's login
shell is tcsh). Both operations are no-ops when the dir/file already exist, and
`touch` preserves an existing log's content and size — so a pre-existing log is
untouched. A freshly created file is empty, so `original_size == "0"` and the
existing `finally` truncate-back still restores it cleanly. The rest of the test
(synthetic-row append, before/after rendering assertions, cleanup) is unchanged.
One fix covers both parametrizations, which share the body.

## Validation

This is a live-VM **Tier-B** test, which is **dispatch-only — not PR-gated** —
so PR CI does not run it. Live validation (the impacted UI leg) will be
dispatched separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
