### PR TITLE
pfblockerng: auto-scroll the prefilled log to the bottom (Update + Software pages)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -403,6 +403,12 @@ events.push(function() {
 			pfb_sw_submit('uninstall');
 		}
 	});
+
+	// Show the newest lines: scroll the prefilled output textarea to the bottom on load
+	// (the streamed update/uninstall paths scroll as they write; the plain-GET prefill did not).
+	$('textarea[name="pfb_output"]').each(function() {
+		this.scrollTop = this.scrollHeight;
+	});
 });
 //]]>
 </script>

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -552,6 +552,12 @@ events.push(function(){
 		$row.find('div.col-sm-10').removeClass('col-sm-10').addClass('col-sm-12');
 	});
 
+	// Show the newest lines: scroll the prefilled log textarea to the bottom on load
+	// (the live-tail/Run-Now paths scroll as they stream; the plain-GET prefill did not).
+	$('textarea[name="pfb_output"]').each(function() {
+		this.scrollTop = this.scrollHeight;
+	});
+
 	// Scroll to the bottom of the page after wizard
 	var pfb_wizard = "<?=$pfb_wizard;?>";
 	if (pfb_wizard) {

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -47,7 +47,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from .conftest import mask_page_identity
-from .test_render_smoke import software_panel_forced
+from .test_render_smoke import _seed_vm_file, software_panel_forced
 
 sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
 expect = sync_api.expect
@@ -352,3 +352,43 @@ def test_software_uninstall_confirm_gate(
         _shot(page, screenshot_dir, "software_uninstall_after_confirm")
         # DO NOT click uninstall_btn — clicking it would uninstall the package and
         # break every subsequent test in this smoke run.
+
+
+def test_software_output_prefill_scrolls_to_bottom(
+    smoke_vm: SmokeVM,
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """The prefilled Software output textarea auto-scrolls to the newest lines on load.
+
+    Scenario (log auto-scroll): the streamed update/uninstall paths scroll as they write,
+    but a plain GET prefilled the output and left it at the top — burying the latest lines.
+
+      Given software.log seeded with more lines than the textarea shows at once,
+      When the Software page is opened in the browser (plain-GET prefill),
+      Then pfb_output is scrolled to the bottom (newest lines visible), not left at the top.
+
+    Fail-before / pass-after: before the auto-scroll snippet the prefilled textarea loads at
+    scrollTop 0; after, it lands at the bottom. The Update page uses the byte-identical
+    snippet, guarded at the render tier by its "Show the newest lines:" marker.
+    """
+    page = browser_page
+    # Seed enough distinct lines to overflow the textarea so a scroll is observable.
+    seed = "".join(f"pfb-autoscroll-line-{i:03d}\n" for i in range(1, 81))
+    with software_panel_forced(smoke_vm, "on"):
+        _seed_vm_file(smoke_vm, "/var/log/pfblockerng/software.log", seed)
+        _open(page, webui, SOFTWARE_PAGE)
+
+        metrics = page.locator('textarea[name="pfb_output"]').evaluate(
+            "el => ({ top: el.scrollTop, sh: el.scrollHeight, ch: el.clientHeight })"
+        )
+        assert metrics["sh"] > metrics["ch"], (
+            "pfb_output is not overflowing — cannot assert scroll "
+            f"(scrollHeight={metrics['sh']} clientHeight={metrics['ch']}); seed more lines"
+        )
+        # At the bottom: scrollTop within a few px of (scrollHeight - clientHeight), and
+        # strictly > 0 (proving it scrolled rather than loading at the top — the pre-fix state).
+        bottom = metrics["sh"] - metrics["ch"]
+        assert metrics["top"] > 0 and metrics["top"] >= bottom - 4, (
+            f"prefilled output not scrolled to bottom: expected scrollTop≈{bottom}, got {metrics['top']}"
+        )

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1129,9 +1129,8 @@ def test_software_log_prefills_on_plain_get(
         )
 
         # The prefilled output auto-scrolls to the bottom on load (issue: log auto-scroll).
-        assert "Show the newest lines:" in webui.get(_SOFTWARE_PAGE).text, (
-            "Software page is missing the prefilled-output auto-scroll snippet"
-        )
+        # Reuse the page already fetched for the prefill check above (m.string) — no extra GET.
+        assert "Show the newest lines:" in m.string, "Software page is missing the prefilled-output auto-scroll snippet"
 
 
 _PENDING_MARKER = "/usr/local/etc/pfb_pending_changes"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -135,7 +135,12 @@ PAGE_TABLE: tuple[Page, ...] = (
     Page("log", "/pfblockerng/pfblockerng_log.php", ("Log/File Browser selections",)),
     Page("sync", "/pfblockerng/pfblockerng_sync.php", ("XMLRPC Sync Settings",)),
     Page("safesearch", "/pfblockerng/pfblockerng_safesearch.php", ("SafeSearch settings", "DNSBL SafeSearch")),
-    Page("update", "/pfblockerng/pfblockerng_update.php", ("Update Settings", "Schedule")),
+    Page(
+        "update",
+        "/pfblockerng/pfblockerng_update.php",
+        # "Show the newest lines:" — the prefilled-log auto-scroll snippet (issue: log auto-scroll).
+        ("Update Settings", "Schedule", "Show the newest lines:"),
+    ),
     # blacklist.php is always the DNSBL Category view; the long info line is a stable literal.
     Page(
         "blacklist",
@@ -1121,6 +1126,11 @@ def test_software_log_prefills_on_plain_get(
         assert seed in content, (
             f"Software page pfb_output is not prefilled on plain GET: "
             f"expected seed marker {seed!r} in textarea content, got {content[:200]!r}"
+        )
+
+        # The prefilled output auto-scrolls to the bottom on load (issue: log auto-scroll).
+        assert "Show the newest lines:" in webui.get(_SOFTWARE_PAGE).text, (
+            "Software page is missing the prefilled-output auto-scroll snippet"
         )
 
 


### PR DESCRIPTION
On a plain page load, the Update page and the Software page prefill their log textarea (`pfb_output`) with the last run's tail — but left it scrolled to the **top**, hiding the newest lines. The live-tail / Run-Now / streamed-pkg paths already scroll as they write; only the static prefill didn't.

## Fix

A small on-load scroll-to-bottom in each page's `events.push()` ready handler:

```js
$('textarea[name="pfb_output"]').each(function() {
    this.scrollTop = this.scrollHeight;
});
```

Harmless when empty (no-op) or during a run (the stream scrolls anyway).

## Tests

- **Tier A (render):** the Update page render gate now checks the `"Show the newest lines:"` snippet marker; the Software prefill render test asserts it too.
- **Tier B (browser):** `test_software_output_prefill_scrolls_to_bottom` seeds a long `software.log`, loads the page, and asserts `pfb_output`'s `scrollTop` is at the bottom (`> 0` and within a few px of `scrollHeight - clientHeight`) — red on the pre-snippet top-load, green after. The Update page uses the byte-identical snippet (covered at the render tier).

`php -l` + ruff clean. Dispatching the UI render + browser tiers to validate live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Software and Update pages now keep prefilled log output scrolled to the newest lines when the page loads.
  * This makes it easier to review recent activity without manually scrolling to the bottom.
* **Tests**
  * Added browser and render checks to verify the log output opens at the bottom and continues to show the expected page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->