### PR TITLE
pfblockerng: only rebuild DNSBLIP (v4 + v6) when the source .ip set changed

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1382,6 +1382,21 @@ function pfb_dnsbl_loaded_fingerprint(array $paths): string {
 	return md5(implode("\n", $parts));
 }
 
+/* DNSBLIP rebuild gate (issue #653). DNSBLIP_<fam> is the union of the *_v<fam>.ip files (the IPs
+   extracted from the DNSBL feeds). Rebuilding + re-filtering it on every IP update is wasteful when
+   no source .ip changed. Decide via a content fingerprint of the .ip source set (ADR-42 style --
+   mtime-agnostic, since a .ip file may be rewritten with identical content): rebuild iff the output
+   is missing, the stored fingerprint is missing, or the current fingerprint differs. Returns
+   [bool $rebuild, string $fp_now]; the caller persists $fp_now beside the output on a rebuild.
+   Pure (read-only fs on the given paths). */
+function pfb_dnsblip_rebuild_check(string $output, array $ip_files, string $fp_path): array {
+	$fp_now  = pfb_dnsbl_loaded_fingerprint($ip_files);
+	$rebuild = !is_file($output)
+		|| !is_file($fp_path)
+		|| trim((string) @file_get_contents($fp_path)) !== $fp_now;
+	return array($rebuild, $fp_now);
+}
+
 // v6 stays OPTIONAL (ADR-13 §7 pivot): a missing v6 VIP never fails validation, even when
 // the resolver listens on IPv6 — pfb_global surfaces that as a non-blocking warning, not a
 // force-disable. The validator only checks the VIPs that ARE configured (existence,
@@ -14425,73 +14440,92 @@ function sync_package_pfblockerng($cron='') {
 		}
 	}
 
-	// Collect all DNSBL IP feeds (IPv4 only) into DNSBLIP_v4.txt
+	// Collect all DNSBL IP feeds (IPv4 only) into DNSBLIP_v4.txt -- but ONLY when the source
+	// *_v4.ip set actually changed (or the output is missing). Rebuilding + re-filtering DNSBLIP
+	// on every IP update churned it needlessly (issue #653); the content fingerprint (ADR-42
+	// style) gates the rebuild, the '.update' reprocess marker, and the ip_cache flush, so an
+	// unchanged source is left alone (the feed loop then logs "exists" instead of reprocessing).
 	if ($pfb['dnsbl_ip'] != 'Disabled' && ($pfb['updateip'] || !file_exists("{$pfb['dbdir']}/DNSBLIP_v4.txt"))) {
 
-		$dnsbl_ip = glob("{$pfb['dnsdir']}/*_v4.ip");
-		if (!empty($dnsbl_ip)) {
-			$pfb_ips = @fopen("{$pfb['dbdir']}/DNSBLIP_v4.txt", 'w');
-			foreach ($dnsbl_ip as $d_ip) {
-				if (($handle = @fopen("{$d_ip}", 'r')) !== FALSE) {
-					while (($line = @fgets($handle)) !== FALSE) {
-						@fwrite($pfb_ips, $line);
+		$dnsblip_v4 = "{$pfb['dbdir']}/DNSBLIP_v4.txt";
+		$dnsbl_ip   = glob("{$pfb['dnsdir']}/*_v4.ip") ?: array();
+		list($pfb_dnsblip_rebuild, $pfb_dnsblip_fp) = pfb_dnsblip_rebuild_check($dnsblip_v4, $dnsbl_ip, "{$dnsblip_v4}.fp");
+
+		if ($pfb_dnsblip_rebuild) {
+			if (!empty($dnsbl_ip)) {
+				$pfb_ips = @fopen($dnsblip_v4, 'w');
+				foreach ($dnsbl_ip as $d_ip) {
+					if (($handle = @fopen("{$d_ip}", 'r')) !== FALSE) {
+						while (($line = @fgets($handle)) !== FALSE) {
+							@fwrite($pfb_ips, $line);
+						}
+					}
+					if ($handle) {
+						@fclose($handle);
 					}
 				}
-				if ($handle) {
-					@fclose($handle);
+				if ($pfb_ips) {
+					@fclose($pfb_ips);
 				}
 			}
-			if ($pfb_ips) {
-				@fclose($pfb_ips);
-			}
-		}
 
-		// Add empty placeholder IP
-		else {
-			@file_put_contents("{$pfb['dbdir']}/DNSBLIP_v4.txt", "{$pfb['ip_ph']}\n", LOCK_EX);
+			// Add empty placeholder IP
+			else {
+				@file_put_contents($dnsblip_v4, "{$pfb['ip_ph']}\n", LOCK_EX);
+			}
+			@file_put_contents("{$dnsblip_v4}.fp", $pfb_dnsblip_fp, LOCK_EX);
+			unlink_if_exists($pfb['ip_cache']);
+			touch("{$pfb['denydir']}/DNSBLIP_v4.update");
 		}
-		unlink_if_exists($pfb['ip_cache']);
-		touch("{$pfb['denydir']}/DNSBLIP_v4.update");
 	}
 
 	// Remove DNSBL IP feed, if disabled
 	if ($pfb['dnsbl_ip'] == 'Disabled') {
 		unlink_if_exists("{$pfb['dbdir']}/DNSBLIP_v4.txt");
+		unlink_if_exists("{$pfb['dbdir']}/DNSBLIP_v4.txt.fp");
 		unlink_if_exists("{$pfb['denydir']}/DNSBLIP_v4.*");
 	}
 
-	// Collect all DNSBL IP feeds (IPv6 only) into DNSBLIP_v6.txt
+	// Collect all DNSBL IP feeds (IPv6 only) into DNSBLIP_v6.txt -- gated on the *_v6.ip source
+	// set changing, identical to the v4 path above (issue #653).
 	if ($pfb['dnsbl_ip'] != 'Disabled' && ($pfb['updateip'] || !file_exists("{$pfb['dbdir']}/DNSBLIP_v6.txt"))) {
 
-		$dnsbl_ip = glob("{$pfb['dnsdir']}/*_v6.ip");
-		if (!empty($dnsbl_ip)) {
-			$pfb_ips = @fopen("{$pfb['dbdir']}/DNSBLIP_v6.txt", 'w');
-			foreach ($dnsbl_ip as $d_ip) {
-				if (($handle = @fopen("{$d_ip}", 'r')) !== FALSE) {
-					while (($line = @fgets($handle)) !== FALSE) {
-						@fwrite($pfb_ips, $line);
+		$dnsblip_v6 = "{$pfb['dbdir']}/DNSBLIP_v6.txt";
+		$dnsbl_ip   = glob("{$pfb['dnsdir']}/*_v6.ip") ?: array();
+		list($pfb_dnsblip_rebuild, $pfb_dnsblip_fp) = pfb_dnsblip_rebuild_check($dnsblip_v6, $dnsbl_ip, "{$dnsblip_v6}.fp");
+
+		if ($pfb_dnsblip_rebuild) {
+			if (!empty($dnsbl_ip)) {
+				$pfb_ips = @fopen($dnsblip_v6, 'w');
+				foreach ($dnsbl_ip as $d_ip) {
+					if (($handle = @fopen("{$d_ip}", 'r')) !== FALSE) {
+						while (($line = @fgets($handle)) !== FALSE) {
+							@fwrite($pfb_ips, $line);
+						}
+					}
+					if ($handle) {
+						@fclose($handle);
 					}
 				}
-				if ($handle) {
-					@fclose($handle);
+				if ($pfb_ips) {
+					@fclose($pfb_ips);
 				}
 			}
-			if ($pfb_ips) {
-				@fclose($pfb_ips);
-			}
-		}
 
-		// Add empty placeholder IP
-		else {
-			@file_put_contents("{$pfb['dbdir']}/DNSBLIP_v6.txt", "::{$pfb['ip_ph']}\n", LOCK_EX);
+			// Add empty placeholder IP
+			else {
+				@file_put_contents($dnsblip_v6, "::{$pfb['ip_ph']}\n", LOCK_EX);
+			}
+			@file_put_contents("{$dnsblip_v6}.fp", $pfb_dnsblip_fp, LOCK_EX);
+			unlink_if_exists($pfb['ip_cache']);
+			touch("{$pfb['denydir']}/DNSBLIP_v6.update");
 		}
-		unlink_if_exists($pfb['ip_cache']);
-		touch("{$pfb['denydir']}/DNSBLIP_v6.update");
 	}
 
 	// Remove DNSBL IP feed, if disabled
 	if ($pfb['dnsbl_ip'] == 'Disabled') {
 		unlink_if_exists("{$pfb['dbdir']}/DNSBLIP_v6.txt");
+		unlink_if_exists("{$pfb['dbdir']}/DNSBLIP_v6.txt.fp");
 		unlink_if_exists("{$pfb['denydir']}/DNSBLIP_v6.*");
 	}
 

--- a/tests/php/PfbDnsblipRebuildCheckTest.php
+++ b/tests/php/PfbDnsblipRebuildCheckTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsblip_rebuild_check() — DNSBLIP rebuild gate (issue #653).
+ *
+ * DNSBLIP_<fam> is the union of the *_v<fam>.ip files (IPs extracted from the DNSBL feeds). It was
+ * rebuilt + re-filtered on every IP update; this gate makes it rebuild ONLY when the output is
+ * missing or the .ip source set actually changed. Detection is content-addressed (ADR-42 style),
+ * not mtime-based, since a .ip file may be rewritten with identical content each pass.
+ *
+ * Each case asserts the [rebuild, fingerprint] pair so the rebuild decision AND the stored-state
+ * value are both pinned. The fingerprint reuses pfb_dnsbl_loaded_fingerprint().
+ */
+#[CoversFunction('pfb_dnsblip_rebuild_check')]
+final class PfbDnsblipRebuildCheckTest extends TestCase
+{
+	private string $tmp;
+	private string $out;
+	private string $fp;
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_dnsblip_' . uniqid('', true);
+		mkdir($this->tmp, 0o755, true);
+		$this->out = "{$this->tmp}/DNSBLIP_v4.txt";
+		$this->fp  = "{$this->out}.fp";
+	}
+
+	protected function tearDown(): void
+	{
+		array_map('unlink', glob("{$this->tmp}/*") ?: []);
+		@rmdir($this->tmp);
+	}
+
+	private function ipfile(string $name, string $body): string
+	{
+		$path = "{$this->tmp}/{$name}";
+		file_put_contents($path, $body);
+		return $path;
+	}
+
+	public function testRebuildsWhenOutputMissing(): void
+	{
+		// Given source .ip files but no DNSBLIP output yet
+		$files = [$this->ipfile('a_v4.ip', "1.2.3.4\n")];
+		// When checked (output + fp absent)
+		[$rebuild, $fp] = pfb_dnsblip_rebuild_check($this->out, $files, $this->fp);
+		// Then it must rebuild, and return the current fingerprint
+		$this->assertTrue($rebuild, 'missing output must force a rebuild');
+		$this->assertNotSame('', $fp);
+	}
+
+	public function testRebuildsWhenFingerprintSidecarMissing(): void
+	{
+		$files = [$this->ipfile('a_v4.ip', "1.2.3.4\n")];
+		touch($this->out);                       // output exists, but no stored fingerprint
+		[$rebuild] = pfb_dnsblip_rebuild_check($this->out, $files, $this->fp);
+		$this->assertTrue($rebuild, 'a missing fingerprint sidecar must force a rebuild');
+	}
+
+	public function testSkipsWhenSourceUnchanged(): void
+	{
+		// Given a built output + a stored fingerprint matching the current .ip set
+		$files = [$this->ipfile('a_v4.ip', "1.2.3.4\n"), $this->ipfile('b_v4.ip', "5.6.7.8\n")];
+		touch($this->out);
+		[$rebuild_first, $fp] = pfb_dnsblip_rebuild_check($this->out, $files, $this->fp);
+		$this->assertTrue($rebuild_first, 'first build (no sidecar) rebuilds');
+		file_put_contents($this->fp, $fp);       // caller persists the fingerprint on rebuild
+
+		// When re-checked with the SAME source set
+		[$rebuild_again, $fp_again] = pfb_dnsblip_rebuild_check($this->out, $files, $this->fp);
+
+		// Then it skips the rebuild and the fingerprint is stable
+		$this->assertFalse($rebuild_again, 'an unchanged .ip set must NOT rebuild');
+		$this->assertSame($fp, $fp_again);
+	}
+
+	public function testRebuildsWhenSourceContentChanges(): void
+	{
+		$files = [$this->ipfile('a_v4.ip', "1.2.3.4\n")];
+		touch($this->out);
+		[, $fp] = pfb_dnsblip_rebuild_check($this->out, $files, $this->fp);
+		file_put_contents($this->fp, $fp);
+
+		// When a source feed's IPs change
+		$this->ipfile('a_v4.ip', "1.2.3.4\n9.9.9.9\n");
+		[$rebuild, $fp_new] = pfb_dnsblip_rebuild_check($this->out, $files, $this->fp);
+
+		$this->assertTrue($rebuild, 'a changed .ip set must rebuild');
+		$this->assertNotSame($fp, $fp_new, 'the fingerprint must reflect the new content');
+	}
+
+	public function testIsMtimeAgnostic(): void
+	{
+		// ADR-42 intent: a .ip rewritten with IDENTICAL content (newer mtime) is NOT a change.
+		$path = $this->ipfile('a_v4.ip', "1.2.3.4\n");
+		touch($this->out);
+		[, $fp] = pfb_dnsblip_rebuild_check($this->out, [$path], $this->fp);
+		file_put_contents($this->fp, $fp);
+
+		// Rewrite same bytes, bump mtime well into the future
+		file_put_contents($path, "1.2.3.4\n");
+		touch($path, time() + 3600);
+
+		[$rebuild] = pfb_dnsblip_rebuild_check($this->out, [$path], $this->fp);
+		$this->assertFalse($rebuild, 'identical content with a newer mtime must NOT rebuild');
+	}
+}


### PR DESCRIPTION
DNSBLIP_v4/_v6 (the IPs extracted from DNSBL feeds) were rebuilt and re-filtered on **every** IP update, even when no source DNSBL feed changed — re-running the aggregate + master-dedup needlessly:

```
[ DNSBLIP_v4 ]   Downloading update .. completed ..
  Aggregation Stats:  578 -> 536
  Original Master Final:  578  479  479  [ Pass ]
```

## Fix

Gate the rebuild on a **content fingerprint** (ADR-42 style, reusing `pfb_dnsbl_loaded_fingerprint`) of the `*_v{4,6}.ip` source set: rebuild **iff** the output is missing or the set/content changed. Only on a rebuild do we rewrite `DNSBLIP_<fam>.txt`, persist the fingerprint sidecar, flush the `ip_cache`, and `touch` the `.update` marker — so the IP-feed loop's gate (`!file_exists(".update")`) logs `exists.` (skips the reprocess) when nothing changed. Both families handled symmetrically.

## Covers add / remove / disable / enable

The existing "Remove un-associated List" reconcile already wipes + regenerates `dnsdir` (`rmdir_recursive`) whenever the enabled-feed set changes — `$pfb['existing']['dnsbl']` is built from **enabled** feeds only (`state != 'Disabled'`), so a removed *or disabled* feed is flagged as un-associated and its `.ip` leaves `dnsdir`. The `*_v{4,6}.ip` glob therefore always reflects the current enabled feeds, and the fingerprint changes exactly when DNSBLIP's content would:

| Case | Rebuild? |
|---|---|
| Add enabled feed with IPs | ✅ |
| Remove / disable a feed | ✅ (dnsdir reconcile drops its `.ip`) |
| Enable a previously-disabled feed | ✅ |
| No IP-affecting change | ✅ no rebuild |

## Tests

New pure helper `pfb_dnsblip_rebuild_check()`, unit-tested (`PfbDnsblipRebuildCheckTest`): missing-output / missing-sidecar / unchanged / content-changed / **mtime-agnostic** (identical content + newer mtime must NOT rebuild). Red→green (neutering the gate fails 4 cases). `php -l` / PHPCS / PHPStan / PHPUnit (1633) green. End-to-end "exists vs Downloading update" on a feed-unchanged pass is the ADR-04/ADR-11 maintainer smoke (out-of-CI).

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
