### PR TITLE
pfblockerng: fix pfb_unbound.py minors — Unknown guard, SafeSearch error path, swap state reset, dead threads (#714)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -169,7 +169,6 @@ try:
     import threading  # noqa: F811
 
     pfb["mod_threading"] = True
-    threads: list[Any] = list()
 except Exception as e:
     pfb["mod_threading"] = False
     pfb["mod_threading_e"] = e
@@ -1304,25 +1303,7 @@ def init_standard(id: int, env: module_env) -> bool:
                         pass
 
             # Collect SafeSearch Redirection list
-            if os.path.isfile(pfb["pfb_py_ss"]):
-                try:
-                    with open(pfb["pfb_py_ss"]) as csv_file:
-                        csv_reader = csv.reader(csv_file, delimiter=",")
-                        for row in csv_reader:
-                            # 3 cols: domain,A,AAAA (A/AAAA rewrite or nxdomain).
-                            # 5 cols: domain,cname,target,baked_v4,baked_v6 -- a CNAME
-                            # redirect (issue #149); v4/v6 are the #2 baked fallback IPs.
-                            if row and len(row) == 3:
-                                safeSearchDB[row[0]] = {"A": row[1], "AAAA": row[2]}
-                            elif row and len(row) == 5:
-                                safeSearchDB[row[0]] = {"A": row[1], "AAAA": row[2], "v4": row[3], "v6": row[4]}
-                            else:
-                                sys.stderr.write("[pfBlockerNG]: Failed to parse: {}: {}".format(pfb["pfb_py_ss"], row))
-
-                        pfb["safeSearchDB"] = True
-                except Exception as e:
-                    sys.stderr.write("[pfBlockerNG]: Failed to load: {}: {}".format(pfb["pfb_py_zone"], e))
-                    pass
+            _load_safesearch_db()
 
             # ADR-06 P4: prefer BUILDING the DNSBL structures from the raw feeds via
             # the pure build() layer (the new shell->Python boundary). When the
@@ -2853,8 +2834,6 @@ def python_control_duration(duration: str) -> int | bool:
 
 # Is thread still active
 def python_control_thread(tname: str) -> bool:
-    global threads
-
     try:
         for t in threading.enumerate():
             if t.name == tname:
@@ -2867,11 +2846,8 @@ def python_control_thread(tname: str) -> bool:
 
 # Python_control Start Thread
 def python_control_start_thread(tname: str, fcall: Callable[..., Any], arg1: Any, arg2: Any) -> bool:
-    global threads
-
     try:
         t1 = threading.Thread(name=tname, target=fcall, args=(arg1, arg2), daemon=True)
-        threads.append(t1)
         t1.start()
         return True
     except Exception as e:
@@ -4999,6 +4975,14 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
     _snapshot = new_snapshot
     decisionDB.clear()
     _db_reset_cache()
+    # #714 FIX #2: a swap installs a brand-new regex_db/allow_regex_db, so the runtime
+    # warn-suppression + perf-fallback strike bookkeeping keyed on pattern NAME must not
+    # survive it -- a name reused across reloads (a re-added or edited rule) would
+    # otherwise inherit stale strikes/suppression from the OLD pattern object. Mirrors
+    # the init_standard clear (ADR-07 P7) so a no-restart swap resets the same state a
+    # restart would.
+    _regex_warned.clear()
+    _regex_perf_strikes.clear()
     # ADR-10: refresh the MASTER DNSBL gate from the new snapshot, parity with init
     # (init sets pfb["python_blacklist"] True when any blocking stratum loaded -- line
     # ~1061). operate() gates ALL DNSBL evaluation on this flag; it is otherwise written
@@ -5761,6 +5745,37 @@ def evaluate_noaaaa(q_name: str, noaaaa_db: dict[str, Any]) -> bool:
     return find_noaaaa_wildcard_parent(q_name, noaaaa_db) is not None
 
 
+def _load_safesearch_db() -> None:
+    """Parse the SafeSearch Redirection CSV (``pfb["pfb_py_ss"]``) into ``safeSearchDB``.
+
+    Extracted out of ``init_standard`` (#714 FIX #6) so the load -- and its failure
+    diagnostic -- are unit-testable without the full Unbound ``env``/``id`` init rig.
+    Behaviour-preserving: same parse rules, same ``pfb["safeSearchDB"]`` flag.
+    """
+    if os.path.isfile(pfb["pfb_py_ss"]):
+        try:
+            with open(pfb["pfb_py_ss"]) as csv_file:
+                csv_reader = csv.reader(csv_file, delimiter=",")
+                for row in csv_reader:
+                    # 3 cols: domain,A,AAAA (A/AAAA rewrite or nxdomain).
+                    # 5 cols: domain,cname,target,baked_v4,baked_v6 -- a CNAME
+                    # redirect (issue #149); v4/v6 are the #2 baked fallback IPs.
+                    if row and len(row) == 3:
+                        safeSearchDB[row[0]] = {"A": row[1], "AAAA": row[2]}
+                    elif row and len(row) == 5:
+                        safeSearchDB[row[0]] = {"A": row[1], "AAAA": row[2], "v4": row[3], "v6": row[4]}
+                    else:
+                        sys.stderr.write("[pfBlockerNG]: Failed to parse: {}: {}".format(pfb["pfb_py_ss"], row))
+
+                pfb["safeSearchDB"] = True
+        except Exception as e:
+            # #714 FIX #6: name the SafeSearch source (pfb_py_ss), not pfb_py_zone -- a
+            # copy-paste leftover from the zone-list loader below sent a real SafeSearch
+            # load failure diagnostic at the wrong file.
+            sys.stderr.write("[pfBlockerNG]: Failed to load: {}: {}".format(pfb["pfb_py_ss"], e))
+            pass
+
+
 def safesearch_entry(q_name_original: str) -> Any:
     """Look up (and memoize on the Decision) the SafeSearch entry for a name.
 
@@ -5898,7 +5913,7 @@ def safesearch_cname_redirect(id: int, qstate: module_qstate, q_type: Any, isSaf
 
 
 def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
-    global pfb, threads, dataDB, zoneDB, hstsDB, whiteDB, decisionDB
+    global pfb, dataDB, zoneDB, hstsDB, whiteDB, decisionDB
     global noAAAADB, gpListDB, safeSearchDB
 
     qstate_valid = False
@@ -6057,9 +6072,14 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                             continue
 
                         for j in range(0, rr.entry.data.count):
-                            domain = convert_other(rr.entry.data.rr_data[j]).lower()
+                            # #714 FIX #3: compare the is_unknown() sentinel BEFORE
+                            # lowering it. convert_other() returns the literal "Unknown"
+                            # (capital U) on decode failure; lowering first turns it into
+                            # "unknown", which never equals "Unknown", so the guard became
+                            # a no-op and the bogus "unknown" string was DNSBL-evaluated.
+                            domain = convert_other(rr.entry.data.rr_data[j])
                             if domain != "Unknown":
-                                validate.append(domain)
+                                validate.append(domain.lower())
 
         isCNAME = False
         for val_counter, q_name in enumerate(validate, start=1):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,6 @@ def reset_pfb_globals() -> None:
     pfb_unbound.hstsDB = defaultdict(str)
     pfb_unbound.gpListDB = defaultdict(str)
     pfb_unbound.noAAAADB = defaultdict(str)
-    pfb_unbound.threads = []
 
     # ADR-10 P2: init_standard bundles the matcher strata into ONE immutable Snapshot
     # and operate() reads every stratum off it. Mirror that here: build the single

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -152,6 +152,31 @@ class TestRebuildAndSwapSuccess:
         assert emitted[P.pfb["pfb_py_count"]] == 42
         assert emitted[P.pfb["pfb_py_regex_count"]] == 7
 
+    def test_swap_clears_regex_warn_and_perf_strike_state(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # #714 FIX #2: a swap installs a BRAND-NEW regex_db/allow_regex_db, so the
+        # runtime warn-suppression + perf-fallback strike bookkeeping (keyed on
+        # pattern NAME, ADR-07 P7) must not survive it -- a name reused across
+        # reloads (a re-added or edited rule) would otherwise inherit stale
+        # strikes/suppression from the OLD pattern object. init_standard already
+        # clears both on a restart; rebuild_and_swap must mirror it for a
+        # no-restart swap (pre-fix it left this state dangling).
+        _set_count_paths(tmp_path)
+        monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P._snapshot = _snapshot(counts=0)
+
+        # ---- BEFORE-state: stale bookkeeping left by a PRIOR pattern set.
+        P._regex_warned.add("stale-pattern")
+        P._regex_perf_strikes["stale-pattern"] = 3
+        assert "stale-pattern" in P._regex_warned
+        assert P._regex_perf_strikes["stale-pattern"] == 3
+
+        # ---- act: a successful swap.
+        assert P.rebuild_and_swap(lambda: _snapshot(counts=1)) is True
+
+        # ---- AFTER-state: both runtime dicts are cleared, in parity with init.
+        assert P._regex_warned == set()
+        assert P._regex_perf_strikes == {}
+
     def test_swap_enables_master_dnsbl_gate_when_new_lists_load(self, tmp_path: Any, monkeypatch: Any) -> None:
         # ADR-10: operate() gates ALL DNSBL evaluation on pfb["python_blacklist"], which
         # is otherwise written only at init. A swap that loads lists into a previously-

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1327,6 +1327,32 @@ class TestOperateDnsbl:
         assert qstate.ext_state[0] == MODULE_FINISHED
         assert calls["n"] == 1
 
+    def test_cname_unknown_sentinel_is_never_evaluated(self, monkeypatch: Any) -> None:
+        # #714 FIX #3: convert_other() returns the is_unknown() decode-failure sentinel
+        # "Unknown" (capital U) for a CNAME target it can't parse. The guard filtering it
+        # out must compare BEFORE lowering -- lowering first turns "Unknown" into
+        # "unknown", which never equals "Unknown", so the (pre-fix) guard was a no-op and
+        # the bogus "unknown" string was appended to `validate` and DNSBL-evaluated.
+        #
+        # Prove it by putting "unknown" itself on the blocklist: pre-fix, the leaked
+        # sentinel is evaluated, matches, and blocks the ORIGINAL query (chained through
+        # decisionDB.get(q_name_original) reassignment); post-fix, the sentinel is
+        # dropped before ever reaching the evaluated `validate` list, so the query
+        # resolves clean and "unknown" is never memoized as a decided name.
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["python_cname"] = True
+        monkeypatch.setattr(pfb_unbound, "convert_other", lambda b: "Unknown")
+        add_data("unknown", log="1", index=0)
+        set_feed_group(0, "F", "G")
+
+        qstate = make_qstate("orig.com.", qtype=RR_A, return_msg=self._cname_reply("orig.com."))
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        assert qstate.ext_state[0] == MODULE_WAIT_MODULE  # resolves clean, not blocked
+        assert not _is_block(pfb_unbound.decisionDB.get("orig.com"))
+        # The sentinel itself must never be memoized as an evaluated decision.
+        assert pfb_unbound.decisionDB.get("unknown") is None
+
 
 class TestOperateEvents:
     def test_moddone_logs_and_finishes(self) -> None:
@@ -1340,6 +1366,57 @@ class TestOperateEvents:
         rcd = pfb_unbound.operate(0, 99, qstate, None)
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_ERROR
+
+
+class TestLoadSafeSearchDb:
+    """_load_safesearch_db() -- extracted out of init_standard (#714 FIX #6) so the
+    SafeSearch CSV load, and its failure diagnostic, are unit-testable."""
+
+    def test_parses_3_and_5_column_rows(self, tmp_path: Any) -> None:
+        # Behaviour-preserving: same 3-col (A/AAAA rewrite) and 5-col (CNAME redirect,
+        # issue #149) row shapes init_standard always parsed.
+        path = tmp_path / "pfb_py_ss.txt"
+        path.write_text(
+            "forcesafe.com,1.2.3.4,::1\ncname.com,cname,target.com,5.6.7.8,::2\n",
+            encoding="utf-8",
+        )
+        pfb_unbound.pfb["pfb_py_ss"] = str(path)
+
+        pfb_unbound._load_safesearch_db()
+
+        assert pfb_unbound.safeSearchDB["forcesafe.com"] == {"A": "1.2.3.4", "AAAA": "::1"}
+        assert pfb_unbound.safeSearchDB["cname.com"] == {
+            "A": "cname",
+            "AAAA": "target.com",
+            "v4": "5.6.7.8",
+            "v6": "::2",
+        }
+        assert pfb_unbound.pfb["safeSearchDB"] is True
+
+    def test_load_failure_names_the_safesearch_file_not_the_zone_file(
+        self, tmp_path: Any, monkeypatch: Any, capsys: Any
+    ) -> None:
+        # #714 FIX #6: the failure diagnostic must name pfb_py_ss (the SafeSearch
+        # source that just failed to load), not pfb_py_zone -- a copy-paste leftover
+        # from the neighbouring zone-list loader that pointed a real SafeSearch load
+        # failure at the WRONG file. Force the parse to raise so the except path runs,
+        # with pfb_py_zone set to a visibly different path (the wrong-file trap), and
+        # assert the emitted message carries the right one.
+        ss_path = tmp_path / "pfb_py_ss.txt"
+        ss_path.write_text("forcesafe.com,1.2.3.4,::1\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_ss"] = str(ss_path)
+        pfb_unbound.pfb["pfb_py_zone"] = str(tmp_path / "pfb_py_zone.txt")
+
+        def _boom(*a: Any, **k: Any) -> Any:
+            raise RuntimeError("csv boom")
+
+        monkeypatch.setattr(pfb_unbound.csv, "reader", _boom)
+
+        pfb_unbound._load_safesearch_db()
+
+        err = capsys.readouterr().err
+        assert str(ss_path) in err
+        assert str(pfb_unbound.pfb["pfb_py_zone"]) not in err
 
 
 class TestSafeSearchEntry:


### PR DESCRIPTION
Four CONFIRMED `pfb_unbound.py` minor fixes from the #714 audit (the perf, sqlite-timeout, q_name-casing and strftime sub-items were verified FALSE and are not touched).

## Fixes

- **Dead `"Unknown"` guard (real bug).** In the CNAME walk, `domain = convert_other(...).lower()` then `if domain != "Unknown":` — but `convert_other()` returns the literal `"Unknown"` (capital U) on decode failure, so lowering first makes it `"unknown"`, the guard never matches, and the bogus sentinel was appended to `validate` and DNSBL-evaluated. Now compares before lowering: `if domain != "Unknown": validate.append(domain.lower())`.
- **SafeSearch load-error names the wrong file (real bug).** The load-failure diagnostic referenced `pfb["pfb_py_zone"]` (a copy-paste leftover) instead of the SafeSearch source `pfb["pfb_py_ss"]`. Extracted the loader into a testable `_load_safesearch_db()` (behaviour-preserving — same 3/5-col parse, same flag) and fixed the diagnostic.
- **Zero-downtime swap didn't reset regex warn/strike state.** `rebuild_and_swap()` installs a new `regex_db` but never cleared `_regex_warned` / `_regex_perf_strikes` (keyed on pattern name), so a name reused across reloads inherited stale suppression/strikes from the old pattern object. Now clears both, mirroring `init_standard`.
- **Dead `threads` list removed.** A module-global `threads` list was appended to but never read (liveness is tracked via `threading.enumerate()`); removed the declaration, the `global` statements, the append, and the conftest reset.

## Tests (red→green pytest)

- `test_cname_unknown_sentinel_is_never_evaluated` — plants `"unknown"` on the blocklist; pre-fix the leaked sentinel is blocked (RED: `assert 4 == 2`), post-fix the query resolves clean.
- `test_load_failure_names_the_safesearch_file_not_the_zone_file` — sets `pfb_py_zone` to a different path as a wrong-file trap, forces a load failure, asserts the diagnostic names `pfb_py_ss`.
- `test_swap_clears_regex_warn_and_perf_strike_state` — seeds stale bookkeeping, asserts it's present then cleared after the swap.
- `test_parses_3_and_5_column_rows` — pins the extracted loader's parse behaviour.

Full suite: 1932 passed, 4 pre-existing skips; `ruff` clean.

Part of #714