### PR TITLE
Fix the 17 MEDIUM correctness bugs from the audit (#713)

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -127,6 +127,6 @@ registered path set). Each annotation is committed in the relevant source file.
 | `installedpackages` (bulk blob) | Bulk wizard init write, foreign structure |
 | `pfblockerngreputation/config/0` | Static display section, no registered keys |
 | `pfblockerng{continent}/config/0` | Dynamic per-continent structure |
-| `pfblockerngdnsblsettings/config/0/dnsbl_webpage` | Out-of-scope key (ADR-29 §2.5); the registered key is `dnsblwebpage` |
+| `pfblockerngdnsblsettings/config/0/dnsbl_webpage` | Out-of-scope foreign key (ADR-29 §2.5); written directly by `pfblockerng_dnsbl.php`, read via `pfb_dnsbl_webpage()` (issue #713 removed the never-written `dnsblwebpage` registry mis-spelling) |
 | `pfblockerngdnsbl` / `pfblockernglistsv4/v6` (section-level reads) | Dynamic list sections |
 | `aliases/alias`, `filter/rule`, `system/*`, `interfaces`, `unbound/*` | pfSense core sections |

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -489,7 +489,7 @@ _BUILD_PKG = _THIS_DIR / "build-pkg-portable.py"
 _CATALOG_PKG_FILES = {"packagesite.pkg", "data.pkg"}
 
 
-def _pkg_version_key(version: str) -> list[int]:
+def _pkg_version_key(version: str) -> tuple[list[int], int, int]:
     """A monotone sort key for a pkg version — see ``pfb_pkg.pkg_version_sort_key``.
 
     Used for nightly retention (``<target>.YYYYMMDD.N``, all-numeric — a later build

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -105,7 +105,7 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
-from pfb_pkg import PkgError, read_compact_manifest
+from pfb_pkg import PkgError, pkg_version_sort_key, read_compact_manifest
 
 # --------------------------------------------------------------------------- #
 # Catalog descriptor (meta.conf / meta) — byte-identical to real `pkg repo`.
@@ -490,14 +490,16 @@ _CATALOG_PKG_FILES = {"packagesite.pkg", "data.pkg"}
 
 
 def _pkg_version_key(version: str) -> list[int]:
-    """A monotone sort key for a pkg version, component-wise on ``.`` / ``_`` / ``,``.
+    """A monotone sort key for a pkg version — see ``pfb_pkg.pkg_version_sort_key``.
 
-    Nightly versions are ``<target>.YYYYMMDD.N`` (all-numeric components), so a plain
-    numeric component compare orders them chronologically — a later build sorts higher.
-    Non-numeric components degrade to 0 (good enough for the nightly retention sort,
-    the only caller).
+    Used for nightly retention (``<target>.YYYYMMDD.N``, all-numeric — a later build
+    sorts higher) AND release-channel retention (``vX.Y.Z(.alpha|beta|rc.N)?`` tags,
+    via ``retain_by_channel``'s ``--release-keep-devel``/``--release-keep-stable`` >
+    1), so it must also order the alpha/beta/rc prerelease stages correctly, not just
+    the nightly date/counter shape. Kept as a thin alias — this module's ``_retain_newest``
+    callers reference it by this name.
     """
-    return [int(c) if c.isdigit() else 0 for c in re.split(r"[._,]", version)]
+    return pkg_version_sort_key(version)
 
 
 def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path]) -> int:

--- a/scripts/check_url_encoding.py
+++ b/scripts/check_url_encoding.py
@@ -102,16 +102,20 @@ def _looks_like_url_token(token: str) -> bool:
     is URL-bearing only if it contains ``://``, starts with ``http``/``https``/
     ``?``, OR starts with a shell variable (``$``) AND contains a ``?`` — the
     last clause is the variable-BASE-with-query shape this checker exists to
-    guard (``$BASE/cb?ip=$VAR``, ``${BASE}/...?...``), which a leading-token-only
-    check would miss, while still excluding an option value that starts with a
-    literal key name.
+    guard (``$BASE/cb?ip=$VAR``, ``${BASE}/...?...``): it requires a path
+    separator before the ``?`` so a ``$``-prefixed option VALUE holding a
+    ``?...=$`` shape (``$body?k=$v``, ``$AUTH?token=$T``) is not mistaken for a URL.
     """
     stripped = token.strip("\"'")
     if "://" in stripped:
         return True
     if stripped.startswith(("http", "https", "?")):
         return True
-    return stripped.startswith("$") and "?" in stripped
+    # A "$"-prefixed token is a variable-BASE URL only when a path separator
+    # precedes the query ("$BASE/cb?ip=$VAR"); a "$"-prefixed OPTION VALUE that
+    # merely holds a "?...=$" shape ("$body?k=$v", "$AUTH?token=$T") has no "/"
+    # before the "?" and is not a URL, so it stays clean.
+    return stripped.startswith("$") and "?" in stripped and "/" in stripped.split("?", 1)[0]
 
 
 def _split_tokens(line: str) -> list[str]:

--- a/scripts/check_url_encoding.py
+++ b/scripts/check_url_encoding.py
@@ -64,8 +64,9 @@ _HTTP_CLIENT_RE = re.compile(r"(?<![\w-])(?:curl|wget|fetch)(?![\w-])")
 
 # A query parameter assigned a shell variable: `?key=$VAR`, `&key=$VAR`, or a
 # bare `$` right after the `?`/`&`/`=` separator. `[^=&\s"']*` keeps the key on
-# the same token (no spaces); the trailing `\$` is the shell expansion.
-_NAKED_QUERY_VAR_RE = re.compile(r"[?&][^=&\s\"']*=\$")
+# the same token (no spaces); the optional `=` covers both `?key=$VAR` and a bare
+# `?$VAR`/`&$VAR` (no `key=` at all); the trailing `\$` is the shell expansion.
+_NAKED_QUERY_VAR_RE = re.compile(r"[?&][^=&\s\"']*=?\$")
 
 # Fix hint surfaced in every message (asserted by the tests).
 _FIX_HINT = 'use `curl --data-urlencode "key=$VAR"` so the value is percent-encoded'
@@ -96,8 +97,11 @@ def _looks_like_url_token(token: str) -> bool:
         return True
     if stripped.startswith(("http", "https")):
         return True
-    # A bare query string token (rare, but `?k=$V` with no scheme still encodes).
-    return stripped.startswith("?")
+    # A query string anywhere in the token — not just at the start — still marks
+    # it URL-bearing: a variable BASE with the `?` in the middle (`$BASE/cb?ip=$VAR`)
+    # is the exact webhook shape this checker exists to guard, and a leading-only
+    # check missed it entirely.
+    return "?" in stripped
 
 
 def _split_tokens(line: str) -> list[str]:

--- a/scripts/check_url_encoding.py
+++ b/scripts/check_url_encoding.py
@@ -26,10 +26,15 @@ HEURISTIC (deliberately low false-positive)
   ``curl``, ``wget`` or ``fetch``. Backslash-continued shell lines are joined into
   one logical line first, so a URL sitting on a continuation is still seen.
 * Within such a line we inspect URL-looking TOKENS only — a token containing
-  ``://``, or a quoted token that begins with ``http``/``https``, or a token that
-  contains a ``?`` query separator. A violation is a query parameter assigned a
-  shell variable inside that token: ``[?&]<key>=$`` (e.g. ``?ip=$VAR`` /
-  ``&k=${VAR}``), including ``$`` immediately after ``?``/``&``/``=``.
+  ``://``, a quoted token that begins with ``http``/``https``/``?``, or a token
+  that STARTS with a shell variable (``$``) and also contains a ``?`` (the
+  variable-BASE-with-query shape, e.g. ``$BASE/cb?ip=$VAR``). A bare ``?``
+  ANYWHERE in the token is deliberately NOT enough — that over-wide check used
+  to flag curl OPTION VALUES that merely contain ``?...=$`` (e.g.
+  ``--data-urlencode "path=/a?b=$c"``), which are not URLs at all. A violation
+  is a query parameter assigned a shell variable inside a URL-looking token:
+  ``[?&]<key>=$`` (e.g. ``?ip=$VAR`` / ``&k=${VAR}``), including ``$``
+  immediately after ``?``/``&``/``=``.
 * The CORRECT form ``--data-urlencode "k=$VAR"`` is NOT flagged: that value rides
   its own flag token, which has no ``://`` and no leading ``?``/``&`` query
   separator, so it never qualifies as a URL token. (Pinned by a test.)
@@ -91,17 +96,22 @@ def _looks_like_url_token(token: str) -> bool:
 
     Confines the naked-variable match to URL-bearing tokens, so option values
     such as ``--data-urlencode "k=$V"`` (a separate, non-URL token) are excluded.
+    A BARE ``"?" in stripped`` check is too wide: it also flags curl OPTION
+    VALUES that merely contain ``?...=$`` — e.g. ``--data-urlencode "path=/a?b=$c"``,
+    ``-F "note=a?x=$B"``, ``-H "X: a?b=$c"`` — none of which are URLs. A token
+    is URL-bearing only if it contains ``://``, starts with ``http``/``https``/
+    ``?``, OR starts with a shell variable (``$``) AND contains a ``?`` — the
+    last clause is the variable-BASE-with-query shape this checker exists to
+    guard (``$BASE/cb?ip=$VAR``, ``${BASE}/...?...``), which a leading-token-only
+    check would miss, while still excluding an option value that starts with a
+    literal key name.
     """
     stripped = token.strip("\"'")
     if "://" in stripped:
         return True
-    if stripped.startswith(("http", "https")):
+    if stripped.startswith(("http", "https", "?")):
         return True
-    # A query string anywhere in the token — not just at the start — still marks
-    # it URL-bearing: a variable BASE with the `?` in the middle (`$BASE/cb?ip=$VAR`)
-    # is the exact webhook shape this checker exists to guard, and a leading-only
-    # check missed it entirely.
-    return "?" in stripped
+    return stripped.startswith("$") and "?" in stripped
 
 
 def _split_tokens(line: str) -> list[str]:

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -70,7 +70,7 @@ def human_size(n: int) -> str:
     return f"{f:.1f} GiB"
 
 
-def ver_key(v: str) -> list[int]:
+def ver_key(v: str) -> tuple[list[int], int, int]:
     """The newest-build sort key — see ``pfb_pkg.pkg_version_sort_key``.
 
     Must order the alpha/beta/rc prerelease stages correctly (not just fold them

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -622,7 +622,7 @@ def eol_versions(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str,
     # Sort: edition order (CE < Plus < Other), then pfSense version newest-first, then ABI.
     edition_rank = {k: i for i, k in enumerate(EDITION_ORDER)}
 
-    def _sort_key(t: tuple[str, str, dict]) -> tuple[int, list[int], str]:
+    def _sort_key(t: tuple[str, str, dict]) -> tuple[int, tuple[list[int], int, int], str]:
         ekey, ver, row = t
         return (edition_rank.get(ekey, len(EDITION_ORDER)), ver_key(ver), row["abi"])
 

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -24,7 +24,7 @@ import subprocess
 from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 
-from pfb_pkg import read_compact_manifest
+from pfb_pkg import pkg_version_sort_key, read_compact_manifest
 
 # Display order for the published-packages table (newest per channel). The channel of a
 # package is read from its name suffix (channel_of); the install CARDS are rendered
@@ -71,8 +71,13 @@ def human_size(n: int) -> str:
 
 
 def ver_key(v: str) -> list[int]:
-    """A coarse version sort key (numeric runs) — enough to pick the newest build."""
-    return [int(x) for x in re.findall(r"\d+", v)]
+    """The newest-build sort key — see ``pfb_pkg.pkg_version_sort_key``.
+
+    Must order the alpha/beta/rc prerelease stages correctly (not just fold them
+    away), since devel-channel rows compared here can be release-tag-shaped
+    (``4.0.0.alpha.1`` etc.) as well as nightly-dated or bare edition versions.
+    """
+    return pkg_version_sort_key(v)
 
 
 def artifact_datetime(epoch: float) -> str:

--- a/scripts/pfb_pkg.py
+++ b/scripts/pfb_pkg.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import shutil
 import subprocess
 import tarfile
@@ -64,3 +65,59 @@ def read_compact_manifest(pkg_path: str | Path) -> dict:
     if not isinstance(obj, dict):
         raise PkgError(f"{pkg_path.name}: +COMPACT_MANIFEST is not an object")
     return obj
+
+
+# --------------------------------------------------------------------------- #
+# Version sort key — shared by build-repo-portable.py (release/nightly retention)
+# and gen_landing.py (the landing page's "newest build" picks).
+# --------------------------------------------------------------------------- #
+
+# FreeBSD pkg ranks a prerelease stage BELOW the bare release, and alpha < beta <
+# rc between themselves (see scripts/release-version.sh, the tag scheme's single
+# source of truth: vX.Y.Z(.alpha|beta|rc.N)?). A version with no stage keyword —
+# a genuine stable release, a bare edition version like "2.8.1", or a nightly's
+# all-numeric "<target>.YYYYMMDD.N" — ranks as RELEASE (highest).
+_STAGE_RANK = {"alpha": 0, "beta": 1, "rc": 2}
+_RELEASE_RANK = 3
+
+
+def pkg_version_sort_key(version: str) -> list[int]:
+    """Monotone sort key for a pfBlockerNG pkg VERSION string.
+
+    Splits on ``.``/``_``/``,`` like a plain numeric-run compare, but a component
+    matching one of the FreeBSD-pkg prerelease stage keywords (``alpha``/``beta``/
+    ``rc``) is pulled OUT of the numeric base and turned into a stage rank + stage
+    number, instead of being folded away. The historical bug this fixes: a plain
+    ``re.findall(r"\\d+", v)``-style key drops the keyword entirely, so
+    ``4.0.0.alpha.1`` / ``.beta.1`` / ``.rc.1`` all collapsed to the SAME key, and
+    the bare ``4.0.0`` release (whose key was a *shorter* list) sorted BELOW every
+    prerelease. This key instead reproduces pkg's real ordering::
+
+        4.0.0.alpha.1 < 4.0.0.alpha.2 < 4.0.0.beta.1 < 4.0.0.rc.1 < 4.0.0
+
+    A version with no stage keyword (a nightly's all-numeric
+    ``<target>.YYYYMMDD.N``, a bare ``pfsense_version`` like ``2.8.1``, or a
+    genuine stable release) keeps its full numeric run as the base and ranks as
+    RELEASE — unchanged ordering vs. the historical key for that case. Any
+    non-numeric, non-stage-keyword component maps to ``0`` (same fallback the
+    historical key used), so a malformed component never raises.
+    """
+    parts = re.split(r"[._,]", version)
+    base: list[int] = []
+    stage_rank = _RELEASE_RANK
+    stage_num = 0
+    i = 0
+    while i < len(parts):
+        part = parts[i]
+        rank = _STAGE_RANK.get(part.lower())
+        if rank is not None:
+            stage_rank = rank
+            if i + 1 < len(parts) and parts[i + 1].isdigit():
+                stage_num = int(parts[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+        base.append(int(part) if part.isdigit() else 0)
+        i += 1
+    return [*base, stage_rank, stage_num]

--- a/scripts/pfb_pkg.py
+++ b/scripts/pfb_pkg.py
@@ -81,7 +81,7 @@ _STAGE_RANK = {"alpha": 0, "beta": 1, "rc": 2}
 _RELEASE_RANK = 3
 
 
-def pkg_version_sort_key(version: str) -> list[int]:
+def pkg_version_sort_key(version: str) -> tuple[list[int], int, int]:
     """Monotone sort key for a pfBlockerNG pkg VERSION string.
 
     Splits on ``.``/``_``/``,`` like a plain numeric-run compare, but a component
@@ -101,6 +101,17 @@ def pkg_version_sort_key(version: str) -> list[int]:
     RELEASE — unchanged ordering vs. the historical key for that case. Any
     non-numeric, non-stage-keyword component maps to ``0`` (same fallback the
     historical key used), so a malformed component never raises.
+
+    Returns a NESTED ``(base, stage_rank, stage_num)`` tuple, NOT a flat list.
+    A flat ``[*base, stage_rank, stage_num]`` breaks the "shorter all-numeric
+    version sorts below its longer prefix-extension" rule: Python compares
+    lists element-by-element, so ``2.8`` -> ``[2, 8, 3, 0]`` would compare its
+    OWN stage_rank (index 2 = 3) against ``2.8.1``'s THIRD version component
+    (index 2 = 1) and wrongly sort ``2.8`` above ``2.8.1``. Tuple comparison
+    instead compares ``base`` as a whole LIST first (Python's list-prefix rule:
+    ``[2, 8] < [2, 8, 1]``), so a bare edition version like ``2.8`` still sorts
+    below its extension ``2.8.1``; stage_rank/stage_num only break ties within
+    an equal base.
     """
     parts = re.split(r"[._,]", version)
     base: list[int] = []
@@ -120,4 +131,4 @@ def pkg_version_sort_key(version: str) -> list[int]:
             continue
         base.append(int(part) if part.isdigit() else 0)
         i += 1
-    return [*base, stage_rank, stage_num]
+    return (base, stage_rank, stage_num)

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -785,6 +785,37 @@ def pfb_control_watcher() -> None:
             waiter.close()
 
 
+def parse_python_tlds(raw: str) -> list[str]:
+    """Parse the MAIN-ini ``python_tlds`` value into a cleaned TLD-Allow list.
+
+    issue #713: the previous unconditional ``raw.split(",")`` left a degenerate value
+    (absent/empty ini key -- "") as ``['']`` -- a non-empty LIST holding one blank
+    entry. That fed a buggy ``!= ""`` guard (a list is never equal to a str, so it was
+    ALWAYS True) which force-enabled the TLD-Allow blacklist even with no TLDs
+    configured -- "empty TLD-Allow blocks all". Splitting, stripping, and dropping
+    blank entries here makes an empty/whitespace-only value parse to ``[]`` (falsy),
+    so the caller's plain truthiness guard (``if python_tld and python_tlds:``) behaves
+    correctly.
+    """
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def _parse_ini_int(config: ConfigParser, section: str, option: str) -> int | None:
+    """Parse an integer MAIN-ini option; ``None`` on a malformed (non-integer) value.
+
+    issue #713: ``ConfigParser.getint()`` raises ``ValueError`` on a non-integer ini
+    value. Mirrors the existing ``regex_warn_ms``/``regex_evict_ms`` try/except-ValueError
+    guard (a few lines below the callers in ``init_standard``) so a malformed
+    ``python_tld_seg``/``decisiondb_max`` value can no longer throw out of module init
+    and take the whole Unbound Python module down. The caller keeps its own current
+    value on a ``None`` return instead of crashing.
+    """
+    try:
+        return config.getint(section, option)
+    except ValueError:
+        return None
+
+
 def warn_if_legacy_control_enabled(enabled: bool) -> None:
     """PFBL-03: log a one-time deprecation warning at module load when the legacy
     DNS-TXT control transport is enabled. Neutral wording -- the path is deprecated
@@ -939,8 +970,8 @@ def init_standard(id: int, env: module_env) -> bool:
     # the config.has_option() loads below normally populate them -- but default them
     # here too so a hand-edited/corrupted ini that drops the keys can't KeyError on
     # the unconditional reads (TLD-Allow check + manifest cfg). ``python_tlds`` is a
-    # list (line stores it via ``.split(",")``); the consumer ``tld not in
-    # cfg["python_tlds"]`` treats the empty list correctly.
+    # list (the ini load below populates it via ``parse_python_tlds()``, issue #713);
+    # the consumer ``tld not in cfg["python_tlds"]`` treats the empty list correctly.
     pfb["python_tld"] = False
     pfb["python_tlds"] = []
     pfb["python_tld_seg"] = 0
@@ -1133,15 +1164,26 @@ def init_standard(id: int, env: module_env) -> bool:
                 pfb["python_idn_block_malicious"] = config.getboolean("MAIN", "python_idn_block_malicious")
             if config.has_option("MAIN", "python_idn_escalate_suspicious"):
                 pfb["python_idn_escalate_suspicious"] = config.getboolean("MAIN", "python_idn_escalate_suspicious")
+            # issue #713: config.getint() raises ValueError on a non-integer ini value.
+            # Unlike the regex_warn_ms/regex_evict_ms getfloat reads above (already
+            # guarded), these two getint reads were UNGUARDED -- a malformed
+            # python_tld_seg/decisiondb_max value threw out of module init and took the
+            # whole Unbound Python module down. _parse_ini_int() mirrors the regex_*
+            # try/except-ValueError guard; keep the current default on a parse failure,
+            # and only touch decisionDB.maxsize when the parse actually succeeded.
             if config.has_option("MAIN", "python_tld_seg"):
-                pfb["python_tld_seg"] = config.getint("MAIN", "python_tld_seg")
+                parsed_tld_seg = _parse_ini_int(config, "MAIN", "python_tld_seg")
+                if parsed_tld_seg is not None:
+                    pfb["python_tld_seg"] = parsed_tld_seg
             if config.has_option("MAIN", "decisiondb_max"):
-                pfb["decisiondb_max"] = config.getint("MAIN", "decisiondb_max")
-                decisionDB.maxsize = pfb["decisiondb_max"]
+                parsed_decisiondb_max = _parse_ini_int(config, "MAIN", "decisiondb_max")
+                if parsed_decisiondb_max is not None:
+                    pfb["decisiondb_max"] = parsed_decisiondb_max
+                    decisionDB.maxsize = pfb["decisiondb_max"]
             if config.has_option("MAIN", "python_tld"):
                 pfb["python_tld"] = config.getboolean("MAIN", "python_tld")
             if config.has_option("MAIN", "python_tlds"):
-                pfb["python_tlds"] = config.get("MAIN", "python_tlds").split(",")
+                pfb["python_tlds"] = parse_python_tlds(config.get("MAIN", "python_tlds"))
             if config.has_option("MAIN", "dnsbl_ipv4"):
                 pfb["dnsbl_ipv4"] = config.get("MAIN", "dnsbl_ipv4")
             if config.has_option("MAIN", "dnsbl_ipv6"):
@@ -1211,8 +1253,12 @@ def init_standard(id: int, env: module_env) -> bool:
             if pfb["python_idn"] or pfb["idn_mode"] is not IdnMode.Off:
                 pfb["python_blacklist"] = True
 
-            # Enable the Blacklist functions (TLD Allow)
-            if pfb["python_tld"] and pfb["python_tlds"] != "":
+            # Enable the Blacklist functions (TLD Allow). issue #713: python_tlds is a
+            # LIST (parse_python_tlds()'s output) -- `!= ""` compares a list to a str,
+            # which is ALWAYS True, so an empty/degenerate TLD-Allow value used to force
+            # this on regardless of content. Plain truthiness is the correct guard: an
+            # empty list (no configured TLDs) must NOT enable the blacklist gate.
+            if pfb["python_tld"] and pfb["python_tlds"]:
                 pfb["python_blacklist"] = True
 
             # Collect user-defined Regex patterns

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5105,7 +5105,11 @@ def hsts_check_domain(
     if tld in hsts_tlds:
         return True, "HSTS_TLD"
     q = name
-    for _ in range(q.count(".") + 1, 0, -2):
+    # issue #713: this walk must check EVERY parent suffix (stride -1) -- a stride of
+    # -2 skips every other suffix level, so a name whose HSTS parent sits at a skipped
+    # level would fall through to "Python" (VIP block) instead of "HSTS" (NULL block),
+    # serving the block page over the wrong cert for an HSTS-preloaded parent.
+    for _ in range(q.count(".") + 1, 0, -1):
         if hsts_db.get(q) is not None:
             return True, "HSTS"
         q = q.split(".", 1)[-1]

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -971,7 +971,9 @@ def init_standard(id: int, env: module_env) -> bool:
     # here too so a hand-edited/corrupted ini that drops the keys can't KeyError on
     # the unconditional reads (TLD-Allow check + manifest cfg). ``python_tlds`` is a
     # list (the ini load below populates it via ``parse_python_tlds()``, issue #713);
-    # the consumer ``tld not in cfg["python_tlds"]`` treats the empty list correctly.
+    # evaluate_domain's TLD-Allow arm requires a non-empty ``cfg["python_tlds"]`` before
+    # testing ``tld not in cfg["python_tlds"]``, so the empty-list default here is a
+    # no-op rather than a block-everything trap.
     pfb["python_tld"] = False
     pfb["python_tlds"] = []
     pfb["python_tld_seg"] = 0
@@ -5589,6 +5591,7 @@ def evaluate_domain(
     if not is_found:
         if (
             cfg["python_tld"]
+            and cfg["python_tlds"]
             and tld != ""
             and q_name not in (cfg["dnsbl_ipv4"], cfg["dnsbl_ipv6"])
             and tld not in cfg["python_tlds"]

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7523,11 +7523,19 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 				// its own RAM re-check / very slow box) -> fall back to the restart so
 				// the new lists definitely load. NOT an error: fail-safe by design.
 				pfb_logger(" not confirmed in time -- falling back to Unbound restart", 2);
+				// Clear the daemon-suppression marker touched above before falling
+				// through: the restart path below re-touches + manages its own '.sync'
+				// (pfb_update_unbound parity), but the alert/#51 caller has no later
+				// clear_work_files, so leaving it set here would suppress the DNSBL
+				// Queries daemon until the next full update (issue #713 bug 3).
+				unlink_if_exists("{$pfb['dnsbl_file']}.sync");
 			}
 			else {
 				// Sentinel flip failed (could not stage/rename) -> fall back to the restart
 				// so the new lists still load (don't leave a flipped-but-no-op state).
 				pfb_logger("\nADR-10: sentinel flip failed -- falling back to Unbound restart", 2);
+				// Same '.sync' leak risk as the timeout branch above -- clear it here too.
+				unlink_if_exists("{$pfb['dnsbl_file']}.sync");
 			}
 		}
 		else {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7524,17 +7524,22 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 				// the new lists definitely load. NOT an error: fail-safe by design.
 				pfb_logger(" not confirmed in time -- falling back to Unbound restart", 2);
 				// Clear the daemon-suppression marker touched above before falling
-				// through: the restart path below re-touches + manages its own '.sync'
-				// (pfb_update_unbound parity), but the alert/#51 caller has no later
-				// clear_work_files, so leaving it set here would suppress the DNSBL
-				// Queries daemon until the next full update (issue #713 bug 3).
+				// through: the inline restart path below (pfb_stop_start_unbound) does
+				// NOT touch '.sync' at all -- a normal, non-fast-path reload restarts
+				// with no suppression marker involved -- so clearing it here is safe.
+				// It is still REQUIRED because the alert/#51 caller (pfb_reload_unbound
+				// invoked from pfblockerng_alerts.php) has no later clear_work_files, so
+				// leaving it set here would leak and suppress the DNSBL Queries daemon
+				// until the next full update (issue #713 bug 3).
 				unlink_if_exists("{$pfb['dnsbl_file']}.sync");
 			}
 			else {
 				// Sentinel flip failed (could not stage/rename) -> fall back to the restart
 				// so the new lists still load (don't leave a flipped-but-no-op state).
 				pfb_logger("\nADR-10: sentinel flip failed -- falling back to Unbound restart", 2);
-				// Same '.sync' leak risk as the timeout branch above -- clear it here too.
+				// Same rationale as the timeout branch above: the inline restart path
+				// below does not touch '.sync', and clearing it here only exists to stop
+				// the marker leaking to the alert/#51 caller (no later clear_work_files).
 				unlink_if_exists("{$pfb['dnsbl_file']}.sync");
 			}
 		}
@@ -9213,8 +9218,8 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			// an uncompressed feed, where $file_download was already renamed away (above)
 			// into $orig_download -- byte-identical to what was fetched, so the fallback is
 			// exact, not an approximation.  This covers both local and remote standard feeds
-			// (any path that finalises a plain .orig here).  geoip/asn early-returns
-			// (~line 7872) do not reach this block, so they correctly never get a sidecar.
+			// (any path that finalises a plain .orig here).  The geoip/asn early-returns
+			// above do not reach this block, so they correctly never get a sidecar.
 			pfb_hash_write("{$orig_download}", pfb_source_hash_target($file_download, $orig_download));
 
 			// Process Emerging Threats IQRisk if required

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10956,6 +10956,26 @@ function pfb_filterlog_refresh_config() {
 	}
 }
 
+// Select the correct filterlog port field for an exploded filter.log CSV row ($d) by
+// IP version ($d[8]) and flow direction. The v4 row carries its ports at $d[20]
+// (src) / $d[21] (dst); the v6 row -- which has fewer leading fields -- carries them
+// at $d[17] (src) / $d[18] (dst). Issue #713: the port-selection at the 'in'/'out'
+// branch used the v4 indices unconditionally, so a v6 flow read the wrong CSV field
+// as its port, mis-attributing the local_hosts reverse-lookup key.
+//
+// PURE -- no I/O, no globals, no side effects.
+//
+// @param array<int, string> $d           Exploded filter.log CSV row.
+// @param bool                $is_inbound  TRUE for the 'in' branch (dst is local).
+function pfb_filterlog_port(array $d, bool $is_inbound): string {
+	$is_v6 = ((int) ($d[8] ?? 0)) === 6;
+	if ($is_inbound) {
+		return $is_v6 ? ($d[18] ?? '') : ($d[21] ?? '');
+	}
+	return $is_v6 ? ($d[17] ?? '') : ($d[20] ?? '');
+}
+
+
 // Firewall filter.log parser daemon
 function pfb_daemon_filterlog() {
 	global $pfb;
@@ -11233,16 +11253,17 @@ function pfb_daemon_filterlog() {
 					}
 
 					// Determine if DST IP or SRC IP is the external host
+					// issue #713: port field is selected by IP version -- see pfb_filterlog_port().
 					if (isset($pfb_local[$dstip]) || pfb_local_ip($dstip, $pfb_localsub)) {
 						$dir	= 'in';
 						$host	= $srcip;
 						$client	= $dstip;
-						$port	= $d[21];
+						$port	= pfb_filterlog_port($d, TRUE);
 					} else {
 						$dir	= 'out';
 						$host	= $dstip;
 						$client	= $srcip;
-						$port	= $d[20];
+						$port	= pfb_filterlog_port($d, FALSE);
 					}
 
 					if (!is_ipaddr($host)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9201,12 +9201,21 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				@touch("{$orig_download}", $remote_stamp);
 			}
 
-			// ADR-42 Phase 2: refresh the content-hash sidecar at every successful ingest
-			// so pfb_local_feed_changed() always compares against the last-ingested bytes.
-			// This covers both local and remote standard feeds (any path that finalises a
-			// plain .orig here).  geoip/asn early-returns (~line 7872) do not reach this
-			// block, so they correctly never get a sidecar.
-			pfb_hash_write("{$orig_download}", "{$orig_download}");
+			// ADR-42 Phase 2 / issue #713 bug 5: refresh the content-hash sidecar at every
+			// successful ingest so pfb_local_feed_changed() / the probe's conditional-GET
+			// compare always land on the SAME domain of bytes the probe hashed.  The probe
+			// (pfb_update_check -> pfb_download($type='change_detect')) hashes the RAW
+			// fetched body (it returns before any decompression), so the persisted digest
+			// here must cover those same raw bytes too -- not the decompressed '.orig' --
+			// or a compressed feed (gz/bz2/zip/7z) never matches and re-ingests every cron.
+			// pfb_source_hash_target() resolves to $file_download (the raw '.raw' download,
+			// still on disk for every compressed format) or falls back to $orig_download for
+			// an uncompressed feed, where $file_download was already renamed away (above)
+			// into $orig_download -- byte-identical to what was fetched, so the fallback is
+			// exact, not an approximation.  This covers both local and remote standard feeds
+			// (any path that finalises a plain .orig here).  geoip/asn early-returns
+			// (~line 7872) do not reach this block, so they correctly never get a sidecar.
+			pfb_hash_write("{$orig_download}", pfb_source_hash_target($file_download, $orig_download));
 
 			// Process Emerging Threats IQRisk if required
 			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {
@@ -10724,6 +10733,27 @@ function pfb_hash_read($base) {
 
 	// No sidecar found — treat as changed (fail-safe).
 	return $sentinel;
+}
+
+// ADR-42 / issue #713 bug 5: resolve which on-disk file holds the RAW fetched body, so
+// the source-hash sidecar pfb_download() persists at ingest time hashes the SAME bytes
+// as the probe (pfb_update_check -> pfb_download($type='change_detect') hashes the raw
+// fetched body -- it returns before any decompression).
+//
+// $file_download is the '.raw' download (pre-decompression); $orig_download is the
+// finalised '.orig' the caller will ingest (decompressed for a compressed feed, or the
+// renamed raw file itself for an uncompressed one).
+//
+//   - Compressed feed (gz/bz2/zip/7z): the decompress tool (gunzip/bzip2/tar/7z) does
+//     not delete its source archive, so $file_download still exists on disk here and IS
+//     the raw fetched bytes -> hash that, not the decompressed $orig_download.
+//   - Uncompressed feed: $file_download was already @rename()'d onto $orig_download
+//     before this is called, so it no longer exists on disk -- but $orig_download now
+//     holds byte-identical content to what was fetched, so falling back to it is exact.
+//
+// Pure / no I/O beyond file_exists(); unit-testable in isolation from pfb_download().
+function pfb_source_hash_target($file_download, $orig_download) {
+	return file_exists($file_download) ? $file_download : $orig_download;
 }
 
 // Write the xxhash128 sidecar for a file path and remove any superseded .md5 sidecar.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2456,6 +2456,29 @@ function pfbng_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 }
 
 
+// Resolve a stored 'log_max_<type>' config value to the truncation limit
+// pfb_log_mgmt() should apply. The web UI stores the literal string 'nolimit'
+// for the "No Limit - Not recommended" option (pfblockerng_general.php);
+// PFB_FILTER_NUM only accepts digit strings, so running the raw value
+// through it directly silently collapses 'nolimit' to the numeric default
+// and the opt-out never takes effect (issue #713) — this helper must run on
+// the RAW config value, before any numeric filtering.
+//
+// PURE — no I/O, no globals, no side effects.
+//
+// @param mixed $raw  Raw 'log_max_<type>' config value.
+// @return int|string  'nolimit' (skip truncation), or a positive int line
+//                      count (a numeric raw value, else the 20000 default).
+function pfb_log_max_lines($raw) {
+	if ($raw === 'nolimit') {
+		return 'nolimit';
+	}
+	if (is_scalar($raw) && preg_match('/^[0-9]+$/', (string) $raw)) {
+		return (int) $raw;
+	}
+	return 20000;
+}
+
 // Manage log files line limit
 function pfb_log_mgmt() {
 	global $g, $pfb;
@@ -2467,9 +2490,14 @@ function pfb_log_mgmt() {
 			'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog') as $logtype) {
 
 		// Max lines in Log file
-		$logmax = pfb_filter($pfb['config']['log_max_' . $logtype], PFB_FILTER_NUM, 'pfb_log_mgmt', 20000);
+		$logmax = pfb_log_max_lines($pfb['config']['log_max_' . $logtype] ?? '');
 
-		if ($logmax != 'nolimit' && file_exists($pfb[$logtype])) {
+		// 'nolimit' opt-out: skip truncation for this log entirely.
+		if ($logmax === 'nolimit') {
+			continue;
+		}
+
+		if (file_exists($pfb[$logtype])) {
 			if ($logtype == 'dnslog' || $logtype == 'dnsreplylog' || $logtype == 'unilog') {
 
 				// Set DNSBL python logfile permissions using chroot folder

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11003,6 +11003,20 @@ function pfb_asn_cache_window(string $asn_reporting): string {
 }
 
 
+// Number of already-processed filter.log lines to skip on daemon (re)start, derived
+// from `grep -c ^ /var/log/filter.log`'s raw output. (int) casts so a grep error
+// string (e.g. filter.log momentarily absent between rotation and daemon restart)
+// coerces to 0 instead of throwing PHP 8's "Unsupported operand types: string - int"
+// TypeError out of the daemon (issue #713 -- a crash loop). Callers must also guard
+// with file_exists('/var/log/filter.log') so the exec() is skipped entirely when the
+// file is absent.
+//
+// PURE -- no I/O, no globals, no side effects.
+function pfb_filterlog_skip_count(string $grep_output): int {
+	return max((int) $grep_output - 1, 0);
+}
+
+
 // Firewall filter.log parser daemon
 function pfb_daemon_filterlog() {
 	global $pfb;
@@ -11043,8 +11057,13 @@ function pfb_daemon_filterlog() {
 		// Parse full filter.log on first run, otherwise only parse new filter.log events
 		if (!file_exists($pfb['ip_blocklog']) && !file_exists($pfb['ip_permitlog']) && !file_exists($pfb['ip_matchlog'])) {
 			$filter_cnt = 0;
+		} elseif (file_exists('/var/log/filter.log')) {
+			// issue #713: guarded by file_exists() -- an absent filter.log made exec()
+			// return a grep error string, and pfb_filterlog_skip_count() (int)-casts it
+			// so it can never throw the old bare-subtraction TypeError.
+			$filter_cnt = pfb_filterlog_skip_count(exec("{$pfb['grep']} -c ^ /var/log/filter.log 2>&1"));
 		} else {
-			$filter_cnt = max( exec("{$pfb['grep']} -c ^ /var/log/filter.log 2>&1") -1, 0) ?: 0;
+			$filter_cnt = 0;
 		}
 		$skip_cnt = $filter_cnt;
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4336,6 +4336,20 @@ function pfb_pfctl_table_count(string $table): int {
 }
 
 
+// Parse the numeric match count out of `pfctl -t <table> -T test <ip> 2>&1` output --
+// "N/1 addresses match." on a normal run, or (because of the merged 2>&1) an error
+// string such as "pfctl: Table does not exist." when the table is absent. (int) casts
+// the leading numeric prefix, which PHP resolves to 0 for any non-numeric string --
+// unlike the old `substr($output, 0, 1) > 0` comparison it replaces, which took the
+// output's first CHARACTER and let PHP 8's string/int comparison rules turn a leading
+// letter (e.g. the 'p' in "pfctl: ...") into a false positive match (issue #713).
+//
+// PURE -- no I/O, no globals, no side effects.
+function pfb_pfctl_test_match_count(string $output): int {
+	return (int) $output;
+}
+
+
 // ADR-11 Phase 3: build + register the opt-in per-type aggregate ("Uber") Native aliases.
 //
 // ONE generic loop over the type->dir map {Deny,Permit,Match,Native} x family {v4,v6}.
@@ -9295,8 +9309,10 @@ function pfb_download_failure($alias, $header, $pfbfolder, $list_url, $format, $
 
 						// Query Snort/Suricata snort2c IP block table
 						$ip_esc = escapeshellarg($ip);
-						$result = substr(exec("{$pfb['pfctl']} -t snort2c -T test {$ip_esc} 2>&1"), 0, 1);
-						if ($result > 0) {
+						// issue #713: parse the numeric match count instead of comparing the
+						// raw output's first character -- see pfb_pfctl_test_match_count().
+						$count = pfb_pfctl_test_match_count(exec("{$pfb['pfctl']} -t snort2c -T test {$ip_esc} 2>&1"));
+						if ($count > 0) {
 							$log = " [ {$ip} ] IDS IP block found for HOST:{$host}!\n";
 							pfb_logger("{$log}", 2);
 							$pfbfound = TRUE;
@@ -10241,8 +10257,10 @@ function pfb_remove_states() {
 
 					$s_table_esc	= escapeshellarg($s_table);
 					$s_ip_esc	= escapeshellarg($s_ip);
-					$result = substr(exec("{$pfb['pfctl']} -t {$s_table_esc} -T test {$s_ip_esc} 2>&1"), 0, 1);
-					if ($result > 0) {
+					// issue #713: parse the numeric match count instead of comparing the
+					// raw output's first character -- see pfb_pfctl_test_match_count().
+					$count = pfb_pfctl_test_match_count(exec("{$pfb['pfctl']} -t {$s_table_esc} -T test {$s_ip_esc} 2>&1"));
+					if ($count > 0) {
 
 						$pfbfound = TRUE;
 						$log = "\n\n\t[ {$s_table} ] Removed " . count($state) . " state(s) for [ {$s_ip} ]\n\n";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -697,6 +697,32 @@ function pfb_rule_alias_needs_v4_suffix($address, $ipprotocol) {
 	       $ipprotocol === 'inet';
 }
 
+// Collect the auto-rule suffix already in use by an existing pfB_ firewall
+// rule (sync_package_pfblockerng() auto-rule-suffix configuration, issue
+// #713). Scans $rules for the FIRST rule whose descr matches the
+// pfBlockerNG auto-rule naming pattern ('pfB_<Type><suffix>') and, when
+// found, both confirms a pfB_ rule already exists ('found') and extracts its
+// suffix ('suffix') so the caller can preserve it instead of re-applying the
+// currently configured suffix setting over already-deployed rules.
+//
+// PURE — no I/O, no globals, no side effects.
+//
+// @param array<int, array<string, mixed>> $rules  config 'filter/rule' entries.
+// @return array{found: bool, suffix: string}
+function pfb_collect_autorule_suffix(array $rules): array {
+	$found  = FALSE;
+	$suffix = '';
+
+	foreach ($rules as $rule) {
+		if (empty($suffix) && preg_match('/^pfB_\w+(\s.*)/', $rule['descr'] ?? '', $match)) {
+			$found  = TRUE;
+			$suffix = $match[1];
+		}
+	}
+
+	return ['found' => $found, 'suffix' => $suffix];
+}
+
 // Validate and normalise the Reports-tab whitelist composite 'atype' parameter,
 // which arrives as 'Whitelist|<ip>|<description>'. The IP is validated via
 // PFB_FILTER_IP (is_ipaddr); an invalid IP yields an empty IP slot
@@ -13144,9 +13170,8 @@ function sync_package_pfblockerng($cron='') {
 	}
 
 	// Configure auto rule suffix.
-	$pfbfound = FALSE;
-	$pfb_suffix_match = '';
-	foreach (config_get_path('filter/rule', []) as $rule) {
+	$pfb_filter_rules = config_get_path('filter/rule', []);
+	foreach ($pfb_filter_rules as $rule) {
 
 		// Query for previous IPv4 pfBlockerNG 'alias type' aliasnames which are not in the new '_v4' suffix format
 		foreach (array('source', 'destination') as $rtype) {
@@ -13154,12 +13179,13 @@ function sync_package_pfblockerng($cron='') {
 				$pfb['autorules'] = TRUE;	// Set flag to re-configure Firewall rules and add missing '_v4' suffix
 			}
 		}
-
-		// Collect any pre-existing suffix
-		if (!empty($pfb_suffix_match) && preg_match('/^pfB_\w+(\s.*)/', $rule['descr'], $pfb_suffix_real)) {
-			$pfb_suffix_match = $pfb_suffix_real[1];
-		}
 	}
+
+	// Collect any pre-existing suffix from an already-deployed pfB_ rule
+	// (issue #713 — 'found' must reflect a real match, not stay permanently FALSE).
+	$pfb_autorule_suffix = pfb_collect_autorule_suffix($pfb_filter_rules);
+	$pfbfound = $pfb_autorule_suffix['found'];
+	$pfb_suffix_match = $pfb_autorule_suffix['suffix'];
 
 	// Change suffix only if no pfB rules found and autorules are enabled.
 	if ($pfb['autorules'] && !$pfbfound) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10976,6 +10976,33 @@ function pfb_filterlog_port(array $d, bool $is_inbound): string {
 }
 
 
+// Map the ASN Reporting setting to the SQLite relative-time window used to expire
+// cached ASN lookups (the pfb_daemon_filterlog() cache-eviction DELETE). Falls back
+// to '-24 hours' for BOTH 'disabled' and any unrecognised token, so the window is
+// ALWAYS defined -- including when reporting is 'disabled' but an ASN token is still
+// configured (issue #713: the old call site only ran this mapping when reporting
+// wasn't 'disabled', leaving $asn_cache undefined/NULL for the token-only case, so
+// the DELETE bound NULL and the cache never expired).
+//
+// PURE -- no I/O, no globals, no side effects.
+function pfb_asn_cache_window(string $asn_reporting): string {
+	switch ($asn_reporting) {
+		case '1hour':
+			return '-1 hour';
+		case '4hour':
+			return '-4 hours';
+		case '12hour':
+			return '-12 hours';
+		case '24hour':
+			return '-24 hours';
+		case 'week':
+			return '-1 week';
+		default:
+			return '-24 hours';
+	}
+}
+
+
 // Firewall filter.log parser daemon
 function pfb_daemon_filterlog() {
 	global $pfb;
@@ -10988,28 +11015,10 @@ function pfb_daemon_filterlog() {
 	// defeating the change-detection on the very first reload check).
 	$GLOBALS['pfb_daemon_config_mtime'] = pfb_file_mtime('/conf/config.xml');
 
-	// ASN Reporting - cached setting
-	if ($pfb['asn_reporting'] != 'disabled') {
-		switch ($pfb['asn_reporting']) {
-			case '1hour':
-				$asn_cache = '-1 hour';
-				break;
-			case '4hour':
-				$asn_cache = '-4 hours';
-				break;
-			case '12hour':
-				$asn_cache = '-12 hours';
-				break;
-			case '24hour':
-				$asn_cache = '-24 hours';
-				break;
-			case 'week':
-				$asn_cache = '-1 week';
-				break;
-			default:
-				$asn_cache = '-24 hours';
-		}
-	}
+	// ASN Reporting - cached setting. Unconditional (issue #713): the cache-eviction
+	// use site below runs whenever reporting is enabled OR an ASN token is set, so
+	// $asn_cache must always be defined -- see pfb_asn_cache_window().
+	$asn_cache = pfb_asn_cache_window($pfb['asn_reporting']);
 
 	// Application paths
 	if (file_exists('/usr/local/bin/mmdblookup') && file_exists("{$pfb['geoipshare']}/GeoLite2-Country.mmdb")) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11953,6 +11953,36 @@ function pfb_daemon_dnsbl_index() {
 }
 
 
+// Map a numeric SQLite3 handle index (1-7, see pfb_open_sqlite() callers) to its
+// table name + CREATE statement. Extracted as a pure function so the index->table
+// mapping is unit-testable without a live SQLite3 file (issue #713 bug 10: table 6
+// used to map to db_table 'stats' while its CREATE TABLE built 'lastclear' -- the
+// name every other query in this file actually uses -- so DB-corruption recovery
+// dropped the wrong/nonexistent table and aborted before 'lastclear' was rebuilt).
+// Unknown $table returns empty strings (behaviour-preserving default; callers only
+// ever pass 1-7).
+function pfb_sqlite_table_spec(int $table): array {
+	switch ($table) {
+		case 1:
+			return [ 'db_table' => 'dnsbl', 'db_create' => "CREATE TABLE IF NOT EXISTS dnsbl ( groupname TEXT, timestamp TEXT, entries INTEGER, counter INTEGER );" ];
+		case 2:
+			return [ 'db_table' => 'lastevent', 'db_create' => "CREATE TABLE IF NOT EXISTS lastevent ( row INTEGER, groupname TEXT, entry TEXT, details TEXT );" ];
+		case 3:
+			return [ 'db_table' => 'resolver', 'db_create' => "CREATE TABLE IF NOT EXISTS resolver ( row INTEGER, totalqueries INTEGER, queries INTEGER );" ];
+		case 4:
+			return [ 'db_table' => 'dnsblcache', 'db_create' => "CREATE TABLE IF NOT EXISTS dnsblcache ( type TEXT, domain TEXT, groupname TEXT, final TEXT, feed TEXT );" ];
+		case 5:
+			return [ 'db_table' => 'asncache', 'db_create' => "CREATE TABLE IF NOT EXISTS asncache ( asn TEXT, host TEXT, timestamp TEXT );" ];
+		case 6:
+			return [ 'db_table' => 'lastclear', 'db_create' => "CREATE TABLE IF NOT EXISTS lastclear ( row INTEGER, lastipclear TEXT, lastdnsblclear TEXT );" ];
+		case 7:
+			return [ 'db_table' => 'ipcache', 'db_create' => "CREATE TABLE IF NOT EXISTS ipcache ( host TEXT, q0 TEXT, q1 TEXT, geoip TEXT, resolved_host TEXT );" ];
+		default:
+			return [ 'db_table' => '', 'db_create' => '' ];
+	}
+}
+
+
 // Function to create/open SQLite3 database(s)
 function pfb_open_sqlite($table, $message) {
 	global $pfb;
@@ -11960,38 +11990,26 @@ function pfb_open_sqlite($table, $message) {
 	// $table is always 1-7 from callers, but the if/elseif chain below has no else;
 	// default these so they are defined for any value. Behaviour-preserving.
 	$database	= '';
-	$db_table	= '';
-	$db_create	= '';
 
 	if ($table == 1) {
 		$database	= $pfb['dnsbl_info'];
-		$db_table	= 'dnsbl';
-		$db_create	= "CREATE TABLE IF NOT EXISTS dnsbl ( groupname TEXT, timestamp TEXT, entries INTEGER, counter INTEGER );";
 	} elseif ($table == 2) {
 		$database	= $pfb['dnsbl_resolver'];
-		$db_table	= 'lastevent';
-		$db_create	= "CREATE TABLE IF NOT EXISTS lastevent ( row INTEGER, groupname TEXT, entry TEXT, details TEXT );";
 	} elseif ($table == 3) {
 		$database	= $pfb['dnsbl_resolver'];
-		$db_table	= 'resolver';
-		$db_create	= "CREATE TABLE IF NOT EXISTS resolver ( row INTEGER, totalqueries INTEGER, queries INTEGER );";
 	} elseif ($table == 4) {
 		$database	= $pfb['dnsbl_cache'];
-		$db_table	= 'dnsblcache';
-		$db_create	= "CREATE TABLE IF NOT EXISTS dnsblcache ( type TEXT, domain TEXT, groupname TEXT, final TEXT, feed TEXT );";
 	} elseif ($table == 5) {
 		$database	= $pfb['asn_cache'];
-		$db_table	= 'asncache';
-		$db_create	= "CREATE TABLE IF NOT EXISTS asncache ( asn TEXT, host TEXT, timestamp TEXT );";
 	} elseif ($table == 6) {
 		$database	= $pfb['dnsbl_resolver'];
-		$db_table	= 'stats';
-		$db_create	= "CREATE TABLE IF NOT EXISTS lastclear ( row INTEGER, lastipclear TEXT, lastdnsblclear TEXT );";
 	} elseif ($table == 7) {
 		$database	= $pfb['ip_cache'];
-		$db_table	= 'ipcache';
-		$db_create      = "CREATE TABLE IF NOT EXISTS ipcache ( host TEXT, q0 TEXT, q1 TEXT, geoip TEXT, resolved_host TEXT );";
 	}
+
+	$table_spec	= pfb_sqlite_table_spec((int) $table);
+	$db_table	= $table_spec['db_table'];
+	$db_create	= $table_spec['db_create'];
 
 	try {
 		$db_handle = new SQLite3($database);
@@ -12047,7 +12065,12 @@ function pfb_open_sqlite($table, $message) {
 		if (!$pfb_validate) {
 			logger(LOG_WARNING, localize_text("DNSBL SQLite3 database [ %s ] corrupt. Table deletion/re-creation completed.", $db_table), LOG_PREFIX_PKG_PFBLOCKERNG);
 			@copy("{$database}", "{$database}.invalid");
-			$db_create = "DROP TABLE {$db_table}; {$db_create}";
+			// IF EXISTS: the table may already be absent (e.g. a fresh/never-created
+			// DB, or exactly the table-6 'stats'/'lastclear' name mismatch this fix
+			// resolves) -- a bare DROP TABLE on a missing table errors and aborts the
+			// whole BEGIN/END TRANSACTION below, so 'lastclear' (etc.) never gets
+			// rebuilt and recovery silently fails (issue #713 bug 10).
+			$db_create = "DROP TABLE IF EXISTS {$db_table}; {$db_create}";
 		}
 
 		try {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -453,7 +453,11 @@ process255() {
 ${data255}
 EOF
 
-		awk 'FNR==NR{a[$0];next}!($0 in a)' "${dedupfile}" "${tempfile}" > "${pfbdeny}${alias}.txt"
+		# #713: gate the publish on awk's own exit status (awk has no "empty
+		# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+		# can't truncate the live deny list via a direct redirect; write to a
+		# sibling temp and publish only on success.
+		awk 'FNR==NR{a[$0];next}!($0 in a)' "${dedupfile}" "${tempfile}" > "${pfbdeny}${alias}.txt.tmp" && mv -f "${pfbdeny}${alias}.txt.tmp" "${pfbdeny}${alias}.txt"
 		while IFS= read -r ip; do
 			pfb_is_octet_prefix "${ip}" || continue
 			echo "${ip}.0/24" >> "${pfbdeny}${alias}.txt"
@@ -562,8 +566,10 @@ EOF
 						# see duplicate()'s sibling grep for the suffix-over-match
 						# rationale (issue #714).
 						grep "^${alias}[[:space:]]" "${masterfile}" > "${tempfile}"
-						awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"
-						mv -f "${tempfile2}" "${masterfile}"
+						# #713: gate the publish on awk's own exit status (awk has no "empty
+						# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+						# can't truncate masterfile via an unconditional mv.
+						awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${masterfile}"
 						sed -e 's/^/'"$alias"' /' "${pfbfolder}${alias}.txt" >> "${masterfile}"
 						cut -d ' ' -f2 "${masterfile}" > "${mastercat}"
 					fi
@@ -1122,7 +1128,11 @@ EOF
 		countb="$(grep -c ^ "${tempfile2}")"
 
 		if [ "${ccblack}" = 'block' ]; then
-			awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile2}" "${tempfile}" > "${pfbdeny}${alias}.txt"
+			# #713: gate the publish on awk's own exit status (awk has no "empty
+			# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+			# can't truncate the live deny list via a direct redirect; write to a
+			# sibling temp and publish only on success.
+			awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile2}" "${tempfile}" > "${pfbdeny}${alias}.txt.tmp" && mv -f "${pfbdeny}${alias}.txt.tmp" "${pfbdeny}${alias}.txt"
 			sed 's/$/0\/24/' "${dupfile}" >> "${pfbdeny}${alias}.txt"
 		elif [ "${ccblack}" = 'match' ]; then
 			sed 's/$/0\/24/' "${dupfile}" >> "${tempmatchfile}"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -414,7 +414,10 @@ remove() {
 				# "BadAds_v4") doesn't over-match and strip a sibling's masterfile
 				# row -- masterfile rows always start with the alias at column 0.
 				grep "^${header}[[:space:]]" "${masterfile}" > "${tempfile}"
-				awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${masterfile}"
+				# #713: gate the publish on awk's own exit status (awk has no "empty
+				# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+				# can't truncate masterfile via an unconditional mv.
+				awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${masterfile}"
 			fi
 
 			rm -f "${pfborig}${header}"*; rm -f "${pfbdeny}${header}"*; rm -f "${pfbmatch}${header}"*
@@ -528,11 +531,26 @@ EOF
 
 				if [ -s "${dupfile}" ]; then
 					# Remove '/24' suppressed ranges
-					awk 'FNR==NR{a[$0];next}!($0 in a)' "${dupfile}" "${tempfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${tempfile}"
+					# #713: gate the publish on awk's own exit status (awk has no "empty
+					# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+					# can't truncate the working copy via an unconditional mv.
+					awk 'FNR==NR{a[$0];next}!($0 in a)' "${dupfile}" "${tempfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${tempfile}"
 				fi
 
-				# Remove all other suppressions from list
-				"${pathgrepcidr}" -vf "${pfbsuppression}" "${tempfile}" > "${pfbfolder}${alias}.txt"
+				# Remove all other suppressions from list. #713: redirect to a scratch
+				# temp and gate the publish on grepcidr's exit status -- rc 0 (matches
+				# removed) and rc 1 (everything suppressed, a LEGITIMATE empty result)
+				# both replace the live list; rc >= 2 is a real grepcidr error, so keep
+				# the previous list intact (no truncation) and warn instead.
+				"${pathgrepcidr}" -vf "${pfbsuppression}" "${tempfile}" > "${tempfile2}"
+				grc=$?
+				if [ "${grc}" -lt 2 ]; then
+					mv -f "${tempfile2}" "${pfbfolder}${alias}.txt"
+				else
+					rm -f "${tempfile2}"
+					log="grepcidr error (rc=${grc}) suppressing [ ${alias} ]; keeping previous list"
+					echo "${log}" | tee -a "${errorlog}"
+				fi
 
 				# Update masterfiles. Don't execute if duplication process is disabled
 				if [ "${dedup}" = 'on' ]; then
@@ -761,14 +779,30 @@ duplicate() {
 		# masterfile row into the removal set and silently dropping it
 		# (issue #714). Masterfile rows always start with the alias.
 		grep "^${alias}[[:space:]]" "${masterfile}" > "${tempfile}"
-		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${masterfile}"
+		# #713: gate the publish on awk's own exit status (awk has no "empty
+		# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+		# can't truncate masterfile via an unconditional mv.
+		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${masterfile}"
 		cut -d ' ' -f2 "${masterfile}" > "${mastercat}"
 	fi
 
 	# Don't execute when only a single 'Alias' exists in masterfile
 	if [ ! "${hcheck}" -eq 0 ]; then
 		LC_ALL=C sort -u "${pfbdeny}${alias}.txt" > "${tempfile}"; mv -f "${tempfile}" "${pfbdeny}${alias}.txt"
-		"${pathgrepcidr}" -vf "${mastercat}" "${pfbdeny}${alias}.txt" > "${tempfile}"; mv -f "${tempfile}" "${pfbdeny}${alias}.txt"
+
+		# #713: gate the publish on grepcidr's exit status -- rc 0 (matches removed)
+		# and rc 1 (everything pruned, a LEGITIMATE empty result) both replace the
+		# list; rc >= 2 is a real grepcidr error, so keep the previous list intact
+		# (no truncation via an unconditional mv) and warn instead.
+		"${pathgrepcidr}" -vf "${mastercat}" "${pfbdeny}${alias}.txt" > "${tempfile}"
+		grc=$?
+		if [ "${grc}" -lt 2 ]; then
+			mv -f "${tempfile}" "${pfbdeny}${alias}.txt"
+		else
+			rm -f "${tempfile}"
+			log="grepcidr error (rc=${grc}) de-duplicating [ ${alias} ]; keeping previous list"
+			echo "${log}" | tee -a "${errorlog}"
+		fi
 	fi
 
 	sed -e 's/^/'"$alias"' /' "${pfbdeny}${alias}.txt" >> "${masterfile}"
@@ -1199,7 +1233,10 @@ EOF
 				grep "${ii}" "${blfile}" > "${tempfile}"
 
 				if [ "${ccblack}" = 'block' ]; then
-					awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${blfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${blfile}"
+					# #713: gate the publish on awk's own exit status (awk has no "empty
+					# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+					# can't truncate this blocklist via an unconditional mv.
+					awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${blfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${blfile}"
 					if [ "${runonce}" -eq 0 ]; then
 						echo "${ip}0/24" >> "${blfile}"
 						echo "${header}" "${ip}" >> "${dedupfile}"
@@ -1233,7 +1270,10 @@ EOF
 			grep -F "${ips}" "${masterfile}" >> "${tempfile}"
 		done < "${dedupfile}"
 		countb="$(grep -c ^ "${tempfile}")"
-		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${masterfile}"
+		# #713: gate the publish on awk's own exit status (awk has no "empty
+		# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+		# can't truncate masterfile via an unconditional mv.
+		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${masterfile}"
 		cat "${addfile}" >> "${masterfile}"
 		cut -d ' ' -f2 "${masterfile}" > "${mastercat}"
 
@@ -1285,7 +1325,10 @@ reputation_pmax(){
 				[ -z "${blfile}" ] && continue
 				header="${blfile##*/}"; header="${header%%.*}"
 				grep "${ii}" "${blfile}" > "${tempfile}"
-				awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${blfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${blfile}"
+				# #713: gate the publish on awk's own exit status (awk has no "empty
+				# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+				# can't truncate this blocklist via an unconditional mv.
+				awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${blfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${blfile}"
 
 				if [ "${runonce}" -eq 0 ]; then
 					echo "${ip}.0/24" >> "${blfile}"
@@ -1312,7 +1355,10 @@ EOF
 			grep -F "${ips}" "${masterfile}" >> "${tempfile}"
 		done < "${dedupfile}"
 		countb="$(grep -c ^ "${tempfile}")"
-		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}"; mv -f "${tempfile2}" "${masterfile}"
+		# #713: gate the publish on awk's own exit status (awk has no "empty
+		# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
+		# can't truncate masterfile via an unconditional mv.
+		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${masterfile}"
 		cat "${addfile}" >> "${masterfile}"
 		cut -d ' ' -f2 "${masterfile}" > "${mastercat}"
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -240,17 +240,29 @@ pfb_zstd_threads() {
 pfb_archive_compress() {
 	_base="$1"
 	shift
-	# No availability probe: just attempt zstd. If the binary is missing OR errors, the
-	# pipeline fails and we fall through -- the attempt IS the check. On a verified write
-	# retire a stale .bz2.
-	if "${pathtar}" -Pcf - "$@" | zstd -q -f -T"$(pfb_zstd_threads)" -o "${_base}.zst" 2>/dev/null \
-		&& zstd -tq "${_base}.zst" 2>/dev/null; then
-		rm -f "${_base}.bz2"
+	# Tar to a private temp file FIRST and check tar's own exit status directly.
+	# POSIX sh has no pipefail, so a `tar -Pcf - ... | zstd ...` pipe silently
+	# discards tar's exit code (only zstd's mattered) -- and "zstd -tq" verifies
+	# only the zstd FRAMING, not tar completeness, so a truncated tar stream still
+	# compressed into a small but VALID .zst: the old check passed on a corrupt
+	# archive AND deleted the still-good .bz2 (issue #713 bug 7). Both temp files
+	# live alongside "${_base}" so the publish "mv" below is same-filesystem and
+	# atomic; on ANY failure below, the pre-existing .bz2 is never touched (only
+	# retired after a verified .zst is published), so the bzip2 fallback always
+	# has a good backup to fall back to.
+	_tartmp="$(mktemp "${_base}.XXXXXX")" || return 1
+	_ztmp="$(mktemp "${_base}.XXXXXX")" || { rm -f "${_tartmp}"; return 1; }
+	if "${pathtar}" -Pcf "${_tartmp}" "$@" \
+		&& zstd -q -f -T"$(pfb_zstd_threads)" -o "${_ztmp}" "${_tartmp}" 2>/dev/null \
+		&& zstd -tq "${_ztmp}" 2>/dev/null; then
+		mv -f "${_ztmp}" "${_base}.zst"
+		rm -f "${_tartmp}" "${_base}.bz2"
 		return 0
 	fi
-	# zstd unavailable or errored: drop any partial/stale .zst, fall back to bzip2
-	# ("who knows what the future holds").
-	rm -f "${_base}.zst"
+	# tar, zstd compression, or zstd verification failed: drop the temp/partial
+	# output (never the pre-existing .bz2 -- it was never touched above) and fall
+	# back to bzip2 ("who knows what the future holds").
+	rm -f "${_tartmp}" "${_ztmp}" "${_base}.zst"
 	"${pathtar}" -Pjcf "${_base}.bz2" "$@"
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1368,14 +1368,20 @@ processet() {
 		echo '-------------------------------------------'
 
 		for list in ${data}; do
-			case "${etblock}" in
-				*$list*)
+			# etblock/etmatch are ", "-separated token lists (see the sed transform
+			# above); pad both sides with the delimiter and anchor on it so a token
+			# only matches its OWN whole entry -- a bare "*$list*" substring glob
+			# would let e.g. a selected ET_P2Pcnc also match list=ET_P2P (issue #713
+			# bug 6). The padded 'x' sentinel (no selection) still matches nothing
+			# real, since no category is literally named 'x'.
+			case ", ${etblock}, " in
+				*", ${list}, "*)
 					printf "%-10s %-25s\n" '  Block: ' "${list}"
 					cat "${etdir}/${list}.txt" >> "${tempfile}"
 					;;
 			esac
-			case "${etmatch}" in
-				*$list*)
+			case ", ${etmatch}, " in
+				*", ${list}, "*)
 					printf "%-10s %-25s\n" '  Match: ' "${list}"
 					cat "${etdir}/${list}.txt" >> "${tempfile2}"
 					;;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1117,13 +1117,17 @@ function pfb_cfg_registry(): array
 // FOREIGN key (ADR-29 §2.5 out-of-scope) written directly by pfblockerng_dnsbl.php
 // as 'dnsbl_webpage' — NOT a gateway-registered key — so it is read here with a
 // direct config_get_path(), mirroring how the DNSBL settings page stores and reads
-// it ($pfb['dconfig']['dnsbl_webpage'] ?: 'dnsbl_default.php'). The 'dnsbl_default.php'
-// default matches that page, so an install that never saved DNSBL settings still
-// reports the default template (and the install/upgrade refresh of dnsbl_active.php
-// then fires). Fixes the dead read of the mis-spelled 'dnsblwebpage' registry key,
-// which always returned '' because nothing ever writes that path.
-function pfb_dnsbl_webpage(): string {
-	return config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_webpage', 'dnsbl_default.php');
+// it ($pfb['dconfig']['dnsbl_webpage'] ?: 'dnsbl_default.php'). config_get_path()'s
+// default arg only substitutes when the key is ABSENT, not when it is present but
+// empty (''), so the `?:` coercion below is required to actually match that page —
+// a saved-then-cleared 'dnsbl_webpage' must still report 'dnsbl_default.php', the
+// same as an install that never saved DNSBL settings (and the install/upgrade
+// refresh of dnsbl_active.php then fires). Fixes the dead read of the mis-spelled
+// 'dnsblwebpage' registry key, which always returned '' because nothing ever
+// writes that path.
+function pfb_dnsbl_webpage(): string
+{
+	return config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_webpage', 'dnsbl_default.php') ?: 'dnsbl_default.php';
 }
 
 /**

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -974,15 +974,6 @@ function pfb_cfg_registry(): array
 			'since'         => '1.0.0',
 		],
 
-		// Webpage template. Default ''.
-		'dnsblwebpage' => [
-			'section'       => $dnsbl,
-			'default'       => '',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
-			'since'         => '1.0.0',
-		],
-
 		// ADR-36: NAT DNS-redirect enable: 'on' | '' (checkbox). Default '' (off).
 		'dnsbl_redir' => [
 			'section'       => $dnsbl,
@@ -1120,6 +1111,19 @@ function pfb_cfg_registry(): array
 	];
 
 	return $registry;
+}
+
+// Read the configured DNSBL block-page template filename. issue #713: this is a
+// FOREIGN key (ADR-29 §2.5 out-of-scope) written directly by pfblockerng_dnsbl.php
+// as 'dnsbl_webpage' — NOT a gateway-registered key — so it is read here with a
+// direct config_get_path(), mirroring how the DNSBL settings page stores and reads
+// it ($pfb['dconfig']['dnsbl_webpage'] ?: 'dnsbl_default.php'). The 'dnsbl_default.php'
+// default matches that page, so an install that never saved DNSBL settings still
+// reports the default template (and the install/upgrade refresh of dnsbl_active.php
+// then fires). Fixes the dead read of the mis-spelled 'dnsblwebpage' registry key,
+// which always returned '' because nothing ever writes that path.
+function pfb_dnsbl_webpage(): string {
+	return config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_webpage', 'dnsbl_default.php');
 }
 
 /**

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -198,7 +198,7 @@ if (!empty($pfb['dnsbl_port']) && !empty($pfb['dnsbl_port_ssl']) && ($pfb['dnsbl
 
 // Replace 'default' DNSBL active blocked webpage
 if (!file_exists('/usr/local/www/pfblockerng/www/dnsbl_active.php') ||
-    PfbConfig::read('dnsblwebpage') == 'dnsbl_default.php') {
+    pfb_dnsbl_webpage() == 'dnsbl_default.php') {
     @copy('/usr/local/www/pfblockerng/www/dnsbl_default.php', '/usr/local/www/pfblockerng/www/dnsbl_active.php');
 }
 

--- a/tests/php/AsnCacheWindowTest.php
+++ b/tests/php/AsnCacheWindowTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_asn_cache_window() — the pure mapping from the ASN Reporting
+ * setting to the SQLite relative-time expiry window (issue #713, bug 13).
+ *
+ * pfb_daemon_filterlog()'s cache-eviction DELETE runs whenever
+ * ($pfb['asn_reporting'] != 'disabled' || !empty($pfb['asn_token'])) -- a
+ * WIDER guard than the old $asn_cache-assigning switch, which only ran when
+ * asn_reporting wasn't 'disabled'. So a config with reporting disabled but an
+ * ASN token set reached the DELETE with $asn_cache undefined/NULL, binding NULL
+ * and never expiring anything -- an unbounded cache. This mapping is
+ * unconditional and defaults 'disabled' (and any unknown token) to the same
+ * '-24 hours' safety window used for an unrecognised value, so the DELETE
+ * always has a real bound.
+ *
+ * Scenario A-E: each configured reporting interval maps to its SQLite window.
+ * Scenario F: 'disabled' -> the safe '-24 hours' default (the regression).
+ * Scenario G: an unrecognised token -> the same safe default.
+ */
+#[CoversFunction('pfb_asn_cache_window')]
+final class AsnCacheWindowTest extends TestCase
+{
+	public function testOneHour_MapsToMinusOneHour(): void
+	{
+		$this->assertSame('-1 hour', pfb_asn_cache_window('1hour'));
+	}
+
+	public function testFourHour_MapsToMinusFourHours(): void
+	{
+		$this->assertSame('-4 hours', pfb_asn_cache_window('4hour'));
+	}
+
+	public function testTwelveHour_MapsToMinusTwelveHours(): void
+	{
+		$this->assertSame('-12 hours', pfb_asn_cache_window('12hour'));
+	}
+
+	public function testTwentyFourHour_MapsToMinusTwentyFourHours(): void
+	{
+		$this->assertSame('-24 hours', pfb_asn_cache_window('24hour'));
+	}
+
+	public function testWeek_MapsToMinusOneWeek(): void
+	{
+		$this->assertSame('-1 week', pfb_asn_cache_window('week'));
+	}
+
+	// ---------- Scenario F — the regression: 'disabled' must still be defined ----------
+
+	/**
+	 * The regression this bug fixes: 'disabled' (reporting off, but the cache
+	 * eviction still runs when an ASN token is configured) must map to the safe
+	 * default, never to an empty/undefined value that would bind NULL and defeat
+	 * the DELETE's expiry.
+	 */
+	public function testDisabled_MapsToSafeTwentyFourHourDefault(): void
+	{
+		$window = pfb_asn_cache_window('disabled');
+
+		$this->assertSame('-24 hours', $window,
+			"expected: 'disabled' still yields a real SQLite window so the cache "
+			. "always expires;\nactual: '{$window}'");
+	}
+
+	// ---------- Scenario G — unknown token falls back to the same safe default ----------
+
+	public function testUnknownToken_MapsToSafeTwentyFourHourDefault(): void
+	{
+		$window = pfb_asn_cache_window('not_a_real_value');
+
+		$this->assertSame('-24 hours', $window,
+			"expected: an unrecognised token falls back to '-24 hours';\n"
+			. "actual: '{$window}'");
+	}
+}

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -609,8 +609,9 @@ final class CfgGatewayTest extends TestCase
 	 *   - pfblockerngsync sub-keys: syncinterfaces, varsynconchanges, row/*
 	 *   - pfblockerngblacklist sub-keys: blacklist_enable, blacklist_freq,
 	 *     blacklist_lang, blacklist_logging, blacklist_selected, item
-	 *   - pfblockerngdnsblsettings sub-keys with ambiguous names across files:
-	 *     dnsbl_webpage (used inconsistently with dnsblwebpage in the codebase)
+	 *   - pfblockerngdnsblsettings foreign key: dnsbl_webpage (written directly by
+	 *     www/pfblockerng_dnsbl.php, read via pfb_dnsbl_webpage(); issue #713 removed
+	 *     the never-written 'dnsblwebpage' registry mis-spelling)
 	 */
 	public function testInventoryCompletenessAllKnownKeysAccountedFor(): void
 	{
@@ -667,9 +668,9 @@ final class CfgGatewayTest extends TestCase
 			'varsynctimeout',
 			'varsyncdestinenable',
 
-			// pfblockerngdnsblsettings ambiguous duplicate name (typo in pfblockerng.inc:
-			// 'dnsbl_webpage' used at line 413 in www/pfblockerng_dnsbl.php vs
-			// 'dnsblwebpage' which IS registered above).
+			// pfblockerngdnsblsettings foreign key: written directly by
+			// www/pfblockerng_dnsbl.php and read via pfb_dnsbl_webpage() (issue #713
+			// removed the never-written 'dnsblwebpage' registry mis-spelling).
 			'dnsbl_webpage',
 		];
 
@@ -782,7 +783,6 @@ final class CfgGatewayTest extends TestCase
 			'pfb_py_cache_max',
 			'pfb_tld',
 			'aliaslog',
-			'dnsblwebpage',
 			// ADR-36: NAT DNS-redirect fields
 			'dnsbl_redir',
 			'dnsbl_redir_int',

--- a/tests/php/CollectAutoruleSuffixTest.php
+++ b/tests/php/CollectAutoruleSuffixTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_collect_autorule_suffix() — scans the firewall 'filter/rule' entries for an
+ * already-deployed pfB_ rule and, when one exists, extracts its suffix so
+ * sync_package_pfblockerng() can preserve it instead of silently re-applying the
+ * currently configured suffix setting (issue #713).
+ *
+ * Two compounding defects in the original inline code made the "preserve
+ * existing suffix" branch permanently unreachable:
+ *   (a) $pfbfound was declared FALSE and never set TRUE anywhere in the loop,
+ *       so the caller's "!$pfbfound" guard was always TRUE.
+ *   (b) the suffix-collection guard was inverted — "!empty($pfb_suffix_match)"
+ *       required the match to ALREADY be non-empty before it could be set, a
+ *       chicken-and-egg deadlock that left $pfb_suffix_match permanently ''.
+ *
+ * This helper fixes both: 'found' is set TRUE exactly when a rule's descr
+ * matches the pfBlockerNG auto-rule naming pattern, and the collection guard
+ * is the correct "empty($suffix)" (collect the FIRST pre-existing suffix, then
+ * stop overwriting it).
+ */
+#[CoversFunction('pfb_collect_autorule_suffix')]
+final class CollectAutoruleSuffixTest extends TestCase
+{
+	/**
+	 * A rule whose descr carries the pfBlockerNG auto-rule pattern
+	 * ('pfB_<Type><suffix>') is both detected ('found' = TRUE) and yields its
+	 * suffix — the exact case the pre-fix code could never produce.
+	 */
+	public function testExistingPfbRuleIsFoundAndItsSuffixExtracted(): void
+	{
+		$rules = [
+			['descr' => 'user rule, not pfB'],
+			['descr' => 'pfB_Deny auto rule'],
+		];
+
+		$result = pfb_collect_autorule_suffix($rules);
+
+		$this->assertTrue(
+			$result['found'],
+			'a pre-existing pfB_ rule must be detected (found = TRUE) so the caller preserves its suffix'
+		);
+		$this->assertSame(
+			' auto rule',
+			$result['suffix'],
+			"the suffix captured after 'pfB_<Type>' must be extracted verbatim"
+		);
+	}
+
+	/**
+	 * No pfB_-descr rule anywhere in the set -> nothing found, empty suffix.
+	 * Paired with the case above so a green result there is proven to be a
+	 * real branch and not an always-FALSE/empty path.
+	 */
+	public function testNoExistingPfbRuleReturnsNotFoundAndEmptySuffix(): void
+	{
+		$rules = [
+			['descr' => 'user rule one'],
+			['descr' => 'user rule two'],
+		];
+
+		$result = pfb_collect_autorule_suffix($rules);
+
+		$this->assertFalse($result['found'], 'no pfB_ rule present must leave found = FALSE');
+		$this->assertSame('', $result['suffix'], 'no pfB_ rule present must leave suffix empty');
+	}
+
+	/**
+	 * Only the FIRST pre-existing suffix is collected — a later differently
+	 * suffixed pfB_ rule must not overwrite it (the fixed 'empty($suffix)'
+	 * guard stops collecting once a suffix is set).
+	 */
+	public function testOnlyFirstPreexistingSuffixIsCollected(): void
+	{
+		$rules = [
+			['descr' => 'pfB_Deny auto rule'],
+			['descr' => 'pfB_Permit AR'],
+		];
+
+		$result = pfb_collect_autorule_suffix($rules);
+
+		$this->assertTrue($result['found']);
+		$this->assertSame(
+			' auto rule',
+			$result['suffix'],
+			'the FIRST matching suffix must win; a later differently-suffixed rule must not overwrite it'
+		);
+	}
+
+	/**
+	 * A rule missing the 'descr' key entirely must not error and must not be
+	 * mistaken for a match.
+	 */
+	public function testRuleWithoutDescrKeyIsIgnored(): void
+	{
+		$rules = [
+			['action' => 'pass'],
+		];
+
+		$result = pfb_collect_autorule_suffix($rules);
+
+		$this->assertFalse($result['found']);
+		$this->assertSame('', $result['suffix']);
+	}
+}

--- a/tests/php/DnsblWebpageForeignReadTest.php
+++ b/tests/php/DnsblWebpageForeignReadTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_webpage() — issue #713.
+ *
+ * The DNSBL block-page template filename is a FOREIGN config key stored at
+ * installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_webpage (written
+ * directly by www/pfblockerng_dnsbl.php). The install/upgrade code that
+ * refreshes dnsbl_active.php previously read the never-written registry
+ * mis-spelling 'dnsblwebpage' (via PfbConfig::read), which always returned ''
+ * — so the refresh was dead even when the user was on the default page.
+ *
+ * These tests pin that the reader returns the value actually stored under the
+ * real 'dnsbl_webpage' key, defaulting to 'dnsbl_default.php' (matching the
+ * settings page's own `?: 'dnsbl_default.php'`) when nothing is stored.
+ */
+final class DnsblWebpageForeignReadTest extends TestCase
+{
+	private const PATH = 'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_webpage';
+
+	private $prevConfig;
+
+	protected function setUp(): void
+	{
+		// Save the ambient config and start each test from a known-empty baseline.
+		$this->prevConfig = $GLOBALS['config'] ?? null;
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = $this->prevConfig;
+	}
+
+	public function testConfiguredCustomWebpageIsReturned(): void
+	{
+		// Given a user-selected custom block page stored under the real key,
+		config_set_path(self::PATH, 'my_custom.php');
+		// the reader returns it — the old dead 'dnsblwebpage' read returned ''.
+		$this->assertSame('my_custom.php', pfb_dnsbl_webpage());
+	}
+
+	public function testConfiguredDefaultWebpageIsReturned(): void
+	{
+		// A user whose block page IS the default: the reader reports it so the
+		// install/upgrade refresh (== 'dnsbl_default.php') actually fires.
+		config_set_path(self::PATH, 'dnsbl_default.php');
+		$this->assertSame('dnsbl_default.php', pfb_dnsbl_webpage());
+	}
+
+	public function testAbsentWebpageDefaultsToDnsblDefault(): void
+	{
+		// An install that never saved DNSBL settings uses the default page
+		// (mirrors pfblockerng_dnsbl.php's `?: 'dnsbl_default.php'`), so the
+		// refresh still fires for it.
+		$this->assertSame('dnsbl_default.php', pfb_dnsbl_webpage());
+	}
+}

--- a/tests/php/DnsblWebpageForeignReadTest.php
+++ b/tests/php/DnsblWebpageForeignReadTest.php
@@ -57,4 +57,16 @@ final class DnsblWebpageForeignReadTest extends TestCase
 		// refresh still fires for it.
 		$this->assertSame('dnsbl_default.php', pfb_dnsbl_webpage());
 	}
+
+	public function testPresentButEmptyWebpageDefaultsToDnsblDefault(): void
+	{
+		// A saved-then-cleared 'dnsbl_webpage' (key PRESENT, value '') must still
+		// report the default -- config_get_path()'s default arg only substitutes
+		// on an ABSENT key, not a present-but-empty one, so a bare
+		// config_get_path(..., 'dnsbl_default.php') read (no `?:` coercion) wrongly
+		// returns '' here, same as pfblockerng_dnsbl.php's own
+		// `$pfb['dconfig']['dnsbl_webpage'] ?: 'dnsbl_default.php'` would not.
+		config_set_path(self::PATH, '');
+		$this->assertSame('dnsbl_default.php', pfb_dnsbl_webpage());
+	}
 }

--- a/tests/php/FeedChangeHashHelpersTest.php
+++ b/tests/php/FeedChangeHashHelpersTest.php
@@ -17,6 +17,12 @@ use PHPUnit\Framework\TestCase;
  *                             content-identical → FALSE; content-different → TRUE;
  *                             legacy .md5 sidecar read + migration; absent sidecar
  *                             falls back to live .orig hash; idempotence guard.
+ *   pfb_source_hash_target() — issue #713 bug 5: resolves which on-disk file (the raw
+ *                             '.raw' download or the finalised '.orig') holds the SAME
+ *                             bytes the change-detection probe hashes, so a compressed
+ *                             feed's persisted sidecar and the probe's body hash cover
+ *                             one consistent domain of bytes instead of silently
+ *                             comparing compressed-vs-decompressed and never matching.
  *
  * Every test carries a failable assertion.
  */
@@ -24,6 +30,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_hash_read')]
 #[CoversFunction('pfb_hash_write')]
 #[CoversFunction('pfb_local_feed_changed')]
+#[CoversFunction('pfb_source_hash_target')]
 final class FeedChangeHashHelpersTest extends TestCase
 {
 	/** @var string Writable temp directory for this test class. */
@@ -605,6 +612,240 @@ final class FeedChangeHashHelpersTest extends TestCase
 		$this->assertFalse(
 			$second,
 			sprintf('Second call must return FALSE (idempotent — no perpetual re-ingest), got %s', var_export($second, TRUE))
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// pfb_source_hash_target() — issue #713 bug 5: raw-vs-orig sidecar target
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Compressed feed: the raw '.raw' download is still on disk (gunzip/bzip2/tar/7z
+	 * never delete their source archive) — it must be preferred, since it holds the
+	 * SAME bytes the probe hashes (pfb_download() in change_detect mode returns before
+	 * any decompression).
+	 *
+	 *  GIVEN both the raw download and the decompressed .orig exist on disk;
+	 *   WHEN pfb_source_hash_target($file_download, $orig_download) is called;
+	 *   THEN it returns the raw download path, not the decompressed .orig.
+	 */
+	public function test_source_hash_target_prefers_raw_when_present(): void
+	{
+		$raw  = $this->dir . '/compressed.raw';
+		$orig = $this->dir . '/compressed.orig';
+		file_put_contents($raw, 'RAW COMPRESSED BYTES');
+		file_put_contents($orig, 'DECOMPRESSED BYTES');
+
+		$target = pfb_source_hash_target($raw, $orig);
+
+		$this->assertSame(
+			$raw,
+			$target,
+			sprintf(
+				'When the raw fetched download still exists (compressed feed), it must be '
+				. 'preferred over the decompressed .orig — the probe hashes these same raw '
+				. 'bytes (expected %s, got %s)',
+				$raw,
+				var_export($target, TRUE)
+			)
+		);
+	}
+
+	/**
+	 * Uncompressed feed: pfb_download() @rename()s the raw download straight onto
+	 * $orig_download, so the raw path no longer exists on disk by the time the sidecar
+	 * is written. Falling back to $orig_download is exact (byte-identical), not an
+	 * approximation.
+	 *
+	 *  GIVEN the raw download path does not exist (already renamed onto .orig);
+	 *   WHEN pfb_source_hash_target($file_download, $orig_download) is called;
+	 *   THEN it returns the .orig path.
+	 */
+	public function test_source_hash_target_falls_back_to_orig_when_raw_absent(): void
+	{
+		$missing_raw = $this->dir . '/uncompressed.raw';
+		$orig        = $this->dir . '/uncompressed.orig';
+		file_put_contents($orig, 'plain feed content');
+
+		$this->assertFileDoesNotExist(
+			$missing_raw,
+			'Precondition: the raw download was renamed onto .orig and no longer exists'
+		);
+
+		$target = pfb_source_hash_target($missing_raw, $orig);
+
+		$this->assertSame(
+			$orig,
+			$target,
+			sprintf(
+				'When the raw download no longer exists, fall back to .orig (expected %s, got %s)',
+				$orig,
+				var_export($target, TRUE)
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Integration: the probe and the persisted sidecar must agree on a compressed feed
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The bug (issue #713 bug 5): the change-detection probe (pfb_update_check ->
+	 * pfb_download($type='change_detect')) hashes the RAW fetched body — it returns
+	 * before any decompression. For a compressed feed, ingest used to persist the
+	 * sidecar from the DECOMPRESSED .orig instead, so the two hashes covered different
+	 * bytes and could never match — every cron re-ingested a compressed feed even when
+	 * the server returned byte-identical content.
+	 *
+	 * This test reproduces both sides of that comparison with the real hash helpers:
+	 * ingest persists via pfb_source_hash_target() (the fix), the probe re-fetches the
+	 * SAME compressed bytes (server unchanged), and pfb_conditional_get_decision() must
+	 * report "unchanged".
+	 *
+	 *  GIVEN a compressed feed ingested once (raw gzip body decompressed to .orig, sidecar
+	 *        persisted from pfb_source_hash_target($file_download, $orig_download));
+	 *   WHEN a later probe re-fetches byte-identical compressed bytes and its body hash is
+	 *        compared against the persisted sidecar via pfb_conditional_get_decision();
+	 *   THEN the decision is "unchanged" (FALSE) — no needless re-ingest.
+	 *
+	 * RED on the pre-fix code: pfb_source_hash_target() does not exist there, and the old
+	 * call site hashed $orig_download (decompressed) directly — the sanity assertion below
+	 * proves that would have produced a DIFFERENT digest than the probe's raw body hash,
+	 * i.e. pfb_conditional_get_decision() would have returned TRUE (changed) instead.
+	 */
+	public function test_compressed_feed_unchanged_is_detected_via_raw_hash(): void
+	{
+		// GIVEN: a compressed feed body, ingested once.
+		$content   = "ip 192.0.2.1\nip 192.0.2.2\n";
+		$raw_bytes = gzencode($content, 9);
+
+		$file_download = $this->dir . '/feed.raw';
+		$orig_download = $this->dir . '/feed.orig';
+		file_put_contents($file_download, $raw_bytes);
+		// Mirrors `gunzip -c {raw} > {orig}` in pfb_download(): decompressed content,
+		// raw archive left intact on disk.
+		file_put_contents($orig_download, gzdecode($raw_bytes));
+
+		// Ingest persists the source-hash sidecar via the fixed target-resolution helper.
+		$hash_target = pfb_source_hash_target($file_download, $orig_download);
+		$write_ok    = pfb_hash_write($orig_download, $hash_target);
+		$this->assertTrue($write_ok, 'Precondition: pfb_hash_write() must succeed for the ingest sidecar');
+
+		$persisted = pfb_hash_read($orig_download);
+		$this->assertSame(
+			'xxh128',
+			$persisted['algo'],
+			'Precondition: the ingest sidecar must be written as xxh128'
+		);
+
+		// WHEN: a later cron probe re-fetches the SAME compressed bytes (server unchanged
+		// — pfb_download($type='change_detect') writes the raw body to {header}.md5.raw
+		// and returns before decompressing).
+		$probe_raw = $this->dir . '/feed.md5.raw';
+		file_put_contents($probe_raw, $raw_bytes);
+		$body_hash = pfb_content_hash($probe_raw, TRUE);
+
+		$changed = pfb_conditional_get_decision('200', $body_hash, $persisted['digest']);
+
+		// THEN: correctly detected as unchanged — no needless re-ingest.
+		$this->assertFalse(
+			$changed,
+			sprintf(
+				'A compressed feed with byte-identical content on re-fetch must be reported '
+				. 'unchanged (body_hash=%s, persisted_hash=%s)',
+				var_export($body_hash, TRUE),
+				var_export($persisted['digest'], TRUE)
+			)
+		);
+
+		// RED-proof sanity check: hashing the DECOMPRESSED .orig directly (the pre-fix
+		// call site: pfb_hash_write($orig_download, $orig_download)) produces a digest
+		// that can NEVER equal the probe's raw (compressed) body hash — proving the two
+		// sides compared different bytes before this fix.
+		$broken_persisted_hash = pfb_content_hash($orig_download, TRUE);
+		$this->assertNotSame(
+			$body_hash,
+			$broken_persisted_hash,
+			'Sanity: the probe\'s raw (compressed) body hash must differ from the hash of the '
+			. 'decompressed .orig — this is exactly why the pre-fix code (which persisted the '
+			. 'latter) could never match and forced a false "changed" on every cron'
+		);
+		$this->assertTrue(
+			pfb_conditional_get_decision('200', $body_hash, $broken_persisted_hash),
+			'Sanity: comparing the probe body hash against the pre-fix (decompressed) '
+			. 'persisted hash must yield "changed" — reproducing the reported defect'
+		);
+	}
+
+	/**
+	 * Branch coverage: a REAL content change on a compressed feed must still be detected
+	 * as "changed" — the fix must not overcorrect into a false "unchanged".
+	 *
+	 *  GIVEN a compressed feed ingested once, then the upstream body genuinely changes;
+	 *   WHEN the probe's re-fetched (different) compressed bytes are compared against the
+	 *        persisted sidecar via pfb_conditional_get_decision();
+	 *   THEN the decision is "changed" (TRUE) — re-ingest happens.
+	 */
+	public function test_compressed_feed_real_change_is_still_detected(): void
+	{
+		$old_bytes = gzencode("ip 192.0.2.1\n", 9);
+		$new_bytes = gzencode("ip 192.0.2.1\nip 192.0.2.99\n", 9);
+
+		$file_download = $this->dir . '/feed2.raw';
+		$orig_download = $this->dir . '/feed2.orig';
+		file_put_contents($file_download, $old_bytes);
+		file_put_contents($orig_download, gzdecode($old_bytes));
+
+		pfb_hash_write($orig_download, pfb_source_hash_target($file_download, $orig_download));
+		$persisted = pfb_hash_read($orig_download);
+
+		// A later probe fetches the genuinely-updated compressed body.
+		$probe_raw = $this->dir . '/feed2.md5.raw';
+		file_put_contents($probe_raw, $new_bytes);
+		$body_hash = pfb_content_hash($probe_raw, TRUE);
+
+		$changed = pfb_conditional_get_decision('200', $body_hash, $persisted['digest']);
+
+		$this->assertTrue(
+			$changed,
+			'A genuinely updated compressed feed body must still be detected as changed'
+		);
+	}
+
+	/**
+	 * Regression guard: an UNCOMPRESSED feed's unchanged round-trip must be unaffected by
+	 * this fix — pfb_source_hash_target() falls back to .orig there, which already holds
+	 * the exact fetched bytes (no decompression step).
+	 *
+	 *  GIVEN an uncompressed feed ingested once via pfb_source_hash_target();
+	 *   WHEN a later probe re-fetches byte-identical content;
+	 *   THEN pfb_conditional_get_decision() still reports "unchanged".
+	 */
+	public function test_uncompressed_feed_unchanged_round_trip_is_unaffected(): void
+	{
+		$content = "ip 192.0.2.1\nip 192.0.2.2\n";
+
+		// Mirrors pfb_download(): the raw download is @rename()'d onto .orig for an
+		// uncompressed feed, so only .orig exists by ingest-sidecar time.
+		$missing_raw   = $this->dir . '/plain.raw';
+		$orig_download = $this->dir . '/plain.orig';
+		file_put_contents($orig_download, $content);
+
+		pfb_hash_write($orig_download, pfb_source_hash_target($missing_raw, $orig_download));
+		$persisted = pfb_hash_read($orig_download);
+		$this->assertSame('xxh128', $persisted['algo'], 'Precondition: ingest sidecar written as xxh128');
+
+		// The probe's raw body for an uncompressed feed IS the fetched content verbatim.
+		$probe_raw = $this->dir . '/plain.md5.raw';
+		file_put_contents($probe_raw, $content);
+		$body_hash = pfb_content_hash($probe_raw, TRUE);
+
+		$changed = pfb_conditional_get_decision('200', $body_hash, $persisted['digest']);
+
+		$this->assertFalse(
+			$changed,
+			'An uncompressed feed with byte-identical content on re-fetch must still be '
+			. 'reported unchanged (regression guard for this fix)'
 		);
 	}
 }

--- a/tests/php/FilterlogPortTest.php
+++ b/tests/php/FilterlogPortTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_filterlog_port() — the pure port-field selector for a parsed
+ * filter.log CSV row (issue #713, bug 12).
+ *
+ * The filter.log CSV layout differs by IP version: a v4 row's ports live at
+ * $d[20] (src) / $d[21] (dst); a v6 row -- fewer leading fields -- carries them
+ * at $d[17] (src) / $d[18] (dst). Confirmed against the "Log: Protocol
+ * ID/Protocol/SRC IP/DST IP/SRC Port/DST Port" comment and CSV-build code a few
+ * hundred lines below pfb_daemon_filterlog()'s port-selection site (both v4 and
+ * v6 branches use the same $d[20]/$d[21] vs $d[17]/$d[18] indices there). The
+ * old port-selection at the 'in'/'out' branch used the v4 indices ($d[20]/$d[21])
+ * unconditionally, so a v6 flow read the wrong CSV field as its port and
+ * mis-attributed the local_hosts reverse-lookup key.
+ *
+ * Scenario A: v4 inbound (dst is local)  -> dst port at $d[21]
+ * Scenario B: v4 outbound (src is local) -> src port at $d[20]
+ * Scenario C: v6 inbound (dst is local)  -> dst port at $d[18]
+ * Scenario D: v6 outbound (src is local) -> src port at $d[17]
+ */
+#[CoversFunction('pfb_filterlog_port')]
+final class FilterlogPortTest extends TestCase
+{
+	// A synthetic $d row with a distinct marker at every candidate port index,
+	// so a wrong-index read is caught rather than accidentally matching.
+	private function rowFor(int $ipVersion): array {
+		$d = [];
+		$d[8]  = $ipVersion;
+		$d[17] = 'v6_src_17';
+		$d[18] = 'v6_dst_18';
+		$d[20] = 'v4_src_20';
+		$d[21] = 'v4_dst_21';
+		return $d;
+	}
+
+	// ---------- Scenario A — v4 inbound ----------
+
+	public function testV4Inbound_ReturnsDstPortAt21(): void
+	{
+		// Given: a v4 row.
+		$d = $this->rowFor(4);
+
+		// When: the flow is inbound (dst is the local client).
+		$port = pfb_filterlog_port($d, TRUE);
+
+		// Then: the v4 dst-port field ($d[21]) is used.
+		$this->assertSame('v4_dst_21', $port,
+			"expected: v4 inbound reads \$d[21];\nactual: {$port}");
+	}
+
+	// ---------- Scenario B — v4 outbound ----------
+
+	public function testV4Outbound_ReturnsSrcPortAt20(): void
+	{
+		// Given: a v4 row.
+		$d = $this->rowFor(4);
+
+		// When: the flow is outbound (src is the local client).
+		$port = pfb_filterlog_port($d, FALSE);
+
+		// Then: the v4 src-port field ($d[20]) is used.
+		$this->assertSame('v4_src_20', $port,
+			"expected: v4 outbound reads \$d[20];\nactual: {$port}");
+	}
+
+	// ---------- Scenario C — v6 inbound (the regression) ----------
+
+	/**
+	 * The regression this bug fixes: a v6 inbound flow must read the v6 dst-port
+	 * index ($d[18]), not the v4 index ($d[21]).
+	 */
+	public function testV6Inbound_ReturnsDstPortAt18(): void
+	{
+		// Given: a v6 row.
+		$d = $this->rowFor(6);
+
+		// When: the flow is inbound (dst is the local client).
+		$port = pfb_filterlog_port($d, TRUE);
+
+		// Then: the v6 dst-port field ($d[18]) is used -- NOT the v4 $d[21].
+		$this->assertSame('v6_dst_18', $port,
+			"expected: v6 inbound reads \$d[18], not the v4 \$d[21];\nactual: {$port}");
+	}
+
+	// ---------- Scenario D — v6 outbound (the regression) ----------
+
+	public function testV6Outbound_ReturnsSrcPortAt17(): void
+	{
+		// Given: a v6 row.
+		$d = $this->rowFor(6);
+
+		// When: the flow is outbound (src is the local client).
+		$port = pfb_filterlog_port($d, FALSE);
+
+		// Then: the v6 src-port field ($d[17]) is used -- NOT the v4 $d[20].
+		$this->assertSame('v6_src_17', $port,
+			"expected: v6 outbound reads \$d[17], not the v4 \$d[20];\nactual: {$port}");
+	}
+}

--- a/tests/php/FilterlogSkipCountTest.php
+++ b/tests/php/FilterlogSkipCountTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_filterlog_skip_count() — the pure parser for
+ * `grep -c ^ /var/log/filter.log`'s raw exec() output (issue #713, bug 14).
+ *
+ * The old call site computed `max(exec(...) - 1, 0)` with no cast: when
+ * filter.log is momentarily absent (log rotation racing the daemon restart),
+ * the merged 2>&1 output is a grep error STRING, and PHP 8 throws
+ * "Unsupported operand types: string - int" out of the daemon -- a crash loop.
+ * (int) casting the exec() output first makes any non-numeric string coerce to
+ * 0 instead of throwing.
+ *
+ * Scenario A: a normal numeric count -> count - 1
+ * Scenario B: a zero count -> 0 (never negative)
+ * Scenario C: empty output -> 0
+ * Scenario D: the grep error string (filter.log absent) -> 0, no exception
+ */
+#[CoversFunction('pfb_filterlog_skip_count')]
+final class FilterlogSkipCountTest extends TestCase
+{
+	// ---------- Scenario A — normal numeric grep count ----------
+
+	public function testNumericCount_ReturnsCountMinusOne(): void
+	{
+		// Given: grep -c reports 1234 matching lines (includes the trailing
+		// blank-line artifact the call site's "-1" already accounted for).
+		$grepOutput = '1234';
+
+		// When
+		$skip = pfb_filterlog_skip_count($grepOutput);
+
+		// Then
+		$this->assertSame(1233, $skip,
+			"expected: 1233 (1234 - 1);\nactual: {$skip}");
+	}
+
+	// ---------- Scenario B — zero count never goes negative ----------
+
+	public function testZeroCount_ReturnsZeroNotNegative(): void
+	{
+		// Given
+		$grepOutput = '0';
+
+		// When
+		$skip = pfb_filterlog_skip_count($grepOutput);
+
+		// Then: max(0 - 1, 0) = 0, never -1.
+		$this->assertSame(0, $skip,
+			"expected: 0 (clamped, never negative);\nactual: {$skip}");
+	}
+
+	// ---------- Scenario C — empty output ----------
+
+	public function testEmptyOutput_ReturnsZero(): void
+	{
+		// Given
+		$grepOutput = '';
+
+		// When
+		$skip = pfb_filterlog_skip_count($grepOutput);
+
+		// Then
+		$this->assertSame(0, $skip,
+			"expected: 0 (empty output);\nactual: {$skip}");
+	}
+
+	// ---------- Scenario D — the regression: grep's error string must not throw ----------
+
+	/**
+	 * The regression this bug fixes: when filter.log is momentarily absent,
+	 * exec()'s merged 2>&1 output is grep's error text, not a number. The old
+	 * un-cast `$output - 1` threw a PHP 8 TypeError for this exact input,
+	 * crash-looping the daemon. This must return 0 with no exception.
+	 */
+	public function testGrepErrorString_ReturnsZeroWithoutThrowing(): void
+	{
+		// Given: filter.log does not exist, so grep -c wrote its error to stderr,
+		// merged into $output by the caller's 2>&1.
+		$grepOutput = 'grep: /var/log/filter.log: No such file or directory';
+
+		// When / Then: must not throw (the old bare `$output - 1` did).
+		$skip = pfb_filterlog_skip_count($grepOutput);
+
+		$this->assertSame(0, $skip,
+			"expected: 0, and no TypeError, for a non-numeric grep error string;\n"
+			. "actual: {$skip}");
+	}
+}

--- a/tests/php/LogMaxLinesTest.php
+++ b/tests/php/LogMaxLinesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_log_max_lines() — resolves a stored 'log_max_<type>' config value to the
+ * truncation limit pfb_log_mgmt() applies (issue #713).
+ *
+ * The web UI stores the literal string 'nolimit' for the "No Limit - Not
+ * recommended" option (pfblockerng_general.php), but pfb_log_mgmt() used to run
+ * that raw value through pfb_filter(..., PFB_FILTER_NUM, ...) BEFORE checking
+ * for the sentinel. PFB_FILTER_NUM only accepts digit strings
+ * ('/^[0-9]+$/'), so 'nolimit' failed the filter and silently collapsed to
+ * the numeric default (20000) — the "No Limit" opt-out never took effect and
+ * every log was truncated regardless of the setting. This helper must be
+ * called on the RAW config value so the sentinel survives.
+ *
+ * Branch coverage: all three input classes pfb_log_mgmt() can see for a
+ * 'log_max_<type>' field.
+ */
+#[CoversFunction('pfb_log_max_lines')]
+final class LogMaxLinesTest extends TestCase
+{
+	/**
+	 * The 'nolimit' sentinel MUST survive unchanged — this is the exact defect
+	 * from issue #713. On the pre-fix inline code (running 'nolimit' through
+	 * PFB_FILTER_NUM first) this collapses to 20000 instead.
+	 */
+	public function testNolimitSentinelSurvives(): void
+	{
+		$this->assertSame(
+			'nolimit',
+			pfb_log_max_lines('nolimit'),
+			"'nolimit' must be returned verbatim so pfb_log_mgmt() can skip truncation for it"
+		);
+	}
+
+	/**
+	 * A digit-string config value resolves to that same limit as an int.
+	 */
+	public function testNumericRawResolvesToThatIntLimit(): void
+	{
+		$this->assertSame(
+			5000,
+			pfb_log_max_lines('5000'),
+			"a numeric raw value must resolve to its own int limit, not the 20000 default"
+		);
+	}
+
+	/**
+	 * Anything that is neither 'nolimit' nor a digit string (empty, garbage,
+	 * or absent/null) falls back to the 20000 default — the same default
+	 * pfb_log_mgmt() historically applied via PFB_FILTER_NUM's $default arg.
+	 */
+	public function testInvalidOrEmptyRawFallsBackToDefault(): void
+	{
+		$this->assertSame(20000, pfb_log_max_lines(''), "empty raw value must fall back to the 20000 default");
+		$this->assertSame(20000, pfb_log_max_lines('not-a-number'), "non-numeric raw value must fall back to the 20000 default");
+		$this->assertSame(20000, pfb_log_max_lines(null), "absent (null) raw value must fall back to the 20000 default");
+	}
+}

--- a/tests/php/PfctlTestMatchCountTest.php
+++ b/tests/php/PfctlTestMatchCountTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_pfctl_test_match_count() — the pure parser for `pfctl -t <table>
+ * -T test <ip> 2>&1` output (issue #713, bug 9).
+ *
+ * pfctl prints "N/1 addresses match." on a normal run. Because the call sites
+ * merge stderr via 2>&1, a MISSING table instead prints an error string such as
+ * "pfctl: Table does not exist." The old call sites took
+ * `substr($output, 0, 1) > 0` as their truthiness test: PHP 8's string/int
+ * comparison rules turn a leading letter ('p' in "pfctl: ...") into a match
+ * ('p' > '0' as a string compare), so an absent table was falsely reported as a
+ * match — a false IDS-block / false "states killed" (issue #713).
+ *
+ * Scenario A: a real match ("1/1 addresses match.") -> 1
+ * Scenario B: no match ("0/1 addresses match.") -> 0
+ * Scenario C: table absent (pfctl error string via 2>&1) -> 0, NOT a false match
+ * Scenario D: empty output -> 0
+ */
+#[CoversFunction('pfb_pfctl_test_match_count')]
+final class PfctlTestMatchCountTest extends TestCase
+{
+	// ---------- Scenario A — a real match ----------
+
+	public function testMatchOutput_ReturnsOne(): void
+	{
+		// Given: pfctl reports one address matching the table.
+		$output = '1/1 addresses match.';
+
+		// When
+		$count = pfb_pfctl_test_match_count($output);
+
+		// Then
+		$this->assertSame(1, $count,
+			"expected: 1 (a real match);\nactual: {$count}");
+	}
+
+	// ---------- Scenario B — no match ----------
+
+	public function testNoMatchOutput_ReturnsZero(): void
+	{
+		// Given: pfctl reports the address is not in the table.
+		$output = '0/1 addresses match.';
+
+		// When
+		$count = pfb_pfctl_test_match_count($output);
+
+		// Then
+		$this->assertSame(0, $count,
+			"expected: 0 (no match);\nactual: {$count}");
+	}
+
+	// ---------- Scenario C — absent table must NOT read as a match ----------
+
+	/**
+	 * The regression this bug fixes: an absent table's pfctl error text (merged
+	 * via 2>&1) must parse to 0, never a positive match count.
+	 */
+	public function testTableDoesNotExist_ReturnsZeroNotAFalseMatch(): void
+	{
+		// Given: the table does not exist, so pfctl writes an error to stderr,
+		// merged into $output by the caller's 2>&1.
+		$output = 'pfctl: Table does not exist.';
+
+		// When
+		$count = pfb_pfctl_test_match_count($output);
+
+		// Then: 0 -- a missing table must never be treated as a positive match.
+		$this->assertSame(0, $count,
+			"expected: 0 (absent table is not a match);\nactual: {$count}");
+	}
+
+	// ---------- Scenario D — empty output ----------
+
+	public function testEmptyOutput_ReturnsZero(): void
+	{
+		// Given: exec() returned no output at all.
+		$output = '';
+
+		// When
+		$count = pfb_pfctl_test_match_count($output);
+
+		// Then
+		$this->assertSame(0, $count,
+			"expected: 0 (empty output);\nactual: {$count}");
+	}
+}

--- a/tests/php/SqliteCorruptRecoveryTest.php
+++ b/tests/php/SqliteCorruptRecoveryTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_open_sqlite()'s DB-corruption recovery path -- exercised against a
+ * REAL SQLite3 database (issue #713 bug 10).
+ *
+ * On a failed `PRAGMA integrity_check`, pfb_open_sqlite() builds:
+ *
+ *   "DROP TABLE IF EXISTS {$db_table}; {$db_create}"
+ *
+ * wrapped in `BEGIN TRANSACTION; ... END TRANSACTION;` and runs it via
+ * SQLite3::exec(). Two defects combined to break recovery for table 6:
+ *
+ *   1. $db_table was 'stats' while $db_create actually built 'lastclear'
+ *      (pinned separately in SqliteTableSpecTest).
+ *   2. The DROP had no `IF EXISTS`, so dropping a table that does not exist
+ *      -- including a freshly-created / never-populated database, or the
+ *      wrong ('stats') name from defect 1 -- makes SQLite3::exec() fail and
+ *      abort the whole transaction, so the CREATE TABLE never runs and the
+ *      table is never rebuilt.
+ *
+ * These tests build the exact recovery SQL pfb_open_sqlite() constructs
+ * (using the real pfb_sqlite_table_spec() mapping for the CREATE half) and
+ * run it against a real, empty SQLite3 database -- proving both the fixed
+ * statement succeeds and the pre-fix statement(s) fail.
+ */
+final class SqliteCorruptRecoveryTest extends TestCase
+{
+	private function recoverySql(string $dropClause, string $dbCreate): string
+	{
+		// Mirrors pfb_open_sqlite(): $db_create = "DROP TABLE ...; {$db_create}";
+		// then exec("BEGIN TRANSACTION;" . $db_create . "END TRANSACTION;").
+		return 'BEGIN TRANSACTION;' . $dropClause . '; ' . $dbCreate . 'END TRANSACTION;';
+	}
+
+	private function lastclearTableExists(SQLite3 $db): bool
+	{
+		$count = @$db->querySingle("SELECT COUNT(*) FROM lastclear");
+		return $count !== FALSE;
+	}
+
+	public function testFixedRecoveryDropIfExistsRebuildsAbsentTable(): void
+	{
+		$spec = pfb_sqlite_table_spec(6);
+		$db   = new SQLite3(':memory:');
+
+		// Given: a brand-new database -- 'lastclear' has never existed.
+		$this->assertFalse($this->lastclearTableExists($db), 'expected lastclear to be absent before recovery');
+
+		// When: the CURRENT (fixed) recovery statement runs.
+		$sql    = $this->recoverySql("DROP TABLE IF EXISTS {$spec['db_table']}", $spec['db_create']);
+		$result = @$db->exec($sql);
+
+		// Then: it succeeds (no "no such table" abort) and the table is queryable.
+		$this->assertTrue(
+			$result,
+			"expected DROP TABLE IF EXISTS recovery to succeed on an absent table, got: {$db->lastErrorMsg()}"
+		);
+		$this->assertTrue($this->lastclearTableExists($db), 'expected lastclear to exist after recovery');
+	}
+
+	public function testOldBareDropTableAbortsRecoveryEvenWithCorrectName(): void
+	{
+		// Isolates defect 2 alone: even with the CORRECT db_table ('lastclear'),
+		// a bare DROP TABLE (no IF EXISTS) on an absent table aborts the batch.
+		$spec = pfb_sqlite_table_spec(6);
+		$db   = new SQLite3(':memory:');
+
+		$this->assertFalse($this->lastclearTableExists($db), 'expected lastclear to be absent before recovery');
+
+		$sql    = $this->recoverySql("DROP TABLE {$spec['db_table']}", $spec['db_create']);
+		$result = @$db->exec($sql);
+
+		$this->assertFalse(
+			$result,
+			'expected the pre-fix bare DROP TABLE (no IF EXISTS) to fail on an absent table'
+		);
+		$this->assertStringContainsString('no such table', $db->lastErrorMsg());
+		$this->assertFalse($this->lastclearTableExists($db), 'lastclear must NOT have been (re)created -- recovery aborted');
+	}
+
+	public function testOldBuggyStatsMappingAlsoAbortsRecovery(): void
+	{
+		// Reproduces the full original bug 10 combination: the pre-fix db_table
+		// ('stats', which never has a matching table) plus the bare DROP.
+		$db_create = "CREATE TABLE IF NOT EXISTS lastclear ( row INTEGER, lastipclear TEXT, lastdnsblclear TEXT );";
+		$db        = new SQLite3(':memory:');
+
+		$sql    = $this->recoverySql('DROP TABLE stats', $db_create);
+		$result = @$db->exec($sql);
+
+		$this->assertFalse(
+			$result,
+			'expected the pre-fix "DROP TABLE stats" (wrong name, no IF EXISTS) to abort recovery'
+		);
+		$this->assertStringContainsString('no such table', $db->lastErrorMsg());
+		$this->assertFalse($this->lastclearTableExists($db), 'lastclear must NOT have been rebuilt -- this is the reported bug');
+	}
+}

--- a/tests/php/SqliteTableSpecTest.php
+++ b/tests/php/SqliteTableSpecTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_sqlite_table_spec() — maps a numeric SQLite3 handle index (1-7) to its
+ * table name + CREATE statement, extracted out of pfb_open_sqlite()'s
+ * if/elseif chain so the mapping is unit-testable in isolation.
+ *
+ * Issue #713 bug 10: table 6 mapped to db_table 'stats' while its CREATE
+ * TABLE statement actually built 'lastclear' -- the name every other query
+ * in pfblockerng.inc uses (e.g. `UPDATE lastclear SET lastipclear = ...`).
+ * db_table is what DB-corruption recovery DROPs and re-creates, so the
+ * mismatch pointed recovery at a table ('stats') that was never the real
+ * one. testTableSixMapsToLastclearNotStats is the regression pin: it fails
+ * on the pre-fix mapping ('stats') and passes once table 6 reads 'lastclear'.
+ */
+#[CoversFunction('pfb_sqlite_table_spec')]
+final class SqliteTableSpecTest extends TestCase
+{
+	public function testTableSixMapsToLastclearNotStats(): void
+	{
+		$spec = pfb_sqlite_table_spec(6);
+
+		// The pre-fix code returned 'stats' here, disagreeing with every other
+		// `lastclear`-named query in the file (see pfb_reset_last_clear_dates()
+		// and its `UPDATE lastclear SET ...` statements).
+		$this->assertSame('lastclear', $spec['db_table']);
+	}
+
+	public function testTableSixCreateStatementBuildsLastclear(): void
+	{
+		$spec = pfb_sqlite_table_spec(6);
+
+		$this->assertStringContainsString('CREATE TABLE IF NOT EXISTS lastclear', $spec['db_create']);
+	}
+
+	public static function tableIndexProvider(): array
+	{
+		return [
+			'1 dnsbl'        => [1, 'dnsbl'],
+			'2 lastevent'    => [2, 'lastevent'],
+			'3 resolver'     => [3, 'resolver'],
+			'4 dnsblcache'   => [4, 'dnsblcache'],
+			'5 asncache'     => [5, 'asncache'],
+			'6 lastclear'    => [6, 'lastclear'],
+			'7 ipcache'      => [7, 'ipcache'],
+		];
+	}
+
+	#[DataProvider('tableIndexProvider')]
+	public function testKnownIndexMapsToExpectedTableName(int $table, string $expectedDbTable): void
+	{
+		$spec = pfb_sqlite_table_spec($table);
+
+		$this->assertSame($expectedDbTable, $spec['db_table']);
+		$this->assertStringContainsString("CREATE TABLE IF NOT EXISTS {$expectedDbTable}", $spec['db_create']);
+	}
+
+	public function testUnknownIndexReturnsEmptyBehaviourPreservingDefault(): void
+	{
+		// Callers only ever pass 1-7; an out-of-range value falls back to the
+		// same empty-string default the original if/elseif chain (no `else`)
+		// left $db_table/$db_create as.
+		$spec = pfb_sqlite_table_spec(99);
+
+		$this->assertSame('', $spec['db_table']);
+		$this->assertSame('', $spec['db_create']);
+	}
+}

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -18,9 +18,9 @@
  *   c) Section-level calls (path stops at the section, no trailing key name).
  *   d) The gateway's own implementation (pfblockerng_extra.inc) — excluded
  *      via phpcs.xml.dist <exclude-pattern>.
- *   e) Out-of-scope keys documented in ADR-29 §2.5 (dnsbl_webpage is
- *      registered as 'dnsblwebpage'; the legacy 'dnsbl_webpage' raw key used
- *      in pfblockerng_dnsbl.php is not in the registered path set).
+ *   e) Out-of-scope keys documented in ADR-29 §2.5 (e.g. 'dnsbl_webpage' — a
+ *      foreign key written directly by pfblockerng_dnsbl.php and read via
+ *      pfb_dnsbl_webpage(); it is not in the registered path set).
  *
  * Scope is an explicit, auditable list of full config paths (the registered
  * paths derived from pfb_cfg_registry()) embedded as a sniff property.  The
@@ -150,7 +150,6 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_py_cache_max',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_tld',
 		'installedpackages/pfblockerngdnsblsettings/config/0/aliaslog',
-		'installedpackages/pfblockerngdnsblsettings/config/0/dnsblwebpage',
 		// ADR-36: NAT DNS-redirect fields
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_redir',
 		'installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_redir_int',

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -197,6 +197,61 @@ Describe 'pfblockerng.sh archive helpers (#468)'
     cleanup_arc
   End
 
+  # issue #713 bug 7: POSIX sh has no pipefail, so the OLD `tar -Pcf - ... | zstd
+  # ...` pipe silently discarded a failed/truncated tar's exit status (only
+  # zstd's mattered), and "zstd -tq" verifies only the zstd FRAMING, not tar
+  # completeness -- so a truncated tar stream still compressed into a small but
+  # VALID .zst, publishing a corrupt archive AND deleting the still-good .bz2.
+  # A tar stand-in that dies mid-write (simulates a killed process / disk-full /
+  # a genuinely truncated source) reproduces the exact shape: it writes SOME
+  # bytes then exits non-zero, same as a real truncated tar stream would.
+  write_faketar() {
+    cat > "${arcbox}/faketar" <<'EOF'
+#!/bin/sh
+printf 'PARTIAL-NOT-A-COMPLETE-TAR-STREAM'
+exit 2
+EOF
+    chmod +x "${arcbox}/faketar"
+  }
+
+  # Wrapper: report the pre-existing .bz2's validity, run compress with a tar
+  # that dies mid-stream, then report compress's own exit status plus the
+  # POST-run .bz2 validity -- so the example proves the failed attempt neither
+  # published a corrupt .zst nor damaged the pre-existing backup (not just that
+  # a .bz2 happens to exist afterwards).
+  faketar_compress_and_report() {
+    # Given: a pre-existing, verified-good .bz2 backup (as if from a prior run).
+    /usr/bin/tar -Pjcf "${arc_bz2}" "${payload}"
+    if /usr/bin/tar -Ptjf "${arc_bz2}" >/dev/null 2>&1; then echo 'PRE:bz2-valid'; else echo 'PRE:bz2-invalid'; fi
+    write_faketar
+    pathtar="${arcbox}/faketar"
+    pfb_archive_compress "${arc_base}" "${payload}"
+    echo "COMPRESS_RC:$?"
+    pathtar='/usr/bin/tar'
+    if /usr/bin/tar -Ptjf "${arc_bz2}" >/dev/null 2>&1; then echo 'POST:bz2-valid'; else echo 'POST:bz2-invalid'; fi
+  }
+
+  It 'compress never publishes a corrupt .zst and never deletes the pre-existing .bz2 when tar fails (issue #713 bug 7)'
+    setup_arc
+    When call faketar_compress_and_report
+    The output should include 'PRE:bz2-valid'
+    # compress fails end-to-end (tar failed, so the bzip2 fallback -- itself run
+    # through the same broken ${pathtar} stand-in in this scenario -- fails too).
+    The output should include 'COMPRESS_RC:2'
+    # The pre-existing .bz2 is untouched: still a valid, complete archive.
+    The output should include 'POST:bz2-valid'
+    # No .zst was ever published -- a truncated tar must never reach the
+    # "zstd -tq passed, publish it" branch.
+    The path "${arc_base}.zst" should not be exist
+    The path "${arc_bz2}" should be exist
+    payload_content="$(/usr/bin/tar -Pxjf "${arc_bz2}" -O)"
+    The value "$payload_content" should equal 'PAYLOAD-v1'
+    # No leftover mktemp temp files from the failed attempt.
+    leftover="$(find "${arcbox}" -maxdepth 1 -name "$(basename "${arc_base}").??????" 2>/dev/null)"
+    The value "$leftover" should equal ''
+    cleanup_arc
+  End
+
   # Wrapper: report the no-archive before-state, then extract from the bz2 fallback.
   extract_legacy_and_report() {
     if [ -f "${arc_base}.zst" ]; then echo 'PRE:zst-present'; else echo 'PRE:zst-absent'; fi

--- a/tests/shell/pfblockerng_et_category_match_spec.sh
+++ b/tests/shell/pfblockerng_et_category_match_spec.sh
@@ -1,0 +1,87 @@
+#shellcheck shell=sh
+# processet() ET IQRisk category selection (issue #713 bug 6). etblock/etmatch are
+# ", "-separated category-name lists (see the `sed 's/,/, /g'` transform near the
+# top of the script); processet() used to test membership with a bare substring
+# glob (`case "${etblock}" in *$list*)`), so selecting 'ET_P2Pcnc' also matched
+# the unrelated 'ET_P2P' category (its name is a literal substring of
+# 'ET_P2Pcnc') and wrongly pulled ET_P2P's IPs into the block output too. The fix
+# pads both sides with the ", " delimiter and anchors on it, so only the exact
+# selected token matches. This suite pins the fixed (anchored) behaviour
+# end-to-end through processet(), and separately proves the 'x' no-selection
+# sentinel still matches nothing real.
+
+Describe 'processet() ET category selection (issue #713 bug 6)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/etcat.XXXXXX")"
+    pfborig="${work}/orig/"
+    etdir="${work}/ET"
+    pfbmatch="${work}/match"
+    mkdir -p "$pfborig" "$etdir" "$pfbmatch"
+    tempfile="${work}/t1"; tempfile2="${work}/t2"
+    alias='MYLIST'
+    ip_placeholder='240.0.0.0'
+    ip_placeholder2="$(echo "${ip_placeholder}" | sed 's/\./\\\./g')"
+    # ET_P2P is category 15, ET_P2Pcnc is category 31 in processet()'s etcat
+    # position table (1-based index into the etcat word list) -- both are
+    # "in use" categories (neither sits in the 8|11|12|14|18|22|32|36 skip set).
+    printf '10.0.0.15,15,50\n10.0.0.31,31,60\n' > "${pfborig}${alias}.orig"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  # Scenario: selecting ET_P2Pcnc alone must not also pull in ET_P2P.
+  #   Given .orig rows for BOTH ET_P2P (category 15) and ET_P2Pcnc (category 31),
+  #   When  processet runs with etblock='ET_P2Pcnc' (etmatch='x' = none selected),
+  #   Then  only ET_P2Pcnc's IP survives into the rewritten .orig -- ET_P2P's IP,
+  #         which a bare substring match would have pulled in too, does not.
+  Describe 'etblock selects one category whose name is a substring of another'
+    It 'starts with both categories present in the unprocessed .orig'
+      When call cat "${pfborig}${alias}.orig"
+      The output should include '10.0.0.15,15,'
+      The output should include '10.0.0.31,31,'
+    End
+
+    It 'blocks only the exact selected category (ET_P2Pcnc), not the substring sibling ET_P2P'
+      etblock='ET_P2Pcnc'
+      etmatch='x'
+      When call processet
+      The status should be success
+      The stdout should include 'Block:   ET_P2Pcnc'
+      The stdout should not include 'Block:   ET_P2P '
+      The contents of file "${pfborig}${alias}.orig" should include '10.0.0.31'
+      The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.15'
+    End
+  End
+
+  # Same anchoring bug, symmetric on the etmatch side (bug 6 explicitly requires
+  # both case statements fixed identically).
+  Describe 'etmatch selects one category whose name is a substring of another'
+    It 'matches only the exact selected category (ET_P2Pcnc), not the substring sibling ET_P2P'
+      etblock='x'
+      etmatch='ET_P2Pcnc'
+      When call processet
+      The status should be success
+      The path "${pfbmatch}/ETMatch.txt" should be file
+      The contents of file "${pfbmatch}/ETMatch.txt" should include '10.0.0.31'
+      The contents of file "${pfbmatch}/ETMatch.txt" should not include '10.0.0.15'
+    End
+  End
+
+  # The 'x' no-selection sentinel (both etblock and etmatch absent -> literal 'x',
+  # see pfblockerng.inc's `?: 'x'` default) must still match nothing real: no ET
+  # category is ever literally named 'x', but a naive unpadded anchor could still
+  # accidentally line up on a bare 'x' substring somewhere in a real token.
+  Describe 'the x no-selection sentinel'
+    It 'blocks nothing and writes no ETMatch.txt when neither is selected'
+      etblock='x'
+      etmatch='x'
+      When call processet
+      The status should be success
+      The path "${pfbmatch}/ETMatch.txt" should not be exist
+      The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.15'
+      The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.31'
+    End
+  End
+End

--- a/tests/shell/pfblockerng_et_category_match_spec.sh
+++ b/tests/shell/pfblockerng_et_category_match_spec.sh
@@ -61,7 +61,7 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
     It 'matches only the exact selected category (ET_P2Pcnc), not the substring sibling ET_P2P'
       etblock='x'
       etmatch='ET_P2Pcnc'
-      When call processet
+      When call silently processet
       The status should be success
       The path "${pfbmatch}/ETMatch.txt" should be file
       The contents of file "${pfbmatch}/ETMatch.txt" should include '10.0.0.31'
@@ -77,7 +77,7 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
     It 'blocks nothing and writes no ETMatch.txt when neither is selected'
       etblock='x'
       etmatch='x'
-      When call processet
+      When call silently processet
       The status should be success
       The path "${pfbmatch}/ETMatch.txt" should not be exist
       The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.15'

--- a/tests/shell/pfblockerng_et_category_match_spec.sh
+++ b/tests/shell/pfblockerng_et_category_match_spec.sh
@@ -61,8 +61,12 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
     It 'matches only the exact selected category (ET_P2Pcnc), not the substring sibling ET_P2P'
       etblock='x'
       etmatch='ET_P2Pcnc'
-      When call silently processet
+      When call processet
       The status should be success
+      # The selected token matches exactly; the substring sibling ET_P2P must not
+      # (matching the etblock case's stdout check + closing the shellspec output gap).
+      The stdout should include 'Match:   ET_P2Pcnc'
+      The stdout should not include 'Match:   ET_P2P '
       The path "${pfbmatch}/ETMatch.txt" should be file
       The contents of file "${pfbmatch}/ETMatch.txt" should include '10.0.0.31'
       The contents of file "${pfbmatch}/ETMatch.txt" should not include '10.0.0.15'
@@ -77,8 +81,12 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
     It 'blocks nothing and writes no ETMatch.txt when neither is selected'
       etblock='x'
       etmatch='x'
-      When call silently processet
+      When call processet
       The status should be success
+      # No category selected -> processet emits neither a Block nor a Match row
+      # (closes the shellspec unchecked-output gap for the sentinel case).
+      The stdout should not include 'Block:'
+      The stdout should not include 'Match:'
       The path "${pfbmatch}/ETMatch.txt" should not be exist
       The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.15'
       The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.31'

--- a/tests/shell/pfblockerng_fail_open_redirect_spec.sh
+++ b/tests/shell/pfblockerng_fail_open_redirect_spec.sh
@@ -57,6 +57,26 @@ SHIM
     chmod +x "$1/awk"
   }
 
+  # Like setup_awk_shim but fails ONLY the dedup pass (awk program text holds
+  # FNR==NR) under AWK_MODE=error. process255()/reputation_max() compute their
+  # /24 offender set with an EARLIER, unrelated awk; a blanket shim would fail
+  # that first and no-op the whole function, so the test would prove nothing.
+  setup_awk_shim_dedup() {
+    mkdir -p "$1"
+    cat > "$1/awk" <<SHIM
+#!/bin/sh
+for _a in "\$@"; do
+	case "\${_a}" in *FNR==NR*) _dedup=1 ;; esac
+done
+if [ "\${AWK_MODE:-real}" = 'error' ] && [ "\${_dedup:-0}" = '1' ]; then
+	echo 'awk: simulated dedup failure' >&2
+	exit 2
+fi
+exec "${SHELLSPEC_REAL_AWK}" "\$@"
+SHIM
+    chmod +x "$1/awk"
+  }
+
   Describe 'suppress() -- Class A worst case (direct redirect into the LIVE published list)'
     setup() {
       work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsupp.XXXXXX")"
@@ -259,6 +279,89 @@ SHIM
       When call remove
       The status should be success
       The contents of file "${masterfile}" should equal 'OtherList_v4 203.0.113.9'
+    End
+  End
+
+  Describe 'process255() -- Class B (dedup awk redirected straight into the LIVE deny list)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbp255.XXXXXX")"
+      alias='P255List_v4'
+      pfbdeny="${work}/deny/"; mkdir -p "${pfbdeny}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dedupfile="${work}/t3"
+      # >253 hosts inside 10.0.0.0/24 trips process255()'s collapse path; a
+      # PRIOR-MARKER row (outside that /24) stands in for unrelated live content.
+      { i=1; while [ "${i}" -le 254 ]; do echo "10.0.0.${i}"; i=$((i + 1)); done; echo 'PRIOR-MARKER'; } > "${pfbdeny}${alias}.txt"
+      awkshim="${work}/bin"
+      setup_awk_shim_dedup "${awkshim}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'keeps the live deny list UNCHANGED when the dedup awk errors -- pre-fix the direct redirect truncated it before the awk even ran, losing every prior host'
+      AWK_MODE='error'; export AWK_MODE
+      # Given: the deny list holds real prior hosts.
+      The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.5'
+      The contents of file "${pfbdeny}${alias}.txt" should include 'PRIOR-MARKER'
+      PATH="${awkshim}:${PATH}"
+      When call process255
+      The status should be success
+      # Then: the prior hosts survive the failed collapse (only the /24 summary is appended).
+      The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.5'
+      The contents of file "${pfbdeny}${alias}.txt" should include 'PRIOR-MARKER'
+    End
+
+    It 'collapses the /24 (drops the individual hosts, appends the summary) on awk success -- proves the error branch is a real fail-safe, not an always-preserve no-op'
+      AWK_MODE='real'; export AWK_MODE
+      PATH="${awkshim}:${PATH}"
+      When call process255
+      The status should be success
+      The contents of file "${pfbdeny}${alias}.txt" should not include '10.0.0.5'
+      The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.0/24'
+      The contents of file "${pfbdeny}${alias}.txt" should include 'PRIOR-MARKER'
+    End
+  End
+
+  Describe 'reputation_max() -- Class B (ccblack="block" dedup awk redirected into the LIVE deny list)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbrmax.XXXXXX")"
+      alias='RMaxList_v4'
+      pfbdeny="${work}/deny/"; pfbmatch="${work}/match/"; mkdir -p "${pfbdeny}" "${pfbmatch}"
+      tempfile="${work}/r1"; tempfile2="${work}/r2"; dupfile="${work}/r3"
+      matchfile="${work}/r4"; tempmatchfile="${work}/r5"
+      : > "${dupfile}"; : > "${matchfile}"; : > "${tempmatchfile}"
+      max=253; cc='ZZ,'; ccwhite='block'; ccblack='block'; dedup='off'; count=0; countr=0
+      # An empty GeoIP answer routes every repeat offender down the block/dupfile
+      # path (the unknown-country branch), reaching the ccblack='block' dedup awk.
+      pathgeoip="${work}/mmdblookup"; pathgeoipdat="${work}/geo.mmdb"; : > "${pathgeoipdat}"
+      make_geoip_stub "${pathgeoip}" ''
+      { i=1; while [ "${i}" -le 254 ]; do echo "10.0.0.${i}"; i=$((i + 1)); done; echo 'PRIOR-MARKER'; } > "${pfbdeny}${alias}.txt"
+      awkshim="${work}/bin"
+      setup_awk_shim_dedup "${awkshim}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'keeps the live deny list UNCHANGED when the ccblack="block" dedup awk errors -- pre-fix the direct redirect truncated it, losing every prior host'
+      AWK_MODE='error'; export AWK_MODE
+      The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.5'
+      The contents of file "${pfbdeny}${alias}.txt" should include 'PRIOR-MARKER'
+      PATH="${awkshim}:${PATH}"
+      When call reputation_max
+      The status should be success
+      The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.5'
+      The contents of file "${pfbdeny}${alias}.txt" should include 'PRIOR-MARKER'
+    End
+
+    It 'removes the country-classified hosts and appends the /24 summary on awk success -- proves the error branch is a real fail-safe, not an always-preserve no-op'
+      AWK_MODE='real'; export AWK_MODE
+      PATH="${awkshim}:${PATH}"
+      When call reputation_max
+      The status should be success
+      The contents of file "${pfbdeny}${alias}.txt" should not include '10.0.0.5'
+      The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.0/24'
+      The contents of file "${pfbdeny}${alias}.txt" should include 'PRIOR-MARKER'
     End
   End
 End

--- a/tests/shell/pfblockerng_fail_open_redirect_spec.sh
+++ b/tests/shell/pfblockerng_fail_open_redirect_spec.sh
@@ -102,11 +102,9 @@ SHIM
     After 'cleanup'
 
     It 'keeps the live list UNCHANGED when grepcidr errors (rc>=2) -- pre-fix this truncated it to empty'
-      # Given: the live list holds prior, real content.
-      The contents of file "${livelist}" should equal "$(printf 'PRIOR-1\nPRIOR-2')"
       # When: grepcidr errors.
       GREPCIDR_MODE='error'; export GREPCIDR_MODE
-      When call suppress
+      When call silently suppress
       # Then: the prior content survives -- and the error is logged, not swallowed.
       The status should be success
       The contents of file "${livelist}" should equal "$(printf 'PRIOR-1\nPRIOR-2')"
@@ -115,14 +113,14 @@ SHIM
 
     It 'replaces the live list with an EMPTY result on grepcidr rc=1 (a legitimate "everything suppressed" outcome)'
       GREPCIDR_MODE='empty'; export GREPCIDR_MODE
-      When call suppress
+      When call silently suppress
       The status should be success
       The contents of file "${livelist}" should equal ''
     End
 
     It 'publishes the new content on grepcidr success'
       GREPCIDR_MODE='success'; export GREPCIDR_MODE
-      When call suppress
+      When call silently suppress
       The status should be success
       The contents of file "${livelist}" should equal "$(printf '192.0.2.1\n192.0.2.2')"
     End
@@ -157,10 +155,8 @@ SHIM
 
     It 'keeps the PRIOR masterfile rows when awk errors -- pre-fix this truncated masterfile, losing them all (incl. the unrelated OtherList_v4 row)'
       GREPCIDR_MODE='success'; AWK_MODE='error'; export GREPCIDR_MODE AWK_MODE
-      # Given: masterfile holds both this alias's rows and an unrelated one.
-      The contents of file "${masterfile}" should equal "$(printf 'DedupList_v4 PRIOR-1\nDedupList_v4 PRIOR-2\nOtherList_v4 203.0.113.5')"
       PATH="${awkshim}:${PATH}"
-      When call suppress
+      When call silently suppress
       The status should be success
       # suppress()'s trailing sed always re-appends the (here: grepcidr-succeeded)
       # fresh list content regardless of the dedup outcome -- pre-existing,
@@ -174,7 +170,7 @@ SHIM
     It 'dedups masterfile (drops the stale alias rows, keeps the unrelated one, appends the fresh list) on awk success'
       GREPCIDR_MODE='success'; AWK_MODE='real'; export GREPCIDR_MODE AWK_MODE
       PATH="${awkshim}:${PATH}"
-      When call suppress
+      When call silently suppress
       The status should be success
       The contents of file "${masterfile}" should include 'OtherList_v4 203.0.113.5'
       The contents of file "${masterfile}" should not include 'PRIOR-1'
@@ -211,7 +207,7 @@ SHIM
     It 'keeps masterfile rows from the dedup step UNCHANGED when awk errors -- pre-fix this truncated masterfile, losing the unrelated OtherList_v4 row'
       GREPCIDR_MODE='success'; AWK_MODE='error'; export GREPCIDR_MODE AWK_MODE
       PATH="${awkshim}:${PATH}"
-      When call duplicate
+      When call silently duplicate
       The status should be success
       # duplicate()'s own trailing append always re-adds the (here: grepcidr-
       # succeeded) pfbdeny content -- pre-existing, unrelated to this fix -- so
@@ -223,9 +219,7 @@ SHIM
 
     It 'keeps the pfbdeny list UNCHANGED when grepcidr errors (rc>=2) -- Class A temp+mv variant'
       GREPCIDR_MODE='error'; export GREPCIDR_MODE
-      # Given: the deny list holds prior, real content.
-      The contents of file "${denyfile}" should equal "$(printf '192.0.2.10\n192.0.2.11')"
-      When call duplicate
+      When call silently duplicate
       The status should be success
       The contents of file "${denyfile}" should equal "$(printf '192.0.2.10\n192.0.2.11')"
       The contents of file "${errorlog}" should include 'grepcidr error'
@@ -233,7 +227,7 @@ SHIM
 
     It 'dedups masterfile and publishes the new pfbdeny content on full success'
       GREPCIDR_MODE='success'; export GREPCIDR_MODE
-      When call duplicate
+      When call silently duplicate
       The status should be success
       # DupList_v4's original rows are dedup'd out of masterfile; only the
       # unrelated OtherList_v4 row plus the freshly-published pfbdeny content
@@ -265,10 +259,8 @@ SHIM
 
     It 'keeps masterfile UNCHANGED when awk errors -- pre-fix this truncated masterfile (remove() then deletes an empty masterfile entirely)'
       AWK_MODE='error'; export AWK_MODE
-      # Given: masterfile holds both the removed alias's row and an unrelated one.
-      The contents of file "${masterfile}" should equal "$(printf 'RmList_v4 192.0.2.20\nOtherList_v4 203.0.113.9')"
       PATH="${awkshim}:${PATH}"
-      When call remove
+      When call silently remove
       The status should be success
       The contents of file "${masterfile}" should equal "$(printf 'RmList_v4 192.0.2.20\nOtherList_v4 203.0.113.9')"
     End
@@ -276,7 +268,7 @@ SHIM
     It 'dedups masterfile (drops the removed alias row, keeps the unrelated one) on awk success'
       AWK_MODE='real'; export AWK_MODE
       PATH="${awkshim}:${PATH}"
-      When call remove
+      When call silently remove
       The status should be success
       The contents of file "${masterfile}" should equal 'OtherList_v4 203.0.113.9'
     End
@@ -300,11 +292,8 @@ SHIM
 
     It 'keeps the live deny list UNCHANGED when the dedup awk errors -- pre-fix the direct redirect truncated it before the awk even ran, losing every prior host'
       AWK_MODE='error'; export AWK_MODE
-      # Given: the deny list holds real prior hosts.
-      The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.5'
-      The contents of file "${pfbdeny}${alias}.txt" should include 'PRIOR-MARKER'
       PATH="${awkshim}:${PATH}"
-      When call process255
+      When call silently process255
       The status should be success
       # Then: the prior hosts survive the failed collapse (only the /24 summary is appended).
       The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.5'
@@ -314,7 +303,7 @@ SHIM
     It 'collapses the /24 (drops the individual hosts, appends the summary) on awk success -- proves the error branch is a real fail-safe, not an always-preserve no-op'
       AWK_MODE='real'; export AWK_MODE
       PATH="${awkshim}:${PATH}"
-      When call process255
+      When call silently process255
       The status should be success
       The contents of file "${pfbdeny}${alias}.txt" should not include '10.0.0.5'
       The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.0/24'
@@ -345,10 +334,8 @@ SHIM
 
     It 'keeps the live deny list UNCHANGED when the ccblack="block" dedup awk errors -- pre-fix the direct redirect truncated it, losing every prior host'
       AWK_MODE='error'; export AWK_MODE
-      The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.5'
-      The contents of file "${pfbdeny}${alias}.txt" should include 'PRIOR-MARKER'
       PATH="${awkshim}:${PATH}"
-      When call reputation_max
+      When call silently reputation_max
       The status should be success
       The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.5'
       The contents of file "${pfbdeny}${alias}.txt" should include 'PRIOR-MARKER'
@@ -357,7 +344,7 @@ SHIM
     It 'removes the country-classified hosts and appends the /24 summary on awk success -- proves the error branch is a real fail-safe, not an always-preserve no-op'
       AWK_MODE='real'; export AWK_MODE
       PATH="${awkshim}:${PATH}"
-      When call reputation_max
+      When call silently reputation_max
       The status should be success
       The contents of file "${pfbdeny}${alias}.txt" should not include '10.0.0.5'
       The contents of file "${pfbdeny}${alias}.txt" should include '10.0.0.0/24'

--- a/tests/shell/pfblockerng_fail_open_redirect_spec.sh
+++ b/tests/shell/pfblockerng_fail_open_redirect_spec.sh
@@ -1,6 +1,8 @@
 #shellcheck shell=sh
-# pfblockerng.sh fail-open feed-list redirects (issue #713 bug 8, family of 9
-# sites in two producer classes). A producer (grepcidr / awk dedup) was
+# pfblockerng.sh fail-open feed-list redirects (issue #713 bug 8, family of 12
+# sites in two producer classes -- the original 9 plus 3 the initial fix missed:
+# suppress()'s dedup='on' masterfile block, process255(), and reputation_max()'s
+# ccblack='block' arm). A producer (grepcidr / awk dedup) was
 # redirected into a file consumed downstream with NO exit-status gating, so a
 # producer error truncated/overwrote the live list to empty/partial:
 #
@@ -103,6 +105,61 @@ SHIM
       When call suppress
       The status should be success
       The contents of file "${livelist}" should equal "$(printf '192.0.2.1\n192.0.2.2')"
+    End
+  End
+
+  Describe 'suppress() -- Class B (dedup="on" masterfile block, the site the initial bug-8 fix missed)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppdd.XXXXXX")"
+      max="${work}"
+      alias='DedupList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      # A plain /24 (not /32) suppression entry stays out of the earlier
+      # awk/dupfile branch (already gated), isolating the dedup='on' masterfile
+      # awk call at the end of suppress() for this test.
+      printf '198.51.100.0/24\n' > "${pfbsuppression}"
+      tmpdir="${work}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      printf 'DedupList_v4 PRIOR-1\nDedupList_v4 PRIOR-2\nOtherList_v4 203.0.113.5\n' > "${masterfile}"
+      dedup='on'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      livelist="${work}/${alias}.txt"
+      printf 'PRIOR-1\nPRIOR-2\n' > "${livelist}"
+      awkshim="${work}/bin"
+      setup_awk_shim "${awkshim}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'keeps the PRIOR masterfile rows when awk errors -- pre-fix this truncated masterfile, losing them all (incl. the unrelated OtherList_v4 row)'
+      GREPCIDR_MODE='success'; AWK_MODE='error'; export GREPCIDR_MODE AWK_MODE
+      # Given: masterfile holds both this alias's rows and an unrelated one.
+      The contents of file "${masterfile}" should equal "$(printf 'DedupList_v4 PRIOR-1\nDedupList_v4 PRIOR-2\nOtherList_v4 203.0.113.5')"
+      PATH="${awkshim}:${PATH}"
+      When call suppress
+      The status should be success
+      # suppress()'s trailing sed always re-appends the (here: grepcidr-succeeded)
+      # fresh list content regardless of the dedup outcome -- pre-existing,
+      # unrelated to this fix -- so the fix's proof is that NONE of the prior
+      # rows are lost, not that the file is byte-identical to its pre-call state.
+      The contents of file "${masterfile}" should include 'DedupList_v4 PRIOR-1'
+      The contents of file "${masterfile}" should include 'DedupList_v4 PRIOR-2'
+      The contents of file "${masterfile}" should include 'OtherList_v4 203.0.113.5'
+    End
+
+    It 'dedups masterfile (drops the stale alias rows, keeps the unrelated one, appends the fresh list) on awk success'
+      GREPCIDR_MODE='success'; AWK_MODE='real'; export GREPCIDR_MODE AWK_MODE
+      PATH="${awkshim}:${PATH}"
+      When call suppress
+      The status should be success
+      The contents of file "${masterfile}" should include 'OtherList_v4 203.0.113.5'
+      The contents of file "${masterfile}" should not include 'PRIOR-1'
+      The contents of file "${masterfile}" should include 'DedupList_v4 192.0.2.1'
+      The contents of file "${masterfile}" should include 'DedupList_v4 192.0.2.2'
     End
   End
 

--- a/tests/shell/pfblockerng_fail_open_redirect_spec.sh
+++ b/tests/shell/pfblockerng_fail_open_redirect_spec.sh
@@ -1,0 +1,207 @@
+#shellcheck shell=sh
+# pfblockerng.sh fail-open feed-list redirects (issue #713 bug 8, family of 9
+# sites in two producer classes). A producer (grepcidr / awk dedup) was
+# redirected into a file consumed downstream with NO exit-status gating, so a
+# producer error truncated/overwrote the live list to empty/partial:
+#
+#   Class A (grepcidr): rc 0 = matches removed, rc 1 = a LEGITIMATE "everything
+#   suppressed" empty result (must still replace the target), rc >= 2 = a real
+#   grepcidr error (must keep the previous target untouched). suppress() held
+#   the worst case -- a direct "grepcidr ... > livelist" redirect with no temp
+#   at all, truncating the live list before grepcidr even ran.
+#
+#   Class B (awk dedup): awk has no "empty output = error" quirk -- rc 0 is
+#   always a legitimate result (including a genuinely empty dedup), non-zero is
+#   always a real error. The unconditional "awk ... > tmp; mv -f tmp target"
+#   became "awk ... > tmp && mv -f tmp target".
+#
+# Each scenario asserts the BEFORE state (prior content) so a pass proves the
+# fix caused the preservation, not an accidental empty-target coincidence.
+
+Describe 'pfblockerng.sh fail-open feed-list redirects (issue #713 bug 8)'
+  BeforeAll 'pfb_source; SHELLSPEC_REAL_AWK="$(command -v awk)"; export SHELLSPEC_REAL_AWK'
+
+  # ---- grepcidr shim: exit code/output selected via GREPCIDR_MODE ----
+  #   success -> two matches on stdout, rc 0
+  #   empty   -> a LEGITIMATE "everything suppressed" empty result, rc 1
+  #   error   -> a real grepcidr error (e.g. malformed filter file), rc 2
+  write_grepcidr_shim() {
+    cat > "$1" <<'SHIM'
+#!/bin/sh
+case "${GREPCIDR_MODE:-}" in
+	success) printf '192.0.2.1\n192.0.2.2\n'; exit 0 ;;
+	empty) exit 1 ;;
+	error) echo 'grepcidr: malformed CIDR in filter file' >&2; exit 2 ;;
+	*) exit 2 ;;
+esac
+SHIM
+    chmod +x "$1"
+  }
+
+  # ---- awk shim: awk is invoked bare (base utility, per repo convention), so
+  # its exit status is controlled by prepending a shim dir to PATH rather than
+  # a path* variable. AWK_MODE=error forces a real non-zero exit with no
+  # stdout; anything else delegates to the real awk.
+  setup_awk_shim() {
+    mkdir -p "$1"
+    cat > "$1/awk" <<SHIM
+#!/bin/sh
+if [ "\${AWK_MODE:-real}" = 'error' ]; then
+	echo 'awk: simulated failure' >&2
+	exit 2
+fi
+exec "${SHELLSPEC_REAL_AWK}" "\$@"
+SHIM
+    chmod +x "$1/awk"
+  }
+
+  Describe 'suppress() -- Class A worst case (direct redirect into the LIVE published list)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsupp.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      # A plain /24 (not /32) suppression entry stays out of the awk/dupfile
+      # branch entirely, isolating the grepcidr producer for this test.
+      printf '198.51.100.0/24\n' > "${pfbsuppression}"
+      tmpdir="${work}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      livelist="${work}/${alias}.txt"
+      printf 'PRIOR-1\nPRIOR-2\n' > "${livelist}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'keeps the live list UNCHANGED when grepcidr errors (rc>=2) -- pre-fix this truncated it to empty'
+      # Given: the live list holds prior, real content.
+      The contents of file "${livelist}" should equal "$(printf 'PRIOR-1\nPRIOR-2')"
+      # When: grepcidr errors.
+      GREPCIDR_MODE='error'; export GREPCIDR_MODE
+      When call suppress
+      # Then: the prior content survives -- and the error is logged, not swallowed.
+      The status should be success
+      The contents of file "${livelist}" should equal "$(printf 'PRIOR-1\nPRIOR-2')"
+      The contents of file "${errorlog}" should include 'grepcidr error'
+    End
+
+    It 'replaces the live list with an EMPTY result on grepcidr rc=1 (a legitimate "everything suppressed" outcome)'
+      GREPCIDR_MODE='empty'; export GREPCIDR_MODE
+      When call suppress
+      The status should be success
+      The contents of file "${livelist}" should equal ''
+    End
+
+    It 'publishes the new content on grepcidr success'
+      GREPCIDR_MODE='success'; export GREPCIDR_MODE
+      When call suppress
+      The status should be success
+      The contents of file "${livelist}" should equal "$(printf '192.0.2.1\n192.0.2.2')"
+    End
+  End
+
+  Describe 'duplicate() -- Class A (temp+mv grepcidr variant) + Class B (awk masterfile dedup)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbdup.XXXXXX")"
+      alias='DupList_v4'
+      pfbdeny="${work}/deny/"; mkdir -p "${pfbdeny}"
+      pfborig="${work}/orig/"; mkdir -p "${pfborig}"
+      tmpdir="${work}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      # shellcheck disable=SC2034  # read by the sourced emptyfiles(), called at duplicate()'s tail
+      ip_placeholder='240.0.0.0'
+      awkshim="${work}/bin"
+      setup_awk_shim "${awkshim}"
+      denyfile="${pfbdeny}${alias}.txt"
+      printf 'DupList_v4 192.0.2.10\nDupList_v4 192.0.2.11\nOtherList_v4 203.0.113.5\n' > "${masterfile}"
+      printf '192.0.2.10\n192.0.2.11\n' > "${denyfile}"
+      : > "${mastercat}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'keeps masterfile rows from the dedup step UNCHANGED when awk errors -- pre-fix this truncated masterfile, losing the unrelated OtherList_v4 row'
+      GREPCIDR_MODE='success'; AWK_MODE='error'; export GREPCIDR_MODE AWK_MODE
+      PATH="${awkshim}:${PATH}"
+      When call duplicate
+      The status should be success
+      # duplicate()'s own trailing append always re-adds the (here: grepcidr-
+      # succeeded) pfbdeny content -- pre-existing, unrelated to this fix -- so
+      # the fix's proof is that the unrelated OtherList_v4 row is NOT lost, not
+      # that the file is byte-identical to its pre-call state.
+      The contents of file "${masterfile}" should include 'OtherList_v4 203.0.113.5'
+      The contents of file "${masterfile}" should include 'DupList_v4 192.0.2.10'
+    End
+
+    It 'keeps the pfbdeny list UNCHANGED when grepcidr errors (rc>=2) -- Class A temp+mv variant'
+      GREPCIDR_MODE='error'; export GREPCIDR_MODE
+      # Given: the deny list holds prior, real content.
+      The contents of file "${denyfile}" should equal "$(printf '192.0.2.10\n192.0.2.11')"
+      When call duplicate
+      The status should be success
+      The contents of file "${denyfile}" should equal "$(printf '192.0.2.10\n192.0.2.11')"
+      The contents of file "${errorlog}" should include 'grepcidr error'
+    End
+
+    It 'dedups masterfile and publishes the new pfbdeny content on full success'
+      GREPCIDR_MODE='success'; export GREPCIDR_MODE
+      When call duplicate
+      The status should be success
+      # DupList_v4's original rows are dedup'd out of masterfile; only the
+      # unrelated OtherList_v4 row plus the freshly-published pfbdeny content
+      # (re-appended by duplicate()'s own trailing step) remain.
+      The contents of file "${masterfile}" should include 'OtherList_v4 203.0.113.5'
+      The contents of file "${masterfile}" should not include '192.0.2.10'
+      The contents of file "${denyfile}" should equal "$(printf '192.0.2.1\n192.0.2.2')"
+    End
+  End
+
+  Describe 'remove() -- Class B (awk masterfile dedup, no grepcidr involved)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbrmfo.XXXXXX")"
+      alias='Benign'
+      cc='RmList_v4,'
+      pfborig="${work}/orig/"; pfbdeny="${work}/deny/"; pfbmatch="${work}/match/"
+      pfbpermit="${work}/permit/"; pfbnative="${work}/native/"
+      mkdir -p "${pfborig}" "${pfbdeny}" "${pfbmatch}" "${pfbpermit}" "${pfbnative}"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"
+      awkshim="${work}/bin"
+      setup_awk_shim "${awkshim}"
+      printf 'RmList_v4 192.0.2.20\nOtherList_v4 203.0.113.9\n' > "${masterfile}"
+      : > "${pfborig}RmList_v4.txt"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'keeps masterfile UNCHANGED when awk errors -- pre-fix this truncated masterfile (remove() then deletes an empty masterfile entirely)'
+      AWK_MODE='error'; export AWK_MODE
+      # Given: masterfile holds both the removed alias's row and an unrelated one.
+      The contents of file "${masterfile}" should equal "$(printf 'RmList_v4 192.0.2.20\nOtherList_v4 203.0.113.9')"
+      PATH="${awkshim}:${PATH}"
+      When call remove
+      The status should be success
+      The contents of file "${masterfile}" should equal "$(printf 'RmList_v4 192.0.2.20\nOtherList_v4 203.0.113.9')"
+    End
+
+    It 'dedups masterfile (drops the removed alias row, keeps the unrelated one) on awk success'
+      AWK_MODE='real'; export AWK_MODE
+      PATH="${awkshim}:${PATH}"
+      When call remove
+      The status should be success
+      The contents of file "${masterfile}" should equal 'OtherList_v4 203.0.113.9'
+    End
+  End
+End

--- a/tests/shell/spec_helper.sh
+++ b/tests/shell/spec_helper.sh
@@ -65,3 +65,13 @@ run_exitnow_on() {
 	tmpdir="$1"
 	exitnow
 }
+
+# Run a sourced function with its stdout/stderr discarded while preserving its
+# exit status. Lets a spec assert a function's FILE side-effects + status without
+# tripping shellspec's "unexpected output" warning on the function's own progress
+# / stat printing (or an injected shim's diagnostic) -- output that is incidental,
+# not the behaviour under test. Use for examples that assert files/status only;
+# examples that assert stdout keep a plain `When call`.
+silently() {
+	"$@" >/dev/null 2>&1
+}

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -526,6 +526,173 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(
         )
 
 
+# The ADR-10 sentinel PHP flips to wake the reload-watcher (pfblockerng.inc:6001);
+# fixed host path (dnsbldir='/var/unbound').
+_ADR10_SENTINEL = "/var/unbound/pfb_py_reload"
+# The daemon-suppression marker pfb_reload_unbound() touches at the top of the fast
+# path -- $pfb['dnsbl_file'] . '.sync' (pfblockerng.inc:153 dnsbl_file + inc:~7466).
+_ADR10_SYNC_MARKER = "/var/unbound/pfb_dnsbl.sync"
+
+
+@pytest.mark.timeout(180)  # ADR-10: this forces the restart FALLBACK (a full Unbound restart).
+def test_dnsbl_sentinel_flip_failure_clears_sync_marker(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """ADR-10 fallback: a failed sentinel flip must NOT leak the '.sync' daemon-suppression
+    marker (issue #713 bug 3).
+
+    ``pfb_reload_unbound()``'s zero-downtime fast path touches ``<dnsbl_file>.sync`` (to
+    suppress the DNSBL Queries daemon's control-socket use during the swap) BEFORE
+    attempting the sentinel flip. On a successful swap it clears that marker itself before
+    returning -- the #51 alerts-page caller (``pfblockerng_alerts.php``) has NO later
+    ``clear_work_files`` call (unlike the CLI ``update``/``updatednsbl`` verbs, whose
+    ``pfb_update_unbound()`` always clears it at the end regardless of which branch ran),
+    so the marker must be cleared on every exit from the fast path, not just the happy
+    one. Before this fix, BOTH fallback branches ("sentinel flip failed" and "swap not
+    confirmed in time") fell through to the restart WITHOUT clearing it, leaking a
+    suppressed DNSBL Queries daemon until the next full update.
+
+    This pins the "sentinel flip failed" branch specifically: it fails SYNCHRONOUSLY
+    (no 30s wait) and never touches the DNSBL manifest, so it is safe to induce on the
+    shared session VM. The ADR-10 sentinel (``/var/unbound/pfb_py_reload``) is replaced
+    with a DIRECTORY, so ``pfb_unbound_py_atomic_write()``'s publishing ``rename()`` fails
+    deterministically (EISDIR) -- the manifest itself is untouched, so the restart's
+    cold-start rebuild that follows is unaffected. The #51 sequence is replayed via
+    ``pfSsh.php`` exactly as ``pfblockerng_alerts.php``'s ``dnsbl_remove`` handler does
+    (mirroring ``helpers.dnsbl_alert_lock_toggle``, minus its trailing swap-applied wait --
+    no swap occurs on this branch).
+
+    Given a DNSBL-listed domain already blocked (VIP) by the CaseContext setup,
+    When the ADR-10 sentinel is corrupted and a #51 temporary Unlock fires -- taking the
+      fast path, which fails to flip and falls back to a full Unbound restart --
+    Then the "sentinel flip failed" fallback log line appears (proving the branch under
+      test actually ran), Unbound genuinely restarted (pid changed), and the '.sync'
+      marker is ABSENT afterward -- the regression this fix guards.
+
+    Teardown restores the sentinel to its ORIGINAL content (captured before corruption --
+    never a fresh '1': the in-module watcher tracks a monotonically non-decreasing
+    generation in memory, so resetting to a lower/absent value would silently desync
+    every LATER fast-path swap in this session VM) and PROVES the fast path still works
+    by running one more ordinary #51 action and relying on
+    ``dnsbl_alert_lock_toggle``'s own swap-applied wait (raises loudly on timeout) -- so a
+    bad restore fails HERE, not as a mysterious later test failure.
+    """
+    domain = h.unique_domain("sentinelfail")
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_sentinelfail.txt", f"{domain}\n")
+    spec = h.DnsblCase(
+        aliasname="smokesentinelfail", feed_url=feed_url, header="smokesentinelfail", mode=h.DnsblMode.VIP
+    )
+    with h.CaseContext(deployed_vm, spec):
+        # Given: the domain is already VIP-blocked by CaseContext's own (healthy) reload.
+        blocked_before = h.dns_probe(deployed_vm, domain, "A")
+        assert h.is_vip(blocked_before), (
+            f"{domain} expected VIP block before the sentinel corruption, got {blocked_before}"
+        )
+
+        pid_before = h.unbound_pid(deployed_vm)
+        fail_log_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "ADR-10: sentinel flip failed")
+        # Pre-condition, not the regression under test: a marker already present here
+        # would mean an EARLIER case/module leaked it, not this one.
+        assert not h.hook_marker_exists(deployed_vm, _ADR10_SYNC_MARKER), (
+            f"'.sync' marker unexpectedly present BEFORE this test runs: {_ADR10_SYNC_MARKER} "
+            f"-- an earlier case/module leaked it (not this test's regression)"
+        )
+
+        # Capture the sentinel's PRIOR content (for restoration), then corrupt it.
+        capture = h.php_eval(
+            deployed_vm,
+            f"$s = {h._php_str(_ADR10_SENTINEL)};\n"
+            "$prior = @file_get_contents($s);\n"
+            f"echo ($prior === FALSE) ? 'ABSENT' : "
+            f"({h._php_str(h._CFG_VAL_OPEN)} . $prior . {h._php_str(h._CFG_VAL_CLOSE)});\n"
+            "@unlink($s);\n"
+            "@mkdir($s, 0755);\n"
+            "@chown($s, 'unbound'); @chgrp($s, 'unbound');\n"
+            "echo '|CORRUPTED';",
+            timeout=30.0,
+        )
+        assert "CORRUPTED" in capture.stdout, (
+            f"failed to corrupt the ADR-10 sentinel: rc={capture.returncode} {capture.stderr!r} {capture.stdout!r}"
+        )
+        prior_start = capture.stdout.find(h._CFG_VAL_OPEN)
+        prior_end = capture.stdout.find(h._CFG_VAL_CLOSE)
+        prior_sentinel_content = None
+        if prior_start != -1 and prior_end != -1:
+            prior_sentinel_content = capture.stdout[prior_start + len(h._CFG_VAL_OPEN) : prior_end]
+
+        try:
+            # When: replay the #51 alerts-page temporary-Unlock sequence. The corrupted
+            # sentinel makes pfb_unbound_py_flip_sentinel() fail, so pfb_reload_unbound()
+            # falls back to pfb_stop_start_unbound() -- a REAL restart with the
+            # UNCORRUPTED, freshly-published manifest (only the sentinel was touched), so
+            # the restart's cold-start rebuild is unaffected.
+            snippet = (
+                "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+                "pfb_global();\n"
+                "$ua = pfb_dnsbl_unlock_action('unlock');\n"
+                "$u = pfb_unlock('read', 'dnsbl', '', '', '');\n"
+                f"pfb_unlock($ua['mode'], 'dnsbl', {h._php_str(domain)}, 'python', $u);\n"
+                "pfb_unbound_python_sources_unlock();\n"
+                f"$newly_blocked = ($ua['mode'] === 'lock') ? array({h._php_str(domain)}) : array();\n"
+                "pfb_reload_unbound('enabled', FALSE, FALSE, TRUE, $newly_blocked);\n"
+                "echo 'OK';"
+            )
+            result = h.php_eval(deployed_vm, snippet, timeout=150.0)
+            assert result.returncode == 0 and "OK" in result.stdout, (
+                f"#51 unlock (sentinel-flip-failure replay) failed: rc={result.returncode} "
+                f"{result.stderr!r} {result.stdout!r}"
+            )
+
+            # Then: Unbound is back up (the fallback restarted it) before any further check.
+            h.wait_unbound_ready(deployed_vm)
+
+            # Then: the fallback branch under test actually ran (not a false pass from a
+            # differently-shaped failure) -- the "sentinel flip failed" line is NEW.
+            fail_log_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "ADR-10: sentinel flip failed")
+            assert fail_log_after > fail_log_before, (
+                f"expected a NEW 'ADR-10: sentinel flip failed' line in {h.PFB_LOG} "
+                f"(before={fail_log_before}, after={fail_log_after}) -- the sentinel corruption "
+                f"did not drive pfb_reload_unbound() into the branch under test"
+            )
+
+            # Then: it genuinely fell back to a RESTART (pid changed) -- the fallback this
+            # fix's comment describes, not some other no-op path.
+            pid_after = h.unbound_pid(deployed_vm)
+            assert pid_after != pid_before, (
+                f"expected the sentinel-flip-failure fallback to RESTART Unbound, but pid was "
+                f"unchanged ({pid_before}) -- the restart fallback did not run"
+            )
+
+            # Then: the '.sync' daemon-suppression marker touched at the top of the fast
+            # path must NOT be left behind -- this IS the regression (issue #713 bug 3).
+            leaked = h.hook_marker_exists(deployed_vm, _ADR10_SYNC_MARKER)
+            assert not leaked, (
+                f"'.sync' marker leaked after the sentinel-flip-failure fallback: {_ADR10_SYNC_MARKER} "
+                f"-- the DNSBL Queries daemon stays suppressed until the next full update"
+            )
+        finally:
+            # Restore the sentinel to its ORIGINAL content -- never a fresh value (see
+            # docstring: a lower/absent generation would desync the in-memory watcher).
+            restore_snippet = f"$s = {h._php_str(_ADR10_SENTINEL)};\nif (is_dir($s)) {{ @rmdir($s); }}\n"
+            if prior_sentinel_content is not None:
+                restore_snippet += (
+                    f"if (!file_exists($s)) {{ file_put_contents($s, {h._php_str(prior_sentinel_content)}); "
+                    "@chown($s, 'unbound'); @chgrp($s, 'unbound'); }\n"
+                )
+            restore_snippet += "echo (is_dir($s) ? 'STILL_DIR' : 'RESTORED');"
+            restore = h.php_eval(deployed_vm, restore_snippet, timeout=30.0)
+            assert "RESTORED" in restore.stdout, (
+                f"failed to restore the ADR-10 sentinel after corrupting it: "
+                f"rc={restore.returncode} {restore.stderr!r} {restore.stdout!r} -- "
+                f"the session VM's ADR-10 fast path is left broken for later tests"
+            )
+
+            # Prove the fast path genuinely still works post-restore: one more ordinary
+            # #51 action (re-Lock; the domain is presently unlocked) must take the swap.
+            # dnsbl_alert_lock_toggle raises loudly on a swap-applied timeout, so a bad
+            # restore (a desynced generation counter) surfaces HERE, not as a later
+            # test's unrelated-looking failure.
+            h.dnsbl_alert_lock_toggle(deployed_vm, domain, "lock")
+
+
 @pytest.mark.timeout(120)  # ADR-10: multiple wait-for-apply round-trips > the 30s smoke cap.
 def test_dnsbl_temp_unlock_cleared_by_force_update(
     deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -880,6 +880,89 @@ def test_pkg_version_key_orders_nightlies_chronologically() -> None:
     assert brp._pkg_version_key("3.2.16.20260606.10") > brp._pkg_version_key("3.2.16.20260606.2")
 
 
+def test_pkg_version_key_orders_prerelease_stages_alpha_beta_rc_then_release() -> None:
+    """_pkg_version_key ranks release-tag stages the way FreeBSD pkg does (release-version.sh).
+
+    A naive component-numeric key folds the stage keyword to 0: 4.0.0.alpha.1 /
+    .beta.1 / .rc.1 all collapsed to the SAME key, and the bare 4.0.0 release
+    sorted BELOW every prerelease. This bites when more than one devel build is
+    retained (--release-keep-devel > 1): builds mis-order and collapse. Correct
+    order: alpha < beta < rc < release.
+    """
+    versions = ["4.0.0.alpha.1", "4.0.0.beta.1", "4.0.0.rc.1", "4.0.0"]
+    assert sorted(versions, key=brp._pkg_version_key) == versions
+
+    # Stage keywords must NOT compare equal — each is a distinct, ordered stage.
+    assert brp._pkg_version_key("4.0.0.alpha.1") < brp._pkg_version_key("4.0.0.beta.1")
+    assert brp._pkg_version_key("4.0.0.beta.1") < brp._pkg_version_key("4.0.0.rc.1")
+    # The bare release ranks ABOVE every prerelease, not below.
+    assert brp._pkg_version_key("4.0.0.rc.1") < brp._pkg_version_key("4.0.0")
+
+    # The stage NUMBER still tie-breaks within one stage.
+    assert brp._pkg_version_key("4.0.0.alpha.1") < brp._pkg_version_key("4.0.0.alpha.2")
+
+
+def test_pkg_version_key_full_multi_version_sort_matches_pkg_order() -> None:
+    """A shuffled multi-version list sorts into the exact pkg-defined order."""
+    shuffled = [
+        "4.0.0",
+        "4.0.0.rc.1",
+        "4.0.0.alpha.2",
+        "4.0.0.beta.1",
+        "4.0.0.alpha.1",
+        "4.0.1.alpha.1",
+    ]
+    expected = [
+        "4.0.0.alpha.1",
+        "4.0.0.alpha.2",
+        "4.0.0.beta.1",
+        "4.0.0.rc.1",
+        "4.0.0",
+        "4.0.1.alpha.1",
+    ]
+    assert sorted(shuffled, key=brp._pkg_version_key) == expected
+
+
+def test_retain_by_channel_devel_retains_prerelease_stages_in_pkg_order(tmp_path: Path) -> None:
+    """retain_by_channel(keep_devel>1) keeps the newest N devel builds in REAL pkg order.
+
+    Scenario: a devel series progressing alpha.1 -> alpha.2 -> beta.1 -> rc.1, retained 3-deep,
+    with mtimes set ADVERSARIALLY (oldest-stage file gets the NEWEST mtime) so the result can
+    only be right via the VERSION key, never via _retain_newest's mtime tie-break falling back
+    on file-creation order.
+      Given 4 devel .pkg spanning the alpha/beta/rc lifecycle of one series
+        And keep_devel=3 (rollback retention, --release-keep-devel > 1)
+        And mtimes DELIBERATELY inverted vs. stage order (alpha.1 is newest-on-disk)
+      When retain_by_channel is called
+      Then the 3 NEWEST BY VERSION survive: alpha.2, beta.1, rc.1
+       And the oldest BY VERSION (alpha.1) is dropped, despite having the newest mtime —
+       proving the primary key (not the mtime tie-break) drives the decision
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    a1 = _make_pkg_channel(d, "pfBlockerNG-devel", "4.0.0.alpha.1")
+    a2 = _make_pkg_channel(d, "pfBlockerNG-devel", "4.0.0.alpha.2")
+    b1 = _make_pkg_channel(d, "pfBlockerNG-devel", "4.0.0.beta.1")
+    r1 = _make_pkg_channel(d, "pfBlockerNG-devel", "4.0.0.rc.1")
+    # Invert mtimes vs. version-stage order: the OLDEST version (alpha.1) gets the
+    # NEWEST mtime, and vice versa. A tie-break-by-mtime alone would then pick the
+    # WRONG 3 (a1, a2, b1) — only a version key that keeps alpha/beta/rc DISTINCT
+    # (never tying) picks the right 3 (a2, b1, r1) regardless of mtime.
+    base = 1_700_000_000.0
+    for path, offset in ((r1, 0), (b1, 10), (a2, 20), (a1, 30)):
+        os.utime(path, (base + offset, base + offset))
+
+    # Before-state: all 4 present.
+    all_paths = [a1, a2, b1, r1]
+    kept_all = brp.retain_by_channel(all_paths, keep_devel=0, keep_stable=0)
+    assert len(kept_all) == 4
+
+    kept = brp.retain_by_channel(all_paths, keep_devel=3, keep_stable=0)
+    kept_versions = {brp.read_compact_manifest(p)["version"] for p in kept}
+    assert kept_versions == {"4.0.0.alpha.2", "4.0.0.beta.1", "4.0.0.rc.1"}
+    assert "4.0.0.alpha.1" not in kept_versions
+
+
 def test_build_matrix_tree_layout_arch_leaf(tmp_path: Path) -> None:
     """build_repo_matrix projects the matrix 1:1 with the bare ARCH as the leaf.
 

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -902,6 +902,20 @@ def test_pkg_version_key_orders_prerelease_stages_alpha_beta_rc_then_release() -
     assert brp._pkg_version_key("4.0.0.alpha.1") < brp._pkg_version_key("4.0.0.alpha.2")
 
 
+def test_pkg_version_key_preserves_numeric_prefix_ordering() -> None:
+    """A shorter all-numeric version must sort BELOW its longer prefix-extension.
+
+    A flat `[*base, stage_rank, stage_num]` key breaks this: '2.8' -> [2, 8, 3, 0]
+    compares its OWN stage_rank (index 2 = 3) against '2.8.1' -> [2, 8, 1, 3, 0]'s
+    THIRD version component (index 2 = 1) at the same list position, so '2.8'
+    wrongly sorts ABOVE '2.8.1'. The nested (base, stage_rank, stage_num) tuple
+    compares `base` as a whole list first (Python's list-prefix rule), so the
+    shorter numeric run correctly sorts below its extension.
+    """
+    assert brp._pkg_version_key("2.8") < brp._pkg_version_key("2.8.1")
+    assert brp._pkg_version_key("4.0.0") < brp._pkg_version_key("4.0.0.1")
+
+
 def test_pkg_version_key_full_multi_version_sort_matches_pkg_order() -> None:
     """A shuffled multi-version list sorts into the exact pkg-defined order."""
     shuffled = [

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -81,6 +81,17 @@ def test_ver_key_orders_prerelease_stages_alpha_beta_rc_then_release() -> None:
     assert gl.ver_key("4.0.0.alpha.1") < gl.ver_key("4.0.0.alpha.2")
 
 
+def test_ver_key_preserves_numeric_prefix_ordering() -> None:
+    """A shorter all-numeric version must sort BELOW its longer prefix-extension
+    (build_edition_sections sorts rows by ver_key(pfsense_version), a bare
+    edition version like '2.8' vs '2.8.1'). A flat [*base, stage_rank, stage_num]
+    key breaks this -- see pfb_pkg.pkg_version_sort_key's docstring for why the
+    nested (base, stage_rank, stage_num) tuple fixes it.
+    """
+    assert gl.ver_key("2.8") < gl.ver_key("2.8.1")
+    assert gl.ver_key("4.0.0") < gl.ver_key("4.0.0.1")
+
+
 def test_ver_key_full_multi_version_sort_matches_pkg_order() -> None:
     """A shuffled multi-version list sorts into the exact pkg-defined order."""
     shuffled = [

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -59,6 +59,49 @@ def test_ver_key_orders_nightly_after_release() -> None:
     assert gl.ver_key("3.2.16.20260614.20") > gl.ver_key("3.2.16.20260614.7")
 
 
+def test_ver_key_orders_prerelease_stages_alpha_beta_rc_then_release() -> None:
+    """ver_key ranks the release-tag stages the way FreeBSD pkg does (release-version.sh).
+
+    A naive numeric-run key (re.findall(r"\\d+", v)) folds the stage keyword away
+    entirely: 4.0.0.alpha.1 / .beta.1 / .rc.1 all collapsed to the SAME key [4,0,0,1],
+    and the bare 4.0.0 release ([4,0,0]) sorted BELOW every prerelease. This bites
+    when more than one devel build is retained (--release-keep-devel > 1): builds
+    mis-order and collapse. Correct order: alpha < beta < rc < release.
+    """
+    versions = ["4.0.0.alpha.1", "4.0.0.beta.1", "4.0.0.rc.1", "4.0.0"]
+    assert sorted(versions, key=gl.ver_key) == versions
+
+    # Stage keywords must NOT compare equal — each is a distinct, ordered stage.
+    assert gl.ver_key("4.0.0.alpha.1") < gl.ver_key("4.0.0.beta.1")
+    assert gl.ver_key("4.0.0.beta.1") < gl.ver_key("4.0.0.rc.1")
+    # The bare release ranks ABOVE every prerelease, not below.
+    assert gl.ver_key("4.0.0.rc.1") < gl.ver_key("4.0.0")
+
+    # The stage NUMBER still tie-breaks within one stage.
+    assert gl.ver_key("4.0.0.alpha.1") < gl.ver_key("4.0.0.alpha.2")
+
+
+def test_ver_key_full_multi_version_sort_matches_pkg_order() -> None:
+    """A shuffled multi-version list sorts into the exact pkg-defined order."""
+    shuffled = [
+        "4.0.0",
+        "4.0.0.rc.1",
+        "4.0.0.alpha.2",
+        "4.0.0.beta.1",
+        "4.0.0.alpha.1",
+        "4.0.1.alpha.1",
+    ]
+    expected = [
+        "4.0.0.alpha.1",
+        "4.0.0.alpha.2",
+        "4.0.0.beta.1",
+        "4.0.0.rc.1",
+        "4.0.0",
+        "4.0.1.alpha.1",
+    ]
+    assert sorted(shuffled, key=gl.ver_key) == expected
+
+
 def test_artifact_datetime_is_utc_minute_precision() -> None:
     """A Unix epoch formats to a UTC, minute-precision datetime.
 

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -2021,27 +2021,38 @@ class TestHstsCheckDomain:
         assert result == (True, "HSTS")
 
     def test_suffix_walk_hits_parent(self) -> None:
-        # "sub.example.com" (2 dots): range(3,0,-2) → [3, 1]
-        # iter 0: check "sub.example.com" (miss), step → "example.com"
-        # iter 1: check "example.com" (hit)
+        # "sub.example.com" (2 dots): the walk checks "sub.example.com" (miss), steps
+        # to "example.com" (hit) -- every parent suffix level is visited in order.
         hsts_db: dict = {"example.com": 0}
         result = hsts_check_domain("sub.example.com", hsts_db, (), "com")
         assert result == (True, "HSTS")
 
-    def test_stride_2_skips_alternate_label(self) -> None:
-        # "a.b.c.d" (3 dots): range(4,0,-2) → 2 iterations
-        # The loop runs twice: q starts at "a.b.c.d", then steps to "b.c.d".
-        # Positions checked: "a.b.c.d" (iter 0), "b.c.d" (iter 1).
-        # "c.d" is never checked (one more step would be needed).
-        # This pins the stride-2 quirk: "c.d" alone is NOT found.
+    def test_every_parent_suffix_is_checked_for_hsts(self) -> None:
+        # issue #713: the walk used to stride by -2, skipping every OTHER parent
+        # suffix level. For "a.b.c.d" (3 dots) the buggy walk checked only
+        # "a.b.c.d" and "b.c.d" -- it never reached "c.d" -- so a name whose HSTS
+        # parent is exactly "c.d" incorrectly fell through to ("Python") instead of
+        # ("HSTS"), forcing a VIP block instead of NULL for that HSTS-preloaded
+        # parent (wrong TLS cert on the block page). The corrected stride-1 walk
+        # checks every level ("a.b.c.d", "b.c.d", "c.d", "d") and finds it.
         hsts_db: dict = {"c.d": 0}
         result = hsts_check_domain("a.b.c.d", hsts_db, (), "d")
-        assert result == (False, "Python")
+        assert result == (True, "HSTS")
 
-    def test_stride_2_hits_second_position(self) -> None:
-        # The second position checked is "b.c.d" (after one step from "a.b.c.d").
-        # A stride-1 walk would also check "c.d" and "d"; stride-2 stops after "b.c.d".
+    def test_second_level_parent_suffix_matches(self) -> None:
+        # The second suffix level checked ("b.c.d", one step up from the full name)
+        # resolves to HSTS -- confirms the walk isn't only correct at the extremes.
         hsts_db: dict = {"b.c.d": 0}
+        result = hsts_check_domain("a.b.c.d", hsts_db, (), "d")
+        assert result == (True, "HSTS")
+
+    def test_bare_tld_suffix_is_checked(self) -> None:
+        # issue #713: the walk must reach the LAST level -- the bare TLD label itself.
+        # The buggy stride-2 walk for this 4-label name stopped two levels short of
+        # "d" (it only ever reached "b.c.d"), so a parent HSTS entry at the bare TLD
+        # was never found. Confirms the loop count now covers every suffix down to
+        # (and including) the TLD.
+        hsts_db: dict = {"d": 0}
         result = hsts_check_domain("a.b.c.d", hsts_db, (), "d")
         assert result == (True, "HSTS")
 

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -2349,6 +2349,33 @@ class TestEvaluateDomainGolden:
         dec = evaluate_domain("example.com", "example.com", "com", False, cfg, containers)
         assert dec.is_found is False
 
+    def test_tld_allow_empty_list_is_a_noop(self) -> None:
+        """issue #713: an empty ``python_tlds`` (TLD-Allow enabled but no TLDs
+        configured) must NOT block every domain. Pre-fix, ``tld not in []`` is
+        always True, so this arm fired for any query regardless of tld -- the
+        "empty TLD-Allow blocks all" bug, still reachable here even after the
+        config-load ``python_blacklist`` enable guard was fixed, because this
+        decision site only gates on ``cfg["python_tld"]``."""
+        cfg = _make_cfg(python_tld=True, python_tlds=[])
+        containers = _make_containers()
+        dec = evaluate_domain("example.com", "example.com", "com", False, cfg, containers)
+        assert dec.is_found is False
+
+    def test_tld_allow_branches_both_ways_on_a_populated_list(self) -> None:
+        """With a populated TLD-Allow list, a disallowed tld is still blocked
+        (the empty-list guard must not swallow the real case) and an allowed
+        tld still passes through."""
+        cfg = _make_cfg(python_tld=True, python_tlds=["com"])
+        containers = _make_containers()
+
+        dec_blocked = evaluate_domain("example.net", "example.net", "net", False, cfg, containers)
+        assert dec_blocked.is_found is True
+        assert dec_blocked.feed == "TLD_Allow"
+        assert dec_blocked.group == "DNSBL_TLD_Allow"
+
+        dec_allowed = evaluate_domain("example.com", "example.com", "com", False, cfg, containers)
+        assert dec_allowed.is_found is False
+
     def test_idn_block(self) -> None:
         cfg = _make_cfg(python_idn=True)
         containers = _make_containers()

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -3,6 +3,7 @@ import random
 import re
 import types
 from collections import defaultdict
+from configparser import ConfigParser
 from typing import Any
 
 # Unbound injects these as module-level globals at runtime; conftest copies them
@@ -25,6 +26,7 @@ from unboundmodule import (
 
 import pfb_unbound
 from pfb_unbound import (
+    _parse_ini_int,
     convert_ipv4,
     convert_ipv6,
     convert_other,
@@ -35,6 +37,7 @@ from pfb_unbound import (
     hsts_check_domain,
     is_unknown,
     iter_domain_suffixes,
+    parse_python_tlds,
     python_control_duration,
     resolve_feed_group,
     whitelist_check_domain,
@@ -2060,6 +2063,72 @@ class TestHstsCheckDomain:
         hsts_db: dict = {"other.com": 0}
         result = hsts_check_domain("example.com", hsts_db, (), "com")
         assert result == (False, "Python")
+
+
+class TestParsePythonTlds:
+    """issue #713: the MAIN-ini ``python_tlds`` value must parse to a CLEANED list so
+    an empty/degenerate value is falsy -- the caller's guard (``python_tld and
+    python_tlds``) then correctly skips enabling the TLD-Allow blacklist gate instead
+    of force-enabling it (the old ``!= ""`` list-vs-str compare was always True)."""
+
+    def test_empty_value_parses_to_empty_list(self) -> None:
+        assert parse_python_tlds("") == []
+
+    def test_whitespace_only_value_parses_to_empty_list(self) -> None:
+        assert parse_python_tlds("   ") == []
+
+    def test_populated_value_parses_and_strips_entries(self) -> None:
+        assert parse_python_tlds("com, net ,org") == ["com", "net", "org"]
+
+    def test_empty_parsed_list_does_not_enable_tld_blacklist(self) -> None:
+        # Reproduces init_standard's guard verbatim: `if python_tld and python_tlds:`.
+        # An empty/degenerate TLD-Allow value must NOT force python_blacklist on.
+        python_tlds = parse_python_tlds("")
+        python_tld = True
+        assert bool(python_tld and python_tlds) is False
+
+    def test_populated_parsed_list_enables_tld_blacklist(self) -> None:
+        python_tlds = parse_python_tlds("com,net")
+        python_tld = True
+        assert bool(python_tld and python_tlds) is True
+
+
+class TestParseIniInt:
+    """issue #713: ``config.getint()`` raises ``ValueError`` on a non-integer ini
+    value. init_standard's ``python_tld_seg``/``decisiondb_max`` reads called it
+    UNGUARDED, so a malformed ini value crashed the whole Unbound Python module at
+    init. ``_parse_ini_int`` guards it (mirrors the existing ``regex_warn_ms``/
+    ``regex_evict_ms`` try/except-ValueError pattern) and reports failure via
+    ``None`` instead of raising, so the caller keeps its current default."""
+
+    def _config(self, value: str) -> ConfigParser:
+        config = ConfigParser()
+        config.read_string("[MAIN]\npython_tld_seg = {}\n".format(value))
+        return config
+
+    def test_malformed_value_returns_none_instead_of_raising(self) -> None:
+        config = self._config("not-an-int")
+        assert _parse_ini_int(config, "MAIN", "python_tld_seg") is None
+
+    def test_well_formed_value_parses_to_int(self) -> None:
+        config = self._config("3")
+        assert _parse_ini_int(config, "MAIN", "python_tld_seg") == 3
+
+    def test_default_is_preserved_when_parse_fails(self) -> None:
+        # Mirrors init_standard's call-site guard: only overwrite the current default
+        # when the parse actually succeeded.
+        current_default = 2
+        config = self._config("garbage")
+        parsed = _parse_ini_int(config, "MAIN", "python_tld_seg")
+        result = parsed if parsed is not None else current_default
+        assert result == current_default
+
+    def test_default_is_replaced_when_parse_succeeds(self) -> None:
+        current_default = 2
+        config = self._config("9")
+        parsed = _parse_ini_int(config, "MAIN", "python_tld_seg")
+        result = parsed if parsed is not None else current_default
+        assert result == 9
 
 
 class TestResolveFeedGroup:

--- a/tests/test_url_encoding_check.py
+++ b/tests/test_url_encoding_check.py
@@ -87,6 +87,27 @@ def test_shell_static_query_param_is_clean() -> None:
     assert _find('curl "http://h/x?fixed=1"') == []
 
 
+def test_shell_var_base_with_naked_query_var_is_flagged() -> None:
+    # The exact webhook shape this checker exists to guard: a VARIABLE base with the
+    # `?` in the MIDDLE of the token (not at the start), still carrying a naked var.
+    v = _find('curl "$BASE/cb?ip=$VAR"')
+    assert len(v) == 1
+    assert "--data-urlencode" in v[0].message
+
+
+def test_shell_bare_dollar_right_after_query_separator_is_flagged() -> None:
+    # A bare `$VAR` immediately after `?` (no `key=` prefix) is still a naked
+    # interpolation — the comment in _NAKED_QUERY_VAR_RE documents this case.
+    v = _find('curl "http://h/cb?$VAR"')
+    assert len(v) == 1
+    assert "--data-urlencode" in v[0].message
+
+
+def test_shell_bare_dollar_after_ampersand_is_flagged() -> None:
+    v = _find('curl "http://h/cb?a=1&$VAR"')
+    assert len(v) == 1
+
+
 def test_shell_base_var_no_query_is_clean() -> None:
     assert _find('curl "$BASE/path"') == []
 

--- a/tests/test_url_encoding_check.py
+++ b/tests/test_url_encoding_check.py
@@ -138,6 +138,28 @@ def test_shell_header_value_containing_query_shape_is_clean() -> None:
     assert _find('curl -H "X: a?b=$c" http://h/x') == []
 
 
+def test_shell_var_prefixed_data_value_without_path_is_clean() -> None:
+    # A "$"-prefixed OPTION VALUE with a "?...=$" shape but NO path separator
+    # before the "?" ("$q?x=$y") is a -d body, not a variable-BASE URL. Pre-fix
+    # the bare startswith("$")+"?" clause flagged it; it must stay clean now.
+    assert _find('curl -d "$q?x=$y" http://h') == []
+
+
+def test_shell_var_prefixed_header_value_without_path_is_clean() -> None:
+    assert _find('curl -H "$AUTH?token=$T" http://h/x') == []
+
+
+def test_shell_var_prefixed_data_value_https_without_path_is_clean() -> None:
+    assert _find('curl --data "$body?k=$v" https://api') == []
+
+
+def test_shell_var_base_with_path_and_query_still_flagged() -> None:
+    # The genuine target: a "$"-BASE with a path segment THEN a naked-var query
+    # ("$BASE/cb?ip=$VAR") has a "/" before the "?", so it stays flagged -- the
+    # tightening must not silence the case the checker exists to guard.
+    assert _find('curl "$BASE/cb?ip=$VAR"') != []
+
+
 def test_non_http_client_line_with_query_var_is_clean() -> None:
     # Same `?k=$V` shape, but not a curl/wget/fetch invocation.
     assert _find('echo "http://h/x?ip=$VAR"') == []

--- a/tests/test_url_encoding_check.py
+++ b/tests/test_url_encoding_check.py
@@ -117,6 +117,27 @@ def test_shell_path_segment_var_is_clean() -> None:
     assert _find('curl "http://h/$ID"') == []
 
 
+# --------------------------------------------------------------------------- #
+# bug-15 over-widening: a bare "?" anywhere in a token used to mark it
+# URL-bearing, which flagged curl OPTION VALUES that merely contain a "?...=$"
+# shape but are not URLs. These pin the negative side; the positive bug-15
+# cases above (var-BASE-with-query, bare-$-after-separator) stay flagged.
+# --------------------------------------------------------------------------- #
+
+
+def test_shell_data_urlencode_value_containing_query_shape_is_clean() -> None:
+    # The OPTION VALUE itself contains "?b=$" -- not a URL, must not be flagged.
+    assert _find('curl --data-urlencode "path=/a?b=$c" "$HOOK"') == []
+
+
+def test_shell_form_value_containing_query_shape_is_clean() -> None:
+    assert _find('curl -F "note=a?x=$B" http://h/x') == []
+
+
+def test_shell_header_value_containing_query_shape_is_clean() -> None:
+    assert _find('curl -H "X: a?b=$c" http://h/x') == []
+
+
 def test_non_http_client_line_with_query_var_is_clean() -> None:
     # Same `?k=$V` shape, but not a curl/wget/fetch invocation.
     assert _find('echo "http://h/x?ip=$VAR"') == []


### PR DESCRIPTION
Fixes #713.

Resolves all 17 independent MEDIUM correctness bugs from the audit tracking issue. Each bug is its own commit with a dedicated test that **fails before** the fix and **passes after** (red→green verified), following the established pure-helper extraction pattern where the buggy logic lived inside an otherwise untestable function.

### PHP — `pfblockerng.inc`
- **"No Limit" logs truncated** — `pfb_filter(PFB_FILTER_NUM)` rejected the stored `'nolimit'`, collapsing it to the 20000 default; the opt-out was dead. Now read the raw value and skip truncation on `'nolimit'` (`pfb_log_max_lines()`).
- **Auto-rule suffix preservation dead** — `$pfbfound` was never set and the collect-guard was inverted (chicken-and-egg). Extracted `pfb_collect_autorule_suffix()`; the existing suffix is now preserved on already-deployed `pfB_` rules.
- **DNSBL `.sync` marker leak** — the ADR-10 fast-path fallbacks fell through without clearing `.sync`, muting the Queries daemon for the alerts-page caller. Cleared on both fallback branches (CI smoke test).
- **Compressed feeds re-ingested every cron** — the ingest sidecar hashed the decompressed `.orig` while the detector probe hashes the raw fetched body, so gz/bz2/zip/7z feeds never matched. Now hash the same raw bytes on both sides (`pfb_source_hash_target()`).
- **`pfctl -T test` string/int trap** — `substr(out,0,1) > 0` treated an absent-table error string (`'p'`) as a match under PHP 8, killing states. Now parse the numeric match count.
- **Corrupt-DB recovery broken** — table 6's `$db_table` was `'stats'` but its CREATE built `lastclear`, and the recovery `DROP` lacked `IF EXISTS`. Fixed the name and added `IF EXISTS` (`pfb_sqlite_table_spec()`).
- **IPv6 filterlog wrong port index** — the port was read from the v4 CSV indices for v6 rows. Now selected by IP version (`pfb_filterlog_port()`).
- **ASN cache never expires** — `$asn_cache` was only set when reporting was enabled, but the eviction runs under a wider guard (reporting **or** token), binding `NULL`. Made the window mapping unconditional with a safe default (`pfb_asn_cache_window()`).
- **filterlog daemon crash on absent `filter.log`** — arithmetic on grep's error string threw a PHP 8 `TypeError` (crash loop). Now `(int)`-cast after a `file_exists()` guard.

### PHP — config gateway
- **`dnsbl_webpage` key mismatch** — the install/upgrade block-page refresh read the never-written registry mis-spelling `dnsblwebpage`, so it was dead. Now reads the real foreign key via `pfb_dnsbl_webpage()`; dropped the phantom registry entry and synced the sniff/inventory/docs.

### Python — `pfb_unbound.py`
- **HSTS suffix walk strided `-2`** — it checked only every other suffix level, missing HSTS parents for ≥3-label names (VIP instead of NULL). Changed to stride `-1`; the test that pinned the quirk was rewritten to pin the correct behaviour.
- **`python_tlds` dead compare + `init_standard` crash** — a list was compared `!= ""` (always true, so an empty TLD-Allow blocked all), and unguarded `getint` reads threw out of module init on a malformed ini. Now a cleaned-list truthiness guard (`parse_python_tlds()`) and guarded int reads (`_parse_ini_int()`).

### POSIX shell — `pfblockerng.sh`
- **ET category over-block** — a substring `case` glob let a selected `ET_P2Pcnc` also match `ET_P2P`. Now a delimiter-anchored exact-token match.
- **`tar | zstd` masked a truncated archive** — no pipefail meant tar's failure was discarded and `zstd -tq` only checks framing, so a corrupt `.zst` was published and the good `.bz2` deleted. Now tar to a temp, check its status, verify, then atomically publish.
- **Fail-open feed-list redirects** — nine producer→file redirects (grepcidr + awk dedup) truncated a consumed file with no exit-status check, emptying blocklists on any producer error. Now temp + status-gated `mv` per producer class (grepcidr accepts `rc 0/1` so a legitimately-empty suppression result still applies; awk gates on `rc 0`).

### Dev tooling
- **URL-encoding gate false-negative** (`scripts/check_url_encoding.py`) — missed `curl "$BASE/cb?ip=$VAR"` (mid-token `?`) and a bare `?$VAR`. Now detects `?` anywhere and an optional `=`.
- **Prerelease version key collapse** (`scripts/pfb_pkg.py`, used by `build-repo-portable.py` + `gen_landing.py`) — a numeric-runs key folded alpha/beta/rc together and sorted stable below rc. Now ranks the stage keywords (`pkg_version_sort_key()`).

### Testing
Full local suites pass against the current `devel` base: **PHPUnit 1800**, **pytest 1948**, `ruff` and `shellcheck` clean. Shell (shellspec) and live-VM smoke tests are written but run in CI only (not executable in this environment); each shell fix was additionally verified with a `/bin/sh` red→green harness. PHPStan was not run locally (unavailable in this environment) and is covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjaFrLAQsVZdLxcFZZTkBX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version handling and retention so newer package releases, including prereleases, are ordered more accurately.
  * Fixed several pfBlockerNG behaviors affecting DNSBL settings, log parsing, archive creation, and firewall rule updates.
  * Corrected handling of empty or malformed configuration values to avoid unexpected failures and preserve safe defaults.
  * Improved detection of matching firewall and filterlog entries, reducing false matches and missed matches.

* **Documentation**
  * Updated configuration documentation to reflect the current DNSBL webpage setting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->