### PR TITLE
pfblockerng: handle storeQueryInCache failure in the SafeSearch CNAME redirect (#749)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5957,11 +5957,18 @@ def safesearch_cname_redirect(id: int, qstate: module_qstate, q_type: Any, isSaf
       1. First pass: plant the synthetic ``orig -> CNAME -> target`` into
          Unbound's message cache as a REFERRAL and restart the iterator
          (MODULE_RESTART_NEXT) so the ITERATOR chases the target's A/AAAA itself.
+         If the plant fails to store (real Unbound's silent falsy failure --
+         issue #749), restarting would chase a referral that was never actually
+         cached, so this falls back to the baked target IP (#2) instead -- never
+         MODULE_RESTART_NEXT on a failed store.
       2. Post-restart pass (the answer now carries our CNAME): if the chase
          produced an address, force ``rep.security`` so the unsigned synthesized
          hop is not marked bogus (the historical DNSSEC blocker, issue #149),
-         re-cache as a final answer and finish; if it produced no address, fall
-         back to the baked target IP (#2).
+         re-cache as a final answer and finish -- a failure to re-cache here
+         (issue #749) only means the chased answer isn't cached, not that the
+         already-built, already-validated reply is invalid, so it still
+         finishes; if the chase produced no address, fall back to the baked
+         target IP (#2).
 
     Runs only for A/AAAA queries. Returns True if it took over the query (caller
     must ``return True``), False to let normal processing continue.
@@ -5979,7 +5986,12 @@ def safesearch_cname_redirect(id: int, qstate: module_qstate, q_type: Any, isSaf
             qstate.return_msg.rep.security = sec_status_insecure
             invalidateQueryInCache(qstate, qstate.qinfo)
             qstate.no_cache_store = 0
-            storeQueryInCache(qstate, qstate.qinfo, qstate.return_msg.rep, 0)
+            if not storeQueryInCache(qstate, qstate.qinfo, qstate.return_msg.rep, 0):
+                # A cache-store failure must not SERVFAIL an already-built, already-
+                # validated answer -- log it and finish anyway (issue #749).
+                log_info(
+                    "[pfBlockerNG]: SafeSearch: failed to re-cache chased answer for {}".format(qstate.qinfo.qname_str)
+                )
             qstate.ext_state[id] = MODULE_FINISHED
             return True
         # #1 chase yielded only a bare CNAME -> #2 baked fallback.
@@ -5993,7 +6005,15 @@ def safesearch_cname_redirect(id: int, qstate: module_qstate, q_type: Any, isSaf
         qstate.ext_state[id] = MODULE_ERROR
         return True
     invalidateQueryInCache(qstate, qstate.return_msg.qinfo)
-    storeQueryInCache(qstate, qstate.return_msg.qinfo, qstate.return_msg.rep, 1)
+    if not storeQueryInCache(qstate, qstate.return_msg.qinfo, qstate.return_msg.rep, 1):
+        # The planted referral isn't actually in cache -- restarting the iterator
+        # would chase nothing and fruitlessly loop back into this first pass
+        # (issue #749). Fall back to the baked target IP instead of restarting.
+        log_info("[pfBlockerNG]: SafeSearch: failed to store planted CNAME referral for {}".format(qname))
+        if _safesearch_baked_fallback(id, qstate, q_type, isSafeSearch):
+            return True
+        qstate.ext_state[id] = MODULE_ERROR
+        return True
     qstate.no_cache_store = 1
     qstate.ext_state[id] = MODULE_RESTART_NEXT
     return True

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1715,7 +1715,7 @@ class TestSafeSearchCnameRedirect:
         pfb_unbound.safeSearchDB["duckduckgo.com"] = entry
 
     @staticmethod
-    def _spy_cache(monkeypatch: Any) -> dict[str, Any]:
+    def _spy_cache(monkeypatch: Any, *, store_fails: bool = False) -> dict[str, Any]:
         calls: dict[str, Any] = {"store": [], "invalidate": 0}
 
         def store_spy(qs: Any, qi: Any, rep: Any, ref: int) -> bool:
@@ -1724,7 +1724,10 @@ class TestSafeSearchCnameRedirect:
             # #747) still guard these call sites; only then record the call.
             result = storeQueryInCache(qs, qi, rep, ref)
             calls["store"].append(ref)
-            return result
+            # store_fails simulates real Unbound's silent falsy failure (a NULL
+            # msgrep / dns_cache_store failure -- issue #749) without disturbing
+            # the fidelity checks the delegated call above still performed.
+            return False if store_fails else result
 
         monkeypatch.setattr(builtins, "storeQueryInCache", store_spy)
         monkeypatch.setattr(
@@ -1795,6 +1798,33 @@ class TestSafeSearchCnameRedirect:
         assert calls["invalidate"] == 1
         assert any("IN CNAME safe.duckduckgo.com" in a for a in DNSMessage.instances[-1].answer)
 
+    def test_first_pass_store_failure_falls_back_to_baked_ip(self, monkeypatch: Any) -> None:
+        # issue #749: When the phase-1 planted-referral store fails (real Unbound's
+        # silent falsy failure -- a NULL msgrep / dns_cache_store failure), Then the
+        # redirect must NOT restart the iterator on a referral that isn't actually in
+        # cache (a fruitless plant/restart cycle) -- it answers from the #2 baked IP
+        # instead, same as the phase-2 no-address fallback.
+        self._enable()
+        self._spy_cache(monkeypatch, store_fails=True)
+        qstate = make_qstate("duckduckgo.com.", qtype=RR_A, return_msg=None)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_MODDONE, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        assert any("IN A 203.0.113.7" in a for a in DNSMessage.instances[-1].answer)
+
+    def test_first_pass_store_failure_without_baked_ip_errors(self, monkeypatch: Any) -> None:
+        # issue #749: the without-baked side of the pair above -- when the referral
+        # store fails AND there is no baked IP to fall back on, the query must end in
+        # MODULE_ERROR, NEVER MODULE_RESTART_NEXT (restarting on a referral that was
+        # never actually cached is the fruitless-loop failure mode being fixed).
+        self._enable(v4="", v6="")
+        self._spy_cache(monkeypatch, store_fails=True)
+        qstate = make_qstate("duckduckgo.com.", qtype=RR_A, return_msg=None)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_MODDONE, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_ERROR
+        assert qstate.ext_state[0] != MODULE_RESTART_NEXT
+
     def test_phase2_success_restamps_dnssec_and_finishes(self, monkeypatch: Any) -> None:
         # Phase 2 success (the AFTER of phase 1): the iterator chased our CNAME to an
         # address. Force rep.security to insecure (the synthesized hop is unsigned;
@@ -1814,6 +1844,29 @@ class TestSafeSearchCnameRedirect:
         assert qstate.return_msg.rep.security == sec_status_insecure
         assert calls["store"] == [0]  # is_referral=0 (final answer)
         assert calls["invalidate"] == 1
+
+    def test_phase2_recache_failure_still_finishes(self, monkeypatch: Any) -> None:
+        # issue #749: When the post-restart final-answer re-cache store fails, Then the
+        # already-built, already-validated reply must still be returned as-is -- a cache
+        # failure must not SERVFAIL a valid answer -- but a warning is logged so the
+        # failure is observable.
+        self._enable()
+        monkeypatch.setattr(pfb_unbound, "convert_other", lambda b: self.TARGET)
+        self._spy_cache(monkeypatch, store_fails=True)
+        log_calls: list[str] = []
+        monkeypatch.setattr(builtins, "log_info", lambda msg: log_calls.append(str(msg)))
+        qstate = make_qstate(
+            "duckduckgo.com.", qtype=RR_A, return_msg=self._reply("duckduckgo.com.", cname=True, has_a=True)
+        )
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_MODDONE, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        assert qstate.return_rcode == RCODE_NOERROR
+        assert qstate.return_msg.rep.security == sec_status_insecure
+        # The failable evidence: a warning was actually emitted for the failed re-cache
+        # (FINISHED/NOERROR/security alone are already true before the fix -- this store
+        # failure is otherwise silently swallowed).
+        assert any("duckduckgo.com" in msg for msg in log_calls)
 
     def test_phase2_baked_fallback_when_chase_has_no_address_a(self, monkeypatch: Any) -> None:
         # #2 fallback (When the chase yields only a bare CNAME, no address): answer the

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1825,6 +1825,29 @@ class TestSafeSearchCnameRedirect:
         assert qstate.ext_state[0] == MODULE_ERROR
         assert qstate.ext_state[0] != MODULE_RESTART_NEXT
 
+    def test_first_pass_store_failure_aaaa_falls_back_to_baked_v6(self, monkeypatch: Any) -> None:
+        # issue #749: the AAAA leg of the store-failure fallback -- the baked answer
+        # must come from the v6 column for an AAAA query.
+        self._enable()
+        self._spy_cache(monkeypatch, store_fails=True)
+        qstate = make_qstate("duckduckgo.com.", qtype=RR_AAAA, return_msg=None)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_MODDONE, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        assert any("IN AAAA 2001:db8::7" in a for a in DNSMessage.instances[-1].answer)
+
+    def test_first_pass_store_failure_aaaa_without_baked_v6_errors(self, monkeypatch: Any) -> None:
+        # issue #749: family mismatch -- the entry has a baked v4 but the AAAA query
+        # can only use the (empty) v6 column, so the fallback declines and the query
+        # fails CLOSED (MODULE_ERROR), documenting the deliberate qtype-strict choice:
+        # SafeSearch never resolves unsafely just because the other family has an IP.
+        self._enable(v4="203.0.113.7", v6="")
+        self._spy_cache(monkeypatch, store_fails=True)
+        qstate = make_qstate("duckduckgo.com.", qtype=RR_AAAA, return_msg=None)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_MODDONE, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_ERROR
+
     def test_phase2_success_restamps_dnssec_and_finishes(self, monkeypatch: Any) -> None:
         # Phase 2 success (the AFTER of phase 1): the iterator chased our CNAME to an
         # address. Force rep.security to insecure (the synthesized hop is unsigned;
@@ -1863,10 +1886,11 @@ class TestSafeSearchCnameRedirect:
         assert qstate.ext_state[0] == MODULE_FINISHED
         assert qstate.return_rcode == RCODE_NOERROR
         assert qstate.return_msg.rep.security == sec_status_insecure
-        # The failable evidence: a warning was actually emitted for the failed re-cache
+        # The failable evidence: THE re-cache warning was actually emitted
         # (FINISHED/NOERROR/security alone are already true before the fix -- this store
-        # failure is otherwise silently swallowed).
-        assert any("duckduckgo.com" in msg for msg in log_calls)
+        # failure is otherwise silently swallowed). Match the warning text itself, not
+        # just the qname, so an unrelated future log line can't green this test.
+        assert any("failed to re-cache" in msg and "duckduckgo.com" in msg for msg in log_calls)
 
     def test_phase2_baked_fallback_when_chase_has_no_address_a(self, monkeypatch: Any) -> None:
         # #2 fallback (When the chase yields only a bare CNAME, no address): answer the


### PR DESCRIPTION
Fixes #749

Both `storeQueryInCache` call sites in the SafeSearch CNAME redirect discarded the return value. Real Unbound signals some failures by returning 0 **without** raising (NULL `msgrep`, `dns_cache_store` failure), so:

- **Post-restart re-cache** (final answer): a failed store now logs a warning and still finishes — the reply is already built and validated; a cache failure must not SERVFAIL it.
- **First-pass referral plant**: a failed store previously still went `MODULE_RESTART_NEXT` — the iterator would chase a referral that was never cached, land back in the first pass, and fruitlessly re-plant on persistent failure. It now logs and falls back to the baked target IP; when no baked IP exists for the qtype, `MODULE_ERROR` (never a restart on a failed store).

Three new tests in `TestSafeSearchCnameRedirect` pin the behaviour, each verified **red on the pre-fix code** (first-pass failure → was `MODULE_RESTART_NEXT`, now baked-fallback `MODULE_FINISHED` / `MODULE_ERROR`; re-cache failure → warning now emitted, answer still finishes). The `_spy_cache` helper gained a `store_fails` mode that still delegates to the real fidelity stub (#748) before forcing the failure.

Gates: `pytest` 273 passed (file) / full suite green minus the known zstd-env baseline; `ruff check` / `ruff format --check`; `mypy tests/`. CI runs the PHP/shell gates (untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013baLunt412HLH6L49aF953

---
_Generated by [Claude Code](https://claude.ai/code/session_013baLunt412HLH6L49aF953)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SafeSearch redirect handling so a cache-store failure no longer causes an incorrect restart or loop.
  * If the initial redirect can’t be cached, the query now falls back to the built-in target address, or returns an error cleanly when no fallback is available.
  * If the final answer can’t be re-cached after a restart, the request now still completes successfully and logs a warning instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->