### PR TITLE
Fix the LOW test-quality / spec-fidelity audit backlog (#723)

### DIFF
--- a/.ADRs/ADR_08_Homoglyph_Protection/ADR.md
+++ b/.ADRs/ADR_08_Homoglyph_Protection/ADR.md
@@ -238,7 +238,10 @@ rework).
   before/after toggle transitions; whitelist-wins; decode-safe; non-IDN pays nothing).
 
 **FP/TP measurement (`python tests/fixtures/adr08_corpus/measure_fp_tp.py`, on-branch):
-GATE = GO.**
+GATE = GO.** *(Historical gate model, #723: the script is the Phase-1 3-tier/dict-lookup
+snapshot — the shipped analyzer adds the FLAGGED tier and uses `unicodedata.name()`, so the
+cost figure below measured the simplified model; production coverage lives in
+`tests/test_adr08_analyzer.py`.)*
 
 | metric | measured (on-branch) | kill-threshold | result |
 | --- | --- | --- | --- |

--- a/benchmarks/spike_adr07_regex.py
+++ b/benchmarks/spike_adr07_regex.py
@@ -146,11 +146,11 @@ def categorise(line: str) -> str:
 #   (^|\.)D$          -> wildcard zone
 #   ^D$               -> exact data
 #   ^(www\.)?D$       -> exact data (+www) ... (kept simple: treat as exact D)
-# where D is a domain literal: labels of [a-z0-9-] joined by an ESCAPED dot (\.),
+# where D is a domain literal: labels of [a-z0-9_-] joined by an ESCAPED dot (\.),
 # no other regex metacharacter. Anything with a char-class, quantifier on a label,
 # alternation in the body, or an unescaped/floating dot is IRREDUCIBLE.
 
-_DOMAIN_LITERAL = re.compile(r"^[a-z0-9-]+(?:\\\.[a-z0-9-]+)+$")
+_DOMAIN_LITERAL = re.compile(r"^[a-z0-9_-]+(?:\\\.[a-z0-9_-]+)+$")  # underscore per #723
 
 _WILDCARD_PREFIXES = (r"^(.+\.)?", r"(^|\.)", r"^(?:.+\.)?")
 _EXACT_PREFIXES = (r"^",)

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2111,10 +2111,12 @@ def get_o_type(qstate: module_qstate | None, rep: reply_info | None) -> str:
 
 
 def get_rep_ttl(rep: reply_info | None) -> str:
-    ttl = ""
-    if rep and rep.ttl:
-        ttl = rep.ttl
-    return str(is_unknown(ttl)).replace("Unknown", "Unk")
+    # Presence, not truthiness: TTL 0 is a valid value (RFC 2181 s8 -- deliverable,
+    # non-cacheable), only a missing reply/TTL is unknown. Bypasses is_unknown(),
+    # whose falsy check would swallow 0 (#723).
+    if rep and rep.ttl is not None:
+        return str(rep.ttl)
+    return "Unk"
 
 
 def get_tld(qstate: module_qstate) -> str:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4015,7 +4015,7 @@ def classify(domain: str, tlds: dict[str, dict[str, str]], exclusion: set[str]) 
 # reduce_pattern). A reducible ``/re/`` decides IDENTICALLY to a domain/wildcard
 # rule, so it folds to a domain Rule at zero per-query cost. ``D`` is a domain
 # literal: labels of [a-z0-9-] joined by ESCAPED dots (``\.``), no other metachar.
-_DNSBL_RX_DOMAIN_LITERAL = re.compile(r"^[a-z0-9-]+(?:\\\.[a-z0-9-]+)+$")
+_DNSBL_RX_DOMAIN_LITERAL = re.compile(r"^[a-z0-9_-]+(?:\\\.[a-z0-9_-]+)+$")  # underscore per #723
 # Prefixes that mean "domain + all subdomains" (-> wildcard zone after fold):
 _DNSBL_RX_WILDCARD_PREFIXES = (r"^(.+\.)?", r"(^|\.)", r"^(?:.+\.)?")
 # Prefix that means "exact domain only" (-> exact data after fold):

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3365,9 +3365,12 @@ RULE_TARGET_REGEX = "regex"
 RULE_PROV_USER = "user"
 RULE_PROV_FEED = "feed"
 
-# Lower-cased label alphabet for the domain-shape gate (mirrors PFB_FILTER_DOMAIN,
-# pfblockerng.inc:7995-8016: labels of [a-z0-9-], not edge-hyphenated, with a dot).
-_DNSBL_LABEL_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-")
+# Lower-cased label alphabet for the domain-shape gate (parity with PFB_FILTER_DOMAIN,
+# pfblockerng.inc:1138-1150, whose regex allows [a-zA-Z0-9_.-]). Underscore is deliberate:
+# DNS labels carry no protocol charset (RFC 2181 s11), underscored names are standardized
+# practice (RFC 8552) and appear on real blocklists -- this gates BLOCKLIST names matched
+# against QNAMEs, not hostnames, so strict LDH would be a coverage hole (#723).
+_DNSBL_LABEL_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-_")
 
 
 @dataclass(frozen=True)
@@ -3918,7 +3921,7 @@ def parse(format_hint: str, line: str) -> ParsedEntry | None:
 
 
 def normalise(value: str) -> str | None:
-    """Lower-case + PFB_FILTER_DOMAIN domain-shape gate (inc:7995-8016).
+    """Lower-case + PFB_FILTER_DOMAIN domain-shape gate (inc:1138-1150).
 
     Returns the validated, lower-cased domain or ``None`` when the token is not a
     valid domain (which is how stray non-domain entries -- including any IP that

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5499,13 +5499,17 @@ function pfb_ss_resolve_target($target) {
 
 	$target_esc = escapeshellarg($filtered);
 	$extdns_esc = escapeshellarg("@{$pfb['extdns']}");
+	// Injectable resolver binary (#723): tests stub it so a unit run never emits real
+	// DNS traffic (a box with a loopback resolver made the real exec succeed and the
+	// off-appliance test fail). Production default unchanged.
+	$drill_esc = escapeshellarg($pfb['drill'] ?? '/usr/bin/drill');
 
 	$out4 = array();
-	exec("/usr/bin/drill A {$target_esc} {$extdns_esc} | /usr/bin/awk '/[ \\t]IN[ \\t]+A[ \\t]/ {print \$5; exit}'", $out4);
+	exec("{$drill_esc} A {$target_esc} {$extdns_esc} | /usr/bin/awk '/[ \\t]IN[ \\t]+A[ \\t]/ {print \$5; exit}'", $out4);
 	$v4 = filter_var(trim($out4[0] ?? ''), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ?: '';
 
 	$out6 = array();
-	exec("/usr/bin/drill AAAA {$target_esc} {$extdns_esc} | /usr/bin/awk '/[ \\t]IN[ \\t]+AAAA[ \\t]/ {print \$5; exit}'", $out6);
+	exec("{$drill_esc} AAAA {$target_esc} {$extdns_esc} | /usr/bin/awk '/[ \\t]IN[ \\t]+AAAA[ \\t]/ {print \$5; exit}'", $out6);
 	$v6 = filter_var(trim($out6[0] ?? ''), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ?: '';
 
 	return array($v4, $v6);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4312,6 +4312,10 @@ function pfb_member_file_is_placeholder_only($path, $placeholder) {
 // floods carry table/op attribution in the log.
 function pfb_pfctl_error_message(string $table, string $op, int $rc, string $stderr): string {
 	$msg = trim(str_replace(["\r\n", "\r", "\n"], ' ', $stderr));
+	if ($msg === '') {
+		// No stderr: end at the rc -- never a dangling ": " (#723).
+		return "[pfctl] op={$op} table={$table} failed (rc={$rc})";
+	}
 	return "[pfctl] op={$op} table={$table} failed (rc={$rc}): {$msg}";
 }
 

--- a/stubs/python/unboundmodule.py
+++ b/stubs/python/unboundmodule.py
@@ -111,16 +111,22 @@ RCODE_NOERROR = 0  # No error; query answered successfully
 RCODE_NXDOMAIN = 3  # Non-existent domain; name does not exist
 
 # ---------------------------------------------------------------------------
-# Module events — passed as the ``event`` argument to operate()
+# Module events — passed as the ``event`` argument to operate().
+# Values are the C enum positions of util/module.h `enum module_ev` (new 0,
+# pass 1, reply 2, noreply 3, capsfail 4, moddone 5, error 6), which pythonmod
+# exposes via SWIG — the old stub's MODDONE=3 was really module_event_noreply.
 # ---------------------------------------------------------------------------
 MODULE_EVENT_NEW = 0  # New query arrived; first module to handle it
 MODULE_EVENT_PASS = 1  # Query passed from a previous module for further processing
-MODULE_EVENT_MODDONE = 3  # Downstream module finished; resume this module
+MODULE_EVENT_MODDONE = 5  # Downstream module finished; resume this module
 
 # ---------------------------------------------------------------------------
-# Module external states — set on qstate.ext_state[id] inside operate()
+# Module external states — set on qstate.ext_state[id] inside operate().
+# Values are the C enum positions of util/module.h `enum module_ext_state`
+# (initial 0, wait_reply 1, wait_module 2, restart_next 3, wait_subquery 4,
+# error 5, finished 6) — the old stub's FINISHED=4 collided with wait_subquery.
 # ---------------------------------------------------------------------------
-MODULE_FINISHED = 4  # Module completed successfully; pass to next module
+MODULE_FINISHED = 6  # Module completed successfully; pass to next module
 MODULE_WAIT_MODULE = 2  # Module is waiting for another module to finish
 MODULE_WAIT_SUBQUERY = 4  # Module is waiting for a sub-query it attached to finish
 MODULE_RESTART_NEXT = 3  # Restart the module chain at the next module (re-run iterator)

--- a/tests/fixtures/adr07_corpus/abp_sample.txt
+++ b/tests/fixtures/adr07_corpus/abp_sample.txt
@@ -71,3 +71,5 @@ example.org#?#div:has(> .ad)
 ||frame.example^$subdocument
 ||csp.example^$csp=script-src
 ||domspecific.example^$domain=foo.com
+! underscore label (#723): DNS-legal, accepted by production and the oracle alike
+||_dmarc.underscore-corpus.com^

--- a/tests/fixtures/adr07_corpus/regex_reducible.txt
+++ b/tests/fixtures/adr07_corpus/regex_reducible.txt
@@ -29,3 +29,5 @@
 @@/^(.+\.)?cdn\.example\.com$/
 @@/^login\.example\.org$/
 @@/(^|\.)static\.example\.net$/
+! underscore literal (#723)
+/^_tracker\.underscore-corpus\.com$/

--- a/tests/fixtures/adr08_corpus/measure_fp_tp.py
+++ b/tests/fixtures/adr08_corpus/measure_fp_tp.py
@@ -16,6 +16,15 @@ replace this embedded map with the full range tables; here it only needs to
 reproduce the resolved set for the corpus labels so the numbers are real.
 
 Run:  python tests/fixtures/adr08_corpus/measure_fp_tp.py
+
+HISTORICAL MODEL (#723): this instrument is the Phase-1 GO-gate snapshot and
+deliberately does NOT track the shipped analyzer. The production TR39 analyzer
+(pfb_unbound.py) has a FLAGGED tier this script lacks (3 tiers here vs 4
+shipped) and derives scripts via unicodedata.name(), while this script times
+its own scoped-dict lookup -- so the ~0.70us cost figure and the tier model
+cited by ADR-08 describe THIS simplified model, not production. Production
+FP/TP behaviour is re-proven by tests/test_adr08_analyzer.py; do not re-run
+this script expecting production numbers.
 """
 
 from __future__ import annotations

--- a/tests/php/AbpExtractIpTest.php
+++ b/tests/php/AbpExtractIpTest.php
@@ -17,6 +17,11 @@ final class AbpExtractIpTest extends TestCase
 	public static function provider(): array
 	{
 		return [
+			// Deliberate DNS/pf coarsening (#723): ABP '||' WITHOUT a trailing '^' is
+			// prefix-matching in ABP semantics (also matches 192.0.2.40), and
+			// $third-party is a page-context scope — neither is expressible in a pf
+			// IP table, so the extractor canonises both to the exact IP and drops the
+			// option. These rows PIN that coarsening as intended behaviour.
 			'abp anchor v4'            => ['||192.0.2.4^', '192.0.2.4'],
 			'abp anchor v4 + options'  => ['||192.0.2.4^$third-party', '192.0.2.4'],
 			'abp anchor v4 no caret'   => ['||192.0.2.4', '192.0.2.4'],

--- a/tests/php/AliasContentGateTest.php
+++ b/tests/php/AliasContentGateTest.php
@@ -524,10 +524,14 @@ final class AliasContentGateTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	/**
-	 * pfb_alias_set_different compares SETS (order-immune).
+	 * pfb_alias_set_different is order-immune on the MIRROR side only (#723).
 	 *
-	 * The last-applied mirror may have been written in a different order than the
-	 * newly-computed set. The comparison must be set-based (immune to order).
+	 * The last-applied mirror may have been written in any order — it is
+	 * re-canonicalised on read. The $new_set side is NOT re-canonicalised: the
+	 * documented contract (@param) requires the caller to pass a canonical
+	 * (sorted, unique) set, and the sole production caller does (it builds
+	 * $canonical_set via pfb_canonical_alias_set first). The companion test
+	 * below pins that sharp edge.
 	 */
 	public function testSetDifferentIsOrderImmune(): void
 	{
@@ -546,6 +550,29 @@ final class AliasContentGateTest extends TestCase
 			"mirror:  192.0.2.3, 192.0.2.1, 192.0.2.2\n" .
 			"new set: " . implode(', ', $newSet) . "\n" .
 			"changed: " . ($changed ? 'true' : 'false')
+		);
+	}
+
+	/**
+	 * The $new_set side is order-SENSITIVE by contract (#723): a non-canonical
+	 * (unsorted) $new_set with identical membership reports "different". This
+	 * pins the documented precondition — if canonicalisation is ever added
+	 * inside pfb_alias_set_different (or removed from the caller), this test
+	 * forces the contract and its callers to be revisited together.
+	 */
+	public function testSetDifferentRequiresCanonicalNewSet(): void
+	{
+		$path = $this->mirrorPath('pfB_OrderNew_v4');
+		$this->writeMirror('pfB_OrderNew_v4', "192.0.2.1\n192.0.2.2\n192.0.2.3\n");
+
+		// Same membership, NOT sorted — violates the @param contract on purpose.
+		$unsorted = ['192.0.2.3', '192.0.2.1', '192.0.2.2'];
+
+		$this->assertTrue(
+			pfb_alias_set_different($unsorted, $path),
+			"contract pin: an unsorted \$new_set must compare as different — the\n" .
+			"function does not re-canonicalise the caller side (callers must pass\n" .
+			"pfb_canonical_alias_set output)"
 		);
 	}
 

--- a/tests/php/DnsblV6RequiredTest.php
+++ b/tests/php/DnsblV6RequiredTest.php
@@ -59,14 +59,43 @@ final class DnsblV6RequiredTest extends TestCase
 		$this->assertNotSame('IPv6 VIP required: the DNS Resolver is listening on IPv6', $err2);
 	}
 
-	public function testConfiguredV6VipStillValidatedNormally(): void
+	// --- pfb_validate_vips: a SUPPLIED v6 VIP is genuinely validated (#723) ---
+	//
+	// The previous form of this test passed interface 'lo0', so the doubled
+	// get_configured_vip_interface ('opt-double') failed the interface check before the
+	// per-VIP branches ever ran, and its assertions (a tautological bool check plus an
+	// assertNotSame against a message string that no longer exists) could not fail on a
+	// regression. These three pin each reachable branch with its exact outcome.
+
+	public function testSuppliedV6VipOnWrongInterfaceFailsInterfaceCheck(): void
 	{
-		// A v6 VIP that IS supplied is still validated (existence / interface / overlap):
-		// the validator continues into the per-VIP checks (which exercise the pfSense
-		// doubles). The assertion of interest: the failure, if any, is never a v6-required
-		// message — v6 is optional, not mandatory.
+		// Interface mismatch ('lo0' vs the double's 'opt-double') fails FIRST, with the
+		// v6 interface message -- the branch the old test hit by accident, now intended.
 		[$ok, $err] = pfb_validate_vips('lo0', '', '_vip_test_v6');
-		$this->assertNotSame('IPv6 VIP required: the DNS Resolver is listening on IPv6', $err);
-		$this->assertTrue($ok === false || $ok === true);
+		$this->assertFalse($ok);
+		$this->assertSame('IPv6 VIP not found on interface lo0', $err);
+	}
+
+	public function testSuppliedV6VipUnknownToVipListFailsExistence(): void
+	{
+		// Interface matches ('opt-double'), so the validator reaches the per-VIP checks;
+		// with no VIP list seeded the id is unknown -> the existence branch fires.
+		[$ok, $err] = pfb_validate_vips('opt-double', '', '_vip_test_v6');
+		$this->assertFalse($ok);
+		$this->assertSame('invalid IPv6 VIP', $err);
+	}
+
+	public function testSuppliedKnownV6VipPassesValidation(): void
+	{
+		// Full happy path: the seeded VIP list makes the id known (existence passes) and
+		// the default where_is_ipaddr_configured double reports no overlap -> [TRUE, null].
+		$GLOBALS['pfb_test_vip_list'] = ['_vip_test_v6' => '2001:db8::10'];
+		try {
+			[$ok, $err] = pfb_validate_vips('opt-double', '', '_vip_test_v6');
+			$this->assertTrue($ok);
+			$this->assertNull($err);
+		} finally {
+			unset($GLOBALS['pfb_test_vip_list']);
+		}
 	}
 }

--- a/tests/php/IpAddrDoublesTest.php
+++ b/tests/php/IpAddrDoublesTest.php
@@ -40,11 +40,13 @@ final class IpAddrDoublesTest extends TestCase
 	public static function v4Provider(): array
 	{
 		return [
-			// Rejected on-box and off: ip2long()/inet_pton() accepts only the
-			// canonical dotted-quad on FreeBSD and glibc alike (see class
-			// docblock) — old and fixed doubles agree here; the pinned oracle
-			// is the real pfSense verdict.
-			'leading-zero octets rejected (inet_pton is canonical-only)' => ['192.000.002.005', false],
+			// Leading-zero octets are LIBC-DEPENDENT (#723): FreeBSD (the
+			// pfSense target) and glibc (CI) reject them at inet_pton(), but
+			// macOS accepts them — so the verdict cannot be pinned as a
+			// constant without failing on a Mac dev box. The invariant that
+			// matters is MECHANISM parity: the double must agree with this
+			// platform's ip2long(), whatever it says (asserted in
+			// testIsIpaddrv4MatchesLocalIp2long below).
 			'plain dotted-quad accepted'   => ['192.0.2.5', true],
 			'three-octet form rejected'    => ['1.2.3', false],
 			'out-of-range octet rejected'  => ['256.1.1.1', false],
@@ -59,6 +61,15 @@ final class IpAddrDoublesTest extends TestCase
 	public function testIsIpaddrv4(mixed $input, bool $expected): void
 	{
 		$this->assertSame($expected, is_ipaddrv4($input));
+	}
+
+	public function testIsIpaddrv4MatchesLocalIp2long(): void
+	{
+		// Mechanism parity with real pfSense (bare ip2long check): whatever this
+		// platform's libc says about a leading-zero octet, the double says the same.
+		$expected = (ip2long('192.000.002.005') !== false);
+		$this->assertSame($expected, is_ipaddrv4('192.000.002.005'),
+			'expected: double verdict identical to local ip2long() for a leading-zero octet');
 	}
 
 	// --- is_ipaddrv6() --------------------------------------------------------

--- a/tests/php/IpAddrDoublesTest.php
+++ b/tests/php/IpAddrDoublesTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('is_ipaddrv6')]
 #[CoversFunction('is_ipaddr')]
 #[CoversFunction('is_linklocal')]
+#[CoversFunction('is_port')]
 final class IpAddrDoublesTest extends TestCase
 {
 	// --- is_ipaddrv4() --------------------------------------------------------
@@ -116,6 +117,35 @@ final class IpAddrDoublesTest extends TestCase
 	public function testIsLinklocal(string $input, int|bool $expected): void
 	{
 		$this->assertSame($expected, is_linklocal($input));
+	}
+
+	// --- is_port() (double aligned with upstream util.inc, #723) ---------------
+
+	public static function portProvider(): array
+	{
+		return [
+			'numeric low bound'        => ['1', true],
+			'numeric high bound'       => ['65535', true],
+			'zero rejected'            => ['0', false],
+			'above range rejected'     => ['65536', false],
+			'service name domain'      => ['domain', true],
+			'service name http'        => ['http', true],
+			'unknown name rejected'    => ['no-such-service-xyz', false],
+		];
+	}
+
+	#[DataProvider('portProvider')]
+	public function testIsPort(string $input, bool $expected): void
+	{
+		$this->assertSame($expected, is_port($input),
+			"is_port({$input}) must match upstream util.inc (digits 1..65535 OR getservbyname)");
+	}
+
+	public function testIsPortNameRejectedWhenValidateNameOff(): void
+	{
+		// The \$validate_name=false branch: service names are rejected, digits still pass.
+		$this->assertFalse(is_port('domain', false));
+		$this->assertTrue(is_port('53', false));
 	}
 
 	// --- is_ipaddr() (existing double, unchanged) ------------------------------

--- a/tests/php/PfctlTableOpTest.php
+++ b/tests/php/PfctlTableOpTest.php
@@ -125,21 +125,29 @@ final class PfctlTableOpTest extends TestCase
 	 *
 	 * Given: stderr is an empty string (pfctl exited non-zero with no output).
 	 * When:  pfb_pfctl_error_message() is called.
-	 * Then:  the returned message still contains table, op, rc, and is a
-	 *        non-empty string (does not degenerate to a bare colon).
+	 * Then:  the message ends at the rc — no trailing ": " artifact. (The header
+	 *        always claimed this; production emitted the dangling colon-space and
+	 *        the old assertions never checked it — #723.)
 	 */
 	public function testEmptyStderrProducesCleanMessage(): void
 	{
 		$msg = pfb_pfctl_error_message('pfB_Permit_v6', 'kill', 1, '');
 
-		$this->assertNotEmpty($msg,
-			'expected: non-empty message even with empty stderr');
-		$this->assertStringContainsString('pfB_Permit_v6', $msg,
-			"expected: table name present;\nactual: {$msg}");
-		$this->assertStringContainsString('kill', $msg,
-			"expected: op present;\nactual: {$msg}");
-		$this->assertStringContainsString('1', $msg,
-			"expected: rc present;\nactual: {$msg}");
+		$this->assertSame('[pfctl] op=kill table=pfB_Permit_v6 failed (rc=1)', $msg,
+			"expected: message ends at the rc with no trailing colon-space;\nactual: {$msg}");
+	}
+
+	/**
+	 * Scenario D counterpart — non-empty stderr keeps the ": <stderr>" suffix.
+	 */
+	public function testNonEmptyStderrKeepsSuffix(): void
+	{
+		$msg = pfb_pfctl_error_message('pfB_Permit_v6', 'kill', 1, 'pfctl: Table does not exist.');
+
+		$this->assertSame(
+			'[pfctl] op=kill table=pfB_Permit_v6 failed (rc=1): pfctl: Table does not exist.',
+			$msg,
+			"expected: stderr suffix preserved;\nactual: {$msg}");
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/SafeSearchCnameTest.php
+++ b/tests/php/SafeSearchCnameTest.php
@@ -271,4 +271,25 @@ final class SafeSearchCnameTest extends TestCase
 		$this->assertSame(['', ''], $result);
 		$this->assertStringNotContainsString('failed validation', $this->logContents());
 	}
+
+	public function test_resolve_target_uses_injected_resolver_binary(): void
+	{
+		// Seam proof (#723): a stub resolver that EMITS a drill-shaped answer must have
+		// its answer consumed -- red on any build where the exec still hard-codes
+		// /usr/bin/drill (the stub is then dead code and this returns ['','']), on every
+		// platform, with or without a real resolver present.
+		$stub = tempnam(sys_get_temp_dir(), 'pfb_drill_stub_');
+		file_put_contents($stub, "#!/bin/sh\n[ \"\$1\" = \"A\" ] && printf 'stub.example.com.\\t300\\tIN\\tA\\t192.0.2.99\\n'\nexit 0\n");
+		chmod($stub, 0755);
+		$GLOBALS['pfb']['drill'] = $stub;
+		try {
+			$result = pfb_ss_resolve_target('safe.duckduckgo.com');
+		} finally {
+			unset($GLOBALS['pfb']['drill']);
+			@unlink($stub);
+		}
+
+		$this->assertSame(['192.0.2.99', ''], $result,
+			'expected: the stubbed resolver binary answers the A lookup (proving the exec uses $pfb[drill])');
+	}
 }

--- a/tests/php/SafeSearchCnameTest.php
+++ b/tests/php/SafeSearchCnameTest.php
@@ -251,12 +251,22 @@ final class SafeSearchCnameTest extends TestCase
 	{
 		// The accept side of the same branch: a domain-valid target proceeds past
 		// the validation boundary to the resolution stage with no rejection logged.
-		// Off-appliance the resolver tool is absent / answers nothing on loopback,
-		// so resolution yields the empty pair — same contract as a failed lookup;
-		// the live resolution leg stays smoke territory.
+		// The resolver exec is STUBBED (#723): the old form ran a real
+		// `drill A safe.duckduckgo.com @127.0.0.1`, which succeeds on any box with
+		// a loopback resolver (failing the empty-pair assertion) and emits real DNS
+		// traffic from a unit test. The live resolution leg stays smoke territory.
 		$this->assertSame('', $this->logContents(), 'log must start empty');
 
-		$result = pfb_ss_resolve_target('safe.duckduckgo.com');
+		$stub = tempnam(sys_get_temp_dir(), 'pfb_drill_stub_');
+		file_put_contents($stub, "#!/bin/sh\nexit 0\n");
+		chmod($stub, 0755);
+		$GLOBALS['pfb']['drill'] = $stub;
+		try {
+			$result = pfb_ss_resolve_target('safe.duckduckgo.com');
+		} finally {
+			unset($GLOBALS['pfb']['drill']);
+			@unlink($stub);
+		}
 
 		$this->assertSame(['', ''], $result);
 		$this->assertStringNotContainsString('failed validation', $this->logContents());

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -146,16 +146,17 @@ if (!function_exists('is_hostname')) {
 }
 
 if (!function_exists('is_port')) {
-	// pfSense util.inc: a single TCP/UDP port — a pure-digit string in 1..65535
-	// (no ranges, no aliases). step3_submitphpaction() validates pfb_dnsport /
-	// pfb_dnsport_ssl through this; WizardVipAutoTest supplies valid ports so the
-	// port branch never masks the VIP-validation branch under test.
-	function is_port($port) {
-		if (!ctype_digit((string) $port)) {
-			return false;
+	// pfSense util.inc verbatim (#723): digits 1..65535, OR a service name resolvable
+	// via getservbyname() when \$validate_name (the default) — 'domain'/'http' are
+	// valid ports to real pfSense, so the double must not model them as rejected.
+	function is_port($port, $validate_name = true) {
+		if (ctype_digit(strval($port)) && ((intval($port) >= 1) && (intval($port) <= 65535))) {
+			return true;
 		}
-		$port = (int) $port;
-		return ($port >= 1 && $port <= 65535);
+		if ($validate_name && (getservbyname($port, "tcp") || getservbyname($port, "udp") || getservbyname($port, "sctp"))) {
+			return true;
+		}
+		return false;
 	}
 }
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4652,6 +4652,24 @@ def collect_localip(
     return pfb_local, pfb_localsub
 
 
+def ip_in(addr: str, pool: set[str] | list[str]) -> bool:
+    """By-VALUE membership for IP strings (#723): equal-but-differently-rendered
+    forms (:: == ::0) must count as present. Unparseable entries on either side
+    never match. Sibling of ip_in_localsub (the CIDR-side counterpart below).
+    """
+    try:
+        target = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    for cand in pool:
+        try:
+            if ipaddress.ip_address(cand) == target:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
 def ip_in_localsub(addr: str, pfb_localsub: list[str]) -> bool:
     """Return True iff ``addr`` falls inside any subnet in ``pfb_localsub``.
 

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -304,13 +304,15 @@ def _redir_match_report(vm: SmokeVM, iface: str, *, expected_present: bool, time
         actual = [f"<pfctl -sn failed: rc={result.returncode} {result.stderr.strip()}>"]
     else:
         actual = [ln.strip() for ln in result.stdout.splitlines() if "rdr" in ln and dev and dev in ln]
-    want = "PRESENT" if expected_present else "ABSENT"
+    want = "PRESENT (both protocols)" if expected_present else "ABSENT (no protocol)"
+    matched = _pfctl_sn_redir_protos(vm, iface, timeout=timeout)
     body = "\n".join(f"      {ln}" for ln in actual) if actual else "      (no rdr rules on this device)"
     return (
         f"  Expecting a pfBlockerNG DNS-redirect rdr rule to be {want} in the live nat ruleset:\n"
         f"    device      : {dev}  (config iface {iface!r})\n"
         f"    destination : ! (self)\n"
         f"    dest port   : domain (53)\n"
+        f"    protocols   : expected {{'tcp', 'udp'}} both rendered — matched {matched or '{}'}\n"
         f"  Actual rdr rules on {dev} (pfctl -sn):\n"
         f"{body}"
     )

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -238,8 +238,13 @@ def _real_iface(vm: SmokeVM, iface: str, *, timeout: float = 60.0) -> str:
     return h._php_read_scalar(vm, "", f"get_real_interface({h._php_str(iface)})", timeout=timeout).strip()
 
 
-def _pfctl_sn_has_redir(vm: SmokeVM, iface: str, *, timeout: float = 30.0) -> bool:
-    """True iff ``pfctl -sn`` shows a pfBlockerNG DNS-redirect rdr rule on ``iface`` for port 53.
+def _pfctl_sn_redir_protos(vm: SmokeVM, iface: str, *, timeout: float = 30.0) -> set[str]:
+    """The protocols ({"tcp","udp"}) with a loaded pfBlockerNG DNS-redirect rdr rule on ``iface``.
+
+    Returns the SET of matched protocols rather than a bare bool (#723): pf expands a
+    config-level ``tcp/udp`` rule into per-protocol rules, so a regression rendering only
+    one protocol must fail the positive gate (require both) while the teardown gate still
+    checks full absence (empty set).
 
     Matches the LOADED form, which differs from the config / rules.debug form twice over:
 
@@ -257,8 +262,9 @@ def _pfctl_sn_has_redir(vm: SmokeVM, iface: str, *, timeout: float = 30.0) -> bo
     """
     dev = _real_iface(vm, iface)
     result = vm.ssh(h.PFCTL, "-sn", timeout=timeout)
+    protos: set[str] = set()
     if result.returncode != 0:
-        return False
+        return protos
     for line in result.stdout.splitlines():
         # Match the redirect hallmark explicitly: an rdr `on <device>` whose destination is
         # the negated self (`to ! (self)`). The anchored ` on {dev} ` (not a bare substring)
@@ -267,8 +273,21 @@ def _pfctl_sn_has_redir(vm: SmokeVM, iface: str, *, timeout: float = 30.0) -> bo
         if "rdr" not in line or not dev or f" on {dev} " not in line or "to ! (self)" not in line:
             continue
         if "domain" in line or "port = 53" in line or "port 53" in line:
-            return True
-    return False
+            if " proto tcp " in line:
+                protos.add("tcp")
+            if " proto udp " in line:
+                protos.add("udp")
+    return protos
+
+
+def _pfctl_sn_has_redir(vm: SmokeVM, iface: str, *, timeout: float = 30.0) -> bool:
+    """Positive render gate: BOTH protocols of the tcp/udp redirect are loaded (#723)."""
+    return {"tcp", "udp"} <= _pfctl_sn_redir_protos(vm, iface, timeout=timeout)
+
+
+def _pfctl_sn_redir_absent(vm: SmokeVM, iface: str, *, timeout: float = 30.0) -> bool:
+    """Negative render gate: NO redirect rule of either protocol remains loaded."""
+    return not _pfctl_sn_redir_protos(vm, iface, timeout=timeout)
 
 
 def _redir_match_report(vm: SmokeVM, iface: str, *, expected_present: bool, timeout: float = 30.0) -> str:
@@ -536,7 +555,7 @@ def test_dns_redirect_enable_creates_nat_and_filter_rules(deployed_vm: SmokeVM, 
         assert _filter_redir_count(vm, _REDIR_DESCR_PFX) == 0, (
             "pfB_DNS_Redirect_* filter/rule entries present before enable — before-state not clean"
         )
-        assert not _pfctl_sn_has_redir(vm, iface), (
+        assert _pfctl_sn_redir_absent(vm, iface), (
             f"pfctl -sn shows an rdr rule on {iface} before enable — before-state not clean\n"
             + _redir_match_report(vm, iface, expected_present=False)
         )
@@ -685,7 +704,7 @@ def test_dns_redirect_disable_removes_nat_and_filter_rules(deployed_vm: SmokeVM,
         )
 
         # THEN — pfctl -sn must show no rdr rule for port 53 on the primary interface.
-        assert not _pfctl_sn_has_redir(vm, iface), (
+        assert _pfctl_sn_redir_absent(vm, iface), (
             f"pfctl -sn still shows an rdr rule on {iface} after disable\n"
             + _redir_match_report(vm, iface, expected_present=False)
         )
@@ -1084,7 +1103,7 @@ def test_dns_redirect_master_disable_removes_rules_despite_toggle_on(deployed_vm
         )
 
         # THEN — pfctl confirms no rdr rule.
-        assert not _pfctl_sn_has_redir(vm, iface), (
+        assert _pfctl_sn_redir_absent(vm, iface), (
             f"pfctl -sn still shows an rdr rule on {iface} after master-disable\n"
             + _redir_match_report(vm, iface, expected_present=False)
         )
@@ -1154,7 +1173,7 @@ def test_dns_redirect_dnsbl_disable_removes_rules_despite_toggle_on(deployed_vm:
         )
 
         # THEN — pfctl confirms no rdr rule.
-        assert not _pfctl_sn_has_redir(vm, iface), (
+        assert _pfctl_sn_redir_absent(vm, iface), (
             f"pfctl -sn still shows an rdr rule on {iface} after DNSBL-disable\n"
             + _redir_match_report(vm, iface, expected_present=False)
         )

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -214,12 +214,30 @@ def _is_block_853_line(line: str) -> bool:
     return "block" in line and ("853" in line or "domain-s" in line)
 
 
-def _pfctl_sr_has_block_853(vm: SmokeVM, *, timeout: float = 30.0) -> bool:
-    """True iff ``pfctl -sr`` output contains a block rule for port 853."""
+def _pfctl_sr_block_853_protos(vm: SmokeVM, *, timeout: float = 30.0) -> set[str]:
+    """The protocols ({"tcp","udp"}) with a loaded block rule for port 853 (#723).
+
+    pf expands the config-level ``tcp/udp`` block into per-protocol rules; returning the
+    set lets the positive gate require BOTH (a lost UDP-853/DoQ leg with TCP-853/DoT kept
+    must fail) while absence checks use the empty set.
+    """
     result = vm.ssh(h.PFCTL, "-sr", timeout=timeout)
+    protos: set[str] = set()
     if result.returncode != 0:
-        return False
-    return any(_is_block_853_line(line) for line in result.stdout.splitlines())
+        return protos
+    for line in result.stdout.splitlines():
+        if not _is_block_853_line(line):
+            continue
+        if " proto tcp " in line:
+            protos.add("tcp")
+        if " proto udp " in line:
+            protos.add("udp")
+    return protos
+
+
+def _pfctl_sr_has_block_853(vm: SmokeVM, *, timeout: float = 30.0) -> bool:
+    """Positive render gate: BOTH protocols of the 853 block are loaded (#723)."""
+    return {"tcp", "udp"} <= _pfctl_sr_block_853_protos(vm, timeout=timeout)
 
 
 def _pfctl_sr_block_853_has_self_exempt(vm: SmokeVM, *, timeout: float = 30.0) -> bool:
@@ -495,7 +513,7 @@ def test_dot_doq_block_rule_appears_on_enable(deployed_vm: SmokeVM, primary_ifac
         assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX) == 0, (
             "pfB_DoT_Block_* filter/rule entries present before enable — before-state not clean"
         )
-        assert not _pfctl_sr_has_block_853(vm), (
+        assert not _pfctl_sr_block_853_protos(vm), (
             "pfctl -sr shows a port-853 block rule before enable — before-state not clean\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -699,7 +717,7 @@ def test_dot_doq_block_rule_removed_on_disable(deployed_vm: SmokeVM, primary_ifa
         )
 
         # THEN — pfctl -sr must show no port-853 block rule.
-        assert not _pfctl_sr_has_block_853(vm), (
+        assert not _pfctl_sr_block_853_protos(vm), (
             "pfctl -sr still shows port-853 block rule after disable\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -1061,7 +1079,7 @@ def test_self_exempt_guard_in_pfctl_output(deployed_vm: SmokeVM, primary_iface: 
         h.reload(vm, "update", wait_unbound=False)
         h.apply_filter_sync(vm)
 
-        assert not _pfctl_sr_has_block_853(vm), (
+        assert not _pfctl_sr_block_853_protos(vm), (
             "pfctl -sr shows a port-853 block rule before enable — before-state not clean\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -1153,7 +1171,7 @@ def test_dot_block_master_disable_removes_rules_despite_toggle_on(deployed_vm: S
         )
 
         # THEN — pfctl confirms no port-853 block.
-        assert not _pfctl_sr_has_block_853(vm), (
+        assert not _pfctl_sr_block_853_protos(vm), (
             "pfctl -sr still shows a port-853 block rule after master-disable\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -1223,7 +1241,7 @@ def test_dot_block_dnsbl_disable_removes_rules_despite_toggle_on(deployed_vm: Sm
         )
 
         # THEN — pfctl confirms no port-853 block.
-        assert not _pfctl_sr_has_block_853(vm), (
+        assert not _pfctl_sr_block_853_protos(vm), (
             "pfctl -sr still shows a port-853 block rule after DNSBL-disable\n"
             + _dot_block_match_report(vm, expected_present=False)
         )

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -240,6 +240,11 @@ def _pfctl_sr_has_block_853(vm: SmokeVM, *, timeout: float = 30.0) -> bool:
     return {"tcp", "udp"} <= _pfctl_sr_block_853_protos(vm, timeout=timeout)
 
 
+def _pfctl_sr_block_853_absent(vm: SmokeVM, *, timeout: float = 30.0) -> bool:
+    """Negative render gate: NO 853 block rule of either protocol remains loaded."""
+    return not _pfctl_sr_block_853_protos(vm, timeout=timeout)
+
+
 def _pfctl_sr_block_853_has_self_exempt(vm: SmokeVM, *, timeout: float = 30.0) -> bool:
     """True iff the port-853 block rule in ``pfctl -sr`` carries a self-exempt guard.
 
@@ -515,7 +520,7 @@ def test_dot_doq_block_rule_appears_on_enable(deployed_vm: SmokeVM, primary_ifac
         assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX) == 0, (
             "pfB_DoT_Block_* filter/rule entries present before enable — before-state not clean"
         )
-        assert not _pfctl_sr_block_853_protos(vm), (
+        assert _pfctl_sr_block_853_absent(vm), (
             "pfctl -sr shows a port-853 block rule before enable — before-state not clean\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -719,7 +724,7 @@ def test_dot_doq_block_rule_removed_on_disable(deployed_vm: SmokeVM, primary_ifa
         )
 
         # THEN — pfctl -sr must show no port-853 block rule.
-        assert not _pfctl_sr_block_853_protos(vm), (
+        assert _pfctl_sr_block_853_absent(vm), (
             "pfctl -sr still shows port-853 block rule after disable\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -1081,7 +1086,7 @@ def test_self_exempt_guard_in_pfctl_output(deployed_vm: SmokeVM, primary_iface: 
         h.reload(vm, "update", wait_unbound=False)
         h.apply_filter_sync(vm)
 
-        assert not _pfctl_sr_block_853_protos(vm), (
+        assert _pfctl_sr_block_853_absent(vm), (
             "pfctl -sr shows a port-853 block rule before enable — before-state not clean\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -1173,7 +1178,7 @@ def test_dot_block_master_disable_removes_rules_despite_toggle_on(deployed_vm: S
         )
 
         # THEN — pfctl confirms no port-853 block.
-        assert not _pfctl_sr_block_853_protos(vm), (
+        assert _pfctl_sr_block_853_absent(vm), (
             "pfctl -sr still shows a port-853 block rule after master-disable\n"
             + _dot_block_match_report(vm, expected_present=False)
         )
@@ -1243,7 +1248,7 @@ def test_dot_block_dnsbl_disable_removes_rules_despite_toggle_on(deployed_vm: Sm
         )
 
         # THEN — pfctl confirms no port-853 block.
-        assert not _pfctl_sr_block_853_protos(vm), (
+        assert _pfctl_sr_block_853_absent(vm), (
             "pfctl -sr still shows a port-853 block rule after DNSBL-disable\n"
             + _dot_block_match_report(vm, expected_present=False)
         )

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -268,8 +268,10 @@ def _dot_block_match_report(vm: SmokeVM, *, expected_present: bool, timeout: flo
         actual = [f"<pfctl -sr failed: rc={result.returncode} {result.stderr.strip()}>"]
     else:
         actual = [ln.strip() for ln in result.stdout.splitlines() if _is_block_853_line(ln)]
-    want = "PRESENT" if expected_present else "ABSENT"
+    want = "PRESENT (both protocols)" if expected_present else "ABSENT (no protocol)"
+    matched = _pfctl_sr_block_853_protos(vm, timeout=timeout)
     body = "\n".join(f"      {ln}" for ln in actual) if actual else "      (no block rule for port 853 / domain-s)"
+    body = f"      protocols matched: {matched or '{}'} — positive gate needs {{'tcp', 'udp'}}\n" + body
     return (
         f"  Expecting a pfBlockerNG DoT/DoQ block rule to be {want} in the live filter ruleset:\n"
         f"    destination : ! (self)\n"

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -21,7 +21,7 @@ set actually changed.
 Phase 4 — forward-delta apply
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 For a changed table, pfBlockerNG applies ``pfctl -t <t> -T add / -T delete``
-for small-churn changes (churn ratio < ``PFB_DELTA_CHURN_THRESHOLD`` = 0.20)
+for small-churn changes (churn ratio < ``PFB_DELTA_CHURN_THRESHOLD`` = 0.05)
 and falls back to ``pfctl -T replace`` for large-churn or when
 ``pfb_alias_delta_mode`` is forced to ``'replace'``.  The key invariant in
 both cases: ``pfctl -t <t> -T show`` membership equals the canonical desired
@@ -54,7 +54,7 @@ WHAT STAYS MANUAL / OUT OF SCOPE HERE:
   traffic on real hardware; not reproducible in CI.  Owner: maintainer manual
   smoke (ADR-40 §7).
 
-* **Large-churn replace fallback (auto mode)** — crossing the 20% threshold
+* **Large-churn replace fallback (auto mode)** — crossing the 5% threshold
   requires synthesising a large alias table in the smoke harness, which would
   dominate test time.  The churn-ratio logic is unit-pinned in
   ``AliasDeltaApplyTest::testLargeChurnFallsBackToReplace``.

--- a/tests/smoke/test_smoke_ipv6_alerts.py
+++ b/tests/smoke/test_smoke_ipv6_alerts.py
@@ -33,12 +33,32 @@ fixtures skip cleanly when absent.
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from collections.abc import Iterator
 
 import pytest
 
 from . import helpers as h
+
+
+def _ip_in(addr: str, pool: set[str] | list[str]) -> bool:
+    """By-VALUE membership for IP strings (#723): the repo convention compares IPs
+    by value (:: == ::0), but pfb_local carries verbatim PHP-rendered strings — an
+    equal-but-differently-rendered form must still count as present."""
+    try:
+        target = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    for cand in pool:
+        try:
+            if ipaddress.ip_address(cand) == target:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
 from .conftest import SmokeVM
 
 pytestmark = pytest.mark.smoke
@@ -189,7 +209,7 @@ def test_collect_localip_recognises_ipv6_address_and_subnet(
         # ------------------------------------------------------------------
         # THEN: Local IPv6 is recognised.
         # ------------------------------------------------------------------
-        assert addr in after_local, (
+        assert _ip_in(addr, after_local), (
             f"THEN violated: {addr!r} NOT in pfb_local after set_interface_ipv6 — "
             f"fix for issue #361 not effective.  pfb_local={after_local!r}"
         )
@@ -217,7 +237,7 @@ def test_collect_localip_recognises_ipv6_address_and_subnet(
         assert lan_ipv4, (
             "AND violated: get_live_ipv4(lan) returned empty — the IPv6 pass may have broken IPv4 enumeration."
         )
-        assert lan_ipv4 in after_local, (
+        assert _ip_in(lan_ipv4, after_local), (
             f"AND violated: LAN IPv4 {lan_ipv4!r} NOT in pfb_local — "
             f"IPv4 enumeration broken after IPv6 change.  pfb_local={after_local!r}"
         )

--- a/tests/smoke/test_smoke_ipv6_alerts.py
+++ b/tests/smoke/test_smoke_ipv6_alerts.py
@@ -33,7 +33,6 @@ fixtures skip cleanly when absent.
 
 from __future__ import annotations
 
-import ipaddress
 import os
 from collections.abc import Iterator
 
@@ -41,24 +40,6 @@ import pytest
 
 from . import helpers as h
 from .conftest import SmokeVM
-
-
-def _ip_in(addr: str, pool: set[str] | list[str]) -> bool:
-    """By-VALUE membership for IP strings (#723): the repo convention compares IPs
-    by value (:: == ::0), but pfb_local carries verbatim PHP-rendered strings — an
-    equal-but-differently-rendered form must still count as present."""
-    try:
-        target = ipaddress.ip_address(addr)
-    except ValueError:
-        return False
-    for cand in pool:
-        try:
-            if ipaddress.ip_address(cand) == target:
-                return True
-        except ValueError:
-            continue
-    return False
-
 
 pytestmark = pytest.mark.smoke
 
@@ -183,7 +164,7 @@ def test_collect_localip_recognises_ipv6_address_and_subnet(
         before_local, before_localsub = h.collect_localip(vm)
 
         # GIVEN assertions: the target address is absent before we add it.
-        assert not _ip_in(addr, before_local), (
+        assert not h.ip_in(addr, before_local), (
             f"GIVEN violated: {addr!r} already in pfb_local before set_interface_ipv6 — "
             f"cannot assert causal before/after.  pfb_local={before_local!r}"
         )
@@ -208,7 +189,7 @@ def test_collect_localip_recognises_ipv6_address_and_subnet(
         # ------------------------------------------------------------------
         # THEN: Local IPv6 is recognised.
         # ------------------------------------------------------------------
-        assert _ip_in(addr, after_local), (
+        assert h.ip_in(addr, after_local), (
             f"THEN violated: {addr!r} NOT in pfb_local after set_interface_ipv6 — "
             f"fix for issue #361 not effective.  pfb_local={after_local!r}"
         )
@@ -236,7 +217,7 @@ def test_collect_localip_recognises_ipv6_address_and_subnet(
         assert lan_ipv4, (
             "AND violated: get_live_ipv4(lan) returned empty — the IPv6 pass may have broken IPv4 enumeration."
         )
-        assert _ip_in(lan_ipv4, after_local), (
+        assert h.ip_in(lan_ipv4, after_local), (
             f"AND violated: LAN IPv4 {lan_ipv4!r} NOT in pfb_local — "
             f"IPv4 enumeration broken after IPv6 change.  pfb_local={after_local!r}"
         )

--- a/tests/smoke/test_smoke_ipv6_alerts.py
+++ b/tests/smoke/test_smoke_ipv6_alerts.py
@@ -40,6 +40,7 @@ from collections.abc import Iterator
 import pytest
 
 from . import helpers as h
+from .conftest import SmokeVM
 
 
 def _ip_in(addr: str, pool: set[str] | list[str]) -> bool:
@@ -58,8 +59,6 @@ def _ip_in(addr: str, pool: set[str] | list[str]) -> bool:
             continue
     return False
 
-
-from .conftest import SmokeVM
 
 pytestmark = pytest.mark.smoke
 
@@ -184,7 +183,7 @@ def test_collect_localip_recognises_ipv6_address_and_subnet(
         before_local, before_localsub = h.collect_localip(vm)
 
         # GIVEN assertions: the target address is absent before we add it.
-        assert addr not in before_local, (
+        assert not _ip_in(addr, before_local), (
             f"GIVEN violated: {addr!r} already in pfb_local before set_interface_ipv6 — "
             f"cannot assert causal before/after.  pfb_local={before_local!r}"
         )

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -230,9 +230,7 @@ def test_dnsbl_exact_null(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: 
         a = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_null_ip(a), f"{domain} A expected {h.NULL_IP4}, got {a}"
         aaaa = h.dns_probe_client(client_vm, domain, "AAAA")
-        assert h.is_null_ip(aaaa, null_ip="::0") or not aaaa.records, (
-            f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
-        )
+        assert h.is_null_ip(aaaa, null_ip="::0"), f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
 
 
 def test_dnsbl_exact_nxdomain(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
@@ -300,9 +298,7 @@ def test_dnsbl_hsts_override_forces_null(deployed_vm: SmokeVM, client_vm: SmokeV
         assert h.is_null_ip(a), f"HSTS override should force A=0.0.0.0, got {a} (VIP leak?)"
         assert not h.is_vip(a), f"HSTS-preload VIP-list block must NOT be the VIP {h.DEFAULT_DNSBL_VIP4}: {a}"
         aaaa = h.dns_probe_client(client_vm, domain, "AAAA")
-        assert h.is_null_ip(aaaa, null_ip="::0") or not aaaa.records, (
-            f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
-        )
+        assert h.is_null_ip(aaaa, null_ip="::0"), f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
 
 
 def test_dnsbl_hsts_disabled_keeps_vip(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -230,7 +230,7 @@ def test_dnsbl_exact_null(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: 
         a = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_null_ip(a), f"{domain} A expected {h.NULL_IP4}, got {a}"
         aaaa = h.dns_probe_client(client_vm, domain, "AAAA")
-        assert h.is_null_ip(aaaa, null_ip="::0"), f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
+        assert h.is_null_ip(aaaa, null_ip="::0"), f"{domain} AAAA expected ::0, got {aaaa}"
 
 
 def test_dnsbl_exact_nxdomain(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
@@ -298,7 +298,7 @@ def test_dnsbl_hsts_override_forces_null(deployed_vm: SmokeVM, client_vm: SmokeV
         assert h.is_null_ip(a), f"HSTS override should force A=0.0.0.0, got {a} (VIP leak?)"
         assert not h.is_vip(a), f"HSTS-preload VIP-list block must NOT be the VIP {h.DEFAULT_DNSBL_VIP4}: {a}"
         aaaa = h.dns_probe_client(client_vm, domain, "AAAA")
-        assert h.is_null_ip(aaaa, null_ip="::0"), f"{domain} AAAA expected ::0 (or no AAAA), got {aaaa}"
+        assert h.is_null_ip(aaaa, null_ip="::0"), f"{domain} AAAA expected ::0, got {aaaa}"
 
 
 def test_dnsbl_hsts_disabled_keeps_vip(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:

--- a/tests/smoke/test_smoke_upstream_block.py
+++ b/tests/smoke/test_smoke_upstream_block.py
@@ -113,6 +113,13 @@ def _upstream_block_lines(log: str, name: str) -> list[str]:
     return out
 
 
+# Absence checks cannot poll for a line that must NOT appear -- they settle, then read
+# once. The settle must cover the SAME async-flush window the positive path budgets
+# (timeout_s=8.0 below): with a shorter settle, an over-trigger whose line lands in the
+# gap reads as a clean pass (#723).
+_ABSENCE_SETTLE_S = 8.0
+
+
 def _wait_for_upstream_block_lines(vm: SmokeVM, name: str, *, timeout_s: float = 8.0, poll_s: float = 0.5) -> list[str]:
     """Poll the on-box dnsbl.log for ``name``'s Upstream_Block lines until they appear.
 
@@ -262,7 +269,7 @@ class TestUpstreamBlockAuthoritativeControl:
         ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
-        time.sleep(2)
+        time.sleep(_ABSENCE_SETTLE_S)
         log = _read_dnsbl_log(vm)
         lines = _upstream_block_lines(log, name)
         assert not lines, (
@@ -295,7 +302,7 @@ class TestUpstreamBlockForwarderNaturalControl:
         ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
-        time.sleep(2)
+        time.sleep(_ABSENCE_SETTLE_S)
         log = _read_dnsbl_log(vm)
         lines = _upstream_block_lines(log, name)
         assert not lines, (
@@ -324,7 +331,7 @@ class TestUpstreamBlockNormalControl:
         ans = h.dns_probe_client(cvm, name, "A")
         assert h.resolves_to(ans, h.STUB_DNS_A), f"Control name should resolve to sentinel {h.STUB_DNS_A}, got {ans}"
 
-        time.sleep(2)
+        time.sleep(_ABSENCE_SETTLE_S)
         log = _read_dnsbl_log(vm)
         lines = _upstream_block_lines(log, name)
         assert not lines, (

--- a/tests/test_adr06_build_module.py
+++ b/tests/test_adr06_build_module.py
@@ -219,11 +219,20 @@ class TestNormalise:
     def test_rejects_edge_hyphen_and_bad_chars(self) -> None:
         assert pfb_unbound.normalise("-bad.com") is None
         assert pfb_unbound.normalise("bad-.com") is None
-        assert pfb_unbound.normalise("under_score.com") is None
         assert pfb_unbound.normalise("emp..ty") is None
+        assert pfb_unbound.normalise("sp ace.com") is None
 
     def test_accepts_valid_domain(self) -> None:
         assert pfb_unbound.normalise("deep.host.cleandata.com") == "deep.host.cleandata.com"
+
+    def test_accepts_underscore_labels(self) -> None:
+        # Underscore is DNS-legal (RFC 2181 s11) and standardized practice (RFC 8552:
+        # _dmarc, _domainkey, SRV _sip._tcp); PHP's PFB_FILTER_DOMAIN accepts it, so the
+        # Python build gate must too or feed entries silently vanish between the two
+        # halves of the pipeline (#723).
+        assert pfb_unbound.normalise("under_score.com") == "under_score.com"
+        assert pfb_unbound.normalise("_dmarc.example.com") == "_dmarc.example.com"
+        assert pfb_unbound.normalise("trailing_.example.com") == "trailing_.example.com"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_adr06_golden_oracle.py
+++ b/tests/test_adr06_golden_oracle.py
@@ -36,7 +36,7 @@ Phase 1 (``RESULTS/01_Results.txt``), with file:line anchors in the docstrings:
   * embedded-IP extraction -> firewall handoff set (generic bare-IP at
     ``inc:7962-7973`` and the csv:pon column-0 IP at ``inc:7824-7833``), with IP
     lines stripped from what the domain build receives;
-  * domain validation + lower-casing (``inc:7995-8016``);
+  * domain validation + lower-casing (``inc:1138-1150``);
   * data/zone classification via the public-suffix TLD master (``tld_analysis`` /
     ``tld_search``, ``inc:2805-2877``), incl. TLD blacklist (whole-TLD zone,
     ``inc:2740``) and TLD exclusion (force exact data, ``inc:2855``);
@@ -208,15 +208,16 @@ class ReferencePipeline:
 
     @staticmethod
     def _validate_domain(host: str) -> str | None:
-        """Lower-case + PFB_FILTER_DOMAIN shape gate (inc:7995-8016)."""
+        """Lower-case + PFB_FILTER_DOMAIN shape gate (inc:1138-1150)."""
         host = host.strip().strip(".").lower()
         if "." not in host:
             return None
-        # Representative domain-shape gate (labels of [a-z0-9-], not all-numeric).
+        # Representative domain-shape gate (labels of [a-z0-9_-], underscore per
+        # #723 — parity with PFB_FILTER_DOMAIN, pfblockerng.inc:1138-1150).
         for label in host.split("."):
             if not label or label[0] == "-" or label[-1] == "-":
                 return None
-            if any(c not in "abcdefghijklmnopqrstuvwxyz0123456789-" for c in label):
+            if any(c not in "abcdefghijklmnopqrstuvwxyz0123456789-_" for c in label):
                 return None
         return host
 

--- a/tests/test_adr07_decision_spec.py
+++ b/tests/test_adr07_decision_spec.py
@@ -170,7 +170,9 @@ def _is_ipv4(token: str) -> bool:
     return True
 
 
-_DOMAIN_RE = re.compile(r"^[a-z0-9-]+(?:\.[a-z0-9-]+)+$")
+# Underscore allowed (#723): parity with production _DNSBL_LABEL_CHARS and PHP's
+# PFB_FILTER_DOMAIN — DNS labels carry no protocol charset (RFC 2181 s11).
+_DOMAIN_RE = re.compile(r"^[a-z0-9_-]+(?:\.[a-z0-9_-]+)+$")
 
 
 def _valid_domain(host: str) -> str | None:
@@ -187,7 +189,7 @@ def _valid_domain(host: str) -> str | None:
 # Regex reduction grammar (mirrors benchmarks/spike_adr07_regex.reduce_pattern).
 # A reducible /re/ decides IDENTICALLY to a domain/wildcard rule (ADR.md SS2).
 # --------------------------------------------------------------------------- #
-_DOMAIN_LITERAL = re.compile(r"^[a-z0-9-]+(?:\\\.[a-z0-9-]+)+$")
+_DOMAIN_LITERAL = re.compile(r"^[a-z0-9_-]+(?:\\\.[a-z0-9_-]+)+$")  # underscore per #723
 _WILDCARD_PREFIXES = (r"^(.+\.)?", r"(^|\.)", r"^(?:.+\.)?")
 _EXACT_PREFIXES = (r"^",)
 

--- a/tests/test_adr07_decision_spec.py
+++ b/tests/test_adr07_decision_spec.py
@@ -697,7 +697,7 @@ def test_important_allow_beats_feed_block() -> None:
     assert d.allow_prio == 4 and d.block_prio == 1
 
 
-def test_important_allow_loses_to_important_block() -> None:
+def test_important_allow_beats_important_block() -> None:
     rs = rules_from(["||z.example^$important", "@@||z.example^$important"])
     d = decide(rs, "z.example")
     # block(3) vs allow(4): allow wins (4>3) -- the higher band always wins.

--- a/tests/test_adr07_decision_spec.py
+++ b/tests/test_adr07_decision_spec.py
@@ -585,6 +585,16 @@ def test_regex_reducible_alt_anchor_is_wildcard() -> None:
     assert decide(rs, "badnxs.com").outcome == "pass"  # not a label boundary
 
 
+def test_regex_reducible_underscored_literal_reduces() -> None:
+    # Underscore rides the reducer too (#723): a regex literal containing '_' folds
+    # to a domain rule (zero per-query cost) exactly like its LDH siblings -- keeping
+    # _DNSBL_RX_DOMAIN_LITERAL in lockstep with _DNSBL_LABEL_CHARS.
+    rs = rules_from([r"/^_dmarc\.example\.com$/"])
+    d = decide(rs, "_dmarc.example.com")
+    assert d.outcome == "block"
+    assert decide(rs, "sub._dmarc.example.com").outcome == "pass"
+
+
 def test_regex_reducible_exact_equals_data() -> None:
     rs_regex = rules_from([r"/^pixel\.example\.com$/"])
     assert decide(rs_regex, "pixel.example.com").outcome == "block"

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -663,8 +663,15 @@ class TestGetRepTtl:
     def test_none_rep_returns_unk(self) -> None:
         assert pfb_unbound.get_rep_ttl(None) == "Unk"
 
-    def test_falsy_ttl_returns_unk(self) -> None:
+    def test_zero_ttl_reported_as_zero(self) -> None:
+        # TTL 0 is a real, meaningful value (RFC 2181 s8: deliverable, non-cacheable)
+        # -- it must reach the DNS-reply log as "0", never masked as unknown (#723).
         rep = types.SimpleNamespace(ttl=0)
+        assert pfb_unbound.get_rep_ttl(rep) == "0"
+
+    def test_absent_ttl_returns_unk(self) -> None:
+        # Only a genuinely missing TTL (no value on the reply) is unknown.
+        rep = types.SimpleNamespace(ttl=None)
         assert pfb_unbound.get_rep_ttl(rep) == "Unk"
 
 

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -20,6 +20,7 @@ from unboundmodule import (
     MODULE_FINISHED,
     MODULE_RESTART_NEXT,
     MODULE_WAIT_MODULE,
+    MODULE_WAIT_SUBQUERY,
     PKT_AA,
     PKT_QR,
     PKT_RA,
@@ -1094,6 +1095,27 @@ def make_qstate(
 RR_A = 1
 RR_AAAA = 28
 RR_TXT = 16
+
+
+class TestModuleConstantsStubFidelity:
+    """The stub's module-event/state values must match util/module.h's C enums --
+    the vocabulary real pythonmod injects. Wrong values are latent until code
+    compares numerically; the collision pins below fail loudly if the stub
+    regresses to the pre-#723 values (FINISHED==WAIT_SUBQUERY, MODDONE==
+    RESTART_NEXT masked distinct states behind equal ints).
+    """
+
+    def test_event_moddone_is_module_h_position(self) -> None:
+        # util/module.h enum module_ev: moddone is position 5 (noreply is 3,
+        # which the old stub mislabeled as MODDONE).
+        assert MODULE_EVENT_MODDONE == 5
+        assert MODULE_EVENT_MODDONE != MODULE_RESTART_NEXT
+
+    def test_finished_is_module_h_position_and_distinct(self) -> None:
+        # util/module.h enum module_ext_state: finished is position 6;
+        # the old stub's 4 collided with wait_subquery.
+        assert MODULE_FINISHED == 6
+        assert MODULE_FINISHED != MODULE_WAIT_SUBQUERY
 
 
 class TestSetReturnMsgStubFidelity:

--- a/tests/test_pfbl03_txt_legacy_gate.py
+++ b/tests/test_pfbl03_txt_legacy_gate.py
@@ -24,12 +24,11 @@ import builtins
 import types
 from typing import Any
 
-from unboundmodule import DNSMessage
+from unboundmodule import MODULE_EVENT_NEW, DNSMessage
 
 import pfb_unbound as P
 
 RR_TXT = 16
-MODULE_EVENT_NEW = 0
 
 
 def _txt_control_qstate(qname: str, q_ip: str = "127.0.0.1") -> types.SimpleNamespace:


### PR DESCRIPTION
Fixes #723

All 17 audit items resolved (16 fixed here; the killstates grep anchoring was already fixed on `devel` — its checkbox gets a resolution note). Every item was re-verified against the current tip before implementation; each fix is a focused commit. Maintainer decisions recorded on the issue: allow underscore in the Python build gate (PHP stays); annotate `measure_fp_tp.py` as historical (no re-measure).

## Python / stubs

- **TTL 0 in the DNS-reply log**: `get_rep_ttl()` routed through `is_unknown()`, whose falsy check swallowed 0 — a valid RFC 2181 §8 value — as "Unk". Returns by presence now; red→green.
- **Underscore labels**: `normalise()` claimed parity with `PFB_FILTER_DOMAIN` but rejected `_`, which PHP accepts — feed entries passed PHP validation then silently vanished in the Python build. Underscore allowed (DNS-legal per RFC 2181 §11, standardized per RFC 8552, matched against QNAMEs, not hostnames); stale anchors corrected; red→green.
- **Stub module constants**: `MODULE_EVENT_MODDONE` 3→5, `MODULE_FINISHED` 4→6 per `util/module.h` (the old FINISHED collided with `wait_subquery`); collision-guard tests; the PFBL-03 test now imports the constant instead of hardcoding it.
- **ADR-07 `$important` test** renamed to match its (correct) assertion.
- **`measure_fp_tp.py`** + ADR-08 evidence annotated as the historical 3-tier/dict-lookup gate model.

## PHP

- **`DnsblV6RequiredTest`**: the v6-VIP test never reached the per-VIP branches (interface mismatch first) and asserted a tautology plus a phantom message string. Replaced with three exact-outcome branch tests (interface mismatch / unknown-VIP existence / seeded happy path).
- **`pfb_pfctl_error_message()`**: empty stderr no longer emits a dangling `": "` (the scenario-D header always claimed this; production and assertions disagreed). Red→green + branch pair.
- **Leading-zero octets are libc-dependent** (found while gating: the #743 pin fails on macOS, whose `inet_pton` accepts them): replaced the fixed verdict with a mechanism-parity assertion (double ≡ local `ip2long`).
- **`pfb_alias_set_different`**: docstring + companion test pin the one-sided order-immunity contract (canonical `$new_set` required; unsorted input compares as different).
- **`SafeSearchCnameTest` live DNS**: `pfb_ss_resolve_target()` gets an injectable `$pfb['drill']` (production default unchanged); the unit test stubs it — no more real `drill` against a real domain, no false failure on boxes with a loopback resolver.
- **`is_port` double** aligned with upstream verbatim (service names via `getservbyname`, verified at the CE-2.8.0-era ref).
- **ABP IP coarsening** (`||ip` without caret, `$third-party` dropped) documented as intended.

## Smoke

- **DNS-redirect / 853-block render gates are protocol-aware**: helpers return the matched-proto set — positives require BOTH tcp and udp (a lost DoQ/UDP-853 leg now fails), absence gates require the empty set.
- **Upstream-block absence settles** now share the positive path's 8 s async-flush budget (was 2 s — an over-trigger in the gap passed).
- **Matrix AAAA assertions strict** (dropped the off-contract `or not aaaa.records` escape).
- **IPv6 locality compared by value** (`::` == `::0`), not exact string.
- **ADR-40 docstring threshold** corrected to the real 0.05.

## Validation

- Full local gates green: pytest (2061), PHPUnit (1861, incl. PHPStan/PHPCS clean), ruff/mypy/markdownlint.
- Live smoke dispatch on this branch validating the tightened gates (dns_redirect, dot_doq, upstream_block, matrix, ipv6_alerts) — link in the review audit comment once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013baLunt412HLH6L49aF953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Domain and regex checks now accept underscores in valid labels, improving support for underscore-based hostnames.
  * DNS/port validation now recognizes service-name ports when enabled.

* **Bug Fixes**
  * TTL values of `0` are now shown correctly instead of being treated as unknown.
  * pfctl error messages no longer end with a dangling `: ` when no stderr is returned.
  * Resolver lookups can now use a configured binary path for more reliable checks.

* **Style**
  * Protocol checks for DNS redirect and block rules now validate both `tcp` and `udp` consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->