### PR TITLE
ci: run the kcov coverage pass under bash and fix the cache key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,6 +244,13 @@ jobs:
         # PG-1: gate that no workflow bypasses the shared build/smoke scripts.
         run: sh scripts/parity-guard.sh .github/workflows
 
+      - name: Resolve runner image id for the kcov cache key
+        # ImageOS/ImageVersion are runner machine env vars, NOT part of the GHA
+        # `env` context — `${{ env.ImageOS }}` renders empty, so a key built from it
+        # never rolls over with the runner image. Export them via a step output.
+        id: runner-image
+        run: echo "id=${ImageOS:-unknown}-${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
       - name: Restore cached kcov binary
         # kcov was removed from ubuntu-latest's apt repos; build from source and
         # cache the install dir so subsequent runs skip the compile step.
@@ -251,7 +258,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.local/kcov
-          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ env.ImageVersion }}
+          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
 
       - name: Build kcov from source (cache miss)
         # Only runs when the cache is cold. best-effort: a compile failure still
@@ -275,7 +282,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.local/kcov
-          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-${{ env.ImageVersion }}
+          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
 
       - name: Install kcov runtime deps and add to PATH
         # Runtime shared libs (libcurl, libelf, libdw) needed on both cache hit
@@ -288,21 +295,27 @@ jobs:
       - name: Coverage (kcov) — informational
         # Informational only (no floor yet, mirroring #38); never gates CI. Guard on
         # kcov being present so a missing tool does not leave an error annotation.
+        # shellspec's kcov integration refuses .shellspec's `--shell sh` ("Require to
+        # use bash/zsh/ksh to run kcov") — override to bash for this re-run only; the
+        # gating `shellspec` run above stays on sh, and the POSIX specs run unchanged
+        # under bash (a superset) purely to collect coverage.
         continue-on-error: true
         run: |
           if command -v kcov >/dev/null 2>&1; then
-            shellspec --kcov
+            shellspec --kcov --shell bash
           else
             echo "kcov absent; skipping informational shell coverage"
           fi
 
       - name: Upload coverage report
+        # if-no-files-found: warn (not ignore) — a coverage run that produced nothing
+        # is exactly the silent-failure mode that hid the broken kcov invocation.
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: shell-coverage
           path: coverage/
-          if-no-files-found: ignore
+          if-no-files-found: warn
 
   php-syntax:
     name: PHP syntax check (php -l) / PHP ${{ matrix.php-version }}


### PR DESCRIPTION
Found by the after-the-fact review of the CodeRabbit quota-missed PRs: PR #514 rebuilt kcov from source but shell coverage never actually ran again, so issue #475's "coverage report produced again" criterion has been unmet — invisibly — on every run since.

## Defect 1 — coverage never runs

shellspec's kcov integration refuses `.shellspec`'s `--shell sh` and exits 1 on every run:

```text
Require to use bash/zsh/ksh to run kcov (e.g: --shell bash).
```

(see devel run 28587096461's Coverage step), swallowed by `continue-on-error: true`; `coverage/` is never created and `if-no-files-found: ignore` hides the missing artifact. Fix: `shellspec --kcov --shell bash` — the CLI flag overrides the options file for the coverage re-run only; the gating `shellspec` run above stays on `sh`, and the POSIX specs run unchanged under bash (a superset) purely to collect coverage. The artifact upload now uses `if-no-files-found: warn` so an empty coverage run surfaces instead of vanishing.

## Defect 2 — cache key never rolls over

The kcov cache key interpolated `${{ env.ImageOS }}`/`${{ env.ImageVersion }}`, which are runner *machine* env vars and not part of the GHA `env` context, so the key rendered as `kcov-v43-Linux-X64--` (visible in the same run's Restore step) and would never invalidate when the runner image rolls. They are now resolved into a step output and referenced from both the restore and save keys.

## Validation

- Local: the full shellspec suite passes under bash (`shellspec --shell bash`, rc=0; 4 pre-existing conditional skips).
- This PR's own `shellspec (POSIX sh)` job is the red→green evidence: the Coverage step must show kcov actually running (no "Require to use bash" refusal), the cache key must render with a real image id, and the `shell-coverage` artifact must be uploaded. Red-before is devel run 28587096461 (kcov refusal, zero artifacts).

Related: issue #475, PR #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved shell test coverage handling to better reuse cached coverage data across runner updates.
  * Coverage checks now run only when the required tooling is available, reducing spurious failures.
  * Missing coverage artifacts now show a warning instead of being silently ignored, making test results clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->