### PR TITLE
pfblockerng: fix stray line break in the DNSBL permit-rules help text

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3128,7 +3128,7 @@ $section->addInput(new Form_Checkbox(
 	gettext('Enable'),
 	pfb_cfg_toggle_read($pconfig['pfb_dnsbl_rule']) === PfbToggle::On,
 	'on'
-))->setHelp('This will create \'Floating\' Firewall permit rules to allow traffic from the Selected Interface(s) to access<br />'
+))->setHelp('This will create \'Floating\' Firewall permit rules to allow traffic from the Selected Interface(s) to access '
 		. 'the <strong>DNSBL Webserver</strong>. (ICMP and Webserver ports only).'
 		. '<br /><br />'
 		. 'This option is not designed to bypass DNSBL for the non-selected LAN segments<br />'

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -96,6 +96,10 @@ PAGE_TABLE: tuple[Page, ...] = (
             "no-AAAA",
             "pfb_dnsbl_nonat",  # issue-#381 NAT opt-out checkbox (name= attr in rendered HTML)
             "pfB_DNSBLIP_v4",  # DNSBL IPs help text names the real alias (was stale 'pfB_DNSBL_IP')
+            # Permit-rules help renders as one flowing sentence — a stray <br /> split
+            # "...to access<br />the DNSBL Webserver", so this space-joined phrase is the
+            # red→green guard (absent with the <br />, present once it is a space).
+            "Selected Interface(s) to access the ",
         ),
     ),
     # feeds.php is split into IPv4/IPv6/DNSBL ?type sub-tabs (ADR-16 Phase 3). Each type


### PR DESCRIPTION
The DNSBL "Floating Firewall permit rules" help text carried a hard `<br />` mid-sentence:

```
...to allow traffic from the Selected Interface(s) to access
the DNSBL Webserver. (ICMP and Webserver ports only).
```

It wrapped between "access" and "the" for no reason. Replaced the `<br />` with a space so the sentence flows.

**Tier-A guard:** the DNSBL render-marker set now includes the space-joined phrase `"Selected Interface(s) to access the "` — absent while the `<br />` was there (red), present once it's a space (green). `php -l` + ruff green; dispatching the UI render leg to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
