### PR TITLE
pfblockerng: show update-hook output on the pkg Software page during install/upgrade (#693)

### DIFF
--- a/docs/misc/external-process-waits.md
+++ b/docs/misc/external-process-waits.md
@@ -88,6 +88,14 @@ so the page streams live progress. The unbound-stop wait logs its keepalive dots
 path, so that closes the silent gap too. Visibility only: the fd-detach, `--foreground`, and
 redirect safety above are untouched.
 
+An **update hook's own** stdout/stderr needs the same treatment, but it can't just be printed live:
+the hook body is redirected to the log file precisely so a daemon it starts can't hold the capture
+pipe (above), so mirroring it with a `tee`/pipe would reintroduce the hang. Instead `pfb_run_hooks()`
+records the log offset before `exec()` and, after the hook returns, `pfb_mirror_hook_output()` reads
+back exactly the bytes the hook appended and prints them (during a lifecycle callback only). A plain
+file read can't hang — the daemon holds a harmless file fd, not the reader — so the page shows the
+`[ pfB Hook ] …` markers *and* the hook's real output between them (issue #693).
+
 ## Following one specific dispatched process — pidfile, not a `ps` pattern or a log string
 
 - **`mwexec_bg()` returns no PID** — only the launcher's status. You cannot wait on what you

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3546,6 +3546,41 @@ function pfb_hook_lifecycle_ctx($lifecycle): array {
 }
 
 /*
+ * #693 (follow-up to #690): mirror a completed hook's captured stdout/stderr to the
+ * package-manager output during a pkg install/upgrade/uninstall.
+ *
+ * pfb_run_hooks() redirects each hook's stdout+stderr to a LOG FILE, never a pipe, so a hook that
+ * (re)starts a daemon -- e.g. the documented HAProxy graceful reload -- cannot hold exec()'s
+ * capture pipe open and hang the pass (#662). The cost: the hook's own output then lands only in
+ * that file, so pfSense's Software page (which shows only STDOUT) frames the hook with its
+ * "[ pfB Hook ] ..." markers but shows an empty body. While a lifecycle callback is active
+ * ($pfb['hook_lifecycle'], set by the install command / pre-deinstall), print exactly the bytes
+ * the hook just appended ($logfile from $offset to EOF) so the page shows what it did.
+ *
+ * The bytes are ALREADY in the log file (the shell append), so this only prints -- it never
+ * re-logs. Reading a regular file cannot hang: a lingering daemon holds a harmless file fd, not
+ * this reader. No-op outside a lifecycle callback (a normal cron/manual/Run-Now pass already
+ * streams the hook body to the per-run log the Update-page tail reads).
+ */
+function pfb_mirror_hook_output(string $logfile, int $offset): void {
+	global $pfb;
+
+	if (empty($pfb['hook_lifecycle']) || $logfile === '') {
+		return;
+	}
+	clearstatcache(TRUE, $logfile);
+	$end = @filesize($logfile);
+	if ($end === FALSE || $end <= $offset) {
+		return;
+	}
+	$body = @file_get_contents($logfile, FALSE, NULL, $offset, $end - $offset);
+	if (is_string($body) && $body !== '') {
+		print $body;
+	}
+}
+
+
+/*
  * Run every enabled hook matching $when, in list order, as root.
  *
  * $ctx is a flat name => value map exported to each hook as PFB_* environment
@@ -3648,13 +3683,25 @@ function pfb_run_hooks($when, $ctx = array()) {
 		// "[ pfB Hook ] ..." markers interleave and stream AS the hook runs); outside a run it falls
 		// back to the cumulative log. (A rare lingering daemon could append a stray line later --
 		// cosmetic.)
-		$logf = escapeshellarg(pfb_run_log_target());
+		$logtarget = pfb_run_log_target();
+		$logf = escapeshellarg($logtarget);
 		$cmd = "{$envprefix} /usr/bin/timeout --foreground -s TERM -k " . PFB_HOOK_KILL_GRACE .
 			" {$timeout} " . escapeshellarg($path) . " >> {$logf} 2>&1 < /dev/null";
+
+		// #693: the hook's own stdout/stderr goes to the log FILE above (never a pipe -- a hook
+		// that restarts a daemon would otherwise hang exec(), #662), so on the pkg Software page
+		// only the surrounding pfb_logger() markers show and the hook body is invisible. Record
+		// where the log ends BEFORE the hook runs so we can mirror exactly what it appends.
+		clearstatcache(TRUE, $logtarget);
+		$hook_log_offset = (int) (@filesize($logtarget) ?: 0);
 
 		$discard = array();
 		$retval  = 0;
 		exec($cmd, $discard, $retval);
+
+		// #693: during a pkg install/upgrade/uninstall (lifecycle callback), stream the hook's
+		// captured output to the package-manager output so the admin sees what it actually did.
+		pfb_mirror_hook_output($logtarget, $hook_log_offset);
 
 		if ($retval === 124) {
 			pfb_logger("[ pfB Hook ] {$when} {$label} TIMED OUT after {$timeout}s (killed); continuing\n", 2);

--- a/tests/php/PfbHookOutputMirrorTest.php
+++ b/tests/php/PfbHookOutputMirrorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #693 (follow-up to #690): pfb_run_hooks() redirects each hook's stdout/stderr to a LOG
+ * FILE (never a pipe, so a daemon-restarting hook can't hang the pass -- #662). The cost is that
+ * during a package install/upgrade/uninstall pfSense's Software page -- which shows only STDOUT --
+ * frames the hook with its markers but shows an empty body.
+ *
+ * pfb_mirror_hook_output() closes that gap: while a pkg lifecycle callback is active
+ * ($pfb['hook_lifecycle']), it prints exactly the bytes the hook appended to the log (from the
+ * pre-exec offset to EOF). The bytes are already in the file, so it only prints -- never re-logs --
+ * and a plain file read cannot hang the pass.
+ *
+ * Branch coverage: lifecycle active (mirror the delta) vs inactive (silent) for the SAME appended
+ * bytes, plus the no-new-bytes and empty-path guards.
+ */
+#[CoversFunction('pfb_mirror_hook_output')]
+final class PfbHookOutputMirrorTest extends TestCase
+{
+	private string $logfile = '';
+
+	protected function setUp(): void
+	{
+		global $pfb;
+		$this->logfile = (string) tempnam(sys_get_temp_dir(), 'pfb_hook_mirror_');
+		unset($pfb['hook_lifecycle']);
+	}
+
+	protected function tearDown(): void
+	{
+		global $pfb;
+		if ($this->logfile !== '') {
+			@unlink($this->logfile);
+		}
+		unset($pfb['hook_lifecycle']);
+	}
+
+	/** Write the "framing marker" already there before the hook runs, then return the pre-exec offset. */
+	private function seedAndOffset(string $preamble): int
+	{
+		@file_put_contents($this->logfile, $preamble);
+		clearstatcache(TRUE, $this->logfile);
+		return (int) filesize($this->logfile);
+	}
+
+	private function capture(int $offset): string
+	{
+		ob_start();
+		pfb_mirror_hook_output($this->logfile, $offset);
+		return (string) ob_get_clean();
+	}
+
+	public function testMirrorsOnlyTheHookBodyDeltaDuringALifecycleCallback(): void
+	{
+		global $pfb;
+		// Given the header marker is already logged (offset), a hook then appends its own output...
+		$offset = $this->seedAndOffset("[ pfB Hook ] post haproxy (hook_post_haproxy.sh)\n");
+		@file_put_contents($this->logfile, "Firing up HAProxy ACL update hook\nReloading HAProxy\n", FILE_APPEND);
+
+		// When a package lifecycle callback is active...
+		$pfb['hook_lifecycle'] = 'install';
+
+		// Then exactly the appended body (not the pre-existing header) reaches STDOUT.
+		$this->assertSame("Firing up HAProxy ACL update hook\nReloading HAProxy\n", $this->capture($offset));
+	}
+
+	public function testStaysSilentWithoutALifecycleCallback(): void
+	{
+		// The pre-#693 behaviour: a normal cron/manual/Run-Now pass (no lifecycle marker) does NOT
+		// print the hook body to STDOUT -- the Update-page tail already reads it from the file.
+		$offset = $this->seedAndOffset("header\n");
+		@file_put_contents($this->logfile, "hook body\n", FILE_APPEND);
+
+		$this->assertSame('', $this->capture($offset));
+	}
+
+	public function testPrintsNothingWhenTheHookAppendedNoOutput(): void
+	{
+		global $pfb;
+		// A silent hook (offset == EOF) yields no output even inside a lifecycle callback.
+		$pfb['hook_lifecycle'] = 'uninstall';
+		$offset = $this->seedAndOffset("header only\n");
+
+		$this->assertSame('', $this->capture($offset));
+	}
+
+	public function testEmptyLogPathIsANoOp(): void
+	{
+		global $pfb;
+		$pfb['hook_lifecycle'] = 'install';
+		ob_start();
+		pfb_mirror_hook_output('', 0);
+		$this->assertSame('', (string) ob_get_clean());
+	}
+}


### PR DESCRIPTION
Fixes #693. Follow-up to #690.

## Problem

After #690 the pfSense Software/upgrade page shows pfBlockerNG's own log lines during a package lifecycle callback, including the `[ pfB Hook ] … ` markers around each update hook. But the hook's **own stdout/stderr** was still missing — the page showed the before/after markers with an empty body between them, so a hook looked like it fired but you couldn't see what it did.

## Cause

`pfb_run_hooks()` runs each hook with stdout+stderr redirected to the pfBlockerNG **log file** (`… >> {logfile} 2>&1 < /dev/null`), never a pipe. That redirect is deliberate and must stay: a hook that (re)starts a daemon — e.g. the documented HAProxy graceful reload — would otherwise have the daemon inherit `exec()`'s capture pipe and hang the whole pass (#662). The markers are `pfb_logger()` calls, so #690 mirrors them; the hook body is appended straight to the file and never reaches stdout.

## Change

Record the log offset before `exec()`; after the hook returns, `pfb_mirror_hook_output()` reads back exactly the bytes the hook appended and `print`s them while a package lifecycle callback is active (`$pfb['hook_lifecycle']`). A plain file read + print — no pipe — so the #662 daemon-hang prevention is untouched, and the bytes are already in the log file so nothing is re-logged. The page then shows the hook's real output between its markers. Syslog output from a hook (`logger …`) is out of scope by design.

## Tests

`PfbHookOutputMirrorTest` pins the delta mirror **on** (lifecycle active → only the appended body, not the pre-existing header), **off** (no lifecycle marker — the pre-#693 behaviour), the **no-new-output** case, and the **empty-path** guard. Fails on the pre-change code (helper absent), passes after. Full PHPUnit green (1714), php -l / PHPStan / PHPCS clean.

## Note (separate decision, not in this PR)

With "Keep enabled during version upgrades" on, the pre-deinstall teardown is correctly skipped, but the post-install resync still re-applies config and fires the `post` hooks (`PFB_POST_INSTALL=1`) — inherent to the resync. Whether a keep-enabled upgrade should fire the post hooks at all is tracked in #693's description as a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_