### PR TITLE
pfblockerng: TTL-gate the uninstall-intent marker; add gateway tests for pfb_keep_on_upgrade (CodeRabbit #688)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7931,6 +7931,22 @@ function pfb_full_uninstall_marker_file(): string {
 }
 
 
+// #688 (CodeRabbit): honour the uninstall-intent marker only while FRESH. The Software-page
+// Uninstall drops it immediately before redirecting to the Package Manager confirm, so a genuine
+// removal consumes it within seconds. But an admin who clicks Uninstall then CANCELS the confirm
+// WITHOUT reopening the Software page would otherwise leave the marker until the next pre-deinstall
+// -- possibly an unrelated, much-later version/OS upgrade -- wrongly forcing a full teardown (and
+// wiping settings) even with "Keep enabled during version upgrades" on. Gate on filemtime within a
+// short TTL so a stale marker can never poison a later upgrade. $mtime is @filemtime()'s result
+// (int, or FALSE when the marker is absent).
+if (!defined('PFB_FULL_UNINSTALL_TTL')) {
+	define('PFB_FULL_UNINSTALL_TTL', 300);	// seconds — a genuine uninstall consumes the marker in seconds
+}
+function pfb_full_uninstall_intent(int|false $mtime, int $now): bool {
+	return ($mtime !== FALSE) && ($mtime >= ($now - PFB_FULL_UNINSTALL_TTL));
+}
+
+
 // #687: decide whether the pre-deinstall performs a FULL teardown (turn pfBlockerNG OFF + remove
 // live objects) or SKIPS it to keep pfBlockerNG active across a version/OS upgrade. Pure decision,
 // no I/O -- pfSense cannot distinguish an upgrade from a real uninstall in the pre-deinstall, so the
@@ -16968,11 +16984,13 @@ function pfblockerng_php_pre_deinstall_command() {
 	// #687: decide whether to fully tear pfBlockerNG down, or keep it live across a version/OS
 	// upgrade. pfSense cannot tell an upgrade from a real uninstall here, so the user's settings
 	// decide (no upgrade-detection). Consume the Software-page "Uninstall" intent marker here so it
-	// never lingers, then apply the pure decision ladder.
+	// never lingers, and honour it only while FRESH (#688) so an abandoned/cancelled uninstall
+	// cannot force a full teardown on a much-later, unrelated upgrade. Then apply the pure ladder.
 	$keep_settings   = (PfbConfig::read('pfb_keep') === PfbLenient::On);
 	$keep_on_upgrade = (PfbConfig::read('pfb_keep_on_upgrade') === PfbLenient::On);
-	$intentional     = @file_exists(pfb_full_uninstall_marker_file());
-	@unlink(pfb_full_uninstall_marker_file());
+	$pfb_marker      = pfb_full_uninstall_marker_file();
+	$intentional     = pfb_full_uninstall_intent(@filemtime($pfb_marker), time());
+	@unlink($pfb_marker);
 
 	if (!pfb_deinstall_full_teardown($keep_settings, $keep_on_upgrade, $intentional)) {
 		// Keep pfBlockerNG active across the upgrade: run NO disable pass and NO teardown, so its

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -251,6 +251,53 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('off', config_get_path($path), "write(read(''))==off for pfb_keep");
 	}
 
+	/**
+	 * pfb_keep_on_upgrade (lenient adapter, #687): 'on'/'off'/'' round-trip; legacy '' -> 'off'.
+	 * Lenient like pfb_keep so the absent-default 'on' (new install) is distinguishable from an
+	 * explicit 'off' (existing install grandfather-seeded at upgrade, or an operator opt-out).
+	 */
+	public function testPfbKeepOnUpgradeLenientRoundTripOn(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_keep_on_upgrade';
+
+		$this->seedConfig($path, 'on');
+		$this->assertSame('on', config_get_path($path), 'before: pfb_keep_on_upgrade seed is on');
+
+		$enum = PfbConfig::read('pfb_keep_on_upgrade');
+		$this->assertSame(PfbLenient::On, $enum, "read: pfb_keep_on_upgrade 'on' -> PfbLenient::On");
+
+		PfbConfig::write('pfb_keep_on_upgrade', $enum);
+		$this->assertSame('on', config_get_path($path), "write(read('on'))==on for pfb_keep_on_upgrade");
+	}
+
+	public function testPfbKeepOnUpgradeLenientRoundTripOff(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_keep_on_upgrade';
+
+		$this->seedConfig($path, 'off');
+		$this->assertSame('off', config_get_path($path), 'before: pfb_keep_on_upgrade seed is off');
+
+		$enum = PfbConfig::read('pfb_keep_on_upgrade');
+		$this->assertSame(PfbLenient::Off, $enum, "read: pfb_keep_on_upgrade 'off' -> PfbLenient::Off");
+
+		PfbConfig::write('pfb_keep_on_upgrade', $enum);
+		$this->assertSame('off', config_get_path($path), "write(read('off'))==off for pfb_keep_on_upgrade");
+	}
+
+	public function testPfbKeepOnUpgradeLenientLegacyEmptyNormalisesToOff(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_keep_on_upgrade';
+
+		$this->seedConfig($path, '');
+		$this->assertSame('', config_get_path($path), 'before: pfb_keep_on_upgrade seed is empty string');
+
+		$enum = PfbConfig::read('pfb_keep_on_upgrade');
+		$this->assertSame(PfbLenient::Off, $enum, "read: pfb_keep_on_upgrade '' -> PfbLenient::Off (legacy)");
+
+		PfbConfig::write('pfb_keep_on_upgrade', $enum);
+		$this->assertSame('off', config_get_path($path), "write(read(''))==off for pfb_keep_on_upgrade");
+	}
+
 	// -----------------------------------------------------------------------
 	// B — Default on absent key
 	// -----------------------------------------------------------------------
@@ -286,6 +333,17 @@ final class CfgGatewayTest extends TestCase
 
 		// Then: returns On (the registered default 'on', applied through lenient adapter).
 		$this->assertSame(PfbLenient::On, $result, 'pfb_keep absent -> PfbLenient::On (default on)');
+	}
+
+	public function testReadReturnsRegisteredDefaultForPfbKeepOnUpgradeAbsentKey(): void
+	{
+		// #687: pfb_keep_on_upgrade default is 'on' (the NEW-install default — stay active across
+		// upgrades). Absent key -> PfbLenient::On through the lenient adapter. (An existing install is
+		// grandfather-seeded to 'off' at upgrade, so the key is only ever absent on a brand-new one.)
+		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_keep_on_upgrade'));
+
+		$result = PfbConfig::read('pfb_keep_on_upgrade');
+		$this->assertSame(PfbLenient::On, $result, 'pfb_keep_on_upgrade absent -> PfbLenient::On (default on)');
 	}
 
 	public function testReadReturnsRegisteredDefaultForLenientAbsentKey(): void

--- a/tests/php/DeinstallTeardownDecisionTest.php
+++ b/tests/php/DeinstallTeardownDecisionTest.php
@@ -21,8 +21,40 @@ use PHPUnit\Framework\TestCase;
  * Only keep-on + toggle-on + no-marker skips teardown. Every branch is asserted below.
  */
 #[CoversFunction('pfb_deinstall_full_teardown')]
+#[CoversFunction('pfb_full_uninstall_intent')]
 final class DeinstallTeardownDecisionTest extends TestCase
 {
+	public function testFreshMarkerIsHonouredAsIntent(): void
+	{
+		// A marker written moments ago (well within the TTL) => the removal is a real uninstall.
+		$now = 1_000_000;
+		$this->assertTrue(pfb_full_uninstall_intent($now - 5, $now), 'a fresh marker signals an intentional uninstall');
+	}
+
+	public function testStaleMarkerIsIgnored(): void
+	{
+		// A marker older than the TTL (an abandoned/cancelled uninstall) must NOT force a teardown on
+		// a much-later, unrelated upgrade (#688).
+		$now = 1_000_000;
+		$this->assertFalse(
+			pfb_full_uninstall_intent($now - (PFB_FULL_UNINSTALL_TTL + 1), $now),
+			'a marker older than the TTL is stale and must be ignored'
+		);
+	}
+
+	public function testAbsentMarkerIsNotIntent(): void
+	{
+		// @filemtime() returns FALSE when the marker file does not exist => not an intentional uninstall.
+		$this->assertFalse(pfb_full_uninstall_intent(false, 1_000_000));
+	}
+
+	public function testMarkerExactlyAtTtlBoundaryIsHonoured(): void
+	{
+		// The boundary is inclusive (>=): a marker exactly TTL seconds old still counts as fresh.
+		$now = 1_000_000;
+		$this->assertTrue(pfb_full_uninstall_intent($now - PFB_FULL_UNINSTALL_TTL, $now));
+	}
+
 	public function testKeepSettingsOffAlwaysTearsDown(): void
 	{
 		// keep=off => cleanup is mandatory regardless of the toggle or the marker.


### PR DESCRIPTION
Follow-up to #688 — two CodeRabbit findings that posted just after it merged.

## 1. Stale uninstall-intent marker (Major — data-loss risk)

The Software-page Uninstall drops `/var/run/pfb_full_uninstall`, cleared only by the next pre-deinstall consumption or a Software-page revisit. If an admin clicks **Uninstall**, then **cancels** the confirm on `pkg_mgr_install.php` and never reopens the Software page, the marker persists until the *next* pre-deinstall — which could be an **unrelated later version/OS upgrade**. `pfb_deinstall_full_teardown()` would then see `$intentional = TRUE` and force a full teardown (wiping settings/data) during what the operator intended as a keep-alive upgrade, even with "Keep enabled during version upgrades" on.

Fix: honour the marker only while **fresh**. New pure `pfb_full_uninstall_intent(@filemtime(), time())` gated on a 300s TTL (`PFB_FULL_UNINSTALL_TTL`) — a genuine uninstall consumes it within seconds, so a stale marker can never poison a much-later upgrade. The marker is still consumed (`unlink`) immediately.

## 2. Missing config-gateway coverage for `pfb_keep_on_upgrade` (Major)

`CfgGatewayTest` had round-trip + absent-default tests for `pfb_keep` but none for the new `pfb_keep_on_upgrade` — the round-trip test CLAUDE.md requires for a new registered field. Added them: `on`/`off`/`''` round-trip and absent → default `on`.

## Tests

- `pfb_full_uninstall_intent` branch coverage (fresh / stale / absent / TTL-boundary) in `DeinstallTeardownDecisionTest`.
- `pfb_keep_on_upgrade` round-trip + absent-default in `CfgGatewayTest`.

Off-box gates green (PHPUnit 1705, PHPStan, PHPCS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_