### PR TITLE
pfblockerng: grandfather existing installs to alias-apply 'replace' (ADR-40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -740,8 +740,10 @@ for large churn, boot, or enable/disable; `delta` always applies the forward del
 large-churn replace fallback (power-user override — can be slow on full-table rebuilds); `replace`
 always does a full `-T replace`. Both paths produce the same `pfctl -t <t> -T show` membership
 (end-state invariant). Two registered `PfbConfig` fields: `pfb_alias_delta_mode` (enum
-`auto`/`delta`/`replace`, default `auto`) and `pfb_alias_delta_batch` (chunk size, default 512,
-clamped 64–4096). See
+`auto`/`delta`/`replace`; **new-install default `auto`**, but an **already-configured install is
+grandfather-seeded to `replace`** at install/upgrade — `pfb_alias_delta_mode_install_default()` —
+so an upgrade keeps the prior full-replace apply path, never silently switching to delta) and
+`pfb_alias_delta_batch` (chunk size, default 512, clamped 64–4096). See
 `docs/misc/architecture-notes.md` ("ADR-40") for the cross-list dedup/reputation scope rules.
 
 **Scheduling, trigger API & verb routing (ADR-43).** The reload entrypoint

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -142,8 +142,14 @@ membership is the canonical desired set — identical to what a full replace wou
 
 | Key | Type | Default | Notes |
 | --- | ---- | ------- | ----- |
-| `pfb_alias_delta_mode` | `alias_delta_mode` | `'auto'` | `PfbAliasDeltaMode` enum: `auto`/`delta`/`replace` |
+| `pfb_alias_delta_mode` | `alias_delta_mode` | `'auto'` † | `PfbAliasDeltaMode` enum: `auto`/`delta`/`replace` |
 | `pfb_alias_delta_batch` | `plain` | `'512'` | Chunk size for `-T add`/`-T delete`; clamped to \[64, 4096\] |
+
+† New-install default. An already-configured install is **grandfather-seeded to `'replace'`** (the
+pre-ADR-40 full `-T replace`) at install/upgrade by `pfb_alias_delta_mode_install_default()` +
+`pfblockerng_install.inc`, so an upgrade preserves the operator's prior apply path instead of
+silently switching to delta; only a brand-new install takes the `'auto'` absent-default. Run-once
+via the `!isset` guard, so an explicit operator choice (incl. an explicit `'auto'`) is never overridden.
 
 **Cross-list correctness.** When dedup (`enable_dup`) or reputation is active, a feed-A change
 that shifts sibling table B's effective membership (through the shared `masterfile` dedup path)

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -12,11 +12,15 @@ field, reasoning about rollback/downgrade, or checking the foreign-key exclusion
   - `dnsbl_lenient` / `pfb_keep` → `PfbLenient` (`'on'`/`'off'`); `dnsbl_vip_auto` and ~76 other
     `'on'`/`''` checkbox fields → `PfbToggle` (off-value `''`).
   - **`pfb_alias_delta_mode` → `PfbAliasDeltaMode`** (ADR-40, registry adapters
-    `pfb_cfg_alias_delta_mode_read/write`): tokens `'auto'` (default) / `'delta'` / `'replace'`.
-    Unknown or absent token reads as `Auto`. Absent on a pre-4.0.0 install → feature silently
-    absent (full replace, the pre-4.0.0 behaviour). `pfb_alias_delta_batch` (plain string,
-    `NULL`/`NULL` adapters) is the batch-size companion field; its stored value is a decimal
-    integer string, clamped to `[64, 4096]` at read time by `pfb_alias_delta_batch_clamp()`.
+    `pfb_cfg_alias_delta_mode_read/write`): tokens `'auto'` (new-install default) / `'delta'` /
+    `'replace'`. Unknown or absent token reads as `Auto`. **Grandfather seed:** an already-configured
+    install is pinned to `'replace'` (pre-ADR-40 full `-T replace`) at install/upgrade by
+    `pfb_alias_delta_mode_install_default()` + `pfblockerng_install.inc` — run-once via its `!isset`
+    guard — so only a brand-new install takes the `'auto'` absent-default; an upgrade keeps full
+    replace. Absent on a pre-4.0.0 (downgrade) install → feature silently absent (full replace).
+    `pfb_alias_delta_batch` (plain string, `NULL`/`NULL` adapters) is the batch-size companion
+    field; its stored value is a decimal integer string, clamped to `[64, 4096]` at read time by
+    `pfb_alias_delta_batch_clamp()`.
   - **`pfb_idn` → `PfbIdnMode`** (registry adapters `pfb_cfg_idn_mode_read/write`): tokens
     `'on'` (= All) / `'confusable'` / `'off'`. `All` **reuses the original `'on'`** block-all
     token, so a pre-4.0.0 install round-trips with no migration *and* an older release reading

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7667,6 +7667,23 @@ function pfb_feed_filter_install_default($gconfig) {
 }
 
 
+// ADR-40: alias-table apply-mode grandfather decision the install/upgrade hook applies.
+// $gconfig is the existing General-settings 'config/0' node (null on a fresh, never-configured
+// install). A new install takes the registry absent-default 'auto' (delta for small churn, full
+// replace for large churn / boot); an
+// already-configured install that has not yet seen the key is pinned to 'replace' (the pre-ADR-40
+// full -T replace) so the upgrade preserves that operator's prior apply behaviour instead of
+// silently switching to delta. Run-once + idempotent: once the key is set (any value) it returns
+// NULL, so a later save never overrides an operator's explicit choice.
+function pfb_alias_delta_mode_install_default($gconfig) {
+
+	if (is_array($gconfig) && !isset($gconfig['pfb_alias_delta_mode'])) {
+		return 'replace';
+	}
+	return NULL;
+}
+
+
 // ADR-02: one-time upgrade migration for the DNSBL python-only mode. $dconfig is the
 // existing DNSBL-settings 'config/0' node. Forces 'dnsbl_mode' to 'dnsbl_python' and
 // 'pfb_py_block' to 'on'. Idempotent: returns NULL when both keys already carry the target

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -180,10 +180,12 @@ enum PfbIdnMode: string implements PfbStoredEnum
 //                         the safe default.
 //   Replace ('replace') — always full -T replace (pre-ADR-40 behaviour).
 //
-// Absent-default = 'auto' for ALL installs (new AND existing): ADR-40 end-state is
-// identical to replace (contract item 1 — table membership unchanged), so no
-// grandfather seed is required. Downgrade-safe: an older release lacking this key
-// ignores it and performs its existing full replace.
+// Absent-default = 'auto' for a NEW install. An already-configured install is grandfathered to
+// 'replace' (pre-ADR-40 full -T replace) by a one-time install/upgrade seed
+// (pfb_alias_delta_mode_install_default() + pfblockerng_install.inc), so an upgrade preserves the
+// operator's prior apply path instead of silently switching to delta — the absent-default 'auto'
+// reaches only brand-new installs. Downgrade-safe: an older release lacking this key ignores it
+// and performs its existing full replace.
 enum PfbAliasDeltaMode: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
@@ -543,12 +545,12 @@ function pfb_cfg_registry(): array
 			'since'         => '2.0.0',
 		],
 
-		// ADR-40: alias-table apply mode: 'auto' | 'delta' | 'replace'. Default 'auto'.
+		// ADR-40: alias-table apply mode: 'auto' | 'delta' | 'replace'. New-install default 'auto'.
 		// 'auto' = delta for small churn (< ~5%), full replace for initial load / large churn;
 		// 'delta' = ALWAYS forward delta, NO large-churn replace fallback (power-user override);
-		// 'replace' = always full -T replace.
-		// Absent-default 'auto' is safe for existing installs (end-state identical to
-		// replace — ADR-40 contract item 1); no grandfather seed needed.
+		// 'replace' = always full -T replace (pre-ADR-40 behaviour).
+		// Existing installs are grandfather-seeded to 'replace' at install/upgrade
+		// (pfb_alias_delta_mode_install_default); only brand-new installs take the 'auto' default.
 		'pfb_alias_delta_mode' => [
 			'section'       => $gen,
 			'default'       => 'auto',

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -522,6 +522,14 @@ if ($pfb_feed_default !== null) {
 	PfbConfig::write('pfb_feed_internal_filter', $pfb_feed_default);
 }
 
+// ADR-40: grandfather an already-configured install to 'replace' (pre-ADR-40 full -T replace) so
+// an upgrade keeps its prior alias-apply behaviour; a new install takes the 'auto' registry
+// default. Run-once via the !isset guard in pfb_alias_delta_mode_install_default().
+$pfb_delta_default = pfb_alias_delta_mode_install_default($pfb_gcfg);
+if ($pfb_delta_default !== null) {
+	PfbConfig::write('pfb_alias_delta_mode', $pfb_delta_default);
+}
+
 // Convert dnsbl_info CSV file to SQLite3 database format
 if (file_exists('/var/db/pfblockerng/dnsbl_info') &&
     !file_exists('/var/db/pfblockerng/dnsbl.sqlite') &&

--- a/tests/php/AliasDeltaModeInstallDefaultTest.php
+++ b/tests/php/AliasDeltaModeInstallDefaultTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_alias_delta_mode_install_default() — the ADR-40 grandfather decision the
+ * install/upgrade hook applies for the alias-table apply mode. (The procedural
+ * application in pfblockerng_install.inc — PfbConfig::write — is smoke/manual-verified;
+ * this pins the pure decision the hook delegates to.)
+ *
+ * Contract:
+ *   - config/0 == null (fresh, never-configured install) => NULL: leave the key unset,
+ *     so the registry absent-default 'auto' applies (delta for small churn, new installs).
+ *   - config/0 present, key absent (an already-configured upgrade) => 'replace': pin the
+ *     pre-ADR-40 full -T replace once, so the upgrade does not silently switch to delta.
+ *   - key already set (any value) => NULL: run-once + idempotent, never overrides an
+ *     operator's explicit choice (incl. an explicit 'auto').
+ */
+#[CoversFunction('pfb_alias_delta_mode_install_default')]
+final class AliasDeltaModeInstallDefaultTest extends TestCase
+{
+	public function testFreshInstallLeavesKeyUnset(): void
+	{
+		// config/0 == null => fresh => NULL (=> registry absent-default 'auto').
+		$this->assertNull(pfb_alias_delta_mode_install_default(null));
+	}
+
+	public function testExistingInstallWithoutKeyIsPinnedReplace(): void
+	{
+		// An already-configured install (other settings present, key absent) is the
+		// grandfather case -> pin 'replace' to preserve pre-ADR-40 behaviour.
+		$gconfig = ['enable_cb' => 'on', 'pfb_keep' => 'on'];
+		$this->assertSame('replace', pfb_alias_delta_mode_install_default($gconfig));
+	}
+
+	public function testKeyAlreadyAutoIsNotRePinned(): void
+	{
+		// An operator who explicitly chose 'auto' must never be flipped to 'replace' by a
+		// later upgrade -> NULL (no write).
+		$this->assertNull(pfb_alias_delta_mode_install_default(['pfb_alias_delta_mode' => 'auto']));
+	}
+
+	public function testKeyAlreadyReplaceIsLeftUnchanged(): void
+	{
+		// Idempotent: a stored 'replace' is not re-applied (NULL => no write).
+		$this->assertNull(pfb_alias_delta_mode_install_default(['pfb_alias_delta_mode' => 'replace']));
+	}
+
+	public function testKeyAlreadyDeltaIsPreserved(): void
+	{
+		// A power-user 'delta' choice survives the seed -> NULL (no write).
+		$this->assertNull(pfb_alias_delta_mode_install_default(['pfb_alias_delta_mode' => 'delta']));
+	}
+}


### PR DESCRIPTION
## What

ADR-40's `pfb_alias_delta_mode` shipped defaulting to **`auto`** (delta for small churn, full replace for large/boot) for *all* installs. Per maintainer decision, **grandfather the prior `replace` behaviour** for already-configured installs across an upgrade, and let **only brand-new installs** take `auto`.

## How

Mirrors the established grandfather-seed pattern (`pfb_feed_internal_filter`):

- **`pfb_alias_delta_mode_install_default($gconfig)`** (`pfblockerng.inc`) — returns `'replace'` for an already-configured install (`config/0` present, key absent), else `NULL` (fresh install → registry `'auto'` absent-default; or key already set → never override an explicit choice, incl. an explicit `'auto'`).
- **`pfblockerng_install.inc`** applies it via `PfbConfig::write`, right after the feed-filter seed (reuses `$pfb_gcfg`). Run-once + idempotent via the `!isset` guard.
- **Registry absent-default stays `'auto'`** (= new-install default). **Downgrade-safe**: an older release lacking the key performs its existing full replace.

End-state is identical either way (ADR-40 contract: same table membership); this only changes the *apply mechanism* an upgrading operator gets by default — conservative `replace`, not delta.

## Tests

`AliasDeltaModeInstallDefaultTest` pins both branches (fresh→`NULL`/`auto`; configured+absent→`'replace'`; already-set `auto`/`replace`/`delta`→`NULL`). Red→green: the function is undefined on pre-change code. Full PHPUnit suite green (1627).

The procedural `PfbConfig::write` application is the same proven path as the existing feed-filter seed (unit-pinned decision; application smoke/manual-verified) — no new live-VM coverage needed.

Docs updated: the enum + registry comments, `CLAUDE.md`, `architecture-notes.md`, `config-gateway.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
