### PR TITLE
docs: add release notes for v4.0.0.alpha.17

### DIFF
--- a/docs/release-notes/v4.0.0.alpha.17.md
+++ b/docs/release-notes/v4.0.0.alpha.17.md
@@ -1,0 +1,7 @@
+<!-- SUMMARY: Live install progress -->
+
+## Improvements
+
+- The Software page's Install, Update and Uninstall now stream pfBlockerNG's progress live. pfSense delegates these operations to its native package manager page, which shows only what the package writes to stdout; pfBlockerNG's lifecycle work previously logged only to its own log file, so the page sat silent through the whole pass — including the up-to-30-second wait while the DNS Resolver restarts — and could look frozen. Progress lines (and the resolver-restart keepalive) are now mirrored to the page so it stays responsive ([#690](https://github.com/pfBlockerNG/pfBlockerNG/issues/690)).
+
+[Full changelog](https://github.com/pfBlockerNG/pfBlockerNG/compare/v4.0.0.alpha.16...v4.0.0.alpha.17)


### PR DESCRIPTION
Release notes for `v4.0.0.alpha.17`, to land on `devel` before the tag is cut so the release workflow uses them as the release body (and skips the GitHub Models step).

Docs-only — CI-skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H37yc4eFbaVST7qHDM3P4G)_