### PR TITLE
tests/smoke: reboot after ramdisk-off in the boot_reload + dnsbl_ramdisk teardowns

### DIFF
--- a/tests/smoke/test_smoke_boot_reload.py
+++ b/tests/smoke/test_smoke_boot_reload.py
@@ -100,6 +100,11 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     try:
         yield smoke_vm
     finally:
+        # Diagnostics FIRST: the revert reboot below wipes the MFS /var this module ran
+        # on, so a snapshot taken after it would show a fresh disk-backed /var instead
+        # of the module's (possibly failing) end-of-run state.
+        h.unblock_egress()
+        h.collect_host_diagnostics(smoke_vm)
         # Leave RAM disks OFF and rebuild the aliases the reboot may have dropped, so
         # the box is left in a known-good state. Best-effort — never mask the result.
         # The reboot is REQUIRED (issue #765): set_ramdisk only flips the config flag,
@@ -110,9 +115,7 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
             h.reload(smoke_vm, "update")
             h.reboot_vm(smoke_vm)
         except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the test result
-            print(f"[smoke] reboot teardown reload failed (non-fatal): {exc}")
-        h.unblock_egress()
-        h.collect_host_diagnostics(smoke_vm)
+            print(f"[smoke] ramdisk-off teardown failed (non-fatal): {exc}")
 
 
 @pytest.fixture(scope="module", params=[False, True], ids=["standard", "ramdisk"])

--- a/tests/smoke/test_smoke_boot_reload.py
+++ b/tests/smoke/test_smoke_boot_reload.py
@@ -102,9 +102,13 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     finally:
         # Leave RAM disks OFF and rebuild the aliases the reboot may have dropped, so
         # the box is left in a known-good state. Best-effort — never mask the result.
+        # The reboot is REQUIRED (issue #765): set_ramdisk only flips the config flag,
+        # so without it the running /var stays MFS and every module that runs after this
+        # one on the shared session VM inherits writes that vanish on the next reboot.
         try:
             h.set_ramdisk(smoke_vm, False)
             h.reload(smoke_vm, "update")
+            h.reboot_vm(smoke_vm)
         except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the test result
             print(f"[smoke] reboot teardown reload failed (non-fatal): {exc}")
         h.unblock_egress()

--- a/tests/smoke/test_smoke_boot_reload.py
+++ b/tests/smoke/test_smoke_boot_reload.py
@@ -113,9 +113,14 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
         try:
             h.set_ramdisk(smoke_vm, False)
             h.reload(smoke_vm, "update")
-            h.reboot_vm(smoke_vm)
         except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the test result
             print(f"[smoke] ramdisk-off teardown failed (non-fatal): {exc}")
+        # Own try: a flaky reload above must not skip the reboot — with the flag already
+        # flipped off, the reboot alone completes the MFS-to-disk transition.
+        try:
+            h.reboot_vm(smoke_vm)
+        except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the test result
+            print(f"[smoke] ramdisk-off teardown reboot failed (non-fatal): {exc}")
 
 
 @pytest.fixture(scope="module", params=[False, True], ids=["standard", "ramdisk"])

--- a/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
+++ b/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
@@ -73,9 +73,13 @@ def dnsbl_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]: 
     try:
         yield smoke_vm
     finally:
+        # The reboot is REQUIRED (issue #765): set_ramdisk only flips the config flag,
+        # so without it the running /var stays MFS and every module that runs after this
+        # one on the shared session VM inherits writes that vanish on the next reboot.
         try:
             h.set_ramdisk(smoke_vm, False)
             h.reload(smoke_vm, "update")
+            h.reboot_vm(smoke_vm)
         except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the result
             print(f"[smoke] #468 teardown reload failed (non-fatal): {exc}")
         h.unblock_egress()

--- a/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
+++ b/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
@@ -84,9 +84,14 @@ def dnsbl_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]: 
         try:
             h.set_ramdisk(smoke_vm, False)
             h.reload(smoke_vm, "update")
-            h.reboot_vm(smoke_vm)
         except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the result
             print(f"[smoke] #468 ramdisk-off teardown failed (non-fatal): {exc}")
+        # Own try: a flaky reload above must not skip the reboot — with the flag already
+        # flipped off, the reboot alone completes the MFS-to-disk transition.
+        try:
+            h.reboot_vm(smoke_vm)
+        except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the result
+            print(f"[smoke] #468 ramdisk-off teardown reboot failed (non-fatal): {exc}")
 
 
 @pytest.fixture(scope="module")

--- a/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
+++ b/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
@@ -73,6 +73,11 @@ def dnsbl_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]: 
     try:
         yield smoke_vm
     finally:
+        # Diagnostics FIRST: the revert reboot below wipes the MFS /var this module ran
+        # on, so a snapshot taken after it would show a fresh disk-backed /var instead
+        # of the module's (possibly failing) end-of-run state.
+        h.unblock_egress()
+        h.collect_host_diagnostics(smoke_vm)
         # The reboot is REQUIRED (issue #765): set_ramdisk only flips the config flag,
         # so without it the running /var stays MFS and every module that runs after this
         # one on the shared session VM inherits writes that vanish on the next reboot.
@@ -81,9 +86,7 @@ def dnsbl_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]: 
             h.reload(smoke_vm, "update")
             h.reboot_vm(smoke_vm)
         except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the result
-            print(f"[smoke] #468 teardown reload failed (non-fatal): {exc}")
-        h.unblock_egress()
-        h.collect_host_diagnostics(smoke_vm)
+            print(f"[smoke] #468 ramdisk-off teardown failed (non-fatal): {exc}")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

Closes the state leak at its source (issue #765, surfaced by the adversarial review on PR #763): the `deployed_vm` teardown in `tests/smoke/test_smoke_boot_reload.py` and the `dnsbl_vm` teardown in `tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py` reverted RAM disks with `set_ramdisk(vm, False)` + `reload(vm, "update")` and no reboot. `set_ramdisk` only flips the `use_mfs_tmpvar` config flag — the running /var stays mounted as MFS until the next reboot — so every module running after either of them on the shared session VM inherited a live MFS /var whose writes vanish on the next reboot (the order-dependence that broke `test_tick_reboot_persists_ledger`, #762).

## Change

Add `h.reboot_vm(smoke_vm)` to both module teardowns after the `set_ramdisk(False)` + reload, inside the existing best-effort `try` — the same shape as the `mfs_var` fixture teardown PR #763 added to `tests/smoke/test_smoke_tick.py`. PR #763 made the tick test self-encapsulated (per-consumer defence); this closes the leak at the source.

Cost: one extra reboot (~90–150 s) per module teardown on the legs that enabled RAM disks.

## Testing

- `ruff check .` / `ruff format --check` — clean
- `mypy tests/` — clean
- `python -m pytest` — 2084 passed, 4 skipped (smoke modules are dispatch-only; unit suite unaffected)
- Live-VM validation: selective smoke dispatch of the two changed modules from this branch (scope=impacted auto-derives them)

The red case is the already-documented #762 failure history (inter-module leak on the shared session VM); the teardown fix is validated by the changed modules staying green on the live VM with the reboot in place.

Fixes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3aGLFmd8VeHoa9zZ7j5af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup in smoke test environments by fully rebooting virtual machines after temporary disk settings are changed, helping prevent leftover state from affecting later runs.
  * Added safer teardown handling so non-critical cleanup failures are logged and test cleanup continues with diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->