### PR TITLE
docs: add release notes for v4.0.0.alpha.14

### DIFF
--- a/docs/release-notes/v4.0.0.alpha.14.md
+++ b/docs/release-notes/v4.0.0.alpha.14.md
@@ -1,0 +1,13 @@
+<!-- SUMMARY: Log viewer & aliases -->
+## Bug Fixes
+
+- **The live Update/Upgrade log no longer freezes the navigation menu, and renders output correctly.** The Update and Software pages previously blocked the page while streaming the log, so the top navigation was unresponsive for the whole run and some characters showed escaped (e.g. `&gt;` instead of `>`). The log now streams over a background poll: the page stays fully interactive during a run, characters render correctly, and the viewer keeps your scroll position (following the newest lines only while you are at the bottom). ([#671](https://github.com/pfBlockerNG/pfBlockerNG/issues/671), [#669](https://github.com/pfBlockerNG/pfBlockerNG/issues/669))
+- **Advanced Inbound/Outbound alias fields accept existing aliases again.** On the IP settings and category-edit pages, an existing, applied alias was wrongly rejected with *"Must use an existing Alias"*, and a save could raise a PHP error. Validation now reads the alias list from the configuration, so valid aliases are accepted and mismatched alias types are reported clearly. ([#676](https://github.com/pfBlockerNG/pfBlockerNG/issues/676), [#636](https://github.com/pfBlockerNG/pfBlockerNG/issues/636))
+- **DNSBLIP lists using a Native alias now reprocess when their content changes.** The reprocess marker was written to the wrong working folder for the `Alias_Native` action, so a changed DNSBLIP list was not rebuilt; the marker now follows the configured action. ([#655](https://github.com/pfBlockerNG/pfBlockerNG/issues/655))
+
+## Improvements
+
+- **Software upgrades update in place.** After a successful upgrade the installed-version and status fields refresh without a full page reload, and the upgrade log stays on screen.
+- **DNSBL page layout tidied.** The DNS Redirect and DoT/DoQ Block sections now sit above the DoH/DoT/DoQ Blocking list, and that long provider list renders as a fixed-height, scrollable box instead of expanding to full height.
+
+**Full changelog:** [`v4.0.0.alpha.13` → `v4.0.0.alpha.14`](https://github.com/pfBlockerNG/pfBlockerNG/compare/v4.0.0.alpha.13...v4.0.0.alpha.14)


### PR DESCRIPTION
Adds the hand-authored release notes for `v4.0.0.alpha.14` so the release workflow uses this file as the GitHub Release body (skipping the GitHub Models step).

Covers the user-facing `src/` changes since `v4.0.0.alpha.13`: the AJAX live-log viewer rewrite (nav menu no longer frozen during a run, in-place Software field update, escaping/scroll fixes — #671/#669), the Advanced In/Out alias validation fixes on the IP settings and category-edit pages (#676/#636), the DNSBLIP Native-alias reprocessing fix (#655), and the DNSBL page layout tidy.

Documentation-only — CI is skipped via `paths-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live update/upgrade log streaming so navigation stays responsive and log text displays correctly.
  * Existing Advanced Inbound/Outbound alias values are now accepted more reliably, with clearer validation behavior.
  * DNSBLIP lists are reprocessed when their contents change, and software upgrade status/version details refresh more consistently.
  * Fixed the DNS page layout for cleaner provider list display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->