### PR TITLE
pfblockerng: clarify the Aliastables/Rules update-log section

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12154,6 +12154,48 @@ function pfb_syslog_logging_needs_update($current, $want) {
 }
 
 /**
+ * Diff two filter-rule arrays, restricted to pfBlockerNG-owned rules (pfb_is_managed_obj()
+ * on the rule 'descr'). Returns the descr lists of pfB rules created / modified / removed
+ * between $old_rules and $new_rules, plus a 'reordered' flag = TRUE when no pfB rule was
+ * added, modified, or removed (the caller only diffs when the full arrays already differ, so
+ * an empty pfB diff means the change was a reorder and/or user-rule edit). User rules are
+ * never reported — ADR-41 reorders them but pfB does not own them.
+ *
+ * @param array $old_rules Rules before the change (created-tag stripped).
+ * @param array $new_rules Rules after the change (created-tag stripped).
+ * @return array{created: list<string>, modified: list<string>, removed: list<string>, reordered: bool}
+ */
+function pfb_diff_managed_rules(array $old_rules, array $new_rules): array {
+	// Build descr => rule maps for pfB-owned rules only (last wins on duplicate descr).
+	$old_map = [];
+	foreach ($old_rules as $r) {
+		$descr = (string) ($r['descr'] ?? '');
+		if (pfb_is_managed_obj($descr)) {
+			$old_map[$descr] = $r;
+		}
+	}
+	$new_map = [];
+	foreach ($new_rules as $r) {
+		$descr = (string) ($r['descr'] ?? '');
+		if (pfb_is_managed_obj($descr)) {
+			$new_map[$descr] = $r;
+		}
+	}
+
+	$created  = array_values(array_diff(array_keys($new_map), array_keys($old_map)));
+	$removed  = array_values(array_diff(array_keys($old_map), array_keys($new_map)));
+	$modified = [];
+	foreach (array_intersect(array_keys($old_map), array_keys($new_map)) as $descr) {
+		if ($old_map[$descr] != $new_map[$descr]) {
+			$modified[] = $descr;
+		}
+	}
+
+	$reordered = empty($created) && empty($modified) && empty($removed);
+	return ['created' => $created, 'modified' => $modified, 'removed' => $removed, 'reordered' => $reordered];
+}
+
+/**
  * pfb_build_autorule_list() — pure emission helper extracted from sync_package_pfblockerng().
  *
  * Reconciles the firewall auto-rules by a STABLE bucket reorder: every surviving rule is sorted
@@ -16292,6 +16334,24 @@ function sync_package_pfblockerng($cron='') {
 			$log = localize_text("Firewall rule changes found, applying Filter Reload");
 			logger(LOG_NOTICE, $log, LOG_PREFIX_PKG_PFBLOCKERNG);
 			pfb_logger("{$log}\n", 1);
+
+			$rule_diff = pfb_diff_managed_rules($orig_rules_nocreated ?? [], $new_rules_nocreated ?? []);
+			if ($rule_diff['reordered']) {
+				pfb_logger(" " . localize_text("Rule order changed (no pfB rules added, modified, or removed)") . "\n", 1);
+			} else {
+				foreach ($rule_diff['created'] as $descr) {
+					pfb_logger(" Created: {$descr}\n", 1);
+				}
+				foreach ($rule_diff['modified'] as $descr) {
+					pfb_logger(" Modified: {$descr}\n", 1);
+				}
+				foreach ($rule_diff['removed'] as $descr) {
+					pfb_logger(" Removed: {$descr}\n", 1);
+				}
+			}
+			if (!empty($pfb_alias_lists)) {
+				pfb_logger(localize_text("Alias tables: skipped (Filter Reload rebuilds them from the alias files)") . "\n", 1);
+			}
 		}
 
 		exec("{$pfb['pfctl']} -s Tables | {$pfb['grep']} '^pfB_'", $pfb_tables);
@@ -16358,6 +16418,8 @@ function sync_package_pfblockerng($cron='') {
 			$final_alias = array_unique($pfb_alias_lists);
 
 			if (!empty($final_alias)) {
+				pfb_logger(localize_text("Alias table changes detected, updating:") . "\n", 1);
+
 				// ADR-40 P4: read mode/batch once for the loop (PfbConfig gateway).
 				$pfb_delta_mode  = (string) PfbConfig::read('pfb_alias_delta_mode')->toStored();
 				$pfb_delta_batch = pfb_alias_delta_batch_clamp((string) PfbConfig::read('pfb_alias_delta_batch'));

--- a/tests/php/ManagedRuleDiffTest.php
+++ b/tests/php/ManagedRuleDiffTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_diff_managed_rules() — pure diff helper that classifies pfBlockerNG-owned
+ * filter rules as created / modified / removed between two rule arrays, and sets
+ * 'reordered' = TRUE when no pfB rule changed content (only order or user rules differ).
+ *
+ * Test fail-before/pass-after applies: the function is new, so calling it on the
+ * pre-change code raises a fatal (undefined function) — definitively red. Green after.
+ */
+#[CoversFunction('pfb_diff_managed_rules')]
+final class ManagedRuleDiffTest extends TestCase
+{
+	/** Minimal pfB rule with a given descr and optional extra field. */
+	private static function rule(string $descr, array $extra = []): array
+	{
+		return array_merge(['descr' => $descr, 'type' => 'block', 'interface' => 'wan'], $extra);
+	}
+
+	public function testEmptyInputsReturnsEmptyDiffAndReordered(): void
+	{
+		$result = pfb_diff_managed_rules([], []);
+
+		$this->assertSame([], $result['created'],  'created must be empty for empty inputs');
+		$this->assertSame([], $result['modified'], 'modified must be empty for empty inputs');
+		$this->assertSame([], $result['removed'],  'removed must be empty for empty inputs');
+		$this->assertTrue($result['reordered'],    'reordered must be TRUE when nothing changed');
+	}
+
+	public function testCreatedDetectedWhenPfbRuleAddedToNew(): void
+	{
+		$old = [];
+		$new = [self::rule('pfB_Deny_Inbound_WAN')];
+
+		$result = pfb_diff_managed_rules($old, $new);
+
+		$this->assertContains('pfB_Deny_Inbound_WAN', $result['created'],
+			'a pfB rule present in new but absent in old must appear in created');
+		$this->assertSame([], $result['modified']);
+		$this->assertSame([], $result['removed']);
+		$this->assertFalse($result['reordered']);
+	}
+
+	public function testRemovedDetectedWhenPfbRuleDroppedFromNew(): void
+	{
+		$old = [self::rule('pfB_PRI4_Outbound')];
+		$new = [];
+
+		$result = pfb_diff_managed_rules($old, $new);
+
+		$this->assertContains('pfB_PRI4_Outbound', $result['removed'],
+			'a pfB rule present in old but absent in new must appear in removed');
+		$this->assertSame([], $result['created']);
+		$this->assertSame([], $result['modified']);
+		$this->assertFalse($result['reordered']);
+	}
+
+	public function testModifiedDetectedWhenPfbRuleContentChanges(): void
+	{
+		$old = [self::rule('pfB_DNSBL_Permit', ['interface' => 'lan'])];
+		$new = [self::rule('pfB_DNSBL_Permit', ['interface' => 'opt1'])];
+
+		$result = pfb_diff_managed_rules($old, $new);
+
+		$this->assertContains('pfB_DNSBL_Permit', $result['modified'],
+			'same descr with differing content must appear in modified, not created/removed');
+		$this->assertSame([], $result['created']);
+		$this->assertSame([], $result['removed']);
+		$this->assertFalse($result['reordered']);
+	}
+
+	public function testReorderedTrueWhenPfbRulesSwapOrderOnly(): void
+	{
+		$rule_a = self::rule('pfB_Deny_Inbound_WAN');
+		$rule_b = self::rule('pfB_PRI4_Outbound');
+		$old    = [$rule_a, $rule_b];
+		$new    = [$rule_b, $rule_a];
+
+		$result = pfb_diff_managed_rules($old, $new);
+
+		$this->assertSame([], $result['created'],  'no pfB rule created on a pure reorder');
+		$this->assertSame([], $result['modified'], 'no pfB rule modified on a pure reorder');
+		$this->assertSame([], $result['removed'],  'no pfB rule removed on a pure reorder');
+		$this->assertTrue($result['reordered'],    'reordered must be TRUE when pfB sets are identical');
+	}
+
+	public function testUserRulesNeverAppearInDiff(): void
+	{
+		// Only a non-pfB rule changes — the pfB diff must be empty and reordered TRUE.
+		$old = [self::rule('My LAN rule', ['type' => 'pass'])];
+		$new = [self::rule('My LAN rule', ['type' => 'block'])];
+
+		$result = pfb_diff_managed_rules($old, $new);
+
+		$this->assertSame([], $result['created'],
+			'a changed user rule must not appear in created');
+		$this->assertSame([], $result['modified'],
+			'a changed user rule must not appear in modified');
+		$this->assertSame([], $result['removed'],
+			'a changed user rule must not appear in removed');
+		$this->assertTrue($result['reordered'],
+			'reordered TRUE when only user rules differ (pfB set is unchanged)');
+	}
+
+	public function testUserRuleAddedOnlyYieldsReorderedTrue(): void
+	{
+		// Adding a user rule: pfB diff empty, reordered TRUE.
+		$old = [self::rule('pfB_Deny_Inbound_WAN')];
+		$new = [self::rule('pfB_Deny_Inbound_WAN'), self::rule('User block rule')];
+
+		$result = pfb_diff_managed_rules($old, $new);
+
+		$this->assertSame([], $result['created']);
+		$this->assertSame([], $result['modified']);
+		$this->assertSame([], $result['removed']);
+		$this->assertTrue($result['reordered'],
+			'adding only a user rule leaves the pfB set unchanged → reordered TRUE');
+	}
+}

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -296,12 +296,16 @@ def test_adr40_content_gate_fires_on_change(adr40_vm: SmokeVM) -> None:
         f"after content change: pf table {ip_spec.alias} still contains old IP {old_ip}: {members_after}"
     )
 
-    # The content change ran the no-rule-change reload path, which logs a per-alias
-    # " Updating: <alias>" line. Those lines must render CONTIGUOUSLY (one per line), not
-    # blank-separated — a leading "\n" in the log format put a blank line above every entry.
-    # Inspect only THIS reload's slice of the log (order-independent — the session VM's log
-    # accumulates across tests), guarding the exact regression: no entry preceded by a blank line.
+    # The content change ran the no-rule-change reload path, which logs:
+    #   "Alias table changes detected, updating:\n"
+    # immediately followed by per-alias " Updating: <alias>" lines, all CONTIGUOUS (one per
+    # line, no blank lines between them). The sub-header is the anchor; without it the block
+    # reads as a contradiction after "No changes to Firewall rules".
     reload_log = adr40_vm.ssh("cat", h.PFB_LOG).stdout[log_len_before:]
+    assert "Alias table changes detected, updating:" in reload_log, (
+        "expected 'Alias table changes detected, updating:' sub-header in the reload log "
+        f"after a content change (no-rule-change path):\n{reload_log[-1500:]}"
+    )
     assert " Updating:" in reload_log, (
         f"expected a per-alias ' Updating:' line in the reload log after a content change:\n{reload_log[-1500:]}"
     )


### PR DESCRIPTION
## Problem

The update log's `Aliastables / Rules` section reads as a contradiction. On a normal feed update where no firewall **rules** change but some alias **memberships** do, it prints:

```
No changes to Firewall rules, skipping Filter Reload
 Updating: pfB_PRI4_v4
 Updating: pfB_Deny_Aggregated_v4
```

"No changes" immediately followed by "Updating" is confusing: the first line is about the **pf ruleset** (skipping `filter_configure()`), the `Updating:` lines are about **alias-table contents** (ADR-40 membership delta). Two different layers, no text making that clear. The rule-change path was also opaque — it announced a Filter Reload without saying which rules changed, and updated the alias tables silently.

## Change (logging only — no control-flow change)

- **No-rule-change path:** add a sub-header before the per-alias lines:
  ```
  No changes to Firewall rules, skipping Filter Reload
  Alias table changes detected, updating:
   Updating: pfB_PRI4_v4
  ```
- **Rule-change path:** enumerate the pfB-owned rules that changed, and state that the alias tables are handled by the reload:
  ```
  Firewall rule changes found, applying Filter Reload
   Created: pfB_Deny_Inbound_WAN
   Removed: pfB_PRI4_Outbound
  Alias tables: skipped (Filter Reload rebuilds them from the alias files)
  ```
  When only rule order changed (ADR-41 bucket reorder, no pfB rule added/modified/removed):
  ```
   Rule order changed (no pfB rules added, modified, or removed)
  ```

The per-rule diff is restricted to pfBlockerNG-owned rules via the existing `pfb_is_managed_obj()` classifier — user rules that ADR-41 merely reorders are never reported as pfB changes.

## Tests

- `tests/php/ManagedRuleDiffTest.php` — 7 cases for the new pure helper `pfb_diff_managed_rules()` (created / modified / removed / pure-reorder / user-rule-only / user-rule-alongside-pfB / empty).
- `tests/smoke/test_smoke_adr40.py` — the existing contiguity check now also asserts the `Alias table changes detected, updating:` sub-header precedes the `Updating:` block (fails without this change).

php -l, phpcs, phpstan, phpunit all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved reload logging to clearly show when rule order changes, when rules are created/updated/removed, and when alias table updates begin.
* **Bug Fixes**
  * Better distinguishes managed firewall rule changes from user-only edits, reducing noisy or misleading logs.
* **Tests**
  * Added coverage for rule-diff behavior across empty, added, removed, modified, reordered, and user-edit scenarios.
  * Updated smoke checks to match the new alias update log message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->