### PR TITLE
tests: pin the deliberate 254-char PFB_FILTER_DOMAIN accept boundary

### DIFF
--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -50,6 +50,14 @@ final class PfbFilterContractTest extends TestCase
 			'leading-dot wildcard'    => ['.example.com'],   // suppression wildcard form
 			'63-char label boundary'  => [str_repeat('a', 63) . '.com'],
 			'253-char total boundary' => [$longest],
+			// 254 chars is DELIBERATELY accepted (issue #724): the `< 255` bound
+			// admits the longest legal name in trailing-root-dot presentation
+			// (253 chars + '.'), and a 254-char name without the dot exceeds the
+			// DNS wire cap so it can never be queried — inert either way. The
+			// length check is a sanity cap; the charset regex and '..' exclusion
+			// are the PFBL-01 security layer. Do not tighten to `<= 253`.
+			'254-char max FQDN + root dot' => [$longest . '.'],
+			'254-char total (lenient cap)' => [str_repeat('a', 63) . '.' . str_repeat('b', 63) . '.' . str_repeat('c', 63) . '.' . str_repeat('d', 62)],
 		];
 	}
 


### PR DESCRIPTION
Fixes #724

## Verdict: the `< 255` bound is deliberate — pin it, don't "fix" it

The issue asks to add the missing 254-char cell and tighten the bound to `<= 253` "if that is the intent". Triage says it is **not** the intent:

- **254 chars is a legal presentation.** RFC 1035 caps the textual name at 253 chars *without* the trailing root dot; the fully-qualified presentation with the root dot (`example.com.`) is 254. `pfb_filter(PFB_FILTER_DOMAIN)` accepts trailing-dot names (the regex and label validator both allow it), so `<= 253` would reject the longest legal FQDN in its dotted form.
- **A 254-char name without the dot is inert.** It exceeds the DNS wire cap (255 octets including length bytes), so it can never be queried — accepting it into a DNSBL list changes no observable behaviour, while rejecting it would *drop* an (unresolvable but harmless) entry.
- **Maintainer intent is lenient, not strict.** @BBcan177's comment on the issue raises exactly this concern: a strict length filter would exclude overlong bad-actor domains from DNSBL. The length check is a sanity cap, not the security layer — the charset regex and `..` exclusion are what PFBL-01 relies on.

## Change

Test-only: two new `domainAcceptedProvider` cells in `PfbFilterContractTest` pin the 254 boundary from both presentations (max FQDN + root dot, and a bare 254-char name), with a comment explaining why the bound must not be tightened to `<= 253`.

Red→green proven: flipping the production bound to `<= 253` fails exactly these two cells; reverting goes green (62 tests, 71 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
