### PR TITLE
smoke: run the ADR-14 Web-UI tiers locally via local-smoke.sh

### DIFF
--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -34,12 +34,25 @@ scripts/local-smoke.sh
 # Specific --filter (pytest -k expression rides as one quoted arg, no word-split):
 scripts/local-smoke.sh --filter "test_dns_redirect or test_killstates"
 
-# Different marker:
-scripts/local-smoke.sh --marker ui_render
+# Different marker (e.g. the reboot-persistence tier):
+scripts/local-smoke.sh --marker reboot
 
 # Skip civm (two-VM LAN-client tests will SKIP):
 scripts/local-smoke.sh --no-two-vm
 
+# The ADR-14 Web-UI tiers (ui_render / ui_e2e / ui_browser):
+scripts/local-smoke.sh --marker ui_render
+```
+
+A UI-tier marker auto-scopes the run to `tests/smoke/ui` with the 300s per-test ceiling
+(matching `ui-tests.yml`); `ui_browser` additionally installs the headless Chromium binary on
+the box. **The webConfigurator admin password must be on the box** — the UI fixtures log in over
+the CSRF form, so an unset `SMOKE_ADMIN_PASSWORD` SKIPS the whole tier off-CI (a false-green of
+all-skips). Put it (and an optional `SMOKE_ADMIN_USER`, default `admin`) in the box's
+`~/.ssh/environment` (needs `PermitUserEnvironment yes`) so the on-box pytest inherits it; it
+must match the password baked into the pfSense image the box pulls.
+
+```sh
 # Explicit ref:
 scripts/local-smoke.sh --ref origin/devel
 ```
@@ -57,7 +70,9 @@ the bootstrap command string.
    - `oras` digest-compare → pull pfSense + civm images to `/root/images/{pfsense,civm}` if stale.
    - `sysctl net.ipv4.ip_unprivileged_port_start=53` + `pkill -9 -f qemu-system-x86_64`.
    - `build-leg.sh` → `SMOKE_PKG`.
-   - `run-smoke.sh --paths tests/smoke --marker <M> --timeout 30 [--filter <K>]`.
+   - `run-smoke.sh --paths <P> --marker <M> --timeout <T> [--filter <K>]` — `<P>`/`<T>` derive
+     from the marker (`scripts/lib/smoke-tier.sh`): a UI tier → `tests/smoke/ui` + 300s, else
+     `tests/smoke` + 30s; a `ui_browser` marker also installs Chromium first.
 3. `run-smoke.sh` is the ONE canonical pytest argv — same script CI uses.
 
 The CI `scope=impacted` / min-CE / auto-derived-`-k` defaulting (see

--- a/scripts/lib/smoke-tier.sh
+++ b/scripts/lib/smoke-tier.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# scripts/lib/smoke-tier.sh — map a pytest marker to the smoke run's target path,
+# per-test timeout, and whether it needs the headless-browser binary.
+#
+# Sourced by smoke-on-box.sh (local lease runs) so a bare `local-smoke.sh -m
+# ui_render` Just Works: the ADR-14 Web-UI tiers live under tests/smoke/ui and
+# want a longer per-test ceiling than the default smoke tier, and the browser
+# tier additionally needs Chromium (the pip `playwright` wheel ships bindings
+# only). The CI path (ui-tests.yml) sets these explicitly; this keeps the local
+# path in parity without the caller having to remember the right --paths/--timeout.
+#
+# The mapping is the testable bit — pinned by tests/shell/smoke_tier_spec.sh.
+# POSIX sh; no side effects (function definitions only).
+
+# pfb_smoke_tier_paths <marker> — echo the pytest target path for that marker.
+# A UI-tier marker scopes to tests/smoke/ui; anything else uses tests/smoke.
+# Glob-matched so a compound marker ("ui_render or ui_browser") still resolves.
+pfb_smoke_tier_paths() {
+    case "$1" in
+        *ui_render*|*ui_e2e*|*ui_browser*) printf 'tests/smoke/ui\n' ;;
+        *)                                 printf 'tests/smoke\n' ;;
+    esac
+}
+
+# pfb_smoke_tier_timeout <marker> — echo the per-test timeout (seconds). UI tiers
+# run multi-step CSRF/browser flows (300s, matching ui-tests.yml); the default
+# smoke tier keeps the 30s ceiling.
+pfb_smoke_tier_timeout() {
+    case "$1" in
+        *ui_render*|*ui_e2e*|*ui_browser*) printf '300\n' ;;
+        *)                                 printf '30\n' ;;
+    esac
+}
+
+# pfb_smoke_tier_needs_browser <marker> — exit 0 iff the marker runs the Tier-B
+# browser tier (needs `playwright install chromium`); non-zero otherwise.
+pfb_smoke_tier_needs_browser() {
+    case "$1" in
+        *ui_browser*) return 0 ;;
+        *)            return 1 ;;
+    esac
+}

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -49,6 +49,9 @@ REPO_ROOT="/root/pfBlockerNG"
 # shellcheck source=scripts/lib/git-env-scrub.sh
 . "${REPO_ROOT}/scripts/lib/git-env-scrub.sh"
 pfb_scrub_git_env
+# Marker → (paths, timeout, browser?) mapping for the ADR-14 UI tiers.
+# shellcheck source=scripts/lib/smoke-tier.sh
+. "${REPO_ROOT}/scripts/lib/smoke-tier.sh"
 PORTS_DIR="/root/FreeBSD-ports"
 IMAGES_DIR="/root/images"
 
@@ -235,10 +238,22 @@ printf 'smoke-on-box: provisioning test venv (.venv)...\n' >&2
 "${REPO_ROOT}/.venv/bin/python" -m pip install --quiet --upgrade pip
 "${REPO_ROOT}/.venv/bin/python" -m pip install --quiet -r "${REPO_ROOT}/tests/smoke/requirements.txt" pytest
 
-# ── Step 6: run smoke ─────────────────────────────────────────────────────── #
-printf 'smoke-on-box: running smoke (marker=%s%s)\n' \
-    "$_MARKER" "${_FILTER:+ filter=$_FILTER}" >&2
+# The Tier-B browser marker needs the Chromium BINARY (the pip wheel above ships
+# the bindings only); mirrors ui-tests.yml. Idempotent — a no-op if present.
+if pfb_smoke_tier_needs_browser "$_MARKER"; then
+    printf 'smoke-on-box: installing headless Chromium (browser tier)...\n' >&2
+    "${REPO_ROOT}/.venv/bin/python" -m playwright install --with-deps chromium
+fi
 
-set -- --paths tests/smoke --marker "$_MARKER" --timeout 30
+# ── Step 6: run smoke ─────────────────────────────────────────────────────── #
+# Paths + per-test timeout follow the marker: a UI tier scopes to tests/smoke/ui
+# with the 300s ceiling (matching ui-tests.yml); everything else keeps the
+# whole-suite tests/smoke + 30s default.
+_PATHS="$(pfb_smoke_tier_paths "$_MARKER")"
+_TIMEOUT="$(pfb_smoke_tier_timeout "$_MARKER")"
+printf 'smoke-on-box: running smoke (marker=%s paths=%s timeout=%s%s)\n' \
+    "$_MARKER" "$_PATHS" "$_TIMEOUT" "${_FILTER:+ filter=$_FILTER}" >&2
+
+set -- --paths "$_PATHS" --marker "$_MARKER" --timeout "$_TIMEOUT"
 [ -n "$_FILTER" ] && set -- "$@" --filter "$_FILTER"
 exec sh scripts/run-smoke.sh "$@"

--- a/tests/shell/smoke_tier_spec.sh
+++ b/tests/shell/smoke_tier_spec.sh
@@ -61,6 +61,11 @@ Describe 'smoke-tier.sh'
       The output should equal '300'
     End
 
+    It 'gives the UI tiers the 300s ceiling (ui_e2e)'
+      When call pfb_smoke_tier_timeout ui_e2e
+      The output should equal '300'
+    End
+
     It 'gives the UI tiers the 300s ceiling (ui_browser)'
       When call pfb_smoke_tier_timeout ui_browser
       The output should equal '300'

--- a/tests/shell/smoke_tier_spec.sh
+++ b/tests/shell/smoke_tier_spec.sh
@@ -1,0 +1,104 @@
+#shellcheck shell=sh
+# smoke_tier_spec.sh — shellspec suite for scripts/lib/smoke-tier.sh
+#
+# Pins the marker → (paths, timeout, browser?) mapping that lets a bare
+# `local-smoke.sh -m ui_render` run the ADR-14 Web-UI tiers locally with the same
+# --paths/--timeout the CI ui-tests.yml uses, plus the Chromium-needed predicate.
+#
+# RED→GREEN: before scripts/lib/smoke-tier.sh exists (and before smoke-on-box.sh
+# derives paths/timeout from the marker), a UI marker resolved to the default
+# tests/smoke + 30s and never installed Chromium — these assertions FAIL. After
+# the helper lands they PASS. Pure functions; no VM, fully hermetic.
+
+Describe 'smoke-tier.sh'
+  setup() {
+    scrub_git_env
+    # shellcheck source=scripts/lib/smoke-tier.sh
+    . "${PFB_ROOT}/scripts/lib/smoke-tier.sh"
+  }
+  BeforeEach 'setup'
+
+  Describe 'pfb_smoke_tier_paths'
+    It 'scopes ui_render to tests/smoke/ui'
+      # Scenario: the render tier's target path.
+      # Given the ui_render marker; When mapped; Then the UI subtree is used.
+      When call pfb_smoke_tier_paths ui_render
+      The output should equal 'tests/smoke/ui'
+    End
+
+    It 'scopes ui_e2e to tests/smoke/ui'
+      When call pfb_smoke_tier_paths ui_e2e
+      The output should equal 'tests/smoke/ui'
+    End
+
+    It 'scopes ui_browser to tests/smoke/ui'
+      When call pfb_smoke_tier_paths ui_browser
+      The output should equal 'tests/smoke/ui'
+    End
+
+    It 'resolves a compound UI marker to tests/smoke/ui'
+      # Scenario: a `-m "ui_render or ui_browser"` expression still scopes to ui.
+      When call pfb_smoke_tier_paths 'ui_render or ui_browser'
+      The output should equal 'tests/smoke/ui'
+    End
+
+    It 'leaves the default smoke marker on tests/smoke'
+      # Branch coverage: the non-UI side must keep the whole-suite path.
+      When call pfb_smoke_tier_paths smoke
+      The output should equal 'tests/smoke'
+    End
+
+    It 'leaves the repo marker on tests/smoke'
+      When call pfb_smoke_tier_paths repo
+      The output should equal 'tests/smoke'
+    End
+  End
+
+  Describe 'pfb_smoke_tier_timeout'
+    It 'gives the UI tiers the 300s ceiling (ui_render)'
+      # Scenario: UI flows need the longer per-test ceiling (matches ui-tests.yml).
+      When call pfb_smoke_tier_timeout ui_render
+      The output should equal '300'
+    End
+
+    It 'gives the UI tiers the 300s ceiling (ui_browser)'
+      When call pfb_smoke_tier_timeout ui_browser
+      The output should equal '300'
+    End
+
+    It 'keeps the default smoke 30s ceiling'
+      # Branch coverage: the non-UI side keeps the tight default.
+      When call pfb_smoke_tier_timeout smoke
+      The output should equal '30'
+    End
+  End
+
+  Describe 'pfb_smoke_tier_needs_browser'
+    It 'is true for ui_browser (needs Chromium)'
+      # Scenario: only the browser tier downloads the Chromium binary.
+      When call pfb_smoke_tier_needs_browser ui_browser
+      The status should be success
+    End
+
+    It 'is true for a compound marker containing ui_browser'
+      When call pfb_smoke_tier_needs_browser 'ui_render or ui_browser'
+      The status should be success
+    End
+
+    It 'is false for ui_render (bindings suffice)'
+      # Branch coverage: the HTTP render tier must NOT trigger the browser install.
+      When call pfb_smoke_tier_needs_browser ui_render
+      The status should be failure
+    End
+
+    It 'is false for ui_e2e (no browser)'
+      When call pfb_smoke_tier_needs_browser ui_e2e
+      The status should be failure
+    End
+
+    It 'is false for the default smoke marker'
+      When call pfb_smoke_tier_needs_browser smoke
+      The status should be failure
+    End
+  End
+End


### PR DESCRIPTION
## What

Make the ADR-14 Web-UI tiers runnable on the local smoke boxes via `local-smoke.sh`, so a bare
`local-smoke.sh -m ui_render` Just Works.

Before this, `smoke-on-box.sh` hardcoded `--paths tests/smoke --timeout 30`, and the browser
tier's Chromium binary was never installed — so the UI tiers either ran with the wrong
paths/timeout or skipped. (Tier A render happened to survive the 30s cap since `run-smoke.sh`
sets `timeout_func_only=true`, but Tier B did not.)

## Changes

- **`scripts/lib/smoke-tier.sh`** (new) — pure marker → `(paths, timeout, browser?)` mapping:
  a UI-tier marker (`ui_render`/`ui_e2e`/`ui_browser`, glob-matched so a compound `-m` expression
  still resolves) → `tests/smoke/ui` + 300s; everything else keeps `tests/smoke` + 30s; only
  `ui_browser` needs the Chromium binary.
- **`scripts/smoke-on-box.sh`** — sources the helper, installs headless Chromium for the browser
  tier (`playwright install --with-deps chromium`, mirroring `ui-tests.yml`), and derives
  `--paths`/`--timeout` from the marker instead of hardcoding them.
- **`tests/shell/smoke_tier_spec.sh`** (new) — shellspec pinning the mapping (every branch, both
  sides). Red→green verified: without `smoke-tier.sh` the UI markers resolve to the default
  `tests/smoke`/30s/no-Chromium and the spec fails; with it, all 14 examples pass.
- **`docs/misc/local-smoke-debian.md`** — documents the UI-tier invocation and the
  `SMOKE_ADMIN_PASSWORD` requirement (the fixtures log in over the CSRF form; an unset password
  SKIPS the whole tier off-CI — a false-green of all-skips), via the box's `~/.ssh/environment`.

## Test

`shellspec tests/shell/smoke_tier_spec.sh` → 14 examples, 0 failures (full suite: 215, 0
failures). Live local run of the UI tiers against a leased box is the out-of-CI validation (the
boxes now carry `SMOKE_ADMIN_PASSWORD` in `~/.ssh/environment`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
