### PR TITLE
pfblockerng: fail the hooks description control-char check closed on invalid UTF-8

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
@@ -128,7 +128,10 @@ if ($_POST) {
 					}
 					break;
 				case 'hook_description':
-					if (preg_match('/[\p{C}]+/u', $value)) {
+					// !== 0 fails closed on invalid UTF-8: with /u, preg_match() returns
+					// FALSE (not 0) rather than a real no-match, and a bare truthiness
+					// check would silently let a malformed value through.
+					if (preg_match('/[\p{C}]+/u', $value) !== 0) {
 						$input_errors[] = gettext('The hook description contains invalid control characters.');
 					}
 					break;

--- a/tests/smoke/ui/test_hooks.py
+++ b/tests/smoke/ui/test_hooks.py
@@ -351,6 +351,94 @@ def test_reject_invalid_script_leaves_config_unchanged(webui: WebUI, smoke_vm: h
         helpers.clear_update_hooks(vm)
 
 
+def test_reject_bad_description_leaves_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A control-char description is rejected on BOTH ways preg_match() can flag it (#756).
+
+    Validator branch (pfblockerng_hooks.php, the 'hook_description' case): the
+    check must fail CLOSED on either outcome that means "control characters
+    present" -- a real match (``preg_match()`` returns ``1``) AND an unparseable
+    subject (``preg_match()`` returns ``FALSE``, ``PREG_BAD_UTF8_ERROR``) -- so
+    the condition is ``!== 0``, not a bare truthiness test. A bare
+    ``if (preg_match(...))`` treats ``FALSE`` as falsy and lets a malformed-UTF-8
+    description sail into config.xml unfiltered (issue #756).
+
+    Two reject sub-cases, both leaving the seeded description intact:
+      (a) a REAL control character (BEL, ``\\x07``) -- ``preg_match()`` returns
+          ``1``. Green under BOTH the pre-fix and post-fix code (a truthy ``1``
+          rejects either way) -- the regression guard for existing behaviour.
+      (b) INVALID UTF-8 -- the two raw bytes ``0xC3 0x28`` (a UTF-8 lead byte
+          followed by a non-continuation byte) -- ``preg_match()`` returns
+          ``FALSE``. THIS is the red/green cell: only ``!== 0`` rejects a
+          ``FALSE`` return; the old bare truthiness check accepted it and saved
+          the malformed bytes. ``requests`` would re-encode a Python ``str`` as
+          valid UTF-8 (the two bytes above would become ``%C3%83%28``, itself
+          valid UTF-8, never triggering the ``FALSE`` path) -- so, mirroring
+          ``test_remove_to_empty_deletes_node``'s manual-POST escape hatch, the
+          request body is built and percent-encoded by hand to put the literal
+          invalid bytes on the wire. The rest of the row stays VALID so the
+          description is the ONLY thing deciding accept-vs-reject.
+    """
+    vm = smoke_vm
+    helpers.clear_update_hooks(vm)
+    _install_test_scripts(vm)
+    seed_description = "smoke-desc-756"
+    _seed_one_hook(vm, script=SCRIPT_POST, when="post", enabled="on", description=seed_description)
+    try:
+        # BEFORE: the seeded description is present.
+        assert helpers.config_get(vm, ROW0_DESCRIPTION) == seed_description, (
+            f"seed description missing before the reject flow: got {helpers.config_get(vm, ROW0_DESCRIPTION)!r}"
+        )
+
+        # (a) A real control character -- preg_match() returns 1 either way.
+        resp = webui.post(HOOKS_PAGE, {"hook_description-0": "smoke\x07desc"}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "control-char POST returned the login form"
+        assert helpers.config_get(vm, ROW0_DESCRIPTION) == seed_description, (
+            f"a real control character was NOT rejected -- expected {seed_description!r}, "
+            f"got {helpers.config_get(vm, ROW0_DESCRIPTION)!r}"
+        )
+
+        # (b) Invalid UTF-8 (0xC3 0x28) -- preg_match() returns FALSE. Build the
+        # raw percent-encoded body by hand (see docstring) so the literal invalid
+        # bytes reach the wire instead of a re-encoded valid-UTF-8 substitute.
+        from urllib.parse import quote
+
+        from .webui import extract_csrf_token
+
+        form = webui.get(HOOKS_PAGE)
+        assert not looks_like_login_page(form.text), "hooks GET returned the login form (session lost)"
+        token = extract_csrf_token(form.text)
+        body = "&".join(
+            [
+                f"hook_script-0={quote(SCRIPT_POST, safe='')}",
+                "hook_when-0=post",
+                "hook_timeout-0=",
+                "hook_enabled-0=on",
+                "hook_description-0=%C3%28",
+                f"__csrf_magic={quote(token, safe='')}",
+                "save=save",
+            ]
+        )
+        resp = webui.session.post(
+            webui.url(HOOKS_PAGE),
+            data=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            verify=False,
+            timeout=120.0,
+        )
+        assert not looks_like_login_page(resp.text), "invalid-UTF-8 POST returned the login form"
+
+        # AFTER (reject): the node still exists and the description is UNCHANGED
+        # -- on unfixed code (a bare `if (preg_match(...))`) this save would have
+        # gone through, overwriting the description with the malformed bytes.
+        assert _hooks_node_exists(vm), "hooks node deleted by a REJECTED invalid-UTF-8-description save"
+        assert helpers.config_get(vm, ROW0_DESCRIPTION) == seed_description, (
+            f"invalid UTF-8 in the description was NOT rejected -- expected {seed_description!r}, "
+            f"got {helpers.config_get(vm, ROW0_DESCRIPTION)!r}"
+        )
+    finally:
+        helpers.clear_update_hooks(vm)
+
+
 def test_reject_bad_when_leaves_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
     """A 'When' value outside {pre,post} is rejected; config stays unchanged.
 


### PR DESCRIPTION
Fixes #756

## Defect

`pfblockerng_hooks.php`'s `hook_description` validator used a bare truthiness test on `preg_match('/[\p{C}]+/u', $value)`. With `/u`, `preg_match()` returns `FALSE` (not `0`) on an invalid-UTF-8 subject (`PREG_BAD_UTF8_ERROR`, no warning), so a malformed-UTF-8 description skipped the error branch and was silently saved to config — the check failed open. This was the last bare `\p{C}` site in `src/`; the `pfb_filter()` front gate got the same treatment in `a13effe3` (#714 c3 / PR #755).

## Fix

Reject on `!== 0`, treating both a real control-char match (`1`) and an unparseable subject (`FALSE`) as rejection — fail-closed, mirroring the `.inc` idiom. One line plus a short comment.

## Test (Tier B `ui_e2e`, red→green proven live)

New `test_reject_bad_description_leaves_config_unchanged` in `tests/smoke/ui/test_hooks.py`, following the module's reject-flow/transition conventions. Branch coverage per the mandate:

- **(a) real control char** (BEL, `preg_match` → `1`): rejected under both old and new code — the regression guard.
- **(b) invalid UTF-8** (`0xC3 0x28`, `preg_match` → `FALSE`): the red→green cell. The bytes are put on the wire via a hand-built percent-encoded body (`%C3%28`) — Python `requests` would otherwise re-encode the field as valid UTF-8 and never reach the `FALSE` path. The row is otherwise valid, so the description check alone decides accept-vs-reject.

Live-VM proof (local smoke, two parallel legs):

- **Red**: temp branch = this test + the fix reverted → `1 failed` (the invalid-UTF-8 assertion — branch (a) is fix-invariant, so with the green leg fully passing the failure can only be the branch (b) cell).
- **Green**: this branch → `7 passed` (whole hooks e2e module).

Gates: `php -l`, PHPStan, PHPCS, ruff, `python -m pytest` (2038 passed), collect-only on the smoke module — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
