### PR TITLE
pfblockerng: ISO-8601 timestamps in logs + widget (drop ambiguous m/j/y)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2590,7 +2590,10 @@ function pfb_log_reset(): void
 function pfb_logger($log, $logtype) {
 	global $g, $pfb;
 
-	$now = date('m/j/y H:i:s', time());
+	// ISO-8601 'YYYY-MM-DD HH:MM:SS' (unambiguous, locale-independent, sorts lexically).
+	// The "FAIL" error-log greps in pfblockerng.inc + the dashboard widget match THIS log
+	// timestamp by today's date, so they use the same Y-m-d pattern (keep them in lockstep).
+	$now = date('Y-m-d H:i:s', time());
 
 	// Only log timestamp if new
 	if (strpos($log, 'NOW') !== FALSE) {
@@ -6281,7 +6284,7 @@ function pfb_unbound_python($mode) {
 
 		$forwarding = (config_get_path('unbound/forwarding') == 'on') ? 'on' : 'off';
 
-		$now = date('m/j/y H:i:s', time());
+		$now = date('Y-m-d H:i:s', time());	// ISO-8601 (py_unbound.ini "File created" comment)
 
 		$pfb_py_conf = <<<EOF
 ; pfBlockerNG DNSBL Unbound python configuration file
@@ -8775,12 +8778,13 @@ function pfb_failures() {
 	$pfb['failed'] = array();
 
 	if (file_exists("{$pfb['errlog']}")) {
-		$today_date = date('m/j/y', time());
+		$today_date = date('Y-m-d', time());	// matches pfb_logger()'s ISO-8601 log timestamp
 		exec("{$pfb['grep']} 'FAIL' {$pfb['errlog']} | {$pfb['grep']} {$today_date}", $results);
 		if (!empty($results)) {
 			foreach ($results as $result) {
 				$header = explode(' ', $result);
-				$pfb['failed'][$header[4]] += 1;
+				$alias  = $header[4] ?? '';
+				$pfb['failed'][$alias] = ($pfb['failed'][$alias] ?? 0) + 1;	// avoid PHP 8 undefined-key warning on first failure
 			}
 		}
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1466,7 +1466,7 @@ function pfblockerng_uc_countries() {
 						$pfb_file = "{$pfb['ccdir']}/Top_Spammers_v{$type}.info";
 
 						if (!file_exists($pfb_file)) {
-							$header  = '# Generated from MaxMind Inc. on: ' . date('m/j/y G:i:s', time()) . "\n";
+							$header  = '# Generated from MaxMind Inc. on: ' . date('Y-m-d H:i:s', time()) . "\n";
 							$header .= "# Continent IPv{$type}: Top_Spammers\n";
 							$header .= "# Continent en: Top_Spammers\n";
 							@file_put_contents($pfb_file, $header, LOCK_EX);
@@ -1494,7 +1494,7 @@ function pfblockerng_uc_countries() {
 							$pfb_file_esc	= escapeshellarg($pfb_file);
 
 							if (!file_exists($pfb_file)) {
-								$header  = '# Generated from MaxMind Inc. on: ' . date('m/j/y G:i:s', time()) . "\n";
+								$header  = '# Generated from MaxMind Inc. on: ' . date('Y-m-d H:i:s', time()) . "\n";
 								$header .= "# Continent IPv{$type}: {$geoip['continent']}\n";
 								$header .= "# Continent en: {$geoip['continent_en']}\n";
 								@file_put_contents($pfb_file, $header, LOCK_EX);

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -485,7 +485,7 @@ function pfBlockerNG_get_failed() {
 	$response = '';
 
 	// Collect any failed downloads
-	$today_date = date('m/j/y', time());
+	$today_date = date('Y-m-d', time());	// matches pfb_logger()'s ISO-8601 log timestamp
 	exec("{$pfb['grep']} 'FAIL' {$pfb['errlog']} | {$pfb['grep']} {$today_date}", $results);
 	$results = array_reverse($results);
 

--- a/tests/php/PfbLoggerIsoTimestampTest.php
+++ b/tests/php/PfbLoggerIsoTimestampTest.php
@@ -85,15 +85,16 @@ final class PfbLoggerIsoTimestampTest extends TestCase
 	 */
 	public function testFailuresGrepMatchesIsoLogTimestamp(): void
 	{
-		// Given: an error log holding a FAIL line stamped with today's date in the SAME ISO
-		// format pfb_logger() now writes ('Y-m-d ...'), plus enough tokens for pfb_failures()'s
-		// explode(' ')[4] alias field.
+		// Given: an error log holding a Download-FAIL line in pfb_logger()'s REAL shape
+		// (pfblockerng.inc:8678 " [ {alias} - {header} ] Download FAIL [ NOW ]"), stamped with
+		// today's date in the SAME ISO format pfb_logger() now writes. pfb_failures() tallies
+		// by explode(' ')[4] = the feed header, so the key we assert is the header token.
 		$errlog = tempnam(sys_get_temp_dir(), 'pfb_errlogtest_');
 		$this->assertNotFalse($errlog, 'could not create temp errlog file');
 		$this->tmpfiles[] = $errlog;
 		$stamp = date('Y-m-d H:i:s', time());
 		$this->assertNotFalse(
-			file_put_contents($errlog, "{$stamp} [ FAIL pfbtestalias ] download error\n"),
+			file_put_contents($errlog, " [ pfB_TestAlias - pfbtestheader ] Download FAIL [ {$stamp} ]\n"),
 			'could not seed the temp errlog'
 		);
 		$GLOBALS['pfb']['errlog'] = $errlog;
@@ -103,9 +104,9 @@ final class PfbLoggerIsoTimestampTest extends TestCase
 		// When.
 		pfb_failures();
 
-		// Then: today's FAIL line was matched by the date grep and tallied.
+		// Then: today's FAIL line was matched by the date grep and tallied under the header.
 		$this->assertArrayHasKey(
-			'pfbtestalias',
+			'pfbtestheader',
 			$GLOBALS['pfb']['failed'] ?? [],
 			"pfb_failures() did not find today's FAIL line — the grep date format is out of sync "
 			. 'with pfb_logger()'

--- a/tests/php/PfbLoggerIsoTimestampTest.php
+++ b/tests/php/PfbLoggerIsoTimestampTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_logger() stamps log lines in ISO-8601 'YYYY-MM-DD HH:MM:SS', not the old
+ * ambiguous US 'm/j/y H:i:s' (issue: American-style dates in user-facing logs).
+ *
+ * The '[ NOW ]' token in a log message is substituted with the current timestamp; this
+ * pins that substitution's FORMAT. The shipped pfb_logger() is exercised against a temp
+ * log file so the on-disk side-effect is asserted (not coverage theater). The shared
+ * $GLOBALS['pfb'] 'log'/'errlog'/'pnow' are saved/restored so the suite stays
+ * order-independent, and 'pnow' is cleared so the first call substitutes the timestamp
+ * (rather than the same-second dedup path stripping it).
+ */
+#[CoversFunction('pfb_logger')]
+#[CoversFunction('pfb_failures')]
+final class PfbLoggerIsoTimestampTest extends TestCase
+{
+	/** @var string[] temp files to remove in tearDown */
+	private array $tmpfiles = [];
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		foreach (['log', 'errlog', 'pnow', 'grep', 'failed'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		foreach ($this->tmpfiles as $f) {
+			if (is_file($f)) {
+				$this->assertTrue(unlink($f), "failed to remove temp file {$f}");
+			}
+		}
+		$this->tmpfiles = [];
+	}
+
+	public function testLogTimestampIsIso8601NotUsStyle(): void
+	{
+		// Given: a temp log target and a cleared 'pnow' so the '[ NOW ]' token is substituted
+		// (not stripped by the same-second dedup branch).
+		$log = tempnam(sys_get_temp_dir(), 'pfb_logtest_');
+		$this->assertNotFalse($log, 'could not create temp log file');
+		$this->tmpfiles[] = $log;
+		$GLOBALS['pfb']['log'] = $log;
+		unset($GLOBALS['pfb']['pnow']);
+
+		// When: a message carrying the '[ NOW ]' token is logged to the main log (logtype 1).
+		pfb_logger("pfb-iso-timestamp-test [ NOW ]\n", 1);
+
+		// Then: the written timestamp is ISO-8601, and never the old US m/j/y form.
+		$written = (string) file_get_contents($log);
+		$this->assertMatchesRegularExpression(
+			'/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/',
+			$written,
+			"log line should carry an ISO-8601 'YYYY-MM-DD HH:MM:SS' timestamp; got: {$written}"
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'#\b\d{2}/\d{1,2}/\d{2}\b#',
+			$written,
+			"log line must not carry an ambiguous US 'm/j/y' date; got: {$written}"
+		);
+	}
+
+	/**
+	 * pfb_failures() greps the error log for TODAY's failures by date — so its date format
+	 * MUST match what pfb_logger() writes. This pins the producer↔consumer coupling: a FAIL
+	 * line stamped with today's ISO date is found (if the grep reverted to m/j/y while the
+	 * log is ISO, it would silently find nothing and this fails).
+	 */
+	public function testFailuresGrepMatchesIsoLogTimestamp(): void
+	{
+		// Given: an error log holding a FAIL line stamped with today's date in the SAME ISO
+		// format pfb_logger() now writes ('Y-m-d ...'), plus enough tokens for pfb_failures()'s
+		// explode(' ')[4] alias field.
+		$errlog = tempnam(sys_get_temp_dir(), 'pfb_errlogtest_');
+		$this->assertNotFalse($errlog, 'could not create temp errlog file');
+		$this->tmpfiles[] = $errlog;
+		$stamp = date('Y-m-d H:i:s', time());
+		$this->assertNotFalse(
+			file_put_contents($errlog, "{$stamp} [ FAIL pfbtestalias ] download error\n"),
+			'could not seed the temp errlog'
+		);
+		$GLOBALS['pfb']['errlog'] = $errlog;
+		$GLOBALS['pfb']['grep']   = 'grep';	// resolved via PATH on the test host
+		unset($GLOBALS['pfb']['failed']);
+
+		// When.
+		pfb_failures();
+
+		// Then: today's FAIL line was matched by the date grep and tallied.
+		$this->assertArrayHasKey(
+			'pfbtestalias',
+			$GLOBALS['pfb']['failed'] ?? [],
+			"pfb_failures() did not find today's FAIL line — the grep date format is out of sync "
+			. 'with pfb_logger()'
+		);
+	}
+}


### PR DESCRIPTION
User-facing log dates used the ambiguous US `m/j/y H:i:s` form (e.g. `06/29/26`). This switches the log/display producers to **ISO-8601 `Y-m-d H:i:s`** — the format the project already standardised on for display via `pfb_iso_timestamp()` (issue #333).

## Changed (in scope)

- **`pfb_logger()` `[ NOW ]` stamp** — every pfBlockerNG log line shown in the GUI log viewer / Update page.
- **The two `FAIL` error-log greps** that filter the log by *today's* date (`pfb_failures()` + the dashboard widget's "failed downloads") — moved to `Y-m-d` **in lockstep** with the producer, so they keep matching.
- **Cosmetic file headers** — the `py_unbound.ini` "File created" comment and the MaxMind generated-file header.

## Deliberately left (per discussion)

- **The unified alert/log CSV datetime** (`pfb_parsed_fail`) stays `m/d/y` — it's a parsed **wire value**, already ISO-converted **at display** by `pfb_iso_timestamp()`. Changing the on-disk format is a separate, opt-in change (back-compat).
- **RFC-3164 syslog-style `M j H:i:s`** lines ("Jun 29 14:30:00") — standard, unambiguous, and some are parsed back; left as-is.

## Extra

Fixes a pre-existing **PHP 8 undefined-key warning** in `pfb_failures()` (`$pfb['failed'][$alias] += 1` on an alias's first failure), surfaced by the new coupling test.

## Tests

`tests/php/PfbLoggerIsoTimestampTest.php`:
- pins the ISO log format — **red** on the old `m/j/y` (verified: `06/29/26 …` fails the ISO assert), **green** on ISO;
- proves `pfb_failures()`'s date grep still finds a today-stamped `FAIL` line — guarding the producer↔consumer format coupling (a drift would silently find nothing).

PHPUnit (1616), PHPCS, PHPStan all green locally. The widget's live "failed downloads" appearance (ISO date) is data-gated (needs a real failure) → maintainer/out-of-CI visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized pfBlockerNG timestamps to a clear ISO-style format across logs, generated files, and widgets.
  * Improved failed-download counting so first-time failures are tracked reliably without warnings.
  * Updated “today” matching so the failed-downloads widget shows the correct entries.

* **Tests**
  * Added automated coverage to verify timestamp formatting and failure detection stay in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->