### PR TITLE
docs: add release notes for v4.0.0.alpha.18

### DIFF
--- a/docs/release-notes/v4.0.0.alpha.18.md
+++ b/docs/release-notes/v4.0.0.alpha.18.md
@@ -1,0 +1,9 @@
+<!-- SUMMARY: Smarter upgrade handling -->
+
+## Improvements
+
+- pfBlockerNG now stays active automatically across a package update or reinstall and tears down only on a genuine uninstall. It determines which package-manager operation is running (install, upgrade, reinstall or delete) and skips the disable pass on anything that is not a removal, so a version bump no longer needs a dedicated setting — the "Keep Enabled During Upgrades" toggle has been removed, and the Software page's Uninstall button now links straight to the pfSense Package Manager. The detected operation is also exported to update hooks as `PFB_PKG_OP`. Note that pfSense performs a firewall OS version upgrade by fully removing and reinstalling packages, so a version upgrade is treated as a removal: with "Keep Settings" disabled this also clears pfBlockerNG's settings (the default keeps them), and the Keep Settings help text now states this ([#697](https://github.com/pfBlockerNG/pfBlockerNG/issues/697)).
+- Update-hook output is now mirrored to the pfSense Package Manager page during install, update and uninstall, so a hook's own progress is visible there instead of only in pfBlockerNG's log ([#693](https://github.com/pfBlockerNG/pfBlockerNG/issues/693)).
+- The `PFB_POST_INSTALL` and `PFB_PRE_UNINSTALL` hook variables are now always exported as `0` or `1`, consistent with the other hook variables, rather than being unset outside their lifecycle ([#695](https://github.com/pfBlockerNG/pfBlockerNG/issues/695)).
+
+[Full changelog](https://github.com/pfBlockerNG/pfBlockerNG/compare/v4.0.0.alpha.17...v4.0.0.alpha.18)


### PR DESCRIPTION
Release notes for the next development pre-release, `v4.0.0.alpha.18`, committed ahead of the tag so the release workflow uses them verbatim (skipping the GitHub Models draft).

Documentation-only (`docs/release-notes/`) — CI is skipped via `paths-ignore`.

Covers the user-facing changes since `v4.0.0.alpha.17`:

- Package-operation detection replacing the "Keep Enabled During Upgrades" toggle; pfBlockerNG now stays live across a package update/reinstall and tears down only on a real uninstall ([#697](https://github.com/pfBlockerNG/pfBlockerNG/issues/697)).
- Update-hook output mirrored to the Package Manager page during install/update/uninstall ([#693](https://github.com/pfBlockerNG/pfBlockerNG/issues/693)).
- `PFB_POST_INSTALL` / `PFB_PRE_UNINSTALL` always exported as `0`/`1` ([#695](https://github.com/pfBlockerNG/pfBlockerNG/issues/695)).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMyC6SRwLJGNZMSBWyDLYV)_