### PR TITLE
Fix the five coverage-theater tests from the spec-correctness audit (#722)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10411,9 +10411,6 @@ function pfb_collect_localip() {
 						$pfb_localsub[]	= "{$int['ipaddr']}/{$int['subnet']}";
 					}
 				}
-				elseif (is_ipaddrv6($int['ipaddr'])) {
-					$pfb_localsub[] = gen_subnetv6("{$int['ipaddr']}", "{$int['subnet']}") . "/{$int['subnet']}";
-				}
 			}
 			elseif (is_ipaddr($int['ipaddr'])) {
 				$pfb_local[] = "{$int['ipaddr']}";
@@ -10422,10 +10419,12 @@ function pfb_collect_localip() {
 	}
 
 	// Collect runtime IPv6 addresses for inbound/outbound list matching.
-	// Interfaces using a dynamic address mode (track6/dhcp6/SLAAC) store a keyword
-	// in config.xml rather than a literal IPv6 address, so the interface loop above
-	// produces nothing for them.  get_configured_ipv6_addresses() returns the actual
-	// runtime addresses (keyed by friendly interface name) and covers all modes.
+	// pfSense stores an interface's IPv6 assignment under ['ipaddrv6']/['subnetv6'];
+	// ['ipaddr'] (read by the interface loop above) only ever holds the IPv4 value or a
+	// mode keyword (dhcp/pppoe/…) — never an IPv6 literal, static or dynamic. So this
+	// runtime block is the SOLE source of interface-IPv6 locality, for every assignment
+	// mode (static as well as track6/dhcp6/SLAAC): get_configured_ipv6_addresses()
+	// returns the actual runtime addresses (keyed by friendly interface name).
 	$pfb_v6 = get_configured_ipv6_addresses();
 	if (!empty($pfb_v6)) {
 		foreach ($pfb_v6 as $iface => $v6addr) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4656,6 +4656,19 @@ function pfb_alias_delta_batch_clamp(int|string $raw): int {
 }
 
 /**
+ * Resolve a raw POST batch-size field to its clamped stored value.
+ *
+ * An empty field (user cleared it in the UI) means "use the default 512" —
+ * it must NOT cast to (int) '' == 0 and clamp down to the 64 floor.
+ *
+ * @param string $raw  Trimmed raw POST value (may be '').
+ * @return int          Clamped batch size, ready for PfbConfig::write().
+ */
+function pfb_alias_delta_batch_resolve(string $raw): int {
+	return pfb_alias_delta_batch_clamp($raw === '' ? 512 : (int) $raw);
+}
+
+/**
  * Apply an alias-table change via forward delta (-T add / -T delete) or full replace.
  *
  * Decision (when $force_replace is FALSE):

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4709,6 +4709,10 @@ function pfb_apply_alias_delta(
 
 	// Force replace: boot/enable-disable initial load path.
 	if ($force_replace || $mode === 'replace') {
+		// issue #722: nothing else on a live box distinguishes the delta path from a
+		// replace (pfb_pfctl_table_op logs only on error) — this line is the sole apply-path
+		// oracle the smoke suite (and a human reading the log) can grep for.
+		pfb_logger(" ADR-40 apply [ {$table} ]: replace\n", 1);
 		pfb_pfctl_table_op($table, 'replace', "-f {$table_file_esc}", $pfctl_bin);
 		return FALSE;
 	}
@@ -4722,9 +4726,14 @@ function pfb_apply_alias_delta(
 
 	// Churn-ratio fallback: auto mode with large churn → replace.
 	if ($mode === 'auto' && $table_size > 0 && ($churn / $table_size) >= PFB_DELTA_CHURN_THRESHOLD) {
+		pfb_logger(" ADR-40 apply [ {$table} ]: replace\n", 1);
 		pfb_pfctl_table_op($table, 'replace', "-f {$table_file_esc}", $pfctl_bin);
 		return FALSE;
 	}
+
+	// issue #722: log the delta decision (incl. the zero-churn idempotent no-op below) so the
+	// delta path is just as observable on a live box as the replace path logged above.
+	pfb_logger(" ADR-40 apply [ {$table} ]: delta +" . count($add_set) . '/-' . count($del_set) . "\n", 1);
 
 	// Idempotence: empty delta → zero pfctl calls.
 	if (empty($add_set) && empty($del_set)) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -236,7 +236,7 @@ if ($_POST) {
 			// ADR-40: batch size — clamp to [64, 4096].  An empty field (user
 			// cleared the value) must default to 512, not cast to 0 and clamp to 64.
 			$_pfb_batch_raw = trim((string) ($_POST['pfb_alias_delta_batch'] ?? ''));
-			PfbConfig::write('pfb_alias_delta_batch', (string) pfb_alias_delta_batch_clamp($_pfb_batch_raw === '' ? 512 : (int) $_pfb_batch_raw));
+			PfbConfig::write('pfb_alias_delta_batch', (string) pfb_alias_delta_batch_resolve($_pfb_batch_raw));
 
 			PfbConfig::writeSection('installedpackages/pfblockerngipsettings/config/0', $pfb['iconfig']);
 			write_config('[pfBlockerNG] save IP settings');

--- a/tests/php/AliasDeltaApplyTest.php
+++ b/tests/php/AliasDeltaApplyTest.php
@@ -68,6 +68,14 @@ final class AliasDeltaApplyTest extends TestCase
 		@mkdir($this->tmp, 0777, TRUE);
 		$this->pfctl_call_log = "{$this->tmp}/pfctl_calls.txt";
 
+		// issue #722: pfb_apply_alias_delta() now calls pfb_logger(), which writes to the
+		// process-global $pfb['log'] (seeded by tests/php/bootstrap.php under $g['varlog_path']).
+		// That directory is only created on demand by the tests that need it (see
+		// LiveLogTailPayloadTest / LiveLogPkgMirrorTest) — ensure it exists here too, so this
+		// class does not depend on another test class having run first in the same process.
+		global $pfb;
+		@mkdir($pfb['logdir'], 0777, TRUE);
+
 		// Write a mock pfctl that records every invocation.
 		// The mock records: "T <flag> <table> <file_content_lines>" per call.
 		// It also accepts -t <table> -T add/delete/replace -f <file> and logs them.
@@ -138,6 +146,25 @@ SH
 		$content = empty($entries) ? '' : implode("\n", $entries) . "\n";
 		file_put_contents($path, $content);
 		return $path;
+	}
+
+	/**
+	 * issue #722: count occurrences of $marker in the CURRENT pfBlockerNG log
+	 * (global $pfb['log'], seeded to a writable sandbox path by tests/php/bootstrap.php).
+	 *
+	 * pfb_apply_alias_delta() is the ONLY thing under test that writes ADR-40 apply-path
+	 * markers, so a before/after delta around a single call isolates that call's decision
+	 * even though the log file is shared process-wide across every test in this run —
+	 * the same before/after-count discipline the live-VM smoke suite uses on its log.
+	 */
+	private function countLogMarker(string $marker): int
+	{
+		global $pfb;
+		$contents = @file_get_contents($pfb['log'] ?? '');
+		if ($contents === FALSE || $contents === '') {
+			return 0;
+		}
+		return substr_count($contents, $marker);
 	}
 
 	// -----------------------------------------------------------------------
@@ -232,7 +259,9 @@ SH
 	 * Given a 1000-entry table with 1-entry churn (0.1% << 5% threshold).
 	 * Before: pfb_apply_alias_delta returns FALSE (we'll verify the path).
 	 * When mode='auto' and churn_ratio=0.001 < PFB_DELTA_CHURN_THRESHOLD.
-	 * Then returns TRUE (delta path taken).
+	 * Then returns TRUE (delta path taken) AND (issue #722) the ONLY on-box signal that
+	 *   distinguishes delta from replace — the " ADR-40 apply [ <table> ]: delta …" log
+	 *   line — was emitted for this table (not the "…: replace" shape).
 	 */
 	public function testSmallChurnAutoModeUsesDeltaPath(): void
 	{
@@ -259,6 +288,12 @@ SH
 		$large_file    = $this->write_alias_file('pfB_Large_v4', $large_desired);
 		@unlink($this->pfctl_call_log);
 
+		// issue #722: before-state — no delta/replace apply-path marker logged yet for this table.
+		$delta_marker   = ' ADR-40 apply [ pfB_Large_v4 ]: delta +';
+		$replace_marker = ' ADR-40 apply [ pfB_Large_v4 ]: replace';
+		$delta_before   = $this->countLogMarker($delta_marker);
+		$replace_before = $this->countLogMarker($replace_marker);
+
 		$used_delta = pfb_apply_alias_delta(
 			$this->pfctl(), 'pfB_Large_v4', $large_file,
 			$large_desired, $large_base, 'auto', 256
@@ -266,6 +301,17 @@ SH
 
 		$this->assertTrue($used_delta,
 			'expected: delta path (TRUE); actual: replace path (FALSE) — churn=1/100=1% < 5% threshold');
+
+		// Then (issue #722) — the delta apply-path marker was logged for THIS table, and the
+		// replace marker was NOT (proves the log call sits on the delta branch, not both).
+		$delta_after   = $this->countLogMarker($delta_marker);
+		$replace_after = $this->countLogMarker($replace_marker);
+		$this->assertSame($delta_before + 1, $delta_after,
+			"expected: one new ' ADR-40 apply [ pfB_Large_v4 ]: delta +…' log line "
+			. "(before={$delta_before}, after={$delta_after}) — apply-path observability regressed");
+		$this->assertSame($replace_before, $replace_after,
+			"expected: NO new '…: replace' log line for a delta apply "
+			. "(before={$replace_before}, after={$replace_after}) — delta wrongly logged as replace");
 	}
 
 	// -----------------------------------------------------------------------
@@ -277,7 +323,10 @@ SH
 	 *
 	 * Given a 100-entry table with 30-entry churn (30% > 5% threshold).
 	 * When mode='auto'.
-	 * Then returns FALSE (replace path taken).
+	 * Then returns FALSE (replace path taken) AND (issue #722) the auto-mode large-churn
+	 *   fallback logs the same "…: replace" apply-path marker as the explicit mode=replace
+	 *   branch (Scenario D) — proving every replace call site is observable, not just the
+	 *   explicit-mode one.
 	 */
 	public function testLargeChurnAutoModeFallsBackToReplace(): void
 	{
@@ -286,8 +335,10 @@ SH
 		$desired = array_map(fn($i) => "10.0.{$i}.1", range(70, 129)); // 60 new, 30 shared -> 70 churn
 		$table_file = $this->write_alias_file($table, $desired);
 
-		// Before: no calls.
+		// Before: no calls, no apply-path marker logged yet for this table.
 		$this->assertFileDoesNotExist($this->pfctl_call_log, 'before: no pfctl calls yet');
+		$replace_marker = " ADR-40 apply [ {$table} ]: replace";
+		$replace_before = $this->countLogMarker($replace_marker);
 
 		// When
 		$used_delta = pfb_apply_alias_delta(
@@ -305,6 +356,13 @@ SH
 		$replace_calls = array_filter($calls, fn($c) => $c['action'] === 'replace');
 		$this->assertNotEmpty($replace_calls,
 			"expected: at least one 'replace' pfctl call; actual calls: " . json_encode($calls));
+
+		// Then (issue #722) — the auto-mode large-churn fallback logged the replace marker.
+		$replace_after = $this->countLogMarker($replace_marker);
+		$this->assertSame($replace_before + 1, $replace_after,
+			"expected: one new ' ADR-40 apply [ {$table} ]: replace' log line from the auto-mode "
+			. "large-churn fallback (before={$replace_before}, after={$replace_after}) — "
+			. "apply-path observability regressed");
 	}
 
 	// -----------------------------------------------------------------------
@@ -316,7 +374,14 @@ SH
 	 *
 	 * Given any churn level.
 	 * When mode='replace'.
-	 * Then returns FALSE (replace path) regardless of churn ratio.
+	 * Then returns FALSE (replace path) regardless of churn ratio, AND (issue #722) the
+	 *   " ADR-40 apply [ <table> ]: replace" apply-path marker is logged — the sole
+	 *   on-box signal a live-VM smoke test (or a human) can use to prove replace, not
+	 *   delta, actually ran (pfb_pfctl_table_op itself logs only on error).
+	 *
+	 * RED proof (issue #722): comment out the new pfb_logger() call on the mode==='replace'
+	 * branch in pfb_apply_alias_delta() — this test's marker assertion fails (0 occurrences)
+	 * while every other assertion in this file still passes; restoring the call turns it green.
 	 */
 	public function testModeReplaceAlwaysUsesReplace(): void
 	{
@@ -328,6 +393,9 @@ SH
 		// Before: asserting that mode=auto would take delta (churn ratio matters less here
 		// since table_size=1, churn=1/1=100%, but let's use mode=replace explicitly).
 		// The key assertion is: mode=replace → replace.
+		$replace_marker = " ADR-40 apply [ {$table} ]: replace";
+		$replace_before = $this->countLogMarker($replace_marker);
+
 		$used_delta = pfb_apply_alias_delta(
 			$this->pfctl(), $table, $table_file,
 			$desired, $last, 'replace', 256
@@ -340,6 +408,12 @@ SH
 		$replace_calls = array_filter($calls, fn($c) => $c['action'] === 'replace');
 		$this->assertNotEmpty($replace_calls,
 			"expected: replace pfctl call; actual calls: " . json_encode($calls));
+
+		// Then (issue #722) — the replace apply-path marker was logged for this table.
+		$replace_after = $this->countLogMarker($replace_marker);
+		$this->assertSame($replace_before + 1, $replace_after,
+			"expected: one new ' ADR-40 apply [ {$table} ]: replace' log line "
+			. "(before={$replace_before}, after={$replace_after}) — apply-path observability regressed");
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/AliasDeltaApplyTest.php
+++ b/tests/php/AliasDeltaApplyTest.php
@@ -17,6 +17,11 @@ use PHPUnit\Framework\TestCase;
  *   pfb_alias_delta_batch_clamp(int|string $raw): int
  *     Clamps a batch-size value to [64, 4096].
  *
+ *   pfb_alias_delta_batch_resolve(string $raw): int
+ *     Resolves a raw (trimmed) POST batch-size field to its clamped stored
+ *     value — '' means "use the default 512", never (int) '' == 0.  This is
+ *     the exact function pfblockerng_ip.php's save path calls.
+ *
  *   pfb_apply_alias_delta(
  *       string $pfctl_bin, string $table, string $table_file,
  *       array $desired_set, array $last_set,
@@ -41,6 +46,7 @@ use PHPUnit\Framework\TestCase;
  *   J — off-by-one detection: a deliberate off-by-one in delta set is caught.
  */
 #[CoversFunction('pfb_alias_delta_batch_clamp')]
+#[CoversFunction('pfb_alias_delta_batch_resolve')]
 #[CoversFunction('pfb_apply_alias_delta')]
 final class AliasDeltaApplyTest extends TestCase
 {
@@ -549,30 +555,32 @@ SH
 	 * Scenario H6 — empty-string POST field → default 512, not clamped-to-64.
 	 *
 	 * An HTML form submits an empty string when the user clears the batch-size
-	 * field.  The UI save path must treat '' as "use default 512", not cast to
-	 * int(0) and clamp to 64.  Pinning the fix in pfblockerng_ip.php F1.
+	 * field.  The UI save path (pfblockerng_ip.php) resolves the raw POST value
+	 * through pfb_alias_delta_batch_resolve() — the real production helper, not
+	 * a reimplementation of its ternary — which must treat '' as "use default
+	 * 512", never cast to int(0) and clamp to 64.
 	 *
 	 * Before the fix: (int)'' == 0 → pfb_alias_delta_batch_clamp(0) == 64.
-	 * After the fix: '' → 512 → pfb_alias_delta_batch_clamp(512) == 512.
+	 * After the fix: pfb_alias_delta_batch_resolve('') == 512.
 	 */
 	public function testEmptyStringBatchPostFieldDefaultsTo512(): void
 	{
-		// Simulate the fixed UI save path logic (F1 fix in pfblockerng_ip.php).
-		$raw_empty  = '';
-		$batch_from_empty = pfb_alias_delta_batch_clamp($raw_empty === '' ? 512 : (int) $raw_empty);
+		// Given: the user cleared the batch-size field — POST submits ''.
+		$batch_from_empty = pfb_alias_delta_batch_resolve('');
 
+		// Then: the real UI-save helper resolves it to the 512 default, not 64.
 		$this->assertSame(512, $batch_from_empty,
 			"expected: empty POST field → 512 (not 64); actual: {$batch_from_empty}\n"
 			. "Bug: (int)'' == 0 → clamp(0) == 64 (incorrect default when user clears field)");
 
-		// Before-fix behaviour would produce 64 — ensure we're not checking the wrong thing.
+		// Sanity: an explicit zero (not an empty field) still clamps to the 64 floor —
+		// proves the '' special-case is genuinely distinct from a real zero.
 		$batch_from_zero = pfb_alias_delta_batch_clamp(0);
 		$this->assertSame(64, $batch_from_zero,
-			"sanity: clamp(0) == 64 (pre-fix path result — still correct when int is explicit zero)");
+			"sanity: clamp(0) == 64 (an explicit zero is still a real value, not 'unset')");
 
-		// Out-of-range value still clamps correctly.
-		$raw_oob  = '9999';
-		$batch_from_oob = pfb_alias_delta_batch_clamp($raw_oob === '' ? 512 : (int) $raw_oob);
+		// A non-empty out-of-range POST value still clamps correctly through the same helper.
+		$batch_from_oob = pfb_alias_delta_batch_resolve('9999');
 		$this->assertSame(4096, $batch_from_oob,
 			"expected: out-of-range POST field → clamped to 4096; actual: {$batch_from_oob}");
 	}

--- a/tests/php/CollectLocalIpV6Test.php
+++ b/tests/php/CollectLocalIpV6Test.php
@@ -214,8 +214,9 @@ final class CollectLocalIpV6Test extends TestCase
 		//           in CIDR notation, exactly like the dynamic (track6/dhcp6/SLAAC) case.
 		//
 		// Background:
-		//   pfSense stores a static IPv6 assignment under interfaces[x]['ipaddrv6']/
-		//   ['subnetv6'] (e.g. 'static'/'64') with the literal address in ['ipv6addr'] —
+		//   pfSense stores a static IPv6 assignment with the literal address directly in
+		//   interfaces[x]['ipaddrv6'] and the prefix bits in ['subnetv6'] (dynamic modes
+		//   store a keyword — 'slaac'/'dhcp6'/'track6' — in ['ipaddrv6'] instead);
 		//   interfaces[x]['ipaddr'] holds the IPv4 value or a mode keyword (dhcp/pppoe/…)
 		//   and NEVER an IPv6 literal. So the config-interface loop in
 		//   pfb_collect_localip() (which only reads ['ipaddr']/['subnet']) cannot see a
@@ -232,8 +233,8 @@ final class CollectLocalIpV6Test extends TestCase
 
 		$GLOBALS['config']['interfaces']['lan'] = [
 			'enable'   => '',
-			'ipaddrv6' => 'static',
-			'ipv6addr' => '2001:db8:99:1::1',
+			// Real pfSense schema: a static assignment puts the v6 literal itself here.
+			'ipaddrv6' => '2001:db8:99:1::1',
 			'subnetv6' => '64',
 			// 'ipaddr' never carries a v6 literal for a static assignment — leave it at
 			// the IPv4 default so the config-interface loop contributes nothing for v6.

--- a/tests/php/CollectLocalIpV6Test.php
+++ b/tests/php/CollectLocalIpV6Test.php
@@ -205,37 +205,44 @@ final class CollectLocalIpV6Test extends TestCase
 	}
 
 	// -------------------------------------------------------------------------
-	// Case E — static IPv6 on an interface (literal ipaddr in config.xml)
+	// Case E — static IPv6 on an interface, via the runtime address path
 	// -------------------------------------------------------------------------
 
-	public function testStaticIpv6InterfaceSubnetIsRecognisedAsLocal(): void
+	public function testStaticIpv6IsLocalViaRuntimeAddressesRegardlessOfAssignmentMode(): void
 	{
-		// Scenario: An interface carrying a literal static IPv6 address and subnet must
-		//           be recognised as local via $pfb_localsub in CIDR notation.
+		// Scenario: A STATIC IPv6 interface must be recognised as local via $pfb_localsub
+		//           in CIDR notation, exactly like the dynamic (track6/dhcp6/SLAAC) case.
 		//
 		// Background:
-		//   pfb_collect_localip() processes config interfaces.  When 'ipaddr' holds a
-		//   literal IPv6 address (static assignment, not a keyword like 'track6'), it
+		//   pfSense stores a static IPv6 assignment under interfaces[x]['ipaddrv6']/
+		//   ['subnetv6'] (e.g. 'static'/'64') with the literal address in ['ipv6addr'] —
+		//   interfaces[x]['ipaddr'] holds the IPv4 value or a mode keyword (dhcp/pppoe/…)
+		//   and NEVER an IPv6 literal. So the config-interface loop in
+		//   pfb_collect_localip() (which only reads ['ipaddr']/['subnet']) cannot see a
+		//   static IPv6 either — static and dynamic v6 both rely on the single runtime
+		//   block that calls get_configured_ipv6_addresses() + get_interface_subnetv6(),
+		//   which reports the live address for EVERY v6 mode alike. That runtime block
 		//   calls gen_subnetv6(addr, bits) and MUST append "/{bits}" to form CIDR
-		//   notation before storing in $pfb_localsub.  Before the fix the bare network
-		//   address was stored (e.g. "2001:db8:1:2::"), so ip_in_subnet() failed to
-		//   match hosts inside the prefix.
+		//   notation before storing in $pfb_localsub, or ip_in_subnet() fails to match
+		//   hosts inside the prefix.
 		//
-		// Given  a LAN interface with a static IPv6 2001:db8:99:1::1/64
+		// Given  a LAN interface whose static IPv6 resolves at runtime to 2001:db8:99:1::1/64
 		// When   pfb_collect_localip() is called
 		// Then   a host inside the /64 (e.g. 2001:db8:99:1::abcd) is recognised as local
 
 		$GLOBALS['config']['interfaces']['lan'] = [
-			'enable'  => '',
+			'enable'   => '',
 			'ipaddrv6' => 'static',
 			'ipv6addr' => '2001:db8:99:1::1',
 			'subnetv6' => '64',
-			// Literal IPv6 in the 'ipaddr' field (pfSense stores static IPv6 here):
-			'ipaddr'   => '2001:db8:99:1::1',
-			'subnet'   => '64',
+			// 'ipaddr' never carries a v6 literal for a static assignment — leave it at
+			// the IPv4 default so the config-interface loop contributes nothing for v6.
+			'ipaddr'   => '',
+			'subnet'   => '',
 		];
-		// No runtime configured-ipv6 needed — this goes through the config loop.
-		$GLOBALS['pfb_test_configured_ipv6'] = [];
+		// The static address surfaces through the same runtime lookup as track6/dhcp6/SLAAC.
+		$GLOBALS['pfb_test_configured_ipv6']    = ['lan' => '2001:db8:99:1::1'];
+		$GLOBALS['pfb_test_interface_subnetv6'] = ['lan' => '64'];
 
 		[$pfb_local, $pfb_localsub] = pfb_collect_localip();
 
@@ -246,8 +253,9 @@ final class CollectLocalIpV6Test extends TestCase
 			$isLocal,
 			sprintf(
 				"Host %s inside static IPv6 /64 must be recognised as local.\n"
-				. "pfb_localsub: %s",
+				. "pfb_local keys: %s\npfb_localsub: %s",
 				$host,
+				implode(', ', array_keys($pfb_local)),
 				implode(', ', $pfb_localsub),
 			)
 		);

--- a/tests/shell/pfblockerng_remove_guard_spec.sh
+++ b/tests/shell/pfblockerng_remove_guard_spec.sh
@@ -28,7 +28,9 @@ Describe 'pfblockerng.sh remove() entry guard'
     tempfile="${sandbox}/t1"
     tempfile2="${sandbox}/t2"
     : > "${masterfile}"
-    # A sentinel OUTSIDE the sandbox that an unguarded traversal glob could delete.
+    # A sentinel INSIDE the sandbox, one level above every ${pfb*} prefix dir
+    # (they all live at "${sandbox}/<name>/") -- exactly where a single "../"
+    # traversal in a header/alias lands, so an unguarded glob can delete it.
     sentinel="${sandbox}/SENTINEL"
     : > "${sentinel}"
   }
@@ -64,11 +66,20 @@ Describe 'pfblockerng.sh remove() entry guard'
   It 'skips a per-entry header that contains a traversal sequence'
     setup_sandbox
     # A benign alias passes the entry guard; the malicious value rides the header.
+    # A single "../" from any ${pfb*} prefix (e.g. "${pfborig}" = "${sandbox}/orig/")
+    # resolves EXACTLY to "${sandbox}/SENTINEL" -- the sentinel itself -- so an
+    # unguarded "rm -f ...${header}*" glob would actually reach it. This is what
+    # makes the assertion below a real effect oracle, not a name that never lines
+    # up with anything on disk.
     alias='Benign'
-    cc='../../SENTINEL,'
+    cc='../SENTINEL,'
     When call remove
+    # remove() completes normally: the per-header guard 'continue's past this one
+    # entry (skipping its rm globs) and the function finishes the rest of its work.
+    The status should be success
     The output should include 'Invalid header'
     # Then the sentinel survives — the malicious header never built an rm glob.
+    # If the 'continue' guard were lost, the unguarded glob above would delete it.
     The path "${sentinel}" should be exist
     cleanup_sandbox
   End

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -46,6 +46,8 @@ import threading
 import time
 from collections.abc import Generator, Iterator, Mapping
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from functools import partial
 from http.server import BaseHTTPRequestHandler, SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -753,6 +755,33 @@ def client_vm(
 # --------------------------------------------------------------------------- #
 
 
+# Fixed Last-Modified the mock emits on every registered-feed 200 (unless
+# disable_lastmod() opts a name out): epoch 1700000000 = 2023-11-14T22:13:20Z.
+# Shared by the emitted header string and the enable_lastmod_304() IMS compare
+# so the two can never drift apart.
+_MOCK_LAST_MODIFIED_EPOCH = 1700000000
+_MOCK_LAST_MODIFIED_HTTPDATE = "Tue, 14 Nov 2023 22:13:20 GMT"
+
+
+def _parse_http_date(raw: str) -> datetime | None:
+    """Parse an RFC 7231 HTTP-date request header (``If-Modified-Since``) to an aware UTC datetime.
+
+    Returns ``None`` for an empty/unparsable value — the caller then falls through to a plain
+    200, exactly as a real server would for a header it cannot understand.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        # email.utils returns a naive datetime for an obsolete/no-tz date; HTTP-dates are
+        # always GMT, so treat naive results as UTC rather than the local zone's offset.
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 class _MockFeedServer:
     """A stdlib HTTP server serving feed fixtures to the guest over SLIRP.
 
@@ -764,6 +793,14 @@ class _MockFeedServer:
     headers on 200 replies, and answer ``304 Not Modified`` to a matching
     ``If-None-Match`` request header.  Use :meth:`set_content` to update a feed's
     body and bump its ETag atomically (simulates a real feed update).
+
+    issue #722: two more per-name opt-outs/opt-ins isolate the OTHER two
+    conditional-GET branches that the always-on Last-Modified header masked:
+    :meth:`disable_lastmod` (no validator at all -> exercises the genuine
+    no-validator download+hash path) and :meth:`enable_lastmod_304` (an
+    RFC-conformant ``If-Modified-Since`` responder -> exercises the
+    Last-Modified/``CURLOPT_TIMECONDITION`` fallback, distinct from the
+    ETag/``If-None-Match`` path above).
     """
 
     def __init__(self, root: Path) -> None:
@@ -773,9 +810,18 @@ class _MockFeedServer:
         # in this map serves no ETag (simulates a server that does not support
         # conditional requests).
         self._etag_map: dict[str, str] = {}
+        # issue #722: names in this set get NO Last-Modified header on 200 (the
+        # genuine "no validator at all" server) — default behaviour (no entry)
+        # still emits the fixed Last-Modified below, unchanged for existing tests.
+        self._no_lastmod: set[str] = set()
+        # issue #722: names in this set get a real If-Modified-Since responder
+        # (RFC 9110 §13.1.3) instead of the fixed header being ignored.
+        self._ims_304: set[str] = set()
         self._lock = threading.Lock()
         registered = self._registered
         etag_map = self._etag_map
+        no_lastmod = self._no_lastmod
+        ims_304 = self._ims_304
         lock = self._lock
 
         class Handler(SimpleHTTPRequestHandler):
@@ -785,10 +831,15 @@ class _MockFeedServer:
                 with lock:
                     body = registered.get(name)
                     etag = etag_map.get(name)
+                    emit_lastmod = name not in no_lastmod
+                    honour_ims = name in ims_304
                 if body is None:
                     super().do_GET()
                     return
                 # ADR-42 Phase 3: honour If-None-Match for conditional-GET.
+                # RFC 9110 §13.1.3: a recipient MUST ignore If-Modified-Since when the
+                # request also carries If-None-Match, so this branch always takes
+                # precedence over the IMS handling below for a name that has an ETag.
                 if etag is not None:
                     client_etag = self.headers.get("If-None-Match", "")
                     if client_etag.strip() == etag:
@@ -796,14 +847,28 @@ class _MockFeedServer:
                         self.send_header("ETag", etag)
                         self.end_headers()
                         return
+                elif honour_ims:
+                    # issue #722: RFC-conformant If-Modified-Since — 304 when this
+                    # resource's fixed Last-Modified is NOT newer than the client's
+                    # IMS value (i.e. the client already has the current version).
+                    ims_raw = self.headers.get("If-Modified-Since", "")
+                    ims_dt = _parse_http_date(ims_raw)
+                    if ims_dt is not None:
+                        resource_dt = datetime.fromtimestamp(_MOCK_LAST_MODIFIED_EPOCH, tz=timezone.utc)
+                        if resource_dt <= ims_dt:
+                            self.send_response(304)
+                            self.send_header("Last-Modified", _MOCK_LAST_MODIFIED_HTTPDATE)
+                            self.end_headers()
+                            return
                 self.send_response(200)
                 self.send_header("Content-Type", "text/plain")
                 self.send_header("Content-Length", str(len(body)))
                 if etag is not None:
                     self.send_header("ETag", etag)
-                # Emit a fixed Last-Modified in the past so the guest also has a
-                # validator to store (epoch 1700000000 = 2023-11-14T22:13:20Z).
-                self.send_header("Last-Modified", "Tue, 14 Nov 2023 22:13:20 GMT")
+                if emit_lastmod:
+                    # Emit a fixed Last-Modified in the past so the guest also has a
+                    # validator to store (epoch 1700000000 = 2023-11-14T22:13:20Z).
+                    self.send_header("Last-Modified", _MOCK_LAST_MODIFIED_HTTPDATE)
                 self.end_headers()
                 self.wfile.write(body)
 
@@ -863,6 +928,35 @@ class _MockFeedServer:
         """
         with self._lock:
             self._etag_map[name] = etag
+
+    def disable_lastmod(self, name: str) -> None:
+        """Opt a registered feed OUT of the default Last-Modified header entirely.
+
+        issue #722: the mock emits a fixed Last-Modified on every 200 by default, so a feed
+        registered without :meth:`enable_etag` still leaves the guest with a ``.lastmod``
+        validator — the genuine "server supports no conditional requests at all" case was
+        never actually reachable. A name in this set gets NO Last-Modified (and, since
+        :meth:`enable_etag` was not called either, no ETag) — the guest stores no validator,
+        so every future probe is a plain GET and the download+hash comparison genuinely
+        decides the outcome.
+        """
+        with self._lock:
+            self._no_lastmod.add(name)
+
+    def enable_lastmod_304(self, name: str) -> None:
+        """Make a registered feed answer a matching ``If-Modified-Since`` with a real 304.
+
+        issue #722: without this, the mock's fixed Last-Modified header is emitted but never
+        consulted on the request side, so a stored ``.lastmod`` validator never actually gets
+        a 304 back — the Last-Modified/``CURLOPT_TIMECONDITION`` fallback (the branch used
+        when a feed has no ETag) was unexercised. After this call, a request whose
+        If-Modified-Since is at or after this feed's fixed Last-Modified
+        (epoch 1700000000) gets a 304 (still with the Last-Modified header echoed back);
+        otherwise a plain 200. Has no effect on a name that also carries an ETag — RFC 9110
+        §13.1.3 has If-None-Match take precedence, and the handler enforces that ordering.
+        """
+        with self._lock:
+            self._ims_304.add(name)
 
     def feed_url(self, name: str) -> str:
         """The URL the GUEST uses to fetch ``name`` (via the SLIRP host alias)."""

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -375,6 +375,15 @@ def test_adr40_delta_apply_small_churn(adr40_vm: h.SmokeVM) -> None:
 
     Together with ``test_adr40_delta_replace_mode`` (which uses mode=replace and
     asserts the same end-state) this proves the two apply paths are equivalent.
+
+    issue #722: the end-state invariant alone does NOT distinguish delta from replace
+    — ``test_adr40_delta_replace_mode`` produces the identical pf-table end-state, so a
+    regression that silently routed this "delta" run through -T replace would pass every
+    assertion above unnoticed. ``pfb_apply_alias_delta()`` now logs a
+    " ADR-40 apply [ <table> ]: delta +N/-M" / "…: replace" marker naming the actual
+    apply path taken (pfblockerng.inc ~4711-4736) — the ONLY on-box signal that
+    discriminates the two (``pfb_pfctl_table_op()`` itself logs only on error). This test
+    asserts the DELTA marker fired for this table and the REPLACE marker did NOT.
     """
     token = "p4delta"
     marker = h.hook_marker_path(token, "post")
@@ -409,6 +418,14 @@ def test_adr40_delta_apply_small_churn(adr40_vm: h.SmokeVM) -> None:
             f"before-state: pf table {ip_spec.alias} already has {new_ip}: {members_before}"
         )
 
+        # issue #722: capture the apply-path markers for THIS table right before the change
+        # reload, isolating its own delta/replace decision from the settling reload above
+        # (which force-replaces on first creation) and from any other table in the run.
+        delta_marker = f" ADR-40 apply [ {ip_spec.alias} ]: delta "
+        replace_marker = f" ADR-40 apply [ {ip_spec.alias} ]: replace"
+        delta_before = h.count_log_marker(adr40_vm, h.PFB_LOG, delta_marker)
+        replace_before = h.count_log_marker(adr40_vm, h.PFB_LOG, replace_marker)
+
         # Change the feed; invalidate the reuse cache.
         h.write_local_feed(adr40_vm, feed_file, f"{new_ip}\n")
         h.force_ip_refetch(adr40_vm, f"{ip_spec.header}_{ip_spec.family}")
@@ -423,6 +440,21 @@ def test_adr40_delta_apply_small_churn(adr40_vm: h.SmokeVM) -> None:
             f"ADR-40 P4 delta FAILED: alias {ip_spec.alias!r} absent from PFB_CHANGED_IP_ALIASES.\n"
             f"Got PFB_CHANGED_IP_ALIASES={changed!r}\n"
             f"Feed changed from {old_ip!r} to {new_ip!r}; content-gate should have fired."
+        )
+
+        # issue #722: the apply-path oracle — DELTA marker fired for this table, REPLACE did
+        # NOT. Without this, a regression silently routing delta -> replace would pass every
+        # end-state assertion below unnoticed (both paths converge on the same pf-table
+        # membership).
+        delta_after = h.count_log_marker(adr40_vm, h.PFB_LOG, delta_marker)
+        replace_after = h.count_log_marker(adr40_vm, h.PFB_LOG, replace_marker)
+        assert delta_after > delta_before, (
+            f"ADR-40 P4 delta FAILED: expected a new {delta_marker!r} log line "
+            f"(before={delta_before}, after={delta_after}) — delta apply path not observed"
+        )
+        assert replace_after == replace_before, (
+            f"ADR-40 P4 delta FAILED: expected NO new {replace_marker!r} log line "
+            f"(before={replace_before}, after={replace_after}) — mode=delta silently used replace"
         )
 
         # End-state: exact table contents must equal the new feed (new_ip only; old_ip gone).
@@ -473,6 +505,12 @@ def test_adr40_delta_replace_mode(adr40_vm: h.SmokeVM) -> None:
     membership equals the canonical desired set — irrespective of whether the
     delta or replace path was taken.  Together they make the delta/replace
     equivalence provable from smoke alone.
+
+    issue #722: the mirror of the ``test_adr40_delta_apply_small_churn`` apply-path
+    assertion — same end-state-only gap, opposite direction. Asserts the REPLACE
+    marker fired for this table and the DELTA marker did NOT, proving branch coverage
+    both ways (a regression that silently routed replace -> delta would otherwise pass
+    every end-state assertion below unnoticed).
     """
     token = "p4repl"
     marker = h.hook_marker_path(token, "post")
@@ -507,6 +545,14 @@ def test_adr40_delta_replace_mode(adr40_vm: h.SmokeVM) -> None:
             f"before-state: pf table {ip_spec.alias} already has {new_ip}: {members_before}"
         )
 
+        # issue #722: capture the apply-path markers for THIS table right before the change
+        # reload (the settling reload above already force-replaces on first creation, so it
+        # must NOT be counted as evidence of this change's own decision).
+        delta_marker = f" ADR-40 apply [ {ip_spec.alias} ]: delta "
+        replace_marker = f" ADR-40 apply [ {ip_spec.alias} ]: replace"
+        delta_before = h.count_log_marker(adr40_vm, h.PFB_LOG, delta_marker)
+        replace_before = h.count_log_marker(adr40_vm, h.PFB_LOG, replace_marker)
+
         # Change the feed; invalidate the reuse cache.
         h.write_local_feed(adr40_vm, feed_file, f"{new_ip}\n")
         h.force_ip_refetch(adr40_vm, f"{ip_spec.header}_{ip_spec.family}")
@@ -520,6 +566,19 @@ def test_adr40_delta_replace_mode(adr40_vm: h.SmokeVM) -> None:
         assert ip_spec.alias in changed, (
             f"ADR-40 P4 replace-mode FAILED: alias {ip_spec.alias!r} absent from "
             f"PFB_CHANGED_IP_ALIASES.\nGot {changed!r}"
+        )
+
+        # issue #722: the apply-path oracle — REPLACE marker fired for this table, DELTA did
+        # NOT. Mirror of the delta-mode assertion above: proves branch coverage both ways.
+        delta_after = h.count_log_marker(adr40_vm, h.PFB_LOG, delta_marker)
+        replace_after = h.count_log_marker(adr40_vm, h.PFB_LOG, replace_marker)
+        assert replace_after > replace_before, (
+            f"ADR-40 P4 replace-mode FAILED: expected a new {replace_marker!r} log line "
+            f"(before={replace_before}, after={replace_after}) — replace apply path not observed"
+        )
+        assert delta_after == delta_before, (
+            f"ADR-40 P4 replace-mode FAILED: expected NO new {delta_marker!r} log line "
+            f"(before={delta_before}, after={delta_after}) — mode=replace silently used delta"
         )
 
         # End-state: exact table contents must equal the new feed (new_ip only; old_ip gone).

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -1555,20 +1555,36 @@ def test_cron_detects_changed_local_feed_same_second(deployed_vm: SmokeVM, clien
 
 
 # --------------------------------------------------------------------------- #
-# ADR-42 Phase 3 — conditional GET (ETag / If-None-Match → 304) over the live box.
+# ADR-42 Phase 3 — conditional GET (ETag / If-None-Match → 304, and the
+# Last-Modified / CURLOPT_TIMECONDITION fallback) over the live box.
 #
-# Four cases prove the four reachable branches of pfb_conditional_get_decision():
+# Five cases prove the reachable branches of pfb_update_check()'s remote-feed
+# detector (the ETag path via pfb_conditional_get_decision(), plus the
+# no-validator and Last-Modified-driven-304 paths that sit in front of it):
 #
 #   (a) unchanged feed + matching ETag → 304 → "304 not modified" → no re-ingest.
 #   (b) changed feed + new ETag → 200 → body_hash != persisted → re-ingest.
-#   (c) server emits no ETag (no validator) → download + hash decides (same bytes →
-#       "content unchanged" → no re-ingest).
-#   (d) spurious 200 with identical bytes (server ignores If-None-Match) →
-#       body_hash == persisted → "content unchanged" → no re-ingest.
+#   (c) server emits NO validator at all (no ETag, no Last-Modified —
+#       mock_feeds.disable_lastmod()) → the guest stores nothing, so every probe
+#       is a plain GET and download + hash genuinely decides (same bytes →
+#       "content unchanged" → no re-ingest). Distinct from (d): here there is no
+#       stored validator to send in the first place.
+#   (d) a stored Last-Modified validator exists but the server IGNORES the
+#       conditional request and always answers 200 (identical bytes) →
+#       body_hash == persisted → "content unchanged" → no re-ingest. Distinct
+#       from (c): the guest DOES send a conditional header; the server just
+#       doesn't honour it.
+#   (e) a stored Last-Modified validator exists and the server DOES honour
+#       If-Modified-Since (mock_feeds.enable_lastmod_304()) → 304 → "304 not
+#       modified" → no re-ingest. Proves the CURLOPT_TIMECONDITION fallback
+#       (no ETag) reaches an actual 304, not just the ETag/If-None-Match path
+#       that (a) already covers.
 #
-# The mock server is extended with ETag support (enable_etag / set_content).
-# All cases use the cron verb — the real detector path.  These run live in Phase 5;
-# they are correct by construction here.
+# The mock server is extended with ETag support (enable_etag / set_content),
+# a no-validator-at-all opt-out (disable_lastmod), and an IMS-aware 304
+# responder (enable_lastmod_304). All cases use the cron verb — the real
+# detector path.  These run live in Phase 5; they are correct by construction
+# here.
 # --------------------------------------------------------------------------- #
 
 
@@ -1760,18 +1776,22 @@ def test_cron_200_reingest_changed_remote_feed(
 def test_cron_no_validator_download_hash_decides(
     deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
 ) -> None:
-    """ADR-42 Phase 3 (c): server with no ETag → download + hash decides (same bytes → no re-ingest).
+    """ADR-42 Phase 3 (c): server with NO validator at all → download + hash decides (same bytes → no re-ingest).
 
-    When no validator is stored (server emits no ETag, no Last-Modified), the detector
-    downloads the full body and compares the xxh128 hash.  Identical bytes → "content
-    unchanged" → no re-ingest.  This proves the last-resort path never stalls.
+    The mock is opted OUT of its default Last-Modified header via ``disable_lastmod()``, so
+    this feed genuinely emits no ETag AND no Last-Modified — the guest never stores a ``.etag``
+    or ``.lastmod`` sidecar for it, and every probe is an unconditional GET. The detector
+    downloads the full body and compares the xxh128 hash. Identical bytes → "content unchanged"
+    → no re-ingest. This proves the last-resort path never stalls even with zero validators to
+    fall back on — distinct from the sibling "spurious 200" case below, where a validator IS
+    stored but the server ignores the conditional request it produces.
 
     RED on a broken impl that skips the download when no validator is stored: no
-    "content unchanged" marker would ever appear for a no-ETag server feed.
+    "content unchanged" marker would ever appear for a no-validator server feed.
 
     Scenario (BDD):
-      Given the remote DNSBL feed is loaded with NO ETag (server does not emit one);
-        ``dom`` is VIP-blocked;
+      Given the remote DNSBL feed is loaded with NO validator at all (server emits neither
+        ETag nor Last-Modified); ``dom`` is VIP-blocked;
       When feed content is UNCHANGED, pfb_reuse is OFF, pfb_dailystart matches now,
         and the ``cron`` verb runs;
       Then the detector downloads the full body, logs "content unchanged",
@@ -1784,8 +1804,11 @@ def test_cron_no_validator_download_hash_decides(
     try:
         h.unblock_egress()
 
-        # Register WITHOUT ETag — server always returns plain 200 (no conditional support).
+        # Register WITHOUT ETag, and opt out of the mock's default Last-Modified header too:
+        # the server emits NO validator whatsoever (no conditional support), so the guest
+        # never has anything to send back and the download+hash path is the only option.
         mock_feeds.register(feed_name, dom + "\n")
+        mock_feeds.disable_lastmod(feed_name)
         feed_url = mock_feeds.feed_url(feed_name)
 
         spec = h.DnsblCase(aliasname="smokep3noetag", feed_url=feed_url, header=header, mode=h.DnsblMode.VIP)
@@ -1842,8 +1865,11 @@ def test_cron_spurious_200_same_bytes_no_reingest(
 ) -> None:
     """ADR-42 Phase 3 (d) — §2 contract #5: a spurious 200 with identical bytes is NOT re-ingested.
 
-    A server that ignores conditional requests always answers 200.  body_hash ==
-    persisted_hash → "content unchanged" → no re-ingest.  This proves contract #5.
+    Unlike case (c), this feed keeps the mock's DEFAULT Last-Modified header (no
+    ``disable_lastmod()`` call), so the guest DOES store a ``.lastmod`` validator and DOES send
+    a conditional request on the next probe — the server just ignores it and always answers
+    200.  body_hash == persisted_hash → "content unchanged" → no re-ingest.  This proves
+    contract #5: the hash compare, not the raw status code, is what decides.
 
     RED on a broken impl that treats every 200 as changed: it would log "Downloading update"
     and re-ingest on every cron run — the "content unchanged" marker proves the hash
@@ -1909,6 +1935,115 @@ def test_cron_spurious_200_same_bytes_no_reingest(
             assert h.member_present(members_after, member_ip), (
                 f"AFTER spurious-200 cron: {member_ip} must still be in {spec.alias}: {members_after}"
             )
+
+    finally:
+        reset_exc = None
+        try:
+            h.reset(deployed_vm)
+        except Exception as exc:  # noqa: BLE001
+            reset_exc = exc
+        if reset_exc is not None:
+            raise reset_exc
+
+
+@pytest.mark.timeout(600)
+def test_cron_lastmod_304_skips_unchanged_feed(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """ADR-42 Phase 3 (e): a Last-Modified-driven 304 (no ETag) skips re-ingest via CURLOPT_TIMECONDITION.
+
+    Case (a) already proves the ETag/If-None-Match half of the conditional-GET contract.  This
+    feed carries NO ETag, so once a ``.lastmod`` validator is stored, the detector's fallback
+    branch (``CURLOPT_TIMECONDITION`` / ``CURLOPT_TIMEVALUE`` — pfblockerng.inc ~8818-8821) is
+    what sends the conditional request; ``mock_feeds.enable_lastmod_304()`` makes the server
+    actually honour ``If-Modified-Since`` and answer 304, distinct from case (d) where a
+    Last-Modified validator exists but the server ignores it. Without this test, the
+    CURLOPT_TIMECONDITION branch could regress to always-200 and nothing would notice — every
+    other case either uses ETag or never reaches an actual 304.
+
+    RED on a broken/regressed CURLOPT_TIMECONDITION wire-up (e.g. the fallback branch silently
+    stops sending a conditional header, or the value sent isn't recognised by an IMS-aware
+    server): the mock's ``enable_lastmod_304()`` responder would never see a satisfying
+    If-Modified-Since, so it always answers 200 — no "304 not modified" marker would appear
+    within the cron-pass cap.
+
+    Scenario (BDD):
+      Given the remote DNSBL feed is loaded with NO ETag (server does not emit one);
+        ``dom`` is VIP-blocked;
+      When feed content is UNCHANGED, the server honours If-Modified-Since with a real 304,
+        pfb_reuse is OFF, pfb_dailystart matches now, and the ``cron`` verb runs;
+      Then the detector logs "304 not modified", does NOT log "Downloading update",
+        and ``dom`` remains blocked.
+    """
+    dom = h.unique_domain("p3lm304")
+    header = "smokep3lm304"
+    feed_name = "p3_lastmod_304.txt"
+
+    try:
+        h.unblock_egress()
+
+        # Register WITHOUT ETag — only the mock's default Last-Modified header is emitted —
+        # and opt this name into the RFC-conformant If-Modified-Since responder so the guest's
+        # stored .lastmod validator actually earns a 304 (not just a header that's ignored, as
+        # in case (d) above).
+        mock_feeds.register(feed_name, dom + "\n")
+        mock_feeds.enable_lastmod_304(feed_name)
+        feed_url = mock_feeds.feed_url(feed_name)
+
+        # GIVEN — inject + Force Update to establish the .orig baseline + ingest the body.
+        spec = h.DnsblCase(aliasname="smokep3lm304", feed_url=feed_url, header=header, mode=h.DnsblMode.VIP)
+        h.inject(deployed_vm, spec)
+        h.reload(deployed_vm, "updatednsbl")
+
+        # BEFORE: dom is VIP-blocked.
+        h.flush_unbound_name(deployed_vm, dom)
+        ans_before = h.dns_probe_client_until(client_vm, dom, h.is_vip)
+        assert h.is_vip(ans_before), f"BEFORE: {dom} must be VIP-blocked after initial ingest, got {ans_before}"
+
+        # Feed unchanged; the stored Last-Modified validator still matches. Same global-count
+        # rationale as case (a): "( 304 not modified )" is logged without a "[ header ]" prefix,
+        # so count it globally over the cron window. No other feed in this run stores a
+        # Last-Modified-only validator that the server actually honours, so the delta isolates
+        # this feed's conditional GET.
+        _pin_cron_due(deployed_vm)
+        not_mod_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "304 not modified")
+        dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
+        hdr_before = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
+
+        # WHEN — same store-then-read span as case (a): the .lastmod validator is written by
+        # the cron detector (pfb_update_check) on its first 200, not by the updatednsbl Force
+        # ingest above. Run cron until "304 not modified" appears, capped so a genuine failure
+        # still surfaces.
+        for _pass in range(4):
+            h.reload(deployed_vm, "cron")
+            if h.count_log_marker(deployed_vm, h.PFB_LOG, "304 not modified") > not_mod_before:
+                break
+
+        # Fast guard — the feed was evaluated at least once.
+        hdr_after = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
+        assert hdr_after > hdr_before, (
+            f"cron did not evaluate [ {header} ] (before={hdr_before}, after={hdr_after}) — "
+            f"EveryDay feed not due (hour rollover?); re-run"
+        )
+
+        # THEN — "304 not modified" appeared within the cap (CURLOPT_TIMECONDITION proof).
+        not_mod_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "304 not modified")
+        assert not_mod_after > not_mod_before, (
+            f"Expected '( 304 not modified )' (Last-Modified/CURLOPT_TIMECONDITION 304 proof) "
+            f"within 4 cron passes (before={not_mod_before}, after={not_mod_after}) — "
+            f"the no-ETag conditional-GET fallback did not reach a 304"
+        )
+
+        # THEN — no re-ingest.
+        dl_after = _feed_log_count(deployed_vm, header, "Downloading update")
+        assert dl_after == dl_before, (
+            f"Expected NO '[ {header} ] ... Downloading update' after 304 "
+            f"(before={dl_before}, after={dl_after}) — detector incorrectly re-ingested"
+        )
+
+        # THEN — dom remains blocked.
+        ans_after = h.dns_probe_client(client_vm, dom, "A")
+        assert h.is_vip(ans_after), f"AFTER 304 cron: {dom} must remain VIP-blocked, got {ans_after}"
 
     finally:
         reset_exc = None


### PR DESCRIPTION
Fixes #722.

Repairs the five tests that could not fail on the regression they exist to catch, one commit per finding. Each fix carries its own red→green (or dead-branch/theater) proof.

### 1. Conditional-GET smoke case (c) — `tests/smoke/` (commit 4)
The mock feed server unconditionally emitted `Last-Modified`, so case (c) stored a validator and ran the same spurious-200 path as case (d); the true no-validator branch and the whole IMS→304 fallback had zero coverage. The mock now supports per-name `disable_lastmod()` (genuinely no validator — case (c) uses it) and an RFC 9110-conformant `enable_lastmod_304()` responder; a new case (e) covers the `CURLOPT_TIMECONDITION` → 304 fallback. The five-case comment block and docstrings now state what each case actually exercises. Defaults are unchanged, so every existing test (case (d) included) keeps its semantics.

### 2. ADR-40 delta apply-path observability (commit 5)
Nothing on a live box distinguished a delta apply from a replace (`pfb_pfctl_table_op` logs only on error), so the delta smoke passed even if `mode=delta` silently routed through `-T replace`. `pfb_apply_alias_delta()` now logs one grep-stable line per apply decision (`ADR-40 apply [ table ]: delta +N/-M` / `…: replace`) on every branch; the unit suite pins all three marker sites red→green via the shared log file, and both ADR-40 smoke tests now assert the apply *path* (delta incremented, replace not — and mirrored) on top of the existing end-state assertions.

### 3. `remove()` header-guard shell spec (commit 3)
The sentinel comment was wrong (it sits inside the sandbox) and the header case's `../../SENTINEL` glob resolved one directory above the sentinel — even fully unguarded code never aimed at it. The traversal is now `../SENTINEL` (resolves exactly to the sentinel), and the example asserts status + sentinel survival, so a lost `continue` goes red. Proven with a four-point sourced-`/bin/sh` harness: guard-reverted + new aim deletes the sentinel (red), guard-reverted + old aim left it alive (the old test was theater).

### 4. `CollectLocalIpV6Test` unreachable branch (commit 1)
pfSense stores static IPv6 under `ipaddrv6`/`subnetv6`, never `ipaddr`, so the config-loop v6 arm was dead code and the test fed an impossible config shape. The arm is removed (behaviour-preserving; a planted `die()` confirmed nothing reaches it) and static-v6 locality is now pinned through the real runtime path (`get_configured_ipv6_addresses()`), with the runtime block's comment documenting it as the sole source of interface-IPv6 locality.

### 5. `AliasDeltaApplyTest` H6 reimplemented ternary (commit 2)
H6 re-implemented the empty-POST-field→512 ternary inline and never executed the UI line. The resolution now lives in `pfb_alias_delta_batch_resolve()`, called by `pfblockerng_ip.php` and tested directly — breaking the default in production turns the test red (verified). Behaviour-preserving extraction; Tier-A `ui_render` already covers the page.

### Testing
Local suites green against the current `devel` base: **PHPUnit 1801**, **pytest 1993**, `ruff`/`ruff format`, `mypy tests/`, `phpcs`, `php -l`, `sh -n`/`shellcheck` all clean. Smoke additions are live-VM-only (collection + typing validated locally; each carries a reasoned red→green analysis in its docstring/handoff). Every finding was re-verified independently after implementation: F5/F2 by breaking production and watching the pinned test fail, F3 by a guard-reverted harness, F4 by a planted `die()` in the removed branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjaFrLAQsVZdLxcFZZTkBX)_