### PR TITLE
tests: count genuine TCP timeouts in the pfctl bench loss tally (#738 F5)

### DIFF
--- a/tests/smoke/test_bench_pfctl.py
+++ b/tests/smoke/test_bench_pfctl.py
@@ -643,10 +643,14 @@ async def probe_once(ip: str) -> tuple[float, float, float]:
         writer.close()
         await writer.wait_closed()
         rtt_ms = (time.monotonic() - t0) * 1000.0
+    # Timeout MUST be caught before OSError: on Python 3.11+ asyncio.TimeoutError
+    # IS the builtin TimeoutError, which subclasses OSError — with OSError first,
+    # a genuine ≥5s stall lands in the RTT clause as a ~5000ms "valid" sample and
+    # the -1 loss record is dead code (the #738 F5 masked-loss bug).
+    except TimeoutError:
+        rtt_ms = -1.0  # genuine ≥5s timeout — no RST received
     except (ConnectionRefusedError, OSError):
         rtt_ms = (time.monotonic() - t0) * 1000.0  # RST → ECONNREFUSED; time is RTT
-    except asyncio.TimeoutError:
-        rtt_ms = -1.0  # genuine ≥5s timeout — no RST received
     return start_epoch, time.time(), rtt_ms
 
 async def run(in_ips: list[str], out_ips: list[str], duration: float) -> None:
@@ -763,9 +767,14 @@ class TcpRstWindow:
 
     ``lost`` is the count of genuine >=5s timeouts (rtt_ms=-1 probe records)
     pooled across the WHOLE probe run that produced this window, not
-    attributed to this window's [t0, t1] slice — same simplification as
-    ICMP's ``_LiveProbe.slice_window`` (see its comment): a probe run spans
-    several batches, so precise sub-window attribution is skipped by design.
+    attributed to this window's [t0, t1] slice — the maintainer-chosen
+    pooled-per-run semantics (#738 F5). NOTE this deliberately DIVERGES from
+    ICMP's ``_LiveProbe.slice_window``, which zeroes ``lost`` on op-aligned
+    windows (its pooled op-aligned loss is always 0); do not "re-align" TCP
+    to that — it would resurrect the fabricated-0.0 loss column. Because the
+    run total rides on each sliced window, ``loss_pct()`` for a SHORT op
+    window divides run-scoped losses by window-scoped sends and is an upper
+    bound, not the window's own loss rate.
     """
 
     samples: list[TcpRstSample] = field(default_factory=list)
@@ -874,8 +883,11 @@ class _LiveTcpProbe:
 
         ``lost`` on the returned window is the probe's TOTAL genuine-timeout
         count across its whole run, not filtered to [t0, t1] — pooled-per-run
-        by design (see ``TcpRstWindow`` docstring), matching ICMP's
-        ``_LiveProbe.slice_window`` treatment of loss as non-window-attributable.
+        by design (see ``TcpRstWindow`` docstring; deliberately unlike ICMP's
+        ``slice_window``, which zeroes lost). INVARIANT: call at most once per
+        probe run — the returned window carries the run's whole lost tally, so
+        pooling summers (``_compute_pooled_tcp*``) that sum ``w.lost`` over
+        windows rely on one window per run to avoid double-counting.
         """
         with self._lock:
             w = TcpRstWindow()

--- a/tests/smoke/test_bench_pfctl.py
+++ b/tests/smoke/test_bench_pfctl.py
@@ -663,15 +663,16 @@ async def run(in_ips: list[str], out_ips: list[str], duration: float) -> None:
     async def one(ip: str) -> None:
         async with sem:
             start_epoch, recv_epoch, rtt_ms = await probe_once(ip)
-            if rtt_ms >= 0:
-                # Print to stdout — one JSON per line.
-                # start_t is used for op-aligned windowing by start time.
-                print(json.dumps({
-                    "start_t": round(start_epoch, 4),
-                    "t": round(recv_epoch, 4),
-                    "rtt_ms": round(rtt_ms, 3),
-                    "ip": ip,
-                }), flush=True)
+            # Print to stdout — one JSON per line, INCLUDING timeouts (rtt_ms=-1):
+            # a genuine >=5s timeout is a real loss and must be counted, not
+            # silently dropped.  start_t is used for op-aligned windowing by
+            # start time; a negative rtt_ms marks "no RST received".
+            print(json.dumps({
+                "start_t": round(start_epoch, 4),
+                "t": round(recv_epoch, 4),
+                "rtt_ms": round(rtt_ms, 3),
+                "ip": ip,
+            }), flush=True)
 
     tasks: list[asyncio.Task[None]] = []
     while time.monotonic() < deadline:
@@ -758,35 +759,69 @@ class TcpRstSample:
 
 @dataclass
 class TcpRstWindow:
-    """Samples from a single op-aligned window of the TCP RST probe."""
+    """Samples from a single op-aligned window of the TCP RST probe.
+
+    ``lost`` is the count of genuine >=5s timeouts (rtt_ms=-1 probe records)
+    pooled across the WHOLE probe run that produced this window, not
+    attributed to this window's [t0, t1] slice — same simplification as
+    ICMP's ``_LiveProbe.slice_window`` (see its comment): a probe run spans
+    several batches, so precise sub-window attribution is skipped by design.
+    """
 
     samples: list[TcpRstSample] = field(default_factory=list)
     total_attempts: int = 0  # incremented on collection
+    lost: int = 0  # genuine >=5s timeouts, pooled per probe run (see docstring)
+
+    def sent(self) -> int:
+        return len(self.samples) + self.lost
 
 
-def _parse_tcp_probe_output(text: str) -> list[TcpRstSample]:
-    """Parse JSON lines from the tcp_rst_probe.py output."""
+@dataclass
+class TcpProbeParse:
+    """Result of parsing tcp_rst_probe.py output: RTT samples plus timeouts.
+
+    A record with rtt_ms < 0 marks a genuine >=5s timeout (no RST received):
+    counted in ``lost``, never added to ``samples``.
+    """
+
+    samples: list[TcpRstSample] = field(default_factory=list)
+    lost: int = 0
+
+
+def _parse_tcp_probe_output(text: str) -> TcpProbeParse:
+    """Parse JSON lines from the tcp_rst_probe.py output.
+
+    Returns the kept RTT samples plus the count of genuine >=5s timeouts
+    (rtt_ms=-1 records) — those never enter the RTT sample list, since they
+    have no RTT to report, but they are real losses and must be counted.
+    """
     import json as _json
 
     samples: list[TcpRstSample] = []
+    lost = 0
     for line in text.splitlines():
         line = line.strip()
         if not line or not line.startswith("{"):
             continue
         try:
             obj = _json.loads(line)
-            if "rtt_ms" in obj and obj.get("rtt_ms", -1) >= 0:
-                samples.append(
-                    TcpRstSample(
-                        recv_epoch=float(obj.get("t", 0)),
-                        rtt_ms=float(obj["rtt_ms"]),
-                        ip=str(obj.get("ip", "")),
-                        start_epoch=float(obj.get("start_t", 0)),
-                    )
+            if "rtt_ms" not in obj:
+                continue
+            rtt_ms = float(obj["rtt_ms"])
+            if rtt_ms < 0:
+                lost += 1
+                continue
+            samples.append(
+                TcpRstSample(
+                    recv_epoch=float(obj.get("t", 0)),
+                    rtt_ms=rtt_ms,
+                    ip=str(obj.get("ip", "")),
+                    start_epoch=float(obj.get("start_t", 0)),
                 )
+            )
         except Exception:
             pass
-    return samples
+    return TcpProbeParse(samples=samples, lost=lost)
 
 
 class _LiveTcpProbe:
@@ -808,6 +843,7 @@ class _LiveTcpProbe:
         self._out_ips = out_ips
         self._batch_dur = batch_duration_s
         self._samples: list[TcpRstSample] = []
+        self._lost: int = 0  # genuine >=5s timeouts, pooled across the whole probe run
         self._lock = threading.Lock()
         self._stop_evt = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
@@ -821,9 +857,10 @@ class _LiveTcpProbe:
         while not self._stop_evt.is_set():
             cmd = f"python3 /tmp/tcp_rst_probe.py {in_arg} {out_arg} {self._batch_dur:.1f} 2>/dev/null"
             result = self._client.ssh(cmd, timeout=self._batch_dur + 15.0)
-            samples = _parse_tcp_probe_output(result.stdout)
+            parsed = _parse_tcp_probe_output(result.stdout)
             with self._lock:
-                self._samples.extend(samples)
+                self._samples.extend(parsed.samples)
+                self._lost += parsed.lost
 
     def slice_window(self, t0: float, t1: float) -> TcpRstWindow:
         """Return samples whose connection was STARTED during [t0, t1] (op-aligned).
@@ -834,16 +871,27 @@ class _LiveTcpProbe:
         would be missed if filtered by completion time.  start_epoch captures
         exactly "connections that were in-flight when the op ran".
         Falls back to recv_epoch when start_epoch is 0 (old probe format).
+
+        ``lost`` on the returned window is the probe's TOTAL genuine-timeout
+        count across its whole run, not filtered to [t0, t1] — pooled-per-run
+        by design (see ``TcpRstWindow`` docstring), matching ICMP's
+        ``_LiveProbe.slice_window`` treatment of loss as non-window-attributable.
         """
         with self._lock:
             w = TcpRstWindow()
             w.samples = [s for s in self._samples if t0 <= (s.start_epoch if s.start_epoch > 0 else s.recv_epoch) <= t1]
             w.total_attempts = len(w.samples)
+            w.lost = self._lost
             return w
 
     def all_samples(self) -> list[TcpRstSample]:
         with self._lock:
             return list(self._samples)
+
+    def total_lost(self) -> int:
+        """Total genuine >=5s timeouts observed across this probe's whole run."""
+        with self._lock:
+            return self._lost
 
     def stop(self) -> None:
         self._stop_evt.set()
@@ -854,10 +902,18 @@ def _compute_pooled_tcp(
     windows: list[TcpRstWindow],
     baseline_windows: list[TcpRstWindow],
 ) -> PooledStats:
-    """Pool TCP RST RTT samples from all repeat windows."""
+    """Pool TCP RST RTT samples from all repeat windows.
+
+    ``total_loss``/``total_sent`` are pooled per-run (summed from each
+    window's own ``.lost``, per-run tally — see ``TcpRstWindow`` docstring),
+    not attributed to a narrower sub-window.
+    """
     all_samples: list[TcpRstSample] = []
     for w in windows:
         all_samples.extend(w.samples)
+
+    total_loss = sum(w.lost for w in windows)
+    total_sent = sum(w.sent() for w in windows)
 
     baseline_rtts: list[float] = []
     for w in baseline_windows:
@@ -871,7 +927,7 @@ def _compute_pooled_tcp(
 
     n = len(all_samples)
     if n == 0:
-        return PooledStats()
+        return PooledStats(total_loss=total_loss, total_sent=total_sent)
 
     rtts = sorted(s.rtt_ms for s in all_samples)
     spikes = sum(1 for r in rtts if r > spike_thresh) if spike_thresh > 0 else 0
@@ -890,8 +946,8 @@ def _compute_pooled_tcp(
         p99_ms=pct(0.99),
         p999_ms=pct(0.999),
         max_ms=rtts[-1],
-        total_loss=0,
-        total_sent=n,
+        total_loss=total_loss,
+        total_sent=total_sent,
         spikes=spikes,
         spike_threshold_ms=spike_thresh,
     )
@@ -915,8 +971,9 @@ def _measure_with_rst_probe(
     out_arg = ",".join(_PROBE_OUT_TABLE_IPS)
     baseline_cmd = f"python3 /tmp/tcp_rst_probe.py {in_arg} {out_arg} {batch_dur_s:.1f} 2>/dev/null"
     baseline_result = client_vm.ssh(baseline_cmd, timeout=batch_dur_s + 15.0)
-    baseline_samples = _parse_tcp_probe_output(baseline_result.stdout)
-    baseline_w = TcpRstWindow(samples=baseline_samples, total_attempts=len(baseline_samples))
+    baseline_parsed = _parse_tcp_probe_output(baseline_result.stdout)
+    baseline_samples = baseline_parsed.samples
+    baseline_w = TcpRstWindow(samples=baseline_samples, total_attempts=len(baseline_samples), lost=baseline_parsed.lost)
     bl_p50 = 0.0
     if baseline_samples:
         sorted_bl = sorted(s.rtt_ms for s in baseline_samples)
@@ -954,7 +1011,7 @@ def _measure_with_rst_probe(
             f" during_samples={len(during_w.samples)}"
         )
     else:
-        during_w = TcpRstWindow(samples=probe.all_samples())
+        during_w = TcpRstWindow(samples=probe.all_samples(), lost=probe.total_lost())
 
     # ---- build result row ---- #
     gd = _parse_guest_row(kv)
@@ -1428,7 +1485,7 @@ def test_pfctl_reject_loop(
     # Keep stderr visible (no 2>/dev/null) for diagnostic purposes on failure.
     verify_cmd = f"python3 /tmp/tcp_rst_probe.py {in_arg} {out_arg} 2.0"
     verify_result = client_vm.ssh(verify_cmd, timeout=10.0)
-    verify_samples = _parse_tcp_probe_output(verify_result.stdout)
+    verify_samples = _parse_tcp_probe_output(verify_result.stdout).samples
     if not verify_samples:
         _bench(smoke_vm, "teardown_rules", timeout=30.0)
         pytest.skip(
@@ -1723,10 +1780,17 @@ def _compute_pooled_tcp_full(
 
     spike_threshold_ms is derived from the quiescent baseline p95 × _DISRUPT_SPIKE_FACTOR
     (NOT p99 × 3.0, which was degenerate in the prior run — see 02b_Replace_Disruption_Baseline.txt).
+
+    ``total_loss``/``total_sent`` are pooled per-run from each window's own
+    ``.lost`` (see ``TcpRstWindow`` docstring) — not attributed to a narrower
+    sub-window; the disruption buckets stay RTT-only.
     """
     all_rtts: list[float] = []
     for w in windows:
         all_rtts.extend(s.rtt_ms for s in w.samples)
+
+    total_loss = sum(w.lost for w in windows)
+    total_sent = sum(w.sent() for w in windows)
 
     # Compute spike threshold from baseline p95.
     baseline_rtts: list[float] = []
@@ -1741,7 +1805,11 @@ def _compute_pooled_tcp_full(
 
     n = len(all_rtts)
     if n == 0:
-        return PooledStats(), {t: (0, 0.0) for t in _DISRUPT_BUCKETS_MS}, spike_thresh
+        return (
+            PooledStats(total_loss=total_loss, total_sent=total_sent),
+            {t: (0, 0.0) for t in _DISRUPT_BUCKETS_MS},
+            spike_thresh,
+        )
 
     rtts_s = sorted(all_rtts)
     spikes = sum(1 for r in rtts_s if r > spike_thresh) if spike_thresh > 0 else 0
@@ -1760,8 +1828,8 @@ def _compute_pooled_tcp_full(
         p99_ms=pct(0.99),
         p999_ms=pct(0.999),
         max_ms=rtts_s[-1],
-        total_loss=0,
-        total_sent=n,
+        total_loss=total_loss,
+        total_sent=total_sent,
         spikes=spikes,
         spike_threshold_ms=spike_thresh,
     )
@@ -1842,7 +1910,7 @@ def test_pfctl_replace_disruption_baseline(
     in_arg = ",".join(_PROBE_IN_TABLE_IPS[:3])
     out_arg = ",".join(_PROBE_OUT_TABLE_IPS[:3])
     verify_result = client_vm.ssh(f"python3 /tmp/tcp_rst_probe.py {in_arg} {out_arg} 2.0", timeout=10.0)
-    verify_samples_disrupt = _parse_tcp_probe_output(verify_result.stdout)
+    verify_samples_disrupt = _parse_tcp_probe_output(verify_result.stdout).samples
     if not verify_samples_disrupt:
         _bench(smoke_vm, "teardown_rules", timeout=30.0)
         _bench(smoke_vm, "cleanup", timeout=30.0)
@@ -1937,7 +2005,8 @@ def test_pfctl_replace_disruption_baseline(
         out_arg2 = ",".join(_PROBE_OUT_TABLE_IPS)
         qcmd = f"python3 /tmp/tcp_rst_probe.py {in_arg2} {out_arg2} 5.0 2>/dev/null"
         qresult = client_vm.ssh(qcmd, timeout=20.0)
-        q_samples = _parse_tcp_probe_output(qresult.stdout)
+        q_parsed = _parse_tcp_probe_output(qresult.stdout)
+        q_samples = q_parsed.samples
         if q_samples:
             q_rtts = sorted(s.rtt_ms for s in q_samples)
             q_n = len(q_rtts)
@@ -1955,14 +2024,14 @@ def test_pfctl_replace_disruption_baseline(
                 p99_ms=q_p99,
                 p999_ms=q_rtts[min(int(math.floor(q_n * 0.999)), q_n - 1)],
                 max_ms=q_rtts[-1],
-                total_loss=0,
-                total_sent=q_n,
+                total_loss=q_parsed.lost,
+                total_sent=q_n + q_parsed.lost,
                 spikes=0,
                 spike_threshold_ms=0.0,
             )
             q_buckets = _compute_disrupt_buckets(q_rtts)
         else:
-            q_ps = PooledStats()
+            q_ps = PooledStats(total_loss=q_parsed.lost, total_sent=q_parsed.lost)
             q_buckets = {t: (0, 0.0) for t in _DISRUPT_BUCKETS_MS}
         quiet_stats[sz] = q_ps
         quiet_buckets[sz] = q_buckets
@@ -2085,7 +2154,9 @@ def test_pfctl_disruption_uncensored(
       1. PROBE CENSORING: prior timeout=0.5s clamped every stall ≥500ms to ~500ms.
          True replace disruption was invisible (100k→1M all flat ~500ms, 100%).
          Now timeout=5.0s records the REAL stall duration; only genuine ≥5s losses
-         are dropped (should be ~none with RST reject rules).
+         are excluded from the RTT distribution (they have no RTT to report) —
+         counted instead in the pooled loss tally (should be ~none with RST
+         reject rules).
       2. PROBE STARVATION (50k n=4): prior sem=64 with 0.5s timeout starved short
          op windows.  Now sem=400 with start-time slicing: connections STARTED during
          the op are captured regardless of when they complete (a 200ms stall on a
@@ -2146,7 +2217,7 @@ def test_pfctl_disruption_uncensored(
     in_arg = ",".join(_PROBE_IN_TABLE_IPS[:3])
     out_arg = ",".join(_PROBE_OUT_TABLE_IPS[:3])
     verify_result = client_vm.ssh(f"python3 /tmp/tcp_rst_probe.py {in_arg} {out_arg} 3.0", timeout=15.0)
-    verify_samples_unc = _parse_tcp_probe_output(verify_result.stdout)
+    verify_samples_unc = _parse_tcp_probe_output(verify_result.stdout).samples
     if not verify_samples_unc:
         _bench(smoke_vm, "teardown_rules", timeout=30.0)
         pytest.skip("TCP RST probe returned no samples — reject loop not working. STOP.")
@@ -2271,7 +2342,8 @@ def test_pfctl_disruption_uncensored(
             f"python3 /tmp/tcp_rst_probe.py {in_arg2} {out_arg2} 5.0 2>/dev/null",
             timeout=30.0,
         )
-        q_samples = _parse_tcp_probe_output(qresult.stdout)
+        q_parsed = _parse_tcp_probe_output(qresult.stdout)
+        q_samples = q_parsed.samples
         if q_samples:
             q_rtts = sorted(s.rtt_ms for s in q_samples)
             qn = len(q_rtts)
@@ -2289,10 +2361,11 @@ def test_pfctl_disruption_uncensored(
                 p99_ms=_qpct(0.99),
                 p999_ms=_qpct(0.999),
                 max_ms=q_rtts[-1],
-                total_sent=qn,
+                total_loss=q_parsed.lost,
+                total_sent=qn + q_parsed.lost,
             )
         else:
-            quiet_ps_unc[sz] = PooledStats()
+            quiet_ps_unc[sz] = PooledStats(total_loss=q_parsed.lost, total_sent=q_parsed.lost)
         qp = quiet_ps_unc[sz]
         print(
             f"  quiescent size={sz:,}: n={qp.n}"
@@ -2415,7 +2488,8 @@ def test_pfctl_disruption_uncensored(
     print(
         "\nProbe: in-table 11.x + out-table 13.x; both paths RST."
         "\nTimeout: 5.0s (loss = genuine ≥5s failures only)."
-        "\nWindow: connections STARTED in [t0, t1] (start-time slice)."
+        "\nWindow: connections STARTED in [t0, t1] (start-time slice) — RTT samples only;"
+        "\n  loss is pooled per RUN (not attributed to this start-time slice), by design."
         f"\n{_UNCENSORED_REPS} reps per cell | op-aligned."
     )
 

--- a/tests/test_bench_pfctl_parse.py
+++ b/tests/test_bench_pfctl_parse.py
@@ -9,9 +9,10 @@ column always read 0.0 even when connections blackholed.
 
 The maintainer's decision (recorded in the issue): SIMPLER pooled semantics — count
 >=5s losses per RUN (summed across a probe's whole capture) and report an honest
-pooled loss%/total_sent, WITHOUT redesigning per-op-window attribution (the ICMP path's
-``_LiveProbe.slice_window`` already treats loss the same way — not attributable to a
-narrow time slice — and this mirrors that, not a new design).
+pooled loss%/total_sent, WITHOUT redesigning per-op-window attribution. NOTE this
+deliberately diverges from ICMP's ``_LiveProbe.slice_window`` (which zeroes ``lost``
+on op-aligned windows); see the ``TcpRstWindow`` docstring for the divergence and the
+one-slice-per-run invariant.
 
 These tests exercise ``_parse_tcp_probe_output`` and ``_compute_pooled_tcp``/
 ``_compute_pooled_tcp_full`` directly (pure functions, no VM needed) — importing
@@ -21,9 +22,12 @@ for the established pattern of pulling pure seams out of ``tests/smoke/`` for th
 
 from __future__ import annotations
 
+import asyncio
 import json
+from typing import Any
 
 from tests.smoke.test_bench_pfctl import (
+    _TCP_PROBE_SCRIPT,
     PooledStats,
     TcpRstWindow,
     _compute_pooled_tcp,
@@ -224,3 +228,98 @@ def test_compute_pooled_tcp_empty_windows_yields_zero_stats() -> None:
     """
     ps = _compute_pooled_tcp([], baseline_windows=[])
     assert ps == PooledStats(), f"expected an all-zero PooledStats() for no windows but got {ps}"
+
+
+def test_compute_pooled_tcp_all_lost_window_reports_full_loss() -> None:
+    """A fully blackholed run (only -1 records, zero RTT samples) reports 100% loss.
+
+    This is the n==0-samples branch where the fix changes the early-return's
+    output: pre-fix it returned an all-zero PooledStats (loss invisible); now
+    the losses ride total_loss/total_sent and loss_pct() reads 100%.
+    """
+    parsed = _parse_tcp_probe_output(
+        "\n".join(
+            [
+                _probe_line(start_t=0.0, t=5.0, rtt_ms=-1.0),
+                _probe_line(start_t=0.1, t=5.1, rtt_ms=-1.0),
+            ]
+        )
+    )
+    window = TcpRstWindow(samples=parsed.samples, lost=parsed.lost)
+
+    ps = _compute_pooled_tcp([window], baseline_windows=[])
+    assert ps.total_loss == 2, f"expected total_loss=2 (all records timed out) but got {ps.total_loss}"
+    assert ps.total_sent == 2, f"expected total_sent=2 but got {ps.total_sent}"
+    assert ps.loss_pct() == 100.0, f"expected loss_pct()=100.0% (fully blackholed) but got {ps.loss_pct():.2f}%"
+
+    ps_full, _buckets, _spike = _compute_pooled_tcp_full([window], baseline_windows=[])
+    assert ps_full.total_loss == 2, f"full-pooled: expected total_loss=2 but got {ps_full.total_loss}"
+    assert ps_full.loss_pct() == 100.0, f"full-pooled: expected 100.0% but got {ps_full.loss_pct():.2f}%"
+
+
+# --------------------------------------------------------------------------- #
+# probe_once — the guest-side except-order (the loss records must be emittable)
+# --------------------------------------------------------------------------- #
+
+
+def _guest_probe_once() -> Any:
+    """Materialize the guest script's probe_once by exec'ing _TCP_PROBE_SCRIPT.
+
+    The script is __main__-guarded, so exec with a test __name__ defines its
+    functions without running main() — the same code the civm guest executes.
+    """
+    ns: dict[str, Any] = {"__name__": "tcp_probe_under_test"}
+    exec(compile(_TCP_PROBE_SCRIPT, "tcp_rst_probe.py", "exec"), ns)  # noqa: S102
+    return ns["probe_once"]
+
+
+def _run_probe_once_with_connect(raiser: BaseException) -> float:
+    """Drive the guest probe_once with asyncio.open_connection raising `raiser`."""
+    probe_once = _guest_probe_once()
+    real_open = asyncio.open_connection
+
+    async def fake_open(*args: Any, **kwargs: Any) -> Any:
+        raise raiser
+
+    async def drive() -> float:
+        asyncio.open_connection = fake_open  # type: ignore[assignment]
+        try:
+            _start, _recv, rtt_ms = await probe_once("192.0.2.1")
+            return float(rtt_ms)
+        finally:
+            asyncio.open_connection = real_open  # type: ignore[assignment]
+
+    return asyncio.run(drive())
+
+
+def test_probe_once_timeout_yields_loss_record() -> None:
+    """A >=5s stall must produce the rtt_ms=-1 LOSS record, not a "valid" RTT sample.
+
+    On Python 3.11+ asyncio.TimeoutError IS the builtin TimeoutError, which
+    subclasses OSError — with the OSError clause first (the pre-fix order) the
+    timeout was swallowed as a positive ~5000ms RTT and the -1 branch was dead
+    code, so no loss could EVER be emitted (the root of the fabricated 0.0
+    loss%). Red on the pre-fix order: rtt_ms >= 0 here.
+    """
+    assert issubclass(asyncio.TimeoutError, OSError), (
+        "precondition: on the targeted Python (3.11+) asyncio.TimeoutError is the "
+        "builtin TimeoutError and subclasses OSError — the except-order trap this pins"
+    )
+    rtt_ms = _run_probe_once_with_connect(asyncio.TimeoutError())
+    assert rtt_ms == -1.0, (
+        f"expected rtt_ms=-1.0 (timeout recorded as a LOSS) but got {rtt_ms} — "
+        "the timeout was caught by the OSError clause and recorded as a valid RTT sample"
+    )
+
+
+def test_probe_once_refused_yields_rtt_sample() -> None:
+    """Branch pair: a fast RST/ECONNREFUSED is a genuine RTT sample, never a loss.
+
+    The RST-reject rules make refused connections the MEASURED behaviour — the
+    refusal time IS the RTT the bench characterizes.
+    """
+    rtt_ms = _run_probe_once_with_connect(ConnectionRefusedError())
+    assert rtt_ms >= 0.0, (
+        f"expected a non-negative RTT for a refused (RST) connection but got {rtt_ms} — "
+        "a refusal must never be tallied as a >=5s loss"
+    )

--- a/tests/test_bench_pfctl_parse.py
+++ b/tests/test_bench_pfctl_parse.py
@@ -1,0 +1,226 @@
+"""Issue #738 F5 — the pfctl bench's TCP-RST probe must count genuine timeouts as loss.
+
+Pins the PURE, off-VM parsing/aggregation seam of ``tests/smoke/test_bench_pfctl.py``'s
+TCP-RST reject-loop probe: before this fix, a connection that genuinely stalled for
+>=5s (``rtt_ms=-1`` in the probe's JSON output) was silently dropped by both the
+guest-side ``if rtt_ms >= 0:`` print filter and the harness-side ``_parse_tcp_probe_output``
+filter, and every TCP ``PooledStats`` hardcoded ``total_loss=0`` — so the printed loss%
+column always read 0.0 even when connections blackholed.
+
+The maintainer's decision (recorded in the issue): SIMPLER pooled semantics — count
+>=5s losses per RUN (summed across a probe's whole capture) and report an honest
+pooled loss%/total_sent, WITHOUT redesigning per-op-window attribution (the ICMP path's
+``_LiveProbe.slice_window`` already treats loss the same way — not attributable to a
+narrow time slice — and this mirrors that, not a new design).
+
+These tests exercise ``_parse_tcp_probe_output`` and ``_compute_pooled_tcp``/
+``_compute_pooled_tcp_full`` directly (pure functions, no VM needed) — importing
+``tests.smoke.test_bench_pfctl`` is import-safe off-VM (see ``tests/test_smoke_diag_redaction.py``
+for the established pattern of pulling pure seams out of ``tests/smoke/`` for the default suite).
+"""
+
+from __future__ import annotations
+
+import json
+
+from tests.smoke.test_bench_pfctl import (
+    PooledStats,
+    TcpRstWindow,
+    _compute_pooled_tcp,
+    _compute_pooled_tcp_full,
+    _parse_tcp_probe_output,
+)
+
+
+def _probe_line(*, start_t: float, t: float, rtt_ms: float, ip: str = "11.0.0.1") -> str:
+    """Build one JSON line in the exact shape tcp_rst_probe.py emits on the guest."""
+    return json.dumps({"start_t": start_t, "t": t, "rtt_ms": rtt_ms, "ip": ip})
+
+
+# --------------------------------------------------------------------------- #
+# _parse_tcp_probe_output — a -1 timeout record is a loss, not a dropped line
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_tcp_probe_output_counts_timeout_as_loss_not_sample() -> None:
+    """A genuine >=5s timeout (rtt_ms=-1) is tallied as a loss and excluded from samples.
+
+    Given probe output with one real RTT record and one -1 timeout record
+    When the output is parsed
+    Then the timeout is counted in ``lost`` (not silently dropped) and never
+      appears in the RTT ``samples`` list (it has no RTT to report).
+    """
+    output = "\n".join(
+        [
+            _probe_line(start_t=100.0, t=100.005, rtt_ms=5.25, ip="11.0.0.1"),
+            _probe_line(start_t=100.1, t=105.1, rtt_ms=-1.0, ip="13.0.0.1"),
+        ]
+    )
+
+    parsed = _parse_tcp_probe_output(output)
+
+    assert parsed.lost == 1, f"expected lost=1 (one genuine >=5s timeout record) but got lost={parsed.lost}"
+    assert len(parsed.samples) == 1, (
+        f"expected 1 kept RTT sample (the timeout must be excluded) but got {len(parsed.samples)}: "
+        f"{[s.rtt_ms for s in parsed.samples]}"
+    )
+    assert parsed.samples[0].rtt_ms == 5.25, (
+        f"expected the surviving sample to be the real RTT record (5.25ms) but got {parsed.samples[0].rtt_ms}ms"
+    )
+    assert all(s.rtt_ms >= 0 for s in parsed.samples), (
+        f"a negative-rtt (timeout) record leaked into samples: {[s.rtt_ms for s in parsed.samples]}"
+    )
+
+
+def test_parse_tcp_probe_output_multiple_losses_all_counted() -> None:
+    """Every -1 record in a batch is tallied, not just the first/last one.
+
+    Given probe output with three timeout records interleaved among two real ones
+    When the output is parsed
+    Then lost == 3 and samples contains exactly the two real RTT records.
+    """
+    lines = [
+        _probe_line(start_t=1.0, t=1.01, rtt_ms=2.0),
+        _probe_line(start_t=1.1, t=6.1, rtt_ms=-1.0),
+        _probe_line(start_t=1.2, t=6.2, rtt_ms=-1.0),
+        _probe_line(start_t=1.3, t=1.31, rtt_ms=3.5),
+        _probe_line(start_t=1.4, t=6.4, rtt_ms=-1.0),
+    ]
+    parsed = _parse_tcp_probe_output("\n".join(lines))
+
+    assert parsed.lost == 3, f"expected lost=3 (three -1 records) but got lost={parsed.lost}"
+    assert len(parsed.samples) == 2, f"expected 2 RTT samples but got {len(parsed.samples)}"
+    assert sorted(s.rtt_ms for s in parsed.samples) == [2.0, 3.5], (
+        f"expected kept RTT samples [2.0, 3.5] but got {sorted(s.rtt_ms for s in parsed.samples)}"
+    )
+
+
+def test_parse_tcp_probe_output_no_losses_stays_zero() -> None:
+    """Branch coverage: output with no timeouts still parses correctly (lost stays 0).
+
+    Given probe output containing only successful RTT records
+    When the output is parsed
+    Then lost == 0 and every record survives into samples.
+    """
+    lines = [
+        _probe_line(start_t=1.0, t=1.001, rtt_ms=1.0),
+        _probe_line(start_t=1.1, t=1.102, rtt_ms=2.2),
+        _probe_line(start_t=1.2, t=1.204, rtt_ms=0.4),
+    ]
+    parsed = _parse_tcp_probe_output("\n".join(lines))
+
+    assert parsed.lost == 0, f"expected lost=0 (no timeout records present) but got lost={parsed.lost}"
+    assert len(parsed.samples) == 3, f"expected all 3 records kept as samples but got {len(parsed.samples)}"
+
+
+# --------------------------------------------------------------------------- #
+# _compute_pooled_tcp / _compute_pooled_tcp_full — real total_loss/total_sent
+# --------------------------------------------------------------------------- #
+
+
+def test_compute_pooled_tcp_reports_real_loss_from_windows() -> None:
+    """Pooled TCP stats surface the windows' real loss tally, not a hardcoded 0.
+
+    Given two per-rep TcpRstWindows: one with 2 samples + 1 loss, one with
+      1 sample + 2 losses (mirrors two probe runs pooled together)
+    When the pooled stats are computed
+    Then total_loss/total_sent reflect the real sums and loss_pct() is the
+      honest percentage — never 0.0 just because losses exist.
+    """
+    parsed_a = _parse_tcp_probe_output(
+        "\n".join(
+            [
+                _probe_line(start_t=0.0, t=0.01, rtt_ms=4.0),
+                _probe_line(start_t=0.1, t=0.11, rtt_ms=6.0),
+                _probe_line(start_t=0.2, t=5.2, rtt_ms=-1.0),
+            ]
+        )
+    )
+    parsed_b = _parse_tcp_probe_output(
+        "\n".join(
+            [
+                _probe_line(start_t=1.0, t=1.02, rtt_ms=3.0),
+                _probe_line(start_t=1.1, t=6.1, rtt_ms=-1.0),
+                _probe_line(start_t=1.2, t=6.2, rtt_ms=-1.0),
+            ]
+        )
+    )
+    window_a = TcpRstWindow(samples=parsed_a.samples, lost=parsed_a.lost)
+    window_b = TcpRstWindow(samples=parsed_b.samples, lost=parsed_b.lost)
+
+    ps = _compute_pooled_tcp([window_a, window_b], baseline_windows=[])
+
+    expected_loss = 3  # 1 (window_a) + 2 (window_b)
+    expected_sent = 6  # 3 samples + 3 losses total
+    assert ps.total_loss == expected_loss, (
+        f"expected total_loss={expected_loss} (real per-run tally, not hardcoded 0) but got {ps.total_loss}"
+    )
+    assert ps.total_sent == expected_sent, f"expected total_sent={expected_sent} but got {ps.total_sent}"
+    expected_pct = 100.0 * expected_loss / expected_sent
+    assert ps.loss_pct() == expected_pct, (
+        f"expected loss_pct()={expected_pct:.2f}% (nonzero — connections genuinely blackholed) "
+        f"but got {ps.loss_pct():.2f}%"
+    )
+    assert ps.loss_pct() > 0.0, "expected a nonzero loss_pct() when the pooled windows contain real losses"
+
+
+def test_compute_pooled_tcp_zero_loss_still_correct() -> None:
+    """Branch coverage: the off side — no losses in any window still reports 0.0% cleanly.
+
+    Given windows built from probe output with zero timeout records
+    When the pooled stats are computed
+    Then total_loss == 0 and loss_pct() == 0.0 (a real zero, not a masked one).
+    """
+    parsed = _parse_tcp_probe_output(
+        "\n".join(
+            [
+                _probe_line(start_t=0.0, t=0.01, rtt_ms=4.0),
+                _probe_line(start_t=0.1, t=0.11, rtt_ms=6.0),
+            ]
+        )
+    )
+    window = TcpRstWindow(samples=parsed.samples, lost=parsed.lost)
+
+    ps = _compute_pooled_tcp([window], baseline_windows=[])
+
+    assert ps.total_loss == 0, f"expected total_loss=0 (no timeouts in input) but got {ps.total_loss}"
+    assert ps.total_sent == 2, f"expected total_sent=2 (2 samples, 0 losses) but got {ps.total_sent}"
+    assert ps.loss_pct() == 0.0, f"expected loss_pct()=0.0% but got {ps.loss_pct():.2f}%"
+
+
+def test_compute_pooled_tcp_full_reports_real_loss_from_windows() -> None:
+    """The disruption-bucket pooling path (_compute_pooled_tcp_full) also gets real loss.
+
+    Given a during-op window with 2 samples + 2 losses
+    When the full-pooled disruption stats are computed
+    Then total_loss/total_sent are real (this is the second of the three sites
+      that hardcoded total_loss=0 before the fix) and loss_pct() > 0.
+    """
+    parsed = _parse_tcp_probe_output(
+        "\n".join(
+            [
+                _probe_line(start_t=0.0, t=0.01, rtt_ms=10.0),
+                _probe_line(start_t=0.1, t=0.11, rtt_ms=20.0),
+                _probe_line(start_t=0.2, t=5.2, rtt_ms=-1.0),
+                _probe_line(start_t=0.3, t=5.3, rtt_ms=-1.0),
+            ]
+        )
+    )
+    window = TcpRstWindow(samples=parsed.samples, lost=parsed.lost)
+
+    ps, _buckets, _spike_thresh = _compute_pooled_tcp_full([window], baseline_windows=[])
+
+    assert ps.total_loss == 2, f"expected total_loss=2 but got {ps.total_loss}"
+    assert ps.total_sent == 4, f"expected total_sent=4 (2 samples + 2 losses) but got {ps.total_sent}"
+    assert ps.loss_pct() == 50.0, f"expected loss_pct()=50.0% but got {ps.loss_pct():.2f}%"
+
+
+def test_compute_pooled_tcp_empty_windows_yields_zero_stats() -> None:
+    """Edge case pinned alongside the fix: no windows at all still returns a clean zero.
+
+    Given no windows (n == 0 short-circuit path in _compute_pooled_tcp)
+    When the pooled stats are computed
+    Then a default (all-zero) PooledStats is returned — not an exception.
+    """
+    ps = _compute_pooled_tcp([], baseline_windows=[])
+    assert ps == PooledStats(), f"expected an all-zero PooledStats() for no windows but got {ps}"


### PR DESCRIPTION
Part of #738 (finding F5; ledger in #729 — `#583 / medium`).

The reject-loop benchmark fabricated its TCP loss metric: the guest probe's `rtt_ms = -1` timeout records were filtered out before printing, `_parse_tcp_probe_output` dropped any that survived, and every TCP `PooledStats` hardcoded `total_loss=0` — the printed `loss%` column always read 0.0 even if connections blackholed. (The ICMP path's accounting was already real.)

Per the maintainer's recorded decision this implements the **pooled per-run tally** (not per-op-window attribution): the guest probe now emits its timeout records; `_parse_tcp_probe_output` returns `TcpProbeParse(samples, lost)`; `TcpRstWindow` carries `lost`/`sent()` mirroring the ICMP `ProbeWindow`; `_compute_pooled_tcp`/`_compute_pooled_tcp_full` and the quiescent baselines thread real `total_loss`/`total_sent`. Disruption-window bucketing keeps its RTT-only semantics; prose/captions updated to state the pooled semantics.

New dev-side `tests/test_bench_pfctl_parse.py` (runs in the default pytest suite) pins the parser and both pooled builders — verified red on the pre-fix module (6/7 fail) and green after (7/7). No live dispatch: the finding is mis-accounting in the harness's own arithmetic, pinned directly by the unit tests; the bench itself remains an always-pass dispatch-only instrument.

Gates: full pytest (baseline zstd env failures unchanged), ruff check/format, mypy — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013baLunt412HLH6L49aF953

---
_Generated by [Claude Code](https://claude.ai/code/session_013baLunt412HLH6L49aF953)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP probe reporting so genuine timeouts are counted as loss instead of being dropped.
  * Loss and latency summaries now better reflect runs with partial or total connection failures.

* **Tests**
  * Added coverage for timeout handling, loss aggregation, empty runs, and fully failed runs.
  * Expanded validation to ensure timeout and connection-refused cases are reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->