### PR TITLE
pfblockerng: decode wire-format dnames correctly in convert_other

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2175,26 +2175,53 @@ def convert_ipv6(x: Any) -> str:
 
 
 def convert_other(x: Any) -> str:
+    """Decode an rr_data payload shaped like an uncompressed RFC 1035 SS3.3.1 wire-format
+    domain name: a 2-byte RDATA-length prefix (x[0:2], the same convention as
+    convert_ipv4()/convert_ipv6()) followed by one or more labels -- each a 1-63 length
+    octet plus that many raw content bytes -- terminated by a zero-length root label.
+
+    Consumers: the DNSBL CNAME walk and the SafeSearch CNAME check (_ss_answer_has_cname_to)
+    feed CNAME rdata through this to compare the decoded target against feed/target names;
+    the reply logger renders other rrtypes (TXT, MX, ...) through it best-effort for logging.
+
+    A malformed length octet -- >63 (e.g. a DNS compression-pointer marker, invalid in an
+    uncompressed dname) or one that would overrun the remaining buffer -- fails safe to the
+    "Unknown" sentinel rather than decoding junk; callers that guard on `!= "Unknown"` (the
+    CNAME walk) skip it instead of DNSBL-evaluating garbage. A bare root label with no
+    preceding labels also decodes to "Unknown" (the empty name).
+
+    Lenient case: a length-prefixed character-string (TXT rdata) carries no root
+    terminator, since that terminator is a dname-only construct -- when the buffer is
+    exhausted mid-walk with no explicit zero octet, the labels parsed so far are still
+    returned joined by ".", not "Unknown".
+
+    Accepted logging-only change (#717): MX/SRV-style rdata carries a leading fixed field
+    (e.g. MX's 2-byte preference) before its dname, which this decoder has no way to know
+    to skip -- that field's leading zero byte reads as a zero-length root label, so the
+    decode is the empty name ("Unknown") rather than the old scrape's accidental
+    "foo.com". Only the cosmetic reply logger ever feeds MX/SRV rdata through here; the
+    DNSBL CNAME walk only ever passes CNAME rdata, which has no such leading field.
+    """
     final = ""
     if x:
-        for i in x[3:]:
-            val = i
-            if val == 0:
-                i = "|"
-            elif 1 <= val <= 12:
-                i = "."
-            elif val == 13:
+        labels = []
+        buf = x[2:]
+        pos = 0
+        malformed = False
+        rooted = False
+        while pos < len(buf):
+            length = buf[pos]
+            pos += 1
+            if length == 0:
+                rooted = True
                 break
-            elif val == 32:
-                i = " "
-            elif val == 58:
-                i = ":"
-            elif val <= 33 or val > 126:
-                continue
-            else:
-                i = chr(i)
-            final += i
-        final = final.strip(".|")
+            if length > 63 or pos + length > len(buf):
+                malformed = True
+                break
+            labels.append("".join(chr(b) for b in buf[pos : pos + length]))
+            pos += length
+        if not malformed and (labels or rooted):
+            final = ".".join(labels)
     return is_unknown(final)
 
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2218,7 +2218,7 @@ def convert_other(x: Any) -> str:
             if length > 63 or pos + length > len(buf):
                 malformed = True
                 break
-            labels.append("".join(chr(b) for b in buf[pos : pos + length]))
+            labels.append(buf[pos : pos + length].decode("latin-1"))
             pos += length
         if not malformed and (labels or rooted):
             final = ".".join(labels)

--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -2,8 +2,9 @@
 
 Proves the **full Adblock-Plus DNS decision logic** (``@@`` exceptions, cross-feed
 ``@@``, deep-anchor subdomain coverage (#718), ``$important`` / ``$badfilter``
-precedence, regex block/allow + admitted count, whitelist sovereignty, and the
-opt-in regex static cap) holds END-TO-END on
+precedence, regex block/allow + admitted count, whitelist sovereignty, the
+opt-in regex static cap, and CNAME-chain validation incl. a deep (3-label) target
+whose long label is INTERIOR to the wire format (#717)) holds END-TO-END on
 a real resolver — what the pure ADR-07 unit oracle (``tests/test_adr07_*``) cannot:
 it models ``decide()`` in Python, but only a live Unbound + ``pfb_unbound.py`` loader
 proves the manifest build + matcher agree with that model on the box.
@@ -564,6 +565,59 @@ def test_cname_validation_on_off(
             h.flush_unbound_cache(deployed_vm)
             ans_tgt = h.dns_probe_client(client_vm, tgt, "A")
             assert h.is_vip(ans_tgt), f"listed target {tgt} expected VIP block (validation ON), got {ans_tgt}"
+    finally:
+        stub_dns.clear_cname()
+
+
+def test_cname_deep_target_long_interior_label_blocks(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer, stub_dns: _StubDnsServer
+) -> None:
+    """A 3-label CNAME target with a long INTERIOR label blocks with validation ON (#717).
+
+    ``test_cname_validation_on_off`` above only exercises a 2-label target
+    (``<uuid-label>.com``), whose long label is the FIRST one in the wire-format
+    dname — the pre-#717 ``convert_other`` scrape skipped the first length octet
+    unconditionally, so a 2-label target happened to decode fine and this bug
+    never tripped on the live suite. Here the target is 3 labels
+    (``ads.<uuid-label>.com``), so the long (>12 char) uuid label sits in the
+    MIDDLE of the wire format — exactly the interior-label shape #717 fixed: the
+    old decoder dropped the dot / truncated / emitted a junk char at that length
+    octet, mangling the target so the DNSBL CNAME walk missed the feed entry
+    entirely and the chain resolved instead of blocking.
+
+    Given a feed listing the 3-label target and CNAME validation ON, When the
+    client resolves the source name (whose chain CNAMEs to that target), Then
+    the source is VIP-blocked via the correctly decoded target. Red on the
+    pre-fix decoder (the chain resolved to the target's own address instead);
+    green with the wire-format decode fixed.
+    """
+    src = h.unique_domain("cnamedsrc")  # A — resolves CNAME→target via the stub
+    base = h.unique_domain("cnamedtgt")
+    tgt = f"ads.{base}"  # 3-label target; base's uuid label (>12 chars) is INTERIOR, not first
+    tgt_ip = "198.51.100.43"  # target's own address (distinct from the sibling test's sentinel)
+    stub_dns.register_a(tgt, tgt_ip)
+    stub_dns.register_cname(src, tgt)
+    feed_url = h.write_local_feed(deployed_vm, "smoke_cname_deep.txt", f"{tgt}\n")
+    try:
+        spec = h.DnsblCase(
+            aliasname="smokecnamedeep",
+            feed_url=feed_url,
+            header="smokecnamedeep",
+            mode=h.DnsblMode.VIP,
+            cname_validation=True,
+        )
+        with h.CaseContext(deployed_vm, spec):
+            h.flush_unbound_cache(deployed_vm)
+            ans_src = h.dns_probe_client(client_vm, src, "A")
+            assert h.is_vip(ans_src), (
+                f"CNAME validation ON: {src} must be VIP-blocked via its deep target {tgt} "
+                f"(long interior label decode, #717), got {ans_src}"
+            )
+            # Sanity leg: the target itself is feed-blocked directly, so a failing
+            # src assertion above isolates the decoder/walk rather than feed loading.
+            h.flush_unbound_cache(deployed_vm)
+            ans_tgt = h.dns_probe_client(client_vm, tgt, "A")
+            assert h.is_vip(ans_tgt), f"listed deep target {tgt} expected VIP block, got {ans_tgt}"
     finally:
         stub_dns.clear_cname()
 

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -221,7 +221,7 @@ class TestConvertOther:
     # (>63 -- e.g. a compression pointer, forbidden in an uncompressed dname) or one
     # that overruns the remaining buffer is fail-safe: the "Unknown" sentinel, the same
     # one used for a genuinely empty name -- never scraped junk. The CNAME walk's
-    # `!= "Unknown"` guard (pfb_unbound.py:6144) depends on that to skip a bad decode
+    # `!= "Unknown"` guard (the DNSBL CNAME walk in operate()) depends on that to skip a bad decode
     # rather than DNSBL-evaluate garbage.
 
     def test_interior_16char_label_decodes_whole_name(self) -> None:
@@ -289,8 +289,25 @@ class TestConvertOther:
     def test_none_returns_unknown(self) -> None:
         assert convert_other(None) == "Unknown"
 
+    def test_63_char_label_is_the_valid_maximum(self) -> None:
+        # RFC 1035 SS2.3.4 caps a label at 63 octets: exactly 63 decodes whole...
+        name = "www." + "a" * 63 + ".com"
+        assert convert_other(_rr_dname(name)) == name
+
+    def test_64_char_label_is_malformed_without_overrun(self) -> None:
+        # ...and 64 is malformed on the length octet ALONE -- the buffer holds enough
+        # bytes that no overrun occurs, isolating the >63 branch from the overrun branch.
+        wire = bytes([3]) + b"www" + bytes([64]) + b"a" * 64 + bytes([3]) + b"com" + b"\x00"
+        x = len(wire).to_bytes(2, "big") + wire
+        assert convert_other(x) == "Unknown"
+
+    def test_truthy_input_with_empty_body_is_unknown(self) -> None:
+        # A 2-byte rr_data (just the length prefix, no dname bytes at all) is truthy
+        # yet decodes to the empty name -- distinct from the b""/None short-circuits.
+        assert convert_other(bytes([0, 5])) == "Unknown"
+
     def test_txt_character_string_without_root_terminator_decodes(self) -> None:
-        # The reply logger (pfb_unbound.py:2771) feeds TXT rdata through this same
+        # The reply logger (the non-A/AAAA branch of get_details_reply's rrset loop) feeds TXT rdata through this same
         # function; a length-prefixed character-string carries no trailing root octet
         # (that terminator is a dname-only construct), so the decoder must still return
         # a defined shape -- the buffer simply ends when the label's content is
@@ -303,7 +320,7 @@ class TestConvertOther:
         # before its dname, which convert_other() has no way to know to skip -- the
         # preference field's leading zero octet (b"\x00\x0a") reads as a zero-length
         # root label, so the decode is the empty name ("Unknown"). Only the cosmetic
-        # reply logger (:2771) ever feeds MX rdata through convert_other(); the DNSBL
+        # reply logger ever feeds MX rdata through convert_other(); the DNSBL
         # CNAME walk only ever passes CNAME rdata, which has no such leading field.
         x = bytes([0, 11]) + b"\x00\x0a" + bytes([3]) + b"foo" + bytes([3]) + b"com" + b"\x00"
         assert convert_other(x) == "Unknown"

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -201,59 +201,86 @@ class TestConvertIPv6:
         assert convert_ipv6(None) == "Unknown"
 
 
+def _rr_dname(name: str) -> bytes:
+    """Build an rr_data-shaped payload: the 2-byte RDATA length prefix (x[0:2])
+    followed by an uncompressed RFC 1035 SS3.3.1 wire-format dname -- each label a
+    1-63 length octet plus that many raw bytes, terminated by the zero-length root
+    label. Shared by TestConvertOther and the operate()-level CNAME test below.
+    """
+    wire = b"".join(len(lbl).to_bytes(1, "big") + lbl.encode("latin-1") for lbl in name.split(".")) + b"\x00"
+    return len(wire).to_bytes(2, "big") + wire
+
+
 class TestConvertOther:
-    # x[0:3] are ignored; x[3:] is the payload
-    # Encoding rules:
-    #   val == 0          → '|'
-    #   1 <= val <= 12    → '.'
-    #   val == 13         → stop
-    #   val == 32         → ' '
-    #   val == 58         → ':'
-    #   val <= 33 or > 126 → skip
-    #   else              → chr(val)
-    # Leading/trailing '.' and '|' are stripped from the result.
+    # rr_data for a CNAME/NS/PTR-class record is a 2-byte RDATA length prefix (x[0:2])
+    # followed by an UNCOMPRESSED wire-format domain name (RFC 1035 SS3.3.1): each label
+    # is a 1-63 length octet followed by that many raw content bytes, terminated by a
+    # zero-length root label. convert_other() must walk that structure -- not scrape
+    # x[3:] byte-by-byte guessing at dot/space/pipe punctuation from the octet VALUE
+    # (the old contract this class used to pin). A malformed/out-of-range length octet
+    # (>63 -- e.g. a compression pointer, forbidden in an uncompressed dname) or one
+    # that overruns the remaining buffer is fail-safe: the "Unknown" sentinel, the same
+    # one used for a genuinely empty name -- never scraped junk. The CNAME walk's
+    # `!= "Unknown"` guard (pfb_unbound.py:6144) depends on that to skip a bad decode
+    # rather than DNSBL-evaluate garbage.
 
-    def test_printable_ascii(self) -> None:
-        x = bytes([0, 0, 0, ord("A"), ord("B"), ord("C")])
-        assert convert_other(x) == "ABC"
+    def test_interior_16char_label_decodes_whole_name(self) -> None:
+        # A label longer than the old scrape's accidental 1..12 "dot" window must NOT
+        # merge with its neighbour. RED today: the 16-char label yields "wwwgoogleadservices.com".
+        x = _rr_dname("www.googleadservices.com")
+        assert convert_other(x) == "www.googleadservices.com"
 
-    def test_null_becomes_pipe(self) -> None:
-        x = bytes([0, 0, 0, ord("A"), 0, ord("B")])
-        assert convert_other(x) == "A|B"
+    def test_interior_13char_label_decodes_whole_name(self) -> None:
+        # The old scrape treated the length octet 13 as a "carriage return" that stops
+        # decoding entirely. RED today: truncates to "www".
+        x = _rr_dname("www.thirteenchars.com")
+        assert convert_other(x) == "www.thirteenchars.com"
 
-    def test_low_byte_becomes_dot(self) -> None:
-        x = bytes([0, 0, 0, ord("A"), 1, ord("B")])
-        assert convert_other(x) == "A.B"
+    def test_interior_40char_label_decodes_whole_name(self) -> None:
+        # A 34-63 length octet fell into the old scrape's `else: chr(val)` branch and was
+        # emitted as a stray punctuation character. RED today: "www(aaaa...aaa.com" (the
+        # "(" is chr(40), the label's own length octet leaking into the output).
+        label = "a" * 40
+        x = _rr_dname(f"www.{label}.com")
+        assert convert_other(x) == f"www.{label}.com"
 
-    def test_carriage_return_stops_processing(self) -> None:
-        x = bytes([0, 0, 0, ord("A"), 13, ord("B")])
-        assert convert_other(x) == "A"
+    def test_label_content_byte_above_126_is_preserved(self) -> None:
+        # Label content is arbitrary binary (RFC 2181 SS11) -- a byte > 126 is part of
+        # the name, not a control code to drop. RED today: the old scrape's
+        # `val <= 33 or val > 126: continue` silently dropped it ("ab" instead of "a\xe9b").
+        wire = bytes([3]) + b"www" + bytes([3]) + bytes([ord("a"), 0xE9, ord("b")]) + bytes([3]) + b"com" + b"\x00"
+        x = bytes([0, len(wire)]) + wire
+        assert convert_other(x) == "www.a\xe9b.com"
 
-    def test_space_preserved(self) -> None:
-        x = bytes([0, 0, 0, ord("A"), 32, ord("B")])
-        assert convert_other(x) == "A B"
+    def test_plain_two_label_name_decodes_unchanged(self) -> None:
+        # No regression on the short-label path: every label here already fit inside the
+        # old scrape's accidental 1..12 "dot" window, so this is green both before and
+        # after the decoder rewrite.
+        x = _rr_dname("example.com")
+        assert convert_other(x) == "example.com"
 
-    def test_colon_preserved(self) -> None:
-        x = bytes([0, 0, 0, ord("h"), 58, ord("1")])
-        assert convert_other(x) == "h:1"
+    def test_root_only_dname_is_unknown(self) -> None:
+        # A bare zero-length root label (no preceding labels) is the empty name --
+        # decodes to the "Unknown" sentinel, not an empty string. Also covers the old
+        # "empty payload" case (b"\x00\x00\x00"), which meant something different under
+        # the retired x[3:]-scrape contract; this is its wire-format-shaped replacement.
+        x = bytes([0, 1, 0])
+        assert convert_other(x) == "Unknown"
 
-    def test_control_chars_skipped(self) -> None:
-        # val 14..31 (excluding 13) and 33 are skipped
-        x = bytes([0, 0, 0, ord("A"), 14, ord("B")])
-        assert convert_other(x) == "AB"
+    def test_length_octet_over_63_is_malformed(self) -> None:
+        # A length octet with the top two bits set (>63 -- e.g. the DNS compression-
+        # pointer marker 0xC0) is invalid in an uncompressed dname; fail safe to
+        # "Unknown" rather than decode the pointer's bytes as label content. RED today:
+        # the old scrape read past it and emitted "*" (chr(42) from the pointer's low
+        # offset byte).
+        x = bytes([0, 2, 0xC0, 0x2A])
+        assert convert_other(x) == "Unknown"
 
-    def test_high_bytes_skipped(self) -> None:
-        x = bytes([0, 0, 0, ord("A"), 200, ord("B")])
-        assert convert_other(x) == "AB"
-
-    def test_leading_trailing_stripped(self) -> None:
-        # Result '.A.' → strip('.|') → 'A'
-        x = bytes([0, 0, 0, ord("."), ord("A"), ord(".")])
-        assert convert_other(x) == "A"
-
-    def test_empty_payload_returns_unknown(self) -> None:
-        # x[3:] is empty
-        x = bytes([0, 0, 0])
+    def test_label_length_overrunning_buffer_is_malformed(self) -> None:
+        # A length octet claiming more bytes than remain in the buffer is malformed;
+        # fail safe to "Unknown". RED today: the old scrape ignored the claimed length
+        # entirely and just echoed the leftover bytes ("ab").
+        x = bytes([0, 3, 10, ord("a"), ord("b")])
         assert convert_other(x) == "Unknown"
 
     def test_empty_bytes_returns_unknown(self) -> None:
@@ -261,6 +288,25 @@ class TestConvertOther:
 
     def test_none_returns_unknown(self) -> None:
         assert convert_other(None) == "Unknown"
+
+    def test_txt_character_string_without_root_terminator_decodes(self) -> None:
+        # The reply logger (pfb_unbound.py:2771) feeds TXT rdata through this same
+        # function; a length-prefixed character-string carries no trailing root octet
+        # (that terminator is a dname-only construct), so the decoder must still return
+        # a defined shape -- the buffer simply ends when the label's content is
+        # exhausted, with no explicit terminator required. Green both before and after.
+        x = b"\x00\x06" + b"\x05hello"
+        assert convert_other(x) == "hello"
+
+    def test_mx_style_rdata_reads_as_root_and_is_unknown(self) -> None:
+        # ACCEPTED logging-only change: MX rdata carries a 2-byte preference field
+        # before its dname, which convert_other() has no way to know to skip -- the
+        # preference field's leading zero octet (b"\x00\x0a") reads as a zero-length
+        # root label, so the decode is the empty name ("Unknown"). Only the cosmetic
+        # reply logger (:2771) ever feeds MX rdata through convert_other(); the DNSBL
+        # CNAME walk only ever passes CNAME rdata, which has no such leading field.
+        x = bytes([0, 11]) + b"\x00\x0a" + bytes([3]) + b"foo" + bytes([3]) + b"com" + b"\x00"
+        assert convert_other(x) == "Unknown"
 
 
 class TestPythonControlDuration:
@@ -1390,6 +1436,44 @@ class TestOperateDnsbl:
         assert not _is_block(pfb_unbound.decisionDB.get("evil-cname.com"))
         answers = DNSMessage.instances[-1].answer
         assert any(a.startswith("orig.com. ") for a in answers)
+
+    def test_cname_target_with_long_interior_label_blocks_without_decoder_stub(self, monkeypatch: Any) -> None:
+        # End-to-end proof that operate()'s CNAME walk feeds the REAL convert_other()
+        # decoder -- unlike the sibling tests above, convert_other is NOT monkeypatched
+        # here. A CNAME target whose interior label is long enough to break the old
+        # byte-scrape (16 chars, the real-world googleadservices.com cloak shape) must
+        # still resolve to the exact blocked name and block. RED today (#717): the old
+        # scrape misdecodes "www.googleadservices.com" to "wwwgoogleadservices.com",
+        # which misses the blocklist entry entirely, so the chain falls through to the
+        # resolver instead of blocking (ext_state stays MODULE_WAIT_MODULE).
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["python_cname"] = True
+        monkeypatch.setattr(pfb_unbound, "get_details_dnsbl", lambda *a, **k: None)
+        add_data("www.googleadservices.com", log="1", index=0)
+        set_feed_group(0, "F", "G")
+
+        cname_rrset = types.SimpleNamespace(
+            rk=types.SimpleNamespace(type_str="CNAME"),
+            entry=types.SimpleNamespace(
+                data=types.SimpleNamespace(count=1, rr_data=[_rr_dname("www.googleadservices.com")])
+            ),
+        )
+        a_rrset = types.SimpleNamespace(
+            rk=types.SimpleNamespace(type_str="A"),
+            entry=types.SimpleNamespace(data=types.SimpleNamespace(count=1, rr_data=[b"\x00"])),
+        )
+        return_msg = types.SimpleNamespace(
+            rep=types.SimpleNamespace(security=0, an_numrrsets=2, rrsets=[a_rrset, cname_rrset]),
+            qinfo=types.SimpleNamespace(qname_str="orig.com.", qname_list="orig.com".split(".")),
+        )
+
+        qstate = make_qstate("orig.com.", qtype=RR_A, return_msg=return_msg)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert rcd is True
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        entry = pfb_unbound.decisionDB.get("orig.com")
+        assert entry is not None
+        assert entry.dnsbl.b_type == "DNSBL_CNAME"
 
     def test_cname_disabled_original_not_blocked(self, monkeypatch: Any) -> None:
         # CNAME validation OFF (the default): the SAME setup -- A (orig.com) CNAMEs to


### PR DESCRIPTION
Fixes #717

## What

`convert_other` reconstructed a resource record's domain name by scraping `rr_data` byte-by-byte, mapping only length octets 1–12 to `.` — so a CNAME target with an interior label of 13 chars was truncated (`break`), 14–33 chars concatenated two labels (dot dropped), 34–63 inserted a stray `chr(len)` character, and content bytes >126 were silently dropped. `www.googleadservices.com` decoded to `wwwgoogleadservices.com`, missing the feed entry — a CNAME-cloaked block bypass for any `python_cname` user whose blocked target has a ≥13-char interior label (common for ad/tracking CDNs). The SafeSearch `_ss_answer_has_cname_to` check read through the same decoder.

## Fix

Decode `rr_data` as a real RFC 1035 §3.3.1 uncompressed domain name: 2-byte RDATA-length prefix (the same convention `convert_ipv4`/`convert_ipv6` already use — the old `x[3:]` skip was itself part of the bug, eating the first label's length octet), then labels of 1–63 raw bytes joined with `.`, terminated by the zero root label. Malformed input (length octet >63, buffer overrun) fails safe to `"Unknown"`, which the CNAME walk's existing guard skips. A length-prefixed string with no root terminator (TXT rdata through the reply logger) still renders as the labels parsed so far.

Accepted logging-only change: MX/SRV-style rdata (leading fixed field before the dname) now logs `"Unknown"` instead of the old scrape's accidental rendering — only the cosmetic reply logger feeds those types through this function; the DNSBL CNAME walk only ever passes CNAME rdata.

## Why the suite missed it

- `TestConvertOther` pinned the scrape's mangled semantics as the contract (byte 13 = "carriage return stops processing", 14–33 "control chars skipped", >126 "high bytes skipped").
- Every `operate()`-level CNAME test monkeypatched `convert_other`, so the real decoder never saw realistic wire bytes.
- The smoke CNAME test used a 2-label target — its long label is the *first* label, whose length octet the old scrape happened to skip, so the live suite never triggered the interior-label paths.

## Tests (red before / green after)

- `TestConvertOther` retargeted to the wire-format contract (12 cases): 13/16/40-char interior labels decode whole, >126 content bytes preserved, malformed (>63 length octet / overrun) → `"Unknown"`, TXT-style no-root string renders, MX-style rdata → `"Unknown"`, 2-label no-regression, empty/None sentinels.
- `TestOperateDnsbl::test_cname_target_with_long_interior_label_blocks_without_decoder_stub` — real wire bytes through `operate()`'s CNAME walk with **no** decoder monkeypatch; red before (chain resolved), green after (DNSBL_CNAME block).
- Smoke: `test_cname_deep_target_long_interior_label_blocks` — live-VM leg with a 3-label CNAME target whose interior label exceeds 12 chars (validation ON), plus a direct-target sanity probe.

Full local run: `tests/test_pfb_unbound.py` 271 passed; `ruff` / `mypy` / pre-commit hooks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWGedfchim3Jf5vXjw9htq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWGedfchim3Jf5vXjw9htq)_