### PR TITLE
pfblockerng: stop pfctl table-size reads leaking bare "Table does not exist"

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3798,6 +3798,21 @@ function pfb_pfctl_table_op(string $table, string $op, string $args = '', string
 }
 
 
+// Number of entries in pf table $table, or 0 when the table does not exist yet (a benign read
+// on boot / mid-reload). Reads via `pfctl -T show` with pfctl's OWN stderr suppressed: a missing
+// table writes "pfctl: Table does not exist" to stderr, which would otherwise leak UNATTRIBUTED
+// into the update / Software-page output. (The mutation wrapper pfb_pfctl_table_op() only covers
+// add/delete/replace/kill; reading an absent table is not a failure to attribute -- just "no
+// entries yet".) Counts in PHP, not `| wc -l`, so a wrapping 2>&1 can't bind to wc instead of
+// pfctl and let the error through.
+function pfb_pfctl_table_count(string $table): int {
+	global $pfb;
+	$out = [];
+	exec("{$pfb['pfctl']} -t " . escapeshellarg($table) . " -T show 2>/dev/null", $out);
+	return count($out);
+}
+
+
 // ADR-11 Phase 3: build + register the opt-in per-type aggregate ("Uber") Native aliases.
 //
 // ONE generic loop over the type->dir map {Deny,Permit,Match,Native} x family {v4,v6}.
@@ -14911,11 +14926,7 @@ function sync_package_pfblockerng($cron='') {
 						}
 
 						// Check if pfBlockerNG pfctl Continent tables are empty (pfBlockerNG was disabled w/ "keep", then re-enabled)
-						$pfctlck = trim(exec_command(implode(' ', [
-							$pfb['pfctl'], '-t',
-							$cc_alias,
-							'-Tshow', '|', $pfb['wc'], '-l'
-						])));
+						$pfctlck = pfb_pfctl_table_count($cc_alias);
 
 						if (empty($pfctlck) && file_exists("{$pfbfolder}/{$cc_alias}.txt")) {
 							@copy("{$pfbfolder}/{$cc_alias}.txt", "{$pfb['aliasdir']}/{$cc_alias}.txt");
@@ -15755,7 +15766,6 @@ function sync_package_pfblockerng($cron='') {
 					pfb_logger("\n Invalid Aliasname:{$list['aliasname']}{$vtype}, *skipping*", 1);
 					continue;
 				}
-				$alias_esc = escapeshellarg($alias);
 
 				// Skip any Alias that are 'enabled' but Lists/customlists are not defined.
 				if (empty($list['row'][0]['url']) && empty($list['custom'])) {
@@ -15797,11 +15807,7 @@ function sync_package_pfblockerng($cron='') {
 								$header_esc	= escapeshellarg($header);
 								$urlvalue	.= "{$header},";
 
-								$pfctlck = trim(exec_command(implode(' ', [
-									$pfb['pfctl'], '-t',
-									$alias_esc,
-									'-Tshow', '|', $pfb['wc'], '-l'
-								])));
+								$pfctlck = pfb_pfctl_table_count($alias);
 
 								// ADR-40 P3: read member files when:
 								//   (a) cross-list scope → always (dedup/rep can shift any alias), OR
@@ -15836,12 +15842,7 @@ function sync_package_pfblockerng($cron='') {
 					$aliasname = "{$list['aliasname']}_custom{$vtype}";
 
 					// Update alias if list file exists and its been updated or if the alias URL table is empty.
-					$alias_esc = escapeshellarg($alias);
-					$pfctlck = trim(exec_command(implode(' ', [
-						$pfb['pfctl'], '-t',
-						$alias_esc,
-						'-Tshow', '|', $pfb['wc'], '-l'
-					])));
+					$pfctlck = pfb_pfctl_table_count($alias);
 					if (!empty($list['custom'])) {
 						$urlvalue .= "{$aliasname},";
 						// ADR-40 P3: same scope logic for custom lists.

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -537,3 +537,35 @@ def test_adr40_delta_replace_mode(adr40_vm: h.SmokeVM) -> None:
     finally:
         _set_delta_mode(adr40_vm, "auto")
         h.clear_update_hooks(adr40_vm)
+
+
+def test_pfctl_table_count_absent_table_no_bare_error(adr40_vm: SmokeVM) -> None:
+    """Reading an absent pf table reports 0 entries and leaks NO bare 'pfctl: Table does not exist'.
+
+    The mutation wrapper pfb_pfctl_table_op() attributes add/delete/replace/kill failures in the
+    log, but the table-SIZE reads were unwrapped and did not redirect pfctl's stderr — so reading
+    an alias whose kernel table does not exist yet (as mid-reload, right after the previous version
+    flushed it during a package update) leaked a bare 'pfctl: Table does not exist' into the update
+    / Software-page output. pfb_pfctl_table_count() now reads with pfctl's OWN stderr suppressed and
+    counts in PHP, so an absent table is simply 0 entries — no leak.
+
+    Red→green: pfb_pfctl_table_count() does not exist before the change, so the snippet fatals (no
+    COUNT marker emitted); green after.
+    """
+    absent = "pfB_smoke_absent_xyzzy_v4"  # a table name that is never created on the box
+    snippet = (
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');"
+        f"echo '<<<CNT>>>' . pfb_pfctl_table_count('{absent}') . '<<<END>>>';"
+    )
+    result = h.php_eval(adr40_vm, snippet)
+    combined = result.stdout + result.stderr
+
+    # A read of an absent table is "0 entries", not a failure.
+    assert "<<<CNT>>>0<<<END>>>" in result.stdout, (
+        f"expected 0 entries for an absent table; rc={result.returncode} "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    # ...and emits no bare pfctl 'Table does not exist' anywhere (stdout or stderr).
+    assert "Table does not exist" not in combined, (
+        f"bare 'pfctl: Table does not exist' leaked despite the read helper: {combined!r}"
+    )


### PR DESCRIPTION
## Problem

During the pfBlockerNG reload (e.g. while updating the package alpha.6→alpha.7), bare `pfctl: Table does not exist` lines appeared in the Software-page output — even though alpha.7 added the pfctl table-op wrapper.

## Why the wrapper didn't catch it

`pfb_pfctl_table_op()` wraps and attributes the table **mutations** (`add`/`delete`/`replace`/`kill`). But the table-**size reads** stayed raw:

```php
$pfctlck = trim(exec_command(implode(' ', [$pfb['pfctl'], '-t', $alias, '-Tshow', '|', $pfb['wc'], '-l'])));
```

pfctl's stderr is unredirected, and in a pipe `pfctl … | wc -l` a trailing `2>&1` binds to `wc`, not `pfctl`. So when a table doesn't exist yet — exactly the case mid-reload, right after the previous version flushed it — pfctl's `Table does not exist` leaks **unattributed** to the page. (`14915` also passed the alias **unescaped**.)

## Fix

Add the read counterpart `pfb_pfctl_table_count()`:

```php
exec("{$pfb['pfctl']} -t " . escapeshellarg($table) . " -T show 2>/dev/null", $out);
return count($out);
```

`pfctl`'s own stderr suppressed (a missing table is `0` entries on a read, not a failure to attribute), counted in PHP so no pipe can swallow the redirect, and the alias escaped. The three reads route through it; `$pfctlck` was only ever used in `empty()` checks, so the int return is behaviour-preserving. Dropped the now-dead `$alias_esc` assignments.

Out of scope (verified): the other raw `pfctl` calls either redirect (`2>&1`) or are reads that don't hit a named missing table (`-s Tables`, `-T test`); the `-T zero` at `:11824` is inside a `/* TODO */` block (dead). Mutations already go through the wrapper.

## Test

`test_pfctl_table_count_absent_table_no_bare_error` (smoke): reads an absent table via the helper and asserts it returns `0` **and** leaks no bare `pfctl: Table does not exist` — red (undefined function) before, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table-count handling so missing firewall tables no longer show raw error messages during updates or reloads.
  * Updated several count-based checks to return `0` when a table is absent, reducing noisy output in GeoIP and alias-related workflows.

* **Tests**
  * Added coverage to ensure absent tables are handled cleanly without exposing pfctl error text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->