### PR TITLE
pfb_unbound: log _db_connect PRAGMA failures and non-WAL fallback

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2305,12 +2305,24 @@ def _db_create(db: int, cursor: Any) -> None:
 
 def _db_connect(db: int) -> Any:
     con = sqlite3.connect(_db_file(db), timeout=100000, check_same_thread=False)
+    # A silently-failed PRAGMA leaves the connection on SQLite defaults -- most
+    # importantly rollback-journal instead of WAL, where a writer's commit blocks
+    # concurrent readers (issue #771). The connection still works, so don't fail
+    # the connect -- but the fallback must be visible in the log.
     try:
-        con.execute("PRAGMA journal_mode=WAL")
+        # PRAGMA journal_mode=WAL returns the mode actually in effect; a non-'wal'
+        # result is a silent downgrade (no exception), so read it back and warn.
+        row = con.execute("PRAGMA journal_mode=WAL").fetchone()
         con.execute("PRAGMA busy_timeout=100000")
         con.execute("PRAGMA synchronous=NORMAL")
-    except Exception:
-        pass
+        mode = str(row[0]).lower() if row else ""
+        if mode != "wal":
+            sys.stderr.write(
+                "[pfBlockerNG]: sqlite journal_mode is '{}' (wanted 'wal') db {}:"
+                " concurrent readers may hit 'database is locked'\n".format(mode, _db_file(db))
+            )
+    except Exception as e:
+        sys.stderr.write("[pfBlockerNG]: sqlite PRAGMA setup failed db {}: {}\n".format(_db_file(db), e))
     _db_create(db, con.cursor())
     con.commit()
     return con

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -535,6 +535,90 @@ class TestDbSubsystem:
         con = pfb_unbound._db_conns[pfb_unbound.DB_RESOLVER]
         assert con.execute("SELECT totalqueries FROM resolver WHERE row = 0").fetchone()[0] == 10
 
+    # -- issue #771: _db_connect PRAGMA observability ----------------------------
+
+    def test_connect_wal_active_and_silent(self, tmp_path: Any, capsys: Any) -> None:
+        """Healthy connect: WAL is granted on a file db and nothing is logged --
+        the warning paths below are real branches, not always-on noise."""
+        self._resolver(tmp_path)
+        con = pfb_unbound._db_connect(pfb_unbound.DB_RESOLVER)
+        try:
+            mode = con.execute("PRAGMA journal_mode").fetchone()[0]
+        finally:
+            con.close()
+        err = capsys.readouterr().err
+        assert str(mode).lower() == "wal", f"expected journal_mode 'wal', got '{mode}'"
+        assert "[pfBlockerNG]" not in err, f"expected silent healthy connect, stderr was: {err!r}"
+
+    def test_connect_logs_pragma_failure_and_still_initialises(
+        self, tmp_path: Any, monkeypatch: Any, capsys: Any
+    ) -> None:
+        """A failing connection PRAGMA must be logged, never silently swallowed
+        (issue #771: the silent rollback-journal fallback was invisible), while the
+        connect itself still completes (tables created + seeded)."""
+        import sqlite3
+
+        self._resolver(tmp_path)
+        real_connect = sqlite3.connect
+
+        class _PragmaRefusingCon:
+            def __init__(self, real: Any) -> None:
+                self._real = real
+
+            def execute(self, sql: str, *args: Any) -> Any:
+                if sql.lstrip().upper().startswith("PRAGMA"):
+                    raise sqlite3.OperationalError("pragma refused by test")
+                return self._real.execute(sql, *args)
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(self._real, name)
+
+        monkeypatch.setattr(pfb_unbound.sqlite3, "connect", lambda *a, **k: _PragmaRefusingCon(real_connect(*a, **k)))
+        con = pfb_unbound._db_connect(pfb_unbound.DB_RESOLVER)
+        err = capsys.readouterr().err
+        try:
+            assert "PRAGMA setup failed" in err and "pragma refused by test" in err, (
+                f"expected a PRAGMA-failure log line with the exception text, stderr was: {err!r}"
+            )
+            # Connect survived the pragma failure: table created and seed row present.
+            assert con.execute("SELECT totalqueries FROM resolver WHERE row = 0").fetchone()[0] == 0
+        finally:
+            con.close()
+
+    def test_connect_warns_when_wal_not_granted(self, tmp_path: Any, monkeypatch: Any, capsys: Any) -> None:
+        """SQLite can decline WAL without raising -- PRAGMA journal_mode=WAL returns
+        the mode actually in effect. A non-'wal' result must produce a warning naming
+        the effective mode, so a lock-contention flake is diagnosable (issue #771)."""
+        import sqlite3
+
+        self._resolver(tmp_path)
+        real_connect = sqlite3.connect
+
+        class _RollbackJournalRow:
+            @staticmethod
+            def fetchone() -> tuple[str]:
+                return ("delete",)
+
+        class _NoWalCon:
+            def __init__(self, real: Any) -> None:
+                self._real = real
+
+            def execute(self, sql: str, *args: Any) -> Any:
+                if "journal_mode" in sql:
+                    return _RollbackJournalRow()
+                return self._real.execute(sql, *args)
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(self._real, name)
+
+        monkeypatch.setattr(pfb_unbound.sqlite3, "connect", lambda *a, **k: _NoWalCon(real_connect(*a, **k)))
+        con = pfb_unbound._db_connect(pfb_unbound.DB_RESOLVER)
+        con.close()
+        err = capsys.readouterr().err
+        assert "journal_mode is 'delete'" in err and "'wal'" in err, (
+            f"expected a non-WAL downgrade warning, stderr was: {err!r}"
+        )
+
 
 class TestDbConcurrencyAndPerf:
     """ADR-03 P3: validate WAL coexistence with a concurrent (PHP-style) writer and


### PR DESCRIPTION
## What

`_db_connect` wrapped its connection pragmas in a blanket `except Exception: pass`, so a failed `PRAGMA journal_mode=WAL` silently left the connection in rollback-journal mode — where a writer's commit blocks concurrent readers — with no trace anywhere. That silent fallback is a plausible mechanism behind the #767 flake.

## Changes

- Log the exception (module convention: `sys.stderr.write("[pfBlockerNG]: …")`, same as the `_db_run` write-failure path) instead of swallowing it.
- Read back the mode `PRAGMA journal_mode=WAL` reports — SQLite can decline WAL without raising — and warn when the effective mode is not `wal`, naming the actual mode.
- Observability only: the connect still completes (tables created/seeded) on any pragma failure, exactly as before.

## Tests

Three new cases in `TestDbSubsystem` (red→green verified by stashing the src change):

- `test_connect_logs_pragma_failure_and_still_initialises` — a raising PRAGMA is logged with the exception text and the connect still initialises the schema (**failed pre-fix**: nothing was logged).
- `test_connect_warns_when_wal_not_granted` — a non-`wal` readback (no exception) produces the downgrade warning naming both modes (**failed pre-fix**).
- `test_connect_wal_active_and_silent` — healthy file-db connect gets WAL and logs nothing (green both sides — pins the warning paths as real branches, not always-on noise).

Gates: `python -m pytest` (2087 passed), `ruff check`, `ruff format --check`, `mypy tests/` all green.

Fixes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG