### PR TITLE
pfblockerng: log table/op/rc attribution on pfctl table-op failures

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3744,6 +3744,41 @@ function pfb_member_file_is_placeholder_only($path, $placeholder) {
 }
 
 
+// Format a single log line for a failed pfctl table operation.  Pure function:
+// no side-effects, fully unit-testable without a live pfctl binary.
+// Callers: pfb_pfctl_table_op() (below) — which is the only exec() wrapper for
+// pfctl -T mutation ops.  The message names every field so "Table does not exist"
+// floods carry table/op attribution in the log.
+function pfb_pfctl_error_message(string $table, string $op, int $rc, string $stderr): string {
+	$msg = trim(str_replace(["\r\n", "\r", "\n"], ' ', $stderr));
+	return "[pfctl] op={$op} table={$table} failed (rc={$rc}): {$msg}";
+}
+
+
+// Thin wrapper around `pfctl -t <table> -T <op>` for mutation ops (kill/replace/add/delete).
+// Owns the escapeshellarg() for the table; $args must already be fully escaped by
+// the caller (e.g. "-f " . escapeshellarg($path)).  On failure (non-zero rc or
+// pfctl error output) logs one attributed line via pfb_logger().
+// $pfctl_bin defaults to $pfb['pfctl']; pass explicitly when the binary is a
+// per-call parameter (e.g. pfb_apply_alias_delta, which accepts a mock binary in tests).
+function pfb_pfctl_table_op(string $table, string $op, string $args = '', string $pfctl_bin = ''): array {
+	global $pfb;
+	if ($pfctl_bin === '') {
+		$pfctl_bin = $pfb['pfctl'];
+	}
+	$table_esc = escapeshellarg($table);
+	$args_part = $args !== '' ? " {$args}" : '';
+	$out       = [];
+	$rc        = 0;
+	exec("{$pfctl_bin} -t {$table_esc} -T {$op}{$args_part} 2>&1", $out, $rc);
+	$stderr    = implode(' ', $out);
+	if ($rc !== 0 || stripos($stderr, 'pfctl:') !== FALSE || stripos($stderr, 'Table does not exist') !== FALSE) {
+		pfb_logger(pfb_pfctl_error_message($table, $op, $rc, $stderr) . "\n", 1);
+	}
+	return ['out' => $out, 'rc' => $rc];
+}
+
+
 // ADR-11 Phase 3: build + register the opt-in per-type aggregate ("Uber") Native aliases.
 //
 // ONE generic loop over the type->dir map {Deny,Permit,Match,Native} x family {v4,v6}.
@@ -3798,7 +3833,7 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 					unlink_if_exists("{$aggout}.members");
 					unlink_if_exists("{$aggout}.tmp");
 					// Kill the pf table only when we had built this aggregate before.
-					exec("{$pfb['pfctl']} -t {$aliasname_esc} -T kill 2>&1");
+					pfb_pfctl_table_op($aliasname, 'kill');
 				}
 				continue;
 			}
@@ -3835,9 +3870,9 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			// (e.g. an HAProxy graceful reload) always sees the FRESH aggregate. A 0-byte
 			// aggout (empty union) is pruned to an empty table, matching pfB member aliases.
 			if (file_exists($aggout) && filesize($aggout) > 0) {
-				exec("{$pfb['pfctl']} -t {$aliasname_esc} -T replace -f {$aggout_esc} 2>&1");
+				pfb_pfctl_table_op($aliasname, 'replace', "-f {$aggout_esc}");
 			} else {
-				exec("{$pfb['pfctl']} -t {$aliasname_esc} -T kill 2>&1");
+				pfb_pfctl_table_op($aliasname, 'kill');
 			}
 
 			// Merge a (re)built aggregate's name into the changed-alias set so the ADR-12
@@ -4089,7 +4124,7 @@ function pfb_apply_alias_delta(
 
 	// Force replace: boot/enable-disable initial load path.
 	if ($force_replace || $mode === 'replace') {
-		exec("{$pfctl_bin} -t {$table_esc} -T replace -f {$table_file_esc} 2>&1");
+		pfb_pfctl_table_op($table, 'replace', "-f {$table_file_esc}", $pfctl_bin);
 		return FALSE;
 	}
 
@@ -4102,7 +4137,7 @@ function pfb_apply_alias_delta(
 
 	// Churn-ratio fallback: auto mode with large churn → replace.
 	if ($mode === 'auto' && $table_size > 0 && ($churn / $table_size) >= PFB_DELTA_CHURN_THRESHOLD) {
-		exec("{$pfctl_bin} -t {$table_esc} -T replace -f {$table_file_esc} 2>&1");
+		pfb_pfctl_table_op($table, 'replace', "-f {$table_file_esc}", $pfctl_bin);
 		return FALSE;
 	}
 
@@ -4121,7 +4156,7 @@ function pfb_apply_alias_delta(
 		}
 		@file_put_contents($tmp, $entries . "\n");
 		$tmp_esc = escapeshellarg($tmp);
-		exec("{$pfctl_bin} -t {$table_esc} -T add -f {$tmp_esc} 2>&1");
+		pfb_pfctl_table_op($table, 'add', "-f {$tmp_esc}", $pfctl_bin);
 		@unlink($tmp);
 	}
 
@@ -4135,7 +4170,7 @@ function pfb_apply_alias_delta(
 		}
 		@file_put_contents($tmp, $entries . "\n");
 		$tmp_esc = escapeshellarg($tmp);
-		exec("{$pfctl_bin} -t {$table_esc} -T delete -f {$tmp_esc} 2>&1");
+		pfb_pfctl_table_op($table, 'delete', "-f {$tmp_esc}", $pfctl_bin);
 		@unlink($tmp);
 	}
 
@@ -15706,7 +15741,7 @@ function sync_package_pfblockerng($cron='') {
 
 				// Skip any Alias that are 'enabled' but Lists/customlists are not defined.
 				if (empty($list['row'][0]['url']) && empty($list['custom'])) {
-					exec("{$pfb['pfctl']} -t {$alias_esc} -T kill 2>&1", $result);
+					pfb_pfctl_table_op($alias, 'kill');
 					continue;
 				}
 
@@ -16113,11 +16148,11 @@ function sync_package_pfblockerng($cron='') {
 					if (in_array($pfb_table, $final_alias)) {
 						// Active + changed: full -T replace so the kernel table is in sync
 						// before filter_configure() rebuilds the ruleset from the aliasdir file.
-						exec("{$pfb['pfctl']} -t {$pfb_table_esc} -T replace -f {$pfb_table_path_esc} 2>&1", $result);
+						pfb_pfctl_table_op($pfb_table, 'replace', "-f {$pfb_table_path_esc}");
 					}
 				} else {
 					// Remove inactive pfB aliastables
-					exec("{$pfb['pfctl']} -t {$pfb_table_esc} -T kill 2>&1", $result);
+					pfb_pfctl_table_op($pfb_table, 'kill');
 				}
 			}
 		}
@@ -16484,8 +16519,7 @@ function pfblockerng_php_pre_deinstall_command() {
 	exec("{$pfb['pfctl']} -s Tables | {$pfb['grep']} '^pfB_'", $pfb_tables);
 	if (isset($pfb_tables)) {
 		foreach ($pfb_tables as $pfb_table) {
-			$pfb_table_esc = escapeshellarg($pfb_table);
-			exec("{$pfb['pfctl']} -t {$pfb_table_esc} -T kill 2>&1", $result);
+			pfb_pfctl_table_op($pfb_table, 'kill');
 		}
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3757,8 +3757,9 @@ function pfb_pfctl_error_message(string $table, string $op, int $rc, string $std
 
 // Thin wrapper around `pfctl -t <table> -T <op>` for mutation ops (kill/replace/add/delete).
 // Owns the escapeshellarg() for the table; $args must already be fully escaped by
-// the caller (e.g. "-f " . escapeshellarg($path)).  On failure (non-zero rc or
-// pfctl error output) logs one attributed line via pfb_logger().
+// the caller (e.g. "-f " . escapeshellarg($path)).  $op is a fixed verb literal
+// (kill|replace|add|delete), interpolated UNescaped — never pass a caller-supplied value.
+// On failure (non-zero rc or pfctl error output) logs one attributed line via pfb_logger().
 // $pfctl_bin defaults to $pfb['pfctl']; pass explicitly when the binary is a
 // per-call parameter (e.g. pfb_apply_alias_delta, which accepts a mock binary in tests).
 function pfb_pfctl_table_op(string $table, string $op, string $args = '', string $pfctl_bin = ''): array {
@@ -3820,7 +3821,6 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			$aliasname	= "pfB_{$type}_Aggregated_{$family}";
 			$aggout		= "{$pfb['aliasdir']}/{$aliasname}.txt";
 			$consumer	= "{$pfb['dbdir']}/{$aliasname}.lst";	// never-empty '-f' consumer (ADR-12)
-			$aliasname_esc	= escapeshellarg($aliasname);
 
 			// ---- Teardown: a NON-selected type (or disabled) leaves no orphans. ----
 			// Strictly additive: only act when this aggregate actually exists -- on a box
@@ -4118,7 +4118,6 @@ function pfb_apply_alias_delta(
 	int    $batch_size,
 	bool   $force_replace = FALSE
 ): bool {
-	$table_esc      = escapeshellarg($table);
 	$table_file_esc = escapeshellarg($table_file);
 	$batch_size     = pfb_alias_delta_batch_clamp($batch_size);
 
@@ -16142,7 +16141,6 @@ function sync_package_pfblockerng($cron='') {
 				? []
 				: array_values(array_intersect(array_unique($pfb_alias_lists), $pfb_active_aliases));
 			foreach ($pfb_tables as $pfb_table) {
-				$pfb_table_esc      = escapeshellarg($pfb_table);
 				$pfb_table_path_esc = escapeshellarg("{$pfb['aliasdir']}/{$pfb_table}.txt");
 				if (in_array($pfb_table, $pfb_active_aliases)) {
 					if (in_array($pfb_table, $final_alias)) {

--- a/tests/php/PfctlTableOpTest.php
+++ b/tests/php/PfctlTableOpTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_pfctl_error_message() — the pure formatter that names a failed
+ * pfctl table operation.  Adding attribution to "pfctl: Table does not exist"
+ * floods during the alpha-6 upgrade (no table/op info in the original exec()
+ * call sites).
+ *
+ * pfb_pfctl_table_op() wraps exec() and cannot be exercised off-appliance, so
+ * only the formatter is tested here (exec doubles would add fragile complexity
+ * for no new coverage benefit — the formatter is the testable invariant).
+ *
+ * Scenarios:
+ *   A — failure message contains table, op, rc, and trimmed stderr.
+ *   B — multiline stderr collapses to a single line.
+ *   C — rc=0 with clean output formats without the error marker.
+ *   D — empty stderr is represented cleanly (no trailing colon-space).
+ */
+#[CoversFunction('pfb_pfctl_error_message')]
+final class PfctlTableOpTest extends TestCase
+{
+	// -----------------------------------------------------------------------
+	// Scenario A — standard failure: message contains all four fields
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario A — pfb_pfctl_error_message names table, op, rc, and stderr.
+	 *
+	 * Given: table='pfB_DNSBLIP_v4', op='replace', rc=1, stderr from pfctl.
+	 * When:  pfb_pfctl_error_message() is called.
+	 * Then:  the returned line contains each field so the log is attributable.
+	 *
+	 * This test is RED before the function exists (calling an undefined function
+	 * raises a Fatal; no assertion needed to prove RED).  GREEN after the function
+	 * is defined AND all four fields appear in the message.
+	 */
+	public function testMessageContainsTableOpRcAndStderr(): void
+	{
+		$table  = 'pfB_DNSBLIP_v4';
+		$op     = 'replace';
+		$rc     = 1;
+		$stderr = 'pfctl: Table does not exist.';
+
+		$msg = pfb_pfctl_error_message($table, $op, $rc, $stderr);
+
+		$this->assertStringContainsString($table, $msg,
+			"expected: message contains table name '{$table}';\nactual: {$msg}");
+		$this->assertStringContainsString($op, $msg,
+			"expected: message contains op '{$op}';\nactual: {$msg}");
+		$this->assertStringContainsString((string) $rc, $msg,
+			"expected: message contains rc='{$rc}';\nactual: {$msg}");
+		$this->assertStringContainsString($stderr, $msg,
+			"expected: message contains stderr text '{$stderr}';\nactual: {$msg}");
+	}
+
+	// -----------------------------------------------------------------------
+	// Scenario B — multiline stderr collapses to a single output line
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario B — multiline stderr is collapsed to a single line in the output.
+	 *
+	 * Given: stderr contains embedded newlines (pfctl occasionally emits multi-line
+	 *        error text).
+	 * When:  pfb_pfctl_error_message() is called.
+	 * Then:  the returned string contains no newline characters so a single
+	 *        pfb_logger() call emits exactly one log line (the caller appends \n).
+	 */
+	public function testMultilineStderrCollapsesToSingleLine(): void
+	{
+		$msg = pfb_pfctl_error_message(
+			'pfB_Test_v4',
+			'kill',
+			2,
+			"pfctl: Table does not exist.\nAnother error line.\r\nThird line."
+		);
+
+		$this->assertStringNotContainsString("\n", $msg,
+			"expected: no embedded newlines in the formatted message;\nactual: " . json_encode($msg));
+		$this->assertStringNotContainsString("\r", $msg,
+			"expected: no embedded carriage returns in the formatted message;\nactual: " . json_encode($msg));
+	}
+
+	// -----------------------------------------------------------------------
+	// Scenario C — format is stable across op variants
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario C — format is stable for all expected op values.
+	 *
+	 * Given: the four mutation ops used at the routed call sites.
+	 * When:  pfb_pfctl_error_message() is called with each op.
+	 * Then:  each returned message contains the op string and the table name.
+	 */
+	public function testFormatStableAcrossOps(): void
+	{
+		$table = 'pfB_Deny_v4';
+		$ops   = ['kill', 'replace', 'add', 'delete'];
+
+		foreach ($ops as $op) {
+			$msg = pfb_pfctl_error_message($table, $op, 1, 'pfctl: EINVAL');
+			$this->assertStringContainsString($op, $msg,
+				"expected: message for op='{$op}' contains the op string;\nactual: {$msg}");
+			$this->assertStringContainsString($table, $msg,
+				"expected: message for op='{$op}' contains the table name;\nactual: {$msg}");
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Scenario D — empty stderr produces a clean message (no trailing artifact)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario D — empty stderr is represented cleanly.
+	 *
+	 * Given: stderr is an empty string (pfctl exited non-zero with no output).
+	 * When:  pfb_pfctl_error_message() is called.
+	 * Then:  the returned message still contains table, op, rc, and is a
+	 *        non-empty string (does not degenerate to a bare colon).
+	 */
+	public function testEmptyStderrProducesCleanMessage(): void
+	{
+		$msg = pfb_pfctl_error_message('pfB_Permit_v6', 'kill', 1, '');
+
+		$this->assertNotEmpty($msg,
+			'expected: non-empty message even with empty stderr');
+		$this->assertStringContainsString('pfB_Permit_v6', $msg,
+			"expected: table name present;\nactual: {$msg}");
+		$this->assertStringContainsString('kill', $msg,
+			"expected: op present;\nactual: {$msg}");
+		$this->assertStringContainsString('1', $msg,
+			"expected: rc present;\nactual: {$msg}");
+	}
+}

--- a/tests/php/PfctlTableOpTest.php
+++ b/tests/php/PfctlTableOpTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  * Scenarios:
  *   A — failure message contains table, op, rc, and trimmed stderr.
  *   B — multiline stderr collapses to a single line.
- *   C — rc=0 with clean output formats without the error marker.
+ *   C — message format is stable across all four mutation ops (kill/replace/add/delete).
  *   D — empty stderr is represented cleanly (no trailing colon-space).
  */
 #[CoversFunction('pfb_pfctl_error_message')]


### PR DESCRIPTION
## pfctl: attribute table/op/rc on table-operation failures

Upgrading to v4.0.0.alpha.6 produced many `pfctl: Table does not exist` messages with no
indication of **which** alias table or **what** operation was involved, making them impossible to
act on. This adds informative logging to the pfctl table-op path.

### Change
- `pfb_pfctl_error_message($table, $op, $rc, $stderr)` — a pure formatter returning one attributed
  line, e.g. `[pfctl] op=replace table=pfB_DNSBLIP_v4 failed (rc=1): pfctl: Table does not exist.`
- `pfb_pfctl_table_op($table, $op, $args, $pfctl_bin)` — a thin wrapper that owns the table
  `escapeshellarg`, runs the op, and logs the attributed line via `pfb_logger()` on failure
  (non-zero rc or pfctl error output). Returns `['out', 'rc']`.

The 11 **mutation** sites (kill / replace / add / delete) in the aggregate-alias build, the ADR-40
delta apply, the main reload loop, and the deinstall teardown now route through the wrapper. The
`-T test` membership checks and `-T zero` stats are intentionally left as-is (they consume their
result and are not the source of the flood). Behaviour is unchanged except for the added log line;
every de-captured `exec(..., $result)` was a throwaway.

Scope is informative logging only — the root cause of a table being absent mid-upgrade
(reload-vs-rule-load ordering) is a separate investigation.

### Tests
- `tests/php/PfctlTableOpTest.php` — 4 tests / 18 assertions on the formatter (names table, op, rc,
  stderr; collapses multiline stderr; stable across ops; clean on empty stderr). RED before
  (undefined function), GREEN after. Full suite green; phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
