### PR TITLE
pfblockerng: gate Software log prefill on post-upgrade, drop it on the Update page (#666)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -152,6 +152,11 @@ if ($_POST && !empty($_POST['pfb_sw_action'])) {
 	$pfb_sw_action = (string) $_POST['pfb_sw_action'];
 }
 
+// Prefill the output textarea with the last software.log tail ONLY when this is the reload
+// right after a successful upgrade — pfb_software_reload() below redirects back here with
+// ?postupgrade=1 on success. A normal visit to the tab leaves the output empty.
+$pfb_sw_postupgrade = (($_GET['postupgrade'] ?? '') === '1');
+
 // "Save" the settings (standard pfSense CSRF POST). A checkbox is absent from the POST when
 // unticked, so persist an explicit 'on'/'off' — an unset value defaults to enabled, an
 // explicit 'off' is the user opting out.
@@ -294,7 +299,9 @@ $section->addInput(new Form_StaticText(null, $btn_uninstall))
 $form->add($section);
 
 // Live terminal window (shown when an Update is streaming).
-// Plain GET (no active update/uninstall stream) → prefill pfb_output with the last software log.
+// pfb_output is prefilled with the last software-log tail ONLY on the post-upgrade reload
+// (?postupgrade=1); a plain visit leaves it empty. While an update/uninstall is streaming it
+// also starts empty (the stream fills it live).
 $pfb_sw_active = ($pfb_sw_action !== '');
 $section = new Form_Section('Output');
 $section->addInput(new Form_Textarea(
@@ -306,7 +313,7 @@ $section->addInput(new Form_Textarea(
 $section->addInput(new Form_Textarea(
 	'pfb_output',
 	null,
-	$pfb_sw_active ? null : pfb_log_tail('/var/log/pfblockerng/software.log')
+	($pfb_sw_active || !$pfb_sw_postupgrade) ? null : pfb_log_tail('/var/log/pfblockerng/software.log')
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '20')->setAttribute('wrap', 'off')
   ->setAttribute('readonly', 'readonly')->setAttribute('style', 'background:#fafafa; width: 100%');
 $form->add($section);
@@ -332,7 +339,9 @@ if ($pfb_sw_action === 'update') {
 		// on failure, leave the terminal log on screen for the user to inspect.
 		if ($pfb_sw_rc === 0) {
 			pfb_software_status(gettext('Update complete — refreshing the page...'));
-			pfb_software_reload();
+			// Reload WITH the post-upgrade marker so the refreshed page prefills the output
+			// with the upgrade log tail (and scrolls to it); a normal visit stays empty.
+			pfb_software_reload('/pfblockerng/pfblockerng_software.php?postupgrade=1');
 		} else {
 			pfb_software_status(gettext('Update task finished with errors — see the log above.'));
 		}
@@ -404,11 +413,14 @@ events.push(function() {
 		}
 	});
 
-	// Show the newest lines: scroll the prefilled output textarea to the bottom on load
-	// (the streamed update/uninstall paths scroll as they write; the plain-GET prefill did not).
+<?php if ($pfb_sw_postupgrade): ?>
+	// Post-upgrade reload only: the output was prefilled with the upgrade log tail, so scroll
+	// it to the newest lines. (The streamed update/uninstall paths scroll as they write; a
+	// normal visit has no prefill, so there is nothing to scroll.)
 	$('textarea[name="pfb_output"]').each(function() {
 		this.scrollTop = this.scrollHeight;
 	});
+<?php endif; ?>
 });
 //]]>
 </script>

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -436,14 +436,9 @@ $section->addInput(new Form_StaticText(
 $form->add($section);
 
 // ---- Log section ----
-// Plain GET (no active run and no live-view) → prefill pfb_output with the last log tail.
-// $pconfig['run'] is the SAME signal the Run Now dispatch gate keys on (set by a button POST
-// and by the wizard-reload GET), so this suppresses the stale prefill on every run-start path.
-// $pfb_auto_tail also suppresses the stale prefill: an in-progress update is streamed live
-// (below) instead, so pfb_output must start empty for the livetail to fill it.
-$pfb_log_active = isset($pconfig['run']) ||
-                  (isset($pconfig['log_view']) && $pconfig['log_view'] !== 'View') ||
-                  $pfb_auto_tail;
+// The output textarea always starts EMPTY on load — no prefill of the last log tail. The
+// live paths fill it dynamically: Run Now / View / an in-progress update stream into it (and
+// scroll as they write); use the View button to inspect the last log.
 $section = new Form_Section('Log');
 $section->addInput(new Form_Textarea(
 	'pfb_status',
@@ -455,7 +450,7 @@ $section->addInput(new Form_Textarea(
 $section->addInput(new Form_Textarea(
 	'pfb_output',
 	NULL,
-	$pfb_log_active ? NULL : pfb_log_tail($pfb['log'])
+	NULL
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '30')->setAttribute('wrap', 'off')
   ->setAttribute('readonly', 'readonly')->setAttribute('style', 'background:#fafafa; width: 100%');
 
@@ -550,12 +545,6 @@ events.push(function(){
 		var $row = $(this).closest('.row.form-group, .form-group');
 		$row.find('label.col-sm-2').remove();
 		$row.find('div.col-sm-10').removeClass('col-sm-10').addClass('col-sm-12');
-	});
-
-	// Show the newest lines: scroll the prefilled log textarea to the bottom on load
-	// (the live-tail/Run-Now paths scroll as they stream; the plain-GET prefill did not).
-	$('textarea[name="pfb_output"]').each(function() {
-		this.scrollTop = this.scrollHeight;
 	});
 
 	// Scroll to the bottom of the page after wizard

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -354,31 +354,42 @@ def test_software_uninstall_confirm_gate(
         # break every subsequent test in this smoke run.
 
 
-def test_software_output_prefill_scrolls_to_bottom(
+def test_software_output_prefill_only_after_upgrade(
     smoke_vm: SmokeVM,
     browser_page: Page,
     webui: WebUI,
 ) -> None:
-    """The prefilled Software output textarea auto-scrolls to the newest lines on load.
+    """The Software output prefill+auto-scroll is gated on the post-upgrade reload (#666).
 
-    Scenario (log auto-scroll): the streamed update/uninstall paths scroll as they write,
-    but a plain GET prefilled the output and left it at the top — burying the latest lines.
+    The output is prefilled with the last software.log tail (and scrolled to the newest lines)
+    ONLY when the page is the reload right after a successful upgrade — which redirects here
+    with ``?postupgrade=1``. A normal visit to the tab leaves the output empty.
 
+    Scenario (post-upgrade prefill):
       Given software.log seeded with more lines than the textarea shows at once,
-      When the Software page is opened in the browser (plain-GET prefill),
-      Then pfb_output is scrolled to the bottom (newest lines visible), not left at the top.
+      When the Software page is opened WITHOUT the marker -> pfb_output is EMPTY (no prefill);
+      When opened WITH ``?postupgrade=1`` -> pfb_output is prefilled AND scrolled to the bottom.
 
-    Fail-before / pass-after: before the auto-scroll snippet the prefilled textarea loads at
-    scrollTop 0; after, it lands at the bottom. The Update page uses the byte-identical
-    snippet, guarded at the render tier by its "Show the newest lines:" marker.
+    Both branches are asserted, so green proves the param — not pre-existing state — drives the
+    prefill (fail-before: the old code prefilled on every plain GET).
     """
     page = browser_page
     # Seed enough distinct lines to overflow the textarea so a scroll is observable.
     seed = "".join(f"pfb-autoscroll-line-{i:03d}\n" for i in range(1, 81))
     with software_panel_forced(smoke_vm, "on"):
         _seed_vm_file(smoke_vm, "/var/log/pfblockerng/software.log", seed)
-        _open(page, webui, SOFTWARE_PAGE)
 
+        # WITHOUT the marker: a normal visit must NOT prefill the output.
+        _open(page, webui, SOFTWARE_PAGE)
+        empty_val = page.locator('textarea[name="pfb_output"]').input_value()
+        assert empty_val == "", f"a normal Software visit must not prefill pfb_output, got {empty_val!r}"
+
+        # WITH ?postupgrade=1: prefilled with the log tail AND scrolled to the bottom.
+        _open(page, webui, f"{SOFTWARE_PAGE}?postupgrade=1")
+        val = page.locator('textarea[name="pfb_output"]').input_value()
+        assert "pfb-autoscroll-line-080" in val, (
+            "the post-upgrade reload must prefill pfb_output with the software.log tail"
+        )
         metrics = page.locator('textarea[name="pfb_output"]').evaluate(
             "el => ({ top: el.scrollTop, sh: el.scrollHeight, ch: el.clientHeight })"
         )
@@ -387,8 +398,32 @@ def test_software_output_prefill_scrolls_to_bottom(
             f"(scrollHeight={metrics['sh']} clientHeight={metrics['ch']}); seed more lines"
         )
         # At the bottom: scrollTop within a few px of (scrollHeight - clientHeight), and
-        # strictly > 0 (proving it scrolled rather than loading at the top — the pre-fix state).
+        # strictly > 0 (proving it scrolled rather than loading at the top).
         bottom = metrics["sh"] - metrics["ch"]
         assert metrics["top"] > 0 and metrics["top"] >= bottom - 4, (
             f"prefilled output not scrolled to bottom: expected scrollTop≈{bottom}, got {metrics['top']}"
         )
+
+
+def test_update_output_is_not_prefilled(
+    smoke_vm: SmokeVM,
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """The Update page no longer prefills the output textarea on a plain GET (#666).
+
+      Given the pfBlockerNG log seeded with content,
+      When the Update page is opened on a plain GET (no run / view / in-progress update),
+      Then pfb_output is EMPTY — the last log tail is no longer prefilled.
+
+    Fail-before / pass-after: the old code prefilled pfb_output with the log tail on a plain
+    GET; now it starts empty (use the View button to inspect the log). The seeded marker proves
+    the textarea is empty by choice, not because the log is empty.
+    """
+    page = browser_page
+    seed = "".join(f"pfb-update-noprefill-{i:03d}\n" for i in range(1, 41))
+    _seed_vm_file(smoke_vm, "/var/log/pfblockerng/pfblockerng.log", seed)
+
+    _open(page, webui, UPDATE_PAGE)
+    val = page.locator('textarea[name="pfb_output"]').input_value()
+    assert val == "", f"the Update page must not prefill pfb_output on a plain GET, got {val!r}"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -911,8 +911,8 @@ def test_log_output_prefill_gating(smoke_vm: SmokeVM, webui: WebUI, php_error_lo
     sw_marker = f"pfb-sw-prefill-{uuid.uuid4().hex[:8]}"
     upd_marker = f"pfb-upd-prefill-{uuid.uuid4().hex[:8]}"
     with software_panel_forced(smoke_vm, "on"):
-        _seed_vm_file(smoke_vm, "/var/log/pfblockerng/software.log", sw_marker + "\n")
-        _seed_vm_file(smoke_vm, helpers.PFB_LOG, upd_marker + "\n")
+        _seed_vm_file(smoke_vm, _SOFTWARE_LOG, sw_marker + "\n")
+        _seed_vm_file(smoke_vm, _PFB_LOG, upd_marker + "\n")
 
         # Software, plain GET → no prefill.
         body = webui.get(_SOFTWARE_PAGE).text
@@ -1122,93 +1122,6 @@ def test_software_textareas_are_readonly(
             assert re.search(r"\breadonly\b", tag), (
                 f"Software page '{name}' textarea is editable (no readonly attribute): {tag!r}"
             )
-
-
-@pytest.mark.ui_e2e
-def test_update_log_prefills_on_plain_get(
-    smoke_vm: SmokeVM,
-    webui: WebUI,
-    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
-) -> None:
-    """A plain GET of the Update page prefills pfb_output with the last log tail.
-
-    Scenario: After seeding the pfBlockerNG log, a fresh plain GET shows the content.
-      Given a known marker line appended to /var/log/pfblockerng/pfblockerng.log on the VM,
-      When the Update page is GET with no POST parameters,
-      Then the pfb_output textarea's initial value contains the seeded marker.
-
-    Fail-before / pass-after: before this change pfb_output was always rendered empty
-    (value=NULL) on a plain GET, so the textarea content would be blank and the seeded
-    marker absent. After the fix, pfb_log_tail() prefills it, so the marker appears.
-
-    Multi-step (seed → GET) classifies as Tier B per the CLAUDE.md mandate.
-    """
-    seed = f"pfb-update-log-prefill-{uuid.uuid4().hex}"
-    pat = r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>'
-
-    # Before seeding: the unique marker is ABSENT — proves the prefill caused it (not a
-    # pre-existing log line), and is robust to a re-run on the same VM where tail -a accumulates.
-    m_before = re.search(pat, webui.get(_UPDATE_PAGE).text, re.DOTALL)
-    assert m_before is not None, "Update page is missing the pfb_output textarea (before seed)"
-    assert seed not in m_before.group(1), (
-        f"seed marker {seed!r} already present before seeding — test is not self-proving"
-    )
-
-    # After seeding the log: a plain GET prefills pfb_output with the tail (marker now present).
-    _seed_vm_file(smoke_vm, _PFB_LOG, seed + "\n")
-    m = re.search(pat, webui.get(_UPDATE_PAGE).text, re.DOTALL)
-    assert m is not None, "Update page is missing the pfb_output textarea in the rendered body"
-    content = m.group(1)
-    assert seed in content, (
-        f"Update page pfb_output is not prefilled on plain GET: "
-        f"expected seed marker {seed!r} in textarea content, got {content[:200]!r}"
-    )
-
-
-@pytest.mark.ui_e2e
-def test_software_log_prefills_on_plain_get(
-    smoke_vm: SmokeVM,
-    webui: WebUI,
-    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
-) -> None:
-    """A plain GET of the Software page prefills pfb_output from software.log.
-
-    Scenario: After seeding /var/log/pfblockerng/software.log, a fresh plain GET shows
-    that content in the pfb_output textarea.
-      Given a known marker line written to software.log on the VM,
-      When the Software page is GET (override gate forced on),
-      Then the pfb_output textarea's initial value contains the seeded marker.
-
-    Fail-before / pass-after: before this change pfb_output was rendered empty on a
-    plain GET (value=NULL). After the fix, pfb_log_tail() reads software.log and prefills
-    the textarea, so the seeded marker appears. A real pkg upgrade is too heavy to
-    simulate in this suite, so the seed-file approach exercises the full prefill path.
-
-    Multi-step (seed → GET) classifies as Tier B per the CLAUDE.md mandate.
-    """
-    seed = f"pfb-software-log-prefill-{uuid.uuid4().hex}"
-    pat = r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>'
-    with software_panel_forced(smoke_vm, "on"):
-        # Before seeding: the unique marker is ABSENT (self-proving + same-VM re-run safe).
-        m_before = re.search(pat, webui.get(_SOFTWARE_PAGE).text, re.DOTALL)
-        assert m_before is not None, "Software page is missing the pfb_output textarea (before seed)"
-        assert seed not in m_before.group(1), (
-            f"seed marker {seed!r} already present before seeding — test is not self-proving"
-        )
-
-        # After seeding software.log: a plain GET prefills pfb_output with its tail.
-        _seed_vm_file(smoke_vm, _SOFTWARE_LOG, seed + "\n")
-        m = re.search(pat, webui.get(_SOFTWARE_PAGE).text, re.DOTALL)
-        assert m is not None, "Software page is missing the pfb_output textarea in the rendered body"
-        content = m.group(1)
-        assert seed in content, (
-            f"Software page pfb_output is not prefilled on plain GET: "
-            f"expected seed marker {seed!r} in textarea content, got {content[:200]!r}"
-        )
-
-        # The prefilled output auto-scrolls to the bottom on load (issue: log auto-scroll).
-        # Reuse the page already fetched for the prefill check above (m.string) — no extra GET.
-        assert "Show the newest lines:" in m.string, "Software page is missing the prefilled-output auto-scroll snippet"
 
 
 _PENDING_MARKER = "/usr/local/etc/pfb_pending_changes"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -138,8 +138,7 @@ PAGE_TABLE: tuple[Page, ...] = (
     Page(
         "update",
         "/pfblockerng/pfblockerng_update.php",
-        # "Show the newest lines:" — the prefilled-log auto-scroll snippet (issue: log auto-scroll).
-        ("Update Settings", "Schedule", "Show the newest lines:"),
+        ("Update Settings", "Schedule"),
     ),
     # blacklist.php is always the DNSBL Category view; the long info line is a stable literal.
     Page(
@@ -886,6 +885,52 @@ def test_software_page_renders_uninstall_controls(
         assert "disabled" in btn_tag, (
             f"Uninstall button expected 'disabled' attribute on initial render, got: {btn_tag!r}"
         )
+
+
+def _pfb_output_value(body: str) -> str:
+    """Return the rendered value (text between the tags) of the ``pfb_output`` textarea."""
+    match = re.search(r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>', body, re.DOTALL)
+    assert match is not None, "pfb_output textarea not found in body"
+    return match.group(1)
+
+
+def test_log_output_prefill_gating(smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The log output textarea is prefilled only on the Software post-upgrade reload (#666).
+
+    Scenario (prefill gating):
+      Given software.log and the pfBlockerNG log each seeded with a unique marker,
+      When the Software page is GET WITHOUT ``?postupgrade=1`` -> pfb_output is EMPTY;
+      When the Software page is GET WITH ``?postupgrade=1`` -> pfb_output is prefilled with the
+           software.log tail (the marker appears);
+      When the Update page is GET -> pfb_output is EMPTY (prefill removed).
+
+    The seeded markers make the empty assertions meaningful (the textarea is empty by choice,
+    not because the log is empty) — fail-before: the old code prefilled the tail on every plain
+    GET, so both markers would appear.
+    """
+    sw_marker = f"pfb-sw-prefill-{uuid.uuid4().hex[:8]}"
+    upd_marker = f"pfb-upd-prefill-{uuid.uuid4().hex[:8]}"
+    with software_panel_forced(smoke_vm, "on"):
+        _seed_vm_file(smoke_vm, "/var/log/pfblockerng/software.log", sw_marker + "\n")
+        _seed_vm_file(smoke_vm, helpers.PFB_LOG, upd_marker + "\n")
+
+        # Software, plain GET → no prefill.
+        body = webui.get(_SOFTWARE_PAGE).text
+        assert sw_marker not in _pfb_output_value(body), (
+            "Software page must not prefill pfb_output without ?postupgrade=1"
+        )
+
+        # Software, post-upgrade reload → prefilled with the software.log tail.
+        body = webui.get(f"{_SOFTWARE_PAGE}?postupgrade=1").text
+        assert sw_marker in _pfb_output_value(body), (
+            "Software ?postupgrade=1 must prefill pfb_output with the software.log tail"
+        )
+
+        # Update page → no prefill (clean render, and the seeded log marker must be absent).
+        resp = webui.get(_UPDATE_PAGE)
+        result = evaluate_render(_UPDATE_PAGE, resp.status_code, resp.text, ("Update Settings", "Schedule"))
+        assert result.ok, f"Update page render oracle failed: {result.detail}"
+        assert upd_marker not in _pfb_output_value(resp.text), "Update page must not prefill pfb_output"
 
 
 def test_software_page_hidden_when_override_forces_off(


### PR DESCRIPTION
Fixes #666.

## Change

Refine the recently-added log auto-prefill / auto-scroll behavior on the two log pages.

- **Software page (`pfblockerng_software.php`)** — prefill the output textarea with the last `software.log` tail (and auto-scroll to the bottom) **only on the reload right after a successful upgrade**. `pfb_software_reload()` now redirects back with `?postupgrade=1` on upgrade success, and the page keys the prefill + scroll on that marker; a normal visit to the tab leaves the output empty. (The uninstall path already redirects to `/pkg_mgr_installed.php`, so it is unaffected.)
- **Update page (`pfblockerng_update.php`)** — remove the prefill entirely. The output starts empty on a plain GET; the live-tail / Run-Now / View paths still stream and scroll as before.

Live-streaming behavior is unchanged on both pages — only the plain-GET prefill of the last log tail changes.

## Tests

- **Tier-A render** (`test_render_smoke.py`): with `software.log` and the pfBlockerNG log seeded with unique markers, the Software page prefills `pfb_output` **only** with `?postupgrade=1`, and the Update page never prefills (the seeded markers make the empty assertions meaningful). Removes the now-stale `"Show the newest lines:"` Update-page render marker.
- **Tier-B browser** (`test_browser_misc.py`): the Software auto-scroll test is reworked to assert no prefill on a plain visit and prefill + scroll-to-bottom on `?postupgrade=1`; adds an Update-page no-prefill assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_