### PR TITLE
pfblockerng: fix widget status-icon freeze + onload null-deref on unknown hash (#714)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfBlockerNG.js
+++ b/src/usr/local/www/pfblockerng/pfBlockerNG.js
@@ -25,7 +25,10 @@ window.onload = function() {
 	if (location.hash) {
 		var elId = location.hash.replace('#','');
 		var scrollToEl = document.getElementById(elId);
-		scrollToEl.scrollIntoView(true);
+		// A hash naming no element (bad/stale bookmark) must not crash onload (#714).
+		if (scrollToEl) {
+			scrollToEl.scrollIntoView(true);
+		}
 
 		// Toggle Collapsible window
 		$("[id$='customlist_panel-body']").removeClass('out').addClass('in');

--- a/src/usr/local/www/widgets/javascript/pfblockerng.js
+++ b/src/usr/local/www/widgets/javascript/pfblockerng.js
@@ -85,9 +85,13 @@ function pfBlockerNG_fetch_new_widget_callback(callback_data) {
 					row_split[1] = row_split[1].replaceAll('_BR_', '\n');
 					$('.pfb_title_' + row_split[0]).attr('title', row_split[1]);
 				} else if (row_split[0] == 'PFBSTATUS') {
-					$('.PFBSTATUS').attr('class', row_split[1]).prop('title', row_split[2]);
+					// The anchor class (PFBSTATUS) must be re-applied, not just the icon
+					// class: the AJAX payload carries only the icon class, and overwriting
+					// the whole class attribute would drop the anchor so the NEXT poll's
+					// $('.PFBSTATUS') selector matches nothing (issue #714).
+					$('.PFBSTATUS').attr('class', 'PFBSTATUS ' + row_split[1]).prop('title', row_split[2]);
 				} else if (row_split[0] == 'DNSBLSTATUS') {
-					$('.DNSBLSTATUS').attr('class', row_split[1]).prop('title', row_split[2]);
+					$('.DNSBLSTATUS').attr('class', 'DNSBLSTATUS ' + row_split[1]).prop('title', row_split[2]);
 				}
 			}
 			else if (row_cnt > 4) {
@@ -226,5 +230,9 @@ if (typeof window !== 'undefined') {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-	module.exports = { pfBlockerNG_escapeHtml: pfBlockerNG_escapeHtml, pfBlockerNG_buildWidgetRow: pfBlockerNG_buildWidgetRow };
+	module.exports = {
+		pfBlockerNG_escapeHtml: pfBlockerNG_escapeHtml,
+		pfBlockerNG_buildWidgetRow: pfBlockerNG_buildWidgetRow,
+		pfBlockerNG_fetch_new_widget_callback: pfBlockerNG_fetch_new_widget_callback
+	};
 }

--- a/tests/js/widget_render.test.js
+++ b/tests/js/widget_render.test.js
@@ -9,7 +9,50 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { pfBlockerNG_escapeHtml, pfBlockerNG_buildWidgetRow } = require('../../src/usr/local/www/widgets/javascript/pfblockerng.js');
+const {
+	pfBlockerNG_escapeHtml,
+	pfBlockerNG_buildWidgetRow,
+	pfBlockerNG_fetch_new_widget_callback,
+} = require('../../src/usr/local/www/widgets/javascript/pfblockerng.js');
+
+// ── jQuery test double for pfBlockerNG_fetch_new_widget_callback ──────────────
+//
+// A minimal chainable stub: $(sel).attr(name, val).prop(name, val) records the
+// last class/title set for the given selector. Installed on global.$/jQuery
+// (the widget JS calls the bare `$` form) only for the lifetime of a test, and
+// removed afterwards so it cannot leak into a sibling test.
+function installJQueryStub() {
+	var state = {};
+	function stub(sel) {
+		if (!state[sel]) {
+			state[sel] = { class: null, title: null };
+		}
+		var record = state[sel];
+		var chain = {
+			attr: function(name, val) {
+				if (name === 'class') {
+					record.class = val;
+				}
+				return chain;
+			},
+			prop: function(name, val) {
+				if (name === 'title') {
+					record.title = val;
+				}
+				return chain;
+			},
+		};
+		return chain;
+	}
+	global.$ = stub;
+	global.jQuery = stub;
+	return state;
+}
+
+function uninstallJQueryStub() {
+	delete global.$;
+	delete global.jQuery;
+}
 
 // ── pfBlockerNG_escapeHtml ────────────────────────────────────────────────────
 
@@ -174,4 +217,49 @@ test('pfBlockerNG_buildWidgetRow: rows join into well-formed markup with no stra
 	assert.ok(!assembled.includes(','), 'no stray comma between rows');
 	assert.equal(assembled.split('<tr>').length - 1, 2, 'one opening <tr> per row');
 	assert.equal(assembled.split('</tr>').length - 1, 2, 'one closing </tr> per row');
+});
+
+// ── pfBlockerNG_fetch_new_widget_callback: status-icon anchor class ───────────
+//
+// Scenario: the status icon must stay pollable across repeated AJAX refreshes.
+//
+// Given the initial server render anchors the status <i> with the class
+//   "PFBSTATUS <icon-classes>" (widget PHP php:906/912), and the AJAX payload
+//   sends only the icon classes (no anchor) as row_split[1],
+// When pfBlockerNG_fetch_new_widget_callback applies the payload,
+// Then the element's class is set back to "PFBSTATUS <icon-classes>" (anchor
+//   preserved) so a LATER poll's $('.PFBSTATUS') selector still matches it
+//   (issue #714: overwriting the whole class attribute with just the icon
+//   classes drops the anchor and freezes the icon after the first poll).
+
+test('pfBlockerNG_fetch_new_widget_callback: PFBSTATUS payload preserves the PFBSTATUS anchor class', () => {
+	var state = installJQueryStub();
+	try {
+		pfBlockerNG_fetch_new_widget_callback('PFBSTATUS||fa-solid fa-check-circle text-success||pfBlockerNG is Active.\n');
+
+		assert.equal(
+			state['.PFBSTATUS'].class,
+			'PFBSTATUS fa-solid fa-check-circle text-success',
+			'the PFBSTATUS anchor class must survive the AJAX class update',
+		);
+		assert.equal(state['.PFBSTATUS'].title, 'pfBlockerNG is Active.');
+	} finally {
+		uninstallJQueryStub();
+	}
+});
+
+test('pfBlockerNG_fetch_new_widget_callback: DNSBLSTATUS payload preserves the DNSBLSTATUS anchor class', () => {
+	var state = installJQueryStub();
+	try {
+		pfBlockerNG_fetch_new_widget_callback('DNSBLSTATUS||fa-solid fa-exclamation-circle text-warning||DNSBL is Inactive.\n');
+
+		assert.equal(
+			state['.DNSBLSTATUS'].class,
+			'DNSBLSTATUS fa-solid fa-exclamation-circle text-warning',
+			'the DNSBLSTATUS anchor class must survive the AJAX class update',
+		);
+		assert.equal(state['.DNSBLSTATUS'].title, 'DNSBL is Inactive.');
+	} finally {
+		uninstallJQueryStub();
+	}
 });

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -72,6 +72,9 @@ SYNC_PAGE = "/pfblockerng/pfblockerng_sync.php"
 # Split into ?type sub-tabs (ADR-16 Phase 3); the IPv4 tab carries the bulk of the
 # pre-defined feeds (and so any Alternate-URL radios), so the alt-URL flow targets it.
 FEEDS_PAGE = "/pfblockerng/pfblockerng_feeds.php?type=ipv4"
+# The IP page includes pfBlockerNG.js, whose window.onload runs the
+# location.hash scroll-to-anchor + CustomList panel toggle (issue #714).
+IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
 
 # A short, explicit timeout (ms) for the JS-driven DOM transitions: the handlers
 # fire synchronously on load/click, so this is a flake ceiling, not a wait knob.
@@ -396,3 +399,36 @@ def test_update_runnow_does_not_scroll_the_page(
 
     offset = page.evaluate("window.pageYOffset")
     assert offset == 0, f"Run Now must not auto-scroll the page; expected top (0), got pageYOffset={offset}"
+
+
+def test_onload_survives_hash_with_no_matching_element(
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """A URL hash naming no element must not crash pfBlockerNG.js's window.onload (#714).
+
+    ``window.onload`` (pfBlockerNG.js:24-33) is wired to scroll to, and expand the
+    CustomList panel for, a bookmarked ``location.hash`` anchor (used by the widget's
+    Suppression/Whitelist links). It called ``document.getElementById(elId)
+    .scrollIntoView(true)`` unconditionally -- a hash the page does not recognise (a
+    stale bookmark, a typo, user-supplied) makes ``getElementById`` return ``null``,
+    so ``null.scrollIntoView()`` threw and aborted onload before the CustomList panel
+    toggle ran.
+
+    Scenario:
+      Given the IP page (which includes pfBlockerNG.js),
+      When it is loaded with a hash that names no element on the page,
+      Then onload completes without an uncaught page error, and the page still
+           renders (the login form is absent, proving a real authenticated render,
+           not a blank/errored page).
+    """
+    page = browser_page
+    errors: list[str] = []
+    page.on("pageerror", lambda exc: errors.append(str(exc)))
+
+    _open(page, webui, f"{IP_PAGE}#pfb_nonexistent_anchor_714")
+
+    assert errors == [], f"window.onload threw on an unmatched hash: {errors!r}"
+    # Same marker Tier A (test_render_smoke.py PAGE_TABLE) asserts for this page --
+    # proves a real authenticated render, not a blank/errored page.
+    assert "IP Configuration" in page.content(), "IP page did not render its 'IP Configuration' section after onload"


### PR DESCRIPTION
Part of #714 — UI batch (`www/` JS behaviour).

### h1 — dashboard widget status icon freezes after the first poll
`widgets/javascript/pfblockerng.js` — the AJAX poll handler did `$('.PFBSTATUS').attr('class', row_split[1])`. The initial server render anchors the icon as `class="PFBSTATUS {$pfb_status}"`, but the payload sends only `$pfb_status` (the `fa-*`/`text-*` icon classes, no anchor). `.attr('class', …)` overwrites the whole attribute, dropping the `PFBSTATUS` anchor, so the next 15s poll's `$('.PFBSTATUS')` selector matches nothing and the icon freezes. Fix: re-apply the anchor — `'PFBSTATUS ' + row_split[1]` (and `'DNSBLSTATUS ' + …`).
- **Test (PR-gating, red→green):** `tests/js/widget_render.test.js` (`node --test`) now exercises `pfBlockerNG_fetch_new_widget_callback` via a minimal jQuery stub and asserts the anchor class survives the update. Pre-fix the class comes back as `fa-solid fa-check-circle text-success` (no anchor) → RED; post-fix `PFBSTATUS fa-solid fa-check-circle text-success` → GREEN. The callback is now exported for the test.

### h2 — `window.onload` crashes on a hash naming no element
`pfblockerng/pfBlockerNG.js` — `document.getElementById(elId).scrollIntoView(true)` ran unconditionally; a `location.hash` that matches no element (stale/typo/user-supplied bookmark) makes `getElementById` return null, so `null.scrollIntoView()` threw and aborted onload (the CustomList panel toggle never ran). Fix: guard `if (scrollToEl) { … }`.
- **Test (Tier B `ui_browser`, dispatch-only):** `tests/smoke/ui/test_browser_misc.py::test_onload_survives_hash_with_no_matching_element` — loads the IP page with an unmatched hash, asserts no `pageerror` and the page still renders. Red-by-construction pre-fix (the unguarded null-deref throws during onload).

Tier A render coverage for both pages already exists (`test_render_smoke.py` / `test_browser.py`).

**Gates:** `node --test` 17/17 ✓, ruff/mypy ✓, UI collection ✓, both JS files parse ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)