### PR TITLE
tests/smoke: realign drifted Tier-B UI tests with shipping behavior

### DIFF
--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -307,10 +307,11 @@ def test_idn_mode_select_gates_confusable_subtoggles(
     """`#pfb_idn` = "Confusable" SHOWS the two Confusable sub-toggle checkboxes; any
     other mode HIDES them (ADR-08).
 
-    ``enable_idn_mode()`` (pfblockerng_dnsbl.php:3143, bound to ``#pfb_idn.change``)
-    ``hideCheckbox()``s ``#pfb_idn_block_malicious`` + ``#pfb_idn_escalate_suspicious``
-    -- shown ONLY when the select is "confusable". Three states are asserted
-    (Off -> Confusable -> All-IDN) so green proves the sub-toggles are confusable-
+    ``enable_idn_mode()`` (pfblockerng_dnsbl.php:3607, bound to ``#pfb_idn.change`` at
+    :3670) ``hideCheckbox()``s ``#pfb_idn_block_malicious`` + ``#pfb_idn_escalate_suspicious``
+    -- shown ONLY when the select is "confusable". The three option values are 'off'
+    (Off) / 'confusable' (Confusable) / 'on' (Always); all three states are asserted
+    (Off -> Confusable -> Always) so green proves the sub-toggles are confusable-
     specific, not always-shown nor merely "anything but Off". Playwright ``to_be_hidden``
     on the input holds when hideCheckbox sets ``display:none`` on the enclosing
     ``.form-group`` row. A full-page screenshot is captured at each state.
@@ -325,14 +326,14 @@ def test_idn_mode_select_gates_confusable_subtoggles(
     expect(block_mal).to_be_attached(timeout=JS_TIMEOUT_MS)
     expect(escalate).to_be_attached(timeout=JS_TIMEOUT_MS)
 
-    # Normalise to a deterministic start (Off) regardless of saved config.
-    if sel.input_value() != "":
-        sel.select_option("")
+    # Normalise to a deterministic start (Off = 'off') regardless of saved config.
+    if sel.input_value() != "off":
+        sel.select_option("off")
         sel.dispatch_event("change")
-        expect(sel).to_have_value("", timeout=JS_TIMEOUT_MS)
+        expect(sel).to_have_value("off", timeout=JS_TIMEOUT_MS)
 
     # BEFORE: Off -> both sub-toggles hidden.
-    expect(sel).to_have_value("", timeout=JS_TIMEOUT_MS)
+    expect(sel).to_have_value("off", timeout=JS_TIMEOUT_MS)
     expect(block_mal).to_be_hidden(timeout=JS_TIMEOUT_MS)
     expect(escalate).to_be_hidden(timeout=JS_TIMEOUT_MS)
     _shot(page, screenshot_dir, "dnsbl_idn_off_subtoggles_hidden")
@@ -345,13 +346,13 @@ def test_idn_mode_select_gates_confusable_subtoggles(
     expect(escalate).to_be_visible(timeout=JS_TIMEOUT_MS)
     _shot(page, screenshot_dir, "dnsbl_idn_confusable_subtoggles_shown")
 
-    # SELECT All-IDN -> hidden again (third state: confusable-specific, not just != Off).
-    sel.select_option("all")
+    # SELECT Always ('on') -> hidden again (third state: confusable-specific, not just != Off).
+    sel.select_option("on")
     sel.dispatch_event("change")
-    expect(sel).to_have_value("all", timeout=JS_TIMEOUT_MS)
+    expect(sel).to_have_value("on", timeout=JS_TIMEOUT_MS)
     expect(block_mal).to_be_hidden(timeout=JS_TIMEOUT_MS)
     expect(escalate).to_be_hidden(timeout=JS_TIMEOUT_MS)
-    _shot(page, screenshot_dir, "dnsbl_idn_all_subtoggles_hidden")
+    _shot(page, screenshot_dir, "dnsbl_idn_always_subtoggles_hidden")
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -106,7 +106,9 @@ def test_gateway_pfb_keep_save_roundtrip(
     page = browser_page
 
     # GIVEN: read the starting value so we know which direction to flip first.
-    original = helpers.config_get(smoke_vm, _CFG_KEEP)
+    # An absent pfb_keep reads as '' over the raw config path; PfbLenient's canonical off
+    # token is 'off' (issue #484), so normalise absent -> 'off' before asserting/flipping.
+    original = helpers.config_get(smoke_vm, _CFG_KEEP) or "off"
     assert original in ("on", "off"), f"pfb_keep starting value {original!r} not in expected vocabulary {{'on', 'off'}}"
     # The two branches: flip to the opposite, then restore. The off-token is the explicit
     # 'off' the save emits for an unchecked box (issue #484), not ''.

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -82,14 +82,19 @@ def test_gateway_pfb_keep_save_roundtrip(
     """pfb_keep (PfbToggle gateway field) persists via the General page and reflects in the DOM.
 
     Proves that the ADR-29 gateway routing on ``pfblockerng_general.php`` stores
-    the exact legacy token for ``pfb_keep`` ('on'/''), and that the General page
+    the exact legacy token for ``pfb_keep`` ('on'/'off'), and that the General page
     re-renders the checkbox in the correct state when the page is reloaded.
+
+    NOTE on the off-token (issue #484): the General save persists an EXPLICIT 'off'
+    for an unchecked pfb_keep (``(($_POST['pfb_keep'] ?? '') === 'on') ? 'on' : 'off'``),
+    not '' -- so a default-on flag can record a deliberate off across a pkg upgrade.
+    The two page-reachable tokens are therefore 'on' (checked) and 'off' (unchecked).
 
     Scenario: ADR-29 gateway save→reload round-trip for pfb_keep on the General page.
       Background: pfBlockerNG deployed; webConfigurator authenticated; wizard dismissed.
 
     Given the current stored value of pfb_keep (read via config_get oracle) is one
-      of the two legal tokens ('on' or ''),
+      of the two legal tokens ('on' or 'off'),
 
     When the General page is POST-saved with pfb_keep set to the OTHER value,
 
@@ -102,9 +107,10 @@ def test_gateway_pfb_keep_save_roundtrip(
 
     # GIVEN: read the starting value so we know which direction to flip first.
     original = helpers.config_get(smoke_vm, _CFG_KEEP)
-    assert original in ("on", ""), f"pfb_keep starting value {original!r} not in expected vocabulary {{'on', ''}}"
-    # The two branches: flip to the opposite, then restore.
-    flipped = "" if original == "on" else "on"
+    assert original in ("on", "off"), f"pfb_keep starting value {original!r} not in expected vocabulary {{'on', 'off'}}"
+    # The two branches: flip to the opposite, then restore. The off-token is the explicit
+    # 'off' the save emits for an unchecked box (issue #484), not ''.
+    flipped = "off" if original == "on" else "on"
 
     try:
         # ---- FLIP: POST pfb_keep to the opposite value ---- #
@@ -206,8 +212,10 @@ def test_log_settings_grouped_layout(
     _shot(page, screenshot_dir, "log_settings_grouped_layout")
 
     # Column header texts visible (emitted by the header Form_Group's StaticText children).
+    # exact=True so the "Schedule" header is not shadowed by the hidden "Schedules" nav
+    # link (/firewall_schedule.php), whose substring match would pick a hidden element.
     for col_header in ("Max lines", "Schedule", "Keep lines"):
-        expect(page.get_by_text(col_header).first).to_be_visible(timeout=JS_TIMEOUT_MS)
+        expect(page.get_by_text(col_header, exact=True).first).to_be_visible(timeout=JS_TIMEOUT_MS)
 
     # The log_max_log control's enclosing form-group carries the per-log label "pfBlockerNG".
     log_max_log = page.locator('select[name="log_max_log"]')

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -116,6 +116,9 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page=GENERAL_PAGE,
         field="pfb_keep",
         config_path="installedpackages/pfblockerng/config/0/pfb_keep",
+        # issue #484: the General save stores an explicit 'off' for an unchecked
+        # pfb_keep (not '') so a default-on flag can persist a deliberate off.
+        off="off",
     ),
     # ---- IP settings (installedpackages/pfblockerngipsettings/config/0) -------
     # The IP save validates ip_placeholder + maxmind_locale and fires a MaxMind
@@ -396,22 +399,26 @@ def test_dnsbl_idn_mode_select_round_trips_all_modes(
 ) -> None:
     """The 'IDN Blocking' select (``pfb_idn``) round-trips all three modes via config.xml.
 
-    Off (``''``) / All-IDN (``'all'``) / Confusable (``'confusable'``) are the options;
-    the save stores the value verbatim for 'all'/'confusable', else '' (Off). Drives
-    EACH mode and asserts the effective config node (branch coverage: every selectable
-    value, not just one), restoring the original at the end. The DNSBL save only
-    write_config()s (config.xml is the oracle) and needs the sinkhole VIP -- supplied
-    by ``dnsbl_vip_ready``.
+    Off (``'off'``) / Confusable (``'confusable'``) / Always (``'on'``) are the options
+    (ADR-08 reuses the legacy ``'on'`` token to back the "Always"/block-all-IDN mode, so it
+    round-trips with no migration); the save stores the posted token verbatim for each
+    (off->off, confusable->confusable, on->on). The 4.0.0-alpha ``'all'`` token no longer
+    exists. Drives EACH mode and asserts the effective config node (branch coverage: every
+    selectable value, not just one), restoring the original at the end. The DNSBL save only
+    write_config()s (config.xml is the oracle) and needs the sinkhole VIP -- supplied by
+    ``dnsbl_vip_ready``.
     """
     page = "/pfblockerng/pfblockerng_dnsbl.php"
     cfg = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn"
     original = helpers.config_get(smoke_vm, cfg)
     try:
-        for mode in ("confusable", "all", ""):
+        for mode in ("confusable", "on", "off"):
             got = _post_and_get(webui, smoke_vm, page, {"pfb_idn": mode}, cfg)
             assert got == mode, f"pfb_idn select: POSTing {mode!r} stored {got!r} (expected {mode!r})"
     finally:
-        _post_and_get(webui, smoke_vm, page, {"pfb_idn": original}, cfg)
+        # Restore the original; fall back to 'off' since the save validator rejects an
+        # empty/absent value (only off/confusable/on are accepted), leaving the box clean.
+        _post_and_get(webui, smoke_vm, page, {"pfb_idn": original or "off"}, cfg)
 
 
 # --------------------------------------------------------------------------- #
@@ -726,11 +733,17 @@ def test_ip_inbound_interface_multiselect_comma_join_and_empty_clear(
 
 # --------------------------------------------------------------------------- #
 # SafeSearch settings (installedpackages/pfblockerngsafesearch -- BARE node, no
-# /config/0 array). All inputs are <select> (three single + one multi). Save is
-# ALL-OR-NOTHING: the doh-Enable-needs-a-list guard aborts the ENTIRE save, so on
-# that reject path NO field is written. Single-value selects coerce a bogus value
-# to '' then ``?: 'Disable'``; the doh_list multi coerces a bogus key to ''.
-# write_config() only -- fully hermetic.
+# /config/0 array). safesearch_enable / safesearch_youtube are <select>s rendered
+# and SAVED ON THE SAFESEARCH PAGE; a bogus value coerces via ``$s_default='' ?:
+# 'Disable'``. write_config() only -- hermetic.
+#
+# The DoH/DoT/DoQ fields (safesearch_doh / safesearch_doh_list) live in the SAME
+# bare section but are rendered and SAVED ON THE DNSBL PAGE (ADR-29 foreign-section
+# write via PfbConfig::write) -- so their tests POST to DNSBL_PAGE and need the
+# sinkhole VIP (dnsbl_vip_ready), exactly like the other DNSBL-page saves. That save
+# is ALL-OR-NOTHING: the doh-Enable-needs-a-list guard aborts the ENTIRE save (no
+# field written); a non-key safesearch_doh coerces to 'Disable', a bogus doh_list key
+# coerces to ''. write_config() only -- hermetic.
 # --------------------------------------------------------------------------- #
 
 
@@ -794,15 +807,19 @@ def test_safesearch_youtube_select_three_branches_and_bogus(
 def test_safesearch_doh_select_valid_needs_list_and_bogus_coerces(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready: None,
 ) -> None:
-    """``safesearch_doh` stores 'Enable' (with a list) and coerces a bogus value to 'Disable'.
+    """``safesearch_doh`` stores 'Enable' (with a list) and coerces a bogus value to 'Disable'.
 
-    Select opts {Disable, Enable}. CAVEAT: 'Enable' with an EMPTY safesearch_doh_list
-    raises an input_error that aborts the WHOLE save, so the valid branch MUST also
-    supply a valid list (overrides include ``safesearch_doh_list='dns.google'``) ->
-    node == 'Enable'. The BOGUS branch ('Bogus') coerces via ``$s_default=''`` then
-    ``?: 'Disable'`` -> 'Disable' (the doh-list guard compares to the literal
-    'Enable', so a bogus value does not trip it). write_config() only -- hermetic.
+    Rendered and saved on the DNSBL page (ADR-29 foreign-section write into the bare
+    pfblockerngsafesearch node). Select opts {Disable, Enable}. CAVEAT: 'Enable' with an
+    EMPTY safesearch_doh_list raises an input_error that aborts the WHOLE save, so the
+    valid branch MUST also supply a valid list (overrides include
+    ``safesearch_doh_list='dns.google'``) -> node == 'Enable'. The BOGUS branch ('Bogus')
+    is not a key of $options_safesearch_doh -> coerced to 'Disable' (the empty-list guard
+    compares to the literal 'Enable', so a bogus value does not trip it). Needs the sinkhole
+    VIP (``dnsbl_vip_ready``) -- every DNSBL save runs pfb_validate_vips. write_config()
+    only -- hermetic.
     """
     vm = smoke_vm
     cfg = "installedpackages/pfblockerngsafesearch/safesearch_doh"
@@ -811,27 +828,30 @@ def test_safesearch_doh_select_valid_needs_list_and_bogus_coerces(
         assert original != "Enable", f"safesearch_doh already 'Enable' before the valid POST (original={original!r})"
         # VALID 'Enable' REQUIRES a non-empty list (else the guard aborts the save).
         got = _post_and_get(
-            webui, vm, SAFESEARCH_PAGE, {"safesearch_doh": "Enable", "safesearch_doh_list": "dns.google"}, cfg
+            webui, vm, DNSBL_PAGE, {"safesearch_doh": "Enable", "safesearch_doh_list": "dns.google"}, cfg
         )
         assert got == "Enable", f"safesearch_doh should store 'Enable' with a valid list, got {got!r}"
         # Restore: doh back to 'Disable' and clear the list.
         assert (
-            _post_and_get(webui, vm, SAFESEARCH_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, cfg)
+            _post_and_get(webui, vm, DNSBL_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, cfg)
             == "Disable"
         )
         # BOGUS doh -> coerced to 'Disable' (the empty-list guard only fires for literal 'Enable').
-        got = _post_and_get(webui, vm, SAFESEARCH_PAGE, {"safesearch_doh": "Bogus", "safesearch_doh_list": ""}, cfg)
+        got = _post_and_get(webui, vm, DNSBL_PAGE, {"safesearch_doh": "Bogus", "safesearch_doh_list": ""}, cfg)
         assert got == "Disable", f"bogus safesearch_doh should coerce to 'Disable', got {got!r}"
     finally:
-        webui.post(SAFESEARCH_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, timeout=SAVE_TIMEOUT)
+        webui.post(DNSBL_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, timeout=SAVE_TIMEOUT)
 
 
 def test_safesearch_doh_list_multiselect_valid_and_bogus_clears(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready: None,
 ) -> None:
     """``safesearch_doh_list`` stores a valid key (CSV); a bogus key coerces to ''.
 
+    Rendered and saved on the DNSBL page (ADR-29 foreign-section write); needs the
+    sinkhole VIP (``dnsbl_vip_ready``) since every DNSBL save runs pfb_validate_vips.
     Multi-select, valid keys are the ~180 entries of ``$options_safesearch_doh_list``
     (e.g. 'dns.google', 'cloudflare-dns.com'), stored as a CSV via
     ``implode(',', (array)$_POST[...])``. The validator sets the field to '' when a
@@ -847,33 +867,34 @@ def test_safesearch_doh_list_multiselect_valid_and_bogus_clears(
     try:
         # VALID single key -> stored verbatim (doh kept Disable so the guard is inert).
         got = _post_and_get(
-            webui, vm, SAFESEARCH_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": "dns.google"}, cfg
+            webui, vm, DNSBL_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": "dns.google"}, cfg
         )
         assert got == "dns.google", f"safesearch_doh_list should store 'dns.google', got {got!r}"
         # Restore/clear to '' (empty list).
-        got_clear = _post_and_get(
-            webui, vm, SAFESEARCH_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, cfg
-        )
+        got_clear = _post_and_get(webui, vm, DNSBL_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, cfg)
         assert got_clear == "", f"clearing safesearch_doh_list should store '', got {got_clear!r}"
         # BOGUS key -> not in the opts map -> coerced to '' (NOT the bogus value).
         got = _post_and_get(
             webui,
             vm,
-            SAFESEARCH_PAGE,
+            DNSBL_PAGE,
             {"safesearch_doh": "Disable", "safesearch_doh_list": "evil.example.invalid"},
             cfg,
         )
         assert got == "", f"bogus safesearch_doh_list key should coerce to '', got {got!r}"
     finally:
-        webui.post(SAFESEARCH_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, timeout=SAVE_TIMEOUT)
+        webui.post(DNSBL_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, timeout=SAVE_TIMEOUT)
 
 
 def test_safesearch_doh_enable_requires_list_guard(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready: None,
 ) -> None:
     """Enabling DoH with an EMPTY list aborts the whole save (config unchanged).
 
+    Rendered and saved on the DNSBL page (ADR-29 foreign-section write); needs the
+    sinkhole VIP (``dnsbl_vip_ready``) since every DNSBL save runs pfb_validate_vips.
     The input_error guard: ``$_POST['safesearch_doh']=='Enable' &&
     empty($_POST['safesearch_doh_list'])`` -> ``$input_errors`` -> the
     ``if (!$input_errors)`` save block is skipped -> NO write_config, config
@@ -893,27 +914,27 @@ def test_safesearch_doh_enable_requires_list_guard(
     cfg = "installedpackages/pfblockerngsafesearch/safesearch_doh"
     list_cfg = "installedpackages/pfblockerngsafesearch/safesearch_doh_list"
     # Establish a known before-state: doh Disable, no list.
-    webui.post(SAFESEARCH_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, timeout=SAVE_TIMEOUT)
+    webui.post(DNSBL_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, timeout=SAVE_TIMEOUT)
     before = helpers.config_get(vm, cfg)
     try:
         # BEFORE: doh is 'Disable' (not 'Enable').
         assert before == "Disable", f"expected safesearch_doh 'Disable' baseline, got {before!r}"
         # PASS path: Enable WITH a valid list -> persists both fields.
         got = _post_and_get(
-            webui, vm, SAFESEARCH_PAGE, {"safesearch_doh": "Enable", "safesearch_doh_list": "dns.google"}, cfg
+            webui, vm, DNSBL_PAGE, {"safesearch_doh": "Enable", "safesearch_doh_list": "dns.google"}, cfg
         )
         assert got == "Enable", f"safesearch_doh should persist 'Enable' with a valid list, got {got!r}"
         assert helpers.config_get(vm, list_cfg) == "dns.google", "safesearch_doh_list not persisted on the pass path"
         # Reset to the Disable baseline before the reject leg.
         assert (
-            _post_and_get(webui, vm, SAFESEARCH_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, cfg)
+            _post_and_get(webui, vm, DNSBL_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, cfg)
             == "Disable"
         )
         # REJECT path: Enable WITHOUT a list -> the whole save aborts -> UNCHANGED.
-        got = _post_and_get(webui, vm, SAFESEARCH_PAGE, {"safesearch_doh": "Enable", "safesearch_doh_list": ""}, cfg)
+        got = _post_and_get(webui, vm, DNSBL_PAGE, {"safesearch_doh": "Enable", "safesearch_doh_list": ""}, cfg)
         assert got == "Disable", f"DoH-Enable-with-empty-list must abort the save (config unchanged), got {got!r}"
     finally:
-        webui.post(SAFESEARCH_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, timeout=SAVE_TIMEOUT)
+        webui.post(DNSBL_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": ""}, timeout=SAVE_TIMEOUT)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -309,7 +309,11 @@ def test_toggle_flow_changes_effective_config(
     final restore leaves the box clean for Tier A / the sibling flows on the
     session VM. The oracle is config.xml read over SSH, never the POST response.
     """
-    original = helpers.config_get(smoke_vm, flow.config_path)
+    # An absent key reads as '' over the raw config path; normalise it to this flow's
+    # canonical off token so the before-state assertion and the restore compare against a
+    # real stored value (PfbLenient pfb_keep stores 'off', never ''). For the PfbToggle
+    # flows whose off token IS '', this is a no-op.
+    original = helpers.config_get(smoke_vm, flow.config_path) or flow.off
     # The toggle's "other" value -- we drive AWAY from original, then BACK.
     flipped = flow.off if original == flow.on else flow.on
 


### PR DESCRIPTION
## Why

The Tier-B Web-UI suites (`ui_e2e` / `ui_browser`) are dispatch-only — they do **not** gate PRs (only Tier A `ui_render` does). So when the shipping `src/` behavior changed, four Tier-B tests silently drifted and the nightly UI run went red. These are **test-only** fixes — the `src/` is correct; each test is realigned to current behavior and the assertions are preserved (no weakening).

## Fixes

### 1. `pfb_idn` IDN-Blocking vocabulary
The select ships options `off` / `confusable` / `on` (where `on` is labeled "Always"), the save validator hard-rejects anything else, and the stored token equals the posted token (`off→off`, `confusable→confusable`, `on→on`; `PfbIdnMode` reuses the legacy `'on'` for "All", so it round-trips with no migration).
- src: `pfblockerng_dnsbl.php:618` (validator `in_array(..., array('off','confusable','on'))`), `:782-783` (`pfb_cfg_idn_mode_write`), select options at `:2711-2719`; the gating JS `enable_idn_mode()` at `:3607` (bound `:3670`) shows the Confusable sub-toggles only when the value is `confusable`.
- `test_functional.py::test_dnsbl_idn_mode_select_round_trips_all_modes`: stale loop `("confusable","all","")` → `("confusable","on","off")`.
- `test_browser_dnsbl.py::test_idn_mode_select_gates_confusable_subtoggles`: stale `select_option("")`/`("all")` → `off`/`on`; still asserts all three states (off hidden → confusable shown → on hidden).
- (Tier A `test_render_smoke.py` already checks `">Always<"` — it was updated; the Tier-B tests were not, which is the drift.)

### 2. `pfb_keep` off-token is `'off'`, not `''`
The General save stores an explicit `'off'` for an unchecked `pfb_keep` (issue #484 backward-safety), never empty string.
- src: `pfblockerng_general.php:218` — `(($_POST['pfb_keep'] ?? '') === 'on') ? 'on' : 'off'`.
- `test_functional.py`: the `general_keep_settings` `ToggleFlow` gets `off="off"` (the dataclass default `off=""` was wrong for this field, so the restore leg `stored 'off' != ''` failed).
- `test_browser_general.py::test_gateway_pfb_keep_save_roundtrip`: off vocabulary `''` → `'off'` (assertion + flip direction).

### 3. SafeSearch DoH tests targeted the wrong page
`safesearch_doh` / `safesearch_doh_list` are rendered and **saved on the DNSBL page**, not the SafeSearch page (which only handles `safesearch_enable` / `safesearch_youtube`).
- src: `pfblockerng_dnsbl.php:711-729` (validate/coerce) and `:875-876` (`PfbConfig::write('safesearch_doh', …)` into the foreign `pfblockerngsafesearch` section); `pfblockerng_safesearch.php:47-67` handles only enable/youtube.
- The three DoH tests now POST to `DNSBL_PAGE` and take the `dnsbl_vip_ready` fixture (the DNSBL save runs `pfb_validate_vips`, so without a sinkhole VIP it aborts with input errors and nothing persists). The config node stays `installedpackages/pfblockerngsafesearch/safesearch_doh`.
- **Correction to the diagnosis:** the brief said to change the shared `SAFESEARCH_PAGE` constant to the DNSBL page. That constant is also used by the (correct) `safesearch_enable` / `safesearch_youtube` tests, so changing it globally would break those. Instead, only the three DoH tests were retargeted to the already-defined `DNSBL_PAGE`; `SAFESEARCH_PAGE` is left intact for the enable/youtube tests.

### 4. Log Settings header locator ambiguity
`get_by_text("Schedule")` substring-matched the hidden **"Schedules"** nav link (`/firewall_schedule.php`), and `.first` selected that hidden element → the visibility assertion failed.
- src: the real headers are exact `<strong>Max lines</strong>` / `<strong>Schedule</strong>` / `<strong>Keep lines</strong>` at `pfblockerng_general.php:467-469`.
- `test_browser_general.py::test_log_settings_grouped_layout`: pass `exact=True` so `"Schedule"` no longer matches `"Schedules"`.

## Validation

These are live-VM Tier-B tests and cannot run off-box; `ruff check` / `ruff format --check` are clean. Live validation (CE + Plus fan-out) is dispatched separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
