### PR TITLE
pfblockerng: correct the DNSBL IPs help text (alias name + IPv6 note)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3335,8 +3335,9 @@ $form->add($section);
 $section = new Form_Section('DNSBL IPs');
 $section->addInput(new Form_StaticText(
 	NULL,
-	'When IPs are found in any Domain based Feed, these IPs will be added to the <strong>pfB_DNSBL_IP</strong> IP Aliastable and<br />'
+	'When literal IP addresses are found in any Domain based Feed, those IPs are added to the <strong>pfB_DNSBLIP_v4</strong> / <strong>pfB_DNSBLIP_v6</strong> IP Aliastables and<br />'
 	. ' a firewall rule will be added to block those IPs.<br /><br />'
+	. 'IPv6 entries appear only when a Feed lists literal IPv6 addresses (uncommon); an empty <strong>pfB_DNSBLIP_v6</strong> does not mean the blocked Domains have no IPv6 &#8212; the Domain itself is sinkholed at the DNS layer for both A and AAAA queries.<br /><br />'
 	. '<span class="text-danger">Note: </span>To utilize this feature, select the appropriate List Action and define the Inbound/Outbound Interfaces in the <strong>IP Tab</strong>.'
 ));
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -93,6 +93,7 @@ PAGE_TABLE: tuple[Page, ...] = (
             "Interface(s)",
             "no-AAAA",
             "pfb_dnsbl_nonat",  # issue-#381 NAT opt-out checkbox (name= attr in rendered HTML)
+            "pfB_DNSBLIP_v4",  # DNSBL IPs help text names the real alias (was stale 'pfB_DNSBL_IP')
         ),
     ),
     # feeds.php is split into IPv4/IPv6/DNSBL ?type sub-tabs (ADR-16 Phase 3). Each type


### PR DESCRIPTION
## Correct the "DNSBL IPs" help text

The DNSBL page's "DNSBL IPs" section described the mechanism correctly (IPs **found in a
domain feed** are blocked — it does not resolve domains), but two things were off:

- It named the aliastable **`pfB_DNSBL_IP`**, a string that exists **nowhere else in the
  code**. The actual firewall aliases are **`pfB_DNSBLIP_v4`** / **`pfB_DNSBLIP_v6`**
  (ground-truthed by `tests/smoke/test_smoke_aggregate.py` + the code comment at
  `pfblockerng.inc:5248`). Corrected, and the v4/v6 split is now stated.
- The IPv6 behaviour was undocumented, which reads as a surprise: `pfB_DNSBLIP_v6` is
  populated **only** when a feed lists literal IPv6 addresses (uncommon), so it's usually
  empty — which does **not** mean the blocked domains have no IPv6. Added one line saying
  so (the domain is sinkholed at the DNS layer for both A and AAAA).

No behaviour change — help text only.

### Tests
Tier-A render: added `pfB_DNSBLIP_v4` to the DNSBL page's marker set, so the render smoke
asserts the corrected alias name is in the page body (red→green vs the old `pfB_DNSBL_IP`).
Validated on a dispatched `ui_render` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the DNSBL IPs help text to better explain how literal IPv4 and IPv6 addresses from feeds are handled.
  * Added clearer guidance on when IPv6 entries appear and what an empty IPv6 table means.

* **Bug Fixes**
  * Updated the DNSBL page render expectations to match the current on-page wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->