### PR TITLE
pfblockerng: auto-tail an in-progress update on Update-page load

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11621,6 +11621,17 @@ function pfb_livetail_force_done(bool $running, bool $saw_output, bool &$seen, i
 }
 
 
+// Decide whether a plain Update-page load should AUTO-TAIL an in-progress update (stream it
+// live like the View button) instead of pre-filling the last-run log tail. TRUE iff a
+// pfBlockerNG feed task is running AND this request is neither a Run-Now/wizard dispatch
+// ($run_dispatch) nor a View/End-View button click ($logview_posted) — those paths drive their
+// own livetail. Pure (no globals/IO) so it is unit-tested directly; the page passes isset()
+// booleans for the two POST signals.
+function pfb_update_autotail(bool $task_running, bool $run_dispatch, bool $logview_posted): bool {
+	return $task_running && !$run_dispatch && !$logview_posted;
+}
+
+
 // Read logfile in realtime (livetail)
 // Reference: http://stackoverflow.com/questions/3218895/php-how-to-read-a-file-live-that-is-constantly-being-written-to
 function pfb_livetail($logfile, $mode, $pidfile = '') {

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -253,12 +253,18 @@ $status = 'NEXT Scheduled CRON Event will run at'
 	. "&emsp;<strong>{$cronreal}</strong>&emsp;with<strong><span style=\"color: red;\">&emsp;{$nextcron}"
 	. '&emsp;</span></strong> time remaining.';
 
-// Query for any active pfBlockerNG task
-if (pfb_active_task_running()) {
+// Query for any active pfBlockerNG task (captured once: reused by the status line AND the
+// auto-tail decision below).
+$pfb_task_running = pfb_active_task_running();
+if ($pfb_task_running) {
 	$status = '<span style="color: red;">&emsp;&emsp;'
 		. 'Active pfBlockerNG CRON JOB'
 		. '</span>&emsp;<i class="fa-solid fa-spinner fa-pulse fa-lg"></i>';
 }
+
+// Auto-tail an IN-PROGRESS update on a plain page load (no Run Now / wizard dispatch, no View
+// button click) — stream it live like the View button instead of showing a stale last-run tail.
+$pfb_auto_tail = pfb_update_autotail($pfb_task_running, isset($pconfig['run']), isset($_POST['log_view']));
 $status .= '<br />&emsp;<small><span style="color: red;">Refresh to update current status and time remaining.</span></small>';
 
 // Read the due-ledger entries for the Schedule view (read-only at page load).
@@ -432,8 +438,11 @@ $form->add($section);
 // Plain GET (no active run and no live-view) → prefill pfb_output with the last log tail.
 // $pconfig['run'] is the SAME signal the Run Now dispatch gate keys on (set by a button POST
 // and by the wizard-reload GET), so this suppresses the stale prefill on every run-start path.
+// $pfb_auto_tail also suppresses the stale prefill: an in-progress update is streamed live
+// (below) instead, so pfb_output must start empty for the livetail to fill it.
 $pfb_log_active = isset($pconfig['run']) ||
-                  (isset($pconfig['log_view']) && $pconfig['log_view'] !== 'View');
+                  (isset($pconfig['log_view']) && $pconfig['log_view'] !== 'View') ||
+                  $pfb_auto_tail;
 $section = new Form_Section('Log');
 $section->addInput(new Form_Textarea(
 	'pfb_status',
@@ -456,6 +465,11 @@ print($form);
 if (isset($pconfig['log_view'])) {
 	if ($pconfig['log_view'] !== 'View') {
 		pfbupdate_status(gettext("Log Viewing in progress.    ** Press 'END VIEW' to Exit ** "));
+		pfb_livetail($pfb['log'], 'view');
+	} elseif ($pfb_auto_tail) {
+		// Plain page load while an update is in progress: tail it live (passive 'view' viewer,
+		// same as the View button) rather than leaving the prefilled last-run tail.
+		pfbupdate_status(gettext("Update in progress — tailing the live log..."));
 		pfb_livetail($pfb['log'], 'view');
 	} else {
 		// End the viewer output Window

--- a/tests/php/PfbUpdateAutotailTest.php
+++ b/tests/php/PfbUpdateAutotailTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_update_autotail — the Update page's "auto-tail an in-progress update on a plain load"
+ * decision. On a plain page load while a feed task is running, the page should stream the live
+ * log (passive 'view' livetail, like the View button) instead of pre-filling the last-run tail.
+ *
+ * It must NOT auto-tail when there is no running task, when the request is a Run-Now/wizard
+ * dispatch ($run_dispatch — that path drives its own 'force' livetail), or when it is a
+ * View/End-View button click ($logview_posted — handled by the existing log_view branch).
+ *
+ * Each of the three inputs is asserted both ways so every branch of the AND is a real gate.
+ * Red→green: pfb_update_autotail() does not exist before the change, so every case fatals with
+ * "undefined function"; green after.
+ */
+#[CoversFunction('pfb_update_autotail')]
+final class PfbUpdateAutotailTest extends TestCase
+{
+	/**
+	 * The target case: a task is running and this is a plain load (no run dispatch, no view
+	 * click) → auto-tail.
+	 */
+	public function testRunningPlainLoadAutoTails(): void
+	{
+		$this->assertTrue(pfb_update_autotail(TRUE, FALSE, FALSE));
+	}
+
+	/**
+	 * No task running → never auto-tail (nothing to stream; the static last-run prefill stands).
+	 */
+	public function testNotRunningDoesNotAutoTail(): void
+	{
+		$this->assertFalse(pfb_update_autotail(FALSE, FALSE, FALSE));
+	}
+
+	/**
+	 * A Run-Now / wizard dispatch ($run_dispatch) drives its own 'force' livetail → no auto-tail,
+	 * even with a task running.
+	 */
+	public function testRunDispatchDoesNotAutoTail(): void
+	{
+		$this->assertFalse(pfb_update_autotail(TRUE, TRUE, FALSE));
+	}
+
+	/**
+	 * A View / End-View button click ($logview_posted) is handled by the existing log_view
+	 * branch → no auto-tail, even with a task running.
+	 */
+	public function testLogViewClickDoesNotAutoTail(): void
+	{
+		$this->assertFalse(pfb_update_autotail(TRUE, FALSE, TRUE));
+	}
+}


### PR DESCRIPTION
When the Update page loads while a feed update is **already running** (a cron tick, or a run started from another tab/CLI), pre-filling the log textarea with the **last** run's tail is misleading — you want to watch the run happening *now*. This detects an active task on a plain load and **streams it live**, exactly as if you'd clicked **View** (or used Run Now).

## Behaviour

- **Plain load + a task running** → auto-tail the live log (passive `'view'` livetail, the same mechanism the View button uses; a cron-launched run has no pidfile for this page, so `'view'` — not the pidfile-keyed `'force'` mode — is the right fit).
- **No task running** → unchanged: pre-fill the last-run tail.
- **Run Now / wizard dispatch** → unchanged: drives its own `'force'` livetail.
- **View / End-View click** → unchanged: the existing `log_view` branch handles it (so End-View still stops).

The auto-tail also suppresses the stale static prefill so the textarea starts empty for the live stream.

## Tests

The decision is a pure helper `pfb_update_autotail($task_running, $run_dispatch, $logview_posted)` (mirrors `pfb_livetail_force_done`), unit-tested across **all three conditions both ways** — `PfbUpdateAutotailTest` (red before the helper exists, green after). The live streaming reuses the unchanged `pfb_livetail('view')`; true streaming correctness is the same out-of-CI/maintainer item as the View button itself (a `'view'` stream holds the request open, so it can't be asserted by a normal GET). Tier-A render (the no-task static-prefill path) stays green via the existing update-page render coverage.

`php -l` / PHPCS / PHPStan / PHPUnit (1620) green locally. Dispatching the UI render leg to confirm the page still renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update pages now automatically follow the live log when an update is already in progress.
  * The page shows a clearer “update in progress” status while live log streaming is active.

* **Bug Fixes**
  * Prevents stale log text from appearing when reopening the update screen during an active run.
  * Improves behavior around manual log view actions so they no longer interfere with automatic live tailing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->