### PR TITLE
pfblockerng: reject RFC 4632-invalid IPv4 masks instead of substring-rewriting them

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7858,7 +7858,14 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 
 	$parts	= explode('/', $ipaddr);
 	$subnet	= $parts[0];
-	$mask	= $parts[1] ?? '';	// '' (not undef) when no CIDR -> avoids str_replace(null) below
+	$mask	= $parts[1] ?? '';	// '' (not undef) when no CIDR
+
+	// An IPv4 prefix length must be 0..32; drop the line outright. A substring
+	// strip here (str_replace('32', '')) used to rewrite an invalid mask into a
+	// valid, far broader one (/132 -> /1 = half of IPv4) (issue #719).
+	if ($mask !== '' && (!ctype_digit($mask) || (int)$mask > 32)) {
+		return;
+	}
 	$iparr = explode('.', $subnet);
 
 	foreach ($iparr as $key => $octet) {
@@ -7881,7 +7888,9 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 		}
 	}
 
-	$mask = str_replace('32', '', $mask);	// Strip '/32' mask
+	if ((int)$mask == 32) {
+		$mask = '';	// Strip '/32' mask (bare host)
+	}
 	$ip_final = implode('.', $ip);
 
 	// Exclude private/reserved IPs (bypass exclusion for custom lists)
@@ -7896,10 +7905,6 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 		if ($pfbcidr != 'Disabled' && !empty($mask) && $mask < $pfbcidr) {
 			pfb_logger("\n  Suppression CIDR Limit: {$ip_final}/{$mask}", 1);
 			$mask = '32';
-		}
-
-		if ($mask > 32) {
-			$mask = '';
 		}
 
 		if (!filter_var($ip_final, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== FALSE) {

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -106,12 +106,15 @@ final class SanitizeIpaddrTest extends TestCase
 	}
 
 	// Suppression's old '> 32' guard rewrote /33 into a bare host instead of
-	// rejecting it; with the mask validated up front the line is dropped on
-	// this branch too.
-	public function testOutOfRangeMaskDroppedUnderSuppression(): void
+	// rejecting it (and the substring strip mangled /132 -> /1, /320 -> bare
+	// host, on this branch too); with the mask validated up front the line is
+	// dropped regardless of suppression state.
+	public function testInvalidMasksDroppedUnderSuppression(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
 		$this->assertNull(sanitize_ipaddr('192.0.2.1/33', false, 'Disabled'));
+		$this->assertNull(sanitize_ipaddr('192.0.2.1/132', false, 'Disabled'));
+		$this->assertNull(sanitize_ipaddr('192.0.2.1/320', false, 'Disabled'));
 	}
 
 	public function testNonNumericMaskDropped(): void

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -85,4 +85,37 @@ final class SanitizeIpaddrTest extends TestCase
 		// mask 8 < floor 24 -> clamped to /32 (public TEST-NET-2 survives the filter).
 		$this->assertSame('198.51.100.0/32', sanitize_ipaddr('198.51.100.0/8', false, 24));
 	}
+
+	// --- RFC 4632-invalid prefix lengths are dropped, never rewritten (#719) ---
+
+	// The old substring str_replace('32', '') rewrote an invalid mask into a
+	// valid, far broader one (/132 -> /1 ingested half of IPv4 into a Deny
+	// table; /320 and /3232 collapsed to a bare host). Such lines must be
+	// dropped outright.
+	public function testMaskContaining32AsSubstringDroppedNotRewritten(): void
+	{
+		$this->assertNull(sanitize_ipaddr('1.2.3.4/132', false, 'Disabled'));
+		$this->assertNull(sanitize_ipaddr('10.0.0.0/232', false, 'Disabled'));
+		$this->assertNull(sanitize_ipaddr('10.0.0.0/320', false, 'Disabled'));
+		$this->assertNull(sanitize_ipaddr('1.2.3.4/3232', false, 'Disabled'));
+	}
+
+	public function testOutOfRangeMaskDropped(): void
+	{
+		$this->assertNull(sanitize_ipaddr('1.2.3.4/33', false, 'Disabled'));
+	}
+
+	// Suppression's old '> 32' guard rewrote /33 into a bare host instead of
+	// rejecting it; with the mask validated up front the line is dropped on
+	// this branch too.
+	public function testOutOfRangeMaskDroppedUnderSuppression(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('192.0.2.1/33', false, 'Disabled'));
+	}
+
+	public function testNonNumericMaskDropped(): void
+	{
+		$this->assertNull(sanitize_ipaddr('1.2.3.4/abc', false, 'Disabled'));
+	}
 }


### PR DESCRIPTION
Fixes #719

## Problem

`sanitize_ipaddr()` stripped a `/32` mask with `str_replace('32', '', $mask)`. Being substring-based, it rewrote RFC 4632-invalid prefix lengths into valid but far broader ones instead of rejecting them — reproduced against the real function off-appliance:

| Feed line | Old result | Effect |
| --- | --- | --- |
| `1.2.3.4/132` | `1.2.3.4/1` [VALID] | half of IPv4 ingested into a Deny table |
| `10.0.0.0/232` | `10.0.0.0/2` [VALID] | quarter of IPv4 |
| `10.0.0.0/320` | `10.0.0.0` [VALID] | collapsed to a bare host |
| `1.2.3.4/3232` | `1.2.3.4` [VALID] | collapsed to a bare host |
| `192.0.2.1/33` (suppression on) | `192.0.2.1` [VALID] | the `> 32` guard rewrote it into a bare host |

`validate_ipv4()` then accepts the mangled result, so a single malformed line in a downloaded feed hugely over-blocks.

## Fix

Validate the mask up front — digits only, `0..32` — and drop the line outright otherwise; strip the mask only when it is exactly `/32`. The suppression-only `> 32` guard became unreachable and is removed.

## Tests

`SanitizeIpaddrTest`: new cases for `/132`, `/232`, `/320`, `/3232`, `/33` (suppression off **and** on), and a non-numeric mask — all red before the fix (each returned a mangled-but-valid result), green after. Full PHP suite: 1805 tests green; `php -l`, PHPStan, PHPCS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP address sanitization to handle CIDR masks more strictly.
  * Invalid, out-of-range, or non-numeric prefix lengths are now dropped instead of being altered.
  * `/32` addresses are now normalized correctly without accidental string-based replacements.
  
* **Tests**
  * Added coverage for invalid prefix handling, including malformed masks and suppressed validation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->