### PR TITLE
pfblockerng: clamp a feed's explicit /0 to a single host, honor /0 on custom lists

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7889,6 +7889,8 @@ function pfblockerng_top1m() {
 
 
 // Function to remove any leading zeros in octets and to exclude private/reserved addresses.
+// A downloaded feed's explicit /0 is clamped to a single host and logged (issue #744);
+// a custom list's /0 is honored as written.
 function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 	global $pfb;
 
@@ -7908,7 +7910,9 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 	// blocked (issue #744). Custom-list entries are user-authored, so /0 is
 	// kept as written (e.g. 0.0.0.0/0 referenced by a manual rule).
 	if ($mask !== '' && (int)$mask === 0 && !$custom) {
-		pfb_logger("\n  Feed /0 CIDR clamped to single host: {$ipaddr}", 1);
+		// Unlike the v6 sibling, callers reach this before validate_ipv4(), so
+		// $ipaddr is raw feed text — strip control chars to keep the log clean.
+		pfb_logger("\n  Feed /0 CIDR clamped to single host: " . preg_replace('/[[:cntrl:]]/', '', $ipaddr), 1);
 		$mask = '';
 	}
 	$iparr = explode('.', $subnet);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7902,6 +7902,15 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 	if ($mask !== '' && (!ctype_digit($mask) || (int)$mask > 32)) {
 		return;
 	}
+
+	// An explicit /0 covers the entire IPv4 space and is never honored from a
+	// downloaded feed: clamp to a single host so the address itself stays
+	// blocked (issue #744). Custom-list entries are user-authored, so /0 is
+	// kept as written (e.g. 0.0.0.0/0 referenced by a manual rule).
+	if ($mask !== '' && (int)$mask === 0 && !$custom) {
+		pfb_logger("\n  Feed /0 CIDR clamped to single host: {$ipaddr}", 1);
+		$mask = '';
+	}
 	$iparr = explode('.', $subnet);
 
 	foreach ($iparr as $key => $octet) {
@@ -7948,7 +7957,9 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 		}
 	}
 
-	if (!empty($mask)) {
+	// '!== '' (not !empty()): empty('0') is TRUE, which silently collapsed a
+	// custom list's honored /0 to a bare host (issue #744).
+	if ($mask !== '') {
 		return "{$ip_final}/{$mask}";
 	}
 	return "{$ip_final}";
@@ -7956,16 +7967,28 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 
 
 // IPv6 sibling of sanitize_ipaddr(): exclude private/reserved/loopback IPv6
-// addresses from loaded block lists when Suppression is enabled. Returns the
-// entry unchanged when kept; returns nothing (drops it) when excluded.
+// addresses from loaded block lists when Suppression is enabled. A downloaded
+// feed's explicit /0 is clamped to a single host (issue #744); otherwise the
+// entry is returned unchanged when kept, nothing (dropped) when excluded.
 function sanitize_ipaddr_v6($ipaddr, $custom) {
 	global $pfb;
 
+	// Extract the address part (before '/' for a CIDR like 'fc00::/7')
+	$parts	= explode('/', $ipaddr);
+	$s_ip	= $parts[0];
+	$mask	= $parts[1] ?? '';
+
+	// An explicit /0 covers the entire IPv6 space and is never honored from a
+	// downloaded feed: clamp to a single host so the address itself stays
+	// blocked (issue #744). Custom-list entries are user-authored, so /0 is
+	// kept as written.
+	if ($mask !== '' && ctype_digit($mask) && (int)$mask === 0 && !$custom) {
+		pfb_logger("\n  Feed /0 CIDR clamped to single host: {$ipaddr}", 1);
+		$ipaddr = $s_ip;
+	}
+
 	// Exclude private/reserved IPs (bypass exclusion for custom lists)
 	if ($pfb['supp'] == 'on' && !$custom) {
-
-		// Extract the address part (before '/' for a CIDR like 'fc00::/7')
-		$s_ip = explode('/', $ipaddr)[0];
 
 		// Drop ULA (fc00::/7), link-local (fe80::/10), loopback (::1),
 		// IPv4-mapped and the reserved set (mirrors inc:7118-7119).

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -8,8 +8,10 @@ use PHPUnit\Framework\TestCase;
 /**
  * sanitize_ipaddr() — normalise an IPv4(/mask): strip leading zeros, drop a /32,
  * keep a bare address as a single host (/32) even when it ends in '.0', force
- * the 4th octet to 0 on an explicit /24, and (when $pfb['supp']=='on' and not a
- * custom list) drop loopback/reserved/private and apply the Advanced CIDR floor.
+ * the 4th octet to 0 on an explicit /24, clamp a downloaded feed's /0 to a
+ * single host while honoring /0 on a custom list (issue #744), and (when
+ * $pfb['supp']=='on' and not a custom list) drop loopback/reserved/private and
+ * apply the Advanced CIDR floor.
  */
 #[CoversFunction('sanitize_ipaddr')]
 final class SanitizeIpaddrTest extends TestCase
@@ -120,5 +122,53 @@ final class SanitizeIpaddrTest extends TestCase
 	public function testNonNumericMaskDropped(): void
 	{
 		$this->assertNull(sanitize_ipaddr('1.2.3.4/abc', false, 'Disabled'));
+	}
+
+	// --- Explicit /0 masks (issue #744) ---------------------------------------
+
+	// A downloaded feed's /0 covers the entire IPv4 space and is never honored:
+	// it is clamped to a single host, so the address itself stays blocked
+	// (dropping the whole line would under-block).
+	public function testFeedSlashZeroClampedToSingleHost(): void
+	{
+		$this->assertSame('198.51.100.7', sanitize_ipaddr('198.51.100.7/0', false, 'Disabled'));
+	}
+
+	// The clamp is visible in the pfBlockerNG log — never a silent rewrite.
+	public function testFeedSlashZeroClampIsLogged(): void
+	{
+		$prev_log = $GLOBALS['pfb']['log'];	// bootstrap sandbox log — restore after
+		$logfile = tempnam(sys_get_temp_dir(), 'pfb_log_');
+		$GLOBALS['pfb']['log'] = $logfile;
+		try {
+			sanitize_ipaddr('198.51.100.7/0', false, 'Disabled');
+			$this->assertStringContainsString('198.51.100.7/0', (string) file_get_contents($logfile));
+		} finally {
+			@unlink($logfile);
+			$GLOBALS['pfb']['log'] = $prev_log;
+		}
+	}
+
+	// The /0 is clamped to a host up front, so under suppression it no longer
+	// slips past the Advanced CIDR floor as an "empty" mask — the result is
+	// the same single host, not an unclamped /0.
+	public function testFeedSlashZeroUnderSuppressionCidrFloorStillSingleHost(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('198.51.100.7', sanitize_ipaddr('198.51.100.7/0', false, 24));
+	}
+
+	// Custom-list entries are user-authored: an explicit /0 is honored as
+	// written, never clamped or collapsed to a bare host (e.g. 0.0.0.0/0 in a
+	// custom list referenced by a manual firewall rule).
+	public function testCustomListSlashZeroHonored(): void
+	{
+		$this->assertSame('0.0.0.0/0', sanitize_ipaddr('0.0.0.0/0', true, 'Disabled'));
+	}
+
+	public function testCustomListSlashZeroHonoredUnderSuppression(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('0.0.0.0/0', sanitize_ipaddr('0.0.0.0/0', true, 24));
 	}
 }

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -128,10 +128,20 @@ final class SanitizeIpaddrTest extends TestCase
 
 	// A downloaded feed's /0 covers the entire IPv4 space and is never honored:
 	// it is clamped to a single host, so the address itself stays blocked
-	// (dropping the whole line would under-block).
+	// (dropping the whole line would under-block). Regression PIN: the old code
+	// produced the same value by accident (empty('0') collapse); this pins it
+	// as intentional — the red→green evidence is the log + custom-honor tests.
 	public function testFeedSlashZeroClampedToSingleHost(): void
 	{
 		$this->assertSame('198.51.100.7', sanitize_ipaddr('198.51.100.7/0', false, 'Disabled'));
+	}
+
+	// The clamp keys on the numeric mask value, not the '0' literal — a
+	// multi-zero spelling (/00) is clamped the same way (previously it leaked
+	// through as 'ip/00' and the whole line was dropped by validation).
+	public function testFeedMultiZeroMaskClampedToSingleHost(): void
+	{
+		$this->assertSame('198.51.100.7', sanitize_ipaddr('198.51.100.7/00', false, 'Disabled'));
 	}
 
 	// The clamp is visible in the pfBlockerNG log — never a silent rewrite.
@@ -151,11 +161,21 @@ final class SanitizeIpaddrTest extends TestCase
 
 	// The /0 is clamped to a host up front, so under suppression it no longer
 	// slips past the Advanced CIDR floor as an "empty" mask — the result is
-	// the same single host, not an unclamped /0.
+	// the same single host, not an unclamped /0. Regression PIN (same
+	// accidental end-state as above, now deliberate).
 	public function testFeedSlashZeroUnderSuppressionCidrFloorStillSingleHost(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
 		$this->assertSame('198.51.100.7', sanitize_ipaddr('198.51.100.7/0', false, 24));
+	}
+
+	// Interaction PIN: a feed 0.0.0.0/0 under suppression is clamped to the
+	// host 0.0.0.0, which the pre-existing '0.0.0.0' exclusion then DROPS —
+	// the line yields nothing, it does not survive as a host entry.
+	public function testFeedZeroSlashZeroUnderSuppressionDropped(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('0.0.0.0/0', false, 'Disabled'));
 	}
 
 	// Custom-list entries are user-authored: an explicit /0 is honored as

--- a/tests/php/SanitizeIpaddrV6Test.php
+++ b/tests/php/SanitizeIpaddrV6Test.php
@@ -110,6 +110,21 @@ final class SanitizeIpaddrV6Test extends TestCase
 		$this->assertSame('2606:4700:4700::1111', sanitize_ipaddr_v6('2606:4700:4700::1111/0', false));
 	}
 
+	// Same clamp with suppression ON: the public address survives the
+	// reserved/private filter and is kept as a single host, not a /0.
+	public function testFeedSlashZeroUnderSuppressionClampedToSingleHost(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('2606:4700:4700::1111', sanitize_ipaddr_v6('2606:4700:4700::1111/0', false));
+	}
+
+	// The clamp keys on the numeric mask value, not the '0' literal — a
+	// multi-zero spelling (/00) is clamped the same way.
+	public function testFeedMultiZeroMaskClampedToSingleHost(): void
+	{
+		$this->assertSame('2606:4700:4700::1111', sanitize_ipaddr_v6('2606:4700:4700::1111/00', false));
+	}
+
 	// Custom-list entries are user-authored: an explicit /0 is honored as
 	// written (::/0 stays ::/0).
 	public function testCustomListSlashZeroHonored(): void

--- a/tests/php/SanitizeIpaddrV6Test.php
+++ b/tests/php/SanitizeIpaddrV6Test.php
@@ -10,7 +10,8 @@ use PHPUnit\Framework\TestCase;
  * $pfb['supp']=='on' and not a custom list, drop private (ULA fc00::/7),
  * link-local (fe80::/10), loopback (::1) and the reserved set (::/128) from
  * loaded block lists; keep a genuinely public address. Suppression off, or a
- * custom list, keeps the entry unchanged.
+ * custom list, keeps the entry unchanged. A downloaded feed's explicit /0 is
+ * clamped to a single host; a custom list's /0 is honored (issue #744).
  */
 #[CoversFunction('sanitize_ipaddr_v6')]
 final class SanitizeIpaddrV6Test extends TestCase
@@ -97,5 +98,23 @@ final class SanitizeIpaddrV6Test extends TestCase
 		$GLOBALS['pfb']['supp'] = 'on';
 		// A routable v6 CIDR survives unchanged (returned as-is, mask intact).
 		$this->assertSame('2606:4700:4700::/48', sanitize_ipaddr_v6('2606:4700:4700::/48', false));
+	}
+
+	// --- Explicit /0 masks (issue #744) ---------------------------------------
+
+	// A downloaded feed's /0 covers the entire IPv6 space and is never honored:
+	// it is clamped to a single host, so the address itself stays blocked
+	// instead of the line loading as a block-everything table entry.
+	public function testFeedSlashZeroClampedToSingleHost(): void
+	{
+		$this->assertSame('2606:4700:4700::1111', sanitize_ipaddr_v6('2606:4700:4700::1111/0', false));
+	}
+
+	// Custom-list entries are user-authored: an explicit /0 is honored as
+	// written (::/0 stays ::/0).
+	public function testCustomListSlashZeroHonored(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('::/0', sanitize_ipaddr_v6('::/0', true));
 	}
 }


### PR DESCRIPTION
Fixes #744

## Problem

`sanitize_ipaddr()` treats an explicit `/0` mask as "no mask" (`empty('0')` is `TRUE`), so a feed line like `1.2.3.0/0` is silently rewritten to a bare host — it skips the Advanced CIDR-floor clamp and the final return drops the mask. The same collapse hits **custom lists**, where `/0` is a supported, user-authored value (per @BBcan177's comment: `0.0.0.0/0` in a custom list referenced by a manual firewall rule). On the v6 side the opposite hazard existed: `sanitize_ipaddr_v6()` passed a feed's `/0` through **verbatim**, so a single malformed feed line could load a block-everything table entry.

## Resolution (per maintainer discussion on the issue)

- **Downloaded feeds (v4 + v6):** an explicit `/0` is never honored — it is **clamped to a single host** and **logged** (`Feed /0 CIDR clamped to single host: <line>`). Clamping (rather than dropping the line) keeps the address itself blocked, so we don't under-block; logging removes the "silent" part of the rewrite.
- **Custom lists:** `/0` is **honored as written** — no clamp, no collapse. This follows @BBcan177's guidance that the restriction should apply to downloaded feeds only, and it *fixes* the custom-list case, which previously collapsed `0.0.0.0/0` to the bare host `0.0.0.0`.

The final return now checks `$mask !== ''` instead of `!empty($mask)`, which is what allows a custom list's `/0` to survive.

## Tests (red → green verified by reverting the src change)

| Case | Before | After |
| ---- | ------ | ----- |
| Feed `198.51.100.7/0` (v4) | bare host, **silent** | bare host, **logged** (log assertion red before) |
| Feed `/0` under suppression + CIDR floor | bare host (floor skipped via empty-mask) | bare host (clamped up front) — pinned |
| Custom `0.0.0.0/0` (supp off / on+floor) | collapsed to `0.0.0.0` | honored as `0.0.0.0/0` (red before) |
| Feed `2606:4700:4700::1111/0` (v6) | passed through as `/0` (block-everything) | clamped to single host (red before) |
| Custom `::/0` (v6) | honored | honored — pinned |

Gates: PHPUnit 1853 tests green (the one `IpAddrDoublesTest` failure is pre-existing on clean `devel`, macOS-only `inet_pton` leniency — CI on Linux is unaffected), PHPStan clean, PHPCS clean, `php -l` clean.

No `www/` change → no UI tier required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IP sanitization so downloaded feed entries with `/0` are treated as a single host instead of a full-range match.
  * Preserved `/0` exactly as entered for custom list entries, including IPv6.
  * Corrected mask formatting so a zero-length mask is no longer dropped in returned IPv4 values.
  * Added logging when `/0` values from feeds are clamped, improving traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->