### PR TITLE
pfblockerng: keep ABP ||host^ wildcard zone at any anchor depth

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4012,7 +4012,9 @@ class BlockDomainRule:
     """A reconciled domain BLOCK ready to emit into dataDB/zoneDB (Phase 6).
 
     ``cls`` is DNSBL_CLASS_DATA (exact) or DNSBL_CLASS_ZONE (wildcard); ``key`` is
-    the registrable parent for a ZONE or the exact domain for DATA (from classify).
+    the anchor domain itself for a ZONE (ABP ``||host^`` covers subdomains at any
+    depth -- no registrable-parent reduction, #718) or the exact domain for DATA
+    (an exact fold, or a TLD-exclusion carve-out).
     """
 
     cls: str

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4097,13 +4097,17 @@ def reconcile(
          ``$badfilter`` rules themselves emit nothing. USER rules are IMMUNE (never
          collected, never pruned -- sovereignty, fact 7).
       2. REGEX REDUCTION: a reducible regex Rule folds to a domain rule (block ->
-         data/zone via classify, allow -> whiteDB wildcard); irreducible regex
-         passes through into the irreducible set (compiled in Phase 6).
-      3. CLASSIFY domain blocks data vs zone via ``classify`` (reuse ADR-06).
+         data/zone by its wildcard bit, allow -> whiteDB wildcard); irreducible
+         regex passes through into the irreducible set (compiled in Phase 6).
+      3. DATA vs ZONE: a wildcard block (``||host^`` / wildcard fold) emits a ZONE
+         keyed at the anchor itself -- ABP subdomain coverage at ANY depth (#718);
+         a TLD-exclusion domain still forces exact DATA; an exact fold stays DATA.
       4. ASSIGN priority BANDS to every surviving rule (``_dnsbl_rule_band``).
 
-    ``tlds`` / ``exclusion`` are the classify inputs (same shapes build() uses).
-    Matches the Phase-2 oracle ``reconcile`` + ``decide`` precedence.
+    ``exclusion`` is the TLD-exclusion set (same shape build() uses). ``tlds`` is
+    kept for signature stability but no longer consulted: classify's registrable-
+    parent rule is a plain/hosts-path concept (ADR-06) that must not demote an ABP
+    anchor. Matches the Phase-2 oracle ``reconcile`` + ``decide`` precedence.
     """
     rule_list = list(rules)
 
@@ -4169,11 +4173,15 @@ def reconcile(
                 )
             )
         else:
-            # BLOCK domain -> classify data vs zone (reuse ADR-06 classify). A
-            # wildcard=False fold (exact /^D$/) is forced to DATA; otherwise the
-            # registrable-parent classify decides (matching the plain/hosts path).
-            if wildcard:
-                cls, key = classify(domain, tlds, exclusion)
+            # BLOCK domain -> data vs zone. ABP wildcard semantics come from the
+            # rule itself: ``||host^`` (and a wildcard-shaped regex fold) covers
+            # host + ALL subdomains, so it emits a ZONE keyed at the anchor at any
+            # depth (#718) -- classify's registrable-parent rule is a plain/hosts
+            # path concept and must not demote an ABP anchor. TLD exclusion still
+            # opts a domain out of wildcarding (transparent exact DATA), and a
+            # wildcard=False fold (exact /^D$/) stays forced to DATA.
+            if wildcard and domain not in exclusion:
+                cls, key = DNSBL_CLASS_ZONE, domain
             else:
                 cls, key = DNSBL_CLASS_DATA, domain
             result.block_domains.append(

--- a/tests/fixtures/adr07_corpus/regex_irreducible.txt
+++ b/tests/fixtures/adr07_corpus/regex_irreducible.txt
@@ -24,9 +24,16 @@
 !
 ! --- deliberately ReDoS-shaped patterns (catastrophic-backtracking exemplars).
 !     Real feeds rarely ship these, but the safety layer must handle them; the
-!     spike times their worst real first-hit on a <=253-char crafted input. ---
+!     spike times their worst real first-hit on a <=253-char crafted input.
+!     NOTE: the nested-quantifier body is anchored to a fixed literal domain
+!     (redos-exemplar.example) rather than a bare \w+ catch-all -- a bare \w+$
+!     tail matches EVERY dotted probe (any domain name), which silently masked
+!     the corpus-wide reconcile-vs-oracle equivalence test (issue #718). Still
+!     a genuine nested-quantifier catastrophic shape (`_regex_is_catastrophic_shape`
+!     stays True on the inner `(\w+\.)+`); it just no longer swallows unrelated
+!     probes. ---
 /^(a+)+$/
 /^(a|a)+$/
-/^(\w+\.)+\w+$/
+/^(\w+\.)+redos-exemplar\.example$/
 /^([a-z]+)*\.example$/
 /^(.*a){20}$/

--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -1,8 +1,9 @@
 """ADR-07 — the ABP DNSBL smoke matrix (live pfSense VM).
 
 Proves the **full Adblock-Plus DNS decision logic** (``@@`` exceptions, cross-feed
-``@@``, ``$important`` / ``$badfilter`` precedence, regex block/allow + admitted
-count, whitelist sovereignty, and the opt-in regex static cap) holds END-TO-END on
+``@@``, deep-anchor subdomain coverage (#718), ``$important`` / ``$badfilter``
+precedence, regex block/allow + admitted count, whitelist sovereignty, and the
+opt-in regex static cap) holds END-TO-END on
 a real resolver — what the pure ADR-07 unit oracle (``tests/test_adr07_*``) cannot:
 it models ``decide()`` in Python, but only a live Unbound + ``pfb_unbound.py`` loader
 proves the manifest build + matcher agree with that model on the box.
@@ -142,6 +143,48 @@ def test_abp_exception_unblocks(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_f
         ans_good = h.dns_probe_client(client_vm, good, "A")
         assert h.resolves_to(ans_good, PASS_IP), f"exempted {good} should resolve to {PASS_IP}, got {ans_good}"
         assert not h.is_vip(ans_good), f"exempted {good} wrongly VIP-blocked: {ans_good}"
+
+
+# --------------------------------------------------------------------------- #
+# 1b) Deep anchor — ||host^ covers subdomains at ANY anchor depth (#718)
+# --------------------------------------------------------------------------- #
+
+
+def test_abp_deep_anchor_blocks_subdomains(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """A ≥3-label ABP anchor ``||ads.base^`` blocks its own subdomains (#718).
+
+    ``||host^`` covers the host AND all its subdomains regardless of
+    registrable-parent depth: the anchor emits a wildcard ZONE keyed at itself
+    (reconcile no longer demotes a deeper-than-registrable anchor to an exact
+    entry). Scenario: Given a feed anchoring ``ads.<base>``, When the client
+    queries the unlisted parent, the anchor apex, and a subdomain of the anchor,
+    Then the parent resolves (block scoped to the anchor) while apex AND
+    subdomain are VIP-blocked.
+    """
+    base = h.unique_domain("abpdeep")
+    anchor = f"ads.{base}"  # 3-label anchor -- deeper than the registrable parent
+    deep = f"deep.{anchor}"  # subdomain of the anchor
+    body = h.abp_feed(f"||{anchor}^")
+    feed_url = h.write_local_feed(deployed_vm, "smoke_abp_deep.txt", body)
+    spec = h.DnsblCase(
+        aliasname="smokeabpdeep",
+        feed_url=feed_url,
+        header="smokeabpdeep",
+        mode=h.DnsblMode.VIP,
+        control_local_data={base: {"A": PASS_IP}},
+    )
+    with h.CaseContext(deployed_vm, spec):
+        # Given: the unlisted parent still resolves -- proves the zone is keyed at
+        # the anchor, not lifted/widened to the registrable parent.
+        ans_base = h.dns_probe_client(client_vm, base, "A")
+        assert h.resolves_to(ans_base, PASS_IP), f"unlisted parent {base} should resolve to {PASS_IP}, got {ans_base}"
+        # Then: the anchor apex and its subdomain are both VIP-blocked.
+        ans_anchor = h.dns_probe_client(client_vm, anchor, "A")
+        assert h.is_vip(ans_anchor), f"anchor {anchor} expected VIP block, got {ans_anchor}"
+        ans_deep = h.dns_probe_client(client_vm, deep, "A")
+        assert h.is_vip(ans_deep), f"{deep} (subdomain of deep anchor) expected VIP block, got {ans_deep}"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_adr06_build_module.py
+++ b/tests/test_adr06_build_module.py
@@ -43,6 +43,7 @@ import pfb_unbound
 # Reuse the Phase-2 oracle's fixtures, golden decision tables and decision driver so
 # the new build layer is validated against the EXACT same contract, not a copy.
 from tests.test_adr06_golden_oracle import (
+    GOLDEN_ABP_CONFORMANT_OVERRIDES,
     GOLDEN_EXTRACTED_IPS,
     GOLDEN_TOP1M_DISABLED,
     GOLDEN_TOP1M_ENABLED_OVERRIDES,
@@ -294,8 +295,10 @@ class TestBuildDecisionsTop1mDisabled:
 
     def test_decisions(self) -> None:
         result, config = _run_build(top1m_enabled=False)
+        expected_map = dict(GOLDEN_TOP1M_DISABLED)
+        expected_map.update(GOLDEN_ABP_CONFORMANT_OVERRIDES)  # conformant ABP zones (#718)
         failures: list[str] = []
-        for q_name, expected in GOLDEN_TOP1M_DISABLED.items():
+        for q_name, expected in expected_map.items():
             got = _evaluate_build(result, config, q_name)
             for k, v in expected.items():
                 if got[k] != v:
@@ -311,6 +314,7 @@ class TestBuildDecisionsTop1mEnabled:
         result, config = _run_build(top1m_enabled=True)
         expected_map = dict(GOLDEN_TOP1M_DISABLED)
         expected_map.update(GOLDEN_TOP1M_ENABLED_OVERRIDES)
+        expected_map.update(GOLDEN_ABP_CONFORMANT_OVERRIDES)  # conformant ABP zones (#718)
         failures: list[str] = []
         for q_name, expected in expected_map.items():
             got = _evaluate_build(result, config, q_name)

--- a/tests/test_adr06_golden_oracle.py
+++ b/tests/test_adr06_golden_oracle.py
@@ -491,7 +491,9 @@ GOLDEN_TOP1M_DISABLED: dict[str, dict[str, Any]] = {
     "silentblock.com": {"decision": "block-nolog", "b_type": "TLD"},
     # basic-ABP "||domain^" 2-label -> blocked ZONE.
     "abpblocked.com": {"decision": "block-null", "b_type": "TLD"},
-    # basic-ABP deep "||sub.abpzone.net^" (parent abpzone.net NOT listed) -> DATA.
+    # basic-ABP deep "||sub.abpzone.net^" (parent abpzone.net NOT listed): the
+    # LEGACY pass demoted it to exact DATA -- pinned here for the reference
+    # pipeline only; production overlays GOLDEN_ABP_CONFORMANT_OVERRIDES (#718).
     "sub.abpzone.net": {"decision": "block-null", "b_type": "DNSBL"},
     "abpzone.net": {"decision": "pass"},
     # basic-ABP IGNORED lines -> NOT blocked (pass-through):
@@ -517,6 +519,20 @@ GOLDEN_TOP1M_DISABLED: dict[str, dict[str, Any]] = {
 # is identical. Asserting both scenarios pins the TOP1M-when-enabled decision.
 GOLDEN_TOP1M_ENABLED_OVERRIDES: dict[str, dict[str, Any]] = {
     "popularcdn.com": {"decision": "whitelist"},
+}
+
+# INTENTIONAL divergence from the legacy pipeline (#718): a conformant ABP
+# "||host^" anchor covers host + ALL subdomains at ANY depth, so production emits
+# a wildcard ZONE where the legacy basic-ABP pass demoted a deep anchor to exact
+# DATA. The reference pipeline (and the GOLDEN dicts above) keep the legacy
+# behaviour; the production-side suites (build module / init-from-raw) overlay
+# these expectations, and the old-loader equivalence comparison skips exactly
+# these keys.
+GOLDEN_ABP_CONFORMANT_OVERRIDES: dict[str, dict[str, Any]] = {
+    # the deep anchor now matches as a zone (b_type TLD); same block decision.
+    "sub.abpzone.net": {"decision": "block-null", "b_type": "TLD"},
+    # ...and its subdomain is now covered (the legacy pass resolved it).
+    "deep.sub.abpzone.net": {"decision": "block-null", "b_type": "TLD"},
 }
 
 # The extracted-IP firewall handoff set (the *_v4.ip -> DNSBLIP_v4 input). Comes

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -44,6 +44,7 @@ import pfb_unbound
 # against the EXACT same contract -- never a copy.
 from tests.test_adr06_golden_oracle import (
     FIXTURES,
+    GOLDEN_ABP_CONFORMANT_OVERRIDES,
     GOLDEN_EXTRACTED_IPS,
     GOLDEN_TOP1M_DISABLED,
     GOLDEN_TOP1M_ENABLED_OVERRIDES,
@@ -162,7 +163,9 @@ class TestInitFromRawDecisionsTop1mDisabled:
         result = _build_from_manifest(tmp_path, top1m_enabled=False)
         config = _load_json("config.json")
         failures: list[str] = []
-        for q_name, expected in GOLDEN_TOP1M_DISABLED.items():
+        expected_map = dict(GOLDEN_TOP1M_DISABLED)
+        expected_map.update(GOLDEN_ABP_CONFORMANT_OVERRIDES)  # conformant ABP zones (#718)
+        for q_name, expected in expected_map.items():
             got = _evaluate_result(result, config, q_name)
             for k, v in expected.items():
                 if got[k] != v:
@@ -176,6 +179,7 @@ class TestInitFromRawDecisionsTop1mEnabled:
         config = _load_json("config.json")
         expected_map = dict(GOLDEN_TOP1M_DISABLED)
         expected_map.update(GOLDEN_TOP1M_ENABLED_OVERRIDES)
+        expected_map.update(GOLDEN_ABP_CONFORMANT_OVERRIDES)  # conformant ABP zones (#718)
         failures: list[str] = []
         for q_name, expected in expected_map.items():
             got = _evaluate_result(result, config, q_name)
@@ -217,6 +221,10 @@ class TestInitFromRawEqualsOldLoader:
 
         failures: list[str] = []
         for q_name in expected_map:
+            if q_name in GOLDEN_ABP_CONFORMANT_OVERRIDES:
+                # INTENTIONAL divergence (#718): conformant ABP deep anchors emit a
+                # wildcard zone; the legacy pipeline demoted them to exact DATA.
+                continue
             new = _evaluate_result(result, config, q_name)
             old = _evaluate(pipeline, config, q_name)
             if new != old:

--- a/tests/test_adr07_emit_wire.py
+++ b/tests/test_adr07_emit_wire.py
@@ -351,6 +351,19 @@ class TestLiveMatcherEqualsOracle:
         for q in ("example.com", "sub.example.com"):
             assert _live_label(res, q) == _oracle_label(feeds, [], q)
 
+    def test_deep_anchor_blocks_subdomains(self) -> None:
+        # ABP anchor semantics: ||host^ blocks host AND every subdomain of host,
+        # regardless of how many labels sit above host's own registrable parent
+        # (Phase-2 oracle decide(): "rule.wildcard and q.endswith('.' + rule.key)",
+        # no depth restriction). A THREE-label anchor like ||ads.example.com^ must
+        # cover deep.ads.example.com exactly as a two-label anchor covers its subs.
+        feeds = {"f": ["||ads.example.com^"]}
+        res = _build(feeds)
+        assert _live_label(res, "ads.example.com") == "block"
+        assert _live_label(res, "deep.ads.example.com") == "block"
+        for q in ("ads.example.com", "deep.ads.example.com", "example.com", "other.example.com"):
+            assert _live_label(res, q) == _oracle_label(feeds, [], q)
+
 
 # --------------------------------------------------------------------------- #
 # 4. User sovereignty (fact 7) is absolute -- user rules win over feeds + $important

--- a/tests/test_adr07_php_boundary.py
+++ b/tests/test_adr07_php_boundary.py
@@ -187,7 +187,9 @@ class TestRawAbpBoundaryDecisions:
     # TLD master), so ``||example.com^`` classifies to a wildcard ZONE covering its
     # subdomains -- matching the Phase-2 oracle's wildcard semantics. The ``@@``
     # exception carves a subdomain back out of an overarching block (the real
-    # over-blocking fix; the old PHP lite parser dropped it).
+    # over-blocking fix; the old PHP lite parser dropped it). ``||ads.metrics.net^``
+    # is a DEEPER anchor (its own registrable parent is metrics.net, one level up):
+    # ABP semantics still cover ITS subdomains too, regardless of that extra depth.
     FEED = [
         "[Adblock Plus 2.0]",  # header (PHP drops; never reaches Python)
         "! Title: test",  # comment (dropped)
@@ -201,6 +203,7 @@ class TestRawAbpBoundaryDecisions:
         "##.banner",  # element-hiding (skip)
         "||img.example.net/banner.gif",  # path/URL (skip)
         "||evil.example.net^$third-party",  # page-context option (skip)
+        "||ads.metrics.net^",  # deep anchor -- blocks its subdomains too
     ]
 
     QUERIES = [
@@ -214,6 +217,9 @@ class TestRawAbpBoundaryDecisions:
         "img.example.net",  # path/URL skipped -> not blocked
         "evil.example.net",  # page-context option skipped -> not blocked
         "nothing.example.org",
+        "ads.metrics.net",  # deep anchor itself -> blocked
+        "deep.ads.metrics.net",  # deep anchor's subdomain -> blocked too
+        "metrics.net",  # unblocked parent -- must stay unblocked
     ]
 
     def test_decisions_match_oracle(self) -> None:

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -293,14 +293,27 @@ class TestClassify:
         b = res.block_domains[0]
         assert (b.cls, b.key) == (P.DNSBL_CLASS_ZONE, "example.com")
 
-    def test_subdomain_block_classifies_via_classify(self) -> None:
-        # ||ads.example.com^ -> classify(ads.example.com) -> DATA (deeper sub) but
-        # wildcard zone semantics come from the rule covering subs; verify classify
-        # agreement directly.
+    def test_deep_anchor_classifies_zone_at_its_own_key(self) -> None:
+        # ABP semantics: ||host^ blocks host AND every subdomain, no matter how many
+        # labels sit above host's own registrable parent (the oracle decide() has no
+        # depth restriction). A deep anchor like ||ads.example.com^ must classify as
+        # ZONE at its OWN key -- NOT get demoted to an exact DATA entry that would
+        # silently drop subdomain coverage.
         res = _reconcile(["||ads.example.com^"])
         b = res.block_domains[0]
-        cls, key = P.classify("ads.example.com", _TLDS, _EXCLUSION)
-        assert (b.cls, b.key) == (cls, key)
+        assert (b.cls, b.key) == (P.DNSBL_CLASS_ZONE, "ads.example.com")
+        assert _resolve(res, "deep.ads.example.com") == "block"
+
+    def test_deep_anchor_exclusion_forces_exact_data(self) -> None:
+        # The OTHER side of the branch (CLAUDE.md: assert every branch, not one
+        # side): a whole-domain TLD exclusion is the user's knob to opt a domain
+        # OUT of wildcarding, so it still forces a transparent exact DATA entry even
+        # for a deep anchor -- subdomains stay unblocked.
+        rules = _production_rules(["||ads.example.com^"])
+        res = P.reconcile(rules, _TLDS, {"ads.example.com"})
+        b = res.block_domains[0]
+        assert (b.cls, b.key) == (P.DNSBL_CLASS_DATA, "ads.example.com")
+        assert _resolve(res, "deep.ads.example.com") == "pass"
 
     def test_exact_fold_forces_data(self) -> None:
         # an exact /^D$/ fold (wildcard=False) must NOT be wildcarded into a zone.

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -285,7 +285,8 @@ class TestRegexReduction:
 
 
 # --------------------------------------------------------------------------- #
-# 3. classify reuse: domain blocks -> data vs zone (ADR-06 classify)
+# 3. DATA vs ZONE: an ABP wildcard block is a zone at its own key at any depth
+#    (#718); the exact fold and the TLD-exclusion carve-out stay exact DATA.
 # --------------------------------------------------------------------------- #
 class TestClassify:
     def test_registrable_parent_is_zone(self) -> None:
@@ -300,6 +301,15 @@ class TestClassify:
         # ZONE at its OWN key -- NOT get demoted to an exact DATA entry that would
         # silently drop subdomain coverage.
         res = _reconcile(["||ads.example.com^"])
+        b = res.block_domains[0]
+        assert (b.cls, b.key) == (P.DNSBL_CLASS_ZONE, "ads.example.com")
+        assert _resolve(res, "deep.ads.example.com") == "block"
+
+    def test_deep_wildcard_regex_fold_classifies_zone_at_its_own_key(self) -> None:
+        # The OTHER wildcard source: a wildcard-shaped reducible regex folds to the
+        # same shape as its ||host^ literal form, so a deep fold must also keep its
+        # zone at the anchor key -- pins that the regex-fold arm shares the #718 fix.
+        res = _reconcile([r"/^(.+\.)?ads\.example\.com$/"])
         b = res.block_domains[0]
         assert (b.cls, b.key) == (P.DNSBL_CLASS_ZONE, "ads.example.com")
         assert _resolve(res, "deep.ads.example.com") == "block"

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -305,10 +305,9 @@ class TestClassify:
         assert _resolve(res, "deep.ads.example.com") == "block"
 
     def test_deep_anchor_exclusion_forces_exact_data(self) -> None:
-        # The OTHER side of the branch (CLAUDE.md: assert every branch, not one
-        # side): a whole-domain TLD exclusion is the user's knob to opt a domain
-        # OUT of wildcarding, so it still forces a transparent exact DATA entry even
-        # for a deep anchor -- subdomains stay unblocked.
+        # The other side of the branch: a whole-domain TLD exclusion is the user's
+        # knob to opt a domain OUT of wildcarding, so it still forces a transparent
+        # exact DATA entry even for a deep anchor -- subdomains stay unblocked.
         rules = _production_rules(["||ads.example.com^"])
         res = P.reconcile(rules, _TLDS, {"ads.example.com"})
         b = res.block_domains[0]


### PR DESCRIPTION
Fixes #718

## What

An ABP `||host^` anchor must block the host **and all its subdomains**. Production `reconcile()` routed every wildcard block through `classify()`, whose registrable-parent rule demoted any deeper anchor (e.g. `||ads.example.com^`) to an exact `dataDB` entry — silently dropping subdomain coverage for the ≥3-label anchors that dominate real ABP feeds (AdGuard DNS, hagezi, …). Allow rules were asymmetric (they kept the wildcard bit), so `@@||x^` unblocked a wider set than `||x^` blocked.

## Fix

- `reconcile()` now emits a wildcard **ZONE keyed at the anchor itself** for any wildcard block (`||host^` or a wildcard-shaped reducible-regex fold), at any depth. The matcher needs no change — `find_zone_match` already suffix-walks `zoneDB`.
- The TLD-exclusion carve-out is preserved: a domain in the exclusion set still forces a transparent exact DATA entry (the user knob that opts a domain out of wildcarding).
- `classify()` itself is untouched — the plain/hosts path (ADR-06 semantics) still uses it.

## Why the suite missed it

- No equivalence test probed a subdomain of a ≥3-label anchor.
- The corpus-wide `TestCorpusEquivalence` probe was masked by the catch-all ReDoS exemplar `/^(\w+\.)+\w+$/` in `regex_irreducible.txt`: it matched every dotted probe on both the live mirror and the oracle, equalizing both sides to "block" — while production's always-on `_regex_is_catastrophic_shape` gate would refuse to load that rule at all.
- `test_subdomain_block_classifies_via_classify` pinned the demotion with a comment incorrectly claiming the wildcard bit survived emit.

## Tests (red before / green after)

- `test_adr07_emit_wire.py::TestLiveMatcherEqualsOracle::test_deep_anchor_blocks_subdomains` — live matcher == Phase-2 oracle for a 3-label anchor's apex and subdomain.
- `test_adr07_reconcile.py::TestClassify::test_deep_anchor_classifies_zone_at_its_own_key` (+ the exclusion branch companion, green across the change, pinning the carve-out).
- `test_adr07_reconcile.py::TestCorpusEquivalence` — unmasked by replacing the catch-all exemplar with `/^(\w+\.)+redos-exemplar\.example$/` (still a nested-quantifier catastrophic shape).
- `test_adr07_php_boundary.py` — deep anchor + subdomain + unblocked-parent probes through the PHP-tag boundary.
- ADR-06 goldens: the deep-anchor divergence from the legacy pipeline is intentional and now explicit — production suites overlay `GOLDEN_ABP_CONFORMANT_OVERRIDES` (decision unchanged, `b_type` DNSBL→TLD; subdomain now covered), and the old-loader equivalence skips exactly those keys with a `#718` comment.
- Smoke: `test_smoke_abp.py::test_abp_deep_anchor_blocks_subdomains` — live-VM leg (3-label anchor apex + subdomain VIP-blocked, unlisted parent resolves).

Full local run: ADR-06/07 suites green (807 passed); `ruff` / `mypy` / pre-commit hooks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWGedfchim3Jf5vXjw9htq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWGedfchim3Jf5vXjw9htq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deeper anchor-style blocking so matching domains are blocked at the anchor itself and across subdomains.
  * Expanded coverage for wildcard-based blocking behavior and deep-anchor query cases.

* **Bug Fixes**
  * Corrected classification for deep anchored domains so they no longer fall back to parent-domain handling.
  * Preserved exact-domain behavior for excluded domains and TLD edge cases.

* **Tests**
  * Added and updated end-to-end, smoke, and oracle checks to validate the new deep-anchor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->