### PR TITLE
tests: prove reboots in reboot_vm and restore the DNSBL-Control baseline on any exit (#738 F4+F6)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2518,7 +2518,16 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
          side was unreadable), the readiness gate answered on the pre-reboot instance and this
          raises loudly instead of letting the caller assert against stale state.
     """
-    before_boottime = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0).stdout
+    # Fail FAST on an unreadable before-side: without it the proof is already lost, so
+    # refusing to reboot saves the whole settle+readiness cycle and leaves the box up in
+    # its pre-reboot state for diagnosis (#761 review).
+    before_read = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0)
+    before_boottime = before_read.stdout
+    if not before_boottime.strip():
+        raise AssertionError(
+            f"reboot_vm: kern.boottime unreadable BEFORE the reboot (rc={before_read.returncode} "
+            f"stderr={before_read.stderr!r}) -- refusing to reboot without the before-side of the proof"
+        )
 
     # Issue the reboot; it drops our SSH connection, so a non-zero/dropped result is EXPECTED.
     vm.ssh("/sbin/reboot", timeout=30.0)

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2521,7 +2521,15 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
     # Fail FAST on an unreadable before-side: without it the proof is already lost, so
     # refusing to reboot saves the whole settle+readiness cycle and leaves the box up in
     # its pre-reboot state for diagnosis (#761 review).
-    before_read = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0)
+    try:
+        before_read = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0)
+    except subprocess.TimeoutExpired as exc:
+        # Route the timeout through the boot-proof diagnostics (#761 review): a hung read
+        # is the same "no before-side" failure as an empty one, just slower.
+        raise AssertionError(
+            f"reboot_vm: kern.boottime read timed out BEFORE the reboot ({exc}) -- refusing to "
+            "reboot without the before-side of the proof"
+        ) from exc
     before_boottime = before_read.stdout
     if not before_boottime.strip():
         raise AssertionError(
@@ -2571,7 +2579,13 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
     # still-up pre-reboot instance if shutdown outlasted the settle on a slow host. Compare
     # kern.boottime now that readiness is fully established -- this is the ONE extra guest round
     # trip, not a poll, so it never eats into the readiness budget.
-    after_boottime = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0).stdout
+    try:
+        after_boottime = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0).stdout
+    except subprocess.TimeoutExpired as exc:
+        raise AssertionError(
+            f"reboot_vm: kern.boottime read timed out AFTER the readiness gate ({exc}) -- the boot "
+            f"proof is incomplete (before={before_boottime.strip()!r}); treat the reboot as unproven"
+        ) from exc
     _assert_boottime_advanced(before_boottime, after_boottime)
 
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2457,32 +2457,74 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
 
 # Fixed settle after issuing /sbin/reboot, before probing readiness: long enough that the box
 # is actually shutting down (so we never read the still-up pre-reboot sshd as "ready"), short
-# relative to the boot it precedes. A deliberate shutdown wait -- not concurrency coordination.
+# relative to the boot it precedes. A deliberate shutdown wait -- not concurrency coordination
+# (issue #456's exception: we are waiting out a real OS shutdown we cannot signal, not
+# coordinating two sides of our own async code).
 _REBOOT_SETTLE_SECS = 30
+
+_BOOTTIME_SYSCTL = "sysctl -n kern.boottime"
+
+
+def _assert_boottime_advanced(before: str, after: str) -> None:
+    """Raise AssertionError unless ``kern.boottime`` genuinely changed across a reboot (#738 F4).
+
+    Pure comparison, no VM I/O, so it is unit-testable off-VM. ``before``/``after`` are the raw
+    ``sysctl -n kern.boottime`` output captured immediately before issuing ``/sbin/reboot`` and
+    immediately after the readiness gate clears. An unchanged value means the readiness gate
+    answered on the PRE-reboot instance -- the guest never actually went down and back up. An
+    empty side means the sysctl read itself failed (e.g. a dropped SSH connection mid-boot),
+    which is just as fatal to the proof, so it raises too, naming which side was empty.
+    """
+    before_val = before.strip()
+    after_val = after.strip()
+    if not before_val:
+        raise AssertionError(
+            "reboot_vm: could not read kern.boottime BEFORE the reboot (empty output) -- cannot prove a reboot happened"
+        )
+    if not after_val:
+        raise AssertionError(
+            "reboot_vm: could not read kern.boottime AFTER the reboot (empty output) -- cannot prove a reboot happened"
+        )
+    if before_val == after_val:
+        raise AssertionError(
+            f"reboot_vm: kern.boottime unchanged (before={before_val!r} after={after_val!r}) -- "
+            "the guest never rebooted; the readiness gate answered on the PRE-reboot instance"
+        )
 
 
 def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
     """Reboot the guest OS and block until it is ready again, reusing the SAME readiness gate
     as the initial boot.
 
-      1. Issue ``/sbin/reboot`` -- best-effort: the command tears down our SSH session, so a
+      1. Read ``kern.boottime`` once, BEFORE issuing the reboot -- the "before" side of the
+         post-reboot proof (#738 F4).
+      2. Issue ``/sbin/reboot`` -- best-effort: the command tears down our SSH session, so a
          non-zero / dropped result is EXPECTED, not an error.
-      2. Sleep a fixed SETTLE so the box is actually DOWN before we probe; otherwise the
+      3. Sleep a fixed SETTLE so the box is actually DOWN before we probe; otherwise the
          still-up pre-reboot sshd answers and ``wait_ready.sh`` false-positives "ready" before
          the reboot has even happened. This replaces the previous ``kern.boottime``-change poll,
          which was fragile and consumed the readiness budget (timing out even when the box came
-         back fine).
-      3. Run the SAME readiness gate the initial boot uses (conftest ``boot_vm``): ``wait_ready.sh``
+         back fine). Deliberate shutdown wait, not concurrency coordination -- issue #456's
+         documented exception (no side of our own code to signal; we are waiting out a real OS
+         shutdown).
+      4. Run the SAME readiness gate the initial boot uses (conftest ``boot_vm``): ``wait_ready.sh``
          (QEMU pid + web port: nginx + PHP up) with the FULL budget, then ``wait_boot_complete``
          (``is_platform_booting()`` cleared, so a post-reboot pfBlockerNG sync cannot race boot --
          the #559 guard). THEN ``wait_unbound_ready`` so DNS assertions are safe immediately (the
          reboot tests probe DNS, which a bare boot does not).
+      5. Read ``kern.boottime`` once more, AFTER the full readiness gate completes, and compare
+         against the "before" reading (#738 F4) -- a SINGLE post-readiness check, so it consumes
+         no readiness budget (unlike the removed poll). If the value never changed (or either
+         side was unreadable), the readiness gate answered on the pre-reboot instance and this
+         raises loudly instead of letting the caller assert against stale state.
     """
+    before_boottime = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0).stdout
+
     # Issue the reboot; it drops our SSH connection, so a non-zero/dropped result is EXPECTED.
     vm.ssh("/sbin/reboot", timeout=30.0)
 
     # Settle: let the box shut down before we probe, so we never read the still-up pre-reboot
-    # sshd as "ready".
+    # sshd as "ready". Deliberate shutdown wait -- see the docstring's step 3.
     time.sleep(_REBOOT_SETTLE_SECS)
 
     # Full readiness via the SAME shell gate the initial boot uses. wait_ready.sh's positional
@@ -2515,6 +2557,13 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
     wait_boot_complete(vm)
     # Extra over a bare boot: the reboot tests probe DNS, so wait for Unbound to answer.
     wait_unbound_ready(vm)
+
+    # Single post-readiness proof (#738 F4): the readiness gate above can false-positive on the
+    # still-up pre-reboot instance if shutdown outlasted the settle on a slow host. Compare
+    # kern.boottime now that readiness is fully established -- this is the ONE extra guest round
+    # trip, not a poll, so it never eats into the readiness budget.
+    after_boottime = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0).stdout
+    _assert_boottime_advanced(before_boottime, after_boottime)
 
 
 # pfBlockerNG archives its IP aliastables + DNSBL DB here for RAMDISK installs; the

--- a/tests/smoke/test_smoke_dnsbl_control.py
+++ b/tests/smoke/test_smoke_dnsbl_control.py
@@ -189,41 +189,49 @@ def test_dnsbl_control_off_makes_cli_channel_inert(control_vm: tuple[SmokeVM, st
     vm, blocked = control_vm
 
     # GIVEN: the fixture baseline — Control on, reader live, domain blocked. Establish it
-    # explicitly (don't depend on a sibling test's end state).
+    # explicitly (don't depend on a sibling test's end state). Nothing mutated yet, so this
+    # stays outside the try below.
     h.assert_control_ini(vm, control=True, legacy=False)
     before = h.dns_probe_client(client_vm, blocked, "A")
     assert h.is_vip(before), f"{blocked} expected VIP block with DNSBL Control on, got {before}"
 
-    # WHEN: turn DNSBL Control OFF and reload so the reader thread does not start.
-    h.set_dnsbl_control(vm, False)
-    h.reload(vm, "update")
-    h.assert_control_ini(vm, control=False, legacy=False)
+    # #738 F6: everything from here mutates the MODULE-scoped control_vm's shared baseline
+    # (Control OFF). The two legacy tests below don't re-establish Control ON — they ASSERT
+    # it via assert_control_ini as a precondition. An assertion failure anywhere in this OFF
+    # phase must not skip the restore, or Control-OFF leaks into those tests and one real
+    # regression here reports as three failures. finally runs on every exit path.
+    try:
+        # WHEN: turn DNSBL Control OFF and reload so the reader thread does not start.
+        h.set_dnsbl_control(vm, False)
+        h.reload(vm, "update")
+        h.assert_control_ini(vm, control=False, legacy=False)
 
-    # AND: issue a disable. The CLI writer still validates + publishes it (returns a seq),
-    # but with no reader thread nothing consumes it — the writer waits up to 5s for the
-    # (absent) reader to confirm, logs "not confirmed applied", then returns the seq.
-    applied_before = h.read_control_applied(vm)
-    seq = h.dnsbl_control_cli(vm, "disable")
-    h.flush_unbound_cache(vm)
+        # AND: issue a disable. The CLI writer still validates + publishes it (returns a seq),
+        # but with no reader thread nothing consumes it — the writer waits up to 5s for the
+        # (absent) reader to confirm, logs "not confirmed applied", then returns the seq.
+        applied_before = h.read_control_applied(vm)
+        seq = h.dnsbl_control_cli(vm, "disable")
+        h.flush_unbound_cache(vm)
 
-    # THEN: blocking is UNCHANGED — the domain stays VIP-blocked (the disable never applied).
-    still = h.dns_probe_client(client_vm, blocked, "A")
-    assert h.is_vip(still), (
-        f"{blocked} should STAY VIP-blocked — with DNSBL Control OFF no reader thread consumes "
-        f"the CLI disable (seq {seq}), got {still}"
-    )
-    # AND: the applied marker did not advance to the queued command (no reader ran).
-    applied_after = h.read_control_applied(vm)
-    assert applied_after == applied_before, (
-        f"applied marker moved to {applied_after} (was {applied_before}); with DNSBL Control OFF "
-        f"the reader thread must be stopped, so command seq {seq} must NOT be applied"
-    )
-
-    # Restore the fixture baseline for the legacy tests below: Control back ON + reload
-    # re-initialises python_blacklist (blocking on) and restarts the reader thread.
-    h.set_dnsbl_control(vm, True)
-    h.reload(vm, "update")
-    h.assert_control_ini(vm, control=True, legacy=False)
+        # THEN: blocking is UNCHANGED — the domain stays VIP-blocked (the disable never applied).
+        still = h.dns_probe_client(client_vm, blocked, "A")
+        assert h.is_vip(still), (
+            f"{blocked} should STAY VIP-blocked — with DNSBL Control OFF no reader thread consumes "
+            f"the CLI disable (seq {seq}), got {still}"
+        )
+        # AND: the applied marker did not advance to the queued command (no reader ran).
+        applied_after = h.read_control_applied(vm)
+        assert applied_after == applied_before, (
+            f"applied marker moved to {applied_after} (was {applied_before}); with DNSBL Control OFF "
+            f"the reader thread must be stopped, so command seq {seq} must NOT be applied"
+        )
+    finally:
+        # Restore the fixture baseline for the legacy tests below: Control back ON + reload
+        # re-initialises python_blacklist (blocking on) and restarts the reader thread. Runs
+        # unconditionally — pass, assertion failure, or any other exception (#738 F6).
+        h.set_dnsbl_control(vm, True)
+        h.reload(vm, "update")
+        h.assert_control_ini(vm, control=True, legacy=False)
 
 
 def test_legacy_dns_txt_control_inert_by_default(control_vm: tuple[SmokeVM, str], client_vm: SmokeVM) -> None:

--- a/tests/smoke/test_smoke_dnsbl_control.py
+++ b/tests/smoke/test_smoke_dnsbl_control.py
@@ -35,6 +35,7 @@ client IP, which an on-box drill presents as 127.0.0.1.
 from __future__ import annotations
 
 import os
+import sys
 from collections.abc import Iterator
 
 import pytest
@@ -229,9 +230,19 @@ def test_dnsbl_control_off_makes_cli_channel_inert(control_vm: tuple[SmokeVM, st
         # Restore the fixture baseline for the legacy tests below: Control back ON + reload
         # re-initialises python_blacklist (blocking on) and restarts the reader thread. Runs
         # unconditionally — pass, assertion failure, or any other exception (#738 F6).
-        h.set_dnsbl_control(vm, True)
-        h.reload(vm, "update")
-        h.assert_control_ini(vm, control=True, legacy=False)
+        # When the try body ALSO failed, keep that primary failure top-line (a restore error
+        # would otherwise replace it, #761 review) — but when the body passed, a failed
+        # restore MUST raise loudly: it is the only signal before the legacy tests inherit a
+        # broken baseline.
+        try:
+            h.set_dnsbl_control(vm, True)
+            h.reload(vm, "update")
+            h.assert_control_ini(vm, control=True, legacy=False)
+        except Exception as restore_exc:  # noqa: BLE001 -- deliberate: triage-order control
+            if sys.exc_info()[1] is not None:
+                print(f"[smoke] Control-OFF baseline restore ALSO failed (primary kept): {restore_exc!r}")
+            else:
+                raise
 
 
 def test_legacy_dns_txt_control_inert_by_default(control_vm: tuple[SmokeVM, str], client_vm: SmokeVM) -> None:

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -272,6 +272,11 @@ def test_tick_wiped_ledger_jittered(deployed_vm: SmokeVM):
 
 @pytest.mark.reboot
 @pytest.mark.tick
+# Unlike the boot_reload siblings (which reboot in a FIXTURE, exempt from the workflow's
+# 30s func-only body cap), this test reboots in its BODY: the 30s settle alone exhausts
+# the default cap, so it could never pass a dispatch without its own budget (#738 F4
+# validation run). Reboot ~90-150s (settle + readiness gate) + ledger checks + margin.
+@pytest.mark.timeout(300)
 def test_tick_reboot_persists_ledger(deployed_vm: SmokeVM):
     """A clean reboot keeps the due-ledger (restored via #468 earlyshellcmd).
 

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -1,0 +1,81 @@
+"""Issue #738 finding F4 — ``reboot_vm`` must PROVE the guest actually rebooted.
+
+``tests/smoke/helpers.reboot_vm`` replaced the old ``kern.boottime``-change POLL with a fixed
+settle sleep (see ``_REBOOT_SETTLE_SECS``): if shutdown outlasts that settle on a slow host, the
+still-up PRE-reboot sshd answers the readiness gate as "ready", and every downstream assertion
+(the reboot-persistence tests in ``tests/smoke/test_smoke_boot_reload.py`` and
+``tests/smoke/test_smoke_tick.py``) silently runs against stale pre-reboot state. The fix restores
+proof WITHOUT restoring the poll: a single ``kern.boottime`` read before the reboot and a single
+read after the full readiness gate, compared by ``_assert_boottime_advanced``.
+
+This module pins that PURE comparison seam off-VM (no VM I/O, no network) — it lives under
+``tests/`` (NOT ``tests/smoke/``) so it runs in the default suite. Importing
+``tests.smoke.helpers`` itself needs no VM (its own module docstring guarantees import-safety;
+mirrors the precedent in ``tests/test_smoke_diag_redaction.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.smoke.helpers import _assert_boottime_advanced
+
+_BEFORE = "{ sec = 1751500000, usec = 123456 }"
+_AFTER = "{ sec = 1751500090, usec = 654321 }"
+
+
+def test_assert_boottime_advanced_passes_when_value_changed() -> None:
+    """Given a kern.boottime reading that DIFFERS before vs. after the reboot
+    When _assert_boottime_advanced runs
+    Then it does not raise — this is the real-reboot case.
+    """
+    _assert_boottime_advanced(_BEFORE, _AFTER)  # must not raise
+
+
+def test_assert_boottime_advanced_raises_when_value_unchanged() -> None:
+    """LOAD-BEARING: an unchanged kern.boottime means the readiness gate answered on the
+    PRE-reboot instance (the guest never actually went down and back up).
+
+    Given the same kern.boottime reading before AND after
+    When _assert_boottime_advanced runs
+    Then it raises AssertionError naming BOTH the before and after value, so a maintainer never
+         has to guess which side is stale.
+    """
+    with pytest.raises(AssertionError) as exc_info:
+        _assert_boottime_advanced(_BEFORE, _BEFORE)
+    message = str(exc_info.value)
+    assert _BEFORE in message, f"expected the unchanged value {_BEFORE!r} in the message, got: {message!r}"
+    assert "never rebooted" in message
+
+
+def test_assert_boottime_advanced_raises_when_before_is_empty() -> None:
+    """Given an EMPTY pre-reboot reading (the sysctl read itself failed)
+    When _assert_boottime_advanced runs
+    Then it raises AssertionError naming the BEFORE side as the empty one — never silently
+         treats a failed read as "changed".
+    """
+    with pytest.raises(AssertionError) as exc_info:
+        _assert_boottime_advanced("", _AFTER)
+    message = str(exc_info.value)
+    assert "BEFORE" in message, f"expected the message to name the empty BEFORE side, got: {message!r}"
+
+
+def test_assert_boottime_advanced_raises_when_after_is_empty() -> None:
+    """Given an EMPTY post-reboot reading (the sysctl read itself failed)
+    When _assert_boottime_advanced runs
+    Then it raises AssertionError naming the AFTER side as the empty one.
+    """
+    with pytest.raises(AssertionError) as exc_info:
+        _assert_boottime_advanced(_BEFORE, "")
+    message = str(exc_info.value)
+    assert "AFTER" in message, f"expected the message to name the empty AFTER side, got: {message!r}"
+
+
+def test_assert_boottime_advanced_strips_whitespace_before_comparing() -> None:
+    """Given the same value but with SSH-transport-typical trailing newline/whitespace noise on
+         one side
+    When _assert_boottime_advanced runs
+    Then it still detects the values as unchanged (whitespace alone must not read as "advanced").
+    """
+    with pytest.raises(AssertionError):
+        _assert_boottime_advanced(_BEFORE, f"{_BEFORE}\n")


### PR DESCRIPTION
Part of #738 (findings F4 + F6; ledger in #729 — `#602 / medium` and `#608 / low`). Grouped: both are smoke-suite integrity fixes validated by one live dispatch.

**F4 — `reboot_vm` no longer proved a reboot happened.** The removed `kern.boottime` poll was replaced by a blind 30 s settle; if shutdown outlasts the settle on a slow host, the readiness gate answers on the still-up pre-reboot instance and the reboot-persistence tests (#334 alias loss, tick-ledger) false-pass their target regression. Restored proof without restoring the poll: read `kern.boottime` once before `/sbin/reboot`, once after the full readiness gate, and require a change — a single extra guest round trip, zero readiness-budget cost. The settle stays (a deliberate shutdown wait — the documented #456 exception). Failure raises with expected-vs-actual boottime values. The comparison helper is pinned by off-VM unit tests (unchanged/changed/empty-read branches).

**F6 — the DNSBL-Control OFF test restored shared module state only on the happy path.** An assert failing mid-OFF-phase left `python_control` off for the two legacy tests that assert (not establish) the ON baseline — one regression reported as three with the root cause masked. The OFF phase is now wrapped in `try/finally` with the unconditional baseline restore (Control ON + reload + ini assert). Behaviour-preserving test infra (stays green across).

**Live validation (green-only per the maintainer's decision):** smoke dispatch on this branch with `-m "smoke or reboot or tick"` and a `-k` filter selecting exactly the reboot-persistence tests (standard + ramdisk legs), the tick-ledger reboot test, and the 5 DNSBL-Control tests — run link in the review audit comment once green.

Gates: full dev-side pytest (baseline env failures unchanged, +5 new unit tests), ruff check/format, mypy, smoke modules collect cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013baLunt412HLH6L49aF953

---
_Generated by [Claude Code](https://claude.ai/code/session_013baLunt412HLH6L49aF953)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reboot readiness checks to verify the system actually rebooted before continuing.
  * Added safer handling around DNSBL Control tests so settings are restored even if an assertion fails.

* **Tests**
  * Added coverage for reboot-detection checks, including empty values, unchanged values, and whitespace handling.
  * Increased the timeout for one reboot-related smoke test to allow enough time for settle and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->