### PR TITLE
pfblockerng: stop Run Now from auto-scrolling the Update page

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -549,10 +549,10 @@ events.push(function(){
 		$("html, body").animate({ scrollTop: $(document).height() }, 2000);
 	}
 
-	// Scroll to the bottom on Run Now click
-	$('#run').click(function() {
-		$("html, body").animate({ scrollTop: $(document).height() }, 2000);
-	});
+	// Run Now no longer yanks the whole page to the bottom on click: it reloads into the
+	// AJAX poll tail, which sticky-follows the live log WITHIN the output box on its own.
+	// The old whole-page animate scrolled the pre-reload page (matching neither View nor the
+	// post-reload state) and left the reloaded page scrolled down. Match View: no page scroll.
 
 <?php if ($pfb_poll): ?>
 	// Live-log tail. The page has fully rendered (foot.inc ran, so the nav menu works); the log

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -353,3 +353,46 @@ def test_update_output_is_not_prefilled(
     _open(page, webui, UPDATE_PAGE)
     val = page.locator('textarea[name="pfb_output"]').input_value()
     assert val == "", f"the Update page must not prefill pfb_output on a plain GET, got {val!r}"
+
+
+@pytest.mark.ui_browser
+def test_update_runnow_does_not_scroll_the_page(
+    smoke_vm: SmokeVM,
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """Clicking Run Now must not auto-scroll the whole page to the bottom (matches View).
+
+    Run Now reloads into the AJAX poll tail, which sticky-follows the live log WITHIN the
+    output box. A leftover jQuery handler additionally animated the ENTIRE page to the
+    document bottom on '#run' click (View had no such handler), yanking the page down and
+    leaving the reloaded page scrolled off the top. This pins that the page stays put.
+
+    Fail-before / pass-after: with the old '#run' bottom-animate handler present the window
+    scrolls down after the click; with it removed the offset stays at the top.
+
+    Scenario:
+      Given the Update page loaded at the top and tall enough to scroll,
+      When Run Now is clicked (its form submit suppressed so the on-click page animation is
+           observed in isolation — no real update run is dispatched on the VM),
+      Then the window scroll offset stays at the top (no whole-page auto-scroll).
+    """
+    page = browser_page
+    _open(page, webui, UPDATE_PAGE)
+
+    # Precondition: the page must actually be scrollable, else a no-scroll assertion is vacuous.
+    scrollable = page.evaluate("document.documentElement.scrollHeight > window.innerHeight + 50")
+    assert scrollable, "Update page is not tall enough to scroll — cannot assert no auto-scroll"
+
+    # Suppress the POST navigation so the (old) on-click animation is observed alone and no
+    # real run is dispatched; the click handler under test still fires either way.
+    page.evaluate("document.forms[0].addEventListener('submit', e => e.preventDefault(), true)")
+    assert page.evaluate("window.pageYOffset") == 0, "the page should start at the top"
+
+    page.locator('button[name="run"], #run').first.click()
+    # Bounded wait to prove ABSENCE of the scroll: outlast the old 2000ms animate window so a
+    # regression would have moved the page by the time we read the offset.
+    page.wait_for_timeout(2500)
+
+    offset = page.evaluate("window.pageYOffset")
+    assert offset == 0, f"Run Now must not auto-scroll the page; expected top (0), got pageYOffset={offset}"


### PR DESCRIPTION
## Summary

The Update page bound a jQuery handler that animated the **whole page** to the document bottom on **Run Now** (`#run`) click:

```js
// Scroll to the bottom on Run Now click
$('#run').click(function() {
    $("html, body").animate({ scrollTop: $(document).height() }, 2000);
});
```

Since the live-tail rework (#671), Run Now reloads into the AJAX poll tail, which already sticky-follows the live log **within** the output box. The whole-page animate is therefore vestigial: it scrolls the *pre-reload* page and leaves the reloaded page scrolled off the top. **View** has no such handler, so Run Now and View behaved inconsistently — the reported bug (Run Now auto-scrolls, View doesn't).

## Fix

Remove the `#run` handler so Run Now matches View: the page stays put and the live log still auto-follows inside the output box.

## Tests

Added a Tier B browser test (`tests/smoke/ui/test_browser_misc.py::test_update_runnow_does_not_scroll_the_page`): loads the Update page, asserts it is scrollable, suppresses the form submit so the on-click animation is observed in isolation (no real run dispatched), clicks Run Now, and asserts `window.pageYOffset` stays at the top. Fail-before/pass-after: with the old handler present the page scrolls down; with it removed the offset stays 0.

Scroll behaviour is only observable in a real browser, so this is Tier B (schedule/dispatch); no Tier A render change (the PHP output/markers are unchanged, `php -l` clean).


---
_Generated by [Claude Code](https://claude.ai/code/session_01H37yc4eFbaVST7qHDM3P4G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Run Now” experience so the page no longer jumps or scrolls to the bottom unexpectedly.
  * Live log updates now stay focused in the output area, with auto-scrolling only when you’re already viewing the latest output.

* **Tests**
  * Added browser coverage to confirm the Update page does not auto-scroll the whole page after clicking “Run Now”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->