### PR TITLE
tests: pin v6 reserved classes kept by the PHP filter flags (issue #760)

### DIFF
--- a/tests/php/SanitizeIpaddrV6Test.php
+++ b/tests/php/SanitizeIpaddrV6Test.php
@@ -63,17 +63,32 @@ final class SanitizeIpaddrV6Test extends TestCase
 	}
 
 	// --- Classes the PHP filter flags do NOT drop (issue #760) ---------------
-
+	//
 	// FILTER_FLAG_NO_PRIV_RANGE|NO_RES_RANGE keep documentation
 	// (2001:db8::/32), multicast (ff00::/8) and NAT64 (64:ff9b::/96) space —
 	// the same permissiveness as the v4 flags (192.0.2.0/24 and 224.0.0.0/4
-	// are kept too). This pins today's behaviour; dropping these classes is a
-	// policy decision tracked in issue #760 and would flip this test.
-	public function testSuppressionKeepsClassesOutsideFlagCoverage(): void
+	// are kept too). These pin today's behaviour; dropping these classes is a
+	// policy decision tracked in issue #760 and would flip these tests.
+
+	// 2001:db8::/32 is non-reserved only since PHP 8.3.16/8.4.3 (php-src
+	// GH-16944, the RFC 6890 range refactor); an older 8.3.x patch level
+	// DROPS it — a failure here on a stale toolchain is a PHP patch-floor
+	// problem, not a #760 policy change.
+	public function testSuppressionKeepsDocumentationRange(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
 		$this->assertSame('2001:db8::1', sanitize_ipaddr_v6('2001:db8::1', false), 'documentation (RFC 3849) is kept');
+	}
+
+	public function testSuppressionKeepsMulticastRange(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
 		$this->assertSame('ff02::1', sanitize_ipaddr_v6('ff02::1', false), 'multicast (ff00::/8) is kept');
+	}
+
+	public function testSuppressionKeepsNat64Range(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
 		$this->assertSame('64:ff9b::1', sanitize_ipaddr_v6('64:ff9b::1', false), 'NAT64 (RFC 6052) is kept');
 	}
 

--- a/tests/php/SanitizeIpaddrV6Test.php
+++ b/tests/php/SanitizeIpaddrV6Test.php
@@ -57,8 +57,24 @@ final class SanitizeIpaddrV6Test extends TestCase
 	public function testSuppressionKeepsPublicIp(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
-		// Routable address (Cloudflare resolver) — NOT 2001:db8::/32 (reserved).
+		// Routable address (Cloudflare resolver) — genuinely public space, so
+		// it must survive independently of the flag-coverage question below.
 		$this->assertSame('2606:4700:4700::1111', sanitize_ipaddr_v6('2606:4700:4700::1111', false));
+	}
+
+	// --- Classes the PHP filter flags do NOT drop (issue #760) ---------------
+
+	// FILTER_FLAG_NO_PRIV_RANGE|NO_RES_RANGE keep documentation
+	// (2001:db8::/32), multicast (ff00::/8) and NAT64 (64:ff9b::/96) space —
+	// the same permissiveness as the v4 flags (192.0.2.0/24 and 224.0.0.0/4
+	// are kept too). This pins today's behaviour; dropping these classes is a
+	// policy decision tracked in issue #760 and would flip this test.
+	public function testSuppressionKeepsClassesOutsideFlagCoverage(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('2001:db8::1', sanitize_ipaddr_v6('2001:db8::1', false), 'documentation (RFC 3849) is kept');
+		$this->assertSame('ff02::1', sanitize_ipaddr_v6('ff02::1', false), 'multicast (ff00::/8) is kept');
+		$this->assertSame('64:ff9b::1', sanitize_ipaddr_v6('64:ff9b::1', false), 'NAT64 (RFC 6052) is kept');
 	}
 
 	// --- Suppression toggle is the cause (assert before-state, then flip) ----


### PR DESCRIPTION
## Summary

Part of #760 (§1 groundwork — does **not** close the issue).

`testSuppressionKeepsPublicIp` carried a comment claiming `2001:db8::/32` is rejected as reserved by `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE`. Empirically it is **kept** — as are multicast (`ff00::/8`) and NAT64 (`64:ff9b::/96`) — matching the v4 flags' permissiveness (`192.0.2.0/24`, `224.0.0.0/4` are kept too). This PR corrects the comment and pins the actual behaviour.

## Changes

- `tests/php/SanitizeIpaddrV6Test.php`
  - Fix the inaccurate `2001:db8::/32` comment on `testSuppressionKeepsPublicIp`.
  - Add `testSuppressionKeepsClassesOutsideFlagCoverage`: pins that documentation / multicast / NAT64 space is kept by `sanitize_ipaddr_v6()` with Suppression on. Behaviour-pinning oracle (test-mandate exception for behaviour-preserving work): whichever way the #760 §1 policy decision goes later, the change flips this test instead of drifting silently.

## Test evidence

- `vendor/bin/phpunit --filter SanitizeIpaddrV6Test` — 14 tests, 17 assertions, green.
- Full PHP suite: 1966 tests, 15953 assertions, green (4 pre-existing skips).
- Kept-classes facts reproduced with `php -r` probes on both families (see the verification table on #760).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVWLiFeaGYpg178rFMeo7P
