### PR TITLE
tests: pin the Update-page live-log sticky auto-follow (Tier-B browser)

### DIFF
--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -41,18 +41,23 @@ module without it installed does not hard-error.
 
 from __future__ import annotations
 
+import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
+from .. import helpers
 from .conftest import mask_page_identity
-from .test_render_smoke import _seed_vm_file, software_panel_forced
+from .test_render_smoke import _PFB_RUNLOG, _seed_vm_file, software_panel_forced
 
 sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
 expect = sync_api.expect
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from playwright.sync_api import Page
 
     from ..conftest import SmokeVM
@@ -432,3 +437,146 @@ def test_onload_survives_hash_with_no_matching_element(
     # Same marker Tier A (test_render_smoke.py PAGE_TABLE) asserts for this page --
     # proves a real authenticated render, not a blank/errored page.
     assert "IP Configuration" in page.content(), "IP page did not render its 'IP Configuration' section after onload"
+
+
+# The real dispatch's pidfile (pfblockerng_update.php pfb_runnow()/pfb_runnow_forcecheck()):
+# `isvalidpid()` on this path is exactly what pfb_log_tail_payload() polls to decide `done`.
+_PFB_RUNNOW_PIDFILE = "/var/run/pfb_runnow.pid"
+
+
+@contextmanager
+def _dummy_pfb_task_running(vm: SmokeVM) -> Iterator[None]:
+    """Simulate an in-flight pfBlockerNG run so the live-log poller keeps polling.
+
+    Starts a ``daemon -p <pidfile> sleep 300`` survivor -- the same daemon(8)+pidfile contract
+    the real dispatch uses -- so ``isvalidpid('/var/run/pfb_runnow.pid')`` reports TRUE and
+    ``pfb_log_tail_payload()``'s ``done`` stays FALSE for as long as this context is open. The
+    run log is truncated (not deleted -- the poller reads it, and the file always exists after
+    install) both before starting and in ``finally``, so a prior aborted run's leftovers can
+    never leak into this test's overflow/marker assertions (self-encapsulated -- CLAUDE.md).
+    """
+
+    def _teardown() -> None:
+        vm.ssh("pkill", "-F", _PFB_RUNNOW_PIDFILE)  # tolerated: no dummy running yet/anymore
+        vm.ssh("/bin/rm", "-f", _PFB_RUNNOW_PIDFILE)
+        vm.ssh(f": > {_PFB_RUNLOG}")
+
+    _teardown()  # clean slate first, in case a previous run of this test aborted mid-scenario
+    # -f detaches the child's std fds to /dev/null: without it the daemonized sleep inherits the
+    # ssh capture pipe and subprocess.run blocks on EOF until its 60s timeout (the CLAUDE.md
+    # "external process waits" gotcha -- the pipe outlives the ssh command).
+    start = vm.ssh("/usr/sbin/daemon", "-f", "-p", _PFB_RUNNOW_PIDFILE, "/bin/sleep", "300")
+    assert start.returncode == 0, f"failed to start the dummy pfb-task daemon: {start.stderr!r}"
+    try:
+        yield
+    finally:
+        _teardown()
+
+
+def _scroll_metrics(page: Page) -> dict[str, float]:
+    """Read scrollTop/scrollHeight/clientHeight off the ``pfb_output`` textarea."""
+    return page.eval_on_selector(
+        'textarea[name="pfb_output"]',
+        "el => ({scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight})",
+    )
+
+
+def _is_pinned(metrics: dict[str, float]) -> bool:
+    """Mirror the poller's own bottom test (pfblockerng_update.php:590): within 16px of bottom."""
+    return (metrics["scrollHeight"] - metrics["scrollTop"] - metrics["clientHeight"]) <= 16
+
+
+def _wait_for_marker(page: Page, marker: str) -> None:
+    """Block until *marker* has arrived in the ``pfb_output`` textarea value.
+
+    Bounded ``wait_for_function`` (raises loudly on timeout) -- never a fixed sleep (#456). The
+    poller's cadence is 1s, so 15s comfortably outlasts a few ticks without masking a real hang.
+    """
+    page.wait_for_function(
+        "needle => document.forms[0].pfb_output.value.includes(needle)",
+        arg=marker,
+        timeout=15_000,
+    )
+
+
+@pytest.mark.ui_browser
+def test_update_livelog_sticky_follow_scroll(
+    smoke_vm: SmokeVM,
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """The live-log viewer sticky-follows the tail, but only while parked at the bottom (#678).
+
+    The auto-follow logic moved out of the unit-tested ``pfb_term_write_js()`` into the inline
+    poller JS in PR #674 (pfblockerng_update.php:590-592); the old unit tests were deleted with
+    it, leaving the contract unguarded. This pins it end-to-end against the real poll loop.
+
+    Scenario:
+      Given a dummy pfBlockerNG task is "running" (daemon(8)+pidfile, same contract as the real
+            dispatch) and its run log is seeded past the textarea's capacity,
+      When the Update page's View button wires the live-log poller and the seed arrives,
+      Then the view starts pinned at the bottom (overflow precondition asserted first, else the
+           scroll assertions below would be vacuous);
+
+      When further lines arrive while still pinned at the bottom (batch A),
+      Then it stays pinned -- sticky auto-follow;
+
+      When the user scrolls up to read (to the top) and more lines arrive (batch B),
+      Then the view does NOT get yanked back down -- follow is paused while reading;
+
+      When the user scrolls back down to the bottom and more lines arrive (batch C),
+      Then auto-follow resumes -- scrolling to the bottom re-arms the sticky behaviour.
+    """
+    page = browser_page
+    run_id = uuid.uuid4().hex[:8]
+    marker_a = f"pfb-678-{run_id}-a"
+    marker_b = f"pfb-678-{run_id}-b"
+    marker_c = f"pfb-678-{run_id}-c"
+    seed_last = f"pfb-678-{run_id}-seed-0150"
+    seed = "".join(f"pfb-678-{run_id}-seed-{i:04d} {'x' * 80}\n" for i in range(1, 151))
+
+    # Guard: don't collide with a real pfBlockerNG task using the same pidfile/run log.
+    helpers.wait_no_active_pfb_task(smoke_vm)
+
+    with _dummy_pfb_task_running(smoke_vm):
+        _seed_vm_file(smoke_vm, _PFB_RUNLOG, seed)
+
+        _open(page, webui, UPDATE_PAGE)
+        page.locator('button[name="log_view"], #log_view').first.click()
+        page.wait_for_load_state("load")  # View submits/reloads the page with the poller wired
+        _wait_for_marker(page, seed_last)
+
+        # Given: the seed overflows the box AND starts pinned at the bottom.
+        metrics = _scroll_metrics(page)
+        assert metrics["scrollHeight"] > metrics["clientHeight"], (
+            f"seed must overflow the textarea for the scroll assertions to mean anything, got {metrics}"
+        )
+        assert _is_pinned(metrics), f"expected pinned at the bottom right after the seed loaded, got {metrics}"
+
+        # Phase 1 -- pinned follow: new lines arrive while at the bottom -> stays pinned.
+        _seed_vm_file(smoke_vm, _PFB_RUNLOG, f"{marker_a}\n")
+        _wait_for_marker(page, marker_a)
+        metrics = _scroll_metrics(page)
+        assert _is_pinned(metrics), f"expected still pinned at the bottom after batch A, got {metrics}"
+
+        # Phase 2 -- follow paused when scrolled up: new lines must NOT yank the view down.
+        page.eval_on_selector('textarea[name="pfb_output"]', "el => { el.scrollTop = 0; }")
+        metrics = _scroll_metrics(page)
+        assert metrics["scrollTop"] == 0, f"expected scrollTop 0 right after scrolling to the top, got {metrics}"
+
+        _seed_vm_file(smoke_vm, _PFB_RUNLOG, f"{marker_b}\n")
+        _wait_for_marker(page, marker_b)
+        metrics = _scroll_metrics(page)
+        assert metrics["scrollTop"] == 0, (
+            f"batch B must NOT yank the scrolled-up-to-read view back to the bottom, got {metrics}"
+        )
+
+        # Phase 3 -- follow resumes at the bottom: scrolling back down re-arms auto-follow.
+        page.eval_on_selector('textarea[name="pfb_output"]', "el => { el.scrollTop = el.scrollHeight; }")
+        metrics = _scroll_metrics(page)
+        assert _is_pinned(metrics), f"expected pinned immediately after scrolling back to the bottom, got {metrics}"
+
+        _seed_vm_file(smoke_vm, _PFB_RUNLOG, f"{marker_c}\n")
+        _wait_for_marker(page, marker_c)
+        metrics = _scroll_metrics(page)
+        assert _is_pinned(metrics), f"expected still pinned at the bottom after batch C, got {metrics}"

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -15,7 +15,12 @@ handler is taken from the pages' own inline ``events.push`` scripts:
   php:286-308) and ``Force`` mode (``#pfb_force_none``/``#pfb_force_parse``/
   ``#pfb_force_download``/``#pfb_force_both``, php:316-323). Each group is a native
   radio set (shared ``name``), so selecting one unchecks its siblings -- there is no
-  custom show/hide JS in this revamp (the page's only script is layout/scroll).
+  custom show/hide JS in this revamp (the page's other scripts are layout/scroll and
+  the live-log poller, covered below).
+* Update page live-log poller (``pfblockerng_update.php`` php:564-610, issue #678):
+  the AJAX tail's sticky auto-follow (measure before append, re-pin only when already
+  at the bottom, php:590-592), driven end-to-end against a controlled stream -- a
+  daemon(8)+pidfile dummy run plus incremental run-log seeding over ssh.
 * Sync page (``pfblockerng_sync.php``): the ``XMLRPC Replication Targets`` section
   is a pfSense ``.repeatable`` rowhelper (php:236) with an ``#addrow`` Add button
   (php:303) and a per-row ``Delete`` button (php:292-297). Each row carries exactly
@@ -50,7 +55,7 @@ import pytest
 
 from .. import helpers
 from .conftest import mask_page_identity
-from .test_render_smoke import _PFB_RUNLOG, _seed_vm_file, software_panel_forced
+from .test_render_smoke import _seed_vm_file, software_panel_forced
 
 sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
 expect = sync_api.expect
@@ -459,7 +464,7 @@ def _dummy_pfb_task_running(vm: SmokeVM) -> Iterator[None]:
     def _teardown() -> None:
         vm.ssh("pkill", "-F", _PFB_RUNNOW_PIDFILE)  # tolerated: no dummy running yet/anymore
         vm.ssh("/bin/rm", "-f", _PFB_RUNNOW_PIDFILE)
-        vm.ssh(f": > {_PFB_RUNLOG}")
+        vm.ssh(f": > {helpers.PFB_RUNLOG}")
 
     _teardown()  # clean slate first, in case a previous run of this test aborted mid-scenario
     # -f detaches the child's std fds to /dev/null: without it the daemonized sleep inherits the
@@ -491,12 +496,22 @@ def _wait_for_marker(page: Page, marker: str) -> None:
 
     Bounded ``wait_for_function`` (raises loudly on timeout) -- never a fixed sleep (#456). The
     poller's cadence is 1s, so 15s comfortably outlasts a few ticks without masking a real hang.
+    On timeout, re-raises with the expected marker next to the textarea's actual tail (CLAUDE.md
+    "print expected vs actual") -- distinguishing "seed never landed" from "poller never appended".
     """
-    page.wait_for_function(
-        "needle => document.forms[0].pfb_output.value.includes(needle)",
-        arg=marker,
-        timeout=15_000,
-    )
+    try:
+        page.wait_for_function(
+            "needle => document.forms[0].pfb_output.value.includes(needle)",
+            arg=marker,
+            timeout=15_000,
+        )
+    except sync_api.TimeoutError as exc:
+        actual = page.eval_on_selector('textarea[name="pfb_output"]', "el => el.value.slice(-600)")
+        raise AssertionError(
+            f"marker never arrived in pfb_output within 15s\n"
+            f"  expected to contain: {marker!r}\n"
+            f"  actual (last 600 chars): {actual!r}"
+        ) from exc
 
 
 @pytest.mark.ui_browser
@@ -539,22 +554,27 @@ def test_update_livelog_sticky_follow_scroll(
     helpers.wait_no_active_pfb_task(smoke_vm)
 
     with _dummy_pfb_task_running(smoke_vm):
-        _seed_vm_file(smoke_vm, _PFB_RUNLOG, seed)
+        # Known (narrow) flake vector: the tick cron stays installed, and a tick whose feed job
+        # comes due mid-test calls pfb_runlog_begin() -> truncates this run log, vanishing the
+        # seeded markers (the marker wait then reports expected-vs-actual for the diagnosis).
+        _seed_vm_file(smoke_vm, helpers.PFB_RUNLOG, seed)
 
         _open(page, webui, UPDATE_PAGE)
         page.locator('button[name="log_view"], #log_view').first.click()
         page.wait_for_load_state("load")  # View submits/reloads the page with the poller wired
         _wait_for_marker(page, seed_last)
 
-        # Given: the seed overflows the box AND starts pinned at the bottom.
+        # Given: the seed overflows the box AND starts pinned at the bottom. Overflow must exceed
+        # the poller's 16px at-bottom slack, else scrollTop=0 would still read as "at bottom" and
+        # phase 2 could fail against a correct poller.
         metrics = _scroll_metrics(page)
-        assert metrics["scrollHeight"] > metrics["clientHeight"], (
-            f"seed must overflow the textarea for the scroll assertions to mean anything, got {metrics}"
+        assert metrics["scrollHeight"] - metrics["clientHeight"] > 16, (
+            f"seed must overflow the textarea past the 16px pin slack, got {metrics}"
         )
         assert _is_pinned(metrics), f"expected pinned at the bottom right after the seed loaded, got {metrics}"
 
         # Phase 1 -- pinned follow: new lines arrive while at the bottom -> stays pinned.
-        _seed_vm_file(smoke_vm, _PFB_RUNLOG, f"{marker_a}\n")
+        _seed_vm_file(smoke_vm, helpers.PFB_RUNLOG, f"{marker_a}\n")
         _wait_for_marker(page, marker_a)
         metrics = _scroll_metrics(page)
         assert _is_pinned(metrics), f"expected still pinned at the bottom after batch A, got {metrics}"
@@ -564,7 +584,7 @@ def test_update_livelog_sticky_follow_scroll(
         metrics = _scroll_metrics(page)
         assert metrics["scrollTop"] == 0, f"expected scrollTop 0 right after scrolling to the top, got {metrics}"
 
-        _seed_vm_file(smoke_vm, _PFB_RUNLOG, f"{marker_b}\n")
+        _seed_vm_file(smoke_vm, helpers.PFB_RUNLOG, f"{marker_b}\n")
         _wait_for_marker(page, marker_b)
         metrics = _scroll_metrics(page)
         assert metrics["scrollTop"] == 0, (
@@ -576,7 +596,7 @@ def test_update_livelog_sticky_follow_scroll(
         metrics = _scroll_metrics(page)
         assert _is_pinned(metrics), f"expected pinned immediately after scrolling back to the bottom, got {metrics}"
 
-        _seed_vm_file(smoke_vm, _PFB_RUNLOG, f"{marker_c}\n")
+        _seed_vm_file(smoke_vm, helpers.PFB_RUNLOG, f"{marker_c}\n")
         _wait_for_marker(page, marker_c)
         metrics = _scroll_metrics(page)
         assert _is_pinned(metrics), f"expected still pinned at the bottom after batch C, got {metrics}"


### PR DESCRIPTION
Fixes #678.

## What

Adds one Tier-B browser test (`ui_browser`) pinning the Update-page live-log viewer's **sticky auto-follow** scroll contract — the logic that moved from the unit-tested `pfb_term_write_js()` into the inline poller JS in #674 (`pfblockerng_update.php:590-592`), losing its coverage. The Software page needs no counterpart: its own AJAX tail was later removed when the page became a Package-Manager shortcut.

## How

`test_update_livelog_sticky_follow_scroll` drives a controlled live stream on the smoke VM:

- A dummy "in-flight run" via `daemon -f -p /var/run/pfb_runnow.pid sleep 300` — the same daemon(8)+pidfile contract the real dispatch uses, so `pfb_log_tail_payload()`'s `done` stays FALSE and the poller keeps ticking. (`-f` is load-bearing: without it the daemonized child inherits the ssh capture pipe and `subprocess.run` blocks until its 60s timeout — the documented external-process-waits gotcha.)
- The run log is seeded incrementally over ssh (`tee -a`) across three phases against one overflowed textarea:
  1. **pinned follow** — new lines arrive at the bottom → view stays pinned;
  2. **paused** — scrolled up to read, new lines arrive → view is NOT yanked down;
  3. **resumed** — scrolled back to the bottom, new lines arrive → pinned again.
- Guarded by `wait_no_active_pfb_task`; setup/teardown is idempotent and runs in `finally` (kill dummy, remove pidfile, truncate run log). All waits are bounded `wait_for_function` calls (no fixed sleeps); every assertion prints the actual scroll metrics.

## Proof (live smoke VM, local lease)

- **Green** on this branch: `1 passed`.
- **Red proof A** — `atBottom` sabotaged to always-TRUE: fails exactly on phase 2 (`batch B must NOT yank the scrolled-up-to-read view back to the bottom, got {'scrollTop': 2109, …}`).
- **Red proof B** — `atBottom` sabotaged to always-FALSE: fails exactly on the pinned precondition (`expected pinned at the bottom right after the seed loaded, got {'scrollTop': 0, …}`).

Each sabotage kills a distinct branch of the contract, so none of the three phases is coverage theater.

Ruff / mypy / full unit suite (2057 passed) green; the test is `ui_browser`-marked (dispatch/schedule only, not a PR gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVWLiFeaGYpg178rFMeo7P
