### PR TITLE
pfblockerng: don't run iprange (IPv4-only) on the v6 aggregate union

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -645,26 +645,29 @@ pfb_aggregate() {
 	done < "${agg_memberlist}"
 	LC_ALL=C sort -u "${tempfile}" > "${dedupfile}"
 
-	# CIDR-collapse the deduped union. iprange is IPv4-ONLY: given IPv6 it truncates each
-	# address at the first ':' and reads the leading hextet as a decimal, emitting bogus
-	# 0.0.x.y entries -- so ONLY v4 is passed through it (mirroring the per-alias path, which
-	# gates cidr_aggregate to _v4 in pfblockerng.inc). For v6 the deduped sort -u union IS the
-	# result: set-correct, just not minimal-CIDR-collapsed -- exactly how every individual v6
-	# alias is already kept. Write via a temp + mv so a transient iprange failure cannot clobber
-	# a previously valid aggregate (the '>' redirect would truncate ${agg_out} before it ran).
+	# CIDR-collapse the deduped union into a temp, then mv into place only on success -- so a
+	# failure in ANY branch (iprange error, or a write/copy failure) cannot clobber a previously
+	# valid aggregate (a direct '>' redirect would truncate ${agg_out} before the producer ran).
+	# iprange is IPv4-ONLY: given IPv6 it truncates each address at the first ':' and reads the
+	# leading hextet as a decimal, emitting bogus 0.0.x.y entries -- so ONLY v4 is passed through
+	# it (mirroring the per-alias path, which gates cidr_aggregate to _v4 in pfblockerng.inc). For
+	# v6 the deduped sort -u union IS the result: set-correct, just not minimal-CIDR-collapsed --
+	# exactly how every individual v6 alias is already kept. An empty union writes an empty
+	# aggregate (the never-empty consumer placeholder is handled below).
+	agg_tmp="${agg_out}.tmp"
 	if [ ! -s "${dedupfile}" ]; then
-		: > "${agg_out}"
+		: > "${agg_tmp}"
 	elif [ "${agg_family}" = 'v6' ]; then
-		cp -f "${dedupfile}" "${agg_out}"
+		cp -f "${dedupfile}" "${agg_tmp}"
 	else
-		agg_tmp="${agg_out}.tmp"
-		if ! "${pathaggregate}" "${dedupfile}" > "${agg_tmp}"; then
-			rm -f "${agg_tmp}"
-			log="aggregate [ ${agg_family} ]: iprange failed; keeping existing [ ${agg_out} ]."
-			echo "${log}" | tee -a "${errorlog}"
-			return
-		fi
-		mv -f "${agg_tmp}" "${agg_out}"
+		"${pathaggregate}" "${dedupfile}" > "${agg_tmp}"
+	fi
+	agg_rc="$?"
+	if [ "${agg_rc}" -ne 0 ] || ! mv -f "${agg_tmp}" "${agg_out}"; then
+		rm -f "${agg_tmp}"
+		log="aggregate [ ${agg_family} ]: build of [ ${agg_out} ] failed; keeping existing."
+		echo "${log}" | tee -a "${errorlog}"
+		return
 	fi
 
 	# Never-empty '-f' consumer file: mirror the aggregate, but substitute a single

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -586,16 +586,18 @@ cidr_aggregate() {
 # the cat|sort -u|iprange entirely. The consumer file must also already exist and be
 # non-empty, else we always (re)build to honour the never-empty contract.
 pfb_aggregate() {
-	if [ ! -x "${pathaggregate}" ]; then
-		log="Application [ iprange ] Not found. Cannot proceed."
-		echo "${log}" | tee -a "${errorlog}"
-		return
-	fi
-
 	agg_family="${2}"
 	agg_memberlist="${3}"
 	agg_out="${4}"
 	agg_consumer="${5}"
+
+	# v4 aggregation CIDR-collapses through iprange (below); v6 does NOT use iprange (it is
+	# IPv4-only), so require it only for v4 -- a v6 aggregate must still build without it.
+	if [ "${agg_family}" != 'v6' ] && [ ! -x "${pathaggregate}" ]; then
+		log="Application [ iprange ] Not found. Cannot proceed."
+		echo "${log}" | tee -a "${errorlog}"
+		return
+	fi
 
 	if [ -z "${agg_memberlist}" ] || [ -z "${agg_out}" ] || [ -z "${agg_consumer}" ]; then
 		log="aggregate [ ${agg_family} ]: missing memberlist/output path argument."
@@ -643,10 +645,18 @@ pfb_aggregate() {
 	done < "${agg_memberlist}"
 	LC_ALL=C sort -u "${tempfile}" > "${dedupfile}"
 
-	# CIDR-collapse the deduped union via iprange (set-exact). Write to a temp and mv into
-	# place only on success, so a transient iprange failure cannot clobber a previously valid
-	# aggregate (the '>' redirect would otherwise truncate ${agg_out} before iprange even ran).
-	if [ -s "${dedupfile}" ]; then
+	# CIDR-collapse the deduped union. iprange is IPv4-ONLY: given IPv6 it truncates each
+	# address at the first ':' and reads the leading hextet as a decimal, emitting bogus
+	# 0.0.x.y entries -- so ONLY v4 is passed through it (mirroring the per-alias path, which
+	# gates cidr_aggregate to _v4 in pfblockerng.inc). For v6 the deduped sort -u union IS the
+	# result: set-correct, just not minimal-CIDR-collapsed -- exactly how every individual v6
+	# alias is already kept. Write via a temp + mv so a transient iprange failure cannot clobber
+	# a previously valid aggregate (the '>' redirect would truncate ${agg_out} before it ran).
+	if [ ! -s "${dedupfile}" ]; then
+		: > "${agg_out}"
+	elif [ "${agg_family}" = 'v6' ]; then
+		cp -f "${dedupfile}" "${agg_out}"
+	else
 		agg_tmp="${agg_out}.tmp"
 		if ! "${pathaggregate}" "${dedupfile}" > "${agg_tmp}"; then
 			rm -f "${agg_tmp}"
@@ -655,8 +665,6 @@ pfb_aggregate() {
 			return
 		fi
 		mv -f "${agg_tmp}" "${agg_out}"
-	else
-		: > "${agg_out}"
 	fi
 
 	# Never-empty '-f' consumer file: mirror the aggregate, but substitute a single

--- a/tests/shell/pfblockerng_aggregate_v6_spec.sh
+++ b/tests/shell/pfblockerng_aggregate_v6_spec.sh
@@ -1,0 +1,74 @@
+#shellcheck shell=sh
+# pfb_aggregate() family-correct collapse (issue #651).
+#
+# The ADR-11 "Uber" aggregate builder must NOT run iprange on the IPv6 union: iprange is
+# IPv4-only, so given IPv6 it truncates each address at the first ':' and reads the leading
+# hextet as a decimal, emitting bogus 0.0.x.y entries (observed live: pfB_Deny_Aggregated_v6
+# held 40 mangled IPv4 entries instead of its ~16k-address v6 union). The fix: v6 takes the
+# deduped sort -u union verbatim; v4 still CIDR-collapses through iprange.
+
+Describe 'pfb_aggregate() family-correct collapse (issue #651)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/agg.XXXXXX")"
+    tempfile="${work}/t1"
+    dedupfile="${work}/dedup"
+    errorlog="${work}/err.log"
+    memberlist="${work}/members"
+    aggout="${work}/agg.txt"
+    consumer="${work}/agg.lst"
+
+    # iprange stub that FAITHFULLY mimics the real IPv4-only tool (iprange 1.0.4): it records
+    # that it ran (so a test can assert it was/was not invoked) and truncates each line at the
+    # first ':' -- exactly how the real tool mangles IPv6 (2000::/16 -> "2000"). v4 lines (no
+    # ':') pass through unchanged, so the v4 path keeps working.
+    marker="${work}/iprange_called"
+    export PFB_AGG_MARKER="${marker}"
+    pathaggregate="${work}/iprange"
+    cat > "${pathaggregate}" <<'STUB'
+#!/bin/sh
+echo called > "${PFB_AGG_MARKER}"
+sed 's/:.*$//' "$1"
+STUB
+    chmod +x "${pathaggregate}"
+  }
+  cleanup() { rm -rf "${work}"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'writes the deduped v6 union verbatim and does NOT run iprange (v6)'
+    # Given two IPv6 member files sharing a duplicate entry
+    printf '2001:db8::/32\n2606:4700::/32\n' > "${work}/m1"
+    printf '2606:4700::/32\n2a00:1450::/32\n' > "${work}/m2"
+    printf '%s\n%s\n' "${work}/m1" "${work}/m2" > "${memberlist}"
+
+    When call pfb_aggregate agg v6 "${memberlist}" "${aggout}" "${consumer}"
+
+    The status should be success
+    # Then the aggregate is the deduped union of REAL IPv6 (not iprange-mangled to "2001"/"2a00")
+    The contents of file "${aggout}" should include '2001:db8::/32'
+    The contents of file "${aggout}" should include '2606:4700::/32'
+    The contents of file "${aggout}" should include '2a00:1450::/32'
+    # and iprange was NOT invoked for v6 (the bug was running the IPv4-only tool on it)
+    The path "${marker}" should not be exist
+    # consumer mirror is populated (never-empty contract)
+    The contents of file "${consumer}" should include '2001:db8::/32'
+    The stdout should include 'aggregate'
+  End
+
+  It 'passes the v4 union through iprange (v4 path unchanged)'
+    # Given two IPv4 member files sharing a duplicate entry
+    printf '192.0.2.0/24\n198.51.100.0/24\n' > "${work}/m1"
+    printf '198.51.100.0/24\n203.0.113.0/24\n' > "${work}/m2"
+    printf '%s\n%s\n' "${work}/m1" "${work}/m2" > "${memberlist}"
+
+    When call pfb_aggregate agg v4 "${memberlist}" "${aggout}" "${consumer}"
+
+    The status should be success
+    # iprange WAS invoked for v4 (the CIDR-collapse path), and the union is present + deduped
+    The path "${marker}" should be exist
+    The contents of file "${aggout}" should include '192.0.2.0/24'
+    The contents of file "${aggout}" should include '203.0.113.0/24'
+    The stdout should include 'aggregate'
+  End
+End

--- a/tests/shell/pfblockerng_aggregate_v6_spec.sh
+++ b/tests/shell/pfblockerng_aggregate_v6_spec.sh
@@ -41,18 +41,19 @@ STUB
     printf '2001:db8::/32\n2606:4700::/32\n' > "${work}/m1"
     printf '2606:4700::/32\n2a00:1450::/32\n' > "${work}/m2"
     printf '%s\n%s\n' "${work}/m1" "${work}/m2" > "${memberlist}"
+    # The EXACT deduped union, LC_ALL=C-sorted (the duplicate 2606:4700::/32 collapses).
+    expected_v6="$(printf '%s\n' '2001:db8::/32' '2606:4700::/32' '2a00:1450::/32')"
 
     When call pfb_aggregate agg v6 "${memberlist}" "${aggout}" "${consumer}"
 
     The status should be success
-    # Then the aggregate is the deduped union of REAL IPv6 (not iprange-mangled to "2001"/"2a00")
-    The contents of file "${aggout}" should include '2001:db8::/32'
-    The contents of file "${aggout}" should include '2606:4700::/32'
-    The contents of file "${aggout}" should include '2a00:1450::/32'
+    # Then the aggregate is EXACTLY the deduped IPv6 union: no duplicates, no extra lines, and
+    # none iprange-mangled to "2001"/"2a00" (an `include` check would miss all three).
+    The contents of file "${aggout}" should equal "${expected_v6}"
     # and iprange was NOT invoked for v6 (the bug was running the IPv4-only tool on it)
     The path "${marker}" should not be exist
-    # consumer mirror is populated (never-empty contract)
-    The contents of file "${consumer}" should include '2001:db8::/32'
+    # consumer mirror equals the aggregate (never-empty contract)
+    The contents of file "${consumer}" should equal "${expected_v6}"
     The stdout should include 'aggregate'
   End
 
@@ -61,14 +62,31 @@ STUB
     printf '192.0.2.0/24\n198.51.100.0/24\n' > "${work}/m1"
     printf '198.51.100.0/24\n203.0.113.0/24\n' > "${work}/m2"
     printf '%s\n%s\n' "${work}/m1" "${work}/m2" > "${memberlist}"
+    expected_v4="$(printf '%s\n' '192.0.2.0/24' '198.51.100.0/24' '203.0.113.0/24')"
 
     When call pfb_aggregate agg v4 "${memberlist}" "${aggout}" "${consumer}"
 
     The status should be success
-    # iprange WAS invoked for v4 (the CIDR-collapse path), and the union is present + deduped
+    # iprange WAS invoked for v4 (the CIDR-collapse path), and the union is exactly the deduped set
     The path "${marker}" should be exist
-    The contents of file "${aggout}" should include '192.0.2.0/24'
-    The contents of file "${aggout}" should include '203.0.113.0/24'
+    The contents of file "${aggout}" should equal "${expected_v4}"
+    The stdout should include 'aggregate'
+  End
+
+  It 'empties the aggregate and writes the consumer placeholder on an empty union'
+    # The third branch: no members -> empty union. A pre-existing (stale) aggregate must be
+    # truncated, the never-empty consumer must fall back to the '#' placeholder, and iprange is
+    # never invoked. Pre-seed stale content to prove the rebuild actually clears it.
+    printf 'stale\n' > "${aggout}"
+    printf 'stale\n' > "${consumer}"
+    : > "${memberlist}"
+
+    When call pfb_aggregate agg v6 "${memberlist}" "${aggout}" "${consumer}"
+
+    The status should be success
+    The contents of file "${aggout}" should equal ''
+    The contents of file "${consumer}" should equal '#'
+    The path "${marker}" should not be exist
     The stdout should include 'aggregate'
   End
 End


### PR DESCRIPTION
Fixes the ADR-11 aggregated ("Uber") IPv6 alias being populated with mangled IPv4 instead of the v6 union.

## Bug

`pfb_aggregate()` in `pfblockerng.sh` CIDR-collapsed the deduped union through **`iprange`** for *both* families. `iprange` (1.0.4) is **IPv4-only** — given IPv6 it truncates each address at the first `:` and reads the leading hextet as a decimal (`2000::/16` → `2000` → `0.0.7.208`), even attempting DNS on `2a03`. Observed on a live box: `pfB_Deny_Aggregated_v6` held 40 bogus `0.0.x.y` entries instead of its ~16k-address v6 union (the member feeds — CC6, Myip_BL6, SFS6, Spamhaus_Drop6 — were all correct IPv6). Confirmed by running `iprange` on a real IPv6 sample.

The per-alias CIDR aggregation is unaffected — `cidr_aggregate` is gated `&& $vtype == '_v4'` (`pfblockerng.inc:14968`, `:15636`). The Uber-aggregate path simply lacked that gate. Affects any aggregate type (Deny/Permit/Match) with v6 members.

## Fix

Pass only **v4** through `iprange`; for **v6** take the deduped `sort -u` union verbatim — set-correct, just not minimal-CIDR-collapsed, exactly how every individual v6 alias is already kept. `iprange` is now required only for v4, so a v6 aggregate builds even without it.

## Tests

`tests/shell/pfblockerng_aggregate_v6_spec.sh` drives `pfb_aggregate` with a **faithful IPv4-only `iprange` stub** (records invocation; truncates at `:`, mimicking iprange 1.0.4):
- **v6** → deduped IPv6 union written verbatim, `iprange` **not** invoked — **red on pre-fix** (iprange ran → output mangled to `2001`/`2a00`, marker present), green after.
- **v4** → still collapsed through `iprange` (regression guard; green before and after).

Both families covered, before/after proven. Full shellspec suite green (218 examples, 0 failures). End-to-end v6-aggregate membership on a live box is the ADR-11 §7 maintainer smoke (out-of-CI).

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP list aggregation so IPv6 results are handled correctly and no longer depend on IPv4-specific processing.
  * Added safer handling for aggregation failures, helping preserve the last valid output instead of replacing it with incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->