### PR TITLE
pfblockerng: read-only Software output fields + persist last update log

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2290,6 +2290,21 @@ function pfbng_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 }
 
 
+/**
+ * Return the last $lines lines of $file as a string; '' if the file is missing or unreadable.
+ *
+ * PURE — library function, no side effects, no globals.
+ */
+function pfb_log_tail(string $file, int $lines = 1000): string
+{
+	if (!file_exists($file) || !is_readable($file)) {
+		return '';
+	}
+	exec('/usr/bin/tail -n ' . escapeshellarg((string)$lines) . ' ' . escapeshellarg($file), $out, $ret);
+	return $ret === 0 ? implode("\n", $out) : '';
+}
+
+
 // Manage log files line limit
 function pfb_log_mgmt() {
 	global $g, $pfb;

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -100,14 +100,27 @@ function pfb_software_status($status) {
 // shell-injection surface — the only variable parts are pkg-derived names already
 // escapeshellarg'd by the caller. Returns the command's exit status (0 = success,
 // -1 if it could not be started) so the caller can act on the result.
+// Each streamed line is also written to /var/log/pfblockerng/software.log (truncated at
+// run start) so a subsequent plain GET can prefill the output textarea.
 function pfb_software_run_stream($cmd) {
-	$fh = popen("{$cmd} 2>&1", 'r');
+	$log    = '/var/log/pfblockerng/software.log';
+	$log_fh = @fopen($log, 'w');
+	$fh     = popen("{$cmd} 2>&1", 'r');
 	if (!is_resource($fh)) {
 		pfb_software_output(gettext('Failed to start the task.'));
+		if (is_resource($log_fh)) {
+			@fclose($log_fh);
+		}
 		return -1;
 	}
 	while (($line = fgets($fh)) !== FALSE) {
+		if (is_resource($log_fh)) {
+			@fwrite($log_fh, $line);
+		}
 		pfb_software_output(rtrim($line, "\r\n"));
+	}
+	if (is_resource($log_fh)) {
+		@fclose($log_fh);
 	}
 	return pclose($fh);
 }
@@ -280,19 +293,21 @@ $section->addInput(new Form_StaticText(null, $btn_uninstall))
 $form->add($section);
 
 // Live terminal window (shown when an Update is streaming).
+// Plain GET (no active update/uninstall stream) → prefill pfb_output with the last software log.
+$pfb_sw_active = ($pfb_sw_action !== '');
 $section = new Form_Section('Output');
 $section->addInput(new Form_Textarea(
 	'pfb_status',
 	null,
 	'Standby'
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '1')->setAttribute('wrap', 'off')
-  ->setAttribute('style', 'background:#fafafa; width: 100%');
+  ->setAttribute('readonly', 'readonly')->setAttribute('style', 'background:#fafafa; width: 100%');
 $section->addInput(new Form_Textarea(
 	'pfb_output',
 	null,
-	null
+	$pfb_sw_active ? null : pfb_log_tail('/var/log/pfblockerng/software.log')
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '20')->setAttribute('wrap', 'off')
-  ->setAttribute('style', 'background:#fafafa; width: 100%');
+  ->setAttribute('readonly', 'readonly')->setAttribute('style', 'background:#fafafa; width: 100%');
 $form->add($section);
 
 print($form);

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -429,8 +429,10 @@ $section->addInput(new Form_StaticText(
 $form->add($section);
 
 // ---- Log section ----
-// Plain GET (not a Run Now POST and not a live-view) → prefill pfb_output with the last log tail.
-$pfb_log_active = (isset($_POST['run']) && $_POST['run']) ||
+// Plain GET (no active run and no live-view) → prefill pfb_output with the last log tail.
+// $pconfig['run'] is the SAME signal the Run Now dispatch gate keys on (set by a button POST
+// and by the wizard-reload GET), so this suppresses the stale prefill on every run-start path.
+$pfb_log_active = isset($pconfig['run']) ||
                   (isset($pconfig['log_view']) && $pconfig['log_view'] !== 'View');
 $section = new Form_Section('Log');
 $section->addInput(new Form_Textarea(

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -429,6 +429,9 @@ $section->addInput(new Form_StaticText(
 $form->add($section);
 
 // ---- Log section ----
+// Plain GET (not a Run Now POST and not a live-view) → prefill pfb_output with the last log tail.
+$pfb_log_active = (isset($_POST['run']) && $_POST['run']) ||
+                  (isset($pconfig['log_view']) && $pconfig['log_view'] !== 'View');
 $section = new Form_Section('Log');
 $section->addInput(new Form_Textarea(
 	'pfb_status',
@@ -440,7 +443,7 @@ $section->addInput(new Form_Textarea(
 $section->addInput(new Form_Textarea(
 	'pfb_output',
 	NULL,
-	NULL
+	$pfb_log_active ? NULL : pfb_log_tail($pfb['log'])
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '30')->setAttribute('wrap', 'off')
   ->setAttribute('readonly', 'readonly')->setAttribute('style', 'background:#fafafa; width: 100%');
 

--- a/tests/php/PfbLogTailTest.php
+++ b/tests/php/PfbLogTailTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_log_tail() — returns the last N lines of a file as a string, used to prefill the
+ * Update/Software page log textareas on a plain GET.
+ *
+ * Pins the branch contract:
+ *   - a missing or unreadable file → '' (the textarea renders empty, never a warning);
+ *   - a file shorter than the limit → every line, joined by "\n" (no trailing newline);
+ *   - a file longer than the limit → only the LAST N lines (the tail, not the head);
+ *   - the default limit returns the whole short file.
+ *
+ * Off-appliance: /usr/bin/tail exists on the Linux CI host, so no exec double is needed.
+ */
+#[CoversFunction('pfb_log_tail')]
+final class PfbLogTailTest extends TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$base = sys_get_temp_dir() . '/pfb_log_tail_' . getmypid() . '_' . mt_rand(0, 0xffff);
+		if (!mkdir($base, 0777, TRUE)) {
+			$this->fail("Could not create temp dir: {$base}");
+		}
+		$this->dir = $base;
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->dir . '/*') ?: array() as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dir);
+	}
+
+	public function testMissingFileReturnsEmptyString(): void
+	{
+		$result = pfb_log_tail($this->dir . '/does-not-exist.log');
+		$this->assertSame('', $result, 'A missing file must yield the empty string, not a warning.');
+	}
+
+	public function testReturnsAllLinesWhenShorterThanLimit(): void
+	{
+		$file = $this->dir . '/short.log';
+		file_put_contents($file, "alpha\nbravo\ncharlie\n");
+
+		$result = pfb_log_tail($file, 10);
+
+		$this->assertSame(
+			"alpha\nbravo\ncharlie",
+			$result,
+			'A file shorter than the limit must return every line joined by a newline (no trailing newline).'
+		);
+	}
+
+	public function testReturnsOnlyTheLastNLines(): void
+	{
+		$file = $this->dir . '/long.log';
+		file_put_contents($file, "l1\nl2\nl3\nl4\nl5\n");
+
+		$result = pfb_log_tail($file, 2);
+
+		$this->assertSame(
+			"l4\nl5",
+			$result,
+			'A file longer than the limit must return the TAIL (last N lines), not the head.'
+		);
+	}
+
+	public function testDefaultLimitReturnsWholeShortFile(): void
+	{
+		$file = $this->dir . '/default.log';
+		file_put_contents($file, "one\ntwo\nthree\n");
+
+		$result = pfb_log_tail($file);
+
+		$this->assertSame(
+			"one\ntwo\nthree",
+			$result,
+			'The default limit (1000) must return the whole short file.'
+		);
+	}
+}

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -24,6 +24,7 @@ with the reason and the access note for Phase 5, NOT silently dropped.
 from __future__ import annotations
 
 import re
+import subprocess
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -971,3 +972,130 @@ def test_page_table_covers_every_pfblockerng_page() -> None:
     excluded_names = {e.name for e in EXCLUDED_FROM_TIER_A}
     assert "geoip_continent_views" in excluded_names
     assert "dnsbl_vip_sinkhole_pages" in excluded_names
+
+
+# ---------------------------------------------------------------------------
+# Tier-B tests — ui_e2e marker; schedule/dispatch-only, NOT PR-blocking.
+# These require VM state setup (seeding files or multi-step POST → GET flows).
+# ---------------------------------------------------------------------------
+
+_PFB_LOG = "/var/log/pfblockerng/pfblockerng.log"
+_SOFTWARE_LOG = "/var/log/pfblockerng/software.log"
+
+
+def _seed_vm_file(vm: SmokeVM, path: str, content: str, *, timeout: float = 30.0) -> None:
+    """Append *content* to *path* on the guest via ``tee -a``.
+
+    Uses ``subprocess.run`` directly so ``input=`` can carry the data (the
+    ``SmokeVM.ssh()`` helper captures stdout/stderr only, no stdin pipe).
+    The parent directory must already exist (``/var/log/pfblockerng/`` is
+    created by pfBlockerNG on install — always present after ``pkg add``).
+    """
+    result = subprocess.run(
+        vm.ssh_argv("tee", "-a", path),
+        input=content,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"_seed_vm_file({path!r}) failed: rc={result.returncode} {result.stderr!r}")
+
+
+@pytest.mark.ui_e2e
+def test_software_textareas_are_readonly(
+    smoke_vm: SmokeVM,
+    webui: WebUI,
+    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
+) -> None:
+    """The Software page's pfb_status and pfb_output textareas carry the readonly attribute.
+
+    Scenario: Software output windows are display-only — they must not be editable.
+      Given the Software page rendered with the override gate forced on,
+      When each log textarea opening tag is located by name,
+      Then it contains the readonly attribute.
+
+    Fail-before / pass-after: before this change the two textareas on the Software page
+    had no readonly attribute (unlike the Update page which already had it). These
+    assertions FAIL on the old markup and PASS only after the attribute is added.
+    Paired with ``test_update_log_textareas_are_readonly`` (Tier A) to prove both pages
+    now carry the attribute.
+
+    The Software page's provenance gate blocks direct GET on the sideload deploy, so the
+    hidden override sentinel is used (same pattern as the other software tests above).
+    """
+    with software_panel_forced(smoke_vm, "on"):
+        body = webui.get(_SOFTWARE_PAGE).text
+        for name in ("pfb_status", "pfb_output"):
+            m = re.search(r"<textarea\b[^>]*\bname=([\"'])" + re.escape(name) + r"\1[^>]*>", body)
+            assert m is not None, f"Software page is missing the '{name}' textarea"
+            tag = m.group(0)
+            assert re.search(r"\breadonly\b", tag), (
+                f"Software page '{name}' textarea is editable (no readonly attribute): {tag!r}"
+            )
+
+
+@pytest.mark.ui_e2e
+def test_update_log_prefills_on_plain_get(
+    smoke_vm: SmokeVM,
+    webui: WebUI,
+    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
+) -> None:
+    """A plain GET of the Update page prefills pfb_output with the last log tail.
+
+    Scenario: After seeding the pfBlockerNG log, a fresh plain GET shows the content.
+      Given a known marker line appended to /var/log/pfblockerng/pfblockerng.log on the VM,
+      When the Update page is GET with no POST parameters,
+      Then the pfb_output textarea's initial value contains the seeded marker.
+
+    Fail-before / pass-after: before this change pfb_output was always rendered empty
+    (value=NULL) on a plain GET, so the textarea content would be blank and the seeded
+    marker absent. After the fix, pfb_log_tail() prefills it, so the marker appears.
+
+    Multi-step (seed → GET) classifies as Tier B per the CLAUDE.md mandate.
+    """
+    seed = "pfb-update-log-prefill-test-marker"
+    _seed_vm_file(smoke_vm, _PFB_LOG, seed + "\n")
+    body = webui.get(_UPDATE_PAGE).text
+    m = re.search(r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>', body, re.DOTALL)
+    assert m is not None, "Update page is missing the pfb_output textarea in the rendered body"
+    content = m.group(1)
+    assert seed in content, (
+        f"Update page pfb_output is not prefilled on plain GET: "
+        f"expected seed marker {seed!r} in textarea content, got {content[:200]!r}"
+    )
+
+
+@pytest.mark.ui_e2e
+def test_software_log_prefills_on_plain_get(
+    smoke_vm: SmokeVM,
+    webui: WebUI,
+    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
+) -> None:
+    """A plain GET of the Software page prefills pfb_output from software.log.
+
+    Scenario: After seeding /var/log/pfblockerng/software.log, a fresh plain GET shows
+    that content in the pfb_output textarea.
+      Given a known marker line written to software.log on the VM,
+      When the Software page is GET (override gate forced on),
+      Then the pfb_output textarea's initial value contains the seeded marker.
+
+    Fail-before / pass-after: before this change pfb_output was rendered empty on a
+    plain GET (value=NULL). After the fix, pfb_log_tail() reads software.log and prefills
+    the textarea, so the seeded marker appears. A real pkg upgrade is too heavy to
+    simulate in this suite, so the seed-file approach exercises the full prefill path.
+
+    Multi-step (seed → GET) classifies as Tier B per the CLAUDE.md mandate.
+    """
+    seed = "pfb-software-log-prefill-test-marker"
+    _seed_vm_file(smoke_vm, _SOFTWARE_LOG, seed + "\n")
+    with software_panel_forced(smoke_vm, "on"):
+        body = webui.get(_SOFTWARE_PAGE).text
+        m = re.search(r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>', body, re.DOTALL)
+        assert m is not None, "Software page is missing the pfb_output textarea in the rendered body"
+        content = m.group(1)
+        assert seed in content, (
+            f"Software page pfb_output is not prefilled on plain GET: "
+            f"expected seed marker {seed!r} in textarea content, got {content[:200]!r}"
+        )

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -1055,10 +1056,20 @@ def test_update_log_prefills_on_plain_get(
 
     Multi-step (seed → GET) classifies as Tier B per the CLAUDE.md mandate.
     """
-    seed = "pfb-update-log-prefill-test-marker"
+    seed = f"pfb-update-log-prefill-{uuid.uuid4().hex}"
+    pat = r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>'
+
+    # Before seeding: the unique marker is ABSENT — proves the prefill caused it (not a
+    # pre-existing log line), and is robust to a re-run on the same VM where tail -a accumulates.
+    m_before = re.search(pat, webui.get(_UPDATE_PAGE).text, re.DOTALL)
+    assert m_before is not None, "Update page is missing the pfb_output textarea (before seed)"
+    assert seed not in m_before.group(1), (
+        f"seed marker {seed!r} already present before seeding — test is not self-proving"
+    )
+
+    # After seeding the log: a plain GET prefills pfb_output with the tail (marker now present).
     _seed_vm_file(smoke_vm, _PFB_LOG, seed + "\n")
-    body = webui.get(_UPDATE_PAGE).text
-    m = re.search(r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>', body, re.DOTALL)
+    m = re.search(pat, webui.get(_UPDATE_PAGE).text, re.DOTALL)
     assert m is not None, "Update page is missing the pfb_output textarea in the rendered body"
     content = m.group(1)
     assert seed in content, (
@@ -1088,11 +1099,19 @@ def test_software_log_prefills_on_plain_get(
 
     Multi-step (seed → GET) classifies as Tier B per the CLAUDE.md mandate.
     """
-    seed = "pfb-software-log-prefill-test-marker"
-    _seed_vm_file(smoke_vm, _SOFTWARE_LOG, seed + "\n")
+    seed = f"pfb-software-log-prefill-{uuid.uuid4().hex}"
+    pat = r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>'
     with software_panel_forced(smoke_vm, "on"):
-        body = webui.get(_SOFTWARE_PAGE).text
-        m = re.search(r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>', body, re.DOTALL)
+        # Before seeding: the unique marker is ABSENT (self-proving + same-VM re-run safe).
+        m_before = re.search(pat, webui.get(_SOFTWARE_PAGE).text, re.DOTALL)
+        assert m_before is not None, "Software page is missing the pfb_output textarea (before seed)"
+        assert seed not in m_before.group(1), (
+            f"seed marker {seed!r} already present before seeding — test is not self-proving"
+        )
+
+        # After seeding software.log: a plain GET prefills pfb_output with its tail.
+        _seed_vm_file(smoke_vm, _SOFTWARE_LOG, seed + "\n")
+        m = re.search(pat, webui.get(_SOFTWARE_PAGE).text, re.DOTALL)
         assert m is not None, "Software page is missing the pfb_output textarea in the rendered body"
         content = m.group(1)
         assert seed in content, (


### PR DESCRIPTION
## Update + Software pages: read-only output fields, and persist the last update log

Two front-end fixes reported by the maintainer after upgrading to v4.0.0.alpha.6.

### 1. Software-page output fields were editable
The `pfb_status` and `pfb_output` textareas on the **Software** page lacked the `readonly`
attribute, so the live-terminal/output windows could be typed into. The **Update** page already
sets it on the identical fields. Added `readonly` to both, matching the Update page.

### 2. Last update log lost on page refresh
On a plain page load the output box rendered empty, so the log from the last run was gone after a
refresh. Now, on a plain GET (not during a Run Now / live-view stream), the output textarea is
prefilled with the tail of the last log:

- **Update page** — tails the existing `pfblockerng.log`.
- **Software page** — the pkg-upgrade stream was never persisted, so `pfb_software_run_stream()`
  now tees each line to `/var/log/pfblockerng/software.log`, and the page prefills from it.

A new reusable helper `pfb_log_tail($file, $lines = 1000)` (reuses the existing `tail` idiom)
backs both pages. Prefill is suppressed during an active stream so it never double-renders.

### Tests
- `tests/smoke/ui/` Tier B (`ui_e2e`): Software textareas carry `readonly`; the Update and
  Software pages prefill `pfb_output` from a seeded log on a plain GET. Each fails on the
  pre-change markup/empty value and passes after.
- Tier A render oracles already cover both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
