### PR TITLE
smoke: collapse CaseContext teardown reset to one filter sync (#611)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2396,9 +2396,10 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
       * drops the derived state — ``clearip``/``cleardnsbl`` (tables/sqlite) then a blocking
         ``apply_filter_sync`` (pf rules).
 
-    NO forced ``update`` (unlike :func:`reset`): the config is now empty, so there is nothing
-    to rebuild — the next module's ``deployed_vm`` re-establishes the VIP/DNS/feed config it
-    needs. Used by the module-scoped autouse teardown in ``conftest.py``; safe to call
+    NO forced ``update``: the config is now empty, so there is nothing to rebuild — the next
+    module's ``deployed_vm`` re-establishes the VIP/DNS/feed config it needs. (Like :func:`reset`,
+    teardown drops derived state only; this one also wipes config.) Used by the module-scoped
+    autouse teardown in ``conftest.py``; safe to call
     directly. Raises on a non-zero ``pfSsh.php`` eval so a broken baseline surfaces loudly.
     """
     del_sections = "".join(f"config_del_path({_php_str(s)});\n" for s in _BASELINE_DEL_SECTIONS)

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2322,18 +2322,24 @@ def apply_filter_sync(vm: SmokeVM, *, timeout: float = 60.0) -> None:
 
 
 @timed_step("reset")
-def reset(vm: SmokeVM, *, timeout: float = 600.0) -> None:
+def reset(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     """Return the VM to the per-case baseline (Phase-3 isolation strategy).
 
     ``clearip`` + ``cleardnsbl`` drop the accumulated tables/sqlite, then a
-    forced ``update`` rebuilds from config — required because pfBlockerNG caches
-    feeds, so an edited mock fixture is re-fetched only on a force.
+    blocking ``apply_filter_sync`` settles the pf ruleset — the same proven
+    teardown shape :func:`reset_pfb_baseline` uses. This is teardown ONLY: it
+    drops derived state so the next case starts clean. It does NOT rebuild from
+    config — the old forced ``update`` here was pure overhead (~31s/case on CI's
+    nested-KVM, issue #611), because the NEXT ``CaseContext.__enter__`` re-injects
+    its spec and runs its own targeted force-reload (``updateip``/``updatednsbl``,
+    which re-reads the feed regardless), so re-fetching the just-tested feed on
+    teardown is wasted work.
     """
     for verb in ("clearip", "cleardnsbl"):
         result = vm.ssh(PHP_BIN, PFB_CLI, verb, timeout=120.0)
         if result.returncode != 0:
             raise RuntimeError(f"reset {verb} failed: rc={result.returncode} stderr={result.stderr!r}")
-    reload(vm, "update", timeout=timeout)
+    apply_filter_sync(vm, timeout=timeout)
 
 
 # Whole config sections a smoke case injects into. reset_pfb_baseline DELETES these — they
@@ -4362,7 +4368,8 @@ class CaseContext:
 
     @timed_step(lambda self, *exc: f"casecontext_exit:{self.spec.aliasname}")
     def __exit__(self, *exc: object) -> None:
-        # Restore egress before reset() — its forced update reloads pfBlockerNG.
+        # Restore egress so the box is left in a clean network state for the next case
+        # (reset() itself is now local-only: clearip/cleardnsbl + a blocking filter sync).
         unblock_egress()
         # Don't let a reset() failure during teardown MASK a failure the case body
         # already raised — pytest would report the teardown error and bury the real

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -89,7 +89,7 @@ def test_inject_control_record_resolves(deployed_vm: SmokeVM, client_vm: SmokeVM
 
 
 def test_reset_returns_to_baseline(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
-    """reset() runs clear* + a forced update and leaves Unbound ready."""
+    """reset() runs clear* + a blocking filter sync and leaves the resolver intact."""
     h.reset(deployed_vm)
     # The baked control name still resolves (reset didn't break the resolver).
     name, expected_ip = expected_control_answer()

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -153,7 +153,7 @@ def test_dnsbl_lock_unlock_lifecycle_via_alerts(
       the name is VIP-blocked again. Poll until the block shape returns.
 
     Oracle = the on-box DNS answer shape, never the HTTP body. ``reset(vm)`` in
-    ``finally`` drops the test feed/alias and rebuilds the baseline so the session VM
+    ``finally`` drops the derived state (tables/sqlite + a filter sync) so the session VM
     is clean for the sibling flows.
     """
     vm = smoke_vm

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -1213,8 +1213,8 @@ def test_dnsvip_auto_form_provisions_and_removes_marked_vip(
             f"auto VIP {helpers.AUTO_VIP_IP4} still live on lo0 after the form disabled it"
         )
     finally:
-        # Leave the box clean for the sibling flows: auto off + drop the test alias
-        # and rebuild from baseline (reset = clearip/cleardnsbl + a forced update).
+        # Leave the box clean for the sibling flows: auto off + drop the derived
+        # state (reset = clearip/cleardnsbl + a blocking filter sync).
         helpers.set_dnsvip_auto(vm, False)
         helpers.reset(vm)
 


### PR DESCRIPTION
Finishes issue #611's second lever. The first (collapse the per-case **enter** to one targeted reload) landed in `94bdd0f1`; this collapses the per-case **teardown**.

## What

`CaseContext.__exit__` → `reset()` ran `clearip`/`cleardnsbl` and then a **full forced `update`** — a ~31s/case cost on CI's nested-KVM (rebuild pf tables + python-chroot Unbound reload + GeoIP). That rebuild is wasted work:

- `reset()` never wipes config, so the forced update just re-loads the *same* case's feed it is tearing down.
- The next `CaseContext.__enter__` re-injects its own spec and runs its own targeted force-reload (`updateip`/`updatednsbl`, which re-reads the feed regardless), immediately discarding whatever the teardown rebuilt.

So `reset()` only needs to drop derived state. This replaces the forced update with a blocking `apply_filter_sync` — the **same proven teardown shape `reset_pfb_baseline` already uses** (clears + filter sync, no update).

Net effect with the enter collapse already merged: each IP-feed case's CI wall drops from ~78s toward ~16s.

## Behaviour-preserving

No behaviour change — the existing IP-feed + DNSBL smoke cases are the oracle. All `reset()` callers (`CaseContext.__exit__`, the matrix/alerts/functional `finally:` blocks) use it purely for teardown; none assert on post-`reset` rebuilt state. `test_reset_returns_to_baseline` pins the one guarantee that matters — `reset()` leaves the resolver intact — and stays green (the change never restarts Unbound). Stale comments/docstrings that described the old "forced update" are corrected.

Validation is the live-VM fan-out (CE + Plus), per the issue.

Part of #611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
