### PR TITLE
ci: prefix release titles with the ISO publish date

### DIFF
--- a/.claude/skills/release-with-changelog/SKILL.md
+++ b/.claude/skills/release-with-changelog/SKILL.md
@@ -57,7 +57,7 @@ model; you apply it by hand here. `scripts/release-version.sh` classifies the ta
 
 5. **Write `docs/release-notes/<tag>.md`.** First line is the title marker
    `<!-- SUMMARY: <three-word summary> -->` (the workflow turns it into the Release title
-   suffix `pfBlockerNG <version> — <summary>` and strips it from the rendered body); then the
+   `<YYYY-MM-DD publish date> - <version> — <summary>` and strips it from the rendered body); then the
    grouped body. Lint it: `npx markdownlint-cli2 docs/release-notes/<tag>.md` → 0 errors.
 
 6. **Confirm the rendered notes with the user.** Show the title + body. This is the public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1038,6 +1038,18 @@ jobs:
             exit 0
           fi
           if [ "$PRERELEASE" = "true" ]; then PRE_FLAG="--prerelease"; else PRE_FLAG="--latest"; fi
+          # Recompute the ISO date prefix at PUBLISH time so the title reflects the actual publish
+          # date, not the draft-creation date: a run crossing midnight UTC, or a draft resumed and
+          # published on a later day (the "resume a prior draft" path), would otherwise keep the
+          # stale draft-creation date. Rewrite only the leading "YYYY-MM-DD - "; the
+          # "<version> — <summary>" tail is preserved. Done BEFORE the flip so a rewrite failure
+          # leaves a resumable draft, never a published release with a stale/bad title.
+          CUR_NAME=$(gh release view "$TAG" --repo "$REPO" --json name --jq '.name')
+          NEW_NAME="$(date -u +%Y-%m-%d) - $(printf '%s' "$CUR_NAME" | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2} - //')"
+          if [ "$NEW_NAME" != "$CUR_NAME" ]; then
+            gh release edit "$TAG" --repo "$REPO" --title "$NEW_NAME"
+            echo "Retitled with publish date: ${CUR_NAME} -> ${NEW_NAME}"
+          fi
           gh release edit "$TAG" --repo "$REPO" --draft=false $PRE_FLAG
           echo "Published release ${TAG} (prerelease=${PRERELEASE})."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -704,11 +704,14 @@ jobs:
             *) BODY=$(printf '%s\n\n%s' "$BODY" "$FULL_LINK") ;;
           esac
 
-          # Release title: product + version, plus the short summary when we have one.
+          # Release title: ISO publish date + version, plus the short summary when we have
+          # one. The date prefix (UTC, yyyy-mm-dd) keeps GitHub's alphabetical release sort
+          # in chronological order. Product name is omitted — this repo only ships pfBlockerNG.
+          DATE=$(date -u +%Y-%m-%d)
           if [ -n "$SUMMARY" ]; then
-            NAME="pfBlockerNG ${VERSION} — ${SUMMARY}"
+            NAME="${DATE} - ${VERSION} — ${SUMMARY}"
           else
-            NAME="pfBlockerNG ${VERSION}"
+            NAME="${DATE} - ${VERSION}"
           fi
 
           # Emit name + body to the step output (consumed by the publish step) …

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -973,7 +973,8 @@ persisted from a prior run) — when present the Models step is **skipped**; els
 the generator). When Models runs, a shell step gathers the commits since the **previous
 same-channel release** (`prev_tag` classifies each tag's channel via `release-version.sh`) and
 feeds them with the static system prompt in **`scripts/release-notes-prompt.txt`**; the model
-returns a `SUMMARY:` line (→ the Release **title** suffix, `pfBlockerNG VER — 3-word summary`) plus
+returns a `SUMMARY:` line (→ the Release **title** suffix; the title is `YYYY-MM-DD - VER — 3-word summary`,
+the ISO publish date prefixed so GitHub's alphabetical release sort stays chronological) plus
 a Markdown code block grouping user-facing changes under **Features / Improvements / Bug Fixes**
 with PR/issue links (CI/test/tooling/ADR noise filtered out), ending with the compare link. A
 **committed file** carries the same notes; its title summary rides in an optional first-line


### PR DESCRIPTION
## Summary

GitHub sorts releases alphabetically by title, which scrambles their chronological order. This builds the release title with the ISO publish date prefixed so the alphabetical sort stays chronological, and drops the redundant `pfBlockerNG ` product prefix (this repo only ships pfBlockerNG).

**Before:** `pfBlockerNG 4.0.0.alpha.18 — Smarter upgrade handling`
**After:** `2026-07-02 - 4.0.0.alpha.18 — Smarter upgrade handling`

## Changes

- `.github/workflows/release.yml` — the "Assemble release body" step now builds `NAME="${DATE} - ${VERSION} — ${SUMMARY}"` (or `${DATE} - ${VERSION}` with no summary), where `DATE` is the UTC publish date (`date -u +%Y-%m-%d`).
- `CLAUDE.md` and the `release-with-changelog` skill — updated the documented title format to match.

## Testing

The title assembly is embedded workflow shell with no unit harness; it is exercised by the existing `release.yml` `workflow_dispatch` dry-run (renders the real title into the run summary, publishing nothing), which is the documented out-of-CI validation for this step.

## Note

This covers **future** releases. The 17 existing pre-releases still carry the old titles — retitling them needs a release-edit path this environment doesn't expose (the GitHub MCP is read-only for releases and direct API access is gated), so they'd be updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014WXb2bSxkEn17ZYKvTgj9y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release-note guidance to use a date-prefixed title format for GitHub releases.
  * Clarified the required summary line structure for release entries.
* **Chores**
  * Changed the generated release title format to include the publish date, improving chronological ordering in GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->