### PR TITLE
pfblockerng: fix live-terminal double-escaping and sticky-scroll the log tail (#669)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11813,6 +11813,37 @@ function pfb_update_autotail(bool $task_running, bool $run_dispatch, bool $logvi
 }
 
 
+// Encode a string as a JavaScript string literal (including the surrounding double quotes) for
+// assignment to a textarea's plain-text .value. json_encode gives correct JS-string escaping --
+// unlike htmlspecialchars(), which HTML-entity-escapes (so a '>' would render as a literal
+// '&gt;' in the .value) and leaves backslashes unescaped (a log line ending in '\' could break
+// out of the literal). JSON_HEX_TAG/AMP/APOS/QUOT neutralise a '</script>' or quote breakout;
+// JSON_INVALID_UTF8_SUBSTITUTE keeps invalid bytes in log data from making json_encode return
+// FALSE (the fallback is an empty literal).
+function pfb_js_string(string $text): string {
+	$json = json_encode($text, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_INVALID_UTF8_SUBSTITUTE);
+	return ($json === FALSE) ? '""' : $json;
+}
+
+
+// Build the JS that writes $text into the named live-terminal textarea and follows the tail.
+// Auto-follow is "sticky": the scroll position is measured BEFORE the value changes, and the box
+// is re-pinned to the bottom ONLY when the user was already at the bottom -- so scrolling up to
+// read older lines pauses the follow instead of being snapped back on every streamed refresh, and
+// scrolling back to the bottom resumes it. $append adds the text to the end (the live tail streams
+// deltas); otherwise it replaces the whole value (a single status line). Newlines belong to $text
+// -- the caller owns them -- so a delta that already ends in "\n" is appended verbatim.
+function pfb_term_write_js(string $field, string $text, bool $append = FALSE): string {
+	$el  = "this.document.forms[0].{$field}";
+	$lit = pfb_js_string($text);
+	$set = $append ? "{$el}.value += {$lit};" : "{$el}.value = {$lit};";
+	return
+		"var _pfb_atbottom = ({$el}.scrollHeight - {$el}.scrollTop - {$el}.clientHeight) <= 16;\n" .
+		"{$set}\n" .
+		"if (_pfb_atbottom) { {$el}.scrollTop = {$el}.scrollHeight; }";
+}
+
+
 // Read logfile in realtime (livetail)
 // Reference: http://stackoverflow.com/questions/3218895/php-how-to-read-a-file-live-that-is-constantly-being-written-to
 function pfb_livetail($logfile, $mode, $pidfile = '') {
@@ -11822,18 +11853,12 @@ function pfb_livetail($logfile, $mode, $pidfile = '') {
 		touch("{$logfile}");
 	}
 
-	$len		= @filesize("{$logfile}");	// Start at EOF
-	$lastpos_old	= $pfb_output = '';
+	$len = @filesize("{$logfile}");	// Start at EOF
 
 	if ($mode == 'view') {
-		// Start at EOF ( - 15000)
-		if ($len > 15000) {
-			$lastpos = ($len - 15000);
-		} else {
-			$lastpos = 0;
-		}
-	}
-	else {
+		// Start ~15000 bytes back so the viewer opens on recent history.
+		$lastpos = ($len > 15000) ? ($len - 15000) : 0;
+	} else {
 		$lastpos = $len;
 	}
 
@@ -11845,8 +11870,15 @@ function pfb_livetail($logfile, $mode, $pidfile = '') {
 	// (or seeing the pid) ends the tail as soon as the process is gone, and the log streams
 	// every cycle regardless, so the page is never held blank.
 	$seen_running	= FALSE;
+	$saw_output	= FALSE;
 	$startup_cycles	= 0;
 	$startup_grace	= 10;	// ~3s at 0.3s/cycle
+
+	// Bytes read but not yet streamed. The terminal appends each delta, so a delta must be WHOLE
+	// lines: we hold back any trailing partial line until its newline arrives. Streaming a partial
+	// line could split a multibyte UTF-8 char across two appends -> a permanent replacement-char
+	// artifact the append-only textarea can never repair.
+	$pending = '';
 
 	while (TRUE) {
 		usleep(300000); //0.3s
@@ -11854,55 +11886,74 @@ function pfb_livetail($logfile, $mode, $pidfile = '') {
 		$len = @filesize("{$logfile}");
 
 		if ($len < $lastpos) {
-			$lastpos = $len;	// File deleted or reset
-		}
-		else {
-			$f = @fopen("{$logfile}", 'rb+');
+			$lastpos = $len;	// File deleted/rotated -- resync to the new EOF.
+			$pending = '';
+		} elseif ($len > $lastpos) {
+			$f = @fopen("{$logfile}", 'rb');
 			if ($f === FALSE) {
 				break;
 			}
 			@fseek($f, $lastpos);
-
 			while (!feof($f)) {
-				$pfb_buffer = @fread($f, 2048);
-				$pfb_output .= str_replace( array ("\r", "\")"), '', $pfb_buffer);
-				// Refresh on new lines only. This allows Scrolling.
-				if ($lastpos != $lastpos_old) {
-					pfbupdate_output($pfb_output);
+				$buf = @fread($f, 8192);
+				if ($buf === FALSE) {
+					break;
 				}
-				$lastpos_old = $lastpos;
+				$pending .= $buf;
+			}
+			$lastpos = @ftell($f);
+			@fclose($f);
+
+			// Stream up to the last complete line; keep the trailing partial for the next cycle.
+			$nl = strrpos($pending, "\n");
+			if ($nl !== FALSE) {
+				$delta   = str_replace("\r", '', substr($pending, 0, $nl + 1));
+				$pending = substr($pending, $nl + 1);
+				if ($delta !== '') {
+					pfbupdate_output($delta);
+					$saw_output = TRUE;
+					ob_flush();
+					flush();
+				}
+			}
+		}
+
+		// Terminate the Run-Now tail when the dispatched process exits -- the process itself is
+		// the completion signal (its pidfile, via isvalidpid), replacing the brittle
+		// 'UPDATE PROCESS ENDED' log-string probe. 'view' is a passive live viewer: it streams
+		// until the client disconnects, so it never stops here.
+		if ($mode != 'view' &&
+		    pfb_livetail_force_done(isvalidpid($pidfile), $saw_output, $seen_running, $startup_cycles, $startup_grace)) {
+			// Final drain: capture anything written between the last read and the process exit,
+			// then flush the remainder including a final line with no trailing newline.
+			clearstatcache(FALSE, "{$logfile}");
+			$len = @filesize("{$logfile}");
+			if ($len > $lastpos) {
+				$f = @fopen("{$logfile}", 'rb');
+				if ($f !== FALSE) {
+					@fseek($f, $lastpos);
+					while (!feof($f)) {
+						$buf = @fread($f, 8192);
+						if ($buf === FALSE) {
+							break;
+						}
+						$pending .= $buf;
+					}
+					$lastpos = @ftell($f);
+					@fclose($f);
+				}
+			}
+			$tail = str_replace("\r", '', $pending);
+			if ($tail !== '') {
+				pfbupdate_output($tail);
+				$pending = '';
 				ob_flush();
 				flush();
 			}
 
-			$lastpos = @ftell($f);
-			if ($f) {
-				@fclose($f);
-			}
-
-			// Terminate the Run-Now tail when the dispatched process exits -- the process
-			// itself is the completion signal (its pidfile, via isvalidpid), replacing the
-			// brittle 'UPDATE PROCESS ENDED' log-string probe. 'view' is a passive live
-			// viewer: it streams until the client disconnects, so it never stops here.
-			if ($mode != 'view' &&
-			    pfb_livetail_force_done(isvalidpid($pidfile), $pfb_output !== '', $seen_running, $startup_cycles, $startup_grace)) {
-				// Capture remaining output, run log mgmt, end the tail.
-				$f = @fopen($pfb['log'], 'rb');
-				if ($f !== FALSE) {
-					@fseek($f, $lastpos);
-					$pfb_buffer = @fread($f, 2048);
-					$pfb_output .= str_replace("\r", '', $pfb_buffer);
-					pfbupdate_output($pfb_output);
-					clearstatcache(FALSE, $pfb['log']);
-					ob_flush();
-					flush();
-					@fclose($f);
-				}
-
-				// Call log mgmt function
-				pfb_log_mgmt();
-				break;
-			}
+			// Call log mgmt function
+			pfb_log_mgmt();
+			break;
 		}
 	}
 }

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -68,13 +68,13 @@ $pfb_sw_check_raw = PfbConfig::read('pfb_software_check');
 $pfb_sw_check	= pfb_software_check_enabled(is_string($pfb_sw_check_raw) ? $pfb_sw_check_raw : null);
 
 
-// Stream one line to the live terminal window (reuses the _update.php mechanic).
+// Stream one line to the live terminal window (reuses the _update.php mechanic). The caller
+// passes a newline-stripped line, so append it with its own line break (the helper appends the
+// text verbatim).
 function pfb_software_output($text) {
-	$text = htmlspecialchars(str_replace("\n", "\\n", $text), ENT_COMPAT);
 	print("\n<script type=\"text/javascript\">");
 	print("\n//<![CDATA[");
-	print("\nthis.document.forms[0].pfb_output.value += \"" . $text . "\\n\";");
-	print("\nthis.document.forms[0].pfb_output.scrollTop = this.document.forms[0].pfb_output.scrollHeight;");
+	print("\n" . pfb_term_write_js('pfb_output', $text . "\n", TRUE));
 	print("\n//]]>");
 	print("\n</script>");
 	ob_flush();
@@ -84,10 +84,9 @@ function pfb_software_output($text) {
 
 // Post a one-line status to the terminal status window.
 function pfb_software_status($status) {
-	$status = htmlspecialchars(str_replace("\n", "\\n", $status), ENT_COMPAT);
 	print("\n<script type=\"text/javascript\">");
 	print("\n//<![CDATA[");
-	print("\nthis.document.forms[0].pfb_status.value=\"" . $status . "\";");
+	print("\nthis.document.forms[0].pfb_status.value = " . pfb_js_string($status) . ";");
 	print("\n//]]>");
 	print("\n</script>");
 	ob_flush();

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -41,13 +41,12 @@ require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 global $pfb;
 pfb_global();
 
-// Collect pfBlockerNG log file and post live output to terminal window.
+// Collect pfBlockerNG log file and post live output to terminal window. pfb_livetail() streams
+// whole-line deltas, so each call APPENDS to the terminal (the text carries its own newlines).
 function pfbupdate_output($text) {
-	$text = htmlspecialchars(str_replace("\n", "\\n", $text), ENT_COMPAT);
 	print("\n<script type=\"text/javascript\">");
 	print("\n//<![CDATA[");
-	print("\nthis.document.forms[0].pfb_output.value = \"" . $text . "\";");
-	print("\nthis.document.forms[0].pfb_output.scrollTop = this.document.forms[0].pfb_output.scrollHeight;");
+	print("\n" . pfb_term_write_js('pfb_output', $text, TRUE));
 	print("\n//]]>");
 	print("\n</script>");
 	/* ensure that contents are written out */
@@ -57,10 +56,9 @@ function pfbupdate_output($text) {
 
 // Post status message to terminal window.
 function pfbupdate_status($status) {
-	$status = htmlspecialchars(str_replace("\n", "\\n", $status), ENT_COMPAT);
 	print("\n<script type=\"text/javascript\">");
 	print("\n//<![CDATA[");
-	print("\nthis.document.forms[0].pfb_status.value=\"" . $status . "\";");
+	print("\nthis.document.forms[0].pfb_status.value = " . pfb_js_string($status) . ";");
 	print("\n//]]>");
 	print("\n</script>");
 	/* ensure that contents are written out */

--- a/tests/php/LiveTerminalEscapeTest.php
+++ b/tests/php/LiveTerminalEscapeTest.php
@@ -47,7 +47,7 @@ final class LiveTerminalEscapeTest extends TestCase
 		// the browser assigns to .value is byte-for-byte the original.
 		$this->assertSame(
 			'feed --> sink',
-			json_decode($literal, false, 512, JSON_THROW_ON_ERROR),
+			json_decode($literal, FALSE, 512, JSON_THROW_ON_ERROR),
 			"decoded literal must equal the input; got literal: {$literal}"
 		);
 		$this->assertStringNotContainsString(
@@ -75,7 +75,7 @@ final class LiveTerminalEscapeTest extends TestCase
 		);
 		$this->assertSame(
 			'oops</script><b>x</b>',
-			json_decode($literal, false, 512, JSON_THROW_ON_ERROR)
+			json_decode($literal, FALSE, 512, JSON_THROW_ON_ERROR)
 		);
 	}
 
@@ -91,7 +91,7 @@ final class LiveTerminalEscapeTest extends TestCase
 
 		$this->assertSame(
 			'C:\\path\\',
-			json_decode($literal, false, 512, JSON_THROW_ON_ERROR),
+			json_decode($literal, FALSE, 512, JSON_THROW_ON_ERROR),
 			"trailing backslash must round-trip; got literal: {$literal}"
 		);
 	}
@@ -102,7 +102,7 @@ final class LiveTerminalEscapeTest extends TestCase
 		$input   = "say \"hi\"\nnext line\tand a tab";
 		$literal = pfb_js_string($input);
 
-		$this->assertSame($input, json_decode($literal, false, 512, JSON_THROW_ON_ERROR));
+		$this->assertSame($input, json_decode($literal, FALSE, 512, JSON_THROW_ON_ERROR));
 	}
 
 	/**
@@ -116,7 +116,7 @@ final class LiveTerminalEscapeTest extends TestCase
 
 		$this->assertNotSame('""', $literal, 'invalid UTF-8 must not collapse to an empty literal');
 		// Still a decodable JSON string literal (the bad byte became U+FFFD).
-		$this->assertIsString(json_decode($literal, false, 512, JSON_THROW_ON_ERROR));
+		$this->assertIsString(json_decode($literal, FALSE, 512, JSON_THROW_ON_ERROR));
 	}
 
 	// ---- 2. pfb_term_write_js(): sticky auto-follow -----------------------------
@@ -128,7 +128,7 @@ final class LiveTerminalEscapeTest extends TestCase
 	 */
 	public function testStickyFollowMeasuresBeforeWriteAndRepinsConditionally(): void
 	{
-		$js = pfb_term_write_js('pfb_output', 'a line', true);
+		$js = pfb_term_write_js('pfb_output', 'a line', TRUE);
 
 		// Guard expression present (distance-from-bottom against the three metrics).
 		$this->assertStringContainsString('scrollHeight', $js);
@@ -156,7 +156,7 @@ final class LiveTerminalEscapeTest extends TestCase
 	/** Append mode adds to the end (live tail); the text is appended verbatim. */
 	public function testAppendModeUsesPlusEquals(): void
 	{
-		$js = pfb_term_write_js('pfb_output', "x>y\n", true);
+		$js = pfb_term_write_js('pfb_output', "x>y\n", TRUE);
 
 		$this->assertStringContainsString('.value +=', $js);
 		$this->assertStringNotContainsString('.value =', $js); // not the replace form
@@ -167,7 +167,7 @@ final class LiveTerminalEscapeTest extends TestCase
 	/** Replace mode (a single status line) overwrites the whole value. */
 	public function testReplaceModeUsesAssignment(): void
 	{
-		$js = pfb_term_write_js('pfb_status', 'Standby', false);
+		$js = pfb_term_write_js('pfb_status', 'Standby', FALSE);
 
 		$this->assertStringContainsString('.value =', $js);
 		$this->assertStringNotContainsString('.value +=', $js);
@@ -177,7 +177,7 @@ final class LiveTerminalEscapeTest extends TestCase
 	/** The targeted field name is honoured (no hard-coded element). */
 	public function testFieldNameIsHonoured(): void
 	{
-		$js = pfb_term_write_js('pfb_custom', 'z', true);
+		$js = pfb_term_write_js('pfb_custom', 'z', TRUE);
 		$this->assertStringContainsString('forms[0].pfb_custom.value', $js);
 	}
 }

--- a/tests/php/LiveTerminalEscapeTest.php
+++ b/tests/php/LiveTerminalEscapeTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the live-terminal output contract shared by the Update and Software pages
+ * (pfblockerng_update.php / pfblockerng_software.php). Those pages stream log
+ * output by flushing inline <script> chunks that assign to a textarea's .value;
+ * the JS-string encoding and the sticky auto-follow both live in two helpers in
+ * pfblockerng.inc -- pfb_js_string() and pfb_term_write_js() -- so they are unit
+ * tested here off-appliance (bootstrap.php loads the real pfblockerng.inc).
+ *
+ * Two behaviours are pinned:
+ *
+ *   1. Correct escaping (issue #669). A textarea .value is a PLAIN-TEXT DOM
+ *      property -- it does not decode HTML entities -- so the text must be a
+ *      JavaScript string literal, NOT htmlspecialchars output. The old code
+ *      htmlspecialchars'd the text, so a '>' rendered as the literal '&gt;'.
+ *      pfb_js_string() must produce a literal that round-trips back to the exact
+ *      input, never emits an HTML entity like '&gt;', and neutralises a
+ *      '</script>' breakout and a trailing backslash.
+ *
+ *   2. Sticky auto-follow (issue #669). pfb_term_write_js() must measure the
+ *      scroll position BEFORE changing the value and re-pin to the bottom ONLY
+ *      when the user was already at the bottom -- so scrolling up to read pauses
+ *      the follow instead of being snapped back on every refresh.
+ */
+#[CoversFunction('pfb_js_string')]
+#[CoversFunction('pfb_term_write_js')]
+final class LiveTerminalEscapeTest extends TestCase
+{
+	// ---- 1. pfb_js_string(): JS-string escaping, not HTML escaping --------------
+
+	/**
+	 * A '>' must survive as a real '>' in the textarea, never the literal '&gt;'.
+	 * This is the exact #669 double-escape bug: htmlspecialchars turned '>' into
+	 * '&gt;', which a plain-text .value shows verbatim.
+	 */
+	public function testAngleBracketIsNotHtmlEntityEncoded(): void
+	{
+		$literal = pfb_js_string('feed --> sink');
+
+		// json_decode reverses a valid JS/JSON string literal, proving the value
+		// the browser assigns to .value is byte-for-byte the original.
+		$this->assertSame(
+			'feed --> sink',
+			json_decode($literal, false, 512, JSON_THROW_ON_ERROR),
+			"decoded literal must equal the input; got literal: {$literal}"
+		);
+		$this->assertStringNotContainsString(
+			'&gt;',
+			$literal,
+			"must not HTML-entity-encode '>' (the #669 double-escape); got: {$literal}"
+		);
+		$this->assertStringNotContainsString('&amp;', $literal, "got: {$literal}");
+	}
+
+	/**
+	 * A '</script>' in log data must not be able to terminate the inline <script>
+	 * element. With JSON_HEX_TAG the '<' and '>' become < / >, so the
+	 * literal sequence '</script>' never appears -- yet it still decodes back to
+	 * the original text.
+	 */
+	public function testScriptCloserIsNeutralised(): void
+	{
+		$literal = pfb_js_string('oops</script><b>x</b>');
+
+		$this->assertStringNotContainsString(
+			'</script>',
+			$literal,
+			"a literal </script> would close the inline script element; got: {$literal}"
+		);
+		$this->assertSame(
+			'oops</script><b>x</b>',
+			json_decode($literal, false, 512, JSON_THROW_ON_ERROR)
+		);
+	}
+
+	/**
+	 * A log line ending in a backslash must not break the literal. htmlspecialchars
+	 * left '\' unescaped, so '...\' followed by the closing '"' produced '\"' --
+	 * an escaped quote that ran the JS string past its end. json_encode escapes the
+	 * backslash, so the literal stays well-formed and decodes to one backslash.
+	 */
+	public function testTrailingBackslashDoesNotBreakOut(): void
+	{
+		$literal = pfb_js_string('C:\\path\\');
+
+		$this->assertSame(
+			'C:\\path\\',
+			json_decode($literal, false, 512, JSON_THROW_ON_ERROR),
+			"trailing backslash must round-trip; got literal: {$literal}"
+		);
+	}
+
+	/** Quotes and newlines round-trip through the literal unchanged. */
+	public function testQuotesAndNewlinesRoundTrip(): void
+	{
+		$input   = "say \"hi\"\nnext line\tand a tab";
+		$literal = pfb_js_string($input);
+
+		$this->assertSame($input, json_decode($literal, false, 512, JSON_THROW_ON_ERROR));
+	}
+
+	/**
+	 * Invalid UTF-8 in raw log bytes must NOT make json_encode return FALSE (which
+	 * would emit nothing / corrupt the stream). JSON_INVALID_UTF8_SUBSTITUTE keeps
+	 * it a valid, non-empty literal.
+	 */
+	public function testInvalidUtf8YieldsValidNonEmptyLiteral(): void
+	{
+		$literal = pfb_js_string("bad\xFFbyte");
+
+		$this->assertNotSame('""', $literal, 'invalid UTF-8 must not collapse to an empty literal');
+		// Still a decodable JSON string literal (the bad byte became U+FFFD).
+		$this->assertIsString(json_decode($literal, false, 512, JSON_THROW_ON_ERROR));
+	}
+
+	// ---- 2. pfb_term_write_js(): sticky auto-follow -----------------------------
+
+	/**
+	 * The follow is sticky: the at-bottom test must be computed BEFORE the value
+	 * changes, and the re-pin must be guarded by it. Measuring after the value grew
+	 * would always read "not at bottom" and the box would never follow.
+	 */
+	public function testStickyFollowMeasuresBeforeWriteAndRepinsConditionally(): void
+	{
+		$js = pfb_term_write_js('pfb_output', 'a line', true);
+
+		// Guard expression present (distance-from-bottom against the three metrics).
+		$this->assertStringContainsString('scrollHeight', $js);
+		$this->assertStringContainsString('scrollTop', $js);
+		$this->assertStringContainsString('clientHeight', $js);
+
+		$measurePos = strpos($js, '_pfb_atbottom');
+		$writePos   = strpos($js, '.value');
+		$this->assertNotFalse($measurePos);
+		$this->assertNotFalse($writePos);
+		$this->assertLessThan(
+			$writePos,
+			$measurePos,
+			"the at-bottom measurement must precede the .value write so follow works; got: {$js}"
+		);
+
+		// The re-pin to the bottom is conditional on the pre-measured flag.
+		$this->assertMatchesRegularExpression(
+			'/if\s*\(\s*_pfb_atbottom\s*\)\s*\{[^}]*scrollTop\s*=[^}]*scrollHeight/',
+			$js,
+			"scroll-to-bottom must be guarded by the at-bottom flag; got: {$js}"
+		);
+	}
+
+	/** Append mode adds to the end (live tail); the text is appended verbatim. */
+	public function testAppendModeUsesPlusEquals(): void
+	{
+		$js = pfb_term_write_js('pfb_output', "x>y\n", true);
+
+		$this->assertStringContainsString('.value +=', $js);
+		$this->assertStringNotContainsString('.value =', $js); // not the replace form
+		// The appended chunk is the escaped literal of the exact text (newline kept).
+		$this->assertStringContainsString(pfb_js_string("x>y\n"), $js);
+	}
+
+	/** Replace mode (a single status line) overwrites the whole value. */
+	public function testReplaceModeUsesAssignment(): void
+	{
+		$js = pfb_term_write_js('pfb_status', 'Standby', false);
+
+		$this->assertStringContainsString('.value =', $js);
+		$this->assertStringNotContainsString('.value +=', $js);
+		$this->assertStringContainsString(pfb_js_string('Standby'), $js);
+	}
+
+	/** The targeted field name is honoured (no hard-coded element). */
+	public function testFieldNameIsHonoured(): void
+	{
+		$js = pfb_term_write_js('pfb_custom', 'z', true);
+		$this->assertStringContainsString('forms[0].pfb_custom.value', $js);
+	}
+}


### PR DESCRIPTION
Fixes #669.

The Update and Software pages stream log output by flushing inline `<script>` chunks that assign to a textarea's `.value`. Two pre-existing defects, both in that streamed path.

## 1. HTML characters were double-escaped (e.g. `&gt;`)

The text was run through `htmlspecialchars()` and then assigned to a textarea `.value` — a **plain-text** DOM property that does not decode HTML entities — so a `>` rendered as the literal `&gt;`. `htmlspecialchars()` also leaves backslashes unescaped, so a log line ending in `\` could break out of the JS string literal.

Fix: a new `pfb_js_string()` helper encodes the text as a proper JavaScript string literal with `json_encode($text, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_INVALID_UTF8_SUBSTITUTE)`. This displays the raw characters correctly, still neutralises a `</script>` breakout, escapes quotes/backslashes properly, and tolerates invalid UTF-8 bytes in raw log data (no `FALSE` return).

## 2. Auto-scroll fought manual scrolling

Each streamed chunk unconditionally set `scrollTop = scrollHeight`, so scrolling up to read older lines was undone by the next refresh. The follow is now **sticky** (`pfb_term_write_js()`): the scroll position is measured *before* the value changes and the box is re-pinned to the bottom **only** when the user was already at the bottom. Scrolling up pauses the follow; scrolling back to the bottom resumes it.

## Streaming model

`pfb_livetail()` now streams **whole-line deltas** (append) instead of re-sending the whole accumulated buffer (replace). It holds back a trailing partial line until its newline arrives, so a delta is always complete lines — a partial line can never split a multibyte UTF-8 char across two appends (which the append-only textarea could not repair). Both pages append; a single status line still uses a plain replace.

## Tests

`tests/php/LiveTerminalEscapeTest.php` pins both helpers off-appliance:
- escaping round-trips back to the exact input and never emits an HTML entity like `&gt;`;
- `</script>`, trailing-backslash, quote/newline, and invalid-UTF-8 cases;
- the sticky guard measures the at-bottom flag **before** the `.value` write and re-pins only under that flag; append vs replace modes.

Full PHP suite, PHPCS, and PHPStan pass. The live streaming/scroll behaviour itself is out-of-CI visual (Tier-B/manual).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live log and status views now update more smoothly, with automatic follow-to-bottom behavior in the terminal area.

* **Bug Fixes**
  * Improved log streaming to avoid broken or partial lines appearing in the UI.
  * Better handling of special characters and long-running output so text displays correctly and safely.

* **Tests**
  * Added coverage for live terminal output behavior, including scrolling, text rendering, and append/replace updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->