### PR TITLE
pfblockerng: fix the IP/DNSBL download-loop cluster (#709 #710 #711 #712)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3998,6 +3998,37 @@ function pfb_parsed_fail($header, $line='', $oline, $logfile) {
 }
 
 
+// Map an IP list's vtype ('_v4'/'_v6') to its config section. The download loop
+// runs AFTER the $ip_types collection loop, so $ip_type is left at its last value
+// ('pfblockernglistsv6') there; deriving the section from the list's own vtype keeps
+// a v4 list reading the v4 section instead of the stale v6 one (#709).
+function pfb_list_section_for_vtype(string $vtype): string {
+	return ($vtype === '_v6') ? 'pfblockernglistsv6' : 'pfblockernglistsv4';
+}
+
+// Drop the Blacklist categories whose download Failed, matching by feed NAME in the
+// child's output line rather than the stdout-line index. pfblockerng_download_extras
+// only processes the not-yet-downloaded types and silently skips some feeds (e.g.
+// Shallalist), so the stdout-line index does NOT map to the $lists index; a positional
+// unset() removed the wrong (often a healthy, already-downloaded) category (#711). The
+// child prints "\t{name} ... Failed" / "... Completed" (pfblockerng.php) with
+// name == $list['aliasname']; the " ... " delimiter guards against a prefix collision.
+function pfb_prune_failed_bl_lists(array $lists, array $pfb_return): array {
+	foreach ($pfb_return as $return_output) {
+		if (strpos($return_output, 'Failed') === FALSE) {
+			continue;
+		}
+		foreach ($lists as $list_key => $list_val) {
+			if (isset($list_val['aliasname']) &&
+			    str_starts_with(ltrim($return_output), "{$list_val['aliasname']} ... ")) {
+				unset($lists[$list_key]);
+				break;
+			}
+		}
+	}
+	return $lists;
+}
+
 // Determine 'list' details
 function pfb_determine_list_detail($list='', $header='', $confconfig='', $key='') {
 	global $pfb, $pfbarr;
@@ -13977,15 +14008,15 @@ function sync_package_pfblockerng($cron='') {
 							exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php bls {$bl_string} 2>&1", $pfb_return);
 
 							if (is_array($pfb_return)) {
-								foreach ($pfb_return as $key => $return_output) {
-
+								foreach ($pfb_return as $return_output) {
 									pfb_logger("{$return_output}\n", 1);
-
-									// On download failure, remove associated Blacklist category configuration
-									if (strpos($return_output, 'Failed') !== FALSE) {
-										unset($lists[$key]);
-									}
 								}
+
+								// On download failure, remove the associated Blacklist category
+								// by matching the feed NAME in the child's output line, not the
+								// stdout-line index (the child skips already-downloaded/some feeds,
+								// so the index does not map to $lists) — #711.
+								$lists = pfb_prune_failed_bl_lists($lists, $pfb_return);
 							}
 						}
 						else {
@@ -14047,6 +14078,13 @@ function sync_package_pfblockerng($cron='') {
 						continue;
 					}
 					$pfb['alias_dnsbl_all'][]	= "{$alias}";
+
+					// cURL Source Interface (sets CURLOPT_INTERFACE) — per-DNSBL-group
+					// field, mirrors the IP loop. Previously $srcint was undefined here
+					// (only assigned later in the IP loop), so the configured interface was
+					// silently ignored on DNSBL ingest (#712). '?? '' keeps a legacy DNSBL
+					// config with no srcint field warning-free.
+					$srcint = $list['srcint'] ?? '' ?: FALSE;
 
 					foreach ($list['row'] as $key => $row) {
 						if (!empty($row['url']) && $row['state'] != 'Disabled') {
@@ -14171,7 +14209,7 @@ function sync_package_pfblockerng($cron='') {
 									} else {
 										// Download file
 										if (!pfb_download($row['url'], $file_dwn, $pflex, $header,
-											$row['format'], 1, '', '', '', '', '', $srcint)) {
+											$row['format'], 1, '', 300, '', '', '', $srcint)) {
 
 											// Determine reason for download failure
 											pfb_download_failure($alias, $header, $pfbfolder, $row['url'], $row['format'], '');
@@ -15773,7 +15811,9 @@ function sync_package_pfblockerng($cron='') {
 						if (isset($list['dnsblip'])) {
 							$list_type = 'pfblockerngdnsblsettings';
 						} else {
-							$list_type = "{$ip_type}";
+							// $ip_type is stale here (this download loop runs after the
+							// collection loop); derive the section from the list's vtype (#709).
+							$list_type = pfb_list_section_for_vtype($list['vtype']);
 						}
 
 						pfb_determine_list_detail($list['action'], $header, $list_type, $list['key']);
@@ -15866,7 +15906,7 @@ function sync_package_pfblockerng($cron='') {
 								else {
 									// Download list
 									if (!pfb_download($row['url'], $file_dwn, $pflex, $header, $row['format'],
-										1, $list['vtype'], '', '', '', '', $srcint)) {
+										1, $list['vtype'], 300, '', '', '', $srcint)) {
 
 										// Determine reason for download failure
 										pfb_download_failure($alias, $header, $pfbfolder, $row['url'], $row['format'], $list['vtype']);
@@ -16372,8 +16412,11 @@ function sync_package_pfblockerng($cron='') {
 					$list_type = "{$ip_type}";
 				}
 
-				// Determine 'list' details (return array $pfbarr)
-				pfb_determine_list_detail($list['action'], '', $list_type, $key);
+				// Determine 'list' details (return array $pfbarr). Use the list's own key
+				// (the synthetic DNSBLIP entry carries key=0 for the pfblockerngdnsblsettings
+				// singleton); real config rows have no 'key', so fall back to the foreach index
+				// = the config row index (#710). Mirrors the download-loop call.
+				pfb_determine_list_detail($list['action'], '', $list_type, $list['key'] ?? $key);
 				$pfbadv		= $pfbarr['adv'];
 				$pfbdescr	= $pfbarr['descr'];
 				$pfbfolder	= $pfbarr['folder'];

--- a/tests/php/DownloadLoopHelpersTest.php
+++ b/tests/php/DownloadLoopHelpersTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pure helpers extracted from sync_package_pfblockerng()'s download loop.
+ *
+ * pfb_prune_failed_bl_lists() — issue #711. On a Blacklist download failure the
+ * cleanup used to unset($lists[$key]) with $key being the child's STDOUT LINE index,
+ * not a $lists index. pfblockerng_download_extras processes only the not-yet-downloaded
+ * types and silently skips some feeds (Shallalist), so the two index spaces do not
+ * correspond: a positional unset() dropped the WRONG category (often a healthy,
+ * already-downloaded one) while the failed feed stayed. The helper matches by feed
+ * NAME in the child's "\t{name} ... Failed" line instead.
+ *
+ * pfb_list_section_for_vtype() — issue #709. Maps a list's vtype to its config
+ * section so the download loop reads the correct per-family section rather than the
+ * stale $ip_type (the caller-level fix is proven by live-VM smoke; this pins the map).
+ */
+#[CoversFunction('pfb_prune_failed_bl_lists')]
+#[CoversFunction('pfb_list_section_for_vtype')]
+final class DownloadLoopHelpersTest extends TestCase
+{
+	/**
+	 * @param array<int, array<string, mixed>> $lists
+	 * @return string[] the surviving aliasnames, in order
+	 */
+	private static function survivingNames(array $lists): array
+	{
+		return array_values(array_map(static fn(array $l): string => $l['aliasname'], $lists));
+	}
+
+	// -----------------------------------------------------------------------
+	// #711 — pfb_prune_failed_bl_lists()
+	// -----------------------------------------------------------------------
+
+	/**
+	 * The canonical desync: a healthy already-downloaded feed A precedes a failed
+	 * new feed B. Only B is in the child's output, at stdout index 0. The positional
+	 * code unset($lists[0]) and dropped HEALTHY A; the name match drops only B.
+	 */
+	public function testHealthyFirstFailedSecondRemovesOnlyTheFailed(): void
+	{
+		// Given: A already-downloaded/healthy, B new and failed.
+		$lists = [
+			['aliasname' => 'AlphaFeed', 'row' => [['url' => 'u']]],
+			['aliasname' => 'BetaFeed',  'row' => [['url' => 'u']]],
+		];
+		// The child processed only B (the not-yet-downloaded one) and it Failed.
+		$pfb_return = ["\tBetaFeed ... Failed"];
+
+		// Before: both present.
+		$this->assertSame(['AlphaFeed', 'BetaFeed'], self::survivingNames($lists));
+
+		// When.
+		$result = pfb_prune_failed_bl_lists($lists, $pfb_return);
+
+		// Then: only BetaFeed removed; AlphaFeed (the healthy one) survives.
+		$this->assertSame(['AlphaFeed'], self::survivingNames($result),
+			'Only the FAILED feed (BetaFeed) must be dropped; the healthy AlphaFeed must survive');
+	}
+
+	/**
+	 * A skipped feed (Shallalist emits no line) shifts the stdout offset, so the
+	 * positional code dropped the skipped/neighbouring entry. Name-matching removes
+	 * exactly the failed feed regardless of the offset.
+	 */
+	public function testSkippedFeedOffsetRemovesOnlyTheFailed(): void
+	{
+		$lists = [
+			['aliasname' => 'Alpha',      'row' => [['url' => 'u']]],
+			['aliasname' => 'Shallalist', 'row' => [['url' => 'u']]],
+			['aliasname' => 'Beta',       'row' => [['url' => 'u']]],
+		];
+		// Shallalist is skipped (no line); Alpha completed, Beta failed.
+		$pfb_return = ["\tAlpha ... Completed", "\tBeta ... Failed"];
+
+		$result = pfb_prune_failed_bl_lists($lists, $pfb_return);
+
+		$this->assertSame(['Alpha', 'Shallalist'], self::survivingNames($result),
+			'Only Beta must be removed; the skipped Shallalist and completed Alpha must survive');
+	}
+
+	/**
+	 * The " ... " delimiter after the name prevents a prefix collision: a failed
+	 * "FeedExtra" must not also drop "Feed".
+	 */
+	public function testPrefixCollisionMatchesWholeNameOnly(): void
+	{
+		$lists = [
+			['aliasname' => 'Feed',      'row' => [['url' => 'u']]],
+			['aliasname' => 'FeedExtra', 'row' => [['url' => 'u']]],
+		];
+		$pfb_return = ["\tFeedExtra ... Failed"];
+
+		$result = pfb_prune_failed_bl_lists($lists, $pfb_return);
+
+		$this->assertSame(['Feed'], self::survivingNames($result),
+			'FeedExtra must be removed; the prefix Feed must NOT be collaterally dropped');
+	}
+
+	/**
+	 * A "Failed" line whose name is not in $lists (e.g. an item with no rows) removes
+	 * nothing — the old blind index unset() could still drop an unrelated entry.
+	 */
+	public function testFailedNameAbsentFromListsIsNoOp(): void
+	{
+		$lists = [
+			['aliasname' => 'Alpha', 'row' => [['url' => 'u']]],
+			['aliasname' => 'Beta',  'row' => [['url' => 'u']]],
+		];
+		$pfb_return = ["\tGamma ... Failed"]; // Gamma is not in $lists
+
+		$result = pfb_prune_failed_bl_lists($lists, $pfb_return);
+
+		$this->assertSame(['Alpha', 'Beta'], self::survivingNames($result),
+			'A Failed line for a name absent from $lists must remove nothing');
+	}
+
+	/**
+	 * All-completed output removes nothing (guards against over-eager matching on
+	 * the "Completed" lines).
+	 */
+	public function testAllCompletedRemovesNothing(): void
+	{
+		$lists = [
+			['aliasname' => 'Alpha', 'row' => [['url' => 'u']]],
+			['aliasname' => 'Beta',  'row' => [['url' => 'u']]],
+		];
+		$pfb_return = ["\tAlpha ... Completed", "\tBeta ... Completed"];
+
+		$result = pfb_prune_failed_bl_lists($lists, $pfb_return);
+
+		$this->assertSame(['Alpha', 'Beta'], self::survivingNames($result),
+			'No Failed line -> no removal');
+	}
+
+	// -----------------------------------------------------------------------
+	// #709 — pfb_list_section_for_vtype()
+	// -----------------------------------------------------------------------
+
+	public function testVtypeV4MapsToV4Section(): void
+	{
+		$this->assertSame('pfblockernglistsv4', pfb_list_section_for_vtype('_v4'));
+	}
+
+	public function testVtypeV6MapsToV6Section(): void
+	{
+		$this->assertSame('pfblockernglistsv6', pfb_list_section_for_vtype('_v6'));
+	}
+
+	public function testNonV6VtypeDefaultsToV4Section(): void
+	{
+		// Anything that is not the exact '_v6' token is treated as v4 (fail-safe).
+		$this->assertSame('pfblockernglistsv4', pfb_list_section_for_vtype(''));
+	}
+}

--- a/tests/smoke/test_smoke_download_loop.py
+++ b/tests/smoke/test_smoke_download_loop.py
@@ -1,0 +1,415 @@
+"""Live-VM smoke coverage for the download-loop cluster fixes (#709 / #710 / #712).
+
+Four related bugs were fixed in ``sync_package_pfblockerng()``'s download/apply
+loops (commit "pfblockerng: fix IP/DNSBL download-loop cluster …").  The two pure
+helpers (#709 ``pfb_list_section_for_vtype`` / #711 ``pfb_prune_failed_bl_lists``)
+are red->green unit-pinned off-box in ``tests/php/DownloadLoopHelpersTest.php``.
+This module proves the CALLER-LEVEL behaviour that only a live pfBlockerNG update
+pass exhibits — the part a pure unit test cannot reach:
+
+* **#709 — a v4 IP list with "Invert src/dst" lands its members in its pf table.**
+  The download loop runs AFTER the ``$ip_types`` collection loop, so ``$ip_type``
+  was left stale at ``'pfblockernglistsv6'``.  A v4 list with the Advanced
+  ``autoaddrnot_in='on'`` flag (which forces Alias-Native) therefore had its member
+  file written to ``denydir`` (the stale-section read missed the invert flag and
+  kept the Deny folder) while the Configure-Aliases loop — which recomputes the
+  section correctly — read ``nativedir``.  The two disagreed, so the v4 list's IPs
+  never reached its ``pfB_<alias>_v4`` table (empty table).  The fix derives the
+  section from the list's OWN vtype (``pfb_list_section_for_vtype($list['vtype'])``).
+
+* **#710 — the DNSBLIP auto firewall rule keeps its configured Invert.**  In the
+  Configure-Aliases loop the synthetic DNSBLIP entry sits at foreach index N (= the
+  number of configured IP lists) but its advanced settings live on the
+  ``pfblockerngdnsblsettings`` config/0 singleton.  Passing the raw foreach index
+  made ``pfb_determine_list_detail()`` read config/N and miss the invert (plus PHP
+  8.3 undefined-key warnings), so the ``pfB_DNSBLIP_v4`` rule lost its ``!``
+  negation.  The bug is MASKED when the index is 0 — so this test configures ≥1 v4
+  IP list on purpose, pushing DNSBLIP to index 1.  The fix passes
+  ``$list['key'] ?? $key`` (DNSBLIP carries key=0).
+
+* **#712 — a DNSBL group's configured Source Interface is honoured on download.**
+  ``$srcint`` was undefined at the top of the DNSBL group loop (only assigned later
+  in the IP loop), so ``CURLOPT_INTERFACE`` was never set for a DNSBL feed and the
+  ``"…will be downloaded via interface: <srcint>"`` log line (pfb_download, emitted
+  only when ``$srcint`` is truthy) never appeared.  The fix sets
+  ``$srcint = $list['srcint'] ?? '' ?: FALSE`` at the loop top.
+
+Each test is a RED->GREEN oracle: against ``origin/devel`` (the pre-fix baseline —
+the cluster fix is not yet on ``devel``) it FAILS for the exact documented reason;
+against this branch it PASSES.
+
+**#711 is DELIBERATELY not smoke-tested here (out-of-CI limitation).**  The #711
+prune (a healthy already-downloaded Blacklist category dropped when a later feed
+404s) exercises the LEGACY pre-defined "Blacklist" category download path
+(``pfblockerng_download_extras`` + the ``pfblockerng.php bls`` child), NOT the
+user-feed path the smoke harness drives.  Reproducing a mid-batch 404 in that
+child on a live box is not cleanly achievable in the harness, and a contrived
+approximation would be coverage theater.  #711 is fully red->green covered off-box
+by ``tests/php/DownloadLoopHelpersTest.php`` (the helper is exercised against the
+old positional-unset logic), which is the authoritative gate for that fix.
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke``).  Run
+via the smoke workflow or locally::
+
+    python -m pytest tests/smoke -m smoke --override-ini="addopts="
+
+Requires the booted ``smoke_vm`` fixture, the branch ``.pkg`` (``SMOKE_PKG``), and
+the smoke deps; without them these tests skip cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM, _MockFeedServer
+
+pytestmark = pytest.mark.smoke
+
+# The SLIRP WAN host-alias net the mock feed server rides (192.168.89.2).  The
+# default-ON feed-host SSRF guard (pfb_feed_internal_filter) would reject the mock's
+# RFC1918 address; allowlisting the net keeps the filter ON yet lets the mock fetch
+# through — needed only by #712 (its DNSBL feed is fetched over HTTP so pfb_download
+# takes the cURL path where the srcint log line lives).
+SLIRP_FEED_NET = "192.168.89.0/24"
+
+# A full set of per-direction "Advanced" fields, GUI defaults, so
+# pfb_determine_list_detail() reads every key it expects (autoproto/autonot/
+# autoaddrnot/agateway + autoports/autoaddr) with NO PHP 8.3 undefined-key warning —
+# exactly the shape pfblockerng_category_edit.php persists.  A test overlays the one
+# field it exercises (autoaddrnot_in/out) on top of this baseline.
+_ADVANCED_FIELD_DEFAULTS: dict[str, str] = {
+    "autoaddrnot_in": "",
+    "autoaddrnot_out": "",
+    "autoports_in": "",
+    "autoports_out": "",
+    "autoaddr_in": "",
+    "autoaddr_out": "",
+    "autonot_in": "",
+    "autonot_out": "",
+    "autoproto_in": "any",
+    "autoproto_out": "any",
+    "agateway_in": "default",
+    "agateway_out": "default",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Module fixture — deploy once, plus a per-test clean slate
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def download_loop_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg once for the download-loop module.
+
+    Egress stays OPEN (``pkg add`` + the DNSBL feed fetch need a reachable
+    network / the SLIRP mock).  The DNSBL VIP is injected (DNSBL force-disables
+    itself without one) and the SLIRP mock net is allowlisted through the SSRF
+    guard so #712's HTTP DNSBL feed downloads.  A full guest snapshot is collected
+    on teardown for the workflow to upload.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.snapshot_unbound_conf(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.set_feed_internal_allowlist(smoke_vm, SLIRP_FEED_NET)
+    try:
+        yield smoke_vm
+    finally:
+        h.collect_host_diagnostics(smoke_vm)
+
+
+@pytest.fixture(autouse=True)
+def _clean_slate(download_loop_vm: SmokeVM) -> Iterator[None]:
+    """Give every test an EMPTY pfBlockerNG config + the shared infra, before it runs.
+
+    The module VM is one long-lived boot whose disk persists across tests, so a
+    prior test's injected feeds/settings would bleed forward (e.g. a leftover v4 IP
+    list would perturb #710's DNSBLIP index arithmetic — a false green).
+    ``reset_pfb_baseline`` wipes the config to empty; it also drops the DNSBL VIP
+    and the SSRF allowlist (both live in wiped sections), so re-establish them here
+    so each test starts from an identical known baseline.
+    """
+    h.reset_pfb_baseline(download_loop_vm)
+    h.ensure_dnsbl_vip(download_loop_vm)
+    h.set_feed_internal_allowlist(download_loop_vm, SLIRP_FEED_NET)
+    yield
+
+
+# --------------------------------------------------------------------------- #
+# Small on-box helpers
+# --------------------------------------------------------------------------- #
+
+
+def _file_present(vm: SmokeVM, path: str, *, timeout: float = 30.0) -> bool:
+    """True iff ``path`` exists on the guest (a plain ``test -f``)."""
+    return vm.ssh("/bin/test", "-f", path, timeout=timeout).returncode == 0
+
+
+def _read_file(vm: SmokeVM, path: str, *, timeout: float = 30.0) -> str:
+    """Return the guest file's text, or '' if it does not exist."""
+    result = vm.ssh("cat", path, timeout=timeout)
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _set_row_advanced_fields(
+    vm: SmokeVM, section: str, rowid: str, fields: dict[str, str], *, timeout: float = 60.0
+) -> None:
+    """Merge ``fields`` into an ``installedpackages/<section>/config/<rowid>`` row.
+
+    Mirrors how pfblockerng_category_edit.php persists a feed row's Advanced
+    settings — a per-key ``config_set_path`` overlay — but done as one merge so the
+    rest of the row (aliasname/action/row[]) written by ``inject`` is preserved.
+    Written AFTER ``inject`` (which replaces its whole section) so the fields survive.
+    """
+    path = f"installedpackages/{section}/config/{rowid}"
+    snippet = (
+        f"$row = config_get_path({h._php_str(path)}, array());\n"
+        f"$row = array_merge($row, {h._php_kv_array(fields)});\n"
+        f"config_set_path({h._php_str(path)}, $row);\n"
+        "write_config('pfBlockerNG smoke: set advanced feed fields');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_set_row_advanced_fields({section}/{rowid}) failed: "
+            f"rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# #709 — a v4 Invert-src/dst list's members reach its pf table
+# --------------------------------------------------------------------------- #
+
+
+def test_709_invert_v4_list_members_reach_pf_table(download_loop_vm: SmokeVM) -> None:
+    """A v4 Deny list with Invert-src/dst lands its feed IP in its pf table (not an empty one).
+
+    Scenario (#709): the download loop must derive the per-list config section from
+    the list's OWN vtype, not the stale ``$ip_type`` left over from the collection
+    loop.
+
+    **Given** exactly ONE v4 Deny IP list whose feed carries an RFC 5737 IP and whose
+    Advanced ``autoaddrnot_in='on'`` (Invert src/dst) forces Alias-Native, and NO v6
+    lists (so the stale ``$ip_type`` = ``'pfblockernglistsv6'`` reads a section that
+    does not exist),
+
+    **When** a full ``update`` runs,
+
+    **Then** the member file lands in ``nativedir`` (Alias-Native's folder) — NOT
+    ``denydir`` — so the Configure-Aliases loop (which also computes ``nativedir``)
+    reads it; the last-applied alias mirror carries the fed IP; and the fed IP is a
+    member of ``pfB_<alias>_v4``.
+
+    Pre-fix (origin/devel): the stale-section read misses the invert flag, keeps the
+    Deny folder, and writes the member file to ``denydir`` while the alias loop reads
+    the empty ``nativedir`` — so the mirror is never written and the pf table is
+    empty.  FAILS before the fix on all three checks; PASSES after.
+    """
+    vm = download_loop_vm
+    fed_ip = "203.0.113.9"  # RFC 5737 TEST-NET-3
+    header = "smokeinvert"
+    spec = h.IpCase(aliasname="smokeinvert", feed_url="", header=header, action="Deny_Both", family="v4")
+
+    # Given: the v4 Deny list + its local feed, with Invert-src/dst forcing Alias-Native.
+    spec.feed_url = h.write_local_feed(vm, "smoke709_invert.txt", f"{fed_ip}\n")
+    h.inject(vm, spec)
+    fields = dict(_ADVANCED_FIELD_DEFAULTS)
+    fields["autoaddrnot_in"] = "on"
+    _set_row_advanced_fields(vm, "pfblockernglistsv4", "0", fields)
+
+    # When: a full update runs.
+    h.reload(vm, "update")
+
+    native_member = f"{h.PFB_DBDIR}/native/{header}_v4.txt"
+    deny_member = f"{h.PFB_DBDIR}/deny/{header}_v4.txt"
+    mirror = f"/var/db/aliastables/{spec.alias}.txt"
+    in_native = _file_present(vm, native_member)
+    in_deny = _file_present(vm, deny_member)
+    mirror_body = _read_file(vm, mirror)
+    members = h.wait_pfctl_table(vm, spec.alias)
+
+    def _report() -> str:
+        return (
+            "  #709 — v4 Invert-src/dst list member routing:\n"
+            f"    Expected member file : {native_member} PRESENT (Alias-Native folder)\n"
+            f"    Expected NOT present : {deny_member} (the stale-section Deny folder)\n"
+            f"    Expected mirror      : {mirror} contains {fed_ip}\n"
+            f"    Expected pf table    : {spec.alias} contains {fed_ip}\n"
+            f"  Actual:\n"
+            f"    native member file present : {in_native}\n"
+            f"    deny   member file present : {in_deny}\n"
+            f"    mirror body                : {mirror_body.strip()!r}\n"
+            f"    pf table members           : {members}"
+        )
+
+    # Then: the member file landed in nativedir (the section fix), not denydir.
+    assert in_native, "member file NOT in nativedir — the download loop wrote to the wrong section\n" + _report()
+    assert not in_deny, "member file ALSO in denydir — the stale v6-section read routed it wrong\n" + _report()
+    # And: the alias mirror (pf's source of truth) carries the fed IP.
+    assert fed_ip in mirror_body, "alias mirror missing the fed IP — the alias loop read an empty folder\n" + _report()
+    # And: the fed IP actually reached the kernel pf table (the user-facing symptom).
+    assert h.member_present(members, fed_ip), f"fed IP {fed_ip} not in {spec.alias} — empty table\n" + _report()
+
+
+# --------------------------------------------------------------------------- #
+# #710 — the DNSBLIP auto rule keeps its configured Invert (index != 0)
+# --------------------------------------------------------------------------- #
+
+
+def _dnsblip_rule_lines(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:
+    """Return the ``pfctl -sr`` rule lines that reference ``pfB_DNSBLIP_v4``."""
+    result = vm.ssh(h.PFCTL, "-sr", timeout=timeout)
+    if result.returncode != 0:
+        return []
+    return [ln.strip() for ln in result.stdout.splitlines() if "pfB_DNSBLIP_v4" in ln]
+
+
+def test_710_dnsblip_auto_rule_keeps_configured_invert(download_loop_vm: SmokeVM) -> None:
+    """With ≥1 IP list present, the pfB_DNSBLIP_v4 auto rule carries its configured Invert.
+
+    Scenario (#710): the synthetic DNSBLIP entry must read its advanced settings from
+    the ``pfblockerngdnsblsettings`` config/0 singleton, not from config/N where N is
+    its foreach index.
+
+    **Given** DNSBL enabled with ``dnsbl_ip`` action = ``Deny_Both`` and Advanced
+    ``autoaddrnot_in='on'`` + ``autoaddrnot_out='on'`` (Invert) set on the DNSBL-IP
+    settings, AND exactly ONE configured v4 IP list — so the DNSBLIP synthetic entry
+    sits at foreach index 1, not 0 (index 0 MASKS the bug: config[0] is the right
+    singleton by luck, giving a false green),
+
+    **When** a full ``update`` runs and the filter reload is applied,
+
+    **Then** a loaded ``pfB_DNSBLIP_v4`` rule exists AND carries the ``!`` negation
+    (the configured Invert reached the rule).
+
+    Pre-fix (origin/devel): ``pfb_determine_list_detail`` is handed the foreach index
+    (1) instead of the DNSBLIP key (0) and reads the non-existent config/1.  Observed
+    live effect: the mis-read advanced settings drop the ``pfB_DNSBLIP_v4`` auto-rule
+    ENTIRELY — pf loads NO v4 DNSBLIP rule at all (``pfB_DNSBLIP_v6``, built with the
+    right index, is unaffected and still carries its ``!``).  So the test fails at the
+    "rule exists" check before the fix; after the fix the rule is present AND carries
+    the ``!`` invert.  (The bug's headline is "loses its Invert"; the live severity is
+    stronger — the whole v4 rule vanishes.)
+    """
+    vm = download_loop_vm
+
+    # Given: one plain v4 Deny IP list (occupies index 0, pushing DNSBLIP to index 1).
+    ip_feed = h.write_local_feed(vm, "smoke710_ip.txt", "198.51.100.20\n")
+    ip_spec = h.IpCase(aliasname="smoke710ip", feed_url=ip_feed, header="smoke710ip", action="Deny_Both", family="v4")
+    h.inject(vm, ip_spec)
+
+    # Given: a DNSBL group with DNSBL-IP = Deny_Both (so pfB_DNSBLIP_v4 is a rule-creating
+    # alias).  Its feed carries a domain + an embedded IP so DNSBLIP_v4.txt is populated.
+    dnsbl_feed = h.write_local_feed(vm, "smoke710_dnsbl.txt", f"{h.unique_domain()}\n203.0.113.42\n")
+    dnsbl_spec = h.DnsblCase(
+        aliasname="smoke710dnsbl",
+        feed_url=dnsbl_feed,
+        header="smoke710dnsbl",
+        mode=h.DnsblMode.VIP,
+        dnsbl_ip_action="Deny_Both",
+    )
+    h.inject(vm, dnsbl_spec)
+
+    # Given: the Invert (autoaddrnot) advanced fields on the DNSBL-IP settings singleton
+    # (config/0 of pfblockerngdnsblsettings) — the settings pfb_determine_list_detail must
+    # read via the DNSBLIP key, not the foreach index.
+    fields = dict(_ADVANCED_FIELD_DEFAULTS)
+    fields["autoaddrnot_in"] = "on"
+    fields["autoaddrnot_out"] = "on"
+    _set_row_advanced_fields(vm, "pfblockerngdnsblsettings", "0", fields)
+
+    # When: a full update runs; make the pf ruleset authoritative (filter_configure is async).
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
+
+    lines = _dnsblip_rule_lines(vm)
+
+    def _report() -> str:
+        body = "\n".join(f"      {ln}" for ln in lines) if lines else "      (no rule references pfB_DNSBLIP_v4)"
+        return (
+            "  #710 — pfB_DNSBLIP_v4 auto-rule Invert:\n"
+            "    Expected: a loaded rule referencing pfB_DNSBLIP_v4 that carries the '!' negation\n"
+            "              (source/dest inverted — the configured autoaddrnot_in/out='on').\n"
+            f"  Actual pfB_DNSBLIP_v4 rules (pfctl -sr):\n{body}"
+        )
+
+    # First red symptom: pre-fix the wrong-index read drops the v4 DNSBLIP rule ENTIRELY,
+    # so pf loads no rule referencing pfB_DNSBLIP_v4.  This is NOT a setup problem — the
+    # IDENTICAL setup builds the rule once the fix reads config/0 (proven by the green leg).
+    assert lines, "no pf rule references pfB_DNSBLIP_v4 — the v4 DNSBLIP auto-rule was not created\n" + _report()
+    # Second check (post-fix regression guard): the rebuilt rule carries the invert negation,
+    # so a future regression that keeps the rule but drops the '!' is still caught.
+    assert any("!" in ln for ln in lines), (
+        "the pfB_DNSBLIP_v4 rule lost its configured Invert (no '!' negation) — "
+        "the DNSBLIP advanced settings were read from the wrong config index\n" + _report()
+    )
+
+
+# --------------------------------------------------------------------------- #
+# #712 — a DNSBL group's Source Interface is honoured on download
+# --------------------------------------------------------------------------- #
+
+
+def test_712_dnsbl_source_interface_used_on_download(download_loop_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """A DNSBL group configured with a Source Interface downloads its feed via that interface.
+
+    Scenario (#712): ``$srcint`` must be set at the top of the DNSBL group loop so a
+    DNSBL feed's cURL download binds ``CURLOPT_INTERFACE`` — mirroring the IP loop.
+
+    **Given** a DNSBL group whose feed is served over HTTP (so pfb_download takes the
+    cURL path, where the source-interface log line lives) and whose ``srcint`` is set
+    to the box's real WAN interface, with the feed forced to re-download (no reuse),
+
+    **When** a DNSBL ``update`` runs,
+
+    **Then** the pfBlockerNG log gains a NEW ``"…will be downloaded via interface:
+    <realif>"`` line for this feed — pfb_download only logs it when ``$srcint`` is
+    truthy.
+
+    Pre-fix (origin/devel): ``$srcint`` is undefined in the DNSBL loop (only assigned
+    later in the IP loop) → falsy → ``CURLOPT_INTERFACE`` unset and the log line never
+    written.  The before/after log-count delta is 0 before the fix, ≥1 after.
+    """
+    vm = download_loop_vm
+
+    # The box's real WAN interface — what the GUI stores in 'srcint' (the realif key of
+    # get_configured_interface_list_by_realif); WAN is the interface that reaches the
+    # SLIRP mock at 192.168.89.2, so the bound download still succeeds.
+    realif = h._php_read_scalar(vm, "", "get_real_interface('wan')").strip()
+    if not realif:
+        pytest.skip("could not resolve the WAN real interface for the srcint test")
+
+    header = "smoke712dl"
+    # Serve the DNSBL feed over HTTP so pfb_download takes the cURL branch (a local-file
+    # feed never reaches the srcint log line, which lives only in the cURL path).
+    feed_url = mock_feeds.register("smoke712_dnsbl.txt", f"{h.unique_domain()}\n")
+    spec = h.DnsblCase(aliasname="smoke712dnsbl", feed_url=feed_url, header=header, mode=h.DnsblMode.VIP)
+    h.inject(vm, spec)
+
+    # Set the DNSBL group's Source Interface (srcint lives on the DNSBL list row, config/0).
+    _set_row_advanced_fields(vm, "pfblockerngdnsbl", "0", {"srcint": realif})
+
+    # Force a real re-download (defeat the reuse gate) so pfb_download runs this pass.
+    h.force_dnsbl_refetch(vm, header)
+
+    marker = f"will be downloaded via interface: {realif}"
+    before = h.count_log_marker(vm, h.PFB_LOG, marker)
+    h.reload(vm, "updatednsbl")
+    after = h.count_log_marker(vm, h.PFB_LOG, marker)
+
+    log_tail = _read_file(vm, h.PFB_LOG)[-1500:]
+    assert after > before, (
+        "  #712 — DNSBL Source Interface on download:\n"
+        f"    Expected: a NEW '{marker}' line in {h.PFB_LOG} after the DNSBL update\n"
+        f"              (pfb_download logs it only when $srcint is truthy).\n"
+        f"    Actual:   marker count before={before}, after={after} (no new line)\n"
+        f"    srcint (WAN realif) = {realif!r}\n"
+        f"  Log tail:\n{log_tail}"
+    )


### PR DESCRIPTION
Fixes four independent bugs in `sync_package_pfblockerng()`'s download/apply loops, found in the codebase audit. Each is small and self-contained; they share the loop so they land together.

## Fixes

- **#709 — stale `$ip_type` reads the wrong config section.** The download loop ran after the `$ip_types` collection loop, so `$ip_type` was left at the last family. A v4 list read its advanced settings from the v6 section (or vice-versa). Now the section is derived from the list's own vtype via the new `pfb_list_section_for_vtype($vtype)` helper.
- **#710 — DNSBLIP synthetic entry passed the foreach index instead of its key.** `pfb_determine_list_detail()` was handed the foreach index `$key`; the synthetic DNSBLIP entry carries `key=0` but sits at a non-zero index when any IP list precedes it, so it read the wrong `config/N` and dropped its advanced settings (Invert). Now passes `$list['key'] ?? $key`.
- **#711 — Blacklist download-failure unset the wrong `$lists` entry.** The cleanup used a child STDOUT *line* index as a `$lists` index; the two spaces desync (skipped/reordered feeds), so a healthy already-downloaded category was dropped while the failed one stayed. Now prunes by matching the failed feed's name in the child's `"\t<name> ... Failed"` line (`pfb_prune_failed_bl_lists()`).
- **#712 — DNSBL feed downloads ignored the configured source interface + had no transfer timeout.** `$srcint` was undefined at the top of the DNSBL group loop (only assigned later in the IP loop), so `CURLOPT_INTERFACE` was never bound for a DNSBL feed; the 8th `pfb_download` arg was `''` (no timeout). Now sets `$srcint` at the loop top and passes a 300s timeout, mirroring the IP loop.

## Tests (red→green)

- **Off-box PHPUnit** — `tests/php/DownloadLoopHelpersTest.php` pins the two extracted pure helpers: `pfb_prune_failed_bl_lists()` (**#711**, proven red against the old positional-unset logic) and `pfb_list_section_for_vtype()` (**#709** mapping).
- **Live-VM smoke** — `tests/smoke/test_smoke_download_loop.py` covers the caller-level behaviour the pure helpers can't reach (**#709 / #710 / #712**). Validated on the live pool: **GREEN (fix+test) 3 passed; RED (test on pre-fix `devel`) 3 failed** for the documented reasons (empty pf table / no `pfB_DNSBLIP_v4` rule / no `via interface` log line).
- **#711** is intentionally not smoke-tested (out-of-CI limitation): its legacy pre-defined Blacklist download path isn't cleanly reproducible on a live box, and a contrived approximation would be coverage theater. It is fully red→green covered off-box by the PHPUnit helper. See the smoke module docstring.

Closes #709
Closes #710
Closes #711
Closes #712