### PR TITLE
pfblockerng: don't log an absent-table pfctl kill as a failure

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4296,6 +4296,22 @@ function pfb_pfctl_error_message(string $table, string $op, int $rc, string $std
 }
 
 
+// Should a completed pfctl mutation op be logged as an attributed failure?  Pure predicate:
+// no side-effects, unit-testable without a live pfctl (sibling of pfb_pfctl_error_message()).
+// A `kill` that reports "Table does not exist" is the IDEMPOTENT SUCCESS case for kill (goal:
+// table gone — it already is): the unguarded kill sites (an enabled alias with no
+// URL/customlist; an empty aggregate union) call it every sync/cron tick, so treating an
+// absent-table kill as a failure would flood the log with a benign no-op forever.  Any OTHER
+// kill error (permissions, syntax), and every non-kill op with a non-zero rc / pfctl error,
+// stays a real failure.
+function pfb_pfctl_op_failed(string $op, int $rc, string $stderr): bool {
+	if ($op === 'kill' && stripos($stderr, 'Table does not exist') !== FALSE) {
+		return FALSE;
+	}
+	return $rc !== 0 || stripos($stderr, 'pfctl:') !== FALSE || stripos($stderr, 'Table does not exist') !== FALSE;
+}
+
+
 // Thin wrapper around `pfctl -t <table> -T <op>` for mutation ops (kill/replace/add/delete).
 // Owns the escapeshellarg() for the table; $args must already be fully escaped by
 // the caller (e.g. "-f " . escapeshellarg($path)).  $op is a fixed verb literal
@@ -4314,7 +4330,7 @@ function pfb_pfctl_table_op(string $table, string $op, string $args = '', string
 	$rc        = 0;
 	exec("{$pfctl_bin} -t {$table_esc} -T {$op}{$args_part} 2>&1", $out, $rc);
 	$stderr    = implode(' ', $out);
-	if ($rc !== 0 || stripos($stderr, 'pfctl:') !== FALSE || stripos($stderr, 'Table does not exist') !== FALSE) {
+	if (pfb_pfctl_op_failed($op, $rc, $stderr)) {
 		pfb_logger(pfb_pfctl_error_message($table, $op, $rc, $stderr) . "\n", 1);
 	}
 	return ['out' => $out, 'rc' => $rc];

--- a/tests/php/PfctlTableOpTest.php
+++ b/tests/php/PfctlTableOpTest.php
@@ -6,22 +6,27 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for pfb_pfctl_error_message() — the pure formatter that names a failed
- * pfctl table operation.  Adding attribution to "pfctl: Table does not exist"
- * floods during the alpha-6 upgrade (no table/op info in the original exec()
- * call sites).
+ * Tests for the two pure helpers of pfb_pfctl_table_op():
+ *   - pfb_pfctl_error_message() — the formatter that names a failed pfctl table
+ *     operation (adding attribution to "pfctl: Table does not exist" floods that
+ *     the original exec() call sites logged with no table/op info); and
+ *   - pfb_pfctl_op_failed() — the predicate that decides WHETHER a completed op is
+ *     a failure worth logging, exempting the idempotent absent-table `kill`.
  *
- * pfb_pfctl_table_op() wraps exec() and cannot be exercised off-appliance, so
- * only the formatter is tested here (exec doubles would add fragile complexity
- * for no new coverage benefit — the formatter is the testable invariant).
+ * pfb_pfctl_table_op() wraps exec() and cannot be exercised off-appliance, so only
+ * its pure helpers are tested here (exec doubles would add fragile complexity for no
+ * new coverage benefit — the helpers are the testable invariants).
  *
  * Scenarios:
  *   A — failure message contains table, op, rc, and trimmed stderr.
  *   B — multiline stderr collapses to a single line.
  *   C — message format is stable across all four mutation ops (kill/replace/add/delete).
  *   D — empty stderr is represented cleanly (no trailing colon-space).
+ *   E — pfb_pfctl_op_failed(): an absent-table `kill` is success (not logged); every
+ *       other kill error, non-kill absent-table op, and clean success is classified right.
  */
 #[CoversFunction('pfb_pfctl_error_message')]
+#[CoversFunction('pfb_pfctl_op_failed')]
 final class PfctlTableOpTest extends TestCase
 {
 	// -----------------------------------------------------------------------
@@ -135,5 +140,75 @@ final class PfctlTableOpTest extends TestCase
 			"expected: op present;\nactual: {$msg}");
 		$this->assertStringContainsString('1', $msg,
 			"expected: rc present;\nactual: {$msg}");
+	}
+
+	// -----------------------------------------------------------------------
+	// Scenario E — pfb_pfctl_op_failed: absent-table `kill` is idempotent
+	//              success, NOT an attributed failure
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario E — a `kill` of a table that does not exist is NOT a failure.
+	 *
+	 * Given: op='kill', rc=1, stderr='pfctl: Table does not exist.' — the shape produced when the
+	 *        unguarded kill sites (an enabled alias with no URL/customlist; an empty aggregate
+	 *        union) kill a table that was never created.
+	 * When:  pfb_pfctl_op_failed() classifies it.
+	 * Then:  it returns FALSE — the kill's goal (table gone) is already met, so no attributed
+	 *        failure line is logged. Pre-fix this reported TRUE and flooded the log every tick.
+	 */
+	public function testKillOfAbsentTableIsNotAFailure(): void
+	{
+		$this->assertFalse(
+			pfb_pfctl_op_failed('kill', 1, 'pfctl: Table does not exist.'),
+			'expected: absent-table kill classified as success (FALSE);\nactual: TRUE (would log a benign no-op)'
+		);
+	}
+
+	/**
+	 * Scenario E (branch) — the carve-out is kill-ONLY: a non-kill op on an absent table is
+	 * still a real failure.
+	 *
+	 * Given: op='replace', rc=1, stderr='pfctl: Table does not exist.'.
+	 * When:  pfb_pfctl_op_failed() classifies it.
+	 * Then:  it returns TRUE — a replace needs the table, so its absence IS a failure to attribute.
+	 */
+	public function testReplaceOfAbsentTableStillFails(): void
+	{
+		$this->assertTrue(
+			pfb_pfctl_op_failed('replace', 1, 'pfctl: Table does not exist.'),
+			'expected: absent-table replace still a failure (TRUE);\nactual: FALSE (would swallow a real error)'
+		);
+	}
+
+	/**
+	 * Scenario E (branch) — a `kill` that fails for ANOTHER reason is still a real failure.
+	 *
+	 * Given: op='kill', rc=1, stderr='pfctl: permission denied' (no "Table does not exist").
+	 * When:  pfb_pfctl_op_failed() classifies it.
+	 * Then:  it returns TRUE — only the absent-table kill is exempt; every other kill error is
+	 *        attributed.
+	 */
+	public function testKillWithOtherErrorStillFails(): void
+	{
+		$this->assertTrue(
+			pfb_pfctl_op_failed('kill', 1, 'pfctl: permission denied'),
+			'expected: kill failing for a non-absent-table reason still a failure (TRUE);\nactual: FALSE'
+		);
+	}
+
+	/**
+	 * Scenario E (branch) — a clean success (rc=0, no stderr) is never a failure, for any op.
+	 *
+	 * Given: op='add', rc=0, stderr=''.
+	 * When:  pfb_pfctl_op_failed() classifies it.
+	 * Then:  it returns FALSE — nothing to log on a healthy mutation.
+	 */
+	public function testCleanSuccessIsNotAFailure(): void
+	{
+		$this->assertFalse(
+			pfb_pfctl_op_failed('add', 0, ''),
+			'expected: rc=0 clean op classified as success (FALSE);\nactual: TRUE'
+		);
 	}
 }


### PR DESCRIPTION
F2 from the substitute-review backlog (#738). Off-VM unit-pinned (PHPUnit), red before / green after.

## F2 — absent-table `pfctl kill` logged as a failure (medium)

`pfb_pfctl_table_op()`'s guard flagged any non-zero rc / "Table does not exist", but the unguarded kill sites — an enabled alias with no URL/customlist (`pfblockerng.inc:16623`) and an empty aggregate union (`:4422`/`:4464`) — kill a table that may never have been created. That is the idempotent success case for `kill` (goal: table gone), so it emitted `[pfctl] op=kill … failed (rc=1): pfctl: Table does not exist.` into the persistent/Update-page log on every sync/cron tick — the exact flood the attribution was meant to make legible.

Fix: extract a pure `pfb_pfctl_op_failed()` predicate that exempts an absent-table `kill` while keeping every other kill error and every non-kill op attributed. `PfctlTableOpTest` pins all four branches (red before the carve-out, green after).

## Note — F3 dropped from this PR

This branch originally also carried an F3 fix (stale `.aggcount` sidecars skewing the "Original IP count"). The adversarial review found that `closingprocess()`'s only call site (`pfblockerng.inc:17329`) is gated on `$pfb['dup'] == 'on'` and passes the literal `"on"`, so the report only ever runs with de-dup on — making both the proposed guard a no-op and the original bug scenario unreachable. F3 is withdrawn as a false positive; see #738.

Gates: PHPUnit 1805, PHPStan, PHPCS, php -l — all green.

Part of #738