### PR TITLE
pfblockerng: resolve DNSBLIP reprocess marker folder from action (#655)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1479,6 +1479,30 @@ function pfb_dnsblip_rebuild_check(string $output, array $ip_files, string $fp_p
 	return array($rebuild, $fp_now);
 }
 
+// Resolve the working folder a DNSBLIP feed lands in from its configured action
+// ($pfb['dnsbl_ip']). This is the SAME action -> folder routing the IP-feed loop applies
+// via pfb_determine_list_detail() (Deny_*/Alias_Deny -> denydir, Alias_Native -> nativedir),
+// so the reprocess marker and the loop's reprocess gate agree on the folder. Returns ''
+// for a non-routable action (e.g. 'Disabled'). (#655)
+function pfb_dnsblip_action_folder($action): string {
+	global $pfbarr;
+	// key 0 + the DNSBL settings section mirror what the IP loop passes for DNSBLIP,
+	// so the force-Native override (Advanced Invert) routes identically here.
+	pfb_determine_list_detail($action, 'DNSBLIP', 'pfblockerngdnsblsettings', 0);
+	return (string) ($pfbarr['folder'] ?? '');
+}
+
+// Write the DNSBLIP '.update' reprocess marker into the folder that matches the feed's
+// configured action, NOT a hardcoded denydir. With $pfb['dnsbl_ip'] = 'Alias_Native' the
+// feed loop looks in nativedir; a denydir marker was never seen there, so a changed
+// Alias_Native DNSBLIP fell into the "exists" branch and was not reprocessed. (#655)
+function pfb_dnsblip_mark_reprocess($action, string $vtype): void {
+	$folder = pfb_dnsblip_action_folder($action);
+	if ($folder !== '') {
+		touch("{$folder}/DNSBLIP{$vtype}.update");
+	}
+}
+
 // v6 stays OPTIONAL (ADR-13 §7 pivot): a missing v6 VIP never fails validation, even when
 // the resolver listens on IPv6 — pfb_global surfaces that as a non-blocking warning, not a
 // force-disable. The validator only checks the VIPs that ARE configured (existence,
@@ -14662,15 +14686,17 @@ function sync_package_pfblockerng($cron='') {
 			}
 			@file_put_contents("{$dnsblip_v4}.fp", $pfb_dnsblip_fp, LOCK_EX);
 			unlink_if_exists($pfb['ip_cache']);
-			touch("{$pfb['denydir']}/DNSBLIP_v4.update");
+			pfb_dnsblip_mark_reprocess($pfb['dnsbl_ip'], '_v4');
 		}
 	}
 
-	// Remove DNSBL IP feed, if disabled
+	// Remove DNSBL IP feed, if disabled. The prior action is unknown here, so clear the
+	// marker/destination from BOTH folders DNSBLIP can land in (denydir + nativedir). (#655)
 	if ($pfb['dnsbl_ip'] == 'Disabled') {
 		unlink_if_exists("{$pfb['dbdir']}/DNSBLIP_v4.txt");
 		unlink_if_exists("{$pfb['dbdir']}/DNSBLIP_v4.txt.fp");
 		unlink_if_exists("{$pfb['denydir']}/DNSBLIP_v4.*");
+		unlink_if_exists("{$pfb['nativedir']}/DNSBLIP_v4.*");
 	}
 
 	// Collect all DNSBL IP feeds (IPv6 only) into DNSBLIP_v6.txt -- gated on the *_v6.ip source
@@ -14705,15 +14731,17 @@ function sync_package_pfblockerng($cron='') {
 			}
 			@file_put_contents("{$dnsblip_v6}.fp", $pfb_dnsblip_fp, LOCK_EX);
 			unlink_if_exists($pfb['ip_cache']);
-			touch("{$pfb['denydir']}/DNSBLIP_v6.update");
+			pfb_dnsblip_mark_reprocess($pfb['dnsbl_ip'], '_v6');
 		}
 	}
 
-	// Remove DNSBL IP feed, if disabled
+	// Remove DNSBL IP feed, if disabled. The prior action is unknown here, so clear the
+	// marker/destination from BOTH folders DNSBLIP can land in (denydir + nativedir). (#655)
 	if ($pfb['dnsbl_ip'] == 'Disabled') {
 		unlink_if_exists("{$pfb['dbdir']}/DNSBLIP_v6.txt");
 		unlink_if_exists("{$pfb['dbdir']}/DNSBLIP_v6.txt.fp");
 		unlink_if_exists("{$pfb['denydir']}/DNSBLIP_v6.*");
+		unlink_if_exists("{$pfb['nativedir']}/DNSBLIP_v6.*");
 	}
 
 	#########################################

--- a/tests/php/DnsblipMarkerFolderTest.php
+++ b/tests/php/DnsblipMarkerFolderTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #655 — the DNSBLIP reprocess '.update' marker must land in the folder that
+ * matches its configured action ($pfb['dnsbl_ip']), not a hardcoded denydir.
+ *
+ * The IP-feed loop resolves the DNSBLIP working folder from the action via
+ * pfb_determine_list_detail() and gates reprocessing on "{folder}/{header}.update".
+ * The Deny actions and Alias_Deny route to denydir; Alias_Native routes to nativedir. The
+ * marker was written to a hardcoded denydir, so for Alias_Native it landed where the loop never
+ * looked → a changed DNSBLIP feed fell into the "exists" branch and was NOT reprocessed.
+ *
+ * Feature: DNSBLIP reprocess-marker folder follows the action
+ *   Background:
+ *     Given the per-action working dirs (deny/native) and a DNSBL settings section with
+ *           no Advanced Invert (so the force-Native override does not fire)
+ *   Branch coverage (both folders + the disabled no-op):
+ *     * Alias Native -> marker in nativedir, NOT denydir  (the #655 bug)
+ *     * Alias Deny / Deny Both -> marker in denydir, NOT nativedir
+ *     * Disabled -> no marker written (unroutable action)
+ */
+#[CoversFunction('pfb_dnsblip_mark_reprocess')]
+#[CoversFunction('pfb_dnsblip_action_folder')]
+final class DnsblipMarkerFolderTest extends TestCase
+{
+	/** @var array<string,array{bool,mixed}> Saved globals to restore. */
+	private array $saved = [];
+
+	private string $denydir;
+	private string $nativedir;
+
+	protected function setUp(): void
+	{
+		foreach (['pfb', 'pfbarr', 'config'] as $g) {
+			$this->saved[$g] = [array_key_exists($g, $GLOBALS), $GLOBALS[$g] ?? null];
+		}
+
+		// Real, isolated temp dirs so we can assert the marker file's actual location.
+		$base = sys_get_temp_dir() . '/pfb_marker_' . uniqid('', TRUE);
+		$this->denydir   = "{$base}/deny";
+		$this->nativedir = "{$base}/native";
+		mkdir($this->denydir, 0o777, TRUE);
+		mkdir($this->nativedir, 0o777, TRUE);
+
+		$GLOBALS['pfb']['denydir']   = $this->denydir;
+		$GLOBALS['pfb']['nativedir'] = $this->nativedir;
+		$GLOBALS['pfb']['origdir']   = "{$base}/orig";
+		$GLOBALS['pfb']['reuse']     = '';
+
+		// Advanced keys present but OFF: autoports/autoaddr block is a no-op AND the
+		// "Invert -> force Native" override (which would mask the routing) does not fire.
+		$off = [];
+		foreach (['autoproto', 'autonot', 'autoaddrnot', 'agateway', 'autoports', 'autoaddr'] as $k) {
+			$off["{$k}_in"]  = '';
+			$off["{$k}_out"] = '';
+		}
+		$GLOBALS['config'] = ['installedpackages' => ['pfblockerngdnsblsettings' => ['config' => [0 => $off]]]];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $g => [$existed, $value]) {
+			if ($existed) {
+				$GLOBALS[$g] = $value;
+			} else {
+				unset($GLOBALS[$g]);
+			}
+		}
+	}
+
+	public function testAliasNativeMarkerLandsInNativeFolderNotDeny(): void
+	{
+		// Given: the marker is absent from both candidate folders
+		$this->assertFileDoesNotExist("{$this->nativedir}/DNSBLIP_v4.update");
+		$this->assertFileDoesNotExist("{$this->denydir}/DNSBLIP_v4.update");
+
+		// When: a changed DNSBLIP_v4 feed whose action is 'Alias Native' is marked
+		pfb_dnsblip_mark_reprocess('Alias_Native', '_v4');
+
+		// Then: the marker lands in nativedir (where the feed loop looks) and NOT in
+		// denydir — the exact mismatch that hid a changed Alias_Native DNSBLIP (#655).
+		$this->assertFileExists("{$this->nativedir}/DNSBLIP_v4.update");
+		$this->assertFileDoesNotExist("{$this->denydir}/DNSBLIP_v4.update");
+	}
+
+	public function testAliasDenyMarkerLandsInDenyFolderNotNative(): void
+	{
+		// When: the action is 'Alias Deny'
+		pfb_dnsblip_mark_reprocess('Alias_Deny', '_v4');
+
+		// Then: denydir gets the marker, nativedir does not — proving the native result
+		// above is a real branch, not a constant.
+		$this->assertFileExists("{$this->denydir}/DNSBLIP_v4.update");
+		$this->assertFileDoesNotExist("{$this->nativedir}/DNSBLIP_v4.update");
+	}
+
+	public function testDenyBothMarkerHonoursV6Suffix(): void
+	{
+		// When: a non-'Alias' Deny action marks the IPv6 feed
+		pfb_dnsblip_mark_reprocess('Deny_Both', '_v6');
+
+		// Then: denydir gets the _v6 marker (vtype propagates), nativedir untouched.
+		$this->assertFileExists("{$this->denydir}/DNSBLIP_v6.update");
+		$this->assertFileDoesNotExist("{$this->nativedir}/DNSBLIP_v6.update");
+	}
+
+	public function testDisabledActionWritesNoMarker(): void
+	{
+		// When: the action is the unroutable 'Disabled'
+		pfb_dnsblip_mark_reprocess('Disabled', '_v4');
+
+		// Then: no marker is written anywhere (folder resolves to '').
+		$this->assertFileDoesNotExist("{$this->denydir}/DNSBLIP_v4.update");
+		$this->assertFileDoesNotExist("{$this->nativedir}/DNSBLIP_v4.update");
+	}
+
+	public function testActionFolderResolvesEachActionClass(): void
+	{
+		// The shared resolver the loop and the marker both rely on.
+		$this->assertSame($this->nativedir, pfb_dnsblip_action_folder('Alias_Native'));
+		$this->assertSame($this->denydir, pfb_dnsblip_action_folder('Alias_Deny'));
+		$this->assertSame($this->denydir, pfb_dnsblip_action_folder('Deny_Both'));
+		$this->assertSame('', pfb_dnsblip_action_folder('Disabled'));
+	}
+}


### PR DESCRIPTION
## Summary

The DNSBLIP `.update` reprocess marker in `sync_package_pfblockerng()` was written to a hardcoded `denydir`:

```php
touch("{$pfb['denydir']}/DNSBLIP_v4.update");   // and _v6
```

But the IP-feed loop resolves the DNSBLIP working folder from its configured action (`$pfb['dnsbl_ip']`) via `pfb_determine_list_detail()` and gates reprocessing on `{$pfbfolder}/{$header}.update`. The DNSBLIP action options include **`Alias_Native`**, which routes to `nativedir`. So for `dnsbl_ip = Alias_Native` the marker landed in `denydir` while the loop looked in `nativedir` → never found → DNSBLIP fell into the "exists" branch and was **not reprocessed even when its content changed**.

`Deny_*` / `Alias_Deny` resolve to `denydir`, so the common case was already correct; only `Alias_Native` was affected. The marker *removal* (line ~16000) already used the action-resolved `$pfbfolder`, so only the *creation* site was wrong.

## Fix

- New helpers `pfb_dnsblip_action_folder()` / `pfb_dnsblip_mark_reprocess()` route the marker through the **same** action → folder resolution the loop uses (`pfb_determine_list_detail`, key `0`, DNSBL settings section — so the force-Native Advanced-Invert override routes identically), so the marker lands where the loop looks.
- The disable-time cleanup now clears the marker/destination from **both** `denydir` and `nativedir`, since the prior action is unknown once `dnsbl_ip == 'Disabled'`.

## Tests

`tests/php/DnsblipMarkerFolderTest.php` pins the marker placement per action class:

- `Alias_Native` → marker in `nativedir`, **not** `denydir` (the bug)
- `Alias_Deny` / `Deny_Both` → marker in `denydir`, **not** `nativedir`
- `Disabled` → no marker written
- shared resolver routing

Verified red→before / green→after: with the marker forced back to a hardcoded `denydir`, `testAliasNativeMarkerLandsInNativeFolderNotDeny` fails; with the fix it passes. Full PHPUnit (1667), PHPStan, and PHPCS are green.

Fixes #655


---
_Generated by [Claude Code](https://claude.ai/code/session_01H37yc4eFbaVST7qHDM3P4G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNSBLIP reprocessing now uses the correct working folder based on the configured action, improving consistency for native, deny, and mixed blocking modes.
  * Rebuilds now trigger follow-up processing more reliably after updating DNSBLIP lists.
  * Disabling DNSBL-IP now removes stale marker and companion files from both working areas, helping prevent leftover artifacts.

* **Tests**
  * Added coverage for DNSBLIP marker placement and action-to-folder handling across supported modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->