### PR TITLE
pfblockerng: validate Advanced In/Out aliases from config, not is_alias() (#636)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1575,6 +1575,48 @@ function pfb_alias_field_type_ok(string $field, string $alias_type): bool
 	return FALSE;
 }
 
+/**
+ * pfb_adv_alias_field_errors — validate the Advanced Inbound/Outbound alias
+ * fields of a category-edit POST (issue #356, #636).
+ *
+ * Each non-empty field must name an EXISTING firewall alias whose type the field
+ * accepts (port fields -> a port alias; address fields -> a network or host alias).
+ *
+ * Existence AND type are resolved from alias_get_type(), which reads the
+ * 'aliases/alias' configuration directly (returning '' for an unknown name) —
+ * the same source the page builds its alias dropdowns/autocomplete from. This
+ * deliberately replaces is_alias(): is_alias() consults the in-memory $aliastable
+ * cache, populated only by alias_make_table() during filter generation, so on the
+ * category-edit page that cache is empty and is_alias() reports every existing
+ * alias as missing — rejecting valid aliases with "Must use an existing Alias" (#636).
+ *
+ * @param  array $post           The submitted form ($_POST).
+ * @return array<int, string>    Human-readable input-error strings (empty when valid).
+ */
+function pfb_adv_alias_field_errors(array $post): array
+{
+	$adv_alias_fields = [
+		'aliasports_in'  => ['dir' => 'Port In',         'type_label' => 'Port-type'],
+		'aliasports_out' => ['dir' => 'Port Out',        'type_label' => 'Port-type'],
+		'aliasaddr_in'   => ['dir' => 'Destination In',  'type_label' => 'Network or Host-type'],
+		'aliasaddr_out'  => ['dir' => 'Source Out',      'type_label' => 'Network or Host-type'],
+	];
+
+	$errors = [];
+	foreach ($adv_alias_fields as $field => $meta) {
+		if (empty($post[$field])) {
+			continue;
+		}
+		$alias_type = alias_get_type($post[$field]);
+		if ($alias_type === '') {
+			$errors[] = "Settings: Advanced {$meta['dir']}bound Alias error - Must use an existing Alias";
+		} elseif (!pfb_alias_field_type_ok($field, $alias_type)) {
+			$errors[] = "Settings: Advanced {$meta['dir']}bound Alias error - Must use a {$meta['type_label']} alias";
+		}
+	}
+	return $errors;
+}
+
 // ---------------------------------------------------------------------------
 // ADR-30 Phase 1 — Pure schedule-period deciders for log rotation.
 //

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -605,23 +605,10 @@ if ($_POST && isset($_POST['save'])) {
 	}
 
 
-	// Validate Adv. firewall rule settings (issue #356: per-field alias-type check).
-	// Port fields require a port-type alias; address fields require a network or host alias.
-	$adv_alias_fields = [
-		'aliasports_in'  => ['dir' => 'Port In',         'type_label' => 'Port-type'],
-		'aliasports_out' => ['dir' => 'Port Out',        'type_label' => 'Port-type'],
-		'aliasaddr_in'   => ['dir' => 'Destination In',  'type_label' => 'Network or Host-type'],
-		'aliasaddr_out'  => ['dir' => 'Source Out',      'type_label' => 'Network or Host-type'],
-	];
-	foreach ($adv_alias_fields as $field => $meta) {
-		if (!empty($_POST[$field])) {
-			if (!is_alias($_POST[$field])) {
-				$input_errors[] = "Settings: Advanced {$meta['dir']}bound Alias error - Must use an existing Alias";
-			} elseif (!pfb_alias_field_type_ok($field, alias_get_type($_POST[$field]))) {
-				$input_errors[] = "Settings: Advanced {$meta['dir']}bound Alias error - Must use a {$meta['type_label']} alias";
-			}
-		}
-	}
+	// Validate Adv. firewall rule settings (issue #356/#636: per-field alias-type check).
+	// Existence + type are resolved from the configuration (alias_get_type), NOT is_alias()
+	// whose $aliastable cache is empty on this page — see pfb_adv_alias_field_errors().
+	$input_errors = array_merge($input_errors, pfb_adv_alias_field_errors($_POST));
 
 	// Validate Adv. firewall rule 'Protocol' setting
 	if (!empty($_POST['autoports_in']) || !empty($_POST['autoaddr_in'])) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -608,7 +608,11 @@ if ($_POST && isset($_POST['save'])) {
 	// Validate Adv. firewall rule settings (issue #356/#636: per-field alias-type check).
 	// Existence + type are resolved from the configuration (alias_get_type), NOT is_alias()
 	// whose $aliastable cache is empty on this page — see pfb_adv_alias_field_errors().
-	$input_errors = array_merge($input_errors, pfb_adv_alias_field_errors($_POST));
+	// Append (not array_merge): $input_errors is left unset until the first error so the
+	// later isset($input_errors) checks hold — appending auto-vivifies only on a real error.
+	foreach (pfb_adv_alias_field_errors($_POST) as $pfb_alias_error) {
+		$input_errors[] = $pfb_alias_error;
+	}
 
 	// Validate Adv. firewall rule 'Protocol' setting
 	if (!empty($_POST['autoports_in']) || !empty($_POST['autoaddr_in'])) {

--- a/tests/php/AdvAliasFieldErrorsTest.php
+++ b/tests/php/AdvAliasFieldErrorsTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_adv_alias_field_errors() (issue #636).
+ *
+ * The category-edit page validates its four Advanced Inbound/Outbound alias
+ * fields (aliasports_in / aliasports_out / aliasaddr_in / aliasaddr_out) by
+ * looking each non-empty value up as a firewall alias and checking its type.
+ *
+ * Existence + type MUST come from alias_get_type() (config-based), NOT
+ * is_alias(): is_alias() reads the in-memory $aliastable cache, which is empty
+ * on the category-edit page (it is only populated during filter generation), so
+ * is_alias() reports every existing alias as missing — rejecting a valid alias
+ * with "Must use an existing Alias" (#636). These tests seed firewall aliases
+ * into the configuration — the source the fixed check reads — and are the
+ * red->green for the fix: against an is_alias()-backed implementation the
+ * "existing alias is accepted" cases fail (the seeded aliases are never written
+ * into $aliastable / $GLOBALS['pfb_test_aliases']).
+ */
+#[CoversFunction('pfb_adv_alias_field_errors')]
+final class AdvAliasFieldErrorsTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		// Belt-and-braces: ensure the is_alias() double's name list is empty, so a
+		// regression to is_alias() would visibly reject the seeded aliases below.
+		$GLOBALS['pfb_test_aliases'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_aliases'] = [];
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Seed firewall aliases into config — the source alias_get_type() reads.
+	 *
+	 * @param array<string, string> $typesByName  name => type ('port'/'network'/'host'/...)
+	 */
+	private function seedAliases(array $typesByName): void
+	{
+		$aliases = [];
+		foreach ($typesByName as $name => $type) {
+			$aliases[] = ['name' => $name, 'type' => $type];
+		}
+		$GLOBALS['config']['aliases']['alias'] = $aliases;
+	}
+
+	// -----------------------------------------------------------------------
+	// Existence oracle — an EXISTING alias of the right type is accepted (the
+	// core #636 regression: is_alias() rejected all of these).
+	// -----------------------------------------------------------------------
+
+	public function testExistingPortAliasInPortFieldIsAccepted(): void
+	{
+		// Given a port alias that exists in the firewall configuration
+		$this->seedAliases(['MyPorts' => 'port']);
+
+		// When it is supplied to a port field
+		$errors = pfb_adv_alias_field_errors(['aliasports_in' => 'MyPorts']);
+
+		// Then the save is allowed (no errors) — under the old is_alias() check this
+		// existing alias was wrongly rejected as non-existent (#636).
+		$this->assertSame([], $errors);
+	}
+
+	public function testExistingNetworkAliasInAddressFieldIsAccepted(): void
+	{
+		// Given a network alias that exists
+		$this->seedAliases(['MyNet' => 'network']);
+
+		// When supplied to an address field
+		$errors = pfb_adv_alias_field_errors(['aliasaddr_out' => 'MyNet']);
+
+		// Then it is accepted
+		$this->assertSame([], $errors);
+	}
+
+	public function testExistingHostAliasInAddressFieldIsAccepted(): void
+	{
+		// Given a host alias (also valid for address fields)
+		$this->seedAliases(['MyHosts' => 'host']);
+
+		$errors = pfb_adv_alias_field_errors(['aliasaddr_in' => 'MyHosts']);
+
+		$this->assertSame([], $errors);
+	}
+
+	// -----------------------------------------------------------------------
+	// Non-existent alias — rejected with "Must use an existing Alias".
+	// -----------------------------------------------------------------------
+
+	public function testNonExistentAliasIsRejectedAsMissing(): void
+	{
+		// Given: before -> the SAME name is accepted while it exists (proves it is the
+		// existence check, not the format/type check, doing the rejecting).
+		$this->seedAliases(['KnownPorts' => 'port']);
+		$this->assertSame([], pfb_adv_alias_field_errors(['aliasports_in' => 'KnownPorts']),
+			'pre-condition: the alias is accepted while it exists');
+
+		// When a name that is NOT a configured alias is supplied (config still seeded)
+		$errors = pfb_adv_alias_field_errors(['aliasports_in' => 'NoSuchAlias']);
+
+		// Then it is rejected as non-existent
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Must use an existing Alias', $errors[0]);
+		$this->assertStringContainsString('Port Inbound', $errors[0]);
+	}
+
+	// -----------------------------------------------------------------------
+	// Wrong-type alias — exists, but the field rejects its type.
+	// -----------------------------------------------------------------------
+
+	public function testNetworkAliasInPortFieldIsRejectedAsWrongType(): void
+	{
+		// Given a network alias that EXISTS (so the existence check passes and the
+		// type check is the one that fires — the #636 page never reached this branch).
+		$this->seedAliases(['NetInPort' => 'network']);
+
+		// When supplied to a port field
+		$errors = pfb_adv_alias_field_errors(['aliasports_in' => 'NetInPort']);
+
+		// Then it is rejected as the wrong type (NOT "Must use an existing Alias")
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Must use a Port-type alias', $errors[0]);
+		$this->assertStringNotContainsString('existing Alias', $errors[0]);
+	}
+
+	public function testPortAliasInAddressFieldIsRejectedAsWrongType(): void
+	{
+		// Given a port alias that EXISTS, supplied to an address field
+		$this->seedAliases(['PortInAddr' => 'port']);
+
+		$errors = pfb_adv_alias_field_errors(['aliasaddr_out' => 'PortInAddr']);
+
+		// Then rejected as the wrong type
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Must use a Network or Host-type alias', $errors[0]);
+	}
+
+	// -----------------------------------------------------------------------
+	// Empty fields are skipped (the feature is optional).
+	// -----------------------------------------------------------------------
+
+	public function testEmptyFieldsProduceNoError(): void
+	{
+		// Given no aliases configured and all four fields empty/absent
+		$errors = pfb_adv_alias_field_errors([
+			'aliasports_in'  => '',
+			'aliasports_out' => '',
+			'aliasaddr_in'   => '',
+			// aliasaddr_out absent entirely
+		]);
+
+		// Then nothing is validated — empty means "no Advanced alias", not an error
+		$this->assertSame([], $errors);
+	}
+
+	// -----------------------------------------------------------------------
+	// Every field is validated independently — each direction reports its own
+	// error (branch coverage across all four fields).
+	// -----------------------------------------------------------------------
+
+	public function testAllFourFieldsAreValidatedIndependently(): void
+	{
+		// Given one valid alias of each kind plus one wrong-type value per field
+		$this->seedAliases([
+			'GoodPorts' => 'port',
+			'GoodNet'   => 'network',
+		]);
+
+		// When: ports_in valid, ports_out wrong-type, addr_in valid, addr_out missing
+		$errors = pfb_adv_alias_field_errors([
+			'aliasports_in'  => 'GoodPorts',   // ok
+			'aliasports_out' => 'GoodNet',     // network in a port field -> wrong type
+			'aliasaddr_in'   => 'GoodNet',     // ok
+			'aliasaddr_out'  => 'Ghost',       // does not exist -> missing
+		]);
+
+		// Then exactly the two invalid fields report, each with its own direction label
+		$this->assertCount(2, $errors);
+		$this->assertStringContainsString('Port Outbound', $errors[0]);
+		$this->assertStringContainsString('Must use a Port-type alias', $errors[0]);
+		$this->assertStringContainsString('Source Outbound', $errors[1]);
+		$this->assertStringContainsString('Must use an existing Alias', $errors[1]);
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -743,6 +743,21 @@ if (!function_exists('is_alias')) {
 	}
 }
 
+if (!function_exists('alias_get_type')) {
+	// pfSense util.inc: return the 'type' of the named firewall alias from the
+	// configuration ('host'/'network'/'port'/'urltable'/...), or '' when no alias
+	// of that name exists. Config-based (reads aliases/alias via config_get_path),
+	// matching the real function — NOT the $aliastable cache that is_alias() uses.
+	function alias_get_type($name) {
+		foreach (config_get_path('aliases/alias', []) as $a) {
+			if (($a['name'] ?? '') === (string) $name) {
+				return (string) ($a['type'] ?? '');
+			}
+		}
+		return '';
+	}
+}
+
 if (!function_exists('get_configured_interface_with_descr')) {
 	// pfSense interfaces.inc: returns a map of interface_name => friendly description.
 	// Off-appliance, use pfb_test_interfaces if seeded; otherwise return an empty map.


### PR DESCRIPTION
Fixes #636.

## Problem

The Advanced Inbound/Outbound alias-type validation (#356) on the IP category-edit page gated each field (`aliasports_in`/`aliasports_out`, `aliasaddr_in`/`aliasaddr_out`) with `is_alias($_POST[$field])`.

`is_alias()` (pfSense `util.inc`) reads only the in-memory `$aliastable` global, populated by `alias_make_table()` during filter generation. `pfblockerng_category_edit.php` never builds `$aliastable`, so it is empty there and `is_alias()` returns FALSE for **every** alias — rejecting even a valid, existing, applied alias with *"Must use an existing Alias"*, and the type-specific check (`pfb_alias_field_type_ok`) was never reached.

The field's dropdown/autocomplete is built from the configuration (`config_get_path('aliases/alias')`), so the page offered aliases the validator could not recognise.

This is the same bug class fixed for the DNS-redirect/DoT exception alias in #664 (commit `95a8510`), and the issue author proposed the same config-based remedy.

## Fix

- Extract the per-field validation loop into `pfb_adv_alias_field_errors()` and resolve existence **and** type from `alias_get_type()` (reads `aliases/alias` directly, returns `''` for an unknown name) instead of `is_alias()` — the same source the page's dropdowns/autocomplete use, correct on this page.
- Add a config-reading `alias_get_type()` test double.
- New `AdvAliasFieldErrorsTest` (PHPUnit): the existence oracle (an existing alias of the right type is accepted — the regression), missing → *"Must use an existing Alias"*, wrong-type → the type error, empty-skip, and all four fields validated independently. Against an `is_alias()`-backed implementation the existence cases fail — the red→green for the fix (verified: 7/8 fail on the old oracle, 8/8 pass on the fix).

Autocomplete is unaffected — it was already sourced from the configuration (`$ports_list`/`$networks_list`).

## Test-harness note

The Tier-B browser test `test_alias_type_port_field_rejects_network_alias` is unblocked by this change: a fresh save POST now reads the applied alias from the configuration rather than the empty `$aliastable`, so the harness's config-coherence concern (an alias on disk being invisible to the immediately-following POST) was a symptom of the `is_alias()` bug. The test is dispatch-only (Tier B), so this leg should be validated by a smoke/UI dispatch.

## Gates

- `vendor/bin/phpunit` — 1675 passed
- `vendor/bin/phpstan analyse` — OK
- `vendor/bin/phpcs --standard=phpcs.xml.dist` — clean
- `php -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H37yc4eFbaVST7qHDM3P4G)_