### PR TITLE
pfblockerng: Update-page polish — DNSBL Category state, Force help, button spacing

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -279,6 +279,32 @@ function pfb_ledger_entry_html(?array $entry): string {
 	return "Last: <strong>{$last}</strong>&emsp;Next: <strong>{$next}</strong>";
 }
 
+/**
+ * Format the DNSBL Category ('bl') schedule row.
+ *
+ * Unlike the feed/extras jobs, the category job only runs (and so only ever records a
+ * ledger entry) when the DNSBL Category feature is enabled with at least one category
+ * selected — the exact gate the tick dispatcher applies before dispatching 'bl'. When the
+ * feature is off, a bare "Not yet run" reads as if a scheduled job is stuck, so report WHY
+ * it is not scheduled instead.
+ */
+function pfb_dnsbl_category_schedule_html(array $pfb, ?array $entry): string {
+	$bl = $pfb['blconfig'] ?? array();
+	if (($pfb['enable'] ?? '') !== 'on' ||
+	    empty($bl['blacklist_enable']) || $bl['blacklist_enable'] === 'Disable') {
+		return '<em>Disabled</em>';
+	}
+	// Enabled — but is any category actually selected? (Mirrors the tick's bl_str build:
+	// an item counts only when it is in blacklist_selected AND flagged selected.)
+	$selected = !empty($bl['blacklist_selected']) ? array_flip(explode(',', $bl['blacklist_selected'])) : array();
+	foreach (($bl['item'] ?? array()) as $item) {
+		if (isset($selected[$item['xml']]) && !empty($item['selected'])) {
+			return pfb_ledger_entry_html($entry);	// active — show the real schedule
+		}
+	}
+	return '<em>None selected</em>';
+}
+
 // Create Form
 $form = new Form(FALSE);
 
@@ -319,7 +345,7 @@ $group->add(new Form_Checkbox(
 	'dnsbl'
 ))->displayAsRadio('pfb_scope_dnsbl')->setAttribute('title', 'Sync DNSBL feeds only.')->setWidth(2);
 
-$group->setHelp('Which lists to sync on Run Now: Both, IP-only, or DNSBL-only.');
+$group->setHelp('Which lists to sync: Both, IP-only, or DNSBL-only.');
 $section->add($group);
 
 // Force mode — mutually-exclusive radios. None = a plain detector-respecting run.
@@ -333,9 +359,10 @@ $group->add(new Form_Checkbox('pfb_force_mode', NULL, 'Download', $pfb_force_mod
 	->displayAsRadio('pfb_force_download')->setAttribute('title', 'Re-fetch all list files (reload only if changes are detected).')->setWidth(2);
 $group->add(new Form_Checkbox('pfb_force_mode', NULL, 'Both',     $pfb_force_mode === 'both',     'both'))
 	->displayAsRadio('pfb_force_both')->setAttribute('title', 'Re-fetch all list files and reload all lists regardless of changes.')->setWidth(2);
-$group->setHelp('Parse: reload all lists regardless of changes (no re-download). '
-	. 'Download: re-fetch all list files (reload only if changes are detected). '
-	. 'Both: re-fetch all list files and reload all lists regardless of changes.');
+$group->setHelp('<strong>None:</strong> reload only what changed (normal run).<br />'
+	. '<strong>Parse:</strong> reload all lists regardless of changes (no re-download).<br />'
+	. '<strong>Download:</strong> re-fetch all list files (reload only if changes are detected).<br />'
+	. '<strong>Both:</strong> re-fetch all list files and reload all lists regardless of changes.');
 $section->add($group);
 
 $group = new Form_Group(NULL);
@@ -345,7 +372,10 @@ $btn_run = new Form_Button(
 	NULL,
 	'fa-solid fa-play-circle'
 );
-$btn_run->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setWidth(1);
+// No setWidth(): a per-button column wrapper floats the two buttons flush together on
+// desktop (the gap only showed on mobile, where the columns stack). Keep them inline and
+// space them with a margin on Run instead.
+$btn_run->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setAttribute('style', 'margin-right: 0.5em;');
 
 // Alternate view/end view button text
 if (!isset($pconfig['log_view'])) {
@@ -368,11 +398,11 @@ $btn_logview = new Form_Button(
 	NULL,
 	'fa-regular fa-circle-play'
 );
-$btn_logview->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setWidth(1)
+$btn_logview->removeClass('btn-primary')->addClass('btn-primary btn-xs')
 	    ->setAttribute('title', $btn_logview_title);
 $group->add(new Form_StaticText(
 		NULL,
-		$btn_run . '&emsp;' . $btn_logview
+		$btn_run . $btn_logview
 ));
 
 $section->add($group);
@@ -394,7 +424,7 @@ $section->addInput(new Form_StaticText(
 ));
 $section->addInput(new Form_StaticText(
 	'DNSBL category',
-	pfb_ledger_entry_html($ledger_bl)
+	pfb_dnsbl_category_schedule_html($pfb, $ledger_bl)
 ));
 $form->add($section);
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -432,6 +432,67 @@ def test_update_revamp_controls_render(webui: WebUI, php_error_log_guard: PhpErr
     )
 
 
+def test_update_page_schedule_and_help_polish(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """Update-page polish: honest DNSBL-category state, itemized Force help, clean Run-Scope
+    help, and spaced Run/View buttons.
+
+    Four user-reported alpha.6 rough edges on the Update page, all guarded here against
+    regression (each assertion fails on the pre-fix markup):
+
+    Scenario: the Update page renders the corrected Schedule + help + button markup.
+      Background: pfBlockerNG deployed with the DNSBL Category feature NOT configured
+      (the suite never enables it), so the category job can never run.
+
+    Given the Update page renders cleanly (200, no PHP diagnostic, section markers),
+
+    When the body is inspected,
+
+    Then the DNSBL Category schedule row reports ``Disabled`` rather than the misleading
+      ``Not yet run`` — the bl job only runs (and records a ledger entry) when the feature
+      is enabled with a category selected, so an unconfigured install must say why it is
+      not scheduled, not pretend a run is pending (pre-fix it showed ``<em>Not yet run</em>``);
+    And the Run Scope help no longer carries the stray ``on Run Now`` qualifier;
+    And the Force help is itemized per mode (a ``<strong>`` label per None/Parse/Download/Both)
+      instead of one run-on sentence (pre-fix there were no ``<strong>`` mode labels);
+    And the Run button carries an inline right margin so it is visibly separated from the
+      View button on desktop too (pre-fix the column-wrapped buttons sat flush, the gap only
+      appearing on mobile).
+
+    ``php_error_log_guard`` enrolls this GET in the module-level no-growth sweep.
+    """
+    resp = webui.get(_UPDATE_PAGE)
+    result = evaluate_render(_UPDATE_PAGE, resp.status_code, resp.text, ("Update Settings", "Schedule"))
+    assert result.ok, f"Update page render oracle failed: {result.detail}"
+    body = resp.text
+
+    # DNSBL Category row: feature unconfigured ⇒ "Disabled" (only this row emits it).
+    assert "DNSBL category" in body, "Update page missing the 'DNSBL category' schedule row"
+    assert "<em>Disabled</em>" in body, (
+        "DNSBL category row should read 'Disabled' when the category feature is off, "
+        "not the misleading 'Not yet run' — got neither in the body"
+    )
+
+    # Run Scope help: the stray 'on Run Now' qualifier is gone.
+    assert "Which lists to sync: Both, IP-only, or DNSBL-only." in body, "Run Scope help text not updated"
+    assert "on Run Now" not in body, "Run Scope help still carries the stray 'on Run Now' qualifier"
+
+    # Force help: itemized with a bold label per mode.
+    for needle in (
+        "<strong>None:</strong>",
+        "<strong>Parse:</strong>",
+        "<strong>Download:</strong>",
+        "<strong>Both:</strong>",
+    ):
+        assert needle in body, f"Force help not itemized — missing {needle!r}"
+
+    # Run button: inline right margin (desktop spacing). The Run Now button is the only
+    # element on the page that sets margin-right, so its presence proves the spacing fix.
+    assert "Run Now" in body, "Update page missing the Run Now button"
+    assert "margin-right: 0.5em" in body, (
+        "Run button has no inline right margin — it will sit flush against View on desktop"
+    )
+
+
 def test_dnsbl_idn_blocking_fields_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """The ADR-08 'IDN Blocking' selector + its two Confusable sub-toggles render
     cleanly on the DNSBL page — so a regression that drops or breaks the field is

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -465,16 +465,19 @@ def test_update_page_schedule_and_help_polish(webui: WebUI, php_error_log_guard:
     assert result.ok, f"Update page render oracle failed: {result.detail}"
     body = resp.text
 
-    # DNSBL Category row: feature unconfigured ⇒ "Disabled" (only this row emits it).
+    # DNSBL Category row: feature unconfigured ⇒ "Disabled". Scope to THIS row's value cell
+    # (the markup right after its label), not the whole body, so unrelated markup can't pass it.
     assert "DNSBL category" in body, "Update page missing the 'DNSBL category' schedule row"
-    assert "<em>Disabled</em>" in body, (
+    cat_row = body.split("DNSBL category", 1)[1][:500]
+    assert "<em>Disabled</em>" in cat_row, (
         "DNSBL category row should read 'Disabled' when the category feature is off, "
-        "not the misleading 'Not yet run' — got neither in the body"
+        f"not the misleading 'Not yet run' — row markup was: {cat_row[:200]!r}"
     )
 
-    # Run Scope help: the stray 'on Run Now' qualifier is gone.
+    # Run Scope help: the stray 'on Run Now' qualifier is gone. Match the precise OLD help
+    # string (not a bare "on Run Now", which also appears in an unrelated inline JS comment).
     assert "Which lists to sync: Both, IP-only, or DNSBL-only." in body, "Run Scope help text not updated"
-    assert "on Run Now" not in body, "Run Scope help still carries the stray 'on Run Now' qualifier"
+    assert "Which lists to sync on Run Now" not in body, "Run Scope help still carries the stray 'on Run Now' qualifier"
 
     # Force help: itemized with a bold label per mode.
     for needle in (
@@ -485,11 +488,12 @@ def test_update_page_schedule_and_help_polish(webui: WebUI, php_error_log_guard:
     ):
         assert needle in body, f"Force help not itemized — missing {needle!r}"
 
-    # Run button: inline right margin (desktop spacing). The Run Now button is the only
-    # element on the page that sets margin-right, so its presence proves the spacing fix.
-    assert "Run Now" in body, "Update page missing the Run Now button"
-    assert "margin-right: 0.5em" in body, (
-        "Run button has no inline right margin — it will sit flush against View on desktop"
+    # Run button: inline right margin (desktop spacing). Scope to the Run Now <button>
+    # element itself, not the whole body, so the margin is proven to be ON that button.
+    run_btn = next((b for b in re.findall(r"<button\b.*?</button>", body, re.S) if "Run Now" in b), None)
+    assert run_btn is not None, "Update page missing the Run Now button"
+    assert "margin-right" in run_btn, (
+        f"Run button has no inline right margin — it will sit flush against View on desktop: {run_btn!r}"
     )
 
 


### PR DESCRIPTION
Four Update-page rough edges reported on alpha.6, all in `pfblockerng_update.php`.

## 1. DNSBL Category row stuck on "Not yet run"

The Schedule section's **DNSBL category** row read `Not yet run` indefinitely, which looks like a stuck job. Root cause: the `bl` ledger job only runs — and so only ever records a ledger entry — when the **DNSBL Category** feature is enabled with at least one category selected (the exact gate the tick dispatcher applies before dispatching `bl`; `cron`/`dcc` have no such gate, which is why they populate). On an install with no DNSBL *Category* feeds configured, `bl` correctly never runs.

New `pfb_dnsbl_category_schedule_html()` reports the real state: **Disabled** (feature off) / **None selected** (enabled but nothing selected) / the actual Last/Next schedule once it is active.

## 2. Force help is one run-on sentence

Itemized with a bold label per mode (None / Parse / Download / Both), and None is now documented too.

## 3. Run / View buttons flush on desktop

Each button carried `setWidth(1)`, which wraps it in a Bootstrap column — on desktop the two columns float flush together, so the gap only appeared on mobile (where columns stack). Dropped the column wrapper and spaced Run with an inline right margin.

## 4. Run Scope help — stray "on Run Now"

`Which lists to sync on Run Now:` → `Which lists to sync:`.

## Tests

Tier-A render test `test_update_page_schedule_and_help_polish` guards all four (each assertion fails on the pre-fix markup): the category row reads `Disabled` with the feature off, the Force help carries a `<strong>` label per mode, the Run Scope help drops `on Run Now`, and the Run button carries the inline margin. PHP gates green locally (`php -l`, PHPCS, PHPStan). True pixel spacing is the documented out-of-CI visual item; the test asserts the margin style is present as the structural guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Update page schedule display so the DNSBL category row now shows clearer status text, including when DNSBL is disabled or no categories are selected.
  * Refined the help text for Run Scope and Force to make the available options easier to understand.
  * Adjusted button spacing and layout on the Update page for a cleaner appearance.

* **Tests**
  * Added UI coverage to verify the updated Update page text, schedule row behavior, and button styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->