### PR TITLE
pfblockerng: harden shell download paths — xlsx tmpdir, anchored grep, whoisconvert rc (#714)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -816,6 +816,13 @@ whoisconvert() {
 	fi
 
 	echo
+	# ${found} ACCUMULATES across the loop: it is initialised false here and only
+	# ever set true on a successful entry, NEVER reset false inside the loop. So
+	# after the loop found=true iff AT LEAST ONE entry resolved (keep the data
+	# collected from the successful entries) and false iff nothing did (restore
+	# the .bk). Resetting it per-iteration would make it reflect only the LAST
+	# entry, discarding good data from earlier entries when the last one fails
+	# (issue #714).
 	found=false
 
 	# Iterate via a here-doc so the loop body stays in THIS shell (it sets the
@@ -847,7 +854,6 @@ whoisconvert() {
 			else
 				printf "... Failed to resolve host [ %s ]" "${host}"
 				touch "${pfborig}${alias}.fail"
-				found=false
 			fi
 			;;
 		*)
@@ -871,7 +877,6 @@ whoisconvert() {
 					''|*[!0-9]*)
 						printf "... Invalid ASN [ %s ]" "${host}"
 						touch "${pfborig}${alias}.fail"
-						found=false
 						continue
 						;;
 				esac
@@ -890,7 +895,6 @@ whoisconvert() {
 			else
 				printf "... Failed to collect ASN"
 				touch "${pfborig}${alias}.fail"
-				found=false
 			fi
 			rm -f "${pfborig}${alias}.wk"
 			;;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -27,6 +27,13 @@ pfb_make_tmpdir() {
 	addfile="${tmpdir}/pfbtemp5"
 	matchfile="${tmpdir}/pfbtemp7"
 	tempmatchfile="${tmpdir}/pfbtemp8"
+	# XLSX extraction scratch dir (issue #714) -- was a fixed /tmp/xlsx/ path
+	# (mkdir guarded only by "[ ! -d ]", which follows symlinks): a predictable
+	# world-writable location TOCTOU/symlink-attackable by another local user
+	# against this root-run script. Folding it under the private 0700 mktemp
+	# dir closes that hole the same way issue #30 closed it for the other temp
+	# files above.
+	tmpxlsx="${tmpdir}/xlsx/"
 }
 
 # Top-level initialisation. Guarded so the script can be sourced for unit tests
@@ -76,7 +83,6 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 
 	# Folder Locations
 	etdir=/var/db/pfblockerng/ET
-	tmpxlsx=/tmp/xlsx/
 	pfbdb=/var/db/pfblockerng/
 	pfbdeny=/var/db/pfblockerng/deny/
 	pfborig=/var/db/pfblockerng/original/
@@ -90,7 +96,8 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	# Store 'Match' d-dedups in matchdedup.txt file
 	matchdedup=matchdedup_v4.txt
 
-	# Create a private per-run temp directory (sets tempfile, tempfile2, ...).
+	# Create a private per-run temp directory (sets tempfile, tempfile2, ...,
+	# tmpxlsx).
 	pfb_make_tmpdir
 
 	# ADR-06: domainmaster / dnsbl_tld_remove / dnsbl_python_{data,zone,count} removed
@@ -111,7 +118,10 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	if [ ! -d "${pfsensealias}" ]; then mkdir "${pfsensealias}"; fi
 	if [ ! -d "${pfbmatch}" ]; then mkdir "${pfbmatch}"; fi
 	if [ ! -d "${etdir}" ]; then mkdir "${etdir}"; fi
-	if [ ! -d "${tmpxlsx}" ]; then mkdir "${tmpxlsx}"; fi
+	# tmpxlsx is a fresh subdir of the private mktemp -d tmpdir -- no existence
+	# guard needed (and none wanted: a pre-existing entry there would be a
+	# symlink-attack signal, not a legitimate state to tolerate).
+	mkdir "${tmpxlsx}"
 
 	if [ ! -f "${masterfile}" ]; then touch "${masterfile}"; fi
 	if [ ! -f "${mastercat}" ]; then touch "${mastercat}"; fi
@@ -387,8 +397,11 @@ remove() {
 			masterchk="$(grep -m1 "${query}" "${masterfile}")"
 
 			if [ -n "${masterchk}" ]; then
-				# Grep header with a trailing space character
-				grep "${header}[[:space:]]" "${masterfile}" > "${tempfile}"
+				# Grep header with a trailing space character. Anchored (^) so a
+				# shorter alias that is a SUFFIX of another (e.g. "Ads_v4" inside
+				# "BadAds_v4") doesn't over-match and strip a sibling's masterfile
+				# row -- masterfile rows always start with the alias at column 0.
+				grep "^${header}[[:space:]]" "${masterfile}" > "${tempfile}"
 				awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${masterfile}"
 			fi
 
@@ -515,8 +528,10 @@ EOF
 					lcheck="$(grep -m1 "${alias}" "${masterfile}")"
 
 					if [ -n "${lcheck}" ]; then
-						# Replace masterfile with changes to list.
-						grep "${alias}[[:space:]]" "${masterfile}" > "${tempfile}"
+						# Replace masterfile with changes to list. Anchored (^) --
+						# see duplicate()'s sibling grep for the suffix-over-match
+						# rationale (issue #714).
+						grep "^${alias}[[:space:]]" "${masterfile}" > "${tempfile}"
 						awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"
 						mv -f "${tempfile2}" "${masterfile}"
 						sed -e 's/^/'"$alias"' /' "${pfbfolder}${alias}.txt" >> "${masterfile}"
@@ -728,8 +743,12 @@ duplicate() {
 
 	# Only execute if 'Alias' exists in masterfile
 	if [ "${dupcheck}" -eq 1 ]; then
-		# Grep alias with a trailing space character
-		grep "${alias}[[:space:]]" "${masterfile}" > "${tempfile}"
+		# Grep alias with a trailing space character. Anchored (^) -- an
+		# unanchored pattern over-matches a shorter alias that is a SUFFIX of
+		# another (e.g. "Ads_v4" inside "BadAds_v4"), pulling the sibling's
+		# masterfile row into the removal set and silently dropping it
+		# (issue #714). Masterfile rows always start with the alias.
+		grep "^${alias}[[:space:]]" "${masterfile}" > "${tempfile}"
 		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${masterfile}"
 		cut -d ' ' -f2 "${masterfile}" > "${mastercat}"
 	fi
@@ -806,11 +825,30 @@ whoisconvert() {
 		# Determine if host is a Domain or an AS: a domain contains a dot.
 		case "${host}" in
 		*.*)
-			found=true
 			printf '  Collecting host IP: %s' "${host}"
-			echo "### Domain: ${host} ###" >> "${pfborig}${alias}.orig"
-			"${pathhost}" -t "${_type}" "${host}" | sed 's/^.* //' >> "${pfborig}${alias}.orig"
-			echo "... completed"
+			# Capture the lookup output + its OWN exit code first (a pipe's $?
+			# would reflect sed's status, not host's, hiding a failed lookup) --
+			# then keep only the "has (IPv6) address" lines so a failure message
+			# (e.g. "Host x not found: 3(NXDOMAIN)") can never be captured as
+			# data (issue #714). Mirrors the ASN branch below.
+			hostout="$("${pathhost}" -t "${_type}" "${host}")"
+			hostrc=$?
+			if [ "${hostrc}" -eq 0 ]; then
+				hostips="$(echo "${hostout}" | grep -E 'has( IPv6)? address' | sed 's/^.* //')"
+			else
+				hostips=''
+			fi
+
+			if [ -n "${hostips}" ]; then
+				found=true
+				echo "### Domain: ${host} ###" >> "${pfborig}${alias}.orig"
+				echo "${hostips}" >> "${pfborig}${alias}.orig"
+				echo "... completed"
+			else
+				printf "... Failed to resolve host [ %s ]" "${host}"
+				touch "${pfborig}${alias}.fail"
+				found=false
+			fi
 			;;
 		*)
 			# Download IPinfo asn databases on first use.

--- a/tests/shell/pfblockerng_masterfile_suffix_anchor_spec.sh
+++ b/tests/shell/pfblockerng_masterfile_suffix_anchor_spec.sh
@@ -1,0 +1,46 @@
+#shellcheck shell=sh
+# duplicate() strips an alias's own prior masterfile rows before re-adding its
+# current data. The grep that finds those rows used to be unanchored
+# (`grep "${alias}[[:space:]]"`), so a shorter alias that is a SUFFIX of
+# another over-matches: alias "Ads_v4" also matches the row for a sibling
+# alias "BadAds_v4" (its row ends "...Ads_v4 20.0.0.0/24" once the leading
+# "Bad" is skipped by an unanchored search), so the sibling's masterfile row
+# was pulled into the removal set and silently dropped (issue #714). Anchoring
+# the grep to the start of the line (masterfile rows always begin with the
+# alias at column 0) fixes it; the same bug + fix applies to the two sibling
+# sites in remove() and suppress().
+
+Describe 'duplicate() masterfile grep is anchored (issue #714 suffix over-match)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/mfanchor.XXXXXX")"
+    pfbdeny="${work}/deny/"; pfborig="${work}/orig/"
+    mkdir -p "$pfbdeny" "$pfborig"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; tempfile2="${work}/t2"
+    errorlog="${work}/err.log"
+    # grepcidr stub: -vf <file> <target> -> target lines not present (literal) in <file>.
+    pathgrepcidr="${work}/grepcidr"
+    printf '#!/bin/sh\ngrep -vxF -f "$2" "$3"\n' > "$pathgrepcidr"; chmod +x "$pathgrepcidr"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'never strips a sibling masterfile row whose alias is a suffix of the current one'
+    alias="Ads_v4"
+    # Ads_v4's own prior row, plus an UNRELATED sibling "BadAds_v4" whose row
+    # tail ("Ads_v4 20.0.0.0/24") is what an unanchored grep for "Ads_v4"
+    # wrongly matches too.
+    printf 'Ads_v4 10.0.0.0/24\nBadAds_v4 20.0.0.0/24\n' > "$masterfile"
+    printf '10.0.0.0/24\n' > "${pfbdeny}${alias}.txt"
+
+    When call duplicate
+    The status should be success
+    # duplicate() also prints an Original/Master/Final sanity table; not under
+    # test here, just consumed so shellspec doesn't flag it as unexpected output.
+    The stdout should include 'Master'
+    # Then BadAds_v4's row must survive untouched -- it was never Ads_v4's to remove.
+    The contents of file "$masterfile" should include 'BadAds_v4 20.0.0.0/24'
+  End
+End

--- a/tests/shell/pfblockerng_tempfile_spec.sh
+++ b/tests/shell/pfblockerng_tempfile_spec.sh
@@ -15,6 +15,16 @@ Describe 'pfblockerng.sh secure temp files (issue #30)'
       # mktemp -d must create the directory mode 0700 (no group/other access).
       The value "$(ls -ld "$tmpdir" | cut -c1-10)" should equal "drwx------"
     End
+
+    # issue #714: the XLSX scratch dir used to be a fixed, predictable /tmp/xlsx/
+    # path (TOCTOU/symlink risk for this root-run script). It must now live
+    # INSIDE the private per-run mktemp dir, not at a fixed /tmp location.
+    It 'folds the xlsx scratch dir inside the private tmpdir (issue #714)'
+      When call pfb_make_tmpdir
+      The variable tmpxlsx should match pattern "*/pfb.*/xlsx/"
+      # Containment: tmpxlsx must sit under this run's own tmpdir, not /tmp/xlsx/.
+      The variable tmpxlsx should match pattern "${tmpdir}/xlsx/"
+    End
   End
 
   Describe 'exitnow'

--- a/tests/shell/pfblockerng_whoisconvert_domain_spec.sh
+++ b/tests/shell/pfblockerng_whoisconvert_domain_spec.sh
@@ -1,0 +1,51 @@
+#shellcheck shell=sh
+# whoisconvert() domain branch (issue #714): a failed `host` lookup used to be
+# treated as success -- found=true was set unconditionally and the lookup's
+# output was piped straight into the .orig sink with no exit-code check, so a
+# failed DNS lookup landed as DATA (e.g. the literal "3(NXDOMAIN)" tail of
+# "Host x not found: 3(NXDOMAIN)"). The sibling ASN branch already checks its
+# result and falls back to the previous .orig (.bk) on failure; the domain
+# branch now mirrors it: on a failed lookup it touches an alias.fail marker
+# and leaves `found=false`, so the existing .bk-restore logic preserves the
+# last-good data instead of being clobbered with garbage.
+
+Describe 'whoisconvert() domain branch checks the host(1) result (issue #714)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/whoisdom.XXXXXX")"
+    pfborig="${work}/orig/"; mkdir -p "$pfborig"
+    alias="TestDomainList"
+    max="_v4"
+    dedup="a-failing-domain.com"
+
+    # host(1) stand-in: a failed lookup prints the classic NXDOMAIN message to
+    # stdout and exits 1 -- exactly what a real `host -t A <name>` does for a
+    # name that doesn't resolve.
+    pathhost="${work}/host"
+    cat > "$pathhost" <<'EOF'
+#!/bin/sh
+echo "Host $3 not found: 3(NXDOMAIN)"
+exit 1
+EOF
+    chmod +x "$pathhost"
+
+    # Last-good data already on disk before this run -- whoisconvert() must
+    # preserve it (via its .bk backup/restore) when the lookup fails.
+    printf '203.0.113.9\n' > "${pfborig}${alias}.orig"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'touches .fail and restores the last-good .orig instead of capturing the NXDOMAIN error text'
+    When call whoisconvert
+    The status should be success
+    The stdout should include 'Restoring previous data'
+    # Then a failure marker is left for the caller to notice...
+    The path "${pfborig}${alias}.fail" should be exist
+    # ...the previously-good data is restored, not clobbered...
+    The contents of file "${pfborig}${alias}.orig" should equal '203.0.113.9'
+    # ...and the raw host(1) error text never lands in .orig as if it were an IP.
+    The contents of file "${pfborig}${alias}.orig" should not include '3(NXDOMAIN)'
+  End
+End

--- a/tests/shell/pfblockerng_whoisconvert_domain_spec.sh
+++ b/tests/shell/pfblockerng_whoisconvert_domain_spec.sh
@@ -1,13 +1,21 @@
 #shellcheck shell=sh
-# whoisconvert() domain branch (issue #714): a failed `host` lookup used to be
-# treated as success -- found=true was set unconditionally and the lookup's
-# output was piped straight into the .orig sink with no exit-code check, so a
-# failed DNS lookup landed as DATA (e.g. the literal "3(NXDOMAIN)" tail of
-# "Host x not found: 3(NXDOMAIN)"). The sibling ASN branch already checks its
-# result and falls back to the previous .orig (.bk) on failure; the domain
-# branch now mirrors it: on a failed lookup it touches an alias.fail marker
-# and leaves `found=false`, so the existing .bk-restore logic preserves the
-# last-good data instead of being clobbered with garbage.
+# whoisconvert() domain branch + found-accumulation (issue #714).
+#
+# Two coupled fixes are pinned here:
+#
+#   1) A failed `host` lookup used to be treated as success -- found=true was set
+#      unconditionally and the lookup output piped straight into the .orig sink
+#      with no exit-code check, so a failed DNS lookup landed as DATA (e.g. the
+#      literal "3(NXDOMAIN)" tail of "Host x not found: 3(NXDOMAIN)"). The domain
+#      branch now checks host(1)'s exit code and keeps only "has (IPv6) address"
+#      lines; on failure it touches an alias.fail marker and collects nothing.
+#
+#   2) ${found} ACCUMULATES across the comma-list loop: it is initialised false
+#      ONCE before the loop and only ever set true on a successful entry, never
+#      reset false inside the loop. So found=true iff AT LEAST ONE entry resolved
+#      (keep the collected data) and false iff nothing did (restore the .bk).
+#      Previously each iteration overwrote found, so a multi-entry list whose LAST
+#      entry failed discarded the good data collected from earlier entries.
 
 Describe 'whoisconvert() domain branch checks the host(1) result (issue #714)'
   setup() {
@@ -43,9 +51,95 @@ EOF
     The stdout should include 'Restoring previous data'
     # Then a failure marker is left for the caller to notice...
     The path "${pfborig}${alias}.fail" should be exist
-    # ...the previously-good data is restored, not clobbered...
+    # ...the previously-good data is restored (nothing resolved -> found stays false)...
     The contents of file "${pfborig}${alias}.orig" should equal '203.0.113.9'
     # ...and the raw host(1) error text never lands in .orig as if it were an IP.
     The contents of file "${pfborig}${alias}.orig" should not include '3(NXDOMAIN)'
+  End
+End
+
+Describe 'whoisconvert() accumulates found across a multi-entry list (issue #714)'
+  # RED→GREEN oracle for the found-accumulation fix: a comma list whose FIRST
+  # entry resolves and LAST entry fails must KEEP the first entry's IP, not
+  # discard it by restoring the .bk (which the per-iteration found=false reset
+  # caused, since found ended up reflecting only the failing last entry).
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/whoismulti.XXXXXX")"
+    pfborig="${work}/orig/"; mkdir -p "$pfborig"
+    alias="MultiList"
+    max="_v4"
+    # good FIRST, failing entry LAST -- the ordering that exposes the bug.
+    dedup="good-one.example,bad-two.example"
+
+    # host(1) stand-in that branches on the queried name ($3 = the host arg):
+    # a name containing "good" resolves, anything else NXDOMAINs.
+    pathhost="${work}/host"
+    cat > "$pathhost" <<'EOF'
+#!/bin/sh
+name="$3"
+case "$name" in
+	*good*) echo "$name has address 203.0.113.5"; exit 0 ;;
+	*)      echo "Host $name not found: 3(NXDOMAIN)"; exit 1 ;;
+esac
+EOF
+    chmod +x "$pathhost"
+
+    # An OLD .orig so a .bk is created at the top of whoisconvert(); if found
+    # wrongly ended false, the restore would bring this back.
+    printf '198.51.100.7\n' > "${pfborig}${alias}.orig"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'keeps the resolved entry IP when a later entry fails (does not restore the .bk)'
+    When call whoisconvert
+    The status should be success
+    The stdout should include 'completed'
+    # The good entry's IP is kept...
+    The contents of file "${pfborig}${alias}.orig" should include '203.0.113.5'
+    # ...the stale .bk is NOT restored over it (found stayed true via the good entry)...
+    The contents of file "${pfborig}${alias}.orig" should not include '198.51.100.7'
+    # ...and the failing entry is still noted with a .fail marker.
+    The path "${pfborig}${alias}.fail" should be exist
+  End
+End
+
+Describe 'whoisconvert() success path keeps the resolved IP with no failure marker (issue #714)'
+  # Green regression pin for a fully-resolving lookup: the valid "has address"
+  # line must survive the exit-code check + the grep filter (a filter that wrongly
+  # dropped it would leave .orig empty -> found false -> a .fail marker, failing
+  # these assertions).
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/whoisok.XXXXXX")"
+    pfborig="${work}/orig/"; mkdir -p "$pfborig"
+    alias="OkList"
+    max="_v4"
+    dedup="good-solo.example"
+
+    pathhost="${work}/host"
+    cat > "$pathhost" <<'EOF'
+#!/bin/sh
+echo "$3 has address 203.0.113.5"
+exit 0
+EOF
+    chmod +x "$pathhost"
+
+    # A prior .orig so a .bk is created; on success it must be removed.
+    printf '198.51.100.7\n' > "${pfborig}${alias}.orig"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'lands the resolved IP in .orig, leaves no .fail, and removes the .bk'
+    When call whoisconvert
+    The status should be success
+    The stdout should include 'completed'
+    The contents of file "${pfborig}${alias}.orig" should include '203.0.113.5'
+    The path "${pfborig}${alias}.fail" should not be exist
+    The path "${pfborig}${alias}.bk" should not be exist
   End
 End


### PR DESCRIPTION
Three CONFIRMED shell-robustness fixes from the #714 audit in `pfblockerng.sh`, each with a red→green shellspec proof.

## Fixes

- **`/tmp/xlsx` TOCTOU → private tmpdir.** Issue #30 moved every predictable `/tmp` path into a private `mktemp -d` dir, but the xlsx extraction scratch dir was left at fixed `/tmp/xlsx/`, created with a `[ ! -d ]`-guarded `mkdir` (which follows symlinks) and written/`rm -r`'d as root — a symlink/TOCTOU hole for a local user. Now `pfb_make_tmpdir()` sets `tmpxlsx="${tmpdir}/xlsx/"` (a fresh subdir of the 0700 mktemp dir) and creates it unconditionally.
- **Unanchored masterfile grep → suffix over-match.** `duplicate()`/`remove()`/`suppress()` strip an alias's own masterfile rows via `grep "${alias}[[:space:]]"` with no `^` anchor, so a shorter alias that is a **suffix** of another (`Ads_v4` inside `BadAds_v4`) over-matches and silently drops the sibling's row. Anchored (`^`) at all three sites — masterfile rows always begin with the alias at column 0.
- **`whoisconvert()` domain branch ignored the lookup result.** It set `found=true` unconditionally and piped `host` output straight into `.orig` with no exit-code check (and a pipe's `$?` reflects `sed`, not `host`), so a failed DNS lookup was captured as data (e.g. `3(NXDOMAIN)`). Now captures the output + `host`'s own rc first, keeps only `has (IPv6) address` lines, and on failure touches `<alias>.fail` + leaves `found=false` so the existing `.bk` restore preserves the last-good data — mirroring the ASN branch.

## Tests (red→green shellspec)

- `pfblockerng_tempfile_spec.sh` — extended: `tmpxlsx` now lives under the private `pfb.XXXX/` dir (RED when it was `/tmp/xlsx/`).
- `pfblockerng_masterfile_suffix_anchor_spec.sh` — a `BadAds_v4` row survives when `duplicate()` runs for `Ads_v4` (RED on the unanchored grep).
- `pfblockerng_whoisconvert_domain_spec.sh` — a stubbed failing `host` leaves `.fail` + restores the last-good `.orig`, and `3(NXDOMAIN)` never lands as data (RED pre-fix).

Full `tests/shell` shellspec suite green (226 examples, 0 failures); `shellcheck`/`sh -n` clean.

Part of #714