### PR TITLE
docs: add release notes for v4.0.0.alpha.13

### DIFF
--- a/docs/release-notes/v4.0.0.alpha.13.md
+++ b/docs/release-notes/v4.0.0.alpha.13.md
@@ -1,0 +1,13 @@
+<!-- SUMMARY: Upgrade alias fixes -->
+## Bug Fixes
+
+- **Package upgrades no longer freeze the live progress log.** During a pfBlockerNG package upgrade the log on the progress page could hang partway and stay incomplete even after a reload; the package's background services no longer hold the package manager's output open, so the log streams to completion. ([#662](https://github.com/pfBlockerNG/pfBlockerNG/issues/662))
+- **DNS Redirect / DoT-DoQ Block exception aliases now apply on scheduled updates.** A valid exception alias was treated as non-existent during a cron or service-restart reload and silently ignored; it now resolves correctly, so the listed hosts bypass the redirect/block as intended. ([#664](https://github.com/pfBlockerNG/pfBlockerNG/issues/664))
+
+## Improvements
+
+- **Stricter Exception Alias validation.** The DNS Redirect and DoT/DoQ Block exception fields now accept only address-type firewall aliases usable as a rule source (host, network, URL, URL Table) and reject port aliases and pfBlockerNG-managed (`pfB_`) aliases, with a clear error and the autocomplete limited to valid choices. ([#664](https://github.com/pfBlockerNG/pfBlockerNG/issues/664))
+- **Clearer logging when an exception alias cannot be applied** — the message now names the specific rule (interface, plus IP version for DNS Redirect) instead of repeating an identical line per rule. ([#664](https://github.com/pfBlockerNG/pfBlockerNG/issues/664))
+- **Tidied log auto-fill on the Update and Software pages.** The output box no longer pre-fills with the previous log on a normal visit; the Software page shows the upgrade log only on the refresh right after an upgrade. ([#666](https://github.com/pfBlockerNG/pfBlockerNG/issues/666))
+
+**Full changelog:** [`v4.0.0.alpha.12` → `v4.0.0.alpha.13`](https://github.com/pfBlockerNG/pfBlockerNG/compare/v4.0.0.alpha.12...v4.0.0.alpha.13)


### PR DESCRIPTION
Adds the hand-authored release notes for `v4.0.0.alpha.13` so the release workflow uses this file as the GitHub Release body (skipping the GitHub Models step).

Covers the user-facing `src/` changes since `v4.0.0.alpha.12`: the package-upgrade live-log fix (#662), the DNS Redirect / DoT-DoQ exception-alias reliability + validation fixes (#664), and the Update/Software log auto-fill rework (#666).

Documentation-only — CI is skipped via `paths-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package upgrades so the live progress log no longer freezes.
  * Corrected exception alias handling during scheduled updates for DNS Redirect and DoT/DoQ block rules.
  * Improved validation so only supported firewall aliases can be selected, with clearer errors for invalid choices.
  * Updated logs to show the specific rule when an exception alias can’t be applied.
  * Adjusted update page log behavior to avoid keeping older log entries between refreshes.

* **Documentation**
  * Added release notes for the alpha.13 update and a link to the full changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->