### PR TITLE
docs: add release notes for v4.0.0.alpha.12

### DIFF
--- a/docs/release-notes/v4.0.0.alpha.12.md
+++ b/docs/release-notes/v4.0.0.alpha.12.md
@@ -1,0 +1,16 @@
+<!-- SUMMARY: DNS Redirect fixes -->
+## Features
+
+- The **Exception Alias** fields on DNS Redirect and DoT/DoQ Block now offer autocomplete from your existing address-type firewall aliases, so a valid alias can be picked rather than typed.
+
+## Improvements
+
+- When **CIDR Aggregation** is enabled, building the IPv4 aggregated ("Uber") alias skips a redundant address-union pass.
+- DNS Redirect and DoT/DoQ Block now reject a saved **Exception Alias that does not exist** as a firewall alias, with a clear error, instead of accepting a name that only looks valid.
+
+## Bug Fixes
+
+- An Exception Alias that is not a real firewall alias (for example, a typo) no longer produces an invalid firewall rule that fails the **entire ruleset load**; an unknown alias is now ignored safely.
+- **"Fill from IP Interfaces"** on the DNS Redirect and DoT/DoQ Block settings now populates the interface selection when clicked, instead of doing nothing.
+
+**Full changelog:** [`v4.0.0.alpha.11` → `v4.0.0.alpha.12`](https://github.com/pfBlockerNG/pfBlockerNG/compare/v4.0.0.alpha.11...v4.0.0.alpha.12)


### PR DESCRIPTION
Adds the hand-authored release notes for `v4.0.0.alpha.12` so the release workflow uses this file as the GitHub Release body (skipping the GitHub Models step).

Notes cover the user-facing `src/` changes since `v4.0.0.alpha.11`: the DNS Redirect / DoT-DoQ Block exception-alias autocomplete, the exception-alias existence validation and safe rule fallback, the "Fill from IP Interfaces" fix, and the CIDR-aggregation address-union skip.

Documentation-only — CI is skipped via `paths-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_