### PR TITLE
pfblockerng: case-insensitive TLD-Allow/HSTS compare + ADR-08 digits/hyphen carve-out (#720)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2107,7 +2107,11 @@ def get_tld(qstate: module_qstate) -> str:
     tld = ""
     try:
         if qstate and qstate.qinfo and len(qstate.qinfo.qname_list) > 1:
-            tld = qstate.qinfo.qname_list[-2]
+            # RFC 4343: DNS name comparison is case-insensitive, but production Unbound's
+            # qname_list preserves the client's wire case (e.g. dns0x20). python_tlds /
+            # hsts_tlds are stored lowercase-only, so lowercase here at the source rather
+            # than at every membership-test call site (#720).
+            tld = qstate.qinfo.qname_list[-2].lower()
     except Exception as e:
         # A qname carrying invalid UTF-8 bytes makes Unbound's qname_list access raise
         # while decoding the labels; swallow it and fall back to an empty TLD rather than
@@ -2130,8 +2134,14 @@ def get_tld_from_name(q_name: str) -> str:
     # CNAME target's TLD-Allow check ran against the wrong label: a target whose real TLD
     # is allowed was falsely blocked, and `tld in hsts_tlds` never fired for a CNAME
     # target (VIP instead of NULL). (#706)
+    #
+    # Lowercased for the same reason as get_tld() (RFC 4343 case-insensitive compare
+    # against the lowercase-only python_tlds/hsts_tlds; #720). The current caller
+    # already passes a lowercased q_name, so this is a no-op there -- it keeps the
+    # pair's contract (both always return a lowercase TLD) consistent for any future
+    # caller that doesn't pre-lowercase.
     parts = q_name.rstrip(".").split(".")
-    return parts[-1] if len(parts) > 1 else ""
+    return parts[-1].lower() if len(parts) > 1 else ""
 
 
 def convert_ipv4(x: Any) -> str:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1752,6 +1752,10 @@ LEVEL_NON_RESTRICTIVE = "non_restrictive"
 # {Han, Hiragana, Katakana, Hangul, Bopomofo}.
 CONFUSABLE_SET = frozenset({"Latin", "Cyrillic", "Greek"})
 _HIGHLY_RESTRICTIVE_SET = frozenset({"Latin", "Han", "Hiragana", "Katakana", "Hangul", "Bopomofo"})
+# ADR-08 Section 2: digits + hyphen are the EURid-exempt, letter-less "Common-only mix"
+# -- legitimate and never touched in Confusable mode, even though they resolve to NO
+# letter-script (same as an empty/control-char/emoji label, which stays flagged; #720).
+_DIGIT_HYPHEN_CHARS = frozenset("0123456789-")
 _SEV_ORDER = {SEV_LEGIT: 0, SEV_FLAGGED: 1, SEV_SUSPICIOUS: 2, SEV_MALICIOUS: 3}
 _DECODE_ERRORS = (UnicodeDecodeError, UnicodeError, ValueError)
 # unicodedata.name() leading token -> script; CJK ideographs name themselves "CJK".
@@ -1806,7 +1810,11 @@ def severity_of(text: str) -> str:
     if len(scripts & CONFUSABLE_SET) >= 2:
         return SEV_MALICIOUS
     if not scripts:
-        return SEV_FLAGGED
+        # A digits/hyphen-only label is the ADR-08 Section 2 Common-only carve-out --
+        # legit, not flagged. Every OTHER scriptless label (empty, control-char, emoji,
+        # combining-marks-alone) has no such contract exemption and stays flagged (the
+        # decision-table's borderline call: "no letter-script -> flagged, NOT legit").
+        return SEV_LEGIT if text and set(text) <= _DIGIT_HYPHEN_CHARS else SEV_FLAGGED
     if restriction_level(scripts) in (LEVEL_SINGLE, LEVEL_HIGHLY_RESTRICTIVE):
         return SEV_LEGIT
     return SEV_SUSPICIOUS

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -796,8 +796,14 @@ def parse_python_tlds(raw: str) -> list[str]:
     blank entries here makes an empty/whitespace-only value parse to ``[]`` (falsy),
     so the caller's plain truthiness guard (``if python_tld and python_tlds:``) behaves
     correctly.
+
+    issue #720: entries are lowercased too. The GUI's TLD checkboxes are lowercase,
+    but the value also splices in the SYSTEM DOMAIN's TLD (``system/domain`` -- a
+    case-preserved free-text field), and the TLD-Allow membership test compares
+    against the lowercased qname label (RFC 4343) -- so normalise the config side
+    at the same read boundary.
     """
-    return [t.strip() for t in raw.split(",") if t.strip()]
+    return [t.strip().lower() for t in raw.split(",") if t.strip()]
 
 
 def _parse_ini_int(config: ConfigParser, section: str, option: str) -> int | None:

--- a/tests/fixtures/adr08_spec/decision_table.json
+++ b/tests/fixtures/adr08_spec/decision_table.json
@@ -16,12 +16,13 @@
       "legit": "none (resolve normally; never touched in Confusable mode).",
       "suspicious": "alert (logged, resolution NOT broken) by default; block only when the opt-in suspicious->block sub-toggle is enabled.",
       "malicious": "block by default (the block-malicious sub-toggle is default-ON; the operator may disable it, downgrading the action to alert).",
-      "flagged": "an undecodable / unresolvable-script label (malformed punycode, or a decoded label whose code points carry no letter-script). NOT malicious; surfaced as flagged so it is never silently passed and never crashes the resolver. Action under the default policy = alert (it is a non-legit anomaly, treated as the suspicious tier for the action mapping)."
+      "flagged": "an undecodable / unresolvable-script label (malformed punycode, or a decoded label whose code points carry no letter-script) THAT IS NOT a digits/hyphen-only Common mix. NOT malicious; surfaced as flagged so it is never silently passed and never crashes the resolver. Action under the default policy = alert (it is a non-legit anomaly, treated as the suspicious tier for the action mapping)."
     },
     "borderline_calls": [
       "Cherokee / Armenian / Coptic mixed with Latin are SUSPICIOUS, not malicious: they confuse with Latin but are outside the high-confidence {Latin,Cyrillic,Greek} trio and have legitimate single-script use; folding them into default-block risks FP without a measured TP need (RESULTS/01 section 3). Revisit only if a future corpus shows a real missed attack class.",
       "Cyrillic+Greek (no Latin) IS malicious: the rule is >=2 of the trio, NOT Latin-anchored (RESULTS/01 section 3); proven by xn--mxa00ab.",
-      "An empty / control-char / emoji label resolves to NO letter-script -> severity 'flagged', NOT 'legit'. It carries no confusable mix so it is not malicious, but it is an anomaly and is surfaced (action = alert), never silently passed."
+      "An empty / control-char / emoji label resolves to NO letter-script -> severity 'flagged', NOT 'legit'. It carries no confusable mix so it is not malicious, but it is an anomaly and is surfaced (action = alert), never silently passed.",
+      "EXCEPTION to the rule above: a digits/hyphen-only label (the EURid Common-only exempt characters, section 2's 'Legitimate (no action)' row) ALSO resolves to NO letter-script, but is 'legit', NOT 'flagged' -- the ADR-08 Section 2 contract carve-out (#720). It is the ONLY scriptless case that reads legit; every other scriptless label (empty/control-char/emoji/marks-only) stays flagged per the row above."
     ],
     "documented_limitations": [
       "Whole-script confusables (an all-Cyrillic look-alike of a Latin word, e.g. xn--80ak6aa92e 'аррӏе') are single-script -> NOT caught. Out of scope (ADR-08 section 7): catching them needs a confusables + protected-brand table, deliberately not built here.",
@@ -189,6 +190,16 @@
       "severity": "suspicious",
       "action": "alert",
       "intent": "Latin+Coptic -> suspicious -> alert. Third non-trio confusable script."
+    },
+    {
+      "id": "digit_hyphen_only",
+      "a_label": "12-21",
+      "decoded": "12-21",
+      "resolved_scripts": [],
+      "restriction_level": "ascii_only",
+      "severity": "legit",
+      "action": "none",
+      "intent": "ADR-08 Section 2: a digits/hyphen-only label (the EURid Common-only exempt characters) resolves to NO letter-script but is legit, never touched in Confusable mode -- distinct from an empty/control-char/emoji label (edge_decode section), which stays flagged (#720)."
     },
     {
       "id": "limitation_whole_script_cyrillic",

--- a/tests/test_adr08_decision_spec.py
+++ b/tests/test_adr08_decision_spec.py
@@ -47,6 +47,9 @@ BORDERLINE CALLS RECORDED (consistent with RESULTS/01)
     carry no letter-script (empty / control char / emoji), resolves to severity
     ``FLAGGED`` -- NOT malicious (no confusable mix) but NOT silently legit either;
     surfaced so it is never silently passed, and the decode never crashes.
+  * EXCEPTION: a digits/hyphen-only label (the EURid Common-only exempt characters,
+    section 2's "Legitimate (no action)" row) also carries no letter-script but
+    resolves ``LEGIT``, not ``FLAGGED`` -- the ONLY scriptless case that does (#720).
 
 DECISION-LABEL DRIVER API (imported by Phases 4/5)
 --------------------------------------------------
@@ -119,6 +122,12 @@ CONFUSABLE_SET = frozenset({"Latin", "Cyrillic", "Greek"})
 # UTS#39 "Highly Restrictive" CJK companions to Han (Jpan / Kore / Hanb).
 CJK_COMPANIONS = frozenset({"Hiragana", "Katakana", "Hangul", "Bopomofo"})
 _HIGHLY_RESTRICTIVE_SET = frozenset({"Latin", "Han"}) | CJK_COMPANIONS
+# ADR-08 section 2: digits/hyphen (Common-only mixes) are the EURid-exempt,
+# letter-less carve-out -- legit, never touched in Confusable mode -- distinct from
+# every OTHER scriptless label (empty/control-char/emoji), which stays flagged
+# (#720). Kept here so this oracle stays in lockstep with the shipped analyzer's
+# severity_of().
+_DIGIT_HYPHEN_CHARS = frozenset("0123456789-")
 
 
 # --------------------------------------------------------------------------- #
@@ -280,7 +289,9 @@ def severity(text: str) -> str:
       * >= 2 of the confusable trio -> MALICIOUS;
       * single resolvable script (incl. all-Latin/-Cyrillic/-Greek) or Latin+CJK
         (Highly Restrictive) -> LEGIT;
-      * a label with NO resolvable letter-script (empty / control / emoji) -> FLAGGED;
+      * a digits/hyphen-only label (Common-only mix, section 2) -> LEGIT;
+      * a label with NO resolvable letter-script AND NOT digits/hyphen-only (empty /
+        control / emoji) -> FLAGGED;
       * any other multi-script mix (fails Highly Restrictive, not the malicious pair)
         -> SUSPICIOUS.
     """
@@ -291,9 +302,11 @@ def severity(text: str) -> str:
     if len(letters & CONFUSABLE_SET) >= 2:
         return SEV_MALICIOUS
 
-    # No resolvable letter-script at all (empty label, control char, emoji) -> flagged.
+    # No resolvable letter-script at all. Digits/hyphen-only is the ADR-08 section 2
+    # Common-only carve-out (legit); every OTHER scriptless label (empty, control
+    # char, emoji) stays flagged.
     if not letters:
-        return SEV_FLAGGED
+        return SEV_LEGIT if text and set(text) <= _DIGIT_HYPHEN_CHARS else SEV_FLAGGED
 
     level = restriction_level(scripts, ascii_only=False)
     if level in (LEVEL_SINGLE, LEVEL_HIGHLY_RESTRICTIVE):

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -948,6 +948,11 @@ class TestSeverityOfDigitHyphenCarveOut:
         # already flagged pre-fix and must remain so).
         assert pfb_unbound.severity_of("") == pfb_unbound.SEV_FLAGGED
         assert pfb_unbound.severity_of("\U0001f4a9") == pfb_unbound.SEV_FLAGGED  # pile of poo
+        # Non-ASCII digits (Arabic-Indic 012, category Nd) are scriptless too but are
+        # NOT in the ASCII-only carve-out set -- pins the boundary so a future
+        # refactor to str.isdigit()/isdecimal() (both True for these) cannot silently
+        # widen the carve-out (#745 review).
+        assert pfb_unbound.severity_of("٠١٢") == pfb_unbound.SEV_FLAGGED
 
     def test_escalate_suspicious_does_not_promote_a_digit_label_to_action(self) -> None:
         # A digits/hyphen-only label reaches idn_confusable_action via classify_idn
@@ -2131,6 +2136,13 @@ class TestParsePythonTlds:
 
     def test_populated_value_parses_and_strips_entries(self) -> None:
         assert parse_python_tlds("com, net ,org") == ["com", "net", "org"]
+
+    def test_entries_are_lowercased(self) -> None:
+        # issue #720: the value can carry the case-preserved system-domain TLD
+        # (free-text `system/domain`, e.g. "MyLab.LOCAL" -> "LOCAL"); the membership
+        # test compares against the lowercased qname label (RFC 4343), so the config
+        # side must normalise at the same read boundary.
+        assert parse_python_tlds("CoM, LOCAL") == ["com", "local"]
 
     def test_empty_parsed_list_does_not_enable_tld_blacklist(self) -> None:
         # Reproduces init_standard's guard verbatim: `if python_tld and python_tlds:`.

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -885,6 +885,15 @@ class TestGetTld:
     def test_none_qstate_returns_empty(self) -> None:
         assert pfb_unbound.get_tld(None) == ""
 
+    def test_mixed_case_wire_label_is_lowercased(self) -> None:
+        # RFC 4343: DNS name comparison is case-insensitive, but production Unbound's
+        # qname_list preserves the CLIENT's wire case (e.g. dns0x20 case
+        # randomization). python_tlds/hsts_tlds are stored lowercase-only, so a
+        # mixed-case wire label must still resolve to the lowercase TLD -- else a
+        # membership test against those lists silently mismatches (#720).
+        qstate = types.SimpleNamespace(qinfo=types.SimpleNamespace(qname_list=["sub", "ExAmPlE", "CoM", ""]))
+        assert pfb_unbound.get_tld(qstate) == "com"
+
     def test_invalid_utf8_qname_returns_empty_not_raise(self) -> None:
         # Regression (issue #328): a qname carrying an invalid UTF-8 byte (0xdc) makes
         # Unbound's qname_list access raise while decoding the labels. get_tld must
@@ -913,6 +922,12 @@ class TestGetTldFromName:
     def test_single_label_returns_empty(self) -> None:
         assert pfb_unbound.get_tld_from_name("com") == ""
         assert pfb_unbound.get_tld_from_name("") == ""
+
+    def test_mixed_case_name_is_lowercased(self) -> None:
+        # Same RFC 4343 contract as get_tld(): a CNAME target string carrying mixed
+        # case must still resolve to the lowercase TLD python_tlds/hsts_tlds compare
+        # against (#720).
+        assert pfb_unbound.get_tld_from_name("sub.ExAmPlE.CoM") == "com"
 
 
 class TestGetQIp:
@@ -2376,6 +2391,27 @@ class TestEvaluateDomainGolden:
         dec_allowed = evaluate_domain("example.com", "example.com", "com", False, cfg, containers)
         assert dec_allowed.is_found is False
 
+    def test_tld_allow_mixed_case_query_gets_same_verdict_as_lowercase(self) -> None:
+        # #720: python_tlds is stored lowercase-only ("com"); operate() derives ``tld``
+        # via get_tld(qstate), which reads production Unbound's qname_list -- carrying
+        # the CLIENT's wire case (RFC 4343 case-insensitive compare, e.g. dns0x20). A
+        # mixed-case query for an ALLOWED tld must resolve exactly like its lowercase
+        # form, not be falsely TLD-Allow-blocked because the raw-case label ("CoM")
+        # never matched the lowercase list.
+        cfg = _make_cfg(python_tld=True, python_tlds=["com"])
+        containers = _make_containers()
+
+        # Before-state: the lowercase wire form's tld ("com") is allowed -> passes.
+        tld_lower = pfb_unbound.get_tld(make_qstate("example.com."))
+        dec_lower = evaluate_domain("example.com", "example.com", tld_lower, False, cfg, containers)
+        assert dec_lower.is_found is False
+
+        # A mixed-case wire form of the SAME domain must get the SAME verdict.
+        tld_mixed = pfb_unbound.get_tld(make_qstate("ExAmPlE.CoM."))
+        assert tld_mixed == "com"
+        dec_mixed = evaluate_domain("example.com", "example.com", tld_mixed, False, cfg, containers)
+        assert dec_mixed.is_found is False
+
     def test_idn_block(self) -> None:
         cfg = _make_cfg(python_idn=True)
         containers = _make_containers()
@@ -2446,6 +2482,32 @@ class TestEvaluateDomainGolden:
         assert dec.in_hsts is True
         assert dec.p_type == "HSTS_TLD"
         assert dec.null_blocking is True
+
+    def test_hsts_tld_mixed_case_query_still_null_blocks(self) -> None:
+        # #720: hsts_tlds is stored lowercase-only ("app"); a mixed-case query under
+        # an HSTS TLD must still trip the NULL-block override (p_type HSTS_TLD, same
+        # as its lowercase form) -- not fall through to a VIP block and serve the
+        # block page under the wrong certificate (an HSTS violation) because
+        # get_tld() returned the raw wire-case label.
+        data_db: dict = {"evil.app": {"log": "1", "index": 0}}
+        fgi_db: dict = {0: {"feed": "F", "group": "G"}}
+        containers = _make_containers(dataDB=data_db, feedGroupIndexDB=fgi_db)
+        cfg = _make_cfg(dataDB=True, hstsDB=True, hsts_tlds=("app",))
+
+        # Before-state: the lowercase wire form's tld ("app") trips the override.
+        tld_lower = pfb_unbound.get_tld(make_qstate("evil.app."))
+        dec_lower = evaluate_domain("evil.app", "evil.app", tld_lower, False, cfg, containers)
+        assert dec_lower.in_hsts is True
+        assert dec_lower.p_type == "HSTS_TLD"
+        assert dec_lower.null_blocking is True
+
+        # A mixed-case wire form of the SAME domain must get the SAME override.
+        tld_mixed = pfb_unbound.get_tld(make_qstate("Evil.APP."))
+        assert tld_mixed == "app"
+        dec_mixed = evaluate_domain("evil.app", "evil.app", tld_mixed, False, cfg, containers)
+        assert dec_mixed.in_hsts is True
+        assert dec_mixed.p_type == "HSTS_TLD"
+        assert dec_mixed.null_blocking is True
 
     def test_cname_b_type_suffix(self) -> None:
         data_db: dict = {"evil.com": {"log": "1", "index": 0}}

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -930,6 +930,43 @@ class TestGetTldFromName:
         assert pfb_unbound.get_tld_from_name("sub.ExAmPlE.CoM") == "com"
 
 
+class TestSeverityOfDigitHyphenCarveOut:
+    """ADR-08 Section 2: a digits/hyphen-only decoded label (the EURid Common-only
+    exempt characters) is LEGITIMATE and must never be touched in Confusable mode --
+    distinct from every OTHER scriptless label (empty / control-char / emoji), which
+    stays FLAGGED. Pins the narrow carve-out, not a blanket "any empty script set is
+    legit" rule (#720)."""
+
+    def test_digits_and_hyphen_only_label_is_legit(self) -> None:
+        assert pfb_unbound.severity_of("24") == pfb_unbound.SEV_LEGIT
+        assert pfb_unbound.severity_of("123-45") == pfb_unbound.SEV_LEGIT
+
+    def test_other_scriptless_labels_stay_flagged(self) -> None:
+        # The contrast that proves the carve-out is narrow: an empty label and an
+        # emoji label (neither is digits/hyphen) resolve to NO letter-script too, but
+        # must stay flagged -- behaviour-PRESERVING on both sides of #720 (these were
+        # already flagged pre-fix and must remain so).
+        assert pfb_unbound.severity_of("") == pfb_unbound.SEV_FLAGGED
+        assert pfb_unbound.severity_of("\U0001f4a9") == pfb_unbound.SEV_FLAGGED  # pile of poo
+
+    def test_escalate_suspicious_does_not_promote_a_digit_label_to_action(self) -> None:
+        # A digits/hyphen-only label reaches idn_confusable_action via classify_idn
+        # whenever ANY label in the name is xn-- (is_idn_domain gates on the WHOLE
+        # name, then classify_idn analyses EVERY label) -- e.g. a numeric subdomain
+        # under an otherwise-legit punycode label. Pre-fix "24" was FLAGGED and
+        # treated like the suspicious tier for the action mapping, so BOTH the
+        # default (alert) and the escalate-suspicious opt-in (block) falsely touched
+        # this benign numeric label. Post-fix it resolves untouched under EITHER
+        # toggle state -- the real branch contrast, not merely "escalation happens to
+        # be off".
+        q_name = "24.xn--mnchen-3ya.com"  # digit subdomain + a legit accented-Latin label
+        action_off, _ = pfb_unbound.idn_confusable_action(q_name, block_malicious=True, escalate_suspicious=False)
+        assert action_off == pfb_unbound.IDN_ACT_NONE
+
+        action_on, _ = pfb_unbound.idn_confusable_action(q_name, block_malicious=True, escalate_suspicious=True)
+        assert action_on == pfb_unbound.IDN_ACT_NONE
+
+
 class TestGetQIp:
     def test_first_node_with_addr_wins(self) -> None:
         node2 = types.SimpleNamespace(query_reply=types.SimpleNamespace(addr="2.2.2.2"), next=None)


### PR DESCRIPTION
Fixes #720.

Two test-masked production correctness bugs in `pfb_unbound.py`, each landed as its own commit with red→green coverage (all six pinning tests verified failing against the pre-fix source).

## 1. TLD-Allow / HSTS compare was case-sensitive against the raw wire case (RFC 4343)

`operate()` lowercases the names it evaluates, but the non-CNAME `tld` came from `get_tld()` = `qname_list[-2]` in the client's original case — so a mixed-case query (dns0x20-style or case-preserving clients) failed the lowercase-only membership tests: a name whose TLD **is** in the TLD-Allow list was falsely blocked, and an HSTS-TLD name missed the NULL override (VIP instead of NULL → cert error on the block page). Fixed at the source: `get_tld()` and `get_tld_from_name()` now return the lowercased label, covering both membership sites. Tests: unit (mixed-case label → lowercase) plus path-level TLD-Allow and HSTS cases asserting the mixed-case query gets the identical verdict to its lowercase form (before-state asserted first).

## 2. ADR-08: a digits/hyphen-only label was flagged; the contract says legitimate

`severity_of()` returned `flagged` for any empty script set, but ADR-08 §2 lists Common-only mixes (digits/hyphen) under "Legitimate (no action) — must never be touched in Confusable mode" (and the Phase-1 instrument encoded exactly that). With the opt-in `escalate_suspicious`, a legitimate name containing a purely numeric label was **blocked**. Fixed with the narrow carve-out that reconciles the ADR contract with the Phase-2 spec's documented borderline call: a scriptless label whose characters are all ASCII digits/hyphen → `legit`; every other scriptless label (empty/control/emoji/marks-only) **stays** `flagged`, and decode errors are untouched. The decision-table `_meta`, the golden row (`12-21` → legit/none), and the Phase-2 oracle were updated in lockstep so spec and analyzer agree; a contrast test pins that the carve-out is narrow (emoji label still flagged), and the escalate-ON branch is asserted not to promote a digit label.

## Verification

- Full suite 2000 passed (re-run after rebasing onto the live `devel` tip); `ruff check` / `ruff format --check` / `mypy tests/` clean.
- Red→green proven independently by the orchestrator: all 6 pinning tests fail against the `origin/devel` source for the exact reported reasons.
- Both features are opt-in (`python_tld` / ADR-08 Confusable mode); no `www/` change (no UI tier required); no manifest/swap/hook surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)