### PR TITLE
pfblockerng: stop package upgrades freezing the live log (#662)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2103,15 +2103,21 @@ function pfb_filter_service() {
 	if [ -e '/var/log/filter.log' ]; then
 		/usr/bin/logger -p daemon.info -t "\${filter_type}" "INFO [{$LOG_PREFIX_PKG_PFBLOCKERNG}] Firewall Filter Service started"
 
+		# Detach the daemon's std fds (#662): a backgrounded daemon that inherits the
+		# caller's pipe -- e.g. the package-manager capture pipe when start_service() runs
+		# during a package install/upgrade -- holds it open for its whole life, so pkg's
+		# streamed output never reaches EOF and the upgrade page's live log freezes. Group
+		# the pipeline and redirect its outer fds to /dev/null (stdin too); the internal
+		# tail->php_pfb pipe is unaffected, so only the inherited descriptor is released.
 		if [ "\${filter_type}" == 'clog_pfb' ]; then
 			# clog_pfb is the pre-2.5 circular-log reader (below min CE 2.8); it reads
 			# only the filter.log clog. The DNSBL feature-log tail is tail_pfb-only.
-			/usr/local/sbin/clog_pfb -f /var/log/filter.log | /usr/local/bin/php_pfb -f /usr/local/pkg/pfblockerng/pfblockerng.inc filterlog &
+			{ /usr/local/sbin/clog_pfb -f /var/log/filter.log | /usr/local/bin/php_pfb -f /usr/local/pkg/pfblockerng/pfblockerng.inc filterlog ; } >/dev/null 2>&1 </dev/null &
 		else
 			# ADR-38 Amendment 1: one daemon also tails the DNSBL feature logs so it
 			# can write unified.log + emit DNSBL syslog host-side. -q suppresses tail's
 			# per-file "==> name <==" headers; -F retries files that don't exist yet.
-			/usr/bin/tail_pfb -q -n0 -F /var/log/filter.log /var/log/pfblockerng/dnsbl.log /var/log/pfblockerng/dns_reply.log | /usr/local/bin/php_pfb -f /usr/local/pkg/pfblockerng/pfblockerng.inc filterlog &
+			{ /usr/bin/tail_pfb -q -n0 -F /var/log/filter.log /var/log/pfblockerng/dnsbl.log /var/log/pfblockerng/dns_reply.log | /usr/local/bin/php_pfb -f /usr/local/pkg/pfblockerng/pfblockerng.inc filterlog ; } >/dev/null 2>&1 </dev/null &
 		fi
 	fi
 
@@ -2159,7 +2165,11 @@ function pfb_dnsbl_service() {
 	# Start DNSBL Lighttpd webserver (Python mode)
 	if [ -e '/var/unbound/pfb_dnsbl_lighty.conf' ]; then
 		/usr/bin/logger -p daemon.info -t lighttpd_pfb "INFO [{$LOG_PREFIX_PKG_PFBLOCKERNG}] DNSBL Webserver started"
-		/usr/local/sbin/lighttpd_pfb -f /var/unbound/pfb_dnsbl_lighty.conf
+		# Detach std fds (#662): lighttpd self-daemonizes, and its forked child would
+		# otherwise inherit the caller's pipe (the package-manager capture pipe during a
+		# package install/upgrade) and hold it open, freezing the upgrade page's live log.
+		# Redirect so the daemon never holds an inherited descriptor.
+		/usr/local/sbin/lighttpd_pfb -f /var/unbound/pfb_dnsbl_lighty.conf >/dev/null 2>&1 </dev/null
 	fi
 
 	# Warn if the DNSBL python script is missing

--- a/tests/php/FilterDaemonRedirectTest.php
+++ b/tests/php/FilterDaemonRedirectTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #662 — the rc.d service daemons must detach their standard file descriptors.
+ *
+ * Functions under test:
+ *   pfb_filter_service() — generates /usr/local/etc/rc.d/pfb_filter.sh (the firewall
+ *                          filter-log daemon: tail_pfb|php_pfb, or clog_pfb|php_pfb).
+ *   pfb_dnsbl_service()  — generates /usr/local/etc/rc.d/pfb_dnsbl.sh (the DNSBL
+ *                          lighttpd_pfb webserver).
+ *
+ * Intent: these daemons are (re)started via start_service() during a package
+ * install/upgrade, which runs under the Package-Manager output capture pipe. A daemon
+ * launched without detaching its std fds inherits that pipe and holds it open for its
+ * whole life, so pkg's streamed output never reaches EOF and the upgrade page's live log
+ * freezes (and shows incomplete after a reload). Each daemon launch must therefore
+ * redirect its std fds away from the inherited descriptor.
+ *
+ * The test captures the generated rc 'start' body via the write_rcfile() double
+ * (pfsense_doubles.php records each $rc into $GLOBALS['pfb_test_rcfiles']) and asserts
+ * the redirect is present. Fail-before/pass-after: on the pre-fix code the daemons were
+ * backgrounded as a bare `... filterlog &` / a bare `lighttpd_pfb -f ...`, so the redirect
+ * assertions fail; after the fix they pass.
+ */
+#[CoversFunction('pfb_filter_service')]
+#[CoversFunction('pfb_dnsbl_service')]
+final class FilterDaemonRedirectTest extends TestCase
+{
+	private function startBody(string $rcfile, callable $generator): string
+	{
+		$GLOBALS['pfb_test_rcfiles'] = [];
+		$generator();
+		$this->assertArrayHasKey($rcfile, $GLOBALS['pfb_test_rcfiles'], "write_rcfile() never produced {$rcfile}");
+		return (string) ($GLOBALS['pfb_test_rcfiles'][$rcfile]['start'] ?? '');
+	}
+
+	public function testFilterDaemonDetachesStdFds(): void
+	{
+		// When the firewall-filter rc.d script is generated
+		$start = $this->startBody('pfb_filter.sh', 'pfb_filter_service');
+
+		// Then the backgrounded filter-log daemon is NOT a bare `... filterlog &` (which
+		// would inherit the caller's pipe), but a grouped pipeline whose outer std fds are
+		// redirected to /dev/null so the inherited descriptor is released (#662).
+		$this->assertStringNotContainsString(
+			"filterlog &\n",
+			$start,
+			'the filter-log daemon is still backgrounded with a bare "& " that inherits the caller pipe (#662)'
+		);
+		$this->assertStringContainsString(
+			'filterlog ; } >/dev/null 2>&1 </dev/null &',
+			$start,
+			'the filter-log daemon launch must detach its std fds (group + >/dev/null 2>&1 </dev/null) (#662)'
+		);
+	}
+
+	public function testDnsblWebserverDetachesStdFds(): void
+	{
+		// When the DNSBL rc.d script is generated
+		$start = $this->startBody('pfb_dnsbl.sh', 'pfb_dnsbl_service');
+
+		// Then the lighttpd_pfb webserver launch redirects its std fds, so its self-forked
+		// daemon child does not inherit and hold the caller's pipe (#662).
+		$this->assertMatchesRegularExpression(
+			'#lighttpd_pfb -f \S+ >/dev/null 2>&1 </dev/null#',
+			$start,
+			'the DNSBL lighttpd_pfb launch must detach its std fds (#662)'
+		);
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -124,9 +124,13 @@ if (!function_exists('system_get_uniqueid')) {
 }
 
 if (!function_exists('write_rcfile')) {
-	// pfb_filter_service()/pfb_dnsbl_service() call this at load time. No-op:
-	// we never assert rc.d generation in unit tests.
+	// pfb_filter_service()/pfb_dnsbl_service() call this at load time. Capture the rc
+	// array (keyed by its 'file') so a test can assert the generated start/stop bodies
+	// (e.g. the #662 daemon-fd-detach); behaviourally still a no-op on disk.
 	function write_rcfile($rc) {
+		if (isset($rc['file'])) {
+			$GLOBALS['pfb_test_rcfiles'][$rc['file']] = $rc;
+		}
 		return true;
 	}
 }


### PR DESCRIPTION
Fixes #662.

## Problem

During a pfBlockerNG package upgrade, the Package-Manager live log freezes partway and reads incomplete even after a reload. The upgrade itself succeeds; only the streamed log display hangs.

## Root cause

The page renders `pkg`'s output as a streamed response that ends only at pipe EOF. pfBlockerNG re-launches its long-lived daemons from the rc.d start scripts during (re)install via `start_service()` — and they were backgrounded **without detaching their standard file descriptors**:

- `pfblockerng.inc:2114` — `tail_pfb … | php_pfb … filterlog &` (and the `clog_pfb` variant)
- `pfblockerng.inc:2162` — `lighttpd_pfb -f …` (DNSBL webserver, self-daemonizing)

Launched that way, the daemon inherits the package-manager capture pipe and holds it open for its whole life, so `pkg`'s output never reaches EOF and the live log freezes. The project already handles this exact pipe-inheritance hazard for the ADR-12 update hooks (`pfblockerng.inc:3513`); the rc.d service daemons just hadn't been given the same treatment.

## Fix

Detach the daemon launches from the inherited descriptor:

- Group the filter-log pipeline and redirect its outer std fds — `{ … filterlog ; } >/dev/null 2>&1 </dev/null &`. The internal `tail`→`php_pfb` pipe is unaffected; only the inherited descriptor is released.
- Redirect the `lighttpd_pfb` launch the same way.

## Tests

`tests/php/FilterDaemonRedirectTest.php` captures the generated rc `start` bodies (via the `write_rcfile()` double, now recording `$rc`) and asserts each daemon launch detaches its std fds. Verified red→green: both assertions fail on the pre-fix bare-`&` form and pass after.

Full PHP suite green (PHPUnit 1646, PHPCS, PHPStan). Note: a live upgrade-path smoke scenario is a larger harness addition and is left as a follow-up (per agreed scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a package upgrade issue where pfBlockerNG’s long-running services could keep install/upgrade logs from finishing, making the page appear stuck.
  * Improved service startup behavior so background processes no longer inherit unwanted input/output handles during upgrades.
* **Tests**
  * Added automated coverage to verify these services start with detached standard file descriptors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->