### PR TITLE
pfblockerng: fix uninstall/reinstall hang on "Removing pfBlockerNG" — suppress hooks during removal (#682)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3523,6 +3523,17 @@ function pfb_hook_script_valid($script, $when, $dir = null) {
 function pfb_run_hooks($when, $ctx = array()) {
 	global $pfb;
 
+	// #682: never run update hooks during a package removal. The pre-deinstall
+	// (pfblockerng_php_pre_deinstall_command) sets $pfb['deinstall'] and drives a DISABLE
+	// teardown, not an update -- firing a user's pre/post hooks while pfBlockerNG is being
+	// uninstalled is semantically wrong, and a hook that (re)starts a service (e.g. the
+	// documented HAProxy graceful reload) would block pkg's "Removing pfBlockerNG..." phase
+	// indefinitely: the spawned/daemonised child holds the operation open (the #662
+	// pipe/daemon class, here under pkg's context). Suppress every fire point on removal.
+	if (!empty($pfb['deinstall'])) {
+		return;
+	}
+
 	$pfbconfig = config_get_path('installedpackages/pfblockerng/config/0', []);
 	$hooks = pfb_get_hooks($pfbconfig, $when);
 	if (empty($hooks)) {
@@ -16901,6 +16912,12 @@ function pfblockerng_php_pre_deinstall_command() {
 
 	// Set these two variables to disable pfBlockerNG on de-install
 	$pfb['save'] = $pfb['install'] = TRUE;
+	// #682: mark this a package-removal pass. pfb_global() already forces enable/dnsbl off for
+	// the install/reinstall flag above, so the sync below runs a clean DISABLE teardown (no feed
+	// download, DNSBL/Unbound disabled) -- but its ADR-12 hook runner would still fire the user's
+	// pre/post hooks. A hook that (re)starts a service during "Removing pfBlockerNG..." hangs the
+	// pkg operation, so hold the hooks back for this pass (pfb_run_hooks checks $pfb['deinstall']).
+	$pfb['deinstall'] = TRUE;
 
 	update_status("Removing pfBlockerNG...");
 	sync_package_pfblockerng();

--- a/tests/php/HookDeinstallSuppressTest.php
+++ b/tests/php/HookDeinstallSuppressTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #682: pfb_run_hooks() must fire NO ADR-12 hooks during a package removal.
+ *
+ * The pre-deinstall (pfblockerng_php_pre_deinstall_command) runs sync_package_pfblockerng()
+ * to DISABLE and tear pfBlockerNG down, but that pass still reached the hook runner -- so a
+ * user's pre/post hook (e.g. a HAProxy graceful reload) fired during "Removing pfBlockerNG...".
+ * A hook that (re)starts a service blocks the pkg operation indefinitely (the #662 pipe/daemon
+ * class, here under pkg's context) -- the reported "stuck on Removing pfBlockerNG" hang. The
+ * fix marks the removal pass with $pfb['deinstall'] and makes pfb_run_hooks() short-circuit on
+ * it, before it ever processes the configured hooks.
+ *
+ * Observable seam (no hook is executed off-appliance): a configured hook whose script is absent
+ * from PFB_HOOK_SCRIPT_DIR makes pfb_run_hooks() log an allow-list "not a valid file; skipping"
+ * line when it PROCESSES the hook. The presence of that line proves the runner reached its
+ * per-hook loop; its ABSENCE proves the deinstall guard returned first. The runner's actual
+ * exec path stays ADR-04 live-smoke territory (see PfbGetHooksTest's note).
+ */
+#[CoversFunction('pfb_run_hooks')]
+final class HookDeinstallSuppressTest extends TestCase
+{
+	private string $logfile = '';
+	private string $errfile = '';
+	/** @var array<string, mixed> snapshot of the $pfb keys this test mutates, restored in tearDown. */
+	private array $pfbSaved = [];
+	private mixed $configSaved = null;
+
+	protected function setUp(): void
+	{
+		global $pfb;
+
+		// Snapshot every global this test touches so no mutation leaks to sibling suites
+		// (a stray unset of e.g. $pfb['runlog'] would break the live-log tail tests).
+		$this->pfbSaved = [
+			'log'           => $pfb['log'] ?? null,
+			'errlog'        => $pfb['errlog'] ?? null,
+			'deinstall'     => $pfb['deinstall'] ?? null,
+			'runlog_active' => $pfb['runlog_active'] ?? null,
+		];
+		$this->configSaved = $GLOBALS['config'] ?? null;
+
+		$this->logfile = tempnam(sys_get_temp_dir(), 'pfb_hooklog_');
+		$this->errfile = tempnam(sys_get_temp_dir(), 'pfb_hookerr_');
+		// pfb_logger() (logtype 2) appends to both of these; seed them so the runner's
+		// "skipping" line has somewhere to land and stays isolated to this test.
+		$pfb['log']    = $this->logfile;
+		$pfb['errlog'] = $this->errfile;
+		// A clean slate: neither a removal pass nor a live per-run mirror (do NOT unset
+		// $pfb['runlog'] itself -- sibling tests read it).
+		unset($pfb['deinstall'], $pfb['runlog_active']);
+
+		// One ENABLED post hook whose script does not exist on this (non-appliance) box, in the
+		// canonical 'row' listtag storage shape pfb_get_hooks() reads.
+		$GLOBALS['config'] = ['installedpackages' => ['pfblockerng' => ['config' => [0 => [
+			'hooks' => ['row' => [
+				['script' => 'hook_post_bogus.sh', 'when' => 'post', 'enabled' => 'on',
+					'description' => 'deinstall-suppress-test'],
+			]],
+		]]]]];
+	}
+
+	protected function tearDown(): void
+	{
+		global $pfb;
+
+		foreach ($this->pfbSaved as $key => $val) {
+			if ($val === null) {
+				unset($pfb[$key]);
+			} else {
+				$pfb[$key] = $val;
+			}
+		}
+		$GLOBALS['config'] = $this->configSaved;
+		@unlink($this->logfile);
+		@unlink($this->errfile);
+	}
+
+	/**
+	 * Baseline (before-state): with NO removal in progress, pfb_run_hooks() PROCESSES the
+	 * configured hook and reaches the script allow-list gate -- proven by the "not a valid file"
+	 * line for its absent script. This is the state the suppression test flips away from.
+	 */
+	public function testEnabledHookIsProcessedWhenNotDeinstalling(): void
+	{
+		pfb_run_hooks('post', ['TRIGGER' => 'cron']);
+
+		$this->assertStringContainsString(
+			'not a valid file',
+			(string) file_get_contents($this->logfile),
+			'baseline: a normal (non-removal) pass must PROCESS the configured hook (reach the script gate)'
+		);
+	}
+
+	/**
+	 * The fix: during a package-removal pass ($pfb['deinstall']), pfb_run_hooks() must return
+	 * immediately and touch NO hook -- so the log stays empty (not even the "skipping" line).
+	 *
+	 * Red -> green: without the guard, the deinstall flag has no effect, the runner still
+	 * processes the hook and logs the "not a valid file" line, so this assertSame('') FAILS.
+	 * With the guard it short-circuits and the log is empty.
+	 */
+	public function testHooksSuppressedDuringDeinstall(): void
+	{
+		global $pfb;
+
+		$pfb['deinstall'] = TRUE;
+		pfb_run_hooks('post', ['TRIGGER' => 'cron']);
+
+		$this->assertSame(
+			'',
+			(string) file_get_contents($this->logfile),
+			'during a deinstall pass pfb_run_hooks() must fire NO hooks and log nothing (#682)'
+		);
+	}
+}


### PR DESCRIPTION
Fixes #682.

## Problem

Uninstalling pfBlockerNG — or reinstalling/upgrading it, since pfSense's package update is a force-reinstall (remove+install) — hangs on the **"Removing pfBlockerNG..."** status and never finishes. It hangs identically on our Software page and on pfSense's own `pkg_mgr_install.php`, confirming the stall is in our deinstall hook, not the page.

## Root cause

`pfblockerng_php_pre_deinstall_command()` calls `sync_package_pfblockerng()` to disable and tear the package down. `pfb_global()` (`:2129`) already sees the install/reinstall flag and forces `enable`/`dnsbl` off, so that pass is a clean **disable** — no feed download, DNSBL/Unbound disabled. But the pass still reached the **ADR-12 hook runner** (`pfb_run_hooks('pre'…)` / `'post'…`), so a user's pre/post hook fired *during package removal*. A hook that (re)starts a service — e.g. the documented HAProxy graceful-reload recipe — blocks the pkg operation indefinitely: the spawned/daemonised child holds it open (the #662 pipe/daemon class, here under pkg's context). That is the hang.

## Fix

Mark the removal pass with `$pfb['deinstall']` in the pre-deinstall and short-circuit `pfb_run_hooks()` on it, before it processes any hook. The disable teardown is unchanged — only the hooks are held back, which is the correct behaviour on removal regardless of the hang.

## Tests

`HookDeinstallSuppressTest` pins it both ways using the runner's own allow-list "skipping" log line as the observable seam (no hook is executed off-appliance):

- a normal pass **processes** the configured hook (reaches the script gate);
- a deinstall pass fires **no** hook and logs nothing.

Verified red→green: without the guard, the deinstall pass still processes the hook and the suppression assertion fails.

Note: this is the ADR-19 §1.6 "deinstall hook is a live wire" surface, so the real acceptance is an on-box uninstall + reinstall that completes without stalling and preserves settings on the keep=on path. Pre-existing in alpha.14, independent of the #680/#671 live-log work (PR #681).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hook actions are now skipped during package removal, preventing pre/post update scripts from running when uninstalling pfBlockerNG.
  * Added coverage to confirm hooks still run normally outside of removal, while staying silent during deinstall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->