### PR TITLE
dev: fail-loud guards + ALTABI/PKGVERSION fixes in build-pkg-portable (#727)

### DIFF
--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -12,10 +12,14 @@ name: build-pkg (Linux, portable)
 # dependency is PRESENT, not its version, so installability is identical). See
 # docs/build-pkg-portable.md.
 #
-# This is the FAST build path the ADR-04 smoke workflow consumes (drop-in for the
-# FreeBSD build-pkg.yml: same `pfBlockerNG-pkg` artifact, same out/*.pkg layout,
-# same `channel` input). The FreeBSD build-pkg.yml is RETAINED as the ground-truth
-# `make package` fidelity oracle (dispatch-only) — not deleted.
+# This is the FAST build path the ADR-04 smoke workflow consumes (drop-in
+# replacement for the retired FreeBSD build-pkg.yml: same `pfBlockerNG-pkg`
+# artifact, same out/*.pkg layout, same `channel` input). The FreeBSD
+# `make package` workflow was retired in 68992f4c after the portable output was
+# validated by hand (field-by-field diff against a real `make package` build of
+# the same commit); that validation is repeated manually on min-CE bumps and
+# ports-framework moves — see the "Re-diff the portable .pkg" step in
+# docs/misc/version-bump-runbook.md.
 #
 # TARGET facts (ABI, py-flavor, PHP) are INPUTS, never read from this fork's tree:
 # they describe the pfSense the .pkg installs onto (CE 2.8 = FreeBSD 15 / py311 /

--- a/docs/build-pkg-portable.md
+++ b/docs/build-pkg-portable.md
@@ -50,8 +50,9 @@ or dependencies, so it tracks changes to the port automatically:
    from the port's embedded `files/` directory, so nothing is fetched.
 3. **Replay the recipe.** The tool interprets the port's `do-extract`,
    `post-extract` and `do-install` targets with a small command vocabulary
-   (`MKDIR`, `INSTALL_DATA`, `INSTALL_SCRIPT`, `INSTALL_PROGRAM`, `MV`, `CP`,
-   `LN`, `RM`, `REINPLACE_CMD`/`SED`) into a controlled staging directory — the
+   (`MKDIR`, `INSTALL_DATA`, `INSTALL_SCRIPT`, `MV`, `REINPLACE_CMD`/`SED` —
+   `CP`/`LN`/`RM`/`INSTALL_PROGRAM` were deliberately dropped, #502, as no port
+   recipe uses them) into a controlled staging directory — the
    same effect `make` would have, minus the shell. An **unknown recipe command
    is a hard error** (a signal that the port changed in a way the tool must be
    taught — rather than silently producing a broken package).

--- a/docs/build-pkg-portable.md
+++ b/docs/build-pkg-portable.md
@@ -40,6 +40,11 @@ or dependencies, so it tracks changes to the port automatically:
    `${VAR}`/`$(VAR)` expansion and a couple of `:modifiers`. Framework variables
    the port relies on (`PREFIX`, `DATADIR`, `WRKSRC`, `FILESDIR`, the install
    macros, the Python prefix, …) are seeded; `.include <bsd.port.mk>` is ignored.
+   A conditional/loop directive (`.if` / `.for` / …) in the port Makefile is a
+   **hard error** — the evaluator has no branch logic, and skipping one would
+   silently drop the logic it guards. (Dependency-port Makefiles, read only for
+   best-effort name/version mining, are exempt: real tree ports routinely carry
+   `.if` blocks.)
 2. **Acquire the source** (USE_GITHUB ports): fetch the GitHub tarball for
    `GH_TAGNAME`, or use a local checkout (`--local-src`). Classic ports install
    from the port's embedded `files/` directory, so nothing is fetched.
@@ -233,6 +238,33 @@ specific past build:
    the tool records `0`.
 2. **A few dependency versions** — read from the build host's installed binary
    packages (see [above](#dependency-versions)). `--repo-catalogue` pins them.
+
+### Known benign divergences vs current pkg
+
+The field-by-field diff above was a one-time validation; libpkg has since moved.
+These divergences are deliberate, interop-safe, and would show up in a fresh
+diff (re-run per the runbook step in
+[`misc/version-bump-runbook.md`](misc/version-bump-runbook.md) on min-CE bumps /
+ports-framework moves):
+
+- **File checksum type**: the tool writes `1$<sha256hex>`; modern `pkg create`
+  writes `2$<blake2b-zbase32>`. Type `1` is a registered type the validator
+  dispatches on (`pkg_checksum_validate_fileat` parses the `N$` prefix), so
+  installs verify fine — but a fresh byte-diff will differ on every `sum`.
+- **Tar flavor**: libpkg writes pax-restricted tar; the tool writes plain ustar.
+  Identical bytes for short paths; an install path over ustar's 100/155-char
+  limits makes Python's `tarfile` raise — loud, and no port path comes close.
+- **Payload tar uid/gid**: libpkg on FreeBSD stamps `65534`, the tool `0`.
+  Extraction uses the manifest's `uname`/`gname` (`root`/`wheel`) either way.
+- **`licenselogic`**: the tool guesses `"and"` for >1 license; the framework
+  emits `LICENSE_COMB` verbatim (`dual`/`multi`). No port has >1 license today.
+- **`FreeBSD_version` annotation**: a real `make package` always records the
+  build host's `__FreeBSD_version`; no CI caller passes `--freebsd-version`, so
+  the annotation is absent from CI/release packages. Verified against libpkg
+  source (`utils.c` `is_valid_os_version`): with the annotation absent, pkg's
+  os-version sanity check is **skipped entirely** (returns valid), not fatal.
+  Acceptable — the ADR-20 versioned php/python variant deps are the real guard
+  against wrong-edition installs.
 
 ## Output format
 

--- a/docs/misc/version-bump-runbook.md
+++ b/docs/misc/version-bump-runbook.md
@@ -77,3 +77,14 @@ entry — no new shipped file, no extra deploy wiring.
    Runs the ADR-04 suite against **all** `ci: true` entries — **CE and Plus** (ADR-24) — in
    parallel (`fail-fast: false`); the `all-smoke-passed` AND-gate fails if **any** leg fails.
    version-tracker triggers it daily; dispatch manually to verify a new image.
+4. **Re-diff the portable `.pkg` against a real `make package` build** (manual; also do this
+   whenever the FreeBSD-ports fork's `Mk/` framework moves). `build-pkg-portable.py` is the sole
+   `.pkg` builder — its `make package` fidelity was validated by a one-time field-by-field diff
+   (the FreeBSD `build-pkg.yml` oracle was retired in `68992f4c`), and that validation rots as
+   libpkg and the ports framework evolve. On a FreeBSD box (a dev pfSense VM works): check out the
+   same port + source commit, run `make package`, then diff the two archives member-by-member
+   (`tar -tvf`; extract both `+MANIFEST`s and compare field-by-field after `json`/UCL
+   normalization). Expected benign divergences — file `sum` type (`1$sha256` vs modern
+   `2$blake2b`), tar flavor/uid, mtime, and best-effort dep versions — are enumerated in
+   `docs/build-pkg-portable.md` ("Fidelity vs `make package`"); anything else is a builder bug to
+   fix before the bump lands.

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -218,7 +218,9 @@ class Makefile:
     def _split_mods(mods: str) -> list[str]:
         # Split a :modifier chain on ':', keeping an :S<delim>old<delim>new<delim>[flags]
         # group intact even when its body contains ':' (e.g. a URL) — a blind
-        # split(':') would mangle it silently. Backslash escapes a delimiter.
+        # split(':') would mangle it silently. Backslash escapes protect the
+        # group-boundary scan only; escape CONTENT is rejected in _apply_mods
+        # (its old/new split does not interpret escapes — fail loud, not wrong).
         out: list[str] = []
         i = 0
         n = len(mods)
@@ -265,23 +267,32 @@ class Makefile:
                 # :S<delim>old<delim>new<delim>[1g]  (make string substitution). Supports
                 # a leading ^ / trailing $ anchor in <old> and the g (global) flag.
                 delim = mod[1]
-                parts = mod[2:].split(delim)
-                if len(parts) >= 2:
-                    old, new = parts[0], parts[1]
-                    flags = parts[2] if len(parts) > 2 else ""
-                    anchor_start, anchor_end = old.startswith("^"), old.endswith("$")
-                    pat = old[1:] if anchor_start else old
-                    pat = pat[:-1] if anchor_end else pat
-                    if not pat:
-                        pass
-                    elif "g" in flags and not (anchor_start or anchor_end):
-                        val = val.replace(pat, new)
-                    elif anchor_start and val.startswith(pat):
-                        val = new + val[len(pat) :]
-                    elif anchor_end and val.endswith(pat):
-                        val = val[: -len(pat)] + new
-                    elif not (anchor_start or anchor_end):
-                        val = val.replace(pat, new, 1)
+                body = mod[2:]
+                # The old/new split below does not interpret backslash escapes —
+                # an escaped delimiter would silently misparse; fail loud instead.
+                if "\\" in body:
+                    raise BuildError(
+                        f"unsupported escape in :S modifier (the parser does not interpret "
+                        f"backslashes; teach build-pkg-portable.py): {mod!r}"
+                    )
+                parts = body.split(delim)
+                if len(parts) < 2:
+                    raise BuildError(f"malformed :S modifier (unterminated?): {mod!r}")
+                old, new = parts[0], parts[1]
+                flags = parts[2] if len(parts) > 2 else ""
+                anchor_start, anchor_end = old.startswith("^"), old.endswith("$")
+                pat = old[1:] if anchor_start else old
+                pat = pat[:-1] if anchor_end else pat
+                if not pat:
+                    pass
+                elif "g" in flags and not (anchor_start or anchor_end):
+                    val = val.replace(pat, new)
+                elif anchor_start and val.startswith(pat):
+                    val = new + val[len(pat) :]
+                elif anchor_end and val.endswith(pat):
+                    val = val[: -len(pat)] + new
+                elif not (anchor_start or anchor_end):
+                    val = val.replace(pat, new, 1)
         return val
 
     def get(self, name: str, default: str = "") -> str:

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -64,22 +64,27 @@ from pathlib import Path
 # Just enough of bsd.port.mk's variable semantics to read a pfSense pkg port:
 # =/?=/+=/:= assignments, line continuations, # comments, ${VAR}/$(VAR) and a
 # couple of :modifiers. .include lines are ignored — we seed the framework
-# variables the port relies on (PREFIX, DATADIR, PYTHON_*, install macros, …).
-# Target recipes (do-install, post-extract, …) are captured verbatim, joined on
+# variables the port relies on (PREFIX, DATADIR, PYTHON_*, install macros, …) —
+# while a conditional/loop directive (.if/.for/…) is a hard error: the evaluator
+# has no branch logic, so skipping one would silently drop port logic. Dep-port
+# mining passes lenient_directives (see _read_dep_port). Target recipes
+# (do-install, post-extract, …) are captured verbatim, joined on
 # backslash-continuation, and run later by the recipe interpreter.
 # --------------------------------------------------------------------------- #
 
 
 class Makefile:
     _ASSIGN = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*(\?=|\+=|:=|=)\s*(.*)$")
+    _BRANCH_DIRECTIVE = re.compile(r"^\.\s*(if\w*|elif\w*|else|endif|for|endfor)\b")
 
-    def __init__(self, path: Path, seed: dict[str, str]):
+    def __init__(self, path: Path, seed: dict[str, str], *, lenient_directives: bool = False):
         self.vars: dict[str, str] = dict(seed)
         # Assignment order matters for ?= (only set if unset). Keep raw values;
         # expand lazily so later-defined vars are visible (ports are order-tolerant
         # for our reads because we expand at access time).
         self.recipes: dict[str, list[str]] = {}
         self._raw: dict[str, tuple[str, str]] = {}  # name -> (op, value) last write
+        self._lenient_directives = lenient_directives
         self._parse(path)
 
     def _parse(self, path: Path) -> None:
@@ -115,7 +120,18 @@ class Makefile:
             if not stripped or stripped.startswith("#"):
                 cur_target = None
                 continue
-            if stripped.startswith(".include") or stripped.startswith("."):
+            if stripped.startswith("."):
+                # .include <bsd.port.mk> is deliberately ignored (the framework
+                # vars are seeded). A conditional/loop would silently lose the
+                # logic it guards if skipped — fail loud instead. Dep-port
+                # mining (best-effort PKGBASE/PORTVERSION reads over real ports
+                # tree Makefiles, which routinely carry .if blocks) stays
+                # lenient — the guard protects the port actually being built.
+                if not self._lenient_directives and self._BRANCH_DIRECTIVE.match(stripped):
+                    raise BuildError(
+                        f"unsupported Makefile directive {stripped.split()[0]!r} — the evaluator has no "
+                        f"conditional/loop support; teach build-pkg-portable.py (line: {stripped!r})"
+                    )
                 cur_target = None
                 continue
             # Target header:  name:  (possibly with deps after the colon)
@@ -199,12 +215,44 @@ class Makefile:
         return self.expand(val, depth + 1)
 
     @staticmethod
+    def _split_mods(mods: str) -> list[str]:
+        # Split a :modifier chain on ':', keeping an :S<delim>old<delim>new<delim>[flags]
+        # group intact even when its body contains ':' (e.g. a URL) — a blind
+        # split(':') would mangle it silently. Backslash escapes a delimiter.
+        out: list[str] = []
+        i = 0
+        n = len(mods)
+        while i < n:
+            if mods[i] == "S" and i + 1 < n:
+                delim = mods[i + 1]
+                j = i + 2
+                seen = 0
+                while j < n and seen < 2:
+                    if mods[j] == "\\":
+                        j += 2
+                        continue
+                    if mods[j] == delim:
+                        seen += 1
+                    j += 1
+                while j < n and mods[j] != ":":  # trailing [1g] flags
+                    j += 1
+                out.append(mods[i:j])
+                i = j + 1
+            else:
+                j = mods.find(":", i)
+                if j < 0:
+                    out.append(mods[i:])
+                    return out
+                out.append(mods[i:j])
+                i = j + 1
+        return out
+
+    @staticmethod
     def _apply_mods(val: str, mods: str) -> str:
         # Minimal :H (dirname), :T (basename), :R (root), :E (ext), and :S/old/new/[g]
         # (string substitution — used to strip the pfSense-pkg- prefix for the info.xml
         # registration <name>). Enough for the recipes we run; extend if a port needs more.
-        # Split on ':' but keep an :S/.../.../ group intact (its body has no ':').
-        for mod in mods.split(":"):
+        for mod in Makefile._split_mods(mods):
             if mod == "H":
                 val = os.path.dirname(val)
             elif mod == "T":
@@ -463,7 +511,22 @@ class Recipe:
         pattern, repl = parts[0], parts[1]
         flags = parts[2] if len(parts) > 2 else ""
         # The pfSense ports only substitute literal %%TOKEN%% placeholders, so a
-        # literal replace is faithful and avoids BRE/ERE ambiguity. 'g' => all.
+        # literal replace is faithful and avoids BRE/ERE ambiguity. Guard that
+        # assumption: a pattern with regex metachars, or a replacement using
+        # sed's & / \N backreferences, would be applied wrongly — fail loud.
+        # Allowed pattern chars are only those that mean themselves in every sed
+        # dialect (BRE/ERE) — notably NO '.', which would silently match any char.
+        if not re.fullmatch(r"[A-Za-z0-9_% /-]+", pattern):
+            raise BuildError(
+                f"sed pattern {pattern!r} is not literal-safe — the emulation does literal "
+                f"replacement only; teach build-pkg-portable.py real regex support"
+            )
+        if "&" in repl or re.search(r"\\\d", repl):
+            raise BuildError(
+                f"sed replacement {repl!r} uses & or a \\N backreference — the emulation does "
+                f"literal replacement only; teach build-pkg-portable.py real regex support"
+            )
+        # 'g' => all.
         if "g" in flags:
             return text.replace(pattern, repl)
         out = []
@@ -622,7 +685,11 @@ def _read_dep_port(makefile: Path, flavor: str, seed: dict[str, str]) -> tuple[s
     if not makefile.is_file():
         return "", ""
     try:
-        mk = Makefile(makefile, seed)
+        # Real ports-tree dep Makefiles routinely carry .if/.for blocks; this is
+        # a best-effort PKGBASE/PORTVERSION read (exact versions come from
+        # --repo-catalogue), so directives stay ignored here — the hard
+        # directive guard protects only the port actually being built.
+        mk = Makefile(makefile, seed, lenient_directives=True)
     except Exception:
         return "", ""
     portname = mk.get("PORTNAME")
@@ -939,22 +1006,38 @@ def build_scripts(mk: Makefile, filesdir: Path) -> dict[str, str]:
     for name in sub_files:
         key = _SCRIPT_KEYS.get(name)
         if key is None:
-            continue
+            # A real `make package` would process it (e.g. pkg-message -> the
+            # +DISPLAY message, pkg-*.lua -> lua_scripts) — shipping without it
+            # would be a silently incomplete package.
+            raise BuildError(
+                f"SUB_FILES names {name!r}, which is not a pkg script this tool models "
+                f"(known: {', '.join(sorted(_SCRIPT_KEYS))}) — teach build-pkg-portable.py"
+            )
         src = filesdir / f"{name}.in"
         if not src.is_file():
             raise BuildError(f"SUB_FILES references {name} but {src} is missing")
         body = src.read_text()
         body = _sub_tokens(body, sub_list)
+        if "%%" in body:
+            bad = next(ln for ln in body.splitlines() if "%%" in ln)
+            raise BuildError(f"unresolved %%token%% in {name}.in after SUB_LIST substitution: {bad.strip()!r}")
         # pkg create embeds the script without its trailing newline.
         scripts[key] = body.rstrip("\n")
     return scripts
 
 
 def _parse_sub_list(mk: Makefile) -> dict[str, str]:
+    # The framework seeds SUB_LIST with PREFIX/LOCALBASE/DATADIR plus DOCSDIR/
+    # EXAMPLESDIR/WWWDIR/ETCDIR (bsd.port.mk); the dir values are seeded in
+    # seed_vars. PORTNAME/PORTVERSION ride along for the pfSense scripts.
     sub: dict[str, str] = {
         "PREFIX": mk.get("PREFIX"),
         "LOCALBASE": mk.get("LOCALBASE"),
         "DATADIR": mk.get("DATADIR"),
+        "DOCSDIR": mk.get("DOCSDIR"),
+        "EXAMPLESDIR": mk.get("EXAMPLESDIR"),
+        "WWWDIR": mk.get("WWWDIR"),
+        "ETCDIR": mk.get("ETCDIR"),
         "PORTNAME": mk.get("PORTNAME"),
         "PORTVERSION": mk.get("PORTVERSION"),
     }
@@ -1114,7 +1197,8 @@ def abi_to_arch(abi: str) -> str:
         "amd64": "x86:64",
         "i386": "x86:32",
         "aarch64": "aarch64:64",
-        "armv7": "armv7:32",
+        # Triplets per machine_arch_translation[] in libpkg/pkg_abi.c.
+        "armv7": "armv7:32:el:eabi:hardfp",
         "powerpc64": "powerpc:64:eb",
         "powerpc64le": "powerpc:64:el",
     }
@@ -1127,6 +1211,9 @@ def abi_to_arch(abi: str) -> str:
 
 def compute_pkgversion(mk: Makefile) -> str:
     ver = mk.get("PORTVERSION") or mk.get("DISTVERSION")
+    # bsd.port.mk: PKGVERSION = ${PORTVERSION:C/[-_,]/./g}… — the framework maps
+    # '-'/'_'/',' in PORTVERSION to '.' before appending revision/epoch.
+    ver = re.sub(r"[-_,]", ".", ver)
     rev = mk.get("PORTREVISION").strip()
     epoch = mk.get("PORTEPOCH").strip()
     if rev and rev != "0":
@@ -1177,6 +1264,11 @@ def seed_vars(portdir: Path, workdir: Path, py_flavor: str) -> dict[str, str]:
         "PREFIX": prefix,
         "LOCALBASE": prefix,
         "DATADIR": "${PREFIX}/share/${PORTNAME}",
+        # Framework dir defaults the SUB_LIST seeds reference (bsd.port.mk).
+        "DOCSDIR": "${PREFIX}/share/doc/${PORTNAME}",
+        "EXAMPLESDIR": "${PREFIX}/share/examples/${PORTNAME}",
+        "WWWDIR": "${PREFIX}/www/${PORTNAME}",
+        "ETCDIR": "${PREFIX}/etc/${PORTNAME}",
         "FILESDIR": str(portdir / "files"),
         "WRKDIR": str(workdir / "work"),
         "WRKSRC": "${WRKDIR}/${DISTNAME}",

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -89,6 +89,34 @@ def test_makefile_comment_stripping(tmp_path: Path) -> None:
     assert mk.get("X") == "value"
 
 
+@pytest.mark.parametrize(
+    "directive",
+    [".if defined(X)", ".ifdef X", ".for f in a b", ".else", ".elif ${X}", ".endif", ".endfor"],
+)
+def test_makefile_conditional_directive_is_a_hard_error(tmp_path: Path, directive: str) -> None:
+    # The evaluator has no branch logic: silently skipping a conditional/loop
+    # would silently drop the port logic it guards (issue #727 finding 3a).
+    with pytest.raises(bpp.BuildError, match="directive"):
+        make_mk(tmp_path, f"A=\t1\n{directive}\n")
+
+
+def test_makefile_include_stays_ignored(tmp_path: Path) -> None:
+    # .include <bsd.port.mk> is the one dot-directive every port legitimately
+    # carries — it must keep parsing cleanly (the framework vars are seeded).
+    mk = make_mk(tmp_path, "A=\t1\n.include <bsd.port.mk>\n")
+    assert mk.get("A") == "1"
+
+
+def test_read_dep_port_tolerates_conditionals(tmp_path: Path) -> None:
+    # Behaviour-preserving pin: dep-port mining is best-effort over REAL ports
+    # tree Makefiles (php83, jq, …), which routinely carry .if blocks — the
+    # directive hard-error must NOT apply there or every real build would break.
+    ports = tmp_path / "ports"
+    write_port(ports, "misc/dep", "PORTNAME=\tdep\nPORTVERSION=\t2.5\n.if defined(NEVER)\n.endif\n")
+    seed = {"PORTREVISION": "0", "PORTEPOCH": "0"}
+    assert bpp._read_dep_port(ports / "misc/dep/Makefile", "", seed) == ("dep", "2.5")
+
+
 def test_makefile_line_continuation_and_recipe_capture(tmp_path: Path) -> None:
     mk = make_mk(
         tmp_path,
@@ -111,7 +139,18 @@ def test_makefile_line_continuation_and_recipe_capture(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     "ver,rev,epoch,expected",
-    [("1.0", "", "", "1.0"), ("1.0", "2", "", "1.0_2"), ("1.0", "0", "", "1.0"), ("1.0", "2", "3", "1.0_2,3")],
+    [
+        ("1.0", "", "", "1.0"),
+        ("1.0", "2", "", "1.0_2"),
+        ("1.0", "0", "", "1.0"),
+        ("1.0", "2", "3", "1.0_2,3"),
+        # bsd.port.mk: PKGVERSION = ${PORTVERSION:C/[-_,]/./g}… — '-'/'_'/',' in
+        # PORTVERSION become '.' BEFORE the _REV/,EPOCH suffixes are appended
+        # (else a '4.0.0-rc1' edit would break the <name>-<version>.pkg split).
+        ("4.0.0-rc1", "", "", "4.0.0.rc1"),
+        ("4.0.0-rc1", "2", "", "4.0.0.rc1_2"),
+        ("1_0,x", "", "", "1.0.x"),
+    ],
 )
 def test_compute_pkgversion(tmp_path: Path, ver: str, rev: str, epoch: str, expected: str) -> None:
     text = f"PORTVERSION=\t{ver}\n"
@@ -134,6 +173,9 @@ def test_compute_pkgversion(tmp_path: Path, ver: str, rev: str, epoch: str, expe
         # big-endian "eb", little-endian "el".
         ("FreeBSD:15:powerpc64le", "freebsd:15:powerpc:64:el"),
         ("FreeBSD:15:powerpc64", "freebsd:15:powerpc:64:eb"),
+        # armv7 carries the full endian/eabi/float triplet — per pkg's own
+        # machine_arch_translation[] (libpkg/pkg_abi.c), not a bare armv7:32.
+        ("FreeBSD:15:armv7", "freebsd:15:armv7:32:el:eabi:hardfp"),
     ],
 )
 def test_abi_to_arch(abi: str, arch: str) -> None:
@@ -200,6 +242,31 @@ def test_sed_s_unsupported() -> None:
     r = bpp.Recipe.__new__(bpp.Recipe)
     with pytest.raises(bpp.BuildError):
         r._sed_s("text", "y|a|b|")  # only the s command is supported
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "s|a.b|Z|",  # '.' would match any char in real sed; literal replace would miss
+        "s|x[0-9]|Z|",  # character class
+        "s|^a|Z|",  # anchor
+        "s|a\\+|Z|",  # escaped metachar — still not literal-safe
+    ],
+)
+def test_sed_s_rejects_non_literal_pattern(expr: str) -> None:
+    # The emulation is a literal str.replace; a regex pattern would be applied
+    # wrongly with no error (issue #727 finding 3b) — it must fail loud instead.
+    r = bpp.Recipe.__new__(bpp.Recipe)
+    with pytest.raises(bpp.BuildError, match="literal"):
+        r._sed_s("aXb", expr)
+
+
+@pytest.mark.parametrize("expr", ["s|A|B&C|", "s|A|\\1|"])
+def test_sed_s_rejects_ampersand_and_backref_replacement(expr: str) -> None:
+    # sed's & (whole match) and \N (group) have no literal-replace equivalent.
+    r = bpp.Recipe.__new__(bpp.Recipe)
+    with pytest.raises(bpp.BuildError, match="literal"):
+        r._sed_s("A", expr)
 
 
 # --------------------------------------------------------------------------- #
@@ -274,6 +341,50 @@ def test_safe_extract_rejects_traversal(tmp_path: Path) -> None:
     buf.seek(0)
     with tarfile.open(fileobj=buf) as tf2, pytest.raises(bpp.BuildError):
         bpp._safe_extract(tf2, tmp_path / "dest")
+
+
+# --------------------------------------------------------------------------- #
+# Scripts (SUB_FILES -> manifest scripts) — fail-loud guards (issue #727 f.1)
+# --------------------------------------------------------------------------- #
+
+
+def test_build_scripts_unknown_sub_files_name_raises(tmp_path: Path) -> None:
+    # A SUB_FILES entry the tool does not model (pkg-message, pkg-*.lua, …) is
+    # picked up by a real `make package`; skipping it ships an incomplete
+    # package. It must be a hard error naming the file, not a silent continue.
+    files = tmp_path / "files"
+    files.mkdir()
+    (files / "pkg-message.in").write_text("hello\n")
+    mk = make_mk(tmp_path, "PORTNAME=\tx\nSUB_FILES=\tpkg-message\n")
+    with pytest.raises(bpp.BuildError, match="pkg-message"):
+        bpp.build_scripts(mk, files)
+
+
+def test_build_scripts_unresolved_token_raises(tmp_path: Path) -> None:
+    # Mirror parse_plist: a %%TOKEN%% still present after SUB_LIST substitution
+    # would ship literally inside the install script — fail loud instead.
+    files = tmp_path / "files"
+    files.mkdir()
+    (files / "pkg-install.in").write_text("#!/bin/sh\necho %%UNKNOWN%%\n")
+    mk = make_mk(tmp_path, "PORTNAME=\tx\nSUB_FILES=\tpkg-install\n")
+    with pytest.raises(bpp.BuildError, match="UNKNOWN"):
+        bpp.build_scripts(mk, files)
+
+
+def test_build_scripts_framework_sub_list_defaults(tmp_path: Path) -> None:
+    # The framework seeds SUB_LIST with DOCSDIR/EXAMPLESDIR/WWWDIR/ETCDIR too
+    # (bsd.port.mk) — a script using one must get the framework default value,
+    # and the pfSense scripts' %%PORTNAME%% must keep substituting.
+    files = tmp_path / "files"
+    files.mkdir()
+    (files / "pkg-install.in").write_text("d=%%DOCSDIR%% e=%%EXAMPLESDIR%% w=%%WWWDIR%% c=%%ETCDIR%% n=%%PORTNAME%%\n")
+    seed = bpp.seed_vars(tmp_path, tmp_path / "work", "py311")
+    mk = make_mk(tmp_path, "PORTNAME=\ttestpkg\nSUB_FILES=\tpkg-install\n", seed=seed)
+    scripts = bpp.build_scripts(mk, files)
+    assert scripts["install"] == (
+        "d=/usr/local/share/doc/testpkg e=/usr/local/share/examples/testpkg"
+        " w=/usr/local/www/testpkg c=/usr/local/etc/testpkg n=testpkg"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -558,6 +669,13 @@ def test_end_to_end_plist_drift_aborts(tmp_path: Path) -> None:
         ("aXbXc", "S/X/-/g", "a-b-c"),  # g (global) flag
         ("no-match", "S/zzz/q/", "no-match"),  # no occurrence → unchanged
         ("/usr/local/share/x.txt", "T", "x.txt"),  # pre-existing :T still works
+        # An :S body containing ':' must survive the modifier split intact —
+        # a blind split(':') silently no-ops it (issue #727 finding 3c).
+        ("http://old.example/x", "S|http://old.example|https://new.example|", "https://new.example/x"),
+        ("x a:b y", "S/a:b/c/", "x c y"),
+        # …and the split must resume correctly after the :S group.
+        ("dir/pfSense-pkg-x", "T:S/pfSense-pkg-//", "x"),
+        ("a:b-c", "S/a:b/z/:S/-/./", "z.c"),
     ],
 )
 def test_makefile_apply_mods_substitution(val: str, mods: str, expected: str) -> None:

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -682,6 +682,20 @@ def test_makefile_apply_mods_substitution(val: str, mods: str, expected: str) ->
     assert bpp.Makefile._apply_mods(val, mods) == expected
 
 
+@pytest.mark.parametrize(
+    "mods",
+    [
+        "S/a\\/b/c/",  # escaped delimiter in the body — the old/new split can't interpret it
+        "S/foo",  # unterminated group (no second delimiter)
+    ],
+)
+def test_makefile_apply_mods_rejects_uninterpretable_s_body(mods: str) -> None:
+    # Both shapes previously no-opped SILENTLY (returned the input unchanged) —
+    # worse than a loud failure for a substitution the recipe relies on.
+    with pytest.raises(bpp.BuildError, match=":S modifier"):
+        bpp.Makefile._apply_mods("xxa/bxx", mods)
+
+
 # --------------------------------------------------------------------------- #
 # Nightly overrides (ADR-18 --channel nightly): --pkgversion / --annotate.
 # The pair below is the branch contrast — OFF (release build, default flags) vs


### PR DESCRIPTION
Closes #727.

Implements the compliance-review findings for `scripts/build-pkg-portable.py`. Every fix extends the tool's fail-loud design; **none changes build output for the current three ports** (verified byte-identical, see below).

## Changes

- **Finding 1** — `build_scripts()`: an unknown `SUB_FILES` name (e.g. a future `pkg-message`) and any `%%TOKEN%%` left after `SUB_LIST` substitution are now hard errors (both were silent); `_parse_sub_list()`/`seed_vars()` gain the framework `SUB_LIST` defaults `DOCSDIR`/`EXAMPLESDIR`/`WWWDIR`/`ETCDIR` (values per `bsd.port.mk`).
- **Finding 3** — evaluator guards: conditional/loop directives (`.if`/`.for`/…) hard-error in the built port's Makefile (`.include` stays ignored; dep-port mining stays lenient — real tree Makefiles like `lang/php83` routinely carry `.if` blocks, and that path is best-effort by design); `:S` modifier groups survive a body containing `:` (previously a blind `split(':')` silently no-opped them); the sed emulation rejects non-literal patterns and `&`/`\N` replacements instead of applying them wrongly.
- **Finding 4** — `compute_pkgversion()` applies the framework's `PKGVERSION = ${PORTVERSION:C/[-_,]/./g}` translation before the `_REV`/`,EPOCH` suffixes.
- **Finding 5** — `abi_to_arch()`: `armv7 → armv7:32:el:eabi:hardfp` per libpkg's `machine_arch_translation[]` (the powerpc rows had already been fixed by #714/PR #733).
- **Finding 2** — `build-pkg-linux.yml` no longer claims the retired FreeBSD `build-pkg.yml` oracle is retained; a manual "re-diff the portable `.pkg` against a real `make package` build" step is added to `docs/misc/version-bump-runbook.md` (min-CE bumps / ports-framework moves).
- **Findings 6+7** — `docs/build-pkg-portable.md` gains a "Known benign divergences vs current pkg" section: `1$sha256` vs modern `2$blake2b` file sums, ustar vs pax-restricted, tar uid/gid 0 vs 65534, `licenselogic` `"and"` vs `LICENSE_COMB`, and the absent `FreeBSD_version` annotation (verified in libpkg `utils.c`: os-version check skipped, not fatal — the ADR-20 variant deps remain the real wrong-edition guard).

The two verification gaps the review left open (compact-manifest field subset; `is_valid_os_version()` with no annotation) were closed against `freebsd/pkg` master source first — results recorded on the issue: https://github.com/pfBlockerNG/pfBlockerNG/issues/727#issuecomment-4868673704 (no divergence found; no new finding).

## Verification

- **Red→green**: all 23 new checks fail on the pre-change builder for the exact reason each targets (guards silent, armv7 wrong, version untranslated, `:S`-with-`:` no-opped); green after. `test_read_dep_port_tolerates_conditionals` / `test_makefile_include_stays_ignored` are behaviour-preserving pins and stay green across.
- **Byte-identity**: the devel-channel `.pkg` built with the base (`origin/devel`) builder vs this branch, same inputs (`--local-src`, CE 2.8 facts), is `cmp`-identical.
- **`--dry-run`** against all three local port dirs (`net/pfSense-pkg-pfBlockerNG{,-devel,-nightly}`) still succeeds — no guard fires on the real ports.
- Full suite: 1989 passed; `ruff check` + `ruff format --check` + `mypy tests/` + `markdownlint` clean.

No shipped `src/` files change — no smoke dispatch needed (PR CI + the dry-run gate cover it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portable package generation reliability by tightening Makefile handling, safer substitution rules, and better detection of unsupported or unresolved script tokens.
  * Expanded architecture and version normalization support for more accurate package output.
  * Added clearer handling for dependency-related edge cases and common package metadata differences.

* **Documentation**
  * Updated build and version-bump guidance with portable package validation steps and expected benign output differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->