### PR TITLE
pfblockerng: clearer VIP-interface message + newline on the auto-VIP deferral log

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1902,7 +1902,7 @@ function pfb_global() {
 			} else {
 				// Manual mode: a genuinely invalid/missing/mismatched VIP disables DNSBL.
 				$pfb['dnsbl'] = '';
-				pfb_logger("\nDNSBL disabled: {$vips_valid_result[1]}", 1);
+				pfb_logger("\nDNSBL disabled: {$vips_valid_result[1]}\n", 1);
 			}
 		} elseif (pfb_dnsbl_v6_vip_required(pfb_unbound_listens_v6(), ($pfb['dnsbl_vip_auto'] === 'on')) && empty($pfb['dnsblconfig']['pfb_dnsvip6'])) {
 			// [ ADR-13 §7 pivot ] NON-BLOCKING: the resolver listens on IPv6 but no v6

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1390,10 +1390,10 @@ function pfb_validate_vips(string $interface, string|null $vip4 = '', string|nul
 	}
 
 	if ($enabled4 && ($interface != get_configured_vip_interface($vip4))) {
-		return [FALSE, sprintf(gettext('IPv4 VIP not on interface %s'), convert_friendly_interface_to_friendly_descr($interface))];
+		return [FALSE, sprintf(gettext('IPv4 VIP not found on interface %s'), convert_friendly_interface_to_friendly_descr($interface))];
 	}
 	if ($enabled6 && ($interface != get_configured_vip_interface($vip6))) {
-		return [FALSE, sprintf(gettext('IPv6 VIP not on interface %s'), convert_friendly_interface_to_friendly_descr($interface))];
+		return [FALSE, sprintf(gettext('IPv6 VIP not found on interface %s'), convert_friendly_interface_to_friendly_descr($interface))];
 	}
 
 	$vips = pfb_get_vips();
@@ -1898,7 +1898,7 @@ function pfb_global() {
 				// interface during this same update pass. A stale / missing / wrong-interface
 				// manual reference must NOT force-disable DNSBL here, or the auto bootstrap
 				// can never run (mode would compute to 'disabled' and creation would be skipped).
-				pfb_logger("\nDNSBL auto-VIP: VIP validation deferred to auto-create ({$vips_valid_result[1]})", 1);
+				pfb_logger("\nDNSBL auto-VIP: VIP validation deferred to auto-create ({$vips_valid_result[1]})\n", 1);
 			} else {
 				// Manual mode: a genuinely invalid/missing/mismatched VIP disables DNSBL.
 				$pfb['dnsbl'] = '';

--- a/tests/php/PfbValidateVipsMessageTest.php
+++ b/tests/php/PfbValidateVipsMessageTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_validate_vips() — the interface-mismatch reason string. When the configured DNSBL VIP
+ * resolves to an interface other than the expected one, validation fails with a reason that is
+ * surfaced to the user (Update log + DNSBL save). The wording is "VIP not FOUND on interface
+ * <iface>" — clearer than the old "VIP not on interface", which read ambiguously ("is there no
+ * VIP, or is it elsewhere?").
+ *
+ * The doubled get_configured_vip_interface() (pfsense_doubles.php) returns 'opt-double' for any
+ * '_vip_test_*' VIP id, so passing expected interface 'lo0' forces the mismatch branch (which
+ * returns BEFORE pfb_get_vips(), so no further VIP state is needed). Both families are asserted.
+ *
+ * Red→green: the old message ("not on interface") lacks "found", so each assertion fails on the
+ * pre-change code and passes after.
+ */
+#[CoversFunction('pfb_validate_vips')]
+final class PfbValidateVipsMessageTest extends TestCase
+{
+	public function testIpv4InterfaceMismatchSaysNotFoundOnInterface(): void
+	{
+		[$ok, $reason] = pfb_validate_vips('lo0', '_vip_test_4', '');
+		$this->assertFalse($ok, 'an IPv4 VIP on the wrong interface must fail validation');
+		$this->assertSame('IPv4 VIP not found on interface lo0', $reason);
+	}
+
+	public function testIpv6InterfaceMismatchSaysNotFoundOnInterface(): void
+	{
+		[$ok, $reason] = pfb_validate_vips('lo0', '', '_vip_test_6');
+		$this->assertFalse($ok, 'an IPv6 VIP on the wrong interface must fail validation');
+		$this->assertSame('IPv6 VIP not found on interface lo0', $reason);
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -329,7 +329,7 @@ if (!function_exists('get_configured_vip_ipv6')) {
 
 if (!function_exists('get_configured_vip_interface')) {
 	// pfSense util.inc: the friendly interface a VIP id lives on. The test sentinels are
-	// not real VIPs, so report a non-'lo0' interface -> the validator's "VIP not on
+	// not real VIPs, so report a non-'lo0' interface -> the validator's "VIP not found on
 	// interface" check fails for them. That is fine: those tests only assert the error is
 	// NOT the v6-required message, never that validation passes.
 	function get_configured_vip_interface($vipif) {
@@ -345,7 +345,7 @@ if (!function_exists('get_configured_vip_interface')) {
 
 if (!function_exists('convert_friendly_interface_to_friendly_descr')) {
 	// pfSense interfaces.inc: friendly name -> human description. Identity is enough for
-	// the "VIP not on interface %s" message the doubled-interface path produces.
+	// the "VIP not found on interface %s" message the doubled-interface path produces.
 	function convert_friendly_interface_to_friendly_descr($interface) {
 		return $interface;
 	}


### PR DESCRIPTION
Two fixes from a confusing auto-VIP log line:

```
DNSBL auto-VIP: VIP validation deferred to auto-create (IPv4 VIP not on interface Loopback) UPDATE PROCESS START [ v4.0.0.alpha.8 ] [ 2026-06-30 07:04:08 ]
```

1. **Missing newline** — the deferral line had no trailing `\n`, so it ran straight into the next log entry (`...UPDATE PROCESS START [...]`). Added `\n`.
2. **Confusing wording** — `pfb_validate_vips()`'s reason `IPv4/IPv6 VIP not on interface <iface>` → **`...not found on interface <iface>`**. The old phrasing read ambiguously (is there *no* VIP, or is it elsewhere?). It means: the *configured* VIP does not resolve to the expected interface.

## Not a detection bug

In **auto-create mode** this deferral is **informational, not an error**: `pfb_manage_dnsbl_vip()` owns the sinkhole VIP and (re)provisions it on the configured interface during the same update pass, so a stale / missing / different manual `pfb_dnsvip4` reference is *expected* and harmless (it does not disable DNSBL — the comment at the call site documents exactly this). So "your VIP is on loopback" and this message are not in conflict — the line is about the configured manual reference, which auto-create supersedes.

## Test

`PfbValidateVipsMessageTest` pins both reworded reasons via the interface-mismatch branch (red on the old "not on interface", green after). `php -l` / PHPCS / PHPStan / PHPUnit (1622) green. The newline is in `pfb_global()` (not unit-testable in isolation); it's exercised by the auto-VIP live smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DNSBL VIP validation messages to say “not found on interface” for both IPv4 and IPv6.
  * Improved log formatting during VIP validation and DNSBL auto-create/manual disable flows.
* **Tests**
  * Added coverage for IPv4 and IPv6 interface-mismatch validation, confirming the updated error text is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->