### PR TITLE
pfblockerng: clear the pending-changes marker on package uninstall (#738 F7)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -17469,13 +17469,12 @@ function pfblockerng_php_pre_deinstall_command() {
 		}
 	}
 
-	// Remove aliastables archive (.zst + .bz2) and earlyshellcmd if found.
-	@unlink_if_exists("{$pfb['aliasarchive']}.zst");
-	@unlink_if_exists("{$pfb['aliasarchive']}.bz2");
-
 	// #738 F7: marker must not survive uninstall (see pfb_deinstall_clear_pending_changes()).
 	pfb_deinstall_clear_pending_changes();
 
+	// Remove aliastables archive (.zst + .bz2) and earlyshellcmd if found.
+	@unlink_if_exists("{$pfb['aliasarchive']}.zst");
+	@unlink_if_exists("{$pfb['aliasarchive']}.bz2");
 	if (config_get_path('system/earlyshellcmd') !== null) {
 		$a_earlyshellcmd = config_get_path('system/earlyshellcmd', '');
 		if (preg_grep("/pfblockerng.sh aliastables/", $a_earlyshellcmd)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3405,6 +3405,20 @@ function pfb_pending_changes(): bool {
 }
 
 /*
+ * #738 F7: the deinstall-side counterpart of the clear above. The update-end guard
+ * (pfb_clear_pending_changes(), just above) is gated on `!$pfb['save']`, and the pre-deinstall
+ * disable pass always sets $pfb['save'] = TRUE before its sync_package_pfblockerng() call, so
+ * that guard never fires there -- nothing else unlinked the marker, so it survived `pkg delete`
+ * into any later reinstall and re-showed the banner before the first real Update. A thin,
+ * separately named wrapper (rather than inlining pfb_clear_pending_changes() at the deinstall
+ * call site) so the deinstall path stays a CLIENT of this module, not a second owner of the
+ * marker file.
+ */
+function pfb_deinstall_clear_pending_changes(): void {
+	pfb_clear_pending_changes();
+}
+
+/*
  * Print the "settings changed — apply on the next Update" info banner when there are pending
  * changes; no-op otherwise. Call immediately after display_top_tabs() on each pfBlockerNG page.
  * $on_update_page drops the redundant cross-link when already on the Update page.
@@ -17458,6 +17472,10 @@ function pfblockerng_php_pre_deinstall_command() {
 	// Remove aliastables archive (.zst + .bz2) and earlyshellcmd if found.
 	@unlink_if_exists("{$pfb['aliasarchive']}.zst");
 	@unlink_if_exists("{$pfb['aliasarchive']}.bz2");
+
+	// #738 F7: marker must not survive uninstall (see pfb_deinstall_clear_pending_changes()).
+	pfb_deinstall_clear_pending_changes();
+
 	if (config_get_path('system/earlyshellcmd') !== null) {
 		$a_earlyshellcmd = config_get_path('system/earlyshellcmd', '');
 		if (preg_grep("/pfblockerng.sh aliastables/", $a_earlyshellcmd)) {

--- a/tests/php/PfbPendingChangesTest.php
+++ b/tests/php/PfbPendingChangesTest.php
@@ -14,11 +14,21 @@ use PHPUnit\Framework\TestCase;
  * restores its cache on boot rather than re-applying config, so a still-unapplied change must stay
  * flagged). This pins the three-state lifecycle (clean -> dirty -> clean) and that the marker
  * really is the file at $pfb['pending_marker'].
+ *
+ * Also pins the deinstall-side clear (#738 F7, pfb_deinstall_clear_pending_changes()): the
+ * update-end guard above only fires on `!$pfb['save']`, which the pre-deinstall disable pass
+ * never satisfies, so nothing else unlinked the marker and it survived `pkg delete` into a later
+ * reinstall. pfblockerng_php_pre_deinstall_command() itself cannot be driven off-appliance (it
+ * runs a full sync_package_pfblockerng() pass plus pfctl/exec teardown), so this pins the
+ * extracted clear helper it calls in isolation; that the helper is actually reached only past the
+ * #697 non-delete early return is validated live (issue #738 F7 is a pending live-VM uninstall
+ * check).
  */
 #[CoversFunction('pfb_mark_pending_changes')]
 #[CoversFunction('pfb_clear_pending_changes')]
 #[CoversFunction('pfb_pending_changes')]
 #[CoversFunction('pfb_pending_changes_marker')]
+#[CoversFunction('pfb_deinstall_clear_pending_changes')]
 final class PfbPendingChangesTest extends TestCase
 {
 	private string $tmpdir;
@@ -68,5 +78,30 @@ final class PfbPendingChangesTest extends TestCase
 		// Then it is clean again (the deferred changes have been applied)
 		$this->assertFalse(pfb_pending_changes(), 'clear must reset the pending flag');
 		$this->assertFileDoesNotExist($marker, 'clear must remove the marker file');
+	}
+
+	/**
+	 * #738 F7: a stale marker must not survive a genuine uninstall. Before this helper existed,
+	 * nothing on the deinstall path unlinked the marker (the update-end guard is gated on
+	 * `!$pfb['save']`, which the deinstall disable pass never satisfies), so a reinstall showed a
+	 * false "pending changes" banner until the first real Update.
+	 */
+	public function testDeinstallHelperClearsStaleMarker(): void
+	{
+		$marker = $this->marker;
+
+		// Given a pending marker left over from an earlier deferred save
+		pfb_mark_pending_changes();
+		$this->assertFileExists($marker, 'setup: marker must exist before the deinstall clear');
+
+		// When the deinstall path's clear helper runs
+		pfb_deinstall_clear_pending_changes();
+
+		// Then the marker is gone -- it must never survive a genuine uninstall
+		$this->assertFalse(pfb_pending_changes(), 'deinstall clear must reset the pending flag');
+		$this->assertFileDoesNotExist(
+			$marker,
+			'deinstall clear must remove the marker file so a later reinstall starts clean'
+		);
 	}
 }

--- a/tests/smoke/test_pkg_op_teardown.py
+++ b/tests/smoke/test_pkg_op_teardown.py
@@ -75,6 +75,17 @@ pytestmark = pytest.mark.repo
 _KEEP_LIVE_LINE = "Keeping pfBlockerNG active across the package"
 _TEARDOWN_LINE = "Removing pfBlockerNG..."
 
+# #738 F7: the deferred-settings marker the deinstall teardown must clear (and a
+# keep-live reinstall must NOT touch). Host path — the marker lives outside the
+# Unbound chroot, plain /bin/sh access.
+_PENDING_MARKER = "/usr/local/etc/pfb_pending_changes"
+
+
+def _marker_exists(vm: SmokeVM) -> bool:
+    """TRUE iff the pending-changes marker file exists on the box."""
+    probe = vm.ssh("/bin/sh", "-c", f"test -f {_PENDING_MARKER} && echo YES || echo NO")
+    return probe.stdout.strip() == "YES"
+
 
 def _enable_dnsbl(vm: SmokeVM) -> None:
     """Set the DNSBL master enable chain (enable_cb + pfb_dnsbl) in config.xml.
@@ -178,6 +189,12 @@ def test_pkg_reinstall_keeps_live_delete_tears_down(repo_vm: SmokeVM) -> None:
             f"got rcode={given.rcode!r} records={given.records!r}"
         )
 
+        # AND: a deferred-settings "pending changes" marker exists (#738 F7). The
+        # reinstall leg must KEEP it (pending changes stay valid across an upgrade,
+        # the #697 keep-live branch); the delete leg below must CLEAR it.
+        vm.ssh("/bin/sh", "-c", f"touch {_PENDING_MARKER}")
+        assert _marker_exists(vm), f"setup: could not create {_PENDING_MARKER} on the box"
+
         # ---- WHEN (1): forced reinstall (op 'reinstall') ----------------------- #
         proc = pkg_reinstall_force(vm)
         combined = proc.stdout + proc.stderr
@@ -201,6 +218,13 @@ def test_pkg_reinstall_keeps_live_delete_tears_down(repo_vm: SmokeVM) -> None:
             f"got rcode={after_reinstall.rcode!r} records={after_reinstall.records!r}"
         )
 
+        # ... and the pending-changes marker SURVIVED the reinstall (#738 F7: the clear
+        # sits past the #697 early return, so an upgrade keeps a genuinely-pending change).
+        assert _marker_exists(vm), (
+            f"AFTER `pkg install -f`: {_PENDING_MARKER} was cleared — the deinstall-side marker "
+            "clear must not run on a keep-live (reinstall/upgrade) pass"
+        )
+
         # ---- WHEN (2): real uninstall (op 'delete') ---------------------------- #
         del_proc = pkg_delete_capture(vm)
         del_combined = del_proc.stdout + del_proc.stderr
@@ -222,5 +246,13 @@ def test_pkg_reinstall_keeps_live_delete_tears_down(repo_vm: SmokeVM) -> None:
             f"AFTER `pkg delete`: {domain!r} still resolved to the DNSBL VIP — teardown did not remove "
             f"the DNSBL block; got rcode={after_delete.rcode!r} records={after_delete.records!r}"
         )
+
+        # AND: the pending-changes marker is GONE (#738 F7: a genuine uninstall clears it,
+        # so a later reinstall shows no false "pending changes" banner).
+        assert not _marker_exists(vm), (
+            f"AFTER `pkg delete`: {_PENDING_MARKER} survived the uninstall — the pre-deinstall "
+            "teardown must clear the deferred-settings marker (#738 F7)"
+        )
     finally:
+        vm.ssh("/bin/sh", "-c", f"rm -f {_PENDING_MARKER}")
         pkg_delete(vm)


### PR DESCRIPTION
Part of #738 (finding F7; ledger in #729 — `#650 / low`).

The only `pfb_clear_pending_changes()` call site (the update-end path) is gated on `!$pfb['save']`, and the pre-deinstall disable pass always sets `$pfb['save'] = TRUE` before its sync — so nothing ever unlinked `/usr/local/etc/pfb_pending_changes` on `pkg delete`, and a later reinstall showed a false "Pending changes" banner until the first real Update.

- New thin helper `pfb_deinstall_clear_pending_changes()` (marker module stays the single owner of the file), called from `pfblockerng_php_pre_deinstall_command()`'s teardown section — **past the #697 non-delete early return**, so a package upgrade/reinstall keeps the marker (pending changes stay valid across an upgrade) and only a genuine `pkg delete` clears it.
- `PfbPendingChangesTest` pins the helper red→green (marker seeded → helper → gone; red before: helper absent). The full pre-deinstall function cannot be driven off-appliance (full sync + pfctl/exec teardown); the wiring-past-the-early-return remains the live-VM uninstall validation noted in #738.

Gates: `php -l` clean; PHPUnit/PHPStan/PHPCS ride CI (vendor unavailable in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013baLunt412HLH6L49aF953

---
_Generated by [Claude Code](https://claude.ai/code/session_013baLunt412HLH6L49aF953)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package removal so leftover “pending changes” markers are cleared during uninstall.
  * Prevents stale state from carrying over after deleting and later reinstalling the package.

* **Tests**
  * Expanded coverage to verify the cleanup behavior during uninstall.
  * Added smoke test checks to confirm the marker remains during reinstall but is removed on package deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->