### PR TITLE
pfblockerng: stream lifecycle progress to stdout so the pkg Software page isn't silent (#690)

### DIFF
--- a/docs/misc/external-process-waits.md
+++ b/docs/misc/external-process-waits.md
@@ -70,6 +70,24 @@ cmd > /tmp/somefile 2>&1 < /dev/null
 A spawned daemon then holds a harmless regular-file fd, and the capture returns the moment the
 direct command exits. Read the output back from the file.
 
+## Package-page visibility is the mirror image: stream to stdout, not just the log file
+
+The same fd that a stray daemon must *not* hold is the one the pfSense **Software page reads** to
+show install/upgrade/uninstall progress: **stdout**. Once the Update/Uninstall buttons delegate to
+pfSense's native `pkg_mgr_install.php`, that page shows only what the package operation writes to
+stdout. But `pfb_logger()` writes the whole sync pass to the **log file** (and, during a Run Now,
+the per-run log the Update page's AJAX viewer tails) — never stdout. So the delegated page sits
+**silent** through the (longstanding) disable/enable passes — worst case the up-to-30 s
+`pfb_stop_start_unbound()` wait — and looks like a frozen/lost pipe even though nothing is stuck
+(issue #690). This is a **visibility** gap, distinct from the fd-hold hang above.
+
+Fix: while a package lifecycle callback is active — `$pfb['hook_lifecycle']` is set by the install
+command (`'install'`) and the pre-deinstall (`'uninstall'`), unset on every normal
+cron/manual/Run-Now pass — `pfb_logger()` also **mirrors its main-log lines (cases 1/2) to stdout**,
+so the page streams live progress. The unbound-stop wait logs its keepalive dots through the same
+path, so that closes the silent gap too. Visibility only: the fd-detach, `--foreground`, and
+redirect safety above are untouched.
+
 ## Following one specific dispatched process — pidfile, not a `ps` pattern or a log string
 
 - **`mwexec_bg()` returns no PID** — only the launcher's status. You cannot wait on what you

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2784,6 +2784,21 @@ function pfb_logger($log, $logtype) {
 		default:
 			break;
 	}
+
+	// #690: a package install/upgrade/uninstall runs its work synchronously inside the pkg
+	// lifecycle callbacks, but pfSense's native Software page (and the pkg CLI) show only what
+	// reaches STDOUT. pfb_logger() otherwise writes the whole sync pass to the log FILE, so the
+	// page sits silent through it -- worst case the ~30s pfb_stop_start_unbound() wait, which
+	// emits its progress dots through this same function -- and looks like a frozen/lost pipe.
+	// While a lifecycle callback is active ($pfb['hook_lifecycle'] is set by the install command
+	// and the pre-deinstall, unset on every normal cron/manual/Run-Now pass and in the log
+	// daemon), mirror the main-log lines (cases 1 and 2) to the package-manager output so the
+	// page streams live progress. This also closes the silent unbound-stop gap with no separate
+	// keepalive, since that wait already logs via case 1. The redirected update hooks and the
+	// detached rc.d daemons are untouched -- this is visibility only, not the process-safety.
+	if (($logtype == 1 || $logtype == 2) && !empty($pfb['hook_lifecycle'])) {
+		print "{$log}";
+	}
 }
 
 

--- a/tests/php/LiveLogPkgMirrorTest.php
+++ b/tests/php/LiveLogPkgMirrorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #690: during a package install/upgrade/uninstall, pfSense's native Software page shows
+ * only what the operation writes to STDOUT. pfb_logger() normally writes the whole sync pass to
+ * the log FILE, so the delegated page sits silent and looks like a frozen/lost pipe.
+ *
+ * pfb_logger() now mirrors its main-log output (cases 1 and 2) to STDOUT while a package lifecycle
+ * callback is active -- $pfb['hook_lifecycle'] is set by the install command ('install') and the
+ * pre-deinstall ('uninstall'), and unset on every normal cron/manual/Run-Now pass and in the log
+ * daemon. The mirror is visibility only: it does not touch the file writes, the redirected update
+ * hooks, or the detached rc.d daemons.
+ *
+ * Branch coverage: lifecycle-active (mirror) vs no-lifecycle (silent) for the SAME call, plus the
+ * non-progress case (3) staying unmirrored even inside a lifecycle callback.
+ */
+#[CoversFunction('pfb_logger')]
+final class LiveLogPkgMirrorTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		global $pfb;
+		// Known-writable log file; no active per-run log (that path is the Update viewer's, not
+		// the pkg page's). Start from a clean lifecycle marker so each test sets its own.
+		@mkdir($pfb['logdir'], 0777, TRUE);
+		@file_put_contents($pfb['log'], '');
+		unset($pfb['runlog_active'], $pfb['hook_lifecycle']);
+	}
+
+	protected function tearDown(): void
+	{
+		global $pfb;
+		// Never leak the lifecycle marker into a sibling test -- it would silently turn the
+		// STDOUT mirror on for an unrelated pfb_logger() assertion.
+		unset($pfb['hook_lifecycle']);
+	}
+
+	private function capture(string $msg, int $logtype): string
+	{
+		ob_start();
+		pfb_logger($msg, $logtype);
+		return (string) ob_get_clean();
+	}
+
+	public function testMainLogMirrorsToStdoutDuringAPackageLifecycleCallback(): void
+	{
+		global $pfb;
+		// Given a package install/upgrade is running (the install command set 'install')...
+		$pfb['hook_lifecycle'] = 'install';
+
+		// When pfBlockerNG logs a progress line...
+		$out = $this->capture("Removing pfBlockerNG...", 1);
+
+		// Then it reaches the package-manager output so the page streams it, AND the log file
+		// still receives it (visibility is additive, not a redirect).
+		$this->assertSame('Removing pfBlockerNG...', $out, 'progress must stream to STDOUT during a lifecycle callback');
+		$this->assertStringContainsString('Removing pfBlockerNG...', (string) @file_get_contents($pfb['log']));
+	}
+
+	public function testMainLogStaysSilentOnStdoutWithoutALifecycleCallback(): void
+	{
+		global $pfb;
+		// Given a normal cron/manual/Run-Now pass (no lifecycle marker) -- the pre-#690 behaviour...
+		unset($pfb['hook_lifecycle']);
+
+		// When the SAME progress line is logged...
+		$out = $this->capture("Removing pfBlockerNG...", 1);
+
+		// Then nothing is printed (a normal pass must not spew onto whatever is reading STDOUT),
+		// but the file write is unchanged.
+		$this->assertSame('', $out, 'a non-lifecycle pass must not mirror to STDOUT');
+		$this->assertStringContainsString('Removing pfBlockerNG...', (string) @file_get_contents($pfb['log']));
+	}
+
+	public function testErrorLogCaseAlsoMirrorsDuringALifecycleCallback(): void
+	{
+		global $pfb;
+		// case 2 (pfBlockerNG log + error log) is a progress line too -> mirrored.
+		$pfb['hook_lifecycle'] = 'uninstall';
+		$this->assertSame('a warning', $this->capture('a warning', 2));
+	}
+
+	public function testUnboundStopWaitDotsStreamDuringALifecycleCallback(): void
+	{
+		global $pfb;
+		// The up-to-30s pfb_stop_start_unbound() wait emits its keepalive dots via case 1, so the
+		// same mirror closes that silent gap with no separate keepalive path.
+		$pfb['hook_lifecycle'] = 'install';
+		$this->assertSame('.', $this->capture('.', 1));
+	}
+
+	public function testNonProgressCaseIsNotMirroredEvenInALifecycleCallback(): void
+	{
+		global $pfb;
+		// case 3 is the Extras log (a side channel), not the install/upgrade progress -- it must
+		// NOT leak onto the package page even while a lifecycle callback is active.
+		$pfb['hook_lifecycle'] = 'install';
+		$this->assertSame('', $this->capture('extras-only detail', 3));
+	}
+}


### PR DESCRIPTION
Fixes #690.

## Problem

Now that the Software page delegates Update/Uninstall to pfSense's native `pkg_mgr_install.php`, an install/upgrade/uninstall looks like it "loses the pipe": the page sits silent for long stretches while pfBlockerNG is actually working.

The pfSense package page shows only what the operation writes to **stdout**. pfBlockerNG's lifecycle callbacks (`pfblockerng_install.inc`, the resync, and `pfblockerng_php_pre_deinstall_command()`) run a full `sync_package_pfblockerng()` pass and log through `pfb_logger()`, which writes to the **log file** — and, during a Run Now, the per-run log the Update page's AJAX viewer tails — but **never stdout**. During a pkg callback the per-run log isn't active either, so the output lands only in the cumulative log. Worst case is `pfb_stop_start_unbound()`, which can block ~30 s in a `sleep(1)` wait emitting `pfb_logger('.')` once per second — all to the file — so the page is silent for that whole window.

This is a **visibility** gap, not a stuck pipe. Verified the process-safety around package operations is correct and stays unchanged: the rc.d daemons detach their std fds (#662), unbound self-detaches when it daemonizes, and update hooks run under `timeout --foreground` with output redirected to a file. Previously the silence was hidden because the package drove its own in-page AJAX viewer tailing the run-log file; delegating to pfSense's stdout page exposes it.

## Change

While a package lifecycle callback is active — `$pfb['hook_lifecycle']` is set to `'install'` by the install command and `'uninstall'` by the pre-deinstall, and unset on every normal cron/manual/Run-Now pass and in the log daemon — `pfb_logger()` mirrors its main-log lines (cases 1 and 2) to stdout, so pfSense's Software/upgrade page streams live progress. Because the unbound-stop wait already emits its keepalive dots through `pfb_logger()`, the same mirror removes the silent ~30 s gap with no separate keepalive path.

No change to the fd-detach / `--foreground` / redirect / pidfile machinery — this is visibility only.

## Tests

`LiveLogPkgMirrorTest` pins the mirror **on** (lifecycle active, cases 1/2, incl. the unbound-wait dots), **off** (no lifecycle marker — the pre-#690 behaviour), and the non-progress case (3) staying **unmirrored** even inside a callback. Fails on the pre-change `pfb_logger()` (nothing printed), passes after. Full PHPUnit suite green (1710), php -l / PHPStan / PHPCS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package install, upgrade, and uninstall progress now stays visible on the pfSense Package page and CLI during long-running actions.
  * Progress updates and wait indicators are now shown more consistently, reducing the appearance of a frozen or silent process.

* **Documentation**
  * Added notes explaining when package progress may appear delayed and what behavior is expected during lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->