### PR TITLE
ADR-53: replace the IP-suppression host-explosion with CIDR set-subtraction (v4+v6 parity)

### DIFF
--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/01_Results.txt
@@ -1,0 +1,200 @@
+ADR-53 Phase 1 — suppress() oracle (shellspec, behaviour-preserving)
+=====================================================================
+
+STATUS: Done. Tests only; zero src/ changes. Green before and after (oracle).
+
+New file: tests/shell/pfblockerng_suppress_spec.sh
+
+Pre-check (action-plan step 1)
+-------------------------------
+Ran `grep -rl suppress tests/shell/` first. It matched 6 files, but none is a
+dedicated suppress() oracle:
+  - tests/shell/pfblockerng_fail_open_redirect_spec.sh -- DOES call suppress()
+    (Class A/B: the #713 grepcidr rc>=2 keep-previous gate, and the dedup="on"
+    masterfile awk redirect), but it is scoped to a cross-function "fail-open
+    redirect" family shared with duplicate()/remove()/process255()/
+    reputation_max() -- not a comprehensive suppress() semantics pin.
+  - the other 5 matches are incidental word hits (comments, unrelated
+    "suppress the false positive" ShellCheck notes, etc).
+Conclusion: no existing spec covers the full contract this phase needs
+(bare-token removal, the /24 explode + dupfile dedup guard, the containing-
+entry defect, absent/empty gating, the stats table) -- created the new
+dedicated file per the phase prompt, rather than extending the narrower one.
+The two files' fail-safe (#713) cases are deliberately redundant, not
+duplicative: each proves the rc-gating contract from its own file's
+self-contained narrative (see the new file's header-comment note).
+
+It-block inventory (letter -> Describe/It)
+-------------------------------------------
+a) 'a — suppression file absent or empty: early return, member file untouched'
+   - 'leaves the member file byte-identical when the suppression file does
+     not exist'        (the "-e" leg of the gate)
+   - 'leaves the member file byte-identical when the suppression file exists
+     but is empty'     (the "-s" leg of the gate)
+
+b) 'b — bare-host token + matching /32 suppression: token removed (the
+   working case)'
+   - 'removes the exact suppressed host, keeping its siblings'
+
+c) 'c — exact-/24 explode: a /32 suppression inside a containing /24 member
+   entry'
+   - 'explodes the /24 line into its 254 non-suppressed host lines (the /24
+     line itself is gone)' -- NOTE: empirically verified 254, NOT 255 (seq
+     255 walks octets 1..255 = 255 values; minus the one suppressed octet =
+     254). The phase-prompt's "255 host lines" figure was an off-by-one; the
+     assertion reflects the REAL function's output (verified by sourcing
+     pfblockerng.sh directly and running suppress() by hand before writing
+     the spec -- see "Empirical verification" below).
+   - 'a SECOND /32 suppression inside the same containing /24 does not
+     re-explode (dupfile dedup): both hosts gone, no duplicate lines' -- two
+     different /32 holes mapping to the same containing /24; proves the
+     dcheck/dupfile guard fires only once (253 lines, no duplicated host).
+
+d) 'd — containing-entry silent no-op: the DEFECT, pinned as todays oracle
+   (Phase 3 flips this)'
+   - 'SURVIVES the containing /16 line unchanged -- the suppressed host stays
+     blocked, ADR-53 §1.2 (Phase 3 flips this to a carve)' -- THE assertion
+     Phase 3 must flip red->green (currently pins the no-op as today's
+     truth).
+
+e) 'e — grepcidr fail-safe publish gating (#713), re-asserted here for a
+   self-contained oracle'
+   - 'keeps the PRIOR member list unchanged when grepcidr errors (rc>=2), and
+     logs the error'
+   - 'publishes an EMPTY member list on grepcidr rc=1 (a legitimate
+     "everything suppressed" outcome)'
+   (rc=0/default-mode "publish on success" is already exercised throughout
+   b/c/d/f — not re-tested here as a third redundant case.)
+
+f) 'f — masterfile resync under dedup="on" mirrors the post-suppression list'
+   - 'drops the stale alias rows, keeps the unrelated row, and appends the
+     post-suppression list'
+
+g) 'g — the Suppression Stats table'
+   - 'prints the header block when alias="suppressheader"'
+   - 'prints the per-alias Pre/Suppress/Master row shape on a normal call'
+
+11 It blocks total, mapping to the 7 lettered cases (a-g) from the phase
+prompt's action plan.
+
+How pfb_source works
+---------------------
+tests/shell/spec_helper.sh (loaded via .shellspec's `--require spec_helper`)
+defines `pfb_source()`: sets `PFB_SOURCED=1` then dot-sources
+src/usr/local/pkg/pfblockerng/pfblockerng.sh. The script's own top-of-file
+source guard (PFB_SOURCED set) makes it define every function and return
+before its normal top-level init / argv dispatch -- so `suppress()` etc.
+become plain shell functions callable directly from a spec, with every global
+variable it reads (max, alias, pfbsuppression, tempfile, tempfile2, dupfile,
+dedupfile, masterfile, mastercat, dedup, errorlog, pathgrepcidr) supplied by
+the spec's own setup(). Every nested Describe here follows the established
+per-file pattern (see pfblockerng_original_count_spec.sh /
+pfblockerng_fail_open_redirect_spec.sh): `BeforeAll 'pfb_source'` once at the
+top, then each Describe has its own `setup()`/`cleanup()` wired via
+`Before`/`After`, using a fresh mktemp workdir so no test shares state with
+another (self-encapsulated per the test-coverage mandate).
+
+The grepcidr stub contract
+----------------------------
+suppress() shells out to `${pathgrepcidr} -vf <suppression-file> <target>`.
+The new file's local `write_grepcidr_shim()` helper writes an executable
+POSIX-sh stub (same pattern as the sibling file's local `write_grepcidr_shim`
+-- these are per-file helpers by house convention, not shared via
+spec_helper.sh) implementing:
+
+  - DEFAULT mode: plain ADDRESS-EQUALITY filtering, mask stripped from both
+    sides. Every suppression entry the UI accepts today is a /32 host
+    (pfblockerng_ip.php:159), so real grepcidr's CIDR-containment test ("is
+    this target line's range a subset of a filter CIDR") collapses to "is
+    this target line's address exactly the suppressed host": a bare host or
+    an exact /32-written line at that address is removed (proven whole-token
+    removal, ADR-53 §1.2); a WIDER target CIDR (a /16 or /24 line) can never
+    equal a single suppressed host's address, so it survives completely
+    untouched -- this is EXACTLY the containing-entry silent no-op ADR-53
+    §1.2 proved live, and it falls out of the address-equality stub for free
+    (verified empirically -- see below), with no need for full CIDR-subset
+    arithmetic in the fake.
+  - GREPCIDR_MODE=empty -> exit 1 with no output (the #713 legitimate-empty
+    case).
+  - GREPCIDR_MODE=error -> exit 2 with a stderr message (the #713 real-error
+    case).
+
+Empirical verification (before writing final assertions)
+------------------------------------------------------------
+Per the "don't guess" working principle, every numeric assertion in the spec
+was checked by sourcing the REAL pfblockerng.sh in a throwaway script (with
+the same stub) and calling suppress() by hand BEFORE encoding it into
+shellspec, rather than trusting the phase prompt's stated counts verbatim.
+This caught the phase prompt's off-by-one ("255 host lines" -> actually 254)
+and confirmed: case (d)'s /16 line truly survives byte-identical; case (c)'s
+dupfile guard truly fires only once across two /32s in the same /24 (253
+final lines, no duplicates); case (a)'s early return really is rc=0 either
+way (POSIX `if false; then …; fi` with no else exits 0).
+
+One iteration bug fixed along the way: an initial `The contents of file …
+should not include '10.9.8.4'` assertion false-failed because '10.9.8.4' is
+a SUBSTRING of '10.9.8.40'..'10.9.8.49', which are legitimately still present
+in the exploded list. Fixed by switching every specific-host
+presence/absence check to an exact-line `grep -c '^host$'` captured into a
+plain variable, asserted via `The variable … should equal N` (mirroring the
+existing `c_count`/`merged` pattern in pfblockerng_adr26_locale_spec.sh) --
+substring "include"/"not include" is kept only where the string is
+unambiguous (the '/24' line, 'PRIOR-1'/'PRIOR-2', alias-prefixed masterfile
+rows). Also had to append `|| true` to every such grep/uniq -d capture:
+shellspec's example execution has `set -e` semantics, so a legitimate
+zero-match (grep rc=1) was aborting the example outright ("Example aborted")
+until guarded.
+
+Gate results
+------------
+- shellspec tests/shell/pfblockerng_suppress_spec.sh -> 11 examples, 0
+  failures.
+- shellspec (full suite)                              -> 260 examples,
+  0 failures, 4 skips (all 4 pre-existing/unrelated: two build-leg real-build
+  parity legs needing REAL_PORTS_DIR, one ADR-26 GNU-stat-only case, one
+  ADR-26 locale-merge case skipped because this libc's ca_AD.UTF-8 doesn't
+  collation-merge the sample).
+- sh -n tests/shell/pfblockerng_suppress_spec.sh -> clean.
+- shellcheck tests/shell/pfblockerng_suppress_spec.sh -> DEVIATION from the
+  literal phase-prompt gate ("shellcheck … -> clean"): it reports SC2329
+  ("function never invoked" on every setup()/cleanup(), which shellspec's
+  Before/After DSL strings invoke indirectly) and SC2034 ("var appears
+  unused" on globals consumed only by the sourced suppress()) -- the EXACT
+  SAME two warning classes the pre-existing, already-merged
+  pfblockerng_fail_open_redirect_spec.sh also triggers verbatim (verified by
+  running shellcheck on it too). This is NOT a gap: .githooks/pre-commit
+  explicitly scopes its shellcheck step to `find src scripts -name '*.sh'`
+  with the inline comment "tests/ shellspec specs trip SC2034
+  false-positives — tracked as a separate cleanup", and CI's shellcheck job
+  (test.yml:205) uses the identical `find src scripts` scope -- tests/shell/
+  is deliberately OUT of the enforced shellcheck gate for exactly this
+  reason. Treated as expected/tolerated, matching the established sibling
+  file's baseline, not a defect to chase.
+- .venv/bin/python -m pytest -q -> 2042 passed, 4 skipped (untouched;
+  sanity-only, this phase touches no Python).
+- vendor/bin/phpunit -> 1846 tests, 15443 assertions, 1 failure, 4 skipped --
+  the exact known environmental baseline (IpAddrDoublesTest::testIsIpaddrv4
+  "leading-zero octets rejected", macOS inet_pton accepts what glibc rejects).
+  No other failures; untouched by this phase (no PHP touched).
+
+Scope confirmation
+-------------------
+`git diff origin/devel...HEAD --stat` (pre-commit) showed nothing (branch was
+at origin/devel tip with only the new untracked file); `git status --porcelain`
+showed exactly one untracked file: tests/shell/pfblockerng_suppress_spec.sh.
+No src/ changes. Diff is tests-only, matching the phase's behaviour-preserving
+scope.
+
+Go-ahead for Phase 2
+---------------------
+Phase 1 is complete and green. Phase 2 (register `v4suppression` in the
+config gateway, behaviour-preserving) can proceed independently of this
+file -- it touches pfblockerng_extra.inc/pfblockerng_alerts.php, not
+pfblockerng.sh, so there is no ordering dependency on this oracle beyond it
+existing as the Phase 3 regression baseline. Phase 3 implementer: flip case
+(d)'s single assertion ('SURVIVES the containing /16 line unchanged…') to the
+real covering-CIDR carve assertion (16 entries, per ADR-53 §1.2's measured
+`/16 − /32` bound) and update case (c)'s "255 host lines" language (this
+spec already correctly encodes 254/253) to the covering-CIDR count (8 entries
+for `/24 − /32`) -- everything else in this file (a, b, e, f, g) must stay
+green unchanged through the Phase 3 rewrite.

--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/02_Results.txt
@@ -1,0 +1,191 @@
+ADR-53 Phase 2 — Config-gateway prep: register v4suppression (behaviour-preserving)
+====================================================================================
+
+STATUS: Done. Registry + sniff + call-site migration + tests. Zero stored-byte
+or read-value change anywhere. Green before and after (mechanism migration,
+not a behaviour change).
+
+Registry entry (pfblockerng_extra.inc)
+---------------------------------------
+New "IP settings section (pfblockerngipsettings/config/0)" block in
+pfb_cfg_registry(), added right after the SafeSearch section (end of the
+array, minimal line churn):
+
+  $ip = 'installedpackages/pfblockerngipsettings/config/0';   // new section var
+
+  'v4suppression' => [
+      'section'       => $ip,
+      'default'       => '',
+      'read_adapter'  => NULL,
+      'write_adapter' => NULL,
+      'since'         => '1.0.0',
+  ],
+
+`since` = '1.0.0': v4suppression is a legacy key from the original addon (the
+IPv4 suppression feature predates the registry entirely), matching the exact
+vintage of its stated precedent -- the DNSBL 'suppression' blob (also plain,
+default '', since '1.0.0'). No other original-era IP-settings sibling exists
+in the registry to cross-check against (pfb_agg_types/pfb_alias_delta_mode
+live in the general $gen section and are newer ADR features), so the DNSBL
+'suppression' shape is the operative precedent per the phase prompt.
+
+Sniff update (tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php)
+------------------------------------------------------------------------------------
+Added 'installedpackages/pfblockerngipsettings/config/0/v4suppression' to
+$registeredPaths.
+
+Mechanical proof (per the phase prompt's step 3): ran phpcs with this sniff
+against the file's PRE-migration content (extracted via `git show HEAD:...`,
+HEAD = the Phase 1 commit) -- it flagged all 5 raw call sites (lines 254, 255,
+269, 847, 1331) that existed before migration. After migration, the same
+sniff run against the live file (and the full `src/` tree) is clean.
+
+Migrated call sites (src/usr/local/www/pfblockerng/pfblockerng_alerts.php)
+------------------------------------------------------------------------------
+Four raw config_*_path sites, all replaced with PfbConfig::read/write,
+mirroring the adjacent already-gatewayed 'suppression'/'tldexclusion' sibling
+lines in the same file (proves the migration reproduces an established,
+already-proven-safe pattern, not a new one):
+
+  1. Line 253 (was 254-255): self-sync write
+     Before: config_set_path(path, config_get_path(path) ?: '')
+     After:  PfbConfig::write('v4suppression', PfbConfig::read('v4suppression') ?: '')
+
+  2. Line 266 (was 269): read into $clists['ipsuppression']['base64']
+     Before: config_get_path(path)                    -- returns NULL if absent
+     After:  PfbConfig::read('v4suppression')          -- returns '' if absent
+     Byte-identical net effect verified: the only consumer is
+     `if (isset(...) && !empty(...))` two lines below -- NULL and '' both
+     fail `!empty()`, so the decode branch is skipped either way. This is the
+     EXACT same NULL-vs-'' non-issue already accepted for the pre-existing
+     'suppression'/'tldexclusion' PfbConfig::read() calls one/two lines below
+     in the identical if/elseif chain -- confirms the pattern is safe by the
+     project's own established precedent, not a new judgment call.
+
+  3. Line 843 (was 847): write in the addsuppress ($_POST['addsuppress']) handler
+     Before: config_set_path(path, $clists['ipsuppression']['base64'])
+     After:  PfbConfig::write('v4suppression', $clists['ipsuppression']['base64'])
+     write_config() on the next line is untouched -- PfbConfig::write() does
+     not persist (same contract as raw config_set_path), so timing is identical.
+
+  4. Line 1326 (was 1331): write in the delete_ip switch-case handler
+     Before: config_set_path(path, $clists['ipsuppression']['base64'])
+     After:  PfbConfig::write('v4suppression', $clists['ipsuppression']['base64'])
+     write_config() fires once, common to every switch-case, after the switch
+     (line ~1370) -- unaffected, same as case 3.
+
+Other v4suppression sites in src/ (grep -rn "v4suppression" src/) -- reviewed,
+NOT migrated (correctly out of scope):
+  - pfblockerng_ip.php (lines 69, 219, 241): already reads/writes through
+    $pfb['iconfig'] populated by PfbConfig::readSection/writeSection -- the
+    sanctioned section-level pattern, not a raw per-key config_*_path call.
+    No sniff finding, no change needed.
+  - pfblockerng.inc (4957-4959, 10178-10179), pfblockerng.widget.php (692):
+    read from the in-memory $pfb['ipconfig'] array (itself built via a
+    section-level config_get_path at pfblockerng.inc:2001) -- plain PHP
+    array-key access, never a config_*_path call. Untouched.
+  - pfblockerng_install.inc (494-519): the one-time pfBlockerNGSuppress-alias
+    migration. Uses PfbConfig::readSection/writeSection deliberately -- it
+    needs `isset($pfb_ip_cfg['v4suppression'])` to distinguish "key literally
+    absent" (never migrated) from "present but empty" (already migrated to an
+    empty list), a distinction PfbConfig::read()'s absent-default ('') cannot
+    express. Left the section-level access as-is (correct, allowed) and
+    updated the two comments that said "v4suppression is unregistered" (now
+    stale) to explain why section-level access remains correct even though
+    the key is registered.
+
+docs/misc/config-gateway.md
+------------------------------
+Removed the now-inaccurate 'pfblockerngipsettings/config/0/v4suppression' row
+from the foreign-key exclusion table (it was the literal source-of-truth
+comment for the old status).
+
+Tests
+-----
+tests/php/CfgGatewayTest.php (registry-level, group A/B):
+  - testV4SuppressionAbsentKeyReturnsDefaultEmptyString -- absent key -> ''
+    (red->green: pre-phase this threw InvalidArgumentException).
+  - testV4SuppressionRoundTrips -- seed a base64 blob, read, write back,
+    assert byte-identical (write(read(v)) == v).
+  - testInventoryCompletenessAllKnownKeysAccountedFor: moved 'v4suppression'
+    out of $out_of_scope (would now conflict with $registered_keys) and into
+    the registered section of $inventory; updated the docblock's
+    "pfblockerngipsettings sub-keys" bullet.
+
+tests/php/WwwGroupCGatewayTest.php (page-routing parity, the exact file whose
+scope is pfblockerng_alerts.php's gateway routing):
+  - testV4SuppressionAbsentDefaultIsEmptyString + testV4SuppressionRoundTrips
+    added alongside the existing suppression/tldexclusion/global_log parity
+    pairs (same shape).
+  - testV4SuppressionIsNotInRegistry (asserted PfbConfig::read('v4suppression')
+    throws) REPLACED by testEnableDupIsNotInRegistry -- v4suppression's
+    "foreign key throws" branch no longer holds (that's the whole point of
+    this phase), so the foreign-key-in-this-section coverage now uses a
+    genuinely-still-foreign ipsettings key (enable_dup) instead. This is the
+    one test whose PRE-phase assertion (throws) would now FAIL post-phase --
+    confirms the migration is real, not a no-op.
+  - Docblock updated (page/key inventory, foreign-key list).
+
+tests/phpcs fixtures + RequireConfigGatewaySniffTest.php:
+  - gateway_violation.php: new pfb_gateway_violation_v4suppression() function,
+    one config_get_path call on v4suppression -- must be flagged (line 38).
+  - gateway_compliant.php: the old "foreign section" example (v4suppression,
+    line 20) swapped for a still-foreign ipsettings key (enable_dup), since
+    v4suppression itself is no longer a valid "foreign" example. Added
+    pfb_gateway_compliant_v4suppression_via_gateway() demonstrating
+    PfbConfig::read/write access to the now-registered key stays silent
+    (neither call is one of the sniff's three gated function names).
+  - RequireConfigGatewaySniffTest::testFlagsRawRegisteredKeyAccess: count
+    4->5, expected lines [20,23,26,29] -> [21,24,27,30,38] (the pre-existing
+    4 lines shifted +1 because the docblock's "Flagged:" list grew one line;
+    verified against the actual file, not assumed).
+  - Docblocks updated throughout (class-level branch inventory, method-level
+    scenario comments).
+
+Gate results
+------------
+- php -l on every touched file (10 files)          -> clean, all files.
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/  -> clean (no output, exit 0).
+- vendor/bin/phpstan analyse --memory-limit=1G     -> "[OK] No errors" (the
+  bare `phpstan analyse` command crashes on this box's default 128M limit --
+  a pre-existing environment quirk, NOT a regression; CI's own invocation
+  (.github/workflows/test.yml:373) already passes --memory-limit=1G, so this
+  matches the real gate exactly).
+- vendor/bin/phpunit                               -> 1861 tests, 15478
+  assertions, 1 failure, 4 skipped. The 1 failure is the exact documented
+  environmental baseline (IpAddrDoublesTest::testIsIpaddrv4 "leading-zero
+  octets rejected", macOS inet_pton vs glibc) -- untouched by this phase, no
+  PHP-validation code changed. Filtered re-run of the three touched test
+  classes (CfgGatewayTest|WwwGroupCGatewayTest|RequireConfigGatewaySniffTest):
+  155 tests, 1725 assertions, 0 failures.
+- .venv/bin/python -m pytest -q                    -> 2042 passed, 4 skipped
+  (identical to Phase 1's recorded baseline; no Python touched this phase).
+- shellspec                                        -> 260 examples, 0
+  failures, 4 skips (identical to Phase 1's recorded baseline; no shell
+  touched this phase).
+
+Scope confirmation
+-------------------
+`git diff origin/devel...HEAD --stat` (pre-commit) showed only Phase 1's
+tests-only diff (branch was at the Phase 1 tip 7c393089, fast-forward from
+origin/devel). `git status --porcelain` showed exactly the 10 files listed
+above as Modified, nothing else. `git diff --stat` (working tree): 205
+insertions, 47 deletions across 10 files -- registry + sniff + one www/ page
++ one install-migration comment fix + doc fix + 4 test files. No src/ file
+outside pfblockerng_extra.inc / pfblockerng_install.inc / pfblockerng_alerts.php
+touched; no v6suppression key added (Phase 6's job); no pfblockerng.sh touched
+(Phase 3's job).
+
+Go-ahead for Phase 3
+---------------------
+Phase 2 is complete and green; v4suppression is now a registered, gateway-only
+key with zero behaviour change (config.xml bytes, page responses, and
+write_config timing all identical to before). Phase 3 (v4 engine swap:
+`iprange --except` in pfblockerng.sh's suppress()) can proceed independently
+-- it touches pfblockerng.sh + the Phase-1 shellspec oracle
+(tests/shell/pfblockerng_suppress_spec.sh), neither of which this phase
+touched. Per Phase 1's handoff, Phase 3 implementer must flip case (d)'s
+single assertion (containing-/16 survives unchanged -> the real covering-CIDR
+carve, 16 entries) and update case (c)'s host-count language to the
+covering-CIDR count (8 entries for /24 - /32), leaving a/b/e/f/g green
+unchanged.

--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/03_Results.txt
@@ -1,0 +1,293 @@
+ADR-53 Phase 3 — v4 engine swap: iprange --except (red->green)
+================================================================
+
+STATUS: Done. Core v4 BEHAVIOUR CHANGE landed. Containing-entry defect fixed
+and proven red->green; every other pinned suppress() semantic stays green
+(oracle preserved where the engine's observable contract is unchanged).
+
+New suppress() shape (filter -> iprange -> rc-gated publish)
+--------------------------------------------------------------
+suppress() (pfblockerng.sh:492-581) is now:
+
+  1. Missing-binary guard on `${pathaggregate}` (iprange), not `${pathgrepcidr}`
+     -- mirrors the old guard's position/shape exactly (pfblockerng.sh:494-498).
+  2. Unchanged: the "-e"/"-s" gate on ${pfbsuppression}, the `suppressheader`
+     stats-table early return, `LC_ALL=C sort -u` dedup of the suppression
+     data, the `countg` Pre-count read.
+  3. NEW core -- two independent strict-shape pre-filters, both writing into
+     the EXISTING scratch vars (no new tmp files needed):
+       - `${dupfile}` <- suppression-list entries passing `pfb_is_cidr_token`
+         (requires a mask -- every UI-accepted entry is /32 or /24 today).
+         A rejected non-empty token is DROPPED AND LOGGED (" Suppression
+         ${alias}: dropping malformed suppression entry [ ${ip} ]") via
+         `tee -a "${errorlog}"` -- this is the DNS-resolution-hazard defense
+         (ADR §1.2): iprange treats anything not in strict IP/CIDR shape as a
+         HOSTNAME and DNS-resolves it (rc=0, no opt-out flag).
+       - `${dedupfile}` <- deny member-file lines passing the NEW
+         `pfb_is_ip_or_cidr_token` (bare host OR CIDR; pfb_is_cidr_token
+         alone can't be reused here since it REQUIRES a mask and member
+         lines are a mix). Silent drop (defense-in-depth only -- feed data
+         is already sanitised upstream, so no log noise expected in practice).
+  4. Single call: `"${pathaggregate}" "${dedupfile}" --except "${dupfile}" >
+     "${tempfile2}"`. iprange merges the files before `--except` (ipset A =
+     the member set) and subtracts every IP in the files after it (ipset B =
+     the suppression set), printing the minimal covering-CIDR remainder.
+  5. rc-gated atomic publish: `irc=$?`; `irc -eq 0` -> `mv -f "${tempfile2}"
+     "${pfbfolder}${alias}.txt"` (INCLUDING a legitimately-empty result --
+     iprange has no grepcidr-style "rc=1=empty" quirk, so there is nothing
+     to special-case); any other rc -> `rm -f "${tempfile2}"` + log
+     `"iprange error (rc=${irc}) suppressing [ ${alias} ]; keeping previous
+     list"` (the #713 fail-safe pattern, same shape as the old grepcidr gate).
+  6. Unchanged: the `dedup='on'` masterfile resync block (byte-identical --
+     grep the alias's stale rows out, awk-dedup gate on its own exit status,
+     re-append the fresh post-suppression list, `cut` the mastercat) and the
+     final `printf` stats row.
+
+DELETED entirely: the `grep -F "${iptrim}.0/24"` exact-/24 detection, the
+`for i in $(seq 255)` host-explode loop, the `${dupfile}`-as-per-hole-dedup-
+guard ("dcheck") bookkeeping, the trailing `${pathgrepcidr} -vf` whole-token
+pass, and the `counter` variable (the "Suppress" stats column is now simply
+the post-publish `countx`, since there is no artificial host-count delta to
+subtract -- verified against case g's Pre=3/Suppress=2 expectation, unchanged).
+`${dupfile}`/`${dedupfile}` are REPURPOSED (filtered-suppression-scratch /
+filtered-member-scratch) rather than dropped, so no new tmp-file plumbing
+was needed. Net effect: suppress() shrank from 115 to 92 lines (`awk` line-
+count check on the function body, devel vs this branch).
+
+New helper: `pfb_is_ip_or_cidr_token()` (pfblockerng.sh:180-197), placed
+right after `pfb_is_cidr_token()`. Bare host (digits/dots only) OR CIDR
+(digits/dots + exactly one '/' + non-empty numeric mask) -- unlike
+`pfb_is_cidr_token`, the mask is optional. `pfb_is_cidr_token`'s own
+docstring was updated (it no longer describes a caller that compares the
+mask with `-eq`, since that comparison is gone).
+
+Red->green evidence
+--------------------
+Ran a THREE-STAGE proof (adjusted from the literal phase-prompt gate because
+my "final" spec rewrite also swapped every case's binary plumbing from
+pathgrepcidr to pathaggregate, which would make old code fail for "missing
+grepcidr" rather than for its actual wrong behaviour -- not a fair red proof):
+
+1. Isolated the ASSERTION flip from the wiring flip. Took `git show
+   7c393089:tests/shell/pfblockerng_suppress_spec.sh` (the exact Phase-1
+   committed file, OLD pathgrepcidr wiring untouched) into a scratch copy,
+   changed ONLY case (c)'s two It-block assertions (254/253 hosts -> 8/12
+   covering CIDRs) and case (d)'s It-block assertion (byte-identical /16 ->
+   carved, 16 covering CIDRs, sample lines present) -- setup()/wiring left
+   exactly as Phase 1 wrote it. Ran that scratch file (temporarily placed at
+   tests/shell/zz_phase1_redcheck_spec.sh, deleted again after) against the
+   UNCHANGED (stashed) src via `git stash push -- src/.../pfblockerng.sh`.
+   Result: **11 examples, 3 failures** -- cases a/b/e/f/g stayed green
+   (proving nothing else broke), and the 3 flipped assertions failed for the
+   EXACT right reason:
+     - case (c) #1: `linecount should equal 8` -> `got: 254` (old explode
+       still produces 254 host lines)
+     - case (c) #2: `linecount should equal 12` -> `got: 253` (old
+       explode+dedup still produces 253, not the new two-hole carve)
+     - case (d): `The contents of file ... should not include '10.0.0.0/16'`
+       -> `expected "10.0.0.0/16" not to include "10.0.0.0/16"` (old code's
+       containing-/16 no-op survives byte-identical -- THE defect, caught
+       live) + `linecount should equal 16` -> `got: 1`.
+   Full captured output archived at the scratchpad path used this session
+   (not committed -- reproducible any time from the 7c393089 spec + a rerun
+   of the same two edits); key excerpts quoted above are the load-bearing
+   evidence.
+2. `git stash pop` restored the src rewrite.
+3. Ran the FULL final spec (all cases converted to pathaggregate wiring)
+   against the NEW src -> green (see Gate results below).
+
+One iteration bug found and fixed along the way: my first `have_iprange()`
+used a bare `command -v iprange`, which found `tests/shell/bin/iprange` --
+an EXISTING test-only stand-in (`exec sort -u`, built for the AWS
+pre-script tests, no `--except`/aggregation semantics) that `spec_helper.sh`
+deliberately prepends onto `PATH`. This made `no_iprange` false even on this
+Mac (which has no REAL iprange), so `Skip if` never skipped, and the real
+cases called the AWS stub instead of the real binary -- "Example aborted"
+(the stub's `sort -u` tried to open the literal argv token `--except` as a
+file). Fixed with `pfb_real_iprange()`: resolves `command -v iprange` against
+`PATH` with `PFB_SHIMS` stripped out, so it finds the REAL binary (or
+nothing) regardless of the AWS shim. Recorded as a "beyond ADR §1.2" iprange
+environment fact for future readers: **a project's own test-shim directory
+on PATH can silently shadow a "is the real tool installed" probe -- always
+resolve past known shim dirs, don't trust a bare `command -v`.**
+
+On-box empirical green (real FreeBSD, shipped binaries)
+----------------------------------------------------------
+Per the task's adjusted protocol (no local iprange on this Mac), ran the
+NEW suppress() standalone on the reachable FreeBSD box (root@10.0.0.1:2223,
+via `/bin/sh -s`, per the tcsh-login-shell rule) with its REAL
+`/usr/local/bin/iprange` (1.0.4) + `/usr/local/bin/grepcidr`. Copied
+pfblockerng.sh + a small driver (sources it with PFB_SOURCED=1, sets
+`pathaggregate=/usr/local/bin/iprange` since the sourced-for-test path skips
+the top-level init that would otherwise set it) to /tmp on the box; cleaned
+up afterward (`rm -rf /tmp/adr53p3 /tmp/adr53`). Results, byte-for-byte
+matching every shellspec expectation:
+
+  c-exact-24-carve       : 10.9.8.0/24 - 10.9.8.4/32 -> 8 lines (10.9.8.0/30,
+                            10.9.8.5, 10.9.8.6/31, 10.9.8.8/29, 10.9.8.16/28,
+                            10.9.8.32/27, 10.9.8.64/26, 10.9.8.128/25); .4
+                            absent; rc=0; errorlog empty.
+  c-two-holes-in-24      : same /24 minus {.4/32, .55/32} -> 12 lines, both
+                            holes absent, no duplicate lines.
+  d-containing-16-carve  : 10.0.0.0/16 - 10.0.3.4/32 -> 16 lines (10.0.0.0/23
+                            .. 10.0.128.0/17); the /16 line itself GONE (was
+                            byte-identical pre-Phase-3 -- the defect, now
+                            fixed); .4 host absent.
+  j-full-suppression     : member == suppression (203.0.113.7) -> member
+                            published EMPTY, rc=0, errorlog empty (the
+                            legitimate-empty-result contract, no grepcidr-
+                            style rc=1 quirk needed).
+  h-hostname-token       : suppression = {203.0.113.7/32, evil.example.com}
+                            -> dupfile (filtered suppression scratch) holds
+                            ONLY '203.0.113.7/32'; errorlog shows " Suppression
+                            TestList_v4: dropping malformed suppression entry
+                            [ evil.example.com ]"; member ends at {.5, .9}
+                            (.7 correctly suppressed despite the noise
+                            token) -- the hostname NEVER reached iprange.
+  b-bare-host-removed    : {.5,.7,.9} - .7/32 -> {.5,.9} (parity with the old
+                            grepcidr whole-token removal, now via iprange).
+  i-missing-binary       : pathaggregate pointed at a nonexistent path ->
+                            "Application [ iprange ] Not found. Cannot
+                            proceed."; member file unchanged; errorlog shows
+                            the guard message. (This exercises the SHELL-level
+                            executable guard, not iprange's own rc=1-on-
+                            unloadable-file behaviour -- that fact was
+                            independently empirically verified during this
+                            session's design investigation: `iprange
+                            /path/does-not-exist --except supp.txt` -> rc=1,
+                            "No such file or directory" / "Cannot load
+                            ipset". suppress()'s rc-gate treats ANY non-zero
+                            `irc` from iprange identically to this shell-
+                            level guard's outcome -- keep-previous + log --
+                            so both failure shapes are covered by the same
+                            gate; the shellspec stub-based case (i) proves
+                            the gate mechanically, this on-box run proves the
+                            guard position, and the earlier design-session
+                            probe proves iprange's own rc semantics.)
+
+Additional iprange behaviour discovered beyond ADR §1.2
+----------------------------------------------------------
+- An EMPTY `--except` file (0 valid suppression entries survived the
+  pre-filter) leaves the haystack UNCHANGED (rc=0) -- confirmed empirically
+  before writing the engine, so an all-malformed suppression list degrades
+  gracefully to "no suppression happened" rather than erroring.
+- An EMPTY haystack file (nothing to suppress from) also just publishes
+  empty, rc=0 -- same "no special-case" contract as the full-suppression case.
+- Multiple holes in ONE containing block are subtracted in a SINGLE
+  `--except` call with no per-hole bookkeeping needed on the caller's side --
+  this is what let the old dupfile/"dcheck" dedup-guard machinery be deleted
+  outright rather than adapted.
+- `tests/shell/spec_helper.sh` prepends its OWN `iprange` test stand-in onto
+  `PATH` for the (unrelated) AWS pre-script tests -- a project-specific
+  shimming gotcha (see "Red->green evidence" above), not an ADR-53 iprange
+  fact, but load-bearing for anyone writing a "is the real binary present"
+  probe in this test suite going forward.
+
+Spec counts (final state)
+--------------------------
+tests/shell/pfblockerng_suppress_spec.sh: 12 It blocks (was 11 in Phase 1),
+lettered a,b,c(x2),d,f,g(x2),h,i,j (reordered so the letters stay sequential
+after h/i/j were appended and the old letter (e) was retired -- its role
+split into the new (i) rc-gate case and the new (j) real-iprange
+legitimate-empty case, since suppress() no longer calls grepcidr at all so
+(e)'s original two Its had no engine left to exercise):
+  a - suppression file absent/empty: early return (unchanged assertions,
+      pathaggregate wiring)
+  b - bare-host + matching /32: removed (unchanged assertion, now via the
+      address-equality iprange STUB)
+  c - exact-/24: FLIPPED to 8/12-covering-CIDR carve assertions, REAL iprange,
+      skip-if-absent
+  d - containing-/16: FLIPPED to the 16-covering-CIDR carve (THE defect fix),
+      REAL iprange, skip-if-absent
+  f - masterfile resync under dedup=on: unchanged assertion, STUB
+  g - Suppression Stats table: unchanged assertions (Pre=3/Suppress=2/
+      Master=0 pattern still holds -- confirms the counter-removal refactor
+      preserved the stats-column semantics), STUB
+  h - NEW: hostname-shaped suppression token never reaches iprange (identity
+      STUB; asserts dupfile content directly + errorlog)
+  i - NEW: iprange rc!=0 (missing/unloadable) -> keep-previous + log
+      (fail-shim STUB)
+  j - NEW: full suppression -> empty publish, rc=0, no error (REAL iprange,
+      skip-if-absent)
+
+tests/shell/pfblockerng_fail_open_redirect_spec.sh: suppress()'s Class A (3
+Its -> 2 Its, the grepcidr-specific "rc=1 legitimate empty" case dropped --
+iprange has no equivalent quirk to simulate, it is covered by the primary
+spec's case j instead) and Class B (2 Its, unchanged assertions) switched
+from pathgrepcidr/GREPCIDR_MODE to pathaggregate/IPRANGE_MODE. duplicate()'s
+Class A/B, remove(), process255(), reputation_max() -- ALL untouched (grepcidr
+producer, unaffected by this ADR).
+
+tests/shell/pfblockerng_adr26_locale_spec.sh: one now-meaningless It block
+removed ("uses a portable seq for the 1..255 range" -- the `seq 255` call
+site it pinned was suppress()'s own explode loop, now deleted entirely, not
+reverted to `/usr/bin/jot`; `seq` no longer appears anywhere in
+pfblockerng.sh). All 5 `LC_ALL=C` sink-prefix gates re-verified still `has`
+their exact strings (the suppression-dedup sink line
+`data="$(LC_ALL=C sort -u "${pfbsuppression}")"` is untouched, byte-identical).
+
+CI tool wiring
+--------------
+.github/workflows/test.yml, `shell-tests` job: added an "Install iprange"
+step (`sudo apt-get install -y iprange`) right after the existing "Install
+jq" step, before "Install shellspec" -- same style/pattern. Verified this is
+ONE continuous job (not a separate job) so the later informational
+`shellspec --kcov --shell bash` re-run (further down the same job) also
+inherits the installed binary. Confirmed locally that the spec's skip-guard
+correctly triggers when iprange is absent (this Mac) via
+`pfb_real_iprange()`.
+
+Gate results
+------------
+- shellspec (full suite)     -> 259 examples, 0 failures, 8 skips (Phase 1/2
+  baseline was 260 examples/4 skips; this phase removed 1 stale ADR-26 It
+  block and added 4 new real-iprange skips: 260 - 1 = 259; 4 baseline skips +
+  4 new = 8). All 4 NEW skips report "needs the real iprange binary (apt-get
+  install iprange in CI; absent locally)" -- the house missing-tool pattern.
+- Red-check run (scratch, not committed) -> 11 examples, 3 failures, the
+  right 3, for the right reasons (see above).
+- shellcheck --severity=info src/usr/local/pkg/pfblockerng/pfblockerng.sh ->
+  clean, no output.
+- sh -n src/usr/local/pkg/pfblockerng/pfblockerng.sh -> clean.
+- sh scripts/git-env-scrub-guard.sh (meta-assertion) -> clean (one comment
+  wording in the sibling spec's docstring accidentally embedded the literal
+  substring "git " inside "empty-but-legit too" -- the guard's own documented
+  heuristic false-positive; reworded to "an empty result too", re-verified
+  clean).
+- .venv/bin/python -m pytest -q -> 2042 passed, 4 skipped (identical to
+  Phase 1/2's baseline; no Python touched this phase).
+- vendor/bin/phpunit -> 1861 tests, 15478 assertions, 1 failure, 4 skipped --
+  the exact documented environmental baseline (IpAddrDoublesTest::
+  testIsIpaddrv4 "leading-zero octets rejected", macOS inet_pton vs glibc).
+  No PHP touched this phase; sanity-only run.
+- On-box empirical (FreeBSD, real binaries) -> all 7 driven scenarios match
+  the shellspec expectations byte-for-byte (see above).
+
+Scope confirmation
+-------------------
+`git status --porcelain` (working tree, on top of the Phase 1+2 commits):
+exactly 5 files touched --
+  .github/workflows/test.yml
+  src/usr/local/pkg/pfblockerng/pfblockerng.sh
+  tests/shell/pfblockerng_adr26_locale_spec.sh
+  tests/shell/pfblockerng_fail_open_redirect_spec.sh
+  tests/shell/pfblockerng_suppress_spec.sh
+No v6 path touched (pfb_suppress_file_v6 doesn't exist yet -- Phase 5's job).
+No UI touched (pfblockerng_ip.php's `/32 or /24 only` validation and help
+text are unchanged -- Phase 4's job). No caller-gating change in
+pfblockerng.inc (16700-16711 region untouched -- v4-only invocation stays
+until Phase 6). grepcidr's OTHER call sites (duplicate(), the standalone
+whole-token removal elsewhere) untouched -- only suppress()'s own producer
+changed.
+
+Go-ahead for Phase 4
+---------------------
+Phase 3 is complete and green (locally + on real FreeBSD hardware + the CI
+tool wiring in place for the fan-out). Phase 4 (v4 UI mask lift, `/8`-`/32`,
+pure PHP -- `pfb_validate_suppression_line()` + `pfblockerng_ip.php` +
+PHPUnit red->green) can proceed independently: it touches
+`pfblockerng_extra.inc`/`pfblockerng_ip.php`/PHPUnit, none of which this
+phase touched. The engine now accepts ANY mask already (iprange is
+mask-agnostic, per the ADR) -- Phase 4 is purely about lifting the UI's
+input-validation ceiling and updating help text, with no suppress() changes
+needed.

--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/04_Results.txt
@@ -1,0 +1,177 @@
+ADR-53 Phase 4 — v4 UI mask lift (/8-/32) with an extracted pure validator
+============================================================================
+
+STATUS: Done. v4suppression textarea now accepts /8-/32 (was /32-or-/24-only)
+through a new pure, PHPUnit-tested validator; help text updated; page renders
+clean. Red->green proven for the exact behaviour change.
+
+New validator
+-------------
+`pfb_validate_suppression_line(string $line, string $family): ?string`
+(pfblockerng_extra.inc, appended after pfb_due_ledger_is_pending(), before the
+logger()/localize_text() CE-2.8 fallback block). Signature matches the phase
+spec exactly. PURE -- no config access, no I/O; only the pfSense is_subnetv4()
+predicate (already doubled in tests/php/pfsense_doubles.php -- no new double
+needed).
+
+Behaviour, one call per raw textarea line (as split on "\r\n", untrimmed):
+  - Blank, or starts with '#' -> NULL (skip, no-op -- matches today's `continue`).
+  - An inline "# comment" suffix is stripped via the SAME `preg_split('/(?=#)/')`
+    the old inline code used, so "10.0.0.1/32 # example.com" validates on
+    "10.0.0.1/32" only (tolerated shape, unchanged).
+  - family == 'ipv6' -> ALWAYS returns an error (see "v6 contract" below).
+  - family == 'ipv4':
+      1. If the entry has a '/' followed by a purely-numeric mask, and that
+         mask is < 8 or > 32 -> return the RANGE message (see below). This
+         check runs BEFORE the general subnet-shape check so an
+         out-of-range-but-well-formed mask (/7, /33) gets the message naming
+         the accepted range, not the generic malformed-input one.
+      2. Else if `is_subnetv4($entry)` fails (bad octets, no '/', non-numeric
+         mask, etc.) -> return the generic SUBNET message.
+      3. Else -> NULL (valid).
+
+Message texts (exact, chosen to match neighbour tone/length -- no existing
+test pinned the old wording, so free to update; new text still follows the
+"IPv{4,6} Suppression: <detail>" pattern already in use):
+  - Range violation (floor /7 or below, ceiling /33 or above):
+    "IPv4 Suppression: Invalid mask [ <entry> ]. Mask must be between /8 and /32."
+  - Generic malformed input (unchanged from today, verbatim):
+    "IPv4 Suppression: Invalid IPv4 subnet address defined [ <entry> ]"
+  - IPv6 (Phase-6-not-yet contract):
+    "IPv6 Suppression: IPv6 suppression is not yet supported [ <entry> ]."
+
+v6-not-yet contract (Phase 6 must flip this)
+---------------------------------------------
+`SuppressionValidatorTest::testIpv6NotYetSupported()` asserts
+`pfb_validate_suppression_line('2001:db8::1/64', 'ipv6')` returns a NON-NULL
+error. This is the deliberate, pinned "not implemented yet" red for Phase 6:
+when Phase 6 wires the pure v6 diff engine + config + UI, it must replace the
+unconditional `if ($family === 'ipv6') { return ...; }` branch with the real
+v6 validation (masks /32-/128 per ADR §2.1) and this exact test must then be
+rewritten to assert NULL for valid v6 lines (and a range message for
+out-of-range v6 masks, mirroring the v4 shape) -- i.e. this test is Phase 6's
+red-check tripwire, not a permanent contract.
+
+Red->green evidence (the exact CLAUDE.md-mandated proof)
+-----------------------------------------------------------
+Wrote the full test file first (tests/php/SuppressionValidatorTest.php, 12
+tests), THEN implemented the function with TODAY'S exact rule verbatim
+(mask must be === '/32' or === '/24', migrated unchanged from the inline
+POST-handler loop) as a temporary stand-in, ran the suite, and got:
+
+  4 failures (12 tests, 14 assertions):
+    1) testSlash16NowValid       -- 'Invalid mask [ 10.0.0.0/16 ]... /32 or /24
+       only.' is not null (old rule rejects the new /16 case)
+    2) testSlash8FloorNowValid   -- same, for '10.0.0.0/8'
+    3) testSlash7BelowFloorRejected  -- error message doesn't yet contain '/8'
+       (old wording names /32-or-/24, not the new accepted range)
+    4) testSlash33AboveCeilingRejected -- same, message doesn't contain '/8' yet
+
+All 4 failures are for the EXACTLY documented reason (the old /32-or-/24-only
+rule, and its old wording). The other 8 tests (legacy /32 + /24 valid, bad
+octet, non-CIDR garbage, comment/blank skip, trailing-comment tolerance, v6
+not-yet) were ALREADY green under the old-rule stand-in, proving nothing else
+regressed by the extraction itself.
+
+Then replaced the mask check with the widened /8-/32 range logic (the block
+shown above) and re-ran: 12 tests, 16 assertions, 0 failures -- full green,
+including the /16 + /8 red->green pair and both /7 and /33 now naming the
+accepted range.
+
+Call-site swap (pfblockerng_ip.php:147-155)
+---------------------------------------------
+The 19-line inline validation loop (comment/blank skip + inline preg_split +
+mask compare + is_subnetv4 check, TWO separate `$input_errors[]` pushes per
+line) collapsed to a 6-line loop that calls the extracted validator once per
+line and pushes at most ONE message per line (a minor, intentional
+simplification: the old code could push both a mask error AND a subnet error
+for the same malformed line with no '/' at all; the new single-message-per-line
+contract returns the more specific message first -- range message when the
+mask parses as an out-of-bounds number, else the generic subnet message).
+This does not change what is ACCEPTED vs REJECTED (the thing pinned by tests
+and the ADR contract), only de-duplicates redundant per-line error text.
+
+Help-text wording chosen (two blocks per the phase's REQUIRED READING pointers,
+both updated -- "/32 or /24" -> "/8 through /32" pattern, matching neighbour
+tone/length):
+  1. Suppression toggle help (pfblockerng_ip.php:358, was :369):
+     "Only for IPv4 lists (/32 and /24)." -> "Only for IPv4 lists (/8 through /32)."
+     And the same block's GeoIP/whitelist-alias caveat (was :373):
+     "For GeoIP/Blocked IPs in a CIDR other than /32 or /24, will need a
+     'Whitelist alias'..." -> "For GeoIP/Blocked IPs in a CIDR broader than /8,
+     will need a 'Whitelist alias'..." (accurate under the new floor: only a
+     block coarser than /8 -- essentially never realistic -- still needs the
+     workaround).
+  2. `$suppression_text` (IPv4 Suppression section, was :500 + :511):
+     "This suppression list is for [ /32 or /24 ] IPv4 addresses only!" ->
+     "This suppression list is for [ /8 through /32 ] IPv4 addresses only!"
+     "Note: When manually adding an IPv4 address [ /32 or /24 only! ]..." ->
+     "Note: When manually adding an IPv4 address [ /8 through /32 only! ]..."
+
+Tier A / Tier B UI test check
+-------------------------------
+- Tier A `ui_render`'s PAGE_TABLE marker set for the "ip" page is
+  `("IP Configuration", "ASN configuration", "Aggregated Aliases", "Alias
+  Table Apply Mode")` (tests/smoke/ui/test_render_smoke.py) -- none of these
+  reference the mask wording, so NO marker update was needed. Verified via
+  `.venv/bin/python -m pytest tests/smoke/ui -m ui_render
+  --override-ini="addopts=" --collect-only -q` -> 79 tests collected (105
+  deselected), no collection errors, IP page's render case present.
+  `--collect-only` over the FULL `tests/smoke/ui` tree -> 184 tests collected,
+  0 errors. Per the orchestrator's UI-tier note, the LIVE Tier A run for
+  pfblockerng_ip.php rides Phase 9's CE+Plus fan-out (no live box touched
+  from this worktree).
+- Found and fixed a STALE Tier B (`ui_e2e`, non-PR-blocking) assertion:
+  `tests/smoke/ui/test_functional.py::
+  test_ip_v4suppression_mask_validation_base64_and_reject_unchanged` asserted
+  that a `/16` mask ABORTS the save -- true under the old rule, now WRONG
+  (a /16 is valid post-Phase-4). Left uncorrected it would have been a live
+  regression the very next time Phase 9's Tier B fan-out ran, testing this
+  phase's own change against stale expectations. Rewrote it to: (1) keep the
+  legacy /24-valid assertion, (2) ADD a new /16-now-valid assertion (proving
+  the widened range persists via the base64 store), (3) swap the rejection
+  case from /16 to /7 (now below the /8 floor -- the genuinely-still-invalid
+  case). Not run live from here (per the orchestrator's constraint); it will
+  execute for real under Phase 9's fan-out.
+
+Gate results
+------------
+- vendor/bin/phpunit -> 1873 tests, 15494 assertions, 1 failure, 4 skipped --
+  the exact documented environmental baseline (IpAddrDoublesTest::
+  testIsIpaddrv4 "leading-zero octets", macOS inet_pton). Test count is P3's
+  1861 + 12 new SuppressionValidatorTest cases = 1873, confirming no other
+  test file changed.
+- php -l on both touched files -> clean.
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> clean, no output.
+- vendor/bin/phpstan --memory-limit=1G -> "[OK] No errors" (28/28 files).
+- .venv/bin/python -m pytest -q -> 2042 passed, 4 skipped (identical to P1-3's
+  baseline; no Python touched this phase, tests/smoke/ui edit doesn't run
+  under the default testpaths without -m ui_render/-k).
+- .venv/bin/ruff check . -> "All checks passed!"; ruff format --check . ->
+  "158 files already formatted" (test_functional.py edit already compliant).
+- shellspec (full suite) -> 259 examples, 0 failures, 8 skips -- byte-identical
+  to P3's baseline (no shell touched this phase).
+- Tier A ui_render collection -> 79/184 selected, 0 errors (see above).
+
+Scope confirmation
+-------------------
+`git diff --stat` vs the P3 commit: exactly 3 files touched + 1 new --
+  src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc  (+54, new validator)
+  src/usr/local/www/pfblockerng/pfblockerng_ip.php     (-19/+8, call site + 2 help texts)
+  tests/smoke/ui/test_functional.py                    (stale Tier B assertion fix)
+  tests/php/SuppressionValidatorTest.php               (new, 12 tests)
+No shell touched. No alerts page touched (Phase 8's job). No v6 engine/config/
+UI touched (Phase 5/6's job) -- the v6 branch of the new validator is a
+deliberate, explicitly-pinned "not yet" stub, not an implementation.
+
+Go-ahead for Phase 5
+---------------------
+Phase 4 is complete and green (PHPUnit, PHPCS, PHPStan, pytest, ruff,
+shellspec, UI-test collection). Phase 5 (pure v6 diff engine, no UI -- parse
+lines to fixed-width binary ranges, subtract suppress ranges, emit remainders
+via `ip_range_to_subnet_array()`, never iprange per §1.2) can proceed
+independently: it touches new pure-PHP engine code, not
+`pfblockerng_extra.inc`'s validator, `pfblockerng_ip.php`, or any test file
+this phase touched. Phase 6 (v6 config/UI wiring) is the one that must revisit
+`pfb_validate_suppression_line()`'s `family === 'ipv6'` branch and flip
+`testIpv6NotYetSupported()`.

--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/05_Results.txt
@@ -1,0 +1,240 @@
+ADR-53 Phase 5 -- v6 set-diff engine (pure PHP, TDD)
+=====================================================
+
+STATUS: Done. New, pure IPv6 CIDR set-subtraction engine landed in
+pfblockerng_extra.inc, unit-tested off-appliance. No caller wired yet (that is
+Phase 6's job) -- pfblockerng.inc, pfblockerng_ip.php and every other src/ file
+are untouched this phase. Only 3 files touched: pfblockerng_extra.inc (new
+engine), tests/php/pfsense_doubles.php (new faithful double for
+ip_range_to_subnet_array + its two PEAR-dependent callees), and the new
+tests/php/V6CidrSubtractTest.php.
+
+Function signatures + error-reporting shape
+--------------------------------------------
+    pfb_cidr_subtract_v6(array $cidrs, array $holes, ?array &$errors = null): array
+    pfb_suppress_file_v6(string $file, string $suppfile): bool
+
+Chosen error shape: a simple by-ref `&$errors` out-param (default NULL,
+overwritten with `[]` on every call), collecting the raw malformed token
+strings skipped from EITHER array (both sides pooled, order preserved:
+$cidrs' malformed tokens first, then $holes'). A blank line or a '#'-led
+comment is a silent no-op (mirrors pfb_validate_suppression_line's existing
+tolerance for the persisted suppression file) and is NEVER added to $errors.
+Nothing throws -- a malformed token anywhere never aborts the rest of the
+file, per the phase spec.
+
+Internal helpers (pfblockerng_extra.inc, all PURE, no I/O):
+    pfb_v6_cidr_to_range(string $token, ?bool &$is_blank = null): ?array
+        Parses one 'addr/bits' token to a [start_bin, end_bin] pair of
+        fixed-width 128-char '0'/'1' strings (inet_pton() + per-byte
+        sprintf('%08b', ...) -- no GMP, per the phase spec).
+    pfb_v6_bin_inc / pfb_v6_bin_dec(string $bin): ?string
+        +/-1 on a 128-bit binary string via the same find-the-flip-bit
+        technique pfSense's own ip_range_to_subnet_array() uses internally
+        (NULL on overflow/underflow at the top/bottom of the address space).
+    pfb_v6_bin_to_addr(string $bin): string
+        Binary string -> textual address (pack + inet_ntop()).
+    pfb_v6_emit_covering_cidrs(string $start_bin, string $end_bin): array
+        bin_to_addr() both ends, then calls the REAL pfSense
+        ip_range_to_subnet_array() (never redefined in production code).
+
+Correctness-critical design note: EVERY comparison between two 128-char
+binary strings goes through strcmp(), never the bare <, >, <=, >=, min(),
+max() operators. A 128-digit string of only '0'/'1' characters is a PHP
+"numeric string", and PHP's own comparison operators can silently coerce two
+numeric strings through a lossy float/overflow path for a string this long
+-- strcmp() is the only byte-exact comparison here. (Verified empirically
+that PHP 8's `<`/`>` on adversarial 128-char digit strings behaved
+correctly in a couple of hand-built cases, but this is undocumented,
+version-sensitive behaviour I am not willing to depend on for NEW
+production code -- vendored upstream code that already relies on it, in the
+double, is left untouched since it is a faithful copy, not something I
+wrote.)
+
+Algorithm shape (matches the phase's own action-plan wording): parse both
+arrays to ranges -> sort holes once, up front -> for each entry
+independently, clip every intersecting hole to the entry's bounds -> walk
+the (pre-sorted) intersecting holes left-to-right, emitting the covering
+CIDRs for the gap before each hole via pfb_v6_bin_dec()/pfb_v6_bin_inc(),
+then a final trailing gap after the last hole -> an entry with zero
+intersecting holes re-emits unchanged (still routed through
+ip_range_to_subnet_array() so notation stays consistent, ADR-53 §2.3 fork 4).
+
+pfb_suppress_file_v6() contract (§2.2 fail-safe): EITHER $file or $suppfile
+missing/unreadable -> FALSE, $file left byte-identical (both inputs treated
+symmetrically as required -- this differs from the v4 shell suppress(),
+where "no suppression file" is the caller-level opt-out gate; Phase 6's
+caller is expected to gate on "is v6suppression configured" the same way
+v4's caller gates, exactly as today, so this engine function itself just
+needs both its named inputs present). A legitimate full suppression
+publishes an EMPTY file and returns TRUE (never FALSE -- the §2.2
+empty-is-legit contract). Non-CIDR lines are dropped and logged via
+pfb_logger(..., 2) (pfBlockerNG log + error log, matching the logtype used
+by comparable validation-warning call sites elsewhere in pfblockerng.inc).
+Publish is same-directory tmp+rename (atomic POSIX rename), mirroring the
+pfb_due_ledger_write_entry() pattern already in this file.
+
+Upstream verification (dated-ref protocol, CLAUDE.md)
+-------------------------------------------------------
+Fetched src/etc/inc/util.inc from the public pfsense/pfsense GitHub mirror at
+three refs and diffed ip6_to_bin(), bin_to_ip6(), ip_range_to_subnet_array(),
+ip_range_to_address_array() and ip_range_size_v4() byte-for-byte:
+
+  - CE 2.8.0 (min supported)  -- ed6c2eb84595aab998c3b3efaf16d226bd62c38d
+    (youngest master commit at/before the 2025-05-28 release date, confirmed
+    via the Netgate blog post + docs.netgate.com release-notes "last updated"
+    stamp; resolved via the GitHub commits API with `until=`, per CLAUDE.md's
+    "the public mirror lacks RELENG tags, use dated commits").
+  - CE 2.8.1 (latest released) -- 97f9eb5c819fd7f0c5f232d2581e5080be1cb18a
+    (youngest master commit at/before the 2025-09-04 release date, confirmed
+    via the Netgate blog post's dateline). Went one release beyond the
+    "min-CE + master" floor the orchestrator set, since it was one more free
+    API call and is the currently-shipping CE.
+  - master tip -- 9363ac5b8651a1c7a333180425ce7719070f95f9 (committer date
+    2026-03-31; the mirror's `pushed_at` matches, so this is genuinely current
+    tip, not a stale cache).
+
+All five functions were BYTE-IDENTICAL across all three refs (diffed via a
+brace-depth-counting Python extractor, not eyeballing). This is 10 months of
+pfSense history with zero change to this code -- consistent with the phase
+prompt's expectation ("ancient pfSense code -- expect identical bodies").
+
+DEVIATION flagged: did NOT individually check each pfSense Plus release
+(25.07/.1, 25.11/.1, 26.03/.1) -- the orchestrator's brief explicitly narrowed
+verification to "min-CE 2.8.0 and current master at minimum", which I
+followed, adding CE 2.8.1 as a bonus rather than the full Plus fan-out. Given
+the function's demonstrated 10-month zero-change history and that master tip
+(2026-03-31) postdates every listed Plus release, the risk of an undetected
+Plus-only divergence is low, but this is a real, disclosed scope reduction
+relative to CLAUDE.md's full per-release protocol, not an oversight -- flagged
+for the orchestrator's judgement call, not silently assumed away.
+
+Faithful double + vendoring (tests/php/pfsense_doubles.php)
+--------------------------------------------------------------
+ip_range_to_subnet_array() is vendored VERBATIM (byte-diffed against the
+fetched 2.8.0 source after re-indentation for its function_exists() wrapper
+-- confirmed identical except for that one added indent level). Its two
+callees are NOT vendored verbatim because upstream implements them via PEAR's
+Net_IPv6 (Uncompress()/compress()), which does not exist off-appliance (the
+same constraint the file's header already documents for is_ipaddrv6()):
+ip6_to_bin() and bin_to_compressed_ip6() are faithful REIMPLEMENTATIONS using
+PHP's builtin inet_pton()/inet_ntop() (pack/unpack + per-byte bit expansion;
+inet_ntop() already implements RFC 5952 canonical compression, so the output
+is byte-identical to Net_IPv6::compress() for any address inet_pton() itself
+accepts). No new stub was needed in stubs/pfsense/util.php -- ip6_to_bin,
+bin_to_ip6, bin_to_compressed_ip6 and ip_range_to_subnet_array were already
+declared there (pre-existing, empty-bodied PHPStan stubs).
+
+Double vector pins (V6CidrSubtractTest::testDoubleVectorV4Aligned/
+V4NonAlignedEdgeCase/V6Aligned/V6NonAlignedEdgeCase) assert hand-derivable
+outputs so a stale/wrong double fails loudly:
+  - v4 aligned:      ip_range_to_subnet_array('10.0.0.0','10.0.0.3')
+                        == ['10.0.0.0/30']
+  - v4 non-aligned:  ip_range_to_subnet_array('10.0.0.1','10.0.0.2')
+                        == ['10.0.0.1/32','10.0.0.2/32']
+  - v6 aligned:      ip_range_to_subnet_array('2001:db8::','2001:db8::3')
+                        == ['2001:db8::/126']
+  - v6 non-aligned:  ip_range_to_subnet_array('2001:db8::1','2001:db8::2')
+                        == ['2001:db8::1/128','2001:db8::2/128']
+
+Red -> green evidence
+-----------------------
+Wrote the full test file first (tests/php/V6CidrSubtractTest.php, 25 tests),
+then `git stash push` on JUST the two production files (pfblockerng_extra.inc
++ pfsense_doubles.php), leaving the new test file in place, and ran:
+
+    vendor/bin/phpunit --filter V6CidrSubtractTest
+    -> ERRORS! Tests: 25, Assertions: 36, Errors: 25.
+       Every failure: "Error: Call to undefined function pfb_cidr_subtract_v6()"
+       or "...pfb_suppress_file_v6()" or "...ip_range_to_subnet_array()" --
+       the exact documented reason (the engine/double do not exist yet).
+
+`git stash pop` restored the implementation; re-ran the same filter:
+
+    -> OK (25 tests, 254 assertions).
+
+Bug found DURING the perf measurement (not by a unit test) -- fixed
+-------------------------------------------------------------------
+The first draft accumulated output via `$out = array_merge($out, ...)` inside
+the per-entry loop. On the 100k-line synthetic benchmark (see below) this
+measured 22.4s -- a classic O(n^2) blowup (array_merge recopies the whole
+accumulated array on every call). Root-caused via the measurement itself,
+fixed by replacing all three call sites with `array_push($out, ...$chunk)`
+(amortised O(k) append for k new elements), and re-verified: same 25/25 green
+PLUS the 100k-line case dropped from 22.4s to ~1.24s (18x). Left an inline
+comment at the fix site naming the anti-pattern and the before/after numbers
+so it isn't silently reintroduced.
+
+Performance measurement (ADR-53 §7 bound: 100k lines / <5s)
+--------------------------------------------------------------
+One-off harness (not committed -- informational per the phase spec's "a small
+harness note" option), run via `tests/php/bootstrap.php` + a synthetic
+100,000-line v6 member file (one /128 host per line, spread across 100,000
+distinct /64 prefixes -- mimicking a realistic DNSBL-derived IPv6 host feed)
+and a 100-line suppression file (holes scattered across a subset of the same
+prefixes so real carve work happens, not just pass-through):
+
+    ok=true elapsed=1.2398s input_lines=100000 supp_lines=100 output_lines=99900
+    (re-run 3x for stability: 1.2383s / 1.2388s / 1.2390s -- consistent)
+
+Machine: Apple M1 Pro (macOS 26.5.1), PHP 8.5.7 CLI (dev box; appliance-class
+hardware is presumably slower, but 1.24s leaves ~4x headroom under the 5s
+bound even accounting for a slower CPU). Well within the §7 reject bound --
+no LOUD flag needed; the engine is ready to wire in Phase 6 as-is.
+
+Test counts / gate results
+-----------------------------
+- vendor/bin/phpunit -> 1898 tests, 15748 assertions, 1 failure, 4 skipped --
+  the exact documented environmental baseline (IpAddrDoublesTest::
+  testIsIpaddrv4 "leading-zero octets", macOS inet_pton). Test count is P4's
+  1873 + 25 new V6CidrSubtractTest cases = 1898, confirming no other test
+  file changed.
+- php -l on all 3 touched/new files -> clean.
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> clean, no output (the two
+  test files are outside phpcs.xml.dist's scanned paths, as expected).
+- vendor/bin/phpstan --memory-limit=1G -> "[OK] No errors" (28/28 files).
+- .venv/bin/python -m pytest -q -> 2052 passed, 4 skipped. NOTE: P4's handoff
+  recorded "2042 passed, 4 skipped" as the untouched baseline; this run (and
+  a repeat) both show 2052 -- a +10 drift with the SAME skip count and ZERO
+  failures, on a branch/worktree where no Python file was touched this phase
+  (git diff confirms only the 2 PHP files + 1 new PHP test file changed).
+  Recorded honestly rather than silently matching P4's number: this is
+  environment/collection drift unrelated to this phase's change, not a
+  regression -- flagging for the orchestrator rather than assuming it away.
+- .venv/bin/ruff check . -> "All checks passed!"; ruff format --check . ->
+  "159 files already formatted" (also +1 vs P4's 158, consistent with the
+  same untouched-Python-tree drift noted above).
+- shellspec (full suite) -> 259 examples, 0 failures, 8 skips -- byte-identical
+  to P3/P4's baseline (no shell touched this phase).
+- Diff-read: confirmed pfb_cidr_subtract_v6() and all its pfb_v6_* helpers
+  are 100% pure (no $pfb/$g access, no file/network I/O, no logging). The
+  ONLY side effect anywhere in this phase's code is pfb_suppress_file_v6()'s
+  target-file write (tmp+rename) plus its companion pfb_logger() calls for
+  dropped tokens -- exactly the one sanctioned I/O boundary the phase spec
+  calls for.
+
+Scope confirmation
+-------------------
+`git diff --stat`: exactly 2 files modified + 1 new --
+  src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc  (+295, new engine)
+  tests/php/pfsense_doubles.php                        (+191, new double)
+  tests/php/V6CidrSubtractTest.php                     (new, 25 tests)
+No pfblockerng.inc, pfblockerng_ip.php, or any other caller touched -- v6
+suppression is NOT wired to anything yet (Phase 6's job). No shell touched.
+No new stub needed in stubs/pfsense/ (the four util.inc functions this phase
+depends on were already stubbed there).
+
+Go-ahead for Phase 6
+----------------------
+Phase 5 is complete and green (PHPUnit, PHPCS, PHPStan, pytest, ruff,
+shellspec). The engine (pfb_cidr_subtract_v6 + pfb_suppress_file_v6) is pure,
+fail-safe, measured fast enough, and ready to wire. Phase 6 (v6 config + UI +
+update-flow wiring) can proceed: register `v6suppression` (plain blob +
+sniff path + round-trip test), add the v6 textarea to pfblockerng_ip.php
+(validator family=v6, masks /32-/128), flip pfb_validate_suppression_line()'s
+`family === 'ipv6'` branch (currently an unconditional "not yet supported"
+stub per P4 -- SuppressionValidatorTest::testIpv6NotYetSupported() is the
+explicitly-pinned tripwire P4 left for this), have
+pfb_create_suppression_file() write pfbsuppression_v6.txt, and call
+pfb_suppress_file_v6() from the alias-build loop for `_v6` member files under
+the v4-equivalent gates (suppression enabled + feed-changed).

--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/06_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/06_Results.txt
@@ -1,0 +1,220 @@
+ADR-53 Phase 6 -- v6suppression: config + UI + update-flow wiring
+====================================================================
+
+STATUS: Done. v6suppression now exists end-to-end: registered config key, IP-page
+UI section, pfbsuppression_v6.txt file, and the alias-build loop's direct-PHP
+invocation of Phase 5's pfb_suppress_file_v6() engine for `_v6` member files --
+the same UX and gating shape as v4, mirrored (not shared) per the ADR's
+per-family split. Red->green proven for all three layers named in the phase
+prompt (validator, config round-trip, wiring).
+
+Key registered
+--------------
+`v6suppression` in pfb_cfg_registry() (pfblockerng_extra.inc), right after
+v4suppression's entry:
+    'v6suppression' => [
+        'section'       => $ip,   // installedpackages/pfblockerngipsettings/config/0
+        'default'       => '',
+        'read_adapter'  => NULL,
+        'write_adapter' => NULL,
+        'since'         => '4.0.0',
+    ],
+Plain blob, same base64/newline shape as v4suppression -- but `since` = '4.0.0'
+(current dev version), NOT v4suppression's legacy '1.0.0': this is a genuinely
+NEW key with no pre-registry era to inherit from, unlike v4's migration-era blob.
+Sniff `$registeredPaths` (tests/phpcs/PfBlockerNG/Sniffs/Config/
+RequireConfigGatewaySniff.php) gained the matching path.
+
+supptxt_v6 path var
+--------------------
+`$pfb['supptxt_v6']` = "{$pfb['dbdir']}/pfbsuppression_v6.txt", defined beside
+`$pfb['supptxt']` at pfblockerng.inc:95 (top-of-file `$pfb` array build).
+pfb_create_suppression_file() (pfblockerng.inc) now decodes+writes BOTH files:
+v4suppression -> supptxt (unchanged), v6suppression -> supptxt_v6 (new,
+identical decode/write/unlink-when-empty shape). pfb_clear_contents() (the
+package's cleanup routine) also unlinks supptxt_v6 alongside supptxt.
+
+UI section
+----------
+New collapsible Form_Section on pfblockerng_ip.php, immediately after the
+existing "IPv4 Suppression" section:
+  - Section id: `IPv6_Suppression_customlist` (mirrors `IPv4_Suppression_customlist`)
+  - Title: "IPv6 Suppression"
+  - Textarea field name: `v6suppression` (same widget shape/attrs as v4's:
+    columns=90, rows=15, wrap=off, background styling)
+  - Help text: masks "/32 through /128"; the alerts-"+"-icon sentence from the
+    v4 help text was deliberately OMITTED for v6 (that flow isn't wired for v6
+    yet -- Phase 8's job; stating it now would be false).
+  - The shared "Suppression" toggle's help text (governs BOTH families, no new
+    checkbox per the phase constraints) gained the v6 range: "For IPv4 lists
+    (/8 through /32) and IPv6 lists (/32 through /128)." (was "Only for IPv4
+    lists...").
+  - $pconfig['v6suppression'] read (base64_decode, mirrors v4's line exactly)
+    + POST validate (family='ipv6' per line, one $input_errors push max) + POST
+    save (base64_encode) added at the same call sites as v4's.
+  - PHPStan note: the v6 validation loop skips the vestigial `!empty($array)`
+    wrapper v4's block has (explode() never returns an empty array, so that
+    check is always true) -- avoids replicating the pre-existing
+    empty.variable finding already baselined for v4suppression at the
+    identical call shape (phpstan-baseline.neon:917), without touching v4's
+    baselined line.
+
+Wiring gates (alias-build loop, pfblockerng.inc ~16700 region)
+-----------------------------------------------------------------
+Added immediately after the existing v4 suppression block (`$vtype == '_v4'`),
+before `$alias_ips .= file_get_contents(...)` -- the v4 block itself is
+BYTE-IDENTICAL, untouched (confirmed via diff read):
+
+  - Header (print-once): `if ($pfbrunonce && $pfb['supp']=='on' && $vtype=='_v6'
+    && $pfb['supp_update'])` -- writes a "Suppression Stats (v6)" table header
+    directly to $pfb['log'] (no exec/shell -- ADR-53 SS2.1 "direct PHP call, no
+    shell round-trip"). Reuses the SAME $pfbrunonce flag v4 gates its own header
+    with: it resets TRUE at the top of EVERY vtype pass (the existing
+    "$pfbrunonce = TRUE;" above the alias loop, unconditional on vtype), so it
+    is still fresh and available during the '_v6' pass, untouched by the v4
+    branch's own consumption of it during the '_v4' pass. This directly
+    "respects the suppressheader print-once behaviour" the phase prompt asked
+    for, with no new flag variable.
+  - Body: `if ($pfb['supp']=='on' && $vtype=='_v6' && $pfb['supp_update'] &&
+    $pfbadv && in_array($alias, $final_alias_old) && is_readable(supptxt_v6) &&
+    filesize(supptxt_v6) > 0)` -- the same gate shape as v4 (suppression
+    enabled, this pass, update-on-change toggle, deny-folder alias
+    ($pfbadv), feed-changed ($final_alias_old membership)) PLUS an explicit
+    "is v6suppression actually configured" check (is_readable + filesize>0) --
+    the caller-level opt-out gate Phase 5's handoff explicitly asked Phase 6 to
+    add (pfb_suppress_file_v6() itself has no such gate; it fails-safe FALSE on
+    ANY missing/unreadable input, which is not the same as "nothing to do").
+    On this gate: pre-count the member file, call pfb_suppress_file_v6()
+    directly (no exec), post-count on success and append one
+    "%-20s %-10s %-10s\n" stats row (List/Pre/Suppress -- no Master column,
+    since dedup/masterfile bookkeeping is v4-only per SS1.2/ADR text); on
+    failure, pfb_logger() the failure (keep-previous is pfb_suppress_file_v6's
+    own contract -- it never touches the target file on a fail-safe path).
+  - No masterfile/dedup resync for v6 anywhere (deliberately absent, per SS1.2).
+
+Tier A / Tier B
+---------------
+- Tier A: added "IPv6 Suppression" to the ip page's PAGE_TABLE marker tuple
+  (tests/smoke/ui/test_render_smoke.py) for sweep continuity, PLUS a dedicated
+  stricter test `test_ip_page_renders_v6_suppression_section` (GETs the page,
+  asserts the section title, the `name="v6suppression"` textarea, AND that the
+  pre-existing "IPv4 Suppression" sibling still renders) -- the PAGE_TABLE
+  tuple alone is an `any()` match (see render_oracle.evaluate_render), so the
+  dedicated test is the real proof this specific section renders, following the
+  same pattern as the existing `test_ip_page_renders_aggregate_select`.
+- Tier B (REQUIRED -- new field, multi-step save->persist flow):
+  `test_ip_v6suppression_mask_validation_base64_and_reject_unchanged`
+  (tests/smoke/ui/test_functional.py), mirroring the v4 sibling test exactly:
+  valid /128 host mask stores base64 verbatim; valid /64 containing block also
+  stores (any in-range mask, not just /128); empty clears to ''; /31 (below the
+  /32 floor) aborts the WHOLE save -> config unchanged.
+- Collection proven (no live box touched, per the orchestrator's constraint):
+    .venv/bin/python -m pytest tests/smoke/ui --collect-only -q --override-ini="addopts="
+      -> 186 tests collected, 0 errors (was 184 pre-phase; +2 = the two new tests)
+    -m ui_render --collect-only -> 80/186 selected (was 79/184; +1, the new Tier A test)
+    -m ui_e2e    --collect-only -> 107/186 selected (the new Tier B test is in this set)
+  Live CE+Plus runs ride Phase 9's fan-out, per the orchestrator's UI-tier note.
+
+Tests FIRST (red->green) -- all three layers named in the phase prompt
+--------------------------------------------------------------------------
+1. Validator flip (tests/php/SuppressionValidatorTest.php): replaced
+   testIpv6NotYetSupported() (P4's pinned tripwire) with 10 new v6 tests
+   (valid /64, /128, /32 floor; /31 and /129 rejected naming the range; garbage;
+   missing mask; comment/blank tolerance). Temporarily reverted
+   pfb_validate_suppression_line()'s v6 branch to the pre-Phase-6
+   "not yet supported" stub and re-ran: 6 FAILURES, each for the exact
+   documented reason (old stub message, or missing '/32'/'128' in the error
+   text). Restored the real implementation: 21/21 green.
+2. Config round-trip (tests/php/CfgGatewayTest.php): added
+   testV6SuppressionAbsentKeyReturnsDefaultEmptyString +
+   testV6SuppressionRoundTrips (mirrors the v4 pair exactly) + added
+   'v6suppression' to the registered-inventory list. Temporarily removed the
+   v6suppression registry entry and re-ran the filter: 2 ERRORS
+   (InvalidArgumentException: key not in the field registry -- the exact
+   documented reason). Restored the entry: 4/4 green (the 2 CfgGatewayTest
+   cases + 2 CreateSuppressionFileTest cases matched by the same filter
+   substring, unaffected by the registry -- confirming they exercise a
+   different layer).
+3. Wiring (tests/php/CreateSuppressionFileTest.php, NEW FILE -- grep of
+   tests/php/ found pfb_create_suppression_file() previously uncovered by
+   PHPUnit, so this phase covers BOTH families per the phase prompt's "cover
+   BOTH now" instruction): 5 tests -- v4 written/unlinked (regression oracle,
+   pre-existing behaviour), v6 written/unlinked (the NEW proof), and both
+   families written independently in one call. Temporarily reverted
+   pfb_create_suppression_file() to the pre-Phase-6 (v4-only) 2-branch shape
+   and re-ran: 3 FAILURES, each for the exact documented reason (pfbsuppression_v6.txt
+   never written/unlinked). Restored the v6 branch: 5/5 green.
+
+Gate results
+------------
+- vendor/bin/phpunit -> 1914 tests, 15788 assertions, 1 failure, 4 skipped --
+  the exact documented environmental baseline (IpAddrDoublesTest::
+  testIsIpaddrv4 "leading-zero octets", macOS inet_pton). Test count is P5's
+  1898 + 9 net new SuppressionValidatorTest (10 added, 1 removed) + 2 new
+  CfgGatewayTest + 5 new CreateSuppressionFileTest = 1914, confirmed by direct
+  arithmetic.
+- php -l on every touched/new PHP file -> clean (pre-existing unrelated
+  E_DEPRECATED notices in pfblockerng.inc, untouched by this phase).
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> clean, no output.
+- vendor/bin/phpstan --memory-limit=1G -> "[OK] No errors" (28/28 files) --
+  required one design choice to get there (the vestigial-!empty()-removal
+  above); documented, not baselined.
+- .venv/bin/python -m pytest -q -> 2057 passed, 4 skipped. No Python file
+  touched this phase (only tests/smoke/ui/*.py, which the default run
+  `--ignore`s -- confirmed via pyproject.toml addopts). The +5 vs P5's 2052 is
+  the SAME unexplained environment/collection drift P4 (+0) and P5 (+10 vs
+  P4's 2042->2052, "unrelated to this phase's change") already flagged --
+  recorded honestly, not silently matched to a prior number.
+- .venv/bin/ruff check . -> "All checks passed!"; ruff format --check . ->
+  "160 files already formatted" (+2 vs P5's 159, consistent with the same
+  untouched-Python-tree drift note -- both smoke/ui files this phase touched
+  ARE Python and already ruff-clean, formatted on write).
+- shellspec (full suite) -> 259 examples, 0 failures, 8 skips -- byte-identical
+  to P3/P4/P5's baseline (no shell touched this phase).
+- UI collection (Tier A + Tier B) -> 186 tests collected (was 184), 0 errors;
+  80/186 ui_render (was 79/184), 107/186 ui_e2e -- see "Tier A / Tier B" above.
+
+Self-review (per the orchestrator's REVIEW step)
+-----------------------------------------------------
+- Every ACTION-PLAN item (1-7) done: tests-first with red evidence for all
+  three named layers; key registered + sniff path; pfb_create_suppression_file()
+  writes/unlinks supptxt_v6; UI section with validator+help text; wiring at the
+  suppress block under matching gates + stats logging + suppressheader
+  print-once respected; Tier A+B written and proven to collect; full gates
+  green.
+- _v4 call path byte-identical: confirmed by direct diff read of
+  pfblockerng.inc -- every pre-existing v4 line in the alias-build block is
+  unchanged; the new v6 block is purely additive, inserted after the v4 body
+  and before the shared `$alias_ips .= file_get_contents(...)` line.
+- v6 wiring under the same gates as v4: verified line-by-line above (supp
+  toggle, supp_update, $pfbadv, feed-changed) plus the v6-specific
+  "is configured" gate Phase 5's handoff called for.
+- Help texts neighbour-styled: v6 textarea help mirrors v4's structure/tone
+  (mask range statement, entry-per-line instructions, comment-suffix example,
+  Force-Reload note) minus the not-yet-true alerts-icon sentence; the shared
+  Suppression-toggle help gained exactly the one v6 clause the phase prompt
+  asked for.
+- Scope clean: `git diff --stat` touches exactly the files the phase prompt
+  named (pfblockerng.inc, pfblockerng_extra.inc, pfblockerng_ip.php, the sniff,
+  2 PHP test files + 1 new PHP test file, 2 UI test files) -- no killstates
+  (Phase 7), no Alerts "+"/widget (Phase 8), no ADR.md edit, no other ADR's
+  files touched. pfblockerng.widget.php's "Suppression" stats column (a
+  v4-only count display, distinct from the Alerts "+" live-punch mechanism)
+  was deliberately left untouched -- it is documentary display infrastructure
+  the ADR routes through Phase 8's "widget" rework, not this phase's config/UI/
+  update-flow wiring; flagging this explicitly rather than silently expanding
+  scope.
+
+Go-ahead for Phase 7 (killstates)
+-------------------------------------
+Phase 6 is complete and green (PHPUnit, PHPCS, PHPStan, pytest, ruff, shellspec,
+UI-test collection). v6suppression is a first-class registered key with a
+working UI, an on-disk file (pfbsuppression_v6.txt / $pfb['supptxt_v6']), and a
+live wiring path into the alias-build loop -- the same UX and gating shape as
+v4, per ADR SS2.1's "v6 wiring" row. Phase 7 (killstates prefix-aware exclusion)
+can now read BOTH v4suppression and v6suppression entries when building its
+exclusion set (`pfb_ip_suppressed(string $ip, array $entries): bool`, replacing
+the exact-IP hashmap + subnetv4_expand block at pfblockerng.inc ~10151-10163,
+now shifted by this phase's earlier edits -- locate by name/context, not the
+stale line numbers in the ADR text). No masterfile/killstates code was touched
+this phase.

--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/07_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/07_Results.txt
@@ -1,0 +1,191 @@
+ADR-53 Phase 7 -- killstates prefix-aware suppression exclusion
+====================================================================
+
+STATUS: Done. pfb_remove_states()'s suppression exclusion is now prefix-aware for
+both families and any mask, via a new pure helper. Red->green proven both for the
+helper in isolation and for the actual production wiring (pfb_remove_states() itself).
+
+Helper -- signature and home
+-----------------------------
+`pfb_ip_suppressed(string $ip, array $entries): bool` in pfblockerng_extra.inc
+(src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc:2926), right after Phase 5/6's
+pfb_suppress_file_v6(), under a new "ADR-53 P7" section banner. PURE: no config
+reads, no I/O -- the caller passes the already-decoded suppression list(s).
+
+Body: foreach $entries, trim + skip blank/'#'-led lines, strip a trailing inline
+'#' comment (same tolerance pfbng_text_area_decode()/pfb_validate_suppression_line()
+apply), then `ip_in_subnet($ip, $entry)` -- return TRUE on first hit, FALSE if the
+list is exhausted. No per-family branching needed: ip_in_subnet() itself returns
+FALSE on a family mismatch (confirmed via its double at tests/php/pfsense_doubles.php:588,
+which mirrors pfSense's real inet_pton-based implementation), so a v4 entry can never
+match a v6 IP or vice versa. This is the exact ip_in_subnet() loop shape
+pfb_local_ip() (pfblockerng.inc:10417) already applies to local subnets -- reused,
+not reinvented.
+
+Where the swap landed
+----------------------
+pfblockerng.inc, inside pfb_remove_states() (function starts at line 10153,
+confirmed via grep -- the ADR's stale "10151-10163" reference has drifted across
+Phases 1-6's edits elsewhere in the file, exactly as P6's handoff warned):
+
+1. Collection (was lines ~10186-10203: the "Collect IPv4 Suppression list IPs"
+   foreach + its /32 str_replace + /24 subnetv4_expand() branch + the following
+   `array_flip($pfb_local)`) -- REPLACED (now lines 10186-10192) with two decode
+   calls, no materialisation:
+       $v4suppression = pfbng_text_area_decode($pfb['ipconfig']['v4suppression'], TRUE, FALSE);
+       $v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'], TRUE, FALSE);
+   $pfb_local is no longer touched by suppression at all -- it now starts and stays
+   empty until pfb_collect_localip()'s merge (unchanged), which is a strictly
+   simpler/cleaner state than before (see "unexpected second bug" below).
+
+2. Exclusion checks (now lines 10304-10321): added `pfb_ip_suppressed($s_ip,
+   $v4suppression) ||` to the v4 branch's OR-chain and `pfb_ip_suppressed($s_ip,
+   $v6suppression) ||` to the v6 branch's, each placed right after the existing
+   `pfb_local_ip($s_ip, $pfb_localsub) ||` term (same family split the ip_version
+   if/else already provides -- no new branching structure). $pfb_local (local/DNS
+   exact-match) and the Permit-customlist `ip_in_subnet` loop a few lines down are
+   BYTE-IDENTICAL, confirmed by diff read.
+
+Net diff: 25 lines changed in pfblockerng.inc (mostly deletions -- the old
+materialisation logic was more code than the new call sites), +50 lines in
+pfblockerng_extra.inc (the new helper + its docblock).
+
+subnetv4_expand() confirmed still used elsewhere (pfb_collect_localip(), lines
+10461/10508, for LOCAL interface/VIP subnet expansion -- unrelated to suppression)
+-- the function itself is untouched, only its suppression call site is removed.
+
+An unrelated second bug this swap incidentally fixes (documented, not fixed further)
+-------------------------------------------------------------------------------------
+Investigating the swap surfaced a PRE-EXISTING, unrelated defect in the $pfb_local
+plumbing this phase deletes for suppression (still present for local-IP/DNS-server
+exact-match -- untouched, out of this phase's scope): the "Remove any duplicate IPs"
+step (`$pfb_local = array_flip(array_unique($pfb_local));`) blindly re-flips
+WHATEVER arrives already hashmap-shaped. The old suppression foreach's own
+`array_flip($pfb_local)` (now deleted) and pfb_collect_localip()'s internal flip
+BOTH hand back an IP=>int hashmap; merging those into $pfb_local and then re-flipping
+at the end double-flips them back into a plain list (keys become ints, values become
+IP strings) -- so `isset($pfb_local[$s_ip])` on an IP string never matches. Worse,
+array_unique()'s value-based comparison (the int values, essentially arbitrary
+per-source list positions) silently drops whichever entries collide on that
+position, independent of key. Confirmed empirically with isolated `php -r` traces
+(both an empty-local-data scenario and a populated one with local IPs + DNS
+servers): v4suppression's legacy exact '/32' match via $pfb_local NEVER reliably
+worked. This phase's swap sidesteps the whole problem for suppression (it no longer
+touches $pfb_local at all), incidentally fixing it there -- the local-IP/DNS-server
+half of the same bug is untouched and remains a latent defect outside this phase's
+"minimal diff to the exclusion swap only" constraint. Flagging for visibility, not
+fixing (would violate the phase's "do NOT restructure the states loop beyond the
+exclusion swap" constraint) -- a candidate for a future issue/ADR if the local-IP/
+DNS-server exclusion path is ever revisited.
+
+Doubles
+-------
+None new needed -- ip_in_subnet() (tests/php/pfsense_doubles.php:588, both-family
+faithful implementation) already existed from an earlier phase and is reused
+as-is. No new pfSense function reached.
+
+Tests FIRST (red->green)
+--------------------------
+1. tests/php/KillstatesSuppressionTest.php (NEW, 11 tests) -- the pure helper in
+   isolation: v4 '/16' containment (the headline red case: today's mechanism can
+   only express '/32'/'/24'), v4 outside-range miss, v4 legacy '/32' exact hit,
+   v4 legacy '/24' member hit, v6 '/64' containment, v6 outside-range miss, v6
+   '/128' exact hit, malformed entry skipped (not fatal, and doesn't block a
+   later real match), empty list -> FALSE, cross-family entry never matches.
+   Red proof: pfb_ip_suppressed() did not exist pre-Phase-7, so ALL 11 tests
+   fail with "Call to undefined function pfb_ip_suppressed()" against the
+   pre-change code (verified by git-stashing just the two src/ files and
+   re-running the filtered suite) and pass once the helper lands.
+
+2. tests/php/PfbRemoveStatesTest.php (extended, +3 tests; setUp now also seeds
+   `$GLOBALS['pfb']['ipconfig']['v6suppression'] = ''` alongside the existing
+   v4suppression seed) -- proves the ACTUAL WIRING in pfb_remove_states(), not
+   just the helper in isolation, using the file's existing fake-pfctl harness:
+     - test_v4_suppression_slash16_spares_contained_state_others_still_killed:
+       v4suppression='198.51.0.0/16', a matched state inside it survives, a
+       matched sibling outside it (198.52.100.9) is still killed. FAILS
+       pre-Phase-7 (old mechanism can't express '/16' -- verified via the same
+       stash-and-rerun).
+     - test_v4_suppression_legacy_slash32_now_reliably_spares_state: a legacy
+       exact '/32' entry. Expected to be a pure oracle (ADR §2.2 asks Phase 7
+       to keep "/32 + /24 entries working identically") -- it is NOT: this is
+       ALSO red->green, because of the unrelated $pfb_local double-flip bug
+       above (empirically confirmed the old mechanism silently failed to
+       suppress even the exact-host case once the final dedupe-flip ran).
+       Renamed from an initially-planned "..._still_spares_state" to
+       "..._now_reliably_spares_state" to state this honestly.
+     - test_v6_suppression_slash64_spares_contained_state_others_still_killed:
+       v6suppression was not read by pfb_remove_states() AT ALL pre-Phase-7, so
+       this is red for any v6 entry (not just a containing mask). Precondition-
+       asserts both fixture addresses (3fff:0:0:1::9 / 3fff:0:0:2::9, RFC 9637
+       documentation range -- NOT 2001:db8::/32, which may validate as reserved
+       under FILTER_FLAG_NO_RES_RANGE depending on PHP version, same rationale
+       as the file's existing V6_VICTIM/V6_PERMIT constants) validate as public
+       under NO_PRIV|NO_RES on the running PHP, mirroring the file's existing
+       #702 precondition-check pattern.
+   All 3 confirmed red pre-change (git-stash the two src/ files, rerun) and
+   green post-change, for the exact documented reasons -- kill-log contents
+   diffed inline in each assertion failure message.
+
+Gate results
+------------
+- vendor/bin/phpunit -> 1928 tests, 15807 assertions, 1 failure, 4 skipped --
+  the exact documented environmental baseline (IpAddrDoublesTest::
+  testIsIpaddrv4 "leading-zero octets", macOS inet_pton). Test count is P6's
+  1914 + 11 new (KillstatesSuppressionTest) + 3 new (PfbRemoveStatesTest) = 1928,
+  confirmed by direct arithmetic. The new/changed tests alone (--filter
+  'KillstatesSuppressionTest|PfbRemoveStatesTest') -> 20 tests, 29 assertions, 0
+  failures.
+- Red proof: `git stash push -- src/usr/local/pkg/pfblockerng/pfblockerng.inc
+  src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` (keeping the new/changed
+  test files in place), rerun the same filter -> 11 errors ("Call to undefined
+  function pfb_ip_suppressed()") + 3 failures (kill-log contains the IP that
+  should have survived), each printing expected-vs-actual kill-log contents.
+  `git stash pop` restored the fix; rerun -> 20/20 green again.
+- php -l on every touched/new PHP file -> clean (pre-existing unrelated
+  E_DEPRECATED notices in pfblockerng.inc, untouched by this phase).
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> clean, no output.
+- vendor/bin/phpstan --memory-limit=1G -> "[OK] No errors" (28/28 files).
+- .venv/bin/python -m pytest -q -> 2057 passed, 4 skipped -- byte-identical to
+  P6's count (no Python file touched this phase).
+- .venv/bin/ruff check . -> "All checks passed!"; ruff format --check . ->
+  "160 files already formatted" -- unchanged from P6 (no Python touched).
+- shellspec (full suite) -> 259 examples, 0 failures, 8 skips -- byte-identical
+  to the P3-P6 baseline (no shell touched this phase).
+
+Self-review (per the orchestrator's REVIEW step)
+-----------------------------------------------------
+- Every ACTION-PLAN item (1-5) done: tests-first with red evidence (both the
+  isolated helper AND the production wiring); helper implemented pure, reusing
+  ip_in_subnet()/pfb_local_ip()'s established shape; killstates pass swapped
+  with the OLD block fully removed (no dead code left behind); subnetv4_expand()
+  usage confirmed still needed elsewhere (grepped before deleting the call
+  site, not the function); full gates green.
+- $pfb_local still covers local/DNS IPs unchanged -- confirmed by diff read:
+  the only lines touched in the exclusion-check OR-chains are the two new
+  `pfb_ip_suppressed(...) ||` insertions; every other term (isset($pfb_local),
+  pfb_local_ip, is_private_ip, the substr/filter_var guards, the Permit
+  ip_in_subnet loop) is byte-identical.
+- Minimal diff in the states loop: no restructuring beyond the exclusion swap
+  (confirmed: the fopen/fgets walk, the ip_version detection, the pfctl -T
+  test verification loop, and the final kill exec() calls are all untouched).
+- Scope clean: `git diff --stat HEAD` touches exactly pfblockerng.inc,
+  pfblockerng_extra.inc, and 2 PHP test files (1 new) -- no Alerts "+"/widget
+  (Phase 8), no ADR.md edit, no other ADR's files, no config/UI files (this
+  phase needed none -- v4suppression/v6suppression already fully wired by
+  Phases 2-6).
+- One naming-convention fix caught in self-review: an early draft of the
+  pfblockerng.inc comment wrote "ADR-53 SS1.2/SS2.2" (an ASCII stand-in for
+  section signs) where every other ADR-53 comment in this codebase uses the
+  real "§" character (confirmed via grep across pfblockerng.inc/_extra.inc) --
+  corrected to "§1.2/§2.2" before commit.
+
+Go-ahead for Phase 8 (Alerts "+")
+-----------------------------------
+Phase 7 is complete and green (PHPUnit incl. red->green proof, PHPCS, PHPStan,
+pytest, ruff, shellspec). Killstates now spares suppressed prefixes at any
+mask, both families, via the standalone pfb_ip_suppressed() helper -- Phase 8
+can reuse the SAME helper (or its ip_in_subnet()-loop shape) for the Alerts
+"+" live-punch rework (ADR §2.1: "locate the containing table entr(y/ies)...
+drop the '/24'-only refusal and the 254-host loop", both families, any mask).
+No Alerts/widget code was touched this phase.

--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/08_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/08_Results.txt
@@ -1,0 +1,274 @@
+ADR-53 Phase 8 -- Alerts "+" / widget live-punch (any mask + v6)
+====================================================================
+
+STATUS: Done. The Alerts "+" (addsuppress) live-punch is now a genuine
+set-subtraction, any mask, both families -- the retired /24-only 254-host
+re-add loop and the "blocked by a CIDR other than /24" refusal are gone.
+
+Helper -- signature and home
+-----------------------------
+`pfb_live_punch_plan(string $ip, array $table_entries): array` in
+pfblockerng_extra.inc (src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc,
+new "ADR-53 P8" section right after Phase 7's pfb_ip_suppressed()). PURE: no
+pfctl/pf-table access -- the caller supplies the already-read membership
+snapshot.
+
+Returns `['delete' => [...containing entries...], 'add' => [...covering
+CIDRs...]]`. For each raw table-membership line: normalise a bare host to
+'/32'/'/128' by family, test containment via `ip_in_subnet($ip, $cidr)`
+(reused as-is, same family-safe primitive P7 already vendored), and on a hit:
+mark the entry for deletion, then compute the covering-CIDR remainder --
+v6 via a direct call to Phase 5's `pfb_cidr_subtract_v6([$cidr], [$host_cidr])`
+(reused, not reinvented -- exactly what the phase brief asked for), v4 via a
+new small sibling `pfb_v4_carve_single(string $cidr, string $host_ip): array`
+(pfblockerng_extra.inc, same file). An exact host match (`$cidr === $host_cidr`)
+short-circuits to delete-only, no re-add -- mirrors the old /32-exact-hit case.
+
+pfb_v4_carve_single() is deliberately NOT the general multi-hole engine
+pfb_cidr_subtract_v6() is: the live punch only ever needs one entry minus one
+host, so it walks plain PHP ints (`ip2long32()`/`long2ip32()`, both already
+real pfSense functions -- ip2long32 already had a faithful double from Phase 5;
+long2ip32 did not, so I added one to tests/php/pfsense_doubles.php, verified
+BYTE-IDENTICAL against the SAME three dated refs already cited for
+ip_range_to_subnet_array (CE 2.8.0 ed6c2eb8..., CE 2.8.1 97f9eb5c...,
+master tip 9363ac5b... -- fetched fresh from the public pfsense/pfsense mirror
+this session, not reused from memory). Never shells out to iprange for the
+one-entry carve, per the phase brief.
+
+Widget finding (verify-first, per the brief)
+---------------------------------------------
+The widget (src/usr/local/www/widgets/widgets/pfblockerng.widget.php) has NO
+separate addsuppress form/JS of its own -- grepped for `addsuppress`,
+`PFBIPSUP`, `ip_suppression`, `.dialog(` and found none. It only reads the
+v4suppression blob's line count for its "Suppression" stats tile
+(`pfBlockerNG_get_header()`, the `Suppression`/`Whitelist` stats branch).
+That count was v4-only; since the "+" now writes v4 OR v6 depending on the
+reported host's family, the widget stat would silently undercount v6 adds.
+Fixed with a 12-line addition (fold in `pfbng_text_area_decode($pfb['ipconfig']
+['v6suppression'], ...)` into the same `$gcount` when `$type == 'Suppression'`)
+-- no separate suppress flow to rework, exactly as the brief anticipated
+("if it posts to the alerts page, one fix covers both").
+
+Mirror-vs-pfctl fallback (pfblockerng_alerts.php addsuppress block)
+----------------------------------------------------------------------
+`$mirror = "{$pfb['aliasdir']}/{$table}.txt"` (ADR-40 last-applied mirror);
+`is_readable($mirror)` selects it, else `tempnam($pfb['dbdir'], 'pfb_punch_')`
++ `exec("pfctl -t <table> -T show > <tmp> 2>&1")` (output-to-file, not a
+captured pipe -- the established idiom this codebase already uses for
+`pfctl -s state`, per CLAUDE.md's external-process-waits guidance) + the tmp
+file is unlinked after the scan. BOTH paths are then read identically via
+`fopen()`/`fgets()` line-by-line into `$table_entries` -- never `file()`,
+never slurped whole (a Deny mirror can be millions of lines). Every token
+reaching `exec()` (the table name, the tmp path, every delete/add CIDR) is
+`escapeshellarg()`'d.
+
+The rewritten flow (accepts v4 AND v6, any mask)
+---------------------------------------------------
+1. `pfb_filter($_POST['ip'], PFB_FILTER_IP, ...)` (was `PFB_FILTER_IPV4` --
+   `PFB_FILTER_IP` (constant 9, `is_ipaddr()`) validates either family).
+2. Family detected via `strpos($ip, ':')`.
+3. Read table membership (mirror/pfctl fallback above) -> `pfb_live_punch_plan()`.
+4. `pfctl -T delete` every containing entry, `pfctl -T add` every covering CIDR.
+5. Write the EXACT host (`ip/32` or `ip/128`, never a chosen network) to the
+   correct-family customlist (`ipsuppression`/`v4suppression` or
+   `ipsuppression_v6`/`v6suppression`), preserving the existing "already
+   exists" dedup shape and the description-comment suffix.
+6. `pfb_create_suppression_file()` refreshes `pfbsuppression(_v6).txt`.
+
+BEHAVIOUR-CHANGE CALL (flagging for the record, per CLAUDE.md ambiguity
+discipline -- made the reasoned default rather than blocking on it): the
+OLD `/32` branch REFUSED (no config write) when neither an exact bare host
+nor an exact `/24` line was found; the OLD `/24` branch, chosen explicitly,
+ALWAYS wrote the config regardless of live match. The ADR text ("Alerts '+'
+keeps immediate effect (live table punch + config write + suppression-file
+refresh)", §2.2) reads as an unconditional list of three effects, and since
+there is no longer a mask CHOICE to gate on, I generalised to the more
+permissive existing behaviour: an empty plan (nothing currently matches
+live) is INFORMATIONAL, never a refusal -- the customlist write always
+proceeds (suppression is a standing exemption for future loads, not
+contingent on today's live snapshot). This is why
+`test_addsuppress_writes_exact_host_and_invalid_ip_rejected` explicitly
+covers "valid IP, no live match, still writes" as an ACCEPT case, replacing
+the old `test_addsuppress_cidr24_writes_and_invalid_ip_rejected` (which
+encoded the retired {ip}/24-network-write shape).
+
+$pfb['ipconfig'][$cfg_key] snapshot-staleness fix (incidental, in-scope)
+----------------------------------------------------------------------------
+`pfb_create_suppression_file()` reads `$pfb['ipconfig'][...]`, a value
+snapshot taken once at `pfb_global()` time (`config_get_path()` returns by
+value, confirmed via the doubles). The pre-existing v4-only code called
+`PfbConfig::write()` then `pfb_create_suppression_file()` in the SAME
+request without ever refreshing that snapshot -- a latent staleness bug
+(the just-written entry wouldn't reach `pfbsuppression.txt` until some LATER
+request). Since my new code depends on this refresh actually working (both
+families, and it is the phase's own explicit "refresh suppression files"
+requirement), I added one line -- `$pfb['ipconfig'][$cfg_key] =
+$clists[$supp_key]['base64'];` -- immediately before the call. Minimal,
+strictly corrective, in-scope (my own new code path depends on it), and
+incidentally fixes the same latent gap for the v4 path too.
+
+JS simplification (in-scope cleanup, not gold-plating)
+----------------------------------------------------------
+The old `/32` vs `/24` "Select Suppression Mask" jQuery-UI dialog
+(`ip_suppression_type()`) is now meaningless -- the backend never reads a
+chosen mask. Replaced with a direct call to `ip_suppression()` once the
+suppression-enabled check passes (dropped a dead `$(this).dialog('close')`
+call in the disabled branch too, which would have targeted a
+never-initialised dialog). The now-unused hidden `#cidr` `Form_Input` and its
+`cidr.value` gate in `ip_suppression()` are deleted. No other JS/markup
+touched; the redirect/savemsg mechanics are byte-identical in shape.
+
+Doubles
+-------
+One new double: `long2ip32()` in tests/php/pfsense_doubles.php (see above --
+verified against the real pfSense source, not guessed). `ip2long32()`,
+`ip_range_to_subnet_array()`, `ip_in_subnet()`, `pfb_cidr_subtract_v6()` are
+all reused as-is from Phases 5/7.
+
+Tests FIRST (red->green) -- the punch-plan helper
+------------------------------------------------------
+tests/php/LivePunchPlanTest.php (NEW, 8 tests, 94 assertions):
+- v4 `/16` containing entry -> delete=[the /16], add = 16 covering CIDRs
+  (cross-checked against ADR-53 §1.2's own measured bound, not guessed --
+  verified with a throwaway `php -r` script against the real implementation
+  before committing to the assertion).
+- v4 bare host entry -> delete=[ip], add=[] (exact match).
+- v4 exact `/24` entry -> 8 covering CIDRs (matches §1.2's measured bound;
+  proves the NEW mechanism reproduces the OLD /24 case's cost, never the
+  254-host shape).
+- v6 `/64` containing entry -> 64 covering CIDRs (v6 had NO live-punch path
+  at all before this phase).
+- IP in no entry -> both empty.
+- Multiple containing entries (a `/24` AND the exact `/32` both matching) ->
+  every one punched, not just the first.
+- A sibling entry entirely outside the hole is left out of the plan.
+- Blank/comment lines in the table snapshot are tolerated.
+
+Red proof: `pfb_live_punch_plan()` did not exist pre-Phase-8, so ALL 8 tests
+fail with "Call to undefined function pfb_live_punch_plan()" against the
+pre-change code (verified via `git stash` of the two src/ files +
+pfsense_doubles.php, rerunning the filtered suite -- 8 errors, exact reason),
+and pass once the helper (+ its v4 carve sibling + the long2ip32 double)
+land.
+
+No PHPUnit coverage of the actual www-page wiring itself: pfblockerng_alerts.php
+calls `header()`/`exit()` directly in this branch, which is not safely
+invokable under PHPUnit (a real `exit()` would terminate the test runner) --
+consistent with how every OTHER www-page action in this file is covered
+(Tier A/B live-VM, never PHPUnit). The wiring is proven by the Tier B e2e
+below (dispatch-only; not run from this session per the orchestrator's
+UI-tier note).
+
+Tier A / Tier B status
+-----------------------
+Tier A: no change needed -- the Alerts page marker ("Alert Settings",
+tests/smoke/ui/test_render_smoke.py) and the render gate are untouched by
+this diff (no new/removed visible markup, only a hidden input + JS).
+
+Tier B (tests/smoke/ui/test_alerts.py), REQUIRED per CLAUDE.md (multi-step
+flow + a new capability observable only in Tier B):
+1. `test_addsuppress_writes_exact_host_and_invalid_ip_rejected` (rewrite of
+   the retired `test_addsuppress_cidr24_writes_and_invalid_ip_rejected`,
+   which encoded the old `{ip}/24`-network-write shape and the now-removed
+   `cidr` POST field -- updated, not just left stale): invalid-IP reject
+   (config unchanged) + valid IP with no live table match still writes the
+   exact `ip/32` host (proves the old refusal is gone AND the new
+   always-write-exact-host semantics).
+2. `test_addsuppress_v4_carves_containing_range_and_spares_sibling` (NEW,
+   the ADR's headline scenario): injects a local IPv4 feed listing an RFC
+   2544 benchmarking `/16` (`198.18.0.0/16` -- per the ADR's Phase 9 fixture
+   guidance, "RFC 2544 / RFC 3849 -- never RFC 1918") plus a separate
+   sibling entry, force-updates it, asserts the BEFORE-state (both target
+   and sibling match the live table via the new `helpers.pfctl_table_test()`
+   -- pf's own longest-prefix membership check, added to tests/smoke/helpers.py
+   since no existing helper did `-T test`, only `-T show`), drives the "+"
+   for the target only, then asserts: target no longer matches (any mask,
+   genuine carve, not a refusal), sibling still matches (an unrelated feed
+   entry untouched), and `v4suppression` gained the exact `ip/32` line.
+3. `test_addsuppress_v6_carves_containing_range_and_spares_sibling` (NEW):
+   the same shape over an RFC 3849 `/64` (`2001:db8:18:1::/64`) and
+   `v6suppression` -- v6 had NO live-punch capability before this phase at
+   all, so this is a pure new-capability case, not a regression guard.
+
+New helper: `helpers.pfctl_table_test(vm, alias, ip)` in tests/smoke/helpers.py
+(`pfctl -t <alias> -T test <ip>`, checks stdout for "1/1 addresses match.") --
+the authoritative "is this address COVERED by the table" oracle; the
+existing `pfctl_table_members()` (an exact-token list) cannot answer this
+once a containing entry has been carved into covering CIDRs.
+
+Collection proof (per the orchestrator's UI-tier note -- no live box driven
+from this session):
+    .venv/bin/python -m pytest tests/smoke/ui --collect-only -q
+    -> 188 tests collected, including the 3 addsuppress tests by name
+       (verified via a targeted collect-only grep).
+Live runs ride Phase 9's CE+Plus fan-out.
+
+Gate results (exact counts)
+----------------------------
+- vendor/bin/phpunit -> 1936 tests, 15901 assertions, 1 failure, 4 skipped --
+  the exact documented environmental baseline (IpAddrDoublesTest::
+  testIsIpaddrv4 "leading-zero octets", macOS inet_pton). Count = P7's 1928 +
+  8 new (LivePunchPlanTest).
+  New/changed filter alone: `--filter 'LivePunchPlanTest|KillstatesSuppressionTest'`
+  -> 19 tests, 105 assertions, 0 failures.
+- Red proof: `git stash push -- src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+  tests/php/pfsense_doubles.php` (keeping LivePunchPlanTest.php in place),
+  rerun `--filter LivePunchPlanTest` -> 8 errors ("Call to undefined function
+  pfb_live_punch_plan()"). `git stash pop` restored the fix; rerun -> 8/8 green.
+- php -l on every touched/new PHP file -> clean (pre-existing unrelated
+  E_DEPRECATED notice in the widget file, untouched by this phase).
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> clean, no output.
+- vendor/bin/phpstan --memory-limit=1G -> "[OK] No errors" (28/28 files).
+- .venv/bin/python -m pytest -q -> 2057 passed, 4 skipped -- byte-identical
+  to P7 (no non-smoke Python file touched; the two touched files live under
+  tests/smoke/, excluded from the default run).
+- .venv/bin/python -m py_compile on both touched tests/smoke/*.py files ->
+  clean; .venv/bin/python -m mypy tests/ -> "Success: no issues found in 62
+  source files".
+- .venv/bin/ruff check . -> "All checks passed!"; ruff format --check . ->
+  "160 files already formatted" (both touched smoke files individually
+  re-checked clean too).
+- shellspec (full suite) -> 259 examples, 0 failures, 8 skips -- byte-identical
+  to the P3-P7 baseline (no shell touched this phase).
+- tests/smoke/ui --collect-only -> 188 tests collected, 0 errors.
+
+Self-review (per the orchestrator's REVIEW step)
+-----------------------------------------------------
+- Every ACTION-PLAN item (1-5) done: pure punch-plan helper with red-first
+  tests; addsuppress reworked (v4+v6, mirror-then-pfctl-fallback streaming,
+  correct-family write, suppression-file refresh); widget's shared stats
+  path fixed; Tier A confirmed unaffected + Tier B written (collection-proven,
+  live deferred to Phase 9 per instruction); full gates green.
+- Every token reaching exec() is escapeshellarg()'d: the table name (once,
+  reused for every pfctl call), the tmp-file path, every delete/add CIDR/entry.
+  Confirmed by diff read -- no bare interpolation of a POST-derived or
+  plan-derived value into any exec() string.
+- The 254-host loop (`for ($k=0; $k <= 255; ...)` / `for ($j=0; $j <= 255;
+  ...)`) and the `/24`-only refusal ("blocked by a CIDR other than /24") are
+  GONE -- confirmed by grep across src/ (only comment-text mentions of the
+  retired behaviour remain, in my own explanatory comments).
+- Scope clean: `git diff --stat` touches exactly pfblockerng_extra.inc,
+  pfblockerng_alerts.php, the widget, pfsense_doubles.php, tests/smoke/helpers.py,
+  tests/smoke/ui/test_alerts.py, and 1 new PHP test file -- no ADR.md edit,
+  no other ADR's files, no killstates/config-gateway files (Phases 2/7,
+  already landed and untouched here).
+- Read-side unaffected: the alerts TABLE VIEW rendering (log parsing,
+  convert_ip_log/convert_dnsbl_log, stats charts) was not touched -- only the
+  `addsuppress` POST branch, the widget's Suppression stat COUNT (a write
+  side of the same feature, per the phase brief), and the JS mask-choice
+  dialog this ADR retires.
+
+Go-ahead for Phase 9 (smoke, docs, DoD)
+------------------------------------------
+Phase 8 is complete and green (PHPUnit incl. red->green proof, PHPCS,
+PHPStan, pytest, mypy, ruff, shellspec, Tier A/B collection). The
+`pfb_live_punch_plan()`/`pfb_v4_carve_single()` engine + the reworked
+addsuppress flow are ready for Phase 9's live-VM fan-out, which should run:
+  - `tests/smoke/ui/test_alerts.py::test_addsuppress_writes_exact_host_and_invalid_ip_rejected`
+  - `tests/smoke/ui/test_alerts.py::test_addsuppress_v4_carves_containing_range_and_spares_sibling`
+  - `tests/smoke/ui/test_alerts.py::test_addsuppress_v6_carves_containing_range_and_spares_sibling`
+  - the full `tests/smoke/ui -m ui_render` Tier A pass over the Alerts page
+    (unaffected marker, but re-confirm live)
+  - Phase 9's own planned `tests/smoke/test_smoke_suppression.py` (the
+    persisted-engine live leg, separate from this phase's live-punch leg)
+No Alerts/widget work remains outstanding from this ADR's action plan.

--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/09_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/09_Results.txt
@@ -1,0 +1,282 @@
+ADR-53 Phase 9 -- Live-VM smoke, docs, Definition-of-Done
+====================================================================
+
+STATUS: Local implementation + gates complete and pushed. Live-VM acceptance
+fan-out DISPATCHED; see "Dispatch" section below for run URLs and the status
+observed at hand-off time (updated by the polling ladder below; if this
+session ended before the ladder completed, the orchestrator/maintainer should
+check the run URLs directly).
+
+Fixtures (new)
+--------------
+- tests/smoke/fixtures/ip_suppress_v4.txt: `198.18.0.0/16` (RFC 2544
+  benchmarking -- inert, NOT RFC 1918) plus two bare hosts,
+  `203.0.113.60`/`198.51.100.77` (RFC 5737), deliberately far apart from each
+  other and from the /16 so iprange's minimal-CIDR aggregation cannot merge
+  them (which would throw off the exact covering-CIDR-count assertions).
+- tests/smoke/fixtures/ip_suppress_v6.txt: `2001:db8:53::/64` (RFC 3849) plus
+  two bare v6 hosts, `2001:db8:99::10`/`2001:db8:aa::20` (RFC 3849), same
+  non-adjacency rationale.
+- tests/smoke/fixtures/README.md: new "IP suppression carve fixtures" section
+  documenting both files, the delivery mechanism (write_local_feed, NOT the
+  HTTP mock_feeds path -- these tests exercise the persisted engine, not the
+  HTTP-fetch contract Part C already covers), and the non-adjacency rationale.
+
+New module: tests/smoke/test_smoke_suppression.py
+--------------------------------------------------
+Pure IP-side (no DNSBL, no DNS probe) -- deployed_vm fixture mirrors the
+minimal test_smoke_714_asn_geoip.py shape: `h.deploy(smoke_vm)` only, no VIP/
+client_vm/stub_dns. An autouse per-test fixture (`_clean_suppression`) wipes
+BOTH suppression customlists before and after every test and FAILS LOUDLY
+(AssertionError, not a silent best-effort) if the readback disagrees with what
+was just written -- the self-encapsulation the test-coverage mandate requires.
+Teardown also runs `helpers.reset()` (clearip/cleardnsbl + blocking filter
+sync) so each test starts from a genuinely clean pf-table baseline regardless
+of run order.
+
+This module covers the UPDATE-FLOW path (config `v4suppression`/
+`v6suppression` -> a reload -> the persisted engine -> pf table) -- a
+DIFFERENT mechanism from the Alerts "+" LIVE PUNCH already covered by Phase
+8's tests/smoke/ui/test_alerts.py::test_addsuppress_{v4,v6}_carves_
+containing_range_and_spares_sibling (which mutates the live pf table directly
+from one web click, independent of any reload). No duplicate coverage.
+
+Scenario inventory (4 tests, BDD-style Given/When/Then):
+
+1. test_suppression_v4_carves_containing_range_spares_sibling (Scenario A --
+   the SS4.1 headline acceptance case). Given: the v4 fixture loaded as a Deny
+   list, suppression enabled but empty; settling update. BEFORE: target
+   (198.18.3.4, inside the /16) AND sibling (203.0.113.60, a separate bare-host
+   feed entry) both match the live pf table (pfctl -T test). When:
+   v4suppression = 198.18.3.4/32; second update. Then: target no longer
+   matches; sibling still matches; the denydir member file holds EXACTLY 16
+   covering-CIDR entries (the /16 minus the /32), including the representative
+   samples '198.18.0.0/23' and '198.18.128.0/17' -- the SAME relative
+   host-in-block shape (octet3=3, octet4=4) as the real-iprange-verified
+   vector in tests/shell/pfblockerng_suppress_spec.sh ("10.0.3.4" inside
+   "10.0.0.0/16"), so the exact count/shape is grounded in an ALREADY-PROVEN
+   result, not a fresh guess.
+
+2. test_suppression_v6_carves_containing_range_spares_sibling (Scenario B --
+   v6 had NO carve mechanism at all before ADR-53). Injects a TRIVIAL
+   companion v4 Deny alias alongside the v6 target via inject_ip_lists() --
+   see "Wiring finding" below for why. BEFORE/AFTER shape mirrors Scenario A;
+   the member file holds exactly 64 covering-CIDR entries for the /64 minus
+   the /128 (matches the exact vector tests/php/V6CidrSubtractTest.php pins
+   `pfb_cidr_subtract_v6()` against: '2001:db8::/64' minus '.../5353/128' ->
+   assertCount(64, ...)).
+
+3. test_suppression_v4_bare_host_removed (Scenario C part 1 -- upgrade-parity,
+   SS2.2). A masked suppression entry over a BARE feed host (no intersection
+   with the /16 at all) removes just that token; the /16 line is left
+   byte-identical (member file = exactly 2 lines: the untouched /16 + the
+   surviving bare host) -- proves the engine carves ONLY entries a hole
+   actually intersects.
+
+4. test_suppression_v4_subnet_mask_carves_at_granularity (Scenario C part 2 --
+   mask-agnostic, SS2.1's /8-/32 UI lift). v4suppression = a CONTAINING /24
+   (not a /32) carves the /16 at /24 granularity: target /24 no longer matches
+   anywhere inside it; a sibling /24 (same /16) still matches; member file
+   holds exactly 8 covering-CIDR entries (24-16=8, the same
+   prefix-length-difference bound the shellspec proves for /24-/32=8, applied
+   one level up).
+
+Every pfctl assertion goes through `_pfctl_test()` (one SSH round trip,
+returns (matched, raw_stdout)) so a failing assert prints pf's OWN rendered
+"N/1 addresses match" text alongside the boolean -- never a bare derived
+boolean (CLAUDE.md "expected vs actual").
+
+Wiring finding (flagged for the maintainer, documented in architecture-notes.md,
+NOT fixed in Phase 9 -- out of scope)
+------------------------------------------------------------------------------
+`$pfb['supp_update']` -- the flag that unlocks BOTH the v4 and v6 suppression
+sub-passes for a given reload pass -- is set TRUE only by a v4 Deny alias's
+OWN genuine reparse (pfblockerng.inc ~16550-16558, inside
+`if ($pfbadv && $list['vtype'] == '_v4')`). Traced this precisely (not
+guessed) by reading the download-loop code around pfblockerng.inc:16440-16770
+and the request-routing code at ~13225-13260. Consequence: an install with
+ONLY v6 Deny lists configured would never flip `supp_update`, so v6
+suppression would never fire even with `v6suppression` populated and a v6
+alias genuinely reparsing. Scenario B works around this with a trivial
+companion v4 Deny alias riding the SAME reload pass (exactly what a
+production box with both families configured would look like) rather than
+silently hiding the gap. Candidate fix for a future phase/issue: also set
+`supp_update` on a v6 Deny alias's own change.
+
+Also confirmed empirically (read, not guessed) while designing the test:
+`updateip` (scope=ip, force=true via pfb_trigger) sets `$pfb['reuse']='on'`
+for the WHOLE reload pass (pfblockerng.inc ~13243), which defeats the
+per-file "already parsed, skip" cache for EVERY Deny alias -- so a SECOND,
+content-unchanged `updateip` call genuinely re-parses every alias present,
+with NO `force_ip_refetch()` marker-touch needed (unlike the ADR-40 tests,
+which use the force=false 'update' verb and must call force_ip_refetch
+explicitly). This simplified the test design significantly once traced.
+
+Docs
+----
+docs/misc/architecture-notes.md gains "## IP suppression set-subtraction
+(ADR-53)" (appended after the ADR-43 section, end of file): the covering-CIDR
+math (b-a formula, invariant to hole position), the v4 iprange --except engine
++ its DNS-resolution hazard + pre-filter, the v6 pure-PHP engine + its
+measured perf bound (1.24s/100k, P5), the supp_update wiring gotcha above,
+consumer inheritance (why content-level fixes every reader for free), and an
+explicit note that the Alerts "+" live punch is a SEPARATE mechanism (not
+duplicated by this module).
+
+Gate results (exact counts)
+----------------------------
+- .venv/bin/python -m pytest -q -> 2057 passed, 4 skipped -- byte-identical to
+  P8's baseline (the two new/changed smoke files live under tests/smoke/,
+  excluded from the default run).
+- .venv/bin/python -m pytest tests/smoke --collect-only -q
+  --ignore=tests/smoke/test_stub_shapes.py -> 467 tests collected (463 on the
+  pre-P9 tip + my 4 new tests; confirmed via `git stash` on the pre-commit
+  tree). test_stub_shapes.py's own collection error (`ModuleNotFoundError:
+  No module named 'dns'`) is a PRE-EXISTING local-venv gap (dnspython not
+  installed in this dev venv) -- confirmed unrelated by reproducing it on the
+  pre-P9 tip too; not a regression.
+- .venv/bin/python -m pytest tests/smoke/test_smoke_suppression.py
+  --collect-only -q -> 4 tests collected, 0 errors (all 4 scenarios by name).
+- .venv/bin/ruff check . -> "All checks passed!"; ruff format --check . ->
+  "161 files already formatted".
+- .venv/bin/python -m mypy tests/ -> "Success: no issues found in 62 source
+  files" (tests/smoke is excluded from this gate per pyproject.toml's mypy
+  config -- unchanged count is expected, not a miss).
+- npx markdownlint-cli2 -> "Summary: 0 error(s)" (107 files, incl. both
+  touched docs).
+- vendor/bin/phpunit -> 1936 tests, 15901 assertions, 1 failure, 4 skipped --
+  the exact documented environmental baseline (IpAddrDoublesTest::
+  testIsIpaddrv4 "leading-zero octets", macOS inet_pton). No PHP touched this
+  phase; byte-identical to P8.
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> clean, no output.
+- vendor/bin/phpstan --memory-limit=1G -> "[OK] No errors" (28/28 files).
+- shellspec (full suite) -> 259 examples, 0 failures, 8 skips -- byte-identical
+  to the P1-P8 baseline (no shell touched this phase).
+- Pre-commit hook (ruff/mypy/markdownlint/url-encoding/no-appliance-python) ->
+  all passed on the actual commit.
+
+Self-review (per the orchestrator's REVIEW step)
+-----------------------------------------------------
+- Every scenario asserts the BEFORE-state first (both target and sibling
+  match, via wait_pfctl_table + pfctl_table_test) before the suppression
+  config change, then re-asserts after -- never a final-state-only check.
+- Every pfctl assertion prints expected vs actual (the raw "N/1 addresses
+  match" pf output) via `_pfctl_test()` -- confirmed via read-through, no bare
+  booleans.
+- Tests are self-encapsulated: the autouse `_clean_suppression` fixture wipes
+  + verifies-empty before AND after every test, failing loudly if the wipe
+  doesn't take; each test injects its OWN uniquely-named alias so there is no
+  pf-table collision between tests regardless of run order.
+- Fixtures use only inert ranges: RFC 2544 (198.18.0.0/16), RFC 5737
+  (203.0.113.x, 198.51.100.x), RFC 3849 (2001:db8:...) -- confirmed no RFC
+  1918, no RFC 6761 TLD (N/A here, IP-only, no DNS names in this module).
+- docs/misc/architecture-notes.md section matches the file's existing
+  reference-style tone (confirmed by reading the neighbouring ADR-40/ADR-42/
+  ADR-43 sections before writing).
+- `git diff --stat` against origin/devel touches exactly: docs/misc/
+  architecture-notes.md, tests/smoke/fixtures/README.md, two new fixture
+  files, and the one new test module -- no other ADR's files, no src/ touched
+  (Phase 9 is test/docs only, per the phase brief).
+- Did NOT flip the ADR Status field -- left for the orchestrator/maintainer
+  on green fan-out evidence, per CLAUDE.md "ADR acceptance".
+
+Commit
+------
+e90b3ebd "tests: live-VM suppression carve smoke + ADR-53 docs (ADR-53 P9)"
+Rebased cleanly onto origin/devel (2 unrelated commits, #678) before push;
+force-with-lease used after confirming the remote tip (06fa7164, P8's
+pre-rebase hash) was this session's own prior state (no foreign push --
+confirmed via `git diff origin/adr/53... 3bb6c1dd` showing only the #678
+devel-rebase delta, zero drift in the ADR-53 commits' own content).
+Pushed to origin/adr/53-ip-suppression-set-subtraction (9 commits ahead of
+origin/devel: P1-P9).
+
+Dispatch (acceptance fan-out)
+------------------------------
+1. smoke.yml (min-CE leg, scope=impacted default, pytest_filter="suppression"
+   per the orchestrator's dispatch policy):
+   https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28677519751
+2. ui-tests.yml (scope=impacted default, tier=all default -- auto-derives the
+   Tier A/B tests from the files this branch's FULL diff vs origin/devel
+   changed: tests/smoke/ui/test_alerts.py [P8's addsuppress carve e2e],
+   tests/smoke/ui/test_functional.py, tests/smoke/ui/test_render_smoke.py
+   [P4/P6's IP-settings mask-lift + v6 textarea Tier A/B]):
+   https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28677527199
+
+Status at last observed check: <<FILL AT HANDOFF TIME -- see final report>>.
+
+Evidence summary for the Accepted flip
+----------------------------------------
+Once BOTH dispatched runs are green, ADR-53's SS4 acceptance list is fully
+proven:
+  1. Containing-entry carve, both families, before-state first -> THIS
+     module's Scenarios A/B.
+  2. v6suppression end-to-end -> Scenario B + Phase 6's own tests.
+  3. Mask range validation (v4 /8-/32, v6 /32-/128) -> Phase 4/6 PHPUnit +
+     this module's Scenario C2 (a real /24 carve, not just /32).
+  4. No materialisation anywhere -> every scenario's exact covering-CIDR-count
+     assertion (16/64/8), never a host explosion.
+  5. Fail-safe publish (missing binary / unloadable file / malformed token /
+     legitimate full suppression) -> Phase 3/5 shellspec + PHPUnit (off-CI by
+     nature of the failure modes; not re-proven live here).
+  6. Killstates spares suppressed IPs, both families -> Phase 7 PHPUnit
+     (KillstatesSuppressionTest); no live leg needed (pure-PHP helper).
+  7. Config round-trip + sniff -> Phase 2/6 PHPUnit (CfgAdaptersTest-style).
+  8. Green CE+Plus smoke/UI fan-out -> THIS phase's dispatch (min-CE leg
+     validated first per orchestrator policy; the orchestrator/maintainer
+     should follow up with the full CE+Plus fan-out
+     (`gh workflow run smoke.yml -f scope=full -f pytest_filter="suppression"`,
+     `gh workflow run ui-tests.yml -f scope=full`) before flipping Status.
+
+No blocking deviations from the phase brief. The ONE non-cosmetic deviation:
+the phase brief's action plan expected `force_ip_refetch()` to be part of the
+test flow (mirroring the ADR-40 tests) -- traced through the actual
+`updateip`/pfb_trigger code and found it unnecessary for THIS scope (`force=true`
+already sets `$pfb['reuse']='on'` globally), so it was dropped from the test
+design with the reasoning documented inline and in this handoff, rather than
+included as unnecessary/misleading scaffolding.
+
+--------------------------------------------------------------------------------
+LIVE-RUN FINDINGS (orchestrator, post-dispatch — first min-CE leg + UI tiers)
+--------------------------------------------------------------------------------
+
+Run 1 evidence (smoke 28677519751 FAILED, ui-tests 28677527199 FAILED) — two
+genuine bugs caught by the live legs, both fixed in the follow-up commit:
+
+1. helpers.pfctl_table_test() read result.stdout, but `pfctl -T test` prints
+   "X/Y addresses match." on STDERR (verified live on FreeBSD: stdout empty,
+   stderr carries the line; the PHP-side pfb_pfctl_test_match_count() call
+   sites append 2>&1 for the same reason). Every before-state assertion in
+   test_smoke_suppression.py and the alerts Tier B e2e therefore read '' and
+   failed. Fix: match against stdout+stderr, docstring records the stderr fact.
+
+2. addsuppress stored a shell-quoted config entry: pfb_filter(..., TRUE)
+   returns an escapeshellarg()'d token (quotes included) — the legacy flow
+   interpolated it into exec() directly, but the P8 rework escapes at each
+   sink, so the quoted form leaked into pfb_live_punch_plan() (empty plan) and
+   the stored customlist entry ('198.51.100.7'/32). Caught by
+   test_addsuppress_writes_exact_host_and_invalid_ip_rejected:
+     assert '198.51.100.7/32' in {"'198.51.100.7'/32"}
+   Fix: drop the escape flag; $ip/$table stay raw (WORD/IP-validated), every
+   exec sink already escapeshellarg()'s.
+
+Failures NOT ours (verified against devel history):
+- ui browser tier: test_alias_type_port_field_rejects_network_alias — already
+  red on the devel nightly (2026-07-03 07:55) before ADR-53 existed.
+- ui render tier: test_software_actions_link_to_package_manager — software
+  page untouched by ADR-53 (last src change 2026-07-02, green on the 07:55
+  nightly); body-state depends on update-availability, tracked separately.
+
+Re-dispatch after the fix commit: run URLs recorded below by the orchestrator.
+
+Run 2/3 findings (after the stderr + escaped-IP fixes):
+- alerts "+" Tier B e2e GREEN (both production fixes proven live).
+- test_smoke_suppression.py had its own _pfctl_test duplicate of the helper
+  (same stdout-only bug) — fixed to combine streams.
+- Run 3 exposed a REAL v6 engine bug: pfb_v6_cidr_to_range() rejected BARE
+  v6 host tokens (no /mask — the dominant feed shape) as malformed, so the
+  suppress pass DROPPED every bare host from the member file (fail-open:
+  hosts silently unblocked; caught by the sibling-still-matches assertion).
+  Fix: a bare address parses as its own /128. Red->green PHPUnit vectors
+  added (entry + hole + file level); the engine canonicalizes a surviving
+  bare host to addr/128 — set-equivalent, tolerated by the smoke oracle.

--- a/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/09_Results.txt
+++ b/.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/09_Results.txt
@@ -280,3 +280,21 @@ Run 2/3 findings (after the stderr + escaped-IP fixes):
   Fix: a bare address parses as its own /128. Red->green PHPUnit vectors
   added (entry + hole + file level); the engine canonicalizes a surviving
   bare host to addr/128 — set-equivalent, tolerated by the smoke oracle.
+
+--------------------------------------------------------------------------------
+ACCEPTANCE EVIDENCE (orchestrator — final, 2026-07-03)
+--------------------------------------------------------------------------------
+
+Min-CE validation leg (post-fix): smoke run 28678721902 = SUCCESS.
+
+Full CE+Plus fan-out (filtered to ADR-53 surfaces, -k "suppress(ion)"):
+- smoke 28678906679 = SUCCESS (CE 2.8 + Plus 26.03 — test_smoke_suppression.py
+  green on both legs: v4 /16 carve, v6 /64 carve, bare-host + /24 parity).
+- ui    28678907701: functional CE+Plus = SUCCESS (addsuppress e2e + v6
+  textarea save-persist), render CE+Plus = SUCCESS (ip page + v6 section).
+  browser CE+Plus legs exited pytest rc=5 (ZERO TESTS COLLECTED — the -k
+  filter matches no browser-tier test; ADR-53 adds none). Not a failure of
+  any ADR-53 test; the tier had nothing to prove.
+
+Every §4 acceptance requirement now maps to a green automated test on the
+CE+Plus fan-out. Status flips to Accepted once PR #768 lands on devel.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,6 +230,14 @@ jobs:
         # jq drives the ip_pre_AWS_*.sh region filters (required).
         run: sudo apt-get update && sudo apt-get install -y jq
 
+      - name: Install iprange
+        # Real `iprange --except` set-subtraction (ADR-53 P3): the same
+        # FireHOL iprange tool pfblockerng.sh's pathaggregate assumes at
+        # /usr/local/bin/iprange on the appliance. Locally the shellspec
+        # cases needing it skip when absent (house pattern); here it must be
+        # present so they actually run.
+        run: sudo apt-get update && sudo apt-get install -y iprange
+
       - name: Install shellspec
         # Pinned release tarball; the executable runs from its extracted tree.
         run: |

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -832,3 +832,76 @@ persistence), `test_smoke_apply_on_change.py` (apply without Force; quiet-hours 
 `test_trigger_api.py` (new API + deprecation log + HA), and the Update-page Tier A/B in
 `tests/smoke/ui/`. Per CLAUDE.md "ADR acceptance", ADR-43 moves to Accepted on the green CE+Plus
 live-VM fan-out of those cases.
+
+## IP suppression set-subtraction (ADR-53)
+
+Replaces the IP-side **Suppression** feature's host-explosion mechanism with genuine CIDR set
+subtraction, in both families. Suppression stays **content-level** (it edits the deny member
+files feeding every consumer — pf tables, ADR-11 aggregates, HAProxy `.lst`, killstates, the
+Alerts/Reports view) rather than a pf rule/table-negation trick (rejected: it would bypass the
+user's own block rules and still kill the exempted host's states — see ADR-53 §1.4).
+
+**The covering-CIDR math.** Subtracting a `/b` hole from a containing `/a` block costs exactly
+`b − a` covering-CIDR entries — one per prefix-length step from the hole up to the container —
+**independent of the hole's exact position** (a standard property of binary CIDR decomposition).
+Measured/pinned: `/24 − /32 = 8`, `/16 − /32 = 16`, `/16 − /24 = 8`, `/64 − /128 = 64` (v6). For
+`k` holes in one block the bound is `k × (b − a)`. This is the entire fix: the old mechanism
+enumerated hosts (`/24 − /32` = 254 lines; a v6 `/64 − /128` would be 2⁶⁴ — impossible), when the
+minimal remainder was always a few dozen lines.
+
+**v4 engine — `iprange --except`** (`pfblockerng.sh suppress()`). `iprange` is already a hard
+dependency (ADR-11's `pathaggregate`). One call per feed-changed Deny member file:
+`${pathaggregate} <member> --except <suppfile>` replaces the old `grep -F` + `seq 255` + awk
+explode. `rc=0` publishes (including a legitimately-empty result — a fully-suppressed member is
+valid, unlike `grepcidr`'s `rc=1`-means-empty quirk); any other `rc` keeps the previous list and
+logs (the same #713 fail-safe shape). **DNS-resolution hazard**: `iprange` is IPv4-only, mangles
+v6 input (parses it as a hostname), and — worse — treats any non-IP token as a **hostname and
+DNS-resolves it** (`rc=0` regardless, no opt-out flag). Both the member file and the suppression
+list are pre-filtered to strict IPv4/CIDR token shape (`pfb_is_cidr_token` / `pfb_is_ip_or_cidr_token`)
+before either reaches `iprange`, so a malformed token is dropped and logged, never DNS-resolved.
+
+**v6 engine — pure PHP** (`pfb_cidr_subtract_v6()` + `pfb_suppress_file_v6()`). `iprange` cannot
+take v6 input at all, so v6 is a from-scratch fixed-width 128-bit binary-string set-diff, emitting
+the minimal covering-CIDR remainder via pfSense's own `ip_range_to_subnet_array()` (verified at
+the min-CE dated ref, faithful PHPUnit double). Every binary-string comparison uses `strcmp()`,
+never `<`/`>`/`min()`/`max()` — a 128-char `'0'`/`'1'` string is a PHP "numeric string", and the
+normal comparison operators risk silent float-precision coercion on a string that long. Streaming,
+atomic tmp+rename publish, same fail-safe-keep-previous contract as v4. Measured perf bound (P5):
+1.24 s / 100k lines on the CI runner — comfortably inside the §7 reject threshold (5 s).
+
+**Wiring gotcha (flagged for the maintainer, not fixed in Phase 9):** `$pfb['supp_update']` — the
+flag that unlocks BOTH the v4 and v6 suppression sub-passes for a given reload pass — is set
+`TRUE` only by a **v4** Deny alias's own genuine reparse (`pfblockerng.inc` ~16550-16558, inside
+`if ($pfbadv && $list['vtype'] == '_v4')`). An install with **only** v6 Deny lists configured
+would never flip it, so v6 suppression would never fire in isolation even with `v6suppression`
+non-empty and a v6 alias genuinely changing. `tests/smoke/test_smoke_suppression.py`'s v6 scenario
+works around this (a trivial companion v4 Deny alias rides the same reload pass) rather than
+hiding it — a production box with both families configured behaves the same way. Candidate fix:
+also set `supp_update` on a v6 Deny alias's change; out of ADR-53 Phase 9's scope (test/docs only).
+
+**Consumer inheritance.** Every downstream reader — pf tables (via the ADR-40 mirror/reload
+model), ADR-11 aggregate aliases, HAProxy `.lst` (ADR-12), the Alerts/Reports "is this IP blocked"
+view, the widget, and killstates — reads the post-suppression member files, so the content-level
+fix reaches all of them with zero consumer-side changes. Killstates' suppression exclusion is
+prefix-aware via `pfb_ip_suppressed()` (both families), replacing the old exact-IP hashmap +
+`subnetv4_expand` host-materialisation.
+
+**Alerts "+" live punch — a SEPARATE mechanism, not this engine.** `pfb_live_punch_plan()`
+(`pfblockerng_extra.inc`) mutates the LIVE pf table directly from a single web click (locate the
+containing table entr(y/ies) via the ADR-40 mirror/`pfctl -T show` fallback, `pfctl -T delete` +
+`-T add` the covering-CIDR difference), independent of any reload — the update-time engines above
+never run for it. Covered by `tests/smoke/ui/test_alerts.py`'s
+`test_addsuppress_{v4,v6}_carves_containing_range_and_spares_sibling`; the update-time proof lives
+in `tests/smoke/test_smoke_suppression.py` and is a genuinely different code path, not duplicate
+coverage.
+
+**Tests.** Off-appliance: `tests/shell/pfblockerng_suppress_spec.sh` (real-`iprange` shellspec —
+the exact `/16 − /32 = 16` / `/24 − /32 = 8` vectors the smoke module's assertions are grounded
+in), `tests/php/V6CidrSubtractTest.php` (the pure-PHP engine, incl. the `/64 − /128 = 64` vector),
+`tests/php/SuppressionValidatorTest.php` (mask floors: v4 `/8`–`/32`, v6 `/32`–`/128`),
+`tests/php/CreateSuppressionFileTest.php`, `tests/php/KillstatesSuppressionTest.php`,
+`tests/php/LivePunchPlanTest.php`. Live-VM (ADR-04, dispatch-only):
+`tests/smoke/test_smoke_suppression.py` (this section's headline acceptance proof — both families,
+before-state asserted first, plus the whole-token/mask-agnostic upgrade-parity scenarios) and the
+Alerts "+" Tier B e2e above. Per CLAUDE.md "ADR acceptance", ADR-53 moves to Accepted on the green
+CE+Plus live-VM fan-out of those cases.

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -111,7 +111,6 @@ registered path set). Each annotation is committed in the relevant source file.
 
 | Section / Key | Reason |
 | --- | --- |
-| `pfblockerngipsettings/config/0/v4suppression` | Foreign section — not in registry |
 | `pfblockerngdnsbl/config/{row}/custom` | Dynamic per-row key, not in registry |
 | `pfblockerngdnsbl/config/{row}/logging` | Dynamic per-row key, not in registry |
 | `pfblockernglistsv4/config/{row}/custom` | Dynamic per-row key, not in registry |

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4676,6 +4676,31 @@ function pfb_cross_list_scope(bool $dup_on, bool $rep_on): bool {
 	return $dup_on || $rep_on;
 }
 
+/**
+ * pfb_supp_update_active — whether this pass should flip $pfb['supp_update']
+ * TRUE, unlocking BOTH families' suppression sub-pass this reload (ADR-53
+ * review finding A).
+ *
+ * $pfb['supp_update'] gates the v4 AND v6 suppression sub-passes alike
+ * (pfblockerng.inc's alias-build loop checks it for both '_v4' and '_v6'
+ * vtype passes). Before this fix it was set TRUE only inside the v4-only
+ * dedup/reputation block (`$pfbadv && $list['vtype'] == '_v4'`), so a
+ * deployment with ONLY v6 Deny aliases configured never flipped it and the
+ * v6 suppress pass could never fire, even with v6suppression populated. The
+ * fix is family-agnostic: any feed-changed DENY-folder alias (v4 or v6)
+ * unlocks suppression for this reload, mirroring the scope suppression
+ * itself already applies (Deny_* + Alias_Deny only, both families,
+ * ADR-53 §2.1 "Scope of application"). Dedup/reputation bookkeeping stays
+ * v4-only (ADR-53 §1.2) — that gate is untouched, only this one is split out.
+ *
+ * @param bool $pfbadv       TRUE for a Deny-folder alias (adv => TRUE).
+ * @param bool $supp_enabled TRUE when the master "Enable Suppression" toggle is on.
+ * @return bool TRUE = flip $pfb['supp_update'] TRUE for this reload.
+ */
+function pfb_supp_update_active(bool $pfbadv, bool $supp_enabled): bool {
+	return $pfbadv && $supp_enabled;
+}
+
 // ---------------------------------------------------------------------------
 // ADR-40 Phase 4 — forward-delta alias-table apply
 // ---------------------------------------------------------------------------
@@ -4959,7 +4984,12 @@ function pfb_build_if_list($show_wan=FALSE, $show_groups=FALSE) {
 function pfb_create_suppression_file() {
 	global $pfb;
 
-	$v4suppression = pfbng_text_area_decode($pfb['ipconfig']['v4suppression'], FALSE, TRUE);
+	// ADR-53 review finding B: '?? ""' -- both keys are absent from config.xml
+	// on every install until its first IP-settings save post-upgrade (the
+	// install migration only seeds v4suppression when a legacy
+	// pfBlockerNGSuppress alias existed; v6suppression is never migrated), so
+	// a direct array read here throws a PHP8 "undefined array key" warning.
+	$v4suppression = pfbng_text_area_decode($pfb['ipconfig']['v4suppression'] ?? '', FALSE, TRUE);
 	if (!empty($v4suppression)) {
 		@file_put_contents("{$pfb['supptxt']}", $v4suppression, LOCK_EX);
 	} else {
@@ -4967,7 +4997,7 @@ function pfb_create_suppression_file() {
 	}
 
 	// ADR-53 P6: v6 sibling -- same decode/write/unlink-when-empty shape as v4 above.
-	$v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'], FALSE, TRUE);
+	$v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', FALSE, TRUE);
 	if (!empty($v6suppression)) {
 		@file_put_contents("{$pfb['supptxt_v6']}", $v6suppression, LOCK_EX);
 	} else {
@@ -10196,8 +10226,11 @@ function pfb_remove_states() {
 	// '/24' materialisation -- which could only express a bare host or an exact '/24';
 	// any other containing mask (v4 '/8'-'/23', any v6 mask) silently stayed
 	// unsuppressed (ADR-53 §1.2/§2.2 -- a correctness strengthening).
-	$v4suppression = pfbng_text_area_decode($pfb['ipconfig']['v4suppression'], TRUE, FALSE);
-	$v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'], TRUE, FALSE);
+	// ADR-53 review finding B: '?? ""' -- same absent-key guard as
+	// pfb_create_suppression_file() (both keys are absent from config.xml
+	// until their first save on an upgraded or fresh install).
+	$v4suppression = pfbng_text_area_decode($pfb['ipconfig']['v4suppression'] ?? '', TRUE, FALSE);
+	$v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', TRUE, FALSE);
 
 	// Collect Interface list that have pfB Rules assigned
 	$data		= pfb_filterrules();
@@ -16556,13 +16589,17 @@ function sync_package_pfblockerng($cron='') {
 								$pfb_alias_lists[] = "{$alias}";
 
 								if ($pfbadv && $list['vtype'] == '_v4') {
-									// Execute Reputation functions, when changes are found.
+									// Execute Reputation functions, when changes are found
+									// (v4-only: dedup/reputation bookkeeping is v4-only,
+									// ADR-53 §1.2).
 									$pfb['repcheck'] = TRUE;
+								}
 
-									// Enable suppression process due to updates
-									if ($pfb['supp'] == 'on') {
-										$pfb['supp_update'] = TRUE;
-									}
+								// Enable suppression process due to updates -- BOTH families
+								// (ADR-53 review finding A): a v6-only Deny alias must also be
+								// able to unlock the v6 suppress pass below, not just v4's.
+								if (pfb_supp_update_active($pfbadv, $pfb['supp'] == 'on')) {
+									$pfb['supp_update'] = TRUE;
 								}
 							} else {
 								if (!$custom) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10191,24 +10191,13 @@ function pfb_remove_states() {
 	// List of IPs to suppress
 	$pfb_local = $pfb_localsub = array();
 
-	// Collect IPv4 Suppression list IPs
+	// Collect v4/v6 Suppression list entries (ADR-53 P7): checked prefix-aware via
+	// pfb_ip_suppressed() below, replacing the old exact-IP hashmap + subnetv4_expand()
+	// '/24' materialisation -- which could only express a bare host or an exact '/24';
+	// any other containing mask (v4 '/8'-'/23', any v6 mask) silently stayed
+	// unsuppressed (ADR-53 §1.2/§2.2 -- a correctness strengthening).
 	$v4suppression = pfbng_text_area_decode($pfb['ipconfig']['v4suppression'], TRUE, FALSE);
-	foreach ($v4suppression as $line) {
-		if (strpos($line, '/32') != FALSE) {
-			$pfb_local[] = str_replace('/32', '', $line);
-		}
-
-		// Convert '/24' CIDRs
-		$pfb_suppcidr = array();
-		if (strpos($line, '/24') !== FALSE && is_ipaddrv4($line)) {
-			$pfb_suppcidr	= subnetv4_expand($line);
-			$pfb_local	= array_merge($pfb_local, $pfb_suppcidr);
-		}
-	}
-
-	if (!empty($pfb_local)) {
-		$pfb_local = array_flip($pfb_local);
-	}
+	$v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'], TRUE, FALSE);
 
 	// Collect Interface list that have pfB Rules assigned
 	$data		= pfb_filterrules();
@@ -10322,6 +10311,7 @@ function pfb_remove_states() {
 				if ($ip_version == 4) {
 					if (isset($pfb_local[$s_ip]) ||
 					    pfb_local_ip($s_ip, $pfb_localsub) ||
+					    pfb_ip_suppressed($s_ip, $v4suppression) ||
 					    is_private_ip($s_ip) ||
 					    substr($s_ip, 0, 2) == '0.' ||
 					    substr($s_ip, 0, 4) == '127.' ||
@@ -10332,6 +10322,7 @@ function pfb_remove_states() {
 				else {
 					if (isset($pfb_local[$s_ip]) ||
 					    pfb_local_ip($s_ip, $pfb_localsub) ||
+					    pfb_ip_suppressed($s_ip, $v6suppression) ||
 					    !filter_var($s_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
 						continue;
 					}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -92,6 +92,7 @@ $pfb['dnsbl_parse_err']	= "{$pfb['logdir']}/dnsbl_parsed_error.log";
 
 $pfb['master']		= "{$pfb['dbdir']}/masterfile";
 $pfb['supptxt']		= "{$pfb['dbdir']}/pfbsuppression.txt";
+$pfb['supptxt_v6']	= "{$pfb['dbdir']}/pfbsuppression_v6.txt";	// ADR-53 P6: IPv6 suppression customlist
 $pfb['dnsbl_supptxt']	= "{$pfb['dbdir']}/pfbdnsblsuppression.txt";
 $pfb['geoip_isos']	= "{$pfb['dbdir']}/geoip.txt";
 $pfb['dnsbl_info']	= '/var/unbound/pfb_py_dnsbl.sqlite';
@@ -4954,7 +4955,7 @@ function pfb_build_if_list($show_wan=FALSE, $show_groups=FALSE) {
 }
 
 
-// Create suppression file from suppression list
+// Create suppression file(s) from the v4/v6 suppression lists
 function pfb_create_suppression_file() {
 	global $pfb;
 
@@ -4963,6 +4964,14 @@ function pfb_create_suppression_file() {
 		@file_put_contents("{$pfb['supptxt']}", $v4suppression, LOCK_EX);
 	} else {
 		unlink_if_exists("{$pfb['supptxt']}");
+	}
+
+	// ADR-53 P6: v6 sibling -- same decode/write/unlink-when-empty shape as v4 above.
+	$v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'], FALSE, TRUE);
+	if (!empty($v6suppression)) {
+		@file_put_contents("{$pfb['supptxt_v6']}", $v6suppression, LOCK_EX);
+	} else {
+		unlink_if_exists("{$pfb['supptxt_v6']}");
 	}
 }
 
@@ -12809,6 +12818,7 @@ function pfb_clear_contents() {
 	unlink_if_exists("{$pfb['dbdir']}/masterfile");
 	unlink_if_exists("{$pfb['dbdir']}/mastercat");
 	unlink_if_exists("{$pfb['supptxt']}");
+	unlink_if_exists("{$pfb['supptxt_v6']}");
 	unlink_if_exists("{$pfb['dnsbl_supptxt']}");
 	unlink_if_exists("{$pfb['dnsbl_info']}");
 	unlink_if_exists("{$pfb['dnsbl_resolver']}");
@@ -16745,6 +16755,34 @@ function sync_package_pfblockerng($cron='') {
 											exec("{$pfb['script']} suppress {$header_esc} {$pfbfolder} off {$elog}");
 										}
 									}
+
+									// ADR-53 P6: v6 sibling of the v4 suppression block above -- a direct
+									// PHP call (pfb_suppress_file_v6()), no shell round-trip (ADR-53 §2.1 v6
+									// wiring). No masterfile/dedup resync here: that bookkeeping is v4-only
+									// (§1.2). $pfbrunonce is reset TRUE at the top of EVERY vtype pass (see
+									// the "$pfbrunonce = TRUE;" above the alias loop), so it is still
+									// available -- untouched by the v4 branch above during a '_v6' pass --
+									// to gate this print-once header the same way v4 gates its own.
+									if ($pfbrunonce && $pfb['supp'] == 'on' && $vtype == '_v6' && $pfb['supp_update']) {
+										$supp_v6_header = "\n===[ Suppression Stats (v6) ]===============================\n\n"
+											. sprintf("%-20s %-10s %-10s\n", 'List', 'Pre', 'Suppress')
+											. "-------------------------------------------------------------\n";
+										@file_put_contents("{$pfb['log']}", $supp_v6_header, FILE_APPEND);
+										$pfbrunonce = FALSE;
+									}
+									if ($pfb['supp'] == 'on' && $vtype == '_v6' && $pfb['supp_update'] && $pfbadv
+									    && in_array($alias, $final_alias_old)
+									    && is_readable("{$pfb['supptxt_v6']}") && filesize("{$pfb['supptxt_v6']}") > 0) {
+										$member_file = "{$pfbfolder}/{$header}.txt";
+										$pre_count   = count(@file($member_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: []);
+										if (pfb_suppress_file_v6($member_file, "{$pfb['supptxt_v6']}")) {
+											$post_count = count(@file($member_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: []);
+											@file_put_contents("{$pfb['log']}", sprintf("%-20s %-10s %-10s\n", $header, $pre_count, $post_count), FILE_APPEND);
+										} else {
+											pfb_logger(" Suppression {$header}: v6 suppression failed; keeping previous list", 2);
+										}
+									}
+
 									$alias_ips .= file_get_contents("{$pfbfolder}/{$header}.txt");
 									$pfbupdate = TRUE;
 								}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -162,9 +162,10 @@ pfb_is_octet_prefix() {
 }
 
 # A CIDR token: digits/dots, then EXACTLY one '/', then a non-empty numeric mask
-# (e.g. '10.0.0.1/32'). The suppress() caller splits on '/' and compares the mask
-# with -eq, so a bare IP, an empty mask ('10.0.0.1/'), or a double slash
-# ('10.0.0.1//32') is rejected here and skipped rather than reaching that compare.
+# (e.g. '10.0.0.1/32'). suppress() (ADR-53) uses this to pre-filter the
+# suppression list -- always mask-annotated (pfblockerng_ip.php's validation)
+# -- before it reaches iprange: a bare IP, an empty mask ('10.0.0.1/'), or a
+# double slash ('10.0.0.1//32') is rejected here and skipped.
 pfb_is_cidr_token() {
 	case "${1}" in
 		''|*[!0-9./]*|*/*/*|/*|*/) return 1 ;;
@@ -172,6 +173,27 @@ pfb_is_cidr_token() {
 	[ "${1#*/}" = "${1}" ] && return 1   # must contain a slash
 	case "${1##*/}" in
 		''|*[!0-9]*) return 1 ;;          # mask must be non-empty digits
+	esac
+	return 0
+}
+
+# An IPv4 host-OR-CIDR token: either a bare host (digits/dots only, e.g.
+# '203.0.113.5') or a CIDR (digits/dots, EXACTLY one '/', non-empty numeric
+# mask, e.g. '10.9.8.0/24'). Unlike pfb_is_cidr_token (which REQUIRES the
+# mask), member/deny-list lines are a mix of bare hosts and CIDRs. suppress()
+# (ADR-53) uses this to pre-filter the deny member file before it reaches
+# iprange: iprange treats anything of the wrong shape as a HOSTNAME and
+# DNS-resolves it (rc=0, no opt-out flag) rather than rejecting it.
+pfb_is_ip_or_cidr_token() {
+	case "${1}" in
+		''|*[!0-9./]*|*/*/*|/*|*/) return 1 ;;
+	esac
+	case "${1}" in
+		*/*)
+			case "${1##*/}" in
+				''|*[!0-9]*) return 1 ;;  # mask must be non-empty digits
+			esac
+			;;
 	esac
 	return 0
 }
@@ -467,10 +489,15 @@ EOF
 	fi
 }
 
-# Process to remove suppressed entries.
+# Process to remove suppressed entries. Set-subtracts every suppression entry
+# from the deny member file via `iprange --except` (ADR-53): a single call
+# performs exact CIDR set subtraction and publishes the minimal covering-CIDR
+# remainder, so a suppressed host is carved out of ANY containing entry (not
+# just the exact /24 the old grep -F explode required) -- with no per-hole
+# dedup bookkeeping, since iprange subtracts every hole in one pass.
 suppress() {
-	if [ ! -x "${pathgrepcidr}" ]; then
-		log="Application [ grepcidr ] Not found. Cannot proceed."
+	if [ ! -x "${pathaggregate}" ]; then
+		log="Application [ iprange ] Not found. Cannot proceed."
 		echo "${log}" | tee -a "${errorlog}"
 		return
 	fi
@@ -487,72 +514,50 @@ suppress() {
 			fi
 
 			pfbfolder="${max}/"
-			counter=0; : > "${dupfile}"
 
 			if [ -n "${alias}" ]; then
 				countg="$(grep -c ^ "${pfbfolder}${alias}.txt")"
-				cp "${pfbfolder}${alias}.txt" "${tempfile}"
 
-				# Iterate the suppression entries safely (no IFS re-splitting) via a
-				# here-doc so the loop body stays in THIS shell -- it accumulates
-				# ${counter} and appends to ${dupfile}/${tempfile}, which a `while|read`
-				# subshell would discard. Validate each token to a CIDR shape
-				# (digits/dots/slashes) and skip a malformed one, so only literal
-				# octet text reaches the fixed-string greps below.
+				# Strict-shape pre-filter on BOTH inputs before either reaches iprange
+				# (ADR-53 §1.2): a malformed token is NOT rejected by iprange -- it is
+				# silently treated as a HOSTNAME and DNS-resolved (rc=0, no opt-out
+				# flag), so anything not a bare IPv4 host or IPv4 CIDR must never
+				# reach it. The suppression list is user free-text; the member file
+				# is already-sanitised feed data, filtered again here as
+				# defense-in-depth, not because it is expected to need it.
+				: > "${dupfile}"
 				while IFS= read -r ip; do
-					pfb_is_cidr_token "${ip}" || continue
-					found=''; dcheck='';
-					mask="${ip##*/}"
-					iptrim="${ip%.*}"
-					ip="${ip%%/*}"
-					# Fixed-string match: '${iptrim}.0/24' is a literal whole token,
-					# no anchor needed, so grep -F matches it exactly (the '.' is a
-					# literal dot, not a regex 'any char').
-					found="$(grep -F -m1 "${iptrim}.0/24" "${tempfile}")"
-
-					# If a suppression is '/32' and a blocklist has a full '/24' block, execute the following.
-					if [ -n "${found}" ] && [ "${mask}" -eq 32 ]; then
-						echo " Suppression ${alias}: ${iptrim}.0/24 (Excluding: ${ip}/32)"
-						octet4="${ip##*.}"
-						dcheck="$(grep -F "${iptrim}.0/24" "${dupfile}")"
-
-						if [ -z "${dcheck}" ]; then
-							echo "${iptrim}.0/24" >> "${dupfile}"
-							counter="$((counter + 1))"
-
-							# Add individual IP addresses from range excluding suppressed IP
-							for i in $(seq 255); do
-								if [ "${i}" != "${octet4}" ]; then
-									echo "${iptrim}.${i}" >> "${tempfile}"
-									counter="$((counter + 1))"
-								fi
-							done
-						fi
+					if pfb_is_cidr_token "${ip}"; then
+						echo "${ip}" >> "${dupfile}"
+					elif [ -n "${ip}" ]; then
+						log=" Suppression ${alias}: dropping malformed suppression entry [ ${ip} ]"
+						echo "${log}" | tee -a "${errorlog}"
 					fi
 				done <<EOF
 ${data}
 EOF
 
-				if [ -s "${dupfile}" ]; then
-					# Remove '/24' suppressed ranges
-					# #713: gate the publish on awk's own exit status (awk has no "empty
-					# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
-					# can't truncate the working copy via an unconditional mv.
-					awk 'FNR==NR{a[$0];next}!($0 in a)' "${dupfile}" "${tempfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${tempfile}"
-				fi
+				: > "${dedupfile}"
+				while IFS= read -r ip; do
+					pfb_is_ip_or_cidr_token "${ip}" || continue
+					echo "${ip}" >> "${dedupfile}"
+				done < "${pfbfolder}${alias}.txt"
 
-				# Remove all other suppressions from list. #713: redirect to a scratch
-				# temp and gate the publish on grepcidr's exit status -- rc 0 (matches
-				# removed) and rc 1 (everything suppressed, a LEGITIMATE empty result)
-				# both replace the live list; rc >= 2 is a real grepcidr error, so keep
-				# the previous list intact (no truncation) and warn instead.
-				"${pathgrepcidr}" -vf "${pfbsuppression}" "${tempfile}" > "${tempfile2}"
-				grc=$?
-				if [ "${grc}" -lt 2 ]; then
+				# iprange --except merges the files before it (ipset A, here the
+				# member file) and removes every IP found in the files after it
+				# (here the suppression file), printing the minimal covering-CIDR
+				# remainder. rc=0 is success -- INCLUDING a legitimately-empty
+				# result (everything suppressed; iprange has no grepcidr-style
+				# "rc=1 = empty" quirk to special-case). Any other rc is a real
+				# error (e.g. a missing/unloadable file): keep the previous list
+				# intact and log, mirroring the #713 fail-safe pattern.
+				"${pathaggregate}" "${dedupfile}" --except "${dupfile}" > "${tempfile2}"
+				irc=$?
+				if [ "${irc}" -eq 0 ]; then
 					mv -f "${tempfile2}" "${pfbfolder}${alias}.txt"
 				else
 					rm -f "${tempfile2}"
-					log="grepcidr error (rc=${grc}) suppressing [ ${alias} ]; keeping previous list"
+					log="iprange error (rc=${irc}) suppressing [ ${alias} ]; keeping previous list"
 					echo "${log}" | tee -a "${errorlog}"
 				fi
 
@@ -577,8 +582,7 @@ EOF
 
 				countk="$(grep -c ^ "${masterfile}")"
 				countx="$(grep -c ^ "${pfbfolder}${alias}.txt")"
-				counto="$((countx - counter))"
-				printf "%-20s %-10s %-10s %-10s\n" "${alias}" "${countg}" "${counto}" "${countk}"
+				printf "%-20s %-10s %-10s %-10s\n" "${alias}" "${countg}" "${countx}" "${countk}"
 			fi
 		fi
 	fi

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -537,11 +537,21 @@ suppress() {
 ${data}
 EOF
 
-				: > "${dedupfile}"
-				while IFS= read -r ip; do
-					pfb_is_ip_or_cidr_token "${ip}" || continue
-					echo "${ip}" >> "${dedupfile}"
-				done < "${pfbfolder}${alias}.txt"
+				# Member-file pre-filter: ONE grep -E pass, not a pure-shell
+				# `while read` loop over the whole deny member file -- measured
+				# ~10s at 200k lines for the loop vs ~0.04s for grep (~250x), and
+				# a single grep is also immune to the classic "last line dropped
+				# when the file lacks a trailing newline" while-read trap. The
+				# ERE reproduces pfb_is_ip_or_cidr_token() EXACTLY: digits/dots
+				# only, at most one '/', a non-empty digits-only mask when
+				# present, never a leading or trailing '/' -- do not tighten this
+				# to a stricter dotted-quad pattern, the function itself is lax.
+				grep -E '^[0-9.]+(/[0-9]+)?$' "${pfbfolder}${alias}.txt" > "${dedupfile}"
+				countd="$(grep -c ^ "${dedupfile}")"
+				if [ "${countd}" -lt "${countg}" ]; then
+					log=" Suppression ${alias}: dropped $((countg - countd)) malformed member-file line(s) before iprange"
+					echo "${log}" | tee -a "${errorlog}"
+				fi
 
 				# iprange --except merges the files before it (ipset A, here the
 				# member file) and removes every IP found in the files after it

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2940,6 +2940,116 @@ function pfb_ip_suppressed(string $ip, array $entries): bool
 	return FALSE;
 }
 
+// ---------------------------------------------------------------------------
+// ADR-53 P8 -- Alerts "+" / widget live-punch plan (any mask + v6)
+// ---------------------------------------------------------------------------
+//
+// The Alerts "+" button (and the dashboard widget, which shares its stats
+// read of the same suppression config) used to punch a hole in a live pf
+// table by deleting an exact '/24' and re-adding 254 sibling hosts, refusing
+// anything "blocked by a CIDR other than /24" (ADR-53 §1.2). This replaces
+// that with the same covering-CIDR set-subtraction already proven for the
+// persisted engines (P3's v4 `iprange --except` pass, P5's v6 PHP pass):
+// locate the table entr(y/ies) that actually contain the host, delete them,
+// and re-add only the covering-CIDR remainder -- any mask, both families.
+
+/**
+ * pfb_v4_carve_single -- the covering-CIDR remainder of one IPv4 CIDR (or
+ * bare host, normalised to '/32') with a single host removed. The IPv4
+ * sibling of pfb_cidr_subtract_v6(), scoped to the one-entry/one-hole shape
+ * the live punch actually needs -- pfb_cidr_subtract_v6() stays the only
+ * general multi-hole engine (the v4 persisted engine already has its own for
+ * that, P3's `iprange --except`). A v4 range fits a plain PHP int (32 bits,
+ * ip2long32() already returns it unsigned on 64-bit PHP), so no
+ * binary-string arithmetic is needed here.
+ *
+ * PURE.
+ *
+ * @param  string $cidr    The containing table entry ('addr/bits' or bare host).
+ * @param  string $host_ip The single IPv4 host to carve out (assumed to fall
+ *                          inside $cidr -- the caller establishes containment
+ *                          via ip_in_subnet() before calling).
+ * @return string[] Covering CIDRs for $cidr minus $host_ip (empty when $cidr
+ *                    IS $host_ip -- an exact host match, nothing left to add back).
+ */
+function pfb_v4_carve_single(string $cidr, string $host_ip): array
+{
+	$cidr  = str_contains($cidr, '/') ? $cidr : "{$cidr}/32";
+	[$addr, $bits] = explode('/', $cidr, 2);
+	$bits  = (int) $bits;
+	$mask  = $bits === 0 ? 0 : ((0xFFFFFFFF << (32 - $bits)) & 0xFFFFFFFF);
+	$start = ip2long32($addr) & $mask;
+	$end   = $start | ((~$mask) & 0xFFFFFFFF);
+	$hole  = ip2long32($host_ip);
+
+	$out = [];
+	if ($hole > $start) {
+		array_push($out, ...ip_range_to_subnet_array(long2ip32($start), long2ip32($hole - 1)));
+	}
+	if ($hole < $end) {
+		array_push($out, ...ip_range_to_subnet_array(long2ip32($hole + 1), long2ip32($end)));
+	}
+	return $out;
+}
+
+/**
+ * pfb_live_punch_plan -- compute the live pf-table punch for the Alerts "+"
+ * / widget suppression action (ADR-53 §2.1 fork 3): which existing table
+ * entries contain $ip (to `pfctl -T delete`) and which covering CIDRs
+ * replace them (to `pfctl -T add`) -- a genuine set-subtraction, replacing
+ * the retired /24-only 254-host re-add loop.
+ *
+ * $table_entries are raw lines from the table's membership snapshot (the
+ * ADR-40 mirror file, or a `pfctl -T show` fallback) -- bare host tokens
+ * ("1.2.3.4") or CIDR tokens ("1.2.3.0/24"), either family; blank/'#'-comment
+ * lines are tolerated (skipped). A bare host token is treated as an exact
+ * /32 or /128 -- containing ONLY itself, so punching it needs no
+ * covering-CIDR add (delete only, same as the old exact-/32-match case).
+ *
+ * PURE -- no pfctl/pf-table access; the caller supplies the already-read
+ * membership snapshot (streamed, never slurped whole -- see the alerts page
+ * call site) and applies the returned plan.
+ *
+ * @param  string   $ip             The host to carve out (v4 or v6).
+ * @param  string[] $table_entries  Raw table membership lines.
+ * @return array{delete: string[], add: string[]} 'delete' = every containing
+ *         entry to remove; 'add' = the covering-CIDR remainder to re-add
+ *         (empty when every containing entry was an exact host match).
+ */
+function pfb_live_punch_plan(string $ip, array $table_entries): array
+{
+	$delete    = [];
+	$add       = [];
+	$is_v6     = str_contains($ip, ':');
+	$host_cidr = $ip . ($is_v6 ? '/128' : '/32');
+
+	foreach ($table_entries as $entry) {
+		$entry = trim((string) $entry);
+		if ($entry === '' || str_starts_with($entry, '#')) {
+			continue;
+		}
+		$cidr = str_contains($entry, '/') ? $entry : $entry . ($is_v6 ? '/128' : '/32');
+
+		if (!ip_in_subnet($ip, $cidr)) {
+			continue;
+		}
+
+		$delete[] = $entry;
+
+		if ($cidr === $host_cidr) {
+			continue; // exact host match -- nothing to re-add
+		}
+
+		if ($is_v6) {
+			array_push($add, ...pfb_cidr_subtract_v6([$cidr], [$host_cidr]));
+		} else {
+			array_push($add, ...pfb_v4_carve_single($cidr, $ip));
+		}
+	}
+
+	return ['delete' => $delete, 'add' => $add];
+}
+
 // logger() and localize_text() are pfSense-core helpers (src/etc/inc/util.inc)
 // on pfSense Plus / master, but absent from released pfSense CE <= 2.8.1. Define
 // fallbacks ONLY when core does not provide them, so this package runs on both:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2567,6 +2567,301 @@ function pfb_validate_suppression_line(string $line, string $family): ?string
 	return NULL;
 }
 
+// ---------------------------------------------------------------------------
+// ADR-53 P5 — pure IPv6 CIDR set-subtraction engine
+// ---------------------------------------------------------------------------
+//
+// IPv6 suppression can't carve by host enumeration (a /64 minus a /128 hole is
+// 2^64 hosts -- ADR-53 §1.2) and `iprange` mangles v6 input outright (it parses
+// a v6 literal as a hostname). Unlike the v4 engine (Phase 3's `iprange
+// --except`), this is a pure-PHP set subtraction over fixed-width 128-bit
+// binary-string ranges, emitting the minimal covering-CIDR remainder via
+// pfSense's own ip_range_to_subnet_array() -- the REAL on-appliance function
+// (never redefined here; a faithful double stands in for it under PHPUnit,
+// see tests/php/pfsense_doubles.php).
+//
+// Every binary-string comparison below goes through strcmp(), NEVER the bare
+// <, >, <=, >=, min(), max() operators: a 128-char string of '0'/'1' digits is
+// a PHP "numeric string", and comparing two of those the normal way risks a
+// silent (lossy, float-precision) numeric coercion for a string this long.
+// strcmp() is the only byte-exact comparison for a fixed-width digit string.
+
+/**
+ * pfb_v6_cidr_to_range — parse one IPv6 CIDR token ('addr/bits') into its
+ * [start, end] 128-bit binary-string range (fixed-width '0'/'1' strings,
+ * lexically ordered exactly like the address's numeric value).
+ *
+ * A blank line or a '#'-led comment (the same tolerance
+ * pfb_validate_suppression_line() applies to the persisted suppression file)
+ * parses to NULL with $is_blank = TRUE -- a silent no-op, never an error. Any
+ * other syntactically invalid token (no '/', out-of-range mask, unparseable
+ * address) also returns NULL, but with $is_blank = FALSE so the caller
+ * reports it.
+ *
+ * PURE.
+ *
+ * @param  string     $token     One raw CIDR line, untrimmed.
+ * @param  bool|null &$is_blank  Set TRUE for a comment/blank no-op, FALSE otherwise.
+ * @return array{0:string,1:string}|null [start_bin, end_bin], or NULL when unparseable.
+ */
+function pfb_v6_cidr_to_range(string $token, ?bool &$is_blank = null): ?array
+{
+	$is_blank = FALSE;
+	$token = trim($token);
+	if ($token === '' || str_starts_with($token, '#')) {
+		$is_blank = TRUE;
+		return NULL;
+	}
+
+	if (!is_subnetv6($token)) {
+		return NULL;
+	}
+
+	[$addr, $bits_raw] = explode('/', $token, 2);
+	$bits = (int) $bits_raw;
+
+	$packed = @inet_pton($addr);
+	if ($packed === FALSE || strlen($packed) !== 16) {
+		return NULL;
+	}
+	$addr_bin = '';
+	foreach (str_split($packed) as $byte) {
+		$addr_bin .= sprintf('%08b', ord($byte));
+	}
+
+	$host_len = 128 - $bits;
+	$start    = substr($addr_bin, 0, $bits) . str_repeat('0', $host_len);
+	$end      = substr($addr_bin, 0, $bits) . str_repeat('1', $host_len);
+
+	return [$start, $end];
+}
+
+/**
+ * pfb_v6_bin_inc — increment a 128-bit binary string by one address.
+ *
+ * PURE.
+ *
+ * @return string|null The incremented string, or NULL on overflow (input was
+ *                      all '1's -- ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff).
+ */
+function pfb_v6_bin_inc(string $bin): ?string
+{
+	$pos = strrpos($bin, '0');
+	if ($pos === FALSE) {
+		return NULL;
+	}
+	return substr($bin, 0, $pos) . '1' . str_repeat('0', strlen($bin) - $pos - 1);
+}
+
+/**
+ * pfb_v6_bin_dec — decrement a 128-bit binary string by one address.
+ *
+ * PURE.
+ *
+ * @return string|null The decremented string, or NULL on underflow (input was
+ *                      all '0's -- ::).
+ */
+function pfb_v6_bin_dec(string $bin): ?string
+{
+	$pos = strrpos($bin, '1');
+	if ($pos === FALSE) {
+		return NULL;
+	}
+	return substr($bin, 0, $pos) . '0' . str_repeat('1', strlen($bin) - $pos - 1);
+}
+
+/**
+ * pfb_v6_bin_to_addr — pack a 128-bit binary string back into a textual IPv6
+ * address. Any valid textual form works: ip_range_to_subnet_array() re-derives
+ * its own binary representation from whatever is passed in, so the specific
+ * notation returned here is not load-bearing.
+ *
+ * PURE.
+ */
+function pfb_v6_bin_to_addr(string $bin): string
+{
+	$bin    = str_pad($bin, 128, '0', STR_PAD_LEFT);
+	$packed = '';
+	foreach (str_split($bin, 8) as $byte_bin) {
+		$packed .= chr(bindec($byte_bin));
+	}
+	return inet_ntop($packed);
+}
+
+/**
+ * pfb_v6_emit_covering_cidrs — the minimal covering-CIDR set for one
+ * [start, end] binary-string range, via pfSense's ip_range_to_subnet_array().
+ *
+ * @return string[] CIDR strings ('addr/bits').
+ */
+function pfb_v6_emit_covering_cidrs(string $start_bin, string $end_bin): array
+{
+	return ip_range_to_subnet_array(pfb_v6_bin_to_addr($start_bin), pfb_v6_bin_to_addr($end_bin));
+}
+
+/**
+ * pfb_cidr_subtract_v6 — set-subtract $holes from $cidrs (both IPv6 CIDR
+ * arrays), returning the minimal covering-CIDR remainder (ADR-53 §2.1 v6
+ * engine).
+ *
+ * Each entry in $cidrs is carved independently: every hole that intersects it
+ * is removed (fully, partially, or not at all), so a hole spanning multiple
+ * entries subtracts from each in turn; a hole containing an entry removes it
+ * entirely; an entry with no intersecting hole re-emits unchanged (still
+ * routed through ip_range_to_subnet_array() so notation/merging stays
+ * consistent with the carved path -- ADR-53 §2.3 fork 4). An
+ * entirely-suppressed input legitimately returns [] (ADR-53 §2.2
+ * empty-is-legit).
+ *
+ * A malformed token in EITHER array is skipped -- never a throw that aborts
+ * the whole file -- and appended to $errors verbatim; a blank/'#'-comment
+ * line is a silent no-op and never reported.
+ *
+ * PURE -- no config access, no I/O.
+ *
+ * @param  string[]       $cidrs    Feed/member CIDR lines to carve.
+ * @param  string[]       $holes    Suppression CIDR lines to carve out.
+ * @param  string[]|null &$errors   By-ref out param: the raw malformed tokens
+ *                                  skipped from either array (both sides pooled).
+ * @return string[] The covering-CIDR remainder (no particular guaranteed order).
+ */
+function pfb_cidr_subtract_v6(array $cidrs, array $holes, ?array &$errors = null): array
+{
+	$errors = [];
+
+	$entries = [];
+	foreach ($cidrs as $token) {
+		$is_blank = FALSE;
+		$range    = pfb_v6_cidr_to_range((string) $token, $is_blank);
+		if ($range === NULL) {
+			if (!$is_blank) {
+				$errors[] = (string) $token;
+			}
+			continue;
+		}
+		$entries[] = $range;
+	}
+
+	$hole_ranges = [];
+	foreach ($holes as $token) {
+		$is_blank = FALSE;
+		$range    = pfb_v6_cidr_to_range((string) $token, $is_blank);
+		if ($range === NULL) {
+			if (!$is_blank) {
+				$errors[] = (string) $token;
+			}
+			continue;
+		}
+		$hole_ranges[] = $range;
+	}
+
+	// Sort once, up front (not per entry): the per-entry filter below preserves
+	// this order, so no repeated sort is needed.
+	usort($hole_ranges, static function (array $a, array $b): int {
+		return strcmp($a[0], $b[0]);
+	});
+
+	$out = [];
+	foreach ($entries as [$estart, $eend]) {
+		// Clip every hole that intersects this entry to the entry's own bounds.
+		$intersecting = [];
+		foreach ($hole_ranges as [$hstart, $hend]) {
+			if (strcmp($hstart, $eend) > 0 || strcmp($hend, $estart) < 0) {
+				continue; // no overlap with this entry
+			}
+			$intersecting[] = [
+				strcmp($hstart, $estart) > 0 ? $hstart : $estart, // clipped start
+				strcmp($hend, $eend) < 0 ? $hend : $eend,         // clipped end
+			];
+		}
+
+		if (empty($intersecting)) {
+			// array_push(...$x) appends in place (amortised O(k) for k new
+			// elements) -- NEVER `$out = array_merge($out, $x)` here, which would
+			// recopy the whole accumulated $out on every one of up to ~100k
+			// entries (an O(n^2) blowup measured at 22s for a 100k-line file;
+			// this form measured well under a second for the same input).
+			array_push($out, ...pfb_v6_emit_covering_cidrs($estart, $eend));
+			continue;
+		}
+
+		// Walk the (already sorted) intersecting holes, emitting the gap before
+		// each one, then advancing the cursor past it; a final gap after the
+		// last hole (if any) closes out the entry.
+		$cursor = $estart;
+		foreach ($intersecting as [$hstart, $hend]) {
+			if ($cursor === NULL) {
+				break; // already carved to the top of the address space
+			}
+			if (strcmp($hstart, $cursor) > 0) {
+				$gap_end = pfb_v6_bin_dec($hstart);
+				if ($gap_end !== NULL) {
+					array_push($out, ...pfb_v6_emit_covering_cidrs($cursor, $gap_end));
+				}
+			}
+			if (strcmp($hend, $cursor) >= 0) {
+				$cursor = pfb_v6_bin_inc($hend);
+			}
+		}
+		if ($cursor !== NULL && strcmp($cursor, $eend) <= 0) {
+			array_push($out, ...pfb_v6_emit_covering_cidrs($cursor, $eend));
+		}
+	}
+
+	return $out;
+}
+
+/**
+ * pfb_suppress_file_v6 — set-subtract $suppfile's IPv6 suppression entries
+ * from $file's member-list CIDR lines and publish the covering-CIDR
+ * remainder, atomically.
+ *
+ * Fail-safe (ADR-53 §2.2): either input missing/unreadable -> FALSE, $file is
+ * left untouched -- never a truncated publish on error. On success, publishes
+ * via a same-directory tmp+rename (an atomic POSIX rename, so no reader ever
+ * observes a partial file); a legitimately-empty remainder (everything
+ * suppressed) still publishes an empty file, never a stale one. A non-CIDR
+ * line in either input is dropped and logged (pfb_logger), never fatal.
+ *
+ * PURE aside from the single target-file write (+ its companion log lines).
+ *
+ * @param  string $file     Member/deny CIDR list to carve (rewritten in place).
+ * @param  string $suppfile Suppression CIDR list (the holes).
+ * @return bool TRUE on a successful publish (including an empty one), FALSE
+ *              on any fail-safe path (previous $file left intact).
+ */
+function pfb_suppress_file_v6(string $file, string $suppfile): bool
+{
+	if (!is_readable($file) || !is_readable($suppfile)) {
+		return FALSE;
+	}
+
+	$cidrs = @file($file, FILE_IGNORE_NEW_LINES);
+	$holes = @file($suppfile, FILE_IGNORE_NEW_LINES);
+	if ($cidrs === FALSE || $holes === FALSE) {
+		return FALSE;
+	}
+
+	$errors = [];
+	$result = pfb_cidr_subtract_v6($cidrs, $holes, $errors);
+
+	foreach ($errors as $bad_token) {
+		pfb_logger("IPv6 Suppression: dropping malformed entry [ {$bad_token} ]", 2);
+	}
+
+	$tmp  = $file . '.tmp';
+	$body = empty($result) ? '' : implode(PHP_EOL, $result) . PHP_EOL;
+	if (@file_put_contents($tmp, $body, LOCK_EX) === FALSE) {
+		return FALSE;
+	}
+	if (!@rename($tmp, $file)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
 // logger() and localize_text() are pfSense-core helpers (src/etc/inc/util.inc)
 // on pfSense Plus / master, but absent from released pfSense CE <= 2.8.1. Define
 // fallbacks ONLY when core does not provide them, so this package runs on both:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -321,6 +321,11 @@ function pfb_cfg_registry(): array
 	// -----------------------------------------------------------------------
 	$ss = 'installedpackages/pfblockerngsafesearch';
 
+	// -----------------------------------------------------------------------
+	// Section: installedpackages/pfblockerngipsettings/config/0
+	// -----------------------------------------------------------------------
+	$ip = 'installedpackages/pfblockerngipsettings/config/0';
+
 	$registry = [
 
 		// -------------------------------------------------------------------
@@ -1107,6 +1112,24 @@ function pfb_cfg_registry(): array
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 			'since'         => '2.0.0',
+		],
+
+		// -------------------------------------------------------------------
+		// IP settings section (pfblockerngipsettings/config/0)
+		// -------------------------------------------------------------------
+
+		// ADR-53: IPv4 suppression customlist -- CIDR/host carve-outs from the
+		// Deny alias set, stored as a base64-encoded newline-separated list
+		// (same shape as the DNSBL 'suppression' blob above). Registered so
+		// every call site routes through the gateway; this is a legacy key
+		// from the original addon (mirrors the '1.0.0' vintage of the sibling
+		// DNSBL blob fields). Default ''.
+		'v4suppression' => [
+			'section'       => $ip,
+			'default'       => '',
+			'read_adapter'  => NULL,
+			'write_adapter' => NULL,
+			'since'         => '1.0.0',
 		],
 	];
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1131,6 +1131,18 @@ function pfb_cfg_registry(): array
 			'write_adapter' => NULL,
 			'since'         => '1.0.0',
 		],
+
+		// ADR-53 P6: IPv6 suppression customlist -- the v4 blob's v6 sibling
+		// (same base64/newline-separated shape). Genuinely new (no pre-registry
+		// era to inherit from v4suppression's), so 'since' is the current
+		// development version rather than a legacy '1.0.0'. Default ''.
+		'v6suppression' => [
+			'section'       => $ip,
+			'default'       => '',
+			'read_adapter'  => NULL,
+			'write_adapter' => NULL,
+			'since'         => '4.0.0',
+		],
 	];
 
 	return $registry;
@@ -2525,11 +2537,12 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir): bool
  * by '#' (e.g. "10.0.0.1/32 # example.com") is stripped before validating the
  * address/mask. IPv4 accepts masks /8-/32 (ADR-53 §2.3 fork 1 — the /8 floor is
  * a fail-open-typo guard; the carve engine itself is mask-agnostic since Phase
- * 3's iprange --except swap). IPv6 is not yet implemented (Phase 6) — every
- * non-skipped v6 line is rejected so this stays a visible gap, not a silent
- * accept, until Phase 6 flips it.
+ * 3's iprange --except swap). IPv6 accepts masks /32-/128 (ADR-53 Phase 6 — the
+ * /32 floor is the same fail-open-typo guard; the Phase 5 pure-PHP set-diff
+ * engine is likewise mask-agnostic).
  *
- * PURE — no config access, no I/O; only the pfSense is_subnetv4() predicate.
+ * PURE — no config access, no I/O; only the pfSense is_subnetv4()/is_subnetv6()
+ * predicates.
  *
  * @param  string $line   One raw textarea line (as split on "\r\n"), untrimmed.
  * @param  string $family 'ipv4' or 'ipv6'.
@@ -2546,7 +2559,22 @@ function pfb_validate_suppression_line(string $line, string $family): ?string
 	$entry = $host[0];
 
 	if ($family === 'ipv6') {
-		return "IPv6 Suppression: IPv6 suppression is not yet supported [ {$entry} ].";
+		// Mask-range check runs BEFORE the general subnet-shape check so an
+		// out-of-range-but-otherwise-well-formed mask (/31, /129) gets the message
+		// naming the accepted range, rather than the generic malformed-input one.
+		$mask = strstr($entry, '/', FALSE);
+		if ($mask !== FALSE && ctype_digit(substr($mask, 1))) {
+			$mask_num = (int) substr($mask, 1);
+			if ($mask_num < 32 || $mask_num > 128) {
+				return "IPv6 Suppression: Invalid mask [ {$entry} ]. Mask must be between /32 and /128.";
+			}
+		}
+
+		if (!is_subnetv6($entry)) {
+			return "IPv6 Suppression: Invalid IPv6 subnet address defined [ {$entry} ]";
+		}
+
+		return NULL;
 	}
 
 	// Mask-range check runs BEFORE the general subnet-shape check so an

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2890,6 +2890,56 @@ function pfb_suppress_file_v6(string $file, string $suppfile): bool
 	return TRUE;
 }
 
+// ---------------------------------------------------------------------------
+// ADR-53 P7 — prefix-aware killstates suppression exclusion
+// ---------------------------------------------------------------------------
+
+/**
+ * pfb_ip_suppressed — TRUE iff $ip falls inside any suppression CIDR in
+ * $entries (ADR-53 §2.2 killstates contract).
+ *
+ * Replaces the old exact-IP hashmap + subnetv4_expand() '/24' materialisation
+ * in pfb_remove_states(), which could only express a bare host or an exact
+ * '/24' entry -- any other containing mask (e.g. a v4 '/16', or any v6 mask)
+ * silently stayed unsuppressed (ADR-53 §1.2). Uses the same ip_in_subnet()
+ * loop shape pfb_local_ip() already applies to local subnets, so any mask is
+ * honoured natively -- no materialisation, no per-family branching needed
+ * here (ip_in_subnet() itself returns FALSE on a family mismatch).
+ *
+ * $entries are raw suppression-textarea lines (untrimmed; may carry a
+ * trailing '#' comment or be entirely blank/comment) -- the same tolerance
+ * pfb_validate_suppression_line() applies. A malformed entry (no '/', bad
+ * address) is silently skipped, never fatal.
+ *
+ * PURE -- no config reads; the caller passes the already-decoded suppression
+ * list(s).
+ *
+ * Cost: a linear scan of $entries per call. Suppression lists are small and
+ * user-authored, so this is fine at this scale.
+ * ponytail: an interval tree would be overkill here — revisit only if a
+ * suppression list ever grows into the thousands of entries.
+ *
+ * @param  string   $ip      The firewall-state IP to test (v4 or v6).
+ * @param  string[] $entries Decoded suppression lines (one family or mixed).
+ * @return bool TRUE when $ip is covered by any entry.
+ */
+function pfb_ip_suppressed(string $ip, array $entries): bool
+{
+	foreach ($entries as $entry) {
+		$entry = trim((string) $entry);
+		if ($entry === '' || str_starts_with($entry, '#')) {
+			continue;
+		}
+		// Strip a trailing inline '#' comment, same as pfbng_text_area_decode().
+		$entry = trim(strstr($entry, '#', TRUE) ?: $entry);
+
+		if (ip_in_subnet($ip, $entry)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
 // logger() and localize_text() are pfSense-core helpers (src/etc/inc/util.inc)
 // on pfSense Plus / master, but absent from released pfSense CE <= 2.8.1. Define
 // fallbacks ONLY when core does not provide them, so this package runs on both:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2513,6 +2513,60 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir): bool
 	return $entry !== NULL && !empty($entry['pending_apply']);
 }
 
+// ---------------------------------------------------------------------------
+// ADR-53 P4 — pure suppression-line validator (v4 mask lift /8-/32)
+// ---------------------------------------------------------------------------
+
+/**
+ * pfb_validate_suppression_line — validate one line of a v4/v6 suppression textarea.
+ *
+ * Mirrors the tolerant textarea shape the page already accepts: a line starting
+ * with '#', or blank, is a no-op (skip, no error); an inline comment introduced
+ * by '#' (e.g. "10.0.0.1/32 # example.com") is stripped before validating the
+ * address/mask. IPv4 accepts masks /8-/32 (ADR-53 §2.3 fork 1 — the /8 floor is
+ * a fail-open-typo guard; the carve engine itself is mask-agnostic since Phase
+ * 3's iprange --except swap). IPv6 is not yet implemented (Phase 6) — every
+ * non-skipped v6 line is rejected so this stays a visible gap, not a silent
+ * accept, until Phase 6 flips it.
+ *
+ * PURE — no config access, no I/O; only the pfSense is_subnetv4() predicate.
+ *
+ * @param  string $line   One raw textarea line (as split on "\r\n"), untrimmed.
+ * @param  string $family 'ipv4' or 'ipv6'.
+ * @return string|null    NULL when the line is valid (or a comment/blank no-op);
+ *                         otherwise the input_errors message for this line.
+ */
+function pfb_validate_suppression_line(string $line, string $family): ?string
+{
+	if (str_starts_with($line, '#') || trim($line) === '') {
+		return NULL;
+	}
+
+	$host  = array_map('trim', preg_split('/(?=#)/', $line));
+	$entry = $host[0];
+
+	if ($family === 'ipv6') {
+		return "IPv6 Suppression: IPv6 suppression is not yet supported [ {$entry} ].";
+	}
+
+	// Mask-range check runs BEFORE the general subnet-shape check so an
+	// out-of-range-but-otherwise-well-formed mask (/7, /33) gets the message
+	// naming the accepted range, rather than the generic malformed-input one.
+	$mask = strstr($entry, '/', FALSE);
+	if ($mask !== FALSE && ctype_digit(substr($mask, 1))) {
+		$mask_num = (int) substr($mask, 1);
+		if ($mask_num < 8 || $mask_num > 32) {
+			return "IPv4 Suppression: Invalid mask [ {$entry} ]. Mask must be between /8 and /32.";
+		}
+	}
+
+	if (!is_subnetv4($entry)) {
+		return "IPv4 Suppression: Invalid IPv4 subnet address defined [ {$entry} ]";
+	}
+
+	return NULL;
+}
+
 // logger() and localize_text() are pfSense-core helpers (src/etc/inc/util.inc)
 // on pfSense Plus / master, but absent from released pfSense CE <= 2.8.1. Define
 // fallbacks ONLY when core does not provide them, so this package runs on both:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2641,12 +2641,21 @@ function pfb_v6_cidr_to_range(string $token, ?bool &$is_blank = null): ?array
 		return NULL;
 	}
 
-	if (!is_subnetv6($token)) {
+	// A bare address (no /mask) is the dominant member-file shape a feed
+	// emits -- treat it as its own /128, never as a malformed token (dropping
+	// it would silently UNBLOCK the host; caught live by the ADR-53 v6 smoke).
+	if (strpos($token, '/') === FALSE) {
+		if (!is_ipaddrv6($token)) {
+			return NULL;
+		}
+		$addr = $token;
+		$bits = 128;
+	} elseif (!is_subnetv6($token)) {
 		return NULL;
+	} else {
+		[$addr, $bits_raw] = explode('/', $token, 2);
+		$bits = (int) $bits_raw;
 	}
-
-	[$addr, $bits_raw] = explode('/', $token, 2);
-	$bits = (int) $bits_raw;
 
 	$packed = @inet_pton($addr);
 	if ($packed === FALSE || strlen($packed) !== 16) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2889,6 +2889,11 @@ function pfb_suppress_file_v6(string $file, string $suppfile): bool
 	$tmp  = $file . '.tmp';
 	$body = empty($result) ? '' : implode(PHP_EOL, $result) . PHP_EOL;
 	if (@file_put_contents($tmp, $body, LOCK_EX) === FALSE) {
+		// ADR-53 review finding H1: a failed write can still leave a stray
+		// (empty/partial, or pre-existing debris from a prior crashed run) file
+		// at $tmp -- unlink it on this branch too, matching the rename-failure
+		// branch below.
+		@unlink($tmp);
 		return FALSE;
 	}
 	if (!@rename($tmp, $file)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -491,7 +491,11 @@ update_status(" pfBlockerNGSuppress Alias -> IPv4 Suppression Customlist...");
 $ufound = FALSE;
 
 $pfb_ip_cfg = PfbConfig::readSection('installedpackages/pfblockerngipsettings/config/0');
-if (!isset($pfb_ip_cfg['v4suppression'])) { // v4suppression is unregistered — check via section read
+// ADR-53: v4suppression IS registered, but this needs the raw "key literally
+// absent from config.xml" check (never-migrated) vs "present but empty" --
+// a distinction PfbConfig::read()'s absent-default can't express -- so the
+// section-level read/write stays correct here (allowed per PfbConfig rules).
+if (!isset($pfb_ip_cfg['v4suppression'])) {
 	$customlist = '';
 	foreach (config_get_path('aliases/alias', []) as $key => $alias) { // foreign key — out of ADR-29 gateway scope
 		if ($alias['name'] == 'pfBlockerNGSuppress') {
@@ -510,7 +514,8 @@ if (!isset($pfb_ip_cfg['v4suppression'])) { // v4suppression is unregistered —
 					}
 				}
 			}
-			// v4suppression is unregistered; write via section to stay within the gateway surface.
+			// ADR-53: write via the same section array read above (a bulk migration
+			// write alongside the rest of $pfb_ip_cfg, not a lone per-field save).
 			$pfb_ip_cfg['v4suppression'] = base64_encode($customlist) ?: '';
 			PfbConfig::writeSection('installedpackages/pfblockerngipsettings/config/0', $pfb_ip_cfg);
 			// unset($config['aliases']['alias'][$key]);

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -252,11 +252,18 @@ if (!$alert_summary) {
 
 	PfbConfig::write('v4suppression', PfbConfig::read('v4suppression') ?: '');
 
+	// ADR-53 P8: v6 sibling -- same absent-key normalisation as v4suppression above.
+	PfbConfig::write('v6suppression', PfbConfig::read('v6suppression') ?: '');
+
 	PfbConfig::write('suppression', PfbConfig::read('suppression') ?: '');
 
 	PfbConfig::write('tldexclusion', PfbConfig::read('tldexclusion') ?: '');
 
-	foreach (array('ipsuppression', 'dnsblwhitelist', 'tldexclusion') as $key => $type) {
+	// ADR-53 P8: 'ipsuppression_v6' is the new v6suppression sibling of
+	// 'ipsuppression' (v4) -- same collection shape, keyed separately so the
+	// addsuppress handler below can dedup/rewrite each family's customlist
+	// independently.
+	foreach (array('ipsuppression', 'ipsuppression_v6', 'dnsblwhitelist', 'tldexclusion') as $key => $type) {
 
 		if (!isset($clists[$type]) || !is_array($clists[$type])) {
 			$clists[$type] = array();
@@ -265,8 +272,10 @@ if (!$alert_summary) {
 		if ($key == 0) {
 			$clists[$type]['base64'] = PfbConfig::read('v4suppression');
 		} elseif ($key == 1) {
-			$clists[$type]['base64'] = PfbConfig::read('suppression');
+			$clists[$type]['base64'] = PfbConfig::read('v6suppression');
 		} elseif ($key == 2) {
+			$clists[$type]['base64'] = PfbConfig::read('suppression');
+		} elseif ($key == 3) {
 			$clists[$type]['base64'] = PfbConfig::read('tldexclusion');
 		}
 
@@ -747,102 +756,117 @@ if (isset($_POST) && !empty($_POST)) {
 		$filterfieldsarray = array();
 	}
 
-	// Add an IPv4 (/32 or /24 only) to the suppression customlist
+	// Add a host (v4 or v6, ANY containing mask) to the suppression customlist,
+	// carving it out of whichever table entr(y/ies) currently block it live
+	// (ADR-53 §2.1 fork 3 -- full rework). The old /24-only 254-host re-add
+	// loop + "blocked by a CIDR other than /24" refusal are retired: any
+	// containing entry is now punched via pfb_live_punch_plan()'s
+	// covering-CIDR set-subtraction, mirroring the persisted v4/v6 engines
+	// (Phases 3/5).
 	elseif (isset($_POST['addsuppress']) && !empty($_POST['addsuppress'])) {
 
-		$cidr = '';
-		if ($_POST['cidr'] == '32' || $_POST['cidr'] == '24') {
-			$cidr = $_POST['cidr'];
-		}
-		$ip	= pfb_filter($_POST['ip'], PFB_FILTER_IPV4, 'alerts addsuppress', '', TRUE);
+		$ip	= pfb_filter($_POST['ip'], PFB_FILTER_IP, 'alerts addsuppress', '', TRUE);
 		$table	= pfb_filter($_POST['table'], PFB_FILTER_WORD, 'alerts addsuppress', '', TRUE);
 
-		// If IP is not valid or CIDR field is empty, or Table not valid exit
-		if (empty($ip) || empty($cidr) || empty($table)) {
-			$savemsg = gettext('Cannot Suppress: IPv4 not valid or CIDR value missing or Table not valid');
+		// If IP is not valid or Table not valid, exit.
+		if (empty($ip) || empty($table)) {
+			$savemsg = gettext('Cannot Suppress: IP address not valid or Table not valid');
 			header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 			exit;
 		}
+
+		$is_v6 = strpos($ip, ':') !== FALSE;
+		$family = $is_v6 ? 6 : 4;
 
 		$descr = '';
 		if (isset($_POST['descr']) && !empty($_POST['descr'])) {
 			$descr = pfb_filter($_POST['descr'], PFB_FILTER_HTML, 'alerts addsuppress');
 		}
 
+		// Read the table's current membership -- the ADR-40 mirror file when
+		// present (freshest applied set), else a live `pfctl -T show` fallback,
+		// both streamed line-by-line (fgets): a Deny table mirror can hold
+		// millions of entries (ADR-53 §3), so it is never slurped whole.
+		$table_esc	= escapeshellarg($table);
+		$mirror		= "{$pfb['aliasdir']}/{$table}.txt";
+		$scan_file	= is_readable($mirror) ? $mirror : NULL;
+		$scan_tmp	= NULL;
+		if ($scan_file === NULL) {
+			$scan_tmp = tempnam($pfb['dbdir'], 'pfb_punch_');
+			exec("{$pfb['pfctl']} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>&1');
+			$scan_file = $scan_tmp;
+		}
+		$table_entries = array();
+		if (($handle = @fopen($scan_file, 'r')) !== FALSE) {
+			while (($line = @fgets($handle)) !== FALSE) {
+				$table_entries[] = trim($line);
+			}
+			fclose($handle);
+		}
+		if ($scan_tmp !== NULL) {
+			@unlink($scan_tmp);
+		}
+
+		// Locate + carve every containing table entry (any mask, both
+		// families). Unlike the old /32 branch, an empty plan (nothing
+		// currently matches live) is NOT a refusal -- the customlist add below
+		// always proceeds, exactly as the old /24 branch already did
+		// unconditionally: suppression is a standing exemption for FUTURE
+		// loads, not contingent on today's live table snapshot.
+		$plan = pfb_live_punch_plan($ip, $table_entries);
+
+		foreach ($plan['delete'] as $entry) {
+			exec("{$pfb['pfctl']} -t {$table_esc} -T delete " . escapeshellarg($entry) . ' 2>&1');
+		}
+		foreach ($plan['add'] as $cidr) {
+			exec("{$pfb['pfctl']} -t {$table_esc} -T add " . escapeshellarg($cidr) . ' 2>&1');
+		}
+
+		$del_cnt = count($plan['delete']);
 		$savemsg1 = "Host IP address {$ip}";
-		$ix = ip_explode(trim($ip, "'"));	// Explode IP into evaluation strings
-		if ($cidr == '32') {
-
-			$pfb_pfctl = exec("{$pfb['pfctl']} -t {$table} -T show | grep {$ip} 2>&1");
-			if (!empty($pfb_pfctl)) {
-				$savemsg2 = ' : Removed /32 entry';
-				exec("{$pfb['pfctl']} -t {$table} -T delete {$ip} 2>&1");
-			}
-			else {
-				$pfb_pfctl = array();
-				$ip_esc = escapeshellarg("{$ix[5]}");
-				exec("{$pfb['pfctl']} -t {$table} -T delete {$ip_esc} 2>&1", $pfb_pfctl);
-				if (preg_grep("/1\/1 addresses deleted/", $pfb_pfctl)) {
-					$savemsg2 = ' : Removed /24 entry, added 254 addr';
-					for ($k=0; $k <= 255; $k++) {
-						if ($k != $ix[4]) {
-							$ip_esc = escapeshellarg("{$ix[6]}{$k}");
-							exec("{$pfb['pfctl']} -t {$table} -T add {$ip_esc} 2>&1");
-						}
-					}
-				}
-				else {
-					$savemsg = gettext("Not Suppressed. Host IP address {$ip} is blocked by a CIDR other than /24");
-					header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
-					exit;
-				}
-			}
-		}
-		else {
-			$cidr = '24';
-			$savemsg2 = ' : Removed /24 entry';
-			$pfb_pfctl = array();
-			$ip_esc = escapeshellarg("{$ix[5]}");
-			exec("{$pfb['pfctl']} -t {$table} -T delete {$ip_esc} 2>&1", $pfb_pfctl);
-			if (!preg_grep("/1\/1 addresses deleted/", $pfb_pfctl)) {
-				$savemsg2 = ' : Removed all entries';
-				// Remove 0-255 IP address from alias table
-				for ($j=0; $j <= 255; $j++) {
-					$ip_esc = escapeshellarg("{$ix[6]}{$j}");
-					exec("{$pfb['pfctl']} -t {$table} -T delete {$ip_esc} 2>&1");
-				}
-			}
-		}
-
-		// Save IP to the v4 Suppression List
-		if (isset($clists['ipsuppression']['data'][$ix[5]]) || isset($clists['ipsuppression']['data'][$ix[0] . '/32'])) {
-			$savemsg = gettext("Host IP address {$ip} already exists in the IPv4 Suppression customlist.");
+		if ($del_cnt > 0) {
+			$add_cnt = count($plan['add']);
+			$savemsg2 = ' : Removed ' . $del_cnt . ' entr' . ($del_cnt == 1 ? 'y' : 'ies')
+				. ', added ' . $add_cnt . ' covering CIDR' . ($add_cnt == 1 ? '' : 's');
 		} else {
-			$v4suppression_dat = '';
-			if ($cidr == '24') {
-				$v4suppression_dat .= "{$ix[5]}";
-			} else {
-				$v4suppression_dat .= "{$ix[0]}/32";
-			}
+			$savemsg2 = " : Not currently blocked by Table [ {$table} ]";
+		}
 
+		$supp_key	= $is_v6 ? 'ipsuppression_v6' : 'ipsuppression';
+		$cfg_key	= $is_v6 ? 'v6suppression' : 'v4suppression';
+		$host_line	= $is_v6 ? "{$ip}/128" : "{$ip}/32";
+
+		// Save the host to the correct-family Suppression List (bare-host dedup
+		// unchanged UX from the original v4-only code -- the "+" always
+		// suppresses the exact reported host, never the whole containing entry).
+		$pfbupdate = FALSE;
+		if (isset($clists[$supp_key]['data'][$host_line])) {
+			$savemsg = gettext("Host IP address {$ip} already exists in the IPv{$family} Suppression customlist.");
+		} else {
+			$supp_dat = $host_line;
 			if (!empty($descr)) {
-				$v4suppression_dat .= " # {$descr}";
+				$supp_dat .= " # {$descr}";
 			}
 
-			$savemsg = gettext($savemsg1) . gettext($savemsg2) . gettext(' and added to the IPv4 Suppression customlist.');
+			$savemsg = gettext($savemsg1) . gettext($savemsg2) . gettext(" and added to the IPv{$family} Suppression customlist.");
 			$pfbupdate = TRUE;
 		}
 
 		if ($pfbupdate) {
 			$data = '';
-			foreach ($clists['ipsuppression']['data'] as $line) {
+			foreach ($clists[$supp_key]['data'] as $line) {
 				$data .= "{$line}";
 			}
-			$data .= "{$v4suppression_dat}\r\n";
-			$clists['ipsuppression']['base64'] = base64_encode($data);
-			PfbConfig::write('v4suppression', $clists['ipsuppression']['base64']);
-			write_config("pfBlockerNG: Added {$ip} to the IPv4 Suppression customlist", FALSE);
-			pfb_create_suppression_file();	// Create pfbsuppression.txt
+			$data .= "{$supp_dat}\r\n";
+			$clists[$supp_key]['base64'] = base64_encode($data);
+			PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
+			write_config("pfBlockerNG: Added {$ip} to the IPv{$family} Suppression customlist", FALSE);
+			// pfb_create_suppression_file() reads $pfb['ipconfig'][...], a
+			// snapshot taken at pfb_global() time -- refresh it in-memory so the
+			// suppression file this request writes reflects the entry just added,
+			// not a stale pre-write snapshot.
+			$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'];
+			pfb_create_suppression_file();	// Refresh pfbsuppression(_v6).txt
 		}
 		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 		exit;
@@ -4116,7 +4140,6 @@ if (!$alert_summary) {
 	$form->addGlobal(new Form_Input('dnsbl_customlist', 'dnsbl_customlist', 'hidden', ''));
 	$form->addGlobal(new Form_Input('table', 'table', 'hidden', ''));
 	$form->addGlobal(new Form_Input('descr', 'descr', 'hidden', ''));
-	$form->addGlobal(new Form_Input('cidr', 'cidr', 'hidden', ''));
 	$form->addGlobal(new Form_Input('ip', 'ip', 'hidden', ''));
 	$form->addGlobal(new Form_Input('addsuppress', 'addsuppress', 'hidden', ''));
 	$form->addGlobal(new Form_Input('addwhitelistdom', 'addwhitelistdom', 'hidden', ''));
@@ -5291,47 +5314,28 @@ function ip_suppression() {
 	var description = prompt('Please enter Suppression description');
 	$('#descr').val(description);
 
-	if (cidr.value != '' && ip && table) {
+	if (ip && table) {
 		$('#addsuppress').val('true');
 		$('form').submit();
 	}
 }
 
+// ADR-53 P8: the "+" now carves the reported host out of WHICHEVER table
+// entry currently contains it, at any mask -- the /32-vs-/24 mask-choice
+// dialog this function used to show is no longer meaningful (the backend
+// never reads a chosen mask, see pfblockerng_alerts.php's addsuppress
+// handler), so it goes straight to ip_suppression() once suppression is
+// confirmed enabled.
 function ip_suppression_type() {
 
 	// Confirm if the Suppression option is enabled
 	var is_supp = "<?=$pfb['supp']?>";
 	if (is_supp != 'on') {
 		alert('The IP Suppression option has not been enabled. Please enable this option in the IP Tab to suppress this IP.');
-		$(this).dialog('close');
+		return;
 	}
 
-	var buttons = {};
-	buttons['Suppress /32'] = function() {
-						$('#cidr').val('32');
-						$(this).dialog('close');
-						ip_suppression();
-						};
-	buttons['Suppress /24'] = function() {
-						$('#cidr').val('24');
-						$(this).dialog('close');
-						ip_suppression();
-						};
-	buttons['Cancel'] = function() { $(this).dialog('close'); };
-
-	$('<div></div>').appendTo('body')
-	.html('<div><h6>Select Suppression Mask:</h6></div>')
-	.dialog({
-		modal: true,
-		autoOpen: true,
-		resizable: false,
-		closeOnEscape: true,
-		width: 'auto',
-		title: 'Select a Suppression Mask:',
-		position: { my: 'top', at: 'top' },
-		buttons: buttons
-	}).css('background-color','#ffd700');
-	$("div[role=dialog]").find('button').addClass('btn-info btn-xs');
+	ip_suppression();
 }
 
 function add_description(mode) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -799,7 +799,11 @@ if (isset($_POST) && !empty($_POST)) {
 		$scan_tmp	= NULL;
 		if ($scan_file === NULL) {
 			$scan_tmp = tempnam($pfb['dbdir'], 'pfb_punch_');
-			exec("{$pfb['pfctl']} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>&1');
+			// ADR-53 review finding H4: stderr -> /dev/null, NOT 2>&1 -- the
+			// capture file is parsed line-by-line as membership entries below;
+			// merging stderr into it would feed any pfctl diagnostic line into
+			// that parse as if it were a table member.
+			exec("{$pfb['pfctl']} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>/dev/null');
 			$scan_file = $scan_tmp;
 		}
 		$table_entries = array();
@@ -845,17 +849,30 @@ if (isset($_POST) && !empty($_POST)) {
 		// Save the host to the correct-family Suppression List (bare-host dedup
 		// unchanged UX from the original v4-only code -- the "+" always
 		// suppresses the exact reported host, never the whole containing entry).
-		$pfbupdate = FALSE;
+		$pfbupdate        = FALSE;
+		$refresh_suppfile = FALSE;
 		if (isset($clists[$supp_key]['data'][$host_line])) {
 			$savemsg = gettext("Host IP address {$ip} already exists in the IPv{$family} Suppression customlist.");
+		} elseif (pfb_ip_suppressed($ip, array_keys($clists[$supp_key]['data']))) {
+			// ADR-53 review finding H6: the old flow also recognised a host
+			// already covered by a BROADER manual suppression entry (e.g. a
+			// /24 already covers this /32) -- appending the exact host on top
+			// would be a redundant customlist entry. Reuses the same
+			// prefix-aware predicate killstates uses (ADR-53 P7) rather than
+			// re-deriving containment here. The live punch above already ran
+			// (unaffected by this dedup); the suppression file is still
+			// refreshed below so it reflects the covering entry.
+			$savemsg          = gettext("Host IP address {$ip} is already covered by an existing IPv{$family} Suppression entry.");
+			$refresh_suppfile = TRUE;
 		} else {
 			$supp_dat = $host_line;
 			if (!empty($descr)) {
 				$supp_dat .= " # {$descr}";
 			}
 
-			$savemsg = gettext($savemsg1) . gettext($savemsg2) . gettext(" and added to the IPv{$family} Suppression customlist.");
-			$pfbupdate = TRUE;
+			$savemsg          = gettext($savemsg1) . gettext($savemsg2) . gettext(" and added to the IPv{$family} Suppression customlist.");
+			$pfbupdate        = TRUE;
+			$refresh_suppfile = TRUE;
 		}
 
 		if ($pfbupdate) {
@@ -867,10 +884,14 @@ if (isset($_POST) && !empty($_POST)) {
 			$clists[$supp_key]['base64'] = base64_encode($data);
 			PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
 			write_config("pfBlockerNG: Added {$ip} to the IPv{$family} Suppression customlist", FALSE);
+		}
+		if ($refresh_suppfile) {
 			// pfb_create_suppression_file() reads $pfb['ipconfig'][...], a
 			// snapshot taken at pfb_global() time -- refresh it in-memory so the
-			// suppression file this request writes reflects the entry just added,
-			// not a stale pre-write snapshot.
+			// suppression file this request writes reflects either the entry
+			// just appended, or (the "already covered" branch above) the
+			// pre-existing broader entry, keeping pfbsuppression(_v6).txt in
+			// step with the live punch that already ran.
 			$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'];
 			pfb_create_suppression_file();	// Refresh pfbsuppression(_v6).txt
 		}

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -765,8 +765,14 @@ if (isset($_POST) && !empty($_POST)) {
 	// (Phases 3/5).
 	elseif (isset($_POST['addsuppress']) && !empty($_POST['addsuppress'])) {
 
-		$ip	= pfb_filter($_POST['ip'], PFB_FILTER_IP, 'alerts addsuppress', '', TRUE);
-		$table	= pfb_filter($_POST['table'], PFB_FILTER_WORD, 'alerts addsuppress', '', TRUE);
+		// NOTE: no $escape flag — pfb_filter(..., TRUE) returns an escapeshellarg()'d
+		// token (quotes included), which the legacy flow interpolated into exec()
+		// directly. This flow escapes at each exec sink instead, and $ip feeds
+		// non-shell consumers (the punch plan, the stored customlist entry) that
+		// must see the raw address — the quoted form corrupted the stored config
+		// entry ('1.2.3.4'/32), caught live by the Tier B addsuppress e2e.
+		$ip	= pfb_filter($_POST['ip'], PFB_FILTER_IP, 'alerts addsuppress');
+		$table	= pfb_filter($_POST['table'], PFB_FILTER_WORD, 'alerts addsuppress');
 
 		// If IP is not valid or Table not valid, exit.
 		if (empty($ip) || empty($table)) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -250,9 +250,7 @@ if (!$alert_summary) {
 		}
 	}
 
-	// foreign key: pfblockerngipsettings not in registry; write directly
-	config_set_path('installedpackages/pfblockerngipsettings/config/0/v4suppression',
-		config_get_path('installedpackages/pfblockerngipsettings/config/0/v4suppression') ?: '');
+	PfbConfig::write('v4suppression', PfbConfig::read('v4suppression') ?: '');
 
 	PfbConfig::write('suppression', PfbConfig::read('suppression') ?: '');
 
@@ -265,8 +263,7 @@ if (!$alert_summary) {
 		}
 
 		if ($key == 0) {
-			// foreign key: pfblockerngipsettings not in registry; read directly
-			$clists[$type]['base64'] = config_get_path('installedpackages/pfblockerngipsettings/config/0/v4suppression');
+			$clists[$type]['base64'] = PfbConfig::read('v4suppression');
 		} elseif ($key == 1) {
 			$clists[$type]['base64'] = PfbConfig::read('suppression');
 		} elseif ($key == 2) {
@@ -843,8 +840,7 @@ if (isset($_POST) && !empty($_POST)) {
 			}
 			$data .= "{$v4suppression_dat}\r\n";
 			$clists['ipsuppression']['base64'] = base64_encode($data);
-			// foreign key: pfblockerngipsettings not in registry; write directly
-			config_set_path('installedpackages/pfblockerngipsettings/config/0/v4suppression', $clists['ipsuppression']['base64']);
+			PfbConfig::write('v4suppression', $clists['ipsuppression']['base64']);
 			write_config("pfBlockerNG: Added {$ip} to the IPv4 Suppression customlist", FALSE);
 			pfb_create_suppression_file();	// Create pfbsuppression.txt
 		}
@@ -1327,8 +1323,7 @@ if (isset($_POST) && !empty($_POST)) {
 						$data .= "{$line}";
 					}
 					$clists['ipsuppression']['base64'] = base64_encode($data);
-					// foreign key: pfblockerngipsettings not in registry; write directly
-					config_set_path('installedpackages/pfblockerngipsettings/config/0/v4suppression', $clists['ipsuppression']['base64']);
+					PfbConfig::write('v4suppression', $clists['ipsuppression']['base64']);
 					$savemsg = "Removed [ {$ip_revert} ] from {$type} customlist and re-added it back into the aliastable [ {$table} ]";
 				}
 				else {

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -67,6 +67,7 @@ $pconfig['pass_order']		= $pfb['iconfig']['pass_order']				?: 'order_0';
 $pconfig['autorule_suffix']	= $pfb['iconfig']['autorule_suffix']			?: 'autorule';
 $pconfig['killstates']		= $pfb['iconfig']['killstates']				?: '';
 $pconfig['v4suppression']	= base64_decode($pfb['iconfig']['v4suppression'])	?: '';
+$pconfig['v6suppression']	= base64_decode($pfb['iconfig']['v6suppression'])	?: '';
 
 // Select array options
 $options_asn_reporting 		= [	'disabled'	=> 'Disabled',
@@ -154,6 +155,17 @@ if ($_POST) {
 			}
 		}
 
+		// ADR-53 P6: v6 sibling of the v4 validation above. explode() always returns a
+		// non-empty array, so (unlike the v4 block above) this skips the vestigial
+		// !empty() wrapper -- avoids replicating the pre-existing PHPStan
+		// empty.variable finding baselined for v4suppression at the same call shape.
+		foreach (explode("\r\n", $_POST['v6suppression']) as $line) {
+			$suppression_error = pfb_validate_suppression_line($line, 'ipv6');
+			if ($suppression_error !== NULL) {
+				$input_errors[] = $suppression_error;
+			}
+		}
+
 		// Apply MaxMind locale changes if required
 		if (in_array($_POST['maxmind_locale'], array('en', 'fr', 'de', 'pt-BR', 'ja', 'zh-CN', 'es')) &&
 		    in_array($pconfig['maxmind_locale'], array('en', 'fr', 'de', 'pt-BR', 'ja', 'zh-CN', 'es'))) {
@@ -206,6 +218,7 @@ if ($_POST) {
 			$pfb['iconfig']['autorule_suffix']	= $_POST['autorule_suffix']					?: 'autorule';
 			$pfb['iconfig']['killstates']		= pfb_filter($_POST['killstates'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['v4suppression']	= base64_encode($_POST['v4suppression'])			?: '';
+			$pfb['iconfig']['v6suppression']	= base64_encode($_POST['v6suppression'])			?: '';
 
 			// ADR-11: per-type aggregate aliases multi-select -> CSV scalar (sanitised to the
 			// known option keys; default none). Gateway-registered in the general section, so
@@ -355,7 +368,7 @@ $section->addInput(new Form_Checkbox(
 	'Enable',
 	pfb_cfg_toggle_read($pconfig['suppression']) === PfbToggle::On,
 	'on'
-))->setHelp('Default enabled. This will prevent Selected IPs (and RFC1918/Loopback addresses) from being blocked. Only for IPv4 lists (/8 through /32).'
+))->setHelp('Default enabled. This will prevent Selected IPs (and RFC1918/Loopback addresses) from being blocked. For IPv4 lists (/8 through /32) and IPv6 lists (/32 through /128).'
 	. '<div class="infoblock">'
 	. 'GeoIP blocklist cannot be suppressed.<br /><br />'
 	. 'Alerts can be suppressed using the \'+\' icon in the Alerts tab and IPs are added to the IPv4 suppression custom list.<br />'
@@ -511,6 +524,32 @@ $section->addInput(new Form_Textarea(
   ->setAttribute('wrap', 'off')
   ->setAttribute('style', 'background:#fafafa; width: 100%')
   ->setHelp($suppression_text);
+
+$form->add($section);
+
+// Print Custom List TextArea section (ADR-53 P6: v6 sibling of the v4 section above)
+$section = new Form_Section('IPv6 Suppression', 'IPv6_Suppression_customlist', COLLAPSIBLE|SEC_CLOSED);
+$suppression_text_v6 = '<strong><u>This suppression list is for [ /32 through /128 ] IPv6 addresses only!</u></strong><br /><br />
+
+			When \'Suppression\' is enabled, all RFC1918 and loopback addresses are also filtered on feed download|Update|Reload.<br /><br />
+
+			Enter one &emsp; <strong>IPv6 address</strong>&emsp; per line<br />
+			You may use "<strong>#</strong>" after any address to add comments. &emsp;IE: (2001:db8::1/128 # example.com)<br /><br />
+
+			Note: When manually adding an IPv6 address <strong>[ /32 through /128 only! ]</strong> to this Suppression List,
+			you must run a <strong>"Force Reload - IP"</strong> for the changes to take effect.';
+
+$section->addInput(new Form_Textarea(
+	'v6suppression',
+	'',
+	$pconfig['v6suppression']
+))->removeClass('form-control')
+  ->addClass('row-fluid col-sm-12')
+  ->setAttribute('columns', '90')
+  ->setAttribute('rows', '15')
+  ->setAttribute('wrap', 'off')
+  ->setAttribute('style', 'background:#fafafa; width: 100%')
+  ->setHelp($suppression_text_v6);
 
 $form->add($section);
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -147,20 +147,9 @@ if ($_POST) {
 		$v4suppression = explode("\r\n", $_POST['v4suppression']);
 		if (!empty($v4suppression)) {
 			foreach ($v4suppression as $line) {
-
-				if (str_starts_with($line, '#') || empty($line)) {
-					continue;
-				}
-
-				$host = array_map('trim', preg_split('/(?=#)/', $line));
-				$mask = strstr($host[0], '/', FALSE);
-
-				if ($mask != '/32' && $mask != '/24') {
-					$input_errors[] = "IPv4 Suppression: Invalid mask [ {$host[0]} ]. Mask must be defined as /32 or /24 only.";
-				}
-
-				if (!is_subnetv4($host[0])) {
-					$input_errors[] = "IPv4 Suppression: Invalid IPv4 subnet address defined [ {$host[0]} ]";
+				$suppression_error = pfb_validate_suppression_line($line, 'ipv4');
+				if ($suppression_error !== NULL) {
+					$input_errors[] = $suppression_error;
 				}
 			}
 		}
@@ -366,11 +355,11 @@ $section->addInput(new Form_Checkbox(
 	'Enable',
 	pfb_cfg_toggle_read($pconfig['suppression']) === PfbToggle::On,
 	'on'
-))->setHelp('Default enabled. This will prevent Selected IPs (and RFC1918/Loopback addresses) from being blocked. Only for IPv4 lists (/32 and /24).'
+))->setHelp('Default enabled. This will prevent Selected IPs (and RFC1918/Loopback addresses) from being blocked. Only for IPv4 lists (/8 through /32).'
 	. '<div class="infoblock">'
 	. 'GeoIP blocklist cannot be suppressed.<br /><br />'
 	. 'Alerts can be suppressed using the \'+\' icon in the Alerts tab and IPs are added to the IPv4 suppression custom list.<br />'
-	. 'For GeoIP/Blocked IPs in a CIDR other than /32 or /24, will need a \'Whitelist alias\' w/ a List Action: \'Permit Outbound\' Firewall rule.<br />'
+	. 'For GeoIP/Blocked IPs in a CIDR broader than /8, will need a \'Whitelist alias\' w/ a List Action: \'Permit Outbound\' Firewall rule.<br />'
 	. 'Only \'Deny\' type Aliases can be suppressed!'
 	. '</div>'
 );
@@ -497,7 +486,7 @@ $form->add($section);
 
 // Print Custom List TextArea section
 $section = new Form_Section('IPv4 Suppression', 'IPv4_Suppression_customlist', COLLAPSIBLE|SEC_CLOSED);
-$suppression_text = '<strong><u>This suppression list is for [ /32 or /24 ] IPv4 addresses only!</u></strong><br /><br />
+$suppression_text = '<strong><u>This suppression list is for [ /8 through /32 ] IPv4 addresses only!</u></strong><br /><br />
 
 			When \'Suppression\' is enabled, all RFC1918 and loopback addresses are also filtered on feed download|Update|Reload.<br /><br />
 
@@ -508,7 +497,7 @@ $suppression_text = '<strong><u>This suppression list is for [ /32 or /24 ] IPv4
 			icon(s) in the Alerts tab to add the IPv4 addresses automatically to this Suppression list and immeditely
 			remove the IPv4 address from the Deny aliastable.<br /><br />
 
-			Note: When manually adding an IPv4 address <strong>[ /32 or /24 only! ]</strong> to this Suppression List,
+			Note: When manually adding an IPv4 address <strong>[ /8 through /32 only! ]</strong> to this Suppression List,
 			you must run a <strong>"Force Reload - IP"</strong> for the changes to take effect.';
 
 $section->addInput(new Form_Textarea(

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -67,7 +67,10 @@ $pconfig['pass_order']		= $pfb['iconfig']['pass_order']				?: 'order_0';
 $pconfig['autorule_suffix']	= $pfb['iconfig']['autorule_suffix']			?: 'autorule';
 $pconfig['killstates']		= $pfb['iconfig']['killstates']				?: '';
 $pconfig['v4suppression']	= base64_decode($pfb['iconfig']['v4suppression'])	?: '';
-$pconfig['v6suppression']	= base64_decode($pfb['iconfig']['v6suppression'])	?: '';
+// ADR-53 review finding B: '?? ""' on the array read -- v6suppression (unlike
+// v4suppression) is NEVER install-migrated, so it is absent from config.xml
+// on every install until this page's first post-upgrade save.
+$pconfig['v6suppression']	= base64_decode($pfb['iconfig']['v6suppression'] ?? '')	?: '';
 
 // Select array options
 $options_asn_reporting 		= [	'disabled'	=> 'Disabled',

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -717,6 +717,18 @@ function pfBlockerNG_get_header($mode='') {
 					}
 				}
 
+				// ADR-53 P8: the Suppression count was v4-only ($config_path above
+				// is v4suppression) -- fold in v6suppression too, now that the
+				// Alerts "+" writes v6 entries as well, so the widget stat reflects
+				// the TOTAL suppressed-host count across both families.
+				if ($type == 'Suppression') {
+					foreach (pfbng_text_area_decode($pfb['ipconfig']['v6suppression'], TRUE, FALSE, TRUE) as $cline) {
+						if (!str_starts_with(trim($cline), '#') && !empty($cline)) {
+							$gcount++;
+						}
+					}
+				}
+
 				if (is_numeric($gcount)) {
 					$stats[$key][$type] = number_format( $gcount, 0, '', ',' ) ?: 0;
 				} else {

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -686,10 +686,14 @@ function pfBlockerNG_get_header($mode='') {
 
 	// Collect folder/file counts
 	$stats = array();
+	// ADR-53 review finding B: '?? ""' -- absent from config.xml until the
+	// IP-settings page's first post-upgrade save. Precomputed (complex '{$...}'
+	// string interpolation does not support the '??' operator).
+	$v4supp_val  = $pfb['ipconfig']['v4suppression'] ?? '';
 	$widget_head = 	array ( array (	'Deny'		=> '',
 					'Pass'		=> '',
 					'Match'		=> '',
-					'Suppression'	=> "{$pfb['ipconfig']['v4suppression']}"),
+					'Suppression'	=> "{$v4supp_val}"),
 
 				array (	'DNSBL'		=> '',
 					'Queries'	=> '',
@@ -722,7 +726,9 @@ function pfBlockerNG_get_header($mode='') {
 				// Alerts "+" writes v6 entries as well, so the widget stat reflects
 				// the TOTAL suppressed-host count across both families.
 				if ($type == 'Suppression') {
-					foreach (pfbng_text_area_decode($pfb['ipconfig']['v6suppression'], TRUE, FALSE, TRUE) as $cline) {
+					// ADR-53 review finding B: '?? ""' -- same absent-key guard
+					// as the v4 read above.
+					foreach (pfbng_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', TRUE, FALSE, TRUE) as $cline) {
 						if (!str_starts_with(trim($cline), '#') && !empty($cline)) {
 							$gcount++;
 						}

--- a/tests/php/AliasContentGateTest.php
+++ b/tests/php/AliasContentGateTest.php
@@ -47,6 +47,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_alias_set_different')]
 #[CoversFunction('pfb_write_canonical_alias')]
 #[CoversFunction('pfb_cross_list_scope')]
+#[CoversFunction('pfb_supp_update_active')]
 final class AliasContentGateTest extends TestCase
 {
 	/** @var string Per-test temp dir for mirror files. */
@@ -516,6 +517,61 @@ final class AliasContentGateTest extends TestCase
 			"dup on, rep on → TRUE\n" .
 			"expected: true\n" .
 			"got:      false"
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Scenario H — pfb_supp_update_active (ADR-53 adversarial-review finding A)
+	// -----------------------------------------------------------------------
+	//
+	// $pfb['supp_update'] gates BOTH the v4 and v6 suppression sub-passes in
+	// pfblockerng.inc's alias-build loop. Before this fix it was flipped TRUE
+	// only from inside the v4-only dedup/reputation block, so a v6-only Deny
+	// deployment could never unlock the v6 suppress pass. This pure helper
+	// did not exist before the fix -- every test below FAILS with a fatal
+	// "undefined function" against the pre-fix code and PASSES once
+	// pfb_supp_update_active() lands and is wired into the call site (the
+	// red->green proof for this ADR-53 review finding).
+
+	/**
+	 * Scenario H: a v6-only Deny alias (family v6, no v4 dedup/reputation
+	 * involvement) still unlocks the suppression pass -- the bug being fixed.
+	 */
+	public function testSuppUpdateActiveForDenyAliasRegardlessOfFamily(): void
+	{
+		$this->assertTrue(
+			pfb_supp_update_active(TRUE, TRUE),
+			"Deny-folder alias (pfbadv=TRUE), suppression enabled → TRUE, independent of v4/v6\n" .
+			"expected: true\n" .
+			"got:      false"
+		);
+	}
+
+	/**
+	 * Scenario H: a non-Deny alias (Permit/Match/Native/GeoIP) never unlocks
+	 * suppression, matching the "deny folder only" scope (ADR-53 §2.1).
+	 */
+	public function testSuppUpdateInactiveForNonDenyAlias(): void
+	{
+		$this->assertFalse(
+			pfb_supp_update_active(FALSE, TRUE),
+			"non-Deny alias, suppression enabled → FALSE (scope is deny-folder only)\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Scenario H: the master "Enable Suppression" toggle off never unlocks
+	 * the pass, even for a Deny alias.
+	 */
+	public function testSuppUpdateInactiveWhenSuppressionDisabled(): void
+	{
+		$this->assertFalse(
+			pfb_supp_update_active(TRUE, FALSE),
+			"Deny alias, suppression disabled → FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
 		);
 	}
 

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -379,6 +379,63 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// ADR-53 — v4suppression (plain base64 blob; IPv4 suppression customlist)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * v4suppression absent key returns the registered default '' (empty customlist).
+	 *
+	 * Scenario:
+	 *   Background: v4suppression is a plain base64-blob field; default = '' --
+	 *     mirrors the DNSBL 'suppression' sibling shape.
+	 *     Given no stored value.
+	 *     When PfbConfig::read('v4suppression').
+	 *     Then '' is returned (registered default).
+	 *
+	 * Red->green: before this phase, 'v4suppression' was not registered ->
+	 *   PfbConfig::read('v4suppression') threw InvalidArgumentException.
+	 */
+	public function testV4SuppressionAbsentKeyReturnsDefaultEmptyString(): void
+	{
+		$path = 'installedpackages/pfblockerngipsettings/config/0/v4suppression';
+
+		// Before: absent.
+		$this->assertNull(config_get_path($path), 'before: v4suppression must be absent');
+
+		// When/Then.
+		$this->assertSame('', PfbConfig::read('v4suppression'), 'v4suppression absent -> ""');
+	}
+
+	/**
+	 * v4suppression round-trips a base64 blob losslessly (write(read(v)) == v).
+	 *
+	 * Scenario:
+	 *   Background: v4suppression stores a base64-encoded CIDR/host customlist.
+	 *     Given stored = base64_encode("192.168.1.1/32\r\n").
+	 *     When PfbConfig::write('v4suppression', PfbConfig::read('v4suppression')).
+	 *     Then the stored string is unchanged (byte-identical round-trip).
+	 */
+	public function testV4SuppressionRoundTrips(): void
+	{
+		$path = 'installedpackages/pfblockerngipsettings/config/0/v4suppression';
+		$blob = base64_encode("192.168.1.1/32\r\n");
+
+		// Given: seed the blob.
+		$this->seedConfig($path, $blob);
+
+		// Before: raw stored value is the blob.
+		$this->assertSame($blob, config_get_path($path), 'before: v4suppression seed matches blob');
+
+		// When: read -> write.
+		$val = PfbConfig::read('v4suppression');
+		$this->assertSame($blob, $val, 'read: v4suppression round-trips the blob unchanged');
+
+		// After: write back produces the identical stored string.
+		PfbConfig::write('v4suppression', $val);
+		$this->assertSame($blob, config_get_path($path), 'write(read(blob))==blob for v4suppression');
+	}
+
+	// -----------------------------------------------------------------------
 	// ADR-43 — pfb_tick_interval (plain string; tick-cron dispatch interval)
 	// -----------------------------------------------------------------------
 
@@ -603,8 +660,10 @@ final class CfgGatewayTest extends TestCase
 	 *     pfblockerngantartica (typo in old data), pfblockerng{continent}
 	 *   - Dynamic feed/continent keys: feed_alt_*, widget-{type}
 	 *   - pfblockerngipsettings sub-keys (all section-level, handled together):
-	 *     v4suppression, maxmind_key, etc. (suppression key in ipsettings is a distinct
-	 *     concept from pfblockerngdnsblsettings/suppression which IS registered).
+	 *     maxmind_key, etc. (suppression key in ipsettings is a distinct concept
+	 *     from pfblockerngdnsblsettings/suppression which IS registered).
+	 *     ADR-53: v4suppression is now registered (see the registered inventory below) --
+	 *     it is the one ipsettings scalar NOT on this out-of-scope list.
 	 *   - pfblockerngreputation sub-keys: et_header
 	 *   - pfblockerngsync sub-keys: syncinterfaces, varsynconchanges, row/*
 	 *   - pfblockerngblacklist sub-keys: blacklist_enable, blacklist_freq,
@@ -641,7 +700,7 @@ final class CfgGatewayTest extends TestCase
 			'pfbextdns',
 
 			// pfblockerngipsettings — section read + sub-keys.
-			'v4suppression',
+			// (v4suppression is registered -- ADR-53 -- and lives in the registry, not here.)
 			'maxmind_key',
 			'maxmind_locale',
 			'database_cc',
@@ -800,6 +859,9 @@ final class CfgGatewayTest extends TestCase
 			'safesearch_doh',
 			'safesearch_doh_list',
 
+			// pfblockerngipsettings/config/0 scalar (ADR-53)
+			'v4suppression',
+
 			// Out-of-scope keys (must also appear in $out_of_scope above)
 			'pfb_wizard_skip',
 			'hooks',
@@ -811,7 +873,6 @@ final class CfgGatewayTest extends TestCase
 			'blacklist_selected',
 			'item',
 			'pfbextdns',
-			'v4suppression',
 			'maxmind_key',
 			'maxmind_locale',
 			'database_cc',

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -436,6 +436,63 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// ADR-53 P6 — v6suppression (plain base64 blob; IPv6 suppression customlist)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * v6suppression absent key returns the registered default '' (empty customlist).
+	 *
+	 * Scenario:
+	 *   Background: v6suppression is a plain base64-blob field; default = '' --
+	 *     mirrors the v4suppression sibling shape (this section, above).
+	 *     Given no stored value.
+	 *     When PfbConfig::read('v6suppression').
+	 *     Then '' is returned (registered default).
+	 *
+	 * Red->green: before Phase 6, 'v6suppression' was not registered at all ->
+	 *   PfbConfig::read('v6suppression') threw InvalidArgumentException.
+	 */
+	public function testV6SuppressionAbsentKeyReturnsDefaultEmptyString(): void
+	{
+		$path = 'installedpackages/pfblockerngipsettings/config/0/v6suppression';
+
+		// Before: absent.
+		$this->assertNull(config_get_path($path), 'before: v6suppression must be absent');
+
+		// When/Then.
+		$this->assertSame('', PfbConfig::read('v6suppression'), 'v6suppression absent -> ""');
+	}
+
+	/**
+	 * v6suppression round-trips a base64 blob losslessly (write(read(v)) == v).
+	 *
+	 * Scenario:
+	 *   Background: v6suppression stores a base64-encoded CIDR customlist.
+	 *     Given stored = base64_encode("2001:db8::1/128\r\n").
+	 *     When PfbConfig::write('v6suppression', PfbConfig::read('v6suppression')).
+	 *     Then the stored string is unchanged (byte-identical round-trip).
+	 */
+	public function testV6SuppressionRoundTrips(): void
+	{
+		$path = 'installedpackages/pfblockerngipsettings/config/0/v6suppression';
+		$blob = base64_encode("2001:db8::1/128\r\n");
+
+		// Given: seed the blob.
+		$this->seedConfig($path, $blob);
+
+		// Before: raw stored value is the blob.
+		$this->assertSame($blob, config_get_path($path), 'before: v6suppression seed matches blob');
+
+		// When: read -> write.
+		$val = PfbConfig::read('v6suppression');
+		$this->assertSame($blob, $val, 'read: v6suppression round-trips the blob unchanged');
+
+		// After: write back produces the identical stored string.
+		PfbConfig::write('v6suppression', $val);
+		$this->assertSame($blob, config_get_path($path), 'write(read(blob))==blob for v6suppression');
+	}
+
+	// -----------------------------------------------------------------------
 	// ADR-43 — pfb_tick_interval (plain string; tick-cron dispatch interval)
 	// -----------------------------------------------------------------------
 
@@ -662,8 +719,9 @@ final class CfgGatewayTest extends TestCase
 	 *   - pfblockerngipsettings sub-keys (all section-level, handled together):
 	 *     maxmind_key, etc. (suppression key in ipsettings is a distinct concept
 	 *     from pfblockerngdnsblsettings/suppression which IS registered).
-	 *     ADR-53: v4suppression is now registered (see the registered inventory below) --
-	 *     it is the one ipsettings scalar NOT on this out-of-scope list.
+	 *     ADR-53: v4suppression + v6suppression are now registered (see the registered
+	 *     inventory below) -- they are the two ipsettings scalars NOT on this
+	 *     out-of-scope list.
 	 *   - pfblockerngreputation sub-keys: et_header
 	 *   - pfblockerngsync sub-keys: syncinterfaces, varsynconchanges, row/*
 	 *   - pfblockerngblacklist sub-keys: blacklist_enable, blacklist_freq,
@@ -859,8 +917,9 @@ final class CfgGatewayTest extends TestCase
 			'safesearch_doh',
 			'safesearch_doh_list',
 
-			// pfblockerngipsettings/config/0 scalar (ADR-53)
+			// pfblockerngipsettings/config/0 scalars (ADR-53)
 			'v4suppression',
+			'v6suppression',
 
 			// Out-of-scope keys (must also appear in $out_of_scope above)
 			'pfb_wizard_skip',

--- a/tests/php/CreateSuppressionFileTest.php
+++ b/tests/php/CreateSuppressionFileTest.php
@@ -98,4 +98,61 @@ final class CreateSuppressionFileTest extends TestCase
 		$this->assertSame("10.0.0.1/32\n", file_get_contents($GLOBALS['pfb']['supptxt']), 'v4 file must hold only the v4 entry');
 		$this->assertSame("2001:db8::1/128\n", file_get_contents($GLOBALS['pfb']['supptxt_v6']), 'v6 file must hold only the v6 entry');
 	}
+
+	// --- ADR-53 adversarial-review finding B: the key ABSENT (not merely '') ---
+	//
+	// setUp() always seeds ['v4suppression' => '', 'v6suppression' => ''] --
+	// this masks a real PHP8 "undefined array key" warning that fires on every
+	// install whose config predates a save of these keys (v6suppression is
+	// NEVER install-migrated; v4suppression only migrates when a legacy
+	// pfBlockerNGSuppress alias existed). PHPUnit does not fail a test merely
+	// for triggering a PHP warning (verified: a bare `$arr['missing']` read
+	// reports "OK, but there were issues!" with exit 0, not a failure) -- these
+	// tests install their own error handler and assert zero warnings were
+	// raised, so the fix is actually enforced.
+
+	private function assertNoWarningsDuring(callable $fn, string $message): void
+	{
+		$warnings = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+			$warnings[] = $errstr;
+			return true; // swallow -- we assert on the collected list instead
+		}, E_WARNING);
+
+		try {
+			$fn();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame([], $warnings, $message . '; got: ' . var_export($warnings, TRUE));
+	}
+
+	public function testV4SuppressionKeyAbsentDoesNotWarn(): void
+	{
+		// The key is literally UNSET, not ''.
+		unset($GLOBALS['pfb']['ipconfig']['v4suppression']);
+
+		$this->assertNoWarningsDuring(
+			static function (): void {
+				pfb_create_suppression_file();
+			},
+			'pfb_create_suppression_file() must not emit a PHP8 "undefined array key" warning '
+				. 'when v4suppression is absent from config (every install until its first save)'
+		);
+	}
+
+	public function testV6SuppressionKeyAbsentDoesNotWarn(): void
+	{
+		unset($GLOBALS['pfb']['ipconfig']['v6suppression']);
+
+		$this->assertNoWarningsDuring(
+			static function (): void {
+				pfb_create_suppression_file();
+			},
+			'pfb_create_suppression_file() must not emit a PHP8 "undefined array key" warning '
+				. 'when v6suppression is absent from config (never install-migrated, so absent '
+				. 'on every install until the IP-settings page is saved once post-upgrade)'
+		);
+	}
 }

--- a/tests/php/CreateSuppressionFileTest.php
+++ b/tests/php/CreateSuppressionFileTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_create_suppression_file() -- ADR-53 Phase 6: decodes the v4/v6 suppression
+ * customlists into the on-disk files the alias-build loop's suppression engines
+ * read (pfbsuppression.txt / pfbsuppression_v6.txt). Previously uncovered by
+ * PHPUnit -- this file covers BOTH the pre-existing v4 behaviour (a regression
+ * pin) and the NEW v6 sibling this phase adds (the red->green wiring proof).
+ *
+ * BEHAVIOUR CHANGE (ADR-53 Phase 6): before this phase, pfb_create_suppression_file()
+ * knew only v4suppression -- $pfb['supptxt_v6'] did not exist and no
+ * pfbsuppression_v6.txt was ever written, regardless of $pfb['ipconfig']['v6suppression'].
+ * testV6SuppressionWrittenToOwnFile() and testBothFamiliesWrittenIndependently() are the
+ * red->green proof: both FAIL (undefined array key / missing file) against the pre-Phase-6
+ * function and PASS once the v6 branch lands.
+ *
+ * pfbng_text_area_decode(text, FALSE, TRUE) (the mode pfb_create_suppression_file() uses)
+ * lowercases + trims each non-comment, non-blank line and joins with a single "\n" --
+ * NOT the original "\r\n" -- so the expected file content below reflects that shape.
+ */
+#[CoversFunction('pfb_create_suppression_file')]
+final class CreateSuppressionFileTest extends TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_supptxt_test_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0777, TRUE);
+		$GLOBALS['pfb']['supptxt']    = "{$this->dir}/pfbsuppression.txt";
+		$GLOBALS['pfb']['supptxt_v6'] = "{$this->dir}/pfbsuppression_v6.txt";
+		$GLOBALS['pfb']['ipconfig']   = ['v4suppression' => '', 'v6suppression' => ''];
+	}
+
+	protected function tearDown(): void
+	{
+		@unlink($GLOBALS['pfb']['supptxt']);
+		@unlink($GLOBALS['pfb']['supptxt_v6']);
+		@rmdir($this->dir);
+	}
+
+	// --- v4: pre-existing behaviour, pinned here as a regression oracle ---
+
+	public function testV4SuppressionWrittenToOwnFile(): void
+	{
+		$GLOBALS['pfb']['ipconfig']['v4suppression'] = base64_encode("10.0.0.1/32\r\n");
+
+		pfb_create_suppression_file();
+
+		$this->assertFileExists($GLOBALS['pfb']['supptxt']);
+		$this->assertSame("10.0.0.1/32\n", file_get_contents($GLOBALS['pfb']['supptxt']));
+	}
+
+	public function testV4SuppressionAbsentUnlinksExistingFile(): void
+	{
+		file_put_contents($GLOBALS['pfb']['supptxt'], 'stale content');
+		$GLOBALS['pfb']['ipconfig']['v4suppression'] = '';
+
+		pfb_create_suppression_file();
+
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['supptxt'], 'empty v4suppression must unlink the stale file');
+	}
+
+	// --- v6: NEW in Phase 6 -- the red->green wiring proof ---
+
+	public function testV6SuppressionWrittenToOwnFile(): void
+	{
+		$GLOBALS['pfb']['ipconfig']['v6suppression'] = base64_encode("2001:db8::1/128\r\n");
+
+		pfb_create_suppression_file();
+
+		$this->assertFileExists($GLOBALS['pfb']['supptxt_v6'], 'ADR-53 Phase 6: pfbsuppression_v6.txt must now be written');
+		$this->assertSame("2001:db8::1/128\n", file_get_contents($GLOBALS['pfb']['supptxt_v6']));
+	}
+
+	public function testV6SuppressionAbsentUnlinksExistingFile(): void
+	{
+		file_put_contents($GLOBALS['pfb']['supptxt_v6'], 'stale content');
+		$GLOBALS['pfb']['ipconfig']['v6suppression'] = '';
+
+		pfb_create_suppression_file();
+
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['supptxt_v6'], 'empty v6suppression must unlink the stale file');
+	}
+
+	public function testBothFamiliesWrittenIndependently(): void
+	{
+		$GLOBALS['pfb']['ipconfig']['v4suppression'] = base64_encode("10.0.0.1/32\r\n");
+		$GLOBALS['pfb']['ipconfig']['v6suppression'] = base64_encode("2001:db8::1/128\r\n");
+
+		pfb_create_suppression_file();
+
+		$this->assertSame("10.0.0.1/32\n", file_get_contents($GLOBALS['pfb']['supptxt']), 'v4 file must hold only the v4 entry');
+		$this->assertSame("2001:db8::1/128\n", file_get_contents($GLOBALS['pfb']['supptxt_v6']), 'v6 file must hold only the v6 entry');
+	}
+}

--- a/tests/php/KillstatesSuppressionTest.php
+++ b/tests/php/KillstatesSuppressionTest.php
@@ -113,4 +113,42 @@ final class KillstatesSuppressionTest extends TestCase
 			pfb_ip_suppressed('2001:db8::1', ['10.0.0.0/8'])
 		);
 	}
+
+	// --- malformed MASK never falsely matches (ADR-53 review finding H3: the
+	// pfsense_doubles.php ip_in_subnet() double's own fidelity on this path --
+	// pfb_ip_suppressed() forwards raw entries straight to ip_in_subnet() with
+	// no mask-range validation of its own, so a lying double here would hide a
+	// real suppression over-match) ---
+
+	public function testV4OutOfRangeMaskEntryIsNeverSuppressed(): void
+	{
+		// '/33' is out of range for IPv4 (real pfSense's is_subnetv4() rejects
+		// it, so ip_in_subnet() always returns FALSE) -- must never silently
+		// degrade to an exact-host match.
+		$this->assertFalse(
+			pfb_ip_suppressed('10.0.0.1', ['10.0.0.1/33']),
+			"/33 is an out-of-range IPv4 mask -- must never match, not silently normalise to /32"
+		);
+	}
+
+	public function testV6OutOfRangeMaskEntryIsNeverSuppressed(): void
+	{
+		// '/129' is out of range for IPv6 -- same contract as the v4 case above.
+		$this->assertFalse(
+			pfb_ip_suppressed('2001:db8::1', ['2001:db8::1/129']),
+			"/129 is an out-of-range IPv6 mask -- must never match"
+		);
+	}
+
+	public function testV4NonNumericMaskEntryIsNeverSuppressed(): void
+	{
+		// A non-numeric mask ('/abc') must never fall through to matching
+		// EVERY address -- real pfSense's is_subnet() requires the mask to be
+		// all-digits; a bare (int) cast on the double's side would coerce
+		// 'abc' to 0, i.e. '/0' (matches everything).
+		$this->assertFalse(
+			pfb_ip_suppressed('8.8.8.8', ['1.2.3.4/abc']),
+			"a non-numeric mask must never coerce to /0 (match-everyone)"
+		);
+	}
 }

--- a/tests/php/KillstatesSuppressionTest.php
+++ b/tests/php/KillstatesSuppressionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_ip_suppressed() -- ADR-53 Phase 7: the prefix-aware suppression-exclusion
+ * predicate that replaces pfb_remove_states()'s old exact-IP hashmap +
+ * subnetv4_expand() '/24' materialisation.
+ *
+ * BEHAVIOUR CHANGE (ADR-53 §2.2 killstates contract -- a correctness
+ * strengthening, red->green): the old mechanism could only express a bare
+ * host ('/32') or an exact '/24' suppression entry -- any other containing
+ * mask (a v4 '/16', or ANY v6 mask, since v6suppression was never read by
+ * killstates at all) silently left the state killed despite the user's
+ * exemption. testV4Slash16ContainedIpIsSuppressed() and
+ * testV6Slash64ContainedIpIsSuppressed() are the red->green proof: this
+ * function did not exist before this phase, so every test here FAILS with a
+ * fatal "undefined function" against the pre-Phase-7 code and PASSES once
+ * pfb_ip_suppressed() lands. The wiring itself (pfb_remove_states() actually
+ * calling this helper) is separately proven end-to-end in
+ * PfbRemoveStatesTest.php.
+ */
+#[CoversFunction('pfb_ip_suppressed')]
+final class KillstatesSuppressionTest extends TestCase
+{
+	// --- v4: containing masks the old exact-map + subnetv4_expand() couldn't express ---
+
+	public function testV4Slash16ContainedIpIsSuppressed(): void
+	{
+		$this->assertTrue(
+			pfb_ip_suppressed('10.0.5.9', ['10.0.0.0/16']),
+			'10.0.5.9 lies inside the suppressed 10.0.0.0/16 -- the old mechanism only understood /32 and /24'
+		);
+	}
+
+	public function testV4IpOutsideSuppressedRangeIsNotSuppressed(): void
+	{
+		$this->assertFalse(
+			pfb_ip_suppressed('10.1.0.1', ['10.0.0.0/16'])
+		);
+	}
+
+	// --- v4: legacy shapes still work (upgrade contract -- no config migration) ---
+
+	public function testV4ExactSlash32HitIsSuppressed(): void
+	{
+		$this->assertTrue(
+			pfb_ip_suppressed('198.51.100.7', ['198.51.100.7/32'])
+		);
+	}
+
+	public function testV4Slash24MemberIsSuppressed(): void
+	{
+		$this->assertTrue(
+			pfb_ip_suppressed('198.51.100.42', ['198.51.100.0/24'])
+		);
+	}
+
+	// --- v6: containing masks (v6suppression was never wired to killstates before this phase) ---
+
+	public function testV6Slash64ContainedIpIsSuppressed(): void
+	{
+		$this->assertTrue(
+			pfb_ip_suppressed('2001:db8::9', ['2001:db8::/64'])
+		);
+	}
+
+	public function testV6IpOutsideSuppressedRangeIsNotSuppressed(): void
+	{
+		$this->assertFalse(
+			pfb_ip_suppressed('2001:db9::1', ['2001:db8::/64'])
+		);
+	}
+
+	public function testV6ExactSlash128HitIsSuppressed(): void
+	{
+		$this->assertTrue(
+			pfb_ip_suppressed('2001:db8::1', ['2001:db8::1/128'])
+		);
+	}
+
+	// --- malformed / empty inputs never fatal ---
+
+	public function testMalformedEntrySkippedNotFatal(): void
+	{
+		$this->assertFalse(
+			pfb_ip_suppressed('10.0.0.1', ['not-a-cidr', '# a comment', ''])
+		);
+	}
+
+	public function testMalformedEntryDoesNotBlockASubsequentRealMatch(): void
+	{
+		$this->assertTrue(
+			pfb_ip_suppressed('10.0.0.1', ['garbage-token', '10.0.0.0/24'])
+		);
+	}
+
+	public function testEmptyListIsNeverSuppressed(): void
+	{
+		$this->assertFalse(
+			pfb_ip_suppressed('10.0.0.1', [])
+		);
+	}
+
+	// --- cross-family entries never falsely match (ip_in_subnet's own family guard) ---
+
+	public function testV4EntryNeverMatchesAV6Ip(): void
+	{
+		$this->assertFalse(
+			pfb_ip_suppressed('2001:db8::1', ['10.0.0.0/8'])
+		);
+	}
+}

--- a/tests/php/LivePunchPlanTest.php
+++ b/tests/php/LivePunchPlanTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_live_punch_plan() -- ADR-53 Phase 8: the Alerts "+" / widget live-punch
+ * planner that replaces the retired /24-only 254-host re-add loop
+ * (pfblockerng_alerts.php's old addsuppress block).
+ *
+ * BEHAVIOUR CHANGE (ADR-53 §2.1 fork 3 -- full rework, red->green): the old
+ * mechanism only understood an exact bare host or an exact /24 table entry --
+ * any other containing mask (any v4 mask other than /24, or ANY v6 mask)
+ * was refused outright ("blocked by a CIDR other than /24"). This function
+ * did not exist before Phase 8, so every test here FAILS with a fatal
+ * "undefined function" against the pre-Phase-8 code and PASSES once
+ * pfb_live_punch_plan() (and its v4 carve helper pfb_v4_carve_single())
+ * land. The counts below are cross-checked against ADR-53 §1.2's measured
+ * covering-CIDR bounds ("/16 - /32 = 16", "/64 (v6) - /128 = 64",
+ * "/24 - /32 = 8"), not guessed.
+ */
+#[CoversFunction('pfb_live_punch_plan')]
+#[CoversFunction('pfb_v4_carve_single')]
+final class LivePunchPlanTest extends TestCase
+{
+	// --- v4: a containing mask the old /24-only mechanism refused outright ---
+
+	public function testV4Slash16ContainingEntryIsCarvedIntoSixteenCoveringCidrs(): void
+	{
+		$plan = pfb_live_punch_plan('10.0.5.9', ['10.0.0.0/16']);
+
+		$this->assertSame(
+			['10.0.0.0/16'],
+			$plan['delete'],
+			'the containing /16 must be marked for deletion -- the old code refused anything but an exact /24'
+		);
+		$this->assertCount(
+			16,
+			$plan['add'],
+			'a /16 minus one host is 16 covering CIDRs (ADR-53 §1.2 measured bound), never a 65535-host explosion'
+		);
+		foreach ($plan['add'] as $cidr) {
+			$this->assertFalse(
+				ip_in_subnet('10.0.5.9', $cidr),
+				"the carved-out host must not fall inside any re-added covering CIDR [ {$cidr} ]"
+			);
+		}
+	}
+
+	// --- v4: a bare host entry -- exact match, nothing to re-add ---
+
+	public function testV4BareHostEntryIsDeletedWithNothingToReAdd(): void
+	{
+		$plan = pfb_live_punch_plan('198.51.100.7', ['198.51.100.7']);
+
+		$this->assertSame(['198.51.100.7'], $plan['delete']);
+		$this->assertSame(
+			[],
+			$plan['add'],
+			'an exact bare-host table entry contains ONLY the punched host -- no covering-CIDR remainder'
+		);
+	}
+
+	// --- v4: legacy exact /24 shape still carves correctly (8 covering CIDRs) ---
+
+	public function testV4ExactSlash24EntryIsCarvedIntoEightCoveringCidrs(): void
+	{
+		$plan = pfb_live_punch_plan('203.0.113.5', ['203.0.113.0/24']);
+
+		$this->assertSame(['203.0.113.0/24'], $plan['delete']);
+		$this->assertCount(
+			8,
+			$plan['add'],
+			'a /24 minus one host is 8 covering CIDRs (ADR-53 §1.2 measured bound) -- NOT the retired 254-host loop'
+		);
+	}
+
+	// --- v6: no mask was ever wired to the old mechanism at all ---
+
+	public function testV6Slash64ContainingEntryIsCarvedIntoSixtyFourCoveringCidrs(): void
+	{
+		$plan = pfb_live_punch_plan('2001:db8::9', ['2001:db8::/64']);
+
+		$this->assertSame(['2001:db8::/64'], $plan['delete']);
+		$this->assertCount(
+			64,
+			$plan['add'],
+			'a /64 minus one host is 64 covering CIDRs (ADR-53 §1.2 measured bound) -- v6 was never punchable before'
+		);
+		foreach ($plan['add'] as $cidr) {
+			$this->assertFalse(
+				ip_in_subnet('2001:db8::9', $cidr),
+				"the carved-out v6 host must not fall inside any re-added covering CIDR [ {$cidr} ]"
+			);
+		}
+	}
+
+	// --- no containing entry -- both empty, never a false punch ---
+
+	public function testIpNotInAnyEntryProducesAnEmptyPlan(): void
+	{
+		$plan = pfb_live_punch_plan('10.1.0.1', ['10.0.0.0/16']);
+
+		$this->assertSame([], $plan['delete']);
+		$this->assertSame([], $plan['add']);
+	}
+
+	// --- multiple containing entries: every one gets punched ---
+
+	public function testMultipleContainingEntriesAreAllPunched(): void
+	{
+		// The host sits inside a containing /24 AND is separately listed as its
+		// own exact /32 -- an overlapping table config the old mechanism could
+		// not have expressed as a single suppression, but the plan must still
+		// carve every containing entry, not just the first match.
+		$plan = pfb_live_punch_plan('203.0.113.5', ['203.0.113.0/24', '203.0.113.5']);
+
+		$this->assertSame(['203.0.113.0/24', '203.0.113.5'], $plan['delete']);
+		$this->assertCount(
+			8,
+			$plan['add'],
+			'only the /24 leaves a covering-CIDR remainder (8, per ADR-53 §1.2) -- the exact /32 match adds nothing'
+		);
+	}
+
+	// --- a sibling address outside the hole is never dropped ---
+
+	public function testSiblingEntryOutsideTheHoleIsUntouched(): void
+	{
+		$plan = pfb_live_punch_plan('198.51.100.99', ['198.51.100.0/16', '198.52.100.9']);
+
+		$this->assertSame(
+			['198.51.100.0/16'],
+			$plan['delete'],
+			'only the containing entry is punched -- an unrelated sibling table entry stays out of the plan entirely'
+		);
+	}
+
+	// --- blank/comment lines in the membership snapshot are tolerated ---
+
+	public function testBlankAndCommentLinesInTableSnapshotAreSkipped(): void
+	{
+		$plan = pfb_live_punch_plan('10.0.0.1', ['', '# a comment', '10.0.0.0/24']);
+
+		$this->assertSame(['10.0.0.0/24'], $plan['delete']);
+	}
+}

--- a/tests/php/PfbRemoveStatesTest.php
+++ b/tests/php/PfbRemoveStatesTest.php
@@ -6,7 +6,8 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_remove_states() — the kill-states validation walk (issues #702 / #705).
+ * pfb_remove_states() — the kill-states validation walk (issues #702 / #705;
+ * ADR-53 Phase 7).
  *
  * The function reaches pfctl exclusively through $pfb['pfctl'], reads the state
  * dump from $pfb['states_tmp'], and takes every policy input from config — so
@@ -40,6 +41,26 @@ use PHPUnit\Framework\TestCase;
  *     'continue 2' is required to skip the state). Covered for bare-IP
  *     (/32-append branch) and explicit-CIDR entries, v4 and v6 list types, and
  *     the negative side (a 'Deny_*' custom list does NOT suppress).
+ *   * ADR-53 Phase 7 — red→green: the v4/v6 Suppression-textarea exclusion is
+ *     now prefix-aware (any mask, both families) via the pure
+ *     pfb_ip_suppressed() helper (KillstatesSuppressionTest.php covers it in
+ *     isolation), replacing the old exact-IP hashmap + subnetv4_expand() '/24'
+ *     materialisation, which could express only a bare host or an exact '/24'.
+ *     Investigating this swap also surfaced an UNRELATED pre-existing bug in
+ *     the $pfb_local plumbing this phase deletes for suppression: the "Remove
+ *     any duplicate IPs" step (`array_flip(array_unique($pfb_local))`, still
+ *     present, still governing local-IP/DNS-server exact-match — untouched,
+ *     out of this phase's scope) blindly re-flips whatever arrives already
+ *     hashmap-shaped, so any source that itself returns a pre-flipped IP=>key
+ *     map (the old suppression flip; pfb_collect_localip()'s own internal
+ *     flip) gets double-flipped back into a plain list — and array_unique()'s
+ *     value-based dedup silently drops collisions on the arbitrary
+ *     position-derived former index. Confirmed empirically (isolated php -r
+ *     traces, both empty and populated local-IP/DNS scenarios): the legacy
+ *     v4suppression exact '/32' match never reliably worked via $pfb_local.
+ *     test_v4_suppression_legacy_slash32_now_reliably_spares_state() is
+ *     therefore ALSO a red→green case, not a pure oracle — this swap fixes it
+ *     as a side effect by moving suppression off that plumbing entirely.
  */
 #[CoversFunction('pfb_remove_states')]
 final class PfbRemoveStatesTest extends TestCase
@@ -82,6 +103,7 @@ final class PfbRemoveStatesTest extends TestCase
 		$GLOBALS['pfb']['log']        = "{$this->root}/pfblockerng.log";
 		$GLOBALS['pfb']['errlog']     = "{$this->root}/error.log";
 		$GLOBALS['pfb']['ipconfig']['v4suppression'] = '';
+		$GLOBALS['pfb']['ipconfig']['v6suppression'] = '';
 		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
 		$GLOBALS['pfb_test_dns_servers'] = [];
 
@@ -151,6 +173,18 @@ final class PfbRemoveStatesTest extends TestCase
 	private function seedTableMatches(string ...$ips): void
 	{
 		putenv('PFB_FAKE_MATCH=' . implode(' ', $ips));
+	}
+
+	/** Seed the IPv4 Suppression textarea config value (same encode shape the real page writes). */
+	private function seedV4Suppression(string ...$lines): void
+	{
+		$GLOBALS['pfb']['ipconfig']['v4suppression'] = base64_encode(implode("\r\n", $lines));
+	}
+
+	/** Seed the IPv6 Suppression textarea config value (same encode shape the real page writes). */
+	private function seedV6Suppression(string ...$lines): void
+	{
+		$GLOBALS['pfb']['ipconfig']['v6suppression'] = base64_encode(implode("\r\n", $lines));
 	}
 
 	/** A NAT-shaped (7-token) v4 state line whose kill-candidate IP is the DESTINATION. */
@@ -378,6 +412,157 @@ final class PfbRemoveStatesTest extends TestCase
 			self::V4_PERMIT,
 			$kills,
 			'a Deny-action custom list must NOT spare ' . self::V4_PERMIT . " — kill log was:\n{$kills}"
+		);
+	}
+
+	// --- ADR-53 P7 — suppression exclusion is prefix-aware, both families ---
+	//
+	// pfb_remove_states() previously excluded suppressed IPs via an exact-IP
+	// hashmap ('/32' entries verbatim + a subnetv4_expand() '/24' materialisation),
+	// which could only express a bare host or an exact '/24'. These scenarios
+	// prove the wiring itself (not just the pure pfb_ip_suppressed() helper,
+	// covered in isolation by KillstatesSuppressionTest.php): a state inside a
+	// containing suppression entry is spared, a sibling outside it is still
+	// killed.
+
+	/**
+	 * Scenario (ADR-53 P7, red->green) — a v4 '/16' suppression entry spares a
+	 * contained state; the old mechanism could only express '/32' or '/24'.
+	 *
+	 * Given: v4suppression = '198.51.0.0/16', a table-matched state inside it
+	 *        (198.51.100.9) and a table-matched sibling outside it
+	 *        (198.52.100.9).
+	 * When:  pfb_remove_states() runs.
+	 * Then:  198.51.100.9 survives (the suppression exclusion), 198.52.100.9 is
+	 *        killed (proves the pass still runs and is not over-suppressing).
+	 *        FAILS pre-Phase-7: the old exact-map/subnetv4_expand() block cannot
+	 *        express a '/16' entry, so 198.51.100.9 would have been killed too.
+	 */
+	public function test_v4_suppression_slash16_spares_contained_state_others_still_killed(): void
+	{
+		$contained = '198.51.100.9';
+		$outside   = '198.52.100.9';
+
+		$this->seedConfig();
+		$this->seedV4Suppression('198.51.0.0/16');
+		$this->seedStates($this->v4State($contained), $this->v4State($outside, 54322));
+		$this->seedTableMatches($contained, $outside);
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringNotContainsString(
+			$contained,
+			$kills,
+			"{$contained} lies inside the suppressed 198.51.0.0/16 and must survive — kill log was:\n{$kills}"
+		);
+		$this->assertStringContainsString(
+			$outside,
+			$kills,
+			"{$outside} lies outside the suppressed range and must be killed — kill log was:\n{$kills}"
+		);
+	}
+
+	/**
+	 * Scenario (ADR-53 P7, red->green — an UNEXPECTED second bug this swap also
+	 * fixes) — a legacy exact '/32' v4 suppression entry spares its state.
+	 *
+	 * ADR-53 §2.2 asks Phase 7 to keep "existing /32 + /24 user entries...
+	 * working identically" -- expected to be a pure oracle (green both sides).
+	 * It is NOT: investigation traced a PRE-EXISTING, unrelated bug in the old
+	 * $pfb_local plumbing this phase deletes. The suppression foreach's own
+	 * array_flip() (old code, now removed) hands back a hashmap keyed by IP;
+	 * the LATER "Remove any duplicate IPs" step (`array_flip(array_unique(...))`,
+	 * untouched by this phase -- it still governs local-IP/DNS-server exact
+	 * match, out of scope) blindly re-flips that same array. Any hashmap-shaped
+	 * input arriving pre-flipped (suppression's own flip, and
+	 * pfb_collect_localip()'s own internal flip) gets double-flipped back into
+	 * a plain list, AND array_unique()'s value-based comparison silently drops
+	 * whichever entries collide on their (arbitrary, position-derived) former
+	 * index. Empirically confirmed off-appliance (php -r trace) with both empty
+	 * and populated local-IP/DNS data: v4suppression's own /32 exact-match
+	 * NEVER reliably worked via $pfb_local. This phase's swap moves suppression
+	 * off that fragile plumbing entirely onto the standalone pfb_ip_suppressed()
+	 * scan, incidentally fixing this too -- the local-IP/DNS half of the same
+	 * bug is untouched (still fragile, out of this phase's scope).
+	 *
+	 * Given: v4suppression = '198.51.100.55/32', a table-matched state for it
+	 *        and a table-matched sibling that is NOT suppressed.
+	 * When:  pfb_remove_states() runs.
+	 * Then:  198.51.100.55 survives, the sibling is killed. FAILS pre-Phase-7
+	 *        (the double-flip bug above), not merely pre-existing-and-still-broken.
+	 */
+	public function test_v4_suppression_legacy_slash32_now_reliably_spares_state(): void
+	{
+		$suppressed = '198.51.100.55';
+		$sibling    = '198.51.100.56';
+
+		$this->seedConfig();
+		$this->seedV4Suppression("{$suppressed}/32");
+		$this->seedStates($this->v4State($suppressed), $this->v4State($sibling, 54322));
+		$this->seedTableMatches($suppressed, $sibling);
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringNotContainsString(
+			$suppressed,
+			$kills,
+			"the exactly-suppressed {$suppressed} must survive — kill log was:\n{$kills}"
+		);
+		$this->assertStringContainsString(
+			$sibling,
+			$kills,
+			"the non-suppressed sibling {$sibling} must be killed — kill log was:\n{$kills}"
+		);
+	}
+
+	/**
+	 * Scenario (ADR-53 P7, red->green) — a v6 '/64' suppression entry spares a
+	 * contained state. Before this phase, v6suppression was not read by
+	 * pfb_remove_states() AT ALL, so this is red for any v6 entry, not just a
+	 * containing mask.
+	 *
+	 * Given: v6suppression = '3fff:0:0:1::/64' (RFC 9637 documentation range —
+	 *        NOT 2001:db8::/32, which may validate as reserved under
+	 *        FILTER_FLAG_NO_RES_RANGE depending on PHP version, same rationale
+	 *        as V6_VICTIM/V6_PERMIT above), a table-matched state inside it
+	 *        (3fff:0:0:1::9) and a table-matched sibling outside it
+	 *        (3fff:0:0:2::9).
+	 * When:  pfb_remove_states() runs.
+	 * Then:  the contained state survives, the outside sibling is killed.
+	 *        FAILS pre-Phase-7: v6suppression was never consulted, so the
+	 *        contained state would have been killed too.
+	 */
+	public function test_v6_suppression_slash64_spares_contained_state_others_still_killed(): void
+	{
+		$contained = '3fff:0:0:1::9';
+		$outside   = '3fff:0:0:2::9';
+
+		// Precondition (not theater): both fixture addresses must validate as
+		// PUBLIC under this PHP's NO_PRIV/NO_RES flags, or the branch under test
+		// is never reached (same rationale as the class's V6_VICTIM precondition).
+		foreach ([$contained, $outside] as $addr) {
+			$this->assertNotFalse(
+				filter_var($addr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE),
+				"{$addr} must validate as public IPv6 under NO_PRIV|NO_RES on this PHP — pick a different fixture address"
+			);
+		}
+
+		$this->seedConfig();
+		$this->seedV6Suppression('3fff:0:0:1::/64');
+		$this->seedStates($this->v6State($contained), $this->v6State($outside));
+		$this->seedTableMatches($contained, $outside);
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringNotContainsString(
+			$contained,
+			$kills,
+			"{$contained} lies inside the suppressed 3fff:0:0:1::/64 and must survive — kill log was:\n{$kills}"
+		);
+		$this->assertStringContainsString(
+			$outside,
+			$kills,
+			"{$outside} lies outside the suppressed range and must be killed — kill log was:\n{$kills}"
 		);
 	}
 }

--- a/tests/php/RequireConfigGatewaySniffTest.php
+++ b/tests/php/RequireConfigGatewaySniffTest.php
@@ -10,11 +10,11 @@ use PHPUnit\Framework\TestCase;
  * Pins both sides of every decision the sniff makes, driving the real `phpcs`
  * binary over fixture files under tests/phpcs/fixtures/:
  *
- *   VIOLATING (gateway_violation.php): three raw config_*_path calls each
- *   targeting a REGISTERED installedpackages/pfblockerng* key — the sniff
- *   MUST flag exactly those three lines (one config_get_path, one
- *   config_set_path, one config_del_path).  Every branch of the gated-function
- *   set is exercised.
+ *   VIOLATING (gateway_violation.php): raw config_*_path calls each targeting
+ *   a REGISTERED installedpackages/pfblockerng* key — the sniff MUST flag
+ *   every one (one config_get_path, one config_set_path, one config_del_path,
+ *   one comment-evasion attempt, and the ADR-53 v4suppression key).  Every
+ *   branch of the gated-function set is exercised.
  *
  *   COMPLIANT (gateway_compliant.php): foreign/unregistered keys, dynamic
  *   paths, pfSense-core sections, and section-level (not scalar-key) accesses
@@ -27,7 +27,9 @@ use PHPUnit\Framework\TestCase;
  *   - registered gen-section key flagged (config_get_path)
  *   - registered DNSBL-settings key flagged (config_set_path)
  *   - registered SafeSearch key flagged (config_del_path)
- *   - foreign section (pfblockerngipsettings) — silent
+ *   - registered v4suppression key flagged (ADR-53, config_get_path)
+ *   - foreign section (pfblockerngipsettings/enable_dup) — silent
+ *   - v4suppression accessed via PfbConfig (not raw config_*_path) — silent
  *   - dynamic per-row path ($row interpolation) — silent
  *   - pfSense-core section (aliases/alias) — silent
  *   - section-level read (path ends at /config/0, no key) — silent
@@ -92,9 +94,11 @@ final class RequireConfigGatewaySniffTest extends TestCase
 	}
 
 	/**
-	 * Violating fixture: four raw config_*_path calls on registered keys MUST
-	 * each be flagged — one per gated function (get / set / del) plus one where
-	 * an inline comment appears between '(' and the key (comment-evasion guard).
+	 * Violating fixture: five raw config_*_path calls on registered keys MUST
+	 * each be flagged — one per gated function (get / set / del), one where
+	 * an inline comment appears between '(' and the key (comment-evasion guard),
+	 * and one on the ADR-53 v4suppression key (proving the sniff picks up a
+	 * newly-registered key with no other change).
 	 *
 	 * Before/after proof: the exact same call patterns appear in the compliant
 	 * fixture but on FOREIGN keys — zero findings there proves the registered
@@ -105,22 +109,23 @@ final class RequireConfigGatewaySniffTest extends TestCase
 		$findings = $this->findingsFor('gateway_violation.php');
 
 		$this->assertCount(
-			4,
+			5,
 			$findings,
-			'exactly four raw registered-key calls must be flagged (get / set / del / comment-evasion)'
+			'exactly five raw registered-key calls must be flagged (get / set / del / comment-evasion / v4suppression)'
 		);
 
 		$lines = array_column($findings, 'line');
 		sort($lines);
 
-		// Line 20: config_get_path on pfb_keep (gen section)
-		// Line 23: config_set_path on pfb_dnsbl (DNSBL settings section)
-		// Line 26: config_del_path on safesearch_enable (SafeSearch section)
-		// Line 29: config_get_path with inline comment before the key (comment-evasion)
+		// Line 21: config_get_path on pfb_keep (gen section)
+		// Line 24: config_set_path on pfb_dnsbl (DNSBL settings section)
+		// Line 27: config_del_path on safesearch_enable (SafeSearch section)
+		// Line 30: config_get_path with inline comment before the key (comment-evasion)
+		// Line 38: config_get_path on v4suppression (ADR-53 -- IP settings section)
 		$this->assertSame(
-			[20, 23, 26, 29],
+			[21, 24, 27, 30, 38],
 			$lines,
-			'findings must land on the four raw registered-key call lines'
+			'findings must land on the five raw registered-key call lines'
 		);
 
 		foreach ($findings as $finding) {

--- a/tests/php/SuppressionValidatorTest.php
+++ b/tests/php/SuppressionValidatorTest.php
@@ -17,6 +17,15 @@ use PHPUnit\Framework\TestCase;
  * floor is a fail-open-typo guard, not an engine limit). testSlash16NowValid()
  * and testSlash8FloorNowValid() are the red->green proof: both FAIL against the
  * old /32-or-/24 rule and PASS against the widened /8-/32 rule.
+ *
+ * BEHAVIOUR CHANGE (ADR-53 Phase 6): family='ipv6' now validates for real. Before
+ * this phase every v6 line was unconditionally rejected ("not yet supported" --
+ * Phase 4's deliberate placeholder, pinned by the since-removed
+ * testIpv6NotYetSupported()). Phase 6 wires the Phase 5 pure-PHP v6 set-diff
+ * engine end-to-end, so v6 accepts masks /32-/128 (the /32 floor is the same
+ * fail-open-typo guard as v4's /8 floor -- the engine itself is mask-agnostic).
+ * testSlash64NowValid() is the red->green proof: it FAILS against the pre-Phase-6
+ * "always reject" stub and PASSES once the real v6 validation lands.
  */
 #[CoversFunction('pfb_validate_suppression_line')]
 final class SuppressionValidatorTest extends TestCase
@@ -94,11 +103,69 @@ final class SuppressionValidatorTest extends TestCase
 		$this->assertNull(pfb_validate_suppression_line('# just a comment', 'ipv4'));
 	}
 
-	// --- v6: not yet implemented (Phase 6 flips this to green) ---
+	// --- v6: implemented in Phase 6 (masks /32-/128) -- the red->green proof ---
 
-	public function testIpv6NotYetSupported(): void
+	public function testSlash64NowValid(): void
 	{
-		$error = pfb_validate_suppression_line('2001:db8::1/64', 'ipv6');
-		$this->assertNotNull($error, 'ADR-53 Phase 6 implements v6 suppression -- until then every v6 line is rejected');
+		$this->assertNull(pfb_validate_suppression_line('2001:db8::/64', 'ipv6'), 'ADR-53 Phase 6: v6 suppression now validates -- FAILS against the pre-Phase-6 always-reject stub');
+	}
+
+	public function testSlash128HostMaskValid(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('2001:db8::1/128', 'ipv6'));
+	}
+
+	public function testSlash32FloorValid(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('2001:db8::/32', 'ipv6'));
+	}
+
+	// --- v6: out-of-range masks rejected, message names the accepted range ---
+
+	public function testSlash31BelowFloorRejected(): void
+	{
+		$error = pfb_validate_suppression_line('2001:db8::/31', 'ipv6');
+		$this->assertNotNull($error, '/31 is below the /32 floor -- must be rejected');
+		$this->assertStringContainsString('/32', $error);
+		$this->assertStringContainsString('/128', $error);
+	}
+
+	public function testSlash129AboveCeilingRejected(): void
+	{
+		$error = pfb_validate_suppression_line('2001:db8::1/129', 'ipv6');
+		$this->assertNotNull($error, '/129 is above the /128 ceiling -- must be rejected');
+		$this->assertStringContainsString('/32', $error);
+		$this->assertStringContainsString('/128', $error);
+	}
+
+	// --- v6: malformed input rejected (generic subnet message, not the range message) ---
+
+	public function testV6NonCidrGarbageRejected(): void
+	{
+		$error = pfb_validate_suppression_line('not-an-ipv6-address', 'ipv6');
+		$this->assertNotNull($error, 'non-CIDR garbage must be rejected');
+	}
+
+	public function testV6MissingMaskRejected(): void
+	{
+		$error = pfb_validate_suppression_line('2001:db8::1', 'ipv6');
+		$this->assertNotNull($error, 'a bare address with no mask must be rejected');
+	}
+
+	// --- v6: tolerated textarea shapes (same tolerance as v4) ---
+
+	public function testV6TrailingInlineCommentTolerated(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('2001:db8::1/128 # example.com', 'ipv6'));
+	}
+
+	public function testV6BlankLineSkipped(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('', 'ipv6'));
+	}
+
+	public function testV6CommentOnlyLineSkipped(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('# just a comment', 'ipv6'));
 	}
 }

--- a/tests/php/SuppressionValidatorTest.php
+++ b/tests/php/SuppressionValidatorTest.php
@@ -86,6 +86,19 @@ final class SuppressionValidatorTest extends TestCase
 		$this->assertNotNull($error, 'an out-of-range octet must be rejected');
 	}
 
+	/**
+	 * ADR-53 review finding H5: pin CURRENT behaviour -- a bare v4 address with
+	 * no mask is REJECTED (is_subnetv4() requires an explicit '/bits'), the
+	 * same contract as testV6MissingMaskRejected() below. No behaviour change;
+	 * this closes a parity gap in coverage (the v6 case was pinned, the v4
+	 * sibling was not).
+	 */
+	public function testMissingMaskRejected(): void
+	{
+		$error = pfb_validate_suppression_line('10.0.0.1', 'ipv4');
+		$this->assertNotNull($error, 'a bare address with no mask must be rejected');
+	}
+
 	// --- v4: tolerated textarea shapes (unchanged from today) ---
 
 	public function testTrailingInlineCommentTolerated(): void

--- a/tests/php/SuppressionValidatorTest.php
+++ b/tests/php/SuppressionValidatorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_validate_suppression_line() -- ADR-53 Phase 4: the v4 suppression textarea's
+ * per-line validator, extracted from pfblockerng_ip.php's POST handler so it is
+ * unit-testable off-appliance (it was previously inline in the page and
+ * unreachable by PHPUnit).
+ *
+ * BEHAVIOUR CHANGE (ADR-53 §2.3 fork 1): the old inline rule accepted ONLY masks
+ * /32 or /24. Phase 3's engine swap (iprange --except set subtraction) made the
+ * carve engine mask-agnostic, so the UI now accepts any v4 mask /8-/32 (the /8
+ * floor is a fail-open-typo guard, not an engine limit). testSlash16NowValid()
+ * and testSlash8FloorNowValid() are the red->green proof: both FAIL against the
+ * old /32-or-/24 rule and PASS against the widened /8-/32 rule.
+ */
+#[CoversFunction('pfb_validate_suppression_line')]
+final class SuppressionValidatorTest extends TestCase
+{
+	// --- v4: legacy-valid shapes keep working (upgrade contract, ADR-53 §2.2) ---
+
+	public function testLegacyBareHostMaskStillValid(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('10.0.0.1/32', 'ipv4'));
+	}
+
+	public function testLegacySlash24MaskStillValid(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('10.0.0.0/24', 'ipv4'));
+	}
+
+	// --- v4: NEW masks the widened /8-/32 range unlocks (the red->green proof) ---
+
+	public function testSlash16NowValid(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('10.0.0.0/16', 'ipv4'));
+	}
+
+	public function testSlash8FloorNowValid(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('10.0.0.0/8', 'ipv4'));
+	}
+
+	// --- v4: out-of-range masks stay rejected, message names the accepted range ---
+
+	public function testSlash7BelowFloorRejected(): void
+	{
+		$error = pfb_validate_suppression_line('10.0.0.0/7', 'ipv4');
+		$this->assertNotNull($error, '/7 is below the /8 floor -- must be rejected');
+		$this->assertStringContainsString('/8', $error);
+		$this->assertStringContainsString('/32', $error);
+	}
+
+	public function testSlash33AboveCeilingRejected(): void
+	{
+		$error = pfb_validate_suppression_line('10.0.0.0/33', 'ipv4');
+		$this->assertNotNull($error, '/33 is above the /32 ceiling -- must be rejected');
+		$this->assertStringContainsString('/8', $error);
+		$this->assertStringContainsString('/32', $error);
+	}
+
+	// --- v4: malformed input rejected (generic subnet message, not the range message) ---
+
+	public function testNonCidrGarbageRejected(): void
+	{
+		$error = pfb_validate_suppression_line('not-an-ip-address', 'ipv4');
+		$this->assertNotNull($error, 'non-CIDR garbage must be rejected');
+	}
+
+	public function testBadOctetRejected(): void
+	{
+		$error = pfb_validate_suppression_line('10.0.0.999/32', 'ipv4');
+		$this->assertNotNull($error, 'an out-of-range octet must be rejected');
+	}
+
+	// --- v4: tolerated textarea shapes (unchanged from today) ---
+
+	public function testTrailingInlineCommentTolerated(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('10.0.0.1/32 # example.com', 'ipv4'));
+	}
+
+	public function testBlankLineSkipped(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('', 'ipv4'));
+	}
+
+	public function testCommentOnlyLineSkipped(): void
+	{
+		$this->assertNull(pfb_validate_suppression_line('# just a comment', 'ipv4'));
+	}
+
+	// --- v6: not yet implemented (Phase 6 flips this to green) ---
+
+	public function testIpv6NotYetSupported(): void
+	{
+		$error = pfb_validate_suppression_line('2001:db8::1/64', 'ipv6');
+		$this->assertNotNull($error, 'ADR-53 Phase 6 implements v6 suppression -- until then every v6 line is rejected');
+	}
+}

--- a/tests/php/V6CidrSubtractTest.php
+++ b/tests/php/V6CidrSubtractTest.php
@@ -27,6 +27,8 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversFunction('pfb_cidr_subtract_v6')]
 #[CoversFunction('pfb_suppress_file_v6')]
+#[CoversFunction('pfb_v6_bin_inc')]
+#[CoversFunction('pfb_v6_bin_dec')]
 final class V6CidrSubtractTest extends TestCase
 {
 	// =========================================================================
@@ -434,6 +436,26 @@ final class V6CidrSubtractTest extends TestCase
 	}
 
 	// =========================================================================
+	// pfb_v6_bin_inc / pfb_v6_bin_dec -- overflow/underflow edges (ADR-53
+	// review finding H2; the binary-string increment/decrement helpers the
+	// subtraction engine walks addresses with, uncovered until now)
+	// =========================================================================
+
+	public function testBinIncOverflowAllOnesReturnsNull(): void
+	{
+		// ffff:ffff:...:ffff (all-ones, the highest representable v6 address)
+		// has no next address -- must overflow to NULL, never wrap to all-zeros.
+		$this->assertNull(pfb_v6_bin_inc(str_repeat('1', 128)));
+	}
+
+	public function testBinDecUnderflowAllZeroesReturnsNull(): void
+	{
+		// :: (all-zeros, the lowest representable v6 address) has no prior
+		// address -- must underflow to NULL, never wrap to all-ones.
+		$this->assertNull(pfb_v6_bin_dec(str_repeat('0', 128)));
+	}
+
+	// =========================================================================
 	// pfb_suppress_file_v6 -- file-level, fail-safe publish
 	// =========================================================================
 
@@ -573,5 +595,43 @@ final class V6CidrSubtractTest extends TestCase
 
 		$this->assertTrue($ok);
 		$this->assertFileDoesNotExist($file . '.tmp', 'the tmp+rename publish must never leave a stray .tmp file behind');
+	}
+
+	/**
+	 * ADR-53 review finding H1: a file_put_contents() FAILURE on the .tmp path
+	 * (not the rename step -- that branch already unlinked) must not leave a
+	 * stray .tmp file behind either.
+	 *
+	 * Deterministic trick: pre-create the .tmp path (simulating debris left by
+	 * a prior crashed run) and strip its write permission -- file_put_contents()
+	 * fails to open it for writing (its own internal fopen()), so it returns
+	 * FALSE without ever touching the pre-existing file's content. The FIX
+	 * must still unlink it on that failure branch.
+	 */
+	public function testFilePutContentsFailureUnlinksStrayTmpFile(): void
+	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('running as root -- permission-based failure injection cannot be simulated');
+		}
+
+		$file     = $this->makeTempFile("2001:db8::/64\n");
+		$suppfile = $this->makeTempFile("2001:db8::5353/128\n");
+
+		$tmp = $file . '.tmp';
+		file_put_contents($tmp, 'stale debris from a prior crashed run');
+		chmod($tmp, 0444);
+		$this->tmpfiles[] = $tmp;
+
+		try {
+			$ok = pfb_suppress_file_v6($file, $suppfile);
+
+			$this->assertFalse($ok, 'a file_put_contents() failure on the tmp path must fail safe (FALSE)');
+			$this->assertFileDoesNotExist(
+				$tmp,
+				'a stray .tmp must not survive a file_put_contents() failure -- it must be unlinked on that branch too'
+			);
+		} finally {
+			@chmod($tmp, 0644); // restore writability so tearDown's cleanup can remove it if still present
+		}
 	}
 }

--- a/tests/php/V6CidrSubtractTest.php
+++ b/tests/php/V6CidrSubtractTest.php
@@ -82,6 +82,47 @@ final class V6CidrSubtractTest extends TestCase
 		$this->assertSame([], $errors);
 	}
 
+	/**
+	 * A BARE v6 host token (no /mask -- the dominant feed-member shape) is a valid
+	 * /128 entry, NOT a malformed token: it must survive the pass verbatim when no
+	 * hole covers it. Pinned after the live smoke caught the parser dropping every
+	 * bare host from the member file (fail-open: hosts silently unblocked).
+	 */
+	public function testBareHostEntryTreatedAsSlash128NotMalformed(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8::/64', '2001:db8:99::10'], ['2001:db8::5353/128'], $errors);
+
+		$this->assertSame([], $errors, 'a bare v6 host is a legitimate /128 entry, never a malformed-token report');
+		// The engine re-emits every entry in canonical covering-CIDR form, so the
+		// surviving bare host publishes as its /128 — set-equivalent for every
+		// consumer (the smoke _has_entry oracle tolerates both notations).
+		$this->assertContains('2001:db8:99::10/128', $result, 'the un-carved bare host must survive (canonical /128 form)');
+		$this->assertCount(65, $result, '64 covering CIDRs for the carved /64 + the untouched bare host');
+		$this->assertFalse($this->anyCidrContains($result, '2001:db8::5353'));
+	}
+
+	/** A bare host entry fully covered by a hole is removed like any other entry. */
+	public function testBareHostEntryRemovedWhenHoleCoversIt(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8:99::10'], ['2001:db8:99::/64'], $errors);
+
+		$this->assertSame([], $result);
+		$this->assertSame([], $errors);
+	}
+
+	/** A bare host HOLE token carves exactly like its explicit /128 form. */
+	public function testBareHostHoleTreatedAsSlash128(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8::/64'], ['2001:db8::5353'], $errors);
+
+		$this->assertCount(64, $result, 'a bare-host hole must carve identically to its /128 form');
+		$this->assertSame([], $errors);
+		$this->assertFalse($this->anyCidrContains($result, '2001:db8::5353'));
+	}
+
 	/** Two adjacent /128 holes in the same entry both carve out (63 covering CIDRs), siblings on either side stay covered. */
 	public function testTwoAdjacentHolesInOneEntry(): void
 	{
@@ -492,6 +533,20 @@ final class V6CidrSubtractTest extends TestCase
 
 		$this->assertTrue($ok, 'a legitimate full suppression must still return TRUE (a real publish), not FALSE');
 		$this->assertSame('', file_get_contents($file), 'the published file must be empty, not left stale');
+	}
+
+	/** File level: a bare v6 host line (the dominant feed shape) publishes unchanged — never dropped as malformed. */
+	public function testBareHostMemberLineSurvivesFilePass(): void
+	{
+		$file     = $this->makeTempFile("2001:db8:53::/64\n2001:db8:99::10\n");
+		$suppfile = $this->makeTempFile("2001:db8:53::42/128\n");
+
+		$ok = pfb_suppress_file_v6($file, $suppfile);
+
+		$this->assertTrue($ok);
+		$lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		$this->assertContains('2001:db8:99::10/128', $lines, 'the bare host line must survive the suppress pass (canonical /128 form)');
+		$this->assertCount(65, $lines, '64 covering CIDRs + the untouched bare host');
 	}
 
 	public function testMalformedMemberLineDroppedAndLogged(): void

--- a/tests/php/V6CidrSubtractTest.php
+++ b/tests/php/V6CidrSubtractTest.php
@@ -1,0 +1,522 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-53 Phase 5 -- the pure IPv6 CIDR set-subtraction engine.
+ *
+ * IPv6 suppression can't carve by host enumeration (a /64 minus a /128 hole is
+ * 2^64 hosts) and `iprange` mangles v6 input outright, so this engine performs
+ * an exact set subtraction over fixed-width 128-bit binary-string ranges and
+ * emits the minimal covering-CIDR remainder via pfSense's own
+ * ip_range_to_subnet_array() (a faithful, vector-pinned double stands in for
+ * it here -- see pfsense_doubles.php).
+ *
+ * Functions under test:
+ *   pfb_cidr_subtract_v6(array $cidrs, array $holes, ?array &$errors): array
+ *   pfb_suppress_file_v6(string $file, string $suppfile): bool
+ *
+ * All expected covering-CIDR counts/shapes below were independently verified
+ * against a from-scratch Python port of the algorithm (arbitrary-precision
+ * integers make hand-checking the bit math tractable) before being pinned
+ * here -- they are not merely "whatever the code happens to produce".
+ */
+#[CoversFunction('pfb_cidr_subtract_v6')]
+#[CoversFunction('pfb_suppress_file_v6')]
+final class V6CidrSubtractTest extends TestCase
+{
+	// =========================================================================
+	// pfb_cidr_subtract_v6 -- known vectors
+	// =========================================================================
+
+	/**
+	 * The headline ADR-53 §1.2 measurement: subtracting a single /128 host from
+	 * a containing /64 costs exactly 64 covering CIDRs (vs 2^64 by host
+	 * enumeration) -- the hole itself is absent, but its immediate siblings
+	 * remain covered (proving this is a real carve, not an over-broad drop).
+	 */
+	public function testContainingSlash64MinusSlash128CarvesExactlySixtyFourCoveringCidrs(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8::/64'], ['2001:db8::5353/128'], $errors);
+
+		$this->assertCount(64, $result, 'a /64 minus one /128 hole must decompose into exactly 64 covering CIDRs (ADR-53 §1.2)');
+		$this->assertSame([], $errors);
+
+		$this->assertNotContains('2001:db8::5353/128', $result, 'the suppressed host itself must not appear as its own entry');
+		$this->assertTrue(
+			$this->anyCidrContains($result, '2001:db8::5352'),
+			'the sibling just below the hole must still be covered'
+		);
+		$this->assertTrue(
+			$this->anyCidrContains($result, '2001:db8::5354'),
+			'the sibling just above the hole must still be covered'
+		);
+		$this->assertFalse(
+			$this->anyCidrContains($result, '2001:db8::5353'),
+			'the suppressed host must not be covered by ANY output CIDR'
+		);
+	}
+
+	/** A hole identical to the entry removes it entirely -- not a partial carve. */
+	public function testHoleEqualToEntryRemovesEntryEntirely(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8::/64'], ['2001:db8::/64'], $errors);
+
+		$this->assertSame([], $result);
+		$this->assertSame([], $errors);
+	}
+
+	/** A hole with no intersection leaves the entry set-wise unchanged. */
+	public function testHoleOutsideEveryEntryLeavesInputUnchanged(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8::/64'], ['2001:dba::1/128'], $errors);
+
+		$this->assertSame(['2001:db8::/64'], $result);
+		$this->assertSame([], $errors);
+	}
+
+	/** Two adjacent /128 holes in the same entry both carve out (63 covering CIDRs), siblings on either side stay covered. */
+	public function testTwoAdjacentHolesInOneEntry(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8::/64'], ['2001:db8::10/128', '2001:db8::11/128'], $errors);
+
+		$this->assertCount(63, $result, 'two adjacent /128 holes in one /64 decompose into 63 covering CIDRs');
+		$this->assertSame([], $errors);
+		$this->assertFalse($this->anyCidrContains($result, '2001:db8::10'));
+		$this->assertFalse($this->anyCidrContains($result, '2001:db8::11'));
+		$this->assertTrue($this->anyCidrContains($result, '2001:db8::f'), 'the address just before both holes stays covered');
+		$this->assertTrue($this->anyCidrContains($result, '2001:db8::12'), 'the address just after both holes stays covered');
+	}
+
+	/**
+	 * Two holes, each confined to a DIFFERENT entry, act independently: neither
+	 * entry's carve is affected by the other entry's hole (128 = 64 + 64).
+	 */
+	public function testTwoHolesInDifferentEntriesActIndependently(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(
+			['2001:db8:1::/64', '2001:db8:2::/64'],
+			['2001:db8:1::5353/128', '2001:db8:2::7777/128'],
+			$errors
+		);
+
+		$this->assertCount(128, $result, 'two independently-suppressed /64 entries yield 64 + 64 covering CIDRs');
+		$this->assertSame([], $errors);
+		$this->assertFalse($this->anyCidrContains($result, '2001:db8:1::5353'));
+		$this->assertFalse($this->anyCidrContains($result, '2001:db8:2::7777'));
+		// Cross-check: entry 1's hole address must not "leak" a false exclusion into entry 2's space and vice versa.
+		$this->assertTrue($this->anyCidrContains($result, '2001:db8:2::5353'), "entry 2's copy of entry 1's hole address must still be covered");
+		$this->assertTrue($this->anyCidrContains($result, '2001:db8:1::7777'), "entry 1's copy of entry 2's hole address must still be covered");
+	}
+
+	/** A coarser hole that fully contains a finer entry removes the entry entirely. */
+	public function testHoleContainingAnEntryRemovesItEntirely(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8:0:5::/64'], ['2001:db8::/48'], $errors);
+
+		$this->assertSame([], $result, 'a /48 hole containing the /64 feed entry must remove it entirely');
+		$this->assertSame([], $errors);
+	}
+
+	/** Full suppression across every entry legitimately returns an empty (not a fail-safe) result. */
+	public function testFullSuppressionOfEveryEntryYieldsLegitimateEmptyResult(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(
+			['2001:db8:1::/64', '2001:db8:2::/64'],
+			['2001:db8:1::/64', '2001:db8:2::/64'],
+			$errors
+		);
+
+		$this->assertSame([], $result);
+		$this->assertSame([], $errors);
+	}
+
+	/** A malformed feed token is skipped (not thrown) and reported verbatim; the well-formed sibling still carves normally. */
+	public function testMalformedCidrTokenSkippedAndReported(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8::/64', 'not-an-ip/64'], [], $errors);
+
+		$this->assertSame(['2001:db8::/64'], $result);
+		$this->assertSame(['not-an-ip/64'], $errors);
+	}
+
+	/** A malformed suppression token is skipped (not thrown) and reported; the legitimate hole in the same call still carves. */
+	public function testMalformedHoleTokenSkippedAndReported(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8::/64'], ['garbage', '2001:db8::5353/128'], $errors);
+
+		$this->assertCount(64, $result, 'the legitimate hole must still carve even though a sibling hole token was malformed');
+		$this->assertSame(['garbage'], $errors);
+	}
+
+	/** Blank lines and '#'-led comments are silent no-ops -- never reported as malformed (mirrors pfb_validate_suppression_line's tolerance). */
+	public function testBlankAndCommentLinesAreSilentNoOps(): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6(['2001:db8::/64', '', '# a note'], ['', '# also a note'], $errors);
+
+		$this->assertSame(['2001:db8::/64'], $result);
+		$this->assertSame([], $errors, 'blank/comment lines must never land in the malformed-token report');
+	}
+
+	// =========================================================================
+	// Set-equivalence property check -- INDEPENDENT representation
+	//
+	// Per ADR-53 Phase 5 spec: verify result ∪ holes ⊇ input, result ∩ holes = ∅,
+	// and result ⊆ input using a representation that shares NO code with the
+	// engine under test -- inet_pton()-derived (start,end) HEX strings, raw
+	// byte masking, and strcmp(), never pfb_v6_cidr_to_range()/
+	// pfb_v6_addr_to_bin() (the engine's own '0'/'1'-binary-string technique).
+	// =========================================================================
+
+	/**
+	 * @return array<int, array{entries: string[], holes: string[]}> Five fixed
+	 *   (deterministic, not random) scenarios exercising different overlap
+	 *   shapes: multiple holes in one entry, a half-overlapping hole, two
+	 *   independent entries, a hole fully containing an entry, and a hole with
+	 *   no overlap at all. Every entry here uses a small (<=4) host-bit count
+	 *   so its address space is exhaustively enumerable.
+	 */
+	public static function propertyScenarios(): array
+	{
+		return [
+			'multiple holes in one entry' => [
+				'entries' => ['2001:db8:9000::/124'],
+				'holes'   => ['2001:db8:9000::3/128', '2001:db8:9000::c/128'],
+			],
+			'half-overlapping coarser hole' => [
+				'entries' => ['2001:db8:9001::/124'],
+				'holes'   => ['2001:db8:9001::/125'],
+			],
+			'two independent entries, one hole each' => [
+				'entries' => ['2001:db8:9002::/125', '2001:db8:9003::/125'],
+				'holes'   => ['2001:db8:9002::3/128', '2001:db8:9003::5/128'],
+			],
+			'hole fully containing the entry' => [
+				'entries' => ['2001:db8:9004::/124'],
+				'holes'   => ['2001:db8:9000::/108'],
+			],
+			'hole with no overlap at all' => [
+				'entries' => ['2001:db8:9005::/124'],
+				'holes'   => ['2001:dead::/32'],
+			],
+		];
+	}
+
+	/**
+	 * @param string[] $entries
+	 * @param string[] $holes
+	 */
+	#[DataProvider('propertyScenarios')]
+	public function testSetEquivalencePropertyHoldsAcrossFixedScenarios(array $entries, array $holes): void
+	{
+		$errors = null;
+		$result = pfb_cidr_subtract_v6($entries, $holes, $errors);
+
+		$resultRanges = array_map([$this, 'independentHexRange'], $result);
+		$holeRanges   = array_map([$this, 'independentHexRange'], $holes);
+
+		// (1) result ∩ holes = ∅ -- no output CIDR may overlap any hole.
+		foreach ($resultRanges as $r) {
+			foreach ($holeRanges as $h) {
+				$this->assertFalse($this->rangesOverlap($r, $h), 'a result CIDR must never overlap a suppression hole');
+			}
+		}
+
+		// (2) result ⊆ input -- every output CIDR must sit fully inside SOME entry
+		// (entries are disjoint by fixture design, so containment-in-any-one is exact).
+		$entryRanges = array_map([$this, 'independentHexRange'], $entries);
+		foreach ($resultRanges as $r) {
+			$this->assertTrue(
+				$this->rangeContainedInAny($r, $entryRanges),
+				'every result CIDR must be fully contained within some input entry'
+			);
+		}
+
+		// (3) result ∪ holes ⊇ input -- exhaustively enumerate every address in
+		// each (small, host-bits<=4) entry and confirm it is covered by the
+		// result OR a hole (nothing may silently vanish).
+		foreach ($entries as $entry) {
+			foreach ($this->enumerateEntryAddresses($entry) as $addrHex) {
+				$covered = $this->addressHexCoveredByAny($addrHex, $resultRanges)
+					|| $this->addressHexCoveredByAny($addrHex, $holeRanges);
+				$this->assertTrue($covered, "address {$addrHex} from entry {$entry} must be covered by the result or a hole");
+			}
+		}
+	}
+
+	/**
+	 * INDEPENDENT (from the engine) expansion of one IPv6 CIDR into its
+	 * [start_hex, end_hex] range: inet_pton() + raw per-byte masking + bin2hex().
+	 * Deliberately does NOT call pfb_v6_cidr_to_range()/pfb_v6_addr_to_bin() --
+	 * a different data representation (hex string vs the engine's '0'/'1'
+	 * binary string) so this check can't share a bug with the code under test.
+	 *
+	 * @return array{0:string,1:string} [start_hex, end_hex].
+	 */
+	private function independentHexRange(string $cidr): array
+	{
+		[$addr, $bitsRaw] = explode('/', $cidr, 2);
+		$bits = (int) $bitsRaw;
+		$packed = inet_pton($addr);
+		$this->assertNotFalse($packed, "test fixture CIDR must be a syntactically valid IPv6 address: {$cidr}");
+
+		$fullBytes = intdiv($bits, 8);
+		$remBits   = $bits % 8;
+
+		$startBytes = substr($packed, 0, $fullBytes);
+		$endBytes   = $startBytes;
+		if ($remBits > 0) {
+			$byte = ord($packed[$fullBytes]);
+			$mask = (0xFF << (8 - $remBits)) & 0xFF;
+			$startBytes .= chr($byte & $mask);
+			$endBytes   .= chr($byte | (~$mask & 0xFF));
+		}
+		$startBytes = str_pad($startBytes, 16, "\x00");
+		$endBytes   = str_pad($endBytes, 16, "\xFF");
+
+		return [bin2hex($startBytes), bin2hex($endBytes)];
+	}
+
+	/** @param array{0:string,1:string} $a @param array{0:string,1:string} $b */
+	private function rangesOverlap(array $a, array $b): bool
+	{
+		return !(strcmp($a[1], $b[0]) < 0 || strcmp($b[1], $a[0]) < 0);
+	}
+
+	/**
+	 * @param array{0:string,1:string}   $inner
+	 * @param array<int,array{0:string,1:string}> $outerSet
+	 */
+	private function rangeContainedInAny(array $inner, array $outerSet): bool
+	{
+		foreach ($outerSet as $outer) {
+			if (strcmp($inner[0], $outer[0]) >= 0 && strcmp($inner[1], $outer[1]) <= 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** @param array<int,array{0:string,1:string}> $ranges */
+	private function addressHexCoveredByAny(string $addrHex, array $ranges): bool
+	{
+		foreach ($ranges as $r) {
+			if (strcmp($addrHex, $r[0]) >= 0 && strcmp($addrHex, $r[1]) <= 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Exhaustively enumerate every address (as an independent hex string) in a
+	 * small CIDR (host bits <=4, i.e. <=16 addresses) by varying only the last
+	 * nibble of the packed address -- every fixture entry above is host-aligned
+	 * within its final hextet, so no cross-byte carry is needed.
+	 *
+	 * @return string[] hex-encoded 16-byte addresses.
+	 */
+	private function enumerateEntryAddresses(string $cidr): array
+	{
+		[$addr, $bitsRaw] = explode('/', $cidr, 2);
+		$bits = (int) $bitsRaw;
+		$hostBits = 128 - $bits;
+		$this->assertLessThanOrEqual(4, $hostBits, 'test fixture entries must stay small enough to enumerate exhaustively');
+
+		$packed = inet_pton($addr);
+		$this->assertNotFalse($packed);
+		$count = 1 << $hostBits;
+		$lastByte = ord($packed[15]);
+
+		$out = [];
+		for ($i = 0; $i < $count; $i++) {
+			$candidate = substr($packed, 0, 15) . chr(($lastByte + $i) & 0xFF);
+			$out[] = bin2hex($candidate);
+		}
+		return $out;
+	}
+
+	/** Membership helper for the plain vector tests (reuses the already-faithful pfSense double, NOT a new representation -- fine outside the dedicated property check above). */
+	private function anyCidrContains(array $cidrs, string $addr): bool
+	{
+		foreach ($cidrs as $cidr) {
+			if (ip_in_subnet($addr, $cidr)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	// =========================================================================
+	// Vector-pin the ip_range_to_subnet_array() double itself
+	//
+	// Hand-derivable examples (not dependent on trusting the double's own
+	// output): an aligned + a non-aligned range for each family. A stale/wrong
+	// double fails these loudly rather than silently corrupting every v6
+	// engine test above.
+	// =========================================================================
+
+	public function testDoubleVectorV4Aligned(): void
+	{
+		$this->assertSame(['10.0.0.0/30'], ip_range_to_subnet_array('10.0.0.0', '10.0.0.3'));
+	}
+
+	public function testDoubleVectorV4NonAlignedEdgeCase(): void
+	{
+		// Two adjacent addresses that do NOT share a power-of-2-aligned block
+		// (1 = ...01, 2 = ...10) must decompose into two separate /32 hosts.
+		$this->assertSame(['10.0.0.1/32', '10.0.0.2/32'], ip_range_to_subnet_array('10.0.0.1', '10.0.0.2'));
+	}
+
+	public function testDoubleVectorV6Aligned(): void
+	{
+		$this->assertSame(['2001:db8::/126'], ip_range_to_subnet_array('2001:db8::', '2001:db8::3'));
+	}
+
+	public function testDoubleVectorV6NonAlignedEdgeCase(): void
+	{
+		$this->assertSame(['2001:db8::1/128', '2001:db8::2/128'], ip_range_to_subnet_array('2001:db8::1', '2001:db8::2'));
+	}
+
+	// =========================================================================
+	// pfb_suppress_file_v6 -- file-level, fail-safe publish
+	// =========================================================================
+
+	/** @var string[] temp files to remove in tearDown */
+	private array $tmpfiles = [];
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $savedPfb = [];
+
+	protected function setUp(): void
+	{
+		foreach (['log', 'errlog'] as $k) {
+			$this->savedPfb[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+		$log = tempnam(sys_get_temp_dir(), 'pfb_v6log_');
+		$this->assertNotFalse($log);
+		$this->tmpfiles[] = $log;
+		$GLOBALS['pfb']['log']    = $log;
+		$GLOBALS['pfb']['errlog'] = $log;
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedPfb as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		foreach ($this->tmpfiles as $f) {
+			if (is_file($f)) {
+				@unlink($f);
+			}
+		}
+		$this->tmpfiles = [];
+	}
+
+	private function makeTempFile(string $contents): string
+	{
+		$path = tempnam(sys_get_temp_dir(), 'pfb_v6file_');
+		$this->assertNotFalse($path);
+		$this->tmpfiles[] = $path;
+		file_put_contents($path, $contents);
+		return $path;
+	}
+
+	public function testSuccessfulCarvePublishesCoveringCidrRemainder(): void
+	{
+		$file     = $this->makeTempFile("2001:db8::/64\n");
+		$suppfile = $this->makeTempFile("2001:db8::5353/128\n");
+
+		$ok = pfb_suppress_file_v6($file, $suppfile);
+
+		$this->assertTrue($ok);
+		$lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		$this->assertCount(64, $lines, 'published member file must hold the 64-entry covering-CIDR remainder');
+		$this->assertNotContains('2001:db8::5353/128', $lines);
+	}
+
+	public function testMissingMemberFileFailsSafeAndWritesNothing(): void
+	{
+		$missing  = sys_get_temp_dir() . '/pfb_v6_does_not_exist_' . getmypid();
+		$suppfile = $this->makeTempFile("2001:db8::5353/128\n");
+
+		$ok = pfb_suppress_file_v6($missing, $suppfile);
+
+		$this->assertFalse($ok);
+		$this->assertFileDoesNotExist($missing, 'a missing member file must never be created by a fail-safe path');
+	}
+
+	/**
+	 * A missing suppression file is also fail-safe: the member file, asserted
+	 * BEFORE the call, is byte-identical AFTER (transition test -- proves the
+	 * function truly left it untouched, not merely "still looks similar").
+	 */
+	public function testMissingSuppressionFileFailsSafeAndLeavesMemberFileIntact(): void
+	{
+		$original = "2001:db8::/64\n";
+		$file     = $this->makeTempFile($original);
+		$missingSuppfile = sys_get_temp_dir() . '/pfb_v6_supp_does_not_exist_' . getmypid();
+
+		$this->assertSame($original, file_get_contents($file), 'sanity: member file holds the expected content before the call');
+
+		$ok = pfb_suppress_file_v6($file, $missingSuppfile);
+
+		$this->assertFalse($ok);
+		$this->assertSame($original, file_get_contents($file), 'member file must be byte-identical after a fail-safe path');
+	}
+
+	public function testFullSuppressionPublishesLegitimateEmptyFile(): void
+	{
+		$file     = $this->makeTempFile("2001:db8::/64\n");
+		$suppfile = $this->makeTempFile("2001:db8::/64\n");
+
+		$ok = pfb_suppress_file_v6($file, $suppfile);
+
+		$this->assertTrue($ok, 'a legitimate full suppression must still return TRUE (a real publish), not FALSE');
+		$this->assertSame('', file_get_contents($file), 'the published file must be empty, not left stale');
+	}
+
+	public function testMalformedMemberLineDroppedAndLogged(): void
+	{
+		$file     = $this->makeTempFile("2001:db8::5353/128\nnot-an-ip/64\n");
+		$suppfile = $this->makeTempFile('');
+
+		$ok = pfb_suppress_file_v6($file, $suppfile);
+
+		$this->assertTrue($ok);
+		$lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		$this->assertSame(['2001:db8::5353/128'], $lines, 'the malformed line must be dropped; the valid line publishes unchanged');
+
+		$logged = file_get_contents($GLOBALS['pfb']['log']);
+		$this->assertStringContainsString('not-an-ip/64', $logged, 'the dropped token must be named in the log');
+	}
+
+	public function testAtomicPublishLeavesNoTmpFileBehind(): void
+	{
+		$file     = $this->makeTempFile("2001:db8::/64\n");
+		$suppfile = $this->makeTempFile("2001:db8::5353/128\n");
+
+		$ok = pfb_suppress_file_v6($file, $suppfile);
+
+		$this->assertTrue($ok);
+		$this->assertFileDoesNotExist($file . '.tmp', 'the tmp+rename publish must never leave a stray .tmp file behind');
+	}
+}

--- a/tests/php/WwwGroupCGatewayTest.php
+++ b/tests/php/WwwGroupCGatewayTest.php
@@ -8,7 +8,8 @@ use PHPUnit\Framework\TestCase;
  * ADR-29 Phase 8 — www/ group C gateway routing tests.
  *
  * Covers the pages routed in Phase 8:
- *   - pfblockerng_alerts.php   (pfblockerngglobal: foreign section; suppression/tldexclusion/global_log: registered)
+ *   - pfblockerng_alerts.php   (pfblockerngglobal: foreign section; suppression/tldexclusion/global_log/
+ *                               v4suppression [ADR-53]: registered)
  *   - pfblockerng_sync.php     (pfblockerngsync/config/0: foreign section)
  *   - pfblockerng_software.php (pfb_software_check: registered)
  *   - pfblockerng_log.php      (no pfblockerng* config access — no routing work)
@@ -18,13 +19,16 @@ use PHPUnit\Framework\TestCase;
  * Test groups:
  *
  * A — LOAD DEFAULT PARITY
- *   Registered keys (pfb_software_check, global_log, suppression, tldexclusion):
+ *   Registered keys (pfb_software_check, global_log, suppression, tldexclusion,
+ *   v4suppression [ADR-53]):
  *     Assert PfbConfig::read($key) on an absent section returns the correct default
  *     (parity with prior page behaviour before routing).
  *
- *   Foreign keys (pfblockerngglobal widget-*, pfblockerngsync, pfblockerngipsettings/v4suppression):
+ *   Foreign keys (pfblockerngglobal widget-*, pfblockerngsync, pfblockerngipsettings/enable_dup):
  *     Assert registry lookup throws (proving they are NOT in the registry and must
- *     stay on direct config_*_path).
+ *     stay on direct config_*_path). v4suppression -- the ADR-53 sibling in the same
+ *     pfblockerngipsettings section -- is now registered; see group A's v4suppression
+ *     tests below rather than this foreign-key list.
  *
  * B — SAVE ROUND-TRIP IDENTITY (section blobs)
  *   For every section routed through PfbConfig::readSection/writeSection, assert that
@@ -199,6 +203,46 @@ final class WwwGroupCGatewayTest extends TestCase
 	}
 
 	/**
+	 * v4suppression: absent -> '' (registry default; ADR-53 P2 migrates the raw
+	 * pfblockerng_alerts.php call sites onto the gateway -- parity with the prior
+	 * page's `config_get_path(...) ?: ''` fallback).
+	 *
+	 * Red->green: before this phase, v4suppression was a foreign key and
+	 * PfbConfig::read('v4suppression') threw InvalidArgumentException (the former
+	 * testV4SuppressionIsNotInRegistry pin this test-pair replaces).
+	 */
+	public function testV4SuppressionAbsentDefaultIsEmptyString(): void
+	{
+		$path = 'installedpackages/pfblockerngipsettings/config/0/v4suppression';
+
+		// Before: key absent.
+		$this->assertNull(config_get_path($path), 'v4suppression must be absent before read');
+
+		// When: gateway read.
+		$result = PfbConfig::read('v4suppression');
+
+		// Then: '' — parity with prior page coalesce `?: ''`.
+		$this->assertSame('', $result, 'v4suppression absent -> "" (parity with prior page fallback)');
+	}
+
+	/**
+	 * v4suppression round-trip: write a base64 blob, read it back byte-identically.
+	 */
+	public function testV4SuppressionRoundTrips(): void
+	{
+		$blob = base64_encode("192.168.1.1/32\r\n192.168.1.2/32\r\n");
+
+		// Before: absent → ''.
+		$this->assertSame('', PfbConfig::read('v4suppression'), 'initial absent -> ""');
+
+		// When: write a base64 blob.
+		PfbConfig::write('v4suppression', $blob);
+
+		// Then: read back byte-identically.
+		$this->assertSame($blob, PfbConfig::read('v4suppression'), 'v4suppression after write round-trips byte-identically');
+	}
+
+	/**
 	 * Foreign section keys must NOT be in the registry.
 	 * widget-popup is a pfblockerngglobal widget key — registry lookup must throw.
 	 */
@@ -209,12 +253,14 @@ final class WwwGroupCGatewayTest extends TestCase
 	}
 
 	/**
-	 * v4suppression is a pfblockerngipsettings key (foreign section) — registry lookup must throw.
+	 * enable_dup is a pfblockerngipsettings key (foreign section) — registry lookup must
+	 * throw. (v4suppression, the ADR-53 sibling in this same section, is now registered
+	 * — see testV4SuppressionAbsentDefaultIsEmptyString / testV4SuppressionRoundTrips above.)
 	 */
-	public function testV4SuppressionIsNotInRegistry(): void
+	public function testEnableDupIsNotInRegistry(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
-		PfbConfig::read('v4suppression');
+		PfbConfig::read('enable_dup');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -911,3 +911,194 @@ if (!function_exists('get_dns_servers')) {
 		return $GLOBALS['pfb_test_dns_servers'] ?? [];
 	}
 }
+
+// --- ADR-53 P5 doubles: pure IPv6 CIDR set-subtraction engine ---
+//
+// pfb_cidr_subtract_v6()/pfb_suppress_file_v6() (pfblockerng_extra.inc) call the
+// REAL pfSense ip_range_to_subnet_array() on-appliance -- it is never redefined
+// in production code. Off-appliance it doesn't exist, so it needs a faithful
+// double here.
+//
+// Upstream body verified BYTE-IDENTICAL at three dated refs on the public
+// pfsense/pfsense mirror (src/etc/inc/util.inc; CLAUDE.md "Resolve pfSense-
+// provided PHP functions from upstream"):
+//   - CE 2.8.0 (min supported)  -- ed6c2eb84595aab998c3b3efaf16d226bd62c38d,
+//     the youngest master commit at/before the 2025-05-28 release.
+//   - CE 2.8.1 (latest released) -- 97f9eb5c819fd7f0c5f232d2581e5080be1cb18a,
+//     the youngest master commit at/before the 2025-09-04 release.
+//   - master tip -- 9363ac5b8651a1c7a333180425ce7719070f95f9 (2026-03-31).
+// ip_range_to_subnet_array()'s body below is VENDORED VERBATIM from that
+// source (its own doc comment kept intact). Its two callees --
+// ip6_to_bin()/bin_to_compressed_ip6() -- use PEAR's Net_IPv6
+// (Uncompress()/compress()) upstream, which doesn't exist off-appliance (the
+// same "no PEAR off-appliance" constraint as is_ipaddrv6() above), so those two
+// are faithful REIMPLEMENTATIONS using PHP's builtin inet_pton()/inet_ntop():
+// packing/unpacking the same 128-bit value produces byte-identical
+// binary-string / canonical-compressed output to the PEAR routines for any
+// address inet_pton() itself accepts (RFC 5952 compression is exactly what
+// inet_ntop() already implements).
+
+if (!function_exists('ip6_to_bin')) {
+	// FAITHFUL REIMPLEMENTATION (no PEAR off-appliance): pack the address with
+	// inet_pton() and expand every byte to 8 bits, producing the same 128-char
+	// '0'/'1' string upstream's Net_IPv6::Uncompress()+base_convert() loop does.
+	function ip6_to_bin($ip) {
+		// Mirror Net_IPv6::removeNetmaskSpec(): drop a trailing "/prefix" if present.
+		$slash = strpos($ip, '/');
+		if ($slash !== false) {
+			$ip = substr($ip, 0, $slash);
+		}
+		$packed = @inet_pton($ip);
+		if ($packed === false) {
+			return '';
+		}
+		$bin = '';
+		foreach (str_split($packed) as $byte) {
+			$bin .= sprintf('%08b', ord($byte));
+		}
+		return $bin;
+	}
+}
+
+if (!function_exists('bin_to_compressed_ip6')) {
+	// FAITHFUL REIMPLEMENTATION (no PEAR off-appliance): pack the 128-bit binary
+	// string back into 16 raw bytes and let inet_ntop() render the canonical
+	// (RFC 5952) compressed form -- the same output Net_IPv6::compress() gives.
+	function bin_to_compressed_ip6($bin) {
+		$bin = str_pad($bin, 128, '0', STR_PAD_LEFT);
+		$packed = '';
+		foreach (str_split($bin, 8) as $byte_bin) {
+			$packed .= chr(bindec($byte_bin));
+		}
+		return inet_ntop($packed);
+	}
+}
+
+if (!function_exists('ip_range_to_subnet_array')) {
+	/*
+	 * Convert an IPv4 or IPv6 IP range to an array of subnets which can contain the range.
+	 * Algorithm and embodying code PD'ed by Stilez - enjoy as you like :-)
+	 *
+	 * Documented on pfsense dev list 19-20 May 2013. Summary:
+	 *
+	 * The algorithm looks at patterns of 0's and 1's in the least significant bit(s), whether IPv4 or IPv6.
+	 * These are all that needs checking to identify a _guaranteed_ correct, minimal and optimal subnet array.
+	 *
+	 * As a result, string/binary pattern matching of the binary IP is very efficient. It uses just 2 pattern-matching rules
+	 * to chop off increasingly larger subnets at both ends that can't be part of larger subnets, until nothing's left.
+	 *
+	 * (a) If any range has EITHER low bit 1 (in startip) or 0 (in endip), that end-point is _always guaranteed_ to be optimally
+	 * represented by its own 'single IP' CIDR; the remaining range then shrinks by one IP up or down, causing the new end-point's
+	 * low bit to change from 1->0 (startip) or 0->1 (endip). Only one edge case needs checking: if a range contains exactly 2
+	 * adjacent IPs of this format, then the two IPs themselves are required to span it, and we're done.
+	 * Once this rule is applied, the remaining range is _guaranteed_ to end in 0's and 1's so rule (b) can now be used, and its
+	 * low bits can now be ignored.
+	 *
+	 * (b) If any range has BOTH startip and endip ending in some number of 0's and 1's respectively, these low bits can
+	 * *always* be ignored and "bit-shifted" for subnet spanning. So provided we remember the bits we've place-shifted, we can
+	 * _always_ right-shift and chop off those bits, leaving a smaller range that has EITHER startip ending in 1 or endip ending
+	 * in 0 (ie can now apply (a) again) or the entire range has vanished and we're done.
+	 * We then loop to redo (a) again on the remaining (place shifted) range until after a few loops, the remaining (place shifted)
+	 * range 'vanishes' by meeting the exit criteria of (a) or (b), and we're done.
+	 *
+	 * VENDORED VERBATIM from pfSense util.inc -- see the doubles-file-header
+	 * attribution above for the three dated refs this was diffed byte-identical
+	 * against.
+	 */
+	function ip_range_to_subnet_array($ip1, $ip2) {
+
+		if (is_ipaddrv4($ip1) && is_ipaddrv4($ip2)) {
+			$proto = 'ipv4';  // for clarity
+			$bits = 32;
+			$ip1bin = decbin(ip2long32($ip1));
+			$ip2bin = decbin(ip2long32($ip2));
+		} elseif (is_ipaddrv6($ip1) && is_ipaddrv6($ip2)) {
+			$proto = 'ipv6';
+			$bits = 128;
+			$ip1bin = ip6_to_bin($ip1);
+			$ip2bin = ip6_to_bin($ip2);
+		} else {
+			return array();
+		}
+
+		// it's *crucial* that binary strings are guaranteed the expected length;  do this for certainty even though for IPv6 it's redundant
+		$ip1bin = str_pad($ip1bin, $bits, '0', STR_PAD_LEFT);
+		$ip2bin = str_pad($ip2bin, $bits, '0', STR_PAD_LEFT);
+
+		if ($ip1bin == $ip2bin) {
+			return array($ip1 . '/' . $bits); // exit if ip1=ip2 (trivial case)
+		}
+
+		if ($ip1bin > $ip2bin) {
+			list ($ip1bin, $ip2bin) = array($ip2bin, $ip1bin);  // swap if needed (ensures ip1 < ip2)
+		}
+
+		$rangesubnets = array();
+		$netsize = 0;
+
+		do {
+			// at loop start, $ip1 is guaranteed strictly less than $ip2 (important for edge case trapping and preventing accidental binary wrapround)
+			// which means the assignments $ip1 += 1 and $ip2 -= 1 will always be "binary-wrapround-safe"
+
+			// step #1 if start ip (as shifted) ends in any '1's, then it must have a single cidr to itself (any cidr would include the '0' below it)
+
+			if (substr($ip1bin, -1, 1) == '1') {
+				// the start ip must be in a separate one-IP cidr range
+				$new_subnet_ip = substr($ip1bin, $netsize, $bits - $netsize) . str_repeat('0', $netsize);
+				$rangesubnets[$new_subnet_ip] = $bits - $netsize;
+				$n = strrpos($ip1bin, '0');  //can't be all 1's
+				$ip1bin = ($n == 0 ? '' : substr($ip1bin, 0, $n)) . '1' . str_repeat('0', $bits - $n - 1);  // BINARY VERSION OF $ip1 += 1
+			}
+
+			// step #2, if end ip (as shifted) ends in any zeros then that must have a cidr to itself (as cidr cant span the 1->0 gap)
+
+			if (substr($ip2bin, -1, 1) == '0') {
+				// the end ip must be in a separate one-IP cidr range
+				$new_subnet_ip = substr($ip2bin, $netsize, $bits - $netsize) . str_repeat('0', $netsize);
+				$rangesubnets[$new_subnet_ip] = $bits - $netsize;
+				$n = strrpos($ip2bin, '1');  //can't be all 0's
+				$ip2bin = ($n == 0 ? '' : substr($ip2bin, 0, $n)) . '0' . str_repeat('1', $bits - $n - 1);  // BINARY VERSION OF $ip2 -= 1
+				// already checked for the edge case where end = start+1 and start ends in 0x1, above, so it's safe
+			}
+
+			// this is the only edge case arising from increment/decrement.
+			// it happens if the range at start of loop is exactly 2 adjacent ips, that spanned the 1->0 gap. (we will have enumerated both by now)
+
+			if ($ip2bin < $ip1bin) {
+				continue;
+			}
+
+			// step #3 the start and end ip MUST now end in '0's and '1's respectively
+			// so we have a non-trivial range AND the last N bits are no longer important for CIDR purposes.
+
+			$shift = $bits - max(strrpos($ip1bin, '0'), strrpos($ip2bin, '1'));  // num of low bits which are '0' in ip1 and '1' in ip2
+			$ip1bin = str_repeat('0', $shift) . substr($ip1bin, 0, $bits - $shift);
+			$ip2bin = str_repeat('0', $shift) . substr($ip2bin, 0, $bits - $shift);
+			$netsize += $shift;
+			if ($ip1bin == $ip2bin) {
+				// we're done.
+				$new_subnet_ip = substr($ip1bin, $netsize, $bits - $netsize) . str_repeat('0', $netsize);
+				$rangesubnets[$new_subnet_ip] = $bits - $netsize;
+				continue;
+			}
+
+			// at this point there's still a remaining range, and either startip ends with '1', or endip ends with '0'. So repeat cycle.
+		} while ($ip1bin < $ip2bin);
+
+		// subnets are ordered by bit size. Re sort by IP ("naturally") and convert back to IPv4/IPv6
+
+		ksort($rangesubnets, SORT_STRING);
+		$out = array();
+
+		foreach ($rangesubnets as $ip => $netmask) {
+			if ($proto == 'ipv4') {
+				$i = str_split($ip, 8);
+				$out[] = implode('.', array(bindec($i[0]), bindec($i[1]), bindec($i[2]), bindec($i[3]))) . '/' . $netmask;
+			} else {
+				$out[] = bin_to_compressed_ip6($ip) . '/' . $netmask;
+			}
+		}
+
+		return $out;
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -853,6 +853,25 @@ if (!function_exists('ip2long32')) {
 	}
 }
 
+// ADR-53 P8: pfb_v4_carve_single() (pfblockerng_extra.inc) calls the REAL
+// pfSense long2ip32() to render the gap-range endpoints it feeds into
+// ip_range_to_subnet_array() -- never redefined in production code.
+// Off-appliance it doesn't exist, so it needs a faithful double.
+//
+// Upstream body verified BYTE-IDENTICAL at the same three dated refs already
+// established for ip_range_to_subnet_array() above (src/etc/inc/util.inc;
+// CLAUDE.md "Resolve pfSense-provided PHP functions from upstream"): CE 2.8.0
+// (ed6c2eb84595aab998c3b3efaf16d226bd62c38d), CE 2.8.1
+// (97f9eb5c819fd7f0c5f232d2581e5080be1cb18a), master tip
+// (9363ac5b8651a1c7a333180425ce7719070f95f9). On 64-bit PHP (PHP_INT_SIZE ==
+// 8, our test environment and the pfSense appliance target) the 32-bit-ARM
+// branch never runs, so the double omits it and mirrors only the live path.
+if (!function_exists('long2ip32')) {
+	function long2ip32($ip) {
+		return long2ip($ip & 0xFFFFFFFF);
+	}
+}
+
 if (!function_exists('find_interface_subnet')) {
 	// pfSense interfaces.inc: returns the IPv4 prefix-length (as a string) for the
 	// REAL interface name (i.e. after get_real_interface() has resolved it).

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -590,8 +590,25 @@ if (!function_exists('ip_in_subnet')) {
 		if (strpos($subnet, '/') === false) {
 			return false;
 		}
-		[$net_addr, $bits] = explode('/', $subnet, 2);
-		$bits = (int) $bits;
+		[$net_addr, $bits_raw] = explode('/', $subnet, 2);
+
+		// ADR-53 review finding H3: real pfSense gates ip_in_subnet() on
+		// is_subnetv4()/is_subnetv6(), whose shared is_subnet() (util.inc)
+		// requires the mask to match `\d{1,3}` (digits only -- no sign, no
+		// decimal point) and be <= 32 (v4) / <= 128 (v6). The previous version
+		// of this double coerced the mask via a bare (int) cast with no range
+		// check, so a malformed mask silently fell through as either an exact-
+		// host match (an out-of-range mask like '/33') or "matches EVERY
+		// address" (a non-numeric mask like '/abc', which (int) coerces to 0)
+		// -- real pfSense rejects both outright (always FALSE). This matters
+		// because pfb_ip_suppressed()/pfb_live_punch_plan() lean on this
+		// double under PHPUnit; a lying double could hide a real suppression
+		// over-match. Pinned by KillstatesSuppressionTest.php's
+		// "OutOfRangeMask"/"NonNumericMask" vectors.
+		if (!preg_match('/^\d{1,3}$/', $bits_raw)) {
+			return false;
+		}
+		$bits = (int) $bits_raw;
 
 		$addr_packed = @inet_pton((string) $addr);
 		$net_packed  = @inet_pton((string) $net_addr);
@@ -601,6 +618,10 @@ if (!function_exists('ip_in_subnet')) {
 		$len = strlen($addr_packed);
 		if ($len !== strlen($net_packed)) {
 			// Different address families.
+			return false;
+		}
+		if ($bits > $len * 8) {
+			// Out-of-range mask for this family (e.g. v4 '/33', v6 '/129').
 			return false;
 		}
 		// Compare $bits leading bits.

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -167,8 +167,9 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerngsafesearch/safesearch_youtube',
 		'installedpackages/pfblockerngsafesearch/safesearch_doh',
 		'installedpackages/pfblockerngsafesearch/safesearch_doh_list',
-		// ADR-53: installedpackages/pfblockerngipsettings/config/0 (IPv4 suppression)
+		// ADR-53: installedpackages/pfblockerngipsettings/config/0 (IPv4/IPv6 suppression)
 		'installedpackages/pfblockerngipsettings/config/0/v4suppression',
+		'installedpackages/pfblockerngipsettings/config/0/v6suppression',
 	];
 
 	/**

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -167,6 +167,8 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerngsafesearch/safesearch_youtube',
 		'installedpackages/pfblockerngsafesearch/safesearch_doh',
 		'installedpackages/pfblockerngsafesearch/safesearch_doh_list',
+		// ADR-53: installedpackages/pfblockerngipsettings/config/0 (IPv4 suppression)
+		'installedpackages/pfblockerngipsettings/config/0/v4suppression',
 	];
 
 	/**

--- a/tests/phpcs/fixtures/gateway_compliant.php
+++ b/tests/phpcs/fixtures/gateway_compliant.php
@@ -10,14 +10,18 @@
  *   c) Section-level read (path is a section, not a registered scalar key) —
  *      sniff stays silent.
  *   d) pfSense-core section access (aliases/*, system/*, unbound/*) — silent.
+ *   e) ADR-53: the registered v4suppression key accessed via PfbConfig (not a
+ *      raw config_*_path call at all) — sniff stays silent.
  *
  * Pinned by RequireConfigGatewaySniffTest::testCompliantCasesAreClean.
  */
 
 function pfb_gateway_compliant_foreign_key()
 {
-	// Foreign section — pfblockerngipsettings is NOT in the registry.
-	$v4 = config_get_path('installedpackages/pfblockerngipsettings/config/0/v4suppression');
+	// Foreign section — pfblockerngipsettings/enable_dup is NOT in the registry.
+	// (v4suppression, the ADR-53 sibling in this same section, IS registered now —
+	// see pfb_gateway_compliant_v4suppression_via_gateway() below.)
+	$dup = config_get_path('installedpackages/pfblockerngipsettings/config/0/enable_dup');
 
 	// Foreign dynamic per-row key — not in the registered path set.
 	$row = 0;
@@ -32,7 +36,18 @@ function pfb_gateway_compliant_foreign_key()
 	// Section-level read of the DNSBL settings section — NOT a scalar key.
 	$dnsbl = config_get_path('installedpackages/pfblockerngdnsblsettings/config/0', []);
 
-	return [$v4, $custom, $aliases, $section, $dnsbl];
+	return [$dup, $custom, $aliases, $section, $dnsbl];
+}
+
+function pfb_gateway_compliant_v4suppression_via_gateway()
+{
+	// ADR-53: v4suppression is registered — access via PfbConfig::read/write, never
+	// raw config_get_path/config_set_path. Neither call here is one of the sniff's
+	// gated function names, so this stays silent regardless of the key.
+	$v4 = PfbConfig::read('v4suppression');
+	PfbConfig::write('v4suppression', $v4);
+
+	return $v4;
 }
 
 function pfb_gateway_compliant_dynamic_path($key)

--- a/tests/phpcs/fixtures/gateway_violation.php
+++ b/tests/phpcs/fixtures/gateway_violation.php
@@ -6,10 +6,11 @@
  * Contains raw config_*_path calls targeting REGISTERED
  * installedpackages/pfblockerng* keys — the sniff MUST flag each one.
  *
- * Flagged: config_get_path on a gen-section key (line 20),
- *          config_set_path on a DNSBL-section key (line 23),
- *          config_del_path on a SafeSearch key (line 26),
- *          config_get_path with inline comment before the key (line 29).
+ * Flagged: config_get_path on a gen-section key (line 21),
+ *          config_set_path on a DNSBL-section key (line 24),
+ *          config_del_path on a SafeSearch key (line 27),
+ *          config_get_path with inline comment before the key (line 30),
+ *          config_get_path on the ADR-53 v4suppression key (line 38).
  *
  * Pinned by RequireConfigGatewaySniffTest::testFlagsRawRegisteredKeyAccess.
  */
@@ -29,4 +30,10 @@ function pfb_gateway_violation_example()
 	$val2 = config_get_path(/* a note */ 'installedpackages/pfblockerng/config/0/pfb_keep');
 
 	return $val . $val2;
+}
+
+function pfb_gateway_violation_v4suppression()
+{
+	// ADR-53: v4suppression became a REGISTERED key — raw access must be flagged too.
+	return config_get_path('installedpackages/pfblockerngipsettings/config/0/v4suppression');
 }

--- a/tests/shell/pfblockerng_adr26_locale_spec.sh
+++ b/tests/shell/pfblockerng_adr26_locale_spec.sh
@@ -110,10 +110,11 @@ Describe 'ADR-26 — pfblockerng.sh locale/portability source invariants (Phases
     When call lacks '/usr/bin/jot'
     The status should be success
   End
-  It 'uses a portable seq for the 1..255 range'
-    When call has 'seq 255'
-    The status should be success
-  End
+  # The portable `seq 255` this gate once pinned lived ONLY in suppress()'s
+  # /24-host-explode loop -- ADR-53 Phase 3 deleted that loop entirely
+  # (replaced by `iprange --except` set-subtraction), so the call site the
+  # jot->seq portability fix protected is gone, not reverted. `seq` no longer
+  # appears anywhere in the script; nothing left to pin here.
 End
 
 Describe 'ADR-26 — LC_ALL=C dedup is byte-exact (§2.1 guarantee)'

--- a/tests/shell/pfblockerng_fail_open_redirect_spec.sh
+++ b/tests/shell/pfblockerng_fail_open_redirect_spec.sh
@@ -2,15 +2,17 @@
 # pfblockerng.sh fail-open feed-list redirects (issue #713 bug 8, family of 12
 # sites in two producer classes -- the original 9 plus 3 the initial fix missed:
 # suppress()'s dedup='on' masterfile block, process255(), and reputation_max()'s
-# ccblack='block' arm). A producer (grepcidr / awk dedup) was
-# redirected into a file consumed downstream with NO exit-status gating, so a
-# producer error truncated/overwrote the live list to empty/partial:
+# ccblack='block' arm). A producer (grepcidr / awk dedup, or -- since ADR-53
+# Phase 3 -- iprange for suppress() specifically) was redirected into a file
+# consumed downstream with NO exit-status gating, so a producer error
+# truncated/overwrote the live list to empty/partial:
 #
-#   Class A (grepcidr): rc 0 = matches removed, rc 1 = a LEGITIMATE "everything
-#   suppressed" empty result (must still replace the target), rc >= 2 = a real
-#   grepcidr error (must keep the previous target untouched). suppress() held
-#   the worst case -- a direct "grepcidr ... > livelist" redirect with no temp
-#   at all, truncating the live list before grepcidr even ran.
+#   Class A (grepcidr, or iprange for suppress() post-ADR-53): rc 0 = success
+#   (for iprange, INCLUDING a legitimately-empty result -- no grepcidr-style
+#   "rc 1 = empty" quirk); any other rc = a real engine error (must keep the
+#   previous target untouched). suppress() held the worst case -- a direct
+#   "<producer> ... > livelist" redirect with no temp at all, truncating the
+#   live list before the producer even ran.
 #
 #   Class B (awk dedup): awk has no "empty output = error" quirk -- rc 0 is
 #   always a legitimate result (including a genuinely empty dedup), non-zero is
@@ -19,6 +21,15 @@
 #
 # Each scenario asserts the BEFORE state (prior content) so a pass proves the
 # fix caused the preservation, not an accidental empty-target coincidence.
+#
+# suppress()'s OWN producer switched from grepcidr to iprange in ADR-53 Phase
+# 3 (tests/shell/pfblockerng_suppress_spec.sh is the dedicated, comprehensive
+# oracle for that engine swap) -- its Class A/B Describe blocks below follow
+# suit (pathaggregate/IPRANGE_MODE, not pathgrepcidr/GREPCIDR_MODE), staying
+# deliberately redundant with that file's own rc-gating cases, not duplicative
+# (each proves the contract from its own file's self-contained narrative).
+# duplicate()'s Class A stays on the REAL grepcidr producer -- untouched by
+# ADR-53, which only rewrites suppress().
 
 Describe 'pfblockerng.sh fail-open feed-list redirects (issue #713 bug 8)'
   BeforeAll 'pfb_source; SHELLSPEC_REAL_AWK="$(command -v awk)"; export SHELLSPEC_REAL_AWK'
@@ -35,6 +46,24 @@ case "${GREPCIDR_MODE:-}" in
 	empty) exit 1 ;;
 	error) echo 'grepcidr: malformed CIDR in filter file' >&2; exit 2 ;;
 	*) exit 2 ;;
+esac
+SHIM
+    chmod +x "$1"
+  }
+
+  # ---- iprange shim (suppress()'s producer post-ADR-53): exit code/output
+  # selected via IPRANGE_MODE ----
+  #   success -> two matches on stdout, rc 0
+  #   error   -> a real iprange error (e.g. a missing/unloadable ipset), rc 1
+  #              (unlike grepcidr, iprange has no separate "rc 1 = legitimate
+  #              empty" case to simulate -- rc 0 covers an empty result too)
+  write_pathaggregate_shim() {
+    cat > "$1" <<'SHIM'
+#!/bin/sh
+case "${IPRANGE_MODE:-}" in
+	success) printf '192.0.2.1\n192.0.2.2\n'; exit 0 ;;
+	error) echo 'iprange: simulated error (missing/unloadable ipset)' >&2; exit 1 ;;
+	*) exit 1 ;;
 esac
 SHIM
     chmod +x "$1"
@@ -83,8 +112,6 @@ SHIM
       max="${work}"
       alias='TestList_v4'
       pfbsuppression="${work}/suppression.txt"
-      # A plain /24 (not /32) suppression entry stays out of the awk/dupfile
-      # branch entirely, isolating the grepcidr producer for this test.
       printf '198.51.100.0/24\n' > "${pfbsuppression}"
       tmpdir="${work}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
@@ -92,8 +119,8 @@ SHIM
       : > "${masterfile}"
       dedup='off'
       errorlog="${work}/error.log"; : > "${errorlog}"
-      pathgrepcidr="${work}/grepcidr"
-      write_grepcidr_shim "${pathgrepcidr}"
+      pathaggregate="${work}/iprange"
+      write_pathaggregate_shim "${pathaggregate}"
       livelist="${work}/${alias}.txt"
       printf 'PRIOR-1\nPRIOR-2\n' > "${livelist}"
     }
@@ -101,25 +128,18 @@ SHIM
     Before 'setup'
     After 'cleanup'
 
-    It 'keeps the live list UNCHANGED when grepcidr errors (rc>=2) -- pre-fix this truncated it to empty'
-      # When: grepcidr errors.
-      GREPCIDR_MODE='error'; export GREPCIDR_MODE
+    It 'keeps the live list UNCHANGED when iprange errors (rc!=0) -- pre-fix this truncated it to empty'
+      # When: iprange errors.
+      IPRANGE_MODE='error'; export IPRANGE_MODE
       When call silently suppress
       # Then: the prior content survives -- and the error is logged, not swallowed.
       The status should be success
       The contents of file "${livelist}" should equal "$(printf 'PRIOR-1\nPRIOR-2')"
-      The contents of file "${errorlog}" should include 'grepcidr error'
+      The contents of file "${errorlog}" should include 'iprange error'
     End
 
-    It 'replaces the live list with an EMPTY result on grepcidr rc=1 (a legitimate "everything suppressed" outcome)'
-      GREPCIDR_MODE='empty'; export GREPCIDR_MODE
-      When call silently suppress
-      The status should be success
-      The contents of file "${livelist}" should equal ''
-    End
-
-    It 'publishes the new content on grepcidr success'
-      GREPCIDR_MODE='success'; export GREPCIDR_MODE
+    It 'publishes the new content on iprange success'
+      IPRANGE_MODE='success'; export IPRANGE_MODE
       When call silently suppress
       The status should be success
       The contents of file "${livelist}" should equal "$(printf '192.0.2.1\n192.0.2.2')"
@@ -132,9 +152,6 @@ SHIM
       max="${work}"
       alias='DedupList_v4'
       pfbsuppression="${work}/suppression.txt"
-      # A plain /24 (not /32) suppression entry stays out of the earlier
-      # awk/dupfile branch (already gated), isolating the dedup='on' masterfile
-      # awk call at the end of suppress() for this test.
       printf '198.51.100.0/24\n' > "${pfbsuppression}"
       tmpdir="${work}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
@@ -142,8 +159,8 @@ SHIM
       printf 'DedupList_v4 PRIOR-1\nDedupList_v4 PRIOR-2\nOtherList_v4 203.0.113.5\n' > "${masterfile}"
       dedup='on'
       errorlog="${work}/error.log"; : > "${errorlog}"
-      pathgrepcidr="${work}/grepcidr"
-      write_grepcidr_shim "${pathgrepcidr}"
+      pathaggregate="${work}/iprange"
+      write_pathaggregate_shim "${pathaggregate}"
       livelist="${work}/${alias}.txt"
       printf 'PRIOR-1\nPRIOR-2\n' > "${livelist}"
       awkshim="${work}/bin"
@@ -154,11 +171,11 @@ SHIM
     After 'cleanup'
 
     It 'keeps the PRIOR masterfile rows when awk errors -- pre-fix this truncated masterfile, losing them all (incl. the unrelated OtherList_v4 row)'
-      GREPCIDR_MODE='success'; AWK_MODE='error'; export GREPCIDR_MODE AWK_MODE
+      IPRANGE_MODE='success'; AWK_MODE='error'; export IPRANGE_MODE AWK_MODE
       PATH="${awkshim}:${PATH}"
       When call silently suppress
       The status should be success
-      # suppress()'s trailing sed always re-appends the (here: grepcidr-succeeded)
+      # suppress()'s trailing sed always re-appends the (here: iprange-succeeded)
       # fresh list content regardless of the dedup outcome -- pre-existing,
       # unrelated to this fix -- so the fix's proof is that NONE of the prior
       # rows are lost, not that the file is byte-identical to its pre-call state.
@@ -168,7 +185,7 @@ SHIM
     End
 
     It 'dedups masterfile (drops the stale alias rows, keeps the unrelated one, appends the fresh list) on awk success'
-      GREPCIDR_MODE='success'; AWK_MODE='real'; export GREPCIDR_MODE AWK_MODE
+      IPRANGE_MODE='success'; AWK_MODE='real'; export IPRANGE_MODE AWK_MODE
       PATH="${awkshim}:${PATH}"
       When call silently suppress
       The status should be success

--- a/tests/shell/pfblockerng_suppress_spec.sh
+++ b/tests/shell/pfblockerng_suppress_spec.sh
@@ -1,0 +1,346 @@
+#shellcheck shell=sh
+# suppress() oracle (ADR-53 Phase 1) -- pins TODAY's IP-suppression semantics,
+# including its known containing-entry defect, as a regression baseline for
+# Phase 3's iprange --except rewrite. This spec is BEHAVIOUR-PRESERVING: it
+# adds no src/ change and must stay green before and after this phase; Phase 3
+# flips exactly the "containing-entry silent no-op" assertion below (§2) from
+# a no-op pin to a real-carve assertion, red on pre-Phase-3 code, green after.
+#
+# suppress() (pfblockerng.sh) carves suppression-list entries out of a deny
+# member file (${max}/${alias}.txt), gated on a non-empty ${pfbsuppression}
+# file. Per suppression entry (always a /32 or /24 today -- pfblockerng_ip.php
+# validation): a bare-host member token is removed by the trailing
+# `grepcidr -vf` whole-token pass; a member token that is the EXACT containing
+# /24 of a /32 suppression entry is exploded into 255 individual hosts (a
+# literal grep -F string match against "<prefix>.0/24", entirely independent
+# of grepcidr) minus the suppressed octet, deduped via ${dupfile} so a second
+# /32 inside the same /24 does not re-explode; but a member token WIDER than
+# /24 (a /16, say) containing the suppressed host is a SILENT NO-OP -- ADR-53
+# §1.2 proved live that grepcidr does not split/pierce a containing CIDR, so
+# the suppressed host stays blocked with no warning. That defect is pinned
+# below as today's oracle, not fixed here.
+#
+# Note: tests/shell/pfblockerng_fail_open_redirect_spec.sh already pins
+# suppress()'s #713 fail-open rc-gating (grepcidr rc>=2 keep-previous; the
+# dedup="on" masterfile awk redirect) as part of a cross-function "fail-open
+# redirect" family (it also covers duplicate()/remove()/process255()/
+# reputation_max()). This file is the dedicated, comprehensive suppress()
+# semantics pin (bare-token removal, the /24 explode + dupfile dedup guard,
+# the containing-entry defect, absent/empty gating, the stats table) and
+# re-asserts the #713 rc gating here too so it is self-contained -- the two
+# files' fail-safe cases are deliberately redundant, not duplicative (each
+# proves it from its own file's narrative).
+
+Describe 'suppress() (ADR-53 Phase 1 oracle)'
+  BeforeAll 'pfb_source'
+
+  # ---- grepcidr shim ----
+  # Fake grepcidr -vf <filter> <target> for the suppress() oracle.
+  #
+  # Default mode performs plain ADDRESS-EQUALITY filtering with the mask
+  # stripped from both sides: every suppression entry the UI accepts today is
+  # a /32 host (mask enforcement at pfblockerng_ip.php:159), so real
+  # grepcidr's CIDR-containment test ("is this target line's range a subset
+  # of a filter CIDR") collapses to "is this target line's address exactly
+  # the suppressed host". A bare host, or a target line written as that exact
+  # /32, is REMOVED -- grepcidr's proven whole-token/host removal (ADR-53
+  # §1.2, both address families). Any WIDER target CIDR (a /16 or /24 line)
+  # can never equal a single suppressed host address, so it survives
+  # completely untouched -- the exact containing-entry silent no-op ADR-53
+  # §1.2 proved live and this suite pins as today's oracle.
+  #
+  # GREPCIDR_MODE overrides the default for the #713 fail-safe rc-gating
+  # cases: empty -> a LEGITIMATE "everything suppressed" empty result, rc 1;
+  # error -> a real grepcidr error (e.g. malformed filter file), rc 2.
+  write_grepcidr_shim() {
+    cat > "$1" <<'SHIM'
+#!/bin/sh
+case "${GREPCIDR_MODE:-}" in
+	empty) exit 1 ;;
+	error) echo 'grepcidr: simulated malformed filter' >&2; exit 2 ;;
+esac
+
+filter="$2"
+target="$3"
+faddrs="$(sed 's#/.*##' "${filter}")"
+while IFS= read -r line; do
+	[ -z "${line}" ] && continue
+	addr="${line%%/*}"
+	if ! printf '%s\n' "${faddrs}" | grep -qxF "${addr}"; then
+		printf '%s\n' "${line}"
+	fi
+done < "${target}"
+SHIM
+    chmod +x "$1"
+  }
+
+  Describe 'a — suppression file absent or empty: early return, member file untouched'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppa.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      member="${work}/${alias}.txt"
+      printf '203.0.113.5\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'leaves the member file byte-identical when the suppression file does not exist'
+      # Given: no pfbsuppression file was ever created (the "-e" leg of the gate).
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should equal '203.0.113.5'
+    End
+
+    It 'leaves the member file byte-identical when the suppression file exists but is empty'
+      # Given: the file exists but is zero-length (the "-s" leg of the gate).
+      : > "${pfbsuppression}"
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should equal '203.0.113.5'
+    End
+  End
+
+  Describe 'b — bare-host token + matching /32 suppression: token removed (the working case)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppb.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      printf '203.0.113.7/32\n' > "${pfbsuppression}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      member="${work}/${alias}.txt"
+      printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'removes the exact suppressed host, keeping its siblings'
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should equal "$(printf '203.0.113.5\n203.0.113.9')"
+    End
+  End
+
+  Describe 'c — exact-/24 explode: a /32 suppression inside a containing /24 member entry'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppc.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      member="${work}/${alias}.txt"
+      printf '10.9.8.0/24\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'explodes the /24 line into its 254 non-suppressed host lines (the /24 line itself is gone)'
+      printf '10.9.8.4/32\n' > "${pfbsuppression}"
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should not include '10.9.8.0/24'
+      # Exact-line greps (never substring "include") -- '10.9.8.4' as a
+      # substring would false-positive-match '10.9.8.40'..'10.9.8.49'. `|| true`
+      # so a legitimate zero-match (grep rc=1) doesn't abort the example.
+      has4="$(grep -c '^10\.9\.8\.4$' "${member}" || true)"
+      The variable has4 should equal 0
+      has1="$(grep -c '^10\.9\.8\.1$' "${member}" || true)"
+      The variable has1 should equal 1
+      has255="$(grep -c '^10\.9\.8\.255$' "${member}" || true)"
+      The variable has255 should equal 1
+      # seq 255 walks octets 1..255 (255 values); excluding the one suppressed
+      # octet (.4) leaves 254 -- verified empirically against the real function.
+      hostcount="$(grep -c ^ "${member}")"
+      The variable hostcount should equal 254
+    End
+
+    It 'a SECOND /32 suppression inside the same containing /24 does not re-explode (dupfile dedup): both hosts gone, no duplicate lines'
+      # Given: two DIFFERENT /32 holes that both map to the same containing
+      # /24 -- the dupfile guard (suppress()'s "dcheck" check) must fire only
+      # once, or the explode loop would run twice and duplicate all 254 hosts.
+      printf '10.9.8.4/32\n10.9.8.55/32\n' > "${pfbsuppression}"
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should not include '10.9.8.0/24'
+      has4="$(grep -c '^10\.9\.8\.4$' "${member}" || true)"
+      The variable has4 should equal 0
+      has55="$(grep -c '^10\.9\.8\.55$' "${member}" || true)"
+      The variable has55 should equal 0
+      # 254 - the second suppressed host (.55, removed by the trailing
+      # grepcidr pass since the single explode run already included it).
+      hostcount="$(grep -c ^ "${member}")"
+      The variable hostcount should equal 253
+      # Then: no line was doubled by a second explode pass -- a real double
+      # explode would leave every non-suppressed host appearing twice.
+      dupcount="$(sort "${member}" | uniq -d | grep -c ^ || true)"
+      The variable dupcount should equal 0
+    End
+  End
+
+  Describe 'd — containing-entry silent no-op: the DEFECT, pinned as todays oracle (Phase 3 flips this)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppd.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      printf '10.0.3.4/32\n' > "${pfbsuppression}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      member="${work}/${alias}.txt"
+      # A /16 member entry containing the suppressed /32 host, but NOT the
+      # exact /24 the explode branch's literal grep -F match requires.
+      printf '10.0.0.0/16\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'SURVIVES the containing /16 line unchanged -- the suppressed host stays blocked, ADR-53 §1.2 (Phase 3 flips this to a carve)'
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should equal '10.0.0.0/16'
+    End
+  End
+
+  Describe 'e — grepcidr fail-safe publish gating (#713), re-asserted here for a self-contained oracle'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppe.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      printf '203.0.113.7/32\n' > "${pfbsuppression}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      member="${work}/${alias}.txt"
+      printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'keeps the PRIOR member list unchanged when grepcidr errors (rc>=2), and logs the error'
+      GREPCIDR_MODE='error'; export GREPCIDR_MODE
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should equal "$(printf '203.0.113.5\n203.0.113.7\n203.0.113.9')"
+      The contents of file "${errorlog}" should include 'grepcidr error'
+    End
+
+    It 'publishes an EMPTY member list on grepcidr rc=1 (a legitimate "everything suppressed" outcome)'
+      GREPCIDR_MODE='empty'; export GREPCIDR_MODE
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should equal ''
+    End
+  End
+
+  Describe 'f — masterfile resync under dedup="on" mirrors the post-suppression list'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppf.XXXXXX")"
+      max="${work}"
+      alias='DedupList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      printf '203.0.113.7/32\n' > "${pfbsuppression}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      # A stale pair of rows for THIS alias, plus one unrelated alias's row
+      # that must survive the resync untouched.
+      printf 'DedupList_v4 PRIOR-1\nDedupList_v4 PRIOR-2\nOtherList_v4 198.51.100.5\n' > "${masterfile}"
+      dedup='on'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      member="${work}/${alias}.txt"
+      printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'drops the stale alias rows, keeps the unrelated row, and appends the post-suppression list'
+      When call silently suppress
+      The status should be success
+      The contents of file "${masterfile}" should include 'OtherList_v4 198.51.100.5'
+      The contents of file "${masterfile}" should not include 'PRIOR-1'
+      The contents of file "${masterfile}" should not include 'PRIOR-2'
+      The contents of file "${masterfile}" should include 'DedupList_v4 203.0.113.5'
+      The contents of file "${masterfile}" should include 'DedupList_v4 203.0.113.9'
+      The contents of file "${masterfile}" should not include 'DedupList_v4 203.0.113.7'
+    End
+  End
+
+  Describe 'g — the Suppression Stats table'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppg.XXXXXX")"
+      max="${work}"
+      pfbsuppression="${work}/suppression.txt"
+      printf '203.0.113.7/32\n' > "${pfbsuppression}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathgrepcidr="${work}/grepcidr"
+      write_grepcidr_shim "${pathgrepcidr}"
+      alias='StatsList_v4'
+      member="${work}/${alias}.txt"
+      printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'prints the header block when alias="suppressheader"'
+      alias='suppressheader'
+      When call suppress
+      The status should be success
+      The stdout should include '===[ Suppression Stats ]==================================='
+      The stdout should include 'List'
+      The stdout should include 'Pre'
+      The stdout should include 'Suppress'
+      The stdout should include 'Master'
+    End
+
+    It 'prints the per-alias Pre/Suppress/Master row shape on a normal call'
+      When call suppress
+      The status should be success
+      The stdout should include 'StatsList_v4'
+      # Pre = 3 (member file before this call); Suppress = 2 (one host removed).
+      The stdout should match pattern "*StatsList_v4*3*2*0*"
+    End
+  End
+End

--- a/tests/shell/pfblockerng_suppress_spec.sh
+++ b/tests/shell/pfblockerng_suppress_spec.sh
@@ -45,7 +45,24 @@ Describe 'suppress() (ADR-53 Phase 1 oracle)'
   have_iprange() { [ -n "$(pfb_real_iprange)" ]; }
   # `Skip if` runs its condition as a simple command -- a leading `!` is not
   # a command in POSIX sh, so wrap the negation in a function.
-  no_iprange() { ! have_iprange; }
+  #
+  # Hardened (adversarial-review item E on PR #768): GitHub Actions sets
+  # CI=true and test.yml installs the real iprange binary for these specs --
+  # a silent skip there would be coverage theater (the install step broke and
+  # nothing would notice). In CI, refuse to skip: if the real binary is truly
+  # absent, let the example run and FAIL against the empty pathaggregate (the
+  # stderr line below explains why) rather than silently reporting green-via-
+  # skip. Locally (CI unset) the skip stays legitimate -- the house "missing
+  # tool = skip, CI is the hard gate" pattern is unchanged there.
+  no_iprange() {
+    have_iprange && return 1
+    if [ -n "${CI:-}" ]; then
+      echo 'FATAL (adversarial-review item E): real iprange binary not found on PATH in CI;' \
+        'refusing to silently skip -- test.yml is supposed to install it (ADR-53 §1.2)' >&2
+      return 1
+    fi
+    return 0
+  }
 
   # ---- iprange stub (address-equality) ----
   # Fake `<shim> <haystack-file> --except <except-file>` (iprange's own CLI
@@ -458,6 +475,105 @@ SHIM
       The status should be success
       The contents of file "${member}" should equal ''
       The contents of file "${errorlog}" should equal ''
+    End
+  End
+
+  Describe 'k — member-file pre-filter is ONE grep -E pass (adversarial-review item C on PR #768)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppk.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      printf '203.0.113.99/32\n' > "${pfbsuppression}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathaggregate="${work}/iprange"
+      # Identity shim (echoes the haystack -- here the pre-filtered member
+      # file -- back unchanged): isolates the member-file grep pre-filter
+      # itself, not iprange's own carve math (that's cases c/d/j above).
+      write_pathaggregate_identity_shim "${pathaggregate}"
+      member="${work}/${alias}.txt"
+      # One valid IPv4 host + one malformed (hostname-shaped) line. The
+      # member file is normally already-sanitised feed data -- the pre-filter
+      # is defense-in-depth against exactly this shape ever reaching iprange
+      # (which would silently DNS-resolve it as a hostname, ADR-53 §1.2).
+      printf '203.0.113.5\nevil.example.com\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'drops the malformed line, keeps the valid line, and logs ONE summary line (replacing the old while-read loop)'
+      When call silently suppress
+      The status should be success
+      # The filtered scratch file (what iprange actually sees) holds only the
+      # valid entry -- proving the grep pass, not just the published result.
+      The contents of file "${dedupfile}" should equal '203.0.113.5'
+      The contents of file "${dedupfile}" should not include 'evil.example.com'
+      # The identity shim echoes the haystack back unchanged, so the
+      # published member file mirrors the filtered scratch file exactly.
+      The contents of file "${member}" should equal '203.0.113.5'
+      The contents of file "${errorlog}" should include 'dropped 1 malformed member-file line'
+    End
+  End
+
+  Describe 'l — iprange binary missing entirely: the executable guard fails safe (adversarial-review item D on PR #768)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppl.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      printf '203.0.113.7/32\n' > "${pfbsuppression}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      # A path that does not exist at all -- `[ ! -x "${pathaggregate}" ]`
+      # (pfblockerng.sh's suppress()) must fire before ANY of the pre-filter
+      # or iprange machinery runs. No coverage existed for this guard before
+      # this ADR's shellspec suite.
+      pathaggregate="${work}/does-not-exist-iprange"
+      member="${work}/${alias}.txt"
+      printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'returns early: member file byte-identical, "Not found" error logged'
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should equal "$(printf '203.0.113.5\n203.0.113.7\n203.0.113.9')"
+      The contents of file "${errorlog}" should include 'Not found'
+    End
+  End
+
+  Describe 'm — no_iprange CI-hardening (adversarial-review item E on PR #768): a broken CI install FAILS, never silently skips'
+    # Force the "no real iprange reachable" condition via a local override of
+    # have_iprange() -- NOT by scrubbing PATH, which would also break
+    # shellspec's own use of coreutils (sed et al.) mid-example. Proves the
+    # CI-vs-local discrimination itself, independent of whatever is actually
+    # installed on the host running this suite (CI included, where the real
+    # binary is normally present).
+    setup() { have_iprange() { return 1; }; }
+    Before 'setup'
+
+    It 'does NOT skip when CI is set and no real iprange is reachable -- fails loudly instead'
+      CI='true'
+      When call no_iprange
+      unset CI
+      The status should be failure
+      The stderr should include 'FATAL'
+    End
+
+    It 'still skips locally (CI unset) when no real iprange is reachable -- unchanged house pattern'
+      unset CI
+      When call no_iprange
+      The status should be success
     End
   End
 End

--- a/tests/shell/pfblockerng_suppress_spec.sh
+++ b/tests/shell/pfblockerng_suppress_spec.sh
@@ -1,75 +1,115 @@
 #shellcheck shell=sh
-# suppress() oracle (ADR-53 Phase 1) -- pins TODAY's IP-suppression semantics,
-# including its known containing-entry defect, as a regression baseline for
-# Phase 3's iprange --except rewrite. This spec is BEHAVIOUR-PRESERVING: it
-# adds no src/ change and must stay green before and after this phase; Phase 3
-# flips exactly the "containing-entry silent no-op" assertion below (§2) from
-# a no-op pin to a real-carve assertion, red on pre-Phase-3 code, green after.
+# suppress() spec (ADR-53). Phase 1 pinned TODAY's IP-suppression semantics
+# (including the containing-entry defect) as a behaviour-preserving oracle.
+# Phase 3 (this revision) flips that oracle red->green against the REWRITTEN
+# suppress(): the grep -F /24-explode + dupfile dedup + `grepcidr -vf`
+# whole-token pass are GONE, replaced by a single `iprange --except` set
+# subtraction (ADR-53 §2.1) -- true CIDR set-subtraction with a minimal
+# covering-CIDR remainder, so a suppressed host is now carved out of ANY
+# containing entry, not just the exact /24 the old explode required.
 #
 # suppress() (pfblockerng.sh) carves suppression-list entries out of a deny
 # member file (${max}/${alias}.txt), gated on a non-empty ${pfbsuppression}
-# file. Per suppression entry (always a /32 or /24 today -- pfblockerng_ip.php
-# validation): a bare-host member token is removed by the trailing
-# `grepcidr -vf` whole-token pass; a member token that is the EXACT containing
-# /24 of a /32 suppression entry is exploded into 255 individual hosts (a
-# literal grep -F string match against "<prefix>.0/24", entirely independent
-# of grepcidr) minus the suppressed octet, deduped via ${dupfile} so a second
-# /32 inside the same /24 does not re-explode; but a member token WIDER than
-# /24 (a /16, say) containing the suppressed host is a SILENT NO-OP -- ADR-53
-# §1.2 proved live that grepcidr does not split/pierce a containing CIDR, so
-# the suppressed host stays blocked with no warning. That defect is pinned
-# below as today's oracle, not fixed here.
+# file. Both inputs are pre-filtered to strict IPv4 host/CIDR token shape
+# before either reaches iprange (ADR-53 §1.2's DNS-resolution hazard: a
+# malformed token is not rejected by iprange -- it is silently treated as a
+# HOSTNAME and DNS-resolved, rc=0, no opt-out flag). Cases (a, b, f, g) use a
+# lightweight iprange-shaped STUB (address-equality removal -- the only shape
+# suppress()'s own wiring/gating logic needs to prove itself); cases (c, d, j)
+# assert something about iprange's OWN empirically-proven behaviour (the
+# covering-CIDR carve math, rc=0-on-empty) and so need the REAL binary,
+# skip-if-absent locally (house pattern: CI installs it and is the hard
+# gate -- see ADR-53 §1.2 for the measured covering-CIDR counts this pins).
 #
-# Note: tests/shell/pfblockerng_fail_open_redirect_spec.sh already pins
-# suppress()'s #713 fail-open rc-gating (grepcidr rc>=2 keep-previous; the
-# dedup="on" masterfile awk redirect) as part of a cross-function "fail-open
-# redirect" family (it also covers duplicate()/remove()/process255()/
-# reputation_max()). This file is the dedicated, comprehensive suppress()
-# semantics pin (bare-token removal, the /24 explode + dupfile dedup guard,
-# the containing-entry defect, absent/empty gating, the stats table) and
-# re-asserts the #713 rc gating here too so it is self-contained -- the two
-# files' fail-safe cases are deliberately redundant, not duplicative (each
-# proves it from its own file's narrative).
+# Note: tests/shell/pfblockerng_fail_open_redirect_spec.sh's suppress()
+# Describe blocks (Class A/B) also switched from the grepcidr-rc gate to the
+# iprange-rc gate in this same phase -- see that file's header. The two
+# files' fail-safe cases stay deliberately redundant, not duplicative: each
+# proves the rc-gating contract from its own file's self-contained narrative.
 
 Describe 'suppress() (ADR-53 Phase 1 oracle)'
   BeforeAll 'pfb_source'
 
-  # ---- grepcidr shim ----
-  # Fake grepcidr -vf <filter> <target> for the suppress() oracle.
+  # Real iprange --except performs actual CIDR set-subtraction with a minimal
+  # covering-CIDR remainder (ADR-53 §1.2) -- a stub cannot fake that math, so
+  # cases (c, d, j) below need the real binary. CI installs it (test.yml);
+  # locally, absent = skip (house pattern: missing tool reported + skipped,
+  # CI is the hard gate).
+  # spec_helper.sh prepends PFB_SHIMS onto PATH with its OWN `iprange` stand-in
+  # (a bare `sort -u` passthrough built for the AWS pre-script tests -- no
+  # --except/aggregation semantics), so a bare `command -v iprange` would
+  # resolve to THAT, not the real binary. Search past it explicitly.
+  pfb_real_iprange() {
+    ( PATH="$(printf '%s\n' "${PATH}" | sed "s#${PFB_SHIMS}:##")"; command -v iprange 2>/dev/null )
+  }
+  have_iprange() { [ -n "$(pfb_real_iprange)" ]; }
+  # `Skip if` runs its condition as a simple command -- a leading `!` is not
+  # a command in POSIX sh, so wrap the negation in a function.
+  no_iprange() { ! have_iprange; }
+
+  # ---- iprange stub (address-equality) ----
+  # Fake `<shim> <haystack-file> --except <except-file>` (iprange's own CLI
+  # shape -- see --help) for cases that pin suppress()'s OWN wiring/gating
+  # logic rather than iprange's covering-CIDR carve math itself (that needs
+  # the REAL binary -- see cases c/d/j further down).
   #
   # Default mode performs plain ADDRESS-EQUALITY filtering with the mask
   # stripped from both sides: every suppression entry the UI accepts today is
   # a /32 host (mask enforcement at pfblockerng_ip.php:159), so real
-  # grepcidr's CIDR-containment test ("is this target line's range a subset
-  # of a filter CIDR") collapses to "is this target line's address exactly
-  # the suppressed host". A bare host, or a target line written as that exact
-  # /32, is REMOVED -- grepcidr's proven whole-token/host removal (ADR-53
-  # §1.2, both address families). Any WIDER target CIDR (a /16 or /24 line)
-  # can never equal a single suppressed host address, so it survives
-  # completely untouched -- the exact containing-entry silent no-op ADR-53
-  # §1.2 proved live and this suite pins as today's oracle.
+  # iprange's exact CIDR-set subtraction collapses to "is this haystack
+  # line's address exactly a suppressed host". A bare host, or a line written
+  # as that exact /32, is REMOVED -- iprange's proven whole-token/host
+  # removal (ADR-53 §1.2, empirically verified). This stub does NOT attempt
+  # covering-CIDR carve math (a wider haystack CIDR is left untouched by this
+  # fake) -- cases needing that assert against the real binary instead.
   #
-  # GREPCIDR_MODE overrides the default for the #713 fail-safe rc-gating
-  # cases: empty -> a LEGITIMATE "everything suppressed" empty result, rc 1;
-  # error -> a real grepcidr error (e.g. malformed filter file), rc 2.
-  write_grepcidr_shim() {
+  # IPRANGE_MODE=error overrides the default for the #713-equivalent
+  # fail-safe rc-gating case: simulates a real iprange error (rc!=0, e.g. a
+  # missing/unloadable ipset file).
+  write_pathaggregate_shim() {
     cat > "$1" <<'SHIM'
 #!/bin/sh
-case "${GREPCIDR_MODE:-}" in
-	empty) exit 1 ;;
-	error) echo 'grepcidr: simulated malformed filter' >&2; exit 2 ;;
+case "${IPRANGE_MODE:-}" in
+	error) echo 'iprange: simulated error (missing/unloadable ipset)' >&2; exit 1 ;;
 esac
 
-filter="$2"
-target="$3"
-faddrs="$(sed 's#/.*##' "${filter}")"
+haystack="$1"
+except="$3"
+faddrs="$(sed 's#/.*##' "${except}")"
 while IFS= read -r line; do
 	[ -z "${line}" ] && continue
 	addr="${line%%/*}"
 	if ! printf '%s\n' "${faddrs}" | grep -qxF "${addr}"; then
 		printf '%s\n' "${line}"
 	fi
-done < "${target}"
+done < "${haystack}"
+SHIM
+    chmod +x "$1"
+  }
+
+  # ---- iprange stub (identity pass-through) ----
+  # Ignores --except entirely and echoes the haystack file back unchanged.
+  # Used only where the assertion targets something OTHER than the published
+  # member-file content (e.g. case h's pre-filter-drop check) and a fixed,
+  # always-succeeding binary is all that's needed to satisfy suppress()'s
+  # executable guard + rc-gated publish.
+  write_pathaggregate_identity_shim() {
+    cat > "$1" <<'SHIM'
+#!/bin/sh
+cat "$1"
+SHIM
+    chmod +x "$1"
+  }
+
+  # ---- iprange stub (always fails) ----
+  # Simulates a real iprange error (rc!=0) unconditionally -- the #713-style
+  # fail-safe gate (case i): suppress() must keep the previous list and log,
+  # never truncate/publish on a real engine error.
+  write_pathaggregate_fail_shim() {
+    cat > "$1" <<'SHIM'
+#!/bin/sh
+echo 'iprange: simulated error (missing/unloadable ipset)' >&2
+exit 1
 SHIM
     chmod +x "$1"
   }
@@ -85,8 +125,8 @@ SHIM
       : > "${masterfile}"
       dedup='off'
       errorlog="${work}/error.log"; : > "${errorlog}"
-      pathgrepcidr="${work}/grepcidr"
-      write_grepcidr_shim "${pathgrepcidr}"
+      pathaggregate="${work}/iprange"
+      write_pathaggregate_shim "${pathaggregate}"
       member="${work}/${alias}.txt"
       printf '203.0.113.5\n' > "${member}"
     }
@@ -122,8 +162,8 @@ SHIM
       : > "${masterfile}"
       dedup='off'
       errorlog="${work}/error.log"; : > "${errorlog}"
-      pathgrepcidr="${work}/grepcidr"
-      write_grepcidr_shim "${pathgrepcidr}"
+      pathaggregate="${work}/iprange"
+      write_pathaggregate_shim "${pathaggregate}"
       member="${work}/${alias}.txt"
       printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
     }
@@ -138,7 +178,7 @@ SHIM
     End
   End
 
-  Describe 'c — exact-/24 explode: a /32 suppression inside a containing /24 member entry'
+  Describe 'c — exact-/24 carve: a /32 suppression inside a containing /24 member entry (real iprange)'
     setup() {
       work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppc.XXXXXX")"
       max="${work}"
@@ -149,8 +189,7 @@ SHIM
       : > "${masterfile}"
       dedup='off'
       errorlog="${work}/error.log"; : > "${errorlog}"
-      pathgrepcidr="${work}/grepcidr"
-      write_grepcidr_shim "${pathgrepcidr}"
+      pathaggregate="$(pfb_real_iprange)"
       member="${work}/${alias}.txt"
       printf '10.9.8.0/24\n' > "${member}"
     }
@@ -158,7 +197,8 @@ SHIM
     Before 'setup'
     After 'cleanup'
 
-    It 'explodes the /24 line into its 254 non-suppressed host lines (the /24 line itself is gone)'
+    It 'carves the /32 hole out of the /24, publishing the 8 minimal covering CIDRs -- NEVER a host explosion (Phase 3: was 254 host lines pre-rewrite)'
+      Skip if 'needs the real iprange binary (apt-get install iprange in CI; absent locally)' no_iprange
       printf '10.9.8.4/32\n' > "${pfbsuppression}"
       When call silently suppress
       The status should be success
@@ -168,20 +208,23 @@ SHIM
       # so a legitimate zero-match (grep rc=1) doesn't abort the example.
       has4="$(grep -c '^10\.9\.8\.4$' "${member}" || true)"
       The variable has4 should equal 0
-      has1="$(grep -c '^10\.9\.8\.1$' "${member}" || true)"
-      The variable has1 should equal 1
-      has255="$(grep -c '^10\.9\.8\.255$' "${member}" || true)"
-      The variable has255 should equal 1
-      # seq 255 walks octets 1..255 (255 values); excluding the one suppressed
-      # octet (.4) leaves 254 -- verified empirically against the real function.
-      hostcount="$(grep -c ^ "${member}")"
-      The variable hostcount should equal 254
+      # /24 - /32 = 8 minimal covering CIDRs (empirically pinned, ADR-53 §1.2) --
+      # never the old 254-host explosion.
+      linecount="$(grep -c ^ "${member}")"
+      The variable linecount should equal 8
+      # Representative samples of the expected covering-CIDR remainder --
+      # asserting PRESENCE (not just the hole's absence) so a "carve away
+      # everything" bug can't false-pass.
+      The contents of file "${member}" should include '10.9.8.5'
+      The contents of file "${member}" should include '10.9.8.128/25'
     End
 
-    It 'a SECOND /32 suppression inside the same containing /24 does not re-explode (dupfile dedup): both hosts gone, no duplicate lines'
+    It 'a SECOND /32 suppression inside the same containing /24 is carved in the SAME iprange call (no dedup bookkeeping needed): both holes gone, minimal cover, no duplicates'
+      Skip if 'needs the real iprange binary (apt-get install iprange in CI; absent locally)' no_iprange
       # Given: two DIFFERENT /32 holes that both map to the same containing
-      # /24 -- the dupfile guard (suppress()'s "dcheck" check) must fire only
-      # once, or the explode loop would run twice and duplicate all 254 hosts.
+      # /24 -- iprange --except subtracts every hole in ONE pass, so there is
+      # no per-hole dedup guard left to prove (the old dupfile/"dcheck" check
+      # is gone).
       printf '10.9.8.4/32\n10.9.8.55/32\n' > "${pfbsuppression}"
       When call silently suppress
       The status should be success
@@ -190,18 +233,18 @@ SHIM
       The variable has4 should equal 0
       has55="$(grep -c '^10\.9\.8\.55$' "${member}" || true)"
       The variable has55 should equal 0
-      # 254 - the second suppressed host (.55, removed by the trailing
-      # grepcidr pass since the single explode run already included it).
-      hostcount="$(grep -c ^ "${member}")"
-      The variable hostcount should equal 253
-      # Then: no line was doubled by a second explode pass -- a real double
-      # explode would leave every non-suppressed host appearing twice.
+      # 12 minimal covering CIDRs for two /32 holes in one /24 (empirically
+      # verified against the real binary).
+      linecount="$(grep -c ^ "${member}")"
+      The variable linecount should equal 12
+      # Then: no line is duplicated -- a real double-explode would leave every
+      # non-suppressed host appearing twice.
       dupcount="$(sort "${member}" | uniq -d | grep -c ^ || true)"
       The variable dupcount should equal 0
     End
   End
 
-  Describe 'd — containing-entry silent no-op: the DEFECT, pinned as todays oracle (Phase 3 flips this)'
+  Describe 'd — containing-entry carve: the DEFECT FIXED (Phase 3) -- a wider containing block is genuinely carved (real iprange)'
     setup() {
       work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppd.XXXXXX")"
       max="${work}"
@@ -213,58 +256,36 @@ SHIM
       : > "${masterfile}"
       dedup='off'
       errorlog="${work}/error.log"; : > "${errorlog}"
-      pathgrepcidr="${work}/grepcidr"
-      write_grepcidr_shim "${pathgrepcidr}"
+      pathaggregate="$(pfb_real_iprange)"
       member="${work}/${alias}.txt"
-      # A /16 member entry containing the suppressed /32 host, but NOT the
-      # exact /24 the explode branch's literal grep -F match requires.
+      # A /16 member entry containing the suppressed /32 host -- the OLD
+      # engine's literal grep -F match only ever fired for the EXACT
+      # containing /24, so this survived byte-identical (Phase 1's pinned
+      # oracle). iprange --except subtracts it regardless of the containing
+      # prefix length.
       printf '10.0.0.0/16\n' > "${member}"
     }
     cleanup() { rm -rf "${work}"; }
     Before 'setup'
     After 'cleanup'
 
-    It 'SURVIVES the containing /16 line unchanged -- the suppressed host stays blocked, ADR-53 §1.2 (Phase 3 flips this to a carve)'
+    It 'CARVES the suppressed host out of the containing /16 (was a silent no-op pre-Phase-3, ADR-53 §1.2) -- 16 covering CIDRs, suppressed host gone, siblings still covered'
+      Skip if 'needs the real iprange binary (apt-get install iprange in CI; absent locally)' no_iprange
       When call silently suppress
       The status should be success
-      The contents of file "${member}" should equal '10.0.0.0/16'
-    End
-  End
-
-  Describe 'e — grepcidr fail-safe publish gating (#713), re-asserted here for a self-contained oracle'
-    setup() {
-      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppe.XXXXXX")"
-      max="${work}"
-      alias='TestList_v4'
-      pfbsuppression="${work}/suppression.txt"
-      printf '203.0.113.7/32\n' > "${pfbsuppression}"
-      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
-      masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
-      dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
-      pathgrepcidr="${work}/grepcidr"
-      write_grepcidr_shim "${pathgrepcidr}"
-      member="${work}/${alias}.txt"
-      printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
-    }
-    cleanup() { rm -rf "${work}"; }
-    Before 'setup'
-    After 'cleanup'
-
-    It 'keeps the PRIOR member list unchanged when grepcidr errors (rc>=2), and logs the error'
-      GREPCIDR_MODE='error'; export GREPCIDR_MODE
-      When call silently suppress
-      The status should be success
-      The contents of file "${member}" should equal "$(printf '203.0.113.5\n203.0.113.7\n203.0.113.9')"
-      The contents of file "${errorlog}" should include 'grepcidr error'
-    End
-
-    It 'publishes an EMPTY member list on grepcidr rc=1 (a legitimate "everything suppressed" outcome)'
-      GREPCIDR_MODE='empty'; export GREPCIDR_MODE
-      When call silently suppress
-      The status should be success
-      The contents of file "${member}" should equal ''
+      # Before Phase 3, this line was pinned BYTE-IDENTICAL '10.0.0.0/16' --
+      # today's defect. After the carve, the /16 line itself is gone,
+      # replaced by its minimal covering-CIDR remainder.
+      The contents of file "${member}" should not include '10.0.0.0/16'
+      # /16 - /32 = 16 minimal covering CIDRs (empirically pinned, ADR-53 §1.2).
+      linecount="$(grep -c ^ "${member}")"
+      The variable linecount should equal 16
+      has_host="$(grep -c '^10\.0\.3\.4$' "${member}" || true)"
+      The variable has_host should equal 0
+      # Representative samples either side of the hole -- proves the
+      # remainder genuinely covers the siblings, not an over-carve.
+      The contents of file "${member}" should include '10.0.0.0/23'
+      The contents of file "${member}" should include '10.0.128.0/17'
     End
   End
 
@@ -282,8 +303,8 @@ SHIM
       printf 'DedupList_v4 PRIOR-1\nDedupList_v4 PRIOR-2\nOtherList_v4 198.51.100.5\n' > "${masterfile}"
       dedup='on'
       errorlog="${work}/error.log"; : > "${errorlog}"
-      pathgrepcidr="${work}/grepcidr"
-      write_grepcidr_shim "${pathgrepcidr}"
+      pathaggregate="${work}/iprange"
+      write_pathaggregate_shim "${pathaggregate}"
       member="${work}/${alias}.txt"
       printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
     }
@@ -314,8 +335,8 @@ SHIM
       : > "${masterfile}"
       dedup='off'
       errorlog="${work}/error.log"; : > "${errorlog}"
-      pathgrepcidr="${work}/grepcidr"
-      write_grepcidr_shim "${pathgrepcidr}"
+      pathaggregate="${work}/iprange"
+      write_pathaggregate_shim "${pathaggregate}"
       alias='StatsList_v4'
       member="${work}/${alias}.txt"
       printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
@@ -341,6 +362,102 @@ SHIM
       The stdout should include 'StatsList_v4'
       # Pre = 3 (member file before this call); Suppress = 2 (one host removed).
       The stdout should match pattern "*StatsList_v4*3*2*0*"
+    End
+  End
+
+  Describe 'h — iprange DNS-resolution hazard (ADR-53 §1.2): a hostname-shaped suppression token is dropped BEFORE it ever reaches iprange'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsupph.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathaggregate="${work}/iprange"
+      write_pathaggregate_identity_shim "${pathaggregate}"
+      member="${work}/${alias}.txt"
+      printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'never reaches iprange: dropped from the filtered suppression scratch file before the call, and logged'
+      # A hostname-shaped token in the suppression list -- ADR-53 §1.2 proved
+      # iprange treats a malformed token as a HOSTNAME and DNS-resolves it
+      # (rc=0, no opt-out flag): a silent mid-update DNS lookup that, if it
+      # resolved, would subtract the resolved IPs as if they were a real
+      # suppression entry. The pre-filter must drop it before iprange ever
+      # sees it -- proven here by inspecting suppress()'s OWN filtered
+      # scratch file (${dupfile}) directly, not merely that the published
+      # result "looks right".
+      printf '203.0.113.7/32\nevil.example.com\n' > "${pfbsuppression}"
+      When call silently suppress
+      The status should be success
+      The contents of file "${dupfile}" should not include 'evil.example.com'
+      The contents of file "${dupfile}" should include '203.0.113.7/32'
+      The contents of file "${errorlog}" should include 'dropping malformed suppression entry'
+    End
+  End
+
+  Describe 'i — iprange fail-safe publish gating (#713-equivalent): a real engine error keeps the previous list'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppi.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      printf '203.0.113.7/32\n' > "${pfbsuppression}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathaggregate="${work}/iprange"
+      write_pathaggregate_fail_shim "${pathaggregate}"
+      member="${work}/${alias}.txt"
+      printf '203.0.113.5\n203.0.113.7\n203.0.113.9\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'keeps the PRIOR member list unchanged when iprange errors (rc!=0, e.g. a missing/unloadable ipset file), and logs the error'
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should equal "$(printf '203.0.113.5\n203.0.113.7\n203.0.113.9')"
+      The contents of file "${errorlog}" should include 'iprange error'
+    End
+  End
+
+  Describe 'j — full suppression: the suppression set exactly equals the member set (real iprange)'
+    setup() {
+      work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbsuppj.XXXXXX")"
+      max="${work}"
+      alias='TestList_v4'
+      pfbsuppression="${work}/suppression.txt"
+      printf '203.0.113.7/32\n' > "${pfbsuppression}"
+      tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
+      masterfile="${work}/master"; mastercat="${work}/mastercat"
+      : > "${masterfile}"
+      dedup='off'
+      errorlog="${work}/error.log"; : > "${errorlog}"
+      pathaggregate="$(pfb_real_iprange)"
+      member="${work}/${alias}.txt"
+      printf '203.0.113.7\n' > "${member}"
+    }
+    cleanup() { rm -rf "${work}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'publishes an EMPTY member list when suppression removes every entry -- a LEGITIMATE outcome (iprange rc=0 either way; no grepcidr-style rc=1 quirk to special-case)'
+      Skip if 'needs the real iprange binary (apt-get install iprange in CI; absent locally)' no_iprange
+      When call silently suppress
+      The status should be success
+      The contents of file "${member}" should equal ''
+      The contents of file "${errorlog}" should equal ''
     End
   End
 End

--- a/tests/smoke/fixtures/README.md
+++ b/tests/smoke/fixtures/README.md
@@ -74,6 +74,24 @@ libmagic/libarchive (or the 7z build) behaviour ever shifts; the tests read each
 exact bytes for the on-box `file(1)` guard (`_fixture_bytes`), so the served feed and the
 guard never drift.
 
+## IP suppression carve fixtures (ADR-53, `IpCase`, `test_smoke_suppression.py`)
+
+Delivered via `write_local_feed` (a committed, documented fixture body copied onto the guest
+as a local file), not the HTTP `mock_feeds` path -- these tests exercise the persisted
+suppression engine (`pfblockerng.sh suppress()` for v4, `pfb_suppress_file_v6()` for v6), not
+the HTTP-fetch contract Part C already covers.
+
+| File | Contents | Purpose |
+| --- | --- | --- |
+| `ip_suppress_v4.txt` | `198.18.0.0/16` (RFC 2544) + two well-separated RFC 5737 bare hosts (`203.0.113.60`, `198.51.100.77`) | Containing-range carve (a `/32`/`/24` suppression carves the `/16`), plus whole-token bare-host removal |
+| `ip_suppress_v6.txt` | `2001:db8:53::/64` (RFC 3849) + two well-separated RFC 3849 bare hosts (`2001:db8:99::10`, `2001:db8:aa::20`) | Same shape, IPv6 (`/128` suppression carves the `/64`) |
+
+The bare hosts are deliberately non-adjacent to each other and to the CIDR block: iprange's
+minimal-CIDR aggregation would otherwise merge two adjacent addresses into one covering entry,
+which would throw off the exact covering-CIDR-count assertions (`/16 - /32 = 16`,
+`/64 - /128 = 64`, `/16 - /24 = 8` -- ADR-53 §1.2, mathematically invariant regardless of the
+hole's exact position within its container).
+
 ## Omitted formats (and why)
 
 CSV/iblocklist, regex, and the ABP IP-anchor (`||1.2.3.4^`) variants are out of the

--- a/tests/smoke/fixtures/ip_suppress_v4.txt
+++ b/tests/smoke/fixtures/ip_suppress_v4.txt
@@ -1,0 +1,10 @@
+# ADR-53 smoke fixture: RFC 2544 benchmarking /16 -- the containing-range
+# carve target (tests/smoke/test_smoke_suppression.py). Never RFC 1918 (the
+# killstates/private-exclusion path would otherwise eat it).
+198.18.0.0/16
+# Bare hosts (RFC 5737 documentation ranges), deliberately far apart from each
+# other and from the /16 above -- iprange's minimal-CIDR aggregation would
+# merge two ADJACENT hosts into one covering CIDR, which would break the
+# exact covering-CIDR-count assertions these tests pin.
+203.0.113.60
+198.51.100.77

--- a/tests/smoke/fixtures/ip_suppress_v6.txt
+++ b/tests/smoke/fixtures/ip_suppress_v6.txt
@@ -1,0 +1,8 @@
+# ADR-53 smoke fixture: RFC 3849 documentation /64 -- the containing-range
+# carve target (tests/smoke/test_smoke_suppression.py).
+2001:db8:53::/64
+# Bare v6 hosts (RFC 3849), in separate prefixes from the /64 above and from
+# each other -- avoids any iprange/engine-side adjacency merge so the
+# covering-CIDR-count assertions stay exact.
+2001:db8:99::10
+2001:db8:aa::20

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3722,8 +3722,8 @@ def pfctl_table_members(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> li
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
-def pfctl_table_test(vm: SmokeVM, alias: str, ip: str, *, timeout: float = 30.0) -> bool:
-    """True iff ``ip`` matches an entry in pf table ``alias`` (``pfctl -t <alias> -T test <ip>``).
+def pfctl_table_test_raw(vm: SmokeVM, alias: str, ip: str, *, timeout: float = 30.0) -> tuple[bool, str]:
+    """Run ``pfctl -t <alias> -T test <ip>`` ONCE; return ``(matched, raw combined output)``.
 
     Unlike :func:`pfctl_table_members` (an exact-token list -- useless once a
     containing entry has been carved into covering CIDRs by ADR-53's live-punch
@@ -3734,10 +3734,21 @@ def pfctl_table_test(vm: SmokeVM, alias: str, ip: str, *, timeout: float = 30.0)
     (rc is 0 either way for a well-formed query against an existing table) —
     on STDERR, not stdout (verified live on FreeBSD; the PHP-side
     ``pfb_pfctl_test_match_count()`` call sites append ``2>&1`` for the same
-    reason), so the check must read both streams.
+    reason), so both streams are combined here and returned RAW so a caller can
+    print pf's own actual output on a failing assertion (CLAUDE.md
+    "expected vs actual" -- never a bare derived boolean).
     """
     result = vm.ssh(PFCTL, "-t", alias, "-T", "test", ip, timeout=timeout)
-    return "1/1 addresses match" in (result.stdout + result.stderr)
+    raw = (result.stdout + result.stderr).strip()
+    return "1/1 addresses match" in raw, raw
+
+
+def pfctl_table_test(vm: SmokeVM, alias: str, ip: str, *, timeout: float = 30.0) -> bool:
+    """True iff ``ip`` matches an entry in pf table ``alias``. See :func:`pfctl_table_test_raw`
+    for the raw pfctl output a failing assertion should print instead of this bare bool.
+    """
+    matched, _raw = pfctl_table_test_raw(vm, alias, ip, timeout=timeout)
+    return matched
 
 
 def pfctl_tables(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3731,10 +3731,13 @@ def pfctl_table_test(vm: SmokeVM, alias: str, ip: str, *, timeout: float = 30.0)
     answers "is this address COVERED by the table", the authoritative oracle for
     the Alerts "+" live-punch e2e (ADR-53 §2.1). ``pfctl`` prints
     ``"1/1 addresses match."`` on a hit and ``"0/1 addresses match."`` on a miss
-    (rc is 0 either way for a well-formed query against an existing table).
+    (rc is 0 either way for a well-formed query against an existing table) —
+    on STDERR, not stdout (verified live on FreeBSD; the PHP-side
+    ``pfb_pfctl_test_match_count()`` call sites append ``2>&1`` for the same
+    reason), so the check must read both streams.
     """
     result = vm.ssh(PFCTL, "-t", alias, "-T", "test", ip, timeout=timeout)
-    return "1/1 addresses match" in result.stdout
+    return "1/1 addresses match" in (result.stdout + result.stderr)
 
 
 def pfctl_tables(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3722,6 +3722,21 @@ def pfctl_table_members(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> li
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
+def pfctl_table_test(vm: SmokeVM, alias: str, ip: str, *, timeout: float = 30.0) -> bool:
+    """True iff ``ip`` matches an entry in pf table ``alias`` (``pfctl -t <alias> -T test <ip>``).
+
+    Unlike :func:`pfctl_table_members` (an exact-token list -- useless once a
+    containing entry has been carved into covering CIDRs by ADR-53's live-punch
+    plan), ``-T test`` is pf's own longest-prefix-match membership check: it
+    answers "is this address COVERED by the table", the authoritative oracle for
+    the Alerts "+" live-punch e2e (ADR-53 §2.1). ``pfctl`` prints
+    ``"1/1 addresses match."`` on a hit and ``"0/1 addresses match."`` on a miss
+    (rc is 0 either way for a well-formed query against an existing table).
+    """
+    result = vm.ssh(PFCTL, "-t", alias, "-T", "test", ip, timeout=timeout)
+    return "1/1 addresses match" in result.stdout
+
+
 def pfctl_tables(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:
     """Return all defined pf table names (``pfctl -sTables``)."""
     result = vm.ssh(PFCTL, "-sTables", timeout=timeout)

--- a/tests/smoke/test_smoke_suppression.py
+++ b/tests/smoke/test_smoke_suppression.py
@@ -133,14 +133,17 @@ def _clean_suppression(deployed_vm: SmokeVM) -> Iterator[None]:
 
 
 def _pfctl_test(vm: SmokeVM, table: str, ip: str) -> tuple[bool, str]:
-    """Run ``pfctl -t <table> -T test <ip>`` ONCE; return (matched, raw stdout).
+    """Run ``pfctl -t <table> -T test <ip>`` ONCE; return (matched, raw output).
 
     Same "1/1 addresses match" substring test as ``helpers.pfctl_table_test``,
     but also returns pf's own rendered output so a failing assertion can print
     it (CLAUDE.md "expected vs actual" -- never a bare derived boolean).
+    ``pfctl -T test`` prints the match line on STDERR (verified live on
+    FreeBSD), so both streams are combined -- stdout alone is always empty.
     """
     result = vm.ssh(h.PFCTL, "-t", table, "-T", "test", ip)
-    return "1/1 addresses match" in result.stdout, result.stdout.strip()
+    raw = (result.stdout + result.stderr).strip()
+    return "1/1 addresses match" in raw, raw
 
 
 def _member_lines(vm: SmokeVM, on_disk_header: str) -> list[str]:

--- a/tests/smoke/test_smoke_suppression.py
+++ b/tests/smoke/test_smoke_suppression.py
@@ -16,15 +16,16 @@ Two independent mechanisms exist for the same set-subtraction invariant:
 This module covers the FIRST mechanism only -- config -> reload -> engine ->
 pf table -- so it does not duplicate Phase 8's UI e2e coverage.
 
-Non-obvious wiring fact this module's Scenario B works around (and flags for
-the maintainer): ``$pfb['supp_update']`` -- the flag that unlocks BOTH the v4
-AND v6 suppression sub-passes for a given reload -- is set TRUE only by a v4
-Deny alias's own genuine reparse (``pfblockerng.inc`` ~16550-16558, inside
-``if ($pfbadv && $list['vtype'] == '_v4')``). An install with ONLY v6 Deny
-lists configured would never flip it, so v6 suppression would never fire in
-isolation. Scenario B injects a trivial companion v4 Deny alias alongside the
-v6 target for exactly this reason -- exercising the wiring as shipped, the
-way a production box with both families configured would.
+``$pfb['supp_update']`` unlocks BOTH the v4 AND v6 suppression sub-passes for
+a given reload. An adversarial-review pass on this ADR (finding A) caught that
+it was originally flipped TRUE only from inside a v4-only dedup/reputation
+block (``pfblockerng.inc`` ~16550-16558), so a v6-only Deny deployment could
+never fire v6 suppression in isolation -- fixed via the pure
+``pfb_supp_update_active()`` helper (family-agnostic: any feed-changed
+Deny-folder alias unlocks it), pinned by ``AliasContentGateTest.php``'s
+Scenario H. Scenario B below still injects a companion v4 Deny alias alongside
+the v6 target -- now exercising the MIXED-family case (both families active
+in the same pass), not working around the fixed bug.
 
 DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke`` in
 pyproject.toml). Run via the smoke workflow or locally::
@@ -132,20 +133,6 @@ def _clean_suppression(deployed_vm: SmokeVM) -> Iterator[None]:
     h.reset(deployed_vm)
 
 
-def _pfctl_test(vm: SmokeVM, table: str, ip: str) -> tuple[bool, str]:
-    """Run ``pfctl -t <table> -T test <ip>`` ONCE; return (matched, raw output).
-
-    Same "1/1 addresses match" substring test as ``helpers.pfctl_table_test``,
-    but also returns pf's own rendered output so a failing assertion can print
-    it (CLAUDE.md "expected vs actual" -- never a bare derived boolean).
-    ``pfctl -T test`` prints the match line on STDERR (verified live on
-    FreeBSD), so both streams are combined -- stdout alone is always empty.
-    """
-    result = vm.ssh(h.PFCTL, "-t", table, "-T", "test", ip)
-    raw = (result.stdout + result.stderr).strip()
-    return "1/1 addresses match" in raw, raw
-
-
 def _member_lines(vm: SmokeVM, on_disk_header: str) -> list[str]:
     """Non-blank lines of a deny-folder member file (the post-suppression content)."""
     result = vm.ssh("cat", f"{DENYDIR}/{on_disk_header}.txt")
@@ -219,9 +206,9 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
     # BEFORE: both addresses match the freshly-loaded, UNSUPPRESSED table.
     members = h.wait_pfctl_table(deployed_vm, spec.alias)
     assert members, f"pf table {spec.alias} never populated after the settling update"
-    matched, raw = _pfctl_test(deployed_vm, spec.alias, target)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, target)
     assert matched, f"expected {target} to MATCH {spec.alias} before suppression; pfctl said: {raw!r}"
-    matched, raw = _pfctl_test(deployed_vm, spec.alias, sibling)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, sibling)
     assert matched, f"expected {sibling} to MATCH {spec.alias} before suppression; pfctl said: {raw!r}"
 
     # WHEN: configure suppression for the target host only, then re-run.
@@ -229,9 +216,9 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
     h.reload(deployed_vm, "updateip", wait_unbound=False)
 
     # THEN: the target is carved out; the sibling -- an unrelated feed entry -- is untouched.
-    matched, raw = _pfctl_test(deployed_vm, spec.alias, target)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, target)
     assert not matched, f"expected {target} to NO LONGER match {spec.alias} after suppression; pfctl said: {raw!r}"
-    matched, raw = _pfctl_test(deployed_vm, spec.alias, sibling)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, sibling)
     assert matched, f"expected {sibling} to STILL match {spec.alias} after suppression; pfctl said: {raw!r}"
 
     # AND: the member file holds covering CIDRs, never a host explosion.
@@ -257,8 +244,9 @@ def test_suppression_v6_carves_containing_range_spares_sibling(deployed_vm: Smok
     set-diff) carves a live-loaded /64 down to covering CIDRs -- v6 had NO
     carve mechanism at all before ADR-53.
 
-    A trivial companion v4 Deny alias is injected alongside the v6 target: see
-    the module docstring for why ($pfb['supp_update'] is a v4-only trigger).
+    A trivial companion v4 Deny alias is injected alongside the v6 target to
+    exercise the mixed-family case (see the module docstring: this used to be a
+    workaround for a v6-only $pfb['supp_update'] gating bug, now fixed).
 
     Given: the v6 fixture feed (``2001:db8:53::/64`` + two bare hosts) is
     loaded as a Deny list, alongside the v4 companion; suppression enabled but
@@ -290,19 +278,21 @@ def test_suppression_v6_carves_containing_range_spares_sibling(deployed_vm: Smok
 
     members = h.wait_pfctl_table(deployed_vm, v6spec.alias)
     assert members, f"pf table {v6spec.alias} never populated after the settling update"
-    matched, raw = _pfctl_test(deployed_vm, v6spec.alias, target)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, v6spec.alias, target)
     assert matched, f"expected {target} to MATCH {v6spec.alias} before suppression; pfctl said: {raw!r}"
-    matched, raw = _pfctl_test(deployed_vm, v6spec.alias, sibling)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, v6spec.alias, sibling)
     assert matched, f"expected {sibling} to MATCH {v6spec.alias} before suppression; pfctl said: {raw!r}"
 
-    # WHEN: configure v6 suppression, then re-run BOTH aliases -- the
-    # companion's own re-parse is what flips $pfb['supp_update'] this pass.
+    # WHEN: configure v6 suppression, then re-run BOTH aliases -- the v6
+    # alias's own re-parse now flips $pfb['supp_update'] on its own (fixed);
+    # the companion v4 alias re-parses alongside it, exercising the
+    # mixed-family case in the same pass.
     _set_suppression(deployed_vm, v6=[host_entry])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
 
-    matched, raw = _pfctl_test(deployed_vm, v6spec.alias, target)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, v6spec.alias, target)
     assert not matched, f"expected {target} to NO LONGER match {v6spec.alias} after suppression; pfctl said: {raw!r}"
-    matched, raw = _pfctl_test(deployed_vm, v6spec.alias, sibling)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, v6spec.alias, sibling)
     assert matched, f"expected {sibling} to STILL match {v6spec.alias} after suppression; pfctl said: {raw!r}"
 
     lines = _member_lines(deployed_vm, f"{v6spec.header}_v6")
@@ -351,17 +341,17 @@ def test_suppression_v4_bare_host_removed(deployed_vm: SmokeVM) -> None:
     members = h.wait_pfctl_table(deployed_vm, spec.alias)
     assert members, f"pf table {spec.alias} never populated after the settling update"
     for ip in (inside_16, removed_host, kept_host):
-        matched, raw = _pfctl_test(deployed_vm, spec.alias, ip)
+        matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, ip)
         assert matched, f"expected {ip} to MATCH {spec.alias} before suppression; pfctl said: {raw!r}"
 
     _set_suppression(deployed_vm, v4=[host_entry])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
 
-    matched, raw = _pfctl_test(deployed_vm, spec.alias, removed_host)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, removed_host)
     assert not matched, f"expected {removed_host} to be REMOVED from {spec.alias}; pfctl said: {raw!r}"
-    matched, raw = _pfctl_test(deployed_vm, spec.alias, kept_host)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, kept_host)
     assert matched, f"expected {kept_host} to still match {spec.alias}; pfctl said: {raw!r}"
-    matched, raw = _pfctl_test(deployed_vm, spec.alias, inside_16)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, inside_16)
     assert matched, (
         f"expected {inside_16} (inside the untouched /16) to STILL match {spec.alias} -- "
         f"a bare-host suppression must never touch an unrelated /16 entry; pfctl said: {raw!r}"
@@ -403,17 +393,17 @@ def test_suppression_v4_subnet_mask_carves_at_granularity(deployed_vm: SmokeVM) 
     members = h.wait_pfctl_table(deployed_vm, spec.alias)
     assert members, f"pf table {spec.alias} never populated after the settling update"
     for ip in (hole_ip, sibling_ip):
-        matched, raw = _pfctl_test(deployed_vm, spec.alias, ip)
+        matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, ip)
         assert matched, f"expected {ip} to MATCH {spec.alias} before suppression; pfctl said: {raw!r}"
 
     _set_suppression(deployed_vm, v4=[hole_subnet])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
 
-    matched, raw = _pfctl_test(deployed_vm, spec.alias, hole_ip)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, hole_ip)
     assert not matched, (
         f"expected {hole_ip} (inside the suppressed /24) to NO LONGER match {spec.alias}; pfctl said: {raw!r}"
     )
-    matched, raw = _pfctl_test(deployed_vm, spec.alias, sibling_ip)
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, sibling_ip)
     assert matched, f"expected {sibling_ip} (a different /24) to STILL match {spec.alias}; pfctl said: {raw!r}"
 
     lines = _member_lines(deployed_vm, f"{spec.header}_v4")

--- a/tests/smoke/test_smoke_suppression.py
+++ b/tests/smoke/test_smoke_suppression.py
@@ -1,0 +1,422 @@
+"""ADR-53 live-VM smoke: the PERSISTED suppression engines carve a live-loaded
+member set, both families -- the §4.1 acceptance requirement's update-time
+proof.
+
+Two independent mechanisms exist for the same set-subtraction invariant:
+
+* The **update-time engine** (this module): ``pfblockerng.sh suppress()``
+  (``iprange --except``, v4) and ``pfb_suppress_file_v6()`` (pure-PHP CIDR
+  set-diff, v6), wired into the alias-build loop and driven by a config
+  ``v4suppression``/``v6suppression`` entry + a reload.
+* The **Alerts "+" live punch** (``pfb_live_punch_plan()``,
+  ``tests/smoke/ui/test_alerts.py``'s ``test_addsuppress_*_carves_containing_range_*``
+  tests, ADR-53 Phase 8): a DIFFERENT code path that mutates the live pf table
+  directly from a single web click, independent of any reload.
+
+This module covers the FIRST mechanism only -- config -> reload -> engine ->
+pf table -- so it does not duplicate Phase 8's UI e2e coverage.
+
+Non-obvious wiring fact this module's Scenario B works around (and flags for
+the maintainer): ``$pfb['supp_update']`` -- the flag that unlocks BOTH the v4
+AND v6 suppression sub-passes for a given reload -- is set TRUE only by a v4
+Deny alias's own genuine reparse (``pfblockerng.inc`` ~16550-16558, inside
+``if ($pfbadv && $list['vtype'] == '_v4')``). An install with ONLY v6 Deny
+lists configured would never flip it, so v6 suppression would never fire in
+isolation. Scenario B injects a trivial companion v4 Deny alias alongside the
+v6 target for exactly this reason -- exercising the wiring as shipped, the
+way a production box with both families configured would.
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke`` in
+pyproject.toml). Run via the smoke workflow or locally::
+
+    python -m pytest tests/smoke/test_smoke_suppression.py -m smoke --override-ini="addopts="
+
+Requires the booted ``smoke_vm`` fixture and the branch ``.pkg`` (``SMOKE_PKG``);
+without it the module fixture skips cleanly. Pure IP-side (no DNSBL, no DNS
+probe) -- mirrors the minimal ``test_smoke_714_asn_geoip.py`` deploy shape.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import FIXTURES_DIR, SmokeVM
+
+pytestmark = pytest.mark.smoke
+
+CFG_IP_SETTINGS = h.CFG_IP_SETTINGS
+DENYDIR = f"{h.PFB_DBDIR}/deny"
+
+# The two bare hosts each fixture carries, in both notations iprange/the v6
+# engine may render a lone covering host (bare, or explicitly masked) -- used
+# to filter "untouched sibling" lines out of a covering-CIDR count.
+V4_BARE_HOSTS = ("203.0.113.60", "198.51.100.77")
+V6_BARE_HOSTS = ("2001:db8:99::10", "2001:db8:aa::20")
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg once for the ADR-53 persisted-suppression-engine module.
+
+    Pure IP-side: the engines under test run inside the IP-scope reload path
+    only (no DNSBL, no DNS probe needed) -- mirrors the minimal
+    ``test_smoke_714_asn_geoip.py`` shape (no DNSBL VIP, no client_vm, no stub_dns).
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.collect_host_diagnostics(smoke_vm)
+
+
+def _set_suppression(vm: SmokeVM, *, v4: list[str] | None = None, v6: list[str] | None = None) -> None:
+    """Enable the master "Enable Suppression" toggle and set BOTH customlists.
+
+    ``v4``/``v6`` are raw textarea lines (e.g. ``"198.18.3.4/32"``) -- every
+    suppression line MUST carry an explicit mask: ``pfb_validate_suppression_line``
+    rejects a bare host (``is_subnetv4()``/``is_subnetv6()`` both require
+    ``/bits``). ``None``/empty clears that family's list. Same base64/CRLF
+    TEXTAREA shape as every other pfBlockerNG customlist (``helpers._b64_textarea``).
+    """
+    snippet = (
+        f"$ip = config_get_path({h._php_str(CFG_IP_SETTINGS)}, array());\n"
+        "$ip['suppression'] = 'on';\n"
+        f"$ip['v4suppression'] = {h._php_str(h._b64_textarea(v4 or []))};\n"
+        f"$ip['v6suppression'] = {h._php_str(h._b64_textarea(v6 or []))};\n"
+        f"config_set_path({h._php_str(CFG_IP_SETTINGS)}, $ip);\n"
+        "write_config('pfBlockerNG smoke: ADR-53 suppression');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_set_suppression failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _wipe_suppression(vm: SmokeVM) -> None:
+    """Force BOTH suppression customlists empty and confirm the write actually took.
+
+    Self-encapsulated per-test baseline (CLAUDE.md test-coverage mandate): a
+    stale v4suppression/v6suppression entry left by one test must never leak
+    into the NEXT test's BEFORE-state assertion. Fails LOUDLY -- never a
+    silent best-effort -- if the readback disagrees with what was just written.
+    """
+    _set_suppression(vm, v4=[], v6=[])
+    v4_after = h.config_get(vm, f"{CFG_IP_SETTINGS}/v4suppression")
+    v6_after = h.config_get(vm, f"{CFG_IP_SETTINGS}/v6suppression")
+    if v4_after or v6_after:
+        raise AssertionError(
+            "wipe of v4suppression/v6suppression did not take -- expected both empty, "
+            f"got v4suppression={v4_after!r} v6suppression={v6_after!r}"
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clean_suppression(deployed_vm: SmokeVM) -> Iterator[None]:
+    """Wipe both suppression customlists before AND after every test in this module.
+
+    Each test injects its OWN uniquely-named alias, so there is no pf-table
+    collision between tests; the v4suppression/v6suppression config nodes are
+    the only state that could otherwise leak test-to-test. Teardown also drops
+    the finishing test's derived pf/sqlite state (``helpers.reset``) so the
+    next test's BEFORE-state assertion starts from a genuinely clean table.
+    """
+    _wipe_suppression(deployed_vm)
+    yield
+    _wipe_suppression(deployed_vm)
+    h.reset(deployed_vm)
+
+
+def _pfctl_test(vm: SmokeVM, table: str, ip: str) -> tuple[bool, str]:
+    """Run ``pfctl -t <table> -T test <ip>`` ONCE; return (matched, raw stdout).
+
+    Same "1/1 addresses match" substring test as ``helpers.pfctl_table_test``,
+    but also returns pf's own rendered output so a failing assertion can print
+    it (CLAUDE.md "expected vs actual" -- never a bare derived boolean).
+    """
+    result = vm.ssh(h.PFCTL, "-t", table, "-T", "test", ip)
+    return "1/1 addresses match" in result.stdout, result.stdout.strip()
+
+
+def _member_lines(vm: SmokeVM, on_disk_header: str) -> list[str]:
+    """Non-blank lines of a deny-folder member file (the post-suppression content)."""
+    result = vm.ssh("cat", f"{DENYDIR}/{on_disk_header}.txt")
+    return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+
+
+def _has_entry(lines: list[str], ip: str) -> bool:
+    """True iff ``ip`` appears in ``lines`` bare, or with an explicit /32 or /128 mask.
+
+    iprange renders a lone covering host WITHOUT a mask suffix (confirmed:
+    ``tests/shell/pfblockerng_suppress_spec.sh``'s ``'10.9.8.5'`` sample); this
+    tolerates either rendering rather than pinning one exact notation.
+    """
+    return ip in lines or f"{ip}/32" in lines or f"{ip}/128" in lines
+
+
+def _carved_only(lines: list[str], bare_hosts: tuple[str, ...]) -> list[str]:
+    """``lines`` with every KNOWN untouched bare-host fixture entry filtered out.
+
+    Isolates the covering-CIDR entries the suppression engine actually
+    produced from the fixture's own untouched sibling hosts, in EITHER
+    notation (see :func:`_has_entry`).
+    """
+    excluded = set(bare_hosts) | {f"{ip}/32" for ip in bare_hosts} | {f"{ip}/128" for ip in bare_hosts}
+    return [ln for ln in lines if ln not in excluded]
+
+
+# --------------------------------------------------------------------------- #
+# Scenario A -- v4 containing-range carve (the §4.1 headline case)
+# --------------------------------------------------------------------------- #
+
+
+def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: SmokeVM) -> None:
+    """The persisted v4 engine (``suppress()``, ``iprange --except``) carves a
+    live-loaded /16 down to covering CIDRs -- ADR-53 §4.1's headline acceptance
+    requirement, proven via the update-time path.
+
+    Given: the v4 fixture feed (``198.18.0.0/16`` + two bare hosts) is loaded
+    as a Deny list; suppression is enabled but empty; a settling update runs.
+
+    When: v4suppression is set to the target host's exact /32 and a second
+    update runs.
+
+    Then: BEFORE the config change, both the target (inside the /16) and an
+    unrelated sibling (a bare-host feed entry) match the live pf table. AFTER,
+    the target no longer matches (the /16 was carved into covering CIDRs --
+    never a 65536-host explosion); the sibling still matches; the member file
+    holds exactly 16 covering-CIDR entries for the /16 minus the /32.
+    """
+    feed_body = (FIXTURES_DIR / "ip_suppress_v4.txt").read_text()
+    feed_url = h.write_local_feed(deployed_vm, "smoke_adr53_v4a.txt", feed_body)
+    spec = h.IpCase(aliasname="adr53v4a", feed_url=feed_url, header="adr53v4a")
+    # Same relative host-in-block position (octet3=3, octet4=4 inside a /16) as
+    # the real-iprange-verified vector in tests/shell/pfblockerng_suppress_spec.sh
+    # ("10.0.3.4" inside "10.0.0.0/16" -> 16 covering CIDRs incl. ".0.0/23" and
+    # ".128.0/17") -- the covering-CIDR count/shape is invariant to the network
+    # prefix, so this grounds the assertions below in an already-proven result.
+    target = "198.18.3.4"
+    sibling = "203.0.113.60"
+    host_entry = f"{target}/32"
+
+    h.inject(deployed_vm, spec)
+    # updateip (scope=ip force=true) sets $pfb['reuse']='on' for the WHOLE pass
+    # (pfblockerng.inc ~13243), which defeats the per-file "already parsed,
+    # skip" cache for EVERY Deny alias -- so a LATER, content-unchanged
+    # updateip call genuinely re-parses this alias with no marker-touch
+    # needed (unlike the ADR-40 tests, which use the force=false 'update'
+    # verb and must call force_ip_refetch explicitly).
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    # BEFORE: both addresses match the freshly-loaded, UNSUPPRESSED table.
+    members = h.wait_pfctl_table(deployed_vm, spec.alias)
+    assert members, f"pf table {spec.alias} never populated after the settling update"
+    matched, raw = _pfctl_test(deployed_vm, spec.alias, target)
+    assert matched, f"expected {target} to MATCH {spec.alias} before suppression; pfctl said: {raw!r}"
+    matched, raw = _pfctl_test(deployed_vm, spec.alias, sibling)
+    assert matched, f"expected {sibling} to MATCH {spec.alias} before suppression; pfctl said: {raw!r}"
+
+    # WHEN: configure suppression for the target host only, then re-run.
+    _set_suppression(deployed_vm, v4=[host_entry])
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    # THEN: the target is carved out; the sibling -- an unrelated feed entry -- is untouched.
+    matched, raw = _pfctl_test(deployed_vm, spec.alias, target)
+    assert not matched, f"expected {target} to NO LONGER match {spec.alias} after suppression; pfctl said: {raw!r}"
+    matched, raw = _pfctl_test(deployed_vm, spec.alias, sibling)
+    assert matched, f"expected {sibling} to STILL match {spec.alias} after suppression; pfctl said: {raw!r}"
+
+    # AND: the member file holds covering CIDRs, never a host explosion.
+    lines = _member_lines(deployed_vm, f"{spec.header}_v4")
+    carved = _carved_only(lines, V4_BARE_HOSTS)
+    assert len(carved) == 16, (
+        "expected 16 covering-CIDR entries for a /16 minus a /32 (ADR-53 §1.2's "
+        f"measured bound); got {len(carved)}: {carved}\nfull member file ({len(lines)} lines): {lines}"
+    )
+    assert "198.18.0.0/23" in carved and "198.18.128.0/17" in carved, (
+        "expected representative covering CIDRs '198.18.0.0/23' and '198.18.128.0/17' "
+        f"(the same relative shape as the real-iprange-verified 10.0.0.0/16-10.0.3.4 vector); got {carved}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Scenario B -- v6 containing-range carve (v6 had NO carve mechanism before ADR-53)
+# --------------------------------------------------------------------------- #
+
+
+def test_suppression_v6_carves_containing_range_spares_sibling(deployed_vm: SmokeVM) -> None:
+    """The persisted v6 engine (``pfb_suppress_file_v6()``, pure-PHP CIDR
+    set-diff) carves a live-loaded /64 down to covering CIDRs -- v6 had NO
+    carve mechanism at all before ADR-53.
+
+    A trivial companion v4 Deny alias is injected alongside the v6 target: see
+    the module docstring for why ($pfb['supp_update'] is a v4-only trigger).
+
+    Given: the v6 fixture feed (``2001:db8:53::/64`` + two bare hosts) is
+    loaded as a Deny list, alongside the v4 companion; suppression enabled but
+    empty; a settling update runs.
+
+    When: v6suppression is set to the target host's exact /128 and a second
+    update runs.
+
+    Then: BEFORE, the target and a sibling both match; AFTER, the target no
+    longer matches (the /64 was carved into covering CIDRs); the sibling still
+    matches; the member file holds exactly 64 covering-CIDR entries for the
+    /64 minus the /128 (ADR-53 §1.2's measured bound; also the exact vector
+    ``pfb_cidr_subtract_v6()`` is unit-pinned against in
+    ``tests/php/V6CidrSubtractTest.php``).
+    """
+    feed_body = (FIXTURES_DIR / "ip_suppress_v6.txt").read_text()
+    feed_url = h.write_local_feed(deployed_vm, "smoke_adr53_v6b.txt", feed_body)
+    v6spec = h.IpCase(aliasname="adr53v6b", feed_url=feed_url, header="adr53v6b", family="v6")
+
+    companion_url = h.write_local_feed(deployed_vm, "smoke_adr53_v6companion.txt", "203.0.113.90\n")
+    companion_spec = h.IpCase(aliasname="adr53v6bcompanion", feed_url=companion_url, header="adr53v6bcompanion")
+
+    target = "2001:db8:53::42"
+    sibling = "2001:db8:99::10"
+    host_entry = f"{target}/128"
+
+    h.inject_ip_lists(deployed_vm, [companion_spec, v6spec])
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    members = h.wait_pfctl_table(deployed_vm, v6spec.alias)
+    assert members, f"pf table {v6spec.alias} never populated after the settling update"
+    matched, raw = _pfctl_test(deployed_vm, v6spec.alias, target)
+    assert matched, f"expected {target} to MATCH {v6spec.alias} before suppression; pfctl said: {raw!r}"
+    matched, raw = _pfctl_test(deployed_vm, v6spec.alias, sibling)
+    assert matched, f"expected {sibling} to MATCH {v6spec.alias} before suppression; pfctl said: {raw!r}"
+
+    # WHEN: configure v6 suppression, then re-run BOTH aliases -- the
+    # companion's own re-parse is what flips $pfb['supp_update'] this pass.
+    _set_suppression(deployed_vm, v6=[host_entry])
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    matched, raw = _pfctl_test(deployed_vm, v6spec.alias, target)
+    assert not matched, f"expected {target} to NO LONGER match {v6spec.alias} after suppression; pfctl said: {raw!r}"
+    matched, raw = _pfctl_test(deployed_vm, v6spec.alias, sibling)
+    assert matched, f"expected {sibling} to STILL match {v6spec.alias} after suppression; pfctl said: {raw!r}"
+
+    lines = _member_lines(deployed_vm, f"{v6spec.header}_v6")
+    carved = _carved_only(lines, V6_BARE_HOSTS)
+    assert len(carved) == 64, (
+        "expected 64 covering-CIDR entries for a /64 minus a /128 (ADR-53 §1.2's measured "
+        f"bound, unit-pinned in V6CidrSubtractTest.php); got {len(carved)}: {carved}\n"
+        f"full member file ({len(lines)} lines): {lines}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Scenario C -- whole-token + legacy-shape upgrade parity (§2.2)
+# --------------------------------------------------------------------------- #
+
+
+def test_suppression_v4_bare_host_removed(deployed_vm: SmokeVM) -> None:
+    """A masked suppression entry over a BARE FEED HOST removes just that
+    token; a /16 entry it never intersects is left byte-identical -- proving
+    the engine only carves entries that actually contain a hole, and that a
+    plain host suppression keeps working identically to the pre-ADR-53
+    mechanism (upgrade parity, ADR-53 §2.2).
+
+    Given: the v4 fixture feed, settled; BEFORE a host inside the /16 and
+    BOTH bare hosts match.
+
+    When: v4suppression is set to ONE bare host's exact /32 (no intersection
+    with the /16 at all).
+
+    Then: that bare host no longer matches; the OTHER bare host and a host
+    inside the untouched /16 still match; the member file holds exactly the
+    /16 line plus the surviving bare host (2 lines) -- never a carve of an
+    entry the suppression list never touched.
+    """
+    feed_body = (FIXTURES_DIR / "ip_suppress_v4.txt").read_text()
+    feed_url = h.write_local_feed(deployed_vm, "smoke_adr53_v4c1.txt", feed_body)
+    spec = h.IpCase(aliasname="adr53v4c1", feed_url=feed_url, header="adr53v4c1")
+    inside_16 = "198.18.3.4"
+    removed_host = "198.51.100.77"
+    kept_host = "203.0.113.60"
+    host_entry = f"{removed_host}/32"
+
+    h.inject(deployed_vm, spec)
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    members = h.wait_pfctl_table(deployed_vm, spec.alias)
+    assert members, f"pf table {spec.alias} never populated after the settling update"
+    for ip in (inside_16, removed_host, kept_host):
+        matched, raw = _pfctl_test(deployed_vm, spec.alias, ip)
+        assert matched, f"expected {ip} to MATCH {spec.alias} before suppression; pfctl said: {raw!r}"
+
+    _set_suppression(deployed_vm, v4=[host_entry])
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    matched, raw = _pfctl_test(deployed_vm, spec.alias, removed_host)
+    assert not matched, f"expected {removed_host} to be REMOVED from {spec.alias}; pfctl said: {raw!r}"
+    matched, raw = _pfctl_test(deployed_vm, spec.alias, kept_host)
+    assert matched, f"expected {kept_host} to still match {spec.alias}; pfctl said: {raw!r}"
+    matched, raw = _pfctl_test(deployed_vm, spec.alias, inside_16)
+    assert matched, (
+        f"expected {inside_16} (inside the untouched /16) to STILL match {spec.alias} -- "
+        f"a bare-host suppression must never touch an unrelated /16 entry; pfctl said: {raw!r}"
+    )
+
+    lines = _member_lines(deployed_vm, f"{spec.header}_v4")
+    assert len(lines) == 2, f"expected exactly 2 member-file lines (untouched /16 + surviving bare host); got {lines}"
+    assert "198.18.0.0/16" in lines, f"expected the untouched /16 line verbatim (never carved); got {lines}"
+    assert _has_entry(lines, kept_host), f"expected the surviving bare host {kept_host}; got {lines}"
+    assert not _has_entry(lines, removed_host), f"expected {removed_host} removed; got {lines}"
+
+
+def test_suppression_v4_subnet_mask_carves_at_granularity(deployed_vm: SmokeVM) -> None:
+    """A /24-mask suppression entry (not just /32) carves the containing /16
+    at /24 granularity -- proves the engine is mask-agnostic (ADR-53 §2.1's
+    UI mask lift to /8-/32) for a wider suppression range, not just a host.
+
+    Given: the v4 fixture feed, settled; BEFORE a host inside the target /24
+    and a sibling /24 (both inside the /16) match.
+
+    When: v4suppression is set to the CONTAINING /24 (not a /32).
+
+    Then: the target /24 no longer matches anywhere inside it; a sibling /24
+    (a different /24 inside the same /16) still matches; the member file
+    holds exactly 8 covering-CIDR entries for the /16 minus the /24
+    (24-16=8 -- the same prefix-length-difference bound the shellspec proves
+    for /24-/32=8, here applied one level up the /16).
+    """
+    feed_body = (FIXTURES_DIR / "ip_suppress_v4.txt").read_text()
+    feed_url = h.write_local_feed(deployed_vm, "smoke_adr53_v4c2.txt", feed_body)
+    spec = h.IpCase(aliasname="adr53v4c2", feed_url=feed_url, header="adr53v4c2")
+    hole_ip = "198.18.5.9"
+    sibling_ip = "198.18.9.9"
+    hole_subnet = "198.18.5.0/24"
+
+    h.inject(deployed_vm, spec)
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    members = h.wait_pfctl_table(deployed_vm, spec.alias)
+    assert members, f"pf table {spec.alias} never populated after the settling update"
+    for ip in (hole_ip, sibling_ip):
+        matched, raw = _pfctl_test(deployed_vm, spec.alias, ip)
+        assert matched, f"expected {ip} to MATCH {spec.alias} before suppression; pfctl said: {raw!r}"
+
+    _set_suppression(deployed_vm, v4=[hole_subnet])
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    matched, raw = _pfctl_test(deployed_vm, spec.alias, hole_ip)
+    assert not matched, (
+        f"expected {hole_ip} (inside the suppressed /24) to NO LONGER match {spec.alias}; pfctl said: {raw!r}"
+    )
+    matched, raw = _pfctl_test(deployed_vm, spec.alias, sibling_ip)
+    assert matched, f"expected {sibling_ip} (a different /24) to STILL match {spec.alias}; pfctl said: {raw!r}"
+
+    lines = _member_lines(deployed_vm, f"{spec.header}_v4")
+    carved = _carved_only(lines, V4_BARE_HOSTS)
+    assert len(carved) == 8, (
+        "expected 8 covering-CIDR entries for a /16 minus a /24 (24-16=8, the same "
+        f"prefix-length-difference bound the shellspec proves for /24-/32=8); got {len(carved)}: {carved}\n"
+        f"full member file ({len(lines)} lines): {lines}"
+    )

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -52,6 +52,7 @@ ALERTS_PAGE = "/pfblockerng/pfblockerng_alerts.php"
 CFG_SUPPRESSION = "installedpackages/pfblockerngdnsblsettings/config/0/suppression"
 CFG_TLDEXCLUSION = "installedpackages/pfblockerngdnsblsettings/config/0/tldexclusion"
 CFG_V4SUPPRESSION = "installedpackages/pfblockerngipsettings/config/0/v4suppression"
+CFG_V6SUPPRESSION = "installedpackages/pfblockerngipsettings/config/0/v6suppression"
 
 
 def _csrf(webui: WebUI) -> str:
@@ -350,65 +351,68 @@ def test_addwhitelistdom_exclude_writes_tld_exclusion_and_entry_delete_removes_i
 
 
 # --------------------------------------------------------------------------- #
-# addsuppress (alerts.php:741): add an IPv4 /32 or /24 to the IPv4 Suppression
-# customlist (``v4suppression`` node). Validator: a valid IPv4 + cidr in {32,24} +
-# a non-empty table word, else it exits with a savemsg and writes NOTHING.
+# addsuppress (alerts.php addsuppress branch): carve a host (v4 or v6, ANY
+# containing mask) out of whichever live pf table entry blocks it, and add the
+# EXACT host to the correct-family Suppression customlist (ADR-53 §2.1 fork 3 --
+# full rework). Validator: a valid IP (either family) + a non-empty table word,
+# else it exits with a savemsg and writes NOTHING. The retired mechanism only
+# understood a bare host or an EXACT /24 network and refused every other
+# containing mask ("blocked by a CIDR other than /24"); it also had no v6 path
+# at all and wrote the CHOSEN mask's network line (not the exact host) into the
+# customlist.
 #
-# We cover the cidr=24 ACCEPT (which writes the network entry to v4suppression even
-# without a live blocked IP -- the /24 branch never takes the /32 "blocked by a
-# CIDR other than /24" early exit) and an invalid-IP REJECT (config unchanged). The
-# /32 ACCEPT is NOT covered: it needs a real blocked IP in a live pf table to pass.
+# We cover: an invalid-IP REJECT (config unchanged); a valid IP with NO live
+# table match, which still writes the exact host (the customlist add is a
+# standing exemption for FUTURE loads, not contingent on today's live snapshot
+# -- ADR-53 §2.1); and, as the headline multi-step scenario, a REAL containing-
+# range carve for both families below.
 # --------------------------------------------------------------------------- #
 
 
-def test_addsuppress_cidr24_writes_and_invalid_ip_rejected(
+def test_addsuppress_writes_exact_host_and_invalid_ip_rejected(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """addsuppress accepts a valid /24 (writes config) and rejects an invalid IP.
+    """addsuppress writes the EXACT host (never a network line) and rejects a bad IP.
 
-    Branch coverage for the IPv4-suppression validator, both with the ``v4suppression``
-    config node as oracle:
+    Branch coverage for the any-mask/v4+v6 suppression validator, with
+    ``v4suppression`` as oracle:
 
-    * REJECT first (proves the node's before-value): an invalid IPv4 makes the handler
-      exit before any write -- the node is UNCHANGED.
-    * ACCEPT (cidr=24): a valid IPv4 + cidr '24' + table word writes the /24 network
-      entry (``a.b.c.0/24``) to ``v4suppression`` -- the node now contains it.
+    * REJECT first (proves the node's before-value): an invalid IPv4 makes the
+      handler exit before any write -- the node is UNCHANGED.
+    * ACCEPT with no live table match: a valid IPv4 against a table with no
+      matching entry still writes the ``ip/32`` line -- the retired mechanism's
+      "blocked by a CIDR other than /24" refusal is gone, and the ADR-53
+      rework always writes the EXACT host (never the old ``{ip}/24`` network
+      line the pre-rework code wrote for its cidr=24 choice).
 
-    The accept asserts the network entry is PRESENT where it was ABSENT, so the green
-    proves the POST caused the write. Config is restored to its original base64 value
-    in ``finally`` (the handler's pfctl calls against a non-resident table are no-ops,
-    so nothing on pf is left to clean up).
+    Config is restored to its original base64 value in ``finally`` (a
+    non-resident table's pfctl calls are no-ops, so nothing on pf needs cleanup).
     """
     vm = smoke_vm
-    # A documentation-range (RFC 5737) IPv4; its /24 network is 198.51.100.0/24.
+    # A documentation-range (RFC 5737) IPv4.
     valid_ip = "198.51.100.7"
-    network24 = "198.51.100.0/24"
+    host_entry = f"{valid_ip}/32"
     table = "pfBlockerNGsmoke"
     original = helpers.config_get(vm, CFG_V4SUPPRESSION)
     try:
         # REJECT: an invalid IPv4 -> handler exits, no write. This also pins the
-        # before-state of the config node (the network must be absent).
-        assert network24 not in _suppression_entries(vm, CFG_V4SUPPRESSION), (
-            f"{network24} already in v4suppression before the test"
+        # before-state of the config node (the host entry must be absent).
+        assert host_entry not in _suppression_entries(vm, CFG_V4SUPPRESSION), (
+            f"{host_entry} already in v4suppression before the test"
         )
-        resp = _post_action(
-            webui,
-            {"addsuppress": "Suppress", "ip": "999.999.999.999", "cidr": "32", "table": table},
-        )
+        resp = _post_action(webui, {"addsuppress": "true", "ip": "999.999.999.999", "table": table})
         assert not looks_like_login_page(resp.text), "addsuppress (invalid) POST returned the login form"
         assert helpers.config_get(vm, CFG_V4SUPPRESSION) == original, (
             "v4suppression config node changed after a REJECTED (invalid IP) addsuppress POST"
         )
 
-        # ACCEPT: a valid IPv4 with cidr 24 -> writes the /24 network entry.
-        resp = _post_action(
-            webui,
-            {"addsuppress": "Suppress", "ip": valid_ip, "cidr": "24", "table": table},
-        )
-        assert not looks_like_login_page(resp.text), "addsuppress (valid /24) POST returned the login form"
-        assert network24 in _suppression_entries(vm, CFG_V4SUPPRESSION), (
-            f"{network24} not written to v4suppression after a valid cidr=24 addsuppress POST"
+        # ACCEPT: a valid IPv4 against a table with no live match -> still writes
+        # the exact host (no mask choice exists any more; no refusal either).
+        resp = _post_action(webui, {"addsuppress": "true", "ip": valid_ip, "table": table})
+        assert not looks_like_login_page(resp.text), "addsuppress (valid, no live match) POST returned the login form"
+        assert host_entry in _suppression_entries(vm, CFG_V4SUPPRESSION), (
+            f"{host_entry} not written to v4suppression after a valid addsuppress POST"
         )
     finally:
         helpers.php_eval(
@@ -417,6 +421,149 @@ def test_addsuppress_cidr24_writes_and_invalid_ip_rejected(
             "write_config('pfBlockerNG smoke: restore v4suppression');\n"
             "echo 'OK';",
         )
+        helpers.reset(vm)
+
+
+def test_addsuppress_v4_carves_containing_range_and_spares_sibling(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The "+" carves a host out of a containing /16 (ADR-53 §2.1 fork 3, headline case).
+
+    True multi-step transition (CLAUDE.md before/after rule): a local IPv4 feed
+    lists an RFC 2544 benchmarking ``/16`` (``198.18.0.0/16`` -- the retired
+    mechanism could only ever express an exact ``/24`` or a bare host, so this
+    mask was UNSUPPRESSIBLE before this phase) plus a separate sibling entry
+    outside it.
+
+    * SETUP: inject the feed as a Deny alias; a force IP update settles it.
+    * BEFORE: the target host AND the sibling both match the live pf table
+      (``pfctl -T test``); the target's exact-host entry is absent from
+      ``v4suppression``.
+    * WHEN: the "+" (``addsuppress``) is driven for the target host only.
+    * THEN: the target no longer matches the table (the containing ``/16`` was
+      carved into covering CIDRs and re-added minus the hole -- never a
+      254-host explosion, never the old refusal); the sibling -- a distinct
+      feed entry entirely outside the hole -- still matches; ``v4suppression``
+      gained the EXACT ``ip/32`` host line.
+
+    Teardown drops the injected list + derived pf state (``helpers.reset``) and
+    restores ``v4suppression`` to its original value.
+    """
+    vm = smoke_vm
+    target = "198.18.5.9"  # inside 198.18.0.0/16
+    sibling = "198.19.50.5"  # a SEPARATE feed entry, RFC 2544 space, outside the /16 hole
+    host_entry = f"{target}/32"
+
+    feed_url = helpers.write_local_feed(vm, "ui_punch4.txt", f"198.18.0.0/16\n{sibling}\n")
+    spec = helpers.IpCase(aliasname="uipunch4", feed_url=feed_url, header="uipunch4")
+    table = spec.alias
+    original = helpers.config_get(vm, CFG_V4SUPPRESSION)
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        # BEFORE: the table is populated (filter_configure lands async after the
+        # CLI returns, hence the poll) and both addresses match it live.
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        assert helpers.pfctl_table_test(vm, table, target), (
+            f"{target} expected to match pf table {table} before suppression"
+        )
+        assert helpers.pfctl_table_test(vm, table, sibling), (
+            f"{sibling} expected to match pf table {table} before suppression"
+        )
+        assert host_entry not in _suppression_entries(vm, CFG_V4SUPPRESSION), (
+            f"{host_entry} already in v4suppression before the test"
+        )
+
+        # WHEN: drive the "+" for the target host against the containing-/16 table.
+        resp = _post_action(webui, {"addsuppress": "true", "ip": target, "table": table})
+        assert not looks_like_login_page(resp.text), "addsuppress POST returned the login form (session lost)"
+
+        # THEN: the target no longer matches (carved out of the /16); the
+        # sibling -- a separate feed entry entirely outside the hole -- is untouched.
+        assert not helpers.pfctl_table_test(vm, table, target), (
+            f"{target} still matches pf table {table} after addsuppress -- the live punch did not take effect"
+        )
+        assert helpers.pfctl_table_test(vm, table, sibling), (
+            f"{sibling} no longer matches pf table {table} after addsuppress -- an unrelated entry was punched"
+        )
+
+        # THEN: v4suppression gained the EXACT host -- never a 254-host
+        # explosion or the retired {ip}/24 shape, any containing mask.
+        assert host_entry in _suppression_entries(vm, CFG_V4SUPPRESSION), (
+            f"{host_entry} not written to v4suppression after addsuppress"
+        )
+    finally:
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_V4SUPPRESSION}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore v4suppression');\n"
+            "echo 'OK';",
+        )
+        helpers.reset(vm)
+
+
+def test_addsuppress_v6_carves_containing_range_and_spares_sibling(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The "+" carves a v6 host out of a containing /64 -- v6 was NEVER punchable before.
+
+    Same multi-step shape as the v4 case above, over the ``v6suppression``
+    node: an RFC 3849 documentation ``/64`` (``2001:db8:18:1::/64``) feed plus a
+    sibling entry in a SEPARATE ``/64``. Before Phase 8, ``v6suppression`` had
+    no live-punch path at all (the retired mechanism was v4-only). BEFORE both
+    addresses match the live table; the "+" carves ONLY the target out (the
+    sibling, a distinct feed entry, is untouched); ``v6suppression`` gains the
+    exact ``ip/128`` host line. Teardown mirrors the v4 case.
+    """
+    vm = smoke_vm
+    target = "2001:db8:18:1::42"  # inside 2001:db8:18:1::/64
+    sibling = "2001:db8:18:2::9"  # a SEPARATE feed entry, a different /64, outside the hole
+    host_entry = f"{target}/128"
+
+    feed_url = helpers.write_local_feed(vm, "ui_punch6.txt", f"2001:db8:18:1::/64\n{sibling}\n")
+    spec = helpers.IpCase(aliasname="uipunch6", feed_url=feed_url, header="uipunch6", family="v6")
+    table = spec.alias
+    original = helpers.config_get(vm, CFG_V6SUPPRESSION)
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        assert helpers.pfctl_table_test(vm, table, target), (
+            f"{target} expected to match pf table {table} before suppression"
+        )
+        assert helpers.pfctl_table_test(vm, table, sibling), (
+            f"{sibling} expected to match pf table {table} before suppression"
+        )
+        assert host_entry not in _suppression_entries(vm, CFG_V6SUPPRESSION), (
+            f"{host_entry} already in v6suppression before the test"
+        )
+
+        resp = _post_action(webui, {"addsuppress": "true", "ip": target, "table": table})
+        assert not looks_like_login_page(resp.text), "addsuppress POST returned the login form (session lost)"
+
+        assert not helpers.pfctl_table_test(vm, table, target), (
+            f"{target} still matches pf table {table} after addsuppress -- the live punch did not take effect"
+        )
+        assert helpers.pfctl_table_test(vm, table, sibling), (
+            f"{sibling} no longer matches pf table {table} after addsuppress -- an unrelated entry was punched"
+        )
+        assert host_entry in _suppression_entries(vm, CFG_V6SUPPRESSION), (
+            f"{host_entry} not written to v6suppression after addsuppress"
+        )
+    finally:
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_V6SUPPRESSION}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore v6suppression');\n"
+            "echo 'OK';",
+        )
+        helpers.reset(vm)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -467,12 +467,10 @@ def test_addsuppress_v4_carves_containing_range_and_spares_sibling(
         # CLI returns, hence the poll) and both addresses match it live.
         members = helpers.wait_pfctl_table(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
-        assert helpers.pfctl_table_test(vm, table, target), (
-            f"{target} expected to match pf table {table} before suppression"
-        )
-        assert helpers.pfctl_table_test(vm, table, sibling), (
-            f"{sibling} expected to match pf table {table} before suppression"
-        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, f"{target} expected to match pf table {table} before suppression; pfctl said: {raw!r}"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, f"{sibling} expected to match pf table {table} before suppression; pfctl said: {raw!r}"
         assert host_entry not in _suppression_entries(vm, CFG_V4SUPPRESSION), (
             f"{host_entry} already in v4suppression before the test"
         )
@@ -483,11 +481,15 @@ def test_addsuppress_v4_carves_containing_range_and_spares_sibling(
 
         # THEN: the target no longer matches (carved out of the /16); the
         # sibling -- a separate feed entry entirely outside the hole -- is untouched.
-        assert not helpers.pfctl_table_test(vm, table, target), (
-            f"{target} still matches pf table {table} after addsuppress -- the live punch did not take effect"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert not matched, (
+            f"{target} still matches pf table {table} after addsuppress -- the live punch did not take "
+            f"effect; pfctl said: {raw!r}"
         )
-        assert helpers.pfctl_table_test(vm, table, sibling), (
-            f"{sibling} no longer matches pf table {table} after addsuppress -- an unrelated entry was punched"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, (
+            f"{sibling} no longer matches pf table {table} after addsuppress -- an unrelated entry was "
+            f"punched; pfctl said: {raw!r}"
         )
 
         # THEN: v4suppression gained the EXACT host -- never a 254-host
@@ -534,12 +536,10 @@ def test_addsuppress_v6_carves_containing_range_and_spares_sibling(
     try:
         members = helpers.wait_pfctl_table(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
-        assert helpers.pfctl_table_test(vm, table, target), (
-            f"{target} expected to match pf table {table} before suppression"
-        )
-        assert helpers.pfctl_table_test(vm, table, sibling), (
-            f"{sibling} expected to match pf table {table} before suppression"
-        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, f"{target} expected to match pf table {table} before suppression; pfctl said: {raw!r}"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, f"{sibling} expected to match pf table {table} before suppression; pfctl said: {raw!r}"
         assert host_entry not in _suppression_entries(vm, CFG_V6SUPPRESSION), (
             f"{host_entry} already in v6suppression before the test"
         )
@@ -547,11 +547,15 @@ def test_addsuppress_v6_carves_containing_range_and_spares_sibling(
         resp = _post_action(webui, {"addsuppress": "true", "ip": target, "table": table})
         assert not looks_like_login_page(resp.text), "addsuppress POST returned the login form (session lost)"
 
-        assert not helpers.pfctl_table_test(vm, table, target), (
-            f"{target} still matches pf table {table} after addsuppress -- the live punch did not take effect"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert not matched, (
+            f"{target} still matches pf table {table} after addsuppress -- the live punch did not take "
+            f"effect; pfctl said: {raw!r}"
         )
-        assert helpers.pfctl_table_test(vm, table, sibling), (
-            f"{sibling} no longer matches pf table {table} after addsuppress -- an unrelated entry was punched"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, (
+            f"{sibling} no longer matches pf table {table} after addsuppress -- an unrelated entry was "
+            f"punched; pfctl said: {raw!r}"
         )
         assert host_entry in _suppression_entries(vm, CFG_V6SUPPRESSION), (
             f"{host_entry} not written to v6suppression after addsuppress"
@@ -561,6 +565,84 @@ def test_addsuppress_v6_carves_containing_range_and_spares_sibling(
             vm,
             f"config_set_path('{CFG_V6SUPPRESSION}', '{original}');\n"
             "write_config('pfBlockerNG smoke: restore v6suppression');\n"
+            "echo 'OK';",
+        )
+        helpers.reset(vm)
+
+
+def test_addsuppress_v4_already_covered_by_broader_entry_skips_duplicate(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The "+" recognises a host already covered by a BROADER manual entry (ADR-53 review H6).
+
+    Before this fix, the addsuppress dedup only matched an EXACT host_line --
+    a host already covered by a wider existing entry (e.g. a /20 added earlier
+    by hand) still got its own redundant '/32' appended. Given a broader
+    v4suppression entry already covering the target (seeded directly, as a
+    prior manual "+"/edit would leave it -- NOT the exact host, so an
+    exact-match-only dedup would miss it): clicking "+" must (1) leave
+    v4suppression WITHOUT a new exact host_line for the target -- only the
+    pre-existing broader entry remains; (2) surface the "already covered by an
+    existing ... Suppression entry" savemsg; (3) still perform the live
+    pf-table punch (unconditional, unaffected by this dedup check).
+    """
+    vm = smoke_vm
+    target = "198.18.9.20"  # inside the broader /20 below
+    broader_entry = "198.18.0.0/20"
+    sibling = "198.19.60.6"  # a SEPARATE feed entry, outside the /20
+
+    feed_url = helpers.write_local_feed(vm, "ui_punch4_covered.txt", f"198.18.0.0/16\n{sibling}\n")
+    spec = helpers.IpCase(aliasname="uipunch4cov", feed_url=feed_url, header="uipunch4cov")
+    table = spec.alias
+    original = helpers.config_get(vm, CFG_V4SUPPRESSION)
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        # GIVEN: a broader manual suppression entry already covers the target
+        # -- seeded directly via config (mirroring a prior manual "+"/edit),
+        # NOT the exact host, so an exact-match-only dedup would miss it.
+        broader_b64 = base64.b64encode(f"{broader_entry}\r\n".encode()).decode()
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_V4SUPPRESSION}', '{broader_b64}');\n"
+            "write_config('pfBlockerNG smoke: seed broader v4suppression entry');\n"
+            "echo 'OK';",
+        )
+
+        # BEFORE: the target still matches the live table (the broader
+        # suppression entry is config-only until this point -- no reload ran
+        # since it was seeded).
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, (
+            f"{target} expected to match pf table {table} before the covered-host addsuppress; pfctl said: {raw!r}"
+        )
+
+        # WHEN: click "+" on the target -- already covered by the broader /20.
+        resp = _post_action(webui, {"addsuppress": "true", "ip": target, "table": table})
+        assert not looks_like_login_page(resp.text), "addsuppress POST returned the login form (session lost)"
+
+        # THEN: no redundant exact-host entry was appended -- only the
+        # pre-existing broader entry remains in v4suppression.
+        entries = _suppression_entries(vm, CFG_V4SUPPRESSION)
+        assert entries == {broader_entry}, (
+            f"expected v4suppression to still hold ONLY the broader entry {broader_entry!r} (no redundant "
+            f"{target}/32 appended); got {entries}"
+        )
+
+        # THEN: the savemsg names the "already covered" case, not "added".
+        assert "already covered by an existing" in resp.text, (
+            "expected the 'already covered by an existing ... Suppression entry' savemsg after a "
+            "covered-host addsuppress POST; response body did not contain it"
+        )
+    finally:
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_V4SUPPRESSION}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore v4suppression');\n"
             "echo 'OK';",
         )
         helpers.reset(vm)

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -680,6 +680,57 @@ def test_ip_v4suppression_mask_validation_base64_and_reject_unchanged(
         webui.post(IP_PAGE, {"v4suppression": restore}, timeout=SAVE_TIMEOUT)
 
 
+def test_ip_v6suppression_mask_validation_base64_and_reject_unchanged(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``v6suppression`` accepts v6 masks /32-/128 (ADR-53 P6); out-of-range masks abort.
+
+    Textarea, one subnet per line -- the v6 sibling of v4suppression's Tier B just
+    above (this is the multi-step save->persist flow ADR-53 requires for the NEW v6
+    textarea -- CLAUDE.md's "front-end changes require Tier B" for a new field).
+    Validation (``pfb_validate_suppression_line()``, family='ipv6', ADR-53 P6): per
+    non-comment line, the mask must fall in [/32, /128] AND ``is_subnetv6`` must
+    pass; either failure -> ``$input_errors`` -> the WHOLE save aborts -> config
+    UNCHANGED. STORAGE IS BASE64, so the oracle compares config_get against base64
+    of the expected textarea content. A valid host mask '2001:db8::1/128' stores
+    base64('2001:db8::1/128'); a containing '2001:db8::/64' is ALSO valid (any mask
+    in the accepted range, not just /128) and stores base64 of its own textarea; a
+    '2001:db8::/31' is below the /32 floor -> rejected -> config unchanged. An empty
+    textarea stores base64('') = '' so clearing/restoring to empty is clean. NO
+    egress, NO reload.
+    """
+    import base64
+
+    vm = smoke_vm
+    cfg = "installedpackages/pfblockerngipsettings/config/0/v6suppression"
+    valid_text = "2001:db8::1/128"
+    valid_b64 = base64.b64encode(valid_text.encode()).decode()
+    original = helpers.config_get(vm, cfg)
+    try:
+        assert original != valid_b64, f"v6suppression already holds {valid_text!r} (base64) before the valid POST"
+        # VALID /128 host mask -> base64 of the textarea is stored.
+        assert _post_and_get(webui, vm, IP_PAGE, {"v6suppression": valid_text}, cfg) == valid_b64
+        # VALID /64 -- a containing block within the accepted /32-/128 range.
+        wide_text = "2001:db8::/64"
+        wide_b64 = base64.b64encode(wide_text.encode()).decode()
+        assert _post_and_get(webui, vm, IP_PAGE, {"v6suppression": wide_text}, cfg) == wide_b64
+        # Restore: an empty textarea stores base64('') = '' (clean clear).
+        got_clear = _post_and_get(webui, vm, IP_PAGE, {"v6suppression": ""}, cfg)
+        assert got_clear == "", f"clearing v6suppression should store '' (base64 of empty), got {got_clear!r}"
+        # REJECT: a /31 is below the /32 floor -> aborts the whole save -> config UNCHANGED (stays '').
+        got = _post_and_get(webui, vm, IP_PAGE, {"v6suppression": "2001:db8::/31"}, cfg)
+        assert got == "", f"below-floor /31 mask must leave v6suppression unchanged at '', got {got!r}"
+    finally:
+        restore = ""
+        if original:
+            try:
+                restore = base64.b64decode(original).decode()
+            except Exception:
+                restore = ""
+        webui.post(IP_PAGE, {"v6suppression": restore}, timeout=SAVE_TIMEOUT)
+
+
 def test_ip_asn_reporting_select_coerces_bogus_to_disabled(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -631,17 +631,20 @@ def test_ip_v4suppression_mask_validation_base64_and_reject_unchanged(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """``v4suppression`` accepts /32 or /24 subnets (stored base64); other masks abort.
+    """``v4suppression`` accepts v4 masks /8-/32 (ADR-53 P4); out-of-range masks abort.
 
-    Textarea, one subnet per line. Validation loop: per non-comment line, the mask
-    ``strstr($host[0],'/')`` must be EXACTLY '/32' or '/24' AND ``is_subnetv4``
-    must pass; either failure -> ``$input_errors`` -> the WHOLE save aborts ->
-    config UNCHANGED. STORAGE IS BASE64 (``base64_encode`` on save, ``base64_decode``
-    on read), so the oracle compares config_get against base64 of the expected
-    textarea content. A valid '10.20.30.0/24' stores base64('10.20.30.0/24'); a
-    '/16' ('10.20.0.0/16') fails the mask check -> rejected -> config unchanged. An
-    empty textarea stores base64('') = '' so clearing/restoring to empty is clean.
-    NO egress, NO reload.
+    Textarea, one subnet per line. Validation (``pfb_validate_suppression_line()``,
+    ADR-53 P4): per non-comment line, the mask must fall in [/8, /32] AND
+    ``is_subnetv4`` must pass; either failure -> ``$input_errors`` -> the WHOLE save
+    aborts -> config UNCHANGED. STORAGE IS BASE64 (``base64_encode`` on save,
+    ``base64_decode`` on read), so the oracle compares config_get against base64 of
+    the expected textarea content. A valid '10.20.30.0/24' stores
+    base64('10.20.30.0/24'); a '/16' ('10.20.0.0/16') is now ALSO valid -- Phase 3's
+    iprange --except engine swap made suppression mask-agnostic, so Phase 4 lifted
+    the UI ceiling from /24 to /8, wider than the old /32-or-/24-only rule -- and
+    stores base64 of its own textarea; a '/7' ('10.20.0.0/7') is below the /8 floor
+    -> rejected -> config unchanged. An empty textarea stores base64('') = '' so
+    clearing/restoring to empty is clean. NO egress, NO reload.
     """
     import base64
 
@@ -652,14 +655,19 @@ def test_ip_v4suppression_mask_validation_base64_and_reject_unchanged(
     original = helpers.config_get(vm, cfg)
     try:
         assert original != valid_b64, f"v4suppression already holds {valid_text!r} (base64) before the valid POST"
-        # VALID /24 -> base64 of the textarea is stored.
+        # VALID /24 (the legacy-accepted shape) -> base64 of the textarea is stored.
         assert _post_and_get(webui, vm, IP_PAGE, {"v4suppression": valid_text}, cfg) == valid_b64
+        # VALID /16 -- NEW in ADR-53 P4: the widened /8-/32 range now accepts a
+        # containing-block mask that the pre-Phase-4 /32-or-/24-only rule rejected.
+        wide_text = "10.20.0.0/16"
+        wide_b64 = base64.b64encode(wide_text.encode()).decode()
+        assert _post_and_get(webui, vm, IP_PAGE, {"v4suppression": wide_text}, cfg) == wide_b64
         # Restore: an empty textarea stores base64('') = '' (clean clear).
         got_clear = _post_and_get(webui, vm, IP_PAGE, {"v4suppression": ""}, cfg)
         assert got_clear == "", f"clearing v4suppression should store '' (base64 of empty), got {got_clear!r}"
-        # REJECT: a /16 mask aborts the whole save -> config UNCHANGED (stays '').
-        got = _post_and_get(webui, vm, IP_PAGE, {"v4suppression": "10.20.0.0/16"}, cfg)
-        assert got == "", f"bogus /16 mask must leave v4suppression unchanged at '', got {got!r}"
+        # REJECT: a /7 is below the /8 floor -> aborts the whole save -> config UNCHANGED (stays '').
+        got = _post_and_get(webui, vm, IP_PAGE, {"v4suppression": "10.20.0.0/7"}, cfg)
+        assert got == "", f"below-floor /7 mask must leave v4suppression unchanged at '', got {got!r}"
     finally:
         # Restore whatever was there originally (re-encode if it was a plain capture
         # -- config_get returns the stored base64 verbatim, so re-post that decoded).

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -96,6 +96,7 @@ GENERAL_PAGE = "/pfblockerng/pfblockerng_general.php"
 IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
 SAFESEARCH_PAGE = "/pfblockerng/pfblockerng_safesearch.php"
 UPDATE_PAGE = "/pfblockerng/pfblockerng_update.php"
+WIDGET_PAGE = "/widgets/widgets/pfblockerng.widget.php"
 # DNSBL_PAGE is defined further down (used by the auto-VIP test too).
 
 FLOWS: tuple[ToggleFlow, ...] = (
@@ -729,6 +730,82 @@ def test_ip_v6suppression_mask_validation_base64_and_reject_unchanged(
             except Exception:
                 restore = ""
         webui.post(IP_PAGE, {"v6suppression": restore}, timeout=SAVE_TIMEOUT)
+
+
+def _widget_suppression_count(webui: WebUI) -> int:
+    """GET the widget's AJAX refresh endpoint and parse the ``Suppression||<n>||-`` line.
+
+    ``pfBlockerNG_get_header('js')`` (hit via ``?getNewWidget=1``, the same AJAX
+    path the dashboard widget's own JS polls) prints one ``<Type>||<value>||-``
+    line per stat -- plain text, no HTML markup to scrape, the cheapest way to
+    read the widget's Suppression count (ADR-53 P8: v4+v6 folded into one total,
+    ``pfblockerng.widget.php`` ~:720).
+    """
+    resp = webui.get(WIDGET_PAGE, params={"getNewWidget": "1"})
+    assert not looks_like_login_page(resp.text), "widget AJAX GET returned the login form (session lost)"
+    for line in resp.text.splitlines():
+        parts = line.split("||")
+        if parts and parts[0] == "Suppression":
+            return int(parts[1].replace(",", ""))
+    raise AssertionError(f"no 'Suppression||<n>||-' line in widget AJAX response: {resp.text!r}")
+
+
+def test_widget_suppression_count_folds_v4_and_v6(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The widget's Suppression stat is a v4+v6 TOTAL, not v4-only (ADR-53 P8).
+
+    Before ADR-53 P8, the widget read only v4suppression; a v6-only entry was
+    invisible in the stat. True transition test (CLAUDE.md before/after rule):
+    given ONE v4 entry seeded (count == 1, matching even the OLD v4-only
+    reader), THEN a v6 entry is ALSO seeded alongside it (v4 untouched) and the
+    count becomes 2 -- provable only if the widget folds v6suppression in too.
+    """
+    import base64
+
+    vm = smoke_vm
+    v4_cfg = "installedpackages/pfblockerngipsettings/config/0/v4suppression"
+    v6_cfg = "installedpackages/pfblockerngipsettings/config/0/v6suppression"
+    original_v4 = helpers.config_get(vm, v4_cfg)
+    original_v6 = helpers.config_get(vm, v6_cfg)
+    try:
+        # GIVEN: both families start empty.
+        webui.post(IP_PAGE, {"v4suppression": ""}, timeout=SAVE_TIMEOUT)
+        webui.post(IP_PAGE, {"v6suppression": ""}, timeout=SAVE_TIMEOUT)
+
+        # WHEN: one v4 entry is seeded -- BEFORE state.
+        webui.post(IP_PAGE, {"v4suppression": "203.0.113.9/32"}, timeout=SAVE_TIMEOUT)
+        count_v4_only = _widget_suppression_count(webui)
+        assert count_v4_only == 1, (
+            f"expected Suppression=1 with one v4 entry seeded (v6 still empty); widget reported {count_v4_only}"
+        )
+
+        # THEN: a v6 entry is ALSO seeded (v4 untouched -- webui.post() scrapes
+        # + re-posts the form's current fields, so the v4 textarea round-trips
+        # unchanged) -- the count must rise to 2, provable only if v6suppression
+        # is folded into the same stat.
+        webui.post(IP_PAGE, {"v6suppression": "2001:db8:53::9/128"}, timeout=SAVE_TIMEOUT)
+        count_v4_v6 = _widget_suppression_count(webui)
+        assert count_v4_v6 == 2, (
+            f"expected Suppression=2 after adding one v6 entry alongside the existing v4 one "
+            f"(ADR-53 P8 v4+v6 fold-in); widget reported {count_v4_v6} -- stayed v4-only if this held at 1"
+        )
+    finally:
+        restore_v4 = ""
+        if original_v4:
+            try:
+                restore_v4 = base64.b64decode(original_v4).decode()
+            except Exception:
+                restore_v4 = ""
+        restore_v6 = ""
+        if original_v6:
+            try:
+                restore_v6 = base64.b64decode(original_v6).decode()
+            except Exception:
+                restore_v6 = ""
+        webui.post(IP_PAGE, {"v4suppression": restore_v4}, timeout=SAVE_TIMEOUT)
+        webui.post(IP_PAGE, {"v6suppression": restore_v6}, timeout=SAVE_TIMEOUT)
 
 
 def test_ip_asn_reporting_select_coerces_bogus_to_disabled(

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -72,10 +72,12 @@ PAGE_TABLE: tuple[Page, ...] = (
     Page("general", "/pfblockerng/pfblockerng_general.php", ("pfBlockerNG", "General Settings")),
     # "Aggregated Aliases" is the ADR-11 pfb_agg_types multi-select label (rendered
     # verbatim) — a third marker so the gate also proves that field renders on the IP page.
+    # "IPv6 Suppression" is the ADR-53 Phase 6 section title (the v6 sibling of the
+    # pre-existing "IPv4 Suppression" section) — proves the new section renders.
     Page(
         "ip",
         "/pfblockerng/pfblockerng_ip.php",
-        ("IP Configuration", "ASN configuration", "Aggregated Aliases", "Alias Table Apply Mode"),
+        ("IP Configuration", "ASN configuration", "Aggregated Aliases", "Alias Table Apply Mode", "IPv6 Suppression"),
     ),
     # "DNS Redirect" is the ADR-36 section title added to this page (Phase 3).
     # "DoT/DoQ Block" is the ADR-37 section title added to this page (Phase 3).
@@ -304,6 +306,23 @@ def test_ip_page_renders_aggregate_select(webui: WebUI) -> None:
     assert _AGG_HELP_CAVEAT in body, (
         f"pfb_agg_types help caveat {_AGG_HELP_CAVEAT!r} (the no-rule wording) not rendered on the IP page"
     )
+
+
+def test_ip_page_renders_v6_suppression_section(webui: WebUI) -> None:
+    """The IP page renders the new IPv6 Suppression section (ADR-53 Phase 6).
+
+    Hermetic (no network — the IP page renders from local config alone). GET the
+    page and assert: (1) the 'IPv6 Suppression' Form_Section title renders; (2) the
+    v6suppression textarea field is present. Pairs with the pre-existing 'IPv4
+    Suppression' section (also asserted here, unchanged by this phase) — proving the
+    v6 sibling section renders ALONGSIDE it, not instead of it.
+    """
+    resp = webui.get(_IP_PAGE)
+    assert resp.status_code == 200, f"GET {_IP_PAGE} -> HTTP {resp.status_code} (expected 200)"
+    body = resp.text
+    assert "IPv6 Suppression" in body, "IPv6 Suppression section title not rendered on the IP page"
+    assert 'name="v6suppression"' in body, "v6suppression textarea not rendered on the IP page"
+    assert "IPv4 Suppression" in body, "IPv4 Suppression section title (existing sibling) missing"
 
 
 _UPDATE_PAGE = "/pfblockerng/pfblockerng_update.php"


### PR DESCRIPTION
## ADR-53: Replace the IP-suppression host-explosion with CIDR set-subtraction (v4+v6 parity)

Implements `.ADRs/ADR_53_IP_Suppression_Set_Subtraction/ADR.md` (all 9 phases). Closes the mechanism half of #422.

### What changes

- **v4 engine** (`pfblockerng.sh suppress()`): the `grep -F` + `seq 255` host-explosion is replaced by a single `iprange --except` set-subtraction with covering-CIDR output — a `/24` hole costs 8 entries instead of 254, a `/8` hole costs 24, and the previously **silent no-op** on containing entries (a suppressed host inside a feed-listed `/16` stayed blocked with no warning) is fixed. Inputs are pre-filtered to strict IP/CIDR shape (iprange DNS-resolves malformed tokens with `rc=0` — probed live), and the publish is rc-gated + atomic (empty result = legitimate full suppression).
- **v6 parity** (new): `v6suppression` config key (registered blob) + UI textarea, `pfbsuppression_v6.txt`, and a pure-PHP 128-bit set-subtraction engine (`pfb_cidr_subtract_v6` / `pfb_suppress_file_v6`, emitting via pfSense's own `ip_range_to_subnet_array()`), wired into the `_v6` alias-build path under the same gates as v4. Measured 1.24 s on a 100 k-line member file (ADR §7 bound: < 5 s).
- **Mask ceiling lifted**: v4 accepts `/8`–`/32`, v6 `/32`–`/128`, via a pure, PHPUnit-tested validator (`pfb_validate_suppression_line`).
- **Alerts "+" / widget**: live punch reworked to covering-CIDR deltas (`pfb_live_punch_plan`), any containing mask, both families; the 254-host re-add loop and the "blocked by a CIDR other than /24" refusal are gone.
- **killstates**: suppression exclusion is prefix-aware (`pfb_ip_suppressed`), both families — a state inside a suppressed `/16` is no longer killed.
- **Config gateway**: `v4suppression` + `v6suppression` registered (plain blobs); raw call sites migrated; sniff `$registeredPaths` updated.

### Bugs found by the live smoke during validation (fixed in the final commit)

1. `pfctl -T test` prints its verdict on **stderr** — the new Python oracles read stdout only.
2. The reworked alerts "+" stored a shell-quoted IP in the config (`'1.2.3.4'/32`) — `pfb_filter(..., TRUE)` returns an `escapeshellarg()`'d token.
3. The v6 engine rejected **bare host tokens** (no `/mask` — the dominant feed shape) as malformed and dropped them from the member file (fail-open). A bare address now parses as its own `/128`.

### Validation

- Off-appliance: PHPUnit (+58 tests incl. red→green vectors per phase), shellspec suppress() oracle (flipped red→green for the carve), pytest, PHPCS/PHPStan/ruff/mypy all green.
- Live, **CE + Plus fan-out green** (acceptance evidence per ADR §7): smoke run 28678906679 — `test_smoke_suppression.py` (v4 `/16` carve, v6 `/64` carve, bare-host + legacy `/24` parity, before-state asserted first) green on both legs; UI run 28678907701 — functional (alerts "+" e2e, v6 textarea save-persist) and render (IP page + v6 section) green on both legs. The UI run's browser-tier legs report pytest rc=5 (zero tests collected — the `-k suppress` filter matches no browser-tier test; ADR-53 adds none), not a test failure. Min-CE validation leg: run 28678721902 green.

Part of #422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016atQbcuVhafvo7SHvWkxdK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IPv6 suppression support alongside IPv4.
  * Expanded suppression handling to work with broader CIDR ranges and exact hosts.
  * Improved live “add suppress” behavior to carve entries more accurately in both IPv4 and IPv6.
  * Updated the widget to show combined suppression counts.

* **Bug Fixes**
  * Fixed suppression-related state handling and file updates for empty or missing values.
  * Improved validation so invalid suppression entries are rejected more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->