### PR TITLE
tests/smoke: distinguish a locked/busy DB from an absent Upstream row

### DIFF
--- a/tests/smoke/test_smoke_upstream_block.py
+++ b/tests/smoke/test_smoke_upstream_block.py
@@ -349,51 +349,91 @@ _CTR_OPEN = "<<<UPCTR>>>"
 _CTR_CLOSE = "<<<UPEND>>>"
 
 
-def _read_upstream_counter(vm: SmokeVM) -> int:
+def _parse_counter_output(out: str) -> tuple[int, str]:
+    """Parse ``_read_upstream_counter``'s delimited pfSsh.php output.
+
+    Issue #767: the on-box read must distinguish a genuinely ABSENT ``Upstream``
+    row from a READ ERROR (e.g. a transient ``SQLITE_BUSY`` while the chrooted
+    Python module holds the DB open in WAL mode) — collapsing both to the same
+    sentinel misdirects a failure straight at the Python DB-init seed.
+
+    Returns ``(value, detail)``:
+
+    * ``value == -1`` — the row is genuinely absent (``querySingle`` returned
+      ``NULL``); ``detail`` is empty.
+    * ``value == -2`` — the read ERRORED (a thrown exception, ``querySingle``
+      returning ``FALSE``, a missing/unparsable payload, or a non-integer
+      value); ``detail`` explains why, non-empty.
+    * ``value >= 0`` — the counter itself; ``detail`` is empty.
+    """
+    start = out.find(_CTR_OPEN)
+    end = out.find(_CTR_CLOSE)
+    if start == -1 or end == -1:
+        return -2, f"no delimited counter in pfSsh.php output: {out[-500:]!r}"
+    payload = out[start + len(_CTR_OPEN) : end]
+    if "|" not in payload:
+        return -2, f"unparsable counter payload (no '|' separator): {payload!r}"
+    value_str, _, message = payload.partition("|")
+    try:
+        value = int(value_str)
+    except ValueError:
+        return -2, f"non-integer counter value {value_str!r} in payload {payload!r}"
+    return value, message
+
+
+def _read_upstream_counter(vm: SmokeVM) -> tuple[int, str]:
     """Read the ``counter`` of the ``Upstream`` row from the on-box dnsbl SQLite DB.
 
     Uses pfSsh.php (PHP + the SQLite3 class the package itself runs on), NOT a python
     one-liner: the appliance ships ``python3.11`` with no ``python3`` symlink, so a
     ``python3 -c`` read is not portable. Reads the same ``/var/unbound/pfb_py_dnsbl.sqlite``
     the chrooted Python module writes. The value is delimited so pfSsh.php's startup
-    banner does not pollute it. Returns the integer counter, or -1 when the row is
-    absent or the DB/table cannot be read.
+    banner does not pollute it.
+
+    A transient ``SQLITE_BUSY`` (the chrooted Python module writes the same DB in
+    WAL mode with a 100 s busy_timeout — see ``pfb_unbound.py``) is absorbed by
+    SQLite's own bounded ``busyTimeout``, not a caller-side sleep loop; a lock held
+    past that timeout still surfaces, loudly, as a read error.
+
+    Returns ``(-1, "")`` when the row is genuinely absent, ``(-2, detail)`` when
+    the read errored, else ``(counter, "")``. See ``_parse_counter_output``.
     """
     snippet = (
-        "$__c = -1;\n"
+        "$__c = -1; $__m = '';\n"
         "try {\n"
         f"    $__db = new SQLite3('{_DNSBL_DB}');\n"
+        "    $__db->enableExceptions(TRUE);\n"
+        "    $__db->busyTimeout(15000);\n"
         "    $__r = $__db->querySingle(\"SELECT counter FROM dnsbl WHERE groupname = 'Upstream'\");\n"
-        "    $__c = ($__r === null || $__r === FALSE) ? -1 : (int) $__r;\n"
+        "    if ($__r === NULL) { $__c = -1; }\n"
+        "    elseif ($__r === FALSE) { $__c = -2; $__m = 'querySingle returned FALSE'; }\n"
+        "    else { $__c = (int) $__r; }\n"
         "    $__db->close();\n"
-        "} catch (Throwable $__e) { $__c = -1; }\n"
-        f"echo '{_CTR_OPEN}' . $__c . '{_CTR_CLOSE}';\n"
+        "} catch (Throwable $__e) { $__c = -2; $__m = $__e->getMessage(); }\n"
+        f"echo '{_CTR_OPEN}' . $__c . '|' . $__m . '{_CTR_CLOSE}';\n"
     )
     out = h.php_eval(vm, snippet).stdout or ""
-    start = out.find(_CTR_OPEN)
-    end = out.find(_CTR_CLOSE)
-    if start == -1 or end == -1:
-        return -1
-    try:
-        return int(out[start + len(_CTR_OPEN) : end])
-    except ValueError:
-        return -1
+    return _parse_counter_output(out)
 
 
-def _wait_for_counter_above(vm: SmokeVM, baseline: int, *, timeout_s: float = 30.0, poll_s: float = 2.0) -> int:
+def _wait_for_counter_above(
+    vm: SmokeVM, baseline: int, *, timeout_s: float = 30.0, poll_s: float = 2.0
+) -> tuple[int, str]:
     """Poll the on-box Upstream dnsbl counter until it exceeds ``baseline`` or the deadline expires.
 
     The counter is flushed by the async db_worker thread, so a freshly-logged block
     does not appear instantly.  Bounded polling matches the log-line polling pattern
-    used by ``_wait_for_upstream_block_lines``.
+    used by ``_wait_for_upstream_block_lines``. A transient read error (-2, e.g. a
+    lock race) is polled through like any other non-matching value — the deadline
+    already bounds it.
 
-    Returns the final observed counter value (may equal ``baseline`` on timeout).
+    Returns the final observed ``(value, detail)`` (may equal ``baseline`` on timeout).
     """
     deadline = time.monotonic() + timeout_s
-    current = baseline
+    current: tuple[int, str] = (baseline, "")
     while time.monotonic() < deadline:
         current = _read_upstream_counter(vm)
-        if current > baseline:
+        if current[0] > baseline:
             return current
         time.sleep(poll_s)
     return current
@@ -423,8 +463,14 @@ class TestUpstreamCounterIncrement:
         stub_dns.register_nxdomain(name)  # RA=0, AA=0 -> NXRA block
 
         # Before: record the baseline counter (row may already have a count from
-        # earlier tests in this session).
-        baseline = _read_upstream_counter(vm)
+        # earlier tests in this session). Issue #767: distinguish a READ ERROR
+        # (e.g. a transient SQLITE_BUSY lock race with the Python writer) from a
+        # genuinely ABSENT row — conflating the two misdirects the failure at the
+        # DB-init seed for what is most likely a transient lock/read error.
+        baseline, baseline_detail = _read_upstream_counter(vm)
+        assert baseline != -2, (
+            f"Upstream counter read ERRORED (NOT an absent row — do not blame the seed): {baseline_detail}"
+        )
         assert baseline >= 0, (
             "Upstream row not found in dnsbl table before probe — "
             "the Python DB-init seed (_db_create) did not create it. "
@@ -445,9 +491,9 @@ class TestUpstreamCounterIncrement:
         )
 
         # Then: wait for the async flush and assert strict increase.
-        final = _wait_for_counter_above(vm, baseline)
+        final, final_detail = _wait_for_counter_above(vm, baseline)
         assert final > baseline, (
             f"Upstream counter did not increase after NXRA block: "
-            f"baseline={baseline}, final={final}. "
+            f"baseline={baseline}, final={final} (detail={final_detail!r}). "
             f"Detection fired (log line present), so the enqueue or flush may be broken."
         )

--- a/tests/smoke/test_smoke_upstream_block.py
+++ b/tests/smoke/test_smoke_upstream_block.py
@@ -390,10 +390,11 @@ def _read_upstream_counter(vm: SmokeVM) -> tuple[int, str]:
     the chrooted Python module writes. The value is delimited so pfSsh.php's startup
     banner does not pollute it.
 
-    A transient ``SQLITE_BUSY`` (the chrooted Python module writes the same DB in
-    WAL mode with a 100 s busy_timeout — see ``pfb_unbound.py``) is absorbed by
-    SQLite's own bounded ``busyTimeout``, not a caller-side sleep loop; a lock held
-    past that timeout still surfaces, loudly, as a read error.
+    A transient ``SQLITE_BUSY`` (e.g. WAL recovery, or a rollback-journal fallback
+    when the module's WAL pragma did not take — ``_db_connect`` in ``pfb_unbound.py``
+    swallows pragma failures) is absorbed by SQLite's own bounded ``busyTimeout``,
+    not a caller-side sleep loop; a lock held past that timeout still surfaces,
+    loudly, as a read error.
 
     Returns ``(-1, "")`` when the row is genuinely absent, ``(-2, detail)`` when
     the read errored, else ``(counter, "")``. See ``_parse_counter_output``.
@@ -408,12 +409,16 @@ def _read_upstream_counter(vm: SmokeVM) -> tuple[int, str]:
         "    if ($__r === NULL) { $__c = -1; }\n"
         "    elseif ($__r === FALSE) { $__c = -2; $__m = 'querySingle returned FALSE'; }\n"
         "    else { $__c = (int) $__r; }\n"
-        "    $__db->close();\n"
+        "    try { $__db->close(); } catch (Throwable $__ignored) {}\n"
         "} catch (Throwable $__e) { $__c = -2; $__m = $__e->getMessage(); }\n"
         f"echo '{_CTR_OPEN}' . $__c . '|' . $__m . '{_CTR_CLOSE}';\n"
     )
-    out = h.php_eval(vm, snippet).stdout or ""
-    return _parse_counter_output(out)
+    res = h.php_eval(vm, snippet)
+    if res.returncode != 0:
+        # A transport/pfSsh.php failure is a read ERROR — surface the stderr instead
+        # of collapsing it into the generic "no delimited counter" parse detail.
+        return -2, f"php_eval failed (rc={res.returncode}): stderr={res.stderr[-500:]!r}"
+    return _parse_counter_output(res.stdout or "")
 
 
 def _wait_for_counter_above(
@@ -469,7 +474,7 @@ class TestUpstreamCounterIncrement:
         # DB-init seed for what is most likely a transient lock/read error.
         baseline, baseline_detail = _read_upstream_counter(vm)
         assert baseline != -2, (
-            f"Upstream counter read ERRORED (NOT an absent row — do not blame the seed): {baseline_detail}"
+            f"Upstream counter read ERRORED (NOT an absent row — do not blame the seed): {baseline_detail!r}"
         )
         assert baseline >= 0, (
             "Upstream row not found in dnsbl table before probe — "
@@ -490,10 +495,16 @@ class TestUpstreamCounterIncrement:
             f"Log excerpt:\n{_read_dnsbl_log(vm)[-2000:]}"
         )
 
-        # Then: wait for the async flush and assert strict increase.
+        # Then: wait for the async flush and assert strict increase. A read that is
+        # still ERRORED at the deadline is a read problem, not a stuck counter — keep
+        # the two failure modes distinct here too (mirrors the baseline assert).
         final, final_detail = _wait_for_counter_above(vm, baseline)
+        assert final != -2, (
+            f"Upstream counter read ERRORED while waiting for the increase "
+            f"(NOT a stuck counter — do not blame the enqueue/flush): {final_detail!r}"
+        )
         assert final > baseline, (
             f"Upstream counter did not increase after NXRA block: "
-            f"baseline={baseline}, final={final} (detail={final_detail!r}). "
+            f"baseline={baseline}, final={final}. "
             f"Detection fired (log line present), so the enqueue or flush may be broken."
         )

--- a/tests/test_upstream_counter_read.py
+++ b/tests/test_upstream_counter_read.py
@@ -21,6 +21,13 @@ error is -2 with a non-empty detail, and a genuine counter is >= 0.
 
 from __future__ import annotations
 
+import subprocess
+from typing import cast
+
+import pytest
+
+from tests.smoke import test_smoke_upstream_block as upstream_mod
+from tests.smoke.conftest import SmokeVM
 from tests.smoke.test_smoke_upstream_block import _CTR_CLOSE, _CTR_OPEN, _parse_counter_output
 
 
@@ -71,3 +78,17 @@ def test_non_integer_value_is_a_read_error_with_detail() -> None:
     value, detail = _parse_counter_output(out)
     assert value == -2
     assert "not-a-number" in detail
+
+
+def test_php_eval_transport_failure_is_a_read_error_carrying_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A nonzero php_eval returncode (SSH/pfSsh.php transport failure) -> -2 with the
+    stderr in the detail — not the generic "no delimited counter" parse message."""
+
+    def fake_php_eval(vm: SmokeVM, snippet: str, *, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=255, stdout="", stderr="ssh: connect refused")
+
+    monkeypatch.setattr(upstream_mod.h, "php_eval", fake_php_eval)
+    value, detail = upstream_mod._read_upstream_counter(cast(SmokeVM, object()))
+    assert value == -2
+    assert "rc=255" in detail
+    assert "ssh: connect refused" in detail

--- a/tests/test_upstream_counter_read.py
+++ b/tests/test_upstream_counter_read.py
@@ -1,0 +1,73 @@
+"""Issue #767 — the Upstream dnsbl-counter parse layer must distinguish an
+ABSENT row from a READ ERROR, so a transient lock/race (e.g. SQLITE_BUSY while
+the chrooted Python module holds the DB open in WAL mode) is never misreported
+as a regression in the Python DB-init seed (``_db_create``).
+
+Pins ``_parse_counter_output`` (``tests/smoke/test_smoke_upstream_block.py``),
+the pure parse function extracted from ``_read_upstream_counter`` so it is
+unit-testable off-appliance — same precedent as ``test_smoke_diag_redaction.py``
+importing from ``tests.smoke.helpers``. ``tests/smoke`` is ``--ignore``d by the
+default ``python -m pytest`` run (see ``pyproject.toml``), but importing a
+symbol from it works fine.
+
+RED -> GREEN evidence: before this change, ``_parse_counter_output`` did not
+exist at all (the import below would raise ``ImportError``) and the inline
+parsing in ``_read_upstream_counter`` returned the single sentinel ``-1`` for
+EVERY failure case (absent row, ``querySingle`` returning ``FALSE``, a thrown
+exception, and missing/unparsable pfSsh.php delimiters alike) — so a caller
+could never tell "no row" from "read blew up". Post-change, absence is -1,
+error is -2 with a non-empty detail, and a genuine counter is >= 0.
+"""
+
+from __future__ import annotations
+
+from tests.smoke.test_smoke_upstream_block import _CTR_CLOSE, _CTR_OPEN, _parse_counter_output
+
+
+def test_valid_counter_parses_to_int_with_no_detail() -> None:
+    out = f"{_CTR_OPEN}7|{_CTR_CLOSE}"
+    assert _parse_counter_output(out) == (7, "")
+
+
+def test_valid_counter_survives_pfssh_banner_noise_around_the_delimiters() -> None:
+    out = f"pfSsh.php shell (WELCOME)\nsome banner text\n{_CTR_OPEN}42|{_CTR_CLOSE}\ntrailing noise"
+    assert _parse_counter_output(out) == (42, "")
+
+
+def test_absent_row_parses_to_negative_one_with_no_detail() -> None:
+    """querySingle() returning NULL (no matching row) -> -1, not an error."""
+    out = f"{_CTR_OPEN}-1|{_CTR_CLOSE}"
+    assert _parse_counter_output(out) == (-1, "")
+
+
+def test_error_sentinel_carries_its_message() -> None:
+    """A thrown SQLITE_BUSY (or any Throwable) -> -2 with the exception detail."""
+    out = f"{_CTR_OPEN}-2|database is locked{_CTR_CLOSE}"
+    assert _parse_counter_output(out) == (-2, "database is locked")
+
+
+def test_message_containing_extra_pipes_splits_on_the_first_only() -> None:
+    out = f"{_CTR_OPEN}-2|SQLSTATE[HY000]: General error: 5 database is locked{_CTR_CLOSE}"
+    assert _parse_counter_output(out) == (-2, "SQLSTATE[HY000]: General error: 5 database is locked")
+
+
+def test_missing_delimiters_is_a_read_error_not_an_absent_row() -> None:
+    """A pfSsh.php transport failure (banner only, no payload) must not collapse to -1."""
+    out = "pfSsh.php shell (WELCOME)\nno counter payload here"
+    value, detail = _parse_counter_output(out)
+    assert value == -2
+    assert detail  # must name what went wrong, not just fail silently
+    assert "no counter payload here" in detail
+
+
+def test_empty_output_is_a_read_error() -> None:
+    value, detail = _parse_counter_output("")
+    assert value == -2
+    assert detail
+
+
+def test_non_integer_value_is_a_read_error_with_detail() -> None:
+    out = f"{_CTR_OPEN}not-a-number|garbled{_CTR_CLOSE}"
+    value, detail = _parse_counter_output(out)
+    assert value == -2
+    assert "not-a-number" in detail


### PR DESCRIPTION
Fixes #767.

`_read_upstream_counter` collapsed every failure — absent row, `querySingle` returning `FALSE`, a thrown `SQLITE_BUSY`, and missing pfSsh.php delimiters — into the same `-1` sentinel, so a transient lock race with the chrooted Python writer (WAL mode, 100 s busy_timeout on its side) misdirected the baseline assertion straight at the Python DB-init seed. A real CI flake (run 28676021702) produced exactly that misleading diagnostic; the immediate re-run passed 29/29.

## Changes

- **PHP snippet**: `enableExceptions(TRUE)` so errors throw deterministically, plus `busyTimeout(15000)` — SQLite's own bounded lock wait absorbs a transient writer lock without a caller-side sleep loop; a lock held past the timeout still surfaces loudly. The payload is now `counter|message`: `-1` = row genuinely absent (`querySingle` returned `NULL`), `-2` = read errored with the exception message captured.
- **New pure `_parse_counter_output()`**: extracted from `_read_upstream_counter` so the parse layer is unit-testable off-appliance. Missing/unparsable delimiters (a pfSsh transport failure) now map to `-2` with detail — previously that also collapsed to `-1`.
- **Callers**: the baseline assertion now distinguishes "read ERRORED (do not blame the seed): <detail>" from "row absent — the seed did not create it"; `_wait_for_counter_above` polls through a transient `-2` (deadline-bounded as before) and the final strict-increase assertion includes the error detail.
- **Unit tests** (`tests/test_upstream_counter_read.py`, runs in the default suite): every parse branch — valid counter (bare + banner noise), absent row, error sentinel with message, message containing extra `|`, missing delimiters, empty output, non-integer value. Red→green: `_parse_counter_output` did not exist before this change (the import fails on the pre-change tree).

## Gates

- `python -m pytest` — 2083 passed, 4 skipped
- `ruff check .` / `ruff format --check .` — clean
- `mypy tests/` — clean

The smoke test itself is dispatch-only (live-VM); this PR changes only its read/diagnostic layer plus the new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of upstream counter checks so transient read errors are handled separately from a missing counter value.
  * Made upstream block verification more accurate, with clearer failure messages when the counter does not increase as expected.
* **Tests**
  * Added coverage for counter parsing across valid values, absent-row cases, read errors, and malformed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->