### PR TITLE
pfblockerng: land the #702-#705 audit fixes with off-appliance and live coverage

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10005,7 +10005,7 @@ function pfb_remove_states() {
 	// Collect any 'Permit' Customlist IPs to suppress
 	$custom_supp = array();
 	foreach (array('pfblockernglistsv4', 'pfblockernglistsv6') as $ip_type) {
-		foreach (config_get_path("installedpackages{$ip_type}/config", []) as $list) {
+		foreach (config_get_path("installedpackages/{$ip_type}/config", []) as $list) {
 			if (!empty($list['custom']) && strpos($list['action'], 'Permit_') !== FALSE) {
 				$custom		= pfbng_text_area_decode($list['custom'], TRUE, FALSE);
 				$custom_supp	= array_merge($custom_supp, $custom);
@@ -10102,8 +10102,7 @@ function pfb_remove_states() {
 				else {
 					if (isset($pfb_local[$s_ip]) ||
 					    pfb_local_ip($s_ip, $pfb_localsub) ||
-					    !filter_var($s_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) ||
-					    !filter_var($s_ip, FILTER_CALLBACK, array('options' => 'FILTER_FLAG_NO_LOOPBACK_RANGE'))) {
+					    !filter_var($s_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
 						continue;
 					}
 				}
@@ -10111,7 +10110,7 @@ function pfb_remove_states() {
 				// Exclude any 'Permit' Customlist IPs
 				foreach ($custom_supp as $custom) {
 					if (ip_in_subnet($s_ip, $custom)) {
-						continue;
+						continue 2;
 					}
 				}
 			}
@@ -15069,6 +15068,10 @@ function sync_package_pfblockerng($cron='') {
 	#################################
 
 	$pfbupdate = $pfbpython = FALSE;
+	// $mode must be a defined string for the consumers below (incl. the typed
+	// pfb_manage_dnsbl_vip(string $mode)); the if/elseif does not cover every state
+	// (e.g. DNSBL enabled while the DNS Resolver is disabled). '' is a no-op mode.
+	$mode = '';
 	if ($pfb['enable'] == 'on' && $pfb['dnsbl'] == 'on' && $pfb['unbound_state'] == 'on') {
 		$mode = 'enabled';
 	}
@@ -15105,7 +15108,7 @@ function sync_package_pfblockerng($cron='') {
 	{
 		$redir_changed = FALSE;
 		$redir_toggle  = PfbConfig::read('dnsbl_redir');
-		$redir_enabled = (($mode ?? '') === 'enabled') && ($redir_toggle instanceof PfbToggle && $redir_toggle === PfbToggle::On);
+		$redir_enabled = ($mode === 'enabled') && ($redir_toggle instanceof PfbToggle && $redir_toggle === PfbToggle::On);
 
 		if (!$redir_enabled) {
 			// DISABLED: remove all pfB_DNS_Redirect_* NAT rules.
@@ -15215,7 +15218,7 @@ function sync_package_pfblockerng($cron='') {
 	{
 		$dot_changed = FALSE;
 		$dot_toggle  = PfbConfig::read('dnsbl_dot_block');
-		$dot_enabled = (($mode ?? '') === 'enabled') && ($dot_toggle instanceof PfbToggle && $dot_toggle === PfbToggle::On);
+		$dot_enabled = ($mode === 'enabled') && ($dot_toggle instanceof PfbToggle && $dot_toggle === PfbToggle::On);
 
 		if (!$dot_enabled) {
 			// DISABLED: remove all pfB_DoT_Block_* filter rules.

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -31,11 +31,6 @@ $action = $gtype = '';
 $rowdata = array();
 $rowid = 0;
 
-// Called via AJAX (Save page order format/settings)
-if (isset($_REQUEST) && isset($_REQUEST['act']) && ($_REQUEST['act'] == 'update')) {
-	$_POST = $_REQUEST;
-}
-
 if (isset($_GET)) {
 	if (isset($_GET['savemsg']) && !empty($_GET['savemsg'])) {
 		$savemsg = htmlspecialchars($_GET['savemsg']);

--- a/tests/php/PfbRemoveStatesTest.php
+++ b/tests/php/PfbRemoveStatesTest.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_remove_states() — the kill-states validation walk (issues #702 / #705).
+ *
+ * The function reaches pfctl exclusively through $pfb['pfctl'], reads the state
+ * dump from $pfb['states_tmp'], and takes every policy input from config — so
+ * the REAL function runs off-appliance against the committed
+ * fixtures/fake_pfctl.sh stub (canned rules/states in, issued kills recorded to
+ * a log the tests assert on). The live end-to-end legs (a real pf state killed /
+ * preserved across an Update) are tests/smoke/test_smoke_killstates.py.
+ *
+ * Feature: kill-states state validation and suppression
+ *   Background:
+ *     Given a pfB block rule on interface em0 referencing the urltable aliases
+ *           pfB_pfbunit_v4 / pfB_pfbunit_v6 (so both tables are kill candidates
+ *           and em0 is a pfB interface)
+ *     And   the fake pfctl reports which IPs "match" a table and records kills
+ *
+ * Pinned behaviour (every branch, both sides):
+ *   * #702 — regression pinning for a behaviour-PRESERVING cleanup. Contrary to
+ *     the issue's crash claim, the removed fourth filter_var() term never
+ *     fataled: 'FILTER_FLAG_NO_LOOPBACK_RANGE' names a REAL function defined in
+ *     pfblockerng.inc (:7826, the legacy "fake filter flag" idiom), so
+ *     FILTER_CALLBACK had a valid callable — and for any IPv6 input that
+ *     callback returns the value (truthy), making the term a NO-OP on the v6
+ *     branch (its 127/8 check is IPv4-only). These tests pin the v6 walk across
+ *     the removal (green before AND after, per the mandate's refactor rule): a
+ *     table-matched public IPv6 state is killed, and loopback/link-local stay
+ *     excluded via FILTER_FLAG_NO_RES_RANGE in the surviving term.
+ *   * #705 — red→green: a state whose IP sits on a 'Permit_*' custom list is
+ *     EXCLUDED from clearing (pre-fix two independent bugs each broke this: the
+ *     config path 'installedpackages{type}' missed its '/' so the suppression
+ *     set was always empty, and the inner-loop 'continue' was a no-op —
+ *     'continue 2' is required to skip the state). Covered for bare-IP
+ *     (/32-append branch) and explicit-CIDR entries, v4 and v6 list types, and
+ *     the negative side (a 'Deny_*' custom list does NOT suppress).
+ */
+#[CoversFunction('pfb_remove_states')]
+final class PfbRemoveStatesTest extends TestCase
+{
+	/** @var string Per-test sandbox root; one fresh dir tree per test. */
+	private string $root;
+
+	/** @var array Snapshot of $GLOBALS['config'] to restore in tearDown. */
+	private array $savedConfig;
+
+	/** @var array Snapshot of $GLOBALS['pfb'] to restore in tearDown. */
+	private array $savedPfb;
+
+	// The pfB interface every fixture state line sits on (must match the rules
+	// fixture: pfb_remove_states skips states on non-pfB interfaces).
+	private const IFACE = 'em0';
+
+	// Inert victims: RFC 5737 TEST-NET-2 (v4) and the RFC 9637 documentation
+	// block 3fff::/20 (v6). 3fff:: is deliberate: FILTER_FLAG_NO_RES_RANGE may
+	// treat other doc ranges (2001:db8::/32) as reserved depending on the PHP
+	// version, which would short-circuit the branch under test — a precondition
+	// assert below pins that 3fff:: stays public on the running PHP.
+	private const V4_VICTIM = '198.51.100.9';
+	private const V4_PERMIT = '198.51.100.7';
+	private const V6_VICTIM = '3fff::9';
+	private const V6_PERMIT = '3fff::7';
+
+	protected function setUp(): void
+	{
+		$this->root = sys_get_temp_dir() . '/pfb_killstates_' . getmypid() . '_' . uniqid();
+		if (!mkdir($this->root, 0777, true)) {
+			$this->fail("could not create sandbox {$this->root}");
+		}
+		$this->savedConfig = $GLOBALS['config'] ?? [];
+		$this->savedPfb    = $GLOBALS['pfb'] ?? [];
+
+		// Route every pfctl call through the committed stub; logs land in the sandbox.
+		$GLOBALS['pfb']['pfctl']      = __DIR__ . '/fixtures/fake_pfctl.sh';
+		$GLOBALS['pfb']['states_tmp'] = "{$this->root}/states_tmp";
+		$GLOBALS['pfb']['log']        = "{$this->root}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog']     = "{$this->root}/error.log";
+		$GLOBALS['pfb']['ipconfig']['v4suppression'] = '';
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+		$GLOBALS['pfb_test_dns_servers'] = [];
+
+		// One pfB block rule on IFACE — enough for pfb_filterrules() to list the
+		// interface (only rule_list['int'] is consumed by pfb_remove_states).
+		$rules = '@1(0) block return in log quick on ' . self::IFACE
+			. ' inet from any to <pfB_pfbunit_v4:1> label "USER_RULE" ridentifier 1770000001' . "\n";
+		file_put_contents("{$this->root}/rules.txt", $rules);
+		putenv("PFB_FAKE_RULES={$this->root}/rules.txt");
+		putenv("PFB_FAKE_KILL_LOG={$this->root}/kill.log");
+		putenv('PFB_FAKE_MATCH=');
+		putenv('PFB_FAKE_STATES=');
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = $this->savedConfig;
+		$GLOBALS['pfb']    = $this->savedPfb;
+		unset($GLOBALS['pfb_test_dns_servers']);
+		foreach (['PFB_FAKE_RULES', 'PFB_FAKE_STATES', 'PFB_FAKE_MATCH', 'PFB_FAKE_KILL_LOG'] as $env) {
+			putenv($env);
+		}
+		// Best-effort recursive cleanup of the sandbox.
+		if (is_dir($this->root)) {
+			$it = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($this->root, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($it as $file) {
+				$file->isDir() ? @rmdir($file->getPathname()) : @unlink($file->getPathname());
+			}
+			@rmdir($this->root);
+		}
+	}
+
+	/**
+	 * Seed $GLOBALS['config']: both pfB urltable aliases wired to block rules
+	 * (so pfB_pfbunit_v4/_v6 are kill-candidate tables) plus the given
+	 * pfblockernglists rows (the Permit-customlist suppression source).
+	 */
+	private function seedConfig(array $lists_v4 = [], array $lists_v6 = []): void
+	{
+		$GLOBALS['config'] = [
+			'aliases' => ['alias' => [
+				['type' => 'urltable', 'name' => 'pfB_pfbunit_v4', 'descr' => 'pfBlockerNG unit'],
+				['type' => 'urltable', 'name' => 'pfB_pfbunit_v6', 'descr' => 'pfBlockerNG unit'],
+			]],
+			'filter' => ['rule' => [
+				['type' => 'block', 'source' => ['address' => 'pfB_pfbunit_v4'], 'descr' => ''],
+				['type' => 'block', 'source' => ['address' => 'pfB_pfbunit_v6'], 'descr' => ''],
+			]],
+			'installedpackages' => [
+				'pfblockernglistsv4' => ['config' => $lists_v4],
+				'pfblockernglistsv6' => ['config' => $lists_v6],
+			],
+		];
+	}
+
+	/** Write the canned `pfctl -s state` dump the walk will parse. */
+	private function seedStates(string ...$lines): void
+	{
+		file_put_contents("{$this->root}/states.txt", implode("\n", $lines) . "\n");
+		putenv("PFB_FAKE_STATES={$this->root}/states.txt");
+	}
+
+	/** Declare which IPs the fake pfctl reports as members of ANY pfB table. */
+	private function seedTableMatches(string ...$ips): void
+	{
+		putenv('PFB_FAKE_MATCH=' . implode(' ', $ips));
+	}
+
+	/** A NAT-shaped (7-token) v4 state line whose kill-candidate IP is the DESTINATION. */
+	private function v4State(string $dst, int $port = 54321): string
+	{
+		return self::IFACE . " tcp 10.0.2.15:{$port} (192.168.1.10:{$port}) -> {$dst}:80 SYN_SENT:CLOSED";
+	}
+
+	/** A 6-token v6 state line whose kill-candidate IP is the LEFT endpoint. */
+	private function v6State(string $left): string
+	{
+		return self::IFACE . " tcp {$left}[443] -> 3fff:ffff::1[80] ESTABLISHED:ESTABLISHED";
+	}
+
+	/**
+	 * Run the REAL pfb_remove_states() and return the recorded kill log.
+	 *
+	 * The walk reads first-seen state-array keys before creating them (an
+	 * appliance-tolerated E_WARNING under PHP 8) — swallow warnings/deprecations
+	 * around the call with a scoped handler (PHPUnit's own handler records them
+	 * regardless of error_reporting masking), so the suite output stays
+	 * signal-only. Real Errors (the pre-fix #702 crash) still surface.
+	 */
+	private function runRemoveStates(): string
+	{
+		set_error_handler(static fn (): bool => true, E_WARNING | E_DEPRECATED);
+		try {
+			pfb_remove_states();
+		} finally {
+			restore_error_handler();
+		}
+		$kill_log = "{$this->root}/kill.log";
+		return is_file($kill_log) ? (string) file_get_contents($kill_log) : '';
+	}
+
+	/**
+	 * Scenario (#702) — a table-matched PUBLIC IPv6 state is killed.
+	 *
+	 * Given: a state on a pfB interface whose examined endpoint is the public
+	 *        3fff::9 (asserted public under THIS PHP's NO_PRIV/NO_RES flags), and
+	 *        the fake pfctl reporting 3fff::9 as a member of the v6 block table.
+	 * When:  pfb_remove_states() runs.
+	 * Then:  the state's kill is issued. Behaviour-preserving pin: the removed
+	 *        FILTER_CALLBACK term was a no-op for IPv6 (its named callback
+	 *        returns any v6 input truthily), so this must hold before AND after
+	 *        the cleanup — it guards the removal, it does not chase a crash.
+	 */
+	public function test_public_ipv6_state_completes_and_kills_when_table_matched(): void
+	{
+		// Precondition (not theater): the chosen doc-range v6 must be PUBLIC to
+		// this PHP's filter, or the branch under test is never reached.
+		$this->assertNotFalse(
+			filter_var(self::V6_VICTIM, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE),
+			self::V6_VICTIM . ' must validate as public IPv6 under NO_PRIV|NO_RES on this PHP — pick a different fixture address'
+		);
+
+		$this->seedConfig();
+		$this->seedStates($this->v6State(self::V6_VICTIM));
+		$this->seedTableMatches(self::V6_VICTIM);
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringContainsString(
+			self::V6_VICTIM,
+			$kills,
+			'expected a kill for the table-matched public IPv6 state ' . self::V6_VICTIM
+			. " — kill log was:\n{$kills}"
+		);
+	}
+
+	/**
+	 * Scenario (#702 rationale) — loopback / link-local IPv6 states stay excluded.
+	 *
+	 * Given: states for ::1 and fe80::1 on a pfB interface, with the fake pfctl
+	 *        willing to report BOTH as table members.
+	 * When:  pfb_remove_states() runs.
+	 * Then:  neither is killed — FILTER_FLAG_NO_RES_RANGE excludes them in the
+	 *        surviving term, which is why dropping the no-op FILTER_CALLBACK
+	 *        "loopback" term loses no coverage (the cleanup's safety argument).
+	 */
+	public function test_reserved_ipv6_states_are_not_killed(): void
+	{
+		$this->seedConfig();
+		$this->seedStates($this->v6State('::1'), $this->v6State('fe80::1'));
+		$this->seedTableMatches('::1', 'fe80::1');
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertSame(
+			'',
+			$kills,
+			"reserved IPv6 endpoints (::1, fe80::1) must never be killed — kill log was:\n{$kills}"
+		);
+	}
+
+	/**
+	 * Scenario (#705) — a bare-IP 'Permit_*' custom entry spares its state.
+	 *
+	 * Given: a v4 Permit custom list holding the bare IP 198.51.100.7 (exercises
+	 *        the '/32'-append branch), and BOTH 198.51.100.7 and 198.51.100.9 as
+	 *        members of the v4 block table with a live state each (the genuine
+	 *        permit-vs-deny conflict).
+	 * When:  pfb_remove_states() runs.
+	 * Then:  the unlisted 198.51.100.9 is killed (kill-states did run) and the
+	 *        permitted 198.51.100.7 is NOT (pre-fix either bug killed it: the
+	 *        misspelt config path made the suppression set empty, and the inner
+	 *        'continue' skipped nothing — 'continue 2' skips the state).
+	 */
+	public function test_permit_customlist_bare_ip_spares_state_others_still_killed(): void
+	{
+		$this->seedConfig(lists_v4: [[
+			'aliasname' => 'pfbpermit',
+			'action'    => 'Permit_Outbound',
+			'custom'    => base64_encode(self::V4_PERMIT),
+		]]);
+		$this->seedStates($this->v4State(self::V4_PERMIT), $this->v4State(self::V4_VICTIM, 54322));
+		$this->seedTableMatches(self::V4_PERMIT, self::V4_VICTIM);
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringContainsString(
+			self::V4_VICTIM,
+			$kills,
+			'the non-permitted ' . self::V4_VICTIM . " must be killed (proves the pass ran) — kill log was:\n{$kills}"
+		);
+		$this->assertStringNotContainsString(
+			self::V4_PERMIT,
+			$kills,
+			'the Permit-customlist IP ' . self::V4_PERMIT . " must be excluded from clearing — kill log was:\n{$kills}"
+		);
+	}
+
+	/**
+	 * Scenario (#705) — an explicit-CIDR 'Permit_*' entry spares only members.
+	 *
+	 * Given: a v4 Permit custom list holding 198.51.100.0/29 (no '/32' append),
+	 *        one state inside the CIDR (198.51.100.5) and one outside
+	 *        (198.51.100.99), both v4-table members.
+	 * When:  pfb_remove_states() runs.
+	 * Then:  the inside IP survives, the outside IP is killed — the exclusion is
+	 *        real subnet membership, not list-presence.
+	 */
+	public function test_permit_customlist_cidr_spares_members_only(): void
+	{
+		$this->seedConfig(lists_v4: [[
+			'aliasname' => 'pfbpermitcidr',
+			'action'    => 'Permit_Both',
+			'custom'    => base64_encode('198.51.100.0/29'),
+		]]);
+		$this->seedStates($this->v4State('198.51.100.5'), $this->v4State('198.51.100.99', 54322));
+		$this->seedTableMatches('198.51.100.5', '198.51.100.99');
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringContainsString(
+			'198.51.100.99',
+			$kills,
+			"198.51.100.99 lies outside the permitted /29 and must be killed — kill log was:\n{$kills}"
+		);
+		$this->assertStringNotContainsString(
+			'198.51.100.5',
+			$kills,
+			"198.51.100.5 lies inside the permitted 198.51.100.0/29 and must survive — kill log was:\n{$kills}"
+		);
+	}
+
+	/**
+	 * Scenario (#705) — the v6 list type feeds the suppression set too.
+	 *
+	 * Given: a pfblockernglistsv6 Permit custom list holding 3fff::7/128 (an
+	 *        explicit host CIDR: the bare-IP branch appends '/32', which for
+	 *        IPv6 would be a 32-BIT prefix — pre-existing quirk, out of scope),
+	 *        and v6-table-matched states for 3fff::7 and 3fff::9.
+	 * When:  pfb_remove_states() runs.
+	 * Then:  3fff::7 survives, 3fff::9 is killed — the config walk reads BOTH
+	 *        pfblockernglistsv4 and pfblockernglistsv6 (the misspelt pre-fix
+	 *        path broke both identically).
+	 */
+	public function test_permit_customlist_v6_row_spares_v6_state(): void
+	{
+		$this->seedConfig(lists_v6: [[
+			'aliasname' => 'pfbpermitv6',
+			'action'    => 'Permit_Outbound',
+			'custom'    => base64_encode(self::V6_PERMIT . '/128'),
+		]]);
+		$this->seedStates($this->v6State(self::V6_PERMIT), $this->v6State(self::V6_VICTIM));
+		$this->seedTableMatches(self::V6_PERMIT, self::V6_VICTIM);
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringContainsString(
+			self::V6_VICTIM,
+			$kills,
+			'the non-permitted ' . self::V6_VICTIM . " must be killed — kill log was:\n{$kills}"
+		);
+		$this->assertStringNotContainsString(
+			self::V6_PERMIT,
+			$kills,
+			'the v6 Permit-customlist IP ' . self::V6_PERMIT . " must survive — kill log was:\n{$kills}"
+		);
+	}
+
+	/**
+	 * Scenario (#705, negative branch) — a 'Deny_*' custom list does NOT suppress.
+	 *
+	 * Given: the SAME custom entry as the bare-IP scenario but on a Deny-action
+	 *        list, with a table-matched state for it.
+	 * When:  pfb_remove_states() runs.
+	 * Then:  the IP is killed — only 'Permit_*' actions feed the suppression set
+	 *        (pins the strpos($list['action'], 'Permit_') filter as a real branch).
+	 */
+	public function test_deny_customlist_does_not_suppress(): void
+	{
+		$this->seedConfig(lists_v4: [[
+			'aliasname' => 'pfbdenycustom',
+			'action'    => 'Deny_Outbound',
+			'custom'    => base64_encode(self::V4_PERMIT),
+		]]);
+		$this->seedStates($this->v4State(self::V4_PERMIT));
+		$this->seedTableMatches(self::V4_PERMIT);
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringContainsString(
+			self::V4_PERMIT,
+			$kills,
+			'a Deny-action custom list must NOT spare ' . self::V4_PERMIT . " — kill log was:\n{$kills}"
+		);
+	}
+}

--- a/tests/php/fixtures/fake_pfctl.sh
+++ b/tests/php/fixtures/fake_pfctl.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Fake pfctl for tests/php/PfbRemoveStatesTest.php.
+#
+# pfb_remove_states() (and its pfb_filterrules() helper) reach pfctl exclusively
+# through $pfb['pfctl'], in four invocation shapes. This stub answers each from
+# env-configured canned data so the REAL function runs off-appliance:
+#
+#   pfctl -vvsr                   -> cat "$PFB_FAKE_RULES"   (pfb_filterrules)
+#   pfctl -s state                -> cat "$PFB_FAKE_STATES"  (caller redirects to states_tmp)
+#   pfctl -t <table> -T test <ip> -> "1/1 addresses match." when <ip> is listed in
+#                                    PFB_FAKE_MATCH (space-separated), else "0/1 ..."
+#   pfctl -k <ip> [-k <ip>]       -> append the argv to "$PFB_FAKE_KILL_LOG"
+#
+# Anything else fails loud: the test drove an invocation this stub does not model.
+
+case "$1" in
+	-vvsr)
+		cat "${PFB_FAKE_RULES}"
+		;;
+	-s)
+		cat "${PFB_FAKE_STATES}"
+		;;
+	-t)
+		# argv: -t <table> -T test <ip>
+		ip="$5"
+		# shellcheck disable=SC2086 # PFB_FAKE_MATCH is a deliberate space-separated word list
+		for m in ${PFB_FAKE_MATCH}; do
+			if [ "${m}" = "${ip}" ]; then
+				echo "1/1 addresses match."
+				exit 0
+			fi
+		done
+		echo "0/1 addresses match."
+		;;
+	-k)
+		echo "$*" >> "${PFB_FAKE_KILL_LOG}"
+		;;
+	*)
+		echo "fake_pfctl: unexpected invocation: $*" >&2
+		exit 64
+		;;
+esac

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -838,3 +838,32 @@ if (!function_exists('isvalidpid')) {
 		return !empty($GLOBALS['pfb_test_valid_pids'][$pidfile]);
 	}
 }
+
+// --- pfb_remove_states() doubles (#702/#705) ---
+//
+// The kill-states validation walk (pfb_remove_states) reaches two util.inc
+// helpers with no prior double: the RFC1918/CGN class check on the IPv4 branch
+// and the DNS-server suppression source. Both are needed so the REAL function
+// runs off-appliance (the pfctl boundary itself is the committed
+// fixtures/fake_pfctl.sh stub).
+
+if (!function_exists('is_private_ip')) {
+	// pfSense util.inc: TRUE when the IPv4 address falls within a private range.
+	// Faithful port of the upstream list-walk over ip_in_subnet().
+	function is_private_ip($iptocheck) {
+		foreach (['10.0.0.0/8', '100.64.0.0/10', '172.16.0.0/12', '192.168.0.0/16'] as $private) {
+			if (ip_in_subnet($iptocheck, $private)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+if (!function_exists('get_dns_servers')) {
+	// pfSense util.inc: the system's configured DNS servers. Test double: seedable
+	// via $GLOBALS['pfb_test_dns_servers'] (default: none configured).
+	function get_dns_servers() {
+		return $GLOBALS['pfb_test_dns_servers'] ?? [];
+	}
+}

--- a/tests/smoke/test_smoke_killstates.py
+++ b/tests/smoke/test_smoke_killstates.py
@@ -10,6 +10,11 @@ real two-VM pfSense CE setup (civm = the LAN client behind the firewall):
   2. killstates ON ⇒ pfBlockerNG kills the state for the newly-blocked IP on Update
      (``pfb_remove_states`` → ``pfctl -k``), so the block takes effect immediately for
      the existing flow too.
+  3. killstates ON + the IP ALSO on a 'Permit_*' custom list ⇒ the state SURVIVES the
+     Update (issue #705): pfb_remove_states excludes Permit-customlist IPs from
+     clearing. Pre-fix, two independent bugs each broke this (a misspelt config path
+     left the suppression set empty; the inner-loop ``continue`` skipped nothing) — the
+     permitted IP's state was killed like any other.
 
 Non-obvious facts this exercises (each cost a live investigation):
 
@@ -59,9 +64,14 @@ CFG_IP_SETTINGS = "installedpackages/pfblockerngipsettings/config/0"
 # The blocked victim: a PUBLIC IP (RFC 5737 TEST-NET-3, inert/non-routable) — public so
 # killstates does not suppress it as local/private. DUMMY keeps the alias non-empty (the
 # rule built) while the victim is UNBLOCKED, so the pre-block state can be created.
+# PERMIT_VICTIM is a SECOND public victim that additionally sits on a Permit custom list
+# (module fixture) — the #705 exclusion subject; it must be a different IP from VICTIM so
+# tests 2 and 3 prove kill-vs-spare in the same pass, attributable only to the permit.
 VICTIM = "203.0.113.9"
+PERMIT_VICTIM = "203.0.113.10"
 DUMMY = "203.0.113.77"
 HEADER = "pfbkillstates"  # IP feed header → on-disk file pfbkillstates_v4.txt
+PERMIT_ALIAS = "pfbkillpermit"  # the Permit custom-list aliasname (config row 1)
 ALIAS_TABLE = f"pfB_{HEADER}_v4"  # the pf alias table the rule references
 FEED_FILE = "pfb_killstates_ip.txt"
 
@@ -87,8 +97,8 @@ def _set_ipcfg(vm: SmokeVM, kv: dict[str, str], *, timeout: float = 60.0) -> Non
         raise RuntimeError(f"_set_ipcfg failed: rc={r.returncode} {r.stderr!r} {r.stdout!r}")
 
 
-def _civm_connect(cl: SmokeVM, *, timeout: float = 20.0) -> int:
-    """civm attempts a TCP connection to the victim through pfSense; return curl's rc.
+def _civm_connect(cl: SmokeVM, ip: str = VICTIM, *, timeout: float = 20.0) -> int:
+    """civm attempts a TCP connection to ``ip`` through pfSense; return curl's rc.
 
     Pins a host route for the victim via pfSense (civm has two equal-metric default
     routes; without the pin the SYN may egress the mgmt NIC). The SYN passes the LAN
@@ -98,8 +108,8 @@ def _civm_connect(cl: SmokeVM, *, timeout: float = 20.0) -> int:
         "/bin/sh",
         "-c",
         f"dev=$(ip -4 -o addr show | awk '/192\\.168\\.1\\./{{print $2; exit}}'); "
-        f'ip route replace {VICTIM}/32 via {PFSENSE_LAN_IP} dev "$dev" 2>/dev/null || true; '
-        f"curl -s -o /dev/null --connect-timeout 3 --max-time 4 http://{VICTIM}/ >/dev/null 2>&1; echo rc=$?",
+        f'ip route replace {ip}/32 via {PFSENSE_LAN_IP} dev "$dev" 2>/dev/null || true; '
+        f"curl -s -o /dev/null --connect-timeout 3 --max-time 4 http://{ip}/ >/dev/null 2>&1; echo rc=$?",
         timeout=timeout,
     )
     marker = "rc="
@@ -107,8 +117,8 @@ def _civm_connect(cl: SmokeVM, *, timeout: float = 20.0) -> int:
     return int(line[len(marker) :] or -1)
 
 
-def _establish_victim_state(vm: SmokeVM, cl: SmokeVM, *, attempts: int = 6) -> str:
-    """civm opens a connection to the (unblocked) victim until a pf state appears.
+def _establish_victim_state(vm: SmokeVM, cl: SmokeVM, ip: str = VICTIM, *, attempts: int = 6) -> str:
+    """civm opens a connection to the (unblocked) ``ip`` until a pf state appears.
 
     The SYN passing the LAN allow creates a SYN_SENT state (pf tcp.first ~120s). A fresh
     reload can briefly leave the WAN gateway re-initialising, so retry until the state is
@@ -116,28 +126,28 @@ def _establish_victim_state(vm: SmokeVM, cl: SmokeVM, *, attempts: int = 6) -> s
     lines. Raises with rich civm/pfSense diagnostics if no state forms.
     """
     for _ in range(attempts):
-        _civm_connect(cl)
+        _civm_connect(cl, ip)
         time.sleep(1.0)
-        st = _victim_states(vm)
-        if VICTIM in st:
+        st = _victim_states(vm, ip)
+        if ip in st:
             return st
         time.sleep(2.0)
     raise AssertionError(
-        f"could not create a firewall state to {VICTIM} from civm after {attempts} attempts.\n"
-        f"{_civm_diag(cl)}\n{_state_diag(vm)}"
+        f"could not create a firewall state to {ip} from civm after {attempts} attempts.\n"
+        f"{_civm_diag(cl, ip)}\n{_state_diag(vm)}"
     )
 
 
-def _civm_diag(cl: SmokeVM) -> str:
+def _civm_diag(cl: SmokeVM, ip: str = VICTIM) -> str:
     """civm-side reachability diagnostics. Never raises."""
     try:
         out = cl.ssh(
             "/bin/sh",
             "-c",
             "echo rc=$(curl -s -o /dev/null --connect-timeout 3 --max-time 4 -w '%{http_code}' "
-            f"http://{VICTIM}/ 2>&1; echo :$?); "
+            f"http://{ip}/ 2>&1; echo :$?); "
             f"ping -c1 -W2 {PFSENSE_LAN_IP} >/dev/null 2>&1 && echo pf_ping=ok || echo pf_ping=FAIL; "
-            "ip route get " + VICTIM + " 2>&1 | head -1",
+            "ip route get " + ip + " 2>&1 | head -1",
             timeout=20,
         ).stdout.strip()
     except Exception:
@@ -145,9 +155,16 @@ def _civm_diag(cl: SmokeVM) -> str:
     return f"  civm: {out}"
 
 
-def _victim_states(vm: SmokeVM, *, timeout: float = 30.0) -> str:
-    """The pf state-table lines referencing the victim (empty string if none)."""
-    return vm.ssh("/bin/sh", "-c", f"pfctl -ss 2>/dev/null | grep '{VICTIM}' || true", timeout=timeout).stdout.strip()
+def _victim_states(vm: SmokeVM, ip: str = VICTIM, *, timeout: float = 30.0) -> str:
+    """The pf state-table lines referencing exactly ``ip`` (empty string if none).
+
+    Boundary-anchored: a bare substring grep for 203.0.113.9 ALSO matches the stub-DNS
+    answer address 203.0.113.99 (``STUB_DNS_A`` — e.g. a civm NTP state resolved through
+    the stub), a false hit observed live that made a killed victim read as surviving.
+    """
+    pat = ip.replace(".", "\\.")
+    cmd = f"pfctl -ss 2>/dev/null | grep -E '(^|[^0-9]){pat}([^0-9]|$)' || true"
+    return vm.ssh("/bin/sh", "-c", cmd, timeout=timeout).stdout.strip()
 
 
 def _rule_block_packets(vm: SmokeVM, *, timeout: float = 30.0) -> int:
@@ -212,14 +229,14 @@ def _assert_fresh_connection_blocked(vm: SmokeVM, cl: SmokeVM) -> None:
     )
 
 
-def _block_victim(vm: SmokeVM, *, timeout: float = 600.0) -> None:
-    """Add the victim to the existing rule's alias and run an Update.
+def _block_victim(vm: SmokeVM, ips: tuple[str, ...] = (VICTIM,), *, timeout: float = 600.0) -> None:
+    """Add the given IPs to the existing rule's alias and run an Update.
 
     Feed CONTENT change only (the rule already exists) ⇒ no rule change ⇒
     ``filter_configure`` stays FALSE ⇒ killstates is eligible to run. ``force_ip_refetch``
     defeats the per-feed reuse gate so the edited feed is actually re-parsed.
     """
-    h.write_local_feed(vm, FEED_FILE, f"{VICTIM}/32\n")
+    h.write_local_feed(vm, FEED_FILE, "".join(f"{ip}/32\n" for ip in ips))
     h.force_ip_refetch(vm, f"{HEADER}_v4")
     h.reload(vm, "update", timeout=timeout)
     time.sleep(SETTLE_SECS)
@@ -231,6 +248,50 @@ def _unblock_baseline(vm: SmokeVM, *, kill_on: bool, timeout: float = 600.0) -> 
     _set_ipcfg(vm, {"killstates": "on" if kill_on else ""})
     h.force_ip_refetch(vm, f"{HEADER}_v4")
     h.reload(vm, "update", timeout=timeout)
+
+
+def _append_permit_customlist(vm: SmokeVM, aliasname: str, ip: str, *, timeout: float = 60.0) -> None:
+    """Append a 'Permit_Inbound' CUSTOM list row holding ``ip`` to the IPv4 lists.
+
+    pfb_remove_states builds its suppression set from config rows whose ``action``
+    contains ``Permit_`` and whose ``custom`` (a base64 textarea) is non-empty — the
+    row itself is the #705 input; no feed row is needed. The action is deliberately
+    INBOUND: the suppression is direction-agnostic (any ``Permit_*``), but a
+    Permit_OUTBOUND list would add a floating ``pass out quick`` rule that then
+    CREATES the outbound test state — and a floating-pass state binds to interface
+    'all', which the kill walk's pfB-interface gate skips, so the state would
+    survive for a reason unrelated to #705 (observed live: the pre-fix code passed
+    the survival assert that way). With an inbound-only permit rule the outbound
+    state is created by the default pass-out path and binds to the WAN interface,
+    exactly like the non-permitted victim's — entering the walk, where only the
+    suppression can spare it. Idempotent: replaces any prior row with the same
+    aliasname.
+    """
+    row = {
+        "aliasname": aliasname,
+        "action": "Permit_Inbound",
+        "cron": "Never",
+        "aliaslog": "enabled",
+        "description": "pfBlockerNG smoke: killstates permit custom list",
+        "custom": h._b64_textarea([ip]),
+    }
+    snippet = (
+        f"$lists = config_get_path({h._php_str(h.CFG_IP_V4_LISTS)}, array());\n"
+        f"$lists = array_values(array_filter($lists, "
+        f"fn($l) => ($l['aliasname'] ?? '') !== {h._php_str(aliasname)}));\n"
+        f"$lists[] = {h._php_kv_array(row)};\n"
+        f"config_set_path({h._php_str(h.CFG_IP_V4_LISTS)}, $lists);\n"
+        "write_config('pfBlockerNG smoke: killstates permit custom list');\n"
+        "echo 'OK';"
+    )
+    r = h.php_eval(vm, snippet, timeout=timeout)
+    if r.returncode != 0 or "OK" not in r.stdout:
+        raise RuntimeError(f"_append_permit_customlist failed: rc={r.returncode} {r.stderr!r} {r.stdout!r}")
+
+
+# The permit custom-list row's config index: h.inject() REPLACES the v4 lists node with
+# the one deny list (index 0), then _append_permit_customlist appends — so row 1, stably.
+PERMIT_ROW = 1
 
 
 # --------------------------------------------------------------------------- #
@@ -245,9 +306,13 @@ def ip_block_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer)
     Given: the smoke VM is booted and the branch .pkg is available; civm is up.
     When:  we deploy and inject one IP block feed (header ``pfbkillstates``) whose alias
            starts with only DUMMY (so the rule is built but the victim is NOT blocked),
-           as a floating rule (enable_float) with logging on.
-    Then:  the module VM is ready: the reject rule exists, the victim is reachable enough
-           for civm to create a firewall state to it.
+           as a floating rule (enable_float) with logging on — plus a 'Permit_Inbound'
+           CUSTOM list holding PERMIT_VICTIM (the #705 suppression source; set up HERE so
+           the per-test measured Update stays a content-only change: adding the list
+           mid-test would rebuild the ruleset, filter_configure would go TRUE, and
+           killstates would be skipped — a false pass).
+    Then:  the module VM is ready: the reject rule exists, both victims are reachable
+           enough for civm to create firewall states to them.
     """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
@@ -260,6 +325,7 @@ def ip_block_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer)
         smoke_vm,
         h.IpCase(aliasname=HEADER, feed_url=feed, action="Deny_Outbound", family="v4", header=HEADER),
     )
+    _append_permit_customlist(smoke_vm, PERMIT_ALIAS, PERMIT_VICTIM)
     # FLOATING rule (inject wired the interface to wan): enable_float flips Deny_Outbound to
     # a floating `block out quick` on WAN that catches the client's forwarded traffic without
     # disturbing the LAN allow. Global IP logging on so the block is visible in filter.log.
@@ -349,3 +415,67 @@ def test_killstates_on_clears_state_so_block_takes_effect(ip_block_vm: SmokeVM, 
 
     # And: the block is live — a connection to the victim is actually dropped by the rule.
     _assert_fresh_connection_blocked(vm, client_vm)
+
+
+# --------------------------------------------------------------------------- #
+# Test 3 (#705): killstates ON + Permit custom list ⇒ the permitted IP's state SURVIVES
+# --------------------------------------------------------------------------- #
+
+
+def test_killstates_on_spares_permit_customlist_state(ip_block_vm: SmokeVM, client_vm: SmokeVM) -> None:
+    """killstates ON: a Permit-customlist IP's state survives the very pass that kills others (#705).
+
+    Given: Clear-States ON; a 'Permit_Inbound' custom list holding PERMIT_VICTIM (module
+           fixture — asserted from config so the suppression input is REAL, not assumed);
+           and civm-created firewall states to BOTH victims.
+    When:  BOTH victims are added to the block alias and pfBlockerNG runs an Update
+           (content-only change, so killstates actually fires).
+    Then:  PERMIT_VICTIM is genuinely IN the live block table (the permit-vs-deny conflict
+           exists — otherwise survival would be trivial), the non-permitted VICTIM's state
+           is KILLED in this same pass (killstates demonstrably ran), and PERMIT_VICTIM's
+           state SURVIVES — attributable only to the Permit-customlist exclusion.
+           Pre-fix, either #705 bug (empty suppression set from the misspelt config path,
+           or the no-op inner 'continue') let the pass kill PERMIT_VICTIM's state too.
+    """
+    vm = ip_block_vm
+    _unblock_baseline(vm, kill_on=True)
+
+    # Given: the Permit custom-list row is present in config — the exact input
+    # pfb_remove_states builds its suppression set from (non-theater guard).
+    row = f"{h.CFG_IP_V4_LISTS}/{PERMIT_ROW}"
+    name = h.config_get(vm, f"{row}/aliasname")
+    action = h.config_get(vm, f"{row}/action")
+    custom = h.config_get(vm, f"{row}/custom")
+    assert (name, action) == (PERMIT_ALIAS, "Permit_Inbound") and custom != "", (
+        f"expected the module fixture's Permit custom-list row '{PERMIT_ALIAS}' (action "
+        f"'Permit_Inbound', non-empty custom) at config row {PERMIT_ROW}, got "
+        f"name={name!r} action={action!r} custom={custom!r} — the suppression input is missing"
+    )
+
+    # Given: civm creates states to BOTH still-unblocked victims.
+    before_victim = _establish_victim_state(vm, client_vm, VICTIM)
+    before_permit = _establish_victim_state(vm, client_vm, PERMIT_VICTIM)
+
+    # When: block BOTH victims (Clear-States ON).
+    _block_victim(vm, (VICTIM, PERMIT_VICTIM))
+
+    # Then: PERMIT_VICTIM is genuinely in the live block table — the deny side of the
+    # conflict is real, so its survival below is the EXCLUSION working, not a missing block.
+    table = vm.ssh("/bin/sh", "-c", f"pfctl -t {ALIAS_TABLE} -T show 2>/dev/null | tr -d ' '", timeout=30).stdout
+    assert PERMIT_VICTIM in table and VICTIM in table, (
+        f"expected both {VICTIM} and {PERMIT_VICTIM} in the live block alias {ALIAS_TABLE}, got:\n{table}"
+    )
+
+    # Then: the NON-permitted victim's state is gone — killstates ran in this pass.
+    after_victim = _victim_states(vm)
+    assert VICTIM not in after_victim, (
+        f"killstates ON must CLEAR the state to the non-permitted {VICTIM} (proves the kill pass "
+        f"ran), but it survived.\n  before: {before_victim!r}\n  after: {after_victim!r}\n{_state_diag(vm)}"
+    )
+
+    # Then: the PERMITTED victim's state SURVIVES the same pass (#705).
+    after_permit = _victim_states(vm, PERMIT_VICTIM)
+    assert PERMIT_VICTIM in after_permit, (
+        f"killstates must EXCLUDE the Permit-customlist IP {PERMIT_VICTIM} from clearing, but its "
+        f"state was killed.\n  before: {before_permit!r}\n  after: {after_permit!r}\n{_state_diag(vm)}"
+    )

--- a/tests/smoke/test_smoke_resolver_off_sync.py
+++ b/tests/smoke/test_smoke_resolver_off_sync.py
@@ -1,0 +1,122 @@
+"""Live-VM smoke: pfBlockerNG sync with DNSBL enabled but the DNS Resolver DISABLED (#703).
+
+``sync_package_pfblockerng()`` derives ``$mode`` from an if/elseif that does not cover
+every enable-state: with the master switch ON and DNSBL ON but Unbound disabled
+(``$pfb['unbound_state'] == ''``), neither branch matches. Pre-fix ``$mode`` stayed
+UNDEFINED (null) and the typed ``pfb_manage_dnsbl_vip(string $mode)`` raised a
+``TypeError`` that aborted the whole sync pass — every Update/save-sync crashed until
+the resolver was re-enabled. The fix defaults ``$mode = ''`` (a no-op mode for every
+consumer).
+
+Red→green: pre-fix the measured sync exits non-zero with the TypeError on stdout (the
+CLI fatal); post-fix it completes cleanly.
+
+The resolver toggle is config-only (``$pfb['unbound_state']`` reads
+``config_path_enabled('unbound')``), so the test flips ``unbound/enable`` in config —
+and RESTORES it in a ``finally`` with a loud check, so a mid-test failure cannot leave
+the shared session VM without its resolver for later modules.
+
+DESELECTED from the default ``python -m pytest`` (smoke-only). Run via::
+
+    python -m pytest tests/smoke/test_smoke_resolver_off_sync.py -m smoke --override-ini="addopts="
+
+Needs the booted ``smoke_vm`` fixture and the branch ``.pkg`` (``SMOKE_PKG``); without
+these the cases skip cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+
+pytestmark = pytest.mark.smoke
+
+
+def _resolver_enabled(vm: SmokeVM, *, timeout: float = 60.0) -> bool:
+    """Whether the DNS Resolver is enabled in config — the exact source
+    ``$pfb['unbound_state']`` reads (``config_path_enabled('unbound')``)."""
+    r = h.php_eval(vm, "echo config_path_enabled('unbound') ? 'ENABLED' : 'DISABLED';", timeout=timeout)
+    out = r.stdout
+    if "ENABLED" in out and "DISABLED" not in out:
+        return True
+    if "DISABLED" in out:
+        return False
+    raise RuntimeError(f"_resolver_enabled: unexpected output rc={r.returncode} {out!r} {r.stderr!r}")
+
+
+def _set_resolver_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Flip the DNS Resolver's config enable key (presence-based, like the GUI checkbox)."""
+    stmt = "config_set_path('unbound/enable', '');" if on else "config_del_path('unbound/enable');"
+    snippet = f"{stmt}\nwrite_config('pfBlockerNG smoke: resolver toggle');\necho 'OK';"
+    r = h.php_eval(vm, snippet, timeout=timeout)
+    if r.returncode != 0 or "OK" not in r.stdout:
+        raise RuntimeError(f"_set_resolver_enabled({on}) failed: rc={r.returncode} {r.stderr!r} {r.stdout!r}")
+
+
+@pytest.fixture(scope="module")
+def dnsbl_on_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg with the #703 trigger preconditions: master ON + DNSBL ON.
+
+    Given: the smoke VM is booted and the branch .pkg is available.
+    When:  we deploy, provision the sinkhole VIP, and switch on the master enable and the
+           DNSBL component (no lists needed — the $mode derivation crashes before any
+           feed work).
+    Then:  the module VM is one resolver-disable away from the pre-fix crash state.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.set_package_enabled(smoke_vm, True)
+    h.set_dnsbl_enabled(smoke_vm, True)
+    yield smoke_vm
+
+
+def test_sync_with_resolver_disabled_completes_without_typeerror(dnsbl_on_vm: SmokeVM) -> None:
+    """A sync with DNSBL on but the Resolver disabled completes instead of crashing (#703).
+
+    Given: master ON + DNSBL ON + Resolver ENABLED, and a baseline sync that SUCCEEDS
+           (proves the rig itself is green before the flip — the failure below is then
+           attributable to the resolver state alone).
+    When:  the Resolver is disabled in config and the same sync runs again.
+    Then:  the sync completes with rc 0 and no TypeError/Fatal on its output — pre-fix,
+           $mode was undefined for pfb_manage_dnsbl_vip(string $mode) and the pass
+           aborted with 'TypeError ... must be of type string' (rc 255).
+    Finally: the Resolver is restored (loud check) so later modules keep working DNS.
+    """
+    vm = dnsbl_on_vm
+
+    # Given: the resolver is enabled — the before-state of the transition.
+    assert _resolver_enabled(vm), "precondition: the DNS Resolver must start ENABLED in config"
+
+    # Given (control): the baseline sync is green with the resolver ON.
+    h.reload(vm, "update")
+
+    try:
+        # When: disable the resolver (config only — $pfb['unbound_state'] reads config).
+        _set_resolver_enabled(vm, False)
+        assert not _resolver_enabled(vm), "resolver disable did not take in config"
+
+        # When/Then: the measured sync. Drive the CLI directly so stdout is assertable —
+        # a PHP fatal (the pre-fix TypeError) lands on stdout with a non-zero rc.
+        r = vm.ssh(h.PHP_BIN, h.PFB_CLI, "pfb_trigger", "scope=both", "force=false", "trigger=cron", timeout=600)
+        assert r.returncode == 0, (
+            f"sync with the Resolver disabled must complete, got rc={r.returncode}\n"
+            f"  stdout: {r.stdout[-2000:]!r}\n  stderr: {r.stderr!r}"
+        )
+        for marker in ("TypeError", "Fatal error", "Uncaught"):
+            assert marker not in r.stdout, (
+                f"sync output must not contain {marker!r} with the Resolver disabled\n  stdout: {r.stdout[-2000:]!r}"
+            )
+    finally:
+        # Restore the resolver for the rest of the session VM — and prove it took.
+        _set_resolver_enabled(vm, True)
+        h.reload(vm, "update")  # waits on unbound readiness — a dead resolver fails here loudly
+
+    assert _resolver_enabled(vm), "teardown: the DNS Resolver must be re-enabled in config"

--- a/tests/smoke/test_smoke_resolver_off_sync.py
+++ b/tests/smoke/test_smoke_resolver_off_sync.py
@@ -104,8 +104,13 @@ def test_sync_with_resolver_disabled_completes_without_typeerror(dnsbl_on_vm: Sm
         assert not _resolver_enabled(vm), "resolver disable did not take in config"
 
         # When/Then: the measured sync. Drive the CLI directly so stdout is assertable —
-        # a PHP fatal (the pre-fix TypeError) lands on stdout with a non-zero rc.
-        r = vm.ssh(h.PHP_BIN, h.PFB_CLI, "pfb_trigger", "scope=both", "force=false", "trigger=cron", timeout=600)
+        # a PHP fatal (the pre-fix TypeError) lands on stdout with a non-zero rc. The
+        # trigger args come from the shared reload() mapping so this stays the same
+        # request shape h.reload(vm, "update") sends.
+        scope, force, trigger = h._SCOPE_TO_PFBTRIGGER["update"]
+        r = vm.ssh(
+            h.PHP_BIN, h.PFB_CLI, "pfb_trigger", f"scope={scope}", f"force={force}", f"trigger={trigger}", timeout=600
+        )
         assert r.returncode == 0, (
             f"sync with the Resolver disabled must complete, got rc={r.returncode}\n"
             f"  stdout: {r.stdout[-2000:]!r}\n  stderr: {r.stderr!r}"

--- a/tests/smoke/ui/test_category.py
+++ b/tests/smoke/ui/test_category.py
@@ -18,11 +18,14 @@ faithfully (a fully-enumerated payload, no same-name multi-value collision).
 
 Handler facts pinned from the PHP source (read end to end):
 
-* ``act=update`` (pfblockerng_category.php:35-37,174-314): the page does
-  ``$_POST = $_REQUEST`` for ``act=update`` then reads ``$_POST['postdata']`` --
-  itself a urlencoded query string -- via ``parse_str`` into ``$post_data``.
-  Each key shaped ``<var>-<rowid>`` (``var`` in {action,cron,aliaslog,logging})
-  is validated against that field's whitelist; on success it writes
+* ``act=update`` (pfblockerng_category.php:169-309): the handler is POST-ONLY —
+  ``$action``/``postdata``/``ids`` are read exclusively from ``$_POST`` (issue
+  #704 removed the historical ``$_POST = $_REQUEST`` fold that let a crafted GET
+  drive the config-writing handler past csrf-magic, which validates POST bodies
+  only). ``$_POST['postdata']`` -- itself a urlencoded query string -- is parsed
+  via ``parse_str`` into ``$post_data``. Each key shaped ``<var>-<rowid>``
+  (``var`` in {action,cron,aliaslog,logging}) is validated against that field's
+  whitelist; on success it writes
   ``config_set_path("{$rowdata_path}/{$rowid}/{$variable}", ...)``. ANY invalid
   key/value appends to ``$input_errors`` and the ``if (!$input_errors)`` guard
   skips the ENTIRE write (config UNCHANGED) and the handler echoes
@@ -247,6 +250,57 @@ def test_category_update_row_cron_valid_and_reject_unchanged(
         _ajax_post(webui, {"act": "update", "type": "ipv4", "rowid": "0", "postdata": postdata})
         got = helpers.config_get(vm, cfg)
         assert got == "Never", f"bogus cron must leave config unchanged at 'Never', got {got!r}"
+    finally:
+        _restore_lists(vm, snap)
+
+
+def test_category_update_via_get_does_not_mutate_config(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """An authenticated GET carrying ``act=update`` params mutates NOTHING (#704).
+
+    csrf-magic validates POST bodies only, so a GET reaching the update handler is a
+    CSRF hole: a logged-in admin lured to a crafted link would flip real config. The
+    fix makes the handler POST-only (``$_POST`` is never populated from ``$_GET``).
+
+    * GET: the full ``act=update&type=ipv4&rowid=0&postdata=action-0%3DPermit_Both``
+      query — the exact crafted-link shape — must leave the seeded row's action
+      UNCHANGED. Pre-fix, the ``$_POST = $_REQUEST`` fold fed these params to the
+      handler and the row flipped to Permit_Both (this assert is the red→green).
+    * CONTROL: the SAME parameters via the CSRF-token POST DO change the row —
+      proving the GET was rejected for its METHOD, not for its payload.
+
+    Oracle is config.xml over SSH, never the HTTP response body.
+    """
+    vm = smoke_vm
+    alias = "pfbcatcsrf"
+    cfg = f"{IPV4_LISTS}/0/action"
+    snap = _snapshot_lists(vm)
+    try:
+        _seed_single_ipv4_row(vm, alias, "Deny_Inbound")
+        # BEFORE: the seeded row holds an action the crafted GET would change.
+        assert helpers.config_get(vm, cfg) == "Deny_Inbound", "seed did not land Deny_Inbound at row 0"
+
+        # WHEN: the crafted-link GET (authenticated session, no CSRF token — GETs never carry one).
+        postdata = urlencode({"action-0": "Permit_Both"})
+        query = urlencode({"act": "update", "type": "ipv4", "rowid": "0", "postdata": postdata})
+        page = webui.get(f"{CATEGORY_PAGE}?{query}")
+        assert not looks_like_login_page(page.text), "Category GET returned the login form (session lost)"
+
+        # THEN: config is UNCHANGED — the update handler must be unreachable via GET.
+        got = helpers.config_get(vm, cfg)
+        assert got == "Deny_Inbound", (
+            f"a GET with act=update params must not mutate config: expected row action to stay "
+            f"'Deny_Inbound', got {got!r} — the handler accepted a GET (CSRF hole, #704)"
+        )
+
+        # CONTROL: the same parameters via the token POST DO mutate — the branch is the method.
+        _update_action(webui, 0, "Permit_Both")
+        got = helpers.config_get(vm, cfg)
+        assert got == "Permit_Both", (
+            f"the CSRF-token POST with identical params must still change the row action, got {got!r}"
+        )
     finally:
         _restore_lists(vm, snap)
 


### PR DESCRIPTION
Lands the CRITICAL/HIGH fixes from the codebase audit — part of #702, #703, #704, #705 — together with their off-appliance and live-VM coverage.

## Fixes

- **#703 (CRITICAL, confirmed):** `sync_package_pfblockerng()` left `$mode` undefined when the master switch and DNSBL are on but the DNS Resolver is disabled; the typed `pfb_manage_dnsbl_vip(string $mode)` then aborted every sync with a `TypeError` until the resolver was re-enabled. `$mode` now defaults to `''` (a no-op mode for every consumer), and the now-redundant `($mode ?? '')` guards are dropped.
- **#705 (HIGH, confirmed — two independent bugs):** `pfb_remove_states()` never actually excluded Permit-customlist IPs from state clearing: the config path `installedpackages{$ip_type}/config` missed its `/` (suppression set always empty), and the inner-loop `continue` skipped nothing (`continue 2` is required to skip the state).
- **#704 (HIGH, confirmed):** `pfblockerng_category.php` copied `$_REQUEST` into `$_POST` for `act=update`, letting a crafted GET drive the config-writing handler past csrf-magic (which validates POST bodies only). The handler is now POST-only.
- **#702 (reclassified — false positive):** the flagged `filter_var(FILTER_CALLBACK, 'FILTER_FLAG_NO_LOOPBACK_RANGE')` term never crashed: that string names a real function defined in `pfblockerng.inc:7826`, and for IPv6 input the callback is truthy — the term was a **no-op** on the v6 branch. It is removed as behaviour-preserving dead code; loopback/link-local stay excluded via `FILTER_FLAG_NO_RES_RANGE`. Details: the correction comment on #702.

## Tests

- **`tests/php/PfbRemoveStatesTest.php`** — runs the real `pfb_remove_states()` off-appliance against the committed `tests/php/fixtures/fake_pfctl.sh` stub (canned rules/states in, issued kills recorded). Red→green for both #705 bugs (bare-IP `/32`-append, explicit CIDR, v4+v6 list types, Deny-list negative); behaviour-preserving pins for the #702 cleanup (table-matched public v6 killed; `::1`/`fe80::` excluded). Two new doubles (`is_private_ip`, `get_dns_servers`).
- **`tests/smoke/test_smoke_killstates.py`** — new live leg: with Clear-States ON, a Permit-customlist IP's state **survives** the same Update that kills the non-permitted victim's state (#705), with non-theater guards (permit row asserted from config; both victims asserted present in the live block table).
- **`tests/smoke/test_smoke_resolver_off_sync.py`** — new module: sync with DNSBL on + Resolver disabled completes with rc 0 and no `TypeError` (#703); resolver restored in `finally` with a loud check.
- **`tests/smoke/ui/test_category.py`** — new Tier-B flow: an authenticated GET carrying the full `act=update` query mutates nothing, while the same parameters via the CSRF-token POST still save (#704). Module docstring updated to the POST-only contract.

## Validation

- Local gates: PHPUnit (1720 tests), pytest (1926 passed), PHPStan, PHPCS, ruff/mypy, markdownlint, shellcheck — all green.
- Off-appliance red→green: with the pre-fix `pfblockerng.inc` checked out, `PfbRemoveStatesTest` fails its three #705 scenarios (the permitted IPs are killed) and passes them post-fix; the #702 pins stay green on both (the no-op proof).
- Live-VM red→green on a pool box via `scripts/local-smoke.sh`, using branch `smoke-red-702-705` (this branch's tests + the src fixes reverted; throwaway):
  - RED (pre-fix): `test_killstates_on_spares_permit_customlist_state` fails with "killstates must EXCLUDE the Permit-customlist IP 203.0.113.10 from clearing, but its state was killed" (#705), and `test_sync_with_resolver_disabled_completes_without_typeerror` fails with the exact `TypeError: pfb_manage_dnsbl_vip(): Argument #1 ($mode) must be of type string, null given` at rc 255 (#703). The two pre-existing killstates tests stay green.
  - GREEN (this branch): all 4 selected smoke tests pass.
- Web-UI Tier B red→green via CI dispatch (UI files byte-identical to this revision): [red run](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28579364174) fails exactly on the new test with `expected row action to stay 'Deny_Inbound', got 'Permit_Both'` (#704); [green run](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28579367753) passes the whole functional tier.
- Bonus live evidence for the #702 reclassification: on the pre-fix code the kill walk logged "Firewall state(s) validation for [ 2 ] IPv6 address(es)" and completed — the claimed IPv6 fatal does not occur on the appliance PHP either.

Test-harness findings folded in along the way: a Permit_OUTBOUND fixture list would let the floating pass rule create the very state under test, binding it to interface 'all' which the kill walk's pfB-interface gate skips (the fixture uses Permit_Inbound so the state binds to WAN like the victim's), and the state grep is now boundary-anchored (a bare substring grep for 203.0.113.9 also matched the stub-DNS 203.0.113.99 NTP states).

Issues are referenced with "part of" deliberately — #702 needs a reclassifying close note and #703/#704/#705 are closed manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjKUuPuVpwtUp9ks1gx8XC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state cleanup behavior so permitted IPs are no longer removed when they should be exempt, while other matching states are still cleared correctly.
  * Fixed DNS-based sync behavior when the resolver is disabled, preventing unexpected failures during updates.
  * Tightened update handling so browser requests using the wrong method no longer change configuration.
* **Tests**
  * Added broader automated coverage for state removal, permit/deny custom-list handling, sync behavior, and update request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->