### PR TITLE
pfblockerng: anchor the reputation masterfile removal grep (#730)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1273,11 +1273,15 @@ EOF
 		# Remove repeat offenders in masterfiles
 		echo '  Removing   [ Block ] IPs'
 		: > "${tempfile}"
-		# Each dedupfile line is 'header 10.0.0.[0/24]' -- a literal whole token,
-		# no anchor needed, so match it with grep -F (the '.' is a literal dot).
+		# Each dedupfile line is '<alias> 10.0.0.'. Anchor it at column 0 and escape
+		# the prefix's dots (via pfb_anchor_octet_pattern; the alias field is \w-only,
+		# so escaping the dots is sufficient) so the removal grep matches ONLY this
+		# alias's own rows in that /24. An unanchored grep -F over-matched a SIBLING
+		# alias whose name ends with this one's (e.g. row 'XMYLIST 1.2.3.9' contains
+		# the substring 'MYLIST 1.2.3.'), silently dropping its masterfile entry (#730).
 		while IFS= read -r ips; do
 			[ -z "${ips}" ] && continue
-			grep -F "${ips}" "${masterfile}" >> "${tempfile}"
+			grep "$(pfb_anchor_octet_pattern "${ips}")" "${masterfile}" >> "${tempfile}"
 		done < "${dedupfile}"
 		countb="$(grep -c ^ "${tempfile}")"
 		# #713: gate the publish on awk's own exit status (awk has no "empty
@@ -1358,11 +1362,15 @@ EOF
 		# Remove repeat offenders in masterfile
 		echo '  Removing   [ Block ] IPs'
 		: > "${tempfile}"
-		# Each dedupfile line is 'header 10.0.0.' -- a literal whole token, no
-		# anchor needed, so match it with grep -F (the '.' is a literal dot).
+		# Each dedupfile line is '<alias> 10.0.0.'. Anchor it at column 0 and escape
+		# the prefix's dots (via pfb_anchor_octet_pattern; the alias field is \w-only,
+		# so escaping the dots is sufficient) so the removal grep matches ONLY this
+		# alias's own rows in that /24. An unanchored grep -F over-matched a SIBLING
+		# alias whose name ends with this one's (e.g. row 'XMYLIST 1.2.3.9' contains
+		# the substring 'MYLIST 1.2.3.'), silently dropping its masterfile entry (#730).
 		while IFS= read -r ips; do
 			[ -z "${ips}" ] && continue
-			grep -F "${ips}" "${masterfile}" >> "${tempfile}"
+			grep "$(pfb_anchor_octet_pattern "${ips}")" "${masterfile}" >> "${tempfile}"
 		done < "${dedupfile}"
 		countb="$(grep -c ^ "${tempfile}")"
 		# #713: gate the publish on awk's own exit status (awk has no "empty

--- a/tests/shell/pfblockerng_reputation_masterfile_grep_spec.sh
+++ b/tests/shell/pfblockerng_reputation_masterfile_grep_spec.sh
@@ -1,0 +1,92 @@
+#shellcheck shell=sh
+# reputation_dmax()/reputation_pmax() masterfile block-removal grep (#730) --
+# pins the sibling-alias over-match at the "Removing [ Block ] IPs" tail of both
+# functions.
+#
+# Each dedupfile line is '<alias> 10.0.0.' and the removal step subtracts every
+# matching masterfile row so the aggregated '10.0.0.0/24' can replace them. The
+# pre-fix code matched with an UNANCHORED `grep -F "${ips}"`, so the substring
+# 'MYLIST 1.2.3.' also matched a SIBLING alias whose name ends with this one's
+# and whose IP is in the same /24 -- e.g. the row 'XMYLIST 1.2.3.9/32' contains
+# 'MYLIST 1.2.3.' -- and the follow-up awk then stripped that unrelated alias's
+# entry from masterfile. Same bug class as #728/#714, on the '<alias> <ip>' field.
+#
+# Transition proven both ways per case: the offender's OWN /24 rows ARE removed
+# (so the removal genuinely ran, not a no-op) while the sibling's row SURVIVES.
+
+Describe 'reputation_dmax() masterfile block removal (#730)'
+  # shellcheck disable=SC2034  # consumed by the sourced reputation_dmax()
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/repdmaxmf.XXXXXX")"
+    pfbdeny="${work}/deny/"; pfbmatch="${work}/match/"
+    mkdir -p "$pfbdeny" "$pfbmatch"
+    tmpdir="${work}"
+    tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"
+    matchfile="${work}/t7"; tempmatchfile="${work}/t8"
+    dedupfile="${work}/d4"; addfile="${work}/d5"; : > "$dedupfile"; : > "$addfile"
+    masterfile="${work}/master"; mastercat="${work}/mastercat"
+    pathgeoip="${work}/mmdblookup"
+    pathgeoipdat="${work}/geo.mmdb"; touch "$pathgeoipdat"
+    ip_placeholder='240.0.0.0'
+    ip_placeholder3="$(echo "${ip_placeholder}" | cut -d '.' -f 1-3)"
+    now="now"
+    count=0; countb=0; counts=0; countr=0
+    dedup="off"; ccwhite="match"; ccblack="block"; cc="US"
+    matchdedup="matchdedup_v4.txt"
+    max=1
+    # One /24 with >max members in the MYLIST outfile -> a repeat offender.
+    printf '1.2.3.4\n1.2.3.5\n1.2.3.6\n' > "${pfbdeny}MYLIST.txt"
+    # masterfile rows are '<alias> <cidr>'. MYLIST's own row must be removed;
+    # XMYLIST (a DIFFERENT alias whose name ends with 'MYLIST', same /24) must
+    # survive -- the substring 'MYLIST 1.2.3.' occurs inside its row.
+    printf 'MYLIST 1.2.3.4/32\nXMYLIST 1.2.3.9/32\n' > "${masterfile}"
+    # A GeoIP miss routes the offender down the block path (empty ${ccheck}).
+    make_geoip_stub "$pathgeoip" 'Could not find an entry for this IP address'
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'removes only the offender alias rows, keeping a sibling alias in the same /24'
+    When call reputation_dmax
+    The status should be success
+    The stdout should include "Reputation - dMax Stats"
+    # The offender's own /24 rows were subtracted (removal actually ran)...
+    The contents of file "${masterfile}" should not include "MYLIST 1.2.3.4/32"
+    # ...but the sibling alias's row -- merely a substring match -- is untouched.
+    The contents of file "${masterfile}" should include "XMYLIST 1.2.3.9/32"
+  End
+End
+
+Describe 'reputation_pmax() masterfile block removal (#730)'
+  # shellcheck disable=SC2034  # consumed by the sourced reputation_pmax()
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/reppmaxmf.XXXXXX")"
+    pfbdeny="${work}/deny/"
+    mkdir -p "$pfbdeny"
+    tmpdir="${work}"
+    tempfile="${work}/t1"; tempfile2="${work}/t2"
+    dedupfile="${work}/d4"; addfile="${work}/d5"; : > "$dedupfile"; : > "$addfile"
+    masterfile="${work}/master"; mastercat="${work}/mastercat"
+    ip_placeholder='240.0.0.0'
+    ip_placeholder3="$(echo "${ip_placeholder}" | cut -d '.' -f 1-3)"
+    now="now"
+    count=0; countb=0
+    max=1
+    printf '1.2.3.4\n1.2.3.5\n1.2.3.6\n' > "${pfbdeny}MYLIST.txt"
+    printf 'MYLIST 1.2.3.4/32\nXMYLIST 1.2.3.9/32\n' > "${masterfile}"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'removes only the offender alias rows, keeping a sibling alias in the same /24'
+    When call reputation_pmax
+    The status should be success
+    The stdout should include "Reputation - pMax Stats"
+    The contents of file "${masterfile}" should not include "MYLIST 1.2.3.4/32"
+    The contents of file "${masterfile}" should include "XMYLIST 1.2.3.9/32"
+  End
+End


### PR DESCRIPTION
Fixes #730.

## Problem

`reputation_dmax()` and `reputation_pmax()` subtract a repeat offender's `/24` from the shared `masterfile` (rows are `<alias> <cidr>`) with an **unanchored fixed-string** grep:

```sh
grep -F "${ips}" "${masterfile}" >> "${tempfile}"
```

`${ips}` is a dedupfile line of the form `<alias> 10.0.0.` (e.g. `MYLIST 1.2.3.`). Because the match is a bare substring, it reaches a **sibling alias** whose name ends with the offender's and whose IP is in the same `/24` — the row `XMYLIST 1.2.3.9/32` contains the substring `MYLIST 1.2.3.`. The follow-up `awk` set-subtraction then strips that unrelated alias's row from `masterfile`, silently dropping its block entry.

This is the same bug class as #728 / #714 (unanchored over-match), on the `<alias> <ip>` field — the variant deferred from #728.

### Correction to the report

The issue's specific example (`grep -F "1.2.3.0/24"` over-matching `OtherAlias 11.2.3.0/24`) does **not** occur: `${ips}` carries the alias header (`MYLIST 1.2.3.`), so the leading `MYLIST ` pins field 1 and a bare leading-digit IP collision can't match. The real over-match is the **alias-suffix** collision described above. The fix (anchor + escape) closes it regardless.

## Fix

Anchor the pattern at column 0 and escape the prefix's dots via the existing `pfb_anchor_octet_pattern()` helper, so the removal grep matches only the offender alias's own rows in that `/24`:

```sh
grep "$(pfb_anchor_octet_pattern "${ips}")" "${masterfile}" >> "${tempfile}"
```

Applied identically at both sites (`reputation_dmax`, `reputation_pmax`) — the only two `grep -F "${ips}"` masterfile-removal sites; `reputation_max()` has no masterfile removal. The alias field is `\w`-only (validated by `pfb_filter`), so escaping the dots is sufficient. Matches the anchoring idiom already used by #714 (`grep "^${header}[[:space:]]"`).

## Test

New `tests/shell/pfblockerng_reputation_masterfile_grep_spec.sh` pins both functions: a sibling alias (`XMYLIST`, name ends with `MYLIST`, IP in the same `/24`) must survive while the offender's own rows are removed. Proven **red on the pre-fix code** (sibling row dropped → `masterfile` only holds the aggregate) and **green after**. Full shellspec suite: 249 examples, 0 failures.

## Out of scope (candidate follow-up)

Two more `grep -F` sites at `pfblockerng.sh:511` and `:517` in `suppress()` (bare-CIDR existence probes — e.g. `grep -F "1.2.3.0/24"` substring-matches `11.2.3.0/24`) are a related but distinct latent collision of the same class: different function, different data shape (no `<alias>` field to anchor on, so #730's `^<alias> <prefix>` fix does not transfer directly), and a different consequence (a boolean probe that can trigger spurious `/24` expansion, not a masterfile-row removal). Left untouched here to keep this fix scoped to #730 — a candidate for its own follow-up issue.
