### PR TITLE
pfblockerng: fix DNS-Redirect/DoT exception-alias handling + interface quick-fill

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -456,6 +456,10 @@ function pfb_validate_dns_redirect_post(
 		if (!is_validaliasname($posted_alias)) {
 			$errors[] = 'DNS Redirect: Invalid exception alias name: ' .
 				htmlspecialchars($posted_alias, ENT_QUOTES);
+		} elseif (!is_alias($posted_alias)) {
+			$errors[] = 'DNS Redirect: Exception alias does not exist: ' .
+				htmlspecialchars($posted_alias, ENT_QUOTES) .
+				' (create it under Firewall > Aliases first)';
 		}
 	}
 	return $errors;
@@ -495,6 +499,10 @@ function pfb_validate_dot_block_post(
 		if (!is_validaliasname($posted_alias)) {
 			$errors[] = 'DoT/DoQ Block: Invalid exception alias name: ' .
 				htmlspecialchars($posted_alias, ENT_QUOTES);
+		} elseif (!is_alias($posted_alias)) {
+			$errors[] = 'DoT/DoQ Block: Exception alias does not exist: ' .
+				htmlspecialchars($posted_alias, ENT_QUOTES) .
+				' (create it under Firewall > Aliases first)';
 		}
 	}
 	if (!in_array($posted_action, ['block', 'reject'], TRUE)) {
@@ -502,6 +510,26 @@ function pfb_validate_dot_block_post(
 			htmlspecialchars($posted_action, ENT_QUOTES);
 	}
 	return $errors;
+}
+
+// Build the NAT/filter SOURCE array for a DNS-redirect / DoT-block exception alias.
+// An empty alias yields source 'any' (no exception). A non-empty alias becomes a negated
+// source (listed hosts bypass) ONLY when it resolves to a real firewall alias; an
+// unknown/stale name (e.g. a typo, or an alias deleted after it was referenced) falls back
+// to 'any' and is logged. This guard is the single point that prevents a non-resolving alias
+// from emitting a sourceless "from ! ..." rule — pf rejects that as a syntax error, which
+// fails the WHOLE ruleset load, not just this one rule. Shared by pfb_dot_block_rule(),
+// pfb_dot_block_floating_rule() and the DNS-redirect NAT builder in sync_package_pfblockerng().
+function pfb_redirect_exclude_source(string $alias): array {
+	if ($alias === '') {
+		return ['any' => ''];
+	}
+	if (!is_alias($alias)) {
+		pfb_logger("\nDNS redirect/DoT block: exception alias [ " .
+			substr(htmlspecialchars($alias), 0, 100) . " ] not found — ignoring (no exception applied)", 2);
+		return ['any' => ''];
+	}
+	return ['address' => $alias, 'not' => ''];
 }
 
 // Build a single DoT/DoQ block filter/rule array for $iface. $action is the rule
@@ -513,9 +541,7 @@ function pfb_validate_dot_block_post(
 // build, preserving the stored key order so the sync change-detection compare stays
 // stable when nothing changed.
 function pfb_dot_block_rule(string $iface, string $exclude_alias, string $action): array {
-	$source = ($exclude_alias !== '')
-		? ['address' => $exclude_alias, 'not' => '']
-		: ['any' => ''];
+	$source = pfb_redirect_exclude_source($exclude_alias);
 
 	return [
 		'type'        => pfb_dot_block_action($action),
@@ -537,9 +563,7 @@ function pfb_dot_block_rule(string $iface, string $exclude_alias, string $action
 // negated-(self):853 destination + optional exception-alias source as the per-interface
 // rule. The caller appends the 'tracker' (last key) after build.
 function pfb_dot_block_floating_rule(array $ifaces, string $exclude_alias, string $action): array {
-	$source = ($exclude_alias !== '')
-		? ['address' => $exclude_alias, 'not' => '']
-		: ['any' => ''];
+	$source = pfb_redirect_exclude_source($exclude_alias);
 
 	return [
 		'type'        => pfb_dot_block_action($action),
@@ -14771,9 +14795,7 @@ function sync_package_pfblockerng($cron='') {
 						$redir_sfx    = ($redir_family === 'inet') ? PFB_DNS_REDIR_DESCR_V4_SFX : PFB_DNS_REDIR_DESCR_V6_SFX;
 						$redir_target = ($redir_family === 'inet') ? '127.0.0.1' : '::1';
 						$redir_descr  = PFB_DNS_REDIR_DESCR_V4_PFX . $redir_iface . $redir_sfx;
-						$redir_source = ($redir_exception !== '')
-							? ['address' => $redir_exception, 'not' => '']
-							: ['any' => ''];
+						$redir_source = pfb_redirect_exclude_source($redir_exception);
 						$redir_new_owned[] = [
 							'source'             => $redir_source,
 							'destination'        => ['network' => '(self)', 'not' => '', 'port' => '53'],

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2847,6 +2847,18 @@ $pfb_redir_fill_ifaces = array_unique(array_filter(array_merge(
 $pfb_redir_fill_ifaces = array_values(array_intersect($pfb_redir_fill_ifaces, array_keys($options_dnsbl_redir_int)));
 $pfb_redir_fill_json   = json_encode($pfb_redir_fill_ifaces);
 
+// [ ADR-36/37 ] Address-type firewall alias names for the Exception Alias autocomplete on the
+// DNS Redirect + DoT/DoQ Block fields. Restrict to host/network/urltable (address) aliases —
+// a port alias cannot be a rule source. The field still accepts free text; existence is
+// enforced server-side (pfb_validate_dns_redirect_post / pfb_validate_dot_block_post).
+$pfb_alias_names = array();
+foreach (config_get_path('aliases/alias', []) as $pfb_alias_entry) {
+	if (in_array($pfb_alias_entry['type'] ?? '', array('host', 'network', 'urltable'), TRUE)) {
+		$pfb_alias_names[] = (string)($pfb_alias_entry['name'] ?? '');
+	}
+}
+$pfb_alias_names_json = json_encode(array_values(array_filter(array_unique($pfb_alias_names), 'strlen')));
+
 $group->add(new Form_Select(
 	'dnsbl_redir_int',
 	NULL,
@@ -3514,16 +3526,27 @@ var networksarray = nlist.split(',');
 // Disable GeoIP/ASN Autocomplete as not required for the DNSBL page
 var geoiparray = 'disabled';
 
+// [ ADR-36/37 ] Address-type firewall alias names for the Exception Alias autocomplete.
+var pfb_alias_names = <?=$pfb_alias_names_json?>;
+
+// Wire jQuery-UI autocomplete onto the DNS Redirect + DoT/DoQ Block exception fields so a
+// valid alias name can be picked rather than typed (a typo there used to save and then emit
+// an unresolvable "from !" rule that broke the whole ruleset). minLength 0 + the focus search
+// shows the full alias list on focus.
+function pfb_redir_exclude_autocomplete() {
+	$('#dnsbl_redir_exclude, #dnsbl_dot_block_exclude')
+		.autocomplete({ minLength: 0, source: pfb_alias_names })
+		.on('focus', function() { $(this).autocomplete('search', $(this).val()); });
+}
+
 // [ ADR-36 ] DNS Redirect quick-fill: union of pfBlockerNG Inbound + Outbound interfaces.
 // When clicked, selects those interfaces in the #dnsbl_redir_int multi-select.
 var pfb_redir_fill_ifaces = <?=$pfb_redir_fill_json?>;
 
 function pfb_redir_fill_interfaces() {
-	var $sel = $('#dnsbl_redir_int');
-	$sel.find('option').prop('selected', false);
-	$.each(pfb_redir_fill_ifaces, function(i, val) {
-		$sel.find('option[value="' + val + '"]').prop('selected', true);
-	});
+	// Set the multi-select to exactly the fill set (deselects the rest). .val([...]) is the
+	// reliable jQuery idiom for a <select multiple>; trigger('change') notifies any listeners.
+	$('#dnsbl_redir_int').val(pfb_redir_fill_ifaces).trigger('change');
 }
 
 // [ ADR-37 ] DoT/DoQ Block quick-fill: union of pfBlockerNG Inbound + Outbound interfaces.
@@ -3531,11 +3554,9 @@ function pfb_redir_fill_interfaces() {
 var pfb_dot_block_fill_ifaces = <?=$pfb_dot_block_fill_json?>;
 
 function pfb_dot_block_fill_interfaces() {
-	var $sel = $('#dnsbl_dot_block_int');
-	$sel.find('option').prop('selected', false);
-	$.each(pfb_dot_block_fill_ifaces, function(i, val) {
-		$sel.find('option[value="' + val + '"]').prop('selected', true);
-	});
+	// Set the multi-select to exactly the fill set (deselects the rest). .val([...]) is the
+	// reliable jQuery idiom for a <select multiple>; trigger('change') notifies any listeners.
+	$('#dnsbl_dot_block_int').val(pfb_dot_block_fill_ifaces).trigger('change');
 }
 
 // [ ADR-13 ] Address(es) the package would auto-create for the selected interface, so
@@ -3699,6 +3720,8 @@ events.push(function(){
 		enable_dnsvip_auto();
 	});
 	enable_dnsvip_auto();
+
+	pfb_redir_exclude_autocomplete();
 });
 
 //]]>

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3540,23 +3540,27 @@ function pfb_redir_exclude_autocomplete() {
 }
 
 // [ ADR-36 ] DNS Redirect quick-fill: union of pfBlockerNG Inbound + Outbound interfaces.
-// When clicked, selects those interfaces in the #dnsbl_redir_int multi-select.
+// When clicked, selects those interfaces in the dnsbl_redir_int multi-select.
 var pfb_redir_fill_ifaces = <?=$pfb_redir_fill_json?>;
 
 function pfb_redir_fill_interfaces() {
 	// Set the multi-select to exactly the fill set (deselects the rest). .val([...]) is the
 	// reliable jQuery idiom for a <select multiple>; trigger('change') notifies any listeners.
-	$('#dnsbl_redir_int').val(pfb_redir_fill_ifaces).trigger('change');
+	// NOTE: a pfSense multi-select renders id (and name) as "<field>[]", so the bracket-free
+	// id selector "#dnsbl_redir_int" matches nothing — target it by name instead (this is why
+	// the button previously appeared to do nothing).
+	$('select[name="dnsbl_redir_int[]"]').val(pfb_redir_fill_ifaces).trigger('change');
 }
 
 // [ ADR-37 ] DoT/DoQ Block quick-fill: union of pfBlockerNG Inbound + Outbound interfaces.
-// When clicked, selects those interfaces in the #dnsbl_dot_block_int multi-select.
+// When clicked, selects those interfaces in the dnsbl_dot_block_int multi-select.
 var pfb_dot_block_fill_ifaces = <?=$pfb_dot_block_fill_json?>;
 
 function pfb_dot_block_fill_interfaces() {
 	// Set the multi-select to exactly the fill set (deselects the rest). .val([...]) is the
 	// reliable jQuery idiom for a <select multiple>; trigger('change') notifies any listeners.
-	$('#dnsbl_dot_block_int').val(pfb_dot_block_fill_ifaces).trigger('change');
+	// Same bracketed-id caveat as the DNS Redirect fill above — select by name, not "#id".
+	$('select[name="dnsbl_dot_block_int[]"]').val(pfb_dot_block_fill_ifaces).trigger('change');
 }
 
 // [ ADR-13 ] Address(es) the package would auto-create for the selected interface, so

--- a/tests/php/DnsRedirectValidatorTest.php
+++ b/tests/php/DnsRedirectValidatorTest.php
@@ -38,6 +38,18 @@ final class DnsRedirectValidatorTest extends TestCase
 	/** @var array<string> */
 	private array $validIfaceList = ['lan', 'opt1', 'opt2', 'wireguard', 'openvpn'];
 
+	// Reset the is_alias() existence oracle before each test (test isolation): the
+	// validator now requires a non-empty exception alias to be a REAL firewall alias.
+	protected function setUp(): void
+	{
+		$GLOBALS['pfb_test_aliases'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb_test_aliases'] = [];
+	}
+
 	// -----------------------------------------------------------------------
 	// Helper: assert no PfbConfig::write() calls happened via the write tracker.
 	// pfblockerng.inc loads PfbConfig; write calls land in pfb_test_write_config_calls.
@@ -76,13 +88,36 @@ final class DnsRedirectValidatorTest extends TestCase
 		$this->assertSame([], $errorsBefore, 'empty alias must be accepted');
 	}
 
-	public function testValidAliasNameIsAccepted(): void
+	public function testValidExistingAliasNameIsAccepted(): void
 	{
-		// Given a valid alias name (alphanumeric + underscore, no leading digit)
+		// Given a valid alias name that EXISTS as a firewall alias
+		$GLOBALS['pfb_test_aliases'] = ['DNS_Whitelist'];
 		$errors = pfb_validate_dns_redirect_post(['opt1'], $this->validIfaceList, 'DNS_Whitelist');
 
 		// Then no errors are returned
-		$this->assertSame([], $errors, 'a valid alias name must be accepted');
+		$this->assertSame([], $errors, 'a valid, existing alias name must be accepted');
+	}
+
+	public function testValidFormatButNonexistentAliasIsRejected(): void
+	{
+		// Regression (the real-world bite): a name that is syntactically valid but is NOT a
+		// real alias used to pass format-only validation, then the rule builder emitted an
+		// unresolvable "from !" that fails the entire pf ruleset load. It must now be rejected.
+
+		// Given: before → the same name accepted WHEN it exists (proves it's the existence
+		// check, not the format check, doing the rejecting)
+		$GLOBALS['pfb_test_aliases'] = ['BraitServers_IPv4'];
+		$errorsExisting = pfb_validate_dns_redirect_post(['lan'], $this->validIfaceList, 'BraitServers_IPv4');
+		$this->assertSame([], $errorsExisting, 'pre-condition: the alias is accepted while it exists');
+
+		// When the alias does NOT exist (e.g. a typo: _v4 instead of _IPv4)
+		$GLOBALS['pfb_test_aliases'] = ['BraitServers_IPv4'];
+		$errors = pfb_validate_dns_redirect_post(['lan'], $this->validIfaceList, 'BraitServers_v4');
+
+		// Then it is rejected with a "does not exist" error
+		$this->assertNotEmpty($errors, 'a non-existent exception alias must be rejected');
+		$this->assertStringContainsString('DNS Redirect', $errors[0]);
+		$this->assertStringContainsString('does not exist', $errors[0]);
 	}
 
 	public function testMultipleValidInterfacesAreAccepted(): void
@@ -135,7 +170,8 @@ final class DnsRedirectValidatorTest extends TestCase
 
 	public function testAliasNameWithShellSpecialCharIsRejected(): void
 	{
-		// Given: before → valid alias accepted
+		// Given: before → valid, existing alias accepted
+		$GLOBALS['pfb_test_aliases'] = ['Good_Alias'];
 		$errorsBefore = pfb_validate_dns_redirect_post(['lan'], $this->validIfaceList, 'Good_Alias');
 		$this->assertSame([], $errorsBefore, 'pre-condition: Good_Alias is accepted');
 

--- a/tests/php/DotBlockRuleBuilderTest.php
+++ b/tests/php/DotBlockRuleBuilderTest.php
@@ -26,6 +26,18 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_dot_block_floating_rule')]
 final class DotBlockRuleBuilderTest extends TestCase
 {
+	// Reset the is_alias() existence oracle before each test (test isolation): the source
+	// builder now only negates an exception alias that actually resolves to a firewall alias.
+	protected function setUp(): void
+	{
+		$GLOBALS['pfb_test_aliases'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb_test_aliases'] = [];
+	}
+
 	// -----------------------------------------------------------------------
 	// pfb_dot_block_action() — normalisation
 	// -----------------------------------------------------------------------
@@ -117,13 +129,35 @@ final class DotBlockRuleBuilderTest extends TestCase
 
 	public function testSourceIsNegatedAliasWhenExcludeAliasGiven(): void
 	{
-		// Given an exception alias, the source negates that alias so listed hosts bypass
+		// Given an exception alias that EXISTS, the source negates it so listed hosts bypass
+		$GLOBALS['pfb_test_aliases'] = ['DoT_Exceptions'];
 		$rule = pfb_dot_block_rule('lan', 'DoT_Exceptions', 'reject');
 		$this->assertSame(
 			['address' => 'DoT_Exceptions', 'not' => ''],
 			$rule['source'],
-			'alias present -> negated alias source'
+			'existing alias present -> negated alias source'
 		);
+	}
+
+	public function testSourceFallsBackToAnyWhenExcludeAliasNotFound(): void
+	{
+		// Regression: a non-empty exception alias that does NOT resolve to a real firewall
+		// alias must NOT be emitted as the source — an unresolvable address renders as a
+		// sourceless "from !" that fails the entire pf ruleset load. The guard falls back to
+		// 'any' (no exception applied) instead.
+		// Before -> the SAME name yields a negated-alias source while it exists (proves the
+		// existence check, not some always-any path, is what changes the result).
+		$GLOBALS['pfb_test_aliases'] = ['DoT_Exceptions'];
+		$ruleExisting = pfb_dot_block_rule('lan', 'DoT_Exceptions', 'reject');
+		$this->assertSame(['address' => 'DoT_Exceptions', 'not' => ''], $ruleExisting['source'],
+			'pre-condition: existing alias -> negated alias source');
+
+		// When the alias is not a real firewall alias
+		$GLOBALS['pfb_test_aliases'] = ['DoT_Exceptions'];
+		$rule = pfb_dot_block_rule('lan', 'DoT_Typo', 'reject');
+
+		// Then the source is 'any' (the exception is dropped, the ruleset stays valid)
+		$this->assertSame(['any' => ''], $rule['source'], 'unknown alias -> source any (no "from !")');
 	}
 
 	// -----------------------------------------------------------------------
@@ -187,13 +221,18 @@ final class DotBlockRuleBuilderTest extends TestCase
 		$this->assertSame('tcp/udp', $rule['protocol'], 'floating protocol = tcp/udp');
 		$this->assertSame(['any' => ''], $rule['source'], 'no alias -> source any');
 
-		// Exception alias negates the source, same as the per-interface rule.
+		// An existing exception alias negates the source, same as the per-interface rule.
+		$GLOBALS['pfb_test_aliases'] = ['DoT_Exceptions'];
 		$withAlias = pfb_dot_block_floating_rule(['lan'], 'DoT_Exceptions', 'reject');
 		$this->assertSame(
 			['address' => 'DoT_Exceptions', 'not' => ''],
 			$withAlias['source'],
-			'alias present -> negated alias source'
+			'existing alias present -> negated alias source'
 		);
+
+		// A non-existent alias falls back to 'any' (never a sourceless "from !").
+		$rule = pfb_dot_block_floating_rule(['lan'], 'DoT_Missing', 'reject');
+		$this->assertSame(['any' => ''], $rule['source'], 'unknown alias -> source any');
 	}
 
 	public function testFloatingBuilderOmitsTrackerAndEndsOnDescr(): void

--- a/tests/php/DotDoQBlockUiValidatorTest.php
+++ b/tests/php/DotDoQBlockUiValidatorTest.php
@@ -41,6 +41,18 @@ final class DotDoQBlockUiValidatorTest extends TestCase
 	/** @var array<string> */
 	private array $validIfaceList = ['lan', 'opt1', 'opt2', 'wireguard', 'openvpn'];
 
+	// Reset the is_alias() existence oracle before each test (test isolation): a non-empty
+	// exception alias must now be a REAL firewall alias to be accepted.
+	protected function setUp(): void
+	{
+		$GLOBALS['pfb_test_aliases'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb_test_aliases'] = [];
+	}
+
 	// -----------------------------------------------------------------------
 	// VALID CASES
 	// -----------------------------------------------------------------------
@@ -72,13 +84,33 @@ final class DotDoQBlockUiValidatorTest extends TestCase
 		$this->assertSame([], $errors, 'empty alias must be accepted');
 	}
 
-	public function testValidAliasNameIsAccepted(): void
+	public function testValidExistingAliasNameIsAccepted(): void
 	{
-		// Given a valid alias name (alphanumeric + underscore, no leading digit)
+		// Given a valid alias name that EXISTS as a firewall alias
+		$GLOBALS['pfb_test_aliases'] = ['DoT_Exceptions'];
 		$errors = pfb_validate_dot_block_post(['opt1'], $this->validIfaceList, 'DoT_Exceptions');
 
 		// Then no errors are returned
-		$this->assertSame([], $errors, 'a valid alias name must be accepted');
+		$this->assertSame([], $errors, 'a valid, existing alias name must be accepted');
+	}
+
+	public function testValidFormatButNonexistentAliasIsRejected(): void
+	{
+		// Regression: a syntactically-valid but non-existent alias used to pass and then emit
+		// an unresolvable "from !" rule. It must now be rejected.
+		// Before -> accepted while it exists (isolates the existence check from the format check)
+		$GLOBALS['pfb_test_aliases'] = ['DoT_Exceptions'];
+		$errorsExisting = pfb_validate_dot_block_post(['lan'], $this->validIfaceList, 'DoT_Exceptions');
+		$this->assertSame([], $errorsExisting, 'pre-condition: accepted while the alias exists');
+
+		// When the alias does not exist
+		$GLOBALS['pfb_test_aliases'] = ['DoT_Exceptions'];
+		$errors = pfb_validate_dot_block_post(['lan'], $this->validIfaceList, 'DoT_Missing');
+
+		// Then it is rejected with a "does not exist" error
+		$this->assertNotEmpty($errors, 'a non-existent exception alias must be rejected');
+		$this->assertStringContainsString('DoT/DoQ Block', $errors[0]);
+		$this->assertStringContainsString('does not exist', $errors[0]);
 	}
 
 	public function testMultipleValidInterfacesAreAccepted(): void
@@ -131,7 +163,8 @@ final class DotDoQBlockUiValidatorTest extends TestCase
 
 	public function testAliasNameWithShellSpecialCharIsRejected(): void
 	{
-		// Given: before → valid alias accepted
+		// Given: before → valid, existing alias accepted
+		$GLOBALS['pfb_test_aliases'] = ['Good_Alias'];
 		$errorsBefore = pfb_validate_dot_block_post(['lan'], $this->validIfaceList, 'Good_Alias');
 		$this->assertSame([], $errorsBefore, 'pre-condition: Good_Alias is accepted');
 

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -731,6 +731,14 @@ if (!function_exists('is_validaliasname')) {
 	}
 }
 
+if (!function_exists('is_alias')) {
+	// pfSense util.inc: TRUE if a firewall alias with this name exists. Off-appliance,
+	// resolve against the seeded $GLOBALS['pfb_test_aliases'] name list (empty by default).
+	function is_alias($name) {
+		return in_array((string) $name, $GLOBALS['pfb_test_aliases'] ?? [], TRUE);
+	}
+}
+
 if (!function_exists('get_configured_interface_with_descr')) {
 	// pfSense interfaces.inc: returns a map of interface_name => friendly description.
 	// Off-appliance, use pfb_test_interfaces if seeded; otherwise return an empty map.

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -57,6 +57,7 @@ absent.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -463,3 +464,173 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
         # Belt-and-suspenders: restore to the original checkbox value on any mid-flip abort.
         if helpers.config_get(smoke_vm, _CFG_LENIENT) != original_box:
             webui.post(DNSBL_PAGE, {"pfb_dnsbl_lenient": original_box}, timeout=_DNSBL_POST_TIMEOUT)
+
+
+# --------------------------------------------------------------------------- #
+# PR #660 (ADR-36/37): DNS-Redirect interface quick-fill + Exception-Alias
+# autocomplete. Both are browser-only behaviours an HTTP POST cannot reach, so
+# they live in the Tier-B browser tier per the CLAUDE.md test mandate.
+# --------------------------------------------------------------------------- #
+
+# IP-settings interface keys feeding the DNS Redirect quick-fill union (inbound ∪
+# outbound). 'lan' is the canonical non-WAN interface on the smoke VM and is in
+# pfb_build_if_list(FALSE, FALSE) (the redirect option list), so it survives the
+# array_intersect that builds pfb_redir_fill_ifaces.
+_CFG_INBOUND = "installedpackages/pfblockerngipsettings/config/0/inbound_interface"
+_CFG_OUTBOUND = "installedpackages/pfblockerngipsettings/config/0/outbound_interface"
+_FILL_IFACE = "lan"
+
+# A host (address-type) alias name for the Exception-Alias autocomplete source. Only
+# host/network/urltable aliases land in pfb_alias_names, so a 'host' alias must appear.
+_AC_ALIAS = "PfbPr660ExcAlias"
+
+
+def _php_ok(smoke_vm: helpers.SmokeVM, snippet: str, *, timeout: float = 120.0) -> None:
+    """Run a config-mutating PHP snippet (must ``echo 'OK'``) and assert it succeeded."""
+    result = helpers.php_eval(smoke_vm, snippet, timeout=timeout)
+    assert result.returncode == 0 and "OK" in result.stdout, (
+        f"php_eval failed: rc={result.returncode}\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+
+
+def test_redir_fill_populates_interface_select(
+    browser_page: Page,
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    screenshot_dir: Path,
+) -> None:
+    """`#pfb_redir_fill` ("Fill from IP Interfaces") sets `#dnsbl_redir_int` to the
+    Inbound∪Outbound interface union — the reported "clicking Fill did nothing" bug.
+
+    ``pfb_redir_fill_interfaces()`` (pfblockerng_dnsbl.php) was rewritten from a broken
+    per-option ``.prop('selected', …)`` loop to the canonical
+    ``$('#dnsbl_redir_int').val(pfb_redir_fill_ifaces).trigger('change')``. This drives
+    the click against the LIVE page with the before-state asserted (CLAUDE.md): seed the
+    IP-settings interfaces so the fill union is non-empty, open the page, force the
+    multi-select EMPTY (deterministic BEFORE), click Fill, assert the select now holds
+    exactly the fill set (AFTER). Restores the original interface config in teardown.
+
+    NOTE (from the PR handoff): the exact ``.prop()`` failure could not be reproduced by
+    inspection — the JS source is non-empty and the function is defined — so this is the
+    canonical forward regression guard for the ``.val()`` form rather than a reproduction
+    of an env-specific failure.
+    """
+    page = browser_page
+
+    original_in = helpers.config_get(smoke_vm, _CFG_INBOUND)
+    original_out = helpers.config_get(smoke_vm, _CFG_OUTBOUND)
+
+    try:
+        # GIVEN the IP-settings inbound/outbound interfaces both include the LAN, so the
+        # DNS-Redirect quick-fill union (read at page render) is the non-empty set {lan}.
+        _php_ok(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(_CFG_INBOUND)}, {helpers._php_str(_FILL_IFACE)});\n"
+            f"config_set_path({helpers._php_str(_CFG_OUTBOUND)}, {helpers._php_str(_FILL_IFACE)});\n"
+            "write_config('pfBlockerNG smoke: PR660 fill setup');\n"
+            "echo 'OK';",
+        )
+
+        _open(page, webui, DNSBL_PAGE)
+        sel = page.locator("#dnsbl_redir_int")
+        expect(sel).to_be_attached(timeout=JS_TIMEOUT_MS)
+
+        # The page-computed fill set (intersection of the union with the option list).
+        fill_set = page.evaluate("pfb_redir_fill_ifaces")
+        assert fill_set, (
+            f"pfb_redir_fill_ifaces is empty — {_FILL_IFACE!r} is not in the DNS-Redirect "
+            f"option list on this VM, so the fill click has nothing to select"
+        )
+        assert _FILL_IFACE in fill_set, f"expected {_FILL_IFACE!r} in the fill set, got {fill_set!r}"
+
+        # BEFORE: force the multi-select empty so a non-empty AFTER proves the click acted.
+        sel.evaluate("el => { for (const o of el.options) o.selected = false; }")
+        selected_before = sel.evaluate("el => Array.from(el.selectedOptions).map(o => o.value)")
+        assert selected_before == [], f"pre-condition: select should be empty, got {selected_before!r}"
+        _shot(page, screenshot_dir, "redir_fill_before_empty")
+
+        # CLICK Fill -> the select is set to exactly the fill union.
+        page.locator("#pfb_redir_fill").click()
+        selected_after = sel.evaluate("el => Array.from(el.selectedOptions).map(o => o.value)")
+        assert sorted(selected_after) == sorted(fill_set), (
+            f"Fill from IP Interfaces did not populate the select: expected {sorted(fill_set)!r}, "
+            f"got {sorted(selected_after)!r}"
+        )
+        _shot(page, screenshot_dir, "redir_fill_after_populated")
+
+    finally:
+        _php_ok(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(_CFG_INBOUND)}, {helpers._php_str(original_in)});\n"
+            f"config_set_path({helpers._php_str(_CFG_OUTBOUND)}, {helpers._php_str(original_out)});\n"
+            "write_config('pfBlockerNG smoke: PR660 fill restore');\n"
+            "echo 'OK';",
+        )
+
+
+def test_redir_exception_field_has_alias_autocomplete(
+    browser_page: Page,
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    screenshot_dir: Path,
+) -> None:
+    """`#dnsbl_redir_exclude` gets jQuery-UI autocomplete sourced from the firewall's
+    address-type alias names — the guidance that was missing (bug 2), whose absence let a
+    typo'd alias save and then break the whole pf ruleset.
+
+    ``pfb_redir_exclude_autocomplete()`` (pfblockerng_dnsbl.php, called from the page's
+    ``events`` ready handler) wires ``.autocomplete({minLength:0, source: pfb_alias_names})``
+    onto the Exception-Alias field. Seed a host alias so the source is non-empty, open the
+    page, then assert (a) the widget initialised — jQuery UI stamps the input with the
+    ``ui-autocomplete-input`` class + ``aria-autocomplete`` attr on init — and (b) typing the
+    alias prefix surfaces it in the ``.ui-autocomplete`` suggestion menu. Removes the seeded
+    alias in teardown.
+    """
+    page = browser_page
+
+    try:
+        # GIVEN a host (address-type) firewall alias exists, so it is in pfb_alias_names.
+        _php_ok(
+            smoke_vm,
+            "$aliases = config_get_path('aliases/alias', array());\n"
+            "$aliases[] = array("
+            f"'name' => {helpers._php_str(_AC_ALIAS)}, 'type' => 'host', "
+            "'address' => '192.0.2.10', 'detail' => 'PR660 smoke', "
+            "'descr' => 'pfBlockerNG PR660 autocomplete smoke');\n"
+            "config_set_path('aliases/alias', $aliases);\n"
+            "write_config('pfBlockerNG smoke: PR660 autocomplete alias');\n"
+            "echo 'OK';",
+        )
+
+        _open(page, webui, DNSBL_PAGE)
+
+        # The alias name must have reached the page's JS source array.
+        alias_names = page.evaluate("pfb_alias_names")
+        assert _AC_ALIAS in alias_names, f"seeded alias {_AC_ALIAS!r} not in pfb_alias_names: {alias_names!r}"
+
+        field = page.locator("#dnsbl_redir_exclude")
+        expect(field).to_be_attached(timeout=JS_TIMEOUT_MS)
+
+        # (a) Widget initialised: jQuery UI adds this class + ARIA attr on .autocomplete().
+        expect(field).to_have_class(re.compile(r"\bui-autocomplete-input\b"), timeout=JS_TIMEOUT_MS)
+        expect(field).to_have_attribute("aria-autocomplete", "list", timeout=JS_TIMEOUT_MS)
+
+        # (b) Behaviour: typing the prefix surfaces the seeded alias in the suggestion menu.
+        field.click()
+        field.press_sequentially(_AC_ALIAS[:6], delay=20)
+        menu = page.locator("ul.ui-autocomplete")
+        expect(menu).to_be_visible(timeout=JS_TIMEOUT_MS)
+        expect(menu.locator("li", has_text=_AC_ALIAS)).to_have_count(1, timeout=JS_TIMEOUT_MS)
+        _shot(page, screenshot_dir, "redir_exclude_autocomplete_menu")
+
+    finally:
+        _php_ok(
+            smoke_vm,
+            "$aliases = config_get_path('aliases/alias', array());\n"
+            "$aliases = array_values(array_filter($aliases, function($a) {\n"
+            f"  return ($a['name'] ?? '') !== {helpers._php_str(_AC_ALIAS)};\n"
+            "}));\n"
+            "config_set_path('aliases/alias', $aliases);\n"
+            "write_config('pfBlockerNG smoke: PR660 autocomplete cleanup');\n"
+            "echo 'OK';",
+        )

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -73,7 +73,7 @@ sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not ins
 expect = sync_api.expect
 
 if TYPE_CHECKING:
-    from playwright.sync_api import Page
+    from playwright.sync_api import Locator, Page
 
     from .webui import WebUI
 
@@ -467,15 +467,17 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
 
 
 # --------------------------------------------------------------------------- #
-# PR #660 (ADR-36/37): DNS-Redirect interface quick-fill + Exception-Alias
-# autocomplete. Both are browser-only behaviours an HTTP POST cannot reach, so
-# they live in the Tier-B browser tier per the CLAUDE.md test mandate.
+# PR #660 (ADR-36/37): DNS-Redirect + DoT/DoQ-Block interface quick-fill and
+# Exception-Alias autocomplete. Both are browser-only behaviours an HTTP POST
+# cannot reach, so they live in the Tier-B browser tier per the CLAUDE.md mandate.
+# Each behaviour is mirrored on the two sections, so every test exercises BOTH the
+# DNS-Redirect and the DoT/DoQ-Block widget (branch coverage).
 # --------------------------------------------------------------------------- #
 
-# IP-settings interface keys feeding the DNS Redirect quick-fill union (inbound ∪
-# outbound). 'lan' is the canonical non-WAN interface on the smoke VM and is in
-# pfb_build_if_list(FALSE, FALSE) (the redirect option list), so it survives the
-# array_intersect that builds pfb_redir_fill_ifaces.
+# IP-settings interface keys feeding the quick-fill union (inbound ∪ outbound) for
+# BOTH the DNS-Redirect and DoT/DoQ-Block sections. 'lan' is the canonical non-WAN
+# interface on the smoke VM and is in pfb_build_if_list(FALSE, FALSE) (the option
+# list), so it survives the array_intersect that builds the fill sets.
 _CFG_INBOUND = "installedpackages/pfblockerngipsettings/config/0/inbound_interface"
 _CFG_OUTBOUND = "installedpackages/pfblockerngipsettings/config/0/outbound_interface"
 _FILL_IFACE = "lan"
@@ -493,27 +495,104 @@ def _php_ok(smoke_vm: helpers.SmokeVM, snippet: str, *, timeout: float = 120.0) 
     )
 
 
-def test_redir_fill_populates_interface_select(
+def _selected_values(sel: Locator) -> list[str]:
+    """Return the selected <option> values of a <select> locator."""
+    return sel.evaluate("el => Array.from(el.selectedOptions).map(o => o.value)")
+
+
+def _assert_fill_button_populates(
+    page: Page,
+    *,
+    button_id: str,
+    fill_var: str,
+    select_name: str,
+    screenshot_dir: Path,
+    shot_prefix: str,
+) -> None:
+    """Click a "Fill from IP Interfaces" button and assert it sets its multi-select.
+
+    The multi-select is located **by name** (``select[name="<field>[]"]``), NOT by a
+    bracket-free ``#id``: a pfSense ``Form_Select`` with multiple=TRUE renders id AND
+    name as ``<field>[]``, so ``$('#dnsbl_redir_int')`` matches nothing — which is the
+    actual reason the Fill button "did nothing" before this fix. Drives the full
+    transition with the before-state asserted (CLAUDE.md): force the select EMPTY
+    (deterministic BEFORE), click Fill, assert it now holds exactly the page-computed
+    fill set (AFTER), so green proves the click — not pre-existing state — populated it.
+    """
+    sel = page.locator(f'select[name="{select_name}"]')
+    expect(sel).to_be_attached(timeout=JS_TIMEOUT_MS)
+
+    # The page-computed fill set (intersection of the inbound∪outbound union with the
+    # option list). Non-empty because the fixture seeded inbound/outbound = lan.
+    fill_set = page.evaluate(fill_var)
+    assert fill_set, (
+        f"{fill_var} is empty — {_FILL_IFACE!r} is not in the option list on this VM, "
+        f"so the fill click has nothing to select"
+    )
+    assert _FILL_IFACE in fill_set, f"expected {_FILL_IFACE!r} in {fill_var}, got {fill_set!r}"
+
+    # BEFORE: force the multi-select empty so a non-empty AFTER proves the click acted.
+    sel.evaluate("el => { for (const o of el.options) o.selected = false; }")
+    before = _selected_values(sel)
+    assert before == [], f"pre-condition: {select_name} should be empty, got {before!r}"
+    _shot(page, screenshot_dir, f"{shot_prefix}_before_empty")
+
+    # CLICK Fill -> the select is set to exactly the fill union.
+    page.locator(f"#{button_id}").click()
+    after = _selected_values(sel)
+    assert sorted(after) == sorted(fill_set), (
+        f"Fill button #{button_id} did not populate {select_name}: expected {sorted(fill_set)!r}, got {sorted(after)!r}"
+    )
+    _shot(page, screenshot_dir, f"{shot_prefix}_after_populated")
+
+
+def _assert_exclude_autocomplete(
+    page: Page,
+    *,
+    field_id: str,
+    screenshot_dir: Path,
+    shot_prefix: str,
+) -> None:
+    """Assert an Exception-Alias field has jQuery-UI autocomplete over the seeded alias.
+
+    (a) Widget initialised: jQuery UI stamps the input with the ``ui-autocomplete-input``
+    class on ``.autocomplete()`` (the ``aria-autocomplete`` attr is NOT set by the bundled
+    jQuery-UI build, so the class is the reliable init marker). (b) Behaviour: typing the
+    alias prefix surfaces the seeded alias in the (visible) ``.ui-autocomplete`` menu —
+    there is one menu element per initialised field, so it is scoped to the visible one.
+    """
+    field = page.locator(f"#{field_id}")
+    expect(field).to_be_attached(timeout=JS_TIMEOUT_MS)
+    expect(field).to_have_class(re.compile(r"\bui-autocomplete-input\b"), timeout=JS_TIMEOUT_MS)
+
+    field.click()
+    field.press_sequentially(_AC_ALIAS[:6], delay=20)
+    menu = page.locator("ul.ui-autocomplete:visible")
+    expect(menu).to_be_visible(timeout=JS_TIMEOUT_MS)
+    expect(menu.locator("li", has_text=_AC_ALIAS)).to_have_count(1, timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, f"{shot_prefix}_menu")
+
+    # Dismiss the menu so it doesn't overlap the next field's search.
+    field.press("Escape")
+
+
+def test_fill_buttons_populate_interface_selects(
     browser_page: Page,
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
     screenshot_dir: Path,
 ) -> None:
-    """`#pfb_redir_fill` ("Fill from IP Interfaces") sets `#dnsbl_redir_int` to the
-    Inbound∪Outbound interface union — the reported "clicking Fill did nothing" bug.
+    """ "Fill from IP Interfaces" populates BOTH the DNS-Redirect and DoT/DoQ-Block
+    interface multi-selects from the Inbound∪Outbound union — the reported "clicking
+    Fill did nothing" bug, on both mirrored sections.
 
-    ``pfb_redir_fill_interfaces()`` (pfblockerng_dnsbl.php) was rewritten from a broken
-    per-option ``.prop('selected', …)`` loop to the canonical
-    ``$('#dnsbl_redir_int').val(pfb_redir_fill_ifaces).trigger('change')``. This drives
-    the click against the LIVE page with the before-state asserted (CLAUDE.md): seed the
-    IP-settings interfaces so the fill union is non-empty, open the page, force the
-    multi-select EMPTY (deterministic BEFORE), click Fill, assert the select now holds
-    exactly the fill set (AFTER). Restores the original interface config in teardown.
-
-    NOTE (from the PR handoff): the exact ``.prop()`` failure could not be reproduced by
-    inspection — the JS source is non-empty and the function is defined — so this is the
-    canonical forward regression guard for the ``.val()`` form rather than a reproduction
-    of an env-specific failure.
+    ``pfb_redir_fill_interfaces()`` / ``pfb_dot_block_fill_interfaces()``
+    (pfblockerng_dnsbl.php) set the multi-select via ``.val(fill_set).trigger('change')``,
+    targeting it **by name** (``select[name="…[]"]``) because a pfSense multi-select's id
+    carries the ``[]`` suffix — the bracket-free ``#id`` the code used before matched
+    nothing, which is why the button did nothing. Seeds inbound/outbound = lan so both
+    fill unions are the non-empty set {lan}; restores the original interface config in
+    teardown.
     """
     page = browser_page
 
@@ -521,8 +600,8 @@ def test_redir_fill_populates_interface_select(
     original_out = helpers.config_get(smoke_vm, _CFG_OUTBOUND)
 
     try:
-        # GIVEN the IP-settings inbound/outbound interfaces both include the LAN, so the
-        # DNS-Redirect quick-fill union (read at page render) is the non-empty set {lan}.
+        # GIVEN the IP-settings inbound/outbound interfaces both include the LAN, so each
+        # section's quick-fill union (read at page render) is the non-empty set {lan}.
         _php_ok(
             smoke_vm,
             f"config_set_path({helpers._php_str(_CFG_INBOUND)}, {helpers._php_str(_FILL_IFACE)});\n"
@@ -532,31 +611,25 @@ def test_redir_fill_populates_interface_select(
         )
 
         _open(page, webui, DNSBL_PAGE)
-        sel = page.locator("#dnsbl_redir_int")
-        expect(sel).to_be_attached(timeout=JS_TIMEOUT_MS)
 
-        # The page-computed fill set (intersection of the union with the option list).
-        fill_set = page.evaluate("pfb_redir_fill_ifaces")
-        assert fill_set, (
-            f"pfb_redir_fill_ifaces is empty — {_FILL_IFACE!r} is not in the DNS-Redirect "
-            f"option list on this VM, so the fill click has nothing to select"
+        # DNS Redirect fill.
+        _assert_fill_button_populates(
+            page,
+            button_id="pfb_redir_fill",
+            fill_var="pfb_redir_fill_ifaces",
+            select_name="dnsbl_redir_int[]",
+            screenshot_dir=screenshot_dir,
+            shot_prefix="redir_fill",
         )
-        assert _FILL_IFACE in fill_set, f"expected {_FILL_IFACE!r} in the fill set, got {fill_set!r}"
-
-        # BEFORE: force the multi-select empty so a non-empty AFTER proves the click acted.
-        sel.evaluate("el => { for (const o of el.options) o.selected = false; }")
-        selected_before = sel.evaluate("el => Array.from(el.selectedOptions).map(o => o.value)")
-        assert selected_before == [], f"pre-condition: select should be empty, got {selected_before!r}"
-        _shot(page, screenshot_dir, "redir_fill_before_empty")
-
-        # CLICK Fill -> the select is set to exactly the fill union.
-        page.locator("#pfb_redir_fill").click()
-        selected_after = sel.evaluate("el => Array.from(el.selectedOptions).map(o => o.value)")
-        assert sorted(selected_after) == sorted(fill_set), (
-            f"Fill from IP Interfaces did not populate the select: expected {sorted(fill_set)!r}, "
-            f"got {sorted(selected_after)!r}"
+        # DoT/DoQ Block fill (the mirrored section — same bug, same fix).
+        _assert_fill_button_populates(
+            page,
+            button_id="pfb_dot_block_fill",
+            fill_var="pfb_dot_block_fill_ifaces",
+            select_name="dnsbl_dot_block_int[]",
+            screenshot_dir=screenshot_dir,
+            shot_prefix="dot_block_fill",
         )
-        _shot(page, screenshot_dir, "redir_fill_after_populated")
 
     finally:
         _php_ok(
@@ -568,23 +641,21 @@ def test_redir_fill_populates_interface_select(
         )
 
 
-def test_redir_exception_field_has_alias_autocomplete(
+def test_exception_fields_have_alias_autocomplete(
     browser_page: Page,
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
     screenshot_dir: Path,
 ) -> None:
-    """`#dnsbl_redir_exclude` gets jQuery-UI autocomplete sourced from the firewall's
-    address-type alias names — the guidance that was missing (bug 2), whose absence let a
-    typo'd alias save and then break the whole pf ruleset.
+    """BOTH Exception-Alias fields (``#dnsbl_redir_exclude`` + ``#dnsbl_dot_block_exclude``)
+    get jQuery-UI autocomplete sourced from the firewall's address-type alias names — the
+    guidance that was missing (bug 2), whose absence let a typo'd alias save and then break
+    the whole pf ruleset.
 
-    ``pfb_redir_exclude_autocomplete()`` (pfblockerng_dnsbl.php, called from the page's
-    ``events`` ready handler) wires ``.autocomplete({minLength:0, source: pfb_alias_names})``
-    onto the Exception-Alias field. Seed a host alias so the source is non-empty, open the
-    page, then assert (a) the widget initialised — jQuery UI stamps the input with the
-    ``ui-autocomplete-input`` class + ``aria-autocomplete`` attr on init — and (b) typing the
-    alias prefix surfaces it in the ``.ui-autocomplete`` suggestion menu. Removes the seeded
-    alias in teardown.
+    ``pfb_redir_exclude_autocomplete()`` wires ``.autocomplete({minLength:0,
+    source: pfb_alias_names})`` onto both fields. Seed one host alias so the source is
+    non-empty, open the page, and assert each field initialised the widget and surfaces
+    the alias in its suggestion menu. Removes the seeded alias in teardown.
     """
     page = browser_page
 
@@ -608,20 +679,19 @@ def test_redir_exception_field_has_alias_autocomplete(
         alias_names = page.evaluate("pfb_alias_names")
         assert _AC_ALIAS in alias_names, f"seeded alias {_AC_ALIAS!r} not in pfb_alias_names: {alias_names!r}"
 
-        field = page.locator("#dnsbl_redir_exclude")
-        expect(field).to_be_attached(timeout=JS_TIMEOUT_MS)
-
-        # (a) Widget initialised: jQuery UI adds this class + ARIA attr on .autocomplete().
-        expect(field).to_have_class(re.compile(r"\bui-autocomplete-input\b"), timeout=JS_TIMEOUT_MS)
-        expect(field).to_have_attribute("aria-autocomplete", "list", timeout=JS_TIMEOUT_MS)
-
-        # (b) Behaviour: typing the prefix surfaces the seeded alias in the suggestion menu.
-        field.click()
-        field.press_sequentially(_AC_ALIAS[:6], delay=20)
-        menu = page.locator("ul.ui-autocomplete")
-        expect(menu).to_be_visible(timeout=JS_TIMEOUT_MS)
-        expect(menu.locator("li", has_text=_AC_ALIAS)).to_have_count(1, timeout=JS_TIMEOUT_MS)
-        _shot(page, screenshot_dir, "redir_exclude_autocomplete_menu")
+        # DNS Redirect exception field, then the mirrored DoT/DoQ Block exception field.
+        _assert_exclude_autocomplete(
+            page,
+            field_id="dnsbl_redir_exclude",
+            screenshot_dir=screenshot_dir,
+            shot_prefix="redir_exclude_autocomplete",
+        )
+        _assert_exclude_autocomplete(
+            page,
+            field_id="dnsbl_dot_block_exclude",
+            screenshot_dir=screenshot_dir,
+            shot_prefix="dot_block_exclude_autocomplete",
+        )
 
     finally:
         _php_ok(

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -600,8 +600,12 @@ def test_dnsbl_redir_exception_and_fill_fields_render(webui: WebUI, php_error_lo
         'name="dnsbl_dot_block_exclude"',
         "pfb_redir_exclude_autocomplete",
         "pfb_alias_names",
-        # (3) The fill rewrite — the canonical .val([...]) form (not the old .prop() loop).
+        # (3) The fill rewrite — the canonical .val([...]) form (not the old .prop() loop),
+        # AND the bracketed-name selectors: a pfSense multi-select renders id/name as
+        # "<field>[]", so the fill must target it by name, not the broken bracket-free "#id".
         ".val(pfb_redir_fill_ifaces)",
+        'select[name="dnsbl_redir_int[]"]',
+        'select[name="dnsbl_dot_block_int[]"]',
     ):
         assert needle in body, f"DNSBL page is missing the redirect/fill marker {needle!r}"
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -577,6 +577,35 @@ def test_dnsbl_lenient_parsing_field_renders(webui: WebUI, php_error_log_guard: 
         assert needle in body, f"DNSBL page is missing the lenient-parsing marker {needle!r}"
 
 
+def test_dnsbl_redir_exception_and_fill_fields_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The ADR-36/37 DNS-Redirect & DoT/DoQ-Block exception-alias autocomplete + the
+    interface quick-fill rewrite render cleanly on the DNSBL page — so a regression that
+    drops the autocomplete wiring or reverts the fill helper is caught at the render tier
+    (the browser-only behaviours themselves are exercised by the Tier-B browser tests).
+
+    Asserts the page passes the clean-render oracle AND that the markers for all three
+    PR-660 fixes are present: the two exception-alias input field names, the autocomplete
+    bootstrap function + its alias-name source array, and the ``.val(...)`` fill rewrite
+    (the form that replaced the broken per-option ``.prop('selected')`` loop).
+    ``php_error_log_guard`` enrolls this GET in the module-level no-growth sweep.
+    """
+    path = "/pfblockerng/pfblockerng_dnsbl.php"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
+    assert result.ok, f"DNSBL render oracle failed: {result.detail}"
+    body = resp.text
+    for needle in (
+        # (2) Exception Alias fields + their autocomplete wiring.
+        'name="dnsbl_redir_exclude"',
+        'name="dnsbl_dot_block_exclude"',
+        "pfb_redir_exclude_autocomplete",
+        "pfb_alias_names",
+        # (3) The fill rewrite — the canonical .val([...]) form (not the old .prop() loop).
+        ".val(pfb_redir_fill_ifaces)",
+    ):
+        assert needle in body, f"DNSBL page is missing the redirect/fill marker {needle!r}"
+
+
 def test_feeds_custom_panel_heading_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """The second Feeds panel — the one listing user-configured feeds that don't match the
     predefined catalog — is headed "Custom Feeds", not the former "Unknown user defined Feeds".


### PR DESCRIPTION
Fixes three related DNS Redirect / DoT-Block UI bugs (ADR-36/37), reported and live-confirmed by the maintainer on a production box.

## The bugs

1. **Unresolvable exception alias breaks the whole pf ruleset.** The exception-alias rule source was built as `['address' => $alias, 'not' => '']` for any *syntactically valid* name. A name that is not a real firewall alias (a typo) renders as a sourceless `rdr pass ... from ! to !(self) port 53 -> 127.0.0.1` — pfctl rejects `from !` as a syntax error, which fails the **entire** ruleset load. Live root cause: `dnsbl_redir_exclude = "BraitServers_v4"` while the real alias is `"BraitServers_IPv4"`.
2. **No autocomplete on the Exception Alias field** — nothing guided the user to the right alias name, which is what produced the typo in (1).
3. **"Fill from IP Interfaces" did nothing** — clicking it left the interface multi-select unchanged.

## The fixes

- **Root cause for (1):** new shared helper `pfb_redirect_exclude_source()` in `pfblockerng.inc` — empty alias → source `any`; a real alias (`is_alias()`) → negated source; an unknown/stale name → source `any` (logged), **never** `from !`. Wired into the DNS-redirect NAT builder (`sync_package_pfblockerng`), `pfb_dot_block_rule()`, and `pfb_dot_block_floating_rule()`.
- **Save-time guard:** `pfb_validate_dns_redirect_post()` + `pfb_validate_dot_block_post()` now reject a non-empty exception alias that does not **exist** (`is_alias`), not just bad *format* — so the typo is caught at save with a clear error.
- **(2) Autocomplete:** `pfblockerng_dnsbl.php` builds `$pfb_alias_names_json` (host/network/urltable alias names) and wires jQuery-UI autocomplete on `#dnsbl_redir_exclude` + `#dnsbl_dot_block_exclude`.
- **(3) Fill:** `pfb_redir_fill_interfaces()` / `pfb_dot_block_fill_interfaces()` rewritten from per-option `.prop('selected')` to the canonical `$('#id').val([...]).trigger('change')`.

## Tests

- **PHP (red→green verified):** `DnsRedirectValidatorTest`, `DotDoQBlockUiValidatorTest`, `DotBlockRuleBuilderTest` extended — they seed `$GLOBALS['pfb_test_aliases']` (new `is_alias` double in `pfsense_doubles.php`) and assert a non-existent alias is rejected (validators) and falls back to source `any` (builders). The new guard tests fail on the pre-fix `.inc`, pass after.
- **Tier-A render (`tests/smoke/ui/test_render_smoke.py`):** asserts `pfblockerng_dnsbl.php` renders the two exception-alias field names, the autocomplete bootstrap + alias-name source array, and the `.val(...)` interface-fill rewrite.
- **Tier-B browser (`tests/smoke/ui/test_browser_dnsbl.py`):** "Fill from IP Interfaces" populates the redirect interface multi-select (before-empty → after = the inbound∪outbound union); the Exception Alias field gets jQuery-UI autocomplete sourced from the address-type alias names (widget init + suggestion menu from a seeded host alias). Config seeded and torn down via `php_eval` for test isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added autocomplete for exception-alias fields to make DNS Redirect and DoT/DoQ block setup faster and easier.
  * Improved the “Fill from IP Interfaces” action so it selects the expected interfaces more reliably.

* **Bug Fixes**
  * Exception aliases must now refer to real, existing aliases before they’re accepted.
  * If an exception alias can’t be found, rule creation now safely falls back to a valid default instead of generating invalid rules.

* **Tests**
  * Expanded automated coverage for alias validation, autocomplete, and interface fill behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->