### PR TITLE
tests: fix set_return_msg stub and is_ipaddrv4/v6 doubles to match real Unbound/pfSense (#721)

### DIFF
--- a/stubs/python/unboundmodule.py
+++ b/stubs/python/unboundmodule.py
@@ -92,12 +92,17 @@ RR_TYPE_ANY = 255  # Wildcard match — any RR type (query only)
 RR_CLASS_IN = 1
 
 # ---------------------------------------------------------------------------
-# Packet flags (DNS header bitmask positions)
+# Packet flags — pythonmod's injected runtime constants (interface.i
+# ``%constant uint16_t PKT_QR = 1`` etc.). These are NOT the wire-format
+# header bits: ``set_return_msg``/``createResponse`` maps them onto the wire
+# internally, and ``reply_info.flags`` carries the WIRE bits (mask those with
+# hex literals, e.g. 0x0080 for RA — see pfb_unbound.py's upstream-block
+# classifier), never these constants.
 # ---------------------------------------------------------------------------
-PKT_QR = 0x8000  # QR bit: set -> response, clear -> query
-PKT_RD = 0x0100  # RD bit: recursion desired (client requests recursive lookup)
-PKT_RA = 0x0080  # RA bit: recursion available (server supports recursion)
-PKT_AA = 0x0400  # AA bit: authoritative answer (as used in pythonmod)
+PKT_QR = 1  # QR: set -> response, clear -> query
+PKT_AA = 2  # AA: authoritative answer
+PKT_RD = 8  # RD: recursion desired (client requests recursive lookup)
+PKT_RA = 32  # RA: recursion available (server supports recursion)
 
 # ---------------------------------------------------------------------------
 # Response codes (RCODE field in DNS header)
@@ -357,7 +362,10 @@ class reply_info(_Struct):
 
     Key attributes (dynamic SWIG surface):
 
-    - ``flags``       : DNS header flags bitmask (``PKT_QR | PKT_RA | …``).
+    - ``flags``       : WIRE-format DNS header flags word — mask with hex
+                        literals (e.g. ``0x0080`` for RA, ``0x0400`` for AA),
+                        NOT the runtime ``PKT_*`` constants above (a different
+                        vocabulary; see the packet-flags comment).
     - ``an_numrrsets``: Number of RRsets in the answer section.
     - ``rrsets``      : List of RRset objects in the reply.
     - ``security``    : DNSSEC security status integer -- one of the
@@ -404,13 +412,16 @@ class DNSMessage:
         """Attach this message as the response on ``qstate.return_msg``.
 
         Mirrors real Unbound's ``createResponse`` (pythonmod/pythonmod_utils.c):
-        it REPLACES any existing ``qstate.return_msg`` wholesale with a fresh,
-        zeroed reply -- it never mutates one in place. The fresh reply's
-        ``rep.security`` is left at :data:`sec_status_unchecked` (0);
-        ``createResponse`` never stamps security, so a caller that wants a
-        trusted synthesized reply must stamp ``rep.security`` itself, exactly
-        as on the real box -- else the validator treats it as unchecked and
-        SERVFAILs it (issue #149 class).
+        it REPLACES any existing ``qstate.return_msg`` wholesale with a fresh
+        reply -- it never mutates one in place. On the real box the message's
+        RR sections are parsed INTO that fresh reply (``rep.rrsets`` carries
+        the answer); this stub deliberately leaves ``rep`` empty as a
+        simplification -- tests inspect ``DNSMessage.instances[-1].answer``
+        instead. The fresh reply's ``rep.security`` is left at
+        :data:`sec_status_unchecked` (0); ``createResponse`` never stamps
+        security, so a caller that wants a trusted synthesized reply must
+        stamp ``rep.security`` itself, exactly as on the real box -- else the
+        validator treats it as unchecked and SERVFAILs it (issue #149 class).
 
         Also mirrors the Python wrapper's post-success step: sets
         ``rep.authoritative = 1`` iff ``PKT_AA`` is set in this message's

--- a/stubs/python/unboundmodule.py
+++ b/stubs/python/unboundmodule.py
@@ -434,8 +434,20 @@ class DNSMessage:
             True on success.
         """
         self._qstate = qstate
+        # reply_info.flags carries WIRE-format header bits on the real box:
+        # createResponse builds a packet from the runtime PKT_* flags and the
+        # parse fills rep.flags with the wire word — map them the same way.
+        wire_flags = 0
+        if self.flags & PKT_QR:
+            wire_flags |= 0x8000
+        if self.flags & PKT_AA:
+            wire_flags |= 0x0400
+        if self.flags & PKT_RD:
+            wire_flags |= 0x0100
+        if self.flags & PKT_RA:
+            wire_flags |= 0x0080
         qstate.return_msg = types.SimpleNamespace(
-            rep=types.SimpleNamespace(security=0, an_numrrsets=0, rrsets=[], authoritative=0),
+            rep=types.SimpleNamespace(flags=wire_flags, security=0, an_numrrsets=0, rrsets=[], authoritative=0),
             qinfo=types.SimpleNamespace(qname_str=self.qname, qname_list=[]),
         )
         if self.flags & PKT_AA:

--- a/stubs/python/unboundmodule.py
+++ b/stubs/python/unboundmodule.py
@@ -49,6 +49,7 @@ __all__ = [
     "PKT_QR",
     "PKT_RA",
     "PKT_RD",
+    "PKT_AA",
     # Response codes
     "RCODE_NOERROR",
     "RCODE_NXDOMAIN",
@@ -96,6 +97,7 @@ RR_CLASS_IN = 1
 PKT_QR = 0x8000  # QR bit: set -> response, clear -> query
 PKT_RD = 0x0100  # RD bit: recursion desired (client requests recursive lookup)
 PKT_RA = 0x0080  # RA bit: recursion available (server supports recursion)
+PKT_AA = 0x0400  # AA bit: authoritative answer (as used in pythonmod)
 
 # ---------------------------------------------------------------------------
 # Response codes (RCODE field in DNS header)
@@ -358,7 +360,9 @@ class reply_info(_Struct):
     - ``flags``       : DNS header flags bitmask (``PKT_QR | PKT_RA | …``).
     - ``an_numrrsets``: Number of RRsets in the answer section.
     - ``rrsets``      : List of RRset objects in the reply.
-    - ``security``    : DNSSEC security status integer (2 = secure).
+    - ``security``    : DNSSEC security status integer -- one of the
+                        ``sec_status_*`` constants above (0 = unchecked,
+                        4 = secure; NOT 2, which is ``indeterminate``).
     """
 
 
@@ -399,8 +403,18 @@ class DNSMessage:
     def set_return_msg(self, qstate: Any) -> bool:
         """Attach this message as the response on ``qstate.return_msg``.
 
-        Initialises ``qstate.return_msg`` if not already set, then marks the
-        reply as DNSSEC-secure (security = 2) so Unbound accepts it.
+        Mirrors real Unbound's ``createResponse`` (pythonmod/pythonmod_utils.c):
+        it REPLACES any existing ``qstate.return_msg`` wholesale with a fresh,
+        zeroed reply -- it never mutates one in place. The fresh reply's
+        ``rep.security`` is left at :data:`sec_status_unchecked` (0);
+        ``createResponse`` never stamps security, so a caller that wants a
+        trusted synthesized reply must stamp ``rep.security`` itself, exactly
+        as on the real box -- else the validator treats it as unchecked and
+        SERVFAILs it (issue #149 class).
+
+        Also mirrors the Python wrapper's post-success step: sets
+        ``rep.authoritative = 1`` iff ``PKT_AA`` is set in this message's
+        ``flags``.
 
         Args:
             qstate: The :class:`module_qstate` whose ``return_msg`` to populate.
@@ -409,10 +423,10 @@ class DNSMessage:
             True on success.
         """
         self._qstate = qstate
-        if getattr(qstate, "return_msg", None) is None:
-            qstate.return_msg = types.SimpleNamespace(
-                rep=types.SimpleNamespace(security=0, an_numrrsets=0, rrsets=[]),
-                qinfo=types.SimpleNamespace(qname_str=self.qname, qname_list=[]),
-            )
-        qstate.return_msg.rep.security = 2
+        qstate.return_msg = types.SimpleNamespace(
+            rep=types.SimpleNamespace(security=0, an_numrrsets=0, rrsets=[], authoritative=0),
+            qinfo=types.SimpleNamespace(qname_str=self.qname, qname_list=[]),
+        )
+        if self.flags & PKT_AA:
+            qstate.return_msg.rep.authoritative = 1
         return True

--- a/tests/php/IpAddrDoublesTest.php
+++ b/tests/php/IpAddrDoublesTest.php
@@ -9,7 +9,10 @@ use PHPUnit\Framework\TestCase;
 /**
  * is_ipaddrv4() / is_ipaddrv6() / is_ipaddr() / is_linklocal() — pin the
  * pfsense_doubles.php behavioural doubles to REAL pfSense util.inc semantics
- * (verified against pfSense master and the CE-2.8.0-era source; identical).
+ * (verified against pfSense master and the CE-2.8.0-era source at commit
+ * 4ecba17, 2025-03-26 — the youngest util.inc change before the CE 2.8.0
+ * release; both bodies identical, including the redmine #16005 try/catch,
+ * which the filter_var() stand-in absorbs since it cannot throw).
  *
  * Regression for two doubles that modeled util.inc wrongly (issue #721):
  *   - is_ipaddrv4() did an ip2long()/long2ip() ROUND-TRIP that real pfSense
@@ -89,10 +92,12 @@ final class IpAddrDoublesTest extends TestCase
 	public static function linklocalProvider(): array
 	{
 		return [
-			'v4 link-local (169.254/16) -> 4' => ['169.254.1.1', 4],
-			'v6 link-local (fe80::) -> 6'     => ['fe80::1', 6],
-			'v6 non-linklocal -> false'       => ['2001:db8::1', false],
-			'v4 non-linklocal -> false'       => ['10.0.0.1', false],
+			'v4 link-local (169.254/16) -> 4'      => ['169.254.1.1', 4],
+			'v6 link-local (fe80::) -> 6'          => ['fe80::1', 6],
+			'v6 link-local /10 upper bound -> 6'   => ['febf::1', 6],
+			'v6 just past /10 (site-local) falsy'  => ['fec0::1', false],
+			'v6 non-linklocal -> false'            => ['2001:db8::1', false],
+			'v4 non-linklocal -> false'            => ['10.0.0.1', false],
 		];
 	}
 

--- a/tests/php/IpAddrDoublesTest.php
+++ b/tests/php/IpAddrDoublesTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * is_ipaddrv4() / is_ipaddrv6() / is_ipaddr() / is_linklocal() — pin the
+ * pfsense_doubles.php behavioural doubles to REAL pfSense util.inc semantics
+ * (verified against pfSense master and the CE-2.8.0-era source; identical).
+ *
+ * Regression for two doubles that modeled util.inc wrongly (issue #721):
+ *   - is_ipaddrv4() did an ip2long()/long2ip() ROUND-TRIP that real pfSense
+ *     never does; real pfSense is a bare `ip2long($ipaddr) === FALSE` check.
+ *     PHP's ip2long() delegates to libc inet_pton(AF_INET), which accepts only
+ *     the canonical dotted-quad — leading-zero octets ('192.000.002.005') are
+ *     rejected on BOTH FreeBSD (the pfSense/CE target; inet_pton4's
+ *     leading-zero guard) and glibc — so the old round-trip was behaviourally
+ *     equivalent for v4 and this is a control-flow-fidelity fix (mirror
+ *     upstream verbatim, prevent future drift), not a verdict flip.
+ *   - is_ipaddrv6() stripped ANY '%zone' suffix before validating. Real
+ *     pfSense strips it ONLY when the address is link-local (is_linklocal()),
+ *     so a non-link-local zoned address ('2001:db8::1%em0') was wrongly
+ *     accepted by the old double instead of failing validation. This flip IS
+ *     observable off-appliance (confirmed red on the old double, green here).
+ */
+#[CoversFunction('is_ipaddrv4')]
+#[CoversFunction('is_ipaddrv6')]
+#[CoversFunction('is_ipaddr')]
+#[CoversFunction('is_linklocal')]
+final class IpAddrDoublesTest extends TestCase
+{
+	// --- is_ipaddrv4() --------------------------------------------------------
+
+	public static function v4Provider(): array
+	{
+		return [
+			// Rejected on-box and off: ip2long()/inet_pton() accepts only the
+			// canonical dotted-quad on FreeBSD and glibc alike (see class
+			// docblock) — old and fixed doubles agree here; the pinned oracle
+			// is the real pfSense verdict.
+			'leading-zero octets rejected (inet_pton is canonical-only)' => ['192.000.002.005', false],
+			'plain dotted-quad accepted'   => ['192.0.2.5', true],
+			'three-octet form rejected'    => ['1.2.3', false],
+			'out-of-range octet rejected'  => ['256.1.1.1', false],
+			'empty string rejected'        => ['', false],
+			'non-string int rejected'      => [42, false],
+			'non-string null rejected'     => [null, false],
+			'non-string array rejected'    => [['192.0.2.5'], false],
+		];
+	}
+
+	#[DataProvider('v4Provider')]
+	public function testIsIpaddrv4(mixed $input, bool $expected): void
+	{
+		$this->assertSame($expected, is_ipaddrv4($input));
+	}
+
+	// --- is_ipaddrv6() --------------------------------------------------------
+
+	public static function v6Provider(): array
+	{
+		return [
+			'plain v6 accepted' => ['2001:db8::1', true],
+			// The flip: a NON-link-local zoned address keeps its '%zone' (real
+			// pfSense strips '%zone' only for a link-local address) and then
+			// fails validation -- the old double stripped every '%zone' first
+			// and wrongly accepted it.
+			'non-linklocal zoned address rejected'     => ['2001:db8::1%em0', false],
+			'linklocal zone stripped, accepted'        => ['fe80::1%em0', true],
+			'linklocal zone strip is case-insensitive' => ['FE80::1%igb0', true],
+			'cidr-suffixed address rejected'           => ['2001:db8::1/64', false],
+			'double compression rejected'              => ['1::2::3', false],
+			'empty string rejected'                    => ['', false],
+			'non-string int rejected'                  => [42, false],
+		];
+	}
+
+	#[DataProvider('v6Provider')]
+	public function testIsIpaddrv6(mixed $input, bool $expected): void
+	{
+		$this->assertSame($expected, is_ipaddrv6($input));
+	}
+
+	// --- is_linklocal() --------------------------------------------------------
+
+	public static function linklocalProvider(): array
+	{
+		return [
+			'v4 link-local (169.254/16) -> 4' => ['169.254.1.1', 4],
+			'v6 link-local (fe80::) -> 6'     => ['fe80::1', 6],
+			'v6 non-linklocal -> false'       => ['2001:db8::1', false],
+			'v4 non-linklocal -> false'       => ['10.0.0.1', false],
+		];
+	}
+
+	#[DataProvider('linklocalProvider')]
+	public function testIsLinklocal(string $input, int|bool $expected): void
+	{
+		$this->assertSame($expected, is_linklocal($input));
+	}
+
+	// --- is_ipaddr() (existing double, unchanged) ------------------------------
+	//
+	// pfb_get_vips() switches on case 4/6, so the 4/6 bucketing (not a loose
+	// bool) is the load-bearing contract -- one assertion per bucket.
+
+	public function testIsIpaddrBucketsV4AddressAsFour(): void
+	{
+		$this->assertSame(4, is_ipaddr('192.0.2.5'));
+	}
+
+	public function testIsIpaddrBucketsV6AddressAsSix(): void
+	{
+		$this->assertSame(6, is_ipaddr('2001:db8::1'));
+	}
+
+	public function testIsIpaddrReturnsFalseForNonAddress(): void
+	{
+		$this->assertFalse(is_ipaddr('not-an-ip'));
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -48,9 +48,10 @@ if (!function_exists('is_ipaddrv4')) {
 if (!function_exists('is_linklocal')) {
 	// pfSense util.inc: 4 for a 169.254.0.0/16 v4 address, 6 for a link-local v6
 	// address, FALSE otherwise. Off-appliance there is no PEAR Net_IPv6, so the
-	// v6 branch approximates NET_IPV6_LOCAL_LINK with a case-insensitive 'fe80:'
-	// prefix check on the address (checked BEFORE any '%zone' is stripped, same
-	// as upstream — the zone is part of the string Net_IPv6::getAddressType sees).
+	// v6 branch approximates NET_IPV6_LOCAL_LINK (fe80::/10, first hextet
+	// fe80–febf) with a first-hextet pattern check on the address (checked
+	// BEFORE any '%zone' is stripped, same as upstream — the zone is part of
+	// the string Net_IPv6::getAddressType sees).
 	function is_linklocal($ipaddr) {
 		if (is_ipaddrv4($ipaddr)) {
 			$ip4 = explode('.', $ipaddr);
@@ -59,7 +60,7 @@ if (!function_exists('is_linklocal')) {
 			}
 			return false;
 		}
-		if (is_string($ipaddr) && stripos($ipaddr, 'fe80:') === 0) {
+		if (is_string($ipaddr) && preg_match('/^fe[89ab][0-9a-f]:/i', $ipaddr) === 1) {
 			return 6;
 		}
 		return false;

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -9,9 +9,19 @@
  * actually invoke, with FAITHFUL behaviour where a tested function's result
  * depends on it:
  *
- *   - is_ipaddrv4 / is_ipaddrv6 / is_ipaddr — mirror pfSense util.inc exactly
- *     (ip2long round-trip for v4; filter_var for v6). pfb_filter (IP/IPV4) and
+ *   - is_ipaddrv4 / is_ipaddrv6 / is_ipaddr / is_linklocal — mirror pfSense
+ *     util.inc CONTROL FLOW exactly: a bare ip2long() check for v4 (NO
+ *     long2ip() round-trip); for v6 the "/" reject + link-local-only "%zone"
+ *     strip + double-"::" reject, via filter_var() standing in for
+ *     Net_IPv6::checkIPv6 (no PEAR off-appliance). pfb_filter (IP/IPV4) and
  *     pfb_dnsbl_abp_extract_ip depend on their precise accept/reject behaviour.
+ *     NOTE on v4: PHP's ip2long() delegates to libc inet_pton(AF_INET), which
+ *     accepts only the canonical dotted-quad — leading-zero octets like
+ *     '192.000.002.005' are rejected on BOTH FreeBSD (the pfSense/CE target;
+ *     inet_pton4's leading-zero guard) and glibc. Consequently the old
+ *     round-trip was behaviourally equivalent for v4; dropping it is a
+ *     control-flow-fidelity fix (mirror upstream verbatim), not a verdict
+ *     flip. The v6 %zone fix IS a real verdict flip — see IpAddrDoublesTest.
  *
  * Everything else is a minimal no-op/throwaway double: it exists only so the
  * symbol resolves. Functions reached only by code paths the seed suite does NOT
@@ -22,27 +32,59 @@
  */
 
 if (!function_exists('is_ipaddrv4')) {
-	// pfSense util.inc: a string whose ip2long round-trips back to itself.
-	// Rejects '1.2.3', leading-zero octets, out-of-range, non-strings.
+	// pfSense util.inc verbatim: a bare ip2long() check, NO long2ip() round-trip.
+	// Rejects '1.2.3' / out-of-range / leading-zero octets / non-strings —
+	// ip2long() (libc inet_pton) accepts only the canonical dotted-quad, on
+	// FreeBSD and glibc alike (see the file-header NOTE), so this double now
+	// runs the exact same control flow as the real function.
 	function is_ipaddrv4($ipaddr) {
-		if (!is_string($ipaddr) || empty($ipaddr)) {
+		if (!is_string($ipaddr) || empty($ipaddr) || ip2long($ipaddr) === FALSE) {
 			return false;
 		}
-		$ip_long = ip2long($ipaddr);
-		$ip_reverse = long2ip($ip_long);
-		return ($ipaddr === $ip_reverse);
+		return true;
+	}
+}
+
+if (!function_exists('is_linklocal')) {
+	// pfSense util.inc: 4 for a 169.254.0.0/16 v4 address, 6 for a link-local v6
+	// address, FALSE otherwise. Off-appliance there is no PEAR Net_IPv6, so the
+	// v6 branch approximates NET_IPV6_LOCAL_LINK with a case-insensitive 'fe80:'
+	// prefix check on the address (checked BEFORE any '%zone' is stripped, same
+	// as upstream — the zone is part of the string Net_IPv6::getAddressType sees).
+	function is_linklocal($ipaddr) {
+		if (is_ipaddrv4($ipaddr)) {
+			$ip4 = explode('.', $ipaddr);
+			if ($ip4[0] === '169' && $ip4[1] === '254') {
+				return 4;
+			}
+			return false;
+		}
+		if (is_string($ipaddr) && stripos($ipaddr, 'fe80:') === 0) {
+			return 6;
+		}
+		return false;
 	}
 }
 
 if (!function_exists('is_ipaddrv6')) {
-	// pfSense util.inc: strip a zone id (%scope), then FILTER_VALIDATE_IP v6.
+	// pfSense util.inc verbatim ordering: string/empty guard -> reject a "/mask"
+	// suffix -> strip a "%zone" ONLY when the address is link-local (a non-link-
+	// local zoned address like '2001:db8::1%em0' keeps its zone and fails to
+	// validate) -> reject a double "::" (redmine #13069) -> validate. filter_var()
+	// with FILTER_FLAG_IPV6 stands in for Net_IPv6::checkIPv6() (no PEAR off-appliance).
 	function is_ipaddrv6($ipaddr) {
 		if (!is_string($ipaddr) || empty($ipaddr)) {
 			return false;
 		}
-		if (strstr($ipaddr, '%') !== false) {
-			$parts = explode('%', $ipaddr);
-			$ipaddr = $parts[0];
+		if (strstr($ipaddr, '/')) {
+			return false;
+		}
+		if (strstr($ipaddr, '%') && is_linklocal($ipaddr)) {
+			$tmpip = explode('%', $ipaddr);
+			$ipaddr = $tmpip[0];
+		}
+		if (substr_count($ipaddr, '::') > 1) {
+			return false;
 		}
 		return (filter_var($ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false);
 	}

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -20,6 +20,7 @@ from unboundmodule import (
     MODULE_WAIT_MODULE,
     PKT_AA,
     PKT_QR,
+    PKT_RA,
     RCODE_NOERROR,
     RCODE_NXDOMAIN,
     RR_CLASS_IN,
@@ -1003,6 +1004,16 @@ class TestSetReturnMsgStubFidelity:
         assert qstate.return_msg.rep.rrsets == []
         assert qstate.return_msg.rep.an_numrrsets == 0
 
+    def test_rep_flags_carry_wire_format_bits(self) -> None:
+        # Given a message built with runtime PKT_* constants, When
+        # set_return_msg() attaches it, Then rep.flags carries the WIRE-format
+        # header word (as real createResponse's packet parse yields), not the
+        # runtime PKT_* vocabulary -- QR|RA maps to 0x8000|0x0080.
+        qstate = make_qstate("example.com.")
+        msg = DNSMessage("example.com.", RR_A, RR_CLASS_IN, PKT_QR | PKT_RA)
+        assert msg.set_return_msg(qstate) is True
+        assert qstate.return_msg.rep.flags == 0x8080
+
     def test_authoritative_set_only_when_pkt_aa_flagged(self) -> None:
         # Given PKT_AA is set on the message's flags, When set_return_msg()
         # attaches it, Then rep.authoritative is 1; given PKT_AA is absent,
@@ -1037,15 +1048,20 @@ class TestOperateNoAAAA:
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED
+        # The wildcard-path synthesized reply needs the same non-bogus stamp
+        # as the exact-match one (issue #149 class).
+        assert qstate.return_msg.rep.security == 2
         # The wildcard-parent hit is memoized as the child's noaaaa verdict on its
         # Decision, so a subsequent identical query short-circuits on the cache.
         assert pfb_unbound.decisionDB["sub.example.com"].noaaaa is True
         assert evaluate_noaaaa("sub.example.com", pfb_unbound.noAAAADB) is True
-        # Fast-path is unchanged: a subsequent identical query still blocks.
+        # Fast-path is unchanged: a subsequent identical query still blocks,
+        # and the memoized-verdict reply carries the stamp too.
         qstate2 = make_qstate("sub.example.com.", qtype=RR_AAAA)
         rcd2 = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate2, None)
         assert rcd2 is True
         assert qstate2.ext_state[0] == MODULE_FINISHED
+        assert qstate2.return_msg.rep.security == 2
 
     def test_excluded_domain_not_blocked(self) -> None:
         add_noaaaa("example.com", wildcard=False)

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -18,8 +18,11 @@ from unboundmodule import (
     MODULE_FINISHED,
     MODULE_RESTART_NEXT,
     MODULE_WAIT_MODULE,
+    PKT_AA,
+    PKT_QR,
     RCODE_NOERROR,
     RCODE_NXDOMAIN,
+    RR_CLASS_IN,
     DNSMessage,
     sec_status_insecure,
 )
@@ -962,6 +965,56 @@ RR_AAAA = 28
 RR_TXT = 16
 
 
+class TestSetReturnMsgStubFidelity:
+    """DNSMessage.set_return_msg() must model real Unbound's createResponse
+    (pythonmod/pythonmod_utils.c): replace ``return_msg`` wholesale, never
+    mutate an existing one, and never stamp ``rep.security`` itself -- a
+    caller that skips its own stamp must see an unchecked (not falsely
+    secure) reply, or a real DNSSEC-failure class (issue #149) goes untested.
+    """
+
+    def test_leaves_security_unchecked(self) -> None:
+        # Given a fresh DNSMessage, When set_return_msg() attaches it to a
+        # qstate with no prior return_msg, Then rep.security stays at
+        # sec_status_unchecked (0) -- createResponse never stamps security.
+        qstate = make_qstate("example.com.")
+        msg = DNSMessage("example.com.", RR_A, RR_CLASS_IN, PKT_QR)
+        assert msg.set_return_msg(qstate) is True
+        assert qstate.return_msg.rep.security == 0
+
+    def test_replaces_existing_return_msg(self) -> None:
+        # Given a qstate that already carries a return_msg (e.g. a resolved
+        # CNAME chain), When set_return_msg() runs, Then it REPLACES the
+        # object wholesale (a fresh rep/qinfo), never mutating the prior one
+        # in place -- real createResponse always allocates a new reply.
+        sentinel = types.SimpleNamespace(
+            rep=types.SimpleNamespace(security=0, an_numrrsets=2, rrsets=["sentinel"]),
+            qinfo=types.SimpleNamespace(qname_str="old.example.com.", qname_list=[]),
+        )
+        qstate = make_qstate("example.com.", return_msg=sentinel)
+        msg = DNSMessage("example.com.", RR_A, RR_CLASS_IN, PKT_QR)
+        assert msg.set_return_msg(qstate) is True
+        assert qstate.return_msg is not sentinel
+        assert qstate.return_msg.rep is not sentinel.rep
+        assert qstate.return_msg.rep.rrsets == []
+        assert qstate.return_msg.rep.an_numrrsets == 0
+
+    def test_authoritative_set_only_when_pkt_aa_flagged(self) -> None:
+        # Given PKT_AA is set on the message's flags, When set_return_msg()
+        # attaches it, Then rep.authoritative is 1; given PKT_AA is absent,
+        # Then it stays 0 -- both branches of the real Python wrapper's
+        # post-success authoritative stamp.
+        qstate_aa = make_qstate("example.com.")
+        msg_aa = DNSMessage("example.com.", RR_A, RR_CLASS_IN, PKT_QR | PKT_AA)
+        msg_aa.set_return_msg(qstate_aa)
+        assert qstate_aa.return_msg.rep.authoritative == 1
+
+        qstate_no_aa = make_qstate("example.com.")
+        msg_no_aa = DNSMessage("example.com.", RR_A, RR_CLASS_IN, PKT_QR)
+        msg_no_aa.set_return_msg(qstate_no_aa)
+        assert qstate_no_aa.return_msg.rep.authoritative == 0
+
+
 class TestOperateNoAAAA:
     def test_exact_match_blocks(self, monkeypatch: Any) -> None:
         add_noaaaa("example.com", wildcard=False)
@@ -970,6 +1023,9 @@ class TestOperateNoAAAA:
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED
         assert qstate.return_rcode == RCODE_NOERROR
+        # The synthesized AAAA -> A reply is unsigned; it must be stamped
+        # non-bogus or the validator SERVFAILs it (issue #149 class).
+        assert qstate.return_msg.rep.security == 2
 
     def test_wildcard_blocks_subdomain_and_caches(self) -> None:
         add_noaaaa("example.com", wildcard=True)
@@ -1329,6 +1385,9 @@ class TestOperateDnsbl:
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_FINISHED
         assert calls["n"] == 1
+        # The synthesized DNSBL block reply is unsigned; it must be stamped
+        # non-bogus or the validator SERVFAILs it (issue #149 class).
+        assert qstate.return_msg.rep.security == 2
 
     def test_cname_unknown_sentinel_is_never_evaluated(self, monkeypatch: Any) -> None:
         # #714 FIX #3: convert_other() returns the is_unknown() decode-failure sentinel
@@ -1369,6 +1428,30 @@ class TestOperateEvents:
         rcd = pfb_unbound.operate(0, 99, qstate, None)
         assert rcd is True
         assert qstate.ext_state[0] == MODULE_ERROR
+
+
+class TestOperatePythonControlLegacy:
+    """The deprecated DNS-TXT control channel (PFBL-03) is inert unless
+    python_control_legacy is explicitly opted in, but when it IS, its
+    synthesized TXT reply must go through the same DNSSEC-stamping discipline
+    as every other set_return_msg() site (issue #149 class).
+    """
+
+    def test_disable_command_answers_txt_and_stamps_security(self) -> None:
+        # Given the legacy control channel is enabled and the query comes from
+        # loopback, When a valid "python_control.disable" TXT query arrives,
+        # Then operate() synthesizes a TXT reply AND stamps rep.security
+        # non-bogus -- an unstamped synthesized reply is SERVFAILed by the
+        # validator.
+        pfb_unbound.pfb["python_control_legacy"] = True
+        pfb_unbound.pfb["python_control"] = True
+        qstate = make_qstate("python_control.disable.", qtype=RR_TXT, q_ip="127.0.0.1")
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        assert qstate.return_rcode == RCODE_NOERROR
+        assert any("IN TXT" in a for a in DNSMessage.instances[-1].answer)
+        assert qstate.return_msg.rep.security == 2
 
 
 class TestLoadSafeSearchDb:
@@ -1562,6 +1645,9 @@ class TestSafeSearchCnameRedirect:
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert qstate.ext_state[0] == MODULE_FINISHED
         assert any(a.startswith("forcesafe.com. ") and " A 1.2.3.4" in a for a in DNSMessage.instances[-1].answer)
+        # The synthesized SafeSearch answer is unsigned; it must be stamped
+        # non-bogus or the validator SERVFAILs it (issue #149 class).
+        assert qstate.return_msg.rep.security == 2
 
     def test_phase1_plants_cname_and_restarts(self, monkeypatch: Any) -> None:
         # Phase 1 (When the resolved answer does not yet carry our CNAME): plant the

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -986,7 +986,11 @@ class TestSetReturnMsgStubFidelity:
         # Given a qstate that already carries a return_msg (e.g. a resolved
         # CNAME chain), When set_return_msg() runs, Then it REPLACES the
         # object wholesale (a fresh rep/qinfo), never mutating the prior one
-        # in place -- real createResponse always allocates a new reply.
+        # in place -- real createResponse always allocates a new reply. The
+        # empty-rep assertions are faithful here because this message appends
+        # no answer RRs (on-box, createResponse parses the answer section into
+        # the fresh rep; the stub leaves rep empty as a documented
+        # simplification -- answers ride DNSMessage.instances).
         sentinel = types.SimpleNamespace(
             rep=types.SimpleNamespace(security=0, an_numrrsets=2, rrsets=["sentinel"]),
             qinfo=types.SimpleNamespace(qname_str="old.example.com.", qname_list=[]),


### PR DESCRIPTION
Fixes #721

Fixture-fidelity fixes for three test doubles/stubs that modeled real pfSense/Unbound behaviour incorrectly, plus the missing assertions that make the masked regression class detectable.

## 1. `stubs/python/unboundmodule.py` — `DNSMessage.set_return_msg`

Verified against Unbound's `pythonmod/pythonmod_utils.c` (`createResponse`) and the `interface.i` Python wrapper:

- No longer auto-stamps `rep.security = 2`; a fresh reply is left at `sec_status_unchecked` (0), so the caller must stamp security itself — exactly like on the real box. Previously, deleting all four production `rep.security = 2` stamps (the issue-#149 DNSSEC fix class) left the suite green.
- Now **replaces** any existing `qstate.return_msg` wholesale (real `createResponse` allocates a fresh reply; the old stub mutated in place).
- Sets `rep.authoritative = 1` iff `PKT_AA` is in the message flags, mirroring the Python wrapper (added the missing `PKT_AA` constant).
- Corrected the docstring/enum note: in Unbound's `sec_status` enum, 2 is `indeterminate`, not "secure" (secure is 4).

New `TestSetReturnMsgStubFidelity` pins the corrected semantics (red on the old stub), and one `rep.security == 2` assertion was added per production synthesized-reply site — no-AAAA, SafeSearch forced A, `python_control` legacy TXT (previously uncovered; new test), and the DNSBL block reply. Mutation-checked: commenting out any of the four production stamps now goes red.

## 2. `tests/php/pfsense_doubles.php` — `is_ipaddrv4`

Now mirrors `util.inc` verbatim (bare `ip2long($ipaddr) === FALSE` check, no `long2ip()` round-trip), verified identical on pfSense master and the CE-2.8.0-era source (`4ecba17`).

**Correction to the issue text:** the claimed leading-zero verdict flip does not exist. PHP's `ip2long()` delegates to libc `inet_pton(AF_INET)`, which accepts only the canonical dotted-quad on **both** FreeBSD (verified against `freebsd-src` `inet_pton4`'s leading-zero guard) and glibc — `ip2long('192.000.002.005')` is `FALSE` everywhere, on-box included. The old round-trip was therefore behaviourally equivalent for v4; this is a control-flow-fidelity fix (prevent future drift), not a behaviour change. The header comment claiming the round-trip mirrored pfSense is corrected.

## 3. `tests/php/pfsense_doubles.php` — `is_ipaddrv6`

Now mirrors `util.inc`'s real ordering: reject a `/mask` up front → strip a `%zone` **only** for a link-local address → reject a double `::` (redmine #13069) → validate (`filter_var` standing in for `Net_IPv6::checkIPv6`, no PEAR off-appliance). This is a real verdict flip, confirmed red→green: `2001:db8::1%em0` was wrongly accepted by the old double; real pfSense rejects it. Added the `is_linklocal()` double the corrected flow needs (v4 169.254/16 → 4, v6 `fe80:` prefix → 6, else false).

New `IpAddrDoublesTest.php` pins both doubles, `is_linklocal()`, and the existing `is_ipaddr()` 4/6 bucketing that `pfb_get_vips()` depends on.

## Notes for review

- No production code changed; `src/` untouched.
- PHPUnit/PHPStan/PHPCS could not run locally in this environment (composer dist downloads blocked by network policy) — `php -l` plus a behavioural harness (old vs new doubles, expected-vs-actual per case) ran locally; CI is the authoritative PHP gate on this PR.
- Python gates ran locally: full pytest, ruff check/format, mypy — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013baLunt412HLH6L49aF953

---
_Generated by [Claude Code](https://claude.ai/code/session_013baLunt412HLH6L49aF953)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP address handling to better match pfSense behavior, including stricter IPv4 validation and more accurate IPv6 zone handling.
  * Fixed DNS reply behavior so response flags and security status are set more consistently, reducing incorrect reply stamping in filtering features.
  * Corrected synthesized responses to preserve authoritative status when appropriate and avoid overwriting existing reply data unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->