### PR TITLE
pfblockerng: fix pfb_filter '0' coercion + dead code + powerpc ALTABI triplet (#714)

### DIFF
--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1115,8 +1115,8 @@ def abi_to_arch(abi: str) -> str:
         "i386": "x86:32",
         "aarch64": "aarch64:64",
         "armv7": "armv7:32",
-        "powerpc64": "powerpc:64",
-        "powerpc64le": "powerpc:64:eb",
+        "powerpc64": "powerpc:64:eb",
+        "powerpc64le": "powerpc:64:el",
     }
     parts = abi.split(":")
     if len(parts) != 3:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1311,7 +1311,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		}
 	}
 
-	return $result == FALSE ? $default : $result;
+	return $result === FALSE ? $default : $result;
 }
 
 function pfb_get_vips(): array {
@@ -11529,11 +11529,9 @@ function pfb_dnsbl_parse($mode='daemon', $domain, $src_ip, $req_agent) {
 
 				$dcnt = count($dparts);
 
-				for ($i=0; $i <= $dcnt; $i++) {
+				for ($i=0; $i < $dcnt; $i++) {
 
-					$domainparse		= str_replace('.', '\.', implode('.', $dparts));
-					$domainparse_esc	= escapeshellarg("^{$domainparse}$");
-
+					$domainparse	= str_replace('.', '\.', implode('.', $dparts));
 
 					$dquery_esc	= escapeshellarg(",{$domainparse},,");
 					$pfb_feed	= exec("{$pfb['grep']} -shm1 {$dquery_esc} {$pfb['unbound_py_zone']} 2>&1");
@@ -14129,8 +14127,6 @@ function sync_package_pfblockerng($cron='') {
 							// If Null Blocking mode is selected, use '0.0.0.0|::0', otherwise utilize DNSBL WebServer/DNSBL VIP
 							// NXDOMAIN modes ('3'/'4', issue #31) emit a bare NXDOMAIN in pfb_unbound.py; no sinkhole IP applies.
 							if ($list['logging'] == 'disabled') {
-								$sinkhole_type4 = '0.0.0.0';
-								$sinkhole_type6 = '::0';
 								$logging_type	= '2';	// Null Blocking no logging
 							}
 							elseif ($list['logging'] == 'disabled_log') {
@@ -14142,8 +14138,6 @@ function sync_package_pfblockerng($cron='') {
 							elseif ($list['logging'] == 'nxdomain') {
 								$logging_type	= '4';	// NXDOMAIN no logging
 							} else {
-								$sinkhole_type4 = "{$pfb['dnsbl_vip4']}";
-								$sinkhole_type6 = "{$pfb['dnsbl_vip6']}";
 								$logging_type	= '1';	// DNSBL VIP logging
 							}
 

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -120,10 +120,12 @@ final class PfbFilterTest extends TestCase
 			'digits'              => ['12345', '12345'],
 			'alpha -> default'    => ['12a', ''],
 			'negative -> default' => ['-5', ''],
-			// Quirk worth pinning: '0' validates, but the final
-			// `return $result == FALSE ? $default : $result` treats the string
-			// '0' as loosely == FALSE, so NUM can never return '0' -> default.
-			'zero is loose-false' => ['0', ''],
+			// '0' is a legitimately validated digit string (matches
+			// /^[0-9]+$/) and must round-trip unchanged, not collapse to
+			// the default -- a hook_timeout of '0' (pfblockerng_hooks.php)
+			// must not be rejected as invalid just because PHP's loose
+			// '0' == FALSE coercion used to treat it as a filter failure.
+			'zero validates'      => ['0', '0'],
 		];
 	}
 

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -130,6 +130,10 @@ def test_compute_pkgversion(tmp_path: Path, ver: str, rev: str, epoch: str, expe
         ("FreeBSD:16:amd64", "freebsd:16:x86:64"),
         ("FreeBSD:14:aarch64", "freebsd:14:aarch64:64"),
         ("FreeBSD:13:i386", "freebsd:13:x86:32"),
+        # FreeBSD pkg ALTABI tags PowerPC with an explicit endian token:
+        # big-endian "eb", little-endian "el".
+        ("FreeBSD:15:powerpc64le", "freebsd:15:powerpc:64:el"),
+        ("FreeBSD:15:powerpc64", "freebsd:15:powerpc:64:eb"),
     ],
 )
 def test_abi_to_arch(abi: str, arch: str) -> None:


### PR DESCRIPTION
Part of #714 — batch 3 (off-appliance `.inc` + build tooling).

Four CONFIRMED audit fixes, each adversarially verified against pristine `origin/devel`:

### c2 — `pfb_filter` loose `== FALSE` collapses a valid `'0'` (real bug)
`pfblockerng.inc:1314`: `$result == FALSE ? $default : $result` treats a legitimately-validated string `'0'` as a filter failure (PHP `'0' == FALSE` is true), so any numeric field whose valid value is `0` is silently rejected and replaced by the default. Reached via `pfblockerng_hooks.php:126` (`hook_timeout` of `0`) and the `PFB_FILTER_NUM` path. Fix: strict `=== FALSE`.
- **Test (red→green):** `PfbFilterTest::numProvider` — the `'0'` case flips from `['0', '']` (pinning the bug) to `['0', '0']`. Red on `==` (`-'0' +''`), green on `===`.

### c5 — `pfb_dnsbl_parse` off-by-one + dead var (behaviour-preserving)
`pfblockerng.inc:11532`: `for ($i=0; $i <= $dcnt; $i++)` ran one iteration too many; the extra pass builds a degenerate `,,,` query that can never match a real zone-file line (every field is non-empty + comma-free by construction), so it is a confirmed no-op. Also removes the computed-but-unused `$domainparse_esc`. Fix: `$i < $dcnt`.

### b3 — dead `$sinkhole_type4` / `$sinkhole_type6` (behaviour-preserving)
`pfblockerng.inc` (~14127-14144): four assignments that are never read anywhere (grep-confirmed). Removed; the sibling `$logging_type` assignments are kept.

### h3 — powerpc ALTABI missing/wrong endian token (real bug, dev tooling)
`scripts/build-pkg-portable.py:1118-1119`: `powerpc64` had no endian token and `powerpc64le` carried the wrong (`eb`) one. FreeBSD pkg tags PowerPC ALTABI with an explicit endian suffix — big-endian `eb`, little-endian `el`. Fix: `powerpc64 → powerpc:64:eb`, `powerpc64le → powerpc:64:el`.
- **Test (red→green):** `test_abi_to_arch` gains both powerpc cases; red on the old map, green after.

**Gates:** PHPUnit 1753 ✓, PHPStan ✓, PHPCS ✓, `php -l` ✓, `ruff` ✓, `pytest` full suite 1934 passed / 4 skipped ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PowerPC package architecture detection so the correct format is used for 64-bit big-endian and little-endian systems.
  * Fixed filter handling to preserve valid zero values instead of incorrectly replacing them with a default.
  * Resolved issues in DNS blocklist parsing and sync processing that could affect how entries and logging-related behavior were handled.

* **Tests**
  * Updated automated coverage to reflect the corrected architecture mapping and zero-value filter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->