### PR TITLE
pfblockerng: keep the Update live-log tail from freezing on a long no-output gap

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -42,6 +42,13 @@ pfb_global();
 // the returned bytes (replacing the old blocking inline-<script> stream that parked the request
 // and left the page -- and its nav menu -- half-loaded). Must run before any head/HTML output.
 if (($_GET['ajax'] ?? '') === 'tail') {
+	// Release the PHP session write-lock immediately: this poll only READS files + isvalidpid,
+	// it never writes the session. guiconfig.inc holds an EXCLUSIVE per-session lock for the whole
+	// request, so without this every 1s poll serialises behind any other same-session request
+	// (other tabs, nav background requests, the dispatching POST). During a long no-output gap --
+	// e.g. an HAProxy graceful-restart drain in an update hook -- one such blocked poll leaves the
+	// client's in-flight guard stuck and freezes the live tail until a manual reload.
+	session_write_close();
 	header('Content-Type: application/json');
 	header('Cache-Control: no-cache, no-store, must-revalidate');
 	$pfb_has_off = isset($_GET['offset']) && ctype_digit((string) $_GET['offset']);
@@ -573,7 +580,11 @@ events.push(function(){
 			if (pending || done) { return; }   // skip the tick while a request is outstanding
 			pending = true;
 			var url = '/pfblockerng/pfblockerng_update.php?ajax=tail' + (offset !== null ? '&offset=' + offset : '');
-			$.ajax({ url: url, type: 'GET', dataType: 'json', cache: false }).done(function(r) {
+			// timeout: a poll normally returns in ms; if one ever blocks, abort at 5s so .always()
+			// clears the in-flight guard and the next tick retries (the offset only advances on a
+			// successful .done, so a retry re-reads the same range -- no data lost). Without it, a
+			// single blocked poll would freeze the tail until a manual reload.
+			$.ajax({ url: url, type: 'GET', dataType: 'json', cache: false, timeout: 5000 }).done(function(r) {
 				if (!r) { return; }
 				if (r.data) {
 					var atBottom = (out.scrollHeight - out.scrollTop - out.clientHeight) <= 16;

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -417,7 +417,7 @@ def test_update_log_textareas_are_readonly(webui: WebUI) -> None:
         assert re.search(r"\breadonly\b", tag), f"'{name}' textarea is editable (no readonly): {tag}"
 
 
-def test_update_ajax_tail_returns_wellformed_json(webui: WebUI) -> None:
+def test_update_ajax_tail_returns_wellformed_json(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """The ?ajax=tail live-log poll endpoint returns well-formed JSON with the poller's contract keys.
 
     The handler now calls session_write_close() before reading the log so the poll never holds the

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -417,6 +417,30 @@ def test_update_log_textareas_are_readonly(webui: WebUI) -> None:
         assert re.search(r"\breadonly\b", tag), f"'{name}' textarea is editable (no readonly): {tag}"
 
 
+def test_update_ajax_tail_returns_wellformed_json(webui: WebUI) -> None:
+    """The ?ajax=tail live-log poll endpoint returns well-formed JSON with the poller's contract keys.
+
+    The handler now calls session_write_close() before reading the log so the poll never holds the
+    PHP session write-lock — otherwise every 1s poll serialises behind any other same-session
+    request, and one such blocked poll freezes the live tail during a long no-output gap (an
+    HAProxy graceful-restart drain in an update hook). This guards that early close: it must not
+    emit a warning/notice into the response (which would corrupt the JSON) and the endpoint must
+    still return the {running, done, offset} contract the client poller consumes.
+
+    Given the Update page's AJAX tail endpoint,
+    When it is fetched with no offset (the client's first poll),
+    Then the body parses as JSON and carries the running/done/offset keys (done is a bool).
+    """
+    resp = webui.get(_UPDATE_PAGE + "?ajax=tail")
+    assert resp.status_code == 200, f"ajax=tail returned HTTP {resp.status_code}, body={resp.text[:200]!r}"
+    # json.loads FAILS if a PHP warning/notice leaked into the body ahead of the JSON — exactly
+    # the failure a misplaced session_write_close() (or an un-started session) would produce.
+    payload = json.loads(resp.text)
+    for key in ("running", "done", "offset"):
+        assert key in payload, f"ajax=tail JSON missing the poller-contract key {key!r}: {payload!r}"
+    assert isinstance(payload["done"], bool), f"'done' must be a bool for the client stop-check: {payload!r}"
+
+
 def test_update_revamp_controls_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """Update page revamp: new scope + force-mode controls present; old opaque ones gone.
 


### PR DESCRIPTION
The Update page's live-log poller (`?ajax=tail`) could **freeze until a manual reload** during a long no-output gap — most visibly an **HAProxy graceful-restart drain** inside an update hook, where the hook blocks at `Starting haproxy.` while old connections drain, and the tail only shows the final lines after the user hits **View**.

The exec-level hook fix (no false timeout; hook stdout → a regular file) already landed — this is purely the live-viewer's resilience. Two shipped weaknesses, either of which produces the freeze:

1. **The `?ajax=tail` handler never released the PHP session write-lock.** `guiconfig.inc` holds an **exclusive per-session lock** for the whole request, so every 1 s poll serialises behind any other same-session request (other tabs, the nav's background requests, the dispatching POST). A long-held lock blocks a poll. The poll only *reads* the log + `isvalidpid`, so it now calls `session_write_close()` immediately.
2. **The client poller's `$.ajax` had no `timeout`** and sets an in-flight guard (`pending = true`) cleared only in `.always()`. One blocked poll left `pending` stuck forever → every subsequent 1 s tick no-op'd (`if (pending || done) return`) → frozen until reload. Added `timeout: 5000`; a blocked poll then aborts, `.always()` clears the guard, and the next tick retries. The offset only advances on a successful `.done`, so the retry re-reads the same range — no data lost.

## Tests

- **Tier A:** `test_update_ajax_tail_returns_wellformed_json` — the endpoint must still return well-formed JSON carrying the `{running, done, offset}` poller contract after the early `session_write_close()`. A misplaced close (or an un-started session) would emit a PHP warning into the body and break `json.loads` — this catches that.
- The session-lock serialisation and the poll-timeout recovery are concurrency/timing behaviours not deterministically reproducible in CI — documented out-of-CI, per the test-coverage mandate (same class as the real-HAProxy-reload leg).

`php -l` + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Update page’s live log tail so it stays responsive during long pauses with no new output.
  * Added a timeout and retry behavior to prevent polling from freezing indefinitely.
* **Tests**
  * Added smoke coverage for the live-log polling response to ensure it returns valid JSON with the expected fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->